### PR TITLE
chore(shadertools); Add uniforms for pbrMaterial extensions

### DIFF
--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-glsl.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-glsl.ts
@@ -70,6 +70,40 @@ uniform pbrMaterialUniforms {
   
   bool alphaCutoffEnabled;
   float alphaCutoff; // #ifdef ALPHA_CUTOFF
+
+  vec3 specularColorFactor;
+  float specularIntensityFactor;
+  bool specularColorMapEnabled;
+  bool specularIntensityMapEnabled;
+
+  float ior;
+
+  float transmissionFactor;
+  bool transmissionMapEnabled;
+
+  float thicknessFactor;
+  float attenuationDistance;
+  vec3 attenuationColor;
+
+  float clearcoatFactor;
+  float clearcoatRoughnessFactor;
+  bool clearcoatMapEnabled;
+
+  vec3 sheenColorFactor;
+  float sheenRoughnessFactor;
+  bool sheenColorMapEnabled;
+
+  float iridescenceFactor;
+  float iridescenceIor;
+  vec2 iridescenceThicknessRange;
+  bool iridescenceMapEnabled;
+
+  float anisotropyStrength;
+  float anisotropyRotation;
+  vec2 anisotropyDirection;
+  bool anisotropyMapEnabled;
+
+  float emissiveStrength;
   
   // IBL
   bool IBLenabled;
@@ -97,6 +131,29 @@ uniform sampler2D pbr_metallicRoughnessSampler;
 #endif
 #ifdef HAS_OCCLUSIONMAP
 uniform sampler2D pbr_occlusionSampler;
+#endif
+#ifdef HAS_SPECULARCOLORMAP
+uniform sampler2D pbr_specularColorSampler;
+#endif
+#ifdef HAS_SPECULARINTENSITYMAP
+uniform sampler2D pbr_specularIntensitySampler;
+#endif
+#ifdef HAS_TRANSMISSIONMAP
+uniform sampler2D pbr_transmissionSampler;
+#endif
+#ifdef HAS_CLEARCOATMAP
+uniform sampler2D pbr_clearcoatSampler;
+uniform sampler2D pbr_clearcoatRoughnessSampler;
+#endif
+#ifdef HAS_SHEENCOLORMAP
+uniform sampler2D pbr_sheenColorSampler;
+uniform sampler2D pbr_sheenRoughnessSampler;
+#endif
+#ifdef HAS_IRIDESCENCEMAP
+uniform sampler2D pbr_iridescenceSampler;
+#endif
+#ifdef HAS_ANISOTROPYMAP
+uniform sampler2D pbr_anisotropySampler;
 #endif
 #ifdef USE_IBL
 uniform samplerCube pbr_diffuseEnvSampler;

--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-wgsl.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-wgsl.ts
@@ -37,6 +37,40 @@ uniform pbrMaterialUniforms {
   
   bool alphaCutoffEnabled;
   float alphaCutoff; // #ifdef ALPHA_CUTOFF
+
+  vec3 specularColorFactor;
+  float specularIntensityFactor;
+  bool specularColorMapEnabled;
+  bool specularIntensityMapEnabled;
+
+  float ior;
+
+  float transmissionFactor;
+  bool transmissionMapEnabled;
+
+  float thicknessFactor;
+  float attenuationDistance;
+  vec3 attenuationColor;
+
+  float clearcoatFactor;
+  float clearcoatRoughnessFactor;
+  bool clearcoatMapEnabled;
+
+  vec3 sheenColorFactor;
+  float sheenRoughnessFactor;
+  bool sheenColorMapEnabled;
+
+  float iridescenceFactor;
+  float iridescenceIor;
+  vec2 iridescenceThicknessRange;
+  bool iridescenceMapEnabled;
+
+  float anisotropyStrength;
+  float anisotropyRotation;
+  vec2 anisotropyDirection;
+  bool anisotropyMapEnabled;
+
+  float emissiveStrength;
   
   // IBL
   bool IBLenabled;
@@ -64,6 +98,29 @@ uniform sampler2D u_MetallicRoughnessSampler;
 #endif
 #ifdef HAS_OCCLUSIONMAP
 uniform sampler2D u_OcclusionSampler;
+#endif
+#ifdef HAS_SPECULARCOLORMAP
+uniform sampler2D u_SpecularColorSampler;
+#endif
+#ifdef HAS_SPECULARINTENSITYMAP
+uniform sampler2D u_SpecularIntensitySampler;
+#endif
+#ifdef HAS_TRANSMISSIONMAP
+uniform sampler2D u_TransmissionSampler;
+#endif
+#ifdef HAS_CLEARCOATMAP
+uniform sampler2D u_ClearcoatSampler;
+uniform sampler2D u_ClearcoatRoughnessSampler;
+#endif
+#ifdef HAS_SHEENCOLORMAP
+uniform sampler2D u_SheenColorSampler;
+uniform sampler2D u_SheenRoughnessSampler;
+#endif
+#ifdef HAS_IRIDESCENCEMAP
+uniform sampler2D u_IridescenceSampler;
+#endif
+#ifdef HAS_ANISOTROPYMAP
+uniform sampler2D u_AnisotropySampler;
 #endif
 #ifdef USE_IBL
 uniform samplerCube u_DiffuseEnvSampler;

--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-material.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-material.ts
@@ -30,6 +30,17 @@ export type PBRMaterialBindings = {
   pbr_metallicRoughnessSampler?: Texture | null; // #ifdef HAS_METALROUGHNESSMAP
   pbr_occlusionSampler?: Texture | null; // #ifdef HAS_OCCLUSIONMAP
 
+  pbr_specularColorSampler?: Texture | null; // #ifdef HAS_SPECULARCOLORMAP
+  pbr_specularIntensitySampler?: Texture | null; // #ifdef HAS_SPECULARINTENSITYMAP
+  pbr_transmissionSampler?: Texture | null; // #ifdef HAS_TRANSMISSIONMAP
+
+  pbr_clearcoatSampler?: Texture | null; // #ifdef HAS_CLEARCOATMAP
+  pbr_clearcoatRoughnessSampler?: Texture | null; // #ifdef HAS_CLEARCOATMAP
+  pbr_sheenColorSampler?: Texture | null; // #ifdef HAS_SHEENCOLORMAP
+  pbr_sheenRoughnessSampler?: Texture | null; // #ifdef HAS_SHEENCOLORMAP
+  pbr_iridescenceSampler?: Texture | null; // #ifdef HAS_IRIDESCENCEMAP
+  pbr_anisotropySampler?: Texture | null; // #ifdef HAS_ANISOTROPYMAP
+
   // IBL Samplers
   pbr_diffuseEnvSampler?: Texture | null; // #ifdef USE_IBL (samplerCube)
   pbr_specularEnvSampler?: Texture | null; // #ifdef USE_IBL (samplerCube)
@@ -66,6 +77,41 @@ export type PBRMaterialUniforms = {
   // #ifdef PBR_DEBUG
   scaleDiffBaseMR?: Readonly<Vector4 | NumberArray4>;
   scaleFGDSpec?: Readonly<Vector4 | NumberArray4>;
+
+  // glTF material extensions
+  specularColorFactor?: Readonly<Vector3 | NumberArray3>;
+  specularIntensityFactor?: number;
+  specularColorMapEnabled?: boolean;
+  specularIntensityMapEnabled?: boolean;
+
+  ior?: number;
+
+  transmissionFactor?: number;
+  transmissionMapEnabled?: boolean;
+
+  thicknessFactor?: number;
+  attenuationDistance?: number;
+  attenuationColor?: Readonly<Vector3 | NumberArray3>;
+
+  clearcoatFactor?: number;
+  clearcoatRoughnessFactor?: number;
+  clearcoatMapEnabled?: boolean;
+
+  sheenColorFactor?: Readonly<Vector3 | NumberArray3>;
+  sheenRoughnessFactor?: number;
+  sheenColorMapEnabled?: boolean;
+
+  iridescenceFactor?: number;
+  iridescenceIor?: number;
+  iridescenceThicknessRange?: Readonly<Vector2 | NumberArray2>;
+  iridescenceMapEnabled?: boolean;
+
+  anisotropyStrength?: number;
+  anisotropyRotation?: number;
+  anisotropyDirection?: Readonly<Vector2 | NumberArray2>;
+  anisotropyMapEnabled?: boolean;
+
+  emissiveStrength?: number;
 };
 
 export type PBRMaterialProps = PBRMaterialBindings & PBRMaterialUniforms;
@@ -91,6 +137,13 @@ export const pbrMaterial = {
     HAS_OCCLUSIONMAP: false,
     HAS_BASECOLORMAP: false,
     HAS_METALROUGHNESSMAP: false,
+    HAS_SPECULARCOLORMAP: false,
+    HAS_SPECULARINTENSITYMAP: false,
+    HAS_TRANSMISSIONMAP: false,
+    HAS_CLEARCOATMAP: false,
+    HAS_SHEENCOLORMAP: false,
+    HAS_IRIDESCENCEMAP: false,
+    HAS_ANISOTROPYMAP: false,
     ALPHA_CUTOFF: false,
     USE_IBL: false,
     PBR_DEBUG: false
@@ -126,6 +179,40 @@ export const pbrMaterial = {
     // debugging flags used for shader output of intermediate PBR variables
     // #ifdef PBR_DEBUG
     scaleDiffBaseMR: 'vec4<f32>',
-    scaleFGDSpec: 'vec4<f32>'
+    scaleFGDSpec: 'vec4<f32>',
+
+    specularColorFactor: 'vec3<f32>',
+    specularIntensityFactor: 'f32',
+    specularColorMapEnabled: 'i32',
+    specularIntensityMapEnabled: 'i32',
+
+    ior: 'f32',
+
+    transmissionFactor: 'f32',
+    transmissionMapEnabled: 'i32',
+
+    thicknessFactor: 'f32',
+    attenuationDistance: 'f32',
+    attenuationColor: 'vec3<f32>',
+
+    clearcoatFactor: 'f32',
+    clearcoatRoughnessFactor: 'f32',
+    clearcoatMapEnabled: 'i32',
+
+    sheenColorFactor: 'vec3<f32>',
+    sheenRoughnessFactor: 'f32',
+    sheenColorMapEnabled: 'i32',
+
+    iridescenceFactor: 'f32',
+    iridescenceIor: 'f32',
+    iridescenceThicknessRange: 'vec2<f32>',
+    iridescenceMapEnabled: 'i32',
+
+    anisotropyStrength: 'f32',
+    anisotropyRotation: 'f32',
+    anisotropyDirection: 'vec2<f32>',
+    anisotropyMapEnabled: 'i32',
+
+    emissiveStrength: 'f32'
   }
 } as const satisfies ShaderModule<PBRMaterialProps, PBRMaterialUniforms, PBRMaterialBindings>;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background

This PR adds the necessary uniforms to the pbrMaterial shader module to be able to pass parameters coming from the glTF material extensions (KHR_materials_*). This includes uniforms for specular, ior, transmission, volume, clearcoat, sheen, iridescence, anisotropy, etc. Additionally the corresponding defines (HAS_SPECULARCOLORMAP …) and extra samplers are made available in GLSL/WGSL.

#### Change List
-
