### PR TITLE
fix: 🐛 Fix issue with setting 0 or false values

### DIFF
--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -359,7 +359,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
   _applyUniforms() {
     for (const uniformLayout of this.layout.uniforms || []) {
       const {name, location, type, textureUnit} = uniformLayout;
-      const value = this.uniforms[name] || textureUnit;
+      const value = this.uniforms[name] ?? textureUnit;
       if (value !== undefined) {
         setUniform(this.device.gl, location, type, value);
       }


### PR DESCRIPTION
The change involves replacing the logical OR operator (`||`) with the nullish coalescing operator (`??`) in the `_applyUniforms()` method. This modification addresses a specific issue where 0 or false values were not being correctly assigned. By using the nullish coalescing operator, the code ensures that if the value of `this.uniforms[name]` is either 0 or false, it will be properly assigned as the value for `value`. This change enhances the accuracy and reliability of the code by handling these specific cases effectively.

✅ Closes: #1741

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1741
<!-- For other PRs without open issue -->
#### Background

The issue with the original code was that it did not handle 0 and false values correctly when assigning them to uniforms. This resulted in unexpected behavior when attempting to set these values. The change to use the nullish coalescing operator ensures that 0 and false values are properly assigned.


<!-- For all the PRs -->
#### Change List
- Replaced logical OR operator (`||`) with nullish coalescing operator (`??`) in the `_applyUniforms()` method to handle 0 and false values correctly when assigning them to uniforms.
