### PR TITLE
chore: pin ubuntu version in Github CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check_branch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_build: ${{ steps.permitted.outputs.result }}
 
@@ -30,7 +30,7 @@ jobs:
           echo "result=${result}" >> "$GITHUB_OUTPUT"
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: check_branch
     permissions:
       contents: write

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check_branch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       should_deploy: ${{ endsWith(github.ref, steps.get_version.outputs.latest) }}
 
@@ -23,7 +23,7 @@ jobs:
           echo "latest=${LATEST}-release" >> "$GITHUB_OUTPUT"
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: check_branch
     
     permissions:


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

Follow up to https://github.com/visgl/luma.gl/pull/2309/files to enable releases

<!-- For all the PRs -->
#### Change List
- Use `ubuntu-20.04` in all workflows
