### PR TITLE
feat: Support new vertex formats in Chrome 133

### DIFF
--- a/docs/api-guide/gpu/gpu-attributes.md
+++ b/docs/api-guide/gpu/gpu-attributes.md
@@ -1,11 +1,18 @@
 # Attributes
 
-In traditional 3D graphics, the purpose of GPU **attributes* is to 
-provide arrays of vertex data (containing positions, normals, texture coordinates for each vertex) 
-describing the 3D models that are to be rendered.
+:::info
+Note that while **attributes** is a structured and performant mechanism to provide columnar data to shaders that works on both WebGPU and WebGL, they are rather rigid and have a number of limitations. In WebGPU a more significantly more flexible approach is to use [storage buffers](./gpu-storage-buffers).
+:::
 
-More generally, a GPU can be thought of as operating on "binary columnar tables". In this a mental model:
-- attributes are "columnar binary arrays" with the same number of elements that each contain one value for each row. 
+The traditional 3D GPU execution model is that shaders work on vertexes, each vertex having a number of unique values such as position, normal, texture coordinates etc. 
+
+In this model, the purpose of GPU vertex **attributes** is to 
+let the application provide arrays of vertex data
+describing the 3D models that are to be rendered.
+Each attribute would be an array containing values for each vertex such as positions, normals, texture coordinates).
+
+More generally, in this model a GPU can be thought of as operating on "binary columnar tables", where:
+- Attributes are "columnar binary arrays" with the same number of elements that each contain one value for each row. 
 - Each column is an array of either floating point values, or signed or unsigned integers.
 - A row can use up either a single value, or represent a vector of 2, 3 or 4 elements.
 - All rows in a column must be of the same format (single value or vector)
