### PR TITLE
webgl: Check for WEBGLTextureView, not WEBGLTexture

### DIFF
--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -463,12 +463,12 @@ export class WEBGLRenderPipeline extends RenderPipeline {
             texture = value;
           } else if (
             value instanceof WEBGLFramebuffer &&
-            value.colorAttachments[0] instanceof WEBGLTexture
+            value.colorAttachments[0] instanceof WEBGLTextureView
           ) {
             log.warn(
               'Passing framebuffer in texture binding may be deprecated. Use fbo.colorAttachments[0] instead'
             )();
-            texture = value.colorAttachments[0];
+            texture = value.colorAttachments[0].texture;
           } else {
             throw new Error('No texture');
           }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

Causing a number of `'No texture'` crashes in deck, because `value.colorAttachments[0] instanceof WEBGLTexture` should never be true

<!-- For all the PRs -->
#### Change List
- Check for `WEBGLTextureView`, not `WEBGLTexture`
