### PR TITLE
Unbreak Model.setBufferLayout

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -422,6 +422,7 @@ export class Model {
     this.bufferLayout = this._gpuGeometry
       ? mergeBufferLayouts(bufferLayout, this._gpuGeometry.bufferLayout)
       : bufferLayout;
+    this._setPipelineNeedsUpdate('bufferLayout');
 
     // Recreate the pipeline
     this.pipeline = this._updatePipeline();
@@ -436,8 +437,6 @@ export class Model {
     if (this._gpuGeometry) {
       this._setGeometryAttributes(this._gpuGeometry);
     }
-
-    this._setPipelineNeedsUpdate('bufferLayout');
   }
 
   /**


### PR DESCRIPTION
Revert breaking change made in #1992

`vertexArray` and attributes are updated in `setBufferLayout` based on the new pipeline.

#### Change List
- Call `_setPipelineNeedsUpdate` before `_updatePipeline`
