### PR TITLE
feat: add new Fence GPU-CPU synchronization primitive

### DIFF
--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -24,6 +24,7 @@ import type {CommandBuffer} from './resources/command-buffer';
 import type {VertexArray, VertexArrayProps} from './resources/vertex-array';
 import type {TransformFeedback, TransformFeedbackProps} from './resources/transform-feedback';
 import type {QuerySet, QuerySetProps} from './resources/query-set';
+import type {Fence} from './resources/fence';
 
 import {getVertexFormatInfo} from '../shadertypes/vertex-arrays/decode-vertex-format';
 import {textureFormatDecoder} from '../shadertypes/textures/texture-format-decoder';
@@ -624,6 +625,11 @@ or create a device with the 'debug: true' prop.`;
   abstract createTransformFeedback(props: TransformFeedbackProps): TransformFeedback;
 
   abstract createQuerySet(props: QuerySetProps): QuerySet;
+
+  /** Create a fence sync object */
+  createFence(): Fence {
+    throw new Error('createFence() not implemented');
+  }
 
   /** Create a RenderPass using the default CommandEncoder */
   beginRenderPass(props?: RenderPassProps): RenderPass {

--- a/modules/core/src/adapter/resources/fence.ts
+++ b/modules/core/src/adapter/resources/fence.ts
@@ -1,0 +1,29 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Device} from '../device';
+import {Resource, type ResourceProps} from './resource';
+
+export type FenceProps = ResourceProps;
+
+/** Synchronization primitive that resolves when GPU work is completed */
+export abstract class Fence extends Resource<FenceProps> {
+  static override defaultProps: Required<FenceProps> = {
+    ...Resource.defaultProps
+  };
+
+  /** Promise that resolves when the fence is signaled */
+  abstract readonly signaled: Promise<void>;
+
+  constructor(device: Device, props: FenceProps = {}) {
+    super(device, props, Fence.defaultProps);
+  }
+
+  /** Check if the fence has been signaled */
+  abstract isSignaled(): boolean;
+
+  /** Destroy the fence and release any resources */
+  abstract override destroy(): void;
+}
+

--- a/modules/core/src/adapter/resources/fence.ts
+++ b/modules/core/src/adapter/resources/fence.ts
@@ -13,6 +13,8 @@ export abstract class Fence extends Resource<FenceProps> {
     ...Resource.defaultProps
   };
 
+  [Symbol.toStringTag]: string = 'WEBGLFence';
+
   /** Promise that resolves when the fence is signaled */
   abstract readonly signaled: Promise<void>;
 
@@ -20,10 +22,9 @@ export abstract class Fence extends Resource<FenceProps> {
     super(device, props, Fence.defaultProps);
   }
 
-  /** Check if the fence has been signaled */
-  abstract isSignaled(): boolean;
-
   /** Destroy the fence and release any resources */
   abstract override destroy(): void;
-}
 
+  /** Check if the fence has been signaled */
+  abstract isSignaled(): boolean;
+}

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -68,6 +68,8 @@ export {TransformFeedback} from './adapter/resources/transform-feedback';
 export type {QuerySetProps} from './adapter/resources/query-set';
 export {QuerySet} from './adapter/resources/query-set';
 
+export {Fence, type FenceProps} from './adapter/resources/fence';
+
 export type {PipelineLayoutProps} from './adapter/resources/pipeline-layout';
 export {PipelineLayout} from './adapter/resources/pipeline-layout';
 

--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -124,7 +124,7 @@ test('Texture#writeData & readDataAsync round-trip for all formats and dimension
         });
 
         const {byteLength, bytesPerRow} = tex.computeMemoryLayout();
-        const ArrayType = getTypedArrayConstructor(info.dataType!);
+        const ArrayType = getTypedArrayConstructor(info.dataType);
         const arraySize = byteLength / ArrayType.BYTES_PER_ELEMENT;
         const input = new ArrayType(arraySize);
         for (let i = 0; i < texSize.height; i++)

--- a/modules/webgl/src/adapter/resources/webgl-fence.ts
+++ b/modules/webgl/src/adapter/resources/webgl-fence.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Fence} from '@luma.gl/core';
+import {Fence, type FenceProps} from '@luma.gl/core';
 import {WebGLDevice} from '../webgl-device';
 
 /** WebGL fence implemented with gl.fenceSync */
@@ -13,11 +13,12 @@ export class WEBGLFence extends Fence {
   readonly signaled: Promise<void>;
   private _signaled = false;
 
-  constructor(device: WebGLDevice) {
+  constructor(device: WebGLDevice, props: FenceProps = {}) {
     super(device, {});
     this.device = device;
     this.gl = device.gl;
-    const sync = this.gl.fenceSync(this.gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
+
+    const sync = this.props.handle || this.gl.fenceSync(this.gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
     if (!sync) {
       throw new Error('Failed to create WebGL fence');
     }
@@ -46,11 +47,9 @@ export class WEBGLFence extends Fence {
     return this._signaled;
   }
 
-  override destroy(): void {
+  destroy(): void {
     if (!this.destroyed) {
       this.gl.deleteSync(this.handle);
-      super.destroy();
     }
   }
 }
-

--- a/modules/webgl/src/adapter/resources/webgl-fence.ts
+++ b/modules/webgl/src/adapter/resources/webgl-fence.ts
@@ -1,0 +1,56 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Fence} from '@luma.gl/core';
+import {WebGLDevice} from '../webgl-device';
+
+/** WebGL fence implemented with gl.fenceSync */
+export class WEBGLFence extends Fence {
+  readonly device: WebGLDevice;
+  readonly gl: WebGL2RenderingContext;
+  readonly handle: WebGLSync;
+  readonly signaled: Promise<void>;
+  private _signaled = false;
+
+  constructor(device: WebGLDevice) {
+    super(device, {});
+    this.device = device;
+    this.gl = device.gl;
+    const sync = this.gl.fenceSync(this.gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
+    if (!sync) {
+      throw new Error('Failed to create WebGL fence');
+    }
+    this.handle = sync;
+
+    this.signaled = new Promise(resolve => {
+      const poll = () => {
+        const status = this.gl.clientWaitSync(this.handle, 0, 0);
+        if (status === this.gl.ALREADY_SIGNALED || status === this.gl.CONDITION_SATISFIED) {
+          this._signaled = true;
+          resolve();
+        } else {
+          setTimeout(poll, 1);
+        }
+      };
+      poll();
+    });
+  }
+
+  isSignaled(): boolean {
+    if (this._signaled) {
+      return true;
+    }
+    const status = this.gl.getSyncParameter(this.handle, this.gl.SYNC_STATUS);
+    this._signaled = status === this.gl.SIGNALED;
+    return this._signaled;
+  }
+
+  override destroy(): void {
+    if (!this.destroyed) {
+      this.gl.deleteSync(this.handle);
+      super.destroy();
+    }
+  }
+}
+

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -57,6 +57,7 @@ import {WEBGLCommandBuffer} from './resources/webgl-command-buffer';
 import {WEBGLVertexArray} from './resources/webgl-vertex-array';
 import {WEBGLTransformFeedback} from './resources/webgl-transform-feedback';
 import {WEBGLQuerySet} from './resources/webgl-query-set';
+import {WEBGLFence} from './resources/webgl-fence';
 
 import {readPixelsToArray, readPixelsToBuffer} from './helpers/webgl-texture-utils';
 import {
@@ -312,6 +313,10 @@ export class WebGLDevice extends Device {
 
   createQuerySet(props: QuerySetProps): WEBGLQuerySet {
     return new WEBGLQuerySet(this, props);
+  }
+
+  override createFence(): WEBGLFence {
+    return new WEBGLFence(this);
   }
 
   createRenderPipeline(props: RenderPipelineProps): WEBGLRenderPipeline {

--- a/modules/webgl/src/index.ts
+++ b/modules/webgl/src/index.ts
@@ -26,6 +26,7 @@ export {WEBGLTexture} from './adapter/resources/webgl-texture';
 export {WEBGLShader} from './adapter/resources/webgl-shader';
 export {WEBGLSampler} from './adapter/resources/webgl-sampler';
 export {WEBGLFramebuffer} from './adapter/resources/webgl-framebuffer';
+export {WEBGLFence} from './adapter/resources/webgl-fence';
 
 export {WEBGLRenderPipeline} from './adapter/resources/webgl-render-pipeline';
 // export {WEBGLComputePipeline} from './adapter/resources/webgl-compute-pipeline';

--- a/modules/webgpu/src/adapter/resources/webgpu-fence.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-fence.ts
@@ -28,4 +28,3 @@ export class WebGPUFence extends Fence {
     // Nothing to release for WebGPU fence
   }
 }
-

--- a/modules/webgpu/src/adapter/resources/webgpu-fence.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-fence.ts
@@ -1,0 +1,32 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Fence} from '@luma.gl/core';
+import {WebGPUDevice} from '../webgpu-device';
+
+/** WebGPU fence implemented by waiting for submitted work */
+export class WebGPUFence extends Fence {
+  readonly device: WebGPUDevice;
+  readonly handle: null = null;
+  readonly signaled: Promise<void>;
+  private _signaled = false;
+
+  constructor(device: WebGPUDevice) {
+    super(device, {});
+    this.device = device;
+    this.signaled = device.handle.queue.onSubmittedWorkDone().then(() => {
+      this._signaled = true;
+    });
+  }
+
+  isSignaled(): boolean {
+    return this._signaled;
+  }
+
+  override destroy(): void {
+    // Nothing to release for WebGPU fence
+    super.destroy();
+  }
+}
+

--- a/modules/webgpu/src/adapter/resources/webgpu-fence.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-fence.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Fence} from '@luma.gl/core';
+import {Fence, type FenceProps} from '@luma.gl/core';
 import {WebGPUDevice} from '../webgpu-device';
 
 /** WebGPU fence implemented by waiting for submitted work */
@@ -12,7 +12,7 @@ export class WebGPUFence extends Fence {
   readonly signaled: Promise<void>;
   private _signaled = false;
 
-  constructor(device: WebGPUDevice) {
+  constructor(device: WebGPUDevice, props: FenceProps = {}) {
     super(device, {});
     this.device = device;
     this.signaled = device.handle.queue.onSubmittedWorkDone().then(() => {
@@ -26,7 +26,6 @@ export class WebGPUFence extends Fence {
 
   override destroy(): void {
     // Nothing to release for WebGPU fence
-    super.destroy();
   }
 }
 

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -45,6 +45,7 @@ import {WebGPUCommandEncoder} from './resources/webgpu-command-encoder';
 import {WebGPUCommandBuffer} from './resources/webgpu-command-buffer';
 import {WebGPUQuerySet} from './resources/webgpu-query-set';
 import {WebGPUPipelineLayout} from './resources/webgpu-pipeline-layout';
+import {WebGPUFence} from './resources/webgpu-fence';
 
 import {getShaderLayoutFromWGSL} from '../wgsl/get-shader-layout-wgsl';
 
@@ -196,6 +197,10 @@ export class WebGPUDevice extends Device {
 
   override createQuerySet(props: QuerySetProps): QuerySet {
     return new WebGPUQuerySet(this, props);
+  }
+
+  override createFence(): WebGPUFence {
+    return new WebGPUFence(this);
   }
 
   createCanvasContext(props: CanvasContextProps): WebGPUCanvasContext {

--- a/modules/webgpu/src/index.ts
+++ b/modules/webgpu/src/index.ts
@@ -12,5 +12,6 @@ export {WebGPUBuffer} from './adapter/resources/webgpu-buffer';
 export {WebGPUTexture} from './adapter/resources/webgpu-texture';
 export {WebGPUSampler} from './adapter/resources/webgpu-sampler';
 export {WebGPUShader} from './adapter/resources/webgpu-shader';
+export {WebGPUFence} from './adapter/resources/webgpu-fence';
 
 export {getShaderLayoutFromWGSL} from './wgsl/get-shader-layout-wgsl';


### PR DESCRIPTION
## Summary

- add Fence resource and device.createFence API
- implement WebGL and WebGPU fence wrappers

- A GPU `Fence` allows us to wait for GPU queue to reach a certain point, for example a buffer write, before we do a sync read of the buffer on WebGL.
- This can potentially speed up picking on WebGL.

- Docs are coming in separate PR https://github.com/visgl/luma.gl/pull/2421

## Testing
- `yarn test` *(fails: error while loading shared libraries: libXfixes.so.3)*

------
https://chatgpt.com/codex/tasks/task_e_689a74d7a554832890e08e7c1523e898