### PR TITLE
feat(arrow) Support loaders-compatible ArrowMeshTable

### DIFF
--- a/docs/api-guide/gpu/arrow-table-columns.md
+++ b/docs/api-guide/gpu/arrow-table-columns.md
@@ -130,6 +130,58 @@ const colorVector: ArrowGPUVector = arrowGPUTable.gpuVectors.instanceColors;
 `Model`. It accepts an Arrow table as an update source and replaces the GPU
 representation when `setProps({arrowTable})` is called.
 
+## Mesh Arrow Geometry
+
+`ArrowGeometry` converts Mesh Arrow tables into `GPUGeometry`. This is intended
+for loaders.gl-compatible mesh and point-cloud tables that use glTF-style column
+names such as `POSITION`, `NORMAL`, `COLOR_0`, and `TEXCOORD_0`.
+
+```ts
+import {ArrowGeometry, ArrowModel, type ArrowMeshTable} from '@luma.gl/arrow';
+
+const geometry = new ArrowGeometry(device, {
+  arrowMesh,
+  interleaved: true
+});
+
+const model = new ArrowModel(device, {
+  vs,
+  fs,
+  shaderLayout,
+  arrowMesh
+});
+```
+
+The local `ArrowMeshTable` type is structural and does not add a dependency on
+loaders.gl. It intentionally mirrors loaders.gl `MeshArrowTable`: a wrapper with
+`shape: 'arrow-table'`, `topology`, optional top-level `indices`, and raw
+`data: arrow.Table`.
+
+Mesh Arrow tables use one row per vertex. Vertex attributes are scalar numeric
+or `FixedSizeList<numeric, 1 | 2 | 3 | 4>` columns. `ArrowGeometry` normalizes
+common glTF semantics to luma.gl shader attribute names:
+
+| Mesh Arrow column | Shader attribute |
+| ----------------- | ---------------- |
+| `POSITION`        | `positions`      |
+| `NORMAL`          | `normals`        |
+| `COLOR_0`         | `colors`         |
+| `TEXCOORD_0`      | `texCoords`      |
+| `TEXCOORD_1`      | `texCoords1`     |
+
+Unknown column names are preserved unless `arrowPaths` maps a shader attribute
+name to a specific Arrow column name.
+
+Indexed Mesh Arrow tables follow the loaders.gl convention: a lowercase
+`indices: List<Int32>` column stores the full primitive index list in row `0`,
+and remaining vertex rows are null. `ArrowGeometry` uploads those indices as a
+separate GPU index buffer. If the wrapper has a top-level `indices` accessor and
+the Arrow table has no `indices` column, that accessor is used as a fallback.
+
+By default, `ArrowGeometry` packs all selected vertex attributes into one
+interleaved vertex buffer and keeps indices separate. Pass `interleaved: false`
+to upload one vertex buffer per attribute.
+
 `StreamingArrowGPUTable` uses the same shader attribute selection model but keeps
 `DynamicBuffer` attributes that can grow as record batches arrive. Use it when
 the table is append-only and model attribute objects should remain stable across

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -16,6 +16,7 @@ Target Release Date: Q3, 2026
 
 - **Arrow shader layouts** - `getArrowBufferLayout()` maps Arrow scalar and `FixedSizeList` columns to shader attribute formats from a shader-first layout, including direct `arrow.Vector` sources and Arrow table path mappings.
 - **Arrow GPU helpers** - New `ArrowGPUVector`, `ArrowGPUTable`, and `ArrowModel` helpers create GPU buffers from compatible Arrow columns and keep Arrow-backed model attributes updatable through `setProps({arrowTable})`.
+- **Mesh Arrow geometry** - New `ArrowGeometry` and `ArrowModel` support for loaders.gl-compatible Mesh Arrow tables, including default interleaved vertex buffers and optional index buffers.
 - **Arrow table buffer planning** - New `TableBufferPlanner` API builds deterministic GPU buffer allocation plans for table columns, including interleaved fallback groups and WebGPU storage-buffer planning output.
 - **[Arrow Instancing Example](/examples/showcase/arrow-instancing)** - New showcase example renders instanced cubes from an Apache Arrow table.
 

--- a/modules/arrow/README.md
+++ b/modules/arrow/README.md
@@ -10,6 +10,11 @@ Uploaded vectors own their generated buffers. Wrapped-buffer vectors are
 non-owning by default unless ownership is explicitly requested or transferred by
 an in-place operation.
 
+`ArrowGeometry` and `ArrowModel` can also consume loaders.gl-compatible Mesh
+Arrow tables through the local structural `ArrowMeshTable` type. Mesh Arrow
+attributes are uploaded as GPU geometry, defaulting to one interleaved vertex
+buffer plus a separate optional index buffer.
+
 For lower-level table pipelines, `TableBufferPlanner` can produce deterministic
 GPU allocation plans from column descriptors while respecting device vertex and
 storage buffer limits.

