### PR TITLE
fix(webgl): Support instanceCount=0 in draw()

### DIFF
--- a/examples/showcase/instancing/index.html
+++ b/examples/showcase/instancing/index.html
@@ -5,7 +5,7 @@
   import {WebGLDevice} from '@luma.gl/webgl';
   import {WebGPUDevice} from '@luma.gl/webgpu';
   import AnimationLoopTemplate from './app.ts';
-  luma.registerDevices([WebGPUDevice, WebGLDevice]);
+  luma.registerDevices([/*WebGPUDevice, */WebGLDevice]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/modules/core/src/adapter/resources/render-pipeline.ts
+++ b/modules/core/src/adapter/resources/render-pipeline.ts
@@ -72,7 +72,7 @@ export abstract class RenderPipeline extends Resource<RenderPipelineProps> {
     parameters: {},
 
     vertexCount: 0,
-    instanceCount: 0,
+    instanceCount: undefined,
 
     bindings: {},
     uniforms: {}

--- a/modules/core/src/adapter/resources/render-pipeline.ts
+++ b/modules/core/src/adapter/resources/render-pipeline.ts
@@ -40,10 +40,12 @@ export type RenderPipelineProps = ResourceProps & {
   /** Parameters that are controlled by pipeline */
   parameters?: RenderPipelineParameters;
 
-  /** Number of vertices */
-  vertexCount?: number;
-  /** Number of instances */
-  instanceCount?: number;
+  // /** Use instanced rendering? */
+  // isInstanced?: boolean;
+  // /** Number of instances */
+  // instanceCount?: number;
+  // /** Number of vertices */
+  // vertexCount?: number;
 
   /** Buffers, Textures, Samplers for the shader bindings */
   bindings?: Record<string, Binding>;
@@ -71,8 +73,9 @@ export abstract class RenderPipeline extends Resource<RenderPipelineProps> {
     topology: 'triangle-list',
     parameters: {},
 
-    vertexCount: 0,
-    instanceCount: undefined,
+    // isInstanced: false,
+    // instanceCount: 0,
+    // vertexCount: 0,
 
     bindings: {},
     uniforms: {}
@@ -116,12 +119,14 @@ export abstract class RenderPipeline extends Resource<RenderPipelineProps> {
     topology?: PrimitiveTopology;
     /** vertex attributes */
     vertexArray: VertexArray;
-    /** Number of "rows" in index buffer */
-    indexCount?: number;
-    /** Number of "rows" in 'vertex' buffers */
-    vertexCount?: number;
+    /** Use instanced rendering? */
+    isInstanced?: boolean;
     /** Number of "rows" in 'instance' buffers */
     instanceCount?: number;
+    /** Number of "rows" in 'vertex' buffers */
+    vertexCount?: number;
+    /** Number of "rows" in index buffer */
+    indexCount?: number;
     /** First vertex to draw from */
     firstVertex?: number;
     /** First index to draw from */

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -53,7 +53,7 @@ export type ModelProps = Omit<RenderPipelineProps, 'vs' | 'fs' | 'bindings'> & {
   /** Geometry */
   geometry?: GPUGeometry | Geometry | null;
 
-  /** Use instanced rendering?  */
+  /** @deprecated Use instanced rendering? Will be auto-detected in 9.1 */
   isInstanced?: boolean;
   /** instance count */
   instanceCount?: number;
@@ -285,8 +285,9 @@ export class Model {
 
     // Apply any dynamic settings that will not trigger pipeline change
     if (props.isInstanced) {
-      this.setInstanced(props.isInstanced);
+      this.isInstanced = props.isInstanced;
     }
+
     if (props.instanceCount) {
       this.setInstanceCount(props.instanceCount);
     }
@@ -485,18 +486,13 @@ export class Model {
 
   // Update dynamic fields
 
-  /** Specify whether instanced rendering should be used */
-  setInstanced(isInstanced: boolean = true): void {
-    this.isInstanced = isInstanced;
-    this.setNeedsRedraw('instanced');
-  }
-
   /**
    * Updates the instance count (used in draw calls)
    * @note Any attributes with stepMode=instance need to be at least this big
    */
   setInstanceCount(instanceCount: number): void {
     this.instanceCount = instanceCount;
+    // luma.gl examples don't set props.isInstanced
     if (instanceCount > 0) {
       this.isInstanced = true;
     }

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -149,8 +149,8 @@ export class Model {
 
   /** Vertex count */
   vertexCount: number;
-  /** instance count */
-  instanceCount: number = 0;
+  /** instance count. `undefined` means not instanced */
+  instanceCount: number | undefined = undefined;
 
   /** Index buffer */
   indexBuffer: Buffer | null = null;

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -45,19 +45,20 @@ export type ModelProps = Omit<RenderPipelineProps, 'vs' | 'fs' | 'bindings'> & {
 
   /** Shader inputs, used to generated uniform buffers and bindings */
   shaderInputs?: ShaderInputs;
-
+  /** Bindings */
   bindings?: Record<string, Binding | AsyncTexture>;
-
   /** Parameters that are built into the pipeline */
   parameters?: RenderPipelineParameters;
 
   /** Geometry */
   geometry?: GPUGeometry | Geometry | null;
 
-  /** Vertex count */
-  vertexCount?: number;
+  /** Use instanced rendering?  */
+  isInstanced?: boolean;
   /** instance count */
   instanceCount?: number;
+  /** Vertex count */
+  vertexCount?: number;
 
   indexBuffer?: Buffer | null;
   /** @note this is really a map of buffers, not a map of attributes */
@@ -113,6 +114,10 @@ export class Model {
     constantAttributes: {},
     varyings: [],
 
+    isInstanced: false,
+    instanceCount: 0,
+    vertexCount: 0,
+
     shaderInputs: undefined!,
     pipelineFactory: undefined!,
     shaderFactory: undefined!,
@@ -147,10 +152,12 @@ export class Model {
 
   // Dynamic properties
 
+  /** Use instanced rendering */
+  isInstanced: boolean = false;
+  /** instance count. `undefined` means not instanced */
+  instanceCount: number = 0;
   /** Vertex count */
   vertexCount: number;
-  /** instance count. `undefined` means not instanced */
-  instanceCount: number | undefined = undefined;
 
   /** Index buffer */
   indexBuffer: Buffer | null = null;
@@ -277,11 +284,14 @@ export class Model {
     }
 
     // Apply any dynamic settings that will not trigger pipeline change
-    if (props.vertexCount) {
-      this.setVertexCount(props.vertexCount);
+    if (props.isInstanced) {
+      this.setInstanced(props.isInstanced);
     }
     if (props.instanceCount) {
       this.setInstanceCount(props.instanceCount);
+    }
+    if (props.vertexCount) {
+      this.setVertexCount(props.vertexCount);
     }
     if (props.indexBuffer) {
       this.setIndexBuffer(props.indexBuffer);
@@ -379,6 +389,7 @@ export class Model {
       drawSuccess = this.pipeline.draw({
         renderPass,
         vertexArray: this.vertexArray,
+        isInstanced: this.isInstanced,
         vertexCount: this.vertexCount,
         instanceCount: this.instanceCount,
         indexCount,
@@ -474,6 +485,24 @@ export class Model {
 
   // Update dynamic fields
 
+  /** Specify whether instanced rendering should be used */
+  setInstanced(isInstanced: boolean = true): void {
+    this.isInstanced = isInstanced;
+    this.setNeedsRedraw('instanced');
+  }
+
+  /**
+   * Updates the instance count (used in draw calls)
+   * @note Any attributes with stepMode=instance need to be at least this big
+   */
+  setInstanceCount(instanceCount: number): void {
+    this.instanceCount = instanceCount;
+    if (instanceCount > 0) {
+      this.isInstanced = true;
+    }
+    this.setNeedsRedraw('instanceCount');
+  }
+
   /**
    * Updates the vertex count (used in draw calls)
    * @note Any attributes with stepMode=vertex need to be at least this big
@@ -483,15 +512,7 @@ export class Model {
     this.setNeedsRedraw('vertexCount');
   }
 
-  /**
-   * Updates the instance count (used in draw calls)
-   * @note Any attributes with stepMode=instance need to be at least this big
-   */
-  setInstanceCount(instanceCount: number): void {
-    this.instanceCount = instanceCount;
-    this.setNeedsRedraw('instanceCount');
-  }
-
+  /** Set the shader inputs */
   setShaderInputs(shaderInputs: ShaderInputs): void {
     this.shaderInputs = shaderInputs;
     this._uniformStore = new UniformStore(this.shaderInputs.modules);
@@ -503,6 +524,7 @@ export class Model {
     this.setNeedsRedraw('shaderInputs');
   }
 
+  /** Update uniform buffers from the model's shader inputs */
   updateShaderInputs(): void {
     this._uniformStore.setUniforms(this.shaderInputs.getUniformValues());
     // TODO - this is already tracked through buffer/texture update times?

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -114,7 +114,7 @@ export class Model {
     constantAttributes: {},
     varyings: [],
 
-    isInstanced: false,
+    isInstanced: undefined!,
     instanceCount: 0,
     vertexCount: 0,
 
@@ -153,7 +153,7 @@ export class Model {
   // Dynamic properties
 
   /** Use instanced rendering */
-  isInstanced: boolean = false;
+  isInstanced: boolean | undefined = undefined;
   /** instance count. `undefined` means not instanced */
   instanceCount: number = 0;
   /** Vertex count */
@@ -492,8 +492,9 @@ export class Model {
    */
   setInstanceCount(instanceCount: number): void {
     this.instanceCount = instanceCount;
-    // luma.gl examples don't set props.isInstanced
-    if (instanceCount > 0) {
+    // luma.gl examples don't set props.isInstanced and rely on auto-detection
+    // but deck.gl sets instanceCount even for models that are not instanced.
+    if (this.isInstanced === undefined && instanceCount > 0) {
       this.isInstanced = true;
     }
     this.setNeedsRedraw('instanceCount');

--- a/modules/test-utils/src/null-device/resources/null-render-pipeline.ts
+++ b/modules/test-utils/src/null-device/resources/null-render-pipeline.ts
@@ -47,16 +47,8 @@ export class NullRenderPipeline extends RenderPipeline {
     instanceCount?: number;
   }): boolean {
     const {renderPass, vertexArray} = options;
-
-    // const isIndexed: boolean = Boolean(vertexArray.indexBuffer);
-    // const isInstanced: boolean = Number(instanceCount) > 0;
-
     vertexArray.bindBeforeRender(renderPass);
-
-    // TODO - verify buffer size
-
     vertexArray.unbindAfterRender(renderPass);
-
     return true;
   }
 }

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -185,7 +185,8 @@ export class WEBGLRenderPipeline extends RenderPipeline {
     const glDrawMode = getGLDrawMode(topology);
     const isIndexed: boolean = Boolean(vertexArray.indexBuffer);
     const glIndexType = (vertexArray.indexBuffer as WEBGLBuffer)?.glIndexType;
-    const isInstanced: boolean = Number(instanceCount) > 0;
+    // Note that we sometimes get called with 0 instances
+    const isInstanced: boolean = Number(instanceCount) >= 0;
 
     // If we are using async linking, we need to wait until linking completes
     if (this.linkStatus !== 'success') {

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -158,6 +158,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
     parameters?: RenderPipelineParameters;
     topology?: PrimitiveTopology;
     vertexArray: VertexArray;
+    isInstanced?: boolean;
     vertexCount?: number;
     indexCount?: number;
     instanceCount?: number;
@@ -175,6 +176,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
       vertexCount,
       // indexCount,
       instanceCount,
+      isInstanced = false,
       firstVertex = 0,
       // firstIndex,
       // firstInstance,
@@ -186,7 +188,6 @@ export class WEBGLRenderPipeline extends RenderPipeline {
     const isIndexed: boolean = Boolean(vertexArray.indexBuffer);
     const glIndexType = (vertexArray.indexBuffer as WEBGLBuffer)?.glIndexType;
     // Note that we sometimes get called with 0 instances
-    const isInstanced: boolean = Number(instanceCount) >= 0;
 
     // If we are using async linking, we need to wait until linking completes
     if (this.linkStatus !== 'success') {

--- a/test/apps/tree-shaking/app.js
+++ b/test/apps/tree-shaking/app.js
@@ -52,7 +52,7 @@ function makeInstancedCube(gl) {
   const colors = new Float32Array(SIDE * SIDE * 3).map(() => Math.random() * 0.75 + 0.25);
 
   return new Cube(gl, {
-    isInstanced: 1,
+    isInstanced: true,
     instanceCount: SIDE * SIDE,
     attributes: {
       instanceOffsets: {value: offsets, size: 2, divisor: 1},


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #https://github.com/visgl/deck.gl/issues/8776
<!-- For other PRs without open issue -->
#### Background
- Setting instanceCount to 0 makes the model draw in non-instanced mode, instead of nothing.
#### Change List
- Add Model.props.isInstanced, Model.setInstanced and RenderPipeline.draw({isInstanced})
- Set isInstanced if instanceCount>0 
