### PR TITLE
feat(webgl): Show translated shader source

### DIFF
--- a/docs/api-reference/core/resources/shader.md
+++ b/docs/api-reference/core/resources/shader.md
@@ -20,14 +20,15 @@ const fs = device.createShader({stage: 'fragment', source});
 
 Properties for a Shader
 
-| Field         | Type                                | Description                           |
-| ------------- | ----------------------------------- | ------------------------------------- |
-| `id`          | `string`                            | name/identifier (for debugging)       |
-| `stage`       | 'vertex' \| 'fragment' \| 'compute' | Required by WebGL and GLSL transpiler |
-| `source`      | `string`                            | Shader source code                    |
-| `sourceMap?`  | `string`                            | WebGPU only                           |
-| `language?`   | 'glsl' \| 'wgsl'                    | wgsl in WebGPU only                   |
-| `entryPoint?` | `string`                            | WGSL only, name of main function     |
+| Field         | Type                                                   | Description                                    |
+| ------------- | ------------------------------------------------------ | ---------------------------------------------- |
+| `id`          | `string`                                               | name/identifier (for debugging)                |
+| `stage`       | 'vertex' \| 'fragment' \| 'compute'                    | Required by WebGL and GLSL transpiler          |
+| `source`      | `string`                                               | Shader source code                             |
+| `sourceMap?`  | `string`                                               | WebGPU only                                    |
+| `language?`   | 'glsl' \| 'wgsl'                                       | wgsl in WebGPU only                            |
+| `entryPoint?` | `string`                                               | WGSL only, name of main function               |
+| `debug`       | `'error'` (default) `'never' \| 'warnings' \| 'always` | Will show a popup in the canvas with error log |
 
 ## Members
 
@@ -47,7 +48,21 @@ Free up any GPU resources associated with this shader immediately (instead of wa
 
 ### `getInfoLog(): Promise<CompilerMessage[]>`
 
+Returns an array of CompilerMessage entries containing errors and warnings from the compilation.
+
+### `getTranslatedSource(): string | null`
+
+On some WebGL 2 systems, it is possible to query the translated shader source in the host platform's native language (HLSL, GLSL, and even GLSL ES).
+
+### `debugShader(trigger?: `'error' | 'never' | 'warnings' | 'always'`): void`
+
+Shows the shader log in a popup in the canvas if the debug condition is met `'error' |\ 'never' \| 'warnings' \| 'always'`.
+Shows errors inline with the source code. If translated source is available (`getTranslatedSource()`), shows the translated source after the original source.
+Note that translated source is only available if shader compilation succeeds.
 
 ## Remarks
 
 - Shader compilation is fairly fast, in particular compared to Pipeline linking.
+- In WebGL, checking for shader compile status and pipeline link status is expensive as it forces a GPU sync.
+- Therefore checking is not done unless `luma.log.level > 0`. If your program fails to render, please increase the level.
+- If the `shader-async-status-webgl` feature is available, WebGL will use async shader compilation and pipeline linking.

--- a/docs/api-reference/engine/model.md
+++ b/docs/api-reference/engine/model.md
@@ -10,9 +10,7 @@ The `Model` class is the centerpiece of the luma.gl API. It brings together all 
 - **shader transpilation****
 - **debugging** - Detailed debug logging of draw calls
 
-
 The `Model` class integrates with the `@luma.gl/shadertools` shader module system: [see `Shader Assembly`]( /docs/api-reference/shadertools/shader-assembler).
-
 
  (Accepts a [`Mesh`] or a [`Geometry`](/docs/- - api-reference/engine/geometry) instance, plus any additional attributes for instanced rendering)
 
@@ -55,13 +53,11 @@ const model = new Model(device, {
   },
   uniforms: {uSampler: texture},
 })
-
 ```
-
 
 On each frame, call the `model.draw()` function after updating any uniforms (typically matrices).
 
-```
+```ts
 model.setUniforms({
   uPMatrix: currentProjectionMatrix,
   uMVMatrix: current ModelViewMatrix
@@ -69,41 +65,49 @@ model.setUniforms({
 model.draw();
 ```
 
