### PR TITLE
chore(webgl): separate memory stats by canvas id

### DIFF
--- a/modules/webgl/src/classes/resource.js
+++ b/modules/webgl/src/classes/resource.js
@@ -295,7 +295,12 @@ export default class Resource {
   }
 
   _trackAllocatedMemory(bytes, name = this[Symbol.toStringTag]) {
-    const stats = lumaStats.get('Memory Usage');
+    this._trackAllocatedMemoryForContext(bytes, name);
+    this._trackAllocatedMemoryForContext(bytes, name, this.gl.canvas && this.gl.canvas.id);
+  }
+
+  _trackAllocatedMemoryForContext(bytes, name = this[Symbol.toStringTag], id = '') {
+    const stats = lumaStats.get(`Memory Usage${id}`);
 
     stats.get('GPU Memory').addCount(bytes);
     stats.get(`${name} Memory`).addCount(bytes);
@@ -303,7 +308,12 @@ export default class Resource {
   }
 
   _trackDeallocatedMemory(name = this[Symbol.toStringTag]) {
-    const stats = lumaStats.get('Memory Usage');
+    this._trackDeallocatedMemoryForContext(name);
+    this._trackDeallocatedMemoryForContext(name, this.gl.canvas && this.gl.canvas.id);
+  }
+
+  _trackDeallocatedMemoryForContext(name = this[Symbol.toStringTag], id = '') {
+    const stats = lumaStats.get(`Memory Usage${id}`);
 
     stats.get('GPU Memory').subtractCount(this.byteLength);
     stats.get(`${name} Memory`).subtractCount(this.byteLength);


### PR DESCRIPTION
#### Background
Having 2 maps in the comparison tool https://redesign-website.d3nof3l3x2sso4.amplifyapp.com/compare-across-layers we need to have separate lumaStats for each side.
#### Change List
- Track additional stat branches in lumaStats for each canvas id.
