### PR TITLE
types: Add BindingValue to getUniforms return type

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -213,7 +213,6 @@ export class Model {
     const moduleMap = Object.fromEntries(
       this.props.modules?.map(module => [module.name, module]) || []
     );
-    // @ts-expect-error Fix typings
     this.setShaderInputs(props.shaderInputs || new ShaderInputs(moduleMap));
 
     // Setup shader assembler

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -8,14 +8,16 @@ import {log} from '@luma.gl/core';
 import {getShaderModuleDependencies, ShaderModule} from '@luma.gl/shadertools';
 import {splitUniformsAndBindings} from './model/split-uniforms-and-bindings';
 
+type BindingValue = Buffer | Texture | Sampler;
+
 /** Minimal ShaderModule subset, we don't need shader code etc */
 export type ShaderModuleInputs<
   PropsT extends Record<string, unknown> = Record<string, unknown>,
   UniformsT extends Record<string, UniformValue> = Record<string, UniformValue>,
-  BindingsT extends Record<string, Texture | Sampler> = Record<string, Texture | Sampler>
+  BindingsT extends Record<string, BindingValue> = Record<string, BindingValue>
 > = {
   defaultUniforms?: UniformsT;
-  getUniforms?: (settings: Partial<PropsT>, prevUniforms?: UniformsT) => UniformsT;
+  getUniforms?: (props?: any, oldProps?: any) => Record<string, BindingValue | UniformValue>;
 
   /** Not used. Used to access props type */
   props?: PropsT;

--- a/modules/engine/test/shader-inputs.spec.ts
+++ b/modules/engine/test/shader-inputs.spec.ts
@@ -74,7 +74,9 @@ test('ShaderInputs#bindings', t => {
       uniformPropTypes: {color: {value: [0, 0, 0]}}
     };
     if (callback) {
-      custom.getUniforms = ({color, colorTexture}) => ({color, colorTexture});
+      custom.getUniforms = ({color, colorTexture}: CustomProps): CustomProps => {
+        return {color, colorTexture};
+      };
     }
 
     const shaderInputs = new ShaderInputs<{

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -10,6 +10,7 @@ import {ShaderInjection} from '../shader-assembly/shader-injections';
 import {makePropValidators, getValidatedProperties} from '../filters/prop-types';
 import {normalizeInjections} from '../shader-assembly/shader-injections';
 
+export type BindingValue = Buffer | Texture | Sampler;
 export type UniformValue = number | boolean | Readonly<NumberArray>; // Float32Array> | Readonly<Int32Array> | Readonly<Uint32Array> | Readonly<number[]>;
 
 export type UniformInfo = {
@@ -24,7 +25,7 @@ export type UniformInfo = {
 export type ShaderModule<
   PropsT extends Record<string, unknown> = Record<string, unknown>,
   UniformsT extends Record<string, UniformValue> = Record<string, UniformValue>,
-  BindingsT extends Record<string, Buffer | Texture | Sampler> = {}
+  BindingsT extends Record<string, BindingValue> = Record<string, BindingValue>
 > = {
   /** Used for type inference not for values */
   props?: PropsT;
@@ -48,7 +49,7 @@ export type ShaderModule<
   defaultUniforms?: Required<UniformsT>; // Record<keyof UniformsT, UniformValue>;
 
   /** Function that maps props to uniforms & bindings */
-  getUniforms?: (props?: any, oldProps?: any) => Record<string, UniformValue>;
+  getUniforms?: (props?: any, oldProps?: any) => Record<string, BindingValue | UniformValue>;
 
   /** uniform buffers, textures, samplers, storage, ... */
   bindings?: Record<keyof BindingsT, {location: number; type: 'texture' | 'sampler' | 'uniforms'}>;

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -121,7 +121,7 @@ export function getShaderModuleUniforms<
   module: ShaderModuleT,
   props: ShaderModuleT['props'],
   oldUniforms?: ShaderModuleT['uniforms']
-): ShaderModuleT['uniforms'] {
+): Record<string, BindingValue | UniformValue> {
   initializeShaderModule(module);
 
   const uniforms = oldUniforms || {...module.defaultUniforms};

--- a/modules/shadertools/test/modules/engine/picking.spec.ts
+++ b/modules/shadertools/test/modules/engine/picking.spec.ts
@@ -7,6 +7,7 @@ import {webglDevice} from '@luma.gl/test-utils';
 
 import {BufferTransform} from '@luma.gl/engine';
 import {picking, getShaderModuleUniforms} from '@luma.gl/shadertools';
+import {UniformValue} from '@luma.gl/core';
 
 /* eslint-disable camelcase */
 
@@ -222,7 +223,7 @@ test.skip('picking#picking_setPickingColor', async t => {
           pickingThreshold: testCase.pickingThreshold
         },
         {}
-      );
+      ) as Record<string, UniformValue>;
 
       transform.model.setUniforms(uniforms);
       transform.run();


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Missing types for https://github.com/visgl/luma.gl/pull/2121
<!-- For other PRs without open issue -->

<!-- For all the PRs -->
#### Change List
- Add `BindingValue` as possible return value from `getUniforms`