### PR TITLE
fix(shadertools): Correct order of uniforms in picking module

### DIFF
--- a/modules/shadertools/src/modules/engine/picking/picking.ts
+++ b/modules/shadertools/src/modules/engine/picking/picking.ts
@@ -210,16 +210,16 @@ export const picking: ShaderModule<PickingProps, PickingUniforms> = {
   uniformTypes: {
     isActive: 'f32',
     isAttribute: 'f32',
-    useFloatColors: 'f32',
     isHighlightActive: 'f32',
+    useFloatColors: 'f32',
     highlightedObjectColor: 'vec3<f32>',
     highlightColor: 'vec4<f32>'
   },
   defaultUniforms: {
     isActive: false,
     isAttribute: false,
-    useFloatColors: true,
     isHighlightActive: false,
+    useFloatColors: true,
     highlightedObjectColor: new Float32Array([0, 0, 0]),
     highlightColor: DEFAULT_HIGHLIGHT_COLOR
   },


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

The order of uniforms in the `uniformTypes` must match that used in the shader. This was not the case in the picking module, which led to the incorrect layout being generated

<img width="430" alt="Screenshot 2024-01-03 at 14 27 51" src="https://github.com/visgl/luma.gl/assets/453755/43e0a64e-23eb-41fc-8cce-ad1ae5fff2a3">

with the positions of `useFloatColors` and `isHighlightActive` being swapped

<img width="246" alt="Screenshot 2024-01-03 at 15 11 31" src="https://github.com/visgl/luma.gl/assets/453755/b8de748a-6fec-4f34-bcdc-625191d9076b">


<!-- For all the PRs -->
#### Change List
- Correct order of uniforms in picking module
