### PR TITLE
fix(shadertools): Add 'invariant' to fp64 varyings, partially fix issue on Apple GPUs

### DIFF
--- a/modules/shadertools/test/modules-webgl1/fp64/fp64-arithmetic-transform.spec.ts
+++ b/modules/shadertools/test/modules-webgl1/fp64/fp64-arithmetic-transform.spec.ts
@@ -10,47 +10,47 @@ import {runTests} from './fp64-test-utils-transform';
 // Many of these tests fail on Apple GPUs with very large margins, see https://github.com/visgl/luma.gl/issues/1764.
 const commonTestCases = [
   {a: 2, b: 2},
-  {a: 0.1, b: 0.1, ignoreFor: {apple: ['sum_fp64', 'mul_fp64', 'div_fp64']}},
-  {a: 3.0e-19, b: 3.3e13, ignoreFor: {apple: ['sum_fp64']}},
+  {a: 0.1, b: 0.1},
+  {a: 3.0e-19, b: 3.3e13},
   {a: 9.9e-40, b: 1.7e3},
   {a: 1.5e-36, b: 1.7e-16},
   {a: 9.4e-26, b: 51},
-  {a: 6.7e-20, b: 0.93, ignoreFor: {apple: ['sum_fp64']}},
+  {a: 6.7e-20, b: 0.93},
 
   // mul_fp64: Large numbers once multipled, can't be represented by 32 bit precision and Math.fround() returns NAN
   // sqrt_fp64: Fail on INTEL with margin 3.906051071870294e-12
-  {a: 2.4e3, b: 5.9e31, ignoreFor: {all: ['mul_fp64'], intel: ['sqrt_fp64'], apple: ['sum_fp64']}},
+  {a: 2.4e3, b: 5.9e31, ignoreFor: {all: ['mul_fp64'], intel: ['sqrt_fp64']}},
 
   // div_fp64 fails on INTEL with margin 1.7318642528355118e-12
   // sqrt_fp64 fails on INTEL with margin 1.5518878351528786e-12
-  {a: 1.4e9, b: 6.3e5, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64'], apple: ['mul_fp64', 'div_fp64']}},
+  {a: 1.4e9, b: 6.3e5, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64']}},
 
   // div fails on INTEL with margin 1.7886288892678105e-14
   // sqrt fails on INTEL with margin 2.5362810256331708e-12
-  {a: 3.0e9, b: 4.3e-23, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64'], apple: ['div_fp64']}},
+  {a: 3.0e9, b: 4.3e-23, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64']}},
 
   // div fail on INTEL with margin 1.137354350370519e-12
-  {a: 1.7e-19, b: 2.7e-27, ignoreFor: {intel: ['div_fp64'], apple: ['div_fp64']}},
+  {a: 1.7e-19, b: 2.7e-27, ignoreFor: {intel: ['div_fp64']}},
 
   // div_fp64 fails on INTEL with margin 2.7291999999999997e-12
   // sqrt_fp64 fails on INTEL with margin 3.501857471494295e-12
-  {a: 0.3, b: 3.2e-16, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64'], apple: ['div_fp64']}},
+  {a: 0.3, b: 3.2e-16, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64']}},
 
   // mul_fp64 : fails since result can't be represented by 32 bit floats
   // div_fp64 : fails on INTEL with margin 1.9999999999999994e-15
   // sqrt_fp64 : fails on INTEL with margin 1.832115697751484e-12
-  {a: 4.1e30, b: 8.2e15, ignoreFor: {all: ['mul_fp64'], intel: ['div_fp64', 'sqrt_fp64'], apple: ['div_fp64']}},
+  {a: 4.1e30, b: 8.2e15, ignoreFor: {all: ['mul_fp64'], intel: ['div_fp64', 'sqrt_fp64']}},
 
   // Fails on INTEL, margin 3.752606081210107e-12
-  {a: 6.2e3, b: 6.3e10, ignoreFor: {intel: ['sqrt_fp64'], apple: ['sum_fp64', 'mul_fp64']}},
+  {a: 6.2e3, b: 6.3e10, ignoreFor: {intel: ['sqrt_fp64']}},
   // Fails on INTEL, margin 3.872578286363912e-13
-  {a: 2.5e2, b: 5.1e-21, ignoreFor: {intel: ['sqrt_fp64'], apple: ['div_fp64']}},
+  {a: 2.5e2, b: 5.1e-21, ignoreFor: {intel: ['sqrt_fp64']}},
   // Fails on INTEL, margin 1.5332142001740705e-12
-  {a: 96, b: 1.7e4, ignoreFor: {intel: ['sqrt_fp64'], apple: ['div_fp64']}},
+  {a: 96, b: 1.7e4, ignoreFor: {intel: ['sqrt_fp64']}},
   // // Fail on INTEL, margin 1.593162047558726e-12
-  {a: 0.27, b: 2.3e16, ignoreFor: {intel: ['sqrt_fp64'], apple: ['sum_fp64', 'mul_fp64']}},
+  {a: 0.27, b: 2.3e16, ignoreFor: {intel: ['sqrt_fp64']}},
   // Fails on INTEL, margin 1.014956357028767e-12
-  {a: 18, b: 9.1e-9, ignoreFor: {intel: ['sqrt_fp64'], apple: ['div_fp64']}}
+  {a: 18, b: 9.1e-9, ignoreFor: {intel: ['sqrt_fp64']}}
 ];
 
 // Filter all tests cases based on current gpu and glsFunc

--- a/modules/shadertools/test/modules-webgl1/fp64/fp64-arithmetic-transform.spec.ts
+++ b/modules/shadertools/test/modules-webgl1/fp64/fp64-arithmetic-transform.spec.ts
@@ -10,47 +10,47 @@ import {runTests} from './fp64-test-utils-transform';
 // Many of these tests fail on Apple GPUs with very large margins, see https://github.com/visgl/luma.gl/issues/1764.
 const commonTestCases = [
   {a: 2, b: 2},
-  {a: 0.1, b: 0.1},
-  {a: 3.0e-19, b: 3.3e13},
+  {a: 0.1, b: 0.1, ignoreFor: {apple: ['sum_fp64', 'mul_fp64', 'div_fp64']}},
+  {a: 3.0e-19, b: 3.3e13, ignoreFor: {apple: ['sum_fp64']}},
   {a: 9.9e-40, b: 1.7e3},
   {a: 1.5e-36, b: 1.7e-16},
   {a: 9.4e-26, b: 51},
-  {a: 6.7e-20, b: 0.93},
+  {a: 6.7e-20, b: 0.93, ignoreFor: {apple: ['sum_fp64']}},
 
   // mul_fp64: Large numbers once multipled, can't be represented by 32 bit precision and Math.fround() returns NAN
   // sqrt_fp64: Fail on INTEL with margin 3.906051071870294e-12
-  {a: 2.4e3, b: 5.9e31, ignoreFor: {all: ['mul_fp64'], intel: ['sqrt_fp64']}},
+  {a: 2.4e3, b: 5.9e31, ignoreFor: {all: ['mul_fp64'], intel: ['sqrt_fp64'], apple: ['sum_fp64']}},
 
   // div_fp64 fails on INTEL with margin 1.7318642528355118e-12
   // sqrt_fp64 fails on INTEL with margin 1.5518878351528786e-12
-  {a: 1.4e9, b: 6.3e5, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64']}},
+  {a: 1.4e9, b: 6.3e5, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64'], apple: ['mul_fp64', 'div_fp64']}},
 
   // div fails on INTEL with margin 1.7886288892678105e-14
   // sqrt fails on INTEL with margin 2.5362810256331708e-12
-  {a: 3.0e9, b: 4.3e-23, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64']}},
+  {a: 3.0e9, b: 4.3e-23, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64'], apple: ['div_fp64']}},
 
   // div fail on INTEL with margin 1.137354350370519e-12
-  {a: 1.7e-19, b: 2.7e-27, ignoreFor: {intel: ['div_fp64']}},
+  {a: 1.7e-19, b: 2.7e-27, ignoreFor: {intel: ['div_fp64'], apple: ['div_fp64']}},
 
   // div_fp64 fails on INTEL with margin 2.7291999999999997e-12
   // sqrt_fp64 fails on INTEL with margin 3.501857471494295e-12
-  {a: 0.3, b: 3.2e-16, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64']}},
+  {a: 0.3, b: 3.2e-16, ignoreFor: {intel: ['div_fp64', 'sqrt_fp64'], apple: ['div_fp64']}},
 
   // mul_fp64 : fails since result can't be represented by 32 bit floats
   // div_fp64 : fails on INTEL with margin 1.9999999999999994e-15
   // sqrt_fp64 : fails on INTEL with margin 1.832115697751484e-12
-  {a: 4.1e30, b: 8.2e15, ignoreFor: {all: ['mul_fp64'], intel: ['div_fp64', 'sqrt_fp64']}},
+  {a: 4.1e30, b: 8.2e15, ignoreFor: {all: ['mul_fp64'], intel: ['div_fp64', 'sqrt_fp64'], apple: ['div_fp64']}},
 
   // Fails on INTEL, margin 3.752606081210107e-12
-  {a: 6.2e3, b: 6.3e10, ignoreFor: {intel: ['sqrt_fp64']}},
+  {a: 6.2e3, b: 6.3e10, ignoreFor: {intel: ['sqrt_fp64'], apple: ['sum_fp64', 'mul_fp64']}},
   // Fails on INTEL, margin 3.872578286363912e-13
-  {a: 2.5e2, b: 5.1e-21, ignoreFor: {intel: ['sqrt_fp64']}},
+  {a: 2.5e2, b: 5.1e-21, ignoreFor: {intel: ['sqrt_fp64'], apple: ['div_fp64']}},
   // Fails on INTEL, margin 1.5332142001740705e-12
-  {a: 96, b: 1.7e4, ignoreFor: {intel: ['sqrt_fp64']}},
+  {a: 96, b: 1.7e4, ignoreFor: {intel: ['sqrt_fp64'], apple: ['div_fp64']}},
   // // Fail on INTEL, margin 1.593162047558726e-12
-  {a: 0.27, b: 2.3e16, ignoreFor: {intel: ['sqrt_fp64']}},
+  {a: 0.27, b: 2.3e16, ignoreFor: {intel: ['sqrt_fp64'], apple: ['sum_fp64', 'mul_fp64']}},
   // Fails on INTEL, margin 1.014956357028767e-12
-  {a: 18, b: 9.1e-9, ignoreFor: {intel: ['sqrt_fp64']}}
+  {a: 18, b: 9.1e-9, ignoreFor: {intel: ['sqrt_fp64'], apple: ['div_fp64']}}
 ];
 
 // Filter all tests cases based on current gpu and glsFunc

--- a/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
+++ b/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
@@ -15,7 +15,7 @@ function getBinaryShader(operation: string): string {
   const shader = `\
 attribute vec2 a;
 attribute vec2 b;
-varying vec2 result;
+invariant varying vec2 result;
 void main(void) {
   result = ${operation}(a, b);
 }
@@ -27,7 +27,7 @@ function getUnaryShader(operation: string): string {
   return `\
 attribute vec2 a;
 attribute vec2 b;
-varying vec2 result;
+invariant varying vec2 result;
 void main(void) {
   result = ${operation}(a);
 }

--- a/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
+++ b/modules/shadertools/test/modules-webgl1/fp64/fp64-test-utils-transform.ts
@@ -11,6 +11,11 @@ import {fp64, fp64arithmetic} from '@luma.gl/shadertools';
 import {equals, config} from '@math.gl/core';
 const {fp64ify} = fp64;
 
+// Use 'invariant' specifier to work around some issues on Apple GPUs. The
+// specifier may or may not have an effect, depending on the browser and the
+// ANGLE backend, but it's an improvement when it's supported.
+// See: https://github.com/visgl/luma.gl/issues/1764
+
 function getBinaryShader(operation: string): string {
   const shader = `\
 attribute vec2 a;


### PR DESCRIPTION
Related:

- #1764 

On my laptop (Apple M2 Pro), adding the `invariant` specifier fixes these tests in Chrome, _if and only if_ I select the "OpenGL" ANGLE backend. That result doesn't make much sense to me, especially given the last response from Kimmo Kinnunen at https://bugs.webkit.org/show_bug.cgi?id=237434:

> Chrome is sometimes using OpenGL ES "backend" sometimes, sometimes Metal backend. The invariant fix is implemented only for Metal. Firefox is using OpenGL ES.
> 
> The OpenGL ES drivers do not have the invariance feature and have different kinds of optimizations. Thus the solution does not work on these implementations, unfortunately.
> 
> The better fix could be to ensure the values of the intermediate computations stay within the 32-bit float value domain.

I would have expected `invariant` to work with the Metal backend selected, and not with the OpenGL backend selected, but I see the opposite. I'll follow up on the Webkit thread about that.


In any case, there seems to be no harm from adding the `invariant` specifier and it may fix some cases. But perhaps we should keep the `ignoreFor` exceptions as-is, since not all contributors to lumagl will be opted-in to the OpenGL backend?