### PR TITLE
Add getBounds() to ScenegraphNode

### DIFF
--- a/docs/api-reference/experimental/scenegraph/scenegraph-node.md
+++ b/docs/api-reference/experimental/scenegraph/scenegraph-node.md
@@ -46,6 +46,10 @@ var node = new Model(gl, props);
 
 Note that setting orientation props does not actually update the object's matrix. `update()` must be called.
 
+### getBounds() : [min: number[], max: number[]] | null
+
+Calculate the bounding box of the node.
+
 ### update() - DEPRECATED
 
 Update the model matrix. Useful to update changes to the `position`, `rotation` or `scale` properties.

--- a/modules/experimental/src/gltf/gltf-instantiator.ts
+++ b/modules/experimental/src/gltf/gltf-instantiator.ts
@@ -125,7 +125,7 @@ export class GLTFInstantiator {
       ? gltfPrimitive.indices.count
       : this.getVertexCount(gltfPrimitive.attributes);
 
-    return createGLTFModel(
+    const model = createGLTFModel(
       this.device,
       {
         id: gltfPrimitive.name || `${gltfMesh.name || gltfMesh.id}-primitive-${i}`,
@@ -136,6 +136,9 @@ export class GLTFInstantiator {
         ...this.options
       }
     );
+    model.bounds = [gltfPrimitive.attributes.POSITION.min, gltfPrimitive.attributes.POSITION.max];
+
+    return model;
   }
 
   getVertexCount(attributes: any) {

--- a/modules/experimental/src/scenegraph/model-node.ts
+++ b/modules/experimental/src/scenegraph/model-node.ts
@@ -8,6 +8,7 @@ export type ModelNodeProps = ScenegraphNodeProps & ModelProps & {
 
 export class ModelNode extends ScenegraphNode {
   readonly model: Model;
+  bounds: [number[], number[]] | null = null;
 
   AfterRender = null;
   managedResources: any[];
@@ -36,6 +37,10 @@ export class ModelNode extends ScenegraphNode {
     super.setProps(props);
     this._setModelNodeProps(props);
     return this;
+  }
+
+  override getBounds(): [number[], number[]] | null {
+    return this.bounds;
   }
 
   override destroy(): void {

--- a/modules/experimental/src/scenegraph/scenegraph-node.ts
+++ b/modules/experimental/src/scenegraph/scenegraph-node.ts
@@ -31,6 +31,10 @@ export class ScenegraphNode {
     this._setScenegraphNodeProps(props);
   }
 
+  getBounds(): [number[], number[]] | null {
+    return null;
+  }
+
   destroy(): void {}
 
   /** @deprecated use .destroy() */

--- a/modules/experimental/test/scenegraph/group-node.spec.js
+++ b/modules/experimental/test/scenegraph/group-node.spec.js
@@ -1,8 +1,12 @@
 // luma.gl, MIT license
 
 import test from 'tape-promise/tape';
-import {GroupNode, ScenegraphNode} from '@luma.gl/experimental';
+import {GroupNode, ScenegraphNode, ModelNode} from '@luma.gl/experimental';
 import {Matrix4} from '@math.gl/core';
+import {fixture} from 'test/setup';
+import {DUMMY_VS, DUMMY_FS} from './model-node.spec';
+
+const {gl} = fixture;
 
 test('GroupNode#construction', (t) => {
   const grandChild = new ScenegraphNode();
@@ -98,6 +102,37 @@ test('GroupNode#traverse', (t) => {
     modelMatrices[grandChildSNode.id],
     new Matrix4().identity().scale(4),
     'should update grand child matrix'
+  );
+
+  t.end();
+});
+
+test('GroupNode#getBounds', (t) => {
+  const matrix = new Matrix4().translate([0, 0, 1]).scale(2);
+
+  const childSNode = new ModelNode(gl, {id: 'childSNode', vs: DUMMY_VS, fs: DUMMY_FS});
+  const grandChildSNode = new ModelNode(gl, {id: 'grandChildSNode', vs: DUMMY_VS, fs: DUMMY_FS});
+  const child1 = new GroupNode({id: 'child-1', matrix, children: [grandChildSNode]});
+  const groupNode = new GroupNode({id: 'parent', matrix, children: [child1, childSNode]});
+
+  t.deepEqual(groupNode.getBounds(), null, 'child bounds are not defined');
+
+  childSNode.bounds = [
+    [0, 0, 0],
+    [1, 1, 1]
+  ];
+  grandChildSNode.bounds = [
+    [-1, -1, -1],
+    [0, 0, 0]
+  ];
+
+  t.deepEqual(
+    groupNode.getBounds(),
+    [
+      [-4, -4, -1],
+      [2, 2, 3]
+    ],
+    'bounds calculated'
   );
 
   t.end();

--- a/modules/experimental/test/scenegraph/model-node.spec.js
+++ b/modules/experimental/test/scenegraph/model-node.spec.js
@@ -6,11 +6,11 @@ import {makeSpy} from '@probe.gl/test-utils';
 import {Model} from '@luma.gl/webgl-legacy';
 import {ModelNode} from '@luma.gl/experimental';
 
-const DUMMY_VS = `
+export const DUMMY_VS = `
   void main() { gl_Position = vec4(1.0); }
 `;
 
-const DUMMY_FS = `
+export const DUMMY_FS = `
   precision highp float;
   void main() { gl_FragColor = vec4(1.0); }
 `;


### PR DESCRIPTION
To support Tile3DLayer + TerrainExtension in deck.gl

#### Change List
- Implement getBounds() in `ModelNode` and `GroupNode`
- Assign node bounds from gltf primitives
- Tests
- Documentation
