### PR TITLE
feat(webgl) Allow passing null to setIndexBuffer

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -295,9 +295,7 @@ export class Model {
     // TODO - delete previous geometry?
     this.vertexCount = gpuGeometry.vertexCount;
     this.setAttributes(gpuGeometry.attributes);
-    if (gpuGeometry.indices) {
-      this.setIndexBuffer(gpuGeometry.indices);
-    }
+    this.setIndexBuffer(gpuGeometry.indices);
   }
 
   /**

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -295,7 +295,9 @@ export class Model {
     // TODO - delete previous geometry?
     this.vertexCount = gpuGeometry.vertexCount;
     this.setAttributes(gpuGeometry.attributes);
-    this.setIndexBuffer(gpuGeometry.indices);
+    if (gpuGeometry.indices) {
+      this.setIndexBuffer(gpuGeometry.indices);
+    }
   }
 
   /**

--- a/modules/webgl/src/adapter/resources/webgl-vertex-array.ts
+++ b/modules/webgl/src/adapter/resources/webgl-vertex-array.ts
@@ -61,6 +61,7 @@ export class WEBGLVertexArray extends VertexArray {
    */
   setIndexBuffer(indexBuffer: Buffer | null): void {
     const buffer = indexBuffer as WEBGLBuffer;
+    // Explicitly allow `null` to support clearing the index buffer
     if (buffer && buffer.glTarget !== GL.ELEMENT_ARRAY_BUFFER) {
       throw new Error('Use .setBuffer()');
     }

--- a/modules/webgl/src/adapter/resources/webgl-vertex-array.ts
+++ b/modules/webgl/src/adapter/resources/webgl-vertex-array.ts
@@ -54,14 +54,14 @@ export class WEBGLVertexArray extends VertexArray {
   }
 
   /**
-  // Set (bind) an elements buffer, for indexed rendering.
-  // Must be a Buffer bound to GL.ELEMENT_ARRAY_BUFFER. Constants not supported
+  // Set (bind/unbind) an elements buffer, for indexed rendering.
+  // Must be a Buffer bound to GL.ELEMENT_ARRAY_BUFFER or null. Constants not supported
    * 
    * @param elementBuffer 
    */
   setIndexBuffer(indexBuffer: Buffer | null): void {
     const buffer = indexBuffer as WEBGLBuffer;
-    if (buffer?.glTarget !== GL.ELEMENT_ARRAY_BUFFER) {
+    if (buffer && buffer.glTarget !== GL.ELEMENT_ARRAY_BUFFER) {
       throw new Error('Use .setBuffer()');
     }
     // In WebGL The GL.ELEMENT_ARRAY_BUFFER_BINDING is stored on the VertexArrayObject


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

Model creation was crashing when passed non-indexed `geometry` prop, e.g. https://github.com/visgl/deck.gl/blob/master/examples/website/orthographic/app.tsx#L24-L29

<!-- For all the PRs -->
#### Change List
- Allow passing `null` to `setIndexBuffer` in `WEBGLVertexArray`