### PR TITLE
feat(shadertools): ShaderAssembler support single compute/unified shader

### DIFF
--- a/docs/api-reference/shadertools/shader-assembler.md
+++ b/docs/api-reference/shadertools/shader-assembler.md
@@ -9,12 +9,42 @@ via the `ShaderAssembler` class.
 - and injections 
 to generate the final vertex and fragment shader source that can be used to create a program.
 
+## Types
+
+## `AssembleShaderOptions`
+
+For single shader compilation
+- `source` - single shader source (always WGSL)
+
+For shader pair compilation
+- `vs` - vertex shader source
+- `fs` - fragment shader source code
+
+Common options
+- `prologue`=`true` (Boolean) - Will inject platform prologue (see below)
+- `defines`=`{}` (Object) - a map of key/value pairs representing custom `#define`s to be injected into the shader source
+- `modules`=`[]` (Array) - list of shader modules (either objects defining the module, or names of previously registered modules)
+- `inject`=`{}` (Object) - map of substituions,
+- `hookFunctions`=`[]` Array of hook functions descriptions. Descriptions can simply be the hook function signature (with a prefix `vs` for vertex shader, or `fs` for fragment shader) or an object with the hook signature, and a header and footer that will always appear in the hook function.
+
+Example of hook function
+
+```typescript
+[
+  'vs:MY_HOOK_FUNCTION1(inout vec4 color)',
+  {
+    hook: 'fs:MY_HOOK_FUNCTION2(inout vec4 color)',
+    header: 'if (color.a == 0.0) discard;\n',
+    footer: 'color.a *= 1.2;\n'
+  }
+];
+```
+
 ## Static Methods
 
 ### `getDefaultShaderAssembler()`
 
 Most applications that register default modules and hooks will want to use a single `Shader`
-
 
 ## Methods
 
@@ -35,41 +65,34 @@ Creates a shader hook function that shader modules can injection code into. Shad
 - `opts.header` (optional): code always included at the beginning of a hook function
 - `opts.footer` (optional): code always included at the end of a hook function
 
-### `assembleShaders`
+### `assembleShader(options: AssembleShaderOptions)`
 
-`ahaderAssebler.assembleShaders()` composes base vertex and fragment shader source with shader modules, 
-hook functions and injections to generate the final vertex and 
-fragment shader source that can be used to create a program.
+generate the shader source that can be used to create a shader and then a pipeline.
 
+- composes a single shader source (compute or unified vertex/fragment WGSL shader) with source from shader modules, 
+- resolving hook functions and injections to 
 
-Takes the source code of a vertex shader and a fragment shader, and a list of modules, defines, etc. Outputs resolved source code for both shaders, after adding prologue, adding defines, importing and transpiling modules, and injecting any shader fragments).
-
-- `vs` - vertex shader source
-- `fs` - fragment shader source code
-- `id` - `id` for the shader, will be used to inject shader names (using `#define SHADER_NAME`) if not already present in the source.
-- `prologue`=`true` (Boolean) - Will inject platform prologue (see below)
-- `defines`=`{}` (Object) - a map of key/value pairs representing custom `#define`s to be injected into the shader source
-- `modules`=`[]` (Array) - list of shader modules (either objects defining the module, or names of previously registered modules)
-- `inject`=`{}` (Object) - map of substituions,
-- `hookFunctions`=`[]` Array of hook functions descriptions. Descriptions can simply be the hook function signature (with a prefix `vs` for vertex shader, or `fs` for fragment shader) or an object with the hook signature, and a header and footer that will always appear in the hook function. For example:
-
-```typescript
-[
-  'vs:MY_HOOK_FUNCTION1(inout vec4 color)',
-  {
-    hook: 'fs:MY_HOOK_FUNCTION2(inout vec4 color)',
-    header: 'if (color.a == 0.0) discard;\n',
-    footer: 'color.a *= 1.2;\n'
-  }
-];
-```
 
 Returns:
 
 - `vs` - the resolved vertex shader
 - `fs` - the resolved fragment shader
 - `getUniforms` - a combined `getUniforms` function covering all modules.
