### PR TITLE
fix(webgpu): Extract texture dim,sampleType,multisample from WGSL declarations

### DIFF
--- a/examples/api/cubemap/app.ts
+++ b/examples/api/cubemap/app.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Device, NumberArray3, NumberArray16} from '@luma.gl/core';
+import {NumberArray3, NumberArray16} from '@math.gl/types';
+import {Device} from '@luma.gl/core';
 import {
   AnimationLoopTemplate,
   AnimationProps,
@@ -30,7 +31,7 @@ const app: ShaderModule<AppUniforms, AppUniforms> = {
   uniformTypes: {
     modelMatrix: 'mat4x4<f32>',
     viewMatrix: 'mat4x4<f32>',
-    projectionMatrix: 'vec3<f32>',
+    projectionMatrix: 'mat4x4<f32>',
     eyePosition: 'vec3<f32>'
   }
 };

--- a/examples/api/cubemap/package.json
+++ b/examples/api/cubemap/package.json
@@ -14,7 +14,8 @@
     "@luma.gl/shadertools": "9.2.0-alpha.6",
     "@luma.gl/webgl": "9.2.0-alpha.6",
     "@luma.gl/webgpu": "9.2.0-alpha.6",
-    "@math.gl/core": "^4.1.0"
+    "@math.gl/core": "^4.1.0",
+    "@math.gl/types": "^4.1.0"
   },
   "devDependencies": {
     "typescript": "^5.5.0",

--- a/modules/webgpu/test/wgsl/get-shader-layout-wgsl.spec.ts
+++ b/modules/webgpu/test/wgsl/get-shader-layout-wgsl.spec.ts
@@ -140,7 +140,7 @@ TEST_CASES.push({
   }
 });
 
-test.only('WebGPU#getShaderLayoutFromWGSL', t => {
+test('WebGPU#getShaderLayoutFromWGSL', t => {
   for (const tc of TEST_CASES) {
     const shaderLayout = getShaderLayoutFromWGSL(tc.wgsl);
     t.deepEqual(shaderLayout, tc.shaderLayout, `correct ShaderLayout parsed ${tc.title || ''}`);

--- a/modules/webgpu/test/wgsl/get-shader-layout-wgsl.spec.ts
+++ b/modules/webgpu/test/wgsl/get-shader-layout-wgsl.spec.ts
@@ -80,7 +80,67 @@ const TEST_CASES: {title?: string; wgsl: string; shaderLayout: ShaderLayout}[] =
   }
 ];
 
-test('WebGPU#getShaderLayoutFromWGSL', t => {
+// ...existing code...
+
+const TEXTURE_SHADER = /* WGSL */ `\
+@group(0) @binding(1) var myTexture: texture_2d<f32>;
+@group(0) @binding(2) var mySampler: sampler;
+@group(0) @binding(3) var myDepthTexture: texture_depth_2d;
+@group(0) @binding(4) var myMultisampledTexture: texture_multisampled_2d<f32>;
+
+@fragment
+fn main(
+  @location(0) fragUV: vec2<f32>
+) -> @location(0) vec4<f32> {
+  // Dummy usage
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+`;
+
+TEST_CASES.push({
+  title: 'texture bindings',
+  wgsl: TEXTURE_SHADER,
+  shaderLayout: {
+    attributes: [],
+    bindings: [
+      {
+        type: 'texture',
+        name: 'myTexture',
+        group: 0,
+        location: 1,
+        viewDimension: '2d',
+        sampleType: 'float',
+        multisampled: false
+      },
+      {
+        type: 'texture',
+        name: 'myDepthTexture',
+        group: 0,
+        location: 3,
+        viewDimension: '2d',
+        sampleType: 'depth',
+        multisampled: false
+      },
+      {
+        type: 'texture',
+        name: 'myMultisampledTexture',
+        group: 0,
+        location: 4,
+        viewDimension: '2d',
+        sampleType: 'float',
+        multisampled: true
+      },
+      {
+        type: 'sampler',
+        name: 'mySampler',
+        group: 0,
+        location: 2
+      }
+    ]
+  }
+});
+
+test.only('WebGPU#getShaderLayoutFromWGSL', t => {
   for (const tc of TEST_CASES) {
     const shaderLayout = getShaderLayoutFromWGSL(tc.wgsl);
     t.deepEqual(shaderLayout, tc.shaderLayout, `correct ShaderLayout parsed ${tc.title || ''}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7948,6 +7948,7 @@ __metadata:
     "@luma.gl/webgl": "npm:9.2.0-alpha.6"
     "@luma.gl/webgpu": "npm:9.2.0-alpha.6"
     "@math.gl/core": "npm:^4.1.0"
+    "@math.gl/types": "npm:^4.1.0"
     typescript: "npm:^5.5.0"
     vite: "npm:^5.0.0"
   languageName: unknown


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background

- cube texture example threw exception under WebGPU since the texture dimension wasn't provided when setting up the bind group.

#### Change List
- extract the required params from wgsl_reflect data
- test
