### PR TITLE
Exposed isContextLost from animation loop

### DIFF
--- a/docs/api-reference/engine/animation-loop.md
+++ b/docs/api-reference/engine/animation-loop.md
@@ -135,6 +135,10 @@ Returns returns a `Promise` that resolves to the data URL of the canvas once dra
 
 `animationLoop.toDataURL()`
 
+### isContextLost()
+
+Returns the current state of the WebGL context used by the animation loop.
+
 ## Callback Parameters
 
 The callbacks `onInitialize`, `onRender` and `onFinalize` that the app supplies to the `AnimationLoop`, will be called with an object containing named parameters:

--- a/modules/engine/src/lib/animation-loop.d.ts
+++ b/modules/engine/src/lib/animation-loop.d.ts
@@ -104,6 +104,7 @@ export default class AnimationLoop {
   toDataURL(): Promise<string>;
   setViewParameters(): AnimationLoop;
   getHTMLControlValue(id: string, defaultValue?: number): number;
+  isContextLost(): boolean;
 
   // Callbacks
   onCreateContext(opts: CreateGLContextOptions): WebGLRenderingContext;

--- a/modules/engine/src/lib/animation-loop.js
+++ b/modules/engine/src/lib/animation-loop.js
@@ -179,6 +179,10 @@ export default class AnimationLoop {
 
   // Redraw now
   redraw() {
+    if (this.isContextLost()) {
+      return this;
+    }
+
     this._beginTimers();
 
     this._setupFrame();
@@ -247,6 +251,10 @@ export default class AnimationLoop {
     await this.waitForRender();
 
     return this.gl.canvas.toDataURL();
+  }
+
+  isContextLost() {
+    return this.gl.isContextLost();
   }
 
   onCreateContext(...args) {

--- a/modules/engine/test/lib/animation-loop.spec.js
+++ b/modules/engine/test/lib/animation-loop.spec.js
@@ -25,6 +25,8 @@ test('core#AnimationLoop start,stop', t => {
     onRender: () => {
       renderCalled++;
 
+      t.is(animationLoop.isContextLost(), false, 'isContextLost returns false');
+
       animationLoop.stop();
 
       t.is(initializeCalled, 1, 'onInitialize called');


### PR DESCRIPTION
For [visgl/deck.gl#5399](https://github.com/visgl/deck.gl/pull/5399)

#### Background
Required to add better context lost state handling.

#### Change List
- added isContextLost to AnimationLoop which returns the current state of the used WebGL context
- AnimationLoop.redraw function exits early in case of a lost context