### PR TITLE
test: add clone and swap framebuffer tests

### DIFF
--- a/modules/core/test/adapter/resources/framebuffer.spec.ts
+++ b/modules/core/test/adapter/resources/framebuffer.spec.ts
@@ -88,6 +88,45 @@ test('WebGLDevice.createFramebuffer()', async t => {
   t.end();
 });
 
+test('Framebuffer#clone overrides size', async t => {
+  for (const device of await getTestDevices()) {
+    const framebuffer = device.createFramebuffer({
+      width: 2,
+      height: 2,
+      colorAttachments: ['rgba8unorm'],
+      depthStencilAttachment: 'depth16unorm'
+    });
+
+    const cloned = framebuffer.clone({width: 4, height: 4});
+
+    t.notEqual(cloned, framebuffer, `${device.type}: clone returns new framebuffer`);
+    t.equal(cloned.width, 4, `${device.type}: cloned width is overridden`);
+    t.equal(cloned.height, 4, `${device.type}: cloned height is overridden`);
+    t.equal(
+      cloned.colorAttachments[0].texture.width,
+      4,
+      `${device.type}: cloned color attachment width overridden`
+    );
+    t.equal(
+      cloned.colorAttachments[0].texture.height,
+      4,
+      `${device.type}: cloned color attachment height overridden`
+    );
+    t.notEqual(
+      cloned.colorAttachments[0].texture,
+      framebuffer.colorAttachments[0].texture,
+      `${device.type}: cloned color attachment is new texture`
+    );
+
+    t.equal(framebuffer.width, 2, `${device.type}: original width unchanged`);
+    t.equal(framebuffer.height, 2, `${device.type}: original height unchanged`);
+
+    framebuffer.destroy();
+    cloned.destroy();
+  }
+  t.end();
+});
+
 test('WebGLFramebuffer create and resize attachments', async t => {
   for (const testDevice of await getTestDevices()) {
     for (const tc of TEST_CASES) {

--- a/modules/core/test/adapter/resources/texture.spec.ts
+++ b/modules/core/test/adapter/resources/texture.spec.ts
@@ -46,6 +46,24 @@ test('Texture#createView returns a TextureView', async t => {
   t.end();
 });
 
+test('Texture#clone overrides size', async t => {
+  for (const device of await getTestDevices()) {
+    const tex = device.createTexture({format: 'rgba8unorm', width: 2, height: 2});
+
+    const cloned = tex.clone({width: 4, height: 4});
+
+    t.notEqual(cloned, tex, `${device.type}: clone returns a new texture`);
+    t.equal(cloned.width, 4, `${device.type}: cloned width is overridden`);
+    t.equal(cloned.height, 4, `${device.type}: cloned height is overridden`);
+    t.equal(tex.width, 2, `${device.type}: original width unchanged`);
+    t.equal(tex.height, 2, `${device.type}: original height unchanged`);
+
+    tex.destroy();
+    cloned.destroy();
+  }
+  t.end();
+});
+
 const RGBA8_DATA = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
 
 test('Texture#copyImageData updates correct cubemap face on WebGL', async t => {

--- a/modules/engine/test/compute/swap.spec.ts
+++ b/modules/engine/test/compute/swap.spec.ts
@@ -1,5 +1,5 @@
 import test from 'tape';
-import {Swap} from '../../src/compute/swap';
+import {Swap, SwapFramebuffers} from '../../src/compute/swap';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 
 // TODO - these tests could run on NullDevice
@@ -46,6 +46,61 @@ test('Swap#swap', async t => {
 
   t.equal(swap.current, next, 'should make the next resource the current resource');
   t.equal(swap.next, current, 'should reuse the current resource as the next resource');
+
+  t.end();
+});
+
+test('SwapFramebuffers#resize', async t => {
+  const webglDevice = await getWebGLTestDevice();
+
+  const swap = new SwapFramebuffers(webglDevice, {
+    colorAttachments: ['rgba8unorm'],
+    width: 4,
+    height: 4
+  });
+
+  const currentTexture = swap.current.colorAttachments[0].texture;
+  const nextTexture = swap.next.colorAttachments[0].texture;
+
+  let resized = swap.resize({width: 4, height: 4});
+  t.equal(resized, false, 'resize with same size returns false');
+  t.equal(
+    swap.current.colorAttachments[0].texture,
+    currentTexture,
+    'current framebuffer texture unchanged'
+  );
+  t.equal(
+    swap.next.colorAttachments[0].texture,
+    nextTexture,
+    'next framebuffer texture unchanged'
+  );
+
+  resized = swap.resize({width: 8, height: 8});
+  t.equal(resized, true, 'resize with new size returns true');
+  t.equal(swap.current.width, 8, 'current framebuffer width updated');
+  t.equal(swap.current.height, 8, 'current framebuffer height updated');
+  t.notEqual(
+    swap.current.colorAttachments[0].texture,
+    currentTexture,
+    'current framebuffer texture replaced after resize'
+  );
+
+  const newCurrent = swap.current.colorAttachments[0].texture;
+  const newNext = swap.next.colorAttachments[0].texture;
+  resized = swap.resize({width: 8, height: 8});
+  t.equal(resized, false, 'resize with same size again returns false');
+  t.equal(
+    swap.current.colorAttachments[0].texture,
+    newCurrent,
+    'current framebuffer texture unchanged after no-op'
+  );
+  t.equal(
+    swap.next.colorAttachments[0].texture,
+    newNext,
+    'next framebuffer texture unchanged after no-op'
+  );
+
+  swap.destroy();
 
   t.end();
 });


### PR DESCRIPTION
## Summary
- add tests verifying texture.clone honors overridden size
- add framebuffer.clone test ensuring new attachments and size update
- add swapFramebuffers.resize test checking no-op on identical size

## Testing
- `yarn test node`
- `yarn test-fast` *(fails: Unable to resolve path to module '@luma.gl/core' and related lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a863379fa88328b629b2bc448381bb