### PR TITLE
gltf: export GLTFMaterialParser

### DIFF
--- a/modules/experimental/src/index.d.ts
+++ b/modules/experimental/src/index.d.ts
@@ -5,6 +5,7 @@ export {default as VRDisplay} from './webvr/vr-display';
 // glTF Scenegraph Instantiator
 export {default as GLTFEnvironment} from './gltf/gltf-environment';
 export {default as createGLTFObjects} from './gltf/create-gltf-objects';
+export {default as GLTFMaterialParser} from './gltf/gltf-material-parser';
 
 // Core nodes
 export {default as ScenegraphNode} from './scenegraph/scenegraph-node';

--- a/modules/experimental/src/index.js
+++ b/modules/experimental/src/index.js
@@ -5,6 +5,7 @@ export {default as VRDisplay} from './webvr/vr-display';
 // glTF Scenegraph Instantiator
 export {default as GLTFEnvironment} from './gltf/gltf-environment';
 export {default as createGLTFObjects} from './gltf/create-gltf-objects';
+export {default as GLTFMaterialParser} from './gltf/gltf-material-parser';
 
 // Core nodes
 export {default as ScenegraphNode} from './scenegraph/scenegraph-node';


### PR DESCRIPTION
#### Background
- we need it in SimpleMeshLayer to support materials in I3S.
#### Change List
- export GLTFMaterialParser.
