### PR TITLE
Fix Model memory leak

### DIFF
--- a/modules/core/src/lib/uniforms/uniform-store.ts
+++ b/modules/core/src/lib/uniforms/uniform-store.ts
@@ -66,7 +66,7 @@ export class UniformStore<
 
   /** Destroy any managed uniform buffers */
   destroy(): void {
-    for (const uniformBuffer of Object.values(this.uniformBuffers)) {
+    for (const uniformBuffer of this.uniformBuffers.values()) {
       uniformBuffer.destroy();
     }
   }

--- a/modules/engine/src/geometry/gpu-geometry.ts
+++ b/modules/engine/src/geometry/gpu-geometry.ts
@@ -49,8 +49,8 @@ export class GPUGeometry {
 
   destroy(): void {
     this.indices?.destroy();
-    for (const name in this.attributes) {
-      this.attributes[name].destroy();
+    for (const attribute of Object.values(this.attributes)) {
+      attribute.destroy();
     }
   }
 

--- a/modules/engine/src/geometry/gpu-geometry.ts
+++ b/modules/engine/src/geometry/gpu-geometry.ts
@@ -48,11 +48,10 @@ export class GPUGeometry {
   }
 
   destroy(): void {
-    this.indices.destroy();
-    this.attributes.positions.destroy();
-    this.attributes.normals.destroy();
-    this.attributes.texCoords.destroy();
-    this.attributes.colors?.destroy();
+    this.indices?.destroy();
+    for (const name in this.attributes) {
+      this.attributes[name].destroy();
+    }
   }
 
   getVertexCount(): number {

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -301,6 +301,7 @@ export class Model {
     this.shaderFactory.release(this.pipeline.vs);
     this.shaderFactory.release(this.pipeline.fs);
     this._uniformStore.destroy();
+    this._gpuGeometry?.destroy();
     this._destroyed = true;
   }
 

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -235,7 +235,7 @@ export class Model {
 
     // Geometry, if provided, sets topology and vertex cound
     if (props.geometry) {
-      this._gpuGeometry = this.setGeometry(props.geometry);
+      this.setGeometry(props.geometry);
     }
 
     this.pipelineFactory =
@@ -355,14 +355,17 @@ export class Model {
    * Geometry, set topology and bufferLayout
    * @note Can trigger a pipeline rebuild / pipeline cache fetch on WebGPU
    */
-  setGeometry(geometry: GPUGeometry | Geometry): GPUGeometry {
+  setGeometry(geometry: GPUGeometry | Geometry | null) {
+    this._gpuGeometry?.destroy();
     const gpuGeometry = geometry && makeGPUGeometry(this.device, geometry);
-    this.setTopology(gpuGeometry.topology || 'triangle-list');
-    this.bufferLayout = mergeBufferLayouts(gpuGeometry.bufferLayout, this.bufferLayout);
-    if (this.vertexArray) {
-      this._setGeometryAttributes(gpuGeometry);
+    if (gpuGeometry) {
+      this.setTopology(gpuGeometry.topology || 'triangle-list');
+      this.bufferLayout = mergeBufferLayouts(gpuGeometry.bufferLayout, this.bufferLayout);
+      if (this.vertexArray) {
+        this._setGeometryAttributes(gpuGeometry);
+      }
     }
-    return gpuGeometry;
+    this._gpuGeometry = gpuGeometry;
   }
 
   /**

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -301,6 +301,7 @@ export class Model {
     this.shaderFactory.release(this.pipeline.vs);
     this.shaderFactory.release(this.pipeline.fs);
     this._uniformStore.destroy();
+    // TODO - mark resource as managed and destroyIfManaged() ?
     this._gpuGeometry?.destroy();
     this._destroyed = true;
   }


### PR DESCRIPTION
`Model.destroy` does not remove all resources

#### Change List
- Fix `UniformStore.destroy`
- Fix `GPUGeometry.destroy`
- Call `GPUGeometry.destroy` from `Model.setGeometry`
- Call `GPUGeometry.destroy` from `Model.destroy`
