### PR TITLE
chore(webgl): Avoid WEBGL_polygon_mode extension warning

### DIFF
--- a/modules/webgl/src/adapter/device-helpers/webgl-device-features.ts
+++ b/modules/webgl/src/adapter/device-helpers/webgl-device-features.ts
@@ -61,12 +61,8 @@ export class WebGLDeviceFeatures extends DeviceFeatures {
   }
 
   *[Symbol.iterator](): IterableIterator<DeviceFeature> {
-    for (const feature of Object.keys(WEBGL_FEATURES) as DeviceFeature[]) {
-      if (this.has(feature)) {
-        yield feature;
-      }
-    }
-    for (const feature of Object.keys(TEXTURE_FEATURES) as DeviceFeature[]) {
+    const features = this.getFeatures();
+    for (const feature of features) {
       if (this.has(feature)) {
         yield feature;
       }
@@ -98,14 +94,19 @@ export class WebGLDeviceFeatures extends DeviceFeatures {
   // FOR DEVICE
 
   initializeFeatures() {
-    // @ts-expect-error
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    for (const feature of this) {
-      // WebGL extensions are initialized by requesting them
+    // Initialize all features by checking them.
+    // Except WEBGL_polygon_mode since Chrome logs ugly console warnings
+    const features = this.getFeatures().filter(feature => feature !== 'polygon-mode-webgl');
+    for (const feature of features) {
+      this.has(feature);
     }
   }
 
   // IMPLEMENTATION
+
+  getFeatures() {
+    return [...Object.keys(WEBGL_FEATURES), ...Object.keys(TEXTURE_FEATURES)] as DeviceFeature[];
+  }
 
   /** Extract all WebGL features */
   protected getWebGLFeature(feature: DeviceFeature): boolean {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Start addressing console warnings.
#### Change List
- One warning comes from luma.gl initializing extensions at initialization, before we use them (which we temporarily reverted to since the v9 on-demand approach caused some deck.gl regression). 
- This PR avoids initializing the extension in question.
