### PR TITLE
Disable warning about updateModuleSettings

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -301,7 +301,7 @@ export class Model {
       this.setUniforms(props.uniforms);
     }
     if (props.moduleSettings) {
-      log.warn('Model.props.moduleSettings is deprecated. Use Model.shaderInputs.setProps()')();
+      // log.warn('Model.props.moduleSettings is deprecated. Use Model.shaderInputs.setProps()')();
       this.updateModuleSettings(props.moduleSettings);
     }
     if (props.transformFeedback) {


### PR DESCRIPTION
Until `Model.shaderInputs.setProps` supports bindings, `Model.updateModuleSettings` is still necessary.

#### Change List
- Disable inaccurate warning
