### PR TITLE
chore(text) ArrowTextModel refinements

### DIFF
--- a/docs/api-guide/gpu/arrow-table-columns.md
+++ b/docs/api-guide/gpu/arrow-table-columns.md
@@ -355,7 +355,7 @@ Construction modes:
 | Mode | Use case |
 | --- | --- |
 | `new GPUVector(device, arrowVector)` | Upload an Arrow vector into owned GPU storage |
-| `{type: 'arrow', ...}` | Named upload form used by table helpers |
+| `{name, device, vector}` | Named upload form used by table helpers |
 | `{type: 'buffer', ...}` | Wrap an existing typed GPU buffer |
 | `{type: 'interleaved', ...}` | Wrap one interleaved opaque binary row buffer |
 | `{type: 'data', ...}` | Aggregate existing `GPUData[]` chunks |

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -10,6 +10,17 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 
 *For detailed commit level logs that include alpha and beta releases, see the [CHANGELOG](https://github.com/visgl/luma.gl/blob/master/CHANGELOG.md) in the github repository.*
 
+## Upgrading to v10.0
+
+**@luma.gl/text**
+- `ArrowTextModel.labelVectors` has been removed. Pass supported row vectors as top-level props instead:
+  - `positions`
+  - `colors`
+  - `angles`
+  - `sizes`
+  - `pixelOffsets`
+- Storage text keeps the same top-level input convention and continues to expose storage-only row vectors such as `textAnchors` and `alignmentBaselines`.
+
 ## Upgrading to v9.3
 
 **Potentially breaking behavior**

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -25,15 +25,10 @@ Target Release Date: Q3, 2026
 **@luma.gl/text**
 
 - **Arrow-native 2D text** - New atlas, layout, and UTF-8 glyph expansion utilities support deck.gl-style text extraction into `@luma.gl/text`.
-- **`ArrowTextModel`** - New `ArrowModel`-derived one-line label renderer expands UTF-8 `GPUVector` rows into glyph instances without row-level string materialization.
+- **`ArrowTextModel`** - New `ArrowModel`-derived one-line label renderer expands UTF-8 `GPUVector` rows into glyph instances without row-level string materialization, using explicit top-level row vectors such as `positions`, `colors`, `angles`, `sizes`, and `pixelOffsets`.
 - **`ArrowStorageTextModel`** - New WebGPU-only storage-backed text path consumes batched GPUVector row/text inputs directly, can read row color/angle/size/pixel-offset styling plus compact text-anchor and baseline enums from aligned GPUVectors with fixed shader bindings and constant fallbacks, expands render buffers with compute, and can consume reusable `ArrowStorageTextState` objects built by `createArrowStorageTextState`.
+- **Packed generated glyph vertex data** - Attribute text uses `expandedGlyphVertexData`, while storage text uses `compactGlyphVertexData`, reducing generated glyph buffer fan-out without folding caller-owned row/style vectors into generated records.
 - **GPU UTF-8 shader mapping** - Reusable text-module WGSL helpers compose sparse UTF-8 byte traversal, code point decode, and storage lookup into one-pass text compute kernels.
-- **Packed text clipping** - Arrow 2D text accepts optional `FixedSizeList<Int16>[4]` clip rectangles and expands them into 8-byte per-glyph clipping attributes only when clipping is enabled.
-
-**@luma.gl/text**
-
-- **Arrow-native 2D text** - New atlas, layout, and UTF-8 glyph expansion utilities support deck.gl-style text extraction into `@luma.gl/text`.
-- **`ArrowTextModel`** - New `ArrowModel`-derived one-line label renderer expands Arrow `Utf8` rows into glyph instances without row-level string materialization.
 - **Packed text clipping** - Arrow 2D text accepts optional `FixedSizeList<Int16>[4]` clip rectangles and expands them into 8-byte per-glyph clipping attributes only when clipping is enabled.
 
 **@luma.gl/gpgpu** NEW MODULE

--- a/examples/gpu-tables/arrow-mesh-geometry/app.ts
+++ b/examples/gpu-tables/arrow-mesh-geometry/app.ts
@@ -142,9 +142,8 @@ export default class ArrowMeshGeometryAnimationLoopTemplate extends AnimationLoo
     this.faceColors =
       device.type === 'webgpu'
         ? new GPUVector({
-            type: 'arrow',
-            name: 'faceColors',
             device,
+            name: 'faceColors',
             vector: faceColors
           })
         : undefined;

--- a/examples/gpu-tables/arrow-text-2d/app.ts
+++ b/examples/gpu-tables/arrow-text-2d/app.ts
@@ -65,7 +65,6 @@ type TextDataset = {
 };
 type ArrowTextInput = {
   positions: GPUVector<arrow.FixedSizeList<arrow.Float32>>;
-  labelVectors: Record<string, GPUVector>;
   texts: GPUVector<arrow.Utf8>;
   clipRects: GPUVector<arrow.FixedSizeList<arrow.Int16>>;
   colors: GPUVector<arrow.FixedSizeList<arrow.Uint8>>;
@@ -674,7 +673,6 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
   readonly textInputs: Partial<Record<TextDatasetKind, ArrowTextInput>> = {};
   readonly textInputPromises: Partial<Record<TextDatasetKind, Promise<ArrowTextInput>>> = {};
   positions!: GPUVector<arrow.FixedSizeList<arrow.Float32>>;
-  labelVectors!: Record<string, GPUVector>;
   texts!: GPUVector<arrow.Utf8>;
   clipRects!: GPUVector<arrow.FixedSizeList<arrow.Int16>>;
   colors!: GPUVector<arrow.FixedSizeList<arrow.Uint8>>;
@@ -720,9 +718,8 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
     if (this.isFinalized) {
       return;
     }
-    const {positions, labelVectors, texts, clipRects, colors, angles, sizes} = defaultTextInput;
+    const {positions, texts, clipRects, colors, angles, sizes} = defaultTextInput;
     this.positions = positions;
-    this.labelVectors = labelVectors;
     this.texts = texts;
     this.clipRects = clipRects;
     this.colors = colors;
@@ -783,9 +780,12 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
   createTextModel(modelKind: TextModelKind): ActiveTextModel {
     const commonProps: ArrowTextModelProps = {
       id: 'arrow-text-2d',
-      labelVectors: this.labelVectors,
+      positions: this.positions,
       texts: this.texts,
       clipRects: this.clipRects,
+      ...(this.colorEnabled ? {colors: this.colors} : {}),
+      ...(this.angleEnabled ? {angles: this.angles} : {}),
+      ...(this.sizeEnabled ? {sizes: this.sizes} : {}),
       characterSet: CHARACTER_SET,
       fontSettings: {
         fontFamily: 'Monaco, Menlo, monospace',
@@ -950,9 +950,7 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
     this.pickingModel?.destroy();
     this.textModel?.destroy();
     for (const textInput of Object.values(this.textInputs)) {
-      for (const vector of Object.values(textInput?.labelVectors || {})) {
-        vector.destroy();
-      }
+      textInput?.positions.destroy();
       textInput?.texts.destroy();
       textInput?.clipRects.destroy();
       textInput?.colors.destroy();
@@ -989,11 +987,12 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
       attributes:
         textModel instanceof ArrowStorageTextModel
           ? {
-              glyphOffsets: textModel.generatedGlyphOffsetsBuffer,
-              glyphIndices: textModel.generatedGlyphIndicesBuffer,
-              rowIndices: textModel.generatedRowIndicesBuffer
+              compactGlyphVertexData: textModel.compactGlyphVertexData
             }
-          : textModel.arrowGPUTable!.attributes,
+          : {
+              ...textModel.arrowGPUTable!.attributes,
+              expandedGlyphVertexData: textModel.expandedGlyphVertexData
+            },
       instanceCount: textModel.instanceCount,
       vertexCount: 6,
       bindings: {...textModel.bindings},
@@ -1061,9 +1060,8 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
       return;
     }
     this.textDatasetKind = nextDatasetKind;
-    const {positions, labelVectors, texts, clipRects, colors, angles, sizes} = nextTextInput;
+    const {positions, texts, clipRects, colors, angles, sizes} = nextTextInput;
     this.positions = positions;
-    this.labelVectors = labelVectors;
     this.texts = texts;
     this.clipRects = clipRects;
     this.colors = colors;
@@ -1285,45 +1283,36 @@ function makeArrowTextInput(device: Device, dataset: TextDataset): ArrowTextInpu
   const angleVector = makeFloat32ArrowVector(angles);
   const sizeVector = makeFloat32ArrowVector(sizes);
   const positionsGpuVector = new GPUVector({
-    type: 'arrow',
-    name: 'positions',
     device,
+    name: 'positions',
     vector: positionVector
   });
 
   return {
     positions: positionsGpuVector,
-    labelVectors: {
-      positions: positionsGpuVector
-    },
     texts: new GPUVector({
-      type: 'arrow',
-      name: 'texts',
       device,
+      name: 'texts',
       vector: texts
     }),
     clipRects: new GPUVector({
-      type: 'arrow',
-      name: 'clipRects',
       device,
+      name: 'clipRects',
       vector: clipRectVector
     }),
     colors: new GPUVector({
-      type: 'arrow',
-      name: 'colors',
       device,
+      name: 'colors',
       vector: colorVector
     }),
     angles: new GPUVector({
-      type: 'arrow',
-      name: 'angles',
       device,
+      name: 'angles',
       vector: angleVector
     }),
     sizes: new GPUVector({
-      type: 'arrow',
-      name: 'sizes',
       device,
+      name: 'sizes',
       vector: sizeVector
     }),
     arrowVectorBuildTimeMs: getNow() - arrowVectorBuildStartTime

--- a/examples/gpu-tables/gpu-vector-storage-particles/app.ts
+++ b/examples/gpu-tables/gpu-vector-storage-particles/app.ts
@@ -201,15 +201,13 @@ function makeParticleVectors(device: AnimationProps['device']): {
 
   return {
     positions: new GPUVector({
-      type: 'arrow',
-      name: 'particlePositions',
       device,
+      name: 'particlePositions',
       vector: arrowPositions
     }),
     velocities: new GPUVector({
-      type: 'arrow',
-      name: 'particleVelocities',
       device,
+      name: 'particleVelocities',
       vector: arrowVelocities
     }),
     initialPositions: positions,

--- a/modules/arrow/src/arrow/arrow-fixed-size-list.ts
+++ b/modules/arrow/src/arrow/arrow-fixed-size-list.ts
@@ -4,7 +4,7 @@
 
 import * as arrow from 'apache-arrow';
 import {getArrowVectorBufferSource} from './arrow-gpu-data';
-import type {NumericArrowType} from './arrow-types';
+import {isNumericArrowType, type NumericArrowType} from './arrow-types';
 
 export {getArrowDataBufferSource, getArrowVectorBufferSource} from './arrow-gpu-data';
 
@@ -21,6 +21,47 @@ const makeFixedSizeListData = arrow.makeData as <T extends NumericArrowType>(pro
   nullBitmap: null;
   child: arrow.Data<T>;
 }) => arrow.Data<arrow.FixedSizeList<T>>;
+
+/**
+ * Create Arrow vectors from JS arrays, with an optional flat FixedSizeList form for numeric rows.
+ *
+ * `makeArrowVectorFromArray(values, type)` mirrors Apache Arrow's scalar/string helper.
+ * `makeArrowVectorFromArray(values, childType, listSize)` packs flat numeric values into
+ * `FixedSizeList<childType>[listSize]` rows.
+ */
+export function makeArrowVectorFromArray<T extends NumericArrowType>(
+  values: readonly number[] | T['TArray'],
+  childType: T,
+  listSize: 1 | 2 | 3 | 4
+): arrow.Vector<arrow.FixedSizeList<T>>;
+export function makeArrowVectorFromArray<T extends arrow.DataType>(
+  values: readonly unknown[],
+  type: T
+): arrow.Vector<T>;
+export function makeArrowVectorFromArray(
+  values: readonly unknown[] | NumericArrowType['TArray'],
+  type: arrow.DataType,
+  listSize?: 1 | 2 | 3 | 4
+): arrow.Vector {
+  if (listSize === undefined) {
+    return arrow.vectorFromArray(Array.from(values as readonly unknown[]), type);
+  }
+  if (!isNumericArrowType(type)) {
+    throw new Error('FixedSizeList array vectors require a numeric Arrow child type');
+  }
+
+  const typedValues = Array.isArray(values)
+    ? getArrowVectorBufferSource(arrow.vectorFromArray(values, type))
+    : values;
+  const makeNumericFixedSizeListVector = makeArrowFixedSizeListVector as <
+    T extends NumericArrowType
+  >(
+    childType: T,
+    fixedListSize: 1 | 2 | 3 | 4,
+    childValues: T['TArray']
+  ) => arrow.Vector<arrow.FixedSizeList<T>>;
+  return makeNumericFixedSizeListVector(type, listSize, typedValues as NumericArrowType['TArray']);
+}
 
 export function makeArrowFixedSizeListVector(
   childType: arrow.Float16,

--- a/modules/arrow/src/arrow/arrow-gpu-vector.ts
+++ b/modules/arrow/src/arrow/arrow-gpu-vector.ts
@@ -38,8 +38,8 @@ export type GPUVectorProps = GPUVectorBufferProps;
 
 /** Constructor props that upload an Arrow vector into a new GPU buffer. */
 export type GPUVectorFromArrowProps<T extends arrow.DataType = AttributeArrowType> = {
-  /** Discriminator for Arrow-vector upload construction. */
-  type: 'arrow';
+  /** Optional discriminator for Arrow-vector upload construction. Inferred from `vector` when omitted. */
+  type?: 'arrow';
   /** Name used when this vector is added to an {@link GPUTable}. */
   name: string;
   /** Device that creates the GPU buffer. */
@@ -202,7 +202,7 @@ export class GPUVector<T extends arrow.DataType = AttributeArrowType> {
             vector: vector!,
             bufferProps: props
           } satisfies GPUVectorFromArrowProps<T>)
-        : deviceOrProps;
+        : normalizeGPUVectorCreateProps(deviceOrProps);
 
     switch (constructionProps.type) {
       case 'arrow': {
@@ -549,6 +549,22 @@ export class GPUVector<T extends arrow.DataType = AttributeArrowType> {
     const nextCapacityRows = Math.max(requiredRows, grownRows);
     this._buffer.ensureSize(nextCapacityRows * this.byteStride, {preserveData: true});
   }
+}
+
+type NormalizedGPUVectorCreateProps<T extends arrow.DataType = AttributeArrowType> =
+  | (GPUVectorFromArrowProps<T> & {type: 'arrow'})
+  | (T extends AttributeArrowType ? GPUVectorFromBufferProps<T> : never)
+  | GPUVectorFromInterleavedProps
+  | GPUVectorFromDataProps<T>
+  | (T extends AttributeArrowType ? GPUVectorFromAppendableProps<T> : never);
+
+function normalizeGPUVectorCreateProps<T extends arrow.DataType>(
+  props: GPUVectorCreateProps<T>
+): NormalizedGPUVectorCreateProps<T> {
+  if ('vector' in props && props.type === undefined) {
+    return {...props, type: 'arrow'};
+  }
+  return props as NormalizedGPUVectorCreateProps<T>;
 }
 
 function getArrowVectorStride(vector: arrow.Vector<AttributeArrowType>): number {

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -14,6 +14,7 @@ export {getArrowPaths, getArrowDataByPath, getArrowVectorByPath} from './arrow/a
 export {getArrowColumnInfo} from './arrow/arrow-column-info';
 
 export {
+  makeArrowVectorFromArray,
   makeArrowFixedSizeListVector,
   isArrowFixedSizeListVector,
   getArrowFixedSizeListValues,

--- a/modules/arrow/test/arrow/arrow-fixed-size-list.spec.ts
+++ b/modules/arrow/test/arrow/arrow-fixed-size-list.spec.ts
@@ -11,6 +11,7 @@ import {
   getArrowMatrixVectorInfo,
   getArrowVectorBufferSource,
   isArrowFixedSizeListVector,
+  makeArrowVectorFromArray,
   makeArrowMatrix3x3Vector,
   makeArrowMatrixVector,
   makeArrowFixedSizeListVector
@@ -39,6 +40,29 @@ test('makeArrowFixedSizeListVector creates FixedSizeList vectors from typed arra
     new Float32Array([1, 2, 3, 4]),
     'returns a buffer source for FixedSizeList vectors'
   );
+
+  t.end();
+});
+
+test('makeArrowVectorFromArray creates flat FixedSizeList rows from JS numeric arrays', t => {
+  const vector = makeArrowVectorFromArray([1, 2, 3, 4], new arrow.Float32(), 2);
+
+  t.ok(arrow.DataType.isFixedSizeList(vector.type), 'creates a FixedSizeList vector');
+  t.equal(vector.type.listSize, 2, 'retains the requested row width');
+  t.deepEqual(
+    getArrowFixedSizeListValues(vector),
+    new Float32Array([1, 2, 3, 4]),
+    'materializes typed child values'
+  );
+
+  t.end();
+});
+
+test('makeArrowVectorFromArray mirrors scalar Apache Arrow array construction', t => {
+  const vector = makeArrowVectorFromArray(['hello', 'luma.gl'], new arrow.Utf8());
+
+  t.equal(vector.length, 2, 'creates one Arrow row per string');
+  t.equal(vector.get(0), 'hello', 'retains scalar row values');
 
   t.end();
 });
@@ -365,7 +389,7 @@ test('GPUVector readAsync round-trips FixedSizeList vectors', async t => {
   t.end();
 });
 
-test('GPUVector supports discriminated Arrow-vector construction', t => {
+test('GPUVector infers Arrow-vector object construction from vector props', t => {
   const device = new NullDevice({});
   const vector = makeArrowFixedSizeListVector(
     new arrow.Float32(),
@@ -373,7 +397,6 @@ test('GPUVector supports discriminated Arrow-vector construction', t => {
     new Float32Array([1, 2, 3, 4])
   );
   const gpuVector = new GPUVector({
-    type: 'arrow',
     name: 'positions',
     device,
     vector

--- a/modules/text/README.md
+++ b/modules/text/README.md
@@ -1,8 +1,7 @@
 # @luma.gl/text
 
-Experimental text utilities for luma.gl. The package contains:
+Experimental Arrow-native 2D text utilities for luma.gl. The package contains:
 
-- 3D text geometry helpers adapted from THREE.js text and extrusion utilities.
 - Arrow-native 2D text utilities adapted from deck.gl's atlas and text layout internals.
 - `ArrowTextModel`, an `ArrowModel`-derived one-line label renderer that expands UTF-8 `GPUVector` rows into glyph instances.
 - `ArrowStorageTextModel`, a WebGPU-only renderer that consumes storage-backed glyph state generated from UTF-8 `GPUVector` input or supplied as reusable `ArrowStorageTextState`.
@@ -10,63 +9,66 @@ Experimental text utilities for luma.gl. The package contains:
 ## Usage
 
 ```ts
-import {TextGeometry, parseFont} from '@luma.gl/text/text-3d'
-import helvetiker from './fonts/helvetiker_regular.typeface.json'
-
-const font = parseFont(helvetiker)
-const geometry = new TextGeometry('Hello luma.gl', {
-  font,
-  align: 'center',
-  size: 24,
-  depth: 4,
-  curveSegments: 8,
-  bevelEnabled: true,
-  bevelThickness: 1,
-  bevelSize: 0.5,
-  bevelSegments: 2
-})
-```
-
-The resulting `TextGeometry` exposes position, normal, and UV attributes ready for consumption by luma.gl models.
-
-## Arrow-Native 2D Text
-
-```ts
 import * as arrow from 'apache-arrow'
-import {GPUVector, makeArrowFixedSizeListVector} from '@luma.gl/arrow'
+import {GPUVector, makeArrowVectorFromArray} from '@luma.gl/arrow'
 import {ArrowTextModel} from '@luma.gl/text'
 
-const labelVectors = {
-  positions: new GPUVector({
-    type: 'arrow',
-    name: 'positions',
-    device,
-    vector: makeArrowFixedSizeListVector(
-      new arrow.Float32(),
-      2,
-      new Float32Array([0, 0, 0.5, 0.25])
-    )
-  })
-}
-const texts = new GPUVector({
-  type: 'arrow',
-  name: 'texts',
+const positions = new GPUVector({
   device,
-  vector: arrow.vectorFromArray(['hello', 'luma.gl'], new arrow.Utf8())
+  name: 'positions',
+  vector: makeArrowVectorFromArray([0, 0, 0.5, 0.25], new arrow.Float32(), 2)
+})
+const texts = new GPUVector({
+  device,
+  name: 'texts',
+  vector: makeArrowVectorFromArray(['hello', 'luma.gl'], new arrow.Utf8())
 })
 
 const model = new ArrowTextModel(device, {
   id: 'arrow-text',
-  labelVectors,
+  positions,
   texts,
   characterSet: 'auto',
   fontSettings: {sdf: true}
 })
 ```
 
-`ArrowTextModel` accepts GPU-resident label columns through `labelVectors`, with `texts` supplied as `GPUVector<Utf8>`. UTF-8 GPU vectors preserve one `GPUData` entry per Arrow source chunk and retain the chunk metadata needed for text expansion, so chunked and sliced sources stay addressable without collapsing them into one host string array. The model repeats compatible Arrow-backed label attributes for each glyph, emits generated `rowIndices` for source-row picking, and delegates GPU upload/update behavior to `ArrowModel`. Pass optional `clipRects` as `GPUVector<FixedSizeList<Int16>[4]>` rows containing `[x, y, width, height]` glyph-layout units; negative width or height disables clipping on that axis. The generated per-glyph clipping attribute stays packed at 8 bytes per glyph.
+`ArrowTextModel` accepts top-level GPU-resident row vectors such as `positions`, `colors`, `angles`, `sizes`, and `pixelOffsets`, with `texts` supplied as `GPUVector<Utf8>`. UTF-8 GPU vectors preserve one `GPUData` entry per Arrow source chunk and retain the chunk metadata needed for text expansion, so chunked and sliced sources stay addressable without collapsing them into one host string array. The model repeats compatible Arrow-backed row attributes for each glyph, emits generated `rowIndices` for source-row picking, and delegates GPU upload/update behavior to `ArrowModel`. Pass optional `clipRects` as `GPUVector<FixedSizeList<Int16>[4]>` rows containing `[x, y, width, height]` glyph-layout units; negative width or height disables clipping on that axis. The generated per-glyph clipping attribute stays packed at 8 bytes per glyph. When the built-in fragment shader is used, `fontSettings.sdf`, `cutoff`, and `smoothing` also drive SDF atlas decoding automatically; custom fragment shaders remain responsible for their own atlas-alpha interpretation.
 
-`ArrowStorageTextModel` is the WebGPU storage-backed path. It requires top-level `positions` as `GPUVector<FixedSizeList<Float32>[2]>` plus `texts`, accepts optional row-style `colors`, `angles`, `sizes`, `pixelOffsets`, `textAnchors`, and `alignmentBaselines` GPUVectors, and falls back to constant deck-like props when a style vector is absent. Storage inputs keep their existing aligned GPUData batches; the model binds each batch directly, renders generated glyph offsets, glyph indexes, and global source `rowIndices`, and only allocates model-owned storage for generated glyph state, small fallback/style config buffers, glyph definitions, and optional packed clip rectangles. Text anchors use `Uint8` row enums `0=start`, `1=middle`, `2=end`; alignment baselines use `0=center`, `1=top`, `2=bottom`.
+`ArrowStorageTextModel` is the WebGPU storage-backed path. It requires top-level `positions` as `GPUVector<FixedSizeList<Float32>[2]>` plus `texts`, accepts optional row-style `colors`, `angles`, `sizes`, `pixelOffsets`, `textAnchors`, and `alignmentBaselines` GPUVectors, and falls back to constant deck-like props when a style vector is absent. Storage inputs keep their existing aligned GPUData batches; the model binds each batch directly, renders one interleaved `compactGlyphVertexData` buffer containing offsets, glyph indexes, and global source `rowIndices`, and only allocates model-owned storage for generated glyph state, small fallback/style config buffers, glyph definitions, and optional packed clip rectangles. Text anchors use `Uint8` row enums `0=start`, `1=middle`, `2=end`; alignment baselines use `0=center`, `1=top`, `2=bottom`.
+
+Both render paths keep caller-owned row vectors separate from model-generated per-glyph data. The attribute path stores generated offsets, inline glyph frames, and row ids in `expandedGlyphVertexData`; the storage path stores generated offsets, glyph ids, and row ids in `compactGlyphVertexData`. That split keeps style vectors independently updateable while reducing generated glyph buffer fan-out.
+
+Text input vectors:
+
+| Input Vector | `ArrowTextModel` | `ArrowStorageTextModel` |
+| --- | --- | --- |
+| positions | `GPUVector<FixedSizeList<Float32>[2]>` | `GPUVector<FixedSizeList<Float32>[2]>` |
+| texts | `GPUVector<Utf8>` | `GPUVector<Utf8>` |
+| colors? | `GPUVector<FixedSizeList<Uint8>[4]>` | `GPUVector<FixedSizeList<Uint8>[4]>` |
+| angles? | `GPUVector<Float32>` | `GPUVector<Float32>` |
+| sizes? | `GPUVector<Float32>` | `GPUVector<Float32>` |
+| pixel offsets? | `GPUVector<FixedSizeList<Float32>[2]>` | `GPUVector<FixedSizeList<Float32>[2]>` |
+| clip rects? | `GPUVector<FixedSizeList<Int16>[4]>`; expanded into generated per-glyph vertex data. | `GPUVector<FixedSizeList<Int16>[4]>`; packed into row storage. |
+| text anchors? | Custom label attribute/shader responsibility. | `GPUVector<Uint8>` |
+| alignment baselines? | Custom label attribute/shader responsibility. | `GPUVector<Uint8>` |
+
+Text draw buffers:
+
+| Buffer | Attribute Model | Storage Model | Description |
+| --- | --- | --- | --- |
+| row positions | vertex | row | Per-label anchor positions for the currently bound input rows or storage batch. |
+| row colors | vertex | row | Optional packed RGBA8 per-label colors, or a one-row storage fallback buffer. |
+| row angles | vertex | row | Optional per-label rotation angles, or a one-row storage fallback buffer. |
+| row sizes | vertex | row | Optional per-label text sizes, or a one-row storage fallback buffer. |
+| row pixel offsets | vertex | row | Optional per-label pixel offsets, or a one-row storage fallback buffer. |
+| row clip rects | - | row | Optional packed `Int16[4]` clip rectangles remain row storage in the storage model; the attribute model expands them into `expandedGlyphVertexData`. |
+| expandedGlyphVertexData | vertex | - | Expanded 16-byte per-glyph vertex payload for the attribute model: model-generated offsets, inline glyph frames, and global source-row ids. Optional generated packed clip rectangles add 8 bytes per glyph. User-supplied row/style columns stay separate. |
+| compactGlyphVertexData | - | vertex | Compact 12-byte storage-path glyph payload: packed signed `Int16[2]` offsets, packed `Uint16[2]` glyph index word, and global source-row id. |
+| glyph frames | vertex | data | Per-glyph atlas frame attributes in the attribute model; shared atlas-frame storage indexed by glyph id in the storage model. |
+| atlas texture | data | data | Font atlas sampled by the fragment shader. |
+| sampler | data | data | Sampler paired with the atlas texture. |
+| style config uniform | - | data | Per-draw fallback style values, row-style presence flags, clip flag, `batchRowIndexBase`, and SDF alpha threshold/smoothing. |
 
 Call `createArrowStorageTextState(device, props)` when storage-state construction should be decoupled from rendering. The returned `ArrowStorageTextState` owns its storage buffers, atlas texture, generated render buffers, byte/timing diagnostics, and a `destroy()` method. `ArrowStorageTextModel` accepts either the original GPUVector input props and owns the generated state, or `{storageState}` plus render overrides when the caller wants to reuse and manage that state directly. With `characterSet: 'auto'`, the CPU builds compact glyph IDs and spans before compute expansion. With an explicit non-auto character set, the state builder uploads normalized Arrow UTF-8 bytes plus row byte ranges and decodes glyph IDs directly on the GPU, avoiding CPU UTF-8/glyph-stream construction.
 

--- a/modules/text/src/text-2d/arrow-text-model.ts
+++ b/modules/text/src/text-2d/arrow-text-model.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, type Device, type RenderPass, type ShaderLayout} from '@luma.gl/core';
+import {
+  Buffer,
+  type BufferLayout,
+  type Device,
+  type RenderPass,
+  type ShaderLayout
+} from '@luma.gl/core';
 import {
   ArrowModel,
   GPUVector,
@@ -46,6 +52,12 @@ const GLYPH_FRAMES_COLUMN = 'glyphFrames';
 const GLYPH_INDICES_COLUMN = 'glyphIndices';
 const GLYPH_CLIP_RECTS_COLUMN = 'glyphClipRects';
 const ROW_INDICES_COLUMN = 'rowIndices';
+const EXPANDED_GLYPH_VERTEX_DATA = 'expandedGlyphVertexData';
+const COMPACT_GLYPH_VERTEX_DATA = 'compactGlyphVertexData';
+const COMPACT_GLYPH_VERTEX_BYTE_STRIDE = Uint32Array.BYTES_PER_ELEMENT * 3;
+const EXPANDED_GLYPH_VERTEX_BYTE_STRIDE = Uint32Array.BYTES_PER_ELEMENT * 4;
+const CLIPPED_EXPANDED_GLYPH_VERTEX_BYTE_STRIDE =
+  EXPANDED_GLYPH_VERTEX_BYTE_STRIDE + Int16Array.BYTES_PER_ELEMENT * 4;
 const MISSING_CHAR_WIDTH = 32;
 const MAX_UINT16 = 65535;
 const DEFAULT_STORAGE_TEXT_COLOR: [number, number, number, number] = [0, 0, 0, 255];
@@ -54,7 +66,14 @@ const DEFAULT_STORAGE_TEXT_SIZE = 32;
 const DEFAULT_STORAGE_TEXT_PIXEL_OFFSET: [number, number] = [0, 0];
 const DEFAULT_STORAGE_TEXT_ANCHOR = 0;
 const DEFAULT_STORAGE_ALIGNMENT_BASELINE = 0;
+const BITMAP_TEXT_SDF_THRESHOLD = -1;
 type StorageTextBuffer = Buffer | DynamicBuffer;
+
+type TextSdfRenderSettings = {
+  sdf: boolean;
+  threshold: number;
+  smoothing: number;
+};
 
 const DEFAULT_ARROW_TEXT_SHADER_LAYOUT: ShaderLayout = {
   attributes: [
@@ -172,11 +191,22 @@ const DEFAULT_ARROW_TEXT_FS = `#version 300 es
 precision highp float;
 
 uniform sampler2D fontAtlasTexture;
+uniform float textUsesSdf;
+uniform float textSdfThreshold;
+uniform float textSdfSmoothing;
 in vec2 vTextureCoordinate;
 out vec4 fragColor;
 
 void main() {
-  float alpha = texture(fontAtlasTexture, vTextureCoordinate).a;
+  float sampledAlpha = texture(fontAtlasTexture, vTextureCoordinate).a;
+  float sdfAlpha = textSdfSmoothing > 0.0
+    ? smoothstep(
+        textSdfThreshold - textSdfSmoothing,
+        textSdfThreshold + textSdfSmoothing,
+        sampledAlpha
+      )
+    : step(textSdfThreshold, sampledAlpha);
+  float alpha = textUsesSdf > 0.5 ? sdfAlpha : sampledAlpha;
   fragColor = vec4(1.0, 1.0, 1.0, alpha);
 }
 `;
@@ -203,7 +233,8 @@ struct TextStorageStyleConfig {
   useRowPixelOffsets : u32,
   hasClipRects : u32,
   batchRowIndexBase : u32,
-  _padding : u32,
+  sdfThreshold : f32,
+  sdfSmoothing : f32,
 };
 
 @group(0) @binding(auto) var<uniform> textStorageStyleConfig : TextStorageStyleConfig;
@@ -332,7 +363,19 @@ fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
 
 @fragment
 fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
-  let alpha = textureSample(fontAtlasTexture, fontAtlasTextureSampler, inputs.atlasUV).a;
+  let sampledAlpha = textureSample(fontAtlasTexture, fontAtlasTextureSampler, inputs.atlasUV).a;
+  var alpha = sampledAlpha;
+  if (textStorageStyleConfig.sdfThreshold >= 0.0) {
+    if (textStorageStyleConfig.sdfSmoothing > 0.0) {
+      alpha = smoothstep(
+        textStorageStyleConfig.sdfThreshold - textStorageStyleConfig.sdfSmoothing,
+        textStorageStyleConfig.sdfThreshold + textStorageStyleConfig.sdfSmoothing,
+        sampledAlpha
+      );
+    } else {
+      alpha = select(0.0, 1.0, sampledAlpha >= textStorageStyleConfig.sdfThreshold);
+    }
+  }
   return vec4<f32>(inputs.color.rgb, inputs.color.a * alpha);
 }
 `;
@@ -349,9 +392,17 @@ export type ArrowTextModelProps = Omit<
   ArrowModelProps,
   'arrowTable' | 'arrowGPUTable' | 'streamingArrowGPUTable' | 'arrowCount'
 > & {
-  /** One named GPU vector per label attribute. `positions` is required. */
-  labelVectors: Record<string, GPUVector>;
-  /** GPU UTF-8 labels aligned row-for-row with `labelVectors.positions`. */
+  /** GPU-resident label origins aligned one-for-one with `texts`. */
+  positions: GPUVector<arrow.FixedSizeList<arrow.Float32>>;
+  /** Optional packed RGBA8 text colors, consumed as label attributes when declared by the shader. */
+  colors?: GPUVector<arrow.FixedSizeList<arrow.Uint8>>;
+  /** Optional per-row angles in degrees, consumed as label attributes when declared by the shader. */
+  angles?: GPUVector<arrow.Float32>;
+  /** Optional per-row deck-style text sizes, consumed as label attributes when declared by the shader. */
+  sizes?: GPUVector<arrow.Float32>;
+  /** Optional per-row pixel offsets, consumed as label attributes when declared by the shader. */
+  pixelOffsets?: GPUVector<arrow.FixedSizeList<arrow.Float32>>;
+  /** GPU UTF-8 labels aligned row-for-row with `positions`. */
   texts: GPUVector<arrow.Utf8>;
   /**
    * Optional packed per-label clip rectangles `[x, y, width, height]`.
@@ -373,17 +424,7 @@ export type ArrowTextModelProps = Omit<
   fontAtlas?: FontAtlas;
 };
 
-export type ArrowStorageTextInputProps = Omit<ArrowTextModelProps, 'labelVectors'> & {
-  /** GPU-resident row origins aligned one-for-one with `texts`. */
-  positions: GPUVector<arrow.FixedSizeList<arrow.Float32>>;
-  /** Optional packed RGBA8 text colors, read directly from storage. */
-  colors?: GPUVector<arrow.FixedSizeList<arrow.Uint8>>;
-  /** Optional per-row angles in degrees, read directly from storage. */
-  angles?: GPUVector<arrow.Float32>;
-  /** Optional per-row deck-style text sizes, read directly from storage. */
-  sizes?: GPUVector<arrow.Float32>;
-  /** Optional per-row pixel offsets. */
-  pixelOffsets?: GPUVector<arrow.FixedSizeList<arrow.Float32>>;
+export type ArrowStorageTextInputProps = ArrowTextModelProps & {
   /** Optional per-row text anchor enum: 0=start, 1=middle, 2=end. */
   textAnchors?: GPUVector<arrow.Uint8>;
   /** Optional per-row alignment baseline enum: 0=center, 1=top, 2=bottom. */
@@ -431,9 +472,7 @@ export type ArrowStorageTextBatchState = {
   rowAlignmentBaselinesBuffer: StorageTextBuffer;
   rowClipRectsBuffer: Buffer;
   styleConfigBuffer: DynamicBuffer;
-  generatedGlyphOffsetsBuffer: Buffer;
-  generatedGlyphIndicesBuffer: Buffer;
-  generatedRowIndicesBuffer: Buffer;
+  compactGlyphVertexData: Buffer;
 };
 
 export type ArrowStorageTextState = {
@@ -450,6 +489,7 @@ export type ArrowStorageTextState = {
   rowStorageByteLength: number;
   glyphDefinitionStorageByteLength: number;
   transientComputeInputByteLength: number;
+  sdfRenderSettings: TextSdfRenderSettings;
   glyphFramesBuffer: Buffer;
   batches: ArrowStorageTextBatchState[];
   ownedRowBindingResources: StorageTextOwnedResource[];
@@ -462,9 +502,7 @@ export type ArrowStorageTextState = {
   rowAlignmentBaselinesBuffer: StorageTextBuffer;
   rowClipRectsBuffer: Buffer;
   styleConfigBuffer: DynamicBuffer;
-  generatedGlyphOffsetsBuffer: Buffer;
-  generatedGlyphIndicesBuffer: Buffer;
-  generatedRowIndicesBuffer: Buffer;
+  compactGlyphVertexData: Buffer;
   destroy: () => void;
 };
 
@@ -483,6 +521,8 @@ export class ArrowTextModel extends ArrowModel {
   glyphTable: arrow.Table;
   glyphAttributeBuildTimeMs: number;
   glyphAttributeByteLength: number;
+  expandedGlyphVertexData: Buffer;
+  private defaultFragmentShaderUniforms?: Record<string, unknown>;
   private textProps: ArrowTextModelProps;
 
   constructor(device: Device, props: ArrowTextModelProps) {
@@ -496,13 +536,19 @@ export class ArrowTextModel extends ArrowModel {
     this.glyphTable = prepared.glyphTable.table;
     this.glyphAttributeBuildTimeMs = prepared.glyphAttributeBuildTimeMs;
     this.glyphAttributeByteLength = prepared.glyphTable.attributeByteLength;
+    this.expandedGlyphVertexData = prepared.expandedGlyphVertexData;
+    this.defaultFragmentShaderUniforms = prepared.defaultFragmentShaderUniforms;
   }
 
   /** Rebuild generated glyph attributes when label rows, text, or font layout inputs change. */
   override setProps(props: Partial<ArrowTextModelProps>): void {
     const nextProps = {...this.textProps, ...props};
     const shouldRebuild =
-      props.labelVectors !== undefined ||
+      props.positions !== undefined ||
+      props.colors !== undefined ||
+      props.angles !== undefined ||
+      props.sizes !== undefined ||
+      props.pixelOffsets !== undefined ||
       props.texts !== undefined ||
       props.clipRects !== undefined ||
       props.characterSet !== undefined ||
@@ -519,6 +565,7 @@ export class ArrowTextModel extends ArrowModel {
 
     const prepared = prepareArrowTextModel(this.device, nextProps);
     this.atlasTexture?.destroy();
+    this.expandedGlyphVertexData.destroy();
     this.fontAtlasManager = prepared.fontAtlasManager;
     this.atlasTexture = prepared.atlasTexture;
     this.glyphLayout = prepared.glyphTable.glyphLayout;
@@ -526,7 +573,15 @@ export class ArrowTextModel extends ArrowModel {
     this.glyphTable = prepared.glyphTable.table;
     this.glyphAttributeBuildTimeMs = prepared.glyphAttributeBuildTimeMs;
     this.glyphAttributeByteLength = prepared.glyphTable.attributeByteLength;
-    super.setProps({arrowTable: prepared.glyphTable.table});
+    this.expandedGlyphVertexData = prepared.expandedGlyphVertexData;
+    if (this.defaultFragmentShaderUniforms && prepared.defaultFragmentShaderUniforms) {
+      updateArrowTextDefaultFragmentShaderUniforms(
+        this.defaultFragmentShaderUniforms,
+        prepared.sdfRenderSettings
+      );
+    }
+    super.setProps({arrowTable: createArrowTextRenderTable(prepared.glyphTable.table)});
+    this.setAttributes({[EXPANDED_GLYPH_VERTEX_DATA]: prepared.expandedGlyphVertexData});
     if (prepared.atlasTexture) {
       this.setBindings({fontAtlasTexture: prepared.atlasTexture});
     }
@@ -536,6 +591,7 @@ export class ArrowTextModel extends ArrowModel {
 
   override destroy(): void {
     this.atlasTexture?.destroy();
+    this.expandedGlyphVertexData.destroy();
     super.destroy();
   }
 }
@@ -567,9 +623,7 @@ export class ArrowStorageTextModel extends Model {
   rowClipRectsBuffer!: Buffer;
   styleConfigBuffer!: DynamicBuffer;
   glyphFramesBuffer!: Buffer;
-  generatedGlyphOffsetsBuffer!: Buffer;
-  generatedGlyphIndicesBuffer!: Buffer;
-  generatedRowIndicesBuffer!: Buffer;
+  compactGlyphVertexData!: Buffer;
   batches!: ArrowStorageTextBatchState[];
   storageState: ArrowStorageTextState;
   private textProps: ArrowStorageTextModelProps;
@@ -643,9 +697,7 @@ export class ArrowStorageTextModel extends Model {
     this.applyStorageState(nextStorageState);
     const firstBatch = getFirstArrowStorageTextBatch(nextStorageState);
     this.setAttributes({
-      [GLYPH_OFFSETS_COLUMN]: firstBatch.generatedGlyphOffsetsBuffer,
-      [GLYPH_INDICES_COLUMN]: firstBatch.generatedGlyphIndicesBuffer,
-      [ROW_INDICES_COLUMN]: firstBatch.generatedRowIndicesBuffer
+      [COMPACT_GLYPH_VERTEX_DATA]: firstBatch.compactGlyphVertexData
     });
     this.setBindings(createArrowStorageTextBindings(nextProps, nextStorageState, firstBatch));
     this.setInstanceCount(firstBatch.glyphCount);
@@ -656,9 +708,7 @@ export class ArrowStorageTextModel extends Model {
     let drawSuccess = true;
     for (const batch of this.storageState.batches) {
       this.setAttributes({
-        [GLYPH_OFFSETS_COLUMN]: batch.generatedGlyphOffsetsBuffer,
-        [GLYPH_INDICES_COLUMN]: batch.generatedGlyphIndicesBuffer,
-        [ROW_INDICES_COLUMN]: batch.generatedRowIndicesBuffer
+        [COMPACT_GLYPH_VERTEX_DATA]: batch.compactGlyphVertexData
       });
       this.setBindings(createArrowStorageTextBindings(this.textProps, this.storageState, batch));
       this.setInstanceCount(batch.glyphCount);
@@ -666,9 +716,7 @@ export class ArrowStorageTextModel extends Model {
     }
     const firstBatch = getFirstArrowStorageTextBatch(this.storageState);
     this.setAttributes({
-      [GLYPH_OFFSETS_COLUMN]: firstBatch.generatedGlyphOffsetsBuffer,
-      [GLYPH_INDICES_COLUMN]: firstBatch.generatedGlyphIndicesBuffer,
-      [ROW_INDICES_COLUMN]: firstBatch.generatedRowIndicesBuffer
+      [COMPACT_GLYPH_VERTEX_DATA]: firstBatch.compactGlyphVertexData
     });
     this.setBindings(createArrowStorageTextBindings(this.textProps, this.storageState, firstBatch));
     this.setInstanceCount(this.storageState.glyphCount);
@@ -707,9 +755,7 @@ export class ArrowStorageTextModel extends Model {
     this.rowClipRectsBuffer = storageState.rowClipRectsBuffer;
     this.styleConfigBuffer = storageState.styleConfigBuffer;
     this.glyphFramesBuffer = storageState.glyphFramesBuffer;
-    this.generatedGlyphOffsetsBuffer = storageState.generatedGlyphOffsetsBuffer;
-    this.generatedGlyphIndicesBuffer = storageState.generatedGlyphIndicesBuffer;
-    this.generatedRowIndicesBuffer = storageState.generatedRowIndicesBuffer;
+    this.compactGlyphVertexData = storageState.compactGlyphVertexData;
   }
 }
 
@@ -797,14 +843,23 @@ type ResolvedArrowTextInputs = {
 };
 
 function resolveArrowTextInputs(props: ArrowTextModelProps): ResolvedArrowTextInputs {
+  assertArrowTextVectorTypes(props);
+  assertArrowTextVectorRowAlignment(props);
   const texts = getRetainedGPUVectorSource(props.texts, 'texts');
-  if (!(texts.type instanceof arrow.Utf8)) {
-    throw new Error('Text models require texts to be GPUVector<Utf8>');
+  const columns: Record<string, arrow.Vector> = {
+    positions: getRetainedGPUVectorSource(props.positions, 'positions')
+  };
+  if (props.colors) {
+    columns['colors'] = getRetainedGPUVectorSource(props.colors, 'colors');
   }
-
-  const columns: Record<string, arrow.Vector> = {};
-  for (const [name, vector] of Object.entries(props.labelVectors)) {
-    columns[name] = getRetainedGPUVectorSource(vector, `labelVectors.${name}`);
+  if (props.angles) {
+    columns['angles'] = getRetainedGPUVectorSource(props.angles, 'angles');
+  }
+  if (props.sizes) {
+    columns['sizes'] = getRetainedGPUVectorSource(props.sizes, 'sizes');
+  }
+  if (props.pixelOffsets) {
+    columns['pixelOffsets'] = getRetainedGPUVectorSource(props.pixelOffsets, 'pixelOffsets');
   }
   const labelTable = new arrow.Table(columns);
   const clipRects = props.clipRects
@@ -818,6 +873,64 @@ function resolveArrowTextInputs(props: ArrowTextModelProps): ResolvedArrowTextIn
     texts: texts as arrow.Vector<arrow.Utf8>,
     clipRects
   };
+}
+
+function assertArrowTextVectorTypes(props: ArrowTextModelProps): void {
+  if (!(props.texts.type instanceof arrow.Utf8)) {
+    throw new Error('ArrowTextModel texts must be GPUVector<Utf8>');
+  }
+  if (
+    !arrow.DataType.isFixedSizeList(props.positions.type) ||
+    props.positions.type.listSize !== 2 ||
+    !(props.positions.type.children[0]?.type instanceof arrow.Float32)
+  ) {
+    throw new Error('ArrowTextModel positions must be GPUVector<FixedSizeList<Float32>[2]>');
+  }
+  if (
+    props.colors &&
+    (!arrow.DataType.isFixedSizeList(props.colors.type) ||
+      props.colors.type.listSize !== 4 ||
+      !(props.colors.type.children[0]?.type instanceof arrow.Uint8))
+  ) {
+    throw new Error('ArrowTextModel colors must be GPUVector<FixedSizeList<Uint8>[4]>');
+  }
+  if (props.angles && !(props.angles.type instanceof arrow.Float32)) {
+    throw new Error('ArrowTextModel angles must be GPUVector<Float32>');
+  }
+  if (props.sizes && !(props.sizes.type instanceof arrow.Float32)) {
+    throw new Error('ArrowTextModel sizes must be GPUVector<Float32>');
+  }
+  if (
+    props.pixelOffsets &&
+    (!arrow.DataType.isFixedSizeList(props.pixelOffsets.type) ||
+      props.pixelOffsets.type.listSize !== 2 ||
+      !(props.pixelOffsets.type.children[0]?.type instanceof arrow.Float32))
+  ) {
+    throw new Error('ArrowTextModel pixelOffsets must be GPUVector<FixedSizeList<Float32>[2]>');
+  }
+}
+
+function assertArrowTextVectorRowAlignment(props: ArrowTextModelProps): void {
+  const rowInputs: Array<[string, GPUVector<any> | undefined]> = [
+    ['positions', props.positions],
+    ['texts', props.texts],
+    ['colors', props.colors],
+    ['angles', props.angles],
+    ['sizes', props.sizes],
+    ['pixelOffsets', props.pixelOffsets],
+    ['clipRects', props.clipRects]
+  ];
+  const suppliedInputs = rowInputs.filter(([, vector]) => vector !== undefined) as Array<
+    [string, GPUVector<any>]
+  >;
+  const [referenceName, referenceVector] = suppliedInputs[0];
+  for (const [name, vector] of suppliedInputs.slice(1)) {
+    if (vector.length !== referenceVector.length) {
+      throw new Error(
+        `ArrowTextModel ${name} rows must match ${referenceName} rows (${vector.length} !== ${referenceVector.length})`
+      );
+    }
+  }
 }
 
 type ResolvedArrowStorageTextBatchInputs = {
@@ -984,12 +1097,19 @@ function prepareArrowTextModel(
 ): {
   modelProps: ArrowModelProps;
   glyphTable: ArrowTextGlyphTable;
+  expandedGlyphVertexData: Buffer;
   fontAtlasManager?: FontAtlasManager;
   atlasTexture?: DynamicTexture;
   glyphAttributeBuildTimeMs: number;
+  sdfRenderSettings: TextSdfRenderSettings;
+  defaultFragmentShaderUniforms?: Record<string, unknown>;
 } {
   const textInputs = resolveArrowTextInputs(props);
   const mappingState = resolveCharacterMapping(props, textInputs.texts);
+  const usesDefaultFragmentShader = props.fs === undefined || props.fs === null;
+  const defaultFragmentShaderUniforms = usesDefaultFragmentShader
+    ? createArrowTextDefaultFragmentShaderUniforms(props.uniforms, mappingState.sdfRenderSettings)
+    : undefined;
   const glyphTable = buildArrowTextGlyphTable({
     labelTable: textInputs.labelTable,
     texts: textInputs.texts,
@@ -998,6 +1118,15 @@ function prepareArrowTextModel(
     baselineOffset: mappingState.baselineOffset,
     lineHeight: mappingState.lineHeight,
     characterSet: mappingState.characterSet
+  });
+  const shaderLayout =
+    props.shaderLayout ??
+    (textInputs.clipRects
+      ? DEFAULT_CLIPPED_ARROW_TEXT_SHADER_LAYOUT
+      : DEFAULT_ARROW_TEXT_SHADER_LAYOUT);
+  const expandedGlyphVertexState = createExpandedGlyphVertexData(device, props, {
+    glyphTable,
+    shaderLayout
   });
   const atlasTexture = mappingState.fontAtlas
     ? new DynamicTexture(device, {
@@ -1012,23 +1141,152 @@ function prepareArrowTextModel(
       vs:
         props.vs ?? (textInputs.clipRects ? DEFAULT_CLIPPED_ARROW_TEXT_VS : DEFAULT_ARROW_TEXT_VS),
       fs: props.fs ?? DEFAULT_ARROW_TEXT_FS,
-      shaderLayout:
-        props.shaderLayout ??
-        (textInputs.clipRects
-          ? DEFAULT_CLIPPED_ARROW_TEXT_SHADER_LAYOUT
-          : DEFAULT_ARROW_TEXT_SHADER_LAYOUT),
+      uniforms: defaultFragmentShaderUniforms ?? props.uniforms,
+      shaderLayout,
       bindings: {
         ...(props.bindings || {}),
         ...(atlasTexture ? {fontAtlasTexture: atlasTexture} : {})
       },
+      attributes: {
+        ...(props.attributes || {}),
+        [EXPANDED_GLYPH_VERTEX_DATA]: expandedGlyphVertexState.buffer
+      },
+      bufferLayout: [...(props.bufferLayout || []), expandedGlyphVertexState.bufferLayout],
       vertexCount: props.vertexCount ?? 6,
-      arrowTable: glyphTable.table,
+      arrowTable: createArrowTextRenderTable(glyphTable.table),
       arrowCount: 'instance'
     },
     glyphTable,
+    expandedGlyphVertexData: expandedGlyphVertexState.buffer,
     fontAtlasManager: mappingState.fontAtlasManager,
     atlasTexture,
-    glyphAttributeBuildTimeMs: glyphTable.glyphAttributeBuildTimeMs
+    glyphAttributeBuildTimeMs: glyphTable.glyphAttributeBuildTimeMs,
+    sdfRenderSettings: mappingState.sdfRenderSettings,
+    defaultFragmentShaderUniforms
+  };
+}
+
+function createArrowTextRenderTable(glyphTable: arrow.Table): arrow.Table {
+  const generatedGlyphColumnNames = new Set([
+    GLYPH_OFFSETS_COLUMN,
+    GLYPH_FRAMES_COLUMN,
+    GLYPH_CLIP_RECTS_COLUMN,
+    ROW_INDICES_COLUMN
+  ]);
+  const fields: arrow.Field[] = [];
+  const columns: Record<string, arrow.Vector> = {};
+
+  for (const field of glyphTable.schema.fields) {
+    if (generatedGlyphColumnNames.has(field.name)) {
+      continue;
+    }
+    const vector = glyphTable.getChild(field.name);
+    if (!vector) {
+      continue;
+    }
+    fields.push(field);
+    columns[field.name] = vector;
+  }
+
+  return new arrow.Table(new arrow.Schema(fields, new Map(glyphTable.schema.metadata)), columns);
+}
+
+function createExpandedGlyphVertexData(
+  device: Device,
+  props: ArrowTextModelProps,
+  {
+    glyphTable,
+    shaderLayout
+  }: {
+    glyphTable: ArrowTextGlyphTable;
+    shaderLayout: ShaderLayout;
+  }
+): {
+  buffer: Buffer;
+  bufferLayout: BufferLayout;
+  byteLength: number;
+} {
+  const {glyphLayout} = glyphTable;
+  const glyphCount = glyphLayout.glyphCount;
+  const glyphClipRects = glyphTable.table.getChild(GLYPH_CLIP_RECTS_COLUMN) as arrow.Vector<
+    arrow.FixedSizeList<arrow.Int16>
+  > | null;
+  const glyphClipRectValues = glyphClipRects
+    ? (getArrowVectorBufferSource(glyphClipRects) as Int16Array)
+    : undefined;
+  const byteStride = glyphClipRectValues
+    ? CLIPPED_EXPANDED_GLYPH_VERTEX_BYTE_STRIDE
+    : EXPANDED_GLYPH_VERTEX_BYTE_STRIDE;
+  const byteLength = glyphCount * byteStride;
+  const arrayBuffer = new ArrayBuffer(Math.max(byteLength, byteStride));
+  const int16Values = new Int16Array(arrayBuffer);
+  const uint16Values = new Uint16Array(arrayBuffer);
+  const uint32Values = new Uint32Array(arrayBuffer);
+  const rowIndices = makeGlyphRowIndices(glyphLayout.startIndices);
+
+  for (let glyphIndex = 0; glyphIndex < glyphCount; glyphIndex++) {
+    const recordInt16Index = (glyphIndex * byteStride) / Int16Array.BYTES_PER_ELEMENT;
+    const recordUint32Index = (glyphIndex * byteStride) / Uint32Array.BYTES_PER_ELEMENT;
+    const glyphOffsetIndex = glyphIndex * 2;
+    const glyphFrameIndex = glyphIndex * 4;
+
+    int16Values[recordInt16Index] = glyphLayout.glyphOffsets[glyphOffsetIndex];
+    int16Values[recordInt16Index + 1] = glyphLayout.glyphOffsets[glyphOffsetIndex + 1];
+    uint16Values[recordInt16Index + 2] = glyphLayout.glyphFrames[glyphFrameIndex];
+    uint16Values[recordInt16Index + 3] = glyphLayout.glyphFrames[glyphFrameIndex + 1];
+    uint16Values[recordInt16Index + 4] = glyphLayout.glyphFrames[glyphFrameIndex + 2];
+    uint16Values[recordInt16Index + 5] = glyphLayout.glyphFrames[glyphFrameIndex + 3];
+    uint32Values[recordUint32Index + 3] = rowIndices[glyphIndex];
+
+    if (glyphClipRectValues) {
+      const glyphClipRectIndex = glyphIndex * 4;
+      int16Values[recordInt16Index + 8] = glyphClipRectValues[glyphClipRectIndex];
+      int16Values[recordInt16Index + 9] = glyphClipRectValues[glyphClipRectIndex + 1];
+      int16Values[recordInt16Index + 10] = glyphClipRectValues[glyphClipRectIndex + 2];
+      int16Values[recordInt16Index + 11] = glyphClipRectValues[glyphClipRectIndex + 3];
+    }
+  }
+
+  const shaderAttributeNames = new Set(shaderLayout.attributes.map(attribute => attribute.name));
+  const attributes: NonNullable<BufferLayout['attributes']> = [];
+  if (shaderAttributeNames.has(GLYPH_OFFSETS_COLUMN)) {
+    attributes.push({attribute: GLYPH_OFFSETS_COLUMN, format: 'sint16x2', byteOffset: 0});
+  }
+  if (shaderAttributeNames.has(GLYPH_FRAMES_COLUMN)) {
+    attributes.push({
+      attribute: GLYPH_FRAMES_COLUMN,
+      format: 'uint16x4',
+      byteOffset: Int16Array.BYTES_PER_ELEMENT * 2
+    });
+  }
+  if (shaderAttributeNames.has(ROW_INDICES_COLUMN)) {
+    attributes.push({
+      attribute: ROW_INDICES_COLUMN,
+      format: 'uint32',
+      byteOffset: Int16Array.BYTES_PER_ELEMENT * 6
+    });
+  }
+  if (glyphClipRectValues && shaderAttributeNames.has(GLYPH_CLIP_RECTS_COLUMN)) {
+    attributes.push({
+      attribute: GLYPH_CLIP_RECTS_COLUMN,
+      format: 'sint16x4',
+      byteOffset: EXPANDED_GLYPH_VERTEX_BYTE_STRIDE
+    });
+  }
+
+  return {
+    buffer: device.createBuffer({
+      id: `${props.id || 'arrow-text-model'}-expanded-glyph-vertex-data`,
+      usage: Buffer.VERTEX | Buffer.COPY_DST | Buffer.COPY_SRC,
+      data: new Uint8Array(arrayBuffer)
+    }),
+    bufferLayout: {
+      name: EXPANDED_GLYPH_VERTEX_DATA,
+      stepMode: 'instance',
+      byteStride,
+      attributes
+    },
+    byteLength
   };
 }
 
@@ -1074,7 +1332,13 @@ export function createArrowStorageTextState(
     glyphFrames = createStorageGlyphFrames(device, props, glyphDefinitions.glyphFrames);
     glyphDefinitionStorageByteLength = glyphFrames.byteLength;
     for (const batchInput of textInputs.batches) {
-      const rowState = createStorageTextBatchRowState(device, props, batchInput, defaultBuffers);
+      const rowState = createStorageTextBatchRowState(
+        device,
+        props,
+        batchInput,
+        defaultBuffers,
+        mappingState.sdfRenderSettings
+      );
       const utf8TextInput = buildGpuUtf8TextInput(batchInput.texts);
       const glyphMetrics = createStorageGlyphMetrics(
         device,
@@ -1126,9 +1390,7 @@ export function createArrowStorageTextState(
         batchRowIndexBase: batchInput.batchRowIndexBase,
         rowCount: batchInput.texts.length,
         glyphCount: utf8TextInput.byteLength,
-        generatedGlyphOffsetsBuffer: generated.glyphOffsetsBuffer,
-        generatedGlyphIndicesBuffer: generated.glyphIndicesBuffer,
-        generatedRowIndicesBuffer: generated.rowIndicesBuffer
+        compactGlyphVertexData: generated.compactGlyphVertexData
       });
       glyphCount += utf8TextInput.byteLength;
       glyphAttributeBuildTimeMs += utf8TextInput.textInputBuildTimeMs;
@@ -1146,7 +1408,13 @@ export function createArrowStorageTextState(
     }
   } else {
     for (const [batchIndex, batchInput] of textInputs.batches.entries()) {
-      const rowState = createStorageTextBatchRowState(device, props, batchInput, defaultBuffers);
+      const rowState = createStorageTextBatchRowState(
+        device,
+        props,
+        batchInput,
+        defaultBuffers,
+        mappingState.sdfRenderSettings
+      );
       const batchGlyphStream = buildGpuExpandedTextStream({
         texts: batchInput.texts,
         mapping: mappingState.mapping,
@@ -1198,9 +1466,7 @@ export function createArrowStorageTextState(
         batchRowIndexBase: batchInput.batchRowIndexBase,
         rowCount: batchInput.texts.length,
         glyphCount: batchGlyphStream.glyphCount,
-        generatedGlyphOffsetsBuffer: generated.glyphOffsetsBuffer,
-        generatedGlyphIndicesBuffer: generated.glyphIndicesBuffer,
-        generatedRowIndicesBuffer: generated.rowIndicesBuffer
+        compactGlyphVertexData: generated.compactGlyphVertexData
       });
       glyphCount += batchGlyphStream.glyphCount;
       glyphAttributeBuildTimeMs += batchGlyphStream.glyphStreamBuildTimeMs;
@@ -1233,6 +1499,7 @@ export function createArrowStorageTextState(
     rowStorageByteLength,
     glyphDefinitionStorageByteLength,
     transientComputeInputByteLength,
+    sdfRenderSettings: mappingState.sdfRenderSettings,
     batches,
     ownedRowBindingResources: ownedRowStorageResources,
     rowPositionsBuffer: firstBatch.rowPositionsBuffer,
@@ -1245,9 +1512,7 @@ export function createArrowStorageTextState(
     rowClipRectsBuffer: firstBatch.rowClipRectsBuffer,
     styleConfigBuffer: firstBatch.styleConfigBuffer,
     glyphFramesBuffer: glyphFrames.buffer,
-    generatedGlyphOffsetsBuffer: firstBatch.generatedGlyphOffsetsBuffer,
-    generatedGlyphIndicesBuffer: firstBatch.generatedGlyphIndicesBuffer,
-    generatedRowIndicesBuffer: firstBatch.generatedRowIndicesBuffer,
+    compactGlyphVertexData: firstBatch.compactGlyphVertexData,
     destroy: () => {
       if (destroyed) {
         return;
@@ -1257,9 +1522,7 @@ export function createArrowStorageTextState(
       destroyStorageTextResources(ownedRowStorageResources);
       glyphFrames.buffer.destroy();
       for (const batch of batches) {
-        batch.generatedGlyphOffsetsBuffer.destroy();
-        batch.generatedGlyphIndicesBuffer.destroy();
-        batch.generatedRowIndicesBuffer.destroy();
+        batch.compactGlyphVertexData.destroy();
       }
     }
   };
@@ -1278,15 +1541,28 @@ function createArrowStorageTextModelProps(
     bindings: createArrowStorageTextBindings(props, storageState, firstBatch),
     attributes: {
       ...(props.attributes || {}),
-      [GLYPH_OFFSETS_COLUMN]: firstBatch.generatedGlyphOffsetsBuffer,
-      [GLYPH_INDICES_COLUMN]: firstBatch.generatedGlyphIndicesBuffer,
-      [ROW_INDICES_COLUMN]: firstBatch.generatedRowIndicesBuffer
+      [COMPACT_GLYPH_VERTEX_DATA]: firstBatch.compactGlyphVertexData
     },
     bufferLayout: [
       ...(props.bufferLayout || []),
-      {name: GLYPH_OFFSETS_COLUMN, format: 'sint16x2', stepMode: 'instance'},
-      {name: GLYPH_INDICES_COLUMN, format: 'uint16x2', stepMode: 'instance'},
-      {name: ROW_INDICES_COLUMN, format: 'uint32', stepMode: 'instance'}
+      {
+        name: COMPACT_GLYPH_VERTEX_DATA,
+        stepMode: 'instance',
+        byteStride: COMPACT_GLYPH_VERTEX_BYTE_STRIDE,
+        attributes: [
+          {attribute: GLYPH_OFFSETS_COLUMN, format: 'sint16x2', byteOffset: 0},
+          {
+            attribute: GLYPH_INDICES_COLUMN,
+            format: 'uint16x2',
+            byteOffset: Uint32Array.BYTES_PER_ELEMENT
+          },
+          {
+            attribute: ROW_INDICES_COLUMN,
+            format: 'uint32',
+            byteOffset: Uint32Array.BYTES_PER_ELEMENT * 2
+          }
+        ]
+      }
     ],
     vertexCount: props.vertexCount ?? 6,
     instanceCount: firstBatch.glyphCount
@@ -1332,6 +1608,7 @@ function resolveCharacterMapping(
   characterSet?: Set<string>;
   fontAtlasManager?: FontAtlasManager;
   fontAtlas?: FontAtlas;
+  sdfRenderSettings: TextSdfRenderSettings;
 } {
   const characterSet =
     props.characterSet === 'auto'
@@ -1346,7 +1623,8 @@ function resolveCharacterMapping(
       baselineOffset: props.fontAtlas?.baselineOffset ?? 0,
       lineHeight: lineHeightMultiplier * fontSize,
       characterSet,
-      fontAtlas: props.fontAtlas
+      fontAtlas: props.fontAtlas,
+      sdfRenderSettings: resolveTextSdfRenderSettings(props)
     };
   }
 
@@ -1367,7 +1645,8 @@ function resolveCharacterMapping(
     lineHeight: lineHeightMultiplier * fontAtlasManager.props.fontSize,
     characterSet,
     fontAtlasManager,
-    fontAtlas
+    fontAtlas,
+    sdfRenderSettings: resolveTextSdfRenderSettings(props, fontAtlasManager)
   };
 }
 
@@ -1393,6 +1672,39 @@ function normalizeCharacterSet(
   return typeof characterSet === 'string'
     ? new Set(Array.from(characterSet))
     : new Set(characterSet);
+}
+
+function resolveTextSdfRenderSettings(
+  props: ArrowTextModelProps | ArrowStorageTextInputProps,
+  fontAtlasManager?: FontAtlasManager
+): TextSdfRenderSettings {
+  const fontSettings = fontAtlasManager?.props ?? {
+    ...DEFAULT_FONT_SETTINGS,
+    ...(props.fontSettings || {})
+  };
+  return {
+    sdf: fontSettings.sdf,
+    threshold: 1 - fontSettings.cutoff,
+    smoothing: Math.max(0, fontSettings.smoothing)
+  };
+}
+
+function createArrowTextDefaultFragmentShaderUniforms(
+  uniforms: Record<string, unknown> | undefined,
+  sdfRenderSettings: TextSdfRenderSettings
+): Record<string, unknown> {
+  const nextUniforms = {...(uniforms || {})};
+  updateArrowTextDefaultFragmentShaderUniforms(nextUniforms, sdfRenderSettings);
+  return nextUniforms;
+}
+
+function updateArrowTextDefaultFragmentShaderUniforms(
+  uniforms: Record<string, unknown>,
+  sdfRenderSettings: TextSdfRenderSettings
+): void {
+  uniforms['textUsesSdf'] = sdfRenderSettings.sdf ? 1 : 0;
+  uniforms['textSdfThreshold'] = sdfRenderSettings.threshold;
+  uniforms['textSdfSmoothing'] = sdfRenderSettings.smoothing;
 }
 
 function assertColumnAvailable(table: arrow.Table, columnName: string): void {
@@ -1543,7 +1855,8 @@ function createStorageTextBatchRowState(
   device: Device,
   props: ArrowStorageTextInputProps,
   batchInput: ResolvedArrowStorageTextBatchInputs,
-  defaultBuffers: StorageTextDefaultBuffers
+  defaultBuffers: StorageTextDefaultBuffers,
+  sdfRenderSettings: TextSdfRenderSettings
 ): StorageTextBatchRowState {
   const packedClipRects = batchInput.clipRects
     ? packStorageTextClipRects(batchInput.clipRects)
@@ -1562,7 +1875,11 @@ function createStorageTextBatchRowState(
   const rowClipRectsBuffer = rowClipRectsVector
     ? getStorageTextGpuVectorBuffer(rowClipRectsVector)
     : defaultBuffers.clipRectsBuffer;
-  const styleConfigData = createStorageTextStyleConfigData(props, batchInput.batchRowIndexBase);
+  const styleConfigData = createStorageTextStyleConfigData(
+    props,
+    batchInput.batchRowIndexBase,
+    sdfRenderSettings
+  );
   const styleConfigBuffer = new DynamicBuffer(device, {
     id: `${props.id || 'storage-text-model'}-style-config-${batchInput.batchRowIndexBase}`,
     usage: Buffer.UNIFORM | Buffer.COPY_DST | Buffer.COPY_SRC,
@@ -1625,7 +1942,13 @@ function refreshArrowStorageTextRowBindings(
   try {
     nextBatches = textInputs.batches.map((batchInput, batchIndex) => {
       const previousBatch = storageState.batches[batchIndex];
-      const rowState = createStorageTextBatchRowState(device, props, batchInput, defaultBuffers);
+      const rowState = createStorageTextBatchRowState(
+        device,
+        props,
+        batchInput,
+        defaultBuffers,
+        storageState.sdfRenderSettings
+      );
       nextOwnedRowBindingResources.push(...rowState.ownedResources);
       rowStorageByteLength += rowState.ownedByteLength;
       return {
@@ -1633,9 +1956,7 @@ function refreshArrowStorageTextRowBindings(
         batchRowIndexBase: previousBatch.batchRowIndexBase,
         rowCount: previousBatch.rowCount,
         glyphCount: previousBatch.glyphCount,
-        generatedGlyphOffsetsBuffer: previousBatch.generatedGlyphOffsetsBuffer,
-        generatedGlyphIndicesBuffer: previousBatch.generatedGlyphIndicesBuffer,
-        generatedRowIndicesBuffer: previousBatch.generatedRowIndicesBuffer
+        compactGlyphVertexData: previousBatch.compactGlyphVertexData
       };
     });
   } catch (error) {
@@ -1682,9 +2003,7 @@ function syncArrowStorageTextStateFirstBatch(storageState: ArrowStorageTextState
   storageState.rowAlignmentBaselinesBuffer = firstBatch.rowAlignmentBaselinesBuffer;
   storageState.rowClipRectsBuffer = firstBatch.rowClipRectsBuffer;
   storageState.styleConfigBuffer = firstBatch.styleConfigBuffer;
-  storageState.generatedGlyphOffsetsBuffer = firstBatch.generatedGlyphOffsetsBuffer;
-  storageState.generatedGlyphIndicesBuffer = firstBatch.generatedGlyphIndicesBuffer;
-  storageState.generatedRowIndicesBuffer = firstBatch.generatedRowIndicesBuffer;
+  storageState.compactGlyphVertexData = firstBatch.compactGlyphVertexData;
 }
 
 function destroyStorageTextResources(resources: StorageTextOwnedResource[]): void {
@@ -1703,7 +2022,8 @@ function replaceOwnedStorageTextResources(
 
 function createStorageTextStyleConfigData(
   props: ArrowStorageTextInputProps,
-  batchRowIndexBase: number
+  batchRowIndexBase: number,
+  sdfRenderSettings: TextSdfRenderSettings
 ): Uint32Array {
   const arrayBuffer = new ArrayBuffer(64);
   const floatValues = new Float32Array(arrayBuffer);
@@ -1723,8 +2043,8 @@ function createStorageTextStyleConfigData(
   uintValues[11] = props.pixelOffsets ? 1 : 0;
   uintValues[12] = props.clipRects ? 1 : 0;
   uintValues[13] = batchRowIndexBase;
-  uintValues[14] = 0;
-  uintValues[15] = 0;
+  floatValues[14] = sdfRenderSettings.sdf ? sdfRenderSettings.threshold : BITMAP_TEXT_SDF_THRESHOLD;
+  floatValues[15] = sdfRenderSettings.smoothing;
   return uintValues;
 }
 

--- a/modules/text/src/text-2d/gpu-text-expansion.ts
+++ b/modules/text/src/text-2d/gpu-text-expansion.ts
@@ -32,9 +32,7 @@ export type GpuUtf8ExpandedInputState = {
 };
 
 export type GpuExpandedGeneratedState = {
-  glyphOffsetsBuffer: Buffer;
-  glyphIndicesBuffer: Buffer;
-  rowIndicesBuffer: Buffer;
+  compactGlyphVertexData: Buffer;
   byteLength: number;
 };
 
@@ -57,11 +55,14 @@ const GPU_EXPANDED_TEXT_COMPUTE_SOURCE = /* wgsl */ `
 @group(0) @binding(1) var<storage, read> textGlyphIds : array<u32>;
 @group(0) @binding(2) var<storage, read> textGlyphMetrics : array<vec2<i32>>;
 @group(0) @binding(3) var<storage, read> textExpansionConfig : array<i32>;
-@group(0) @binding(4) var<storage, read_write> generatedGlyphOffsets : array<u32>;
-@group(0) @binding(5) var<storage, read_write> generatedGlyphIndices : array<u32>;
-@group(0) @binding(6) var<storage, read_write> generatedRowIndices : array<u32>;
-@group(0) @binding(7) var<storage, read> textRowTextAnchors : array<u32>;
-@group(0) @binding(8) var<storage, read> textRowAlignmentBaselines : array<u32>;
+struct GeneratedGlyphVertex {
+  glyphOffsets : u32,
+  glyphIndices : u32,
+  rowIndex : u32,
+}
+@group(0) @binding(4) var<storage, read_write> generatedGlyphVertices : array<GeneratedGlyphVertex>;
+@group(0) @binding(5) var<storage, read> textRowTextAnchors : array<u32>;
+@group(0) @binding(6) var<storage, read> textRowAlignmentBaselines : array<u32>;
 
 fn unpackGlyphId(glyphIndex: u32) -> u32 {
   let word = textGlyphIds[glyphIndex >> 1u];
@@ -130,10 +131,11 @@ fn main(@builtin(global_invocation_id) globalInvocationId: vec3<u32>) {
     if (glyphIndex >= glyphRange.y) { break; }
     let glyphId = unpackGlyphId(glyphIndex);
     let metrics = textGlyphMetrics[glyphId];
-    generatedGlyphOffsets[glyphIndex] =
-      packSignedInt16Pair(width + metrics.x + anchorShift, baselineOffsetY + baselineShift);
-    generatedGlyphIndices[glyphIndex] = glyphId & 0xffffu;
-    generatedRowIndices[glyphIndex] = rowIndex + u32(max(textExpansionConfig[2], 0));
+    generatedGlyphVertices[glyphIndex] = GeneratedGlyphVertex(
+      packSignedInt16Pair(width + metrics.x + anchorShift, baselineOffsetY + baselineShift),
+      glyphId & 0xffffu,
+      rowIndex + u32(max(textExpansionConfig[2], 0))
+    );
     width += metrics.y;
     glyphIndex += 1u;
   }
@@ -146,11 +148,9 @@ const GPU_EXPANDED_TEXT_COMPUTE_SHADER_LAYOUT: ShaderLayout = {
     {name: 'textGlyphIds', type: 'read-only-storage', group: 0, location: 1},
     {name: 'textGlyphMetrics', type: 'read-only-storage', group: 0, location: 2},
     {name: 'textExpansionConfig', type: 'read-only-storage', group: 0, location: 3},
-    {name: 'generatedGlyphOffsets', type: 'storage', group: 0, location: 4},
-    {name: 'generatedGlyphIndices', type: 'storage', group: 0, location: 5},
-    {name: 'generatedRowIndices', type: 'storage', group: 0, location: 6},
-    {name: 'textRowTextAnchors', type: 'read-only-storage', group: 0, location: 7},
-    {name: 'textRowAlignmentBaselines', type: 'read-only-storage', group: 0, location: 8}
+    {name: 'generatedGlyphVertices', type: 'storage', group: 0, location: 4},
+    {name: 'textRowTextAnchors', type: 'read-only-storage', group: 0, location: 5},
+    {name: 'textRowAlignmentBaselines', type: 'read-only-storage', group: 0, location: 6}
   ],
   attributes: []
 };
@@ -166,11 +166,14 @@ const GPU_UTF8_EXPANDED_TEXT_COMPUTE_SOURCE = /* wgsl */ `
 ${getGpuUtf8MapShaderSource(GPU_UTF8_MAP_BINDING_OPTIONS)}
 @group(0) @binding(3) var<storage, read> textGlyphMetrics : array<vec2<i32>>;
 @group(0) @binding(4) var<storage, read> textExpansionConfig : array<i32>;
-@group(0) @binding(5) var<storage, read_write> generatedGlyphOffsets : array<u32>;
-@group(0) @binding(6) var<storage, read_write> generatedGlyphIndices : array<u32>;
-@group(0) @binding(7) var<storage, read_write> generatedRowIndices : array<u32>;
-@group(0) @binding(8) var<storage, read> textRowTextAnchors : array<u32>;
-@group(0) @binding(9) var<storage, read> textRowAlignmentBaselines : array<u32>;
+struct GeneratedGlyphVertex {
+  glyphOffsets : u32,
+  glyphIndices : u32,
+  rowIndex : u32,
+}
+@group(0) @binding(5) var<storage, read_write> generatedGlyphVertices : array<GeneratedGlyphVertex>;
+@group(0) @binding(6) var<storage, read> textRowTextAnchors : array<u32>;
+@group(0) @binding(7) var<storage, read> textRowAlignmentBaselines : array<u32>;
 
 fn packSignedInt16Pair(lowerValue: i32, upperValue: i32) -> u32 {
   return (u32(lowerValue) & 0xffffu) | ((u32(upperValue) & 0xffffu) << 16u);
@@ -239,10 +242,11 @@ fn main(@builtin(global_invocation_id) globalInvocationId: vec3<u32>) {
     if (isGpuUtf8MapCodePointStart(firstByte)) {
       let glyphId = mapGpuUtf8CodePoint(decodeGpuUtf8MapCodePoint(byteIndex));
       let metrics = textGlyphMetrics[glyphId];
-      generatedGlyphOffsets[byteIndex] =
-        packSignedInt16Pair(width + metrics.x + anchorShift, baselineOffsetY + baselineShift);
-      generatedGlyphIndices[byteIndex] = glyphId & 0xffffu;
-      generatedRowIndices[byteIndex] = rowIndex + u32(max(textExpansionConfig[3], 0));
+      generatedGlyphVertices[byteIndex] = GeneratedGlyphVertex(
+        packSignedInt16Pair(width + metrics.x + anchorShift, baselineOffsetY + baselineShift),
+        glyphId & 0xffffu,
+        rowIndex + u32(max(textExpansionConfig[3], 0))
+      );
       width += metrics.y;
     }
     byteIndex += 1u;
@@ -255,11 +259,9 @@ const GPU_UTF8_EXPANDED_TEXT_COMPUTE_SHADER_LAYOUT: ShaderLayout = {
     ...getGpuUtf8MapShaderBindings(GPU_UTF8_MAP_BINDING_OPTIONS),
     {name: 'textGlyphMetrics', type: 'read-only-storage', group: 0, location: 3},
     {name: 'textExpansionConfig', type: 'read-only-storage', group: 0, location: 4},
-    {name: 'generatedGlyphOffsets', type: 'storage', group: 0, location: 5},
-    {name: 'generatedGlyphIndices', type: 'storage', group: 0, location: 6},
-    {name: 'generatedRowIndices', type: 'storage', group: 0, location: 7},
-    {name: 'textRowTextAnchors', type: 'read-only-storage', group: 0, location: 8},
-    {name: 'textRowAlignmentBaselines', type: 'read-only-storage', group: 0, location: 9}
+    {name: 'generatedGlyphVertices', type: 'storage', group: 0, location: 5},
+    {name: 'textRowTextAnchors', type: 'read-only-storage', group: 0, location: 6},
+    {name: 'textRowAlignmentBaselines', type: 'read-only-storage', group: 0, location: 7}
   ],
   attributes: []
 };
@@ -399,23 +401,13 @@ export function createGpuExpandedGeneratedState(
   options: GpuTextExpansionResourceOptions,
   glyphCount: number
 ): GpuExpandedGeneratedState {
-  const outputWordCount = Math.max(glyphCount, 1);
+  const outputRecordCount = Math.max(glyphCount, 1);
   const byteLength = glyphCount * Uint32Array.BYTES_PER_ELEMENT * 3;
   return {
-    glyphOffsetsBuffer: device.createBuffer({
-      id: `${options.id || 'gpu-expanded-text-model'}-generated-glyph-offsets`,
+    compactGlyphVertexData: device.createBuffer({
+      id: `${options.id || 'gpu-expanded-text-model'}-generated-glyph-vertices`,
       usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
-      data: new Uint32Array(outputWordCount)
-    }),
-    glyphIndicesBuffer: device.createBuffer({
-      id: `${options.id || 'gpu-expanded-text-model'}-generated-glyph-indices`,
-      usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
-      data: new Uint32Array(outputWordCount)
-    }),
-    rowIndicesBuffer: device.createBuffer({
-      id: `${options.id || 'gpu-expanded-text-model'}-generated-row-indices`,
-      usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
-      data: new Uint32Array(outputWordCount)
+      data: new Uint32Array(outputRecordCount * 3)
     }),
     byteLength
   };
@@ -444,9 +436,7 @@ export function dispatchGpuExpandedTextCompute(
       textGlyphIds: state.compactInput.glyphIdsBuffer,
       textGlyphMetrics: state.glyphMetrics.buffer,
       textExpansionConfig: state.compactInput.expansionConfigBuffer,
-      generatedGlyphOffsets: state.generated.glyphOffsetsBuffer,
-      generatedGlyphIndices: state.generated.glyphIndicesBuffer,
-      generatedRowIndices: state.generated.rowIndicesBuffer,
+      generatedGlyphVertices: state.generated.compactGlyphVertexData,
       textRowTextAnchors: state.alignment.rowTextAnchorsBuffer,
       textRowAlignmentBaselines: state.alignment.rowAlignmentBaselinesBuffer
     }
@@ -485,9 +475,7 @@ export function dispatchGpuUtf8ExpandedTextCompute(
       textGlyphLookup: state.glyphLookup.buffer,
       textGlyphMetrics: state.glyphMetrics.buffer,
       textExpansionConfig: state.utf8Input.expansionConfigBuffer,
-      generatedGlyphOffsets: state.generated.glyphOffsetsBuffer,
-      generatedGlyphIndices: state.generated.glyphIndicesBuffer,
-      generatedRowIndices: state.generated.rowIndicesBuffer,
+      generatedGlyphVertices: state.generated.compactGlyphVertexData,
       textRowTextAnchors: state.alignment.rowTextAnchorsBuffer,
       textRowAlignmentBaselines: state.alignment.rowAlignmentBaselinesBuffer
     }

--- a/modules/text/test/text-2d/arrow-text-model.spec.ts
+++ b/modules/text/test/text-2d/arrow-text-model.spec.ts
@@ -108,6 +108,79 @@ test('ArrowTextModel derives from ArrowModel and updates glyph instance counts',
   t.end();
 });
 
+test('ArrowTextModel interleaves expanded glyph vertex records', async t => {
+  const device = new NullDevice({});
+  const textProps = makeGpuTextProps(device, ['AB', 'A']);
+  const model = new ArrowTextModel(device, {
+    id: 'arrow-text-model-expanded-glyph-vertices-test',
+    ...textProps,
+    characterMapping: CHARACTER_MAPPING,
+    fontSettings: {fontSize: 10}
+  });
+  const expandedGlyphBytes = await model.expandedGlyphVertexData.readAsync();
+  const expandedGlyphWords = new Uint32Array(
+    expandedGlyphBytes.buffer,
+    expandedGlyphBytes.byteOffset,
+    12
+  );
+  const expandedGlyphLayout = model.bufferLayout.find(
+    layout => layout.name === 'expandedGlyphVertexData'
+  );
+
+  t.equal(expandedGlyphLayout?.byteStride, 16, 'expanded glyph records use a 16-byte stride');
+  t.deepEqual(
+    expandedGlyphLayout?.attributes,
+    [
+      {attribute: 'glyphOffsets', format: 'sint16x2', byteOffset: 0},
+      {attribute: 'glyphFrames', format: 'uint16x4', byteOffset: 4}
+    ],
+    'default render attributes read from the expanded glyph vertex data'
+  );
+  t.deepEqual(
+    Array.from(expandedGlyphWords),
+    [
+      packSignedInt16Pair(2, 5),
+      packUint16Pair(0, 0),
+      packUint16Pair(4, 6),
+      0,
+      packSignedInt16Pair(7, 5),
+      packUint16Pair(4, 0),
+      packUint16Pair(4, 6),
+      0,
+      packSignedInt16Pair(2, 5),
+      packUint16Pair(0, 0),
+      packUint16Pair(4, 6),
+      1
+    ],
+    'expanded glyph records store generated offsets, inline frames, and source row ids'
+  );
+
+  model.destroy();
+  destroyGpuTextProps(textProps);
+  t.end();
+});
+
+test('ArrowTextModel built-in fragment shader decodes SDF atlas alpha', t => {
+  const device = new NullDevice({});
+  const textProps = makeGpuTextProps(device, ['AB', 'A']);
+  const model = new ArrowTextModel(device, {
+    id: 'arrow-text-model-sdf-shader-test',
+    ...textProps,
+    characterMapping: CHARACTER_MAPPING,
+    fontSettings: {fontSize: 10, sdf: true, cutoff: 0.25, smoothing: 0.07}
+  });
+
+  t.ok(
+    model.fs.includes('uniform float textUsesSdf;'),
+    'default shader exposes an SDF mode uniform'
+  );
+  t.ok(model.fs.includes('smoothstep('), 'default shader smooths sampled SDF alpha');
+
+  model.destroy();
+  destroyGpuTextProps(textProps);
+  t.end();
+});
+
 test('ArrowTextModel expands chunked UTF-8 GPUVector data', t => {
   const device = new NullDevice({});
   const firstChunk = arrow.vectorFromArray(['AB'], new arrow.Utf8());
@@ -134,6 +207,99 @@ test('ArrowTextModel expands chunked UTF-8 GPUVector data', t => {
 
   model.destroy();
   destroyGpuTextProps(textProps);
+  t.end();
+});
+
+test('ArrowStorageTextModel packs SDF alpha settings into the style config uniform', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const textProps = makeStorageGpuTextProps(device, ['AB', 'A']);
+  const model = new ArrowStorageTextModel(device, {
+    id: 'arrow-storage-text-sdf-style-config-test',
+    ...textProps,
+    characterMapping: CHARACTER_MAPPING,
+    fontSettings: {fontSize: 10, sdf: true, cutoff: 0.25, smoothing: 0.07}
+  });
+  const styleConfigBytes = await model.styleConfigBuffer.readAsync();
+  const styleConfigFloats = new Float32Array(
+    styleConfigBytes.buffer,
+    styleConfigBytes.byteOffset,
+    styleConfigBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+  );
+
+  t.ok(
+    Math.abs(styleConfigFloats[14] - 0.75) < 1e-6,
+    'style config stores TinySDF alpha edge threshold'
+  );
+  t.ok(
+    Math.abs(styleConfigFloats[15] - 0.07) < 1e-6,
+    'style config stores fragment smoothing width'
+  );
+
+  model.destroy();
+  destroyStorageGpuTextProps(textProps);
+  t.end();
+});
+
+test('ArrowStorageTextModel interleaves compact glyph vertex records', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const textProps = makeStorageGpuTextProps(device, ['AB', 'A']);
+  const model = new ArrowStorageTextModel(device, {
+    id: 'arrow-storage-text-generated-glyph-vertices-test',
+    ...textProps,
+    characterMapping: CHARACTER_MAPPING,
+    fontSettings: {fontSize: 10}
+  });
+  const glyphVertexBytes = await model.compactGlyphVertexData.readAsync();
+  const generatedGlyphVertexWords = new Uint32Array(
+    glyphVertexBytes.buffer,
+    glyphVertexBytes.byteOffset,
+    model.generatedRenderBufferByteLength / Uint32Array.BYTES_PER_ELEMENT
+  );
+  const generatedGlyphVertexLayout = model.bufferLayout.find(
+    layout => layout.name === 'compactGlyphVertexData'
+  );
+
+  t.equal(model.generatedRenderBufferByteLength, 36, 'three glyphs keep the 12-byte record budget');
+  t.equal(generatedGlyphVertexLayout?.byteStride, 12, 'generated records use a 12-byte stride');
+  t.deepEqual(
+    generatedGlyphVertexLayout?.attributes,
+    [
+      {attribute: 'glyphOffsets', format: 'sint16x2', byteOffset: 0},
+      {attribute: 'glyphIndices', format: 'uint16x2', byteOffset: 4},
+      {attribute: 'rowIndices', format: 'uint32', byteOffset: 8}
+    ],
+    'one interleaved buffer exposes the three logical render attributes'
+  );
+  t.deepEqual(
+    Array.from(generatedGlyphVertexWords),
+    [
+      packSignedInt16Pair(2, 5),
+      1,
+      0,
+      packSignedInt16Pair(7, 5),
+      2,
+      0,
+      packSignedInt16Pair(2, 5),
+      1,
+      1
+    ],
+    'generated records store packed offsets, glyph ids, and source row indices in order'
+  );
+
+  model.destroy();
+  destroyStorageGpuTextProps(textProps);
   t.end();
 });
 
@@ -191,16 +357,16 @@ test('ArrowStorageTextModel refreshes row bindings without rebuilding glyph buff
     fontSettings: {fontSize: 10}
   });
   const storageState = model.storageState;
-  const glyphOffsetsBuffer = model.generatedGlyphOffsetsBuffer;
+  const compactGlyphVertexData = model.compactGlyphVertexData;
   const styleConfigBuffer = model.styleConfigBuffer;
 
   model.setProps({color: [255, 0, 0, 255]});
 
   t.equal(model.storageState, storageState, 'row-binding updates preserve storage state');
   t.equal(
-    model.generatedGlyphOffsetsBuffer,
-    glyphOffsetsBuffer,
-    'row-binding updates preserve generated glyph buffers'
+    model.compactGlyphVertexData,
+    compactGlyphVertexData,
+    'row-binding updates preserve compact glyph vertex data'
   );
   t.notEqual(
     model.styleConfigBuffer,
@@ -213,9 +379,9 @@ test('ArrowStorageTextModel refreshes row bindings without rebuilding glyph buff
 
   t.notEqual(model.storageState, storageState, 'text updates replace storage state');
   t.notEqual(
-    model.generatedGlyphOffsetsBuffer,
-    glyphOffsetsBuffer,
-    'text updates rebuild generated glyph buffers'
+    model.compactGlyphVertexData,
+    compactGlyphVertexData,
+    'text updates rebuild compact glyph vertex data'
   );
 
   model.destroy();
@@ -232,14 +398,12 @@ function makeLabelTable(): arrow.Table {
 
 function makeGpuTextProps(device: NullDevice, labels: string[]) {
   return {
-    labelVectors: {
-      positions: new GPUVector({
-        type: 'arrow',
-        name: 'positions',
-        device,
-        vector: makeArrowFixedSizeListVector(new arrow.Float32(), 2, new Float32Array([0, 0, 1, 1]))
-      })
-    },
+    positions: new GPUVector({
+      type: 'arrow',
+      name: 'positions',
+      device,
+      vector: makeArrowFixedSizeListVector(new arrow.Float32(), 2, new Float32Array([0, 0, 1, 1]))
+    }),
     texts: makeGpuTexts(device, labels)
   };
 }
@@ -254,7 +418,7 @@ function makeGpuTexts(device: NullDevice, labels: string[]): GPUVector<arrow.Utf
 }
 
 function destroyGpuTextProps(props: ReturnType<typeof makeGpuTextProps>): void {
-  props.labelVectors.positions.destroy();
+  props.positions.destroy();
   props.texts.destroy();
 }
 
@@ -277,6 +441,14 @@ function destroyStorageGpuTextProps(props: ReturnType<typeof makeStorageGpuTextP
 
 function unpackSignedInt16Pair(word: number): [number, number] {
   return [toSignedInt16(word & 0xffff), toSignedInt16((word >>> 16) & 0xffff)];
+}
+
+function packSignedInt16Pair(lowerValue: number, upperValue: number): number {
+  return ((lowerValue & 0xffff) | ((upperValue & 0xffff) << 16)) >>> 0;
+}
+
+function packUint16Pair(lowerValue: number, upperValue: number): number {
+  return ((lowerValue & 0xffff) | ((upperValue & 0xffff) << 16)) >>> 0;
 }
 
 function toSignedInt16(value: number): number {

--- a/modules/text/text-3d.md
+++ b/modules/text/text-3d.md
@@ -1,0 +1,23 @@
+# @luma.gl/text/text-3d
+
+3D text geometry helpers are exposed from the dedicated `@luma.gl/text/text-3d` entry point.
+
+```ts
+import {TextGeometry, parseFont} from '@luma.gl/text/text-3d'
+import helvetiker from './fonts/helvetiker_regular.typeface.json'
+
+const font = parseFont(helvetiker)
+const geometry = new TextGeometry('Hello luma.gl', {
+  font,
+  align: 'center',
+  size: 24,
+  depth: 4,
+  curveSegments: 8,
+  bevelEnabled: true,
+  bevelThickness: 1,
+  bevelSize: 0.5,
+  bevelSegments: 2
+})
+```
+
+The resulting `TextGeometry` exposes position, normal, and UV attributes ready for consumption by luma.gl models.


### PR DESCRIPTION
## Goals

- Reduce GPU buffer and binding pressure in the text rendering paths, especially the WebGPU storage model.
- Make `ArrowTextModel` input props explicit and consistent with the storage model.
- Keep caller-owned row/style vectors separate from model-generated per-glyph render data.
- Move SDF interpretation into the built-in text model shaders instead of leaving it to examples.
- Improve Arrow helper ergonomics and refresh the related docs/examples.

## Changes

### Text model API and render data

- Removed `ArrowTextModel.labelVectors` with no compatibility path.
- `ArrowTextModel` now takes top-level row vectors directly:
  - `positions`
  - `texts`
  - optional `colors`, `angles`, `sizes`, `pixelOffsets`, `clipRects`
- Added explicit type and row-alignment validation for top-level text vectors.
- Kept storage-only row inputs explicit on `ArrowStorageTextModel`, including `textAnchors` and `alignmentBaselines`.

### Generated glyph packing

- Added model-owned `expandedGlyphVertexData` for the attribute path.
  - Interleaves generated glyph offsets, inline glyph frames, and source row ids.
  - Uses a 16-byte record per glyph, with optional generated clip rect data adding 8 bytes per glyph.
- Replaced the storage path’s three generated glyph buffers with one interleaved `compactGlyphVertexData`.
  - Packs glyph offsets, glyph ids, and row ids into one 12-byte per-glyph record.
  - Compute expansion shaders now write one generated glyph vertex record buffer instead of three separate output buffers.
- Updated storage text draw bindings, reusable storage state, picking/example code, and tests to use the new interleaved glyph data buffers.
- Preserved user-supplied row/style vectors as separate zero-copy bindings rather than folding them into generated glyph data.

### Rebuild and refresh behavior

- Split storage text “layout rebuild” from lighter-weight row/render-state refreshes.
- Style-only updates now refresh row bindings/style config while preserving generated glyph vertex data.
- Text/layout changes still rebuild generated glyph state.

### SDF handling

- Moved built-in SDF alpha interpretation into the text model shaders.
- `ArrowTextModel` and `ArrowStorageTextModel` now honor SDF-related font settings through the built-in shader path.
- Storage style config now carries SDF threshold/smoothing state.

### Arrow helper ergonomics

- Added exported `makeArrowVectorFromArray(...)`.
  - Supports standard scalar Arrow vectors.
  - Supports compact flat-array creation of numeric `FixedSizeList` vectors.
- `GPUVector` Arrow-object construction now infers Arrow mode from `{device, name, vector}` without requiring `type: 'arrow'`.
- Updated examples, docs, and tests to use the simplified constructor form.

### Documentation

- Expanded text module docs with:
  - input-vector comparison tables
  - draw-buffer usage tables
  - explicit notes on `expandedGlyphVertexData` vs `compactGlyphVertexData`
- Moved 3D text usage into a dedicated `modules/text/text-3d.md` page and kept the main text README focused on Arrow-native 2D text.
- Updated release notes and upgrade guidance:
  - documented the `labelVectors` removal
  - documented the new generated glyph buffer packing direction
- Updated `AGENTS.md` so “get ready for merge” requires a copyable Markdown summary against `master`.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test-node`
- `yarn test-headless`
- `yarn website:build`

All completed successfully.

## Notes

- This is intentionally a Phase 1 packing/API cleanup, not a full typography/layout expansion.
- Multiline layout, wrapping, richer text shaping, and deeper glyph compression remain follow-up work.