### PR TITLE
feat(arrow) Storage based paths

### DIFF
--- a/docs/api-guide/gpu/arrow-table-columns.md
+++ b/docs/api-guide/gpu/arrow-table-columns.md
@@ -19,7 +19,14 @@ directly to the memory layouts used by GPU vertex attributes.
 
 Arrow also supports variable-length `List` columns. These are useful for data
 such as polygons and paths, but they do not map directly to a single vertex
-attribute without an additional conversion step.
+attribute without an additional conversion step. `ArrowPathModel` provides the
+attribute-backed conversion for Float32 XY, XYZ, and XYZM path coordinate rows,
+expanding each logical path into segment instances while keeping row-level style
+columns at the path boundary. `ArrowStoragePathModel` provides the WebGPU
+storage-backed form: compute expands GPU-resident path values into compact indexed
+segment records from copied list-offset metadata, render shaders fetch coordinates
+from the original path-value storage buffer, and per-path style rows remain storage
+bindings instead of being repeated for every generated segment.
 
 ## Shader and Buffer Layout Preliminaries
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -16,10 +16,17 @@ Target Release Date: Q3, 2026
 
 - **Arrow shader layouts** - `getArrowBufferLayout()` maps Arrow scalar and `FixedSizeList` columns to shader attribute formats from a shader-first layout, including direct `arrow.Vector` sources and Arrow table path mappings.
 - **Arrow GPU helpers** - New `GPUVector`, `GPUTable`, and `ArrowModel` helpers create GPU buffers from compatible Arrow columns, preserve chunked UTF-8 GPU vector input for text workflows, and keep Arrow-backed model attributes updatable through `setProps({arrowTable})`.
+<<<<<<< Updated upstream
+=======
+- **Variable-length Arrow attribute lists** - `GPUVector` can retain chunked nested list columns whose elements contain one to four numeric components, covering scalar streams plus tuple-style data such as XY, XYZ, and XYZM coordinates for future path-rendering workflows.
+- **`ArrowPathModel`** - New attribute-backed path renderer expands Float32 XY, XYZ, and XYZM Arrow path rows into packed per-segment render records while keeping caller-retained CPU source vectors explicit and preserving per-path color and width styling.
+- **`ArrowStoragePathModel`** - New WebGPU-only storage-backed path renderer expands nested Float32 XY, XYZ, and XYZM rows through compute into indexed segment records using GPU path values plus compact list-offset metadata, keeps per-path color and width rows as storage bindings, and can consume reusable `ArrowStoragePathState` objects built by `createArrowStoragePathState`.
+>>>>>>> Stashed changes
 - **Mesh Arrow geometry** - New `ArrowGeometry` and `ArrowModel` support for loaders.gl-compatible Mesh Arrow tables, including default interleaved vertex buffers and optional index buffers.
 - **Arrow table buffer planning** - New `TableBufferPlanner` API builds deterministic GPU buffer allocation plans for table columns, including interleaved fallback groups and WebGPU storage-buffer planning output.
 - **[Columnar GPU tables](/docs/api-guide/gpu/arrow-table-columns)** - Matrix Arrow vectors, storage-selected table bindings, `TableTransform`, and `TableComputation`.
-- **[GPU Tables examples](/examples/gpu-tables/arrow-instancing)** - Arrow instancing, 2D text, mesh geometry, and storage particles now live in the GPU Tables section.
+- **[GPU Tables examples](/examples/gpu-tables/arrow-instancing)** - Arrow instancing, 2D text, path rendering, mesh geometry, and storage particles now live in the GPU Tables section.
+- **[Arrow Path Model Example](/examples/gpu-tables/arrow-path-model)** - New showcase expands nested Arrow XYZM path rows into styled GPU segment instances with attribute-backed and storage-backed models, with M-driven time highlighting plus square/round caps, miter/round joins, and adjustable miter limits.
 - **[Arrow Instancing Example](/examples/gpu-tables/arrow-instancing)** - New showcase example renders instanced cubes from an Apache Arrow table.
 
 **@luma.gl/text**

