### PR TITLE
fix(webgl): shader debug

### DIFF
--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -319,7 +319,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
           throw new Error(`Error during compilation of shader ${this.vs.id}`);
         }
         if (this.fs?.compilationStatus === 'error') {
-          this.vs.debugShader();
+          this.fs.debugShader();
           throw new Error(`Error during compilation of shader ${this.fs.id}`);
         }
         throw new Error(`Error during ${status}: ${this.device.gl.getProgramInfoLog(this.handle)}`);


### PR DESCRIPTION
#### Change List
- Correct typo

Overall I am not sure what this code path is supposed to do. According to 

https://github.com/visgl/luma.gl/blob/0d1f1d9f402dd40c5339f24fa2cf47ed7409b8d0/modules/webgl/src/adapter/resources/webgl-shader.ts#L71-L74

If `log.level = 0`, then `compilationStatus` will never be `'error'`
If `log.level = 1`, then the shader instance would have called `debugShader()` already.
