### PR TITLE
feat(engine): Add ShaderFactory utility and caching

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,6 +16,7 @@ test
 !modules/core/src/adapter/types/shader-layout.ts
 !modules/core/src/index.ts
 !modules/engine/src/model/model.ts
+!modules/engine/src/lib/shader-factory.ts
 !modules/webgl/src/adapter/resources/webgl-buffer.ts
 !modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
 !modules/webgl/src/adapter/resources/webgl-transform-feedback.ts

--- a/docs/api-reference/engine/shader-factory.md
+++ b/docs/api-reference/engine/shader-factory.md
@@ -1,0 +1,68 @@
+# ShaderFactory
+
+The `ShaderFactory` class provides a `createShader()` method that caches and reuses `Shader` resources.
+
+Compiling shaders is costly, and may block the render pipeline on some devices. Using a shader factory allows applications to more easily consolidate shaders with identical properties, minimizing the amount of time spent compiling shaders.
+
+The `ShaderFactory` will return the requested shader, creating it the first time, and then re-using a cached version if it is requested more than once. An application that tends to create multiple identical `Shader` instances should consider replacing calls to `device.createShader(...)` with calls to `shaderFactory.createShader(...)`.
+
+It is possible to create multiple shader factories, but normally applications rely on the default factory that is created for each device.
+
+## Usage
+
+An application that tends to create multiple identical `Shader` instances
+should consider replacing calls to `device.createShader(...)` with calls to `shaderFactory.createShader(...)`.
+
+To deduplicate `Shader` instances, simply replace existing shader creation
+
+```typescript
+const shader = device.createShader({stage: 'vertex', source: '...'}));
+```
+
+with similar calls to the default shader factory
+
+```typescript
+import {ShaderFactory} from '@luma.gl/engine';
+const shaderFactory = ShaderFactory.getDefaultShaderFactory(device);
+const shader = shaderFactory.createShader({stage: 'vertex', source: '...'});
+```
+
+To prevent the cache from growing too big, an optional `release()` method is also available.
+
+```typescript
+shaderFactory.release(shader);
+```
+
+Shaders are destroyed by the factory automatically after all users of the shader have released their references. To clean up unused shaders and avoid memory leaks, every call to `createShader` must be paired with a corresponding call to `release` at some later time.
+
+## Static Methods
+
+### ShaderFactory.getDefaultShaderFactory()
+
+Returns the default shader factory for a device.
+
+```typescript
+ShaderFactory.getDefaultShaderFactory(device: Device): ShaderFactory
+```
+
+While it is possible to create multiple factories, most applications will use the default factory.
+
+## Methods
+
+### createShader()
+
+Returns a `Shader` configured with the properties specified.
+
+```typescript
+createShader(props: ShaderProps): Shader
+```
+
+If one is already cached, return it, otherwise create and cache a new one.
+
+### release()
+
+```typescript
+release(shader: Shader): void
+```
+
+Indicates that a shader is no longer in use. Each call to `createShader()` increments a reference count, and only when all references to a shader are released, the shader is destroyed and deleted from the cache.

--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -108,6 +108,7 @@
           "api-reference/engine/geometry/geometry",
           "api-reference/engine/model",
           "api-reference/engine/pipeline-factory",
+          "api-reference/engine/shader-factory",
           "api-reference/engine/transform",
           "api-reference/engine/transform/buffer-transform",
           "api-reference/engine/transform/texture-transform",

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -42,8 +42,9 @@ New features
 **`@luma.gl/engine`**
 
 - NEW: Scenegraph classes: `ModelNode`, `GroupNode`, `ScenegraphNode`. (Moved from `@luma.gl/experimental`).
-- NEW: `ShaderInputs` - A class that manages uniform buffers for a `Model`
-- NEW: `AnimationLoopTemplate` - a small helper class that can help write cleaner demos and applications in TypeScript.
+- NEW: `ShaderInputs` - Class that manages uniform buffers for a `Model`
+- NEW: `ShaderFactory` - Creates and caches reusable `Shader` resources
+- NEW: `AnimationLoopTemplate` - Small helper class that can help write cleaner demos and applications in TypeScript.
 
 **`@luma.gl/gltf`**
 

--- a/modules/engine/src/index.ts
+++ b/modules/engine/src/index.ts
@@ -23,6 +23,7 @@ export type {TextureTransformProps} from './transform/texture-transform';
 export {TextureTransform} from './transform/texture-transform';
 
 export {PipelineFactory} from './lib/pipeline-factory';
+export {ShaderFactory} from './lib/shader-factory';
 
 // Utils
 export {ClipSpace} from './lib/clip-space';

