### PR TITLE
Do not reset scissorTest in WEBGLRenderPass

### DIFF
--- a/modules/webgl/src/adapter/resources/webgl-render-pass.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pass.ts
@@ -81,8 +81,8 @@ export class WEBGLRenderPass extends RenderPass {
         glParameters.viewport = parameters.viewport;
       }
     }
-    glParameters.scissorTest = Boolean(parameters.scissorRect);
     if (parameters.scissorRect) {
+      glParameters.scissorTest = true;
       glParameters.scissor = parameters.scissorRect;
     }
     if (parameters.blendConstant) {


### PR DESCRIPTION
This is causing a regression in deck.gl's picking and collision filter. Calling `device.beginRenderPass()` or `renderPass.setParameters()` will always set `scissorTest` to `false`.

It could be argued that `beginRenderPass` is expected to reset the state (questionable because it doesn't do this to any other parameter), however `setParameters()` as a public method should never affect a value not present in the argument.

Alternatively we can allow `scissorRect` to accept `null` on which we disable scissor test.

#### Change List
- Only sets `scissorTest` if `scissorRect` is present
