### PR TITLE
feat(arrow): Support List<> attributes

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -16,6 +16,7 @@ Target Release Date: Q3, 2026
 
 - **Arrow shader layouts** - `getArrowBufferLayout()` maps Arrow scalar and `FixedSizeList` columns to shader attribute formats from a shader-first layout, including direct `arrow.Vector` sources and Arrow table path mappings.
 - **Arrow GPU helpers** - New `GPUVector`, `GPUTable`, and `ArrowModel` helpers create GPU buffers from compatible Arrow columns, preserve chunked UTF-8 GPU vector input for text workflows, and keep Arrow-backed model attributes updatable through `setProps({arrowTable})`.
+- **Variable-length Arrow attribute lists** - `GPUVector` can retain chunked nested list columns whose elements contain one to four numeric components, covering scalar streams plus tuple-style data such as XY, XYZ, and XYZM coordinates for future path-rendering workflows.
 - **Mesh Arrow geometry** - New `ArrowGeometry` and `ArrowModel` support for loaders.gl-compatible Mesh Arrow tables, including default interleaved vertex buffers and optional index buffers.
 - **Arrow table buffer planning** - New `TableBufferPlanner` API builds deterministic GPU buffer allocation plans for table columns, including interleaved fallback groups and WebGPU storage-buffer planning output.
 - **[Columnar GPU tables](/docs/api-guide/gpu/arrow-table-columns)** - Matrix Arrow vectors, storage-selected table bindings, `TableTransform`, and `TableComputation`.

--- a/examples/gpu-tables/arrow-text-2d/app.ts
+++ b/examples/gpu-tables/arrow-text-2d/app.ts
@@ -20,7 +20,8 @@ import {
   ArrowStorageTextModel,
   ArrowTextModel,
   type ArrowStorageTextInputProps,
-  type ArrowTextModelProps
+  type ArrowTextModelProps,
+  type ArrowTextSourceVectors
 } from '@luma.gl/text';
 import * as arrow from 'apache-arrow';
 
@@ -77,6 +78,7 @@ type ArrowTextInput = {
   colors: GPUVector<arrow.FixedSizeList<arrow.Uint8>>;
   angles: GPUVector<arrow.Float32>;
   sizes: GPUVector<arrow.Float32>;
+  sourceVectors: ArrowTextSourceVectors;
   arrowVectorBuildTimeMs: number;
 };
 
@@ -715,6 +717,7 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
   colors!: GPUVector<arrow.FixedSizeList<arrow.Uint8>>;
   angles!: GPUVector<arrow.Float32>;
   sizes!: GPUVector<arrow.Float32>;
+  sourceVectors!: ArrowTextSourceVectors;
   textModel!: ActiveTextModel;
   pickingModel: Model | null = null;
   picker: PickingManager | null = null;
@@ -761,13 +764,14 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
     if (this.isFinalized) {
       return;
     }
-    const {positions, texts, clipRects, colors, angles, sizes} = defaultTextInput;
+    const {positions, texts, clipRects, colors, angles, sizes, sourceVectors} = defaultTextInput;
     this.positions = positions;
     this.texts = texts;
     this.clipRects = clipRects;
     this.colors = colors;
     this.angles = angles;
     this.sizes = sizes;
+    this.sourceVectors = sourceVectors;
     this.arrowVectorBuildTimeMs = defaultTextInput.arrowVectorBuildTimeMs;
     this.textModel = this.createTextModel('direct');
     this.pickingModel = supportsTextIndexPicking(this.device)
@@ -828,6 +832,7 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
       positions: this.positions,
       texts: this.texts,
       clipRects: this.clipRects,
+      sourceVectors: this.sourceVectors,
       ...(this.colorEnabled ? {colors: this.colors} : {}),
       ...(this.angleEnabled ? {angles: this.angles} : {}),
       ...(this.sizeEnabled ? {sizes: this.sizes} : {}),
@@ -867,6 +872,10 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
         positions: this.positions,
         texts: this.texts,
         clipRects: this.clipRects,
+        sourceVectors: {
+          texts: this.sourceVectors.texts,
+          clipRects: this.sourceVectors.clipRects
+        },
         ...(this.colorEnabled ? {colors: this.colors} : {}),
         ...(this.angleEnabled ? {angles: this.angles} : {}),
         ...(this.sizeEnabled ? {sizes: this.sizes} : {}),
@@ -1221,6 +1230,7 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
 
     const streamingTextInput = makeArrowTextInputFromGpuTable(
       streamingTextTable,
+      [firstRecordBatchResult.value],
       streamingSource.arrowVectorBuildTimeMs
     );
     this.textDatasetKind = textDatasetKind;
@@ -1230,6 +1240,7 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
     this.colors = streamingTextInput.colors;
     this.angles = streamingTextInput.angles;
     this.sizes = streamingTextInput.sizes;
+    this.sourceVectors = streamingTextInput.sourceVectors;
     this.arrowVectorBuildTimeMs = streamingTextInput.arrowVectorBuildTimeMs;
     this.activeStreamingTextTable = streamingTextTable;
     this.updateStreamingBatchStatus(streamingTextTable.batches.length);
@@ -1239,6 +1250,7 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
     void this.consumeStreamingRecordBatches(
       recordBatchIterator,
       streamingTextTable,
+      [firstRecordBatchResult.value],
       streamingSessionVersion
     );
   }
@@ -1246,6 +1258,7 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
   async consumeStreamingRecordBatches(
     recordBatchIterator: AsyncIterator<arrow.RecordBatch>,
     streamingTextTable: GPUTable,
+    sourceRecordBatches: arrow.RecordBatch[],
     streamingSessionVersion: number
   ): Promise<void> {
     for (
@@ -1265,8 +1278,10 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
           shaderLayout: STREAMING_TEXT_INPUT_SHADER_LAYOUT
         })
       );
+      sourceRecordBatches.push(recordBatchResult.value);
       const streamingTextInput = makeArrowTextInputFromGpuTable(
         streamingTextTable,
+        sourceRecordBatches,
         this.arrowVectorBuildTimeMs
       );
       this.refreshStreamingTextModel(streamingTextInput, 'streaming Arrow record batch appended');
@@ -1281,10 +1296,12 @@ export default class ArrowText2DAnimationLoopTemplate extends AnimationLoopTempl
     this.colors = streamingTextInput.colors;
     this.angles = streamingTextInput.angles;
     this.sizes = streamingTextInput.sizes;
+    this.sourceVectors = streamingTextInput.sourceVectors;
     const appendedTextProps = {
       positions: this.positions,
       texts: this.texts,
       clipRects: this.clipRects,
+      sourceVectors: this.sourceVectors,
       ...(this.colorEnabled ? {colors: this.colors} : {}),
       ...(this.angleEnabled ? {angles: this.angles} : {}),
       ...(this.sizeEnabled ? {sizes: this.sizes} : {})
@@ -1588,6 +1605,14 @@ function makeArrowTextInput(device: Device, dataset: TextDataset): ArrowTextInpu
       name: 'sizes',
       vector: sizeVector
     }),
+    sourceVectors: {
+      positions: positionVector,
+      texts: texts as arrow.Vector<arrow.Utf8>,
+      clipRects: clipRectVector,
+      colors: colorVector,
+      angles: angleVector,
+      sizes: sizeVector
+    },
     arrowVectorBuildTimeMs: getNow() - arrowVectorBuildStartTime
   };
 }
