### PR TITLE
chore(dev): Remove dev-modules/ from yarn workspace

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -22,7 +22,6 @@ const plugins = [
 // on it. This plugin uses LOCAL `@luma.gl/constants`, and will fail without
 // it, so delay using the plugin until reaching a package depending on constants.
 if (pkg.dependencies && '@luma.gl/constants' in pkg.dependencies) {
-  // TODO(v9): CI builds are flaky with this enabled, need to investigate cause.
   // plugins.push('./dev-modules/babel-plugin-remove-glsl-comments/index.js');
   plugins.push('babel-plugin-inline-webgl-constants');
 }

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -24,7 +24,7 @@ const plugins = [
 if (pkg.dependencies && '@luma.gl/constants' in pkg.dependencies) {
   // TODO(v9): CI builds are flaky with this enabled, need to investigate cause.
   // plugins.push('./dev-modules/babel-plugin-remove-glsl-comments/index.js');
-  // plugins.push('babel-plugin-inline-webgl-constants');
+  plugins.push('babel-plugin-inline-webgl-constants');
 }
 
 module.exports = getBabelConfig({

--- a/dev-modules/babel-plugin-inline-webgl-constants/package.json
+++ b/dev-modules/babel-plugin-inline-webgl-constants/package.json
@@ -1,7 +1,6 @@
 {
   "name": "babel-plugin-inline-webgl-constants",
-  "private": true,
-  "version": "9.0.0-alpha.47",
+  "version": "2.0.0-alpha.1",
   "description": "Babel plugin for replacing long gl constants with the shorter corresponding numbers",
   "type": "module",
   "license": "MIT",
@@ -26,6 +25,5 @@
   },
   "dependencies": {
     "@luma.gl/constants": "9.0.0-alpha.47"
-  },
-  "gitHead": "c636c34b8f1581eed163e94543a8eb1f4382ba8e"
+  }
 }

--- a/dev-modules/babel-plugin-remove-glsl-comments/package.json
+++ b/dev-modules/babel-plugin-remove-glsl-comments/package.json
@@ -1,7 +1,6 @@
 {
   "name": "babel-plugin-remove-glsl-comments",
-  "private": true,
-  "version": "9.0.0-alpha.47",
+  "version": "1.0.0",
   "description": "Babel plugin for removing glsl comments",
   "license": "MIT",
   "repository": {
@@ -16,6 +15,5 @@
   "main": "index.js",
   "dependencies": {
     "minimatch": "^3.0.0"
-  },
-  "gitHead": "c636c34b8f1581eed163e94543a8eb1f4382ba8e"
+  }
 }

--- a/dev-modules/eslint-plugin-luma-gl-custom-rules/package.json
+++ b/dev-modules/eslint-plugin-luma-gl-custom-rules/package.json
@@ -1,7 +1,5 @@
 {
   "name": "eslint-plugin-luma-gl-custom-rules",
-  "private": "true",
-  "version": "9.0.0-alpha.47",
-  "main": "index.cjs",
-  "gitHead": "c636c34b8f1581eed163e94543a8eb1f4382ba8e"
+  "version": "9.0.0-alpha.17",
+  "main": "index.cjs"
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   ],
   "workspaces": [
     "examples/*/*",
-    "dev-modules/*",
     "modules/*"
   ],
   "browser": {


### PR DESCRIPTION
Previously `babel-plugin-inline-webgl-constants` was disabled because it failed inconsistently in CI. There's some tricky timing required in building the entire workspace — we ideally want to build `@luma.gl/constants` without the plugin, then build `babel-plugin-inline-webgl-constants`, then build everything else using the plugin.

Theoretically Lerna's task execution can order these steps correctly, but I believe ocular-dev-tools does not use Lerna for that, and frankly it might be trickier than expected in Lerna too. It might be best just to remove `dev-modules/*` from the Yarn workspace? I think this was suggested by @ibgreen in another issue or in Slack, as well.

Changes:

- `dev-modules/*` should _not_ be linked automatically, and our builds will use packages from npm unless explicitly imported from the local folder
- `dev-modules/*` should _not_ be versioned or published alongside the other packages, but can be versioned and published independently
- `dev-modules/*` no longer set `"private": true`, which (I assume?) was a workaround to prevent the publish script from including them previously
- Reverted the `version` field in each package to its last real release
- Restored `babel-plugin-inline-webgl-constants` in the build script

Questions:

- [ ] The only previously-published versions of [`eslint-plugin-luma-gl-custom-rules`](https://www.npmjs.com/package/eslint-plugin-luma-gl-custom-rules?activeTab=versions) are from the v9 alpha. I'm not sure if these were intentional, or if this was intended to be a local-only package?

Alternatives:

- Move these plugins into separate repositories
- Have the plugins not be 'packages' but just files that we import from the relevant config (unsure if this solves anything or not...)
- Don't strip GL constants, or don't depend on `@luma.gl/constants` in order to do so.

Related:

- https://github.com/visgl/luma.gl/pull/1870
- https://github.com/visgl/luma.gl/pull/1867
- https://github.com/visgl/luma.gl/pull/1859
- https://github.com/visgl/luma.gl/issues/1501