### PR TITLE
feat(engine): ShaderModule.getBindings()

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -505,6 +505,7 @@ export class Model {
   /** Update uniform buffers from the model's shader inputs */
   updateShaderInputs(): void {
     this._uniformStore.setUniforms(this.shaderInputs.getUniformValues());
+    this.setBindings(this.shaderInputs.getBindings());
     // TODO - this is already tracked through buffer/texture update times?
     this.setNeedsRedraw('shaderInputs');
   }

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -109,7 +109,6 @@ export class ShaderInputs<
         module.getUniforms?.(moduleProps, this.moduleUniforms[moduleName]) || (moduleProps as any);
 
       const {uniforms, bindings} = splitUniformsAndBindings(uniformsAndBindings);
-      // console.error(uniforms)
       this.moduleUniforms[moduleName] = {...oldUniforms, ...uniforms};
       this.moduleBindings[moduleName] = {...oldBindings, ...bindings};
       // this.moduleUniformsChanged ||= moduleName;

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -26,6 +26,7 @@ export type ShaderModuleInputs<
       type: 'texture' | 'sampler' | 'uniforms';
     }
   >;
+  getBindings?: (settings: Partial<PropsT>, prevBindings?: BindingsT) => BindingsT;
 
   uniformTypes?: any;
 };
@@ -112,9 +113,8 @@ export class ShaderInputs<
 
       // console.log(`setProps(${String(moduleName)}`, moduleName, this.moduleUniforms[moduleName])
 
-      // TODO - Get Module bindings
-      // const bindings = module.getBindings?.(moduleProps);
-      // this.moduleUniforms[moduleName] = bindings;
+      const bindings = module.getBindings?.(moduleProps);
+      this.moduleBindings[moduleName] = bindings;
     }
   }
 

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {UniformValue, Texture, Sampler} from '@luma.gl/core';
-import {log} from '@luma.gl/core';
+import {log, splitUniformsAndBindings} from '@luma.gl/core';
 // import type {ShaderUniformType, UniformValue, UniformFormat, UniformInfoDevice, Texture, Sampler} from '@luma.gl/core';
 import {_resolveModules, ShaderModuleInstance} from '@luma.gl/shadertools';
 
@@ -26,7 +26,6 @@ export type ShaderModuleInputs<
       type: 'texture' | 'sampler' | 'uniforms';
     }
   >;
-  getBindings?: (settings: Partial<PropsT>, prevBindings?: BindingsT) => BindingsT;
 
   uniformTypes?: any;
 };
@@ -105,16 +104,17 @@ export class ShaderInputs<
       }
 
       const oldUniforms = this.moduleUniforms[moduleName];
-      const uniforms =
+      const oldBindings = this.moduleBindings[moduleName];
+      const uniformsAndBindings =
         module.getUniforms?.(moduleProps, this.moduleUniforms[moduleName]) || (moduleProps as any);
+
+      const {uniforms, bindings} = splitUniformsAndBindings(uniformsAndBindings);
       // console.error(uniforms)
       this.moduleUniforms[moduleName] = {...oldUniforms, ...uniforms};
+      this.moduleBindings[moduleName] = {...oldBindings, ...bindings};
       // this.moduleUniformsChanged ||= moduleName;
 
       // console.log(`setProps(${String(moduleName)}`, moduleName, this.moduleUniforms[moduleName])
-
-      const bindings = module.getBindings?.(moduleProps);
-      this.moduleBindings[moduleName] = bindings;
     }
   }
 

--- a/modules/engine/test/shader-inputs.spec.ts
+++ b/modules/engine/test/shader-inputs.spec.ts
@@ -7,6 +7,7 @@ import {picking} from '../../shadertools/src/index';
 // import {_ShaderInputs as ShaderInputs} from '@luma.gl/engine';
 import {ShaderInputs} from '../src/shader-inputs';
 import {ShaderModule} from '@luma.gl/shadertools';
