### PR TITLE
fix: luma8 sampler param compatibility

### DIFF
--- a/modules/core/src/adapter/resources/framebuffer.ts
+++ b/modules/core/src/adapter/resources/framebuffer.ts
@@ -112,7 +112,12 @@ export abstract class Framebuffer extends Resource<FramebufferProps> {
       usage: Texture.RENDER_ATTACHMENT,
       format,
       width: this.width,
-      height: this.height
+      height: this.height,
+      // TODO deprecated? - luma.gl v8 compatibility
+      sampler: {
+        magFilter: 'linear',
+        minFilter: 'linear'
+      }
     });
   }
 
@@ -123,7 +128,8 @@ export abstract class Framebuffer extends Resource<FramebufferProps> {
       usage: Texture.RENDER_ATTACHMENT,
       format,
       width: this.width,
-      height: this.height
+      height: this.height,
+      mipmaps: false
     });
   }
 

--- a/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
+++ b/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {FramebufferProps, TextureFormat} from '@luma.gl/core';
-import {Framebuffer, Texture} from '@luma.gl/core';
+import type {FramebufferProps} from '@luma.gl/core';
+import {Framebuffer} from '@luma.gl/core';
 import {GL} from '@luma.gl/constants';
 import {WebGLDevice} from '../webgl-device';
 import {WEBGLTexture} from './webgl-texture';

--- a/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
+++ b/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
@@ -91,16 +91,16 @@ export class WEBGLFramebuffer extends Framebuffer {
   // PRIVATE
 
   /** In WebGL we must use renderbuffers for depth/stencil attachments (unless we have extensions) */
-  protected override createDepthStencilTexture(format: TextureFormat): Texture {
-    // return new WEBGLRenderbuffer(this.device, {
-    return new WEBGLTexture(this.device, {
-      id: `${this.id}-depth-stencil`,
-      format,
-      width: this.width,
-      height: this.height,
-      mipmaps: false
-    });
-  }
+  // protected override createDepthStencilTexture(format: TextureFormat): Texture {
+  //   // return new WEBGLRenderbuffer(this.device, {
+  //   return new WEBGLTexture(this.device, {
+  //     id: `${this.id}-depth-stencil`,
+  //     format,
+  //     width: this.width,
+  //     height: this.height,
+  //     mipmaps: false
+  //   });
+  // }
 
   /**
    * @param attachment


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- In luma v8, textures autocreated by framebuffers have linear filtering
#### Change List
-
