### PR TITLE
fix: add WebGLContextProps.stencil

### DIFF
--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -294,6 +294,7 @@ type WebGLContextProps = {
   alpha?: boolean; // indicates if the canvas contains an alpha buffer.
   desynchronized?: boolean; // hints the user agent to reduce the latency by desynchronizing the canvas paint cycle from the event loop
   antialias?: boolean; // indicates whether or not to perform anti-aliasing.
+  stencil?: boolean; // indicates that the render target has a stencil buffer of at least `8` bits.   
   depth?: boolean; // indicates that the drawing buffer has a depth buffer of at least 16 bits.
   failIfMajorPerformanceCaveat?: boolean; // indicates if a context will be created if the system performance is low or if no hardware GPU is available.
   powerPreference?: 'default' | 'high-performance' | 'low-power';


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/hubble.gl/pull/285#discussion_r1940460265
<!-- For other PRs without open issue -->
#### Background

Migrating hubble.gl to luma/deck v9+ revealed that hte stencil property was not present in `CreateDeviceProps`

<!-- For all the PRs -->
#### Change List
- adds `stencil` field to `CreateDeviceProps.webgl`
