### PR TITLE
fix(engine): ShaderInputs ignore props with disableWarnings (9.1)

### DIFF
--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -90,9 +90,11 @@ export class ShaderInputs<
       const moduleName = name as keyof ShaderPropsT;
       const moduleProps = props[moduleName] || {};
       const module = this.modules[moduleName];
-      if (!module && !this.options.disableWarnings) {
+      if (!module) {
         // Ignore props for unregistered modules
-        log.warn(`Module ${name} not found`)();
+        if (!this.options.disableWarnings) {
+          log.warn(`Module ${name} not found`)();
+        }
         continue; // eslint-disable-line no-continue
       }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fix issue introduced by https://github.com/visgl/luma.gl/pull/2301
<!-- For other PRs without open issue -->

<!-- For all the PRs -->
#### Change List
- Reinstate old behavior, when hiding the warning we still need to `continue` otherwise we crash