### PR TITLE
fix(webgl): enable polygon offset with depthBias

### DIFF
--- a/modules/webgl/src/adapter/converters/device-parameters.ts
+++ b/modules/webgl/src/adapter/converters/device-parameters.ts
@@ -150,6 +150,7 @@ export function setDeviceParameters(device: Device, parameters: Parameters) {
   }
 
   if (parameters.depthBias !== undefined) {
+    gl.enable(GL.POLYGON_OFFSET_FILL);
     gl.polygonOffset(parameters.depthBias, parameters.depthBiasSlopeScale || 0);
   }
 


### PR DESCRIPTION
`gl.polygonOffset()` is only effective if `POLYGON_OFFSET_FILL` is enabled.

#### Change List
- Enable `POLYGON_OFFSET_FILL` when using `gl.polygonOffset()`
