### PR TITLE
feat: GLSL/WGSL syntax highlighting

### DIFF
--- a/examples/api-v8/program-management/app.ts
+++ b/examples/api-v8/program-management/app.ts
@@ -1,4 +1,4 @@
-import {getRandom} from '@luma.gl/api';
+import {getRandom, glsl} from '@luma.gl/api';
 import {dirlight as dirlightBase} from '@luma.gl/shadertools';
 import {makeAnimationLoop, AnimationLoopTemplate, AnimationProps, CubeGeometry} from '@luma.gl/engine';
 import {ClassicModel as Model, ProgramManager} from '@luma.gl/webgl-legacy';
@@ -11,7 +11,7 @@ const INFO_HTML = `
 Using a ProgramManager to cache and share programs between models.
 `;
 
-const vs = `\
+const vs = glsl`\
 attribute vec3 positions;
 attribute vec3 normals;
 
@@ -32,7 +32,7 @@ void main(void) {
 }
 `;
 
-const fs = `\
+const fs = glsl`\
 precision highp float;
 
 varying vec3 color;

--- a/examples/api-v8/stress-test/app.ts
+++ b/examples/api-v8/stress-test/app.ts
@@ -1,4 +1,4 @@
-import {Device, getRandom} from '@luma.gl/api';
+import {Device, getRandom,glsl} from '@luma.gl/api';
 import {makeAnimationLoop, AnimationLoopTemplate, AnimationProps, CubeGeometry} from '@luma.gl/engine';
 import {dirlight} from '@luma.gl/shadertools';
 import GL from '@luma.gl/constants';
@@ -24,7 +24,7 @@ const FAR = 2000.0;
 
 const random = getRandom();
 
-const CUBE_VERTEX = `\
+const CUBE_VERTEX = glsl`\
 #version 300 es
 #define SHADER_NAME scene.vs
 
@@ -43,7 +43,7 @@ void main(void) {
   vUV = texCoords;
 }
 `;
-const CUBE_FRAGMENT = `\
+const CUBE_FRAGMENT = glsl`\
 #version 300 es
 precision highp float;
 #define SHADER_NAME scene.fs

--- a/examples/api/animation/app.ts
+++ b/examples/api/animation/app.ts
@@ -1,3 +1,4 @@
+import {glsl} from '@luma.gl/api';
 import {makeAnimationLoop, AnimationLoopTemplate, AnimationProps, Model, CubeGeometry, Timeline, KeyFrames} from '@luma.gl/engine';
 import {clear} from '@luma.gl/webgl-legacy';
 import {dirlight} from '@luma.gl/shadertools';
@@ -14,7 +15,7 @@ Key frame animation based on multiple hierarchical timelines.
 Time: <input type="range" id="time" min="0" max="30000" step="1"><BR>
 `;
 
-const vs = `\
+const vs = glsl`\
 attribute vec3 positions;
 attribute vec3 normals;
 
@@ -35,7 +36,7 @@ void main(void) {
 }
 `;
 
-const fs = `\
+const fs = glsl`\
 precision highp float;
 
 varying vec3 color;

--- a/examples/api/cubemap/app.ts
+++ b/examples/api/cubemap/app.ts
@@ -1,4 +1,4 @@
-import {Device, loadImage} from '@luma.gl/api';
+import {Device, loadImage, glsl} from '@luma.gl/api';
 import {makeAnimationLoop, AnimationLoopTemplate, AnimationProps, CubeGeometry, Model, ModelProps} from '@luma.gl/engine';
 import {clear} from '@luma.gl/webgl-legacy';
 import GL from '@luma.gl/constants';
@@ -13,7 +13,7 @@ surface
 
 class RoomCube extends Model {
   constructor(device: Device, props: Omit<ModelProps, 'vs' | 'fs'>) {
-    const vs = `\
+    const vs = glsl`\
 attribute vec3 positions;
 
 uniform mat4 uModel;
@@ -27,7 +27,7 @@ void main(void) {
   vPosition = positions;
 }
 `;
-    const fs = `\
+    const fs = glsl`\
 precision highp float;
 
 uniform samplerCube uTextureCube;
@@ -45,7 +45,7 @@ void main(void) {
 
 class Prism extends Model {
   constructor(device: Device, props: Omit<ModelProps, 'vs' | 'fs'>) {
-    const vs = `\
+    const vs = glsl`\
 attribute vec3 positions;
 attribute vec3 normals;
 attribute vec2 texCoords;
@@ -65,7 +65,7 @@ void main(void) {
   vUV = texCoords;
 }
 `;
-    const fs = `\
+    const fs = glsl`\
 precision highp float;
 
 uniform sampler2D uTexture;

--- a/examples/api/texture-3d/app.ts
+++ b/examples/api/texture-3d/app.ts
@@ -2,7 +2,7 @@
   Ported from PicoGL.js example: https://tsherif.github.io/picogl.js/examples/3Dtexture.html
 */
 
-import {getRandom} from '@luma.gl/api';
+import {getRandom, glsl} from '@luma.gl/api';
 import {makeAnimationLoop, AnimationLoopTemplate, AnimationProps, Model} from '@luma.gl/engine';
 import GL from '@luma.gl/constants';
 import {setParameters, clear} from '@luma.gl/webgl-legacy';
@@ -18,7 +18,7 @@ Volumetric 3D noise visualized using a <b>3D texture</b>.
 Uses the luma.gl <code>Texture3D</code> class.
 `;
 
-const vs = `\
+const vs = glsl`\
 #version 300 es
 in vec3 position;
 
@@ -31,7 +31,7 @@ void main() {
   gl_PointSize = 2.0;
 }`;
 
-const fs = `\
+const fs = glsl`\
 #version 300 es
 precision highp float;
 precision lowp sampler3D;

--- a/examples/getting-started/hello-cube/app.ts
+++ b/examples/getting-started/hello-cube/app.ts
@@ -1,3 +1,4 @@
+import {glsl} from '@luma.gl/api';
 import {AnimationLoopTemplate, AnimationProps, Model, CubeGeometry} from '@luma.gl/engine';
 import {clear} from '@luma.gl/webgl-legacy';
 import {Matrix4} from '@math.gl/core';
@@ -8,7 +9,7 @@ Drawing a textured cube
 </p>
 `;
 
-const vs = `\
+const vs = glsl`\
   attribute vec3 positions;
   attribute vec2 texCoords;
 
@@ -21,7 +22,7 @@ const vs = `\
   }
 `;
 
-const fs = `\
+const fs = glsl`\
   precision highp float;
 
   uniform sampler2D uTexture;

--- a/examples/getting-started/instanced-transform/app.ts
+++ b/examples/getting-started/instanced-transform/app.ts
@@ -1,3 +1,4 @@
+import {glsl} from '@luma.gl/api';
 import {AnimationLoopTemplate, AnimationProps, CubeGeometry, Model} from '@luma.gl/engine';
 import {clear, Transform} from '@luma.gl/webgl-legacy';
 import {phongLighting} from '@luma.gl/shadertools';
@@ -23,7 +24,7 @@ const transformVs = `
   }
 `;
 
-const vs = `\
+const vs = glsl`\
   attribute vec3 positions;
   attribute vec3 normals;
   attribute vec2 texCoords;
@@ -69,7 +70,7 @@ const vs = `\
   }
 `;
 
-const fs = `\
+const fs = glsl`\
   precision highp float;
 
   uniform sampler2D uTexture;

--- a/examples/getting-started/lighting/app.ts
+++ b/examples/getting-started/lighting/app.ts
@@ -1,6 +1,7 @@
+import {glsl} from '@luma.gl/api';
 import {AnimationLoopTemplate, AnimationProps, Model, CubeGeometry} from '@luma.gl/engine';
-import {clear} from '@luma.gl/webgl-legacy';
 import {phongLighting} from '@luma.gl/shadertools';
+import {clear} from '@luma.gl/webgl-legacy';
 import {Matrix4} from '@math.gl/core';
 
 const INFO_HTML = `
@@ -9,7 +10,7 @@ Drawing a phong-shaded cube
 </p>
 `;
 
-const vs = `\
+const vs = glsl`\
   attribute vec3 positions;
   attribute vec3 normals;
   attribute vec2 texCoords;
@@ -29,7 +30,7 @@ const vs = `\
   }
 `;
 
-const fs = `\
+const fs = glsl`\
   precision highp float;
 
   uniform sampler2D uTexture;

--- a/examples/getting-started/transform-feedback/app.ts
+++ b/examples/getting-started/transform-feedback/app.ts
@@ -1,3 +1,4 @@
+import {glsl} from '@luma.gl/api';
 import {AnimationLoopTemplate, AnimationProps, Model} from '@luma.gl/engine';
 import {clear, Transform} from '@luma.gl/webgl-legacy';
 
@@ -7,7 +8,7 @@ Animation via transform feedback.
 
 const ALT_TEXT = "THIS DEMO REQUIRES WEBGL 2, BUT YOUR BROWSER DOESN'T SUPPORT IT";
 
-const transformVs = `\
+const transformVs = glsl`\
 #version 300 es
 #define SIN2 0.03489949
 #define COS2 0.99939082
@@ -24,7 +25,7 @@ void main() {
 }
 `;
 
-const renderVs = `\
+const renderVs = glsl`\
 #version 300 es
 
 in vec2 position;
@@ -37,7 +38,7 @@ void main() {
 }
 `;
 
-const renderFs = `\
+const renderFs = glsl`\
 #version 300 es
 precision highp float;
 

--- a/examples/script/index.html
+++ b/examples/script/index.html
@@ -9,6 +9,7 @@
   </head>
   <body>
     <script>
+      const glsl = x => x;
       const {mat4} = glMatrix;
 
       const SIDE = 256;
@@ -56,7 +57,7 @@
 
           const colors = new Float32Array(SIDE * SIDE * 3).map(() => Math.random() * 0.75 + 0.25);
 
-          const vs = `\
+          const vs = glsl`\
       attribute float instanceSizes;
       attribute vec3 positions;
       attribute vec3 normals;
@@ -86,7 +87,7 @@
         gl_Position = uProjection * uView * (uModel * vec4(positions * instanceSizes, 1.0) + offset);
       }
       `;
