### PR TITLE
Explicitly export UniformTypes

### DIFF
--- a/modules/shadertools/src/index.ts
+++ b/modules/shadertools/src/index.ts
@@ -14,6 +14,7 @@ export type {PlatformInfo} from './lib/shader-assembly/platform-info';
 
 export type {ShaderModule} from './lib/shader-module/shader-module';
 export type {ShaderPass} from './lib/shader-module/shader-pass';
+export type {UniformTypes} from './lib/utils/uniform-types';
 
 export {initializeShaderModule, initializeShaderModules} from './lib/shader-module/shader-module';
 export {getShaderModuleUniforms} from './lib/shader-module/shader-module';


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/9416

Source:

```ts
export const picking = {...} as const satisfies ShaderModule<PickingProps, PickingUniforms, PickingBindings>;
```

Compiled (before):

```ts
export declare const pickingUniforms: {
    readonly props: PickingProps;
    readonly uniforms: PickingUniforms;
    readonly uniformTypes: Required<import("modules/shadertools/dist/lib/utils/uniform-types").UniformTypes<PickingUniforms>>;
    ...
}
```

Compiled (after):

```ts
export declare const pickingUniforms: {
    readonly props: PickingProps;
    readonly uniforms: PickingUniforms;
    readonly uniformTypes: Required<import("@luma.gl/shadertools").UniformTypes<PickingUniforms>>;
    ...
}
```

#### Change List
- Explicitly export `UniformTypes` from `@luma.gl/shadertools`