--- a/modules/engine/src/lib/shader-factory.ts
+++ b/modules/engine/src/lib/shader-factory.ts
@@ -1,0 +1,52 @@
+import {Device, Shader, ShaderProps} from '@luma.gl/core';
+
+/** Manages a cached pool of Shaders for reuse. */
+export class ShaderFactory {
+  static readonly defaultProps: Required<ShaderProps> = {...Shader.defaultProps};
+
+  public readonly device: Device;
+
+  private readonly _shaderCache: Record<string, Shader> = {};
+  private readonly _useCounts: Record<string, number> = {};
+
+  /** Returns the default ShaderFactory for the given {@link Device}, creating one if necessary. */
+  static getDefaultShaderFactory(device: Device): ShaderFactory {
+    device._lumaData.defaultShaderFactory =
+      device._lumaData.defaultShaderFactory || new ShaderFactory(device);
+    return device._lumaData.defaultShaderFactory as ShaderFactory;
+  }
+
+  /** @internal */
+  constructor(device: Device) {
+    this.device = device;
+  }
+
+  /** Requests a {@link Shader} from the cache, creating a new Shader only if necessary. */
+  createShader(props: ShaderProps): Shader {
+    const key = this._hashShader(props);
+    if (!this._shaderCache[key]) {
+      this._shaderCache[key] = this.device.createShader(props);
+      this._useCounts[key] = 0;
+    }
+    this._useCounts[key]++;
+    return this._shaderCache[key];
+  }
+
+  /** Releases a previously-requested {@link Shader}, destroying it if no users remain. */
+  release(shader: Shader): void {
+    const key = this._hashShader(shader);
+    this._useCounts[key]--;
+    if (this._useCounts[key] === 0) {
+      const shader = this._shaderCache[key];
+      delete this._shaderCache[key];
+      delete this._useCounts[key];
+      shader.destroy();
+    }
+  }
+
+  // PRIVATE
+
+  private _hashShader(value: Shader | ShaderProps): string {
+    return `${value.stage}:${value.source}`;
+  }
+}

