### PR TITLE
Fix video texture error when video is still loading

### DIFF
--- a/modules/webgl/src/classes/texture.js
+++ b/modules/webgl/src/classes/texture.js
@@ -92,6 +92,7 @@ export default class Texture extends Resource {
     const isVideo = typeof HTMLVideoElement !== 'undefined' && data instanceof HTMLVideoElement;
     // @ts-ignore
     if (isVideo && data.readyState < HTMLVideoElement.HAVE_METADATA) {
+      this._video = null; // Declare member before the object is sealed
       data.addEventListener('loadedmetadata', () => this.initialize(props));
       return this;
     }


### PR DESCRIPTION
Fix `Uncaught TypeError: Cannot add property _video, object is not extensible` error with asynchronously loaded video

#### Change List
- Add `_video` member before the instance is sealed 
