### PR TITLE
shadertools: lighting module fixes

### DIFF
--- a/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-material.ts
+++ b/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-material.ts
@@ -18,7 +18,7 @@ export type GouraudMaterialUniforms = {
 
 /** In Gouraud shading, color is calculated for each triangle vertex normal, and then color is interpolated colors across the triangle */
 export const gouraudMaterial: ShaderModule<GouraudMaterialProps, GouraudMaterialUniforms> = {
-  name: 'gouraud-lighting',
+  name: 'gouraudMaterial',
   // Note these are switched between phong and gouraud
   vs: GOURAUD_VS,
   fs: GOURAUD_FS,

--- a/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-shaders-glsl.ts
+++ b/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-shaders-glsl.ts
@@ -5,7 +5,7 @@
 import {glsl} from '../../../lib/glsl-utils/highlight';
 
 export const GOURAUD_VS = glsl`\
-uniform materialUniforms {
+uniform gouraudMaterialUniforms {
   uniform float ambient;
   uniform float diffuse;
   uniform float shininess;
@@ -14,7 +14,7 @@ uniform materialUniforms {
 `;
 
 export const GOURAUD_FS = glsl`\
-uniform materialUniforms {
+uniform gouraudMaterialUniforms {
   uniform float ambient;
   uniform float diffuse;
   uniform float shininess;

--- a/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-shaders-glsl.ts
+++ b/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-shaders-glsl.ts
@@ -36,39 +36,41 @@ vec3 lighting_getLightColor(vec3 surfaceColor, vec3 light_direction, vec3 view_d
 vec3 lighting_getLightColor(vec3 surfaceColor, vec3 cameraPosition, vec3 position_worldspace, vec3 normal_worldspace) {
   vec3 lightColor = surfaceColor;
 
-  if (lighting.enabled) {
-    vec3 view_direction = normalize(cameraPosition - position_worldspace);
-    lightColor = material.ambient * surfaceColor * lighting.ambientColor;
-
-    if (lighting.lightType == 0) {
-      PointLight pointLight = lighting_getPointLight(0);
-      vec3 light_position_worldspace = pointLight.position;
-      vec3 light_direction = normalize(light_position_worldspace - position_worldspace);
-      lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.color);
-    } else if (lighting.lightType == 1) {
-      DirectionalLight directionalLight = lighting_getDirectionalLight(0);
-      lightColor += lighting_getLightColor(surfaceColor, -directionalLight.direction, view_direction, normal_worldspace, directionalLight.color);
-    }
-    /*
-    for (int i = 0; i < MAX_LIGHTS; i++) {
-      if (i >= lighting.pointLightCount) {
-        break;
-      }
-      PointLight pointLight = lighting.pointLight[i];
-      vec3 light_position_worldspace = pointLight.position;
-      vec3 light_direction = normalize(light_position_worldspace - position_worldspace);
-      lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.color);
-    }
-
-    for (int i = 0; i < MAX_LIGHTS; i++) {
-      if (i >= lighting.directionalLightCount) {
-        break;
-      }
-      DirectionalLight directionalLight = lighting.directionalLight[i];
-      lightColor += lighting_getLightColor(surfaceColor, -directionalLight.direction, view_direction, normal_worldspace, directionalLight.color);
-    }
-    */
+  if (lighting.enabled == 0) {
+    return lightColor;
   }
+
+  vec3 view_direction = normalize(cameraPosition - position_worldspace);
+  lightColor = material.ambient * surfaceColor * lighting.ambientColor;
+
+  if (lighting.lightType == 0) {
+    PointLight pointLight = lighting_getPointLight(0);
+    vec3 light_position_worldspace = pointLight.position;
+    vec3 light_direction = normalize(light_position_worldspace - position_worldspace);
+    lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.color);
+  } else if (lighting.lightType == 1) {
+    DirectionalLight directionalLight = lighting_getDirectionalLight(0);
+    lightColor += lighting_getLightColor(surfaceColor, -directionalLight.direction, view_direction, normal_worldspace, directionalLight.color);
+  }
+  /*
+  for (int i = 0; i < MAX_LIGHTS; i++) {
+    if (i >= lighting.pointLightCount) {
+      break;
+    }
+    PointLight pointLight = lighting.pointLight[i];
+    vec3 light_position_worldspace = pointLight.position;
+    vec3 light_direction = normalize(light_position_worldspace - position_worldspace);
+    lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.color);
+  }
+
+  for (int i = 0; i < MAX_LIGHTS; i++) {
+    if (i >= lighting.directionalLightCount) {
+      break;
+    }
+    DirectionalLight directionalLight = lighting.directionalLight[i];
+    lightColor += lighting_getLightColor(surfaceColor, -directionalLight.direction, view_direction, normal_worldspace, directionalLight.color);
+  }
+  */
   return lightColor;
 }
 
@@ -76,23 +78,26 @@ vec3 lighting_getSpecularLightColor(vec3 cameraPosition, vec3 position_worldspac
   vec3 lightColor = vec3(0, 0, 0);
   vec3 surfaceColor = vec3(0, 0, 0);
 
-  if (lighting.enabled) {
-    vec3 view_direction = normalize(cameraPosition - position_worldspace);
-
-    switch (lighting.lightType) {
-      case 0:
-        PointLight pointLight = lighting_getPointLight(0);
-        vec3 light_position_worldspace = pointLight.position;
-        vec3 light_direction = normalize(light_position_worldspace - position_worldspace);
-        lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.color);
-        break;
-
-      case 1:
-        DirectionalLight directionalLight = lighting_getDirectionalLight(0);
-        lightColor += lighting_getLightColor(surfaceColor, -directionalLight.direction, view_direction, normal_worldspace, directionalLight.color);
-        break;
-    }
+  if (lighting.enabled == 0) {
+    return lightColor;
   }
+
+  vec3 view_direction = normalize(cameraPosition - position_worldspace);
+
+  switch (lighting.lightType) {
+    case 0:
+      PointLight pointLight = lighting_getPointLight(0);
+      vec3 light_position_worldspace = pointLight.position;
+      vec3 light_direction = normalize(light_position_worldspace - position_worldspace);
+      lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.color);
+      break;
+
+    case 1:
+      DirectionalLight directionalLight = lighting_getDirectionalLight(0);
+      lightColor += lighting_getLightColor(surfaceColor, -directionalLight.direction, view_direction, normal_worldspace, directionalLight.color);
+      break;
+  }
+
   return lightColor;
 }
 `;

--- a/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-shaders-glsl.ts
+++ b/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-shaders-glsl.ts
@@ -11,15 +11,6 @@ uniform gouraudMaterialUniforms {
   uniform float shininess;
   uniform vec3  specularColor;
 } material;
-`;
-
-export const GOURAUD_FS = glsl`\
-uniform gouraudMaterialUniforms {
-  uniform float ambient;
-  uniform float diffuse;
-  uniform float shininess;
-  uniform vec3  specularColor;
-} material;
 
 vec3 lighting_getLightColor(vec3 surfaceColor, vec3 light_direction, vec3 view_direction, vec3 normal_worldspace, vec3 color) {
   vec3 halfway_direction = normalize(light_direction + view_direction);
@@ -100,6 +91,15 @@ vec3 lighting_getSpecularLightColor(vec3 cameraPosition, vec3 position_worldspac
 
   return lightColor;
 }
+`;
+
+export const GOURAUD_FS = glsl`\
+uniform gouraudMaterialUniforms {
+  uniform float ambient;
+  uniform float diffuse;
+  uniform float shininess;
+  uniform vec3  specularColor;
+} material;
 `;
 
 // TODO - handle multiple lights

--- a/modules/shadertools/src/modules/lighting/lights/lighting-uniforms-glsl.ts
+++ b/modules/shadertools/src/modules/lighting/lights/lighting-uniforms-glsl.ts
@@ -25,15 +25,16 @@ struct DirectionalLight {
 
 uniform lightingUniforms {
   int enabled;
-  int pointLightCount;
+  int lightType;
+
   int directionalLightCount;
+  int pointLightCount;
 
   vec3 ambientColor;
 
-  int lightType;
   vec3 lightColor;
-  vec3 lightDirection;
   vec3 lightPosition;
+  vec3 lightDirection;
   vec3 lightAttenuation;
 
   // AmbientLight ambientLight;

--- a/modules/shadertools/src/modules/lighting/lights/lighting-uniforms.ts
+++ b/modules/shadertools/src/modules/lighting/lights/lighting-uniforms.ts
@@ -58,7 +58,8 @@ export type LightingProps = {
 export type LightingUniforms = {
   enabled: number;
   ambientLightColor: Readonly<NumberArray3>;
-  numberOfLights: number;
+  directionalLightCount: number;
+  pointLightCount: number;
   lightType: number; // [];
   lightColor: Readonly<NumberArray3>; // [];
   lightPosition: Readonly<NumberArray3>; // [];
@@ -82,9 +83,12 @@ export const lighting: ShaderModule<LightingProps, LightingUniforms, {}> = {
 
   uniformTypes: {
     enabled: 'i32',
-    ambientLightColor: 'vec3<f32>',
-    numberOfLights: 'i32', // , array: MAX_LIGHTS,
     lightType: 'i32', // , array: MAX_LIGHTS,
+
+    directionalLightCount: 'i32', // , array: MAX_LIGHTS,
+    pointLightCount: 'i32', // , array: MAX_LIGHTS,
+
+    ambientLightColor: 'vec3<f32>',
     lightColor: 'vec3<f32>', // , array: MAX_LIGHTS,
     lightPosition: 'vec3<f32>', // , array: MAX_LIGHTS,
     // TODO - could combine direction and attenuation
@@ -94,9 +98,12 @@ export const lighting: ShaderModule<LightingProps, LightingUniforms, {}> = {
 
   defaultUniforms: {
     enabled: 1,
-    ambientLightColor: [0.1, 0.1, 0.1],
-    numberOfLights: 0,
     lightType: LIGHT_TYPE.POINT,
+
+    directionalLightCount: 0,
+    pointLightCount: 0,
+
+    ambientLightColor: [0.1, 0.1, 0.1],
     lightColor: [1, 1, 1],
     lightPosition: [1, 1, 2],
     // TODO - could combine direction and attenuation
@@ -187,7 +194,8 @@ function getLightSourceUniforms({
     currentLight++;
   }
 
-  lightSourceUniforms.numberOfLights = currentLight;
+  lightSourceUniforms.directionalLightCount = directionalLights.length;
+  lightSourceUniforms.pointLightCount = pointLights.length;
 
   return lightSourceUniforms;
 }

--- a/modules/shadertools/src/modules/lighting/phong-material/phong-material.ts
+++ b/modules/shadertools/src/modules/lighting/phong-material/phong-material.ts
@@ -18,7 +18,7 @@ export type PhongMaterialUniforms = {
 
 /** In Phong shading, the normal vector is linearly interpolated across the surface of the polygon from the polygon's vertex normals. */
 export const phongMaterial: ShaderModule<PhongMaterialProps, PhongMaterialUniforms> = {
-  name: 'phong-lighting',
+  name: 'phongMaterial',
   // Note these are switched between phong and gouraud
   vs: PHONG_VS,
   fs: PHONG_FS,

--- a/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-glsl.ts
+++ b/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-glsl.ts
@@ -80,21 +80,23 @@ vec3 lighting_getSpecularLightColor(vec3 cameraPosition, vec3 position_worldspac
   vec3 surfaceColor = vec3(0, 0, 0);
 
   if (lighting.enabled == 0) {
-    vec3 view_direction = normalize(cameraPosition - position_worldspace);
+    return lightColor;
+  }
 
-    switch (lighting.lightType) {
-      case 0:
-        PointLight pointLight = lighting_getPointLight(0);
-        vec3 light_position_worldspace = pointLight.position;
-        vec3 light_direction = normalize(light_position_worldspace - position_worldspace);
-        lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.color);
-        break;
+  vec3 view_direction = normalize(cameraPosition - position_worldspace);
 
-      case 1:
-        DirectionalLight directionalLight = lighting_getDirectionalLight(0);
-        lightColor += lighting_getLightColor(surfaceColor, -directionalLight.direction, view_direction, normal_worldspace, directionalLight.color);
-        break;
-    }
+  switch (lighting.lightType) {
+    case 0:
+      PointLight pointLight = lighting_getPointLight(0);
+      vec3 light_position_worldspace = pointLight.position;
+      vec3 light_direction = normalize(light_position_worldspace - position_worldspace);
+      lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.color);
+      break;
+
+    case 1:
+      DirectionalLight directionalLight = lighting_getDirectionalLight(0);
+      lightColor += lighting_getLightColor(surfaceColor, -directionalLight.direction, view_direction, normal_worldspace, directionalLight.color);
+      break;
   }
   return lightColor;
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/pull/9074

<!-- For all the PRs -->
#### Change List
- Rename modules to fit convention & UBO blocks
- Consistent use of early returns in shaders
- Correct order of props in `uniformTypes`
- Swap `GOURAUD_VS` and `GOURAUD_FS`
