### PR TITLE
chore: expose webgl-only functions on device

### DIFF
--- a/examples/showcase/instancing/app.ts
+++ b/examples/showcase/instancing/app.ts
@@ -3,7 +3,6 @@ import type {ShaderUniformType, NumberArray} from '@luma.gl/core';
 import {Device, Framebuffer, makeRandomNumberGenerator, glsl} from '@luma.gl/core';
 import type {AnimationProps, ModelProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, CubeGeometry, Timeline, Model, _ShaderInputs} from '@luma.gl/engine';
-import {readPixelsToArray} from '@luma.gl/webgl';
 import {picking, dirlight} from '@luma.gl/shadertools';
 import {Matrix4, radians} from '@math.gl/core';
 
@@ -366,7 +365,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     pickingPass.end();
 
     // Read back
-    const color255 = readPixelsToArray(framebuffer, {
+    const color255 = framebuffer.device.readPixelsToArrayWebGL(framebuffer, {
       sourceX: pickX,
       sourceY: pickY,
       sourceWidth: 1,

--- a/modules/core-tests/test/adapter/device-helpers/set-device-parameters.spec.ts
+++ b/modules/core-tests/test/adapter/device-helpers/set-device-parameters.spec.ts
@@ -2,8 +2,8 @@ import test, {Test} from 'tape-promise/tape';
 import {webgl1Device, webgl2Device} from '@luma.gl/test-utils';
 
 import {Parameters} from '@luma.gl/core';
-import {GL} from '@luma.gl/constants';
-import {setDeviceParameters, GLParameters, getGLParameters, resetGLParameters} from '@luma.gl/webgl';
+import {GL, GLParameters} from '@luma.gl/constants';
+import {setDeviceParameters, getGLParameters, resetGLParameters} from '@luma.gl/webgl';
 
 // import {createTestDevice} from '@luma.gl/test-utils';
 // const webgl1Device = createTestDevice({debug: true, webgl2: false});

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -355,7 +355,8 @@ export abstract class Device {
     throw new Error('not implemented');
   }
 
-  // HACKS - until we have a better way to handle these
+  // WebGL specific HACKS - enables app to remove webgl import
+  // Use until we have a better way to handle these
 
   /** @deprecated - will be removed - should use command encoder */
   readPixelsToArrayWebGL(
@@ -390,6 +391,21 @@ export abstract class Device {
       sourceType?: number;
     }
   ): Buffer {
+    throw new Error('not implemented');
+  }
+
+  /** @deprecated - will be removed - should use WebGPU parameters (pipeline) */
+  setParametersWebGL(parameters: any): void {
+    throw new Error('not implemented');
+  }
+
+  /** @deprecated - will be removed - should use WebGPU parameters (pipeline) */
+  withParametersWebGL(parameters: any, func: any): any {
+    throw new Error('not implemented');
+  }
+
+  /** @deprecated - will be removed - should use clear arguments in RenderPass */
+  clearWebGL(options?: {framebuffer?: Framebuffer; color?: any; depth?: any; stencil?: any}): void {
     throw new Error('not implemented');
   }
 

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -28,6 +28,7 @@ import {
   createHeadlessContext,
   isHeadlessGLRegistered
 } from '../context/context/create-headless-context';
+
 import {getDeviceInfo} from './device-helpers/get-device-info';
 import {getDeviceFeatures} from './device-helpers/device-features';
 import {getDeviceLimits, getWebGLLimits, WebGLLimits} from './device-helpers/device-limits';
@@ -75,6 +76,9 @@ import {WEBGLVertexArray} from './resources/webgl-vertex-array';
 import {WEBGLTransformFeedback} from './resources/webgl-transform-feedback';
 
 import {readPixelsToArray, readPixelsToBuffer} from '../classic/copy-and-blit';
+import {setGLParameters} from '../context/parameters/unified-parameter-api';
+import {withGLParameters} from '../context/state-tracker/with-parameters';
+import {clear} from '../classic/clear';
 
 const LOG_LEVEL = 1;
 
@@ -422,6 +426,18 @@ ${device.info.vendor}, ${device.info.renderer} for canvas: ${device.canvasContex
     return readPixelsToBuffer(source, options);
   }
 
+  override setParametersWebGL(parameters: any): void {
+    setGLParameters(this, parameters);
+  }
+
+  override withParametersWebGL(parameters: any, func: any): any {
+    withGLParameters(this, parameters, func);
+  }
+
+  override clearWebGL(options?: {framebuffer?: Framebuffer; color?: any; depth?: any; stencil?: any}): void {
+    clear(this, options);
+  }
+  
   //
   // WebGL-only API (not part of `Device` API)
   //

--- a/modules/webgl/src/index.ts
+++ b/modules/webgl/src/index.ts
@@ -36,7 +36,7 @@ export {WEBGLVertexArray} from './adapter/resources/webgl-vertex-array';
 export type {RenderbufferProps} from './adapter/objects/webgl-renderbuffer';
 export {WEBGLRenderbuffer} from './adapter/objects/webgl-renderbuffer';
 
-// WebGL adapter classes 
+// WebGL adapter classes
 export {WEBGLTransformFeedback} from './adapter/resources/webgl-transform-feedback';
 
 // WebGL adapter classes
@@ -55,15 +55,6 @@ export {
 
 export {setDeviceParameters, withDeviceParameters} from './adapter/converters/device-parameters';
 
-export type {GLParameters} from '@luma.gl/constants';
-export {
-  getGLParameters,
-  setGLParameters,
-  resetGLParameters
-} from './context/parameters/unified-parameter-api';
-
-export {withGLParameters} from './context/state-tracker/with-parameters';
-
 // HELPERS - EXPERIMENTAL
 export {getShaderLayout} from './adapter/helpers/get-shader-layout';
 export {
@@ -74,9 +65,7 @@ export {
 // TEST EXPORTS
 export {TEXTURE_FORMATS as _TEXTURE_FORMATS} from './adapter/converters/texture-formats';
 
-// DEPRECATED EXPORTS
-export {clear} from './classic/clear';
-export {readPixelsToBuffer, readPixelsToArray, copyToTexture} from './classic/copy-and-blit';
+// DEPRECATED TEST EXPORTS
 // State tracking
 export {
   trackContextState,
@@ -86,25 +75,10 @@ export {
 // Polyfills (supports a subset of WebGL2 APIs on WebGL1 contexts)
 export {polyfillContext} from './context/polyfill/polyfill-context';
 
-// HELPERS - EXPERIMENTAL
-// export {getShaderLayout, getProgramBindings} from './adapter/helpers/get-shader-layout';
-// export {convertGLToTextureFormat, _checkFloat32ColorAttachment} from './adapter/converters/texture-formats';
-// export {TEXTURE_FORMATS as _TEXTURE_FORMATS} from './adapter/converters/texture-formats';
+export {
+  resetGLParameters,
+  setGLParameters,
+  getGLParameters
+} from './context/parameters/unified-parameter-api';
 
-// // WebGL Types - Experimental exports
-// export type {
-//   GLDrawMode,
-//   GLPrimitive,
-//   GLDataType,
-//   GLPixelType,
-//   GLUniformType,
-//   GLSamplerType,
-//   GLCompositeType,
-//   GLFunction,
-//   GLBlendEquation,
-//   GLBlendFunction,
-//   GLStencilOp,
-//   GLSamplerParameters,
-//   GLValueParameters,
-//   GLFunctionParameters
-// } from '@luma.gl/constants';
+export {withGLParameters} from './context/state-tracker/with-parameters';

--- a/modules/webgl/test/adapter/device-helpers/set-device-parameters.spec.ts
+++ b/modules/webgl/test/adapter/device-helpers/set-device-parameters.spec.ts
@@ -4,8 +4,8 @@
 import test from 'tape-promise/tape';
 import {webgl1Device, webgl2Device} from '@luma.gl/test-utils';
 
-import {GL} from '@luma.gl/constants';
-import {setDeviceParameters, GLParameters, getGLParameters, resetGLParameters} from '@luma.gl/webgl';
+import {GL, GLParameters} from '@luma.gl/constants';
+import {setDeviceParameters, getGLParameters, resetGLParameters} from '@luma.gl/webgl';
 
 // Settings test, could be beneficial to not reuse a context
 const fixture = {

--- a/modules/webgl/test/context/state-tracker/context-state.spec.ts
+++ b/modules/webgl/test/context/state-tracker/context-state.spec.ts
@@ -4,10 +4,10 @@
 import test from 'tape-promise/tape';
 import {webgl1Device, webgl2Device} from '@luma.gl/test-utils';
 
+import type {GLParameters} from '@luma.gl/constants';
 import {GL} from '@luma.gl/constants';
 
 import type {TypedArray} from '@luma.gl/core'
-import type {GLParameters} from '@luma.gl/webgl';
 import {getGLParameters, setGLParameters, resetGLParameters, withGLParameters} from '@luma.gl/webgl';
 
 import {GL_PARAMETER_DEFAULTS as GL_PARAMETERS} from '@luma.gl/webgl/context/parameters/webgl-parameter-tables';

--- a/modules/webgl/test/context/state-tracker/data/sample-enum-settings.ts
+++ b/modules/webgl/test/context/state-tracker/data/sample-enum-settings.ts
@@ -1,8 +1,8 @@
 // luma.gl, MIT license
 // Copyright (c) vis.gl contributors
 
+import type {GLParameters} from '@luma.gl/constants';
 import {GL} from '@luma.gl/constants';
-import {GLParameters} from '@luma.gl/webgl';
 
 // NOTE: These settings should be in sync with FUNCTION_STYLE_SETTINGS_SET1
 export const ENUM_STYLE_SETTINGS_SET1_PRIMITIVE: GLParameters = {

--- a/modules/webgl/test/context/state-tracker/data/sample-function-settings.ts
+++ b/modules/webgl/test/context/state-tracker/data/sample-function-settings.ts
@@ -1,5 +1,5 @@
+import type {GLParameters} from '@luma.gl/constants';
 import {GL} from '@luma.gl/constants';
-import type {GLParameters} from '@luma.gl/webgl';
 
 // NOTE: These settings are same as ENUM_STYLE_SETTINGS_SET1
 // In unit tests for bellow settings, we use ENUM_STYLE_SETTINGS_SET1


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1501 
<!-- For other PRs without open issue -->
#### Background
- deck.gl still uses some webgl module methods, which forces it to import the webgl module
#### Change List
- Expose the required methods on the Device (for now)
- `device.setGLParameters(), `device.withGLParameters()`, `device.clear()`

