### PR TITLE
feat(arrow) GPUArrowTable.schema, GPUArrowVector.type

### DIFF
--- a/docs/api-guide/gpu/arrow-table-columns.md
+++ b/docs/api-guide/gpu/arrow-table-columns.md
@@ -21,14 +21,19 @@ attribute without an additional conversion step.
 
 ## Shader and Buffer Layout Preliminaries
 
-luma.gl provides separate descriptions of shader attributes and the buffers that are provided to provide the data for those attributes. The key observation here is that shaders only work with four types ('f32', 'f16', 'i32' and 'u32') and there is some flexibility in what binary buffer layouts can feed these declarations.
+luma.gl provides separate descriptions of shader attributes and the buffers that
+provide data for those attributes. The key observation here is that shaders only
+work with four vertex attribute scalar types (`f32`, `f16`, `i32`, and `u32`),
+and there is some flexibility in what binary buffer layouts can feed these
+declarations.
 
 - `ShaderLayout` describes what the shader can accept, such as `vec4<f32>`.
 - `BufferLayout` describes how the current table column is stored in memory, such as
   `float32x4`, `float16x4`, or `unorm8x4`.
 
-This means the shader does not need to be written specifically for every memory representation. A shader
-attribute is declared using the type used in the shader source code:
+This means the shader does not need to be written specifically for every memory
+representation. A shader attribute is declared using the type used in the shader
+source code:
 
 ```ts
 const shaderLayout = {
@@ -37,11 +42,13 @@ const shaderLayout = {
 };
 ```
 
-Then different Arrow table schemas can use different buffer layouts. For the `vec4<f32>` described in the shader layout, the following buffer formats are all accepted by the GPU. 
+Then different Arrow table schemas can use different buffer layouts. For the
+`vec4<f32>` described in the shader layout, the following buffer formats are all
+accepted by the GPU.
 
 | Arrow column type           | Buffer layout format | Notes                                      |
 | --------------------------- | -------------------- | ------------------------------------------ |
-| `FixedSizeList<Float32, 4>` | `float32x4`          | |
+| `FixedSizeList<Float32, 4>` | `float32x4`          |                                            |
 | `FixedSizeList<Float16, 4>` | `float16x4`          | Shader sees f32                            |
 | `FixedSizeList<Int16, 4>`   | `snorm16x4`          | Shader sees f32, normalized to [-1.0, 1.0] |
 | `FixedSizeList<Uint16, 4>`  | `unorm16x4`          |