-          const fs = `\
+          const fs = glsl`\
       precision highp float;
 
       varying vec3 color;

--- a/examples/showcase/dof/app.ts
+++ b/examples/showcase/dof/app.ts
@@ -4,6 +4,7 @@
 */
 // @ts-nocheck
 
+import {glsl} from '@luma.gl/api';
 import GL from '@luma.gl/constants';
 import {makeAnimationLoop, AnimationLoopTemplate, AnimationProps, Model, CubeGeometry} from '@luma.gl/engine';
 import {
@@ -44,7 +45,7 @@ const NUM_CUBES = CUBES_PER_ROW * NUM_ROWS;
 const NEAR = 0.1;
 const FAR = 30.0;
 
-const vs = `\
+const vs = glsl`\
 #version 300 es
 #define SHADER_NAME scene.vs
 
@@ -74,7 +75,7 @@ void main(void) {
 }
 `;
 
-const fs = `\
+const fs = glsl`\
 #version 300 es
 precision highp float;
 #define SHADER_NAME scene.fs
@@ -161,7 +162,7 @@ class InstancedCube extends Model {
   }
 }
 
-const DOF_VERTEX = `\
+const DOF_VERTEX = glsl`\
 #version 300 es
 #define SHADER_NAME quad.vs
 
@@ -172,7 +173,7 @@ void main() {
 }
 `;
 
-const DOF_FRAGMENT = `\
+const DOF_FRAGMENT = glsl`\
 #version 300 es
 precision highp float;
 #define SHADER_NAME dof.fs

--- a/examples/showcase/instancing/app.ts
+++ b/examples/showcase/instancing/app.ts
@@ -1,4 +1,4 @@
-import {Device, getRandom} from '@luma.gl/api';
+import {Device, getRandom, glsl} from '@luma.gl/api';
 import {makeAnimationLoop, AnimationLoopTemplate, AnimationProps, CubeGeometry, Timeline} from '@luma.gl/engine';
 import {ClassicModel as Model, ClassicModelProps as ModelProps, ProgramManager} from '@luma.gl/webgl-legacy';
 import {picking as pickingBase, dirlight as dirlightBase} from '@luma.gl/shadertools';
@@ -34,7 +34,7 @@ const dirlight = {
   ...dirlightBase
 };
 
-const vs = `\
+const vs = glsl`\
 attribute float instanceSizes;
 attribute vec3 positions;
 attribute vec3 normals;
@@ -65,7 +65,7 @@ void main(void) {
 }
 `;
 
-const fs = `\
+const fs = glsl`\
 precision highp float;
 
 varying vec3 color;

--- a/examples/showcase/persistence/app.ts
+++ b/examples/showcase/persistence/app.ts
@@ -1,4 +1,4 @@
-import {Framebuffer, getRandom} from '@luma.gl/api';
+import {Framebuffer, getRandom, glsl} from '@luma.gl/api';
 import {makeAnimationLoop, AnimationLoopTemplate, Geometry, SphereGeometry, AnimationProps} from '@luma.gl/engine';
 import {clear, setParameters, ClassicModel as Model} from '@luma.gl/webgl-legacy';
 import {Matrix4, Vector3, radians} from '@math.gl/core';
@@ -11,7 +11,7 @@ const INFO_HTML = `
 </p>
 `;
 
-const SCREEN_QUAD_VS = `\
+const SCREEN_QUAD_VS = glsl`\
 attribute vec2 aPosition;
 
 void main(void) {
@@ -19,7 +19,7 @@ void main(void) {
 }
 `;
 
-const SCREEN_QUAD_FS = `\
+const SCREEN_QUAD_FS = glsl`\
 precision highp float;
 
 uniform sampler2D uTexture;
@@ -31,7 +31,7 @@ void main(void) {
 }
 `;
 
-const PERSISTENCE_FS = `\
+const PERSISTENCE_FS = glsl`\
 precision highp float;
 
 uniform sampler2D uScene;
@@ -46,7 +46,7 @@ void main(void) {
 }
 `;
 
-const SPHERE_VS = `\
+const SPHERE_VS = glsl`\
 attribute vec3 positions;
 attribute vec3 normals;
 
@@ -61,7 +61,7 @@ void main(void) {
 }
 `;
 
-const SPHERE_FS = `\
+const SPHERE_FS = glsl`\
 precision highp float;
 
 uniform vec3 uColor;

--- a/examples/showcase/wandering/app.ts
+++ b/examples/showcase/wandering/app.ts
@@ -1,13 +1,12 @@
 /* eslint-enable camelcase */
 // import {Buffer} from '@luma.gl/api';
+import {getRandom, glsl} from '@luma.gl/api';
 import {makeAnimationLoop, AnimationLoopTemplate, AnimationProps} from '@luma.gl/engine';
-import {Buffer} from '@luma.gl/webgl-legacy';
-import {ClassicModel as Model, Transform} from '@luma.gl/webgl-legacy';
-import {Framebuffer} from '@luma.gl/webgl-legacy';
 import {picking} from '@luma.gl/shadertools';
 import GL from '@luma.gl/constants';
+import {Buffer, ClassicModel as Model, Transform, Framebuffer} from '@luma.gl/webgl-legacy';
 
-import {getRandom} from '@luma.gl/api';
+
 // Ensure repeatable rendertests
 const random = getRandom();
 
@@ -25,7 +24,7 @@ const INFO_HTML = `
 // Text to be displayed on environments when this demos is not supported.
 const ALT_TEXT = "THIS DEMO REQUIRES WEBGL 2, BUT YOUR BROWSER DOESN'T SUPPORT IT";
 
-const EMIT_VS = `\
+const EMIT_VS = glsl`\
 #version 300 es
 #define OFFSET_LOCATION 0
 #define ROTATION_LOCATION 1
@@ -86,7 +85,7 @@ void main()
 }
 `;
 
-const DRAW_VS = `\
+const DRAW_VS = glsl`\
 #version 300 es
 #define OFFSET_LOCATION 0
 #define ROTATION_LOCATION 1
@@ -115,7 +114,7 @@ void main()
 }
 `;
 
-const DRAW_FS = `\
+const DRAW_FS = glsl`\
 #version 300 es
 #define ALPHA 0.9
 precision highp float;

--- a/examples/webgpu/hello-triangle/app.ts
+++ b/examples/webgpu/hello-triangle/app.ts
@@ -1,3 +1,4 @@
+import {glsl} from '@luma.gl/api';
 import {makeAnimationLoop, AnimationLoopTemplate, AnimationProps, Model} from '@luma.gl/engine';
 import '@luma.gl/webgpu';
 
