### PR TITLE
feat(arrow) TableBufferPlanner

### DIFF
--- a/docs/api-guide/gpu/arrow-table-columns.md
+++ b/docs/api-guide/gpu/arrow-table-columns.md
@@ -126,6 +126,80 @@ const colorVector: ArrowGPUVector = arrowGPUTable.gpuVectors.instanceColors;
 `Model`. It accepts an Arrow table as an update source and replaces the GPU
 representation when `setProps({arrowTable})` is called.
 
+## Planning Table Buffer Groups
+
+`TableBufferPlanner` is a lower-level helper for applications that already have
+column descriptors and need to decide how those columns should consume GPU
+buffer bindings. It does not upload buffers, interleave data, or bind storage
+buffers. It only returns a plan that describes allocation groups, column
+mappings, and which columns should be represented by planner-owned packed or
+storage buffers.
+
+Use it when a table has more columns than the target device can expose as
+separate vertex buffers, or when row-geometry data may later be read from WebGPU
+storage buffers instead of expanded into per-vertex attributes.
+
+```ts
+import {TableBufferPlanner} from '@luma.gl/arrow';
+
+const plan = TableBufferPlanner.getAllocationPlan({
+  device,
+  modelInfo: {isInstanced: true},
+  generateConstantAttributes: device.type === 'webgpu',
+  columns: [
+    {
+      id: 'positions',
+      byteStride: 8,
+      byteLength: 8 * 4,
+      rowCount: 4,
+      stepMode: 'vertex',
+      supportsPackedBuffer: true
+    },
+    {
+      id: 'instancePositions',
+      byteStride: 12,
+      byteLength: 12 * table.numRows,
+      rowCount: table.numRows,
+      stepMode: 'instance',
+      isPosition: true,
+      supportsPackedBuffer: true,
+      priority: 'high'
+    },
+    {
+      id: 'instanceColors',
+      byteStride: 4,
+      byteLength: 4 * table.numRows,
+      rowCount: table.numRows,
+      stepMode: 'instance',
+      supportsPackedBuffer: true
+    }
+  ]
+});
+```
+
+The planner supports two modes:
+
+- `table-with-shared-geometry`: one reusable geometry is drawn once for each
+  table row. Vertex-rate columns describe the shared geometry; table columns are
+  usually instance-rate attributes.
+- `table-with-row-geometries`: each table row expands into its own generated
+  vertices, such as paths or polygons. Constants are planned as a one-row
+  instance-rate group.
+
+The returned `plan.groups` describe physical allocation groups such as
+`separate-attribute-column`, `interleaved-attribute-columns`,
+`position-attribute-columns`, and `interleaved-constant-attribute-columns`.
+`plan.mappingsByColumnId` maps each source column to shader-visible attribute
+names and group ids. `plan.packedColumnIds` identifies columns that callers may
+pack into planner-owned vertex buffers.
+
+When `useStorageBuffers` is enabled, WebGPU row-geometry data columns may be
+assigned to `separate-storage-column` or `stacked-storage-columns` groups. This
+is planner output only in the current arrow module; callers still need their own
+storage-buffer upload and shader binding path. Storage planning observes
+`maxStorageBuffersPerShaderStage`, `maxStorageBufferBindingSize`, and uses
+256-byte alignment for stacked column offsets.
+
 ## Supported Shader Types
 
 Arrow scalar numeric columns map to scalar shader attributes. Arrow

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -10,6 +10,7 @@ Target Release Date: Q3, 2026
 
 - **Arrow shader layouts** - `getArrowBufferLayout()` maps Arrow scalar and `FixedSizeList` columns to shader attribute formats from a shader-first layout, including direct `arrow.Vector` sources and Arrow table path mappings.
 - **Arrow GPU helpers** - New `ArrowGPUVector`, `ArrowGPUTable`, and `ArrowModel` helpers create GPU buffers from compatible Arrow columns and keep Arrow-backed model attributes updatable through `setProps({arrowTable})`.
+- **Arrow table buffer planning** - New `TableBufferPlanner` API builds deterministic GPU buffer allocation plans for table columns, including interleaved fallback groups and WebGPU storage-buffer planning output.
 - **[Arrow Instancing Example](/examples/showcase/arrow-instancing)** - New showcase example renders instanced cubes from an Apache Arrow table.
 
 **@luma.gl/engine**

--- a/modules/arrow/README.md
+++ b/modules/arrow/README.md
@@ -7,4 +7,8 @@ GPU-side `ArrowGPUVector`, `ArrowGPUTable`, and `ArrowModel` objects from
 compatible Arrow columns. Arrow tables and vectors are construction inputs; the
 GPU objects retain GPU buffers plus Arrow-derived type and schema metadata.
 
