### PR TITLE
feat(engine) Partial prop updates in ShaderInputs.setProps

### DIFF
--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -89,7 +89,7 @@ export class ShaderInputs<
       const moduleProps = props[moduleName];
       const module = this.modules[moduleName];
 
-      const oldUniforms = this.moduleUniforms[moduleName] || {};  
+      const oldUniforms = this.moduleUniforms[moduleName];  
       const uniforms = module.getUniforms?.(moduleProps, this.moduleUniforms[moduleName]) || moduleProps as any;
       // console.error(uniforms)
       this.moduleUniforms[moduleName] = {...oldUniforms, ...uniforms};

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -72,7 +72,7 @@ export class ShaderInputs<
       const moduleName = name as keyof ShaderPropsT;
 
       // Get default uniforms from module
-      this.moduleUniforms[moduleName] = module.getUniforms?.({}) || module.defaultUniforms || {};
+      this.moduleUniforms[moduleName] = module.defaultUniforms || {};
       this.moduleBindings[moduleName] = {};
     }
   }
@@ -89,9 +89,10 @@ export class ShaderInputs<
       const moduleProps = props[moduleName];
       const module = this.modules[moduleName];
 
-      const uniforms = module.getUniforms?.(moduleProps, this.moduleUniforms[moduleName]);
+      const oldUniforms = this.moduleUniforms[moduleName] || {};  
+      const uniforms = module.getUniforms?.(moduleProps, this.moduleUniforms[moduleName]) || moduleProps as any;
       // console.error(uniforms)
-      this.moduleUniforms[moduleName] = uniforms || moduleProps as any;
+      this.moduleUniforms[moduleName] = {...oldUniforms, ...uniforms};
       // this.moduleUniformsChanged ||= moduleName;
 
       // console.log(`setProps(${String(moduleName)}`, moduleName, this.moduleUniforms[moduleName])

--- a/modules/engine/test/shader-inputs.spec.ts
+++ b/modules/engine/test/shader-inputs.spec.ts
@@ -39,3 +39,21 @@ test('ShaderInputs#picking', (t) => {
 
   t.end();
 });
+
+test('ShaderInputs#picking prop merge', (t) => {
+  const shaderInputs = new ShaderInputs<{picking: typeof picking.props}>({picking});
+  const expected = {...picking.defaultUniforms};
+  t.deepEqual(shaderInputs.moduleUniforms.picking, expected, 'defaults set');
+
+  shaderInputs.setProps({picking: {highlightColor: [255, 0, 255]}});
+  expected.highlightColor = [1, 0, 1, 1]; // Color normalized and alpha added
+  t.deepEqual(shaderInputs.moduleUniforms.picking, expected, 'Only highlight color updated');
+
+  // Setting the highlighted object also enables highlight
+  shaderInputs.setProps({picking: {highlightedObjectColor: [255, 255, 255]}});
+  expected.highlightedObjectColor = [255, 255, 255];
+  expected.isHighlightActive = true;
+  t.deepEqual(shaderInputs.moduleUniforms.picking, expected, 'Only highlight object and highlight active updated');
+
+  t.end();
+});

--- a/modules/shadertools/src/modules/engine/picking/picking.ts
+++ b/modules/shadertools/src/modules/engine/picking/picking.ts
@@ -227,10 +227,10 @@ export const picking: ShaderModule<PickingProps, PickingUniforms> = {
 };
 
 function getUniforms(opts: PickingProps = {}, prevUniforms?: PickingUniforms): PickingUniforms {
-  const uniforms = {...picking.defaultUniforms};
+  const uniforms = {} as PickingUniforms;
 
   if (opts.highlightedObjectColor === undefined) {
-    delete uniforms.highlightedObjectColor;
+    // Unless highlightedObjectColor explicitly null or set, do not update state
   } else if (opts.highlightedObjectColor === null) {
     uniforms.isHighlightActive = false;
   } else {

--- a/modules/shadertools/test/modules/engine/picking.spec.ts
+++ b/modules/shadertools/test/modules/engine/picking.spec.ts
@@ -57,13 +57,7 @@ const TEST_CASES = [
 ];
 
 test('picking#getUniforms', (t) => {
-  t.deepEqual(picking.getUniforms({}), {
-    isActive: false,
-    isAttribute: false,
-    useFloatColors: true,
-    isHighlightActive: false,
-    highlightColor: [0, 1, 1, 1]
-  }, 'Empty input');
+  t.deepEqual(picking.getUniforms({}), {}, 'Empty input');
 
   t.deepEqual(
     picking.getUniforms({
@@ -74,10 +68,8 @@ test('picking#getUniforms', (t) => {
     {
       isActive: true,
       isAttribute: false,
-      useFloatColors: true,
-      isHighlightActive: false,
       highlightColor: [1, 0, 0, 1]
-    }, 'Undefined input');
+    }, 'Undefined input (no change to highlighted object)');
 
   t.deepEqual(
     picking.getUniforms({
@@ -88,11 +80,9 @@ test('picking#getUniforms', (t) => {
     {
       isActive: true,
       isAttribute: false,
-      useFloatColors: true,
       isHighlightActive: false,
-      highlightedObjectColor: [0, 0, 0],
       highlightColor: [1, 0, 0, 1]
-    }, 'Null input');
+    }, 'Null input (clear highlighted object)');
 
   t.deepEqual(
     picking.getUniforms({
@@ -100,13 +90,10 @@ test('picking#getUniforms', (t) => {
       highlightColor: [102, 0, 0, 51]
     }),
     {
-      isActive: false,
-      isAttribute: false,
-      useFloatColors: true,
       isHighlightActive: true,
       highlightedObjectColor: [0, 0, 1],
       highlightColor: [0.4, 0, 0, 0.2]
-    }
+    }, 'Picked input (set highlighted object)'
   );
 
   t.deepEqual(
@@ -116,13 +103,11 @@ test('picking#getUniforms', (t) => {
       useFloatColors: false
     }),
     {
-      isActive: false,
-      isAttribute: false,
       useFloatColors: false,
       isHighlightActive: true,
       highlightedObjectColor: [0, 0, 1],
-      highlightColor: [0.4, 0, 0, 0.2]
-    }
+      highlightColor: [0.4, 0, 0, 0.2],
+    }, 'Override useFloatColors'
   );
 
   t.end();


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

deck.gl doesn't update all of the props for picking in one place, for example the `highlightColor` is set once when the layer is created. In contrast the `isActive` is changed very frequently, depending on whether a screen or picking pass is being rendered. In order to save the application (deck) from having to keep track of the state this change:

- Modifies `picking.getUniforms` to only return uniforms which are relevant to the passed in props
- Removes all knowledge of `picking.defaultUniforms` from `picking.getUniforms`
- Moves the responsibility for reading `defaultUniforms` into the `ShaderInputs` constructor
- Merges old uniforms with new uniforms in `ShaderInputs`

This design allows the `ShaderModule` to remain stateless, and only specify how props are translated into uniforms, while `ShaderInputs` holds the state.

