### PR TITLE
feat(engine) Model.setAttributes handle interleaved attributes

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -446,16 +446,14 @@ export class Model {
       )();
     }
     for (const [bufferName, buffer] of Object.entries(buffers)) {
-      const bufferLayout = this.bufferLayout.find(layout => layout.name === bufferName);
+      const bufferLayout = this.bufferLayout.find(layout => getAttributeNames(layout).includes(bufferName));
       if (!bufferLayout) {
         log.warn(`Model(${this.id}): Missing layout for buffer "${bufferName}".`)();
         continue; // eslint-disable-line no-continue
       }
 
       // For an interleaved attribute we may need to set multiple attributes
-      const attributeNames = bufferLayout.attributes
-        ? bufferLayout.attributes?.map(layout => layout.attribute)
-        : [bufferLayout.name];
+      const attributeNames = getAttributeNames(bufferLayout);
       let set = false;
       for (const attributeName of attributeNames) {
         const attributeInfo = this._attributeInfos[attributeName];
@@ -591,4 +589,11 @@ export function getPlatformInfo(device: Device): PlatformInfo {
     gpu: device.info.gpu,
     features: device.features
   };
+}
+
+/** Get attribute names from a BufferLayout */
+function getAttributeNames(bufferLayout: BufferLayout): string[] {
+  return bufferLayout.attributes
+  ? bufferLayout.attributes?.map(layout => layout.attribute)
+  : [bufferLayout.name];
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

`BufferLayout` can specify multiple attributes in `bufferLayout.attributes`, for example deck.gl uses this to supply 64bit `instancePositions` via `instancePositions` and `instancePositionsLow64`. `setAttributes` was only inspecting `bufferLayout.name` when matching to a passes attribute, leading to warnings:

<img width="708" alt="Screenshot 2024-01-16 at 11 41 42" src="https://github.com/visgl/luma.gl/assets/453755/d2d9c0a8-2f6d-403c-868f-bdecb6627925">


<!-- For all the PRs -->
#### Change List
- Consider all attribute names when matching to buffer name
