### PR TITLE
Bind framebuffer color attachment in render pipeline

### DIFF
--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -17,6 +17,7 @@ import {setUniform} from '../helpers/set-uniform';
 import {WebGLDevice} from '../webgl-device';
 import {WEBGLBuffer} from './webgl-buffer';
 import {WEBGLShader} from './webgl-shader';
+import {WEBGLFramebuffer} from './webgl-framebuffer';
 import {WEBGLTexture} from './webgl-texture';
 // import {WEBGLVertexArray} from './webgl-vertex-array';
 import {WEBGLRenderPass} from './webgl-render-pass';
@@ -146,7 +147,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
           }
           break;
         case 'texture':
-          if (!(value instanceof WEBGLTexture)) {
+          if (!(value instanceof WEBGLTexture || value instanceof WEBGLFramebuffer)) {
             throw new Error('texture value');
           }
           break;
@@ -407,10 +408,18 @@ export class WEBGLRenderPipeline extends RenderPipeline {
           break;
 
         case 'texture':
-          if (!(value instanceof WEBGLTexture)) {
+          if (!(value instanceof WEBGLTexture || value instanceof WEBGLFramebuffer)) {
             throw new Error('texture');
           }
-          const texture: WEBGLTexture = value;
+          let texture: WEBGLTexture;
+          if (value instanceof WEBGLTexture) {
+            texture = value;
+          } else if (value instanceof WEBGLFramebuffer && value.colorAttachments[0] instanceof WEBGLTexture) {
+            texture = value.colorAttachments[0];
+          } else {
+            throw new Error('No texture');
+          }
+
           gl2.activeTexture(GL.TEXTURE0 + textureUnit);
           gl2.bindTexture(texture.target, texture.handle);
           // gl2.bindSampler(textureUnit, sampler.handle);

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -415,6 +415,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
           if (value instanceof WEBGLTexture) {
             texture = value;
           } else if (value instanceof WEBGLFramebuffer && value.colorAttachments[0] instanceof WEBGLTexture) {
+            log.warn(`Passing framebuffer in texture binding may be deprecated. Use fbo.colorAttachments[0] instead`)();
             texture = value.colorAttachments[0];
           } else {
             throw new Error('No texture');


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

The `WebGLRenderPipeline` has no support for framebuffers. This PR adds minimal support for handling the basic use case of binding the first color attachment of a framebuffer to a texture slot (in effect treating it as if were a texture). This change fixes the `CollisionFilterExtension` in deck.gl

<!-- For all the PRs -->
#### Change List
- Allow for `WEBGLFramebuffer` in `WebGLRenderPipeline`
- Unpack first color attachment and use as source for texture