--- a/modules/arrow/src/arrow/arrow-geometry.ts
+++ b/modules/arrow/src/arrow/arrow-geometry.ts
@@ -1,0 +1,454 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {TypedArray} from '@math.gl/core';
+import {
+  Buffer,
+  Device,
+  type BufferLayout,
+  type VertexFormat,
+  vertexFormatDecoder
+} from '@luma.gl/core';
+import {GPUGeometry} from '@luma.gl/engine';
+import * as arrow from 'apache-arrow';
+import type {ArrowMeshTable, ArrowMeshTopology} from './arrow-mesh-types';
+
+export type ArrowGeometryProps = {
+  /**
+   * Mesh Arrow wrapper or raw Apache Arrow table.
+   *
+   * Wrapped tables may carry topology and top-level index accessor metadata.
+   * Raw tables use schema metadata key `topology` when present and otherwise
+   * default to `triangle-list`.
+   */
+  arrowMesh: ArrowMeshTable | arrow.Table;
+  /** Name of the generated interleaved vertex buffer. Defaults to `geometry`. */
+  bufferName?: string;
+  /**
+   * Whether to pack vertex attributes into one buffer.
+   *
+   * Defaults to `true`. When `false`, each selected Mesh Arrow attribute is
+   * uploaded as its own vertex buffer.
+   */
+  interleaved?: boolean;
+  /**
+   * Maps output shader attribute names to Arrow column names.
+   *
+   * When omitted, common glTF mesh semantics are normalized automatically:
+   * `POSITION` -> `positions`, `NORMAL` -> `normals`, `COLOR_0` -> `colors`,
+   * `TEXCOORD_0` -> `texCoords`, and `TEXCOORD_1` -> `texCoords1`.
+   */
+  arrowPaths?: Record<string, string>;
+};
+
+type ArrowMeshAttributeData = {
+  sourceName: string;
+  attributeName: string;
+  value: TypedArray;
+  size: number;
+  format: VertexFormat;
+  normalized?: boolean;
+};
+
+type InterleavedAttribute = ArrowMeshAttributeData & {
+  byteOffset: number;
+  byteLength: number;
+};
+
+const DEFAULT_TOPOLOGY: ArrowMeshTopology = 'triangle-list';
+const DEFAULT_BUFFER_NAME = 'geometry';
+const MIN_ATTRIBUTE_ALIGNMENT = 4;
+const INDEX_COLUMN_NAME = 'indices';
+
+/**
+ * GPU geometry derived from a loaders.gl-compatible Mesh Arrow table.
+ *
+ * `ArrowGeometry` uploads Mesh Arrow vertex attributes into GPU buffers and
+ * keeps primitive indices, when present, in a separate index buffer. By default
+ * all vertex attributes are packed into one interleaved vertex buffer, matching
+ * the common static mesh upload path used by luma.gl geometry.
+ */
+export class ArrowGeometry extends GPUGeometry {
+  /** Creates GPU geometry from Mesh Arrow input. */
+  constructor(device: Device, props: ArrowGeometryProps) {
+    const {arrowMesh, interleaved = true, bufferName = DEFAULT_BUFFER_NAME, arrowPaths} = props;
+    const table = getArrowMeshTable(arrowMesh);
+    const topology = getArrowMeshTopology(arrowMesh, table);
+    const attributes = getArrowMeshAttributes(table, arrowPaths);
+    const indexData = getArrowMeshIndices(arrowMesh, table);
+    const indices = indexData && device.createBuffer({usage: Buffer.INDEX, data: indexData});
+    const vertexCount = indexData?.length ?? table.numRows;
+    const geometryBuffers = interleaved
+      ? createInterleavedAttributes(device, attributes, bufferName, table.numRows)
+      : createSeparateAttributes(device, attributes);
+
+    super({
+      topology,
+      vertexCount,
+      indices,
+      attributes: geometryBuffers.attributes,
+      bufferLayout: geometryBuffers.bufferLayout
+    });
+  }
+}
+
+function getArrowMeshTable(arrowMesh: ArrowMeshTable | arrow.Table): arrow.Table {
+  return arrowMesh instanceof arrow.Table ? arrowMesh : arrowMesh.data;
+}
+
+function getArrowMeshTopology(
+  arrowMesh: ArrowMeshTable | arrow.Table,
+  table: arrow.Table
+): ArrowMeshTopology {
+  const topology =
+    arrowMesh instanceof arrow.Table ? table.schema.metadata.get('topology') : arrowMesh.topology;
+
+  switch (topology) {
+    case 'point-list':
+    case 'triangle-list':
+    case 'triangle-strip':
+      return topology;
+    default:
+      return DEFAULT_TOPOLOGY;
+  }
+}
+
+function getArrowMeshAttributes(
+  table: arrow.Table,
+  arrowPaths?: Record<string, string>
+): ArrowMeshAttributeData[] {
+  const attributes: ArrowMeshAttributeData[] = [];
+  const positionVector = table.getChild('POSITION');
+  if (!positionVector) {
+    throw new Error('ArrowGeometry requires a POSITION column');
+  }
+
+  const requestedColumns = new Set(Object.values(arrowPaths || {}));
+  for (const field of table.schema.fields) {
+    if (field.name === INDEX_COLUMN_NAME) {
+      continue;
+    }
+    if (requestedColumns.size > 0 && !requestedColumns.has(field.name)) {
+      continue;
+    }
+
+    const vector = table.getChild(field.name);
+    if (!vector) {
+      continue;
+    }
+    const attributeName = getMappedAttributeName(field.name, arrowPaths);
+    const normalized = parseBooleanMetadata(field.metadata.get('normalized'));
+    const attribute = getArrowMeshAttributeData(field.name, attributeName, vector, normalized);
+    attributes.push(attribute);
+  }
+
+  return attributes;
+}
+
+function getMappedAttributeName(sourceName: string, arrowPaths?: Record<string, string>): string {
+  if (arrowPaths) {
+    for (const [attributeName, arrowPath] of Object.entries(arrowPaths)) {
+      if (arrowPath === sourceName) {
+        return attributeName;
+      }
+    }
+  }
+
+  switch (sourceName) {
+    case 'POSITION':
+      return 'positions';
+    case 'NORMAL':
+      return 'normals';
+    case 'COLOR_0':
+      return 'colors';
+    case 'TEXCOORD_0':
+      return 'texCoords';
+    case 'TEXCOORD_1':
+      return 'texCoords1';
+    default:
+      return sourceName;
+  }
+}
+
+function getArrowMeshAttributeData(
+  sourceName: string,
+  attributeName: string,
+  vector: arrow.Vector,
+  normalized?: boolean
+): ArrowMeshAttributeData {
+  const {childType, size} = getArrowAttributeType(vector.type, sourceName);
+  const value = getArrowAttributeValues(vector, childType, size);
+  const format = getArrowAttributeVertexFormat(childType, size, normalized);
+
+  return {
+    sourceName,
+    attributeName,
+    value,
+    size,
+    format,
+    normalized
+  };
+}
+
+function getArrowAttributeType(
+  type: arrow.DataType,
+  sourceName: string
+): {childType: arrow.Int | arrow.Float; size: 1 | 2 | 3 | 4} {
+  if (arrow.DataType.isFixedSizeList(type)) {
+    const listSize = type.listSize;
+    if (listSize < 1 || listSize > 4) {
+      throw new Error(`ArrowGeometry column "${sourceName}" list size must be between 1 and 4`);
+    }
+    const childType = type.children[0].type;
+    if (!arrow.DataType.isInt(childType) && !arrow.DataType.isFloat(childType)) {
+      throw new Error(`ArrowGeometry column "${sourceName}" must contain numeric values`);
+    }
+    validateSupportedNumericType(sourceName, childType);
+    return {childType, size: listSize as 1 | 2 | 3 | 4};
+  }
+
+  if (arrow.DataType.isInt(type) || arrow.DataType.isFloat(type)) {
+    validateSupportedNumericType(sourceName, type);
+    return {childType: type, size: 1};
+  }
+
+  throw new Error(`ArrowGeometry column "${sourceName}" must be numeric or FixedSizeList numeric`);
+}
+
+function validateSupportedNumericType(sourceName: string, type: arrow.Int | arrow.Float): void {
+  if (arrow.DataType.isInt(type) && type.bitWidth === 64) {
+    throw new Error(`ArrowGeometry column "${sourceName}" cannot use 64-bit integer values`);
+  }
+  if (arrow.DataType.isFloat(type) && type.precision === arrow.Precision.DOUBLE) {
+    throw new Error(`ArrowGeometry column "${sourceName}" cannot use float64 values`);
+  }
+}
+
+function getArrowAttributeValues(
+  vector: arrow.Vector,
+  childType: arrow.Int | arrow.Float,
+  size: number
+): TypedArray {
+  const values = makeTypedArray(childType, vector.length * size);
+  let targetOffset = 0;
+
+  for (const data of vector.data) {
+    const source = arrow.DataType.isFixedSizeList(vector.type)
+      ? data.children[0].values
+      : data.values;
+    const sourceOffset = arrow.DataType.isFixedSizeList(vector.type)
+      ? data.offset * size
+      : data.offset;
+    const sourceLength = data.length * size;
+    values.set(
+      source.subarray(sourceOffset, sourceOffset + sourceLength) as TypedArray,
+      targetOffset
+    );
+    targetOffset += sourceLength;
+  }
+
+  return values;
+}
+
+function makeTypedArray(type: arrow.Int | arrow.Float, length: number): TypedArray {
+  if (arrow.DataType.isInt(type)) {
+    if (type.isSigned) {
+      switch (type.bitWidth) {
+        case 8:
+          return new Int8Array(length);
+        case 16:
+          return new Int16Array(length);
+        case 32:
+          return new Int32Array(length);
+      }
+    } else {
+      switch (type.bitWidth) {
+        case 8:
+          return new Uint8Array(length);
+        case 16:
+          return new Uint16Array(length);
+        case 32:
+          return new Uint32Array(length);
+      }
+    }
+  } else {
+    switch (type.precision) {
+      case arrow.Precision.HALF:
+        return new Uint16Array(length);
+      case arrow.Precision.SINGLE:
+        return new Float32Array(length);
+    }
+  }
+
+  throw new Error(`ArrowGeometry does not support Arrow type ${type}`);
+}
+
+function getArrowAttributeVertexFormat(
+  type: arrow.Int | arrow.Float,
+  size: 1 | 2 | 3 | 4,
+  normalized?: boolean
+): VertexFormat {
+  if (arrow.DataType.isFloat(type)) {
+    switch (type.precision) {
+      case arrow.Precision.HALF:
+        return vertexFormatDecoder.makeVertexFormat('float16', size, false);
+      case arrow.Precision.SINGLE:
+        return vertexFormatDecoder.makeVertexFormat('float32', size, false);
+    }
+  }
+
+  if (arrow.DataType.isInt(type)) {
+    const signedDataType = `${type.isSigned ? 'sint' : 'uint'}${type.bitWidth}` as
+      | 'sint8'
+      | 'uint8'
+      | 'sint16'
+      | 'uint16'
+      | 'sint32'
+      | 'uint32';
+    return vertexFormatDecoder.makeVertexFormat(signedDataType, size, normalized);
+  }
+
+  throw new Error(`ArrowGeometry does not support Arrow type ${type}`);
+}
+
+function getArrowMeshIndices(
+  arrowMesh: ArrowMeshTable | arrow.Table,
+  table: arrow.Table
+): Uint16Array | Uint32Array | null {
+  const indexVector = table.getChild(INDEX_COLUMN_NAME);
+  if (!indexVector && !(arrowMesh instanceof arrow.Table) && arrowMesh.indices) {
+    return normalizeIndexArray(Array.from(arrowMesh.indices.value, Number));
+  }
+  if (!indexVector) {
+    return null;
+  }
+  if (!arrow.DataType.isList(indexVector.type)) {
+    throw new Error('ArrowGeometry indices column must be a List column');
+  }
+
+  const childType = indexVector.type.children[0].type;
+  if (!arrow.DataType.isInt(childType) || childType.bitWidth > 32) {
+    throw new Error('ArrowGeometry indices column must contain 32-bit integer values');
+  }
+
+  const firstRow = indexVector.get(0);
+  if (!firstRow || typeof (firstRow as Iterable<unknown>)[Symbol.iterator] !== 'function') {
+    throw new Error('ArrowGeometry indices column row 0 must contain the index list');
+  }
+
+  return normalizeIndexArray(Array.from(firstRow as Iterable<number>, Number));
+}
+
+function normalizeIndexArray(indices: number[]): Uint16Array | Uint32Array {
+  let maxIndex = 0;
+  for (const index of indices) {
+    if (!Number.isInteger(index) || index < 0) {
+      throw new Error('ArrowGeometry indices must be non-negative integers');
+    }
+    maxIndex = Math.max(maxIndex, index);
+  }
+
+  return maxIndex <= 65535 ? Uint16Array.from(indices) : Uint32Array.from(indices);
+}
+
+function createInterleavedAttributes(
+  device: Device,
+  attributes: ArrowMeshAttributeData[],
+  bufferName: string,
+  rowCount: number
+): {attributes: Record<string, Buffer>; bufferLayout: BufferLayout[]} {
+  const interleavedAttributes: InterleavedAttribute[] = [];
+  let byteOffset = 0;
+
+  for (const attribute of attributes) {
+    const formatInfo = vertexFormatDecoder.getVertexFormatInfo(attribute.format);
+    byteOffset = alignTo(byteOffset, MIN_ATTRIBUTE_ALIGNMENT);
+    interleavedAttributes.push({
+      ...attribute,
+      byteOffset,
+      byteLength: formatInfo.byteLength
+    });
+    byteOffset += formatInfo.byteLength;
+  }
+
+  const byteStride = alignTo(byteOffset, MIN_ATTRIBUTE_ALIGNMENT);
+  const data = new Uint8Array(rowCount * byteStride);
+  for (const attribute of interleavedAttributes) {
+    writeInterleavedAttribute(data, rowCount, byteStride, attribute);
+  }
+
+  return {
+    attributes: {
+      [bufferName]: device.createBuffer({usage: Buffer.VERTEX | Buffer.COPY_SRC, data})
+    },
+    bufferLayout: [
+      {
+        name: bufferName,
+        stepMode: 'vertex',
+        byteStride,
+        attributes: interleavedAttributes.map(attribute => ({
+          attribute: attribute.attributeName,
+          format: attribute.format,
+          byteOffset: attribute.byteOffset
+        }))
+      }
+    ]
+  };
+}
+
+function writeInterleavedAttribute(
+  target: Uint8Array,
+  rowCount: number,
+  byteStride: number,
+  attribute: InterleavedAttribute
+): void {
+  const source = new Uint8Array(
+    attribute.value.buffer,
+    attribute.value.byteOffset,
+    attribute.value.byteLength
+  );
+
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+    const sourceOffset = rowIndex * attribute.byteLength;
+    const targetOffset = rowIndex * byteStride + attribute.byteOffset;
+    target.set(source.subarray(sourceOffset, sourceOffset + attribute.byteLength), targetOffset);
+  }
+}
+
+function createSeparateAttributes(
+  device: Device,
+  attributes: ArrowMeshAttributeData[]
+): {attributes: Record<string, Buffer>; bufferLayout: BufferLayout[]} {
+  const buffers: Record<string, Buffer> = {};
+  const bufferLayout: BufferLayout[] = [];
+
+  for (const attribute of attributes) {
+    buffers[attribute.attributeName] = device.createBuffer({
+      usage: Buffer.VERTEX | Buffer.COPY_SRC,
+      data: attribute.value
+    });
+    bufferLayout.push({
+      name: attribute.attributeName,
+      stepMode: 'vertex',
+      format: attribute.format
+    });
+  }
+
+  return {attributes: buffers, bufferLayout};
+}
+
+function parseBooleanMetadata(value: string | undefined): boolean | undefined {
+  switch (value) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+function alignTo(byteOffset: number, alignment: number): number {
+  return Math.ceil(byteOffset / alignment) * alignment;
+}

--- a/modules/arrow/src/arrow/arrow-mesh-types.ts
+++ b/modules/arrow/src/arrow/arrow-mesh-types.ts
@@ -1,0 +1,41 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {TypedArray} from '@math.gl/core';
+import type * as arrow from 'apache-arrow';
+
+/** Primitive topology values supported by Mesh Arrow geometry input. */
+export type ArrowMeshTopology = 'point-list' | 'triangle-list' | 'triangle-strip';
+
+/** Accessor-style typed array descriptor used by Mesh Arrow table wrappers. */
+export type ArrowMeshAttribute = {
+  /** Attribute or index values. */
+  value: TypedArray;
+  /** Number of typed-array elements per logical attribute. */
+  size: number;
+  /** Optional byte offset into {@link value}. */
+  byteOffset?: number;
+  /** Optional byte stride between logical values in {@link value}. */
+  byteStride?: number;
+  /** Whether integer values should be interpreted through normalized vertex formats. */
+  normalized?: boolean;
+};
+
+/**
+ * Structural Mesh Arrow table accepted by luma.gl.
+ *
+ * This intentionally mirrors loaders.gl `MeshArrowTable` and should be kept
+ * structurally consistent with
+ * `/Users/ib/opensource/loaders.gl/modules/schema/src/categories/category-mesh.ts`.
+ */
+export type ArrowMeshTable = {
+  /** loaders.gl-compatible table shape discriminator. */
+  shape: 'arrow-table';
+  /** Mesh primitive topology represented by the Arrow rows and optional indices. */
+  topology: ArrowMeshTopology;
+  /** Optional top-level primitive index accessor. The Arrow `indices` column takes precedence. */
+  indices?: ArrowMeshAttribute;
+  /** Raw Apache Arrow table containing vertex attribute columns and optional `indices` column. */
+  data: arrow.Table;
+};

--- a/modules/arrow/src/arrow/arrow-model.ts
+++ b/modules/arrow/src/arrow/arrow-model.ts
@@ -9,6 +9,8 @@ import {type ArrowVertexFormatOptions} from './arrow-shader-layout';
 import {ArrowGPUTable, type ArrowGPUTableProps} from './plain-gpu-table';
 import {StreamingArrowGPUTable} from './streaming-arrow-gpu-table';
 import type {ArrowGPUVectorProps} from './arrow-gpu-vector';
+import {ArrowGeometry, type ArrowGeometryProps} from './arrow-geometry';
+import type {ArrowMeshTable} from './arrow-mesh-types';
 
 /** GPU table source accepted by ArrowModel. */
 export type ArrowModelGPUTable = ArrowGPUTable | StreamingArrowGPUTable;
@@ -16,6 +18,15 @@ export type ArrowModelGPUTable = ArrowGPUTable | StreamingArrowGPUTable;
 /** Props for creating a Model whose attributes are derived from an Arrow table. */
 export type ArrowModelProps = ModelProps &
   ArrowVertexFormatOptions & {
+    /**
+     * Mesh Arrow table used as the construction source for GPU geometry buffers.
+     *
+     * Mesh input is converted through {@link ArrowGeometry}. It is mutually
+     * exclusive with `arrowTable`, `streamingArrowGPUTable`, and `geometry`.
+     */
+    arrowMesh?: ArrowMeshTable | arrow.Table;
+    /** Options applied when converting Mesh Arrow input into GPU geometry. */
+    arrowMeshOptions?: Omit<ArrowGeometryProps, 'arrowMesh'>;
     /** Arrow table used as the construction source for GPU attribute buffers. */
     arrowTable?: arrow.Table;
     /** Existing streaming GPU table used as the source for model attributes. */
@@ -29,8 +40,9 @@ export type ArrowModelProps = ModelProps &
   };
 
 type ArrowModelState = {
-  arrowGPUTable: ArrowModelGPUTable;
+  arrowGPUTable?: ArrowModelGPUTable;
   ownsArrowGPUTable: boolean;
+  arrowGeometry?: ArrowGeometry;
   modelProps: ModelProps;
   arrowState: ArrowModelArrowState;
 };
@@ -40,6 +52,7 @@ type ArrowModelExplicitAttributes = NonNullable<ModelProps['attributes']>;
 type ArrowModelArrowState = {
   shaderLayout: ShaderLayout;
   arrowPaths?: Record<string, string>;
+  arrowMeshOptions?: Omit<ArrowGeometryProps, 'arrowMesh'>;
   arrowBufferProps?: ArrowGPUVectorProps;
   arrowCount: 'instance' | 'vertex' | 'none';
   allowWebGLOnlyFormats?: boolean;
@@ -52,31 +65,36 @@ type ArrowModelArrowState = {
 /** A luma.gl Model with GPU attributes backed by Arrow table columns. */
 export class ArrowModel extends Model {
   /** GPU representation of the currently active Arrow table attributes. */
-  arrowGPUTable: ArrowModelGPUTable;
+  arrowGPUTable?: ArrowModelGPUTable;
+  /** GPU representation of the currently active Mesh Arrow geometry. */
+  arrowGeometry?: ArrowGeometry;
   private arrowState: ArrowModelArrowState;
   private ownsArrowGPUTable: boolean;
   private arrowModelDestroyed = false;
 
   constructor(device: Device, props: ArrowModelProps) {
-    const {arrowGPUTable, ownsArrowGPUTable, modelProps, arrowState} = getArrowModelState(
-      device,
-      props
-    );
+    const {arrowGPUTable, ownsArrowGPUTable, arrowGeometry, modelProps, arrowState} =
+      getArrowModelState(device, props);
     try {
       super(device, modelProps);
     } catch (error) {
       if (ownsArrowGPUTable) {
-        arrowGPUTable.destroy();
+        arrowGPUTable?.destroy();
       }
+      arrowGeometry?.destroy();
       throw error;
     }
     this.arrowGPUTable = arrowGPUTable;
+    this.arrowGeometry = arrowGeometry;
     this.ownsArrowGPUTable = ownsArrowGPUTable;
     this.arrowState = arrowState;
   }
 
   /** Updates the model when a replacement Arrow table is supplied. */
   setProps(props: Partial<ArrowModelProps>): void {
+    if (props.arrowMesh) {
+      this.setArrowMesh(props.arrowMesh, props.arrowMeshOptions);
+    }
     if (props.arrowTable) {
       this.setArrowTable(props.arrowTable);
     }
@@ -101,10 +119,35 @@ export class ArrowModel extends Model {
     if (!this.arrowModelDestroyed) {
       super.destroy();
       if (this.ownsArrowGPUTable) {
-        this.arrowGPUTable.destroy();
+        this.arrowGPUTable?.destroy();
       }
       this.arrowModelDestroyed = true;
     }
+  }
+
+  private setArrowMesh(
+    arrowMesh: ArrowMeshTable | arrow.Table,
+    arrowMeshOptions?: Omit<ArrowGeometryProps, 'arrowMesh'>
+  ): void {
+    const arrowGeometry = new ArrowGeometry(this.device, {
+      arrowMesh,
+      ...this.arrowState.arrowMeshOptions,
+      ...arrowMeshOptions
+    });
+
+    try {
+      this.setGeometry(arrowGeometry);
+    } catch (error) {
+      arrowGeometry.destroy();
+      throw error;
+    }
+
+    if (this.ownsArrowGPUTable) {
+      this.arrowGPUTable?.destroy();
+    }
+    this.arrowGPUTable = undefined;
+    this.arrowGeometry = arrowGeometry;
+    this.ownsArrowGPUTable = false;
   }
 
   private setArrowTable(arrowTable: arrow.Table): void {
@@ -161,11 +204,14 @@ export class ArrowModel extends Model {
     this.arrowGPUTable = nextArrowGPUTable;
     this.ownsArrowGPUTable = ownsNextArrowGPUTable;
     if (ownsPreviousArrowGPUTable) {
-      previousArrowGPUTable.destroy();
+      previousArrowGPUTable?.destroy();
     }
   }
 
   private syncArrowGPUTableCount(): void {
+    if (!this.arrowGPUTable) {
+      return;
+    }
     if (this.arrowState.inferInstanceCount && this.instanceCount !== this.arrowGPUTable.numRows) {
       this.setInstanceCount(this.arrowGPUTable.numRows);
     }
@@ -177,6 +223,8 @@ export class ArrowModel extends Model {
 
 function getArrowModelState(device: Device, props: ArrowModelProps): ArrowModelState {
   const {
+    arrowMesh,
+    arrowMeshOptions,
     arrowTable,
     streamingArrowGPUTable,
     arrowPaths,
@@ -186,14 +234,46 @@ function getArrowModelState(device: Device, props: ArrowModelProps): ArrowModelS
     ...modelProps
   } = props;
 
+  validateArrowModelSources({arrowMesh, arrowTable, streamingArrowGPUTable});
+
   if (!modelProps.shaderLayout) {
     throw new Error('ArrowModel requires shaderLayout');
+  }
+  if (arrowMesh && modelProps.geometry) {
+    throw new Error('ArrowModel requires only one of arrowMesh or geometry');
   }
 
   const explicitAttributes = modelProps.attributes || {};
   const explicitBufferLayout = modelProps.bufferLayout || [];
-  const inferInstanceCount = arrowCount === 'instance' && modelProps.instanceCount === undefined;
-  const inferVertexCount = arrowCount === 'vertex' && modelProps.vertexCount === undefined;
+  const inferInstanceCount =
+    !arrowMesh && arrowCount === 'instance' && modelProps.instanceCount === undefined;
+  const inferVertexCount =
+    !arrowMesh && arrowCount === 'vertex' && modelProps.vertexCount === undefined;
+
+  if (arrowMesh) {
+    const arrowGeometry = new ArrowGeometry(device, {arrowMesh, ...arrowMeshOptions});
+    return {
+      arrowGPUTable: undefined,
+      ownsArrowGPUTable: false,
+      arrowGeometry,
+      arrowState: {
+        shaderLayout: modelProps.shaderLayout,
+        arrowPaths,
+        arrowMeshOptions,
+        arrowBufferProps,
+        arrowCount,
+        allowWebGLOnlyFormats,
+        explicitAttributes,
+        explicitBufferLayout,
+        inferInstanceCount,
+        inferVertexCount
+      },
+      modelProps: {
+        ...modelProps,
+        geometry: arrowGeometry
+      }
+    };
+  }
 
   const {arrowGPUTable, ownsArrowGPUTable} = getInitialArrowGPUTable({
     device,
@@ -224,9 +304,11 @@ function getArrowModelState(device: Device, props: ArrowModelProps): ArrowModelS
   return {
     arrowGPUTable,
     ownsArrowGPUTable,
+    arrowGeometry: undefined,
     arrowState: {
       shaderLayout: modelProps.shaderLayout,
       arrowPaths,
+      arrowMeshOptions,
       arrowBufferProps,
       arrowCount,
       allowWebGLOnlyFormats,
@@ -254,18 +336,12 @@ function getInitialArrowGPUTable(props: {
   arrowBufferProps?: ArrowGPUVectorProps;
   allowWebGLOnlyFormats?: boolean;
 }): {arrowGPUTable: ArrowModelGPUTable; ownsArrowGPUTable: boolean} {
-  if (props.arrowTable && props.streamingArrowGPUTable) {
-    throw new Error('ArrowModel requires only one of arrowTable or streamingArrowGPUTable');
-  }
   if (props.streamingArrowGPUTable) {
     return {arrowGPUTable: props.streamingArrowGPUTable, ownsArrowGPUTable: false};
   }
-  if (!props.arrowTable) {
-    throw new Error('ArrowModel requires arrowTable or streamingArrowGPUTable');
-  }
 
   return {
-    arrowGPUTable: new ArrowGPUTable(props.device, props.arrowTable, {
+    arrowGPUTable: new ArrowGPUTable(props.device, props.arrowTable!, {
       shaderLayout: props.shaderLayout,
       arrowPaths: props.arrowPaths,
       bufferProps: props.arrowBufferProps,
@@ -273,6 +349,25 @@ function getInitialArrowGPUTable(props: {
     } satisfies ArrowGPUTableProps),
     ownsArrowGPUTable: true
   };
+}
+
+function validateArrowModelSources(props: {
+  arrowMesh?: ArrowMeshTable | arrow.Table;
+  arrowTable?: arrow.Table;
+  streamingArrowGPUTable?: StreamingArrowGPUTable;
+}): void {
+  const sourceCount =
+    Number(Boolean(props.arrowMesh)) +
+    Number(Boolean(props.arrowTable)) +
+    Number(Boolean(props.streamingArrowGPUTable));
+  if (sourceCount > 1) {
+    throw new Error(
+      'ArrowModel requires only one of arrowMesh, arrowTable, or streamingArrowGPUTable'
+    );
+  }
+  if (sourceCount === 0) {
+    throw new Error('ArrowModel requires arrowMesh, arrowTable or streamingArrowGPUTable');
+  }
 }
 
 function getBufferLayoutNames(bufferLayout: BufferLayout[]): string[] {

--- a/modules/arrow/src/arrow/streaming-arrow-gpu-table.ts
+++ b/modules/arrow/src/arrow/streaming-arrow-gpu-table.ts
@@ -6,7 +6,7 @@ import {Buffer, type BufferLayout, type Device, type ShaderLayout} from '@luma.g
 import {DynamicBuffer, type DynamicBufferProps} from '@luma.gl/engine';
 import * as arrow from 'apache-arrow';
 import {readArrowGPUVectorAsync} from './arrow-gpu-vector';
-import {getArrowDataByPath, getArrowVectorByPath} from './arrow-paths';
+import {getArrowDataByPath} from './arrow-paths';
 import {getArrowVertexFormat, type ArrowVertexFormatOptions} from './arrow-shader-layout';
 import {
   getSignedShaderType,
@@ -332,17 +332,9 @@ export class StreamingArrowGPUTable {
   /** Appends all record batches from one Arrow table. */
   appendTable(table: arrow.Table): void {
     this.assertCompatibleSchema(table.schema);
-    const pendingVectors = this.selectedColumns.map(column => ({
-      column,
-      vector: getArrowVectorByPath(table, column.arrowPath) as arrow.Vector<AttributeArrowType>
-    }));
-    validateSelectedVectors(table.numRows, pendingVectors);
-
-    for (const {column, vector} of pendingVectors) {
-      this.gpuVectors[column.attributeName].appendVector(vector);
+    for (const recordBatch of table.batches) {
+      this.appendRecordBatch(recordBatch);
     }
-    this.rowCount += table.numRows;
-    this.nullableRowCount += table.nullCount;
   }
 
   /** Appends all record batches from a synchronous source. */
@@ -587,20 +579,6 @@ function validateSelectedData(
   }
 }
 
-function validateSelectedVectors(
-  expectedRows: number,
-  pendingVectors: {column: SelectedStreamingColumn; vector: arrow.Vector<AttributeArrowType>}[]
-): void {
-  for (const {column, vector} of pendingVectors) {
-    if (vector.length !== expectedRows) {
-      throw new Error(`StreamingArrowGPUTable column "${column.arrowPath}" row count mismatch`);
-    }
-    for (const data of vector.data) {
-      validateDataForDirectUpload(column.attributeName, data as arrow.Data<AttributeArrowType>);
-    }
-  }
-}
-
 function validateDataForDirectUpload(name: string, data: arrow.Data<AttributeArrowType>): void {
   if (data.nullCount > 0) {
     throw new Error(`StreamingArrowGPUVector "${name}" does not support nullable data`);
@@ -615,11 +593,19 @@ function getArrowDataValueView<T extends AttributeArrowType>(
   stride: number
 ): ArrayBufferView {
   const values = getArrowDataValues(data);
+  const elementCount = data.length * stride;
+  if (values.length < elementCount) {
+    throw new Error('Arrow data values are shorter than the logical upload length');
+  }
+  if (values.length === elementCount) {
+    return values;
+  }
+
   const childOffset = arrow.DataType.isFixedSizeList(data.type)
     ? (data.children[0]?.offset ?? 0)
     : 0;
   const startElement = childOffset + data.offset * stride;
-  const endElement = startElement + data.length * stride;
+  const endElement = startElement + elementCount;
   return values.subarray(startElement, endElement);
 }
 

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -34,6 +34,8 @@ export {
   type ArrowGPUTableFromVectorsProps,
   type ArrowGPUTableProps
 } from './arrow/plain-gpu-table';
+export {ArrowGeometry, type ArrowGeometryProps} from './arrow/arrow-geometry';
+export type {ArrowMeshAttribute, ArrowMeshTable, ArrowMeshTopology} from './arrow/arrow-mesh-types';
 export {
   StreamingArrowGPUTable,
   StreamingArrowGPUVector,

--- a/modules/arrow/test/arrow/arrow-geometry.spec.ts
+++ b/modules/arrow/test/arrow/arrow-geometry.spec.ts
@@ -1,0 +1,246 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {ArrowGeometry, makeArrowFixedSizeListVector, type ArrowMeshTable} from '@luma.gl/arrow';
+import {NullDevice} from '@luma.gl/test-utils';
+import * as arrow from 'apache-arrow';
+
+test('ArrowGeometry creates interleaved GPU geometry from a Mesh Arrow table', t => {
+  const device = new NullDevice({});
+  const arrowMesh = makeArrowMeshTable();
+  const geometry = new ArrowGeometry(device, {arrowMesh});
+
+  t.equal(geometry.topology, 'triangle-list', 'uses mesh topology');
+  t.equal(geometry.vertexCount, 3, 'uses Arrow row count for non-indexed geometry');
+  t.deepEqual(Object.keys(geometry.attributes), ['geometry'], 'creates one interleaved buffer');
+  t.deepEqual(
+    geometry.bufferLayout,
+    [
+      {
+        name: 'geometry',
+        stepMode: 'vertex',
+        byteStride: 36,
+        attributes: [
+          {attribute: 'positions', format: 'float32x3', byteOffset: 0},
+          {attribute: 'normals', format: 'float32x3', byteOffset: 12},
+          {attribute: 'colors', format: 'unorm8x4', byteOffset: 24},
+          {attribute: 'texCoords', format: 'float32x2', byteOffset: 28}
+        ]
+      }
+    ],
+    'maps Mesh Arrow attributes into one interleaved buffer layout'
+  );
+  t.equal(geometry.attributes.geometry.byteLength, 108, 'uploads packed interleaved bytes');
+
+  geometry.destroy();
+  t.end();
+});
+
+test('ArrowGeometry creates separate GPU buffers when interleaving is disabled', t => {
+  const device = new NullDevice({});
+  const geometry = new ArrowGeometry(device, {
+    arrowMesh: makeArrowMeshTable(),
+    interleaved: false
+  });
+
+  t.deepEqual(
+    Object.keys(geometry.attributes),
+    ['positions', 'normals', 'colors', 'texCoords'],
+    'creates one GPU buffer per Mesh Arrow attribute'
+  );
+  t.deepEqual(
+    geometry.bufferLayout,
+    [
+      {name: 'positions', stepMode: 'vertex', format: 'float32x3'},
+      {name: 'normals', stepMode: 'vertex', format: 'float32x3'},
+      {name: 'colors', stepMode: 'vertex', format: 'unorm8x4'},
+      {name: 'texCoords', stepMode: 'vertex', format: 'float32x2'}
+    ],
+    'creates one buffer layout per Mesh Arrow attribute'
+  );
+
+  geometry.destroy();
+  t.end();
+});
+
+test('ArrowGeometry reads indexed Mesh Arrow indices from row 0', t => {
+  const device = new NullDevice({});
+  const arrowMesh = makeArrowMeshTable({indices: new Int32Array([0, 1, 2, 2, 1, 0])});
+  const geometry = new ArrowGeometry(device, {arrowMesh});
+
+  t.equal(geometry.vertexCount, 6, 'uses index count for indexed geometry');
+  t.ok(geometry.indices, 'creates an index buffer');
+  t.equal(geometry.indices?.byteLength, 12, 'uploads uint16 indices when possible');
+
+  geometry.destroy();
+  t.end();
+});
+
+test('ArrowGeometry accepts raw Arrow tables and reads topology metadata', t => {
+  const device = new NullDevice({});
+  const table = makeArrowMeshTable().data;
+  const geometry = new ArrowGeometry(device, {arrowMesh: table});
+
+  t.equal(geometry.topology, 'triangle-list', 'uses topology from Arrow schema metadata');
+  t.equal(geometry.vertexCount, 3, 'uses raw Arrow table row count');
+
+  geometry.destroy();
+  t.end();
+});
+
+test('ArrowGeometry validates Mesh Arrow input', t => {
+  const device = new NullDevice({});
+  const tableWithoutPosition = new arrow.Table({
+    NORMAL: makeArrowFixedSizeListVector(new arrow.Float32(), 3, new Float32Array([0, 0, 1]))
+  });
+  const invalidAttributeTable = new arrow.Table({
+    POSITION: makeArrowFixedSizeListVector(new arrow.Float32(), 3, new Float32Array([0, 0, 0])),
+    NAME: arrow.vectorFromArray(['a'], new arrow.Utf8())
+  });
+  const invalidIndicesSchema = new arrow.Schema([
+    new arrow.Field(
+      'POSITION',
+      new arrow.FixedSizeList(3, new arrow.Field('value', new arrow.Float32(), false)),
+      false
+    ),
+    new arrow.Field('indices', new arrow.Int32(), false)
+  ]);
+  const invalidIndicesTable = new arrow.Table(invalidIndicesSchema, {
+    POSITION: makeArrowFixedSizeListVector(new arrow.Float32(), 3, new Float32Array([0, 0, 0])),
+    indices: arrow.makeVector(new Int32Array([0]))
+  });
+
+  t.throws(
+    () => new ArrowGeometry(device, {arrowMesh: tableWithoutPosition}),
+    /POSITION/,
+    'requires POSITION'
+  );
+  t.throws(
+    () => new ArrowGeometry(device, {arrowMesh: invalidAttributeTable}),
+    /numeric/,
+    'rejects non-numeric attribute columns'
+  );
+  t.throws(
+    () => new ArrowGeometry(device, {arrowMesh: invalidIndicesTable}),
+    /indices column must be a List/,
+    'rejects malformed indices columns'
+  );
+
+  t.end();
+});
+
+function makeArrowMeshTable(options: {indices?: Int32Array} = {}): ArrowMeshTable {
+  const positions = makeArrowFixedSizeListVector(
+    new arrow.Float32(),
+    3,
+    new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])
+  );
+  const normals = makeArrowFixedSizeListVector(
+    new arrow.Float32(),
+    3,
+    new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1])
+  );
+  const colors = makeArrowFixedSizeListVector(
+    new arrow.Uint8(),
+    4,
+    new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255])
+  );
+  const texCoords = makeArrowFixedSizeListVector(
+    new arrow.Float32(),
+    2,
+    new Float32Array([0, 0, 1, 0, 0, 1])
+  );
+  const fields = [
+    new arrow.Field(
+      'POSITION',
+      new arrow.FixedSizeList(3, new arrow.Field('value', new arrow.Float32(), false)),
+      false
+    ),
+    new arrow.Field(
+      'NORMAL',
+      new arrow.FixedSizeList(3, new arrow.Field('value', new arrow.Float32(), false)),
+      false
+    ),
+    new arrow.Field(
+      'COLOR_0',
+      new arrow.FixedSizeList(4, new arrow.Field('value', new arrow.Uint8(), false)),
+      false,
+      new Map([['normalized', 'true']])
+    ),
+    new arrow.Field(
+      'TEXCOORD_0',
+      new arrow.FixedSizeList(2, new arrow.Field('value', new arrow.Float32(), false)),
+      false
+    )
+  ];
+  let columns: Record<string, arrow.Vector> = {
+    POSITION: positions,
+    NORMAL: normals,
+    COLOR_0: colors,
+    TEXCOORD_0: texCoords
+  };
+
+  if (options.indices) {
+    fields.splice(
+      1,
+      0,
+      new arrow.Field(
+        'indices',
+        new arrow.List(new arrow.Field('item', new arrow.Int32(), false)),
+        true
+      )
+    );
+    columns = {
+      POSITION: positions,
+      indices: makeIndicesVector(options.indices, positions.length),
+      NORMAL: normals,
+      COLOR_0: colors,
+      TEXCOORD_0: texCoords
+    };
+  }
+
+  return {
+    shape: 'arrow-table',
+    topology: 'triangle-list',
+    data: new arrow.Table(
+      new arrow.Schema(fields, new Map([['topology', 'triangle-list']])),
+      columns
+    )
+  };
+}
+
+function makeIndicesVector(indices: Int32Array, vertexCount: number): arrow.Vector {
+  const indicesType = new arrow.List(new arrow.Field('item', new arrow.Int32(), false));
+  const valueOffsets = new Int32Array(vertexCount + 1);
+  if (vertexCount > 0) {
+    valueOffsets.fill(indices.length, 1);
+  }
+
+  const nullBitmap = new Uint8Array(Math.ceil(vertexCount / 8));
+  if (vertexCount > 0) {
+    nullBitmap[0] = 1;
+  }
+
+  const valuesData = new arrow.Data<arrow.Int32>(
+    indicesType.children[0].type,
+    0,
+    indices.length,
+    0,
+    {[arrow.BufferType.DATA]: indices}
+  );
+  const indicesData = new arrow.Data<arrow.List<arrow.Int32>>(
+    indicesType,
+    0,
+    vertexCount,
+    Math.max(0, vertexCount - 1),
+    {
+      [arrow.BufferType.OFFSET]: valueOffsets,
+      [arrow.BufferType.VALIDITY]: nullBitmap
+    },
+    [valuesData]
+  );
+
+  return new arrow.Vector([indicesData]);
+}

--- a/modules/arrow/test/arrow/arrow-model.spec.ts
+++ b/modules/arrow/test/arrow/arrow-model.spec.ts
@@ -7,7 +7,8 @@ import {
   ArrowGPUTable,
   ArrowModel,
   makeArrowFixedSizeListVector,
-  StreamingArrowGPUTable
+  StreamingArrowGPUTable,
+  type ArrowMeshTable
 } from '@luma.gl/arrow';
 import type {ShaderLayout} from '@luma.gl/core';
 import {NullDevice} from '@luma.gl/test-utils';
@@ -36,6 +37,22 @@ void main() {
 }
 `;
 
+const MESH_SHADER_LAYOUT: ShaderLayout = {
+  attributes: [
+    {name: 'positions', location: 0, type: 'vec3<f32>'},
+    {name: 'colors', location: 1, type: 'vec4<f32>'}
+  ],
+  bindings: []
+};
+
+const DUMMY_MESH_VS = `#version 300 es
+in vec3 positions;
+in vec4 colors;
+void main() {
+  gl_Position = vec4(positions, 1.0);
+}
+`;
+
 test('ArrowModel creates a Model from an Arrow table', t => {
   const device = new NullDevice({});
   const arrowTable = makeArrowModelTable();
@@ -46,7 +63,7 @@ test('ArrowModel creates a Model from an Arrow table', t => {
     shaderLayout: SHADER_LAYOUT,
     arrowTable
   });
-  const positionsBuffer = model.arrowGPUTable.gpuVectors['positions'].buffer;
+  const positionsBuffer = model.arrowGPUTable!.gpuVectors['positions'].buffer;
 
   t.ok(model.arrowGPUTable instanceof ArrowGPUTable, 'creates an ArrowGPUTable');
   t.deepEqual(
@@ -59,7 +76,7 @@ test('ArrowModel creates a Model from an Arrow table', t => {
   );
   t.equal(
     model.vertexArray.attributes[0],
-    model.arrowGPUTable.attributes['positions'],
+    model.arrowGPUTable!.attributes['positions'],
     'sets Model vertex array attributes from Arrow buffers'
   );
   t.equal(model.instanceCount, arrowTable.numRows, 'defaults instanceCount to Arrow row count');
@@ -112,7 +129,7 @@ test('ArrowModel updates Arrow table props', t => {
     shaderLayout: SHADER_LAYOUT,
     arrowTable
   });
-  const previousPositionsBuffer = model.arrowGPUTable.gpuVectors['positions'].buffer;
+  const previousPositionsBuffer = model.arrowGPUTable!.gpuVectors['positions'].buffer;
   const previousPipeline = model.pipeline;
 
   model.setProps({arrowTable: nextArrowTable});
@@ -125,7 +142,7 @@ test('ArrowModel updates Arrow table props', t => {
   );
   t.equal(
     model.vertexArray.attributes[0],
-    model.arrowGPUTable.attributes['positions'],
+    model.arrowGPUTable!.attributes['positions'],
     'sets vertex array attributes from the updated Arrow buffers'
   );
   t.ok(previousPositionsBuffer.destroyed, 'destroys previous Arrow GPU vector buffers');
@@ -170,6 +187,41 @@ test('ArrowModel consumes a StreamingArrowGPUTable', t => {
   t.end();
 });
 
+test('ArrowModel creates a Model from a Mesh Arrow table', t => {
+  const device = new NullDevice({});
+  const arrowMesh = makeArrowModelMeshTable();
+  const model = new ArrowModel(device, {
+    id: 'arrow-model-mesh-test',
+    vs: DUMMY_MESH_VS,
+    fs: DUMMY_FS,
+    shaderLayout: MESH_SHADER_LAYOUT,
+    arrowMesh
+  });
+
+  t.ok(model.arrowGeometry, 'creates ArrowGeometry');
+  t.equal(model.arrowGPUTable, undefined, 'does not create ArrowGPUTable for mesh input');
+  t.equal(model.vertexCount, 3, 'uses Mesh Arrow index count as vertex count');
+  t.ok(model.vertexArray.indexBuffer, 'binds Mesh Arrow index buffer');
+  t.deepEqual(
+    model.bufferLayout,
+    [
+      {
+        name: 'geometry',
+        stepMode: 'vertex',
+        byteStride: 16,
+        attributes: [
+          {attribute: 'positions', format: 'float32x3', byteOffset: 0},
+          {attribute: 'colors', format: 'unorm8x4', byteOffset: 12}
+        ]
+      }
+    ],
+    'sets Model buffer layout from Mesh Arrow geometry'
+  );
+
+  model.destroy();
+  t.end();
+});
+
 test('ArrowModel validates required shader layout and duplicate attributes', t => {
   const device = new NullDevice({});
   const arrowTable = makeArrowModelTable();
@@ -199,6 +251,19 @@ test('ArrowModel validates required shader layout and duplicate attributes', t =
     /duplicates an explicit attribute/,
     'rejects duplicate explicit attributes'
   );
+  t.throws(
+    () =>
+      new ArrowModel(device, {
+        id: 'arrow-model-duplicate-source-test',
+        vs: DUMMY_MESH_VS,
+        fs: DUMMY_FS,
+        shaderLayout: MESH_SHADER_LAYOUT,
+        arrowMesh: makeArrowModelMeshTable(),
+        arrowTable
+      }),
+    /only one of arrowMesh, arrowTable, or streamingArrowGPUTable/,
+    'rejects duplicate Arrow sources'
+  );
 
   duplicateBuffer.destroy();
   t.end();
@@ -221,4 +286,77 @@ function makeArrowModelTable(rowCount = 2): arrow.Table {
     positions: makeArrowFixedSizeListVector(new arrow.Float32(), 2, positions),
     colors: makeArrowFixedSizeListVector(new arrow.Uint8(), 4, colors)
   });
+}
+
+function makeArrowModelMeshTable(): ArrowMeshTable {
+  const positions = makeArrowFixedSizeListVector(
+    new arrow.Float32(),
+    3,
+    new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0])
+  );
+  const colors = makeArrowFixedSizeListVector(
+    new arrow.Uint8(),
+    4,
+    new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255])
+  );
+  const fields = [
+    new arrow.Field(
+      'POSITION',
+      new arrow.FixedSizeList(3, new arrow.Field('value', new arrow.Float32(), false)),
+      false
+    ),
+    new arrow.Field(
+      'indices',
+      new arrow.List(new arrow.Field('item', new arrow.Int32(), false)),
+      true
+    ),
+    new arrow.Field(
+      'COLOR_0',
+      new arrow.FixedSizeList(4, new arrow.Field('value', new arrow.Uint8(), false)),
+      false,
+      new Map([['normalized', 'true']])
+    )
+  ];
+
+  return {
+    shape: 'arrow-table',
+    topology: 'triangle-list',
+    data: new arrow.Table(new arrow.Schema(fields), {
+      POSITION: positions,
+      indices: makeArrowModelIndicesVector(new Int32Array([0, 1, 2]), positions.length),
+      COLOR_0: colors
+    })
+  };
+}
+
+function makeArrowModelIndicesVector(indices: Int32Array, vertexCount: number): arrow.Vector {
+  const indicesType = new arrow.List(new arrow.Field('item', new arrow.Int32(), false));
+  const valueOffsets = new Int32Array(vertexCount + 1);
+  if (vertexCount > 0) {
+    valueOffsets.fill(indices.length, 1);
+  }
+  const nullBitmap = new Uint8Array(Math.ceil(vertexCount / 8));
+  if (vertexCount > 0) {
+    nullBitmap[0] = 1;
+  }
+  const valuesData = new arrow.Data<arrow.Int32>(
+    indicesType.children[0].type,
+    0,
+    indices.length,
+    0,
+    {[arrow.BufferType.DATA]: indices}
+  );
+  const indicesData = new arrow.Data<arrow.List<arrow.Int32>>(
+    indicesType,
+    0,
+    vertexCount,
+    Math.max(0, vertexCount - 1),
+    {
+      [arrow.BufferType.OFFSET]: valueOffsets,
+      [arrow.BufferType.VALIDITY]: nullBitmap
+    },
+    [valuesData]
+  );
+
+  return new arrow.Vector([indicesData]);
 }

--- a/modules/arrow/test/arrow/streaming-arrow-gpu-table.spec.ts
+++ b/modules/arrow/test/arrow/streaming-arrow-gpu-table.spec.ts
@@ -87,6 +87,53 @@ test('StreamingArrowGPUVector appends sliced Arrow Data from the correct source 
   t.end();
 });
 
+test('StreamingArrowGPUVector appends sliced Arrow Vector data without double offsetting', t => {
+  const device = new NullDevice({});
+  const sourceVector = arrow.makeVector(new Float32Array([0, 1, 2, 3])).slice(1, 3);
+  const vector = new StreamingArrowGPUVector({
+    name: 'positions',
+    device,
+    arrowType: new arrow.Float32()
+  });
+  const writes = recordDynamicBufferWrites(vector.buffer);
+
+  vector.appendVector(sourceVector);
+
+  t.equal(writes.length, 1, 'writes one sliced data chunk');
+  t.deepEqual(Array.from(writes[0].data as Float32Array), [1, 2], 'writes sliced values once');
+
+  vector.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUVector appends sliced FixedSizeList Vector data without double offsetting', t => {
+  const device = new NullDevice({});
+  const sourceData = makeFixedSizeListData(
+    new arrow.Float32(),
+    2,
+    new Float32Array([0, 1, 2, 3, 4, 5, 6, 7])
+  );
+  const sourceVector = arrow.makeVector(sourceData).slice(1, 3);
+  const vector = new StreamingArrowGPUVector({
+    name: 'positions',
+    device,
+    arrowType: sourceVector.type
+  });
+  const writes = recordDynamicBufferWrites(vector.buffer);
+
+  vector.appendVector(sourceVector);
+
+  t.equal(writes.length, 1, 'writes one sliced FixedSizeList data chunk');
+  t.deepEqual(
+    Array.from(writes[0].data as Float32Array),
+    [2, 3, 4, 5],
+    'writes sliced child values once'
+  );
+
+  vector.destroy();
+  t.end();
+});
+
 test('StreamingArrowGPUVector grows capacity without replacing the public DynamicBuffer', t => {
   const device = new NullDevice({});
   const vector = new StreamingArrowGPUVector({
@@ -272,6 +319,36 @@ test('StreamingArrowGPUTable appends record batches and tables into stable attri
     'keeps attribute object stable'
   );
   t.equal(streamingTable.numCols, 2, 'exposes selected column count');
+
+  streamingTable.destroy();
+  t.end();
+});
+
+test('StreamingArrowGPUTable appends table record batches as separate data uploads', t => {
+  const device = new NullDevice({});
+  const firstBatch = makeGpuMetadataRecordBatch([0, 0, 1, 1], [255, 0, 0, 255, 0, 255, 0, 255]);
+  const secondBatch = makeGpuMetadataRecordBatch([2, 2], [0, 0, 255, 255]);
+  const streamingTable = new StreamingArrowGPUTable({
+    device,
+    schema: firstBatch.schema,
+    shaderLayout: makePositionColorShaderLayout()
+  });
+  const positionWrites = recordDynamicBufferWrites(streamingTable.gpuVectors['positions'].buffer);
+
+  streamingTable.appendTable(new arrow.Table([firstBatch, secondBatch]));
+
+  t.equal(positionWrites.length, 2, 'writes one chunk per table record batch');
+  t.deepEqual(
+    Array.from(positionWrites[0].data as Float32Array),
+    [0, 0, 1, 1],
+    'writes first batch values'
+  );
+  t.deepEqual(
+    Array.from(positionWrites[1].data as Float32Array),
+    [2, 2],
+    'writes second batch values'
+  );
+  t.equal(streamingTable.numRows, 3, 'updates row count across table batches');
 
   streamingTable.destroy();
   t.end();

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -5,6 +5,7 @@
 import './arrow/arrow-paths.spec';
 import './arrow/arrow-column-info.spec';
 import './arrow/arrow-fixed-size-list.spec';
+import './arrow/arrow-geometry.spec';
 import './arrow/plain-gpu-table.spec';
 import './arrow/streaming-arrow-gpu-table.spec';
 import './arrow/arrow-model.spec';


### PR DESCRIPTION
## Summary

This PR adds Mesh Arrow table support to `@luma.gl/arrow`, allowing loaders.gl-style Mesh Arrow data to be converted directly into luma.gl GPU geometry and consumed by `ArrowModel`.

The main goals are:
- Add an `ArrowGeometry` path for Mesh Arrow tables.
- Let `ArrowModel` construct and update geometry from `arrowMesh`.
- Support both interleaved and separate GPU attribute buffers.
- Preserve existing Arrow table and streaming Arrow table model paths.

## Changes

- Added `ArrowGeometry`, a `GPUGeometry` implementation backed by Mesh Arrow tables.
  - Accepts either a structural `ArrowMeshTable` wrapper or a raw `apache-arrow` `Table`.
  - Requires a `POSITION` column and maps common mesh semantics:
    - `POSITION` -> `positions`
    - `NORMAL` -> `normals`
    - `COLOR_0` -> `colors`
    - `TEXCOORD_0` -> `texCoords`
    - `TEXCOORD_1` -> `texCoords1`
  - Supports topology from the wrapper or table schema metadata, defaulting to `triangle-list`.
  - Supports indexed geometry from an `indices` Arrow list column or wrapper-provided indices.
  - Supports normalized integer attributes via Arrow field metadata.
  - Defaults to one interleaved vertex buffer, with `interleaved: false` for separate buffers.
  - Supports `arrowPaths` to map output shader attributes to Mesh Arrow column names.

- Added Mesh Arrow types.
  - Introduces `ArrowMeshTable`, `ArrowMeshTopology`, and `ArrowMeshAttribute`.
  - The structure mirrors loaders.gl Mesh Arrow table shape.

- Extended `ArrowModel`.
  - Adds `arrowMesh?: ArrowMeshTable | arrow.Table`.
  - Adds `arrowMeshOptions?: Omit<ArrowGeometryProps, 'arrowMesh'>`.
  - Validates that only one data source is provided: `arrowMesh`, `arrowTable`, or `streamingArrowGPUTable`.
  - Creates and owns `ArrowGeometry` when constructed from `arrowMesh`.
  - Supports `setProps({arrowMesh})` to replace geometry.
  - Keeps existing `arrowTable` and `streamingArrowGPUTable` behavior.

- Tightened streaming Arrow table uploads.
  - `appendTable()` now iterates table record batches and uploads per-batch `Data` chunks instead of building a whole-table vector path.
  - Sliced Arrow `Data` uploads avoid double-applying offsets.

## Testing

- Added coverage for:
  - `ArrowGeometry` interleaved geometry creation.
  - separate attribute buffer creation.
  - indexed Mesh Arrow geometry.
  - raw Arrow table topology metadata.
  - invalid Mesh Arrow inputs.
  - `ArrowModel` construction and updates from `arrowMesh`.
  - streaming table per-record-batch uploads and sliced data handling.

Current local validation:
- `yarn test-headless modules/arrow/test/arrow/arrow-geometry.spec.ts modules/arrow/test/arrow/arrow-model.spec.ts modules/arrow/test/arrow/streaming-arrow-gpu-table.spec.ts`
  - Failing: 2 tests in `arrow-geometry.spec.ts`
  - Failures:
    - indexed mesh test rejects `TEXCOORD_0`
    - validation test fails while constructing the invalid string vector fixture