### PR TITLE
Picking module: normalize highlight color

### DIFF
--- a/modules/shadertools/src/modules/picking/picking.js
+++ b/modules/shadertools/src/modules/picking/picking.js
@@ -20,7 +20,11 @@ function getUniforms(opts = DEFAULT_MODULE_OPTIONS) {
     }
   }
   if (opts.pickingHighlightColor) {
-    uniforms.picking_uHighlightColor = opts.pickingHighlightColor.map(x => x / 255);
+    const color = opts.pickingHighlightColor.map(x => x / 255);
+    if (!Number.isFinite(color[3])) {
+      color[3] = 1;
+    }
+    uniforms.picking_uHighlightColor = color;
   }
   if (opts.pickingActive !== undefined) {
     uniforms.picking_uActive = Boolean(opts.pickingActive);

--- a/modules/shadertools/src/modules/picking/picking.js
+++ b/modules/shadertools/src/modules/picking/picking.js
@@ -20,7 +20,7 @@ function getUniforms(opts = DEFAULT_MODULE_OPTIONS) {
     }
   }
   if (opts.pickingHighlightColor) {
-    const color = opts.pickingHighlightColor.map(x => x / 255);
+    const color = Array.from(opts.pickingHighlightColor, x => x / 255);
     if (!Number.isFinite(color[3])) {
       color[3] = 1;
     }

--- a/modules/shadertools/test/modules/picking/picking.spec.js
+++ b/modules/shadertools/test/modules/picking/picking.spec.js
@@ -74,6 +74,38 @@ const TEST_CASES = [
   }
 ];
 
+test('picking#getUniforms', t => {
+  t.deepEqual(picking.getUniforms({}), {}, 'Empty input');
+
+  t.deepEqual(
+    picking.getUniforms({
+      pickingActive: true,
+      pickingSelectedColor: null,
+      pickingHighlightColor: [255, 0, 0]
+    }),
+    {
+      picking_uSelectedColorValid: 0,
+      picking_uHighlightColor: [1, 0, 0, 1],
+      picking_uActive: true,
+      picking_uAttribute: false
+    }
+  );
+
+  t.deepEqual(
+    picking.getUniforms({
+      pickingSelectedColor: [0, 0, 1],
+      pickingHighlightColor: [255, 0, 0, 51]
+    }),
+    {
+      picking_uSelectedColorValid: 1,
+      picking_uSelectedColor: [0, 0, 1],
+      picking_uHighlightColor: [1, 0, 0, 0.2]
+    }
+  );
+
+  t.end();
+});
+
 test('picking#isVertexPicked(pickingSelectedColor invalid)', t => {
   if (!Transform.isSupported(gl)) {
     t.comment('Transform not available, skipping tests');


### PR DESCRIPTION
#### Background

`setUniforms` crashes if `pickingHighlightColor` is a vec3.

#### Change List
- Normalize `pickingHighlightColor`
- Test
