### PR TITLE
fix(webgpu): animation example, dirlight module

### DIFF
--- a/examples/api/animation/app.ts
+++ b/examples/api/animation/app.ts
@@ -40,6 +40,48 @@ const app: {uniformTypes: Record<string, ShaderUniformType>} = {
   }
 };
 
+const source = /* wgsl */ `\
+struct Uniforms {
+  uColor : vec3<f32>,
+  uModel : mat4x4<f32>,
+  uView : mat4x4<f32>,
+  uProjection : mat4x4<f32>,
+};
+
+@binding(0) @group(0) var<uniform> app : Uniforms;
+
+struct VertexInputs {
+  // CUBE GEOMETRY
+  @location(0) positions : vec4<f32>,
+  @location(1) normals : vec3<f32>
+};
+
+struct FragmentInputs {
+  @builtin(position) Position : vec4<f32>,
+  @location(0) color : vec3<f32>,
+  @location(1) dirlightNormal: DirlightNormal,
+}
+
+@vertex
+fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
+  var outputs : FragmentInputs;
+  // gl_Position = app.uProjection * app.uView * app.uModel * vec4(positions, 1.0);
+  outputs.Position = app.uProjection * app.uView * app.uModel * inputs.positions;
+  outputs.color = app.uColor;
+
+  let normal: vec3<f32> = (app.uModel * vec4<f32>(inputs.normals, 0.0)).xyz;
+  outputs.dirlightNormal = dirlight_setNormal(normal);
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
+  var fragColor = vec4(inputs.color, 1.);
+  fragColor = dirlight_filterColor(fragColor, DirlightInputs(inputs.dirlightNormal));
+  return fragColor;
+}
+`;
+
 const vs = /* glsl */ `\
 #version 300 es
 
@@ -194,8 +236,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         keyFrames: keyFrames[i],
         model: new Model(device, {
           id: `cube-${i}`,
+          source,
           vs,
           fs,
+          instanceCount: 1,
           modules: [dirlight],
           geometry: new CubeGeometry(),
           parameters: {
@@ -251,6 +295,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       clearColor: [0, 0, 0, 1]
       // clearDepth: true
     });
+    debugger
     for (const cube of this.cubes) {
       cube.model.draw(renderPass);
     }

--- a/examples/api/animation/index.html
+++ b/examples/api/animation/index.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <script type="module">
   import {luma} from '@luma.gl/core';
+  import {webgpuAdapter} from '@luma.gl/webgpu';
+  luma.registerAdapters([webgpuAdapter]);
   import {webgl2Adapter} from '@luma.gl/webgl';
   luma.registerAdapters([webgl2Adapter]);
 

--- a/examples/api/animation/package.json
+++ b/examples/api/animation/package.json
@@ -8,10 +8,10 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@luma.gl/core": "9.1.0-alpha.6",
-    "@luma.gl/engine": "9.1.0-alpha.6",
-    "@luma.gl/shadertools": "9.1.0-alpha.6",
-    "@luma.gl/webgl": "9.1.0-alpha.6",
+    "@luma.gl/core": "9.1.0-alpha.10",
+    "@luma.gl/engine": "9.1.0-alpha.10",
+    "@luma.gl/shadertools": "9.1.0-alpha.10",
+    "@luma.gl/webgl": "9.1.0-alpha.10",
     "@math.gl/core": "^4.0.0"
   },
   "devDependencies": {

--- a/modules/shadertools/src/modules/lighting/no-material/dirlight.ts
+++ b/modules/shadertools/src/modules/lighting/no-material/dirlight.ts
@@ -12,21 +12,30 @@ export type DirlightProps = {
 export type DirlightUniforms = DirlightProps;
 
 // TODO
-export const VS_WGSL = /* WGSL */ `\  
-void dirlight_setNormal(normal: vec3<f32>) {
-  dirlight_vNormal = normalize(normal);
-}
-`;
+export const SOURCE_WGSL = /* WGSL */ `\  
+struct dirlightUniforms {
+  lightDirection: vec3<f32>,
+};
 
-// TODO
-export const FS_WGSL = /* WGSL */ `\
-uniform dirlightUniforms {
-  vec3 lightDirection;
-} dirlight;
+alias DirlightNormal = vec3<f32>;
+
+struct DirlightInputs {
+  normal: DirlightNormal,
+};
+
+@binding(1) @group(0) var<uniform> dirlight : dirlightUniforms;
+
+// For vertex
+fn dirlight_setNormal(normal: vec3<f32>) -> DirlightNormal {
+  return normalize(normal);
+}
 
 // Returns color attenuated by angle from light source
-fn dirlight_filterColor(color: vec4<f32>, dirlightInputs): vec4<f32> {
-  const d: float = abs(dot(dirlight_vNormal, normalize(dirlight.lightDirection)));
+fn dirlight_filterColor(color: vec4<f32>, inputs: DirlightInputs) -> vec4<f32> {
+  // TODO - fix default light direction
+  // let lightDirection = dirlight.lightDirection;
+  let lightDirection = vec3<f32>(1, 1, 1);
+  let d: f32 = abs(dot(inputs.normal, normalize(lightDirection)));
   return vec4<f32>(color.rgb * d, color.a);
 }
 `;
@@ -62,6 +71,7 @@ export const dirlight = {
 
   name: 'dirlight',
   dependencies: [],
+  source: SOURCE_WGSL,
   vs: VS_GLSL,
   fs: FS_GLSL,
 

--- a/website/content/examples/api/animation.mdx
+++ b/website/content/examples/api/animation.mdx
@@ -3,5 +3,5 @@ import {AnimationExample} from '@site';
 
 # Animation
 
-<DeviceTabs devices={["webgl2"]} />
+<DeviceTabs />
 <AnimationExample />


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Continue porting examples to WebGPU, this time its the animation example (which also uses the `dirlight` module.
#### Change List
- Implement WGSL shader in animation/app.ts
- Implement WGSL shader in dirlight shader module.
- Find workarounds for severe WGSL limitations around modularizing module parameter passing.
