### PR TITLE
feat: Add Texture.copyExternalImage() function

### DIFF
--- a/docs/api-reference/core/resources/texture.md
+++ b/docs/api-reference/core/resources/texture.md
@@ -13,6 +13,21 @@ Creating a texture
 const texture = device.createTexture({sampler: {addressModeU: 'clamp-to-edge'});
 ```
 
+Setting texture data from an image
+
+```ts
+const imageBitmap = // load an image from a URL, perhaps with loaders.gl ImageLoader
+texture.copyFromExternalImage({source: imageBitmap});
+```
+
+Note that setting texture data from 8 bit RGBA arrays can also be done via `texture.copyFromExternalImage()` via `ImageData`.
+
+```ts
+const data = new ClampedUint8Array([...]);
+const imageData = new ImageData(data, width, height); 
+texture.copyFromExternalImage({source: imageData});
+```
+
 Setting texture data for non-8-bit-per-channel bit depths, texture arrays etc.
 
 :::caution
@@ -107,11 +122,11 @@ These are referred to as external (to the GPU) images.
 
 luma.gl allows textures to be created from a number of different data sources.
 
-| Type                           | Description                                                                                           |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------- |
-| `null`                         | A texture will be created with the appropriate format, size and width. Bytes will be "uninitialized". |
-| `typed array`                  | Bytes will be interpreted according to format/type parameters and pixel store parameters.             |
-| `Buffer`                       | Bytes will be interpreted according to format/type parameters and pixel store parameters.             |
+| Type          | Description                                                                                           |
+| ------------- | ----------------------------------------------------------------------------------------------------- |
+| `null`        | A texture will be created with the appropriate format, size and width. Bytes will be "uninitialized". |
+| `typed array` | Bytes will be interpreted according to format/type parameters and pixel store parameters.             |
+| `Buffer`      | Bytes will be interpreted according to format/type parameters and pixel store parameters.             |
 
 ## CubeFace
 
@@ -192,3 +207,43 @@ Free up any GPU resources associated with this texture immediately (instead of w
 Call to regenerate mipmaps after modifying texture(s)
 
 WebGL References [gl.generateMipmap](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/generateMipmap)
+
+### `copyExternalImage()`
+
+Copy data from an image data into the texture. 
+
+This function offers a highly granular control but can be called with just an `image` parameter and the remaining arguments will be deduced or set to canonical defaults.
+
+```ts
+copyExternalImage(options: {
+  image: ExternalImage;
+  sourceX?: number;
+  sourceY?: number;
+  width?: number;
+  height?: number;
+  depth?: number;
+  mipLevel?: number;
+  x?: number;
+  y?: number;
+  z?: number;
+  aspect?: 'all' | 'stencil-only' | 'depth-only';
+  colorSpace?: 'srgb';
+  premultipliedAlpha?: boolean;
+}: {width: number; height: number}
+```
+
+| Parameter             | Type                                       |                                                          |
+| --------------------- | ------------------------------------------ | -------------------------------------------------------- |
+| `image`               | `ExternalImage`                            | Image                                                    |
+| `sourceX?`            | `number`                                   | Copy from image x offset (default 0)                     |
+| `sourceY?`            | `number`                                   | Copy from image y offset (default 0)                     |
+| `width?`              | `number`                                   | Copy area width (default 1)                              |
+| `height?`             | `number`                                   | Copy area height (default 1)                             |
+| `depth?`              | `number`                                   | Copy depth (default 1)                                   |
+| `mipLevel?`           | `number`                                   | Which mip-level to copy into (default 0)                 |
+| `x?`                  | `number`                                   | Start copying into offset x (default 0)                  |
+| `y?`                  | `number`                                   | Start copying into offset y (default 0)                  |
+| `z?`                  | `number`                                   | Start copying from depth layer z (default 0)             |
+| `aspect?`             | `'all' \| 'stencil-only' \| 'depth-only'`; | When copying into depth stencil textures (default 'all') |
+| `colorSpace?`         | `'srgb'`                                   | Specific color space of image data                       |
+| `premultipliedAlpha?` | `boolean`                                  | premultiplied                                            |

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -14,11 +14,20 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 
 v9.1 continues to build out WebGPU support. Some additional deprecations and breaking changes have been necessary, but impact on most applications should be minimal.
 
-**Spotlight: AsyncTextures**
+**Notable change: Adapters**
 
-- To stream line code across WebGL and WebGPU,`Textures` no longer accept promises (for e.g. `loadImage(url)` when setting data. 
-- However, a new `AsyncTexture` class is now available that does accept promises and creates actual `Textures` once the promise resolves and data is available.
-- In addition, the `Model` class accepts `AsyncTextures` as bindings and defers rendering until the underlying texture has been created.
+When initializing luma.gl, applications now import an `Adapter` singleton from either the WebGPU or the WebGL module, and pass that to `luma.createDevice()`.
+
+**Notable change: Textures**
+
+- The texture API is being streamlined to work symmetrically across WebGPU and WebGL.
+- `Texture.copyExternalImage()` replaces `Texture.setImageData()` when initializing textures with image data.
+
+**Notable change: AsyncTextures**
+
+- `Textures` no longer accept promises when setting data (e.g. from `loadImageBitmap(url)`. 
+- Instead, a new `AsyncTexture` class does accept promises and creates actual `Textures` once the promise resolves and data is available.
+- The `Model` class now accepts `AsyncTextures` as bindings and defers rendering until the underlying texture has been created.
 
 **@luma.gl/core**
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -19,6 +19,7 @@ Improvements focused on enhancing WebGPU support.
 - New [`Adapter`](/docs/api-reference/core/adapter) class for singleton objects representing pluggable GPU backends. 
 - New [`luma.registerAdapters()`](/docs/api-reference/core/luma#lumaregisteradapters) method - Register adapters for WebGL and WebGPU.
 - New `Parameters.blend` - Provides explicit control over color blending activation.
+- New `Texture.copyExternalImage()` function that works on both WebGPU and WebGL.
 
 **@luma.gl/engine**
 

--- a/modules/core/src/adapter/resources/texture.ts
+++ b/modules/core/src/adapter/resources/texture.ts
@@ -264,7 +264,7 @@ export abstract class Texture extends Resource<TextureProps> {
     }
     // Recurse into arrays (array of miplevels)
     if (Array.isArray(data)) {
-      return this.getTextureDataSize(data[0]);
+      return Texture.getTextureDataSize(data[0]);
     }
     if (Texture.isExternalImage(data)) {
       return Texture.getExternalImageSize(data);
@@ -310,7 +310,7 @@ export abstract class Texture extends Resource<TextureProps> {
     // Calculate size, if not provided
     if (this.props.width === undefined || this.props.height === undefined) {
       // @ts-ignore
-      const size = this.getTextureDataSize(this.props.data);
+      const size = Texture.getTextureDataSize(this.props.data);
       this.width = size?.width || 1;
       this.height = size?.height || 1;
     }

--- a/modules/core/src/adapter/resources/texture.ts
+++ b/modules/core/src/adapter/resources/texture.ts
@@ -83,7 +83,7 @@ export type TextureArrayData = TextureData[];
 /** Array of 6 face textures */
 export type TextureCubeArrayData = Record<TextureCubeFace, TextureData>[];
 
-type TextureDataProps =
+export type TextureDataProps =
   | Texture1DProps
   | Texture2DProps
   | Texture3DProps
@@ -91,12 +91,12 @@ type TextureDataProps =
   | TextureCubeProps
   | TextureCubeArrayProps;
 
-type Texture1DProps = {dimension: '1d'; data?: Texture1DData | null};
-type Texture2DProps = {dimension?: '2d'; data?: Texture2DData | null};
-type Texture3DProps = {dimension: '3d'; data?: Texture3DData | null};
-type TextureArrayProps = {dimension: '2d-array'; data?: TextureArrayData | null};
-type TextureCubeProps = {dimension: 'cube'; data?: TextureCubeData | null};
-type TextureCubeArrayProps = {dimension: 'cube-array'; data: TextureCubeArrayData | null};
+export type Texture1DProps = {dimension: '1d'; data?: Texture1DData | null};
+export type Texture2DProps = {dimension?: '2d'; data?: Texture2DData | null};
+export type Texture3DProps = {dimension: '3d'; data?: Texture3DData | null};
+export type TextureArrayProps = {dimension: '2d-array'; data?: TextureArrayData | null};
+export type TextureCubeProps = {dimension: 'cube'; data?: TextureCubeData | null};
+export type TextureCubeArrayProps = {dimension: 'cube-array'; data: TextureCubeArrayData | null};
 
 /** Texture properties */
 export type TextureProps = ResourceProps &
@@ -123,6 +123,36 @@ export type TextureProps = ResourceProps &
     /** @deprecated - this is implicit from format */
     compressed?: boolean;
   };
+
+/** Options for Texture.copyExternalImage */
+export type CopyExternalImageOptions = {
+  /** Image */
+  image: ExternalImage;
+  /** Copy from image x offset (default 0) */
+  sourceX?: number;
+  /** Copy from image y offset (default 0) */
+  sourceY?: number;
+  /** Copy area width (default 1) */
+  width?: number;
+  /** Copy area height (default 1) */
+  height?: number;
+  /** Copy depth (default 1) */
+  depth?: number;
+  /** Which mip-level to copy into (default 0) */
+  mipLevel?: number;
+  /** Start copying into offset x (default 0) */
+  x?: number;
+  /** Start copying into offset y (default 0) */
+  y?: number;
+  /** Start copying from depth layer z (default 0) */
+  z?: number;
+  /** When copying into depth stencil textures (default 'all') */
+  aspect?: 'all' | 'stencil-only' | 'depth-only';
+  /** Specific color space of image data */
+  colorSpace?: 'srgb';
+  /** premultiplied  */
+  premultipliedAlpha?: boolean;
+};
 
 /**
  * Abstract Texture interface
@@ -217,13 +247,13 @@ export abstract class Texture extends Resource<TextureProps> {
   }
 
   /** Check if texture data is a typed array */
-  isTextureLevelData(data: TextureData): data is TextureLevelData {
+  static isTextureLevelData(data: TextureData): data is TextureLevelData {
     const typedArray = (data as TextureLevelData)?.data;
     return ArrayBuffer.isView(typedArray);
   }
 
   /** Get the size of the texture described by the provided TextureData */
-  getTextureDataSize(
+  static getTextureDataSize(
     data: TextureData | TextureCubeData | TextureArrayData | TextureCubeArrayData | TypedArray
   ): {width: number; height: number} | null {
     if (!data) {
@@ -248,12 +278,12 @@ export abstract class Texture extends Resource<TextureProps> {
   }
 
   /** Calculate the number of mip levels for a texture of width and height */
-  getMipLevelCount(width: number, height: number): number {
+  static getMipLevelCount(width: number, height: number): number {
     return Math.floor(Math.log2(Math.max(width, height))) + 1;
   }
 
   /** Convert luma.gl cubemap face constants to depth index */
-  getCubeFaceDepth(face: TextureCubeFace): number {
+  static getCubeFaceDepth(face: TextureCubeFace): number {
     // prettier-ignore
     switch (face) {
         case '+X': return  0;
@@ -296,7 +326,7 @@ export abstract class Texture extends Resource<TextureProps> {
     // TODO - Should we clamp to 1-getMipLevelCount?
     this.mipLevels =
       this.props.mipLevels === 'pyramid'
-        ? this.getMipLevelCount(this.width, this.height)
+        ? Texture.getMipLevelCount(this.width, this.height)
         : this.props.mipLevels || 1;
 
     // TODO - perhaps this should be set on async write completion?
@@ -308,4 +338,24 @@ export abstract class Texture extends Resource<TextureProps> {
 
   /** Set sampler props associated with this texture */
   abstract setSampler(sampler?: Sampler | SamplerProps): void;
+
+  /** Copy external image data into the texture */
+  abstract copyExternalImage(options: CopyExternalImageOptions): {width: number; height: number};
+
+  /** Default options */
+  protected static defaultCopyExternalImageOptions: Required<CopyExternalImageOptions> = {
+    image: undefined!,
+    sourceX: 0,
+    sourceY: 0,
+    width: undefined!,
+    height: undefined!,
+    depth: 1,
+    mipLevel: 0,
+    x: 0,
+    y: 0,
+    z: 0,
+    aspect: 'all',
+    colorSpace: 'srgb',
+    premultipliedAlpha: false
+  };
 }

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -86,7 +86,8 @@ export type {
   Texture3DData,
   TextureCubeData,
   TextureArrayData,
-  TextureCubeArrayData
+  TextureCubeArrayData,
+  CopyExternalImageOptions
 } from './adapter/resources/texture';
 
 export type {Parameters, PrimitiveTopology, IndexFormat} from './adapter/types/parameters';

--- a/modules/core/test/adapter/resources/sampler.spec.ts
+++ b/modules/core/test/adapter/resources/sampler.spec.ts
@@ -88,3 +88,110 @@ function testSampler(t: Test, device: Device): void {
     }
   }
 }
+
+/*
+// Shared with texture*.spec.js
+export function testSamplerParameters({t, texture, parameters}) {
+  for (const parameterName in parameters) {
+    const values = parameters[parameterName];
+    const parameter = Number(parameterName);
+    for (const valueName in values) {
+      const value = Number(valueName);
+      texture.setParameters({
+        [parameter]: value
+      });
+      const name = texture.constructor.name;
+      const newValue = getParameter(texture, parameter);
+      t.equals(
+        newValue,
+        value,
+        `${name}.setParameters({[${device.getGLKey(parameter)}]: ${device.getGLKey(
+          value
+        )}}) read back OK`
+      );
+    }
+  }
+}
+  test.skip('Texture#NPOT Workaround: texture creation', t => {
+  // Create NPOT texture with no parameters
+  let texture = webglDevice.createTexture({data: null, width: 500, height: 512});
+  t.ok(texture instanceof Texture, 'Texture construction successful');
+
+  // Default parameters should be changed to supported NPOT parameters.
+  let minFilter = getParameter(texture, 'minFilter');
+  t.equals(minFilter, GL.LINEAR, 'NPOT texture min filter is set to LINEAR');
+  let wrapS = getParameter(texture, 'addressModeU');
+  t.equals(wrapS, 'clamp-to-edge', 'NPOT texture wrap_s is set to CLAMP_TO_EDGE');
+  let wrapT = getParameter(texture, 'addressModeV');
+  t.equals(wrapT, 'clamp-to-edge', 'NPOT texture wrap_t is set to CLAMP_TO_EDGE');
+
+  const parameters = {
+    ['minFilter']: 'nearest',
+    ['addressModeU']: 'repeat',
+    ['addressModeV']: 'mirrored-repeat'
+  };
+
+  // Create NPOT texture with parameters
+  texture = webglDevice.createTexture({
+    data: null,
+    width: 512,
+    height: 600,
+    parameters
+  });
+  t.ok(texture instanceof Texture, 'Texture construction successful');
+
+  // Above parameters should be changed to supported NPOT parameters.
+  minFilter = getParameter(texture, 'minFilter');
+  t.equals(minFilter, 'nearest', 'NPOT texture min filter is set to NEAREST');
+  wrapS = getParameter(texture, 'addressModeU');
+  t.equals(wrapS, 'clamp-to-edge', 'NPOT texture wrap_s is set to CLAMP_TO_EDGE');
+  wrapT = getParameter(texture, 'addressModeV');
+  t.equals(wrapT, 'clamp-to-edge', 'NPOT texture wrap_t is set to CLAMP_TO_EDGE');
+
+  t.end();
+});
+
+test.skip('Texture#NPOT Workaround: setParameters', t => {
+  // Create NPOT texture
+  const texture = webglDevice.createTexture({data: null, width: 100, height: 100});
+  t.ok(texture instanceof Texture, 'Texture construction successful');
+
+  const invalidNPOTParameters = {
+    ['minFilter']: 'linear',
+    ['mipmapFilter']: 'nearest',
+    ['addressModeU']: 'mirrored-repeat',
+    ['addressModeV']: 'repeat'
+  };
+  texture.setParameters(invalidNPOTParameters);
+
+  // Above parameters should be changed to supported NPOT parameters.
+  const minFilter = getParameter(texture, 'minFilter');
+  t.equals(minFilter, 'linear', 'NPOT texture min filter is set to LINEAR');
+  const wrapS = getParameter(texture, 'addressModeU');
+  t.equals(wrapS, 'clamp-to-edge', 'NPOT texture wrap_s is set to CLAMP_TO_EDGE');
+  const wrapT = getParameter(texture, 'addressModeV');
+  t.equals(wrapT, 'clamp-to-edge', 'NPOT texture wrap_t is set to CLAMP_TO_EDGE');
+
+  t.end();
+});
+
+function getParameter(texture: Texture, pname: number): any {
+  const webglTexture = texture as WEBGLTexture;
+  webglTexture.gl.bindTexture(webglTexture.target, webglTexture.handle);
+  const value = webglTexture.gl.getTexParameter(webglTexture.target, pname);
+  webglTexture.gl.bindTexture(webglTexture.target, null);
+  return value;
+}
+test.skip('WebGL2#Texture setParameters', t => {
+  const texture = webglDevice.createTexture({});
+  t.ok(texture instanceof Texture, 'Texture construction successful');
+
+  testSamplerParameters({t, texture, parameters: SAMPLER_PARAMETERS_WEBGL2});
+
+  texture.destroy();
+  t.ok(texture instanceof Texture, 'Texture delete successful');
+
+  t.end();
+});
+
+*/

--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -339,29 +339,6 @@ test.skip('WebGL2#Texture generateMipmap', t => {
   t.end();
 });
 
-// Shared with texture*.spec.js
-export function testSamplerParameters({t, texture, parameters}) {
-  for (const parameterName in parameters) {
-    const values = parameters[parameterName];
-    const parameter = Number(parameterName);
-    for (const valueName in values) {
-      const value = Number(valueName);
-      texture.setParameters({
-        [parameter]: value
-      });
-      const name = texture.constructor.name;
-      const newValue = getParameter(texture, parameter);
-      t.equals(
-        newValue,
-        value,
-        `${name}.setParameters({[${device.getGLKey(parameter)}]: ${device.getGLKey(
-          value
-        )}}) read back OK`
-      );
-    }
-  }
-}
-
 // NON-2D TEXTURES
 
 test('Texture(dimension)#construct/delete', async t => {
@@ -369,7 +346,11 @@ test('Texture(dimension)#construct/delete', async t => {
     for (const dimension of ['3d', '2d-array', 'cube']) {
       const texture = webglDevice.createTexture({dimension});
       t.equal(texture.dimension, dimension, `${device.info.type} Texture construction successful`);
-      t.equal(texture.view.props.dimension, dimension,  `${device.info.type} Texture view construction successful`);
+      t.equal(
+        texture.view.props.dimension,
+        dimension,
+        `${device.info.type} Texture view construction successful`
+      );
       texture.destroy();
     }
   }
@@ -492,13 +473,11 @@ test.skip('WebGL#Texture3D construct/delete', t => {
   t.end();
 });
 
-// HELPERS
-
 test.skip('Texture#setParameters', t => {
   const texture = webglDevice.createTexture({});
   t.ok(texture instanceof Texture, 'Texture construction successful');
 
-  testSamplerParameters({t, texture, parameters: SAMPLER_PARAMETERS});
+  testSamplerParameters({t, texture, sampler: SAMPLER_PARAMETERS});
 
   /*
   // Bad tests
@@ -517,86 +496,3 @@ test.skip('Texture#setParameters', t => {
 
   t.end();
 });
-
-test.skip('WebGL2#Texture setParameters', t => {
-  const texture = webglDevice.createTexture({});
-  t.ok(texture instanceof Texture, 'Texture construction successful');
-
-  testSamplerParameters({t, texture, parameters: SAMPLER_PARAMETERS_WEBGL2});
-
-  texture.destroy();
-  t.ok(texture instanceof Texture, 'Texture delete successful');
-
-  t.end();
-});
-
-test.skip('Texture#NPOT Workaround: texture creation', t => {
-  // Create NPOT texture with no parameters
-  let texture = webglDevice.createTexture({data: null, width: 500, height: 512});
-  t.ok(texture instanceof Texture, 'Texture construction successful');
-
-  // Default parameters should be changed to supported NPOT parameters.
-  let minFilter = getParameter(texture, 'minFilter');
-  t.equals(minFilter, GL.LINEAR, 'NPOT texture min filter is set to LINEAR');
-  let wrapS = getParameter(texture, 'addressModeU');
-  t.equals(wrapS, 'clamp-to-edge', 'NPOT texture wrap_s is set to CLAMP_TO_EDGE');
-  let wrapT = getParameter(texture, 'addressModeV');
-  t.equals(wrapT, 'clamp-to-edge', 'NPOT texture wrap_t is set to CLAMP_TO_EDGE');
-
-  const parameters = {
-    ['minFilter']: 'nearest',
-    ['addressModeU']: 'repeat',
-    ['addressModeV']: 'mirrored-repeat'
-  };
-
-  // Create NPOT texture with parameters
-  texture = webglDevice.createTexture({
-    data: null,
-    width: 512,
-    height: 600,
-    parameters
-  });
-  t.ok(texture instanceof Texture, 'Texture construction successful');
-
-  // Above parameters should be changed to supported NPOT parameters.
-  minFilter = getParameter(texture, 'minFilter');
-  t.equals(minFilter, 'nearest', 'NPOT texture min filter is set to NEAREST');
-  wrapS = getParameter(texture, 'addressModeU');
-  t.equals(wrapS, 'clamp-to-edge', 'NPOT texture wrap_s is set to CLAMP_TO_EDGE');
-  wrapT = getParameter(texture, 'addressModeV');
-  t.equals(wrapT, 'clamp-to-edge', 'NPOT texture wrap_t is set to CLAMP_TO_EDGE');
-
-  t.end();
-});
-
-test.skip('Texture#NPOT Workaround: setParameters', t => {
-  // Create NPOT texture
-  const texture = webglDevice.createTexture({data: null, width: 100, height: 100});
-  t.ok(texture instanceof Texture, 'Texture construction successful');
-
-  const invalidNPOTParameters = {
-    ['minFilter']: 'linear',
-    ['mipmapFilter']: 'nearest',
-    ['addressModeU']: 'mirrored-repeat',
-    ['addressModeV']: 'repeat'
-  };
-  texture.setParameters(invalidNPOTParameters);
-
-  // Above parameters should be changed to supported NPOT parameters.
-  const minFilter = getParameter(texture, 'minFilter');
-  t.equals(minFilter, 'linear', 'NPOT texture min filter is set to LINEAR');
-  const wrapS = getParameter(texture, 'addressModeU');
-  t.equals(wrapS, 'clamp-to-edge', 'NPOT texture wrap_s is set to CLAMP_TO_EDGE');
-  const wrapT = getParameter(texture, 'addressModeV');
-  t.equals(wrapT, 'clamp-to-edge', 'NPOT texture wrap_t is set to CLAMP_TO_EDGE');
-
-  t.end();
-});
-
-function getParameter(texture: Texture, pname: number): any {
-  const webglTexture = texture as WEBGLTexture;
-  webglTexture.gl.bindTexture(webglTexture.target, webglTexture.handle);
-  const value = webglTexture.gl.getTexParameter(webglTexture.target, pname);
-  webglTexture.gl.bindTexture(webglTexture.target, null);
-  return value;
-}

--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -203,111 +203,52 @@ test('Texture#format creation with data', async t => {
   t.end();
 });
 
-test.skip('Texture#setParameters', t => {
-  const texture = webglDevice.createTexture({});
-  t.ok(texture instanceof Texture, 'Texture construction successful');
+test('Texture#copyExternaImage', async t => {
+  for (const device of await getTestDevices()) {
+    const texture = device.createTexture({
+      width: 2,
+      height: 1,
+      format: 'rgba8unorm',
+      mipmaps: false
+    });
 
-  testSamplerParameters({t, texture, parameters: SAMPLER_PARAMETERS});
+    if (device.info.type === 'webgl') {
+      t.deepEquals(
+        webglDevice.readPixelsToArrayWebGL(texture),
+        new Uint8Array(8),
+        `${device.info.type} Pixels are initially empty`
+      );
+    }
 
-  /*
-  // Bad tests
-  const parameter = GL.TEXTURE_MAG_FILTER;
-  const value = GL.LINEAR_MIPMAP_LINEAR;
-  texture.setParameters({
-    [parameter]: value
-  });
-  const newValue = getParameter(texture, GL.TEXTURE_MAG_FILTER);
-  t.equals(newValue, value,
-    `Texture.setParameters({[${device.getGLKey(parameter)}]: ${device.getGLKey(value)}})`);
-  */
+    // data: canvas
+    if (typeof document !== 'undefined') {
+      const canvas = document.createElement('canvas');
+      canvas.width = 2;
+      canvas.height = 1;
+      const ctx = canvas.getContext('2d');
+      ctx.fillRect(0, 0, 2, 1);
+      texture.copyExternalImage({image: canvas});
 
-  texture.destroy();
-  t.ok(texture instanceof Texture, 'Texture delete successful');
-
-  t.end();
-});
-
-test.skip('WebGL2#Texture setParameters', t => {
-  const texture = webglDevice.createTexture({});
-  t.ok(texture instanceof Texture, 'Texture construction successful');
-
-  testSamplerParameters({t, texture, parameters: SAMPLER_PARAMETERS_WEBGL2});
-
-  texture.destroy();
-  t.ok(texture instanceof Texture, 'Texture delete successful');
-
-  t.end();
-});
-
-test.skip('Texture#NPOT Workaround: texture creation', t => {
-  // Create NPOT texture with no parameters
-  let texture = webglDevice.createTexture({data: null, width: 500, height: 512});
-  t.ok(texture instanceof Texture, 'Texture construction successful');
-
-  // Default parameters should be changed to supported NPOT parameters.
-  let minFilter = getParameter(texture, 'minFilter');
-  t.equals(minFilter, GL.LINEAR, 'NPOT texture min filter is set to LINEAR');
-  let wrapS = getParameter(texture, 'addressModeU');
-  t.equals(wrapS, 'clamp-to-edge', 'NPOT texture wrap_s is set to CLAMP_TO_EDGE');
-  let wrapT = getParameter(texture, 'addressModeV');
-  t.equals(wrapT, 'clamp-to-edge', 'NPOT texture wrap_t is set to CLAMP_TO_EDGE');
-
-  const parameters = {
-    ['minFilter']: 'nearest',
-    ['addressModeU']: 'repeat',
-    ['addressModeV']: 'mirrored-repeat'
-  };
-
-  // Create NPOT texture with parameters
-  texture = webglDevice.createTexture({
-    data: null,
-    width: 512,
-    height: 600,
-    parameters
-  });
-  t.ok(texture instanceof Texture, 'Texture construction successful');
-
-  // Above parameters should be changed to supported NPOT parameters.
-  minFilter = getParameter(texture, 'minFilter');
-  t.equals(minFilter, 'nearest', 'NPOT texture min filter is set to NEAREST');
-  wrapS = getParameter(texture, 'addressModeU');
-  t.equals(wrapS, 'clamp-to-edge', 'NPOT texture wrap_s is set to CLAMP_TO_EDGE');
-  wrapT = getParameter(texture, 'addressModeV');
-  t.equals(wrapT, 'clamp-to-edge', 'NPOT texture wrap_t is set to CLAMP_TO_EDGE');
+      if (device.info.type === 'webgl') {
+        t.deepEquals(
+          device.readPixelsToArrayWebGL(texture),
+          new Uint8Array([0, 0, 0, 255, 0, 0, 0, 255]),
+          `${device.info.type} Pixels are then set correctly`
+        );
+      } else {
+        t.pass('WebGPU copyExternalImage test cannot yet read pixels');
+      }
+    }
+  }
 
   t.end();
 });
 
-test.skip('Texture#NPOT Workaround: setParameters', t => {
-  // Create NPOT texture
-  const texture = webglDevice.createTexture({data: null, width: 100, height: 100});
-  t.ok(texture instanceof Texture, 'Texture construction successful');
-
-  const invalidNPOTParameters = {
-    ['minFilter']: 'linear',
-    ['mipmapFilter']: 'nearest',
-    ['addressModeU']: 'mirrored-repeat',
-    ['addressModeV']: 'repeat'
-  };
-  texture.setParameters(invalidNPOTParameters);
-
-  // Above parameters should be changed to supported NPOT parameters.
-  const minFilter = getParameter(texture, 'minFilter');
-  t.equals(minFilter, 'linear', 'NPOT texture min filter is set to LINEAR');
-  const wrapS = getParameter(texture, 'addressModeU');
-  t.equals(wrapS, 'clamp-to-edge', 'NPOT texture wrap_s is set to CLAMP_TO_EDGE');
-  const wrapT = getParameter(texture, 'addressModeV');
-  t.equals(wrapT, 'clamp-to-edge', 'NPOT texture wrap_t is set to CLAMP_TO_EDGE');
-
-  t.end();
-});
-
-test.skip('WebGL2#Texture setImageData', t => {
+test.skip('Texture#setImageData', t => {
   let data;
 
   // data: null
   const texture = webglDevice.createTexture({
-    data: null,
     width: 2,
     height: 1,
     format: GL.RGBA32F,
@@ -318,30 +259,8 @@ test.skip('WebGL2#Texture setImageData', t => {
 
   // data: typed array
   data = new Float32Array([0.1, 0.2, -3, -2, 0, 0.5, 128, 255]);
-  texture.setImageData({data});
+  texture.copyExternalImage({data});
   t.deepEquals(readPixelsToArray(texture), data, 'Pixels are set correctly');
-
-  // data: buffer
-  data = new Float32Array([21, 0.82, 0, 1, 0, 255, 128, 3.333]);
-  const buffer = webglDevice.createByffer({data, accessor: {size: 4, type: GL.FLOAT}});
-  texture.setImageData({data: buffer});
-  t.deepEquals(readPixelsToArray(texture), data, 'Pixels are set correctly');
-
-  // data: canvas
-  if (typeof document !== 'undefined') {
-    const canvas = document.createElement('canvas');
-    canvas.width = 2;
-    canvas.height = 1;
-    const ctx = canvas.getContext('2d');
-    ctx.fillRect(0, 0, 2, 1);
-    texture.setImageData({data: canvas});
-    t.deepEquals(
-      readPixelsToArray(texture),
-      new Float32Array([0, 0, 0, 1, 0, 0, 0, 1]),
-      'Pixels are set correctly'
-    );
-  }
-
   t.end();
 });
 
@@ -583,6 +502,105 @@ test.skip('WebGL#Texture3D construct/delete', t => {
 });
 
 // HELPERS
+
+test.skip('Texture#setParameters', t => {
+  const texture = webglDevice.createTexture({});
+  t.ok(texture instanceof Texture, 'Texture construction successful');
+
+  testSamplerParameters({t, texture, parameters: SAMPLER_PARAMETERS});
+
+  /*
+  // Bad tests
+  const parameter = GL.TEXTURE_MAG_FILTER;
+  const value = GL.LINEAR_MIPMAP_LINEAR;
+  texture.setParameters({
+    [parameter]: value
+  });
+  const newValue = getParameter(texture, GL.TEXTURE_MAG_FILTER);
+  t.equals(newValue, value,
+    `Texture.setParameters({[${device.getGLKey(parameter)}]: ${device.getGLKey(value)}})`);
+  */
+
+  texture.destroy();
+  t.ok(texture instanceof Texture, 'Texture delete successful');
+
+  t.end();
+});
+
+test.skip('WebGL2#Texture setParameters', t => {
+  const texture = webglDevice.createTexture({});
+  t.ok(texture instanceof Texture, 'Texture construction successful');
+
+  testSamplerParameters({t, texture, parameters: SAMPLER_PARAMETERS_WEBGL2});
+
+  texture.destroy();
+  t.ok(texture instanceof Texture, 'Texture delete successful');
+
+  t.end();
+});
+
+test.skip('Texture#NPOT Workaround: texture creation', t => {
+  // Create NPOT texture with no parameters
+  let texture = webglDevice.createTexture({data: null, width: 500, height: 512});
+  t.ok(texture instanceof Texture, 'Texture construction successful');
+
+  // Default parameters should be changed to supported NPOT parameters.
+  let minFilter = getParameter(texture, 'minFilter');
+  t.equals(minFilter, GL.LINEAR, 'NPOT texture min filter is set to LINEAR');
+  let wrapS = getParameter(texture, 'addressModeU');
+  t.equals(wrapS, 'clamp-to-edge', 'NPOT texture wrap_s is set to CLAMP_TO_EDGE');
+  let wrapT = getParameter(texture, 'addressModeV');
+  t.equals(wrapT, 'clamp-to-edge', 'NPOT texture wrap_t is set to CLAMP_TO_EDGE');
+
+  const parameters = {
+    ['minFilter']: 'nearest',
+    ['addressModeU']: 'repeat',
+    ['addressModeV']: 'mirrored-repeat'
+  };
+
+  // Create NPOT texture with parameters
+  texture = webglDevice.createTexture({
+    data: null,
+    width: 512,
+    height: 600,
+    parameters
+  });
+  t.ok(texture instanceof Texture, 'Texture construction successful');
+
+  // Above parameters should be changed to supported NPOT parameters.
+  minFilter = getParameter(texture, 'minFilter');
+  t.equals(minFilter, 'nearest', 'NPOT texture min filter is set to NEAREST');
+  wrapS = getParameter(texture, 'addressModeU');
+  t.equals(wrapS, 'clamp-to-edge', 'NPOT texture wrap_s is set to CLAMP_TO_EDGE');
+  wrapT = getParameter(texture, 'addressModeV');
+  t.equals(wrapT, 'clamp-to-edge', 'NPOT texture wrap_t is set to CLAMP_TO_EDGE');
+
+  t.end();
+});
+
+test.skip('Texture#NPOT Workaround: setParameters', t => {
+  // Create NPOT texture
+  const texture = webglDevice.createTexture({data: null, width: 100, height: 100});
+  t.ok(texture instanceof Texture, 'Texture construction successful');
+
+  const invalidNPOTParameters = {
+    ['minFilter']: 'linear',
+    ['mipmapFilter']: 'nearest',
+    ['addressModeU']: 'mirrored-repeat',
+    ['addressModeV']: 'repeat'
+  };
+  texture.setParameters(invalidNPOTParameters);
+
+  // Above parameters should be changed to supported NPOT parameters.
+  const minFilter = getParameter(texture, 'minFilter');
+  t.equals(minFilter, 'linear', 'NPOT texture min filter is set to LINEAR');
+  const wrapS = getParameter(texture, 'addressModeU');
+  t.equals(wrapS, 'clamp-to-edge', 'NPOT texture wrap_s is set to CLAMP_TO_EDGE');
+  const wrapT = getParameter(texture, 'addressModeV');
+  t.equals(wrapT, 'clamp-to-edge', 'NPOT texture wrap_t is set to CLAMP_TO_EDGE');
+
+  t.end();
+});
 
 function getParameter(texture: Texture, pname: number): any {
   const webglTexture = texture as WEBGLTexture;

--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -362,26 +362,17 @@ export function testSamplerParameters({t, texture, parameters}) {
   }
 }
 
-// 2D TEXTURES
+// NON-2D TEXTURES
 
-test.skip('Texture#construct/delete', t => {
-  t.throws(
-    // @ts-expect-error
-    () => new Texture(),
-    /.*WebGLRenderingContext.*/,
-    'Texture throws on missing gl context'
-  );
-
-  const texture = webglDevice.createTexture();
-  t.ok(texture instanceof Texture, 'Texture construction successful');
-
-  t.comment(JSON.stringify(texture.getParameters({keys: true})));
-
-  texture.destroy();
-  t.ok(texture instanceof Texture, 'Texture delete successful');
-
-  texture.destroy();
-  t.ok(texture instanceof Texture, 'Texture repeated delete successful');
+test('Texture(dimension)#construct/delete', async t => {
+  for (const device of await getTestDevices()) {
+    for (const dimension of ['3d', '2d-array', 'cube']) {
+      const texture = webglDevice.createTexture({dimension});
+      t.equal(texture.dimension, dimension, `${device.info.type} Texture construction successful`);
+      t.equal(texture.view.props.dimension, dimension,  `${device.info.type} Texture view construction successful`);
+      texture.destroy();
+    }
+  }
 
   t.end();
 });

--- a/modules/engine/src/model/split-uniforms-and-bindings.ts
+++ b/modules/engine/src/model/split-uniforms-and-bindings.ts
@@ -5,7 +5,7 @@
 import type {UniformValue, Binding} from '@luma.gl/core';
 import {isNumericArray} from '@math.gl/types';
 
-export function isUniformValue(value: unknown): boolean {
+export function isUniformValue(value: unknown): value is UniformValue {
   return isNumericArray(value) !== null || typeof value === 'number' || typeof value === 'boolean';
 }
 
@@ -21,9 +21,9 @@ export function splitUniformsAndBindings(
   Object.keys(uniforms).forEach(name => {
     const uniform = uniforms[name];
     if (isUniformValue(uniform)) {
-      result.uniforms[name] = uniform as UniformValue;
+      result.uniforms[name] = uniform;
     } else {
-      result.bindings[name] = uniform as Binding;
+      result.bindings[name] = uniform;
     }
   });
 

--- a/modules/test-utils/src/null-device/resources/null-texture.ts
+++ b/modules/test-utils/src/null-device/resources/null-texture.ts
@@ -80,8 +80,7 @@ export class NullTexture extends Texture {
   }
 
   initialize(props: TextureProps = {}): this {
-    const data = props.data;
-
+    // const data = props.data;
     // this.setImageData(props);
 
     this.setSampler(props.sampler);

--- a/modules/test-utils/src/null-device/resources/null-texture.ts
+++ b/modules/test-utils/src/null-device/resources/null-texture.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {TextureProps, Sampler, SamplerProps, TextureViewProps} from '@luma.gl/core';
+import type {
+  TextureProps,
+  Sampler,
+  SamplerProps,
+  TextureViewProps,
+  CopyExternalImageOptions
+} from '@luma.gl/core';
 import type {
   Texture1DData,
   Texture2DData,
@@ -112,10 +118,10 @@ export class NullTexture extends Texture {
     return this;
   }
 
-  setImageData(options: {data?: any; width?: number; height?: number}) {
+  copyExternalImage(options: CopyExternalImageOptions): {width: number; height: number} {
     this.trackDeallocatedMemory('Texture');
 
-    const {data} = options;
+    const {image: data} = options;
 
     if (data && data.byteLength) {
       this.trackAllocatedMemory(data.byteLength, 'Texture');
@@ -130,7 +136,7 @@ export class NullTexture extends Texture {
     this.width = width;
     this.height = height;
 
-    return this;
+    return {width, height};
   }
 
   setSubImageData(options: {data: any; width?: number; height?: number; x?: number; y?: number}) {

--- a/modules/test-utils/src/null-device/resources/null-texture.ts
+++ b/modules/test-utils/src/null-device/resources/null-texture.ts
@@ -82,19 +82,7 @@ export class NullTexture extends Texture {
   initialize(props: TextureProps = {}): this {
     const data = props.data;
 
-    if (data instanceof Promise) {
-      data.then(resolvedImageData =>
-        this.initialize(
-          Object.assign({}, props, {
-            pixels: resolvedImageData,
-            data: resolvedImageData
-          })
-        )
-      );
-      return this;
-    }
-
-    this.setImageData(props);
+    // this.setImageData(props);
 
     this.setSampler(props.sampler);
 
@@ -123,12 +111,12 @@ export class NullTexture extends Texture {
 
     const {image: data} = options;
 
-    if (data && data.byteLength) {
-      this.trackAllocatedMemory(data.byteLength, 'Texture');
-    } else {
-      const bytesPerPixel = 4;
-      this.trackAllocatedMemory(this.width * this.height * bytesPerPixel, 'Texture');
-    }
+    // if (data && data.byteLength) {
+    //   this.trackAllocatedMemory(data.byteLength, 'Texture');
+    // } else {
+    const bytesPerPixel = 4;
+    this.trackAllocatedMemory(this.width * this.height * bytesPerPixel, 'Texture');
+    // }
 
     const width = options.width ?? (data as ImageBitmap).width;
     const height = options.height ?? (data as ImageBitmap).height;
@@ -137,12 +125,5 @@ export class NullTexture extends Texture {
     this.height = height;
 
     return {width, height};
-  }
-
-  setSubImageData(options: {data: any; width?: number; height?: number; x?: number; y?: number}) {
-    // const {data, x = 0, y = 0} = options;
-    // const width = options.width ?? (data as ImageBitmap).width;
-    // const height = options.height ?? (data as ImageBitmap).height;
-    // assert(width + x <= this.width && height + y <= this.height);
   }
 }

--- a/modules/webgl/src/adapter/resources/webgl-texture.ts
+++ b/modules/webgl/src/adapter/resources/webgl-texture.ts
@@ -192,7 +192,7 @@ export class WEBGLTexture extends Texture {
     let {width, height} = props;
 
     if (!width || !height) {
-      const textureSize = this.getTextureDataSize(data);
+      const textureSize = Texture.getTextureDataSize(data);
       width = textureSize?.width || 1;
       height = textureSize?.height || 1;
     }
@@ -333,6 +333,29 @@ export class WEBGLTexture extends Texture {
   }
 
   // Image Data Setters
+  copyExternalImage(options: {
+    image: ExternalImage;
+    sourceX?: number;
+    sourceY?: number;
+    width?: number;
+    height?: number;
+    depth?: number;
+    mipLevel?: number;
+    x?: number;
+    y?: number;
+    z?: number;
+    aspect?: 'all' | 'stencil-only' | 'depth-only';
+    colorSpace?: 'srgb';
+    premultipliedAlpha?: boolean;
+  }): {width: number; height: number} {
+    const size = Texture.getExternalImageSize(options.image);
+    const opts = {...Texture.defaultCopyExternalImageOptions, ...size, ...options};
+    const {depth, mipLevel: lodLevel, image} = opts;
+    this.bind();
+    this._setMipLevel(depth, lodLevel, image);
+    this.unbind();
+    return {width: opts.width, height: opts.height};
+  }
 
   setTexture1DData(data: Texture1DData): void {
     throw new Error('setTexture1DData not supported in WebGL.');
@@ -594,6 +617,7 @@ export class WEBGLTexture extends Texture {
 
     // @ts-expect-error
     if (this.isTextureLevelData(textureData)) {
+      // @ts-expect-error
       copyCPUDataToMipLevel(this.device.gl, textureData.data, {
         ...this,
         depth,

--- a/modules/webgl/src/adapter/resources/webgl-texture.ts
+++ b/modules/webgl/src/adapter/resources/webgl-texture.ts
@@ -616,8 +616,7 @@ export class WEBGLTexture extends Texture {
     }
 
     // @ts-expect-error
-    if (this.isTextureLevelData(textureData)) {
-      // @ts-expect-error
+    if (Texture.isTextureLevelData(textureData)) {
       copyCPUDataToMipLevel(this.device.gl, textureData.data, {
         ...this,
         depth,

--- a/modules/webgl/src/utils/split-uniforms-and-bindings.ts
+++ b/modules/webgl/src/utils/split-uniforms-and-bindings.ts
@@ -5,7 +5,7 @@
 import type {UniformValue, Binding} from '@luma.gl/core';
 import {isNumericArray} from '@math.gl/types';
 
-export function isUniformValue(value: unknown): boolean {
+export function isUniformValue(value: unknown): value is UniformValue {
   return isNumericArray(value) !== null || typeof value === 'number' || typeof value === 'boolean';
 }
 
@@ -21,9 +21,9 @@ export function splitUniformsAndBindings(
   Object.keys(uniforms).forEach(name => {
     const uniform = uniforms[name];
     if (isUniformValue(uniform)) {
-      result.uniforms[name] = uniform as UniformValue;
+      result.uniforms[name] = uniform;
     } else {
-      result.bindings[name] = uniform as Binding;
+      result.bindings[name] = uniform;
     }
   });
 

--- a/modules/webgpu/src/adapter/resources/webgpu-command-encoder.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-command-encoder.ts
@@ -145,3 +145,21 @@ export class WebGPUCommandEncoder extends CommandEncoder {
     );
   }
 }
+
+/*
+  // setDataFromTypedArray(data): this {
+  //   const textureDataBuffer = this.device.handle.createBuffer({
+  //     size: data.byteLength,
+  //     usage: Buffer.COPY_DST | Buffer.COPY_SRC,
+  //     mappedAtCreation: true
+  //   });
+  //   new Uint8Array(textureDataBuffer.getMappedRange()).set(data);
+  //   textureDataBuffer.unmap();
+
+  //   this.setBuffer(textureDataBuffer);
+
+  //   textureDataBuffer.destroy();
+  //   return this;
+  // }
+
+ */


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- WebGPU has one texture setting function that doesn't require CommandBuffers and working through GPU buffers.
#### Change List
- Expose `Texture.copyExternalImage()` function.
