### PR TITLE
fix(engine): Prevent infinite recursion in RAF polyfills

### DIFF
--- a/modules/engine/src/animation-loop/animation-loop.ts
+++ b/modules/engine/src/animation-loop/animation-loop.ts
@@ -3,7 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import {luma, Device} from '@luma.gl/core';
-import {requestAnimationFrame, cancelAnimationFrame} from './request-animation-frame';
+import {
+  requestAnimationFramePolyfill,
+  cancelAnimationFramePolyfill
+} from './request-animation-frame';
 import {Timeline} from '../animation/timeline';
 import {AnimationProps} from './animation-props';
 import {Stats, Stat} from '@probe.gl/stats';
@@ -320,7 +323,7 @@ export class AnimationLoop {
     // if (this.display && this.display.requestAnimationFrame) {
     //   this._animationFrameId = this.display.requestAnimationFrame(this._animationFrame.bind(this));
     // }
-    this._animationFrameId = requestAnimationFrame(this._animationFrame.bind(this));
+    this._animationFrameId = requestAnimationFramePolyfill(this._animationFrame.bind(this));
   }
 
   _cancelAnimationFrame(): void {
@@ -331,10 +334,10 @@ export class AnimationLoop {
     // VR display has a separate animation frame to sync with headset
     // TODO WebVR API discontinued, replaced by WebXR: https://immersive-web.github.io/webxr/
     // See https://developer.mozilla.org/en-US/docs/Web/API/VRDisplay/requestAnimationFrame
-    // if (this.display && this.display.cancelAnimationFrame) {
+    // if (this.display && this.display.cancelAnimationFramePolyfill) {
     //   this.display.cancelAnimationFrame(this._animationFrameId);
     // }
-    cancelAnimationFrame(this._animationFrameId);
+    cancelAnimationFramePolyfill(this._animationFrameId);
     this._animationFrameId = null;
   }
 

--- a/modules/engine/src/animation-loop/request-animation-frame.ts
+++ b/modules/engine/src/animation-loop/request-animation-frame.ts
@@ -2,17 +2,18 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-// Node.js polyfills for requestAnimationFrame and cancelAnimationFrame
 /* global window, setTimeout, clearTimeout */
 
+/** Node.js polyfill for requestAnimationFrame */
 // / <reference types="@types/node" />
-export function requestAnimationFrame(callback: (time?: any) => void): any {
+export function requestAnimationFramePolyfill(callback: (time?: any) => void): any {
   return typeof window !== 'undefined' && window.requestAnimationFrame
     ? window.requestAnimationFrame(callback)
     : setTimeout(callback, 1000 / 60);
 }
 
-export function cancelAnimationFrame(timerId: any): void {
+/** Node.js polyfill for cancelAnimationFrame */
+export function cancelAnimationFramePolyfill(timerId: any): void {
   return typeof window !== 'undefined' && window.cancelAnimationFrame
     ? window.cancelAnimationFrame(timerId)
     : clearTimeout(timerId);

--- a/modules/engine/src/index.ts
+++ b/modules/engine/src/index.ts
@@ -81,15 +81,18 @@ export {SwapFramebuffers} from './compute/swap';
 export type {ComputationProps} from './compute/computation';
 export {Computation} from './compute/computation';
 
-export {
-  requestAnimationFrame,
-  cancelAnimationFrame
-} from './animation-loop/request-animation-frame';
-
 export type {AsyncTextureProps} from './async-texture/async-texture';
 export {AsyncTexture} from './async-texture/async-texture';
 
-export {LegacyPickingManager} from './modules/picking/legacy-picking-manager';
 export {PickingManager} from './modules/picking/picking-manager';
 export {picking as indexPicking} from './modules/picking/index-picking';
 export {picking as colorPicking} from './modules/picking/color-picking';
+
+export {
+  requestAnimationFramePolyfill,
+  cancelAnimationFramePolyfill
+} from './animation-loop/request-animation-frame';
+
+// DEPRECATED
+
+export {LegacyPickingManager} from './modules/picking/legacy-picking-manager';

--- a/modules/test-utils/src/deprecated/classic-animation-loop.ts
+++ b/modules/test-utils/src/deprecated/classic-animation-loop.ts
@@ -6,8 +6,8 @@
 // TODO - remove dependency on framebuffer (bundle size impact)
 import {luma, Device, DeviceProps, log} from '@luma.gl/core';
 import {
-  requestAnimationFrame,
-  cancelAnimationFrame,
+  requestAnimationFramePolyfill,
+  cancelAnimationFramePolyfill,
   Timeline,
   AnimationProps
 } from '@luma.gl/engine';
@@ -428,7 +428,7 @@ export class ClassicAnimationLoop {
     // if (this.display && this.display.requestAnimationFrame) {
     //   this._animationFrameId = this.display.requestAnimationFrame(this._animationFrame.bind(this));
     // }
-    this._animationFrameId = requestAnimationFrame(this._animationFrame.bind(this));
+    this._animationFrameId = requestAnimationFramePolyfill(this._animationFrame.bind(this));
   }
 
   _cancelAnimationFrame() {
@@ -442,7 +442,7 @@ export class ClassicAnimationLoop {
     // if (this.display && this.display.cancelAnimationFrame) {
     //   this.display.cancelAnimationFrame(this._animationFrameId);
     // }
-    cancelAnimationFrame(this._animationFrameId);
+    cancelAnimationFramePolyfill(this._animationFrameId);
     this._animationFrameId = null;
   }
 

--- a/modules/test-utils/src/test-runner.ts
+++ b/modules/test-utils/src/test-runner.ts
@@ -9,7 +9,7 @@ import {AnimationProps} from '@luma.gl/engine';
 import {webglDevice} from './create-test-device';
 
 // TODO - Replace with new AnimationLoop from `@luma.gl/engine`
-import {ClassicAnimationLoop as AnimationLoop} from './engine/classic-animation-loop';
+import {ClassicAnimationLoop as AnimationLoop} from './deprecated/classic-animation-loop';
 
 /** Describes a test case */
 export type TestRunnerTestCase = {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes ##2111
<!-- For other PRs without open issue -->
#### Background
- In the script, the polyfill overwrites window.requestAnimationFrame and ends up calling itself ad infinitum.
#### Change List
- Rename the polyfills to avoid collision
