### PR TITLE
[9.1-release] Lock peer dependencies to 9.1

### DIFF
--- a/modules/effects/package.json
+++ b/modules/effects/package.json
@@ -46,7 +46,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/shadertools": "^9.1.0"
+    "@luma.gl/shadertools": "~9.1.0"
   },
   "dependencies": {
     "@math.gl/core": "^4.1.0",

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -40,8 +40,8 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "^9.1.0",
-    "@luma.gl/shadertools": "^9.1.0"
+    "@luma.gl/core": "~9.1.0",
+    "@luma.gl/shadertools": "~9.1.0"
   },
   "dependencies": {
     "@math.gl/core": "^4.1.0",

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -40,9 +40,9 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "^9.1.0",
-    "@luma.gl/engine": "^9.1.0",
-    "@luma.gl/shadertools": "^9.1.0"
+    "@luma.gl/core": "~9.1.0",
+    "@luma.gl/engine": "~9.1.0",
+    "@luma.gl/shadertools": "~9.1.0"
   },
   "dependencies": {
     "@loaders.gl/core": "^4.2.0",

--- a/modules/shadertools/package.json
+++ b/modules/shadertools/package.json
@@ -46,7 +46,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "^9.1.0"
+    "@luma.gl/core": "~9.1.0"
   },
   "dependencies": {
     "@math.gl/core": "^4.1.0",

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -36,11 +36,11 @@
     "pre-build": "echo test utils has no bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "^9.1.0",
-    "@luma.gl/engine": "^9.1.0",
-    "@luma.gl/shadertools": "^9.1.0",
-    "@luma.gl/webgl": "^9.1.0",
-    "@luma.gl/webgpu": "^9.1.0"
+    "@luma.gl/core": "~9.1.0",
+    "@luma.gl/engine": "~9.1.0",
+    "@luma.gl/shadertools": "~9.1.0",
+    "@luma.gl/webgl": "~9.1.0",
+    "@luma.gl/webgpu": "~9.1.0"
   },
   "dependencies": {
     "@probe.gl/env": "^4.0.8",

--- a/modules/webgl/package.json
+++ b/modules/webgl/package.json
@@ -40,7 +40,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "^9.1.0"
+    "@luma.gl/core": "~9.1.0"
   },
   "dependencies": {
     "@luma.gl/constants": "9.1.9",

--- a/modules/webgpu/package.json
+++ b/modules/webgpu/package.json
@@ -37,7 +37,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "^9.1.0"
+    "@luma.gl/core": "~9.1.0"
   },
   "dependencies": {
     "@probe.gl/env": "^4.0.8",


### PR DESCRIPTION
For https://github.com/visgl/deck.gl/issues/9793

Prevent npm pulling peer dependencies from 9.2 if they are not explicitly installed.

#### Change List
- Lock peer dependencies to 9.1
