### PR TITLE
chore: Strengthen Framebuffer.attachment typings

### DIFF
--- a/modules/core/src/adapter/resources/framebuffer.ts
+++ b/modules/core/src/adapter/resources/framebuffer.ts
@@ -42,15 +42,14 @@ export abstract class Framebuffer extends Resource<FramebufferProps> {
   /** Height of all attachments in this framebuffer */
   height: number;
   /** Color attachments */
-  colorAttachments: TextureView[] = [];
+  abstract colorAttachments: TextureView[];
   /** Depth-stencil attachment, if provided */
-  depthStencilAttachment: TextureView | null = null;
+  abstract depthStencilAttachment: TextureView | null;
 
   constructor(device: Device, props: FramebufferProps = {}) {
     super(device, props, Framebuffer.defaultProps);
     this.width = this.props.width;
     this.height = this.props.height;
-
     // NOTE: call from subclass constructor as we cannot call overridden methods here (subclass not yet constructed)
     // this.autoCreateAttachmentTextures();
   }

--- a/modules/test-utils/src/null-device/resources/null-framebuffer.ts
+++ b/modules/test-utils/src/null-device/resources/null-framebuffer.ts
@@ -5,9 +5,13 @@
 import type {FramebufferProps} from '@luma.gl/core';
 import {Framebuffer} from '@luma.gl/core';
 import type {NullDevice} from '../null-device';
+import type {NullTextureView} from './null-texture-view';
 
 export class NullFramebuffer extends Framebuffer {
   device: NullDevice;
+
+  colorAttachments: NullTextureView[] = [];
+  depthStencilAttachment: NullTextureView | null = null;
 
   constructor(device: NullDevice, props: FramebufferProps) {
     super(device, props);

--- a/modules/webgl/src/adapter/resources/webgl-command-buffer.ts
+++ b/modules/webgl/src/adapter/resources/webgl-command-buffer.ts
@@ -153,7 +153,9 @@ function _copyTextureToBuffer(device: WebGLDevice, options: CopyTextureToBufferO
     const webglBuffer = destination as WEBGLBuffer;
     const sourceWidth = width || framebuffer.width;
     const sourceHeight = height || framebuffer.height;
-    const sourceParams = getWebGLTextureParameters(framebuffer.texture.props.format);
+    const sourceParams = getWebGLTextureParameters(
+      framebuffer.colorAttachments[0].texture.props.format
+    );
     const sourceFormat = sourceParams.dataFormat;
     const sourceType = sourceParams.type;
 

--- a/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
+++ b/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
@@ -21,9 +21,8 @@ export class WEBGLFramebuffer extends Framebuffer {
   gl: WebGL2RenderingContext;
   handle: WebGLFramebuffer;
 
-  get texture() {
-    return this.colorAttachments[0];
-  }
+  colorAttachments: WEBGLTextureView[] = [];
+  depthStencilAttachment: WEBGLTextureView | null = null;
 
   constructor(device: WebGLDevice, props: FramebufferProps) {
     super(device, props);
@@ -48,7 +47,7 @@ export class WEBGLFramebuffer extends Framebuffer {
 
       // Walk the attachments
       for (let i = 0; i < this.colorAttachments.length; ++i) {
-        const attachment = this.colorAttachments[i] as WEBGLTextureView;
+        const attachment = this.colorAttachments[i];
         const attachmentPoint = GL.COLOR_ATTACHMENT0 + i;
         if (attachment) {
           this._attachOne(attachmentPoint, attachment);
@@ -58,7 +57,7 @@ export class WEBGLFramebuffer extends Framebuffer {
       if (this.depthStencilAttachment) {
         this._attachOne(
           getDepthStencilAttachmentWebGL(this.depthStencilAttachment.props.format),
-          this.depthStencilAttachment as WEBGLTextureView
+          this.depthStencilAttachment
         );
       }
 
@@ -120,10 +119,10 @@ export class WEBGLFramebuffer extends Framebuffer {
     // TODO Not clear that this is better than default destroy/create implementation
 
     for (const colorAttachment of this.colorAttachments) {
-      (colorAttachment.texture as WEBGLTexture).resize({width, height});
+      colorAttachment.texture.resize({width, height});
     }
     if (this.depthStencilAttachment) {
-      (this.depthStencilAttachment.texture as WEBGLTexture).resize({width, height});
+      this.depthStencilAttachment.texture.resize({width, height});
     }
     return this;
   }

--- a/modules/webgl/src/classic/copy-and-blit.ts
+++ b/modules/webgl/src/classic/copy-and-blit.ts
@@ -5,7 +5,6 @@
 import {Buffer, Texture, Framebuffer, FramebufferProps} from '@luma.gl/core';
 import {GL} from '@luma.gl/constants';
 
-import {WEBGLTextureView} from '../adapter/resources/webgl-texture-view';
 import {WEBGLFramebuffer} from '../adapter/resources/webgl-framebuffer';
 import {getGLTypeFromTypedArray, getTypedArrayFromGLType} from './typed-array-utils';
 import {glFormatToComponents, glTypeToBytes} from './format-utils';
@@ -52,7 +51,7 @@ export function readPixelsToArray(
 
   const {framebuffer, deleteFramebuffer} = getFramebuffer(source);
   // assert(framebuffer);
-  const {gl, handle} = framebuffer as WEBGLFramebuffer;
+  const {gl, handle} = framebuffer;
   sourceWidth = sourceWidth || framebuffer.width;
   sourceHeight = sourceHeight || framebuffer.height;
 
@@ -66,9 +65,7 @@ export function readPixelsToArray(
 
   // Deduce the type from color attachment if not provided.
   sourceType =
-    sourceType ||
-    (framebuffer.colorAttachments[attachment] as WEBGLTextureView)?.texture?.type ||
-    GL.UNSIGNED_BYTE;
+    sourceType || framebuffer.colorAttachments[attachment]?.texture?.type || GL.UNSIGNED_BYTE;
 
   // Deduce type and allocated pixelArray if needed
   target = getPixelArray(target, sourceType, sourceFormat, sourceWidth, sourceHeight);
@@ -122,7 +119,7 @@ export function readPixelsToBuffer(
   sourceHeight = sourceHeight || framebuffer.height;
 
   // Asynchronous read (PIXEL_PACK_BUFFER) is WebGL2 only feature
-  const webglFramebuffer = framebuffer as WEBGLFramebuffer;
+  const webglFramebuffer = framebuffer;
 
   // deduce type if not available.
   sourceType = sourceType || GL.UNSIGNED_BYTE;
@@ -194,7 +191,7 @@ export function copyToTexture(
 
   const {framebuffer, deleteFramebuffer} = getFramebuffer(source);
   // assert(framebuffer);
-  const webglFramebuffer = framebuffer as WEBGLFramebuffer;
+  const webglFramebuffer = framebuffer;
   const {device, handle} = webglFramebuffer;
   const isSubCopy =
     typeof targetX !== 'undefined' ||
@@ -274,20 +271,20 @@ export function copyToTexture(
 }
 
 function getFramebuffer(source: Texture | Framebuffer): {
-  framebuffer: Framebuffer;
+  framebuffer: WEBGLFramebuffer;
   deleteFramebuffer: boolean;
 } {
   if (!(source instanceof Framebuffer)) {
     return {framebuffer: toFramebuffer(source), deleteFramebuffer: true};
   }
-  return {framebuffer: source, deleteFramebuffer: false};
+  return {framebuffer: source as WEBGLFramebuffer, deleteFramebuffer: false};
 }
 
 /**
  * Wraps a given texture into a framebuffer object, that can be further used
  * to read data from the texture object.
  */
-export function toFramebuffer(texture: Texture, props?: FramebufferProps): Framebuffer {
+export function toFramebuffer(texture: Texture, props?: FramebufferProps): WEBGLFramebuffer {
   const {device, width, height, id} = texture;
   const framebuffer = device.createFramebuffer({
     ...props,
@@ -296,7 +293,7 @@ export function toFramebuffer(texture: Texture, props?: FramebufferProps): Frame
     height,
     colorAttachments: [texture]
   });
-  return framebuffer;
+  return framebuffer as WEBGLFramebuffer;
 }
 
 function getPixelArray(

--- a/modules/webgpu/src/adapter/resources/webgpu-framebuffer.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-framebuffer.ts
@@ -5,6 +5,7 @@
 import type {FramebufferProps} from '@luma.gl/core';
 import {Framebuffer} from '@luma.gl/core';
 import {WebGPUDevice} from '../webgpu-device';
+import {WebGPUTextureView} from '../resources/webgpu-texture-view';
 
 /**
  * Create new textures with correct size for all attachments.
@@ -12,6 +13,9 @@ import {WebGPUDevice} from '../webgpu-device';
  */
 export class WebGPUFramebuffer extends Framebuffer {
   readonly device: WebGPUDevice;
+
+  colorAttachments: WebGPUTextureView[] = [];
+  depthStencilAttachment: WebGPUTextureView | null = null;
 
   constructor(device: WebGPUDevice, props: FramebufferProps) {
     super(device, props);


### PR DESCRIPTION
For #2014

#### Background
- A couple of bugs have been patched around incorrect usage of colorAttachments, as delayed effect of TextureView adoption.
#### Change List
- Abstract framebuiffer attachment props can now be properly typed in sub classes, removing need for potentially "error hiding" type casts in code that access them.
