### PR TITLE
feat: Dynamically load backends

### DIFF
--- a/docs/api-reference/core/luma.md
+++ b/docs/api-reference/core/luma.md
@@ -140,7 +140,7 @@ Note: A specific device type is available and supported if both of the following
 ### `luma.attachDevice()`
 
 ```ts
-luma.attachDevice({handle: WebGL2RenderingContext | GPUDevice, adapters, ...deviceProps}: AttachDeviceProps);
+luma.attachDevice(handle: WebGL2RenderingContext | GPUDevice | null, {adapters, ...deviceProps}: AttachDeviceProps);
 ```
 
 A luma.gl Device can be attached to an externally created `WebGL2RenderingContext` or `GPUDevice`.

--- a/modules/core/src/adapter/adapter.ts
+++ b/modules/core/src/adapter/adapter.ts
@@ -18,7 +18,7 @@ export abstract class Adapter {
   /** Create a new device for this backend */
   abstract create(props: DeviceProps): Promise<Device>;
   /** Attach a Device to a valid handle for this backend (GPUDevice, WebGL2RenderingContext etc) */
-  abstract attach?(handle: unknown): Promise<Device>;
+  abstract attach(handle: unknown, props: DeviceProps): Promise<Device>;
 
   /**
    * Page load promise

--- a/modules/core/src/adapter/adapter.ts
+++ b/modules/core/src/adapter/adapter.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import {isBrowser} from '@probe.gl/env';
 import {Device, DeviceProps} from './device';
 
 /**
@@ -10,7 +11,41 @@ import {Device, DeviceProps} from './device';
 export abstract class Adapter {
   // new (props: DeviceProps): Device; Constructor isn't used
   abstract type: string;
+  /** Check if this backend is supported */
   abstract isSupported(): boolean;
+  /** Check if the given handle is a valid device handle for this backend */
+  abstract isDeviceHandle(handle: unknown): boolean;
+  /** Create a new device for this backend */
   abstract create(props: DeviceProps): Promise<Device>;
+  /** Attach a Device to a valid handle for this backend (GPUDevice, WebGL2RenderingContext etc) */
   abstract attach?(handle: unknown): Promise<Device>;
+
+  /**
+   * Page load promise
+   * Resolves when the DOM is loaded.
+   * @note Since are be limitations on number of `load` event listeners,
+   * it is recommended avoid calling this accessor until actually needed.
+   * I.e. we don't call it unless you know that you will be looking up a string in the DOM.
+   */
+  get pageLoaded(): Promise<void> {
+    return getPageLoadPromise();
+  }
+}
+
+// HELPER FUNCTIONS
+
+const isPage: boolean = isBrowser() && typeof document !== 'undefined';
+const isPageLoaded: () => boolean = () => isPage && document.readyState === 'complete';
+let pageLoadPromise: Promise<void> | null = null;
+
+/** Returns a promise that resolves when the page is loaded */
+function getPageLoadPromise(): Promise<void> {
+  if (!pageLoadPromise) {
+    if (isPageLoaded() || typeof window === 'undefined') {
+      pageLoadPromise = Promise.resolve();
+    } else {
+      pageLoadPromise = new Promise(resolve => window.addEventListener('load', () => resolve()));
+    }
+  }
+  return pageLoadPromise;
 }

--- a/modules/core/src/adapter/luma.ts
+++ b/modules/core/src/adapter/luma.ts
@@ -3,15 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 import type {Log} from '@probe.gl/log';
-import {isBrowser} from '@probe.gl/env';
 import type {DeviceProps} from './device';
 import {Device} from './device';
 import {Adapter} from './adapter';
 import {StatsManager, lumaStats} from '../utils/stats-manager';
 import {log} from '../utils/log';
