### PR TITLE
Track glTF updates under new 9.3 section

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -43,8 +43,9 @@ It is considered a foundational framework in the [deck.gl ecosystem](https://www
 
 &nbsp;
 
-This documentation describes luma.gl **v9.1**. See our [**release notes**](/docs/whats-new) to learn what is new.
+This documentation describes luma.gl **v9.2**. See our [**release notes**](/docs/whats-new) to learn what is new.
 Docs for older versions are available on github:
+**[v9.1](https://github.com/visgl/luma.gl/blob/9.1-release/docs/README.md)**,
 **[v9.0](https://github.com/visgl/luma.gl/blob/9.0-release/docs/README.md)**,
 **[v8.5](https://github.com/visgl/luma.gl/blob/8.5-release/docs/README.md)**,
 **[v7.3](https://github.com/visgl/luma.gl/blob/7.3-release/docs/README.md)**,

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,9 +2,20 @@
 
 _This page contains news for recent luma.gl releases. For older releases (through v8.5) refer to the [Legacy What's New](/docs/legacy/legacy-upgrade-guide) page._
 
-## Version 9.2 (In Development)
+## Version 9.3 (In Development)
 
-Target Date: Q2, 2025
+Target Date: TBD
+
+**@luma.gl/gltf**
+
+- glTF Skeleton Animation Support
+- glTF Mesh Target Animation Support
+- glTF and PRB now supported on WebGPU
+- Improved documentation
+
+## Version 9.2
+
+Release Date: Sep 24, 2025
 
 Production quality WebGPU backend
 
@@ -39,23 +50,16 @@ Production quality WebGPU backend
 
 **@luma.gl/engine**
 
-- `DynamicTexture` 
-  - now supports mipmap generation for WebGPU textures (in progress)
-
-**@luma.gl/gltf**
-
-- glTF Skeleton Animation Support  (in progress)
-- glTF Mesh Target Animation Support  (in progress)
-- glTF and PRB now supported on WebGPU (in progress)
-- Improved documentation
+- `DynamicTexture`
+  - now supports mipmap generation for WebGPU textures
 
 **@luma.gl/effects**
 
-- All postprocessing effects ported to WGSL (in progress)
+- More postprocessing effects ported to WGSL
 
 **@luma.gl/shadertools**
 
-- All shader modules ported to WGSL (in progress)
+- More shader modules ported to WGSL
 
 
 ## Version 9.1


### PR DESCRIPTION
## Summary
- add a new "Version 9.3 (In Development)" section that captures the glTF feature updates while that release is in progress
- soften 9.2 release claims to "More … ported to WGSL" now that the remaining work is tracked under 9.3

## Testing
- yarn install
- yarn build
- yarn lint
- yarn test *(fails: browser-headless tests require libatk-1.0.so.0 in this container)*
- (website) yarn install
- (website) yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d46c6c87e483289517cbf81b3b3690