+For lower-level table pipelines, `TableBufferPlanner` can produce deterministic
+GPU allocation plans from column descriptors while respecting device vertex and
+storage buffer limits.
+
 See [luma.gl](http://luma.gl) for documentation.

--- a/modules/arrow/src/arrow/table-buffer-planner.ts
+++ b/modules/arrow/src/arrow/table-buffer-planner.ts
@@ -1,0 +1,742 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Device} from '@luma.gl/core';
+
+/** Priority hint for assigning scarce dedicated vertex-buffer slots to table columns. */
+export type TableColumnPriority = 'high' | 'medium' | 'low';
+
+/**
+ * Physical GPU allocation shape chosen for a table column or group of columns.
+ *
+ * @remarks
+ * These values describe planner output only. Callers remain responsible for
+ * allocating buffers, packing data for interleaved groups, and binding any
+ * storage-buffer groups.
+ */
+export type AllocationGroupKind =
+  /** Interleaved vertex-rate columns that describe a reusable geometry shared by all table rows. */
+  | 'interleaved-shared-geometry-columns'
+  /** Position columns, including multiple named position columns and fp64 high components. */
+  | 'position-attribute-columns'
+  /** Interleaved small buffer for constant columns and fp64 low position components. */
+  | 'interleaved-constant-attribute-columns'
+  /** One vertex-buffer binding dedicated to one attribute column. */
+  | 'separate-attribute-column'
+  /** One interleaved vertex-buffer binding shared by lower-priority attribute columns. */
+  | 'interleaved-attribute-columns'
+  /** One storage-buffer binding dedicated to one original table column. */
+  | 'separate-storage-column'
+  /** One storage-buffer binding containing multiple whole-column slices at aligned offsets. */
+  | 'stacked-storage-columns'
+  /** A column that keeps its existing external allocation/publication path. */
+  | 'unmanaged-attribute-column';
+
+/**
+ * Planner mode describing how source table rows map to draw-time geometry.
+ *
+ * @remarks
+ * Shared-geometry mode is the default and models one table row as one instance.
+ * Row-geometry mode models one table row as a variable number of generated
+ * vertices, such as paths or polygons.
+ */
+export type TableBufferPlannerMode =
+  /** Each source table row draws one instance of reusable shared geometry. */
+  | 'table-with-shared-geometry'
+  /** Each source table row expands into its own inline generated vertices. */
+  | 'table-with-row-geometries';
+
+/** Model geometry hints used by {@link TableBufferPlanner}. */
+export type TableBufferPlannerModelInfo = {
+  /** Whether the model draws one shared geometry instance per table row. */
+  isInstanced?: boolean;
+  /** Vertex-buffer slots already consumed by model geometry. */
+  reservedVertexBufferCount?: number;
+};
+
+/**
+ * One allocation group emitted by {@link TableBufferPlanner}.
+ *
+ * @remarks
+ * A group represents one physical GPU allocation or one externally managed
+ * column. For vertex-buffer groups, `columns` describes the attributes that
+ * should be published from that allocation. For storage-buffer groups,
+ * `byteLength` and `byteOffsets` describe whole-column storage slices.
+ */
+export type TableBufferGroup = {
+  /** Stable buffer/group id used by downstream model-binding code. */
+  id: string;
+  /** Physical allocation shape for this group. */
+  kind: AllocationGroupKind;
+  /** Vertex attribute columns or fp64 component views assigned to this group. */
+  columns: PlannedColumn[];
+  /** Number of rows to materialize for small generated buffers, such as constants. */
+  rowCount?: number;
+  /** Vertex input step mode for groups whose row count is planner-owned. */
+  stepMode?: 'vertex' | 'instance';
+  /** Byte length for storage-buffer groups. */
+  byteLength?: number;
+  /** Per-column byte offsets for storage-buffer groups. */
+  byteOffsets?: Record<string, number>;
+};
+
+/**
+ * Source table column descriptor consumed by {@link TableBufferPlanner}.
+ *
+ * @remarks
+ * The planner intentionally works from abstract descriptors. It does not
+ * inspect Arrow vectors, upload GPU buffers, run accessors, or pack typed
+ * arrays. Callers derive these descriptors from their own table and shader
+ * metadata, then consume the returned {@link TableBufferPlan}.
+ */
+export type TableColumnDescriptor = {
+  /** Stable column id, usually the shader attribute id. */
+  id: string;
+  /** Byte stride contributed by this column to an interleaved vertex attribute buffer. */
+  byteStride: number;
+  /** Byte length of the original column when represented as storage data. */
+  byteLength: number;
+  /** Number of rows currently materialized for this column. */
+  rowCount: number;
+  /** Vertex input step mode this column would publish to a model. */
+  stepMode: 'vertex' | 'instance';
+  /** Whether this is a geometry-defining position column. */
+  isPosition?: boolean;
+  /** Whether this column is currently a constant value. */
+  isConstant?: boolean;
+  /** Whether this column is an index buffer. */
+  isIndexed?: boolean;
+  /** Whether this column is currently controlled by transitions. */
+  isTransition?: boolean;
+  /** Whether the column is backed only by an external GPU buffer and has no CPU value to pack. */
+  isExternalBufferOnly?: boolean;
+  /** Whether this is an fp64 source column. Non-position fp64 columns are unmanaged. */
+  isDoublePrecision?: boolean;
+  /** Whether this column should avoid standalone GPU buffers. */
+  noAlloc?: boolean;
+  /** Whether noAlloc may be ignored because the column is generated and CPU-backed. */
+  allowNoAllocManaged?: boolean;
+  /** Whether this column can be copied into planner-owned packed buffers. */
+  supportsPackedBuffer?: boolean;
+  /** Whether this generated row-geometry column must stay as a vertex attribute. */
+  isGeneratedRowGeometry?: boolean;
+  /** Priority for receiving a separate vertex-buffer binding. */
+  priority?: TableColumnPriority;
+};
+
+/**
+ * Column view assigned to a {@link TableBufferGroup}.
+ *
+ * @remarks
+ * Double-precision position columns can produce separate `high` and `low`
+ * component views so callers can publish fp64 shader attributes from different
+ * physical groups.
+ */
+export type PlannedColumn = {
+  /** Source table column id. */
+  id: string;
+  /** Selects the fp64 high or low component view for position columns. */
+  fp64Component?: 'high' | 'low';
+};
+
+/**
+ * Complete planner output consumed by downstream model-binding code.
+ *
+ * @remarks
+ * The plan is deterministic for a given set of descriptors and device limits.
+ * `groups` is ordered for publication. The reverse lookups let callers update
+ * or bind only the groups affected by a changed source column.
+ */
+export type TableBufferPlan = {
+  /** Ordered allocation groups to publish to a Model. */
+  groups: TableBufferGroup[];
+  /** Reverse lookup from source column id to all groups containing that column. */
+  groupsByColumnId: Record<string, TableBufferGroup[]>;
+  /** Reverse lookup from source column id to shader/model binding names and offsets. */
+  mappingsByColumnId: Record<string, TableBufferMapping[]>;
+  /** Columns represented by planner-owned vertex buffers. */
+  packedColumnIds: Set<string>;
+  /** Columns represented by storage-buffer groups. */
+  storageColumnIds: Set<string>;
+};
+
+/** Model-binding mapping for one planned vertex attribute or fp64 component view. */
+export type TableBufferMapping = {
+  /** Source table column id. */
+  columnId: string;
+  /** Shader-visible attribute name, e.g. instanceSourcePositions64Low. */
+  attributeName: string;
+  /** Buffer/group id that contains this attribute view. */
+  bufferName: string;
+  /** Physical allocation shape of the containing group. */
+  groupKind: AllocationGroupKind;
+  /** fp64 component represented by this mapping, if any. */
+  fp64Component?: 'high' | 'low';
+  /** Byte offset within a storage-buffer group. */
+  byteOffset?: number;
+};
+
+/** Inputs to {@link TableBufferPlanner.getAllocationPlan}. */
+export type TableBufferPlannerProps = {
+  /** Device whose vertex/storage binding limits constrain the plan. */
+  device: Device;
+  /** Candidate table columns. */
+  columns: TableColumnDescriptor[];
+  /** Model geometry mode and reserved vertex-buffer slots. */
+  modelInfo?: TableBufferPlannerModelInfo;
+  /** Optional explicit planner mode. Defaults from modelInfo.isInstanced. */
+  mode?: TableBufferPlannerMode;
+  /** Enables planner-only storage-buffer allocation for row-geometry table columns. */
+  useStorageBuffers?: boolean;
+  /** Whether constant columns should be materialized into small planner-owned buffers. */
+  generateConstantAttributes?: boolean;
+};
+
+const PRIORITY_RANK: Record<TableColumnPriority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2
+};
+const POSITIONS_GROUP_ID = 'position-attribute-columns';
+const STORAGE_OVERFLOW_COLUMN_ALIGNMENT = 256;
+
+/**
+ * Builds table-first GPU buffer allocation plans from abstract column descriptors.
+ *
+ * @remarks
+ * `TableBufferPlanner` is a pure planning utility. It does not allocate GPU
+ * buffers, mutate descriptors, retain Arrow data, or bind model resources.
+ */
+export class TableBufferPlanner {
+  /**
+   * Classifies columns, assigns allocation groups, validates device limits, and
+   * returns model mappings.
+   *
+   * @param props - Planner inputs including device limits, candidate columns,
+   * model geometry hints, and optional storage/constant planning flags.
+   * @returns A deterministic table buffer allocation plan.
+   */
+  static getAllocationPlan({
+    device,
+    columns,
+    modelInfo,
+    mode = getPlannerMode(modelInfo),
+    useStorageBuffers = false,
+    generateConstantAttributes = false
+  }: TableBufferPlannerProps): TableBufferPlan {
+    const sortedColumns = [...columns].sort((a, b) => a.id.localeCompare(b.id));
+    const columnsById = Object.fromEntries(
+      sortedColumns.map(column => [column.id, column])
+    ) as Record<string, TableColumnDescriptor>;
+    const groups: TableBufferGroup[] = [];
+    const geometryColumns: PlannedColumn[] = [];
+    const constantColumns: PlannedColumn[] = [];
+    const positionColumns: PlannedColumn[] = [];
+    const dataColumns: PlannedColumn[] = [];
+    const reservedVertexBufferCount = modelInfo?.reservedVertexBufferCount || 0;
+
+    for (const column of sortedColumns) {
+      if (
+        column.isIndexed ||
+        column.isTransition ||
+        column.isExternalBufferOnly ||
+        (column.isConstant && !generateConstantAttributes) ||
+        (column.isPosition && column.isDoublePrecision && !generateConstantAttributes) ||
+        !canUsePlannedBuffer(column) ||
+        (!column.supportsPackedBuffer && !column.isPosition)
+      ) {
+        groups.push({
+          id: column.id,
+          kind: 'unmanaged-attribute-column',
+          columns: [{id: column.id}]
+        });
+      } else if (mode === 'table-with-row-geometries') {
+        if (column.isPosition) {
+          positionColumns.push({
+            id: column.id,
+            fp64Component: column.isDoublePrecision ? 'high' : undefined
+          });
+          if (column.isDoublePrecision && generateConstantAttributes) {
+            constantColumns.push({id: column.id, fp64Component: 'low'});
+          }
+        } else if (column.isConstant && generateConstantAttributes) {
+          constantColumns.push({id: column.id});
+        } else {
+          dataColumns.push({id: column.id});
+        }
+      } else if (column.stepMode === 'vertex') {
+        geometryColumns.push({id: column.id});
+      } else if (column.isPosition) {
+        positionColumns.push({
+          id: column.id,
+          fp64Component: column.isDoublePrecision ? 'high' : undefined
+        });
+        if (column.isDoublePrecision && generateConstantAttributes) {
+          constantColumns.push({id: column.id, fp64Component: 'low'});
+        }
+      } else if (column.isConstant && generateConstantAttributes) {
+        constantColumns.push({id: column.id});
+      } else {
+        dataColumns.push({id: column.id});
+      }
+    }
+
+    if (geometryColumns.length) {
+      groups.push({
+        id: 'interleaved-shared-geometry-columns',
+        kind: 'interleaved-shared-geometry-columns',
+        columns: geometryColumns
+      });
+    }
+    if (constantColumns.length) {
+      groups.push({
+        id: 'interleaved-constant-attribute-columns',
+        kind: 'interleaved-constant-attribute-columns',
+        columns: constantColumns,
+        rowCount:
+          mode === 'table-with-row-geometries'
+            ? 1
+            : getPackedRowCount([...geometryColumns, ...positionColumns], columnsById),
+        stepMode: mode === 'table-with-row-geometries' ? 'instance' : 'vertex'
+      });
+    }
+    if (positionColumns.length) {
+      groups.push({
+        id: POSITIONS_GROUP_ID,
+        kind: 'position-attribute-columns',
+        columns: positionColumns
+      });
+    }
+
+    const {storageGroups, vertexColumns} = allocateStorageAttributes({
+      device,
+      mode,
+      useStorageBuffers,
+      columns: dataColumns,
+      columnsById
+    });
+    groups.push(...storageGroups);
+    groups.push(
+      ...allocateDataAttributes(
+        device,
+        groups,
+        vertexColumns,
+        columnsById,
+        reservedVertexBufferCount
+      )
+    );
+    validatePlan(device, groups, columnsById, reservedVertexBufferCount);
+
+    const groupsByColumnId: Record<string, TableBufferGroup[]> = {};
+    const mappingsByColumnId: Record<string, TableBufferMapping[]> = {};
+    const packedColumnIds = new Set<string>();
+    const storageColumnIds = new Set<string>();
+    for (const group of groups) {
+      for (const {id: columnId, fp64Component} of group.columns) {
+        groupsByColumnId[columnId] = groupsByColumnId[columnId] || [];
+        groupsByColumnId[columnId].push(group);
+        mappingsByColumnId[columnId] = mappingsByColumnId[columnId] || [];
+        const byteOffset = getStorageBufferByteOffset(group, columnId);
+        mappingsByColumnId[columnId].push({
+          columnId,
+          attributeName: fp64Component === 'low' ? `${columnId}64Low` : columnId,
+          bufferName: group.id,
+          groupKind: group.kind,
+          fp64Component,
+          ...(byteOffset === undefined ? {} : {byteOffset})
+        });
+        if (group.kind === 'separate-storage-column' || group.kind === 'stacked-storage-columns') {
+          storageColumnIds.add(columnId);
+        } else if (group.kind !== 'unmanaged-attribute-column') {
+          packedColumnIds.add(columnId);
+        }
+      }
+    }
+
+    return {
+      groups,
+      groupsByColumnId,
+      mappingsByColumnId,
+      packedColumnIds,
+      storageColumnIds
+    };
+  }
+
+  /**
+   * Returns true when a column should compute CPU values but skip creating
+   * its own standalone GPU buffer because the caller will publish it.
+   *
+   * @param column - Source column descriptor to classify.
+   * @returns `true` when the column is eligible for caller-owned publication
+   * through planner-managed buffers.
+   */
+  static shouldSkipColumnBuffer(column: TableColumnDescriptor): boolean {
+    return (
+      !column.isIndexed &&
+      (!column.isDoublePrecision || Boolean(column.isPosition)) &&
+      !column.isExternalBufferOnly &&
+      (!column.noAlloc || Boolean(column.allowNoAllocManaged)) &&
+      !column.isTransition &&
+      (column.stepMode === 'vertex' || column.stepMode === 'instance')
+    );
+  }
+}
+
+/**
+ * Optionally moves row-geometry data columns into storage-buffer groups.
+ * Columns that cannot be represented as storage buffers fall back to vertex attributes.
+ *
+ * @param props - Storage planning inputs and the already-classified data columns.
+ * @returns Storage-buffer groups plus columns that still need vertex-buffer planning.
+ */
+function allocateStorageAttributes({
+  device,
+  mode,
+  useStorageBuffers,
+  columns,
+  columnsById
+}: {
+  device: Device;
+  mode: TableBufferPlannerMode;
+  useStorageBuffers: boolean;
+  columns: PlannedColumn[];
+  columnsById: Record<string, TableColumnDescriptor>;
+}): {storageGroups: TableBufferGroup[]; vertexColumns: PlannedColumn[]} {
+  if (!shouldUseStorageBuffers(device, mode, useStorageBuffers) || !columns.length) {
+    return {storageGroups: [], vertexColumns: columns};
+  }
+
+  const maxStorageBuffers = Math.max(0, device.limits.maxStorageBuffersPerShaderStage || 0);
+  const storageGroups: TableBufferGroup[] = [];
+  const vertexColumns: PlannedColumn[] = [];
+  const storageColumns: PlannedColumn[] = [];
+
+  for (const column of sortDataAttributes(columns, columnsById)) {
+    const descriptor = columnsById[column.id];
+    const byteLength = descriptor.byteLength;
+    if (
+      byteLength <= device.limits.maxStorageBufferBindingSize &&
+      !descriptor.isGeneratedRowGeometry
+    ) {
+      storageColumns.push(column);
+    } else {
+      vertexColumns.push(column);
+    }
+  }
+
+  const dedicatedCount =
+    maxStorageBuffers >= storageColumns.length
+      ? storageColumns.length
+      : Math.max(0, maxStorageBuffers - 1);
+
+  for (const column of storageColumns.slice(0, dedicatedCount)) {
+    storageGroups.push({
+      id: column.id,
+      kind: 'separate-storage-column',
+      columns: [column],
+      byteLength: columnsById[column.id].byteLength,
+      byteOffsets: {[column.id]: 0}
+    });
+  }
+
+  const overflowColumns = storageColumns.slice(dedicatedCount);
+  if (overflowColumns.length) {
+    const layout = getStorageOverflowLayout(overflowColumns, columnsById);
+    if (
+      storageGroups.length < maxStorageBuffers &&
+      layout.byteLength <= device.limits.maxStorageBufferBindingSize
+    ) {
+      storageGroups.push({
+        id: 'stacked-storage-columns',
+        kind: 'stacked-storage-columns',
+        columns: overflowColumns,
+        byteLength: layout.byteLength,
+        byteOffsets: layout.byteOffsets
+      });
+    } else {
+      vertexColumns.push(...overflowColumns);
+    }
+  }
+
+  return {storageGroups, vertexColumns};
+}
+
+/**
+ * Assigns ordinary data columns to dedicated vertex buffers while slots remain,
+ * then packs the rest into one interleaved overflow attribute buffer.
+ *
+ * @param device - Device whose vertex-buffer count limits constrain allocation.
+ * @param fixedGroups - Groups already allocated before data columns are assigned.
+ * @param columns - Data columns eligible for vertex-buffer allocation.
+ * @param columnsById - Source descriptors keyed by column id.
+ * @param reservedVertexBufferCount - Vertex-buffer slots already consumed by model geometry.
+ * @returns Additional data-column allocation groups.
+ */
+function allocateDataAttributes(
+  device: Device,
+  fixedGroups: TableBufferGroup[],
+  columns: PlannedColumn[],
+  columnsById: Record<string, TableColumnDescriptor>,
+  reservedVertexBufferCount: number
+): TableBufferGroup[] {
+  if (!columns.length) {
+    return [];
+  }
+
+  const sortedColumns = sortDataAttributes(columns, columnsById);
+
+  const fixedVertexBufferCount = countVertexBufferGroups(fixedGroups, columnsById);
+  const availableSlots =
+    device.limits.maxVertexBuffers - reservedVertexBufferCount - fixedVertexBufferCount;
+  const dedicatedCount =
+    availableSlots >= sortedColumns.length ? sortedColumns.length : Math.max(0, availableSlots - 1);
+  const groups: TableBufferGroup[] = [];
+
+  for (const column of sortedColumns.slice(0, dedicatedCount)) {
+    groups.push({
+      id: column.id,
+      kind: 'separate-attribute-column',
+      columns: [column]
+    });
+  }
+
+  const overflowColumns = sortedColumns.slice(dedicatedCount);
+  if (overflowColumns.length) {
+    groups.push({
+      id: 'interleaved-attribute-columns',
+      kind: 'interleaved-attribute-columns',
+      columns: overflowColumns
+    });
+  }
+
+  return groups;
+}
+
+/**
+ * Verifies vertex-buffer counts, storage-buffer counts/sizes, and vertex array stride limits.
+ *
+ * @param device - Device whose limits are enforced.
+ * @param groups - Complete allocation groups to validate.
+ * @param columnsById - Source descriptors keyed by column id.
+ * @param reservedVertexBufferCount - Vertex-buffer slots already consumed by model geometry.
+ */
+function validatePlan(
+  device: Device,
+  groups: TableBufferGroup[],
+  columnsById: Record<string, TableColumnDescriptor>,
+  reservedVertexBufferCount: number
+): void {
+  const vertexBufferCount =
+    reservedVertexBufferCount + countVertexBufferGroups(groups, columnsById);
+  if (vertexBufferCount > device.limits.maxVertexBuffers) {
+    throw new Error(
+      `Attribute buffer allocation requires ${vertexBufferCount} vertex buffers, ` +
+        `but this device supports ${device.limits.maxVertexBuffers}`
+    );
+  }
+
+  const storageBufferGroups = groups.filter(
+    group => group.kind === 'separate-storage-column' || group.kind === 'stacked-storage-columns'
+  );
+  if (storageBufferGroups.length > device.limits.maxStorageBuffersPerShaderStage) {
+    throw new Error(
+      `Attribute buffer allocation requires ${storageBufferGroups.length} storage buffers, ` +
+        `but this device supports ${device.limits.maxStorageBuffersPerShaderStage}`
+    );
+  }
+
+  for (const group of storageBufferGroups) {
+    const byteLength = group.byteLength || columnsById[group.columns[0].id].byteLength;
+    if (byteLength > device.limits.maxStorageBufferBindingSize) {
+      throw new Error(
+        `Attribute storage buffer group "${group.id}" requires byteLength ${byteLength}, ` +
+          `but this device supports ${device.limits.maxStorageBufferBindingSize}`
+      );
+    }
+  }
+
+  for (const group of groups) {
+    if (
+      group.kind === 'unmanaged-attribute-column' ||
+      group.kind === 'separate-storage-column' ||
+      group.kind === 'stacked-storage-columns' ||
+      columnsById[group.columns[0]?.id]?.isIndexed
+    ) {
+      continue;
+    }
+    const byteStride = getGroupByteStride(group, columnsById);
+    if (byteStride > device.limits.maxVertexBufferArrayStride) {
+      throw new Error(
+        `Attribute buffer group "${group.id}" requires byteStride ${byteStride}, ` +
+          `but this device supports ${device.limits.maxVertexBufferArrayStride}`
+      );
+    }
+  }
+}
+
+/**
+ * Counts groups that consume vertex-buffer bindings, excluding storage and index groups.
+ *
+ * @param groups - Allocation groups to inspect.
+ * @param columnsById - Source descriptors keyed by column id.
+ * @returns Number of vertex-buffer bindings consumed by the groups.
+ */
+function countVertexBufferGroups(
+  groups: TableBufferGroup[],
+  columnsById: Record<string, TableColumnDescriptor>
+): number {
+  return groups.filter(
+    group =>
+      group.kind !== 'separate-storage-column' &&
+      group.kind !== 'stacked-storage-columns' &&
+      !columnsById[group.columns[0]?.id]?.isIndexed
+  ).length;
+}
+
+/**
+ * Sorts data columns by layout priority and then by id for deterministic plans.
+ *
+ * @param columns - Planned column views to sort.
+ * @param columnsById - Source descriptors keyed by column id.
+ * @returns A new sorted column array.
+ */
+function sortDataAttributes(
+  columns: PlannedColumn[],
+  columnsById: Record<string, TableColumnDescriptor>
+): PlannedColumn[] {
+  return [...columns].sort((a, b) => {
+    const priorityDiff = getPriorityRank(columnsById[a.id]) - getPriorityRank(columnsById[b.id]);
+    return priorityDiff || a.id.localeCompare(b.id);
+  });
+}
+
+/**
+ * Converts a layout priority into a sortable rank.
+ *
+ * @param column - Source column descriptor.
+ * @returns Numeric rank where lower values receive dedicated buffers first.
+ */
+function getPriorityRank(column: TableColumnDescriptor): number {
+  return PRIORITY_RANK[column.priority || 'medium'];
+}
+
+/**
+ * Selects the default planner mode from model instancing metadata.
+ *
+ * @param modelInfo - Optional model geometry hints.
+ * @returns Row-geometry mode when `isInstanced` is exactly `false`; otherwise shared-geometry mode.
+ */
+function getPlannerMode(modelInfo?: TableBufferPlannerModelInfo): TableBufferPlannerMode {
+  return modelInfo?.isInstanced === false
+    ? 'table-with-row-geometries'
+    : 'table-with-shared-geometry';
+}
+
+/**
+ * Computes the materialized row count for shared geometry/constant packed groups.
+ *
+ * @param columns - Column views that determine shared geometry row count.
+ * @param columnsById - Source descriptors keyed by column id.
+ * @returns At least one row, or the maximum row count among the provided columns.
+ */
+function getPackedRowCount(
+  columns: PlannedColumn[],
+  columnsById: Record<string, TableColumnDescriptor>
+): number {
+  return Math.max(1, ...columns.map(({id}) => columnsById[id].rowCount));
+}
+
+/**
+ * Returns whether a column can be represented by a planner-owned group.
+ *
+ * @param column - Source column descriptor.
+ * @returns `true` when planner-owned allocation can preserve column semantics.
+ */
+function canUsePlannedBuffer(column: TableColumnDescriptor): boolean {
+  if (column.isDoublePrecision && !column.isPosition) {
+    return false;
+  }
+  return !column.noAlloc || Boolean(column.allowNoAllocManaged);
+}
+
+/**
+ * Returns whether optional storage-buffer planning is enabled for this device/mode.
+ *
+ * @param device - Device whose backend type is checked.
+ * @param mode - Active planner mode.
+ * @param useStorageBuffers - Caller opt-in flag.
+ * @returns `true` only for WebGPU row-geometry planning with storage enabled.
+ */
+function shouldUseStorageBuffers(
+  device: Device,
+  mode: TableBufferPlannerMode,
+  useStorageBuffers: boolean
+): boolean {
+  return useStorageBuffers && device.type === 'webgpu' && mode === 'table-with-row-geometries';
+}
+
+/**
+ * Builds 256-byte-aligned whole-column slices for the stacked storage overflow buffer.
+ *
+ * @param columns - Storage-eligible columns assigned to the overflow group.
+ * @param columnsById - Source descriptors keyed by column id.
+ * @returns Total byte length and byte offsets for each source column.
+ */
+function getStorageOverflowLayout(
+  columns: PlannedColumn[],
+  columnsById: Record<string, TableColumnDescriptor>
+): {
+  byteLength: number;
+  byteOffsets: Record<string, number>;
+} {
+  let byteLength = 0;
+  const byteOffsets: Record<string, number> = {};
+
+  for (const {id} of columns) {
+    byteLength = alignTo(byteLength, STORAGE_OVERFLOW_COLUMN_ALIGNMENT);
+    byteOffsets[id] = byteLength;
+    byteLength += columnsById[id].byteLength;
+  }
+
+  return {byteLength: alignTo(byteLength, STORAGE_OVERFLOW_COLUMN_ALIGNMENT), byteOffsets};
+}
+
+/**
+ * Returns a column's byte offset inside a storage-buffer group.
+ *
+ * @param group - Allocation group that may represent storage data.
+ * @param columnId - Source column id.
+ * @returns The byte offset for storage-buffer mappings, or `undefined` for vertex-buffer groups.
+ */
+function getStorageBufferByteOffset(group: TableBufferGroup, columnId: string): number | undefined {
+  if (group.kind !== 'separate-storage-column' && group.kind !== 'stacked-storage-columns') {
+    return undefined;
+  }
+  return group.byteOffsets?.[columnId] ?? 0;
+}
+
+/**
+ * Rounds a value up to the next multiple of an alignment.
+ *
+ * @param value - Byte offset or length to align.
+ * @param alignment - Positive byte alignment.
+ * @returns Aligned value.
+ */
+function alignTo(value: number, alignment: number): number {
+  return Math.ceil(value / alignment) * alignment;
+}
+
+/**
+ * Computes byte stride for an interleaved vertex attribute group.
+ *
+ * @param group - Allocation group containing one or more planned columns.
+ * @param columnsById - Source descriptors keyed by column id.
+ * @returns Sum of source column byte strides in the group.
+ */
+function getGroupByteStride(
+  group: TableBufferGroup,
+  columnsById: Record<string, TableColumnDescriptor>
+): number {
+  return group.columns.reduce((byteStride, {id}) => byteStride + columnsById[id].byteStride, 0);
+}

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -35,6 +35,20 @@ export {analyzeArrowTable} from './arrow/analyze-arrow-table';
 
 export {getArrowListNestingLevel} from './arrow/arrow-utils';
 
