### PR TITLE
chore(webgl): separate mem stats another way

### DIFF
--- a/modules/webgl/src/classes/resource.js
+++ b/modules/webgl/src/classes/resource.js
@@ -1,5 +1,5 @@
 import {isWebGL2, assertWebGLContext} from '@luma.gl/gltools';
-import {lumaStats, StatsManager} from '../init';
+import {lumaStats} from '../init';
 import {getKey, getKeyValue} from '../webgl-utils/constants-to-keys';
 import {assert} from '../utils/assert';
 import {uid} from '../utils/utils';
@@ -44,7 +44,6 @@ export default class Resource {
     // Only meaningful for resources that allocate GPU memory
     this.byteLength = 0;
 
-    this._initStats();
     this._addStats();
   }
 
@@ -279,10 +278,6 @@ export default class Resource {
     return this.gl.luma;
   }
 
-  _initStats() {
-    this.gl.stats = this.gl.stats || new StatsManager();
-  }
-
   _addStats() {
     const name = this[Symbol.toStringTag];
     const stats = lumaStats.get('Resource Counts');
@@ -300,29 +295,26 @@ export default class Resource {
   }
 
   _trackAllocatedMemory(bytes, name = this[Symbol.toStringTag]) {
-    this._doTrackAllocatedMemory(bytes, name);
-    this._doTrackAllocatedMemory(bytes, name, this.gl.stats.get(`Memory Usage`));
+    this._trackAllocatedMemoryForContext(bytes, name);
+    this._trackAllocatedMemoryForContext(bytes, name, this.gl.canvas && this.gl.canvas.id);
   }
 
-  _doTrackAllocatedMemory(
-    bytes,
-    name = this[Symbol.toStringTag],
-    stats = lumaStats.get(`Memory Usage`)
-  ) {
+  _trackAllocatedMemoryForContext(bytes, name = this[Symbol.toStringTag], id = '') {
+    const stats = lumaStats.get(`Memory Usage${id}`);
+
     stats.get('GPU Memory').addCount(bytes);
     stats.get(`${name} Memory`).addCount(bytes);
     this.byteLength = bytes;
   }
 
   _trackDeallocatedMemory(name = this[Symbol.toStringTag]) {
-    this._doTrackDeallocatedMemory(name);
-    this._doTrackDeallocatedMemory(name, this.gl.stats.get(`Memory Usage`));
+    this._trackDeallocatedMemoryForContext(name);
+    this._trackDeallocatedMemoryForContext(name, this.gl.canvas && this.gl.canvas.id);
   }
 
-  _doTrackDeallocatedMemory(
-    name = this[Symbol.toStringTag],
-    stats = lumaStats.get(`Memory Usage`)
-  ) {
+  _trackDeallocatedMemoryForContext(name = this[Symbol.toStringTag], id = '') {
+    const stats = lumaStats.get(`Memory Usage${id}`);
+
     stats.get('GPU Memory').subtractCount(this.byteLength);
     stats.get(`${name} Memory`).subtractCount(this.byteLength);
     this.byteLength = 0;


### PR DESCRIPTION
Fix an issue with adding new fields to `gl` context object in firefox and mobile safari.
