### PR TITLE
chore(engine): Restore tests for Model class

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -168,6 +168,8 @@ export class Model {
   private _getModuleUniforms: (props?: Record<string, Record<string, any>>) => Record<string, any>;
   private props: Required<ModelProps>;
 
+  private _destroyed = false;
+
   constructor(device: Device, props: ModelProps) {
     this.props = {...Model.defaultProps, ...props};
     props = this.props;
@@ -285,10 +287,12 @@ export class Model {
   }
 
   destroy(): void {
+    if (this._destroyed) return;
     this.pipelineFactory.release(this.pipeline);
     this.shaderFactory.release(this.pipeline.vs);
     this.shaderFactory.release(this.pipeline.fs);
     this._uniformStore.destroy();
+    this._destroyed = true;
   }
 
   // Draw call
@@ -386,7 +390,7 @@ export class Model {
 
   /**
    * Updates the buffer layout.
-   * @note Triggers a pipeline rebuild / pipeline cache fetch on WebGPU
+   * @note Triggers a pipeline rebuild / pipeline cache fetch
    */
   setBufferLayout(bufferLayout: BufferLayout[]): void {
     this.bufferLayout = this._gpuGeometry

--- a/modules/engine/test/index.ts
+++ b/modules/engine/test/index.ts
@@ -1,4 +1,4 @@
-// import './lib/model.spec';
+import './lib/model.spec';
 import './lib/animation-loop.spec';
 import './lib/pipeline-factory.spec';
 import './lib/shader-factory.spec';


### PR DESCRIPTION
Restore most unit tests on the Model class. For some tests (getModuleUniforms, getBuffersFromGeometry) it was not obvious what the equivalent v9 behavior was, and I've removed those tests here. A couple more tests remain commented-out in `model.spec.ts`.


