### PR TITLE
feat(effects): add bloom effect

### DIFF
--- a/docs/api-reference/shadertools/shader-passes/image-processing.mdx
+++ b/docs/api-reference/shadertools/shader-passes/image-processing.mdx
@@ -196,6 +196,14 @@ Blurs the image away from a certain point, which looks like radial motion blur.
   </tbody>
 </table>
 
+### bloom
+
+Adds a glow to bright areas of the image by averaging nearby high-luminance pixels and mixing them back with the original color.
+
+- `radius` Radius of the sampling kernel in pixels. Default value is `4`.
+- `threshold` Luminance threshold above which a pixel contributes to bloom. Default value is `0.8`.
+- `intensity` Strength of the bloom contribution. Default value is `1`.
+
 ### colorHalftone
 
 Simulates a CMYK halftone rendering of the image by multiplying pixel values with a four rotated 2D sine wave patterns, one each for cyan, magenta, yellow, and black.

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -51,6 +51,11 @@ export type {
   ZoomBlurUniforms
 } from './passes/postprocessing/image-blur-filters/zoomblur';
 export {zoomBlur} from './passes/postprocessing/image-blur-filters/zoomblur';
+export type {
+  BloomProps,
+  BloomUniforms
+} from './passes/postprocessing/image-blur-filters/bloom';
+export {bloom} from './passes/postprocessing/image-blur-filters/bloom';
 
 // glfx FUN shader modules
 export type {

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/bloom.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/bloom.ts
@@ -1,0 +1,109 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ShaderPass} from '@luma.gl/shadertools';
+
+const source = /* wgsl */ `
+uniform bloomUniforms {
+  radius: f32,
+  threshold: f32,
+  intensity: f32,
+};
+
+@group(0) @binding(1) var<uniform> bloom: bloomUniforms;
+
+fn bloom_sampleColor(sampler2D source, vec2 texSize, vec2 texCoord) -> vec4f {
+  let base: vec4f = texture(source, texCoord);
+  let texel: vec2f = vec2f(bloom.radius) / texSize;
+  var sum: vec4f = vec4f(0.0);
+  var total: f32 = 0.0;
+
+  for (var x: f32 = -1.0; x <= 1.0; x = x + 1.0) {
+    for (var y: f32 = -1.0; y <= 1.0; y = y + 1.0) {
+      let offset: vec2f = vec2f(x, y) * texel;
+      let sampleColor: vec4f = texture(source, texCoord + offset);
+      let brightness: f32 = max(max(sampleColor.r, sampleColor.g), sampleColor.b);
+      if (brightness > bloom.threshold) {
+        sum = sum + sampleColor;
+        total = total + 1.0;
+      }
+    }
+  }
+
+  if (total > 0.0) {
+    sum = sum / total;
+  }
+
+  return base + sum * bloom.intensity;
+}
+`;
+
+const fs = /* glsl */ `
+uniform bloomUniforms {
+  float radius;
+  float threshold;
+  float intensity;
+} bloom;
+
+vec4 bloom_sampleColor(sampler2D source, vec2 texSize, vec2 texCoord) {
+  vec4 base = texture(source, texCoord);
+  vec2 texel = vec2(bloom.radius) / texSize;
+  vec4 sum = vec4(0.0);
+  float total = 0.0;
+
+  for (float x = -1.0; x <= 1.0; x++) {
+    for (float y = -1.0; y <= 1.0; y++) {
+      vec2 offset = vec2(x, y) * texel;
+      vec4 sampleColor = texture(source, texCoord + offset);
+      float brightness = max(max(sampleColor.r, sampleColor.g), sampleColor.b);
+      if (brightness > bloom.threshold) {
+        sum += sampleColor;
+        total += 1.0;
+      }
+    }
+  }
+
+  if (total > 0.0) {
+    sum /= total;
+  }
+
+  return base + sum * bloom.intensity;
+}
+`;
+
+/**
+ * Bloom - Adds a simple glow to bright areas of the image.
+ */
+export type BloomProps = {
+  /** Radius of the sampling kernel in pixels. */
+  radius?: number;
+  /** Luminance threshold above which a pixel contributes to bloom. */
+  threshold?: number;
+  /** Strength of the bloom contribution. */
+  intensity?: number;
+};
+
+export type BloomUniforms = BloomProps;
+
+export const bloom = {
+  name: 'bloom',
+  source,
+  fs,
+
+  props: {} as BloomProps,
+  uniforms: {} as BloomUniforms,
+  uniformTypes: {
+    radius: 'f32',
+    threshold: 'f32',
+    intensity: 'f32'
+  },
+  propTypes: {
+    radius: {value: 4, min: 0, softMax: 20},
+    threshold: {value: 0.8, min: 0, max: 1},
+    intensity: {value: 1, min: 0, softMax: 3}
+  },
+
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<BloomProps, BloomProps>;
+

--- a/modules/effects/test/index.ts
+++ b/modules/effects/test/index.ts
@@ -7,6 +7,7 @@
 import './passes/image-blur-filters/tiltshift.spec';
 import './passes/image-blur-filters/triangleblur.spec';
 import './passes/image-blur-filters/zoomblur.spec';
+import './passes/image-blur-filters/bloom.spec';
 
 import './passes/image-adjust-filters/brightnesscontrast.spec';
 import './passes/image-adjust-filters/denoise.spec';

--- a/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
+++ b/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
@@ -1,0 +1,17 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {bloom} from '@luma.gl/effects';
+import {getShaderModuleUniforms} from '@luma.gl/shadertools';
+import test from 'tape-promise/tape';
+
+test('bloom#build/uniform', t => {
+  const uniforms = getShaderModuleUniforms(bloom, {}, {});
+  t.ok(uniforms, 'bloom module build is ok');
+  t.equal(uniforms.radius, 4, 'bloom radius uniform is ok');
+  t.equal(uniforms.threshold, 0.8, 'bloom threshold uniform is ok');
+  t.equal(uniforms.intensity, 1, 'bloom intensity uniform is ok');
+  t.end();
+});
+


### PR DESCRIPTION
## Summary
- add bloom post-processing shader pass with configurable radius, threshold, and intensity
- export bloom effect and document usage
- add basic unit test for bloom default uniforms

## Testing
- `yarn test modules/effects/test` *(fails: Unknown test mode modules/effects/test)*
- `yarn lint modules/effects/src/passes/postprocessing/image-blur-filters/bloom.ts modules/effects/test/passes/image-blur-filters/bloom.spec.ts` *(fails: Unable to resolve path to module '@luma.gl/shadertools' and many others)*

------
https://chatgpt.com/codex/tasks/task_e_688e6bde939083289bad675b0b095a9e