+Debug shader source (even when shader successful)
+```ts
+// construct the model.
+const model = new Model(device, {
+  vs: VERTEX_SHADER,
+  fs: FRAGMENT_SHADER,
+  debugShaders: true
+});
+```
 
 ## Types
 
 ### ModelProps
 
-| Property             | Type                 | Description                                                                                                                    |
-| -------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `vs`                 | `Shader` \| _string_ | A vertex shader object, or source as a string.                                                                                 |
-| `fs`                 | `Shader` \| _string_ | A fragment shader object, or source as a string.                                                                               |
-| `modules`            |                      | shader modules to be applied (shadertools).                                                                                    |
-| `programManager`     |                      | `ProgramManager` to use for program creation and caching.                                                                      |
-| `varyings`           | (WebGL 2)            | An array of vertex shader output variables, that needs to be recorded (used in TransformFeedback flow).                        |
-| `bufferMode`         | (WebGL 2)            | Mode to be used when recording vertex shader outputs (used in TransformFeedback flow). |
+| Property           | Type                                           | Description                                                                         |
+| ------------------ | ---------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `vs`               | `Shader` \| _string_                           | A vertex shader object, or source as a string.                                      |
+| `fs`               | `Shader` \| _string_                           | A fragment shader object, or source as a string.                                    |
+| `modules`          |                                                | shader modules to be applied (shadertools).                                         |
+| `pipelineFactory?` |                                                | `PipelineFactory` to use for program creation and caching.                          |
+| `varyings?`        | `string[]`                                     | WebGL 2: Array of vertex shader output variables (used in TransformFeedback flow).  |
+| `bufferMode`       |                                                | WebGL 2: Mode for recording vertex shader outputs (used in TransformFeedback flow). |
+| `debugShaders?`    | `'error' \| 'never' \| 'warnings' \| 'always'` | Specify in what triggers the display shader compilation log (default: `'error'`).   |
 
 `ModelProps` passes through `RenderPipelineProps`
 
-| Property      | Type                       | Description                                                                             |
-| ------------- | -------------------------- | --------------------------------------------------------------------------------------- |
-| `layout`      | `ShaderLayout`             | Describes how shader attributes and bindings are laid out.                              |
-| `topology?`   |                            | `'point-list'`, `'line-list'`, `'line-strip'`, `'triangle-list'` or `'triangle-strip'`, |
-| `parameters?` | `RenderPipelineParameters` |                                                                                         |
-| Property          | Type                     | Description                                                         |
-| ----------------- | ------------------------ | ------------------------------------------------------------------- |
-| `vertexCount?`    | `number`                 |                                                                     |
-| `instanceCount?`  | `number`                 |                                                                     |
-| `moduleSettings?` | `Record<string, any>`    | any values required by shader modules (will be mapped to uniforms). |
-| `uniforms?`       | `Record<string, any>`    | any non-binding uniform values                                      |
-| `bindings?`       | `Record<string, any>`    |                                                                     |
-| `buffers?`        | `Record<string, Buffer>` |                                                                     |
+| Property          | Type                       | Description                                                                             |
+| ----------------- | -------------------------- | --------------------------------------------------------------------------------------- |
+| `layout`          | `ShaderLayout`             | Describes how shader attributes and bindings are laid out.                              |
+| `topology?`       |                            | `'point-list'`, `'line-list'`, `'line-strip'`, `'triangle-list'` or `'triangle-strip'`, |
+| `parameters?`     | `RenderPipelineParameters` |                                                                                         |
+| `vertexCount?`    | `number`                   |                                                                                         |
+| `instanceCount?`  | `number`                   |                                                                                         |
+| `moduleSettings?` | `Record<string, any>`      | any values required by shader modules (will be mapped to uniforms).                     |
+| `uniforms?`       | `Record<string, any>`      | any non-binding uniform values                                                          |
+| `bindings?`       | `Record<string, any>`      |                                                                                         |
+| `buffers?`        | `Record<string, Buffer>`   |                                                                                         |
 
 ## Properties
 
 ### renderPipeline: RenderPipeline
 
-Get model's `Program` instance
+Get model's `RenderPipeline` instance
 
 ### onBeforeRender
 

--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -24,7 +24,7 @@ Most classes in luma.gl allow you to supply an optional `id` string to their con
 This allows you to later easily check in the debugger which object 
 (which specific instance of that class) you are looking at when debugging code.
 
