### PR TITLE
fix(gpgpu): effectively handle large vectors

### DIFF
--- a/modules/gpgpu/src/operation/gpu-table-evaluator.ts
+++ b/modules/gpgpu/src/operation/gpu-table-evaluator.ts
@@ -389,33 +389,43 @@ export class GPUTableEvaluator {
    */
   async readValue(startRow: number = 0, endRow?: number): Promise<TypedArray> {
     const {ValueType} = this;
-    if (!this._value) {
-      const bytes = await getGPUVectorBuffer(this.gpuVector).readAsync(
-        this.offset,
-        this.byteLength
-      );
-      this._value = new ValueType(bytes.buffer as ArrayBuffer);
-    }
-
     const {size, offset, stride, length} = this;
     const width = ValueType.BYTES_PER_ELEMENT * size;
     endRow = endRow ?? length;
+    startRow = Math.max(0, Math.min(length, startRow));
+    endRow = Math.max(startRow, Math.min(length, endRow));
+
+    if (this._value) {
+      return getRowsFromValue(this, this._value, startRow, endRow);
+    }
+
+    const rowCount = endRow - startRow;
+    if (rowCount === 0) {
+      return new ValueType(0) as TypedArray;
+    }
+
+    const byteOffset = offset + startRow * stride;
+    const byteLength = stride === width ? rowCount * width : (rowCount - 1) * stride + width;
+    const bytes = await getGPUVectorBuffer(this.gpuVector).readAsync(byteOffset, byteLength);
+    const value = new ValueType(
+      bytes.buffer as ArrayBuffer,
+      bytes.byteOffset,
+      bytes.byteLength / ValueType.BYTES_PER_ELEMENT
+    );
 
     if (stride === width) {
-      const buffer = this._value!.buffer as ArrayBuffer;
-      return new ValueType(buffer, offset + stride * startRow, (endRow - startRow) * size);
+      return value;
     }
 
-    const bytes = new Uint8Array(width * (endRow - startRow));
-    let i0 = offset + startRow * stride,
-      i1 = 0;
-    for (let y = startRow; y < endRow; y++) {
-      for (let x = 0; x < width; x++) {
-        bytes[i1++] = bytes[i0 + x];
-      }
-      i0 += stride;
+    const compactBytes = new Uint8Array(width * rowCount);
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      const sourceByteOffset = rowIndex * stride;
+      compactBytes.set(
+        bytes.subarray(sourceByteOffset, sourceByteOffset + width),
+        rowIndex * width
+      );
     }
-    return new ValueType(bytes.buffer);
+    return new ValueType(compactBytes.buffer);
   }
 
   /** Returns the debug id, source description, or class name. */
@@ -433,6 +443,30 @@ export class GPUTableEvaluator {
     }
     this._destroyed = true;
   }
+}
+
+function getRowsFromValue(
+  table: GPUTableEvaluator,
+  value: TypedArray,
+  startRow: number,
+  endRow: number
+): TypedArray {
+  const {ValueType, size, offset, stride} = table;
+  const valueStride = stride / ValueType.BYTES_PER_ELEMENT;
+  const valueOffset = offset / ValueType.BYTES_PER_ELEMENT;
+  const rowCount = endRow - startRow;
+
+  if (valueStride === size) {
+    const startIndex = valueOffset + startRow * valueStride;
+    return value.subarray(startIndex, startIndex + rowCount * size) as TypedArray;
+  }
+
+  const result = new ValueType(rowCount * size) as TypedArray;
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+    const sourceStart = valueOffset + (startRow + rowIndex) * valueStride;
+    result.set(value.subarray(sourceStart, sourceStart + size), rowIndex * size);
+  }
+  return result;
 }
 
 /** Input accepted by operations that normalize GPUVectors into evaluators. */

