### PR TITLE
fix(webgpu): Chrome has removed requestAdapterInfo (v9.0)

### DIFF
--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -92,7 +92,11 @@ export class WebGPUDevice extends Device {
       throw new Error('Failed to request WebGPU adapter');
     }
 
-    const adapterInfo = await adapter.requestAdapterInfo();
+    //  Note: adapter.requestAdapterInfo() has been replaced with adapter.info. Fall back in case adapter.info is not available
+    const adapterInfo =
+      adapter.info ||
+      // @ts-ignore
+      (await adapter.requestAdapterInfo?.());
     log.probe(2, 'Adapter available', adapterInfo)();
 
     const requiredFeatures: GPUFeatureName[] = [];


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #2292
<!-- For other PRs without open issue -->
#### Background
See ticket
#### Change List
- Check optionally for both adapter.info and getAdapterInfo()
