### PR TITLE
Fix transpiling minified shader

### DIFF
--- a/modules/shadertools/src/lib/transpile-shader.js
+++ b/modules/shadertools/src/lib/transpile-shader.js
@@ -12,16 +12,16 @@ const ES300_REPLACEMENTS = [
 const ES300_VERTEX_REPLACEMENTS = [
   ...ES300_REPLACEMENTS,
   // `attribute` keyword replaced with `in`
-  [/^[ \t]*attribute[ \t]+(.+;)/gm, 'in $1'],
+  [/\battribute[ \t]+(.+;)/g, 'in $1'],
   // `varying` keyword replaced with `out`
-  [/^[ \t]*varying[ \t]+(.+;)/gm, 'out $1']
+  [/\bvarying[ \t]+(.+;)/g, 'out $1']
 ];
 
 /** Simple regex replacements for GLSL ES 1.00 syntax that has changed in GLSL ES 3.00 */
 const ES300_FRAGMENT_REPLACEMENTS = [
   ...ES300_REPLACEMENTS,
   // `varying` keyword replaced with `in`
-  [/^[ \t]*varying[ \t]+(.+;)/gm, 'in $1']
+  [/\bvarying[ \t]+(.+;)/g, 'in $1']
 ];
 
 const ES100_REPLACEMENTS = [
@@ -38,18 +38,18 @@ const ES100_REPLACEMENTS = [
 
 const ES100_VERTEX_REPLACEMENTS = [
   ...ES100_REPLACEMENTS,
-  [/^[ \t]*in[ \t]+(.+;)/gm, 'attribute $1'],
-  [/^[ \t]*out[ \t]+(.+;)/gm, 'varying $1']
+  [/\bin[ \t]+(.+;)/g, 'attribute $1'],
+  [/\bout[ \t]+(.+;)/g, 'varying $1']
 ];
 
 const ES100_FRAGMENT_REPLACEMENTS = [
   ...ES100_REPLACEMENTS,
   // Replace `in` with `varying`
-  [/^[ \t]*in[ \t]+/gm, 'varying ']
+  [/\bin[ \t]+(.+;)/g, 'varying $1']
 ];
 
 const ES100_FRAGMENT_OUTPUT_NAME = 'gl_FragColor';
-const ES300_FRAGMENT_OUTPUT_REGEX = /^[ \t]*out[ \t]+vec4[ \t]+(\w+)[ \t]*;\s+/m;
+const ES300_FRAGMENT_OUTPUT_REGEX = /\bout[ \t]+vec4[ \t]+(\w+)[ \t]*;\n?/;
 
 const REGEX_START_OF_MAIN = /void\s+main\s*\([^)]*\)\s*\{\n?/; // Beginning of main
 
@@ -79,7 +79,6 @@ function convertShader(source, replacements) {
 }
 
 function convertFragmentShaderTo300(source) {
-  // /gm - treats each line as a string, so that ^ matches after newlines
   source = convertShader(source, ES300_FRAGMENT_REPLACEMENTS);
 
   const outputMatch = source.match(ES300_FRAGMENT_OUTPUT_REGEX);
@@ -97,7 +96,6 @@ function convertFragmentShaderTo300(source) {
 }
 
 function convertFragmentShaderTo100(source) {
-  // /gm - treats each line as a string, so that ^ matches after newlines
   source = convertShader(source, ES100_FRAGMENT_REPLACEMENTS);
 
   const outputMatch = source.match(ES300_FRAGMENT_OUTPUT_REGEX);

--- a/modules/shadertools/src/lib/transpile-shader.js
+++ b/modules/shadertools/src/lib/transpile-shader.js
@@ -12,16 +12,16 @@ const ES300_REPLACEMENTS = [
 const ES300_VERTEX_REPLACEMENTS = [
   ...ES300_REPLACEMENTS,
   // `attribute` keyword replaced with `in`
-  [/\battribute[ \t]+(.+;)/g, 'in $1'],
+  [/\battribute[ \t]+([^,;\)\]]+;)/g, 'in $1'],
   // `varying` keyword replaced with `out`
-  [/\bvarying[ \t]+(.+;)/g, 'out $1']
+  [/\bvarying[ \t]+([^,;\)\]]+;)/g, 'out $1']
 ];
 
 /** Simple regex replacements for GLSL ES 1.00 syntax that has changed in GLSL ES 3.00 */
 const ES300_FRAGMENT_REPLACEMENTS = [
   ...ES300_REPLACEMENTS,
   // `varying` keyword replaced with `in`
-  [/\bvarying[ \t]+(.+;)/g, 'in $1']
+  [/\bvarying[ \t]+([^,;\)\]]+;)/g, 'in $1']
 ];
 
 const ES100_REPLACEMENTS = [
@@ -38,14 +38,14 @@ const ES100_REPLACEMENTS = [
 
 const ES100_VERTEX_REPLACEMENTS = [
   ...ES100_REPLACEMENTS,
-  [/\bin[ \t]+(.+;)/g, 'attribute $1'],
-  [/\bout[ \t]+(.+;)/g, 'varying $1']
+  [/\bin[ \t]+([^,;\)\]]+;)/g, 'attribute $1'],
+  [/\bout[ \t]+([^,;\)\]]+;)/g, 'varying $1']
 ];
 
 const ES100_FRAGMENT_REPLACEMENTS = [
   ...ES100_REPLACEMENTS,
   // Replace `in` with `varying`
-  [/\bin[ \t]+(.+;)/g, 'varying $1']
+  [/\bin[ \t]+([^,;\)\]]+;)/g, 'varying $1']
 ];
 
 const ES100_FRAGMENT_OUTPUT_NAME = 'gl_FragColor';

