### PR TITLE
test: add fence resource tests

### DIFF
--- a/modules/core/test/adapter/resources/fence.spec.ts
+++ b/modules/core/test/adapter/resources/fence.spec.ts
@@ -1,0 +1,29 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'tape-promise/tape';
+import {getTestDevices} from '@luma.gl/test-utils';
+import {Fence} from '@luma.gl/core';
+
+// Test basic fence functionality across supported devices
+
+// Only WebGL and WebGPU devices implement fences
+const DEVICE_TYPES = ['webgl', 'webgpu'] as const;
+
+test('Fence#signaled/destroy', async t => {
+  for (const device of await getTestDevices(DEVICE_TYPES)) {
+    const fence = device.createFence();
+    t.ok(fence instanceof Fence, `${device.type} Fence construction successful`);
+
+    await fence.signaled;
+    t.ok(fence.isSignaled(), `${device.type} Fence signals`);
+
+    fence.destroy();
+    t.pass(`${device.type} Fence destroy successful`);
+
+    fence.destroy();
+    t.pass(`${device.type} Fence repeated destroy successful`);
+  }
+  t.end();
+});

--- a/modules/core/test/index.ts
+++ b/modules/core/test/index.ts
@@ -43,6 +43,7 @@ import './adapter/resources/texture.spec';
 import './adapter/resources/framebuffer.spec';
 import './adapter/resources/vertex-array.spec';
 import './adapter/resources/query-set.spec';
+import './adapter/resources/fence.spec';
 
 // portable - uniform buffers
 import './portable/uniform-buffer-layout.spec';


### PR DESCRIPTION
## Summary
- add fence resource tests covering signaled behavior and destruction
- include fence tests in core test index

## Testing
- `npx eslint modules/core/test/adapter/resources/fence.spec.ts modules/core/test/index.ts`
- `npx ocular-test browser-headless` *(fails: Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_689a802840bc8328bc7682c8affc7436