### PR TITLE
Docs: Make clear that count is derived from the length of points array

### DIFF
--- a/modules/experimental/src/gpgpu/point-in-polygon/gpu-point-in-polygon.md
+++ b/modules/experimental/src/gpgpu/point-in-polygon/gpu-point-in-polygon.md
@@ -21,7 +21,7 @@ const points = [
 ];
 
 const positionBuffer = new Buffer(gl2, new Float32Array(points));
-const count = points.length;
+const count = points.length / 2;
 // Allocate result buffer with enough space (2 floats for each point)
 const filterValueIndexBuffer = new Buffer(gl2, count * 2 * 4);
 

--- a/modules/experimental/src/gpgpu/point-in-polygon/gpu-point-in-polygon.md
+++ b/modules/experimental/src/gpgpu/point-in-polygon/gpu-point-in-polygon.md
@@ -21,7 +21,7 @@ const points = [
 ];
 
 const positionBuffer = new Buffer(gl2, new Float32Array(points));
-const count = 6;
+const count = points.length;
 // Allocate result buffer with enough space (2 floats for each point)
 const filterValueIndexBuffer = new Buffer(gl2, count * 2 * 4);
 


### PR DESCRIPTION
Small docs change. I was at first unsure where `count=6` came from.