### PR TITLE
webgl: Canvas resizing minimal back-compatibility fix

### DIFF
--- a/modules/webgl/src/adapter/webgl-canvas-context.ts
+++ b/modules/webgl/src/adapter/webgl-canvas-context.ts
@@ -53,10 +53,6 @@ export class WebGLCanvasContext extends CanvasContext {
   resize(options?: {width?: number; height?: number; useDevicePixels?: boolean | number}): void {
     if (!this.device.gl) return;
 
-    if (this.props.autoResize) {
-      return;
-    }
-
     // Resize browser context. TODO - this likely needs to be rewritten
     if (this.canvas) {
       const devicePixelRatio = this.getDevicePixelRatio(options?.useDevicePixels);


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

#### Background
Follow-up to https://github.com/visgl/luma.gl/pull/2237 which breaks canvas handling in deck.

@ibgreen I'm going to try and integrate this into deck to see if we can update luma9.1 there and move forward. I don't think it is worth trying to update deck to the new APIs in luma now, as there is still a lot of cleanup needed on the luma side (many TODOs & deprecated in the `canvas-context.ts` & `webgl-canvas-context.ts`)

<!-- For other PRs without open issue -->

<!-- For all the PRs -->
#### Change List
- Re-instate old behavior where `WebGLCanvasContext.resize()` calls  `_setDevicePixelRatio()`
