### PR TITLE
fix(webgl): Do not assume luma WEBGLFramebuffer

### DIFF
--- a/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
+++ b/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
@@ -36,19 +36,20 @@ export class WEBGLFramebuffer extends Framebuffer {
       // default framebuffer handle is null, so we can't set debug metadata...
       device._setWebGLDebugMetadata(this.handle, this, {spector: this.props});
 
-      // Auto create textures for attachments if needed
-      this.autoCreateAttachmentTextures();
+      if (!props.handle) {
+        // Auto create textures for attachments if needed
+        this.autoCreateAttachmentTextures();
 
-      this.updateAttachments();
+        this.updateAttachments();
+      }
     }
   }
 
   /** destroys any auto created resources etc. */
   override destroy(): void {
     super.destroy(); // destroys owned resources etc.
-    if (!this.destroyed && this.handle !== null) {
+    if (!this.destroyed && this.handle !== null && !this.props.handle) {
       this.gl.deleteFramebuffer(this.handle);
-      // this.handle = null;
     }
   }
 

--- a/modules/webgl/src/adapter/resources/webgl-render-pass.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pass.ts
@@ -54,16 +54,12 @@ export class WEBGLRenderPass extends RenderPass {
     this.setParameters({viewport, ...this.props.parameters});
 
     // Specify mapping of draw buffer locations to color attachments
-    if (webglFramebuffer instanceof WEBGLFramebuffer) {
-      if (!isDefaultFramebuffer) {
-        const drawBuffers = webglFramebuffer.colorAttachments.map(
-          (_, i) => GL.COLOR_ATTACHMENT0 + i
-        );
-        this.device.gl.drawBuffers(drawBuffers);
-      } else {
-        // Default framebuffer only supports GL.BACK/GL.NONE draw buffers
-        this.device.gl.drawBuffers([GL.BACK]);
-      }
+    if (!isDefaultFramebuffer && webglFramebuffer instanceof WEBGLFramebuffer) {
+      const drawBuffers = webglFramebuffer.colorAttachments.map((_, i) => GL.COLOR_ATTACHMENT0 + i);
+      this.device.gl.drawBuffers(drawBuffers);
+    } else if (isDefaultFramebuffer) {
+      // Default framebuffer only supports GL.BACK/GL.NONE draw buffers
+      this.device.gl.drawBuffers([GL.BACK]);
     }
 
     // Hack - for now WebGL draws in "immediate mode" (instead of queueing the operations)...

--- a/modules/webgl/src/adapter/resources/webgl-render-pass.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pass.ts
@@ -23,8 +23,11 @@ export class WEBGLRenderPass extends RenderPass {
   constructor(device: WebGLDevice, props: RenderPassProps) {
     super(device, props);
     this.device = device;
-    const webglFramebuffer = this.props.framebuffer as WEBGLFramebuffer | null;
-    const isDefaultFramebuffer = !webglFramebuffer || webglFramebuffer.handle === null;
+    // The framebuffer may be a luma.gl WEBGLFramebuffer, a raw WebGLFramebuffer
+    // handle (e.g. from an external context like Google Maps), or null (default).
+    const webglFramebuffer = this.props.framebuffer as WEBGLFramebuffer | WebGLFramebuffer | null;
+    const isDefaultFramebuffer =
+      !webglFramebuffer || ('handle' in webglFramebuffer && webglFramebuffer.handle === null);
 
     if (isDefaultFramebuffer) {
       // Treat an explicit wrapper around the default framebuffer the same as the
@@ -35,7 +38,7 @@ export class WEBGLRenderPass extends RenderPass {
     // If no viewport is provided, apply reasonably defaults
     let viewport: NumberArray4 | undefined;
     if (!props?.parameters?.viewport) {
-      if (!isDefaultFramebuffer) {
+      if (!isDefaultFramebuffer && webglFramebuffer instanceof WEBGLFramebuffer) {
         // Set the viewport to the size of the framebuffer
         const {width, height} = webglFramebuffer;
         viewport = [0, 0, width, height];
@@ -51,14 +54,16 @@ export class WEBGLRenderPass extends RenderPass {
     this.setParameters({viewport, ...this.props.parameters});
 
     // Specify mapping of draw buffer locations to color attachments
-    // Default framebuffers can only be set to GL.BACK or GL.NONE
-    if (!isDefaultFramebuffer) {
-      const drawBuffers = webglFramebuffer.colorAttachments.map((_, i) => GL.COLOR_ATTACHMENT0 + i);
-      this.device.gl.drawBuffers(drawBuffers);
-    } else {
-      // Default framebuffer only supports GL.BACK/GL.NONE draw buffers, even when
-      // passed through an explicit framebuffer wrapper.
-      this.device.gl.drawBuffers([GL.BACK]);
+    if (webglFramebuffer instanceof WEBGLFramebuffer) {
+      if (!isDefaultFramebuffer) {
+        const drawBuffers = webglFramebuffer.colorAttachments.map(
+          (_, i) => GL.COLOR_ATTACHMENT0 + i
+        );
+        this.device.gl.drawBuffers(drawBuffers);
+      } else {
+        // Default framebuffer only supports GL.BACK/GL.NONE draw buffers
+        this.device.gl.drawBuffers([GL.BACK]);
+      }
     }
 
     // Hack - for now WebGL draws in "immediate mode" (instead of queueing the operations)...

--- a/modules/webgl/src/adapter/resources/webgl-render-pass.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pass.ts
@@ -23,11 +23,8 @@ export class WEBGLRenderPass extends RenderPass {
   constructor(device: WebGLDevice, props: RenderPassProps) {
     super(device, props);
     this.device = device;
-    // The framebuffer may be a luma.gl WEBGLFramebuffer, a raw WebGLFramebuffer
-    // handle (e.g. from an external context like Google Maps), or null (default).
-    const webglFramebuffer = this.props.framebuffer as WEBGLFramebuffer | WebGLFramebuffer | null;
-    const isDefaultFramebuffer =
-      !webglFramebuffer || ('handle' in webglFramebuffer && webglFramebuffer.handle === null);
+    const webglFramebuffer = this.props.framebuffer as WEBGLFramebuffer | null;
+    const isDefaultFramebuffer = !webglFramebuffer || webglFramebuffer.handle === null;
 
     if (isDefaultFramebuffer) {
       // Treat an explicit wrapper around the default framebuffer the same as the
@@ -38,7 +35,7 @@ export class WEBGLRenderPass extends RenderPass {
     // If no viewport is provided, apply reasonably defaults
     let viewport: NumberArray4 | undefined;
     if (!props?.parameters?.viewport) {
-      if (!isDefaultFramebuffer && webglFramebuffer instanceof WEBGLFramebuffer) {
+      if (!isDefaultFramebuffer && webglFramebuffer) {
         // Set the viewport to the size of the framebuffer
         const {width, height} = webglFramebuffer;
         viewport = [0, 0, width, height];
@@ -54,7 +51,7 @@ export class WEBGLRenderPass extends RenderPass {
     this.setParameters({viewport, ...this.props.parameters});
 
     // Specify mapping of draw buffer locations to color attachments
-    if (!isDefaultFramebuffer && webglFramebuffer instanceof WEBGLFramebuffer) {
+    if (!isDefaultFramebuffer && webglFramebuffer?.colorAttachments.length) {
       const drawBuffers = webglFramebuffer.colorAttachments.map((_, i) => GL.COLOR_ATTACHMENT0 + i);
       this.device.gl.drawBuffers(drawBuffers);
     } else if (isDefaultFramebuffer) {

--- a/modules/webgl/test/adapter/resources/webgl-render-pass.spec.ts
+++ b/modules/webgl/test/adapter/resources/webgl-render-pass.spec.ts
@@ -79,7 +79,7 @@ test('WEBGLRenderPass#drawBuffers for explicit default framebuffer wrapper', asy
   t.end();
 });
 
-test('WEBGLRenderPass#drawBuffers for external WebGLFramebuffer', async t => {
+test('WEBGLRenderPass#drawBuffers for wrapped external WebGLFramebuffer', async t => {
   const device = await getWebGLTestDevice();
   const {gl} = device;
 
@@ -90,7 +90,7 @@ test('WEBGLRenderPass#drawBuffers for external WebGLFramebuffer', async t => {
     return originalDrawBuffers(buffers as any);
   }) as typeof gl.drawBuffers;
 
-  // Simulate an external WebGLFramebuffer (e.g. from Google Maps interleaved rendering).
+  // Simulate wrapping an external WebGLFramebuffer (e.g. from Google Maps interleaved rendering).
   // Attach a color renderbuffer so gl.clear() doesn't error on an incomplete FBO.
   const externalFbo = gl.createFramebuffer()!;
   gl.bindFramebuffer(GL.FRAMEBUFFER, externalFbo);
@@ -100,14 +100,17 @@ test('WEBGLRenderPass#drawBuffers for external WebGLFramebuffer', async t => {
   gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.RENDERBUFFER, rb);
   gl.bindFramebuffer(GL.FRAMEBUFFER, null);
 
-  // Should not crash accessing colorAttachments.map() on external framebuffer
-  const renderPass = new WEBGLRenderPass(device, {framebuffer: externalFbo as any});
-  t.ok(renderPass, 'does not crash on external WebGLFramebuffer without colorAttachments');
+  const framebuffer = device.createFramebuffer({handle: externalFbo, width: 64, height: 64});
+
+  // Should not crash accessing colorAttachments.map() on wrapped external framebuffer
+  const renderPass = new WEBGLRenderPass(device, {framebuffer});
+  t.ok(renderPass, 'does not crash on wrapped external WebGLFramebuffer');
   renderPass.end();
 
-  t.equal(drawBufferCalls.length, 0, 'does not call drawBuffers for external WebGLFramebuffer');
+  t.equal(drawBufferCalls.length, 0, 'does not call drawBuffers for wrapped external WebGLFramebuffer');
 
   gl.drawBuffers = originalDrawBuffers;
+  framebuffer.destroy();
   gl.deleteRenderbuffer(rb);
   gl.deleteFramebuffer(externalFbo);
   device.destroy();

--- a/modules/webgl/test/adapter/resources/webgl-render-pass.spec.ts
+++ b/modules/webgl/test/adapter/resources/webgl-render-pass.spec.ts
@@ -107,7 +107,11 @@ test('WEBGLRenderPass#drawBuffers for wrapped external WebGLFramebuffer', async 
   t.ok(renderPass, 'does not crash on wrapped external WebGLFramebuffer');
   renderPass.end();
 
-  t.equal(drawBufferCalls.length, 0, 'does not call drawBuffers for wrapped external WebGLFramebuffer');
+  t.equal(
+    drawBufferCalls.length,
+    0,
+    'does not call drawBuffers for wrapped external WebGLFramebuffer'
+  );
 
   gl.drawBuffers = originalDrawBuffers;
   framebuffer.destroy();

--- a/modules/webgl/test/adapter/resources/webgl-render-pass.spec.ts
+++ b/modules/webgl/test/adapter/resources/webgl-render-pass.spec.ts
@@ -79,6 +79,41 @@ test('WEBGLRenderPass#drawBuffers for explicit default framebuffer wrapper', asy
   t.end();
 });
 
+test('WEBGLRenderPass#drawBuffers for external WebGLFramebuffer', async t => {
+  const device = await getWebGLTestDevice();
+  const {gl} = device;
+
+  const drawBufferCalls: number[][] = [];
+  const originalDrawBuffers = gl.drawBuffers.bind(gl);
+  gl.drawBuffers = ((buffers: number[]) => {
+    drawBufferCalls.push([...buffers]);
+    return originalDrawBuffers(buffers as any);
+  }) as typeof gl.drawBuffers;
+
+  // Simulate an external WebGLFramebuffer (e.g. from Google Maps interleaved rendering).
+  // Attach a color renderbuffer so gl.clear() doesn't error on an incomplete FBO.
+  const externalFbo = gl.createFramebuffer()!;
+  gl.bindFramebuffer(GL.FRAMEBUFFER, externalFbo);
+  const rb = gl.createRenderbuffer()!;
+  gl.bindRenderbuffer(GL.RENDERBUFFER, rb);
+  gl.renderbufferStorage(GL.RENDERBUFFER, gl.RGBA8, 64, 64);
+  gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.RENDERBUFFER, rb);
+  gl.bindFramebuffer(GL.FRAMEBUFFER, null);
+
+  // Should not crash accessing colorAttachments.map() on external framebuffer
+  const renderPass = new WEBGLRenderPass(device, {framebuffer: externalFbo as any});
+  t.ok(renderPass, 'does not crash on external WebGLFramebuffer without colorAttachments');
+  renderPass.end();
+
+  t.equal(drawBufferCalls.length, 0, 'does not call drawBuffers for external WebGLFramebuffer');
+
+  gl.drawBuffers = originalDrawBuffers;
+  gl.deleteRenderbuffer(rb);
+  gl.deleteFramebuffer(externalFbo);
+  device.destroy();
+  t.end();
+});
+
 test('WEBGLRenderPass flushes deferred default canvas resize', async t => {
   const device = await getWebGLTestDevice();
   const canvasContext = device.getDefaultCanvasContext();


### PR DESCRIPTION
#### Background

Fixes regression introduced first introduced in `9.3-alpha.10` breaking Google interleaved rendering together with https://github.com/visgl/deck.gl/pull/10253

<img width="947" height="508" alt="Screenshot 2026-04-08 at 16 19 18" src="https://github.com/user-attachments/assets/e814d7b6-0d1c-44ed-817d-55b62b6af5b9" />

Error logged:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'map')
    at new WEBGLRenderPass (webgl-render-pass.ts:56:61)
    at WEBGLCommandEncoder.beginRenderPass (webgl-command-encoder.ts:53:12)
    at _WebGLDevice.beginRenderPass (device.ts:775:32)
    at DrawLayersPass._render (layers-pass.ts:109:36)
    at DrawLayersPass.render (draw-layers-pass.ts:15:17)
    at DeckRenderer.renderLayers (deck-renderer.ts:94:36)
    at Deck._drawLayers (deck.ts:1419:24)
    at google-maps-overlay.ts:344:16
    at withGLParameters (with-parameters.ts:37:13)
```

Repro using deck.gl `examples/basemap-browser`

#### Change List
- Don't autocreate textures for external framebuffer
- Prevent crashes when we have no colorAttachments