### PR TITLE
feat(engine): Visual framebuffer debugger

### DIFF
--- a/examples/showcase/persistence/app.ts
+++ b/examples/showcase/persistence/app.ts
@@ -96,7 +96,7 @@ const screenQuad: {uniformTypes: Record<keyof ScreenQuadUniforms, ShaderUniformT
 const SCREEN_QUAD_VS = glsl`\
 #version 300 es
 
-attribute vec2 aPosition;
+in vec2 aPosition;
 
 void main(void) {
   gl_Position = vec4(aPosition, 0, 1);
@@ -118,7 +118,7 @@ out vec4 fragColor;
 
 void main(void) {
   vec2 p = gl_FragCoord.xy/screenQuad.resolution.xy;
-  fragColor = texture2D(uTexture, p);
+  fragColor = texture(uTexture, p);
 }
 `;
 
@@ -150,8 +150,8 @@ out vec4 fragColor;
 
 void main(void) {
   vec2 p = gl_FragCoord.xy / persistence.resolution.xy;
-  vec4 cS = texture2D(uScene, p);
-  vec4 cP = texture2D(uPersistence, p);
+  vec4 cS = texture(uScene, p);
+  vec4 cP = texture(uPersistence, p);
   fragColor = mix(cS*4.0, cP, 0.9);
 }
 `;

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -336,10 +336,6 @@ export abstract class Device {
   /** Create a compute pipeline (aka program). WebGPU only. */
   abstract createComputePipeline(props: ComputePipelineProps): ComputePipeline;
 
-  createCommandEncoder(props: CommandEncoderProps = {}): CommandEncoder {
-    throw new Error('not implemented');
-  }
-
   /** Create a vertex array */
   abstract createVertexArray(props: VertexArrayProps): VertexArray;
 
@@ -354,6 +350,48 @@ export abstract class Device {
 
   /** Create a transform feedback (immutable set of output buffer bindings). WebGL 2 only. */
   abstract createTransformFeedback(props: TransformFeedbackProps): TransformFeedback;
+
+  createCommandEncoder(props: CommandEncoderProps = {}): CommandEncoder {
+    throw new Error('not implemented');
+  }
+
+  // HACKS - until we have a better way to handle these
+
+  /** @deprecated - will be removed - should use command encoder */
+  readPixelsToArrayWebGL(
+    source: Framebuffer | Texture,
+    options?: {
+      sourceX?: number;
+      sourceY?: number;
+      sourceFormat?: number;
+      sourceAttachment?: number;
+      target?: Uint8Array | Uint16Array | Float32Array;
+      // following parameters are auto deduced if not provided
+      sourceWidth?: number;
+      sourceHeight?: number;
+      sourceType?: number;
+    }
+  ): Uint8Array | Uint16Array | Float32Array {
+    throw new Error('not implemented');
+  }
+  
+  /** @deprecated - will be removed - should use command encoder */
+  readPixelsToBufferWebGL2(
+    source: Framebuffer | Texture,
+    options?: {
+      sourceX?: number;
+      sourceY?: number;
+      sourceFormat?: number;
+      target?: Buffer; // A new Buffer object is created when not provided.
+      targetByteOffset?: number; // byte offset in buffer object
+      // following parameters are auto deduced if not provided
+      sourceWidth?: number;
+      sourceHeight?: number;
+      sourceType?: number;
+    }
+  ): Buffer {
+    throw new Error('not implemented');
+  }
 
   // Implementation
 

--- a/modules/engine/src/debug/copy-texture-to-image.ts
+++ b/modules/engine/src/debug/copy-texture-to-image.ts
@@ -1,0 +1,72 @@
+// luma.gl, MIT license
+import {Texture, Framebuffer} from '@luma.gl/core';
+import {GL} from '@luma.gl/constants';
+import {flipRows, scalePixels} from './pixel-data-utils';
+
+/**
+ * Options for copying texture pixels to image
+ * @todo - support gl.readBuffer
+ */
+export type CopyTextureToImageOptions = {
+  sourceAttachment?: number; 
+  targetMaxHeight?: number;
+  targetImage?: HTMLImageElement;
+};
+
+/**
+ * Reads pixels from a Framebuffer or Texture object into an HTML Image
+ * @todo - can we move this to @luma.gl/core?
+ * @param source 
+ * @param options options passed to copyToDataUrl
+ * @returns 
+ */
+export function copyTextureToImage(
+  source: Texture | Framebuffer,
+  options?: CopyTextureToImageOptions
+): HTMLImageElement {
+
+  const dataUrl = copyTextureToDataUrl(source, options);
+  const targetImage: HTMLImageElement = options?.targetImage || new Image();
+  targetImage.src = dataUrl;
+
+  return targetImage;
+}
+
+/**
+ * Reads pixels from a Framebuffer or Texture object to a dataUrl
+ * @todo - can we move this to @luma.gl/core?
+ * @param source texture or framebuffer to read from
+ * @param options 
+ */
+export function copyTextureToDataUrl(
+  source: Texture | Framebuffer,
+  options: CopyTextureToImageOptions = {}
+): string {
+  const {
+    sourceAttachment = GL.COLOR_ATTACHMENT0, // TODO - support gl.readBuffer
+    targetMaxHeight = Number.MAX_SAFE_INTEGER
+  } = options;
+
+  let data = source.device.readPixelsToArrayWebGL(source, {sourceAttachment});
+
+  // Scale down
+  let {width, height} = source;
+  while (height > targetMaxHeight) {
+    ({data, width, height} = scalePixels({data, width, height}));
+  }
+
+  // Flip to top down coordinate system
+  flipRows({data, width, height});
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext('2d');
+
+  // Copy the pixels to a 2D canvas
+  const imageData = context.createImageData(width, height);
+  imageData.data.set(data);
+  context.putImageData(imageData, 0, 0);
+
+  return canvas.toDataURL('image/png');
+}

--- a/modules/engine/src/debug/debug-framebuffer.ts
+++ b/modules/engine/src/debug/debug-framebuffer.ts
@@ -1,0 +1,57 @@
+import type {Framebuffer, Texture} from '@luma.gl/core';
+// import {copyTextureToImage} from '../debug/copy-texture-to-image';
+
+/** Only works with 1st device? */
+let canvas: HTMLCanvasElement | null = null;
+let ctx: CanvasRenderingContext2D | null = null;
+// let targetImage: HTMLImageElement | null = null;
+
+/** Debug utility to draw FBO contents onto screen */
+// eslint-disable-next-line
+export function debugFramebuffer(
+  fbo: Framebuffer | Texture,
+  {id, minimap, opaque, top = '0', left = '0', rgbaScale = 1}: {id: string, minimap?: boolean; opaque?: boolean, top?: string, left?: string, rgbaScale?: number}
+) {
+  if (!canvas) {
+    canvas = document.createElement('canvas');
+    canvas.id = id;
+    canvas.title = id;
+    canvas.style.zIndex = '100';
+    canvas.style.position = 'absolute';
+    canvas.style.top = top; // ⚠️
+    canvas.style.left = left; // ⚠️
+    canvas.style.border = 'blue 1px solid';
+    canvas.style.transform = 'scaleY(-1)';
+    document.body.appendChild(canvas);
+
+    ctx = canvas.getContext('2d');
+    // targetImage = new Image();
+  }
+
+  // const canvasHeight = (minimap ? 2 : 1) * fbo.height;
+  if (canvas.width !== fbo.width || canvas.height !== fbo.height) {
+    canvas.width = fbo.width / 2;
+    canvas.height = fbo.height / 2;
+    canvas.style.width = '400px';
+    canvas.style.height = '400px';
+
+  }
+
+  // const image = copyTextureToImage(fbo, {targetMaxHeight: 100, targetImage});
+  // ctx.drawImage(image, 0, 0);
+
+  const color = fbo.device.readPixelsToArrayWebGL(fbo);
+  const imageData = ctx.createImageData(fbo.width, fbo.height);
+  // Full map
+  const offset = 0;
+  // if (color.some((v) => v > 0)) {
+  //   console.error('THERE IS NON-ZERO DATA IN THE FBO!');
+  // }
+  for (let i = 0; i < color.length; i += 4) {
+    imageData.data[offset + i + 0] = color[i + 0] * rgbaScale;
+    imageData.data[offset + i + 1] = color[i + 1] * rgbaScale;
+    imageData.data[offset + i + 2] = color[i + 2] * rgbaScale;
+    imageData.data[offset + i + 3] = opaque ? 255 : color[i + 3] * rgbaScale;
+  }
+  ctx.putImageData(imageData, 0, 0);
+};

--- a/modules/engine/src/debug/pixel-data-utils.ts
+++ b/modules/engine/src/debug/pixel-data-utils.ts
@@ -1,0 +1,57 @@
+// luma.gl, MIT license
+// Copyright (c) vis.gl contributors
+
+import {TypedArray} from '@luma.gl/core';
+
+/**
+ * Flip rows (can be used on arrays returned from `Framebuffer.readPixels`)
+ * https: *stackoverflow.com/questions/41969562/
+ * how-can-i-flip-the-result-of-webglrenderingcontext-readpixels
+ * @param param0
+ */
+export function flipRows(options: {
+  data: TypedArray;
+  width: number;
+  height: number;
+  bytesPerPixel?: number;
+  temp?: Uint8Array;
+}): void {
+  const {data, width, height, bytesPerPixel = 4, temp} = options;
+  const bytesPerRow = width * bytesPerPixel;
+
+  // make a temp buffer to hold one row
+  const tempBuffer = temp || new Uint8Array(bytesPerRow);
+  for (let y = 0; y < height / 2; ++y) {
+    const topOffset = y * bytesPerRow;
+    const bottomOffset = (height - y - 1) * bytesPerRow;
+    // make copy of a row on the top half
+    tempBuffer.set(data.subarray(topOffset, topOffset + bytesPerRow));
+    // copy a row from the bottom half to the top
+    data.copyWithin(topOffset, bottomOffset, bottomOffset + bytesPerRow);
+    // copy the copy of the top half row to the bottom half
+    data.set(tempBuffer, bottomOffset);
+  }
+}
+
+export function scalePixels(options: {
+  data: TypedArray;
+  width: number;
+  height: number;
+}): {
+  data: Uint8Array;
+  width: number;
+  height: number;
+} {
+  const {data, width, height} = options;
+  const newWidth = Math.round(width / 2);
+  const newHeight = Math.round(height / 2);
+  const newData = new Uint8Array(newWidth * newHeight * 4);
+  for (let y = 0; y < newHeight; y++) {
+    for (let x = 0; x < newWidth; x++) {
+      for (let c = 0; c < 4; c++) {
+        newData[(y * newWidth + x) * 4 + c] = data[(y * 2 * width + x * 2) * 4 + c];
+      }
+    }
+  }
+  return {data: newData, width: newWidth, height: newHeight};
+}

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -25,6 +25,7 @@ import type {Geometry} from '../geometry/geometry';
 import {GPUGeometry, makeGPUGeometry} from '../geometry/gpu-geometry';
 import {PipelineFactory} from '../lib/pipeline-factory';
 import {getDebugTableForShaderLayout} from '../debug/debug-shader-layout';
+import { copyTextureToImage } from '../debug/copy-texture-to-image';
 
 const LOG_DRAW_PRIORITY = 2;
 const LOG_DRAW_TIMEOUT = 10000;
@@ -294,7 +295,7 @@ export class Model {
         transformFeedback: this.transformFeedback
       });
     } finally {
-      this._logDrawCallEnd();
+      this._logDrawCallEnd(renderPass);
     }
   }
 
@@ -560,7 +561,7 @@ export class Model {
     log.group(LOG_DRAW_PRIORITY, `>>> DRAWING MODEL ${this.id}`, {collapsed: log.level <= 2})();
   }
 
-  _logDrawCallEnd(): void {
+  _logDrawCallEnd(renderPass: RenderPass): void {
     if (this._logOpen) {
       const shaderLayoutTable = getDebugTableForShaderLayout(this.pipeline.shaderLayout);
 
@@ -581,6 +582,25 @@ export class Model {
 
       log.groupEnd(LOG_DRAW_PRIORITY)();
       this._logOpen = false;
+
+      const framebuffer = renderPass.props.framebuffer;
+      if (framebuffer) {
+        const img = copyTextureToImage(renderPass.props.framebuffer, {targetMaxHeight: 100});
+        debugger
+        const scale = 1;
+        console.log(`aaa %c sup?` ,
+        `
+          font-size: 1px;
+          padding: ${Math.floor((img.height * scale) / 2)}px ${Math.floor((img.width * scale) / 2)}px;
+          background-image: url(${img.src});
+          background-repeat: no-repeat;
+          background-size: ${img.width * scale}px ${img.height * scale}px;
+          color: transparent;
+        `
+      );
+        
+        // log.image({logLevel: LOG_DRAW_PRIORITY, message: `${framebuffer.id} %c sup?`, image})();
+      }
     }
   }
 

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -10,6 +10,9 @@ import type {
   TextureFormat,
   VertexArray,
   VertexArrayProps,
+  Framebuffer,
+  Buffer,
+  Texture,
   TypedArray
 } from '@luma.gl/core';
 import {Device, CanvasContext, log, uid, assert} from '@luma.gl/core';
@@ -70,6 +73,8 @@ import {WEBGLRenderPipeline} from './resources/webgl-render-pipeline';
 import {WEBGLCommandEncoder} from './resources/webgl-command-encoder';
 import {WEBGLVertexArray} from './resources/webgl-vertex-array';
 import {WEBGLTransformFeedback} from './resources/webgl-transform-feedback';
+
+import {readPixelsToArray, readPixelsToBuffer} from '../classic/copy-and-blit';
 
 const LOG_LEVEL = 1;
 
@@ -376,6 +381,46 @@ ${device.info.vendor}, ${device.info.renderer} for canvas: ${device.canvasContex
   }
 
   //
+  // TEMPORARY HACKS - will be removed in v9.1
+  // 
+
+  /** @deprecated - should use command encoder */
+  override readPixelsToArrayWebGL(
+    source: Framebuffer | Texture,
+    options?: {
+      sourceX?: number;
+      sourceY?: number;
+      sourceFormat?: number;
+      sourceAttachment?: number;
+      target?: Uint8Array | Uint16Array | Float32Array;
+      // following parameters are auto deduced if not provided
+      sourceWidth?: number;
+      sourceHeight?: number;
+      sourceType?: number;
+    }
+  ): Uint8Array | Uint16Array | Float32Array {
+    return readPixelsToArray(source, options);
+  }
+
+  /** @deprecated - should use command encoder */
+  override readPixelsToBufferWebGL2(
+    source: Framebuffer | Texture,
+    options?: {
+      sourceX?: number;
+      sourceY?: number;
+      sourceFormat?: number;
+      target?: Buffer; // A new Buffer object is created when not provided.
+      targetByteOffset?: number; // byte offset in buffer object
+      // following parameters are auto deduced if not provided
+      sourceWidth?: number;
+      sourceHeight?: number;
+      sourceType?: number;
+    }
+  ): Buffer {
+    return readPixelsToBuffer(source, options);
+  }
+
+  //
   // WebGL-only API (not part of `Device` API)
   //
 
@@ -585,8 +630,8 @@ function setConstantUintArray(device: WebGLDevice, location: number, array: Uint
   // }
 }
 
-/** 
- * Compares contents of two typed arrays 
+/**
+ * Compares contents of two typed arrays
  * @todo max length?
  */
 function compareConstantArrayValues(v1: TypedArray, v2: TypedArray): boolean {

--- a/modules/webgl/src/classic/copy-and-blit.ts
+++ b/modules/webgl/src/classic/copy-and-blit.ts
@@ -106,9 +106,9 @@ export function readPixelsToBuffer(
     sourceType?: number;
   }
 ): WEBGLBuffer {
-  const {sourceX = 0, sourceY = 0, sourceFormat = GL.RGBA, targetByteOffset = 0} = options || {};
+  const {target, sourceX = 0, sourceY = 0, sourceFormat = GL.RGBA, targetByteOffset = 0} = options || {};
   // following parameters are auto deduced if not provided
-  let {target, sourceWidth, sourceHeight, sourceType} = options || {};
+  let {sourceWidth, sourceHeight, sourceType} = options || {};
   const {framebuffer, deleteFramebuffer} = getFramebuffer(source);
   assert(framebuffer);
   sourceWidth = sourceWidth || framebuffer.width;

--- a/modules/webgl/src/classic/copy-and-blit.ts
+++ b/modules/webgl/src/classic/copy-and-blit.ts
@@ -1,7 +1,7 @@
 // luma.gl, MIT license
 // Copyright (c) vis.gl contributors
 
-import {assert, Texture, Framebuffer, FramebufferProps} from '@luma.gl/core';
+import {assert, Buffer, Texture, Framebuffer, FramebufferProps} from '@luma.gl/core';
 import {GL} from '@luma.gl/constants';
 
 import {WEBGLTexture} from '../adapter/resources/webgl-texture';
@@ -98,7 +98,7 @@ export function readPixelsToBuffer(
     sourceX?: number;
     sourceY?: number;
     sourceFormat?: number;
-    target?: WEBGLBuffer; // A new Buffer object is created when not provided.
+    target?: Buffer; // A new Buffer object is created when not provided.
     targetByteOffset?: number; // byte offset in buffer object
     // following parameters are auto deduced if not provided
     sourceWidth?: number;
@@ -120,12 +120,13 @@ export function readPixelsToBuffer(
   // deduce type if not available.
   sourceType = sourceType || GL.UNSIGNED_BYTE;
 
-  if (!target) {
+  let webglBufferTarget = target as unknown as WEBGLBuffer | undefined;
+  if (!webglBufferTarget) {
     // Create new buffer with enough size
     const components = glFormatToComponents(sourceFormat);
     const byteCount = glTypeToBytes(sourceType);
     const byteLength = targetByteOffset + sourceWidth * sourceHeight * components * byteCount;
-    target = webglFramebuffer.device.createBuffer({byteLength});
+    webglBufferTarget = webglFramebuffer.device.createBuffer({byteLength});
   }
 
   // TODO(donmccurdy): Do we have tests to confirm this is working?
@@ -135,7 +136,7 @@ export function readPixelsToBuffer(
     width: sourceWidth,
     height: sourceHeight,
     origin: [sourceX, sourceY],
-    destination: target,
+    destination: webglBufferTarget,
     byteOffset: targetByteOffset
   });
   commandEncoder.destroy();
@@ -144,7 +145,7 @@ export function readPixelsToBuffer(
     framebuffer.destroy();
   }
 
-  return target;
+  return webglBufferTarget;
 }
 
 /**


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Adds optional ability to display framebuffer contents in mini-window.
- Based on similar code in deck.gl
- Renders all framebuffers however only one canvas and no handling for offsets etc, so only final fbo is shown, handing that is for future PRs.
- Added `copyTextureToImage` helper from v8 but didn't get it to work in this PR.
#### Change List
- Add temporary methods for `readPixels...()` to Device so apps don't have to import `@luma.gl/webgl` directly
- Add framebuffer debug support
