### PR TITLE
Fix model.setBufferLayout

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -314,6 +314,7 @@ export class Model {
             this.vertexArray.setBuffer(location, value);
           }
         }
+        oldVertexArray.destroy();
       }
     }
   }

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -296,26 +296,16 @@ export class Model {
 
     // Recreate the pipeline
     this.pipeline = this._updatePipeline();
-
-    const oldVertexArray = this.vertexArray;
+    
     // vertex array needs to be updated if we update buffer layout,
     // but not if we update parameters
     this.vertexArray = this.device.createVertexArray({
       renderPipeline: this.pipeline
     });
 
-    // Transfer previously set attributes
-    if (oldVertexArray) {
-      this.vertexArray.setIndexBuffer(oldVertexArray.indexBuffer);
-      for (let location = 0; location < oldVertexArray.attributes.length; location++) {
-        const value = oldVertexArray.attributes[location];
-        if (ArrayBuffer.isView(value)) {
-          this.vertexArray.setConstant(location, value);
-        } else if (value) {
-          this.vertexArray.setBuffer(location, value);
-        }
-      }
-      oldVertexArray.destroy();
+    // Reapply geometry attributes to the new vertex array
+    if (this._gpuGeometry) {
+      this._setGeometryAttributes(this._gpuGeometry);
     }
   }
 

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -128,6 +128,7 @@ export class Model {
 
   _pipelineNeedsUpdate: string | false = 'newly created';
   _attributeInfos: Record<string, AttributeInfo> = {};
+  _gpuGeometry: GPUGeometry | null = null;
   private _getModuleUniforms: (props?: Record<string, Record<string, any>>) => Record<string, any>;
   private props: Required<ModelProps>;
 
@@ -162,10 +163,9 @@ export class Model {
     this.bufferLayout = this.props.bufferLayout;
     this.parameters = this.props.parameters;
 
-    let gpuGeometry: GPUGeometry;
     // Geometry, if provided, sets topology and vertex cound
     if (props.geometry) {
-      gpuGeometry = this.setGeometry(props.geometry);
+      this._gpuGeometry = this.setGeometry(props.geometry);
     }
 
     this.pipelineFactory =
@@ -180,8 +180,8 @@ export class Model {
     });
 
     // Now we can apply geometry attributes
-    if (gpuGeometry) {
-      this._setGeometryAttributes(gpuGeometry);
+    if (this._gpuGeometry) {
+      this._setGeometryAttributes(this._gpuGeometry);
     }
 
     // Apply any dynamic settings that will not trigger pipeline change
@@ -289,33 +289,33 @@ export class Model {
    * @note Triggers a pipeline rebuild / pipeline cache fetch on WebGPU
    */
   setBufferLayout(bufferLayout: BufferLayout[]): void {
-    if (bufferLayout !== this.bufferLayout) {
-      this.bufferLayout = bufferLayout;
-      this._setPipelineNeedsUpdate('bufferLayout');
+    this.bufferLayout = this._gpuGeometry
+      ? mergeBufferLayouts(bufferLayout, this._gpuGeometry.bufferLayout)
+      : bufferLayout;
+    this._setPipelineNeedsUpdate('bufferLayout');
 
-      // Recreate the pipeline
-      this.pipeline = this._updatePipeline();
+    // Recreate the pipeline
+    this.pipeline = this._updatePipeline();
 
-      const oldVertexArray = this.vertexArray;
-      // vertex array needs to be updated if we update buffer layout,
-      // but not if we update parameters
-      this.vertexArray = this.device.createVertexArray({
-        renderPipeline: this.pipeline
-      });
+    const oldVertexArray = this.vertexArray;
+    // vertex array needs to be updated if we update buffer layout,
+    // but not if we update parameters
+    this.vertexArray = this.device.createVertexArray({
+      renderPipeline: this.pipeline
+    });
 
-      // Transfer previously set attributes
-      if (oldVertexArray) {
-        this.vertexArray.setIndexBuffer(oldVertexArray.indexBuffer);
-        for (let location = 0; location < oldVertexArray.attributes.length; location++) {
-          const value = oldVertexArray.attributes[location];
-          if (ArrayBuffer.isView(value)) {
-            this.vertexArray.setConstant(location, value);
-          } else if (value) {
-            this.vertexArray.setBuffer(location, value);
-          }
+    // Transfer previously set attributes
+    if (oldVertexArray) {
+      this.vertexArray.setIndexBuffer(oldVertexArray.indexBuffer);
+      for (let location = 0; location < oldVertexArray.attributes.length; location++) {
+        const value = oldVertexArray.attributes[location];
+        if (ArrayBuffer.isView(value)) {
+          this.vertexArray.setConstant(location, value);
+        } else if (value) {
+          this.vertexArray.setBuffer(location, value);
         }
-        oldVertexArray.destroy();
       }
+      oldVertexArray.destroy();
     }
   }
 


### PR DESCRIPTION
- Merge with `geometry.bufferLayout` if geometry is set
- Upon calling `model.setBufferLayout`, recreate the pipeline and vertexArray. Pipeline recreation cannot be deferred to `model.draw` because `setAttribute`/`setConstantAttribute` directly operates on the vertexArray.