-```typescript
+```ts
 const program = device.createRenderPipeline({id: 'cube-program', ...});
 const program = device.createRenderPipeline({id: 'pyramid-program', ...});
 ```
@@ -42,7 +42,7 @@ luma.gl logs its activities.
 
 Set the global variable `luma.log.level` (this can be done in the browser console at any time) 
 
-```typescript
+```ts
 luma.log.level=1 
 ```
 
@@ -56,12 +56,16 @@ luma.log.level=1
 luma.gl extract as much information as possible about shader compiler errors etc, 
 and will throw exceptions with messages intended to help narrow down the problematic shader code when a shader fails to compile. 
 
-When running in the browser, luma.gl will open a shader source code viewer window inside the application's browser tab.
+When running in the browser, luma.gl will open a shader source code viewer window inside the application's canvas.
 This window shows both the shader source as well as any error messages and warnings from the shader compiler.
+If available translated native source is also shown.
+Normally this window is shown only if errors occur. By setting `Model.props.debugShaders: 'always'` the application can force
+the debug window to always appear.
 
 Note that luma.gl also injects and parses `glslify`-style `#define SHADER_NAME` "shader names". 
 Naming shaders directly in the shader code can help identify which 
 shader is involved when debugging shader parsing errors occur.
+
 
 ## Buffer data inspection
 
@@ -99,7 +103,7 @@ then reload your browser tab.
 
 While usually not recommended, it is also possible to activate the developer tools manually. Call [`luma.createDevice`](/docs/api-reference/core) with `debug: true` to create a WebGL context instrumented with the WebGL developer tools:
 