--- a/examples/gpu-tables/arrow-path-model/app.ts
+++ b/examples/gpu-tables/arrow-path-model/app.ts
@@ -1,0 +1,1339 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  ArrowPathModel,
+  ArrowStoragePathModel,
+  GPUVector,
+  makeArrowFixedSizeListVector,
+  type ArrowPathSourceVectors
+} from '@luma.gl/arrow';
+import {type Device, type ShaderLayout} from '@luma.gl/core';
+import type {AnimationProps} from '@luma.gl/engine';
+import {AnimationLoopTemplate, ShaderInputs} from '@luma.gl/engine';
+import {type ShaderModule} from '@luma.gl/shadertools';
+import * as arrow from 'apache-arrow';
+
+export const title = 'Arrow Paths';
+export const description =
+  'Variable-length Arrow XYZM path rows rendered through attribute-backed and storage-backed path models with M-driven time highlighting.';
+
+const MODEL_SELECTOR_ID = 'arrow-path-model-model';
+const DATA_SELECTOR_ID = 'arrow-path-model-data';
+const MEASURE_SWEEP_TOGGLE_ID = 'arrow-path-model-measure-sweep';
+const COLOR_TOGGLE_ID = 'arrow-path-model-colors';
+const WIDTH_TOGGLE_ID = 'arrow-path-model-widths';
+const CAP_SELECTOR_ID = 'arrow-path-model-cap-style';
+const JOINT_SELECTOR_ID = 'arrow-path-model-joint-style';
+const MITER_LIMIT_INPUT_ID = 'arrow-path-model-miter-limit';
+const MITER_LIMIT_VALUE_ID = 'arrow-path-model-miter-limit-value';
+const INFO_DETAILS_ID = 'arrow-path-model-details';
+const PATH_COUNT_ID = 'arrow-path-model-path-count';
+const SEGMENT_COUNT_ID = 'arrow-path-model-segment-count';
+const ARROW_BUILD_TIME_ID = 'arrow-path-model-arrow-build-time';
+const CPU_EXPANSION_TIME_ID = 'arrow-path-model-cpu-expansion-time';
+const SOURCE_GPU_BYTES_ID = 'arrow-path-model-source-gpu-bytes';
+const GENERATED_GPU_BYTES_ID = 'arrow-path-model-generated-gpu-bytes';
+const STYLE_GPU_BYTES_ID = 'arrow-path-model-style-gpu-bytes';
+const TOTAL_GPU_BYTES_ID = 'arrow-path-model-total-gpu-bytes';
+
+type ArrowPathCoordinateType = arrow.List<arrow.FixedSizeList<arrow.Float32>>;
+type ArrowPathDatasetKind = '240' | '960' | '2400';
+type ArrowPathModelKind = 'attributes' | 'storage';
+type ArrowPathCapKind = 'square' | 'round';
+type ArrowPathJointKind = 'miter' | 'round';
+type ActiveArrowPathModel = ArrowPathModel | ArrowStoragePathModel;
+type ArrowPathDataset = {
+  pathCount: number;
+  pointCount: number;
+  label: string;
+};
+type ArrowPathInput = {
+  paths: GPUVector<ArrowPathCoordinateType>;
+  colors: GPUVector<arrow.FixedSizeList<arrow.Uint8>>;
+  widths: GPUVector<arrow.Float32>;
+  sourceVectors: ArrowPathSourceVectors;
+  arrowVectorBuildTimeMs: number;
+};
+
+const PATH_DATASETS: Record<ArrowPathDatasetKind, ArrowPathDataset> = {
+  '240': {pathCount: 240, pointCount: 18, label: '240 paths, 4.1K segments'},
+  '960': {pathCount: 960, pointCount: 22, label: '960 paths, 20K segments'},
+  '2400': {pathCount: 2400, pointCount: 26, label: '2.4K paths, 60K segments'}
+};
+
+const PATH_SHADER_LAYOUT = {
+  attributes: [
+    {name: 'segmentStartPositions', location: 0, type: 'vec4<f32>', stepMode: 'instance'},
+    {name: 'segmentEndPositions', location: 1, type: 'vec4<f32>', stepMode: 'instance'},
+    {name: 'segmentPreviousPositions', location: 2, type: 'vec4<f32>', stepMode: 'instance'},
+    {name: 'segmentNextPositions', location: 3, type: 'vec4<f32>', stepMode: 'instance'},
+    {name: 'segmentFlags', location: 4, type: 'u32', stepMode: 'instance'},
+    {name: 'rowIndices', location: 5, type: 'u32', stepMode: 'instance'},
+    {name: 'colors', location: 6, type: 'vec4<f32>', stepMode: 'instance'},
+    {name: 'widths', location: 7, type: 'f32', stepMode: 'instance'}
+  ],
+  bindings: []
+} satisfies ShaderLayout;
+
+const STORAGE_PATH_SHADER_LAYOUT = {
+  attributes: [
+    {name: 'segmentStartPointIndices', location: 0, type: 'u32', stepMode: 'instance'},
+    {name: 'segmentEndPointIndices', location: 1, type: 'u32', stepMode: 'instance'},
+    {name: 'segmentPreviousPointIndices', location: 2, type: 'u32', stepMode: 'instance'},
+    {name: 'segmentNextPointIndices', location: 3, type: 'u32', stepMode: 'instance'},
+    {name: 'segmentFlags', location: 4, type: 'u32', stepMode: 'instance'},
+    {name: 'rowIndices', location: 5, type: 'u32', stepMode: 'instance'}
+  ],
+  bindings: []
+} satisfies ShaderLayout;
+
+const WGSL_SHADER = /* wgsl */ `\
+struct PathViewportUniforms {
+  viewportScale : vec2<f32>,
+  time : f32,
+  colorsEnabled : f32,
+  widthsEnabled : f32,
+  capRounded : f32,
+  jointRounded : f32,
+  miterLimit : f32,
+};
+
+@group(0) @binding(auto) var<uniform> pathViewport : PathViewportUniforms;
+
+struct VertexInputs {
+  @builtin(vertex_index) vertexIndex : u32,
+  @location(0) segmentStartPositions : vec4<f32>,
+  @location(1) segmentEndPositions : vec4<f32>,
+  @location(2) segmentPreviousPositions : vec4<f32>,
+  @location(3) segmentNextPositions : vec4<f32>,
+  @location(4) segmentFlags : u32,
+  @location(5) rowIndices : u32,
+  @location(6) colors : vec4<f32>,
+  @location(7) widths : f32,
+};
+
+struct FragmentInputs {
+  @builtin(position) Position : vec4<f32>,
+  @location(0) color : vec4<f32>,
+  @location(1) measure : f32,
+  @location(2) cornerOffset : vec2<f32>,
+  @location(3) miterLength : f32,
+  @location(4) pathPosition : vec2<f32>,
+  @location(5) pathLength : f32,
+  @location(6) jointType : f32,
+};
+
+struct PathExtrusion {
+  offset : vec2<f32>,
+  cornerOffset : vec2<f32>,
+  miterLength : f32,
+  pathPosition : vec2<f32>,
+  pathLength : f32,
+  jointType : f32,
+};
+
+const PATH_EPSILON : f32 = 0.00001;
+const PATH_SEGMENT_FIRST : u32 = 1u;
+const PATH_SEGMENT_LAST : u32 = 2u;
+const PATH_SEGMENT_CLOSED : u32 = 4u;
+
+fn getSegmentVertex(vertexIndex : u32) -> vec2<f32> {
+  if (vertexIndex == 0u) { return vec2<f32>(0.0, 0.0); }
+  if (vertexIndex == 1u) { return vec2<f32>(0.0, -1.0); }
+  if (vertexIndex == 2u) { return vec2<f32>(0.0, 1.0); }
+  if (vertexIndex == 3u) { return vec2<f32>(0.0, -1.0); }
+  if (vertexIndex == 4u) { return vec2<f32>(1.0, 1.0); }
+  if (vertexIndex == 5u) { return vec2<f32>(0.0, 1.0); }
+  if (vertexIndex == 6u) { return vec2<f32>(0.0, -1.0); }
+  if (vertexIndex == 7u) { return vec2<f32>(1.0, -1.0); }
+  if (vertexIndex == 8u) { return vec2<f32>(1.0, 1.0); }
+  if (vertexIndex == 9u) { return vec2<f32>(1.0, -1.0); }
+  if (vertexIndex == 10u) { return vec2<f32>(1.0, 0.0); }
+  return vec2<f32>(1.0, 1.0);
+}
+
+fn flipIfTrue(flag : bool) -> f32 {
+  return select(1.0, -1.0, flag);
+}
+
+fn computePathExtrusion(
+  previousPoint : vec2<f32>,
+  currentPoint : vec2<f32>,
+  nextPoint : vec2<f32>,
+  segmentVertex : vec2<f32>,
+  halfWidth : f32,
+  segmentFlags : u32
+) -> PathExtrusion {
+  let isEnd = segmentVertex.x > 0.5;
+  let sideOfPath = segmentVertex.y;
+  let isJoint = select(0.0, 1.0, abs(sideOfPath) < 0.5);
+  let normalizedWidth = max(halfWidth, PATH_EPSILON);
+  let deltaA = (currentPoint - previousPoint) / normalizedWidth;
+  let deltaB = (nextPoint - currentPoint) / normalizedWidth;
+  let lenA = length(deltaA);
+  let lenB = length(deltaB);
+  let dirA = deltaA / max(lenA, PATH_EPSILON);
+  let dirB = deltaB / max(lenB, PATH_EPSILON);
+  let perpA = vec2<f32>(-dirA.y, dirA.x);
+  let perpB = vec2<f32>(-dirB.y, dirB.x);
+  let tangentBasis = dirA + dirB;
+  let tangentLength = length(tangentBasis);
+  let tangent = select(
+    perpA,
+    tangentBasis / max(tangentLength, PATH_EPSILON),
+    tangentLength > PATH_EPSILON
+  );
+  let miterVector = vec2<f32>(-tangent.y, tangent.x);
+  let direction = select(dirB, dirA, isEnd);
+  let perpendicular = select(perpB, perpA, isEnd);
+  let pathLength = select(lenB, lenA, isEnd);
+  let sinHalfAngle = abs(dot(miterVector, perpendicular));
+  let cosHalfAngle = abs(dot(dirA, miterVector));
+  let turnDirection = flipIfTrue(dirA.x * dirB.y >= dirA.y * dirB.x);
+  let cornerPosition = sideOfPath * turnDirection;
+  var miterSize = 1.0 / max(sinHalfAngle, PATH_EPSILON);
+  let trimmedMiterSize = min(
+    miterSize,
+    max(lenA, lenB) / max(cosHalfAngle, PATH_EPSILON)
+  );
+  miterSize = select(trimmedMiterSize, miterSize, cornerPosition >= 0.0);
+  var cornerOffset = mix(
+    miterVector * miterSize,
+    perpendicular,
+    step(0.5, cornerPosition)
+  ) * (sideOfPath + isJoint * turnDirection);
+  let isFirst = (segmentFlags & PATH_SEGMENT_FIRST) != 0u;
+  let isLast = (segmentFlags & PATH_SEGMENT_LAST) != 0u;
+  let isClosed = (segmentFlags & PATH_SEGMENT_CLOSED) != 0u;
+  let isStartCap = lenA <= PATH_EPSILON || (!isEnd && isFirst && !isClosed);
+  let isEndCap = lenB <= PATH_EPSILON || (isEnd && isLast && !isClosed);
+  let isCap = isStartCap || isEndCap;
+  var jointType = pathViewport.jointRounded;
+  if (isCap) {
+    let capOffset =
+      direction * pathViewport.capRounded * 4.0 * flipIfTrue(isStartCap);
+    cornerOffset = mix(perpendicular * sideOfPath, capOffset, isJoint);
+    jointType = pathViewport.capRounded;
+  }
+  let miterLength = select(
+    dot(cornerOffset, miterVector * turnDirection),
+    isJoint,
+    isCap
+  );
+  let offsetFromStart = cornerOffset + deltaA * select(0.0, 1.0, isEnd);
+  var extrusion : PathExtrusion;
+  extrusion.offset = cornerOffset * halfWidth;
+  extrusion.cornerOffset = cornerOffset;
+  extrusion.miterLength = miterLength;
+  extrusion.pathPosition = vec2<f32>(
+    dot(offsetFromStart, perpendicular),
+    dot(offsetFromStart, direction)
+  );
+  extrusion.pathLength = pathLength;
+  extrusion.jointType = jointType;
+  return extrusion;
+}
+
+@vertex
+fn vertexMain(inputs : VertexInputs) -> FragmentInputs {
+  var outputs : FragmentInputs;
+  let segmentVertex = getSegmentVertex(inputs.vertexIndex % 12u);
+  let previousSegmentPosition = inputs.segmentPreviousPositions.xy;
+  let startPosition = inputs.segmentStartPositions.xy;
+  let endPosition = inputs.segmentEndPositions.xy;
+  let nextSegmentPosition = inputs.segmentNextPositions.xy;
+  let previousPoint = mix(previousSegmentPosition, startPosition, segmentVertex.x);
+  let currentPoint = mix(startPosition, endPosition, segmentVertex.x);
+  let nextPoint = mix(endPosition, nextSegmentPosition, segmentVertex.x);
+  let halfWidth = mix(0.0035, inputs.widths, pathViewport.widthsEnabled);
+  let extrusion = computePathExtrusion(
+    previousPoint,
+    currentPoint,
+    nextPoint,
+    segmentVertex,
+    halfWidth,
+    inputs.segmentFlags
+  );
+  let worldPosition = currentPoint + extrusion.offset;
+  let neutralColor = vec4<f32>(0.78, 0.86, 0.96, 0.92);
+  outputs.Position = vec4<f32>(worldPosition * pathViewport.viewportScale, 0.0, 1.0);
+  outputs.color = mix(neutralColor, inputs.colors, pathViewport.colorsEnabled);
+  outputs.measure = mix(inputs.segmentStartPositions.w, inputs.segmentEndPositions.w, segmentVertex.x);
+  outputs.cornerOffset = extrusion.cornerOffset;
+  outputs.miterLength = extrusion.miterLength;
+  outputs.pathPosition = extrusion.pathPosition;
+  outputs.pathLength = extrusion.pathLength;
+  outputs.jointType = extrusion.jointType;
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs : FragmentInputs) -> @location(0) vec4<f32> {
+  if (inputs.pathPosition.y < 0.0 || inputs.pathPosition.y > inputs.pathLength) {
+    if (inputs.jointType > 0.5 && length(inputs.cornerOffset) > 1.0) {
+      discard;
+    }
+    if (inputs.jointType < 0.5 && inputs.miterLength > pathViewport.miterLimit + 1.0) {
+      discard;
+    }
+  }
+  let measureLag = pathViewport.time - inputs.measure;
+  let measureReached = select(0.0, 1.0, measureLag >= 0.0);
+  let measureHighlight = measureReached * (1.0 - smoothstep(0.0, 0.16, measureLag));
+  let highlight = 0.24 + measureHighlight * 0.76;
+  let lightenedColor = mix(
+    inputs.color.rgb * 0.72,
+    min(inputs.color.rgb * 1.18 + vec3<f32>(0.05), vec3<f32>(1.0)),
+    highlight
+  );
+  return vec4<f32>(lightenedColor, inputs.color.a);
+}
+`;
+
+const STORAGE_WGSL_SHADER = /* wgsl */ `\
+struct PathViewportUniforms {
+  viewportScale : vec2<f32>,
+  time : f32,
+  colorsEnabled : f32,
+  widthsEnabled : f32,
+  capRounded : f32,
+  jointRounded : f32,
+  miterLimit : f32,
+};
+
+@group(0) @binding(auto) var<uniform> pathViewport : PathViewportUniforms;
+@group(0) @binding(auto) var<storage, read> pathValues : array<f32>;
+@group(0) @binding(auto) var<storage, read> pathRowColors : array<u32>;
+@group(0) @binding(auto) var<storage, read> pathRowWidths : array<f32>;
+
+struct PathStorageStyleConfig {
+  constantColor : vec4<f32>,
+  constantWidth : f32,
+  useRowColors : u32,
+  useRowWidths : u32,
+  batchRowIndexBase : u32,
+  pathComponentCount : u32,
+  _padding0 : u32,
+  _padding1 : u32,
+  _padding2 : u32,
+};
+
+@group(0) @binding(auto) var<uniform> pathStorageStyleConfig : PathStorageStyleConfig;
+
+struct VertexInputs {
+  @builtin(vertex_index) vertexIndex : u32,
+  @location(0) segmentStartPointIndices : u32,
+  @location(1) segmentEndPointIndices : u32,
+  @location(2) segmentPreviousPointIndices : u32,
+  @location(3) segmentNextPointIndices : u32,
+  @location(4) segmentFlags : u32,
+  @location(5) rowIndices : u32,
+};
+
+struct FragmentInputs {
+  @builtin(position) Position : vec4<f32>,
+  @location(0) color : vec4<f32>,
+  @location(1) measure : f32,
+  @location(2) cornerOffset : vec2<f32>,
+  @location(3) miterLength : f32,
+  @location(4) pathPosition : vec2<f32>,
+  @location(5) pathLength : f32,
+  @location(6) jointType : f32,
+};
+
+struct PathExtrusion {
+  offset : vec2<f32>,
+  cornerOffset : vec2<f32>,
+  miterLength : f32,
+  pathPosition : vec2<f32>,
+  pathLength : f32,
+  jointType : f32,
+};
+
+const PATH_EPSILON : f32 = 0.00001;
+const PATH_SEGMENT_FIRST : u32 = 1u;
+const PATH_SEGMENT_LAST : u32 = 2u;
+const PATH_SEGMENT_CLOSED : u32 = 4u;
+
+fn getSegmentVertex(vertexIndex : u32) -> vec2<f32> {
+  if (vertexIndex == 0u) { return vec2<f32>(0.0, 0.0); }
+  if (vertexIndex == 1u) { return vec2<f32>(0.0, -1.0); }
+  if (vertexIndex == 2u) { return vec2<f32>(0.0, 1.0); }
+  if (vertexIndex == 3u) { return vec2<f32>(0.0, -1.0); }
+  if (vertexIndex == 4u) { return vec2<f32>(1.0, 1.0); }
+  if (vertexIndex == 5u) { return vec2<f32>(0.0, 1.0); }
+  if (vertexIndex == 6u) { return vec2<f32>(0.0, -1.0); }
+  if (vertexIndex == 7u) { return vec2<f32>(1.0, -1.0); }
+  if (vertexIndex == 8u) { return vec2<f32>(1.0, 1.0); }
+  if (vertexIndex == 9u) { return vec2<f32>(1.0, -1.0); }
+  if (vertexIndex == 10u) { return vec2<f32>(1.0, 0.0); }
+  return vec2<f32>(1.0, 1.0);
+}
+
+fn unpackPathColor(colorWord : u32) -> vec4<f32> {
+  return vec4<f32>(
+    f32(colorWord & 0xffu),
+    f32((colorWord >> 8u) & 0xffu),
+    f32((colorWord >> 16u) & 0xffu),
+    f32((colorWord >> 24u) & 0xffu)
+  ) / 255.0;
+}
+
+fn readPathComponent(pointIndex : u32, componentIndex : u32) -> f32 {
+  if (componentIndex >= pathStorageStyleConfig.pathComponentCount) {
+    return 0.0;
+  }
+  return pathValues[pointIndex * pathStorageStyleConfig.pathComponentCount + componentIndex];
+}
+
+fn readPathPoint(pointIndex : u32) -> vec4<f32> {
+  return vec4<f32>(
+    readPathComponent(pointIndex, 0u),
+    readPathComponent(pointIndex, 1u),
+    readPathComponent(pointIndex, 2u),
+    readPathComponent(pointIndex, 3u)
+  );
+}
+
+fn flipIfTrue(flag : bool) -> f32 {
+  return select(1.0, -1.0, flag);
+}
+
+fn computePathExtrusion(
+  previousPoint : vec2<f32>,
+  currentPoint : vec2<f32>,
+  nextPoint : vec2<f32>,
+  segmentVertex : vec2<f32>,
+  halfWidth : f32,
+  segmentFlags : u32
+) -> PathExtrusion {
+  let isEnd = segmentVertex.x > 0.5;
+  let sideOfPath = segmentVertex.y;
+  let isJoint = select(0.0, 1.0, abs(sideOfPath) < 0.5);
+  let normalizedWidth = max(halfWidth, PATH_EPSILON);
+  let deltaA = (currentPoint - previousPoint) / normalizedWidth;
+  let deltaB = (nextPoint - currentPoint) / normalizedWidth;
+  let lenA = length(deltaA);
+  let lenB = length(deltaB);
+  let dirA = deltaA / max(lenA, PATH_EPSILON);
+  let dirB = deltaB / max(lenB, PATH_EPSILON);
+  let perpA = vec2<f32>(-dirA.y, dirA.x);
+  let perpB = vec2<f32>(-dirB.y, dirB.x);
+  let tangentBasis = dirA + dirB;
+  let tangentLength = length(tangentBasis);
+  let tangent = select(
+    perpA,
+    tangentBasis / max(tangentLength, PATH_EPSILON),
+    tangentLength > PATH_EPSILON
+  );
+  let miterVector = vec2<f32>(-tangent.y, tangent.x);
+  let direction = select(dirB, dirA, isEnd);
+  let perpendicular = select(perpB, perpA, isEnd);
+  let pathLength = select(lenB, lenA, isEnd);
+  let sinHalfAngle = abs(dot(miterVector, perpendicular));
+  let cosHalfAngle = abs(dot(dirA, miterVector));
+  let turnDirection = flipIfTrue(dirA.x * dirB.y >= dirA.y * dirB.x);
+  let cornerPosition = sideOfPath * turnDirection;
+  var miterSize = 1.0 / max(sinHalfAngle, PATH_EPSILON);
+  let trimmedMiterSize = min(
+    miterSize,
+    max(lenA, lenB) / max(cosHalfAngle, PATH_EPSILON)
+  );
+  miterSize = select(trimmedMiterSize, miterSize, cornerPosition >= 0.0);
+  var cornerOffset = mix(
+    miterVector * miterSize,
+    perpendicular,
+    step(0.5, cornerPosition)
+  ) * (sideOfPath + isJoint * turnDirection);
+  let isFirst = (segmentFlags & PATH_SEGMENT_FIRST) != 0u;
+  let isLast = (segmentFlags & PATH_SEGMENT_LAST) != 0u;
+  let isClosed = (segmentFlags & PATH_SEGMENT_CLOSED) != 0u;
+  let isStartCap = lenA <= PATH_EPSILON || (!isEnd && isFirst && !isClosed);
+  let isEndCap = lenB <= PATH_EPSILON || (isEnd && isLast && !isClosed);
+  let isCap = isStartCap || isEndCap;
+  var jointType = pathViewport.jointRounded;
+  if (isCap) {
+    let capOffset =
+      direction * pathViewport.capRounded * 4.0 * flipIfTrue(isStartCap);
+    cornerOffset = mix(perpendicular * sideOfPath, capOffset, isJoint);
+    jointType = pathViewport.capRounded;
+  }
+  let miterLength = select(
+    dot(cornerOffset, miterVector * turnDirection),
+    isJoint,
+    isCap
+  );
+  let offsetFromStart = cornerOffset + deltaA * select(0.0, 1.0, isEnd);
+  var extrusion : PathExtrusion;
+  extrusion.offset = cornerOffset * halfWidth;
+  extrusion.cornerOffset = cornerOffset;
+  extrusion.miterLength = miterLength;
+  extrusion.pathPosition = vec2<f32>(
+    dot(offsetFromStart, perpendicular),
+    dot(offsetFromStart, direction)
+  );
+  extrusion.pathLength = pathLength;
+  extrusion.jointType = jointType;
+  return extrusion;
+}
+
+@vertex
+fn vertexMain(inputs : VertexInputs) -> FragmentInputs {
+  var outputs : FragmentInputs;
+  let segmentVertex = getSegmentVertex(inputs.vertexIndex % 12u);
+  let previousPointValue = readPathPoint(inputs.segmentPreviousPointIndices);
+  let startPointValue = readPathPoint(inputs.segmentStartPointIndices);
+  let endPointValue = readPathPoint(inputs.segmentEndPointIndices);
+  let nextPointValue = readPathPoint(inputs.segmentNextPointIndices);
+  let previousPoint = mix(previousPointValue.xy, startPointValue.xy, segmentVertex.x);
+  let currentPoint = mix(startPointValue.xy, endPointValue.xy, segmentVertex.x);
+  let nextPoint = mix(endPointValue.xy, nextPointValue.xy, segmentVertex.x);
+  let rowIndex = inputs.rowIndices - pathStorageStyleConfig.batchRowIndexBase;
+  let storageWidth = select(
+    pathStorageStyleConfig.constantWidth,
+    pathRowWidths[rowIndex],
+    pathStorageStyleConfig.useRowWidths != 0u
+  );
+  let halfWidth = mix(0.0035, storageWidth, pathViewport.widthsEnabled);
+  let extrusion = computePathExtrusion(
+    previousPoint,
+    currentPoint,
+    nextPoint,
+    segmentVertex,
+    halfWidth,
+    inputs.segmentFlags
+  );
+  let worldPosition = currentPoint + extrusion.offset;
+  let neutralColor = vec4<f32>(0.78, 0.86, 0.96, 0.92);
+  var storageColor = pathStorageStyleConfig.constantColor;
+  if (pathStorageStyleConfig.useRowColors != 0u) {
+    storageColor = unpackPathColor(pathRowColors[rowIndex]);
+  }
+  outputs.Position = vec4<f32>(worldPosition * pathViewport.viewportScale, 0.0, 1.0);
+  outputs.color = mix(neutralColor, storageColor, pathViewport.colorsEnabled);
+  outputs.measure = mix(startPointValue.w, endPointValue.w, segmentVertex.x);
+  outputs.cornerOffset = extrusion.cornerOffset;
+  outputs.miterLength = extrusion.miterLength;
+  outputs.pathPosition = extrusion.pathPosition;
+  outputs.pathLength = extrusion.pathLength;
+  outputs.jointType = extrusion.jointType;
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs : FragmentInputs) -> @location(0) vec4<f32> {
+  if (inputs.pathPosition.y < 0.0 || inputs.pathPosition.y > inputs.pathLength) {
+    if (inputs.jointType > 0.5 && length(inputs.cornerOffset) > 1.0) {
+      discard;
+    }
+    if (inputs.jointType < 0.5 && inputs.miterLength > pathViewport.miterLimit + 1.0) {
+      discard;
+    }
+  }
+  let measureLag = pathViewport.time - inputs.measure;
+  let measureReached = select(0.0, 1.0, measureLag >= 0.0);
+  let measureHighlight = measureReached * (1.0 - smoothstep(0.0, 0.16, measureLag));
+  let highlight = 0.24 + measureHighlight * 0.76;
+  let lightenedColor = mix(
+    inputs.color.rgb * 0.72,
+    min(inputs.color.rgb * 1.18 + vec3<f32>(0.05), vec3<f32>(1.0)),
+    highlight
+  );
+  return vec4<f32>(lightenedColor, inputs.color.a);
+}
+`;
+
+const VS_GLSL = /* glsl */ `\
+#version 300 es
+precision highp float;
+precision highp int;
+
+in vec4 segmentStartPositions;
+in vec4 segmentEndPositions;
+in vec4 segmentPreviousPositions;
+in vec4 segmentNextPositions;
+in uint segmentFlags;
+in uint rowIndices;
+in vec4 colors;
+in float widths;
+
+layout(std140) uniform pathViewportUniforms {
+  vec2 viewportScale;
+  float time;
+  float colorsEnabled;
+  float widthsEnabled;
+  float capRounded;
+  float jointRounded;
+  float miterLimit;
+} pathViewport;
+
+out vec4 vColor;
+out float vMeasure;
+out vec2 vCornerOffset;
+out float vMiterLength;
+out vec2 vPathPosition;
+out float vPathLength;
+out float vJointType;
+
+struct PathExtrusion {
+  vec2 offset;
+  vec2 cornerOffset;
+  float miterLength;
+  vec2 pathPosition;
+  float pathLength;
+  float jointType;
+};
+
+const float PATH_EPSILON = 0.00001;
+const uint PATH_SEGMENT_FIRST = 1u;
+const uint PATH_SEGMENT_LAST = 2u;
+const uint PATH_SEGMENT_CLOSED = 4u;
+
+vec2 getSegmentVertex(int vertexIndex) {
+  if (vertexIndex == 0) return vec2(0.0, 0.0);
+  if (vertexIndex == 1) return vec2(0.0, -1.0);
+  if (vertexIndex == 2) return vec2(0.0, 1.0);
+  if (vertexIndex == 3) return vec2(0.0, -1.0);
+  if (vertexIndex == 4) return vec2(1.0, 1.0);
+  if (vertexIndex == 5) return vec2(0.0, 1.0);
+  if (vertexIndex == 6) return vec2(0.0, -1.0);
+  if (vertexIndex == 7) return vec2(1.0, -1.0);
+  if (vertexIndex == 8) return vec2(1.0, 1.0);
+  if (vertexIndex == 9) return vec2(1.0, -1.0);
+  if (vertexIndex == 10) return vec2(1.0, 0.0);
+  return vec2(1.0, 1.0);
+}
+
+float flipIfTrue(bool flag) {
+  return flag ? -1.0 : 1.0;
+}
+
+PathExtrusion computePathExtrusion(
+  vec2 previousPoint,
+  vec2 currentPoint,
+  vec2 nextPoint,
+  vec2 segmentVertex,
+  float halfWidth,
+  uint segmentMetadata
+) {
+  bool isEnd = segmentVertex.x > 0.5;
+  float sideOfPath = segmentVertex.y;
+  float isJoint = abs(sideOfPath) < 0.5 ? 1.0 : 0.0;
+  float normalizedWidth = max(halfWidth, PATH_EPSILON);
+  vec2 deltaA = (currentPoint - previousPoint) / normalizedWidth;
+  vec2 deltaB = (nextPoint - currentPoint) / normalizedWidth;
+  float lenA = length(deltaA);
+  float lenB = length(deltaB);
+  vec2 dirA = lenA > PATH_EPSILON ? normalize(deltaA) : vec2(0.0);
+  vec2 dirB = lenB > PATH_EPSILON ? normalize(deltaB) : vec2(0.0);
+  vec2 perpA = vec2(-dirA.y, dirA.x);
+  vec2 perpB = vec2(-dirB.y, dirB.x);
+  vec2 tangentBasis = dirA + dirB;
+  vec2 tangent = length(tangentBasis) > PATH_EPSILON ? normalize(tangentBasis) : perpA;
+  vec2 miterVector = vec2(-tangent.y, tangent.x);
+  vec2 direction = isEnd ? dirA : dirB;
+  vec2 perpendicular = isEnd ? perpA : perpB;
+  float pathLength = isEnd ? lenA : lenB;
+  float sinHalfAngle = abs(dot(miterVector, perpendicular));
+  float cosHalfAngle = abs(dot(dirA, miterVector));
+  float turnDirection = flipIfTrue(dirA.x * dirB.y >= dirA.y * dirB.x);
+  float cornerPosition = sideOfPath * turnDirection;
+  float miterSize = 1.0 / max(sinHalfAngle, PATH_EPSILON);
+  float trimmedMiterSize = min(miterSize, max(lenA, lenB) / max(cosHalfAngle, PATH_EPSILON));
+  miterSize = cornerPosition >= 0.0 ? miterSize : trimmedMiterSize;
+  vec2 cornerOffset = mix(
+    miterVector * miterSize,
+    perpendicular,
+    step(0.5, cornerPosition)
+  ) * (sideOfPath + isJoint * turnDirection);
+  bool isFirst = (segmentMetadata & PATH_SEGMENT_FIRST) != 0u;
+  bool isLast = (segmentMetadata & PATH_SEGMENT_LAST) != 0u;
+  bool isClosed = (segmentMetadata & PATH_SEGMENT_CLOSED) != 0u;
+  bool isStartCap = lenA <= PATH_EPSILON || (!isEnd && isFirst && !isClosed);
+  bool isEndCap = lenB <= PATH_EPSILON || (isEnd && isLast && !isClosed);
+  bool isCap = isStartCap || isEndCap;
+  float jointType = pathViewport.jointRounded;
+  if (isCap) {
+    vec2 capOffset = direction * pathViewport.capRounded * 4.0 * flipIfTrue(isStartCap);
+    cornerOffset = mix(perpendicular * sideOfPath, capOffset, isJoint);
+    jointType = pathViewport.capRounded;
+  }
+  float miterLength = isCap
+    ? isJoint
+    : dot(cornerOffset, miterVector * turnDirection);
+  vec2 offsetFromStart = cornerOffset + deltaA * (isEnd ? 1.0 : 0.0);
+  PathExtrusion extrusion;
+  extrusion.offset = cornerOffset * halfWidth;
+  extrusion.cornerOffset = cornerOffset;
+  extrusion.miterLength = miterLength;
+  extrusion.pathPosition = vec2(
+    dot(offsetFromStart, perpendicular),
+    dot(offsetFromStart, direction)
+  );
+  extrusion.pathLength = pathLength;
+  extrusion.jointType = jointType;
+  return extrusion;
+}
+
+void main() {
+  vec2 segmentVertex = getSegmentVertex(gl_VertexID % 12);
+  vec2 previousSegmentPosition = segmentPreviousPositions.xy;
+  vec2 startPosition = segmentStartPositions.xy;
+  vec2 endPosition = segmentEndPositions.xy;
+  vec2 nextSegmentPosition = segmentNextPositions.xy;
+  vec2 previousPoint = mix(previousSegmentPosition, startPosition, segmentVertex.x);
+  vec2 currentPoint = mix(startPosition, endPosition, segmentVertex.x);
+  vec2 nextPoint = mix(endPosition, nextSegmentPosition, segmentVertex.x);
+  float halfWidth = mix(0.0035, widths, pathViewport.widthsEnabled);
+  PathExtrusion extrusion = computePathExtrusion(
+    previousPoint,
+    currentPoint,
+    nextPoint,
+    segmentVertex,
+    halfWidth,
+    segmentFlags
+  );
+  vec2 worldPosition = currentPoint + extrusion.offset;
+  vec4 neutralColor = vec4(0.78, 0.86, 0.96, 0.92);
+  gl_Position = vec4(worldPosition * pathViewport.viewportScale, 0.0, 1.0);
+  vColor = mix(neutralColor, colors, pathViewport.colorsEnabled);
+  vMeasure = mix(segmentStartPositions.w, segmentEndPositions.w, segmentVertex.x);
+  vCornerOffset = extrusion.cornerOffset;
+  vMiterLength = extrusion.miterLength;
+  vPathPosition = extrusion.pathPosition;
+  vPathLength = extrusion.pathLength;
+  vJointType = extrusion.jointType;
+}
+`;
+
+const FS_GLSL = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+in vec4 vColor;
+in float vMeasure;
+in vec2 vCornerOffset;
+in float vMiterLength;
+in vec2 vPathPosition;
+in float vPathLength;
+in float vJointType;
+out vec4 fragColor;
+
+layout(std140) uniform pathViewportUniforms {
+  vec2 viewportScale;
+  float time;
+  float colorsEnabled;
+  float widthsEnabled;
+  float capRounded;
+  float jointRounded;
+  float miterLimit;
+} pathViewport;
+
+void main() {
+  if (vPathPosition.y < 0.0 || vPathPosition.y > vPathLength) {
+    if (vJointType > 0.5 && length(vCornerOffset) > 1.0) {
+      discard;
+    }
+    if (vJointType < 0.5 && vMiterLength > pathViewport.miterLimit + 1.0) {
+      discard;
+    }
+  }
+  float measureLag = pathViewport.time - vMeasure;
+  float measureReached = measureLag >= 0.0 ? 1.0 : 0.0;
+  float measureHighlight = measureReached * (1.0 - smoothstep(0.0, 0.16, measureLag));
+  float highlight = 0.24 + measureHighlight * 0.76;
+  vec3 lightenedColor = mix(
+    vColor.rgb * 0.72,
+    min(vColor.rgb * 1.18 + vec3(0.05), vec3(1.0)),
+    highlight
+  );
+  fragColor = vec4(lightenedColor, vColor.a);
+}
+`;
+
+type PathViewportUniforms = {
+  viewportScale: [number, number];
+  time: number;
+  colorsEnabled: number;
+  widthsEnabled: number;
+  capRounded: number;
+  jointRounded: number;
+  miterLimit: number;
+};
+
+const pathViewport: ShaderModule<PathViewportUniforms> = {
+  name: 'pathViewport',
+  uniformTypes: {
+    viewportScale: 'vec2<f32>',
+    time: 'f32',
+    colorsEnabled: 'f32',
+    widthsEnabled: 'f32',
+    capRounded: 'f32',
+    jointRounded: 'f32',
+    miterLimit: 'f32'
+  }
+};
+
+export default class ArrowPathModelAnimationLoopTemplate extends AnimationLoopTemplate {
+  static info = `\
+  <p>Renders nested Arrow coordinate lists through <code>ArrowPathModel</code> or <code>ArrowStoragePathModel</code>, one logical Arrow row per path.</p>
+  <style>
+    #${INFO_DETAILS_ID}[open] {
+      min-height: 196px;
+    }
+  </style>
+  <div style="min-height: 640px; max-height: calc(100vh - 72px); overflow-y: auto; margin-top: 16px; padding: 14px 16px; border: 1px solid rgba(208, 215, 222, 0.9); border-radius: 16px; background: linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(246, 248, 250, 0.96) 100%); box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);">
+    <div style="display: grid; grid-template-columns: minmax(48px, auto) minmax(0, 1fr); align-items: center; gap: 10px 12px; margin-bottom: 12px; color: #0f172a; font-size: 15px; font-weight: 600;">
+      <label for="${MODEL_SELECTOR_ID}">Model</label>
+      <select id="${MODEL_SELECTOR_ID}" style="min-width: 0; min-height: 34px; border: 1px solid rgba(148, 163, 184, 0.8); border-radius: 6px; background: #ffffff; color: #0f172a; font: inherit;">
+        <option value="attributes">ArrowPathModel</option>
+        <option value="storage">ArrowStoragePathModel</option>
+      </select>
+      <label for="${DATA_SELECTOR_ID}">Data</label>
+      <select id="${DATA_SELECTOR_ID}" style="min-width: 0; min-height: 34px; border: 1px solid rgba(148, 163, 184, 0.8); border-radius: 6px; background: #ffffff; color: #0f172a; font: inherit;">
+        <option value="240">${PATH_DATASETS['240'].label}</option>
+        <option value="960">${PATH_DATASETS['960'].label}</option>
+        <option value="2400">${PATH_DATASETS['2400'].label}</option>
+      </select>
+    </div>
+    <div style="display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px 14px; color: #0f172a; font-size: 15px; font-weight: 600;">
+      <label for="${MEASURE_SWEEP_TOGGLE_ID}" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+        <input id="${MEASURE_SWEEP_TOGGLE_ID}" type="checkbox" checked style="width: 18px; height: 18px; margin: 0; accent-color: #2563eb;" />
+        <span>Sweep M</span>
+      </label>
+      <label for="${COLOR_TOGGLE_ID}" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+        <input id="${COLOR_TOGGLE_ID}" type="checkbox" checked style="width: 18px; height: 18px; margin: 0; accent-color: #2563eb;" />
+        <span>Color</span>
+      </label>
+      <label for="${WIDTH_TOGGLE_ID}" style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+        <input id="${WIDTH_TOGGLE_ID}" type="checkbox" checked style="width: 18px; height: 18px; margin: 0; accent-color: #2563eb;" />
+        <span>Width</span>
+      </label>
+    </div>
+    <div style="display: grid; grid-template-columns: minmax(56px, auto) minmax(0, 1fr); align-items: center; gap: 10px 12px; margin-top: 14px; color: #0f172a; font-size: 14px; font-weight: 600;">
+      <label for="${CAP_SELECTOR_ID}">Caps</label>
+      <select id="${CAP_SELECTOR_ID}" style="min-width: 0; min-height: 32px; border: 1px solid rgba(148, 163, 184, 0.8); border-radius: 6px; background: #ffffff; color: #0f172a; font: inherit;">
+        <option value="square">Square</option>
+        <option value="round">Round</option>
+      </select>
+      <label for="${JOINT_SELECTOR_ID}">Joins</label>
+      <select id="${JOINT_SELECTOR_ID}" style="min-width: 0; min-height: 32px; border: 1px solid rgba(148, 163, 184, 0.8); border-radius: 6px; background: #ffffff; color: #0f172a; font: inherit;">
+        <option value="miter">Miter</option>
+        <option value="round">Round</option>
+      </select>
+      <label for="${MITER_LIMIT_INPUT_ID}">Miter</label>
+      <div style="display: flex; align-items: center; gap: 10px;">
+        <input id="${MITER_LIMIT_INPUT_ID}" type="range" min="1" max="8" step="0.25" value="4" style="width: 100%; accent-color: #2563eb;" />
+        <output id="${MITER_LIMIT_VALUE_ID}" for="${MITER_LIMIT_INPUT_ID}" style="min-width: 36px; color: #334155; font-variant-numeric: tabular-nums;">4.00</output>
+      </div>
+    </div>
+    ${makeMetricRow('Arrow path rows', PATH_COUNT_ID)}
+    ${makeMetricRow('Generated segment rows', SEGMENT_COUNT_ID)}
+    ${makeMetricRow('Arrow vector build time', ARROW_BUILD_TIME_ID)}
+    ${makeMetricRow('Segment prep time', CPU_EXPANSION_TIME_ID)}
+    ${makeMetricRow('Source GPU vector bytes', SOURCE_GPU_BYTES_ID)}
+    ${makeMetricRow('Generated segment geometry GPU bytes', GENERATED_GPU_BYTES_ID)}
+    ${makeMetricRow('Renderer style GPU bytes', STYLE_GPU_BYTES_ID)}
+    ${makeMetricRow('Total tracked GPU bytes', TOTAL_GPU_BYTES_ID)}
+    <details id="${INFO_DETAILS_ID}" style="margin-top: 14px; border-top: 1px solid rgba(208, 215, 222, 0.9); padding-top: 10px; color: #334155; font-size: 12px; line-height: 1.4;">
+      <summary style="cursor: pointer; color: #0f172a; font-weight: 700;">What this example isolates</summary>
+      <table style="width: 100%; margin-top: 10px; border-collapse: collapse; color: #334155; font-size: 12px; line-height: 1.4;">
+        <tbody>
+          <tr style="border-bottom: 1px solid rgba(226, 232, 240, 0.9);"><td style="padding: 7px 0;">Input</td><td style="padding: 7px 0;">Nested Float32 XYZM Arrow lists plus per-path color/width rows; M drives the time sweep</td></tr>
+          <tr style="border-bottom: 1px solid rgba(226, 232, 240, 0.9);"><td style="padding: 7px 0;">Shared drawing</td><td style="padding: 7px 0;">Both models render the same miter/round joins, square/round caps, and M-driven sweep; storage mode keeps generated segment records indexed</td></tr>
+          <tr style="border-bottom: 1px solid rgba(226, 232, 240, 0.9);"><td style="padding: 7px 0;">Attribute model</td><td style="padding: 7px 0;">CPU expansion builds segment records and repeats selected style rows into render attributes</td></tr>
+          <tr><td style="padding: 7px 0;">Storage model</td><td style="padding: 7px 0;">WebGPU compute expands nested rows while per-path colors and widths remain storage-backed</td></tr>
+        </tbody>
+      </table>
+    </details>
+  </div>
+  `;
+
+  static props = {useDevicePixels: true};
+
+  readonly device: Device;
+  readonly shaderInputs = new ShaderInputs<{pathViewport: typeof pathViewport.props}>({
+    pathViewport
+  });
+  readonly pathInputs: Partial<Record<ArrowPathDatasetKind, ArrowPathInput>> = {};
+  activeDatasetKind: ArrowPathDatasetKind = '240';
+  activePathModelKind: ArrowPathModelKind = 'attributes';
+  activePathInput!: ArrowPathInput;
+  pathModel!: ActiveArrowPathModel;
+  measureSweepEnabled = true;
+  colorsEnabled = true;
+  widthsEnabled = true;
+  capKind: ArrowPathCapKind = 'square';
+  jointKind: ArrowPathJointKind = 'miter';
+  miterLimit = 4;
+  measureTime = 0;
+  lastRenderSeconds: number | null = null;
+  modelSelector: HTMLSelectElement | null = null;
+  dataSelector: HTMLSelectElement | null = null;
+  measureSweepToggle: HTMLInputElement | null = null;
+  colorToggle: HTMLInputElement | null = null;
+  widthToggle: HTMLInputElement | null = null;
+  capSelector: HTMLSelectElement | null = null;
+  jointSelector: HTMLSelectElement | null = null;
+  miterLimitInput: HTMLInputElement | null = null;
+  miterLimitValue: HTMLOutputElement | null = null;
+  pathCountLabel: HTMLElement | null = null;
+  segmentCountLabel: HTMLElement | null = null;
+  arrowBuildTimeLabel: HTMLElement | null = null;
+  cpuExpansionTimeLabel: HTMLElement | null = null;
+  sourceGpuBytesLabel: HTMLElement | null = null;
+  generatedGpuBytesLabel: HTMLElement | null = null;
+  styleGpuBytesLabel: HTMLElement | null = null;
+  totalGpuBytesLabel: HTMLElement | null = null;
+
+  constructor({device}: AnimationProps) {
+    super();
+    this.device = device as Device;
+  }
+
+  override async onInitialize(): Promise<void> {
+    this.activePathInput = this.getOrCreatePathInput(this.activeDatasetKind);
+    this.pathModel = this.createPathModel(this.activePathInput, this.activePathModelKind);
+    this.initializeControls();
+    this.initializeMetricLabels();
+    this.updateMetricLabels();
+  }
+
+  override onRender({aspect, device, time}: AnimationProps): void {
+    const seconds = time / 1000;
+    if (this.lastRenderSeconds === null) {
+      this.lastRenderSeconds = seconds;
+    }
+    const elapsedSeconds = Math.max(seconds - this.lastRenderSeconds, 0);
+    this.lastRenderSeconds = seconds;
+    if (this.measureSweepEnabled) {
+      this.measureTime += elapsedSeconds * 0.24;
+      if (this.measureTime > 1.16) {
+        this.measureTime -= 1.16;
+      }
+    }
+
+    this.shaderInputs.setProps({
+      pathViewport: {
+        viewportScale: [1 / Math.max(aspect, 0.2), 1],
+        time: this.measureTime,
+        colorsEnabled: this.colorsEnabled ? 1 : 0,
+        widthsEnabled: this.widthsEnabled ? 1 : 0,
+        capRounded: this.capKind === 'round' ? 1 : 0,
+        jointRounded: this.jointKind === 'round' ? 1 : 0,
+        miterLimit: this.miterLimit
+      }
+    });
+
+    const renderPass = device.beginRenderPass({
+      clearColor: [0.015, 0.035, 0.07, 1]
+    });
+    this.pathModel.draw(renderPass);
+    renderPass.end();
+  }
+
+  override onFinalize(): void {
+    this.modelSelector?.removeEventListener('change', this.handleModelSelection);
+    this.dataSelector?.removeEventListener('change', this.handleDatasetSelection);
+    this.measureSweepToggle?.removeEventListener('change', this.handleMeasureSweepToggle);
+    this.colorToggle?.removeEventListener('change', this.handleColorToggle);
+    this.widthToggle?.removeEventListener('change', this.handleWidthToggle);
+    this.capSelector?.removeEventListener('change', this.handleCapSelection);
+    this.jointSelector?.removeEventListener('change', this.handleJointSelection);
+    this.miterLimitInput?.removeEventListener('input', this.handleMiterLimitInput);
+    this.pathModel?.destroy();
+    for (const pathInput of Object.values(this.pathInputs)) {
+      pathInput?.paths.destroy();
+      pathInput?.colors.destroy();
+      pathInput?.widths.destroy();
+    }
+  }
+
+  createPathModel(pathInput: ArrowPathInput, modelKind: ArrowPathModelKind): ActiveArrowPathModel {
+    const commonProps = {
+      id: 'arrow-path-model',
+      paths: pathInput.paths,
+      colors: pathInput.colors,
+      widths: pathInput.widths,
+      shaderInputs: this.shaderInputs,
+      topology: 'triangle-list' as const,
+      vertexCount: 12,
+      parameters: {
+        depthWriteEnabled: false,
+        blend: true,
+        blendColorOperation: 'add',
+        blendAlphaOperation: 'add',
+        blendColorSrcFactor: 'src-alpha',
+        blendColorDstFactor: 'one-minus-src-alpha',
+        blendAlphaSrcFactor: 'one',
+        blendAlphaDstFactor: 'one-minus-src-alpha'
+      } as const
+    };
+    if (modelKind === 'storage') {
+      if (this.device.type !== 'webgpu') {
+        throw new Error('ArrowStoragePathModel showcase mode requires WebGPU');
+      }
+      return new ArrowStoragePathModel(this.device, {
+        ...commonProps,
+        color: [199, 219, 245, 235],
+        width: 0.0035,
+        source: STORAGE_WGSL_SHADER,
+        shaderLayout: STORAGE_PATH_SHADER_LAYOUT
+      });
+    }
+    return new ArrowPathModel(this.device, {
+      ...commonProps,
+      sourceVectors: pathInput.sourceVectors,
+      source: WGSL_SHADER,
+      vs: VS_GLSL,
+      fs: FS_GLSL,
+      shaderLayout: PATH_SHADER_LAYOUT
+    });
+  }
+
+  getOrCreatePathInput(datasetKind: ArrowPathDatasetKind): ArrowPathInput {
+    const cachedPathInput = this.pathInputs[datasetKind];
+    if (cachedPathInput) {
+      return cachedPathInput;
+    }
+    const pathInput = makeArrowPathInput(this.device, PATH_DATASETS[datasetKind]);
+    this.pathInputs[datasetKind] = pathInput;
+    return pathInput;
+  }
+
+  initializeControls(): void {
+    this.modelSelector = document.getElementById(MODEL_SELECTOR_ID) as HTMLSelectElement | null;
+    this.dataSelector = document.getElementById(DATA_SELECTOR_ID) as HTMLSelectElement | null;
+    this.measureSweepToggle = document.getElementById(
+      MEASURE_SWEEP_TOGGLE_ID
+    ) as HTMLInputElement | null;
+    this.colorToggle = document.getElementById(COLOR_TOGGLE_ID) as HTMLInputElement | null;
+    this.widthToggle = document.getElementById(WIDTH_TOGGLE_ID) as HTMLInputElement | null;
+    this.capSelector = document.getElementById(CAP_SELECTOR_ID) as HTMLSelectElement | null;
+    this.jointSelector = document.getElementById(JOINT_SELECTOR_ID) as HTMLSelectElement | null;
+    this.miterLimitInput = document.getElementById(MITER_LIMIT_INPUT_ID) as HTMLInputElement | null;
+    this.miterLimitValue = document.getElementById(
+      MITER_LIMIT_VALUE_ID
+    ) as HTMLOutputElement | null;
+    if (this.modelSelector) {
+      this.modelSelector.value = this.activePathModelKind;
+      this.modelSelector.disabled = this.device.type !== 'webgpu';
+      this.modelSelector.addEventListener('change', this.handleModelSelection);
+    }
+    if (this.capSelector) {
+      this.capSelector.value = this.capKind;
+      this.capSelector.addEventListener('change', this.handleCapSelection);
+    }
+    if (this.jointSelector) {
+      this.jointSelector.value = this.jointKind;
+      this.jointSelector.addEventListener('change', this.handleJointSelection);
+    }
+    if (this.miterLimitInput) {
+      this.miterLimitInput.value = this.miterLimit.toFixed(2);
+      this.miterLimitInput.addEventListener('input', this.handleMiterLimitInput);
+    }
+    this.syncMiterLimitControls();
+    this.dataSelector?.addEventListener('change', this.handleDatasetSelection);
+    this.measureSweepToggle?.addEventListener('change', this.handleMeasureSweepToggle);
+    this.colorToggle?.addEventListener('change', this.handleColorToggle);
+    this.widthToggle?.addEventListener('change', this.handleWidthToggle);
+  }
+
+  initializeMetricLabels(): void {
+    this.pathCountLabel = document.getElementById(PATH_COUNT_ID);
+    this.segmentCountLabel = document.getElementById(SEGMENT_COUNT_ID);
+    this.arrowBuildTimeLabel = document.getElementById(ARROW_BUILD_TIME_ID);
+    this.cpuExpansionTimeLabel = document.getElementById(CPU_EXPANSION_TIME_ID);
+    this.sourceGpuBytesLabel = document.getElementById(SOURCE_GPU_BYTES_ID);
+    this.generatedGpuBytesLabel = document.getElementById(GENERATED_GPU_BYTES_ID);
+    this.styleGpuBytesLabel = document.getElementById(STYLE_GPU_BYTES_ID);
+    this.totalGpuBytesLabel = document.getElementById(TOTAL_GPU_BYTES_ID);
+  }
+
+  updateMetricLabels(): void {
+    const sourceGpuBytes = getArrowPathSourceGpuByteLength(this.activePathInput);
+    const generatedGpuBytes = getGeneratedPathGpuByteLength(this.pathModel);
+    const styleGpuBytes = getRendererStyleGpuByteLength(this.pathModel);
+    setMetricText(this.pathCountLabel, formatInteger(this.activePathInput.paths.length));
+    setMetricText(
+      this.segmentCountLabel,
+      formatInteger(getGeneratedPathSegmentCount(this.pathModel))
+    );
+    setMetricText(
+      this.arrowBuildTimeLabel,
+      `${this.activePathInput.arrowVectorBuildTimeMs.toFixed(1)} ms`
+    );
+    setMetricText(
+      this.cpuExpansionTimeLabel,
+      `${getPathModelPrepTimeMs(this.pathModel).toFixed(1)} ms`
+    );
+    setMetricText(this.sourceGpuBytesLabel, formatBytes(sourceGpuBytes));
+    setMetricText(this.generatedGpuBytesLabel, formatBytes(generatedGpuBytes));
+    setMetricText(this.styleGpuBytesLabel, formatBytes(styleGpuBytes));
+    setMetricText(
+      this.totalGpuBytesLabel,
+      formatBytes(sourceGpuBytes + generatedGpuBytes + styleGpuBytes)
+    );
+  }
+
+  readonly handleDatasetSelection = (): void => {
+    const nextDatasetKind = this.dataSelector?.value as ArrowPathDatasetKind | undefined;
+    if (!nextDatasetKind || nextDatasetKind === this.activeDatasetKind) {
+      return;
+    }
+    this.activeDatasetKind = nextDatasetKind;
+    this.activePathInput = this.getOrCreatePathInput(nextDatasetKind);
+    this.replacePathModel(this.activePathModelKind);
+    this.updateMetricLabels();
+  };
+
+  readonly handleModelSelection = (): void => {
+    const requestedPathModelKind = this.modelSelector?.value as ArrowPathModelKind | undefined;
+    const nextPathModelKind =
+      requestedPathModelKind === 'storage' && this.device.type === 'webgpu'
+        ? 'storage'
+        : 'attributes';
+    if (nextPathModelKind === this.activePathModelKind) {
+      return;
+    }
+    this.replacePathModel(nextPathModelKind);
+    this.updateMetricLabels();
+  };
+
+  replacePathModel(nextPathModelKind: ArrowPathModelKind): void {
+    const previousPathModel = this.pathModel;
+    this.pathModel = this.createPathModel(this.activePathInput, nextPathModelKind);
+    this.activePathModelKind = nextPathModelKind;
+    if (this.modelSelector) {
+      this.modelSelector.value = nextPathModelKind;
+    }
+    previousPathModel.destroy();
+  }
+
+  readonly handleMeasureSweepToggle = (): void => {
+    this.measureSweepEnabled = Boolean(this.measureSweepToggle?.checked);
+  };
+
+  readonly handleColorToggle = (): void => {
+    this.colorsEnabled = Boolean(this.colorToggle?.checked);
+  };
+
+  readonly handleWidthToggle = (): void => {
+    this.widthsEnabled = Boolean(this.widthToggle?.checked);
+  };
+
+  readonly handleCapSelection = (): void => {
+    this.capKind = this.capSelector?.value === 'round' ? 'round' : 'square';
+  };
+
+  readonly handleJointSelection = (): void => {
+    this.jointKind = this.jointSelector?.value === 'round' ? 'round' : 'miter';
+    this.syncMiterLimitControls();
+  };
+
+  readonly handleMiterLimitInput = (): void => {
+    const nextMiterLimit = Number(this.miterLimitInput?.value ?? this.miterLimit);
+    this.miterLimit = Number.isFinite(nextMiterLimit) ? nextMiterLimit : this.miterLimit;
+    this.syncMiterLimitControls();
+  };
+
+  syncMiterLimitControls(): void {
+    if (this.miterLimitInput) {
+      this.miterLimitInput.disabled = this.jointKind !== 'miter';
+    }
+    if (this.miterLimitValue) {
+      this.miterLimitValue.textContent = this.miterLimit.toFixed(2);
+    }
+  }
+}
+
+function makeMetricRow(label: string, id: string): string {
+  return `<div style="display: flex; justify-content: space-between; gap: 16px; margin-top: 10px; padding-top: 10px; border-top: 1px solid rgba(226, 232, 240, 0.9); color: #334155; font-size: 13px; line-height: 1.4;"><span>${label}</span><strong id="${id}" style="color: #0f172a; font-variant-numeric: tabular-nums;">Measuring...</strong></div>`;
+}
+
+function getGeneratedPathGpuByteLength(pathModel: ActiveArrowPathModel): number {
+  if (pathModel instanceof ArrowStoragePathModel) {
+    return pathModel.renderBatches.reduce(
+      (byteLength, renderBatch) => byteLength + renderBatch.compactPathVertexData.byteLength,
+      0
+    );
+  }
+  return pathModel.renderBatches.reduce(
+    (byteLength, renderBatch) => byteLength + renderBatch.expandedPathVertexData.byteLength,
+    0
+  );
+}
+
+function getGeneratedPathSegmentCount(pathModel: ActiveArrowPathModel): number {
+  return pathModel instanceof ArrowStoragePathModel
+    ? pathModel.segmentCount
+    : pathModel.segmentLayout.segmentCount;
+}
+
+function getRendererStyleGpuByteLength(pathModel: ActiveArrowPathModel): number {
+  if (pathModel instanceof ArrowStoragePathModel) {
+    return pathModel.rowStorageByteLength;
+  }
+  return Object.values(pathModel.arrowGPUTable?.gpuVectors || {}).reduce(
+    (byteLength, vector) => byteLength + getGpuVectorByteLength(vector),
+    0
+  );
+}
+
+function getPathModelPrepTimeMs(pathModel: ActiveArrowPathModel): number {
+  return pathModel instanceof ArrowStoragePathModel
+    ? pathModel.pathRangeBuildTimeMs
+    : pathModel.segmentAttributeBuildTimeMs;
+}
+
+function makeArrowPathInput(device: Device, dataset: ArrowPathDataset): ArrowPathInput {
+  const buildStartTime = getNow();
+  const paths = makePathVector(dataset.pathCount, dataset.pointCount);
+  const colors = makeArrowFixedSizeListVector(
+    new arrow.Uint8(),
+    4,
+    makePathColors(dataset.pathCount)
+  );
+  const widths = arrow.vectorFromArray(makePathWidths(dataset.pathCount), new arrow.Float32());
+  const arrowVectorBuildTimeMs = getNow() - buildStartTime;
+  const sourceVectors: ArrowPathSourceVectors = {paths, colors, widths};
+
+  return {
+    paths: new GPUVector({type: 'arrow', name: 'paths', device, vector: paths}),
+    colors: new GPUVector({type: 'arrow', name: 'colors', device, vector: colors}),
+    widths: new GPUVector({type: 'arrow', name: 'widths', device, vector: widths}),
+    sourceVectors,
+    arrowVectorBuildTimeMs
+  };
+}
+
+function makePathVector(
+  pathCount: number,
+  pointCount: number
+): arrow.Vector<ArrowPathCoordinateType> {
+  const valueOffsets = new Int32Array(pathCount + 1);
+  const values = new Float32Array(pathCount * pointCount * 4);
+  for (let pathIndex = 0; pathIndex < pathCount; pathIndex++) {
+    valueOffsets[pathIndex] = pathIndex * pointCount;
+    const normalizedPathIndex = pathCount <= 1 ? 0 : pathIndex / (pathCount - 1);
+    const baseY = -0.92 + normalizedPathIndex * 1.84;
+    const phase = pathIndex * 0.13;
+    const pathClusterIndex = pathIndex % 5;
+    const pathMeasureRate = 0.58 + pathClusterIndex * 0.16;
+    const pathMeasurePhase = (Math.floor(pathIndex / 5) % 4) * 0.08;
+    for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
+      const pathProgress = pointCount <= 1 ? 0 : pointIndex / (pointCount - 1);
+      const coordinateIndex = (pathIndex * pointCount + pointIndex) * 4;
+      values[coordinateIndex] = -1.24 + pathProgress * 2.48;
+      values[coordinateIndex + 1] =
+        baseY +
+        Math.sin(pathProgress * 11.5 + phase) * 0.028 +
+        Math.cos(pathProgress * 4.2 - phase * 0.55) * 0.014;
+      values[coordinateIndex + 2] = 0;
+      values[coordinateIndex + 3] = (1 - pathProgress) * pathMeasureRate + pathMeasurePhase;
+    }
+  }
+  valueOffsets[pathCount] = pathCount * pointCount;
+
+  const coordinateType = new arrow.FixedSizeList(
+    4,
+    new arrow.Field('values', new arrow.Float32(), false)
+  );
+  const pathType = new arrow.List(
+    new arrow.Field('coordinates', coordinateType, false)
+  ) as ArrowPathCoordinateType;
+  const coordinateValueData = new arrow.Data<arrow.Float32>(
+    new arrow.Float32(),
+    0,
+    values.length,
+    0,
+    {[arrow.BufferType.DATA]: values}
+  );
+  const coordinateData = new arrow.Data<arrow.FixedSizeList<arrow.Float32>>(
+    coordinateType,
+    0,
+    values.length / 4,
+    0,
+    {},
+    [coordinateValueData]
+  );
+  const pathData = new arrow.Data<ArrowPathCoordinateType>(
+    pathType,
+    0,
+    pathCount,
+    0,
+    {[arrow.BufferType.OFFSET]: valueOffsets},
+    [coordinateData]
+  );
+  return new arrow.Vector<ArrowPathCoordinateType>([pathData]);
+}
+
+function makePathColors(pathCount: number): Uint8Array {
+  const colors = new Uint8Array(pathCount * 4);
+  for (let pathIndex = 0; pathIndex < pathCount; pathIndex++) {
+    const paletteColor = getPathPaletteColor(pathIndex);
+    const colorOffset = pathIndex * 4;
+    colors[colorOffset] = paletteColor[0];
+    colors[colorOffset + 1] = paletteColor[1];
+    colors[colorOffset + 2] = paletteColor[2];
+    colors[colorOffset + 3] = 220;
+  }
+  return colors;
+}
+
+function makePathWidths(pathCount: number): number[] {
+  return Array.from({length: pathCount}, (_, pathIndex) => 0.0022 + (pathIndex % 7) * 0.00072);
+}
+
+function getPathPaletteColor(pathIndex: number): [number, number, number] {
+  switch (pathIndex % 5) {
+    case 0:
+      return [72, 205, 217];
+    case 1:
+      return [255, 186, 73];
+    case 2:
+      return [255, 111, 97];
+    case 3:
+      return [120, 177, 255];
+    default:
+      return [152, 221, 132];
+  }
+}
+
+function getArrowPathSourceGpuByteLength(pathInput: ArrowPathInput): number {
+  return (
+    getGpuVectorByteLength(pathInput.paths) +
+    getGpuVectorByteLength(pathInput.colors) +
+    getGpuVectorByteLength(pathInput.widths)
+  );
+}
+
+function getGpuVectorByteLength(vector: GPUVector<any>): number {
+  return vector.data.reduce((byteLength, data) => byteLength + data.buffer.byteLength, 0);
+}
+
+function setMetricText(element: HTMLElement | null, value: string): void {
+  if (element) {
+    element.textContent = value;
+  }
+}
+
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function formatBytes(byteLength: number): string {
+  if (byteLength < 1024) {
+    return `${byteLength} B`;
+  }
+  if (byteLength < 1024 * 1024) {
+    return `${(byteLength / 1024).toFixed(1)} KB`;
+  }
+  return `${(byteLength / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getNow(): number {
+  return typeof performance === 'undefined' ? Date.now() : performance.now();
+}

--- a/examples/gpu-tables/arrow-path-model/index.html
+++ b/examples/gpu-tables/arrow-path-model/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<script type="module">
+  import {makeAnimationLoop} from '@luma.gl/engine';
+  import {webgl2Adapter} from '@luma.gl/webgl';
+  import {webgpuAdapter} from '@luma.gl/webgpu';
+  import AnimationLoopTemplate from './app.ts';
+
+  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+    adapters: [webgl2Adapter, webgpuAdapter]
+  });
+  animationLoop.start();
+</script>
+<body>
+</body>

