### PR TITLE
fix: Ensure VertexBufferLayout matches parsed WGSL shader @location layout

### DIFF
--- a/modules/webgpu/src/adapter/helpers/get-vertex-buffer-layout.ts
+++ b/modules/webgpu/src/adapter/helpers/get-vertex-buffer-layout.ts
@@ -28,8 +28,8 @@ export function getVertexBufferLayout(
   const vertexBufferLayouts: GPUVertexBufferLayout[] = [];
   const usedAttributes = new Set<string>();
 
+  // First handle any buffers mentioned in `bufferLayout`
   for (const mapping of bufferLayout) {
-    // First handle any buffers mentioned in `bufferLayout`
     // Build vertex attributes for one buffer
     const vertexAttributes: GPUVertexAttribute[] = [];
 

--- a/modules/webgpu/src/adapter/helpers/get-vertex-buffer-layout.ts
+++ b/modules/webgpu/src/adapter/helpers/get-vertex-buffer-layout.ts
@@ -28,23 +28,7 @@ export function getVertexBufferLayout(
   const vertexBufferLayouts: GPUVertexBufferLayout[] = [];
   const usedAttributes = new Set<string>();
 
-  // don't mutate the original array
-  const orderedBufferLayout = bufferLayout.slice();
-  // it's important that the VertexBufferLayout order matches the
-  // @location order of the attribute struct otherwise the buffers
-  // will not contain the data the shader expects them to.
-  orderedBufferLayout.sort((a, b) => {
-    const attributeA = findAttributeLayout(shaderLayout, a.name);
-    const attributeB = findAttributeLayout(shaderLayout, b.name);
-
-    if (attributeA && attributeB) {
-      return attributeA.location - attributeB.location;
-    }
-
-    return 0;
-  });
-
-  for (const mapping of orderedBufferLayout) {
+  for (const mapping of bufferLayout) {
     // First handle any buffers mentioned in `bufferLayout`
     // Build vertex attributes for one buffer
     const vertexAttributes: GPUVertexAttribute[] = [];
@@ -121,6 +105,16 @@ export function getVertexBufferLayout(
       });
     }
   }
+
+  // it's important that the VertexBufferLayout order matches the
+  // @location order of the attribute struct otherwise the buffers
+  // will not contain the data the shader expects them to.
+  vertexBufferLayouts.sort((a, b) => {
+    const minLocationA = Math.min(...Array.from(a.attributes).map(attr => attr.shaderLocation));
+    const minLocationB = Math.min(...Array.from(b.attributes).map(attr => attr.shaderLocation));
+
+    return minLocationA - minLocationB;
+  });
 
   return vertexBufferLayouts;
 }

--- a/modules/webgpu/src/adapter/helpers/get-vertex-buffer-layout.ts
+++ b/modules/webgpu/src/adapter/helpers/get-vertex-buffer-layout.ts
@@ -110,8 +110,8 @@ export function getVertexBufferLayout(
   // @location order of the attribute struct otherwise the buffers
   // will not contain the data the shader expects them to.
   vertexBufferLayouts.sort((a, b) => {
-    const minLocationA = Math.min(...Array.from(a.attributes).map(attr => attr.shaderLocation));
-    const minLocationB = Math.min(...Array.from(b.attributes).map(attr => attr.shaderLocation));
+    const minLocationA = Math.min(...Array.from(a.attributes, attr => attr.shaderLocation));
+    const minLocationB = Math.min(...Array.from(b.attributes, attr => attr.shaderLocation));
 
     return minLocationA - minLocationB;
   });

--- a/modules/webgpu/test/adapter/helpers/get-vertex-buffer-layout.spec.ts
+++ b/modules/webgpu/test/adapter/helpers/get-vertex-buffer-layout.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'tape-promise/tape';
-import {ShaderLayout} from '@luma.gl/core';
+import {BufferLayout, ShaderLayout} from '@luma.gl/core';
 import {getVertexBufferLayout} from '@luma.gl/webgpu/adapter/helpers/get-vertex-buffer-layout';
 
 const shaderLayout: ShaderLayout = {
@@ -16,63 +16,88 @@ const shaderLayout: ShaderLayout = {
 };
 
 // We want to use "non-standard" buffers: two attributes interleaved in same buffer
-const bufferLayout = [
-  {name: 'particles', attributes: [{name: 'instancePositions'}, {name: 'instanceVelocities'}]}
+const bufferLayout: BufferLayout[] = [
+  {
+    name: 'particles',
+    attributes: [
+      {attribute: 'instancePositions', byteOffset: 0, format: 'float32x2'},
+      {attribute: 'instanceVelocities', byteOffset: 8, format: 'float32x2'}
+    ]
+  },
+  {
+    name: 'positions',
+    attributes: [{attribute: 'vertexPositions', byteOffset: 0, format: 'float32x2'}]
+  }
+];
+
+// Order of this layout is intentionally descending of the shader attribute locations
+const badlyOrderedBufferLayout: BufferLayout[] = [
+  {
+    name: 'positions',
+    attributes: [{attribute: 'vertexPositions', byteOffset: 0, format: 'float32x2'}]
+  },
+  {
+    name: 'particles-second',
+    attributes: [{attribute: 'instanceVelocities', byteOffset: 0, format: 'float32x2'}]
+  },
+  {
+    name: 'particles-first',
+    attributes: [{attribute: 'instancePositions', byteOffset: 0, format: 'float32x2'}]
+  }
 ];
 
 const TEST_CASES: {
   shaderLayout: ShaderLayout;
-  bufferLayout;
+  bufferLayout: BufferLayout[];
   vertexBufferLayout: GPUVertexBufferLayout[];
 }[] = [
-  {
-    shaderLayout,
-    bufferLayout: [],
-
-    vertexBufferLayout: [
-      {
-        stepMode: 'instance',
-        arrayStride: 8,
-        attributes: [
-          {
-            format: 'float32x2',
-            offset: 0,
-            shaderLocation: 0
-          }
-        ]
-      },
-      {
-        stepMode: 'instance',
-        arrayStride: 8,
-        attributes: [
-          {
-            format: 'float32x2',
-            offset: 0,
-            shaderLocation: 1
-          }
-        ]
-      },
-      {
-        stepMode: 'vertex',
-        arrayStride: 8,
-        attributes: [
-          {
-            format: 'float32x2',
-            offset: 0,
-            shaderLocation: 2
-          }
-        ]
-      }
-    ]
-  },
+  // TODO: Renable test without bufferLayout when not using hardcoded types
+  // {
+  //   shaderLayout,
+  //   bufferLayout: [],
+  //   vertexBufferLayout: [
+  //     {
+  //       stepMode: 'instance',
+  //       arrayStride: 8,
+  //       attributes: [
+  //         {
+  //           format: 'float32x2',
+  //           offset: 0,
+  //           shaderLocation: 0
+  //         }
+  //       ]
+  //     },
+  //     {
+  //       stepMode: 'instance',
+  //       arrayStride: 8,
+  //       attributes: [
+  //         {
+  //           format: 'float32x2',
+  //           offset: 0,
+  //           shaderLocation: 1
+  //         }
+  //       ]
+  //     },
+  //     {
+  //       stepMode: 'vertex',
+  //       arrayStride: 8,
+  //       attributes: [
+  //         {
+  //           format: 'float32x2',
+  //           offset: 0,
+  //           shaderLocation: 2
+  //         }
+  //       ]
+  //     }
+  //   ]
+  // }
   {
     shaderLayout,
     bufferLayout,
-
     vertexBufferLayout: [
       {
-        stepMode: 'instance',
         arrayStride: 16,
+        stepMode: 'instance',
         attributes: [
           {
             format: 'float32x2',
@@ -87,8 +112,48 @@ const TEST_CASES: {
         ]
       },
       {
-        stepMode: 'vertex',
         arrayStride: 8,
+        stepMode: 'vertex',
+        attributes: [
+          {
+            format: 'float32x2',
+            offset: 0,
+            shaderLocation: 2
+          }
+        ]
+      }
+    ]
+  },
+  {
+    shaderLayout,
+    // ensure we sort it to match the WGSL source @locations
+    bufferLayout: badlyOrderedBufferLayout,
+    vertexBufferLayout: [
+      {
+        arrayStride: 8,
+        stepMode: 'instance',
+        attributes: [
+          {
+            format: 'float32x2',
+            offset: 0,
+            shaderLocation: 0
+          }
+        ]
+      },
+      {
+        arrayStride: 8,
+        stepMode: 'instance',
+        attributes: [
+          {
+            format: 'float32x2',
+            offset: 0,
+            shaderLocation: 1
+          }
+        ]
+      },
+      {
+        arrayStride: 8,
+        stepMode: 'vertex',
         attributes: [
           {
             format: 'float32x2',
@@ -101,8 +166,7 @@ const TEST_CASES: {
   }
 ];
 
-// TODO restore asap
-test.skip('WebGPU#getVertexBufferLayout', t => {
+test('WebGPU#getVertexBufferLayout', t => {
   for (const tc of TEST_CASES) {
     const vertexBufferLayout = getVertexBufferLayout(tc.shaderLayout, tc.bufferLayout);
     t.deepEqual(vertexBufferLayout, tc.vertexBufferLayout);

--- a/modules/webgpu/test/adapter/helpers/get-vertex-buffer-layout.spec.ts
+++ b/modules/webgpu/test/adapter/helpers/get-vertex-buffer-layout.spec.ts
@@ -51,7 +51,7 @@ const TEST_CASES: {
   bufferLayout: BufferLayout[];
   vertexBufferLayout: GPUVertexBufferLayout[];
 }[] = [
-  // TODO: Renable test without bufferLayout when not using hardcoded types
+  // TODO: Re-enable test without bufferLayout when not using hardcoded types
   // {
   //   shaderLayout,
   //   bufferLayout: [],


### PR DESCRIPTION
For [deck.gl tracker](https://github.com/visgl/deck.gl/issues/9504), and to fix issue raised in https://github.com/visgl/deck.gl/pull/9531

#### Background
When I originally ported the pointcloud layer, the attribute struct had been set up like the following:
```wgsl
struct Attributes {
  @builtin(instance_index) instanceIndex : u32,
  @builtin(vertex_index) vertexIndex : u32,
  @location(0) positions: vec3<f32>,
  @location(1) instanceNormals: vec3<f32>,
  @location(2) instanceColors: vec4<f32>,
  @location(3) instancePositions: vec3<f32>,
  @location(4) instancePositions64Low: vec3<f32>,
  @location(5) instancePickingColors: vec3<f32>
};
```
which results, perhaps confusingly, in the following error, as `instanceColors` are provided as a `unorm8x4` and should have stride 4, not 24.
<img width="870" alt="image" src="https://github.com/user-attachments/assets/ed20f8e1-b3cd-4e62-be1b-0d61b0a01f50" />

If, instead, that struct is ordered in the following way (note: `instancePositions` have been moved down), it works as expected:
```wgsl
struct Attributes {
  @builtin(instance_index) instanceIndex : u32,
  @builtin(vertex_index) vertexIndex : u32,
  @location(0) positions: vec3<f32>,
  @location(1) instancePositions: vec3<f32>,
  @location(2) instancePositions64Low: vec3<f32>,
  @location(3) instanceNormals: vec3<f32>,
  @location(4) instanceColors: vec4<f32>,
  @location(5) instancePickingColors: vec3<f32>
};
```

After some digging, it turns out that error is being thrown because the `VertexBufferLayout` we pass to the `WebGPURenderPipeline` contained a **different order** of attributes than those being bound to the shader by `setVertexBuffer`. In some cases that generates this error. In other cases, where the buffer sizes all match it subtly binds the buffers with data meant for other buffers. In my case, I got 'lucky' that I re-ordered the buffers into the same order as they were specified by deck's AttributeManager.

Instead, ensure that we produce a `VertexBufferLayout` that matches the order of the attributes from the WGSL source code by sorting the `bufferLayout`. This means that both WGSL samples work as expected.

