### PR TITLE
feat(gpgpu): Add cleanEvaluate helper

### DIFF
--- a/docs/api-reference/gpgpu/README.md
+++ b/docs/api-reference/gpgpu/README.md
@@ -6,6 +6,7 @@ The `@luma.gl/gpgpu` module performs GPU-based data transformation.
 
 - [`Operations`](/docs/api-reference/gpgpu/operations)
 - [`GPUTableEvaluator`](/docs/api-reference/gpgpu/gpu-table)
+- [`cleanEvaluate`](/docs/api-reference/gpgpu/clean-evaluate)
 
 ## Installing
 
@@ -55,6 +56,7 @@ backendRegistry.add('webgpu', webgpuBackend);
 
 - [`Operations`](/docs/api-reference/gpgpu/operations) documents the supported lazy compute operations such as `add()`, `interleave()`, and `fround()`.
 - [`GPUTableEvaluator`](/docs/api-reference/gpgpu/gpu-table) represents structured input and output data for lazy GPGPU operations.
+- [`cleanEvaluate`](/docs/api-reference/gpgpu/clean-evaluate) evaluates final result tables and cleans up intermediate dependencies in one step.
 
 ## Related Engine APIs
 

--- a/docs/api-reference/gpgpu/clean-evaluate.md
+++ b/docs/api-reference/gpgpu/clean-evaluate.md
@@ -1,0 +1,61 @@
+# cleanEvaluate
+
+`cleanEvaluate()` is a small utility for evaluating one or more result tables while cleaning up intermediate `GPUTableEvaluator` dependencies that are no longer needed.
+
+This is most useful when you build a lazy operation graph inline and only want to keep the final output evaluators alive.
+
+## Usage
+
+```ts
+import {GPUTableEvaluator, add, cleanEvaluate} from '@luma.gl/gpgpu';
+
+const positions = GPUTableEvaluator.fromArray(
+  new Float32Array([
+    0, 0, 0,
+    1, 0, 0
+  ]),
+  {size: 3}
+);
+
+const offset = GPUTableEvaluator.fromConstant([1, 2, 3]);
+const translated = add(positions, offset);
+
+await cleanEvaluate(device, {translated});
+
+const values = await translated.readValue();
+translated.destroy();
+```
+
+## Signature
+
+### `cleanEvaluate(device, result): Promise<ResultT>`
+
+```ts
+function cleanEvaluate<
+  ResultT extends GPUTableEvaluator | GPUTableEvaluator[] | Record<string, unknown>
+>(device: Device, result: ResultT): Promise<ResultT>;
+```
+
+## Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `device` | `Device` | The device used to evaluate the returned tables. |
+| `result` | `GPUTableEvaluator \| GPUTableEvaluator[] \| Record<string, unknown>` | The final evaluator or evaluators that should remain alive after evaluation. |
+
+## Behavior
+
+`cleanEvaluate()`:
+
+- finds all `GPUTableEvaluator` instances directly referenced by `result`
+- evaluates those root evaluators
+- walks their dependency graph through `source`
+- destroys dependency evaluators whose GPU buffers are not also used by the root evaluators
+- returns the original `result` object
+
+This lets you keep a compact final result shape while avoiding manual cleanup of temporary operation nodes.
+
+## Remarks
+
+- `cleanEvaluate()` only looks at evaluators directly contained in the provided result value. If you pass a record, non-evaluator properties are ignored.
+- Returned root evaluators are not destroyed automatically. Call `destroy()` on them when you are done.

--- a/modules/gpgpu/src/index.ts
+++ b/modules/gpgpu/src/index.ts
@@ -15,3 +15,4 @@ export {fround} from './operations/fround';
 export {backendRegistry} from './operation/backend-registry';
 export {webglBackend} from './operations/webgl/index';
 export {webgpuBackend} from './operations/webgpu/index';
+export {cleanEvaluate} from './utils/clean-evaluate';

