### PR TITLE
chore(core): remove splitUniforms() utility & Model.moduleSettings

### DIFF
--- a/examples/tutorials/hello-gltf/app.ts
+++ b/examples/tutorials/hello-gltf/app.ts
@@ -66,7 +66,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         u_NormalMatrix: new Matrix4(worldMatrix).invert().transpose()
       });
 
-      model.updateModuleSettings({lightSources});
+      // model.updateModuleSettings({lightSources});
       model.draw(renderPass);
     });
     renderPass.end();
@@ -102,7 +102,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   }
 }
 
-const lightSources: LightingProps = {
+export const lightSources: LightingProps = {
   ambientLight: {
     color: [255, 133, 133],
     intensity: 1,

--- a/examples/tutorials/lighting/app-old.ts
+++ b/examples/tutorials/lighting/app-old.ts
@@ -132,22 +132,22 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       fs,
       geometry: new CubeGeometry(),
       modules: [phongMaterial],
-      moduleSettings: {
-        // material: {
-        //   specularColor: [255, 255, 255]
-        // },
-        // lights: [
-        //   {
-        //     type: 'ambient',
-        //     color: [255, 255, 255]
-        //   },
-        //   {
-        //     type: 'point',
-        //     color: [255, 255, 255],
-        //     position: [1, 2, 1]
-        //   }
-        // ]
-      },
+      // moduleSettings: {
+      // material: {
+      //   specularColor: [255, 255, 255]
+      // },
+      // lights: [
+      //   {
+      //     type: 'ambient',
+      //     color: [255, 255, 255]
+      //   },
+      //   {
+      //     type: 'point',
+      //     color: [255, 255, 255],
+      //     position: [1, 2, 1]
+      //   }
+      // ]
+      // },
       bindings: {
         uTexture: texture,
         app: this.uniformStore.getManagedUniformBuffer(device, 'app'),

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -12,7 +12,6 @@ import {GL} from '@luma.gl/constants';
 import {getShaderLayout} from '../helpers/get-shader-layout';
 import {withDeviceAndGLParameters} from '../converters/device-parameters';
 import {setUniform} from '../helpers/set-uniform';
-import {splitUniformsAndBindings} from '../../utils/split-uniforms-and-bindings';
 // import {copyUniform, checkUniformValues} from '../../classes/uniforms';
 
 import {WebGLDevice} from '../webgl-device';
@@ -273,11 +272,10 @@ export class WEBGLRenderPipeline extends RenderPipeline {
   // DEPRECATED METHODS
 
   override setUniformsWebGL(uniforms: Record<string, UniformValue>) {
-    const {bindings} = splitUniformsAndBindings(uniforms);
-    Object.keys(bindings).forEach(name => {
+    Object.keys(uniforms).forEach(name => {
       log.warn(
         `Unsupported value "${JSON.stringify(
-          bindings[name]
+          uniforms[name]
         )}" used in setUniforms() for key ${name}. Use setBindings() instead?`
       )();
     });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2000 
<!-- For other PRs without open issue -->
#### Background
- Concern about size of core module utilities.
#### Change List
- Testing a removal of `splitUniformsAndBindings()`
#### Result
- index.cjs (unminified) down from 76.9kb -> 76.5kb (~400 bytes).
