### PR TITLE
fix(examples): Fix persistence example (uniform buffers)

### DIFF
--- a/docs/api-reference/core/shader-layout.md
+++ b/docs/api-reference/core/shader-layout.md
@@ -36,7 +36,7 @@ type ShaderLayout = {
   ],
 
   bindings: {
-    projectionUniforms: {location: 0, type: 'uniforms'},
+    projection: {location: 0, type: 'uniforms'},
     textureSampler: {location: 1, type: 'sampler'},
     texture: {location: 2, type: 'texture'}
   }
@@ -96,7 +96,7 @@ and type are the key pieces of information that need to be provided.
 
 ```typescript
   bindings?: {
-    projectionUniforms: {location: 0, type: 'uniforms'},
+    projection: {location: 0, type: 'uniforms'},
     textureSampler: {location: 1, type: 'sampler'},
     texture: {location: 2, type: 'texture'}
   }

--- a/examples/showcase/persistence/app.ts
+++ b/examples/showcase/persistence/app.ts
@@ -16,7 +16,7 @@ const INFO_HTML = `
 
 type SphereUniforms = {
   color: NumberArray;
-  lighting: NumberArray;
+  lighting: boolean;
   modelViewMatrix: NumberArray;
   projectionMatrix: NumberArray;
 };
@@ -258,7 +258,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       fs: SCREEN_QUAD_FS,
       geometry: quadGeometry,
       bindings: {
-        screenQuadUniforms: this.uniformStore.getManagedUniformBuffer(device, 'screenQuad')
+        screenQuad: this.uniformStore.getManagedUniformBuffer(device, 'screenQuad')
       },
       parameters: {
         depthWriteEnabled: true,
@@ -273,7 +273,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       fs: PERSISTENCE_FS,
       geometry: quadGeometry,
       bindings: {
-        persistenceQuadUniforms: this.uniformStore.getManagedUniformBuffer(
+        persistenceQuad: this.uniformStore.getManagedUniformBuffer(
           device,
           'persistenceQuad'
         )
@@ -341,7 +341,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
     // Render electrons to framebuffer
 
-    this.uniformStore.setUniforms({sphere: {color: [0.0, 0.5, 1], lighting: 0}});
+    this.uniformStore.setUniforms({sphere: {color: [0.0, 0.5, 1], lighting: false}});
 
     for (let i = 0; i < ELECTRON_COUNT; i++) {
       electronPosition[i] = electronRotation[i].transformVector(electronPosition[i]);
@@ -363,7 +363,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.uniformStore.setUniforms({
       sphere: {
         color: [1, 0.25, 0.25],
-        lighting: 1
+        lighting: true
       }
     });
 

--- a/examples/tutorials/hello-cube/app.ts
+++ b/examples/tutorials/hello-cube/app.ts
@@ -78,7 +78,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       geometry: new CubeGeometry(),
       bindings: {
         uTexture: texture,
-        AppUniforms: this.uniformStore.getManagedUniformBuffer(device, 'app')
+        app: this.uniformStore.getManagedUniformBuffer(device, 'app')
       },
       parameters: {
         depthWriteEnabled: true,

--- a/examples/tutorials/shader-modules/app.ts
+++ b/examples/tutorials/shader-modules/app.ts
@@ -106,7 +106,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         position: this.positionBuffer
       },
       bindings: {
-        colorUniforms: this.uniformBuffer1
+        color: this.uniformBuffer1
       },
       vertexCount: 3
     });

--- a/modules/webgl/src/adapter/resources/webgl-render-pass.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pass.ts
@@ -6,6 +6,7 @@ import {WebGLDevice} from '../webgl-device';
 import {GL, GLParameters} from '@luma.gl/constants';
 import {withGLParameters} from '../../context/state-tracker/with-parameters';
 import {setGLParameters} from '../../context/parameters/unified-parameter-api';
+import {pushContextState, popContextState} from '../../context/state-tracker/track-context-state';
 
 // Should collapse during minification
 const GL_DEPTH_BUFFER_BIT = 0x00000100;
@@ -25,6 +26,7 @@ export class WEBGLRenderPass extends RenderPass {
     this.device = device;
 
     // TODO - do parameters (scissorRect) affect the clear operation?
+    pushContextState(this.device.gl);
     this.setParameters(this.props.parameters);
 
     // Hack - for now WebGL draws in "immediate mode" (instead of queueing the operations)...
@@ -32,6 +34,10 @@ export class WEBGLRenderPass extends RenderPass {
   }
 
   end(): void {
+    popContextState(this.device.gl);
+    if (this.props.framebuffer) {
+      setGLParameters(this.device, {framebuffer: null});
+    }
     // should add commands to CommandEncoder.
   }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Persistence example broken
#### Change List
- Align persistence example and a few remaining examples with the new uniform block naming conventions
- Fix a bug in renderpass that doesn't reset framebuffer when renderpass.end() is called
