### PR TITLE
Remove 'modules', 'test', and 'examples' from .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,4 @@ workers/
 wip/
 encoding.js
 encoding-indexes.js
-examples
-modules
-test
 .ocularrc.js


### PR DESCRIPTION
These directories were added to `.prettierignore` in #1745, I'm guessing that was not intended to be a long-term change – ok to re-enable them? I don't personally care much about formatting `examples/` at the moment, but being able to format `modules/` and `test/` would save me a bit of time. 