### PR TITLE
Extract bindings from shader module props

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -344,7 +344,18 @@ export class Model {
    */
   setShaderModuleProps(props: Record<string, any>): void {
     const uniforms = this._getModuleUniforms(props);
+
+    // Extract textures & framebuffers set by the modules
+    // TODO better way to extract bindings
+    const keys = Object.keys(uniforms).filter(k => uniforms[k].constructor.name.includes('WEBGL'));
+    const bindings: Record<string, Binding> = {};
+    for (const k of keys) {
+      bindings[k] = uniforms[k];
+      delete uniforms[k];
+    }
+
     Object.assign(this.uniforms, uniforms);
+    Object.assign(this.bindings, bindings);
   }
 
   /**


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

Modules set textures as well as uniforms as their properties, this extracts WebGLTextures&WebGLFramebuffers (admitedly in a hacky manner) and applies them to the bindings rather than the uniforms list. With this change, I can get the shadow effect working in deck.gl & it is a step forward to fixing the broken extensions. 

It is worth discussing how to do this more cleanly, ideas:

- Filter for specific types to support WebGPU&WebGL rather than `includes('WEBGL')`
- Include an explicit `getBindings()` method in the `ShaderModule`

<!-- For all the PRs -->
#### Change List
- Extract WebGL resources and apply to bindings, rather than uniforms
