### PR TITLE
feat(webgl): Add device.resetWebGL() for debugging

### DIFF
--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -479,7 +479,7 @@ export abstract class Device {
     throw new Error('not implemented');
   }
 
-  /** @deprecated */
+  /** @deprecated - will be removed - should use for debugging only */
   resetWebGL(): void {
     throw new Error('not implemented');
   }

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -479,6 +479,11 @@ export abstract class Device {
     throw new Error('not implemented');
   }
 
+  /** @deprecated */
+  resetWebGL(): void {
+    throw new Error('not implemented');
+  }
+
   timestamp: number = 0;
 
   /** A monotonic counter for tracking buffer and texture updates */

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -62,7 +62,11 @@ import {WEBGLTransformFeedback} from './resources/webgl-transform-feedback';
 import {WEBGLQuerySet} from './resources/webgl-query-set';
 
 import {readPixelsToArray, readPixelsToBuffer} from '../classic/copy-and-blit';
-import {setGLParameters, getGLParameters, resetGLParameters} from '../context/parameters/unified-parameter-api';
+import {
+  setGLParameters,
+  getGLParameters,
+  resetGLParameters
+} from '../context/parameters/unified-parameter-api';
 import {withGLParameters} from '../context/state-tracker/with-parameters';
 import {clear} from '../classic/clear';
 import {getWebGLExtension} from '../context/helpers/webgl-extensions';

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -417,6 +417,7 @@ ${device.info.vendor}, ${device.info.renderer} for canvas: ${device.canvasContex
   }
 
   override resetWebGL(): void {
+    log.warn('WebGLDevice.resetWebGL is deprecated, use only for debugging')();
     resetGLParameters(this.gl);
   }
 

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -62,7 +62,7 @@ import {WEBGLTransformFeedback} from './resources/webgl-transform-feedback';
 import {WEBGLQuerySet} from './resources/webgl-query-set';
 
 import {readPixelsToArray, readPixelsToBuffer} from '../classic/copy-and-blit';
-import {setGLParameters, getGLParameters} from '../context/parameters/unified-parameter-api';
+import {setGLParameters, getGLParameters, resetGLParameters} from '../context/parameters/unified-parameter-api';
 import {withGLParameters} from '../context/state-tracker/with-parameters';
 import {clear} from '../classic/clear';
 import {getWebGLExtension} from '../context/helpers/webgl-extensions';
@@ -410,6 +410,10 @@ ${device.info.vendor}, ${device.info.renderer} for canvas: ${device.canvasContex
     stencil?: any;
   }): void {
     clear(this, options);
+  }
+
+  override resetWebGL(): void {
+    resetGLParameters(this.gl);
   }
 
   //


### PR DESCRIPTION
When debugging issues with interleaved layers ([example](https://github.com/visgl/deck.gl/issues/8602)) it can be helpful to have some way of resetting WebGL state, to isolate whether state is leaking between applications. I realize this method is one we'd probably want to avoid in production code, but perhaps with providing on the device API during v9.0 and v9.1 development? Thanks!