### PR TITLE
chore(core): export cleanup

### DIFF
--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -1,39 +1,10 @@
+// luma.gl, MIT license
+// core module exports
 
 // UTILS: undocumented API for other luma.gl modules
 export {log, assert, uid} from '@luma.gl/api';
 
 // CORE MODULE EXPORTS FOR LUMA.GL
-
-export {
-  isWebGL,
-  isWebGL2,
-  getParameters,
-  setParameters,
-  withParameters,
-  resetParameters,
-  cssToDeviceRatio,
-  cssToDevicePixels
-} from '@luma.gl/webgl';
-
-// WEBGL
-export {
-  lumaStats,
-  Buffer,
-  Program,
-  Framebuffer,
-  Renderbuffer,
-  Texture2D,
-  TextureCube,
-  clear,
-  // Copy and Blit
-  readPixelsToArray,
-  readPixelsToBuffer,
-  cloneTextureFrom,
-  copyToTexture,
-  // WebGL2 classes & Extensions
-  Texture3D,
-  TransformFeedback
-} from '@luma.gl/webgl';
 
 // ENGINE
 export {
@@ -41,7 +12,10 @@ export {
   Model,
   Transform,
   ProgramManager,
-  Timeline,
+  Timeline
+} from '@luma.gl/engine';
+
+export {
   Geometry,
   ClipSpace,
   ConeGeometry,
@@ -53,30 +27,120 @@ export {
   TruncatedConeGeometry
 } from '@luma.gl/engine';
 
-// TODO/CLEAN UP FOR V7
-//  We should have a minimal set of forwarding exports from shadertools (ideally none)
-//  Analyze risk of breaking apps
-export {
+// TODO - the following exports will be removed in v9
+
+// WEBGL - importing from `@luma.gl/core` is deprecated
+
+import {
+  isWebGL as isWebGLDeprecated,
+  isWebGL2 as isWebGL2Deprecated,
+  getParameters as getParametersDeprecated,
+  setParameters as setParametersDeprecated,
+  withParameters as withParametersDeprecated,
+  resetParameters as resetParametersDeprecated,
+  cssToDeviceRatio as cssToDeviceRatioDeprecated,
+  cssToDevicePixels as cssToDevicePixelsDeprecated,
+  lumaStats as lumaStatsDeprecated,
+  Buffer as BufferDeprecated,
+  Program as ProgramDeprecated,
+  Framebuffer as FramebufferDeprecated,
+  Renderbuffer as RenderbufferDeprecated,
+  Texture2D as Texture2DDeprecated,
+  TextureCube as TextureCubeDeprecated,
+  clear as clearDeprecated,
+  readPixelsToArray as readPixelsToArrayDeprecated,
+  readPixelsToBuffer as readPixelsToBufferDeprecated,
+  cloneTextureFrom as cloneTextureFromDeprecated,
+  copyToTexture as copyToTextureDeprecated,
+  Texture3D as Texture3DDeprecated,
+  TransformFeedback as TransformFeedbackDeprecated
+} from '@luma.gl/webgl';
+
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const isWebGL = isWebGLDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const isWebGL2 = isWebGL2Deprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const getParameters = getParametersDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const setParameters = setParametersDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const withParameters = withParametersDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const resetParameters = resetParametersDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const cssToDeviceRatio = cssToDeviceRatioDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const cssToDevicePixels = cssToDevicePixelsDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const lumaStats = lumaStatsDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const Buffer = BufferDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const Program = ProgramDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const Framebuffer = FramebufferDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const Renderbuffer = RenderbufferDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const Texture2D = Texture2DDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const TextureCube = TextureCubeDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const clear = clearDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const readPixelsToArray = readPixelsToArrayDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const readPixelsToBuffer = readPixelsToBufferDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const cloneTextureFrom = cloneTextureFromDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const copyToTexture = copyToTextureDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const Texture3D = Texture3DDeprecated;
+/** @deprecated Import directly from `@luma.gl/webgl` */
+export const TransformFeedback = TransformFeedbackDeprecated;
+
+// SHADERTOOLS - importing from `@luma.gl/core` is deprecated
+
+import {
   // HELPERS
-  normalizeShaderModule,
+  normalizeShaderModule as normalizeShaderModuleDeprecated,
   // SHADER MODULES
-  fp32,
-  fp64,
-  project,
-  dirlight,
-  picking,
-  gouraudLighting,
-  phongLighting,
-  pbr
+  fp32 as fp32Deprecated,
+  fp64 as fp64Deprecated,
+  project as projectDeprecated,
+  dirlight as dirlightDeprecated,
+  picking as pickingDeprecated,
+  gouraudLighting as gouraudLightingDeprecated,
+  phongLighting as phongLightingDeprecated,
+  pbr as pbrDeprecated
 } from '@luma.gl/shadertools';
 
-/* TODO restore for 8.7
-// GLTOOLS
+/** @deprecated Import directly from `@luma.gl/shadertools` */
+export const normalizeShaderModule = normalizeShaderModuleDeprecated;
+/** @deprecated Import directly from `@luma.gl/shadertools` */
+export const fp32 = fp32Deprecated;
+/** @deprecated Import directly from `@luma.gl/shadertools` */
+export const fp64 = fp64Deprecated;
+/** @deprecated Import directly from `@luma.gl/shadertools` */
+export const project = projectDeprecated;
+/** @deprecated Import directly from `@luma.gl/shadertools` */
+export const dirlight = dirlightDeprecated;
+/** @deprecated Import directly from `@luma.gl/shadertools` */
+export const picking = pickingDeprecated;
+/** @deprecated Import directly from `@luma.gl/shadertools` */
+export const gouraudLighting = gouraudLightingDeprecated;
+/** @deprecated Import directly from `@luma.gl/shadertools` */
+export const phongLighting = phongLightingDeprecated;
+/** @deprecated Import directly from `@luma.gl/shadertools` */
+export const pbr = pbrDeprecated;
+
+// GLTOOLS - Already marked as deprecated at source
 export {
   createGLContext,
   instrumentGLContext,
   FEATURES,
-  // hasFeature,
-  // hasFeatures,
+  hasFeature,
+  hasFeatures
 } from '@luma.gl/gltools';
-*/

--- a/modules/gltools/src/lib/deprecated/context-api.ts
+++ b/modules/gltools/src/lib/deprecated/context-api.ts
@@ -1,5 +1,6 @@
 // luma.gl, MIT license
-// LEGACY v8 API for WebGLRendering context
+// LEGACY luma.gl v8 API for WebGLRendering context
+// DEPRECATED API - may be removed in luma.gl v9 or v10.
 
 /* eslint-disable quotes */
 import GL from '@luma.gl/constants';
@@ -10,12 +11,14 @@ export type GLContextOptions = WebGLDeviceProps & {
   throwOnError?: boolean; // If set to false, return `null` if context creation fails.
 };
 
+/** @deprecated Use `new WebGLDevice()` or `luma.createDevice()` */
 export function createGLContext(options?: GLContextOptions): WebGLRenderingContext | null {
   const webglDevice = new WebGLDevice(options);
   // Note: OK to return the context, it holds on to the device
   return webglDevice.gl;
 }
 
+/** @deprecated Use `WebGLDevice.attach()` */
 export function instrumentGLContext(
   gl: WebGLRenderingContext | WebGL2RenderingContext,
   options?: GLContextOptions
@@ -37,6 +40,7 @@ export function instrumentGLContext(
  * See http://webgl2fundamentals.org/webgl/lessons/webgl-resizing-the-canvas.html
  *
  * resizeGLContext(gl, {width, height, useDevicePixels})
+ * @deprecated Use WebGLDevice.resize()
  */
 export function resizeGLContext(
   gl: WebGLRenderingContext,
@@ -50,7 +54,10 @@ export function resizeGLContext(
   webglDevice.resize(options);
 }
 
-/** Check one or more features */
+/** 
+ * Check one or more features
+ * @deprecated Use `WebGLDevice.features.has()`
+*/
 export function hasFeatures(gl: WebGLRenderingContext, features: string | string[]): boolean {
   const webglDevice = WebGLDevice.attach(gl);
   const normalizedFeatures = Array.isArray(features) ? features : [features];
@@ -62,11 +69,9 @@ function getDeviceFeature(feature) {
   return feature.toLowerCase().replace('webgl-', '').replace('-', '_');
 }
 
-// DEPRECATED API
-
 /**
  * Check one feature
- * @deprecated Use `WebGLDevice.webglFeatures` or `getFeatures()`
+ * @deprecated Use `WebGLDevice.features`
  */
 export function hasFeature(gl: WebGLRenderingContext, feature: string): boolean {
   return hasFeatures(gl, feature);
@@ -74,7 +79,7 @@ export function hasFeature(gl: WebGLRenderingContext, feature: string): boolean 
 
 /**
  * Return a map of supported features
- * @deprecated Use `WebGLDevice.webglFeatures`
+ * @deprecated Use `WebGLDevice.features`
  */
 export function getFeatures(gl: WebGLRenderingContext): Record<string, boolean>  {
   const webglDevice = WebGLDevice.attach(gl);


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1525 
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Deprecate importing webgl and shadertools re-exports through core module
- Add back deprecated gltools re-exports
