### PR TITLE
feat(engine) Ignore props for unregistered modules in ShaderInputs

### DIFF
--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -88,6 +88,10 @@ export class ShaderInputs<
       const moduleName = name as keyof ShaderPropsT;
       const moduleProps = props[moduleName];
       const module = this.modules[moduleName];
+      if (!module) {
+        // Ignore props for unregistered modules
+        continue;
+      }
 
       const oldUniforms = this.moduleUniforms[moduleName];  
       const uniforms = module.getUniforms?.(moduleProps, this.moduleUniforms[moduleName]) || moduleProps as any;

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -90,6 +90,7 @@ export class ShaderInputs<
       const module = this.modules[moduleName];
       if (!module) {
         // Ignore props for unregistered modules
+        log.warn(`Module ${name} not found`)();
         continue;
       }
 


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

Applications may want to globally update props for modules (e.g. picking in deck) across many models, without having to worry about which models actually support the modules.