### PR TITLE
fix(webgl): disableWarnings option

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -287,9 +287,7 @@ export class Model {
       this.setIndexBuffer(props.indexBuffer);
     }
     if (props.attributes) {
-      this.setAttributes(props.attributes, {
-        disableWarnings: props.disableWarnings
-      });
+      this.setAttributes(props.attributes);
     }
     if (props.constantAttributes) {
       this.setConstantAttributes(props.constantAttributes);
@@ -565,7 +563,7 @@ export class Model {
           set = true;
         }
       }
-      if (!set && !(options?.disableWarnings || this.props.disableWarnings)) {
+      if (!set && !(options?.disableWarnings ?? this.props.disableWarnings)) {
         log.warn(
           `Model(${this.id}): Ignoring buffer "${buffer.id}" for unknown attribute "${bufferName}"`
         )();
@@ -590,7 +588,7 @@ export class Model {
       const attributeInfo = this._attributeInfos[attributeName];
       if (attributeInfo) {
         this.vertexArray.setConstantWebGL(attributeInfo.location, value);
-      } else if (!(options?.disableWarnings || this.props.disableWarnings)) {
+      } else if (!(options?.disableWarnings ?? this.props.disableWarnings)) {
         log.warn(
           `Model "${this.id}: Ignoring constant supplied for unknown attribute "${attributeName}"`
         )();

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -110,7 +110,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
         const validBindings = this.shaderLayout.bindings
           .map(binding => `"${binding.name}"`)
           .join(', ');
-        if (options?.disableWarnings) {
+        if (!options?.disableWarnings) {
           log.warn(
             `Unknown binding "${name}" in render pipeline "${this.id}", expected one of ${validBindings}`
           )();


### PR DESCRIPTION
#### Change List
- Model: use `this.props.disableWarnings` as fallback not override
- WEBGLRenderPipeline: correctly respects disableWarnings
