### PR TITLE
fix(webgl): withParametersWebGL return value

### DIFF
--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -404,7 +404,7 @@ ${device.info.vendor}, ${device.info.renderer} for canvas: ${device.canvasContex
   }
 
   override withParametersWebGL(parameters: any, func: any): any {
-    withGLParameters(this.gl, parameters, func);
+    return withGLParameters(this.gl, parameters, func);
   }
 
   override clearWebGL(options?: {


### PR DESCRIPTION
This is breaking some test cases in deck.gl.

#### Change List
- `Device.withParametersWebGL` should return value from `func`
