### PR TITLE
chore: Bump node version in workflows to 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check_branch:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.08
     outputs:
       should_build: ${{ steps.permitted.outputs.result }}
 
@@ -30,7 +30,7 @@ jobs:
           echo "result=${result}" >> "$GITHUB_OUTPUT"
 
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.08
     needs: check_branch
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check_branch:
-    runs-on: ubuntu-22.08
+    runs-on: ubuntu-22.04
     outputs:
       should_build: ${{ steps.permitted.outputs.result }}
 
@@ -30,7 +30,7 @@ jobs:
           echo "result=${result}" >> "$GITHUB_OUTPUT"
 
   release:
-    runs-on: ubuntu-22.08
+    runs-on: ubuntu-22.04
     needs: check_branch
     permissions:
       contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.08
     timeout-minutes: 15
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.08
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     strategy:
       matrix:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check_branch:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.08
     outputs:
       should_deploy: ${{ endsWith(github.ref, steps.get_version.outputs.latest) }}
 
@@ -23,7 +23,7 @@ jobs:
           echo "latest=${LATEST}-release" >> "$GITHUB_OUTPUT"
 
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.08
     needs: check_branch
     
     permissions:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check_branch:
-    runs-on: ubuntu-22.08
+    runs-on: ubuntu-22.04
     outputs:
       should_deploy: ${{ endsWith(github.ref, steps.get_version.outputs.latest) }}
 
@@ -23,7 +23,7 @@ jobs:
           echo "latest=${LATEST}-release" >> "$GITHUB_OUTPUT"
 
   deploy:
-    runs-on: ubuntu-22.08
+    runs-on: ubuntu-22.04
     needs: check_branch
     
     permissions:


### PR DESCRIPTION
CI is [failing](https://github.com/visgl/luma.gl/actions/runs/14474031623/job/40595097807) with node v20

<img width="955" alt="Screenshot 2025-04-15 at 18 06 18" src="https://github.com/user-attachments/assets/64dbbb11-00d0-48eb-a95a-ff0a7ec0f446" />
