### PR TITLE
chore(ci): Disable babel inline webgl plugin

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -22,8 +22,9 @@ const plugins = [
 // on it. This plugin uses LOCAL `@luma.gl/constants`, and will fail without
 // it, so delay using the plugin until reaching a package depending on constants.
 if (pkg.dependencies && '@luma.gl/constants' in pkg.dependencies) {
+  // TODO(v9): CI builds are flaky with this enabled, need to investigate cause.
   // plugins.push('./dev-modules/babel-plugin-remove-glsl-comments/index.js');
-  plugins.push('babel-plugin-inline-webgl-constants');
+  // plugins.push('babel-plugin-inline-webgl-constants');
 }
 
 module.exports = getBabelConfig({


### PR DESCRIPTION
CI builds are currently flaky due to the babel plugin for inlining constants. I need to investigate further, but will go ahead and disable it so it doesn't block CI for other PRs.