@@ -90,6 +97,34 @@ The generated layouts use shader attribute names as buffer names:
   {name: 'instanceColors', format: 'unorm8x4'}
 ]
 ```
+
+## Arrow GPU Objects
+
+`ArrowGPUVector` and `ArrowGPUTable` are GPU-side representations derived from
+Apache Arrow data. Arrow vectors and tables are construction inputs; the GPU
+objects do not retain references to those sources after extracting the buffer
+data and metadata they need.
+
+An `ArrowGPUTable` owns GPU buffers and a GPU-facing Arrow `Schema` for the
+selected shader attributes. Field names, types, nullability, and metadata live in
+`arrowGPUTable.schema.fields`. An `ArrowGPUVector` owns one GPU buffer and uses
+Arrow's type system to describe it through `type`, `length`, and `stride`.
+
+```ts
+import {ArrowGPUTable, ArrowGPUVector} from '@luma.gl/arrow';
+
+const arrowGPUTable = new ArrowGPUTable(device, table, {shaderLayout});
+
+// The schema describes the selected GPU columns, not necessarily the full table.
+const [colorField] = arrowGPUTable.schema.fields;
+
+// Each GPU vector owns a buffer and Arrow-derived type/shape metadata.
+const colorVector: ArrowGPUVector = arrowGPUTable.gpuVectors.instanceColors;
+```
+
+`ArrowModel` is the convenience wrapper that combines `ArrowGPUTable` with
+`Model`. It accepts an Arrow table as an update source and replaces the GPU
+representation when `setProps({arrowTable})` is called.
 
 ## Supported Shader Types
 

--- a/modules/arrow/README.md
+++ b/modules/arrow/README.md
@@ -1,5 +1,10 @@
 # @luma.gl/arrow
 
-This is Apache Arrow utilities for luma.gl.
+Apache Arrow utilities for luma.gl.
+
+The module can derive GPU `BufferLayout` entries from Arrow schemas and create
+GPU-side `ArrowGPUVector`, `ArrowGPUTable`, and `ArrowModel` objects from
+compatible Arrow columns. Arrow tables and vectors are construction inputs; the
+GPU objects retain GPU buffers plus Arrow-derived type and schema metadata.
 
 See [luma.gl](http://luma.gl) for documentation.

--- a/modules/arrow/src/arrow/analyze-arrow-table.ts
+++ b/modules/arrow/src/arrow/analyze-arrow-table.ts
@@ -7,6 +7,7 @@ import {getArrowPaths} from './arrow-paths';
 import {ArrowColumnInfo} from './arrow-types';
 import {getArrowColumnInfo} from './arrow-column-info';
 
+/** Returns GPU-compatible column information for every compatible leaf column in an Arrow table. */
 export function analyzeArrowTable(arrowTable: arrow.Table): Record<string, ArrowColumnInfo> {
   const paths = getArrowPaths(arrowTable);
   const columnInfos: Record<string, ArrowColumnInfo> = {};

--- a/modules/arrow/src/arrow/arrow-column-info.ts
+++ b/modules/arrow/src/arrow/arrow-column-info.ts
@@ -13,7 +13,7 @@ import {
 } from './arrow-types';
 import {getArrowVectorByPath} from './arrow-paths';
 
-/** Extracts info from columns that can be used as GPU data sources */
+/** Returns GPU attribute information for an Arrow table column path, if compatible. */
 export function getArrowColumnInfo(arrowTable: arrow.Table, path: string): ArrowColumnInfo | null {
   const vector = getArrowVectorByPath(arrowTable, path);
   if (isInstanceArrowType(vector.type)) {
@@ -25,7 +25,7 @@ export function getArrowColumnInfo(arrowTable: arrow.Table, path: string): Arrow
   return null;
 }
 
-/** Extracts info from columns that can be used with GPU instanced attributes */
+/** Returns GPU attribute information for a scalar or FixedSizeList Arrow vector. */
 export function getInstanceColumnInfo(vector: arrow.Vector<AttributeArrowType>): ArrowColumnInfo {
   let components: 1 | 2 | 3 | 4 = 1;
 

--- a/modules/arrow/src/arrow/arrow-gpu-vector.ts
+++ b/modules/arrow/src/arrow/arrow-gpu-vector.ts
@@ -7,15 +7,31 @@ import * as arrow from 'apache-arrow';
 import type {AttributeArrowType} from './arrow-types';
 import {getArrowVectorBufferSource} from './arrow-fixed-size-list';
 
+/** Buffer creation props forwarded when uploading Arrow vector memory to the GPU. */
 export type ArrowGPUVectorProps = Omit<BufferProps, 'byteLength' | 'data'>;
 
-/** A GPU buffer backed by one Arrow vector. */
+/**
+ * GPU memory and Arrow type metadata derived from one Arrow vector.
+ *
+ * The Arrow vector is a construction input only. ArrowGPUVector does not retain
+ * the source vector; it owns a GPU buffer plus the type, length, and stride that
+ * describe the uploaded memory.
+ */
 export class ArrowGPUVector<T extends AttributeArrowType = AttributeArrowType> {
-  readonly vector: arrow.Vector<T>;
+  /** GPU buffer containing the Arrow vector's attribute-compatible value memory. */
   readonly buffer: Buffer;
+  /** Arrow type that describes the uploaded vector memory. */
+  readonly type: T;
+  /** Number of logical Arrow vector rows uploaded into the GPU buffer. */
+  readonly length: number;
+  /** Number of scalar values per logical vector row. */
+  readonly stride: number;
 
-  constructor(device: Device, vector: arrow.Vector<T>, props?: ArrowGPUVectorProps) {
-    this.vector = vector;
+  /** Creates a GPU representation from an Arrow vector without retaining the source vector. */
+  constructor(device: Device, vector: arrow.Vector<T>, props: ArrowGPUVectorProps = {}) {
+    this.type = vector.type;
+    this.length = vector.length;
+    this.stride = getArrowVectorStride(vector);
     this.buffer = device.createBuffer({
       ...props,
       data: getArrowVectorBufferSource(vector as any)
@@ -25,4 +41,8 @@ export class ArrowGPUVector<T extends AttributeArrowType = AttributeArrowType> {
   destroy(): void {
     this.buffer.destroy();
   }
+}
+
+function getArrowVectorStride(vector: arrow.Vector<AttributeArrowType>): number {
+  return arrow.DataType.isFixedSizeList(vector.type) ? vector.type.listSize : 1;
 }

--- a/modules/arrow/src/arrow/arrow-model.ts
+++ b/modules/arrow/src/arrow/arrow-model.ts
@@ -9,11 +9,16 @@ import {type ArrowVertexFormatOptions} from './arrow-shader-layout';
 import {ArrowGPUTable, type ArrowGPUTableProps} from './plain-gpu-table';
 import type {ArrowGPUVectorProps} from './arrow-gpu-vector';
 
+/** Props for creating a Model whose attributes are derived from an Arrow table. */
 export type ArrowModelProps = ModelProps &
   ArrowVertexFormatOptions & {
+    /** Arrow table used as the construction source for GPU attribute buffers. */
     arrowTable: arrow.Table;
+    /** Maps shader attribute names to Arrow column paths. Defaults to using attribute names. */
     arrowPaths?: Record<string, string>;
+    /** Buffer props applied to each Arrow-derived GPU vector. */
     arrowBufferProps?: ArrowGPUVectorProps;
+    /** Controls whether row count is assigned to instanceCount, vertexCount, or neither. */
     arrowCount?: 'instance' | 'vertex' | 'none';
   };
 
@@ -39,6 +44,7 @@ type ArrowModelArrowState = {
 
 /** A luma.gl Model with GPU attributes backed by Arrow table columns. */
 export class ArrowModel extends Model {
+  /** GPU representation of the currently active Arrow table attributes. */
   arrowGPUTable: ArrowGPUTable;
   private arrowState: ArrowModelArrowState;
   private arrowModelDestroyed = false;
@@ -55,6 +61,7 @@ export class ArrowModel extends Model {
     this.arrowState = arrowState;
   }
 
+  /** Updates the model when a replacement Arrow table is supplied. */
   setProps(props: Partial<ArrowModelProps>): void {
     if (props.arrowTable) {
       this.setArrowTable(props.arrowTable);
@@ -99,10 +106,10 @@ export class ArrowModel extends Model {
       });
 
       if (this.arrowState.inferInstanceCount) {
-        this.setInstanceCount(arrowTable.numRows);
+        this.setInstanceCount(nextArrowGPUTable.numRows);
       }
       if (this.arrowState.inferVertexCount) {
-        this.setVertexCount(arrowTable.numRows);
+        this.setVertexCount(nextArrowGPUTable.numRows);
       }
     } catch (error) {
       nextArrowGPUTable.destroy();
@@ -174,8 +181,8 @@ function getArrowModelState(device: Device, props: ArrowModelProps): ArrowModelS
       ...modelProps,
       bufferLayout: [...explicitBufferLayout, ...arrowGPUTable.bufferLayout],
       attributes: {...explicitAttributes, ...arrowGPUTable.attributes},
-      ...(inferInstanceCount ? {instanceCount: arrowTable.numRows} : {}),
-      ...(inferVertexCount ? {vertexCount: arrowTable.numRows} : {})
+      ...(inferInstanceCount ? {instanceCount: arrowGPUTable.numRows} : {}),
+      ...(inferVertexCount ? {vertexCount: arrowGPUTable.numRows} : {})
     }
   };
 }

--- a/modules/arrow/src/arrow/arrow-paths.ts
+++ b/modules/arrow/src/arrow/arrow-paths.ts
@@ -4,6 +4,7 @@
 
 import * as arrow from 'apache-arrow';
 
+/** Returns all leaf column paths in an Arrow object, using dot notation for nested structs. */
 export function getArrowPaths(
   arrowObject: arrow.Data | arrow.Table | arrow.RecordBatch | arrow.Vector
 ): string[] {
@@ -11,6 +12,7 @@ export function getArrowPaths(
   return getArrowPathsRecursive(data, []);
 }
 
+/** Recursively returns all leaf paths below an Arrow data node. */
 export function getArrowPathsRecursive(arrowData: arrow.Data, currentPath: string[]): string[] {
   if (!arrow.DataType.isStruct(arrowData.type)) {
     return [currentPath.join('.')];
@@ -29,6 +31,7 @@ export function getArrowPathsRecursive(arrowData: arrow.Data, currentPath: strin
   return nestedPaths;
 }
 
+/** Returns the Arrow data node at a dot-separated column path. */
 export function getArrowDataByPath(
   arrowObject: arrow.Data | arrow.Table | arrow.RecordBatch | arrow.Vector,
   columnPath: string
@@ -62,6 +65,7 @@ export function getArrowDataByPath(
   return nestedData;
 }
 
+/** Returns the Arrow vector at a dot-separated table column path. */
 export function getArrowVectorByPath(arrowTable: arrow.Table, columnPath: string): arrow.Vector {
   // Make a temporary vector from the top level struct data.
   const vector = arrow.makeVector(arrowTable.data);
@@ -93,7 +97,41 @@ export function getArrowVectorByPath(arrowTable: arrow.Table, columnPath: string
   return nestedVector;
 }
 
-/** Get a data object from an arrow object */
+/** Returns the Arrow schema field at a dot-separated table column path. */
+export function getArrowFieldByPath(arrowTable: arrow.Table, columnPath: string): arrow.Field {
+  const path = decomposePath(columnPath);
+  let fields = arrowTable.schema.fields;
+  let resolvedField: arrow.Field | null = null;
+
+  for (let pathIndex = 0; pathIndex < path.length; pathIndex++) {
+    const key = path[pathIndex];
+    const isLeafField = pathIndex === path.length - 1;
+    const indexByField = fields.findIndex(field => field.name === key);
+    if (indexByField === -1) {
+      throw new Error(
+        `Arrow table schema does not contain nested column '${key} in '${path.join('.')}'`
+      );
+    }
+
+    resolvedField = fields[indexByField];
+    if (!isLeafField) {
+      if (!arrow.DataType.isStruct(resolvedField.type)) {
+        throw new Error(
+          `Arrow table nested column is a not a struct: '${key} in '${path.join('.')}'`
+        );
+      }
+      fields = resolvedField.type.children;
+    }
+  }
+
+  if (!resolvedField || arrow.DataType.isStruct(resolvedField.type)) {
+    throw new Error(`Arrow table nested column '${path.join('.')}' is a struct`);
+  }
+
+  return resolvedField;
+}
+
+/** Returns the data chunks contained by an Arrow object. */
 export function getArrowDataArray(
   arrowObject: arrow.Data | arrow.Table | arrow.RecordBatch | arrow.Vector
 ): arrow.Data[] {

--- a/modules/arrow/src/arrow/arrow-shader-layout.ts
+++ b/modules/arrow/src/arrow/arrow-shader-layout.ts
@@ -15,11 +15,13 @@ import {getArrowPaths} from './arrow-paths';
 import {getArrowColumnInfo, getInstanceColumnInfo} from './arrow-column-info';
 import {isInstanceArrowType, type ArrowColumnInfo, type AttributeArrowType} from './arrow-types';
 
+/** Options that control Arrow column to GPU vertex format selection. */
 export type ArrowVertexFormatOptions = {
   /** Allow WebGL-only 3-component 8/16-bit integer vertex formats. */
   allowWebGLOnlyFormats?: boolean;
 };
 
+/** Source options for deriving a BufferLayout from Arrow data and a ShaderLayout. */
 export type ArrowBufferLayoutOptions = ArrowVertexFormatOptions & {
   /** Arrow vectors keyed by shader attribute name. */
   arrowVectors?: Record<string, arrow.Vector>;
@@ -40,7 +42,12 @@ type ArrowBufferLayoutSource =
     }
   | {type: 'vectors'; arrowVectors: Record<string, arrow.Vector>};
 
-/** Returns the vertex format needed to expose one Arrow column to one shader attribute. */
+/**
+ * Returns the GPU vertex format needed to expose one Arrow column to one shader attribute.
+ *
+ * The shader type describes what the shader can consume. The Arrow column info
+ * describes the memory representation that will be uploaded.
+ */
 export function getArrowVertexFormat(
   columnInfo: ArrowColumnInfo,
   shaderType: AttributeShaderType,
@@ -68,7 +75,12 @@ export function getArrowVertexFormat(
   }
 }
 
-/** Builds a BufferLayout that maps matching Arrow columns to shader attributes. */
+/**
+ * Builds a BufferLayout by matching shader attributes to Arrow table columns or vectors.
+ *
+ * The canonical overload is shader-layout first with either `arrowTable` or
+ * `arrowVectors` supplied in the options object.
+ */
 export function getArrowBufferLayout(
   shaderLayout: ShaderLayout,
   options: ArrowBufferLayoutOptions

--- a/modules/arrow/src/arrow/arrow-types.ts
+++ b/modules/arrow/src/arrow/arrow-types.ts
@@ -5,28 +5,35 @@
 import type {SignedDataType, BigTypedArray} from '@luma.gl/core';
 import * as arrow from 'apache-arrow';
 
+/** Numeric Apache Arrow scalar types that can be represented as GPU vertex attributes. */
 export type NumericArrowType = arrow.Int | arrow.Float;
 
-/** An instance attribute-compatible column - has 1-4 (fixed) numeric values per row */
+/** Attribute-compatible Arrow column type with one to four numeric values per row. */
 export type AttributeArrowType = NumericArrowType | arrow.FixedSizeList<NumericArrowType>;
 
-/** A non-instance attribute compatible column - has a list of 1-4 (fixed) numeric values per row */
+/** Mesh-compatible Arrow column type with a list of attribute-compatible values per row. */
 export type MeshArrowType = arrow.List<NumericArrowType | arrow.FixedSizeList<NumericArrowType>>;
 
-/** Extracted information required to populate a mesh */
+/** Arrow column shape and numeric type information needed to derive a GPU vertex format. */
 export type ArrowColumnInfo = {
+  /** Whether values advance per instance or per vertex. */
   stepMode: 'instance' | 'vertex';
+  /** luma.gl signed data type for the scalar values in the column. */
   signedDataType: SignedDataType;
+  /** Number of scalar values per logical attribute. */
   components: 1 | 2 | 3 | 4;
+  /** Underlying Arrow value buffers for this column. */
   values: BigTypedArray[];
+  /** Nested list offsets for variable-length mesh columns. */
   offsets: Uint32Array[][];
 };
 
+/** Returns true when an Arrow type is an integer or floating point scalar type. */
 export function isNumericArrowType(type: arrow.DataType): type is arrow.Int | arrow.Float {
   return arrow.DataType.isFloat(type) || arrow.DataType.isInt(type);
 }
 
-/** Instance = One "vec1-vec4 value" per step */
+/** Returns true when an Arrow type can provide one scalar/vector attribute per row. */
 export function isInstanceArrowType(type: arrow.DataType): type is AttributeArrowType {
   return (
     isNumericArrowType(type) ||
@@ -35,12 +42,12 @@ export function isInstanceArrowType(type: arrow.DataType): type is AttributeArro
   );
 }
 
-/** Vertex = Multiple "vec1-vec4 values" per step */
+/** Returns true when an Arrow type can provide multiple scalar/vector attributes per row. */
 export function isVertexArrowType(type: arrow.DataType): type is MeshArrowType {
   return arrow.DataType.isList(type) && isInstanceArrowType(type.children[0].type);
 }
 
-/** Get the luma.gl signed shader type corresponding to an Apache Arrow type */
+/** Returns the luma.gl signed data type corresponding to a numeric Arrow type. */
 export function getSignedShaderType(
   arrowType: NumericArrowType,
   size: 1 | 2 | 3 | 4

--- a/modules/arrow/src/arrow/arrow-utils.ts
+++ b/modules/arrow/src/arrow/arrow-utils.ts
@@ -4,7 +4,7 @@
 
 import * as arrow from 'apache-arrow';
 
-/** Count number of nested top level Arrow Lists */
+/** Returns the number of top-level nested Arrow List wrappers around a data node. */
 export function getArrowListNestingLevel(data: arrow.Data): number {
   let nestingLevel = 0;
   if (arrow.DataType.isList(data.type)) {

--- a/modules/arrow/src/arrow/plain-gpu-table.ts
+++ b/modules/arrow/src/arrow/plain-gpu-table.ts
@@ -4,11 +4,12 @@
 
 import {Buffer, Device, type BufferLayout, type ShaderLayout} from '@luma.gl/core';
 import * as arrow from 'apache-arrow';
-import {getArrowVectorByPath} from './arrow-paths';
+import {getArrowFieldByPath, getArrowVectorByPath} from './arrow-paths';
 import {getArrowBufferLayout, type ArrowVertexFormatOptions} from './arrow-shader-layout';
 import type {AttributeArrowType} from './arrow-types';
 import {ArrowGPUVector, type ArrowGPUVectorProps} from './arrow-gpu-vector';
 
+/** Options for creating GPU buffers from shader-compatible Arrow table columns. */
 export type ArrowGPUTableProps = ArrowVertexFormatOptions & {
   /** Shader layout that selects which Arrow columns should be uploaded. */
   shaderLayout: ShaderLayout;
@@ -18,33 +19,63 @@ export type ArrowGPUTableProps = ArrowVertexFormatOptions & {
   bufferProps?: ArrowGPUVectorProps;
 };
 
-/** GPU buffers backed by Arrow table columns selected by a shader layout. */
+/**
+ * GPU memory and Arrow schema metadata derived from selected Arrow table columns.
+ *
+ * The Arrow table is a construction input only. ArrowGPUTable does not retain
+ * the source table; it owns GPU buffers, a BufferLayout, and a GPU-facing Arrow
+ * schema that describes the selected columns.
+ */
 export class ArrowGPUTable {
-  readonly table: arrow.Table;
+  /** GPU-facing schema for the selected shader attribute columns. */
+  readonly schema: arrow.Schema;
+  /** Number of rows in the source Arrow table at construction time. */
+  readonly numRows: number;
+  /** Number of selected GPU columns in {@link schema}. */
+  readonly numCols: number;
+  /** Number of null rows in the source Arrow table at construction time. */
+  readonly nullCount: number;
+  /** Buffer layout derived from the selected Arrow columns and shader layout. */
   readonly bufferLayout: BufferLayout[];
+  /** GPU vectors keyed by shader attribute name. */
   readonly gpuVectors: Record<string, ArrowGPUVector> = {};
+  /** Model-ready attribute buffers keyed by shader attribute name. */
   readonly attributes: Record<string, Buffer> = {};
 
+  /** Creates GPU buffers and a GPU-facing schema from an Arrow table. */
   constructor(device: Device, table: arrow.Table, props: ArrowGPUTableProps) {
-    this.table = table;
+    this.numRows = table.numRows;
+    this.nullCount = table.nullCount;
     this.bufferLayout = getArrowBufferLayout(props.shaderLayout, {
       arrowTable: table,
       arrowPaths: props.arrowPaths,
       allowWebGLOnlyFormats: props.allowWebGLOnlyFormats
     });
 
+    const fields: arrow.Field[] = [];
     for (const bufferLayout of this.bufferLayout) {
       const arrowPath = props.arrowPaths?.[bufferLayout.name] || bufferLayout.name;
       const vector = getArrowVectorByPath(table, arrowPath);
+      const sourceField = getArrowFieldByPath(table, arrowPath);
+      const field = new arrow.Field(
+        bufferLayout.name,
+        vector.type,
+        sourceField.nullable,
+        new Map(sourceField.metadata)
+      );
       const gpuVector = new ArrowGPUVector(
         device,
         vector as arrow.Vector<AttributeArrowType>,
         props.bufferProps
       );
 
+      fields.push(field);
       this.gpuVectors[bufferLayout.name] = gpuVector;
       this.attributes[bufferLayout.name] = gpuVector.buffer;
     }
+
+    this.schema = new arrow.Schema(fields, new Map(table.schema.metadata));
+    this.numCols = this.schema.fields.length;
   }
 
   destroy(): void {

--- a/modules/arrow/test/arrow/arrow-fixed-size-list.spec.ts
+++ b/modules/arrow/test/arrow/arrow-fixed-size-list.spec.ts
@@ -96,8 +96,23 @@ test('ArrowGPUVector creates a GPU buffer from an Arrow vector', t => {
   );
   const gpuVector = new ArrowGPUVector(device, vector);
 
-  t.equal(gpuVector.vector, vector, 'stores the Arrow vector');
+  t.notOk('vector' in gpuVector, 'does not retain the source Arrow vector');
+  t.equal(gpuVector.type, vector.type, 'exposes the Arrow vector type');
+  t.equal(gpuVector.length, 2, 'exposes the Arrow vector length');
+  t.equal(gpuVector.stride, 2, 'exposes the FixedSizeList stride');
   t.equal(gpuVector.buffer.byteLength, 16, 'creates a buffer from the vector values');
+
+  gpuVector.destroy();
+  t.end();
+});
+
+test('ArrowGPUVector exposes primitive vector length and stride', t => {
+  const device = new NullDevice({});
+  const vector = arrow.makeVector(new Float32Array([1, 2, 3]));
+  const gpuVector = new ArrowGPUVector(device, vector);
+
+  t.equal(gpuVector.length, 3, 'exposes the primitive vector length');
+  t.equal(gpuVector.stride, 1, 'exposes primitive vector stride as 1');
 
   gpuVector.destroy();
   t.end();

--- a/modules/arrow/test/arrow/plain-gpu-table.spec.ts
+++ b/modules/arrow/test/arrow/plain-gpu-table.spec.ts
@@ -3,21 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {ArrowGPUVector, ArrowGPUTable, makeArrowFixedSizeListVector} from '@luma.gl/arrow';
+import {ArrowGPUVector, ArrowGPUTable} from '@luma.gl/arrow';
 import type {ShaderLayout} from '@luma.gl/core';
 import {NullDevice} from '@luma.gl/test-utils';
 import * as arrow from 'apache-arrow';
 
 test('ArrowGPUTable creates GPU vectors from shader-compatible Arrow table columns', t => {
   const device = new NullDevice({});
-  const table = new arrow.Table({
-    positions: makeArrowFixedSizeListVector(new arrow.Float32(), 2, new Float32Array([0, 0, 1, 1])),
-    colors: makeArrowFixedSizeListVector(
-      new arrow.Uint8(),
-      4,
-      new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255])
-    )
-  });
+  const table = makeGpuMetadataTable();
   const shaderLayout: ShaderLayout = {
     attributes: [
       {name: 'positions', location: 0, type: 'vec2<f32>'},
@@ -29,6 +22,17 @@ test('ArrowGPUTable creates GPU vectors from shader-compatible Arrow table colum
 
   const gpuTable = new ArrowGPUTable(device, table, {shaderLayout});
 
+  t.notOk('table' in gpuTable, 'does not retain the source Arrow table');
+  t.equal(gpuTable.numRows, table.numRows, 'exposes source table row count');
+  t.equal(gpuTable.numCols, gpuTable.schema.fields.length, 'exposes GPU schema column count');
+  t.equal(gpuTable.nullCount, table.nullCount, 'exposes source table null count');
+  t.equal(gpuTable.schema.metadata.get('table'), 'source', 'exposes GPU schema metadata');
+  t.equal(gpuTable.schema.fields.length, 2, 'exposes selected GPU fields');
+  t.deepEqual(
+    gpuTable.schema.fields.map(field => field.name),
+    ['positions', 'colors'],
+    'GPU schema fields use shader attribute names'
+  );
   t.deepEqual(
     gpuTable.bufferLayout,
     [
@@ -39,6 +43,19 @@ test('ArrowGPUTable creates GPU vectors from shader-compatible Arrow table colum
   );
   t.ok(gpuTable.gpuVectors.positions instanceof ArrowGPUVector, 'creates a positions GPU vector');
   t.ok(gpuTable.gpuVectors.colors instanceof ArrowGPUVector, 'creates a colors GPU vector');
+  t.equal(
+    gpuTable.gpuVectors.positions.type,
+    table.getChild('positions')?.type,
+    'vector exposes type'
+  );
+  t.equal(gpuTable.gpuVectors.positions.length, 2, 'vector exposes length');
+  t.equal(gpuTable.gpuVectors.positions.stride, 2, 'vector exposes stride');
+  t.equal(gpuTable.gpuVectors.colors.stride, 4, 'vector exposes color stride');
+  t.equal(
+    gpuTable.schema.fields[0].metadata.get('semantic'),
+    'position',
+    'preserves same-name field metadata'
+  );
   t.equal(
     gpuTable.attributes.positions,
     gpuTable.gpuVectors.positions.buffer,
@@ -57,9 +74,7 @@ test('ArrowGPUTable creates GPU vectors from shader-compatible Arrow table colum
 
 test('ArrowGPUTable maps shader attributes through Arrow paths', t => {
   const device = new NullDevice({});
-  const table = new arrow.Table({
-    color: makeArrowFixedSizeListVector(new arrow.Uint8(), 4, new Uint8Array([255, 0, 0, 255]))
-  });
+  const table = makeGpuMetadataTable();
   const shaderLayout: ShaderLayout = {
     attributes: [{name: 'instanceColors', location: 0, type: 'vec4<f32>'}],
     bindings: []
@@ -67,7 +82,7 @@ test('ArrowGPUTable maps shader attributes through Arrow paths', t => {
 
   const gpuTable = new ArrowGPUTable(device, table, {
     shaderLayout,
-    arrowPaths: {instanceColors: 'color'}
+    arrowPaths: {instanceColors: 'colors'}
   });
 
   t.deepEqual(
@@ -76,7 +91,131 @@ test('ArrowGPUTable maps shader attributes through Arrow paths', t => {
     'derives buffer layouts from explicit Arrow paths'
   );
   t.ok(gpuTable.attributes.instanceColors, 'exposes renamed shader attribute buffer');
+  t.deepEqual(
+    gpuTable.schema.fields.map(field => field.name),
+    ['instanceColors'],
+    'renamed GPU schema field uses shader attribute name'
+  );
+  t.equal(
+    gpuTable.schema.fields[0].metadata.get('semantic'),
+    'color',
+    'renamed GPU schema field preserves source field metadata'
+  );
+  t.equal(
+    gpuTable.schema.fields[0].type,
+    table.getChild('colors')?.type,
+    'renamed GPU schema field preserves source field type'
+  );
 
   gpuTable.destroy();
   t.end();
 });
+
+test('ArrowGPUTable preserves nested Arrow field metadata', t => {
+  const device = new NullDevice({});
+  const table = makeNestedGpuMetadataTable();
+  const shaderLayout: ShaderLayout = {
+    attributes: [{name: 'instanceColors', location: 0, type: 'vec4<f32>'}],
+    bindings: []
+  };
+
+  const gpuTable = new ArrowGPUTable(device, table, {
+    shaderLayout,
+    arrowPaths: {instanceColors: 'style.colors'}
+  });
+
+  t.equal(
+    gpuTable.schema.fields[0].name,
+    'instanceColors',
+    'nested path GPU schema field uses shader attribute name'
+  );
+  t.equal(
+    gpuTable.schema.fields[0].metadata.get('semantic'),
+    'nested-color',
+    'nested path GPU schema field preserves leaf field metadata'
+  );
+  gpuTable.destroy();
+  t.end();
+});
+
+function makeGpuMetadataTable(): arrow.Table {
+  const positionsData = makeFixedSizeListData(
+    new arrow.Float32(),
+    2,
+    new Float32Array([0, 0, 1, 1])
+  );
+  const colorsData = makeFixedSizeListData(
+    new arrow.Uint8(),
+    4,
+    new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255])
+  );
+  const schema = new arrow.Schema(
+    [
+      new arrow.Field('positions', positionsData.type, false, new Map([['semantic', 'position']])),
+      new arrow.Field('colors', colorsData.type, false, new Map([['semantic', 'color']]))
+    ],
+    new Map([['table', 'source']])
+  );
+  const structData = arrow.makeData({
+    type: new arrow.Struct(schema.fields),
+    length: 2,
+    nullCount: 0,
+    nullBitmap: null,
+    children: [positionsData, colorsData]
+  });
+
+  return new arrow.Table([new arrow.RecordBatch(schema, structData)]);
+}
+
+function makeNestedGpuMetadataTable(): arrow.Table {
+  const colorsData = makeFixedSizeListData(
+    new arrow.Uint8(),
+    4,
+    new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255])
+  );
+  const nestedSchema = new arrow.Schema([
+    new arrow.Field('colors', colorsData.type, false, new Map([['semantic', 'nested-color']]))
+  ]);
+  const nestedStructData = arrow.makeData({
+    type: new arrow.Struct(nestedSchema.fields),
+    length: 2,
+    nullCount: 0,
+    nullBitmap: null,
+    children: [colorsData]
+  });
+  const schema = new arrow.Schema(
+    [new arrow.Field('style', nestedStructData.type)],
+    new Map([['table', 'nested-source']])
+  );
+  const structData = arrow.makeData({
+    type: new arrow.Struct(schema.fields),
+    length: 2,
+    nullCount: 0,
+    nullBitmap: null,
+    children: [nestedStructData]
+  });
+
+  return new arrow.Table([new arrow.RecordBatch(schema, structData)]);
+}
+
+function makeFixedSizeListData<T extends arrow.DataType>(
+  childType: T,
+  listSize: 2 | 3 | 4,
+  values: T['TArray']
+): arrow.Data<arrow.FixedSizeList<T>> {
+  const childData = arrow.makeData({
+    type: childType,
+    length: values.length,
+    nullCount: 0,
+    nullBitmap: null,
+    data: values
+  });
+  const listType = new arrow.FixedSizeList(listSize, new arrow.Field('value', childType));
+  return arrow.makeData({
+    type: listType,
+    length: values.length / listSize,
+    nullCount: 0,
+    nullBitmap: null,
+    child: childData
+  });
+}


### PR DESCRIPTION
## Summary

Adds Arrow-derived GPU metadata surfaces to `@luma.gl/arrow` and clarifies that `ArrowGPUVector` / `ArrowGPUTable` are GPU representations created from Arrow inputs, not wrappers that retain source Arrow objects.

## Changes

- Adds GPU-side Arrow metadata:
  - `ArrowGPUVector` exposes `buffer`, `type`, `length`, and `stride`.
  - `ArrowGPUTable` exposes `schema`, `numRows`, `numCols`, `nullCount`, `bufferLayout`, `gpuVectors`, and `attributes`.
- Keeps field names, types, nullability, and metadata on `ArrowGPUTable.schema.fields`.
- Preserves table-level schema metadata on `ArrowGPUTable.schema.metadata`.
- Preserves field metadata for same-name columns, `arrowPaths`, and nested Arrow paths.
- Removes retained source references from GPU objects:
  - no retained `arrow.Vector` on `ArrowGPUVector`
  - no retained `arrow.Table` on `ArrowGPUTable`
- Updates `ArrowModel` to infer counts from `ArrowGPUTable.numRows`.
- Adds TSDoc for Arrow GPU classes, props, helpers, and type utilities.
- Expands Arrow shader-column docs and the module README with the source-independent GPU object model.

## Tests

Passed locally:

- `corepack yarn lint fix`
- `corepack yarn lint`
- `corepack yarn build`
- `corepack yarn test-node`
- `corepack yarn test-browser modules/arrow/test/arrow/plain-gpu-table.spec.ts modules/arrow/test/arrow/arrow-fixed-size-list.spec.ts modules/arrow/test/arrow/arrow-model.spec.ts`
- `corepack yarn website:build`
- `git diff --check`

Note: `website:build` completed successfully but printed a non-fatal Docusaurus update-check permission warning for `/Users/ib/.config`.
