### PR TITLE
fix(webgl): Prevent auto resizing when using external gl context (master)

### DIFF
--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -62,7 +62,10 @@ export class WebGLAdapter extends Adapter {
     if (!isWebGL(gl)) {
       throw new Error('Invalid WebGL2RenderingContext');
     }
-    return new WebGLDevice({_handle: gl as WebGL2RenderingContext});
+    return new WebGLDevice({
+      _handle: gl as WebGL2RenderingContext,
+      createCanvasContext: {autoResize: false}
+    });
   }
 
   async create(props: DeviceProps = {}): Promise<WebGLDevice> {


### PR DESCRIPTION
For #2295

#### Change List
- Disable `autoResize` when using an external WebGL context