@@ -1671,8 +1696,19 @@ function makeStreamingArrowTextSource(dataset: TextDataset): StreamingArrowTextS
 
 function makeArrowTextInputFromGpuTable(
   gpuTable: GPUTable,
+  recordBatches: arrow.RecordBatch[],
   arrowVectorBuildTimeMs: number
 ): ArrowTextInput {
+  const sourceTable = new arrow.Table(recordBatches);
+  const positions = sourceTable.getChild('positions');
+  const texts = sourceTable.getChild('texts');
+  const clipRects = sourceTable.getChild('clipRects');
+  const colors = sourceTable.getChild('colors');
+  const angles = sourceTable.getChild('angles');
+  const sizes = sourceTable.getChild('sizes');
+  if (!positions || !texts || !clipRects || !colors || !angles || !sizes) {
+    throw new Error('Streaming Arrow text input requires complete CPU source vectors');
+  }
   return {
     positions: getGpuTableTextVector<arrow.FixedSizeList<arrow.Float32>>(gpuTable, 'positions'),
     texts: getGpuTableTextVector<arrow.Utf8>(gpuTable, 'texts'),
@@ -1680,6 +1716,14 @@ function makeArrowTextInputFromGpuTable(
     colors: getGpuTableTextVector<arrow.FixedSizeList<arrow.Uint8>>(gpuTable, 'colors'),
     angles: getGpuTableTextVector<arrow.Float32>(gpuTable, 'angles'),
     sizes: getGpuTableTextVector<arrow.Float32>(gpuTable, 'sizes'),
+    sourceVectors: {
+      positions: positions as arrow.Vector<arrow.FixedSizeList<arrow.Float32>>,
+      texts: texts as arrow.Vector<arrow.Utf8>,
+      clipRects: clipRects as arrow.Vector<arrow.FixedSizeList<arrow.Int16>>,
+      colors: colors as arrow.Vector<arrow.FixedSizeList<arrow.Uint8>>,
+      angles: angles as arrow.Vector<arrow.Float32>,
+      sizes: sizes as arrow.Vector<arrow.Float32>
+    },
     arrowVectorBuildTimeMs
   };
 }

--- a/modules/arrow/README.md
+++ b/modules/arrow/README.md
@@ -22,6 +22,10 @@ attributes without switching to a separate table abstraction.
 Uploaded vectors own their generated buffers. Wrapped-buffer vectors are
 non-owning by default unless ownership is explicitly requested or transferred by
 an in-place operation.
+`GPUVector` also supports variable-length Arrow list columns whose nested elements
+contain one to four numeric components. This covers scalar lists plus tuple-style
+data such as XY, XYZ, and XYZM coordinates, while copying only compact list-offset
+metadata needed for readback instead of retaining the uploaded Arrow value arrays.
 
 `ArrowGeometry` and `ArrowModel` can also consume loaders.gl-compatible Mesh
 Arrow tables through the local structural `ArrowMeshTable` type. Mesh Arrow

--- a/modules/arrow/src/arrow/arrow-gpu-data.ts
+++ b/modules/arrow/src/arrow/arrow-gpu-data.ts
@@ -5,9 +5,31 @@
 import {Buffer, Device, type BigTypedArray} from '@luma.gl/core';
 import {DynamicBuffer, type DynamicBufferProps} from '@luma.gl/engine';
 import * as arrow from 'apache-arrow';
-import type {AttributeArrowType, NumericArrowType} from './arrow-types';
+import {
+  isVariableLengthAttributeArrowType,
+  type AttributeArrowType,
+  type NumericArrowType,
+  type VariableLengthAttributeArrowType
+} from './arrow-types';
 
 type GPUDataBufferProps = Omit<DynamicBufferProps, 'byteLength' | 'data' | 'buffer' | 'ownsBuffer'>;
+
+/** Compact CPU metadata required to reconstruct variable-width Arrow chunks after GPU readback. */
+export type GPUDataReadbackMetadata =
+  | {
+      kind: 'utf8';
+      valueOffsets: Int32Array;
+      nullCount: number;
+      nullBitmap?: Uint8Array;
+      valueByteLength: number;
+    }
+  | {
+      kind: 'variable-length-attribute';
+      valueOffsets: Int32Array;
+      nullCount: number;
+      nullBitmap?: Uint8Array;
+      valueByteLength: number;
+    };
 
 /** Constructor props that wrap one existing typed GPU data buffer. */
 export type GPUDataFromBufferProps<T extends arrow.DataType = AttributeArrowType> = {
@@ -23,8 +45,8 @@ export type GPUDataFromBufferProps<T extends arrow.DataType = AttributeArrowType
   byteStride?: number;
   /** Whether this data view should destroy the buffer. */
   ownsBuffer?: boolean;
-  /** Optional source Arrow data retained for CPU-side consumers such as text expansion. */
-  sourceData?: arrow.Data<T>;
+  /** Optional compact metadata for reconstructing variable-width Arrow chunks after GPU readback. */
+  readbackMetadata?: GPUDataReadbackMetadata;
 };
 
 type GPUVectorReadableBuffer = Pick<Buffer, 'readAsync'>;
@@ -75,8 +97,8 @@ export class GPUData<T extends arrow.DataType = AttributeArrowType> {
   readonly byteOffset: number;
   /** Bytes between adjacent logical rows in {@link buffer}. */
   readonly byteStride: number;
-  /** Optional source Arrow data retained for CPU-side consumers such as text expansion. */
-  readonly sourceData?: arrow.Data<T>;
+  /** Optional compact metadata for reconstructing variable-width Arrow chunks after GPU readback. */
+  readonly readbackMetadata?: GPUDataReadbackMetadata;
   /** Whether this data view is responsible for destroying {@link buffer}. */
   private _ownsBuffer: boolean;
 
@@ -93,7 +115,7 @@ export class GPUData<T extends arrow.DataType = AttributeArrowType> {
       const arrowData = data!;
       this.type = arrowData.type as T;
       this.length = arrowData.length;
-      this.sourceData = arrowData;
+      this.readbackMetadata = getArrowGPUDataReadbackMetadata(arrowData);
       if (arrow.DataType.isUtf8(arrowData.type)) {
         this.stride = 1;
         this.byteOffset = 0;
@@ -102,6 +124,20 @@ export class GPUData<T extends arrow.DataType = AttributeArrowType> {
           usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
           ...props,
           data: getArrowUtf8DataBufferSource(arrowData as arrow.Data<arrow.Utf8>)
+        });
+        this._ownsBuffer = true;
+        return;
+      }
+      if (isVariableLengthAttributeArrowType(arrowData.type)) {
+        this.stride = getArrowVariableLengthAttributeElementStride(arrowData.type);
+        this.byteOffset = 0;
+        this.byteStride = getArrowVariableLengthAttributeElementByteStride(arrowData.type);
+        this.buffer = new DynamicBuffer(deviceOrProps, {
+          usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
+          ...props,
+          data: getArrowVariableLengthAttributeDataBufferSource(
+            arrowData as unknown as arrow.Data<VariableLengthAttributeArrowType>
+          )
         });
         this._ownsBuffer = true;
         return;
@@ -125,7 +161,7 @@ export class GPUData<T extends arrow.DataType = AttributeArrowType> {
       byteOffset = 0,
       byteStride = getArrowTypeByteStride(arrowType),
       ownsBuffer = false,
-      sourceData
+      readbackMetadata
     } = deviceOrProps;
     this.buffer = buffer;
     this.type = arrowType as T;
@@ -133,7 +169,7 @@ export class GPUData<T extends arrow.DataType = AttributeArrowType> {
     this.stride = getArrowTypeStride(arrowType);
     this.byteOffset = byteOffset;
     this.byteStride = byteStride;
-    this.sourceData = sourceData;
+    this.readbackMetadata = readbackMetadata;
     this._ownsBuffer = ownsBuffer;
   }
 
@@ -144,23 +180,38 @@ export class GPUData<T extends arrow.DataType = AttributeArrowType> {
   /** Reads this GPU chunk back into a single non-null Arrow Data chunk. */
   async readAsync(): Promise<arrow.Data<T>> {
     if (arrow.DataType.isUtf8(this.type)) {
-      if (!this.sourceData) {
-        throw new Error('GPUData.readAsync() requires retained UTF-8 source offsets');
+      const metadata = this.readbackMetadata;
+      if (metadata?.kind !== 'utf8') {
+        throw new Error('GPUData.readAsync() requires UTF-8 readback metadata');
       }
-      const sourceData = this.sourceData as unknown as arrow.Data<arrow.Utf8>;
-      const values = getArrowUtf8DataBufferSource(sourceData);
       const bytes =
-        values.byteLength === 0
+        metadata.valueByteLength === 0
           ? new Uint8Array(0)
-          : await this.buffer.readAsync(this.byteOffset, values.byteLength);
+          : await this.buffer.readAsync(this.byteOffset, metadata.valueByteLength);
       return arrow.makeData({
         type: new arrow.Utf8(),
-        length: sourceData.length,
-        nullCount: sourceData.nullCount,
-        nullBitmap: sourceData.nullBitmap as Uint8Array | undefined,
-        valueOffsets: sourceData.valueOffsets as Int32Array,
+        length: this.length,
+        nullCount: metadata.nullCount,
+        nullBitmap: metadata.nullBitmap,
+        valueOffsets: metadata.valueOffsets,
         data: bytes
       }) as arrow.Data<T>;
+    }
+    if (isVariableLengthAttributeArrowType(this.type)) {
+      const metadata = this.readbackMetadata;
+      if (metadata?.kind !== 'variable-length-attribute') {
+        throw new Error('GPUData.readAsync() requires variable-length attribute readback metadata');
+      }
+      const bytes =
+        metadata.valueByteLength === 0
+          ? new Uint8Array(0)
+          : await this.buffer.readAsync(this.byteOffset, metadata.valueByteLength);
+      return makeArrowVariableLengthAttributeDataFromPackedBytes(
+        this.type,
+        this.length,
+        metadata,
+        bytes
+      ) as unknown as arrow.Data<T>;
     }
     const vector = await readArrowGPUVectorAsync({
       type: this.type as unknown as AttributeArrowType,
@@ -218,6 +269,75 @@ export function getArrowUtf8DataBufferSource(data: arrow.Data<arrow.Utf8>): Uint
   return values.subarray(firstValueOffset, lastValueOffset);
 }
 
+/** Return flattened numeric values referenced by one variable-length nested attribute chunk. */
+export function getArrowVariableLengthAttributeDataBufferSource(
+  data: arrow.Data<VariableLengthAttributeArrowType>
+): NumericArrowType['TArray'] {
+  const valueOffsets = data.valueOffsets as Int32Array | undefined;
+  const elementData = data.children[0] as arrow.Data | undefined;
+  if (!valueOffsets || !elementData) {
+    return new Float32Array(0);
+  }
+
+  const firstElementOffset = valueOffsets[0] ?? 0;
+  const lastElementOffset = valueOffsets[data.length] ?? firstElementOffset;
+
+  if (arrow.DataType.isFixedSizeList(elementData.type)) {
+    const numericData = elementData.children[0] as arrow.Data<NumericArrowType> | undefined;
+    const values = numericData?.values as NumericArrowType['TArray'] | undefined;
+    if (!numericData || !values) {
+      return new Float32Array(0);
+    }
+
+    const elementStride = elementData.type.listSize;
+    const numericValueOffset = numericData.offset ?? 0;
+    const firstValueOffset = numericValueOffset + firstElementOffset * elementStride;
+    const lastValueOffset = numericValueOffset + lastElementOffset * elementStride;
+    return values.subarray(firstValueOffset, lastValueOffset) as NumericArrowType['TArray'];
+  }
+
+  const values = elementData.values as NumericArrowType['TArray'] | undefined;
+  if (!values) {
+    return new Float32Array(0);
+  }
+  const numericValueOffset = elementData.offset ?? 0;
+  return values.subarray(
+    numericValueOffset + firstElementOffset,
+    numericValueOffset + lastElementOffset
+  ) as NumericArrowType['TArray'];
+}
+
+/** Copy compact variable-width reconstruction metadata without retaining Arrow value buffers. */
+export function getArrowGPUDataReadbackMetadata(
+  data: arrow.Data
+): GPUDataReadbackMetadata | undefined {
+  if (arrow.DataType.isUtf8(data.type)) {
+    const values = getArrowUtf8DataBufferSource(data as arrow.Data<arrow.Utf8>);
+    return {
+      kind: 'utf8',
+      valueOffsets: copyNormalizedArrowValueOffsets(data),
+      nullCount: data.nullCount,
+      nullBitmap: copyNormalizedArrowNullBitmap(data),
+      valueByteLength: values.byteLength
+    };
+  }
+
+  if (isVariableLengthAttributeArrowType(data.type)) {
+    const values = getArrowVariableLengthAttributeDataBufferSource(
+      data as arrow.Data<VariableLengthAttributeArrowType>
+    );
+    return {
+      kind: 'variable-length-attribute',
+      valueOffsets: copyNormalizedArrowValueOffsets(data),
+      nullCount: data.nullCount,
+      nullBitmap: copyNormalizedArrowNullBitmap(data),
+      valueByteLength: values.byteLength
+    };
+  }
+
+  return undefined;
+}
+
 export function getArrowVectorBufferSource<T extends NumericArrowType>(
   vector: arrow.Vector<T>
 ): T['TArray'];
@@ -249,11 +369,17 @@ export function getArrowVectorBufferSource(vector: arrow.Vector): NumericArrowTy
 
 /** Number of scalar values in one logical Arrow row. */
 export function getArrowTypeStride(type: arrow.DataType): number {
+  if (isVariableLengthAttributeArrowType(type)) {
+    return getArrowVariableLengthAttributeElementStride(type);
+  }
   return arrow.DataType.isFixedSizeList(type) ? type.listSize : 1;
 }
 
 /** Number of uploaded bytes in one logical Arrow row. */
 export function getArrowTypeByteStride(type: arrow.DataType): number {
+  if (isVariableLengthAttributeArrowType(type)) {
+    return getArrowVariableLengthAttributeElementByteStride(type);
+  }
   if (arrow.DataType.isFixedSizeList(type)) {
     return type.listSize * getArrowTypeByteStride(type.children[0].type);
   }
@@ -276,13 +402,22 @@ export function getArrowTypeByteStride(type: arrow.DataType): number {
 /** Reject nullable Arrow chunks that cannot be uploaded directly into GPU attribute buffers. */
 export function validateArrowGPUDataDirectUpload(
   name: string,
-  data: arrow.Data<AttributeArrowType | arrow.Utf8>
+  data: arrow.Data<AttributeArrowType | arrow.Utf8 | VariableLengthAttributeArrowType>
 ): void {
   if (data.nullCount > 0) {
     throw new Error(`GPUVector "${name}" does not support nullable data`);
   }
   if (arrow.DataType.isFixedSizeList(data.type) && (data.children[0]?.nullCount ?? 0) > 0) {
     throw new Error(`GPUVector "${name}" does not support nullable child data`);
+  }
+  if (isVariableLengthAttributeArrowType(data.type)) {
+    const elementData = data.children[0];
+    const nestedNumericData = arrow.DataType.isFixedSizeList(elementData?.type)
+      ? elementData.children[0]
+      : undefined;
+    if ((elementData?.nullCount ?? 0) > 0 || (nestedNumericData?.nullCount ?? 0) > 0) {
+      throw new Error(`GPUVector "${name}" does not support nullable nested list data`);
+    }
   }
 }
 
@@ -392,6 +527,117 @@ function makeArrowVectorFromPackedBytes<T extends AttributeArrowType>(
     data: values as NumericArrowType['TArray']
   });
   return arrow.makeVector(data) as arrow.Vector<T>;
+}
+
+function makeArrowVariableLengthAttributeDataFromPackedBytes(
+  type: VariableLengthAttributeArrowType,
+  length: number,
+  metadata: Extract<GPUDataReadbackMetadata, {kind: 'variable-length-attribute'}>,
+  bytes: Uint8Array
+): arrow.Data<VariableLengthAttributeArrowType> {
+  const elementType = type.children[0].type;
+  const elementData = arrow.DataType.isFixedSizeList(elementType)
+    ? makeArrowFixedSizeListElementDataFromPackedBytes(elementType, bytes)
+    : makeArrowNumericElementDataFromPackedBytes(elementType as NumericArrowType, bytes);
+
+  return new arrow.Data<VariableLengthAttributeArrowType>(
+    type,
+    0,
+    length,
+    metadata.nullCount,
+    {
+      [arrow.BufferType.OFFSET]: metadata.valueOffsets,
+      ...(metadata.nullBitmap ? {[arrow.BufferType.VALIDITY]: metadata.nullBitmap} : {})
+    },
+    [elementData]
+  );
+}
+
+function copyNormalizedArrowValueOffsets(data: arrow.Data): Int32Array {
+  const valueOffsets = data.valueOffsets as Int32Array | undefined;
+  const copiedOffsets = new Int32Array(data.length + 1);
+  if (!valueOffsets) {
+    return copiedOffsets;
+  }
+
+  const firstValueOffset = valueOffsets[0] ?? 0;
+  for (let offsetIndex = 0; offsetIndex <= data.length; offsetIndex++) {
+    copiedOffsets[offsetIndex] = Math.max(
+      0,
+      (valueOffsets[offsetIndex] ?? firstValueOffset) - firstValueOffset
+    );
+  }
+  return copiedOffsets;
+}
+
+function copyNormalizedArrowNullBitmap(data: arrow.Data): Uint8Array | undefined {
+  if (data.nullCount === 0 || !data.nullBitmap) {
+    return undefined;
+  }
+
+  const copiedBitmap = new Uint8Array(Math.ceil(data.length / 8));
+  const sourceBitmap = data.nullBitmap as Uint8Array;
+  const sourceRowOffset = data.offset ?? 0;
+  for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
+    const sourceBitIndex = sourceRowOffset + rowIndex;
+    const sourceByte = sourceBitmap[sourceBitIndex >> 3] ?? 0;
+    if ((sourceByte & (1 << (sourceBitIndex & 7))) !== 0) {
+      copiedBitmap[rowIndex >> 3] |= 1 << (rowIndex & 7);
+    }
+  }
+  return copiedBitmap;
+}
+
+function makeArrowFixedSizeListElementDataFromPackedBytes(
+  type: arrow.FixedSizeList<NumericArrowType>,
+  bytes: Uint8Array
+): arrow.Data<arrow.FixedSizeList<NumericArrowType>> {
+  const numericType = type.children[0].type as NumericArrowType;
+  const values = makeNumericTypedArray(
+    numericType,
+    bytes,
+    bytes.byteLength / getArrowTypeByteStride(numericType)
+  ) as NumericArrowType['TArray'];
+  const numericData = makeNumericData({
+    type: numericType,
+    length: values.length,
+    data: values
+  });
+  return makeFixedSizeListData({
+    type,
+    length: type.listSize === 0 ? 0 : values.length / type.listSize,
+    nullCount: 0,
+    nullBitmap: null,
+    child: numericData
+  });
+}
+
+function makeArrowNumericElementDataFromPackedBytes(
+  type: NumericArrowType,
+  bytes: Uint8Array
+): arrow.Data<NumericArrowType> {
+  const values = makeNumericTypedArray(
+    type,
+    bytes,
+    bytes.byteLength / getArrowTypeByteStride(type)
+  ) as NumericArrowType['TArray'];
+  return makeNumericData({
+    type,
+    length: values.length,
+    data: values
+  });
+}
+
+function getArrowVariableLengthAttributeElementStride(
+  type: VariableLengthAttributeArrowType
+): number {
+  return getArrowTypeStride(type.children[0].type);
+}
+
+function getArrowVariableLengthAttributeElementByteStride(
+  type: VariableLengthAttributeArrowType
+): number {
+  return getArrowTypeByteStride(type.children[0].type);
 }
 
 function makeNumericTypedArray(

--- a/modules/arrow/src/arrow/arrow-gpu-vector.ts
+++ b/modules/arrow/src/arrow/arrow-gpu-vector.ts
@@ -11,13 +11,20 @@ import {
 } from '@luma.gl/core';
 import {DynamicBuffer, type DynamicBufferProps} from '@luma.gl/engine';
 import * as arrow from 'apache-arrow';
-import {isInstanceArrowType, type AttributeArrowType} from './arrow-types';
+import {
+  isInstanceArrowType,
+  isVariableLengthAttributeArrowType,
+  type AttributeArrowType,
+  type VariableLengthAttributeArrowType
+} from './arrow-types';
 import {
   GPUData,
   getArrowDataBufferSource,
+  getArrowGPUDataReadbackMetadata,
   getArrowUtf8DataBufferSource,
   getArrowTypeByteStride,
   getArrowTypeStride,
+  getArrowVariableLengthAttributeDataBufferSource,
   getArrowVectorBufferSource,
   readArrowGPUVectorAsync,
   validateArrowGPUDataDirectUpload
@@ -26,7 +33,8 @@ import {
 export {
   GPUData,
   readArrowGPUVectorAsync,
-  type GPUDataFromBufferProps
+  type GPUDataFromBufferProps,
+  type GPUDataReadbackMetadata
 } from './arrow-gpu-data';
 
 /** Buffer creation props forwarded when uploading Arrow vector memory to the GPU. */
@@ -34,7 +42,7 @@ export type GPUVectorBufferProps = Omit<BufferProps, 'byteLength' | 'data'>;
 /** Dynamic buffer props forwarded when creating appendable Arrow GPU vectors. */
 export type GPUVectorDynamicBufferProps = Omit<DynamicBufferProps, 'byteLength' | 'data'>;
 
-type AppendableArrowType = AttributeArrowType | arrow.Utf8;
+type AppendableArrowType = AttributeArrowType | VariableLengthAttributeArrowType | arrow.Utf8;
 
 /** @deprecated Use {@link GPUVectorBufferProps}. */
 export type GPUVectorProps = GPUVectorBufferProps;
@@ -215,11 +223,27 @@ export class GPUVector<T extends arrow.DataType = AttributeArrowType> {
         this.name = name;
         this.type = arrowVector.type;
         this.length = arrowVector.length;
-        if (arrow.DataType.isUtf8(arrowVector.type)) {
-          this.stride = 1;
+        if (
+          arrow.DataType.isUtf8(arrowVector.type) ||
+          isVariableLengthAttributeArrowType(arrowVector.type)
+        ) {
+          const isVariableLengthAttributeVector = isVariableLengthAttributeArrowType(
+            arrowVector.type
+          );
+          this.stride = isVariableLengthAttributeVector
+            ? getArrowTypeStride(arrowVector.type as VariableLengthAttributeArrowType)
+            : 1;
           this.byteOffset = 0;
-          this.byteStride = 1;
+          this.byteStride = isVariableLengthAttributeVector
+            ? getArrowTypeByteStride(arrowVector.type as VariableLengthAttributeArrowType)
+            : 1;
           for (const arrowData of arrowVector.data) {
+            if (isVariableLengthAttributeVector) {
+              validateArrowGPUDataDirectUpload(
+                name,
+                arrowData as arrow.Data<VariableLengthAttributeArrowType>
+              );
+            }
             this.data.push(new GPUData(device, arrowData as arrow.Data<T>, bufferProps));
           }
           this._ownsBuffer = false;
@@ -246,8 +270,7 @@ export class GPUVector<T extends arrow.DataType = AttributeArrowType> {
             length: arrowData.length,
             byteOffset,
             byteStride: this.byteStride,
-            ownsBuffer: false,
-            sourceData: arrowData as arrow.Data<T>
+            ownsBuffer: false
           });
           this.data.push(gpuData);
           byteOffset += arrowData.length * this.byteStride;
@@ -349,7 +372,11 @@ export class GPUVector<T extends arrow.DataType = AttributeArrowType> {
           capacityGrowthFactor = 1.5,
           bufferProps
         } = constructionProps;
-        if (!isInstanceArrowType(arrowType) && !arrow.DataType.isUtf8(arrowType)) {
+        if (
+          !isInstanceArrowType(arrowType) &&
+          !isVariableLengthAttributeArrowType(arrowType) &&
+          !arrow.DataType.isUtf8(arrowType)
+        ) {
           throw new Error(`GPUVector does not support Arrow type ${arrowType}`);
         }
         this.name = name;
@@ -419,7 +446,7 @@ export class GPUVector<T extends arrow.DataType = AttributeArrowType> {
 
   /** Number of rows the appendable backing DynamicBuffer can hold without reallocating. */
   get capacityRows(): number | undefined {
-    if (arrow.DataType.isUtf8(this.type)) {
+    if (arrow.DataType.isUtf8(this.type) || isVariableLengthAttributeArrowType(this.type)) {
       return undefined;
     }
     return this._buffer instanceof DynamicBuffer
@@ -438,9 +465,14 @@ export class GPUVector<T extends arrow.DataType = AttributeArrowType> {
     validateArrowGPUDataDirectUpload(this.name, data);
 
     const isUtf8Data = arrow.DataType.isUtf8(data.type);
+    const isVariableLengthAttributeData = isVariableLengthAttributeArrowType(data.type);
     const uploadData = isUtf8Data
       ? getArrowUtf8DataBufferSource(data as arrow.Data<arrow.Utf8>)
-      : getArrowDataBufferSource(data as arrow.Data<AttributeArrowType>);
+      : isVariableLengthAttributeData
+        ? getArrowVariableLengthAttributeDataBufferSource(
+            data as arrow.Data<VariableLengthAttributeArrowType>
+          )
+        : getArrowDataBufferSource(data as arrow.Data<AttributeArrowType>);
     const byteOffset = isUtf8Data
       ? alignAppendableByteLength(this.appendableByteLength)
       : this.appendableByteLength;
@@ -461,7 +493,7 @@ export class GPUVector<T extends arrow.DataType = AttributeArrowType> {
         byteOffset,
         byteStride: this.byteStride,
         ownsBuffer: false,
-        sourceData: data as arrow.Data<T>
+        readbackMetadata: getArrowGPUDataReadbackMetadata(data)
       }) as GPUData<T>
     );
     this.length = requiredRows;
@@ -524,7 +556,7 @@ export class GPUVector<T extends arrow.DataType = AttributeArrowType> {
       throw new Error('GPUVector.readAsync() does not support interleaved vectors');
     }
 
-    if (arrow.DataType.isUtf8(this.type)) {
+    if (arrow.DataType.isUtf8(this.type) || isVariableLengthAttributeArrowType(this.type)) {
       const data = await Promise.all(this.data.map(chunk => chunk.readAsync()));
       return new arrow.Vector(data) as arrow.Vector<T>;
     }

--- a/modules/arrow/src/arrow/arrow-types.ts
+++ b/modules/arrow/src/arrow/arrow-types.ts
@@ -11,8 +11,13 @@ export type NumericArrowType = arrow.Int | arrow.Float;
 /** Attribute-compatible Arrow column type with one to four numeric values per row. */
 export type AttributeArrowType = NumericArrowType | arrow.FixedSizeList<NumericArrowType>;
 
+/** Variable-length Arrow column with one to four numeric values per nested element. */
+export type VariableLengthAttributeArrowType = arrow.List<
+  NumericArrowType | arrow.FixedSizeList<NumericArrowType>
+>;
+
 /** Mesh-compatible Arrow column type with a list of attribute-compatible values per row. */
-export type MeshArrowType = arrow.List<NumericArrowType | arrow.FixedSizeList<NumericArrowType>>;
+export type MeshArrowType = VariableLengthAttributeArrowType;
 
 /** Arrow column shape and numeric type information needed to derive a GPU vertex format. */
 export type ArrowColumnInfo = {
@@ -37,13 +42,22 @@ export function isNumericArrowType(type: arrow.DataType): type is arrow.Int | ar
 export function isInstanceArrowType(type: arrow.DataType): type is AttributeArrowType {
   return (
     isNumericArrowType(type) ||
-    (arrow.DataType.isFixedSizeList(type) && isNumericArrowType(type.children[0].type))
-    // TODO - check listSize?
+    (arrow.DataType.isFixedSizeList(type) &&
+      type.listSize >= 1 &&
+      type.listSize <= 4 &&
+      isNumericArrowType(type.children[0].type))
   );
 }
 
 /** Returns true when an Arrow type can provide multiple scalar/vector attributes per row. */
 export function isVertexArrowType(type: arrow.DataType): type is MeshArrowType {
+  return isVariableLengthAttributeArrowType(type);
+}
+
+/** Returns true when an Arrow type can encode variable-length nested numeric attributes. */
+export function isVariableLengthAttributeArrowType(
+  type: arrow.DataType
+): type is VariableLengthAttributeArrowType {
   return arrow.DataType.isList(type) && isInstanceArrowType(type.children[0].type);
 }
 

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -52,6 +52,7 @@ export {
   GPUData,
   GPUVector,
   type GPUDataFromBufferProps,
+  type GPUDataReadbackMetadata,
   type GPUVectorBufferProps,
   type GPUVectorCreateProps,
   type GPUVectorDynamicBufferProps,

--- a/modules/arrow/test/arrow/arrow-fixed-size-list.spec.ts
+++ b/modules/arrow/test/arrow/arrow-fixed-size-list.spec.ts
@@ -326,7 +326,10 @@ test('GPUVector preserves Arrow Data chunk boundaries over one packed GPU buffer
   t.equal(gpuVector.buffer.byteLength, 12, 'uploads every vector chunk into one GPU buffer');
   t.equal(gpuVector.data.length, 2, 'exposes one GPUData view per source chunk');
   t.ok(gpuVector.data[0] instanceof GPUData, 'uses GPUData chunk views');
-  t.ok(gpuVector.data[0].sourceData, 'retains source chunk metadata for consumers');
+  t.notOk(
+    gpuVector.data[0].readbackMetadata,
+    'fixed-width chunks do not retain extra readback metadata'
+  );
   t.equal(gpuVector.data[1].byteOffset, 8, 'tracks packed byte offsets across chunks');
   t.deepEqual(Array.from(vectorResult.toArray()), [1, 2, 3], 'reads every packed row');
   t.deepEqual(
@@ -350,7 +353,11 @@ test('GPUVector preserves UTF-8 chunk boundaries and readAsync rows', async t =>
   const firstChunkResult = await gpuVector.data[0].readAsync();
 
   t.equal(gpuVector.data.length, 2, 'keeps one GPUData object per UTF-8 source chunk');
-  t.ok(gpuVector.data[0].sourceData, 'retains UTF-8 source metadata for text consumers');
+  t.equal(
+    gpuVector.data[0].readbackMetadata?.kind,
+    'utf8',
+    'retains compact UTF-8 readback metadata'
+  );
   t.deepEqual(
     Array.from(vectorResult.toArray()),
     ['alpha', null, 'beta'],
@@ -360,6 +367,25 @@ test('GPUVector preserves UTF-8 chunk boundaries and readAsync rows', async t =>
     Array.from(arrow.makeVector(firstChunkResult).toArray()),
     ['alpha', null],
     'reads an individual UTF-8 GPUData chunk'
+  );
+
+  gpuVector.destroy();
+  t.end();
+});
+
+test('GPUVector UTF-8 readAsync normalizes sliced offsets without retaining source data', async t => {
+  const device = new NullDevice({});
+  const sourceVector = arrow.vectorFromArray(['skip', null, 'kept'], new arrow.Utf8());
+  const slicedVector = sourceVector.slice(1) as arrow.Vector<arrow.Utf8>;
+  const gpuVector = new GPUVector(device, slicedVector);
+
+  const result = await gpuVector.readAsync();
+
+  t.deepEqual(Array.from(result.toArray()), [null, 'kept'], 'reads sliced UTF-8 rows');
+  t.deepEqual(
+    Array.from(result.data[0].valueOffsets as Int32Array),
+    [0, 0, 4],
+    'reconstructs local compact UTF-8 offsets'
   );
 
   gpuVector.destroy();
@@ -631,8 +657,10 @@ test('GPUVector addToLastData appends Arrow data into appendable vector storage'
   t.equal(gpuVector.length, 4, 'tracks rows appended into the final mutable batch');
   t.equal(gpuVector.data.length, 2, 'exposes one GPU data range per appended Arrow chunk');
   t.equal(gpuVector.data[1].byteOffset, 8, 'tracks the later append byte offset');
-  t.equal(gpuVector.data[0].sourceData, firstData, 'retains the first appended Arrow source');
-  t.equal(gpuVector.data[1].sourceData, secondData, 'retains the later appended Arrow source');
+  t.notOk(
+    gpuVector.data[0].readbackMetadata,
+    'fixed-width append chunks do not retain reconstruction metadata'
+  );
   t.ok((gpuVector.capacityRows ?? 0) >= 4, 'grows appendable capacity as needed');
 
   gpuVector.resetLastBatch();
@@ -658,8 +686,16 @@ test('GPUVector addToLastData appends UTF-8 Arrow data into appendable vector st
 
   t.equal(gpuVector.length, 3, 'tracks UTF-8 logical rows across appends');
   t.equal(gpuVector.data.length, 2, 'preserves UTF-8 append chunk boundaries');
-  t.equal(gpuVector.data[0].sourceData, firstData, 'retains the first UTF-8 source chunk');
-  t.equal(gpuVector.data[1].sourceData, secondData, 'retains the later UTF-8 source chunk');
+  t.equal(
+    gpuVector.data[0].readbackMetadata?.kind,
+    'utf8',
+    'retains copied UTF-8 offsets for the first append chunk'
+  );
+  t.equal(
+    gpuVector.data[1].readbackMetadata?.kind,
+    'utf8',
+    'retains copied UTF-8 offsets for the later append chunk'
+  );
   t.ok(gpuVector.data[1].byteOffset > 0, 'writes later UTF-8 bytes after earlier bytes');
   t.equal(
     gpuVector.data[1].byteOffset % 4,

--- a/modules/arrow/test/arrow/arrow-variable-length-attribute-gpu-vector.spec.ts
+++ b/modules/arrow/test/arrow/arrow-variable-length-attribute-gpu-vector.spec.ts
@@ -1,0 +1,335 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {GPUVector} from '@luma.gl/arrow';
+import {NullDevice} from '@luma.gl/test-utils';
+import * as arrow from 'apache-arrow';
+
+type ScalarNestedAttributeType = arrow.List<arrow.Int16>;
+type TupleNestedAttributeType = arrow.List<arrow.FixedSizeList<arrow.Float32>>;
+
+test('GPUVector uploads nested scalar attributes and round-trips Arrow offsets', async t => {
+  const device = new NullDevice({});
+  const sourceVector = makeScalarNestedAttributeVector(
+    new Int32Array([0, 3, 5]),
+    new Int16Array([10, 20, 30, 40, 50])
+  );
+  const gpuVector = new GPUVector({
+    type: 'arrow',
+    name: 'nestedScalars',
+    device,
+    vector: sourceVector
+  });
+  const result = await gpuVector.readAsync();
+
+  t.equal(gpuVector.length, 2, 'retains one logical GPU row per nested list row');
+  t.equal(gpuVector.stride, 1, 'reports scalar nested elements as stride one');
+  t.equal(gpuVector.byteStride, 2, 'reports one Int16 scalar byte stride');
+  t.equal(gpuVector.data[0].buffer.byteLength, 10, 'uploads flattened scalar bytes');
+  t.deepEqual(
+    Array.from(result.data[0].valueOffsets as Int32Array),
+    [0, 3, 5],
+    'readAsync preserves variable-length scalar offsets'
+  );
+  t.deepEqual(
+    Array.from(getScalarNestedAttributeValues(result)),
+    [10, 20, 30, 40, 50],
+    'readAsync preserves flattened scalar values'
+  );
+
+  gpuVector.destroy();
+  t.end();
+});
+
+test('GPUVector supports fixed nested attribute widths from one to four components', async t => {
+  const device = new NullDevice({});
+
+  for (const dimension of [1, 2, 3, 4] as const) {
+    const expectedValues = makeFloatValues(dimension, 3);
+    const sourceVector = makeTupleNestedAttributeVector(
+      dimension,
+      new Int32Array([0, 2, 3]),
+      expectedValues
+    );
+    const gpuVector = new GPUVector({
+      type: 'arrow',
+      name: `nestedTuple${dimension}`,
+      device,
+      vector: sourceVector
+    });
+    const result = await gpuVector.readAsync();
+
+    t.equal(gpuVector.stride, dimension, `reports vec${dimension} nested element stride`);
+    t.equal(
+      gpuVector.byteStride,
+      dimension * Float32Array.BYTES_PER_ELEMENT,
+      `reports vec${dimension} nested element byte stride`
+    );
+    t.deepEqual(
+      Array.from(result.data[0].valueOffsets as Int32Array),
+      [0, 2, 3],
+      `readAsync preserves vec${dimension} offsets`
+    );
+    t.deepEqual(
+      Array.from(getTupleNestedAttributeValues(result)),
+      Array.from(expectedValues),
+      `readAsync preserves vec${dimension} flattened values`
+    );
+
+    gpuVector.destroy();
+  }
+
+  t.end();
+});
+
+test('GPUVector preserves chunked tuple nested attribute batches', async t => {
+  const device = new NullDevice({});
+  const firstChunk = makeTupleNestedAttributeVector(
+    3,
+    new Int32Array([0, 2]),
+    new Float32Array([0, 0, 0, 1, 0, 0])
+  );
+  const secondChunk = makeTupleNestedAttributeVector(
+    3,
+    new Int32Array([0, 3]),
+    new Float32Array([2, 0, 0, 2, 1, 0, 2, 1, 1])
+  );
+  const sourceVector = new arrow.Vector<TupleNestedAttributeType>([
+    ...(firstChunk.data as arrow.Data<TupleNestedAttributeType>[]),
+    ...(secondChunk.data as arrow.Data<TupleNestedAttributeType>[])
+  ]);
+  const gpuVector = new GPUVector({
+    type: 'arrow',
+    name: 'nestedTuples',
+    device,
+    vector: sourceVector
+  });
+  const result = await gpuVector.readAsync();
+
+  t.equal(gpuVector.data.length, 2, 'keeps one GPUData chunk per Arrow list chunk');
+  t.equal(
+    gpuVector.data[0].readbackMetadata?.kind,
+    'variable-length-attribute',
+    'retains compact nested-list readback metadata'
+  );
+  t.equal(gpuVector.byteStride, 12, 'reports one vec3 Float32 element byte stride');
+  t.deepEqual(
+    result.data.map(data => data.length),
+    [1, 1],
+    'readAsync preserves chunk-local nested list row counts'
+  );
+  t.deepEqual(
+    Array.from(getTupleNestedAttributeValues(result)),
+    [0, 0, 0, 1, 0, 0, 2, 0, 0, 2, 1, 0, 2, 1, 1],
+    'readAsync merges flattened vec3 values across chunks'
+  );
+
+  gpuVector.destroy();
+  t.end();
+});
+
+test('GPUVector nested list readAsync normalizes sliced offsets', async t => {
+  const device = new NullDevice({});
+  const sourceVector = makeTupleNestedAttributeVector(
+    2,
+    new Int32Array([0, 2, 3]),
+    new Float32Array([0, 0, 1, 1, 2, 2])
+  );
+  const slicedVector = sourceVector.slice(1) as arrow.Vector<TupleNestedAttributeType>;
+  const gpuVector = new GPUVector({
+    type: 'arrow',
+    name: 'slicedNestedTuples',
+    device,
+    vector: slicedVector
+  });
+  const result = await gpuVector.readAsync();
+
+  t.deepEqual(
+    Array.from(result.data[0].valueOffsets as Int32Array),
+    [0, 1],
+    'reconstructs local compact nested-list offsets'
+  );
+  t.deepEqual(
+    Array.from(getTupleNestedAttributeValues(result)),
+    [2, 2],
+    'reads the sliced nested tuple payload'
+  );
+
+  gpuVector.destroy();
+  t.end();
+});
+
+test('GPUVector appendable nested lists retain compact readback metadata', async t => {
+  const device = new NullDevice({});
+  const firstData = makeTupleNestedAttributeData(
+    2,
+    new Int32Array([0, 2]),
+    new Float32Array([0, 0, 1, 1])
+  );
+  const secondData = makeTupleNestedAttributeData(
+    2,
+    new Int32Array([0, 1]),
+    new Float32Array([2, 2])
+  );
+  const gpuVector = new GPUVector<TupleNestedAttributeType>({
+    type: 'appendable',
+    name: 'appendableNestedTuples',
+    device,
+    arrowType: firstData.type,
+    initialCapacityRows: 1
+  });
+
+  gpuVector.addToLastData(firstData);
+  gpuVector.addToLastData(secondData);
+  const result = await gpuVector.readAsync();
+
+  t.equal(gpuVector.length, 2, 'tracks appended nested list rows');
+  t.equal(gpuVector.data.length, 2, 'keeps one GPUData chunk per nested append');
+  t.equal(
+    gpuVector.data[0].readbackMetadata?.kind,
+    'variable-length-attribute',
+    'stores copied nested-list readback metadata'
+  );
+  t.deepEqual(
+    result.data.map(data => Array.from(data.valueOffsets as Int32Array)),
+    [
+      [0, 2],
+      [0, 1]
+    ],
+    'round-trips chunk-local appended nested offsets'
+  );
+  t.deepEqual(
+    Array.from(getTupleNestedAttributeValues(result)),
+    [0, 0, 1, 1, 2, 2],
+    'round-trips appended nested tuple values'
+  );
+
+  gpuVector.destroy();
+  t.end();
+});
+
+test('GPUVector rejects nullable variable-length nested attribute rows', t => {
+  const device = new NullDevice({});
+  const nullableData = makeTupleNestedAttributeData(
+    2,
+    new Int32Array([0, 2]),
+    new Float32Array([0, 0, 1, 1]),
+    1,
+    new Uint8Array([0])
+  );
+  const vector = new arrow.Vector<TupleNestedAttributeType>([nullableData]);
+
+  t.throws(
+    () =>
+      new GPUVector({
+        type: 'arrow',
+        name: 'nestedTuples',
+        device,
+        vector
+      }),
+    /does not support nullable data/,
+    'nested uploads fail before GPU allocation when top-level row nulls are present'
+  );
+  t.end();
+});
+
+function makeScalarNestedAttributeVector(
+  valueOffsets: Int32Array,
+  values: Int16Array
+): arrow.Vector<ScalarNestedAttributeType> {
+  const scalarType = new arrow.Int16();
+  const listType = new arrow.List(
+    new arrow.Field('values', scalarType, false)
+  ) as ScalarNestedAttributeType;
+  const scalarData = new arrow.Data<arrow.Int16>(scalarType, 0, values.length, 0, {
+    [arrow.BufferType.DATA]: values
+  });
+  const listData = new arrow.Data<ScalarNestedAttributeType>(
+    listType,
+    0,
+    valueOffsets.length - 1,
+    0,
+    {[arrow.BufferType.OFFSET]: valueOffsets},
+    [scalarData]
+  );
+  return new arrow.Vector<ScalarNestedAttributeType>([listData]);
+}
+
+function makeTupleNestedAttributeVector(
+  dimension: 1 | 2 | 3 | 4,
+  valueOffsets: Int32Array,
+  values: Float32Array
+): arrow.Vector<TupleNestedAttributeType> {
+  return new arrow.Vector<TupleNestedAttributeType>([
+    makeTupleNestedAttributeData(dimension, valueOffsets, values)
+  ]);
+}
+
+function makeTupleNestedAttributeData(
+  dimension: 1 | 2 | 3 | 4,
+  valueOffsets: Int32Array,
+  values: Float32Array,
+  nullCount = 0,
+  nullBitmap?: Uint8Array
+): arrow.Data<TupleNestedAttributeType> {
+  const tupleType = new arrow.FixedSizeList(
+    dimension,
+    new arrow.Field('values', new arrow.Float32(), false)
+  );
+  const listType = new arrow.List(
+    new arrow.Field('attributes', tupleType, false)
+  ) as TupleNestedAttributeType;
+  const numericData = new arrow.Data<arrow.Float32>(new arrow.Float32(), 0, values.length, 0, {
+    [arrow.BufferType.DATA]: values
+  });
+  const tupleData = new arrow.Data<arrow.FixedSizeList<arrow.Float32>>(
+    tupleType,
+    0,
+    values.length / dimension,
+    0,
+    {},
+    [numericData]
+  );
+  return new arrow.Data<TupleNestedAttributeType>(
+    listType,
+    0,
+    valueOffsets.length - 1,
+    nullCount,
+    {
+      [arrow.BufferType.OFFSET]: valueOffsets,
+      ...(nullBitmap ? {[arrow.BufferType.VALIDITY]: nullBitmap} : {})
+    },
+    [tupleData]
+  );
+}
+
+function makeFloatValues(dimension: 1 | 2 | 3 | 4, elementCount: number): Float32Array {
+  return new Float32Array(
+    Array.from({length: dimension * elementCount}, (_, valueIndex) => valueIndex + 0.5)
+  );
+}
+
+function getScalarNestedAttributeValues(
+  vector: arrow.Vector<ScalarNestedAttributeType>
+): Int16Array {
+  const values: number[] = [];
+  for (const data of vector.data as arrow.Data<ScalarNestedAttributeType>[]) {
+    const scalarData = data.children[0] as arrow.Data<arrow.Int16>;
+    values.push(...Array.from(scalarData.values as Int16Array));
+  }
+  return new Int16Array(values);
+}
+
+function getTupleNestedAttributeValues(
+  vector: arrow.Vector<TupleNestedAttributeType>
+): Float32Array {
+  const values: number[] = [];
+  for (const data of vector.data as arrow.Data<TupleNestedAttributeType>[]) {
+    const tupleData = data.children[0] as arrow.Data<arrow.FixedSizeList<arrow.Float32>>;
+    const numericData = tupleData.children[0] as arrow.Data<arrow.Float32>;
+    values.push(...Array.from(numericData.values as Float32Array));
+  }
+  return new Float32Array(values);
+}

--- a/modules/arrow/test/arrow/plain-gpu-table.spec.ts
+++ b/modules/arrow/test/arrow/plain-gpu-table.spec.ts
@@ -338,9 +338,9 @@ test('GPUTable addToLastBatch appends Arrow batches into one mutable trailing GP
   t.equal(gpuTable.numRows, 4, 'updates table rows across append operations');
   t.equal(gpuTable.batches[0].numRows, 4, 'updates trailing batch row count');
   t.equal(gpuTable.gpuVectors.positions.data.length, 2, 'restitches aggregate GPU ranges');
-  t.ok(
-    gpuTable.gpuVectors.positions.data[0].sourceData,
-    'retains appended Arrow source chunks through aggregate table vectors'
+  t.notOk(
+    gpuTable.gpuVectors.positions.data[0].readbackMetadata,
+    'aggregate fixed-width table vectors do not retain Arrow source payload metadata'
   );
   t.ok(
     gpuTable.attributes.positions instanceof DynamicBuffer,
@@ -355,7 +355,7 @@ test('GPUTable addToLastBatch appends Arrow batches into one mutable trailing GP
   t.end();
 });
 
-test('GPUTable appendable batches expose UTF-8 storage vectors with retained sources', t => {
+test('GPUTable appendable batches expose UTF-8 storage vectors with compact metadata', t => {
   const device = new NullDevice({});
   const positions = makeArrowFixedSizeListVector(
     new arrow.Float32(),
@@ -380,7 +380,11 @@ test('GPUTable appendable batches expose UTF-8 storage vectors with retained sou
   t.equal(gpuTable.numRows, 2, 'tracks appended table rows');
   t.ok(gpuTable.bindings.texts, 'exposes the UTF-8 vector as a storage binding');
   t.equal(gpuTable.gpuVectors.texts.length, 2, 'tracks UTF-8 vector rows');
-  t.ok(gpuTable.gpuVectors.texts.data[0].sourceData, 'retains UTF-8 source offsets');
+  t.equal(
+    gpuTable.gpuVectors.texts.data[0].readbackMetadata?.kind,
+    'utf8',
+    'retains copied UTF-8 readback offsets'
+  );
 
   gpuTable.destroy();
   t.end();

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -5,6 +5,7 @@
 import './arrow/arrow-paths.spec';
 import './arrow/arrow-column-info.spec';
 import './arrow/arrow-fixed-size-list.spec';
+import './arrow/arrow-variable-length-attribute-gpu-vector.spec';
 import './arrow/arrow-geometry.spec';
 import './arrow/plain-gpu-table.spec';
 import './arrow/arrow-model.spec';

--- a/modules/text/README.md
+++ b/modules/text/README.md
@@ -13,29 +13,32 @@ import * as arrow from 'apache-arrow'
 import {GPUVector, makeArrowVectorFromArray} from '@luma.gl/arrow'
 import {ArrowTextModel} from '@luma.gl/text'
 
+const positionSource = makeArrowVectorFromArray([0, 0, 0.5, 0.25], new arrow.Float32(), 2)
+const textSource = makeArrowVectorFromArray(['hello', 'luma.gl'], new arrow.Utf8())
 const positions = new GPUVector({
   device,
   name: 'positions',
-  vector: makeArrowVectorFromArray([0, 0, 0.5, 0.25], new arrow.Float32(), 2)
+  vector: positionSource
 })
 const texts = new GPUVector({
   device,
   name: 'texts',
-  vector: makeArrowVectorFromArray(['hello', 'luma.gl'], new arrow.Utf8())
+  vector: textSource
 })
 
 const model = new ArrowTextModel(device, {
   id: 'arrow-text',
   positions,
   texts,
+  sourceVectors: {positions: positionSource, texts: textSource},
   characterSet: 'auto',
   fontSettings: {sdf: true}
 })
 ```
 
-`ArrowTextModel` accepts top-level GPU-resident row vectors such as `positions`, `colors`, `angles`, `sizes`, and `pixelOffsets`, with `texts` supplied as `GPUVector<Utf8>`. UTF-8 GPU vectors preserve one `GPUData` entry per Arrow source chunk and retain the chunk metadata needed for text expansion, so chunked and sliced sources stay addressable without collapsing them into one host string array. The model repeats compatible Arrow-backed row attributes for each glyph, emits generated `rowIndices` for source-row picking, and delegates GPU upload/update behavior to `ArrowModel`. Pass optional `clipRects` as `GPUVector<FixedSizeList<Int16>[4]>` rows containing `[x, y, width, height]` glyph-layout units; negative width or height disables clipping on that axis. The generated per-glyph clipping attribute stays packed at 8 bytes per glyph. When the built-in fragment shader is used, `fontSettings.sdf`, `cutoff`, and `smoothing` also drive SDF atlas decoding automatically; custom fragment shaders remain responsible for their own atlas-alpha interpretation.
+`ArrowTextModel` accepts top-level GPU-resident row vectors such as `positions`, `colors`, `angles`, `sizes`, and `pixelOffsets`, with `texts` supplied as `GPUVector<Utf8>`. CPU-side glyph expansion is explicit through aligned `sourceVectors`, so generic GPU wrappers do not retain the uploaded Arrow value arrays. The model repeats compatible Arrow-backed row attributes for each glyph, emits generated `rowIndices` for source-row picking, and delegates GPU upload/update behavior to `ArrowModel`. Pass optional `clipRects` as `GPUVector<FixedSizeList<Int16>[4]>` rows containing `[x, y, width, height]` glyph-layout units and provide the matching source vector when clipping participates in glyph generation; negative width or height disables clipping on that axis. The generated per-glyph clipping attribute stays packed at 8 bytes per glyph. When the built-in fragment shader is used, `fontSettings.sdf`, `cutoff`, and `smoothing` also drive SDF atlas decoding automatically; custom fragment shaders remain responsible for their own atlas-alpha interpretation.
 
-`ArrowStorageTextModel` is the WebGPU storage-backed path. It requires top-level `positions` as `GPUVector<FixedSizeList<Float32>[2]>` plus `texts`, accepts optional row-style `colors`, `angles`, `sizes`, `pixelOffsets`, `textAnchors`, and `alignmentBaselines` GPUVectors, and falls back to constant deck-like props when a style vector is absent. Storage inputs keep their existing aligned GPUData batches; the model binds each batch directly, renders interleaved `compactGlyphVertexData` buffers containing offsets, glyph indexes, and global source `rowIndices`, and only allocates model-owned storage for generated glyph state, small fallback/style config buffers, glyph definitions, and optional packed clip rectangles. Large generated glyph payloads are split into multiple render batches when device buffer limits require it. Text anchors use `Uint8` row enums `0=start`, `1=middle`, `2=end`; alignment baselines use `0=center`, `1=top`, `2=bottom`.
+`ArrowStorageTextModel` is the WebGPU storage-backed path. It requires top-level `positions` as `GPUVector<FixedSizeList<Float32>[2]>` plus `texts`, accepts optional row-style `colors`, `angles`, `sizes`, `pixelOffsets`, `textAnchors`, and `alignmentBaselines` GPUVectors, and falls back to constant deck-like props when a style vector is absent. Storage expansion receives explicit CPU `sourceVectors` for UTF-8 text rows and optional clip rectangles only; GPU-only row style and position vectors stay GPU-resident. Storage inputs keep their existing aligned GPUData batches; the model binds each batch directly, renders interleaved `compactGlyphVertexData` buffers containing offsets, glyph indexes, and global source `rowIndices`, and only allocates model-owned storage for generated glyph state, small fallback/style config buffers, glyph definitions, and optional packed clip rectangles. Large generated glyph payloads are split into multiple render batches when device buffer limits require it. Text anchors use `Uint8` row enums `0=start`, `1=middle`, `2=end`; alignment baselines use `0=center`, `1=top`, `2=bottom`.
 
 Both render paths keep caller-owned row vectors separate from model-generated per-glyph data. The attribute path stores generated offsets, inline glyph frames, and row ids in `expandedGlyphVertexData`; the storage path stores generated offsets, glyph ids, and row ids in `compactGlyphVertexData`. That split keeps style vectors independently updateable while reducing generated glyph buffer fan-out.
 
@@ -72,6 +75,6 @@ Text draw buffers:
 
 Call `createArrowStorageTextState(device, props)` when storage-state construction should be decoupled from rendering. The returned `ArrowStorageTextState` owns its storage buffers, atlas texture, generated render buffers, byte/timing diagnostics, row-binding batches, generated render batches, and a `destroy()` method. `ArrowStorageTextModel` accepts either the original GPUVector input props and owns the generated state, or `{storageState}` plus render overrides when the caller wants to reuse and manage that state directly. With `characterSet: 'auto'`, the CPU builds compact glyph IDs and spans before compute expansion. With an explicit non-auto character set, the state builder uploads normalized Arrow UTF-8 bytes plus row byte ranges and decodes glyph IDs directly on the GPU, avoiding CPU UTF-8/glyph-stream construction.
 
-For streamed Arrow tables that retain source `GPURecordBatch` boundaries, `ArrowTextModel.appendTextBatches(...)` and `ArrowStorageTextModel.appendTextBatches(...)` convert only the newly arrived row batches into generated glyph render batches. Previously generated glyph buffers stay resident; one source batch may still fan out into multiple generated render batches when device buffer limits require splitting.
+For streamed Arrow tables that retain source `GPURecordBatch` boundaries, `ArrowTextModel.appendTextBatches(...)` and `ArrowStorageTextModel.appendTextBatches(...)` convert only the newly arrived row batches into generated glyph render batches. Append calls must include source-vector bundles with matching new CPU Arrow chunks. Previously generated glyph buffers stay resident; one source batch may still fan out into multiple generated render batches when device buffer limits require splitting.
 
 `getGpuUtf8MapShaderSource()` and `getGpuUtf8MapShaderBindings()` expose the reusable WebGPU UTF-8 mapping fragment behind that explicit-character-set path. Consumers can compose the shared sparse byte-indexed UTF-8 row traversal, code point decoding, and lookup-table mapping into a one-pass text-oriented compute shader without taking on a separate compact-output stage.

--- a/modules/text/src/text-2d/arrow-text-model.ts
+++ b/modules/text/src/text-2d/arrow-text-model.ts
@@ -402,6 +402,23 @@ export type ArrowTextGlyphTable = {
   glyphAttributeBuildTimeMs: number;
 };
 
+/** CPU Arrow vectors used when one-line text layout expands rows into glyph attributes. */
+export type ArrowTextSourceVectors = {
+  positions: arrow.Vector<arrow.FixedSizeList<arrow.Float32>>;
+  texts: arrow.Vector<arrow.Utf8>;
+  colors?: arrow.Vector<arrow.FixedSizeList<arrow.Uint8>>;
+  angles?: arrow.Vector<arrow.Float32>;
+  sizes?: arrow.Vector<arrow.Float32>;
+  pixelOffsets?: arrow.Vector<arrow.FixedSizeList<arrow.Float32>>;
+  clipRects?: arrow.Vector<arrow.FixedSizeList<arrow.Int16>>;
+};
+
+/** CPU Arrow vectors still needed by storage-backed text expansion. */
+export type ArrowStorageTextSourceVectors = {
+  texts: arrow.Vector<arrow.Utf8>;
+  clipRects?: arrow.Vector<arrow.FixedSizeList<arrow.Int16>>;
+};
+
 export type ArrowTextModelProps = Omit<
   ArrowModelProps,
   'arrowTable' | 'arrowGPUTable' | 'arrowCount'
@@ -418,6 +435,8 @@ export type ArrowTextModelProps = Omit<
   pixelOffsets?: GPUVector<arrow.FixedSizeList<arrow.Float32>>;
   /** GPU UTF-8 labels aligned row-for-row with `positions`. */
   texts: GPUVector<arrow.Utf8>;
+  /** CPU Arrow vectors explicitly retained by the caller for glyph/layout expansion. */
+  sourceVectors: ArrowTextSourceVectors;
   /**
    * Optional packed per-label clip rectangles `[x, y, width, height]`.
    * Values are signed 16-bit glyph-layout units relative to the label origin.
@@ -438,7 +457,9 @@ export type ArrowTextModelProps = Omit<
   fontAtlas?: FontAtlas;
 };
 
-export type ArrowStorageTextInputProps = ArrowTextModelProps & {
+export type ArrowStorageTextInputProps = Omit<ArrowTextModelProps, 'sourceVectors'> & {
+  /** CPU Arrow vectors explicitly retained by the caller for storage glyph expansion. */
+  sourceVectors: ArrowStorageTextSourceVectors;
   /** Optional per-row text anchor enum: 0=start, 1=middle, 2=end. */
   textAnchors?: GPUVector<arrow.Uint8>;
   /** Optional per-row alignment baseline enum: 0=center, 1=top, 2=bottom. */
@@ -471,6 +492,7 @@ type ArrowStorageTextRenderProps = Omit<
   | 'fontAtlasManager'
   | 'characterMapping'
   | 'fontAtlas'
+  | 'sourceVectors'
 >;
 
 export type ArrowStorageTextBatchState = {
@@ -587,6 +609,7 @@ export class ArrowTextModel extends ArrowModel {
       props.sizes !== undefined ||
       props.pixelOffsets !== undefined ||
       props.texts !== undefined ||
+      props.sourceVectors !== undefined ||
       props.clipRects !== undefined ||
       props.characterSet !== undefined ||
       props.fontSettings !== undefined ||
@@ -637,6 +660,11 @@ export class ArrowTextModel extends ArrowModel {
     assertArrowTextVectorTypes(nextProps);
     assertArrowTextVectorBatchAlignment(nextProps);
     assertArrowTextAppendPrefixStable(this.textProps, nextProps, this.processedTextBatchCount);
+    assertArrowTextSourceAppendPrefixStable(
+      this.textProps,
+      nextProps,
+      this.processedTextBatchCount
+    );
 
     const nextBatchCount = nextProps.texts.data.length;
     if (nextBatchCount < this.processedTextBatchCount) {
@@ -813,6 +841,7 @@ export class ArrowStorageTextModel extends Model {
     const shouldReplaceState =
       shouldReplaceExternalState ||
       arrowProps.texts !== undefined ||
+      arrowProps.sourceVectors !== undefined ||
       arrowProps.textAnchors !== undefined ||
       arrowProps.alignmentBaselines !== undefined ||
       arrowProps.textAnchor !== undefined ||
@@ -873,6 +902,11 @@ export class ArrowStorageTextModel extends Model {
     }
     const nextProps = {...this.textProps, ...props} as ArrowStorageTextInputProps;
     assertArrowStorageTextAppendProps(props);
+    assertArrowStorageTextSourceAppendPrefixStable(
+      this.textProps as ArrowStorageTextInputProps,
+      nextProps,
+      this.storageState.batches.length
+    );
     appendArrowStorageTextStateBatches(this.device, nextProps, this.storageState);
     this.textProps = nextProps;
     this.applyStorageState(this.storageState);
@@ -1026,35 +1060,34 @@ type ResolvedArrowTextInputs = {
 };
 
 function resolveArrowTextInputs(props: ArrowTextModelProps): ResolvedArrowTextInputs {
+  if (!props.sourceVectors) {
+    throw new Error('ArrowTextModel requires explicit sourceVectors for CPU glyph expansion');
+  }
   assertArrowTextVectorTypes(props);
   assertArrowTextVectorRowAlignment(props);
-  const texts = getRetainedGPUVectorSource(props.texts, 'texts');
+  assertArrowTextSourceVectorAlignment(props);
+  const {sourceVectors} = props;
   const columns: Record<string, arrow.Vector> = {
-    positions: getRetainedGPUVectorSource(props.positions, 'positions')
+    positions: sourceVectors.positions
   };
-  if (props.colors) {
-    columns['colors'] = getRetainedGPUVectorSource(props.colors, 'colors');
+  if (sourceVectors.colors) {
+    columns['colors'] = sourceVectors.colors;
   }
-  if (props.angles) {
-    columns['angles'] = getRetainedGPUVectorSource(props.angles, 'angles');
+  if (sourceVectors.angles) {
+    columns['angles'] = sourceVectors.angles;
   }
-  if (props.sizes) {
-    columns['sizes'] = getRetainedGPUVectorSource(props.sizes, 'sizes');
+  if (sourceVectors.sizes) {
+    columns['sizes'] = sourceVectors.sizes;
   }
-  if (props.pixelOffsets) {
-    columns['pixelOffsets'] = getRetainedGPUVectorSource(props.pixelOffsets, 'pixelOffsets');
+  if (sourceVectors.pixelOffsets) {
+    columns['pixelOffsets'] = sourceVectors.pixelOffsets;
   }
   const labelTable = new arrow.Table(columns);
-  const clipRects = props.clipRects
-    ? (getRetainedGPUVectorSource(props.clipRects, 'clipRects') as arrow.Vector<
-        arrow.FixedSizeList<arrow.Int16>
-      >)
-    : undefined;
 
   return {
     labelTable,
-    texts: texts as arrow.Vector<arrow.Utf8>,
-    clipRects
+    texts: sourceVectors.texts,
+    clipRects: sourceVectors.clipRects
   };
 }
 
@@ -1062,25 +1095,22 @@ function resolveArrowTextBatchInputs(
   props: ArrowTextModelProps,
   batchIndex: number
 ): ResolvedArrowTextInputs {
-  const textData = props.texts.data[batchIndex];
-  const positionData = props.positions.data[batchIndex];
-  if (!textData?.sourceData || !positionData?.sourceData) {
-    throw new Error('ArrowTextModel appended batches require retained text and position sources');
-  }
+  const {sourceVectors} = props;
   const columns: Record<string, arrow.Vector> = {
-    positions: new arrow.Vector([positionData.sourceData])
+    positions: getArrowTextSourceBatch(sourceVectors.positions, 'positions', batchIndex)
   };
-  appendArrowTextBatchSourceColumn(columns, 'colors', props.colors, batchIndex);
-  appendArrowTextBatchSourceColumn(columns, 'angles', props.angles, batchIndex);
-  appendArrowTextBatchSourceColumn(columns, 'sizes', props.sizes, batchIndex);
-  appendArrowTextBatchSourceColumn(columns, 'pixelOffsets', props.pixelOffsets, batchIndex);
+  appendArrowTextBatchSourceColumn(columns, 'colors', sourceVectors.colors, batchIndex);
+  appendArrowTextBatchSourceColumn(columns, 'angles', sourceVectors.angles, batchIndex);
+  appendArrowTextBatchSourceColumn(columns, 'sizes', sourceVectors.sizes, batchIndex);
+  appendArrowTextBatchSourceColumn(columns, 'pixelOffsets', sourceVectors.pixelOffsets, batchIndex);
 
-  const clipRectSourceData = props.clipRects?.data[batchIndex]?.sourceData;
   return {
     labelTable: new arrow.Table(columns),
-    texts: new arrow.Vector([textData.sourceData]) as arrow.Vector<arrow.Utf8>,
-    clipRects: clipRectSourceData
-      ? (new arrow.Vector([clipRectSourceData]) as arrow.Vector<arrow.FixedSizeList<arrow.Int16>>)
+    texts: getArrowTextSourceBatch(sourceVectors.texts, 'texts', batchIndex),
+    clipRects: sourceVectors.clipRects
+      ? (getArrowTextSourceBatch(sourceVectors.clipRects, 'clipRects', batchIndex) as arrow.Vector<
+          arrow.FixedSizeList<arrow.Int16>
+        >)
       : undefined
   };
 }
@@ -1088,17 +1118,25 @@ function resolveArrowTextBatchInputs(
 function appendArrowTextBatchSourceColumn(
   columns: Record<string, arrow.Vector>,
   columnName: string,
-  vector: GPUVector<any> | undefined,
+  vector: arrow.Vector | undefined,
   batchIndex: number
 ): void {
   if (!vector) {
     return;
   }
-  const sourceData = vector.data[batchIndex]?.sourceData;
-  if (!sourceData) {
-    throw new Error(`ArrowTextModel appended ${columnName} batches require retained Arrow sources`);
+  columns[columnName] = getArrowTextSourceBatch(vector, columnName, batchIndex);
+}
+
+function getArrowTextSourceBatch<T extends arrow.DataType>(
+  vector: arrow.Vector<T>,
+  vectorName: string,
+  batchIndex: number
+): arrow.Vector<T> {
+  const data = vector.data[batchIndex];
+  if (!data) {
+    throw new Error(`Arrow text ${vectorName} source is missing batch ${batchIndex}`);
   }
-  columns[columnName] = new arrow.Vector([sourceData]);
+  return new arrow.Vector([data]) as arrow.Vector<T>;
 }
 
 function assertArrowTextVectorTypes(props: ArrowTextModelProps): void {
@@ -1177,6 +1215,31 @@ function assertArrowTextVectorBatchAlignment(props: ArrowTextModelProps): void {
   }
 }
 
+function assertArrowTextSourceVectorAlignment(props: ArrowTextModelProps): void {
+  const sourceInputs: Array<[string, GPUVector<any> | undefined, arrow.Vector | undefined]> = [
+    ['positions', props.positions, props.sourceVectors.positions],
+    ['texts', props.texts, props.sourceVectors.texts],
+    ['colors', props.colors, props.sourceVectors.colors],
+    ['angles', props.angles, props.sourceVectors.angles],
+    ['sizes', props.sizes, props.sourceVectors.sizes],
+    ['pixelOffsets', props.pixelOffsets, props.sourceVectors.pixelOffsets],
+    ['clipRects', props.clipRects, props.sourceVectors.clipRects]
+  ];
+
+  for (const [name, gpuVector, sourceVector] of sourceInputs) {
+    if (gpuVector && !sourceVector) {
+      throw new Error(`ArrowTextModel ${name} GPU rows require matching sourceVectors rows`);
+    }
+    if (!gpuVector && sourceVector) {
+      throw new Error(`ArrowTextModel sourceVectors.${name} requires matching GPU rows`);
+    }
+    if (!gpuVector || !sourceVector) {
+      continue;
+    }
+    assertSourceVectorMatchesGPUVector('ArrowTextModel', name, gpuVector, sourceVector);
+  }
+}
+
 function getArrowTextRowInputs(props: ArrowTextModelProps): Array<[string, GPUVector<any>]> {
   return [
     ['positions', props.positions],
@@ -1197,7 +1260,8 @@ function assertArrowTextAppendProps(props: Partial<ArrowTextModelProps>): void {
     'angles',
     'sizes',
     'pixelOffsets',
-    'clipRects'
+    'clipRects',
+    'sourceVectors'
   ]);
   for (const propName of Object.keys(props)) {
     if (!appendablePropNames.has(propName)) {
@@ -1229,6 +1293,90 @@ function assertArrowTextAppendPrefixStable(
   }
 }
 
+function assertArrowTextSourceAppendPrefixStable(
+  previousProps: ArrowTextModelProps,
+  nextProps: ArrowTextModelProps,
+  processedBatchCount: number
+): void {
+  const previousSourceVectors = previousProps.sourceVectors;
+  const nextSourceVectors = nextProps.sourceVectors;
+  const sourceInputs: Array<[string, arrow.Vector | undefined, arrow.Vector | undefined]> = [
+    ['positions', previousSourceVectors.positions, nextSourceVectors.positions],
+    ['texts', previousSourceVectors.texts, nextSourceVectors.texts],
+    ['colors', previousSourceVectors.colors, nextSourceVectors.colors],
+    ['angles', previousSourceVectors.angles, nextSourceVectors.angles],
+    ['sizes', previousSourceVectors.sizes, nextSourceVectors.sizes],
+    ['pixelOffsets', previousSourceVectors.pixelOffsets, nextSourceVectors.pixelOffsets],
+    ['clipRects', previousSourceVectors.clipRects, nextSourceVectors.clipRects]
+  ];
+
+  for (const [name, previousVector, nextVector] of sourceInputs) {
+    if (!previousVector && nextVector && processedBatchCount > 0) {
+      throw new Error(`ArrowTextModel appendTextBatches() cannot add prior ${name} sources`);
+    }
+    if (!previousVector || !nextVector) {
+      continue;
+    }
+    for (let batchIndex = 0; batchIndex < processedBatchCount; batchIndex++) {
+      if (previousVector.data[batchIndex] !== nextVector.data[batchIndex]) {
+        throw new Error(
+          `ArrowTextModel appendTextBatches() requires existing ${name} source batches to stay unchanged`
+        );
+      }
+    }
+  }
+}
+
+function assertArrowStorageTextSourceAppendPrefixStable(
+  previousProps: ArrowStorageTextInputProps,
+  nextProps: ArrowStorageTextInputProps,
+  processedBatchCount: number
+): void {
+  const sourceInputs: Array<[string, arrow.Vector | undefined, arrow.Vector | undefined]> = [
+    ['texts', previousProps.sourceVectors.texts, nextProps.sourceVectors.texts],
+    ['clipRects', previousProps.sourceVectors.clipRects, nextProps.sourceVectors.clipRects]
+  ];
+
+  for (const [name, previousVector, nextVector] of sourceInputs) {
+    if (!previousVector && nextVector && processedBatchCount > 0) {
+      throw new Error(`ArrowStorageTextModel appendTextBatches() cannot add prior ${name} sources`);
+    }
+    if (!previousVector || !nextVector) {
+      continue;
+    }
+    for (let batchIndex = 0; batchIndex < processedBatchCount; batchIndex++) {
+      if (previousVector.data[batchIndex] !== nextVector.data[batchIndex]) {
+        throw new Error(
+          `ArrowStorageTextModel appendTextBatches() requires existing ${name} source batches to stay unchanged`
+        );
+      }
+    }
+  }
+}
+
+function assertSourceVectorMatchesGPUVector(
+  ownerName: 'ArrowTextModel' | 'ArrowStorageTextModel',
+  vectorName: string,
+  gpuVector: GPUVector<any>,
+  sourceVector: arrow.Vector
+): void {
+  if (sourceVector.length !== gpuVector.length) {
+    throw new Error(
+      `${ownerName} sourceVectors.${vectorName} rows must match GPU rows (${sourceVector.length} !== ${gpuVector.length})`
+    );
+  }
+  if (sourceVector.data.length !== gpuVector.data.length) {
+    throw new Error(`${ownerName} sourceVectors.${vectorName} batch count must match GPU batches`);
+  }
+  for (let batchIndex = 0; batchIndex < sourceVector.data.length; batchIndex++) {
+    if (sourceVector.data[batchIndex].length !== gpuVector.data[batchIndex].length) {
+      throw new Error(
+        `${ownerName} sourceVectors.${vectorName} batch ${batchIndex} rows must match GPU rows`
+      );
+    }
+  }
+}
+
 type ResolvedArrowStorageTextBatchInputs = {
   batchRowIndexBase: number;
   texts: arrow.Vector<arrow.Utf8>;
@@ -1250,23 +1398,29 @@ type ResolvedArrowStorageTextInputs = {
 function resolveArrowStorageTextInputs(
   props: ArrowStorageTextInputProps
 ): ResolvedArrowStorageTextInputs {
+  if (!props.sourceVectors) {
+    throw new Error(
+      'ArrowStorageTextModel requires explicit sourceVectors for CPU glyph expansion'
+    );
+  }
   assertStorageVectorTypes(props);
   assertStorageVectorBatchAlignment(props);
-  const texts = getRetainedGPUVectorSource(props.texts, 'texts');
+  assertStorageSourceVectorAlignment(props);
+  const {sourceVectors} = props;
   const batches: ResolvedArrowStorageTextBatchInputs[] = [];
   let batchRowIndexBase = 0;
 
   for (let batchIndex = 0; batchIndex < props.texts.data.length; batchIndex++) {
     const textData = props.texts.data[batchIndex];
-    if (!textData.sourceData) {
-      throw new Error('Text models require texts GPUData chunks to retain Arrow source data');
-    }
-    const clipRectSourceData = props.clipRects?.data[batchIndex]?.sourceData;
     batches.push({
       batchRowIndexBase,
-      texts: new arrow.Vector([textData.sourceData]) as arrow.Vector<arrow.Utf8>,
-      clipRects: clipRectSourceData
-        ? (new arrow.Vector([clipRectSourceData]) as arrow.Vector<arrow.FixedSizeList<arrow.Int16>>)
+      texts: getArrowTextSourceBatch(sourceVectors.texts, 'texts', batchIndex),
+      clipRects: sourceVectors.clipRects
+        ? (getArrowTextSourceBatch(
+            sourceVectors.clipRects,
+            'clipRects',
+            batchIndex
+          ) as arrow.Vector<arrow.FixedSizeList<arrow.Int16>>)
         : undefined,
       positionsBuffer: props.positions.data[batchIndex].buffer,
       colorsBuffer: props.colors?.data[batchIndex].buffer,
@@ -1279,7 +1433,7 @@ function resolveArrowStorageTextInputs(
     batchRowIndexBase += textData.length;
   }
 
-  return {texts: texts as arrow.Vector<arrow.Utf8>, batches};
+  return {texts: sourceVectors.texts, batches};
 }
 
 function assertStorageVectorTypes(props: ArrowStorageTextInputProps): void {
@@ -1323,9 +1477,7 @@ function assertStorageVectorTypes(props: ArrowStorageTextInputProps): void {
   if (props.alignmentBaselines && !(props.alignmentBaselines.type instanceof arrow.Uint8)) {
     throw new Error('ArrowStorageTextModel alignmentBaselines must be GPUVector<Uint8>');
   }
-  const clipRects = props.clipRects
-    ? getRetainedGPUVectorSource(props.clipRects, 'clipRects')
-    : undefined;
+  const clipRects = props.sourceVectors.clipRects;
   assertClipRects(
     clipRects as arrow.Vector<arrow.FixedSizeList<arrow.Int16>> | undefined,
     props.texts.length
@@ -1369,6 +1521,31 @@ function assertStorageVectorBatchAlignment(props: ArrowStorageTextInputProps): v
   }
 }
 
+function assertStorageSourceVectorAlignment(props: ArrowStorageTextInputProps): void {
+  assertSourceVectorMatchesGPUVector(
+    'ArrowStorageTextModel',
+    'texts',
+    props.texts,
+    props.sourceVectors.texts
+  );
+  if (props.clipRects && !props.sourceVectors.clipRects) {
+    throw new Error('ArrowStorageTextModel clipRects GPU rows require matching sourceVectors rows');
+  }
+  if (!props.clipRects && props.sourceVectors.clipRects) {
+    throw new Error(
+      'ArrowStorageTextModel sourceVectors.clipRects requires matching GPU clipRects rows'
+    );
+  }
+  if (props.clipRects && props.sourceVectors.clipRects) {
+    assertSourceVectorMatchesGPUVector(
+      'ArrowStorageTextModel',
+      'clipRects',
+      props.clipRects,
+      props.sourceVectors.clipRects
+    );
+  }
+}
+
 function assertArrowStorageTextAppendProps(props: Partial<ArrowStorageTextInputProps>): void {
   const appendablePropNames = new Set([
     'positions',
@@ -1379,7 +1556,8 @@ function assertArrowStorageTextAppendProps(props: Partial<ArrowStorageTextInputP
     'pixelOffsets',
     'textAnchors',
     'alignmentBaselines',
-    'clipRects'
+    'clipRects',
+    'sourceVectors'
   ]);
   for (const propName of Object.keys(props)) {
     if (!appendablePropNames.has(propName)) {
@@ -1388,24 +1566,6 @@ function assertArrowStorageTextAppendProps(props: Partial<ArrowStorageTextInputP
       );
     }
   }
-}
-
-function getRetainedGPUVectorSource<T extends arrow.DataType>(
-  vector: GPUVector<T>,
-  vectorName: string
-): arrow.Vector<T> {
-  if (vector.data.length === 0) {
-    return new arrow.Vector([]) as arrow.Vector<T>;
-  }
-  const data = vector.data.map(chunk => {
-    if (!chunk.sourceData) {
-      throw new Error(
-        `Text models require ${vectorName} GPUData chunks to retain Arrow source data`
-      );
-    }
-    return chunk.sourceData;
-  });
-  return new arrow.Vector(data) as arrow.Vector<T>;
 }
 
 function prepareArrowTextModel(

--- a/modules/text/src/text-2d/index.ts
+++ b/modules/text/src/text-2d/index.ts
@@ -71,8 +71,10 @@ export {
   type ArrowStorageTextInputProps,
   type ArrowStorageTextModelProps,
   type ArrowStorageTextRenderBatchState,
+  type ArrowStorageTextSourceVectors,
   type ArrowStorageTextState,
   type ArrowTextGlyphTable,
   type ArrowTextModelProps,
-  type ArrowTextRenderBatchState
+  type ArrowTextRenderBatchState,
+  type ArrowTextSourceVectors
 } from './arrow-text-model';

--- a/modules/text/test/text-2d/arrow-text-model.spec.ts
+++ b/modules/text/test/text-2d/arrow-text-model.spec.ts
@@ -103,14 +103,65 @@ test('ArrowTextModel derives from ArrowModel and updates glyph instance counts',
   t.deepEqual(model.glyphLayout.startIndices, [0, 2, 3], 'model exposes glyph start indices');
   t.equal(model.glyphTable.numRows, 3, 'model retains generated glyph table');
 
-  const updatedTexts = makeGpuTexts(device, ['A', 'A']);
-  model.setProps({texts: updatedTexts});
+  const updatedTextSource = makeArrowTexts(['A', 'A']);
+  const updatedTexts = makeGpuTexts(device, updatedTextSource);
+  model.setProps({
+    texts: updatedTexts,
+    sourceVectors: {...textProps.sourceVectors, texts: updatedTextSource}
+  });
   t.equal(model.instanceCount, 2, 'updates instance count when text changes');
   t.deepEqual(model.glyphLayout.startIndices, [0, 1, 2], 'updates start indices');
 
   model.destroy();
   destroyGpuTextProps(textProps);
   updatedTexts.destroy();
+  t.end();
+});
+
+test('ArrowTextModel requires explicit CPU source vectors', t => {
+  const device = new NullDevice({});
+  const textProps = makeGpuTextProps(device, ['AB', 'A']);
+  const {sourceVectors, ...propsWithoutSourceVectors} = textProps;
+
+  t.throws(
+    () =>
+      new ArrowTextModel(device, {
+        id: 'arrow-text-model-missing-sources-test',
+        ...(propsWithoutSourceVectors as Omit<typeof textProps, 'sourceVectors'>),
+        characterMapping: CHARACTER_MAPPING,
+        fontSettings: {fontSize: 10}
+      } as never),
+    /requires explicit sourceVectors/,
+    'CPU source ownership is visible at the text model boundary'
+  );
+
+  destroyGpuTextProps(textProps);
+  t.end();
+});
+
+test('ArrowTextModel rejects source batch alignment mismatches', t => {
+  const device = new NullDevice({});
+  const textProps = makeGpuTextProps(device, ['AB', 'A']);
+  const firstChunk = makeArrowTexts(['AB']);
+  const secondChunk = makeArrowTexts(['A']);
+
+  t.throws(
+    () =>
+      new ArrowTextModel(device, {
+        id: 'arrow-text-model-source-batch-alignment-test',
+        ...textProps,
+        sourceVectors: {
+          ...textProps.sourceVectors,
+          texts: new arrow.Vector<arrow.Utf8>([...firstChunk.data, ...secondChunk.data])
+        },
+        characterMapping: CHARACTER_MAPPING,
+        fontSettings: {fontSize: 10}
+      }),
+    /batch count must match GPU batches/,
+    'source vector batches stay explicitly aligned with GPU vector batches'
+  );
+
+  destroyGpuTextProps(textProps);
   t.end();
 });
 
@@ -222,12 +273,14 @@ test('ArrowTextModel expands chunked UTF-8 GPUVector data', t => {
   const secondChunk = arrow.vectorFromArray(['A'], new arrow.Utf8());
   const textProps = makeGpuTextProps(device, []);
   textProps.texts.destroy();
+  const sourceTexts = new arrow.Vector<arrow.Utf8>([...firstChunk.data, ...secondChunk.data]);
   textProps.texts = new GPUVector({
     type: 'arrow',
     name: 'texts',
     device,
-    vector: new arrow.Vector([...firstChunk.data, ...secondChunk.data])
+    vector: sourceTexts
   });
+  textProps.sourceVectors = {...textProps.sourceVectors, texts: sourceTexts};
 
   const model = new ArrowTextModel(device, {
     id: 'chunked-arrow-text-model-test',
@@ -252,11 +305,13 @@ test('ArrowTextModel appends GPUTable-backed text batches without rebuilding pri
   const gpuTable = new GPUTable(device, new arrow.Table([firstBatch]), {
     shaderLayout: APPENDABLE_TEXT_INPUT_SHADER_LAYOUT
   });
+  const firstSourceVectors = makeArrowTextSourceVectorsFromBatches([firstBatch]);
 
   const model = new ArrowTextModel(device, {
     id: 'arrow-text-model-appendable-gpu-table-test',
     positions: gpuTable.gpuVectors.positions as GPUVector<arrow.FixedSizeList<arrow.Float32>>,
     texts: gpuTable.gpuVectors.texts as GPUVector<arrow.Utf8>,
+    sourceVectors: firstSourceVectors,
     characterMapping: CHARACTER_MAPPING,
     fontSettings: {fontSize: 10}
   });
@@ -270,7 +325,8 @@ test('ArrowTextModel appends GPUTable-backed text batches without rebuilding pri
   );
   model.appendTextBatches({
     positions: gpuTable.gpuVectors.positions as GPUVector<arrow.FixedSizeList<arrow.Float32>>,
-    texts: gpuTable.gpuVectors.texts as GPUVector<arrow.Utf8>
+    texts: gpuTable.gpuVectors.texts as GPUVector<arrow.Utf8>,
+    sourceVectors: makeArrowTextSourceVectorsFromBatches([firstBatch, secondBatch])
   });
   t.equal(model.glyphLayout.glyphCount, 3, 'adds glyphs from the later GPU record batch');
   t.equal(
@@ -389,11 +445,13 @@ test('ArrowStorageTextModel appends GPUTable-backed text batches without rebuild
   const gpuTable = new GPUTable(device, new arrow.Table([firstBatch]), {
     shaderLayout: APPENDABLE_TEXT_INPUT_SHADER_LAYOUT
   });
+  const firstSourceVectors = makeArrowStorageTextSourceVectorsFromBatches([firstBatch]);
 
   const model = new ArrowStorageTextModel(device, {
     id: 'arrow-storage-text-appendable-gpu-table-test',
     positions: gpuTable.gpuVectors.positions as GPUVector<arrow.FixedSizeList<arrow.Float32>>,
     texts: gpuTable.gpuVectors.texts as GPUVector<arrow.Utf8>,
+    sourceVectors: firstSourceVectors,
     characterMapping: CHARACTER_MAPPING,
     fontSettings: {fontSize: 10}
   });
@@ -406,7 +464,8 @@ test('ArrowStorageTextModel appends GPUTable-backed text batches without rebuild
   );
   model.appendTextBatches({
     positions: gpuTable.gpuVectors.positions as GPUVector<arrow.FixedSizeList<arrow.Float32>>,
-    texts: gpuTable.gpuVectors.texts as GPUVector<arrow.Utf8>
+    texts: gpuTable.gpuVectors.texts as GPUVector<arrow.Utf8>,
+    sourceVectors: makeArrowStorageTextSourceVectorsFromBatches([firstBatch, secondBatch])
   });
 
   t.equal(model.glyphCount, 3, 'storage text expansion reads the appended UTF-8 batch');
@@ -549,8 +608,12 @@ test('ArrowStorageTextModel refreshes row bindings without rebuilding glyph buff
     'row-binding updates refresh owned style config buffers'
   );
 
-  const updatedTexts = makeGpuTexts(device, ['A', 'A']);
-  model.setProps({texts: updatedTexts});
+  const updatedTextSource = makeArrowTexts(['A', 'A']);
+  const updatedTexts = makeGpuTexts(device, updatedTextSource);
+  model.setProps({
+    texts: updatedTexts,
+    sourceVectors: {...textProps.sourceVectors, texts: updatedTextSource}
+  });
 
   t.notEqual(model.storageState, storageState, 'text updates replace storage state');
   t.notEqual(
@@ -586,24 +649,57 @@ function makeAppendableTextRecordBatch(
   return recordBatch;
 }
 
+function makeArrowTextSourceVectorsFromBatches(recordBatches: arrow.RecordBatch[]) {
+  const table = new arrow.Table(recordBatches);
+  const positions = table.getChild('positions');
+  const texts = table.getChild('texts');
+  if (!positions || !texts) {
+    throw new Error('Text source vectors require positions and texts columns');
+  }
+  return {
+    positions: positions as arrow.Vector<arrow.FixedSizeList<arrow.Float32>>,
+    texts: texts as arrow.Vector<arrow.Utf8>
+  };
+}
+
+function makeArrowStorageTextSourceVectorsFromBatches(recordBatches: arrow.RecordBatch[]) {
+  const table = new arrow.Table(recordBatches);
+  const texts = table.getChild('texts');
+  if (!texts) {
+    throw new Error('Storage text source vectors require a texts column');
+  }
+  return {texts: texts as arrow.Vector<arrow.Utf8>};
+}
+
 function makeGpuTextProps(device: NullDevice, labels: string[]) {
+  const positions = makeArrowFixedSizeListVector(
+    new arrow.Float32(),
+    2,
+    new Float32Array([0, 0, 1, 1])
+  );
+  const texts = makeArrowTexts(labels);
   return {
     positions: new GPUVector({
       type: 'arrow',
       name: 'positions',
       device,
-      vector: makeArrowFixedSizeListVector(new arrow.Float32(), 2, new Float32Array([0, 0, 1, 1]))
+      vector: positions
     }),
-    texts: makeGpuTexts(device, labels)
+    texts: makeGpuTexts(device, texts),
+    sourceVectors: {positions, texts}
   };
 }
 
-function makeGpuTexts(device: NullDevice, labels: string[]): GPUVector<arrow.Utf8> {
+function makeArrowTexts(labels: string[]): arrow.Vector<arrow.Utf8> {
+  return arrow.vectorFromArray(labels, new arrow.Utf8()) as arrow.Vector<arrow.Utf8>;
+}
+
+function makeGpuTexts(device: NullDevice, vector: arrow.Vector<arrow.Utf8>): GPUVector<arrow.Utf8> {
   return new GPUVector({
     type: 'arrow',
     name: 'texts',
     device,
-    vector: arrow.vectorFromArray(labels, new arrow.Utf8())
+    vector
   });
 }
 
@@ -613,14 +709,21 @@ function destroyGpuTextProps(props: ReturnType<typeof makeGpuTextProps>): void {
 }
 
 function makeStorageGpuTextProps(device: NullDevice, labels: string[]) {
+  const positions = makeArrowFixedSizeListVector(
+    new arrow.Float32(),
+    2,
+    new Float32Array([0, 0, 1, 1])
+  );
+  const texts = makeArrowTexts(labels);
   return {
     positions: new GPUVector({
       type: 'arrow',
       name: 'positions',
       device,
-      vector: makeArrowFixedSizeListVector(new arrow.Float32(), 2, new Float32Array([0, 0, 1, 1]))
+      vector: positions
     }),
-    texts: makeGpuTexts(device, labels)
+    texts: makeGpuTexts(device, texts),
+    sourceVectors: {texts}
   };
 }
 


### PR DESCRIPTION
## Goals

- Add generic GPU support for Arrow variable-length numeric attribute lists.
- Avoid retaining uploaded Arrow payload arrays inside GPU wrapper objects after upload.
- Keep text rendering behavior intact by making required CPU-side source vectors explicit at the text-model layer.

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/3c745cb7-dc2a-4035-9b7f-5e54de4dab3b" />


## Changes

- Added internal support for variable-length Arrow attribute columns:
  - `List<Numeric>`
  - `List<FixedSizeList<Numeric>>` with tuple widths `1` through `4`
- Generalized the nested-list implementation around attribute semantics rather than path-specific naming.
- Extended `GPUVector` / `GPUData` handling so variable-length numeric attribute lists can be uploaded, appended, and read back.
- Reworked readback metadata ownership:
  - Removed retained bulk Arrow payload references from GPU wrapper reconstruction paths.
  - Preserved only compact metadata required for variable-width reconstruction, such as offsets, null metadata, and byte sizing.
- Updated UTF-8 and nested-list readback to reconstruct Arrow values from GPU bytes plus compact copied metadata.
- Refactored Arrow text models to use explicit CPU source bundles:
  - `ArrowTextModel` now receives aligned source vectors for CPU glyph expansion inputs.
  - `ArrowStorageTextModel` receives only CPU-needed source vectors such as text rows and optional clip rectangles.
  - Append flows now validate source-vector batch alignment instead of relying on hidden retained Arrow payloads.
- Updated the Arrow text example app to pass and maintain explicit CPU source vectors during streaming updates.
- Documented:
  - Generic variable-length nested attribute support in Arrow docs and release notes.
  - Explicit text source-vector ownership in text docs.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test-node -- modules/arrow/test/index.ts modules/text/test/index.ts`
- `yarn test-headless -- modules/arrow/test/arrow/arrow-fixed-size-list.spec.ts modules/arrow/test/arrow/arrow-variable-length-attribute-gpu-vector.spec.ts modules/text/test/text-2d/arrow-text-model.spec.ts`

Headless browser suite result:
- `176` test files passed
- `797` tests passed
- `25` skipped

## Risks

- Text-model construction and append callers must now provide correctly aligned explicit CPU source vectors where glyph expansion depends on CPU-readable row data.
- Variable-length nested-list support is intentionally scoped to numeric element widths `1` through `4`; broader nested Arrow coverage remains out of scope.

## Follow-Up

- Build higher-level path-specific models, such as `ArrowPathModel` / `ArrowStoragePathModel`, on top of the new generic nested attribute representation in a separate PR.