### PR TITLE
feat: Use explicit pipeline layouts from shaderLayout

### DIFF
--- a/modules/core/src/adapter/resources/pipeline-layout.ts
+++ b/modules/core/src/adapter/resources/pipeline-layout.ts
@@ -1,0 +1,26 @@
+import {Device} from '../device';
+import {ShaderLayout} from '../types/shader-layout';
+import {Resource, ResourceProps} from './resource';
+
+export type PipelineLayoutProps = ResourceProps & {
+  shaderLayout: ShaderLayout;
+};
+
+/** Immutable PipelineLayout object */
+export abstract class PipelineLayout extends Resource<PipelineLayoutProps> {
+  get [Symbol.toStringTag](): string {
+    return 'PipelineLayout';
+  }
+
+  constructor(device: Device, props: PipelineLayoutProps) {
+    super(device, props, PipelineLayout.defaultProps);
+  }
+
+  static override defaultProps: Required<PipelineLayoutProps> = {
+    ...Resource.defaultProps,
+    shaderLayout: {
+      attributes: [],
+      bindings: []
+    }
+  };
+}

--- a/modules/core/src/adapter/types/shader-layout.ts
+++ b/modules/core/src/adapter/types/shader-layout.ts
@@ -110,7 +110,7 @@ export type StorageBufferBindingLayout = {
   minBindingSize?: number;
 };
 
