### PR TITLE
fix(webgl): Fix texture.copyExternalImage() with offsets

### DIFF
--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -203,7 +203,7 @@ test('Texture#format creation with data', async t => {
   t.end();
 });
 
-test.only('Texture#copyExternaImage', async t => {
+test('Texture#copyExternaImage', async t => {
   for (const device of await getTestDevices()) {
     const texture = device.createTexture({
       width: 2,
@@ -235,7 +235,7 @@ test.only('Texture#copyExternaImage', async t => {
         t.deepEquals(
           device.readPixelsToArrayWebGL(texture),
           new Uint8Array([255, 0, 0, 255, 255, 0, 0, 255]),
-          `${device.info.type} Pixels are then set correctly`
+          `${device.info.type} Pixels were set correctly (full image)`
         );
       }
 
@@ -244,12 +244,12 @@ test.only('Texture#copyExternaImage', async t => {
       ctx.fillRect(0, 0, 2, 1);
 
       texture.copyExternalImage({image: canvas, x: 1});
-      
+
       if (device.info.type === 'webgl') {
         t.deepEquals(
           device.readPixelsToArrayWebGL(texture),
-          new Uint8Array([0, 0, 0, 255, 0, 0, 0, 255]),
-          `${device.info.type} Pixels are then set correctly`
+          new Uint8Array([255, 0, 0, 255, 0, 0, 0, 255]),
+          `${device.info.type} Pixels were set correctly (sub image)`
         );
       }
     }

--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -203,7 +203,7 @@ test('Texture#format creation with data', async t => {
   t.end();
 });
 
-test('Texture#copyExternaImage', async t => {
+test.only('Texture#copyExternaImage', async t => {
   for (const device of await getTestDevices()) {
     const texture = device.createTexture({
       width: 2,
@@ -220,24 +220,42 @@ test('Texture#copyExternaImage', async t => {
       );
     }
 
-    // data: canvas
     if (typeof document !== 'undefined') {
       const canvas = document.createElement('canvas');
       canvas.width = 2;
       canvas.height = 1;
       const ctx = canvas.getContext('2d');
+
+      // Full copy
+      ctx.fillStyle = '#FF0000';
       ctx.fillRect(0, 0, 2, 1);
       texture.copyExternalImage({image: canvas});
 
       if (device.info.type === 'webgl') {
         t.deepEquals(
           device.readPixelsToArrayWebGL(texture),
+          new Uint8Array([255, 0, 0, 255, 255, 0, 0, 255]),
+          `${device.info.type} Pixels are then set correctly`
+        );
+      }
+
+      // Subimage copy
+      ctx.fillStyle = '#000000';
+      ctx.fillRect(0, 0, 2, 1);
+
+      texture.copyExternalImage({image: canvas, x: 1});
+      
+      if (device.info.type === 'webgl') {
+        t.deepEquals(
+          device.readPixelsToArrayWebGL(texture),
           new Uint8Array([0, 0, 0, 255, 0, 0, 0, 255]),
           `${device.info.type} Pixels are then set correctly`
         );
-      } else {
-        t.pass('WebGPU copyExternalImage test cannot yet read pixels');
       }
+    }
+
+    if (device.info.type !== 'webgl') {
+      t.pass('WebGPU copyExternalImage test cannot yet read pixels');
     }
   }
 

--- a/modules/webgl/src/adapter/helpers/webgl-texture-utils.ts
+++ b/modules/webgl/src/adapter/helpers/webgl-texture-utils.ts
@@ -28,14 +28,13 @@ export type WebGLSetTextureOptions = {
   dimension: '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
   height: number;
   width: number;
-  depth?: number;
+  depth: number;
   mipLevel?: number;
   glTarget: GLTextureTarget;
   glInternalFormat: GL;
   glFormat: GLTexelDataFormat;
   glType: GLPixelType;
   compressed?: boolean;
-
   byteOffset?: number;
   byteLength?: number;
 };
@@ -120,6 +119,7 @@ export function copyExternalImageToMipLevel(
   const {dimension, depth = 0, mipLevel = 0} = options;
   const {x = 0, y = 0, z = 0} = options;
   const {glFormat, glType} = options;
+
   const glTarget = getWebGLCubeFaceTarget(options.glTarget, dimension, depth);
 
   switch (dimension) {

--- a/modules/webgl/src/adapter/helpers/webgl-texture-utils.ts
+++ b/modules/webgl/src/adapter/helpers/webgl-texture-utils.ts
@@ -21,12 +21,15 @@ import {TypedArray} from '@math.gl/types';
 /** A "border" parameter is required in many WebGL texture APIs, but must always be 0... */
 const BORDER = 0;
 
+/**
+ * Options for setting data into a texture
+ */
 export type WebGLSetTextureOptions = {
   dimension: '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
   height: number;
   width: number;
   depth?: number;
-  level?: number;
+  mipLevel?: number;
   glTarget: GLTextureTarget;
   glInternalFormat: GL;
   glFormat: GLTexelDataFormat;
@@ -38,19 +41,8 @@ export type WebGLSetTextureOptions = {
 };
 
 /**
- * @param {*} pixels, data -
- *  null - create empty texture of specified format
- *  Typed array - init from image data in typed array
- *  Buffer|WebGLBuffer - (WEBGL2) init from image data in WebGLBuffer
- *  HTMLImageElement|Image - Inits with content of image. Auto width/height
- *  HTMLCanvasElement - Inits with contents of canvas. Auto width/height
- *  HTMLVideoElement - Creates video texture. Auto width/height
+ * Options for copying an image or data into a texture
  *
- * @param  x - xOffset from where texture to be updated
- * @param  y - yOffset from where texture to be updated
- * @param  width - width of the sub image to be updated
- * @param  height - height of the sub image to be updated
- * @param  level - mip level to be updated
  * @param {GLenum} format - internal format of image data.
  * @param {GLenum} type
  *  - format of array (autodetect from type) or
@@ -61,12 +53,19 @@ export type WebGLSetTextureOptions = {
  */
 export type WebGLCopyTextureOptions = {
   dimension: '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
-  level?: number;
-  height: number;
+  /** mip level to be updated */
+  mipLevel?: number;
+  /** width of the sub image to be updated */
   width: number;
+  /** height of the sub image to be updated */
+  height: number;
+  /** depth of texture to be updated */
   depth?: number;
+  /** xOffset from where texture to be updated */
   x?: number;
+  /** yOffset from where texture to be updated */
   y?: number;
+  /** yOffset from where texture to be updated */
   z?: number;
 
   glTarget: GLTextureTarget;
@@ -74,7 +73,6 @@ export type WebGLCopyTextureOptions = {
   glFormat: GL;
   glType: GL;
   compressed?: boolean;
-
   byteOffset?: number;
   byteLength?: number;
 };
@@ -112,30 +110,33 @@ export function initializeTextureStorage(
 /**
  * Copy a region of compressed data from a GPU memory buffer into this texture.
  */
-export function copyCPUImageToMipLevel(
+export function copyExternalImageToMipLevel(
   gl: WebGL2RenderingContext,
+  handle: WebGLTexture,
   image: ExternalImage,
   options: WebGLCopyTextureOptions
 ): void {
-  const {dimension, width, height, depth = 0, level = 0} = options;
+  const {width, height} = options;
+  const {dimension, depth = 0, mipLevel = 0} = options;
   const {x = 0, y = 0, z = 0} = options;
   const {glFormat, glType} = options;
   const glTarget = getWebGLCubeFaceTarget(options.glTarget, dimension, depth);
 
-  // width = size.width,
-  // height = size.height
-
   switch (dimension) {
     case '2d-array':
     case '3d':
+      gl.bindTexture(glTarget, handle);
       // prettier-ignore
-      gl.texSubImage3D(glTarget, level, x, y, z, width, height, depth, glFormat, glType, image);
+      gl.texSubImage3D(glTarget, mipLevel, x, y, z, width, height, depth, glFormat, glType, image);
+      gl.bindTexture(glTarget, null);
       break;
 
     case '2d':
     case 'cube':
+      gl.bindTexture(glTarget, handle);
       // prettier-ignore
-      gl.texSubImage2D(glTarget, level, x, y, width, height, glFormat, glType, image);
+      gl.texSubImage2D(glTarget, mipLevel, x, y, width, height, glFormat, glType, image);
+      gl.bindTexture(glTarget, null);
       break;
 
     default:
@@ -151,7 +152,7 @@ export function copyCPUDataToMipLevel(
   typedArray: TypedArray,
   options: WebGLCopyTextureOptions
 ): void {
-  const {dimension, width, height, depth = 0, level = 0, byteOffset = 0} = options;
+  const {dimension, width, height, depth = 0, mipLevel = 0, byteOffset = 0} = options;
   const {x = 0, y = 0, z = 0} = options;
   const {glFormat, glType, compressed} = options;
   const glTarget = getWebGLCubeFaceTarget(options.glTarget, dimension, depth);
@@ -163,10 +164,10 @@ export function copyCPUDataToMipLevel(
     case '3d':
       if (compressed) {
         // prettier-ignore
-        gl.compressedTexSubImage3D(glTarget, level, x, y, z, width, height, depth, glFormat, typedArray, byteOffset); // , byteLength
+        gl.compressedTexSubImage3D(glTarget, mipLevel, x, y, z, width, height, depth, glFormat, typedArray, byteOffset); // , byteLength
       } else {
         // prettier-ignore
-        gl.texSubImage3D(glTarget, level, x, y, z, width, height, depth, glFormat, glType, typedArray, byteOffset); // , byteLength
+        gl.texSubImage3D(glTarget, mipLevel, x, y, z, width, height, depth, glFormat, glType, typedArray, byteOffset); // , byteLength
       }
       break;
 
@@ -174,10 +175,10 @@ export function copyCPUDataToMipLevel(
     case 'cube':
       if (compressed) {
         // prettier-ignore
-        gl.compressedTexSubImage2D(glTarget, level, x, y, width, height, glFormat, typedArray, byteOffset); // , byteLength
+        gl.compressedTexSubImage2D(glTarget, mipLevel, x, y, width, height, glFormat, typedArray, byteOffset); // , byteLength
       } else {
         // prettier-ignore
-        gl.texSubImage2D(glTarget, level, x, y, width, height, glFormat, glType, typedArray, byteOffset); // , byteLength
+        gl.texSubImage2D(glTarget, mipLevel, x, y, width, height, glFormat, glType, typedArray, byteOffset); // , byteLength
       }
       break;
 
@@ -195,7 +196,7 @@ export function copyGPUBufferToMipLevel(
   byteLength: number,
   options: WebGLCopyTextureOptions
 ): void {
-  const {dimension, width, height, depth = 0, level = 0, byteOffset = 0} = options;
+  const {dimension, width, height, depth = 0, mipLevel = 0, byteOffset = 0} = options;
   const {x = 0, y = 0, z = 0} = options;
   const {glFormat, glType, compressed} = options;
   const glTarget = getWebGLCubeFaceTarget(options.glTarget, dimension, depth);
@@ -209,10 +210,10 @@ export function copyGPUBufferToMipLevel(
       if (compressed) {
         // TODO enable extension?
         // prettier-ignore
-        gl.compressedTexSubImage3D(glTarget, level, x, y, z, width, height, depth, glFormat, byteLength, byteOffset);
+        gl.compressedTexSubImage3D(glTarget, mipLevel, x, y, z, width, height, depth, glFormat, byteLength, byteOffset);
       } else {
         // prettier-ignore
-        gl.texSubImage3D(glTarget, level, x, y, z, width, height, depth, glFormat, glType, byteOffset);
+        gl.texSubImage3D(glTarget, mipLevel, x, y, z, width, height, depth, glFormat, glType, byteOffset);
       }
       break;
 
@@ -220,10 +221,10 @@ export function copyGPUBufferToMipLevel(
     case 'cube':
       if (compressed) {
         // prettier-ignore
-        gl.compressedTexSubImage2D(glTarget, level, x, y, width, height, glFormat, byteLength, byteOffset);
+        gl.compressedTexSubImage2D(glTarget, mipLevel, x, y, width, height, glFormat, byteLength, byteOffset);
       } else {
         // prettier-ignore
-        gl.texSubImage2D(glTarget, level, x, y, width, height, BORDER, glFormat, byteOffset);
+        gl.texSubImage2D(glTarget, mipLevel, x, y, width, height, BORDER, glFormat, byteOffset);
       }
       break;
 
@@ -255,7 +256,7 @@ export function getWebGLTextureTarget(
  * @note We still bind the texture using GL.TEXTURE_CUBE_MAP, but we need to use the face-specific target when setting mip levels.
  * @returns glTarget unchanged, if dimension !== 'cube'.
  */
-function getWebGLCubeFaceTarget(
+export function getWebGLCubeFaceTarget(
   glTarget: GLTextureTarget,
   dimension: '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d',
   level: number


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Fixes breakage found in deck.gl v9.1 testing
#### Change List
-