-```typescript
+```ts
 import {luma} from '@luma.gl/core';
 const device = luma.createDevice({type: 'webgl', debug: true});
 ```

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -35,14 +35,14 @@ Legacy Functionality
 
 New module structure
 
-| Module                     | Impact               | Description                                                                                                     |
-| -------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------- |
-| **`@luma.gl/core`**        | New API              | The new portable luma.gl GPU API. Applications can run on both WebGPU and WebGL2 devices.                       |
-| **`@luma.gl/engine`**      | Light API updates    | Classic luma.gl engine classes ()`Model`, `AnimationLoop` etc), which work portably on both WebGPU and WebGL 2. |
-| **`@luma.gl/gltf`**        | Renamed module       | New module that exports the glTF classes (moved from `@luma.gl/experimental`).                                  |
-| **`@luma.gl/shadertools`** | Light API updates    | The shader assembler API and the shader module library.                                                         |
+| Module                     | Impact               | Description                                                                                                      |
+| -------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **`@luma.gl/core`**        | New API              | The new portable luma.gl GPU API. Applications can run on both WebGPU and WebGL2 devices.                        |
+| **`@luma.gl/engine`**      | Light API updates    | Classic luma.gl engine classes ()`Model`, `AnimationLoop` etc), which work portably on both WebGPU and WebGL 2.  |
+| **`@luma.gl/gltf`**        | Renamed module       | New module that exports the glTF classes (moved from `@luma.gl/experimental`).                                   |
+| **`@luma.gl/shadertools`** | Light API updates    | The shader assembler API and the shader module library.                                                          |
 | **`@luma.gl/webgl`**       | No exported API      | Now an optional "GPU backend module". Importing this module enables the application to create WebGL 2 `Device`s. |
-| **`@luma.gl/webgpu`**      | new, no exported API | A new optional "GPU backend module". Importing this module enables the application to create WebGPU `Device`s.  |
+| **`@luma.gl/webgpu`**      | new, no exported API | A new optional "GPU backend module". Importing this module enables the application to create WebGPU `Device`s.   |
 
 New features
 
@@ -58,7 +58,7 @@ New features
 
 **`@luma.gl/gltf`**
 
-- New module that exports the glTF classes (moved from `@luma.gl/experimental`).
+- New module that exports glTF functionality (in v8 these were found in `@luma.gl/experimental`).
 
 **`@luma.gl/shadertools`**
 
@@ -68,5 +68,15 @@ New features
 
 **`@luma.gl/webgl`** 
 
-- Asynchronous shader compilation and linking is now supported on systems that support the [KHR_parallel_shader_compile](https://registry.khronos.org/webgl/extensions/KHR_parallel_shader_compile/) WebGL extension. This should speed up initialization for applications that create a lot of `RenderPipelines`.
+- Asynchronous shader compilation and linking is used if the [`KHR_parallel_shader_compile`][KHR_parallel_shader_compile] WebGL extension is available. This should speed up initialization of applications that create many `RenderPipelines`.
 - `Parameters.provokingVertex: 'first' \| 'last'` can be used to control which primitive vertex is used for flat shading if the `provoking-vertex-webgl` feature is available. Can improve performance.
+- `Shader.getTranslatedSource()` returns translated native shader source if the [`WEBGL_debug_shaders`][WEBGL_debug_shaders] extension is supported.
+
+Debugging improvements
+
+- `Shader.debugShader()` - Shader compilation errors are shown in a window inside your canvas.
+
+
+[KHR_parallel_shader_compile]: https://registry.khronos.org/webgl/extensions/KHR_parallel_shader_compile/
+[WEBGL_debug_shaders]: https://registry.khronos.org/webgl/extensions/WEBGL_debug_shaders/
+

--- a/examples/glfx/package.json
+++ b/examples/glfx/package.json
@@ -3,8 +3,8 @@
   "license": "MIT",
   "contributors": [
     "Evan Wallace",
-    "David McArthur <daviestar@gmail.com>",
-    "Ib Green <ib@uber.com>"
+    "David McArthur",
+    "Ib Green"
   ],
   "scripts": {
     "start": "yarn build-lib && open index.html",

--- a/modules/core/src/adapter/resources/shader.ts
+++ b/modules/core/src/adapter/resources/shader.ts
@@ -66,11 +66,16 @@ export abstract class Shader extends Resource<ShaderProps> {
     return null;
   }
 
+  /** Get translated shader source in host platform's native language (HLSL, GLSL, and even GLSL ES), if available */
+  getTranslatedSource(): string | null {
+    return null;
+  }
+
   // PORTABLE HELPERS
 
   /** In browser logging of errors */
-  async debugShader(): Promise<void> {
-    switch (this.props.debug) {
+  async debugShader(trigger = this.props.debug): Promise<void> {
+    switch (trigger) {
       case 'never':
         return;
       case 'errors':
@@ -102,8 +107,12 @@ export abstract class Shader extends Resource<ShaderProps> {
 
     const shaderName: string = getShaderInfo(this.source).name;
     const shaderTitle: string = `${this.stage} ${shaderName}`;
-    const htmlLog = formatCompilerLog(messages, this.source, {showSourceCode: 'all', html: true});
-
+    let htmlLog = formatCompilerLog(messages, this.source, {showSourceCode: 'all', html: true});
+    // Show translated source if available
+    const translatedSource = this.getTranslatedSource();
+    if (translatedSource) {
+      htmlLog += `<br /><br /><h1>Translated Source</h1><br /><br /><code style="user-select:text;"><pre>${translatedSource}</pre></code>`;
+    }
     // Make it clickable so we can copy to clipboard
     const button = document.createElement('Button');
     button.innerHTML = `

--- a/modules/webgl/src/adapter/resources/webgl-shader.ts
+++ b/modules/webgl/src/adapter/resources/webgl-shader.ts
@@ -48,6 +48,11 @@ export class WEBGLShader extends Shader {
     return parseShaderCompilerLog(log);
   }
 
+  override getTranslatedSource(): string | null {
+    const ext = this.device.gl.getExtension('WEBGL_debug_shaders');
+    return  ext?.getTranslatedShaderSource(this.handle);
+  }
+
   // PRIVATE METHODS
 
   /** Compile a shader and get compilation status */


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Noticed that Chrome supports the `WEBGL_debug_shaders`, can be instructive to see the native (translated) shader source.
#### Change List
- New method `Shader.getTranslatedSource()`
- Add translated source to `Shader.debugShader()` window
- New option `Model.props.debugShaders` (to force debug windows, translated source is only available when compilation succeeds)
- Documentation updates

![image](https://github.com/visgl/luma.gl/assets/7025232/f1f76658-4688-4fa4-95a7-12491ef46abe)
