### PR TITLE
chore: drop Node 12 from CI. Use current node version for Node setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 18]
 
     steps:
       - uses: actions/checkout@v2.1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [14, 16]
 
     steps:
       - uses: actions/checkout@v2.1.1
@@ -20,7 +20,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
#### Background
- Align CI with current LTS Node releases, drop Node 12
#### Change List
- Drop Node 12
- Previously the node install wasn't using the node version in the test matrix which caused e.g. `gl` upgrade to fail.
- Can add 18 in separate PR
