### PR TITLE
Fix `babel-plugin-inline-webgl-constants`

### DIFF
--- a/dev-modules/babel-plugin-inline-webgl-constants/index.js
+++ b/dev-modules/babel-plugin-inline-webgl-constants/index.js
@@ -5,15 +5,22 @@ const COLOR_RESET = '\x1b[0m';
 const COLOR_YELLOW = '\x1b[33m';
 const COLOR_RED = '\x1b[31m';
 
+// When building `@luma.gl/constants`, skip MemberExpressions with
+// these types so declarations are not overwritten.
+const EXCLUDED_TYPES = ['AssignmentExpression', 'StringLiteral'];
+
 export default function _(opts) {
   return {
     visitor: {
       ImportDeclaration(path, state) {
         // specifiers: [ ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier ];
         // source: Literal;
-        const specifiers = path.get('specifiers');
+
+        let modified = false;
+        let specifiers = path.get('specifiers');
+
         specifiers.forEach((specifier) => {
-          if (specifier.type === 'ImportDefaultSpecifier') {
+          if (specifier.type === 'ImportDefaultSpecifier' || specifier.type === 'ImportSpecifier') {
             const local = specifier.node.local;
             if (local.type === 'Identifier' && local.name === 'GL') {
               if (state.opts.debug) {
@@ -23,10 +30,18 @@ export default function _(opts) {
                   `${COLOR_YELLOW}${filename}:${line} Dropping GL import${COLOR_RESET}`
                 );
               }
-              path.remove();
+              specifier.remove();
+              modified = true;
             }
           }
         });
+
+        specifiers = path.get('specifiers');
+
+        // If the last imported specifier was removed, remove the entire import.
+        if (modified && specifiers.length === 0) {
+          path.remove();
+        }
       },
 
       MemberExpression(path, state) {
@@ -37,7 +52,7 @@ export default function _(opts) {
         const isGLIdentifier =
           object.isIdentifier({name: 'GL'}) || object.isIdentifier({name: 'gl'});
 
-        if (isGLIdentifier) {
+        if (isGLIdentifier && !EXCLUDED_TYPES.includes(property.node.type)) {
           const filename = getFilename(state);
           const constant = `${object.node.name}.${property.node.name}`;
 

--- a/test/dev-modules/babel-plugin-inline-webgl-constants.spec.js
+++ b/test/dev-modules/babel-plugin-inline-webgl-constants.spec.js
@@ -37,12 +37,23 @@ const TEST_CASES = [
     `
   },
   {
-    title: 'remove import',
+    title: 'remove full import',
     input: `
       import {GL} from '@luma.gl/constants';
       const x = GL.FLOAT;
     `,
     output: 'const x = 5126;'
+  },
+  {
+    title: 'remove partial import',
+    input: `
+      import {GL, UnknownItem} from '@luma.gl/constants';
+      const x = GL.FLOAT;
+    `,
+    output: `
+      import { UnknownItem } from '@luma.gl/constants';
+      const x = 5126;
+    `
   }
 ];
 
@@ -51,9 +62,7 @@ function clean(code) {
   return code.replace('"use strict";', '').replace(/\n\s+/g, '\n').trim();
 }
 
-// TODO - restore
-/* eslint-disable */
-test.skip('InlineGLSLConstants Babel Plugin', (t) => {
+test('InlineGLSLConstants Babel Plugin', (t) => {
   TEST_CASES.forEach((testCase) => {
     const transform = () =>
       babel.transform(testCase.input, {

--- a/test/dev-modules/babel-plugin-inline-webgl-constants.spec.js
+++ b/test/dev-modules/babel-plugin-inline-webgl-constants.spec.js
@@ -37,7 +37,7 @@ const TEST_CASES = [
     `
   },
   {
-    title: 'remove full import',
+    title: 'remove import',
     input: `
       import {GL} from '@luma.gl/constants';
       const x = GL.FLOAT;
@@ -45,7 +45,7 @@ const TEST_CASES = [
     output: 'const x = 5126;'
   },
   {
-    title: 'remove partial import',
+    title: 'remove import specifier',
     input: `
       import {GL, UnknownItem} from '@luma.gl/constants';
       const x = GL.FLOAT;

--- a/test/dev-modules/index.js
+++ b/test/dev-modules/index.js
@@ -1,3 +1,3 @@
-import './babel-plugin-inline-gl-constants.spec';
+import './babel-plugin-inline-webgl-constants.spec';
 import './babel-plugin-remove-glsl-comments.spec';
 import './eslint-plugin-luma-gl-custom-rules.spec';


### PR DESCRIPTION
Fixes for `babel-plugin-inline-webgl-constants` in v9. I haven't published the plugin to npm, so I haven't added it back to `babel.config.cjs` yet either. When building locally, I needed to disable the `ocular-clean` step before each build, so that the constants are there when the plugin imports them. I don't know if that would be an issue once the plugin is published to npm? Or should we be doing something to ensure `@luma.gl/constants` builds first, without this plugin?

Changes:

- Handle both default and non-default imports
- Skip certain expressions so that including the babel plugin when building `@luma.gl/constants` does not fail
- Update and re-enable unit tests

***

- From #1501 