### PR TITLE
chore(core): DeviceProps.createCanvasContext: CanvasContextProps | true

### DIFF
--- a/docs/api-guide/gpu/gpu-initialization.md
+++ b/docs/api-guide/gpu/gpu-initialization.md
@@ -45,7 +45,7 @@ import {luma} from '@luma.gl/core';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 
 luma.registerAdapters([webgpuAdapter]);
-const device = await luma.createDevice({type: 'webgpu', canvasContext: {canvas: ...}});
+const device = await luma.createDevice({type: 'webgpu', createCanvasContext: {canvas: ...}});
 ```
 
 It is possible to register more than one device adapter to create an application
@@ -65,5 +65,5 @@ import {WebGPUDevice} from '@luma.gl/webgpu';
 
 luma.registerAdapters([WebGLDevice, WebGPUDevice]);
 
-const webgpuDevice = luma.createDevice({type: 'best-available', canvasContext: {canvas: ...}});
+const webgpuDevice = luma.createDevice({type: 'best-available', createCanvasContext true});
 ```

--- a/docs/api-reference/core/README.md
+++ b/docs/api-reference/core/README.md
@@ -14,7 +14,7 @@ import {luma} from '@luma.gl/core';
 import {WebGPUAdapter} from '@luma.gl/webgpu';
 
 luma.registerDevice([WebGPUAdapter])
-const device = await luma.createDevice({type: 'webgpu', canvasContext: ...});
+const device = await luma.createDevice({type: 'webgpu', createCanvasContext: ...});
 ```
 
 It is possible to register more than one device adapter to create an application
@@ -26,7 +26,7 @@ import {luma} from '@luma.gl/core';
 import {WebGPUAdapter} from '@luma.gl/webgpu';
 import {WebGLAdapter} '@luma.gl/webgl';
 
-const webgpuDevice = luma.createDevice({type: 'best-available', canvasContext: ...});
+const webgpuDevice = luma.createDevice({type: 'best-available', createCanvasContext: ...});
 ```
 
 ## Creating GPU Resources

--- a/docs/api-reference/core/device.md
+++ b/docs/api-reference/core/device.md
@@ -61,17 +61,17 @@ This object can also include all [`CanvasContextProps`][canvas-context-props] pr
 
 Specifies props to use when luma creates the device.
 