--- a/modules/gpgpu/src/operation/gpu-table.ts
+++ b/modules/gpgpu/src/operation/gpu-table.ts
@@ -25,6 +25,8 @@ export type GPUTableEvaluatorProps = {
   stride?: number;
   /** CPU buffer that initializes the table, required unless `source` is supplied. */
   value?: TypedArray;
+  /** External GPU buffer that backs this table and is not owned by the evaluator. */
+  buffer?: Buffer;
   /** Lazy operation or table whose output initializes this table, required unless `value` is supplied. */
   source?: Operation | GPUTableEvaluator | null;
   /** Whether every row should read the same value. */
@@ -57,6 +59,8 @@ export class GPUTableEvaluator {
   readonly byteLength: number;
   /** TypedArray constructor for CPU representation, derived from {@link GPUTableEvaluator.type}. */
   readonly ValueType: TypedArrayConstructor;
+  /** Operation whose output is used to fill the vector, required unless `value` is supplied */
+  readonly source: Operation | GPUTableEvaluator | null = null;
 
   /** User-assigned id for easy debugging */
   protected _id?: string;
@@ -65,10 +69,10 @@ export class GPUTableEvaluator {
 
   /** CPU buffer, either provided by the user or read back from the GPU */
   protected _value?: TypedArray;
-  /** Operation whose output is used to fill the vector, required unless `value` is supplied */
-  protected _source: Operation | GPUTableEvaluator | null = null;
   /** GPU buffer */
   private _buffer?: Buffer;
+  /** Whether the GPU buffer is externally owned and must not be recycled by the evaluator. */
+  private _hasExternalBuffer: boolean = false;
 
   /**
    * Constructs a table from a CPU array.
@@ -147,10 +151,11 @@ export class GPUTableEvaluator {
       offset = 0,
       stride,
       value,
+      buffer,
       source = null,
       isConstant = false
     } = props;
-    if (!source && !value) {
+    if (!source && !value && !buffer) {
       throw new Error('OperationResource must have a value source');
     }
 
@@ -160,8 +165,10 @@ export class GPUTableEvaluator {
     this.ValueType = getTypedArrayFromDataType(this.type);
     this.offset = offset;
     this.stride = stride || this.ValueType.BYTES_PER_ELEMENT * size;
+    this.source = source;
     this._value = value;
-    this._source = source;
+    this._buffer = buffer;
+    this._hasExternalBuffer = source instanceof GPUTableEvaluator || Boolean(buffer);
 
     let {length} = props;
     if (length === undefined) {
@@ -202,17 +209,20 @@ export class GPUTableEvaluator {
     if (this._destroyed) {
       throw new Error(`GPUTableEvaluator ${this} already destroyed`);
     }
+    if (this._hasExternalBuffer) {
+      return;
+    }
     if (!this._buffer) {
       let buffer: Buffer;
-      if (this._source instanceof GPUTableEvaluator) {
-        await this._source.evaluate(device);
-        buffer = this._source.buffer;
+      if (this.source instanceof GPUTableEvaluator) {
+        await this.source.evaluate(device);
+        buffer = this.source.buffer;
       } else {
         buffer = bufferPool.createOrReuse(device, this.byteLength);
         if (this._value) {
           buffer.write(this._value);
         } else {
-          await this._source!.execute(device, buffer);
+          await this.source!.execute(device, buffer);
         }
       }
       // cache the result when successful
@@ -256,16 +266,17 @@ export class GPUTableEvaluator {
 
   /** Returns the debug id, source description, or class name. */
   toString(): string {
-    return this._id ?? this._source?.toString() ?? this.constructor.name;
+    return this._id ?? this.source?.toString() ?? this.constructor.name;
   }
 
   /** Releases cached GPU storage and prevents future evaluation. */
   destroy() {
     if (this._buffer) {
-      bufferPool.recycle(this._buffer);
+      if (!this._hasExternalBuffer) {
+        bufferPool.recycle(this._buffer);
+      }
       this._buffer = undefined;
     }
     this._destroyed = true;
-    this._source = null;
   }
 }

--- a/modules/gpgpu/src/utils/clean-evaluate.ts
+++ b/modules/gpgpu/src/utils/clean-evaluate.ts
@@ -10,7 +10,7 @@ type EvaluatorResult = GPUTableEvaluator | GPUTableEvaluator[] | Record<string, 
 export async function cleanEvaluate<ResultT extends EvaluatorResult>(
   device: Device,
   result: ResultT
-): Promise<void> {
+): Promise<ResultT> {
   const rootEvaluators = collectReferencedEvaluators(result);
 
   await Promise.all(rootEvaluators.map(evaluator => evaluator.evaluate(device)));
@@ -28,14 +28,15 @@ export async function cleanEvaluate<ResultT extends EvaluatorResult>(
       evaluator.destroy();
     }
   }
+  return result;
 }
 
 function collectReferencedEvaluators(value: EvaluatorResult): GPUTableEvaluator[] {
   const evaluators = new Set<GPUTableEvaluator>();
-  let valuesArray: unknown[];
   if (value instanceof GPUTableEvaluator) {
-    valuesArray = [value];
+    return [value];
   }
+  let valuesArray: unknown[];
   if (Array.isArray(value)) {
     valuesArray = value;
   } else {

--- a/modules/gpgpu/src/utils/clean-evaluate.ts
+++ b/modules/gpgpu/src/utils/clean-evaluate.ts
@@ -1,0 +1,73 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Buffer, Device} from '@luma.gl/core';
+import {GPUTableEvaluator} from '../operation/gpu-table';
+
+type EvaluatorResult = GPUTableEvaluator | GPUTableEvaluator[] | Record<string, unknown>;
+
+export async function cleanEvaluate<ResultT extends EvaluatorResult>(
+  device: Device,
+  result: ResultT
+): Promise<void> {
+  const rootEvaluators = collectReferencedEvaluators(result);
+
+  await Promise.all(rootEvaluators.map(evaluator => evaluator.evaluate(device)));
+
+  const preservedBuffers = new Set<Buffer>(rootEvaluators.map(evaluator => evaluator.buffer));
+
+  const dependencyEvaluators = new Set<GPUTableEvaluator>();
+  for (const evaluator of rootEvaluators) {
+    collectDependencies(evaluator, dependencyEvaluators);
+  }
+
+  for (const evaluator of dependencyEvaluators) {
+    // Multiple evaluators could share the same underlying buffer
+    if (!preservedBuffers.has(evaluator.buffer)) {
+      evaluator.destroy();
+    }
+  }
+}
+
+function collectReferencedEvaluators(value: EvaluatorResult): GPUTableEvaluator[] {
+  const evaluators = new Set<GPUTableEvaluator>();
+  let valuesArray: unknown[];
+  if (value instanceof GPUTableEvaluator) {
+    valuesArray = [value];
+  }
+  if (Array.isArray(value)) {
+    valuesArray = value;
+  } else {
+    valuesArray = Object.values(value);
+  }
+  for (const item of valuesArray) {
+    if (item instanceof GPUTableEvaluator) {
+      evaluators.add(item);
+    }
+  }
+  return Array.from(evaluators);
+}
+
+function collectDependencies(
+  evaluator: GPUTableEvaluator,
+  dependencyEvaluators: Set<GPUTableEvaluator>
+): void {
+  const source = evaluator.source;
+  if (!source) {
+    return;
+  }
+  if (source instanceof GPUTableEvaluator) {
+    if (!dependencyEvaluators.has(source)) {
+      dependencyEvaluators.add(source);
+      collectDependencies(source, dependencyEvaluators);
+    }
+    return;
+  }
+  for (const dependency of source.dependencies) {
+    if (!dependencyEvaluators.has(dependency)) {
+      dependencyEvaluators.add(dependency);
+      collectDependencies(dependency, dependencyEvaluators);
+    }
+  }
+}

--- a/modules/gpgpu/test/operations/add.spec.ts
+++ b/modules/gpgpu/test/operations/add.spec.ts
@@ -3,61 +3,9 @@
 // Copyright (c) vis.gl contributors
 
 import {test, expect} from 'vitest';
-import {add} from '@luma.gl/gpgpu';
+import {add, cleanEvaluate, GPUTableEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice} from '@luma.gl/test-utils';
-import {TestData, makeTable, verifyTableValue, isSupportedByWebGPU} from './fixtures';
-
-const TEST_CASES: {
-  title: string;
-  x: TestData;
-  y: TestData;
-  z?: TestData;
-  sum: TestData;
-}[] = [
-  {
-    title: 'vec2 + vec2',
-    x: {value: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], size: 2},
-    y: {value: [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], size: 2},
-    sum: {value: [0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16], type: 'float32', size: 2}
-  },
-  {
-    title: 'uvec2 + uvec2',
-    x: {value: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], type: 'uint32', size: 2},
-    y: {value: [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], type: 'uint8', size: 2},
-    sum: {value: [0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16], type: 'uint32', size: 2}
-  },
-  {
-    title: 'vec6 + vec6',
-    x: {value: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], size: 6},
-    y: {value: [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], size: 6},
-    sum: {value: [0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16], type: 'float32', size: 6}
-  },
-  {
-    title: 'vec3 + float',
-    x: {value: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], size: 3},
-    y: {value: [1, -1, 1, -1], size: 1},
-    sum: {value: [1, 1, 2, 2, 4, 5, 7, 7, 8, 8, 10, 11], type: 'float32', size: 3}
-  },
-  {
-    title: 'vec3 + constant',
-    x: {value: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], size: 3},
-    y: {constant: 1},
-    sum: {value: [1, 1, 2, 4, 4, 5, 7, 7, 8, 10, 10, 11], type: 'float32', size: 3}
-  },
-  {
-    title: 'constant + constant',
-    x: {constant: [0, 1, 2]},
-    y: {constant: [1, 2, 3]},
-    sum: {constant: [1, 3, 5], type: 'float32', size: 3}
-  },
-  {
-    title: 'vec2 + vec2 + int',
-    x: {value: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], size: 2},
-    y: {value: [0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], size: 2},
-    z: {value: [1, -1, 1, -1, 1, -1], type: 'sint8', size: 1},
-    sum: {value: [1, 1, 2, 4, 7, 7, 8, 10, 13, 13, 14, 16], type: 'float32', size: 2}
-  }
-];
+import {TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu'] as const) {
   test(`GPGPU#add#execute:${deviceType}`, async t => {
@@ -66,23 +14,83 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
       t.annotate(`${deviceType} not available`);
       return;
     }
-    for (const {title, x, y, z, sum} of TEST_CASES) {
-      if (device.type === 'webgpu' && !isSupportedByWebGPU(x, y, z)) {
+    const TEST_CASES: {
+      title: string;
+      sum: GPUTableEvaluator;
+      expected: TestData;
+    }[] = [
+      {
+        title: 'vec2 + vec2',
+        sum: add(
+          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 2}),
+          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 2})
+        ),
+        expected: {value: [0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16], type: 'float32', size: 2}
+      },
+      {
+        title: 'uvec2 + uvec2',
+        sum: add(
+          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {
+            type: 'uint32',
+            size: 2
+          }),
+          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {
+            type: 'uint8',
+            size: 2
+          })
+        ),
+        expected: {value: [0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16], type: 'uint32', size: 2}
+      },
+      {
+        title: 'vec6 + vec6',
+        sum: add(
+          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 6}),
+          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 6})
+        ),
+        expected: {value: [0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16], type: 'float32', size: 6}
+      },
+      {
+        title: 'vec3 + float',
+        sum: add(
+          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
+          GPUTableEvaluator.fromArray([1, -1, 1, -1], {size: 1})
+        ),
+        expected: {value: [1, 1, 2, 2, 4, 5, 7, 7, 8, 8, 10, 11], type: 'float32', size: 3}
+      },
+      {
+        title: 'vec3 + constant',
+        sum: add(
+          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
+          GPUTableEvaluator.fromConstant(1)
+        ),
+        expected: {value: [1, 1, 2, 4, 4, 5, 7, 7, 8, 10, 10, 11], type: 'float32', size: 3}
+      },
+      {
+        title: 'constant + constant',
+        sum: add(
+          GPUTableEvaluator.fromConstant([0, 1, 2]),
+          GPUTableEvaluator.fromConstant([1, 2, 3])
+        ),
+        expected: {constant: [1, 3, 5], type: 'float32', size: 3}
+      },
+      {
+        title: 'vec2 + vec2 + int',
+        sum: add(
+          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 2}),
+          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 2}),
+          GPUTableEvaluator.fromArray([1, -1, 1, -1, 1, -1], {type: 'sint8', size: 1})
+        ),
+        expected: {value: [1, 1, 2, 4, 7, 7, 8, 10, 13, 13, 14, 16], type: 'float32', size: 2}
+      }
+    ];
+    for (const testCase of TEST_CASES) {
+      if (device.type === 'webgpu' && !isSupportedByWebGPU(testCase.sum)) {
         continue;
       }
-      const tx = makeTable(x);
-      const ty = makeTable(y);
-      const tz = z && makeTable(z);
-      const ts = tz ? add(tx, ty, tz) : add(tx, ty);
-
-      await ts.evaluate(device);
-      await ts.readValue();
-      expect(verifyTableValue(ts, sum), title).toBe(null);
-      // clean up
-      tx.destroy();
-      ty.destroy();
-      tz?.destroy();
-      ts.destroy();
+      await cleanEvaluate(device, testCase);
+      await testCase.sum.readValue();
+      expect(verifyTableValue(testCase.sum, testCase.expected), testCase.title).toBe(null);
+      testCase.sum.destroy();
     }
   });
 }

