### PR TITLE
feat(webgl): Export legacy BufferWithAccessor

### DIFF
--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -50,7 +50,7 @@ import type {
   CommandEncoderProps
 } from '@luma.gl/api';
 
-import {ClassicBuffer} from '../classic/buffer';
+import {BufferWithAccessor} from '../classic/buffer-with-accessor';
 import {WEBGLBuffer} from './resources/webgl-buffer';
 import {WEBGLShader} from './resources/webgl-shader';
 import {WEBGLSampler} from './resources/webgl-sampler';
@@ -284,7 +284,7 @@ ${this.info.vendor}, ${this.info.renderer} for canvas: ${this.canvasContext.id}`
 
   createBuffer(props: BufferProps | ArrayBuffer | ArrayBufferView): WEBGLBuffer {
     const newProps = this._getBufferProps(props);
-    return new ClassicBuffer(this, newProps);
+    return new BufferWithAccessor(this, newProps);
   }
 
   _createTexture(props: TextureProps): WEBGLTexture {

--- a/modules/webgl/src/classic/buffer-with-accessor.ts
+++ b/modules/webgl/src/classic/buffer-with-accessor.ts
@@ -42,7 +42,7 @@ const PROP_CHECKS_SET_PROPS = {
   removedProps: DEPRECATED_PROPS
 };
 
-function getWEBGLBufferProps(props: ClassicBufferProps | ArrayBufferView | number): BufferProps {
+function getWEBGLBufferProps(props: BufferWithAccessorProps | ArrayBufferView | number): BufferProps {
   // Signature `new Buffer(gl, new Float32Array(...)`
   if (ArrayBuffer.isView(props)) {
     return {data: props};
@@ -62,7 +62,7 @@ function getWEBGLBufferProps(props: ClassicBufferProps | ArrayBufferView | numbe
 }
 
 /** WebGL Buffer interface */
-export type ClassicBufferProps = BufferProps & {
+export type BufferWithAccessorProps = BufferProps & {
   handle?: WebGLBuffer;
 
   target?: number;
@@ -81,11 +81,11 @@ export type ClassicBufferProps = BufferProps & {
 }
 
 /** WebGL Buffer interface */
-export class ClassicBuffer extends WEBGLBuffer {
+export class BufferWithAccessor extends WEBGLBuffer {
   usage: number;
   accessor: Accessor;
 
-  constructor(device: Device | WebGLRenderingContext, props?: ClassicBufferProps);
+  constructor(device: Device | WebGLRenderingContext, props?: BufferWithAccessorProps);
   constructor(device: Device | WebGLRenderingContext, data: ArrayBufferView | number[]);
   constructor(device: Device | WebGLRenderingContext, byteLength: number);
 
@@ -96,7 +96,7 @@ export class ClassicBuffer extends WEBGLBuffer {
     // this.initialize(props);
 
     // Deprecated: Merge main props and accessor
-    this.setAccessor(Object.assign({}, props, (props as ClassicBufferProps).accessor));
+    this.setAccessor(Object.assign({}, props, (props as BufferWithAccessorProps).accessor));
 
     // infer GL type from supplied typed array
     if (this.props.data) {
@@ -126,7 +126,7 @@ export class ClassicBuffer extends WEBGLBuffer {
   // Signature: `new Buffer(gl, {data: new Float32Array(...)})`
   // Signature: `new Buffer(gl, new Float32Array(...))`
   // Signature: `new Buffer(gl, 100)`
-  initialize(props: ClassicBufferProps = {}): this {
+  initialize(props: BufferWithAccessorProps = {}): this {
     // Signature `new Buffer(gl, new Float32Array(...)`
     if (ArrayBuffer.isView(props)) {
       props = {data: props};
@@ -157,7 +157,7 @@ export class ClassicBuffer extends WEBGLBuffer {
     return this;
   }
 
-  setProps(props: ClassicBufferProps): this {
+  setProps(props: BufferWithAccessorProps): this {
     props = checkProps('Buffer', props, PROP_CHECKS_SET_PROPS);
 
     if ('accessor' in props) {
@@ -197,7 +197,7 @@ export class ClassicBuffer extends WEBGLBuffer {
   }
 
   // Update with new data. Reinitializes the buffer
-  setData(props: ClassicBufferProps) {
+  setData(props: BufferWithAccessorProps) {
     return this.initialize(props);
   }
 

--- a/modules/webgl/src/classic/copy-and-blit.ts
+++ b/modules/webgl/src/classic/copy-and-blit.ts
@@ -2,7 +2,7 @@
 import {assert, Texture, Framebuffer, FramebufferProps} from '@luma.gl/api';
 import {GL} from '@luma.gl/constants';
 
-import {ClassicBuffer as Buffer} from './buffer';
+import {BufferWithAccessor as Buffer} from './buffer-with-accessor';
 import {WEBGLTexture}  from  '../adapter/resources/webgl-texture';
 import {WEBGLFramebuffer} from '../adapter/resources/webgl-framebuffer';
 import {withParameters} from '../context/state-tracker/with-parameters';

--- a/modules/webgl/src/index.ts
+++ b/modules/webgl/src/index.ts
@@ -36,8 +36,8 @@ export {WEBGLVertexArrayObject} from './adapter/objects/webgl-vertex-array-objec
 // WebGL adapter classes (Legacy, will be moved to webgl-legacy)
 export {Accessor} from './classic/accessor';
 export type {AccessorObject} from './types';
-export type {ClassicBufferProps, ClassicBufferProps as BufferProps} from './classic/buffer';
-export {ClassicBuffer, ClassicBuffer as Buffer} from './classic/buffer';
+export type {BufferWithAccessorProps} from './classic/buffer-with-accessor';
+export {BufferWithAccessor} from './classic/buffer-with-accessor';
 
 export {
   isWebGL,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- The legacy buffer class with the accessor is much too complicated and needs to be streamlined to allow WebGPU support.
- But the impact on applications will be too high, so keep the class for now and export it from the webgl module (instead of api).
<!-- For all the PRs -->
#### Change List
-
