### PR TITLE
feat(gpgpu) Backend registration changes

### DIFF
--- a/docs/api-reference/gpgpu/README.md
+++ b/docs/api-reference/gpgpu/README.md
@@ -21,7 +21,7 @@ Interleaving two buffers together
 ```ts
 import {luma} from '@luma.gl/core';
 import {webglAdapter} from '@luma.gl/webgl';
-import {GPUTableEvaluator, backendRegistry, webglBackend, add, interleave} from '@luma.gl/gpgpu';
+import {GPUTableEvaluator, add, interleave} from '@luma.gl/gpgpu';
 
 const inputA = GPUTableEvaluator.fromArray(new Float32Array([0, 0, 0, 1, 0, 0]), {size: 3});
 const inputB = GPUTableEvaluator.fromArray(new Float32Array([10, 20]), {size: 1});
@@ -30,8 +30,8 @@ const output = interleave(inputA, inputB);
 // Operations can be chained
 const outputAlt = interleave(inputA, add(inputB, GPUTableEvaluator.fromConstant(1)));
 
-// No computation is performed until the output is evaluated
-backendRegistry.add('webgl', webglBackend);
+// No computation is performed until the output is evaluated.
+// The WebGL backend is loaded automatically on first use.
 
 const device = await luma.createDevice({
   type: 'webgl',
@@ -43,14 +43,42 @@ const outputVector = await output.evaluate(device);
 
 ## BackendRegistry
 
-The `backendRegistry` allows apps to include only the implementations for the device types that they wish to support. The CPU backend is registered by default. Register `webglBackend` or `webgpuBackend` before evaluating operation-backed tables on those device types.
+The `backendRegistry` dispatches lazy operations to the backend module for the
+evaluation device. The CPU backend is available by default. If no backend has
+been registered for a `webgl` or `webgpu` device, `@luma.gl/gpgpu`
+automatically loads the matching backend with a dynamic import, so built-in
+backend registration is not required.
 
 ```ts