--- a/modules/shadertools/src/lib/transpile-shader.js
+++ b/modules/shadertools/src/lib/transpile-shader.js
@@ -12,16 +12,16 @@ const ES300_REPLACEMENTS = [
 const ES300_VERTEX_REPLACEMENTS = [
   ...ES300_REPLACEMENTS,
   // `attribute` keyword replaced with `in`
-  [/\battribute[ \t]+([^,;\)\]]+;)/g, 'in $1'],
+  [/\battribute[ \t]+([ \t\w]+;)/g, 'in $1'],
   // `varying` keyword replaced with `out`
-  [/\bvarying[ \t]+([^,;\)\]]+;)/g, 'out $1']
+  [/\bvarying[ \t]+([ \t\w]+;)/g, 'out $1']
 ];
 
 /** Simple regex replacements for GLSL ES 1.00 syntax that has changed in GLSL ES 3.00 */
 const ES300_FRAGMENT_REPLACEMENTS = [
   ...ES300_REPLACEMENTS,
   // `varying` keyword replaced with `in`
-  [/\bvarying[ \t]+([^,;\)\]]+;)/g, 'in $1']
+  [/\bvarying[ \t]+([ \t\w]+;)/g, 'in $1']
 ];
 
 const ES100_REPLACEMENTS = [
@@ -38,14 +38,14 @@ const ES100_REPLACEMENTS = [
 
 const ES100_VERTEX_REPLACEMENTS = [
   ...ES100_REPLACEMENTS,
-  [/\bin[ \t]+([^,;\)\]]+;)/g, 'attribute $1'],
-  [/\bout[ \t]+([^,;\)\]]+;)/g, 'varying $1']
+  [/\bin[ \t]+([ \t\w]+;)/g, 'attribute $1'],
+  [/\bout[ \t]+([ \t\w]+;)/g, 'varying $1']
 ];
 
 const ES100_FRAGMENT_REPLACEMENTS = [
   ...ES100_REPLACEMENTS,
   // Replace `in` with `varying`
-  [/\bin[ \t]+([^,;\)\]]+;)/g, 'varying $1']
+  [/\bin[ \t]+([ \t\w]+;)/g, 'varying $1']
 ];
 
 const ES100_FRAGMENT_OUTPUT_NAME = 'gl_FragColor';

--- a/modules/shadertools/test/lib/minify-shader.js
+++ b/modules/shadertools/test/lib/minify-shader.js
@@ -1,5 +1,5 @@
 // copied from rollup-plugin-glslify
