### PR TITLE
chore(lint): Fix lint errors

### DIFF
--- a/modules/core-tests/test/adapter/resources/framebuffer.spec.ts
+++ b/modules/core-tests/test/adapter/resources/framebuffer.spec.ts
@@ -66,7 +66,7 @@ const TEST_CASES = [
 ];
 
 test('WebGLDevice.createFramebuffer()', async (t) => {
-  for (const testDevice of await getWebGLTestDevices()) {
+  for (const testDevice of getWebGLTestDevices()) {
     t.throws(() => testDevice.createFramebuffer({}), 'Framebuffer without attachment fails');
 
     const framebuffer = testDevice.createFramebuffer({
@@ -85,7 +85,7 @@ test('WebGLDevice.createFramebuffer()', async (t) => {
 });
 
 test('WebGLFramebuffer create and resize attachments', async (t) => {
-  for (const testDevice of await getWebGLTestDevices()) {
+  for (const testDevice of getWebGLTestDevices()) {
     for (const tc of TEST_CASES) {
       let props;
 

--- a/modules/core/src/adapter/canvas-context.ts
+++ b/modules/core/src/adapter/canvas-context.ts
@@ -348,7 +348,7 @@ function getCanvasFromDOM(canvasId: string): HTMLCanvasElement {
     throw new Error(`Accessing '${canvasId}' before page was loaded`);
   }
   if (!(canvas instanceof HTMLCanvasElement)) {
-    throw new Error(`'${canvas}' is not a canvas element`);
+    throw new Error('Object is not a canvas element');
   }
   return canvas;
 }

--- a/modules/core/src/lib/uniforms/uniform-buffer-layout.ts
+++ b/modules/core/src/lib/uniforms/uniform-buffer-layout.ts
@@ -66,6 +66,7 @@ export class UniformBufferLayout {
       const uniformLayout = this.layout[name];
       if (!uniformLayout) {
         log.warn(`Supplied uniform value ${name} not present in uniform block layout`)();
+        // eslint-disable-next-line no-continue
         continue;
       }
 
@@ -74,6 +75,7 @@ export class UniformBufferLayout {
       if (size === 1) {
         if (typeof value !== 'number' && typeof value !== 'boolean') {
           log.warn(`Supplied value for single component uniform ${name} is not a number: ${value}`)();
+          // eslint-disable-next-line no-continue
           continue;
         }
         // single value -> just set it
@@ -82,6 +84,7 @@ export class UniformBufferLayout {
         const numericArray = isNumberArray(value);
         if (!numericArray) {
           log.warn(`Supplied value for multi component / array uniform ${name} is not a numeric array: ${value}`)();
+          // eslint-disable-next-line no-continue
           continue;
         }
         // vector/matrix -> copy the supplied (typed) array, starting from offset

--- a/modules/core/src/lib/utils/load-file.ts
+++ b/modules/core/src/lib/utils/load-file.ts
@@ -83,7 +83,7 @@ export async function loadScript(scriptUrl: string, scriptId?: string): Promise<
 
   return new Promise((resolve, reject) => {
     script.onload = resolve;
-    script.onerror = (error) => reject(new Error(`Unable to load script '${scriptUrl}': ${error}`));
+    script.onerror = (error) => reject(new Error(`Unable to load script '${scriptUrl}': ${error as string}`));
     head.appendChild(script);
   });
 }

--- a/modules/engine/src/animation-loop/animation-loop.ts
+++ b/modules/engine/src/animation-loop/animation-loop.ts
@@ -300,7 +300,7 @@ export class AnimationLoop {
   }
 
   _cancelAnimationFrame() {
-    if (this._animationFrameId == null) {
+    if (this._animationFrameId === null) {
       return;
     }
 

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -223,6 +223,7 @@ export class Model {
       this.setUniforms(props.uniforms);
     }
     if (props.moduleSettings) {
+      // eslint-disable-next-line no-console
       console.warn('Model.props.moduleSettings is deprecated. Use Model.shaderInputs.setProps()');
       this.updateModuleSettings(props.moduleSettings);
     }
@@ -386,6 +387,7 @@ export class Model {
    * @deprecated Updates shader module settings (which results in uniforms being set)
    */
   updateModuleSettings(props: Record<string, any>): void {
+    // eslint-disable-next-line no-console
     console.warn('Model.updateModuleSettings is deprecated. Use Model.shaderInputs.setProps()');
     const {bindings, uniforms} = splitUniformsAndBindings(this._getModuleUniforms(props));
     Object.assign(this.bindings, bindings);

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -90,11 +90,11 @@ export class ShaderInputs<
       const module = this.modules[moduleName];
 
       const uniforms = module.getUniforms?.(moduleProps, this.moduleUniforms[moduleName]);
-      console.error(uniforms)
+      // console.error(uniforms)
       this.moduleUniforms[moduleName] = uniforms || moduleProps as any;
       // this.moduleUniformsChanged ||= moduleName;
 
-      console.log(`setProps(${String(moduleName)}`, moduleName, this.moduleUniforms[moduleName])
+      // console.log(`setProps(${String(moduleName)}`, moduleName, this.moduleUniforms[moduleName])
 
       // TODO - Get Module bindings
       // const bindings = module.getBindings?.(moduleProps);

--- a/modules/engine/test/shader-inputs.spec.ts
+++ b/modules/engine/test/shader-inputs.spec.ts
@@ -19,8 +19,6 @@ test('ShaderInputs#picking', (t) => {
   shaderInputs.setProps({picking: {highlightedObjectColor: [255, 255, 255]}});
   t.ok(shaderInputs, 'typed access');
 
-  shaderInputs
-
   t.end();
 });
 

--- a/modules/shadertools/src/lib/shader-module/shader-module-instance.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module-instance.ts
@@ -34,7 +34,7 @@ export class ShaderModuleInstance {
 
       assert(
         typeof module !== 'string',
-        `Shader module use by name is deprecated. Import shader module '${module.name}' and use it directly.`
+        `Shader module use by name is deprecated. Import shader module '${JSON.stringify(module)}' and use it directly.`
       );
       if (!module.name) {
         // eslint-disable-next-line no-console

--- a/modules/shadertools/src/lib/shader-module/shader-module-instance.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module-instance.ts
@@ -34,9 +34,10 @@ export class ShaderModuleInstance {
 
       assert(
         typeof module !== 'string',
-        `Shader module use by name is deprecated. Import shader module '${module}' and use it directly.`
+        `Shader module use by name is deprecated. Import shader module '${module.name}' and use it directly.`
       );
       if (!module.name) {
+        // eslint-disable-next-line no-console
         console.warn('shader module has no name');
         module.name = `shader-module-${index++}`;
       }

--- a/modules/shadertools/src/modules/lighting/lights/lighting-uniforms.ts
+++ b/modules/shadertools/src/modules/lighting/lights/lighting-uniforms.ts
@@ -139,7 +139,6 @@ function getUniforms(props?: LightingProps, prevUniforms: Partial<LightingUnifor
     uniforms.enabled = props.enabled ? 1 : 0;
   }
 
-  console.error(uniforms)
   return uniforms;
 }
 

--- a/modules/webgl/src/adapter/converters/sampler-parameters.ts
+++ b/modules/webgl/src/adapter/converters/sampler-parameters.ts
@@ -29,7 +29,10 @@ export function convertSamplerParametersToWebGL(props: SamplerParameters): GLSam
   }
   if (props.minFilter || props.mipmapFilter) {
     // TODO - arbitrary choice of linear?
-    params[GL.TEXTURE_MIN_FILTER] = convertMinFilterMode(props.minFilter || 'linear', props.mipmapFilter);
+    params[GL.TEXTURE_MIN_FILTER] = convertMinFilterMode(
+      props.minFilter || 'linear',
+      props.mipmapFilter
+    );
   }
   if (props.lodMinClamp !== undefined) {
     params[GL.TEXTURE_MIN_LOD] = props.lodMinClamp;
@@ -54,30 +57,40 @@ export function convertSamplerParametersToWebGL(props: SamplerParameters): GLSam
 /** Convert address more */
 function convertAddressMode(addressMode: 'clamp-to-edge' | 'repeat' | 'mirror-repeat'): GL {
   switch (addressMode) {
-    case 'clamp-to-edge': return GL.CLAMP_TO_EDGE;
-    case 'repeat': return GL.REPEAT;
-    case 'mirror-repeat': return GL.MIRRORED_REPEAT;
+    case 'clamp-to-edge':
+      return GL.CLAMP_TO_EDGE;
+    case 'repeat':
+      return GL.REPEAT;
+    case 'mirror-repeat':
+      return GL.MIRRORED_REPEAT;
   }
 }
 
 function convertMaxFilterMode(maxFilter: 'nearest' | 'linear'): GL {
   switch (maxFilter) {
-    case 'nearest': return GL.NEAREST;
-    case 'linear': return GL.LINEAR;
+    case 'nearest':
+      return GL.NEAREST;
+    case 'linear':
+      return GL.LINEAR;
   }
 }
 
-/** 
- * WebGPU has separate min filter and mipmap filter, 
+/**
+ * WebGPU has separate min filter and mipmap filter,
  * WebGL is combined and effectively offers 6 options
  */
-function convertMinFilterMode(minFilter: 'nearest' | 'linear', mipmapFilter?: 'nearest' | 'linear'): GL {
+function convertMinFilterMode(
+  minFilter: 'nearest' | 'linear',
+  mipmapFilter?: 'nearest' | 'linear'
+): GL {
   if (!mipmapFilter) {
     return convertMaxFilterMode(minFilter);
   }
   switch (minFilter) {
-    case 'nearest': return mipmapFilter === 'nearest' ? GL.NEAREST_MIPMAP_NEAREST : GL.NEAREST_MIPMAP_LINEAR;
-    case 'linear': return mipmapFilter === 'nearest' ? GL.LINEAR_MIPMAP_NEAREST : GL.LINEAR_MIPMAP_LINEAR;
+    case 'nearest':
+      return mipmapFilter === 'nearest' ? GL.NEAREST_MIPMAP_NEAREST : GL.NEAREST_MIPMAP_LINEAR;
+    case 'linear':
+      return mipmapFilter === 'nearest' ? GL.LINEAR_MIPMAP_NEAREST : GL.LINEAR_MIPMAP_LINEAR;
   }
 }
 
@@ -115,7 +128,10 @@ export function convertToSamplerParameters(params: GLSamplerParameters): Sampler
     props.lodMaxClamp = params[GL.TEXTURE_MAX_LOD];
   }
   if (params[GL.TEXTURE_COMPARE_MODE]) {
-    props.type = params[GL.TEXTURE_COMPARE_MODE]  === GL.COMPARE_REF_TO_TEXTURE ? 'comparison-sampler' : 'color-sampler';
+    props.type =
+      params[GL.TEXTURE_COMPARE_MODE] === GL.COMPARE_REF_TO_TEXTURE
+        ? 'comparison-sampler'
+        : 'color-sampler';
   }
   if (params[GL.TEXTURE_COMPARE_FUNC]) {
     props.compare = convertToCompareFunction('compare', params[GL.TEXTURE_COMPARE_FUNC]);
@@ -128,54 +144,87 @@ export function convertToSamplerParameters(params: GLSamplerParameters): Sampler
 }
 
 /** Convert address more */
-function convertToAddressMode(addressMode: number): 'clamp-to-edge' | 'repeat' | 'mirror-repeat' {
+function convertToAddressMode(
+  addressMode: GL.CLAMP_TO_EDGE | GL.REPEAT | GL.MIRRORED_REPEAT
+): 'clamp-to-edge' | 'repeat' | 'mirror-repeat' {
   switch (addressMode) {
-    case GL.CLAMP_TO_EDGE: return 'clamp-to-edge';
-    case GL.REPEAT: return 'repeat';
-    case GL.MIRRORED_REPEAT: return 'mirror-repeat';
-    default: throw new Error('address');
+    case GL.CLAMP_TO_EDGE:
+      return 'clamp-to-edge';
+    case GL.REPEAT:
+      return 'repeat';
+    case GL.MIRRORED_REPEAT:
+      return 'mirror-repeat';
+    default:
+      throw new Error('address');
   }
 }
 
-function convertToMaxFilterMode(filterMode: number): 'nearest' | 'linear' {
+function convertToMaxFilterMode(filterMode: GL.NEAREST | GL.LINEAR): 'nearest' | 'linear' {
   switch (filterMode) {
-    case GL.NEAREST: return 'nearest';
-    case GL.LINEAR: return 'linear';
-    default: throw new Error('maxfilter');
+    case GL.NEAREST:
+      return 'nearest';
+    case GL.LINEAR:
+      return 'linear';
+    default:
+      throw new Error('maxfilter');
   }
 }
+
+type GLMinFilter =
+  | GL.NEAREST
+  | GL.LINEAR
+  | GL.NEAREST_MIPMAP_NEAREST
+  | GL.LINEAR_MIPMAP_NEAREST
+  | GL.NEAREST_MIPMAP_LINEAR
+  | GL.LINEAR_MIPMAP_LINEAR;
 
 /** WebGPU has separate min filter and mipmap filter, WebGL is combined */
-function convertToMinFilterMode(filterMode: number): 'nearest' | 'linear' {
+function convertToMinFilterMode(filterMode: GLMinFilter): 'nearest' | 'linear' {
   switch (filterMode) {
     // TODO is this correct?
-    case GL.NEAREST: return 'nearest';
-    case GL.LINEAR: return 'linear';
-    case GL.NEAREST_MIPMAP_NEAREST: return 'nearest';
-    case GL.LINEAR_MIPMAP_NEAREST: return 'linear';
-    case GL.NEAREST_MIPMAP_LINEAR: return 'nearest';
-    case GL.LINEAR_MIPMAP_LINEAR: return 'linear';
-    default: throw new Error('minfilter');
+    case GL.NEAREST:
+      return 'nearest';
+    case GL.LINEAR:
+      return 'linear';
+    case GL.NEAREST_MIPMAP_NEAREST:
+      return 'nearest';
+    case GL.LINEAR_MIPMAP_NEAREST:
+      return 'linear';
+    case GL.NEAREST_MIPMAP_LINEAR:
+      return 'nearest';
+    case GL.LINEAR_MIPMAP_LINEAR:
+      return 'linear';
+    default:
+      throw new Error('minfilter');
   }
 }
 
-function convertToMipmapFilterMode(filterMode: number): 'nearest' | 'linear' {
+function convertToMipmapFilterMode(filterMode: GLMinFilter): 'nearest' | 'linear' {
   switch (filterMode) {
     // TODO is this correct?
-    case GL.NEAREST: return 'nearest';
-    case GL.LINEAR: return 'linear';
-    case GL.NEAREST_MIPMAP_NEAREST: return 'nearest';
-    case GL.LINEAR_MIPMAP_NEAREST: return 'nearest';
-    case GL.NEAREST_MIPMAP_LINEAR: return 'linear';
-    case GL.LINEAR_MIPMAP_LINEAR: return 'linear';
-    default: throw new Error('mipmap');
+    case GL.NEAREST:
+      return 'nearest';
+    case GL.LINEAR:
+      return 'linear';
+    case GL.NEAREST_MIPMAP_NEAREST:
+      return 'nearest';
+    case GL.LINEAR_MIPMAP_NEAREST:
+      return 'nearest';
+    case GL.NEAREST_MIPMAP_LINEAR:
+      return 'linear';
+    case GL.LINEAR_MIPMAP_LINEAR:
+      return 'linear';
+    default:
+      throw new Error('mipmap');
   }
 }
 
 /**
  * Override sampler settings that are not supported by Non-Power-of-Two textures in WebGL1.
-*/
-export function updateSamplerParametersForNPOT(parameters: GLSamplerParameters): GLSamplerParameters {
+ */
+export function updateSamplerParametersForNPOT(
+  parameters: GLSamplerParameters
+): GLSamplerParameters {
   const newParameters = {...parameters};
   if (parameters[GL.TEXTURE_MIN_FILTER] !== GL.NEAREST) {
     // log.warn(`texture: ${this} is Non-Power-Of-Two, forcing TEXTURE_MIN_FILTER to LINEAR`)();

--- a/modules/webgl/src/adapter/converters/texture-formats.ts
+++ b/modules/webgl/src/adapter/converters/texture-formats.ts
@@ -660,7 +660,7 @@ export function _checkFloat32ColorAttachment(
     framebuffer = gl.createFramebuffer();
     gl.bindFramebuffer(GL.FRAMEBUFFER, framebuffer);
     gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.TEXTURE_2D, texture, 0);
-    const status = gl.checkFramebufferStatus(GL.FRAMEBUFFER) === GL.FRAMEBUFFER_COMPLETE;
+    const status = gl.checkFramebufferStatus(GL.FRAMEBUFFER) as GL === GL.FRAMEBUFFER_COMPLETE;
 
     gl.bindTexture(GL.TEXTURE_2D, null);
     return status;

--- a/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
+++ b/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
@@ -207,7 +207,7 @@ export class WEBGLFramebuffer extends Framebuffer {
 function mapIndexToCubeMapFace(layer: number | GL): GL {
   // TEXTURE_CUBE_MAP_POSITIVE_X is a big value (0x8515)
   // if smaller assume layer is index, otherwise assume it is already a cube map face constant
-  return layer < GL.TEXTURE_CUBE_MAP_POSITIVE_X ? layer + GL.TEXTURE_CUBE_MAP_POSITIVE_X : layer;
+  return layer < (GL.TEXTURE_CUBE_MAP_POSITIVE_X as number) ? layer + GL.TEXTURE_CUBE_MAP_POSITIVE_X : layer;
 }
 
 // Helper METHODS

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -178,7 +178,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
     const {bindings} = splitUniformsAndBindings(uniforms);
     Object.keys(bindings).forEach(name => {
       log.warn(
-        `Unsupported value "${bindings[name]}" used in setUniforms() for key ${name}. Use setBindings() instead?`
+        `Unsupported value "${JSON.stringify(bindings[name])}" used in setUniforms() for key ${name}. Use setBindings() instead?`
       )();
     });
     // TODO - check against layout
@@ -403,7 +403,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
           // Set buffer
           const {name} = binding;
           const location = gl2.getUniformBlockIndex(this.handle, name);
-          if (location === GL.INVALID_INDEX) {
+          if (location as GL === GL.INVALID_INDEX) {
             throw new Error(`Invalid uniform block name ${name}`);
           }
           gl2.uniformBlockBinding(this.handle, uniformBufferIndex, location);

--- a/modules/webgl/src/adapter/resources/webgl-sampler.ts
+++ b/modules/webgl/src/adapter/resources/webgl-sampler.ts
@@ -45,7 +45,7 @@ export class WEBGLSampler extends Sampler {
     for (const [pname, value] of Object.entries(parameters)) {
       // Apparently there are integer/float conversion issues requires two parameter setting functions in JavaScript.
       // For now, pick the float version for parameters specified as GLfloat.
-      const param = Number(pname);
+      const param = Number(pname) as GL.TEXTURE_MIN_LOD | GL.TEXTURE_MAX_LOD;
       switch (param) {
         case GL.TEXTURE_MIN_LOD:
         case GL.TEXTURE_MAX_LOD:

--- a/modules/webgl/src/adapter/resources/webgl-texture.ts
+++ b/modules/webgl/src/adapter/resources/webgl-texture.ts
@@ -56,17 +56,16 @@ export const DEFAULT_WEBGL_TEXTURE_PROPS = {
   border: 0,
   dataFormat: undefined!,
   textureUnit: undefined!,
-  target: undefined!,
+  target: undefined!
 };
 
-export type TextureSourceData = 
-  TypedArray |
-  ImageData |
-  HTMLImageElement |
-  HTMLCanvasElement |
-  ImageBitmap |
-  HTMLVideoElement
-  ;
+export type TextureSourceData =
+  | TypedArray
+  | ImageData
+  | HTMLImageElement
+  | HTMLCanvasElement
+  | ImageBitmap
+  | HTMLVideoElement;
 
 type SetImageDataOptions = {
   target?: number;
@@ -83,7 +82,7 @@ type SetImageDataOptions = {
   parameters?: Record<GL, any>;
   /** @deprecated */
   pixels?: any;
-}
+};
 
 /**
  * @param {*} pixels, data -
@@ -138,7 +137,6 @@ type SetImageData3DOptions = {
   data: any;
   parameters?: Record<GL, any>;
 };
-
 
 // Polyfill
 export class WEBGLTexture extends Texture<WEBGLTextureProps> {
@@ -241,7 +239,7 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
     let data = props.data;
 
     if (data instanceof Promise) {
-      data.then((resolvedImageData) =>
+      data.then(resolvedImageData =>
         this.initialize(
           Object.assign({}, props, {
             pixels: resolvedImageData,
@@ -261,10 +259,9 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
       return this;
     }
 
-    const {parameters = {}  as Record<GL, any>} = props;
+    const {parameters = {} as Record<GL, any>} = props;
 
-    const {
-      pixels = null, pixelStore = {}, textureUnit = undefined} = props;
+    const {pixels = null, pixelStore = {}, textureUnit = undefined} = props;
 
     // pixels variable is for API compatibility purpose
     if (!data) {
@@ -319,7 +316,7 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
       format: glFormat,
       type,
       dataFormat,
-      // @ts-expect-error 
+      // @ts-expect-error
       parameters: pixelStore,
       compressed
     });
@@ -345,7 +342,7 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
   }
 
   initializeCube(props?: WEBGLTextureProps): this {
-    const {mipmaps = true, parameters = {}  as Record<GL, any>} = props;
+    const {mipmaps = true, parameters = {} as Record<GL, any>} = props;
 
     // Store props for accessors
     // this.props = props;
@@ -386,7 +383,7 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
    * If size has changed, reinitializes with current format
    * @note note clears image and mipmaps
    */
-  resize(options: {height: number, width: number, mipmaps?: boolean}): this {
+  resize(options: {height: number; width: number; mipmaps?: boolean}): this {
     const {height, width, mipmaps = false} = options;
     if (width !== this.width || height !== this.height) {
       return this.initialize({
@@ -471,7 +468,7 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
       level = 0,
       glFormat = this.glFormat,
       offset = 0,
-      parameters = {}  as Record<GL, any>
+      parameters = {} as Record<GL, any>
     } = options;
 
     let {
@@ -509,7 +506,17 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
     withGLParameters(this.gl, parameters, () => {
       switch (dataType) {
         case 'null':
-          gl.texImage2D(target, level, glFormat, width, height, 0 /* border*/, dataFormat, type, data);
+          gl.texImage2D(
+            target,
+            level,
+            glFormat,
+            width,
+            height,
+            0 /* border*/,
+            dataFormat,
+            type,
+            data
+          );
           break;
         case 'typed-array':
           // Looks like this assert is not necessary, as offset is ignored under WebGL1
@@ -821,7 +828,7 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
     // ... }
 
     const resolvedFaces = await Promise.all(
-      WEBGLTexture.FACES.map((face) => {
+      WEBGLTexture.FACES.map(face => {
         const facePixels = imageDataMap[face];
         return Promise.all(Array.isArray(facePixels) ? facePixels : [facePixels]);
       })
@@ -867,7 +874,7 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
 
     this.bind();
     if (imageData instanceof Promise) {
-      imageData.then((resolvedImageData) =>
+      imageData.then(resolvedImageData =>
         this.setImageDataForFace(
           Object.assign({}, options, {
             face,
@@ -974,7 +981,7 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
 
     this.gl.bindTexture(this.target, this.handle);
     for (const [pname, pvalue] of Object.entries(parameters)) {
-      const param = Number(pname);
+      const param = Number(pname) as GL.TEXTURE_MIN_LOD | GL.TEXTURE_MAX_LOD;
       const value = pvalue;
 
       // Apparently there are integer/float conversion issues requires two parameter setting functions in JavaScript.
@@ -995,7 +1002,10 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
   }
 
   /** @deprecated For LegacyTexture subclass */
-  protected _getWebGL1NPOTParameterOverride(pname: number, value: number): number {
+  protected _getWebGL1NPOTParameterOverride(
+    pname: GL.TEXTURE_MIN_FILTER | GL.TEXTURE_WRAP_S | GL.TEXTURE_WRAP_T,
+    value: GL.LINEAR | GL.NEAREST
+  ): number {
     // NOTE: Apply NPOT workaround
     const npot = this.device.isWebGL1 && isNPOT(this.width, this.height);
     if (npot) {

--- a/modules/webgl/src/classic/accessor.ts
+++ b/modules/webgl/src/classic/accessor.ts
@@ -87,7 +87,7 @@ export class Accessor implements AccessorObject {
       this.type = props.type;
 
       // Auto-deduce integer type?
-      if (props.type === GL.INT || props.type === GL.UNSIGNED_INT) {
+      if ((props.type as GL) === GL.INT || (props.type as GL) === GL.UNSIGNED_INT) {
         this.integer = true;
       }
     }

--- a/modules/webgl/test/adapter/webgl-canvas-context.spec.ts
+++ b/modules/webgl/test/adapter/webgl-canvas-context.spec.ts
@@ -306,7 +306,7 @@ test('WebGLCanvasContext#cssToDevicePixels', (t) => {
       t.deepEqual(
         canvasContext?.cssToDevicePixels( tc.windowPositions[i]),
         tc.devicePositionsInverted[i],
-        `${tc.name}(yInvert=true): device pixel should be ${tc.devicePositionsInverted[i]} for window position ${tc.windowPositions[i]}`
+        `${tc.name}(yInvert=true): device pixel should be ${JSON.stringify(tc.devicePositionsInverted[i])} for window position ${tc.windowPositions[i]}`
       );
       t.deepEqual(
         canvasContext?.cssToDevicePixels(tc.windowPositions[i], false),

--- a/modules/webgpu/src/adapter/helpers/generate-mipmaps.ts
+++ b/modules/webgpu/src/adapter/helpers/generate-mipmaps.ts
@@ -67,7 +67,7 @@ export class WebGPUMipmapGenerator {
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.SAMPLED | GPUTextureUsage.OUTPUT_ATTACHMENT,
       mipLevelCount
     });
-    this.device.queue.copyImageBitmapToTexture({ imageBitmap }, { texture: srcTexture }, textureSize);
+    this.device.queue.copyImageBitmapToTexture({ imageBitmap }, { texture }, textureSize);
 
     const commandEncoder = this.device.createCommandEncoder({});
     for (let i = 1; i < mipLevelCount; ++i) {

--- a/modules/webgpu/src/adapter/helpers/get-vertex-buffer-layout.ts
+++ b/modules/webgpu/src/adapter/helpers/get-vertex-buffer-layout.ts
@@ -1,6 +1,6 @@
 // luma.gl, MIT license
 import type {ShaderLayout, BufferLayout, AttributeDeclaration, VertexFormat} from '@luma.gl/core';
-import {getAttributeInfosFromLayouts, decodeVertexFormat} from '@luma.gl/core';
+import {decodeVertexFormat} from '@luma.gl/core';
 
 /** Throw error on any WebGL-only vertex formats */
 function getWebGPUVertexFormat(format: VertexFormat): GPUVertexFormat {
@@ -21,9 +21,6 @@ export function getVertexBufferLayout(
   shaderLayout: ShaderLayout,
   bufferLayout: BufferLayout[]
 ): GPUVertexBufferLayout[] {
-  // @ts-expect-error Deduplicate and make use of the new core attribute logic here in webgpu module
-  const attributeInfos = getAttributeInfosFromLayouts(shaderLayout, bufferLayout);
-
   const vertexBufferLayouts: GPUVertexBufferLayout[] = [];
   const usedAttributes = new Set<string>();
 


### PR DESCRIPTION
Should be no functional changes here, just making `yarn lint` happy.

There were a few cases like this...

```javascript
console.log(`Error because of ${object}`);
```

... which I tried to resolve reasonably, but the error message might appear a little different. I also removed a few debug logs in the shader input code.