### PR TITLE
Add Program Manager to website table of contents

### DIFF
--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -42,6 +42,7 @@
             { "entry": "docs/api-reference/engine/transform" },
             { "entry": "docs/api-reference/engine/geometry" },
             { "entry": "docs/api-reference/engine/geometries" },
+            { "entry": "docs/api-reference/engine/program-manager" },
             { "entry": "docs/api-reference/engine/animation/timeline" },
             { "entry": "docs/api-reference/engine/animation/key-frames" }
           ]


### PR DESCRIPTION
#### Change List

Adds `program-manager.md` to the website's table of contents. The page already exists on the website, but isn't in the sidebar.

Additionally
```
/docs/api-reference/engine/transform/buffer-transform.md
/docs/api-reference/engine/transform/texture-transform.md
```
aren't in the table of contents, and I can't tell if that's intentional.

---

When I build the website locally, I have to add an `index: 1` to `ADDITIONAL_LINKS` in the Gatsby config in order to build the site with current ocular. 

Though when I do build, the site doesn't match the public website:
![image](https://user-images.githubusercontent.com/15164633/83720847-22f1d280-a5f7-11ea-91fc-984dc719e11e.png)
