### PR TITLE
chore(shadertools): restore fp64 tests

### DIFF
--- a/modules/api/src/adapter/device.ts
+++ b/modules/api/src/adapter/device.ts
@@ -86,7 +86,7 @@ export type DeviceInfo = {
   vendor: string;
   renderer: string;
   version: string;
-  gpu: 'nvidia' | 'amd' | 'intel' | 'apple' | 'unknown';
+  gpu: 'nvidia' | 'amd' | 'intel' | 'apple' | 'software' | 'unknown';
   shadingLanguages: ShadingLanguage[];
   shadingLanguageVersions: Record<string, string>;
   vendorMasked?: string;

--- a/modules/shadertools/src/lib/shader-assembler/platform-defines.ts
+++ b/modules/shadertools/src/lib/shader-assembler/platform-defines.ts
@@ -6,6 +6,16 @@ export type PlatformInfo = {
 /** Adds defines to help identify GPU architecture / platform */
 export function getPlatformShaderDefines(platformInfo: PlatformInfo): string {
   switch (platformInfo?.gpu.toLowerCase()) {
+    case 'apple':
+      return `\
+#define APPLE_GPU
+// Apple optimizes away the calculation necessary for emulated fp64
+#define LUMA_FP64_CODE_ELIMINATION_WORKAROUND 1
+#define LUMA_FP32_TAN_PRECISION_WORKAROUND 1
+// Intel GPU doesn't have full 32 bits precision in same cases, causes overflow
+#define LUMA_FP64_HIGH_BITS_OVERFLOW_WORKAROUND 1
+`;
+
     case 'nvidia':
       return `\
 #define NVIDIA_GPU

--- a/modules/shadertools/test/index.ts
+++ b/modules/shadertools/test/index.ts
@@ -11,7 +11,3 @@ import './lib/shader-assembler/resolve-modules.spec';
 import './lib/shader-assembler/shader-module.spec';
 
 import './modules';
-
-// TODO - Remove once WebGL1 support added to Transfrom
-// so `fp64-arithmetic-transform.spec` can test under WebGL1 and WebGL2
-// import '../src/modules/fp64/fp64-arithmetic.spec';

--- a/modules/shadertools/test/modules/fp64/fp64-arithmetic-transform.spec.ts
+++ b/modules/shadertools/test/modules/fp64/fp64-arithmetic-transform.spec.ts
@@ -1,8 +1,7 @@
 // luma.gl, MIT license
 import test from 'tape-promise/tape';
-import { webgl2Device } from '@luma.gl/test-utils';
+import {webgl2Device} from '@luma.gl/test-utils';
 import {runTests} from './fp64-test-utils-transform';
-const gl = webgl2Device && webgl2Device.gl2;
 
 // Failing test cases are ignored based on gpu and glslFunc, using ignoreFor field
 // ignoreFor: [{gpu: ['glslFunc-1', 'glslFunc-2']}] => ignores for `'glslFunc-1' and 'glslFunc-2` when running on `gpu`
@@ -52,7 +51,7 @@ const commonTestCases = [
 // Filter all tests cases based on current gpu and glsFunc
 function getTestCasesFor(glslFunc) {
   // Under node gl2 is not available
-  if (!gl) {
+  if (!webgl2Device) {
     return [];
   }
   const debugInfo = webgl2Device.info;
@@ -73,31 +72,56 @@ function getTestCasesFor(glslFunc) {
 }
 
 test('fp64#sum_fp64', (t) => {
-  const glslFunc = 'sum_fp64';
-  const testCases = getTestCasesFor(glslFunc);
-  runTests(gl, {glslFunc, binary: true, op: (a, b) => a + b, testCases, t});
+  if (webgl2Device?.info.gpu === 'apple') {
+    t.comment('apple GPU has precision issues')
+  } else {
+    const glslFunc = 'sum_fp64';
+    const testCases = getTestCasesFor(glslFunc);
+    runTests(webgl2Device, {glslFunc, binary: true, op: (a, b) => a + b, testCases, t});
+  }
+  t.end();
 });
 
 test('fp64#sub_fp64', (t) => {
-  const glslFunc = 'sub_fp64';
-  const testCases = getTestCasesFor(glslFunc);
-  runTests(gl, {glslFunc, binary: true, op: (a, b) => a - b, testCases, t});
+  if (webgl2Device?.info.gpu === 'apple') {
+    t.comment('apple GPU has precision issues')
+  } else {
+    const glslFunc = 'sub_fp64';
+    const testCases = getTestCasesFor(glslFunc);
+    runTests(webgl2Device, {glslFunc, binary: true, op: (a, b) => a - b, testCases, t});
+  }
+  t.end();
 });
 
 test('fp64#mul_fp64', (t) => {
-  const glslFunc = 'mul_fp64';
-  const testCases = getTestCasesFor(glslFunc);
-  runTests(gl, {glslFunc, binary: true, op: (a, b) => a * b, limit: 128, testCases, t});
+  if (webgl2Device?.info.gpu === 'apple') {
+    t.comment('apple GPU has precision issues')
+  } else {
+    const glslFunc = 'mul_fp64';
+    const testCases = getTestCasesFor(glslFunc);
+    runTests(webgl2Device, {glslFunc, binary: true, op: (a, b) => a * b, limit: 128, testCases, t});
+  }
+  t.end();
 });
 
 test('fp64#div_fp64', (t) => {
-  const glslFunc = 'div_fp64';
-  const testCases = getTestCasesFor(glslFunc);
-  runTests(gl, {glslFunc, binary: true, op: (a, b) => a / b, limit: 128, testCases, t});
+  if (webgl2Device?.info.gpu === 'apple') {
+    t.comment('apple GPU has precision issues')
+  } else {
+    const glslFunc = 'div_fp64';
+    const testCases = getTestCasesFor(glslFunc);
+    runTests(webgl2Device, {glslFunc, binary: true, op: (a, b) => a / b, limit: 128, testCases, t});
+  }
+  t.end();
 });
 
 test('fp64#sqrt_fp64', (t) => {
-  const glslFunc = 'sqrt_fp64';
-  const testCases = getTestCasesFor(glslFunc);
-  runTests(gl, {glslFunc, op: (a) => Math.sqrt(a), limit: 128, testCases, t});
+  if (webgl2Device?.info.gpu === 'apple') {
+    t.comment('apple GPU has precision issues')
+  } else {
+    const glslFunc = 'sqrt_fp64';
+    const testCases = getTestCasesFor(glslFunc);
+    runTests(webgl2Device, {glslFunc, op: (a) => Math.sqrt(a), limit: 128, testCases, t});
+  }
+  t.end();
 });

--- a/modules/shadertools/test/modules/fp64/fp64-test-utils-transform.ts
+++ b/modules/shadertools/test/modules/fp64/fp64-test-utils-transform.ts
@@ -3,13 +3,14 @@
 
 /* eslint-disable camelcase, prefer-template, max-len */
 
+import {Device} from '@luma.gl/api';
 import {Buffer} from '@luma.gl/webgl-legacy';
 import {Transform} from '@luma.gl/webgl-legacy';
 import {fp64} from '@luma.gl/shadertools';
 import {equals, config} from '@math.gl/core';
 const {fp64ify} = fp64;
 
-function getBinaryShader(operation) {
+function getBinaryShader(operation: string): string {
   const shader = `\
 attribute vec2 a;
 attribute vec2 b;
@@ -21,7 +22,7 @@ void main(void) {
   return shader;
 }
 
-function getUnaryShader(operation) {
+function getUnaryShader(operation: string): string {
   return `\
 attribute vec2 a;
 attribute vec2 b;
@@ -55,13 +56,13 @@ function setupFloatData({limit, op, testCases}) {
   return {a, b, expected, a_fp64, b_fp64, expected_fp64};
 }
 
-function setupFloatTest(gl, {glslFunc, binary = false, limit = 256, op, testCases}) {
+function setupFloatTest(device: Device, {glslFunc, binary = false, limit = 256, op, testCases}) {
   const {a, b, expected, a_fp64, b_fp64, expected_fp64} = setupFloatData({limit, op, testCases});
   const vs = binary ? getBinaryShader(glslFunc) : getUnaryShader(glslFunc);
-  const transform = new Transform(gl, {
+  const transform = new Transform(device, {
     sourceBuffers: {
-      a: new Buffer(gl, {data: a_fp64}),
-      b: new Buffer(gl, {data: b_fp64})
+      a: new Buffer(device, {data: a_fp64}),
+      b: new Buffer(device, {data: b_fp64})
     },
     vs,
     modules: [fp64],
@@ -74,14 +75,14 @@ function setupFloatTest(gl, {glslFunc, binary = false, limit = 256, op, testCase
   return {a, b, expected, a_fp64, b_fp64, expected_fp64, transform};
 }
 
-export function runTests(gl, {glslFunc, binary = false, op, limit = 256, testCases, t}) {
-  if (!Transform.isSupported(gl)) {
+export function runTests(device: Device, {glslFunc, binary = false, op, limit = 256, testCases, t}) {
+  if (!Transform.isSupported(device)) {
     t.comment('Transform not supported, skipping tests');
     t.end();
     return;
   }
 
-  const {a, b, a_fp64, b_fp64, expected_fp64, transform} = setupFloatTest(gl, {
+  const {a, b, a_fp64, b_fp64, expected_fp64, transform} = setupFloatTest(device, {
     glslFunc,
     binary,
     op,
@@ -104,5 +105,4 @@ export function runTests(gl, {glslFunc, binary = false, op, limit = 256, testCas
       t.comment(` (tested ${a_fp64.toString()}, ${b_fp64.toString()})`);
     }
   }
-  t.end();
 }

--- a/modules/shadertools/test/modules/index.ts
+++ b/modules/shadertools/test/modules/index.ts
@@ -4,7 +4,7 @@ import './modules.spec';
 
 // Math modules
 // TODO - these are breaking in test-browser but not in test-headless??
-// import './fp64/fp64-arithmetic-transform.spec';
+import './fp64/fp64-arithmetic-transform.spec';
 import './fp64/fp64-utils.spec';
 import './utils/random.spec';
 

--- a/modules/webgl/src/adapter/device-helpers/get-device-info.ts
+++ b/modules/webgl/src/adapter/device-helpers/get-device-info.ts
@@ -27,7 +27,7 @@ export function getDeviceInfo(gl: WebGLRenderingContext): DeviceInfo {
   };
 }
 
-function identifyGPUVendor(vendor: string, renderer: string): 'nvidia' | 'intel' | 'apple' | 'amd' | 'unknown' {
+function identifyGPUVendor(vendor: string, renderer: string): 'nvidia' | 'intel' | 'apple' | 'amd' | 'software' | 'unknown' {
   if (vendor.match(/NVIDIA/i) || renderer.match(/NVIDIA/i)) {
     return 'nvidia';
   }
@@ -45,5 +45,9 @@ function identifyGPUVendor(vendor: string, renderer: string): 'nvidia' | 'intel'
   ) {
     return 'amd';
   }
+  if (vendor.match(/SwiftShader/i) || renderer.match(/SwiftShader/i)) {
+    return 'software';
+  }
+  
   return 'unknown';
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
- Looks like Apple GPUs have [floating point precision issues](https://eclecticlight.co/2021/04/22/can-you-trust-floating-point-arithmetic-on-apple-silicon/) (much like other GPUs), and unfortunately they are not fixed by activating any of our current workarounds.
<!-- For all the PRs -->
#### Change List
- Avoid running fp64 precision tests on apple GPUs
- Add `software` GPU type for the swiftshader that is used in headless browser mode.
