### PR TITLE
chore(gltf-material-parser): add cleanup method

### DIFF
--- a/modules/experimental/src/gltf/gltf-material-parser.ts
+++ b/modules/experimental/src/gltf/gltf-material-parser.ts
@@ -173,4 +173,11 @@ export default class GLTFMaterialParser {
       });
     }
   }
+
+  /**
+   * Destroy all generated textures to release memory.
+   */
+  destroyTextures(): void {
+    this.generatedTextures.forEach(texture => texture.delete());
+  }
 }

--- a/modules/experimental/src/gltf/gltf-material-parser.ts
+++ b/modules/experimental/src/gltf/gltf-material-parser.ts
@@ -175,9 +175,9 @@ export default class GLTFMaterialParser {
   }
 
   /**
-   * Destroy all generated textures to release memory.
+   * Destroy all generated resources to release memory.
    */
-  destroyTextures(): void {
+  deleteResources(): void {
     this.generatedTextures.forEach(texture => texture.delete());
   }
 }

--- a/modules/experimental/src/gltf/gltf-material-parser.ts
+++ b/modules/experimental/src/gltf/gltf-material-parser.ts
@@ -1,4 +1,4 @@
-import {Device, log} from '@luma.gl/api';
+import {Device, log, Texture} from '@luma.gl/api';
 import GL from '@luma.gl/constants';
 import GLTFEnvironment from './gltf-environment';
 
@@ -16,7 +16,7 @@ export default class GLTFMaterialParser {
   readonly defines: Record<string, number | boolean>;
   readonly uniforms: Record<string, any>;
   readonly parameters: Record<string, any>;
-  readonly generatedTextures: object[];
+  readonly generatedTextures: Texture[];
 
   constructor(device: Device, props: GLTFMaterialParserProps) {
     const {attributes, material, pbrDebug, imageBasedLightingEnvironment, lights, useTangents} = props;
@@ -96,7 +96,7 @@ export default class GLTFMaterialParser {
       textureOptions = {data: image};
     }
 
-    const texture = this.device.createTexture({
+    const texture: Texture = this.device.createTexture({
       id: gltfTexture.name || gltfTexture.id,
       parameters: {
         ...parameters,
@@ -177,7 +177,7 @@ export default class GLTFMaterialParser {
   /**
    * Destroy all generated resources to release memory.
    */
-  deleteResources(): void {
-    this.generatedTextures.forEach(texture => texture.delete());
+  delete(): void {
+    this.generatedTextures.forEach(texture => texture.destroy());
   }
 }

--- a/modules/experimental/src/gltf/gltf-material-parser.ts
+++ b/modules/experimental/src/gltf/gltf-material-parser.ts
@@ -1,4 +1,6 @@
-import {Device, log, Texture} from '@luma.gl/api';
+import type {Device, Texture} from '@luma.gl/api';
+import {log} from '@luma.gl/api';
+
 import GL from '@luma.gl/constants';
 import GLTFEnvironment from './gltf-environment';
 


### PR DESCRIPTION
We should be able to explicitly destroy created textures.
It will be used in deck.gl and also improve Texture statistics calculation.