### PR TITLE
Restore fallback platform defines deleted in #1496

### DIFF
--- a/modules/shadertools/src/lib/shader-assembly/platform-defines.ts
+++ b/modules/shadertools/src/lib/shader-assembly/platform-defines.ts
@@ -48,6 +48,10 @@ export function getPlatformShaderDefines(platformInfo: PlatformInfo): string {
 #define DEFAULT_GPU
 // Prevent driver from optimizing away the calculation necessary for emulated fp64
 #define LUMA_FP64_CODE_ELIMINATION_WORKAROUND 1
+// Headless Chrome's software shader 'tan' function doesn't have acceptable precision
+#define LUMA_FP32_TAN_PRECISION_WORKAROUND 1
+// If the GPU doesn't have full 32 bits precision, will causes overflow
+#define LUMA_FP64_HIGH_BITS_OVERFLOW_WORKAROUND 1
 `;
   }
 }


### PR DESCRIPTION
#1496 is reverted on 8.5-release but not on master.
This is breaking render test because headless Chrome's tan function has precision issues.

#### Change List
- Restore platform defines for unknown GPU
