### PR TITLE
fix(engine): Cannot find name 'OffscreenCanvas'

### DIFF
--- a/modules/engine/src/lib/animation-loop.d.ts
+++ b/modules/engine/src/lib/animation-loop.d.ts
@@ -5,6 +5,7 @@ import { Timeline } from '../animation/timeline'
 
 import {CreateGLContextOptions} from '@luma.gl/gltools'
 import {StatsManager} from '@luma.gl/webgl/src/init';
+import '@types/offscreencanvas';
 
 interface AnimationProps {
   gl: WebGLRenderingContext


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #1656 
#### Background
Seeing error `error TS2304: Cannot find name 'OffscreenCanvas'.` when building projects with this library.

PR https://github.com/visgl/luma.gl/pull/1649 added the `@types/offscreencanvas` dependency, but it is not currently being imported in `modules/engine/src/lib/animation-loop.d.ts`.
#### Change List
- Add missing import to `modules/engine/src/lib/animation-loop.d.ts` to fix missing Typescript reference