@@ -25,7 +32,18 @@ A `BufferLayout` describes the dynamic structure of one buffer (the actual GPU m
 that is expected be bound to the pipeline before `draw()` or `run()` is called. 
 Specifically it
 
-## Data Formats
+## VertexFormats
+
+The format of a vertex attribute indicates how data from a vertex buffer 
+will be interpreted and exposed to the shader. Each format has a name that encodes
+the order of components, bits per component, and vertex data type for the component.
+The `VertexFormat` type is a string union of all the defined vertex formats.
+
+See the [VertexFormat reference](/docs/api-reference/core/vertex-formats) for information about which formats are available..
+
+Note that [WebGPU](https://www.w3.org/TR/webgpu/#vertex-state) is more restrictive than WebGL in terms of supported data formats for vertex attributes.
+
+## Buffer Memory Layout
 
 A `BufferLayout` enumerates the attributes that will be read from the memory in each bound buffer.
 - the data format of the memory in the buffer, i.e: the primitive data type (float, int, short, byte etc)
@@ -48,75 +66,6 @@ The structure (memory layout and format) of these memory contained in these buff
 must match the constraints imposed by the shader source code, 
 and the structure of the data in the buffers must also be communicated to the GPU.
 
-## VertexFormat
+## Index Buffers
 
-The format of a vertex attribute indicates how data from a vertex buffer 
-will be interpreted and exposed to the shader. Each format has a name that encodes
-the order of components, bits per component, and vertex data type for the component.
-The `VertexFormat` type is a string union of all the defined vertex formats.
-
-Each vertex data type can map to any WGSL scalar type of the same base type, regardless of the bits per component:
-
-| Vertex format prefix | Vertex data type      | Compatible WGSL types | Compatible GLSL types             |
-| -------------------- | --------------------- | --------------------- | --------------------------------- |
-| `uint`               | `unsigned int`        | `u32`                 | `uint`, `uvec2`, `uvec3`, `uvec4` |
-| `sint`               | `signed int`          | `i32`                 | `int`, `ivec2`, `ivec3`, `ivec4`  |
-| `unorm`              | `unsigned normalized` | `f16`, `f32`          | `float`, `vec2`, `vec3`, `vec4`   |
-| `snorm`              | `signed normalized`   | `f16`, `f32`          | `float`, `vec2`, `vec3`, `vec4`   |
-| `float`              | `floating point`      | `f16`, `f32`          | `float`, `vec2`, `vec3`, `vec4`   |
-
-| Vertex Format | Data Type | WGSL types   | GLSL Types                       |
-| ------------- | --------- | ------------ | -------------------------------- |
-| `uint8x2`     | `uint8`   | `u32`        | `uint`, `uvec2-4`                |
-| `uint8x4`     | `uint8`   | `u32`        | `uint`, `uvec2-4`                |
-| `sint8x2`     | `sint8`   | `i32`        | `int`, `ivec2-4`                 |
-| `sint8x4`     | `sint8`   | `i32`        | `int`, `ivec2-4`                 |
-| `unorm8x2`    | `unorm8`  | `f16`, `f32` | `float`, `vec2`, `vec3`, `vec4`  |
-| `unorm8x4`    | `unorm8`  | `f16`, `f32` | `float`, ...                     |
-| `snorm8x2`    | `snorm8`  | `f16`, `f32` | `float`, ...                     |
-| `snorm8x4`    | `snorm8`  | `f16`, `f32` | `float`, ...                     |
-| `uint16x2`    | `uint16`  | `u32`        |                                  |
-| `uint16x4`    | `uint16`  | `u32`        |                                  |
-| `sint16x2`    | `sint16`  | `i32`        | `int`, `ivec2-4`                 |
-| `sint16x4`    | `sint16`  | `i32`        | `int`, `ivec2-4`                 |
-| `unorm16x2`   | `unorm16` | `f16`, `f32` |                                  |
-| `unorm16x4`   | `unorm16` | `f16`, `f32` |                                  |
-| `snorm16x2`   | `snorm16` | `f16`, `f32` |                                  |
-| `snorm16x4`   | `snorm16` | `f16`, `f32` |                                  |
-| `float16x2`   | `float16` | `f16`        | ?                                |
-| `float16x4`   | `float16` | `f16`        | ?                                |
-| `float32`     | `float32` | `f32`        |                                  |
-| `float32x2`   | `float32` | `f32`        |                                  |
-| `float32x3`   | `float32` | `f32`        |                                  |
-| `float32x4`   | `float32` | `f32`        |                                  |
-| `uint32`      | `uint`    | `u32`        |                                  |
-| `uint32x2`    | `uint32`  | `u32`        |                                  |
-| `uint32x3`    | `uint32`  | `u32`        |                                  |
-| `uint32x4`    | `uint32`  | `u32`        |                                  |
-| `sint32`      | `sint`    | `i32`        | `int`, `ivec2`, `ivec3`, `ivec4` |
-| `sint32x2`    | `sint32`  | `i32`        | `int`, ...                       |
-| `sint32x3`    | `sint32`  | `i32`        | `int`, ...                       |
-| `sint32x4`    | `sint32`  | `i32`        | `int`, ...                       |
-
-## Backend Notes
-
-When it comes to attributes, [WebGPU](https://www.w3.org/TR/webgpu/#vertex-state) is significantly more restrictive than WebGL:
-
-| Feature                       | WebGL | WebGPU | Comment                                                                                                                                                        |
-| ----------------------------- | ----- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Dynamic `VertexFormat`        | ✅     | ❌      | Buffers with different structure (different `BufferLayout`) can be provided without relinking the `RenderPipeline`                                             |
-| Constant attributes           | ✅     | ❌      | (attribute locations can be disabled in which case a constant value is read from the WebGLRenderingContext)                                                    |
-| Component mismatch            | ✅     | ❌      | Use buffers with more or fewer components than expected by the shader (missing values will be filled with `[0, 0, 0, 1]`).                                     |
-| Non-normalized integers       | ✅     | ❌      | Non-normalized integer attributes can be assigned to floating point GLSL shader variables (e.g. `vec4`).                                                       |
-| Alignment free 8-bit formats  | ✅     | ❌      | WebGPU 8 bit integers must be aligned to 16 bits (`uint8x1`, `uint8x3`, `unorm8x1`, `unorm8x3` etc` are not supported)                                         |
-| Alignment free 16-bit formats | ✅     | ❌      | WebGPU 16 bit integers must be aligned to 32 bits (`uint16x1`, `uint16x3`, `unorm16x1`, `unorm16x3` etc` are not supported)                                    |
-| Normalized 32-bit integers    | ✅     | ❌      | WebGPU 32 bit integer formats cannot be normalized                                                                                                             |
-| Per-attribute`stepMode`       | ✅     | ❌      | `stepMode` (WebGL: `divisor`, controls whether an attribute is instanced) can be set per-attribute, even when multiple attributes bind to the same buffer.     |
-| Per-attribute`byteStride`     | ✅     | ❌      | `byteStride` (controls byte distance between two successive values in memory) can be set per-attribute, even when multiple attributes bind to the same buffer. |
-
-Presumably, the heavy restrictions in WebGPU support reduced run-time validation overhead, additional optimizations during shader compilation and/or portability across Vulkan/Metal/D3D12.
-
-Note:
-- 8 and 16 bit values only support 2 or 4 components. This is a WebGPU specific limitation that does not exist on WebGL.
-- WebGL: GLSL supports `bool` and `bvec*` but these are not portable to WebGPU and not included here.
-- WebGL: GLSL types `double` and `dvec*` are not supported in any WebGL version (nor is `f64` supported in WebGPU).
+An index buffer can be provided to provide a list of indices into the vertex array attributes. This allows vertexes to be reordered, filtered out, or duplicated without copying / modifying any memory other than the index array.

--- a/docs/api-guide/gpu/gpu-rendering.md
+++ b/docs/api-guide/gpu/gpu-rendering.md
@@ -1,4 +1,4 @@
-# How Rendering Works
+# How GPU Rendering Works
 
 :::info
 Note that the luma.gl documentation includes a series of tutorials that explain how to render with the luma.gl API.

--- a/docs/api-guide/gpu/gpu-storage-buffers.md
+++ b/docs/api-guide/gpu/gpu-storage-buffers.md
@@ -1,0 +1,19 @@
+# Storage Buffers
+
+**storage buffers** represent a flexible mechanism for providing data to shaders, they are not available in WebGL, so applications may need to consider fallbacks.
+
+The alternative mechanism is **attributes**, a structured and performant mechanism that works on both WebGPU and WebGL, though they are more rigid and have a number of limitations. 
+
+## Storage Buffer Basics
+
+```ts
+const buffer = device.createBuffer({usage: Buffer.STORAGE, ...});
+
+model.setBindings({
+  ...
+})
+```
+
+Storage buffers have many similarities to uniform buffers.
+
+TBA

--- a/docs/api-reference/core/texture-formats.mdx
+++ b/docs/api-reference/core/texture-formats.mdx
@@ -11,7 +11,7 @@ The following table lists all the texture formats constants supported by luma.gl
 
 Note that even though a GPU supports creating and sampling textures of a certain format, additional capabilities may need to be checked separatey, more information below the table.
 
-## Formats
+<DeviceTabs />
 
 | `TextureFormat`                       | Available                           | Filterable                         | Renderable                         | Notes / WebGL counterpart                                                                                               |
 | ------------------------------------- | ----------------------------------- | ---------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |

--- a/docs/api-reference/core/vertex-formats.mdx
+++ b/docs/api-reference/core/vertex-formats.mdx
@@ -1,0 +1,112 @@
+import {DeviceTabs, VFormat as Vf} from '@site/src/react-luma';
+
+# Vertex Formats
+
+The format of a vertex attribute indicates how data in a vertex buffer is laid out,
+and how it will exposed to the shader. Each format has a name that encodes
+
+- the order of components
+- bits per component
+- and vertex data type for the component.
+
+The `VertexFormat` type is a string union of all the defined vertex formats.
+
+<DeviceTabs />
+
+| Vertex Format     | Availability Check         | WGSL types               | GLSL Types | Notes                         |
+| ----------------- | -------------------------- | ------------------------ | ---------- | ----------------------------- |
+| `uint8`           | <Vf f="uint8" />           | `u32`                    | `uint`     | [Chrome v133+][chrome_133_vf] |
+| `uint8x2`         | <Vf f="uint8x2" />         | `vec2<u32>`              | `uvec2`    |                               |
+| `uint8x4`         | <Vf f="uint8x4" />         | `vec2<u32>`              | `uvec4`    |                               |
+| `sint8`           | <Vf f="sint8" />           | `i32`                    | `int`      | [Chrome v133+][chrome_133_vf] |
+| `sint8x2`         | <Vf f="sint8x2" />         | `vec2<i32>`              | `ivec2`    |                               |
+| `sint8x4`         | <Vf f="sint8x4" />         | `vec2<i32>`              | `ivec4`    |                               |
+| `unorm8`          | <Vf f="unorm8" />          | `f16`, `f32`             | `float`    | [Chrome v133+][chrome_133_vf] |
+| `unorm8x2`        | <Vf f="unorm8x2" />        | `vec2<f16>`, `vec2<f32>` | `vec2`     |                               |
+| `unorm8x4`        | <Vf f="unorm8x4" />        | `vec2<f16>`, `vec2<f32>` | `vec4`     |                               |
+| `unorm8x4-bgra`   | <Vf f="unorm8x4-bgra" />   | `vec4<f16>`, `vec4<f32>` | ❌         | [Chrome v133+][chrome_133_vf] |
+| `unorm10-10-10-2` | <Vf f="unorm10-10-10-2" /> | `vec4<f16>`, `vec4<f32>` | ❌         | [Chrome v119+][chrome_119_vf] |
+| `snorm8`          | <Vf f="snorm8" />          | `f16`, `f32`             | `float`    | [Chrome v133+][chrome_133_vf] |
+| `snorm8x2`        | <Vf f="snorm8x2" />        | `vec2<f16>`, `vec2<f32>` | `vec2`     |                               |
+| `snorm8x4`        | <Vf f="snorm8x4" />        | `vec2<f16>`, `vec2<f32>` | `vec4`     |                               |
+| `uint16`          | <Vf f="uint16" />          | `u32`                    | `uint`     | [Chrome v133+][chrome_133_vf] |
+| `uint16x2`        | <Vf f="uint16x2" />        | `vec2<u32>`              | `ivec2`    |                               |
+| `uint16x4`        | <Vf f="uint16x4" />        | `vec3<u32>`              | `ivec4`    |                               |
+| `sint16`          | <Vf f="sint16" />          | `i32`                    | `int`      | [Chrome v133+][chrome_133_vf] |
+| `sint16x2`        | <Vf f="sint16x2" />        | `vec2<i32>`              | `ivec2`    |                               |
+| `sint16x4`        | <Vf f="sint16x4" />        | `vec2<i32>`              | `ivec4`    |                               |
+| `unorm16`         | <Vf f="unorm16" />         | `f16`, `f32`             | `float`    | [Chrome v133+][chrome_133_vf] |
+| `unorm16x2`       | <Vf f="unorm16x2" />       | `vec2<f16>`, `vec2<f32>` | `vec2`     |                               |
+| `unorm16x4`       | <Vf f="unorm16x4" />       | `vec3<f16>`, `vec4<f32>` | `vec4`     |                               |
+| `snorm16`         | <Vf f="snorm16" />         | `f16`, `f32`             | `float`    | [Chrome v133+][chrome_133_vf] |
+| `snorm16x2`       | <Vf f="snorm16x2" />       | `vec2<f16>`, `vec2<f32>` | `vec2`     |                               |
+| `snorm16x4`       | <Vf f="snorm16x4" />       | `vec4<f16>`, `vec4<f32>` | `vec4`     |                               |
+| `float16`         | <Vf f="float16" />         | `f16`, `f32`             | ❌         | [Chrome v133+][chrome_133_vf] |
+| `float16x2`       | <Vf f="float16x2" />       | `vec2<f16>`, `vec2<f32>` | ❌         |                               |
+| `float16x4`       | <Vf f="float16x4" />       | `vec4<f16>`, `vec4<f32>` | ❌         |                               |
+| `float32`         | <Vf f="float32" />         | `f32`                    | `float`    |                               |
+| `float32x2`       | <Vf f="float32x2" />       | `vec2<f32`               | `vec2`     |                               |
+| `float32x3`       | <Vf f="float32x3" />       | `vec3<f32`               | `vec3`     |                               |
+| `float32x4`       | <Vf f="float32x4" />       | `vec4<f32`               | `vec4      |                               |
+| `uint32`          | <Vf f="uint32" />          | `u32`                    | `uint`     |                               |
+| `uint32x2`        | <Vf f="uint32x2" />        | `vec2<u32>`              | `uvec2`    |                               |
+| `uint32x3`        | <Vf f="uint32x3" />        | `vec3<u32>`              | `uvec3`    |                               |
+| `uint32x4`        | <Vf f="uint32x4" />        | `vec4<u32>`              | `uvec4`    |                               |
+| `sint32`          | <Vf f="sint32" />          | `i32`                    | `int`      |                               |
+| `sint32x2`        | <Vf f="sint32x2" />        | `vec2<i32>`              | `ivec2`    |                               |
+| `sint32x3`        | <Vf f="sint32x3" />        | `vec3<i32>`              | `ivec3`    |                               |
+| `sint32x4`        | <Vf f="sint32x4" />        | `vec4<i32>`              | `ivec4`    |                               |
+
+[chrome_133_vf]: https://developer.chrome.com/blog/new-in-webgpu-133#additional_unorm8x4-bgra_and_1-component_vertex_formats
+[chrome_119_vf]: https://developer.chrome.com/blog/new-in-webgpu-119#unorm10-10-10-2_vertex_format
+
+## Shader Type mappings
+
+Each vertex data type can map to any WGSL scalar type of the same base type, regardless of the bits per component:
+
+| Vertex format prefix | Vertex data type      | Compatible WGSL types | Compatible GLSL types             |
+| -------------------- | --------------------- | --------------------- | --------------------------------- |
+| `uint`               | `unsigned int`        | `u32`                 | `uint`, `uvec2`, `uvec3`, `uvec4` |
+| `sint`               | `signed int`          | `i32`                 | `int`, `ivec2`, `ivec3`, `ivec4`  |
+| `unorm`              | `unsigned normalized` | `f16`, `f32`          | `float`, `vec2`, `vec3`, `vec4`   |
+| `snorm`              | `signed normalized`   | `f16`, `f32`          | `float`, `vec2`, `vec3`, `vec4`   |
+| `float16`            | `floating point`      | `f16`, `f32`          | `float`, `vec2`, `vec3`, `vec4`   |
+| `float32`            | `floating point`      | `f32`                 | `float`, `vec2`, `vec3`, `vec4`   |
+
+## GPU Backend Differences
+
+luma.gl attempts to provide a consistent API across WebGPU and WebGL, but there are significant differences in vertex format supported across the two APIs.
+
+- The multi-component formats specify the number of components after "x".
+- **Mismatches in the number of components between the vertex format and shader type are allowed**, with components being either dropped or filled with default values to compensate.
+
+When it comes to attributes, [WebGPU](https://www.w3.org/TR/webgpu/#vertex-state) is significantly more restrictive than WebGL:
+
+| Feature                    | WebGL | WebGPU | Comment                                                                                                                                                        |
+| -------------------------- | ----- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 8-bit x1 alignment         | ✅    | (✅)   | WebGPU 8 bit integers must be aligned to 16, 32 bits (`uint8x1`, `uint8x3`, `unorm8x1`, `unorm8x3` etc` are not supported)                                     |
+| 8-bit x3 alignment         | ✅    | ❌     | WebGPU 8 bit integers must be aligned to 8, 16, 32 bits (`uint8x1`, `uint8x3`, `unorm8x1`, `unorm8x3` etc` are not supported)                                  |
+| 16-bit x1 alignment        | ✅    | (✅)   | WebGPU 16 bit integers must be aligned to 32 bits (`uint16x1`, `uint16x3`, `unorm16x1`, `unorm16x3` etc` are not supported)                                    |
+| 16-bit x3 alignment        | ✅    | ❌     | WebGPU 16 bit integers must be aligned to 32 bits (`uint16x1`, `uint16x3`, `unorm16x1`, `unorm16x3` etc` are not supported)                                    |
+| Component mismatch         | ✅    | (✅)   | Use buffers with more or fewer components than expected by the shader (missing values will be filled with `[0, 0, 0, 1]`).                                     |
+| Normalized 32-bit integers | ✅    | ❌     | WebGPU 32 bit integer formats cannot be normalized                                                                                                             |
+| Per-attribute`stepMode`    | ✅    | ❌     | `stepMode` (WebGL: `divisor`, controls whether an attribute is instanced) can be set per-attribute, even when multiple attributes bind to the same buffer.     |
+| Per-attribute`byteStride`  | ✅    | ❌     | `byteStride` (controls byte distance between two successive values in memory) can be set per-attribute, even when multiple attributes bind to the same buffer. |
+| Dynamic `VertexFormat`     | ✅    | ❌     | Buffers with different structure (different `BufferLayout`) can be provided without relinking the `RenderPipeline`                                             |
+| Constant attributes        | ✅    | ❌     | (attribute locations can be disabled in which case a constant value is read from the WebGLRenderingContext)                                                    |
+| Non-normalized integers    | ✅    | ❌     | Non-normalized integer attributes can be assigned to floating point GLSL shader variables (e.g. `vec4`).                                                       |
+
+Presumably, the heavy restrictions in WebGPU are motivated by:
+
+- portability across Vulkan/Metal/D3D12.
+- additional optimizations during shader compilation
+- reduced run-time validation overhead
+
+In general, an argument can be made that in WebGPU / WGLS, attributes are less important
+since storage buffers are much more flexible, allowing arbitrary memory layouts, random access, and less limitations on number of bindings etc.
+Attributes **may** be faster than storage bindings, but at the moment there is no clear evidence that this is the case.
+
+Notes:
+- WebGPU: 8 and 16 bit formats only support 1, 2 or 4 components (only 2 or 4 components pre Chrome c133).
+- WebGL: GLSL supports `bool` and `bvec*` but these are not portable to WebGPU and are not included by luma.gl.
+- WebGL: GLSL types `double` and `dvec*` are not supported in any WebGL version (nor is `f64` supported in WebGPU).

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -44,7 +44,8 @@
           "api-guide/gpu/gpu-parameters",
           "api-guide/gpu/gpu-bindings",
           "api-guide/gpu/gpu-attributes",
-          "api-guide/gpu/gpu-uniforms"
+          "api-guide/gpu/gpu-uniforms",
+          "api-guide/gpu/gpu-storage-buffers"
         ]
       },
       {
@@ -83,6 +84,7 @@
           "api-reference/core/parameters",
           "api-reference/core/bindings",
           "api-reference/core/shader-layout",
+          "api-reference/core/vertex-formats",
           "api-reference/core/texture-formats",
           "api-reference/core/resources/buffer",
           "api-reference/core/resources/compute-pass",

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -14,6 +14,9 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 
 v9.2 brings full WebGPU support. Some additional deprecations and breaking changes have been necessary, but apart from the `Texture` -> `AsyncTexture` split, impact on most applications should be minimal. 
 
+**New VertexFormats**
+- `VertexFormat` Replace `'unorm8-webgl'` with `'unorm8'`.
+
 **Texture and AsyncTexture**
 - The `Texture` class has been simplified to the minimum API required for GPU portability. The  `AsyncTexture` texture class provides a higher-level API and is recommended for most applications.
 - `device.createTexture()` no longer accepts `props.data`: Use `AsyncTexture` or call `texture.setImageData()`

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,6 +1,6 @@
 # What's New
 
-*This page contains news for recent luma.gl releases. For older releases (through v8.5) refer to the  [Legacy What's New](/docs/legacy/legacy-upgrade-guide) page.*
+_This page contains news for recent luma.gl releases. For older releases (through v8.5) refer to the [Legacy What's New](/docs/legacy/legacy-upgrade-guide) page._
 
 ## Version 9.2 (In Development)
 
@@ -9,14 +9,21 @@ Target Date: Q2, 2025
 Production quality WebGPU backend
 
 **General**
+
+- All luma.gl examples now run under both WebGPU and WebGL
+- API updates to cover [new Chrome WebGPU features](https://developer.chrome.com/docs/web-platform/webgpu/news)
 - TypeScript v5.6, all `"strict"` TypeScript options are now applied to all luma.gl modules.
 - Website tooling upgrades
-- All examples run on WebGPU
 - Documentation improvements (TBD)
 - Improved GitHub issue templates
 
 **@luma.gl/core**
 
+- New [Vertex Formats](/docs/api-reference/core/vertex-formats) (added in Chrome v133 and v119)
+  - Single component 8 and 16 bit formats are now supported by WebGPU: `'uint8'`, `'sint8'`, `'unorm8'`, `'snorm8'`, `'uint16'`, `'sint16'`, `'unorm16'`, `'snorm16'`, and `'float16'`.
+  - Note: 3 component formats are still missing in WebGPU. 
+  - `'unorm8x4-bgra'` - WebGPU only. Simplifies working with BGRA data.
+  - `'unorm10-10-10-2` - Exposed since available in all WebGPU backends. Also supported by WebGL2.
 - Shader type APIs have been improved.
 - `CommandEncoder`/`CommandBuffer` API improvements
 - `Texture` class refactors complete.
@@ -38,7 +45,6 @@ Production quality WebGPU backend
 
 - glTF and PRB now supported on WebGPU (in progress)
 
-
 ## Version 9.1
 
 Target Date: Dec, 2024
@@ -46,6 +52,7 @@ Target Date: Dec, 2024
 Enhanced WebGPU support.
 
 **Highlights**
+
 - GPU backend management is streamlined via the new `Adapter` API.
 - GPU connection to HTML DOM (via `canvas` elements) improved via `CanvasContext` API changes.
 - `Texture`s are now immutable, however a new `AsyncTexture` class offers a higher-level, mutable texture API.
@@ -59,7 +66,7 @@ Enhanced WebGPU support.
 - [`luma`](/docs/api-reference/core/luma)
   - Now relies on `Adapter` instances to define which GPU backends are available.
   - Adapter can be supplied during device creation, avoiding the need for global registration of GPU backends.
-  -  `CreateDeviceProps.adapters` prop to supply list of GPU backend adapters to `luma.createDevice()`. 
+  - `CreateDeviceProps.adapters` prop to supply list of GPU backend adapters to `luma.createDevice()`.
   - [`luma.registerAdapters()`](/docs/api-reference/core/luma#lumaregisteradapters) New method for global registration of adapters (in case it still desired).
 - `Device`
   - `DeviceProps.createCanvasContext` - New prop for creating a default `CanvasContext`.
@@ -87,7 +94,7 @@ Enhanced WebGPU support.
   - Accepts a new `.adapters` prop. (Avoids need for global registration of adapters).
 - `AsyncTexture`](/docs/api-reference/engine/async-texture)
   - New class allows that applications to work withcreate textures from a Promise.
-- `ShaderPassRenderer` 
+- `ShaderPassRenderer`
   - New class that helps applications apply a `ShaderPass` list to a texture.
 
 **@luma.gl/shadertools**
@@ -100,7 +107,7 @@ Enhanced WebGPU support.
 
 **@luma.gl/webgl**
 
-- `webglAdapter` 
+- `webglAdapter`
   - New object representing the WebGL backend
   - New: adds mock WEBGL1 extensions to WebGL2 contexts for better compatibility with old WebGL libraries
   - Big texture refactor to align WebGL implementation with WebGPU APIs
@@ -137,7 +144,7 @@ The biggest change is that the core API is now portable (no longer WebGL-specifi
 luma.gl v9 drops support for WebGL 1 functionality.
 
 - **WebGL1** WebGL 1 support is dropped.
-- **GLSL 1.00** is  no longer supported. GLSL shaders need to be ported to **GLSL 3.00**.
+- **GLSL 1.00** is no longer supported. GLSL shaders need to be ported to **GLSL 3.00**.
 - **headless-gl** The Node.js WebGL 1 integration is no longer supported
 
 On the upside this means that all features requiring WebGL 2 are now available and luma.gl also brings support for a range of new WebGL 2 extensions, see more below.
@@ -185,33 +192,36 @@ On the upside this means that all features requiring WebGL 2 are now available a
 - New `CompilerMessage` type and `formatCompilerLog` function for portable shader log handling.
 - Shader assembly now supports WGSL and single shader source (compute or single vertex+fragment WGSL shaders)
 
-**`@luma.gl/webgl`** 
+**`@luma.gl/webgl`**
 
 - The new bindings API now supports WebGL 2 Uniform Buffers.
 
-WebGL 2 Extension support: WebGL is not dead yet! Browsers (Chrome in particular) 
-are actively developing "extensions" for WebGL 2, 
-and luma.gl is exposing support for many of the new WebGL extensions through the 
+WebGL 2 Extension support: WebGL is not dead yet! Browsers (Chrome in particular)
+are actively developing "extensions" for WebGL 2,
+and luma.gl is exposing support for many of the new WebGL extensions through the
 [`DeviceFeatures`](/docs/api-reference/core/device-features) API.
 
 New `Device.features` that improve application performance in WebGL:
-- `compilation-status-async-webgl`: Asynchronous shader compilation and linking is used automatically by luma.gl and significantly speeds up applications that create many `RenderPipelines`. 
+
+- `compilation-status-async-webgl`: Asynchronous shader compilation and linking is used automatically by luma.gl and significantly speeds up applications that create many `RenderPipelines`.
 
 New `Device.features` that enable additional color format support in WebGL:
+
 - `rgb9e5ufloat-renderable-webgl`: `rgb9e5ufloat` is renderable.
 - `snorm8-renderable-webgl`: `r,rg,rgba8snorm` are renderable.
-- `norm16-renderable-webgl`: `r,rg,rgba16norm` are renderable. 
+- `norm16-renderable-webgl`: `r,rg,rgba16norm` are renderable.
 - `snorm16-renderable-webgl`: `r,rg,rgba16snorm` are renderable.
 
 New `Device.features` that expose new GPU parameters in WebGL:
+
 - `depth-clip-control`: `parameters.unclippedDepth` - depth clipping can now be disabled.
-- `provoking-vertex-webgl`: `parameters.provokingVertex` - controls which primitive vertex is used for flat shading. 
+- `provoking-vertex-webgl`: `parameters.provokingVertex` - controls which primitive vertex is used for flat shading.
 - `polygon-mode-webgl`: `parameters.polygonMode` - enables wire frame rendering of polygons.
-- `polygon-mode-webgl`: `parameters.polygonOffsetLine` - enables depth bias (polygon offset) for lines. 
+- `polygon-mode-webgl`: `parameters.polygonOffsetLine` - enables depth bias (polygon offset) for lines.
 - `shader-clip-cull-distance-webgl`: `parameters.clipCullDistance0-7`, also see GLSL effects below.
 
 New `Device.features` that enable new GLSL syntax
+
 - `shader-noperspective-interpolation-webgl`: GLSL vertex outputs and fragment inputs may be declared with a `noperspective` interpolation qualifier.
 - `shader-conservative-depth-webgl`: GLSL `gl_FragDepth` qualifiers `depth_any` `depth_greater` `depth_less` `depth_unchanged` can enable early depth test optimizations.
 - `shader-clip-cull-distance-webgl`: Enables `gl_ClipDistance[] / gl_CullDistance[]`.
-

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -5,6 +5,7 @@
 import {StatsManager, lumaStats} from '../utils/stats-manager';
 import {log} from '../utils/log';
 import {uid} from '../utils/uid';
+import type {VertexFormat, VertexFormatInfo} from '../shadertypes/vertex-formats';
 import type {TextureFormat, TextureFormatInfo} from '../shadertypes/texture-formats';
 import type {CanvasContext, CanvasContextProps} from './canvas-context';
 import type {BufferProps} from './resources/buffer';
@@ -24,12 +25,12 @@ import type {VertexArray, VertexArrayProps} from './resources/vertex-array';
 import type {TransformFeedback, TransformFeedbackProps} from './resources/transform-feedback';
 import type {QuerySet, QuerySetProps} from './resources/query-set';
 
+import {getVertexFormatInfo} from '../shadertypes/utils/decode-vertex-format';
 import {
   isTextureFormatCompressed,
   getTextureFormatInfo,
   getTextureFormatCapabilities
 } from '../shadertypes/utils/decode-texture-format';
-
 import type {ExternalImage} from '../image-utils/image-types';
 import {isExternalImage, getExternalImageSize} from '../image-utils/image-types';
 
@@ -150,16 +151,22 @@ export type DeviceFeature =
 
 export type WebGPUDeviceFeature =
   | 'depth-clip-control'
-  | 'indirect-first-instance'
-  | 'timestamp-query'
-  | 'shader-f16'
   | 'depth32float-stencil8'
-  | 'rg11b10ufloat-renderable' // Is the rg11b10ufloat texture format renderable?
-  | 'float32-filterable' // Is the float32 format filterable?
-  | 'bgra8unorm-storage' // Can the bgra8unorm texture format be used in storage buffers?
   | 'texture-compression-bc'
+  | 'texture-compression-bc-sliced-3d'
   | 'texture-compression-etc2'
-  | 'texture-compression-astc';
+  | 'texture-compression-astc'
+  | 'texture-compression-astc-sliced-3d'
+  | 'timestamp-query'
+  | 'indirect-first-instance'
+  | 'shader-f16'
+  | 'rg11b10ufloat-renderable' // Is the rg11b10ufloat texture format renderable?
+  | 'bgra8unorm-storage' // Can the bgra8unorm texture format be used in storage buffers?
+  | 'float32-filterable' // Is the float32 format filterable?
+  | 'float32-blendable' // Is the float32 format blendable?
+  | 'clip-distances'
+  | 'dual-source-blending'
+  | 'subgroups'
 // | 'depth-clamping' // removed from the WebGPU spec...
 // | 'pipeline-statistics-query' // removed from the WebGPU spec...
 
@@ -399,6 +406,14 @@ export abstract class Device {
   abstract preferredDepthFormat: 'depth16' | 'depth24plus' | 'depth32float';
 
   protected _textureCaps: Partial<Record<TextureFormat, DeviceTextureFormatCapabilities>> = {};
+
+  getVertexFormatInfo(format: VertexFormat): VertexFormatInfo {
+    return getVertexFormatInfo(format);
+  }
+
+  isVertexFormatSupported(format: VertexFormat): boolean {
+    return true;
+  }
 
   /** Returns information about a texture format, such as data type, channels, bits per channel, compression etc */
   getTextureFormatInfo(format: TextureFormat): TextureFormatInfo {

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -166,7 +166,7 @@ export type WebGPUDeviceFeature =
   | 'float32-blendable' // Is the float32 format blendable?
   | 'clip-distances'
   | 'dual-source-blending'
-  | 'subgroups'
+  | 'subgroups';
 // | 'depth-clamping' // removed from the WebGPU spec...
 // | 'pipeline-statistics-query' // removed from the WebGPU spec...
 

--- a/modules/core/src/shadertypes/utils/decode-vertex-format.ts
+++ b/modules/core/src/shadertypes/utils/decode-vertex-format.ts
@@ -55,7 +55,7 @@ export function makeVertexFormat(
     // TODO - Special cases for WebGL (not supported on WebGPU), overrides the check below
     case 'unorm8':
       if (components === 1) {
-        return 'unorm8-webgl';
+        return 'unorm8';
       }
       if (components === 3) {
         return 'unorm8x3-webgl';

--- a/modules/core/src/shadertypes/vertex-formats.ts
+++ b/modules/core/src/shadertypes/vertex-formats.ts
@@ -21,7 +21,6 @@ export type VertexFormat =
   | 'sint8x2'
   | 'sint8x4'
   | 'unorm8' // Chrome 133+
-  | 'unorm8'
   | 'unorm8x2'
   | 'unorm8x3-webgl' // Not in WebGPU
   | 'unorm8x4'
@@ -29,7 +28,6 @@ export type VertexFormat =
   | 'unorm10-10-10-2' // Chrome 119+
   // | 'snorm-10-10-10-2' // Not in WebGPU, DXD12 doesn't support
   | 'snorm8' // Chrome 133+
-  | 'snorm8'
   | 'snorm8x2'
   | 'snorm8x3-webgl'
   | 'snorm8x4'

--- a/modules/core/src/shadertypes/vertex-formats.ts
+++ b/modules/core/src/shadertypes/vertex-formats.ts
@@ -4,27 +4,40 @@
 
 import {NormalizedDataType} from './data-types';
 
+/*
+ */
 /**
  * Describes the **memory format** and interpretation (normalization) of a buffer that will be supplied to vertex attributes
  * @note Must be compatible with the AttributeShaderType of the shaders, see documentation.
- * @note This is a superset of WebGPU vertex formats to allow foe some flexibility for WebGL only applications
+ * @note This is a superset of WebGPU vertex formats to allow for some flexibility for WebGL only applications
  * @todo Add device.isTextureFormatSupported() method?
  */
 export type VertexFormat =
   // 8 bit integers, note that only 16 bit aligned formats are supported in WebGPU (x2 and x4)
+  | 'uint8' // Chrome 133+
   | 'uint8x2'
   | 'uint8x4'
+  | 'sint8' // Chrome 133+
   | 'sint8x2'
   | 'sint8x4'
-  | 'unorm8-webgl'
+  | 'unorm8' // Chrome 133+
+  | 'unorm8'
   | 'unorm8x2'
-  | 'unorm8x3-webgl'
+  | 'unorm8x3-webgl' // Not in WebGPU
   | 'unorm8x4'
-  | 'snorm8-webgl'
+  | 'unorm8x4-bgra' // Chrome 133+
+  | 'unorm10-10-10-2' // Chrome 119+
+  // | 'snorm-10-10-10-2' // Not in WebGPU, DXD12 doesn't support
+  | 'snorm8' // Chrome 133+
+  | 'snorm8'
   | 'snorm8x2'
   | 'snorm8x3-webgl'
   | 'snorm8x4'
-  // 16 bit integers, note that only 32 bit aligned formats are supported in WebGPU (x2 and x4)
+  // 16 bit integers, that only 32 bit aligned formats are supported in WebGPU (x2 and x4)
+  | 'uint16' // Chrome 133+
+  | 'sint16' // Chrome 133+
+  | 'unorm16' // Chrome 133+
+  | 'snorm16' // Chrome 133+
   | 'uint16x2'
   | 'uint16x4'
   | 'sint16x2'
@@ -52,6 +65,7 @@ export type VertexFormat =
   // | 'snorm32x3'
   // | 'snorm32x4'
   // floats
+  | 'float16' // Chrome 133+
   | 'float16x2'
   | 'float16x4'
   | 'float32'
@@ -72,6 +86,8 @@ export type VertexFormatInfo = {
   signed: boolean;
   /** Is this a normalized format? */
   normalized: boolean;
+  /** Is this a bgra format? */
+  bgra?: boolean;
   /** Is this a webgl only format? */
   webglOnly?: boolean;
 };

--- a/modules/webgl/src/adapter/converters/webgl-shadertypes.ts
+++ b/modules/webgl/src/adapter/converters/webgl-shadertypes.ts
@@ -48,10 +48,9 @@ export function getVertexFormatFromGL(type: GLDataType, components: 1 | 2 | 3 | 
   const base = getVertexTypeFromGL(type);
   // prettier-ignore
   switch (components) {
-    // @ts-expect-error TODO deal with lack of formats
     case 1: return base;
     case 2: return `${base}x2`;
-    // @ts-expect-error TODO deal with lack of formats
+    // @ts-expect-error - deal with lack of "unaligned" formats
     case 3: return `${base}x3`;
     case 4: return `${base}x4`;
   }

--- a/modules/webgl/src/adapter/converters/webgl-vertex-formats.ts
+++ b/modules/webgl/src/adapter/converters/webgl-vertex-formats.ts
@@ -20,10 +20,9 @@ export function getVertexFormatFromGL(type: GLDataType, components: 1 | 2 | 3 | 
   const base = getVertexTypeFromGL(type);
   // prettier-ignore
   switch (components) {
-    // @ts-expect-error TODO deal with lack of formats
     case 1: return base;
     case 2: return `${base}x2`;
-    // @ts-expect-error TODO deal with lack of formats
+    // @ts-expect-error TODO deal with lack of "unaligned" formats
     case 3: return `${base}x3`;
     case 4: return `${base}x4`;
   }

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -29,7 +29,8 @@ import type {
   CommandEncoderProps,
   TransformFeedbackProps,
   QuerySetProps,
-  Resource
+  Resource,
+  VertexFormat
 } from '@luma.gl/core';
 import {Device, CanvasContext, log} from '@luma.gl/core';
 import type {GLExtensions} from '@luma.gl/constants';
@@ -111,6 +112,15 @@ export class WebGLDevice extends Device {
 
   override toString(): string {
     return `${this[Symbol.toStringTag]}(${this.id})`;
+  }
+
+  override isVertexFormatSupported(format: VertexFormat): boolean {
+    switch (format) {
+      case 'unorm8x4-bgra':
+        return false;
+      default:
+        return true;
+    }
   }
 
   constructor(props: DeviceProps) {

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -10,6 +10,7 @@ import type {
   DeviceLimits,
   DeviceFeature,
   DeviceTextureFormatCapabilities,
+  VertexFormat,
   CanvasContextProps,
   BufferProps,
   SamplerProps,
@@ -125,6 +126,11 @@ export class WebGPUDevice extends Device {
 
   get isLost(): boolean {
     return this._isLost;
+  }
+
+  override isVertexFormatSupported(format: VertexFormat): boolean {
+    const info = this.getVertexFormatInfo(format);
+    return !info.webglOnly;
   }
 
   createBuffer(props: BufferProps | ArrayBuffer | ArrayBufferView): WebGPUBuffer {

--- a/website/src/react-luma/components/device-info.tsx
+++ b/website/src/react-luma/components/device-info.tsx
@@ -1,5 +1,6 @@
+// luma.gl
 import React from 'react';
-import {Device, DeviceFeature, DeviceLimits, TextureFormat} from '@luma.gl/core';
+import type {Device, DeviceFeature, DeviceLimits, TextureFormat, VertexFormat} from '@luma.gl/core';
 import {GL} from '@luma.gl/constants';
 import {WebGLDevice} from '@luma.gl/webgl';
 
@@ -11,6 +12,15 @@ function getLimit(device: Device, feature: keyof DeviceLimits): string {
 
 function getFeature(device: Device, feature: string): string {
   return device ? device.features.has(feature as DeviceFeature) ? '✅' : '❌' : 'N/A';
+}
+
+function getVertexFormat(device: Device, format: VertexFormat): string {
+  try {
+    const isSupported = device && device.isVertexFormatSupported(format);
+    return device ? isSupported ? '✅' : '❌' : 'N/A';
+  } catch {
+    return '❌';
+  }
 }
 
 function getFormat(device: Device, format: TextureFormat): string {
@@ -47,6 +57,11 @@ export const Limit = ({f}) => {
 export const Feature = ({f}) => {
   const device = useStore(state => state.device);
   return <span>{getFeature(device, f)}</span>;
+}
+
+export const VFormat = ({f}) => {
+  const device = useStore(state => state.device);
+  return <span key={f}>{getVertexFormat(device, f)}</span>;
 }
 
 export const Format = ({f}) => {

--- a/website/src/react-luma/index.ts
+++ b/website/src/react-luma/index.ts
@@ -11,6 +11,7 @@ export {
   Info,
   Limit,
   Feature,
+  VFormat,
   Format,
   Filter,
   Render,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background
- WebGPU now supports single component 8 and 16 bit attributes, starting with Chrome 133.
- However 3 component attributes are still not supported, so this doesn't bring WebGL parity.

#### Change List

