### PR TITLE
Fix bug when a model is deleted multiple times

### DIFF
--- a/modules/engine/src/lib/model.js
+++ b/modules/engine/src/lib/model.js
@@ -132,6 +132,7 @@ export default class Model {
 
     if (this._managedProgram) {
       this.programManager.release(this.program);
+      this._managedProgram = false;
     }
 
     this.vertexArray.delete();

--- a/modules/engine/test/lib/model.spec.js
+++ b/modules/engine/test/lib/model.spec.js
@@ -72,6 +72,37 @@ test('Model#construct/destruct', t => {
   t.end();
 });
 
+test('Model#multiple delete', t => {
+  const {gl} = fixture;
+
+  // Avoid re-using program from ProgramManager
+  const vs = '/* DO_NOT_CACHE Model#construct/destruct */ void main() {gl_Position = vec4(0.0);}';
+  const fs = '/* DO_NOT_CACHE Model#construct/destruct */ void main() {gl_FragColor = vec4(0.0);}';
+
+  const model1 = new Model(gl, {
+    drawMode: GL.POINTS,
+    vertexCount: 0,
+    vs,
+    fs
+  });
+
+  const model2 = new Model(gl, {
+    drawMode: GL.POINTS,
+    vertexCount: 0,
+    vs,
+    fs
+  });
+
+  model1.delete();
+  t.ok(model2.program.handle, 'program still in use');
+  model1.delete();
+  t.ok(model2.program.handle, 'program still in use');
+  model2.delete();
+  t.notOk(model2.program.handle, 'program is released');
+
+  t.end();
+});
+
 test('Model#setAttribute', t => {
   const {gl} = fixture;
 


### PR DESCRIPTION
There was a bug in deck.gl's`ScreenGridLayer` where aggregation models were deleted twice. This PR guards against `program.draw` error if it happens elsewhere.

#### Change List
- Avoid calling `programManager.release` if `model.delete` is called again
- Unit test
