### PR TITLE
fix(webgl): Render pass parameter handling

### DIFF
--- a/modules/webgl/src/adapter/resources/webgl-render-pass.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pass.ts
@@ -39,9 +39,6 @@ export class WEBGLRenderPass extends RenderPass {
 
   end(): void {
     popContextState(this.device.gl);
-    if (this.props.framebuffer) {
-      setGLParameters(this.device.gl, {framebuffer: null});
-    }
     // should add commands to CommandEncoder.
   }
 
@@ -58,7 +55,7 @@ export class WEBGLRenderPass extends RenderPass {
    * Maps RenderPass parameters to GL parameters
    */
   setParameters(parameters: RenderPassParameters = {}): void {
-    const glParameters: GLParameters = {};
+    const glParameters: GLParameters = {...this.glParameters};
 
     // Framebuffers are specified using parameters in WebGL
     glParameters.framebuffer = this.props.framebuffer || null;


### PR DESCRIPTION
#### Change List
- WEBGLRenderPass.end(): `popContextState` already restores framebuffer binding to what it was before `beginRenderPass()`. Should not mutate global state.
- `WEBGLRenderPass.setParameters()`: partially modify, not replace, `glParameters`
