### PR TITLE
fix(effects): Reinstate vignette GLSL shader

### DIFF
--- a/modules/effects/src/passes/postprocessing/image-adjust-filters/vignette.ts
+++ b/modules/effects/src/passes/postprocessing/image-adjust-filters/vignette.ts
@@ -4,7 +4,7 @@
 
 import type {ShaderPass} from '@luma.gl/shadertools';
 
-const fs = /* wgsl */ `\
+const source = /* wgsl */ `\
 struct vignetteUniforms {
   radius: f32,
   amount: f32
@@ -24,6 +24,19 @@ fn vignette_filterColor_ext(color: vec4f, texSize: vec2f, texCoord: vec2f) ->vec
   let dist: f32 = distance(texCoord, vec2f(0.5, 0.5));
   let ratio: f32 = smoothstep(0.8, vignette.radius * 0.799, dist * (vignette.amount + vignette.radius));
   return color.rgba * ratio + (1.0 - ratio)*vec4f(0.0, 0.0, 0.0, 1.0);
+}
+`;
+
+const fs = /* glsl */ `\
+uniform vignetteUniforms {
+  float radius;
+  float amount;
+} vignette;
+
+vec4 vignette_filterColor_ext(vec4 color, vec2 texSize, vec2 texCoord) {
+  float dist = distance(texCoord, vec2(0.5, 0.5));
+  float ratio = smoothstep(0.8, vignette.radius * 0.799, dist * (vignette.amount + vignette.radius));
+  return color.rgba * ratio + (1.0 - ratio)*vec4(0.0, 0.0, 0.0, 1.0);
 }
 `;
 
@@ -48,6 +61,8 @@ export const vignette = {
   uniforms: {} as VignetteUniforms,
 
   name: 'vignette',
+  source,
+  fs,
 
   uniformTypes: {
     radius: 'f32',
@@ -62,7 +77,5 @@ export const vignette = {
     amount: {value: 0.5, min: 0, max: 1}
   },
 
-  passes: [{filter: true}],
-
-  fs
+  passes: [{filter: true}]
 } as const satisfies ShaderPass<VignetteProps, VignetteProps>;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For github.com/visgl/deck.gl/pull/9241

<!-- For other PRs without open issue -->
#### Background

https://github.com/visgl/luma.gl/commit/798b3d96722254e857d62f00d75d448ad09eff71#diff-48a2f361037445fef8accb97240f23aba968e8446f9bd066030626f211e5641f accidentally removed the GLSL vignette shader
<!-- For all the PRs -->
#### Change List
- Add back vignette shader
