### PR TITLE
feat(core): Break out Adapter class from Device

### DIFF
--- a/docs/api-guide/gpu/gpu-initialization.md
+++ b/docs/api-guide/gpu/gpu-initialization.md
@@ -1,5 +1,9 @@
 # GPU Initialization
 
+## Adapter
+
+An `Adapter` is a factory for `Device` instances for a specific backend (e.g. WebGPU or WebGL).
+
 ## Device
 
 The [`Device`](/docs/api-reference/core/device) class provides luma.gl applications with access to the GPU. 
@@ -22,31 +26,7 @@ A `CanvasContext` takes care of:
 - canvas resizing
 - device pixel ratio calculations
 
-## Usage
-
-Create a `Device` using the best available registered backend, 
-specifying an existing canvas to initialize the default `CanvasContext`.
-
-```typescript
-import {luma} from '@luma.gl/core';
-import {WebGLDevice} from '@luma.gl/webgl';
-import {WebGPUDevice} from '@luma.gl/webgpu';
-
-luma.registerDevices([WebGLDevice]);
-const device = luma.createDevice({canvas: ...});
-```
-
-Create a WebGL 2 device, auto creating a canvas.
-
-```typescript
-import {luma} from '@luma.gl/core';
-import {WebGLDevice} from '@luma.gl/webgl';
-
-luma.registerDevices([WebGLDevice]);
-const webglDevice = luma.createDevice({type: 'webgl'});
-```
-
-## Registering Device Backends
+## Registering Backend Adapters
 
 The `@luma.gl/core` module defines abstract API interfaces such as `Device`, `Buffer` etc and is not usable on its own. 
 
@@ -62,9 +42,9 @@ yarn add @luma.gl/webgpu
 
 ```typescript
 import {luma} from '@luma.gl/core';
-import {WebGPUDevice} from '@luma.gl/webgpu';
+import {webgpuAdapter} from '@luma.gl/webgpu';
 
-luma.registerDevices([WebGPUDevice]);
+luma.registerAdapters([webgpuAdapter]);
 const device = await luma.createDevice({type: 'webgpu', canvas: ...});
 ```
 
@@ -83,7 +63,7 @@ import {luma} from '@luma.gl/core';
 import {WebGLDevice} from '@luma.gl/webgl';
 import {WebGPUDevice} from '@luma.gl/webgpu';
 
