### PR TITLE
fix(webgl): Prevent auto resizing when using external gl context (9.1-release)

### DIFF
--- a/modules/core/src/adapter/canvas-context.ts
+++ b/modules/core/src/adapter/canvas-context.ts
@@ -195,7 +195,8 @@ export abstract class CanvasContext {
       // For headless gl we might have used custom width and height
       // hence use cached clientWidth
       const [drawingBufferWidth] = this.getDrawingBufferSize();
-      const {clientWidth} = this._canvasSizeInfo;
+      // _canvasSizeInfo may not be populated if `setDevicePixelRatio` is never called
+      const clientWidth = this._canvasSizeInfo.clientWidth || this.htmlCanvas?.clientWidth;
       return clientWidth ? drawingBufferWidth / clientWidth : 1;
     } catch {
       return 1;

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -52,7 +52,10 @@ export class WebGLAdapter extends Adapter {
     if (!isWebGL(gl)) {
       throw new Error('Invalid WebGL2RenderingContext');
     }
-    return new WebGLDevice({_handle: gl as WebGL2RenderingContext});
+    return new WebGLDevice({
+      _handle: gl as WebGL2RenderingContext,
+      createCanvasContext: {autoResize: false}
+    });
   }
 
   async create(props: DeviceProps = {}): Promise<WebGLDevice> {

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -188,7 +188,9 @@ export class WebGLDevice extends Device {
       this.features.initializeFeatures();
     }
 
-    this.canvasContext.resize();
+    if (canvasContextProps.autoResize) {
+      this.canvasContext.resize();
+    }
 
     // Install context state tracking
     const glState = new WebGLStateTracker(this.gl, {


### PR DESCRIPTION
For #2295

#### Change List
- Disable `autoResize` when using an external WebGL context
- `cssToDeviceRatio()` fallback to canvas clientWidth when dimension cache is unavailable (this happens when resize() is never called)
