### PR TITLE
fix(core): Allow webgl 1,3 component unorm8 attributes (#2196)

### DIFF
--- a/modules/core/src/adapter/type-utils/vertex-format-from-attribute.ts
+++ b/modules/core/src/adapter/type-utils/vertex-format-from-attribute.ts
@@ -77,6 +77,14 @@ export function getVertexFormatFromAttribute(
   const components = size as 1 | 2 | 3 | 4;
   let dataType: DataType | DataTypeNorm = getDataTypeFromTypedArray(typedArray);
 
+  // TODO - Special cases for WebGL (not supported on WebGPU), overrides the check below
+  if (dataType === 'uint8' && normalized && components === 1) {
+    return 'unorm8-webgl';
+  }
+  if (dataType === 'uint8' && normalized && components === 3) {
+    return 'unorm8x3-webgl';
+  }
+
   if (dataType === 'uint8' || dataType === 'sint8') {
     if (components === 1 || components === 3) {
       // WebGPU 8 bit formats must be aligned to 16 bit boundaries');


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- temporarily restore support for webgl only vertex attributes
#### Change List
-