--- a/modules/engine/src/lib/shader-factory.ts
+++ b/modules/engine/src/lib/shader-factory.ts
@@ -11,8 +11,7 @@ export class ShaderFactory {
 
   /** Returns the default ShaderFactory for the given {@link Device}, creating one if necessary. */
   static getDefaultShaderFactory(device: Device): ShaderFactory {
-    device._lumaData.defaultShaderFactory =
-      device._lumaData.defaultShaderFactory || new ShaderFactory(device);
+    device._lumaData.defaultShaderFactory ||= new ShaderFactory(device);
     return device._lumaData.defaultShaderFactory as ShaderFactory;
   }
 

--- a/modules/engine/src/lib/shader-factory.ts
+++ b/modules/engine/src/lib/shader-factory.ts
@@ -25,7 +25,11 @@ export class ShaderFactory {
 
     let cacheEntry = this._cache[key];
     if (!cacheEntry) {
-      this._cache[key] = cacheEntry = {shader: this.device.createShader(props), useCount: 0};
+      const shader = this.device.createShader({
+        ...props,
+        id: props.id ? `${props.id}-cached` : undefined
+      });
+      this._cache[key] = cacheEntry = {shader, useCount: 0};
     }
 
     cacheEntry.useCount++;

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -597,10 +597,10 @@ export class Model {
 
       const fs = this.fs
         ? this.shaderFactory.createShader({
-            id: `${this.id}-fragment`,
-            stage: 'fragment',
-            source: this.fs
-          })
+          id: `${this.id}-fragment`,
+          stage: 'fragment',
+          source: this.fs
+        })
         : null;
 
       this.pipeline = this.pipelineFactory.createRenderPipeline({

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -231,7 +231,7 @@ export class Model {
 
     this.pipelineFactory =
       props.pipelineFactory || PipelineFactory.getDefaultPipelineFactory(this.device);
-    this.shaderFactory = props.shaderFactory || ShaderFactory.getDefaultShaderFactory(this.device);
+    this.shaderFactory ||= ShaderFactory.getDefaultShaderFactory(this.device);
 
     // Create the pipeline
     // @note order is important
@@ -578,7 +578,7 @@ export class Model {
 
   _updatePipeline(): RenderPipeline {
     if (this._pipelineNeedsUpdate) {
-      const prevShaders = [] as Shader[];
+      const prevShaders: Shader[] = [];
       if (this.pipeline) {
         log.log(
           1,

--- a/modules/engine/test/index.ts
+++ b/modules/engine/test/index.ts
@@ -1,6 +1,7 @@
 // import './lib/model.spec';
 import './lib/animation-loop.spec';
 import './lib/pipeline-factory.spec';
+import './lib/shader-factory.spec';
 
 import './geometry/geometries.spec';
 import './geometry/geometry.spec';

--- a/modules/engine/test/lib/shader-factory.spec.ts
+++ b/modules/engine/test/lib/shader-factory.spec.ts
@@ -1,0 +1,76 @@
+import test from 'tape-promise/tape';
+import {webglDevice} from '@luma.gl/test-utils';
+
+import {glsl} from '@luma.gl/core';
+import {ShaderFactory} from '@luma.gl/engine';
+
+const vs1 = glsl`\
+void main(void) {
+  gl_Position = vec4(0.0, 0.0, 0.0, 0.0);
+}
+`;
+
+const vs2 = glsl`\
+void main(void) {
+  gl_Position = vec4(10.0, 10.0, 10.0, 10.0);
+}
+`;
+
+test('ShaderFactory#import', t => {
+  t.ok(ShaderFactory !== undefined, 'ShaderFactory import successful');
+  t.end();
+});
+
+test('ShaderFactory#getDefaultShaderFactory', t => {
+  const factory1 = ShaderFactory.getDefaultShaderFactory(webglDevice);
+  const factory2 = ShaderFactory.getDefaultShaderFactory(webglDevice);
+
+  t.ok(factory1 instanceof ShaderFactory, 'Default pipeline manager created');
+  t.isEqual(factory1, factory2, 'Default pipeline manager cached');
+
+  t.end();
+});
+
+test('ShaderFactory#createShader', t => {
+  const factory = ShaderFactory.getDefaultShaderFactory(webglDevice);
+  const shader1 = factory.createShader({id: '1', stage: 'vertex', source: vs1});
+  const shader2 = factory.createShader({id: '2', stage: 'vertex', source: vs1});
+  const shader3 = factory.createShader({id: '3', stage: 'vertex', source: vs2});
+
+  t.isEqual(shader1, shader2, 'Caches identical shaders');
+  t.notEqual(shader1, shader3, 'Does not cache non-identical shaders');
+
+  t.isEqual(shader1.id, '1-cached', 'Annotates IDs of cached shaders');
+  t.isEqual(shader2.id, '1-cached', 'Annotates IDs of cached shaders');
+  t.isEqual(shader3.id, '3-cached', 'Annotates IDs of cached shaders');
+
+  factory.release(shader1);
+  factory.release(shader2);
+  factory.release(shader3);
+
+  t.end();
+});
+
+test('ShaderFactory#release', t => {
+  const factory = new ShaderFactory(webglDevice);
+  const shader1 = factory.createShader({id: '1', stage: 'vertex', source: vs1});
+  const shader2 = factory.createShader({id: '2', stage: 'vertex', source: vs1});
+  const shader3 = factory.createShader({id: '3', stage: 'vertex', source: vs2});
+
+  factory.release(shader2);
+  factory.release(shader3);
+  t.deepEqual(
+    [shader1.destroyed, shader2.destroyed, shader3.destroyed],
+    [false, false, true],
+    'Keeps used shaders'
+  );
+
+  factory.release(shader1);
+  t.deepEqual(
+    [shader1.destroyed, shader2.destroyed, shader3.destroyed],
+    [true, true, true],
+    'Destroys unused shaders'
+  );
+
+  t.end();
+});

--- a/modules/engine/test/lib/shader-factory.spec.ts
+++ b/modules/engine/test/lib/shader-factory.spec.ts
@@ -40,9 +40,11 @@ test('ShaderFactory#createShader', t => {
   t.isEqual(shader1, shader2, 'Caches identical shaders');
   t.notEqual(shader1, shader3, 'Does not cache non-identical shaders');
 
-  t.isEqual(shader1.id, '1-cached', 'Annotates IDs of cached shaders');
-  t.isEqual(shader2.id, '1-cached', 'Annotates IDs of cached shaders');
-  t.isEqual(shader3.id, '3-cached', 'Annotates IDs of cached shaders');
+  t.deepEqual(
+    [shader1.id, shader2.id, shader3.id],
+    ['1-cached', '1-cached', '3-cached'],
+    'Annotates IDs of cached shaders'
+  );
 
   factory.release(shader1);
   factory.release(shader2);


### PR DESCRIPTION
Adds a `ShaderFactory` utility, similar to PipelineFactory, for caching and reusing Shader instances. Upstream in DeckGL, each tile currently creates a model, and each model creates a RenderPipeline and two Shader instances. With these changes, the models reuse cached RenderPipeline and Shader instances where possible.

The before/after images below show performance profiles running while animating the map from point A to point B.

### Before

![Screenshot 2024-02-20 at 3 55 52 PM](https://github.com/visgl/deck.gl/assets/1848368/d9b97763-bd98-464b-9ffd-821f34fd5511)

### After

![after](https://github.com/visgl/luma.gl/assets/1848368/529b8820-54cd-4f1a-aaef-ee0e76a3ba8d)



### Related

- Fixes https://github.com/visgl/deck.gl/issues/8458#issuecomment-1955087738