### PR TITLE
fix(webgl): Prevent auto resizing when using external gl context (9.0-release)

### DIFF
--- a/modules/core/src/adapter/canvas-context.ts
+++ b/modules/core/src/adapter/canvas-context.ts
@@ -198,7 +198,8 @@ export abstract class CanvasContext {
       // For headless gl we might have used custom width and height
       // hence use cached clientWidth
       const [drawingBufferWidth] = this.getDrawingBufferSize();
-      const {clientWidth} = this._canvasSizeInfo;
+      // _canvasSizeInfo may not be populated if `setDevicePixelRatio` is never called
+      const clientWidth = this._canvasSizeInfo.clientWidth || this.htmlCanvas?.clientWidth;
       return clientWidth ? drawingBufferWidth / clientWidth : 1;
     } catch {
       return 1;

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -203,7 +203,8 @@ ${device.info.vendor}, ${device.info.renderer} for canvas: ${device.canvasContex
 
     // Create and instrument context
     const canvas = props.gl?.canvas || props.canvas;
-    this.canvasContext = new WebGLCanvasContext(this, {...props, canvas});
+    const autoResize = !props.gl;
+    this.canvasContext = new WebGLCanvasContext(this, {...props, autoResize, canvas});
 
     this.lost = new Promise<{reason: 'destroyed'; message: string}>(resolve => {
       this._resolveContextLost = resolve;
@@ -241,7 +242,9 @@ ${device.info.vendor}, ${device.info.renderer} for canvas: ${device.canvasContex
       this.features.initializeFeatures();
     }
 
-    this.canvasContext.resize();
+    if (autoResize) {
+      this.canvasContext.resize();
+    }
 
     // Install context state tracking
     // @ts-expect-error - hidden parameters


### PR DESCRIPTION
For #2295

#### Change List
- Disable `autoResize` when using an external WebGL context
- `cssToDeviceRatio()` fallback to canvas clientWidth when dimension cache is unavailable (this happens when resize() is never called)
