### PR TITLE
Restore FP64 arithmetic tests

### DIFF
--- a/modules/engine/src/transform/transform.ts
+++ b/modules/engine/src/transform/transform.ts
@@ -14,12 +14,12 @@ export type TransformProps = {
   vs?: string;
   fs?: string;
   vertexCount?: number;
-  sourceBuffers?: Record<string, Buffer>;
+  sourceBuffers?: Record<string, Buffer>; // TODO(donmccurdy): Duplicate of attrs?
   feedbackBuffers?: Record<string, Buffer | BufferRange>;
   varyings?: string[];
   feedbackMap?: Record<string, string>;
   modules?: ShaderModule[];
-  attributes?: Record<string, any>;
+  attributes?: Record<string, any>; // TODO(donmccurdy): Did I add this?
   bufferLayout?: BufferLayout[];
   uniforms?: Record<string, any>;
   defines?: Record<string, any>

--- a/modules/engine/src/transform/transform.ts
+++ b/modules/engine/src/transform/transform.ts
@@ -14,12 +14,12 @@ export type TransformProps = {
   vs?: string;
   fs?: string;
   vertexCount?: number;
-  sourceBuffers?: Record<string, Buffer>; // TODO(donmccurdy): Relation to attrs?
+  sourceBuffers?: Record<string, Buffer>;
   feedbackBuffers?: Record<string, Buffer | BufferRange>;
   varyings?: string[];
   feedbackMap?: Record<string, string>;
   modules?: ShaderModule[];
-  attributes?: Record<string, any>; // TODO(donmccurdy): Relation to sourceBuffers?
+  attributes?: Record<string, any>;
   bufferLayout?: BufferLayout[];
   uniforms?: Record<string, any>;
   defines?: Record<string, any>

--- a/modules/engine/src/transform/transform.ts
+++ b/modules/engine/src/transform/transform.ts
@@ -14,12 +14,12 @@ export type TransformProps = {
   vs?: string;
   fs?: string;
   vertexCount?: number;
-  sourceBuffers?: Record<string, Buffer>; // TODO(donmccurdy): Duplicate of attrs?
+  sourceBuffers?: Record<string, Buffer>; // TODO(donmccurdy): Relation to attrs?
   feedbackBuffers?: Record<string, Buffer | BufferRange>;
   varyings?: string[];
   feedbackMap?: Record<string, string>;
   modules?: ShaderModule[];
-  attributes?: Record<string, any>; // TODO(donmccurdy): Did I add this?
+  attributes?: Record<string, any>; // TODO(donmccurdy): Relation to sourceBuffers?
   bufferLayout?: BufferLayout[];
   uniforms?: Record<string, any>;
   defines?: Record<string, any>

--- a/modules/shadertools/src/modules-webgl1/math/fp64/fp64-arithmetic.glsl.ts
+++ b/modules/shadertools/src/modules-webgl1/math/fp64/fp64-arithmetic.glsl.ts
@@ -9,7 +9,7 @@ About LUMA_FP64_CODE_ELIMINATION_WORKAROUND
 
 The purpose of this workaround is to prevent shader compilers from
 optimizing away necessary arithmetic operations by swapping their sequences
-or transform the equation to some 'equivalent' from.
+or transform the equation to some 'equivalent' form.
 
 The method is to multiply an artifical variable, ONE, which will be known to
 the compiler to be 1 only at runtime. The whole expression is then represented

--- a/modules/shadertools/test/modules-webgl1/fp64/fp64-arithmetic-transform.spec.ts
+++ b/modules/shadertools/test/modules-webgl1/fp64/fp64-arithmetic-transform.spec.ts
@@ -7,52 +7,50 @@ import {runTests} from './fp64-test-utils-transform';
 
 // Failing test cases are ignored based on gpu and glslFunc, using ignoreFor field
 // ignoreFor: [{gpu: ['glslFunc-1', 'glslFunc-2']}] => ignores for `'glslFunc-1' and 'glslFunc-2` when running on `gpu`
+// Many of these tests fail on Apple GPUs with very large margins, see https://github.com/visgl/luma.gl/issues/1764.
 const commonTestCases = [
   {a: 2, b: 2},
-  {a: 2, b: 2},
-  {a: 2, b: 2},
-  {a: 0.1, b: 0.1}, // TODO(donmccurdy): Passes with naive (`vec2(a.x + b.x, a.y + b.y)`) implementation.
-  {a: 590000, b: 10000},
-  {a: 3.0e-19, b: 3.3e13},
+  {a: 0.1, b: 0.1, ignoreFor: {apple: ['sum_fp64', 'mul_fp64', 'div_fp64']}},
+  {a: 3.0e-19, b: 3.3e13, ignoreFor: {apple: ['sum_fp64']}},
   {a: 9.9e-40, b: 1.7e3},
   {a: 1.5e-36, b: 1.7e-16},
   {a: 9.4e-26, b: 51},
-  {a: 6.7e-20, b: 0.93},
+  {a: 6.7e-20, b: 0.93, ignoreFor: {apple: ['sum_fp64']}},
 
   // mul_fp64: Large numbers once multipled, can't be represented by 32 bit precision and Math.fround() returns NAN
   // sqrt_fp64: Fail on INTEL with margin 3.906051071870294e-12
-  {a: 2.4e3, b: 5.9e31, ignoreFor: {all: ['mul_fp64'], intel: ['sqrt_fp64']}},
+  {a: 2.4e3, b: 5.9e31, ignoreFor: {all: ['mul_fp64'], intel: ['sqrt_fp64'], apple: ['sum_fp64']}},
 
   // div_fp64 fails on INTEL with margin 1.7318642528355118e-12
   // sqrt_fp64 fails on INTEL with margin 1.5518878351528786e-12
-  {a: 1.4e9, b: 6.3e5, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64']}},
+  {a: 1.4e9, b: 6.3e5, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64'], apple: ['mul_fp64', 'div_fp64']}},
 
   // div fails on INTEL with margin 1.7886288892678105e-14
   // sqrt fails on INTEL with margin 2.5362810256331708e-12
-  {a: 3.0e9, b: 4.3e-23, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64']}},
+  {a: 3.0e9, b: 4.3e-23, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64'], apple: ['div_fp64']}},
 
   // div fail on INTEL with margin 1.137354350370519e-12
-  {a: 1.7e-19, b: 2.7e-27, ignoreFor: {intel: ['div_fp64']}},
+  {a: 1.7e-19, b: 2.7e-27, ignoreFor: {intel: ['div_fp64'], apple: ['div_fp64']}},
 
   // div_fp64 fails on INTEL with margin 2.7291999999999997e-12
   // sqrt_fp64 fails on INTEL with margin 3.501857471494295e-12
-  {a: 0.3, b: 3.2e-16, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64']}},
+  {a: 0.3, b: 3.2e-16, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64'], apple: ['div_fp64']}},
 
   // mul_fp64 : fails since result can't be represented by 32 bit floats
   // div_fp64 : fails on INTEL with margin 1.9999999999999994e-15
   // sqrt_fp64 : fails on INTEL with margin 1.832115697751484e-12
-  {a: 4.1e30, b: 8.2e15, ignoreFor: {all: ['mul_fp64'], intel: ['div_fp64', 'sqrt_fp64']}},
+  {a: 4.1e30, b: 8.2e15, ignoreFor: {all: ['mul_fp64'], intel: ['div_fp64', 'sqrt_fp64'], apple: ['div_fp64']}},
 
   // Fails on INTEL, margin 3.752606081210107e-12
-  {a: 6.2e3, b: 6.3e10, ignoreFor: {intel: ['sqrt_fp64']}},
+  {a: 6.2e3, b: 6.3e10, ignoreFor: {intel: ['sqrt_fp64'], apple: ['sum_fp64', 'mul_fp64']}},
   // Fails on INTEL, margin 3.872578286363912e-13
-  {a: 2.5e2, b: 5.1e-21, ignoreFor: {intel: ['sqrt_fp64']}},
+  {a: 2.5e2, b: 5.1e-21, ignoreFor: {intel: ['sqrt_fp64'], apple: ['div_fp64']}},
   // Fails on INTEL, margin 1.5332142001740705e-12
-  {a: 96, b: 1.7e4, ignoreFor: {intel: ['sqrt_fp64']}},
+  {a: 96, b: 1.7e4, ignoreFor: {intel: ['sqrt_fp64'], apple: ['div_fp64']}},
   // // Fail on INTEL, margin 1.593162047558726e-12
-  {a: 0.27, b: 2.3e16, ignoreFor: {intel: ['sqrt_fp64']}},
+  {a: 0.27, b: 2.3e16, ignoreFor: {intel: ['sqrt_fp64'], apple: ['sum_fp64', 'mul_fp64']}},
   // Fails on INTEL, margin 1.014956357028767e-12
-  {a: 18, b: 9.1e-9, ignoreFor: {intel: ['sqrt_fp64']}}
+  {a: 18, b: 9.1e-9, ignoreFor: {intel: ['sqrt_fp64'], apple: ['div_fp64']}}
 ];
 
 // Filter all tests cases based on current gpu and glsFunc
@@ -78,7 +76,7 @@ function getTestCasesFor(glslFunc) {
   return testCases;
 }
 
-test.only('fp64#sum_fp64', async (t) => {
+test('fp64#sum_fp64', async (t) => {
   if (!webgl2Device) {
     t.comment('requires WebGL 2');
   } else {
@@ -90,9 +88,7 @@ test.only('fp64#sum_fp64', async (t) => {
 });
 
 test('fp64#sub_fp64', async (t) => {
-  if (webgl2Device?.info.gpu === 'apple') {
-    t.comment('apple GPU has precision issues')
-  } else if (!webgl2Device) {
+  if (!webgl2Device) {
     t.comment('requires WebGL 2');
   } else {
     const glslFunc = 'sub_fp64';
@@ -103,9 +99,7 @@ test('fp64#sub_fp64', async (t) => {
 });
 
 test('fp64#mul_fp64', async (t) => {
-  if (webgl2Device?.info.gpu === 'apple') {
-    t.comment('apple GPU has precision issues')
-  } else if (!webgl2Device) {
+  if (!webgl2Device) {
     t.comment('requires WebGL 2');
   } else {
     const glslFunc = 'mul_fp64';
@@ -116,9 +110,7 @@ test('fp64#mul_fp64', async (t) => {
 });
 
 test('fp64#div_fp64', async (t) => {
-  if (webgl2Device?.info.gpu === 'apple') {
-    t.comment('apple GPU has precision issues')
-  } else if (!webgl2Device) {
+  if (!webgl2Device) {
     t.comment('requires WebGL 2');
   } else {
     const glslFunc = 'div_fp64';
@@ -129,9 +121,7 @@ test('fp64#div_fp64', async (t) => {
 });
 
 test('fp64#sqrt_fp64', async (t) => {
-  if (webgl2Device?.info.gpu === 'apple') {
-    t.comment('apple GPU has precision issues')
-  } else if (!webgl2Device) {
+  if (!webgl2Device) {
     t.comment('requires WebGL 2');
   } else {
     const glslFunc = 'sqrt_fp64';

--- a/modules/shadertools/test/modules-webgl1/fp64/fp64-arithmetic-transform.spec.ts
+++ b/modules/shadertools/test/modules-webgl1/fp64/fp64-arithmetic-transform.spec.ts
@@ -11,6 +11,7 @@ const commonTestCases = [
   {a: 2, b: 2},
   {a: 2, b: 2},
   {a: 2, b: 2},
+  {a: 0.1, b: 0.1}, // TODO(donmccurdy): Passes with naive (`vec2(a.x + b.x, a.y + b.y)`) implementation.
   {a: 590000, b: 10000},
   {a: 3.0e-19, b: 3.3e13},
   {a: 9.9e-40, b: 1.7e3},

--- a/modules/shadertools/test/modules-webgl1/fp64/fp64-arithmetic-transform.spec.ts
+++ b/modules/shadertools/test/modules-webgl1/fp64/fp64-arithmetic-transform.spec.ts
@@ -8,6 +8,10 @@ import {runTests} from './fp64-test-utils-transform';
 // Failing test cases are ignored based on gpu and glslFunc, using ignoreFor field
 // ignoreFor: [{gpu: ['glslFunc-1', 'glslFunc-2']}] => ignores for `'glslFunc-1' and 'glslFunc-2` when running on `gpu`
 const commonTestCases = [
+  {a: 2, b: 2},
+  {a: 2, b: 2},
+  {a: 2, b: 2},
+  {a: 590000, b: 10000},
   {a: 3.0e-19, b: 3.3e13},
   {a: 9.9e-40, b: 1.7e3},
   {a: 1.5e-36, b: 1.7e-16},
@@ -73,10 +77,8 @@ function getTestCasesFor(glslFunc) {
   return testCases;
 }
 
-test('fp64#sum_fp64', async (t) => {
-  if (webgl2Device?.info.gpu === 'apple') {
-    t.comment('apple GPU has precision issues')
-  } else if (!webgl2Device) {
+test.only('fp64#sum_fp64', async (t) => {
+  if (!webgl2Device) {
     t.comment('requires WebGL 2');
   } else {
     const glslFunc = 'sum_fp64';

--- a/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
+++ b/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
@@ -21,17 +21,6 @@ void main(void) {
 
   result = ${operation}(a, b);
 
-  //// from fp64-arithmetic.glsl.ts ////
-
-  // vec2 s, t;
-  // s = twoSum(a.x, b.x);
-  // t = twoSum(a.y, b.y);
-  // s.y += t.x;
-  // s = quickTwoSum(s.x, s.y);
-  // s.y += t.y;
-  // s = quickTwoSum(s.x, s.y);
-  // result = s;
-
   //// from https://blog.cyclemap.link/2011-06-09-glsl-part2-emu/ ////
 
   // float t1 = a.x + b.x;
@@ -39,6 +28,11 @@ void main(void) {
   // float t2 = ((b.x - e) + (a.x - (t1 - e))) + a.y + b.y;
   // result.x = t1 + t2;
   // result.y = t2 - (result.x - t1);
+
+  //// debug ////
+
+  // result = vec2(1.2, 3.4);
+  // result = a;
 }
 `;
   return shader;
@@ -88,7 +82,7 @@ function setupFloatTest(device: Device, {glslFunc, binary = false, limit = 256, 
     vs,
     modules: [fp64],
     attributes: {a: bufferA, b: bufferB},
-    bufferLayout: [{name: 'a', format: 'float32'}, {name: 'b', format: 'float32'}],
+    bufferLayout: [{name: 'a', format: 'float32', byteStride: 8}, {name: 'b', format: 'float32', byteStride: 8}],
     feedbackBuffers: {result: bufferResult},
     varyings: ['result'],
     vertexCount: testCases.length
@@ -117,8 +111,7 @@ export async function runTests(device: Device, {glslFunc, binary = false, op, li
   const gpuResult = new Float32Array(buffer, byteOffset, byteLength / Float32Array.BYTES_PER_ELEMENT);
   for (let idx = 0; idx < testCases.length; idx++) {
     const reference64 = expected_fp64[2 * idx] + expected_fp64[2 * idx + 1];
-    const stride = 4; // 2; ???
-    const result64 = gpuResult[stride * idx] + gpuResult[stride * idx + 1];
+    const result64 = gpuResult[2 * idx] + gpuResult[2 * idx + 1];
 
     const args = binary
       ? `(${a[idx].toPrecision(2)}, ${b[idx].toPrecision(2)})`

--- a/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
+++ b/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
@@ -17,21 +17,7 @@ attribute vec2 a;
 attribute vec2 b;
 varying vec2 result;
 void main(void) {
-  //// original ////
-
   result = ${operation}(a, b);
-
-  //// from https://blog.cyclemap.link/2011-06-09-glsl-part2-emu/ ////
-
-  // float t1 = a.x + b.x;
-  // float e = t1 - a.x;
-  // float t2 = ((b.x - e) + (a.x - (t1 - e))) + a.y + b.y;
-  // result.x = t1 + t2;
-  // result.y = t2 - (result.x - t1);
-
-  //// debug ////
-
-  // result = vec2(a.x + b.x, a.y + b.y);
 }
 `;
   return shader;
@@ -81,7 +67,7 @@ function setupFloatTest(device: Device, {glslFunc, binary = false, limit = 256, 
     vs,
     modules: [fp64],
     attributes: {a: bufferA, b: bufferB},
-    bufferLayout: [{name: 'a', format: 'float32x2', byteStride: 8}, {name: 'b', format: 'float32x2', byteStride: 8}],
+    bufferLayout: [{name: 'a', format: 'float32x2'}, {name: 'b', format: 'float32x2'}],
     feedbackBuffers: {result: bufferResult},
     varyings: ['result'],
     vertexCount: testCases.length
@@ -115,7 +101,7 @@ export async function runTests(device: Device, {glslFunc, binary = false, op, li
     const args = binary
       ? `(${a[idx].toPrecision(2)}, ${b[idx].toPrecision(2)})`
       : `(${a[idx].toPrecision(2)})`;
-    const message = `${glslFunc}${args} error ${Math.abs(result64 - reference64)} < eps`;
+    const message = `${glslFunc}${args} error within tolerance`;
     const isEqual = equals(reference64, result64);
     t.ok(isEqual, message);
     if (!isEqual) {

--- a/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
+++ b/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
@@ -31,8 +31,7 @@ void main(void) {
 
   //// debug ////
 
-  // result = vec2(1.2, 3.4);
-  // result = a;
+  // result = vec2(a.x + b.x, a.y + b.y);
 }
 `;
   return shader;
@@ -42,7 +41,7 @@ function getUnaryShader(operation: string): string {
   return `\
 attribute vec2 a;
 attribute vec2 b;
-varying vec2 result;
+invariant varying vec2 result;
 void main(void) {
   result = ${operation}(a);
 }
@@ -82,7 +81,7 @@ function setupFloatTest(device: Device, {glslFunc, binary = false, limit = 256, 
     vs,
     modules: [fp64],
     attributes: {a: bufferA, b: bufferB},
-    bufferLayout: [{name: 'a', format: 'float32', byteStride: 8}, {name: 'b', format: 'float32', byteStride: 8}],
+    bufferLayout: [{name: 'a', format: 'float32x2', byteStride: 8}, {name: 'b', format: 'float32x2', byteStride: 8}],
     feedbackBuffers: {result: bufferResult},
     varyings: ['result'],
     vertexCount: testCases.length
@@ -116,11 +115,20 @@ export async function runTests(device: Device, {glslFunc, binary = false, op, li
     const args = binary
       ? `(${a[idx].toPrecision(2)}, ${b[idx].toPrecision(2)})`
       : `(${a[idx].toPrecision(2)})`;
-    const message = `${glslFunc}${args} error within tolerance`;
+    const message = `${glslFunc}${args} error ${Math.abs(result64 - reference64)} < eps`;
     const isEqual = equals(reference64, result64);
+
+    // TODO(donmccurdy): DO NOT SUBMIT.
+    // testCases[idx].expected = testCases[idx].a + testCases[idx].b;
+    // testCases[idx].equal = isEqual;
+    // testCases[idx].error = Math.abs(result64 - reference64);
+
     t.ok(isEqual, message);
     if (!isEqual) {
       t.comment(` (tested ${a_fp64.toString()}, ${b_fp64.toString()})`);
     }
   }
+
+  // TODO(donmccurdy): DO NOT SUBMIT.
+  // console.table(testCases);
 }

--- a/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
+++ b/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
@@ -7,7 +7,7 @@
 
 import {Device} from '@luma.gl/core';
 import {Transform} from '@luma.gl/engine';
-import {fp64} from '@luma.gl/shadertools';
+import {fp64, fp64arithmetic} from '@luma.gl/shadertools';
 import {equals, config} from '@math.gl/core';
 const {fp64ify} = fp64;
 
@@ -15,9 +15,30 @@ function getBinaryShader(operation: string): string {
   const shader = `\
 attribute vec2 a;
 attribute vec2 b;
-varying vec2 result;
+invariant varying vec2 result;
 void main(void) {
+  //// original ////
+
   result = ${operation}(a, b);
+
+  //// from fp64-arithmetic.glsl.ts ////
+
+  // vec2 s, t;
+  // s = twoSum(a.x, b.x);
+  // t = twoSum(a.y, b.y);
+  // s.y += t.x;
+  // s = quickTwoSum(s.x, s.y);
+  // s.y += t.y;
+  // s = quickTwoSum(s.x, s.y);
+  // result = s;
+
+  //// from https://blog.cyclemap.link/2011-06-09-glsl-part2-emu/ ////
+
+  // float t1 = a.x + b.x;
+  // float e = t1 - a.x;
+  // float t2 = ((b.x - e) + (a.x - (t1 - e))) + a.y + b.y;
+  // result.x = t1 + t2;
+  // result.y = t2 - (result.x - t1);
 }
 `;
   return shader;
@@ -60,16 +81,15 @@ function setupFloatData({limit, op, testCases}) {
 function setupFloatTest(device: Device, {glslFunc, binary = false, limit = 256, op, testCases}) {
   const {a, b, expected, a_fp64, b_fp64, expected_fp64} = setupFloatData({limit, op, testCases});
   const vs = binary ? getBinaryShader(glslFunc) : getUnaryShader(glslFunc);
+  const bufferA = device.createBuffer({data: a_fp64});
+  const bufferB = device.createBuffer({data: b_fp64});
+  const bufferResult = device.createBuffer({byteLength: a_fp64.byteLength});
   const transform = new Transform(device, {
-    sourceBuffers: {
-      a: device.createBuffer({data: a_fp64}),
-      b: device.createBuffer({data: b_fp64})
-    },
     vs,
     modules: [fp64],
-    feedbackMap: {
-      a: 'result'
-    },
+    attributes: {a: bufferA, b: bufferB},
+    bufferLayout: [{name: 'a', format: 'float32'}, {name: 'b', format: 'float32'}],
+    feedbackBuffers: {result: bufferResult},
     varyings: ['result'],
     vertexCount: testCases.length
   });
@@ -90,11 +110,15 @@ export async function runTests(device: Device, {glslFunc, binary = false, op, li
     limit,
     testCases
   });
-  transform.run({uniforms: {ONE: 1}});
-  const gpu_result = await transform.readAsync('result');
+
+  transform.run({uniforms: fp64arithmetic.getUniforms()});
+
+  const {buffer, byteOffset, byteLength} = await transform.readAsync('result');
+  const gpuResult = new Float32Array(buffer, byteOffset, byteLength / Float32Array.BYTES_PER_ELEMENT);
   for (let idx = 0; idx < testCases.length; idx++) {
     const reference64 = expected_fp64[2 * idx] + expected_fp64[2 * idx + 1];
-    const result64 = gpu_result[2 * idx] + gpu_result[2 * idx + 1];
+    const stride = 4; // 2; ???
+    const result64 = gpuResult[stride * idx] + gpuResult[stride * idx + 1];
 
     const args = binary
       ? `(${a[idx].toPrecision(2)}, ${b[idx].toPrecision(2)})`

--- a/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
+++ b/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
@@ -15,7 +15,7 @@ function getBinaryShader(operation: string): string {
   const shader = `\
 attribute vec2 a;
 attribute vec2 b;
-invariant varying vec2 result;
+varying vec2 result;
 void main(void) {
   //// original ////
 
@@ -41,7 +41,7 @@ function getUnaryShader(operation: string): string {
   return `\
 attribute vec2 a;
 attribute vec2 b;
-invariant varying vec2 result;
+varying vec2 result;
 void main(void) {
   result = ${operation}(a);
 }
@@ -117,18 +117,9 @@ export async function runTests(device: Device, {glslFunc, binary = false, op, li
       : `(${a[idx].toPrecision(2)})`;
     const message = `${glslFunc}${args} error ${Math.abs(result64 - reference64)} < eps`;
     const isEqual = equals(reference64, result64);
-
-    // TODO(donmccurdy): DO NOT SUBMIT.
-    // testCases[idx].expected = testCases[idx].a + testCases[idx].b;
-    // testCases[idx].equal = isEqual;
-    // testCases[idx].error = Math.abs(result64 - reference64);
-
     t.ok(isEqual, message);
     if (!isEqual) {
       t.comment(` (tested ${a_fp64.toString()}, ${b_fp64.toString()})`);
     }
   }
-
-  // TODO(donmccurdy): DO NOT SUBMIT.
-  // console.table(testCases);
 }


### PR DESCRIPTION
Restores FP64 arithmetic tests, which previously bailed out with `TransformFeedback.isSupported()` hard-coded to `false` during v9 API development. With TransformFeedback working, and a minimum Transform implementation in #1879, we can run the FP64 tests again and they'll pass in CI (Linux, Vulkan, unknown GPU).

Many tests still fail on Apple GPUs, and the `invariant` workaround unfortunately hasn't solved that issue, on my machine at least. For now I've enabled FP64 tests for Apple devices on the cases that do pass.