### PR TITLE
feat(webgl): Unify shader block naming in JS

### DIFF
--- a/examples/tutorials/lighting/app.ts
+++ b/examples/tutorials/lighting/app.ts
@@ -37,13 +37,13 @@ const vs = glsl`\
     mat4 modelMatrix;
     mat4 mvpMatrix;
     vec3 eyePosition;
-  } uApp;
+  } app;
 
   void main(void) {
-    vPosition = (uApp.modelMatrix * vec4(positions, 1.0)).xyz;
-    vNormal = mat3(uApp.modelMatrix) * normals;
+    vPosition = (app.modelMatrix * vec4(positions, 1.0)).xyz;
+    vNormal = mat3(app.modelMatrix) * normals;
     vUV = texCoords;
-    gl_Position = uApp.mvpMatrix * vec4(positions, 1.0);
+    gl_Position = app.mvpMatrix * vec4(positions, 1.0);
   }
 `;
 
@@ -80,8 +80,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
   uniformStore = new UniformStore<{
     app: AppUniforms;
-    lighting: (typeof lighting)['defaultUniforms'];
-    phongMaterial: (typeof phongMaterial)['defaultUniforms'];
+    lighting: typeof lighting.uniforms;
+    phongMaterial: typeof phongMaterial.uniforms;
   }>({
     app,
     lighting,
@@ -146,9 +146,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       },
       bindings: {
         uTexture: texture,
-        appUniforms: this.uniformStore.getManagedUniformBuffer(device, 'app'),
-        lightingUniforms: this.uniformStore.getManagedUniformBuffer(device, 'lighting'),
-        phongMaterialUniforms: this.uniformStore.getManagedUniformBuffer(device, 'phongMaterial')
+        app: this.uniformStore.getManagedUniformBuffer(device, 'app'),
+        lighting: this.uniformStore.getManagedUniformBuffer(device, 'lighting'),
+        phongMaterial: this.uniformStore.getManagedUniformBuffer(device, 'phongMaterial')
       },
       parameters: {
         depthWriteEnabled: true,

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -131,7 +131,11 @@ export class WEBGLRenderPipeline extends RenderPipeline {
     // }
 
     for (const [name, value] of Object.entries(bindings)) {
-      const binding = this.shaderLayout.bindings.find(binding => binding.name === name);
+      const binding = 
+        this.shaderLayout.bindings.find(binding => binding.name === name) ||
+        // By convention we name uniform blocks with `Uniforms` suffix
+        this.shaderLayout.bindings.find(binding => binding.name === `${name}Uniforms`);
+
       if (!binding) {
         const validBindings = this.shaderLayout.bindings
           .map(binding => `"${binding.name}"`)
@@ -386,7 +390,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
     let textureUnit = 0;
     let uniformBufferIndex = 0;
     for (const binding of this.shaderLayout.bindings) {
-      const value = this.bindings[binding.name];
+      const value = this.bindings[binding.name] || this.bindings[binding.name.replace(/Uniforms$/, '')];
       if (!value) {
         throw new Error(`No value for binding ${binding.name} in ${this.id}`);
       }

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -131,9 +131,12 @@ export class WEBGLRenderPipeline extends RenderPipeline {
     // }
 
     for (const [name, value] of Object.entries(bindings)) {
+      // Accept both `xyz` and `xyzUniforms` as valid names for `xyzUniforms` uniform block
+      // This convention allows shaders to name uniform blocks as `uniform appUniforms {} app;`
+      // and reference them as `app` from both GLSL and JS.
+      // TODO - this is rather hacky - we could also remap the name directly in the shader layout.
       const binding = 
         this.shaderLayout.bindings.find(binding => binding.name === name) ||
-        // By convention we name uniform blocks with `Uniforms` suffix
         this.shaderLayout.bindings.find(binding => binding.name === `${name}Uniforms`);
 
       if (!binding) {
@@ -390,6 +393,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
     let textureUnit = 0;
     let uniformBufferIndex = 0;
     for (const binding of this.shaderLayout.bindings) {
+      // Accept both `xyz` and `xyzUniforms` as valid names for `xyzUniforms` uniform block
       const value = this.bindings[binding.name] || this.bindings[binding.name.replace(/Uniforms$/, '')];
       if (!value) {
         throw new Error(`No value for binding ${binding.name} in ${this.id}`);


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Address comments
#### Change List
- Allow uniform blocks named `xyzUniforms` to be reference as `xyz` from JS.
