### PR TITLE
chore(core): Remove webgl-only topologies (9.1)

### DIFF
--- a/docs/api-reference/core/resources/render-pipeline.md
+++ b/docs/api-reference/core/resources/render-pipeline.md
@@ -112,10 +112,8 @@ Describes how primitives (points, lines or triangles) are formed from vertexes.
 | `'point-list'`         | ✅     | ✅      | Each vertex defines a point primitive.                                                                 |
 | `'line-list'`          | ✅     | ✅      | Each consecutive pair of two vertices defines a line primitive.                                        |
 | `'line-strip'`         | ✅     | ✅      | Each vertex after the first defines a line primitive between it and the previous vertex.               |
-| `'line-loop-webgl'`    | ✅     | ❌      | As `line-strip`, connects the last vertex back to the first.                                           |
 | `'triangle-list'`      | ✅     | ✅      | Each consecutive triplet of three vertices defines a triangle primitive.                               |
 | `'triangle-strip'`     | ✅     | ✅      | Each vertex after the first two defines a triangle primitive between it and the previous two vertices. |
-| `'triangle-fan-webgl'` | ✅     | ❌      | A set of connected triangles that share one central vertex.                                            |
 
 
 ## Members

--- a/docs/api-reference/core/resources/transform-feedback.md
+++ b/docs/api-reference/core/resources/transform-feedback.md
@@ -124,11 +124,11 @@ WebGL APIs [`gl.endTransformFeedback`](https://developer.mozilla.org/en-US/docs/
 
 ## Enumerations
 
-| Primitive Mode | Compatible Topology                                     |
-| -------------- | ------------------------------------------------------- |
-| `GL.POINTS`    | `point-list`                                            |
-| `GL.LINES`     | `line-list`, `line-strip`, `line-loop-webgl`            |
-| `GL.TRIANGLES` | `triangle-list`, `triangle-strip`, `triangle-fan-webgl` |
+| Primitive Mode | Compatible Topology               |
+| -------------- | --------------------------------- |
+| `GL.POINTS`    | `point-list`                      |
+| `GL.LINES`     | `line-list`, `line-strip`         |
+| `GL.TRIANGLES` | `triangle-list`, `triangle-strip` |
 
 ## Limits
 

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -10,6 +10,12 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 
 *For detailed commit level logs that include alpha and beta releases, see the [CHANGELOG](https://github.com/visgl/luma.gl/blob/master/CHANGELOG.md) in the github repository.*
 
+## Upgrading to v9.1
+
+**@luma.gl/core**
+
+- `RenderPipeline.topology`: `line-loop-webgl` and `triangle-fan-webgl` topologies are no longer supported. Rebuild your geometries using `triangle-strip` and `line-list`.
+
 ## Upgrading to v9.0
 
 luma.gl v9 is a major modernization of the luma.gl API, with many breaking changes, so the upgrade notes for this release are unusually long. To facilitate porting to the v9 release we have also provided a

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -14,6 +14,7 @@ Target Date: Q2 2024
 - New [`luma.attachDevice()`](/docs/api-reference/core/luma#attachdevice) method - A `Device` can now be attached to a `WebGL2RenderingContext` without calling `WebGLDevice.attach()`.
 
 **@luma.gl/engine**
+
 - New `AsyncTexture` class allows applications to create textures from a URL or Promise.
 
 ## Version 9.0

--- a/modules/core/src/adapter/types/parameters.ts
+++ b/modules/core/src/adapter/types/parameters.ts
@@ -20,12 +20,8 @@ export type PrimitiveTopology =
   | 'point-list'
   | 'line-list'
   | 'line-strip'
-  /** @deprecated */
-  | 'line-loop-webgl'
   | 'triangle-list'
-  | 'triangle-strip'
-  /** @deprecated */
-  | 'triangle-fan-webgl';
+  | 'triangle-strip';
 
 export type IndexFormat = 'uint16' | 'uint32';
 

--- a/modules/engine/src/geometry/geometry.ts
+++ b/modules/engine/src/geometry/geometry.ts
@@ -9,14 +9,7 @@ import {uid} from '../utils/uid';
 export type GeometryProps = {
   id?: string;
   /** Determines how vertices are read from the 'vertex' attributes */
-  topology:
-    | 'point-list'
-    | 'line-list'
-    | 'line-strip'
-    | 'line-loop-webgl'
-    | 'triangle-list'
-    | 'triangle-strip'
-    | 'triangle-fan-webgl';
+  topology: 'point-list' | 'line-list' | 'line-strip' | 'triangle-list' | 'triangle-strip';
   /** Auto calculated from attributes if not provided */
   vertexCount?: number;
   attributes: Record<string, GeometryAttribute | TypedArray>;

--- a/modules/engine/src/geometry/gpu-geometry.ts
+++ b/modules/engine/src/geometry/gpu-geometry.ts
@@ -10,14 +10,7 @@ import {uid} from '../utils/uid';
 export type GPUGeometryProps = {
   id?: string;
   /** Determines how vertices are read from the 'vertex' attributes */
-  topology:
-    | 'point-list'
-    | 'line-list'
-    | 'line-strip'
-    | 'line-loop-webgl'
-    | 'triangle-list'
-    | 'triangle-strip'
-    | 'triangle-fan-webgl';
+  topology: 'point-list' | 'line-list' | 'line-strip' | 'triangle-list' | 'triangle-strip';
   /** Auto calculated from attributes if not provided */
   vertexCount: number;
   bufferLayout: BufferLayout[];

--- a/modules/gltf/src/gltf/gl-utils.ts
+++ b/modules/gltf/src/gltf/gl-utils.ts
@@ -32,10 +32,8 @@ export function convertGLDrawModeToTopology(
     case GLEnum.POINTS: return 'point-list';
     case GLEnum.LINES: return 'line-list';
     case GLEnum.LINE_STRIP: return 'line-strip';
-    case GLEnum.LINE_LOOP: return 'line-loop-webgl';
     case GLEnum.TRIANGLES: return 'triangle-list';
     case GLEnum.TRIANGLE_STRIP: return 'triangle-strip';
-    case GLEnum.TRIANGLE_FAN: return 'triangle-fan-webgl';
-    default: throw new Error(drawMode);
+    default: throw new Error(String(drawMode));
   }
 }

--- a/modules/webgl/src/adapter/helpers/webgl-topology-utils.ts
+++ b/modules/webgl/src/adapter/helpers/webgl-topology-utils.ts
@@ -86,10 +86,8 @@ export function getGLDrawMode(
     case 'point-list': return GL.POINTS;
     case 'line-list': return GL.LINES;
     case 'line-strip': return GL.LINE_STRIP;
-    case 'line-loop-webgl': return GL.LINE_LOOP;
     case 'triangle-list': return GL.TRIANGLES;
     case 'triangle-strip': return GL.TRIANGLE_STRIP;
-    case 'triangle-fan-webgl': return GL.TRIANGLE_FAN;
     default: throw new Error(topology);
   }
 }
@@ -101,10 +99,8 @@ export function getGLPrimitive(topology: PrimitiveTopology): GL.POINTS | GL.LINE
     case 'point-list': return GL.POINTS;
     case 'line-list': return GL.LINES;
     case 'line-strip': return GL.LINES;
-    case 'line-loop-webgl': return GL.LINES;
     case 'triangle-list': return GL.TRIANGLES;
     case 'triangle-strip': return GL.TRIANGLES;
-    case 'triangle-fan-webgl': return GL.TRIANGLES;
     default: throw new Error(topology);
   }
 }

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -78,17 +78,6 @@ export class WEBGLRenderPipeline extends RenderPipeline {
 
     // Merge provided layout with introspected layout
     this.shaderLayout = mergeShaderLayout(this.introspectedLayout, props.shaderLayout);
-
-    // WebGPU has more restrictive topology support than WebGL
-    switch (this.props.topology) {
-      case 'triangle-fan-webgl':
-      case 'line-loop-webgl':
-        log.warn(
-          `Primitive topology ${this.props.topology} is deprecated and will be removed in v9.1`
-        );
-        break;
-      default:
-    }
   }
 
   override destroy(): void {

--- a/modules/webgpu/src/adapter/resources/webgpu-render-pipeline.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-render-pipeline.ts
@@ -158,14 +158,6 @@ export class WebGPURenderPipeline extends RenderPipeline {
       ]
     };
 
-    // WebGPU has more restrictive topology support than WebGL
-    switch (this.props.topology) {
-      case 'triangle-fan-webgl':
-      case 'line-loop-webgl':
-        throw new Error(`WebGPU does not support primitive topology ${this.props.topology}`);
-      default:
-    }
-
     // Create a partially populated descriptor
     const descriptor: GPURenderPipelineDescriptor = {
       vertex,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- WebGPU is more restrictive than WebGL in which topologies (WebGL draw modes) it supports.
- Warnings have been present announcing that the two WebGL-only topologies (`triangle-fan-webgl` and `line-loop-webgl` ) will be removed in 9.1
- deck.gl 9.1 is going to have to update its triangle-fan geometries to run on WebGPU anyways, so there is not much point in keeping these around.
#### Change List
- Remove support for `triangle-fan-webgl` and `line-loop-webgl` topologies.