@@ -7,14 +8,14 @@ export const description = 'Shows rendering a basic triangle.';
 /** Provide both GLSL and WGSL shaders */
 const SHADERS = {
   vs: {
-    glsl: `\
+    glsl: glsl`\
 #version 300 es
 const vec2 pos[3] = vec2[3](vec2(0.0f, 0.5f), vec2(-0.5f, -0.5f), vec2(0.5f, -0.5f));
 void main() {
   gl_Position = vec4(pos[gl_VertexID], 0.0, 1.0);
 }
 `,
-    wgsl: `\
+    wgsl: /* WGSL */`\
 [[stage(vertex)]]
 fn main([[builtin(vertex_index)]] VertexIndex : u32)
     -> [[builtin(position)]] vec4<f32> {
@@ -27,7 +28,7 @@ fn main([[builtin(vertex_index)]] VertexIndex : u32)
 `
   },
   fs: {
-    glsl: `\
+    glsl: glsl`\
 #version 300 es
 precision highp float;
 layout(location = 0) out vec4 outColor;
@@ -35,7 +36,7 @@ void main() {
     outColor = vec4(1.0, 0.0, 0.0, 1.0);
 }
 `,
-    wgsl: `\
+    wgsl: /* WGSL */`\
 [[stage(fragment)]]
 fn main() -> [[location(0)]] vec4<f32> {
   return vec4<f32>(1.0, 0.0, 0.0, 1.0);

--- a/examples/webgpu/instanced-cubes/app.ts
+++ b/examples/webgpu/instanced-cubes/app.ts
@@ -1,4 +1,4 @@
-import {Buffer, ShaderLayout, RenderPipelineParameters} from '@luma.gl/api';
+import {Buffer, ShaderLayout, RenderPipelineParameters, glsl} from '@luma.gl/api';
 import {makeAnimationLoop, AnimationLoopTemplate, AnimationProps, Model, CubeGeometry} from '@luma.gl/engine';
 import '@luma.gl/webgpu';
 import {Matrix4} from '@math.gl/core';
@@ -9,7 +9,7 @@ export const description = 'Shows usage of multiple uniform buffers.';
 /** TODO - Provide both GLSL and WGSL shaders */
 const SHADERS = {
   vs: {
-    glsl: `\
+    glsl: glsl`\
 #version 300 es
 #define SHADER_NAME cube-vs
 
@@ -29,7 +29,7 @@ void main() {
   fragPosition = vec4(position, 1.);
 }
     `,
-    wgsl: `
+    wgsl: /* WGSL */`
 struct Uniforms {
   modelViewProjectionMatrix : [[stride(64)]] array<mat4x4<f32>, 16>;
 };
@@ -55,7 +55,7 @@ fn main([[builtin(instance_index)]] instanceIdx : u32,
     `
   },
   fs: {
-    glsl: `\
+    glsl: glsl`\
 #version 300 es
 #define SHADER_NAME cube-fs
 precision highp float;
@@ -68,7 +68,7 @@ void main() {
   fragColor = fragPosition;
 }
     `,
-    wgsl: `
+    wgsl: /* WGSL */`
 [[stage(fragment)]]
 fn main([[location(0)]] fragUV: vec2<f32>,
         [[location(1)]] fragPosition: vec4<f32>) -> [[location(0)]] vec4<f32> {

--- a/examples/webgpu/rotating-cube/app.ts
+++ b/examples/webgpu/rotating-cube/app.ts
@@ -1,4 +1,4 @@
-import {Buffer} from '@luma.gl/api';
+import {Buffer, glsl} from '@luma.gl/api';
 import {makeAnimationLoop, AnimationLoopTemplate, AnimationProps, Model, CubeGeometry} from '@luma.gl/engine';
 import '@luma.gl/webgpu';
 import {Matrix4} from '@math.gl/core';
@@ -9,7 +9,7 @@ export const description = 'Shows rendering a basic triangle.';
 /** @todo - Provide both GLSL and WGSL shaders */
 const SHADERS = {
   vs: {
-    glsl: `\
+    glsl: glsl`\
 #version 300 es
 #define SHADER_NAME cube-vs
 
@@ -30,7 +30,7 @@ void main() {
   // fragPosition = 0.5 * (vec4(position, 1.) + vec4(1., 1., 1., 1.));
 }
     `,
-    wgsl: `\
+    wgsl: /* WGSL */`\
 struct Uniforms {
   modelViewProjectionMatrix : mat4x4<f32>;
 };
@@ -54,7 +54,7 @@ fn main([[location(0)]] position : vec4<f32>,
 `
   },
   fs: {
-    glsl: `\
+    glsl: glsl`\
 #version 300 es
 #define SHADER_NAME cube-fs
 precision highp float;
@@ -67,7 +67,7 @@ void main() {
   fragColor = fragPosition;
 }
     `,
-    wgsl: `\
+    wgsl: /* WGSL */`\
 [[stage(fragment)]]
 fn main([[location(0)]] fragUV: vec2<f32>,
         [[location(1)]] fragPosition: vec4<f32>) -> [[location(0)]] vec4<f32> {

--- a/examples/webgpu/textured-cube/app.ts
+++ b/examples/webgpu/textured-cube/app.ts
@@ -1,4 +1,4 @@
-import {Buffer, Texture, loadImageBitmap, ShaderLayout} from '@luma.gl/api';
+import {Buffer, Texture, loadImageBitmap, ShaderLayout, glsl} from '@luma.gl/api';
 import {Model, CubeGeometry, AnimationLoopTemplate, AnimationProps} from '@luma.gl/engine';
 // import {luma, Device, Buffer, Texture, loadImageBitmap, ShaderLayout} from '@luma.gl/api';
 // import {Model, CubeGeometry, AnimationLoopTemplate, makeAnimationLoop, AnimationProps} from '@luma.gl/engine';
@@ -13,7 +13,7 @@ const TEXTURE_URL = 'https://raw.githubusercontent.com/uber/luma.gl/8.5-release/
 /** @todo - Provide both GLSL and WGSL shaders */
 const SHADERS = {
   vs: {
-    glsl: `\
+    glsl: glsl`\
 #version 300 es
 #define SHADER_NAME cube-vs
 
@@ -34,7 +34,7 @@ void main() {
   // fragPosition = 0.5 * (vec4(position, 1.) + vec4(1., 1., 1., 1.));
 }
     `,
-    wgsl: `
+    wgsl: /* WGSL */`
 struct Uniforms {
   modelViewProjectionMatrix : mat4x4<f32>;
 };
@@ -57,7 +57,7 @@ fn main([[location(0)]] position : vec4<f32>,
 }        `
   },
   fs: {
-    glsl: `\
+    glsl: glsl`\
 #version 300 es
 #define SHADER_NAME cube-fs
 precision highp float;
@@ -72,7 +72,7 @@ void main() {
   fragColor = texture(uTexture, vec2(fragUV.x, 1.0 - fragUV.y));;
 }
   `,
-    wgsl: `
+    wgsl: /* WGSL */`
 [[group(0), binding(1)]] var mySampler: sampler;
 [[group(0), binding(2)]] var myTexture: texture_2d<f32>;
 

--- a/examples/webgpu/two-cubes/app.ts
+++ b/examples/webgpu/two-cubes/app.ts
@@ -1,5 +1,5 @@
 // luma.gl, MIT license
-import {ShaderLayout, RenderPipelineParameters, Buffer} from '@luma.gl/api';
+import {ShaderLayout, RenderPipelineParameters, Buffer, glsl} from '@luma.gl/api';
 import {makeAnimationLoop, AnimationLoopTemplate, AnimationProps, Model, CubeGeometry} from '@luma.gl/engine';
 import '@luma.gl/webgpu';
 import {Matrix4} from '@math.gl/core';
@@ -10,7 +10,7 @@ export const description = 'Shows usage of multiple uniform buffers.';
 /** Provide both GLSL and WGSL shaders */
 const SHADERS = {
   vs: {
-    glsl: `\
+    glsl: glsl`\
 #version 300 es
 #define SHADER_NAME cube-vs
 
@@ -30,7 +30,7 @@ void main() {
   fragPosition = vec4(position, 1.);
 }
     `,
-    wgsl: `
+    wgsl: /* WGSL */`
 struct Uniforms {
   modelViewProjectionMatrix : mat4x4<f32>;
 };
@@ -54,7 +54,7 @@ fn main([[location(0)]] position : vec4<f32>,
         `
 },
 fs: {
-  glsl: `\
+  glsl: glsl`\
 #version 300 es
 #define SHADER_NAME cube-fs
 precision highp float;
@@ -67,7 +67,7 @@ void main() {
   fragColor = fragPosition;
 }
     `,
-    wgsl: `
+    wgsl: /* WGSL */`
 [[stage(fragment)]]
 fn main([[location(0)]] fragUV: vec2<f32>,
         [[location(1)]] fragPosition: vec4<f32>) -> [[location(0)]] vec4<f32> {

--- a/modules/api/src/index.ts
+++ b/modules/api/src/index.ts
@@ -118,6 +118,14 @@ export {getRandom, random} from './utils/random';
 // ENGINE - TODO/move to @luma.gl/engine once that module is webgl-independent?
 export {requestAnimationFrame, cancelAnimationFrame} from './lib/request-animation-frame';
 
+// SHADER HELPERS
+
+/**
+ * Marks GLSL shaders for syntax highlighting: glsl`...`
+ * Install https://marketplace.visualstudio.com/items?itemName=boyswan.glsl-literal
+ */
+export const glsl = (x: TemplateStringsArray) => `${x}`;
+
 // INTERNAL
 
 export type {

--- a/modules/api/test/lib/uniform-buffer-layout.spec.js
+++ b/modules/api/test/lib/uniform-buffer-layout.spec.js
@@ -9,7 +9,7 @@ const VEC2 = [2.0, 2.0];
 const VEC3 = [3.0, 3.0, 3.0];
 const VEC4 = [4.0, 4.0, 4.0, 4.0];
 
-const VS = `\
+const VS = glsl`\
 #version 300 es
 in float inValue;
 layout(std140) uniform;
@@ -35,7 +35,7 @@ outValue = m * inValue;
 }
 `;
 
-const FS = `\
+const FS = glsl`\
 #version 300 es
 precision highp float;
 out vec4 oColor;

--- a/modules/engine/src/lib/clip-space.ts
+++ b/modules/engine/src/lib/clip-space.ts
@@ -5,7 +5,7 @@ import GL from '@luma.gl/constants';
 import Model, {ModelProps} from './model';
 import Geometry from '../geometry/geometry';
 
-const CLIPSPACE_VERTEX_SHADER = `\
+const CLIPSPACE_VERTEX_SHADER = glsl`\
 attribute vec2 aClipSpacePosition;
 attribute vec2 aTexCoord;
 attribute vec2 aCoordinate;

--- a/modules/engine/test/lib/pipeline-factory.spec.ts
+++ b/modules/engine/test/lib/pipeline-factory.spec.ts
@@ -1,20 +1,21 @@
 import test from 'tape-promise/tape';
 import {webgl1Device} from '@luma.gl/test-utils';
 
+import {glsl} from '@luma.gl/api';
 import {PipelineFactory} from '@luma.gl/engine';
 import {dirlight, picking} from '@luma.gl/shadertools';
 
 
 // TODO - this doesn't test that parameters etc are properly cached
 
-const vs = `\
+const vs = glsl`\
 attribute vec4 positions;
 
 void main(void) {
   gl_Position = positions;
 }
 `;
-const fs = `\
+const fs = glsl`\
 precision highp float;
 
 void main(void) {
@@ -22,7 +23,7 @@ void main(void) {
 }
 `;
 
-const VS_300 = `#version 300 es
+const VS_300 = glsl`#version 300 es
 
   in vec4 positions;
   in vec2 uvs;
@@ -35,7 +36,7 @@ const VS_300 = `#version 300 es
   }
 `;
 
-const FS_300 = `#version 300 es
+const FS_300 = glsl`#version 300 es
   precision highp float;
 
   in vec2 vUV;

--- a/modules/experimental/src/gpgpu/histopyramid/histopyramid-shaders.ts
+++ b/modules/experimental/src/gpgpu/histopyramid/histopyramid-shaders.ts
@@ -1,9 +1,10 @@
 // TODO: move to gpgpu module.
+import {glsl} from '@luma.gl/api';
 
 // Following shaders implement Histopyramid operations as described in 'High‐speed marching cubes using histopyramids' by Dyken C, Ziegler G, Theobalt C and Seidel H
 // Link to the paper: http://olmozavala.com/Custom/OpenGL/Tutorials/OpenGL4_Examples/MarchingCubes_Dyken/Dyken_et_al-2008-Computer_Graphics_Forum.pdf
 
-export const HISTOPYRAMID_BUILD_VS_UTILS = `\
+export const HISTOPYRAMID_BUILD_VS_UTILS = glsl`\
 // Get current pixel indices for a given size
 vec2 histoPyramid_getPixelIndices(vec2 size) {
   vec2 pixelOffset = transform_getPixelSizeHalf(size);
@@ -45,7 +46,7 @@ vec4 histoPyramid_getInput(sampler2D texSampler, vec2 size, vec2 scale, vec2 off
 `;
 
 // Vertex shader to build histopyramid
-export const HISTOPYRAMID_BUILD_VS = `\
+export const HISTOPYRAMID_BUILD_VS = glsl`\
 attribute vec4 inTexture;
 varying vec4 outTexture;
 
@@ -68,7 +69,7 @@ void main()
 `;
 
 // Vertex shader to build histopyramid
-export const HISTOPYRAMID_BASE_BUILD_VS = `\
+export const HISTOPYRAMID_BASE_BUILD_VS = glsl`\
 attribute vec4 inTexture;
 varying vec4 outTexture;
 uniform int channel;
@@ -124,7 +125,7 @@ void main()
 }
 `;
 
-export const HISTOPYRAMID_TRAVERSAL_UTILS = `\
+export const HISTOPYRAMID_TRAVERSAL_UTILS = glsl`\
 // Check 2X2 texture block to find relative index the given key index falls into
 // 2X2 block is represented by a single RGBA weight
 int histopyramid_traversal_findRangeIndex(float currentKey, vec4 weights, out float lowerBound) {
@@ -169,7 +170,7 @@ vec4 histopyramid_traversal_getWeight(sampler2D flatPyramid, vec2 size, int leve
 }
 `;
 
-export const HISTOPYRAMID_TRAVERSAL_VS = `\
+export const HISTOPYRAMID_TRAVERSAL_VS = glsl`\
 attribute float keyIndex;
 attribute vec4 flatPyramidTexture;
 varying vec4 locationAndIndex;

--- a/modules/experimental/src/gpgpu/point-in-polygon/shaders.ts
+++ b/modules/experimental/src/gpgpu/point-in-polygon/shaders.ts
@@ -1,4 +1,6 @@
-export const POLY_TEX_VS = `\
+import {glsl} from '@luma.gl/api';
+
+export const POLY_TEX_VS = glsl`\
 uniform vec4 boundingBoxOriginSize; //[xMin, yMin, xSize, ySize]
 attribute vec2 a_position;
 attribute float a_polygonID;
@@ -14,7 +16,7 @@ void main()
 }
 `;
 
-export const FILTER_VS = `\
+export const FILTER_VS = glsl`\
 #version 300 es
 in vec2 a_position;
 out vec2 filterValueIndex; //[x: 0 (outside polygon)/1 (inside), y: position index]

--- a/modules/experimental/test/gpgpu/histopyramid.spec.ts
+++ b/modules/experimental/test/gpgpu/histopyramid.spec.ts
@@ -3,10 +3,9 @@ import test from 'tape-promise/tape';
 import {webgl2Device} from '@luma.gl/test-utils';
 import {equals} from '@math.gl/core';
 
-import {Buffer, Texture2D} from '@luma.gl/webgl-legacy';
-import {Transform} from '@luma.gl/webgl-legacy';
+import {Transform, Buffer, Texture2D} from '@luma.gl/webgl-legacy';
 import GL from '@luma.gl/constants';
-import {_transform as transformModule} from '@luma.gl/shadertools';
+import {_transform as transformModule, glsl} from '@luma.gl/shadertools';
 import {
   buildHistopyramidBaseLevel,
   getHistoPyramid,
@@ -27,7 +26,7 @@ test('histopyramid#histoPyramid_getTexCoord', (t) => {
     return;
   }
 
-  const VS = `\
+  const VS = glsl`\
   uniform vec2 size;
   uniform vec2 scale;
   attribute float unusedAttribute;
@@ -104,7 +103,7 @@ test('histopyramid#histoPyramid_getPixelIndices', (t) => {
     return;
   }
 
-  const VS = `\
+  const VS = glsl`\
   attribute float unusedAttribute;
   varying vec2 pixelIndices;
   uniform vec2 size;
@@ -168,7 +167,7 @@ test('histopyramid#histoPyramid_getPixelIndices', (t) => {
   t.end();
 });
 
-const HISTOPYRAMID_GETINPUT_VS = `\
+const HISTOPYRAMID_GETINPUT_VS = glsl`\
 attribute float inTexture;
 varying float outTexture;
 uniform vec2 pixelOffset;
@@ -288,7 +287,7 @@ test('histopyramid#histoPyramid_getInput', (t) => {
   t.end();
 });
 
-const HISTOPYRAMID_BUILD_VS = `\
+const HISTOPYRAMID_BUILD_VS = glsl`\
 attribute float inTexture;
 varying float outTexture;
 
@@ -515,7 +514,7 @@ test('histopyramid#histopyramid_traversal_findRangeIndex', (t) => {
     return;
   }
 
-  const VS = `\
+  const VS = glsl`\
   attribute vec4 weights;
   attribute float currentKey;
   varying float relativeIndex;
@@ -565,7 +564,7 @@ test('histopyramid#histopyramid_traversal_findRangeIndex consecutive calls', (t)
     return;
   }
 
-  const VS = `\
+  const VS = glsl`\
   varying float lowerBound1;
   varying float lowerBound2;
 
@@ -612,7 +611,7 @@ test('histopyramid#histopyramid_traversal_mapIndexToCoord', (t) => {
     return;
   }
 
-  const VS = `\
+  const VS = glsl`\
   attribute float index;
   varying vec2 coord;
 
@@ -650,7 +649,7 @@ if (!DISABLE_FLAKY_TRANSFORM_TESTS) {
       return;
     }
 
-    const VS = `\
+    const VS = glsl`\
   attribute float level;
   attribute vec2 offset;
   uniform sampler2D flatPyramid;

--- a/modules/shadertools/src/index.ts
+++ b/modules/shadertools/src/index.ts
@@ -24,6 +24,14 @@ export {
   convertToVec4
 } from './lib/glsl-utils/shader-utils';
 
+// SHADER HELPERS
+
+/**
+ * Marks GLSL shaders for syntax highlighting: glsl`...`
+ * Install https://marketplace.visualstudio.com/items?itemName=boyswan.glsl-literal
+ */
+export {glsl} from './lib/glsl-utils/highlight';
+
 // SHADER MODULES
 
 // utils

--- a/modules/shadertools/src/lib/glsl-utils/highlight.ts
+++ b/modules/shadertools/src/lib/glsl-utils/highlight.ts
@@ -1,0 +1,7 @@
+// SHADER HELPERS
+
+/**
+ * Marks GLSL shaders for syntax highlighting: glsl`...`
+ * Install https://marketplace.visualstudio.com/items?itemName=boyswan.glsl-literal
+ */
+export const glsl = (x: TemplateStringsArray) => `${x}`;

--- a/modules/shadertools/src/lib/glsl-utils/shader-utils.ts
+++ b/modules/shadertools/src/lib/glsl-utils/shader-utils.ts
@@ -1,6 +1,8 @@
 // luma.gl, MIT license
-const FS100 = `void main() {gl_FragColor = vec4(0);}`;
-const FS_GLES = `\
+import {glsl} from './highlight';
+
+const FS100 = glsl`void main() {gl_FragColor = vec4(0);}`;
+const FS_GLES = glsl`\
 out vec4 transform_output;
 void main() {
   transform_output = vec4(0);

--- a/modules/shadertools/src/lib/shader-assembler/assemble-shaders.ts
+++ b/modules/shadertools/src/lib/shader-assembler/assemble-shaders.ts
@@ -1,3 +1,5 @@
+// luma.gl, MIT license
+import {glsl} from '../glsl-utils/highlight';
 import {resolveModules} from './resolve-modules';
 import {getPlatformShaderDefines, getVersionDefines, PlatformInfo} from './platform-defines';
 import injectShader, {DECLARATION_INJECT_MARKER} from './inject-shader';
@@ -18,7 +20,7 @@ const SHADER_TYPE = {
  * Precision prologue to inject before functions are injected in shader
  * TODO - extract any existing prologue in the fragment source and move it up...
  */
-const FRAGMENT_SHADER_PROLOGUE = `\
+const FRAGMENT_SHADER_PROLOGUE = glsl`\
 precision highp float;
 
 `;

--- a/modules/shadertools/src/lib/shader-assembler/platform-defines.ts
+++ b/modules/shadertools/src/lib/shader-assembler/platform-defines.ts
@@ -1,3 +1,7 @@
+// luma.gl, MIT license
+
+import {glsl} from '../glsl-utils/highlight';
+
 export type PlatformInfo = {
   gpu: string;
   features: Set<string>;
@@ -7,7 +11,7 @@ export type PlatformInfo = {
 export function getPlatformShaderDefines(platformInfo: PlatformInfo): string {
   switch (platformInfo?.gpu.toLowerCase()) {
     case 'apple':
-      return `\
+      return glsl`\
 #define APPLE_GPU
 // Apple optimizes away the calculation necessary for emulated fp64
 #define LUMA_FP64_CODE_ELIMINATION_WORKAROUND 1
@@ -17,14 +21,14 @@ export function getPlatformShaderDefines(platformInfo: PlatformInfo): string {
 `;
 
     case 'nvidia':
-      return `\
+      return glsl`\
 #define NVIDIA_GPU
 // Nvidia optimizes away the calculation necessary for emulated fp64
 #define LUMA_FP64_CODE_ELIMINATION_WORKAROUND 1
 `;
 
     case 'intel':
-      return `\
+      return glsl`\
 #define INTEL_GPU
 // Intel optimizes away the calculation necessary for emulated fp64
 #define LUMA_FP64_CODE_ELIMINATION_WORKAROUND 1
@@ -36,7 +40,7 @@ export function getPlatformShaderDefines(platformInfo: PlatformInfo): string {
 
     case 'amd':
       // AMD Does not eliminate fp64 code
-      return `\
+      return glsl`\
 #define AMD_GPU
 `;
 
@@ -44,7 +48,7 @@ export function getPlatformShaderDefines(platformInfo: PlatformInfo): string {
       // We don't know what GPU it is, could be that the GPU driver or
       // browser is not implementing UNMASKED_RENDERER constant and not
       // reporting a correct name
-      return `\
+      return glsl`\
 #define DEFAULT_GPU
 // Prevent driver from optimizing away the calculation necessary for emulated fp64
 #define LUMA_FP64_CODE_ELIMINATION_WORKAROUND 1
@@ -54,7 +58,7 @@ export function getPlatformShaderDefines(platformInfo: PlatformInfo): string {
 
 /** Adds defines to let shaders portably v1/v3 check for features */
 export function getVersionDefines(platformInfo: PlatformInfo): string {
-  let versionDefines = `\
+  let versionDefines = glsl`\
 #if (__VERSION__ > 120)
 
 # define FEATURE_GLSL_DERIVATIVES
@@ -72,7 +76,7 @@ export function getVersionDefines(platformInfo: PlatformInfo): string {
 `;
 
   if (platformInfo.features.has('glsl-frag-depth')) {
-    versionDefines += `\
+    versionDefines += glsl`\
 
 // FRAG_DEPTH => gl_FragDepth is available
 #ifdef GL_EXT_frag_depth
@@ -84,7 +88,7 @@ export function getVersionDefines(platformInfo: PlatformInfo): string {
 `;
   }
   if (platformInfo?.features.has('glsl-derivatives')) {
-    versionDefines += `\
+    versionDefines += glsl`\
 
 // DERIVATIVES => dxdF, dxdY and fwidth are available
 #if defined(GL_OES_standard_derivatives) || defined(FEATURE_GLSL_DERIVATIVES)
@@ -95,7 +99,7 @@ export function getVersionDefines(platformInfo: PlatformInfo): string {
 `;
   }
   if (platformInfo?.features.has('glsl-frag-data')) {
-    versionDefines += `\
+    versionDefines += glsl`\
 
 // DRAW_BUFFERS => gl_FragData[] is available
 #ifdef GL_EXT_draw_buffers
@@ -106,7 +110,7 @@ export function getVersionDefines(platformInfo: PlatformInfo): string {
 `;
   }
   if (platformInfo?.features.has('glsl-texture-lod')) {
-    versionDefines += `\
+    versionDefines += glsl`\
 // TEXTURE_LOD => texture2DLod etc are available
 #ifdef GL_EXT_shader_texture_lod
 #extension GL_EXT_shader_texture_lod : enable

--- a/modules/shadertools/src/modules/dirlight/dirlight.ts
+++ b/modules/shadertools/src/modules/dirlight/dirlight.ts
@@ -1,4 +1,5 @@
 // luma.gl, MIT license
+import {glsl} from '../../lib/glsl-utils/highlight';
 import type {NumberArray} from '../../types';
 import {project} from '../project/project';
 
@@ -19,7 +20,7 @@ function getUniforms(opts: DirlightOptions = DEFAULT_MODULE_OPTIONS): Record<str
   return uniforms;
 }
 
-var fs = `\
+var fs = glsl`\
 uniform vec3 dirlight_uLightDirection;
 
 /*

--- a/modules/shadertools/src/modules/fp32/fp32.ts
+++ b/modules/shadertools/src/modules/fp32/fp32.ts
@@ -1,6 +1,7 @@
+import {glsl} from '../../lib/glsl-utils/highlight';
 // import {ShaderModule} from '../../types';
 
-const fp32shader = `\
+const fp32shader = glsl`\
 #ifdef LUMA_FP32_TAN_PRECISION_WORKAROUND
 
 // All these functions are for substituting tan() function from Intel GPU only

--- a/modules/shadertools/src/modules/fp64/fp64-arithmetic.glsl.ts
+++ b/modules/shadertools/src/modules/fp64/fp64-arithmetic.glsl.ts
@@ -1,6 +1,7 @@
 // luma.gl, MIT license
+import {glsl} from '../../lib/glsl-utils/highlight';
 
-export default `\
+export default glsl`\
 uniform float ONE;
 
 /*

--- a/modules/shadertools/src/modules/fp64/fp64-functions.glsl.ts
+++ b/modules/shadertools/src/modules/fp64/fp64-functions.glsl.ts
@@ -1,6 +1,7 @@
 // luma.gl, MIT license
+import {glsl} from '../../lib/glsl-utils/highlight';
 
-export default `\
+export default glsl`\
 const vec2 E_FP64 = vec2(2.7182817459106445e+00, 8.254840366817007e-08);
 const vec2 LOG2_FP64 = vec2(0.6931471824645996e+00, -1.9046542121259336e-09);
 const vec2 PI_FP64 = vec2(3.1415927410125732, -8.742278012618954e-8);

--- a/modules/shadertools/src/modules/geometry/geometry.ts
+++ b/modules/shadertools/src/modules/geometry/geometry.ts
@@ -1,7 +1,8 @@
 // import {ShaderModule} from '../../types';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
 // TODO - reuse normal from geometry module
-const vs = `\
+const vs = glsl`\
 varying vec4 geometry_vPosition;
 varying vec3 geometry_vNormal;
 
@@ -18,7 +19,7 @@ void geometry_setPosition(vec3 position) {
 }
 `;
 
-const fs = `\
+const fs = glsl`\
 varying vec4 geometry_vPosition;
 varying vec3 geometry_vNormal;
 

--- a/modules/shadertools/src/modules/image-adjust-filters/brightnesscontrast.ts
+++ b/modules/shadertools/src/modules/image-adjust-filters/brightnesscontrast.ts
@@ -1,3 +1,4 @@
+import {glsl} from '../../lib/glsl-utils/highlight';
 // import {ShaderPass} from '../../lib/shaderpass';
 
 
@@ -11,7 +12,7 @@ const uniforms = {
   contrast: {value: 0, min: -1, max: 1}
 };
 
-var fs = `\
+var fs = glsl`\
 uniform float brightness;
 uniform float contrast;
 

--- a/modules/shadertools/src/modules/image-adjust-filters/denoise.ts
+++ b/modules/shadertools/src/modules/image-adjust-filters/denoise.ts
@@ -1,7 +1,8 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
 // Do a 9x9 bilateral box filter
-const fs = `\
+const fs = glsl`\
 uniform float strength;
 
 vec4 denoise_sampleColor(sampler2D texture, vec2 texSize, vec2 texCoord) {

--- a/modules/shadertools/src/modules/image-adjust-filters/huesaturation.ts
+++ b/modules/shadertools/src/modules/image-adjust-filters/huesaturation.ts
@@ -1,6 +1,7 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
-const fs = `\
+const fs = glsl`\
 uniform float hue;
 uniform float saturation;
 

--- a/modules/shadertools/src/modules/image-adjust-filters/noise.ts
+++ b/modules/shadertools/src/modules/image-adjust-filters/noise.ts
@@ -1,6 +1,7 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
-const fs = `\
+const fs = glsl`\
 uniform float amount;
 
 float rand(vec2 co) {

--- a/modules/shadertools/src/modules/image-adjust-filters/sepia.ts
+++ b/modules/shadertools/src/modules/image-adjust-filters/sepia.ts
@@ -1,6 +1,7 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
-const fs = `\
+const fs = glsl`\
 uniform float amount;
 
 vec4 sepia_filterColor(vec4 color) {

--- a/modules/shadertools/src/modules/image-adjust-filters/vibrance.ts
+++ b/modules/shadertools/src/modules/image-adjust-filters/vibrance.ts
@@ -1,6 +1,7 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
-const fs = `\
+const fs = glsl`\
 uniform float amount;
 
 vec4 vibrance_filterColor(vec4 color) {

--- a/modules/shadertools/src/modules/image-adjust-filters/vignette.ts
+++ b/modules/shadertools/src/modules/image-adjust-filters/vignette.ts
@@ -1,6 +1,7 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
-const fs = `\
+const fs = glsl`\
 uniform float radius;
 uniform float amount;
 

--- a/modules/shadertools/src/modules/image-blur-filters/triangleblur.ts
+++ b/modules/shadertools/src/modules/image-blur-filters/triangleblur.ts
@@ -1,7 +1,8 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
 import {random} from '../utils/random';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
-const fs = `\
+const fs = glsl`\
 uniform float radius;
 uniform vec2 delta;
 

--- a/modules/shadertools/src/modules/image-fun-filters/colorhalftone.ts
+++ b/modules/shadertools/src/modules/image-fun-filters/colorhalftone.ts
@@ -1,7 +1,8 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
 // TODO pass texCoord to angle
-const fs = `\
+const fs = glsl`\
 uniform vec2 center;
 uniform float angle;
 uniform float size;

--- a/modules/shadertools/src/modules/image-fun-filters/dotscreen.ts
+++ b/modules/shadertools/src/modules/image-fun-filters/dotscreen.ts
@@ -1,6 +1,7 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
-const fs = `\
+const fs = glsl`\
 uniform vec2 center;
 uniform float angle;
 uniform float size;

--- a/modules/shadertools/src/modules/image-fun-filters/edgework.ts
+++ b/modules/shadertools/src/modules/image-fun-filters/edgework.ts
@@ -1,8 +1,9 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
 
 import {random} from '../utils/random';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
-const fs = `\
+const fs = glsl`\
 uniform float radius;
 uniform vec2 delta;
 

--- a/modules/shadertools/src/modules/image-fun-filters/hexagonalpixelate.ts
+++ b/modules/shadertools/src/modules/image-fun-filters/hexagonalpixelate.ts
@@ -1,6 +1,7 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
-const fs = `\
+const fs = glsl`\
 uniform vec2 center;
 uniform float scale;
 

--- a/modules/shadertools/src/modules/image-fun-filters/ink.ts
+++ b/modules/shadertools/src/modules/image-fun-filters/ink.ts
@@ -1,6 +1,7 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
-const fs = `\
+const fs = glsl`\
 uniform float strength;
 
 vec4 ink_sampleColor(sampler2D texture, vec2 texSize, vec2 texCoord) {

--- a/modules/shadertools/src/modules/image-warp-filters/bulgepinch.ts
+++ b/modules/shadertools/src/modules/image-warp-filters/bulgepinch.ts
@@ -1,8 +1,8 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
-
+import {glsl} from '../../lib/glsl-utils/highlight';
 import {warp} from './warp';
 
-const fs = `\
+const fs = glsl`\
 uniform float radius;
 uniform float strength;
 uniform vec2 center;

--- a/modules/shadertools/src/modules/image-warp-filters/swirl.ts
+++ b/modules/shadertools/src/modules/image-warp-filters/swirl.ts
@@ -1,7 +1,8 @@
 // import type {ShaderPass} from '../../lib/shader-pass-descriptor';
+import {glsl} from '../../lib/glsl-utils/highlight';
 import {warp} from './warp';
 
-const fs = `\
+const fs = glsl`\
 uniform float radius;
 uniform float angle;
 uniform vec2 center;

--- a/modules/shadertools/src/modules/image-warp-filters/warp.ts
+++ b/modules/shadertools/src/modules/image-warp-filters/warp.ts
@@ -1,4 +1,6 @@
-const fs = `\
+import {glsl} from '../../lib/glsl-utils/highlight';
+
+const fs = glsl`\
 vec4 warp_sampleColor(sampler2D texture, vec2 texSize, vec2 coord) {
   vec4 color = texture2D(texture, coord / texSize);
   vec2 clampedCoord = clamp(coord, vec2(0.0), texSize);

--- a/modules/shadertools/src/modules/lights/lights.glsl.ts
+++ b/modules/shadertools/src/modules/lights/lights.glsl.ts
@@ -1,4 +1,6 @@
-export default `\
+import {glsl} from '../../lib/glsl-utils/highlight';
+
+export default glsl`\
 #if (defined(SHADER_TYPE_FRAGMENT) && defined(LIGHTING_FRAGMENT)) || (defined(SHADER_TYPE_VERTEX) && defined(LIGHTING_VERTEX))
 
 struct AmbientLight {

--- a/modules/shadertools/src/modules/module-injectors.ts
+++ b/modules/shadertools/src/modules/module-injectors.ts
@@ -1,10 +1,12 @@
-export const MODULE_INJECTORS_VS = `\
+import {glsl} from '../lib/glsl-utils/highlight';
+
+export const MODULE_INJECTORS_VS = glsl`\
 #ifdef MODULE_LOGDEPTH
   logdepth_adjustPosition(gl_Position);
 #endif
 `;
 
-export const MODULE_INJECTORS_FS = `\
+export const MODULE_INJECTORS_FS = glsl`\
 #ifdef MODULE_MATERIAL
   gl_FragColor = material_filterColor(gl_FragColor);
 #endif

--- a/modules/shadertools/src/modules/pbr/pbr-fragment.glsl.ts
+++ b/modules/shadertools/src/modules/pbr/pbr-fragment.glsl.ts
@@ -5,7 +5,9 @@
 // MIT license, Copyright (c) 2016-2017 Mohamad Moneimne and Contributors
 
 // TODO - better do the checks outside of shader
-export default `\
+import {glsl} from '../../lib/glsl-utils/highlight';
+
+export default glsl`\
 #if defined(USE_TEX_LOD) && !defined(FEATURE_GLSL_TEXTURE_LOD)
 # error PBR fragment shader: Texture LOD is not available
 #endif

--- a/modules/shadertools/src/modules/pbr/pbr-vertex.glsl.ts
+++ b/modules/shadertools/src/modules/pbr/pbr-vertex.glsl.ts
@@ -1,4 +1,6 @@
-export default `\
+import {glsl} from '../../lib/glsl-utils/highlight';
+
+export default glsl`\
 uniform mat4 u_MVPMatrix;
 uniform mat4 u_ModelMatrix;
 uniform mat4 u_NormalMatrix;

--- a/modules/shadertools/src/modules/phong-lighting/phong-lighting.glsl.ts
+++ b/modules/shadertools/src/modules/phong-lighting/phong-lighting.glsl.ts
@@ -1,4 +1,6 @@
-export default `\
+import {glsl} from '../../lib/glsl-utils/highlight';
+
+export default glsl`\
 
 uniform float lighting_uAmbient;
 uniform float lighting_uDiffuse;

--- a/modules/shadertools/src/modules/picking/picking.ts
+++ b/modules/shadertools/src/modules/picking/picking.ts
@@ -1,4 +1,5 @@
 import {NumberArray} from '../../types';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
 const DEFAULT_HIGHLIGHT_COLOR = new Uint8Array([0, 255, 255, 255]);
 
@@ -41,7 +42,7 @@ function getUniforms(opts = DEFAULT_MODULE_OPTIONS): Record<string, any> {
   return uniforms;
 }
 
-const vs = `\
+const vs = glsl`\
 uniform bool picking_uActive;
 uniform bool picking_uAttribute;
 uniform vec3 picking_uSelectedColor;
@@ -93,7 +94,7 @@ void picking_setPickingAttribute(vec3 value) {
 }
 `;
 
-const fs = `\
+const fs = glsl`\
 uniform bool picking_uActive;
 uniform vec3 picking_uSelectedColor;
 uniform vec4 picking_uHighlightColor;

--- a/modules/shadertools/src/modules/project/project.ts
+++ b/modules/shadertools/src/modules/project/project.ts
@@ -1,4 +1,5 @@
 import {Matrix4} from '@math.gl/core';
+import {glsl} from '../../lib/glsl-utils/highlight';
 
 const IDENTITY_MATRIX = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 
@@ -38,7 +39,7 @@ function getUniforms(opts = DEFAULT_MODULE_OPTIONS, prevUniforms = {}) {
   return uniforms;
 }
 
-const common = `\
+const common = glsl`\
 varying vec4 project_vPositionWorld;
 varying vec3 project_vNormalWorld;
 

--- a/modules/shadertools/src/modules/transform/transform.ts
+++ b/modules/shadertools/src/modules/transform/transform.ts
@@ -1,4 +1,6 @@
-const vs = `\
+import {glsl} from '../../lib/glsl-utils/highlight';
+
+const vs = glsl`\
 attribute float transform_elementID;
 
 // returns half of pixel size, used to move the pixel position to center of the pixel.

--- a/modules/shadertools/src/modules/utils/random.ts
+++ b/modules/shadertools/src/modules/utils/random.ts
@@ -1,4 +1,6 @@
-const fs = `\
+import {glsl} from '../../lib/glsl-utils/highlight';
+
+const fs = glsl`\
 float random(vec3 scale, float seed) {
   /* use the fragment position for a different seed per-pixel */
   return fract(sin(dot(gl_FragCoord.xyz + seed, scale)) * 43758.5453 + seed);

--- a/modules/shadertools/test/lib/glsl-utils/get-shader-info.spec.js
+++ b/modules/shadertools/test/lib/glsl-utils/get-shader-info.spec.js
@@ -1,39 +1,46 @@
 import test from 'tape-promise/tape';
-import {getShaderInfo} from '@luma.gl/shadertools';
+import {getShaderInfo, glsl} from '@luma.gl/shadertools';
 
-const SHADER_1 = `\
+const SHADER_1 = glsl`\
 uniform float floaty;
 #define SHADER_NAME name-of-shader
 main() {}
 `;
 
-const SHADER_2 = `\
+const SHADER_2 = glsl`\
 uniform float floaty;
 #define SHADER name
 main() {}
 `;
 
 const SHADER1 = 'void main() {}';
+
 const SHADER2 = '#version 100 void main() {}';
-const SHADER3 = `\
+
+const SHADER3 = glsl`\
 void main() {
 
 }`;
-const SHADER4 = `\
+
+const SHADER4 = glsl`\
 #version 300 es
 void main() {
 
 }`;
+
 const SHADER5 = `#version 300 es
 void main() {
 
 }`;
-const SHADER6 = `\
+
+const SHADER6 = glsl`\
 #version 100
 void main() {
 
 }`;
-const SHADER7 = '#version 300 es void main() {}';
+
+const SHADER7 = glsl`#version 300 es void main() {}`;
+
 const versionTests = {
   [SHADER1]: 100,
   [SHADER2]: 100,

--- a/modules/shadertools/test/lib/glsl-utils/shader-utils.spec.js
+++ b/modules/shadertools/test/lib/glsl-utils/shader-utils.spec.js
@@ -1,11 +1,12 @@
+import test from 'tape-promise/tape';
 import {
   getQualifierDetails,
   getPassthroughFS,
   typeToChannelSuffix,
   typeToChannelCount,
-  convertToVec4
+  convertToVec4,
+  glsl
 } from '@luma.gl/shadertools';
-import test from 'tape-promise/tape';
 
 test('shader-utils#getQualifierDetails', (t) => {
   const QUALIFIER_TEST_CASES = [
@@ -57,7 +58,7 @@ test('shader-utils#getPassthroughFS', (t) => {
       version: 100,
       input: 'myInput',
       inputType: 'vec2',
-      expected: `\
+      expected: glsl`\
 varying vec2 myInput;
 void main() {
   gl_FragColor = vec4(myInput, 0.0, 1.0);
@@ -68,7 +69,7 @@ void main() {
       input: 'myInput',
       inputType: 'float',
       output: 'myOutput',
-      expected: `\
+      expected: glsl`\
 #version 300 es
 in float myInput;
 out vec4 myOutput;

--- a/modules/shadertools/test/lib/glsl-utils/shader-utils.spec.ts
+++ b/modules/shadertools/test/lib/glsl-utils/shader-utils.spec.ts
@@ -3,7 +3,8 @@ import {
   getPassthroughFS,
   typeToChannelSuffix,
   typeToChannelCount,
-  convertToVec4
+  convertToVec4,
+  glsl
 } from '@luma.gl/shadertools';
 import test from 'tape-promise/tape';
 
@@ -57,7 +58,7 @@ test('shader-utils#getPassthroughFS', (t) => {
       version: 100,
       input: 'myInput',
       inputType: 'vec2',
-      expected: `\
+      expected: glsl`\
 varying vec2 myInput;
 void main() {
   gl_FragColor = vec4(myInput, 0.0, 1.0);
@@ -68,7 +69,7 @@ void main() {
       input: 'myInput',
       inputType: 'float',
       output: 'myOutput',
-      expected: `\
+      expected: glsl`\
 #version 300 es
 in float myInput;
 out vec4 myOutput;

--- a/modules/shadertools/test/lib/shader-assembler/assemble-shaders.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembler/assemble-shaders.spec.ts
@@ -1,7 +1,7 @@
 import test from 'tape-promise/tape';
 import {Device} from '@luma.gl/api';
 import {webgl1Device, webgl2Device} from '@luma.gl/test-utils';
-import {assembleShaders, picking, fp64, pbr} from '@luma.gl/shadertools';
+import {assembleShaders, picking, fp64, pbr, glsl} from '@luma.gl/shadertools';
 import type {WebGLDevice} from '@luma.gl/webgl';
 import {isBrowser} from '@probe.gl/env';
 
@@ -12,7 +12,7 @@ function getInfo(device: Device) {
   };
 }
 
-const VS_GLSL_300 = `\
+const VS_GLSL_300 = glsl`\
 #version 300 es
 
 in vec4 positions;
@@ -22,7 +22,7 @@ void main(void) {
 }
 `;
 
-const FS_GLSL_300 = `\
+const FS_GLSL_300 = glsl`\
 #version 300 es
 
 precision highp float;
@@ -34,7 +34,7 @@ void main(void) {
 }
 `;
 
-const VS_GLSL_300_2 = `\
+const VS_GLSL_300_2 = glsl`\
 #version 300 es
 
 in vec4 positions;
@@ -65,7 +65,7 @@ void main(void) {
 }
 `;
 
-const FS_GLSL_300_2 = `\
+const FS_GLSL_300_2 = glsl`\
 #version 300 es
 
 precision highp float;
@@ -85,7 +85,8 @@ void main(void) {
 // deck.gl mesh layer shaders
 // TODO - broken tests
 
-const VS_GLSL_300_DECK = `#version 300 es
+const VS_GLSL_300_DECK = glsl`\
+#version 300 es
 #define SHADER_NAME simple-mesh-layer-vs
 
 // Scale the model
@@ -129,7 +130,8 @@ void main(void) {
 }
 `;
 
-const FS_GLSL_300_DECK = `#version 300 es
+const FS_GLSL_300_DECK = glsl`\
+#version 300 es
 #define SHADER_NAME simple-mesh-layer-fs
 
 precision highp float;
@@ -161,7 +163,8 @@ void main(void) {
 }
 `;
 
-const VS_GLSL_300_GLTF = `#version 300 es
+const VS_GLSL_300_GLTF = glsl`\
+#version 300 es
 
 #if (__VERSION__ < 300)
   #define _attr attribute
@@ -205,7 +208,8 @@ const VS_GLSL_300_GLTF = `#version 300 es
   }
 `;
 
-const FS_GLSL_300_GLTF = `#version 300 es
+const FS_GLSL_300_GLTF = glsl`\
+#version 300 es
 
   out vec4 fragmentColor;
 
@@ -227,7 +231,7 @@ const TEST_MODULE = {
   }
 };
 
-const VS_GLSL_300_MODULES = `\
+const VS_GLSL_300_MODULES = glsl`\
 #version 300 es
 
 in float floatAttribute;
@@ -239,7 +243,7 @@ void main(void) {
 }
 `;
 
-const FS_GLSL_300_MODULES = `\
+const FS_GLSL_300_MODULES = glsl`\
 #version 300 es
 precision highp float;
 

--- a/modules/shadertools/test/lib/shader-assembler/inject-shader.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembler/inject-shader.spec.ts
@@ -2,7 +2,7 @@
 import test from 'tape-promise/tape';
 import {Device} from '@luma.gl/api';
 import {webgl1Device} from '@luma.gl/test-utils';
-import {assembleShaders} from '@luma.gl/shadertools';
+import {assembleShaders, glsl} from '@luma.gl/shadertools';
 import injectShader, {
   combineInjects,
   DECLARATION_INJECT_MARKER
@@ -33,7 +33,7 @@ void main(void) {
 
 const VS_GLSL_RESOLVED_DECL = 'uniform float uNewUniform';
 
-const VS_GLSL_RESOLVED_MAIN = `\
+const VS_GLSL_RESOLVED_MAIN = glsl`\
 void main(void) {
   vNew = uNewUniform;
   gl_Position = positions;
@@ -61,7 +61,7 @@ void main(void) {
 
 const FS_GLSL_RESOLVED_DECL = 'uniform bool uDiscard';
 
-const FS_GLSL_RESOLVED_MAIN = `\
+const FS_GLSL_RESOLVED_MAIN = glsl`\
 void main(void) {
   if (uDiscard} { discard } else {
   fragmentColor = vColor;

--- a/modules/shadertools/test/lib/transpiler/transpile-shader-cases.ts
+++ b/modules/shadertools/test/lib/transpiler/transpile-shader-cases.ts
@@ -1,3 +1,5 @@
+import {glsl} from '@luma.gl/shadertools';
+
 /**
  *
  */
@@ -7,7 +9,7 @@ export const TRANSPILATION_TEST_CASES = [
     isVertex: true,
 
     // 300 version should use 'textureCube()'' instead of 'texture()'
-    GLSL_300: `\
+    GLSL_300: glsl`\
 #version 300 es
 
 in vec4 positions;
@@ -34,7 +36,7 @@ void main(void) {
 `,
 
     // transpiled 300 version should have correct `texure()` syntax
-    GLSL_300_TRANSPILED: `\
+    GLSL_300_TRANSPILED: glsl`\
 #version 300 es
 
 in vec4 positions;
@@ -60,7 +62,7 @@ void main(void) {
 }
 `,
 
-    GLSL_100: `\
+    GLSL_100: glsl`\
 #version 100
 
 attribute vec4 positions;
@@ -91,7 +93,7 @@ void main(void) {
     isVertex: false,
 
     // 300 version should use 'textureCube()'' instead of 'texture()'
-    GLSL_300: `\
+    GLSL_300: glsl`\
 #version 300 es
 
 precision highp float;
@@ -115,7 +117,7 @@ void main(void) {
 `,
 
     // transpiled 300 version should have correct `texure()` syntax
-    GLSL_300_TRANSPILED: `\
+    GLSL_300_TRANSPILED: glsl`\
 #version 300 es
 
 precision highp float;
@@ -138,7 +140,7 @@ void main(void) {
 }
 `,
 
-    GLSL_100: `\
+    GLSL_100: glsl`\
 #version 100
 
 precision highp float;
@@ -165,7 +167,7 @@ void main(void) {
 export const COMPILATION_TEST_CASES = [
   {
     title: 'textureCube',
-    VS_300_VALID: `\
+    VS_300_VALID: glsl`\
 #version 300 es
 
 in vec4 positions;
@@ -183,7 +185,7 @@ void main(void) {
 }
 `,
 
-    FS_300_VALID: `\
+    FS_300_VALID: glsl`\
 #version 300 es
 
 precision highp float;

--- a/modules/shadertools/test/modules/fp64/fp64-test-utils-transform.ts
+++ b/modules/shadertools/test/modules/fp64/fp64-test-utils-transform.ts
@@ -4,8 +4,7 @@
 /* eslint-disable camelcase, prefer-template, max-len */
 
 import {Device} from '@luma.gl/api';
-import {Buffer} from '@luma.gl/webgl-legacy';
-import {Transform} from '@luma.gl/webgl-legacy';
+import {Buffer, Transform} from '@luma.gl/webgl-legacy';
 import {fp64} from '@luma.gl/shadertools';
 import {equals, config} from '@math.gl/core';
 const {fp64ify} = fp64;

--- a/modules/webgl-legacy/test/classic/transform-feedback.spec.js
+++ b/modules/webgl-legacy/test/classic/transform-feedback.spec.js
@@ -1,3 +1,4 @@
+import {glsl} from '@luma.gl/api';
 import GL from '@luma.gl/constants';
 import {TransformFeedback, Buffer} from '@luma.gl/webgl-legacy';
 // TODO - tests shouldn't depend on higher level module?
@@ -6,7 +7,7 @@ import test from 'tape-promise/tape';
 
 import {fixture} from 'test/setup';
 
-const VS = `\
+const VS = glsl`\
 attribute float inValue;
 varying float outValue;
 void main()
@@ -15,7 +16,7 @@ void main()
 }
 `;
 
-const FS = `\
+const FS = glsl`\
 varying float outValue;
 void main()
 {

--- a/modules/webgl-legacy/test/classic/uniform-buffer-layout.spec.js
+++ b/modules/webgl-legacy/test/classic/uniform-buffer-layout.spec.js
@@ -1,4 +1,5 @@
 import test from 'tape-promise/tape';
+import {glsl} from '@luma.gl/api';
 import GL from '@luma.gl/constants';
 import {UniformBufferLayout, Buffer, Program} from '@luma.gl/webgl-legacy';
 // TODO - tests shouldn't depend on higher level module?
@@ -11,7 +12,7 @@ const VEC2 = [2.0, 2.0];
 const VEC3 = [3.0, 3.0, 3.0];
 const VEC4 = [4.0, 4.0, 4.0, 4.0];
 
-const VS = `\
+const VS = glsl`\
 #version 300 es
 in float inValue;
 layout(std140) uniform;
@@ -37,7 +38,7 @@ outValue = m * inValue;
 }
 `;
 
-const FS = `\
+const FS = glsl`\
 #version 300 es
 precision highp float;
 out vec4 oColor;

--- a/modules/webgl-legacy/test/engine/program-manager.spec.js
+++ b/modules/webgl-legacy/test/engine/program-manager.spec.js
@@ -2,16 +2,16 @@ import {webgl1Device} from '@luma.gl/test-utils';
 import test from 'tape-promise/tape';
 
 import {ProgramManager} from '@luma.gl/webgl-legacy';
-import {dirlight, picking} from '@luma.gl/shadertools';
+import {dirlight, picking, glsl} from '@luma.gl/shadertools';
 
-const vs = `\
+const vs = glsl`\
 attribute vec4 positions;
 
 void main(void) {
   gl_Position = positions;
 }
 `;
-const fs = `\
+const fs = glsl`\
 precision highp float;
 
 void main(void) {
@@ -19,7 +19,8 @@ void main(void) {
 }
 `;
 
-const VS_300 = `#version 300 es
+const VS_300 = glsl`\
+#version 300 es
 
   in vec4 positions;
   in vec2 uvs;
@@ -32,7 +33,8 @@ const VS_300 = `#version 300 es
   }
 `;
 
-const FS_300 = `#version 300 es
+const FS_300 = glsl`\
+#version 300 es
   precision highp float;
 
   in vec2 vUV;

--- a/modules/webgl-legacy/test/transform/buffer-transform.spec.js
+++ b/modules/webgl-legacy/test/transform/buffer-transform.spec.js
@@ -1,10 +1,11 @@
 import test from 'tape-promise/tape';
+import {glsl} from '@luma.gl/api';
 import BufferTransform from '@luma.gl/webgl-legacy/transform/buffer-transform';
 import {Buffer, TransformFeedback} from '@luma.gl/webgl-legacy';
 import {ClassicModel as Model} from '@luma.gl/webgl-legacy';
 import {fixture} from 'test/setup';
 
-const VS = `\
+const VS = glsl`\
 attribute float source;
 varying float feedback;
 
@@ -14,7 +15,7 @@ void main()
 }
 `;
 
-const FS = `\
+const FS = glsl`\
 void main(void) {
   gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
 }

--- a/modules/webgl-legacy/test/transform/transform-shader-utils.spec.js
+++ b/modules/webgl-legacy/test/transform/transform-shader-utils.spec.js
@@ -1,10 +1,11 @@
+import {glsl} from '@luma.gl/api';
 import {updateForTextures} from '@luma.gl/webgl-legacy/transform/transform-shader-utils';
 import {Texture2D} from '@luma.gl/webgl-legacy';
 import test from 'tape-promise/tape';
 import {fixture} from 'test/setup';
 
-test('TransformShaderUitls#updateForTextures', (t) => {
-  const VS = `\
+test('TransformShaderUtils#updateForTextures', (t) => {
+  const VS = glsl`\
 attribute vec4 inTexture;
 attribute float scale;
 varying vec4 output;
@@ -43,8 +44,8 @@ void main()
   t.end();
 });
 
-test('TransformShaderUitls#updateForTextures (with target texture)', (t) => {
-  const VS = `\
+test('TransformShaderUtils#updateForTextures (with target texture)', (t) => {
+  const VS = glsl`\
 attribute vec4 inTexture;
 attribute float scale;
 varying vec4 outTexture;

--- a/modules/webgl-legacy/test/transform/transform.spec.js
+++ b/modules/webgl-legacy/test/transform/transform.spec.js
@@ -1,7 +1,7 @@
 import test from 'tape-promise/tape';
 import {fixture} from 'test/setup';
 
-import {luma} from '@luma.gl/api';
+import {luma, glsl} from '@luma.gl/api';
 import GL from '@luma.gl/constants';
 import {Transform} from '@luma.gl/webgl-legacy';
 import {Buffer, Texture2D, setParameters, getParameters} from '@luma.gl/webgl-legacy';
@@ -9,7 +9,7 @@ import {Buffer, Texture2D, setParameters, getParameters} from '@luma.gl/webgl-le
 // TODO - these tests have started failing on CI, we need to debug and fix
 const DISABLE_FLAKY_TRANSFORM_TESTS = true;
 
-const VS = `\
+const VS = glsl`\
 #version 300 es
 in float inValue;
 out float outValue;
@@ -20,7 +20,7 @@ void main()
 }
 `;
 
-const VS2 = `\
+const VS2 = glsl`\
 #version 300 es
 in float inValue1;
 in float inValue2;
@@ -34,7 +34,7 @@ void main()
 }
 `;
 
-const VS_NO_SOURCE_BUFFER = `\
+const VS_NO_SOURCE_BUFFER = glsl`\
 varying float outValue;
 uniform float uValue;
 
@@ -522,7 +522,7 @@ test('WebGL#Transform update', (t) => {
   t.end();
 });
 
-const VSTexInput = `\
+const VSTexInput = glsl`\
 #version 300 es
 in float inBuffer;
 in float inTexture;
@@ -592,7 +592,7 @@ const TEXTURE_BUFFER_TEST_CASES = [
     type: GL.FLOAT,
     width: 4,
     height: 4,
-    vs: `\
+    vs: glsl`\
 #version 300 es
 in float inBuffer;
 in float inTexture;
@@ -614,7 +614,7 @@ void main()
     type: GL.UNSIGNED_BYTE,
     width: 2,
     height: 2,
-    vs: `\
+    vs: glsl`\
 #version 300 es
 in float inBuffer;
 in vec4 inTexture;
@@ -707,7 +707,7 @@ const TEXTURE_TEST_CASES = [
     type: GL.FLOAT,
     width: 4,
     height: 4,
-    vs: `\
+    vs: glsl`\
 #version 300 es
 in vec4 inTexture;
 out vec4 outTexture;
@@ -726,7 +726,7 @@ void main()
     type: GL.FLOAT,
     width: 4,
     height: 4,
-    vs: `\
+    vs: glsl`\
 #version 300 es
 in float inTexture;
 out float outTexture;
@@ -745,7 +745,7 @@ void main()
     type: GL.UNSIGNED_BYTE,
     width: 2,
     height: 2,
-    vs: `\
+    vs: glsl`\
 #version 300 es
 in vec4 inTexture;
 out vec4 outTexture;
@@ -963,7 +963,7 @@ const OFFLINE_RENDERING_TEST_CASES = [
     height: 4,
     expected: 123,
     position: new Float32Array([1, 1, -1, 1, 1, -1, -1, -1]),
-    vs: `\
+    vs: glsl`\
 #version 300 es
 in vec2 position;
 out float outTexture;
@@ -984,7 +984,7 @@ void main()
     height: 2,
     expected: 255,
     position: new Float32Array([1, 1, -1, 1, 1, -1, -1, -1]),
-    vs: `\
+    vs: glsl`\
 #version 300 es
 in vec2 position;
 out vec4 outTexture;
@@ -1054,7 +1054,7 @@ test('WebGL#Transform run with shader injects', (t) => {
     return;
   }
 
-  const vs = `\
+  const vs = glsl`\
 attribute float inValue;
 varying float outValue;
 
@@ -1125,7 +1125,7 @@ if (!DISABLE_FLAKY_TRANSFORM_TESTS) {
     const type = GL.FLOAT;
     const width = 4;
     const height = 4;
-    const vs = `\
+    const vs = glsl`\
 #version 300 es
 in vec4 inTexture;
 out vec4 outTexture;
@@ -1135,7 +1135,7 @@ void main()
 outTexture = inTexture;
 }
 `;
-    const fs = `\
+    const fs = glsl`\
 #version 300 es
 in vec4 outTexture;
 out vec4 transform_output;
@@ -1262,7 +1262,7 @@ test('WebGL#Transform (Buffer to Texture)', (t) => {
     return;
   }
 
-  const vs = `\
+  const vs = glsl`\
 #define EPSILON 0.00001
 attribute vec4 aCur;
 attribute vec4 aNext;
@@ -1275,7 +1275,7 @@ gl_Position = vec4(0, 0, 0, 1.);
 }
 `;
 
-  const fs = `\
+  const fs = glsl`\
 varying float equal;
 void main()
 {

--- a/test/apps/tree-shaking/app.js
+++ b/test/apps/tree-shaking/app.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-var, max-statements */
+import {glsl} from '@luma.gl/api';
 import GL from '@luma.gl/constants';
 // eslint-disable-next-line
 import {AnimationLoop, Cube} from '@luma.gl/core';
@@ -57,7 +58,7 @@ function makeInstancedCube(gl) {
       instanceOffsets: {value: offsets, size: 2, divisor: 1},
       instanceColors: {value: colors, size: 3, divisor: 1}
     },
-    vs: `\
+    vs: glsl`\
 attribute vec3 positions;
 attribute vec3 normals;
 attribute vec2 instanceOffsets;
@@ -80,7 +81,7 @@ void main(void) {
   color = instanceColors;
 }
 `,
-    fs: `\
+    fs: glsl`\
 precision highp float;
 
 varying vec3 color;

--- a/website-docusaurus/sidebars.js
+++ b/website-docusaurus/sidebars.js
@@ -36,6 +36,7 @@ const sidebars = {
       label: 'Developer Guide',
       items: [
         'developer-guide/installing',
+        'developer-guide/editing',
         'developer-guide/debugging',
         'developer-guide/testing',
         'developer-guide/profiling',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3986,9 +3986,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001254:
-  version "1.0.30001439"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz"
-  integrity sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==
+  version "1.0.30001441"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz"
+  integrity sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #

Enable syntax highlighting of shader strings in vscode. Simle, harmless code annotations enable vscode extensions to do the highlighting.

<img width="649" alt="Screen Shot 2022-12-22 at 2 25 08 PM" src="https://user-images.githubusercontent.com/7025232/209211314-74258c7e-70d7-4769-8dec-7a221aae458e.png">

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
