### PR TITLE
fix: Vertex buffer locations set in the same order as pipeline, derived from shader source

### DIFF
--- a/modules/core/src/adapter-utils/buffer-layout-helper.ts
+++ b/modules/core/src/adapter-utils/buffer-layout-helper.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {BufferLayout} from '../adapter/types/buffer-layout';
+import {log} from '../utils/log';
 
 /** BufferLayoutHelper is a helper class that should not be used directly by applications */
 export class BufferLayoutHelper {
@@ -37,5 +38,15 @@ export class BufferLayoutHelper {
       }
     }
     return mergedLayouts;
+  }
+
+  getBufferIndex(bufferName: string): number {
+    const bufferIndex = this.bufferLayouts.findIndex(layout => layout.name === bufferName);
+
+    if (bufferIndex === -1) {
+      log.warn(`BufferLayout: Missing buffer for "${bufferName}".`)();
+    }
+
+    return bufferIndex;
   }
 }

--- a/modules/core/src/adapter-utils/buffer-layout-order.ts
+++ b/modules/core/src/adapter-utils/buffer-layout-order.ts
@@ -1,0 +1,27 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {BufferLayout} from '../adapter/types/buffer-layout';
+import {ShaderLayout} from '../adapter/types/shader-layout';
+
+export function sortedBufferLayoutByShaderSourceLocations(
+  shaderLayout: ShaderLayout,
+  bufferLayout: BufferLayout[]
+): BufferLayout[] {
+  const shaderLayoutMap = Object.fromEntries(
+    shaderLayout.attributes.map(attr => [attr.name, attr.location])
+  );
+
+  const sortedLayout = bufferLayout.slice();
+  sortedLayout.sort((a, b) => {
+    const attributeNamesA = a.attributes ? a.attributes.map(attr => attr.attribute) : [a.name];
+    const attributeNamesB = b.attributes ? b.attributes.map(attr => attr.attribute) : [b.name];
+    const minLocationA = Math.min(...attributeNamesA.map(name => shaderLayoutMap[name]));
+    const minLocationB = Math.min(...attributeNamesB.map(name => shaderLayoutMap[name]));
+
+    return minLocationA - minLocationB;
+  });
+
+  return sortedLayout;
+}

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -196,6 +196,7 @@ export {getScratchArray} from './utils/array-utils-flat';
 export type {AttributeInfo} from './adapter-utils/get-attribute-from-layouts';
 export {BufferLayoutHelper as _BufferLayoutHelper} from './adapter-utils/buffer-layout-helper';
 export {getAttributeInfosFromLayouts} from './adapter-utils/get-attribute-from-layouts';
