### PR TITLE
shadertools: Normalize specularColor

### DIFF
--- a/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-material.ts
+++ b/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-material.ts
@@ -42,6 +42,6 @@ export const gouraudMaterial: ShaderModule<GouraudMaterialProps> = {
     if (uniforms.specularColor) {
       uniforms.specularColor = uniforms.specularColor.map(x => x / 255) as NumberArray3;
     }
-    return {...gouraudMaterial.defaultUniforms, ...props};
+    return {...gouraudMaterial.defaultUniforms, ...uniforms};
   }
 };

--- a/modules/shadertools/src/modules/lighting/phong-material/phong-material.ts
+++ b/modules/shadertools/src/modules/lighting/phong-material/phong-material.ts
@@ -42,6 +42,6 @@ export const phongMaterial: ShaderModule<PhongMaterialProps> = {
     if (uniforms.specularColor) {
       uniforms.specularColor = uniforms.specularColor.map(x => x / 255) as NumberArray3;
     }
-    return {...phongMaterial.defaultUniforms, ...props};
+    return {...phongMaterial.defaultUniforms, ...uniforms};
   }
 };


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fix typo in https://github.com/visgl/luma.gl/pull/2169
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Actually normalize `specularColor`