--- a/modules/gpgpu/test/operations/fixtures.ts
+++ b/modules/gpgpu/test/operations/fixtures.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 import {SignedDataType} from '@luma.gl/core';
-import {TypedArray} from '@math.gl/core';
+import {TypedArray, equals} from '@math.gl/core';
 import {GPUTableEvaluator, backendRegistry, webglBackend} from '@luma.gl/gpgpu';
 import {webgpuBackend} from '../../src/operations/webgpu';
 
@@ -22,15 +22,12 @@ export type TestData =
       type?: SignedDataType;
     };
 
-export function makeTable(source: TestData): GPUTableEvaluator {
-  if ('constant' in source) {
-    return GPUTableEvaluator.fromConstant(source.constant, source.type);
-  }
-  return GPUTableEvaluator.fromArray(source.value, source);
-}
-
 /** Check table value against definition, returns error if any */
-export function verifyTableValue(table: GPUTableEvaluator, expected: TestData): string | null {
+export function verifyTableValue(
+  table: GPUTableEvaluator,
+  expected: TestData,
+  epsilon?: number
+): string | null {
   const size = table.size;
 
   if ('type' in expected && expected.type !== table.type) {
@@ -48,11 +45,12 @@ export function verifyTableValue(table: GPUTableEvaluator, expected: TestData): 
   if (!actual) {
     return `Unexpected empty result`;
   }
+  const equalFunc = epsilon === undefined ? exactEquals : (a: any, b: any) => equals(a, b, epsilon);
   const mismatches: {index: number; expected: number[]; actual: number[]}[] = [];
   for (let i = 0; i < target.length; i += size) {
     const actualItem = actual?.slice(i, i + size);
     const expectedItem = target.slice(i, i + size);
-    if (!equals(actualItem, expectedItem)) {
+    if (!equalFunc(actualItem, expectedItem)) {
       mismatches.push({
         index: i / size,
         expected: Array.from(expectedItem),
@@ -68,25 +66,46 @@ export function verifyTableValue(table: GPUTableEvaluator, expected: TestData): 
     .join('\n')}`;
 }
 
-export function isSupportedByWebGPU(...inputs: (TestData | undefined)[]): boolean {
-  return inputs.every(input => {
-    if (!input) {
-      return true;
-    }
-    return (
-      (input.type ?? 'float32') === 'float32' || input.type === 'uint32' || input.type === 'sint32'
-    );
-  });
+export function isSupportedByWebGPU(...inputs: (GPUTableEvaluator | undefined)[]): boolean {
+  const visitedEvaluators = new Set<GPUTableEvaluator>();
+  return inputs.every(input => isEvaluatorSupportedByWebGPU(input, visitedEvaluators));
+}
+
+function isEvaluatorSupportedByWebGPU(
+  evaluator: GPUTableEvaluator | undefined,
+  visitedEvaluators: Set<GPUTableEvaluator>
+): boolean {
+  if (!evaluator || visitedEvaluators.has(evaluator)) {
+    return true;
+  }
+  visitedEvaluators.add(evaluator);
+  if (evaluator.type !== 'float32' && evaluator.type !== 'uint32' && evaluator.type !== 'sint32') {
+    return false;
+  }
+
+  const source = evaluator.source;
+
+  if (source instanceof GPUTableEvaluator) {
+    return isEvaluatorSupportedByWebGPU(source, visitedEvaluators);
+  }
+
+  if (!source || !('dependencies' in source) || !source.dependencies) {
+    return true;
+  }
+
+  return source.dependencies.every(dependency =>
+    isEvaluatorSupportedByWebGPU(dependency, visitedEvaluators)
+  );
 }
 
 /** numeric or numeric array comparison at GPU precision (float32) */
-function equals(a: any, b: any) {
+function exactEquals(a: any, b: any) {
   if (a === b) return true;
   if (Number.isNaN(a)) return Number.isNaN(b);
 
   if (isArray(a) && isArray(b)) {
     if (a.length !== b.length) return false;
-    for (let i = 0; i < a.length; ++i) if (!equals(a[i], b[i])) return false;
+    for (let i = 0; i < a.length; ++i) if (!exactEquals(a[i], b[i])) return false;
     return true;
   }
   if (typeof a === 'number' && typeof b === 'number') {

--- a/modules/gpgpu/test/operations/fround.spec.ts
+++ b/modules/gpgpu/test/operations/fround.spec.ts
@@ -3,78 +3,9 @@
 // Copyright (c) vis.gl contributors
 
 import {test, expect} from 'vitest';
-import {fround} from '@luma.gl/gpgpu';
+import {cleanEvaluate, fround, GPUTableEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice} from '@luma.gl/test-utils';
-import {makeTable, verifyTableValue} from './fixtures';
-
-const TEST_CASES: {
-  title: string;
-  input: number[];
-  size: number;
-}[] = [
-  {
-    title: 'size 1',
-    input: [1, -2, 0.1, -0.2, 0.3, -1 / 3, 1 / 5, -1 / 7, -Math.E, Math.E, -Math.PI, Math.PI],
-    size: 1
-  },
-  {
-    title: 'size 3',
-    input: new Array(1000).fill(0).flatMap((_, i) => {
-      return [-122.123 - i / 1000, 37.789 + i / 1000, 1000 + i / 100];
-    }),
-    size: 3
-  },
-  {
-    title: 'edge cases',
-    input: [
-      0,
-      -0,
-      // special numbers
-      NaN,
-      Infinity,
-      -Infinity,
-      // f32 integer precision boundary
-      16777215,
-      16777216,
-      16777217,
-      16777218,
-      33554431,
-      33554432,
-      33554433,
-      // f32 subnormal boundary
-      2 ** -126,
-      2 ** -127,
-      -(2 ** -126),
-      2 ** -149,
-      2 ** -150,
-      -(2 ** -149),
-      // low part round up behavior
-      1 + 2 ** -24,
-      1 + 2 ** -25,
-      1 + 3 * 2 ** -25,
-      -1 - 2 ** -24,
-      2 + 2 ** -23,
-      2 + 2 ** -24,
-      // very small numbers
-      Number.MIN_VALUE,
-      -Number.MIN_VALUE,
-      1e-310,
-      2e-307,
-      5e-324,
-      // very big numbers
-      Number.MAX_SAFE_INTEGER,
-      Number.MAX_SAFE_INTEGER - 1,
-      -Number.MAX_SAFE_INTEGER,
-      3.4028234663852886e38,
-      3.4028235e38,
-      3.5e38,
-      -3.5e38,
-      2 ** 53,
-      2 ** 60
-    ],
-    size: 1
-  }
-];
+import {verifyTableValue} from './fixtures';
 
 function splitFloatsCPU(input: number[], size: number): number[] {
   const inputArr = new Float64Array(input);
@@ -98,23 +29,164 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
       t.annotate(`${deviceType} not available`);
       return;
     }
-    for (const {title, input, size} of TEST_CASES) {
+    const TEST_CASES: {
+      title: string;
+      output: GPUTableEvaluator;
+      values: number[];
+      size: number;
+    }[] = [
+      {
+        title: 'size 1',
+        output: fround(
+          GPUTableEvaluator.fromArray(
+            new Float64Array([
+              1,
+              -2,
+              0.1,
+              -0.2,
+              0.3,
+              -1 / 3,
+              1 / 5,
+              -1 / 7,
+              -Math.E,
+              Math.E,
+              -Math.PI,
+              Math.PI
+            ]),
+            {size: 1}
+          )
+        ),
+        values: [1, -2, 0.1, -0.2, 0.3, -1 / 3, 1 / 5, -1 / 7, -Math.E, Math.E, -Math.PI, Math.PI],
+        size: 1
+      },
+      {
+        title: 'size 3',
+        output: fround(
+          GPUTableEvaluator.fromArray(
+            new Float64Array(
+              new Array(1000).fill(0).flatMap((_, i) => {
+                return [-122.123 - i / 1000, 37.789 + i / 1000, 1000 + i / 100];
+              })
+            ),
+            {size: 3}
+          )
+        ),
+        values: new Array(1000).fill(0).flatMap((_, i) => {
+          return [-122.123 - i / 1000, 37.789 + i / 1000, 1000 + i / 100];
+        }),
+        size: 3
+      },
+      {
+        title: 'edge cases',
+        output: fround(
+          GPUTableEvaluator.fromArray(
+            new Float64Array([
+              0,
+              -0,
+              // special numbers
+              NaN,
+              Infinity,
+              -Infinity,
+              // f32 integer precision boundary
+              16777215,
+              16777216,
+              16777217,
+              16777218,
+              33554431,
+              33554432,
+              33554433,
+              // f32 subnormal boundary
+              2 ** -126,
+              2 ** -127,
+              -(2 ** -126),
+              2 ** -149,
+              2 ** -150,
+              -(2 ** -149),
+              // low part round up behavior
+              1 + 2 ** -24,
+              1 + 2 ** -25,
+              1 + 3 * 2 ** -25,
+              -1 - 2 ** -24,
+              2 + 2 ** -23,
+              2 + 2 ** -24,
+              // very small numbers
+              Number.MIN_VALUE,
+              -Number.MIN_VALUE,
+              1e-310,
+              2e-307,
+              5e-324,
+              // very big numbers
+              Number.MAX_SAFE_INTEGER,
+              Number.MAX_SAFE_INTEGER - 1,
+              -Number.MAX_SAFE_INTEGER,
+              3.4028234663852886e38,
+              3.4028235e38,
+              3.5e38,
+              -3.5e38,
+              2 ** 53,
+              2 ** 60
+            ]),
+            {size: 1}
+          )
+        ),
+        values: [
+          0,
+          -0,
+          // special numbers
+          NaN,
+          Infinity,
+          -Infinity,
+          // f32 integer precision boundary
+          16777215,
+          16777216,
+          16777217,
+          16777218,
+          33554431,
+          33554432,
+          33554433,
+          // f32 subnormal boundary
+          2 ** -126,
+          2 ** -127,
+          -(2 ** -126),
+          2 ** -149,
+          2 ** -150,
+          -(2 ** -149),
+          // low part round up behavior
+          1 + 2 ** -24,
+          1 + 2 ** -25,
+          1 + 3 * 2 ** -25,
+          -1 - 2 ** -24,
+          2 + 2 ** -23,
+          2 + 2 ** -24,
+          // very small numbers
+          Number.MIN_VALUE,
+          -Number.MIN_VALUE,
+          1e-310,
+          2e-307,
+          5e-324,
+          // very big numbers
+          Number.MAX_SAFE_INTEGER,
+          Number.MAX_SAFE_INTEGER - 1,
+          -Number.MAX_SAFE_INTEGER,
+          3.4028234663852886e38,
+          3.4028235e38,
+          3.5e38,
+          -3.5e38,
+          2 ** 53,
+          2 ** 60
+        ],
+        size: 1
+      }
+    ];
+    for (const testCase of TEST_CASES) {
       const expected = {
-        value: splitFloatsCPU(input, size),
-        size: size * 2
+        value: splitFloatsCPU(testCase.values, testCase.size),
+        size: testCase.size * 2
       };
-      const tx = makeTable({
-        value: new Float64Array(input),
-        size
-      });
-      const ts = fround(tx);
-
-      await ts.evaluate(device);
-      await ts.readValue();
-      expect(verifyTableValue(ts, expected), title).toBe(null);
-      // clean up
-      tx.destroy();
-      ts.destroy();
+      await cleanEvaluate(device, testCase);
+      await testCase.output.readValue();
+      expect(verifyTableValue(testCase.output, expected), testCase.title).toBe(null);
+      testCase.output.destroy();
     }
   });
 }

--- a/modules/gpgpu/test/operations/interleave.spec.ts
+++ b/modules/gpgpu/test/operations/interleave.spec.ts
@@ -3,51 +3,9 @@
 // Copyright (c) vis.gl contributors
 
 import {test, expect} from 'vitest';
-import {interleave} from '@luma.gl/gpgpu';
+import {cleanEvaluate, interleave, GPUTableEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice} from '@luma.gl/test-utils';
-import {TestData, makeTable, verifyTableValue, isSupportedByWebGPU} from './fixtures';
-
-const TEST_CASES: {
-  title: string;
-  x: TestData;
-  y: TestData;
-  z?: TestData;
-  result: TestData;
-}[] = [
-  {
-    title: 'vec2 + vec2',
-    x: {value: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], size: 2},
-    y: {value: [0, 0, 1, 1, 2, 2, 3, 3, 4, 4], size: 2},
-    result: {
-      value: [0, 1, 0, 0, 2, 3, 1, 1, 4, 5, 2, 2, 6, 7, 3, 3, 8, 9, 4, 4],
-      type: 'float32',
-      size: 4
-    }
-  },
-  {
-    title: 'vec3 + float',
-    x: {value: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], size: 3},
-    y: {value: [1, -1, 1, -1], size: 1},
-    result: {value: [0, 1, 2, 1, 3, 4, 5, -1, 6, 7, 8, 1, 9, 10, 11, -1], type: 'float32', size: 4}
-  },
-  {
-    title: 'constant + constant',
-    x: {constant: [0, 1, 2]},
-    y: {constant: [1, 2, 3]},
-    result: {constant: [0, 1, 2, 1, 2, 3], type: 'float32', size: 6}
-  },
-  {
-    title: 'vec4 + vec2 + uint',
-    x: {value: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], size: 4},
-    y: {value: [0, 0, 1, 1, 2, 2], size: 2},
-    z: {value: [1, 2, 1], type: 'uint32', size: 1},
-    result: {
-      value: [0, 1, 2, 3, 0, 0, 1, 4, 5, 6, 7, 1, 1, 2, 8, 9, 10, 11, 2, 2, 1],
-      type: 'float32',
-      size: 7
-    }
-  }
-];
+import {TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu'] as const) {
   test(`GPGPU#interleave#execute:${deviceType}`, async t => {
@@ -56,23 +14,65 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
       t.annotate(`${deviceType} not available`);
       return;
     }
-    for (const {title, x, y, z, result} of TEST_CASES) {
-      if (device.type === 'webgpu' && !isSupportedByWebGPU(x, y, z)) {
+    const TEST_CASES: {
+      title: string;
+      result: GPUTableEvaluator;
+      expected: TestData;
+    }[] = [
+      {
+        title: 'vec2 + vec2',
+        result: interleave(
+          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], {size: 2}),
+          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4], {size: 2})
+        ),
+        expected: {
+          value: [0, 1, 0, 0, 2, 3, 1, 1, 4, 5, 2, 2, 6, 7, 3, 3, 8, 9, 4, 4],
+          type: 'float32',
+          size: 4
+        }
+      },
+      {
+        title: 'vec3 + float',
+        result: interleave(
+          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
+          GPUTableEvaluator.fromArray([1, -1, 1, -1], {size: 1})
+        ),
+        expected: {
+          value: [0, 1, 2, 1, 3, 4, 5, -1, 6, 7, 8, 1, 9, 10, 11, -1],
+          type: 'float32',
+          size: 4
+        }
+      },
+      {
+        title: 'constant + constant',
+        result: interleave(
+          GPUTableEvaluator.fromConstant([0, 1, 2]),
+          GPUTableEvaluator.fromConstant([1, 2, 3])
+        ),
+        expected: {constant: [0, 1, 2, 1, 2, 3], type: 'float32', size: 6}
+      },
+      {
+        title: 'vec4 + vec2 + uint',
+        result: interleave(
+          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 4}),
+          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2], {size: 2}),
+          GPUTableEvaluator.fromArray([1, 2, 1], {type: 'uint32', size: 1})
+        ),
+        expected: {
+          value: [0, 1, 2, 3, 0, 0, 1, 4, 5, 6, 7, 1, 1, 2, 8, 9, 10, 11, 2, 2, 1],
+          type: 'float32',
+          size: 7
+        }
+      }
+    ];
+    for (const testCase of TEST_CASES) {
+      if (device.type === 'webgpu' && !isSupportedByWebGPU(testCase.result)) {
         continue;
       }
-      const tx = makeTable(x);
-      const ty = makeTable(y);
-      const tz = z && makeTable(z);
-      const ts = tz ? interleave(tx, ty, tz) : interleave(tx, ty);
-
-      await ts.evaluate(device);
-      await ts.readValue();
-      expect(verifyTableValue(ts, result), title).toBe(null);
-      // clean up
-      tx.destroy();
-      ty.destroy();
-      tz?.destroy();
-      ts.destroy();
+      await cleanEvaluate(device, testCase);
+      await testCase.result.readValue();
+      expect(verifyTableValue(testCase.result, testCase.expected), testCase.title).toBe(null);
+      testCase.result.destroy();
     }
   });
 }

