### PR TITLE
chore(webgpu): Fix webgpu texture creation for 8 bit data inputs

### DIFF
--- a/modules/core/src/gpu-type-utils/decode-texture-format.ts
+++ b/modules/core/src/gpu-type-utils/decode-texture-format.ts
@@ -20,16 +20,18 @@ export type DecodedTextureFormat = {
   components: 1 | 2 | 3 | 4;
   /** What is the data type of each component */
   dataType?: VertexType;
+  /** If this is a packed data type */
+  packed?: boolean;
   /** Number of bytes per pixel */
-  bpp?: number;
+  bytesPerPixel?: number;
+  /** Number of bits per channel (may be unreliable for packed formats) */
+  bitsPerChannel: number;
   /** Depth stencil formats */
   a?: 'depth' | 'stencil' | 'depth-stencil';
   /** SRGB texture format? */
   srgb?: boolean;
   /** WebGL specific texture format? */
   webgl?: boolean;
-  /** byteLength */
-  byteLength: number;
   /** Is this an integer or floating point format? */
   integer: boolean;
   /** Is this a signed or unsigned format? */
@@ -42,6 +44,7 @@ export type DecodedTextureFormat = {
   blockWidth?: number;
   /** Block size for ASTC formats (texture must be a multiple) */
   blockHeight?: number;
+  /** */
 };
 
 /**
@@ -64,6 +67,8 @@ export function decodeTextureFormat(format: TextureFormat): DecodedTextureFormat
       const info: DecodedTextureFormat = {
         channels: channels as 'r' | 'rg' | 'rgb' | 'rgba',
         components: channels.length as 1 | 2 | 3 | 4,
+        bitsPerChannel: decodedType.byteLength * 8,
+        bytesPerPixel: decodedType.byteLength * channels.length,
         ...decodedType
       };
       if (suffix === '-webgl') {
@@ -84,22 +89,22 @@ export function decodeTextureFormat(format: TextureFormat): DecodedTextureFormat
 
 const EXCEPTIONS: Partial<Record<TextureFormat, Partial<DecodedTextureFormat>>> = {
   // Packed 16 bit formats
-  'rgba4unorm-webgl': {channels: 'rgba', bpp: 2},
-  'rgb565unorm-webgl': {channels: 'rgb', bpp: 2},
-  'rgb5a1unorm-webgl': {channels: 'rgba', bpp: 2},
+  'rgba4unorm-webgl': {channels: 'rgba', bytesPerPixel: 2, packed: true},
+  'rgb565unorm-webgl': {channels: 'rgb', bytesPerPixel: 2, packed: true},
+  'rgb5a1unorm-webgl': {channels: 'rgba', bytesPerPixel: 2, packed: true},
   // Packed 32 bit formats
-  rgb9e5ufloat: {channels: 'rgb', bpp: 4},
-  rg11b10ufloat: {channels: 'rgb', bpp: 4},
-  rgb10a2unorm: {channels: 'rgba', bpp: 4},
-  'rgb10a2uint-webgl': {channels: 'rgba', bpp: 4},
+  rgb9e5ufloat: {channels: 'rgb', bytesPerPixel: 4, packed: true},
+  rg11b10ufloat: {channels: 'rgb', bytesPerPixel: 4, packed: true},
+  rgb10a2unorm: {channels: 'rgba', bytesPerPixel: 4, packed: true},
+  'rgb10a2uint-webgl': {channels: 'rgba', bytesPerPixel: 4, packed: true},
   // Depth/stencil
-  stencil8: {components: 1, bpp: 1, a: 'stencil'},
-  depth16unorm: {components: 1, bpp: 2, a: 'depth'},
-  depth24plus: {components: 1, bpp: 3, a: 'depth'},
-  depth32float: {components: 1, bpp: 4, a: 'depth'},
-  'depth24plus-stencil8': {components: 2, bpp: 4, a: 'depth-stencil'},
+  stencil8: {components: 1, bytesPerPixel: 1, a: 'stencil', dataType: 'uint8'},
+  depth16unorm: {components: 1, bytesPerPixel: 2, a: 'depth', dataType: 'uint16'},
+  depth24plus: {components: 1, bytesPerPixel: 3, a: 'depth', dataType: 'uint32'},
+  depth32float: {components: 1, bytesPerPixel: 4, a: 'depth', dataType: 'float32'},
+  'depth24plus-stencil8': {components: 2, bytesPerPixel: 4, a: 'depth-stencil', packed: true},
   // "depth32float-stencil8" feature
-  'depth32float-stencil8': {components: 2, bpp: 4, a: 'depth-stencil'}
+  'depth32float-stencil8': {components: 2, bytesPerPixel: 4, a: 'depth-stencil', packed: true}
 };
 
 function decodeNonStandardFormat(format: TextureFormat): DecodedTextureFormat {
@@ -107,7 +112,7 @@ function decodeNonStandardFormat(format: TextureFormat): DecodedTextureFormat {
     const info: DecodedTextureFormat = {
       channels: 'rgb',
       components: 3,
-      byteLength: 1,
+      bytesPerPixel: 1,
       srgb: false,
       compressed: true
     } as DecodedTextureFormat;
@@ -122,12 +127,17 @@ function decodeNonStandardFormat(format: TextureFormat): DecodedTextureFormat {
   if (!data) {
     throw new Error(`Unknown format ${format}`);
   }
-  return {
+  const info: DecodedTextureFormat = {
+    ...data,
     channels: data.channels || '',
     components: data.components || data.channels?.length || 1,
-    byteLength: data.bpp || 1,
+    bytesPerPixel: data.bytesPerPixel || 1,
     srgb: false
   } as DecodedTextureFormat;
+  if (data.packed) {
+    info.packed = data.packed;
+  }
+  return info;
 }
 
 /** Parses ASTC block widths from format string */

--- a/modules/core/src/gpu-type-utils/decode-texture-format.ts
+++ b/modules/core/src/gpu-type-utils/decode-texture-format.ts
@@ -69,7 +69,10 @@ export function decodeTextureFormat(format: TextureFormat): DecodedTextureFormat
         components: channels.length as 1 | 2 | 3 | 4,
         bitsPerChannel: decodedType.byteLength * 8,
         bytesPerPixel: decodedType.byteLength * channels.length,
-        ...decodedType
+        dataType: decodedType.dataType,
+        integer: decodedType.integer,
+        signed: decodedType.signed,
+        normalized: decodedType.normalized
       };
       if (suffix === '-webgl') {
         info.webgl = true;

--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -142,8 +142,6 @@ function testFormatCreation(t, device: Device, withData: boolean = false) {
     const decodedFormat = decodeTextureFormat(formatName);
     const {dataType, packed, bitsPerChannel} = decodedFormat;
 
-    debugger;
-
     // WebGPU texture can currently only be set from 8 bit data
     const notImplemented = device.type === 'webgpu' && bitsPerChannel !== 8;
     console.log(formatName, bitsPerChannel);
@@ -198,7 +196,7 @@ function testFormatCreation(t, device: Device, withData: boolean = false) {
 //   t.end();
 // });
 
-test.only('Texture#format creation with data', async t => {
+test('Texture#format creation with data', async t => {
   for (const device of await getTestDevices()) {
     testFormatCreation(t, device, true);
   }

--- a/modules/core/test/gpu-type-utils/decode-texture-format.spec.ts
+++ b/modules/core/test/gpu-type-utils/decode-texture-format.spec.ts
@@ -8,15 +8,15 @@ import {decodeTextureFormat, TextureFormat} from '@luma.gl/core';
 // prettier-ignore
 const TEST_CASES: {format: TextureFormat, result: any}[] = [
   // 8-bit formats
-  {format: 'r8unorm', result: {channels: 'r', components: 1, dataType: 'uint8', byteLength: 1, integer: false, signed: false, normalized: true}},
-  {format: 'r8snorm', result: {channels: 'r', components: 1, dataType: 'sint8', byteLength: 1, integer: false, signed: true, normalized: true}},
-  {format: 'r8uint', result: {channels: 'r', components: 1, dataType: 'uint8', byteLength: 1, integer: true, signed: false, normalized: false}},
-  {format: 'r8sint', result: {channels: 'r', components: 1, dataType: 'sint8', byteLength: 1, integer: true, signed: true, normalized: false}},
+  {format: 'r8unorm', result: {channels: 'r', components: 1, dataType: 'uint8', bitsPerChannel: 8, bytesPerPixel: 1, integer: false, signed: false, normalized: true}},
+  {format: 'r8snorm', result: {channels: 'r', components: 1, dataType: 'sint8', bitsPerChannel: 8, bytesPerPixel: 1, integer: false, signed: true, normalized: true}},
+  {format: 'r8uint', result: {channels: 'r', components: 1, dataType: 'uint8', bitsPerChannel: 8, bytesPerPixel: 1, integer: true, signed: false, normalized: false}},
+  {format: 'r8sint', result: {channels: 'r', components: 1, dataType: 'sint8', bitsPerChannel: 8, bytesPerPixel: 1, integer: true, signed: true, normalized: false}},
 
   // 16-bit formats
-  {format: 'r16uint', result: {channels: 'r', components: 1, dataType: 'uint16', byteLength: 2, integer: true, signed: false, normalized: false}},
-  {format: 'r16sint', result: {channels: 'r', components: 1, dataType: 'sint16', byteLength: 2, integer: true, signed: true, normalized: false}},
-  {format: 'r16float', result: {channels: 'r', components: 1, dataType: 'float16', byteLength: 2, integer: false, signed: false, normalized: false }}
+  {format: 'r16uint', result: {channels: 'r', components: 1, dataType: 'uint16', bitsPerChannel: 16, bytesPerPixel: 2, integer: true, signed: false, normalized: false}},
+  {format: 'r16sint', result: {channels: 'r', components: 1, dataType: 'sint16', bitsPerChannel: 16, bytesPerPixel: 2, integer: true, signed: true, normalized: false}},
+  {format: 'r16float', result: {channels: 'r', components: 1, dataType: 'float16', bitsPerChannel: 16, bytesPerPixel: 2, integer: false, signed: false, normalized: false }}
 ];
 
 test('api#decodeTextureFormat', t => {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Texture initialization from data (rather than images) is more complicated in WebGPU as we need to work with buffers and command queues.
#### Change List
- For now creating `ImageData` objects for 8 bit data inputs enables test cases.
- Keep improving `decodeVertexFormat` to help identify which formats can be supported.
