### PR TITLE
chore(test-utils); Make webgl test device creation async to ensure debuggability

### DIFF
--- a/modules/core-tests/test/adapter/canvas-context.spec.ts
+++ b/modules/core-tests/test/adapter/canvas-context.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
+import {getTestDevices} from '@luma.gl/test-utils';
 
 import {CanvasContext} from '@luma.gl/core';
 
@@ -13,7 +13,7 @@ test('CanvasContext#defined', t => {
   t.end();
 });
 
-test('CanvasContext#getDevicePixelRatio', t => {
+test('CanvasContext#getDevicePixelRatio', async t => {
   const windowPixelRatio = (typeof window !== 'undefined' && window.devicePixelRatio) || 1;
   const TEST_CASES = [
     {
@@ -48,7 +48,7 @@ test('CanvasContext#getDevicePixelRatio', t => {
     }
   ];
 
-  for (const device of getWebGLTestDevices()) {
+  for (const device of await getTestDevices()) {
     TEST_CASES.forEach(tc => {
       const result = device.canvasContext?.getDevicePixelRatio(tc.useDevicePixels);
       t.equal(result, tc.expected, tc.name);

--- a/modules/core-tests/test/adapter/device-helpers/set-device-parameters.spec.ts
+++ b/modules/core-tests/test/adapter/device-helpers/set-device-parameters.spec.ts
@@ -9,10 +9,6 @@ import {Parameters} from '@luma.gl/core';
 import {GL, GLParameters} from '@luma.gl/constants';
 import {setDeviceParameters, getGLParameters, resetGLParameters} from '@luma.gl/webgl';
 
-// import {createTestDevice} from '@luma.gl/test-utils';
-// const webglDevice = createTestDevice({debug: true, webgl2: false});
-// const webglDevice = createTestDevice({debug: true, webgl2: true, webgl1: false});
-
 // Settings test, could be beneficial to not reuse a context
 const {gl} = webglDevice;
 

--- a/modules/core-tests/test/adapter/device.spec.ts
+++ b/modules/core-tests/test/adapter/device.spec.ts
@@ -3,12 +3,12 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {getWebGLTestDevices, getTestDevices} from '@luma.gl/test-utils';
+import {getTestDevices} from '@luma.gl/test-utils';
 
 // import {luma} from '@luma.gl/core';
 
-test('WebGLDevice#info', t => {
-  for (const device of getWebGLTestDevices()) {
+test('WebGLDevice#info', async t => {
+  for (const device of await getTestDevices()) {
     // TODO
     t.ok(typeof device.info.vendor === 'string', 'info.vendor ok');
     t.ok(typeof device.info.renderer === 'string', 'info.renderer ok');

--- a/modules/core-tests/test/adapter/resources/buffer.spec.ts
+++ b/modules/core-tests/test/adapter/resources/buffer.spec.ts
@@ -2,21 +2,24 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import test from 'tape-promise/tape';
+import {getTestDevices, webglDevice} from '@luma.gl/test-utils';
+
 import {Buffer, TypedArray} from '@luma.gl/core';
 import {GL} from '@luma.gl/constants';
-import test from 'tape-promise/tape';
 
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
-
-test('Buffer#constructor/delete', t => {
-  for (const device of getWebGLTestDevices()) {
+test('Buffer#constructor/delete', async t => {
+  for (const device of await getTestDevices()) {
     const buffer = device.createBuffer({usage: Buffer.VERTEX});
+    // @ts-ignore handle
     t.ok(buffer.handle, `${device.info.type} Buffer construction successful`);
 
     buffer.destroy();
+    // @ts-ignore handle
     t.ok(!buffer.handle, `${device.info.type} Buffer.destroy() successful`);
 
     buffer.destroy();
+    // @ts-ignore handle
     t.ok(!buffer.handle, `${device.info.type} repeated Buffer.destroy() successful`);
   }
   t.end();
@@ -25,7 +28,10 @@ test('Buffer#constructor/delete', t => {
 test('Buffer#constructor offset and size', async t => {
   const data = new Float32Array([1, 2, 3]);
 
-  for (const device of getWebGLTestDevices()) {
+  for (const device of await getTestDevices()) {
+    if (device.info.type === 'webgpu') {
+      continue;
+    }
     let buffer = device.createBuffer({data, byteOffset: 8});
     let expectedData = new Float32Array([0, 0, 1, 2, 3]);
     t.equal(
@@ -74,8 +80,9 @@ test('Buffer#constructor offset and size', async t => {
   t.end();
 });
 
-test('Buffer#bind/unbind', t => {
-  for (const device of getWebGLTestDevices()) {
+/*
+test('Buffer#bind/unbind', async t => {
+  for (const device of await getTestDevices()) {
     const buffer = device.createBuffer({usage: Buffer.VERTEX});
     device.gl.bindBuffer(buffer.glTarget, buffer.handle);
     t.ok(buffer instanceof Buffer, `${device.info.type} Buffer bind/unbind successful`);
@@ -84,34 +91,14 @@ test('Buffer#bind/unbind', t => {
   }
   t.end();
 });
-
-test('Buffer#construction', t => {
-  for (const device of getWebGLTestDevices()) {
-    let buffer;
-
-    buffer = device.createBuffer({usage: Buffer.VERTEX, data: new Float32Array([1, 2, 3])});
-    t.ok(
-      buffer.glTarget === GL.ARRAY_BUFFER,
-      `${device.info.type} Buffer(ARRAY_BUFFER) successful`
-    );
-    buffer.destroy();
-
-    // TODO - buffer could check for integer ELEMENT_ARRAY_BUFFER types
-    buffer = device.createBuffer({usage: Buffer.INDEX, data: new Float32Array([1, 2, 3])});
-    t.ok(
-      buffer.glTarget === GL.ELEMENT_ARRAY_BUFFER,
-      `${device.info.type} Buffer(ELEMENT_ARRAY_BUFFER) successful`
-    );
-
-    buffer.destroy();
-  }
-
-  t.end();
-});
+*/
 
 test('Buffer#write', async t => {
   const expectedData = new Float32Array([1, 2, 3]);
-  for (const device of getWebGLTestDevices()) {
+  for (const device of await getTestDevices()) {
+    if (device.info.type === 'webgpu') {
+      continue;
+    }
     const buffer = device.createBuffer({usage: Buffer.VERTEX, byteLength: 12});
     buffer.write(expectedData);
     const receivedData = await buffer.readAsync();
@@ -139,7 +126,10 @@ test('Buffer#write', async t => {
 });
 
 test('Buffer#readAsync', async t => {
-  for (const device of getWebGLTestDevices()) {
+  for (const device of await getTestDevices()) {
+    if (device.info.type === 'webgpu') {
+      continue;
+    }
     let data: TypedArray = new Float32Array([1, 2, 3]);
     let buffer = device.createBuffer({data});
 
@@ -184,7 +174,10 @@ test('Buffer#readAsync', async t => {
 });
 
 test('Buffer#debugData', async t => {
-  for (const device of getWebGLTestDevices()) {
+  for (const device of await getTestDevices()) {
+    if (device.info.type === 'webgpu') {
+      continue;
+    }
     const buffer = device.createBuffer({usage: Buffer.VERTEX, byteLength: 24});
     t.equal(buffer.debugData.byteLength, 24, 'Buffer.debugData is not null before write');
 
@@ -199,6 +192,32 @@ test('Buffer#debugData', async t => {
 
     buffer.destroy();
   }
+
+  t.end();
+});
+
+// WEBGL specific tests
+
+test('WEBGLBuffer#construction', async t => {
+  await getTestDevices();
+
+  let buffer;
+
+  buffer = webglDevice.createBuffer({usage: Buffer.VERTEX, data: new Float32Array([1, 2, 3])});
+  t.ok(
+    buffer.glTarget === GL.ARRAY_BUFFER,
+    `${webglDevice.info.type} Buffer(ARRAY_BUFFER) successful`
+  );
+  buffer.destroy();
+
+  // TODO - buffer could check for integer ELEMENT_ARRAY_BUFFER types
+  buffer = webglDevice.createBuffer({usage: Buffer.INDEX, data: new Float32Array([1, 2, 3])});
+  t.ok(
+    buffer.glTarget === GL.ELEMENT_ARRAY_BUFFER,
+    `${webglDevice.info.type} Buffer(ELEMENT_ARRAY_BUFFER) successful`
+  );
+
+  buffer.destroy();
 
   t.end();
 });

--- a/modules/core-tests/test/adapter/resources/command-buffer.spec.ts
+++ b/modules/core-tests/test/adapter/resources/command-buffer.spec.ts
@@ -4,13 +4,12 @@
 
 import test, {Test} from 'tape-promise/tape';
 import {Buffer, Device, TextureFormat} from '@luma.gl/core';
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
+import {webglDevice as device} from '@luma.gl/test-utils';
 
 const EPSILON = 1e-6;
 const {abs} = Math;
 
 test('CommandBuffer#copyBufferToBuffer', async t => {
-  for (const device of getWebGLTestDevices()) {
     const sourceData = new Float32Array([1, 2, 3]);
     const source = device.createBuffer({data: sourceData});
     const destinationData = new Float32Array([4, 5, 6]);
@@ -47,7 +46,7 @@ test('CommandBuffer#copyBufferToBuffer', async t => {
     receivedData = await readAsyncF32(destination);
     expectedData = new Float32Array([1, 2, 2]);
     t.deepEqual(receivedData, expectedData, 'copyBufferToBuffer: with size and offsets successful');
-  }
+
   t.end();
 });
 
@@ -114,7 +113,6 @@ const COPY_TEXTURE_TO_BUFFER_FIXTURES: CopyTextureToBufferFixture[] = [
 ];
 
 test('CommandBuffer#copyTextureToBuffer', async t => {
-  for (const device of getWebGLTestDevices()) {
     for (const fixture of COPY_TEXTURE_TO_BUFFER_FIXTURES) {
       await testCopyTextureToBuffer(t, device, {...fixture});
       await testCopyTextureToBuffer(t, device, {
@@ -123,7 +121,7 @@ test('CommandBuffer#copyTextureToBuffer', async t => {
         title: `${fixture.title} + framebuffer`
       });
     }
-  }
+
   t.end();
 });
 

--- a/modules/core-tests/test/adapter/resources/framebuffer.spec.ts
+++ b/modules/core-tests/test/adapter/resources/framebuffer.spec.ts
@@ -4,8 +4,8 @@
 
 /* eslint-disable max-len */
 import test from 'tape-promise/tape';
+import {webglDevice, getTestDevices} from '@luma.gl/test-utils';
 import {Framebuffer} from '@luma.gl/core';
-import {webglDevice, getWebGLTestDevices} from '@luma.gl/test-utils';
 
 const TEST_CASES = [
   {
@@ -21,7 +21,7 @@ const TEST_CASES = [
   {
     title: 'Autocreated Depth Renderbuffer + Color Texture',
     getOpts: device => ({
-      colorAttachments: ['rgba8unorm-unsized'],
+      colorAttachments: ['rgba8unorm'],
       depthStencilAttachment: 'depth16unorm'
     }),
     pass: true
@@ -70,11 +70,11 @@ const TEST_CASES = [
 ];
 
 test('WebGLDevice.createFramebuffer()', async t => {
-  for (const testDevice of getWebGLTestDevices()) {
+  for (const testDevice of await getTestDevices()) {
     t.throws(() => testDevice.createFramebuffer({}), 'Framebuffer without attachment fails');
 
     const framebuffer = testDevice.createFramebuffer({
-      colorAttachments: ['rgba8unorm-unsized'],
+      colorAttachments: ['rgba8unorm'],
       depthStencilAttachment: 'depth16unorm'
     });
     t.ok(framebuffer instanceof Framebuffer, 'Framebuffer with attachment');
@@ -89,7 +89,7 @@ test('WebGLDevice.createFramebuffer()', async t => {
 });
 
 test('WebGLFramebuffer create and resize attachments', async t => {
-  for (const testDevice of getWebGLTestDevices()) {
+  for (const testDevice of await getTestDevices()) {
     for (const tc of TEST_CASES) {
       let props;
 

--- a/modules/core-tests/test/adapter/resources/shader.spec.ts
+++ b/modules/core-tests/test/adapter/resources/shader.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
+import {getTestDevices} from '@luma.gl/test-utils';
 
 const BAD_SHADER_SOURCE = `\
 #define BAD_SHADERS
@@ -16,7 +16,7 @@ vec4 goggledygook = 100;
 // TODO - sync shader compilation checks and throws are now a debug-only feature
 test.skip('Shader', async t => {
   // Only test WebGL, WebGPU is not able to detect shader failures synchronously, but require polling.
-  for (const device of getWebGLTestDevices()) {
+  for (const device of await getTestDevices()) {
     t.throws(
       () => device.createShader({stage: 'vertex', source: BAD_SHADER_SOURCE}),
       `${device.info.type} device.createShader throws on bad shader source`

--- a/modules/core-tests/test/adapter/resources/vertex-array.spec.ts
+++ b/modules/core-tests/test/adapter/resources/vertex-array.spec.ts
@@ -3,12 +3,12 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
+import {webglDevice} from '@luma.gl/test-utils';
 
 import {VertexArray} from '@luma.gl/core';
 
 test('VertexArray construct/delete', t => {
-  for (const device of getWebGLTestDevices()) {
+  for (const device of [webglDevice]) {
     const renderPipeline = device.createRenderPipeline({});
     const vertexArray = device.createVertexArray({renderPipeline});
     t.ok(vertexArray instanceof VertexArray, 'VertexArray construction successful');

--- a/modules/core/src/adapter/resources/framebuffer.ts
+++ b/modules/core/src/adapter/resources/framebuffer.ts
@@ -29,7 +29,7 @@ export abstract class Framebuffer extends Resource<FramebufferProps> {
     ...Resource.defaultProps,
     width: 1,
     height: 1,
-    colorAttachments: [], // ['rgba8unorm-unsized'],
+    colorAttachments: [], // ['rgba8unorm'],
     depthStencilAttachment: null // 'depth24plus-stencil8'
   };
 
@@ -78,6 +78,10 @@ export abstract class Framebuffer extends Resource<FramebufferProps> {
 
   /** Auto creates any textures */
   protected autoCreateAttachmentTextures(): void {
+    if (this.props.colorAttachments.length === 0 && !this.props.depthStencilAttachment) {
+      throw new Error('Framebuffer has noattachments');
+    }
+    
     this.colorAttachments = this.props.colorAttachments.map(attachment => {
       if (typeof attachment === 'string') {
         const texture = this.createColorTexture(attachment);

--- a/modules/core/src/adapter/types/texture-formats.ts
+++ b/modules/core/src/adapter/types/texture-formats.ts
@@ -133,10 +133,9 @@ export type WebGPUColorTextureFormat =
   | 'astc-12x12-unorm-srgb';
 
 /** Unsized texture formats (the only formats supported by WebGL1) */
-export type UnsizedColorTextureFormat =
-  // 'r8unorm-unsized' |
-  // 'ra8unorm-unsized' |
-  'rgb8unorm-unsized' | 'rgba8unorm-unsized';
+export type UnsizedColorTextureFormat = 'rgb8unorm-unsized' | 'rgba8unorm-unsized';
+// 'r8unorm-unsized' |
+// 'ra8unorm-unsized' |
 // 'rgb8unorm-srgb-unsized' |
 // 'rgba8unorm-srgb-unsized'
 

--- a/modules/core/test/lib/utils/uniform.spec.ts
+++ b/modules/core/test/lib/utils/uniform.spec.ts
@@ -1,6 +1,6 @@
 import {isUniformValue, splitUniformsAndBindings} from '@luma.gl/core';
 import {WEBGLSampler, WEBGLTexture} from '@luma.gl/webgl';
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
+import {webglDevice as device} from '@luma.gl/test-utils';
 import test from 'tape-promise/tape';
 
 test('isUniformValue', t => {
@@ -12,14 +12,12 @@ test('isUniformValue', t => {
   t.ok(isUniformValue([1, 2, 3, 4]), 'Number array is uniform value');
   t.ok(isUniformValue(new Float32Array([1, 2, 3, 4])), 'Number array is uniform value');
 
-  const device = getWebGLTestDevices()[0];
   t.notOk(isUniformValue(new WEBGLTexture(device, {})), 'WEBGLTexture is not a uniform value');
   t.notOk(isUniformValue(new WEBGLSampler(device, {})), 'WEBGLSampler is not a uniform value');
   t.end();
 });
 
 test('splitUniformsAndBindings', t => {
-  const device = getWebGLTestDevices()[0];
   const mixed: Parameters<typeof splitUniformsAndBindings>[0] = {
     array: [1, 2, 3, 4],
     boolean: true,

--- a/modules/engine/test/scenegraph/group-node.spec.ts
+++ b/modules/engine/test/scenegraph/group-node.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
+import {webglDevice as device} from '@luma.gl/test-utils';
 import {GroupNode, ScenegraphNode, ModelNode, Model} from '@luma.gl/engine';
 import {Matrix4} from '@math.gl/core';
 import {DUMMY_VS, DUMMY_FS} from './model-node.spec';
@@ -108,7 +108,6 @@ test('GroupNode#traverse', t => {
 });
 
 test('GroupNode#getBounds', t => {
-  for (const device of getWebGLTestDevices()) {
     const matrix = new Matrix4().translate([0, 0, 1]).scale(2);
 
     const model1 = new Model(device, {id: 'childSNode', vs: DUMMY_VS, fs: DUMMY_FS});
@@ -137,6 +136,5 @@ test('GroupNode#getBounds', t => {
       ],
       'bounds calculated'
     );
-  }
   t.end();
 });

--- a/modules/engine/test/scenegraph/model-node.spec.ts
+++ b/modules/engine/test/scenegraph/model-node.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
+import {webglDevice} from '@luma.gl/test-utils';
 // import {makeSpy} from '@probe.gl/test-utils';
 import {Model, ModelNode} from '@luma.gl/engine';
 
@@ -20,7 +20,7 @@ void main() { fragmentColor = vec4(1.0); }
 `;
 
 test('ModelNode#constructor', t => {
-  for (const device of getWebGLTestDevices()) {
+  for (const device of [webglDevice]) {
     const model = new Model(device, {vs: DUMMY_VS, fs: DUMMY_FS});
 
     const mNode1 = new ModelNode({model});

--- a/modules/engine/test/transform/buffer-transform.spec.ts
+++ b/modules/engine/test/transform/buffer-transform.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
+import {webglDevice} from '@luma.gl/test-utils';
 import {BufferTransform} from '@luma.gl/engine';
 import {Buffer, Device, glsl} from '@luma.gl/core';
 
@@ -22,9 +22,7 @@ void main() { fragColor.x = dst; }
 `;
 
 test('BufferTransform#constructor', async t => {
-  for (const device of getWebGLTestDevices()) {
-    t.ok(createBufferTransform(device), 'WebGL succeeds');
-  }
+    t.ok(createBufferTransform(webglDevice), 'WebGL succeeds');
   t.end();
 });
 
@@ -32,28 +30,27 @@ test('BufferTransform#run', async t => {
   const SRC_ARRAY = new Float32Array([0, 1, 2, 3, 4, 5]);
   const DST_ARRAY = new Float32Array([0, 1, 4, 9, 16, 25]);
 
-  for (const device of getWebGLTestDevices()) {
-    const src = device.createBuffer({data: SRC_ARRAY});
-    const dst = device.createBuffer({byteLength: 24});
+    const src = webglDevice.createBuffer({data: SRC_ARRAY});
+    const dst = webglDevice.createBuffer({byteLength: 24});
     const elementCount = 6;
-    const transform = createBufferTransform(device, src, dst, elementCount);
+    const transform = createBufferTransform(webglDevice, src, dst, elementCount);
 
     transform.run();
 
     const bytes = await transform.readAsync('dst');
     const array = new Float32Array(bytes.buffer, bytes.byteOffset, elementCount);
     t.deepEqual(array, DST_ARRAY, 'output transformed');
-  }
-  t.end();
+
+    t.end();
 });
 
 function createBufferTransform(
-  device: Device,
+  webglDevice: Device,
   src?: Buffer,
   dst?: Buffer,
   vertexCount?: number
 ): BufferTransform {
-  return new BufferTransform(device, {
+  return new BufferTransform(webglDevice, {
     vs: VS,
     fs: FS,
     vertexCount,

--- a/modules/engine/test/transform/texture-transform.spec.ts
+++ b/modules/engine/test/transform/texture-transform.spec.ts
@@ -3,135 +3,140 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
+import {webglDevice} from '@luma.gl/test-utils';
 import {TextureTransform} from '@luma.gl/engine';
 import {Device, Texture} from '@luma.gl/core';
 
 /** Creates a minimal, no-op transform. */
 test('TextureTransform#constructor', async t => {
-  for (const device of getWebGLTestDevices()) {
-    const targetTexture = device.createTexture({
-      data: new Float32Array([201, 202, 203, 1.0]),
-      width: 1,
-      height: 1,
-      format: 'rgba32float'
-    });
-    const transform = new TextureTransform(device, {
-      vs: BASIC_VS,
-      topology: 'point-list',
-      targetTexture,
-      targetTextureChannels: 1,
-      targetTextureVarying: 'vSrc',
-      vertexCount: 1
-    });
-    t.ok(transform, 'creates transform');
-  }
+  const targetTexture = webglDevice.createTexture({
+    data: new Float32Array([201, 202, 203, 1.0]),
+    width: 1,
+    height: 1,
+    format: 'rgba32float'
+  });
+  const transform = new TextureTransform(webglDevice, {
+    vs: BASIC_VS,
+    topology: 'point-list',
+    targetTexture,
+    targetTextureChannels: 1,
+    targetTextureVarying: 'vSrc',
+    vertexCount: 1
+  });
+  t.ok(transform, 'creates transform');
+
   t.end();
 });
 
 /** Computes a sum over vertex attribute values by writing to framebuffer. */
 test('TextureTransform#attribute', async t => {
-  for (const device of getWebGLTestDevices()) {
-    const src = device.createBuffer({data: new Float32Array([10, 20, 30, 70, 80, 90])});
-    const targetTexture = device.createTexture({
-      data: new Float32Array([201, 202, 203, 1.0]),
-      width: 1,
-      height: 1,
-      format: 'rgba32float'
-    });
-    const transform = new TextureTransform(device, {
-      vs: SUM_VS,
-      attributes: {src},
-      bufferLayout: [{name: 'src', format: 'float32'}],
-      topology: 'point-list',
-      targetTexture,
-      targetTextureChannels: 1,
-      targetTextureVarying: 'vSrc',
-      vertexCount: 6,
-      parameters: {
-        depthCompare: 'always',
-        blendColorOperation: 'add',
-        blendColorSrcFactor: 'one',
-        blendColorDstFactor: 'one'
-      }
-    });
-    const source = transform.getTargetTexture();
+  const src = webglDevice.createBuffer({data: new Float32Array([10, 20, 30, 70, 80, 90])});
+  const targetTexture = webglDevice.createTexture({
+    data: new Float32Array([201, 202, 203, 1.0]),
+    width: 1,
+    height: 1,
+    format: 'rgba32float'
+  });
+  const transform = new TextureTransform(webglDevice, {
+    vs: SUM_VS,
+    attributes: {src},
+    bufferLayout: [{name: 'src', format: 'float32'}],
+    topology: 'point-list',
+    targetTexture,
+    targetTextureChannels: 1,
+    targetTextureVarying: 'vSrc',
+    vertexCount: 6,
+    parameters: {
+      depthCompare: 'always',
+      blendColorOperation: 'add',
+      blendColorSrcFactor: 'one',
+      blendColorDstFactor: 'one'
+    }
+  });
+  const source = transform.getTargetTexture();
 
-    // TODO(donmccurdy): Consider having Transform inherit from Model, or at
-    // least mimic its API by accepting a RenderPass in .run().
-    transform.run({clearColor: [0, 0, 0, 0]});
+  // TODO(donmccurdy): Consider having Transform inherit from Model, or at
+  // least mimic its API by accepting a RenderPass in .run().
+  transform.run({clearColor: [0, 0, 0, 0]});
 
-    const sum = await readF32(device, source, 16);
-    t.is(sum[0], 300, 'computes sum');
+  const sum = await readF32(webglDevice, source, 16);
+  t.is(sum[0], 300, 'computes sum');
 
-    transform.destroy();
-  }
+  transform.destroy();
+
   t.end();
 });
 
 /** Computes a sum over texture pixels by writing to framebuffer. */
 test('TextureTransform#texture', async t => {
-  for (const device of getWebGLTestDevices()) {
-    const srcData = new Uint8Array([2, 10, 255, 255]);
-    const dstData = new Uint8Array([8, 40, 255, 255]); // src x 4
-    const dstOffsetData = new Uint8Array([108, 140, 255, 255]); // src x 4 + 100
+  const srcData = new Uint8Array([2, 10, 255, 255]);
+  const dstData = new Uint8Array([8, 40, 255, 255]); // src x 4
+  const dstOffsetData = new Uint8Array([108, 140, 255, 255]); // src x 4 + 100
 
-    const inputTexture = device.createTexture({
-      data: srcData,
-      width: 1,
-      height: 1,
-      format: 'rgba8unorm'
-    });
-    const targetTexture = device.createTexture({
-      data: new Uint8Array([0, 0, 0, 1]),
-      width: 1,
-      height: 1,
-      format: 'rgba8unorm'
-    });
-    const transform = new TextureTransform(device, {
-      vs: BLEND_VS,
-      fs: BLEND_FS,
-      topology: 'point-list',
-      vertexCount: 4,
-      targetTexture,
-      targetTextureChannels: 4,
-      targetTextureVarying: 'vUv',
-      bindings: {uSampler: inputTexture},
-      parameters: {
-        depthCompare: 'always',
-        blendColorOperation: 'add',
-        blendColorSrcFactor: 'one',
-        blendColorDstFactor: 'one'
-      }
-    });
+  const inputTexture = webglDevice.createTexture({
+    data: srcData,
+    width: 1,
+    height: 1,
+    format: 'rgba8unorm'
+  });
+  const targetTexture = webglDevice.createTexture({
+    data: new Uint8Array([0, 0, 0, 1]),
+    width: 1,
+    height: 1,
+    format: 'rgba8unorm'
+  });
+  const transform = new TextureTransform(webglDevice, {
+    vs: BLEND_VS,
+    fs: BLEND_FS,
+    topology: 'point-list',
+    vertexCount: 4,
+    targetTexture,
+    targetTextureChannels: 4,
+    targetTextureVarying: 'vUv',
+    bindings: {uSampler: inputTexture},
+    parameters: {
+      depthCompare: 'always',
+      blendColorOperation: 'add',
+      blendColorSrcFactor: 'one',
+      blendColorDstFactor: 'one'
+    }
+  });
 
-    // TODO(donmccurdy): Consider having Transform inherit from Model, or at
-    // least mimic its API by accepting a RenderPass in .run().
-    transform.run({clearColor: [0, 0, 0, 0]});
-    let blend = await readU8(device, targetTexture, 4);
-    t.deepEqual(Array.from(blend), Array.from(dstData), 'computes blend');
+  // TODO(donmccurdy): Consider having Transform inherit from Model, or at
+  // least mimic its API by accepting a RenderPass in .run().
+  transform.run({clearColor: [0, 0, 0, 0]});
+  let blend = await readU8(webglDevice, targetTexture, 4);
+  t.deepEqual(Array.from(blend), Array.from(dstData), 'computes blend');
 
-    const offset = 100 / 255;
-    transform.run({clearColor: [offset, offset, offset, 1]});
-    blend = await readU8(device, targetTexture, 4);
-    t.deepEqual(Array.from(blend), Array.from(dstOffsetData), 'computes blend');
+  const offset = 100 / 255;
+  transform.run({clearColor: [offset, offset, offset, 1]});
+  blend = await readU8(webglDevice, targetTexture, 4);
+  t.deepEqual(Array.from(blend), Array.from(dstOffsetData), 'computes blend');
 
-    transform.destroy();
-    inputTexture.destroy();
-    targetTexture.destroy();
-  }
+  transform.destroy();
+  inputTexture.destroy();
+  targetTexture.destroy();
+
   t.end();
 });
 
-async function readF32(device: Device, source: Texture, byteLength: number): Promise<Float32Array> {
-  const bytes = await readU8(device, source, byteLength);
+async function readF32(
+  webglDevice: Device,
+  source: Texture,
+  byteLength: number
+): Promise<Float32Array> {
+  const bytes = await readU8(webglDevice, source, byteLength);
   return new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
 }
 
-async function readU8(device: Device, source: Texture, byteLength: number): Promise<Uint8Array> {
-  const destination = device.createBuffer({byteLength});
+async function readU8(
+  webglDevice: Device,
+  source: Texture,
+  byteLength: number
+): Promise<Uint8Array> {
+  const destination = webglDevice.createBuffer({byteLength});
   try {
-    const cmd = device.createCommandEncoder();
+    const cmd = webglDevice.createCommandEncoder();
     cmd.copyTextureToBuffer({source, destination});
     cmd.finish();
     return destination.readAsync();

--- a/modules/test-utils/src/index.ts
+++ b/modules/test-utils/src/index.ts
@@ -9,7 +9,7 @@ export {PerformanceTestRunner} from './performance-test-runner';
 
 // TEST DEVICES
 export {webglDevice, webgpuDevice} from './create-test-device';
-export {getTestDevices, getWebGLTestDevices} from './create-test-device';
+export {getTestDevices} from './create-test-device';
 export {createTestDevice, createTestContext} from './create-test-device';
 
 // UTILS

--- a/modules/webgl/src/adapter/converters/texture-formats.ts
+++ b/modules/webgl/src/adapter/converters/texture-formats.ts
@@ -142,13 +142,12 @@ type Format = {
  */
 // prettier-ignore
 export const TEXTURE_FORMATS: Record<TextureFormat, Format> = {
-  // Unsized formats that leave the precision up to the driver.
-  // TODO - Fix bpp constants
-  // 'r8unorm-unsized': {gl: GL.LUMINANCE, b: 4, c: 2, bpp: 4},
+  // Unsized formats that leave the precision up to the driver. TODO - Fix bpp constants
   'rgb8unorm-unsized': {gl: GL.RGB, b: 4, c: 2, bpp: 4,
     dataFormat: GL.RGB, types: [GL.UNSIGNED_BYTE, GL.UNSIGNED_SHORT_5_6_5]},
   'rgba8unorm-unsized': {gl: GL.RGBA, b: 4, c: 2, bpp: 4,
     dataFormat: GL.RGBA, types: [GL.UNSIGNED_BYTE, GL.UNSIGNED_SHORT_4_4_4_4, GL.UNSIGNED_SHORT_5_5_5_1]},
+  // 'r8unorm-unsized': {gl: GL.LUMINANCE, b: 4, c: 2, bpp: 4},
   // 'rgb8unorm-srgb-unsized': {gl: GL.SRGB_EXT, b: 4, c: 2, bpp: 4, gl1Ext: SRGB},
   // 'rgba8unorm-srgb-unsized': {gl: GL.SRGB_ALPHA_EXT, b: 4, c: 2, bpp: 4, gl1Ext: SRGB},
 

--- a/modules/webgl/test/adapter/objects/webgl-renderbuffer.spec.ts
+++ b/modules/webgl/test/adapter/objects/webgl-renderbuffer.spec.ts
@@ -3,58 +3,54 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
+import {webglDevice} from '@luma.gl/test-utils';
 
 import {TextureFormat} from '@luma.gl/core';
 import {_WEBGLRenderbuffer as WEBGLRenderbuffer, _TEXTURE_FORMATS} from '@luma.gl/webgl';
 
 test('WebGL#WEBGLRenderbuffer construct/delete', t => {
-  for (const device of getWebGLTestDevices()) {
-    t.throws(
-      // @ts-ignore
-      () => new WEBGLRenderbuffer(),
-      'WEBGLRenderbuffer throws on missing gl context'
-    );
+  t.throws(
+    // @ts-ignore
+    () => new WEBGLRenderbuffer(),
+    'WEBGLRenderbuffer throws on missing gl context'
+  );
 
-    const renderbuffer = new WEBGLRenderbuffer(device, {
-      format: 'depth16unorm',
-      width: 1,
-      height: 1
-    });
-    t.ok(renderbuffer instanceof WEBGLRenderbuffer, 'WEBGLRenderbuffer construction successful');
+  const renderbuffer = new WEBGLRenderbuffer(webglDevice, {
+    format: 'depth16unorm',
+    width: 1,
+    height: 1
+  });
+  t.ok(renderbuffer instanceof WEBGLRenderbuffer, 'WEBGLRenderbuffer construction successful');
 
-    renderbuffer.destroy();
-    t.ok(renderbuffer instanceof WEBGLRenderbuffer, 'WEBGLRenderbuffer delete successful');
+  renderbuffer.destroy();
+  t.ok(renderbuffer instanceof WEBGLRenderbuffer, 'WEBGLRenderbuffer delete successful');
 
-    renderbuffer.destroy();
-    t.ok(renderbuffer instanceof WEBGLRenderbuffer, 'WEBGLRenderbuffer repeated delete successful');
-  }
+  renderbuffer.destroy();
+  t.ok(renderbuffer instanceof WEBGLRenderbuffer, 'WEBGLRenderbuffer repeated delete successful');
 
   t.end();
 });
 
 test('WebGL#WEBGLRenderbuffer format creation', t => {
-  for (const device of getWebGLTestDevices()) {
-    for (const formatName of Object.keys(_TEXTURE_FORMATS)) {
-      const format = formatName as TextureFormat;
-      if (WEBGLRenderbuffer.isTextureFormatSupported(device, format)) {
-        t.comment(format);
-        const renderbuffer = new WEBGLRenderbuffer(device, {format});
-        t.equals(
-          renderbuffer.format,
-          format,
-          `${device.info.type}: WEBGLRenderbuffer(${format}) created with correct format`
-        );
-        t.doesNotThrow(() => renderbuffer.resize({width: 100, height: 100}), 'resize ok');
-        t.equals(renderbuffer.width, 100);
-        t.equals(renderbuffer.height, 100);
-        renderbuffer.destroy();
-      } else {
-        // TODO - uncomment and make sure all formats are correct in TEXTURE_FORMATS table.
-        // t.comment(format);
-        // t.throws(() => new WEBGLRenderbuffer(device, {format}),
-        //   `${device.info.type}: WEBGLRenderbuffer(${format}) cannot be created with incorrect format`);
-      }
+  for (const formatName of Object.keys(_TEXTURE_FORMATS)) {
+    const format = formatName as TextureFormat;
+    if (WEBGLRenderbuffer.isTextureFormatSupported(webglDevice, format)) {
+      t.comment(format);
+      const renderbuffer = new WEBGLRenderbuffer(webglDevice, {format});
+      t.equals(
+        renderbuffer.format,
+        format,
+        `${webglDevice.info.type}: WEBGLRenderbuffer(${format}) created with correct format`
+      );
+      t.doesNotThrow(() => renderbuffer.resize({width: 100, height: 100}), 'resize ok');
+      t.equals(renderbuffer.width, 100);
+      t.equals(renderbuffer.height, 100);
+      renderbuffer.destroy();
+    } else {
+      // TODO - uncomment and make sure all formats are correct in TEXTURE_FORMATS table.
+      // t.comment(format);
+      // t.throws(() => new WEBGLRenderbuffer(webglDevice, {format}),
+      //   `${webglDevice.info.type}: WEBGLRenderbuffer(${format}) cannot be created with incorrect format`);
     }
   }
 

--- a/modules/webgl/test/adapter/resources/webgl-buffer.spec.ts
+++ b/modules/webgl/test/adapter/resources/webgl-buffer.spec.ts
@@ -6,17 +6,15 @@ import test from 'tape-promise/tape';
 import {Buffer} from '@luma.gl/core';
 import {WEBGLBuffer} from '@luma.gl/webgl';
 
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
+import {webglDevice as device} from '@luma.gl/test-utils';
 
 test('WEBGLBuffer#bind/unbind with index', t => {
-  for (const device of getWebGLTestDevices()) {
     const buffer = device.createBuffer({usage: Buffer.UNIFORM});
     device.gl.bindBufferBase(buffer.glTarget, 0, buffer.handle);
     t.ok(buffer instanceof Buffer, `${device.info.type} Buffer bind/unbind with index successful`);
     device.gl.bindBufferBase(buffer.glTarget, 0, null);
 
     buffer.destroy();
-  }
 
   t.end();
 });
@@ -25,7 +23,6 @@ test('WEBGLBuffer#write', async t => {
   const initialData = new Float32Array([1, 2, 3]);
   const updateData = new Float32Array([4, 5, 6]);
 
-  for (const device of getWebGLTestDevices()) {
     let buffer: WEBGLBuffer;
 
     buffer = device.createBuffer({usage: Buffer.VERTEX, data: initialData});
@@ -62,7 +59,7 @@ test('WEBGLBuffer#write', async t => {
     );
 
     buffer.destroy();
-  }
+
   t.end();
 });
 

--- a/modules/webgl/test/adapter/resources/webgl-vertex-array.spec.ts
+++ b/modules/webgl/test/adapter/resources/webgl-vertex-array.spec.ts
@@ -3,113 +3,109 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {getWebGLTestDevices} from '@luma.gl/test-utils';
+import {webglDevice as device} from '@luma.gl/test-utils';
 
 import {GL} from '@luma.gl/constants';
 import {WEBGLBuffer, WEBGLVertexArray} from '@luma.gl/webgl';
 
 // TODO(v9): Fix and re-enable test.
 test.skip('WEBGLVertexArray#divisors', t => {
-  for (const device of getWebGLTestDevices()) {
-    const vertexArray = new WEBGLVertexArray(device);
+  const vertexArray = new WEBGLVertexArray(device);
 
-    const maxVertexAttributes = device.limits.maxVertexAttributes;
+  const maxVertexAttributes = device.limits.maxVertexAttributes;
 
-    for (let i = 0; i < maxVertexAttributes; i++) {
-      device.gl.bindVertexArray(vertexArray.handle);
-      const divisor = device.gl.getVertexAttrib(i, GL.VERTEX_ATTRIB_ARRAY_DIVISOR);
-      device.gl.bindVertexArray(null);
+  for (let i = 0; i < maxVertexAttributes; i++) {
+    device.gl.bindVertexArray(vertexArray.handle);
+    const divisor = device.gl.getVertexAttrib(i, GL.VERTEX_ATTRIB_ARRAY_DIVISOR);
+    device.gl.bindVertexArray(null);
 
-      t.equal(divisor, 0, `vertex attribute ${i} should have 0 divisor`);
-    }
-
-    vertexArray.destroy();
+    t.equal(divisor, 0, `vertex attribute ${i} should have 0 divisor`);
   }
+
+  vertexArray.destroy();
+
   t.end();
 });
 
 // TODO(v9): Fix and re-enable test.
 test.skip('WEBGLVertexArray#enable', t => {
-  for (const device of getWebGLTestDevices()) {
-    const renderPipeline = device.createRenderPipeline({});
-    const vertexArray = device.createVertexArray({renderPipeline}) as WEBGLVertexArray;
+  const renderPipeline = device.createRenderPipeline({});
+  const vertexArray = device.createVertexArray({renderPipeline}) as WEBGLVertexArray;
 
-    const maxVertexAttributes = device.limits.maxVertexAttributes;
-    t.ok(maxVertexAttributes >= 8, 'maxVertexAttributes >= 8');
+  const maxVertexAttributes = device.limits.maxVertexAttributes;
+  t.ok(maxVertexAttributes >= 8, 'maxVertexAttributes >= 8');
 
-    for (let i = 1; i < maxVertexAttributes; i++) {
-      device.gl.bindVertexArray(vertexArray.handle);
-      const enabled = device.gl.getVertexAttrib(i, GL.VERTEX_ATTRIB_ARRAY_ENABLED);
-      device.gl.bindVertexArray(null);
+  for (let i = 1; i < maxVertexAttributes; i++) {
+    device.gl.bindVertexArray(vertexArray.handle);
+    const enabled = device.gl.getVertexAttrib(i, GL.VERTEX_ATTRIB_ARRAY_ENABLED);
+    device.gl.bindVertexArray(null);
 
-      t.equal(enabled, false, `vertex attribute ${i} should initially be disabled`);
-    }
-
-    for (let i = 0; i < maxVertexAttributes; i++) {
-      // @ts-ignore
-      vertexArray._enable(i);
-    }
-
-    for (let i = 0; i < maxVertexAttributes; i++) {
-      device.gl.bindVertexArray(vertexArray.handle);
-      const enabled = device.gl.getVertexAttrib(i, GL.VERTEX_ATTRIB_ARRAY_ENABLED);
-      device.gl.bindVertexArray(null);
-
-      t.equal(enabled, true, `vertex attribute ${i} should now be enabled`);
-    }
-
-    for (let i = 1; i < maxVertexAttributes; i++) {
-      // @ts-ignore
-      vertexArray._enable(i, false);
-    }
-
-    // t.equal(vertexArray.getParameter(GL.VERTEX_ATTRIB_ARRAY_ENABLED, {location: 0}), true,
-    //   'vertex attribute 0 should **NOT** be disabled');
-
-    for (let i = 1; i < maxVertexAttributes; i++) {
-      device.gl.bindVertexArray(vertexArray.handle);
-      const enabled = device.gl.getVertexAttrib(i, GL.VERTEX_ATTRIB_ARRAY_ENABLED);
-      device.gl.bindVertexArray(null);
-
-      t.equal(enabled, false, `vertex attribute ${i} should now be disabled`);
-    }
-
-    vertexArray.destroy();
-    renderPipeline.destroy();
+    t.equal(enabled, false, `vertex attribute ${i} should initially be disabled`);
   }
+
+  for (let i = 0; i < maxVertexAttributes; i++) {
+    // @ts-ignore
+    vertexArray._enable(i);
+  }
+
+  for (let i = 0; i < maxVertexAttributes; i++) {
+    device.gl.bindVertexArray(vertexArray.handle);
+    const enabled = device.gl.getVertexAttrib(i, GL.VERTEX_ATTRIB_ARRAY_ENABLED);
+    device.gl.bindVertexArray(null);
+
+    t.equal(enabled, true, `vertex attribute ${i} should now be enabled`);
+  }
+
+  for (let i = 1; i < maxVertexAttributes; i++) {
+    // @ts-ignore
+    vertexArray._enable(i, false);
+  }
+
+  // t.equal(vertexArray.getParameter(GL.VERTEX_ATTRIB_ARRAY_ENABLED, {location: 0}), true,
+  //   'vertex attribute 0 should **NOT** be disabled');
+
+  for (let i = 1; i < maxVertexAttributes; i++) {
+    device.gl.bindVertexArray(vertexArray.handle);
+    const enabled = device.gl.getVertexAttrib(i, GL.VERTEX_ATTRIB_ARRAY_ENABLED);
+    device.gl.bindVertexArray(null);
+
+    t.equal(enabled, false, `vertex attribute ${i} should now be disabled`);
+  }
+
+  vertexArray.destroy();
+  renderPipeline.destroy();
 
   t.end();
 });
 
 // TODO(v9): Fix and re-enable test.
 test.skip('WEBGLVertexArray#getConstantBuffer', t => {
-  for (const device of getWebGLTestDevices()) {
-    const vertexArray = new WEBGLVertexArray(device);
+  const vertexArray = new WEBGLVertexArray(device);
 
-    let buffer = vertexArray.getConstantBuffer(100, new Float32Array([5, 4, 3])) as WEBGLBuffer;
+  let buffer = vertexArray.getConstantBuffer(100, new Float32Array([5, 4, 3])) as WEBGLBuffer;
 
-    t.equal(buffer.byteLength, 1200, 'byteLength should match');
-    t.equal(buffer.bytesUsed, 1200, 'bytesUsed should match');
+  t.equal(buffer.byteLength, 1200, 'byteLength should match');
+  t.equal(buffer.bytesUsed, 1200, 'bytesUsed should match');
 
-    buffer = vertexArray.getConstantBuffer(5, new Float32Array([5, 3, 2])) as WEBGLBuffer;
-    t.equal(buffer.byteLength, 1200, 'byteLength should be unchanged');
-    t.equal(buffer.bytesUsed, 60, 'bytesUsed should have changed');
+  buffer = vertexArray.getConstantBuffer(5, new Float32Array([5, 3, 2])) as WEBGLBuffer;
+  t.equal(buffer.byteLength, 1200, 'byteLength should be unchanged');
+  t.equal(buffer.bytesUsed, 60, 'bytesUsed should have changed');
 
-    vertexArray.destroy();
+  vertexArray.destroy();
 
-    // if (device.isWebGL2) {
-    //   const vertexArray2 = WEBGLVertexArray.getDefaultArray(gl2);
-    //   buffer = vertexArray2.getConstantBuffer(5, new Float32Array([5, 3, 2]));
-    //   t.equal(buffer.byteLength, 60, 'byteLength should be unchanged');
-    //   t.equal(buffer.bytesUsed, 60, 'bytesUsed should have changed');
-    //   const data = buffer.getData();
-    //   t.deepEqual(
-    //     data,
-    //     new Float32Array([5, 3, 2, 5, 3, 2, 5, 3, 2, 5, 3, 2, 5, 3, 2]),
-    //     'Constant buffer was correctly set'
-    //   );
-    //   t.comment(JSON.stringify(data));
-    // }
-  }
+  // if (device.isWebGL2) {
+  //   const vertexArray2 = WEBGLVertexArray.getDefaultArray(gl2);
+  //   buffer = vertexArray2.getConstantBuffer(5, new Float32Array([5, 3, 2]));
+  //   t.equal(buffer.byteLength, 60, 'byteLength should be unchanged');
+  //   t.equal(buffer.bytesUsed, 60, 'bytesUsed should have changed');
+  //   const data = buffer.getData();
+  //   t.deepEqual(
+  //     data,
+  //     new Float32Array([5, 3, 2, 5, 3, 2, 5, 3, 2, 5, 3, 2, 5, 3, 2]),
+  //     'Constant buffer was correctly set'
+  //   );
+  //   t.comment(JSON.stringify(data));
+  // }
+
   t.end();
 });

--- a/modules/webgl/test/context/state-tracker/set-parameters.spec.ts
+++ b/modules/webgl/test/context/state-tracker/set-parameters.spec.ts
@@ -155,7 +155,6 @@ test('WebGLState#setGLParameters framebuffer', t => {
 });
 
 test('WebGLState#setGLParameters read-framebuffer (WebGL2 only)', t => {
-  // const webglDevice = createTestContext({webgl2: true, webgl1: false});
   resetGLParameters(webglDevice.gl);
 
   let fbHandle = getGLParameters(webglDevice.gl, [GL.READ_FRAMEBUFFER_BINDING])[

--- a/modules/webgpu/src/adapter/resources/webgpu-buffer.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-buffer.ts
@@ -45,7 +45,8 @@ export class WebGPUBuffer extends Buffer {
   }
 
   override destroy(): void {
-    this.handle.destroy();
+    this.handle?.destroy();
+    this.handle = null;
   }
 
   // WebGPU provides multiple ways to write a buffer...

--- a/modules/webgpu/src/adapter/resources/webgpu-external-texture.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-external-texture.ts
@@ -31,6 +31,7 @@ export class WebGPUExternalTexture extends ExternalTexture {
     // External textures are destroyed automatically,
     // as a microtask, instead of manually or upon garbage collection like other resources.
     // this.handle.destroy();
+    this.handle = null;
   }
 
   /** Set default sampler */

--- a/modules/webgpu/src/adapter/resources/webgpu-query-set.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-query-set.ts
@@ -30,6 +30,7 @@ export class WebGPUQuerySet extends QuerySet {
   }
 
   override destroy(): void {
-    this.handle.destroy();
+    this.handle?.destroy();
+    this.handle = null;
   }
 }

--- a/modules/webgpu/src/adapter/resources/webgpu-render-pipeline.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-render-pipeline.ts
@@ -51,6 +51,7 @@ export class WebGPURenderPipeline extends RenderPipeline {
 
   override destroy(): void {
     // WebGPURenderPipeline has no destroy method.
+    this.handle = null;
   }
 
   /**

--- a/modules/webgpu/src/adapter/resources/webgpu-sampler.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-sampler.ts
@@ -28,5 +28,6 @@ export class WebGPUSampler extends Sampler {
 
   override destroy(): void {
     // this.handle.destroy();
+    this.handle = null;
   }
 }

--- a/modules/webgpu/src/adapter/resources/webgpu-shader.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-shader.ts
@@ -42,6 +42,7 @@ export class WebGPUShader extends Shader {
   override destroy(): void {
     // Note: WebGPU does not offer a method to destroy shaders
     // this.handle.destroy();
+    this.handle = null;
   }
 
   /** Returns compilation info for this shader */

--- a/modules/webgpu/src/adapter/resources/webgpu-texture-view.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-texture-view.ts
@@ -39,5 +39,6 @@ export class WebGPUTextureView extends TextureView {
 
   override destroy(): void {
     // this.handle.destroy();
+    this.handle = null;
   }
 }

--- a/modules/webgpu/src/adapter/resources/webgpu-texture.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-texture.ts
@@ -52,7 +52,8 @@ export class WebGPUTexture extends Texture {
   }
 
   override destroy(): void {
-    this.handle.destroy();
+    this.handle?.destroy();
+    this.handle = null;
   }
 
   createView(props: TextureViewProps): WebGPUTextureView {

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -213,7 +213,7 @@ export class WebGPUDevice extends Device {
   }
 
   createFramebuffer(props: FramebufferProps): WebGPUFramebuffer {
-    throw new Error('Not implemented');
+    return new WebGPUFramebuffer(this, props);
   }
 
   createComputePipeline(props: ComputePipelineProps): WebGPUComputePipeline {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- WebGL debug libraries are loaded async, synchronously created device doesn't benefit and won't throw exceptions on GL errors.
#### Change List
- Remove getWebGLTestDevices() (we have only one)
- Make getTestDevices() (which is already async) use the async path for creating a device context. 
