### PR TITLE
fix(lighting): Default to 3 MAX_LIGHTS

### DIFF
--- a/modules/shadertools/src/modules/lighting/lights/lighting.ts
+++ b/modules/shadertools/src/modules/lighting/lights/lighting.ts
@@ -59,7 +59,7 @@ export type LightingProps = {
 
 export type LightingUniforms = {
   enabled: number;
-  ambientLightColor: Readonly<NumberArray3>;
+  ambientColor: Readonly<NumberArray3>;
   directionalLightCount: number;
   pointLightCount: number;
   lightType: number; // [];
@@ -95,7 +95,7 @@ export const lighting = {
     directionalLightCount: 'i32',
     pointLightCount: 'i32',
 
-    ambientLightColor: 'vec3<f32>',
+    ambientColor: 'vec3<f32>',
 
     // TODO define as arrays once we have appropriate uniformTypes
     lightColor0: 'vec3<f32>',
@@ -121,7 +121,7 @@ export const lighting = {
     directionalLightCount: 0,
     pointLightCount: 0,
 
-    ambientLightColor: [0.1, 0.1, 0.1],
+    ambientColor: [0.1, 0.1, 0.1],
     lightColor0: [1, 1, 1],
     lightPosition0: [1, 1, 2],
     // TODO - could combine direction and attenuation
@@ -192,7 +192,7 @@ function getLightSourceUniforms({
 }: LightingProps): Partial<LightingUniforms> {
   const lightSourceUniforms: Partial<LightingUniforms> = {};
 
-  lightSourceUniforms.ambientLightColor = convertColor(ambientLight);
+  lightSourceUniforms.ambientColor = convertColor(ambientLight);
 
   let currentLight: 0 | 1 | 2 = 0;
 

--- a/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-glsl.ts
+++ b/modules/shadertools/src/modules/lighting/phong-material/phong-shaders-glsl.ts
@@ -12,7 +12,7 @@ uniform phongMaterialUniforms {
 `;
 
 export const PHONG_FS = /* glsl */ `\
-#define MAX_LIGHTS 1
+#define MAX_LIGHTS 3
 
 uniform phongMaterialUniforms {
   uniform float ambient;


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/pull/9241
<!-- For other PRs without open issue -->
#### Background

https://github.com/visgl/luma.gl/pull/2190/files#diff-a9db84520c6b1bac02c1add1e117b9b1fbe19df69521554b26129f0cdc44ddf6 changed the default number of `MAX_LIGHTS` in the lighting module to 1. The default deck.gl `LightingEffect` uses 2 so this change makes the lighting look very different

<!-- For all the PRs -->
#### Change List
- Default back to 3 max lights
- Consistent naming of `ambientColor` between TS and GLSL
