### PR TITLE
Differentiate between settings/uniforms in picking

### DIFF
--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -21,7 +21,7 @@ export type ShaderModule<UniformsT extends Record<string, UniformValue> = Record
   vs?: string;
   
   /** Used for type inference, not currently used for values */
-  uniforms?: Required<UniformsT>;
+  uniforms?: UniformsT;
 
   /** Uniform shader types */
   uniformTypes?: Record<keyof UniformsT, UniformFormat>;

--- a/modules/shadertools/src/modules/engine/picking/picking.ts
+++ b/modules/shadertools/src/modules/engine/picking/picking.ts
@@ -206,9 +206,9 @@ export const picking: ShaderModule<PickingUniforms, PickingSettings> = {
 function getUniforms(opts: Partial<PickingSettings> = {}, prevUniforms?: PickingUniforms): PickingUniforms {
   const uniforms = {...picking.defaultUniforms};
 
-  if (opts.highlightedObjectColor === null) {
+  if (opts.highlightedObjectColor === undefined) {
     delete uniforms.highlightedObjectColor;
-  } else if (opts.highlightedObjectColor === undefined) {
+  } else if (opts.highlightedObjectColor === null) {
     uniforms.isHighlightActive = false;
   } else {
     uniforms.isHighlightActive = true;

--- a/modules/shadertools/src/modules/engine/picking/picking.ts
+++ b/modules/shadertools/src/modules/engine/picking/picking.ts
@@ -25,14 +25,19 @@ export type PickingUniforms = {
   useFloatColors?: boolean;
   /** Do we have a highlighted item? */
   isHighlightActive?: boolean;
+  /** Set to a picking color to visually highlight that item */
+  highlightedObjectColor?: NumberArray;
+  /** Color of visual highlight of "selected" item */
+  highlightColor?: NumberArray;
+};
+
+export type PickingSettings = Omit<PickingUniforms, 'isHighlightActive' | 'highlightedObjectColor'> & {
   /**
    * Set to a picking color to visually highlight that item.
    * The picking module will persist the last highlighted object, unless
    * `null` is passed to explicitly clear
    **/
   highlightedObjectColor?: NumberArray | null;
-  /** Color of visual highlight of "selected" item */
-  highlightColor?: NumberArray;
 };
 
 const vs = glsl`\
@@ -175,7 +180,7 @@ vec4 picking_filterColor(vec4 color) {
  * and correspondingly, supports picking and highlighting groups of
  * primitives with the same picking color in non-instanced draw-calls
  */
-export const picking: ShaderModule<PickingUniforms> = {
+export const picking: ShaderModule<PickingUniforms, PickingSettings> = {
   name: 'picking',
   vs,
   fs,
@@ -198,19 +203,17 @@ export const picking: ShaderModule<PickingUniforms> = {
   getUniforms
 };
 
-function getUniforms(opts: Partial<PickingUniforms> = {}, prevUniforms?: PickingUniforms): PickingUniforms {
+function getUniforms(opts: Partial<PickingSettings> = {}, prevUniforms?: PickingUniforms): PickingUniforms {
   const uniforms = {...picking.defaultUniforms};
 
-  if (opts.highlightedObjectColor !== undefined) {
-    if (!opts.highlightedObjectColor) {
-      uniforms.isHighlightActive = false;
-    } else {
-      uniforms.isHighlightActive = true;
-      const highlightedObjectColor = opts.highlightedObjectColor.slice(0, 3);
-      uniforms.highlightedObjectColor = highlightedObjectColor;
-    }
-  } else {
+  if (opts.highlightedObjectColor === null) {
     delete uniforms.highlightedObjectColor;
+  } else if (opts.highlightedObjectColor === undefined) {
+    uniforms.isHighlightActive = false;
+  } else {
+    uniforms.isHighlightActive = true;
+    const highlightedObjectColor = opts.highlightedObjectColor.slice(0, 3);
+    uniforms.highlightedObjectColor = highlightedObjectColor;
   }
 
   if (opts.highlightColor) {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Follow up to https://github.com/visgl/luma.gl/pull/1856
<!-- For other PRs without open issue -->

<!-- For all the PRs -->
#### Change List
- Differentiate types between input settings & uniforms in picking module
- Remove `Required` for type `uniforms` inference helper