-import {backendRegistry, webglBackend, webgpuBackend} from '@luma.gl/gpgpu';
+const outputVector = await output.evaluate(device);
+```
+
+Backend modules are also available from dedicated endpoints. Use these imports
+when you want to eagerly load a backend or register a custom subset of operation
+handlers:
+
+```ts
+import {backendRegistry} from '@luma.gl/gpgpu';
+import * as webglBackend from '@luma.gl/gpgpu/webgl';
+import * as webgpuBackend from '@luma.gl/gpgpu/webgpu';
 
 backendRegistry.add('webgl', webglBackend);
 backendRegistry.add('webgpu', webgpuBackend);
 ```
+
+The same endpoints export individual backend operation handlers, so applications
+can choose only the handlers they need. When registering a subset, only those
+operations can be evaluated for that device type:
+
+```ts
+import {backendRegistry} from '@luma.gl/gpgpu';
+import {interleave, swizzle} from '@luma.gl/gpgpu/webgl';
+
+backendRegistry.add('webgl', {interleave, swizzle});
+```
+
+The CPU backend can be imported from `@luma.gl/gpgpu/cpu` when explicitly
+registering CPU handlers for another device type.
 
 ## Concepts
 

--- a/docs/api-reference/gpgpu/operations.md
+++ b/docs/api-reference/gpgpu/operations.md
@@ -14,7 +14,12 @@ Each operation returns a new [`GPUTableEvaluator`](/docs/api-reference/gpgpu/gpu
 - Output evaluation is backend-driven through `backendRegistry`.
 - Operations can be chained to build larger compute graphs.
 - Operation result evaluators own their materialized immutable output buffer.
-- The CPU backend is registered by default. Register `webglBackend` or `webgpuBackend` before evaluating on those device types.
+- The CPU backend is available by default. If no backend has been registered for
+  a WebGL or WebGPU device, the matching backend is loaded automatically on
+  first evaluation.
+- Backend operation handlers can also be imported from `@luma.gl/gpgpu/webgl`,
+  `@luma.gl/gpgpu/webgpu`, or `@luma.gl/gpgpu/cpu` for eager loading or custom
+  subset registration.
 
 ## Arithmetic
 

--- a/examples/showcase/gpgpu/src/app.ts
+++ b/examples/showcase/gpgpu/src/app.ts
@@ -3,13 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {luma, type Device} from '@luma.gl/core';
-import {
-  backendRegistry,
-  cleanEvaluate,
-  type GPUTableEvaluator,
-  webglBackend,
-  webgpuBackend
-} from '@luma.gl/gpgpu';
+import {cleanEvaluate, type GPUTableEvaluator} from '@luma.gl/gpgpu';
 import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 import {makeShowcaseData} from './arrow-data';
@@ -197,8 +191,6 @@ async function makeOutputTableColumn(
 
 async function getEvaluationDevice(): Promise<Device> {
   if (!evaluationDevicePromise) {
-    backendRegistry.add('webgpu', webgpuBackend);
-    backendRegistry.add('webgl', webglBackend);
     evaluationDevicePromise = luma.createDevice({
       adapters: [webgpuAdapter, webgl2Adapter],
       createCanvasContext:

--- a/modules/gpgpu/package.json
+++ b/modules/gpgpu/package.json
@@ -23,6 +23,21 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./cpu": {
+      "types": "./dist/operations/cpu/index.d.ts",
+      "import": "./dist/operations/cpu/index.js",
+      "require": "./dist/operations/cpu/index.cjs"
+    },
+    "./webgl": {
+      "types": "./dist/operations/webgl/index.d.ts",
+      "import": "./dist/operations/webgl/index.js",
+      "require": "./dist/operations/webgl/index.cjs"
+    },
+    "./webgpu": {
+      "types": "./dist/operations/webgpu/index.d.ts",
+      "import": "./dist/operations/webgpu/index.js",
+      "require": "./dist/operations/webgpu/index.cjs"
     }
   },
   "files": [

--- a/modules/gpgpu/src/index.ts
+++ b/modules/gpgpu/src/index.ts
@@ -39,7 +39,4 @@ export {swizzle} from './operations/swizzle';
 
 // Backends
 export {backendRegistry} from './operation/backend-registry';
-export {webglBackend} from './operations/webgl/index';
-export {webgpuBackend} from './operations/webgpu/index';
-export {cpuBackend} from './operations/cpu/index';
 export {cleanEvaluate} from './utils/clean-evaluate';

--- a/modules/gpgpu/src/operation/backend-registry.ts
+++ b/modules/gpgpu/src/operation/backend-registry.ts
@@ -4,7 +4,7 @@
 
 import {log} from '@luma.gl/core';
 import type {OperationHandler} from './operation';
-import {cpuBackend} from '../operations/cpu/index';
+import * as cpuBackend from '../operations/cpu/index';
 
 /** Map from operation names to backend-specific operation handlers. */
 export type BackendModule = Record<string, OperationHandler>;
@@ -16,8 +16,9 @@ export type BackendModule = Record<string, OperationHandler>;
  * unused WebGL or WebGPU implementations can be tree-shaken or loaded lazily.
  */
 class BackendRegistry {
-  private _loading: Promise<BackendModule>[] = [];
-  private _modules: {[deviceType: string]: BackendModule} = {};
+  private _modules: {[deviceType: string]: BackendModule | Promise<BackendModule>} = {
+    cpu: cpuBackend
+  };
 
   /**
    * Registers operation handlers for a device type.
@@ -25,20 +26,20 @@ class BackendRegistry {
    * @param deviceType - Device type such as `'webgl'`, `'webgpu'`, or `'cpu'`.
    * @param moduleOrPromise - Backend module or a promise that resolves to one.
    */
-  add(deviceType: string, moduleOrPromise: BackendModule | Promise<BackendModule>) {
+  add(
+    deviceType: string,
+    moduleOrPromise: BackendModule | Promise<BackendModule>
+  ): Promise<BackendModule> {
     const loader = Promise.resolve(moduleOrPromise);
-    const pendingLoaders = this._loading;
-    pendingLoaders.push(loader);
+    this._modules[deviceType] = loader;
     loader
       .then(module => {
         this._modules[deviceType] = module;
       })
       .catch(ex => {
         log.error(`Failed to register ${deviceType} backend: ${ex}`)();
-      })
-      .finally(() => {
-        pendingLoaders.splice(pendingLoaders.indexOf(loader), 1);
       });
+    return loader;
   }
 
   /**
@@ -47,17 +48,21 @@ class BackendRegistry {
    * Pending async backend registrations are awaited before lookup.
    */
   async get(deviceType: string, operationName: string): Promise<OperationHandler> {
-    if (this._loading.length) {
-      await Promise.all(this._loading);
-    }
-    const module = this._modules[deviceType];
+    let module = this._modules[deviceType];
     if (!module) {
-      throw new Error(`${deviceType} backend not registered`);
+      if (deviceType === 'webgl') {
+        module = this.add('webgl', import('../operations/webgl/index'));
+      } else if (deviceType === 'webgpu') {
+        module = this.add('webgpu', import('../operations/webgpu/index'));
+      } else {
+        throw new Error(`${deviceType} backend not registered`);
+      }
     }
-    if (!(operationName in module)) {
+    const resolvedModule = await module;
+    if (!(operationName in resolvedModule)) {
       throw new Error(`${deviceType} backend does not implement ${operationName}`);
     }
-    return module[operationName];
+    return resolvedModule[operationName];
   }
 
   /** Removes all registered backend modules. Primarily intended for tests. */
@@ -73,4 +78,3 @@ class BackendRegistry {
  * devices.
  */
 export const backendRegistry = new BackendRegistry();
-backendRegistry.add('cpu', cpuBackend);

--- a/modules/gpgpu/src/operations/cpu/index.ts
+++ b/modules/gpgpu/src/operations/cpu/index.ts
@@ -12,7 +12,7 @@ import {sequence} from './sequence';
 import {swizzle} from './swizzle';
 
 /** CPU fallback backend for built-in GPGPU operations. Registered by default. */
-export const cpuBackend = {
+export {
   arithmetic,
   dot,
   equalAll,

--- a/modules/gpgpu/src/operations/webgl/index.ts
+++ b/modules/gpgpu/src/operations/webgl/index.ts
@@ -12,7 +12,7 @@ import {sequence} from './sequence';
 import {swizzle} from './swizzle';
 
 /** WebGL backend for built-in GPGPU operations, implemented with transform feedback. */
-export const webglBackend = {
+export {
   arithmetic,
   dot,
   equalAll,

--- a/modules/gpgpu/src/operations/webgpu/index.ts
+++ b/modules/gpgpu/src/operations/webgpu/index.ts
@@ -12,7 +12,7 @@ import {sequence} from './sequence';
 import {swizzle} from './swizzle';
 
 /** WebGPU backend for built-in GPGPU operations, implemented with compute pipelines. */
-export const webgpuBackend = {
+export {
   arithmetic,
   dot,
   equalAll,

--- a/modules/gpgpu/test/operations/fixtures.ts
+++ b/modules/gpgpu/test/operations/fixtures.ts
@@ -3,18 +3,11 @@
 // Copyright (c) vis.gl contributors
 import {SignedDataType, Device} from '@luma.gl/core';
 import {TypedArray, equals} from '@math.gl/core';
-import {
-  GPUTableEvaluator,
-  backendRegistry,
-  webglBackend,
-  webgpuBackend,
-  cpuBackend
-} from '@luma.gl/gpgpu';
+import {GPUTableEvaluator, backendRegistry} from '@luma.gl/gpgpu';
+import * as cpuBackend from '@luma.gl/gpgpu/operations/cpu';
 import {Stat} from '@probe.gl/stats';
 import {getTestDevice as _getTestDevice} from '@luma.gl/test-utils';
 
-backendRegistry.add('webgl', webglBackend);
-backendRegistry.add('webgpu', webgpuBackend);
 backendRegistry.add('null', cpuBackend);
 
 export type TestData =


### PR DESCRIPTION
- Backend registration for built-in device types is no longer required. WebGL and WebGPU devices automatically fallback to the respective backend with dynamic import (separate bundle, only loaded on demand)
- Backend registry still exposed for custom device types and/or operations
- Backend imports are moved to dedicated endpoints: 

  ```ts
  // before
  import {webgpuBackend} from '@luma.gl/webgpu';
  // after
  import * as webgpuBackend from '@luma.gl/gpgpu/webgpu';
  ```

  This also allows users to pick and choose only the operations they need.