### PR TITLE
fix: lighting WebGPU shaders

### DIFF
--- a/modules/shadertools/package.json
+++ b/modules/shadertools/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@math.gl/core": "^4.1.0",
     "@math.gl/types": "^4.1.0",
-    "wgsl_reflect": "^1.0.1"
+    "wgsl_reflect": "^1.2.0"
   },
   "gitHead": "c636c34b8f1581eed163e94543a8eb1f4382ba8e"
 }

--- a/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-material.ts
+++ b/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-material.ts
@@ -6,6 +6,7 @@ import {NumberArray3} from '@math.gl/types';
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
 import {lighting} from '../lights/lighting';
 import {PHONG_VS, PHONG_FS} from '../phong-material/phong-shaders-glsl';
+import { PHONG_WGSL } from '../phong-material/phong-shaders-wgsl';
 
 export type GouraudMaterialProps = {
   ambient?: number;
@@ -23,6 +24,7 @@ export const gouraudMaterial: ShaderModule<GouraudMaterialProps> = {
   // Note these are switched between phong and gouraud
   vs: PHONG_FS.replace('phongMaterial', 'gouraudMaterial'),
   fs: PHONG_VS.replace('phongMaterial', 'gouraudMaterial'),
+  source: PHONG_WGSL.replaceAll('phongMaterial', 'gouraudMaterial'),
   defines: {
     LIGHTING_VERTEX: true
   },

--- a/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-material.ts
+++ b/modules/shadertools/src/modules/lighting/gouraud-material/gouraud-material.ts
@@ -6,7 +6,7 @@ import {NumberArray3} from '@math.gl/types';
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
 import {lighting} from '../lights/lighting';
 import {PHONG_VS, PHONG_FS} from '../phong-material/phong-shaders-glsl';
-import { PHONG_WGSL } from '../phong-material/phong-shaders-wgsl';
+import {PHONG_WGSL} from '../phong-material/phong-shaders-wgsl';
 
 export type GouraudMaterialProps = {
   ambient?: number;

--- a/modules/shadertools/src/modules/lighting/lights/lighting-wgsl.ts
+++ b/modules/shadertools/src/modules/lighting/lights/lighting-wgsl.ts
@@ -21,7 +21,7 @@ struct DirectionalLight {
 
 struct lightingUniforms {
   enabled: i32,
-  poightCount: i32,
+  pointLightCount: i32,
   directionalLightCount: i32,
 
   ambientColor: vec3<f32>,

--- a/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-wgsl.ts
+++ b/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-wgsl.ts
@@ -74,16 +74,7 @@ fn lighting_getSpecularLightColor(cameraPosition: vec3<f32>, position_worldspace
     let view_direction = normalize(cameraPosition - position_worldspace);
 
     switch (lighting.lightType) {
-      case 0: {
-        let pointLight: PointLight = lighting_getPointLight(0);
-        let light_position_worldspace: vec3<f32> = pointLight.position;
-        let light_direction: vec3<f32> = normalize(light_position_worldspace - position_worldspace);
-        lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.color);
-      }
-      // TODO (kaapp): these branches are identical but wgsl_reflect will error
-      // on a case containing both 0 and default. Will attempt to upstream a fix to that
-      // so we can combine these again.
-      default: {
+      case 0, default: {
         let pointLight: PointLight = lighting_getPointLight(0);
         let light_position_worldspace: vec3<f32> = pointLight.position;
         let light_direction: vec3<f32> = normalize(light_position_worldspace - position_worldspace);

--- a/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-wgsl.ts
+++ b/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-wgsl.ts
@@ -80,7 +80,7 @@ fn lighting_getSpecularLightColor(cameraPosition: vec3<f32>, position_worldspace
         let light_direction: vec3<f32> = normalize(light_position_worldspace - position_worldspace);
         lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.color);
       }
-      // TODO (kaapp): these branches are identical but wgsl_parser will error
+      // TODO (kaapp): these branches are identical but wgsl_reflect will error
       // on a case containing both 0 and default. Will attempt to upstream a fix to that
       // so we can combine these again.
       default: {
@@ -98,8 +98,6 @@ fn lighting_getSpecularLightColor(cameraPosition: vec3<f32>, position_worldspace
   return lightColor;
 }
 `;
-
-
 
 // TODO - handle multiple lights
 /**

--- a/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-wgsl.ts
+++ b/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-wgsl.ts
@@ -66,9 +66,6 @@ fn lighting_getLightColor2(surfaceColor: vec3<f32>, cameraPosition: vec3<f32>, p
   */
 }
 
-// TODO: wgsl parser has a bug which will error on this code, will upstream a fix.
-/**
-
 fn lighting_getSpecularLightColor(cameraPosition: vec3<f32>, position_worldspace: vec3<f32>, normal_worldspace: vec3<f32>) -> vec3<f32>{
   var lightColor = vec3<f32>(0, 0, 0);
   let surfaceColor = vec3<f32>(0, 0, 0);
@@ -77,7 +74,16 @@ fn lighting_getSpecularLightColor(cameraPosition: vec3<f32>, position_worldspace
     let view_direction = normalize(cameraPosition - position_worldspace);
 
     switch (lighting.lightType) {
-      case 0, default: {
+      case 0: {
+        let pointLight: PointLight = lighting_getPointLight(0);
+        let light_position_worldspace: vec3<f32> = pointLight.position;
+        let light_direction: vec3<f32> = normalize(light_position_worldspace - position_worldspace);
+        lightColor += lighting_getLightColor(surfaceColor, light_direction, view_direction, normal_worldspace, pointLight.color);
+      }
+      // TODO (kaapp): these branches are identical but wgsl_parser will error
+      // on a case containing both 0 and default. Will attempt to upstream a fix to that
+      // so we can combine these again.
+      default: {
         let pointLight: PointLight = lighting_getPointLight(0);
         let light_position_worldspace: vec3<f32> = pointLight.position;
         let light_direction: vec3<f32> = normalize(light_position_worldspace - position_worldspace);
@@ -92,6 +98,7 @@ fn lighting_getSpecularLightColor(cameraPosition: vec3<f32>, position_worldspace
   return lightColor;
 }
 `;
+
 
 
 // TODO - handle multiple lights

--- a/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-wgsl.ts
+++ b/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-wgsl.ts
@@ -66,6 +66,9 @@ fn lighting_getLightColor2(surfaceColor: vec3<f32>, cameraPosition: vec3<f32>, p
   */
 }
 
+// TODO: wgsl parser has a bug which will error on this code, will upstream a fix.
+/**
+
 fn lighting_getSpecularLightColor(cameraPosition: vec3<f32>, position_worldspace: vec3<f32>, normal_worldspace: vec3<f32>) -> vec3<f32>{
   var lightColor = vec3<f32>(0, 0, 0);
   let surfaceColor = vec3<f32>(0, 0, 0);
@@ -89,6 +92,7 @@ fn lighting_getSpecularLightColor(cameraPosition: vec3<f32>, position_worldspace
   return lightColor;
 }
 `;
+
 
 // TODO - handle multiple lights
 /**

--- a/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-wgsl.ts
+++ b/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-wgsl.ts
@@ -10,7 +10,7 @@ struct phongMaterialUniforms {
   specularColor: vec3<f32>,
 };
 
-@binding(2) @group(0) var<uniform> material : phongMaterialUniforms;
+@binding(2) @group(0) var<uniform> phongMaterial : phongMaterialUniforms;
 
 fn lighting_getLightColor(surfaceColor: vec3<f32>, light_direction: vec3<f32>, view_direction: vec3<f32>, normal_worldspace: vec3<f32>, color: vec3<f32>) -> vec3<f32> {
   let halfway_direction: vec3<f32> = normalize(light_direction + view_direction);
@@ -18,10 +18,10 @@ fn lighting_getLightColor(surfaceColor: vec3<f32>, light_direction: vec3<f32>, v
   var specular: f32 = 0.0;
   if (lambertian > 0.0) {
     let specular_angle = max(dot(normal_worldspace, halfway_direction), 0.0);
-    specular = pow(specular_angle, material.shininess);
+    specular = pow(specular_angle, phongMaterial.shininess);
   }
   lambertian = max(lambertian, 0.0);
-  return (lambertian * material.diffuse * surfaceColor + specular * material.specularColor) * color;
+  return (lambertian * phongMaterial.diffuse * surfaceColor + specular * phongMaterial.specularColor) * color;
 }
 
 fn lighting_getLightColor2(surfaceColor: vec3<f32>, cameraPosition: vec3<f32>, position_worldspace: vec3<f32>, normal_worldspace: vec3<f32>) -> vec3<f32> {
@@ -32,7 +32,7 @@ fn lighting_getLightColor2(surfaceColor: vec3<f32>, cameraPosition: vec3<f32>, p
   }
 
   let view_direction: vec3<f32> = normalize(cameraPosition - position_worldspace);
-  lightColor = material.ambient * surfaceColor * lighting.ambientColor;
+  lightColor = phongMaterial.ambient * surfaceColor * lighting.ambientColor;
 
   if (lighting.lightType == 0) {
     let pointLight: PointLight  = lighting_getPointLight(0);

--- a/modules/webgpu/src/adapter/helpers/get-bind-group.ts
+++ b/modules/webgpu/src/adapter/helpers/get-bind-group.ts
@@ -54,7 +54,7 @@ export function getShaderLayoutBinding(
 ): BindingDeclaration | null {
   const bindingLayout = shaderLayout.bindings.find(
     binding =>
-      binding.name === bindingName || `${binding.name}uniforms` === bindingName.toLocaleLowerCase()
+      binding.name === bindingName || `${binding.name.toLocaleLowerCase()}uniforms` === bindingName.toLocaleLowerCase()
   );
   if (!bindingLayout && !options?.ignoreWarnings) {
     log.warn(`Binding ${bindingName} not set: Not found in shader layout.`)();

--- a/modules/webgpu/src/adapter/helpers/get-bind-group.ts
+++ b/modules/webgpu/src/adapter/helpers/get-bind-group.ts
@@ -54,7 +54,8 @@ export function getShaderLayoutBinding(
 ): BindingDeclaration | null {
   const bindingLayout = shaderLayout.bindings.find(
     binding =>
-      binding.name === bindingName || `${binding.name.toLocaleLowerCase()}uniforms` === bindingName.toLocaleLowerCase()
+      binding.name === bindingName ||
+      `${binding.name.toLocaleLowerCase()}uniforms` === bindingName.toLocaleLowerCase()
   );
   if (!bindingLayout && !options?.ignoreWarnings) {
     log.warn(`Binding ${bindingName} not set: Not found in shader layout.`)();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,7 +1243,7 @@ __metadata:
   dependencies:
     "@math.gl/core": "npm:^4.1.0"
     "@math.gl/types": "npm:^4.1.0"
-    wgsl_reflect: "npm:^1.0.1"
+    wgsl_reflect: "npm:^1.2.0"
   peerDependencies:
     "@luma.gl/core": 9.2.0-alpha.1
   languageName: unknown
@@ -11881,6 +11881,13 @@ __metadata:
   version: 1.0.12
   resolution: "wgsl_reflect@npm:1.0.12"
   checksum: 10c0/bd0373aa8f427846241494d112c8601b5c5561e76a7ccfe2a8df6a97b75b6522081fb9223733ff452d7981bc559e8c2d9c991cb26220d00b22dd4bfbc7b643f9
+  languageName: node
+  linkType: hard
+
+"wgsl_reflect@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "wgsl_reflect@npm:1.2.0"
+  checksum: 10c0/1e8439b3f9b660775a21ccc68db918b69485df0f82870e75952e718e62cc58ebbe8f4c190256c6bce940fd6a8652c85f56ec66ab18d82488378178f4d84792f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Needed for https://github.com/visgl/deck.gl/pull/9531 in order to port point-cloud-layer to WebGPU.

#### Change List
- Add missing WGSL source for gouraud material
- Fix a typo in the lighting WGSL shader
- Fix uniform bindings not being found when a uniform is named in camelCase (e.g. `pointCloud`)
- Updated `wgsl_reflect` as the version being used crashes when encoutering a switch statement with multiple comma-separated `case`s when one case is `default`.
