### PR TITLE
chore: Separate out website build step in CI test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,10 @@ jobs:
         run: |
           yarn test-ci
 
+      - name: Test website build
+        run: |
+          yarn test-website
+
       - name: Coveralls
         uses: coverallsapp/github-action@09b709cf6a16e30b0808ba050c7a6e8a5ef13f8d # v1.2.5
         with:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "publish-prod": "ocular-publish version-only-prod",
     "version": "node scripts/verify-changelog.js && git add CHANGELOG.md",
     "test": "ocular-test",
-    "test-ci": "ocular-lint && ocular-test node && ocular-test cover && yarn test-website",
+    "test-ci": "ocular-lint && ocular-test node && ocular-test cover",
     "test-fast": "ocular-test fast",
     "test-browser": "ocular-test browser",
     "test-browser-headless": "ocular-test browser-headless | tap-spec",


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- tests often fail because yarn.lock in website directory has not been updated.
- the logs are confusing since this step is added to normal tests
#### Change List
- mark website build as separate CI step