+import {Texture} from '@luma.gl/core';
 
 test('ShaderInputs#picking', t => {
   const shaderInputsUntyped = new ShaderInputs({picking});
@@ -89,6 +90,35 @@ test('ShaderInputs#dependencies', t => {
     [1, 2, 3],
     'highlight object color updated'
   );
+
+  t.end();
+});
+
+test('ShaderInputs#bindings', t => {
+  type CustomProps = {color: number[]; colorTexture: Texture};
+  const custom: ShaderModule<CustomProps> = {
+    name: 'custom',
+    uniformTypes: {color: 'vec3<f32>'},
+    uniformPropTypes: {color: {value: [0, 0, 0]}},
+    getUniforms: ({color}) => ({color}),
+    getBindings: ({colorTexture}) => ({colorTexture})
+  };
+
+  const shaderInputs = new ShaderInputs<{
+    custom: CustomProps;
+  }>({custom});
+
+  const MOCK_TEXTURE = 'MOCK_TEXTURE' as unknown as Texture;
+  shaderInputs.setProps({
+    custom: {color: [255, 0, 0], colorTexture: MOCK_TEXTURE}
+  });
+  t.deepEqual(shaderInputs.moduleUniforms.custom.color, [255, 0, 0], 'custom color updated');
+  t.equal(shaderInputs.moduleBindings.custom.colorTexture, MOCK_TEXTURE, 'colorTexture updated');
+
+  const uniformValues = shaderInputs.getUniformValues();
+  const bindings = shaderInputs.getBindings();
+  t.deepEqual(uniformValues, {custom: {color: [255, 0, 0]}}, 'uniformValues correct');
+  t.deepEqual(bindings, {colorTexture: 'MOCK_TEXTURE'}, 'bindings correct');
 
   t.end();
 });

--- a/modules/engine/test/shader-inputs.spec.ts
+++ b/modules/engine/test/shader-inputs.spec.ts
@@ -95,29 +95,34 @@ test('ShaderInputs#dependencies', t => {
 });
 
 test('ShaderInputs#bindings', t => {
-  type CustomProps = {color: number[]; colorTexture: Texture};
-  const custom: ShaderModule<CustomProps> = {
-    name: 'custom',
-    uniformTypes: {color: 'vec3<f32>'},
-    uniformPropTypes: {color: {value: [0, 0, 0]}},
-    getUniforms: ({color, colorTexture}) => ({color, colorTexture})
-  };
+  [true, false].map(callback => {
+    t.comment(`custom module created ${callback ? 'with' : 'without'} getUniforms()`);
+    type CustomProps = {color: number[]; colorTexture: Texture};
+    const custom: ShaderModule<CustomProps> = {
+      name: 'custom',
+      uniformTypes: {color: 'vec3<f32>'},
+      uniformPropTypes: {color: {value: [0, 0, 0]}}
+    };
+    if (callback) {
+      custom.getUniforms = ({color, colorTexture}) => ({color, colorTexture});
+    }
 
-  const shaderInputs = new ShaderInputs<{
-    custom: CustomProps;
-  }>({custom});
+    const shaderInputs = new ShaderInputs<{
+      custom: CustomProps;
+    }>({custom});
 
-  const MOCK_TEXTURE = 'MOCK_TEXTURE' as unknown as Texture;
-  shaderInputs.setProps({
-    custom: {color: [255, 0, 0], colorTexture: MOCK_TEXTURE}
+    const MOCK_TEXTURE = 'MOCK_TEXTURE' as unknown as Texture;
+    shaderInputs.setProps({
+      custom: {color: [255, 0, 0], colorTexture: MOCK_TEXTURE}
+    });
+    t.deepEqual(shaderInputs.moduleUniforms.custom.color, [255, 0, 0], 'custom color updated');
+    t.equal(shaderInputs.moduleBindings.custom.colorTexture, MOCK_TEXTURE, 'colorTexture updated');
+
+    const uniformValues = shaderInputs.getUniformValues();
+    const bindings = shaderInputs.getBindings();
+    t.deepEqual(uniformValues, {custom: {color: [255, 0, 0]}}, 'uniformValues correct');
+    t.deepEqual(bindings, {colorTexture: 'MOCK_TEXTURE'}, 'bindings correct');
+
+    t.end();
   });
-  t.deepEqual(shaderInputs.moduleUniforms.custom.color, [255, 0, 0], 'custom color updated');
-  t.equal(shaderInputs.moduleBindings.custom.colorTexture, MOCK_TEXTURE, 'colorTexture updated');
-
-  const uniformValues = shaderInputs.getUniformValues();
-  const bindings = shaderInputs.getBindings();
-  t.deepEqual(uniformValues, {custom: {color: [255, 0, 0]}}, 'uniformValues correct');
-  t.deepEqual(bindings, {colorTexture: 'MOCK_TEXTURE'}, 'bindings correct');
-
-  t.end();
 });

--- a/modules/engine/test/shader-inputs.spec.ts
+++ b/modules/engine/test/shader-inputs.spec.ts
@@ -100,8 +100,7 @@ test('ShaderInputs#bindings', t => {
     name: 'custom',
     uniformTypes: {color: 'vec3<f32>'},
     uniformPropTypes: {color: {value: [0, 0, 0]}},
-    getUniforms: ({color}) => ({color}),
-    getBindings: ({colorTexture}) => ({colorTexture})
+    getUniforms: ({color, colorTexture}) => ({color, colorTexture})
   };
 
   const shaderInputs = new ShaderInputs<{

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -5,6 +5,7 @@
 import {NumberArray} from '@math.gl/types';
 import {UniformFormat} from '../../types';
 import {PropType} from '../filters/prop-types';
+import {Sampler, Texture} from '@luma.gl/core';
 
 export type UniformValue = number | boolean | Readonly<NumberArray>; // Float32Array> | Readonly<Int32Array> | Readonly<Uint32Array> | Readonly<number[]>;
 
@@ -19,7 +20,7 @@ export type UniformInfo = {
 export type ShaderModule<
   PropsT extends Record<string, unknown> = Record<string, unknown>,
   UniformsT extends Record<string, UniformValue> = Record<string, UniformValue>,
-  BindingsT extends Record<string, unknown> = {}
+  BindingsT extends Record<string, Texture | Sampler> = {}
 > = {
   /** Used for type inference not for values */
   props?: Required<PropsT>;
@@ -43,6 +44,7 @@ export type ShaderModule<
 
   /** uniform buffers, textures, samplers, storage, ... */
   bindings?: Record<keyof BindingsT, {location: number; type: 'texture' | 'sampler' | 'uniforms'}>;
+  getBindings?: (settings?: any, prevBindings?: any) => Record<string, Texture | Sampler>;
 
   defines?: Record<string, string | number>;
   /** Injections */

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -20,7 +20,7 @@ export type UniformInfo = {
 export type ShaderModule<
   PropsT extends Record<string, unknown> = Record<string, unknown>,
   UniformsT extends Record<string, UniformValue> = Record<string, UniformValue>,
-  BindingsT extends Record<string, Texture | Sampler> = {}
+  BindingsT extends Record<string, Buffer | Texture | Sampler> = {}
 > = {
   /** Used for type inference not for values */
   props?: Required<PropsT>;
@@ -38,13 +38,11 @@ export type ShaderModule<
   /** Default uniform values */
   defaultUniforms?: Required<UniformsT>; // Record<keyof UniformsT, UniformValue>;
 
-  /** Function that maps settings to uniforms */
-  // getUniforms?: (settings?: Partial<SettingsT>, prevUniforms?: any /* UniformsT */) => UniformsT;
-  getUniforms?: (settings?: any, prevUniforms?: any) => Record<string, UniformValue>;
+  /** Function that maps props to uniforms & bindings */
+  getUniforms?: (props?: any, oldProps?: any) => Record<string, UniformValue>;
 
   /** uniform buffers, textures, samplers, storage, ... */
   bindings?: Record<keyof BindingsT, {location: number; type: 'texture' | 'sampler' | 'uniforms'}>;
-  getBindings?: (settings?: any, prevBindings?: any) => Record<string, Texture | Sampler>;
 
   defines?: Record<string, string | number>;
   /** Injections */


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

`ShaderModule` has no support for bindings, which are needed to complete the port over to UBOs. If this approach looks OK I can make a PR on master, but doing this on v9 in order to test against deck.gl

<!-- For all the PRs -->
#### Change List
- Add `getBindings` to `ShaderModule` type
- Support in `ShaderInputs` & `Model` classes
- Tests