-| Parameter                                           | Default                                      | Description                                                                                |
-| --------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `id?: string`                                       | `null`                                       | Optional string id, mainly intended for debugging.                                         |
-| `canvasContext?: CanvasContextProps`                | [CanvasContexProps][canvas-context-props]    | Props used to create the default `CanvasContext` for the new `Device`.                     |
-| `onError?: (error: Error) => unknown`               | `log.error`                                  | Error handling.                                                                            |
-| `powerPreference?: string`                          | `'high-performance'`                         | `'default' \| 'high-performance' \| 'low-power'` (WebGL).                                  |
-| `webgl?: WebGLContextAttributes`                    | [`WebGLContextAttributes`][webgl-attributes] | Attributes passed on to WebGL (`canvas.getContext('webgl2', props.webgl)`                  |
-| `_requestMaxLimits?: boolean`                        | `true`                                       | Ensures that the Device exposes the highest `DeviceLimits` supported by platform (WebGPU). |
-| `_initializeFeatures?: boolean`                      | `true`                                       | Initialize all `DeviceFeatures` on startup. 🧪                                              |
-| `_disabledFeatures?: Record<DeviceFeature, boolean>` | `{ 'compilation-status-async-webgl': true }` | Disable specific `DeviceFeatures`. 🧪                                                       |
-| `_factoryDestroyPolicy?: string`                    | `'unused'`                                   | `'unused' \| 'never'` Never destroy cached shaders and pipelines. 🧪                        |
+| Parameter                                            | Default                                      | Description                                                                                                                                            |
+| ---------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `id?: string`                                        | `null`                                       | Optional string id, mainly intended for debugging.                                                                                                     |
+| `createCanvasContext?: CanvasContextProps` \| `true` | [CanvasContexProps][canvas-context-props]    | Props used to create the default `CanvasContext` for the new `Device`. `true` or `{}` uses default settings. |
+| `onError?: (error: Error) => unknown`                | `log.error`                                  | Error handling.                                                                                                                                        |
+| `powerPreference?: string`                           | `'high-performance'`                         | `'default' \| 'high-performance' \| 'low-power'` (WebGL).                                                                                              |
+| `webgl?: WebGLContextAttributes`                     | [`WebGLContextAttributes`][webgl-attributes] | Attributes passed on to WebGL (`canvas.getContext('webgl2', props.webgl)`                                                                              |
+| `_requestMaxLimits?: boolean`                        | `true`                                       | Ensures that the Device exposes the highest `DeviceLimits` supported by platform (WebGPU).                                                             |
+| `_initializeFeatures?: boolean`                      | `true`                                       | Initialize all `DeviceFeatures` on startup. 🧪                                                                                                          |
+| `_disabledFeatures?: Record<DeviceFeature, boolean>` | `{ 'compilation-status-async-webgl': true }` | Disable specific `DeviceFeatures`. 🧪                                                                                                                   |
+| `_factoryDestroyPolicy?: string`                     | `'unused'`                                   | `'unused' \| 'never'` Never destroy cached shaders and pipelines. 🧪                                                                                    |
 
 :::caution
 🧪 denotes experimental feature. Expect API to change.

--- a/docs/api-reference/core/device.md
+++ b/docs/api-reference/core/device.md
@@ -61,17 +61,17 @@ This object can also include all [`CanvasContextProps`][canvas-context-props] pr
 
 Specifies props to use when luma creates the device.
 
-| Parameter                                            | Default                                      | Description                                                                                                                                            |
-| ---------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `id?: string`                                        | `null`                                       | Optional string id, mainly intended for debugging.                                                                                                     |
-| `createCanvasContext?: CanvasContextProps` \| `true` | [CanvasContexProps][canvas-context-props]    | Props used to create the default `CanvasContext` for the new `Device`. `true` or `{}` uses default settings. |
-| `onError?: (error: Error) => unknown`                | `log.error`                                  | Error handling.                                                                                                                                        |
-| `powerPreference?: string`                           | `'high-performance'`                         | `'default' \| 'high-performance' \| 'low-power'` (WebGL).                                                                                              |
-| `webgl?: WebGLContextAttributes`                     | [`WebGLContextAttributes`][webgl-attributes] | Attributes passed on to WebGL (`canvas.getContext('webgl2', props.webgl)`                                                                              |
-| `_requestMaxLimits?: boolean`                        | `true`                                       | Ensures that the Device exposes the highest `DeviceLimits` supported by platform (WebGPU).                                                             |
-| `_initializeFeatures?: boolean`                      | `true`                                       | Initialize all `DeviceFeatures` on startup. 🧪                                                                                                          |
-| `_disabledFeatures?: Record<DeviceFeature, boolean>` | `{ 'compilation-status-async-webgl': true }` | Disable specific `DeviceFeatures`. 🧪                                                                                                                   |
-| `_factoryDestroyPolicy?: string`                     | `'unused'`                                   | `'unused' \| 'never'` Never destroy cached shaders and pipelines. 🧪                                                                                    |
+| Parameter                                            | Default                                      | Description                                                                                                          |
+| ---------------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `id?: string`                                        | `null`                                       | Optional string id, mainly intended for debugging.                                                                   |
+| `createCanvasContext?: CanvasContextProps` \| `true` | [CanvasContexProps][canvas-context-props]    | Props used to create the default `CanvasContext` for the new `Device`. `true` or `{}` creates a context with default props. |
+| `onError?: (error: Error) => unknown`                | `log.error`                                  | Error handling.                                                                                                      |
+| `powerPreference?: string`                           | `'high-performance'`                         | `'default' \| 'high-performance' \| 'low-power'` (WebGL).                                                            |
+| `webgl?: WebGLContextAttributes`                     | [`WebGLContextAttributes`][webgl-attributes] | Attributes passed on to WebGL (`canvas.getContext('webgl2', props.webgl)`                                            |
+| `_requestMaxLimits?: boolean`                        | `true`                                       | Ensures that the Device exposes the highest `DeviceLimits` supported by platform (WebGPU).                           |
+| `_initializeFeatures?: boolean`                      | `true`                                       | Initialize all `DeviceFeatures` on startup. 🧪                                                                        |
+| `_disabledFeatures?: Record<DeviceFeature, boolean>` | `{ 'compilation-status-async-webgl': true }` | Disable specific `DeviceFeatures`. 🧪                                                                                 |
+| `_factoryDestroyPolicy?: string`                     | `'unused'`                                   | `'unused' \| 'never'` Never destroy cached shaders and pipelines. 🧪                                                  |
 
 :::caution
 🧪 denotes experimental feature. Expect API to change.
@@ -286,17 +286,16 @@ Creates a new [`CanvasContext`](./canvas-context).
 WebGPU only. WebGL devices can only render into the canvas they were created with.
 :::
 
-### getCanvasContext()
+### getDefaultCanvasContext()
 
 ```typescript
-getCanvasContext(): CanvasContext
+getDefaultCanvasContext(): CanvasContext
 ```
 
-- Returns the primary canvas context of a device.
+- Returns the primary / default canvas context of a device.
 - Throws an error if no canvas context is available (a WebGPU compute device).
 
-In TypeScript applications this helps applications avoid having to repeatedly check if `device.canvasContext` is null,
-otherwise the two are equivalent.
+In TypeScript applications this helps applications avoid having to repeatedly check if `device.canvasContext` is null, otherwise the two are equivalent.
 
 ### submit
 

--- a/docs/api-reference/core/luma.md
+++ b/docs/api-reference/core/luma.md
@@ -22,13 +22,13 @@ Create a WebGL 2 context (throws if WebGL2 not supported)
 import {luma} from '@luma.gl/core';
 import {webgl2Adapter} from '@luma.gl/webgl';
 
-const webgpuDevice = luma.createDevice({type: 'webgl', adapters: [webgl2Adapter], canvasContext: {canvas: ...}});
+const webgpuDevice = luma.createDevice({type: 'webgl', adapters: [webgl2Adapter], createCanvasContext: true});
 ```
 
 ```typescript
 const webgpuDevice = luma.createDevice({
   type: 'best-available', 
-  canvasContext: {...}, 
+  createCanvasContext: true, 
   adapters: [webgl2Adapter, WebGPUDevice]
 });
 ```
@@ -41,7 +41,7 @@ Register the WebGL backend, then create a WebGL2 context, auto creating a canvas
 import {luma} from '@luma.gl/core';
 import {webgl2Adapter} from '@luma.gl/webgl';
 luma.registerAdapters([webgl2Adapter]);
-const webglDevice = luma.createDevice({type: 'webgl', canvasContext: {canvas: ...}});
+const webglDevice = luma.createDevice({type: 'webgl', createCanvasContext: {canvas: ...}});
 ```
 
 It is possible to register more than one device to create an application
@@ -52,7 +52,7 @@ import {luma} from '@luma.gl/core';
 import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuDevice} from '@luma.gl/webgl';
 luma.registerAdapters([webgl2Adapter, webgpuDevice]);
-const device = luma.createDevice({type: 'best-available', canvasContext: {canvas: ...}});
+const device = luma.createDevice({type: 'best-available', createCanvasContext: {canvas: ...}});
 ```
 
 ## Registering Adapters
@@ -72,7 +72,7 @@ import {luma} from '@luma.gl/core';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 
 luma.registerAdapters([webgpuAdapter]);
-const device = await luma.createDevice({type: 'webgpu', canvasContext: ...});
+const device = await luma.createDevice({type: 'webgpu', createCanvasContext: ...});
 ```
 
 Pre-register devices
@@ -83,7 +83,7 @@ import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 
 luma.registerAdapters([webgl2Adapter, webgpuAdapter]);
-const webgpuDevice = luma.createDevice({type: 'best-available', canvasContext: ...});
+const webgpuDevice = luma.createDevice({type: 'best-available', createCanvasContext: ...});
 ```
 
 ## Types

--- a/docs/api-reference/webgl/README.md
+++ b/docs/api-reference/webgl/README.md
@@ -11,7 +11,7 @@ be created using `luma.createDevice(props)`. See [`CreateDeviceProps`](../core/l
 import {luma} from '@luma.gl/core';
 import {webgl2Adapter}'@luma.gl/webgl';
 
-const device = await luma.createDevice({adapters: [webgl2Adapter], canvasContext: {width: 800: height: 600}});
+const device = await luma.createDevice({adapters: [webgl2Adapter], createCanvasContext: {width: 800: height: 600}});
 
 // Resources can now be created
 const buffer = device.createBuffer(...);

--- a/docs/api-reference/webgpu/README.md
+++ b/docs/api-reference/webgpu/README.md
@@ -11,7 +11,7 @@ be created using `luma.createDevice(props)`: See [`CreateDeviceProps`](../core/l
 import {luma} from '@luma.gl/core';
 import {webgpuAdapter}'@luma.gl/webgpu'; // Installs the WebGPUDevice adapter
 
-const device = await luma.createDevice({adapters: [webgpuAdapter], canvasContext: {width: 800, height: 600}});
+const device = await luma.createDevice({adapters: [webgpuAdapter], createCanvasContext: {width: 800, height: 600}});
 
 // Resources can now be created
 const buffer = device.createBuffer(...);

--- a/docs/developer-guide/installing.md
+++ b/docs/developer-guide/installing.md
@@ -22,9 +22,9 @@ yarn add @luma.gl/webgpu
 
 ```typescript
 import {luma} from '@luma.gl/core';
-import '@luma.gl/webgpu';
+import {webgl2Adapter} '@luma.gl/webgpu';
 
-const device = await luma.createDevice({type: 'webgpu', canvasContext: ...});
+const device = await luma.createDevice({type: 'webgpu', adapters: [webgl2Adapter], createCanvasContext: ...});
 ```
 
 It is possible to register more than one device adapter to create an application
@@ -32,10 +32,10 @@ that can work in both WebGL and WebGPU environments.
 
 ```typescript
 import {luma} from '@luma.gl/core';
-import '@luma.gl/webgpu';
-import '@luma.gl/webgl';
+import {webgl2Adapter} '@luma.gl/webgpu';
+import {webgpuAdapter} '@luma.gl/webgl';
 
-const webgpuDevice = luma.createDevice({type: 'best-available', canvasContext: ...});
+const webgpuDevice = luma.createDevice({type: 'best-available', adapters: [webgl2Adapter, webgpuAdapter], createCanvasContext: ...});
 ```
 
 ## A Typical Install

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -38,7 +38,6 @@ When initializing luma.gl, applications now import an `Adapter` singleton from e
 | `luma.registerDevices()`       | Deprecated | [`luma.registerAdapters()`][adapters].    | Adapters provide a cleaner way to work with GPU backends.       |
 | `DeviceProps` for canvas       | Moved      | [`DeviceProps.canvasContext...`][canvas]. | Move canvas related props to `props.createCanvasContext: {}`.         |
 | `DeviceProps` for webgl        | Moved      | [`DeviceProps.webgl`][webgl].             | Move canvas related props to `props.webgl: {}`.                 |
->>>>>>> 57e9105eb (chore(core): DeviceProps.createCanvasContext: CanvasContextProps | true)
 | `Texture.props.data` (Promise) | Removed    | `AsyncTexture` class                      | Textures no longer accept promises.                             |
 | `Parameters.blend`             | New        |                                           | Explicit activation of color blending                           |
 | `triangle-fan-webgl` topology  | Removed    | `triangle-strip`.                         | Reorganize your geometries                                      |

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -36,7 +36,7 @@ When initializing luma.gl, applications now import an `Adapter` singleton from e
 | Updated API                    | Status     | Replacement                               | Comment                                                         |
 | ------------------------------ | ---------- | ----------------------------------------- | --------------------------------------------------------------- |
 | `luma.registerDevices()`       | Deprecated | [`luma.registerAdapters()`][adapters].    | Adapters provide a cleaner way to work with GPU backends.       |
-| `DeviceProps` for canvas       | Moved      | [`DeviceProps.canvasContext...`][canvas]. | Move canvas related props to `props.createCanvasContext: {}`.         |
+| `DeviceProps` for canvas       | Moved      | [`DeviceProps.canvasContextContext`][canvas]. | Move canvas related props to `props.createCanvasContext: {}`.         |
 | `DeviceProps` for webgl        | Moved      | [`DeviceProps.webgl`][webgl].             | Move canvas related props to `props.webgl: {}`.                 |
 | `Texture.props.data` (Promise) | Removed    | `AsyncTexture` class                      | Textures no longer accept promises.                             |
 | `Parameters.blend`             | New        |                                           | Explicit activation of color blending                           |

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -33,19 +33,20 @@ When initializing luma.gl, applications now import an `Adapter` singleton from e
 
 **@luma.gl/core**
 
-| Updated API                    | Status     | Replacement                               | Comment                                                         |
-| ------------------------------ | ---------- | ----------------------------------------- | --------------------------------------------------------------- |
-| `luma.registerDevices()`       | Deprecated | [`luma.registerAdapters()`][adapters].    | Adapters provide a cleaner way to work with GPU backends.       |
-| `DeviceProps` for canvas       | Moved      | [`DeviceProps.canvasContextContext`][canvas]. | Move canvas related props to `props.createCanvasContext: {}`.         |
-| `DeviceProps` for webgl        | Moved      | [`DeviceProps.webgl`][webgl].             | Move canvas related props to `props.webgl: {}`.                 |
-| `Texture.props.data` (Promise) | Removed    | `AsyncTexture` class                      | Textures no longer accept promises.                             |
-| `Parameters.blend`             | New        |                                           | Explicit activation of color blending                           |
-| `triangle-fan-webgl` topology  | Removed    | `triangle-strip`.                         | Reorganize your geometries                                      |
-| `line-loop-webgl` topology     | Removed    | `line-list`.                              | Reorganize your geometries                                      |
-| `glsl` shader template string  | Removed    | `/* glsl */` comment                      | Enable syntax highlighting in vscode using before shader string |
-| `depth24unorm-stencil8`        | Removed    | `depth24plus-stencil8`                    | The `TextureFormat` was removed from the WebGPU spec            |
-| `rgb8unorm-unsized`            | Removed    | `rgb8unorm`                               | No longer support unsized WebGL1 `TextureFormat`                |
-| `rgba8unorm-unsized`           | Removed    | `rgb8aunorm`                              | No longer support unsized WebGL1 `TextureFormat`                |
+| Updated API                    | Status     | Replacement                                  | Comment                                                         |
+| ------------------------------ | ---------- | -------------------------------------------- | --------------------------------------------------------------- |
+| `luma.registerDevices()`       | Deprecated | [`luma.registerAdapters()`][adapters].       | Adapters provide a cleaner way to work with GPU backends.       |
+| `DeviceProps` for canvas       | Moved      | [`DeviceProps.createCanvasContext`][canvas]. | Move canvas related props to `props.createCanvasContext: {}`.   |
+| `DeviceProps` for webgl        | Moved      | [`DeviceProps.webgl`][webgl].                | Move canvas related props to `props.webgl: {}`.                 |
+| `DeviceProps.break`            | Removed    |                                              | Use an alterative [debugger][debugging]                         |
+| `Texture.props.data` (Promise) | Removed    | `AsyncTexture` class                         | Textures no longer accept promises.                             |
+| `Parameters.blend`             | New        |                                              | Explicit activation of color blending                           |
+| `triangle-fan-webgl` topology  | Removed    | `triangle-strip`.                            | Reorganize your geometries                                      |
+| `line-loop-webgl` topology     | Removed    | `line-list`.                                 | Reorganize your geometries                                      |
+| `glsl` shader template string  | Removed    | `/* glsl */` comment                         | Enable syntax highlighting in vscode using before shader string |
+| `depth24unorm-stencil8`        | Removed    | `depth24plus-stencil8`                       | The `TextureFormat` was removed from the WebGPU spec            |
+| `rgb8unorm-unsized`            | Removed    | `rgb8unorm`                                  | No longer support unsized WebGL1 `TextureFormat`                |
+| `rgba8unorm-unsized`           | Removed    | `rgb8aunorm`                                 | No longer support unsized WebGL1 `TextureFormat`                |
 
 [adapters]: /docs/api-reference/core/luma#lumaregisteradapters
 [canvas]: /docs/api-reference/core/canvas-context#canvascontextprops

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -36,9 +36,9 @@ When initializing luma.gl, applications now import an `Adapter` singleton from e
 | Updated API                    | Status     | Replacement                               | Comment                                                         |
 | ------------------------------ | ---------- | ----------------------------------------- | --------------------------------------------------------------- |
 | `luma.registerDevices()`       | Deprecated | [`luma.registerAdapters()`][adapters].    | Adapters provide a cleaner way to work with GPU backends.       |
-| `DeviceProps` for canvas       | Moved      | [`DeviceProps.canvasContext`][canvas].    | Move canvas related props to `props.canvasContext: {}`.         |
+| `DeviceProps` for canvas       | Moved      | [`DeviceProps.canvasContext...`][canvas]. | Move canvas related props to `props.createCanvasContext: {}`.         |
 | `DeviceProps` for webgl        | Moved      | [`DeviceProps.webgl`][webgl].             | Move canvas related props to `props.webgl: {}`.                 |
-| `DeviceProps.break`            | Removed    |                                           | Use an alterative [debugger][debugging]                         |
+>>>>>>> 57e9105eb (chore(core): DeviceProps.createCanvasContext: CanvasContextProps | true)
 | `Texture.props.data` (Promise) | Removed    | `AsyncTexture` class                      | Textures no longer accept promises.                             |
 | `Parameters.blend`             | New        |                                           | Explicit activation of color blending                           |
 | `triangle-fan-webgl` topology  | Removed    | `triangle-strip`.                         | Reorganize your geometries                                      |

--- a/examples/showcase/instancing/app.ts
+++ b/examples/showcase/instancing/app.ts
@@ -5,7 +5,7 @@
 import type {ShaderUniformType, NumberArray} from '@luma.gl/core';
 import {Device} from '@luma.gl/core';
 import type {AnimationProps, ModelProps} from '@luma.gl/engine';
-// @ts-expect-error
+// @ts-ignore - ib added this to solve module resolution mess
 import {AnimationLoopTemplate, CubeGeometry, Timeline, Model, ShaderInputs} from '@luma.gl/engine';
 // @ts-ignore TODO - ib added this to solve module resolution mess
 import {makeRandomGenerator, _PickingManager as PickingManager} from '@luma.gl/engine';

--- a/examples/showcase/instancing/app.ts
+++ b/examples/showcase/instancing/app.ts
@@ -5,6 +5,7 @@
 import type {ShaderUniformType, NumberArray} from '@luma.gl/core';
 import {Device} from '@luma.gl/core';
 import type {AnimationProps, ModelProps} from '@luma.gl/engine';
+// @ts-expect-error
 import {AnimationLoopTemplate, CubeGeometry, Timeline, Model, ShaderInputs} from '@luma.gl/engine';
 // @ts-ignore TODO - ib added this to solve module resolution mess
 import {makeRandomGenerator, _PickingManager as PickingManager} from '@luma.gl/engine';

--- a/examples/showcase/instancing/index.html
+++ b/examples/showcase/instancing/index.html
@@ -4,7 +4,7 @@
   import {webgl2Adapter} from '@luma.gl/webgl';
   import {webgpuAdapter} from '@luma.gl/webgpu';
   import AnimationLoopTemplate from './app.ts';
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [/* webgpuAdapter, */ webgl2Adapter]})
+  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]})
   animationLoop.start();
 </script>
 <body>

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -373,7 +373,7 @@ export abstract class Device {
   /** Returns the default / primary canvas context. Throws an error if no canvas context is available (a WebGPU compute device) */
   getDefaultCanvasContext(): CanvasContext {
     if (!this.canvasContext) {
-      throw new Error('Device has no default CanvasContext');
+      throw new Error('Device has no default CanvasContext. See props.createCanvasContext');
     }
     return this.canvasContext;
   }

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -196,8 +196,8 @@ type WebGLCompressedTextureFeatures =
 export type DeviceProps = {
   /** string id for debugging. Stored on the object, used in logging and set on underlying GPU objects when feasible. */
   id?: string;
-  /** Properties for the default canvas context */
-  canvasContext?: CanvasContextProps;
+  /** Properties for creating a default canvas context */
+  createCanvasContext?: CanvasContextProps | true;
   /** Control which type of GPU is preferred on systems with both integrated and discrete GPU. Defaults to "high-performance" / discrete GPU. */
   powerPreference?: 'default' | 'high-performance' | 'low-power';
   /** Hints that device creation should fail if no hardware GPU is available (if the system performance is "low"). */
@@ -267,7 +267,7 @@ export abstract class Device {
     id: null!,
     powerPreference: 'high-performance',
     failIfMajorPerformanceCaveat: false,
-    canvasContext: undefined!,
+    createCanvasContext: undefined!,
 
     // Callbacks
     onError: (error: Error) => log.error(error.message),
@@ -312,6 +312,8 @@ export abstract class Device {
   userData: {[key: string]: unknown} = {};
   /** stats */
   readonly statsManager: StatsManager = lumaStats;
+  /** An abstract timestamp used for change tracking */
+  timestamp: number = 0;
 
   /** Used by other luma.gl modules to store data on the device */
   _lumaData: {[key: string]: unknown} = {};
@@ -369,9 +371,9 @@ export abstract class Device {
   abstract canvasContext: CanvasContext | null;
 
   /** Returns the default / primary canvas context. Throws an error if no canvas context is available (a WebGPU compute device) */
-  getCanvasContext(): CanvasContext {
+  getDefaultCanvasContext(): CanvasContext {
     if (!this.canvasContext) {
-      throw new Error('Device has no CanvasContext');
+      throw new Error('Device has no default CanvasContext');
     }
     return this.canvasContext;
   }
@@ -424,6 +426,25 @@ export abstract class Device {
 
   createCommandEncoder(props: CommandEncoderProps = {}): CommandEncoder {
     throw new Error('not implemented');
+  }
+
+  /** A monotonic counter for tracking buffer and texture updates */
+  incrementTimestamp(): number {
+    return this.timestamp++;
+  }
+
+  // Error Handling
+
+  /** Report unhandled device errors */
+  onError(error: Error) {
+    this.props.onError(error);
+  }
+
+  // DEPRECATED METHODS
+
+  /** @deprecated Use getDefaultCanvasContext() */
+  getCanvasContext(): CanvasContext {
+    return this.getDefaultCanvasContext();
   }
 
   // WebGL specific HACKS - enables app to remove webgl import
@@ -490,23 +511,10 @@ export abstract class Device {
     throw new Error('not implemented');
   }
 
-  timestamp: number = 0;
-
-  /** A monotonic counter for tracking buffer and texture updates */
-  incrementTimestamp(): number {
-    return this.timestamp++;
-  }
-
-  // Error Handling
-
-  /** Report unhandled device errors */
-  onError(error: Error) {
-    this.props.onError(error);
-  }
-
   // IMPLEMENTATION
 
-  protected _getBufferProps(props: BufferProps | ArrayBuffer | ArrayBufferView): BufferProps {
+  /** Subclasses use this to support .createBuffer() overloads */
+  protected _normalizeBufferProps(props: BufferProps | ArrayBuffer | ArrayBufferView): BufferProps {
     if (props instanceof ArrayBuffer || ArrayBuffer.isView(props)) {
       props = {data: props};
     }

--- a/modules/engine/src/animation-loop/make-animation-loop.ts
+++ b/modules/engine/src/animation-loop/make-animation-loop.ts
@@ -23,7 +23,8 @@ export function makeAnimationLoop(
   let renderLoop: AnimationLoopTemplate | null = null;
 
   const device =
-    props?.device || luma.createDevice({id: 'animation-loop', adapters: props?.adapters});
+    props?.device ||
+    luma.createDevice({id: 'animation-loop', adapters: props?.adapters, createCanvasContext: true});
 
   // Create an animation loop;
   const animationLoop = new AnimationLoop({

--- a/modules/test-utils/src/create-test-device.ts
+++ b/modules/test-utils/src/create-test-device.ts
@@ -16,7 +16,7 @@ const DEFAULT_CANVAS_CONTEXT_PROPS: CanvasContextProps = {
 export function createTestDevice(): WebGLDevice | null {
   try {
     // TODO - We do not use luma.createDevice since createTestDevice currently expect WebGL context to be created synchronously
-    return new WebGLDevice({canvasContext: DEFAULT_CANVAS_CONTEXT_PROPS, debugWebGL: true});
+    return new WebGLDevice({createCanvasContext: DEFAULT_CANVAS_CONTEXT_PROPS, debugWebGL: true});
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(`Failed to created device: ${(error as Error).message}`);
@@ -45,7 +45,7 @@ export async function getTestDevices(type?: 'webgl' | 'webgpu'): Promise<Device[
         id: 'webgpu-test-device',
         type: 'webgpu',
         adapters: [webgpuAdapter],
-        canvasContext: DEFAULT_CANVAS_CONTEXT_PROPS
+        createCanvasContext: DEFAULT_CANVAS_CONTEXT_PROPS
       })) as WebGPUDevice;
     } catch (error) {
       log.error(String(error))();
@@ -55,7 +55,7 @@ export async function getTestDevices(type?: 'webgl' | 'webgpu'): Promise<Device[
         id: 'webgl-test-device',
         type: 'webgl',
         adapters: [webgl2Adapter],
-        canvasContext: DEFAULT_CANVAS_CONTEXT_PROPS,
+        createCanvasContext: DEFAULT_CANVAS_CONTEXT_PROPS,
         debugWebGL: true
       })) as WebGLDevice;
     } catch (error) {

--- a/modules/test-utils/src/null-device/null-adapter.ts
+++ b/modules/test-utils/src/null-device/null-adapter.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Adapter, DeviceProps, CanvasContext} from '@luma.gl/core';
+import {Adapter, DeviceProps} from '@luma.gl/core';
 import {NullDevice} from './null-device';
 
 export class NullAdapter extends Adapter {
@@ -25,12 +25,6 @@ export class NullAdapter extends Adapter {
   }
 
   async create(props: DeviceProps = {}): Promise<NullDevice> {
-    // Wait for page to load: if canvas is a string we need to query the DOM for the canvas element.
-    // We only wait when props.canvas is string to avoids setting the global page onload callback unless necessary.
-    if (typeof props.canvasContext?.canvas === 'string') {
-      await CanvasContext.pageLoaded;
-    }
-
     return new NullDevice(props);
   }
 }

--- a/modules/test-utils/src/null-device/null-device.ts
+++ b/modules/test-utils/src/null-device/null-device.ts
@@ -58,7 +58,8 @@ export class NullDevice extends Device {
   constructor(props: DeviceProps) {
     super({...props, id: props.id || 'null-device'});
 
-    this.canvasContext = new NullCanvasContext(this, props.canvasContext);
+    const canvasContextProps = props.createCanvasContext === true ? {} : props.createCanvasContext;
+    this.canvasContext = new NullCanvasContext(this, canvasContextProps);
     this.lost = new Promise(resolve => {});
     this.canvasContext.resize();
   }
@@ -92,7 +93,7 @@ export class NullDevice extends Device {
   }
 
   createBuffer(props: BufferProps | ArrayBuffer | ArrayBufferView): NullBuffer {
-    const newProps = this._getBufferProps(props);
+    const newProps = this._normalizeBufferProps(props);
     return new NullBuffer(this, newProps);
   }
 

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Adapter, Device, DeviceProps, CanvasContext, log} from '@luma.gl/core';
+import {Adapter, Device, DeviceProps, log} from '@luma.gl/core';
 import {WebGLDevice} from './webgl-device';
 import {enforceWebGL2} from '../context/polyfills/polyfill-webgl1-extensions';
 import {loadSpectorJS, DEFAULT_SPECTOR_PROPS} from '../context/debug/spector';
@@ -69,12 +69,6 @@ export class WebGLAdapter extends Adapter {
       promises.push(loadSpectorJS(props));
     }
 
-    // Wait for page to load: if canvas is a string we need to query the DOM for the canvas element.
-    // We only wait when props.canvas is string to avoids setting the global page onload callback unless necessary.
-    if (typeof props.canvasContext?.canvas === 'string') {
-      promises.push(CanvasContext.pageLoaded);
-    }
-
     // Wait for all the loads to settle before creating the context.
     // The Device.create() functions are async, so in contrast to the constructor, we can `await` here.
     const results = await Promise.allSettled(promises);
@@ -83,8 +77,6 @@ export class WebGLAdapter extends Adapter {
         log.error(`Failed to initialize debug libraries ${result.reason}`)();
       }
     }
-
-    log.probe(LOG_LEVEL + 1, 'DOM is loaded')();
 
     const device = new WebGLDevice(props);
 

--- a/modules/webgl/test/adapter/webgl-device.spec.ts
+++ b/modules/webgl/test/adapter/webgl-device.spec.ts
@@ -7,7 +7,7 @@ import {webglDevice} from '@luma.gl/test-utils';
 import {webgl2Adapter} from '@luma.gl/webgl';
 
 test('WebGLDevice#lost (Promise)', async t => {
-  const device = await webgl2Adapter.create();
+  const device = await webgl2Adapter.create({createCanvasContext: true});
 
   // Wrap in a promise to make sure tape waits for us
   await new Promise<void>(async resolve => {

--- a/modules/webgpu/src/adapter/webgpu-adapter.ts
+++ b/modules/webgpu/src/adapter/webgpu-adapter.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Adapter, DeviceProps, CanvasContext, log} from '@luma.gl/core';
+import {Adapter, DeviceProps, log} from '@luma.gl/core';
 import {WebGPUDevice} from './webgpu-device';
 
 // / <reference types="@webgpu/types" />
@@ -68,11 +68,6 @@ export class WebGPUAdapter extends Adapter {
     });
 
     log.probe(1, 'GPUDevice available')();
-
-    if (typeof props.canvasContext?.canvas === 'string') {
-      await CanvasContext.pageLoaded;
-      log.probe(1, 'DOM is loaded')();
-    }
 
     const device = new WebGPUDevice(props, gpuDevice, adapter, adapterInfo);
 

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -101,8 +101,10 @@ export class WebGPUDevice extends Device {
     });
 
     // Note: WebGPU devices can be created without a canvas, for compute shader purposes
-    if (props.canvasContext) {
-      this.canvasContext = new WebGPUCanvasContext(this, this.adapter, props.canvasContext);
+    if (props.createCanvasContext) {
+      const canvasContextProps =
+        props.createCanvasContext === true ? {} : props.createCanvasContext;
+      this.canvasContext = new WebGPUCanvasContext(this, this.adapter, canvasContextProps);
     }
   }
 
@@ -138,7 +140,7 @@ export class WebGPUDevice extends Device {
   }
 
   createBuffer(props: BufferProps | ArrayBuffer | ArrayBufferView): WebGPUBuffer {
-    const newProps = this._getBufferProps(props);
+    const newProps = this._normalizeBufferProps(props);
     return new WebGPUBuffer(this, newProps);
   }
 

--- a/website/src/examples/templates.tsx
+++ b/website/src/examples/templates.tsx
@@ -98,7 +98,7 @@ export const InstancingExample: React.FC = () => (
 export const PersistenceExample: React.FC = () => (
   <LumaExample
     id="persistence"
-    directory="showcase/persistence"
+    directory="showcase"
     template={PersistenceApp}
     config={exampleConfig}
   />

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -88,6 +88,7 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
       device = await luma.createDevice({
         adapters: [webgl2Adapter, webgpuAdapter],
         type: deviceType,
+        // @ts-expect-error
         createCanvasContext: {
           canvas,
           container: containerName

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -88,7 +88,7 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
       device = await luma.createDevice({
         adapters: [webgl2Adapter, webgpuAdapter],
         type: deviceType,
-        canvasContext: {
+        createCanvasContext: {
           canvas,
           container: containerName
         }

--- a/website/src/react-luma/store/device-store.tsx
+++ b/website/src/react-luma/store/device-store.tsx
@@ -30,7 +30,8 @@ export async function createDevice(type: 'webgl' | 'webgpu'): Promise<Device> {
       adapters: [webgl2Adapter, webgpuAdapter],
       type,
       height: 0,
-      canvasContext: {
+      // @ts-expect-error
+      createCanvasContext: {
         container: getCanvasContainer()
       }
     });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Felt that the new `DeviceProps.canvasContext` prop was not clear enough.
#### Change List
- Clean up the new DeviceProps.canvasContext prop to DeviceProps.createCanvasContext
- Accept `true` as a value
- Move page load synchronization to luma.create/attachDevice to deduplicate logic from the 3 device implementations