--- a/examples/gpu-tables/arrow-path-model/package.json
+++ b/examples/gpu-tables/arrow-path-model/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "luma.gl-examples-arrow-path-model",
+  "version": "9.3.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "vite",
+    "build": "tsc && vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "@luma.gl/arrow": "~9.3.0",
+    "@luma.gl/core": "~9.3.0",
+    "@luma.gl/engine": "~9.3.0",
+    "@luma.gl/shadertools": "~9.3.0",
+    "@luma.gl/webgl": "~9.3.0",
+    "@luma.gl/webgpu": "~9.3.0",
+    "apache-arrow": "^17.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/examples/gpu-tables/arrow-path-model/tsconfig.json
+++ b/examples/gpu-tables/arrow-path-model/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["."]
+}

--- a/examples/gpu-tables/arrow-path-model/vite.config.ts
+++ b/examples/gpu-tables/arrow-path-model/vite.config.ts
@@ -1,0 +1,18 @@
+import {defineConfig} from 'vite';
+
+const alias = {
+  '@luma.gl/arrow': `${__dirname}/../../../modules/arrow/src`,
+  '@luma.gl/core': `${__dirname}/../../../modules/core/src`,
+  '@luma.gl/engine': `${__dirname}/../../../modules/engine/src`,
+  '@luma.gl/experimental': `${__dirname}/../../../modules/experimental/src`,
+  '@luma.gl/shadertools': `${__dirname}/../../../modules/shadertools/src`,
+  '@luma.gl/test-utils': `${__dirname}/../../../modules/test-utils/src`,
+  '@luma.gl/webgl/constants': `${__dirname}/../../../modules/webgl/src/constants`,
+  '@luma.gl/webgl': `${__dirname}/../../../modules/webgl/src`,
+  '@luma.gl/webgpu': `${__dirname}/../../../modules/webgpu/src`
+};
+
+export default defineConfig({
+  resolve: {alias},
+  server: {open: true}
+});

