### PR TITLE
chore(engine): Add back Model.setUniforms()

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -678,6 +678,15 @@ export class Model {
    * @deprecated WebGL only, use uniform buffers for portability
    * @param uniforms
    */
+  setUniforms(uniforms: Record<string, UniformValue>): void {
+    this.setUniformsWebGL(uniforms);
+  }
+
+  /**
+   * Sets individual uniforms
+   * @deprecated WebGL only, use uniform buffers for portability
+   * @param uniforms
+   */
   setUniformsWebGL(uniforms: Record<string, UniformValue>): void {
     if (!isObjectEmpty(uniforms)) {
       this.pipeline.setUniformsWebGL(uniforms);


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- deck.gl raised concerns that removal of `model.setUniforms()` will break custom layers.
#### Change List
- Add back `model.setUniforms()`. 
