### PR TITLE
Handle resizing when attachment is not TextureView

### DIFF
--- a/modules/core/src/adapter/resources/framebuffer.ts
+++ b/modules/core/src/adapter/resources/framebuffer.ts
@@ -42,9 +42,9 @@ export abstract class Framebuffer extends Resource<FramebufferProps> {
   /** Height of all attachments in this framebuffer */
   height: number;
   /** Color attachments */
-  colorAttachments: TextureView[] = [];
+  colorAttachments: (TextureView | Texture)[] = [];
   /** Depth-stencil attachment, if provided */
-  depthStencilAttachment: TextureView | null = null;
+  depthStencilAttachment: TextureView | Texture | null = null;
 
   constructor(device: Device, props: FramebufferProps = {}) {
     super(device, props, Framebuffer.defaultProps);

--- a/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
+++ b/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
@@ -118,10 +118,15 @@ export class WEBGLFramebuffer extends Framebuffer {
     // TODO Not clear that this is better than default destroy/create implementation
 
     for (const colorAttachment of this.colorAttachments) {
-      (colorAttachment.texture as WEBGLTexture).resize({width, height});
+      const texture = 'texture' in colorAttachment ? colorAttachment.texture : colorAttachment;
+      (texture as WEBGLTexture).resize({width, height});
     }
     if (this.depthStencilAttachment) {
-      (this.depthStencilAttachment.texture as WEBGLTexture).resize({width, height});
+      const texture =
+        'texture' in this.depthStencilAttachment
+          ? this.depthStencilAttachment.texture
+          : this.depthStencilAttachment;
+      (texture as WEBGLTexture).resize({width, height});
     }
     return this;
   }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->



<!-- For other PRs without open issue -->
#### Background

https://github.com/visgl/luma.gl/pull/1967 introduced `TextureView` however `WebGLFramebuffer` was not updated to handle resizing, causing a crash in deck.gl as `this.depthStencilAttachment.texture` is undefined when `depthStencilAttachment` is a `Texture`

<img width="657" alt="Screenshot 2024-03-01 at 12 06 49" src="https://github.com/visgl/luma.gl/assets/453755/9377b83f-8cd7-44da-b3cd-219e96a28a93">

For repro: https://github.com/visgl/deck.gl/pull/8567

<!-- For all the PRs -->
#### Change List
- Handle case where attachments are `Texture`