--- a/modules/arrow/README.md
+++ b/modules/arrow/README.md
@@ -22,6 +22,25 @@ attributes without switching to a separate table abstraction.
 Uploaded vectors own their generated buffers. Wrapped-buffer vectors are
 non-owning by default unless ownership is explicitly requested or transferred by
 an in-place operation.
+<<<<<<< Updated upstream
+=======
+`GPUVector` also supports variable-length Arrow list columns whose nested elements
+contain one to four numeric components. This covers scalar lists plus tuple-style
+data such as XY, XYZ, and XYZM coordinates, while copying only compact list-offset
+metadata needed for readback instead of retaining the uploaded Arrow value arrays.
+`ArrowPathModel` consumes Float32 XY, XYZ, or XYZM nested coordinate rows from that
+representation, expands one logical path row into packed per-segment render records,
+and repeats optional per-path color and width columns only for the attribute-backed
+render table that needs them. CPU path/style vectors used for that expansion remain
+explicit caller-owned `sourceVectors`.
+`ArrowStoragePathModel` is the WebGPU storage-backed counterpart. It expands nested
+path rows into compact indexed segment records through compute using the
+GPU-resident path values plus copied list-offset metadata. Render shaders fetch
+coordinates from the original path-value storage buffer, while per-path color and
+width rows remain storage-buffer bindings instead of being duplicated per generated
+segment. Reusable storage state can be built separately with
+`createArrowStoragePathState`.
+>>>>>>> Stashed changes
 
 `ArrowGeometry` and `ArrowModel` can also consume loaders.gl-compatible Mesh
 Arrow tables through the local structural `ArrowMeshTable` type. Mesh Arrow

