### PR TITLE
fix(webgl): Add DeviceProps._reuseDevices to support deck.gl React StrictMode

### DIFF
--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -642,7 +642,7 @@ export abstract class Device {
   // IMPLEMENTATION
 
   /** Helper to get the canvas context props */
-  protected static _getCanvasContextProps(props: DeviceProps): CanvasContextProps | undefined {
+  static _getCanvasContextProps(props: DeviceProps): CanvasContextProps | undefined {
     return props.createCanvasContext === true ? {} : props.createCanvasContext;
   }
 

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -641,6 +641,11 @@ export abstract class Device {
 
   // IMPLEMENTATION
 
+  /** Helper to get the canvas context props */
+  protected static _getCanvasContextProps(props: DeviceProps): CanvasContextProps | undefined {
+    return props.createCanvasContext === true ? {} : props.createCanvasContext;
+  }
+
   protected _getDeviceTextureFormatCapabilities(
     format: TextureFormat
   ): DeviceTextureFormatCapabilities {

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -259,6 +259,8 @@ export type DeviceProps = {
 
   // EXPERIMENTAL SETTINGS - subject to change
 
+  /** adapter.create() returns the existing Device if the provided canvas' WebGL context is already associated with a Device.  */
+  _reuseDevices?: boolean;
   /** WebGPU specific - Request a Device with the highest limits supported by platform. On WebGPU devices can be created with minimal limits. */
   _requestMaxLimits?: boolean;
   /** Disable specific features */
@@ -333,6 +335,7 @@ export abstract class Device {
     debugSpectorJSUrl: undefined!,
 
     // Experimental
+    _reuseDevices: false,
     _requestMaxLimits: true,
     _cacheShaders: false,
     _cachePipelines: false,

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -375,6 +375,8 @@ export abstract class Device {
   /** An abstract timestamp used for change tracking */
   timestamp: number = 0;
 
+  /** True if this device has been reused during device creation (app has multiple references) */
+  _reused: boolean = false;
   /** Used by other luma.gl modules to store data on the device */
   _lumaData: {[key: string]: unknown} = {};
 

--- a/modules/test-utils/src/null-device/null-device.ts
+++ b/modules/test-utils/src/null-device/null-device.ts
@@ -61,7 +61,7 @@ export class NullDevice extends Device {
   constructor(props: DeviceProps) {
     super({...props, id: props.id || 'null-device'});
 
-    const canvasContextProps = props.createCanvasContext === true ? {} : props.createCanvasContext;
+    const canvasContextProps = Device._getCanvasContextProps(props);
     this.canvasContext = new NullCanvasContext(this, canvasContextProps);
     this.lost = new Promise(resolve => {});
     this.commandEncoder = new NullCommandEncoder(this, {id: 'null-command-encoder'});

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -99,8 +99,10 @@ export class WebGLAdapter extends Adapter {
 
     // Check if the WebGL context is already associated with a device
     // If attaching to an already attached context, return the attached device
+    const canvasContextProps = Device._getCanvasContextProps(props);
+    const canvas = canvasContextProps?.canvas;
     // @ts-expect-error device is attached to context
-    let device: WebGLDevice | undefined = canvasContextProps.canvas?.gl?.device;
+    let device: WebGLDevice | undefined = canvas?.gl?.device;
     if (device) {
       if (props._reuseDevices) {
         log.log(

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -103,14 +103,15 @@ export class WebGLAdapter extends Adapter {
     let device: WebGLDevice | undefined = canvasContextProps.canvas?.gl?.device;
     if (device) {
       if (props._reuseDevices) {
-        log.log(1, 
+        log.log(
+          1,
           `webgl2adapter.create() - Returning existing Device ${device.id} already attached to WebGL context`,
           device
         )();
         return device;
-      } 
+      }
     }
-    
+
     device = new WebGLDevice(props);
 
     // Log some debug info about the newly created context

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -97,28 +97,11 @@ export class WebGLAdapter extends Adapter {
       }
     }
 
-    // Check if the WebGL context is already associated with a device
-    // If attaching to an already attached context, return the attached device
-    const canvasContextProps = Device._getCanvasContextProps(props);
-    const canvas = canvasContextProps?.canvas;
-    // @ts-expect-error device is attached to context
-    let device: WebGLDevice | undefined = canvas?.gl?.device;
-    if (device) {
-      if (props._reuseDevices) {
-        log.log(
-          1,
-          `webgl2adapter.create() - Returning existing Device ${device.id} already attached to WebGL context`,
-          device
-        )();
-        return device;
-      }
-    }
-
-    device = new WebGLDevice(props);
+    const device = new WebGLDevice(props);
 
     // Log some debug info about the newly created context
     const message = `\
-Created ${device.type}${device.debug ? ' debug' : ''} context: \
+${device._reused ? 'Reusing' : 'Created'} device with WebGL2 ${device.debug ? 'debug ' : ''}context: \
 ${device.info.vendor}, ${device.info.renderer} for canvas: ${device.canvasContext.id}`;
     log.probe(LOG_LEVEL, message)();
     log.table(LOG_LEVEL, device.info)();

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -97,7 +97,21 @@ export class WebGLAdapter extends Adapter {
       }
     }
 
-    const device = new WebGLDevice(props);
+    // Check if the WebGL context is already associated with a device
+    // If attaching to an already attached context, return the attached device
+    // @ts-expect-error device is attached to context
+    let device: WebGLDevice | undefined = canvasContextProps.canvas?.gl?.device;
+    if (device) {
+      if (props._reuseDevices) {
+        log.log(1, 
+          `webgl2adapter.create() - Returning existing Device ${device.id} already attached to WebGL context`,
+          device
+        )();
+        return device;
+      } 
+    }
+    
+    device = new WebGLDevice(props);
 
     // Log some debug info about the newly created context
     const message = `\

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -121,7 +121,7 @@ export class WebGLDevice extends Device {
     }
     const canvasContextProps = props.createCanvasContext === true ? {} : props.createCanvasContext;
 
-    // If attaching to an already attached context, return the attached device
+    // Check if the WebGL context is already associated with a device
     // @ts-expect-error device is attached to context
     let device: WebGLDevice | undefined = canvasContextProps.canvas?.gl?.device;
     if (device) {

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -221,15 +221,23 @@ export class WebGLDevice extends Device {
   /**
    * Destroys the device
    *
-   * @note "detaches" from the WebGL context,
-   * implying that another WebGLDevice could now attach to it.
+   * @note "Detaches" from the WebGL context unless _reuseDevices is true.
    *
-   * @note The underlying WebGL context is not immediately destroyed, but may be destroyed later
-   * through normal JavaScript garbage collection. This is a fundamental limitation as WebGL
-   * since WebGL does not offer any browser API for destroying WeGL contexts.
+   * @note The underlying WebGL context is not immediately destroyed,
+   * but may be destroyed later through normal JavaScript garbage collection.
+   * This is a fundamental limitation since WebGL does not offer any
+   * browser API for destroying WebGL contexts.
    */
   destroy(): void {
-    delete (this.gl as any).device;
+    // Note that deck.gl depends on being able to create a Device against
+    // the same WebGL context multiple times and getting the same device back.
+    // Since deck is not aware of this sharing, it may call destroy()
+    // multiple times on the same device.
+    // Therefore we must do nothing in destroy() if _reuseDevices is true
+    // unless we e.g. implement reference counting.
+    if (!this.props._reuseDevices) {
+      delete (this.gl as any).device;
+    }
   }
 
   get isLost(): boolean {

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -219,13 +219,13 @@ export class WebGLDevice extends Device {
   }
 
   /**
-   * Destroys the device 
-   * 
+   * Destroys the device
+   *
    * @note "detaches" from the WebGL context,
    * implying that another WebGLDevice could now attach to it.
-   * 
-   * @note The underlying WebGL context is not immediately destroyed, but may be destroyed later 
-   * through normal JavaScript garbage collection. This is a fundamental limitation as WebGL 
+   *
+   * @note The underlying WebGL context is not immediately destroyed, but may be destroyed later
+   * through normal JavaScript garbage collection. This is a fundamental limitation as WebGL
    * since WebGL does not offer any browser API for destroying WeGL contexts.
    */
   destroy(): void {

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -73,24 +73,25 @@ export class WebGLDevice extends Device {
   /** type of this device */
   readonly type = 'webgl';
 
+  // Use the ! assertion to handle the case where _reuseDevices causes the constructor to return early
   /** The underlying WebGL context */
-  readonly handle: WebGL2RenderingContext;
-  features: WebGLDeviceFeatures;
-  limits: WebGLDeviceLimits;
-  readonly info: DeviceInfo;
-  readonly canvasContext: WebGLCanvasContext;
+  readonly handle!: WebGL2RenderingContext;
+  features!: WebGLDeviceFeatures;
+  limits!: WebGLDeviceLimits;
+  readonly info!: DeviceInfo;
+  readonly canvasContext!: WebGLCanvasContext;
 
   readonly preferredColorFormat = 'rgba8unorm';
   readonly preferredDepthFormat = 'depth24plus';
 
-  commandEncoder: WEBGLCommandEncoder;
+  commandEncoder!: WEBGLCommandEncoder;
 
   readonly lost: Promise<{reason: 'destroyed'; message: string}>;
 
   private _resolveContextLost?: (value: {reason: 'destroyed'; message: string}) => void;
 
   /** WebGL2 context. */
-  readonly gl: WebGL2RenderingContext;
+  readonly gl!: WebGL2RenderingContext;
   readonly debug: boolean = false;
 
   /** Store constants */
@@ -102,7 +103,7 @@ export class WebGLDevice extends Device {
   _polyfilled: boolean = false;
 
   /** Instance of Spector.js (if initialized) */
-  spectorJS: Spector | null;
+  spectorJS!: Spector | null;
 
   //
   // Public API

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -183,6 +183,7 @@ export class WebGLDevice extends Device {
 
     // Instrument context
     (this.gl as any).device = this; // Update GL context: Link webgl context back to device
+    // TODO - remove, this is only used to detect debug contexts.
     (this.gl as any)._version = 2; // Update GL context: Store WebGL version field on gl context (HACK to identify debug contexts)
 
     // initialize luma Device fields
@@ -218,10 +219,18 @@ export class WebGLDevice extends Device {
   }
 
   /**
-   * Destroys the context
-   * @note Has no effect for WebGL browser contexts, there is no browser API for destroying contexts
+   * Destroys the device 
+   * 
+   * @note "detaches" from the WebGL context,
+   * implying that another WebGLDevice could now attach to it.
+   * 
+   * @note The underlying WebGL context is not immediately destroyed, but may be destroyed later 
+   * through normal JavaScript garbage collection. This is a fundamental limitation as WebGL 
+   * since WebGL does not offer any browser API for destroying WeGL contexts.
    */
-  destroy(): void {}
+  destroy(): void {
+    delete (this.gl as any).device;
+  }
 
   get isLost(): boolean {
     return this.gl.isContextLost();

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -115,13 +115,16 @@ export class WebGLDevice extends Device {
   constructor(props: DeviceProps) {
     super({...props, id: props.id || uid('webgl-device')});
 
+    const canvasContextProps = Device._getCanvasContextProps(props)!;
+
     // WebGL requires a canvas to be created before creating the context
-    if (!props.createCanvasContext) {
+    if (!canvasContextProps) {
       throw new Error('WebGLDevice requires props.createCanvasContext to be set');
     }
-    const canvasContextProps = props.createCanvasContext === true ? {} : props.createCanvasContext;
 
     // Check if the WebGL context is already associated with a device
+    // Note that this can be avoided in webgl2adapter.create() if
+    // DeviceProps._reuseDevices is set.
     // @ts-expect-error device is attached to context
     let device: WebGLDevice | undefined = canvasContextProps.canvas?.gl?.device;
     if (device) {
@@ -235,9 +238,9 @@ export class WebGLDevice extends Device {
     // multiple times on the same device.
     // Therefore we must do nothing in destroy() if _reuseDevices is true
     // unless we e.g. implement reference counting.
-    if (!this.props._reuseDevices) {
-      delete (this.gl as any).device;
-    }
+    // if (!this.props._reuseDevices) {
+    //   delete (this.gl as any).device;
+    // }
   }
 
   get isLost(): boolean {

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -106,9 +106,8 @@ export class WebGPUDevice extends Device {
     });
 
     // Note: WebGPU devices can be created without a canvas, for compute shader purposes
-    if (props.createCanvasContext) {
-      const canvasContextProps =
-        props.createCanvasContext === true ? {} : props.createCanvasContext;
+    const canvasContextProps = Device._getCanvasContextProps(props);
+    if (canvasContextProps) {
       this.canvasContext = new WebGPUCanvasContext(this, this.adapter, canvasContextProps);
     }
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #9379
<!-- For other PRs without open issue -->
#### Background
- Looks like deck.gl/react strict mode initializes and destroys a device two times on the same canvas == WewbGL context.
#### Change List
- Add a new option that returns the already attached device instead of creating a new device when creating two devices against the same canvas.
#### TODO
- Cherry pick to 9.1-release
