### PR TITLE
webgl: Support colorMask in RenderPass

### DIFF
--- a/modules/core/src/adapter/types/parameters.ts
+++ b/modules/core/src/adapter/types/parameters.ts
@@ -181,8 +181,8 @@ export type RenderPassParameters = {
   /** Stencil operation "replace" sets the value to stencilReference */
   stencilReference?: number; // GPUStencilValue
 
-  /** Sets mask for channels (RGBA) to render/clear **/
-  colorMask?: boolean[];
+  /** Bitmask controlling which channels are are written to when drawing/clearing. defaulting to 0xF */
+  colorMask?: number;
 };
 
 export type RenderPipelineParameters = RasterizationParameters &

--- a/modules/core/src/adapter/types/parameters.ts
+++ b/modules/core/src/adapter/types/parameters.ts
@@ -180,6 +180,9 @@ export type RenderPassParameters = {
   blendConstant?: number[]; // GPUColor
   /** Stencil operation "replace" sets the value to stencilReference */
   stencilReference?: number; // GPUStencilValue
+
+  /** Sets mask for channels (RGBA) to render/clear **/
+  colorMask?: boolean[];
 };
 
 export type RenderPipelineParameters = RasterizationParameters &

--- a/modules/webgl/src/adapter/resources/webgl-render-pass.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pass.ts
@@ -17,8 +17,7 @@ const GL_STENCIL_BUFFER_BIT = 0x00000400;
 const GL_COLOR_BUFFER_BIT = 0x00004000;
 
 const GL_COLOR = 0x1800;
-const {RED, GREEN, BLUE, ALPHA} = GPUColorWrite;
-const COLOR_CHANNELS = [RED, GREEN, BLUE, ALPHA];
+const COLOR_CHANNELS = [0x1, 0x2, 0x4, 0x8]; // GPUColorWrite RED, GREEN, BLUE, ALPHA
 
 export class WEBGLRenderPass extends RenderPass {
   readonly device: WebGLDevice;

--- a/modules/webgl/src/adapter/resources/webgl-render-pass.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pass.ts
@@ -17,6 +17,8 @@ const GL_STENCIL_BUFFER_BIT = 0x00000400;
 const GL_COLOR_BUFFER_BIT = 0x00004000;
 
 const GL_COLOR = 0x1800;
+const {RED, GREEN, BLUE, ALPHA} = GPUColorWrite;
+const COLOR_CHANNELS = [RED, GREEN, BLUE, ALPHA];
 
 export class WEBGLRenderPass extends RenderPass {
   readonly device: WebGLDevice;
@@ -95,8 +97,11 @@ export class WEBGLRenderPass extends RenderPass {
       // Does this work?
       parameters[GL.STENCIL_REF] = parameters.stencilReference;
     }
+
     if (parameters.colorMask) {
-      glParameters.colorMask = parameters.colorMask;
+      glParameters.colorMask = COLOR_CHANNELS.map(channel =>
+        Boolean(channel & parameters.colorMask)
+      );
     }
 
     this.glParameters = glParameters;

--- a/modules/webgl/src/adapter/resources/webgl-render-pass.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pass.ts
@@ -95,6 +95,9 @@ export class WEBGLRenderPass extends RenderPass {
       // Does this work?
       parameters[GL.STENCIL_REF] = parameters.stencilReference;
     }
+    if (parameters.colorMask) {
+      glParameters.colorMask = parameters.colorMask;
+    }
 
     this.glParameters = glParameters;
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/pull/8636

When a WebGLRenderPass is created it [immediately does a clear()](https://github.com/visgl/luma.gl/blob/master/modules/webgl/src/adapter/resources/webgl-render-pass.ts#L36). deck.gl was previously setting a `colorMask` using `withParametersWebGL`, but now with this removed there is no way to set the `colorMask` before the clear operation. Doing it in `Pass.getLayerParameters()` is too late, as by then the `clear` operation has happened

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Support colorMask in RenderPass
