### PR TITLE
ShaderModule type improvement (v9)

### DIFF
--- a/modules/core/src/adapter/types/types.ts
+++ b/modules/core/src/adapter/types/types.ts
@@ -9,7 +9,7 @@ import type {Texture} from '../resources/texture'; // TextureView...
 // UNIFORMS
 
 /** Valid values for uniforms. @note boolean values get converted to 0 or 1 before setting */
-export type UniformValue = number | boolean | number[];
+export type UniformValue = number | boolean | Readonly<number[]>;
 
 // BINDINGS
 

--- a/modules/core/src/adapter/types/types.ts
+++ b/modules/core/src/adapter/types/types.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {NumberArray} from '../../types';
 import type {ColorTextureFormat, DepthStencilTextureFormat, TextureFormat} from './texture-formats';
 import type {Buffer} from '../resources/buffer';
 import type {Texture} from '../resources/texture'; // TextureView...
@@ -10,7 +9,7 @@ import type {Texture} from '../resources/texture'; // TextureView...
 // UNIFORMS
 
 /** Valid values for uniforms. @note boolean values get converted to 0 or 1 before setting */
-export type UniformValue = number | boolean | Readonly<NumberArray>; // Float32Array> | Readonly<Int32Array> | Readonly<Uint32Array> | Readonly<number[]>;
+export type UniformValue = number | boolean | number[];
 
 // BINDINGS
 

--- a/modules/core/src/lib/uniforms/uniform-store.ts
+++ b/modules/core/src/lib/uniforms/uniform-store.ts
@@ -10,12 +10,6 @@ import {UniformBlock} from './uniform-block';
 import {UniformBufferLayout} from './uniform-buffer-layout';
 import {log} from '../../utils/log';
 
-export type ShaderModuleInputs = {
-  uniformTypes?: Record<string, ShaderUniformType>;
-  defaultProps?: Record<string, unknown>;
-  defaultUniforms?: Record<string, UniformValue>;
-};
-
 /**
  * A uniform store holds a uniform values for one or more uniform blocks,
  * - It can generate binary data for any uniform buffer

--- a/modules/core/test/lib/utils/uniform.spec.ts
+++ b/modules/core/test/lib/utils/uniform.spec.ts
@@ -21,7 +21,6 @@ test('splitUniformsAndBindings', t => {
   const mixed: Parameters<typeof splitUniformsAndBindings>[0] = {
     array: [1, 2, 3, 4],
     boolean: true,
-    float32array: new Float32Array([1, 2, 3, 4]),
     number: 123,
     sampler: new WEBGLSampler(device, {}),
     texture: new WEBGLTexture(device, {})
@@ -30,7 +29,7 @@ test('splitUniformsAndBindings', t => {
   t.deepEquals(Object.keys(bindings), ['sampler', 'texture'], 'bindings correctly extracted');
   t.deepEquals(
     Object.keys(uniforms),
-    ['array', 'boolean', 'float32array', 'number'],
+    ['array', 'boolean', 'number'],
     'bindings correctly extracted'
   );
   t.end();

--- a/modules/engine/src/index.ts
+++ b/modules/engine/src/index.ts
@@ -57,7 +57,6 @@ export type {TruncatedConeGeometryProps} from './geometries/truncated-cone-geome
 export {TruncatedConeGeometry} from './geometries/truncated-cone-geometry';
 
 // EXPERIMENTAL
-export type {ShaderModuleInputs} from './shader-inputs';
 export {ShaderInputs as _ShaderInputs} from './shader-inputs';
 export type {ComputationProps} from './computation';
 export {Computation} from './computation';

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -80,7 +80,7 @@ export class ShaderInputs<
         continue; // eslint-disable-line no-continue
       }
 
-      const oldUniforms = this.moduleUniforms[moduleName] as any;
+      const oldUniforms = this.moduleUniforms[moduleName] as (typeof module)['uniforms'];
       const oldBindings = this.moduleBindings[moduleName];
       const uniformsAndBindings =
         module.getUniforms?.(moduleProps, oldUniforms) || (moduleProps as any);
@@ -126,8 +126,7 @@ export class ShaderInputs<
     for (const [moduleName, module] of Object.entries(this.moduleUniforms)) {
       for (const [key, value] of Object.entries(module)) {
         table[`${moduleName}.${key}`] = {
-          // @ts-ignore
-          type: this.modules[moduleName].uniformTypes?.[key],
+          type: this.modules[moduleName].uniformTypes?.[key as keyof ShaderPropsT],
           value: String(value)
         };
       }

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -2,19 +2,24 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {UniformValue, Texture, Sampler} from '@luma.gl/core';
+import type {Buffer, UniformValue, Texture, Sampler} from '@luma.gl/core';
 import {log, splitUniformsAndBindings} from '@luma.gl/core';
 // import type {ShaderUniformType, UniformValue, UniformFormat, UniformInfoDevice, Texture, Sampler} from '@luma.gl/core';
 import {_resolveModules, ShaderModuleInstance} from '@luma.gl/shadertools';
+
+type BindingValue = Buffer | Texture | Sampler;
 
 /** Minimal ShaderModule subset, we don't need shader code etc */
 export type ShaderModuleInputs<
   PropsT extends Record<string, unknown> = Record<string, unknown>,
   UniformsT extends Record<string, UniformValue> = Record<string, UniformValue>,
