### PR TITLE
fix(webgl): Do not enable mipmap filtering by default

### DIFF
--- a/docs/api-guide/gpu/gpu-textures.mdx
+++ b/docs/api-guide/gpu/gpu-textures.mdx
@@ -80,7 +80,7 @@ The textures may not be completely packed, there may be padding (per row)
 const texture = device.createTexture({});
 ```
 
-## Reading from Textures on the GPU (Sampling)
+## Sampling
 
 A primary purpose of textures is to allow the GPU to read from them.
 
@@ -108,7 +108,21 @@ The parameters used for sampling is specified in a sampler object.
 
 ### Mipmaps
 
-To improve samling mipmaps can be prepared.
+To improve samling mipmaps can be included in a texture. Mipmaps are a pyramid of lower resolution images that are used when the texture is sampled at a distance.
+Mipmaps can be generated automatically by the GPU, or can be provided by the application.
+
+Mipmap usage is controller via `SamplerProps.mipmapFilter`:
+
+| `mipmapFilter` | `minFilter` | Description                                     | Linearity             | Speed |
+| -------------- | ----------- | ----------------------------------------------- | --------------------- | --- |
+| `none`         | `nearest`   | Mo filtering, no mipmaps                        |                       | |
+| `none`         | `linear`    | Filtering, no mipmaps                           | bilinear              | slowest \* |
+| `nearest`      | `nearest`   | No filtering, sharp switching between mipmaps   |                       | |
+| `nearest`      | `linear`    | No filtering, smooth transition between mipmaps |                       | |
+| `linear`       | `nearest`   | Filtering, sharp switching between mipmaps      | bilinear with mipmaps | fastest \* |
+| `linear`       | `linear`    | Filtering, smooth transition between mipmaps    | trilinear             | |
+
+Performance typically depends on texture LOD, and perhaps surprisingly, mipmaps not only improve visual quality, but can also improve performance. When a scaled down, lower quality mipmap is selected it reduces memory bandwidth requirements.
 
 ## Binding textures
 

--- a/docs/api-guide/gpu/gpu-textures.mdx
+++ b/docs/api-guide/gpu/gpu-textures.mdx
@@ -124,6 +124,8 @@ Mipmap usage is controller via `SamplerProps.mipmapFilter`:
 
 Performance typically depends on texture LOD, and perhaps surprisingly, mipmaps not only improve visual quality, but can also improve performance. When a scaled down, lower quality mipmap is selected it reduces memory bandwidth requirements.
 
+Texture filtering is considered bilinear because it is a linear filter that is applied in two directions, sequentially. First, a linear filter is applied along the image's x axis (width), and then a second filter is applied along the y axis (height). This is why bilinear filtering is sometimes referred to as linear/bilinear.
+
 ## Binding textures
 
 Before textures can be sampled in the

--- a/docs/api-reference/core/resources/sampler.md
+++ b/docs/api-reference/core/resources/sampler.md
@@ -14,6 +14,8 @@ During comparison sampling, the interpolated and clamped `r` texture coordinate 
 and the result of the comparison (`0` or `1`) is assigned to the red channel.
 Specifying the `type: 'comparison-sampler'` sampler property creates a comparison sampler.
 
+For more information, see [Sampling](/docs/api-guide/gpu/gpu-textures#sampling) in the API Guide.
+
 ## Usage
 
 Create a new `Sampler`
@@ -59,7 +61,7 @@ const sampler = device.createSampler(gl, {
 | `addressModeW?`   | `'clamp-to-edge'` \* \| `'repeat'` \| `'mirror-repeat'` | Texture wrapping for texture coordinate `w` (`r`)                   |
 | `magFilter?`      | `'nearest'` \* \| `'linear'`                            | Sample nearest texel, or interpolate closest texels                 |
 | `minFilter?`      | `'nearest'` \* \| `'linear'`                            | Sample nearest texel, or interpolate closest texels                 |
-| `mipmapFilter?`   | `'nearest'` \* \| `'linear'`                            | Sample closest mipmap, or interpolate two closest mipmaps           |
+| `mipmapFilter?`   | `'none'` \* \| `'nearest'` \| `'linear'`                | Sample closest mipmap, or interpolate two closest mipmaps           |
 | `maxAnisotropy?`  | `number`                                                | Combine samples from multiple mipmap levels when appropriate        |
 | `lodMinClamp?`    | `number`                                                | Minimum level of detail to use when sampling                        |
 | `lodMaxClamp?`    | `number`                                                | Maximum level of detail to use when sampling                        |
@@ -111,7 +113,9 @@ Parameter: `mipmapFilter`
 | ------------------- | --------------------------- |
 | `nearest` (default) | nearest mipmap              |
 | `linear`            | interpolate between mipmaps |
-| N/A                 | no mipmaps                  |
+| `none`              | no mipmaps                  |
+
+For more information, see [GPU Textures](/docs/api-guide/gpu/gpu-textures#mipmaps).
 
 #### Texture Max Anisotropy
 
@@ -124,16 +128,16 @@ Controls multiple mipmap level can be consulted when texturing a pixel.
 
 Parameter: `compare`
 
-| `Value                 | Computed result                    |
-| ---------------------- | ---------------------------------- |
+| `Value                 | Computed result                      |
+| ---------------------- | ------------------------------------ |
 | `less-equal` (default) | result = 1.0 0.0, r \<\= D t r > D t |
 | `greater-equal`        | result = 1.0 0.0, r \>\= D t r < D t |
 | `less`                 | result = 1.0 0.0, r < D t r \>\= D t |
 | `greater`              | result = 1.0 0.0, r > D t r \<\= D t |
-| `equal`                | result = 1.0 0.0, r = D t r ≠ D t  |
-| `not-equal`            | result = 1.0 0.0, r ≠ D t r = D t  |
-| `always`               | result = 1.0                       |
-| `never`                | result = 0.0                       |
+| `equal`                | result = 1.0 0.0, r = D t r ≠ D t    |
+| `not-equal`            | result = 1.0 0.0, r ≠ D t r = D t    |
+| `always`               | result = 1.0                         |
+| `never`                | result = 0.0                         |
 
 During sampling, the interpolated and clamped `r` texture coordinate is compared to currently bound depth texture,
 and the result of the comparison (`0` or `1`) is assigned to the red channel.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -39,7 +39,7 @@ When initializing luma.gl, applications now import an `Adapter` singleton from e
 | `DeviceProps` for canvas       | Moved      | [`DeviceProps.createCanvasContext`][canvas]. | Move canvas related props to `props.createCanvasContext: {}`.   |
 | `DeviceProps` for webgl        | Moved      | [`DeviceProps.webgl`][webgl].                | Move canvas related props to `props.webgl: {}`.                 |
 | `DeviceProps.break`            | Removed    |                                              | Use an alterative [debugger][debugging]                         |
-| `Texture.props.data` (Promise) | Removed    | `AsyncTexture` class                         | Textures no longer accept promises.                             |
+| `TextureProps.data` (Promise) | Removed    | `AsyncTexture` class                         | Textures no longer accept promises.                             |
 | `Parameters.blend`             | New        |                                              | Explicit activation of color blending                           |
 | `triangle-fan-webgl` topology  | Removed    | `triangle-strip`.                            | Reorganize your geometries                                      |
 | `line-loop-webgl` topology     | Removed    | `line-list`.                                 | Reorganize your geometries                                      |

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -19,8 +19,9 @@ Improvements focused on enhancing WebGPU support.
 - New [`Adapter`](/docs/api-reference/core/adapter) class for singleton objects representing pluggable GPU backends. 
 - New `adapters` options for `luma.createDevice()` and `makeAnimationLoopTemplate` as alternative to global registration of adapters.
 - New [`luma.registerAdapters()`](/docs/api-reference/core/luma#lumaregisteradapters) method for old-stye global registration of adapters.
-- New `Parameters.blend` - Provides explicit control over color blending activation.
 - New `Texture.copyExternalImage()` function that works on both WebGPU and WebGL.
+- New `Parameters.blend` - Provides explicit control over color blending activation.
+- New `SamplerProps.mipmapFilter` has a new value `'none'` providing a more explicit API for mipmap filtering.
 
 **@luma.gl/engine**
 

--- a/modules/core/src/adapter/resources/sampler.ts
+++ b/modules/core/src/adapter/resources/sampler.ts
@@ -30,7 +30,7 @@ export type SamplerProps = ResourceProps & {
   /** Minification: the area of the fragment in texture space is larger than a texel */
   minFilter?: 'nearest' | 'linear';
   /** mipmapping: select between multiple mipmaps based on angle and size of the texture relative to the screen. */
-  mipmapFilter?: 'nearest' | 'linear';
+  mipmapFilter?: 'none' | 'nearest' | 'linear';
   /** Affects the mipmap image selection */
   lodMinClamp?: number;
   /** Affects the mipmap image selection */
@@ -53,7 +53,7 @@ export abstract class Sampler extends Resource<SamplerProps> {
     addressModeW: 'clamp-to-edge',
     magFilter: 'nearest',
     minFilter: 'nearest',
-    mipmapFilter: 'nearest',
+    mipmapFilter: 'none',
     lodMinClamp: 0,
     lodMaxClamp: 32, // Per WebGPU spec
     compare: 'less-equal',

--- a/modules/webgl/src/adapter/converters/sampler-parameters.ts
+++ b/modules/webgl/src/adapter/converters/sampler-parameters.ts
@@ -84,7 +84,7 @@ function convertMaxFilterMode(maxFilter: 'nearest' | 'linear'): GL.NEAREST | GL.
  */
 function convertMinFilterMode(
   minFilter: 'nearest' | 'linear',
-  mipmapFilter?: 'nearest' | 'linear'
+  mipmapFilter: 'none' | 'nearest' | 'linear' = 'none'
 ):
   | GL.NEAREST
   | GL.LINEAR
@@ -95,10 +95,12 @@ function convertMinFilterMode(
   if (!mipmapFilter) {
     return convertMaxFilterMode(minFilter);
   }
-  switch (minFilter) {
+  switch (mipmapFilter) {
+    case 'none':
+      return convertMaxFilterMode(minFilter);
     case 'nearest':
-      return mipmapFilter === 'nearest' ? GL.NEAREST_MIPMAP_NEAREST : GL.NEAREST_MIPMAP_LINEAR;
+      return minFilter === 'nearest' ? GL.NEAREST_MIPMAP_NEAREST : GL.NEAREST_MIPMAP_LINEAR;
     case 'linear':
-      return mipmapFilter === 'nearest' ? GL.LINEAR_MIPMAP_NEAREST : GL.LINEAR_MIPMAP_LINEAR;
+      return minFilter === 'nearest' ? GL.LINEAR_MIPMAP_NEAREST : GL.LINEAR_MIPMAP_LINEAR;
   }
 }

--- a/modules/webgpu/src/adapter/resources/webgpu-sampler.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-sampler.ts
@@ -9,7 +9,7 @@ export type WebGPUSamplerProps = SamplerProps & {
 };
 
 /**
- *
+ * A WebGPU sampler object
  */
 export class WebGPUSampler extends Sampler {
   readonly device: WebGPUDevice;
@@ -19,13 +19,23 @@ export class WebGPUSampler extends Sampler {
     super(device, props);
     this.device = device;
 
-    // Prepare sampler props
-    const samplerProps: Partial<WebGPUSamplerProps> = {...this.props};
-    if (samplerProps.type !== 'comparison-sampler') {
-      delete samplerProps.compare;
+    // Prepare sampler props. Mostly identical
+    const samplerDescriptor: Partial<GPUSamplerDescriptor> = {
+      ...this.props,
+      mipmapFilter: undefined
+    };
+
+    // props.compare automatically turns this into a comparison sampler
+    if (props.type !== 'comparison-sampler') {
+      delete samplerDescriptor.compare;
     }
 
-    this.handle = this.handle || this.device.handle.createSampler(samplerProps);
+    // disable mipmapFilter if not set
+    if (props.mipmapFilter && props.mipmapFilter !== 'none') {
+      samplerDescriptor.mipmapFilter = props.mipmapFilter;
+    }
+
+    this.handle = this.handle || this.device.handle.createSampler(samplerDescriptor);
     this.handle.label = this.props.id;
   }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- deck.gl tests on 9.1 branch seem to fail due to texture filtering being better than in 9.0.
- One possibility is that we now use mipmap filtering whereas we did not in 9.0 (based on quick code search, pretty sure we did not in 8.x).
#### Change List
- mipmapFiltering default changed from `'nearest'` to `'none'`
