### PR TITLE
Fix transpilation of array variables

### DIFF
--- a/modules/shadertools/src/lib/transpile-shader.js
+++ b/modules/shadertools/src/lib/transpile-shader.js
@@ -1,5 +1,16 @@
 // TRANSPILATION TABLES
 
+function testVariable(qualifier) {
+  /*
+    should match:
+      in float weight;
+      out vec4 positions[2];
+    should not match:
+      void f(out float a, in float b) {}
+   */
+  return new RegExp(`\\b${qualifier}[ \\t]+(\\w+[ \\t]+\\w+(\\[\\w+\\])?;)`, 'g');
+}
+
 /** Simple regex replacements for GLSL ES 1.00 syntax that has changed in GLSL ES 3.00 */
 const ES300_REPLACEMENTS = [
   // Fix poorly formatted version directive
@@ -12,16 +23,16 @@ const ES300_REPLACEMENTS = [
 const ES300_VERTEX_REPLACEMENTS = [
   ...ES300_REPLACEMENTS,
   // `attribute` keyword replaced with `in`
-  [/\battribute[ \t]+([ \t\w]+;)/g, 'in $1'],
+  [testVariable('attribute'), 'in $1'],
   // `varying` keyword replaced with `out`
-  [/\bvarying[ \t]+([ \t\w]+;)/g, 'out $1']
+  [testVariable('varying'), 'out $1']
 ];
 
 /** Simple regex replacements for GLSL ES 1.00 syntax that has changed in GLSL ES 3.00 */
 const ES300_FRAGMENT_REPLACEMENTS = [
   ...ES300_REPLACEMENTS,
   // `varying` keyword replaced with `in`
-  [/\bvarying[ \t]+([ \t\w]+;)/g, 'in $1']
+  [testVariable('varying'), 'in $1']
 ];
 
 const ES100_REPLACEMENTS = [
@@ -38,14 +49,14 @@ const ES100_REPLACEMENTS = [
 
 const ES100_VERTEX_REPLACEMENTS = [
   ...ES100_REPLACEMENTS,
-  [/\bin[ \t]+([ \t\w]+;)/g, 'attribute $1'],
-  [/\bout[ \t]+([ \t\w]+;)/g, 'varying $1']
+  [testVariable('in'), 'attribute $1'],
+  [testVariable('out'), 'varying $1']
 ];
 
 const ES100_FRAGMENT_REPLACEMENTS = [
   ...ES100_REPLACEMENTS,
   // Replace `in` with `varying`
-  [/\bin[ \t]+([ \t\w]+;)/g, 'varying $1']
+  [testVariable('in'), 'varying $1']
 ];
 
 const ES100_FRAGMENT_OUTPUT_NAME = 'gl_FragColor';

--- a/modules/shadertools/test/lib/transpile-shader-cases.js
+++ b/modules/shadertools/test/lib/transpile-shader-cases.js
@@ -11,9 +11,11 @@ export const TRANSPILATION_TEST_CASES = [
 #version 300 es
 
 in vec4 positions;
+in vec4 texCoords[2];
 uniform sampler2D sampler;
 uniform samplerCube sCube;
 out vec4 vColor;
+out vec4 vTexCoords[2];
 
 void f(out float a, in float b) {}
 
@@ -26,6 +28,8 @@ void main(void) {
   texLod = texture2DLod(sampler, texCoord, 1.0);
   texCubeLod = textureCubeLod(sCube, cubeCoord, 1.0);
   vColor = vec4(1., 0., 0., 1.);
+  vTexCoords[0] = texCoords[0];
+  vTexCoords[1] = texCoords[1];
 }
 `,
 
@@ -34,9 +38,11 @@ void main(void) {
 #version 300 es
 
 in vec4 positions;
+in vec4 texCoords[2];
 uniform sampler2D sampler;
 uniform samplerCube sCube;
 out vec4 vColor;
+out vec4 vTexCoords[2];
 
 void f(out float a, in float b) {}
 
@@ -49,6 +55,8 @@ void main(void) {
   texLod = textureLod(sampler, texCoord, 1.0);
   texCubeLod = textureLod(sCube, cubeCoord, 1.0);
   vColor = vec4(1., 0., 0., 1.);
+  vTexCoords[0] = texCoords[0];
+  vTexCoords[1] = texCoords[1];
 }
 `,
 
@@ -56,9 +64,11 @@ void main(void) {
 #version 100
 
 attribute vec4 positions;
+attribute vec4 texCoords[2];
 uniform sampler2D sampler;
 uniform samplerCube sCube;
 varying vec4 vColor;
+varying vec4 vTexCoords[2];
 
 void f(out float a, in float b) {}
 
@@ -71,6 +81,8 @@ void main(void) {
   texLod = texture2DLodEXT(sampler, texCoord, 1.0);
   texCubeLod = textureCubeLodEXT(sCube, cubeCoord, 1.0);
   vColor = vec4(1., 0., 0., 1.);
+  vTexCoords[0] = texCoords[0];
+  vTexCoords[1] = texCoords[1];
 }
 `
   },


### PR DESCRIPTION
Follow up of #1482

The current RegExp does not match [array variables](https://www.khronos.org/opengl/wiki/Data_Type_(GLSL)#Arrays) e.g. `in vec4 positions[2];`

@zakjan 