### PR TITLE
chore: Remove WebGL specific exports from core

### DIFF
--- a/docs/api-reference/test-utils/api-reference/snapshot-test-runner.md
+++ b/docs/api-reference/test-utils/api-reference/snapshot-test-runner.md
@@ -30,7 +30,7 @@ In your script that is run on the browser:
 
 ```typescript
 const {SnapshotTestRunner} = require('@luma.gl/test-utils');
-const {Cube} = require('@luma.gl/core');
+const {Cube} = require('@luma.gl/engine');
 
 const TEST_CASES = [
   {

--- a/docs/api-reference/test-utils/snapshot-test-runner.md
+++ b/docs/api-reference/test-utils/snapshot-test-runner.md
@@ -30,7 +30,7 @@ In your script that is run on the browser:
 
 ```typescript
 const {SnapshotTestRunner} = require('@luma.gl/test-utils');
-const {Cube} = require('@luma.gl/core');
+const {Cube} = require('@luma.gl/engine');
 
 const TEST_CASES = [
   {

--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -82,7 +82,7 @@ and then reloading the browser tab.
 While usually not recommended, it is also possible to activate the developer tools manually. Call [`luma.createDevice`](/docs/api-reference/gltools/context/context-api) with `debug: true` to create a WebGL context instrumented with the WebGL developer tools:
 
 ```typescript
-import {luma} from '@luma.gl/core';
+import {luma} from '@luma.gl/api';
 import '@luma.gl/debug';
 const device = luma.createDevice({type: 'webgl', debug: true});
 ```

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -59,7 +59,7 @@ In your script that is run on the browser:
 
 ```typescript
 const {SnapshotTestRunner} = require('@luma.gl/test-utils');
-const {Cube} = require('@luma.gl/core');
+const {Cube} = require('@luma.gl/engine');
 
 const TEST_CASES = [
   {

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -1,14 +1,21 @@
 // luma.gl, MIT license
-// core module exports
+
+// core module re-exports API and engine
+
+// @luma.gl/api exports
+// TODO - export full api in v10 (names conflict with removed WebGL exports)
+
+export type {DeviceProps} from '@luma.gl/api';
+export {Device, luma} from '@luma.gl/api';
 
 // UTILS
 export {log, assert, uid} from '@luma.gl/api';
 
-// TODO in v10 - export @luma.gl/api
-
 // @luma.gl/engine exports
+
 export {Timeline} from '@luma.gl/engine';
 
+// TODO - these still have breaking changes, will be upgraded later
 export {
   ClassicAnimationLoop as AnimationLoop,
   ClassicModel as Model,
@@ -16,5 +23,3 @@ export {
   ProgramManager,
   ClipSpace
 } from '@luma.gl/webgl-legacy';
-
-// TODO - the following exports will be removed in v9

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -1,12 +1,12 @@
 // luma.gl, MIT license
 // core module exports
 
-// UTILS: undocumented API for other luma.gl modules
+// UTILS
 export {log, assert, uid} from '@luma.gl/api';
 
-// CORE MODULE EXPORTS FOR LUMA.GL
+// TODO in v10 - export @luma.gl/api
 
-// ENGINE
+// @luma.gl/engine exports
 export {Timeline} from '@luma.gl/engine';
 
 export {
@@ -17,89 +17,4 @@ export {
   ClipSpace
 } from '@luma.gl/webgl-legacy';
 
-export {
-  Geometry,
-  ConeGeometry,
-  CubeGeometry,
-  CylinderGeometry,
-  IcoSphereGeometry,
-  PlaneGeometry,
-  SphereGeometry,
-  TruncatedConeGeometry
-} from '@luma.gl/engine';
-
 // TODO - the following exports will be removed in v9
-
-// WEBGL - importing from `@luma.gl/core` is deprecated
-
-// GLTOOLS
-export {
-  createGLContext,
-  instrumentGLContext,
-  FEATURES,
-  hasFeature,
-  hasFeatures
-} from '@luma.gl/webgl-legacy';
-
-import {luma} from '@luma.gl/api';
-/** @deprecated Use luma.stats */
-export const lumaStats = luma.stats;
-
-export {
-  isWebGL,
-  isWebGL2,
-  getParameters,
-  setParameters,
-  withParameters,
-  resetParameters,
-  cssToDeviceRatio,
-  cssToDevicePixels,
-  Buffer,
-  Program,
-  Framebuffer,
-  Renderbuffer,
-  Texture2D,
-  TextureCube,
-  clear,
-  readPixelsToArray,
-  readPixelsToBuffer,
-  cloneTextureFrom,
-  copyToTexture,
-  Texture3D,
-  TransformFeedback
-} from '@luma.gl/webgl-legacy';
-
-// SHADERTOOLS - importing from `@luma.gl/core` is deprecated
-
-import {
-  // HELPERS
-  normalizeShaderModule as normalizeShaderModuleDeprecated,
-  // SHADER MODULES
-  fp32 as fp32Deprecated,
-  fp64 as fp64Deprecated,
-  project as projectDeprecated,
-  dirlight as dirlightDeprecated,
-  picking as pickingDeprecated,
-  gouraudLighting as gouraudLightingDeprecated,
-  phongLighting as phongLightingDeprecated,
-  pbr as pbrDeprecated
-} from '@luma.gl/shadertools';
-
-/** @deprecated Import directly from `@luma.gl/shadertools` */
-export const normalizeShaderModule = normalizeShaderModuleDeprecated;
-/** @deprecated Import directly from `@luma.gl/shadertools` */
-export const fp32 = fp32Deprecated;
-/** @deprecated Import directly from `@luma.gl/shadertools` */
-export const fp64 = fp64Deprecated;
-/** @deprecated Import directly from `@luma.gl/shadertools` */
-export const project = projectDeprecated;
-/** @deprecated Import directly from `@luma.gl/shadertools` */
-export const dirlight = dirlightDeprecated;
-/** @deprecated Import directly from `@luma.gl/shadertools` */
-export const picking = pickingDeprecated;
-/** @deprecated Import directly from `@luma.gl/shadertools` */
-export const gouraudLighting = gouraudLightingDeprecated;
-/** @deprecated Import directly from `@luma.gl/shadertools` */
-export const phongLighting = phongLightingDeprecated;
-/** @deprecated Import directly from `@luma.gl/shadertools` */
-export const pbr = pbrDeprecated;

--- a/modules/debug/src/index.ts
+++ b/modules/debug/src/index.ts
@@ -1,4 +1,4 @@
-import {log} from '@luma.gl/core';
+import {log} from '@luma.gl/api';
 
 export {COLOR_MODE} from './glsl-to-js-compiler/draw-model';
 export {default as _DebugContext} from './glsl-to-js-compiler/debug-context';

--- a/modules/debug/src/webgl-api-tracing/webgl-debug-context.ts
+++ b/modules/debug/src/webgl-api-tracing/webgl-debug-context.ts
@@ -1,6 +1,6 @@
 // Depends on Khronos Debug support module being imported via "luma.gl/debug"
 // NOTE deprecated, this file has been copied into luma.gl/webgl
-import {log} from '@luma.gl/core';
+import {log} from '@luma.gl/api';
 import GL from '@luma.gl/constants';
 
 // Expose Khronos Debug support module on global context

--- a/modules/experimental/test/scenegraph/model-node.spec.js
+++ b/modules/experimental/test/scenegraph/model-node.spec.js
@@ -1,9 +1,9 @@
 // luma.gl, MIT license
 
 import test from 'tape-promise/tape';
-import {makeSpy} from '@probe.gl/test-utils';
 import {fixture} from 'test/setup';
-import {Model} from '@luma.gl/core';
+import {makeSpy} from '@probe.gl/test-utils';
+import {Model} from '@luma.gl/webgl-legacy';
 import {ModelNode} from '@luma.gl/experimental';
 
 const DUMMY_VS = `

--- a/modules/shadertools/test/gpu-test-utils.js
+++ b/modules/shadertools/test/gpu-test-utils.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len, prefer-template, camelcase */
 /* eslint-disable no-console */
-import {setParameters} from '@luma.gl/core';
+import {setParameters} from '@luma.gl/webgl';
 import {createTestContext} from '@luma.gl/test-utils';
 
 // Utilities functions that to be moved to a common place for future tests

--- a/modules/test-utils/src/test-runner.ts
+++ b/modules/test-utils/src/test-runner.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck TODO remove
 /* eslint-disable no-console */
-import {AnimationLoop, AnimationProps} from '@luma.gl/core';
+import {AnimationLoop, AnimationProps} from '@luma.gl/webgl-legacy';
 import {webglDevice} from './create-test-device';
 
 /** Describes a test case */

--- a/modules/webgl-legacy/test/classic/transform-feedback.spec.js
+++ b/modules/webgl-legacy/test/classic/transform-feedback.spec.js
@@ -2,7 +2,7 @@ import {glsl} from '@luma.gl/api';
 import GL from '@luma.gl/constants';
 import {TransformFeedback, Buffer} from '@luma.gl/webgl-legacy';
 // TODO - tests shouldn't depend on higher level module?
-import {Model} from '@luma.gl/core';
+import {Model} from '@luma.gl/webgl-legacy';
 import test from 'tape-promise/tape';
 
 import {fixture} from 'test/setup';

--- a/modules/webgl-legacy/test/engine/animation-loop.spec.js
+++ b/modules/webgl-legacy/test/engine/animation-loop.spec.js
@@ -1,6 +1,6 @@
-import {AnimationLoop} from '@luma.gl/core';
 import test from 'tape-promise/tape';
 import {fixture} from 'test/setup';
+import {AnimationLoop} from '@luma.gl/webgl-legacy';
 
 test('gltools#AnimationLoop constructor', (t) => {
   t.ok(AnimationLoop, 'AnimationLoop imported');

--- a/test/apps/tree-shaking/app.js
+++ b/test/apps/tree-shaking/app.js
@@ -2,7 +2,7 @@
 import {glsl} from '@luma.gl/api';
 import GL from '@luma.gl/constants';
 // eslint-disable-next-line
-import {AnimationLoop, Cube} from '@luma.gl/core';
+import {AnimationLoop, Cube} from '@luma.gl/engine';
 import {createTestContext} from '@luma.gl/test-utils';
 import {Matrix4, radians} from '@math.gl/core';
 

--- a/test/bench/shaders.bench.js
+++ b/test/bench/shaders.bench.js
@@ -1,8 +1,9 @@
 // luma.gl, MIT license
 
 // eslint-disable-next-line
-import {Program, VertexShader, FragmentShader} from '@luma.gl/core';
+import {Program, VertexShader, FragmentShader} from '@luma.gl/webgl-legacy';
 import {createTestContext} from '@luma.gl/test-utils';
+
 const gl = createTestContext();
 
 const VS = `

--- a/test/bench/uniforms.bench.js
+++ b/test/bench/uniforms.bench.js
@@ -1,6 +1,6 @@
 // luma.gl, MIT license
 
-import {Program} from '@luma.gl/core';
+import {Program} from '@luma.gl/webgl-legacy';
 import {createTestContext} from '@luma.gl/test-utils';
 const gl = createTestContext();
 

--- a/test/render/gltf-test-cases.js.disabled
+++ b/test/render/gltf-test-cases.js.disabled
@@ -1,4 +1,4 @@
-import {AnimationLoop} from '@luma.gl/core';
+import {AnimationLoop} from '@luma.gl/webgl-legacy';
 import {DemoApp, GLTF_BASE_URL} from './gtlf-demo-app';
 
 const examples = {

--- a/test/size/import-nothing.js
+++ b/test/size/import-nothing.js
@@ -1,3 +1,3 @@
-import {Model, AnimationLoop} from '@luma.gl/core';
+import {Model, AnimationLoop} from '@luma.gl/engine';
 
 console.log(Model, AnimationLoop); // eslint-disable-line

--- a/website-gatsby/src/components/animation-loop-example-page.jsx
+++ b/website-gatsby/src/components/animation-loop-example-page.jsx
@@ -1,8 +1,7 @@
 import React, {Component} from 'react'; // eslint-disable-line
 import PropTypes from 'prop-types'; 
 import {isBrowser} from '@probe.gl/env';
-import {setPathPrefix} from '@luma.gl/api';
-import {lumaStats} from '@luma.gl/core';
+import {luma, setPathPrefix} from '@luma.gl/api';
 import {AnimationLoopTemplate} from '@luma.gl/engine';
 import {luma} from '@luma.gl/api';
 import {WebGLDevice} from '@luma.gl/webgl';
@@ -149,7 +148,7 @@ export default class AnimationLoopExamplePage extends Component {
       }
     });
 
-    lumaStats.get('Memory Usage').reset();
+    luma.stats.get('Memory Usage').reset();
     const memWidget = new StatsWidget(lumaStats.get('Memory Usage'), {
       container: this.refs.memStats,
       css: {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- luma.gl v9 API is WebGL independent, so core shouldn't re-export the WebGL module.
#### Change List
-
