### PR TITLE
gltf: fix samplers parsing for textures

### DIFF
--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -40,6 +40,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
+    "@luma.gl/constants": "9.2.0-alpha.1",
     "@luma.gl/core": "9.2.0-alpha.1",
     "@luma.gl/engine": "9.2.0-alpha.1",
     "@luma.gl/shadertools": "9.2.0-alpha.1"

--- a/modules/gltf/src/pbr/convert-webgl.ts
+++ b/modules/gltf/src/pbr/convert-webgl.ts
@@ -1,0 +1,71 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {SamplerProps} from '@luma.gl/core';
+import {GL} from '@luma.gl/constants';
+
+export function convertSampler(gltfSampler: any): SamplerProps {
+  return {
+    addressModeU: convertSamplerWrapMode(gltfSampler.wrapS),
+    addressModeV: convertSamplerWrapMode(gltfSampler.wrapT),
+    magFilter: convertSamplerMagFilter(gltfSampler.magFilter),
+    ...convertSamplerMinFilter(gltfSampler.minFilter)
+  };
+}
+
+function convertSamplerWrapMode(
+  mode: GL.CLAMP_TO_EDGE | GL.REPEAT | GL.MIRRORED_REPEAT | undefined
+): 'clamp-to-edge' | 'repeat' | 'mirror-repeat' | undefined {
+  switch (mode) {
+    case GL.CLAMP_TO_EDGE:
+      return 'clamp-to-edge';
+    case GL.REPEAT:
+      return 'repeat';
+    case GL.MIRRORED_REPEAT:
+      return 'mirror-repeat';
+    default:
+      return undefined;
+  }
+}
+
+function convertSamplerMagFilter(
+  mode: GL.NEAREST | GL.LINEAR | undefined
+): 'nearest' | 'linear' | undefined {
+  switch (mode) {
+    case GL.NEAREST:
+      return 'nearest';
+    case GL.LINEAR:
+      return 'linear';
+    default:
+      return undefined;
+  }
+}
+
+function convertSamplerMinFilter(
+  mode:
+    | GL.NEAREST
+    | GL.LINEAR
+    | GL.NEAREST_MIPMAP_NEAREST
+    | GL.LINEAR_MIPMAP_NEAREST
+    | GL.NEAREST_MIPMAP_LINEAR
+    | GL.LINEAR_MIPMAP_LINEAR
+    | undefined
+): {minFilter?: 'nearest' | 'linear'; mipmapFilter?: 'nearest' | 'linear'} {
+  switch (mode) {
+    case GL.NEAREST:
+      return {minFilter: 'nearest'};
+    case GL.LINEAR:
+      return {minFilter: 'linear'};
+    case GL.NEAREST_MIPMAP_NEAREST:
+      return {minFilter: 'nearest', mipmapFilter: 'nearest'};
+    case GL.LINEAR_MIPMAP_NEAREST:
+      return {minFilter: 'linear', mipmapFilter: 'nearest'};
+    case GL.NEAREST_MIPMAP_LINEAR:
+      return {minFilter: 'nearest', mipmapFilter: 'linear'};
+    case GL.LINEAR_MIPMAP_LINEAR:
+      return {minFilter: 'linear', mipmapFilter: 'linear'};
+    default:
+      return {};
+  }
+}

--- a/modules/gltf/src/pbr/parse-pbr-material.ts
+++ b/modules/gltf/src/pbr/parse-pbr-material.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Device, Texture, Parameters, SamplerProps} from '@luma.gl/core';
+import type {Device, Texture, Parameters} from '@luma.gl/core';
 import {log} from '@luma.gl/core';
 import {PBREnvironment} from './pbr-environment';
 import {PBRMaterialBindings, PBRMaterialUniforms, PBRProjectionProps} from '@luma.gl/shadertools';
 import {GL} from '@luma.gl/constants';
+import {convertSampler} from './convert-webgl';
 
 // TODO - synchronize the GLTF... types with loaders.gl
 // TODO - remove the glParameters, use only parameters
