### PR TITLE
Add luma namespace to docs

### DIFF
--- a/docs/sidebar.json
+++ b/docs/sidebar.json
@@ -77,6 +77,7 @@
         "label": "@luma.gl/core",
         "items": [
           "api-reference/core/README",
+          "api-reference/core/luma",
           "api-reference/core/device",
           "api-reference/core/device-info",
           "api-reference/core/device-features",


### PR DESCRIPTION
Core functions are documented, but aren't discoverable unless they're in the TOC.

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Add luma.md to the sidebar