-  BindingsT extends Record<string, Texture | Sampler> = Record<string, Texture | Sampler>
+  BindingsT extends Record<string, BindingValue> = Record<string, BindingValue>
 > = {
-  defaultUniforms?: UniformsT;
-  getUniforms?: (settings: Partial<PropsT>, prevUniforms?: UniformsT) => UniformsT;
+  defaultUniforms?: Required<UniformsT>;
+  getUniforms?: (
+    props: Partial<PropsT>,
+    prevUniforms?: UniformsT
+  ) => Record<string, BindingValue | UniformValue>;
 
   /** Not used. Used to access props type */
   props?: PropsT;

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {UniformValue, Texture, Sampler} from '@luma.gl/core';
+import type {Binding, UniformValue} from '@luma.gl/core';
 import {log, splitUniformsAndBindings} from '@luma.gl/core';
 // import type {ShaderUniformType, UniformValue, UniformFormat, UniformInfoDevice, Texture, Sampler} from '@luma.gl/core';
 import {_resolveModules, ShaderModule, ShaderModuleInstance} from '@luma.gl/shadertools';
@@ -28,7 +28,7 @@ export class ShaderInputs<
   /** Stores the uniform values for each module */
   moduleUniforms: Record<keyof ShaderPropsT, Record<string, UniformValue>>;
   /** Stores the uniform bindings for each module  */
-  moduleBindings: Record<keyof ShaderPropsT, Record<string, Texture | Sampler>>;
+  moduleBindings: Record<keyof ShaderPropsT, Record<string, Binding>>;
   /** Tracks if uniforms have changed */
   moduleUniformsChanged: Record<keyof ShaderPropsT, false | string>;
 
@@ -51,7 +51,7 @@ export class ShaderInputs<
     // Store the module definitions and create storage for uniform values and binding values, per module
     this.modules = modules as {[P in keyof ShaderPropsT]: ShaderModule<ShaderPropsT[P]>};
     this.moduleUniforms = {} as Record<keyof ShaderPropsT, Record<string, UniformValue>>;
-    this.moduleBindings = {} as Record<keyof ShaderPropsT, Record<string, Texture | Sampler>>;
+    this.moduleBindings = {} as Record<keyof ShaderPropsT, Record<string, Binding>>;
 
     // Initialize the modules
     for (const [name, module] of Object.entries(modules)) {
@@ -113,8 +113,8 @@ export class ShaderInputs<
   }
 
   /** Merges all bindings for the shader (from the various modules) */
-  getBindings(): Record<string, Texture | Sampler> {
-    const bindings = {} as Record<string, Texture | Sampler>;
+  getBindings(): Record<string, Binding> {
+    const bindings = {} as Record<string, Binding>;
     for (const moduleBindings of Object.values(this.moduleBindings)) {
       Object.assign(bindings, moduleBindings);
     }

--- a/modules/engine/test/shader-inputs.spec.ts
+++ b/modules/engine/test/shader-inputs.spec.ts
@@ -97,14 +97,14 @@ test('ShaderInputs#dependencies', t => {
 test('ShaderInputs#bindings', t => {
   [true, false].map(callback => {
     t.comment(`custom module created ${callback ? 'with' : 'without'} getUniforms()`);
-    type CustomProps = {color: number[]; colorTexture: Texture};
+    type CustomProps = {color: [number, number, number]; colorTexture: Texture};
     const custom: ShaderModule<CustomProps> = {
       name: 'custom',
       uniformTypes: {color: 'vec3<f32>'},
       uniformPropTypes: {color: {value: [0, 0, 0]}}
     };
     if (callback) {
-      custom.getUniforms = ({color, colorTexture}) => ({color, colorTexture});
+      custom.getUniforms = props => ({color: props!.color!, colorTexture: props!.colorTexture!});
     }
 
     const shaderInputs = new ShaderInputs<{

--- a/modules/engine/test/shader-inputs.spec.ts
+++ b/modules/engine/test/shader-inputs.spec.ts
@@ -104,7 +104,7 @@ test('ShaderInputs#bindings', t => {
       uniformPropTypes: {color: {value: [0, 0, 0]}}
     };
     if (callback) {
-      custom.getUniforms = props => ({color: props!.color!, colorTexture: props!.colorTexture!});
+      custom.getUniforms = ({color, colorTexture}) => ({color, colorTexture});
     }
 
     const shaderInputs = new ShaderInputs<{

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -4,11 +4,9 @@
 
 import {UniformFormat} from '../../types';
 import {PropType} from '../filters/prop-types';
-import {Buffer, Sampler, Texture} from '@luma.gl/core';
-import {UniformTypes} from '../utils/uniform-types';
+import type {Buffer, Sampler, Texture} from '@luma.gl/core';
+import type {UniformTypes, UniformValue} from '../utils/uniform-types';
 
-// Do not allow NumberArray as we cannot then typecheck on length
-export type UniformValue = number | boolean | number[];
 type BindingValue = Buffer | Texture | Sampler;
 
 export type UniformInfo = {

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -24,7 +24,8 @@ export type PickUniforms<T> = {[K in UniformKeys<Required<T>>]: T[K]};
 
 /**
  * A shader module definition object
- * @note Can be viewed as the ShaderModuleProps for a ShaderModuleInstance
+ * @note `UniformsT` & `BindingsT` are deduced from `PropsT` by default. If
+ * a custom type for `UniformsT` is used, `BindingsT` should be also be provided.
  */
 export type ShaderModule<
   PropsT extends Record<string, any> = Record<string, any>,

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -51,7 +51,10 @@ export type ShaderModule<
   defaultUniforms?: Required<UniformsT>; // Record<keyof UniformsT, UniformValue>;
 
   /** Function that maps props to uniforms & bindings */
-  getUniforms?: (props?: Partial<PropsT>, prevUniforms?: UniformsT) => UniformsT & BindingsT;
+  getUniforms?: (
+    props?: Partial<PropsT>,
+    prevUniforms?: UniformsT
+  ) => Partial<UniformsT & BindingsT>;
 
   defines?: Record<string, string | number>;
   /** Injections */

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import type {Binding} from '@luma.gl/core';
 import {UniformFormat} from '../../types';
 import {PropType} from '../filters/prop-types';
-import type {Buffer, Sampler, Texture} from '@luma.gl/core';
 import type {UniformTypes, UniformValue} from '../utils/uniform-types';
-
-export type BindingValue = Buffer | Texture | Sampler;
 
 export type UniformInfo = {
   format?: UniformFormat;
@@ -26,7 +24,7 @@ export type PickUniforms<T> = {[K in UniformKeys<Required<T>>]: T[K]};
 export type ShaderModule<
   PropsT extends Record<string, any> = Record<string, any>,
   UniformsT extends Record<string, UniformValue> = PickUniforms<PropsT>,
-  BindingsT extends Record<string, BindingValue> = PickBindings<PropsT>
+  BindingsT extends Record<string, Binding> = PickBindings<PropsT>
 > = {
   /** Used for type inference not for values */
   props?: Required<PropsT>;
@@ -48,7 +46,7 @@ export type ShaderModule<
   getUniforms?: (
     props?: Partial<PropsT>,
     prevUniforms?: UniformsT
-  ) => Record<string, BindingValue | UniformValue>;
+  ) => Record<string, Binding | UniformValue>;
 
   /** uniform buffers, textures, samplers, storage, ... */
   bindings?: Record<keyof BindingsT, {location: number; type: 'texture' | 'sampler' | 'uniforms'}>;

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -5,9 +5,10 @@
 import {NumberArray} from '@math.gl/types';
 import {UniformFormat} from '../../types';
 import {PropType} from '../filters/prop-types';
-import {Sampler, Texture} from '@luma.gl/core';
+import {Buffer, Sampler, Texture} from '@luma.gl/core';
 
-export type UniformValue = number | boolean | Readonly<NumberArray>; // Float32Array> | Readonly<Int32Array> | Readonly<Uint32Array> | Readonly<number[]>;
+export type UniformValue = number | boolean | Readonly<NumberArray>; // Readonly<Float32Array> | Readonly<Int32Array> | Readonly<Uint32Array> | Readonly<number[]>;
+type BindingValue = Buffer | Texture | Sampler;
 
 export type UniformInfo = {
   format?: UniformFormat;
@@ -20,7 +21,7 @@ export type UniformInfo = {
 export type ShaderModule<
   PropsT extends Record<string, unknown> = Record<string, unknown>,
   UniformsT extends Record<string, UniformValue> = Record<string, UniformValue>,
-  BindingsT extends Record<string, Buffer | Texture | Sampler> = {}
+  BindingsT extends Record<string, BindingValue> = Record<string, BindingValue>
 > = {
   /** Used for type inference not for values */
   props?: Required<PropsT>;
@@ -39,7 +40,10 @@ export type ShaderModule<
   defaultUniforms?: Required<UniformsT>; // Record<keyof UniformsT, UniformValue>;
 
   /** Function that maps props to uniforms & bindings */
-  getUniforms?: (props?: any, oldProps?: any) => Record<string, UniformValue>;
+  getUniforms?: (
+    props?: Partial<PropsT>,
+    prevUniforms?: UniformsT
+  ) => Record<string, BindingValue | UniformValue>;
 
   /** uniform buffers, textures, samplers, storage, ... */
   bindings?: Record<keyof BindingsT, {location: number; type: 'texture' | 'sampler' | 'uniforms'}>;

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -7,7 +7,7 @@ import {PropType} from '../filters/prop-types';
 import type {Buffer, Sampler, Texture} from '@luma.gl/core';
 import type {UniformTypes, UniformValue} from '../utils/uniform-types';
 
-type BindingValue = Buffer | Texture | Sampler;
+export type BindingValue = Buffer | Texture | Sampler;
 
 export type UniformInfo = {
   format?: UniformFormat;
@@ -16,8 +16,8 @@ export type UniformInfo = {
 // Helper types
 type FilterBindingKeys<T> = {[K in keyof T]: T[K] extends UniformValue ? never : K}[keyof T];
 type FilterUniformKeys<T> = {[K in keyof T]: T[K] extends UniformValue ? K : never}[keyof T];
-type BindingsOnly<T> = {[K in FilterBindingKeys<Required<T>>]: T[K]};
-type UniformsOnly<T> = {[K in FilterUniformKeys<Required<T>>]: T[K]};
+export type BindingsOnly<T> = {[K in FilterBindingKeys<Required<T>>]: T[K]};
+export type UniformsOnly<T> = {[K in FilterUniformKeys<Required<T>>]: T[K]};
 
 /**
  * A shader module definition object

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -2,10 +2,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Binding} from '@luma.gl/core';
 import {UniformFormat} from '../../types';
 import {PropType} from '../filters/prop-types';
 import type {UniformTypes, UniformValue} from '../utils/uniform-types';
+
+// To avoid dependency on core module, do not import `Binding` type.
+// The ShaderModule is not concerned with the type of `Binding`,
+// it is the repsonsibility of `splitUniformsAndBindings` in
+// ShaderInputs to type the result of `getUniforms()`
+type Binding = unknown; // import type {Binding} from '@luma.gl/core';
 
 export type UniformInfo = {
   format?: UniformFormat;
@@ -30,6 +35,8 @@ export type ShaderModule<
   props?: Required<PropsT>;
   /** Used for type inference, not currently used for values */
   uniforms?: UniformsT;
+  /** Used for type inference, not currently used for values */
+  bindings?: BindingsT;
 
   name: string;
   fs?: string;
@@ -43,13 +50,7 @@ export type ShaderModule<
   defaultUniforms?: Required<UniformsT>; // Record<keyof UniformsT, UniformValue>;
 
   /** Function that maps props to uniforms & bindings */
-  getUniforms?: (
-    props?: Partial<PropsT>,
-    prevUniforms?: UniformsT
-  ) => Record<string, Binding | UniformValue>;
-
-  /** uniform buffers, textures, samplers, storage, ... */
-  bindings?: Record<keyof BindingsT, {location: number; type: 'texture' | 'sampler' | 'uniforms'}>;
+  getUniforms?: (props?: Partial<PropsT>, prevUniforms?: UniformsT) => UniformsT & BindingsT;
 
   defines?: Record<string, string | number>;
   /** Injections */

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -2,26 +2,33 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {NumberArray} from '@math.gl/types';
 import {UniformFormat} from '../../types';
 import {PropType} from '../filters/prop-types';
 import {Buffer, Sampler, Texture} from '@luma.gl/core';
+import {UniformTypes} from '../utils/uniform-types';
 
-export type UniformValue = number | boolean | Readonly<NumberArray>; // Readonly<Float32Array> | Readonly<Int32Array> | Readonly<Uint32Array> | Readonly<number[]>;
+// Do not allow NumberArray as we cannot then typecheck on length
+export type UniformValue = number | boolean | number[];
 type BindingValue = Buffer | Texture | Sampler;
 
 export type UniformInfo = {
   format?: UniformFormat;
 } & PropType;
 
+// Helper types
+type FilterBindingKeys<T> = {[K in keyof T]: T[K] extends UniformValue ? never : K}[keyof T];
+type FilterUniformKeys<T> = {[K in keyof T]: T[K] extends UniformValue ? K : never}[keyof T];
+type BindingsOnly<T> = {[K in FilterBindingKeys<Required<T>>]: T[K]};
+type UniformsOnly<T> = {[K in FilterUniformKeys<Required<T>>]: T[K]};
+
 /**
  * A shader module definition object
  * @note Can be viewed as the ShaderModuleProps for a ShaderModuleInstance
  */
 export type ShaderModule<
-  PropsT extends Record<string, unknown> = Record<string, unknown>,
-  UniformsT extends Record<string, UniformValue> = Record<string, UniformValue>,
-  BindingsT extends Record<string, BindingValue> = Record<string, BindingValue>
+  PropsT extends Record<string, any> = Record<string, any>,
+  UniformsT extends Record<string, UniformValue> = UniformsOnly<PropsT>,
+  BindingsT extends Record<string, BindingValue> = BindingsOnly<PropsT>
 > = {
   /** Used for type inference not for values */
   props?: Required<PropsT>;
@@ -33,7 +40,7 @@ export type ShaderModule<
   vs?: string;
 
   /** Uniform shader types @note: Both order and types MUST match uniform block declarations in shader */
-  uniformTypes?: Record<keyof UniformsT, UniformFormat>;
+  uniformTypes?: Required<UniformTypes<UniformsT>>; // Record<keyof UniformsT, UniformFormat>;
   /** Uniform JS prop types  */
   uniformPropTypes?: Record<keyof UniformsT, UniformInfo>;
   /** Default uniform values */

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -14,10 +14,10 @@ export type UniformInfo = {
 } & PropType;
 
 // Helper types
-type FilterBindingKeys<T> = {[K in keyof T]: T[K] extends UniformValue ? never : K}[keyof T];
-type FilterUniformKeys<T> = {[K in keyof T]: T[K] extends UniformValue ? K : never}[keyof T];
-export type BindingsOnly<T> = {[K in FilterBindingKeys<Required<T>>]: T[K]};
-export type UniformsOnly<T> = {[K in FilterUniformKeys<Required<T>>]: T[K]};
+type BindingKeys<T> = {[K in keyof T]: T[K] extends UniformValue ? never : K}[keyof T];
+type UniformKeys<T> = {[K in keyof T]: T[K] extends UniformValue ? K : never}[keyof T];
+export type PickBindings<T> = {[K in BindingKeys<Required<T>>]: T[K]};
+export type PickUniforms<T> = {[K in UniformKeys<Required<T>>]: T[K]};
 
 /**
  * A shader module definition object
@@ -25,8 +25,8 @@ export type UniformsOnly<T> = {[K in FilterUniformKeys<Required<T>>]: T[K]};
  */
 export type ShaderModule<
   PropsT extends Record<string, any> = Record<string, any>,
-  UniformsT extends Record<string, UniformValue> = UniformsOnly<PropsT>,
-  BindingsT extends Record<string, BindingValue> = BindingsOnly<PropsT>
+  UniformsT extends Record<string, UniformValue> = PickUniforms<PropsT>,
+  BindingsT extends Record<string, BindingValue> = PickBindings<PropsT>
 > = {
   /** Used for type inference not for values */
   props?: Required<PropsT>;

--- a/modules/shadertools/src/lib/shader-module/shader-pass.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-pass.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {BindingValue, PickBindings, PickUniforms, ShaderModule} from './shader-module';
+import type {Binding} from '@luma.gl/core';
+import type {PickBindings, PickUniforms, ShaderModule} from './shader-module';
 import type {UniformValue} from '../utils/uniform-types';
 
 /**
@@ -12,7 +13,7 @@ import type {UniformValue} from '../utils/uniform-types';
 export type ShaderPass<
   PropsT extends Record<string, any> = Record<string, any>,
   UniformsT extends Record<string, UniformValue> = PickUniforms<PropsT>,
-  BindingsT extends Record<string, BindingValue> = PickBindings<PropsT>
+  BindingsT extends Record<string, Binding> = PickBindings<PropsT>
 > = ShaderModule<PropsT, UniformsT, BindingsT> & {
   passes: ShaderPassData[];
 };

--- a/modules/shadertools/src/lib/shader-module/shader-pass.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-pass.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {BindingsOnly, BindingValue, ShaderModule, UniformsOnly} from './shader-module';
+import type {BindingValue, PickBindings, PickUniforms, ShaderModule} from './shader-module';
 import type {UniformValue} from '../utils/uniform-types';
 
 /**
@@ -11,8 +11,8 @@ import type {UniformValue} from '../utils/uniform-types';
  */
 export type ShaderPass<
   PropsT extends Record<string, any> = Record<string, any>,
-  UniformsT extends Record<string, UniformValue> = UniformsOnly<PropsT>,
-  BindingsT extends Record<string, BindingValue> = BindingsOnly<PropsT>
+  UniformsT extends Record<string, UniformValue> = PickUniforms<PropsT>,
+  BindingsT extends Record<string, BindingValue> = PickBindings<PropsT>
 > = ShaderModule<PropsT, UniformsT, BindingsT> & {
   passes: ShaderPassData[];
 };

--- a/modules/shadertools/src/lib/shader-module/shader-pass.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-pass.ts
@@ -2,16 +2,18 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {ShaderModule, UniformValue} from './shader-module';
+import type {BindingsOnly, BindingValue, ShaderModule, UniformsOnly} from './shader-module';
+import type {UniformValue} from '../utils/uniform-types';
 
 /**
  * A shaderpass is a shader module with additional information
  * on how to run
  */
 export type ShaderPass<
-  PropsT extends Record<string, unknown> = Record<string, unknown>,
-  UniformsT extends Record<string, UniformValue> = Record<string, UniformValue>
-> = ShaderModule<PropsT, UniformsT> & {
+  PropsT extends Record<string, any> = Record<string, any>,
+  UniformsT extends Record<string, UniformValue> = UniformsOnly<PropsT>,
+  BindingsT extends Record<string, BindingValue> = BindingsOnly<PropsT>
+> = ShaderModule<PropsT, UniformsT, BindingsT> & {
   passes: ShaderPassData[];
 };
 

--- a/modules/shadertools/src/lib/utils/uniform-types.ts
+++ b/modules/shadertools/src/lib/utils/uniform-types.ts
@@ -44,7 +44,7 @@ export type NumArray16 = [
  *
  * Only allow types whose length we can type-check (not `TypedArray`)
  */
-export type UniformValue =
+export type UniformValue = Readonly<
   | number
   | boolean
   | NumArray2
@@ -59,7 +59,8 @@ export type UniformValue =
   | Vector3
   | Vector4
   | Matrix3
-  | Matrix4;
+  | Matrix4
+>;
 
 type UniformType<ValueT extends UniformValue> = ValueT extends number | boolean
   ? 'f32' | 'i32' | 'u32'

--- a/modules/shadertools/src/lib/utils/uniform-types.ts
+++ b/modules/shadertools/src/lib/utils/uniform-types.ts
@@ -1,12 +1,12 @@
 import type {Matrix3, Matrix4, Vector2, Vector3, Vector4} from '@math.gl/core';
 
-export type NumArray2 = [number, number];
-export type NumArray3 = [number, number, number];
-export type NumArray4 = [number, number, number, number];
-export type NumArray6 = [number, number, number, number, number, number];
-export type NumArray8 = [number, number, number, number, number, number, number, number];
-export type NumArray9 = [number, number, number, number, number, number, number, number, number];
-export type NumArray12 = [
+export type NumberArray2 = [number, number];
+export type NumberArray3 = [number, number, number];
+export type NumberArray4 = [number, number, number, number];
+export type NumberArray6 = [number, number, number, number, number, number];
+export type NumberArray8 = [number, number, number, number, number, number, number, number];
+export type NumberArray9 = [number, number, number, number, number, number, number, number, number];
+export type NumberArray12 = [
   number,
   number,
   number,
@@ -20,7 +20,7 @@ export type NumArray12 = [
   number,
   number
 ];
-export type NumArray16 = [
+export type NumberArray16 = [
   number,
   number,
   number,
@@ -47,14 +47,14 @@ export type NumArray16 = [
 export type UniformValue = Readonly<
   | number
   | boolean
-  | NumArray2
-  | NumArray3
-  | NumArray4
-  | NumArray6
-  | NumArray8
-  | NumArray9
-  | NumArray12
-  | NumArray16
+  | NumberArray2
+  | NumberArray3
+  | NumberArray4
+  | NumberArray6
+  | NumberArray8
+  | NumberArray9
+  | NumberArray12
+  | NumberArray16
   | Vector2
   | Vector3
   | Vector4
@@ -64,21 +64,21 @@ export type UniformValue = Readonly<
 
 type UniformType<ValueT extends UniformValue> = ValueT extends number | boolean
   ? 'f32' | 'i32' | 'u32'
-  : ValueT extends Readonly<NumArray2 | Vector2>
+  : ValueT extends Readonly<NumberArray2 | Vector2>
   ? 'vec2<f32>' | 'vec2<i32>' | 'vec2<u32>'
-  : ValueT extends Readonly<NumArray3 | Vector3>
+  : ValueT extends Readonly<NumberArray3 | Vector3>
   ? 'vec3<f32>' | 'vec3<i32>' | 'vec3<u32>'
-  : ValueT extends Readonly<NumArray4 | Vector4>
+  : ValueT extends Readonly<NumberArray4 | Vector4>
   ? 'vec4<f32>' | 'vec4<i32>' | 'vec4<u32>' | 'mat2x2<f32>'
-  : ValueT extends Readonly<NumArray6>
+  : ValueT extends Readonly<NumberArray6>
   ? 'mat2x3<f32>' | 'mat3x2<f32>'
-  : ValueT extends Readonly<NumArray8>
+  : ValueT extends Readonly<NumberArray8>
   ? 'mat2x4<f32>' | 'mat4x2<f32>'
-  : ValueT extends Readonly<NumArray9 | Matrix3>
+  : ValueT extends Readonly<NumberArray9 | Matrix3>
   ? 'mat3x3<f32>'
-  : ValueT extends Readonly<NumArray12>
+  : ValueT extends Readonly<NumberArray12>
   ? 'mat3x4<f32>' | 'mat4x3<f32>'
-  : ValueT extends Readonly<NumArray16 | Matrix4>
+  : ValueT extends Readonly<NumberArray16 | Matrix4>
   ? 'mat4x4<f32>'
   : never;
 

--- a/modules/shadertools/src/lib/utils/uniform-types.ts
+++ b/modules/shadertools/src/lib/utils/uniform-types.ts
@@ -64,21 +64,21 @@ export type UniformValue = Readonly<
 
 type UniformType<ValueT extends UniformValue> = ValueT extends number | boolean
   ? 'f32' | 'i32' | 'u32'
-  : ValueT extends NumArray2 | Vector2
+  : ValueT extends Readonly<NumArray2 | Vector2>
   ? 'vec2<f32>' | 'vec2<i32>' | 'vec2<u32>'
-  : ValueT extends NumArray3 | Vector3
+  : ValueT extends Readonly<NumArray3 | Vector3>
   ? 'vec3<f32>' | 'vec3<i32>' | 'vec3<u32>'
-  : ValueT extends NumArray4 | Vector4
+  : ValueT extends Readonly<NumArray4 | Vector4>
   ? 'vec4<f32>' | 'vec4<i32>' | 'vec4<u32>' | 'mat2x2<f32>'
-  : ValueT extends NumArray6
+  : ValueT extends Readonly<NumArray6>
   ? 'mat2x3<f32>' | 'mat3x2<f32>'
-  : ValueT extends NumArray8
+  : ValueT extends Readonly<NumArray8>
   ? 'mat2x4<f32>' | 'mat4x2<f32>'
-  : ValueT extends NumArray9 | Matrix3
+  : ValueT extends Readonly<NumArray9 | Matrix3>
   ? 'mat3x3<f32>'
-  : ValueT extends NumArray12
+  : ValueT extends Readonly<NumArray12>
   ? 'mat3x4<f32>' | 'mat4x3<f32>'
-  : ValueT extends NumArray16 | Matrix4
+  : ValueT extends Readonly<NumArray16 | Matrix4>
   ? 'mat4x4<f32>'
   : never;
 

--- a/modules/shadertools/src/lib/utils/uniform-types.ts
+++ b/modules/shadertools/src/lib/utils/uniform-types.ts
@@ -1,12 +1,12 @@
 import type {Matrix3, Matrix4, Vector2, Vector3, Vector4} from '@math.gl/core';
 
-type NumberArray2 = [number, number];
-type NumberArray3 = [number, number, number];
-type NumberArray4 = [number, number, number, number];
-type NumberArray6 = [number, number, number, number, number, number];
-type NumberArray8 = [number, number, number, number, number, number, number, number];
-type NumberArray9 = [number, number, number, number, number, number, number, number, number];
-type NumberArray12 = [
+export type NumArray2 = [number, number];
+export type NumArray3 = [number, number, number];
+export type NumArray4 = [number, number, number, number];
+export type NumArray6 = [number, number, number, number, number, number];
+export type NumArray8 = [number, number, number, number, number, number, number, number];
+export type NumArray9 = [number, number, number, number, number, number, number, number, number];
+export type NumArray12 = [
   number,
   number,
   number,
@@ -20,7 +20,7 @@ type NumberArray12 = [
   number,
   number
 ];
-export type NumberArray16 = [
+export type NumArray16 = [
   number,
   number,
   number,
@@ -47,14 +47,14 @@ export type NumberArray16 = [
 export type UniformValue =
   | number
   | boolean
-  | NumberArray2
-  | NumberArray3
-  | NumberArray4
-  | NumberArray6
-  | NumberArray8
-  | NumberArray9
-  | NumberArray12
-  | NumberArray16
+  | NumArray2
+  | NumArray3
+  | NumArray4
+  | NumArray6
+  | NumArray8
+  | NumArray9
+  | NumArray12
+  | NumArray16
   | Vector2
   | Vector3
   | Vector4
@@ -63,21 +63,21 @@ export type UniformValue =
 
 type UniformType<ValueT extends UniformValue> = ValueT extends number | boolean
   ? 'f32' | 'i32' | 'u32'
-  : ValueT extends NumberArray2 | Vector2
+  : ValueT extends NumArray2 | Vector2
   ? 'vec2<f32>' | 'vec2<i32>' | 'vec2<u32>'
-  : ValueT extends NumberArray3 | Vector3
+  : ValueT extends NumArray3 | Vector3
   ? 'vec3<f32>' | 'vec3<i32>' | 'vec3<u32>'
-  : ValueT extends NumberArray4 | Vector4
+  : ValueT extends NumArray4 | Vector4
   ? 'vec4<f32>' | 'vec4<i32>' | 'vec4<u32>' | 'mat2x2<f32>'
-  : ValueT extends NumberArray6
+  : ValueT extends NumArray6
   ? 'mat2x3<f32>' | 'mat3x2<f32>'
-  : ValueT extends NumberArray8
+  : ValueT extends NumArray8
   ? 'mat2x4<f32>' | 'mat4x2<f32>'
-  : ValueT extends NumberArray9 | Matrix3
+  : ValueT extends NumArray9 | Matrix3
   ? 'mat3x3<f32>'
-  : ValueT extends NumberArray12
+  : ValueT extends NumArray12
   ? 'mat3x4<f32>' | 'mat4x3<f32>'
-  : ValueT extends NumberArray16 | Matrix4
+  : ValueT extends NumArray16 | Matrix4
   ? 'mat4x4<f32>'
   : never;
 

--- a/modules/shadertools/src/lib/utils/uniform-types.ts
+++ b/modules/shadertools/src/lib/utils/uniform-types.ts
@@ -1,0 +1,90 @@
+import type {Matrix3, Matrix4, Vector2, Vector3, Vector4} from '@math.gl/core';
+
+type NumberArray2 = [number, number];
+type NumberArray3 = [number, number, number];
+type NumberArray4 = [number, number, number, number];
+type NumberArray6 = [number, number, number, number, number, number];
+type NumberArray8 = [number, number, number, number, number, number, number, number];
+type NumberArray9 = [number, number, number, number, number, number, number, number, number];
+type NumberArray12 = [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number
+];
+export type NumberArray16 = [
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number,
+  number
+];
+
+/*
+ * Allowed types to be used for uniform values
+ *
+ * Only allow types whose length we can type-check (not `TypedArray`)
+ */
+export type UniformValue =
+  | number
+  | boolean
+  | NumberArray2
+  | NumberArray3
+  | NumberArray4
+  | NumberArray6
+  | NumberArray8
+  | NumberArray9
+  | NumberArray12
+  | NumberArray16
+  | Vector2
+  | Vector3
+  | Vector4
+  | Matrix3
+  | Matrix4;
+
+type UniformType<ValueT extends UniformValue> = ValueT extends number | boolean
+  ? 'f32' | 'i32' | 'u32'
+  : ValueT extends NumberArray2 | Vector2
+  ? 'vec2<f32>' | 'vec2<i32>' | 'vec2<u32>'
+  : ValueT extends NumberArray3 | Vector3
+  ? 'vec3<f32>' | 'vec3<i32>' | 'vec3<u32>'
+  : ValueT extends NumberArray4 | Vector4
+  ? 'vec4<f32>' | 'vec4<i32>' | 'vec4<u32>' | 'mat2x2<f32>'
+  : ValueT extends NumberArray6
+  ? 'mat2x3<f32>' | 'mat3x2<f32>'
+  : ValueT extends NumberArray8
+  ? 'mat2x4<f32>' | 'mat4x2<f32>'
+  : ValueT extends NumberArray9 | Matrix3
+  ? 'mat3x3<f32>'
+  : ValueT extends NumberArray12
+  ? 'mat3x4<f32>' | 'mat4x3<f32>'
+  : ValueT extends NumberArray16 | Matrix4
+  ? 'mat4x4<f32>'
+  : never;
+
+type UniformProps = {
+  [name: string]: UniformValue;
+};
+
+export type UniformTypes<PropsT extends UniformProps> = {
+  [name in keyof PropsT]: UniformType<PropsT[name]>;
+};

--- a/modules/shadertools/src/modules-webgl1/project/project.ts
+++ b/modules/shadertools/src/modules-webgl1/project/project.ts
@@ -2,20 +2,21 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Matrix4} from '@math.gl/core';
+import {Vector3, Matrix4} from '@math.gl/core';
 import {glsl} from '../../lib/glsl-utils/highlight';
 import {ShaderModule} from '../../lib/shader-module/shader-module';
+import {NumArray3, NumArray16} from '../../lib/utils/uniform-types';
 
 type ProjectionProps = {
-  modelMatrix?: readonly number[];
-  viewMatrix?: readonly number[];
-  projectionMatrix?: readonly number[];
-  cameraPositionWorld?: readonly number[];
+  modelMatrix?: Readonly<Matrix4 | NumArray16>;
+  viewMatrix?: Readonly<Matrix4 | NumArray16>;
+  projectionMatrix?: Readonly<Matrix4 | NumArray16>;
+  cameraPositionWorld?: Readonly<Vector3 | NumArray3>;
 };
 
-const IDENTITY_MATRIX = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+const IDENTITY_MATRIX: NumArray16 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 
-const DEFAULT_MODULE_OPTIONS = {
+const DEFAULT_MODULE_OPTIONS: ProjectionProps = {
   modelMatrix: IDENTITY_MATRIX,
   viewMatrix: IDENTITY_MATRIX,
   projectionMatrix: IDENTITY_MATRIX,

--- a/modules/shadertools/src/modules-webgl1/project/project.ts
+++ b/modules/shadertools/src/modules-webgl1/project/project.ts
@@ -5,7 +5,7 @@
 import {Vector3, Matrix4} from '@math.gl/core';
 import {glsl} from '../../lib/glsl-utils/highlight';
 import {ShaderModule} from '../../lib/shader-module/shader-module';
-import {NumArray3, NumArray16} from '../../lib/utils/uniform-types';
+import type {NumArray3, NumArray16} from '../../lib/utils/uniform-types';
 
 type ProjectionProps = {
   modelMatrix?: Readonly<Matrix4 | NumArray16>;

--- a/modules/shadertools/src/modules-webgl1/project/project.ts
+++ b/modules/shadertools/src/modules-webgl1/project/project.ts
@@ -5,16 +5,16 @@
 import {Vector3, Matrix4} from '@math.gl/core';
 import {glsl} from '../../lib/glsl-utils/highlight';
 import {ShaderModule} from '../../lib/shader-module/shader-module';
-import type {NumArray3, NumArray16} from '../../lib/utils/uniform-types';
+import type {NumberArray3, NumberArray16} from '../../lib/utils/uniform-types';
 
 type ProjectionProps = {
-  modelMatrix?: Readonly<Matrix4 | NumArray16>;
-  viewMatrix?: Readonly<Matrix4 | NumArray16>;
-  projectionMatrix?: Readonly<Matrix4 | NumArray16>;
-  cameraPositionWorld?: Readonly<Vector3 | NumArray3>;
+  modelMatrix?: Readonly<Matrix4 | NumberArray16>;
+  viewMatrix?: Readonly<Matrix4 | NumberArray16>;
+  projectionMatrix?: Readonly<Matrix4 | NumberArray16>;
+  cameraPositionWorld?: Readonly<Vector3 | NumberArray3>;
 };
 
-const IDENTITY_MATRIX: NumArray16 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+const IDENTITY_MATRIX: NumberArray16 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 
 const DEFAULT_MODULE_OPTIONS: ProjectionProps = {
   modelMatrix: IDENTITY_MATRIX,

--- a/modules/shadertools/src/modules/engine/picking/picking.ts
+++ b/modules/shadertools/src/modules/engine/picking/picking.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {NumberArray} from '../../../types';
 import {glsl} from '../../../lib/glsl-utils/highlight';
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
+import type {NumArray3, NumArray4} from '../../../lib/utils/uniform-types';
 
 // cyan color
-const DEFAULT_HIGHLIGHT_COLOR = new Float32Array([0, 1, 1, 1]);
+const DEFAULT_HIGHLIGHT_COLOR: NumArray4 = [0, 1, 1, 1];
 
 /**
  * Props for the picking module, which depending on mode renders picking colors or highlighted item.
@@ -20,9 +20,9 @@ export type PickingProps = {
   /** Set to true when picking an attribute value instead of object index */
   isAttribute?: boolean;
   /** Set to a picking color to visually highlight that item, or `null` to explicitly clear **/
-  highlightedObjectColor?: NumberArray | null;
+  highlightedObjectColor?: NumArray3 | null;
   /** Color of visual highlight of "selected" item */
-  highlightColor?: NumberArray;
+  highlightColor?: NumArray3 | NumArray4;
   /** Color range 0-1 or 0-255 */
   useFloatColors?: boolean;
 };
@@ -45,9 +45,9 @@ export type PickingUniforms = {
   /** Do we have a highlighted item? */
   isHighlightActive?: boolean;
   /** Set to a picking color to visually highlight that item */
-  highlightedObjectColor?: NumberArray;
+  highlightedObjectColor?: NumArray3;
   /** Color of visual highlight of "selected" item */
-  highlightColor?: NumberArray;
+  highlightColor?: NumArray4;
 };
 
 const vs = glsl`\
@@ -207,7 +207,7 @@ export const picking: ShaderModule<PickingProps, PickingUniforms> = {
     isAttribute: false,
     isHighlightActive: false,
     useFloatColors: true,
-    highlightedObjectColor: new Float32Array([0, 0, 0]),
+    highlightedObjectColor: [0, 0, 0],
     highlightColor: DEFAULT_HIGHLIGHT_COLOR
   },
   getUniforms
@@ -222,7 +222,7 @@ function getUniforms(opts: PickingProps = {}, prevUniforms?: PickingUniforms): P
     uniforms.isHighlightActive = false;
   } else {
     uniforms.isHighlightActive = true;
-    const highlightedObjectColor = opts.highlightedObjectColor.slice(0, 3);
+    const highlightedObjectColor = opts.highlightedObjectColor.slice(0, 3) as NumArray3;
     uniforms.highlightedObjectColor = highlightedObjectColor;
   }
 
@@ -231,7 +231,7 @@ function getUniforms(opts: PickingProps = {}, prevUniforms?: PickingUniforms): P
     if (!Number.isFinite(color[3])) {
       color[3] = 1;
     }
-    uniforms.highlightColor = color;
+    uniforms.highlightColor = color as NumArray4;
   }
 
   if (opts.isActive !== undefined) {

--- a/modules/shadertools/src/modules/engine/picking/picking.ts
+++ b/modules/shadertools/src/modules/engine/picking/picking.ts
@@ -4,10 +4,10 @@
 
 import {glsl} from '../../../lib/glsl-utils/highlight';
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
-import type {NumArray3, NumArray4} from '../../../lib/utils/uniform-types';
+import type {NumberArray3, NumberArray4} from '../../../lib/utils/uniform-types';
 
 // cyan color
-const DEFAULT_HIGHLIGHT_COLOR: NumArray4 = [0, 1, 1, 1];
+const DEFAULT_HIGHLIGHT_COLOR: NumberArray4 = [0, 1, 1, 1];
 
 /**
  * Props for the picking module, which depending on mode renders picking colors or highlighted item.
@@ -20,9 +20,9 @@ export type PickingProps = {
   /** Set to true when picking an attribute value instead of object index */
   isAttribute?: boolean;
   /** Set to a picking color to visually highlight that item, or `null` to explicitly clear **/
-  highlightedObjectColor?: NumArray3 | null;
+  highlightedObjectColor?: NumberArray3 | null;
   /** Color of visual highlight of "selected" item */
-  highlightColor?: NumArray3 | NumArray4;
+  highlightColor?: NumberArray3 | NumberArray4;
   /** Color range 0-1 or 0-255 */
   useFloatColors?: boolean;
 };
@@ -45,9 +45,9 @@ export type PickingUniforms = {
   /** Do we have a highlighted item? */
   isHighlightActive?: boolean;
   /** Set to a picking color to visually highlight that item */
-  highlightedObjectColor?: NumArray3;
+  highlightedObjectColor?: NumberArray3;
   /** Color of visual highlight of "selected" item */
-  highlightColor?: NumArray4;
+  highlightColor?: NumberArray4;
 };
 
 const vs = glsl`\
@@ -222,7 +222,7 @@ function getUniforms(opts: PickingProps = {}, prevUniforms?: PickingUniforms): P
     uniforms.isHighlightActive = false;
   } else {
     uniforms.isHighlightActive = true;
-    const highlightedObjectColor = opts.highlightedObjectColor.slice(0, 3) as NumArray3;
+    const highlightedObjectColor = opts.highlightedObjectColor.slice(0, 3) as NumberArray3;
     uniforms.highlightedObjectColor = highlightedObjectColor;
   }
 
@@ -231,7 +231,7 @@ function getUniforms(opts: PickingProps = {}, prevUniforms?: PickingUniforms): P
     if (!Number.isFinite(color[3])) {
       color[3] = 1;
     }
-    uniforms.highlightColor = color as NumArray4;
+    uniforms.highlightColor = color as NumberArray4;
   }
 
   if (opts.isActive !== undefined) {

--- a/modules/shadertools/src/modules/engine/project/project.ts
+++ b/modules/shadertools/src/modules/engine/project/project.ts
@@ -5,18 +5,18 @@
 import {Matrix4, Vector3} from '@math.gl/core';
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
 import {glsl} from '../../../lib/glsl-utils/highlight';
-import type {NumArray3, NumArray16} from '../../../lib/utils/uniform-types';
+import type {NumberArray3, NumberArray16} from '../../../lib/utils/uniform-types';
 
-const IDENTITY_MATRIX: Readonly<NumArray16> = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+const IDENTITY_MATRIX: Readonly<NumberArray16> = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 
 /**
  * @note Projection uniforms are normally constant across draw calls,
  * at least for each view.
  */
 export type ProjectionProps = {
-  viewMatrix?: Readonly<Matrix4 | NumArray16>;
-  projectionMatrix?: Readonly<Matrix4 | NumArray16>;
-  cameraPositionWorld?: Readonly<Vector3 | NumArray3>;
+  viewMatrix?: Readonly<Matrix4 | NumberArray16>;
+  projectionMatrix?: Readonly<Matrix4 | NumberArray16>;
+  cameraPositionWorld?: Readonly<Vector3 | NumberArray3>;
 };
 
 /**
@@ -24,10 +24,10 @@ export type ProjectionProps = {
  * at least for each view.
  */
 export type ProjectionUniforms = {
-  viewMatrix?: Readonly<Matrix4 | NumArray16>;
-  projectionMatrix?: Readonly<Matrix4 | NumArray16>;
-  viewProjectionMatrix?: Readonly<Matrix4 | NumArray16>;
-  cameraPositionWorld?: Readonly<Vector3 | NumArray3>;
+  viewMatrix?: Readonly<Matrix4 | NumberArray16>;
+  projectionMatrix?: Readonly<Matrix4 | NumberArray16>;
+  viewProjectionMatrix?: Readonly<Matrix4 | NumberArray16>;
+  cameraPositionWorld?: Readonly<Vector3 | NumberArray3>;
 };
 
 const DEFAULT_MODULE_OPTIONS: Required<ProjectionUniforms> = {

--- a/modules/shadertools/src/modules/engine/project/project.ts
+++ b/modules/shadertools/src/modules/engine/project/project.ts
@@ -5,7 +5,7 @@
 import {Matrix4, Vector3} from '@math.gl/core';
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
 import {glsl} from '../../../lib/glsl-utils/highlight';
-import {NumArray3, NumArray16} from '../../../lib/utils/uniform-types';
+import type {NumArray3, NumArray16} from '../../../lib/utils/uniform-types';
 
 const IDENTITY_MATRIX: Readonly<NumArray16> = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 

--- a/modules/shadertools/src/modules/engine/project/project.ts
+++ b/modules/shadertools/src/modules/engine/project/project.ts
@@ -2,20 +2,21 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {NumericArray as NumberArray, Matrix4, Vector3} from '@math.gl/core';
+import {Matrix4, Vector3} from '@math.gl/core';
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
 import {glsl} from '../../../lib/glsl-utils/highlight';
+import {NumArray3, NumArray16} from '../../../lib/utils/uniform-types';
 
-const IDENTITY_MATRIX: Readonly<NumberArray> = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+const IDENTITY_MATRIX: Readonly<NumArray16> = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
 
 /**
  * @note Projection uniforms are normally constant across draw calls,
  * at least for each view.
  */
 export type ProjectionProps = {
-  viewMatrix?: Readonly<Matrix4 | NumberArray>;
-  projectionMatrix?: Readonly<Matrix4 | NumberArray>;
-  cameraPositionWorld?: Readonly<Vector3 | NumberArray>;
+  viewMatrix?: Readonly<Matrix4 | NumArray16>;
+  projectionMatrix?: Readonly<Matrix4 | NumArray16>;
+  cameraPositionWorld?: Readonly<Vector3 | NumArray3>;
 };
 
 /**
@@ -23,10 +24,10 @@ export type ProjectionProps = {
  * at least for each view.
  */
 export type ProjectionUniforms = {
-  viewMatrix?: Readonly<Matrix4 | NumberArray>;
-  projectionMatrix?: Readonly<Matrix4 | NumberArray>;
-  viewProjectionMatrix?: Readonly<Matrix4 | NumberArray>;
-  cameraPositionWorld?: Readonly<Vector3 | NumberArray>;
+  viewMatrix?: Readonly<Matrix4 | NumArray16>;
+  projectionMatrix?: Readonly<Matrix4 | NumArray16>;
+  viewProjectionMatrix?: Readonly<Matrix4 | NumArray16>;
+  cameraPositionWorld?: Readonly<Vector3 | NumArray3>;
 };
 
 const DEFAULT_MODULE_OPTIONS: Required<ProjectionUniforms> = {

--- a/modules/shadertools/src/modules/lighting/lights/lighting-uniforms.ts
+++ b/modules/shadertools/src/modules/lighting/lights/lighting-uniforms.ts
@@ -67,7 +67,7 @@ export type LightingUniforms = {
 };
 
 /** UBO ready lighting module */
-export const lighting: ShaderModule<LightingProps, LightingUniforms> = {
+export const lighting: ShaderModule<LightingProps, LightingUniforms, {}> = {
   name: 'lighting',
   vs: lightingUniforms,
   fs: lightingUniforms,

--- a/modules/shadertools/src/modules/lighting/lights/lighting-uniforms.ts
+++ b/modules/shadertools/src/modules/lighting/lights/lighting-uniforms.ts
@@ -4,7 +4,7 @@
 
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
 import {lightingUniforms} from './lighting-uniforms-glsl';
-import type {NumArray3} from '../../../lib/utils/uniform-types';
+import type {NumberArray3} from '../../../lib/utils/uniform-types';
 
 /** Max number of supported lights (in addition to ambient light */
 const MAX_LIGHTS = 5;
@@ -24,23 +24,23 @@ export type Light = AmbientLight | PointLight | DirectionalLight;
 
 export type AmbientLight = {
   type: 'ambient';
-  color?: Readonly<NumArray3>;
+  color?: Readonly<NumberArray3>;
   intensity?: number;
 };
 
 export type PointLight = {
   type: 'point';
-  position: Readonly<NumArray3>;
-  color?: Readonly<NumArray3>;
+  position: Readonly<NumberArray3>;
+  color?: Readonly<NumberArray3>;
   intensity?: number;
   attenuation?: number;
 };
 
 export type DirectionalLight = {
   type: 'directional';
-  position: Readonly<NumArray3>;
-  direction: Readonly<NumArray3>;
-  color?: Readonly<NumArray3>;
+  position: Readonly<NumberArray3>;
+  direction: Readonly<NumberArray3>;
+  color?: Readonly<NumberArray3>;
   intensity?: number;
 };
 
@@ -57,13 +57,13 @@ export type LightingProps = {
 
 export type LightingUniforms = {
   enabled: number;
-  ambientLightColor: Readonly<NumArray3>;
+  ambientLightColor: Readonly<NumberArray3>;
   numberOfLights: number;
   lightType: number; // [];
-  lightColor: Readonly<NumArray3>; // [];
-  lightPosition: Readonly<NumArray3>; // [];
-  lightDirection: Readonly<NumArray3>; // [];
-  lightAttenuation: Readonly<NumArray3>; // [];
+  lightColor: Readonly<NumberArray3>; // [];
+  lightPosition: Readonly<NumberArray3>; // [];
+  lightDirection: Readonly<NumberArray3>; // [];
+  lightAttenuation: Readonly<NumberArray3>; // [];
 };
 
 /** UBO ready lighting module */
@@ -216,7 +216,9 @@ function extractLightTypes(lights: Light[]): LightingProps {
 }
 
 /** Take color 0-255 and intensity as input and output 0.0-1.0 range */
-function convertColor(colorDef: {color?: Readonly<NumArray3>; intensity?: number} = {}): NumArray3 {
+function convertColor(
+  colorDef: {color?: Readonly<NumberArray3>; intensity?: number} = {}
+): NumberArray3 {
   const {color = [0, 0, 0], intensity = 1.0} = colorDef;
-  return color.map(component => (component * intensity) / COLOR_FACTOR) as NumArray3;
+  return color.map(component => (component * intensity) / COLOR_FACTOR) as NumberArray3;
 }

--- a/modules/shadertools/src/modules/lighting/lights/lighting-uniforms.ts
+++ b/modules/shadertools/src/modules/lighting/lights/lighting-uniforms.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {NumberArray} from '@math.gl/types';
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
 import {lightingUniforms} from './lighting-uniforms-glsl';
+import type {NumArray3} from '../../../lib/utils/uniform-types';
 
 /** Max number of supported lights (in addition to ambient light */
 const MAX_LIGHTS = 5;
@@ -24,23 +24,23 @@ export type Light = AmbientLight | PointLight | DirectionalLight;
 
 export type AmbientLight = {
   type: 'ambient';
-  color?: Readonly<NumberArray>;
+  color?: Readonly<NumArray3>;
   intensity?: number;
 };
 
 export type PointLight = {
   type: 'point';
-  position: Readonly<NumberArray>;
-  color?: Readonly<NumberArray>;
+  position: Readonly<NumArray3>;
+  color?: Readonly<NumArray3>;
   intensity?: number;
   attenuation?: number;
 };
 
 export type DirectionalLight = {
   type: 'directional';
-  position: Readonly<NumberArray>;
-  direction: Readonly<NumberArray>;
-  color?: Readonly<NumberArray>;
+  position: Readonly<NumArray3>;
+  direction: Readonly<NumArray3>;
+  color?: Readonly<NumArray3>;
   intensity?: number;
 };
 
@@ -57,13 +57,13 @@ export type LightingProps = {
 
 export type LightingUniforms = {
   enabled: number;
-  ambientLightColor: Readonly<NumberArray>;
+  ambientLightColor: Readonly<NumArray3>;
   numberOfLights: number;
   lightType: number; // [];
-  lightColor: Readonly<NumberArray>; // [];
-  lightPosition: Readonly<NumberArray>; // [];
-  lightDirection: Readonly<NumberArray>; // [];
-  lightAttenuation: Readonly<NumberArray>; // [];
+  lightColor: Readonly<NumArray3>; // [];
+  lightPosition: Readonly<NumArray3>; // [];
+  lightDirection: Readonly<NumArray3>; // [];
+  lightAttenuation: Readonly<NumArray3>; // [];
 };
 
 /** UBO ready lighting module */
@@ -216,9 +216,7 @@ function extractLightTypes(lights: Light[]): LightingProps {
 }
 
 /** Take color 0-255 and intensity as input and output 0.0-1.0 range */
-function convertColor(
-  colorDef: {color?: Readonly<NumberArray>; intensity?: number} = {}
-): NumberArray {
+function convertColor(colorDef: {color?: Readonly<NumArray3>; intensity?: number} = {}): NumArray3 {
   const {color = [0, 0, 0], intensity = 1.0} = colorDef;
-  return color.map(component => (component * intensity) / COLOR_FACTOR);
+  return color.map(component => (component * intensity) / COLOR_FACTOR) as NumArray3;
 }

--- a/modules/shadertools/src/modules/lighting/no-material/dirlight.ts
+++ b/modules/shadertools/src/modules/lighting/no-material/dirlight.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {NumberArray} from '@math.gl/types';
+import type {Vector3} from '@math.gl/core';
 import {glsl} from '../../../lib/glsl-utils/highlight';
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
 
 export type DirlightProps = {
-  lightDirection?: NumberArray | [number, number, number];
+  lightDirection?: Vector3 | [number, number, number];
 };
 
 export type DirlightUniforms = DirlightProps;
@@ -72,7 +72,7 @@ export const dirlight: ShaderModule<DirlightProps, DirlightUniforms> = {
     lightDirection: 'vec3<f32>'
   },
   defaultUniforms: {
-    lightDirection: new Float32Array([1, 1, 2])
+    lightDirection: [1, 1, 2]
   },
   getUniforms
 };

--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-material.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-material.ts
@@ -4,8 +4,9 @@
 
 /* eslint-disable camelcase */
 
-import type {NumberArray, Texture} from '@luma.gl/core';
+import type {Texture} from '@luma.gl/core';
 import type {Vector2, Vector3, Vector4} from '@math.gl/core';
+import type {NumArray2, NumArray3, NumArray4} from '../../../lib/utils/uniform-types';
 
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
 import {lighting} from '../lights/lighting-uniforms';
@@ -18,15 +19,15 @@ export type PBRMaterialProps = PBRMaterialBindings & {
 
   // Base color map
   baseColorMapEnabled: boolean;
-  baseColorFactor: Readonly<Vector4 | NumberArray>;
+  baseColorFactor: Readonly<Vector4 | NumArray4>;
 
   normalMapEnabled: boolean;
   normalScale: number; // #ifdef HAS_NORMALMAP
 
   emissiveMapEnabled: boolean;
-  emissiveFactor: Readonly<Vector3 | NumberArray>; // #ifdef HAS_EMISSIVEMAP
+  emissiveFactor: Readonly<Vector3 | NumArray3>; // #ifdef HAS_EMISSIVEMAP
 
-  metallicRoughnessValues: Readonly<Vector2 | NumberArray>;
+  metallicRoughnessValues: Readonly<Vector2 | NumArray2>;
   metallicRoughnessMapEnabled: boolean;
 
   occlusionMapEnabled: boolean;
@@ -37,12 +38,12 @@ export type PBRMaterialProps = PBRMaterialBindings & {
 
   // IBL
   IBLenabled: boolean;
-  scaleIBLAmbient: Readonly<Vector2 | NumberArray>; // #ifdef USE_IBL
+  scaleIBLAmbient: Readonly<Vector2 | NumArray2>; // #ifdef USE_IBL
 
   // debugging flags used for shader output of intermediate PBR variables
   // #ifdef PBR_DEBUG
-  scaleDiffBaseMR: Readonly<Vector4 | NumberArray>;
-  scaleFGDSpec: Readonly<Vector4 | NumberArray>;
+  scaleDiffBaseMR: Readonly<Vector4 | NumArray4>;
+  scaleFGDSpec: Readonly<Vector4 | NumArray4>;
 };
 
 /** Non-uniform block bindings for pbr module */
@@ -65,15 +66,15 @@ export type PBRMaterialUniforms = {
 
   // Base color map
   baseColorMapEnabled: boolean;
-  baseColorFactor: Readonly<Vector4 | NumberArray>;
+  baseColorFactor: Readonly<Vector4 | NumArray4>;
 
   normalMapEnabled: boolean;
   normalScale: number; // #ifdef HAS_NORMALMAP
 
   emissiveMapEnabled: boolean;
-  emissiveFactor: Readonly<Vector3 | NumberArray>; // #ifdef HAS_EMISSIVEMAP
+  emissiveFactor: Readonly<Vector3 | NumArray3>; // #ifdef HAS_EMISSIVEMAP
 
-  metallicRoughnessValues: Readonly<Vector2 | NumberArray>;
+  metallicRoughnessValues: Readonly<Vector2 | NumArray2>;
   metallicRoughnessMapEnabled: boolean;
 
   occlusionMapEnabled: boolean;
@@ -84,12 +85,12 @@ export type PBRMaterialUniforms = {
 
   // IBL
   IBLenabled: boolean;
-  scaleIBLAmbient: Readonly<Vector2 | NumberArray>; // #ifdef USE_IBL
+  scaleIBLAmbient: Readonly<Vector2 | NumArray2>; // #ifdef USE_IBL
 
   // debugging flags used for shader output of intermediate PBR variables
   // #ifdef PBR_DEBUG
-  scaleDiffBaseMR: Readonly<Vector4 | NumberArray>;
-  scaleFGDSpec: Readonly<Vector4 | NumberArray>;
+  scaleDiffBaseMR: Readonly<Vector4 | NumArray4>;
+  scaleFGDSpec: Readonly<Vector4 | NumArray4>;
 };
 
 /**

--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-material.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-material.ts
@@ -6,7 +6,7 @@
 
 import type {Texture} from '@luma.gl/core';
 import type {Vector2, Vector3, Vector4} from '@math.gl/core';
-import type {NumArray2, NumArray3, NumArray4} from '../../../lib/utils/uniform-types';
+import type {NumberArray2, NumberArray3, NumberArray4} from '../../../lib/utils/uniform-types';
 
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
 import {lighting} from '../lights/lighting-uniforms';
@@ -19,15 +19,15 @@ export type PBRMaterialProps = PBRMaterialBindings & {
 
   // Base color map
   baseColorMapEnabled: boolean;
-  baseColorFactor: Readonly<Vector4 | NumArray4>;
+  baseColorFactor: Readonly<Vector4 | NumberArray4>;
 
   normalMapEnabled: boolean;
   normalScale: number; // #ifdef HAS_NORMALMAP
 
   emissiveMapEnabled: boolean;
-  emissiveFactor: Readonly<Vector3 | NumArray3>; // #ifdef HAS_EMISSIVEMAP
+  emissiveFactor: Readonly<Vector3 | NumberArray3>; // #ifdef HAS_EMISSIVEMAP
 
-  metallicRoughnessValues: Readonly<Vector2 | NumArray2>;
+  metallicRoughnessValues: Readonly<Vector2 | NumberArray2>;
   metallicRoughnessMapEnabled: boolean;
 
   occlusionMapEnabled: boolean;
@@ -38,12 +38,12 @@ export type PBRMaterialProps = PBRMaterialBindings & {
 
   // IBL
   IBLenabled: boolean;
-  scaleIBLAmbient: Readonly<Vector2 | NumArray2>; // #ifdef USE_IBL
+  scaleIBLAmbient: Readonly<Vector2 | NumberArray2>; // #ifdef USE_IBL
 
   // debugging flags used for shader output of intermediate PBR variables
   // #ifdef PBR_DEBUG
-  scaleDiffBaseMR: Readonly<Vector4 | NumArray4>;
-  scaleFGDSpec: Readonly<Vector4 | NumArray4>;
+  scaleDiffBaseMR: Readonly<Vector4 | NumberArray4>;
+  scaleFGDSpec: Readonly<Vector4 | NumberArray4>;
 };
 
 /** Non-uniform block bindings for pbr module */
@@ -66,15 +66,15 @@ export type PBRMaterialUniforms = {
 
   // Base color map
   baseColorMapEnabled: boolean;
-  baseColorFactor: Readonly<Vector4 | NumArray4>;
+  baseColorFactor: Readonly<Vector4 | NumberArray4>;
 
   normalMapEnabled: boolean;
   normalScale: number; // #ifdef HAS_NORMALMAP
 
   emissiveMapEnabled: boolean;
-  emissiveFactor: Readonly<Vector3 | NumArray3>; // #ifdef HAS_EMISSIVEMAP
+  emissiveFactor: Readonly<Vector3 | NumberArray3>; // #ifdef HAS_EMISSIVEMAP
 
-  metallicRoughnessValues: Readonly<Vector2 | NumArray2>;
+  metallicRoughnessValues: Readonly<Vector2 | NumberArray2>;
   metallicRoughnessMapEnabled: boolean;
 
   occlusionMapEnabled: boolean;
@@ -85,12 +85,12 @@ export type PBRMaterialUniforms = {
 
   // IBL
   IBLenabled: boolean;
-  scaleIBLAmbient: Readonly<Vector2 | NumArray2>; // #ifdef USE_IBL
+  scaleIBLAmbient: Readonly<Vector2 | NumberArray2>; // #ifdef USE_IBL
 
   // debugging flags used for shader output of intermediate PBR variables
   // #ifdef PBR_DEBUG
-  scaleDiffBaseMR: Readonly<Vector4 | NumArray4>;
-  scaleFGDSpec: Readonly<Vector4 | NumArray4>;
+  scaleDiffBaseMR: Readonly<Vector4 | NumberArray4>;
+  scaleFGDSpec: Readonly<Vector4 | NumberArray4>;
 };
 
 /**

--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-material.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-material.ts
@@ -144,16 +144,5 @@ export const pbrMaterial: ShaderModule<PBRMaterialProps, PBRMaterialUniforms> = 
     scaleDiffBaseMR: 'vec4<f32>',
     scaleFGDSpec: 'vec4<f32>'
   },
-  bindings: {
-    baseColorSampler: {type: 'texture', location: 8}, // #ifdef HAS_BASECOLORMAP
-    normalSampler: {type: 'texture', location: 9}, // #ifdef HAS_NORMALMAP
-    emissiveSampler: {type: 'texture', location: 10}, // #ifdef HAS_EMISSIVEMAP
-    metallicRoughnessSampler: {type: 'texture', location: 11}, // #ifdef HAS_METALROUGHNESSMAP
-    occlusionSampler: {type: 'texture', location: 12}, // #ifdef HAS_OCCLUSIONMAP
-    // IBL Samplers
-    diffuseEnvSampler: {type: 'texture', location: 13}, // #ifdef USE_IBL (samplerCube)
-    specularEnvSampler: {type: 'texture', location: 14}, // #ifdef USE_IBL (samplerCube)
-    brdfLUT: {type: 'texture', location: 15} // #ifdef USE_IBL
-  },
   dependencies: [lighting]
 };

--- a/modules/shadertools/src/modules/postprocessing/image-blur-filters/tiltshift.ts
+++ b/modules/shadertools/src/modules/postprocessing/image-blur-filters/tiltshift.ts
@@ -58,9 +58,9 @@ vec4 tiltShift_sampleColor(sampler2D source, vec2 texSize, vec2 texCoord) {
  */
 export type TiltShiftProps = {
   /** The x,y coordinate of the start of the line segment. */
-  start?: number[];
+  start?: [number, number];
   /** The xm y coordinate of the end of the line segment. */
-  end?: number[];
+  end?: [number, number];
   /** The maximum radius of the pyramid blur. */
   blurRadius?: number;
   /** The distance from the line at which the maximum blur radius is reached. */

--- a/modules/shadertools/src/modules/postprocessing/image-blur-filters/triangleblur.ts
+++ b/modules/shadertools/src/modules/postprocessing/image-blur-filters/triangleblur.ts
@@ -52,7 +52,7 @@ export type TriangleBlurProps = {
   /** The radius of the pyramid convolved with the image. */
   radius?: number;
   /** @deprecated internal property */
-  delta?: number[];
+  delta?: [number, number];
 };
 
 /**

--- a/modules/shadertools/src/modules/postprocessing/image-blur-filters/zoomblur.ts
+++ b/modules/shadertools/src/modules/postprocessing/image-blur-filters/zoomblur.ts
@@ -45,7 +45,7 @@ vec4 zoomBlur_sampleColor(sampler2D source, vec2 texSize, vec2 texCoord) {
  */
 export type ZoomBlurProps = {
   /** - The x, y coordinate of the blur origin. */
-  center?: number[];
+  center?: [number, number];
   /** - The strength of the blur. Values in the range 0 to 1 are usually sufficient, where 0 doesn't change the image and 1 creates a highly blurred image. */
   strength?: number;
 };

--- a/modules/shadertools/src/modules/postprocessing/image-fun-filters/colorhalftone.ts
+++ b/modules/shadertools/src/modules/postprocessing/image-fun-filters/colorhalftone.ts
@@ -51,7 +51,7 @@ vec4 colorHalftone_filterColor(vec4 color, vec2 texSize, vec2 texCoord) {
  */
 export type ColorHalftoneProps = {
   /** The x,y coordinate of the pattern origin. */
-  center?: number[];
+  center?: [number, number];
   /** The rotation of the pattern in radians. */
   angle?: number;
   /** The diameter of a dot in pixels. */

--- a/modules/shadertools/src/modules/postprocessing/image-fun-filters/dotscreen.ts
+++ b/modules/shadertools/src/modules/postprocessing/image-fun-filters/dotscreen.ts
@@ -37,7 +37,7 @@ vec4 dotScreen_filterColor(vec4 color, vec2 texSize, vec2 texCoord) {
  */
 export type DotScreenProps = {
   /** The x, y coordinate of the pattern origin. */
-  center?: number[];
+  center?: [number, number];
   /** The rotation of the pattern in radians. */
   angle?: number;
   /** The diameter of a dot in pixels. */

--- a/modules/shadertools/src/modules/postprocessing/image-fun-filters/hexagonalpixelate.ts
+++ b/modules/shadertools/src/modules/postprocessing/image-fun-filters/hexagonalpixelate.ts
@@ -57,7 +57,7 @@ vec4 hexagonalPixelate_sampleColor(sampler2D source, vec2 texSize, vec2 texCoord
  */
 export type HexagonalPixelateProps = {
   /** The [x, y] coordinates of the pattern center. */
-  center?: number[];
+  center?: [number, number];
   /** The width of an individual tile, in pixels. */
   scale?: number;
 };

--- a/modules/shadertools/src/modules/postprocessing/image-fun-filters/magnify.ts
+++ b/modules/shadertools/src/modules/postprocessing/image-fun-filters/magnify.ts
@@ -33,7 +33,7 @@ vec4 magnify_sampleColor(sampler2D source, vec2 texSize, vec2 texCoord) {
  */
 export type MagnifyProps = {
   /** x, y position in screen coords, both x and y is normalized and in range `[0, 1]`. `[0, 0]` is the up left corner, `[1, 1]` is the bottom right corner. Default value is `[0, 0]`. */
-  screenXY?: number[];
+  screenXY?: [number, number];
   /** effect radius in pixels. Default value is `100`. */
   radiusPixels?: number;
   /** magnify level. Default value is `2`. */
@@ -41,7 +41,7 @@ export type MagnifyProps = {
   /** border width of the effect circle, will not show border if value <= 0.0. Default value is `0`. */
   borderWidthPixels?: number;
   /** border color of the effect circle. Default value is `[255, 255, 255, 255]`. */
-  borderColor?: number[];
+  borderColor?: [number, number, number, number];
 };
 
 /**

--- a/modules/shadertools/src/modules/postprocessing/image-warp-filters/bulgepinch.ts
+++ b/modules/shadertools/src/modules/postprocessing/image-warp-filters/bulgepinch.ts
@@ -39,7 +39,7 @@ vec4 bulgePinch_sampleColor(sampler2D source, vec2 texSize, vec2 texCoord) {
 /** Bulges or pinches the image in a circle. */
 export type BulgePinchProps = {
   /** The [x, y] coordinates of the center of the circle of effect. */
-  center?: number[];
+  center?: [number, number];
   /** The radius of the circle of effect. */
   radius?: number;
   /** strength -1 to 1 (-1 is strong pinch, 0 is no effect, 1 is strong bulge) */

--- a/modules/shadertools/test/modules-webgl1/lights/lights.spec.ts
+++ b/modules/shadertools/test/modules-webgl1/lights/lights.spec.ts
@@ -2,8 +2,12 @@ import test from 'tape-promise/tape';
 import {checkType} from '@luma.gl/test-utils';
 
 import {lighting, ShaderModule} from '@luma.gl/shadertools';
+import type {
+  LightingProps,
+  LightingUniforms
+} from '@luma.gl/shadertools/src/modules/lighting/lights/lighting-uniforms';
 
-checkType<ShaderModule>(lighting);
+checkType<ShaderModule<LightingProps, LightingUniforms>>(lighting);
 
 test('shadertools#lighting', t => {
   let uniforms = lighting.getUniforms({});

--- a/modules/shadertools/test/modules-webgl1/lights/lights.spec.ts
+++ b/modules/shadertools/test/modules-webgl1/lights/lights.spec.ts
@@ -7,7 +7,7 @@ import type {
   LightingUniforms
 } from '@luma.gl/shadertools/src/modules/lighting/lights/lighting-uniforms';
 
-checkType<ShaderModule<LightingProps, LightingUniforms>>(lighting);
+checkType<ShaderModule<LightingProps, LightingUniforms, {}>>(lighting);
 
 test('shadertools#lighting', t => {
   let uniforms = lighting.getUniforms({});

--- a/modules/shadertools/test/modules/engine/picking.spec.ts
+++ b/modules/shadertools/test/modules/engine/picking.spec.ts
@@ -58,10 +58,10 @@ const TEST_CASES = [
 ];
 
 test('picking#getUniforms', t => {
-  t.deepEqual(picking.getUniforms!({}), {}, 'Empty input');
+  t.deepEqual(picking.getUniforms({}), {}, 'Empty input');
 
   t.deepEqual(
-    picking.getUniforms!({
+    picking.getUniforms({
       isActive: true,
       highlightedObjectColor: undefined,
       highlightColor: [255, 0, 0]
@@ -75,7 +75,7 @@ test('picking#getUniforms', t => {
   );
 
   t.deepEqual(
-    picking.getUniforms!({
+    picking.getUniforms({
       isActive: true,
       highlightedObjectColor: null,
       highlightColor: [255, 0, 0]
@@ -90,7 +90,7 @@ test('picking#getUniforms', t => {
   );
 
   t.deepEqual(
-    picking.getUniforms!({
+    picking.getUniforms({
       highlightedObjectColor: [0, 0, 1],
       highlightColor: [102, 0, 0, 51]
     }),
@@ -103,7 +103,7 @@ test('picking#getUniforms', t => {
   );
 
   t.deepEqual(
-    picking.getUniforms!({
+    picking.getUniforms({
       highlightedObjectColor: [0, 0, 1],
       highlightColor: [102, 0, 0, 51],
       useFloatColors: false
@@ -159,7 +159,7 @@ test.skip('picking#isVertexPicked(highlightedObjectColor invalid)', async t => {
 
   await Promise.all(
     TEST_CASES.map(async testCase => {
-      const uniforms = picking.getUniforms!({
+      const uniforms = picking.getUniforms({
         highlightedObjectColor: testCase.highlightedObjectColor
       });
 
@@ -214,7 +214,7 @@ test.skip('picking#picking_setPickingColor', async t => {
 
   await Promise.all(
     TEST_CASES.map(async testCase => {
-      const uniforms = picking.getUniforms!({
+      const uniforms = picking.getUniforms({
         highlightedObjectColor: testCase.highlightedObjectColor,
         // @ts-expect-error
         pickingThreshold: testCase.pickingThreshold

--- a/modules/shadertools/test/modules/engine/picking.spec.ts
+++ b/modules/shadertools/test/modules/engine/picking.spec.ts
@@ -163,6 +163,7 @@ test.skip('picking#isVertexPicked(highlightedObjectColor invalid)', async t => {
         highlightedObjectColor: testCase.highlightedObjectColor
       });
 
+      // @ts-ignore
       transform.model.setUniforms(uniforms);
       transform.run();
 
@@ -219,6 +220,7 @@ test.skip('picking#picking_setPickingColor', async t => {
         pickingThreshold: testCase.pickingThreshold
       });
 
+      // @ts-ignore
       transform.model.setUniforms(uniforms);
       transform.run();
 

--- a/modules/shadertools/test/modules/engine/picking.spec.ts
+++ b/modules/shadertools/test/modules/engine/picking.spec.ts
@@ -48,20 +48,20 @@ const TEST_CASES = [
     isPicked: [0, 0, 0, 0, 0, 0, 0, 0, 0]
   },
   {
-    highlightedObjectColor: [255, 255, 255],
+    highlightedObjectColor: [255, 255, 255] as [number, number, number],
     isPicked: [0, 0, 0, 0, 0, 0, 0, 1, 0]
   },
   {
-    highlightedObjectColor: [255, 100, 150],
+    highlightedObjectColor: [255, 100, 150] as [number, number, number],
     isPicked: [0, 1, 0, 0, 0, 0, 0, 0, 0]
   }
 ];
 
 test('picking#getUniforms', t => {
-  t.deepEqual(picking.getUniforms({}), {}, 'Empty input');
+  t.deepEqual(picking.getUniforms!({}), {}, 'Empty input');
 
   t.deepEqual(
-    picking.getUniforms({
+    picking.getUniforms!({
       isActive: true,
       highlightedObjectColor: undefined,
       highlightColor: [255, 0, 0]
@@ -75,7 +75,7 @@ test('picking#getUniforms', t => {
   );
 
   t.deepEqual(
-    picking.getUniforms({
+    picking.getUniforms!({
       isActive: true,
       highlightedObjectColor: null,
       highlightColor: [255, 0, 0]
@@ -90,7 +90,7 @@ test('picking#getUniforms', t => {
   );
 
   t.deepEqual(
-    picking.getUniforms({
+    picking.getUniforms!({
       highlightedObjectColor: [0, 0, 1],
       highlightColor: [102, 0, 0, 51]
     }),
@@ -103,7 +103,7 @@ test('picking#getUniforms', t => {
   );
 
   t.deepEqual(
-    picking.getUniforms({
+    picking.getUniforms!({
       highlightedObjectColor: [0, 0, 1],
       highlightColor: [102, 0, 0, 51],
       useFloatColors: false
@@ -159,7 +159,7 @@ test.skip('picking#isVertexPicked(highlightedObjectColor invalid)', async t => {
 
   await Promise.all(
     TEST_CASES.map(async testCase => {
-      const uniforms = picking.getUniforms({
+      const uniforms = picking.getUniforms!({
         highlightedObjectColor: testCase.highlightedObjectColor
       });
 
@@ -214,7 +214,7 @@ test.skip('picking#picking_setPickingColor', async t => {
 
   await Promise.all(
     TEST_CASES.map(async testCase => {
-      const uniforms = picking.getUniforms({
+      const uniforms = picking.getUniforms!({
         highlightedObjectColor: testCase.highlightedObjectColor,
         // @ts-expect-error
         pickingThreshold: testCase.pickingThreshold

--- a/modules/shadertools/test/modules/lighting/gouraud-material.spec.ts
+++ b/modules/shadertools/test/modules/lighting/gouraud-material.spec.ts
@@ -8,7 +8,7 @@ import {gouraudMaterial} from '@luma.gl/shadertools';
 
 test('shadertools#gouraudMaterial', t => {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-  let uniforms: Record<string, UniformValue> = gouraudMaterial.getUniforms?.({})!;
+  let uniforms: Record<string, UniformValue | any> = gouraudMaterial.getUniforms?.({})!;
   t.deepEqual(uniforms, gouraudMaterial.defaultUniforms, 'Default phong lighting uniforms ok');
 
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Implements changes described https://github.com/visgl/deck.gl/pull/9044

<!-- For all the PRs -->
#### Change List
- Improve `ShaderModule` type to deduce `UniformsT` & `BindingsT` from `PropsT`
- Remove `ShaderModuleInputs` (it is so close to `ShaderModule` I'm not sure I see the value in keeping it)
- Add `UniformTypes` helper from deck
- Fix types & tests