-export function compressShader(code) {
+export function minifyShader(code) {
   let needNewline = false;
   return code
     .replace(/\\(?:\r\n|\n\r|\n|\r)|\/\*.*?\*\/|\/\/(?:\\(?:\r\n|\n\r|\n|\r)|[^\n\r])*/g, '')

--- a/modules/shadertools/test/lib/transpile-shader-compress.js
+++ b/modules/shadertools/test/lib/transpile-shader-compress.js
@@ -1,18 +1,23 @@
 // copied from rollup-plugin-glslify
 export function compressShader(code) {
   let needNewline = false;
-  return code.replace(/\\(?:\r\n|\n\r|\n|\r)|\/\*.*?\*\/|\/\/(?:\\(?:\r\n|\n\r|\n|\r)|[^\n\r])*/g, '').split(/\n+/).reduce((result, line) => {
-    line = line.trim().replace(/\s{2,}|\t/, ' ');
-    if (line.charAt(0) === '#') {
-      if (needNewline) {
-        result.push('\n');
+  return code
+    .replace(/\\(?:\r\n|\n\r|\n|\r)|\/\*.*?\*\/|\/\/(?:\\(?:\r\n|\n\r|\n|\r)|[^\n\r])*/g, '')
+    .split(/\n+/)
+    .reduce((result, line) => {
+      line = line.trim().replace(/\s{2,}|\t/, ' ');
+      if (line.charAt(0) === '#') {
+        if (needNewline) {
+          result.push('\n');
+        }
+        result.push(line, '\n');
+        needNewline = false;
+      } else {
+        result.push(line.replace(/\s*({|}|=|\*|,|\+|\/|>|<|&|\||\[|\]|\(|\)|-|!|;)\s*/g, '$1'));
+        needNewline = true;
       }
-      result.push(line, '\n');
-      needNewline = false;
-    } else {
-      result.push(line.replace(/\s*({|}|=|\*|,|\+|\/|>|<|&|\||\[|\]|\(|\)|-|!|;)\s*/g, '$1'));
-      needNewline = true;
-    }
-    return result;
-  }, []).join('').replace(/\n+/g, '\n');
+      return result;
+    }, [])
+    .join('')
+    .replace(/\n+/g, '\n');
 }

--- a/modules/shadertools/test/lib/transpile-shader-compress.js
+++ b/modules/shadertools/test/lib/transpile-shader-compress.js
@@ -1,0 +1,18 @@
+// copied from rollup-plugin-glslify
+export function compressShader(code) {
+  let needNewline = false;
+  return code.replace(/\\(?:\r\n|\n\r|\n|\r)|\/\*.*?\*\/|\/\/(?:\\(?:\r\n|\n\r|\n|\r)|[^\n\r])*/g, '').split(/\n+/).reduce((result, line) => {
+    line = line.trim().replace(/\s{2,}|\t/, ' ');
+    if (line.charAt(0) === '#') {
+      if (needNewline) {
+        result.push('\n');
+      }
+      result.push(line, '\n');
+      needNewline = false;
+    } else {
+      result.push(line.replace(/\s*({|}|=|\*|,|\+|\/|>|<|&|\||\[|\]|\(|\)|-|!|;)\s*/g, '$1'));
+      needNewline = true;
+    }
+    return result;
+  }, []).join('').replace(/\n+/g, '\n');
+}

--- a/modules/shadertools/test/lib/transpile-shader.spec.js
+++ b/modules/shadertools/test/lib/transpile-shader.spec.js
@@ -4,6 +4,7 @@ import transpileShader from '@luma.gl/shadertools/lib/transpile-shader';
 import test from 'tape-catch';
 
 import {TRANSPILATION_TEST_CASES, COMPILATION_TEST_CASES} from './transpile-shader-cases';
+import {compressShader} from './transpile-shader-compress';
 
 const VERTEX = true;
 const FRAGMENT = false;
@@ -41,6 +42,19 @@ test('transpileShader', t => {
 
     assembleResult = transpileShader(GLSL_100, 300, isVertex);
     t.equal(assembleResult, GLSL_300_transpiled, `1.00 => 3.00: ${title}`);
+
+    // minified shaders
+    assembleResult = compressShader(transpileShader(compressShader(GLSL_300), 100, isVertex));
+    t.equal(assembleResult, compressShader(GLSL_100), `minified 3.00 => 1.00: ${title}`);
+
+    assembleResult = compressShader(transpileShader(compressShader(GLSL_300), 300, isVertex));
+    t.equal(assembleResult, compressShader(GLSL_300_transpiled), `minified 3.00 => 3.00: ${title}`);
+
+    assembleResult = compressShader(transpileShader(compressShader(GLSL_100), 100, isVertex));
+    t.equal(assembleResult, compressShader(GLSL_100), `minified 1.00 => 1.00: ${title}`);
+
+    assembleResult = compressShader(transpileShader(compressShader(GLSL_100), 300, isVertex));
+    t.equal(assembleResult, compressShader(GLSL_300_transpiled), `minified 1.00 => 3.00: ${title}`);
   }
 
   t.end();

--- a/modules/shadertools/test/lib/transpile-shader.spec.js
+++ b/modules/shadertools/test/lib/transpile-shader.spec.js
@@ -4,7 +4,7 @@ import transpileShader from '@luma.gl/shadertools/lib/transpile-shader';
 import test from 'tape-catch';
 
 import {TRANSPILATION_TEST_CASES, COMPILATION_TEST_CASES} from './transpile-shader-cases';
-import {compressShader} from './transpile-shader-compress';
+import {minifyShader} from './minify-shader';
 
 const VERTEX = true;
 const FRAGMENT = false;
@@ -44,17 +44,17 @@ test('transpileShader', t => {
     t.equal(assembleResult, GLSL_300_transpiled, `1.00 => 3.00: ${title}`);
 
     // minified shaders
-    assembleResult = compressShader(transpileShader(compressShader(GLSL_300), 100, isVertex));
-    t.equal(assembleResult, compressShader(GLSL_100), `minified 3.00 => 1.00: ${title}`);
+    assembleResult = minifyShader(transpileShader(minifyShader(GLSL_300), 100, isVertex));
+    t.equal(assembleResult, minifyShader(GLSL_100), `minified 3.00 => 1.00: ${title}`);
 
-    assembleResult = compressShader(transpileShader(compressShader(GLSL_300), 300, isVertex));
-    t.equal(assembleResult, compressShader(GLSL_300_transpiled), `minified 3.00 => 3.00: ${title}`);
+    assembleResult = minifyShader(transpileShader(minifyShader(GLSL_300), 300, isVertex));
+    t.equal(assembleResult, minifyShader(GLSL_300_transpiled), `minified 3.00 => 3.00: ${title}`);
 
-    assembleResult = compressShader(transpileShader(compressShader(GLSL_100), 100, isVertex));
-    t.equal(assembleResult, compressShader(GLSL_100), `minified 1.00 => 1.00: ${title}`);
+    assembleResult = minifyShader(transpileShader(minifyShader(GLSL_100), 100, isVertex));
+    t.equal(assembleResult, minifyShader(GLSL_100), `minified 1.00 => 1.00: ${title}`);
 
-    assembleResult = compressShader(transpileShader(compressShader(GLSL_100), 300, isVertex));
-    t.equal(assembleResult, compressShader(GLSL_300_transpiled), `minified 1.00 => 3.00: ${title}`);
+    assembleResult = minifyShader(transpileShader(minifyShader(GLSL_100), 300, isVertex));
+    t.equal(assembleResult, minifyShader(GLSL_300_transpiled), `minified 1.00 => 3.00: ${title}`);
   }
 
   t.end();


### PR DESCRIPTION
Fixes #1481

Changes:
- multiline regexes `/^[ \t]*…/m` replaced with `/\b…/`, to match on word boundaries on a single line in a minified shader
- ES100 replacement `in[ \t]+` -> `varying ` replaced with `in[ \t]+(.+;)` -> `varying $1`, to match shader varyings only, skip function arguments