### PR TITLE
Transpile gl_FragColor in fragment shader from GLSL 1.00 to 3.00

### DIFF
--- a/modules/shadertools/test/lib/assemble-shaders.spec.js
+++ b/modules/shadertools/test/lib/assemble-shaders.spec.js
@@ -205,11 +205,7 @@ const VS_GLSL_300_GLTF = `#version 300 es
 
 const FS_GLSL_300_GLTF = `#version 300 es
 
-#if (__VERSION__ < 300)
-  #define fragmentColor gl_FragColor
-#else
   out vec4 fragmentColor;
-#endif
 
   void main(void) {
     fragmentColor = pbr_filterColor(vec4(0));
@@ -391,7 +387,7 @@ test('assembleShaders#shaderhooks', t => {
   );
 
   t.ok(
-    assembleResult.fs.indexOf('gl_FragColor = picking_filterColor(gl_FragColor)') === -1,
+    assembleResult.fs.indexOf('fragmentColor = picking_filterColor(fragmentColor)') === -1,
     'regex injection code not included in fragment shader without module'
   );
 
@@ -424,7 +420,7 @@ test('assembleShaders#shaderhooks', t => {
     'hook footer injected after injection code'
   );
   t.ok(
-    assembleResult.fs.indexOf('gl_FragColor = picking_filterColor(gl_FragColor)') > -1,
+    assembleResult.fs.indexOf('fragmentColor = picking_filterColor(fragmentColor)') > -1,
     'regex injection code included in fragment shader with module'
   );
 

--- a/modules/shadertools/test/lib/transpile-shader-cases.js
+++ b/modules/shadertools/test/lib/transpile-shader-cases.js
@@ -84,13 +84,13 @@ void main(void) {
 
 precision highp float;
 
-out vec4 fragmentColor;
 uniform sampler2D sampler;
 uniform samplerCube sCube;
 in vec4 vColor;
 
 void f(out float a, in float b) {}
 
+out vec4 fragmentColor;
 void main(void) {
   vec4 texColor = texture(sampler, texCoord);
   vec4 texCubeColor = textureCube(sCube, cubeCoord);
@@ -108,13 +108,13 @@ void main(void) {
 
 precision highp float;
 
-out vec4 fragmentColor;
 uniform sampler2D sampler;
 uniform samplerCube sCube;
 in vec4 vColor;
 
 void f(out float a, in float b) {}
 
+out vec4 fragmentColor;
 void main(void) {
   vec4 texColor = texture(sampler, texCoord);
   vec4 texCubeColor = texture(sCube, cubeCoord);

--- a/modules/shadertools/test/lib/transpile-shader.spec.js
+++ b/modules/shadertools/test/lib/transpile-shader.spec.js
@@ -36,12 +36,11 @@ test('transpileShader', t => {
     assembleResult = transpileShader(GLSL_300, 300, isVertex);
     t.equal(assembleResult, GLSL_300_transpiled, `3.00 => 3.00: ${title}`);
 
-    if (isVertex) {
-      // TODO - investigate missing frag color out statement
-      // test case was left out in 8.3
-      assembleResult = transpileShader(GLSL_100, 300, isVertex);
-      t.equal(assembleResult, GLSL_300_transpiled, `1.00 => 3.00: ${title}`);
-    }
+    assembleResult = transpileShader(GLSL_100, 100, isVertex);
+    t.equal(assembleResult, GLSL_100, `1.00 => 1.00: ${title}`);
+
+    assembleResult = transpileShader(GLSL_100, 300, isVertex);
+    t.equal(assembleResult, GLSL_300_transpiled, `1.00 => 3.00: ${title}`);
   }
 
   t.end();


### PR DESCRIPTION
#### Background

Usecase: when subclassing a deck.gl layer, support injecting GLSL 3.00 features into GLSL 1.00 shaders

transpileShader 1.00 -> 3.00 needs to inject a new output variable to replace `gl_FragColor`

This PR implements a TODO mentioning this missing feature:

https://github.com/visgl/luma.gl/blob/d5bd93ef6bd0a0ff4af7880424286bda269e29a8/modules/shadertools/test/lib/transpile-shader.spec.js#L39-L44

#### Change List
- transpile-shader.js replaces all occurences of `gl_FragColor` with detected output name. If there is no output name detected, default `fragmentColor` name is used, and a new output variable is injected before the main.
- transpile-shader.spec.js checks all transpilation directions