### PR TITLE
Fix animation frame scheduling and cancellation

### DIFF
--- a/modules/engine/src/lib/animation-loop.js
+++ b/modules/engine/src/lib/animation-loop.js
@@ -342,7 +342,7 @@ export default class AnimationLoop {
       return this.display.cancelAnimationFrame(animationFrameId);
     }
 
-    cancelAnimationFrame(animationFrameId);
+    return cancelAnimationFrame(animationFrameId);
   }
 
   _requestAnimationFrame(renderFrameCallback) {
@@ -354,6 +354,7 @@ export default class AnimationLoop {
 
       return requestAnimationFrame(renderFrameCallback);
     }
+    return undefined;
   }
 
   // Called on each frame, can be overridden to call onRender multiple times


### PR DESCRIPTION
* only schedule animation frames if the loop is running
* return the id from `_requestAnimationFrame` so it can be canceled later
* add `_cancelAnimationFrame` method so the party that scheduled the frame also cancels it
