### PR TITLE
chore: Remove spurios device.getSize()

### DIFF
--- a/modules/test-utils/src/null-device/null-device.ts
+++ b/modules/test-utils/src/null-device/null-device.ts
@@ -76,10 +76,6 @@ export class NullDevice extends Device {
     return false;
   }
 
-  getSize(): [number, number] {
-    return [this.canvasContext.width, this.canvasContext.height];
-  }
-
   isTextureFormatSupported(format: TextureFormat): boolean {
     return true;
   }

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -184,10 +184,6 @@ export class WebGLDevice extends Device {
     return this.gl.isContextLost();
   }
 
-  getSize(): [number, number] {
-    return [this.gl.drawingBufferWidth, this.gl.drawingBufferHeight];
-  }
-
   isTextureFormatSupported(format: TextureFormat): boolean {
     return isTextureFormatSupported(this.gl, format, this._extensions);
   }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Not sure why we have .getSize method on just two devices. I feel it is confusing as the mental model in luma v9 is that size is managed by a canvasContext (which has several getSize() methods for more detailed control over what size is intended).
- E.g. `device.getCanvasContext().getDrawingBufferSize()`

#### Change List
- Remove WebGLDevice.getSize() and NullDevice.getSize()
