### PR TITLE
feat(arrow) Support RecordBatch stream to ArrowGPUTable

### DIFF
--- a/docs/api-guide/gpu/arrow-table-columns.md
+++ b/docs/api-guide/gpu/arrow-table-columns.md
@@ -130,6 +130,41 @@ const colorVector: ArrowGPUVector = arrowGPUTable.gpuVectors.instanceColors;
 `Model`. It accepts an Arrow table as an update source and replaces the GPU
 representation when `setProps({arrowTable})` is called.
 
+`StreamingArrowGPUTable` uses the same shader attribute selection model but keeps
+`DynamicBuffer` attributes that can grow as record batches arrive. Use it when
+the table is append-only and model attribute objects should remain stable across
+buffer reallocations.
+
+```ts
+import {StreamingArrowGPUTable} from '@luma.gl/arrow';
+
+const streamingTable = new StreamingArrowGPUTable({
+  device,
+  schema,
+  shaderLayout
+});
+
+model.setBufferLayout(streamingTable.bufferLayout);
+model.setAttributes(streamingTable.attributes);
+
+streamingTable.appendRecordBatch(recordBatch);
+model.setInstanceCount(streamingTable.numRows);
+```
+
+The constructor can also consume synchronous record batch iterators immediately,
+or async record batch iterators when a schema is provided:
+
+```ts
+const streamingTable = new StreamingArrowGPUTable({
+  device,
+  schema,
+  asyncRecordBatches,
+  shaderLayout
+});
+
+await streamingTable.ready;
+```
+
 ## Planning Table Buffer Groups
 
 `TableBufferPlanner` is a lower-level helper for applications that already have

--- a/modules/arrow/src/arrow/arrow-gpu-vector.ts
+++ b/modules/arrow/src/arrow/arrow-gpu-vector.ts
@@ -7,10 +7,11 @@ import {
   Device,
   type BufferAttributeLayout,
   type BufferLayout,
-  type BufferProps
+  type BufferProps,
+  type BigTypedArray
 } from '@luma.gl/core';
 import * as arrow from 'apache-arrow';
-import type {AttributeArrowType} from './arrow-types';
+import type {AttributeArrowType, NumericArrowType} from './arrow-types';
 import {getArrowVectorBufferSource} from './arrow-fixed-size-list';
 
 /** Buffer creation props forwarded when uploading Arrow vector memory to the GPU. */
@@ -89,6 +90,58 @@ export type ArrowGPUVectorCreateProps<T extends arrow.DataType = AttributeArrowT
       ? ArrowGPUVectorFromArrowProps<T> | ArrowGPUVectorFromBufferProps<T>
       : never)
   | ArrowGPUVectorFromInterleavedProps;
+
+type ArrowGPUVectorReadableBuffer = Pick<Buffer, 'readAsync'>;
+
+type ArrowGPUVectorReadProps<T extends AttributeArrowType> = {
+  type: T;
+  buffer: ArrowGPUVectorReadableBuffer;
+  length: number;
+  byteOffset: number;
+  byteStride: number;
+};
+
+type NumericTypedArrayConstructor = {
+  readonly BYTES_PER_ELEMENT: number;
+  new (buffer: ArrayBufferLike, byteOffset?: number, length?: number): BigTypedArray;
+};
+
+const makeNumericData = arrow.makeData as <T extends NumericArrowType>(props: {
+  type: T;
+  length: number;
+  data: T['TArray'];
+}) => arrow.Data<T>;
+
+const makeFixedSizeListData = arrow.makeData as <T extends NumericArrowType>(props: {
+  type: arrow.FixedSizeList<T>;
+  length: number;
+  nullCount: number;
+  nullBitmap: null;
+  child: arrow.Data<T>;
+}) => arrow.Data<arrow.FixedSizeList<T>>;
+
+/** Read GPU bytes and reconstruct one non-null Arrow vector with the supplied Arrow type. */
+export async function readArrowGPUVectorAsync<T extends AttributeArrowType>(
+  props: ArrowGPUVectorReadProps<T>
+): Promise<arrow.Vector<T>> {
+  const {buffer, type, length, byteOffset, byteStride} = props;
+  const rowByteWidth = getArrowTypeByteStride(type);
+  if (byteStride < rowByteWidth) {
+    throw new Error(
+      `ArrowGPUVector.readAsync() byteStride ${byteStride} is smaller than row byte width ${rowByteWidth}`
+    );
+  }
+
+  const readByteLength = length === 0 ? 0 : (length - 1) * byteStride + rowByteWidth;
+  const bytes =
+    readByteLength === 0 ? new Uint8Array(0) : await buffer.readAsync(byteOffset, readByteLength);
+  const packedBytes =
+    byteStride === rowByteWidth
+      ? bytes
+      : compactStridedRows(bytes, length, byteStride, rowByteWidth);
+
+  return makeArrowVectorFromPackedBytes(type, length, packedBytes);
+}
 
 /**
  * GPU memory and Arrow type metadata derived from one Arrow vector.
@@ -237,6 +290,21 @@ export class ArrowGPUVector<T extends arrow.DataType = AttributeArrowType> {
     this._ownsBuffer = false;
   }
 
+  /** Reads the GPU buffer contents back into a single non-null Arrow vector. */
+  async readAsync(): Promise<arrow.Vector<T>> {
+    if (this.bufferLayout) {
+      throw new Error('ArrowGPUVector.readAsync() does not support interleaved vectors');
+    }
+
+    return readArrowGPUVectorAsync({
+      type: this.type as unknown as AttributeArrowType,
+      buffer: this.buffer,
+      length: this.length,
+      byteOffset: this.byteOffset,
+      byteStride: this.byteStride
+    }) as unknown as Promise<arrow.Vector<T>>;
+  }
+
   destroy(): void {
     if (this._ownsBuffer) {
       this.buffer.destroy();
@@ -271,4 +339,112 @@ function getArrowTypeByteStride(type: arrow.DataType): number {
     }
   }
   throw new Error(`Cannot determine byte stride for Arrow type ${type}`);
+}
+
+function compactStridedRows(
+  bytes: Uint8Array,
+  length: number,
+  byteStride: number,
+  rowByteWidth: number
+): Uint8Array {
+  const packedBytes = new Uint8Array(length * rowByteWidth);
+  for (let rowIndex = 0; rowIndex < length; rowIndex++) {
+    const sourceOffset = rowIndex * byteStride;
+    const targetOffset = rowIndex * rowByteWidth;
+    packedBytes.set(bytes.subarray(sourceOffset, sourceOffset + rowByteWidth), targetOffset);
+  }
+  return packedBytes;
+}
+
+function makeArrowVectorFromPackedBytes<T extends AttributeArrowType>(
+  type: T,
+  length: number,
+  bytes: Uint8Array
+): arrow.Vector<T> {
+  if (arrow.DataType.isFixedSizeList(type)) {
+    const childType = type.children[0].type as NumericArrowType;
+    const values = makeNumericTypedArray(childType, bytes, length * type.listSize);
+    const childData = makeNumericData({
+      type: childType,
+      length: length * type.listSize,
+      data: values as NumericArrowType['TArray']
+    });
+    const listData = makeFixedSizeListData({
+      type: type as arrow.FixedSizeList<NumericArrowType>,
+      length,
+      nullCount: 0,
+      nullBitmap: null,
+      child: childData
+    });
+    return arrow.makeVector(listData) as arrow.Vector<T>;
+  }
+
+  const numericType = type as NumericArrowType;
+  const values = makeNumericTypedArray(numericType, bytes, length);
+  const data = makeNumericData({
+    type: numericType,
+    length,
+    data: values as NumericArrowType['TArray']
+  });
+  return arrow.makeVector(data) as arrow.Vector<T>;
+}
+
+function makeNumericTypedArray(
+  type: NumericArrowType,
+  bytes: Uint8Array,
+  length: number
+): BigTypedArray {
+  if (arrow.DataType.isInt(type)) {
+    if (type.isSigned) {
+      switch (type.bitWidth) {
+        case 8:
+          return makeTypedArrayView(Int8Array, bytes, length);
+        case 16:
+          return makeTypedArrayView(Int16Array, bytes, length);
+        case 32:
+          return makeTypedArrayView(Int32Array, bytes, length);
+        case 64:
+          return makeTypedArrayView(BigInt64Array, bytes, length);
+      }
+    }
+
+    switch (type.bitWidth) {
+      case 8:
+        return makeTypedArrayView(Uint8Array, bytes, length);
+      case 16:
+        return makeTypedArrayView(Uint16Array, bytes, length);
+      case 32:
+        return makeTypedArrayView(Uint32Array, bytes, length);
+      case 64:
+        return makeTypedArrayView(BigUint64Array, bytes, length);
+    }
+  }
+
+  if (arrow.DataType.isFloat(type)) {
+    switch (type.precision) {
+      case arrow.Precision.HALF:
+        return makeTypedArrayView(Uint16Array, bytes, length);
+      case arrow.Precision.SINGLE:
+        return makeTypedArrayView(Float32Array, bytes, length);
+      case arrow.Precision.DOUBLE:
+        return makeTypedArrayView(Float64Array, bytes, length);
+    }
+  }
+
+  throw new Error(`ArrowGPUVector.readAsync() does not support Arrow type ${type}`);
+}
+
+function makeTypedArrayView<T extends BigTypedArray>(
+  TypedArrayConstructor: NumericTypedArrayConstructor,
+  bytes: Uint8Array,
+  length: number
+): T {
+  const byteLength = length * TypedArrayConstructor.BYTES_PER_ELEMENT;
+  if (bytes.byteOffset % TypedArrayConstructor.BYTES_PER_ELEMENT === 0) {
+    return new TypedArrayConstructor(bytes.buffer, bytes.byteOffset, length) as T;
+  }
+
+  const alignedBytes = new Uint8Array(byteLength);
+  alignedBytes.set(bytes.subarray(0, byteLength));
+  return new TypedArrayConstructor(alignedBytes.buffer, 0, length) as T;
 }

--- a/modules/arrow/src/arrow/arrow-model.ts
+++ b/modules/arrow/src/arrow/arrow-model.ts
@@ -2,18 +2,24 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Device, type BufferLayout, type ShaderLayout} from '@luma.gl/core';
+import {Device, type BufferLayout, type CommandEncoder, type ShaderLayout} from '@luma.gl/core';
 import {Model, type ModelProps} from '@luma.gl/engine';
 import * as arrow from 'apache-arrow';
 import {type ArrowVertexFormatOptions} from './arrow-shader-layout';
 import {ArrowGPUTable, type ArrowGPUTableProps} from './plain-gpu-table';
+import {StreamingArrowGPUTable} from './streaming-arrow-gpu-table';
 import type {ArrowGPUVectorProps} from './arrow-gpu-vector';
+
+/** GPU table source accepted by ArrowModel. */
+export type ArrowModelGPUTable = ArrowGPUTable | StreamingArrowGPUTable;
 
 /** Props for creating a Model whose attributes are derived from an Arrow table. */
 export type ArrowModelProps = ModelProps &
   ArrowVertexFormatOptions & {
     /** Arrow table used as the construction source for GPU attribute buffers. */
-    arrowTable: arrow.Table;
+    arrowTable?: arrow.Table;
+    /** Existing streaming GPU table used as the source for model attributes. */
+    streamingArrowGPUTable?: StreamingArrowGPUTable;
     /** Maps shader attribute names to Arrow column paths. Defaults to using attribute names. */
     arrowPaths?: Record<string, string>;
     /** Buffer props applied to each Arrow-derived GPU vector. */
@@ -23,7 +29,8 @@ export type ArrowModelProps = ModelProps &
   };
 
 type ArrowModelState = {
-  arrowGPUTable: ArrowGPUTable;
+  arrowGPUTable: ArrowModelGPUTable;
+  ownsArrowGPUTable: boolean;
   modelProps: ModelProps;
   arrowState: ArrowModelArrowState;
 };
