### PR TITLE
feat(core): Add float64 VertexType and VertexFormat values

### DIFF
--- a/modules/core/src/adapter/type-utils/decode-data-type.ts
+++ b/modules/core/src/adapter/type-utils/decode-data-type.ts
@@ -50,6 +50,7 @@ const TYPE_MAP: Record<NormalizedDataType, DataType> = {
   snorm16: 'sint16',
   float16: 'float16',
   float32: 'float32',
+  float64: 'float64',
   uint32: 'uint32',
   sint32: 'sint32'
 };
@@ -61,6 +62,7 @@ const TYPE_SIZES: Record<DataType, number> = {
   sint16: 2,
   float16: 2,
   float32: 4,
+  float64: 8,
   uint32: 4,
   sint32: 4
 };

--- a/modules/core/src/adapter/types/vertex-formats.ts
+++ b/modules/core/src/adapter/types/vertex-formats.ts
@@ -11,7 +11,8 @@ export type DataType =
   | 'uint32'
   | 'sint32'
   | 'float16'
-  | 'float32';
+  | 'float32'
+  | 'float64';
 
 /** Vertex and Pixel data types. Include normalized integers */
 export type NormalizedDataType =
@@ -28,8 +29,9 @@ export type NormalizedDataType =
   // WebGPU does not support normalized 32 bit integer attributes...
   // | 'unorm32'
   // | 'snorm32'
+  | 'float16'
   | 'float32'
-  | 'float16';
+  | 'float64';
 
 /** Describes the type (without number of components) of a vertex format */
 export type VertexType = NormalizedDataType;
@@ -87,4 +89,8 @@ export type VertexFormat =
   | 'float32'
   | 'float32x2'
   | 'float32x3'
-  | 'float32x4';
+  | 'float32x4'
+  | 'float64'
+  | 'float64x2'
+  | 'float64x3'
+  | 'float64x4';

--- a/modules/webgl/src/adapter/converters/vertex-formats.ts
+++ b/modules/webgl/src/adapter/converters/vertex-formats.ts
@@ -13,7 +13,8 @@ type GLDataType =
   | GL.UNSIGNED_INT
   | GL.INT
   | GL.HALF_FLOAT
-  | GL.FLOAT;
+  | GL.FLOAT
+  | GL.DOUBLE;
 
 /** Get vertex format from GL constants */
 export function getVertexFormatFromGL(type: GLDataType, components: 1 | 2 | 3 | 4): VertexFormat {
@@ -42,6 +43,7 @@ export function getVertexTypeFromGL(type: GLDataType, normalized = false): Verte
     case GL.UNSIGNED_SHORT: return normalized ? 'uint16' : 'unorm16';
     case GL.BYTE: return normalized ? 'sint8' : 'snorm16';
     case GL.UNSIGNED_BYTE: return normalized ? 'uint8' : 'unorm8';
+    case GL.DOUBLE: return 'float64';
     case GL.FLOAT: return 'float32';
     case GL.HALF_FLOAT: return 'float16';
   }
@@ -59,7 +61,8 @@ export function getGLFromVertexType(
   | GL.UNSIGNED_INT
   | GL.INT
   | GL.HALF_FLOAT
-  | GL.FLOAT {
+  | GL.FLOAT
+  | GL.DOUBLE {
   // prettier-ignore
   switch (dataType) {
     case 'uint8': return GL.UNSIGNED_BYTE;
@@ -77,6 +80,7 @@ export function getGLFromVertexType(
     // case 'snorm32': return GL.INT;
     case 'float16': return GL.HALF_FLOAT;
     case 'float32': return GL.FLOAT;
+    case 'float64': return GL.DOUBLE;
   }
   // @ts-ignore unreachable
   throw new Error(String(dataType));


### PR DESCRIPTION
## Background

Currently in luma.gl and deck.gl there are main references to GL constants, particularly when declaring types for vertex attributes. In many cases, the type is 'GL.DOUBLE', used to support double-precision floating point math. In v9, we want to minimize references to GL constants, and so we may want some solution for getting these GL.DOUBLE references out of the public API.

See:

- https://github.com/search?q=repo%3Avisgl%2Fdeck.gl%20%22GL.DOUBLE%22&type=code

## Changes

While WebGPU does not actually have any 'float64' type today, I think it might be worth exporting it from luma.gl's VertexType and VertexFormat enums anyway, so that we can use the types to replace GL references throughout the codebase without a lot of `VertexType | 'float64'` workarounds. Other suggestions welcome. :)


