### PR TITLE
fix(coew): boolean uniform fix

### DIFF
--- a/examples/showcase/instancing/app.ts
+++ b/examples/showcase/instancing/app.ts
@@ -53,7 +53,6 @@ varying vec3 color;
 void main(void) {
   gl_FragColor = vec4(color, 1.);
   gl_FragColor = dirlight_filterColor(gl_FragColor);
-  // TODO - 
   gl_FragColor = picking_filterColor(gl_FragColor);
 }
 `;
@@ -91,11 +90,6 @@ class InstancedCube extends Model {
     const colorsBuffer = device.createBuffer(colors);
     const pickingColorsBuffer = device.createBuffer(pickingColors);
 
-    // TODO - Should we really be setting global hooks in a simple example?
-    // const pipelineFactory = PipelineFactory.getDefaultPipelineFactory(device);
-    // pipelineFactory.addShaderHook('vs:MY_SHADER_HOOK_pickColor(inout vec4 color)');
-    // pipelineFactory.addShaderHook('fs:MY_SHADER_HOOK_fragmentColor(inout vec4 color)');
-
     // Model
     super(device, {
       ...props,
@@ -122,7 +116,7 @@ class InstancedCube extends Model {
       },
       bufferMap: [
         {name: 'instanceColors', format: 'unorm8x4'},
-        {name: 'instancePickingColors', format: 'unorm8x2'},
+        {name: 'instancePickingColors', format: 'uint8x2'},
       ],
       parameters: {
         depthWriteEnabled: true,
@@ -233,9 +227,7 @@ export function pickInstance(
     sourceX: pickX,
     sourceY: pickY,
     sourceWidth: 1,
-    sourceHeight: 1,
-    // sourceFormat: GL.RGBA,
-    // sourceType: GL.UNSIGNED_BYTE
+    sourceHeight: 1
   });
 
   if (color[0] + color[1] + color[2] > 0) {

--- a/modules/core/src/adapter/utils/decode-vertex-format.ts
+++ b/modules/core/src/adapter/utils/decode-vertex-format.ts
@@ -38,11 +38,7 @@ export function decodeVertexFormat(format: VertexFormat): VertexFormatInfo {
     type,
     components,
     byteLength: decodedType.byteLength * components,
-    // It is not the vertex memory format that determines if the data will be treated as an integer,
-    // it is the shader attribute declaration. 
-    // Also note that WebGL supports assigning non-normalized integer data to floating point attributes,
-    // but as far as we can tell, WebGPU does not.
-    integer: false, // decodedType.integer,
+    integer: decodedType.integer,
     signed: decodedType.signed,
     normalized: decodedType.normalized
   };

--- a/modules/core/src/adapter/utils/decode-vertex-format.ts
+++ b/modules/core/src/adapter/utils/decode-vertex-format.ts
@@ -38,7 +38,11 @@ export function decodeVertexFormat(format: VertexFormat): VertexFormatInfo {
     type,
     components,
     byteLength: decodedType.byteLength * components,
-    integer: decodedType.integer,
+    // It is not the vertex memory format that determines if the data will be treated as an integer,
+    // it is the shader attribute declaration. 
+    // Also note that WebGL supports assigning non-normalized integer data to floating point attributes,
+    // but as far as we can tell, WebGPU does not.
+    integer: false, // decodedType.integer,
     signed: decodedType.signed,
     normalized: decodedType.normalized
   };

--- a/modules/shadertools/src/modules/picking/picking.ts
+++ b/modules/shadertools/src/modules/picking/picking.ts
@@ -80,7 +80,7 @@ void picking_setPickingColor(vec3 pickingColor) {
 
     // if (!picking_uAttribute) {
       // Stores the picking color so that the fragment shader can render it during picking
-      picking_vRGBcolor_Avalid.rgb = pickingColor; //  * COLOR_SCALE;
+      picking_vRGBcolor_Avalid.rgb = pickingColor * COLOR_SCALE;
     // }
   } else {
     // Do the comparison with selected item color in vertex shader as it should mean fewer compares

--- a/modules/webgl/src/adapter/helpers/set-uniform.ts
+++ b/modules/webgl/src/adapter/helpers/set-uniform.ts
@@ -9,7 +9,7 @@ export function setUniform(
   gl: WebGLRenderingContext,
   location: WebGLUniformLocation,
   type: GL,
-  value: number | Float32Array | Int32Array | Uint32Array
+  value: number | Float32Array | Int32Array | Uint32Array | boolean
 ): void {
   const gl2 = gl as WebGL2RenderingContext;
 
@@ -37,13 +37,12 @@ export function setUniform(
     }
   }
 
-  // @ts-expect-error
   if (value === true) {
     value = 1;
   }
-  // @ts-expect-error
+
   if (value === false) {
-    value = 1;
+    value = 0;
   }
   const arrayValue = (typeof value === 'number') ? [value] : value;
 

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -120,7 +120,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
         continue; // eslint-disable-line no-continue
       }
       const decoded = decodeVertexFormat(attribute.format);
-      const {type: typeString, components: size, byteLength: stride, normalized, integer} = decoded;
+      const {type: typeString, components: size, byteLength: stride, normalized /* , integer*/} = decoded;
       const divisor = attribute.stepMode === 'instance' ? 1 : 0;
       const type = getWebGLDataType(typeString);
       this.vertexArrayObject.setBuffer(attribute.location, webglBuffer, {
@@ -129,7 +129,12 @@ export class WEBGLRenderPipeline extends RenderPipeline {
         stride,
         offset: 0,
         normalized,
-        integer,
+        // it is the shader attribute declaration, not the vertex memory format, 
+        // that determines if the data in the buffer will be treated as integers.
+        // /
+        // Also note that WebGL supports assigning non-normalized integer data to floating point attributes,
+        // but as far as we can tell, WebGPU does not.
+        integer: false,
         divisor
       });
     }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Fix refactored uniform setters.
#### Change List
- Correct handling of `false` valued uniforms.
- Avoid setting `integer` flag on an attribute info just because the provided data is in non-normalized integer form (since this mapping works on WebGL).
- Undo random change in picking module that was compensating for the broken uniform setter.