### PR TITLE
fix #1760 - the phenomenon that data is not properly initialize

### DIFF
--- a/modules/webgl/src/adapter/resources/webgl-texture.ts
+++ b/modules/webgl/src/adapter/resources/webgl-texture.ts
@@ -457,7 +457,7 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
    */
   // eslint-disable-next-line max-statements, complexity
   setImageData(options: SetImageDataOptions) {
-    if (this.props.dimension === '3d') {
+    if (this.props.dimension === '3d' || this.props.dimension === '2d-array') {
       return this.setImageData3D(options);
     }
 


### PR DESCRIPTION
Modify to call "setImageData3D" method even if "2d-array" in addition to "3d"

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1760
<!-- For other PRs without open issue -->
#### Background
- If the value of 'dimension' is '2d-array', the phenomenon that was incorrectly initialized by performing a basic initialization without initializing using the 'setImageData3D' method

<!-- For all the PRs -->
#### Change List
- If the value of 'dimension' is '3d' or '2d-array', call the 'setImageData3D' method and modify it to perform initialization.
