### PR TITLE
feat(core): Fix flicker when resizing CanvasContext

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -33,7 +33,7 @@ v9.2 brings full WebGPU support. Some additional deprecations and breaking chang
 - `canvasContext.devicePixelWidth` and `canvasContext.devicePixelHeight` are now kept updated to exact device pixel size of underlying canvas. 
 - Instead `canvasContext.setDrawingBufferSize()` to explicitly control drawing buffer size, if not using `CanvasContextProps.autoResize` 
 - A new `DeviceProps.onResize` callback can be used to react to changes.
-- `CanvasContextProps.useDevicePixelRatio` no longer accepts `number`s, just a `boolean` value. 
+- Drawing buffer resize (canvas.style.width.height changes) are deferred till render to avoid flicker.
 
 **Minor changes**
 - `core`: The shader types has been refactored, some shader type names have changed. These are typically not used directly by applications.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -33,7 +33,6 @@ v9.2 brings full WebGPU support. Some additional deprecations and breaking chang
 - `canvasContext.devicePixelWidth` and `canvasContext.devicePixelHeight` are now kept updated to exact device pixel size of underlying canvas. 
 - Instead `canvasContext.setDrawingBufferSize()` to explicitly control drawing buffer size, if not using `CanvasContextProps.autoResize` 
 - A new `DeviceProps.onResize` callback can be used to react to changes.
-- Drawing buffer resize (canvas.style.width.height changes) are deferred till render to avoid flicker.
 
 **Minor changes**
 - `core`: The shader types has been refactored, some shader type names have changed. These are typically not used directly by applications.

--- a/modules/core/test/adapter/canvas-context.spec.ts
+++ b/modules/core/test/adapter/canvas-context.spec.ts
@@ -24,7 +24,7 @@ class TestCanvasContext extends CanvasContext {
     throw new Error('test');
   }
   updateSize() {}
-  protected override _updateDevice(): void {
+  protected override _configureDevice(): void {
     // Mock update device
   }
 }

--- a/modules/gltf/src/parsers/parse-gltf-lights.ts
+++ b/modules/gltf/src/parsers/parse-gltf-lights.ts
@@ -14,10 +14,12 @@ export function parseGLTFLights(gltf: GLTFPostprocessed): Light[] {
   for (const node of gltf.nodes || []) {
     const nodeLight = node.extensions?.KHR_lights_punctual;
     if (!nodeLight || typeof nodeLight.light !== 'number') {
+      // eslint-disable-next-line no-continue
       continue;
     }
     const gltfLight = lightDefs[nodeLight.light];
     if (!gltfLight) {
+      // eslint-disable-next-line no-continue
       continue;
     }
 

--- a/modules/test-utils/src/null-device/null-canvas-context.ts
+++ b/modules/test-utils/src/null-device/null-canvas-context.ts
@@ -31,7 +31,7 @@ export class NullCanvasContext extends CanvasContext {
     this._updateDevice();
   }
 
-  getCurrentFramebuffer(): NullFramebuffer {
+  _getCurrentFramebuffer(): NullFramebuffer {
     // Setting handle to null returns a reference to the default framebuffer
     this._framebuffer = this._framebuffer || new NullFramebuffer(this.device, {handle: null});
     return this._framebuffer;

--- a/modules/test-utils/src/null-device/null-canvas-context.ts
+++ b/modules/test-utils/src/null-device/null-canvas-context.ts
@@ -28,7 +28,7 @@ export class NullCanvasContext extends CanvasContext {
 
     // Base class constructor cannot access derived methods/fields, so we need to call these functions in the subclass constructor
     this._setAutoCreatedCanvasId(`${this.device.id}-canvas`);
-    this._updateDevice();
+    this._configureDevice();
   }
 
   _getCurrentFramebuffer(): NullFramebuffer {
@@ -37,5 +37,5 @@ export class NullCanvasContext extends CanvasContext {
     return this._framebuffer;
   }
 
-  _updateDevice() {}
+  _configureDevice() {}
 }

--- a/modules/webgl/src/adapter/webgl-canvas-context.ts
+++ b/modules/webgl/src/adapter/webgl-canvas-context.ts
@@ -30,7 +30,7 @@ export class WebGLCanvasContext extends CanvasContext {
     this._updateDevice();
   }
 
-  getCurrentFramebuffer(): WEBGLFramebuffer {
+  _getCurrentFramebuffer(): WEBGLFramebuffer {
     // Setting handle to null returns a reference to the default framebuffer
     this._framebuffer = this._framebuffer || new WEBGLFramebuffer(this.device, {handle: null});
     return this._framebuffer;

--- a/modules/webgl/src/adapter/webgl-canvas-context.ts
+++ b/modules/webgl/src/adapter/webgl-canvas-context.ts
@@ -27,16 +27,16 @@ export class WebGLCanvasContext extends CanvasContext {
 
     // Base class constructor cannot access derived methods/fields, so we need to call these functions in the subclass constructor
     this._setAutoCreatedCanvasId(`${this.device.id}-canvas`);
-    this._updateDevice();
+    this._configureDevice();
   }
+
+  // IMPLEMENTATION OF ABSTRACT METHODS
+
+  _configureDevice(): void {}
 
   _getCurrentFramebuffer(): WEBGLFramebuffer {
     // Setting handle to null returns a reference to the default framebuffer
     this._framebuffer = this._framebuffer || new WEBGLFramebuffer(this.device, {handle: null});
     return this._framebuffer;
   }
-
-  // IMPLEMENTATION OF ABSTRACT METHODS
-
-  _updateDevice(): void {}
 }

--- a/modules/webgpu/src/adapter/webgpu-canvas-context.ts
+++ b/modules/webgpu/src/adapter/webgpu-canvas-context.ts
@@ -48,13 +48,13 @@ export class WebGPUCanvasContext extends CanvasContext {
   }
 
   /** Update framebuffer with properly resized "swap chain" texture views */
-  getCurrentFramebuffer(
+  _getCurrentFramebuffer(
     options: {depthStencilFormat?: TextureFormatDepthStencil | false} = {
       depthStencilFormat: 'depth24plus'
     }
   ): WebGPUFramebuffer {
     // Wrap the current canvas context texture in a luma.gl texture
-    const currentColorAttachment = this.getCurrentTexture();
+    const currentColorAttachment = this._getCurrentTexture();
     // TODO - temporary debug code
     if (
       currentColorAttachment.width !== this.drawingBufferWidth ||
@@ -101,7 +101,7 @@ export class WebGPUCanvasContext extends CanvasContext {
   }
 
   /** Wrap the current canvas context texture in a luma.gl texture */
-  getCurrentTexture(): WebGPUTexture {
+  _getCurrentTexture(): WebGPUTexture {
     const handle = this.handle.getCurrentTexture();
     return this.device.createTexture({
       id: `${this.id}#color-texture`,


### PR DESCRIPTION
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
For #
<!-- For other PRs without open issue -->
#### Background

- The advanced pixel perfect canvas size tracking in 9.2 caused a regression in the form of flicker on resize.
- This is because a drawing buffer resize clears the canvas, and also WebGPU reconfigures the context.
- The fix here is to defer the resize until the updated framebuffer is requested, which is typically done in the render loop.

#### Change List

- Add a needsResize flag
- Defer update to getCurrentFramebuffer
- Add "missing" TSDoc comments to CanvasContext fields and methods.
