### PR TITLE
shadertools: Resolve dependencies in ShaderInputs

### DIFF
--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -68,13 +68,14 @@ export class ShaderInputs<
       false
     );
     for (const resolvedModule of resolvedModules) {
-      // @ts-ignore
+      // @ts-expect-error Fix typings
       modules[resolvedModule.name] = resolvedModule;
     }
 
     log.log(1, 'Creating ShaderInputs with modules', Object.keys(modules))();
 
     // Store the module definitions and create storage for uniform values and binding values, per module
+    // @ts-expect-error Fix typings
     this.modules = modules as {[P in keyof ShaderPropsT]: ShaderModuleInputs<ShaderPropsT[P]>};
     this.moduleUniforms = {} as Record<keyof ShaderPropsT, Record<string, UniformValue>>;
     this.moduleBindings = {} as Record<keyof ShaderPropsT, Record<string, Texture | Sampler>>;

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -5,7 +5,7 @@
 import type {UniformValue, Texture, Sampler} from '@luma.gl/core';
 import {log} from '@luma.gl/core';
 // import type {ShaderUniformType, UniformValue, UniformFormat, UniformInfoDevice, Texture, Sampler} from '@luma.gl/core';
-import {_getDependencyGraph, ShaderModuleInstance} from '@luma.gl/shadertools';
+import {_resolveModules, ShaderModuleInstance} from '@luma.gl/shadertools';
 
 /** Minimal ShaderModule subset, we don't need shader code etc */
 export type ShaderModuleInputs<
@@ -62,19 +62,20 @@ export class ShaderInputs<
    */
   // @ts-expect-error Fix typings
   constructor(modules: {[P in keyof ShaderPropsT]?: ShaderModuleInputs<ShaderPropsT[P]>}) {
-    // Extract modules with dependencies and resolve
-    const allModules = {};
-    _getDependencyGraph({
-      modules: Object.values(modules).filter(module => module.dependencies),
-      level: 0,
-      moduleMap: allModules,
-      moduleDepth: {}
-    });
-    modules = {...modules, ...allModules};
+    // Extract modules with dependencies
+    const resolvedModules = _resolveModules(
+      Object.values(modules).filter(module => module.dependencies),
+      false
+    );
+    for (const resolvedModule of resolvedModules) {
+      // @ts-ignore
+      modules[resolvedModule.name] = resolvedModule;
+    }
+
     log.log(1, 'Creating ShaderInputs with modules', Object.keys(modules))();
 
     // Store the module definitions and create storage for uniform values and binding values, per module
-    this.modules = modules as typeof this.modules;
+    this.modules = modules as {[P in keyof ShaderPropsT]: ShaderModuleInputs<ShaderPropsT[P]>};
     this.moduleUniforms = {} as Record<keyof ShaderPropsT, Record<string, UniformValue>>;
     this.moduleBindings = {} as Record<keyof ShaderPropsT, Record<string, Texture | Sampler>>;
 

--- a/modules/engine/test/shader-inputs.spec.ts
+++ b/modules/engine/test/shader-inputs.spec.ts
@@ -6,6 +6,7 @@ import test from 'tape-promise/tape';
 import {picking} from '../../shadertools/src/index';
 // import {_ShaderInputs as ShaderInputs} from '@luma.gl/engine';
 import {ShaderInputs} from '../src/shader-inputs';
+import {ShaderModule} from '@luma.gl/shadertools';
 
 test('ShaderInputs#picking', t => {
   const shaderInputsUntyped = new ShaderInputs({picking});
@@ -58,6 +59,36 @@ test('ShaderInputs#picking prop merge', t => {
     shaderInputs.moduleUniforms.picking,
     expected,
     'Only highlight object and highlight active updated'
+  );
+
+  t.end();
+});
+
+test('ShaderInputs#dependencies', t => {
+  type CustomProps = {color: number[]};
+  const custom: ShaderModule<CustomProps> = {
+    name: 'custom',
+    dependencies: [picking],
+    uniformTypes: {
+      color: 'vec3<f32>'
+    }
+  };
+
+  const shaderInputs = new ShaderInputs<{
+    custom: CustomProps;
+    picking: typeof picking.props;
+  }>({custom});
+  t.deepEqual(Object.keys(shaderInputs.modules), ['custom', 'picking']);
+
+  shaderInputs.setProps({
+    custom: {color: [255, 0, 0]},
+    picking: {highlightedObjectColor: [1, 2, 3]}
+  });
+  t.deepEqual(shaderInputs.moduleUniforms.custom.color, [255, 0, 0], 'custom color updated');
+  t.deepEqual(
+    shaderInputs.moduleUniforms.picking.highlightedObjectColor,
+    [1, 2, 3],
+    'highlight object color updated'
   );
 
   t.end();

--- a/modules/shadertools/src/lib/shader-assembly/resolve-modules.ts
+++ b/modules/shadertools/src/lib/shader-assembly/resolve-modules.ts
@@ -38,6 +38,11 @@ function getShaderDependencies(modules: ShaderModuleInstance[]): ShaderModuleIns
     .map(name => moduleMap[name]);
 }
 
+type AbstractModule = {
+  name: string;
+  dependencies: AbstractModule[];
+};
+
 /**
  * Recursively checks module dependencies to calculate dependency level of each module.
  *
@@ -48,10 +53,10 @@ function getShaderDependencies(modules: ShaderModuleInstance[]): ShaderModuleIns
  * @return - Map of module name to its level
  */
 // Adds another level of dependencies to the result map
-export function getDependencyGraph(options: {
-  modules: ShaderModuleInstance[];
+export function getDependencyGraph<T extends AbstractModule>(options: {
+  modules: T[];
   level: number;
-  moduleMap: Record<string, ShaderModuleInstance>;
+  moduleMap: Record<string, T>;
   moduleDepth: Record<string, number>;
 }) {
   const {modules, level, moduleMap, moduleDepth} = options;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/pull/8782 implemented on 9.0 branch and tested against deck. Works for `project/project32` pair. Also tested with `luma.gl/examples/showcase/instancing` which uses a [non-ShaderModule input](https://github.com/visgl/luma.gl/blob/master/examples/showcase/instancing/app.ts#L240)

<!-- For all the PRs -->
#### Change List
- Obtain module dependencies when constructing `ShaderInputs`
- Uncouple `getDependencyGraph` from `ShaderModuleInstance` type
- Test
