### PR TITLE
feat(webgpu): Read pixels

### DIFF
--- a/dev-modules/babel-plugin-inline-webgl-constants/package.json
+++ b/dev-modules/babel-plugin-inline-webgl-constants/package.json
@@ -24,6 +24,6 @@
     "require": "./dist/index.cjs"
   },
   "dependencies": {
-    "@luma.gl/constants": "9.2.0-alpha.1"
+    "@luma.gl/constants": "9.2.0-alpha.6"
   }
 }

--- a/modules/core/src/adapter/resources/command-buffer.ts
+++ b/modules/core/src/adapter/resources/command-buffer.ts
@@ -11,7 +11,7 @@ import {Resource, ResourceProps} from './resource';
 //   // onSubmittedWorkDone(): Promise<undefined>;
 
 //   writeBuffer(options: WriteBufferOptions): void;
-//   writeTexture(options: WriteTextureOptions): void;
+//   writeTexture(options: TextureWriteOptions): void;
 
 //   // copyExternalImageToTexture(
 //   //   GPUImageCopyExternalImage source,

--- a/modules/core/src/adapter/resources/command-encoder.ts
+++ b/modules/core/src/adapter/resources/command-encoder.ts
@@ -113,7 +113,7 @@ export type ClearTextureOptions = {
 //   size?: number;
 // };
 
-// export type WriteTextureOptions = {
+// export type TextureWriteOptions = {
 //   destination: Texture;
 //   mipLevel?: number; //  = 0;
 //   origin?: [number, number, number] | number[];
@@ -166,7 +166,7 @@ export abstract class CommandEncoder extends Resource<CommandEncoderProps> {
   /** Add a command that clears a texture mip level. */
   // abstract clearTexture(options: ClearTextureOptions): void;
 
-  // abstract readTexture(options: ReadTextureOptions): Promise<TypedArray>;
+  // abstract readTexture(options: TextureReadOptions): Promise<TypedArray>;
 
   /** Reads results from a query set into a GPU buffer. Values are 64 bits so byteLength must be querySet.props.count * 8 */
   abstract resolveQuerySet(

--- a/modules/core/src/adapter/resources/resource.ts
+++ b/modules/core/src/adapter/resources/resource.ts
@@ -33,10 +33,15 @@ export abstract class Resource<Props extends ResourceProps> {
 
   /** props.id, for debugging. */
   id: string;
+  /** The props that this resource was created with */
   readonly props: Required<Props>;
+  /** User data object, reserved for the application */
   readonly userData: Record<string, unknown> = {};
+  /** The device that this resource is associated with */
   abstract readonly device: Device;
+  /** The handle for the underlying resource, e.g. WebGL object or WebGPU handle */
   abstract readonly handle: unknown;
+  /** The device that this resource is associated with - TODO can we remove this dup? */
   private _device: Device;
 
   /** Whether this resource has been destroyed */

--- a/modules/core/src/adapter/resources/texture.ts
+++ b/modules/core/src/adapter/resources/texture.ts
@@ -243,7 +243,7 @@ export abstract class Texture extends Resource<TextureProps> {
    * @return the memory layout of the texture, in particular bytesPerRow which includes required padding
    */
   getMemoryLayout(options_: TextureReadOptions = {}): TextureMemoryLayout {
-    const options = this._normalizeTextureReadOptions(options_)
+    const options = this._normalizeTextureReadOptions(options_);
     const {width = this.width, height = this.height, depthOrArrayLayers = this.depth} = options;
     const {device, format} = this;
     const formatInfo = device.getTextureFormatInfo(format);
@@ -257,7 +257,7 @@ export abstract class Texture extends Resource<TextureProps> {
       bytesPerPixel,
       byteAlignment
     });
-  } 
+  }
 
   /**
    * Read the contents of a texture into a GPU Buffer.
@@ -270,7 +270,7 @@ export abstract class Texture extends Resource<TextureProps> {
    */
   readBuffer(options?: TextureReadOptions, buffer?: Buffer): Buffer {
     throw new Error('readBuffer not implemented');
-}
+  }
 
   /**
    * Reads data from a texture into an ArrayBuffer.
@@ -281,7 +281,7 @@ export abstract class Texture extends Resource<TextureProps> {
    */
   readDataAsync(options?: TextureReadOptions): Promise<ArrayBuffer> {
     throw new Error('readBuffer not implemented');
-}
+  }
 
   /**
    * Writes an GPU Buffer into a texture.
@@ -403,9 +403,7 @@ export abstract class Texture extends Resource<TextureProps> {
     return options;
   }
 
-  _normalizeTextureReadOptions(
-    options_: TextureReadOptions
-  ): Required<TextureReadOptions> {
+  _normalizeTextureReadOptions(options_: TextureReadOptions): Required<TextureReadOptions> {
     const {width, height} = this;
     const options = {...Texture.defaultTextureReadOptions, width, height, ...options_};
     // WebGL will error if we try to copy outside the bounds of the texture
@@ -414,9 +412,7 @@ export abstract class Texture extends Resource<TextureProps> {
     return options;
   }
 
-  _normalizeTextureWriteOptions(
-    options_: TextureWriteOptions
-  ): Required<TextureWriteOptions> {
+  _normalizeTextureWriteOptions(options_: TextureWriteOptions): Required<TextureWriteOptions> {
     const {width, height} = this;
     const options = {...Texture.defaultTextureReadOptions, width, height, ...options_};
     // WebGL will error if we try to copy outside the bounds of the texture

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -84,7 +84,9 @@ export type {ExternalImage} from './image-utils/image-types';
 
 export {
   type CopyExternalImageOptions,
-  type CopyImageDataOptions
+  type CopyImageDataOptions,
+  type TextureReadOptions,
+  type TextureWriteOptions
 } from './adapter/resources/texture';
 
 export type {Parameters, PrimitiveTopology, IndexFormat} from './adapter/types/parameters';
@@ -191,6 +193,13 @@ export {
   TextureFormatDecoder,
   textureFormatDecoder
 } from './shadertypes/textures/texture-format-decoder';
+
+export {
+  type TextureMemoryLayout,
+  getTextureMemoryLayout
+} from './shadertypes/textures/texture-layout';
+
+// export {TexturePacker} from './shadertypes/textures/texture-packer'
 
 export {type PixelData, readPixel, writePixel} from './shadertypes/textures/pixel-utils';
 

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -186,7 +186,8 @@ export {
   type TextureFormatDepthStencil,
   type TextureCompression,
   type TextureFormatInfo,
-  type TextureFormatCapabilities
+  type TextureFormatCapabilities,
+  type TextureMemoryLayout
 } from './shadertypes/textures/texture-formats';
 
 export {
@@ -194,10 +195,7 @@ export {
   textureFormatDecoder
 } from './shadertypes/textures/texture-format-decoder';
 
-export {
-  type TextureMemoryLayout,
-  getTextureMemoryLayout
-} from './shadertypes/textures/texture-layout';
+export {getTextureImageView, setTextureImageData} from './shadertypes/textures/texture-layout';
 
 // export {TexturePacker} from './shadertypes/textures/texture-packer'
 

--- a/modules/core/src/shadertypes/textures/texture-format-decoder.ts
+++ b/modules/core/src/shadertypes/textures/texture-format-decoder.ts
@@ -79,7 +79,7 @@ export const textureFormatDecoder = new TextureFormatDecoder();
 /**
  * Decodes a texture format, returning e.g. attatchment type, components, byte length and flags (integer, signed, normalized)
  */
-function getTextureFormatInfo(format: TextureFormat): TextureFormatInfo {
+export function getTextureFormatInfo(format: TextureFormat): TextureFormatInfo {
   let formatInfo: TextureFormatInfo = getTextureFormatInfoUsingTable(format);
 
   if (textureFormatDecoder.isCompressed(format)) {

--- a/modules/core/src/shadertypes/textures/texture-formats.ts
+++ b/modules/core/src/shadertypes/textures/texture-formats.ts
@@ -59,6 +59,33 @@ export type TextureFormatCapabilities = {
 };
 
 /**
+ * Memory layout for reading/writing data to a texture's memory.
+ *
+ * @note Due to alignment, GPU texture data is typically not contiguous.
+ *
+ * @note  GPU texure data must be accessed according to this layout.
+ * - On CPU, only the range of rows that are actually read or written need to be allocated.
+ * - However, space for the full, padded/aligned rows must be allocated in the buffer,
+ *   even if just a partial horizontal range `{x, width}` is actually read or written.
+ *
+ * @note byteLength = bytesPerRow * rowsPerImage * depthOrArrayLayers.
+ */
+export type TextureMemoryLayout = {
+  /** Total length in bytes */
+  byteLength: number;
+  /** Number of images */
+  depthOrArrayLayers: number;
+  /** Stride between successive images (Use when depthOrArrayLayers > 1) */
+  bytesPerImage: number;
+  /** Number of rows per image */
+  rowsPerImage: number;
+  /** Number of bytes per row (padded) */
+  bytesPerRow: number;
+  /** Number of bytes per pixel */
+  bytesPerPixel: number;
+};
+
+/**
  * These represent the main compressed texture formats
  * Each format typically has a number of more specific subformats
  */
@@ -133,7 +160,7 @@ export type TextureFormatColorUncompressed =
   | TextureFormatPacked16
   | TextureFormatPacked32;
 
-type TextureFormatUnorm8 =
+export type TextureFormatUnorm8 =
   | 'r8unorm'
   | 'rg8unorm'
   | 'rgb8unorm-webgl'
@@ -142,32 +169,36 @@ type TextureFormatUnorm8 =
   | 'bgra8unorm'
   | 'bgra8unorm-srgb';
 
-type TextureFormatSnorm8 = 'r8snorm' | 'rg8snorm' | 'rgb8snorm-webgl' | 'rgba8snorm';
+export type TextureFormatSnorm8 = 'r8snorm' | 'rg8snorm' | 'rgb8snorm-webgl' | 'rgba8snorm';
 
-type TextureFormatUint8 = 'r8uint' | 'rg8uint' | 'rgba8uint';
+export type TextureFormatUint8 = 'r8uint' | 'rg8uint' | 'rgba8uint';
 
-type TextureFormatSint8 = 'r8sint' | 'rg8sint' | 'rgba8sint';
+export type TextureFormatSint8 = 'r8sint' | 'rg8sint' | 'rgba8sint';
 
-type TextureFormatUnorm16 = 'r16unorm' | 'rg16unorm' | 'rgb16unorm-webgl' | 'rgba16unorm';
+export type TextureFormatUnorm16 = 'r16unorm' | 'rg16unorm' | 'rgb16unorm-webgl' | 'rgba16unorm';
 
-type TextureFormatSnorm16 = 'r16snorm' | 'rg16snorm' | 'rgb16snorm-webgl' | 'rgba16snorm';
+export type TextureFormatSnorm16 = 'r16snorm' | 'rg16snorm' | 'rgb16snorm-webgl' | 'rgba16snorm';
 
-type TextureFormatUint16 = 'r16uint' | 'rg16uint' | 'rgba16uint';
+export type TextureFormatUint16 = 'r16uint' | 'rg16uint' | 'rgba16uint';
 
-type TextureFormatSint16 = 'r16sint' | 'rg16sint' | 'rgba16sint';
+export type TextureFormatSint16 = 'r16sint' | 'rg16sint' | 'rgba16sint';
 
-type TextureFormatFloat16 = 'r16float' | 'rg16float' | 'rgba16float';
+export type TextureFormatFloat16 = 'r16float' | 'rg16float' | 'rgba16float';
 
 // 96-bit formats (deprecated!)
-type TextureFormatUint32 = 'r32uint' | 'rg32uint' | 'rgba32uint';
+export type TextureFormatUint32 = 'r32uint' | 'rg32uint' | 'rgba32uint';
 
-type TextureFormatSint32 = 'r32sint' | 'rg32sint' | 'rgba32sint';
+export type TextureFormatSint32 = 'r32sint' | 'rg32sint' | 'rgba32sint';
 
-type TextureFormatFloat32 = 'r32float' | 'rg32float' | 'rgb32float-webgl' | 'rgba32float';
+export type TextureFormatFloat32 = 'r32float' | 'rg32float' | 'rgb32float-webgl' | 'rgba32float';
 
-type TextureFormatPacked16 = 'rgba4unorm-webgl' | 'rgb565unorm-webgl' | 'rgb5a1unorm-webgl';
+export type TextureFormatPacked16 = 'rgba4unorm-webgl' | 'rgb565unorm-webgl' | 'rgb5a1unorm-webgl';
 
-type TextureFormatPacked32 = 'rgb9e5ufloat' | 'rg11b10ufloat' | 'rgb10a2unorm' | 'rgb10a2uint';
+export type TextureFormatPacked32 =
+  | 'rgb9e5ufloat'
+  | 'rg11b10ufloat'
+  | 'rgb10a2unorm'
+  | 'rgb10a2uint';
 
 export type TextureFormatCompressed =
   | 'bc1-rgb-unorm-webgl'

--- a/modules/core/src/shadertypes/textures/texture-formats.ts
+++ b/modules/core/src/shadertypes/textures/texture-formats.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {NormalizedDataType} from '../data-types/data-types';
+import {NormalizedDataType, DataTypeArray, NormalizedDataTypeArray} from '../data-types/data-types';
 
 /** Information about the structure of a texture format */
 export type TextureFormatInfo = {
@@ -244,6 +244,14 @@ export type TextureFormatCompressed =
   | 'astc-12x12-unorm-srgb';
 
 // Texture format helper types
+
+export type TextureFormatTypedArray<T extends TextureFormat> = DataTypeArray<
+  TextureFormatDataType<T>
+>;
+
+export type TextureFormatNormalizedTypedArray<T extends TextureFormat> = NormalizedDataTypeArray<
+  TextureFormatDataType<T>
+>;
 
 export type TextureFormatDataType<T extends TextureFormat> = T extends TextureFormatUint8
   ? 'uint8'

--- a/modules/core/src/shadertypes/textures/texture-layout.ts
+++ b/modules/core/src/shadertypes/textures/texture-layout.ts
@@ -1,0 +1,131 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {TypedArray} from '@math.gl/types';
+import {TextureFormat} from './texture-formats';
+
+// type TextureFormatToTypedArray<T extends TextureFormat> = T extends
+//   | 'r8unorm'
+//   | 'rgba8unorm'
+//   | 'bgra8unorm'
+//   | 'rgba8uint'
+//   ? Uint8Array<ArrayBuffer>
+//   : T extends 'r16uint' | 'rgba16uint' | 'rgba16float'
+//     ? Uint16Array<ArrayBuffer>
+//     : T extends 'r32uint' | 'rgba32uint'
+//       ? Uint32Array<ArrayBuffer>
+//       : T extends 'r32float' | 'rgba32float'
+//         ? Float32Array<ArrayBuffer>
+//         : // Default to UINT8Array for other formats
+//           Uint8Array<ArrayBuffer>;
+
+/**
+ * Memory layout for reading/writing to a texture
+ * Layout and size of  memory covering a specific range of rows and images in a texture.
+ *
+ * @note The total length is bytesPerRow * rowsPerImage * depthOrArrayLayers.
+ *
+ * @note Texture data must be provided in this layout.
+ * - Only the range of rows that are actually read or written need to be allocated.
+ * - However, space for the full, padded! rows must be allocated in the buffer,
+ *   even if just a partial horizontal range `{x, width}` is actually read or written.
+ */
+export type TextureMemoryLayout = {
+  bytesPerPixel: number;
+  /** Number of bytes per row (padded) */
+  bytesPerRow: number;
+  /** Number of rows per image */
+  rowsPerImage: number;
+  /** Number of images */
+  depthOrArrayLayers: number;
+  /** Stride between successive images (Use when depthOrArrayLayers > 1) */
+  bytesPerImage: number;
+  /** Total length in bytes */
+  byteLength: number;
+};
+
+export type TextureMemoryLayoutOptions = {
+  /** Width of the texture in pixels/texels */
+  textureWidth: number;
+  /** Number of rows to be read or written */
+  rows: number;
+  /** Number of images to be read or written */
+  depthOrArrayLayers: number;
+  /** Number of bytes per pixel */
+  bytesPerPixel: number;
+  /** Alignment of each row */
+  byteAlignment: number;
+};
+
+/** Get the memory layout of a texture */
+export function getTextureMemoryLayout({
+  textureWidth,
+  rows,
+  depthOrArrayLayers,
+  bytesPerPixel,
+  byteAlignment
+}: TextureMemoryLayoutOptions): TextureMemoryLayout {
+  // WebGPU requires bytesPerRow to be a multiple of 256.
+  const unpaddedBytesPerRow = textureWidth * bytesPerPixel;
+  const bytesPerRow = Math.ceil(unpaddedBytesPerRow / byteAlignment) * byteAlignment;
+  const rowsPerImage = rows;
+  const byteLength = bytesPerRow * rowsPerImage * depthOrArrayLayers;
+
+  return {
+    bytesPerPixel,
+    bytesPerRow,
+    rowsPerImage: rows,
+    depthOrArrayLayers,
+    bytesPerImage: bytesPerRow * rowsPerImage,
+    byteLength
+  };
+}
+
+export function getTextureSlice<T extends TextureFormat>(
+  arrayBuffer: ArrayBuffer,
+  memoryLayout: TextureMemoryLayout,
+  format: T,
+  slice = 0
+) {
+  const {bytesPerImage} = memoryLayout;
+  const offset = bytesPerImage * slice;
+  const totalPixels = memoryLayout.bytesPerImage / memoryLayout.bytesPerPixel;
+
+  switch (format) {
+    case 'rgba8unorm':
+    case 'bgra8unorm':
+    case 'rgba8uint':
+      return new Uint8Array(arrayBuffer, offset, totalPixels);
+    case 'r8unorm':
+      return new Uint8Array(arrayBuffer, offset, totalPixels);
+    case 'r16uint':
+    case 'rgba16uint':
+      return new Uint16Array(arrayBuffer, offset, totalPixels);
+    case 'r32uint':
+    case 'rgba32uint':
+      return new Uint32Array(arrayBuffer, offset, totalPixels);
+    case 'r32float':
+      return new Float32Array(arrayBuffer, offset, totalPixels);
+    case 'rgba16float':
+      return new Uint16Array(arrayBuffer, offset, totalPixels); // 4 channels
+    case 'rgba32float':
+      return new Float32Array(arrayBuffer, offset, totalPixels);
+    default:
+      throw new Error(`Unsupported format: ${format}`);
+  }
+}
+
+export function setTextureSlice<T extends TextureFormat>(
+  arrayBuffer: ArrayBuffer,
+  memoryLayout: TextureMemoryLayout,
+  format: T,
+  data: TypedArray,
+  slice = 0
+): void {
+  const {bytesPerImage} = memoryLayout;
+  const offset = bytesPerImage * slice;
+  const totalPixels = memoryLayout.bytesPerImage / memoryLayout.bytesPerPixel;
+  const typedArray = getTextureSlice(arrayBuffer, memoryLayout, format, slice);
+  typedArray.set(data.subarray(0, totalPixels), offset);
+}

--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -1,21 +1,236 @@
-// TODO - fix
-// @ts-nocheck
-/* eslint-disable */
-
 import test from 'tape-promise/tape';
 import {getWebGLTestDevice, getTestDevices} from '@luma.gl/test-utils';
 
-import {Device, Texture, TextureFormat, textureFormatDecoder, VertexType} from '@luma.gl/core';
-// TODO(v9): Avoid import from `@luma.gl/constants` in core tests.
+import {TypedArray, Device, Texture, TextureFormat, textureFormatDecoder, VertexType, _getTextureFormatTable,
+  TextureView,
+  Buffer as LumaBuffer,
+} from '@luma.gl/core';
 import {GL} from '@luma.gl/constants';
 import {WebGLDevice} from '@luma.gl/webgl';
 
-import {_getTextureFormatTable, getTextureFormatWebGL} from '@luma.gl/core';
 import {SAMPLER_PARAMETERS} from './sampler.spec';
 
-import {WEBGLTexture} from '@luma.gl/webgl/adapter/resources/webgl-texture';
-import {WebGLDevice} from '../../../../webgl/dist/adapter/webgl-device';
-// import {convertToSamplerProps} from '@luma.gl/webgl/adapter/converters/sampler-parameters';
+
+
+// Utility to compare TypedArray contents
+function toUint8(arr: ArrayBuffer | ArrayBufferView): Uint8Array {
+  return arr instanceof ArrayBuffer
+    ? new Uint8Array(arr)
+    : new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength);
+}
+
+test.skip('Texture#createView returns a TextureView', async t => {
+  for (const device of await getTestDevices()) {
+    const tex = device.createTexture({width: 2, height: 2});
+    const view = tex.createView({});
+    t.ok(view instanceof TextureView, `${device.type}: createView returns TextureView`);
+    t.equal(
+      view.props.width,
+      tex.width,
+      `${device.type}: view.props.width matches texture.width`
+    );
+    t.equal(
+      view.props.height,
+      tex.height,
+      `${device.type}: view.props.height matches texture.height`
+    );
+    tex.destroy();
+  }
+  t.end();
+});
+
+test('Texture#writeData & readDataAsync round-trip', async t => {
+  for (const device of await getTestDevices()) {
+    t.comment(`Testing ${device.type}`);
+    const RGBA8_DATA = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+
+    const tex = device.createTexture({width: 2, height: 1, format: 'rgba8unorm', usage: Texture.COPY_DST | Texture.COPY_SRC});
+
+
+    tex.writeData(RGBA8_DATA);
+    const arrayBuffer = await tex.readDataAsync();
+    const result = toUint8(arrayBuffer).slice(0, RGBA8_DATA.length);
+
+    t.deepEquals(
+      result,
+      RGBA8_DATA,
+      `${device.type}: writeData + readDataAsync returns same pixels`
+    );
+    tex.destroy();
+  }
+  t.end();
+});
+
+test.only('Texture#writeData & readDataAsync round-trip for all formats and dimensions', async t => {
+  for (const device of await getTestDevices()) {
+    t.comment(`Testing device: ${device.type}`);
+    const formatTable = _getTextureFormatTable(device);
+    const formats: TextureFormat[] = Object.keys(formatTable) as TextureFormat[];
+
+    for (const format of formats) {
+      const info = device.getTextureFormatInfo(format);
+
+      // Loop over supported dimensions
+      for (const dimension of ['2d', '3d'] as const) {
+        if (dimension === '3d' && device.type === 'webgl') continue;
+
+        // Pick small, fixed size
+        const texSize = {
+          // '1d': {width: 8},
+          '2d': {width: 4, height: 2},
+          '3d': {width: 2, height: 2, depthOrArrayLayers: 2}
+        }[dimension];
+
+        const tex = device.createTexture({
+          ...texSize,
+          dimension,
+          format,
+          usage: Texture.COPY_SRC | Texture.COPY_DST
+        });
+
+        const ArrayType = Uint8Array;
+        const {byteLength} = tex.getMemoryLayout();
+        const arraySize = byteLength / ArrayType.BYTES_PER_ELEMENT;
+        const input = new ArrayType(arraySize);
+        for (let i = 0; i < input.length; i++) input[i] = i % 251;
+
+        try {
+          tex.writeData(input);
+          const outputBuffer = await tex.readDataAsync();
+          const output = new ArrayType(outputBuffer).slice(0, input.length);
+
+          const match = ArrayType === Float32Array
+            ? almostEqual(output, input)
+            : deepEqual(output, input);
+
+            if (!match) {
+              debugger
+            }
+          t.ok(match, `${device.type} ${format} ${dimension} round-trip succeeded`);
+        } catch (err) {
+          t.fail(`${device.type} ${format} ${dimension} round-trip failed: ${err.message}`);
+        }
+
+        tex.destroy();
+      }
+    }
+  }
+
+  t.end();
+});
+
+// Helpers
+function getTypedArrayConstructor(type: string): any {
+  switch (type) {
+    case 'uint8': return Uint8Array;
+    case 'uint16': return Uint16Array;
+    case 'float32': return Float32Array;
+    default: return null;
+  }
+}
+
+function deepEqual(a: TypedArray, b: TypedArray): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function almostEqual(a: Float32Array, b: Float32Array, epsilon = 1e-6): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (Math.abs(a[i] - b[i]) > epsilon) return false;
+  }
+  return true;
+}
+
+
+test('Texture#copyImageData & readDataAsync round-trip', async t => {
+  for (const device of await getTestDevices()) {
+    const tex = device.createTexture({width: 2, height: 1, format: 'rgba8unorm'});
+    tex.copyImageData({data: RGBA8_DATA});
+    const buffer = await tex.readDataAsync({});
+    const result = toUint8(buffer);
+    t.deepEquals(
+      result,
+      RGBA8_DATA,
+      `${device.type}: copyImageData + readDataAsync returns same pixels`
+    );
+    tex.destroy();
+  }
+  t.end();
+});
+
+
+test('Texture#writeBuffer & readDataAsync round-trip', async t => {
+  for (const device of await getTestDevices()) {
+    const width = 2;
+    const height = 1;
+    const bytesPerRow = width * 4;
+    const bufferSize = bytesPerRow * height;
+    const upload = device.createBuffer({
+      size: bufferSize,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+      mappedAtCreation: true
+    });
+    new Uint8Array(upload.getMappedRange()).set(RGBA8_DATA);
+    upload.unmap();
+
+    const tex = device.createTexture({width, height, format: 'rgba8unorm'});
+    tex.writeBuffer(upload, {});
+    const data = await tex.readDataAsync({});
+    const result = toUint8(data);
+    t.deepEquals(
+      result,
+      RGBA8_DATA,
+      `${device.type}: writeBuffer + readDataAsync returns same pixels`
+    );
+    upload.destroy();
+    tex.destroy();
+  }
+  t.end();
+});
+
+
+test('Texture#readBuffer & Buffer.readAsync round-trip', async t => {
+  for (const device of await getTestDevices()) {
+    const tex = device.createTexture({width: 2, height: 1, format: 'rgba8unorm'});
+    // initialize via writeData
+    tex.writeData(RGBA8_DATA, {});
+    const buf = tex.readBuffer({});
+    const arr = await (buf).readAsync();
+    const result = toUint8(arr);
+    t.deepEquals(
+      result,
+      RGBA8_DATA,
+      `${device.type}: readBuffer + Buffer.readAsync returns same pixels`
+    );
+    tex.destroy();
+  }
+  t.end();
+});
+
+
+test('Texture#readDataSyncWebGL returns correct data on WebGL', async t => {
+  const devices = await getTestDevices();
+  for (const device of devices) {
+    if (device instanceof WebGLDevice) {
+      const tex = device.createTexture({width: 2, height: 1, format: 'rgba8unorm'});
+      tex.writeData(RGBA8_DATA, {});
+      const syncData = tex.readDataSyncWebGL({});
+      const result = toUint8(syncData);
+      t.deepEquals(
+        result,
+        RGBA8_DATA,
+        `webgl: readDataSyncWebGL returns same pixels`
+      );
+      tex.destroy();
+    }
+  }
+  t.end();
+});
+
+
+// //////////////////////////////
 
 test('Device#isTextureFormatSupported()', async t => {
   const UNSUPPORTED_FORMATS: Record<string, TextureFormat[]> = {
@@ -43,7 +258,7 @@ test('Device#isTextureFormatSupported()', async t => {
 });
 
 test('Device#isTextureFormatFilterable()', async t => {
-  const UNSUPPORTED_FORMATS: Record<string, Record<Device['type'], TextureFormat[]>> = {
+  const UNSUPPORTED_FORMATS: Record<Device['type'], TextureFormat[]> = {
     webgl: ['rgba8unorm', 'r32float', 'rg32float', 'rgb32float-webgl', 'rgba32float'],
     webgpu: []
   };
@@ -68,7 +283,7 @@ test('Device#isTextureFormatFilterable()', async t => {
 });
 
 test('Device#isTextureFormatRenderable()', async t => {
-  const UNSUPPORTED_FORMATS: Record<string, Record<Device['type'], TextureFormat[]>> = {
+  const UNSUPPORTED_FORMATS: Record<Device['type'], TextureFormat[]> = {
     webgl: ['rgba8unorm', 'r32float', 'rg32float', 'rgb32float-webgl', 'rgba32float'],
     webgpu: []
   };
@@ -258,10 +473,9 @@ test('Texture#dimension=3d,format=r32float', async t => {
       depth: 16,
       dimension: '3d',
       format: 'r32float',
-      mipmaps: false,
       sampler: {
         minFilter: 'linear',
-        magFilterFilter: 'linear',
+        magFilter: 'linear',
         addressModeU: 'clamp-to-edge',
         addressModeV: 'clamp-to-edge',
         addressModeW: 'clamp-to-edge'
@@ -278,7 +492,6 @@ test('Texture#copyExternalImage', async t => {
       width: 2,
       height: 1,
       format: 'rgba8unorm',
-      mipmaps: false
     });
 
     if (device.info.type === 'webgl') {
@@ -294,7 +507,7 @@ test('Texture#copyExternalImage', async t => {
       const canvas = document.createElement('canvas');
       canvas.width = 2;
       canvas.height = 1;
-      const ctx = canvas.getContext('2d');
+      const ctx = canvas.getContext('2d')!;
 
       // Full copy
       ctx.fillStyle = '#FF0000';
@@ -416,30 +629,6 @@ test.skip('WebGL2#Texture setSubImageData', async t => {
       'Pixels are set correctly'
     );
   }
-
-  t.end();
-});
-
-test.skip('WebGL2#Texture generateMipmap', async t => {
-  let texture = webglDevice.createTexture({
-    data: null,
-    width: 3,
-    height: 3,
-    mipmaps: false
-  });
-
-  texture.generateMipmap();
-  t.notOk(texture.mipmaps, 'Should not turn on mipmaps for NPOT.');
-
-  texture = webglDevice.createTexture({
-    data: null,
-    width: 2,
-    height: 2,
-    mipmaps: false
-  });
-
-  texture.generateMipmap();
-  t.ok(texture.mipmaps, 'Should turn on mipmaps for POT.');
 
   t.end();
 });
@@ -598,6 +787,32 @@ test.skip('Texture#setParameters', async t => {
 
   texture.destroy();
   t.ok(texture instanceof Texture, 'Texture delete successful');
+
+  t.end();
+});
+
+// Move to engine
+
+test.skip('WebGL2#Texture generateMipmap', async t => {
+  let texture = webglDevice.createTexture({
+    data: null,
+    width: 3,
+    height: 3,
+    mipmaps: false
+  });
+
+  texture.generateMipmap();
+  t.notOk(texture.mipmaps, 'Should not turn on mipmaps for NPOT.');
+
+  texture = webglDevice.createTexture({
+    data: null,
+    width: 2,
+    height: 2,
+    mipmaps: false
+  });
+
+  texture.generateMipmap();
+  t.ok(texture.mipmaps, 'Should turn on mipmaps for POT.');
 
   t.end();
 });

--- a/modules/core/test/index.ts
+++ b/modules/core/test/index.ts
@@ -5,7 +5,9 @@ import './utils/uid.spec';
 import './shadertypes/decode-attribute-type.spec';
 import './shadertypes/decode-vertex-format.spec';
 import './shadertypes/vertex-format-from-attribute.spec';
-import './shadertypes/decode-texture-format.spec';
+
+import './shadertypes/textures/decode-texture-format.spec';
+import './shadertypes/textures/texture-layout.spec';
 
 // adapter utils
 import './adapter-utils/get-attribute-from-layout.spec';

--- a/modules/core/test/shadertypes/textures/decode-texture-format.spec.ts
+++ b/modules/core/test/shadertypes/textures/decode-texture-format.spec.ts
@@ -57,3 +57,25 @@ test('shadertype#textureFormatDecoder.getCapabilities', t => {
   }
   t.end();
 });
+
+/**
+ * Compute bytesPerPixel from format metadata.
+ * If you prefer not to pass `bytesPerPixel` into `textureFormatDecoder.computeMemoryLayout`,
+ * you can derive it from `TextureFormat` via this helper.
+ */
+const bytesPerPixelFromFormat = (format: TextureFormat) =>
+  textureFormatDecoder.getInfo(format).bytesPerPixel;
+
+test('bytesPerPixelFromFormat', t => {
+  t.equal(bytesPerPixelFromFormat('r8unorm'), 1, 'r8unorm = 1 B/px');
+  t.equal(bytesPerPixelFromFormat('rgba8unorm'), 4, 'rgba8unorm = 4 B/px');
+  t.equal(bytesPerPixelFromFormat('bgra8unorm'), 4, 'bgra8unorm = 4 B/px');
+  t.equal(bytesPerPixelFromFormat('r16uint'), 2, 'r16uint = 2 B/px');
+  t.equal(bytesPerPixelFromFormat('rgba16uint'), 8, 'rgba16uint = 8 B/px');
+  t.equal(bytesPerPixelFromFormat('rgba16float'), 8, 'rgba16float = 8 B/px');
+  t.equal(bytesPerPixelFromFormat('r32uint'), 4, 'r32uint = 4 B/px');
+  t.equal(bytesPerPixelFromFormat('rgba32uint'), 16, 'rgba32uint = 16 B/px');
+  t.equal(bytesPerPixelFromFormat('r32float'), 4, 'r32float = 4 B/px');
+  t.equal(bytesPerPixelFromFormat('rgba32float'), 16, 'rgba32float = 16 B/px');
+  t.end();
+});

--- a/modules/core/test/shadertypes/textures/texture-layout.spec.ts
+++ b/modules/core/test/shadertypes/textures/texture-layout.spec.ts
@@ -1,0 +1,145 @@
+// test/texture-memory-layout.tape.ts
+import test from 'tape';
+import {getTextureImageView, setTextureImageData, textureFormatDecoder} from '../../../src'; // '@luma.gl/core';
+
+const ALIGN_256 = 256;
+
+function makeLayout(opts: {
+  format:
+    | 'r8unorm'
+    | 'rgba8unorm'
+    | 'bgra8unorm'
+    | 'rgba8uint'
+    | 'r16uint'
+    | 'rgba16uint'
+    | 'rgba16float'
+    | 'r32uint'
+    | 'rgba32uint'
+    | 'r32float'
+    | 'rgba32float';
+  width: number;
+  rows: number;
+  layers?: number;
+  alignment?: number;
+}) {
+  const {format, width, rows, layers = 1, alignment = ALIGN_256} = opts;
+  const layout = textureFormatDecoder.computeMemoryLayout({
+    format,
+    width,
+    height: rows,
+    depth: layers,
+    byteAlignment: alignment
+  });
+  return {layout, format};
+}
+
+test('alignment & sizes (rgba8unorm, width=3, rows=2)', t => {
+  const {layout} = makeLayout({format: 'rgba8unorm', width: 3, rows: 2});
+  t.equal(layout.bytesPerRow, 256, 'bytesPerRow aligned to 256');
+  t.equal(layout.bytesPerImage, 256 * 2, 'bytesPerImage = bytesPerRow * rows');
+  t.equal(layout.byteLength, 256 * 2 * 1, 'byteLength = bytesPerImage * layers');
+  t.equal(layout.rowsPerImage, 2, 'rowsPerImage = 2');
+  t.equal(layout.depthOrArrayLayers, 1, 'layers = 1');
+  t.end();
+});
+
+test('getTextureImageView types & element lengths', t => {
+  {
+    const {layout} = makeLayout({format: 'rgba8unorm', width: 3, rows: 2});
+    const buf = new ArrayBuffer(layout.byteLength);
+    const view = getTextureImageView(buf, layout, 'rgba8unorm', 0);
+    t.equal(view.constructor.name, 'Uint8Array', 'rgba8unorm -> Uint8Array');
+    t.equal(view.length, layout.bytesPerImage / 1, 'elements = bytesPerImage / 1');
+  }
+  {
+    const {layout} = makeLayout({format: 'rgba16float', width: 4, rows: 3});
+    const buf = new ArrayBuffer(layout.byteLength);
+    const view = getTextureImageView(buf, layout, 'rgba16float', 0);
+    t.equal(view.constructor.name, 'Uint16Array', 'rgba16float -> Uint16Array');
+    t.equal(view.length, layout.bytesPerImage / 2, 'elements = bytesPerImage / 2');
+  }
+  {
+    const {layout} = makeLayout({format: 'rgba32float', width: 2, rows: 2});
+    const buf = new ArrayBuffer(layout.byteLength);
+    const view = getTextureImageView(buf, layout, 'rgba32float', 0);
+    t.equal(view.constructor.name, 'Float32Array', 'rgba32float -> Float32Array');
+    t.equal(view.length, layout.bytesPerImage / 4, 'elements = bytesPerImage / 4');
+  }
+  t.end();
+});
+
+test('multi-layer writes do not bleed across layers (rgba8unorm)', t => {
+  const {layout} = makeLayout({format: 'rgba8unorm', width: 2, rows: 2, layers: 2});
+  const buf = new ArrayBuffer(layout.byteLength);
+
+  // Write 7s into layer 1
+  const v1 = getTextureImageView(buf, layout, 'rgba8unorm', 1) as Uint8Array;
+  const data1 = new Uint8Array(v1.length).fill(7);
+  setTextureImageData(buf, layout, 'rgba8unorm', data1, 1);
+
+  const v0 = getTextureImageView(buf, layout, 'rgba8unorm', 0) as Uint8Array;
+
+  // Quick spot checks
+  t.ok(
+    v0.slice(0, 64).every(x => x === 0),
+    'layer 0 remains zero-initialized'
+  );
+  t.ok(
+    v1.slice(0, 64).every(x => x === 7),
+    'layer 1 filled with 7s'
+  );
+  t.end();
+});
+
+test('setTextureImageData clamps to view length (r8unorm)', t => {
+  const {layout} = makeLayout({format: 'r8unorm', width: 4, rows: 1});
+  const buf = new ArrayBuffer(layout.byteLength);
+  const view = getTextureImageView(buf, layout, 'r8unorm', 0) as Uint8Array;
+
+  const big = new Uint8Array(view.length + 1024).fill(9);
+  setTextureImageData(buf, layout, 'r8unorm', big, 0);
+
+  t.ok(
+    view.every(x => x === 9),
+    'entire view written with 9s'
+  );
+  t.end();
+});
+
+test('no double offset on write (r32float)', t => {
+  const {layout} = makeLayout({format: 'r32float', width: 1, rows: 1, layers: 2});
+  const buf = new ArrayBuffer(layout.byteLength);
+
+  const layer1 = getTextureImageView(buf, layout, 'r32float', 1) as Float32Array;
+  const layer0 = getTextureImageView(buf, layout, 'r32float', 0) as Float32Array;
+
+  const data = new Float32Array(layer1.length);
+  data[0] = 1.25;
+  data[1] = 2.5;
+  setTextureImageData(buf, layout, 'r32float', data, 1);
+
+  t.equal(layer1[0], 1.25, 'layer1 first element matches');
+  t.equal(layer1[1], 2.5, 'layer1 second element matches');
+  t.equal(layer0[0], 0, 'layer0 unaffected [0]');
+  t.equal(layer0[1], 0, 'layer0 unaffected [1]');
+  t.end();
+});
+
+test('padding: tiny width -> large bytesPerRow; lengths reflect padding (rgba8unorm)', t => {
+  const {layout} = makeLayout({format: 'rgba8unorm', width: 1, rows: 3});
+  t.equal(layout.bytesPerRow, 256, 'row padded to 256');
+  t.equal(layout.bytesPerImage, 256 * 3, 'bytesPerImage = 256 * rows');
+  const buf = new ArrayBuffer(layout.byteLength);
+  const view = getTextureImageView(buf, layout, 'rgba8unorm', 0) as Uint8Array;
+  t.equal(view.length, layout.bytesPerImage, 'Uint8Array length equals bytesPerImage');
+  t.end();
+});
+
+test('bgra8unorm typed view & length', t => {
+  const {layout} = makeLayout({format: 'bgra8unorm', width: 5, rows: 2});
+  const buf = new ArrayBuffer(layout.byteLength);
+  const view = getTextureImageView(buf, layout, 'bgra8unorm', 0) as Uint8Array;
+  t.equal(view.constructor.name, 'Uint8Array', 'bgra8unorm -> Uint8Array');
+  t.equal(view.length, layout.bytesPerImage, 'length equals bytesPerImage');
+  t.end();
+});

--- a/modules/effects/package.json
+++ b/modules/effects/package.json
@@ -46,7 +46,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/shadertools": "9.2.0-alpha.1"
+    "@luma.gl/shadertools": "9.2.0-alpha.6"
   },
   "dependencies": {
     "@math.gl/core": "^4.1.0",

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -40,8 +40,8 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "9.2.0-alpha.1",
-    "@luma.gl/shadertools": "9.2.0-alpha.1"
+    "@luma.gl/core": "9.2.0-alpha.6",
+    "@luma.gl/shadertools": "9.2.0-alpha.6"
   },
   "dependencies": {
     "@math.gl/core": "^4.1.0",

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -40,10 +40,10 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/constants": "9.2.0-alpha.1",
-    "@luma.gl/core": "9.2.0-alpha.1",
-    "@luma.gl/engine": "9.2.0-alpha.1",
-    "@luma.gl/shadertools": "9.2.0-alpha.1"
+    "@luma.gl/constants": "9.2.0-alpha.6",
+    "@luma.gl/core": "9.2.0-alpha.6",
+    "@luma.gl/engine": "9.2.0-alpha.6",
+    "@luma.gl/shadertools": "9.2.0-alpha.6"
   },
   "dependencies": {
     "@loaders.gl/core": "^4.2.0",

--- a/modules/shadertools/package.json
+++ b/modules/shadertools/package.json
@@ -46,7 +46,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "9.2.0-alpha.1"
+    "@luma.gl/core": "9.2.0-alpha.6"
   },
   "dependencies": {
     "@math.gl/core": "^4.1.0",

--- a/modules/shadertools/test/index.ts
+++ b/modules/shadertools/test/index.ts
@@ -31,8 +31,8 @@ import './lib/shader-assembler.spec';
 
 // Data utilities
 import './modules/math/fp16-utils.spec';
-import './modules/math/fp64-arithmetic-transform.spec';
-import './modules/math/fp64-utils.spec';
+// import './modules/math/fp64-arithmetic-transform.spec';
+// import './modules/math/fp64-utils.spec';
 
 // General modules tests
 import './modules/modules.spec';

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -36,11 +36,11 @@
     "pre-build": "echo test utils has no bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "9.2.0-alpha.1",
-    "@luma.gl/engine": "9.2.0-alpha.1",
-    "@luma.gl/shadertools": "9.2.0-alpha.1",
-    "@luma.gl/webgl": "9.2.0-alpha.1",
-    "@luma.gl/webgpu": "9.2.0-alpha.1"
+    "@luma.gl/core": "9.2.0-alpha.6",
+    "@luma.gl/engine": "9.2.0-alpha.6",
+    "@luma.gl/shadertools": "9.2.0-alpha.6",
+    "@luma.gl/webgl": "9.2.0-alpha.6",
+    "@luma.gl/webgpu": "9.2.0-alpha.6"
   },
   "dependencies": {
     "@probe.gl/env": "^4.0.8",

--- a/modules/test-utils/src/null-device/resources/null-texture.ts
+++ b/modules/test-utils/src/null-device/resources/null-texture.ts
@@ -2,16 +2,19 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {
-  TextureProps,
-  TextureViewProps,
-  CopyExternalImageOptions,
-  CopyImageDataOptions,
-  Sampler,
-  SamplerProps
+import {
+  type TextureProps,
+  type TextureViewProps,
+  type CopyExternalImageOptions,
+  type CopyImageDataOptions,
+  type TextureReadOptions,
+  type TextureWriteOptions,
+  type Sampler,
+  type SamplerProps,
+  type TextureFormat,
+  Buffer,
+  Texture
 } from '@luma.gl/core';
-
-import {Texture} from '@luma.gl/core';
 import {NullDevice} from '../null-device';
 import {NullSampler} from './null-sampler';
 import {NullTextureView} from './null-texture-view';
@@ -87,7 +90,23 @@ export class NullTexture extends Texture {
     throw new Error('copyImageData not implemented');
   }
 
-  generateMipmapsWebGL(): void {
+  override readBuffer(options: TextureReadOptions = {}, buffer?: Buffer): Buffer {
+    return this.device.createBuffer({});
+  }
+
+  override async readDataAsync(options: TextureReadOptions = {}): Promise<ArrayBuffer> {
+    return new ArrayBuffer(0);
+  }
+
+  override writeBuffer(buffer: Buffer, options: TextureWriteOptions = {}) {
     // ignore
+  }
+
+  override writeData(data: ArrayBuffer | ArrayBufferView, options: TextureWriteOptions = {}): void {
+    // ignore
+  }
+
+  override _getRowByteAlignment(format: TextureFormat): number {
+    return 1;
   }
 }

--- a/modules/test-utils/src/null-device/resources/null-texture.ts
+++ b/modules/test-utils/src/null-device/resources/null-texture.ts
@@ -11,7 +11,6 @@ import {
   type TextureWriteOptions,
   type Sampler,
   type SamplerProps,
-  type TextureFormat,
   Buffer,
   Texture
 } from '@luma.gl/core';
@@ -64,8 +63,7 @@ export class NullTexture extends Texture {
   copyExternalImage(options: CopyExternalImageOptions): {width: number; height: number} {
     this.trackDeallocatedMemory('Texture');
 
-    const {image: data} = options;
-
+    // const {image: data} = options;
     // if (data && data.byteLength) {
     //   this.trackAllocatedMemory(data.byteLength, 'Texture');
     // } else {
@@ -73,13 +71,7 @@ export class NullTexture extends Texture {
     this.trackAllocatedMemory(this.width * this.height * bytesPerPixel, 'Texture');
     // }
 
-    const width = options.width ?? (data as ImageBitmap).width;
-    const height = options.height ?? (data as ImageBitmap).height;
-
-    this.width = width;
-    this.height = height;
-
-    return {width, height};
+    return {width: this.width, height: this.height};
   }
 
   override setSampler(sampler?: Sampler | SamplerProps): void {
@@ -104,9 +96,5 @@ export class NullTexture extends Texture {
 
   override writeData(data: ArrayBuffer | ArrayBufferView, options: TextureWriteOptions = {}): void {
     // ignore
-  }
-
-  override _getRowByteAlignment(format: TextureFormat): number {
-    return 1;
   }
 }

--- a/modules/webgl/package.json
+++ b/modules/webgl/package.json
@@ -40,7 +40,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "9.2.0-alpha.1"
+    "@luma.gl/core": "9.2.0-alpha.6"
   },
   "dependencies": {
     "@luma.gl/constants": "9.2.0-alpha.6",

--- a/modules/webgl/src/adapter/resources/webgl-texture.ts
+++ b/modules/webgl/src/adapter/resources/webgl-texture.ts
@@ -21,7 +21,9 @@ import {
   log
 } from '@luma.gl/core';
 
-import {GLSamplerParameters, GLValueParameters,
+import {
+  GLSamplerParameters,
+  GLValueParameters,
   GL,
   GLTextureTarget,
   GLTextureCubeMapTarget,
@@ -297,7 +299,7 @@ export class WEBGLTexture extends Texture {
     const memoryLayout = this.getMemoryLayout(options);
     const {bytesPerRow, rowsPerImage} = memoryLayout;
 
-    const byteAlignment  = this._getRowByteAlignment(this.format, width)
+    const byteAlignment = this._getRowByteAlignment(this.format, width);
 
     const glParameters: GLValueParameters = !this.compressed
       ? {

--- a/modules/webgl/src/adapter/resources/webgl-texture.ts
+++ b/modules/webgl/src/adapter/resources/webgl-texture.ts
@@ -382,7 +382,6 @@ export class WEBGLTexture extends Texture {
     // const components = glFormatToComponents(this.glFormat);
     // TODO - check for composite type (components = 1).
 
-    debugger;
     const targetArray = new ArrayType(memoryLayout.byteLength) as
       | Uint8Array
       | Uint16Array

--- a/modules/webgpu/package.json
+++ b/modules/webgpu/package.json
@@ -37,7 +37,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "9.2.0-alpha.1"
+    "@luma.gl/core": "9.2.0-alpha.6"
   },
   "dependencies": {
     "@probe.gl/env": "^4.0.8",

--- a/modules/webgpu/src/adapter/resources/webgpu-texture.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-texture.ts
@@ -1,17 +1,25 @@
 // luma.gl, MIT license
-import type {
-  TextureProps,
-  TextureViewProps,
-  CopyExternalImageOptions,
-  CopyImageDataOptions,
-  SamplerProps
+import {
+  type TextureFormat,
+  type TextureProps,
+  type TextureViewProps,
+  type CopyExternalImageOptions,
+  type CopyImageDataOptions,
+  type TextureReadOptions,
+  type TextureWriteOptions,
+  type SamplerProps,
+  Buffer,
+  Texture,
+  getTextureMemoryLayout,
+  log
 } from '@luma.gl/core';
-import {Texture, log} from '@luma.gl/core';
 
 import {getWebGPUTextureFormat} from '../helpers/convert-texture-format';
 import type {WebGPUDevice} from '../webgpu-device';
 import {WebGPUSampler} from './webgpu-sampler';
 import {WebGPUTextureView} from './webgpu-texture-view';
+
+// Move to core/texture
 
 export class WebGPUTexture extends Texture {
   readonly device: WebGPUDevice;
@@ -90,6 +98,38 @@ export class WebGPUTexture extends Texture {
     return new WebGPUTextureView(this.device, {...props, texture: this});
   }
 
+  copyExternalImage(options_: CopyExternalImageOptions): {width: number; height: number} {
+    const options = this._normalizeCopyExternalImageOptions(options_);
+
+    this.device.pushErrorScope('validation');
+    this.device.handle.queue.copyExternalImageToTexture(
+      // source: GPUImageCopyExternalImage
+      {
+        source: options.image,
+        origin: [options.sourceX, options.sourceY],
+        flipY: options.flipY
+      },
+      // destination: GPUImageCopyTextureTagged
+      {
+        texture: this.handle,
+        origin: [options.x, options.y, options.depth],
+        mipLevel: options.mipLevel,
+        aspect: options.aspect,
+        colorSpace: options.colorSpace,
+        premultipliedAlpha: options.premultipliedAlpha
+      },
+      // copySize: GPUExtent3D
+      [options.width, options.height, 0] // options.depth
+    );
+    this.device.popErrorScope((error: GPUError) => {
+      this.device.reportError(new Error(`copyExternalImage: ${error.message}`), this)();
+      this.device.debug();
+    });
+
+    // TODO - should these be clipped to the texture size minus x,y,z?
+    return {width: options.width, height: options.height};
+  }
+
   copyImageData(options_: CopyImageDataOptions): void {
     const {width, height, depth} = this;
     const options = this._normalizeCopyImageDataOptions(options_);
@@ -121,108 +161,190 @@ export class WebGPUTexture extends Texture {
     });
   }
 
-  copyExternalImage(options_: CopyExternalImageOptions): {width: number; height: number} {
-    const options = this._normalizeCopyExternalImageOptions(options_);
-
-    this.device.pushErrorScope('validation');
-    this.device.handle.queue.copyExternalImageToTexture(
-      // source: GPUImageCopyExternalImage
-      {
-        source: options.image,
-        origin: [options.sourceX, options.sourceY],
-        flipY: options.flipY
-      },
-      // destination: GPUImageCopyTextureTagged
-      {
-        texture: this.handle,
-        origin: [options.x, options.y, 0], // options.depth],
-        mipLevel: options.mipLevel,
-        aspect: options.aspect,
-        colorSpace: options.colorSpace,
-        premultipliedAlpha: options.premultipliedAlpha
-      },
-      // copySize: GPUExtent3D
-      [options.width, options.height, 1]
-    );
-    this.device.popErrorScope((error: GPUError) => {
-      this.device.reportError(new Error(`copyExternalImage: ${error.message}`), this)();
-      this.device.debug();
-    });
-
-    // TODO - should these be clipped to the texture size minus x,y,z?
-    return {width: options.width, height: options.height};
-  }
-
   override generateMipmapsWebGL(): void {
     log.warn(`${this}: generateMipmaps not supported in WebGPU`)();
   }
 
-  // WebGPU specific
-
-  /*
-  async readPixels() {
-    const readbackBuffer = device.createBuffer({
-        usage: Buffer.COPY_DST | Buffer.MAP_READ,
-        size: 4 * textureWidth * textureHeight,
-    });
-
-    // Copy data from the texture to the buffer.
-    const encoder = device.createCommandEncoder();
-    encoder.copyTextureToBuffer(
-        { texture },
-        { buffer, rowPitch: textureWidth * 4 },
-        [textureWidth, textureHeight],
-    );
-    device.submit([encoder.finish()]);
-
-    // Get the data on the CPU.
-    await buffer.mapAndReadAsync(GPUMapMode.READ);
-    saveScreenshot(buffer.getMappedRange());
-    buffer.unmap();
+  override _getRowByteAlignment(format: TextureFormat): number {
+    // WebGPU requires row width to be a multiple of 256 bytes
+    return 256;
   }
 
-  setImageData(imageData, usage): this {
-    let data = null;
-
-    const bytesPerRow = Math.ceil((img.width * 4) / 256) * 256;
-    if (bytesPerRow == img.width * 4) {
-      data = imageData.data;
-    } else {
-      data = new Uint8Array(bytesPerRow * img.height);
-      let imagePixelIndex = 0;
-      for (let y = 0; y < img.height; ++y) {
-        for (let x = 0; x < img.width; ++x) {
-          const i = x * 4 + y * bytesPerRow;
-          data[i] = imageData.data[imagePixelIndex];
-          data[i + 1] = imageData.data[imagePixelIndex + 1];
-          data[i + 2] = imageData.data[imagePixelIndex + 2];
-          data[i + 3] = imageData.data[imagePixelIndex + 3];
-          imagePixelIndex += 4;
-        }
-      }
-    }
-    return this;
+  getImageDataLayout(options: TextureReadOptions): {
+    byteLength: number;
+    bytesPerRow: number;
+    rowsPerImage: number;
+  } {
+    return {
+      byteLength: 0,
+      bytesPerRow: 0,
+      rowsPerImage: 0
+    };
   }
 
-  setBuffer(textureDataBuffer, {bytesPerRow}): this {
-    const commandEncoder = this.device.handle.createCommandEncoder();
-    commandEncoder.copyBufferToTexture(
+  override readBuffer(options: TextureReadOptions = {}, buffer?: Buffer): Buffer {
+    const {
+      x = 0,
+      y = 0,
+      z = 0,
+      width = this.width,
+      height = this.height,
+      depthOrArrayLayers = this.depth,
+      mipLevel = 0,
+      aspect = 'all'
+    } = options;
+
+    const layout = this.getMemoryLayout(options);
+
+    const {bytesPerRow, rowsPerImage, byteLength} = layout;
+
+    // Create a GPUBuffer to hold the copied pixel data.
+    const readBuffer =
+      buffer ||
+      this.device.createBuffer({
+        byteLength,
+        usage: Buffer.COPY_DST | Buffer.MAP_READ
+      });
+    const gpuReadBuffer = readBuffer.handle as GPUBuffer;
+
+    // Record commands to copy from the texture to the buffer.
+    const gpuDevice = this.device.handle;
+
+    this.device.pushErrorScope('validation');
+    const commandEncoder = gpuDevice.createCommandEncoder();
+    commandEncoder.copyTextureToBuffer(
+      // source
       {
-        buffer: textureDataBuffer,
-        bytesPerRow
+        texture: this.handle,
+        origin: {x, y, z},
+        // origin: [options.x, options.y, 0], // options.depth],
+        mipLevel,
+        aspect,
+        // colorSpace: options.colorSpace,
+        // premultipliedAlpha: options.premultipliedAlpha
       },
+      // destination
       {
-        texture: this.handle
+        buffer: gpuReadBuffer,
+        offset: 0,
+        bytesPerRow,
+        rowsPerImage
       },
+      // copy size
       {
         width,
         height,
-        depth
+        depthOrArrayLayers
       }
     );
 
-    this.device.handle.defaultQueue.submit([commandEncoder.finish()]);
-    return this;
+    // Submit the command.
+    const commandBuffer = commandEncoder.finish();
+    this.device.handle.queue.submit([commandBuffer]);
+    this.device.popErrorScope((error: GPUError) => {
+      this.device.reportError(new Error(`${this} readBuffer: ${error.message}`), this)();
+      this.device.debug();
+    });
+
+    return readBuffer;
   }
-  */
+
+  override async readDataAsync(options: TextureReadOptions = {}): Promise<ArrayBuffer> {
+    const buffer = this.readBuffer(options);
+    const data = await buffer.readAsync();
+    buffer.destroy();
+    return data.buffer as ArrayBuffer;
+  }
+
+  override writeBuffer(buffer: Buffer, options: TextureWriteOptions = {}) {
+    const {
+      x = 0,
+      y = 0,
+      z = 0,
+      width = this.width,
+      height = this.height,
+      depthOrArrayLayers = this.depth,
+      mipLevel = 0,
+      aspect = 'all'
+    } = options;
+
+    const layout = this.getMemoryLayout(options);
+
+    // Get the data on the CPU.
+    // await buffer.mapAndReadAsync();
+  
+    const {bytesPerRow, rowsPerImage} = layout;
+
+    const gpuDevice = this.device.handle;
+
+    this.device.pushErrorScope('validation');
+    const commandEncoder = gpuDevice.createCommandEncoder();
+    commandEncoder.copyBufferToTexture(
+      {
+        buffer: buffer.handle as GPUBuffer,
+        offset: 0,
+        bytesPerRow,
+        rowsPerImage
+      },
+      {
+        texture: this.handle,
+        origin: {x, y, z},
+        mipLevel,
+        aspect
+      },
+      {width, height, depthOrArrayLayers}
+    );
+    const commandBuffer = commandEncoder.finish();
+    this.device.handle.queue.submit([commandBuffer]);
+    this.device.popErrorScope((error: GPUError) => {
+      this.device.reportError(new Error(`${this} writeBuffer: ${error.message}`), this)();
+      this.device.debug();
+    });
+  }
+
+  override writeData(data: ArrayBuffer | ArrayBufferView, options: TextureWriteOptions = {}): void {
+    const device = this.device;
+
+    const {
+      x = 0,
+      y = 0,
+      z = 0,
+      width = this.width,
+      height = this.height,
+      depthOrArrayLayers = this.depth,
+      mipLevel = 0,
+      aspect = 'all'
+    } = options;
+
+    const layout = getTextureMemoryLayout({
+      textureWidth: this.width,
+      rows: this.height,
+      bytesPerPixel: 4,
+      depthOrArrayLayers: this.depth,
+      byteAlignment: this._getRowByteAlignment(this.format),
+    });
+
+    const {bytesPerRow, rowsPerImage} = layout;
+
+    this.device.pushErrorScope('validation');
+    device.handle.queue.writeTexture(
+      {
+        texture: this.handle,
+        mipLevel,
+        aspect,
+        origin: {x, y, z}
+      },
+      data,
+      {
+        offset: 0,
+        bytesPerRow,
+        rowsPerImage
+      },
+      {width, height, depthOrArrayLayers}
+    );
+    this.device.popErrorScope((error: GPUError) => {
+      this.device.reportError(new Error(`${this} writeData: ${error.message}`), this)();
+      this.device.debug();
+    });
+  }
 }

--- a/modules/webgpu/src/adapter/resources/webgpu-texture.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-texture.ts
@@ -219,7 +219,7 @@ export class WebGPUTexture extends Texture {
         origin: {x, y, z},
         // origin: [options.x, options.y, 0], // options.depth],
         mipLevel,
-        aspect,
+        aspect
         // colorSpace: options.colorSpace,
         // premultipliedAlpha: options.premultipliedAlpha
       },
@@ -272,7 +272,7 @@ export class WebGPUTexture extends Texture {
 
     // Get the data on the CPU.
     // await buffer.mapAndReadAsync();
-  
+
     const {bytesPerRow, rowsPerImage} = layout;
 
     const gpuDevice = this.device.handle;
@@ -321,7 +321,7 @@ export class WebGPUTexture extends Texture {
       rows: this.height,
       bytesPerPixel: 4,
       depthOrArrayLayers: this.depth,
-      byteAlignment: this._getRowByteAlignment(this.format),
+      byteAlignment: this._getRowByteAlignment(this.format)
     });
 
     const {bytesPerRow, rowsPerImage} = layout;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1366,7 +1366,7 @@ __metadata:
     "@math.gl/core": "npm:^4.1.0"
     "@math.gl/types": "npm:^4.1.0"
   peerDependencies:
-    "@luma.gl/shadertools": 9.2.0-alpha.1
+    "@luma.gl/shadertools": 9.2.0-alpha.6
   languageName: unknown
   linkType: soft
 
@@ -1379,8 +1379,8 @@ __metadata:
     "@probe.gl/log": "npm:^4.0.8"
     "@probe.gl/stats": "npm:^4.0.8"
   peerDependencies:
-    "@luma.gl/core": 9.2.0-alpha.1
-    "@luma.gl/shadertools": 9.2.0-alpha.1
+    "@luma.gl/core": 9.2.0-alpha.6
+    "@luma.gl/shadertools": 9.2.0-alpha.6
   languageName: unknown
   linkType: soft
 
@@ -1404,10 +1404,10 @@ __metadata:
     "@loaders.gl/textures": "npm:^4.2.0"
     "@math.gl/core": "npm:^4.1.0"
   peerDependencies:
-    "@luma.gl/constants": 9.2.0-alpha.1
-    "@luma.gl/core": 9.2.0-alpha.1
-    "@luma.gl/engine": 9.2.0-alpha.1
-    "@luma.gl/shadertools": 9.2.0-alpha.1
+    "@luma.gl/constants": 9.2.0-alpha.6
+    "@luma.gl/core": 9.2.0-alpha.6
+    "@luma.gl/engine": 9.2.0-alpha.6
+    "@luma.gl/shadertools": 9.2.0-alpha.6
   languageName: unknown
   linkType: soft
 
@@ -1419,7 +1419,7 @@ __metadata:
     "@math.gl/types": "npm:^4.1.0"
     wgsl_reflect: "npm:^1.2.1"
   peerDependencies:
-    "@luma.gl/core": 9.2.0-alpha.1
+    "@luma.gl/core": 9.2.0-alpha.6
   languageName: unknown
   linkType: soft
 
@@ -1430,11 +1430,11 @@ __metadata:
     "@probe.gl/env": "npm:^4.0.8"
     "@probe.gl/stats": "npm:^4.0.8"
   peerDependencies:
-    "@luma.gl/core": 9.2.0-alpha.1
-    "@luma.gl/engine": 9.2.0-alpha.1
-    "@luma.gl/shadertools": 9.2.0-alpha.1
-    "@luma.gl/webgl": 9.2.0-alpha.1
-    "@luma.gl/webgpu": 9.2.0-alpha.1
+    "@luma.gl/core": 9.2.0-alpha.6
+    "@luma.gl/engine": 9.2.0-alpha.6
+    "@luma.gl/shadertools": 9.2.0-alpha.6
+    "@luma.gl/webgl": 9.2.0-alpha.6
+    "@luma.gl/webgpu": 9.2.0-alpha.6
   languageName: unknown
   linkType: soft
 
@@ -1446,7 +1446,7 @@ __metadata:
     "@math.gl/types": "npm:^4.1.0"
     "@probe.gl/env": "npm:^4.0.8"
   peerDependencies:
-    "@luma.gl/core": 9.2.0-alpha.1
+    "@luma.gl/core": 9.2.0-alpha.6
   languageName: unknown
   linkType: soft
 
@@ -1457,7 +1457,7 @@ __metadata:
     "@probe.gl/env": "npm:^4.0.8"
     "@webgpu/types": "npm:^0.1.34"
   peerDependencies:
-    "@luma.gl/core": 9.2.0-alpha.1
+    "@luma.gl/core": 9.2.0-alpha.6
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->

#### Background
- Primary goal is to get WebGPU picking working in deck.gl
- This adds new methods so is safe to land, it does not break existing coe.

#### Change List
- Add new read/write methods to the Texture class hierarchy.
- These methods will be refined in upcoming PRs, with better tests etc.