+export {sortedBufferLayoutByShaderSourceLocations} from './adapter-utils/buffer-layout-order';
 
 // TEST EXPORTS
 export {

--- a/modules/core/test/adapter-utils/buffer-layout-order.spec.ts
+++ b/modules/core/test/adapter-utils/buffer-layout-order.spec.ts
@@ -1,0 +1,143 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {ShaderLayout, sortedBufferLayoutByShaderSourceLocations, BufferLayout} from '@luma.gl/core';
+
+const shaderLayout: ShaderLayout = {
+  bindings: [],
+  attributes: [
+    {
+      name: 'vertexPositions',
+      location: 0,
+      type: 'vec3<f32>',
+      stepMode: 'vertex'
+    },
+    {
+      name: 'vertexPositions64Low',
+      location: 1,
+      type: 'vec3<f32>',
+      stepMode: 'vertex'
+    },
+    {
+      name: 'vertexVelocity',
+      location: 2,
+      type: 'vec3<f32>',
+      stepMode: 'vertex'
+    },
+    {
+      name: 'instancePositions',
+      location: 3,
+      type: 'vec3<f32>',
+      stepMode: 'instance'
+    },
+    {
+      name: 'instancePositions64Low',
+      location: 4,
+      type: 'vec3<f32>',
+      stepMode: 'instance'
+    },
+    {
+      name: 'instanceColors',
+      location: 5,
+      type: 'vec4<f32>',
+      stepMode: 'instance'
+    }
+  ]
+};
+
+const bufferLayout: BufferLayout[] = [
+  {
+    name: 'vertexPositions',
+    byteStride: 24,
+    attributes: [
+      {
+        attribute: 'vertexPositions',
+        format: 'float32x3',
+        byteOffset: 0
+      },
+      {
+        attribute: 'vertexPositions64Low',
+        format: 'float32x3',
+        byteOffset: 12
+      }
+    ]
+  },
+  {
+    name: 'instancePositions',
+    byteStride: 24,
+    attributes: [
+      {
+        attribute: 'instancePositions',
+        format: 'float32x3',
+        byteOffset: 0
+      },
+      {
+        attribute: 'instancePositions64Low',
+        format: 'float32x3',
+        byteOffset: 12
+      }
+    ]
+  },
+  {
+    name: 'instanceColors',
+    format: 'float32x4'
+  },
+  {
+    name: 'vertexVelocity',
+    format: 'float32x3'
+  }
+];
+
+const sortedBufferLayout = [
+  {
+    name: 'vertexPositions',
+    byteStride: 24,
+    attributes: [
+      {
+        attribute: 'vertexPositions',
+        format: 'float32x3',
+        byteOffset: 0
+      },
+      {
+        attribute: 'vertexPositions64Low',
+        format: 'float32x3',
+        byteOffset: 12
+      }
+    ]
+  },
+  {
+    name: 'vertexVelocity',
+    format: 'float32x3'
+  },
+  {
+    name: 'instancePositions',
+    byteStride: 24,
+    attributes: [
+      {
+        attribute: 'instancePositions',
+        format: 'float32x3',
+        byteOffset: 0
+      },
+      {
+        attribute: 'instancePositions64Low',
+        format: 'float32x3',
+        byteOffset: 12
+      }
+    ]
+  },
+  {
+    name: 'instanceColors',
+    format: 'float32x4'
+  }
+];
+
+test('sortedBufferLayoutByShaderSourceLocations', t => {
+  const result = sortedBufferLayoutByShaderSourceLocations(shaderLayout, bufferLayout);
+  for (let i = 0; i < sortedBufferLayout.length; i++) {
+    t.deepEqual(result[i], sortedBufferLayout[i], `Buffer layout order is correct`);
+    // t.comment(JSON.stringify(result[i], null, 2));
+  }
+  t.end();
+});

--- a/modules/core/test/index.ts
+++ b/modules/core/test/index.ts
@@ -9,6 +9,7 @@ import './shadertypes/vertex-format-from-attribute.spec';
 import './shadertypes/decode-texture-format.spec';
 
 // adapter utils
+import './adapter-utils/buffer-layout-order.spec';
 import './adapter-utils/get-attribute-from-layout.spec';
 import './adapter-utils/is-uniform-value.spec';
 import './adapter-utils/format-compiler-log.spec';

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -28,7 +28,8 @@ import {
   log,
   getTypedArrayFromDataType,
   getAttributeInfosFromLayouts,
-  _BufferLayoutHelper
+  _BufferLayoutHelper,
+  sortedBufferLayoutByShaderSourceLocations
 } from '@luma.gl/core';
 
 import type {ShaderModule, PlatformInfo} from '@luma.gl/shadertools';
@@ -604,6 +605,12 @@ export class Model {
       )();
     }
 
+    // ensure bufferLayout order matches source layout so we bind
+    // the correct buffers to the correct indices in webgpu.
+    this.bufferLayout = sortedBufferLayoutByShaderSourceLocations(
+      this.pipeline.shaderLayout,
+      this.bufferLayout
+    );
     const bufferLayoutHelper = new _BufferLayoutHelper(this.bufferLayout);
 
     // Check if all buffers have a layout
@@ -616,13 +623,19 @@ export class Model {
         continue; // eslint-disable-line no-continue
       }
 
-      // For an interleaved attribute we may need to set multiple attributes
+      // In WebGL, for an interleaved attribute we may need to set multiple attributes
+      // but in WebGPU, we set it according to the buffer's position in the vertexArray
       const attributeNames = bufferLayoutHelper.getAttributeNamesForBuffer(bufferLayout);
       let set = false;
       for (const attributeName of attributeNames) {
         const attributeInfo = this._attributeInfos[attributeName];
         if (attributeInfo) {
-          this.vertexArray.setBuffer(attributeInfo.location, buffer);
+          const location =
+            this.device.type === 'webgpu'
+              ? bufferLayoutHelper.getBufferIndex(attributeInfo.bufferName)
+              : attributeInfo.location;
+
+          this.vertexArray.setBuffer(location, buffer);
           set = true;
         }
       }


### PR DESCRIPTION
#### Background

Similar to https://github.com/visgl/luma.gl/pull/2363, keep the shader as the single source of truth for vertex attribute binding order. The previous PR ensured the pipeline is created with the same order, but I then discovered the buffers could be bound at the wrong indices if an interleaved attribute existed (ie a buffer that is shared by two or more attributes).

In WebGPU, the binding location of a vertex buffer needs to match the buffer in the pipeline, not the `@location` reference in the shader. This meant that before some buffers were being bound in the wrong order leading to the wrong values being read in the shader.

With this and the previous PR, all attributes should be bound in a deterministic order which is derived from the shader source order which should make for a less fragile API and much better developer experience.

As can be seen in the demo webgpu project in deck, colours are now correct where previously normals were being read as colours
Scatter: 
<img width="835" alt="image" src="https://github.com/user-attachments/assets/1035cd2a-e140-485d-bae2-5e3bac660ea4" />
Pointcloud (the lack of lighting makes the colours look off, assigning colours directly looks like the scatter layer again):
<img width="971" alt="image" src="https://github.com/user-attachments/assets/9635030c-dbff-40ab-9cce-db49da377ec7" />


#### Change List
-
