### PR TITLE
fix(shadertools): Fix ../.. imports

### DIFF
--- a/modules/core/src/adapter/resources/render-pass.ts
+++ b/modules/core/src/adapter/resources/render-pass.ts
@@ -7,7 +7,7 @@ import type {RenderPassParameters} from '../types/parameters';
 // import {Binding} from '../types/shader-layout';
 import {Resource, ResourceProps} from './resource';
 import {Framebuffer} from './framebuffer';
-import {NumberArray} from '../..';
+import {NumberArray} from '../../types';
 import {QuerySet} from './query-set';
 
 /**

--- a/modules/core/src/adapter/type-utils/vertex-format-from-attribute.ts
+++ b/modules/core/src/adapter/type-utils/vertex-format-from-attribute.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {TypedArray, TypedArrayConstructor} from '../..';
+import {TypedArray, TypedArrayConstructor} from '../../types';
 import {VertexFormat} from '../types/vertex-formats';
 
 // import {DataType} from '../types/vertex-formats';

--- a/modules/shadertools/src/modules-webgl1/project/project.ts
+++ b/modules/shadertools/src/modules-webgl1/project/project.ts
@@ -4,7 +4,7 @@
 
 import {Matrix4} from '@math.gl/core';
 import {glsl} from '../../lib/glsl-utils/highlight';
-import {ShaderModule} from '../..';
+import {ShaderModule} from '../../lib/shader-module/shader-module';
 
 type ProjectionProps = {
   modelMatrix?: readonly number[];

--- a/modules/webgl/src/adapter/resources/webgl-vertex-array.ts
+++ b/modules/webgl/src/adapter/resources/webgl-vertex-array.ts
@@ -11,7 +11,6 @@ import {WebGLDevice} from '../webgl-device';
 import {WEBGLBuffer} from '../resources/webgl-buffer';
 
 import {getGLFromVertexType} from '../converters/vertex-formats';
-// import {AccessorObject} from '../..';
 // import {getGLFromVertexType} from '../converters/vertex-formats';
 
 /** VertexArrayObject wrapper */


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/8711
#### Background
- Broken '../..'  import, probably injected by vscode.
#### Change List
- Fix the import
#### Notes
- There seem to be two more cases on the release branch that have already been fixed on master, will make a separate PR for those.
