### PR TITLE
Fix occasional error when using video texture

### DIFF
--- a/modules/webgl/src/classes/texture.js
+++ b/modules/webgl/src/classes/texture.js
@@ -93,7 +93,7 @@ export default class Texture extends Resource {
     // @ts-ignore
     if (isVideo && data.readyState < HTMLVideoElement.HAVE_METADATA) {
       this._video = null; // Declare member before the object is sealed
-      data.addEventListener('loadedmetadata', () => this.initialize(props));
+      data.addEventListener('loadeddata', () => this.initialize(props));
       return this;
     }
 


### PR DESCRIPTION
`texImage2D` fails if the video has not loaded its first frame.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#events

#### Change List
- Wait till the first frame is loaded
