### PR TITLE
feat(webgl): Pass through canvas in WebGLDevice.attach()

### DIFF
--- a/modules/core/src/adapter/canvas-context.ts
+++ b/modules/core/src/adapter/canvas-context.ts
@@ -285,7 +285,7 @@ export abstract class CanvasContext {
   /** @todo Major hack done to port the CSS methods above, base canvas context should not depend on WebGL */
   getDrawingBufferSize(): [number, number] {
     // @ts-expect-error This only works for WebGL
-    const gl = this.device.gl || this.props.gl;
+    const gl = this.device.gl;
     if (!gl) {
       // use default device pixel ratio
       throw new Error('canvas size');

--- a/modules/core/src/adapter/canvas-context.ts
+++ b/modules/core/src/adapter/canvas-context.ts
@@ -285,7 +285,7 @@ export abstract class CanvasContext {
   /** @todo Major hack done to port the CSS methods above, base canvas context should not depend on WebGL */
   getDrawingBufferSize(): [number, number] {
     // @ts-expect-error This only works for WebGL
-    const gl = this.device.gl;
+    const gl = this.device.gl || this.props.gl;
     if (!gl) {
       // use default device pixel ratio
       throw new Error('canvas size');

--- a/modules/webgl/src/adapter/webgl-canvas-context.ts
+++ b/modules/webgl/src/adapter/webgl-canvas-context.ts
@@ -36,6 +36,7 @@ export class WebGLCanvasContext extends CanvasContext {
     const sizeChanged = size[0] !== this.presentationSize[0] || size[1] !== this.presentationSize[1];
     if (sizeChanged) {
       this.presentationSize = size;
+      this.resize();
     }
   }
 
@@ -52,6 +53,8 @@ export class WebGLCanvasContext extends CanvasContext {
    * See http://webgl2fundamentals.org/webgl/lessons/webgl-resizing-the-canvas.html
    */
   resize(options?: {width?: number; height?: number; useDevicePixels?: boolean | number}): void {
+    if (!this.device.gl) return;
+
     // Resize browser context .
     if (this.canvas) {
       const devicePixelRatio = this.getDevicePixelRatio(options?.useDevicePixels);

--- a/modules/webgl/src/adapter/webgl-canvas-context.ts
+++ b/modules/webgl/src/adapter/webgl-canvas-context.ts
@@ -36,6 +36,12 @@ export class WebGLCanvasContext extends CanvasContext {
     const sizeChanged = size[0] !== this.presentationSize[0] || size[1] !== this.presentationSize[1];
     if (sizeChanged) {
       this.presentationSize = size;
+      if (this.device.gl) {
+        // this._canvasSizeInfo.clientHeight = this.canvas.clientHeight;
+        // this._canvasSizeInfo.clientWidth = this.canvas.clientWidth;
+        // this._canvasSizeInfo.devicePixelRatio = this.getDevicePixelRatio();
+        this.setDevicePixelRatio(this.getDevicePixelRatio());
+      }
     }
   }
 

--- a/modules/webgl/src/adapter/webgl-canvas-context.ts
+++ b/modules/webgl/src/adapter/webgl-canvas-context.ts
@@ -36,12 +36,6 @@ export class WebGLCanvasContext extends CanvasContext {
     const sizeChanged = size[0] !== this.presentationSize[0] || size[1] !== this.presentationSize[1];
     if (sizeChanged) {
       this.presentationSize = size;
-      if (this.device.gl) {
-        // this._canvasSizeInfo.clientHeight = this.canvas.clientHeight;
-        // this._canvasSizeInfo.clientWidth = this.canvas.clientWidth;
-        // this._canvasSizeInfo.devicePixelRatio = this.getDevicePixelRatio();
-        this.setDevicePixelRatio(this.getDevicePixelRatio());
-      }
     }
   }
 

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -133,7 +133,7 @@ export class WebGLDevice extends Device {
     if (!isWebGL(gl)) {
       throw new Error('Invalid WebGLRenderingContext');
     }
-    return new WebGLDevice({gl: gl as WebGLRenderingContext, canvas: (gl as WebGLRenderingContext).canvas});
+    return new WebGLDevice({gl: gl as WebGLRenderingContext});
   }
 
   static async create(props: DeviceProps = {}): Promise<WebGLDevice> {
@@ -192,7 +192,8 @@ ${device.info.vendor}, ${device.info.renderer} for canvas: ${device.canvasContex
     }
 
     // Create and instrument context
-    this.canvasContext = new WebGLCanvasContext(this, props);
+    const canvas = props.canvas || props.gl?.canvas;
+    this.canvasContext = new WebGLCanvasContext(this, {...props, canvas});
 
     this.lost = new Promise<{reason: 'destroyed'; message: string}>(resolve => {
       this._resolveContextLost = resolve;

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -221,6 +221,7 @@ ${device.info.vendor}, ${device.info.renderer} for canvas: ${device.canvasContex
     this.gl2 = this.gl as WebGL2RenderingContext;
     this.isWebGL2 = isWebGL2(this.gl);
     this.isWebGL1 = !this.isWebGL2;
+    this.canvasContext.resize();
 
     // luma Device fields
     this.info = getDeviceInfo(this.gl);

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -133,7 +133,7 @@ export class WebGLDevice extends Device {
     if (!isWebGL(gl)) {
       throw new Error('Invalid WebGLRenderingContext');
     }
-    return new WebGLDevice({gl: gl as WebGLRenderingContext});
+    return new WebGLDevice({gl: gl as WebGLRenderingContext, canvas: (gl as WebGLRenderingContext).canvas});
   }
 
   static async create(props: DeviceProps = {}): Promise<WebGLDevice> {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

When attaching to an existing WebGL context `WebGLDevice.attach()` doesn't pass through the canvas, leading to `new WebGLDevice()` to create another canvas, even if the WebGL context already has one (as is commonly the case). For example affects: https://github.com/visgl/deck.gl/pull/8442


<!-- For all the PRs -->
#### Change List
- Pass through `canvas` in `WebGLDevice.attach()`
- Handle resizing of external canvas
