### PR TITLE
chore(ci): Bump Node.js in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ name: test
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '20.x'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Hopefully a quick fix to keep CI alive on the v8.5 branch a while longer.