### PR TITLE
feat(core): Add factory destroy policy 'never' (9.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,10 @@ package-lock.json
 lerna-debug.log
 
 */**/yarn.lock
-yarn-error.log
 !website/yarn.lock
+
+*/**/.yarn/*
+*/**/yarn-error.log
 
 .yarn/*
 !.yarn/cache
@@ -35,7 +37,6 @@ yarn-error.log
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
-
 
 .project
 .DS_Store

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -219,24 +219,26 @@ export type DeviceProps = {
   /** Error handling */
   onError?: (error: Error) => unknown;
 
-  // DEBUG SETTINGS
+  // @deprecated Attach to existing context. Rename to handle? Use Device.attach?
+  gl?: WebGL2RenderingContext | null;
 
+  // DEBUG SETTINGS
   /** WebGL: Instrument WebGL2RenderingContext (at the expense of performance) */
   debug?: boolean;
   /** Break on WebGL functions matching these strings */
   break?: string[];
   /** WebGL: Initialize the SpectorJS WebGL debugger */
   spector?: boolean;
+
+  // EXPERIMENTAL SETTINGS
+  /** Set to false to disable WebGL state management instrumentation: TODO- Unclear if still supported / useful */
+  manageState?: boolean;
   /** Initialize all features on startup */
   initalizeFeatures?: boolean;
   /** Disable specific features */
   disabledFeatures?: Partial<Record<DeviceFeature, boolean>>;
-
-  /** TODO- Unclear if still supported: Set to false to disable WebGL state management instrumentation */
-  manageState?: boolean;
-
-  // @deprecated Attach to existing context. Rename to handle? Use Device.attach?
-  gl?: WebGL2RenderingContext | null;
+  /** Never destroy cached shaders and pipelines */
+  _factoryDestroyPolicy?: 'unused' | 'never';
 };
 
 /**
@@ -250,17 +252,12 @@ export abstract class Device {
     manageState: true,
     width: 800, // width are height are only used by headless gl
     height: 600,
-
     requestMaxLimits: true,
-    debug: Boolean(log.get('debug')), // Instrument context (at the expense of performance)
-    spector: Boolean(log.get('spector')), // Initialize the SpectorJS WebGL debugger
-    break: [],
 
-    // TODO - Change these after confirming things work as expected
-    initalizeFeatures: true,
-    disabledFeatures: {
-      'compilation-status-async-webgl': true
-    },
+    // Callbacks
+    onError: (error: Error) => log.error(error.message),
+
+    gl: null,
 
     // alpha: undefined,
     // depth: undefined,
@@ -270,10 +267,16 @@ export abstract class Device {
     // preserveDrawingBuffer: undefined,
     // failIfMajorPerformanceCaveat: undefined
 
-    gl: null,
+    debug: Boolean(log.get('debug')), // Instrument context (at the expense of performance)
+    spector: Boolean(log.get('spector')), // Initialize the SpectorJS WebGL debugger
+    break: (log.get('break') as string[]) || [],
 
-    // Callbacks
-    onError: (error: Error) => log.error(error.message)
+    // TODO - Change these after confirming things work as expected
+    initalizeFeatures: true,
+    disabledFeatures: {
+      'compilation-status-async-webgl': true
+    },
+    _factoryDestroyPolicy: 'unused'
   };
 
   get [Symbol.toStringTag](): string {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- We have implemented caching via the Pipeline and Shader Factory classes.
- This means that if the app is creating several identical such objects at the same time, we will only create one copy.
- However we destroy cached elements as soon as they are no longer referenced.
- An app that repeatedly creates and destroys an object (perhaps a temporary layer or transform) won't benefit.
- While the perfect model would probably be a system that held on to only a certain number of released objects on an LRU-basis, that would require more book-keeping.
- This. PR adds an experimental `Device` option `_factoryDestroyPolicy: 'never'` that simply stops destroying unused objects and keeps them in the cache.
- Intended to allow us to test whether longer life of cached items has sufficient performance advantages to be worthwhile.
#### Change List
- experimental `Device` option `_factoryDestroyPolicy: 'never'`
- Factory classes copy the option and avoid destroying object if it is set.
