### PR TITLE
fix(webgl): Do not set drawBuffers for external Framebuffer

### DIFF
--- a/modules/webgl/src/adapter/resources/webgl-render-pass.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pass.ts
@@ -9,6 +9,7 @@ import {GL, GLParameters} from '@luma.gl/constants';
 import {withGLParameters} from '../../context/state-tracker/with-parameters';
 import {setGLParameters} from '../../context/parameters/unified-parameter-api';
 import {WEBGLQuerySet} from './webgl-query-set';
+import {WEBGLFramebuffer} from './webgl-framebuffer';
 
 const COLOR_CHANNELS = [0x1, 0x2, 0x4, 0x8]; // GPUColorWrite RED, GREEN, BLUE, ALPHA
 
@@ -41,13 +42,16 @@ export class WEBGLRenderPass extends RenderPass {
     this.setParameters({viewport, ...this.props.parameters});
 
     // Specify mapping of draw buffer locations to color attachments
-    if (this.props.framebuffer) {
-      const drawBuffers = this.props.framebuffer.colorAttachments.map(
-        (_, i) => GL.COLOR_ATTACHMENT0 + i
-      );
-      this.device.gl.drawBuffers(drawBuffers);
-    } else {
-      this.device.gl.drawBuffers([GL.BACK]);
+    const webglFramebuffer = this.props.framebuffer as WEBGLFramebuffer;
+    if (webglFramebuffer?.handle) {
+      if (this.props.framebuffer) {
+        const drawBuffers = this.props.framebuffer.colorAttachments.map(
+          (_, i) => GL.COLOR_ATTACHMENT0 + i
+        );
+        this.device.gl.drawBuffers(drawBuffers);
+      } else {
+        this.device.gl.drawBuffers([GL.BACK]);
+      }
     }
 
     // Hack - for now WebGL draws in "immediate mode" (instead of queueing the operations)...


### PR DESCRIPTION
The google-maps-overlay in deck sets `WebGLFramebuffer` as `Deck._framebuffer` in order to render into it: https://github.com/visgl/deck.gl/blob/master/modules/google-maps/src/google-maps-overlay.ts#L263-L268

This was working in luma 9.0, but 9.1 crashes as the `WebGLRenderPass` expects a luma.gl `WEBGLFramebuffer` object here: https://github.com/visgl/luma.gl/blob/master/modules/webgl/src/adapter/resources/webgl-render-pass.ts#L48-L50

This fix simply skips the `this.device.gl.drawBuffers()` calls when the passed `this.props.framebuffer` is not of the right type