--- a/modules/gpgpu/test/utils/clean-evaluate.spec.ts
+++ b/modules/gpgpu/test/utils/clean-evaluate.spec.ts
@@ -1,0 +1,37 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {add, cleanEvaluate, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {getTestDevice} from '@luma.gl/test-utils';
+import '../operations/fixtures';
+
+test(`GPGPU#cleanEvaluate`, async t => {
+  const device = await getTestDevice('webgl');
+  if (!device) {
+    t.annotate(`webgl not available`);
+    return;
+  }
+
+  const x = GPUTableEvaluator.fromArray([1, 2, 3, 4], {type: 'sint32', size: 1});
+  const y = GPUTableEvaluator.fromArray([10, 20, 30, 40], {type: 'sint32', size: 1});
+  const z = GPUTableEvaluator.fromArray([100, 200, 300, 400], {type: 'sint32', size: 1});
+
+  const partial = add(x, y);
+  const sum = add(partial, z);
+
+  await cleanEvaluate(device, {sum, x});
+
+  expect(sum.buffer).toBeTruthy();
+  expect(x.buffer).toBeTruthy();
+
+  expect((x as any)._destroyed).toBe(false);
+  expect((y as any)._destroyed).toBe(true);
+  expect((z as any)._destroyed).toBe(true);
+  expect((partial as any)._destroyed).toBe(true);
+  expect((sum as any)._destroyed).toBe(false);
+
+  x.destroy();
+  sum.destroy();
+});


### PR DESCRIPTION
Add a `cleanEvaluate` that automatically destroys all intermediate resources

Before:

```ts
async function calc(xData: Float32Array, yData: Float32Array, zData: Float32Array): Buffer {
  const x = GPUTableEvaluator.fromArray(xData);
  const y = GPUTableEvaluator.fromArray(yData);
  const z = GPUTableEvaluator.fromArray(zData);
  const sum = add(x, y);
  const result = multiply(sum, z);
  await result.evaluate(device);
  x.destroy();
  y.destroy();
  z.destroy();
  sum.destroy();
  return result.buffer;
}
```

After:

```ts
async function calc(xData: Float32Array, yData: Float32Array, zData: Float32Array): Buffer {
  const result = multiply(
    add(
      GPUTableEvaluator.fromArray(xData),
      GPUTableEvaluator.fromArray(yData),
    ),
    GPUTableEvaluator.fromArray(zData)
  );
  await cleanEvaluate(device, result);
  return result.buffer;
}
```
