### PR TITLE
Fix isWebGL check on non-instrumented context

### DIFF
--- a/modules/gltools/src/utils/webgl-checks.js
+++ b/modules/gltools/src/utils/webgl-checks.js
@@ -8,6 +8,9 @@ export function isWebGL(gl) {
   if (typeof WebGLRenderingContext !== 'undefined' && gl instanceof WebGLRenderingContext) {
     return true;
   }
+  if (typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext) {
+    return true;
+  }
   // Look for debug contexts, headless gl etc
   return Boolean(gl && Number.isFinite(gl._version));
 }

--- a/modules/shadertools/src/utils/webgl-info.js
+++ b/modules/shadertools/src/utils/webgl-info.js
@@ -30,6 +30,9 @@ Object.keys(WEBGL_FEATURES).forEach(key => {
 export {FEATURES};
 
 function isWebGL2(gl) {
+  if (typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext) {
+    return true;
+  }
   return Boolean(gl && gl._version === 2);
 }
 


### PR DESCRIPTION
Currently, the following code throws error `Invalid WebGLRenderingContext`:

```js
const gl = canvas.getContext('webgl2');
const texture = new Texture2D(gl, {});
```

Because `isWebGL` does not recognize `WebGL2RenderingContext` that is not instrumented by luma.

#### Change List
- `isWebGL` should recognize `WebGL2RenderingContext`
