### PR TITLE
fix(docs): Fix table layouts, broken links, and typos in v9 docs

### DIFF
--- a/docs/api-reference/core/bindings.md
+++ b/docs/api-reference/core/bindings.md
@@ -4,7 +4,7 @@ A key responsibility of any GPU API is to enable the application to
 set up data so that it can be accessed by shaders. in luma.b
 
 The terminology can be a little confusing. To make it easy to cross-reference other code and
-documentation, luma.gl attempts to roughly follow WebGPU / WGLSL conventions. The following terms are used:
+documentation, luma.gl attempts to roughly follow WebGPU / WGSL conventions. The following terms are used:
 
 - **layouts** - metadata for various shader connection points
 - **attribute layout** - actual values for attributes
@@ -109,7 +109,7 @@ new Model(device, {
 })
 ```
 
-WGLSL vertex shader
+WGSL vertex shader
 
 ```rust
 struct Uniforms {
@@ -134,7 +134,7 @@ fn main([[location(0)]] position : vec4<f32>,
 }
 ```
 
-WGLS FRAGMENT SHADER
+WGSL FRAGMENT SHADER
 
 ```rust
 [[group(0), binding(1)]] var mySampler: sampler; // BINDING 1

--- a/docs/api-reference/core/canvas-context.md
+++ b/docs/api-reference/core/canvas-context.md
@@ -2,10 +2,10 @@
 
 A `CanvasContext` holds a connection between a GPU `Device` and an HTML `canvas` or `OffscreenCanvas` into which it can render.
 
-Canvas contexts are created using `device.createCanvasContext()`. Depending on options passed, this either: 
-- creates a new canvas element, or 
-- attaches the context to an existing canvas element 
-- 
+Canvas contexts are created using `device.createCanvasContext()`. Depending on options passed, this either:
+- creates a new canvas element, or
+- attaches the context to an existing canvas element
+-
 - (see [remarks](#remarks) below for WebGL limitations).
 
 a `CanvasContext` handles the following responsibilities:
@@ -37,7 +37,7 @@ const renderPass = device.beginRenderPass({
 
 ### `CanvasContextProps`
 
-| Property                | Type                                                 |
+| Property                | Type                                                 |                                                                               |
 | ----------------------- | ---------------------------------------------------- | ----------------------------------------------------------------------------- |
 | `canvas?`               | `HTMLCanvasElement` \| `OffscreenCanvas` \| `string` | A new canvas will be created if not supplied.                                 |
 | `container?`            | `HTMLElement`                                        | Parent DOM element for new canvas. Defaults to first child of `document.body` |
@@ -106,6 +106,6 @@ canvasContext.resize(options)
 
 ## Remarks
 
-- Note that a WebGPU `Device` can have multiple associated `CanvasContext` instances (or none, if only used for compute). 
+- Note that a WebGPU `Device` can have multiple associated `CanvasContext` instances (or none, if only used for compute).
 - However a WebGL `Device` always has exactly one `CanvasContext` and can only render into that single canvas. (This is a fundamental limitation of WebGL.)
 - `useDevicePixels` can accept a custom ratio (Number), instead of `true` or `false`. This allows rendering to a much smaller or higher resolutions. When using high value (usually more than device pixel ratio), it is possible it can get clamped down outside of luma.gl's control due to system memory limitation, in such cases a warning will be logged to the browser console.

--- a/docs/api-reference/core/device-features.mdx
+++ b/docs/api-reference/core/device-features.mdx
@@ -24,7 +24,7 @@ A `DeviceInfo` object with fields that describe the device.
 <DeviceTabs />
 
 | Field                    | This Browser                        | Description                                                |
-| ------------------------ | ----------------------------------- | ---------------------------------------------------------- | --- |
+| ------------------------ | ----------------------------------- | ---------------------------------------------------------- |
 | `type`                   | <Info f="type" />                   | Device type `webgpu`, `webgl2` or `webgl`                  |
 | `vendor`                 | <Info f="vendor" />                 | GPU vendor                                                 |
 | `renderer`               | <Info f="renderer" />               | GPU Driver                                                 |
@@ -34,7 +34,7 @@ A `DeviceInfo` object with fields that describe the device.
 | `gpuBackend`             | <Info f="gpuBackend" />             | `metal`, `opengl`, `vulkan`, `d3d12`, ... or `unknown`     |
 | `gpuArchitecture`        | <Info f="gpuArchitecture" />        | `common-3` on Apple                                        |
 | `shadingLanguage`        | <Info f="shadingLanguage" />        | Shanding language `wgsl`, `glsl`                           |
-| `shadingLanguageVersion` | <Info f="shadingLanguageVersion" /> | Shading language version GLSL 3.00 = 300, GLSL 1.00 = 100) |     |
+| `shadingLanguageVersion` | <Info f="shadingLanguageVersion" /> | Shading language version GLSL 3.00 = 300, GLSL 1.00 = 100) |
 
 - Note that the Chrome browser only exposes limited information by default. Set the [chrome://flags/#enable-webgpu-developer-features](chrome://flags/#enable-webgpu-developer-features) flag to see more WebGPU info.
 
@@ -125,20 +125,20 @@ enabling subfeatures of bigger features.
 :::
 
 | `luma.gl feature`                           | WebGL Extension                                                | Description                                                                                                                                                    |
-| ------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
-| **General WebGL Features**                  |                                                                |                                                                                                                                                                | ß   |
+| ------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **General WebGL Features**                  |                                                                |                                                                                                                                                                |
 | `webgl2`                                    | True for WebGL 2 Context                                       |                                                                                                                                                                |
-| `timer-query-webgl` (WebGL2)                | [`EXT_disjoint_timer_query_webgl2`][timer_query_webgl2]        |                                                                                              |
+| `timer-query-webgl` (WebGL2)                | [`EXT_disjoint_timer_query_webgl2`][timer_query_webgl2]        |                                                                                                                                                                |
 | \*\* GLSL extensions\*\*                    |                                                                |                                                                                                                                                                |
 | **`Texture`s and `Framebuffer`s**           |                                                                |                                                                                                                                                                |
 | `texture-float32-webgl1`                    | [`OES_texture_float`][texture_float]                           | Floating point (`Float32Array`) textures can be created and set as samplers (Note that filtering and rendering need to be queried separately, even in WebGL 2) |
 | `texture-float16-webgl1` (Extension 1 of 2) | [`OES_texture_half_float`][texture_half_float]                 | Half float (`Uint16Array`) textures can be created and set as samplers                                                                                         |
-| `texture-float16-webgl1` (Extension 2 of 2) | [`WEBGL_color_buffer_float`][webgl_color_buffer_float]         | \* (This feature depends on 2 extensions)                                                                                                                      |
+| `texture-float16-webgl1` (Extension 2 of 2) | [`WEBGL_color_buffer_float`][webgl_color_buffer_float]         | (This feature depends on 2 extensions)                                                                                                                         |
 | `multiple-render-targets-webgl1`            | [`WEBGL_draw_buffers`][draw_buffers]                           | `Framebuffer`s can have multiple color attachments that fragment shaders can access, see `Framebuffer.drawBuffers`                                             |
 | `texture-renderable-rgba32float-webgl`      |                                                                | Floating point `Texture`s using the `GL.RGBA32F` format are renderable and readable                                                                            |
-| `texture-renderable-float32-webgl`          | [`EXT_color_buffer_float`]color_buffer_float)                  | Floating point `Texture`s are renderable/readable, (attach to `Framebuffer`s and write from fragment shaders, read from with `readPixels` etc. `GL.RGBA32F`.   |
-| `texture-renderable-float16-webgl`          | [`EXT_color_buffer_half_float`]color_buffer_half_float)        | Half float format `Texture`s are renderable and readable                                                                                                       |
-| `float-blend-webgl1`                        | [`EXT_float_blend`]float_blend)                                | Blending with 32-bit floating point color buffers                                                                                                              |
+| `texture-renderable-float32-webgl`          | [`EXT_color_buffer_float`][ext_color_buffer_float]             | Floating point `Texture`s are renderable/readable, (attach to `Framebuffer`s and write from fragment shaders, read from with `readPixels` etc. `GL.RGBA32F`.   |
+| `texture-renderable-float16-webgl`          | [`EXT_color_buffer_half_float`][color_buffer_half_float]       | Half float format `Texture`s are renderable and readable                                                                                                       |
+| `float-blend-webgl1`                        | [`EXT_float_blend`][float_blend]                               | Blending with 32-bit floating point color buffers                                                                                                              |
 | `depth_buffers`                             | [`WEBGL_depth_texture`][depth_texture]                         | Depth buffers can be stored in `Texture`s, e.g. for shadow map calculations                                                                                    |
 | `texture-filter-linear-float`               | [`OES_texture_float_linear`][texture_float_linear]             | Linear texture filtering for floating point textures                                                                                                           |
 | `texture-filter-linear-half-float-webgl`    | [`OES_texture_half_float_linear`][texture_half_float_linear]   | Linear texture filtering for half float textures                                                                                                               |
@@ -162,18 +162,16 @@ enabling subfeatures of bigger features.
 [texture_compression_rgtc]: https://developer.mozilla.org/en-US/docs/Web/API/EXT_texture_compression_rgtc
 [texture_float]: https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_float
 [texture_half_float]: https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_half_float
-[color_buffer_float]: https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_color_buffer_float
 [draw_buffers]: https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_draw_buffers
-[ext_color_buffer_float`]: https://developer.mozilla.org/en-US/docs/Web/API/EXT_color_buffer_float
-[webgl_color_buffer_float`]: https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_color_buffer_float
+[ext_color_buffer_float]: https://developer.mozilla.org/en-US/docs/Web/API/EXT_color_buffer_float
+[webgl_color_buffer_float]: https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_color_buffer_float
 [shader_texture_lod]: https://developer.mozilla.org/en-US/docs/Web/API/EXT_shader_texture_lod
 [draw_buffers]: https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_draw_buffers
-
-[frag_depth]; https://developer.mozilla.org/en-US/docs/Web/API/EXT_frag_depth
+[frag_depth]: https://developer.mozilla.org/en-US/docs/Web/API/EXT_frag_depth
 [standard_derivatives]: https://developer.mozilla.org/en-US/docs/Web/API/OES_standard_derivatives
-[color_buffer_float](https://developer.mozilla.org/en-US/docs/Web/API/EXT_color_buffer_float)
-[color_buffer_half_float](https://developer.mozilla.org/en-US/docs/Web/API/EXT_color_buffer_half_float)
-[float_blend](https://developer.mozilla.org/en-US/docs/Web/API/EXT_float_blend)
+[color_buffer_float]: https://developer.mozilla.org/en-US/docs/Web/API/EXT_color_buffer_float
+[color_buffer_half_float]: https://developer.mozilla.org/en-US/docs/Web/API/EXT_color_buffer_half_float
+[float_blend]: https://developer.mozilla.org/en-US/docs/Web/API/EXT_float_blend
 [depth_texture]: https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_depth_texture
 [texture_float_linear]: https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_float_linear
 [texture_half_float_linear]: https://developer.mozilla.org/en-US/docs/Web/API/OES_texture_half_float_linear

--- a/docs/api-reference/core/parameters.md
+++ b/docs/api-reference/core/parameters.md
@@ -37,7 +37,7 @@ All parameters listed in a single table
 | clearColor                   | `beginRenderPass({colorAttachments})`  |
 
 
-## Otehr types of parameters
+## Other types of parameters
 
 Note that there are certain types of parameters affecting GPU operation that are not handled by the main parameter system:
 
@@ -54,12 +54,12 @@ Note that there are certain types of parameters affecting GPU operation that are
 
 The only parameters that can be changed freely at any time (i.e. between each draw call) are viewport parameters, blend constant and stencil reference.
 
-| Parameter          | Description                                                                                    | Values                      |
-| ------------------ | ---------------------------------------------------------------------------------------------- | --------------------------- | -------------- |
-| `viewport`         | Specifying viewport size                                                                       | `number` (**`0xffffffff`**) |
-| `scissor`          | Specifyi                                                                                       | `number` (**`0xffffffff`**) | `gl.frontFace` |
-| `blendConstant`    | Sets color referenced by pipeline targets using blend factors `constant`, `one-minus-constant` |
-| `stencilReference` |                                                                                                |
+| Parameter          | Description                                                                                    | Values                           |
+| ------------------ | ---------------------------------------------------------------------------------------------- | -------------------------------- |
+| `viewport`         | Specifying viewport size                                                                       | `number` (**`0xffffffff`**)      |
+| `scissor`          | Specifying scissor region                                                                      | `number` (**`0xffffffff`**)      |
+| `blendConstant`    | Sets color referenced by pipeline targets using blend factors                                  | `constant`, `one-minus-constant` |
+| `stencilReference` |                                                                                                |                                  |
 
 These parameters can be set on the current `RenderPass`, and these parameters can be changed at any time.
 

--- a/docs/api-reference/core/resources/shader.md
+++ b/docs/api-reference/core/resources/shader.md
@@ -1,8 +1,8 @@
 # Shader
 
-The `Shader` class holds a compiled shader. 
-- It takes shader source code and compiles it during construction. 
-- Shaders are used as inputs when creating `RenderPipeline` and `ComputePipeline` objects. 
+The `Shader` class holds a compiled shader.
+- It takes shader source code and compiles it during construction.
+- Shaders are used as inputs when creating `RenderPipeline` and `ComputePipeline` objects.
 - A `Shader` is immutable and the same compiled shader can safely be referenced by many pipelines.
 
 ## Usage
@@ -27,11 +27,11 @@ Properties for a Shader
 | `source`      | `string`                            | Shader source code                    |
 | `sourceMap?`  | `string`                            | WebGPU only                           |
 | `language?`   | 'glsl' \| 'wgsl'                    | wgsl in WebGPU only                   |
-| `entryPoint?` | `string`                            | WGLSL only, name of main function     |
+| `entryPoint?` | `string`                            | WGSL only, name of main function     |
 
 ## Members
 
-- `device`: `Device` - holds a reference to the 
+- `device`: `Device` - holds a reference to the
 - `handle`: `unknown` - holds the underlying WebGL or WebGPU shader object
 - `props`: `ShaderProps` - holds a copy of the `ShaderProps` used to create this `Shader`.
 
@@ -43,7 +43,7 @@ Properties for a Shader
 
 ### `destroy(): void`
 
-Free up any GPU resources associated with this shader immediately (instead of waiting for garbage collection). 
+Free up any GPU resources associated with this shader immediately (instead of waiting for garbage collection).
 
 ### `getInfoLog(): Promise<CompilerMessage[]>`
 

--- a/docs/api-reference/core/resources/texture.md
+++ b/docs/api-reference/core/resources/texture.md
@@ -64,7 +64,7 @@ Note that the allowed combinations are very limited, especially in WebGPU.
 
 ## TextureDimension
 
-| Dimension    | WebGPU | WebGL2 | Description                                                          |
+| Dimension    | WebGPU | WebGL2 | WebGL1 | Description                                                          |
 | ------------ | ------ | ------ | ------ | -------------------------------------------------------------------- |
 | `1d`         | ✅     | ❌     | ❌     | Contains a one dimensional texture (typically used for compute )     |
 | `2d`         | ✅     | ✅     | ✅     | Contains a "normal" image texture                                    |

--- a/docs/api-reference/core/shader-layout.md
+++ b/docs/api-reference/core/shader-layout.md
@@ -10,17 +10,17 @@ could choose to provide buffers with different vertex formats, strides, and offs
 
 Shader code (WGSL and GLSL) contains declarations of attributes, uniform blocks, samplers etc, describing all required data inputs and outputs. After compilation and linking of fragment and vertex shaders into a pipeline, the resolved declarations collectively define the layout of the data that needs to be bound before the shader can execute on the GPU.
 
-As a preparation to a `RenderPipeline` `draw()` call, the GPU data 
-required by the pipeline's shaders must be bound on the CPU via luma.gl calls such as `setAttributes()`, `setIndexBuffer()`, `setBindings()` etc. 
+As a preparation to a `RenderPipeline` `draw()` call, the GPU data
+required by the pipeline's shaders must be bound on the CPU via luma.gl calls such as `setAttributes()`, `setIndexBuffer()`, `setBindings()` etc.
 For these calls to work, the metadata in the `ShaderLayout` object is needed in JavaScript.
 
 Note that `ShaderLayout`s are designed to be created manually by a programmer (who needs to make sure all relevant declarations in the shader code are described in the `ShaderLayout`).
 
 Remarks:
-- In WebGL, a default `ShaderLayout` is extracted automatically by the `RenderPipeline` in WebGL. 
+- In WebGL, a default `ShaderLayout` is extracted automatically by the `RenderPipeline` in WebGL.
 However this is not yet possible in WebGPU. Therefore it is necessary to provide an explicit `layout` property to any `RenderPipeline` that is expected to run in WebGPU. This restriction may be lifted in the future.
 - It is not possible to automatically infer from a shader which attributes should have instanced step modes. The heuristic applied by luma.gl under WebGL is that any attribute which contains the string `instanced` will be assumed to have `stepMode='instance'`.
--  
+
 ## Usage
 
 ```typescript
@@ -82,7 +82,7 @@ It contains  fixed information about each attribute such as its location (the in
 
 - `location: number` Compiled pipelines use small integer indices ("locations") to describe binding points (rather than string names). `ShaderLayout` assigns names to each attribute which allows applications to avoid keeping track of these location indices.
 - `format: VertexFormat`
-- `stepMode: 'vertex' | 'instance'` - 
+- `stepMode: 'vertex' | 'instance'` -
 
 
 ### bindings
@@ -99,7 +99,7 @@ and type are the key pieces of information that need to be provided.
 ```
 
 - `location: number` Compiled pipelines use small integer indices ("locations") to describe binding points (rather than string names). `ShaderLayout` assigns names to each attribute which allows applications to avoid keeping track of these location indices.
-- `type: 'texture' | 'sampler' | uniform'` The type of bind point (texture, sampler or uniform buffer). WebGPU requires separate bind points for textures and samplers. 
+- `type: 'texture' | 'sampler' | uniform'` The type of bind point (texture, sampler or uniform buffer). WebGPU requires separate bind points for textures and samplers.
 
 
 ### uniforms

--- a/docs/api-reference/core/texture-formats.mdx
+++ b/docs/api-reference/core/texture-formats.mdx
@@ -60,7 +60,7 @@ Note that even though a GPU supports creating and sampling textures of a certain
 | **6 bytes per pixel formats**         |                                     |                                    |                                    |
 | `rgb16unorm-webgl`                    | <Ft f="rgb16unorm-webgl" />         | <L f="rgb16unorm-webgl" />         | <R f="rgb16unorm-webgl" />         |                                                                                                                         |
 | `rgb16snorm-webgl`                    | <Ft f="rgb16snorm-webgl" />         | <L f="rgb16snorm-webgl" />         | <R f="rgb16snorm-webgl" />         |                                                                                                                         |
-| **8 bytes per pixel formats**         |                                     | }}                                 |
+| **8 bytes per pixel formats**         |                                     |                                    |
 | `rg32uint`                            | <Ft f="rg32uint" />                 | <L f="rg32uint" />                 | <R f="rg32uint" />                 | `GL.RG32UI`                                                                                                             |
 | `rg32sint`                            | <Ft f="rg32sint" />                 | <L f="rg32sint" />                 | <R f="rg32sint" />                 | `GL.RG32I`                                                                                                              |
 | `rg32float`                           | <Ft f="rg32float" />                | <L f="rg32float" />                | <R f="rg32float" />                | `GL.RG32F`                                                                                                              |
@@ -101,7 +101,7 @@ Note that even though a GPU supports creating and sampling textures of a certain
 | `bc6h-rgb-float`                      | <Ft f="bc6h-rgb-float" />           | <L f="bc6h-rgb-float" />           | <R f="bc6h-rgb-float" />           |                                                                                                                         |
 | `bc7-rgba-unorm`                      | <Ft f="bc7-rgba-unorm" />           | <L f="bc7-rgba-unorm" />           | <R f="bc7-rgba-unorm" />           | BC7: encodes 16 input RGB8/RGBA8 pixels into 128 bits of output                                                         |
 | `bc7-rgba-unorm-srgb`                 | <Ft f="bc7-rgba-unorm-srgb" />      | <L f="bc7-rgba-unorm-srgb" />      | <R f="bc7-rgba-unorm-srgb" />      |                                                                                                                         |
-| **`texture-compression-etc2`**`       |                                     |                                    |                                    | Performance caveat: Often CPU decompressed.                                                                             |
+| **`texture-compression-etc2`**        |                                     |                                    |                                    | Performance caveat: Often CPU decompressed.                                                                             |
 | `etc2-rgb8unorm`                      | <Ft f="etc2-rgb8unorm" />           | <L f="etc2-rgb8unorm" />           | <R f="etc2-rgb8unorm" />           | `GL.COMPRESSED_RGB8_ETC2`                                                                                               |
 | `etc2-rgb8unorm-srgb`                 | <Ft f="etc2-rgb8unorm-srgb" />      | <L f="etc2-rgb8unorm-srgb" />      | <R f="etc2-rgb8unorm-srgb" />      | `GL.COMPRESSED_SRGB8_ETC2`                                                                                              |
 | `etc2-rgb8a1unorm`                    | <Ft f="etc2-rgb8a1unorm" />         | <L f="etc2-rgb8a1unorm" />         | <R f="etc2-rgb8a1unorm" />         | `GL.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2`                                                                           |
@@ -112,7 +112,7 @@ Note that even though a GPU supports creating and sampling textures of a certain
 | `eac-r11snorm`                        | <Ft f="eac-r11snorm" />             | <L f="eac-r11snorm" />             | <R f="eac-r11snorm" />             | `GL.COMPRESSED_SIGNED_R11_EAC`                                                                                          |
 | `eac-rg11unorm`                       | <Ft f="eac-rg11unorm" />            | <L f="eac-rg11unorm" />            | <R f="eac-rg11unorm" />            | `GL.COMPRESSED_RG11_EAC`                                                                                                |
 | `eac-rg11snorm`                       | <Ft f="eac-rg11snorm" />            | <L f="eac-rg11snorm" />            | <R f="eac-rg11snorm" />            | `GL.COMPRESSED_SIGNED_RG11_EAC`                                                                                         |
-| **`texture-compression-astc`**`       |                                     |                                    |                                    | X_ASTC compressed formats device.features.has                                                                           |
+| **`texture-compression-astc`**        |                                     |                                    |                                    | X_ASTC compressed formats device.features.has                                                                           |
 | `astc-4x4-unorm`                      | <Ft f="astc-4x4-unorm" />           | <L f="astc-4x4-unorm" />           | <R f="astc-4x4-unorm" />           | `GL.COMPRESSED_RGBA_ASTC_4x4_KHR`                                                                                       |
 | `astc-4x4-unorm-srgb`                 | <Ft f="astc-4x4-unorm-srgb" />      | <L f="astc-4x4-unorm-srgb" />      | <R f="astc-4x4-unorm-srgb" />      | `GL.COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR`                                                                               |
 | `astc-5x4-unorm`                      | <Ft f="astc-5x4-unorm" />           | <L f="astc-5x4-unorm" />           | <R f="astc-5x4-unorm" />           | `GL.COMPRESSED_RGBA_ASTC_5x4_KHR`                                                                                       |
@@ -262,7 +262,7 @@ and exactly the component types shown for that format, although it may not match
 
 Describes the layout of each color component in memory.
 
-| Value                               | WebGL 2 |
+| Value                               | WebGL 2 |                                                     |
 | ----------------------------------- | ------- | --------------------------------------------------- |
 | `GL.UNSIGNED_BYTE`                  | Yes     | GLbyte 8 bits per channel for `GL.RGBA`             |
 | `GL.UNSIGNED_SHORT_5_6_5`           | Yes     | 5 red bits, 6 green bits, 5 blue bits               |
@@ -274,7 +274,7 @@ Describes the layout of each color component in memory.
 | `GL.UNSIGNED_INT`                   | Yes     |                                                     |
 | `GL.INT`                            | Yes     |                                                     |
 | `GL.HALF_FLOAT`                     | Yes     |                                                     |
-| `GL.FLOAT`                          | Yes     |
+| `GL.FLOAT`                          | Yes     |                                                     |
 | `GL.UNSIGNED_INT_2_10_10_10_REV`    | Yes     |                                                     |
 | `GL.UNSIGNED_INT_10F_11F_11F_REV`   | Yes     |                                                     |
 | `GL.UNSIGNED_INT_5_9_9_9_REV`       | Yes     |                                                     |

--- a/docs/api-reference/engine/animation-loop.md
+++ b/docs/api-reference/engine/animation-loop.md
@@ -31,20 +31,19 @@ animationLoop.start({canvas: 'my-canvas'});
 
 ## Types
 
-
 ### AnimationLoopProps
 
-| Property                   | Type                        | Default | Description                                                                                                          |
-| -------------------------- | --------------------------- |
-| `device?`                  | `Device \| Promise<Device>` |         | the `Device` to render into.                                                                                         |
-| `onInitialize?`            | (callback)                  |         | Called once after the first call to `animationLoop.start()`. Use to create GPU resources                             |
-| `onRender?`                | (callback)                  |         | - Called on every animation frame. Use to render .                                                                   |
-| `onFinalize?`              | (callback)                  |         | - Called once when animation is stopped. Used to delete objects or free any resources created during `onInitialize?` |
-| `onError`                  | (callback)                  |         | - Called when an error is about to be thrown.                                                                        |
-| `autoResizeViewport?`      | `boolean`                   | `true`  | If true, auto resizes GPU viewport each frame before `onRender` is called.                                           |
-| `autoResizeDrawingBuffer?` | `boolean`                   | `true`  | If true, resizes the drawing buffer  each frame before `onRender` is called.                                         |
-| `useDevicePixels?`         | `boolean \| number`         |         | Multiplier. `true` uses `window.devicePixelRatio` as a multiplier in `autoResizeDrawingBuffer` etc.                  |
-| `stats?`                   | `Stats`                     |         | A probe.gl `Stats` instance, Auto-created if not supplied.                                                           |
+| Property                   | Type                           | Default | Description                                                                                                          |
+| -------------------------- | ------------------------------ | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| `device?`                  | `Device` \| `Promise<Device>`  |         | A `Device` to render into.                                                                                           |
+| `onInitialize?`            | (callback)                     |         | Called once after the first call to `animationLoop.start()`. Use to create GPU resources                             |
+| `onRender?`                | (callback)                     |         | - Called on every animation frame. Use to render .                                                                   |
+| `onFinalize?`              | (callback)                     |         | - Called once when animation is stopped. Used to delete objects or free any resources created during `onInitialize?` |
+| `onError`                  | (callback)                     |         | - Called when an error is about to be thrown.                                                                        |
+| `autoResizeViewport?`      | `boolean`                      | `true`  | If true, auto resizes GPU viewport each frame before `onRender` is called.                                           |
+| `autoResizeDrawingBuffer?` | `boolean`                      | `true`  | If true, resizes the drawing buffer  each frame before `onRender` is called.                                         |
+| `useDevicePixels?`         | `boolean \| number`            |         | Multiplier. `true` uses `window.devicePixelRatio` as a multiplier in `autoResizeDrawingBuffer` etc.                  |
+| `stats?`                   | `Stats`                        |         | A probe.gl `Stats` instance, Auto-created if not supplied.                                                           |
 
 ### AnimationProps
 
@@ -95,7 +94,7 @@ Restarts the animation
 animationLoop.start(options)
 ```
 
-- `options`=`{}` (object) - Options to create the WebGLContext with. 
+- `options`=`{}` (object) - Options to create the WebGLContext with.
 
 ### stop()
 
@@ -170,4 +169,4 @@ The callbacks `onInitialize`, `onRender` and `onFinalize` that the app supplies 
 - The supplied callback function must return a WebGLRenderingContext or an error will be thrown.
 - This callback registration function should not be called if a `WebGLRenderingContext` was supplied to the AnimationLoop constructor.
 - `useDevicePixels` can accept a custom ratio (Number), instead of `true` or `false`. This allows rendering to a much smaller or higher resolutions. When using high value (usually more than device pixel ratio), it is possible it can get clamped down, this happens due to system memory limitation, in such cases a warning will be logged to the browser console.
-- `onInitialize`` is called after page load completes and the passed in device promise has been resolved (the device has been created).                               
+- `onInitialize`` is called after page load completes and the passed in device promise has been resolved (the device has been created).

--- a/docs/api-reference/engine/transform/buffer-transform.md
+++ b/docs/api-reference/engine/transform/buffer-transform.md
@@ -6,9 +6,7 @@ NOTE: In following sections 'buffer transform' is used to refer to 'reading from
 
 ## Constructor
 
-```ts
 ### Transform(device: Device, props: Object)
-```
 
 - `gl` (`WebGLRenderingContext`) gl - context
 - `props` (`Object`, Optional) - contains following data.

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -78,11 +78,6 @@
       },
       {
         "type": "category",
-        "label": "@luma.gl/core",
-        "items": ["api-reference/core/README"]
-      },
-      {
-        "type": "category",
         "label": "@luma.gl/engine",
         "items": [
           "api-reference/engine/animation-loop",
@@ -106,9 +101,7 @@
       {
         "type": "category",
         "label": "@luma.gl/gltf",
-        "items": [
-          "api-reference/gltf/README"
-        ]
+        "items": ["api-reference/gltf/README"]
       },
       {
         "type": "category",
@@ -131,9 +124,7 @@
           {
             "type": "category",
             "label": "Shader Passes",
-            "items": [
-              "api-reference/shadertools/shader-passes/image-processing"
-            ]
+            "items": ["api-reference/shadertools/shader-passes/image-processing"]
           },
           "api-reference/shadertools/README",
           "api-reference/shadertools/shader-assembler",
@@ -176,10 +167,6 @@
   {
     "type": "category",
     "label": "Upgrade Guide",
-    "items": [
-      "upgrade-guide/README",
-      "upgrade-guide/porting-guide",
-      "upgrade-guide/legacy-guide"
-    ]
+    "items": ["upgrade-guide/README", "upgrade-guide/porting-guide", "upgrade-guide/legacy-guide"]
   }
 ]

--- a/docs/upgrade-guide/README.md
+++ b/docs/upgrade-guide/README.md
@@ -3,20 +3,20 @@
 This upgrade guide lists breaking changes in the luma.gl API, and provides information on how to update applications.
 
 :::info
-This page covers luma.gl v9 and later releases. For information on upgrading to v8 and earlier releases, see our [Legacy Upgrade Guide](/docs/upgrade-guide/legacy-guide). 
+This page covers luma.gl v9 and later releases. For information on upgrading to v8 and earlier releases, see our [Legacy Upgrade Guide](/docs/upgrade-guide/legacy-guide).
 :::
 
 ## Conventions
 
-- **semantic versioning** - luma.gl follows [SEMVER](https://semver.org) conventions. This means that breaking changes are only done in major versions, minor version bumps bring new functionality but no breaking changes, and patch releases typically contain only low-risk fixes. 
+- **semantic versioning** - luma.gl follows [SEMVER](https://semver.org) conventions. This means that breaking changes are only done in major versions, minor version bumps bring new functionality but no breaking changes, and patch releases typically contain only low-risk fixes.
 - **sequential upgrades** - Upgrade instructions assume that you are upgrading from the immediately previous release.
 If you are upgrading across multiple releases you will want to consider the release notes for all
 intermediary releases.
 
 ## Upgrading to v9.0
 
-luma.gl v9 is a major modernization of the luma.gl API, so the upgrade notes for this release are unusually long. 
-This page primarily contains a reference list of API changes. To facilitate porting to the v9 release we have also provided a 
+luma.gl v9 is a major modernization of the luma.gl API, so the upgrade notes for this release are unusually long.
+This page primarily contains a reference list of API changes. To facilitate porting to the v9 release we have also provided a
 [Porting Guide](/docs/upgrade-guide/porting-guide) that provides more background information and recommended porting strategies.
 
 ### Non-API changes
@@ -46,13 +46,13 @@ luma.gl v9 upgrades tooling and packaging to latest JavaScript ecosystem standar
 
 - The engine module is largely unchanged in that it provides the same classes as before.
 
-**`@luma.gl/webgl`** 
+**`@luma.gl/webgl`**
 
 - While the webgl module still contains the WebGL 2 classes, these classes can no longer be imported directly. Instead the application should use `Device` create methods (`device.createBuffer()`, `device.createTexture()` etc to create these ojects in a portable way).
 
 **`@luma.gl/constants`** (INTERNAL)
 
-- The constant module remains but is now considered an internal luma.gl module, and is no longer intended to be imported by applications. 
+- The constant module remains but is now considered an internal luma.gl module, and is no longer intended to be imported by applications.
 - In the external API, all WebGL-style numeric constants (`GL.` constants) have been replaced with strictly typed WebGPU style string constants.
 
 **`@luma.gl/debug`** (REMOVED)
@@ -83,7 +83,7 @@ The debug module has been removed. Debug functionality is now built-in (and dyna
 
 ### `luma.gl/core` / `@luma.gl/webgl`
 
-The core module was re-exporting the webgl classes. 
+The core module was re-exporting the webgl classes.
 
 A long list of changes, some required to make the API portable between WebGPU and WebGL, and many to accommodate the limitations of the more locked-down WebGPU API.
 
@@ -93,7 +93,7 @@ A long list of changes, some required to make the API portable between WebGPU an
 | `Program`               | `RenderPipeline`             | WebGPU alignment                                                                                                                                     |
 
 **`@luma.gl/gltools`** (removed)
-    
+
 The WebGL context functions from `@luma.gl/gltools`(`createGLContext` etc), have been replaced by methods on to the new `Device` and `CanvasContext` classes.
 
 The v8 luma.gl API was designed to allow apps to work directly with the `WebGLRenderingContext` object. v9 enables applications to work portably with both WebGPU and WebGL, and accordingly it wraps the WebGL context in a `Device` instance.
@@ -257,10 +257,10 @@ TODO - this section needs updating
 
 After the fragment shader runs, optional stencil tests are performed, with resulting operations on the the stencil buffer.
 
-| V8/WebGL Function           | Description                            | Values                         |
+| V8/WebGL Function           | Description                            | Values                         |                  |
 | --------------------------- | -------------------------------------- | ------------------------------ | ---------------- |
 | **Stencil Parameters**      |
-| `stencilReadMask`           | Binary mask for reading stencil values | `number` (**`0xffffffff`**)    |
+| `stencilReadMask`           | Binary mask for reading stencil values | `number` (**`0xffffffff`**)    |                  |
 | `stencilWriteMask`          | Binary mask for writing stencil values | `number` (**`0xffffffff`**)    | `gl.frontFace`   |
 | `stencilCompare`            | How the mask is compared               | **`always`**, `not-equal`, ... | `gl.stencilFunc` |
 | `stencilPassOperation`      |                                        | **`'keep'`**                   | `gl.stencilOp`   |
@@ -324,7 +324,7 @@ Remarks:
 
 | Function                                                                                        | Sets parameters      |
 | ----------------------------------------------------------------------------------------------- | -------------------- |
-| [clearColor][https]//developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/clearColor) | GL.COLOR_CLEAR_VALUE |
+| [clearColor](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/clearColor) | GL.COLOR_CLEAR_VALUE |
 
 | Parameter              | Type                | Default      | Description |
 | ---------------------- | ------------------- | ------------ | ----------- |
@@ -496,5 +496,3 @@ const value = model.setParameters({
 | `GL.BLEND_SRC_ALPHA`      | GLenum          | `GL.ZERO`      | srcAlpha         |
 | `GL.BLEND_DST_RGB`        | GLenum          | `GL.ONE`       | dstRgb           |
 | `GL.BLEND_DST_ALPHA`      | GLenum          | `GL.ZERO`      | dstAlpha         |
-
-


### PR DESCRIPTION
Formatting, broken link, and typo corrections made by me. Whitespace changes made by Prettier. 