-luma.registerDevices([WebGLDevice, WebGPUDevice]);
+luma.registerAdapters([WebGLDevice, WebGPUDevice]);
 
 const webgpuDevice = luma.createDevice({type: 'best-available', canvas: ...});
 ```

--- a/docs/api-reference/core/adapter.md
+++ b/docs/api-reference/core/adapter.md
@@ -1,0 +1,6 @@
+# Adapter
+
+An `Adapter` is a factory for `Device` instances for a specific backend (e.g. WebGPU or WebGL).
+
+Adapters are normally not used directly, they are imported and passed to 
+methods like [`luma.createDevice`].

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -15,6 +15,8 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 **@luma.gl/core**
 
 - `RenderPipeline.topology`: `line-loop-webgl` and `triangle-fan-webgl` topologies are no longer supported. Rebuild your geometries using `triangle-strip` and `line-list`.
+- New [`luma.registerAdapters()`](/docs/api-reference/core/luma#lumaregisteradapters) method - Now register adapters rather than devices.
+- `Texture`: Textures no longer accept promises, use `AsyncTexture` class instead.
 
 **@luma.gl/shadertools**
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -10,10 +10,11 @@ Target Date: Q2 2024
 
 **@luma.gl/core**
 
-- New `Adapter` class - A dedicated `Device` factory is exported by each specific backend (e.g. WebGPU or WebGL).
-- New [`luma.registerAdapters()`](/docs/api-reference/core/luma#lumaregisteradapters) method - Now register adapters rather than devices.
-- New [`luma.attachDevice()`](/docs/api-reference/core/luma#lumaattachdevice) method - A `Device` can now be attached to a `WebGL2RenderingContext` without calling `WebGLDevice.attach()`.
-- `Texture`: Textures no longer accept promises, use `AsyncTexture` class instead.
+| Updated API              | Status     | Replacement                                                                                  |
+| ------------------------ | ---------- | -------------------------------------------------------------------------------------------- |
+| `luma.registerDevices()` | Deprecated | Use [`luma.registerAdapters()`](/docs/api-reference/core/luma#lumaregisteradapters) instead. |
+| `WebGLDevice.attach()`   | Deprecated | Use [`luma.attachDevice()`](/docs/api-reference/core/luma#lumaattachdevice) instead .        |
+| `Texture` promise data   | Removed    | Use `AsyncTexture` class instead.                                                            |
 
 **@luma.gl/engine**
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -10,8 +10,10 @@ Target Date: Q2 2024
 
 **@luma.gl/core**
 
-- `Texture` class has been refactored. Textures no longer accept promises, use `AsyncTexture` class instead.
+- New `Adapter` class - A dedicated `Device` factory is exported by each specific backend (e.g. WebGPU or WebGL).
+- New [`luma.registerAdapters()`](/docs/api-reference/core/luma#lumaregisteradapters) method - Now register adapters rather than devices.
 - New [`luma.attachDevice()`](/docs/api-reference/core/luma#lumaattachdevice) method - A `Device` can now be attached to a `WebGL2RenderingContext` without calling `WebGLDevice.attach()`.
+- `Texture`: Textures no longer accept promises, use `AsyncTexture` class instead.
 
 **@luma.gl/engine**
 

--- a/examples/api/animation/index.html
+++ b/examples/api/animation/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <script type="module">
   import {luma} from '@luma.gl/core';
-  import {WebGLDevice} from '@luma.gl/webgl';
-  luma.registerDevices([WebGLDevice]);
+  import {webglAdaprter} from '@luma.gl/webgl';
+  luma.registerAdapters([webgl2Adapter]);
 
   import AnimationLoopTemplate from './app.ts';
   import {makeAnimationLoop} from '@luma.gl/engine';

--- a/examples/api/cubemap/index.html
+++ b/examples/api/cubemap/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <script type="module">
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   // import {WebGPUDevice} from '@luma.gl/webgpu';
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGLDevice]);
+  luma.reagisterAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/api/texture-3d/index.html
+++ b/examples/api/texture-3d/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <script type="module">
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   // import {WebGPUDevice} from '@luma.gl/webgpu';
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGLDevice]);
+  luma.reagisterAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/script/webgl/transform-feedback/index.html
+++ b/examples/script/webgl/transform-feedback/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <script type="module">
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   // import {WebGPUDevice} from '@luma.gl/webgpu';
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGLDevice]);
+  luma.reagisterAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/showcase/instancing/index.html
+++ b/examples/showcase/instancing/index.html
@@ -2,10 +2,10 @@
 <script type="module">
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
-  import {WebGLDevice} from '@luma.gl/webgl';
-  import {WebGPUDevice} from '@luma.gl/webgpu';
+  import {webgl2Adapter} from '@luma.gl/webgl';
+  import {webgpuAdapter} from '@luma.gl/webgpu';
   import AnimationLoopTemplate from './app.ts';
-  luma.registerDevices([/*WebGPUDevice, */WebGLDevice]);
+  luma.reagisterAdapters([/*webgpuAdapter, */ webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/showcase/persistence/index.html
+++ b/examples/showcase/persistence/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
 <script type="module">
   import {luma} from '@luma.gl/core';
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AppAnimationLoop from './app.ts';
-  luma.registerDevices([WebGLDevice]);
+  luma.reagisterAdapters([webgl2Adapter]);
   const animationLoop = makeAnimationLoop(AppAnimationLoop);
   animationLoop.start();
 </script>

--- a/examples/tutorials/hello-cube/index.html
+++ b/examples/tutorials/hello-cube/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <script type="module">
-  import {WebGLDevice} from '@luma.gl/webgl';
-  import {WebGPUDevice} from '@luma.gl/webgpu';
+  import {webgl2Adapter} from '@luma.gl/webgl';
+  import {webgpuAdapter} from '@luma.gl/webgpu';
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGLDevice]);
+  luma.reagisterAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/tutorials/hello-gltf/index.html
+++ b/examples/tutorials/hello-gltf/index.html
@@ -21,13 +21,13 @@
 </head>
 <script type="module">
   import {luma} from '@luma.gl/core';
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   // import {WebGPUDevice} from '@luma.gl/webgpu';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGLDevice]);
-  // luma.registerDevices([WebGLDevice, WebGPUDevice]);
+  luma.reagisterAdapters([webgl2Adapter]);
+  // luma.reagisterAdapters([webglDevice, webgpuDevice]);
 
   const resolution = 2;
   const device = luma.createDevice({width: resolution * window.innerWidth, height: resolution * window.innerHeight});

--- a/examples/tutorials/hello-instanced-cubes/index.html
+++ b/examples/tutorials/hello-instanced-cubes/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <script type="module">
   import {luma} from '@luma.gl/core';
-  import {WebGPUDevice} from '@luma.gl/webgpu';
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgpuAdapter} from '@luma.gl/webgpu';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGPUDevice, WebGLDevice]);
+  luma.reagisterAdapters([we, webglDevice]);
   makeAnimationLoop(AnimationLoopTemplate).start({canvas: 'canvas'});
 </script>
 <body style=" margin: 0px;">

--- a/examples/tutorials/hello-instancing/index.html
+++ b/examples/tutorials/hello-instancing/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <script type="module">
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   // import {WebGPUDevice} from '@luma.gl/webgpu';
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGLDevice]);
+  luma.reagisterAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/tutorials/hello-triangle-geometry/index.html
+++ b/examples/tutorials/hello-triangle-geometry/index.html
@@ -1,13 +1,13 @@
 <!doctype html>
 <script type="module">
   import {luma} from '@luma.gl/core';
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   // import {WebGPUDevice} from '@luma.gl/webgpu';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGLDevice]);
-  // luma.registerDevices([WebGLDevice, WebGPUDevice]);
+  luma.reagisterAdapters([webgl2Adapter]);
+  // luma.reagisterAdapters([webglDevice, webgpuDevice]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/tutorials/hello-triangle/index.html
+++ b/examples/tutorials/hello-triangle/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <script type="module">
-  import {WebGPUDevice} from '@luma.gl/webgpu';
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgpuAdapter} from '@luma.gl/webgpu';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGPUDevice, WebGLDevice]);
+  luma.reagisterAdapters([webgpuDevice, webglDevice]);
   makeAnimationLoop(AnimationLoopTemplate).start({canvas: 'canvas'});
 </script>
 <body style="margin: 0;">

--- a/examples/tutorials/hello-two-cubes/index.html
+++ b/examples/tutorials/hello-two-cubes/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <script type="module">
-  import {WebGPUDevice} from '@luma.gl/webgpu';
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgpuAdapter} from '@luma.gl/webgpu';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGPUDevice, WebGLDevice]);
+  luma.reagisterAdapters([webgpuDevice, webglDevice]);
   makeAnimationLoop(AnimationLoopTemplate).start({canvas: 'canvas'});
 </script>
 <body style=" margin: 0px;">

--- a/examples/tutorials/lighting/index.html
+++ b/examples/tutorials/lighting/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <script type="module">
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   // import {WebGPUDevice} from '@luma.gl/webgpu';
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGLDevice]);
+  luma.reagisterAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/tutorials/shader-hooks/index.html
+++ b/examples/tutorials/shader-hooks/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <script type="module">
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   // import {WebGPUDevice} from '@luma.gl/webgpu';
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGLDevice]);
+  luma.reagisterAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/tutorials/shader-modules/index.html
+++ b/examples/tutorials/shader-modules/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <script type="module">
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   // import {WebGPUDevice} from '@luma.gl/webgpu';
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGLDevice]);
+  luma.reagisterAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/webgpu/textured-cube/index.html
+++ b/examples/webgpu/textured-cube/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <script type="module">
-  import {WebGPUDevice} from '@luma.gl/webgpu';
-  import {WebGLDevice} from '@luma.gl/webgl';
+  import {webgpuAdapter} from '@luma.gl/webgpu';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGPUDevice, WebGLDevice]);
+  luma.reagisterAdapters([webgpuDevice, webglDevice]);
   makeAnimationLoop(AnimationLoopTemplate).start({canvas: 'canvas'});
 </script>
 <body style=" margin: 0px;">

--- a/modules/core/src/adapter/adapter.ts
+++ b/modules/core/src/adapter/adapter.ts
@@ -1,0 +1,15 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Device, DeviceProps} from './device';
+/**
+ * Create and attach devices for a specific backend. Currently static methods on each device
+ */
+export abstract class Adapter {
+  // new (props: DeviceProps): Device; Constructor isn't used
+  abstract type: string;
+  abstract isSupported(): boolean;
+  abstract create(props: DeviceProps): Promise<Device>;
+  abstract attach?(handle: unknown): Device;
+}

--- a/modules/core/src/adapter/luma.ts
+++ b/modules/core/src/adapter/luma.ts
@@ -4,7 +4,8 @@
 
 import type {Log} from '@probe.gl/log';
 import type {DeviceProps} from './device';
-import {Device, DeviceFactory} from './device';
+import {Device} from './device';
+import {Adapter} from './adapter';
 import {StatsManager} from '../utils/stats-manager';
 import {lumaStats} from '../utils/stats-manager';
 import {log} from '../utils/log';
@@ -12,68 +13,62 @@ import {log} from '../utils/log';
 const ERROR_MESSAGE =
   'No matching device found. Ensure `@luma.gl/webgl` and/or `@luma.gl/webgpu` modules are imported.';
 
-const deviceMap = new Map<string, DeviceFactory>();
+const preregisteredAdapters = new Map<string, Adapter>();
 
 /** Properties for creating a new device */
 export type CreateDeviceProps = DeviceProps & {
   /** Selects the type of device. `best-available` uses webgpu if available, then webgl. */
   type?: 'webgl' | 'webgpu' | 'unknown' | 'best-available';
-  devices?: DeviceFactory[];
+  adapters?: Adapter[];
 };
 
 /** Properties for attaching an existing WebGL context or WebGPU device to a new luma Device */
 export type AttachDeviceProps = DeviceProps & {
   /** Externally created WebGL context or WebGPU device */
   handle: WebGL2RenderingContext; // | GPUDevice;
-  devices?: DeviceFactory[];
+  adapters?: Adapter[];
 };
 
 /**
  * Entry point to the luma.gl GPU abstraction
- * Register WebGPU and/or WebGL devices (controls application bundle size)
+ * Register WebGPU and/or WebGL adapters (controls application bundle size)
  * Run-time selection of the first available Device
  */
 export class luma {
   static defaultProps: Required<CreateDeviceProps> = {
     ...Device.defaultProps,
     type: 'best-available',
-    devices: undefined!
+    adapters: undefined!
   };
 
-  /** Global stats for all devices */
+  /** Global stats for all adapters */
   static stats: StatsManager = lumaStats;
 
   /** Global log */
   static log: Log = log;
 
-  static registerDevices(deviceClasses: DeviceFactory[]): void {
-    for (const deviceClass of deviceClasses) {
-      deviceMap.set(deviceClass.type, deviceClass);
+  static registerAdapters(adapters: Adapter[]): void {
+    for (const deviceClass of adapters) {
+      preregisteredAdapters.set(deviceClass.type, deviceClass);
     }
   }
 
-  static getAvailableDevices(): string[] {
-    // @ts-expect-error
-    return Array.from(deviceMap).map(Device => Device.type);
-  }
-
-  static getSupportedDevices(): string[] {
-    return (
-      Array.from(deviceMap)
-        // @ts-expect-error
-        .filter(Device => Device.isSupported())
-        // @ts-expect-error
-        .map(Device => Device.type)
-    );
+  /** Get type strings for supported Devices */
+  static getSupportedAdapters(adapters: Adapter[] = []): string[] {
+    const adapterMap = getAdapterMap(adapters);
+    return Array.from(adapterMap)
+      .map(([, adapter]) => adapter)
+      .filter(adapter => adapter.isSupported?.())
+      .map(adapter => adapter.type);
   }
 
   /** Get type strings for best available Device */
-  static getBestAvailableDeviceType(devices: DeviceFactory[] = []): 'webgpu' | 'webgl' | null {
-    const deviceMap = getDeviceMap(devices);
-    if (deviceMap.get('webgpu')?.isSupported?.()) {
+  static getBestAvailableAdapter(adapters: Adapter[] = []): 'webgpu' | 'webgl' | null {
+    const adapterMap = getAdapterMap(adapters);
+    if (adapterMap.get('webgpu')?.isSupported?.()) {
       return 'webgpu';
     }
-    if (deviceMap.get('webgl')?.isSupported?.()) {
+    if (adapterMap.get('webgl')?.isSupported?.()) {
       return 'webgl';
     }
     return null;
@@ -83,22 +78,46 @@ export class luma {
     Object.assign(luma.defaultProps, props);
   }
 
+  /** Creates a device. Asynchronously. */
+  static async createDevice(props: CreateDeviceProps = {}): Promise<Device> {
+    props = {...luma.defaultProps, ...props};
+
+    // Should be handled by attach device
+    // if (props.gl) {
+    //   props.type = 'webgl';
+    // }
+
+    const adapterMap = getAdapterMap(props.adapters);
+
+    let type: string = props.type || '';
+    if (type === 'best-available') {
+      type = luma.getBestAvailableAdapter(props.adapters) || type;
+    }
+
+    const adapters = getAdapterMap(props.adapters) || adapterMap;
+
+    const adapter = adapters.get(type);
+    const device = await adapter?.create?.(props);
+    if (device) {
+      return device;
+    }
+
+    throw new Error(ERROR_MESSAGE);
+  }
+
   /** Attach to an existing GPU API handle (WebGL2RenderingContext or GPUDevice). */
   static async attachDevice(props: AttachDeviceProps): Promise<Device> {
-    const devices = getDeviceMap(props.devices) || deviceMap;
+    const adapters = getAdapterMap(props.adapters);
 
     // WebGL
+    let type = '';
     if (props.handle instanceof WebGL2RenderingContext) {
-      const Device = devices.get('webgl');
-      const device = Device?.attach?.(null);
-      if (device) {
-        return device;
-      }
+      type = 'webgl';
     }
 
     // TODO - WebGPU does not yet have a stable API
     // if (props.handle instanceof GPUDevice) {
-    //   const WebGPUDevice = devices.get('webgpu') as any;
+    //   const WebGPUDevice = adapters.get('webgpu') as any;
     //   if (WebGPUDevice) {
     //     return (await WebGPUDevice.attach(props.handle)) as Device;
     //   }
@@ -106,32 +125,11 @@ export class luma {
 
     // null
     if (props.handle === null) {
-      const Device = devices.get('unknown');
-      const device = Device?.attach?.(null);
-      if (device) {
-        return device;
-      }
+      type = 'unknown';
     }
 
-    throw new Error(ERROR_MESSAGE);
-  }
-
-  /** Creates a device. Asynchronously. */
-  static async createDevice(props: CreateDeviceProps = {}): Promise<Device> {
-    props = {...luma.defaultProps, ...props};
-    if (props.gl) {
-      props.type = 'webgl';
-    }
-
-    const devices = getDeviceMap(props.devices) || deviceMap;
-
-    let type: string = props.type || '';
-    if (type === 'best-available') {
-      type = luma.getBestAvailableDeviceType(props.devices) || type;
-    }
-
-    const Device = devices.get(type);
-    const device = await Device?.create?.(props);
+    const adapter = adapters.get(type);
+    const device = adapter?.attach?.(null);
     if (device) {
       return device;
     }
@@ -160,18 +158,41 @@ export class luma {
     prototype.getContext = function (contextId: string, options?: WebGLContextAttributes) {
       // Attempt to force WebGL2 for all WebGL1 contexts
       if (contextId === 'webgl' || contextId === 'experimental-webgl') {
-        return this.originalGetContext('webgl2', options);
+        const context = this.originalGetContext('webgl2', options);
+        return context;
       }
       // For any other type, return the original context
       return this.originalGetContext(contextId, options);
     };
   }
+
+  /** Convert a list of adapters to a map */
+  protected getAdapterMap(adapters: Adapter[] = []): Map<string, Adapter> {
+    const map = new Map(preregisteredAdapters);
+    for (const adapter of adapters) {
+      map.set(adapter.type, adapter);
+    }
+    return map;
+  }
+
+  // DEPRECATED
+
+  /** @deprecated Use registerAdapters */
+  static registerDevices(deviceClasses: any[]): void {
+    log.warn('luma.registerDevices() is deprecated, use luma.registerAdapters() instead');
+    for (const deviceClass of deviceClasses) {
+      const adapter = deviceClass.adapter as Adapter;
+      if (adapter) {
+        preregisteredAdapters.set(adapter.type, adapter);
+      }
+    }
+  }
 }
 
-/** Convert a list of devices to a map */
-function getDeviceMap(deviceClasses: DeviceFactory[] = []): Map<string, DeviceFactory> {
-  const map = new Map<string, DeviceFactory>(deviceMap);
-  for (const deviceClass of deviceClasses) {
+/** Convert a list of adapters to a map */
+function getAdapterMap(adapters: Adapter[] = []): Map<string, Adapter> {
+  const map = new Map<string, Adapter>(preregisteredAdapters);
+  for (const deviceClass of adapters) {
     // assert(deviceClass.type && deviceClass.isSupported && deviceClass.create);
     map.set(deviceClass.type, deviceClass);
   }

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -8,6 +8,8 @@ export {VERSION} from './init';
 export {luma} from './adapter/luma';
 
 // ADAPTER (DEVICE AND GPU RESOURCE INTERFACES)
+export {Adapter} from './adapter/adapter';
+
 export type {DeviceProps, DeviceInfo, DeviceFeature} from './adapter/device';
 export {Device, DeviceFeatures, DeviceLimits} from './adapter/device';
 

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -3,11 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {NullDevice} from '@luma.gl/test-utils';
+import {nullAdapter, NullDevice} from '@luma.gl/test-utils';
 import {luma} from '@luma.gl/core';
 
 test('luma#attachDevice', async t => {
-  const device = await luma.attachDevice({handle: null, devices: [NullDevice]});
+  const device = await luma.attachDevice({handle: null, adapters: [nullAdapter]});
   t.equal(device.type, 'unknown', 'info.vendor ok');
   t.equal(device.info.vendor, 'no one', 'info.vendor ok');
   t.equal(device.info.renderer, 'none', 'info.renderer ok');
@@ -15,7 +15,7 @@ test('luma#attachDevice', async t => {
 });
 
 test('luma#createDevice', async t => {
-  const device = await luma.createDevice({type: 'unknown', devices: [NullDevice]});
+  const device = await luma.createDevice({type: 'unknown', adapters: [nullAdapter]});
   t.equal(device.type, 'unknown', 'info.vendor ok');
   t.equal(device.info.vendor, 'no one', 'info.vendor ok');
   t.equal(device.info.renderer, 'none', 'info.renderer ok');
@@ -29,6 +29,20 @@ test('luma#registerDevices', async t => {
   t.equal(device.info.vendor, 'no one', 'info.vendor ok');
   t.equal(device.info.renderer, 'none', 'info.renderer ok');
   t.end();
+});
+
+test('luma#getSupportedDevices', async t => {
+  luma.registerDevices([NullDevice]);
+  const types = luma.getSupportedAdapters();
+  t.ok(types.includes('unknown'), 'null device is supported');
+});
+
+test('luma#getBestAvailableDeviceType', async t => {
+  luma.registerDevices([NullDevice]);
+  // Somewhat dummy test, as tests rely on test utils registering webgl and webgpu devices
+  // But they might not be supported on all devices.
+  const types = luma.getBestAvailableAdapter();
+  t.ok(typeof types === 'string', 'doesnt crash');
 });
 
 // To suppress @typescript-eslint/unbound-method

--- a/modules/test-utils/src/create-test-device.ts
+++ b/modules/test-utils/src/create-test-device.ts
@@ -4,8 +4,8 @@
 
 import type {Device, DeviceProps} from '@luma.gl/core';
 import {luma, log} from '@luma.gl/core';
-import {WebGLDevice} from '@luma.gl/webgl';
-import {WebGPUDevice} from '@luma.gl/webgpu';
+import {webgl2Adapter, WebGLDevice} from '@luma.gl/webgl';
+import {webgpuAdapter, WebGPUDevice} from '@luma.gl/webgpu';
 
 const CONTEXT_DEFAULTS: Partial<DeviceProps> = {
   width: 1,
@@ -23,8 +23,8 @@ export function createTestContext(opts: Record<string, any> = {}): WebGL2Renderi
 export function createTestDevice(props: DeviceProps = {}): WebGLDevice | null {
   try {
     props = {...CONTEXT_DEFAULTS, ...props, debug: true};
-    // We dont use luma.createDevice since this tests current expect this context to be created synchronously
-    return new WebGLDevice(props);
+    // TODO - We dont use luma.createDevice since this function currently expect the context to be created synchronously
+    return webgl2Adapter.createSync(props);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(`Failed to created device '${props.id}': ${(error as Error).message}`);
@@ -50,7 +50,8 @@ export async function getTestDevices(type?: 'webgl' | 'webgpu'): Promise<Device[
     try {
       webgpuDevice = (await luma.createDevice({
         id: 'webgpu-test-device',
-        type: 'webgpu'
+        type: 'webgpu',
+        adapters: [webgpuAdapter]
       })) as WebGPUDevice;
     } catch (error) {
       log.error(String(error))();
@@ -58,7 +59,8 @@ export async function getTestDevices(type?: 'webgl' | 'webgpu'): Promise<Device[
     try {
       webglDeviceAsync = (await luma.createDevice({
         id: 'webgl-test-device',
-        type: 'webgl'
+        type: 'webgl',
+        adapters: [webgl2Adapter]
       })) as WebGLDevice;
     } catch (error) {
       log.error(String(error))();

--- a/modules/test-utils/src/index.ts
+++ b/modules/test-utils/src/index.ts
@@ -11,6 +11,9 @@ export {PerformanceTestRunner} from './performance-test-runner';
 export {webglDevice, webgpuDevice} from './create-test-device';
 export {getTestDevices} from './create-test-device';
 export {createTestDevice, createTestContext} from './create-test-device';
+
+export {nullAdapter, NullAdapter} from './null-device/null-adapter';
+
 export {NullDevice} from './null-device/null-device';
 
 // UTILS

--- a/modules/test-utils/src/null-device/null-adapter.ts
+++ b/modules/test-utils/src/null-device/null-adapter.ts
@@ -1,0 +1,38 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Adapter, DeviceProps, CanvasContext} from '@luma.gl/core';
+import {NullDevice} from './null-device';
+
+export class NullAdapter extends Adapter {
+  /** type of device's created by this adapter */
+  readonly type: NullDevice['type'] = 'unknown';
+
+  constructor() {
+    super();
+    // @ts-ignore DEPRECATED For backwards compatibility luma.registerDevices
+    NullDevice.adapter = this;
+  }
+
+  /** Check if WebGPU is available */
+  isSupported(): boolean {
+    return true;
+  }
+
+  attach(handle: null): NullDevice {
+    return new NullDevice({});
+  }
+
+  async create(props: DeviceProps = {}): Promise<NullDevice> {
+    // Wait for page to load: if canvas is a string we need to query the DOM for the canvas element.
+    // We only wait when props.canvas is string to avoids setting the global page onload callback unless necessary.
+    if (typeof props.canvas === 'string') {
+      await CanvasContext.pageLoaded;
+    }
+
+    return new NullDevice(props);
+  }
+}
+
+export const nullAdapter = new NullAdapter();

--- a/modules/test-utils/src/null-device/null-device.ts
+++ b/modules/test-utils/src/null-device/null-device.ts
@@ -9,7 +9,7 @@ import type {
   VertexArray,
   VertexArrayProps
 } from '@luma.gl/core';
-import {Device, CanvasContext, DeviceFeatures} from '@luma.gl/core';
+import {Device, DeviceFeatures} from '@luma.gl/core';
 
 import type {
   BufferProps,
@@ -50,7 +50,6 @@ export class NullDevice extends Device {
   static isSupported(): boolean {
     return true;
   }
-  static type: string = 'unknown';
   readonly type = 'unknown';
   features: DeviceFeatures = new DeviceFeatures([], this.props.disabledFeatures);
   limits: NullDeviceLimits = new NullDeviceLimits();
@@ -58,20 +57,6 @@ export class NullDevice extends Device {
 
   readonly canvasContext: NullCanvasContext;
   readonly lost: Promise<{reason: 'destroyed'; message: string}>;
-
-  static attach(handle: null): NullDevice {
-    return new NullDevice({});
-  }
-
-  static async create(props: DeviceProps = {}): Promise<NullDevice> {
-    // Wait for page to load: if canvas is a string we need to query the DOM for the canvas element.
-    // We only wait when props.canvas is string to avoids setting the global page onload callback unless necessary.
-    if (typeof props.canvas === 'string') {
-      await CanvasContext.pageLoaded;
-    }
-
-    return new NullDevice(props);
-  }
 
   constructor(props: DeviceProps) {
     super({...props, id: props.id || 'null-device'});

--- a/modules/test-utils/src/register-devices.ts
+++ b/modules/test-utils/src/register-devices.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {luma} from '@luma.gl/core';
-import {WebGLDevice} from '@luma.gl/webgl';
-import {WebGPUDevice} from '@luma.gl/webgpu';
+import {webgl2Adapter} from '@luma.gl/webgl';
+import {webgpuAdapter} from '@luma.gl/webgpu';
 
-luma.registerDevices([WebGLDevice, WebGPUDevice]);
+luma.registerAdapters([webgl2Adapter, webgpuAdapter]);

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -1,0 +1,115 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Adapter, Device, DeviceProps, CanvasContext, log} from '@luma.gl/core';
+import {WebGLDevice} from './webgl-device';
+import {loadSpectorJS} from '../context/debug/spector';
+import {loadWebGLDeveloperTools} from '../context/debug/webgl-developer-tools';
+
+const LOG_LEVEL = 1;
+
+export class WebGLAdapter extends Adapter {
+  /** type of device's created by this adapter */
+  readonly type: Device['type'] = 'webgl';
+
+  constructor() {
+    super();
+    // @ts-ignore DEPRECATED For backwards compatibility luma.registerDevices
+    WebGLDevice.adapter = this;
+  }
+
+  /** Check if WebGL 2 is available */
+  isSupported(): boolean {
+    return typeof WebGL2RenderingContext !== 'undefined';
+  }
+
+  /**
+   * Get a device instance from a GL context
+   * Creates and instruments the device if not already created
+   * @param gl
+   * @returns
+   */
+  attach(gl: Device | WebGL2RenderingContext): WebGLDevice {
+    if (gl instanceof WebGLDevice) {
+      return gl;
+    }
+    // @ts-expect-error
+    if (gl?.device instanceof Device) {
+      // @ts-expect-error
+      return gl.device as WebGLDevice;
+    }
+    if (!isWebGL(gl)) {
+      throw new Error('Invalid WebGL2RenderingContext');
+    }
+    return new WebGLDevice({gl: gl as WebGL2RenderingContext});
+  }
+
+  async create(props: DeviceProps = {}): Promise<WebGLDevice> {
+    log.groupCollapsed(LOG_LEVEL, 'WebGLDevice created')();
+
+    const promises: Promise<unknown>[] = [];
+
+    // Load webgl and spector debug scripts from CDN if requested
+    if (props.debug) {
+      promises.push(loadWebGLDeveloperTools());
+    }
+
+    if (props.spector) {
+      promises.push(loadSpectorJS());
+    }
+
+    // Wait for page to load: if canvas is a string we need to query the DOM for the canvas element.
+    // We only wait when props.canvas is string to avoids setting the global page onload callback unless necessary.
+    if (typeof props.canvas === 'string') {
+      promises.push(CanvasContext.pageLoaded);
+    }
+
+    // Wait for all the loads to settle before creating the context.
+    // The Device.create() functions are async, so in contrast to the constructor, we can `await` here.
+    const results = await Promise.allSettled(promises);
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        log.error(`Failed to initialize debug libraries ${result.reason}`)();
+      }
+    }
+
+    log.probe(LOG_LEVEL + 1, 'DOM is loaded')();
+
+    const device = this.createSync(props);
+    log.groupEnd(LOG_LEVEL)();
+
+    return device;
+  }
+
+  /** Create or attach device synchronously. Not supported for all devices. */
+  createSync(props: DeviceProps = {}): WebGLDevice {
+    // @ts-expect-error
+    if (props.gl?.device) {
+      log.warn('reattaching existing device')();
+      return this.attach(props.gl);
+    }
+
+    const device = new WebGLDevice(props);
+
+    // Log some debug info about the newly created context
+    const message = `\
+Created ${device.type}${device.debug ? ' debug' : ''} context: \
+${device.info.vendor}, ${device.info.renderer} for canvas: ${device.canvasContext.id}`;
+    log.probe(LOG_LEVEL, message)();
+    log.table(LOG_LEVEL, device.info)();
+
+    return device;
+  }
+}
+
+/** Check if supplied parameter is a WebGL2RenderingContext */
+function isWebGL(gl: any): boolean {
+  if (typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext) {
+    return true;
+  }
+  // Look for debug contexts, headless gl etc
+  return Boolean(gl && Number.isFinite(gl._version));
+}
+
+export const webgl2Adapter = new WebGLAdapter();

--- a/modules/webgl/src/index.ts
+++ b/modules/webgl/src/index.ts
@@ -12,6 +12,10 @@
 export type {WebGLDeviceLimits} from './adapter/device-helpers/webgl-device-limits';
 
 // WebGL adapter classes
+export {webgl2Adapter} from './adapter/webgl-adapter';
+export type {WebGLAdapter} from './adapter/webgl-adapter';
+
+// WebGL Device classes
 export {WebGLDevice} from './adapter/webgl-device';
 export {WebGLCanvasContext} from './adapter/webgl-canvas-context';
 

--- a/modules/webgl/test/adapter/webgl-device.spec.ts
+++ b/modules/webgl/test/adapter/webgl-device.spec.ts
@@ -4,10 +4,10 @@
 
 import test from 'tape-promise/tape';
 import {webglDevice} from '@luma.gl/test-utils';
-import {WebGLDevice} from '@luma.gl/webgl';
+import {webgl2Adapter} from '@luma.gl/webgl';
 
 test('WebGLDevice#lost (Promise)', async t => {
-  const device = await WebGLDevice.create();
+  const device = await webgl2Adapter.create();
 
   // Wrap in a promise to make sure tape waits for us
   await new Promise<void>(async resolve => {

--- a/modules/webgpu/src/adapter/webgpu-adapter.ts
+++ b/modules/webgpu/src/adapter/webgpu-adapter.ts
@@ -1,0 +1,91 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Adapter, DeviceProps, CanvasContext, log} from '@luma.gl/core';
+import {WebGPUDevice} from './webgpu-device';
+
+export class WebGPUAdapter extends Adapter {
+  /** type of device's created by this adapter */
+  readonly type: WebGPUDevice['type'] = 'webgpu';
+
+  constructor() {
+    super();
+    // @ts-ignore For backwards compatibility luma.registerDevices
+    WebGPUDevice.adapter = this;
+  }
+
+  /** Check if WebGPU is available */
+  isSupported(): boolean {
+    return Boolean(typeof navigator !== 'undefined' && navigator.gpu);
+  }
+
+  async create(props: DeviceProps): Promise<WebGPUDevice> {
+    if (!navigator.gpu) {
+      throw new Error(
+        'WebGPU not available. Open in Chrome Canary and turn on chrome://flags/#enable-unsafe-webgpu'
+      );
+    }
+    log.groupCollapsed(1, 'WebGPUDevice created')();
+    const adapter = await navigator.gpu.requestAdapter({
+      powerPreference: 'high-performance'
+      // forceSoftware: false
+    });
+
+    if (!adapter) {
+      throw new Error('Failed to request WebGPU adapter');
+    }
+
+    const adapterInfo = await adapter.requestAdapterInfo();
+    log.probe(2, 'Adapter available', adapterInfo)();
+
+    const requiredFeatures: GPUFeatureName[] = [];
+    const requiredLimits: Record<string, number> = {};
+
+    if (props.requestMaxLimits) {
+      // Require all features
+      requiredFeatures.push(...(Array.from(adapter.features) as GPUFeatureName[]));
+
+      // Require all limits
+      // Filter out chrome specific keys (avoid crash)
+      const limits = Object.keys(adapter.limits).filter(
+        key => !['minSubgroupSize', 'maxSubgroupSize'].includes(key)
+      );
+      for (const key of limits) {
+        const limit = key as keyof GPUSupportedLimits;
+        const value = adapter.limits[limit];
+        if (typeof value === 'number') {
+          requiredLimits[limit] = value;
+        }
+      }
+    }
+
+    const gpuDevice = await adapter.requestDevice({
+      requiredFeatures,
+      requiredLimits
+    });
+
+    log.probe(1, 'GPUDevice available')();
+
+    if (typeof props.canvas === 'string') {
+      await CanvasContext.pageLoaded;
+      log.probe(1, 'DOM is loaded')();
+    }
+
+    const device = new WebGPUDevice(props, gpuDevice, adapter, adapterInfo);
+
+    log.probe(
+      1,
+      'Device created. For more info, set chrome://flags/#enable-webgpu-developer-features'
+    )();
+    log.table(1, device.info)();
+    log.groupEnd(1)();
+    return device;
+  }
+
+  attach(handle: GPUDevice): WebGPUDevice {
+    throw new Error('WebGPUAdapter.attach() not implemented');
+  }
+}
+
+export const webgpuAdapter = new WebGPUAdapter();

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -30,7 +30,7 @@ import type {
   QuerySet,
   QuerySetProps
 } from '@luma.gl/core';
-import {Device, DeviceFeatures, CanvasContext, log} from '@luma.gl/core';
+import {Device, DeviceFeatures} from '@luma.gl/core';
 import {WebGPUBuffer} from './resources/webgpu-buffer';
 import {WebGPUTexture} from './resources/webgpu-texture';
 import {WebGPUExternalTexture} from './resources/webgpu-external-texture';
@@ -49,8 +49,6 @@ import {WebGPUQuerySet} from './resources/webgpu-query-set';
 
 /** WebGPU Device implementation */
 export class WebGPUDevice extends Device {
-  static type: string = 'webgpu';
-
   /** type of this device */
   readonly type = 'webgpu';
 
@@ -72,78 +70,11 @@ export class WebGPUDevice extends Device {
   commandEncoder: GPUCommandEncoder | null = null;
   renderPass: WebGPURenderPass | null = null;
 
-  /** Check if WebGPU is available */
-  static isSupported(): boolean {
-    return Boolean(typeof navigator !== 'undefined' && navigator.gpu);
-  }
-
-  static async create(props: DeviceProps): Promise<WebGPUDevice> {
-    if (!navigator.gpu) {
-      throw new Error(
-        'WebGPU not available. Open in Chrome Canary and turn on chrome://flags/#enable-unsafe-webgpu'
-      );
-    }
-    log.groupCollapsed(1, 'WebGPUDevice created')();
-    const adapter = await navigator.gpu.requestAdapter({
-      powerPreference: 'high-performance'
-      // forceSoftware: false
-    });
-    if (!adapter) {
-      throw new Error('Failed to request WebGPU adapter');
-    }
-
-    const adapterInfo = await adapter.requestAdapterInfo();
-    log.probe(2, 'Adapter available', adapterInfo)();
-
-    const requiredFeatures: GPUFeatureName[] = [];
-    const requiredLimits: Record<string, number> = {};
-
-    if (props.requestMaxLimits) {
-      // Require all features
-      requiredFeatures.push(...(Array.from(adapter.features) as GPUFeatureName[]));
-
-      // Require all limits
-      // Filter out chrome specific keys (avoid crash)
-      const limits = Object.keys(adapter.limits).filter(
-        key => !['minSubgroupSize', 'maxSubgroupSize'].includes(key)
-      );
-      for (const key of limits) {
-        const limit = key as keyof GPUSupportedLimits;
-        const value = adapter.limits[limit];
-        if (typeof value === 'number') {
-          requiredLimits[limit] = value;
-        }
-      }
-    }
-
-    const gpuDevice = await adapter.requestDevice({
-      requiredFeatures,
-      requiredLimits
-    });
-
-    log.probe(1, 'GPUDevice available')();
-
-    if (typeof props.canvas === 'string') {
-      await CanvasContext.pageLoaded;
-      log.probe(1, 'DOM is loaded')();
-    }
-
-    const device = new WebGPUDevice(gpuDevice, adapter, adapterInfo, props);
-
-    log.probe(
-      1,
-      'Device created. For more info, set chrome://flags/#enable-webgpu-developer-features'
-    )();
-    log.table(1, device.info)();
-    log.groupEnd(1)();
-    return device;
-  }
-
   constructor(
+    props: DeviceProps,
     device: GPUDevice,
     adapter: GPUAdapter,
-    adapterInfo: GPUAdapterInfo,
-    props: DeviceProps
+    adapterInfo: GPUAdapterInfo
   ) {
     super({...props, id: props.id || 'webgpu-device'});
     this.handle = device;

--- a/modules/webgpu/src/index.ts
+++ b/modules/webgpu/src/index.ts
@@ -3,9 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 // WEBGPU ADAPTER
-export {WebGPUDevice} from './adapter/webgpu-device';
+export type {WebGPUAdapter} from './adapter/webgpu-adapter';
+export {webgpuAdapter} from './adapter/webgpu-adapter';
 
 // WEBGPU CLASSES (typically not accessed directly)
+export {WebGPUDevice} from './adapter/webgpu-device';
 export {WebGPUBuffer} from './adapter/resources/webgpu-buffer';
 export {WebGPUTexture} from './adapter/resources/webgpu-texture';
 export {WebGPUSampler} from './adapter/resources/webgpu-sampler';

--- a/website/src/react-luma/store/device-store.tsx
+++ b/website/src/react-luma/store/device-store.tsx
@@ -1,10 +1,10 @@
 import {create} from 'zustand';
 
 import {luma, Device} from '@luma.gl/core';
-import {WebGLDevice} from '@luma.gl/webgl';
-import {WebGPUDevice} from '@luma.gl/webgpu';
+import {webgl2Adapter} from '@luma.gl/webgl';
+import {webgpuAdapter} from '@luma.gl/webgpu';
 
-luma.registerDevices([WebGLDevice, WebGPUDevice]);
+luma.registerAdapters([webgl2Adapter, webgpuAdapter]);
 
 export type Store = {
   device?: Device;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Combining device registration as static Device methods was supposed to be a short cut but created more trouble than its worth. 
#### Change List
- Break out a proper Adapter class (a device factory)
