### PR TITLE
chore(ci): Update CI dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
         node-version: [18]
 
     steps:
-      - uses: actions/checkout@v2.1.1
+      - uses: actions/checkout@v4.1.1
       
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4.0.0
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -12,12 +12,12 @@ jobs:
     if: github.repository_owner == 'visgl'
 
     steps:
-      - uses: actions/checkout@v2.1.1
+      - uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.ADMIN_TOKEN }}
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4.0.0
         with:
           node-version: '18.x'
 


### PR DESCRIPTION
Fixes warnings in CI:

![Screenshot 2023-11-30 at 12 58 54 PM](https://github.com/visgl/luma.gl/assets/1848368/9a85111a-7f03-4f7c-ab15-d9089165e5ad)

- related https://github.com/visgl/deck.gl/pull/8331