### PR TITLE
chore: revert gl to v5, pin probe to >3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "esbuild": "^0.13.13",
     "eslint-plugin-luma-gl-custom-rules": "file:./dev-modules/eslint-plugin-luma-gl-custom-rules",
     "eslint-plugin-tree-shaking": "^1.9.2",
-    "gl": "^6.0.1",
+    "gl": "^5.0.3",
     "mjolnir.js": "^2.1.2",
     "mkdirp": "^0.5.1",
     "npm-normalize-package-bin": "^1.0.0",
@@ -66,11 +66,14 @@
   "resolutions_notes": [
     "TODO - remove when ocular upgrades",
     "Note: tape 4.12 and higher no longer compares 0 and -0 equally...",
-    "Note: newer prettier breaks on typescript import type"
+    "Note: newer prettier breaks on typescript import type",
+    "Note: probe.gl needs to be 3.5 or higher to avoid timeouts"
   ],
   "resolutions": {
     "tape": "4.11.0",
-    "prettier": "2.3.1"
+    "prettier": "2.3.1",
+    "@probe.gl/test-utils": "3.5.2",
+    "probe.gl": "3.5.2"
   },
   "pre-commit": [
     "test-fast"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6544,17 +6544,17 @@ gl-matrix@^3.2.1:
   resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.4.3.tgz#fc1191e8320009fd4d20e9339595c6041ddc22c9"
   integrity sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==
 
-gl@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/gl/-/gl-6.0.1.tgz#fb1e8e58fa6539072cb5b1c2debd7b81f1d6e211"
-  integrity sha512-OpW8FFG3fuRrt5ZAa3L3Ybrj66UIV+i0MWbA7tHe83P0ze0QycYrt5L6xTMgd3zsFGQPh/uKY86CFCYMnAJVGQ==
+gl@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/gl/-/gl-5.0.3.tgz#a10f37c50e48954348cc3e790b83313049bdbe1c"
+  integrity sha512-toWmb3Rgli5Wl9ygjZeglFBVLDYMOomy+rXlVZVDCoIRV+6mQE5nY4NgQgokYIc5oQzc1pvWY9lQJ0hGn61ZUg==
   dependencies:
     bindings "^1.5.0"
     bit-twiddle "^1.0.2"
     glsl-tokenizer "^2.1.5"
     nan "^2.16.0"
-    node-abi "^3.26.0"
-    node-gyp "^9.2.0"
+    node-abi "^3.22.0"
+    node-gyp "^9.0.0"
     prebuild-install "^7.1.1"
 
 glob-parent@^3.1.0:
@@ -8926,7 +8926,7 @@ no-case@^2.2.0:
   dependencies:
     lower-case "^1.1.1"
 
-node-abi@^3.26.0, node-abi@^3.3.0:
+node-abi@^3.22.0, node-abi@^3.3.0:
   version "3.28.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.28.0.tgz#b0df8b317e1c4f2f323756c5fc8ffccc5bca4718"
   integrity sha512-fRlDb4I0eLcQeUvGq7IY3xHrSb0c9ummdvDSYWfT9+LKP+3jCKw/tKoqaM7r1BAoiAC6GtwyjaGnOz6B3OtF+A==
@@ -8974,7 +8974,7 @@ node-gyp@^5.0.2:
     tar "^4.4.12"
     which "^1.3.1"
 
-node-gyp@^9.2.0:
+node-gyp@^9.0.0:
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-9.3.0.tgz#f8eefe77f0ad8edb3b3b898409b53e697642b319"
   integrity sha512-A6rJWfXFz7TQNjpldJ915WFb1LnhO4lIve3ANPbWreuEoLoKlFT3sxIepPBkLhM27crW8YmN+pjlgbasH6cH/Q==


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- gl v6 seems to have some flakiness initializing.
- puppeteer is timing out
#### Change List
- change gl to latest v5 
- pin probe.gl to v3.5 or higher since that version disables the 30s timeout
