### PR TITLE
feat(gltf) Support both size & components in GLTF attributes

### DIFF
--- a/modules/gltf/src/gltf/gltf-instantiator.ts
+++ b/modules/gltf/src/gltf/gltf-instantiator.ts
@@ -149,8 +149,9 @@ export class GLTFInstantiator {
   createGeometry(id: string, gltfPrimitive: any, topology: PrimitiveTopology): Geometry {
     const attributes = {}
     for (const [attributeName, attribute] of Object.entries(gltfPrimitive.attributes)) {
-      const {components: size, value} = attribute as GeometryAttribute;
-      attributes[attributeName] = {size, value};
+      const {components, size, value} = attribute as GeometryAttribute;
+
+      attributes[attributeName] = {size: size ?? components, value};
     };
 
     return new Geometry({


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/luma.gl/issues/1847
<!-- For other PRs without open issue -->

#### Background

The `gltfPrimitive` sometimes has the number of components specified by `size`, and sometimes by `components`, due to postprocessing done in loaders.gl https://github.com/visgl/loaders.gl/blob/master/modules/gltf/src/lib/api/post-process-gltf.ts#L397

It would be nice to tidy this up, for now this PR makes the code support both

<!-- For all the PRs -->
#### Change List
- Support `size/components` when creating GLTF geometry