--- a/modules/gpgpu/src/operations/webgpu/common/dispatch.ts
+++ b/modules/gpgpu/src/operations/webgpu/common/dispatch.ts
@@ -1,0 +1,58 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export type WebGPUDispatchLayout = {
+  x: number;
+  y: number;
+  z: number;
+};
+
+const WEBGPU_MINIMUM_MAX_COMPUTE_WORKGROUPS_PER_DIMENSION = 65_535;
+
+export function getWebGPUDispatchLayout(
+  workgroupCount: number,
+  maxWorkgroupsPerDimension?: number
+): WebGPUDispatchLayout {
+  const maximumWorkgroupsPerDimension = getMaximumWorkgroupsPerDimension(maxWorkgroupsPerDimension);
+  const totalWorkgroupCount = Math.max(1, Math.ceil(workgroupCount));
+  const x = Math.min(totalWorkgroupCount, maximumWorkgroupsPerDimension);
+  const y = Math.min(Math.ceil(totalWorkgroupCount / x), maximumWorkgroupsPerDimension);
+  const z = Math.ceil(totalWorkgroupCount / x / y);
+
+  if (z > maximumWorkgroupsPerDimension) {
+    throw new Error(
+      `WebGPU dispatch requires ${totalWorkgroupCount} workgroups, exceeding the 3D dispatch limit of ${maximumWorkgroupsPerDimension} per dimension`
+    );
+  }
+
+  return {x, y, z};
+}
+
+export function getWebGPUDispatchWorkgroupIndex(
+  layout: WebGPUDispatchLayout,
+  workgroupId: string = 'workgroupId'
+): string {
+  return (
+    `((${workgroupId}.z * ${layout.y}u + ${workgroupId}.y) * ` + `${layout.x}u + ${workgroupId}.x)`
+  );
+}
+
+export function getWebGPUDispatchRowIndex(
+  layout: WebGPUDispatchLayout,
+  workgroupSize: number,
+  workgroupId: string = 'workgroupId',
+  localId: string = 'localId'
+): string {
+  return (
+    `(${getWebGPUDispatchWorkgroupIndex(layout, workgroupId)} * ` +
+    `${workgroupSize}u + ${localId}.x)`
+  );
+}
+
+function getMaximumWorkgroupsPerDimension(maxWorkgroupsPerDimension?: number): number {
+  if (Number.isFinite(maxWorkgroupsPerDimension) && maxWorkgroupsPerDimension! > 0) {
+    return Math.floor(maxWorkgroupsPerDimension!);
+  }
+  return WEBGPU_MINIMUM_MAX_COMPUTE_WORKGROUPS_PER_DIMENSION;
+}

--- a/modules/gpgpu/src/operations/webgpu/common/row-transform.ts
+++ b/modules/gpgpu/src/operations/webgpu/common/row-transform.ts
@@ -6,6 +6,7 @@ import {Buffer, SignedDataType} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {ShaderModule} from '@luma.gl/shadertools';
 import {getGPUVectorBuffer, GPUTableEvaluator} from '../../../operation/gpu-table-evaluator';
+import {getWebGPUDispatchLayout, getWebGPUDispatchRowIndex} from './dispatch';
 import {getLiteralValue, getWGSLType, getZeroValue} from './helper';
 
 const WORKGROUP_SIZE = 64;