-
-const isPage: boolean = isBrowser() && typeof document !== 'undefined';
-const isPageLoaded: () => boolean = () => isPage && document.readyState === 'complete';
 
 declare global {
   // eslint-disable-next-line no-var
@@ -55,17 +51,6 @@ export class Luma {
     waitForPageLoad: true
   };
 
-  /**
-   * Page load promise
-   * Get a 'lazy' promise that resolves when the DOM is loaded.
-   * @note Since there may be limitations on number of `load` event listeners,
-   * it is recommended avoid calling this function until actually needed.
-   * I.e. don't call it until you know that you will be looking up a string in the DOM.
-   */
-  static pageLoaded: Promise<void> = getPageLoadPromise().then(() => {
-    log.probe(2, 'DOM is loaded')();
-  });
-
   /** Global stats for all devices */
   readonly stats: StatsManager = lumaStats;
 
@@ -104,6 +89,10 @@ export class Luma {
     globalThis.luma = this;
   }
 
+  /** 
+   * Global adapter registration. 
+   * @deprecated Use props.adapters instead
+   */
   registerAdapters(adapters: Adapter[]): void {
     for (const deviceClass of adapters) {
       this.preregisteredAdapters.set(deviceClass.type, deviceClass);
@@ -112,7 +101,7 @@ export class Luma {
 
   /** Get type strings for supported Devices */
   getSupportedAdapters(adapters: Adapter[] = []): string[] {
-    const adapterMap = this.getAdapterMap(adapters);
+    const adapterMap = this._getAdapterMap(adapters);
     return Array.from(adapterMap)
       .map(([, adapter]) => adapter)
       .filter(adapter => adapter.isSupported?.())
@@ -120,9 +109,9 @@ export class Luma {
   }
 
   /** Get type strings for best available Device */
-  getBestAvailableAdapter(adapters: Adapter[] = []): 'webgpu' | 'webgl' | 'null' | null {
+  getBestAvailableAdapterType(adapters: Adapter[] = []): 'webgpu' | 'webgl' | 'null' | null {
     const KNOWN_ADAPTERS: ('webgpu' | 'webgl' | 'null')[] = ['webgpu', 'webgl', 'null'];
-    const adapterMap = this.getAdapterMap(adapters);
+    const adapterMap = this._getAdapterMap(adapters);
     for (const type of KNOWN_ADAPTERS) {
       if (adapterMap.get(type)?.isSupported?.()) {
         return type;
@@ -131,32 +120,31 @@ export class Luma {
     return null;
   }
 
-  setDefaultDeviceProps(props: CreateDeviceProps): void {
-    Object.assign(Luma.defaultProps, props);
+  /** Select adapter of type from registered adapters */
+  selectAdapter(type: string, adapters: Adapter[] = []): Adapter | null {
+    let selectedType: string | null = type;
+    if (type === 'best-available') {
+      selectedType = this.getBestAvailableAdapterType(adapters);
+    }
+
+    const adapterMap = this._getAdapterMap(adapters);
+    return (selectedType && adapterMap.get(selectedType)) || null;
   }
 
   /** Creates a device. Asynchronously. */
   async createDevice(props: CreateDeviceProps = {}): Promise<Device> {
     props = {...Luma.defaultProps, ...props};
 
-    if (props.waitForPageLoad) {
-      // || props.createCanvasContext) {
-      await Luma.pageLoaded;
-    }
+    const adapter = this.selectAdapter(props.type, props.adapters);
+    if (adapter) {
+      if (props.waitForPageLoad) { // || props.createCanvasContext.canvas) {
+        await adapter.pageLoaded;
+      }
 
-    const adapterMap = this.getAdapterMap(props.adapters);
-
-    let type: string = props.type || '';
-    if (type === 'best-available') {
-      type = this.getBestAvailableAdapter(props.adapters) || type;
-    }
-
-    const adapters = this.getAdapterMap(props.adapters) || adapterMap;
-
-    const adapter = adapters.get(type);
-    const device = await adapter?.create?.(props);
-    if (device) {
-      return device;
+      const device = await adapter.create(props);
+      if (device) {
+        return device;
+      }
     }
 
     throw new Error(ERROR_MESSAGE);
@@ -164,36 +152,15 @@ export class Luma {
 
   /** Attach to an existing GPU API handle (WebGL2RenderingContext or GPUDevice). */
   async attachDevice(props: AttachDeviceProps): Promise<Device> {
-    const adapters = this.getAdapterMap(props.adapters);
+    const type = this._getTypeFromHandle(props.handle, props.adapters);
 
-    // WebGL
-    let type = 'unknown';
-    if (props.handle instanceof WebGL2RenderingContext) {
-      type = 'webgl';
-    }
-
-    if (props.createCanvasContext) {
-      await Luma.pageLoaded;
-    }
-
-    // TODO - WebGPU does not yet seem to have a stable in-browser API, so we "sniff" instead
-    // if (props.handle instanceof GPUDevice) {
-    if ((props.handle as any)?.queue) {
-      const WebGPUDevice = adapters.get('webgpu') as any;
-      if (WebGPUDevice) {
-        return (await WebGPUDevice.attach(props.handle)) as Device;
+    const adapter = type && this.selectAdapter(type, props.adapters);
+    if (adapter) {
+      // TODO - pass in props to attach?
+      const device = await adapter?.attach?.(props.handle);
+      if (device) {
+        return device;
       }
-    }
-
-    // null
-    if (props.handle === null) {
-      type = 'null';
-    }
-
-    const adapter = adapters.get(type);
-    const device = await adapter?.attach?.(null);
-    if (device) {
-      return device;
     }
 
     throw new Error(ERROR_MESSAGE);
@@ -204,7 +171,7 @@ export class Luma {
    * Useful when attaching luma to a context from an external library does not support creating WebGL2 contexts.
    */
   enforceWebGL2(enforce: boolean = true, adapters: Adapter[] = []): void {
-    const adapterMap = this.getAdapterMap(adapters);
+    const adapterMap = this._getAdapterMap(adapters);
     const webgl2Adapter = adapterMap.get('webgl');
     if (!webgl2Adapter) {
       log.warn('enforceWebGL2: webgl adapter not found')();
@@ -212,8 +179,17 @@ export class Luma {
     (webgl2Adapter as any)?.enforceWebGL2?.(enforce);
   }
 
+  // DEPRECATED
+
+  /** @deprecated */
+  setDefaultDeviceProps(props: CreateDeviceProps): void {
+    Object.assign(Luma.defaultProps, props);
+  }
+
+  // HELPERS
+
   /** Convert a list of adapters to a map */
-  protected getAdapterMap(adapters: Adapter[] = []): Map<string, Adapter> {
+  protected _getAdapterMap(adapters: Adapter[] = []): Map<string, Adapter> {
     const map = new Map(this.preregisteredAdapters);
     for (const adapter of adapters) {
       map.set(adapter.type, adapter);
@@ -221,18 +197,37 @@ export class Luma {
     return map;
   }
 
-  // DEPRECATED
+  /** Get type of a handle (for attachDevice) */
+  protected _getTypeFromHandle(handle: unknown, adapters: Adapter[] = []): 'webgpu' | 'webgl' | 'null' | null {
+    // TODO - delegate handle identification to adapters
 
-  /** @deprecated Use registerAdapters */
-  registerDevices(deviceClasses: any[]): void {
-    log.warn('luma.registerDevices() is deprecated, use luma.registerAdapters() instead');
-    for (const deviceClass of deviceClasses) {
-      const adapter = deviceClass.adapter as Adapter;
-      if (adapter) {
-        this.preregisteredAdapters.set(adapter.type, adapter);
-      }
+    // WebGL
+    if (handle instanceof WebGL2RenderingContext) {
+      return 'webgl';
     }
-  }
+
+    if (typeof GPUDevice !=='undefined' && handle instanceof GPUDevice) {
+      return 'webgpu';
+    }
+
+    // TODO - WebGPU does not yet seem to have a stable in-browser API, so we "sniff" for members instead
+    if ((handle as any)?.queue) {
+      return 'webgpu';
+    }
+
+    // null
+    if (handle === null) {
+      return 'null';
+    }
+
+    if (handle instanceof WebGLRenderingContext) {
+      log.warn('WebGL1 is not supported', handle)();
+    } else {
+      log.warn('Unknown handle type', handle)();
+    }
+
+    return null;
+  }  
 }
 
 /**
@@ -241,15 +236,3 @@ export class Luma {
  * Run-time selection of the first available Device
  */
 export const luma = new Luma();
-
-// HELPER FUNCTIONS
-
-/** Returns a promise that resolves when the page is loaded */
-function getPageLoadPromise(): Promise<void> {
-  if (isPageLoaded() || typeof window === 'undefined') {
-    return Promise.resolve();
-  }
-  return new Promise(resolve => {
-    window.addEventListener('load', () => resolve());
-  });
-}

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -7,7 +7,7 @@ import {nullAdapter} from '@luma.gl/test-utils';
 import {luma} from '@luma.gl/core';
 
 test('luma#attachDevice', async t => {
-  const device = await luma.attachDevice({handle: null, adapters: [nullAdapter]});
+  const device = await luma.attachDevice(null, {adapters: [nullAdapter]});
   t.equal(device.type, 'null', 'info.vendor ok');
   t.equal(device.info.vendor, 'no one', 'info.vendor ok');
   t.equal(device.info.renderer, 'none', 'info.renderer ok');
@@ -23,7 +23,7 @@ test('luma#createDevice', async t => {
 });
 
 test('luma#registerAdapters', async t => {
-  luma.registerAdapters([NullDevice]);
+  luma.registerAdapters([nullAdapter]);
   const device = await luma.createDevice({type: 'null'});
   t.equal(device.type, 'null', 'info.vendor ok');
   t.equal(device.info.vendor, 'no one', 'info.vendor ok');
@@ -37,12 +37,12 @@ test('luma#getSupportedAdapters', async t => {
   t.ok(types.includes('null'), 'null device is supported');
 });
 
-test('luma#getBestAvailableDeviceType', async t => {
+test('luma#getBestAvailableAdapterType', async t => {
   luma.registerAdapters([nullAdapter]);
   // Somewhat dummy test, as tests rely on test utils registering webgl and webgpu devices
   // But they might not be supported on all devices.
-  const types = luma.getBestAvailableAdapter();
-  t.ok(typeof types === 'string', 'does not crash');
+  const type = luma.getBestAvailableAdapterType();
+  t.ok(typeof type === 'string', 'does not crash');
 });
 
 // To suppress @typescript-eslint/unbound-method

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {nullAdapter, NullDevice} from '@luma.gl/test-utils';
+import {nullAdapter} from '@luma.gl/test-utils';
 import {luma} from '@luma.gl/core';
 
 test('luma#attachDevice', async t => {
@@ -22,8 +22,8 @@ test('luma#createDevice', async t => {
   t.end();
 });
 
-test('luma#registerDevices', async t => {
-  luma.registerDevices([NullDevice]);
+test('luma#registerAdapters', async t => {
+  luma.registerAdapters([NullDevice]);
   const device = await luma.createDevice({type: 'null'});
   t.equal(device.type, 'null', 'info.vendor ok');
   t.equal(device.info.vendor, 'no one', 'info.vendor ok');

--- a/modules/test-utils/src/null-device/null-adapter.ts
+++ b/modules/test-utils/src/null-device/null-adapter.ts
@@ -15,9 +15,12 @@ export class NullAdapter extends Adapter {
     NullDevice.adapter = this;
   }
 
-  /** Check if WebGPU is available */
   isSupported(): boolean {
     return true;
+  }
+
+  isDeviceHandle(handle: any): boolean {
+    return (handle === null);
   }
 
   async attach(handle: null): Promise<NullDevice> {

--- a/modules/test-utils/src/null-device/null-adapter.ts
+++ b/modules/test-utils/src/null-device/null-adapter.ts
@@ -20,7 +20,7 @@ export class NullAdapter extends Adapter {
   }
 
   isDeviceHandle(handle: any): boolean {
-    return (handle === null);
+    return handle === null;
   }
 
   async attach(handle: null): Promise<NullDevice> {

--- a/modules/webgl/src/adapter/converters/webgl-shadertypes.ts
+++ b/modules/webgl/src/adapter/converters/webgl-shadertypes.ts
@@ -66,7 +66,7 @@ export function getVertexTypeFromGL(glType: GLDataType, normalized = false): Nor
 }
 
 // Composite types table
-// @ts-ignore TODO
+// @ts-ignore TODO - fix the type confusion here
 const WEBGL_SHADER_TYPES: Record<GLUniformType, VariableShaderType> = {
   [GL.FLOAT]: 'f32',
   [GL.FLOAT_VEC2]: 'vec2<f32>',

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import type {WebGLDevice} from './webgl-device';
 import {Adapter, Device, DeviceProps, log} from '@luma.gl/core';
-import {WebGLDevice} from './webgl-device';
 import {enforceWebGL2} from '../context/polyfills/polyfill-webgl1-extensions';
 import {loadSpectorJS, DEFAULT_SPECTOR_PROPS} from '../context/debug/spector';
 import {loadWebGLDeveloperTools} from '../context/debug/webgl-developer-tools';
@@ -16,23 +16,34 @@ export class WebGLAdapter extends Adapter {
 
   constructor() {
     super();
-
     // Add spector default props to device default props, so that runtime settings are observed
     Device.defaultProps = {...Device.defaultProps, ...DEFAULT_SPECTOR_PROPS};
-
-    // @ts-ignore DEPRECATED For backwards compatibility luma.registerDevices
-    WebGLDevice.adapter = this;
   }
 
+    /** Force any created WebGL contexts to be WebGL2 contexts, polyfilled with WebGL1 extensions */
+    enforceWebGL2(enable: boolean): void {
+      enforceWebGL2(enable);
+    }
+  
+  
   /** Check if WebGL 2 is available */
   isSupported(): boolean {
     return typeof WebGL2RenderingContext !== 'undefined';
   }
 
-  /** Force any created WebGL contexts to be WebGL2 contexts, polyfilled with WebGL1 extensions */
-  enforceWebGL2(enable: boolean): void {
-    enforceWebGL2(enable);
+  override isDeviceHandle(handle: unknown): boolean {
+    // WebGL
+    if (typeof WebGL2RenderingContext !== 'undefined' && handle instanceof WebGL2RenderingContext) {
+      return true;
+    }
+
+    if (typeof WebGLRenderingContext !== 'undefined' && handle instanceof WebGLRenderingContext) {
+      log.warn('WebGL1 is not supported', handle)();
+    }
+
+    return false;
   }
+
 
   /**
    * Get a device instance from a GL context
@@ -41,11 +52,12 @@ export class WebGLAdapter extends Adapter {
    * @returns
    */
   async attach(gl: Device | WebGL2RenderingContext): Promise<WebGLDevice> {
+    const {WebGLDevice} = await import('./webgl-device');
     if (gl instanceof WebGLDevice) {
       return gl;
     }
     // @ts-expect-error
-    if (gl?.device instanceof Device) {
+    if (gl?.device instanceof WebGLDevice) {
       // @ts-expect-error
       return gl.device as WebGLDevice;
     }
@@ -56,6 +68,8 @@ export class WebGLAdapter extends Adapter {
   }
 
   async create(props: DeviceProps = {}): Promise<WebGLDevice> {
+    const {WebGLDevice} = await import('./webgl-device');
+
     log.groupCollapsed(LOG_LEVEL, 'WebGLDevice created')();
 
     const promises: Promise<unknown>[] = [];

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -20,12 +20,11 @@ export class WebGLAdapter extends Adapter {
     Device.defaultProps = {...Device.defaultProps, ...DEFAULT_SPECTOR_PROPS};
   }
 
-    /** Force any created WebGL contexts to be WebGL2 contexts, polyfilled with WebGL1 extensions */
-    enforceWebGL2(enable: boolean): void {
-      enforceWebGL2(enable);
-    }
-  
-  
+  /** Force any created WebGL contexts to be WebGL2 contexts, polyfilled with WebGL1 extensions */
+  enforceWebGL2(enable: boolean): void {
+    enforceWebGL2(enable);
+  }
+
   /** Check if WebGL 2 is available */
   isSupported(): boolean {
     return typeof WebGL2RenderingContext !== 'undefined';
@@ -43,7 +42,6 @@ export class WebGLAdapter extends Adapter {
 
     return false;
   }
-
 
   /**
    * Get a device instance from a GL context

--- a/modules/webgpu/src/adapter/webgpu-adapter.ts
+++ b/modules/webgpu/src/adapter/webgpu-adapter.ts
@@ -18,7 +18,7 @@ export class WebGPUAdapter extends Adapter {
   }
 
   isDeviceHandle(handle: unknown): boolean {
-    if (typeof GPUDevice !=='undefined' && handle instanceof GPUDevice) {
+    if (typeof GPUDevice !== 'undefined' && handle instanceof GPUDevice) {
       return true;
     }
 
@@ -79,11 +79,6 @@ export class WebGPUAdapter extends Adapter {
     });
 
     log.probe(1, 'GPUDevice available')();
-
-    if (typeof props.canvas === 'string') {
-      await this.pageLoaded;
-      log.probe(1, 'DOM is loaded')();
-    }
 
     const {WebGPUDevice} = await import('./webgpu-device');
 

--- a/modules/webgpu/src/adapter/webgpu-adapter.ts
+++ b/modules/webgpu/src/adapter/webgpu-adapter.ts
@@ -2,32 +2,39 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Adapter, DeviceProps, log} from '@luma.gl/core';
-import {WebGPUDevice} from './webgpu-device';
-
+// prettier-ignore
 // / <reference types="@webgpu/types" />
+
+import {Adapter, DeviceProps, log} from '@luma.gl/core';
+import type {WebGPUDevice} from './webgpu-device';
 
 export class WebGPUAdapter extends Adapter {
   /** type of device's created by this adapter */
   readonly type: WebGPUDevice['type'] = 'webgpu';
 
-  constructor() {
-    super();
-    // @ts-ignore For backwards compatibility luma.registerDevices
-    WebGPUDevice.adapter = this;
+  isSupported(): boolean {
+    // Check if WebGPU is available
+    return Boolean(typeof navigator !== 'undefined' && navigator.gpu);
   }
 
-  /** Check if WebGPU is available */
-  isSupported(): boolean {
-    return Boolean(typeof navigator !== 'undefined' && navigator.gpu);
+  isDeviceHandle(handle: unknown): boolean {
+    if (typeof GPUDevice !=='undefined' && handle instanceof GPUDevice) {
+      return true;
+    }
+
+    // TODO - WebGPU does not yet seem to have a stable in-browser API, so we "sniff" for members instead
+    if ((handle as any)?.queue) {
+      return true;
+    }
+
+    return false;
   }
 
   async create(props: DeviceProps): Promise<WebGPUDevice> {
     if (!navigator.gpu) {
-      throw new Error(
-        'WebGPU not available. Open in Chrome Canary and turn on chrome://flags/#enable-unsafe-webgpu'
-      );
+      throw new Error('WebGPU not available. Recent Chrome browsers should work.');
     }
+
     log.groupCollapsed(1, 'WebGPUDevice created')();
     const adapter = await navigator.gpu.requestAdapter({
       powerPreference: 'high-performance'
@@ -72,6 +79,13 @@ export class WebGPUAdapter extends Adapter {
     });
 
     log.probe(1, 'GPUDevice available')();
+
+    if (typeof props.canvas === 'string') {
+      await this.pageLoaded;
+      log.probe(1, 'DOM is loaded')();
+    }
+
+    const {WebGPUDevice} = await import('./webgpu-device');
 
     const device = new WebGPUDevice(props, gpuDevice, adapter, adapterInfo);
 

--- a/modules/webgpu/src/adapter/webgpu-canvas-context.ts
+++ b/modules/webgpu/src/adapter/webgpu-canvas-context.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+// prettier-ignore
 // / <reference types="@webgpu/types" />
 
 import type {DepthStencilTextureFormat, CanvasContextProps} from '@luma.gl/core';


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Implement dynamic import in webgl and webgpu modules
#### Change List
- Breaking change `luma.registerDevices()` backwards compatibility was no longer feasible, apps must now update to `luma.registerAdapters()`.
### Follow up
- webgpu and webgl index.ts should no longer export anything except the adapter and pure types?
- How to measure bundle size impact?