--- a/modules/arrow/src/arrow/arrow-path-model.ts
+++ b/modules/arrow/src/arrow/arrow-path-model.ts
@@ -1,0 +1,860 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  Buffer,
+  type BufferLayout,
+  type Device,
+  type RenderPass,
+  type ShaderLayout
+} from '@luma.gl/core';
+import * as arrow from 'apache-arrow';
+import {ArrowModel, type ArrowModelProps} from './arrow-model';
+import {GPUVector} from './arrow-gpu-vector';
+import {expandArrowVector} from './arrow-vector-utils';
+import {
+  getArrowVariableLengthAttributeDataBufferSource,
+  getArrowVectorBufferSource
+} from './arrow-gpu-data';
+import {makeArrowFixedSizeListVector} from './arrow-fixed-size-list';
+import {planGeneratedBufferBatches, type GeneratedBufferBatch} from './generated-buffer-batches';
+import {
+  isInstanceArrowType,
+  isVariableLengthAttributeArrowType,
+  type NumericArrowType
+} from './arrow-types';
+
+const SEGMENT_START_POSITIONS_COLUMN = 'segmentStartPositions';
+const SEGMENT_END_POSITIONS_COLUMN = 'segmentEndPositions';
+const SEGMENT_PREVIOUS_POSITIONS_COLUMN = 'segmentPreviousPositions';
+const SEGMENT_NEXT_POSITIONS_COLUMN = 'segmentNextPositions';
+const SEGMENT_FLAGS_COLUMN = 'segmentFlags';
+const ROW_INDICES_COLUMN = 'rowIndices';
+const EXPANDED_PATH_VERTEX_DATA = 'expandedPathVertexData';
+
+const PATH_SEGMENT_FIRST = 1;
+const PATH_SEGMENT_LAST = 2;
+const PATH_SEGMENT_CLOSED = 4;
+
+const EXPANDED_PATH_VERTEX_BYTE_STRIDE =
+  Float32Array.BYTES_PER_ELEMENT * 16 + Uint32Array.BYTES_PER_ELEMENT * 2;
+const SEGMENT_END_POSITIONS_BYTE_OFFSET = Float32Array.BYTES_PER_ELEMENT * 4;
+const SEGMENT_PREVIOUS_POSITIONS_BYTE_OFFSET = Float32Array.BYTES_PER_ELEMENT * 8;
+const SEGMENT_NEXT_POSITIONS_BYTE_OFFSET = Float32Array.BYTES_PER_ELEMENT * 12;
+const SEGMENT_FLAGS_BYTE_OFFSET = Float32Array.BYTES_PER_ELEMENT * 16;
+const ROW_INDICES_BYTE_OFFSET = SEGMENT_FLAGS_BYTE_OFFSET + Uint32Array.BYTES_PER_ELEMENT;
+
+type ArrowPathCoordinateType = arrow.List<arrow.FixedSizeList<arrow.Float32>>;
+type ArrowPathColorType = arrow.FixedSizeList<arrow.Uint8>;
+
+const DEFAULT_ARROW_PATH_SHADER_LAYOUT: ShaderLayout = {
+  attributes: [
+    {name: SEGMENT_START_POSITIONS_COLUMN, location: 0, type: 'vec4<f32>', stepMode: 'instance'},
+    {name: SEGMENT_END_POSITIONS_COLUMN, location: 1, type: 'vec4<f32>', stepMode: 'instance'}
+  ],
+  bindings: []
+};
+
+const DEFAULT_ARROW_PATH_VS = `#version 300 es
+precision highp float;
+
+in vec4 segmentStartPositions;
+in vec4 segmentEndPositions;
+
+void main() {
+  vec4 pathPosition = gl_VertexID % 2 == 0 ? segmentStartPositions : segmentEndPositions;
+  gl_Position = vec4(pathPosition.xyz, 1.0);
+}
+`;
+
+const DEFAULT_ARROW_PATH_FS = `#version 300 es
+precision highp float;
+
+out vec4 fragColor;
+
+void main() {
+  fragColor = vec4(1.0);
+}
+`;
+
+/** CPU Arrow vectors retained explicitly while path rows expand into segment attributes. */
+export type ArrowPathSourceVectors = {
+  paths: arrow.Vector<ArrowPathCoordinateType>;
+  colors?: arrow.Vector<ArrowPathColorType>;
+  widths?: arrow.Vector<arrow.Float32>;
+};
+
+/** Props for the CPU-expanded attribute-backed Arrow path renderer. */
+export type ArrowPathModelProps = Omit<
+  ArrowModelProps,
+  'arrowTable' | 'arrowGPUTable' | 'arrowCount'
+> & {
+  /** Variable-length Float32 XY, XYZ, or XYZM path coordinates, one Arrow row per path. */
+  paths: GPUVector<ArrowPathCoordinateType>;
+  /** Optional packed RGBA8 path colors, one Arrow row per path. */
+  colors?: GPUVector<ArrowPathColorType>;
+  /** Optional per-path widths, one Arrow row per path. */
+  widths?: GPUVector<arrow.Float32>;
+  /** CPU Arrow vectors explicitly retained by the caller for segment expansion. */
+  sourceVectors: ArrowPathSourceVectors;
+};
+
+/** CPU-generated segment geometry for one expanded Arrow path table. */
+export type ArrowPathSegmentLayout = {
+  /** Cumulative segment offsets, length = source path rows + 1. */
+  startIndices: number[];
+  /** Number of generated segment records. */
+  segmentCount: number;
+  /** Generated segment starts, padded to four Float32 lanes per segment. */
+  segmentStartPositions: Float32Array;
+  /** Generated segment ends, padded to four Float32 lanes per segment. */
+  segmentEndPositions: Float32Array;
+  /** Previous coordinate used for join/cap decisions, padded to four Float32 lanes. */
+  segmentPreviousPositions: Float32Array;
+  /** Next coordinate used for join/cap decisions, padded to four Float32 lanes. */
+  segmentNextPositions: Float32Array;
+  /** Packed first/last/closed flags for each generated segment. */
+  segmentFlags: Uint32Array;
+};
+
+/** Expanded Arrow table plus generated path layout diagnostics. */
+export type ArrowPathSegmentTable = {
+  table: arrow.Table;
+  segmentLayout: ArrowPathSegmentLayout;
+  segmentAttributeBuildTimeMs: number;
+  attributeByteLength: number;
+};
+
+/** Generated render-batch state owned by {@link ArrowPathModel}. */
+export type ArrowPathRenderBatchState = {
+  rowStart: number;
+  rowEnd: number;
+  segmentCount: number;
+  expandedPathVertexData: Buffer;
+};
+
+type ResolvedArrowPathInputs = {
+  rowTable: arrow.Table;
+  paths: arrow.Vector<ArrowPathCoordinateType>;
+};
+
+/** Arrow-backed path renderer that expands one logical path row into segment instances. */
+export class ArrowPathModel extends ArrowModel {
+  segmentLayout: ArrowPathSegmentLayout;
+  segmentTable: arrow.Table;
+  segmentAttributeBuildTimeMs: number;
+  segmentAttributeByteLength: number;
+  expandedPathVertexData: Buffer;
+  renderBatches: ArrowPathRenderBatchState[];
+  private pathProps: ArrowPathModelProps;
+
+  constructor(device: Device, props: ArrowPathModelProps) {
+    const prepared = prepareArrowPathModel(device, props);
+    super(device, prepared.modelProps);
+    this.pathProps = props;
+    this.segmentLayout = prepared.segmentTable.segmentLayout;
+    this.segmentTable = prepared.segmentTable.table;
+    this.segmentAttributeBuildTimeMs = prepared.segmentTable.segmentAttributeBuildTimeMs;
+    this.segmentAttributeByteLength = prepared.segmentTable.attributeByteLength;
+    this.expandedPathVertexData = prepared.expandedPathVertexData;
+    this.renderBatches = prepared.renderBatches;
+  }
+
+  /** Rebuild generated segment records when path rows or CPU-visible row styles change. */
+  override setProps(props: Partial<ArrowPathModelProps>): void {
+    const nextProps = {...this.pathProps, ...props};
+    const shouldRebuild =
+      props.paths !== undefined ||
+      props.colors !== undefined ||
+      props.widths !== undefined ||
+      props.sourceVectors !== undefined;
+
+    this.pathProps = nextProps;
+    if (!shouldRebuild) {
+      super.setProps({});
+      return;
+    }
+
+    const prepared = prepareArrowPathModel(this.device, nextProps);
+    destroyArrowPathRenderBatches(this.renderBatches);
+    this.segmentLayout = prepared.segmentTable.segmentLayout;
+    this.segmentTable = prepared.segmentTable.table;
+    this.segmentAttributeBuildTimeMs = prepared.segmentTable.segmentAttributeBuildTimeMs;
+    this.segmentAttributeByteLength = prepared.segmentTable.attributeByteLength;
+    this.expandedPathVertexData = prepared.expandedPathVertexData;
+    this.renderBatches = prepared.renderBatches;
+
+    super.setProps({arrowTable: prepared.modelProps.arrowTable as arrow.Table});
+    this.setAttributes({[EXPANDED_PATH_VERTEX_DATA]: prepared.expandedPathVertexData});
+    this.setInstanceCount(prepared.segmentTable.segmentLayout.segmentCount);
+    this.setNeedsRedraw('Arrow path segment table updated');
+  }
+
+  override draw(renderPass: RenderPass): boolean {
+    const arrowBatches = this.arrowGPUTable?.batches || [];
+    if (arrowBatches.length > 0 && arrowBatches.length !== this.renderBatches.length) {
+      throw new Error('ArrowPathModel draw batches must align with generated path render batches');
+    }
+
+    let drawSuccess = true;
+    try {
+      for (const [batchIndex, renderBatch] of this.renderBatches.entries()) {
+        const arrowBatch = arrowBatches[batchIndex];
+        this.setAttributes({
+          ...(arrowBatch?.attributes || {}),
+          [EXPANDED_PATH_VERTEX_DATA]: renderBatch.expandedPathVertexData
+        });
+        this.setInstanceCount(renderBatch.segmentCount);
+        drawSuccess = super.draw(renderPass) && drawSuccess;
+      }
+    } finally {
+      this.setAttributes({
+        ...(this.arrowGPUTable?.attributes || {}),
+        [EXPANDED_PATH_VERTEX_DATA]: this.expandedPathVertexData
+      });
+      this.setInstanceCount(this.segmentLayout.segmentCount);
+    }
+
+    return drawSuccess;
+  }
+
+  override destroy(): void {
+    destroyArrowPathRenderBatches(this.renderBatches);
+    super.destroy();
+  }
+}
+
+/** Expand path rows into per-segment Arrow rows without creating a GPU Model. */
+export function buildArrowPathSegmentTable(props: {
+  rowTable: arrow.Table;
+  paths: arrow.Vector<ArrowPathCoordinateType>;
+  rowIndexBase?: number;
+}): ArrowPathSegmentTable {
+  if (props.rowTable.schema.fields.length > 0 && props.rowTable.numRows !== props.paths.length) {
+    throw new Error('ArrowPathModel requires rowTable rows to match path rows');
+  }
+  assertArrowPathColumnAvailable(props.rowTable, SEGMENT_START_POSITIONS_COLUMN);
+  assertArrowPathColumnAvailable(props.rowTable, SEGMENT_END_POSITIONS_COLUMN);
+  assertArrowPathColumnAvailable(props.rowTable, SEGMENT_PREVIOUS_POSITIONS_COLUMN);
+  assertArrowPathColumnAvailable(props.rowTable, SEGMENT_NEXT_POSITIONS_COLUMN);
+  assertArrowPathColumnAvailable(props.rowTable, SEGMENT_FLAGS_COLUMN);
+  assertArrowPathColumnAvailable(props.rowTable, ROW_INDICES_COLUMN);
+
+  const segmentAttributeBuildStartTime = getNow();
+  const segmentLayout = buildArrowPathSegmentLayout(props.paths);
+  const segmentRowIndices = makeArrowPathRowIndices(segmentLayout.startIndices, props.rowIndexBase);
+  const localSegmentRowIndices = makeArrowPathRowIndices(segmentLayout.startIndices);
+  const fields: arrow.Field[] = [];
+  const columns: Record<string, arrow.Vector> = {};
+
+  for (const field of props.rowTable.schema.fields) {
+    const vector = props.rowTable.getChild(field.name);
+    if (!vector || !isInstanceArrowType(vector.type)) {
+      continue;
+    }
+    fields.push(field);
+    columns[field.name] = expandArrowVector(vector as arrow.Vector<any>, localSegmentRowIndices);
+  }
+
+  fields.push(makeFixedSizeListFloatField(SEGMENT_START_POSITIONS_COLUMN, 4));
+  fields.push(makeFixedSizeListFloatField(SEGMENT_END_POSITIONS_COLUMN, 4));
+  fields.push(makeFixedSizeListFloatField(SEGMENT_PREVIOUS_POSITIONS_COLUMN, 4));
+  fields.push(makeFixedSizeListFloatField(SEGMENT_NEXT_POSITIONS_COLUMN, 4));
+  fields.push(new arrow.Field(SEGMENT_FLAGS_COLUMN, new arrow.Uint32(), false));
+  fields.push(new arrow.Field(ROW_INDICES_COLUMN, new arrow.Uint32(), false));
+  columns[SEGMENT_START_POSITIONS_COLUMN] = makeArrowFixedSizeListVector(
+    new arrow.Float32(),
+    4,
+    segmentLayout.segmentStartPositions
+  );
+  columns[SEGMENT_END_POSITIONS_COLUMN] = makeArrowFixedSizeListVector(
+    new arrow.Float32(),
+    4,
+    segmentLayout.segmentEndPositions
+  );
+  columns[SEGMENT_PREVIOUS_POSITIONS_COLUMN] = makeArrowFixedSizeListVector(
+    new arrow.Float32(),
+    4,
+    segmentLayout.segmentPreviousPositions
+  );
+  columns[SEGMENT_NEXT_POSITIONS_COLUMN] = makeArrowFixedSizeListVector(
+    new arrow.Float32(),
+    4,
+    segmentLayout.segmentNextPositions
+  );
+  columns[SEGMENT_FLAGS_COLUMN] = makeNumericArrowVector(
+    new arrow.Uint32(),
+    segmentLayout.segmentFlags
+  );
+  columns[ROW_INDICES_COLUMN] = makeNumericArrowVector(new arrow.Uint32(), segmentRowIndices);
+
+  const segmentAttributeBuildTimeMs = getNow() - segmentAttributeBuildStartTime;
+  const attributeByteLength = getGeneratedAttributeByteLength(columns);
+
+  return {
+    table: new arrow.Table(new arrow.Schema(fields, props.rowTable.schema.metadata), columns),
+    segmentLayout,
+    segmentAttributeBuildTimeMs,
+    attributeByteLength
+  };
+}
+
+function prepareArrowPathModel(
+  device: Device,
+  props: ArrowPathModelProps
+): {
+  modelProps: ArrowModelProps;
+  segmentTable: ArrowPathSegmentTable;
+  expandedPathVertexData: Buffer;
+  renderBatches: ArrowPathRenderBatchState[];
+} {
+  const pathInputs = resolveArrowPathInputs(props);
+  const segmentTable = buildArrowPathSegmentTable(pathInputs);
+  const shaderLayout = props.shaderLayout ?? DEFAULT_ARROW_PATH_SHADER_LAYOUT;
+  const generatedBufferBatches = planGeneratedBufferBatches({
+    device,
+    recordOffsets: segmentTable.segmentLayout.startIndices,
+    recordByteStride: EXPANDED_PATH_VERTEX_BYTE_STRIDE,
+    resourceLabel: 'ArrowPathModel expanded path vertex data'
+  });
+  const expandedPathVertexStates = generatedBufferBatches.map(generatedBufferBatch =>
+    createExpandedPathVertexData(device, props, {
+      segmentTable,
+      shaderLayout,
+      generatedBufferBatch
+    })
+  );
+  const firstExpandedPathVertexState = expandedPathVertexStates[0];
+  if (!firstExpandedPathVertexState) {
+    throw new Error('ArrowPathModel requires at least one generated path render batch');
+  }
+  const renderBatches = generatedBufferBatches.map((generatedBufferBatch, batchIndex) => ({
+    rowStart: generatedBufferBatch.rowStart,
+    rowEnd: generatedBufferBatch.rowEnd,
+    segmentCount: generatedBufferBatch.recordCount,
+    expandedPathVertexData: expandedPathVertexStates[batchIndex]!.buffer
+  }));
+
+  return {
+    modelProps: {
+      ...props,
+      vs: props.vs ?? DEFAULT_ARROW_PATH_VS,
+      fs: props.fs ?? DEFAULT_ARROW_PATH_FS,
+      shaderLayout,
+      attributes: {
+        ...(props.attributes || {}),
+        [EXPANDED_PATH_VERTEX_DATA]: firstExpandedPathVertexState.buffer
+      },
+      bufferLayout: [...(props.bufferLayout || []), firstExpandedPathVertexState.bufferLayout],
+      topology: props.topology ?? 'line-list',
+      vertexCount: props.vertexCount ?? 2,
+      instanceCount: segmentTable.segmentLayout.segmentCount,
+      arrowTable: createArrowPathRenderTable(segmentTable.table, generatedBufferBatches),
+      arrowCount: 'none'
+    },
+    segmentTable,
+    expandedPathVertexData: firstExpandedPathVertexState.buffer,
+    renderBatches
+  };
+}
+
+function resolveArrowPathInputs(props: ArrowPathModelProps): ResolvedArrowPathInputs {
+  if (!props.sourceVectors) {
+    throw new Error('ArrowPathModel requires explicit sourceVectors for CPU segment expansion');
+  }
+  assertArrowPathVectorTypes(props);
+  assertArrowPathVectorRowAlignment(props);
+  assertArrowPathSourceVectorAlignment(props);
+  const columns: Record<string, arrow.Vector> = {};
+  if (props.sourceVectors.colors) {
+    columns['colors'] = props.sourceVectors.colors;
+  }
+  if (props.sourceVectors.widths) {
+    columns['widths'] = props.sourceVectors.widths;
+  }
+
+  return {
+    rowTable: new arrow.Table(columns),
+    paths: props.sourceVectors.paths
+  };
+}
+
+function assertArrowPathVectorTypes(props: ArrowPathModelProps): void {
+  assertArrowPathCoordinateType(props.paths.type, 'paths');
+  if (
+    props.colors &&
+    (!arrow.DataType.isFixedSizeList(props.colors.type) ||
+      props.colors.type.listSize !== 4 ||
+      !(props.colors.type.children[0]?.type instanceof arrow.Uint8))
+  ) {
+    throw new Error('ArrowPathModel colors must be GPUVector<FixedSizeList<Uint8>[4]>');
+  }
+  if (props.widths && !(props.widths.type instanceof arrow.Float32)) {
+    throw new Error('ArrowPathModel widths must be GPUVector<Float32>');
+  }
+}
+
+function assertArrowPathCoordinateType(type: arrow.DataType, name: string): void {
+  if (
+    !isVariableLengthAttributeArrowType(type) ||
+    !arrow.DataType.isFixedSizeList(type.children[0].type) ||
+    type.children[0].type.listSize < 2 ||
+    type.children[0].type.listSize > 4 ||
+    !(type.children[0].type.children[0]?.type instanceof arrow.Float32)
+  ) {
+    throw new Error(`ArrowPathModel ${name} must be GPUVector<List<FixedSizeList<Float32>[2..4]>>`);
+  }
+}
+
+function assertArrowPathVectorRowAlignment(props: ArrowPathModelProps): void {
+  const rowInputs = getArrowPathRowInputs(props);
+  const [referenceName, referenceVector] = rowInputs[0];
+  for (const [name, vector] of rowInputs.slice(1)) {
+    if (vector.length !== referenceVector.length) {
+      throw new Error(
+        `ArrowPathModel ${name} rows must match ${referenceName} rows (${vector.length} !== ${referenceVector.length})`
+      );
+    }
+    if (vector.data.length !== referenceVector.data.length) {
+      throw new Error(`ArrowPathModel ${name} batch count must match ${referenceName} batch count`);
+    }
+    for (let batchIndex = 0; batchIndex < vector.data.length; batchIndex++) {
+      if (vector.data[batchIndex].length !== referenceVector.data[batchIndex].length) {
+        throw new Error(
+          `ArrowPathModel ${name} batch ${batchIndex} rows must match ${referenceName}`
+        );
+      }
+    }
+  }
+}
+
+function assertArrowPathSourceVectorAlignment(props: ArrowPathModelProps): void {
+  const sourceInputs: Array<[string, GPUVector<any> | undefined, arrow.Vector | undefined]> = [
+    ['paths', props.paths, props.sourceVectors.paths],
+    ['colors', props.colors, props.sourceVectors.colors],
+    ['widths', props.widths, props.sourceVectors.widths]
+  ];
+
+  for (const [name, gpuVector, sourceVector] of sourceInputs) {
+    if (gpuVector && !sourceVector) {
+      throw new Error(`ArrowPathModel ${name} GPU rows require matching sourceVectors rows`);
+    }
+    if (!gpuVector && sourceVector) {
+      throw new Error(`ArrowPathModel sourceVectors.${name} requires matching GPU rows`);
+    }
+    if (!gpuVector || !sourceVector) {
+      continue;
+    }
+    assertSourceVectorMatchesGPUVector(name, gpuVector, sourceVector);
+  }
+}
+
+function getArrowPathRowInputs(props: ArrowPathModelProps): Array<[string, GPUVector<any>]> {
+  return [
+    ['paths', props.paths],
+    ['colors', props.colors],
+    ['widths', props.widths]
+  ].filter(([, vector]) => vector !== undefined) as Array<[string, GPUVector<any>]>;
+}
+
+function assertSourceVectorMatchesGPUVector(
+  vectorName: string,
+  gpuVector: GPUVector<any>,
+  sourceVector: arrow.Vector
+): void {
+  if (sourceVector.length !== gpuVector.length) {
+    throw new Error(
+      `ArrowPathModel sourceVectors.${vectorName} rows must match GPU rows (${sourceVector.length} !== ${gpuVector.length})`
+    );
+  }
+  if (sourceVector.data.length !== gpuVector.data.length) {
+    throw new Error(
+      `ArrowPathModel sourceVectors.${vectorName} batch count must match GPU batches`
+    );
+  }
+  for (let batchIndex = 0; batchIndex < sourceVector.data.length; batchIndex++) {
+    if (sourceVector.data[batchIndex].length !== gpuVector.data[batchIndex].length) {
+      throw new Error(
+        `ArrowPathModel sourceVectors.${vectorName} batch ${batchIndex} rows must match GPU rows`
+      );
+    }
+  }
+}
+
+function buildArrowPathSegmentLayout(
+  paths: arrow.Vector<ArrowPathCoordinateType>
+): ArrowPathSegmentLayout {
+  assertArrowPathCoordinateType(paths.type, 'sourceVectors.paths');
+  const pathComponentCount = getArrowPathCoordinateComponentCount(paths.type);
+  const startIndices: number[] = [0];
+  for (const data of paths.data) {
+    const valueOffsets = data.valueOffsets as Int32Array | undefined;
+    if (!valueOffsets) {
+      throw new Error('ArrowPathModel source path chunks require Arrow list offsets');
+    }
+    for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
+      const pathStart = valueOffsets[rowIndex] ?? 0;
+      const pathEnd = valueOffsets[rowIndex + 1] ?? pathStart;
+      const segmentCount = Math.max(0, pathEnd - pathStart - 1);
+      startIndices.push((startIndices[startIndices.length - 1] ?? 0) + segmentCount);
+    }
+  }
+
+  const segmentCount = startIndices[startIndices.length - 1] ?? 0;
+  const segmentStartPositions = new Float32Array(segmentCount * 4);
+  const segmentEndPositions = new Float32Array(segmentCount * 4);
+  const segmentPreviousPositions = new Float32Array(segmentCount * 4);
+  const segmentNextPositions = new Float32Array(segmentCount * 4);
+  const segmentFlags = new Uint32Array(segmentCount);
+  let globalSegmentIndex = 0;
+
+  for (const data of paths.data) {
+    const valueOffsets = data.valueOffsets as Int32Array | undefined;
+    if (!valueOffsets) {
+      throw new Error('ArrowPathModel source path chunks require Arrow list offsets');
+    }
+    const pathValues = getArrowVariableLengthAttributeDataBufferSource(
+      data as arrow.Data<ArrowPathCoordinateType>
+    ) as Float32Array;
+    const firstElementOffset = valueOffsets[0] ?? 0;
+
+    for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
+      const pathStart = (valueOffsets[rowIndex] ?? firstElementOffset) - firstElementOffset;
+      const pathEnd = (valueOffsets[rowIndex + 1] ?? pathStart) - firstElementOffset;
+      const pointCount = Math.max(0, pathEnd - pathStart);
+      const rowSegmentCount = Math.max(0, pointCount - 1);
+      const closedPath = isClosedArrowPath(pathValues, pathComponentCount, pathStart, pointCount);
+
+      for (let segmentOffset = 0; segmentOffset < rowSegmentCount; segmentOffset++) {
+        const segmentStartPointIndex = pathStart + segmentOffset;
+        const segmentEndPointIndex = segmentStartPointIndex + 1;
+        const previousPointIndex =
+          segmentOffset === 0
+            ? closedPath
+              ? pathEnd - 2
+              : segmentStartPointIndex
+            : segmentStartPointIndex - 1;
+        const nextPointIndex =
+          segmentOffset === rowSegmentCount - 1
+            ? closedPath
+              ? pathStart + 1
+              : segmentEndPointIndex
+            : segmentEndPointIndex + 1;
+        copyArrowPathPoint(
+          segmentStartPositions,
+          globalSegmentIndex,
+          pathValues,
+          segmentStartPointIndex,
+          pathComponentCount
+        );
+        copyArrowPathPoint(
+          segmentEndPositions,
+          globalSegmentIndex,
+          pathValues,
+          segmentEndPointIndex,
+          pathComponentCount
+        );
+        copyArrowPathPoint(
+          segmentPreviousPositions,
+          globalSegmentIndex,
+          pathValues,
+          previousPointIndex,
+          pathComponentCount
+        );
+        copyArrowPathPoint(
+          segmentNextPositions,
+          globalSegmentIndex,
+          pathValues,
+          nextPointIndex,
+          pathComponentCount
+        );
+
+        let pathSegmentFlags = closedPath ? PATH_SEGMENT_CLOSED : 0;
+        if (segmentOffset === 0) {
+          pathSegmentFlags |= PATH_SEGMENT_FIRST;
+        }
+        if (segmentOffset === rowSegmentCount - 1) {
+          pathSegmentFlags |= PATH_SEGMENT_LAST;
+        }
+        segmentFlags[globalSegmentIndex] = pathSegmentFlags;
+        globalSegmentIndex++;
+      }
+    }
+  }
+
+  return {
+    startIndices,
+    segmentCount,
+    segmentStartPositions,
+    segmentEndPositions,
+    segmentPreviousPositions,
+    segmentNextPositions,
+    segmentFlags
+  };
+}
+
+function getArrowPathCoordinateComponentCount(type: arrow.DataType): number {
+  const pathElementType = type.children[0]?.type;
+  if (!pathElementType || !arrow.DataType.isFixedSizeList(pathElementType)) {
+    throw new Error('ArrowPathModel paths require FixedSizeList coordinate elements');
+  }
+  return pathElementType.listSize;
+}
+
+function isClosedArrowPath(
+  values: Float32Array,
+  componentCount: number,
+  pointStart: number,
+  pointCount: number
+): boolean {
+  if (pointCount < 3) {
+    return false;
+  }
+  const firstPointOffset = pointStart * componentCount;
+  const lastPointOffset = (pointStart + pointCount - 1) * componentCount;
+  for (let componentIndex = 0; componentIndex < componentCount; componentIndex++) {
+    if (values[firstPointOffset + componentIndex] !== values[lastPointOffset + componentIndex]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function copyArrowPathPoint(
+  target: Float32Array,
+  targetSegmentIndex: number,
+  source: Float32Array,
+  sourcePointIndex: number,
+  componentCount: number
+): void {
+  const targetOffset = targetSegmentIndex * 4;
+  const sourceOffset = sourcePointIndex * componentCount;
+  for (let componentIndex = 0; componentIndex < componentCount; componentIndex++) {
+    target[targetOffset + componentIndex] = source[sourceOffset + componentIndex] ?? 0;
+  }
+}
+
+function createArrowPathRenderTable(
+  segmentTable: arrow.Table,
+  generatedBufferBatches?: GeneratedBufferBatch[]
+): arrow.Table {
+  const generatedColumnNames = new Set([
+    SEGMENT_START_POSITIONS_COLUMN,
+    SEGMENT_END_POSITIONS_COLUMN,
+    SEGMENT_PREVIOUS_POSITIONS_COLUMN,
+    SEGMENT_NEXT_POSITIONS_COLUMN,
+    SEGMENT_FLAGS_COLUMN,
+    ROW_INDICES_COLUMN
+  ]);
+  const fields: arrow.Field[] = [];
+  const columns: Record<string, arrow.Vector> = {};
+
+  for (const field of segmentTable.schema.fields) {
+    if (generatedColumnNames.has(field.name)) {
+      continue;
+    }
+    const vector = segmentTable.getChild(field.name);
+    if (!vector) {
+      continue;
+    }
+    fields.push(field);
+    columns[field.name] = vector;
+  }
+
+  const renderTable = new arrow.Table(
+    new arrow.Schema(fields, new Map(segmentTable.schema.metadata)),
+    columns
+  );
+  if (!generatedBufferBatches || generatedBufferBatches.length <= 1 || fields.length === 0) {
+    return renderTable;
+  }
+  const recordBatches = generatedBufferBatches.flatMap(
+    batch => renderTable.slice(batch.recordStart, batch.recordEnd).batches
+  );
+  return new arrow.Table(renderTable.schema, recordBatches);
+}
+
+function createExpandedPathVertexData(
+  device: Device,
+  props: ArrowPathModelProps,
+  {
+    segmentTable,
+    shaderLayout,
+    generatedBufferBatch
+  }: {
+    segmentTable: ArrowPathSegmentTable;
+    shaderLayout: ShaderLayout;
+    generatedBufferBatch: GeneratedBufferBatch;
+  }
+): {buffer: Buffer; bufferLayout: BufferLayout; byteLength: number} {
+  const {segmentLayout} = segmentTable;
+  const byteLength = generatedBufferBatch.byteLength;
+  const arrayBuffer = new ArrayBuffer(Math.max(byteLength, EXPANDED_PATH_VERTEX_BYTE_STRIDE));
+  const float32Values = new Float32Array(arrayBuffer);
+  const uint32Values = new Uint32Array(arrayBuffer);
+  const rowIndices = makeArrowPathRowIndices(segmentLayout.startIndices);
+
+  for (
+    let segmentIndex = generatedBufferBatch.recordStart;
+    segmentIndex < generatedBufferBatch.recordEnd;
+    segmentIndex++
+  ) {
+    const batchSegmentIndex = segmentIndex - generatedBufferBatch.recordStart;
+    const recordFloat32Index =
+      (batchSegmentIndex * EXPANDED_PATH_VERTEX_BYTE_STRIDE) / Float32Array.BYTES_PER_ELEMENT;
+    const recordUint32Index =
+      (batchSegmentIndex * EXPANDED_PATH_VERTEX_BYTE_STRIDE) / Uint32Array.BYTES_PER_ELEMENT;
+    const segmentPositionOffset = segmentIndex * 4;
+
+    float32Values.set(
+      segmentLayout.segmentStartPositions.subarray(
+        segmentPositionOffset,
+        segmentPositionOffset + 4
+      ),
+      recordFloat32Index
+    );
+    float32Values.set(
+      segmentLayout.segmentEndPositions.subarray(segmentPositionOffset, segmentPositionOffset + 4),
+      recordFloat32Index + 4
+    );
+    float32Values.set(
+      segmentLayout.segmentPreviousPositions.subarray(
+        segmentPositionOffset,
+        segmentPositionOffset + 4
+      ),
+      recordFloat32Index + 8
+    );
+    float32Values.set(
+      segmentLayout.segmentNextPositions.subarray(segmentPositionOffset, segmentPositionOffset + 4),
+      recordFloat32Index + 12
+    );
+    uint32Values[recordUint32Index + 16] = segmentLayout.segmentFlags[segmentIndex];
+    uint32Values[recordUint32Index + 17] = rowIndices[segmentIndex];
+  }
+
+  const shaderAttributeNames = new Set(shaderLayout.attributes.map(attribute => attribute.name));
+  const attributes: NonNullable<BufferLayout['attributes']> = [];
+  if (shaderAttributeNames.has(SEGMENT_START_POSITIONS_COLUMN)) {
+    attributes.push({
+      attribute: SEGMENT_START_POSITIONS_COLUMN,
+      format: 'float32x4',
+      byteOffset: 0
+    });
+  }
+  if (shaderAttributeNames.has(SEGMENT_END_POSITIONS_COLUMN)) {
+    attributes.push({
+      attribute: SEGMENT_END_POSITIONS_COLUMN,
+      format: 'float32x4',
+      byteOffset: SEGMENT_END_POSITIONS_BYTE_OFFSET
+    });
+  }
+  if (shaderAttributeNames.has(SEGMENT_PREVIOUS_POSITIONS_COLUMN)) {
+    attributes.push({
+      attribute: SEGMENT_PREVIOUS_POSITIONS_COLUMN,
+      format: 'float32x4',
+      byteOffset: SEGMENT_PREVIOUS_POSITIONS_BYTE_OFFSET
+    });
+  }
+  if (shaderAttributeNames.has(SEGMENT_NEXT_POSITIONS_COLUMN)) {
+    attributes.push({
+      attribute: SEGMENT_NEXT_POSITIONS_COLUMN,
+      format: 'float32x4',
+      byteOffset: SEGMENT_NEXT_POSITIONS_BYTE_OFFSET
+    });
+  }
+  if (shaderAttributeNames.has(SEGMENT_FLAGS_COLUMN)) {
+    attributes.push({
+      attribute: SEGMENT_FLAGS_COLUMN,
+      format: 'uint32',
+      byteOffset: SEGMENT_FLAGS_BYTE_OFFSET
+    });
+  }
+  if (shaderAttributeNames.has(ROW_INDICES_COLUMN)) {
+    attributes.push({
+      attribute: ROW_INDICES_COLUMN,
+      format: 'uint32',
+      byteOffset: ROW_INDICES_BYTE_OFFSET
+    });
+  }
+
+  return {
+    buffer: device.createBuffer({
+      id:
+        `${props.id || 'arrow-path-model'}-expanded-path-vertex-data-` +
+        `${generatedBufferBatch.rowStart}`,
+      usage: Buffer.VERTEX | Buffer.COPY_DST | Buffer.COPY_SRC,
+      data: new Uint8Array(arrayBuffer, 0, Math.max(byteLength, EXPANDED_PATH_VERTEX_BYTE_STRIDE))
+    }),
+    bufferLayout: {
+      name: EXPANDED_PATH_VERTEX_DATA,
+      byteStride: EXPANDED_PATH_VERTEX_BYTE_STRIDE,
+      stepMode: 'instance',
+      attributes
+    },
+    byteLength
+  };
+}
+
+function makeArrowPathRowIndices(startIndices: number[], rowIndexBase: number = 0): Uint32Array {
+  const segmentCount = startIndices[startIndices.length - 1] ?? 0;
+  const rowIndices = new Uint32Array(segmentCount);
+  for (let rowIndex = 0; rowIndex < startIndices.length - 1; rowIndex++) {
+    rowIndices.fill(rowIndexBase + rowIndex, startIndices[rowIndex], startIndices[rowIndex + 1]);
+  }
+  return rowIndices;
+}
+
+function assertArrowPathColumnAvailable(table: arrow.Table, columnName: string): void {
+  if (table.getChild(columnName)) {
+    throw new Error(`ArrowPathModel rowTable column "${columnName}" is reserved`);
+  }
+}
+
+function makeFixedSizeListFloatField(name: string, listSize: 4): arrow.Field {
+  return new arrow.Field(
+    name,
+    new arrow.FixedSizeList(listSize, new arrow.Field('value', new arrow.Float32(), false)),
+    false
+  );
+}
+
+function makeNumericArrowVector<TypeT extends NumericArrowType>(
+  type: TypeT,
+  data: TypeT['TArray']
+): arrow.Vector<TypeT> {
+  const makeNumericData = arrow.makeData as <NumericTypeT extends NumericArrowType>(props: {
+    type: NumericTypeT;
+    length: number;
+    data: NumericTypeT['TArray'];
+  }) => arrow.Data<NumericTypeT>;
+  return arrow.makeVector(
+    makeNumericData({
+      type,
+      length: data.length,
+      data
+    })
+  );
+}
+
+function getGeneratedAttributeByteLength(columns: Record<string, arrow.Vector>): number {
+  let attributeByteLength = 0;
+  for (const vector of Object.values(columns)) {
+    if (!isInstanceArrowType(vector.type)) {
+      continue;
+    }
+    attributeByteLength += getArrowVectorBufferSource(vector as arrow.Vector<any>).byteLength;
+  }
+  return attributeByteLength;
+}
+
+function destroyArrowPathRenderBatches(renderBatches: ArrowPathRenderBatchState[]): void {
+  const buffers = new Set(renderBatches.map(renderBatch => renderBatch.expandedPathVertexData));
+  for (const buffer of buffers) {
+    buffer.destroy();
+  }
+}
+
+function getNow(): number {
+  return typeof performance === 'undefined' ? Date.now() : performance.now();
+}

--- a/modules/arrow/src/arrow/arrow-storage-path-gpu-vectors.ts
+++ b/modules/arrow/src/arrow/arrow-storage-path-gpu-vectors.ts
@@ -1,0 +1,165 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {type Binding} from '@luma.gl/core';
+import * as arrow from 'apache-arrow';
+import type {GPUData} from './arrow-gpu-data';
+import {GPUVector} from './arrow-gpu-vector';
+import {isVariableLengthAttributeArrowType} from './arrow-types';
+import type {ArrowStoragePathInputProps} from './arrow-storage-path-model';
+
+type ArrowPathCoordinateType = arrow.List<arrow.FixedSizeList<arrow.Float32>>;
+
+export type ResolvedArrowStoragePathBatchInputs = {
+  batchRowIndexBase: number;
+  rowCount: number;
+  componentCount: number;
+  valueOffsets: Int32Array;
+  recordOffsets: number[];
+  segmentCount: number;
+  pathValuesBinding: Binding;
+  colorsBinding?: Binding;
+  widthsBinding?: Binding;
+};
+
+export type ResolvedArrowStoragePathInputs = {
+  batches: ResolvedArrowStoragePathBatchInputs[];
+};
+
+/** Prepare aligned path/style GPUVector batches for storage-backed path expansion. */
+export function resolveArrowStoragePathInputs(
+  props: ArrowStoragePathInputProps
+): ResolvedArrowStoragePathInputs {
+  assertArrowStoragePathVectorTypes(props);
+  assertArrowStoragePathVectorRowAlignment(props);
+  const batches: ResolvedArrowStoragePathBatchInputs[] = [];
+  const componentCount = getArrowStoragePathCoordinateComponentCount(props.paths.type);
+  let batchRowIndexBase = 0;
+
+  for (let batchIndex = 0; batchIndex < props.paths.data.length; batchIndex++) {
+    const pathData = props.paths.data[batchIndex] as GPUData<ArrowPathCoordinateType>;
+    const valueOffsets = getArrowStoragePathOffsets(pathData);
+    const recordOffsets = makeArrowStoragePathRecordOffsets(valueOffsets, pathData.length);
+    const segmentCount = recordOffsets[recordOffsets.length - 1] ?? 0;
+    const colorData = props.colors?.data[batchIndex];
+    const widthData = props.widths?.data[batchIndex];
+    batches.push({
+      batchRowIndexBase,
+      rowCount: pathData.length,
+      componentCount,
+      valueOffsets,
+      recordOffsets,
+      segmentCount,
+      pathValuesBinding: getStorageGPUDataBinding(
+        pathData,
+        pathData.readbackMetadata?.kind === 'variable-length-attribute'
+          ? pathData.readbackMetadata.valueByteLength
+          : undefined
+      ),
+      colorsBinding: colorData
+        ? getStorageGPUDataBinding(colorData, colorData.length * props.colors!.byteStride)
+        : undefined,
+      widthsBinding: widthData
+        ? getStorageGPUDataBinding(widthData, widthData.length * props.widths!.byteStride)
+        : undefined
+    });
+    batchRowIndexBase += pathData.length;
+  }
+
+  return {batches};
+}
+
+function assertArrowStoragePathVectorTypes(props: ArrowStoragePathInputProps): void {
+  assertArrowStoragePathCoordinateType(props.paths.type, 'paths');
+  if (
+    props.colors &&
+    (!arrow.DataType.isFixedSizeList(props.colors.type) ||
+      props.colors.type.listSize !== 4 ||
+      !(props.colors.type.children[0]?.type instanceof arrow.Uint8))
+  ) {
+    throw new Error('ArrowStoragePathModel colors must be GPUVector<FixedSizeList<Uint8>[4]>');
+  }
+  if (props.widths && !(props.widths.type instanceof arrow.Float32)) {
+    throw new Error('ArrowStoragePathModel widths must be GPUVector<Float32>');
+  }
+}
+
+function assertArrowStoragePathCoordinateType(type: arrow.DataType, name: string): void {
+  if (
+    !isVariableLengthAttributeArrowType(type) ||
+    !arrow.DataType.isFixedSizeList(type.children[0].type) ||
+    type.children[0].type.listSize < 2 ||
+    type.children[0].type.listSize > 4 ||
+    !(type.children[0].type.children[0]?.type instanceof arrow.Float32)
+  ) {
+    throw new Error(
+      `ArrowStoragePathModel ${name} must be GPUVector<List<FixedSizeList<Float32>[2..4]>>`
+    );
+  }
+}
+
+function assertArrowStoragePathVectorRowAlignment(props: ArrowStoragePathInputProps): void {
+  const rowInputs = [
+    ['paths', props.paths],
+    ['colors', props.colors],
+    ['widths', props.widths]
+  ].filter(([, vector]) => vector !== undefined) as Array<[string, GPUVector<any>]>;
+  const [referenceName, referenceVector] = rowInputs[0];
+  for (const [name, vector] of rowInputs.slice(1)) {
+    if (vector.length !== referenceVector.length) {
+      throw new Error(
+        `ArrowStoragePathModel ${name} rows must match ${referenceName} rows (${vector.length} !== ${referenceVector.length})`
+      );
+    }
+    if (vector.data.length !== referenceVector.data.length) {
+      throw new Error(
+        `ArrowStoragePathModel ${name} batch count must match ${referenceName} batch count`
+      );
+    }
+    for (let batchIndex = 0; batchIndex < vector.data.length; batchIndex++) {
+      if (vector.data[batchIndex].length !== referenceVector.data[batchIndex].length) {
+        throw new Error(
+          `ArrowStoragePathModel ${name} batch ${batchIndex} rows must match ${referenceName}`
+        );
+      }
+    }
+  }
+}
+
+function getArrowStoragePathOffsets(data: GPUData<ArrowPathCoordinateType>): Int32Array {
+  const metadata = data.readbackMetadata;
+  if (metadata?.kind !== 'variable-length-attribute') {
+    throw new Error(
+      'ArrowStoragePathModel paths require copied variable-length Arrow offset metadata'
+    );
+  }
+  return metadata.valueOffsets;
+}
+
+function makeArrowStoragePathRecordOffsets(valueOffsets: Int32Array, rowCount: number): number[] {
+  const recordOffsets: number[] = [0];
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+    const pathStart = valueOffsets[rowIndex] ?? 0;
+    const pathEnd = valueOffsets[rowIndex + 1] ?? pathStart;
+    const segmentCount = Math.max(0, pathEnd - pathStart - 1);
+    recordOffsets.push((recordOffsets[recordOffsets.length - 1] ?? 0) + segmentCount);
+  }
+  return recordOffsets;
+}
+
+function getArrowStoragePathCoordinateComponentCount(type: arrow.DataType): number {
+  const pathElementType = type.children[0]?.type;
+  if (!pathElementType || !arrow.DataType.isFixedSizeList(pathElementType)) {
+    throw new Error('ArrowStoragePathModel paths require FixedSizeList coordinate elements');
+  }
+  return pathElementType.listSize;
+}
+
+function getStorageGPUDataBinding(data: GPUData<any>, size?: number): Binding {
+  return {
+    buffer: data.buffer.buffer,
+    offset: data.byteOffset,
+    ...(size && size > 0 ? {size} : {})
+  };
+}

--- a/modules/arrow/src/arrow/arrow-storage-path-model.ts
+++ b/modules/arrow/src/arrow/arrow-storage-path-model.ts
@@ -1,0 +1,751 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  Buffer,
+  type Binding,
+  type BufferLayout,
+  type Device,
+  type RenderPass,
+  type ShaderLayout
+} from '@luma.gl/core';
+import {DynamicBuffer, Model} from '@luma.gl/engine';
+import * as arrow from 'apache-arrow';
+import type {ArrowModelProps} from './arrow-model';
+import {GPUVector} from './arrow-gpu-vector';
+import {makeArrowFixedSizeListVector} from './arrow-fixed-size-list';
+import {planGeneratedBufferBatches} from './generated-buffer-batches';
+import {
+  createGpuPathExpansionInput,
+  createGpuPathGeneratedState,
+  dispatchGpuPathExpansionCompute
+} from './gpu-path-expansion';
+import {
+  resolveArrowStoragePathInputs,
+  type ResolvedArrowStoragePathBatchInputs
+} from './arrow-storage-path-gpu-vectors';
+
+const SEGMENT_START_POINT_INDICES_COLUMN = 'segmentStartPointIndices';
+const SEGMENT_END_POINT_INDICES_COLUMN = 'segmentEndPointIndices';
+const SEGMENT_PREVIOUS_POINT_INDICES_COLUMN = 'segmentPreviousPointIndices';
+const SEGMENT_NEXT_POINT_INDICES_COLUMN = 'segmentNextPointIndices';
+const SEGMENT_FLAGS_COLUMN = 'segmentFlags';
+const ROW_INDICES_COLUMN = 'rowIndices';
+const COMPACT_PATH_VERTEX_DATA = 'compactPathVertexData';
+
+const INDEXED_PATH_VERTEX_BYTE_STRIDE = Uint32Array.BYTES_PER_ELEMENT * 6;
+const SEGMENT_END_POINT_INDICES_BYTE_OFFSET = Uint32Array.BYTES_PER_ELEMENT;
+const SEGMENT_PREVIOUS_POINT_INDICES_BYTE_OFFSET = Uint32Array.BYTES_PER_ELEMENT * 2;
+const SEGMENT_NEXT_POINT_INDICES_BYTE_OFFSET = Uint32Array.BYTES_PER_ELEMENT * 3;
+const SEGMENT_FLAGS_BYTE_OFFSET = Uint32Array.BYTES_PER_ELEMENT * 4;
+const ROW_INDICES_BYTE_OFFSET = Uint32Array.BYTES_PER_ELEMENT * 5;
+
+const DEFAULT_STORAGE_PATH_COLOR: [number, number, number, number] = [255, 255, 255, 255];
+const DEFAULT_STORAGE_PATH_WIDTH = 1;
+
+type ArrowPathCoordinateType = arrow.List<arrow.FixedSizeList<arrow.Float32>>;
+type ArrowPathColorType = arrow.FixedSizeList<arrow.Uint8>;
+type StoragePathOwnedResource = Pick<GPUVector, 'destroy'> | Pick<DynamicBuffer, 'destroy'>;
+
+const DEFAULT_STORAGE_ARROW_PATH_SHADER_LAYOUT: ShaderLayout = {
+  attributes: [
+    {name: SEGMENT_START_POINT_INDICES_COLUMN, location: 0, type: 'u32', stepMode: 'instance'},
+    {name: SEGMENT_END_POINT_INDICES_COLUMN, location: 1, type: 'u32', stepMode: 'instance'},
+    {name: ROW_INDICES_COLUMN, location: 2, type: 'u32', stepMode: 'instance'}
+  ],
+  bindings: []
+};
+
+const DEFAULT_STORAGE_ARROW_PATH_SOURCE = /* wgsl */ `
+@group(0) @binding(auto) var<storage, read> pathValues : array<f32>;
+@group(0) @binding(auto) var<storage, read> pathRowColors : array<u32>;
+@group(0) @binding(auto) var<storage, read> pathRowWidths : array<f32>;
+
+struct PathStorageStyleConfig {
+  constantColor : vec4<f32>,
+  constantWidth : f32,
+  useRowColors : u32,
+  useRowWidths : u32,
+  batchRowIndexBase : u32,
+  pathComponentCount : u32,
+  _padding0 : u32,
+  _padding1 : u32,
+  _padding2 : u32,
+};
+
+@group(0) @binding(auto) var<uniform> pathStorageStyleConfig : PathStorageStyleConfig;
+
+struct VertexInputs {
+  @builtin(vertex_index) vertexIndex : u32,
+  @location(0) segmentStartPointIndices : u32,
+  @location(1) segmentEndPointIndices : u32,
+  @location(2) rowIndices : u32,
+};
+
+struct FragmentInputs {
+  @builtin(position) position : vec4<f32>,
+  @location(0) color : vec4<f32>,
+};
+
+fn unpackPathColor(colorWord: u32) -> vec4<f32> {
+  return vec4<f32>(
+    f32(colorWord & 0xffu),
+    f32((colorWord >> 8u) & 0xffu),
+    f32((colorWord >> 16u) & 0xffu),
+    f32((colorWord >> 24u) & 0xffu)
+  ) / 255.0;
+}
+
+fn readPathComponent(pointIndex: u32, componentIndex: u32) -> f32 {
+  if (componentIndex >= pathStorageStyleConfig.pathComponentCount) {
+    return 0.0;
+  }
+  return pathValues[pointIndex * pathStorageStyleConfig.pathComponentCount + componentIndex];
+}
+
+fn readPathPoint(pointIndex: u32) -> vec4<f32> {
+  return vec4<f32>(
+    readPathComponent(pointIndex, 0u),
+    readPathComponent(pointIndex, 1u),
+    readPathComponent(pointIndex, 2u),
+    readPathComponent(pointIndex, 3u)
+  );
+}
+
+@vertex
+fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
+  let rowIndex = inputs.rowIndices - pathStorageStyleConfig.batchRowIndexBase;
+  let pathWidth = select(
+    pathStorageStyleConfig.constantWidth,
+    pathRowWidths[rowIndex],
+    pathStorageStyleConfig.useRowWidths != 0u
+  );
+  let pathPosition = select(
+    readPathPoint(inputs.segmentStartPointIndices),
+    readPathPoint(inputs.segmentEndPointIndices),
+    (inputs.vertexIndex & 1u) == 1u
+  );
+  var outputs : FragmentInputs;
+  outputs.position = vec4<f32>(
+    pathPosition.xyz + vec3<f32>(0.0, 0.0, pathWidth * 0.0),
+    1.0
+  );
+  outputs.color = pathStorageStyleConfig.constantColor;
+  if (pathStorageStyleConfig.useRowColors != 0u) {
+    outputs.color = unpackPathColor(pathRowColors[rowIndex]);
+  }
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
+  return inputs.color;
+}
+`;
+
+/** GPU vectors used by the storage-backed path model. */
+export type ArrowStoragePathInputProps = Omit<
+  ArrowModelProps,
+  'arrowTable' | 'arrowGPUTable' | 'arrowCount'
+> & {
+  /** Variable-length Float32 XY, XYZ, or XYZM path coordinates, one Arrow row per path. */
+  paths: GPUVector<ArrowPathCoordinateType>;
+  /** Optional packed RGBA8 path colors, one Arrow row per path. */
+  colors?: GPUVector<ArrowPathColorType>;
+  /** Optional per-path widths, one Arrow row per path. */
+  widths?: GPUVector<arrow.Float32>;
+  /** Constant fallback path color used when `colors` is absent. */
+  color?: [number, number, number, number];
+  /** Constant fallback path width used when `widths` is absent. */
+  width?: number;
+};
+
+type ArrowStoragePathRenderProps = Omit<
+  ArrowStoragePathInputProps,
+  'paths' | 'colors' | 'widths' | 'color' | 'width'
+>;
+
+export type ArrowStoragePathBatchState = {
+  batchRowIndexBase: number;
+  rowCount: number;
+  segmentCount: number;
+  pathValuesBinding: Binding;
+  rowColorsBinding: Binding;
+  rowWidthsBinding: Binding;
+  styleConfigBuffer: DynamicBuffer;
+};
+
+export type ArrowStoragePathRenderBatchState = {
+  rowBindingBatchIndex: number;
+  rowStart: number;
+  rowEnd: number;
+  segmentCount: number;
+  compactPathVertexData: Buffer;
+};
+
+export type ArrowStoragePathState = {
+  segmentCount: number;
+  pathRangeBuildTimeMs: number;
+  compactPathVertexByteLength: number;
+  generatedRenderBufferByteLength: number;
+  rowStorageByteLength: number;
+  transientComputeInputByteLength: number;
+  batches: ArrowStoragePathBatchState[];
+  renderBatches: ArrowStoragePathRenderBatchState[];
+  ownedRowBindingResources: StoragePathOwnedResource[];
+  rowColorsBinding: Binding;
+  rowWidthsBinding: Binding;
+  styleConfigBuffer: DynamicBuffer;
+  compactPathVertexData: Buffer;
+  destroy: () => void;
+};
+
+export type ArrowStoragePathModelProps =
+  | (ArrowStoragePathInputProps & {storageState?: never})
+  | (ArrowStoragePathRenderProps & {storageState: ArrowStoragePathState});
+
+type StoragePathDefaultBindings = {
+  colorsBinding: Binding;
+  widthsBinding: Binding;
+  byteLength: number;
+  ownedResources: StoragePathOwnedResource[];
+};
+
+type StoragePathBatchRowState = {
+  rowColorsBinding: Binding;
+  rowWidthsBinding: Binding;
+  styleConfigBuffer: DynamicBuffer;
+  ownedResources: StoragePathOwnedResource[];
+  ownedByteLength: number;
+};
+
+/**
+ * WebGPU-only path model that expands nested Arrow path rows through compute,
+ * while keeping per-row style values as storage-buffer reads during rendering.
+ */
+export class ArrowStoragePathModel extends Model {
+  segmentCount!: number;
+  pathRangeBuildTimeMs!: number;
+  compactPathVertexByteLength!: number;
+  generatedRenderBufferByteLength!: number;
+  rowStorageByteLength!: number;
+  transientComputeInputByteLength!: number;
+  batches!: ArrowStoragePathBatchState[];
+  renderBatches!: ArrowStoragePathRenderBatchState[];
+  rowColorsBinding!: Binding;
+  rowWidthsBinding!: Binding;
+  styleConfigBuffer!: DynamicBuffer;
+  compactPathVertexData!: Buffer;
+  storageState: ArrowStoragePathState;
+  private pathProps: ArrowStoragePathModelProps;
+  private ownsStorageState: boolean;
+
+  constructor(device: Device, props: ArrowStoragePathModelProps) {
+    if (device.type !== 'webgpu') {
+      throw new Error('ArrowStoragePathModel is WebGPU-only');
+    }
+    const ownsStorageState = !hasArrowStoragePathState(props);
+    const storageState = ownsStorageState
+      ? createArrowStoragePathState(device, props)
+      : props.storageState;
+    super(device, createArrowStoragePathModelProps(props, storageState));
+    this.pathProps = props;
+    this.storageState = storageState;
+    this.ownsStorageState = ownsStorageState;
+    this.applyStorageState(storageState);
+  }
+
+  setProps(props: Partial<ArrowStoragePathModelProps>): void {
+    const nextProps = {...this.pathProps, ...props} as ArrowStoragePathModelProps;
+    const nextUsesExternalState = hasArrowStoragePathState(nextProps);
+    const pathProps = props as Partial<ArrowStoragePathInputProps>;
+    const shouldReplaceExternalState = 'storageState' in props && props.storageState !== undefined;
+    const shouldReplaceState = shouldReplaceExternalState || pathProps.paths !== undefined;
+    const shouldRefreshRowBindings =
+      !nextUsesExternalState &&
+      (pathProps.colors !== undefined ||
+        pathProps.widths !== undefined ||
+        pathProps.color !== undefined ||
+        pathProps.width !== undefined);
+
+    this.pathProps = nextProps;
+    if (!shouldReplaceState) {
+      if (shouldRefreshRowBindings) {
+        refreshArrowStoragePathRowBindings(this.device, nextProps, this.storageState);
+        this.applyStorageState(this.storageState);
+        const firstBatch = getFirstArrowStoragePathBatch(this.storageState);
+        this.setBindings(createArrowStoragePathBindings(nextProps, firstBatch));
+        this.setNeedsRedraw('Arrow storage path row bindings updated');
+      }
+      return;
+    }
+
+    const nextStorageState = nextUsesExternalState
+      ? nextProps.storageState
+      : createArrowStoragePathState(this.device, nextProps);
+    if (this.ownsStorageState) {
+      this.storageState.destroy();
+    }
+    this.storageState = nextStorageState;
+    this.ownsStorageState = !nextUsesExternalState;
+    this.applyStorageState(nextStorageState);
+    const firstBatch = getFirstArrowStoragePathBatch(nextStorageState);
+    const firstRenderBatch = getFirstArrowStoragePathRenderBatch(nextStorageState);
+    this.setAttributes({
+      [COMPACT_PATH_VERTEX_DATA]: firstRenderBatch.compactPathVertexData
+    });
+    this.setBindings(createArrowStoragePathBindings(nextProps, firstBatch));
+    this.setInstanceCount(firstRenderBatch.segmentCount);
+    this.setNeedsRedraw('Arrow storage path state updated');
+  }
+
+  override draw(renderPass: RenderPass): boolean {
+    let drawSuccess = true;
+    for (const renderBatch of this.storageState.renderBatches) {
+      const batch = this.storageState.batches[renderBatch.rowBindingBatchIndex];
+      if (!batch) {
+        throw new Error('ArrowStoragePathModel render batch is missing its row-binding batch');
+      }
+      this.setAttributes({
+        [COMPACT_PATH_VERTEX_DATA]: renderBatch.compactPathVertexData
+      });
+      this.setBindings(createArrowStoragePathBindings(this.pathProps, batch));
+      this.setInstanceCount(renderBatch.segmentCount);
+      drawSuccess = super.draw(renderPass) && drawSuccess;
+    }
+    const firstBatch = getFirstArrowStoragePathBatch(this.storageState);
+    const firstRenderBatch = getFirstArrowStoragePathRenderBatch(this.storageState);
+    this.setAttributes({
+      [COMPACT_PATH_VERTEX_DATA]: firstRenderBatch.compactPathVertexData
+    });
+    this.setBindings(createArrowStoragePathBindings(this.pathProps, firstBatch));
+    this.setInstanceCount(this.storageState.segmentCount);
+    return drawSuccess;
+  }
+
+  override destroy(): void {
+    if (this.ownsStorageState) {
+      this.storageState.destroy();
+    }
+    super.destroy();
+  }
+
+  private applyStorageState(storageState: ArrowStoragePathState): void {
+    this.segmentCount = storageState.segmentCount;
+    this.pathRangeBuildTimeMs = storageState.pathRangeBuildTimeMs;
+    this.compactPathVertexByteLength = storageState.compactPathVertexByteLength;
+    this.generatedRenderBufferByteLength = storageState.generatedRenderBufferByteLength;
+    this.rowStorageByteLength = storageState.rowStorageByteLength;
+    this.transientComputeInputByteLength = storageState.transientComputeInputByteLength;
+    this.batches = storageState.batches;
+    this.renderBatches = storageState.renderBatches;
+    this.rowColorsBinding = storageState.rowColorsBinding;
+    this.rowWidthsBinding = storageState.rowWidthsBinding;
+    this.styleConfigBuffer = storageState.styleConfigBuffer;
+    this.compactPathVertexData = storageState.compactPathVertexData;
+  }
+}
+
+export function createArrowStoragePathState(
+  device: Device,
+  props: ArrowStoragePathInputProps
+): ArrowStoragePathState {
+  if (device.type !== 'webgpu') {
+    throw new Error('createArrowStoragePathState requires a WebGPU device');
+  }
+  const pathRangeBuildStartTime = getNow();
+  const pathInputs = resolveArrowStoragePathInputs(props);
+  const defaultBindings = createStoragePathDefaultBindings(device, props);
+  const ownedRowBindingResources: StoragePathOwnedResource[] = [...defaultBindings.ownedResources];
+  const batches: ArrowStoragePathBatchState[] = [];
+  const renderBatches: ArrowStoragePathRenderBatchState[] = [];
+  let segmentCount = 0;
+  let generatedRenderBufferByteLength = 0;
+  let rowStorageByteLength = defaultBindings.byteLength;
+  let transientComputeInputByteLength = 0;
+
+  for (const [rowBindingBatchIndex, batchInput] of pathInputs.batches.entries()) {
+    const rowState = createStoragePathBatchRowState(device, props, batchInput, defaultBindings);
+    const generatedBufferBatches = planGeneratedBufferBatches({
+      device,
+      recordOffsets: batchInput.recordOffsets,
+      recordByteStride: INDEXED_PATH_VERTEX_BYTE_STRIDE,
+      maxBatchByteLength: device.limits.maxStorageBufferBindingSize,
+      resourceLabel: 'ArrowStoragePathModel indexed generated path vertex data'
+    });
+
+    for (const generatedBufferBatch of generatedBufferBatches) {
+      const expansionInput = createGpuPathExpansionInput(
+        device,
+        {id: props.id},
+        {
+          valueOffsets: batchInput.valueOffsets,
+          recordOffsets: batchInput.recordOffsets,
+          generatedBufferBatch,
+          batchRowIndexBase: batchInput.batchRowIndexBase,
+          componentCount: batchInput.componentCount
+        }
+      );
+      const generated = createGpuPathGeneratedState(
+        device,
+        {id: props.id},
+        generatedBufferBatch.recordCount
+      );
+      dispatchGpuPathExpansionCompute(
+        device,
+        {id: props.id},
+        {
+          pathValues: batchInput.pathValuesBinding,
+          expansionInput,
+          generated,
+          rowCount: generatedBufferBatch.rowEnd - generatedBufferBatch.rowStart,
+          segmentCount: generatedBufferBatch.recordCount
+        }
+      );
+      renderBatches.push({
+        rowBindingBatchIndex,
+        rowStart: generatedBufferBatch.rowStart,
+        rowEnd: generatedBufferBatch.rowEnd,
+        segmentCount: generatedBufferBatch.recordCount,
+        compactPathVertexData: generated.compactPathVertexData
+      });
+      generatedRenderBufferByteLength += generated.byteLength;
+      transientComputeInputByteLength += expansionInput.byteLength;
+      expansionInput.pathRangesBuffer.destroy();
+      expansionInput.expansionConfigBuffer.destroy();
+    }
+
+    batches.push({
+      ...rowState,
+      batchRowIndexBase: batchInput.batchRowIndexBase,
+      rowCount: batchInput.rowCount,
+      segmentCount: batchInput.segmentCount,
+      pathValuesBinding: batchInput.pathValuesBinding
+    });
+    ownedRowBindingResources.push(...rowState.ownedResources);
+    rowStorageByteLength += rowState.ownedByteLength;
+    segmentCount += batchInput.segmentCount;
+  }
+
+  const firstBatch = getFirstArrowStoragePathBatch({batches});
+  const firstRenderBatch = getFirstArrowStoragePathRenderBatch({renderBatches});
+  let destroyed = false;
+  return {
+    segmentCount,
+    pathRangeBuildTimeMs: getNow() - pathRangeBuildStartTime,
+    compactPathVertexByteLength: generatedRenderBufferByteLength,
+    generatedRenderBufferByteLength,
+    rowStorageByteLength,
+    transientComputeInputByteLength,
+    batches,
+    renderBatches,
+    ownedRowBindingResources,
+    rowColorsBinding: firstBatch.rowColorsBinding,
+    rowWidthsBinding: firstBatch.rowWidthsBinding,
+    styleConfigBuffer: firstBatch.styleConfigBuffer,
+    compactPathVertexData: firstRenderBatch.compactPathVertexData,
+    destroy: () => {
+      if (destroyed) {
+        return;
+      }
+      destroyed = true;
+      destroyStoragePathResources(ownedRowBindingResources);
+      for (const renderBatch of renderBatches) {
+        renderBatch.compactPathVertexData.destroy();
+      }
+    }
+  };
+}
+
+function createArrowStoragePathModelProps(
+  props: ArrowStoragePathModelProps,
+  storageState: ArrowStoragePathState
+): ArrowModelProps {
+  const shaderLayout = props.shaderLayout ?? DEFAULT_STORAGE_ARROW_PATH_SHADER_LAYOUT;
+  const firstBatch = getFirstArrowStoragePathBatch(storageState);
+  const firstRenderBatch = getFirstArrowStoragePathRenderBatch(storageState);
+  return {
+    ...props,
+    source: props.source ?? DEFAULT_STORAGE_ARROW_PATH_SOURCE,
+    shaderLayout,
+    bindings: createArrowStoragePathBindings(props, firstBatch),
+    attributes: {
+      ...(props.attributes || {}),
+      [COMPACT_PATH_VERTEX_DATA]: firstRenderBatch.compactPathVertexData
+    },
+    bufferLayout: [...(props.bufferLayout || []), createCompactPathBufferLayout(shaderLayout)],
+    topology: props.topology ?? 'line-list',
+    vertexCount: props.vertexCount ?? 2,
+    instanceCount: firstRenderBatch.segmentCount
+  };
+}
+
+function createArrowStoragePathBindings(
+  props: ArrowStoragePathModelProps,
+  batch: ArrowStoragePathBatchState
+): NonNullable<ArrowModelProps['bindings']> {
+  return {
+    ...(props.bindings || {}),
+    pathValues: batch.pathValuesBinding,
+    pathRowColors: batch.rowColorsBinding,
+    pathRowWidths: batch.rowWidthsBinding,
+    pathStorageStyleConfig: batch.styleConfigBuffer
+  };
+}
+
+function createCompactPathBufferLayout(shaderLayout: ShaderLayout): BufferLayout {
+  const shaderAttributeNames = new Set(shaderLayout.attributes.map(attribute => attribute.name));
+  const attributes: NonNullable<BufferLayout['attributes']> = [];
+  if (shaderAttributeNames.has(SEGMENT_START_POINT_INDICES_COLUMN)) {
+    attributes.push({
+      attribute: SEGMENT_START_POINT_INDICES_COLUMN,
+      format: 'uint32',
+      byteOffset: 0
+    });
+  }
+  if (shaderAttributeNames.has(SEGMENT_END_POINT_INDICES_COLUMN)) {
+    attributes.push({
+      attribute: SEGMENT_END_POINT_INDICES_COLUMN,
+      format: 'uint32',
+      byteOffset: SEGMENT_END_POINT_INDICES_BYTE_OFFSET
+    });
+  }
+  if (shaderAttributeNames.has(SEGMENT_PREVIOUS_POINT_INDICES_COLUMN)) {
+    attributes.push({
+      attribute: SEGMENT_PREVIOUS_POINT_INDICES_COLUMN,
+      format: 'uint32',
+      byteOffset: SEGMENT_PREVIOUS_POINT_INDICES_BYTE_OFFSET
+    });
+  }
+  if (shaderAttributeNames.has(SEGMENT_NEXT_POINT_INDICES_COLUMN)) {
+    attributes.push({
+      attribute: SEGMENT_NEXT_POINT_INDICES_COLUMN,
+      format: 'uint32',
+      byteOffset: SEGMENT_NEXT_POINT_INDICES_BYTE_OFFSET
+    });
+  }
+  if (shaderAttributeNames.has(SEGMENT_FLAGS_COLUMN)) {
+    attributes.push({
+      attribute: SEGMENT_FLAGS_COLUMN,
+      format: 'uint32',
+      byteOffset: SEGMENT_FLAGS_BYTE_OFFSET
+    });
+  }
+  if (shaderAttributeNames.has(ROW_INDICES_COLUMN)) {
+    attributes.push({
+      attribute: ROW_INDICES_COLUMN,
+      format: 'uint32',
+      byteOffset: ROW_INDICES_BYTE_OFFSET
+    });
+  }
+  return {
+    name: COMPACT_PATH_VERTEX_DATA,
+    stepMode: 'instance',
+    byteStride: INDEXED_PATH_VERTEX_BYTE_STRIDE,
+    attributes
+  };
+}
+
+function createStoragePathDefaultBindings(
+  device: Device,
+  props: ArrowStoragePathInputProps
+): StoragePathDefaultBindings {
+  const id = props.id || 'arrow-storage-path-model';
+  const colorsVector = createStoragePathOwnedGpuVector(
+    device,
+    `${id}-default-row-colors`,
+    makeArrowFixedSizeListVector(
+      new arrow.Uint8(),
+      4,
+      new Uint8Array(props.color ?? DEFAULT_STORAGE_PATH_COLOR)
+    )
+  );
+  const widthsVector = createStoragePathOwnedGpuVector(
+    device,
+    `${id}-default-row-widths`,
+    arrow.vectorFromArray([props.width ?? DEFAULT_STORAGE_PATH_WIDTH], new arrow.Float32())
+  );
+  return {
+    colorsBinding: getStoragePathGpuVectorBinding(colorsVector),
+    widthsBinding: getStoragePathGpuVectorBinding(widthsVector),
+    byteLength: Uint8Array.BYTES_PER_ELEMENT * 4 + Float32Array.BYTES_PER_ELEMENT,
+    ownedResources: [colorsVector, widthsVector]
+  };
+}
+
+function createStoragePathBatchRowState(
+  device: Device,
+  props: ArrowStoragePathInputProps,
+  batchInput: ResolvedArrowStoragePathBatchInputs,
+  defaultBindings: StoragePathDefaultBindings
+): StoragePathBatchRowState {
+  const styleConfigData = createStoragePathStyleConfigData(
+    props,
+    batchInput.batchRowIndexBase,
+    batchInput.componentCount
+  );
+  const styleConfigBuffer = new DynamicBuffer(device, {
+    id: `${props.id || 'arrow-storage-path-model'}-style-config-${batchInput.batchRowIndexBase}`,
+    usage: Buffer.UNIFORM | Buffer.COPY_DST | Buffer.COPY_SRC,
+    data: styleConfigData
+  });
+  return {
+    rowColorsBinding: batchInput.colorsBinding ?? defaultBindings.colorsBinding,
+    rowWidthsBinding: batchInput.widthsBinding ?? defaultBindings.widthsBinding,
+    styleConfigBuffer,
+    ownedResources: [styleConfigBuffer],
+    ownedByteLength: styleConfigData.byteLength
+  };
+}
+
+function createStoragePathOwnedGpuVector<T extends arrow.DataType>(
+  device: Device,
+  name: string,
+  vector: arrow.Vector<T>
+): GPUVector<T> {
+  return new GPUVector({
+    type: 'arrow',
+    name,
+    device,
+    vector,
+    bufferProps: {
+      id: name,
+      usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+    }
+  });
+}
+
+function getStoragePathGpuVectorBinding(vector: GPUVector): Binding {
+  const buffer = vector.buffer;
+  return buffer instanceof DynamicBuffer ? buffer.buffer : buffer;
+}
+
+function createStoragePathStyleConfigData(
+  props: ArrowStoragePathInputProps,
+  batchRowIndexBase: number,
+  pathComponentCount: number
+): Uint32Array {
+  const arrayBuffer = new ArrayBuffer(48);
+  const floatValues = new Float32Array(arrayBuffer);
+  const uintValues = new Uint32Array(arrayBuffer);
+  const color = props.color ?? DEFAULT_STORAGE_PATH_COLOR;
+  floatValues[0] = color[0] / 255;
+  floatValues[1] = color[1] / 255;
+  floatValues[2] = color[2] / 255;
+  floatValues[3] = color[3] / 255;
+  floatValues[4] = props.width ?? DEFAULT_STORAGE_PATH_WIDTH;
+  uintValues[5] = props.colors ? 1 : 0;
+  uintValues[6] = props.widths ? 1 : 0;
+  uintValues[7] = batchRowIndexBase;
+  uintValues[8] = pathComponentCount;
+  return uintValues;
+}
+
+function refreshArrowStoragePathRowBindings(
+  device: Device,
+  props: ArrowStoragePathInputProps,
+  storageState: ArrowStoragePathState
+): void {
+  const pathInputs = resolveArrowStoragePathInputs(props);
+  assertStoragePathRowBindingRefreshCompatible(storageState, pathInputs.batches);
+  const nextOwnedRowBindingResources: StoragePathOwnedResource[] = [];
+  const defaultBindings = createStoragePathDefaultBindings(device, props);
+  nextOwnedRowBindingResources.push(...defaultBindings.ownedResources);
+  let rowStorageByteLength = defaultBindings.byteLength;
+
+  const nextBatches = pathInputs.batches.map((batchInput, batchIndex) => {
+    const previousBatch = storageState.batches[batchIndex];
+    const rowState = createStoragePathBatchRowState(device, props, batchInput, defaultBindings);
+    nextOwnedRowBindingResources.push(...rowState.ownedResources);
+    rowStorageByteLength += rowState.ownedByteLength;
+    return {
+      ...rowState,
+      batchRowIndexBase: previousBatch.batchRowIndexBase,
+      rowCount: previousBatch.rowCount,
+      segmentCount: previousBatch.segmentCount,
+      pathValuesBinding: previousBatch.pathValuesBinding
+    };
+  });
+
+  replaceOwnedStoragePathResources(
+    storageState.ownedRowBindingResources,
+    nextOwnedRowBindingResources
+  );
+  storageState.batches = nextBatches;
+  storageState.rowStorageByteLength = rowStorageByteLength;
+  syncArrowStoragePathStateFirstBatch(storageState);
+}
+
+function assertStoragePathRowBindingRefreshCompatible(
+  storageState: ArrowStoragePathState,
+  batches: ResolvedArrowStoragePathBatchInputs[]
+): void {
+  if (batches.length !== storageState.batches.length) {
+    throw new Error('ArrowStoragePathModel row-binding updates must preserve path batch count');
+  }
+  for (const [batchIndex, batchInput] of batches.entries()) {
+    const existingBatch = storageState.batches[batchIndex];
+    if (
+      !existingBatch ||
+      existingBatch.batchRowIndexBase !== batchInput.batchRowIndexBase ||
+      existingBatch.rowCount !== batchInput.rowCount ||
+      existingBatch.segmentCount !== batchInput.segmentCount
+    ) {
+      throw new Error('ArrowStoragePathModel row-binding updates must preserve path batch rows');
+    }
+  }
+}
+
+function syncArrowStoragePathStateFirstBatch(storageState: ArrowStoragePathState): void {
+  const firstBatch = getFirstArrowStoragePathBatch(storageState);
+  const firstRenderBatch = getFirstArrowStoragePathRenderBatch(storageState);
+  storageState.rowColorsBinding = firstBatch.rowColorsBinding;
+  storageState.rowWidthsBinding = firstBatch.rowWidthsBinding;
+  storageState.styleConfigBuffer = firstBatch.styleConfigBuffer;
+  storageState.compactPathVertexData = firstRenderBatch.compactPathVertexData;
+}
+
+function destroyStoragePathResources(resources: StoragePathOwnedResource[]): void {
+  for (const resource of resources) {
+    resource.destroy();
+  }
+}
+
+function replaceOwnedStoragePathResources(
+  currentResources: StoragePathOwnedResource[],
+  nextResources: StoragePathOwnedResource[]
+): void {
+  destroyStoragePathResources(currentResources);
+  currentResources.splice(0, currentResources.length, ...nextResources);
+}
+
+function getFirstArrowStoragePathBatch(
+  storageState: Pick<ArrowStoragePathState, 'batches'>
+): ArrowStoragePathBatchState {
+  const firstBatch = storageState.batches[0];
+  if (!firstBatch) {
+    throw new Error('ArrowStoragePathState requires at least one row-binding batch');
+  }
+  return firstBatch;
+}
+
+function getFirstArrowStoragePathRenderBatch(
+  storageState: Pick<ArrowStoragePathState, 'renderBatches'>
+): ArrowStoragePathRenderBatchState {
+  const firstRenderBatch = storageState.renderBatches[0];
+  if (!firstRenderBatch) {
+    throw new Error('ArrowStoragePathState requires at least one render batch');
+  }
+  return firstRenderBatch;
+}
+
+function hasArrowStoragePathState(
+  props: ArrowStoragePathModelProps
+): props is ArrowStoragePathRenderProps & {storageState: ArrowStoragePathState} {
+  return 'storageState' in props && props.storageState !== undefined;
+}
+
+function getNow(): number {
+  return typeof performance === 'undefined' ? Date.now() : performance.now();
+}

--- a/modules/arrow/src/arrow/gpu-path-expansion.ts
+++ b/modules/arrow/src/arrow/gpu-path-expansion.ts
@@ -1,0 +1,237 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Binding, type Device, type ShaderLayout} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import type {GeneratedBufferBatch} from './generated-buffer-batches';
+
+export type GpuPathExpansionResourceOptions = {
+  id?: string;
+};
+
+export type GpuPathExpansionInputState = {
+  pathRangesBuffer: Buffer;
+  expansionConfigBuffer: Buffer;
+  byteLength: number;
+};
+
+export type GpuPathGeneratedState = {
+  compactPathVertexData: Buffer;
+  byteLength: number;
+};
+
+export type GpuPathExpansionInputProps = {
+  valueOffsets: Int32Array;
+  recordOffsets: readonly number[];
+  generatedBufferBatch: GeneratedBufferBatch;
+  batchRowIndexBase: number;
+  componentCount: number;
+};
+
+const INDEXED_PATH_VERTEX_WORD_COUNT = 6;
+
+const GPU_PATH_EXPANSION_COMPUTE_SOURCE = /* wgsl */ `
+@group(0) @binding(0) var<storage, read> pathValues : array<f32>;
+@group(0) @binding(1) var<storage, read> pathRanges : array<vec4<u32>>;
+@group(0) @binding(2) var<storage, read> pathExpansionConfig : array<u32>;
+@group(0) @binding(3) var<storage, read_write> generatedPathVertices : array<u32>;
+
+const PATH_SEGMENT_FIRST : u32 = 1u;
+const PATH_SEGMENT_LAST : u32 = 2u;
+const PATH_SEGMENT_CLOSED : u32 = 4u;
+const PATH_RECORD_WORD_COUNT : u32 = 6u;
+
+fn getPathComponentCount() -> u32 {
+  return pathExpansionConfig[1];
+}
+
+fn readPathComponent(pointIndex: u32, componentIndex: u32) -> f32 {
+  if (componentIndex >= getPathComponentCount()) {
+    return 0.0;
+  }
+  return pathValues[pointIndex * getPathComponentCount() + componentIndex];
+}
+
+fn pathIsClosed(pathStart: u32, pointCount: u32) -> bool {
+  if (pointCount < 3u) {
+    return false;
+  }
+  let lastPointIndex = pathStart + pointCount - 1u;
+  var componentIndex = 0u;
+  loop {
+    if (componentIndex >= getPathComponentCount()) {
+      break;
+    }
+    if (
+      readPathComponent(pathStart, componentIndex) !=
+      readPathComponent(lastPointIndex, componentIndex)
+    ) {
+      return false;
+    }
+    componentIndex += 1u;
+  }
+  return true;
+}
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) globalInvocationId: vec3<u32>) {
+  let batchRowIndex = globalInvocationId.x;
+  let rowCount = pathExpansionConfig[0];
+  if (batchRowIndex >= rowCount) {
+    return;
+  }
+
+  let pathRange = pathRanges[batchRowIndex];
+  let pathStart = pathRange.x;
+  let pathEnd = pathRange.y;
+  let outputStart = pathRange.z;
+  let rowIndex = pathRange.w;
+  let pointCount = select(0u, pathEnd - pathStart, pathEnd >= pathStart);
+  let segmentCount = select(0u, pointCount - 1u, pointCount > 0u);
+  let closedPath = pathIsClosed(pathStart, pointCount);
+
+  var segmentOffset = 0u;
+  loop {
+    if (segmentOffset >= segmentCount) {
+      break;
+    }
+    let segmentStartPointIndex = pathStart + segmentOffset;
+    let segmentEndPointIndex = segmentStartPointIndex + 1u;
+    var previousPointIndex = segmentStartPointIndex;
+    if (segmentOffset > 0u) {
+      previousPointIndex = segmentStartPointIndex - 1u;
+    } else if (closedPath) {
+      previousPointIndex = pathEnd - 2u;
+    }
+    var nextPointIndex = segmentEndPointIndex + 1u;
+    if (segmentOffset == segmentCount - 1u) {
+      nextPointIndex = segmentEndPointIndex;
+      if (closedPath) {
+        nextPointIndex = pathStart + 1u;
+      }
+    }
+
+    let recordWordOffset = (outputStart + segmentOffset) * PATH_RECORD_WORD_COUNT;
+    generatedPathVertices[recordWordOffset] = segmentStartPointIndex;
+    generatedPathVertices[recordWordOffset + 1u] = segmentEndPointIndex;
+    generatedPathVertices[recordWordOffset + 2u] = previousPointIndex;
+    generatedPathVertices[recordWordOffset + 3u] = nextPointIndex;
+
+    var flags = select(0u, PATH_SEGMENT_CLOSED, closedPath);
+    if (segmentOffset == 0u) {
+      flags |= PATH_SEGMENT_FIRST;
+    }
+    if (segmentOffset == segmentCount - 1u) {
+      flags |= PATH_SEGMENT_LAST;
+    }
+    generatedPathVertices[recordWordOffset + 4u] = flags;
+    generatedPathVertices[recordWordOffset + 5u] = rowIndex;
+    segmentOffset += 1u;
+  }
+}
+`;
+
+const GPU_PATH_EXPANSION_COMPUTE_SHADER_LAYOUT: ShaderLayout = {
+  bindings: [
+    {name: 'pathValues', type: 'read-only-storage', group: 0, location: 0},
+    {name: 'pathRanges', type: 'read-only-storage', group: 0, location: 1},
+    {name: 'pathExpansionConfig', type: 'read-only-storage', group: 0, location: 2},
+    {name: 'generatedPathVertices', type: 'storage', group: 0, location: 3}
+  ],
+  attributes: []
+};
+
+export function createGpuPathExpansionInput(
+  device: Device,
+  options: GpuPathExpansionResourceOptions,
+  props: GpuPathExpansionInputProps
+): GpuPathExpansionInputState {
+  const {valueOffsets, recordOffsets, generatedBufferBatch, batchRowIndexBase, componentCount} =
+    props;
+  const rowCount = generatedBufferBatch.rowEnd - generatedBufferBatch.rowStart;
+  const pathRanges = new Uint32Array(Math.max(rowCount, 1) * 4);
+
+  for (
+    let rowIndex = generatedBufferBatch.rowStart;
+    rowIndex < generatedBufferBatch.rowEnd;
+    rowIndex++
+  ) {
+    const localRowIndex = rowIndex - generatedBufferBatch.rowStart;
+    const rangeOffset = localRowIndex * 4;
+    pathRanges[rangeOffset] = Math.max(0, valueOffsets[rowIndex] ?? 0);
+    pathRanges[rangeOffset + 1] = Math.max(
+      pathRanges[rangeOffset],
+      valueOffsets[rowIndex + 1] ?? pathRanges[rangeOffset]
+    );
+    pathRanges[rangeOffset + 2] = Math.max(
+      0,
+      (recordOffsets[rowIndex] ?? generatedBufferBatch.recordStart) -
+        generatedBufferBatch.recordStart
+    );
+    pathRanges[rangeOffset + 3] = batchRowIndexBase + rowIndex;
+  }
+
+  const expansionConfig = new Uint32Array([rowCount, componentCount]);
+  return {
+    pathRangesBuffer: device.createBuffer({
+      id: `${options.id || 'gpu-expanded-path-model'}-path-ranges`,
+      usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
+      data: pathRanges
+    }),
+    expansionConfigBuffer: device.createBuffer({
+      id: `${options.id || 'gpu-expanded-path-model'}-expansion-config`,
+      usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
+      data: expansionConfig
+    }),
+    byteLength: rowCount * Uint32Array.BYTES_PER_ELEMENT * 4 + expansionConfig.byteLength
+  };
+}
+
+export function createGpuPathGeneratedState(
+  device: Device,
+  options: GpuPathExpansionResourceOptions,
+  segmentCount: number
+): GpuPathGeneratedState {
+  const outputRecordCount = Math.max(segmentCount, 1);
+  const byteLength = segmentCount * Uint32Array.BYTES_PER_ELEMENT * INDEXED_PATH_VERTEX_WORD_COUNT;
+  return {
+    compactPathVertexData: device.createBuffer({
+      id: `${options.id || 'gpu-expanded-path-model'}-generated-path-vertices`,
+      usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
+      data: new Uint32Array(outputRecordCount * INDEXED_PATH_VERTEX_WORD_COUNT)
+    }),
+    byteLength
+  };
+}
+
+export function dispatchGpuPathExpansionCompute(
+  device: Device,
+  options: GpuPathExpansionResourceOptions,
+  state: {
+    pathValues: Binding;
+    expansionInput: GpuPathExpansionInputState;
+    generated: GpuPathGeneratedState;
+    rowCount: number;
+    segmentCount: number;
+  }
+): void {
+  const computation = new Computation(device, {
+    id: `${options.id || 'gpu-expanded-path-model'}-compute`,
+    source: GPU_PATH_EXPANSION_COMPUTE_SOURCE,
+    shaderLayout: GPU_PATH_EXPANSION_COMPUTE_SHADER_LAYOUT,
+    bindings: {
+      pathValues: state.pathValues,
+      pathRanges: state.expansionInput.pathRangesBuffer,
+      pathExpansionConfig: state.expansionInput.expansionConfigBuffer,
+      generatedPathVertices: state.generated.compactPathVertexData
+    }
+  });
+  if (state.rowCount > 0 && state.segmentCount > 0) {
+    const computePass = device.beginComputePass({});
+    computation.dispatch(computePass, Math.ceil(state.rowCount / 64));
+    computePass.end();
+    device.submit();
+  }
+  computation.destroy();
+}

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -80,6 +80,24 @@ export {ArrowGeometry, type ArrowGeometryProps} from './arrow/arrow-geometry';
 export type {ArrowMeshAttribute, ArrowMeshTable, ArrowMeshTopology} from './arrow/arrow-mesh-types';
 export {ArrowModel, type ArrowModelGPUTable, type ArrowModelProps} from './arrow/arrow-model';
 export {
+  ArrowPathModel,
+  buildArrowPathSegmentTable,
+  type ArrowPathModelProps,
+  type ArrowPathRenderBatchState,
+  type ArrowPathSegmentLayout,
+  type ArrowPathSegmentTable,
+  type ArrowPathSourceVectors
+} from './arrow/arrow-path-model';
+export {
+  ArrowStoragePathModel,
+  createArrowStoragePathState,
+  type ArrowStoragePathBatchState,
+  type ArrowStoragePathInputProps,
+  type ArrowStoragePathModelProps,
+  type ArrowStoragePathRenderBatchState,
+  type ArrowStoragePathState
+} from './arrow/arrow-storage-path-model';
+export {
   TableTransform,
   type TableTransformBatchOptions,
   type TableTransformOutputCopyMap,

--- a/modules/arrow/test/arrow/arrow-path-model.spec.ts
+++ b/modules/arrow/test/arrow/arrow-path-model.spec.ts
@@ -1,0 +1,498 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {
+  ArrowPathModel,
+  ArrowStoragePathModel,
+  GPUVector,
+  buildArrowPathSegmentTable,
+  createArrowStoragePathState,
+  makeArrowFixedSizeListVector
+} from '@luma.gl/arrow';
+import {NullDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
+import * as arrow from 'apache-arrow';
+
+type PathArrowType = arrow.List<arrow.FixedSizeList<arrow.Float32>>;
+
+test('buildArrowPathSegmentTable expands path rows and repeats row styles', t => {
+  const sourceVectors = makeArrowPathSourceVectors();
+  const result = buildArrowPathSegmentTable({
+    rowTable: new arrow.Table({
+      colors: sourceVectors.colors,
+      widths: sourceVectors.widths
+    }),
+    paths: sourceVectors.paths
+  });
+
+  t.equal(result.table.numRows, 5, 'emits one Arrow row per generated segment');
+  t.deepEqual(result.segmentLayout.startIndices, [0, 2, 5], 'retains path segment offsets');
+  t.deepEqual(
+    Array.from(result.segmentLayout.segmentStartPositions),
+    [0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 3, 1, 0, 0],
+    'segment starts preserve open and closed path order'
+  );
+  t.deepEqual(
+    Array.from(result.segmentLayout.segmentEndPositions),
+    [1, 0, 0, 0, 1, 1, 0, 0, 3, 0, 0, 0, 3, 1, 0, 0, 2, 0, 0, 0],
+    'segment ends preserve the source path edge order'
+  );
+  t.deepEqual(
+    Array.from(result.segmentLayout.segmentPreviousPositions),
+    [0, 0, 0, 0, 0, 0, 0, 0, 3, 1, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0],
+    'previous positions preserve open caps and closed joins'
+  );
+  t.deepEqual(
+    Array.from(result.segmentLayout.segmentNextPositions),
+    [1, 1, 0, 0, 1, 1, 0, 0, 3, 1, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0],
+    'next positions preserve open caps and closed joins'
+  );
+  t.deepEqual(
+    Array.from(result.segmentLayout.segmentFlags),
+    [1, 2, 5, 4, 6],
+    'segment flags identify first, last, and closed rows'
+  );
+  t.deepEqual(
+    Array.from(getFixedSizeListValues(result.table.getChild('colors')!)),
+    [255, 0, 0, 255, 255, 0, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255],
+    'RGBA row styles repeat across generated segments'
+  );
+  t.deepEqual(
+    Array.from(result.table.getChild('widths')!.data[0]!.values as Float32Array),
+    [2, 2, 4, 4, 4],
+    'scalar row styles repeat across generated segments'
+  );
+  t.deepEqual(
+    Array.from(result.table.getChild('rowIndices')!.data[0]!.values as Uint32Array),
+    [0, 0, 1, 1, 1],
+    'generated rows retain source path row indices'
+  );
+  t.end();
+});
+
+test('buildArrowPathSegmentTable preserves XYZ and XYZM coordinate lanes', t => {
+  for (const dimension of [3, 4] as const) {
+    const path = makePathVector(
+      new Int32Array([0, 2]),
+      new Float32Array(dimension === 3 ? [0, 1, 2, 3, 4, 5] : [0, 1, 2, 3, 4, 5, 6, 7]),
+      dimension
+    );
+    const result = buildArrowPathSegmentTable({
+      rowTable: new arrow.Table({}),
+      paths: path
+    });
+
+    t.deepEqual(
+      Array.from(result.segmentLayout.segmentStartPositions.subarray(0, 4)),
+      dimension === 3 ? [0, 1, 2, 0] : [0, 1, 2, 3],
+      `vec${dimension} starts preserve source coordinate lanes`
+    );
+    t.deepEqual(
+      Array.from(result.segmentLayout.segmentEndPositions.subarray(0, 4)),
+      dimension === 3 ? [3, 4, 5, 0] : [4, 5, 6, 7],
+      `vec${dimension} ends preserve source coordinate lanes`
+    );
+  }
+
+  t.end();
+});
+
+test('ArrowPathModel derives from ArrowModel and packs generated segment records', async t => {
+  const device = new NullDevice({});
+  const pathProps = makeGpuArrowPathProps(device);
+  const model = new ArrowPathModel(device, {
+    id: 'arrow-path-model-test',
+    ...pathProps
+  });
+  const expandedPathBytes = await model.expandedPathVertexData.readAsync();
+  const firstSegmentPositions = new Float32Array(
+    expandedPathBytes.buffer,
+    expandedPathBytes.byteOffset,
+    16
+  );
+  const firstSegmentMetadata = new Uint32Array(
+    expandedPathBytes.buffer,
+    expandedPathBytes.byteOffset + Float32Array.BYTES_PER_ELEMENT * 16,
+    2
+  );
+  const expandedPathLayout = model.bufferLayout.find(
+    layout => layout.name === 'expandedPathVertexData'
+  );
+
+  t.equal(model.instanceCount, 5, 'instance count uses generated segment rows');
+  t.deepEqual(model.segmentLayout.startIndices, [0, 2, 5], 'model exposes segment offsets');
+  t.equal(expandedPathLayout?.byteStride, 72, 'expanded segment records use a 72-byte stride');
+  t.deepEqual(
+    expandedPathLayout?.attributes,
+    [
+      {attribute: 'segmentStartPositions', format: 'float32x4', byteOffset: 0},
+      {attribute: 'segmentEndPositions', format: 'float32x4', byteOffset: 16}
+    ],
+    'default generated vertex data exposes segment endpoints'
+  );
+  t.deepEqual(
+    Array.from(firstSegmentPositions),
+    [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0],
+    'packed record stores start, end, previous, and next positions'
+  );
+  t.deepEqual(
+    Array.from(firstSegmentMetadata),
+    [1, 0],
+    'packed record stores generated flags and source row index'
+  );
+
+  model.destroy();
+  destroyGpuArrowPathProps(pathProps);
+  t.end();
+});
+
+test('ArrowPathModel requires explicit CPU source vectors', t => {
+  const device = new NullDevice({});
+  const pathProps = makeGpuArrowPathProps(device);
+  const {sourceVectors, ...propsWithoutSourceVectors} = pathProps;
+
+  t.throws(
+    () =>
+      new ArrowPathModel(device, {
+        id: 'arrow-path-model-missing-sources-test',
+        ...(propsWithoutSourceVectors as Omit<typeof pathProps, 'sourceVectors'>)
+      } as never),
+    /requires explicit sourceVectors/,
+    'CPU source ownership is visible at the path model boundary'
+  );
+
+  destroyGpuArrowPathProps(pathProps);
+  t.end();
+});
+
+test('ArrowPathModel rejects source batch alignment mismatches', t => {
+  const device = new NullDevice({});
+  const pathProps = makeGpuArrowPathProps(device);
+  const firstChunk = makePathVector(new Int32Array([0, 3]), new Float32Array([0, 0, 1, 0, 1, 1]));
+  const secondChunk = makePathVector(
+    new Int32Array([0, 4]),
+    new Float32Array([2, 0, 3, 0, 3, 1, 2, 0])
+  );
+
+  t.throws(
+    () =>
+      new ArrowPathModel(device, {
+        id: 'arrow-path-model-source-batch-alignment-test',
+        ...pathProps,
+        sourceVectors: {
+          ...pathProps.sourceVectors,
+          paths: new arrow.Vector<PathArrowType>([...firstChunk.data, ...secondChunk.data])
+        }
+      }),
+    /batch count must match GPU batches/,
+    'path source vector batches stay explicitly aligned with GPU vector batches'
+  );
+
+  destroyGpuArrowPathProps(pathProps);
+  t.end();
+});
+
+test('ArrowPathModel splits generated path buffers by source-row boundaries', t => {
+  const device = new NullDevice({});
+  Object.defineProperty(device.limits, 'maxBufferSize', {value: 300});
+  const pathProps = makeGpuArrowPathProps(device);
+  const model = new ArrowPathModel(device, {
+    id: 'arrow-path-model-buffer-batching-test',
+    ...pathProps
+  });
+
+  t.equal(model.renderBatches.length, 2, 'generated path output splits into two render batches');
+  t.deepEqual(
+    model.renderBatches.map(batch => batch.segmentCount),
+    [2, 3],
+    'batching preserves whole source-path rows'
+  );
+  t.equal(model.instanceCount, 5, 'aggregate segment count remains unchanged');
+
+  model.destroy();
+  destroyGpuArrowPathProps(pathProps);
+  t.end();
+});
+
+test('ArrowStoragePathModel emits indexed compute-generated segment records', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const pathProps = makeStorageGpuArrowPathProps(device);
+  const model = new ArrowStoragePathModel(device, {
+    id: 'arrow-storage-path-generated-segments-test',
+    ...pathProps
+  });
+  const compactPathBytes = await model.compactPathVertexData.readAsync();
+  const generatedPathWords = new Uint32Array(
+    compactPathBytes.buffer,
+    compactPathBytes.byteOffset,
+    model.generatedRenderBufferByteLength / Uint32Array.BYTES_PER_ELEMENT
+  );
+  const compactPathLayout = model.bufferLayout.find(
+    layout => layout.name === 'compactPathVertexData'
+  );
+
+  t.equal(model.segmentCount, 5, 'storage expansion emits one generated row per path segment');
+  t.equal(
+    model.generatedRenderBufferByteLength,
+    120,
+    'five generated segment records keep the 24-byte indexed stride'
+  );
+  t.equal(compactPathLayout?.byteStride, 24, 'generated storage path records use a 24-byte stride');
+  t.deepEqual(
+    compactPathLayout?.attributes,
+    [
+      {attribute: 'segmentStartPointIndices', format: 'uint32', byteOffset: 0},
+      {attribute: 'segmentEndPointIndices', format: 'uint32', byteOffset: 4},
+      {attribute: 'rowIndices', format: 'uint32', byteOffset: 20}
+    ],
+    'default storage rendering exposes point indices plus source row indices'
+  );
+  t.deepEqual(
+    Array.from(generatedPathWords.subarray(0, 6)),
+    [0, 1, 0, 2, 1, 0],
+    'compute output stores start, end, previous, next point indices, flags, and row index'
+  );
+  t.deepEqual(
+    Array.from({length: 5}, (_, segmentIndex) => generatedPathWords[segmentIndex * 6 + 4]),
+    [1, 2, 5, 4, 6],
+    'compute output preserves first, last, and closed path flags'
+  );
+  t.deepEqual(
+    Array.from({length: 5}, (_, segmentIndex) => generatedPathWords[segmentIndex * 6 + 5]),
+    [0, 0, 1, 1, 1],
+    'compute output preserves source path row indices'
+  );
+
+  model.destroy();
+  destroyStorageGpuArrowPathProps(pathProps);
+  t.end();
+});
+
+test('ArrowStoragePathModel refreshes row styles without rebuilding segment buffers', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const pathProps = makeStorageGpuArrowPathProps(device);
+  const model = new ArrowStoragePathModel(device, {
+    id: 'arrow-storage-path-row-style-refresh-test',
+    ...pathProps
+  });
+  const storageState = model.storageState;
+  const compactPathVertexData = model.compactPathVertexData;
+  const renderBatches = model.renderBatches;
+  const styleConfigBuffer = model.styleConfigBuffer;
+
+  model.setProps({color: [255, 0, 0, 255], width: 4});
+
+  t.equal(model.storageState, storageState, 'row-style updates preserve storage state');
+  t.equal(
+    model.compactPathVertexData,
+    compactPathVertexData,
+    'row-style updates preserve generated segment data'
+  );
+  t.equal(model.renderBatches, renderBatches, 'row-style updates preserve render batches');
+  t.notEqual(
+    model.styleConfigBuffer,
+    styleConfigBuffer,
+    'row-style updates refresh the owned storage style config'
+  );
+
+  model.destroy();
+  destroyStorageGpuArrowPathProps(pathProps);
+  t.end();
+});
+
+test('ArrowStoragePathModel splits compute-generated segment buffers by storage limits', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const originalMaxStorageBufferBindingSize = device.limits.maxStorageBufferBindingSize;
+  Object.defineProperty(device.limits, 'maxStorageBufferBindingSize', {
+    value: 80,
+    configurable: true
+  });
+
+  try {
+    const pathProps = makeStorageGpuArrowPathProps(device);
+    const model = new ArrowStoragePathModel(device, {
+      id: 'arrow-storage-path-buffer-batching-test',
+      ...pathProps
+    });
+
+    t.equal(model.storageState.batches.length, 1, 'row bindings retain the source path batch');
+    t.equal(model.renderBatches.length, 2, 'generated path output splits into render batches');
+    t.deepEqual(
+      model.renderBatches.map(batch => batch.segmentCount),
+      [2, 3],
+      'storage batching preserves whole source-path rows'
+    );
+    t.equal(
+      model.generatedRenderBufferByteLength,
+      120,
+      'aggregate generated path byte accounting stays exact'
+    );
+
+    model.destroy();
+    destroyStorageGpuArrowPathProps(pathProps);
+  } finally {
+    Object.defineProperty(device.limits, 'maxStorageBufferBindingSize', {
+      value: originalMaxStorageBufferBindingSize,
+      configurable: true
+    });
+  }
+  t.end();
+});
+
+test('ArrowStoragePathModel rejects non-WebGPU devices', t => {
+  const device = new NullDevice({});
+  const pathProps = makeStorageGpuArrowPathProps(device);
+
+  t.throws(
+    () =>
+      new ArrowStoragePathModel(device, {
+        id: 'arrow-storage-path-model-test',
+        ...pathProps
+      }),
+    /WebGPU-only/,
+    'storage path model reports its backend contract'
+  );
+
+  destroyStorageGpuArrowPathProps(pathProps);
+  t.end();
+});
+
+test('createArrowStoragePathState rejects non-WebGPU devices', t => {
+  const device = new NullDevice({});
+  const pathProps = makeStorageGpuArrowPathProps(device);
+
+  t.throws(
+    () =>
+      createArrowStoragePathState(device, {
+        id: 'arrow-storage-path-state-test',
+        ...pathProps
+      }),
+    /WebGPU device/,
+    'storage-state builder reports its backend contract'
+  );
+
+  destroyStorageGpuArrowPathProps(pathProps);
+  t.end();
+});
+
+function makeGpuArrowPathProps(device: NullDevice) {
+  const sourceVectors = makeArrowPathSourceVectors();
+  return {
+    paths: makeGpuArrowPathVector(device, 'paths', sourceVectors.paths),
+    colors: makeGpuArrowPathVector(device, 'colors', sourceVectors.colors),
+    widths: makeGpuArrowPathVector(device, 'widths', sourceVectors.widths),
+    sourceVectors
+  };
+}
+
+function makeStorageGpuArrowPathProps(device: NullDevice) {
+  const sourceVectors = makeArrowPathSourceVectors();
+  return {
+    paths: makeGpuArrowPathVector(device, 'paths', sourceVectors.paths),
+    colors: makeGpuArrowPathVector(device, 'colors', sourceVectors.colors),
+    widths: makeGpuArrowPathVector(device, 'widths', sourceVectors.widths)
+  };
+}
+
+function makeGpuArrowPathVector<TypeT extends arrow.DataType>(
+  device: NullDevice,
+  name: string,
+  vector: arrow.Vector<TypeT>
+): GPUVector<TypeT> {
+  return new GPUVector({
+    type: 'arrow',
+    name,
+    device,
+    vector
+  });
+}
+
+function destroyGpuArrowPathProps(pathProps: ReturnType<typeof makeGpuArrowPathProps>): void {
+  pathProps.paths.destroy();
+  pathProps.colors.destroy();
+  pathProps.widths.destroy();
+}
+
+function destroyStorageGpuArrowPathProps(
+  pathProps: ReturnType<typeof makeStorageGpuArrowPathProps>
+): void {
+  pathProps.paths.destroy();
+  pathProps.colors.destroy();
+  pathProps.widths.destroy();
+}
+
+function makeArrowPathSourceVectors() {
+  return {
+    paths: makePathVector(
+      new Int32Array([0, 3, 7]),
+      new Float32Array([0, 0, 1, 0, 1, 1, 2, 0, 3, 0, 3, 1, 2, 0])
+    ),
+    colors: makeArrowFixedSizeListVector(
+      new arrow.Uint8(),
+      4,
+      new Uint8Array([255, 0, 0, 255, 0, 255, 0, 255])
+    ),
+    widths: arrow.vectorFromArray([2, 4], new arrow.Float32())
+  };
+}
+
+function makePathVector(
+  valueOffsets: Int32Array,
+  values: Float32Array,
+  dimension: 2 | 3 | 4 = 2
+): arrow.Vector<PathArrowType> {
+  const coordinateType = new arrow.FixedSizeList(
+    dimension,
+    new arrow.Field('values', new arrow.Float32(), false)
+  );
+  const pathType = new arrow.List(
+    new arrow.Field('coordinates', coordinateType, false)
+  ) as PathArrowType;
+  const coordinateValueData = new arrow.Data<arrow.Float32>(
+    new arrow.Float32(),
+    0,
+    values.length,
+    0,
+    {[arrow.BufferType.DATA]: values}
+  );
+  const coordinateData = new arrow.Data<arrow.FixedSizeList<arrow.Float32>>(
+    coordinateType,
+    0,
+    values.length / dimension,
+    0,
+    {},
+    [coordinateValueData]
+  );
+  const pathData = new arrow.Data<PathArrowType>(
+    pathType,
+    0,
+    valueOffsets.length - 1,
+    0,
+    {[arrow.BufferType.OFFSET]: valueOffsets},
+    [coordinateData]
+  );
+  return new arrow.Vector<PathArrowType>([pathData]);
+}
+
+function getFixedSizeListValues(vector: arrow.Vector): Uint8Array {
+  const childData = vector.data[0]!.children[0] as arrow.Data<arrow.Uint8>;
+  return childData.values as Uint8Array;
+}

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -5,6 +5,11 @@
 import './arrow/arrow-paths.spec';
 import './arrow/arrow-column-info.spec';
 import './arrow/arrow-fixed-size-list.spec';
