### PR TITLE
fix(core) Prevent crash when scrollIntoView unavailable

### DIFF
--- a/modules/core/src/adapter/resources/shader.ts
+++ b/modules/core/src/adapter/resources/shader.ts
@@ -117,7 +117,10 @@ ${htmlLog}
     button.style.textAlign = 'left';
     document.body.appendChild(button);
 
-    document.getElementsByClassName('luma-compiler-log-error')[0]?.scrollIntoView();
+    const errors = document.getElementsByClassName('luma-compiler-log-error');
+    if (errors[0]?.scrollIntoView) {
+      errors[0].scrollIntoView();
+    }
 
     // TODO - add a small embedded copy button (instead of main button)
     button.onclick = () => {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

When running unit tests, it isn't possible to `scrollIntoView()`:

```
    (_a = document.getElementsByClassName("luma-compiler-log-error")[0]) == null ? void 0 : _a.scrollIntoView();
                                                                                               ^
TypeError: _a.scrollIntoView is not a function
    at WEBGLShader._displayShaderLog (/Users/carto/git/visgl/deck.gl/node_modules/@luma.gl/core/dist/index.cjs:1042:96)
    at WEBGLShader.debugShader (/Users/carto/git/visgl/deck.gl/node_modules/@luma.gl/core/dist/index.cjs:1017:10)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```