### PR TITLE
fix(shadertools): Standardize the matching of getShaderName

### DIFF
--- a/modules/shadertools/src/lib/glsl-utils/get-shader-info.ts
+++ b/modules/shadertools/src/lib/glsl-utils/get-shader-info.ts
@@ -19,7 +19,7 @@ export function getShaderInfo(source: string, defaultName?: string): ShaderInfo 
 
 /** Extracts GLSLIFY style naming of shaders: `#define SHADER_NAME ...` */
 function getShaderName(shader: string, defaultName: string = 'unnamed'): string {
-  const SHADER_NAME_REGEXP = /#define[\s*]SHADER_NAME[\s*]([A-Za-z0-9_-]+)[\s*]/;
+  const SHADER_NAME_REGEXP = /#define[^\S\r\n]*SHADER_NAME[^\S\r\n]*([A-Za-z0-9_-]+)\s*/;
   const match = SHADER_NAME_REGEXP.exec(shader);
   return match ? match[1] : defaultName;
 }

--- a/modules/shadertools/test/lib/glsl-utils/get-shader-info.spec.ts
+++ b/modules/shadertools/test/lib/glsl-utils/get-shader-info.spec.ts
@@ -13,6 +13,47 @@ uniform float floaty;
 main() {}
 `;
 
+const SHADER_3 = glsl`\
+uniform float floaty;
+#define  SHADER_NAME name-of-shader
+main() {}
+`;
+
+const SHADER_4 = glsl`\
+uniform float floaty;
+#define  SHADER_NAME  name-of-shader
+main() {}
+`;
+
+const SHADER_5 = glsl`\
+uniform float floaty;
+#define
+SHADER_NAME name-of-shader
+main() {}
+`;
+
+const SHADER_6 = glsl`\
+uniform float floaty;
+#define SHADER_NAME
+name-of-shader
+main() {}
+`;
+const SHADER_7 = glsl`\
+uniform float floaty;
+#define
+
+SHADER_NAME name-of-shader
+main() {}
+`;
+
+const SHADER_8 = glsl`\
+uniform float floaty;
+#define SHADER_NAME
+
+name-of-shader
+main() {}
+`;
+
 const SHADER1 = 'void main() {}';
 
 const SHADER2 = '#version 100 void main() {}';
@@ -57,7 +98,44 @@ test('WebGL#getShaderInfo()', (t) => {
     'name-of-shader',
     'getShaderInfo().name extracted correct name'
   );
+
   t.equal(getShaderInfo(SHADER_2).name, 'unnamed', 'getShaderInfo().name extracted default name');
+
+  t.equal(
+    getShaderInfo(SHADER_3).name,
+    'name-of-shader',
+    'getShaderInfo().name extracted correct name'
+  );
+
+  t.equal(
+    getShaderInfo(SHADER_4).name,
+    'name-of-shader',
+    'getShaderInfo().name extracted correct name'
+  );
+
+  t.equal(
+    getShaderInfo(SHADER_5).name,
+    'unnamed',
+    'getShaderInfo().name extracted default name'
+  );
+
+  t.equal(
+    getShaderInfo(SHADER_6).name,
+    'unnamed',
+    'getShaderInfo().name extracted default name'
+  );
+
+  t.equal(
+    getShaderInfo(SHADER_7).name,
+    'unnamed',
+    'getShaderInfo().name extracted default name'
+  );
+
+  t.equal(
+    getShaderInfo(SHADER_8).name,
+    'unnamed',
+    'getShaderInfo().name extracted default name'
+  );
 
   for (const string in versionTests) {
     t.equal(getShaderInfo(string).version, versionTests[string], 'Version should match');


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #1923

Some adjustments have been made to getShaderName in this PR

1. Allow SHADER_NAME Multiple spaces before and after the name

2. Mismatched line breaks, such as

```glsl
uniform float floaty;
#define SHADER_NAME
name-of-shader
main() {}
```

<!-- For all the PRs -->
#### Change List
- [x] Coding
- [x] Test
