### PR TITLE
Tex3d patch

### DIFF
--- a/examples/api/texture-3d/app.ts
+++ b/examples/api/texture-3d/app.ts
@@ -1,7 +1,7 @@
 // Ported from PicoGL.js example: https://tsherif.github.io/picogl.js/examples/3Dtexture.html
 
 import {makeRandomNumberGenerator, glsl} from '@luma.gl/core';
-import {AnimationLoopTemplate, AnimationProps, Model} from '@luma.gl/engine';
+import {AnimationLoopTemplate, AnimationProps, Geometry, Model} from '@luma.gl/engine';
 import {Matrix4, radians} from '@math.gl/core';
 import {perlin, lerp, shuffle, range} from './perlin';
 
@@ -81,8 +81,6 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       x += INCREMENT;
     }
 
-    const positionBuffer = device.createBuffer(positionData);
-
     // CREATE 3D TEXTURE
     const TEXTURE_DIMENSIONS = 16;
     const NOISE_DIMENSIONS = TEXTURE_DIMENSIONS * 0.07;
@@ -124,11 +122,16 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.cloud = new Model(device, {
       vs,
       fs,
-      topology: 'point-list',
-      vertexCount: positionData.length / 3,
-      attributes: {
-        position: positionBuffer
-      },
+      geometry: new Geometry({
+        topology: 'point-list',
+        vertexCount: positionData.length / 3,
+        attributes: {
+          position: {
+            value: positionData,
+            size: 3
+          }
+        }
+      }),
       bindings: {
         uTexture: texture
       },

--- a/examples/api/texture-3d/index.html
+++ b/examples/api/texture-3d/index.html
@@ -6,8 +6,9 @@
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
 
-  luma.registerDevices([WebGLDevice]);
-  makeAnimationLoop(AnimationLoopTemplate).start();
+  // luma.registerDevices([WebGLDevice]);
+  const device = WebGLDevice.create();
+  makeAnimationLoop(AnimationLoopTemplate, { device }).start();
 </script>
 <body>
 </body>

--- a/modules/webgl/src/adapter/resources/webgl-texture.ts
+++ b/modules/webgl/src/adapter/resources/webgl-texture.ts
@@ -311,7 +311,7 @@ export class WEBGLTexture extends Texture<WEBGLTextureProps> {
       width,
       height,
       depth,
-      format: glFormat,
+      format: props.format,
       type,
       dataFormat,
       // @ts-expect-error


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2115 
#### Change List
In `webgl-texture.ts`, `setImageData` was being called with `format: glFormat` which in the `'3d'` case would cause a problem.

There were also a couple of other changes that seemed to be necessary to get the example to work.