### PR TITLE
fix(gltf): Copy across ImageBitmap in deepCopy

### DIFF
--- a/modules/gltf/src/gltf/gltf-instantiator.ts
+++ b/modules/gltf/src/gltf/gltf-instantiator.ts
@@ -212,7 +212,11 @@ export class GLTFInstantiator {
 /** Deeply copies a JS data structure */
 function deepCopy(object: any): any {
   // don't copy binary data
-  if (ArrayBuffer.isView(object) || object instanceof ArrayBuffer) {
+  if (
+    ArrayBuffer.isView(object) ||
+    object instanceof ArrayBuffer ||
+    object instanceof ImageBitmap
+  ) {
     return object;
   }
   if (Array.isArray(object)) {


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

Fixes regression introduced in https://github.com/visgl/luma.gl/pull/2203

`deepCopy` has no handling for `ImageBitmap`, which means it attempts to clone it as a standard JS object. Later this leads to [isExternalImage](https://github.com/visgl/luma.gl/blob/master/modules/core/src/image-utils/image-types.ts#L29) erroneously returning false. The end result is that all image loading fails for GLTF models, breaking many things in deck: `ScenegraphLayer`, `Google 3D tiles` etc 

Will create PR for 9.2 once fix merged & confirmed in deck.gl

<!-- For all the PRs -->
#### Change List
- Do not clone `ImageBitmap`