-- `moduleMap` - a map with all resolved modules, keyed by name
+
+### `assembleShaderPair(options: AssembleShaderOptions)`
+
+Generate the final vertex and fragment shader source that can be compiled to create two shaders and then link them into a pipeline.
+
+- composes base vertex and fragment shader source with source from shader modules
+- resolves hook functions and injections
+
+Takes the source code of a vertex shader and a fragment shader, and a list of modules, defines, etc. Outputs resolved source code for both shaders, after adding prologue, adding defines, importing and transpiling modules, and injecting any shader fragments).
+
+Returns:
+
+- `vs` - the resolved vertex shader
+- `fs` - the resolved fragment shader
+- `getUniforms` - a combined `getUniforms` function covering all modules.
 
 ## Shader Module Assembly
 
@@ -115,6 +138,7 @@ void MY_HOOK_FUNCTION(inout vec4 color) {
 ```
 
 The hook function now changes the color from white to red.
+
 
 ## Constants and Values
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -79,10 +79,16 @@ To accelerate WebGPU development, luma.gl v9 drops support for legacy functional
 WebGL is not dead yet! Browsers (Chrome in particular) are still adding extensions to WebGL 2, and luma.gl
 is adding support for many of the new features through the [`DeviceFeatures`](/docs/api-reference/core/device-features) API.
 
-New `Device.features` that improve WebGL application performance:
+New `Device.features` that improve application performance in WebGL:
 - `compilation-status-async-webgl`: Asynchronous shader compilation and linking is used automatically when available and speeds up applications that create many `RenderPipelines`. 
 
-New `Device.features` that expose new WebGL GPU parameters:
+New `Device.features` that enable additional color format support in WebGL:
+- `rgb9e5ufloat-renderable-webgl`: `rgb9e5ufloat` is renderable.
+- `snorm8-renderable-webgl`: `r,rg,rgba8snorm` are renderable.
+- `norm16-renderable-webgl`: `r,rg,rgba16norm` are renderable. 
+- `snorm16-renderable-webgl`: `r,rg,rgba16snorm` are renderable.
+
+New `Device.features` that expose new GPU parameters in WebGL:
 - `depth-clip-control`: `parameters.unclippedDepth` - depth clipping can now be disabled if the  feature is available.
 - `provoking-vertex-webgl`: `parameters.provokingVertex` - controls which primitive vertex is used for flat shading. 
 - `polygon-mode-webgl`: `parameters.polygonMode` - enables wire frame rendering of polygons. Check the  feature. 
@@ -93,8 +99,3 @@ New `Device.features` that enable new GLSL syntax
 - `shader-noperspective-interpolation-webgl`: GLSL vertex outputs and fragment inputs may be declared with a `noperspective` interpolation qualifier.
 - `shader-conservative-depth-webgl`: GLSL `gl_FragDepth` qualifiers `depth_any` `depth_greater` `depth_less` `depth_unchanged` can enable early depth test optimizations.
 
-New `Device.features` that enable additional WebGL color format support:
-- `rgb9e5ufloat-renderable-webgl`: `rgb9e5ufloat` are renderable.
-- `snorm8-renderable-webgl`: `r,rg,rgba8snorm` are renderable.
-- `norm16-renderable-webgl`: `r,rg,rgba16norm` are renderable. 
-- `snorm16-renderable-webgl`: `r,rg,rgba16snorm` are renderable.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -70,8 +70,9 @@ To accelerate WebGPU development, luma.gl v9 drops support for legacy functional
 **`@luma.gl/shadertools`**
 
 - All shader modules now use uniform buffers.
-- NEW: `ShaderAssembler` class that provides a clean entry point to the shader module system.
+- New `ShaderAssembler` class that provides a clean entry point to the shader module system.
 - New `CompilerMessage` type and `formatCompilerLog` function for portable shader log handling.
+- Shader assembly now supports WGSL and single shader source (compute or single vertex+fragment WGSL shaders)
 
 **`@luma.gl/webgl`** 
 

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -208,7 +208,7 @@ export class Model {
     const modules =
       (this.props.modules?.length > 0 ? this.props.modules : this.shaderInputs?.getModules()) || [];
 
-    const {vs, fs, getUniforms} = this.props.shaderAssembler.assembleShaders({
+    const {vs, fs, getUniforms} = this.props.shaderAssembler.assembleShaderPair({
       platformInfo,
       ...this.props,
       modules

--- a/modules/shadertools/src/index.ts
+++ b/modules/shadertools/src/index.ts
@@ -41,7 +41,7 @@ export {generateShaderForModule} from './lib/shader-generator/generate-shader';
 export {capitalize} from './lib/shader-generator/utils/capitalize';
 
 // TEST EXPORTS - Do not use in production applications
-export {assembleShaders} from './lib/shader-assembly/assemble-shaders';
+export {assembleShaderPairGLSL} from './lib/shader-assembly/assemble-shaders';
 export {ShaderModuleInstance as _ShaderModuleInstance} from './lib/shader-module/shader-module-instance';
 export {combineInjects} from './lib/shader-assembly/shader-injections';
 export {resolveModules as _resolveModules} from './lib/shader-assembly/resolve-modules';

--- a/modules/shadertools/src/lib/shader-assembler.ts
+++ b/modules/shadertools/src/lib/shader-assembler.ts
@@ -7,7 +7,7 @@ import {ShaderModuleInstance} from './shader-module/shader-module-instance';
 import {selectShaders, AssembleShaderProps} from './shader-assembly/select-shaders';
 import {
   GetUniformsFunc,
-  assembleSingleShaderWGSL,
+  assembleShaderWGSL,
   assembleShaderPairWGSL,
   assembleShaderPairGLSL
 } from './shader-assembly/assemble-shaders';
@@ -73,7 +73,7 @@ export class ShaderAssembler {
    * @param props
    * @returns
    */
-  assembleSingleShader(props: AssembleShaderProps): {
+  assembleShader(props: AssembleShaderProps): {
     source: string;
     getUniforms: GetUniformsFunc;
     modules: ShaderModuleInstance[];
@@ -81,7 +81,7 @@ export class ShaderAssembler {
     const modules = this._getModuleList(props.modules); // Combine with default modules
     const hookFunctions = this._hookFunctions; // TODO - combine with default hook functions
     const options = selectShaders(props);
-    const assembled = assembleSingleShaderWGSL({
+    const assembled = assembleShaderWGSL({
       platformInfo: props.platformInfo,
       ...options,
       modules,

--- a/modules/shadertools/src/lib/shader-assembly/assemble-shaders.ts
+++ b/modules/shadertools/src/lib/shader-assembly/assemble-shaders.ts
@@ -83,7 +83,7 @@ export type GetUniformsFunc = (opts: Record<string, any>) => Record<string, any>
 /**
  * Inject a list of shader modules into a single shader source for WGSL
  */
-export function assembleSingleShaderWGSL(options: AssembleShaderOptions): {
+export function assembleShaderWGSL(options: AssembleShaderOptions): {
   source: string;
   getUniforms: GetUniformsFunc;
 } {

--- a/modules/shadertools/src/lib/shader-assembly/select-shaders.ts
+++ b/modules/shadertools/src/lib/shader-assembly/select-shaders.ts
@@ -10,6 +10,8 @@ import type {AssembleShaderOptions} from './assemble-shaders';
  */
 export type AssembleShaderProps = Omit<AssembleShaderOptions, 'vs' | 'fs'> & {
   platformInfo: PlatformInfo;
+  /** Single shader source. Always WGSL */
+  source?: string | null;
   /** Vertex shader source. Can be GLSL or WGSL or both */
   vs?: {glsl?: string; wgsl?: string} | string | null;
   /** Fragment shader source. Can be GLSL or WGSL or both */

--- a/modules/shadertools/test/lib/shader-assembler.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembler.spec.ts
@@ -59,7 +59,7 @@ const FS_300 = glsl`\
 test('ShaderAssembler#hooks', t => {
   const shaderAssembler = new ShaderAssembler();
 
-  const preHookShaders = shaderAssembler.assembleShaders({platformInfo, vs, fs});
+  const preHookShaders = shaderAssembler.assembleShaderPair({platformInfo, vs, fs});
 
   shaderAssembler.addShaderHook('vs:LUMAGL_pickColor(inout vec4 color)');
   shaderAssembler.addShaderHook('fs:LUMAGL_fragmentColor(inout vec4 color)', {
@@ -67,7 +67,7 @@ test('ShaderAssembler#hooks', t => {
     footer: 'color.a *= 1.2;\n'
   });
 
-  const assemblyResults = shaderAssembler.assembleShaders({platformInfo, vs, fs});
+  const assemblyResults = shaderAssembler.assembleShaderPair({platformInfo, vs, fs});
 
   t.ok(preHookShaders !== assemblyResults, 'Adding hooks changes hash');
 
@@ -84,7 +84,7 @@ test('ShaderAssembler#hooks', t => {
     picking
   );
 
-  const noModuleProgram = shaderAssembler.assembleShaders({platformInfo, vs, fs});
+  const noModuleProgram = shaderAssembler.assembleShaderPair({platformInfo, vs, fs});
 
   t.ok(preHookShaders !== noModuleProgram, 'Adding hooks changes hash');
 
@@ -106,7 +106,7 @@ test('ShaderAssembler#hooks', t => {
     'injection code not included in fragment shader without module'
   );
 
-  const modulesProgram = shaderAssembler.assembleShaders({
+  const modulesProgram = shaderAssembler.assembleShaderPair({
     platformInfo,
     vs,
     fs,
@@ -138,7 +138,7 @@ test('ShaderAssembler#hooks', t => {
     'hook footer injected after injection code'
   );
 
-  const injectedShaders = shaderAssembler.assembleShaders({
+  const injectedShaders = shaderAssembler.assembleShaderPair({
     platformInfo,
     vs,
     fs,
@@ -153,7 +153,7 @@ test('ShaderAssembler#hooks', t => {
   t.ok(injectVs.indexOf('color *= 0.1') > -1, 'argument injection code included in shader hook');
   t.ok(injectFs.indexOf('color += 0.1') > -1, 'argument injection code included in shader hook');
 
-  const injectDefineProgram1 = shaderAssembler.assembleShaders({
+  const injectDefineProgram1 = shaderAssembler.assembleShaderPair({
     platformInfo,
     vs,
     fs,
@@ -162,7 +162,7 @@ test('ShaderAssembler#hooks', t => {
     }
   });
 
-  const injectDefineProgram2 = shaderAssembler.assembleShaders({
+  const injectDefineProgram2 = shaderAssembler.assembleShaderPair({
     platformInfo,
     vs,
     fs,
@@ -179,9 +179,9 @@ test('ShaderAssembler#hooks', t => {
 test('ShaderAssembler#defaultModules', t => {
   const shaderAssembler = new ShaderAssembler();
 
-  const program = shaderAssembler.assembleShaders({platformInfo, vs, fs});
+  const program = shaderAssembler.assembleShaderPair({platformInfo, vs, fs});
 
-  const preDefaultModuleProgram = shaderAssembler.assembleShaders({
+  const preDefaultModuleProgram = shaderAssembler.assembleShaderPair({
     platformInfo,
     vs,
     fs,
@@ -192,8 +192,8 @@ test('ShaderAssembler#defaultModules', t => {
 
   shaderAssembler.addDefaultModule(dirlight);
 
-  const defaultModuleProgram = shaderAssembler.assembleShaders({platformInfo, vs, fs});
-  const moduleProgram = shaderAssembler.assembleShaders({
+  const defaultModuleProgram = shaderAssembler.assembleShaderPair({platformInfo, vs, fs});
+  const moduleProgram = shaderAssembler.assembleShaderPair({
     platformInfo,
     vs,
     fs,
@@ -211,7 +211,7 @@ test('ShaderAssembler#defaultModules', t => {
 
   shaderAssembler.removeDefaultModule(dirlight);
 
-  const noDefaultModuleProgram = shaderAssembler.assembleShaders({platformInfo, vs, fs});
+  const noDefaultModuleProgram = shaderAssembler.assembleShaderPair({platformInfo, vs, fs});
 
   t.ok(program.fs === noDefaultModuleProgram.fs, 'Default module was removed');
   t.ok(moduleProgram.fs !== noDefaultModuleProgram.fs, 'Default module was removed');
@@ -219,7 +219,7 @@ test('ShaderAssembler#defaultModules', t => {
   // Reset program manager
 
   shaderAssembler.addDefaultModule(dirlight);
-  const uncachedProgram = shaderAssembler.assembleShaders({platformInfo, vs, fs});
+  const uncachedProgram = shaderAssembler.assembleShaderPair({platformInfo, vs, fs});
   const defaultModuleSource = uncachedProgram.fs;
 
   // TODO - this deep equal thing doesn't make sense due to getUniforms

--- a/modules/shadertools/test/lib/shader-assembly/assemble-shaders.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembly/assemble-shaders.spec.ts
@@ -1,7 +1,7 @@
 import test from 'tape-promise/tape';
 import {Device} from '@luma.gl/core';
 import {webglDevice} from '@luma.gl/test-utils';
-import {assembleShaders, picking, fp64, pbr, glsl, PlatformInfo} from '@luma.gl/shadertools';
+import {assembleShaderPairGLSL, picking, fp64, pbr, glsl, PlatformInfo} from '@luma.gl/shadertools';
 import type {WebGLDevice} from '@luma.gl/webgl';
 import {isBrowser} from '@probe.gl/env';
 
@@ -259,13 +259,13 @@ void main(void) {
 }
 `;
 
-test('assembleShaders#import', t => {
-  t.ok(assembleShaders !== undefined, 'assembleShaders import successful');
+test('assembleShaderPairGLSL#import', t => {
+  t.ok(assembleShaderPairGLSL !== undefined, 'assembleShaderPairGLSL import successful');
   t.end();
 });
 
-test('assembleShaders#version_directive', t => {
-  const assembleResult = assembleShaders({
+test('assembleShaderPairGLSL#version_directive', t => {
+  const assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300,
     fs: FS_GLSL_300,
@@ -285,7 +285,7 @@ test('assembleShaders#version_directive', t => {
   t.end();
 });
 
-test('assembleShaders#getUniforms', t => {
+test('assembleShaderPairGLSL#getUniforms', t => {
   // inject spy into the picking module's getUniforms
   // const module = getShaderModule(picking);
   // const getUniformsSpy = makeSpy(module, 'getUniforms');
@@ -293,7 +293,7 @@ test('assembleShaders#getUniforms', t => {
   let assembleResult;
 
   // Without shader modules
-  assembleResult = assembleShaders({
+  assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300,
     fs: FS_GLSL_300
@@ -314,7 +314,7 @@ test('assembleShaders#getUniforms', t => {
     dependencies: [picking]
   };
 
-  assembleResult = assembleShaders({
+  assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300,
     fs: FS_GLSL_300,
@@ -327,8 +327,8 @@ test('assembleShaders#getUniforms', t => {
   t.end();
 });
 
-test('assembleShaders#defines', t => {
-  const assembleResult = assembleShaders({
+test('assembleShaderPairGLSL#defines', t => {
+  const assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300,
     fs: FS_GLSL_300,
@@ -341,7 +341,7 @@ test('assembleShaders#defines', t => {
   t.end();
 });
 
-test('assembleShaders#shaderhooks', t => {
+test('assembleShaderPairGLSL#shaderhooks', t => {
   const hookFunctions = [
     'vs:LUMAGL_pickColor(inout vec4 color)',
     {
@@ -372,7 +372,7 @@ test('assembleShaders#shaderhooks', t => {
     }
   };
 
-  let assembleResult = assembleShaders({
+  let assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300,
     fs: FS_GLSL_300,
@@ -405,7 +405,7 @@ test('assembleShaders#shaderhooks', t => {
     'regex injection code not included in fragment shader without module'
   );
 
-  assembleResult = assembleShaders({
+  assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300,
     fs: FS_GLSL_300,
@@ -440,7 +440,7 @@ test('assembleShaders#shaderhooks', t => {
     'regex injection code included in fragment shader with module'
   );
 
-  assembleResult = assembleShaders({
+  assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300,
     fs: FS_GLSL_300,
@@ -466,7 +466,7 @@ test('assembleShaders#shaderhooks', t => {
     'argument injection code injected in the correct order'
   );
 
-  assembleResult = assembleShaders({
+  assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300,
     fs: FS_GLSL_300,
@@ -484,7 +484,7 @@ test('assembleShaders#shaderhooks', t => {
     'module injection code injected in the correct order'
   );
 
-  assembleResult = assembleShaders({
+  assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300,
     fs: FS_GLSL_300,
@@ -502,8 +502,8 @@ test('assembleShaders#shaderhooks', t => {
   t.end();
 });
 
-test('assembleShaders#injection order', t => {
-  let assembleResult = assembleShaders({
+test('assembleShaderPairGLSL#injection order', t => {
+  let assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300_MODULES,
     fs: FS_GLSL_300_MODULES,
@@ -524,7 +524,7 @@ test('assembleShaders#injection order', t => {
     'Hook functions have access to injected variables.'
   );
 
-  assembleResult = assembleShaders({
+  assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300_MODULES,
     fs: FS_GLSL_300_MODULES,
@@ -541,8 +541,8 @@ test('assembleShaders#injection order', t => {
 });
 
 // TODO - restore if we ever support transpilation of uniform blocks
-test.skip('assembleShaders#transpilation', t => {
-  let assembleResult = assembleShaders({
+test.skip('assembleShaderPairGLSL#transpilation', t => {
+  let assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300,
     fs: FS_GLSL_300,
@@ -560,7 +560,7 @@ test.skip('assembleShaders#transpilation', t => {
     'assemble GLSL300 + picking and transpile to GLSL100'
   );
 
-  assembleResult = assembleShaders({
+  assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300_2,
     fs: FS_GLSL_300_2,
@@ -576,7 +576,7 @@ test.skip('assembleShaders#transpilation', t => {
   // TODO - this doesn't work in headless gl
   if (isBrowser() && extension) {
     t.comment(JSON.stringify(extension));
-    assembleResult = assembleShaders({
+    assembleResult = assembleShaderPairGLSL({
       platformInfo: getInfo(webglDevice),
       vs: VS_GLSL_300_DECK,
       fs: FS_GLSL_300_DECK
@@ -588,7 +588,7 @@ test.skip('assembleShaders#transpilation', t => {
     );
   }
 
-  assembleResult = assembleShaders({
+  assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_300_GLTF,
     fs: FS_GLSL_300_GLTF,

--- a/modules/shadertools/test/lib/shader-assembly/inject-shader.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembly/inject-shader.spec.ts
@@ -2,7 +2,7 @@
 import test from 'tape-promise/tape';
 import {Device} from '@luma.gl/core';
 import {webglDevice} from '@luma.gl/test-utils';
-import {assembleShaders, glsl, PlatformInfo} from '@luma.gl/shadertools';
+import {assembleShaderPairGLSL, glsl, PlatformInfo} from '@luma.gl/shadertools';
 import {
   injectShader,
   combineInjects,
@@ -136,8 +136,8 @@ test('injectShader#injectShader', t => {
   t.end();
 });
 
-test('injectShader#assembleShaders', t => {
-  const assembleResult = assembleShaders({
+test('injectShader#assembleShaderPairGLSL', t => {
+  const assembleResult = assembleShaderPairGLSL({
     platformInfo: getInfo(webglDevice),
     vs: VS_GLSL_TEMPLATE,
     fs: FS_GLSL_TEMPLATE,


### PR DESCRIPTION
…rPair

<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- WGSL compute shaders and unified shaders have only a single shader.
#### Change List
- New assembleSingleShader() and assembleShaderPair() methods on ShaderAssembler.
