### PR TITLE
fix: Framebuffer resize

### DIFF
--- a/examples/showcase/instancing/app.ts
+++ b/examples/showcase/instancing/app.ts
@@ -152,10 +152,10 @@ class InstancedCube extends Model {
     const pickingColors = new Uint8Array(SIDE * SIDE * 4);
     for (let i = 0; i < SIDE; i++) {
       for (let j = 0; j < SIDE; j++) {
-        pickingColors[(i * SIDE + j) * 2 + 0] = i;
-        pickingColors[(i * SIDE + j) * 2 + 1] = j;
-        pickingColors[(i * SIDE + j) * 2 + 2] = 0;
-        pickingColors[(i * SIDE + j) * 2 + 3] = 0;
+        pickingColors[(i * SIDE + j) * 4 + 0] = i;
+        pickingColors[(i * SIDE + j) * 4 + 1] = j;
+        pickingColors[(i * SIDE + j) * 4 + 2] = 0;
+        pickingColors[(i * SIDE + j) * 4 + 3] = 0;
       }
     }
 
@@ -339,7 +339,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       sourceWidth: 1,
       sourceHeight: 1
     });
-    // console.log(color255);
+    console.log(color255);
 
     let highlightedObjectColor = new Float32Array(color255).map(x => x / 255);
     const isHighlightActive =

--- a/examples/showcase/instancing/app.ts
+++ b/examples/showcase/instancing/app.ts
@@ -339,7 +339,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       sourceWidth: 1,
       sourceHeight: 1
     });
-    console.log(color255);
+    // console.log(color255);
 
     let highlightedObjectColor = new Float32Array(color255).map(x => x / 255);
     const isHighlightActive =

--- a/modules/core/src/adapter/resources/framebuffer.ts
+++ b/modules/core/src/adapter/resources/framebuffer.ts
@@ -143,6 +143,7 @@ export abstract class Framebuffer extends Resource<FramebufferProps> {
         this.destroyAttachedResource(this.colorAttachments[i]);
         this.colorAttachments[i] = resizedTexture.view;
         this.attachResource(resizedTexture.view);
+        this.updateColorAttachment(i, resizedTexture.view);
       }
     }
 
@@ -155,6 +156,12 @@ export abstract class Framebuffer extends Resource<FramebufferProps> {
       this.destroyAttachedResource(this.depthStencilAttachment);
       this.depthStencilAttachment = resizedTexture.view;
       this.attachResource(resizedTexture);
+      this.updateDepthStencilAttachment(resizedTexture.view);
     }
   }
+
+  /** Implementation is expected to update any underlying binding (WebGL framebuffer attachment) */
+  protected abstract updateColorAttachment(index: number, textureView: TextureView): void;
+  /** Implementation is expected to update any underlying binding (WebGL framebuffer attachment) */
+  protected abstract updateDepthStencilAttachment(textureView: TextureView): void;
 }

--- a/modules/core/src/adapter/resources/framebuffer.ts
+++ b/modules/core/src/adapter/resources/framebuffer.ts
@@ -143,7 +143,6 @@ export abstract class Framebuffer extends Resource<FramebufferProps> {
         this.destroyAttachedResource(this.colorAttachments[i]);
         this.colorAttachments[i] = resizedTexture.view;
         this.attachResource(resizedTexture.view);
-        this.updateColorAttachment(i, resizedTexture.view);
       }
     }
 
@@ -156,12 +155,11 @@ export abstract class Framebuffer extends Resource<FramebufferProps> {
       this.destroyAttachedResource(this.depthStencilAttachment);
       this.depthStencilAttachment = resizedTexture.view;
       this.attachResource(resizedTexture);
-      this.updateDepthStencilAttachment(resizedTexture.view);
     }
+
+    this.updateAttachments();
   }
 
   /** Implementation is expected to update any underlying binding (WebGL framebuffer attachment) */
-  protected abstract updateColorAttachment(index: number, textureView: TextureView): void;
-  /** Implementation is expected to update any underlying binding (WebGL framebuffer attachment) */
-  protected abstract updateDepthStencilAttachment(textureView: TextureView): void;
+  protected abstract updateAttachments(): void;
 }

--- a/modules/test-utils/src/null-device/resources/null-framebuffer.ts
+++ b/modules/test-utils/src/null-device/resources/null-framebuffer.ts
@@ -17,4 +17,8 @@ export class NullFramebuffer extends Framebuffer {
     super(device, props);
     this.device = device;
   }
+
+  protected override updateAttachments(): void {
+    // Null framebuffers are JS only objects, nothing to
+  }
 }

--- a/modules/webgpu/src/adapter/resources/webgpu-framebuffer.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-framebuffer.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {FramebufferProps} from '@luma.gl/core';
+import type {FramebufferProps, TextureView} from '@luma.gl/core';
 import {Framebuffer} from '@luma.gl/core';
 import {WebGPUDevice} from '../webgpu-device';
 import {WebGPUTextureView} from '../resources/webgpu-texture-view';
@@ -23,5 +23,13 @@ export class WebGPUFramebuffer extends Framebuffer {
 
     // Auto create textures for attachments if needed
     this.autoCreateAttachmentTextures();
+  }
+
+  protected updateColorAttachment(index: number, textureView: TextureView): void {
+    // WebGPU framebuffers are JS only objects, nothing to update
+  }
+
+  protected updateDepthStencilAttachment(textureView: TextureView): void {
+    // WebGPU framebuffers are JS only objects, nothing to update
   }
 }

--- a/modules/webgpu/src/adapter/resources/webgpu-framebuffer.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-framebuffer.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {FramebufferProps, TextureView} from '@luma.gl/core';
+import type {FramebufferProps} from '@luma.gl/core';
 import {Framebuffer} from '@luma.gl/core';
 import {WebGPUDevice} from '../webgpu-device';
 import {WebGPUTextureView} from '../resources/webgpu-texture-view';
@@ -25,11 +25,7 @@ export class WebGPUFramebuffer extends Framebuffer {
     this.autoCreateAttachmentTextures();
   }
 
-  protected updateColorAttachment(index: number, textureView: TextureView): void {
-    // WebGPU framebuffers are JS only objects, nothing to update
-  }
-
-  protected updateDepthStencilAttachment(textureView: TextureView): void {
+  protected updateAttachments(): void {
     // WebGPU framebuffers are JS only objects, nothing to update
   }
 }


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Fixes picking
#### Change List
- Update framebuffer bindings after framebuffer.resize
- 9.1 aligns with WebGPU and uses WebGL readonly textures, meaning that textures need to be destroyed and recreated on resize.
- After a new texture handle is created, the framebuffer attachment points were not updated.
