### PR TITLE
fix(webgl): buffer bound to multiple targets when running transform feedback

### DIFF
--- a/modules/webgl/src/adapter/resources/webgl-transform-feedback.ts
+++ b/modules/webgl/src/adapter/resources/webgl-transform-feedback.ts
@@ -56,7 +56,7 @@ export class WEBGLTransformFeedback extends TransformFeedback {
 
   end(): void {
     this.gl.endTransformFeedback();
-    if (!this.bindOnUse) {
+    if (this.bindOnUse) {
       this._unbindBuffers();
     }
     this.gl.bindTransformFeedback(GL.TRANSFORM_FEEDBACK, null);

--- a/modules/webgl/src/adapter/resources/webgl-vertex-array.ts
+++ b/modules/webgl/src/adapter/resources/webgl-vertex-array.ts
@@ -97,6 +97,9 @@ export class WEBGLVertexArray extends VertexArray {
       // Attaches ARRAY_BUFFER with specified buffer format to location
       this.device.gl.vertexAttribPointer(location, size, type, normalized, stride, offset);
     }
+    // Clear binding - keeping it may cause [.WebGL-0x12804417100]
+    // GL_INVALID_OPERATION: A transform feedback buffer that would be written to is also bound to a non-transform-feedback target
+    this.device.gl.bindBuffer(GL.ARRAY_BUFFER, null);
 
     // Mark as non-constant
     this.device.gl.enableVertexAttribArray(location);


### PR DESCRIPTION
#### Background

The `GL_INVALID_OPERATION` is back after [#2032](https://github.com/visgl/luma.gl/pull/2032/files#r1523847153) removes changes from #2023.

```mermaid
sequenceDiagram
  participant B as Buffer
  participant T as BufferTransform
  participant M as Model
  participant gl as WebGLContext

  B->>T: TransformFeedback.setBuffers
  B->>M: Model.setAttributes
  M->>gl: Model.VertexArray.setBuffer
  Note right of gl: bindBuffer to ARRAY_BUFFER

  loop AnimationFrame
    T->>gl: TransformFeedback.begin
    Note right of gl: bindBuffer to TRANSFORM_FEEDBACK_BUFFER
    T->>gl: Model.draw
    Note right of gl: GL_INVALID_OPERATION
    M->>gl: Model.draw
  end

```

Technically we don't need to clear the binding after every `VertexArray.setBuffer` call; however there's no way we can tell if a buffer is double-bound before beginning a TransformFeedback. Alternatively we could force clear the binding on every animation frame (it's what deck.gl is doing to [work around this issue](https://github.com/visgl/deck.gl/blob/1b9c5a0d3cb42d2d5c24e06fbb6dca5ded1b41ed/modules/core/src/transitions/gpu-interpolation-transition.ts#L99-L101)) but that seems even more excessive?

@ibgreen When I was working on this I poked into why WEBGLTransformFeedback has a hard-coded `bindOnUse: true` flag. It seems something excessive to do on every run. The scenarios where a buffer MAY become double bound are:
- Buffer used as output of a TF AND attribute of a Model, could be set in either order - i.e. the scenario I'm trying to address in this PR. This is the case in deck.gl's attribute transition use case. Won't be a problem if `VertexArray.setBuffer` always cleans after itself, as the error is only thrown at draw time.
- Buffer used as output of a TF and then read out to CPU/copy to another Buffer/copy to another Texture. This is the case in deck.gl's GPU aggregation use case. This currently cannot be done without the `bindOnUse` behavior, however, if there was an API to unbind the buffer before reading, I would argue that it's the user's responsibility to unbind/rebind the TF buffer.

#### Change List
- Reset ARRAY_BUFFER binding after `WEBGLVertexArray.setBuffer`
- Fix bug of unbinding in `WEBGLTransformFeedback.end`
