### PR TITLE
docs: fix typo "agains" → "against" in assert.ts comment

### DIFF
--- a/modules/shadertools/src/lib/utils/assert.ts
+++ b/modules/shadertools/src/lib/utils/assert.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-// Recommendation is to ignore message but current test suite checks agains the
+// Recommendation is to ignore message but current test suite checks against the
 // message so keep it for now.
 export function assert(condition: unknown, message?: string): void {
   if (!condition) {


### PR DESCRIPTION
Comment-only typo fix in `modules/shadertools/src/lib/utils/assert.ts:5`. No behavior change.