### PR TITLE
fix(core): Support number for useDevicePixels

### DIFF
--- a/modules/core/src/adapter/canvas-context.ts
+++ b/modules/core/src/adapter/canvas-context.ts
@@ -23,8 +23,8 @@ export type CanvasContextProps = {
   height?: number;
   /** Visibility (only used if new canvas is created). */
   visible?: boolean;
-  /** Whether to size the drawing buffer to the pixel size during auto resize */
-  useDevicePixels?: boolean;
+  /** Whether to size the drawing buffer to the pixel size during auto resize. If a number is provided it is used as a static pixel ratio */
+  useDevicePixels?: boolean | number;
   /** Whether to track window resizes. */
   autoResize?: boolean;
   /** @see https://developer.mozilla.org/en-US/docs/Web/API/GPUCanvasContext/configure#alphamode */
@@ -362,7 +362,10 @@ export abstract class CanvasContext {
 
     // Update the canvas drawing buffer size
     if (this.props.autoResize) {
-      if (this.props.useDevicePixels) {
+      if (typeof this.props.useDevicePixels === 'number') {
+        const dpr = this.props.useDevicePixels;
+        this.setDrawingBufferSize(this.cssWidth * dpr, this.cssHeight * dpr);
+      } else if (this.props.useDevicePixels) {
         this.setDrawingBufferSize(this.devicePixelWidth, this.devicePixelHeight);
       } else {
         this.setDrawingBufferSize(this.cssWidth, this.cssHeight);


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For https://github.com/visgl/deck.gl/pull/9241

<!-- For other PRs without open issue -->
#### Background

deck.gl expects to be able to pass a number for `useDevicePixels`. Without this it is impossible to force HD rendering on a low def screen (or in tests). 


Repro of `'scatterplot-smoothedge'` test case in browser with DPR configured to 1:

### useDevicePixels: `2` (and fix in this PR)

<img width="508" alt="Screenshot 2025-07-08 at 16 45 11" src="https://github.com/user-attachments/assets/ccf2d183-adc4-4cb5-8989-53570ace9d58" />

### useDevicePixels: `1 | true | false`
<img width="508" alt="Screenshot 2025-07-08 at 16 44 50" src="https://github.com/user-attachments/assets/b700f67f-ac5d-46bf-8b2b-3b5b71010d7b" />

I would argue that `getDevicePixelRatio()` should be removed - it is not currently used and I think trying to add it in the code block where I made the change makes the code harder to read

<!-- For all the PRs -->
#### Change List
- Manually set DPR when `useDevicePixels` is a number
