### PR TITLE
fix{engine): Model - do not bind uniform buffers for modules without uniforms…

### DIFF
--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -123,11 +123,6 @@ export class ShaderInputs<
     }
   }
 
-  /** Merges all bindings for the shader (from the various modules) */
-  // getUniformBlocks(): Record<string, Texture | Sampler> {
-  //   return this.moduleUniforms;
-  // }
-
   /**
    * Return the map of modules
    * @todo should should this include the resolved dependencies?
@@ -137,12 +132,12 @@ export class ShaderInputs<
   }
 
   /** Get all uniform values for all modules */
-  getUniformValues(): Record<keyof ShaderPropsT, Record<string, UniformValue>> {
+  getUniformValues(): Partial<Record<keyof ShaderPropsT, Record<string, UniformValue>>> {
     return this.moduleUniforms;
   }
 
   /** Merges all bindings for the shader (from the various modules) */
-  getBindings(): Record<string, Texture | Sampler> {
+  getBindingValues(): Record<string, Texture | Sampler> {
     const bindings = {} as Record<string, Texture | Sampler>;
     for (const moduleBindings of Object.values(this.moduleBindings)) {
       Object.assign(bindings, moduleBindings);
@@ -150,6 +145,7 @@ export class ShaderInputs<
     return bindings;
   }
 
+  /** Return a debug table that can be used for console.table() or log.table() */
   getDebugTable(): Record<string, Record<string, unknown>> {
     const table: Record<string, Record<string, unknown>> = {};
     for (const [moduleName, module] of Object.entries(this.moduleUniforms)) {

--- a/modules/engine/test/shader-inputs.spec.ts
+++ b/modules/engine/test/shader-inputs.spec.ts
@@ -120,7 +120,7 @@ test('ShaderInputs#bindings', t => {
     t.equal(shaderInputs.moduleBindings.custom.colorTexture, MOCK_TEXTURE, 'colorTexture updated');
 
     const uniformValues = shaderInputs.getUniformValues();
-    const bindings = shaderInputs.getBindings();
+    const bindings = shaderInputs.getBindingValues();
     t.deepEqual(uniformValues, {custom: {color: [255, 0, 0]}}, 'uniformValues correct');
     t.deepEqual(bindings, {colorTexture: 'MOCK_TEXTURE'}, 'bindings correct');
 

--- a/modules/shadertools/src/lib/shader-module/shader-module.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-module.ts
@@ -123,14 +123,14 @@ export function getShaderModuleUniforms<
   ShaderModuleT extends ShaderModule<Record<string, unknown>, Record<string, UniformValue>>
 >(
   module: ShaderModuleT,
-  props: ShaderModuleT['props'],
+  props?: ShaderModuleT['props'],
   oldUniforms?: ShaderModuleT['uniforms']
 ): Record<string, BindingValue | UniformValue> {
   initializeShaderModule(module);
 
   const uniforms = oldUniforms || {...module.defaultUniforms};
   // If module has a getUniforms function, use it
-  if (module.getUniforms) {
+  if (props && module.getUniforms) {
     return module.getUniforms(props, uniforms);
   }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Generates a lot of warnings in deck.gl for modules without uniforms like random etc.
#### Change List
- Filter out uniform buffers for modules without uniforms.
- Doesn't cover the case where a module is included but optimized out due to no usage.
