### PR TITLE
refactor(engine): AnimationLoop start

### DIFF
--- a/modules/engine/src/animation-loop/animation-loop.ts
+++ b/modules/engine/src/animation-loop/animation-loop.ts
@@ -148,10 +148,6 @@ export class AnimationLoop {
     this._running = true;
 
     try {
-      // check that we haven't been stopped
-      if (!this._running) {
-        return null;
-      }
 
       let appContext;
       if (!this._initialized) {


### PR DESCRIPTION
Remove the redundant `_running` check in `AnimationLoop.start`