### PR TITLE
chore: Fill viewport depth for webgpu if not provided

### DIFF
--- a/modules/webgpu/src/adapter/resources/webgpu-render-pass.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-render-pass.ts
@@ -148,8 +148,8 @@ export class WebGPURenderPass extends RenderPass {
         viewport[1],
         viewport[2],
         viewport[3],
-        viewport[4] as any,
-        viewport[5] as any
+        viewport[4] ?? 0,
+        viewport[5] ?? 1
       );
     }
   }


### PR DESCRIPTION
#### Background
WebGPU requires 6 coordinates instead of 4, automatically fill depth with default values if they are not provided.

There's a separate issue I've noticed in deck where on the initial render the viewport is calculated incorrectly when a viewport (e.g. WebMercator) is calculated off the current canvas size but the canvas ResizeObserver has not triggered yet so `getGLViewport` uses a stale canvas size and produces a viewport with negative values. Those don't cause errors in WebGL, meaning the second render works as intended but WebGPU rejects this and prevents the app from rendering further.

For example, on my machine:
<img width="1003" alt="image" src="https://github.com/user-attachments/assets/ab6ef99f-8b50-4417-9cd8-673257193e90" />


I'm not sure we should be silently adjusting values to avoid WebGPU errors in luma so the above should probably be fixed in deck as part of the WebGPU enablement.

#### Change List
-