@@ -268,71 +269,6 @@ function addTexture(
   parsedMaterial.bindings[uniformName] = texture;
   if (define) parsedMaterial.defines[define] = true;
   parsedMaterial.generatedTextures.push(texture);
-}
-
-export function convertSampler(gltfSampler: any): SamplerProps {
-  return {
-    addressModeU: convertSamplerWrapMode(gltfSampler.wrapS),
-    addressModeV: convertSamplerWrapMode(gltfSampler.wrapT),
-    magFilter: convertSamplerMagFilter(gltfSampler.magFilter),
-    ...convertSamplerMinFilter(gltfSampler.minFilter)
-  };
-}
-
-function convertSamplerWrapMode(
-  mode: GL.CLAMP_TO_EDGE | GL.REPEAT | GL.MIRRORED_REPEAT | undefined
-): 'clamp-to-edge' | 'repeat' | 'mirror-repeat' | undefined {
-  switch (mode) {
-    case GL.CLAMP_TO_EDGE:
-      return 'clamp-to-edge';
-    case GL.REPEAT:
-      return 'repeat';
-    case GL.MIRRORED_REPEAT:
-      return 'mirror-repeat';
-    default:
-      return undefined;
-  }
-}
-
-function convertSamplerMagFilter(
-  mode: GL.NEAREST | GL.LINEAR | undefined
-): 'nearest' | 'linear' | undefined {
-  switch (mode) {
-    case GL.NEAREST:
-      return 'nearest';
-    case GL.LINEAR:
-      return 'linear';
-    default:
-      return undefined;
-  }
-}
-
-function convertSamplerMinFilter(
-  mode:
-    | GL.NEAREST
-    | GL.LINEAR
-    | GL.NEAREST_MIPMAP_NEAREST
-    | GL.LINEAR_MIPMAP_NEAREST
-    | GL.NEAREST_MIPMAP_LINEAR
-    | GL.LINEAR_MIPMAP_LINEAR
-    | undefined
-): {minFilter?: 'nearest' | 'linear'; mipmapFilter?: 'nearest' | 'linear'} {
-  switch (mode) {
-    case GL.NEAREST:
-      return {minFilter: 'nearest'};
-    case GL.LINEAR:
-      return {minFilter: 'linear'};
-    case GL.NEAREST_MIPMAP_NEAREST:
-      return {minFilter: 'nearest', mipmapFilter: 'nearest'};
-    case GL.NEAREST_MIPMAP_LINEAR:
-      return {minFilter: 'linear', mipmapFilter: 'nearest'};
-    case GL.LINEAR_MIPMAP_NEAREST:
-      return {minFilter: 'nearest', mipmapFilter: 'linear'};
-    case GL.LINEAR_MIPMAP_LINEAR:
-      return {minFilter: 'linear', mipmapFilter: 'linear'};
-    default:
-      return {};
-  }
 }
 
 /*

--- a/modules/gltf/test/index.ts
+++ b/modules/gltf/test/index.ts
@@ -3,4 +3,4 @@
 // Copyright (c) vis.gl contributors
 
 import './gltf/gltf.spec';
-import './pbr/pbr.spec';
+import './pbr/convert-webgl.spec';

--- a/modules/gltf/test/index.ts
+++ b/modules/gltf/test/index.ts
@@ -3,3 +3,4 @@
 // Copyright (c) vis.gl contributors
 
 import './gltf/gltf.spec';
+import './pbr/pbr.spec';

--- a/modules/gltf/test/pbr/convert-webgl.spec.ts
+++ b/modules/gltf/test/pbr/convert-webgl.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {GL} from '@luma.gl/constants/webgl-constants';
-import {convertSampler} from '@luma.gl/gltf/pbr/parse-pbr-material';
+import {convertSampler} from '@luma.gl/gltf/pbr/convert-webgl';
 import {convertSamplerParametersToWebGL} from '@luma.gl/webgl/adapter/converters/sampler-parameters';
 import test from 'tape-promise/tape';
 

--- a/modules/gltf/test/pbr/pbr.spec.ts
+++ b/modules/gltf/test/pbr/pbr.spec.ts
@@ -1,0 +1,55 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {GL} from '@luma.gl/constants/webgl-constants';
+import {convertSampler} from '@luma.gl/gltf/pbr/parse-pbr-material';
+import {convertSamplerParametersToWebGL} from '@luma.gl/webgl/adapter/converters/sampler-parameters';
+import test from 'tape-promise/tape';
+
+test('pbr#convertSampler#minFilter', async t => {
+  [
+    GL.NEAREST,
+    GL.LINEAR,
+    GL.NEAREST_MIPMAP_NEAREST,
+    GL.LINEAR_MIPMAP_NEAREST,
+    GL.NEAREST_MIPMAP_LINEAR,
+    GL.LINEAR_MIPMAP_LINEAR
+  ].forEach(minFilter => {
+    const props = convertSampler({minFilter});
+    const gl = convertSamplerParametersToWebGL(props);
+    const glValues = Object.values(gl);
+
+    t.equals(glValues.length, 1, 'Should return 1 value');
+    t.equals(glValues[0], minFilter, 'Value matches minFilter');
+  });
+
+  t.end();
+});
+
+test('pbr#convertSampler#magFilter', async t => {
+  [GL.NEAREST, GL.LINEAR].forEach(magFilter => {
+    const props = convertSampler({magFilter});
+    const gl = convertSamplerParametersToWebGL(props);
+    const glValues = Object.values(gl);
+
+    t.equals(glValues.length, 1, 'Should return 1 value');
+    t.equals(glValues[0], magFilter, 'Value matches magFilter');
+  });
+
+  t.end();
+});
+
+test('pbr#convertSampler#wrap', async t => {
+  [GL.CLAMP_TO_EDGE, GL.REPEAT, GL.MIRRORED_REPEAT].forEach(wrap => {
+    const props = convertSampler({wrapS: wrap, wrapT: wrap});
+    const gl = convertSamplerParametersToWebGL(props);
+    const glValues = Object.values(gl);
+
+    t.equals(glValues.length, 2, 'Should return 2 values');
+    t.equals(glValues[0], wrap, 'Value matches wrapT');
+    t.equals(glValues[1], wrap, 'Value matches wrapS');
+  });
+
+  t.end();
+});

--- a/modules/webgl/src/adapter/converters/sampler-parameters.ts
+++ b/modules/webgl/src/adapter/converters/sampler-parameters.ts
@@ -99,8 +99,19 @@ function convertMinFilterMode(
     case 'none':
       return convertMaxFilterMode(minFilter);
     case 'nearest':
-      return minFilter === 'nearest' ? GL.NEAREST_MIPMAP_NEAREST : GL.NEAREST_MIPMAP_LINEAR;
+      switch (minFilter) {
+        case 'nearest':
+          return GL.NEAREST_MIPMAP_NEAREST;
+        case 'linear':
+          return GL.LINEAR_MIPMAP_NEAREST;
+      }
+      break;
     case 'linear':
-      return minFilter === 'nearest' ? GL.LINEAR_MIPMAP_NEAREST : GL.LINEAR_MIPMAP_LINEAR;
+      switch (minFilter) {
+        case 'nearest':
+          return GL.NEAREST_MIPMAP_LINEAR;
+        case 'linear':
+          return GL.LINEAR_MIPMAP_LINEAR;
+      }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1405,6 +1405,7 @@ __metadata:
     "@loaders.gl/textures": "npm:^4.2.0"
     "@math.gl/core": "npm:^4.1.0"
   peerDependencies:
+    "@luma.gl/constants": 9.2.0-alpha.1
     "@luma.gl/core": 9.2.0-alpha.1
     "@luma.gl/engine": 9.2.0-alpha.1
     "@luma.gl/shadertools": 9.2.0-alpha.1


### PR DESCRIPTION
#### Background
When switching from WebGL to WebGL/WebGPU some logic was abstracted so we have to make the glTF generate the sampler logic using the abstracted props.

#### Change List
- Logic to create sampler props from glTF
- Unit tests
