### PR TITLE
feat(engine): Use PipelineFactory in Model

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -571,7 +571,7 @@ export class Model {
           `Model ${this.id}: Recreating pipeline because "${this._pipelineNeedsUpdate}".`
         )();
       }
-      
+
       this._pipelineNeedsUpdate = false;
 
       const vs = this.device.createShader({
@@ -588,7 +588,7 @@ export class Model {
         })
         : null;
 
-      this.pipeline = this.device.createRenderPipeline({
+      this.pipeline = this.pipelineFactory.createRenderPipeline({
         ...this.props,
         bufferLayout: this.bufferLayout,
         topology: this.topology,

--- a/modules/engine/test/lib/pipeline-factory.spec.ts
+++ b/modules/engine/test/lib/pipeline-factory.spec.ts
@@ -7,14 +7,14 @@ import {PipelineFactory} from '@luma.gl/engine';
 
 // TODO - this doesn't test that parameters etc are properly cached
 
-const vs = glsl`\
+const vsSource = glsl`\
 attribute vec4 positions;
 
 void main(void) {
   gl_Position = positions;
 }
 `;
-const fs = glsl`\
+const fsSource = glsl`\
 precision highp float;
 
 void main(void) {
@@ -40,6 +40,8 @@ test('PipelineFactory#getDefaultPipelineFactory', (t) => {
 test('PipelineFactory#release', (t) => {
   const pipelineFactory = new PipelineFactory(webglDevice);
 
+  const vs = webglDevice.createShader({stage: 'vertex', source: vsSource});
+  const fs = webglDevice.createShader({stage: 'fragment', source: fsSource});
   const pipeline1 = pipelineFactory.createRenderPipeline({vs, fs, topology: 'triangle-list'});
   const pipeline2 = pipelineFactory.createRenderPipeline({vs, fs, topology: 'triangle-list'});
 


### PR DESCRIPTION
Related to https://github.com/visgl/deck.gl/issues/8458. Uses a PipelineFactory when models create new render pipelines. On its own this PR does not address the performance issue in deckgl, but should be done anyway. Further changes in #1950 and/or #1952 will address the performance.