### PR TITLE
chore: Avoid double yarn install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
   
       - name: Build code
         run: |
-          yarn bootstrap
+          yarn bootstrap-noinstall
   
       - name: Run tests
         run: |

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "bootstrap": "yarn && ocular-bootstrap",
+    "bootstrap-noinstall": "ocular-bootstrap",
     "postinstall": "echo postinstall",
     "start": "open https://luma.gl/docs/getting-started",
     "clean": "ocular-clean",


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- https://github.com/visgl/luma.gl/actions/runs/8176087831/job/22354700505?pr=1995
#### Change List
- new bootstrap-noinstall packag.json scriptthat doesn't run yarn
#### Comments
- Still double install - Looks like ocular-bootstrap script is also doing one more `yarn` just for good measure... Maybe an `ocular-install` script would be useful to break out and separate from build.
