### PR TITLE
fix(webgl): Update video texture bindings before draw

### DIFF
--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -44,8 +44,6 @@ export class WEBGLRenderPipeline extends RenderPipeline {
   /** WebGL varyings */
   varyings: string[] | null = null;
 
-  _textureUniforms: Record<string, any> = {};
-  _textureIndexCounter: number = 0;
   _uniformCount: number = 0;
   _uniformSetters: Record<string, Function> = {}; // TODO are these used?
 
@@ -348,13 +346,10 @@ export class WEBGLRenderPipeline extends RenderPipeline {
   _areTexturesRenderable() {
     let texturesRenderable = true;
 
-    for (const [, texture] of Object.entries(this._textureUniforms)) {
-      texture.update();
-      texturesRenderable = texturesRenderable && texture.loaded;
-    }
-
     for (const [, texture] of Object.entries(this.bindings)) {
-      // texture.update();
+      if (texture instanceof WEBGLTexture) {
+        texture.update();
+      }
       // @ts-expect-error
       if (texture.loaded !== undefined) {
         // @ts-expect-error

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -349,9 +349,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
     for (const [, texture] of Object.entries(this.bindings)) {
       if (texture instanceof WEBGLTexture) {
         texture.update();
-        if (texture.loaded !== undefined) {
-          texturesRenderable = texturesRenderable && texture.loaded;
-        }
+        texturesRenderable = texturesRenderable && texture.loaded;
       }
     }
 

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -349,11 +349,9 @@ export class WEBGLRenderPipeline extends RenderPipeline {
     for (const [, texture] of Object.entries(this.bindings)) {
       if (texture instanceof WEBGLTexture) {
         texture.update();
-      }
-      // @ts-expect-error
-      if (texture.loaded !== undefined) {
-        // @ts-expect-error
-        texturesRenderable = texturesRenderable && texture.loaded;
+        if (texture.loaded !== undefined) {
+          texturesRenderable = texturesRenderable && texture.loaded;
+        }
       }
     }
 


### PR DESCRIPTION
Restores `texture.update()` call for video textures in WebGL render pipeline.  Removes unused `_textureUniforms` and `_textureIndexCounter` properties on WEBGLRenderPipeline class.

Context:

- https://github.com/visgl/deck.gl/issues/8315