### PR TITLE
fix(core): Allow webgl 1,3 component unorm8 attributes

### DIFF
--- a/modules/core/src/gpu-type-utils/vertex-format-from-attribute.ts
+++ b/modules/core/src/gpu-type-utils/vertex-format-from-attribute.ts
@@ -77,14 +77,12 @@ export function getVertexFormatFromAttribute(
   const components = size as 1 | 2 | 3 | 4;
   let dataType: DataType | DataTypeNorm = getDataTypeFromTypedArray(typedArray);
 
-  // Special case for WebGL, overrides check below
-  if ((dataType === 'uint8' || dataType === 'sint8') && normalized) {
-    if (components === 1) {
-      return 'unorm8-webgl';
-    }
-    if (components === 3) {
-      return 'unorm8x3-webgl';
-    }
+  // TODO - Special cases for WebGL (not supported on WebGPU), overrides the check below
+  if (dataType === 'uint8' && normalized && components === 1) {
+    return 'unorm8-webgl';
+  }
+  if (dataType === 'uint8' && normalized && components === 3) {
+    return 'unorm8x3-webgl';
   }
 
   if (dataType === 'uint8' || dataType === 'sint8') {

--- a/modules/core/src/gpu-type-utils/vertex-format-from-attribute.ts
+++ b/modules/core/src/gpu-type-utils/vertex-format-from-attribute.ts
@@ -77,6 +77,16 @@ export function getVertexFormatFromAttribute(
   const components = size as 1 | 2 | 3 | 4;
   let dataType: DataType | DataTypeNorm = getDataTypeFromTypedArray(typedArray);
 
+  // Special case for WebGL, overrides check below
+  if ((dataType === 'uint8' || dataType === 'sint8') && normalized) {
+    if (components === 1) {
+      return 'unorm8-webgl';
+    }
+    if (components === 3) {
+      return 'unorm8x3-webgl';
+    }
+  }
+
   if (dataType === 'uint8' || dataType === 'sint8') {
     if (components === 1 || components === 3) {
       // WebGPU 8 bit formats must be aligned to 16 bit boundaries');


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/discussions/8815#discussioncomment-10405194
<!-- For other PRs without open issue -->
#### Background
- Relax restriction on vertex formats temporarily to unblock 3D Tiles.
#### Change List
- Allow webgl 1,3 component unorm8 attributes