@@ -45,19 +52,26 @@ type ArrowModelArrowState = {
 /** A luma.gl Model with GPU attributes backed by Arrow table columns. */
 export class ArrowModel extends Model {
   /** GPU representation of the currently active Arrow table attributes. */
-  arrowGPUTable: ArrowGPUTable;
+  arrowGPUTable: ArrowModelGPUTable;
   private arrowState: ArrowModelArrowState;
+  private ownsArrowGPUTable: boolean;
   private arrowModelDestroyed = false;
 
   constructor(device: Device, props: ArrowModelProps) {
-    const {arrowGPUTable, modelProps, arrowState} = getArrowModelState(device, props);
+    const {arrowGPUTable, ownsArrowGPUTable, modelProps, arrowState} = getArrowModelState(
+      device,
+      props
+    );
     try {
       super(device, modelProps);
     } catch (error) {
-      arrowGPUTable.destroy();
+      if (ownsArrowGPUTable) {
+        arrowGPUTable.destroy();
+      }
       throw error;
     }
     this.arrowGPUTable = arrowGPUTable;
+    this.ownsArrowGPUTable = ownsArrowGPUTable;
     this.arrowState = arrowState;
   }
 
@@ -66,12 +80,29 @@ export class ArrowModel extends Model {
     if (props.arrowTable) {
       this.setArrowTable(props.arrowTable);
     }
+    if (props.streamingArrowGPUTable) {
+      this.setArrowGPUTable(props.streamingArrowGPUTable, false);
+    }
+  }
+
+  /** Query redraw status. Clears the status. */
+  override needsRedraw(): false | string {
+    this.syncArrowGPUTableCount();
+    return super.needsRedraw();
+  }
+
+  /** Updates uniforms, dynamic buffers, and inferred Arrow counts before opening a render pass. */
+  override predraw(commandEncoder: CommandEncoder): void {
+    this.syncArrowGPUTableCount();
+    super.predraw(commandEncoder);
   }
 
   override destroy(): void {
     if (!this.arrowModelDestroyed) {
       super.destroy();
-      this.arrowGPUTable.destroy();
+      if (this.ownsArrowGPUTable) {
+        this.arrowGPUTable.destroy();
+      }
       this.arrowModelDestroyed = true;
     }
   }
@@ -84,6 +115,13 @@ export class ArrowModel extends Model {
       allowWebGLOnlyFormats: this.arrowState.allowWebGLOnlyFormats
     });
 
+    this.setArrowGPUTable(nextArrowGPUTable, true);
+  }
+
+  private setArrowGPUTable(
+    nextArrowGPUTable: ArrowModelGPUTable,
+    ownsNextArrowGPUTable: boolean
+  ): void {
     try {
       assertNoDuplicateNames(
         Object.keys(this.arrowState.explicitAttributes),
@@ -112,19 +150,35 @@ export class ArrowModel extends Model {
         this.setVertexCount(nextArrowGPUTable.numRows);
       }
     } catch (error) {
-      nextArrowGPUTable.destroy();
+      if (ownsNextArrowGPUTable) {
+        nextArrowGPUTable.destroy();
+      }
       throw error;
     }
 
     const previousArrowGPUTable = this.arrowGPUTable;
+    const ownsPreviousArrowGPUTable = this.ownsArrowGPUTable;
     this.arrowGPUTable = nextArrowGPUTable;
-    previousArrowGPUTable.destroy();
+    this.ownsArrowGPUTable = ownsNextArrowGPUTable;
+    if (ownsPreviousArrowGPUTable) {
+      previousArrowGPUTable.destroy();
+    }
+  }
+
+  private syncArrowGPUTableCount(): void {
+    if (this.arrowState.inferInstanceCount && this.instanceCount !== this.arrowGPUTable.numRows) {
+      this.setInstanceCount(this.arrowGPUTable.numRows);
+    }
+    if (this.arrowState.inferVertexCount && this.vertexCount !== this.arrowGPUTable.numRows) {
+      this.setVertexCount(this.arrowGPUTable.numRows);
+    }
   }
 }
 
 function getArrowModelState(device: Device, props: ArrowModelProps): ArrowModelState {
   const {
     arrowTable,
+    streamingArrowGPUTable,
     arrowPaths,
     arrowBufferProps,
     arrowCount = 'instance',
@@ -141,12 +195,15 @@ function getArrowModelState(device: Device, props: ArrowModelProps): ArrowModelS
   const inferInstanceCount = arrowCount === 'instance' && modelProps.instanceCount === undefined;
   const inferVertexCount = arrowCount === 'vertex' && modelProps.vertexCount === undefined;
 
-  const arrowGPUTable = new ArrowGPUTable(device, arrowTable, {
+  const {arrowGPUTable, ownsArrowGPUTable} = getInitialArrowGPUTable({
+    device,
+    arrowTable,
+    streamingArrowGPUTable,
     shaderLayout: modelProps.shaderLayout,
     arrowPaths,
-    bufferProps: arrowBufferProps,
+    arrowBufferProps,
     allowWebGLOnlyFormats
-  } satisfies ArrowGPUTableProps);
+  });
 
   try {
     assertNoDuplicateNames(
@@ -166,6 +223,7 @@ function getArrowModelState(device: Device, props: ArrowModelProps): ArrowModelS
 
   return {
     arrowGPUTable,
+    ownsArrowGPUTable,
     arrowState: {
       shaderLayout: modelProps.shaderLayout,
       arrowPaths,
@@ -184,6 +242,36 @@ function getArrowModelState(device: Device, props: ArrowModelProps): ArrowModelS
       ...(inferInstanceCount ? {instanceCount: arrowGPUTable.numRows} : {}),
       ...(inferVertexCount ? {vertexCount: arrowGPUTable.numRows} : {})
     }
+  };
+}
+
+function getInitialArrowGPUTable(props: {
+  device: Device;
+  arrowTable?: arrow.Table;
+  streamingArrowGPUTable?: StreamingArrowGPUTable;
+  shaderLayout: ShaderLayout;
+  arrowPaths?: Record<string, string>;
+  arrowBufferProps?: ArrowGPUVectorProps;
+  allowWebGLOnlyFormats?: boolean;
+}): {arrowGPUTable: ArrowModelGPUTable; ownsArrowGPUTable: boolean} {
+  if (props.arrowTable && props.streamingArrowGPUTable) {
+    throw new Error('ArrowModel requires only one of arrowTable or streamingArrowGPUTable');
+  }
+  if (props.streamingArrowGPUTable) {
+    return {arrowGPUTable: props.streamingArrowGPUTable, ownsArrowGPUTable: false};
+  }
+  if (!props.arrowTable) {
+    throw new Error('ArrowModel requires arrowTable or streamingArrowGPUTable');
+  }
+
+  return {
+    arrowGPUTable: new ArrowGPUTable(props.device, props.arrowTable, {
+      shaderLayout: props.shaderLayout,
+      arrowPaths: props.arrowPaths,
+      bufferProps: props.arrowBufferProps,
+      allowWebGLOnlyFormats: props.allowWebGLOnlyFormats
+    } satisfies ArrowGPUTableProps),
+    ownsArrowGPUTable: true
   };
 }
 

--- a/modules/arrow/src/arrow/streaming-arrow-gpu-table.ts
+++ b/modules/arrow/src/arrow/streaming-arrow-gpu-table.ts
@@ -1,0 +1,664 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type BufferLayout, type Device, type ShaderLayout} from '@luma.gl/core';
+import {DynamicBuffer, type DynamicBufferProps} from '@luma.gl/engine';
+import * as arrow from 'apache-arrow';
+import {readArrowGPUVectorAsync} from './arrow-gpu-vector';
+import {getArrowDataByPath, getArrowVectorByPath} from './arrow-paths';
+import {getArrowVertexFormat, type ArrowVertexFormatOptions} from './arrow-shader-layout';
+import {
+  getSignedShaderType,
+  isInstanceArrowType,
+  isNumericArrowType,
+  type ArrowColumnInfo,
+  type AttributeArrowType,
+  type NumericArrowType
+} from './arrow-types';
+
+/** Buffer props forwarded when creating streaming Arrow GPU buffers. */
+export type StreamingArrowGPUVectorBufferProps = Omit<DynamicBufferProps, 'byteLength' | 'data'>;
+
+/** Synchronous source of Arrow record batches to append into a streaming table. */
+export type StreamingArrowRecordBatchSource =
+  | Iterable<arrow.RecordBatch>
+  | Iterator<arrow.RecordBatch>;
+
+/** Asynchronous source of Arrow record batches to append into a streaming table. */
+export type StreamingArrowAsyncRecordBatchSource =
+  | AsyncIterable<arrow.RecordBatch>
+  | AsyncIterator<arrow.RecordBatch>;
+
+/** Constructor props for a streaming GPU vector backed by a DynamicBuffer. */
+export type StreamingArrowGPUVectorProps<T extends AttributeArrowType = AttributeArrowType> = {
+  /** Name used when this vector is added to a StreamingArrowGPUTable. */
+  name: string;
+  /** Device that creates the backing DynamicBuffer. */
+  device: Device;
+  /** Arrow type that describes source data appended to this vector. */
+  arrowType: T;
+  /** Initial row capacity. Defaults to 0. */
+  initialCapacityRows?: number;
+  /** Buffer capacity growth multiplier used when appends exceed capacity. */
+  capacityGrowthFactor?: number;
+  /** DynamicBuffer construction props forwarded to the backing buffer. */
+  bufferProps?: StreamingArrowGPUVectorBufferProps;
+};
+
+/** Props for constructing an empty or initially populated StreamingArrowGPUTable. */
+export type StreamingArrowGPUTableProps = ArrowVertexFormatOptions & {
+  /** Device that creates streaming vector buffers. */
+  device: Device;
+  /** Schema used to select GPU columns for an initially empty streaming table. */
+  schema?: arrow.Schema;
+  /** Record batch to append after creating the selected GPU columns. */
+  recordBatch?: arrow.RecordBatch;
+  /** Table to append after creating the selected GPU columns. */
+  table?: arrow.Table;
+  /** Synchronous record batches to append after creating the selected GPU columns. */
+  recordBatches?: StreamingArrowRecordBatchSource;
+  /** Asynchronous record batches to append after creating the selected GPU columns. */
+  asyncRecordBatches?: StreamingArrowAsyncRecordBatchSource;
+  /** Shader layout that selects which Arrow columns should be uploaded. */
+  shaderLayout: ShaderLayout;
+  /** Maps shader attribute names to Arrow column paths. Defaults to using the attribute name. */
+  arrowPaths?: Record<string, string>;
+  /** Buffer props applied to every streaming Arrow GPU vector. */
+  bufferProps?: StreamingArrowGPUVectorBufferProps;
+  /** Initial row capacity for every streaming vector. Defaults to the initial source row count. */
+  initialCapacityRows?: number;
+  /** Buffer capacity growth multiplier used when appends exceed capacity. */
+  capacityGrowthFactor?: number;
+};
+
+type SelectedStreamingColumn = {
+  /** Shader-visible attribute name. */
+  attributeName: string;
+  /** Dot-separated Arrow column path. */
+  arrowPath: string;
+  /** Source Arrow field. */
+  field: arrow.Field;
+  /** Buffer layout entry for this selected attribute. */
+  bufferLayout: BufferLayout;
+};
+
+type InitialStreamingSource = {
+  /** Schema used to select streaming GPU columns. */
+  schema: arrow.Schema;
+  /** First record batch to append, if one was provided directly or read from a synchronous source. */
+  recordBatch?: arrow.RecordBatch;
+  /** Arrow table to append after vectors are created. */
+  table?: arrow.Table;
+  /** Remaining synchronous record batch iterator after any first batch was consumed. */
+  recordBatches?: Iterator<arrow.RecordBatch>;
+  /** Asynchronous record batch iterator to consume after vectors are created. */
+  asyncRecordBatches?: AsyncIterator<arrow.RecordBatch>;
+};
+
+/**
+ * Streaming GPU memory and Arrow type metadata for one compatible Arrow column.
+ *
+ * A StreamingArrowGPUVector keeps a stable DynamicBuffer object while replacing
+ * its backing GPU buffer as needed when appended Arrow batches exceed capacity.
+ */
+export class StreamingArrowGPUVector<T extends AttributeArrowType = AttributeArrowType> {
+  /** Name used when this vector is added to a StreamingArrowGPUTable. */
+  readonly name: string;
+  /** Dynamic GPU buffer containing appended Arrow value memory. */
+  readonly buffer: DynamicBuffer;
+  /** Arrow type that describes the uploaded vector memory. */
+  readonly type: T;
+  /** Number of scalar values per logical vector row. */
+  readonly stride: number;
+  /** Byte offset of the first logical row in buffer. */
+  readonly byteOffset = 0;
+  /** Bytes between adjacent logical rows in buffer. */
+  readonly byteStride: number;
+  /** Number of logical rows appended into buffer. */
+  length = 0;
+
+  private readonly capacityGrowthFactor: number;
+
+  /** Creates an empty streaming GPU vector. */
+  constructor(props: StreamingArrowGPUVectorProps<T>) {
+    if (!isInstanceArrowType(props.arrowType)) {
+      throw new Error(`StreamingArrowGPUVector does not support Arrow type ${props.arrowType}`);
+    }
+
+    this.name = props.name;
+    this.type = props.arrowType;
+    this.stride = getArrowTypeStride(props.arrowType);
+    this.byteStride = getArrowTypeByteStride(props.arrowType);
+    this.capacityGrowthFactor = props.capacityGrowthFactor ?? 1.5;
+
+    const initialCapacityRows = props.initialCapacityRows ?? 0;
+    this.buffer = new DynamicBuffer(props.device, {
+      usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
+      ...props.bufferProps,
+      id: props.bufferProps?.id ?? `${props.name}-streaming-arrow-vector`,
+      byteLength: Math.max(1, initialCapacityRows * this.byteStride)
+    });
+  }
+
+  /** Number of rows the current backing buffer can hold without reallocating. */
+  get capacityRows(): number {
+    return Math.floor(this.buffer.byteLength / this.byteStride);
+  }
+
+  /** Appends all data chunks from an Arrow vector. */
+  appendVector(vector: arrow.Vector<T>): void {
+    if (!arrow.util.compareTypes(vector.type, this.type)) {
+      throw new Error(
+        `StreamingArrowGPUVector "${this.name}" cannot append a different Arrow type`
+      );
+    }
+
+    for (const data of vector.data) {
+      this.appendData(data as arrow.Data<T>);
+    }
+  }
+
+  /** Appends one Arrow data chunk with one GPU write. */
+  appendData(data: arrow.Data<T>): void {
+    this.validateData(data);
+
+    const rowCount = data.length;
+    const requiredRows = this.length + rowCount;
+    this.ensureCapacityRows(requiredRows);
+
+    const sourceView = getArrowDataValueView(data, this.stride);
+    this.buffer.write(sourceView, this.length * this.byteStride);
+    this.length = requiredRows;
+  }
+
+  /** Clears the logical row count while retaining the reusable DynamicBuffer allocation. */
+  reset(): void {
+    this.length = 0;
+  }
+
+  /** Reads appended GPU rows back into a single non-null Arrow vector. */
+  async readAsync(): Promise<arrow.Vector<T>> {
+    return readArrowGPUVectorAsync({
+      type: this.type,
+      buffer: this.buffer,
+      length: this.length,
+      byteOffset: this.byteOffset,
+      byteStride: this.byteStride
+    });
+  }
+
+  /** Destroys the backing DynamicBuffer. */
+  destroy(): void {
+    this.buffer.destroy();
+  }
+
+  private validateData(data: arrow.Data<T>): void {
+    if (!arrow.util.compareTypes(data.type, this.type)) {
+      throw new Error(
+        `StreamingArrowGPUVector "${this.name}" cannot append a different Arrow type`
+      );
+    }
+    if (data.nullCount > 0) {
+      throw new Error(`StreamingArrowGPUVector "${this.name}" does not support nullable data`);
+    }
+    if (arrow.DataType.isFixedSizeList(data.type) && (data.children[0]?.nullCount ?? 0) > 0) {
+      throw new Error(
+        `StreamingArrowGPUVector "${this.name}" does not support nullable child data`
+      );
+    }
+  }
+
+  private ensureCapacityRows(requiredRows: number): void {
+    if (requiredRows <= this.capacityRows) {
+      return;
+    }
+
+    const grownRows = Math.ceil(Math.max(this.capacityRows, 1) * this.capacityGrowthFactor);
+    const nextCapacityRows = Math.max(requiredRows, grownRows);
+    this.buffer.ensureSize(nextCapacityRows * this.byteStride, {preserveData: true});
+  }
+}
+
+/**
+ * Append-only GPU representation of selected Arrow table columns.
+ *
+ * StreamingArrowGPUTable mirrors ArrowGPUTable's column selection and metadata
+ * model but keeps DynamicBuffer-backed vectors that can grow as record batches
+ * arrive.
+ */
+export class StreamingArrowGPUTable {
+  /** GPU-facing schema for the selected shader attribute columns. */
+  readonly schema: arrow.Schema;
+  /** Number of selected GPU columns in schema. */
+  readonly numCols: number;
+  /** Buffer layout derived from the selected Arrow columns and shader layout. */
+  readonly bufferLayout: BufferLayout[];
+  /** Streaming GPU vectors keyed by shader attribute name. */
+  readonly gpuVectors: Record<string, StreamingArrowGPUVector> = {};
+  /** Model-ready DynamicBuffer attributes keyed by shader attribute name. */
+  readonly attributes: Record<string, DynamicBuffer> = {};
+  /** Resolves after any constructor-provided async record batches have been appended. */
+  readonly ready: Promise<void>;
+
+  private readonly selectedColumns: SelectedStreamingColumn[];
+  private readonly sourceSchema: arrow.Schema;
+  private destroyed = false;
+  private rowCount = 0;
+  private nullableRowCount = 0;
+
+  /** Creates an empty or initially populated streaming GPU table. */
+  constructor(props: StreamingArrowGPUTableProps) {
+    const initialSource = getInitialSource(props);
+    this.sourceSchema = initialSource.schema;
+    this.selectedColumns = getSelectedStreamingColumns({
+      schema: this.sourceSchema,
+      shaderLayout: props.shaderLayout,
+      arrowPaths: props.arrowPaths,
+      allowWebGLOnlyFormats: props.allowWebGLOnlyFormats
+    });
+    this.bufferLayout = this.selectedColumns.map(column => column.bufferLayout);
+    this.schema = new arrow.Schema(
+      this.selectedColumns.map(
+        column =>
+          new arrow.Field(
+            column.attributeName,
+            column.field.type,
+            column.field.nullable,
+            new Map(column.field.metadata)
+          )
+      ),
+      new Map(this.sourceSchema.metadata)
+    );
+    this.numCols = this.schema.fields.length;
+
+    const initialCapacityRows =
+      props.initialCapacityRows ??
+      getInitialSourceRowCount(initialSource.table, initialSource.recordBatch);
+    for (const column of this.selectedColumns) {
+      const vector = new StreamingArrowGPUVector({
+        name: column.attributeName,
+        device: props.device,
+        arrowType: column.field.type as AttributeArrowType,
+        initialCapacityRows,
+        capacityGrowthFactor: props.capacityGrowthFactor,
+        bufferProps: props.bufferProps
+      });
+      this.gpuVectors[column.attributeName] = vector;
+      this.attributes[column.attributeName] = vector.buffer;
+    }
+
+    if (initialSource.recordBatch) {
+      this.appendRecordBatch(initialSource.recordBatch);
+    }
+    if (initialSource.table) {
+      this.appendTable(initialSource.table);
+    }
+    if (initialSource.recordBatches) {
+      this.appendRecordBatches(initialSource.recordBatches);
+    }
+
+    this.ready = initialSource.asyncRecordBatches
+      ? this.appendRecordBatchesAsync(initialSource.asyncRecordBatches)
+      : Promise.resolve();
+  }
+
+  /** Number of appended rows currently represented by every selected vector. */
+  get numRows(): number {
+    return this.rowCount;
+  }
+
+  /** Number of null rows in appended sources. */
+  get nullCount(): number {
+    return this.nullableRowCount;
+  }
+
+  /** Appends one record batch into every selected streaming vector. */
+  appendRecordBatch(recordBatch: arrow.RecordBatch): void {
+    this.assertCompatibleSchema(recordBatch.schema);
+    const pendingData = this.selectedColumns.map(column => ({
+      column,
+      data: getArrowDataByPath(recordBatch, column.arrowPath) as arrow.Data<AttributeArrowType>
+    }));
+    validateSelectedData(recordBatch.numRows, pendingData);
+
+    for (const {column, data} of pendingData) {
+      this.gpuVectors[column.attributeName].appendData(data);
+    }
+    this.rowCount += recordBatch.numRows;
+    this.nullableRowCount += recordBatch.nullCount;
+  }
+
+  /** Appends all record batches from one Arrow table. */
+  appendTable(table: arrow.Table): void {
+    this.assertCompatibleSchema(table.schema);
+    const pendingVectors = this.selectedColumns.map(column => ({
+      column,
+      vector: getArrowVectorByPath(table, column.arrowPath) as arrow.Vector<AttributeArrowType>
+    }));
+    validateSelectedVectors(table.numRows, pendingVectors);
+
+    for (const {column, vector} of pendingVectors) {
+      this.gpuVectors[column.attributeName].appendVector(vector);
+    }
+    this.rowCount += table.numRows;
+    this.nullableRowCount += table.nullCount;
+  }
+
+  /** Appends all record batches from a synchronous source. */
+  appendRecordBatches(recordBatches: StreamingArrowRecordBatchSource): void {
+    const iterator = getRecordBatchIterator(recordBatches);
+    for (let result = iterator.next(); !result.done; result = iterator.next()) {
+      this.appendRecordBatch(result.value);
+    }
+  }
+
+  /** Appends all record batches from an asynchronous source. */
+  async appendRecordBatchesAsync(
+    recordBatches: StreamingArrowAsyncRecordBatchSource
+  ): Promise<void> {
+    const iterator = getAsyncRecordBatchIterator(recordBatches);
+    for (let result = await iterator.next(); !result.done; result = await iterator.next()) {
+      this.appendRecordBatch(result.value);
+    }
+  }
+
+  /** Clears all logical rows while retaining reusable vector buffers. */
+  reset(): void {
+    for (const vector of Object.values(this.gpuVectors)) {
+      vector.reset();
+    }
+    this.rowCount = 0;
+    this.nullableRowCount = 0;
+  }
+
+  /** Destroys all owned streaming vector buffers. */
+  destroy(): void {
+    if (!this.destroyed) {
+      for (const vector of Object.values(this.gpuVectors)) {
+        vector.destroy();
+      }
+      this.destroyed = true;
+    }
+  }
+
+  private assertCompatibleSchema(schema: arrow.Schema): void {
+    for (const column of this.selectedColumns) {
+      const field = getFieldByPath(schema, column.arrowPath);
+      if (!field || !arrow.util.compareTypes(field.type, column.field.type)) {
+        throw new Error(
+          `StreamingArrowGPUTable column "${column.arrowPath}" does not match the source schema`
+        );
+      }
+    }
+  }
+}
+
+function getInitialSource(props: StreamingArrowGPUTableProps): InitialStreamingSource {
+  const dataSourceCount =
+    Number(Boolean(props.recordBatch)) +
+    Number(Boolean(props.table)) +
+    Number(Boolean(props.recordBatches)) +
+    Number(Boolean(props.asyncRecordBatches));
+  if (dataSourceCount > 1) {
+    throw new Error(
+      'StreamingArrowGPUTable accepts at most one initial data source: recordBatch, table, recordBatches, or asyncRecordBatches'
+    );
+  }
+
+  if (props.asyncRecordBatches && !props.schema) {
+    throw new Error(
+      'StreamingArrowGPUTable requires schema when initialized with asyncRecordBatches'
+    );
+  }
+
+  if (props.schema) {
+    return {
+      schema: props.schema,
+      recordBatch: props.recordBatch,
+      table: props.table,
+      recordBatches: props.recordBatches ? getRecordBatchIterator(props.recordBatches) : undefined,
+      asyncRecordBatches: props.asyncRecordBatches
+        ? getAsyncRecordBatchIterator(props.asyncRecordBatches)
+        : undefined
+    };
+  }
+  if (props.recordBatch) {
+    return {schema: props.recordBatch.schema, recordBatch: props.recordBatch};
+  }
+  if (props.table) {
+    return {schema: props.table.schema, table: props.table};
+  }
+  if (props.recordBatches) {
+    const iterator = getRecordBatchIterator(props.recordBatches);
+    const firstResult = iterator.next();
+    if (firstResult.done) {
+      throw new Error(
+        'StreamingArrowGPUTable requires schema when initialized with empty recordBatches'
+      );
+    }
+    return {
+      schema: firstResult.value.schema,
+      recordBatch: firstResult.value,
+      recordBatches: iterator
+    };
+  }
+
+  throw new Error(
+    'StreamingArrowGPUTable requires schema, recordBatch, table, recordBatches, or asyncRecordBatches'
+  );
+}
+
+function getInitialSourceRowCount(table?: arrow.Table, recordBatch?: arrow.RecordBatch): number {
+  return table?.numRows ?? recordBatch?.numRows ?? 0;
+}
+
+function getRecordBatchIterator(
+  source: StreamingArrowRecordBatchSource
+): Iterator<arrow.RecordBatch> {
+  const iterable = source as Partial<Iterable<arrow.RecordBatch>>;
+  const getIterator = iterable[Symbol.iterator];
+  return getIterator ? getIterator.call(iterable) : (source as Iterator<arrow.RecordBatch>);
+}
+
+function getAsyncRecordBatchIterator(
+  source: StreamingArrowAsyncRecordBatchSource
+): AsyncIterator<arrow.RecordBatch> {
+  const iterable = source as Partial<AsyncIterable<arrow.RecordBatch>>;
+  const getIterator = iterable[Symbol.asyncIterator];
+  return getIterator ? getIterator.call(iterable) : (source as AsyncIterator<arrow.RecordBatch>);
+}
+
+function getSelectedStreamingColumns(props: {
+  schema: arrow.Schema;
+  shaderLayout: ShaderLayout;
+  arrowPaths?: Record<string, string>;
+  allowWebGLOnlyFormats?: boolean;
+}): SelectedStreamingColumn[] {
+  const schemaPaths = new Set(getSchemaPaths(props.schema));
+  const columns: SelectedStreamingColumn[] = [];
+
+  for (const attribute of props.shaderLayout.attributes) {
+    const hasExplicitPath = Boolean(
+      props.arrowPaths && Object.prototype.hasOwnProperty.call(props.arrowPaths, attribute.name)
+    );
+    const arrowPath = props.arrowPaths?.[attribute.name] || attribute.name;
+    if (!hasExplicitPath && !schemaPaths.has(arrowPath)) {
+      continue;
+    }
+
+    const field = getFieldByPath(props.schema, arrowPath);
+    if (!field) {
+      throw new Error(`Arrow table schema does not contain column "${arrowPath}"`);
+    }
+    if (!isInstanceArrowType(field.type)) {
+      throw new Error(`Arrow column "${arrowPath}" is not compatible with shader attributes`);
+    }
+    const columnInfo = getArrowColumnInfoFromType(field.type);
+    const format = getArrowVertexFormat(columnInfo, attribute.type, {
+      allowWebGLOnlyFormats: props.allowWebGLOnlyFormats
+    });
+    columns.push({
+      attributeName: attribute.name,
+      arrowPath,
+      field,
+      bufferLayout: {
+        name: attribute.name,
+        format,
+        ...(attribute.stepMode ? {stepMode: attribute.stepMode} : {})
+      }
+    });
+  }
+
+  return columns;
+}
+
+function getSchemaPaths(schema: arrow.Schema): string[] {
+  return getSchemaPathsRecursive(schema.fields, []);
+}
+
+function getSchemaPathsRecursive(fields: arrow.Field[], currentPath: string[]): string[] {
+  const paths: string[] = [];
+  for (const field of fields) {
+    const fieldPath = [...currentPath, field.name];
+    if (arrow.DataType.isStruct(field.type)) {
+      paths.push(...getSchemaPathsRecursive(field.type.children, fieldPath));
+    } else {
+      paths.push(fieldPath.join('.'));
+    }
+  }
+  return paths;
+}
+
+function getFieldByPath(schema: arrow.Schema, columnPath: string): arrow.Field | null {
+  const path = columnPath.split('.');
+  let fields = schema.fields;
+  let resolvedField: arrow.Field | null = null;
+
+  for (let pathIndex = 0; pathIndex < path.length; pathIndex++) {
+    const key = path[pathIndex];
+    const isLeafField = pathIndex === path.length - 1;
+    resolvedField = fields.find(field => field.name === key) ?? null;
+    if (!resolvedField) {
+      return null;
+    }
+    if (!isLeafField) {
+      if (!arrow.DataType.isStruct(resolvedField.type)) {
+        return null;
+      }
+      fields = resolvedField.type.children;
+    }
+  }
+
+  return resolvedField && !arrow.DataType.isStruct(resolvedField.type) ? resolvedField : null;
+}
+
+function getArrowColumnInfoFromType(type: AttributeArrowType): ArrowColumnInfo {
+  let numericType = type as NumericArrowType;
+  let components: 1 | 2 | 3 | 4 = 1;
+  if (arrow.DataType.isFixedSizeList(type)) {
+    numericType = type.children[0].type as NumericArrowType;
+    if (type.listSize < 1 || type.listSize > 4) {
+      throw new Error('Attribute column fixed list size must be between 1 and 4');
+    }
+    components = type.listSize as 1 | 2 | 3 | 4;
+  }
+  if (!isNumericArrowType(numericType)) {
+    throw new Error('Attribute column must be numeric or fixed list of numeric');
+  }
+  return {
+    signedDataType: getSignedShaderType(numericType, components),
+    components,
+    stepMode: 'instance',
+    values: [],
+    offsets: []
+  };
+}
+
+function validateSelectedData(
+  expectedRows: number,
+  pendingData: {column: SelectedStreamingColumn; data: arrow.Data<AttributeArrowType>}[]
+): void {
+  for (const {column, data} of pendingData) {
+    if (data.length !== expectedRows) {
+      throw new Error(`StreamingArrowGPUTable column "${column.arrowPath}" row count mismatch`);
+    }
+    validateDataForDirectUpload(column.attributeName, data);
+  }
+}
+
+function validateSelectedVectors(
+  expectedRows: number,
+  pendingVectors: {column: SelectedStreamingColumn; vector: arrow.Vector<AttributeArrowType>}[]
+): void {
+  for (const {column, vector} of pendingVectors) {
+    if (vector.length !== expectedRows) {
+      throw new Error(`StreamingArrowGPUTable column "${column.arrowPath}" row count mismatch`);
+    }
+    for (const data of vector.data) {
+      validateDataForDirectUpload(column.attributeName, data as arrow.Data<AttributeArrowType>);
+    }
+  }
+}
+
+function validateDataForDirectUpload(name: string, data: arrow.Data<AttributeArrowType>): void {
+  if (data.nullCount > 0) {
+    throw new Error(`StreamingArrowGPUVector "${name}" does not support nullable data`);
+  }
+  if (arrow.DataType.isFixedSizeList(data.type) && (data.children[0]?.nullCount ?? 0) > 0) {
+    throw new Error(`StreamingArrowGPUVector "${name}" does not support nullable child data`);
+  }
+}
+
+function getArrowDataValueView<T extends AttributeArrowType>(
+  data: arrow.Data<T>,
+  stride: number
+): ArrayBufferView {
+  const values = getArrowDataValues(data);
+  const childOffset = arrow.DataType.isFixedSizeList(data.type)
+    ? (data.children[0]?.offset ?? 0)
+    : 0;
+  const startElement = childOffset + data.offset * stride;
+  const endElement = startElement + data.length * stride;
+  return values.subarray(startElement, endElement);
+}
+
+function getArrowDataValues(data: arrow.Data<AttributeArrowType>): NumericArrowType['TArray'] {
+  if (arrow.DataType.isFixedSizeList(data.type)) {
+    const childValues = data.children[0]?.values;
+    if (!childValues) {
+      throw new Error('Arrow FixedSizeList data has no child values');
+    }
+    return childValues as NumericArrowType['TArray'];
+  }
+
+  const values = data.values;
+  if (!values) {
+    throw new Error('Arrow data has no values');
+  }
+  return values as NumericArrowType['TArray'];
+}
+
+function getArrowTypeStride(type: arrow.DataType): number {
+  return arrow.DataType.isFixedSizeList(type) ? type.listSize : 1;
+}
+
+function getArrowTypeByteStride(type: arrow.DataType): number {
+  if (arrow.DataType.isFixedSizeList(type)) {
+    return type.listSize * getArrowTypeByteStride(type.children[0].type);
+  }
+  if (arrow.DataType.isInt(type)) {
+    return type.bitWidth / 8;
+  }
+  if (arrow.DataType.isFloat(type)) {
+    switch (type.precision) {
+      case arrow.Precision.HALF:
+        return 2;
+      case arrow.Precision.SINGLE:
+        return 4;
+      case arrow.Precision.DOUBLE:
+        return 8;
+    }
+  }
+  throw new Error(`Cannot determine byte stride for Arrow type ${type}`);
+}

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -34,7 +34,16 @@ export {
   type ArrowGPUTableFromVectorsProps,
   type ArrowGPUTableProps
 } from './arrow/plain-gpu-table';
-export {ArrowModel, type ArrowModelProps} from './arrow/arrow-model';
+export {
+  StreamingArrowGPUTable,
+  StreamingArrowGPUVector,
+  type StreamingArrowAsyncRecordBatchSource,
+  type StreamingArrowGPUTableProps,
+  type StreamingArrowGPUVectorBufferProps,
+  type StreamingArrowGPUVectorProps,
+  type StreamingArrowRecordBatchSource
+} from './arrow/streaming-arrow-gpu-table';
+export {ArrowModel, type ArrowModelGPUTable, type ArrowModelProps} from './arrow/arrow-model';
 
 export {
   getArrowVertexFormat,

--- a/modules/arrow/test/arrow/arrow-fixed-size-list.spec.ts
+++ b/modules/arrow/test/arrow/arrow-fixed-size-list.spec.ts
@@ -106,6 +106,44 @@ test('ArrowGPUVector creates a GPU buffer from an Arrow vector', t => {
   t.end();
 });
 
+test('ArrowGPUVector readAsync round-trips scalar numeric vectors', async t => {
+  const device = new NullDevice({});
+  const sourceVector = arrow.makeVector(new Int32Array([1, -2, 3]));
+  const gpuVector = new ArrowGPUVector(device, sourceVector);
+
+  const result = await gpuVector.readAsync();
+
+  t.ok(arrow.util.compareTypes(result.type, sourceVector.type), 'preserves Arrow dynamic type');
+  t.equal(result.length, sourceVector.length, 'preserves row count');
+  t.deepEqual(Array.from(result.toArray()), [1, -2, 3], 'reads scalar values from GPU buffer');
+
+  gpuVector.destroy();
+  t.end();
+});
+
+test('ArrowGPUVector readAsync round-trips FixedSizeList vectors', async t => {
+  const device = new NullDevice({});
+  const sourceVector = makeArrowFixedSizeListVector(
+    new arrow.Float32(),
+    2,
+    new Float32Array([1, 2, 3, 4])
+  );
+  const gpuVector = new ArrowGPUVector(device, sourceVector);
+
+  const result = await gpuVector.readAsync();
+
+  t.ok(arrow.util.compareTypes(result.type, sourceVector.type), 'preserves FixedSizeList type');
+  t.equal(result.length, sourceVector.length, 'preserves FixedSizeList row count');
+  t.deepEqual(
+    getArrowFixedSizeListValues(result),
+    new Float32Array([1, 2, 3, 4]),
+    'reads child values from GPU buffer'
+  );
+
+  gpuVector.destroy();
+  t.end();
+});
+
 test('ArrowGPUVector supports discriminated Arrow-vector construction', t => {
   const device = new NullDevice({});
   const vector = makeArrowFixedSizeListVector(
@@ -162,6 +200,32 @@ test('ArrowGPUVector wraps existing typed buffers', t => {
   t.end();
 });
 
+test('ArrowGPUVector readAsync respects wrapped-buffer byteOffset and padded byteStride', async t => {
+  const device = new NullDevice({});
+  const bytes = new Uint8Array(20);
+  new Float32Array(bytes.buffer, 4, 1)[0] = 1.5;
+  new Float32Array(bytes.buffer, 12, 1)[0] = 2.5;
+  const buffer = device.createBuffer({data: bytes});
+  const gpuVector = new ArrowGPUVector({
+    type: 'buffer',
+    name: 'weights',
+    buffer,
+    arrowType: new arrow.Float32(),
+    length: 2,
+    byteOffset: 4,
+    byteStride: 8,
+    ownsBuffer: false
+  });
+
+  const result = await gpuVector.readAsync();
+
+  t.deepEqual(Array.from(result.toArray()), [1.5, 2.5], 'compacts padded rows');
+
+  gpuVector.destroy();
+  buffer.destroy();
+  t.end();
+});
+
 test('ArrowGPUVector wraps interleaved buffers', t => {
   const device = new NullDevice({});
   const buffer = device.createBuffer({byteLength: 32});
@@ -194,6 +258,35 @@ test('ArrowGPUVector wraps interleaved buffers', t => {
     },
     'exposes interleaved buffer layout'
   );
+
+  gpuVector.destroy();
+  t.end();
+});
+
+test('ArrowGPUVector readAsync rejects interleaved vectors', async t => {
+  const device = new NullDevice({});
+  const gpuVector = new ArrowGPUVector({
+    type: 'interleaved',
+    name: 'instances',
+    buffer: device.createBuffer({byteLength: 32}),
+    length: 2,
+    byteStride: 16,
+    attributes: [
+      {attribute: 'positions', format: 'float32x3', byteOffset: 0},
+      {attribute: 'colors', format: 'uint8x4', byteOffset: 12}
+    ],
+    ownsBuffer: true
+  });
+
+  try {
+    await gpuVector.readAsync();
+    t.fail('readAsync should reject interleaved vectors');
+  } catch (error) {
+    t.ok(
+      error instanceof Error && /does not support interleaved vectors/.test(error.message),
+      'throws a clear unsupported error'
+    );
+  }
 
   gpuVector.destroy();
   t.end();

--- a/modules/arrow/test/arrow/arrow-model.spec.ts
+++ b/modules/arrow/test/arrow/arrow-model.spec.ts
@@ -3,7 +3,12 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {ArrowGPUTable, ArrowModel, makeArrowFixedSizeListVector} from '@luma.gl/arrow';
+import {
+  ArrowGPUTable,
+  ArrowModel,
+  makeArrowFixedSizeListVector,
+  StreamingArrowGPUTable
+} from '@luma.gl/arrow';
 import type {ShaderLayout} from '@luma.gl/core';
 import {NullDevice} from '@luma.gl/test-utils';
 import * as arrow from 'apache-arrow';
@@ -41,7 +46,7 @@ test('ArrowModel creates a Model from an Arrow table', t => {
     shaderLayout: SHADER_LAYOUT,
     arrowTable
   });
-  const positionsBuffer = model.arrowGPUTable.gpuVectors.positions.buffer;
+  const positionsBuffer = model.arrowGPUTable.gpuVectors['positions'].buffer;
 
   t.ok(model.arrowGPUTable instanceof ArrowGPUTable, 'creates an ArrowGPUTable');
   t.deepEqual(
@@ -54,7 +59,7 @@ test('ArrowModel creates a Model from an Arrow table', t => {
   );
   t.equal(
     model.vertexArray.attributes[0],
-    model.arrowGPUTable.attributes.positions,
+    model.arrowGPUTable.attributes['positions'],
     'sets Model vertex array attributes from Arrow buffers'
   );
   t.equal(model.instanceCount, arrowTable.numRows, 'defaults instanceCount to Arrow row count');
@@ -107,7 +112,7 @@ test('ArrowModel updates Arrow table props', t => {
     shaderLayout: SHADER_LAYOUT,
     arrowTable
   });
-  const previousPositionsBuffer = model.arrowGPUTable.gpuVectors.positions.buffer;
+  const previousPositionsBuffer = model.arrowGPUTable.gpuVectors['positions'].buffer;
   const previousPipeline = model.pipeline;
 
   model.setProps({arrowTable: nextArrowTable});
@@ -120,12 +125,48 @@ test('ArrowModel updates Arrow table props', t => {
   );
   t.equal(
     model.vertexArray.attributes[0],
-    model.arrowGPUTable.attributes.positions,
+    model.arrowGPUTable.attributes['positions'],
     'sets vertex array attributes from the updated Arrow buffers'
   );
   t.ok(previousPositionsBuffer.destroyed, 'destroys previous Arrow GPU vector buffers');
 
   model.destroy();
+  t.end();
+});
+
+test('ArrowModel consumes a StreamingArrowGPUTable', t => {
+  const device = new NullDevice({});
+  const firstTable = makeArrowModelTable(1);
+  const nextTable = makeArrowModelTable(3);
+  const streamingArrowGPUTable = new StreamingArrowGPUTable({
+    device,
+    schema: firstTable.schema,
+    shaderLayout: SHADER_LAYOUT
+  });
+
+  streamingArrowGPUTable.appendRecordBatch(firstTable.batches[0]);
+  const model = new ArrowModel(device, {
+    id: 'arrow-model-streaming-test',
+    vs: DUMMY_VS,
+    fs: DUMMY_FS,
+    shaderLayout: SHADER_LAYOUT,
+    streamingArrowGPUTable
+  });
+  const positionsBuffer = streamingArrowGPUTable.gpuVectors['positions'].buffer;
+  const initialNeedsRedraw = model.needsRedraw();
+
+  streamingArrowGPUTable.appendRecordBatch(nextTable.batches[0]);
+
+  t.equal(model.arrowGPUTable, streamingArrowGPUTable, 'uses the provided streaming table');
+  t.equal(model.instanceCount, 1, 'initially infers row count from streaming table');
+  t.ok(model.needsRedraw(), 'detects writes to streaming DynamicBuffer attributes');
+  t.equal(model.instanceCount, 4, 'refreshes inferred row count after streaming append');
+
+  model.destroy();
+  t.notOk(positionsBuffer.destroyed, 'does not destroy externally provided streaming table');
+  streamingArrowGPUTable.destroy();
+  t.ok(positionsBuffer.destroyed, 'external owner can destroy the streaming table');
+  t.ok(initialNeedsRedraw, 'model starts needing redraw');
   t.end();
 });
 

--- a/modules/arrow/test/arrow/streaming-arrow-gpu-table.spec.ts
+++ b/modules/arrow/test/arrow/streaming-arrow-gpu-table.spec.ts
@@ -1,0 +1,435 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {ArrowGPUTable, StreamingArrowGPUTable, StreamingArrowGPUVector} from '@luma.gl/arrow';
+import type {ShaderLayout} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import {NullDevice} from '@luma.gl/test-utils';
+import * as arrow from 'apache-arrow';
+
+type RecordedWrite = {
+  data: ArrayBufferView;
+  byteOffset: number;
+};
+
+test('StreamingArrowGPUVector appends one Arrow Data chunk without copying the source view', t => {
+  const device = new NullDevice({});
+  const values = new Float32Array([1, 2, 3, 4]);
+  const data = new arrow.Data(new arrow.Float32(), 0, 4, 0, [undefined, values]);
+  const vector = new StreamingArrowGPUVector({
+    name: 'weights',
+    device,
+    arrowType: new arrow.Float32()
+  });
+  const writes = recordDynamicBufferWrites(vector.buffer);
+
+  vector.appendData(data);
+
+  t.equal(vector.length, 4, 'updates row count');
+  t.equal(writes.length, 1, 'writes one source chunk');
+  t.equal(writes[0].data.buffer, values.buffer, 'writes a view over the Arrow value buffer');
+  t.equal(writes[0].byteOffset, 0, 'writes at the current append offset');
+
+  vector.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUVector appends chunked Arrow vectors one write per Data chunk', t => {
+  const device = new NullDevice({});
+  const firstValues = new Float32Array([1, 2]);
+  const secondValues = new Float32Array([3, 4, 5]);
+  const firstData = new arrow.Data(new arrow.Float32(), 0, 2, 0, [undefined, firstValues]);
+  const secondData = new arrow.Data(new arrow.Float32(), 0, 3, 0, [undefined, secondValues]);
+  const arrowVector = new arrow.Vector([firstData, secondData]);
+  const gpuVector = new StreamingArrowGPUVector({
+    name: 'weights',
+    device,
+    arrowType: new arrow.Float32()
+  });
+  const writes = recordDynamicBufferWrites(gpuVector.buffer);
+
+  gpuVector.appendVector(arrowVector);
+
+  t.equal(gpuVector.length, 5, 'updates row count across chunks');
+  t.equal(writes.length, 2, 'writes each chunk separately');
+  t.equal(writes[0].data.buffer, firstValues.buffer, 'writes first Arrow buffer directly');
+  t.equal(writes[1].data.buffer, secondValues.buffer, 'writes second Arrow buffer directly');
+  t.equal(writes[1].byteOffset, firstValues.byteLength, 'writes second chunk after first chunk');
+
+  gpuVector.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUVector appends sliced Arrow Data from the correct source offset', t => {
+  const device = new NullDevice({});
+  const values = new Float32Array([0, 1, 2, 3, 4, 5]);
+  const data = new arrow.Data(new arrow.Float32(), 1, 2, 0, [undefined, values]);
+  const vector = new StreamingArrowGPUVector({
+    name: 'positions',
+    device,
+    arrowType: new arrow.Float32()
+  });
+  const writes = recordDynamicBufferWrites(vector.buffer);
+
+  vector.appendData(data);
+
+  t.equal(writes[0].data.buffer, values.buffer, 'writes a source-buffer view');
+  t.equal(
+    writes[0].data.byteOffset,
+    values.byteOffset + Float32Array.BYTES_PER_ELEMENT,
+    'uses the Arrow Data offset'
+  );
+  t.deepEqual(Array.from(writes[0].data as Float32Array), [1, 2], 'writes the sliced rows');
+
+  vector.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUVector grows capacity without replacing the public DynamicBuffer', t => {
+  const device = new NullDevice({});
+  const vector = new StreamingArrowGPUVector({
+    name: 'weights',
+    device,
+    arrowType: new arrow.Float32(),
+    initialCapacityRows: 3
+  });
+  const dynamicBuffer = vector.buffer;
+  const initialBackingBuffer = dynamicBuffer.buffer;
+
+  vector.appendData(
+    new arrow.Data(new arrow.Float32(), 0, 1, 0, [undefined, new Float32Array([1])])
+  );
+  vector.appendData(
+    new arrow.Data(new arrow.Float32(), 0, 3, 0, [undefined, new Float32Array([2, 3, 4])])
+  );
+
+  t.equal(vector.buffer, dynamicBuffer, 'keeps the public DynamicBuffer stable');
+  t.notEqual(
+    dynamicBuffer.buffer,
+    initialBackingBuffer,
+    'replaces the backing GPU buffer on growth'
+  );
+  t.ok(vector.capacityRows >= 4, 'grows capacity to fit appended rows');
+
+  vector.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUVector reset clears length and keeps reusable allocation', t => {
+  const device = new NullDevice({});
+  const vector = new StreamingArrowGPUVector({
+    name: 'weights',
+    device,
+    arrowType: new arrow.Float32()
+  });
+
+  vector.appendData(
+    new arrow.Data(new arrow.Float32(), 0, 2, 0, [undefined, new Float32Array([1, 2])])
+  );
+  const dynamicBuffer = vector.buffer;
+  vector.reset();
+
+  t.equal(vector.length, 0, 'clears logical rows');
+  t.equal(vector.buffer, dynamicBuffer, 'keeps DynamicBuffer allocation');
+
+  vector.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUVector readAsync returns appended rows only', async t => {
+  const device = new NullDevice({});
+  const vector = new StreamingArrowGPUVector({
+    name: 'weights',
+    device,
+    arrowType: new arrow.Float32(),
+    initialCapacityRows: 3
+  });
+
+  vector.appendData(
+    new arrow.Data(new arrow.Float32(), 0, 1, 0, [undefined, new Float32Array([1])])
+  );
+  vector.appendData(
+    new arrow.Data(new arrow.Float32(), 0, 3, 0, [undefined, new Float32Array([2, 3, 4])])
+  );
+
+  const result = await vector.readAsync();
+
+  t.ok(vector.capacityRows > vector.length, 'has unused capacity after growth');
+  t.equal(result.length, 4, 'returns logical row count');
+  t.deepEqual(Array.from(result.toArray()), [1, 2, 3, 4], 'reads appended rows');
+
+  vector.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUVector readAsync returns an empty vector after reset', async t => {
+  const device = new NullDevice({});
+  const vector = new StreamingArrowGPUVector({
+    name: 'weights',
+    device,
+    arrowType: new arrow.Float32()
+  });
+
+  vector.appendData(
+    new arrow.Data(new arrow.Float32(), 0, 2, 0, [undefined, new Float32Array([1, 2])])
+  );
+  vector.reset();
+
+  const result = await vector.readAsync();
+
+  t.ok(arrow.util.compareTypes(result.type, new arrow.Float32()), 'preserves Arrow type');
+  t.equal(result.length, 0, 'returns no rows');
+  t.deepEqual(Array.from(result.toArray()), [], 'returns empty values');
+
+  vector.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUVector rejects nullable and unsupported sources', t => {
+  const device = new NullDevice({});
+  const vector = new StreamingArrowGPUVector({
+    name: 'weights',
+    device,
+    arrowType: new arrow.Float32()
+  });
+  const nullableData = new arrow.Data(new arrow.Float32(), 0, 1, 1, [
+    new Uint8Array([0]),
+    new Float32Array([1])
+  ]);
+
+  t.throws(() => vector.appendData(nullableData), /nullable data/, 'rejects nullable chunks');
+  t.throws(
+    () =>
+      new StreamingArrowGPUVector({
+        name: 'labels',
+        device,
+        arrowType: new arrow.Utf8() as unknown as arrow.Float32
+      }),
+    /does not support Arrow type/,
+    'rejects non-attribute Arrow types'
+  );
+
+  vector.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUTable matches ArrowGPUTable selection and arrowPaths behavior', t => {
+  const device = new NullDevice({});
+  const table = makeGpuMetadataTable([0, 0, 1, 1], [255, 0, 0, 255, 0, 255, 0, 255]);
+  const shaderLayout: ShaderLayout = {
+    attributes: [{name: 'instanceColors', location: 0, type: 'vec4<f32>'}],
+    bindings: []
+  };
+  const streamingTable = new StreamingArrowGPUTable({
+    device,
+    schema: table.schema,
+    shaderLayout,
+    arrowPaths: {instanceColors: 'colors'}
+  });
+  const staticTable = new ArrowGPUTable(device, table, {
+    shaderLayout,
+    arrowPaths: {instanceColors: 'colors'}
+  });
+
+  t.deepEqual(streamingTable.bufferLayout, staticTable.bufferLayout, 'matches static table layout');
+  t.deepEqual(
+    streamingTable.schema.fields.map(field => field.name),
+    staticTable.schema.fields.map(field => field.name),
+    'matches static table selected schema names'
+  );
+  t.ok(
+    streamingTable.attributes['instanceColors'] instanceof DynamicBuffer,
+    'exposes DynamicBuffer attributes'
+  );
+
+  streamingTable.destroy();
+  staticTable.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUTable appends record batches and tables into stable attributes', t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGpuMetadataRecordBatch([0, 0, 1, 1], [255, 0, 0, 255, 0, 255, 0, 255]);
+  const secondBatch = makeGpuMetadataRecordBatch([2, 2], [0, 0, 255, 255]);
+  const streamingTable = new StreamingArrowGPUTable({
+    device,
+    schema: firstBatch.schema,
+    shaderLayout: makePositionColorShaderLayout(),
+    initialCapacityRows: 1
+  });
+  const positionsAttribute = streamingTable.attributes['positions'];
+
+  streamingTable.appendRecordBatch(firstBatch);
+  streamingTable.appendTable(new arrow.Table([secondBatch]));
+
+  t.equal(streamingTable.numRows, 3, 'updates table row count across appends');
+  t.equal(streamingTable.gpuVectors['positions'].length, 3, 'updates vector row count');
+  t.equal(
+    streamingTable.attributes['positions'],
+    positionsAttribute,
+    'keeps attribute object stable'
+  );
+  t.equal(streamingTable.numCols, 2, 'exposes selected column count');
+
+  streamingTable.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUTable initializes from synchronous record batch sources', t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGpuMetadataRecordBatch([0, 0], [255, 0, 0, 255]);
+  const secondBatch = makeGpuMetadataRecordBatch([1, 1, 2, 2], [0, 255, 0, 255, 0, 0, 255, 255]);
+  const streamingTable = new StreamingArrowGPUTable({
+    device,
+    recordBatches: [firstBatch, secondBatch],
+    shaderLayout: makePositionColorShaderLayout()
+  });
+
+  t.equal(streamingTable.numRows, 3, 'consumes iterable record batches during construction');
+  t.equal(streamingTable.gpuVectors['positions'].length, 3, 'uploads every iterable row');
+  t.equal(streamingTable.nullCount, 0, 'tracks appended null count');
+
+  streamingTable.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUTable initializes from async record batch sources', async t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGpuMetadataRecordBatch([0, 0], [255, 0, 0, 255]);
+  const secondBatch = makeGpuMetadataRecordBatch([1, 1], [0, 255, 0, 255]);
+  const streamingTable = new StreamingArrowGPUTable({
+    device,
+    schema: firstBatch.schema,
+    asyncRecordBatches: makeAsyncRecordBatches([firstBatch, secondBatch]),
+    shaderLayout: makePositionColorShaderLayout()
+  });
+
+  t.equal(streamingTable.numRows, 0, 'starts before async constructor source is consumed');
+  await streamingTable.ready;
+  t.equal(streamingTable.numRows, 2, 'consumes async record batches through ready');
+  t.equal(streamingTable.gpuVectors['colors'].length, 2, 'uploads async source rows');
+
+  streamingTable.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUTable appends async record batch sources after construction', async t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGpuMetadataRecordBatch([0, 0], [255, 0, 0, 255]);
+  const streamingTable = new StreamingArrowGPUTable({
+    device,
+    schema: firstBatch.schema,
+    shaderLayout: makePositionColorShaderLayout()
+  });
+
+  await streamingTable.appendRecordBatchesAsync(makeAsyncRecordBatches([firstBatch]));
+
+  t.equal(streamingTable.numRows, 1, 'appends async source rows');
+
+  streamingTable.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUTable validates append schemas and reset/destroy lifecycle', t => {
+  const device = new NullDevice({});
+  const batch = makeGpuMetadataRecordBatch([0, 0], [255, 0, 0, 255]);
+  const streamingTable = new StreamingArrowGPUTable({
+    device,
+    recordBatch: batch,
+    shaderLayout: makePositionColorShaderLayout()
+  });
+  const missingPositionsBatch = makeColorsOnlyRecordBatch([0, 0, 255, 255]);
+  const positionsBuffer = streamingTable.gpuVectors['positions'].buffer;
+
+  t.equal(streamingTable.numRows, 1, 'appends constructor record batch');
+  t.throws(
+    () => streamingTable.appendRecordBatch(missingPositionsBatch),
+    /does not match the source schema/,
+    'rejects mismatched schemas'
+  );
+
+  streamingTable.reset();
+  t.equal(streamingTable.numRows, 0, 'reset clears table rows');
+  t.equal(streamingTable.gpuVectors['positions'].length, 0, 'reset clears vector rows');
+
+  streamingTable.destroy();
+  t.ok(positionsBuffer.destroyed, 'destroy releases owned dynamic buffers');
+  t.end();
+});
+
+function recordDynamicBufferWrites(buffer: DynamicBuffer): RecordedWrite[] {
+  const writes: RecordedWrite[] = [];
+  const originalWrite = buffer.write.bind(buffer);
+  buffer.write = (data: ArrayBuffer | SharedArrayBuffer | ArrayBufferView, byteOffset = 0) => {
+    writes.push({data: data as ArrayBufferView, byteOffset});
+    originalWrite(data, byteOffset);
+  };
+  return writes;
+}
+
+function makePositionColorShaderLayout(): ShaderLayout {
+  return {
+    attributes: [
+      {name: 'positions', location: 0, type: 'vec2<f32>'},
+      {name: 'colors', location: 1, type: 'vec4<f32>'}
+    ],
+    bindings: []
+  };
+}
+
+function makeGpuMetadataTable(positions: number[], colors: number[]): arrow.Table {
+  return new arrow.Table([makeGpuMetadataRecordBatch(positions, colors)]);
+}
+
+function makeGpuMetadataRecordBatch(positions: number[], colors: number[]): arrow.RecordBatch {
+  const positionsData = makeFixedSizeListData(new arrow.Float32(), 2, new Float32Array(positions));
+  const colorsData = makeFixedSizeListData(new arrow.Uint8(), 4, new Uint8Array(colors));
+  const schema = new arrow.Schema(
+    [
+      new arrow.Field('positions', positionsData.type, false, new Map([['semantic', 'position']])),
+      new arrow.Field('colors', colorsData.type, false, new Map([['semantic', 'color']]))
+    ],
+    new Map([['table', 'source']])
+  );
+  const structData = arrow.makeData({
+    type: new arrow.Struct(schema.fields),
+    length: positionsData.length,
+    nullCount: 0,
+    nullBitmap: null,
+    children: [positionsData, colorsData]
+  });
+  return new arrow.RecordBatch(schema, structData);
+}
+
+function makeColorsOnlyRecordBatch(colors: number[]): arrow.RecordBatch {
+  const colorsData = makeFixedSizeListData(new arrow.Uint8(), 4, new Uint8Array(colors));
+  const schema = new arrow.Schema([new arrow.Field('colors', colorsData.type, false)]);
+  const structData = arrow.makeData({
+    type: new arrow.Struct(schema.fields),
+    length: colorsData.length,
+    nullCount: 0,
+    nullBitmap: null,
+    children: [colorsData]
+  });
+  return new arrow.RecordBatch(schema, structData);
+}
+
+async function* makeAsyncRecordBatches(
+  recordBatches: arrow.RecordBatch[]
+): AsyncGenerator<arrow.RecordBatch> {
+  for (const recordBatch of recordBatches) {
+    yield recordBatch;
+  }
+}
+
+function makeFixedSizeListData<T extends arrow.DataType>(
+  childType: T,
+  listSize: 2 | 3 | 4,
+  values: T['TArray']
+): arrow.Data<arrow.FixedSizeList<T>> {
+  const childData = new arrow.Data(childType, 0, values.length, 0, [undefined, values]);
+  const listType = new arrow.FixedSizeList(listSize, new arrow.Field('value', childType));
+  return new arrow.Data(listType, 0, values.length / listSize, 0, undefined, [childData]);
+}

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -6,6 +6,7 @@ import './arrow/arrow-paths.spec';
 import './arrow/arrow-column-info.spec';
 import './arrow/arrow-fixed-size-list.spec';
 import './arrow/plain-gpu-table.spec';
+import './arrow/streaming-arrow-gpu-table.spec';
 import './arrow/arrow-model.spec';
 import './arrow/arrow-shader-layout.spec';
 import './arrow/analyze-arrow-table.spec';

--- a/modules/engine/src/dynamic-buffer/dynamic-buffer.ts
+++ b/modules/engine/src/dynamic-buffer/dynamic-buffer.ts
@@ -322,10 +322,6 @@ export class DynamicBuffer {
     destinationBuffer: Buffer,
     byteLength: number
   ): void {
-    if (this.device.type === 'null') {
-      throw new Error(`${this} resize({preserveData: true}) is not supported on NullDevice`);
-    }
-
     const commandEncoder = this.device.createCommandEncoder();
     commandEncoder.copyBufferToBuffer({
       sourceBuffer,

--- a/modules/engine/src/dynamic-texture/dynamic-texture.ts
+++ b/modules/engine/src/dynamic-texture/dynamic-texture.ts
@@ -91,6 +91,12 @@ export class DynamicTexture {
   readonly ready: Promise<Texture>;
   isReady = false;
   destroyed = false;
+  /** Monotonic version that increments whenever texture, view, or sampler identity changes. */
+  generation = 0;
+  /** Last update timestamp for texture content, readiness, or identity changes. */
+  updateTimestamp: number;
+  /** Token replaced whenever cache users need a new resource identity. */
+  cacheToken: object = {};
 
   private resolveReady: (t: Texture) => void = () => {};
   private rejectReady: (error: Error) => void = () => {};
@@ -130,6 +136,7 @@ export class DynamicTexture {
       this.resolveReady = resolve;
       this.rejectReady = reject;
     });
+    this.updateTimestamp = this.device.incrementTimestamp();
 
     this.initAsync(originalPropsWithAsyncData);
   }
@@ -224,6 +231,7 @@ export class DynamicTexture {
       this._texture = this.device.createTexture(finalTextureProps);
       this._sampler = this.texture.sampler;
       this._view = this.texture.view;
+      this._touchGeneration();
 
       // Upload data if provided
       if (textureData.subresources.length) {
@@ -261,8 +269,10 @@ export class DynamicTexture {
   generateMipmaps(): void {
     if (this.device.type === 'webgl') {
       this.texture.generateMipmapsWebGL();
+      this._touch();
     } else if (this.device.type === 'webgpu') {
       this.device.generateMipmapsWebGPU(this.texture);
+      this._touch();
     } else {
       log.warn(`${this} mipmaps not supported on ${this.device.type}`);
     }
@@ -274,6 +284,7 @@ export class DynamicTexture {
     const s = sampler instanceof Sampler ? sampler : this.device.createSampler(sampler);
     this.texture.setSampler(s);
     this._sampler = s;
+    this._touchGeneration();
   }
 
   /**
@@ -345,6 +356,7 @@ export class DynamicTexture {
     this._view = this.texture.view;
 
     prev.destroy();
+    this._touchGeneration();
     log.info(`${this} resized`);
     return true;
   }
@@ -455,6 +467,9 @@ export class DynamicTexture {
           throw new Error('Unsupported 2D mip-level payload');
       }
     }
+    if (subresources.length > 0) {
+      this._touch();
+    }
   }
 
   // ------------------ helpers ------------------
@@ -476,6 +491,16 @@ export class DynamicTexture {
     if (!this.isReady) {
       log.warn(`${this} Cannot perform this operation before ready`);
     }
+  }
+
+  private _touch(): void {
+    this.updateTimestamp = this.device.incrementTimestamp();
+  }
+
+  private _touchGeneration(): void {
+    this.generation++;
+    this.cacheToken = {};
+    this._touch();
   }
 
   static defaultProps: Required<DynamicTextureProps> = {

--- a/modules/engine/src/material/material.ts
+++ b/modules/engine/src/material/material.ts
@@ -84,7 +84,7 @@ export class Material<
 
   private _uniformStore: UniformStore;
   private _bindGroupCacheToken: object = {};
-  private _dynamicBufferGenerations: Record<string, number> = {};
+  private _dynamicResourceGenerations: Record<string, number> = {};
 
   constructor(device: Device, props: MaterialProps<TModuleProps, TBindings> = {}) {
     this.id = props.id || uid('material');
@@ -190,7 +190,7 @@ export class Material<
 
   /** Returns the resolved bindings, including internal uniform buffers and ready textures. */
   getBindings(): Partial<{[K in keyof TBindings]: Binding}> & Record<string, Binding> {
-    this._syncDynamicBufferCacheToken();
+    this._syncDynamicResourceCacheToken();
 
     const validBindings = {} as Partial<{[K in keyof TBindings]: Binding}> &
       Record<string, Binding>;
@@ -220,7 +220,7 @@ export class Material<
 
   /** Returns the stable bind-group cache token for the requested bind group. */
   getBindGroupCacheKey(group: number): object | null {
-    this._syncDynamicBufferCacheToken();
+    this._syncDynamicResourceCacheToken();
     return group === MATERIAL_BIND_GROUP ? this._bindGroupCacheToken : null;
   }
 
@@ -235,9 +235,7 @@ export class Material<
       } else if (binding instanceof DynamicBuffer) {
         timestamp = Math.max(timestamp, binding.updateTimestamp);
       } else if (binding instanceof DynamicTexture) {
-        timestamp = binding.texture
-          ? Math.max(timestamp, binding.texture.updateTimestamp)
-          : Infinity;
+        timestamp = binding.isReady ? Math.max(timestamp, binding.updateTimestamp) : Infinity;
       } else if (isBufferRangeBinding(binding)) {
         timestamp = Math.max(
           timestamp,
@@ -280,29 +278,37 @@ export class Material<
     return didChange;
   }
 
-  private _syncDynamicBufferCacheToken(): void {
+  private _syncDynamicResourceCacheToken(): void {
     const nextGenerations: Record<string, number> = {};
     let didChange = false;
 
     for (const [name, binding] of Object.entries(this.bindings)) {
-      const dynamicBuffer = getDynamicBufferFromBinding(binding);
-      if (dynamicBuffer) {
-        nextGenerations[name] = dynamicBuffer.generation;
-        if (this._dynamicBufferGenerations[name] !== dynamicBuffer.generation) {
+      const dynamicResourceGeneration = getDynamicResourceGeneration(binding);
+      if (dynamicResourceGeneration !== null) {
+        nextGenerations[name] = dynamicResourceGeneration;
+        if (this._dynamicResourceGenerations[name] !== dynamicResourceGeneration) {
           didChange = true;
         }
       }
     }
 
     if (
-      Object.keys(nextGenerations).length !== Object.keys(this._dynamicBufferGenerations).length
+      Object.keys(nextGenerations).length !== Object.keys(this._dynamicResourceGenerations).length
     ) {
       didChange = true;
     }
 
-    this._dynamicBufferGenerations = nextGenerations;
+    this._dynamicResourceGenerations = nextGenerations;
     if (didChange) {
       this._bindGroupCacheToken = {};
     }
   }
+}
+
+function getDynamicResourceGeneration(binding: MaterialBinding): number | null {
+  if (binding instanceof DynamicTexture) {
+    return binding.generation;
+  }
+
+  return getDynamicBufferFromBinding(binding)?.generation ?? null;
 }

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -902,6 +902,12 @@ export class Model {
   /** Get the timestamp of the latest updated bound GPU memory resource (buffer/texture). */
   _getBindingsUpdateTimestamp(): number {
     let timestamp = 0;
+    if (this._dynamicIndexBufferSource) {
+      timestamp = Math.max(timestamp, this._dynamicIndexBufferSource.source.updateTimestamp);
+    }
+    for (const entry of Object.values(this._dynamicAttributeBufferSources)) {
+      timestamp = Math.max(timestamp, entry.source.updateTimestamp);
+    }
     for (const binding of Object.values(this.bindings)) {
       if (binding instanceof TextureView) {
         timestamp = Math.max(timestamp, binding.texture.updateTimestamp);
@@ -910,8 +916,8 @@ export class Model {
       } else if (binding instanceof DynamicBuffer) {
         timestamp = Math.max(timestamp, binding.updateTimestamp);
       } else if (binding instanceof DynamicTexture) {
-        timestamp = binding.texture
-          ? Math.max(timestamp, binding.texture.updateTimestamp)
+        timestamp = binding.isReady
+          ? Math.max(timestamp, binding.updateTimestamp)
           : // The texture will become available in the future
             Infinity;
       } else if (isBufferRangeBinding(binding)) {

--- a/modules/engine/test/dynamic-texture/dynamic-texture.spec.ts
+++ b/modules/engine/test/dynamic-texture/dynamic-texture.spec.ts
@@ -25,7 +25,7 @@ test('DynamicTexture#readAsync', async t => {
   const data = new Uint8Array([1, 2, 3, 4]);
 
   const texture = new DynamicTexture(device, {
-    data,
+    data: data as any,
     width: 1,
     height: 1,
     format: 'rgba8unorm',
@@ -46,7 +46,7 @@ test('DynamicTexture accepts bare typed-array 2d payloads', async t => {
   const data = new Uint8Array([9, 8, 7, 6]);
 
   const texture = new DynamicTexture(device, {
-    data,
+    data: data as any,
     width: 1,
     height: 1,
     format: 'rgba8unorm'
@@ -55,6 +55,48 @@ test('DynamicTexture accepts bare typed-array 2d payloads', async t => {
   await texture.ready;
   t.equal(texture.texture.width, 1, 'typed-array payload initializes width');
   t.equal(texture.texture.height, 1, 'typed-array payload initializes height');
+
+  texture.destroy();
+  t.end();
+});
+
+test('DynamicTexture tracks update timestamps and resource generations', async t => {
+  const device = await getNullTestDevice();
+  const texture = new DynamicTexture(device, {
+    data: {data: new Uint8Array([1, 2, 3, 4]), width: 1, height: 1},
+    width: 1,
+    height: 1,
+    format: 'rgba8unorm'
+  });
+  const initialTimestamp = texture.updateTimestamp;
+  const initialCacheToken = texture.cacheToken;
+
+  await texture.ready;
+
+  t.equal(texture.generation, 1, 'initial texture creation increments generation');
+  t.ok(texture.updateTimestamp > initialTimestamp, 'initial texture creation updates timestamp');
+  t.notEqual(
+    texture.cacheToken,
+    initialCacheToken,
+    'initial texture creation replaces cache token'
+  );
+
+  const readyGeneration = texture.generation;
+  const readyCacheToken = texture.cacheToken;
+  const readyTimestamp = texture.updateTimestamp;
+
+  texture.setTexture2DData({data: new Uint8Array([5, 6, 7, 8]), width: 1, height: 1});
+
+  t.equal(texture.generation, readyGeneration, 'texture data upload preserves generation');
+  t.equal(texture.cacheToken, readyCacheToken, 'texture data upload preserves cache token');
+  t.ok(texture.updateTimestamp > readyTimestamp, 'texture data upload updates timestamp');
+
+  const uploadTimestamp = texture.updateTimestamp;
+  texture.resize({width: 2, height: 2});
+
+  t.equal(texture.generation, readyGeneration + 1, 'resize increments generation');
+  t.notEqual(texture.cacheToken, readyCacheToken, 'resize replaces cache token');
+  t.ok(texture.updateTimestamp > uploadTimestamp, 'resize updates timestamp');
 
   texture.destroy();
   t.end();
@@ -474,7 +516,7 @@ test('DynamicTexture WebGPU [render][rgba8unorm] throws for unsupported 3d rende
   await texture.ready;
 
   const originalGetTextureFormatCapabilities = device.getTextureFormatCapabilities.bind(device);
-  (device as any).getTextureFormatCapabilities = (format: string) => {
+  (device as any).getTextureFormatCapabilities = (format: TextureFormat) => {
     const capabilities = originalGetTextureFormatCapabilities(format);
     if (format === RENDER_MIPMAP_TEST_FORMAT) {
       return {...capabilities, render: false, filter: false};
@@ -575,7 +617,7 @@ test('DynamicTexture WebGPU [compute][rgba8unorm] throws for unsupported compute
   await texture.ready;
 
   const originalGetTextureFormatCapabilities = device.getTextureFormatCapabilities.bind(device);
-  (device as any).getTextureFormatCapabilities = (format: string) => {
+  (device as any).getTextureFormatCapabilities = (format: TextureFormat) => {
     const capabilities = originalGetTextureFormatCapabilities(format);
     if (format === COMPUTE_MIPMAP_TEST_FORMAT) {
       return {...capabilities, filter: false, store: false};
@@ -680,7 +722,7 @@ test('DynamicTexture WebGPU [render][rgba8unorm] throws when render capabilities
   await texture.ready;
 
   const originalGetTextureFormatCapabilities = device.getTextureFormatCapabilities.bind(device);
-  (device as any).getTextureFormatCapabilities = (format: string) => {
+  (device as any).getTextureFormatCapabilities = (format: TextureFormat) => {
     const capabilities = originalGetTextureFormatCapabilities(format);
     if (format === RENDER_MIPMAP_TEST_FORMAT) {
       return {...capabilities, render: false, filter: false};

--- a/modules/engine/test/lib/material.spec.ts
+++ b/modules/engine/test/lib/material.spec.ts
@@ -6,8 +6,8 @@ import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import type {ShaderModule} from '@luma.gl/shadertools';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 import {waterMaterial} from '../../../shadertools/src/modules/lighting/water-material/water-material';
-import {Buffer} from '../../../core/src';
-import {DynamicBuffer, MaterialFactory} from '../../src';
+import {Buffer, Texture} from '../../../core/src';
+import {DynamicBuffer, DynamicTexture, MaterialFactory} from '../../src';
 
 const defaultUniformMaterial: ShaderModule<{value: number}> = {
   name: 'defaultUniformMaterial',
@@ -29,17 +29,26 @@ const dynamicBufferMaterial: ShaderModule<Record<string, never>> = {
   dependencies: []
 };
 
+const dynamicTextureMaterial: ShaderModule<Record<string, never>> = {
+  name: 'dynamicTextureMaterial',
+  bindingLayout: [{name: 'materialTexture', group: 3}],
+  getUniforms: () => ({}),
+  dependencies: []
+};
+
 test('Material initializes uniform buffers with default module uniforms', async t => {
   const webglDevice = await getWebGLTestDevice();
   const materialFactory = new MaterialFactory<{defaultUniformMaterial: {value?: number}}, {}>(
     webglDevice,
     {
-      modules: [defaultUniformMaterial]
+      modules: [defaultUniformMaterial as ShaderModule]
     }
   );
   const material = materialFactory.createMaterial();
 
-  const uniformBuffer = material.getBindings().defaultUniformMaterialUniforms as unknown as Buffer;
+  const uniformBuffer = material.getBindings()[
+    'defaultUniformMaterialUniforms'
+  ] as unknown as Buffer;
   const storedValue = new Float32Array(uniformBuffer.debugData, 0, 1)[0];
 
   t.equal(storedValue, 2.5, 'constructor writes module default uniforms into the managed buffer');
@@ -53,7 +62,7 @@ test('Material preserves prior waterMaterial uniforms across partial updates', a
   const materialFactory = new MaterialFactory<{waterMaterial: typeof waterMaterial.props}, {}>(
     webglDevice,
     {
-      modules: [waterMaterial]
+      modules: [waterMaterial as ShaderModule]
     }
   );
   const material = materialFactory.createMaterial();
@@ -65,13 +74,13 @@ test('Material preserves prior waterMaterial uniforms across partial updates', a
       waveADirection: [0, 2]
     }
   });
-  const uniformsAfterFirstUpdate = material.shaderInputs.getUniformValues().waterMaterial;
+  const uniformsAfterFirstUpdate = material.shaderInputs.getUniformValues()['waterMaterial']!;
   t.deepEqual(
-    uniformsAfterFirstUpdate.baseColor,
+    uniformsAfterFirstUpdate['baseColor'],
     [0, 64 / 255, 128 / 255],
     'first update normalizes and stores vector uniforms'
   );
-  const directMergedUniforms = waterMaterial.getUniforms(
+  const directMergedUniforms = waterMaterial.getUniforms!(
     {
       time: 3.5,
       mapping: 'world'
@@ -79,7 +88,7 @@ test('Material preserves prior waterMaterial uniforms across partial updates', a
     uniformsAfterFirstUpdate
   );
   t.deepEqual(
-    directMergedUniforms.baseColor,
+    directMergedUniforms['baseColor'],
     [0, 64 / 255, 128 / 255],
     'waterMaterial.getUniforms preserves prior vector uniforms when previous uniforms are supplied'
   );
@@ -91,16 +100,16 @@ test('Material preserves prior waterMaterial uniforms across partial updates', a
     }
   });
 
-  const uniforms = material.shaderInputs.getUniformValues().waterMaterial;
+  const uniforms = material.shaderInputs.getUniformValues()['waterMaterial']!;
   t.deepEqual(
-    uniforms.baseColor,
+    uniforms['baseColor'],
     [0, 64 / 255, 128 / 255],
     'partial updates preserve normalized sibling vector uniforms'
   );
-  t.equal(uniforms.fresnelPower, 6, 'partial updates preserve sibling scalar uniforms');
-  t.deepEqual(uniforms.waveADirection, [0, 1], 'partial updates preserve normalized directions');
-  t.equal(uniforms.time, 3.5, 'new scalar uniform is applied');
-  t.equal(uniforms.mappingMode, 1, 'mapping prop resolves to world-space mode');
+  t.equal(uniforms['fresnelPower'], 6, 'partial updates preserve sibling scalar uniforms');
+  t.deepEqual(uniforms['waveADirection'], [0, 1], 'partial updates preserve normalized directions');
+  t.equal(uniforms['time'], 3.5, 'new scalar uniform is applied');
+  t.equal(uniforms['mappingMode'], 1, 'mapping prop resolves to world-space mode');
 
   material.destroy();
   t.end();
@@ -109,7 +118,7 @@ test('Material preserves prior waterMaterial uniforms across partial updates', a
 test('Material invalidates bind-group cache keys when DynamicBuffer generation changes', async t => {
   const webglDevice = await getWebGLTestDevice();
   const materialFactory = new MaterialFactory<{}, {materialBuffer: DynamicBuffer}>(webglDevice, {
-    modules: [dynamicBufferMaterial]
+    modules: [dynamicBufferMaterial as ShaderModule]
   });
   const dynamicBuffer = new DynamicBuffer(webglDevice, {
     byteLength: 16,
@@ -130,12 +139,49 @@ test('Material invalidates bind-group cache keys when DynamicBuffer generation c
 
   t.ok(initialCacheKey !== resizedCacheKey, 'resizing DynamicBuffer invalidates cache token');
   t.equal(
-    material.getBindings().materialBuffer,
+    material.getBindings()['materialBuffer'],
     dynamicBuffer.buffer,
     'resolved bindings use the current DynamicBuffer backing buffer'
   );
 
   material.destroy();
   dynamicBuffer.destroy();
+  t.end();
+});
+
+test('Material invalidates bind-group cache keys when DynamicTexture generation changes', async t => {
+  const webglDevice = await getWebGLTestDevice();
+  const materialFactory = new MaterialFactory<{}, {materialTexture: DynamicTexture}>(webglDevice, {
+    modules: [dynamicTextureMaterial as ShaderModule]
+  });
+  const dynamicTexture = new DynamicTexture(webglDevice, {
+    width: 1,
+    height: 1,
+    format: 'rgba8unorm',
+    usage: Texture.SAMPLE | Texture.COPY_DST
+  });
+  await dynamicTexture.ready;
+  const material = materialFactory.createMaterial({
+    bindings: {
+      materialTexture: dynamicTexture
+    }
+  });
+
+  material.getBindings();
+  const initialCacheKey = material.getBindGroupCacheKey(3);
+
+  dynamicTexture.resize({width: 2, height: 2});
+  material.getBindings();
+  const resizedCacheKey = material.getBindGroupCacheKey(3);
+
+  t.ok(initialCacheKey !== resizedCacheKey, 'resizing DynamicTexture invalidates cache token');
+  t.equal(
+    material.getBindings()['materialTexture'],
+    dynamicTexture.texture,
+    'resolved bindings use the current DynamicTexture backing texture'
+  );
+
+  material.destroy();
+  dynamicTexture.destroy();
   t.end();
 });

--- a/modules/test-utils/src/null-device/resources/null-buffer.ts
+++ b/modules/test-utils/src/null-device/resources/null-buffer.ts
@@ -45,14 +45,29 @@ export class NullBuffer extends Buffer {
     const source = ArrayBuffer.isView(data)
       ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
       : new Uint8Array(data);
-    const target = new Uint8Array(this._storage, byteOffset, source.byteLength);
 
     if (byteOffset + source.byteLength > this.byteLength) {
       throw new RangeError(`NullBuffer.write(): write would overflow buffer`);
     }
 
+    const target = new Uint8Array(this._storage, byteOffset, source.byteLength);
     target.set(source);
+    this.updateTimestamp = this.device.incrementTimestamp();
     this._setDebugData(data, byteOffset, source.byteLength);
+  }
+
+  copyToBuffer(
+    destinationBuffer: Buffer,
+    sourceOffset: number,
+    destinationOffset: number,
+    size: number
+  ): void {
+    if (sourceOffset + size > this.byteLength) {
+      throw new RangeError(`NullBuffer.copyToBuffer(): read would overflow source buffer`);
+    }
+
+    const source = new Uint8Array(this._storage, sourceOffset, size);
+    destinationBuffer.write(source, destinationOffset);
   }
 
   async mapAndWriteAsync(

--- a/modules/test-utils/src/null-device/resources/null-command-buffer.ts
+++ b/modules/test-utils/src/null-device/resources/null-command-buffer.ts
@@ -12,6 +12,7 @@ import type {
 } from '@luma.gl/core';
 import {CommandBuffer} from '@luma.gl/core';
 import type {NullDevice} from '../null-device';
+import {NullBuffer} from './null-buffer';
 
 export class NullCommandBuffer extends CommandBuffer {
   readonly device: NullDevice;
@@ -22,8 +23,17 @@ export class NullCommandBuffer extends CommandBuffer {
     this.device = device;
   }
 
-  copyBufferToBuffer(_options: CopyBufferToBufferOptions): void {
-    throw new Error('copyBufferToBuffer is not supported on NullDevice');
+  copyBufferToBuffer(options: CopyBufferToBufferOptions): void {
+    if (!(options.sourceBuffer instanceof NullBuffer)) {
+      throw new Error('NullCommandBuffer.copyBufferToBuffer requires a NullBuffer source');
+    }
+
+    options.sourceBuffer.copyToBuffer(
+      options.destinationBuffer,
+      options.sourceOffset || 0,
+      options.destinationOffset || 0,
+      options.size
+    );
   }
 
   copyBufferToTexture(_options: CopyBufferToTextureOptions) {

--- a/modules/test-utils/src/null-device/resources/null-command-encoder.ts
+++ b/modules/test-utils/src/null-device/resources/null-command-encoder.ts
@@ -15,6 +15,7 @@ import type {
   CopyTextureToTextureOptions
 } from '@luma.gl/core';
 import type {NullDevice} from '../null-device';
+import {NullBuffer} from './null-buffer';
 import {NullCommandBuffer} from './null-command-buffer';
 import {NullRenderPass} from './null-render-pass';
 
@@ -45,8 +46,17 @@ export class NullCommandEncoder extends CommandEncoder {
     throw new Error('ComputePass is not supported on NullDevice');
   }
 
-  copyBufferToBuffer(_options: CopyBufferToBufferOptions): void {
-    throw new Error('copyBufferToBuffer is not supported on NullDevice');
+  copyBufferToBuffer(options: CopyBufferToBufferOptions): void {
+    if (!(options.sourceBuffer instanceof NullBuffer)) {
+      throw new Error('NullCommandEncoder.copyBufferToBuffer requires a NullBuffer source');
+    }
+
+    options.sourceBuffer.copyToBuffer(
+      options.destinationBuffer,
+      options.sourceOffset || 0,
+      options.destinationOffset || 0,
+      options.size
+    );
   }
 
   copyBufferToTexture(_options: CopyBufferToTextureOptions) {


### PR DESCRIPTION
## Summary

This PR adds streaming Arrow GPU table support and aligns dynamic GPU resource behavior so Arrow-backed models can consume append-only record batches without replacing model attribute objects.

The main goals are:
- Stream Arrow `RecordBatch`/`Table` data into stable `DynamicBuffer`-backed GPU vectors.
- Allow `ArrowModel` to consume either one-shot `ArrowGPUTable` data or a `StreamingArrowGPUTable`.
- Keep `DynamicBuffer` and `DynamicTexture` update/generation APIs aligned so model/material redraw and bind-group cache invalidation can detect resource changes.
- Add GPU-to-Arrow readback for Arrow GPU vectors.

## Changes

- Added `StreamingArrowGPUVector` and `StreamingArrowGPUTable` in `@luma.gl/arrow`.
  - Supports append-only `RecordBatch`, `Table`, sync iterator, and async iterator ingestion.
  - Uses stable `DynamicBuffer` objects while allowing backing buffers to grow.
  - Rejects nullable and unsupported Arrow columns on the direct upload path.
  - Exposes `bufferLayout`, `gpuVectors`, `attributes`, `numRows`, reset, and destroy behavior.

- Updated `ArrowModel` to accept `streamingArrowGPUTable`.
  - Reuses streaming table attributes and buffer layout directly.
  - Avoids owning/destroying externally supplied streaming tables.
  - Updates instance count from streaming row count.

- Added `readAsync()` to `ArrowGPUVector` and `StreamingArrowGPUVector`.
  - Reconstructs non-null Arrow vectors from GPU buffer bytes.
  - Supports numeric scalar and `FixedSizeList<Numeric>` Arrow types.
  - Respects logical length, byte offset, and padded byte stride.
  - Interleaved vectors throw a clear unsupported error for V1.

- Aligned dynamic GPU resource tracking.
  - `DynamicTexture` now has `generation`, `updateTimestamp`, and `cacheToken`, matching the DynamicBuffer-style resource identity model.
  - `Material` invalidates bind-group cache keys for DynamicTexture generation changes.
  - `Model` includes DynamicBuffer attribute/index sources and DynamicTexture wrappers in binding update timestamp checks.

- Improved NullDevice buffer emulation.
  - `NullBuffer` now stores data, supports read/write/copy behavior, and updates timestamps.
  - Null command encoder/buffer now support buffer-to-buffer copies, enabling DynamicBuffer preservation tests.

- Added docs for streaming Arrow table usage in `docs/api-guide/gpu/arrow-table-columns.md`.

## Testing

- `./node_modules/.bin/biome check --config-path=biome.jsonc --files-ignore-unknown=true ...`
- Targeted `./node_modules/.bin/tsc --noEmit --pretty false | rg ...`
  - No diagnostics for touched Arrow, engine, dynamic resource, and NullDevice files.
- `yarn test-headless modules/arrow/test/arrow/arrow-fixed-size-list.spec.ts modules/arrow/test/arrow/streaming-arrow-gpu-table.spec.ts modules/arrow/test/arrow/arrow-model.spec.ts modules/engine/test/dynamic-buffer/dynamic-buffer.spec.ts modules/engine/test/dynamic-texture/dynamic-texture.spec.ts modules/engine/test/lib/material.spec.ts`
  - 6 files passed
  - 60 tests passed

## Notes

- `package.json` was not changed.
- Streaming V1 is append/reset only; no row deletion, compaction, or overwrite ranges.
- Streaming V1 follows the existing `ArrowGPUTable` selection model rather than `TableBufferPlanner`.