### PR TITLE
fix(engine): Disable warnings in ShaderInputs

### DIFF
--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -230,6 +230,7 @@ export class Model {
     const moduleMap = Object.fromEntries(
       this.props.modules?.map(module => [module.name, module]) || []
     );
+
     // @ts-expect-error Fix typings
     this.setShaderInputs(
       props.shaderInputs ||

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -231,18 +231,18 @@ export class Model {
       this.props.modules?.map(module => [module.name, module]) || []
     );
 
-    // @ts-expect-error Fix typings
-    this.setShaderInputs(
+    const shaderInputs =
       props.shaderInputs ||
-        new ShaderInputs(moduleMap, {disableWarnings: this.props.disableWarnings})
-    );
+      new ShaderInputs(moduleMap, {disableWarnings: this.props.disableWarnings});
+    // @ts-ignore
+    this.setShaderInputs(shaderInputs);
 
     // Setup shader assembler
     const platformInfo = getPlatformInfo(device);
 
     // Extract modules from shader inputs if not supplied
     const modules =
-      // @ts-expect-error shaderInputs is assigned in setShaderInputs above.
+      // @ts-ignore shaderInputs is assigned in setShaderInputs above.
       (this.props.modules?.length > 0 ? this.props.modules : this.shaderInputs?.getModules()) || [];
 
     const isWebGPU = this.device.type === 'webgpu';

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -231,7 +231,10 @@ export class Model {
       this.props.modules?.map(module => [module.name, module]) || []
     );
     // @ts-expect-error Fix typings
-    this.setShaderInputs(props.shaderInputs || new ShaderInputs(moduleMap));
+    this.setShaderInputs(
+      props.shaderInputs ||
+        new ShaderInputs(moduleMap, {disableWarnings: this.props.disableWarnings})
+    );
 
     // Setup shader assembler
     const platformInfo = getPlatformInfo(device);

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -25,7 +25,7 @@ export class ShaderInputs<
   >
 > {
   options: Required<ShaderInputsOptions> = {
-    disableWarnings: false;
+    disableWarnings: false
   }
 
   /**

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -10,7 +10,7 @@ import {splitUniformsAndBindings} from './model/split-uniforms-and-bindings';
 
 export type ShaderInputsOptions = {
   disableWarnings?: boolean;
-}
+};
 
 /**
  * ShaderInputs holds uniform and binding values for one or more shader modules,
@@ -26,7 +26,7 @@ export class ShaderInputs<
 > {
   options: Required<ShaderInputsOptions> = {
     disableWarnings: false
-  }
+  };
 
   /**
    * The map of modules
@@ -47,7 +47,10 @@ export class ShaderInputs<
    * @param modules
    */
   // @ts-expect-error Fix typings
-  constructor(modules: {[P in keyof ShaderPropsT]?: ShaderModule<ShaderPropsT[P], any>}, options?: ShaderInputsOptions) {
+  constructor(
+    modules: {[P in keyof ShaderPropsT]?: ShaderModule<ShaderPropsT[P], any>},
+    options?: ShaderInputsOptions
+  ) {
     Object.assign(this.options, options);
 
     // Extract modules with dependencies

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -8,6 +8,10 @@ import {log} from '@luma.gl/core';
 import {getShaderModuleDependencies, ShaderModule} from '@luma.gl/shadertools';
 import {splitUniformsAndBindings} from './model/split-uniforms-and-bindings';
 
+export type ShaderInputsOptions = {
+  disableWarnings?: boolean;
+}
+
 /**
  * ShaderInputs holds uniform and binding values for one or more shader modules,
  * - It can generate binary data for any uniform buffer
@@ -20,6 +24,10 @@ export class ShaderInputs<
     Record<string, Record<string, unknown>>
   >
 > {
+  options: Required<ShaderInputsOptions> = {
+    disableWarnings: false;
+  }
+
   /**
    * The map of modules
    * @todo should should this include the resolved dependencies?
@@ -39,7 +47,9 @@ export class ShaderInputs<
    * @param modules
    */
   // @ts-expect-error Fix typings
-  constructor(modules: {[P in keyof ShaderPropsT]?: ShaderModule<ShaderPropsT[P], any>}) {
+  constructor(modules: {[P in keyof ShaderPropsT]?: ShaderModule<ShaderPropsT[P], any>}, options?: ShaderInputsOptions) {
+    Object.assign(this.options, options);
+
     // Extract modules with dependencies
     const resolvedModules = getShaderModuleDependencies(
       Object.values(modules).filter(module => module.dependencies)
@@ -60,7 +70,7 @@ export class ShaderInputs<
     // Initialize the modules
     for (const [name, module] of Object.entries(modules)) {
       this._addModule(module);
-      if (module.name && name !== module.name) {
+      if (module.name && name !== module.name && !this.options.disableWarnings) {
         log.warn(`Module name: ${name} vs ${module.name}`)();
       }
     }
@@ -77,7 +87,7 @@ export class ShaderInputs<
       const moduleName = name as keyof ShaderPropsT;
       const moduleProps = props[moduleName] || {};
       const module = this.modules[moduleName];
-      if (!module) {
+      if (!module && !this.options.disableWarnings) {
         // Ignore props for unregistered modules
         log.warn(`Module ${name} not found`)();
         continue; // eslint-disable-line no-continue

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -32,7 +32,7 @@ export class ShaderInputs<
    * The map of modules
    * @todo should should this include the resolved dependencies?
    */
-  // @ts-expect-error Fix typings
+  // @ts-ignore Fix typings
   modules: Readonly<{[P in keyof ShaderPropsT]: ShaderModule<ShaderPropsT[P]>}>;
 
   /** Stores the uniform values for each module */
@@ -46,8 +46,8 @@ export class ShaderInputs<
    * Create a new UniformStore instance
    * @param modules
    */
-  // @ts-expect-error Fix typings
   constructor(
+    // @ts-ignore Fix typings
     modules: {[P in keyof ShaderPropsT]?: ShaderModule<ShaderPropsT[P], any>},
     options?: ShaderInputsOptions
   ) {
@@ -65,7 +65,7 @@ export class ShaderInputs<
     log.log(1, 'Creating ShaderInputs with modules', Object.keys(modules))();
 
     // Store the module definitions and create storage for uniform values and binding values, per module
-    // @ts-expect-error Fix typings
+    // @ts-ignore Fix typings
     this.modules = modules as {[P in keyof ShaderPropsT]: ShaderModule<ShaderPropsT[P]>};
     this.moduleUniforms = {} as Record<keyof ShaderPropsT, Record<string, UniformValue>>;
     this.moduleBindings = {} as Record<keyof ShaderPropsT, Record<string, Binding>>;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- deck.gl gets excessive warnings for intentional usage
#### Change List
- disableWarnings flag on ShaderInputs, pass down from Model
- Somehow the typings are starting to act up, didn't have time to dig in, changed some expect-errors to ignore
