### PR TITLE
fix: Support sharing cached Pipelines with different parameters/topology in WebGL

### DIFF
--- a/modules/core/src/adapter/resources/render-pipeline.ts
+++ b/modules/core/src/adapter/resources/render-pipeline.ts
@@ -110,6 +110,8 @@ export abstract class RenderPipeline extends Resource<RenderPipelineProps> {
   abstract draw(options: {
     /** Render pass to draw into (targeting screen or framebuffer) */
     renderPass?: RenderPass;
+    /** Parameters to be set before draw call. Note that most parameters can only be overridden in WebGL. */
+    parameters?: RenderPipelineParameters;
     /** vertex attributes */
     vertexArray: VertexArray;
     /** Number of "rows" in index buffer */

--- a/modules/core/src/adapter/resources/render-pipeline.ts
+++ b/modules/core/src/adapter/resources/render-pipeline.ts
@@ -110,8 +110,10 @@ export abstract class RenderPipeline extends Resource<RenderPipelineProps> {
   abstract draw(options: {
     /** Render pass to draw into (targeting screen or framebuffer) */
     renderPass?: RenderPass;
-    /** Parameters to be set before draw call. Note that most parameters can only be overridden in WebGL. */
+    /** Parameters to be set during draw call. Note that most parameters can only be overridden in WebGL. */
     parameters?: RenderPipelineParameters;
+    /** Topology. Note can only be overridden in WebGL. */
+    topology?: PrimitiveTopology;
     /** vertex attributes */
     vertexArray: VertexArray;
     /** Number of "rows" in index buffer */

--- a/modules/engine/src/lib/pipeline-factory.ts
+++ b/modules/engine/src/lib/pipeline-factory.ts
@@ -107,7 +107,7 @@ export class PipelineFactory {
       case 'webgl':
         // WebGL is more dynamic
         return `${vsHash}/${fsHash}V${varyingHash}BL${bufferLayoutHash}`;
-        
+
       default:
         // On WebGPU we need to rebuild the pipeline if topology, parameters or bufferLayout change
         const parameterHash = this._getHash(JSON.stringify(props.parameters));

--- a/modules/engine/src/lib/pipeline-factory.ts
+++ b/modules/engine/src/lib/pipeline-factory.ts
@@ -104,9 +104,10 @@ export class PipelineFactory {
     const bufferLayoutHash = this._getHash(JSON.stringify(props.bufferLayout));
 
     switch (this.device.type) {
-      // case 'webgl':
-      // WebGL is more dynamic
-      // return `${vsHash}/${fsHash}V${varyingHash}BL${bufferLayoutHash}`;
+      case 'webgl':
+        // WebGL is more dynamic
+        return `${vsHash}/${fsHash}V${varyingHash}BL${bufferLayoutHash}`;
+        
       default:
         // On WebGPU we need to rebuild the pipeline if topology, parameters or bufferLayout change
         const parameterHash = this._getHash(JSON.stringify(props.parameters));

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -390,7 +390,6 @@ export class Model {
         // (In WebGPU most parameters are encoded in the pipeline and cannot be changed per draw call)
         parameters: this.parameters,
         topology: this.topology
-
       });
     } finally {
       this._logDrawCallEnd();

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -385,10 +385,12 @@ export class Model {
         instanceCount: this.instanceCount,
         indexCount,
         transformFeedback: this.transformFeedback || undefined,
-        // WebGL shares underlying cached pipelines even for models that have different parameters, 
+        // WebGL shares underlying cached pipelines even for models that have different parameters and topology,
         // so we must provide our unique parameters to each draw
         // (In WebGPU most parameters are encoded in the pipeline and cannot be changed per draw call)
-        parameters: this.parameters
+        parameters: this.parameters,
+        topology: this.topology
+
       });
     } finally {
       this._logDrawCallEnd();

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -384,7 +384,11 @@ export class Model {
         vertexCount: this.vertexCount,
         instanceCount: this.instanceCount,
         indexCount,
-        transformFeedback: this.transformFeedback || undefined
+        transformFeedback: this.transformFeedback || undefined,
+        // WebGL shares underlying cached pipelines even for models that have different parameters, 
+        // so we must provide our unique parameters to each draw
+        // (In WebGPU most parameters are encoded in the pipeline and cannot be changed per draw call)
+        parameters: this.parameters
       });
     } finally {
       this._logDrawCallEnd();

--- a/modules/engine/test/lib/model.spec.ts
+++ b/modules/engine/test/lib/model.spec.ts
@@ -175,7 +175,11 @@ test('Model#topology', async t => {
     t.equal(model.topology, 'triangle-list', 'Pipeline has triangle-list topology');
     if (device.type === 'webgpu') {
       // Cached model in WebGL can have a different topology
-      t.equal(model.pipeline.props.topology, 'triangle-list', 'Pipeline has triangle-list topology');
+      t.equal(
+        model.pipeline.props.topology,
+        'triangle-list',
+        'Pipeline has triangle-list topology'
+      );
     }
 
     model.setTopology('line-strip');

--- a/modules/engine/test/lib/model.spec.ts
+++ b/modules/engine/test/lib/model.spec.ts
@@ -172,14 +172,22 @@ test('Model#topology', async t => {
       fragmentEntryPoint: 'fragmentMain'
     });
 
-    t.equal(model.pipeline.props.topology, 'triangle-list', 'Pipeline has triangle-list topology');
+    t.equal(model.topology, 'triangle-list', 'Pipeline has triangle-list topology');
+    if (device.type === 'webgpu') {
+      // Cached model in WebGL can have a different topology
+      t.equal(model.pipeline.props.topology, 'triangle-list', 'Pipeline has triangle-list topology');
+    }
 
     model.setTopology('line-strip');
 
     const renderPass = device.beginRenderPass({clearColor: [0, 0, 0, 0]});
     model.draw(renderPass);
 
-    t.equal(model.pipeline.props.topology, 'line-strip', 'Pipeline has line-strip topology');
+    t.equal(model.topology, 'line-strip', 'Pipeline has line-strip topology');
+    if (device.type === 'webgpu') {
+      // Cached model in WebGL can have a different topology
+      t.equal(model.pipeline.props.topology, 'line-strip', 'Pipeline has triangle-list topology');
+    }
 
     renderPass.end();
     device.submit();

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {UniformValue, RenderPipelineProps, Binding} from '@luma.gl/core';
-import type {ShaderLayout} from '@luma.gl/core';
+import type {RenderPipelineProps, RenderPipelineParameters} from '@luma.gl/core';
+import type {ShaderLayout, UniformValue, Binding} from '@luma.gl/core';
 import type {RenderPass, VertexArray} from '@luma.gl/core';
 import {RenderPipeline, log} from '@luma.gl/core';
 // import {getAttributeInfosFromLayouts} from '@luma.gl/core';
@@ -155,7 +155,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
    */
   draw(options: {
     renderPass: RenderPass;
-    /** vertex attributes */
+    parameters?: RenderPipelineParameters;
     vertexArray: VertexArray;
     vertexCount?: number;
     indexCount?: number;
@@ -168,6 +168,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
   }): boolean {
     const {
       renderPass,
+      parameters = this.props.parameters,
       vertexArray,
       vertexCount,
       // indexCount,
@@ -224,7 +225,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
 
     withDeviceAndGLParameters(
       this.device,
-      this.props.parameters,
+      parameters,
       webglRenderPass.glParameters,
       () => {
         if (isIndexed && isInstanced) {


### PR DESCRIPTION
For discussion.

#### Background
- Make sure we don't create more copies of a Program in WebGL than we need. Before this PR, we create one pipeline for every parameter configuration (just as we must in WebGPU).
#### Change List
- Renderpipeline.draw() now accepts optional `parameters` and `topology`.
- These are ignored on WebGPU but on WebGL these are used instead of `RenderPipeline.parameters/topology` if provided.
- PipelineFactor no longer includes topology and parameters in hash on WebGL

#### Notes
- 4 parameters can be changed in WebGPU should they be handled by this mechanism in parallel with existing mechanism?

#### Commentary

There is a balance between completely pushing this type of logic down into `core` and keeping `core` as a thin GPU API mapping layer. 

I have given this quite a bit of thought. By handling some small amounts of device differences like this in the `Model`, we can keep the complexity of the `@luma.gl/core` module low and we still hide WebGL/WebGPU differences from applications. 

There are a few other differences such as constant attributes and TransformFeedback that that are also handled this way. I feel that this is a good balance, better than the alternatives.

