### PR TITLE
fix(engine) Model handling props.isInstanced: false

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -284,7 +284,7 @@ export class Model {
     }
 
     // Apply any dynamic settings that will not trigger pipeline change
-    if (props.isInstanced) {
+    if ('isInstanced' in props) {
       this.isInstanced = props.isInstanced;
     }
 


### PR DESCRIPTION
Follow up of #2070

`this.isInstanced` should be assigned if `props.isInstanced` is `false`.

#### Change List
- Fix prop presence check
