### PR TITLE
Example typo fixes

### DIFF
--- a/examples/api/animation/index.html
+++ b/examples/api/animation/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <script type="module">
   import {luma} from '@luma.gl/core';
-  import {webglAdaprter} from '@luma.gl/webgl';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   luma.registerAdapters([webgl2Adapter]);
 
   import AnimationLoopTemplate from './app.ts';

--- a/examples/api/cubemap/index.html
+++ b/examples/api/cubemap/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgl2Adapter]);
+  luma.registerAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/api/texture-3d/index.html
+++ b/examples/api/texture-3d/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgl2Adapter]);
+  luma.registerAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/script/webgl/transform-feedback/index.html
+++ b/examples/script/webgl/transform-feedback/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgl2Adapter]);
+  luma.registerAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/showcase/instancing/index.html
+++ b/examples/showcase/instancing/index.html
@@ -5,7 +5,7 @@
   import {webgl2Adapter} from '@luma.gl/webgl';
   import {webgpuAdapter} from '@luma.gl/webgpu';
   import AnimationLoopTemplate from './app.ts';
-  luma.reagisterAdapters([/*webgpuAdapter, */ webgl2Adapter]);
+  luma.registerAdapters([/*webgpuAdapter, */ webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/showcase/persistence/index.html
+++ b/examples/showcase/persistence/index.html
@@ -4,7 +4,7 @@
   import {webgl2Adapter} from '@luma.gl/webgl';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AppAnimationLoop from './app.ts';
-  luma.reagisterAdapters([webgl2Adapter]);
+  luma.registerAdapters([webgl2Adapter]);
   const animationLoop = makeAnimationLoop(AppAnimationLoop);
   animationLoop.start();
 </script>

--- a/examples/tutorials/hello-cube/index.html
+++ b/examples/tutorials/hello-cube/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgl2Adapter]);
+  luma.registerAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/tutorials/hello-gltf/index.html
+++ b/examples/tutorials/hello-gltf/index.html
@@ -26,8 +26,8 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgl2Adapter]);
-  // luma.reagisterAdapters([webglDevice, webgpuDevice]);
+  luma.registerAdapters([webgl2Adapter]);
+  // luma.registerAdapters([webglDevice, webgpuDevice]);
 
   const resolution = 2;
   const device = luma.createDevice({width: resolution * window.innerWidth, height: resolution * window.innerHeight});

--- a/examples/tutorials/hello-instanced-cubes/index.html
+++ b/examples/tutorials/hello-instanced-cubes/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerAdapters([we, webglDevice]);
+  luma.registerAdapters([webgpuAdapter, webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start({canvas: 'canvas'});
 </script>
 <body style=" margin: 0px;">

--- a/examples/tutorials/hello-instanced-cubes/index.html
+++ b/examples/tutorials/hello-instanced-cubes/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([we, webglDevice]);
+  luma.registerAdapters([we, webglDevice]);
   makeAnimationLoop(AnimationLoopTemplate).start({canvas: 'canvas'});
 </script>
 <body style=" margin: 0px;">

--- a/examples/tutorials/hello-instancing/index.html
+++ b/examples/tutorials/hello-instancing/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgl2Adapter]);
+  luma.registerAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/tutorials/hello-triangle-geometry/index.html
+++ b/examples/tutorials/hello-triangle-geometry/index.html
@@ -6,8 +6,8 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgl2Adapter]);
-  // luma.reagisterAdapters([webglDevice, webgpuDevice]);
+  luma.registerAdapters([webgl2Adapter]);
+  // luma.registerAdapters([webglDevice, webgpuDevice]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/tutorials/hello-triangle/index.html
+++ b/examples/tutorials/hello-triangle/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerAdapters([webgpuDevice, webglDevice]);
+  luma.registerAdapters([webgpuAdapter, webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start({canvas: 'canvas'});
 </script>
 <body style="margin: 0;">

--- a/examples/tutorials/hello-triangle/index.html
+++ b/examples/tutorials/hello-triangle/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgpuDevice, webglDevice]);
+  luma.registerAdapters([webgpuDevice, webglDevice]);
   makeAnimationLoop(AnimationLoopTemplate).start({canvas: 'canvas'});
 </script>
 <body style="margin: 0;">

--- a/examples/tutorials/hello-two-cubes/index.html
+++ b/examples/tutorials/hello-two-cubes/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgpuDevice, webglDevice]);
+  luma.registerAdapters([webgpuDevice, webglDevice]);
   makeAnimationLoop(AnimationLoopTemplate).start({canvas: 'canvas'});
 </script>
 <body style=" margin: 0px;">

--- a/examples/tutorials/hello-two-cubes/index.html
+++ b/examples/tutorials/hello-two-cubes/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerAdapters([webgpuDevice, webglDevice]);
+  luma.registerAdapters([webgpuAdapter, webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start({canvas: 'canvas'});
 </script>
 <body style=" margin: 0px;">

--- a/examples/tutorials/lighting/index.html
+++ b/examples/tutorials/lighting/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgl2Adapter]);
+  luma.registerAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/tutorials/shader-hooks/index.html
+++ b/examples/tutorials/shader-hooks/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgl2Adapter]);
+  luma.registerAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/tutorials/shader-modules/index.html
+++ b/examples/tutorials/shader-modules/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgl2Adapter]);
+  luma.registerAdapters([webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start();
 </script>
 <body>

--- a/examples/webgpu/textured-cube/index.html
+++ b/examples/webgpu/textured-cube/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.reagisterAdapters([webgpuDevice, webglDevice]);
+  luma.registerAdapters([webgpuDevice, webglDevice]);
   makeAnimationLoop(AnimationLoopTemplate).start({canvas: 'canvas'});
 </script>
 <body style=" margin: 0px;">

--- a/examples/webgpu/textured-cube/index.html
+++ b/examples/webgpu/textured-cube/index.html
@@ -6,7 +6,7 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerAdapters([webgpuDevice, webglDevice]);
+  luma.registerAdapters([webgpuAdapter, webgl2Adapter]);
   makeAnimationLoop(AnimationLoopTemplate).start({canvas: 'canvas'});
 </script>
 <body style=" margin: 0px;">


### PR DESCRIPTION
For #2101

#### Change List
- Fix typos in examples
- Fix a few cases where registerDevices() was changed to registerAdapters() but the arguments was not changed
