### PR TITLE
Handle TypedArrays when extracting bindings

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -10,7 +10,7 @@ import type {
   AttributeInfo
 } from '@luma.gl/core';
 import type {Binding, UniformValue, PrimitiveTopology} from '@luma.gl/core';
-import {Device, Buffer, RenderPipeline, RenderPass, log, uid, deepEqual} from '@luma.gl/core';
+import {Device, Buffer, RenderPipeline, RenderPass, log, uid, deepEqual, isNumberArray} from '@luma.gl/core';
 import {getAttributeInfosFromLayouts} from '@luma.gl/core';
 import type {ShaderModule, PlatformInfo} from '@luma.gl/shadertools';
 import {ShaderAssembler} from '@luma.gl/shadertools';
@@ -350,7 +350,7 @@ export class Model {
     // TODO better way to extract bindings
     const keys = Object.keys(uniforms).filter(k => {
       const uniform = uniforms[k];
-      return !Array.isArray(uniform) && (typeof uniform !== 'number') && (typeof uniform !== 'boolean');
+      return !isNumberArray(uniform) && (typeof uniform !== 'number') && (typeof uniform !== 'boolean');
     });
     const bindings: Record<string, Binding> = {};
     for (const k of keys) {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Followup to https://github.com/visgl/luma.gl/pull/1831
<!-- For other PRs without open issue -->

<!-- For all the PRs -->
#### Change List
- Also filter out TypedArrays (to support deck Fp64Extension which uses them)