+export {
+  TableBufferPlanner,
+  type AllocationGroupKind,
+  type PlannedColumn,
+  type TableBufferGroup,
+  type TableBufferMapping,
+  type TableBufferPlan,
+  type TableBufferPlannerMode,
+  type TableBufferPlannerModelInfo,
+  type TableBufferPlannerProps,
+  type TableColumnDescriptor,
+  type TableColumnPriority
+} from './arrow/table-buffer-planner';
+
 // GEOARROW
 
 export {

--- a/modules/arrow/test/arrow/table-buffer-planner.spec.ts
+++ b/modules/arrow/test/arrow/table-buffer-planner.spec.ts
@@ -1,0 +1,426 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {TableBufferPlanner, type TableColumnDescriptor} from '@luma.gl/arrow';
+import type {Device} from '@luma.gl/core';
+import {NullDevice} from '@luma.gl/test-utils';
+
+test('TableBufferPlanner builds shared-geometry allocation groups deterministically', t => {
+  const plan = TableBufferPlanner.getAllocationPlan({
+    device: createDevice({maxVertexBuffers: 8}),
+    modelInfo: {isInstanced: true},
+    generateConstantAttributes: true,
+    columns: [
+      makeColumn('instanceSizes', {isConstant: true, priority: 'low'}),
+      makeColumn('positions', {stepMode: 'vertex', byteStride: 8, byteLength: 32, rowCount: 4}),
+      makeColumn('instanceAngles'),
+      makeColumn('instancePositions', {byteStride: 12, byteLength: 24, isPosition: true})
+    ]
+  });
+
+  t.deepEqual(
+    plan.groups.map(group => [group.id, group.kind, group.columns.map(column => column.id)]),
+    [
+      ['interleaved-shared-geometry-columns', 'interleaved-shared-geometry-columns', ['positions']],
+      [
+        'interleaved-constant-attribute-columns',
+        'interleaved-constant-attribute-columns',
+        ['instanceSizes']
+      ],
+      ['position-attribute-columns', 'position-attribute-columns', ['instancePositions']],
+      ['instanceAngles', 'separate-attribute-column', ['instanceAngles']]
+    ],
+    'builds stable groups independent of input order'
+  );
+  t.equal(
+    plan.groups.find(group => group.id === 'interleaved-constant-attribute-columns')?.rowCount,
+    4,
+    'shared-geometry constants use shared geometry row count'
+  );
+  t.equal(
+    plan.groups.find(group => group.id === 'interleaved-constant-attribute-columns')?.stepMode,
+    'vertex',
+    'shared-geometry constants use vertex step mode'
+  );
+  t.deepEqual(
+    [...plan.packedColumnIds].sort(),
+    ['instanceAngles', 'instancePositions', 'instanceSizes', 'positions'],
+    'tracks planner-owned vertex buffer columns'
+  );
+  t.equal(
+    plan.mappingsByColumnId.instancePositions[0].bufferName,
+    'position-attribute-columns',
+    'maps position column to position group'
+  );
+
+  t.end();
+});
+
+test('TableBufferPlanner builds row-geometry constants with instance step mode', t => {
+  const plan = TableBufferPlanner.getAllocationPlan({
+    device: createDevice({maxVertexBuffers: 8}),
+    modelInfo: {isInstanced: false},
+    generateConstantAttributes: true,
+    columns: [
+      makeColumn('positions', {
+        stepMode: 'vertex',
+        byteStride: 8,
+        byteLength: 80,
+        rowCount: 10,
+        isPosition: true
+      }),
+      makeColumn('angles', {isConstant: true})
+    ]
+  });
+
+  t.deepEqual(
+    plan.groups.map(group => [group.id, group.kind, group.columns.map(column => column.id)]),
+    [
+      [
+        'interleaved-constant-attribute-columns',
+        'interleaved-constant-attribute-columns',
+        ['angles']
+      ],
+      ['position-attribute-columns', 'position-attribute-columns', ['positions']]
+    ],
+    'row-geometry mode separates constants from positions'
+  );
+  t.equal(plan.groups[0].rowCount, 1, 'row-geometry constants use one materialized row');
+  t.equal(plan.groups[0].stepMode, 'instance', 'row-geometry constants use instance step mode');
+
+  t.end();
+});
+
+test('TableBufferPlanner uses priority for separate vs interleaved data columns', t => {
+  const plan = TableBufferPlanner.getAllocationPlan({
+    device: createDevice({maxVertexBuffers: 2}),
+    modelInfo: {isInstanced: true},
+    columns: [
+      makeColumn('instancePickingColors', {priority: 'low'}),
+      makeColumn('instanceAngles', {priority: 'medium'}),
+      makeColumn('instanceColors', {priority: 'high'})
+    ]
+  });
+
+  t.deepEqual(
+    plan.groups.map(group => [group.id, group.kind, group.columns.map(column => column.id)]),
+    [
+      ['instanceColors', 'separate-attribute-column', ['instanceColors']],
+      [
+        'interleaved-attribute-columns',
+        'interleaved-attribute-columns',
+        ['instanceAngles', 'instancePickingColors']
+      ]
+    ],
+    'assigns scarce separate slots by priority, then id'
+  );
+
+  t.end();
+});
+
+test('TableBufferPlanner marks unsupported columns as unmanaged', t => {
+  const plan = TableBufferPlanner.getAllocationPlan({
+    device: createDevice({maxVertexBuffers: 16}),
+    modelInfo: {isInstanced: true},
+    generateConstantAttributes: true,
+    columns: [
+      makeColumn('externalValues', {isExternalBufferOnly: true}),
+      makeColumn('indices', {isIndexed: true}),
+      makeColumn('nonPosition64', {isDoublePrecision: true}),
+      makeColumn('noAllocValues', {noAlloc: true}),
+      makeColumn('transitionValues', {isTransition: true}),
+      makeColumn('generatedPickingColors', {
+        noAlloc: true,
+        allowNoAllocManaged: true,
+        priority: 'low'
+      })
+    ]
+  });
+
+  t.deepEqual(
+    Object.fromEntries(
+      Object.entries(plan.groupsByColumnId).map(([columnId, groups]) => [columnId, groups[0].kind])
+    ),
+    {
+      externalValues: 'unmanaged-attribute-column',
+      generatedPickingColors: 'separate-attribute-column',
+      indices: 'unmanaged-attribute-column',
+      nonPosition64: 'unmanaged-attribute-column',
+      noAllocValues: 'unmanaged-attribute-column',
+      transitionValues: 'unmanaged-attribute-column'
+    },
+    'keeps unsafe columns unmanaged while allowing generated noAlloc CPU data'
+  );
+  t.notOk(
+    TableBufferPlanner.shouldSkipColumnBuffer(makeColumn('transitionValues', {isTransition: true})),
+    'does not skip unmanaged transition columns'
+  );
+  t.ok(
+    TableBufferPlanner.shouldSkipColumnBuffer(
+      makeColumn('generatedPickingColors', {noAlloc: true, allowNoAllocManaged: true})
+    ),
+    'can skip generated noAlloc columns that the planner can publish'
+  );
+
+  t.end();
+});
+
+test('TableBufferPlanner maps fp64 position high and low components separately', t => {
+  const plan = TableBufferPlanner.getAllocationPlan({
+    device: createDevice({maxVertexBuffers: 8}),
+    modelInfo: {isInstanced: true},
+    generateConstantAttributes: true,
+    columns: [
+      makeColumn('instanceSourcePositions', {
+        byteStride: 24,
+        byteLength: 48,
+        isPosition: true,
+        isDoublePrecision: true
+      }),
+      makeColumn('instanceTargetPositions', {
+        byteStride: 24,
+        byteLength: 48,
+        isPosition: true,
+        isDoublePrecision: true
+      })
+    ]
+  });
+
+  t.deepEqual(
+    plan.groups.map(group => [group.id, group.columns]),
+    [
+      [
+        'interleaved-constant-attribute-columns',
+        [
+          {id: 'instanceSourcePositions', fp64Component: 'low'},
+          {id: 'instanceTargetPositions', fp64Component: 'low'}
+        ]
+      ],
+      [
+        'position-attribute-columns',
+        [
+          {id: 'instanceSourcePositions', fp64Component: 'high'},
+          {id: 'instanceTargetPositions', fp64Component: 'high'}
+        ]
+      ]
+    ],
+    'splits fp64 position columns into low constants and high position group'
+  );
+  t.deepEqual(
+    plan.mappingsByColumnId.instanceSourcePositions.map(mapping => [
+      mapping.attributeName,
+      mapping.bufferName,
+      mapping.fp64Component
+    ]),
+    [
+      ['instanceSourcePositions64Low', 'interleaved-constant-attribute-columns', 'low'],
+      ['instanceSourcePositions', 'position-attribute-columns', 'high']
+    ],
+    'maps shader-visible fp64 attributes'
+  );
+
+  t.end();
+});
+
+test('TableBufferPlanner uses WebGPU row-geometry storage groups when enabled', t => {
+  const webgpuPlan = TableBufferPlanner.getAllocationPlan({
+    device: createDevice({
+      type: 'webgpu',
+      maxStorageBuffersPerShaderStage: 4,
+      maxStorageBufferBindingSize: 1024
+    }),
+    modelInfo: {isInstanced: false},
+    useStorageBuffers: true,
+    columns: [
+      makeColumn('positions', {
+        stepMode: 'vertex',
+        byteStride: 8,
+        byteLength: 80,
+        rowCount: 10,
+        isPosition: true
+      }),
+      makeColumn('fillColors', {byteStride: 4, byteLength: 8, priority: 'high'}),
+      makeColumn('elevations', {byteStride: 4, byteLength: 8})
+    ]
+  });
+  const webglPlan = TableBufferPlanner.getAllocationPlan({
+    device: createDevice({type: 'webgl', maxStorageBuffersPerShaderStage: 4}),
+    modelInfo: {isInstanced: false},
+    useStorageBuffers: true,
+    columns: [
+      makeColumn('positions', {stepMode: 'vertex', isPosition: true}),
+      makeColumn('elevations')
+    ]
+  });
+  const sharedGeometryPlan = TableBufferPlanner.getAllocationPlan({
+    device: createDevice({type: 'webgpu', maxStorageBuffersPerShaderStage: 4}),
+    modelInfo: {isInstanced: true},
+    useStorageBuffers: true,
+    columns: [makeColumn('elevations')]
+  });
+
+  t.deepEqual(
+    webgpuPlan.groups
+      .filter(group => group.kind === 'separate-storage-column')
+      .map(group => group.id)
+      .sort(),
+    ['elevations', 'fillColors'],
+    'uses dedicated storage buffers on WebGPU row geometries'
+  );
+  t.deepEqual(
+    [...webgpuPlan.storageColumnIds].sort(),
+    ['elevations', 'fillColors'],
+    'tracks storage columns'
+  );
+  t.notOk(webgpuPlan.packedColumnIds.has('fillColors'), 'storage columns are not packed columns');
+  t.notOk(
+    webglPlan.groups.some(group => group.kind === 'separate-storage-column'),
+    'does not use storage buffers on WebGL'
+  );
+  t.notOk(
+    sharedGeometryPlan.groups.some(group => group.kind === 'separate-storage-column'),
+    'does not use storage buffers for shared-geometry mode'
+  );
+
+  t.end();
+});
+
+test('TableBufferPlanner stacks storage groups and falls back on size limits', t => {
+  const countLimitedPlan = TableBufferPlanner.getAllocationPlan({
+    device: createDevice({
+      type: 'webgpu',
+      maxStorageBuffersPerShaderStage: 1,
+      maxStorageBufferBindingSize: 1024
+    }),
+    modelInfo: {isInstanced: false},
+    useStorageBuffers: true,
+    columns: [
+      makeColumn('positions', {stepMode: 'vertex', isPosition: true}),
+      makeColumn('fillColors', {byteStride: 4, byteLength: 8, priority: 'high'}),
+      makeColumn('elevations', {byteStride: 4, byteLength: 8})
+    ]
+  });
+  const sizeLimitedPlan = TableBufferPlanner.getAllocationPlan({
+    device: createDevice({
+      type: 'webgpu',
+      maxStorageBuffersPerShaderStage: 4,
+      maxStorageBufferBindingSize: 4
+    }),
+    modelInfo: {isInstanced: false},
+    useStorageBuffers: true,
+    columns: [
+      makeColumn('positions', {stepMode: 'vertex', isPosition: true}),
+      makeColumn('fillColors', {byteStride: 4, byteLength: 8, priority: 'high'}),
+      makeColumn('elevations', {byteStride: 4, byteLength: 8})
+    ]
+  });
+
+  const stackedGroup = countLimitedPlan.groups.find(
+    group => group.kind === 'stacked-storage-columns'
+  );
+  t.deepEqual(
+    stackedGroup && [stackedGroup.id, stackedGroup.columns.map(column => column.id)],
+    ['stacked-storage-columns', ['fillColors', 'elevations']],
+    'stacks overflow storage columns when only one binding is available'
+  );
+  t.deepEqual(
+    stackedGroup?.byteOffsets,
+    {fillColors: 0, elevations: 256},
+    'aligns stacked storage columns'
+  );
+  t.equal(
+    countLimitedPlan.mappingsByColumnId.elevations[0].byteOffset,
+    256,
+    'adds storage byte offsets to mappings'
+  );
+  t.notOk(
+    sizeLimitedPlan.groups.some(
+      group => group.kind === 'separate-storage-column' || group.kind === 'stacked-storage-columns'
+    ),
+    'falls back to vertex buffers when storage binding size is too small'
+  );
+
+  t.end();
+});
+
+test('TableBufferPlanner validates vertex buffer count and array stride limits', t => {
+  t.throws(
+    () =>
+      TableBufferPlanner.getAllocationPlan({
+        device: createDevice({maxVertexBuffers: 1}),
+        modelInfo: {isInstanced: true},
+        columns: [
+          makeColumn('positions', {stepMode: 'vertex'}),
+          makeColumn('instanceColors', {priority: 'high'})
+        ]
+      }),
+    /requires 2 vertex buffers/,
+    'throws when required vertex buffers exceed device limit'
+  );
+  t.throws(
+    () =>
+      TableBufferPlanner.getAllocationPlan({
+        device: createDevice({maxVertexBuffers: 1, maxVertexBufferArrayStride: 16}),
+        modelInfo: {isInstanced: true},
+        columns: [
+          makeColumn('instanceAngles', {byteStride: 12, priority: 'low'}),
+          makeColumn('instanceSizes', {byteStride: 12, priority: 'low'})
+        ]
+      }),
+    /requires byteStride 24/,
+    'throws when interleaved group stride exceeds device limit'
+  );
+
+  t.end();
+});
+
+function makeColumn(
+  id: string,
+  overrides: Partial<TableColumnDescriptor> = {}
+): TableColumnDescriptor {
+  return {
+    id,
+    byteStride: 4,
+    byteLength: 8,
+    rowCount: 2,
+    stepMode: 'instance',
+    supportsPackedBuffer: true,
+    ...overrides
+  };
+}
+
+function createDevice({
+  type = 'webgpu',
+  maxVertexBuffers,
+  maxVertexBufferArrayStride,
+  maxStorageBuffersPerShaderStage,
+  maxStorageBufferBindingSize
+}: {
+  type?: 'webgl' | 'webgpu' | 'null' | 'unknown';
+  maxVertexBuffers?: number;
+  maxVertexBufferArrayStride?: number;
+  maxStorageBuffersPerShaderStage?: number;
+  maxStorageBufferBindingSize?: number;
+} = {}): Device {
+  const device = new NullDevice({});
+  const limits = Object.create(device.limits);
+  Object.defineProperty(limits, 'maxVertexBuffers', {
+    value: maxVertexBuffers ?? device.limits.maxVertexBuffers
+  });
+  Object.defineProperty(limits, 'maxVertexBufferArrayStride', {
+    value: maxVertexBufferArrayStride ?? device.limits.maxVertexBufferArrayStride
+  });
+  Object.defineProperty(limits, 'maxStorageBuffersPerShaderStage', {
+    value: maxStorageBuffersPerShaderStage ?? device.limits.maxStorageBuffersPerShaderStage
+  });
+  Object.defineProperty(limits, 'maxStorageBufferBindingSize', {
+    value: maxStorageBufferBindingSize ?? device.limits.maxStorageBufferBindingSize
+  });
+
+  const testDevice = Object.create(device);
+  Object.defineProperty(testDevice, 'type', {value: type});
+  Object.defineProperty(testDevice, 'limits', {value: limits});
+  return testDevice;
+}

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -9,5 +9,6 @@ import './arrow/plain-gpu-table.spec';
 import './arrow/arrow-model.spec';
 import './arrow/arrow-shader-layout.spec';
 import './arrow/analyze-arrow-table.spec';
+import './arrow/table-buffer-planner.spec';
 
 import './geoarrow/geoarrow.spec';


### PR DESCRIPTION
## Summary

adds `TableBufferPlanner` into `@luma.gl/arrow` as a planner-only API for table/Arrow column GPU buffer allocation.

## Changes

- Adds `TableBufferPlanner` and exported planner types to `@luma.gl/arrow`.
- Supports deterministic planning for:
  - shared-geometry and row-geometry table modes
  - separate vs interleaved vertex-buffer groups
  - position groups and fp64 high/low mappings
  - unmanaged columns
  - WebGPU storage-buffer planning output
- Documents the planner in:
  - `docs/api-guide/gpu/arrow-table-columns.md`
  - `modules/arrow/README.md`
  - `docs/whats-new.md`
- Adds implementation tests for planner grouping, priority, unmanaged columns, fp64 positions, storage planning, and device-limit validation.

## Notes

This is intentionally planner-only. It does not change `ArrowGPUTable`, `getArrowBufferLayout()`, or `ArrowModel` runtime behavior, and it does not implement interleaved packing/upload or storage-buffer binding.

## Compared to `master`

- 7 files changed
- 1262 insertions
- New files:
  - `modules/arrow/src/arrow/table-buffer-planner.ts`
  - `modules/arrow/test/arrow/table-buffer-planner.spec.ts`

## Verification

- [x] `corepack yarn lint fix`
- [x] `corepack yarn test-node`
- [x] `corepack yarn build`
- [x] `git diff --check`