@@ -43,6 +44,10 @@ export function runRowComputation({
     TYPE: castToType,
     RESULT_LEN: output.size.toString()
   };
+  const dispatchLayout = getWebGPUDispatchLayout(
+    Math.ceil(output.length / WORKGROUP_SIZE),
+    outputBuffer.device.limits.maxComputeWorkgroupsPerDimension
+  );
 
   for (const name in inputs) {
     const input = inputs[name];
@@ -57,9 +62,10 @@ ${getOutputBinding(output, storageBindings.length)}
 ${getOutputWriter(output)}
 
 @compute @workgroup_size(${WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) id: vec3<u32>
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>
 ) {
-  let rowIndex = id.x;
+  let rowIndex = ${getWebGPUDispatchRowIndex(dispatchLayout, WORKGROUP_SIZE)};
   if (rowIndex >= ${output.length}u) {
     return;
   }
@@ -97,7 +103,7 @@ ${getComputeBlock(module.name, inputs, output, elementWise, expression)}
     .getStats(GPGPU_OPERATION_STATS)
     .get(COMPUTATION_RUNS)
     .incrementCount();
-  computation.dispatch(computePass, Math.ceil(output.length / WORKGROUP_SIZE));
+  computation.dispatch(computePass, dispatchLayout.x, dispatchLayout.y, dispatchLayout.z);
   computePass.end();
   outputBuffer.device.submit();
   computation.destroy();

--- a/modules/gpgpu/src/operations/webgpu/extent.ts
+++ b/modules/gpgpu/src/operations/webgpu/extent.ts
@@ -7,6 +7,7 @@ import {Computation} from '@luma.gl/engine';
 import {OperationHandler} from '../../operation/operation';
 import {getGPUVectorBuffer, GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
 import {bufferPool} from '../../utils/buffer-pool';
+import {getWebGPUDispatchLayout, getWebGPUDispatchWorkgroupIndex} from './common/dispatch';
 import {getWGSLType} from './common/helper';
 import {
   getInputBinding,
@@ -119,6 +120,10 @@ function runExtentPass({
   outputOffset: number;
 }): void {
   const wgslType = getWGSLType(outputType);
+  const dispatchLayout = getWebGPUDispatchLayout(
+    outputLength,
+    outputBuffer.device.limits.maxComputeWorkgroupsPerDimension
+  );
   const outputTable = new GPUTableEvaluator({
     buffer: outputBuffer,
     type: outputType,
@@ -141,7 +146,7 @@ var<workgroup> sharedMax: array<${wgslType}, ${RANDOM_ACCESS_WORKGROUP_SIZE}>;
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>
 ) {
-  let outputRowIndex = workgroupId.x;
+  let outputRowIndex = ${getWebGPUDispatchWorkgroupIndex(dispatchLayout)};
   if (outputRowIndex >= ${outputLength}u) {
     return;
   }
@@ -203,7 +208,7 @@ var<workgroup> sharedMax: array<${wgslType}, ${RANDOM_ACCESS_WORKGROUP_SIZE}>;
   computation.setBindings(bindings);
 
   const computePass = outputBuffer.device.beginComputePass({});
-  computation.dispatch(computePass, outputLength);
+  computation.dispatch(computePass, dispatchLayout.x, dispatchLayout.y, dispatchLayout.z);
   computePass.end();
   outputBuffer.device.submit();
   computation.destroy();

--- a/modules/gpgpu/src/operations/webgpu/gather.ts
+++ b/modules/gpgpu/src/operations/webgpu/gather.ts
@@ -6,6 +6,7 @@ import {Buffer} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {OperationHandler} from '../../operation/operation';
 import {getGPUVectorBuffer, GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {getWebGPUDispatchLayout, getWebGPUDispatchRowIndex} from './common/dispatch';
 import {getLiteralValue, getWGSLType} from './common/helper';
 import {
   getInputBinding,
@@ -29,6 +30,10 @@ export const gather: OperationHandler<{
   if (!sourceValues.isConstant) {
     bindings.push({name: 'sourceValues', input: sourceValues, index: bindings.length});
   }
+  const dispatchLayout = getWebGPUDispatchLayout(
+    Math.ceil(output.length / RANDOM_ACCESS_WORKGROUP_SIZE),
+    target.device.limits.maxComputeWorkgroupsPerDimension
+  );
 
   const source = /* wgsl */ `
 ${bindings.map(({name, input, index}) => getInputBinding(name, input, index)).join('\n')}
@@ -40,9 +45,10 @@ ${getZeroResultFunction(output.type, output.size)}
 ${getGatherFunction(ids.type, output.type, output.size, sourceValues.length)}
 
 @compute @workgroup_size(${RANDOM_ACCESS_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) id: vec3<u32>
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>
 ) {
-  let rowIndex = id.x;
+  let rowIndex = ${getWebGPUDispatchRowIndex(dispatchLayout, RANDOM_ACCESS_WORKGROUP_SIZE)};
   if (rowIndex >= ${output.length}u) {
     return;
   }
@@ -79,7 +85,7 @@ ${getGatherFunction(ids.type, output.type, output.size, sourceValues.length)}
   computation.setBindings(computationBindings);
 
   const computePass = target.device.beginComputePass({});
-  computation.dispatch(computePass, Math.ceil(output.length / RANDOM_ACCESS_WORKGROUP_SIZE));
+  computation.dispatch(computePass, dispatchLayout.x, dispatchLayout.y, dispatchLayout.z);
   computePass.end();
   target.device.submit();
   computation.destroy();

--- a/modules/gpgpu/src/operations/webgpu/segmented-map.ts
+++ b/modules/gpgpu/src/operations/webgpu/segmented-map.ts
@@ -6,6 +6,7 @@ import {Buffer} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {OperationHandler} from '../../operation/operation';
 import {getGPUVectorBuffer, GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {getWebGPUDispatchLayout, getWebGPUDispatchRowIndex} from './common/dispatch';
 import {
   getInputBinding,
   getOutputBinding,
@@ -20,6 +21,10 @@ export const segmentedMap: OperationHandler<{
 }> = async ({inputs, output, target}) => {
   const {segments} = inputs;
   const bindings = segments.isConstant ? [] : [{name: 'segments', input: segments, index: 0}];
+  const dispatchLayout = getWebGPUDispatchLayout(
+    Math.ceil(output.length / RANDOM_ACCESS_WORKGROUP_SIZE),
+    target.device.limits.maxComputeWorkgroupsPerDimension
+  );
   const source = /* wgsl */ `
 ${bindings.map(({name, input, index}) => getInputBinding(name, input, index)).join('\n')}
 ${getTableAccessor('segments', segments, 'uint32')}
@@ -28,9 +33,10 @@ ${getOutputWriter(output)}
 ${getSegmentedMapFunction(segments.length)}
 
 @compute @workgroup_size(${RANDOM_ACCESS_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) id: vec3<u32>
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>
 ) {
-  let rowIndex = id.x;
+  let rowIndex = ${getWebGPUDispatchRowIndex(dispatchLayout, RANDOM_ACCESS_WORKGROUP_SIZE)};
   if (rowIndex >= ${output.length}u) {
     return;
   }
@@ -62,7 +68,7 @@ ${getSegmentedMapFunction(segments.length)}
   computation.setBindings(computationBindings);
 
   const computePass = target.device.beginComputePass({});
-  computation.dispatch(computePass, Math.ceil(output.length / RANDOM_ACCESS_WORKGROUP_SIZE));
+  computation.dispatch(computePass, dispatchLayout.x, dispatchLayout.y, dispatchLayout.z);
   computePass.end();
   target.device.submit();
   computation.destroy();

--- a/modules/gpgpu/src/operations/webgpu/sequence.ts
+++ b/modules/gpgpu/src/operations/webgpu/sequence.ts
@@ -4,6 +4,7 @@
 
 import {Computation} from '@luma.gl/engine';
 import {OperationHandler} from '../../operation/operation';
+import {getWebGPUDispatchLayout, getWebGPUDispatchRowIndex} from './common/dispatch';
 
 const WORKGROUP_SIZE = 64;
 
@@ -12,13 +13,18 @@ export const sequence: OperationHandler<{start: number; step: number}> = async (
   output,
   target
 }) => {
+  const dispatchLayout = getWebGPUDispatchLayout(
+    Math.ceil(output.length / WORKGROUP_SIZE),
+    target.device.limits.maxComputeWorkgroupsPerDimension
+  );
   const source = `\
 @group(0) @binding(0) var<storage, read_write> result: array<i32>;
 
 @compute @workgroup_size(${WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) id: vec3<u32>
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>
 ) {
-  let rowIndex = id.x;
+  let rowIndex = ${getWebGPUDispatchRowIndex(dispatchLayout, WORKGROUP_SIZE)};
   if (rowIndex >= ${output.length}u) {
     return;
   }
@@ -37,7 +43,7 @@ export const sequence: OperationHandler<{start: number; step: number}> = async (
 
   computation.setBindings({result: target});
   const computePass = target.device.beginComputePass({});
-  computation.dispatch(computePass, Math.ceil(output.length / WORKGROUP_SIZE));
+  computation.dispatch(computePass, dispatchLayout.x, dispatchLayout.y, dispatchLayout.z);
   computePass.end();
   target.device.submit();
   computation.destroy();

--- a/modules/gpgpu/test/gpu-vector/gpu-vector-from-gpu-vector.node.spec.ts
+++ b/modules/gpgpu/test/gpu-vector/gpu-vector-from-gpu-vector.node.spec.ts
@@ -6,7 +6,7 @@ import {Buffer, NativeFloat16ArrayConstructor, type Device} from '@luma.gl/core'
 import {GPUTableEvaluator} from '@luma.gl/gpgpu';
 import {GPUVector, type GPUVectorFormat} from '@luma.gl/tables';
 import {NullDevice} from '@luma.gl/test-utils';
-import {expect, test} from 'vitest';
+import {expect, test, vi} from 'vitest';
 
 test('GPUTableEvaluator.fromGPUVector accepts packed Float16 vectors', () => {
   const device = new NullDevice({});
@@ -69,13 +69,61 @@ test('GPUTableEvaluator.fromGPUVector validates packed numeric vectors', () => {
   device.destroy();
 });
 
+test('GPUTableEvaluator.readValue only reads requested rows from GPU buffers', async () => {
+  const device = new NullDevice({});
+  const packed = makeFloat32Vector(device, 'packed-values', [10, 11, 20, 21, 30, 31, 40, 41], 2);
+  const strided = makeFloat32Vector(
+    device,
+    'strided-values',
+    [10, 11, -1, 20, 21, -1, 30, 31, -1],
+    2,
+    {
+      byteStride: 12,
+      rowByteLength: 8
+    }
+  );
+
+  const packedEvaluator = GPUTableEvaluator.fromGPUVector(packed);
+  const stridedEvaluator = new GPUTableEvaluator({
+    id: 'strided-evaluator',
+    type: 'float32',
+    size: 2,
+    stride: 12,
+    length: 3,
+    buffer: strided.data[0].buffer,
+    format: 'float32x2'
+  });
+
+  const packedBuffer = packed.data[0].buffer;
+  const stridedBuffer = strided.data[0].buffer;
+  const packedReadAsyncSpy = vi.spyOn(packedBuffer, 'readAsync');
+  const stridedReadAsyncSpy = vi.spyOn(stridedBuffer, 'readAsync');
+
+  expect(Array.from(await packedEvaluator.readValue(1, 3))).toEqual([20, 21, 30, 31]);
+  expect(packedReadAsyncSpy).toHaveBeenCalledWith(8, 16);
+
+  expect(Array.from(await stridedEvaluator.readValue(1, 3))).toEqual([20, 21, 30, 31]);
+  expect(stridedReadAsyncSpy).toHaveBeenCalledWith(12, 20);
+
+  packedReadAsyncSpy.mockRestore();
+  stridedReadAsyncSpy.mockRestore();
+  packedEvaluator.destroy();
+  stridedEvaluator.destroy();
+  packed.destroy();
+  strided.destroy();
+  device.destroy();
+});
+
 function makeFloat32Vector(
   device: Device,
   name: string,
   values: number[],
-  stride: number
+  stride: number,
+  options: {byteStride?: number; rowByteLength?: number} = {}
 ): GPUVector {
   const data = new Float32Array(values);
+  const byteStride = options.byteStride ?? stride * Float32Array.BYTES_PER_ELEMENT;
+  const rowByteLength = options.rowByteLength ?? stride * Float32Array.BYTES_PER_ELEMENT;
   const buffer = device.createBuffer({
     usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
     data
@@ -87,8 +135,8 @@ function makeFloat32Vector(
     format: getFloat32VectorFormat(stride),
     length: values.length / stride,
     stride,
-    byteStride: stride * Float32Array.BYTES_PER_ELEMENT,
-    rowByteLength: stride * Float32Array.BYTES_PER_ELEMENT,
+    byteStride,
+    rowByteLength,
     ownsBuffer: true
   });
 }

--- a/modules/gpgpu/test/operations/add.spec.ts
+++ b/modules/gpgpu/test/operations/add.spec.ts
@@ -84,8 +84,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/arithmetic.spec.ts
+++ b/modules/gpgpu/test/operations/arithmetic.spec.ts
@@ -143,8 +143,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
         const stat = getRunStats(device);
         const beforeCount = stat?.count ?? 0;
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected, 1e-6)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected, 1e-6)).toBe(null);
         if (stat) {
           expect(stat.count - beforeCount).toBe(testCase.runCount ?? 1);
         }

--- a/modules/gpgpu/test/operations/divide.spec.ts
+++ b/modules/gpgpu/test/operations/divide.spec.ts
@@ -91,8 +91,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected, 1e-7)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected, 1e-7)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/dot.spec.ts
+++ b/modules/gpgpu/test/operations/dot.spec.ts
@@ -42,8 +42,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected, 1e-6)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected, 1e-6)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/equal-all.spec.ts
+++ b/modules/gpgpu/test/operations/equal-all.spec.ts
@@ -42,8 +42,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/extent.spec.ts
+++ b/modules/gpgpu/test/operations/extent.spec.ts
@@ -43,8 +43,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/fixtures.ts
+++ b/modules/gpgpu/test/operations/fixtures.ts
@@ -31,11 +31,11 @@ export type TestData =
     };
 
 /** Check table value against definition, returns error if any */
-export function verifyTableValue(
+export async function verifyTableValue(
   table: GPUTableEvaluator,
   expected: TestData,
   epsilon?: number
-): string | null {
+): Promise<string | null> {
   const size = table.size;
 
   if ('type' in expected && expected.type !== table.type) {
@@ -48,7 +48,7 @@ export function verifyTableValue(
     return `isConstant does not match. Expected: ${'constant' in expected}, actual: ${table.isConstant}`;
   }
 
-  const actual = table.value;
+  const actual = table.isConstant ? table.value : await table.readValue();
   const target = 'constant' in expected ? (expected.constant as number[]) : expected.value;
   if (!actual) {
     return `Unexpected empty result`;

--- a/modules/gpgpu/test/operations/fround.spec.ts
+++ b/modules/gpgpu/test/operations/fround.spec.ts
@@ -109,8 +109,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           size: testCase.size * 2
         };
         await cleanEvaluate(device, output);
-        await output.readValue();
-        expect(verifyTableValue(output, expected)).toBe(null);
+        expect(await verifyTableValue(output, expected)).toBe(null);
         output.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/gather.spec.ts
+++ b/modules/gpgpu/test/operations/gather.spec.ts
@@ -59,8 +59,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/interleave.spec.ts
+++ b/modules/gpgpu/test/operations/interleave.spec.ts
@@ -71,8 +71,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/length.spec.ts
+++ b/modules/gpgpu/test/operations/length.spec.ts
@@ -36,8 +36,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected, 1e-6)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected, 1e-6)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/multiply.spec.ts
+++ b/modules/gpgpu/test/operations/multiply.spec.ts
@@ -92,8 +92,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/segmented-map.spec.ts
+++ b/modules/gpgpu/test/operations/segmented-map.spec.ts
@@ -77,8 +77,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/select.spec.ts
+++ b/modules/gpgpu/test/operations/select.spec.ts
@@ -52,8 +52,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected, 1e-6)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected, 1e-6)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/sequence.spec.ts
+++ b/modules/gpgpu/test/operations/sequence.spec.ts
@@ -37,8 +37,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/operations/subtract.spec.ts
+++ b/modules/gpgpu/test/operations/subtract.spec.ts
@@ -92,8 +92,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
           return;
         }
         await cleanEvaluate(device, testCase);
-        await testCase.eval.readValue();
-        expect(verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
+        expect(await verifyTableValue(testCase.eval, testCase.expected)).toBe(null);
         testCase.eval.destroy();
       });
     }

--- a/modules/gpgpu/test/utils/webgpu-dispatch.spec.ts
+++ b/modules/gpgpu/test/utils/webgpu-dispatch.spec.ts
@@ -1,0 +1,18 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {getWebGPUDispatchLayout} from '../../src/operations/webgpu/common/dispatch';
+
+test('getWebGPUDispatchLayout expands into y when workgroups exceed x capacity', () => {
+  expect(getWebGPUDispatchLayout(5, 4)).toEqual({x: 4, y: 2, z: 1});
+});
+
+test('getWebGPUDispatchLayout expands into z when workgroups exceed x and y capacity', () => {
+  expect(getWebGPUDispatchLayout(17, 4)).toEqual({x: 4, y: 4, z: 2});
+});
+
+test('getWebGPUDispatchLayout rejects counts beyond the 3D dispatch limit', () => {
+  expect(() => getWebGPUDispatchLayout(65, 4)).toThrow(/exceeding the 3D dispatch limit/);
+});


### PR DESCRIPTION
- `GPUTableEvaluator.readValue` only reads requested buffer
- WebGPU backend dispatches larger thread counts with correct dimensions
- Unit tests