### PR TITLE
Add onError prop to AnimationLoop

### DIFF
--- a/docs/api-reference/engine/animation-loop.md
+++ b/docs/api-reference/engine/animation-loop.md
@@ -61,6 +61,7 @@ new AnimationLoop({
 * `props.onInitialize` (callback) - if supplied, will be called once after first `start()` has been called, after page load completes and a context has been created.
 * `props.onRender`=`null` (callback) - Called on every animation frame.
 * `props.onFinalize`=`null` (callback) - Called once when animation is stopped. Can be used to delete objects or free any resources created during `onInitialize`.
+* `props.onError`=`null` (callback) - Called when an error is about to be thrown.
 * `props.autoResizeViewport`=`true` - If true, calls `gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight)` each frame before `onRender` is called. Set to false to control viewport size.
 * `props.autoResizeDrawingBuffer`=`true` - If true, checks the canvas size every frame and updates the drawing buffer size if needed.
 * `props.useDevicePixels` - Whether to use `window.devicePixelRatio` as a multiplier, e.g. in `autoResizeDrawingBuffer` etc. Refer to `Experimental API` section below for more use cases of this prop.

--- a/modules/engine/src/lib/animation-loop.js
+++ b/modules/engine/src/lib/animation-loop.js
@@ -33,6 +33,7 @@ export default class AnimationLoop {
       onInitialize = () => {},
       onRender = () => {},
       onFinalize = () => {},
+      onError,
 
       gl = null,
       glOptions = {},
@@ -59,6 +60,7 @@ export default class AnimationLoop {
       onInitialize,
       onRender,
       onFinalize,
+      onError,
 
       gl,
       glOptions,
@@ -131,7 +133,7 @@ export default class AnimationLoop {
     this._running = true;
     // console.debug(`Starting ${this.constructor.name}`);
     // Wait for start promise before rendering frame
-    this._getPageLoadPromise()
+    const startPromise = this._getPageLoadPromise()
       .then(() => {
         if (!this._running || this._initialized) {
           return null;
@@ -165,6 +167,11 @@ export default class AnimationLoop {
           }
         }
       });
+
+    if (this.props.onError) {
+      startPromise.catch(this.props.onError);
+    }
+
     return this;
   }
 


### PR DESCRIPTION
#### Background

Right now there is no way to handle promise rejections when starting the animation loop (e.g. failed to create WebGLContext, see See https://github.com/visgl/deck.gl/issues/4006#issuecomment-565212098).

#### Change List
- Add `onError` prop to `AnimationLoop`
