### PR TITLE
Fix cssToDeviceRatio when auto resize is disabled

### DIFF
--- a/modules/gltools/src/utils/device-pixels.js
+++ b/modules/gltools/src/utils/device-pixels.js
@@ -10,8 +10,10 @@ export function cssToDeviceRatio(gl) {
 
   if (gl.canvas && luma) {
     // For headless gl we might have used custom width and height
-    // hence use cached clientWidth
-    const {clientWidth} = luma.canvasSizeInfo;
+    // hence prioritize cached clientWidth
+    const cachedSize = luma.canvasSizeInfo;
+    const clientWidth =
+      'clientWidth' in cachedSize ? cachedSize.clientWidth : gl.canvas.clientWidth;
     return clientWidth ? gl.drawingBufferWidth / clientWidth : 1;
   }
   // use default device pixel ratio


### PR DESCRIPTION
If `autoResizeFramebuffer` is disabled then `luma.canvasSizeInfo` cache is never populated.

#### Change List
- Fallback to `canvas.clientWidth` if cache is not available
