### PR TITLE
chore: Consolidate texture implementations, move setters to AsyncTexture (v9.2)

### DIFF
--- a/modules/core/src/adapter/resources/buffer.ts
+++ b/modules/core/src/adapter/resources/buffer.ts
@@ -25,21 +25,6 @@ export type BufferProps = ResourceProps & {
 
 /** Abstract GPU buffer */
 export abstract class Buffer extends Resource<BufferProps> {
-  static override defaultProps: Required<BufferProps> = {
-    ...Resource.defaultProps,
-    usage: 0, // Buffer.COPY_DST | Buffer.COPY_SRC
-    byteLength: 0,
-    byteOffset: 0,
-    data: null,
-    indexType: 'uint16',
-    mappedAtCreation: false
-  };
-
-  // Usage Flags
-  static MAP_READ = 0x01;
-  static MAP_WRITE = 0x02;
-  static COPY_SRC = 0x0004;
-  static COPY_DST = 0x0008;
   /** Index buffer */
   static INDEX = 0x0010;
   /** Vertex buffer */
@@ -50,6 +35,12 @@ export abstract class Buffer extends Resource<BufferProps> {
   static STORAGE = 0x0080;
   static INDIRECT = 0x0100;
   static QUERY_RESOLVE = 0x0200;
+
+  // Usage Flags
+  static MAP_READ = 0x01;
+  static MAP_WRITE = 0x02;
+  static COPY_SRC = 0x0004;
+  static COPY_DST = 0x0008;
 
   override get [Symbol.toStringTag](): string {
     return 'Buffer';
@@ -134,4 +125,14 @@ export abstract class Buffer extends Resource<BufferProps> {
       this.debugData = arrayBuffer.slice(byteOffset, byteOffset + debugDataLength);
     }
   }
+
+  static override defaultProps: Required<BufferProps> = {
+    ...Resource.defaultProps,
+    usage: 0, // Buffer.COPY_DST | Buffer.COPY_SRC
+    byteLength: 0,
+    byteOffset: 0,
+    data: null,
+    indexType: 'uint16',
+    mappedAtCreation: false
+  };
 }

--- a/modules/core/src/adapter/resources/command-buffer.ts
+++ b/modules/core/src/adapter/resources/command-buffer.ts
@@ -26,10 +26,6 @@ export type CommandBufferProps = ResourceProps & {};
  * Encodes commands to queue that can be executed later
  */
 export abstract class CommandBuffer extends Resource<CommandBufferProps> {
-  static override defaultProps: Required<CommandBufferProps> = {
-    ...Resource.defaultProps
-  };
-
   override get [Symbol.toStringTag](): string {
     return 'CommandBuffer';
   }
@@ -37,4 +33,8 @@ export abstract class CommandBuffer extends Resource<CommandBufferProps> {
   constructor(device: Device, props: CommandBufferProps) {
     super(device, props, CommandBuffer.defaultProps);
   }
+
+  static override defaultProps: Required<CommandBufferProps> = {
+    ...Resource.defaultProps
+  };
 }

--- a/modules/core/src/adapter/resources/command-encoder.ts
+++ b/modules/core/src/adapter/resources/command-encoder.ts
@@ -131,11 +131,6 @@ export type CommandEncoderProps = ResourceProps & {
  * Encodes commands to queue that can be executed later
  */
 export abstract class CommandEncoder extends Resource<CommandEncoderProps> {
-  static override defaultProps: Required<CommandEncoderProps> = {
-    ...Resource.defaultProps,
-    measureExecutionTime: undefined!
-  };
-
   override get [Symbol.toStringTag](): string {
     return 'CommandEncoder';
   }
@@ -185,4 +180,9 @@ export abstract class CommandEncoder extends Resource<CommandEncoderProps> {
   // TODO - luma.gl has these on the device, should we align with WebGPU API?
   // beginRenderPass(GPURenderPassDescriptor descriptor): GPURenderPassEncoder;
   // beginComputePass(optional GPUComputePassDescriptor descriptor = {}): GPUComputePassEncoder;
+
+  static override defaultProps: Required<CommandEncoderProps> = {
+    ...Resource.defaultProps,
+    measureExecutionTime: undefined!
+  };
 }

--- a/modules/core/src/adapter/resources/compute-pass.ts
+++ b/modules/core/src/adapter/resources/compute-pass.ts
@@ -18,17 +18,6 @@ export type ComputePassProps = ResourceProps & {
 };
 
 export abstract class ComputePass extends Resource<ComputePassProps> {
-  static override defaultProps: Required<ComputePassProps> = {
-    ...Resource.defaultProps,
-    timestampQuerySet: undefined!,
-    beginTimestampIndex: undefined!,
-    endTimestampIndex: undefined!
-  };
-
-  override get [Symbol.toStringTag](): string {
-    return 'ComputePass';
-  }
-
   constructor(device: Device, props: ComputePassProps) {
     super(device, props, ComputePass.defaultProps);
   }
@@ -63,4 +52,15 @@ export abstract class ComputePass extends Resource<ComputePassProps> {
   abstract popDebugGroup(): void;
   /** Marks a point in a stream of commands with a label */
   abstract insertDebugMarker(markerLabel: string): void;
+
+  static override defaultProps: Required<ComputePassProps> = {
+    ...Resource.defaultProps,
+    timestampQuerySet: undefined!,
+    beginTimestampIndex: undefined!,
+    endTimestampIndex: undefined!
+  };
+
+  override get [Symbol.toStringTag](): string {
+    return 'ComputePass';
+  }
 }

--- a/modules/core/src/adapter/resources/compute-pipeline.ts
+++ b/modules/core/src/adapter/resources/compute-pipeline.ts
@@ -26,14 +26,6 @@ export type ComputePipelineProps = ResourceProps & {
  * A compiled and linked shader program for compute
  */
 export abstract class ComputePipeline extends Resource<ComputePipelineProps> {
-  static override defaultProps: Required<ComputePipelineProps> = {
-    ...Resource.defaultProps,
-    shader: undefined!,
-    entryPoint: undefined!,
-    constants: {},
-    shaderLayout: undefined!
-  };
-
   override get [Symbol.toStringTag](): string {
     return 'ComputePipeline';
   }
@@ -52,4 +44,12 @@ export abstract class ComputePipeline extends Resource<ComputePipelineProps> {
    * @todo Do we want to expose BindGroups in the API and remove this?
    */
   abstract setBindings(bindings: Record<string, Binding>): void;
+
+  static override defaultProps: Required<ComputePipelineProps> = {
+    ...Resource.defaultProps,
+    shader: undefined!,
+    entryPoint: undefined!,
+    constants: {},
+    shaderLayout: undefined!
+  };
 }

--- a/modules/core/src/adapter/resources/external-texture.ts
+++ b/modules/core/src/adapter/resources/external-texture.ts
@@ -10,12 +10,6 @@ export type ExternalTextureProps = ResourceProps & {
   colorSpace?: 'srgb';
 };
 export abstract class ExternalTexture extends Resource<ExternalTextureProps> {
-  static override defaultProps: Required<ExternalTextureProps> = {
-    ...Resource.defaultProps,
-    source: undefined!,
-    colorSpace: 'srgb'
-  };
-
   override get [Symbol.toStringTag](): string {
     return 'ExternalTexture';
   }
@@ -23,4 +17,10 @@ export abstract class ExternalTexture extends Resource<ExternalTextureProps> {
   constructor(device: Device, props: ExternalTextureProps) {
     super(device, props, ExternalTexture.defaultProps);
   }
+
+  static override defaultProps: Required<ExternalTextureProps> = {
+    ...Resource.defaultProps,
+    source: undefined!,
+    colorSpace: 'srgb'
+  };
 }

--- a/modules/core/src/adapter/resources/framebuffer.ts
+++ b/modules/core/src/adapter/resources/framebuffer.ts
@@ -25,14 +25,6 @@ export type FramebufferProps = ResourceProps & {
  * @note resize() destroys existing textures (if size has changed).
  */
 export abstract class Framebuffer extends Resource<FramebufferProps> {
-  static override defaultProps: Required<FramebufferProps> = {
-    ...Resource.defaultProps,
-    width: 1,
-    height: 1,
-    colorAttachments: [], // ['rgba8unorm'],
-    depthStencilAttachment: null // 'depth24plus-stencil8'
-  };
-
   override get [Symbol.toStringTag](): string {
     return 'Framebuffer';
   }
@@ -182,4 +174,12 @@ export abstract class Framebuffer extends Resource<FramebufferProps> {
 
   /** Implementation is expected to update any underlying binding (WebGL framebuffer attachment) */
   protected abstract updateAttachments(): void;
+
+  static override defaultProps: Required<FramebufferProps> = {
+    ...Resource.defaultProps,
+    width: 1,
+    height: 1,
+    colorAttachments: [], // ['rgba8unorm'],
+    depthStencilAttachment: null // 'depth24plus-stencil8'
+  };
 }

--- a/modules/core/src/adapter/resources/query-set.ts
+++ b/modules/core/src/adapter/resources/query-set.ts
@@ -25,12 +25,6 @@ export type QuerySetProps = ResourceProps & {
 
 /** Immutable QuerySet object */
 export abstract class QuerySet extends Resource<QuerySetProps> {
-  static override defaultProps: Required<QuerySetProps> = {
-    ...Resource.defaultProps,
-    type: undefined!,
-    count: undefined!
-  };
-
   get [Symbol.toStringTag](): string {
     return 'QuerySet';
   }
@@ -38,4 +32,10 @@ export abstract class QuerySet extends Resource<QuerySetProps> {
   constructor(device: Device, props: QuerySetProps) {
     super(device, props, QuerySet.defaultProps);
   }
+
+  static override defaultProps: Required<QuerySetProps> = {
+    ...Resource.defaultProps,
+    type: undefined!,
+    count: undefined!
+  };
 }

--- a/modules/core/src/adapter/resources/render-pass.ts
+++ b/modules/core/src/adapter/resources/render-pass.ts
@@ -64,25 +64,6 @@ export abstract class RenderPass extends Resource<RenderPassProps> {
   /** Clears all stencil bits */
   static defaultClearStencil = 0;
 
-  /** Default properties for RenderPass */
-  static override defaultProps: Required<RenderPassProps> = {
-    ...Resource.defaultProps,
-    framebuffer: null,
-    parameters: undefined!,
-    clearColor: RenderPass.defaultClearColor,
-    clearColors: undefined!,
-    clearDepth: RenderPass.defaultClearDepth,
-    clearStencil: RenderPass.defaultClearStencil,
-    depthReadOnly: false,
-    stencilReadOnly: false,
-    discard: false,
-
-    occlusionQuerySet: undefined!,
-    timestampQuerySet: undefined!,
-    beginTimestampIndex: undefined!,
-    endTimestampIndex: undefined!
-  };
-
   override get [Symbol.toStringTag](): string {
     return 'RenderPass';
   }
@@ -118,6 +99,25 @@ export abstract class RenderPass extends Resource<RenderPassProps> {
     const newProps = {...overriddenDefaultProps, ...props};
     return newProps;
   }
+
+  /** Default properties for RenderPass */
+  static override defaultProps: Required<RenderPassProps> = {
+    ...Resource.defaultProps,
+    framebuffer: null,
+    parameters: undefined!,
+    clearColor: RenderPass.defaultClearColor,
+    clearColors: undefined!,
+    clearDepth: RenderPass.defaultClearDepth,
+    clearStencil: RenderPass.defaultClearStencil,
+    depthReadOnly: false,
+    stencilReadOnly: false,
+    discard: false,
+
+    occlusionQuerySet: undefined!,
+    timestampQuerySet: undefined!,
+    beginTimestampIndex: undefined!,
+    endTimestampIndex: undefined!
+  };
 }
 
 // TODO - Can we align WebGL implementation with WebGPU API?

--- a/modules/core/src/adapter/resources/render-pipeline.ts
+++ b/modules/core/src/adapter/resources/render-pipeline.ts
@@ -63,30 +63,6 @@ export type RenderPipelineProps = ResourceProps & {
  * A compiled and linked shader program
  */
 export abstract class RenderPipeline extends Resource<RenderPipelineProps> {
-  static override defaultProps: Required<RenderPipelineProps> = {
-    ...Resource.defaultProps,
-
-    vs: null,
-    vertexEntryPoint: 'vertexMain',
-    vsConstants: {},
-
-    fs: null,
-    fragmentEntryPoint: 'fragmentMain',
-    fsConstants: {},
-
-    shaderLayout: null,
-    bufferLayout: [],
-    topology: 'triangle-list',
-
-    colorAttachmentFormats: undefined!,
-    depthStencilAttachmentFormat: undefined!,
-
-    parameters: {},
-
-    bindings: {},
-    uniforms: {}
-  };
-
   override get [Symbol.toStringTag](): string {
     return 'RenderPipeline';
   }
@@ -155,4 +131,28 @@ export abstract class RenderPipeline extends Resource<RenderPipelineProps> {
   setUniformsWebGL(uniforms: Record<string, UniformValue>): void {
     throw new Error('Use uniform blocks');
   }
+
+  static override defaultProps: Required<RenderPipelineProps> = {
+    ...Resource.defaultProps,
+
+    vs: null,
+    vertexEntryPoint: 'vertexMain',
+    vsConstants: {},
+
+    fs: null,
+    fragmentEntryPoint: 'fragmentMain',
+    fsConstants: {},
+
+    shaderLayout: null,
+    bufferLayout: [],
+    topology: 'triangle-list',
+
+    colorAttachmentFormats: undefined!,
+    depthStencilAttachmentFormat: undefined!,
+
+    parameters: {},
+
+    bindings: {},
+    uniforms: {}
+  };
 }

--- a/modules/core/src/adapter/resources/shader.ts
+++ b/modules/core/src/adapter/resources/shader.ts
@@ -32,16 +32,6 @@ export type ShaderProps = ResourceProps & {
  * In WebGPU the handle can be copied between threads
  */
 export abstract class Shader extends Resource<ShaderProps> {
-  static override defaultProps: Required<ShaderProps> = {
-    ...Resource.defaultProps,
-    language: 'auto',
-    stage: undefined!,
-    source: '',
-    sourceMap: null,
-    entryPoint: 'main',
-    debugShaders: undefined!
-  };
-
   override get [Symbol.toStringTag](): string {
     return 'Shader';
   }
@@ -149,6 +139,16 @@ ${htmlLog}
 
     // TODO - add a small embedded close button
   }
+
+  static override defaultProps: Required<ShaderProps> = {
+    ...Resource.defaultProps,
+    language: 'auto',
+    stage: undefined!,
+    source: '',
+    sourceMap: null,
+    entryPoint: 'main',
+    debugShaders: undefined!
+  };
 }
 
 // HELPERS

--- a/modules/core/src/adapter/resources/texture-view.ts
+++ b/modules/core/src/adapter/resources/texture-view.ts
@@ -27,17 +27,6 @@ export type TextureViewProps = ResourceProps & {
 
 /** Immutable TextureView object */
 export abstract class TextureView extends Resource<TextureViewProps> {
-  static override defaultProps: Required<TextureViewProps> = {
-    ...Resource.defaultProps,
-    format: undefined!,
-    dimension: undefined!,
-    aspect: 'all',
-    baseMipLevel: 0,
-    mipLevelCount: undefined!,
-    baseArrayLayer: 0,
-    arrayLayerCount: undefined!
-  };
-
   abstract texture: Texture;
 
   override get [Symbol.toStringTag](): string {
@@ -48,4 +37,15 @@ export abstract class TextureView extends Resource<TextureViewProps> {
   constructor(device: Device, props: TextureViewProps & {texture: Texture}) {
     super(device, props, TextureView.defaultProps);
   }
+
+  static override defaultProps: Required<TextureViewProps> = {
+    ...Resource.defaultProps,
+    format: undefined!,
+    dimension: undefined!,
+    aspect: 'all',
+    baseMipLevel: 0,
+    mipLevelCount: undefined!,
+    baseArrayLayer: 0,
+    arrayLayerCount: undefined!
+  };
 }

--- a/modules/core/src/adapter/resources/texture.ts
+++ b/modules/core/src/adapter/resources/texture.ts
@@ -2,130 +2,50 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import {TypedArray} from '@math.gl/types';
 import type {Device} from '../device';
-import type {TypedArray} from '../../types';
 import type {TextureFormat} from '../../gpu-type-utils/texture-formats';
 import type {TextureView, TextureViewProps} from './texture-view';
 import {Resource, ResourceProps} from './resource';
 import {Sampler, SamplerProps} from './sampler';
-
-/**
- * These represent the main compressed texture formats
- * Each format typically has a number of more specific subformats
- */
-export type TextureCompressionFormat =
-  | 'dxt'
-  | 'dxt-srgb'
-  | 'etc1'
-  | 'etc2'
-  | 'pvrtc'
-  | 'atc'
-  | 'astc'
-  | 'rgtc';
-
-/** Names of cube texture faces */
-export type TextureCubeFace = '+X' | '-X' | '+Y' | '-Y' | '+Z' | '-Z';
-
-/**
- * One mip level
- * Basic data structure is similar to `ImageData`
- * additional optional fields can describe compressed texture data.
- */
-export type TextureLevelData = {
-  /** WebGPU style format string. Defaults to 'rgba8unorm' */
-  format?: TextureFormat;
-  data: TypedArray;
-  width: number;
-  height: number;
-
-  compressed?: boolean;
-  byteLength?: number;
-  hasAlpha?: boolean;
-};
-
-/**
- * Built-in data types that can be used to initialize textures
- * @note ImageData can be used for 8 bit data via Uint8ClampedArray
- */
-export type ExternalImage =
-  | ImageBitmap
-  | ImageData
-  | HTMLImageElement
-  | HTMLVideoElement
-  | VideoFrame
-  | HTMLCanvasElement
-  | OffscreenCanvas;
-
-export type TextureLevelSource = TextureLevelData | ExternalImage;
-
-/** Texture data can be one or more mip levels */
-export type TextureData = TextureLevelData | ExternalImage | (TextureLevelData | ExternalImage)[];
-
-/** @todo - define what data type is supported for 1D textures */
-export type Texture1DData = TypedArray | TextureLevelData;
-
-/** Texture data can be one or more mip levels */
-export type Texture2DData =
-  | TypedArray
-  | TextureLevelData
-  | ExternalImage
-  | (TextureLevelData | ExternalImage)[];
-
-/** Array of textures */
-export type Texture3DData = TypedArray | TextureData[];
-
-/** 6 face textures */
-export type TextureCubeData = Record<TextureCubeFace, Texture2DData>;
-
-/** Array of textures */
-export type TextureArrayData = TextureData[];
-
-/** Array of 6 face textures */
-export type TextureCubeArrayData = Record<TextureCubeFace, TextureData>[];
-
-export type TextureDataProps =
-  | Texture1DProps
-  | Texture2DProps
-  | Texture3DProps
-  | TextureArrayProps
-  | TextureCubeProps
-  | TextureCubeArrayProps;
-
-export type Texture1DProps = {dimension: '1d'; data?: Texture1DData | null};
-export type Texture2DProps = {dimension?: '2d'; data?: Texture2DData | null};
-export type Texture3DProps = {dimension: '3d'; data?: Texture3DData | null};
-export type TextureArrayProps = {dimension: '2d-array'; data?: TextureArrayData | null};
-export type TextureCubeProps = {dimension: 'cube'; data?: TextureCubeData | null};
-export type TextureCubeArrayProps = {dimension: 'cube-array'; data: TextureCubeArrayData | null};
+import {ExternalImage} from '../../image-utils/image-types';
+import {log} from '../../utils/log';
 
 /** Texture properties */
-export type TextureProps = ResourceProps &
-  TextureDataProps & {
-    format?: TextureFormat;
-    width?: number | undefined;
-    height?: number | undefined;
-    depth?: number;
-    usage?: number;
+export type TextureProps = ResourceProps & {
+  /** @deprecated Use AsyncTexture to create textures with data. */
+  data?: ExternalImage | TypedArray | null;
+  /** Dimension of this texture. Defaults to '2d' */
+  dimension?: '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
+  /** The format (bit layout) of the textures pixel data */
+  format?: TextureFormat;
+  /** Width in texels */
+  width?: number | undefined;
+  /** Width in texels */
+  height?: number | undefined;
+  /** Number of depth layers */
+  depth?: number;
+  /** How this texture will be used. Defaults to TEXTURE | COPY_DST | RENDER_ATTACHMENT */
+  usage?: number;
+  /** How many mip levels */
+  mipLevels?: number | 'auto';
+  /** Multi sampling */
+  samples?: number;
 
-    /** How many mip levels */
-    mipLevels?: number | 'pyramid';
-    /** Multi sampling */
-    samples?: number;
+  /** Specifying mipmaps will default mipLevels to 'auto' and attempt to generate mipmaps */
+  mipmaps?: boolean;
 
-    /** Specifying mipmaps will default mipLevels to 'pyramid' and attempt to generate mipmaps */
-    mipmaps?: boolean;
+  /** Sampler (or SamplerProps) for the default sampler for this texture. Used if no sampler provided. Note that other samplers can still be used. */
+  sampler?: Sampler | SamplerProps;
+  /** Props for the default TextureView for this texture. Note that other views can still be created and used. */
+  view?: TextureViewProps;
 
-    /** Sampler (or SamplerProps) for the default sampler for this texture. Used if no sampler provided. Note that other samplers can still be used. */
-    sampler?: Sampler | SamplerProps;
-    /** Props for the default TextureView for this texture. Note that other views can still be created and used. */
-    view?: TextureViewProps;
+  /** @deprecated - this is implicit from format */
+  compressed?: boolean;
 
-    /** Whether to flip the image vertically. Used if texture is initialized with an image. */
-    flipY?: boolean;
-
-    /** @deprecated - this is implicit from format */
-    compressed?: boolean;
-  };
+  /** Whether to flip a supplied image bitmap vertically. Used only if texture is initialized with an image. */
+  flipY?: boolean;
+};
 
 /** Options for Texture.copyExternalImage */
 export type CopyExternalImageOptions = {
@@ -139,16 +59,16 @@ export type CopyExternalImageOptions = {
   width?: number;
   /** Copy area height (default 1) */
   height?: number;
-  /** Copy depth (default 1) */
+  /** Copy depth, number of layers/depth slices(default 1) */
   depth?: number;
-  /** Which mip-level to copy into (default 0) */
-  mipLevel?: number;
   /** Start copying into offset x (default 0) */
   x?: number;
   /** Start copying into offset y (default 0) */
   y?: number;
-  /** Start copying from depth layer z (default 0) */
+  /** Start copying into layer / depth slice z (default 0) */
   z?: number;
+  /** Which mip-level to copy into (default 0) */
+  mipLevel?: number;
   /** When copying into depth stencil textures (default 'all') */
   aspect?: 'all' | 'stencil-only' | 'depth-only';
   /** Specific color space of image data */
@@ -159,45 +79,49 @@ export type CopyExternalImageOptions = {
   flipY?: boolean;
 };
 
+/** Options for copyImageData */
+export type CopyImageDataOptions = {
+  /** Data to copy (array of bytes) */
+  data: ArrayBuffer | SharedArrayBuffer | ArrayBufferView;
+  /** Offset into the data (in addition to any offset built-in to the ArrayBufferView) */
+  byteOffset?: number;
+  /** The stride, in bytes, between the beginning of each texel block row and the subsequent texel block row. Required if there are multiple texel block rows (i.e. the copy height or depth is more than one block). */
+  bytesPerRow?: number;
+  /** Number or rows per image (needed if multiple images are being set) */
+  rowsPerImage?: number;
+  /** Start copying into offset x (default 0) */
+  x?: number;
+  /** Start copying into offset y (default 0) */
+  y?: number;
+  /** Start copying from depth layer z (default 0) */
+  z?: number;
+  /** Which mip-level to copy into (default 0) */
+  mipLevel?: number;
+  /** When copying into depth stencil textures (default 'all') */
+  aspect?: 'all' | 'stencil-only' | 'depth-only';
+};
+
 /**
  * Abstract Texture interface
  * Texture Object
  * https://gpuweb.github.io/gpuweb/#gputexture
  */
 export abstract class Texture extends Resource<TextureProps> {
-  static COPY_SRC = 0x01;
-  static COPY_DST = 0x02;
-  static TEXTURE = 0x04;
+  /** The texture can be bound for use as a sampled texture in a shader */
+  static SAMPLER = 0x04;
+  /** The texture can be bound for use as a storage texture in a shader */
   static STORAGE = 0x08;
+  /** The texture can be used as a color or depth/stencil attachment in a render pass */
+  static RENDER = 0x10;
+  /** The texture can be used as the source of a copy operation */
+  static COPY_SRC = 0x01;
+  /** he texture can be used as the destination of a copy or write operation */
+  static COPY_DST = 0x02;
+
+  /** @deprecated Use Texture.SAMPLE */
+  static TEXTURE = 0x04;
+  /** @deprecated Use Texture.RENDER */
   static RENDER_ATTACHMENT = 0x10;
-
-  static CubeFaces: TextureCubeFace[] = ['+X', '-X', '+Y', '-Y', '+Z', '-Z'];
-
-  static override defaultProps: Required<TextureProps> = {
-    ...Resource.defaultProps,
-    data: null,
-    dimension: '2d',
-    format: 'rgba8unorm',
-    width: undefined!,
-    height: undefined!,
-    depth: 1,
-    mipmaps: false,
-    compressed: false,
-    usage: 0,
-    mipLevels: undefined!,
-    samples: undefined!,
-    sampler: {},
-    view: undefined!,
-    flipY: undefined!
-  };
-
-  override get [Symbol.toStringTag](): string {
-    return 'Texture';
-  }
-
-  override toString(): string {
-    return `Texture(${this.id},${this.format},${this.width}x${this.height})`;
-  }
 
   /** dimension of this texture */
   readonly dimension: '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
@@ -211,7 +135,6 @@ export abstract class Texture extends Resource<TextureProps> {
   depth: number;
   /** mip levels in this texture */
   mipLevels: number;
-
   /** Default sampler for this texture */
   abstract sampler: Sampler;
   /** Default view for this texture */
@@ -219,6 +142,14 @@ export abstract class Texture extends Resource<TextureProps> {
 
   /** "Time" of last update. Monotonically increasing timestamp. TODO move to AsyncTexture? */
   updateTimestamp: number;
+
+  override get [Symbol.toStringTag](): string {
+    return 'Texture';
+  }
+
+  override toString(): string {
+    return `Texture(${this.id},${this.format},${this.width}x${this.height})`;
+  }
 
   /** Do not use directly. Create with device.createTexture() */
   constructor(device: Device, props: TextureProps) {
@@ -232,26 +163,38 @@ export abstract class Texture extends Resource<TextureProps> {
     this.height = this.props.height;
     this.depth = this.props.depth;
 
+    // this.mipmaps = Boolean(this.props.mipmaps);
+
     // Calculate size, if not provided
     if (this.props.width === undefined || this.props.height === undefined) {
-      // @ts-ignore
-      const size = Texture.getTextureDataSize(this.props.data);
-      this.width = size?.width || 1;
-      this.height = size?.height || 1;
+      if (device.isExternalImage(props.data)) {
+        const size = device.getExternalImageSize(props.data);
+        this.width = size?.width || 1;
+        this.height = size?.height || 1;
+      } else {
+        this.width = 1;
+        this.height = 1;
+        if (this.props.width === undefined || this.props.height === undefined) {
+          log.warn(
+            `${this} created with undefined width or height. This is deprecated. Use AsyncTexture instead.`
+          )();
+        }
+      }
     }
 
     // mipLevels
 
     // If mipmap generation is requested and mipLevels is not provided, initialize a full pyramid
+    // TODO - is this too clever? Require app to specify both mipLevels: 'auto' and mipmaps: true?
     if (this.props.mipmaps && this.props.mipLevels === undefined) {
-      this.props.mipLevels = 'pyramid';
+      this.props.mipLevels = 'auto';
     }
 
     // Auto-calculate the number of mip levels as a convenience
     // TODO - Should we clamp to 1-getMipLevelCount?
     this.mipLevels =
-      this.props.mipLevels === 'pyramid'
-        ? Texture.getMipLevelCount(this.width, this.height)
+      this.props.mipLevels === 'auto'
+        ? device.getMipLevelCount(this.width, this.height)
         : this.props.mipLevels || 1;
 
     // TODO - perhaps this should be set on async write completion?
@@ -260,15 +203,15 @@ export abstract class Texture extends Resource<TextureProps> {
 
   /** Create a texture view for this texture */
   abstract createView(props: TextureViewProps): TextureView;
-
   /** Set sampler props associated with this texture */
   abstract setSampler(sampler?: Sampler | SamplerProps): void;
-
-  /** Copy external image data into the texture */
+  /** Copy an image (e.g an ImageBitmap) into the texture */
   abstract copyExternalImage(options: CopyExternalImageOptions): {width: number; height: number};
+  /** Copy raw image data (bytes) into the texture */
+  abstract copyImageData(options: CopyImageDataOptions): void;
 
   /**
-   * Create a new texture with the same parameters and optionally, a different size
+   * Create a new texture with the same parameters and optionally a different size
    * @note Textures are immutable and cannot be resized after creation, but we can create a similar texture with the same parameters but a new size.
    * @note Does not copy contents of the texture
    */
@@ -276,120 +219,77 @@ export abstract class Texture extends Resource<TextureProps> {
     return this.device.createTexture({...this.props, ...size});
   }
 
-  /** Check if data is an external image */
-  static isExternalImage(data: unknown): data is ExternalImage {
-    return (
-      (typeof ImageData !== 'undefined' && data instanceof ImageData) ||
-      (typeof ImageBitmap !== 'undefined' && data instanceof ImageBitmap) ||
-      (typeof HTMLImageElement !== 'undefined' && data instanceof HTMLImageElement) ||
-      (typeof HTMLVideoElement !== 'undefined' && data instanceof HTMLVideoElement) ||
-      (typeof VideoFrame !== 'undefined' && data instanceof VideoFrame) ||
-      (typeof HTMLCanvasElement !== 'undefined' && data instanceof HTMLCanvasElement) ||
-      (typeof OffscreenCanvas !== 'undefined' && data instanceof OffscreenCanvas)
-    );
+  /** Ensure we have integer coordinates */
+  protected static normalizeProps(device: Device, props: TextureProps): TextureProps {
+    const newProps = {...props};
+
+    // Allow device to override props (e.g. props.mipmaps)
+    const overriddenDefaultProps: Partial<TextureProps> =
+      device?.props?._resourceDefaults?.texture || {};
+    // Note: Type issue with props.data circumvented with Object.assign
+    Object.assign(newProps, overriddenDefaultProps);
+
+    // Ensure we have integer coordinates
+    const {width, height} = newProps;
+    if (typeof width === 'number') {
+      newProps.width = Math.max(1, Math.ceil(width));
+    }
+    if (typeof height === 'number') {
+      newProps.height = Math.max(1, Math.ceil(height));
+    }
+    return newProps;
   }
 
-  /** Determine size (width and height) of provided image data */
-  static getExternalImageSize(data: ExternalImage): {width: number; height: number} {
-    if (
-      (typeof ImageData !== 'undefined' && data instanceof ImageData) ||
-      (typeof ImageBitmap !== 'undefined' && data instanceof ImageBitmap) ||
-      (typeof HTMLCanvasElement !== 'undefined' && data instanceof HTMLCanvasElement) ||
-      (typeof OffscreenCanvas !== 'undefined' && data instanceof OffscreenCanvas)
-    ) {
-      return {width: data.width, height: data.height};
-    }
-    if (typeof HTMLImageElement !== 'undefined' && data instanceof HTMLImageElement) {
-      return {width: data.naturalWidth, height: data.naturalHeight};
-    }
-    if (typeof HTMLVideoElement !== 'undefined' && data instanceof HTMLVideoElement) {
-      return {width: data.videoWidth, height: data.videoHeight};
-    }
-    if (typeof VideoFrame !== 'undefined' && data instanceof VideoFrame) {
-      // TODO: is this the right choice for width and height?
-      return {width: data.displayWidth, height: data.displayHeight};
-    }
-    throw new Error('Unknown image type');
+  _normalizeCopyImageDataOptions(options_: CopyImageDataOptions): Required<CopyImageDataOptions> {
+    const {width, height, depth} = this;
+    const options = {...Texture.defaultCopyDataOptions, width, height, depth, ...options_};
+    // WebGL will error if we try to copy outside the bounds of the texture
+    // options.width = Math.min(options.width, this.width - options.x);
+    // options.height = Math.min(options.height, this.height - options.y);
+    return options;
   }
 
-  /** Check if texture data is a typed array */
-  static isTextureLevelData(data: TextureData): data is TextureLevelData {
-    const typedArray = (data as TextureLevelData)?.data;
-    return ArrayBuffer.isView(typedArray);
+  _normalizeCopyExternalImageOptions(
+    options_: CopyExternalImageOptions
+  ): Required<CopyExternalImageOptions> {
+    const size = this.device.getExternalImageSize(options_.image);
+    const options = {...Texture.defaultCopyExternalImageOptions, ...size, ...options_};
+    // WebGL will error if we try to copy outside the bounds of the texture
+    options.width = Math.min(options.width, this.width - options.x);
+    options.height = Math.min(options.height, this.height - options.y);
+    return options;
   }
 
-  /** Get the size of the texture described by the provided TextureData */
-  static getTextureDataSize(
-    data: TextureData | TextureCubeData | TextureArrayData | TextureCubeArrayData | TypedArray
-  ): {width: number; height: number} | null {
-    if (!data) {
-      return null;
-    }
-    if (ArrayBuffer.isView(data)) {
-      return null;
-    }
-    // Recurse into arrays (array of miplevels)
-    if (Array.isArray(data)) {
-      return Texture.getTextureDataSize(data[0]);
-    }
-    if (Texture.isExternalImage(data)) {
-      return Texture.getExternalImageSize(data);
-    }
-    if (data && typeof data === 'object' && data.constructor === Object) {
-      const textureDataArray = Object.values(data) as Texture2DData[];
-      const untypedData = textureDataArray[0] as any;
-      return {width: untypedData.width, height: untypedData.height};
-    }
-    throw new Error('texture size deduction failed');
-  }
+  /** Default options */
+  static override defaultProps: Required<TextureProps> = {
+    ...Resource.defaultProps,
+    data: null,
+    dimension: '2d',
+    format: 'rgba8unorm',
+    usage: Texture.TEXTURE | Texture.RENDER_ATTACHMENT | Texture.COPY_DST,
+    width: undefined!,
+    height: undefined!,
+    depth: 1,
+    mipmaps: false,
+    compressed: false,
+    mipLevels: undefined!,
+    samples: undefined!,
+    sampler: {},
+    view: undefined!,
+    flipY: undefined!
+  };
 
-  /**
-   * Normalize TextureData to an array of TextureLevelData / ExternalImages
-   * @param data
-   * @param options
-   * @returns array of TextureLevelData / ExternalImages
-   */
-  static normalizeTextureData(
-    data: Texture2DData,
-    options: {width: number; height: number; depth: number}
-  ): (TextureLevelData | ExternalImage)[] {
-    let lodArray: (TextureLevelData | ExternalImage)[];
-    if (ArrayBuffer.isView(data)) {
-      lodArray = [
-        {
-          // ts-expect-error does data really need to be Uint8ClampedArray?
-          data,
-          width: options.width,
-          height: options.height
-          // depth: options.depth
-        }
-      ];
-    } else if (!Array.isArray(data)) {
-      lodArray = [data];
-    } else {
-      lodArray = data;
-    }
-    return lodArray;
-  }
-
-  /** Calculate the number of mip levels for a texture of width and height */
-  static getMipLevelCount(width: number, height: number): number {
-    return Math.floor(Math.log2(Math.max(width, height))) + 1;
-  }
-
-  /** Convert luma.gl cubemap face constants to depth index */
-  static getCubeFaceDepth(face: TextureCubeFace): number {
-    // prettier-ignore
-    switch (face) {
-        case '+X': return  0;
-        case '-X': return  1;
-        case '+Y': return  2;
-        case '-Y': return  3;
-        case '+Z': return  4;
-        case '-Z': return  5;
-        default: throw new Error(face);
-      }
-  }
+  protected static defaultCopyDataOptions: Required<CopyImageDataOptions> = {
+    data: undefined!,
+    byteOffset: 0,
+    bytesPerRow: 0,
+    rowsPerImage: 0,
+    mipLevel: 0,
+    x: 0,
+    y: 0,
+    z: 0,
+    aspect: 'all'
+  };
 
   /** Default options */
   protected static defaultCopyExternalImageOptions: Required<CopyExternalImageOptions> = {
@@ -408,25 +308,4 @@ export abstract class Texture extends Resource<TextureProps> {
     premultipliedAlpha: false,
     flipY: false
   };
-
-  /** Ensure we have integer coordinates */
-  protected static normalizeProps(device: Device, props: TextureProps): TextureProps {
-    const newProps = {...props};
-
-    // Allow device to override props (e.g. props.mipmaps)
-    const overriddenDefaultProps: Partial<TextureProps> =
-      device?.props?._resourceDefaults?.texture || {};
-    // TODO - Type issue with props.data circumvented with Object.assign
-    Object.assign(newProps, overriddenDefaultProps);
-
-    // Ensure we have integer coordinates
-    const {width, height} = newProps;
-    if (typeof width === 'number') {
-      newProps.width = Math.max(1, Math.ceil(width));
-    }
-    if (typeof height === 'number') {
-      newProps.height = Math.max(1, Math.ceil(height));
-    }
-    return newProps;
-  }
 }

--- a/modules/core/src/gpu-type-utils/texture-formats.ts
+++ b/modules/core/src/gpu-type-utils/texture-formats.ts
@@ -2,6 +2,20 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+/**
+ * These represent the main compressed texture formats
+ * Each format typically has a number of more specific subformats
+ */
+export type TextureCompression =
+  | 'dxt'
+  | 'dxt-srgb'
+  | 'etc1'
+  | 'etc2'
+  | 'pvrtc'
+  | 'atc'
+  | 'astc'
+  | 'rgtc';
+
 /** Texture formats */
 export type TextureFormat = ColorTextureFormat | DepthStencilTextureFormat;
 

--- a/modules/core/src/image-utils/image-types.ts
+++ b/modules/core/src/image-utils/image-types.ts
@@ -1,0 +1,59 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/**
+ * Built-in data types that can be used to initialize textures
+ * @note ImageData can be used for contiguous 8 bit data via Uint8ClampedArray
+ */
+export type ExternalImage =
+  | ImageBitmap
+  | ImageData
+  | HTMLImageElement
+  | HTMLVideoElement
+  | VideoFrame
+  | HTMLCanvasElement
+  | OffscreenCanvas;
+
+export type ExternalImageData = {
+  data: ArrayBuffer | SharedArrayBuffer | ArrayBufferView;
+  byteOffset?: number;
+  bytesPerRow?: number;
+  rowsPerImage?: number;
+};
+
+/** Check if data is an external image */
+export function isExternalImage(data: unknown): data is ExternalImage {
+  return (
+    (typeof ImageData !== 'undefined' && data instanceof ImageData) ||
+    (typeof ImageBitmap !== 'undefined' && data instanceof ImageBitmap) ||
+    (typeof HTMLImageElement !== 'undefined' && data instanceof HTMLImageElement) ||
+    (typeof HTMLVideoElement !== 'undefined' && data instanceof HTMLVideoElement) ||
+    (typeof VideoFrame !== 'undefined' && data instanceof VideoFrame) ||
+    (typeof HTMLCanvasElement !== 'undefined' && data instanceof HTMLCanvasElement) ||
+    (typeof OffscreenCanvas !== 'undefined' && data instanceof OffscreenCanvas)
+  );
+}
+
+/** Determine size (width and height) of provided image data */
+export function getExternalImageSize(data: ExternalImage): {width: number; height: number} {
+  if (
+    (typeof ImageData !== 'undefined' && data instanceof ImageData) ||
+    (typeof ImageBitmap !== 'undefined' && data instanceof ImageBitmap) ||
+    (typeof HTMLCanvasElement !== 'undefined' && data instanceof HTMLCanvasElement) ||
+    (typeof OffscreenCanvas !== 'undefined' && data instanceof OffscreenCanvas)
+  ) {
+    return {width: data.width, height: data.height};
+  }
+  if (typeof HTMLImageElement !== 'undefined' && data instanceof HTMLImageElement) {
+    return {width: data.naturalWidth, height: data.naturalHeight};
+  }
+  if (typeof HTMLVideoElement !== 'undefined' && data instanceof HTMLVideoElement) {
+    return {width: data.videoWidth, height: data.videoHeight};
+  }
+  if (typeof VideoFrame !== 'undefined' && data instanceof VideoFrame) {
+    // TODO: is this the right choice for width and height?
+    return {width: data.displayWidth, height: data.displayHeight};
+  }
+  throw new Error('Unknown image type');
+}

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -81,20 +81,8 @@ export {UniformStore} from './portable/uniform-store';
 // API TYPES
 export type {CompilerMessage} from './adapter/types/compiler-message';
 
-export type {
-  TextureCompressionFormat,
-  TextureCubeFace,
-  TextureLevelData,
-  ExternalImage,
-  TextureData,
-  Texture1DData,
-  Texture2DData,
-  Texture3DData,
-  TextureCubeData,
-  TextureArrayData,
-  TextureCubeArrayData,
-  CopyExternalImageOptions
-} from './adapter/resources/texture';
+export type {ExternalImage} from './image-utils/image-types';
+export type {CopyExternalImageOptions, CopyImageDataOptions} from './adapter/resources/texture';
 
 export type {Parameters, PrimitiveTopology, IndexFormat} from './adapter/types/parameters';
 
@@ -147,7 +135,8 @@ export type {
 export type {
   TextureFormat,
   ColorTextureFormat,
-  DepthStencilTextureFormat
+  DepthStencilTextureFormat,
+  TextureCompression
 } from './gpu-type-utils/texture-formats';
 export type {TextureFormatInfo} from './gpu-type-utils/texture-format-info';
 export type {TextureFormatCapabilities} from './gpu-type-utils/texture-format-capabilities';

--- a/modules/core/test/adapter/canvas-context.spec.ts
+++ b/modules/core/test/adapter/canvas-context.spec.ts
@@ -50,7 +50,7 @@ test('CanvasContext#getDevicePixelRatio', async t => {
 
   for (const device of await getTestDevices()) {
     TEST_CASES.forEach(tc => {
-      const result = device.canvasContext?.getDevicePixelRatio(tc.useDevicePixels);
+      const result = device.getDefaultCanvasContext().getDevicePixelRatio(tc.useDevicePixels);
       t.equal(result, tc.expected, tc.name);
     });
   }

--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -195,6 +195,7 @@ function testFormatCreation(t, device: Device, withData: boolean = false) {
     if (canGenerateMipmaps) {
       try {
         const data = withData && !packed ? TEXTURE_DATA[dataType] || DEFAULT_TEXTURE_DATA : null;
+
         const capabilities = device.getTextureFormatCapabilities(format);
         const mipmaps = capabilities.render && capabilities.filter;
 

--- a/modules/effects/src/passes/postprocessing/image-adjust-filters/brightnesscontrast.ts
+++ b/modules/effects/src/passes/postprocessing/image-adjust-filters/brightnesscontrast.ts
@@ -6,8 +6,8 @@ import type {ShaderPass} from '@luma.gl/shadertools';
 
 const source = /* wgsl */ `\
 struct brightnessContrastUniforms {
-  float brightness;
-  float contrast;
+  brightness: f32,
+  contrast: f32
 };
 
 // Binding 0:1 is reserved for shader passes
@@ -20,7 +20,7 @@ fn brightnessContrast_filterColor_ext(color: vec4<f32>, texSize: vec2<f32>, texC
   } else {
     color.rgb = (color.rgb - 0.5) * (1.0 + brightnessContrast.contrast) + 0.5;
   }
-  return color;
+  return vec4<f32>(1.0, 0.0, 0.0, 1.0);
 }
 `;
 

--- a/modules/engine/src/animation-loop/animation-loop.ts
+++ b/modules/engine/src/animation-loop/animation-loop.ts
@@ -130,7 +130,7 @@ export class AnimationLoop {
   setError(error: Error): void {
     this.props.onError(error);
     this._error = Error();
-    const canvas = this.device?.canvasContext?.canvas;
+    const canvas = this.device?.getDefaultCanvasContext().canvas;
     if (canvas instanceof HTMLCanvasElement) {
       const errorDiv = document.createElement('h1');
       errorDiv.innerHTML = error.message;
@@ -377,7 +377,7 @@ export class AnimationLoop {
 
   // Initialize the  object that will be passed to app callbacks
   _initializeAnimationProps(): void {
-    const canvas = this.device?.canvasContext?.canvas;
+    const canvas = this.device?.getDefaultCanvasContext().canvas;
 
     if (!this.device || !canvas) {
       throw new Error('loop');
@@ -460,7 +460,7 @@ export class AnimationLoop {
     if (!this.device) {
       throw new Error('No device provided');
     }
-    this.canvas = this.device.canvasContext?.canvas || null;
+    this.canvas = this.device.getDefaultCanvasContext().canvas || null;
     // this._createInfoDiv();
   }
 
@@ -491,11 +491,11 @@ export class AnimationLoop {
       return {width: 1, height: 1, aspect: 1};
     }
     // https://webglfundamentals.org/webgl/lessons/webgl-resizing-the-canvas.html
-    const [width, height] = this.device?.canvasContext?.getPixelSize() || [1, 1];
+    const [width, height] = this.device?.getDefaultCanvasContext().getPixelSize() || [1, 1];
 
     // https://webglfundamentals.org/webgl/lessons/webgl-anti-patterns.html
     let aspect = 1;
-    const canvas = this.device?.canvasContext?.canvas;
+    const canvas = this.device?.getDefaultCanvasContext().canvas;
 
     // @ts-expect-error
     if (canvas && canvas.clientHeight) {
@@ -531,7 +531,7 @@ export class AnimationLoop {
    */
   _resizeCanvasDrawingBuffer(): void {
     if (this.props.autoResizeDrawingBuffer) {
-      this.device?.canvasContext?.resize({useDevicePixels: this.props.useDevicePixels});
+      this.device?.getDefaultCanvasContext().resize({useDevicePixels: this.props.useDevicePixels});
     }
   }
 

--- a/modules/engine/src/async-texture/texture-setters.ts.disabled
+++ b/modules/engine/src/async-texture/texture-setters.ts.disabled
@@ -1,0 +1,296 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Texture, TypedArray, TextureFormat, ExternalImage} from '@luma.gl/core';
+import {isExternalImage, getExternalImageSize} from '@luma.gl/core';
+
+/** Names of cube texture faces */
+export type TextureCubeFace = '+X' | '-X' | '+Y' | '-Y' | '+Z' | '-Z';
+
+/**
+ * One mip level
+ * Basic data structure is similar to `ImageData`
+ * additional optional fields can describe compressed texture data.
+ */
+export type TextureLevelData = {
+  /** WebGPU style format string. Defaults to 'rgba8unorm' */
+  format?: TextureFormat;
+  data: TypedArray;
+  width: number;
+  height: number;
+
+  compressed?: boolean;
+  byteLength?: number;
+  hasAlpha?: boolean;
+};
+
+export type TextureLevelSource = TextureLevelData | ExternalImage;
+
+/** Texture data can be one or more mip levels */
+export type TextureData = TextureLevelData | ExternalImage | (TextureLevelData | ExternalImage)[];
+
+/** @todo - define what data type is supported for 1D textures */
+export type Texture1DData = TypedArray | TextureLevelData;
+
+/** Texture data can be one or more mip levels */
+export type Texture2DData =
+  | TypedArray
+  | TextureLevelData
+  | ExternalImage
+  | (TextureLevelData | ExternalImage)[];
+
+/** Array of textures */
+export type Texture3DData = TypedArray | TextureData[];
+
+/** 6 face textures */
+export type TextureCubeData = Record<TextureCubeFace, Texture2DData>;
+
+/** Array of textures */
+export type TextureArrayData = TextureData[];
+
+/** Array of 6 face textures */
+export type TextureCubeArrayData = Record<TextureCubeFace, TextureData>[];
+
+export type TextureDataProps =
+  | Texture1DProps
+  | Texture2DProps
+  | Texture3DProps
+  | TextureArrayProps
+  | TextureCubeProps
+  | TextureCubeArrayProps;
+
+export type Texture1DProps = {dimension: '1d'; data?: Texture1DData | null};
+export type Texture2DProps = {dimension?: '2d'; data?: Texture2DData | null};
+export type Texture3DProps = {dimension: '3d'; data?: Texture3DData | null};
+export type TextureArrayProps = {dimension: '2d-array'; data?: TextureArrayData | null};
+export type TextureCubeProps = {dimension: 'cube'; data?: TextureCubeData | null};
+export type TextureCubeArrayProps = {dimension: 'cube-array'; data: TextureCubeArrayData | null};
+
+export const CubeFaces: TextureCubeFace[] = ['+X', '-X', '+Y', '-Y', '+Z', '-Z'];
+
+/** Check if texture data is a typed array */
+export function isTextureLevelData(data: TextureData): data is TextureLevelData {
+  const typedArray = (data as TextureLevelData)?.data;
+  return ArrayBuffer.isView(typedArray);
+}
+
+/** Get the size of the texture described by the provided TextureData */
+export function getTextureDataSize(
+  data: TextureData | TextureCubeData | TextureArrayData | TextureCubeArrayData | TypedArray
+): {width: number; height: number} | null {
+  if (!data) {
+    return null;
+  }
+  if (ArrayBuffer.isView(data)) {
+    return null;
+  }
+  // Recurse into arrays (array of miplevels)
+  if (Array.isArray(data)) {
+    return getTextureDataSize(data[0]);
+  }
+  if (isExternalImage(data)) {
+    return getExternalImageSize(data);
+  }
+  if (data && typeof data === 'object' && data.constructor === Object) {
+    const textureDataArray = Object.values(data) as Texture2DData[];
+    const untypedData = textureDataArray[0] as any;
+    return {width: untypedData.width, height: untypedData.height};
+  }
+  throw new Error('texture size deduction failed');
+}
+
+/**
+ * Normalize TextureData to an array of TextureLevelData / ExternalImages
+ * @param data
+ * @param options
+ * @returns array of TextureLevelData / ExternalImages
+ */
+export function normalizeTextureData(
+  data: Texture2DData,
+  options: {width: number; height: number; depth: number}
+): (TextureLevelData | ExternalImage)[] {
+  let lodArray: (TextureLevelData | ExternalImage)[];
+  if (ArrayBuffer.isView(data)) {
+    lodArray = [
+      {
+        // ts-expect-error does data really need to be Uint8ClampedArray?
+        data,
+        width: options.width,
+        height: options.height
+        // depth: options.depth
+      }
+    ];
+  } else if (!Array.isArray(data)) {
+    lodArray = [data];
+  } else {
+    lodArray = data;
+  }
+  return lodArray;
+}
+
+/** Convert luma.gl cubemap face constants to depth index */
+export function getCubeFaceDepth(face: TextureCubeFace): number {
+  // prettier-ignore
+  switch (face) {
+        case '+X': return  0;
+        case '-X': return  1;
+        case '+Y': return  2;
+        case '-Y': return  3;
+        case '+Z': return  4;
+        case '-Z': return  5;
+        default: throw new Error(face);
+      }
+}
+
+// EXPERIMENTAL
+
+/** Set multiple mip levels */
+export function setTexture1DData(texture: Texture, data: Texture1DData): void {
+  throw new Error('setTexture1DData not supported in WebGL.');
+}
+
+/** Set multiple mip levels */
+export function setTexture2DData(texture: Texture, lodData: Texture2DData, depth = 0): void {
+  this.bind();
+
+  const lodArray = Texture.normalizeTextureData(lodData, this);
+
+  // If the user provides multiple LODs, then automatic mipmap
+  // generation generateMipmap() should be disabled to avoid overwriting them.
+  if (lodArray.length > 1 && this.props.mipmaps !== false) {
+    log.warn(`Texture ${this.id} mipmap and multiple LODs.`)();
+  }
+
+  for (let lodLevel = 0; lodLevel < lodArray.length; lodLevel++) {
+    const imageData = lodArray[lodLevel];
+    this._setMipLevel(depth, lodLevel, imageData);
+  }
+
+  this.unbind();
+}
+
+/**
+ * Sets 3D texture data: multiple depth slices, multiple mip levels
+ * @param data
+ */
+export function setTexture3DData(texture: Texture, data: Texture3DData): void {
+  if (this.props.dimension !== '3d') {
+    throw new Error(this.id);
+  }
+  if (ArrayBuffer.isView(data)) {
+    this.bind();
+    copyCPUDataToMipLevel(this.device.gl, data, this);
+    this.unbind();
+  }
+}
+
+/**
+ * Set Cube texture data, multiple faces, multiple mip levels
+ * @todo - could support TextureCubeArray with depth
+ * @param data
+ * @param index
+ */
+export function setTextureCubeData(texture: Texture, data: TextureCubeData): void {
+  if (this.props.dimension !== 'cube') {
+    throw new Error(this.id);
+  }
+  for (const face of Texture.CubeFaces) {
+    this.setTextureCubeFaceData(data[face], face);
+  }
+}
+
+/**
+ * Sets texture array data, multiple levels, multiple depth slices
+ * @param data
+ */
+export function setTextureArrayData(texture: Texture, data: TextureArrayData): void {
+  if (this.props.dimension !== '2d-array') {
+    throw new Error(this.id);
+  }
+  throw new Error('setTextureArrayData not implemented.');
+}
+
+/**
+ * Sets texture cube array, multiple faces, multiple levels, multiple mip levels
+ * @param data
+ */
+export function setTextureCubeArrayData(texture: Texture, data: TextureCubeArrayData): void {
+  throw new Error('setTextureCubeArrayData not supported in WebGL2.');
+}
+
+export function setTextureCubeFaceData(
+  texture: Texture,
+  lodData: Texture2DData,
+  face: TextureCubeFace,
+  depth: number = 0
+): void {
+  // assert(this.props.dimension === 'cube');
+
+  // If the user provides multiple LODs, then automatic mipmap
+  // generation generateMipmap() should be disabled to avoid overwriting them.
+  if (Array.isArray(lodData) && lodData.length > 1 && this.props.mipmaps !== false) {
+    log.warn(`${this.id} has mipmap and multiple LODs.`)();
+  }
+
+  const faceDepth = Texture.CubeFaces.indexOf(face);
+
+  this.setTexture2DData(lodData, faceDepth);
+}
+
+// TODO - Remove when texture refactor is complete
+
+/*
+setCubeMapData(options: {
+  width: number;
+  height: number;
+  data: Record<GL, Texture2DData> | Record<TextureCubeFace, Texture2DData>;
+  format?: any;
+  type?: any;
+  /** @deprecated Use .data *
+  pixels: any;
+}): void {
+  const {gl} = this;
+
+  const {width, height, pixels, data, format = GL.RGBA, type = GL.UNSIGNED_BYTE} = options;
+
+  // pixel data (imageDataMap) is an Object from Face to Image or Promise.
+  // For example:
+  // {
+  // GL.TEXTURE_CUBE_MAP_POSITIVE_X : Image-or-Promise,
+  // GL.TEXTURE_CUBE_MAP_NEGATIVE_X : Image-or-Promise,
+  // ... }
+  // To provide multiple level-of-details (LODs) this can be Face to Array
+  // of Image or Promise, like this
+  // {
+  // GL.TEXTURE_CUBE_MAP_POSITIVE_X : [Image-or-Promise-LOD-0, Image-or-Promise-LOD-1],
+  // GL.TEXTURE_CUBE_MAP_NEGATIVE_X : [Image-or-Promise-LOD-0, Image-or-Promise-LOD-1],
+  // ... }
+
+  const imageDataMap = this._getImageDataMap(pixels || data);
+
+  const resolvedFaces = WEBGLTexture.FACES.map(face => {
+    const facePixels = imageDataMap[face];
+    return Array.isArray(facePixels) ? facePixels : [facePixels];
+  });
+  this.bind();
+
+  WEBGLTexture.FACES.forEach((face, index) => {
+    if (resolvedFaces[index].length > 1 && this.props.mipmaps !== false) {
+      // If the user provides multiple LODs, then automatic mipmap
+      // generation generateMipmaps() should be disabled to avoid overwritting them.
+      log.warn(`${this.id} has mipmap and multiple LODs.`)();
+    }
+    resolvedFaces[index].forEach((image, lodLevel) => {
+      // TODO: adjust width & height for LOD!
+      if (width && height) {
+        gl.texImage2D(face, lodLevel, format, width, height, 0 /* border*, format, type, image);
+      } else {
+        gl.texImage2D(face, lodLevel, format, format, type, image);
+      }
+    });
+  });
+
+  this.unbind();
+}
+*/

--- a/modules/engine/src/compute/swap.ts
+++ b/modules/engine/src/compute/swap.ts
@@ -46,7 +46,7 @@ export class SwapFramebuffers extends Swap<Framebuffer> {
         ? colorAttachment
         : device.createTexture({
             format: colorAttachment,
-            usage: Texture.COPY_DST | Texture.RENDER_ATTACHMENT
+            usage: Texture.TEXTURE | Texture.COPY_SRC | Texture.COPY_DST | Texture.RENDER_ATTACHMENT
           })
     );
 
@@ -57,7 +57,7 @@ export class SwapFramebuffers extends Swap<Framebuffer> {
         ? colorAttachment
         : device.createTexture({
             format: colorAttachment,
-            usage: Texture.COPY_DST | Texture.RENDER_ATTACHMENT
+            usage: Texture.TEXTURE | Texture.COPY_SRC | Texture.COPY_DST | Texture.RENDER_ATTACHMENT
           })
     );
 

--- a/modules/engine/src/index.ts
+++ b/modules/engine/src/index.ts
@@ -80,6 +80,18 @@ export {SwapFramebuffers} from './compute/swap';
 export type {ComputationProps} from './compute/computation';
 export {Computation} from './compute/computation';
 
+export type {
+  TextureCubeFace,
+  TextureImageData,
+  TextureData,
+  Texture1DData,
+  Texture2DData,
+  Texture3DData,
+  TextureCubeData,
+  TextureArrayData,
+  TextureCubeArrayData
+} from './async-texture/async-texture';
+
 export type {AsyncTextureProps} from './async-texture/async-texture';
 export {AsyncTexture} from './async-texture/async-texture';
 

--- a/modules/engine/src/models/billboard-texture-model.ts
+++ b/modules/engine/src/models/billboard-texture-model.ts
@@ -67,7 +67,6 @@ export class BackgroundTextureModel extends ClipSpace {
       fs: BACKGROUND_FS,
       parameters: {
         depthWriteEnabled: false,
-        depthCompare: 'always',
         ...(props.blend
           ? {
               blend: true,

--- a/modules/engine/src/passes/get-fragment-shader.ts
+++ b/modules/engine/src/passes/get-fragment-shader.ts
@@ -37,11 +37,11 @@ export function getFragmentShaderForRenderPass(options: {
 function getFilterShaderWGSL(func: string) {
   return /* wgsl */ `\
 // Binding 0:1 is reserved for shader passes
-@group(0) @binding(0) var<uniform> brightnessContrast : brightnessContrastUniforms;
+// @group(0) @binding(0) var<uniform> brightnessContrast : brightnessContrastUniforms;
 @group(0) @binding(1) var texture: texture_2d<f32>;
 @group(0) @binding(2) var sampler: sampler;
 
-struct FragmentInputs = {
+struct FragmentInputs {
   @location(0) fragUV: vec2f,
   @location(1) fragPosition: vec4f,
   @location(2) fragCoordinate: vec4f

--- a/modules/test-utils/src/deprecated/classic-animation-loop.ts
+++ b/modules/test-utils/src/deprecated/classic-animation-loop.ts
@@ -637,7 +637,7 @@ export class ClassicAnimationLoop {
    */
   _resizeCanvasDrawingBuffer() {
     if (this.props.autoResizeDrawingBuffer) {
-      this.device.canvasContext.resize({useDevicePixels: this.props.useDevicePixels});
+      this.device.getDefaultCanvasContext().resize({useDevicePixels: this.props.useDevicePixels});
     }
   }
 

--- a/modules/test-utils/src/null-device/resources/null-texture.ts
+++ b/modules/test-utils/src/null-device/resources/null-texture.ts
@@ -8,12 +8,7 @@ import type {
   SamplerProps,
   TextureViewProps,
   CopyExternalImageOptions,
-  Texture1DData,
-  Texture2DData,
-  Texture3DData,
-  TextureCubeData,
-  TextureArrayData,
-  TextureCubeArrayData
+  CopyImageDataOptions
 } from '@luma.gl/core';
 
 import {Texture} from '@luma.gl/core';
@@ -50,30 +45,6 @@ export class NullTexture extends Texture {
 
   createView(props: TextureViewProps): NullTextureView {
     return new NullTextureView(this.device, {...props, texture: this});
-  }
-
-  setTexture1DData(data: Texture1DData): void {
-    throw new Error('not implemented');
-  }
-
-  setTexture2DData(lodData: Texture2DData, depth?: number, target?: number): void {
-    throw new Error('not implemented');
-  }
-
-  setTexture3DData(lodData: Texture3DData, depth?: number, target?: number): void {
-    throw new Error('not implemented');
-  }
-
-  setTextureCubeData(data: TextureCubeData, depth?: number): void {
-    throw new Error('not implemented');
-  }
-
-  setTextureArrayData(data: TextureArrayData): void {
-    throw new Error('not implemented');
-  }
-
-  setTextureCubeArrayData(data: TextureCubeArrayData): void {
-    throw new Error('not implemented');
   }
 
   initialize(props: TextureProps = {}): this {
@@ -121,5 +92,9 @@ export class NullTexture extends Texture {
     this.height = height;
 
     return {width, height};
+  }
+
+  override copyImageData(options: CopyImageDataOptions): void {
+    throw new Error('copyImageData not implemented');
   }
 }

--- a/modules/webgl/src/adapter/helpers/webgl-texture-utils.ts
+++ b/modules/webgl/src/adapter/helpers/webgl-texture-utils.ts
@@ -2,12 +2,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-//
-// WebGL... the texture API from hell... hopefully made simpler
-//
-
-import {TypedArray} from '@math.gl/types';
-import type {ExternalImage} from '@luma.gl/core';
 import {Buffer, Texture, Framebuffer, FramebufferProps} from '@luma.gl/core';
 import {
   GL,
@@ -23,7 +17,6 @@ import {getGLTypeFromTypedArray, getTypedArrayFromGLType} from './typed-array-ut
 import {glFormatToComponents, glTypeToBytes} from './format-utils';
 import {WEBGLBuffer} from '../resources/webgl-buffer';
 import {WEBGLTexture} from '../resources/webgl-texture';
-import {withGLParameters} from '../../context/state-tracker/with-parameters';
 
 /** A "border" parameter is required in many WebGL texture APIs, but must always be 0... */
 const BORDER = 0;
@@ -82,120 +75,6 @@ export type WebGLCopyTextureOptions = {
   byteOffset?: number;
   byteLength?: number;
 };
-
-/**
- * Initializes a texture memory space
- * Clear all the textures and mip levels of a two-dimensional or array texture at the same time.
- * On some implementations faster than repeatedly setting levels
- *
- * @note From WebGL 2 spec section 3.7.6:
- * @see https://registry.khronos.org/webgl/specs/latest/2.0/
- * - The image contents are set as if a buffer of sufficient size initialized to 0 would be passed to each level's texImage2D/3D
- * - texStorage2D should be considered a preferred alternative to texImage2D. It may have lower memory costs than texImage2D in some implementations.
- * - Once texStorage*D has been called, the texture is immutable and can only be updated with texSubImage*(), not texImage()
- */
-export function initializeTextureStorage(
-  gl: WebGL2RenderingContext,
-  levels: number,
-  options: WebGLSetTextureOptions
-): void {
-  const {dimension, width, height, depth = 0} = options;
-  const {glInternalFormat} = options;
-  const glTarget = options.glTarget; // getWebGLCubeFaceTarget(options.glTarget, dimension, depth);
-  switch (dimension) {
-    case '2d-array':
-    case '3d':
-      gl.texStorage3D(glTarget, levels, glInternalFormat, width, height, depth);
-      break;
-
-    default:
-      gl.texStorage2D(glTarget, levels, glInternalFormat, width, height);
-  }
-}
-
-/**
- * Copy a region of compressed data from a GPU memory buffer into this texture.
- */
-export function copyExternalImageToMipLevel(
-  gl: WebGL2RenderingContext,
-  handle: WebGLTexture,
-  image: ExternalImage,
-  options: WebGLCopyTextureOptions & {flipY?: boolean}
-): void {
-  const {width, height} = options;
-  const {dimension, depth = 0, mipLevel = 0} = options;
-  const {x = 0, y = 0, z = 0} = options;
-  const {glFormat, glType} = options;
-
-  const glTarget = getWebGLCubeFaceTarget(options.glTarget, dimension, depth);
-
-  const glParameters = options.flipY ? {[GL.UNPACK_FLIP_Y_WEBGL]: true} : {};
-  withGLParameters(gl, glParameters, () => {
-    switch (dimension) {
-      case '2d-array':
-      case '3d':
-        gl.bindTexture(glTarget, handle);
-        // prettier-ignore
-        gl.texSubImage3D(glTarget, mipLevel, x, y, z, width, height, depth, glFormat, glType, image);
-        gl.bindTexture(glTarget, null);
-        break;
-
-      case '2d':
-      case 'cube':
-        gl.bindTexture(glTarget, handle);
-        // prettier-ignore
-        gl.texSubImage2D(glTarget, mipLevel, x, y, width, height, glFormat, glType, image);
-        gl.bindTexture(glTarget, null);
-        break;
-
-      default:
-        throw new Error(dimension);
-    }
-  });
-}
-
-/**
- * Copy a region of data from a CPU memory buffer into this texture.
- */
-export function copyCPUDataToMipLevel(
-  gl: WebGL2RenderingContext,
-  typedArray: TypedArray,
-  options: WebGLCopyTextureOptions
-): void {
-  const {dimension, width, height, depth = 0, mipLevel = 0, byteOffset = 0} = options;
-  const {x = 0, y = 0, z = 0} = options;
-  const {glFormat, glType, compressed} = options;
-  const glTarget = getWebGLCubeFaceTarget(options.glTarget, dimension, depth);
-
-  // gl.bindTexture(glTarget, null);
-
-  switch (dimension) {
-    case '2d-array':
-    case '3d':
-      if (compressed) {
-        // prettier-ignore
-        gl.compressedTexSubImage3D(glTarget, mipLevel, x, y, z, width, height, depth, glFormat, typedArray, byteOffset); // , byteLength
-      } else {
-        // prettier-ignore
-        gl.texSubImage3D(glTarget, mipLevel, x, y, z, width, height, depth, glFormat, glType, typedArray, byteOffset); // , byteLength
-      }
-      break;
-
-    case '2d':
-    case 'cube':
-      if (compressed) {
-        // prettier-ignore
-        gl.compressedTexSubImage2D(glTarget, mipLevel, x, y, width, height, glFormat, typedArray, byteOffset); // , byteLength
-      } else {
-        // prettier-ignore
-        gl.texSubImage2D(glTarget, mipLevel, x, y, width, height, glFormat, glType, typedArray, byteOffset); // , byteLength
-      }
-      break;
-
-    default:
-      throw new Error(dimension);
-  }
-}
 
 /**
  * Copy a region of compressed data from a GPU memory buffer into this texture.

--- a/modules/webgl/src/adapter/resources/webgl-texture.ts
+++ b/modules/webgl/src/adapter/resources/webgl-texture.ts
@@ -9,37 +9,27 @@ import type {
   Sampler,
   SamplerProps,
   SamplerParameters,
-  TextureCubeFace,
-  ExternalImage,
-  Texture1DData,
-  Texture2DData,
-  Texture3DData,
-  TextureCubeData,
-  TextureArrayData,
-  TextureCubeArrayData
+  CopyExternalImageOptions,
+  CopyImageDataOptions,
+  TypedArray
 } from '@luma.gl/core';
 import {Texture, log} from '@luma.gl/core';
 import {
   GL,
-  GLPixelType,
-  GLSamplerParameters,
+  GLTextureTarget,
+  GLTextureCubeMapTarget,
   GLTexelDataFormat,
-  GLTextureTarget
+  GLPixelType,
+  // GLDataType,
+  GLSamplerParameters,
+  GLValueParameters
 } from '@luma.gl/constants';
 import {getTextureFormatWebGL} from '../converters/webgl-texture-table';
 import {convertSamplerParametersToWebGL} from '../converters/sampler-parameters';
+import {withGLParameters} from '../../context/state-tracker/with-parameters';
 import {WebGLDevice} from '../webgl-device';
 import {WEBGLSampler} from './webgl-sampler';
 import {WEBGLTextureView} from './webgl-texture-view';
-
-import {
-  initializeTextureStorage,
-  // clearMipLevel,
-  copyExternalImageToMipLevel,
-  copyCPUDataToMipLevel,
-  // copyGPUBufferToMipLevel,
-  getWebGLTextureTarget
-} from '../helpers/webgl-texture-utils';
 
 /**
  * WebGL... the texture API from hell... hopefully made simpler
@@ -53,11 +43,8 @@ export class WEBGLTexture extends Texture {
   sampler: WEBGLSampler = undefined; // TODO - currently unused in WebGL. Create dummy sampler?
   view: WEBGLTextureView = undefined; // TODO - currently unused in WebGL. Create dummy view?
 
+  /** Whether mipmaps were requested for this texture */
   mipmaps: boolean;
-
-  // Texture type
-  /** Whether the internal format is compressed */
-  compressed: boolean;
 
   /**
    * The WebGL target corresponding to the texture type
@@ -75,85 +62,103 @@ export class WEBGLTexture extends Texture {
   glType: GLPixelType;
   /** The WebGL constant corresponding to the WebGPU style constant in format */
   glInternalFormat: GL;
+  /** Whether the internal format is compressed */
+  compressed: boolean;
 
   // state
   /** Texture binding slot - TODO - move to texture view? */
-  textureUnit: number = 0;
+  _textureUnit: number = 0;
 
   constructor(device: Device, props: TextureProps) {
     super(device, props);
 
-    // Texture base class strips out the data prop, so we need to add it back in
-    const propsWithData = {...this.props};
-    propsWithData.data = props.data;
-
     this.device = device as WebGLDevice;
     this.gl = this.device.gl;
 
+    this.mipmaps = Boolean(this.props.mipmaps);
+
+    const formatInfo = getTextureFormatWebGL(this.props.format);
+
     // Note: In WebGL the texture target defines the type of texture on first bind.
     this.glTarget = getWebGLTextureTarget(this.props.dimension);
-
-    // The target format of this texture
-    const formatInfo = getTextureFormatWebGL(this.props.format);
     this.glInternalFormat = formatInfo.internalFormat;
     this.glFormat = formatInfo.format;
     this.glType = formatInfo.type;
     this.compressed = formatInfo.compressed;
-    this.mipmaps = Boolean(this.props.mipmaps);
 
-    this._initialize(propsWithData);
+    this.handle = this.props.handle || this.gl.createTexture();
+    this.device._setWebGLDebugMetadata(this.handle, this, {spector: this.props});
+
+    /**
+     * Use WebGL immutable texture storage to allocate and clear texture memory.
+     * - texStorage2D should be considered a preferred alternative to texImage2D. It may have lower memory costs than texImage2D in some implementations.
+     * - Once texStorage*D has been called, the texture is immutable and can only be updated with texSubImage*(), not texImage()
+     * @see https://registry.khronos.org/webgl/specs/latest/2.0/ WebGL 2 spec section 3.7.6
+     */
+    this.gl.bindTexture(this.glTarget, this.handle);
+    const {dimension, width, height, depth, mipLevels, glTarget, glInternalFormat} = this;
+    switch (dimension) {
+      case '2d':
+      case 'cube':
+        this.gl.texStorage2D(glTarget, mipLevels, glInternalFormat, width, height);
+        break;
+      case '2d-array':
+      case '3d':
+        this.gl.texStorage3D(glTarget, mipLevels, glInternalFormat, width, height, depth);
+        break;
+      default:
+      // Can never happen in WebGL
+    }
+    this.gl.bindTexture(this.glTarget, null);
+
+    // Set data
+    this._initializeData(props.data);
+
+    // Set texture sampler parameters
+    this.setSampler(this.props.sampler);
+    // @ts-ignore TODO - fix types
+    this.view = new WEBGLTextureView(this.device, {...this.props, texture: this});
 
     Object.seal(this);
   }
 
   /** Initialize texture with supplied props */
   // eslint-disable-next-line max-statements
-  _initialize(propsWithData: TextureProps): void {
-    this.handle = this.props.handle || this.gl.createTexture();
-    this.device._setWebGLDebugMetadata(this.handle, this, {
-      spector: {
-        ...this.props,
-        data: propsWithData.data
-      }
-    });
-
-    let {width, height} = propsWithData;
-
-    if (!width || !height) {
-      const textureSize = Texture.getTextureDataSize(propsWithData.data);
-      width = textureSize?.width || 1;
-      height = textureSize?.height || 1;
-    }
-
+  _initializeData(data: TextureProps['data']): void {
     // Store opts for accessors
-    this.width = width;
-    this.height = height;
-    this.depth = propsWithData.depth;
 
-    // Set texture sampler parameters
-    this.setSampler(propsWithData.sampler);
-    // @ts-ignore TODO - fix types
-    this.view = new WEBGLTextureView(this.device, {...this.props, texture: this});
-
-    this.bind();
-    initializeTextureStorage(this.gl, this.mipLevels, this);
-
-    if (propsWithData.data) {
-      // prettier-ignore
-      switch (propsWithData.dimension) {
-        case '1d': this.setTexture1DData(propsWithData.data); break;
-        case '2d': this.setTexture2DData(propsWithData.data); break;
-        case '3d': this.setTexture3DData(propsWithData.data); break;
-        case 'cube': this.setTextureCubeData(propsWithData.data); break;
-        case '2d-array': this.setTextureArrayData(propsWithData.data); break;
-        case 'cube-array': this.setTextureCubeArrayData(propsWithData.data); break;
-        // @ts-expect-error
-        default: throw new Error(propsWithData.dimension);
-      }
+    if (this.device.isExternalImage(data)) {
+      this.copyExternalImage({
+        image: data,
+        width: this.width,
+        height: this.height,
+        depth: this.depth,
+        mipLevel: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+        aspect: 'all',
+        colorSpace: 'srgb',
+        premultipliedAlpha: false,
+        flipY: false
+      });
+    } else if (data) {
+      this.copyImageData({
+        data,
+        // width: this.width,
+        // height: this.height,
+        // depth: this.depth,
+        mipLevel: 0,
+        x: 0,
+        y: 0,
+        z: 0,
+        aspect: 'all'
+      });
     }
 
+    // Do we need to generate mipmaps?
     if (this.mipmaps) {
-      this.generateMipmap();
+      this.generateMipmaps();
     }
   }
 
@@ -185,8 +190,7 @@ export class WEBGLTexture extends Texture {
     this._setSamplerParameters(parameters);
   }
 
-  // Call to regenerate mipmaps after modifying texture(s)
-  generateMipmap(options?: {force?: boolean}): void {
+  generateMipmaps(options?: {force?: boolean}): void {
     const isFilterableAndRenderable =
       this.device.isTextureFormatRenderable(this.props.format) &&
       this.device.isTextureFormatFilterable(this.props.format);
@@ -208,197 +212,90 @@ export class WEBGLTexture extends Texture {
   }
 
   // Image Data Setters
-  copyExternalImage(options: {
-    image: ExternalImage;
-    sourceX?: number;
-    sourceY?: number;
-    width?: number;
-    height?: number;
-    depth?: number;
-    mipLevel?: number;
-    x?: number;
-    y?: number;
-    z?: number;
-    aspect?: 'all' | 'stencil-only' | 'depth-only';
-    colorSpace?: 'srgb';
-    premultipliedAlpha?: boolean;
-    flipY?: boolean;
-  }): {width: number; height: number} {
-    const size = Texture.getExternalImageSize(options.image);
-    const opts = {...Texture.defaultCopyExternalImageOptions, ...size, ...options};
 
-    const {image, depth, mipLevel, x, y, z, flipY} = opts;
-    let {width, height} = opts;
-    const {dimension, glTarget, glFormat, glInternalFormat, glType} = this;
+  copyImageData(options_: CopyImageDataOptions): void {
+    const options = this._normalizeCopyImageDataOptions(options_);
 
-    // WebGL will error if we try to copy outside the bounds of the texture
-    width = Math.min(width, this.width - x);
-    height = Math.min(height, this.height - y);
+    const typedArray = options.data as TypedArray;
+    const {width, height, depth} = this;
+    const {mipLevel = 0, byteOffset = 0, x = 0, y = 0, z = 0} = options;
+    const {glFormat, glType, compressed} = this;
+    const glTarget = getWebGLCubeFaceTarget(this.glTarget, this.dimension, depth);
+
+    const glParameters: GLValueParameters = {
+      [GL.UNPACK_ROW_LENGTH]: options.bytesPerRow,
+      [GL.UNPACK_IMAGE_HEIGHT]: options.rowsPerImage
+    };
+
+    this.gl.bindTexture(glTarget, this.handle);
+
+    withGLParameters(this.gl, glParameters, () => {
+      switch (this.dimension) {
+        case '2d':
+        case 'cube':
+          if (compressed) {
+            // prettier-ignore
+            this.gl.compressedTexSubImage2D(glTarget, mipLevel, x, y, width, height, glFormat, typedArray, byteOffset); // , byteLength
+          } else {
+            // prettier-ignore
+            this.gl.texSubImage2D(glTarget, mipLevel, x, y, width, height, glFormat, glType, typedArray, byteOffset); // , byteLength
+          }
+          break;
+        case '2d-array':
+        case '3d':
+          if (compressed) {
+            // prettier-ignore
+            this.gl.compressedTexSubImage3D(glTarget, mipLevel, x, y, z, width, height, depth, glFormat, typedArray, byteOffset); // , byteLength
+          } else {
+            // prettier-ignore
+            this.gl.texSubImage3D(glTarget, mipLevel, x, y, z, width, height, depth, glFormat, glType, typedArray, byteOffset); // , byteLength
+          }
+          break;
+        default:
+        // Can never happen in WebGL
+      }
+    });
+
+    this.gl.bindTexture(glTarget, null);
+  }
+
+  copyExternalImage(options_: CopyExternalImageOptions): {width: number; height: number} {
+    const options = this._normalizeCopyExternalImageOptions(options_);
 
     if (options.sourceX || options.sourceY) {
       // requires copyTexSubImage2D from a framebuffer'
       throw new Error('WebGL does not support sourceX/sourceY)');
     }
 
-    copyExternalImageToMipLevel(this.device.gl, this.handle, image, {
-      dimension,
-      mipLevel,
-      x,
-      y,
-      z,
-      width,
-      height,
-      depth,
-      glFormat,
-      glInternalFormat,
-      glType,
-      glTarget,
-      flipY
+    const {glFormat, glType} = this;
+    const {image, depth, mipLevel, x, y, z, width, height} = options;
+
+    // WebGL cube maps specify faces by overriding target instead of using the depth parameter
+    const glTarget = getWebGLCubeFaceTarget(this.glTarget, this.dimension, depth);
+    const glParameters: GLValueParameters = options.flipY ? {[GL.UNPACK_FLIP_Y_WEBGL]: true} : {};
+
+    this.gl.bindTexture(glTarget, this.handle);
+
+    withGLParameters(this.gl, glParameters, () => {
+      switch (this.dimension) {
+        case '2d':
+        case 'cube':
+          // prettier-ignore
+          this.gl.texSubImage2D(glTarget, mipLevel, x, y, width, height, glFormat, glType, image);
+          break;
+        case '2d-array':
+        case '3d':
+          // prettier-ignore
+          this.gl.texSubImage3D(glTarget, mipLevel, x, y, z, width, height, depth, glFormat, glType, image);
+          break;
+        default:
+        // Can never happen in WebGL
+      }
     });
 
-    return {width: opts.width, height: opts.height};
-  }
+    this.gl.bindTexture(glTarget, null);
 
-  setTexture1DData(data: Texture1DData): void {
-    throw new Error('setTexture1DData not supported in WebGL.');
-  }
-
-  /** Set a simple texture */
-  setTexture2DData(lodData: Texture2DData, depth = 0): void {
-    this.bind();
-
-    const lodArray = Texture.normalizeTextureData(lodData, this);
-
-    // If the user provides multiple LODs, then automatic mipmap
-    // generation generateMipmap() should be disabled to avoid overwriting them.
-    if (lodArray.length > 1 && this.props.mipmaps !== false) {
-      log.warn(`Texture ${this.id} mipmap and multiple LODs.`)();
-    }
-
-    for (let lodLevel = 0; lodLevel < lodArray.length; lodLevel++) {
-      const imageData = lodArray[lodLevel];
-      this._setMipLevel(depth, lodLevel, imageData);
-    }
-
-    this.unbind();
-  }
-
-  /**
-   * Sets a 3D texture
-   * @param data
-   */
-  setTexture3DData(data: Texture3DData): void {
-    if (this.props.dimension !== '3d') {
-      throw new Error(this.id);
-    }
-    if (ArrayBuffer.isView(data)) {
-      this.bind();
-      copyCPUDataToMipLevel(this.device.gl, data, this);
-      this.unbind();
-    }
-  }
-
-  /**
-   * Set a Texture Cube Data
-   * @todo - could support TextureCubeArray with depth
-   * @param data
-   * @param index
-   */
-  setTextureCubeData(data: TextureCubeData, depth: number = 0): void {
-    if (this.props.dimension !== 'cube') {
-      throw new Error(this.id);
-    }
-    for (const face of Texture.CubeFaces) {
-      this.setTextureCubeFaceData(data[face], face);
-    }
-  }
-
-  /**
-   * Sets an entire texture array
-   * @param data
-   */
-  setTextureArrayData(data: TextureArrayData): void {
-    if (this.props.dimension !== '2d-array') {
-      throw new Error(this.id);
-    }
-    throw new Error('setTextureArrayData not implemented.');
-  }
-
-  /**
-   * Sets an entire texture cube array
-   * @param data
-   */
-  setTextureCubeArrayData(data: TextureCubeArrayData): void {
-    throw new Error('setTextureCubeArrayData not supported in WebGL2.');
-  }
-
-  setTextureCubeFaceData(lodData: Texture2DData, face: TextureCubeFace, depth: number = 0): void {
-    // assert(this.props.dimension === 'cube');
-
-    // If the user provides multiple LODs, then automatic mipmap
-    // generation generateMipmap() should be disabled to avoid overwriting them.
-    if (Array.isArray(lodData) && lodData.length > 1 && this.props.mipmaps !== false) {
-      log.warn(`${this.id} has mipmap and multiple LODs.`)();
-    }
-
-    const faceDepth = Texture.CubeFaces.indexOf(face);
-
-    this.setTexture2DData(lodData, faceDepth);
-  }
-
-  // DEPRECATED METHODS
-
-  /** Update external texture (video frame or canvas) @deprecated Use ExternalTexture */
-  update(): void {
-    throw new Error('Texture.update() not implemented. Use ExternalTexture');
-  }
-
-  // INTERNAL METHODS
-
-  /** @todo update this method to accept LODs */
-  setImageDataForFace(options): void {
-    const {
-      face,
-      width,
-      height,
-      pixels,
-      data,
-      format = GL.RGBA,
-      type = GL.UNSIGNED_BYTE
-      // generateMipmap = false // TODO
-    } = options;
-
-    const {gl} = this;
-
-    const imageData = pixels || data;
-
-    this.bind();
-    if (imageData instanceof Promise) {
-      imageData.then(resolvedImageData =>
-        this.setImageDataForFace(
-          Object.assign({}, options, {
-            face,
-            data: resolvedImageData,
-            pixels: resolvedImageData
-          })
-        )
-      );
-    } else if (this.width || this.height) {
-      gl.texImage2D(face, 0, format, width, height, 0 /* border*/, format, type, imageData);
-    } else {
-      gl.texImage2D(face, 0, format, format, type, imageData);
-    }
-  }
-
-  _getImageDataMap(faceData: Record<string | GL, any>): Record<GL, any> {
-    for (let i = 0; i < Texture.CubeFaces.length; ++i) {
-      const faceName = Texture.CubeFaces[i];
-      if (faceData[faceName]) {
-        faceData[GL.TEXTURE_CUBE_MAP_POSITIVE_X + i] = faceData[faceName];
-        delete faceData[faceName];
-      }
-    }
-    return faceData;
+    return {width: options.width, height: options.height};
   }
 
   // RESOURCE METHODS
@@ -410,6 +307,7 @@ export class WEBGLTexture extends Texture {
     log.log(1, `${this.id} sampler parameters`, this.device.getGLKeys(parameters))();
 
     this.gl.bindTexture(this.glTarget, this.handle);
+
     for (const [pname, pvalue] of Object.entries(parameters)) {
       const param = Number(pname) as keyof GLSamplerParameters;
       const value = pvalue;
@@ -447,129 +345,64 @@ export class WEBGLTexture extends Texture {
 
   // INTERNAL SETTERS
 
-  /**
-   * Copy a region of data from a CPU memory buffer into this texture.
-   * @todo -   GLUnpackParameters parameters
-   */
-  protected _setMipLevel(
-    depth: number,
-    mipLevel: number,
-    textureData: Texture2DData,
-    glTarget: GL = this.glTarget
-  ) {
-    // if (!textureData) {
-    //   clearMipLevel(this.device.gl, {...this, depth, level});
-    //   return;
-    // }
-
-    if (Texture.isExternalImage(textureData)) {
-      copyExternalImageToMipLevel(this.device.gl, this.handle, textureData, {
-        ...this,
-        depth,
-        mipLevel,
-        glTarget,
-        flipY: this.props.flipY
-      });
-      return;
-    }
-
-    // @ts-expect-error
-    if (Texture.isTextureLevelData(textureData)) {
-      copyCPUDataToMipLevel(this.device.gl, textureData.data, {
-        ...this,
-        depth,
-        mipLevel,
-        glTarget
-      });
-      return;
-    }
-
-    throw new Error('Texture: invalid image data');
-  }
   // HELPERS
 
   getActiveUnit(): number {
     return this.gl.getParameter(GL.ACTIVE_TEXTURE) - GL.TEXTURE0;
   }
 
-  bind(textureUnit?: number): number {
+  bind(_textureUnit?: number): number {
     const {gl} = this;
 
-    if (textureUnit !== undefined) {
-      this.textureUnit = textureUnit;
-      gl.activeTexture(gl.TEXTURE0 + textureUnit);
+    if (_textureUnit !== undefined) {
+      this._textureUnit = _textureUnit;
+      gl.activeTexture(gl.TEXTURE0 + _textureUnit);
     }
 
     gl.bindTexture(this.glTarget, this.handle);
-    return textureUnit;
+    return _textureUnit;
   }
 
-  unbind(textureUnit?: number): number | undefined {
+  unbind(_textureUnit?: number): number | undefined {
     const {gl} = this;
 
-    if (textureUnit !== undefined) {
-      this.textureUnit = textureUnit;
-      gl.activeTexture(gl.TEXTURE0 + textureUnit);
+    if (_textureUnit !== undefined) {
+      this._textureUnit = _textureUnit;
+      gl.activeTexture(gl.TEXTURE0 + _textureUnit);
     }
 
     gl.bindTexture(this.glTarget, null);
-    return textureUnit;
+    return _textureUnit;
   }
 }
 
-// TODO - Remove when texture refactor is complete
+// INTERNAL HELPERS
 
-/*
-setCubeMapData(options: {
-  width: number;
-  height: number;
-  data: Record<GL, Texture2DData> | Record<TextureCubeFace, Texture2DData>;
-  format?: any;
-  type?: any;
-  /** @deprecated Use .data *
-  pixels: any;
-}): void {
-  const {gl} = this;
-
-  const {width, height, pixels, data, format = GL.RGBA, type = GL.UNSIGNED_BYTE} = options;
-
-  // pixel data (imageDataMap) is an Object from Face to Image or Promise.
-  // For example:
-  // {
-  // GL.TEXTURE_CUBE_MAP_POSITIVE_X : Image-or-Promise,
-  // GL.TEXTURE_CUBE_MAP_NEGATIVE_X : Image-or-Promise,
-  // ... }
-  // To provide multiple level-of-details (LODs) this can be Face to Array
-  // of Image or Promise, like this
-  // {
-  // GL.TEXTURE_CUBE_MAP_POSITIVE_X : [Image-or-Promise-LOD-0, Image-or-Promise-LOD-1],
-  // GL.TEXTURE_CUBE_MAP_NEGATIVE_X : [Image-or-Promise-LOD-0, Image-or-Promise-LOD-1],
-  // ... }
-
-  const imageDataMap = this._getImageDataMap(pixels || data);
-
-  const resolvedFaces = WEBGLTexture.FACES.map(face => {
-    const facePixels = imageDataMap[face];
-    return Array.isArray(facePixels) ? facePixels : [facePixels];
-  });
-  this.bind();
-
-  WEBGLTexture.FACES.forEach((face, index) => {
-    if (resolvedFaces[index].length > 1 && this.props.mipmaps !== false) {
-      // If the user provides multiple LODs, then automatic mipmap
-      // generation generateMipmap() should be disabled to avoid overwritting them.
-      log.warn(`${this.id} has mipmap and multiple LODs.`)();
-    }
-    resolvedFaces[index].forEach((image, lodLevel) => {
-      // TODO: adjust width & height for LOD!
-      if (width && height) {
-        gl.texImage2D(face, lodLevel, format, width, height, 0 /* border*, format, type, image);
-      } else {
-        gl.texImage2D(face, lodLevel, format, format, type, image);
-      }
-    });
-  });
-
-  this.unbind();
+/** Convert a WebGPU style texture constant to a WebGL style texture constant */
+export function getWebGLTextureTarget(
+  dimension: '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d'
+): GLTextureTarget {
+  // prettier-ignore
+  switch (dimension) {
+    case '1d': break; // not supported in any WebGL version
+    case '2d': return GL.TEXTURE_2D; // supported in WebGL1
+    case '3d': return GL.TEXTURE_3D; // supported in WebGL2
+    case 'cube': return GL.TEXTURE_CUBE_MAP; // supported in WebGL1
+    case '2d-array': return GL.TEXTURE_2D_ARRAY; // supported in WebGL2
+    case 'cube-array': break; // not supported in any WebGL version
+  }
+  throw new Error(dimension);
 }
-*/
+
+/**
+ * In WebGL, cube maps specify faces by overriding target instead of using the depth parameter.
+ * @note We still bind the texture using GL.TEXTURE_CUBE_MAP, but we need to use the face-specific target when setting mip levels.
+ * @returns glTarget unchanged, if dimension !== 'cube'.
+ */
+export function getWebGLCubeFaceTarget(
+  glTarget: GLTextureTarget,
+  dimension: '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d',
+  level: number
+): GLTextureTarget | GLTextureCubeMapTarget {
+  return dimension === 'cube' ? GL.TEXTURE_CUBE_MAP_POSITIVE_X + level : glTarget;
+}

--- a/modules/webgl/src/index.ts
+++ b/modules/webgl/src/index.ts
@@ -37,10 +37,6 @@ export {WEBGLVertexArray} from './adapter/resources/webgl-vertex-array';
 // WebGL adapter classes
 export {WEBGLTransformFeedback} from './adapter/resources/webgl-transform-feedback';
 
-// WebGL adapter classes
-export {Accessor} from './deprecated/accessor';
-export type {AccessorObject} from './types';
-
 // Unified parameter API
 
 export {setDeviceParameters, withDeviceParameters} from './adapter/converters/device-parameters';

--- a/modules/webgl/wip/deprecated/accessor.ts
+++ b/modules/webgl/wip/deprecated/accessor.ts
@@ -1,0 +1,225 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, log} from '@luma.gl/core';
+import {GL, GLDataType, GLPixelType} from '@luma.gl/constants';
+import {TypedArrayConstructor} from '@math.gl/types';
+
+/**
+ * Attribute descriptor object
+ * @deprecated Use ShaderLayout
+ */
+export interface AccessorObject {
+  buffer?: Buffer;
+  // format: VertexFormat;
+  offset?: number;
+  // can now be described with single WebGPU-style `format` string
+
+  //
+  stride?: number;
+
+  /** @deprecated - Use accessor.stepMode */
+  divisor?: number;
+
+  /** @deprecated - Infer from format */
+  type?: number;
+  /** @deprecated - Infer from format */
+  size?: number;
+  /** @deprecated - Infer from format */
+  normalized?: boolean;
+  /** @deprecated - Infer from format */
+  integer?: boolean;
+
+  /** @deprecated */
+  index?: number;
+}
+
+const DEFAULT_ACCESSOR_VALUES = {
+  offset: 0,
+  stride: 0,
+  type: GL.FLOAT,
+  size: 1,
+  divisor: 0,
+  normalized: false,
+  integer: false
+};
+
+export class Accessor implements AccessorObject {
+  offset?: number;
+  stride?: number;
+  type?: number;
+  size?: number;
+  divisor?: number;
+  normalized?: boolean;
+  integer?: boolean;
+
+  buffer?: Buffer;
+  index?: number;
+
+  static getBytesPerElement(accessor: Accessor | AccessorObject): number {
+    // TODO: using `FLOAT` when type is not specified,
+    // ensure this assumption is valid or force API to specify type.
+    const ArrayType = getTypedArrayFromGLType(accessor.type || GL.FLOAT);
+    return ArrayType.BYTES_PER_ELEMENT;
+  }
+
+  static getBytesPerVertex(accessor: AccessorObject): number {
+    // assert(accessor.size);
+    // TODO: using `FLOAT` when type is not specified,
+    // ensure this assumption is valid or force API to specify type.
+    const ArrayType = getTypedArrayFromGLType(accessor.type || GL.FLOAT);
+    return ArrayType.BYTES_PER_ELEMENT * accessor.size;
+  }
+
+  // Combines (merges) a list of accessors. On top of default values
+  // Usually [programAccessor, bufferAccessor, appAccessor]
+  // All props will be set in the returned object.
+  // TODO check for conflicts between values in the supplied accessors
+  static resolve(...accessors: AccessorObject[]): Accessor {
+    return new Accessor(...[DEFAULT_ACCESSOR_VALUES, ...accessors]); // Default values
+  }
+
+  constructor(...accessors: AccessorObject[]) {
+    log.warn('Accessor will be removed in next minor release');
+    accessors.forEach(accessor => this._assign(accessor)); // Merge in sequence
+    Object.freeze(this);
+  }
+
+  toString(): string {
+    return JSON.stringify(this);
+  }
+
+  // ACCESSORS
+
+  // TODO - remove>
+  get BYTES_PER_ELEMENT(): number {
+    return Accessor.getBytesPerElement(this);
+  }
+
+  get BYTES_PER_VERTEX(): number {
+    return Accessor.getBytesPerVertex(this);
+  }
+
+  // PRIVATE
+
+  // eslint-disable-next-line complexity, max-statements
+  _assign(props: AccessorObject = {}): this {
+    if (props.type !== undefined) {
+      this.type = props.type;
+
+      // Auto-deduce integer type?
+      if ((props.type as GL) === GL.INT || (props.type as GL) === GL.UNSIGNED_INT) {
+        this.integer = true;
+      }
+    }
+    if (props.size !== undefined) {
+      this.size = props.size;
+    }
+    if (props.offset !== undefined) {
+      this.offset = props.offset;
+    }
+    if (props.stride !== undefined) {
+      this.stride = props.stride;
+    }
+    // @ts-expect-error
+    if (props.normalize !== undefined) {
+      // @ts-expect-error
+      this.normalized = props.normalize;
+    }
+    if (props.normalized !== undefined) {
+      this.normalized = props.normalized;
+    }
+    if (props.integer !== undefined) {
+      this.integer = props.integer;
+    }
+
+    // INSTANCE DIVISOR
+    if (props.divisor !== undefined) {
+      this.divisor = props.divisor;
+    }
+
+    // Buffer is optional
+    if (props.buffer !== undefined) {
+      this.buffer = props.buffer;
+    }
+
+    // The binding index (for binding e.g. Transform feedbacks and Uniform buffers)
+    // TODO - should this be part of accessor?
+    if (props.index !== undefined) {
+      if (typeof props.index === 'boolean') {
+        this.index = props.index ? 1 : 0;
+      } else {
+        this.index = props.index;
+      }
+    }
+
+    // DEPRECATED
+    // @ts-expect-error
+    if (props.instanced !== undefined) {
+      // @ts-expect-error
+      this.divisor = props.instanced ? 1 : 0;
+    }
+    // @ts-expect-error
+    if (props.isInstanced !== undefined) {
+      // @ts-expect-error
+      this.divisor = props.isInstanced ? 1 : 0;
+    }
+
+    if (this.offset === undefined) delete this.offset;
+    if (this.stride === undefined) delete this.stride;
+    if (this.type === undefined) delete this.type;
+    if (this.size === undefined) delete this.size;
+    if (this.divisor === undefined) delete this.divisor;
+    if (this.normalized === undefined) delete this.normalized;
+    if (this.integer === undefined) delete this.integer;
+
+    if (this.buffer === undefined) delete this.buffer;
+    if (this.index === undefined) delete this.index;
+
+    return this;
+  }
+}
+
+/**
+ * Converts GL constant to corresponding TYPED ARRAY
+ * Used to auto deduce gl parameter types
+ * @deprecated Use getTypedArrayFromDataType
+ * @param glType
+ * @param param1
+ * @returns
+ */
+// eslint-disable-next-line complexity
+function getTypedArrayFromGLType(
+  glType: GLDataType | GLPixelType,
+  options?: {
+    clamped?: boolean;
+  }
+): TypedArrayConstructor {
+  const {clamped = true} = options || {};
+  // Sorted in some order of likelihood to reduce amount of comparisons
+  switch (glType) {
+    case GL.FLOAT:
+      return Float32Array;
+    case GL.UNSIGNED_SHORT:
+    case GL.UNSIGNED_SHORT_5_6_5:
+    case GL.UNSIGNED_SHORT_4_4_4_4:
+    case GL.UNSIGNED_SHORT_5_5_5_1:
+      return Uint16Array;
+    case GL.UNSIGNED_INT:
+      return Uint32Array;
+    case GL.UNSIGNED_BYTE:
+      return clamped ? Uint8ClampedArray : Uint8Array;
+    case GL.BYTE:
+      return Int8Array;
+    case GL.SHORT:
+      return Int16Array;
+    case GL.INT:
+      return Int32Array;
+    default:
+      throw new Error('Failed to deduce typed array type from GL constant');
+  }
+}
+
+// TEST EXPORTS
+export {DEFAULT_ACCESSOR_VALUES};

--- a/modules/webgpu/src/adapter/helpers/webgpu-parameters.ts
+++ b/modules/webgpu/src/adapter/helpers/webgpu-parameters.ts
@@ -54,8 +54,10 @@ export const PARAMETER_TABLE: Record<keyof Parameters, Function> = {
     value: any,
     descriptor: GPURenderPipelineDescriptor
   ) => {
-    const depthStencil = addDepthStencil(descriptor);
-    depthStencil.depthWriteEnabled = value;
+    if (value) {
+      const depthStencil = addDepthStencil(descriptor);
+      depthStencil.depthWriteEnabled = value;
+    }
   },
 
   depthCompare: (

--- a/modules/webgpu/src/adapter/resources/webgpu-command-encoder.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-command-encoder.ts
@@ -19,6 +19,7 @@ export class WebGPUCommandEncoder extends CommandEncoder {
     this.handle =
       props.handle ||
       this.device.handle.createCommandEncoder({
+        label: this.props.id
         // TODO was this removed in standard?
         // measureExecutionTime: this.props.measureExecutionTime
       });


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- Opening against 9.2-dev branch.
- Continued Texture cleanup, targeting one of the hardest to maintain areas of luma.gl
- Keep Texture minimally focused on exposing GPU capabilities, move convenience methods to AsyncTexture
#### Change List
- Remove duplicated code between WebGL and WebGPU, simplify texture implementations, move sharable, non-platform-specific functions to AsyncTexture, 
