### PR TITLE
fix(api): Support more topologies for WebGL

### DIFF
--- a/modules/api/src/adapter/resources/render-pipeline.ts
+++ b/modules/api/src/adapter/resources/render-pipeline.ts
@@ -1,6 +1,6 @@
 // luma.gl, MIT license
 import type Device from '../device';
-import type {RenderPipelineParameters} from '../types/parameters';
+import type {PrimitiveTopology, RenderPipelineParameters} from '../types/parameters';
 import type {ShaderLayout, BufferMapping, Binding} from '../types/shader-layout';
 // import {normalizeAttributeMap} from '../helpers/attribute-bindings';
 import Resource, {ResourceProps, DEFAULT_RESOURCE_PROPS} from './resource';
@@ -28,7 +28,7 @@ export type RenderPipelineProps = ResourceProps & {
   layout?: ShaderLayout | null;
 
   /** Determines how vertices are read from the 'vertex' attributes */
-  topology?: 'point-list' | 'line-list' | 'line-strip' | 'triangle-list' | 'triangle-strip';
+  topology?: PrimitiveTopology;
   /** Parameters that are controlled by pipeline */
   parameters?: RenderPipelineParameters;
   // targets...

--- a/modules/api/src/adapter/types/parameters.ts
+++ b/modules/api/src/adapter/types/parameters.ts
@@ -16,8 +16,12 @@ export type PrimitiveTopology =
   "point-list" |
   "line-list" |
   "line-strip" |
+  /** @deprecated */
+  'line-loop' |
   "triangle-list" |
-  "triangle-strip";
+  "triangle-strip" |
+  /** @deprecated */
+  'triangle-fan';
 
 export type IndexFormat = 'uint16' | 'uint32';
 

--- a/modules/api/src/adapter/types/parameters.ts.disabled
+++ b/modules/api/src/adapter/types/parameters.ts.disabled
@@ -1,4 +1,5 @@
 // luma.gl, MIT license
+import { PrimitiveTopology } from "./types/parameters";
 
 export type CompareFunction =
   'never' |
@@ -11,13 +12,6 @@ export type CompareFunction =
   'always';
 
 // Primitive state
-
-export type PrimitiveTopology =
-  "point-list" |
-  "line-list" |
-  "line-strip" |
-  "triangle-list" |
-  "triangle-strip";
 
 export type IndexFormat = 'uint16' | 'uint32';
 

--- a/modules/webgpu/src/adapter/resources/webgpu-render-pipeline.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-render-pipeline.ts
@@ -137,12 +137,19 @@ export default class WebGPURenderPipeline extends RenderPipeline {
       };
     }
 
+    switch (this.props.topology) {
+      case 'triangle-fan':
+      case 'line-loop':
+        throw new Error(`WebGPU does not support primitive topology ${this.props.topology}`);
+      default:
+    }
+
     // Create a partially populated descriptor
     let descriptor: GPURenderPipelineDescriptor = {
       vertex,
       fragment,
       primitive: {
-        topology: this.props.topology
+        topology: this.props.topology as GPUPrimitiveTopology
       }
     };
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- triangle-fan and line-loop were not included since WebGPU doesn't support them.
- Add them back to unblock initial luma porting
#### Change List
-
