### PR TITLE
website: device-store to create hidden canvases for device

### DIFF
--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -125,7 +125,12 @@ export class WebGPUDevice extends Device {
 
     // Note: WebGPU devices can be created without a canvas, for compute shader purposes
     // if (props.canvas) {
-    this.canvasContext = new WebGPUCanvasContext(this, this.adapter, {canvas: props.canvas});
+    this.canvasContext = new WebGPUCanvasContext(this, this.adapter, {
+      canvas: props.canvas,
+      height: props.height,
+      width: props.width,
+      container: props.container
+    });
     // }
 
     this.features = this._getFeatures();

--- a/website/src/react-luma/components/device-tabs.tsx
+++ b/website/src/react-luma/components/device-tabs.tsx
@@ -13,16 +13,15 @@ export const DeviceTabs = props => {
         {/* <img height="80" src="https://raw.github.com/visgl/deck.gl-data/master/images/whats-new/webgl2.jpg" />*/}
         {deviceError}
       </Tab>
-      { /*
+
       <Tab key="WebGL" title="WebGL" tag='webgl1'>
-        {/* <img height="80" src="https://raw.github.com/visgl/deck.gl-data/master/images/whats-new/webgl2.jpg" /> }
+        {/* <img height="80" src="https://raw.github.com/visgl/deck.gl-data/master/images/whats-new/webgl2.jpg" /> */}
         {deviceError}
       </Tab>
       <Tab key="WebGPU" title="WebGPU" tag='webgpu'>
-        {/* <img height="80" src="https://raw.githubusercontent.com/gpuweb/gpuweb/3b3a1632ff1ad6a573330a58710e341bb9d65576/logo/webgpu-horizontal.svg" />}
+        {/* <img height="80" src="https://raw.githubusercontent.com/gpuweb/gpuweb/3b3a1632ff1ad6a573330a58710e341bb9d65576/logo/webgpu-horizontal.svg" /> */}
         {deviceError}
       </Tab>
-      */ }
     </Tabs>
   );
 };

--- a/website/src/react-luma/components/device-tabs.tsx
+++ b/website/src/react-luma/components/device-tabs.tsx
@@ -1,27 +1,31 @@
 import React from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+
 import {Tabs, Tab} from './tabs';
 import {useStore} from '../store/device-store';
 
-export const DeviceTabs = props => {
+export const DeviceTabsPriv = props => {
   const deviceType = useStore(state => state.deviceType);
   const deviceError = useStore(state => state.deviceError);
   const setDeviceType = useStore(state => state.setDeviceType);
 
   return (
     <Tabs selectedItem={deviceType} setSelectedItem={setDeviceType}>
-      <Tab key="WebGL2" title="WebGL2" tag='webgl2'>
+      <Tab key="WebGL2" title="WebGL2" tag="webgl2">
         {/* <img height="80" src="https://raw.github.com/visgl/deck.gl-data/master/images/whats-new/webgl2.jpg" />*/}
         {deviceError}
       </Tab>
 
-      <Tab key="WebGL" title="WebGL" tag='webgl1'>
+      <Tab key="WebGL" title="WebGL" tag="webgl1">
         {/* <img height="80" src="https://raw.github.com/visgl/deck.gl-data/master/images/whats-new/webgl2.jpg" /> */}
         {deviceError}
       </Tab>
-      <Tab key="WebGPU" title="WebGPU" tag='webgpu'>
+      <Tab key="WebGPU" title="WebGPU" tag="webgpu">
         {/* <img height="80" src="https://raw.githubusercontent.com/gpuweb/gpuweb/3b3a1632ff1ad6a573330a58710e341bb9d65576/logo/webgpu-horizontal.svg" /> */}
         {deviceError}
       </Tab>
     </Tabs>
   );
 };
+
+export const DeviceTabs = () => <BrowserOnly>{() => <DeviceTabsPriv />}</BrowserOnly>;

--- a/website/src/react-luma/store/device-store.tsx
+++ b/website/src/react-luma/store/device-store.tsx
@@ -15,10 +15,14 @@ export type Store = {
 
 let cachedDevice: Record<string, Promise<Device>> = {};
 
+const container = document.createElement('div');
+container.style.display = 'none';
+document.body.appendChild(container);
+
 export async function createDevice(deviceType: string): Promise<Device> {
   const type = deviceType.toLowerCase();
   // @ts-expect-error
-  cachedDevice[type] = cachedDevice[type] || luma.createDevice({type, height: 0});
+  cachedDevice[type] = cachedDevice[type] || luma.createDevice({type, height: 0, container});
   return await cachedDevice[type];
 }
 

--- a/website/src/react-luma/store/device-store.tsx
+++ b/website/src/react-luma/store/device-store.tsx
@@ -15,14 +15,21 @@ export type Store = {
 
 let cachedDevice: Record<string, Promise<Device>> = {};
 
-const container = document.createElement('div');
-container.style.display = 'none';
-document.body.appendChild(container);
+let cachedContainer: HTMLDivElement | undefined;
+function getCanvasContainer() {
+  if (!cachedContainer) {
+    cachedContainer = document.createElement('div');
+    cachedContainer.style.display = 'none';
+    document.body.appendChild(cachedContainer);
+  }
+  return cachedContainer;
+}
 
 export async function createDevice(deviceType: string): Promise<Device> {
   const type = deviceType.toLowerCase();
   // @ts-expect-error
-  cachedDevice[type] = cachedDevice[type] || luma.createDevice({type, height: 0, container});
+  cachedDevice[type] =
+    cachedDevice[type] || luma.createDevice({type, height: 0, container: getCanvasContainer()});
   return await cachedDevice[type];
 }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1501

<!-- For all the PRs -->
#### Change List
- DeviceTabs creates hidden container for canvases used to create temporary devices
- DeviceTabs is browser only (enabled static build)
- WebGPUDevice to pass height, width and container to WebGPUCanvasContext context
