### PR TITLE
feat(arrow) WebGL transform handles Vectors and writeback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@
 ## Before committing
 - Format code: `yarn lint fix`
 - Always `yarn lint fix` after making changes to ensure that Biome formatting is maintained.
+
+## Merge preparation
+- When asked to "get ready for merge", create a copyable Markdown description of the changes versus `master`.
+- Start that Markdown description with `Goals` and `Changes` sections, then include verification, risks, follow-up notes, or other merge-relevant sections when useful.
  
 ## Code style
 - TypeScript strict mode

--- a/docs/api-guide/gpu/arrow-table-columns.md
+++ b/docs/api-guide/gpu/arrow-table-columns.md
@@ -537,7 +537,8 @@ const model = new ArrowModel(device, {
 
 `TableTransform` is the WebGL transform-feedback counterpart. It converts an
 Arrow table to a `GPUTable` when needed, merges the table attribute layouts into
-the underlying `BufferTransform`, and can run one preserved GPU batch at a time:
+the underlying `BufferTransform`, accepts already-created `GPUVector` inputs,
+and can run one preserved GPU batch at a time:
 
 ```ts
 const transform = new TableTransform(device, {
@@ -553,6 +554,29 @@ transform.runBatches({
 });
 ```
 
+For a compute-like update path, pass `inputVectors` plus
+`copyOutputToInputVectors`. `outputs` is inferred from the copy map when it is
+omitted:
+
+```ts
+const transform = new TableTransform(device, {
+  vs,
+  shaderLayout,
+  inputVectors: {
+    particlePositions,
+    particleVelocities
+  },
+  copyOutputToInputVectors: {
+    nextParticlePositions: 'particlePositions',
+    nextParticleVelocities: 'particleVelocities'
+  }
+});
+```
+
+Transform feedback writes a dense output stream, so automatic copy-back targets
+tightly packed, directly bindable GPUVectors. It can not scatter-copy into
+padded or interleaved rows.
+
 Use `TableTransform` only for attribute-backed WebGL transform feedback. It is
 not a storage-buffer compute abstraction.
 
@@ -560,7 +584,7 @@ Relevant public types:
 
 | Type | Meaning |
 | --- | --- |
-| `TableTransformProps` | Construction props, including `table`, `arrowTable`, `arrowPaths`, `arrowBufferProps`, and `tableCount`. |
+| `TableTransformProps` | Construction props, including `table`, `arrowTable`, `inputVectors`, `copyOutputToInputVectors`, `arrowPaths`, `arrowBufferProps`, and `tableCount`. |
 | `TableTransformBatchOptions` | `runBatches()` options, including fixed or per-batch `outputBuffers`. |
 
 ### `TableComputation`
@@ -572,7 +596,7 @@ storage bindings. Supply `GPUVector` objects by binding name:
 const computation = new TableComputation(device, {
   source: computeShader,
   shaderLayout: computeShaderLayout,
-  vectorBindings: {
+  inputVectors: {
     particlePositions,
     particleVelocities
   }
@@ -587,7 +611,7 @@ Relevant public types:
 
 | Type | Meaning |
 | --- | --- |
-| `TableComputationProps` | Construction props, including ordinary `bindings` plus `vectorBindings`. |
+| `TableComputationProps` | Construction props, including ordinary `bindings` plus `inputVectors`. |
 | `TableComputationBatch` | Batch metadata passed to a dynamic workgroup-count callback. |
 
 ## Mesh Arrow Geometry

--- a/docs/api-guide/gpu/gpu-storage-buffers.md
+++ b/docs/api-guide/gpu/gpu-storage-buffers.md
@@ -104,7 +104,7 @@ For table vectors, use `TableComputation` when storage bindings should come from
 const computation = new TableComputation(device, {
   source: computeShader,
   shaderLayout,
-  vectorBindings: {
+  inputVectors: {
     particlePositions,
     particleVelocities
   }

--- a/docs/api-reference/engine/picking-manager.md
+++ b/docs/api-reference/engine/picking-manager.md
@@ -12,7 +12,8 @@ import {Model, PickingManager, ShaderInputs, picking} from '@luma.gl/engine';
 const shaderInputs = new ShaderInputs({picking});
 const pickingManager = new PickingManager(device, {
   shaderInputs,
-  mode: 'auto'
+  mode: 'auto',
+  getTooltip: ({objectIndex}) => (objectIndex === null ? null : `row ${objectIndex}`)
 });
 
 const pickingPass = pickingManager.beginRenderPass();
@@ -33,6 +34,12 @@ export type PickInfo = {
 };
 ```
 
+### `PickingTooltip`
+
+```ts
+export type PickingTooltip = string | null;
+```
+
 ### `PickingMode`
 
 ```ts
@@ -50,9 +57,13 @@ export type PickingMode = 'auto' | 'index' | 'color';
 export type PickingManagerProps = {
   shaderInputs?: ShaderInputs<{picking: typeof pickingUniforms.props}>;
   onObjectPicked?: (info: PickInfo) => void;
+  getTooltip?: (info: PickInfo) => PickingTooltip;
   mode?: PickingMode;
 };
 ```
+
+- `getTooltip` returns plain tooltip text for the latest picked row/object. Returning `null` hides the tooltip.
+- The tooltip is positioned beside the latest mouse position within the active canvas container.
 
 ### `supportsIndexPicking(device: Device): boolean`
 
@@ -100,7 +111,7 @@ When the backend is:
 
 ### `updatePickInfo(mousePosition: [number, number]): Promise<PickInfo | null>`
 
-Reads back one picked pixel, updates shader inputs, and calls `onObjectPicked` when the pick result changes.
+Reads back one picked pixel, updates shader inputs, calls `onObjectPicked` when the pick result changes, and refreshes the tooltip when `getTooltip` is provided.
 
 ### `getPickPosition(mousePosition: [number, number]): [number, number]`
 
@@ -109,6 +120,7 @@ Converts CSS pixel mouse coordinates into device-pixel picking coordinates.
 ## Remarks
 
 - `PickingManager` only manages the framebuffer and readback flow. Your model shaders still need to use a compatible picking module.
+- `getTooltip` is intentionally a formatting callback. Table-aware row lookup belongs with the caller so engine picking does not depend on Arrow or another columnar-data container.
 - Use `picking` when you want the engine to select the appropriate shader path for GLSL/WebGL vs WGSL/WebGPU.
 - Use `colorPicking` when you explicitly want the color-encoded path.
 - Use `indexPicking` when you explicitly want the integer render-target path.

--- a/examples/gpu-tables/arrow-mesh-geometry/app.ts
+++ b/examples/gpu-tables/arrow-mesh-geometry/app.ts
@@ -9,9 +9,18 @@ import {
   makeArrowFixedSizeListVector,
   type ArrowMeshTable
 } from '@luma.gl/arrow';
-import type {ShaderLayout} from '@luma.gl/core';
+import type {Device, ShaderLayout} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
-import {AnimationLoopTemplate, CubeGeometry, ShaderInputs} from '@luma.gl/engine';
+import {
+  AnimationLoopTemplate,
+  CubeGeometry,
+  Model,
+  PickingManager,
+  ShaderInputs,
+  indexColorPicking,
+  indexPicking,
+  supportsIndexPicking
+} from '@luma.gl/engine';
 import type {ShaderModule} from '@luma.gl/shadertools';
 import {Matrix4, radians} from '@math.gl/core';
 import * as arrow from 'apache-arrow';
@@ -19,6 +28,8 @@ import * as arrow from 'apache-arrow';
 export const title = 'Arrow Mesh Geometry';
 export const description =
   'CubeGeometry face ids routed through Mesh Arrow data and rendered by ArrowModel.';
+
+const FACE_NAMES = ['Front', 'Back', 'Top', 'Bottom', 'Right', 'Left'] as const;
 
 const WGSL_SHADER = /* wgsl */ `\
 struct AppUniforms {
@@ -38,6 +49,13 @@ struct VertexInputs {
 struct FragmentInputs {
   @builtin(position) Position : vec4<f32>,
   @location(0) color : vec4<f32>,
+  @interpolate(flat)
+  @location(1) objectIndex : i32,
+};
+
+struct PickingFragmentOutputs {
+  @location(0) fragColor : vec4<f32>,
+  @location(1) pickingColor : vec2<i32>,
 };
 
 @vertex
@@ -49,12 +67,21 @@ fn vertexMain(inputs : VertexInputs) -> FragmentInputs {
     app.modelMatrix *
     vec4<f32>(inputs.positions, 1.0);
   outputs.color = faceColors[inputs.faceIndex];
+  outputs.objectIndex = i32(inputs.faceIndex);
   return outputs;
 }
 
 @fragment
 fn fragmentMain(inputs : FragmentInputs) -> @location(0) vec4<f32> {
-  return inputs.color;
+  return picking_filterHighlightColor(inputs.color, inputs.objectIndex);
+}
+
+@fragment
+fn fragmentPicking(inputs : FragmentInputs) -> PickingFragmentOutputs {
+  var outputs : PickingFragmentOutputs;
+  outputs.fragColor = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+  outputs.pickingColor = picking_getPickingColor(inputs.objectIndex);
+  return outputs;
 }
 `;
 
@@ -70,6 +97,7 @@ uniform appUniforms {
 
 in vec3 positions;
 in vec4 colors;
+in uint faceIndices;
 
 out vec4 vColor;
 
@@ -80,6 +108,7 @@ void main(void) {
     app.modelMatrix *
     vec4(positions, 1.0);
   vColor = colors;
+  picking_setObjectIndex(int(faceIndices));
 }
 `;
 
@@ -91,7 +120,21 @@ in vec4 vColor;
 out vec4 fragColor;
 
 void main(void) {
-  fragColor = vColor;
+  fragColor = picking_filterColor(vColor);
+}
+`;
+
+const PICKING_FS_GLSL = /* glsl */ `\
+#version 300 es
+precision highp float;
+precision highp int;
+
+layout(location = 0) out vec4 fragColor;
+layout(location = 1) out ivec4 pickingColor;
+
+void main(void) {
+  fragColor = vec4(0.0);
+  pickingColor = picking_getPickingColor();
 }
 `;
 
@@ -121,7 +164,8 @@ const WEBGPU_MESH_SHADER_LAYOUT = {
 const WEBGL_MESH_SHADER_LAYOUT = {
   attributes: [
     {name: 'positions', location: 0, type: 'vec3<f32>'},
-    {name: 'colors', location: 1, type: 'vec4<f32>'}
+    {name: 'colors', location: 1, type: 'vec4<f32>'},
+    {name: 'faceIndices', location: 2, type: 'u32'}
   ],
   bindings: []
 } satisfies ShaderLayout;
@@ -131,14 +175,28 @@ export default class ArrowMeshGeometryAnimationLoopTemplate extends AnimationLoo
 <p>Builds indexed Mesh Arrow data from <code>CubeGeometry</code> face ids and renders it through <code>ArrowModel</code>.</p>
 `;
 
+  readonly device: Device;
   readonly model: ArrowModel;
+  readonly pickingModel: Model | null;
+  readonly picker: PickingManager;
   readonly faceColors?: GPUVector<arrow.FixedSizeList<arrow.Float32>>;
-  readonly shaderInputs = new ShaderInputs<{app: typeof app.props}>({app});
+  readonly faceNames: arrow.Vector<arrow.Utf8>;
+  readonly shaderInputs = new ShaderInputs<{
+    app: typeof app.props;
+    picking: typeof indexPicking.props;
+  }>({app, picking: indexPicking});
 
   constructor({device}: AnimationProps) {
     super();
+    this.device = device;
+    this.shaderInputs.setProps({picking: {indexMode: 'attribute', batchIndex: 0}});
 
-    const faceColors = makeFaceColorVector();
+    const faceMetadata = makeFaceMetadataTable();
+    const faceColors = faceMetadata.getChild('COLOR_0') as arrow.Vector<
+      arrow.FixedSizeList<arrow.Float32>
+    >;
+    const arrowMesh = makeArrowMeshTable(device.type, faceColors);
+    this.faceNames = faceMetadata.getChild('name') as arrow.Vector<arrow.Utf8>;
     this.faceColors =
       device.type === 'webgpu'
         ? new GPUVector({
@@ -150,21 +208,34 @@ export default class ArrowMeshGeometryAnimationLoopTemplate extends AnimationLoo
 
     this.model = new ArrowModel(device, {
       id: 'arrow-mesh-geometry',
-      arrowMesh: makeArrowMeshTable(device.type, faceColors),
+      arrowMesh,
       source: WGSL_SHADER,
       vs: VS_GLSL,
       fs: FS_GLSL,
       shaderLayout: device.type === 'webgpu' ? WEBGPU_MESH_SHADER_LAYOUT : WEBGL_MESH_SHADER_LAYOUT,
       shaderInputs: this.shaderInputs,
+      modules: [supportsIndexPicking(device) ? indexPicking : indexColorPicking] as ShaderModule[],
       ...(this.faceColors ? {bindings: {faceColors: this.faceColors.buffer}} : {}),
       parameters: {
         depthWriteEnabled: true,
         depthCompare: 'less-equal'
       }
     });
+    this.pickingModel = supportsIndexPicking(device) ? this.createPickingModel() : null;
+    this.picker = new PickingManager(device, {
+      shaderInputs: this.shaderInputs,
+      mode: 'auto',
+      getTooltip: ({batchIndex, objectIndex}) => {
+        if (batchIndex === null || objectIndex === null) {
+          return null;
+        }
+        const faceName = this.faceNames.get(objectIndex);
+        return typeof faceName === 'string' ? `${faceName} face` : null;
+      }
+    });
   }
 
-  onRender({aspect, device, tick}: AnimationProps): void {
+  onRender({aspect, device, tick, _mousePosition}: AnimationProps): void {
     this.shaderInputs.setProps({
       app: {
         modelMatrix: new Matrix4().rotateX(tick * 0.01).rotateY(tick * 0.013),
@@ -177,6 +248,7 @@ export default class ArrowMeshGeometryAnimationLoopTemplate extends AnimationLoo
         })
       }
     });
+    this.shaderInputs.setProps({picking: {isActive: false, batchIndex: 0}});
 
     const renderPass = device.beginRenderPass({
       clearColor: [0.03, 0.04, 0.08, 1],
@@ -184,11 +256,57 @@ export default class ArrowMeshGeometryAnimationLoopTemplate extends AnimationLoo
     });
     this.model.draw(renderPass);
     renderPass.end();
+    this.pickFace(_mousePosition);
   }
 
   onFinalize(): void {
+    this.picker.destroy();
+    this.pickingModel?.destroy();
     this.model.destroy();
     this.faceColors?.destroy();
+  }
+
+  pickFace(mousePosition: number[] | null | undefined): void {
+    if (!this.picker.shouldPick(mousePosition as [number, number] | null)) {
+      return;
+    }
+
+    const pickingPass = this.picker.beginRenderPass();
+    this.shaderInputs.setProps({picking: {batchIndex: 0}});
+    (this.pickingModel ?? this.model).draw(pickingPass);
+    pickingPass.end();
+    this.shaderInputs.setProps({picking: {isActive: false}});
+    void this.picker.updatePickInfo(mousePosition as [number, number]);
+  }
+
+  createPickingModel(): Model {
+    const arrowGeometry = this.model.arrowGeometry;
+    if (!arrowGeometry) {
+      throw new Error('Arrow Mesh Geometry picking requires mesh GPU geometry');
+    }
+
+    return new Model(this.device, {
+      id: `${this.model.id || 'arrow-mesh-geometry'}-picking`,
+      source: WGSL_SHADER,
+      vs: VS_GLSL,
+      fs: PICKING_FS_GLSL,
+      fragmentEntryPoint: 'fragmentPicking',
+      modules: [indexPicking] as ShaderModule[],
+      shaderLayout:
+        this.device.type === 'webgpu' ? WEBGPU_MESH_SHADER_LAYOUT : WEBGL_MESH_SHADER_LAYOUT,
+      bufferLayout: arrowGeometry.bufferLayout,
+      attributes: arrowGeometry.attributes,
+      bindings: {...this.model.bindings},
+      vertexCount: arrowGeometry.vertexCount,
+      indexBuffer: arrowGeometry.indices || null,
+      shaderInputs: this.shaderInputs,
+      colorAttachmentFormats: ['rgba8unorm', 'rg32sint'],
+      depthStencilAttachmentFormat: 'depth24plus',
+      parameters: {
+        depthWriteEnabled: true,
+        depthCompare: 'less-equal'
+      }
+    });
   }
 }
 
@@ -215,7 +333,11 @@ function makeArrowMeshTable(
   const table =
     deviceType === 'webgpu'
       ? makeWebGPUMeshTable(positions, cubeFaceIndices)
-      : makeWebGLMeshTable(positions, expandArrowVector(faceColors, cubeFaceIndices));
+      : makeWebGLMeshTable(
+          positions,
+          expandArrowVector(faceColors, cubeFaceIndices),
+          cubeFaceIndices
+        );
 
   return {
     shape: 'arrow-table',
@@ -249,7 +371,8 @@ function makeWebGPUMeshTable(
 
 function makeWebGLMeshTable(
   positions: arrow.Vector<arrow.FixedSizeList<arrow.Float32>>,
-  colors: arrow.Vector<arrow.FixedSizeList<arrow.Float32>>
+  colors: arrow.Vector<arrow.FixedSizeList<arrow.Float32>>,
+  faceIndices: Uint32Array
 ): arrow.Table {
   const schema = new arrow.Schema([
     new arrow.Field(
@@ -261,22 +384,36 @@ function makeWebGLMeshTable(
       'COLOR_0',
       new arrow.FixedSizeList(4, new arrow.Field('value', new arrow.Float32(), false)),
       false
-    )
+    ),
+    new arrow.Field('faceIndices', new arrow.Uint32(), false)
   ]);
 
   return new arrow.Table(schema, {
     POSITION: positions,
-    COLOR_0: colors
+    COLOR_0: colors,
+    faceIndices: arrow.makeVector(faceIndices)
   });
 }
 
-function makeFaceColorVector(): arrow.Vector<arrow.FixedSizeList<arrow.Float32>> {
-  return makeArrowFixedSizeListVector(
-    new arrow.Float32(),
-    4,
-    new Float32Array([
-      1.0, 0.32, 0.32, 1.0, 1.0, 0.67, 0.3, 1.0, 0.98, 0.9, 0.36, 1.0, 0.46, 0.84, 0.42, 1.0, 0.28,
-      0.77, 1.0, 1.0, 0.58, 0.47, 1.0, 1.0
-    ])
-  );
+function makeFaceMetadataTable(): arrow.Table {
+  const schema = new arrow.Schema([
+    new arrow.Field('name', new arrow.Utf8(), false),
+    new arrow.Field(
+      'COLOR_0',
+      new arrow.FixedSizeList(4, new arrow.Field('value', new arrow.Float32(), false)),
+      false
+    )
+  ]);
+
+  return new arrow.Table(schema, {
+    name: arrow.vectorFromArray(FACE_NAMES, new arrow.Utf8()),
+    COLOR_0: makeArrowFixedSizeListVector(
+      new arrow.Float32(),
+      4,
+      new Float32Array([
+        1.0, 0.32, 0.32, 1.0, 1.0, 0.67, 0.3, 1.0, 0.98, 0.9, 0.36, 1.0, 0.46, 0.84, 0.42, 1.0,
+        0.28, 0.77, 1.0, 1.0, 0.58, 0.47, 1.0, 1.0
+      ])
+    )
+  });
 }

--- a/examples/gpu-tables/gpu-vector-storage-particles/app.ts
+++ b/examples/gpu-tables/gpu-vector-storage-particles/app.ts
@@ -2,20 +2,25 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {GPUVector, TableComputation, makeArrowFixedSizeListVector} from '@luma.gl/arrow';
+import {
+  GPUVector,
+  TableComputation,
+  TableTransform,
+  makeArrowFixedSizeListVector
+} from '@luma.gl/arrow';
 import type {ComputeShaderLayout, ShaderLayout} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Model} from '@luma.gl/engine';
 import * as arrow from 'apache-arrow';
 
-export const title = 'GPUVector Storage Particles';
+export const title = 'Arrow Particles';
 export const description =
-  'Arrow-created GPUVectors updated through WebGPU storage-buffer compute.';
+  'Arrow-created GPUVectors updated through storage compute or transform feedback.';
 
 const PARTICLE_COUNT = 4096;
 const WORKGROUP_SIZE = 64;
 const PARTICLE_SIZE = 0.014;
-const RESET_INTERVAL_MILLISECONDS = 15_000;
+const RESET_INTERVAL_MILLISECONDS = 8_000;
 
 const COMPUTE_SHADER = /* wgsl */ `\
 @group(0) @binding(0) var<storage, read_write> particlePositions : array<vec2<f32>>;
@@ -47,7 +52,7 @@ fn computeMain(@builtin(global_invocation_id) globalInvocationId : vec3<u32>) {
 }
 `;
 
-const RENDER_SHADER = /* wgsl */ `\
+const WEBGPU_RENDER_SHADER = /* wgsl */ `\
 @group(0) @binding(0) var<storage, read> particlePositions : array<vec2<f32>>;
 
 struct VertexInputs {
@@ -87,6 +92,71 @@ fn fragmentMain(inputs : FragmentInputs) -> @location(0) vec4<f32> {
 }
 `;
 
+const WEBGL_TRANSFORM_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+in vec2 particlePositions;
+in vec2 particleVelocities;
+out vec2 nextParticlePositions;
+out vec2 nextParticleVelocities;
+
+void main() {
+  vec2 position = particlePositions + particleVelocities;
+  vec2 velocity = particleVelocities;
+
+  if (position.x < -0.98 || position.x > 0.98) {
+    velocity.x = -velocity.x;
+    position.x = clamp(position.x, -0.98, 0.98);
+  }
+
+  if (position.y < -0.98 || position.y > 0.98) {
+    velocity.y = -velocity.y;
+    position.y = clamp(position.y, -0.98, 0.98);
+  }
+
+  nextParticlePositions = position;
+  nextParticleVelocities = velocity;
+}
+`;
+
+const WEBGL_RENDER_VERTEX_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+precision highp int;
+
+in vec2 particlePositions;
+out vec3 vColor;
+
+vec2 getQuadCorner(int vertexIndex) {
+  if (vertexIndex == 0) { return vec2(-1.0, -1.0); }
+  if (vertexIndex == 1) { return vec2(1.0, -1.0); }
+  if (vertexIndex == 2) { return vec2(1.0, 1.0); }
+  if (vertexIndex == 3) { return vec2(-1.0, -1.0); }
+  if (vertexIndex == 4) { return vec2(1.0, 1.0); }
+  return vec2(-1.0, 1.0);
+}
+
+void main() {
+  vec2 corner = getQuadCorner(gl_VertexID % 6) * ${PARTICLE_SIZE};
+  float colorPhase = float(gl_InstanceID % 11) / 10.0;
+  gl_Position = vec4(particlePositions + corner, 0.0, 1.0);
+  vColor = vec3(0.25 + colorPhase * 0.7, 0.92 - colorPhase * 0.48, 1.0);
+}
+`;
+
+const WEBGL_RENDER_FRAGMENT_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+in vec3 vColor;
+out vec4 fragColor;
+
+void main() {
+  fragColor = vec4(vColor, 1.0);
+}
+`;
+
 const COMPUTE_SHADER_LAYOUT = {
   bindings: [
     {name: 'particlePositions', type: 'storage', group: 0, location: 0},
@@ -99,24 +169,38 @@ const RENDER_SHADER_LAYOUT = {
   bindings: [{name: 'particlePositions', type: 'read-only-storage', group: 0, location: 0}]
 } satisfies ShaderLayout;
 
+const WEBGL_TRANSFORM_SHADER_LAYOUT = {
+  attributes: [
+    {name: 'particlePositions', location: 0, type: 'vec2<f32>'},
+    {name: 'particleVelocities', location: 1, type: 'vec2<f32>'}
+  ],
+  bindings: []
+} satisfies ShaderLayout;
+
+const WEBGL_RENDER_SHADER_LAYOUT = {
+  attributes: [{name: 'particlePositions', location: 0, type: 'vec2<f32>', stepMode: 'instance'}],
+  bindings: []
+} satisfies ShaderLayout;
+
 export default class GPUVectorStorageParticlesAnimationLoopTemplate extends AnimationLoopTemplate {
   static info = `
-<p>Builds Arrow vectors once, uploads them through <code>GPUVector</code>, then updates and renders them from WebGPU storage buffers.</p>
+<p>Builds Arrow vectors once, uploads them through <code>GPUVector</code>, then updates them with storage compute on WebGPU or transform feedback on WebGL.</p>
 `;
 
   readonly positionVector: GPUVector<arrow.FixedSizeList<arrow.Float32>>;
   readonly velocityVector: GPUVector<arrow.FixedSizeList<arrow.Float32>>;
   readonly initialPositions: Float32Array;
   readonly initialVelocities: Float32Array;
-  readonly computation: TableComputation;
+  readonly computation?: TableComputation;
+  readonly transform?: TableTransform;
   readonly model: Model;
   private lastResetTime = 0;
 
   constructor({device}: AnimationProps) {
     super();
 
-    if (device.type !== 'webgpu') {
-      throw new Error('GPUVector Storage Particles requires WebGPU');
+    if (device.type !== 'webgpu' && device.type !== 'webgl') {
+      throw new Error('Arrow Particles requires WebGPU or WebGL2');
     }
 
     const particleVectors = makeParticleVectors(device);
@@ -125,24 +209,56 @@ export default class GPUVectorStorageParticlesAnimationLoopTemplate extends Anim
     this.initialPositions = particleVectors.initialPositions;
     this.initialVelocities = particleVectors.initialVelocities;
 
-    this.computation = new TableComputation(device, {
-      id: 'gpu-vector-storage-particles-compute',
-      source: COMPUTE_SHADER,
-      shaderLayout: COMPUTE_SHADER_LAYOUT,
-      vectorBindings: {
+    if (device.type === 'webgpu') {
+      this.computation = new TableComputation(device, {
+        id: 'gpu-vector-storage-particles-compute',
+        source: COMPUTE_SHADER,
+        shaderLayout: COMPUTE_SHADER_LAYOUT,
+        inputVectors: {
+          particlePositions: this.positionVector,
+          particleVelocities: this.velocityVector
+        }
+      });
+
+      this.model = new Model(device, {
+        id: 'gpu-vector-storage-particles-render',
+        source: WEBGPU_RENDER_SHADER,
+        shaderLayout: RENDER_SHADER_LAYOUT,
+        bindings: {
+          particlePositions: this.positionVector.buffer
+        },
+        topology: 'triangle-list',
+        vertexCount: 6,
+        instanceCount: PARTICLE_COUNT
+      });
+      return;
+    }
+
+    this.transform = new TableTransform(device, {
+      id: 'gpu-vector-storage-particles-transform',
+      vs: WEBGL_TRANSFORM_SHADER,
+      shaderLayout: WEBGL_TRANSFORM_SHADER_LAYOUT,
+      inputVectors: {
         particlePositions: this.positionVector,
         particleVelocities: this.velocityVector
+      },
+      copyOutputToInputVectors: {
+        nextParticlePositions: 'particlePositions',
+        nextParticleVelocities: 'particleVelocities'
       }
     });
 
     this.model = new Model(device, {
       id: 'gpu-vector-storage-particles-render',
-      source: RENDER_SHADER,
-      shaderLayout: RENDER_SHADER_LAYOUT,
-      bindings: {
+      vs: WEBGL_RENDER_VERTEX_SHADER,
+      fs: WEBGL_RENDER_FRAGMENT_SHADER,
+      shaderLayout: WEBGL_RENDER_SHADER_LAYOUT,
+      attributes: {
         particlePositions: this.positionVector.buffer
       },
+      bufferLayout: [{name: 'particlePositions', format: 'float32x2', stepMode: 'instance'}],
       topology: 'triangle-list',
+      isInstanced: true,
       vertexCount: 6,
       instanceCount: PARTICLE_COUNT
     });
@@ -155,11 +271,15 @@ export default class GPUVectorStorageParticlesAnimationLoopTemplate extends Anim
       this.lastResetTime = time;
     }
 
-    const computePass = device.beginComputePass({});
-    this.computation.dispatchBatches(computePass, batch =>
-      Math.ceil(batch.numRows / WORKGROUP_SIZE)
-    );
-    computePass.end();
+    if (this.computation) {
+      const computePass = device.beginComputePass({});
+      this.computation.dispatchBatches(computePass, batch =>
+        Math.ceil(batch.numRows / WORKGROUP_SIZE)
+      );
+      computePass.end();
+    } else {
+      this.transform?.run();
+    }
 
     const renderPass = device.beginRenderPass({
       clearColor: [0.01, 0.02, 0.05, 1]
@@ -170,7 +290,8 @@ export default class GPUVectorStorageParticlesAnimationLoopTemplate extends Anim
 
   onFinalize(): void {
     this.model.destroy();
-    this.computation.destroy();
+    this.computation?.destroy();
+    this.transform?.destroy();
     this.positionVector.destroy();
     this.velocityVector.destroy();
   }

--- a/examples/gpu-tables/gpu-vector-storage-particles/index.html
+++ b/examples/gpu-tables/gpu-vector-storage-particles/index.html
@@ -1,11 +1,12 @@
 <!doctype html>
 <script type="module">
   import {makeAnimationLoop} from '@luma.gl/engine';
+  import {webgl2Adapter} from '@luma.gl/webgl';
   import {webgpuAdapter} from '@luma.gl/webgpu';
   import AnimationLoopTemplate from './app.ts';
 
   const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-    adapters: [webgpuAdapter]
+    adapters: [webgl2Adapter, webgpuAdapter]
   });
   animationLoop.start();
 </script>

--- a/modules/arrow/src/arrow/table-computation.ts
+++ b/modules/arrow/src/arrow/table-computation.ts
@@ -21,7 +21,7 @@ export type TableComputationProps = Omit<ComputationProps, 'bindings'> & {
   /** Ordinary non-table bindings forwarded to {@link Computation}. */
   bindings?: Record<string, Binding>;
   /** GPU vectors converted to storage-buffer bindings by name. */
-  vectorBindings?: Record<string, GPUVector>;
+  inputVectors?: Record<string, GPUVector>;
 };
 
 /**
@@ -32,17 +32,17 @@ export type TableComputationProps = Omit<ComputationProps, 'bindings'> & {
  */
 export class TableComputation extends Computation {
   /** GPU vectors supplied when the computation was created. */
-  readonly vectorBindings: Record<string, GPUVector>;
+  readonly inputVectors: Record<string, GPUVector>;
   private readonly baseBindings: Record<string, Binding>;
   private readonly batchState: TableComputationBatchState;
 
   constructor(device: Device, props: TableComputationProps) {
-    const {vectorBindings = {}, bindings = {}, ...computationProps} = props;
-    assertNoDuplicateBindingNames(vectorBindings, bindings);
+    const {inputVectors = {}, bindings = {}, ...computationProps} = props;
+    assertNoDuplicateBindingNames(inputVectors, bindings);
 
-    const batchState = getTableComputationBatchState(vectorBindings);
+    const batchState = getTableComputationBatchState(inputVectors);
     const baseBindings = {
-      ...getDirectVectorBindings(vectorBindings),
+      ...getDirectVectorBindings(inputVectors),
       ...bindings
     };
 
@@ -51,7 +51,7 @@ export class TableComputation extends Computation {
       bindings: baseBindings
     });
 
-    this.vectorBindings = {...vectorBindings};
+    this.inputVectors = {...inputVectors};
     this.baseBindings = baseBindings;
     this.batchState = batchState;
   }
@@ -70,7 +70,7 @@ export class TableComputation extends Computation {
       } satisfies TableComputationBatch;
       this.setBindings({
         ...this.baseBindings,
-        ...getBatchVectorBindings(this.vectorBindings, batchIndex)
+        ...getBatchVectorBindings(this.inputVectors, batchIndex)
       });
 
       const workgroupCount =
@@ -88,13 +88,13 @@ type TableComputationBatchState = {
 };
 
 function getTableComputationBatchState(
-  vectorBindings: Record<string, GPUVector>
+  inputVectors: Record<string, GPUVector>
 ): TableComputationBatchState {
-  const batchedVectorEntries = Object.entries(vectorBindings).filter(([, vector]) =>
+  const batchedVectorEntries = Object.entries(inputVectors).filter(([, vector]) =>
     requiresBatchBinding(vector)
   );
   if (batchedVectorEntries.length === 0) {
-    const firstVector = Object.values(vectorBindings)[0];
+    const firstVector = Object.values(inputVectors)[0];
     return {
       batchCount: 1,
       batchRowCounts: [firstVector?.length ?? 0]
@@ -132,11 +132,9 @@ function requiresBatchBinding(vector: GPUVector): boolean {
   }
 }
 
-function getDirectVectorBindings(
-  vectorBindings: Record<string, GPUVector>
-): Record<string, Binding> {
+function getDirectVectorBindings(inputVectors: Record<string, GPUVector>): Record<string, Binding> {
   const bindings: Record<string, Binding> = {};
-  for (const [name, vector] of Object.entries(vectorBindings)) {
+  for (const [name, vector] of Object.entries(inputVectors)) {
     if (!requiresBatchBinding(vector)) {
       bindings[name] = getDirectVectorBinding(vector);
     }
@@ -150,11 +148,11 @@ function getDirectVectorBinding(vector: GPUVector): Binding {
 }
 
 function getBatchVectorBindings(
-  vectorBindings: Record<string, GPUVector>,
+  inputVectors: Record<string, GPUVector>,
   batchIndex: number
 ): Record<string, Binding> {
   const bindings: Record<string, Binding> = {};
-  for (const [name, vector] of Object.entries(vectorBindings)) {
+  for (const [name, vector] of Object.entries(inputVectors)) {
     if (!requiresBatchBinding(vector)) {
       continue;
     }
@@ -176,10 +174,10 @@ function getGPUDataBinding(data: GPUData): Binding {
 }
 
 function assertNoDuplicateBindingNames(
-  vectorBindings: Record<string, GPUVector>,
+  inputVectors: Record<string, GPUVector>,
   bindings: Record<string, Binding>
 ): void {
-  for (const name of Object.keys(vectorBindings)) {
+  for (const name of Object.keys(inputVectors)) {
     if (name in bindings) {
       throw new Error(`TableComputation binding "${name}" duplicates an explicit binding`);
     }

--- a/modules/arrow/src/arrow/table-transform.ts
+++ b/modules/arrow/src/arrow/table-transform.ts
@@ -2,15 +2,28 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {type BufferLayout, Device, type RenderPassProps, type ShaderLayout} from '@luma.gl/core';
-import {BufferTransform, type BufferTransformProps} from '@luma.gl/engine';
+import {
+  Buffer,
+  type BufferLayout,
+  Device,
+  type RenderPassProps,
+  type ShaderLayout
+} from '@luma.gl/core';
+import {BufferTransform, DynamicBuffer, type BufferTransformProps} from '@luma.gl/engine';
 import * as arrow from 'apache-arrow';
 import type {ArrowVertexFormatOptions} from './arrow-shader-layout';
-import type {GPUVectorProps} from './arrow-gpu-vector';
+import {GPUVector, type GPUVectorProps} from './arrow-gpu-vector';
 import {GPURecordBatch} from './arrow-gpu-record-batch';
 import {GPUTable, type GPUTableProps} from './plain-gpu-table';
+import type {AttributeArrowType} from './arrow-types';
+import {getArrowTypeByteStride} from './arrow-gpu-data';
 
 type TableTransformBufferMap = NonNullable<Parameters<BufferTransform['run']>[0]>['outputBuffers'];
+type TableTransformRunOptions = Parameters<BufferTransform['run']>[0];
+type TableTransformInputVectors = Record<string, GPUVector> | GPUVector[];
+
+/** Maps transform-feedback output varying names back to the input GPU vector they should update. */
+export type TableTransformOutputCopyMap = Record<string, string>;
 
 /** Options supplied for one {@link TableTransform.runBatches} dispatch. */
 export type TableTransformBatchOptions = RenderPassProps & {
@@ -27,10 +40,19 @@ export type TableTransformProps = BufferTransformProps &
     table?: GPUTable;
     /** Arrow table convenience input converted into a {@link GPUTable}. */
     arrowTable?: arrow.Table;
+    /** Existing GPU vectors converted into the transform input table. */
+    inputVectors?: TableTransformInputVectors;
     /** Maps shader attribute names to Arrow column paths. Defaults to using attribute names. */
     arrowPaths?: Record<string, string>;
     /** Buffer props applied when `arrowTable` is materialized into GPU vectors. */
     arrowBufferProps?: GPUVectorProps;
+    /**
+     * Allocates dense transform-feedback output vectors and copies them back into named input
+     * vectors after each run.
+     *
+     * Output names are inferred as transform-feedback outputs when `outputs` is omitted.
+     */
+    copyOutputToInputVectors?: TableTransformOutputCopyMap;
     /** Controls whether GPU table row count is assigned to vertexCount. */
     tableCount?: 'vertex' | 'none';
   };
@@ -42,6 +64,8 @@ type TableTransformState = {
   explicitAttributes: NonNullable<BufferTransformProps['attributes']>;
   explicitBufferLayout: BufferLayout[];
   inferVertexCount: boolean;
+  copyOutputToInputVectors: TableTransformOutputCopyMap;
+  outputVectors: Record<string, GPUVector>;
 };
 
 /**
@@ -53,10 +77,15 @@ type TableTransformState = {
 export class TableTransform extends BufferTransform {
   /** GPU table backing the transform input attributes. */
   readonly table: GPUTable;
+  /** GPU vectors backing the transform input attributes. */
+  readonly inputVectors: Record<string, GPUVector>;
+  /** Dense transform-feedback output vectors allocated for automatic input writeback. */
+  readonly outputVectors: Record<string, GPUVector>;
   private readonly ownsTable: boolean;
   private readonly explicitAttributes: NonNullable<BufferTransformProps['attributes']>;
   private readonly explicitBufferLayout: BufferLayout[];
   private readonly inferVertexCount: boolean;
+  private readonly copyOutputToInputVectors: TableTransformOutputCopyMap;
   private tableTransformDestroyed = false;
 
   constructor(device: Device, props: TableTransformProps) {
@@ -66,12 +95,15 @@ export class TableTransform extends BufferTransform {
       transformProps,
       explicitAttributes,
       explicitBufferLayout,
-      inferVertexCount
+      inferVertexCount,
+      copyOutputToInputVectors,
+      outputVectors
     } = getTableTransformState(device, props);
 
     try {
       super(device, transformProps);
     } catch (error) {
+      destroyGPUVectors(outputVectors);
       if (ownsTable) {
         table.destroy();
       }
@@ -79,14 +111,36 @@ export class TableTransform extends BufferTransform {
     }
 
     this.table = table;
+    this.inputVectors = table.gpuVectors;
+    this.outputVectors = outputVectors;
     this.ownsTable = ownsTable;
     this.explicitAttributes = explicitAttributes;
     this.explicitBufferLayout = explicitBufferLayout;
     this.inferVertexCount = inferVertexCount;
+    this.copyOutputToInputVectors = copyOutputToInputVectors;
+  }
+
+  /** Runs the transform once and optionally copies transform outputs back into input vectors. */
+  override run(options: TableTransformRunOptions = {}): void {
+    if (!this.hasAutomaticOutputWriteback()) {
+      super.run(options);
+      return;
+    }
+    assertNoExplicitOutputBuffers(
+      options?.outputBuffers,
+      'TableTransform.run() cannot combine outputBuffers with copyOutputToInputVectors'
+    );
+    super.run({...options, outputBuffers: this.getAutomaticOutputBuffers()});
+    this.copyOutputsToInputVectors();
   }
 
   /** Runs the transform once per preserved GPU record batch. */
   runBatches(options: TableTransformBatchOptions = {}): void {
+    if (this.hasAutomaticOutputWriteback() && options.outputBuffers) {
+      throw new Error(
+        'TableTransform.runBatches() cannot combine outputBuffers with copyOutputToInputVectors'
+      );
+    }
     assertMatchingBufferLayouts(
       this.table.bufferLayout,
       this.explicitBufferLayout,
@@ -115,8 +169,15 @@ export class TableTransform extends BufferTransform {
             ? options.outputBuffers(batch, batchIndex)
             : options.outputBuffers;
         const {outputBuffers: _ignoredOutputBuffers, ...renderPassProps} = options;
-        super.run({...renderPassProps, outputBuffers});
+        if (this.hasAutomaticOutputWriteback()) {
+          super.run({...renderPassProps, outputBuffers: this.getAutomaticOutputBuffers()});
+        } else {
+          super.run({...renderPassProps, outputBuffers});
+        }
       });
+      if (this.hasAutomaticOutputWriteback()) {
+        this.copyOutputsToInputVectors();
+      }
     } finally {
       this.model.setAttributes({
         ...this.explicitAttributes,
@@ -133,10 +194,53 @@ export class TableTransform extends BufferTransform {
       return;
     }
     super.destroy();
+    destroyGPUVectors(this.outputVectors);
     if (this.ownsTable) {
       this.table.destroy();
     }
     this.tableTransformDestroyed = true;
+  }
+
+  private hasAutomaticOutputWriteback(): boolean {
+    return Object.keys(this.copyOutputToInputVectors).length > 0;
+  }
+
+  private getAutomaticOutputBuffers(): TableTransformBufferMap {
+    return Object.fromEntries(
+      Object.entries(this.outputVectors).map(([outputName, vector]) => [
+        outputName,
+        getConcreteBuffer(vector.buffer)
+      ])
+    );
+  }
+
+  private copyOutputsToInputVectors(): void {
+    const commandEncoder = this.device.createCommandEncoder();
+    let copyCount = 0;
+
+    for (const [outputName, inputName] of Object.entries(this.copyOutputToInputVectors)) {
+      const outputVector = this.outputVectors[outputName];
+      const inputVector = this.inputVectors[inputName];
+      if (!outputVector || !inputVector) {
+        throw new Error(`TableTransform writeback mapping "${outputName}" is incomplete`);
+      }
+      const size = inputVector.length * inputVector.byteStride;
+      if (size === 0) {
+        continue;
+      }
+      commandEncoder.copyBufferToBuffer({
+        sourceBuffer: getConcreteBuffer(outputVector.buffer),
+        destinationBuffer: getConcreteBuffer(inputVector.buffer),
+        size
+      });
+      copyCount++;
+    }
+
+    if (copyCount > 0) {
+      this.device.submit(commandEncoder.finish());
+      return;
+    }
+    commandEncoder.destroy();
   }
 }
 
@@ -144,14 +248,16 @@ function getTableTransformState(device: Device, props: TableTransformProps): Tab
   const {
     table: explicitTable,
     arrowTable,
+    inputVectors,
     arrowPaths,
     arrowBufferProps,
+    copyOutputToInputVectors = {},
     tableCount = 'vertex',
     allowWebGLOnlyFormats,
     ...transformProps
   } = props;
 
-  validateTableTransformSources({table: explicitTable, arrowTable});
+  validateTableTransformSources({table: explicitTable, arrowTable, inputVectors});
   if (!transformProps.shaderLayout) {
     throw new Error('TableTransform requires shaderLayout');
   }
@@ -160,6 +266,7 @@ function getTableTransformState(device: Device, props: TableTransformProps): Tab
     device,
     table: explicitTable,
     arrowTable,
+    inputVectors,
     shaderLayout: transformProps.shaderLayout,
     arrowPaths,
     arrowBufferProps,
@@ -169,6 +276,8 @@ function getTableTransformState(device: Device, props: TableTransformProps): Tab
   const explicitAttributes = transformProps.attributes || {};
   const explicitBufferLayout = transformProps.bufferLayout || [];
   const inferVertexCount = tableCount === 'vertex' && transformProps.vertexCount === undefined;
+  let outputVectors: Record<string, GPUVector> = {};
+  let transformOutputs: string[] | undefined;
 
   try {
     assertNoDuplicateNames(
@@ -181,7 +290,10 @@ function getTableTransformState(device: Device, props: TableTransformProps): Tab
       getBufferLayoutNames(table.bufferLayout),
       'buffer layout'
     );
+    outputVectors = createAutomaticOutputVectors(device, table, copyOutputToInputVectors);
+    transformOutputs = getTableTransformOutputs(transformProps, copyOutputToInputVectors);
   } catch (error) {
+    destroyGPUVectors(outputVectors);
     if (ownsTable) {
       table.destroy();
     }
@@ -194,8 +306,11 @@ function getTableTransformState(device: Device, props: TableTransformProps): Tab
     explicitAttributes,
     explicitBufferLayout,
     inferVertexCount,
+    copyOutputToInputVectors,
+    outputVectors,
     transformProps: {
       ...transformProps,
+      ...(transformOutputs ? {outputs: transformOutputs} : {}),
       attributes: {...explicitAttributes, ...table.attributes},
       bufferLayout: [...explicitBufferLayout, ...table.bufferLayout],
       ...(inferVertexCount ? {vertexCount: table.numRows} : {})
@@ -207,6 +322,7 @@ function getInitialTable(props: {
   device: Device;
   table?: GPUTable;
   arrowTable?: arrow.Table;
+  inputVectors?: TableTransformInputVectors;
   shaderLayout: ShaderLayout;
   arrowPaths?: Record<string, string>;
   arrowBufferProps?: GPUVectorProps;
@@ -214,6 +330,9 @@ function getInitialTable(props: {
 }): {table: GPUTable; ownsTable: boolean} {
   if (props.table) {
     return {table: props.table, ownsTable: false};
+  }
+  if (props.inputVectors) {
+    return {table: new GPUTable({vectors: props.inputVectors}), ownsTable: true};
   }
 
   return {
@@ -227,13 +346,145 @@ function getInitialTable(props: {
   };
 }
 
-function validateTableTransformSources(props: {table?: GPUTable; arrowTable?: arrow.Table}): void {
-  const sourceCount = Number(Boolean(props.table)) + Number(Boolean(props.arrowTable));
+function validateTableTransformSources(props: {
+  table?: GPUTable;
+  arrowTable?: arrow.Table;
+  inputVectors?: TableTransformInputVectors;
+}): void {
+  const sourceCount =
+    Number(Boolean(props.table)) +
+    Number(Boolean(props.arrowTable)) +
+    Number(Boolean(props.inputVectors));
   if (sourceCount > 1) {
-    throw new Error('TableTransform requires only one of table or arrowTable');
+    throw new Error('TableTransform requires only one of table, arrowTable, or inputVectors');
   }
   if (sourceCount === 0) {
-    throw new Error('TableTransform requires table or arrowTable');
+    throw new Error('TableTransform requires table, arrowTable, or inputVectors');
+  }
+}
+
+function createAutomaticOutputVectors(
+  device: Device,
+  table: GPUTable,
+  copyOutputToInputVectors: TableTransformOutputCopyMap
+): Record<string, GPUVector> {
+  const outputEntries = Object.entries(copyOutputToInputVectors);
+  if (outputEntries.length === 0) {
+    return {};
+  }
+  if (table.batches.length !== 1) {
+    throw new Error(
+      'TableTransform copyOutputToInputVectors currently requires one directly bindable GPU batch'
+    );
+  }
+
+  const copiedInputNames = new Set<string>();
+  const outputVectors: Record<string, GPUVector> = {};
+
+  try {
+    for (const [outputName, inputName] of outputEntries) {
+      if (copiedInputNames.has(inputName)) {
+        throw new Error(
+          `TableTransform copyOutputToInputVectors maps more than one output to "${inputName}"`
+        );
+      }
+      copiedInputNames.add(inputName);
+
+      const inputVector = table.gpuVectors[inputName];
+      if (!inputVector) {
+        throw new Error(
+          `TableTransform copyOutputToInputVectors references missing input vector "${inputName}"`
+        );
+      }
+      validateAutomaticWritebackVector(inputName, inputVector);
+
+      const byteLength = inputVector.length * inputVector.byteStride;
+      const outputBuffer = device.createBuffer({
+        usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST,
+        byteLength: Math.max(1, byteLength)
+      });
+      outputVectors[outputName] = new GPUVector({
+        type: 'buffer',
+        name: outputName,
+        buffer: outputBuffer,
+        arrowType: inputVector.type as AttributeArrowType,
+        length: inputVector.length,
+        byteStride: inputVector.byteStride,
+        ownsBuffer: true
+      } as any);
+    }
+  } catch (error) {
+    destroyGPUVectors(outputVectors);
+    throw error;
+  }
+
+  return outputVectors;
+}
+
+function validateAutomaticWritebackVector(name: string, vector: GPUVector): void {
+  if (vector.bufferLayout) {
+    throw new Error(
+      `TableTransform copyOutputToInputVectors does not support interleaved input vector "${name}"`
+    );
+  }
+  if (vector.byteOffset !== 0) {
+    throw new Error(
+      `TableTransform copyOutputToInputVectors requires zero byteOffset for input vector "${name}"`
+    );
+  }
+  const packedByteStride = getArrowTypeByteStride(vector.type as AttributeArrowType);
+  if (vector.byteStride !== packedByteStride) {
+    throw new Error(
+      `TableTransform copyOutputToInputVectors requires tightly packed input vector "${name}"`
+    );
+  }
+  getConcreteBuffer(vector.buffer);
+}
+
+function getTableTransformOutputs(
+  transformProps: BufferTransformProps,
+  copyOutputToInputVectors: TableTransformOutputCopyMap
+): string[] | undefined {
+  const inferredOutputs = Object.keys(copyOutputToInputVectors);
+  if (inferredOutputs.length === 0) {
+    return transformProps.outputs;
+  }
+
+  const declaredOutputs = transformProps.outputs || transformProps.varyings;
+  if (!declaredOutputs) {
+    return inferredOutputs;
+  }
+  assertSameOutputNames(declaredOutputs, inferredOutputs);
+  return transformProps.outputs;
+}
+
+function assertSameOutputNames(declaredOutputs: string[], inferredOutputs: string[]): void {
+  if (
+    declaredOutputs.length !== inferredOutputs.length ||
+    declaredOutputs.some(outputName => !inferredOutputs.includes(outputName))
+  ) {
+    throw new Error(
+      'TableTransform outputs must match copyOutputToInputVectors output names when both are supplied'
+    );
+  }
+}
+
+function assertNoExplicitOutputBuffers(
+  outputBuffers: TableTransformBufferMap | undefined,
+  errorMessage: string
+): void {
+  if (outputBuffers) {
+    throw new Error(errorMessage);
+  }
+}
+
+function getConcreteBuffer(buffer: Buffer | DynamicBuffer): Buffer {
+  return buffer instanceof DynamicBuffer ? buffer.buffer : buffer;
+}
+
+function destroyGPUVectors(vectors: Record<string, GPUVector>): void {
+  for (const vector of Object.values(vectors)) {
+    vector.destroy();
   }
 }
 

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -91,6 +91,7 @@ export {ArrowModel, type ArrowModelGPUTable, type ArrowModelProps} from './arrow
 export {
   TableTransform,
   type TableTransformBatchOptions,
+  type TableTransformOutputCopyMap,
   type TableTransformProps
 } from './arrow/table-transform';
 export {

--- a/modules/arrow/test/arrow/table-computation.spec.ts
+++ b/modules/arrow/test/arrow/table-computation.spec.ts
@@ -1,0 +1,64 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {GPUVector, TableComputation} from '@luma.gl/arrow';
+import type {ComputeShaderLayout, Device} from '@luma.gl/core';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import * as arrow from 'apache-arrow';
+
+const COMPUTE_SHADER = /* wgsl */ `\
+@group(0) @binding(0) var<storage, read_write> values : array<i32>;
+
+@compute @workgroup_size(1)
+fn computeMain(@builtin(global_invocation_id) globalInvocationId : vec3<u32>) {
+  values[globalInvocationId.x] = values[globalInvocationId.x] * 3;
+}
+`;
+
+const COMPUTE_SHADER_LAYOUT = {
+  bindings: [{name: 'values', type: 'storage', group: 0, location: 0}]
+} satisfies ComputeShaderLayout;
+
+test('TableComputation binds inputVectors for storage compute', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device || isSoftwareBackedDevice(device)) {
+    t.comment('Skipping TableComputation storage test without hardware WebGPU');
+    t.end();
+    return;
+  }
+
+  const values = new GPUVector({
+    name: 'values',
+    device,
+    vector: arrow.makeVector(new Int32Array([2, 4, 6]))
+  });
+  const computation = new TableComputation(device, {
+    source: COMPUTE_SHADER,
+    shaderLayout: COMPUTE_SHADER_LAYOUT,
+    inputVectors: {values}
+  });
+
+  const computePass = device.beginComputePass({});
+  computation.dispatchBatches(computePass, batch => batch.numRows);
+  computePass.end();
+  device.submit();
+
+  const computedValues = await values.readAsync();
+  t.deepEqual(
+    Array.from(computedValues.toArray() as Int32Array),
+    [6, 12, 18],
+    'dispatches with input vector storage bindings'
+  );
+
+  computation.destroy();
+  values.destroy();
+  t.end();
+});
+
+function isSoftwareBackedDevice(device: Device): boolean {
+  return (
+    device.info.gpu === 'software' || device.info.gpuType === 'cpu' || Boolean(device.info.fallback)
+  );
+}

--- a/modules/arrow/test/arrow/table-transform.spec.ts
+++ b/modules/arrow/test/arrow/table-transform.spec.ts
@@ -1,0 +1,84 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {GPUVector, TableTransform} from '@luma.gl/arrow';
+import type {ShaderLayout} from '@luma.gl/core';
+import {getWebGLTestDevice} from '@luma.gl/test-utils';
+import * as arrow from 'apache-arrow';
+
+const TRANSFORM_VERTEX_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+in float values;
+out float nextValues;
+
+void main() {
+  nextValues = values * 2.0;
+}
+`;
+
+const TRANSFORM_SHADER_LAYOUT = {
+  attributes: [{name: 'values', location: 0, type: 'f32'}],
+  bindings: []
+} satisfies ShaderLayout;
+
+test('TableTransform copies dense outputs back into inputVectors', async t => {
+  const device = await getWebGLTestDevice();
+  const values = new GPUVector({
+    name: 'values',
+    device,
+    vector: arrow.makeVector(new Float32Array([1, 2, 3]))
+  });
+  const transform = new TableTransform(device, {
+    vs: TRANSFORM_VERTEX_SHADER,
+    shaderLayout: TRANSFORM_SHADER_LAYOUT,
+    inputVectors: {values},
+    copyOutputToInputVectors: {nextValues: 'values'}
+  });
+
+  t.ok(transform.outputVectors.nextValues, 'allocates an output vector for writeback');
+  transform.run();
+
+  const transformedValues = await values.readAsync();
+  t.deepEqual(
+    Array.from(transformedValues.toArray() as Float32Array),
+    [2, 4, 6],
+    'copies transform outputs back into the input vector buffer'
+  );
+
+  transform.destroy();
+  values.destroy();
+  t.end();
+});
+
+test('TableTransform rejects padded automatic writeback vectors', async t => {
+  const device = await getWebGLTestDevice();
+  const buffer = device.createBuffer({byteLength: 16});
+  const values = new GPUVector({
+    type: 'buffer',
+    name: 'values',
+    buffer,
+    arrowType: new arrow.Float32(),
+    length: 2,
+    byteStride: 8,
+    ownsBuffer: true
+  });
+
+  t.throws(
+    () =>
+      new TableTransform(device, {
+        vs: TRANSFORM_VERTEX_SHADER,
+        shaderLayout: TRANSFORM_SHADER_LAYOUT,
+        inputVectors: {values},
+        copyOutputToInputVectors: {nextValues: 'values'}
+      }),
+    /requires tightly packed input vector/,
+    'automatic writeback documents its dense-copy limitation in behavior'
+  );
+
+  values.destroy();
+  t.end();
+});

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -12,5 +12,7 @@ import './arrow/arrow-model.spec';
 import './arrow/arrow-shader-layout.spec';
 import './arrow/analyze-arrow-table.spec';
 import './arrow/table-buffer-planner.spec';
+import './arrow/table-computation.spec';
+import './arrow/table-transform.spec';
 
 import './geoarrow/geoarrow.spec';

--- a/modules/engine/src/index.ts
+++ b/modules/engine/src/index.ts
@@ -123,6 +123,7 @@ export {DynamicBuffer} from './dynamic-buffer/dynamic-buffer';
 
 export type {
   PickInfo,
+  PickingTooltip,
   PickingMode,
   ResolvedPickingMode,
   PickingBackend,

--- a/modules/engine/src/modules/picking/picking-manager.ts
+++ b/modules/engine/src/modules/picking/picking-manager.ts
@@ -409,7 +409,8 @@ export class PickingManager {
     if (
       typeof document === 'undefined' ||
       typeof window === 'undefined' ||
-      typeof HTMLCanvasElement === 'undefined'
+      typeof HTMLCanvasElement === 'undefined' ||
+      typeof this.device.getDefaultCanvasContext !== 'function'
     ) {
       return null;
     }
@@ -443,7 +444,10 @@ export class PickingManager {
   }
 
   protected positionTooltip(tooltipElement: HTMLDivElement, mousePosition: [number, number]): void {
-    if (typeof HTMLCanvasElement === 'undefined') {
+    if (
+      typeof HTMLCanvasElement === 'undefined' ||
+      typeof this.device.getDefaultCanvasContext !== 'function'
+    ) {
       return;
     }
 

--- a/modules/engine/src/modules/picking/picking-manager.ts
+++ b/modules/engine/src/modules/picking/picking-manager.ts
@@ -10,12 +10,17 @@ const INDEX_PICKING_ATTACHMENT_INDEX = 1;
 const INDEX_PICKING_CLEAR_COLOR = new Int32Array([INVALID_INDEX, INVALID_INDEX, 0, 0]);
 const COLOR_PICKING_MAX_OBJECT_INDEX = 16777214;
 const COLOR_PICKING_MAX_BATCH_INDEX = 254;
+const TOOLTIP_OFFSET_PIXELS = 14;
+const TOOLTIP_MARGIN_PIXELS = 8;
 
 /** Information about picked object */
 export type PickInfo = {
   batchIndex: number | null;
   objectIndex: number | null;
 };
+
+/** Text shown by `PickingManager` beside the latest picked cursor position. */
+export type PickingTooltip = string | null;
 
 export type PickingMode = 'auto' | 'index' | 'color';
 export type ResolvedPickingMode = Exclude<PickingMode, 'auto'>;
@@ -29,6 +34,11 @@ export type PickingManagerProps = {
   shaderInputs?: ShaderInputs<{picking: typeof pickingUniforms.props}>;
   /** Callback */
   onObjectPicked?: (info: PickInfo) => void;
+  /**
+   * Returns tooltip text for the latest pick result.
+   * Returning `null` hides the tooltip.
+   */
+  getTooltip?: (info: PickInfo) => PickingTooltip;
   /** Select a picking mode. Defaults to `color`. Use `auto` to prefer `index` when supported. */
   mode?: PickingMode;
   /** @deprecated Use `mode`. */
@@ -98,10 +108,13 @@ export class PickingManager {
   framebuffer: Framebuffer | null = null;
   /** Last cursor position that triggered a picking render/readback. */
   protected lastMousePosition: [number, number] | null = null;
+  /** Tooltip element created lazily when `getTooltip` returns visible content. */
+  protected tooltipElement: HTMLDivElement | null = null;
 
   static defaultProps: Required<PickingManagerProps> = {
     shaderInputs: undefined!,
     onObjectPicked: () => {},
+    getTooltip: () => null,
     mode: 'color',
     backend: 'color'
   };
@@ -121,6 +134,8 @@ export class PickingManager {
 
   destroy() {
     this.framebuffer?.destroy();
+    this.tooltipElement?.remove();
+    this.tooltipElement = null;
   }
 
   // TODO - Ask for a cached framebuffer? a Framebuffer factory?
@@ -136,6 +151,7 @@ export class PickingManager {
   clearPickState() {
     this.lastMousePosition = null;
     this.setPickingProps({highlightedBatchIndex: null, highlightedObjectIndex: null});
+    this.hideTooltip();
   }
 
   /** Return whether callers need to render a fresh picking pass for this cursor position. */
@@ -195,6 +211,7 @@ export class PickingManager {
       this.props.onObjectPicked(pickInfo);
     }
 
+    this.updateTooltip(pickInfo, mousePosition);
     this.setPickingProps({
       isActive: false,
       highlightedBatchIndex: pickInfo.batchIndex,
@@ -360,6 +377,93 @@ export class PickingManager {
       pickInfo.objectIndex !== this.pickInfo.objectIndex ||
       pickInfo.batchIndex !== this.pickInfo.batchIndex
     );
+  }
+
+  protected updateTooltip(pickInfo: PickInfo, mousePosition: [number, number]): void {
+    const tooltipText = this.props.getTooltip(pickInfo);
+    if (!tooltipText) {
+      this.hideTooltip();
+      return;
+    }
+
+    const tooltipElement = this.getOrCreateTooltipElement();
+    if (!tooltipElement) {
+      return;
+    }
+
+    tooltipElement.textContent = tooltipText;
+    tooltipElement.style.display = 'block';
+    this.positionTooltip(tooltipElement, mousePosition);
+  }
+
+  protected hideTooltip(): void {
+    if (this.tooltipElement) {
+      this.tooltipElement.style.display = 'none';
+    }
+  }
+
+  protected getOrCreateTooltipElement(): HTMLDivElement | null {
+    if (this.tooltipElement) {
+      return this.tooltipElement;
+    }
+    if (
+      typeof document === 'undefined' ||
+      typeof window === 'undefined' ||
+      typeof HTMLCanvasElement === 'undefined'
+    ) {
+      return null;
+    }
+
+    const canvas = this.device.getDefaultCanvasContext().canvas;
+    if (!(canvas instanceof HTMLCanvasElement) || !canvas.parentElement) {
+      return null;
+    }
+
+    const tooltipElement = document.createElement('div');
+    tooltipElement.style.position = 'absolute';
+    tooltipElement.style.zIndex = '12';
+    tooltipElement.style.display = 'none';
+    tooltipElement.style.maxWidth = '220px';
+    tooltipElement.style.padding = '8px 10px';
+    tooltipElement.style.borderRadius = '6px';
+    tooltipElement.style.background = 'rgba(15, 23, 42, 0.92)';
+    tooltipElement.style.color = '#f8fafc';
+    tooltipElement.style.font = '600 13px/1.35 system-ui, sans-serif';
+    tooltipElement.style.pointerEvents = 'none';
+    tooltipElement.style.whiteSpace = 'nowrap';
+    tooltipElement.style.boxShadow = '0 10px 24px rgba(15, 23, 42, 0.22)';
+
+    const tooltipParent = canvas.parentElement;
+    if (window.getComputedStyle(tooltipParent).position === 'static') {
+      tooltipParent.style.position = 'relative';
+    }
+    tooltipParent.appendChild(tooltipElement);
+    this.tooltipElement = tooltipElement;
+    return tooltipElement;
+  }
+
+  protected positionTooltip(tooltipElement: HTMLDivElement, mousePosition: [number, number]): void {
+    if (typeof HTMLCanvasElement === 'undefined') {
+      return;
+    }
+
+    const canvas = this.device.getDefaultCanvasContext().canvas;
+    if (!(canvas instanceof HTMLCanvasElement)) {
+      return;
+    }
+
+    const maxLeft = Math.max(
+      TOOLTIP_MARGIN_PIXELS,
+      canvas.clientWidth - tooltipElement.offsetWidth - TOOLTIP_MARGIN_PIXELS
+    );
+    const maxTop = Math.max(
+      TOOLTIP_MARGIN_PIXELS,
+      canvas.clientHeight - tooltipElement.offsetHeight - TOOLTIP_MARGIN_PIXELS
+    );
+    const left = Math.min(mousePosition[0] + TOOLTIP_OFFSET_PIXELS, maxLeft);
+    const top = Math.min(mousePosition[1] + TOOLTIP_OFFSET_PIXELS, maxTop);
+    tooltipElement.style.left = `${Math.max(TOOLTIP_MARGIN_PIXELS, left)}px`;
+    tooltipElement.style.top = `${Math.max(TOOLTIP_MARGIN_PIXELS, top)}px`;
   }
 }
 

--- a/modules/engine/test/lib/picking-manager.spec.ts
+++ b/modules/engine/test/lib/picking-manager.spec.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import type {Framebuffer} from '@luma.gl/core';
 
 import {
   PickingManager,
@@ -45,6 +46,43 @@ test('PickingManager#shouldPick', t => {
   t.equal(picker.shouldPick([13, 34]), true, 'cursor movement should pick');
   t.equal(picker.shouldPick(null), false, 'missing cursor position clears without picking');
   t.equal(picker.shouldPick([13, 34]), true, 'cursor can pick again after clearing');
+  picker.destroy();
+  t.end();
+});
+
+test('PickingManager#getTooltip', async t => {
+  let tooltipPickInfo: {batchIndex: number | null; objectIndex: number | null} | null = null;
+  class TooltipPickingManager extends PickingManager {
+    override getFramebuffer(): Framebuffer {
+      return {} as Framebuffer;
+    }
+
+    override getPickPosition(mousePosition: [number, number]): [number, number] {
+      return mousePosition;
+    }
+
+    protected override async readPickInfo(): Promise<{
+      batchIndex: number | null;
+      objectIndex: number | null;
+    }> {
+      return {batchIndex: 2, objectIndex: 7};
+    }
+  }
+
+  const picker = new TooltipPickingManager(getNullTestDevice(), {
+    getTooltip: pickInfo => {
+      tooltipPickInfo = pickInfo;
+      return pickInfo.objectIndex === null ? null : `row ${pickInfo.objectIndex}`;
+    }
+  });
+
+  const pickInfo = await picker.updatePickInfo([12, 34]);
+  t.deepEqual(pickInfo, {batchIndex: 2, objectIndex: 7}, 'pick result is returned');
+  t.deepEqual(
+    tooltipPickInfo,
+    {batchIndex: 2, objectIndex: 7},
+    'tooltip formatter receives the decoded pick info'
+  );
   picker.destroy();
   t.end();
 });

--- a/website/content/examples/gpu-tables/gpu-vector-storage-particles.mdx
+++ b/website/content/examples/gpu-tables/gpu-vector-storage-particles.mdx
@@ -1,5 +1,5 @@
 ---
-title: GPUVector Storage Particles
+title: Arrow Particles
 ---
 
 import {GPUVectorStorageParticlesExample} from '@site/src/examples';

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -217,11 +217,10 @@ export const ArrowMeshGeometryExample: React.FC = props => (
 export const GPUVectorStorageParticlesExample: React.FC = props => (
   <LumaExample
     id="gpu-vector-storage-particles"
-    title="GPUVector Storage Particles"
+    title="Arrow Particles"
     directory="gpu-tables"
     template={GPUVectorStorageParticlesApp}
     config={exampleConfig}
-    devices={['webgpu']}
     {...props}
   />
 );


### PR DESCRIPTION
## Goals

- Make the Arrow/table compute path more consistent across WebGPU and WebGL.
- Improve the GPU Tables examples so they demonstrate reusable table-driven workflows more clearly.
- Add practical picking/tooltip support for row-oriented examples.

## Changes

- Extended `TableTransform` to:
  - accept `inputVectors`
  - allocate outputs when needed
  - copy dense transform-feedback outputs back into selected input vectors
  - infer `outputs` from the copy-back map when possible

- Renamed `TableComputation` vector input naming to `inputVectors` for consistency with `TableTransform`.

- Updated GPU/table documentation to cover:
  - `inputVectors`
  - automatic copy-back behavior
  - the dense-output limitation for transform feedback

- Refined the particles example:
  - renamed the visible example to `Arrow Particles`
  - reduced reset cadence
  - aligned its table-compute flow with the new APIs

- Expanded Arrow Mesh Geometry picking:
  - row-based face picking
  - face-name metadata table
  - per-face highlight behavior on WebGPU and WebGL2
  - tooltip display driven by picked row data

- Added `PickingManager#getTooltip(info)` support:
  - lightweight tooltip text callback
  - canvas-local tooltip placement and cleanup
  - public `PickingTooltip` type
  - API reference updates and tests

- Added focused tests for:
  - `TableComputation`
  - `TableTransform`
  - tooltip callback behavior in `PickingManager`

- Added a small `AGENTS.md` merge-prep note so future “get ready for merge” requests include a copyable Markdown summary.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn --cwd examples/gpu-tables/arrow-mesh-geometry build`
- `yarn examples:typecheck`
- `yarn test-node`
- `yarn website:build`

Manual verification:
- Arrow Mesh Geometry shows a floating tooltip over the canvas.
- Only the picked cube face highlights.
- Behavior checked on both WebGPU and WebGL2.
- No browser console warnings/errors observed during that verification.

## Notes

- `website:build` succeeds; Docusaurus still emits its non-fatal local update-check warning.
- Transform-feedback copy-back intentionally only targets tightly packed, directly bindable `GPUVector`s.