### PR TITLE
fix(webgpu): Fix webgpu command submission error in 9.1

### DIFF
--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -211,6 +211,7 @@ export class WebGPUDevice extends Device {
         }
       });
     }
+    this.commandEncoder = null;
   }
 
   // PRIVATE METHODS


### PR DESCRIPTION
Not sure if you have a preferred way to handle this, but trying to unblock https://github.com/visgl/deck.gl/pull/9706

#### Background
- Mirror the WebGL API in luma 9.1.x otherwise the user can never create a new command buffer and we will repeatedly call `finish()` on an already finished command buffer.
- #2329 made significant changes to this part of the code in 9.2 so cherry-picking that seems riskier
- Currently prevents deck.gl examples from working
- Also raised in https://github.com/visgl/deck.gl/issues/9701

<!-- For all the PRs -->
#### Change List
- After submission, remove our reference to the current command encoder so that subsequent `beginRenderPass` or `beginComputePass` calls will work as expected.