-type TextureBindingLayout = {
+export type TextureBindingLayout = {
   type: 'texture';
   /** Name of the binding. Used by luma to map bindings by name */
   name: string;
@@ -125,7 +125,7 @@ type TextureBindingLayout = {
   multisampled?: boolean;
 };
 
-type SamplerBindingLayout = {
+export type SamplerBindingLayout = {
   type: 'sampler';
   /** Name of the binding. Used by luma to map bindings by name */
   name: string;
@@ -138,7 +138,7 @@ type SamplerBindingLayout = {
   samplerType?: 'filtering' | 'non-filtering' | 'comparison'; // default: filtering
 };
 
-type StorageTextureBindingLayout = {
+export type StorageTextureBindingLayout = {
   type: 'storage';
   /** Name of the binding. Used by luma to map bindings by name */
   name: string;

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -72,6 +72,9 @@ export {TransformFeedback} from './adapter/resources/transform-feedback';
 export type {QuerySetProps} from './adapter/resources/query-set';
 export {QuerySet} from './adapter/resources/query-set';
 
+export type {PipelineLayoutProps} from './adapter/resources/pipeline-layout';
+export {PipelineLayout} from './adapter/resources/pipeline-layout';
+
 // PORTABLE API - UNIFORM BUFFERS
 export {UniformBufferLayout} from './portable/uniform-buffer-layout';
 export {UniformBlock} from './portable/uniform-block';
@@ -110,7 +113,12 @@ export type {
   ComputeShaderLayout,
   AttributeDeclaration,
   BindingDeclaration,
-  Binding
+  Binding,
+  UniformBufferBindingLayout,
+  StorageBufferBindingLayout,
+  TextureBindingLayout,
+  SamplerBindingLayout,
+  StorageTextureBindingLayout
 } from './adapter/types/shader-layout';
 export type {BufferLayout, BufferAttributeLayout} from './adapter/types/buffer-layout';
 export type {

--- a/modules/webgpu/src/adapter/resources/webgpu-pipeline-layout.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-pipeline-layout.ts
@@ -5,7 +5,6 @@ import {
   StorageTextureBindingLayout
 } from '@luma.gl/core';
 import {WebGPUDevice} from '../webgpu-device';
-import {uid} from '@luma.gl/core/utils/uid';
 
 const VISIBILITY_ALL = GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT | GPUShaderStage.COMPUTE;
 
@@ -27,11 +26,17 @@ export class WebGPUPipelineLayout extends PipelineLayout {
         // layers, particularly if using a separate group for injected
         // bindings (e.g. project/lighting)
         this.device.handle.createBindGroupLayout({
-          label: uid('bind-group-layout'),
+          label: 'bind-group-layout',
           entries: bindGroupEntries
         })
       ]
     });
+  }
+
+  override destroy(): void {
+    // WebGPUPipelineLayout has no destroy method.
+    // @ts-expect-error
+    this.handle = null;
   }
 
   protected mapShaderLayoutToBindGroupEntries(): GPUBindGroupLayoutEntry[] {
@@ -116,5 +121,5 @@ export class WebGPUPipelineLayout extends PipelineLayout {
 const isStorageTextureBindingLayout = (
   maybe: StorageBufferBindingLayout | StorageTextureBindingLayout
 ): maybe is StorageTextureBindingLayout => {
-  return !!(maybe as StorageTextureBindingLayout).format;
+  return (maybe as StorageTextureBindingLayout).format !== undefined;
 };

--- a/modules/webgpu/src/adapter/resources/webgpu-pipeline-layout.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-pipeline-layout.ts
@@ -1,0 +1,120 @@
+import {
+  PipelineLayout,
+  PipelineLayoutProps,
+  StorageBufferBindingLayout,
+  StorageTextureBindingLayout
+} from '@luma.gl/core';
+import {WebGPUDevice} from '../webgpu-device';
+import {uid} from '@luma.gl/core/utils/uid';
+
+const VISIBILITY_ALL = GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT | GPUShaderStage.COMPUTE;
+
+export class WebGPUPipelineLayout extends PipelineLayout {
+  device: WebGPUDevice;
+  handle: GPUPipelineLayout;
+
+  constructor(device: WebGPUDevice, props: PipelineLayoutProps) {
+    super(device, props);
+
+    this.device = device;
+
+    const bindGroupEntries = this.mapShaderLayoutToBindGroupEntries();
+
+    this.handle = this.device.handle.createPipelineLayout({
+      label: props?.id ?? 'unnamed-pipeline-layout',
+      bindGroupLayouts: [
+        // TODO (kaapp): We can cache these to re-use them across
+        // layers, particularly if using a separate group for injected
+        // bindings (e.g. project/lighting)
+        this.device.handle.createBindGroupLayout({
+          label: uid('bind-group-layout'),
+          entries: bindGroupEntries
+        })
+      ]
+    });
+  }
+
+  protected mapShaderLayoutToBindGroupEntries(): GPUBindGroupLayoutEntry[] {
+    // Set up the pipeline layout
+    // TODO (kaapp): This only supports the first group, but so does the rest of the code
+    const bindGroupEntries: GPUBindGroupLayoutEntry[] = [];
+
+    for (let i = 0; i < this.props.shaderLayout.bindings.length; i++) {
+      const binding = this.props.shaderLayout.bindings[i];
+      const bindingTypeInfo: Omit<GPUBindGroupLayoutEntry, 'binding' | 'visibility'> = {};
+
+      switch (binding.type) {
+        case 'uniform': {
+          bindingTypeInfo.buffer = {
+            type: 'uniform',
+            hasDynamicOffset: binding.hasDynamicOffset,
+            minBindingSize: binding.minBindingSize
+          };
+          break;
+        }
+
+        case 'read-only-storage': {
+          bindingTypeInfo.buffer = {
+            type: 'read-only-storage',
+            hasDynamicOffset: binding.hasDynamicOffset,
+            minBindingSize: binding.minBindingSize
+          };
+          break;
+        }
+
+        case 'sampler': {
+          bindingTypeInfo.sampler = {
+            type: binding.samplerType
+          };
+          break;
+        }
+
+        case 'storage': {
+          if (isStorageTextureBindingLayout(binding)) {
+            bindingTypeInfo.storageTexture = {
+              // TODO (kaapp): Not all formats in the binding layout are supported
+              // by WebGPU, but at least it will provide a clear error for now.
+              format: binding.format as GPUTextureFormat,
+              access: binding.access,
+              viewDimension: binding.viewDimension
+            };
+          } else {
+            bindingTypeInfo.buffer = {
+              type: 'storage',
+              hasDynamicOffset: binding.hasDynamicOffset,
+              minBindingSize: binding.minBindingSize
+            };
+          }
+          break;
+        }
+
+        case 'texture': {
+          bindingTypeInfo.texture = {
+            multisampled: binding.multisampled,
+            sampleType: binding.sampleType,
+            viewDimension: binding.viewDimension
+          };
+          break;
+        }
+
+        default: {
+          console.warn('unhandled binding type when creating pipeline descriptor');
+        }
+      }
+
+      bindGroupEntries.push({
+        binding: binding.location,
+        visibility: binding.visibility || VISIBILITY_ALL,
+        ...bindingTypeInfo
+      });
+    }
+
+    return bindGroupEntries;
+  }
+}
+
+const isStorageTextureBindingLayout = (
+  maybe: StorageBufferBindingLayout | StorageTextureBindingLayout
+): maybe is StorageTextureBindingLayout => {
+  return !!(maybe as StorageTextureBindingLayout).format;
+};

--- a/modules/webgpu/src/adapter/resources/webgpu-render-pipeline.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-render-pipeline.ts
@@ -1,12 +1,6 @@
 // luma.gl MIT license
 
-import type {
-  Binding,
-  RenderPass,
-  VertexArray,
-  StorageTextureBindingLayout,
-  StorageBufferBindingLayout
-} from '@luma.gl/core';
+import type {Binding, RenderPass, VertexArray} from '@luma.gl/core';
 import {RenderPipeline, RenderPipelineProps, log} from '@luma.gl/core';
 import {applyParametersToRenderPipelineDescriptor} from '../helpers/webgpu-parameters';
 import {getWebGPUTextureFormat} from '../helpers/convert-texture-format';

--- a/modules/webgpu/src/adapter/resources/webgpu-render-pipeline.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-render-pipeline.ts
@@ -1,6 +1,12 @@
 // luma.gl MIT license
 
-import type {Binding, RenderPass, VertexArray} from '@luma.gl/core';
+import type {
+  Binding,
+  RenderPass,
+  VertexArray,
+  StorageTextureBindingLayout,
+  StorageBufferBindingLayout
+} from '@luma.gl/core';
 import {RenderPipeline, RenderPipelineProps, log} from '@luma.gl/core';
 import {applyParametersToRenderPipelineDescriptor} from '../helpers/webgpu-parameters';
 import {getWebGPUTextureFormat} from '../helpers/convert-texture-format';
@@ -182,6 +188,10 @@ export class WebGPURenderPipeline extends RenderPipeline {
       targets
     };
 
+    const layout = this.device.createPipelineLayout({
+      shaderLayout: this.shaderLayout
+    });
+
     // Create a partially populated descriptor
     const descriptor: GPURenderPipelineDescriptor = {
       vertex,
@@ -189,7 +199,7 @@ export class WebGPURenderPipeline extends RenderPipeline {
       primitive: {
         topology: this.props.topology
       },
-      layout: 'auto'
+      layout: layout.handle
     };
 
     // Set depth format if required, defaulting to the preferred depth format

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -27,6 +27,7 @@ import type {
   QuerySetProps,
   DeviceProps,
   CommandEncoderProps,
+  PipelineLayoutProps,
 } from '@luma.gl/core';
 import {Device, DeviceFeatures} from '@luma.gl/core';
 import {WebGPUBuffer} from './resources/webgpu-buffer';
@@ -43,6 +44,7 @@ import {WebGPUCanvasContext} from './webgpu-canvas-context';
 import {WebGPUCommandEncoder} from './resources/webgpu-command-encoder';
 import {WebGPUCommandBuffer} from './resources/webgpu-command-buffer';
 import {WebGPUQuerySet} from './resources/webgpu-query-set';
+import {WebGPUPipelineLayout} from './resources/webgpu-pipeline-layout';
 
 /** WebGPU Device implementation */
 export class WebGPUDevice extends Device {
@@ -191,6 +193,10 @@ export class WebGPUDevice extends Device {
 
   createCanvasContext(props: CanvasContextProps): WebGPUCanvasContext {
     return new WebGPUCanvasContext(this, this.adapter, props);
+  }
+
+  createPipelineLayout(props: PipelineLayoutProps): WebGPUPipelineLayout {
+    return new WebGPUPipelineLayout(this, props);
   }
 
   submit(commandBuffer?: WebGPUCommandBuffer): void {


### PR DESCRIPTION
#### Background
Solves an issue raised in: https://github.com/visgl/deck.gl/pull/9531

Unused uniforms are stripped from WebGPU shaders by the compiler as they are not part of the shader's resource interface ([as per spec](https://www.w3.org/TR/WGSL/#example-aee0565d))

When shader source injection is performed as a result of using `modules` in `getShaders`, if the bindings injected by that call (such as lighting) go unused, the automatic layout generated by WebGPU will not contain these unused bindings.

Attempting to create the `BindGroupLayout` in this case will result in `luma` attempting to pass a binding for each uniform it's aware of from our WGSL introspection library. Ideally, we want to avoid this mismatch as it makes for a poor developer experience as commenting out lines of code to debug shaders will result in these sorts of errors being thrown.

#### Possible solutions
1. Use the existing WGSL introspection to attempt to determine which bindings are used, not just present and remove those unused bindings from the `shaderLayout` in order to match the automatic layout.
2. Create an explicit pipeline layout based on the `shaderLayout`, which will allow us to bind values to the unused bindings without throwing an error.

Here I've experimented with implementing option 2 for the following reasons:
- Option 1 is brittle and that level of source parsing is probably best avoided
- Option 2 opens up the possibility of caching the `BindGroup`/`BindLayout`s so that they can be shared across layouts/layers. This could be quite useful for luma-injected bindings like `project` and `lighting`.
- Option 2 is required if you want to be able to use `dynamicOffset`s or unfiltered textures, which users creating custom layers may well want to do in the future.

#### Change List
- Add a new pipeline layout object which parses the `shaderLayout` and produces a layout for the render pipeline to use.
- It does not yet handle multiple binding groups, but we have this limitation elsewhere too, so not sure that needs to be addressed here.
