### PR TITLE
Remove overly broad platform defines

### DIFF
--- a/modules/shadertools/src/lib/platform-defines.js
+++ b/modules/shadertools/src/lib/platform-defines.js
@@ -36,10 +36,6 @@ export function getPlatformShaderDefines(gl) {
 #define DEFAULT_GPU
 // Prevent driver from optimizing away the calculation necessary for emulated fp64
 #define LUMA_FP64_CODE_ELIMINATION_WORKAROUND 1
-// Intel's built-in 'tan' function doesn't have acceptable precision
-#define LUMA_FP32_TAN_PRECISION_WORKAROUND 1
-// Intel GPU doesn't have full 32 bits precision in same cases, causes overflow
-#define LUMA_FP64_HIGH_BITS_OVERFLOW_WORKAROUND 1
 `;
   }
 }

--- a/modules/shadertools/src/utils/webgl-info.js
+++ b/modules/shadertools/src/utils/webgl-info.js
@@ -58,6 +58,9 @@ function identifyGPUVendor(vendor, renderer) {
   if (vendor.match(/INTEL/i) || renderer.match(/INTEL/i)) {
     return 'INTEL';
   }
+  if (vendor.match(/Apple/i) || renderer.match(/Apple/i)) {
+    return 'APPLE';
+  }
   if (
     vendor.match(/AMD/i) ||
     renderer.match(/AMD/i) ||
@@ -66,7 +69,7 @@ function identifyGPUVendor(vendor, renderer) {
   ) {
     return 'AMD';
   }
-  return 'UNKNOWN GPU';
+  return 'UNKNOWN';
 }
 
 const compiledGlslExtensions = {};


### PR DESCRIPTION
iPhone/Apple M1 have been using the custom tan_fp32 function meant for integrated intel GPUs. This PR removes the flag and we can add it back on a more targeted basis if necessary.