### PR TITLE
webgl: clip image write based on texture size

### DIFF
--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -329,6 +329,22 @@ test('Texture#copyExternalImage', async t => {
           `${device.info.type} Pixels were set correctly (sub image)`
         );
       }
+
+      // Subimage copy (smaller canvas)
+      canvas.width = 1;
+      canvas.height = 1;
+      ctx.fillStyle = '#00FF00';
+      ctx.fillRect(0, 0, 1, 1);
+
+      texture.copyExternalImage({image: canvas, x: 1});
+
+      if (device.info.type === 'webgl') {
+        t.deepEquals(
+          device.readPixelsToArrayWebGL(texture),
+          new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255]),
+          `${device.info.type} Pixels were set correctly (sub image small canvas)`
+        );
+      }
     }
 
     if (device.info.type !== 'webgl') {

--- a/modules/webgl/src/adapter/resources/webgl-texture.ts
+++ b/modules/webgl/src/adapter/resources/webgl-texture.ts
@@ -243,8 +243,8 @@ export class WEBGLTexture extends Texture {
     const {dimension, glTarget, glFormat, glInternalFormat, glType} = this;
 
     // WebGL will error if we try to copy outside the bounds of the texture
-    width = Math.min(width, size.width - x);
-    height = Math.min(height, size.height - y);
+    width = Math.min(width, this.width - x);
+    height = Math.min(height, this.height - y);
 
     if (options.sourceX || options.sourceY) {
       // requires copyTexSubImage2D from a framebuffer'


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/pull/8833
<!-- For other PRs without open issue -->
#### Background

<!-- For all the PRs -->
#### Change List
- Clip width/height based on texture (not image) size
- Test