+<<<<<<< Updated upstream
+=======
+import './arrow/arrow-variable-length-attribute-gpu-vector.spec';
+import './arrow/arrow-path-model.spec';
+>>>>>>> Stashed changes
 import './arrow/arrow-geometry.spec';
 import './arrow/plain-gpu-table.spec';
 import './arrow/arrow-model.spec';

--- a/modules/webgpu/src/adapter/helpers/get-bind-group.ts
+++ b/modules/webgpu/src/adapter/helpers/get-bind-group.ts
@@ -184,6 +184,16 @@ function getBindGroupEntry(
       }
     };
   }
+  if (isBufferRangeBinding(binding)) {
+    return {
+      binding: index,
+      resource: {
+        buffer: (binding.buffer as WebGPUBuffer).handle,
+        ...(binding.offset === undefined ? {} : {offset: binding.offset}),
+        ...(binding.size === undefined ? {} : {size: binding.size})
+      }
+    };
+  }
   if (binding instanceof Sampler) {
     return {
       binding: index,
@@ -210,6 +220,17 @@ function getBindGroupEntry(
   }
   log.warn(`invalid binding ${bindingName}`, binding);
   return null;
+}
+
+function isBufferRangeBinding(
+  binding: Binding
+): binding is {buffer: Buffer; offset?: number; size?: number} {
+  return (
+    binding !== null &&
+    typeof binding === 'object' &&
+    'buffer' in binding &&
+    binding.buffer instanceof Buffer
+  );
 }
 
 function getExpectedBindingsForGroup(

--- a/website/content/examples/gpu-tables/arrow-path-model.mdx
+++ b/website/content/examples/gpu-tables/arrow-path-model.mdx
@@ -1,0 +1,7 @@
+---
+title: Arrow Path Model
+---
+
+import {ArrowPathModelExample} from '@site/src/examples';
+
+<ArrowPathModelExample />

--- a/website/content/examples/table-of-contents.json
+++ b/website/content/examples/table-of-contents.json
@@ -22,6 +22,7 @@
     "items": [
       "gpu-tables/arrow-instancing",
       "gpu-tables/arrow-text-2d",
+      "gpu-tables/arrow-path-model",
       "gpu-tables/arrow-mesh-geometry",
       "gpu-tables/gpu-vector-storage-particles"
     ]

--- a/website/content/sidebar-examples.js
+++ b/website/content/sidebar-examples.js
@@ -22,6 +22,7 @@ const sidebars = {
       items: [
         'gpu-tables/arrow-instancing',
         'gpu-tables/arrow-text-2d',
+        'gpu-tables/arrow-path-model',
         'gpu-tables/arrow-mesh-geometry',
         'gpu-tables/gpu-vector-storage-particles'
       ]

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -6,6 +6,7 @@ import {ExampleHeader, ExamplePage, LumaExample, ReactExample, useStore} from '.
 import AnimationApp from '../../examples/api/animation/app';
 import CubemapApp from '../../examples/api/cubemap/app';
 import ArrowMeshGeometryApp from '../../examples/gpu-tables/arrow-mesh-geometry/app';
+import ArrowPathModelApp from '../../examples/gpu-tables/arrow-path-model/app';
 import BloomApp from '../../examples/experimental/bloom/app';
 import FP64App from '../../examples/experimental/fp64/app';
 import GPUVectorStorageParticlesApp from '../../examples/gpu-tables/gpu-vector-storage-particles/app';
@@ -132,6 +133,18 @@ export const ArrowText2DExample: React.FC = props => (
     title="Arrow 2D Text"
     directory="gpu-tables"
     template={ArrowText2DApp}
+    config={exampleConfig}
+    showStats
+    {...props}
+  />
+);
+
+export const ArrowPathModelExample: React.FC = props => (
+  <LumaExample
+    id="arrow-path-model"
+    title="Arrow Path Model"
+    directory="gpu-tables"
+    template={ArrowPathModelApp}
     config={exampleConfig}
     showStats
     {...props}

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -330,8 +330,8 @@ export const InfoBox: FC<InfoBoxProps> = (props: InfoBoxProps) => {
   const sourceUrl = getExampleSourceUrl(props);
   const title = getExampleTitle(props.id, props.title);
   const [isCollapsed, setIsCollapsed] = useState(() => isInfoBoxCollapsedByDefault);
-  const maxInfoHeight = 400;
-  const maxInfoContentHeight = 320;
+  const maxInfoHeight = 760;
+  const maxInfoContentHeight = 680;
   const toggleCollapsed = () => setIsCollapsed(value => !value);
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15324,6 +15324,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"luma.gl-examples-arrow-path-model@workspace:examples/gpu-tables/arrow-path-model":
+  version: 0.0.0-use.local
+  resolution: "luma.gl-examples-arrow-path-model@workspace:examples/gpu-tables/arrow-path-model"
+  dependencies:
+    "@luma.gl/arrow": "npm:~9.3.0"
+    "@luma.gl/core": "npm:~9.3.0"
+    "@luma.gl/engine": "npm:~9.3.0"
+    "@luma.gl/shadertools": "npm:~9.3.0"
+    "@luma.gl/webgl": "npm:~9.3.0"
+    "@luma.gl/webgpu": "npm:~9.3.0"
+    apache-arrow: "npm:^17.0.0"
+    typescript: "npm:^5.9.3"
+    vite: "npm:^8.0.0"
+  languageName: unknown
+  linkType: soft
+
 "luma.gl-examples-arrow-text-2d@workspace:examples/gpu-tables/arrow-text-2d":
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-arrow-text-2d@workspace:examples/gpu-tables/arrow-text-2d"


### PR DESCRIPTION
## Goals

- Add generic GPU support for Arrow variable-length numeric attribute lists without retaining bulk Arrow payloads after upload.
- Introduce Arrow-backed path rendering for nested coordinate lists, including both attribute-expanded and WebGPU storage-backed models.
- Demonstrate the path models in the GPU Tables examples with meaningful styling, storage metrics, and XYZM measure-driven highlighting.
- Keep CPU-retained Arrow vectors explicit only where higher-level expansion workflows actually need them.

## Changes

- Added generic variable-length Arrow attribute list support for:
  - `List<Numeric>`
  - `List<FixedSizeList<Numeric>[1..4]>`
- Refactored Arrow GPU wrappers so they no longer retain uploaded Arrow value arrays or Arrow table/vector/data objects solely for readback reconstruction.
  - Retains only compact structural metadata where needed, such as offsets/null metadata for UTF-8 and nested lists.
- Updated text-model CPU dependencies to use explicit source-vector inputs instead of hidden retention through generic GPU wrappers.
- Added `ArrowPathModel`:
  - Expands nested Float32 XY, XYZ, and XYZM Arrow path rows into per-segment render records.
  - Preserves per-path style rows while exposing generated segment metadata such as previous/next positions, flags, and source-row indices.
- Added `ArrowStoragePathModel` and reusable `ArrowStoragePathState`:
  - WebGPU compute expands nested Arrow path rows into compact indexed segment records.
  - Render shaders fetch coordinates from the original storage-backed path-value buffer.
  - Per-path color and width remain storage-backed rather than being duplicated per generated segment.
- Added GPU path expansion utilities and storage-path GPU vector preparation helpers.
- Fixed WebGPU bind-group helper handling for ranged buffer bindings, which is required by the storage-backed path path.
- Added the Arrow Path Model GPU Tables example and website wiring.
  - Model selector for attribute-backed vs storage-backed rendering.
  - GPU byte accounting for source vectors, generated geometry, style buffers, and totals.
  - XYZM demo data where `M` drives time-based highlighting.
  - Per-cluster M-rate variation with leftward sweep behavior.
  - Join/cap rendering controls:
    - miter joins with adjustable `miterLimit`
    - rounded joins
    - square caps
    - rounded caps
- Expanded docs and release notes to describe:
  - generic nested Arrow attribute lists
  - path model workflows
  - storage-backed path rendering
  - the new example surface

## Verification

Passed:

- `env -u YARN_NO_PROXY -u NPM_CONFIG_NOPROXY -u npm_config_noproxy corepack yarn lint fix`
- `./node_modules/.bin/tsc --project modules/arrow/tsconfig.json`
- `./node_modules/.bin/tsc --project examples/gpu-tables/arrow-path-model/tsconfig.json`
- `env -u YARN_NO_PROXY -u NPM_CONFIG_NOPROXY -u npm_config_noproxy corepack yarn build`
  - run from `examples/gpu-tables/arrow-path-model`
- `env -u YARN_NO_PROXY -u NPM_CONFIG_NOPROXY -u npm_config_noproxy corepack yarn test-node -- modules/arrow/test/index.ts`
- `env -u YARN_NO_PROXY -u NPM_CONFIG_NOPROXY -u npm_config_noproxy corepack yarn test-headless -- modules/arrow/test/arrow/arrow-path-model.spec.ts`
  - `177` test files passed
  - `808` tests passed, `25` skipped

## Risks / Notes

- The merge diff is substantial: roughly `30` files, `3998` insertions, and `140` deletions versus `master`.
- The storage path record is currently `24 bytes/segment`:
  - start index
  - end index
  - previous index
  - next index
  - flags
  - row index
- That layout is reasonable for a self-contained render record, though there is likely a follow-up reduction path:
  - `20 bytes/segment` by deriving `end = start + 1`
  - potentially lower if path ranges stay available for render-time neighbor reconstruction
- The new measure-driven demo currently assumes **XYZM** semantics, with `M` in the fourth lane. Supporting **XYM** as a first-class semantic form would need explicit coordinate-semantic metadata rather than relying only on tuple width.
- The path example shaders now implement richer path styling behavior, but these controls remain example-local rather than promoted to a shared high-level public path-style API.

## Follow-Up Candidates

- Reduce storage segment record width further.
- Decide whether path join/cap controls belong in reusable model-level helpers or should remain shader/example concerns.
- Add explicit XYM/XYZM semantic metadata if measure-aware workflows should become first-class.
- Extend path rendering coverage toward additional deck.gl-like semantics if needed.