### PR TITLE
Update org name in website

### DIFF
--- a/website/ocular-config.js
+++ b/website/ocular-config.js
@@ -30,7 +30,7 @@ module.exports = {
   PROJECT_TYPE: 'github',
 
   PROJECT_NAME: 'luma.gl',
-  PROJECT_ORG: 'uber',
+  PROJECT_ORG: 'visgl',
   PROJECT_ORG_LOGO: 'images/uber-logo.png',
   PROJECT_URL: `https://luma.gl`,
   PROJECT_DESC: 'High-performance Toolkit for WebGL-based Data Visualization',


### PR DESCRIPTION
#### Change List
- Fixes the org of the top-right "Github" link to point to https://github.com/visgl/luma.gl instead of https://github.com/uber/luma.gl
