### PR TITLE
examples/gltf: Remove DracoLoader import (no longer needed)

### DIFF
--- a/examples/showcase/gltf/app.js
+++ b/examples/showcase/gltf/app.js
@@ -3,7 +3,6 @@
 import {parse} from '@loaders.gl/core';
 // eslint-disable-next-line import/no-unresolved
 import {GLTFLoader} from '@loaders.gl/gltf';
-import {DracoLoader} from '@loaders.gl/draco';
 import '@loaders.gl/polyfills'; // text-encoding polyfill for older MS browsers
 import GL from '@luma.gl/constants';
 import {AnimationLoop, Timeline} from '@luma.gl/engine';
@@ -163,8 +162,7 @@ async function loadGLTF(urlOrPromise, gl, options) {
   const data = typeof urlOrPromise === 'string' ? window.fetch(urlOrPromise) : urlOrPromise;
   const gltf = await parse(data, GLTFLoader, {
     ...options,
-    gl,
-    DracoLoader
+    gl
   });
   const {scenes, animator} = createGLTFObjects(gl, gltf, options);
 

--- a/examples/showcase/gltf/package.json
+++ b/examples/showcase/gltf/package.json
@@ -9,10 +9,9 @@
     "open-vr": "adb reverse tcp:8080 tcp:8080 && adb shell am start -a android.intent.action.VIEW -d http://localhost:8080/"
   },
   "dependencies": {
-    "@loaders.gl/core": "^2.1.1",
-    "@loaders.gl/draco": "^2.1.1",
-    "@loaders.gl/gltf": "^2.1.1",
-    "@loaders.gl/polyfills": "^2.1.1",
+    "@loaders.gl/core": "^2.2.0-alpha.3",
+    "@loaders.gl/gltf": "^2.2.0-alpha.3",
+    "@loaders.gl/polyfills": "^2.2.0-alpha.3",
     "@luma.gl/experimental": "^8.1.0",
     "@luma.gl/constants": "^8.1.0",
     "@luma.gl/webgl": "^8.1.0",


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- In loaders.gl 2.2 the GLTFLoader already imports the DracoLoader dependency, the application no longer needs to deal with this.
#### Change List
- remove DracoLoader dependency from gltf example
