### PR TITLE
Fix unnecessary uniform buffer writes when uniform values are unchanged

### DIFF
--- a/modules/core/src/portable/uniform-block.ts
+++ b/modules/core/src/portable/uniform-block.ts
@@ -53,8 +53,8 @@ export class UniformBlock<
   /** Set a map of uniforms */
   setUniforms(uniforms: Partial<TUniforms>): void {
     for (const [key, value] of Object.entries(uniforms)) {
-      this._setUniform(key, value);
-      if (!this.needsRedraw) {
+      const changed = this._setUniform(key, value);
+      if (changed && !this.needsRedraw) {
         this.setNeedsRedraw(`${this.name}.${key}=${value}`);
       }
     }
@@ -72,13 +72,14 @@ export class UniformBlock<
     return (this.uniforms || {}) as Record<string, UniformValue>;
   }
 
-  /** Set a single uniform */
-  private _setUniform(key: keyof TUniforms, value: UniformValue) {
+  /** Set a single uniform. Returns `true` if the value changed. */
+  private _setUniform(key: keyof TUniforms, value: UniformValue): boolean {
     if (arrayEqual(this.uniforms[key], value)) {
-      return;
+      return false;
     }
     this.uniforms[key] = arrayCopy(value);
     this.modifiedUniforms[key] = true;
     this.modified = true;
+    return true;
   }
 }


### PR DESCRIPTION
I started a discussion in #2599 but didn't get any responses, so I'm opening a PR. I'm fairly confident this is a real bug, and in my own tests it gives a significant performance boost with no visual regressions.

No open issue, see discussion #2599.

#### Background
`needsRedraw` gates the buffer upload in `UniformStore.updateUniformBuffer()`, and it's re-flagged on the per-frame hot path (`Model.predraw` → `updateShaderInputs` → `setUniforms`). So unchanged uniforms were re-uploaded to the GPU every frame, for every block, on every model.

#### Change List
- `_setUniform()` returns `boolean` (`true` when changed).
- `setUniforms()` only flags `needsRedraw` when a value actually changed.