### PR TITLE
feat(gpgpu): Evaluators focus on GPUData, not GPUVector

### DIFF
--- a/docs/api-reference/gpgpu/README.md
+++ b/docs/api-reference/gpgpu/README.md
@@ -10,7 +10,7 @@ The `@luma.gl/gpgpu` module performs GPU-based data transformation.
 
 - [`Operations`](/docs/api-reference/gpgpu/operations)
 - [`Custom Operations`](/docs/api-reference/gpgpu/custom-operation)
-- [`GPUDataEvaluator`](/docs/api-reference/gpgpu/gpu-data-evaluator)
+- [`GPU Evaluators`](/docs/api-reference/gpgpu/gpu-data-evaluator)
 - [`cleanEvaluate`](/docs/api-reference/gpgpu/clean-evaluate)
 
 ## Installing
@@ -101,7 +101,7 @@ registering CPU handlers for another device type.
 
 - [`Operations`](/docs/api-reference/gpgpu/operations) documents the supported lazy compute operations such as `add()`, `interleave()`, and `fround()`.
 - [`Custom Operations`](/docs/api-reference/gpgpu/custom-operation) shows how to define lazy operations and register backend handlers.
-- [`GPUDataEvaluator`](/docs/api-reference/gpgpu/gpu-data-evaluator) represents one packed GPUData chunk for lazy GPGPU operations. `GPUDataEvaluator` remains an alias, and `GPUVectorEvaluator` maps the same transform over preserved `GPUVector.data[]` chunks.
+- [`GPU Evaluators`](/docs/api-reference/gpgpu/gpu-data-evaluator) documents `GPUDataEvaluator` for one packed `GPUData` chunk and `GPUVectorEvaluator` for chunk-preserving `GPUVector.data[]` transforms.
 - [`cleanEvaluate`](/docs/api-reference/gpgpu/clean-evaluate) evaluates final result tables and cleans up intermediate dependencies in one step.
 
 ## Related Engine APIs

--- a/docs/api-reference/gpgpu/README.md
+++ b/docs/api-reference/gpgpu/README.md
@@ -10,7 +10,7 @@ The `@luma.gl/gpgpu` module performs GPU-based data transformation.
 
 - [`Operations`](/docs/api-reference/gpgpu/operations)
 - [`Custom Operations`](/docs/api-reference/gpgpu/custom-operation)
-- [`GPUTableEvaluator`](/docs/api-reference/gpgpu/gpu-table)
+- [`GPUDataEvaluator`](/docs/api-reference/gpgpu/gpu-data-evaluator)
 - [`cleanEvaluate`](/docs/api-reference/gpgpu/clean-evaluate)
 
 ## Installing
@@ -26,14 +26,14 @@ Interleaving two buffers together
 ```ts
 import {luma} from '@luma.gl/core';
 import {webglAdapter} from '@luma.gl/webgl';
-import {GPUTableEvaluator, add, interleave} from '@luma.gl/gpgpu';
+import {GPUDataEvaluator, add, interleave} from '@luma.gl/gpgpu';
 
-const inputA = GPUTableEvaluator.fromArray(new Float32Array([0, 0, 0, 1, 0, 0]), {size: 3});
-const inputB = GPUTableEvaluator.fromArray(new Float32Array([10, 20]), {size: 1});
+const inputA = GPUDataEvaluator.fromArray(new Float32Array([0, 0, 0, 1, 0, 0]), {size: 3});
+const inputB = GPUDataEvaluator.fromArray(new Float32Array([10, 20]), {size: 1});
 const output = interleave(inputA, inputB);
 
 // Operations can be chained
-const outputAlt = interleave(inputA, add(inputB, GPUTableEvaluator.fromConstant(1)));
+const outputAlt = interleave(inputA, add(inputB, GPUDataEvaluator.fromConstant(1)));
 
 // No computation is performed until the output is evaluated.
 // The WebGL backend is loaded automatically on first use.
@@ -101,7 +101,7 @@ registering CPU handlers for another device type.
 
 - [`Operations`](/docs/api-reference/gpgpu/operations) documents the supported lazy compute operations such as `add()`, `interleave()`, and `fround()`.
 - [`Custom Operations`](/docs/api-reference/gpgpu/custom-operation) shows how to define lazy operations and register backend handlers.
-- [`GPUTableEvaluator`](/docs/api-reference/gpgpu/gpu-table) represents structured input and output data for lazy GPGPU operations. It can borrow packed single-chunk `GPUVector` inputs from `@luma.gl/tables`.
+- [`GPUDataEvaluator`](/docs/api-reference/gpgpu/gpu-data-evaluator) represents one packed GPUData chunk for lazy GPGPU operations. `GPUDataEvaluator` remains an alias, and `GPUVectorEvaluator` maps the same transform over preserved `GPUVector.data[]` chunks.
 - [`cleanEvaluate`](/docs/api-reference/gpgpu/clean-evaluate) evaluates final result tables and cleans up intermediate dependencies in one step.
 
 ## Related Engine APIs

--- a/docs/api-reference/gpgpu/clean-evaluate.md
+++ b/docs/api-reference/gpgpu/clean-evaluate.md
@@ -4,16 +4,16 @@ import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
 
 <GPGPUDocsTabs active="clean-evaluate" />
 
-`cleanEvaluate()` is a small utility for evaluating one or more result tables while cleaning up intermediate `GPUTableEvaluator` dependencies that are no longer needed.
+`cleanEvaluate()` is a small utility for evaluating one or more result evaluators while cleaning up intermediate `GPUDataEvaluator` dependencies that are no longer needed. `GPUDataEvaluator` remains the compatibility alias, and `GPUVectorEvaluator` roots are also supported.
 
 This is most useful when you build a lazy operation graph inline and only want to keep the final output evaluators alive.
 
 ## Usage
 
 ```ts
-import {GPUTableEvaluator, add, cleanEvaluate} from '@luma.gl/gpgpu';
+import {GPUDataEvaluator, add, cleanEvaluate} from '@luma.gl/gpgpu';
 
-const positions = GPUTableEvaluator.fromArray(
+const positions = GPUDataEvaluator.fromArray(
   new Float32Array([
     0, 0, 0,
     1, 0, 0
@@ -21,7 +21,7 @@ const positions = GPUTableEvaluator.fromArray(
   {size: 3}
 );
 
-const offset = GPUTableEvaluator.fromConstant([1, 2, 3]);
+const offset = GPUDataEvaluator.fromConstant([1, 2, 3]);
 const translated = add(positions, offset);
 
 await cleanEvaluate(device, {translated});
@@ -36,7 +36,7 @@ translated.destroy();
 
 ```ts
 function cleanEvaluate<
-  ResultT extends GPUTableEvaluator | GPUTableEvaluator[] | Record<string, unknown>
+  ResultT extends GPUDataEvaluator | GPUVectorEvaluator | Array<GPUDataEvaluator | GPUVectorEvaluator> | Record<string, unknown>
 >(device: Device, result: ResultT): Promise<ResultT>;
 ```
 
@@ -45,13 +45,13 @@ function cleanEvaluate<
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `device` | `Device` | The device used to evaluate the returned tables. |
-| `result` | `GPUTableEvaluator \| GPUTableEvaluator[] \| Record<string, unknown>` | The final evaluator or evaluators that should remain alive after evaluation. |
+| `result` | `GPUDataEvaluator \| GPUVectorEvaluator \| Array<GPUDataEvaluator \| GPUVectorEvaluator> \| Record<string, unknown>` | The final evaluator or evaluators that should remain alive after evaluation. |
 
 ## Behavior
 
 `cleanEvaluate()`:
 
-- finds all `GPUTableEvaluator` instances directly referenced by `result`
+- finds all `GPUDataEvaluator` instances directly referenced by `result`
 - evaluates those root evaluators
 - walks their dependency graph through `source`
 - destroys dependency evaluators whose GPU buffers are not also used by the root evaluators

--- a/docs/api-reference/gpgpu/clean-evaluate.md
+++ b/docs/api-reference/gpgpu/clean-evaluate.md
@@ -4,7 +4,7 @@ import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
 
 <GPGPUDocsTabs active="clean-evaluate" />
 
-`cleanEvaluate()` is a small utility for evaluating one or more result evaluators while cleaning up intermediate `GPUDataEvaluator` dependencies that are no longer needed. `GPUDataEvaluator` remains the compatibility alias, and `GPUVectorEvaluator` roots are also supported.
+`cleanEvaluate()` evaluates one or more result evaluators while cleaning up intermediate `GPUDataEvaluator` dependencies that are no longer needed. `GPUVectorEvaluator` roots are also supported.
 
 This is most useful when you build a lazy operation graph inline and only want to keep the final output evaluators alive.
 
@@ -51,7 +51,7 @@ function cleanEvaluate<
 
 `cleanEvaluate()`:
 
-- finds all `GPUDataEvaluator` instances directly referenced by `result`
+- finds all `GPUDataEvaluator` and `GPUVectorEvaluator` instances directly referenced by `result`
 - evaluates those root evaluators
 - walks their dependency graph through `source`
 - destroys dependency evaluators whose GPU buffers are not also used by the root evaluators

--- a/docs/api-reference/gpgpu/custom-operation.md
+++ b/docs/api-reference/gpgpu/custom-operation.md
@@ -328,9 +328,11 @@ const result = await projected.readValue();
 
 - `Operation.name` and the backend module key must be identical.
 - Dependencies are evaluated before the handler is called.
-- WebGPU compute handlers bind input tables as storage buffers. Buffers
+- WebGPU compute handlers bind input evaluators as storage buffers. Buffers
   materialized by `GPUDataEvaluator.evaluate()` are storage-bindable; externally
-  supplied `GPUData` or `GPUVector` buffers must also be created with storage usage.
+  supplied `GPUData` buffers must also be created with storage usage.
+- Use `GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(...)` when the same
+  custom leaf operation should run independently across preserved vector chunks.
 - Register a handler for every device type that may evaluate the operation.
 - Registering a custom backend module for `cpu`, `webgl`, or `webgpu` replaces
   the previously registered module for that device type.

--- a/docs/api-reference/gpgpu/custom-operation.md
+++ b/docs/api-reference/gpgpu/custom-operation.md
@@ -4,7 +4,7 @@ import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
 
 <GPGPUDocsTabs active="custom-operation" />
 
-Custom operations let applications add lazy `GPUTableEvaluator` operations that
+Custom operations let applications add lazy `GPUDataEvaluator` operations that
 are dispatched through `backendRegistry`, just like the built-in operations.
 
 A custom operation has two parts:
@@ -25,25 +25,25 @@ registered with `backendRegistry.add()`.
 
 ```ts
 import {
-  getGPUTableEvaluator,
-  GPUTableEvaluator,
+  getGPUDataEvaluator,
+  GPUDataEvaluator,
   Operation,
-  type GPUTableEvaluatorInput
+  type GPUDataEvaluatorInput
 } from '@luma.gl/gpgpu';
 
 type ProjectNaturalEarthInputs = {
-  coordinates: GPUTableEvaluator;
+  coordinates: GPUDataEvaluator;
 };
 
 class ProjectNaturalEarthOperation extends Operation<ProjectNaturalEarthInputs> {
   name = 'projectNaturalEarth';
 
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
-  constructor(coordinates: GPUTableEvaluator) {
+  constructor(coordinates: GPUDataEvaluator) {
     super({coordinates});
 
-    this.output = new GPUTableEvaluator({
+    this.output = new GPUDataEvaluator({
       isConstant: coordinates.isConstant,
       type: 'float32',
       size: 2,
@@ -57,8 +57,8 @@ class ProjectNaturalEarthOperation extends Operation<ProjectNaturalEarthInputs> 
   }
 }
 
-export function projectNaturalEarth(coordinates: GPUTableEvaluatorInput): GPUTableEvaluator {
-  const coordinatesTable = getGPUTableEvaluator(coordinates);
+export function projectNaturalEarth(coordinates: GPUDataEvaluatorInput): GPUDataEvaluator {
+  const coordinatesTable = getGPUDataEvaluator(coordinates);
   if (coordinatesTable.type !== 'float32' || coordinatesTable.size !== 2) {
     throw new Error('projectNaturalEarth() requires vec2<f32> longitude/latitude input');
   }
@@ -306,11 +306,11 @@ backendRegistry.add('webgpu', {
 
 ## Use the Operation
 
-Custom operations return `GPUTableEvaluator` instances, so they can be evaluated
+Custom operations return `GPUDataEvaluator` instances, so they can be evaluated
 or chained with other GPGPU operations.
 
 ```ts
-const coordinates = GPUTableEvaluator.fromArray(
+const coordinates = GPUDataEvaluator.fromArray(
   new Float32Array([
     -122.4194, 37.7749,
     -74.006, 40.7128
@@ -329,8 +329,8 @@ const result = await projected.readValue();
 - `Operation.name` and the backend module key must be identical.
 - Dependencies are evaluated before the handler is called.
 - WebGPU compute handlers bind input tables as storage buffers. Buffers
-  materialized by `GPUTableEvaluator.evaluate()` are storage-bindable; externally
-  supplied `GPUVector` buffers must also be created with storage usage.
+  materialized by `GPUDataEvaluator.evaluate()` are storage-bindable; externally
+  supplied `GPUData` or `GPUVector` buffers must also be created with storage usage.
 - Register a handler for every device type that may evaluate the operation.
 - Registering a custom backend module for `cpu`, `webgl`, or `webgpu` replaces
   the previously registered module for that device type.

--- a/docs/api-reference/gpgpu/gpu-data-evaluator.md
+++ b/docs/api-reference/gpgpu/gpu-data-evaluator.md
@@ -1,28 +1,33 @@
 import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
 
-# GPUTableEvaluator
+# GPUDataEvaluator
 
-<GPGPUDocsTabs active="gpu-table" />
+<GPGPUDocsTabs active="gpu-data-evaluator" />
 
-`GPUTableEvaluator` is the core data container in `@luma.gl/gpgpu`. It
-describes a 2D table of numeric values that can be backed by CPU data, by
-another `GPUTableEvaluator`, by a packed single-chunk `GPUVector`, or by the
-output of a lazy operation.
+`GPUDataEvaluator` is the single-chunk lazy data container in `@luma.gl/gpgpu`.
+It describes a 2D table of numeric values backed by CPU data, another
+`GPUDataEvaluator`, one packed `GPUData` chunk, a legacy packed single-chunk
+`GPUVector`, or the output of a lazy operation.
+
+`GPUDataEvaluator` remains a compatibility alias for `GPUDataEvaluator`.
+Use [`GPUVectorEvaluator`](/docs/api-reference/gpgpu/gpu-data-evaluator) when one
+transform should run independently over every `GPUData` chunk in a `GPUVector`
+without packing streaming batches together.
 
 Each row contains `size` elements of the same numeric type. Tables can represent tightly packed rows or strided data with a byte `offset` and `stride`.
 
 ## Usage
 
 ```ts
-import {GPUTableEvaluator, add} from '@luma.gl/gpgpu';
+import {GPUDataEvaluator, add} from '@luma.gl/gpgpu';
 
-const positions = GPUTableEvaluator.fromArray(new Float32Array([
+const positions = GPUDataEvaluator.fromArray(new Float32Array([
   0, 0, 0,
   1, 0, 0,
   0, 1, 0
 ]), {size: 3});
 
-const offset = GPUTableEvaluator.fromConstant([1, 2, 3]);
+const offset = GPUDataEvaluator.fromConstant([1, 2, 3]);
 const translated = add(positions, offset);
 
 await translated.evaluate(device);
@@ -31,7 +36,7 @@ const values = await translated.readValue();
 
 ## Types
 
-### `GPUTableEvaluatorProps`
+### `GPUDataEvaluatorProps`
 
 | Property | Type | Description |
 | --- | --- | --- |
@@ -42,30 +47,44 @@ const values = await translated.readValue();
 | `stride?` | `number` | Byte distance between adjacent rows. Defaults to `ValueType.BYTES_PER_ELEMENT * size`. |
 | `value?` | `TypedArray` | CPU-side data for the table. Required unless `source` is provided. |
 | `buffer?` | `Buffer` | Borrowed GPU buffer backing this evaluator. |
-| `gpuVector?` | `GPUVector` | Borrowed single-chunk numeric GPUVector resource backing this evaluator. |
+| `gpuData?` | `GPUData` | Borrowed packed numeric GPUData chunk backing this evaluator. |
+| `gpuVector?` | `GPUVector` | Borrowed legacy single-chunk numeric GPUVector resource backing this evaluator. |
 | `format?` | `GPUVectorFormat` | Optional memory format preserved for GPUVector interop. |
-| `source?` | `Operation \| GPUTableEvaluator \| null` | Lazy data source for this table. |
+| `source?` | `Operation \| GPUDataEvaluator \| null` | Lazy data source for this table. |
 | `isConstant?` | `boolean` | Whether every row shares the same value. Defaults to `false`. |
 | `length?` | `number` | Row count. Optional when `isConstant` is `true` or `value` is provided. |
 
 ## Static Methods
 
-### `GPUTableEvaluator.fromArray(value, props?): GPUTableEvaluator`
+### `GPUDataEvaluator.fromArray(value, props?): GPUDataEvaluator`
 
 Creates a table from a typed array or numeric array. When passed a plain JavaScript array, the method creates a typed array using `props.type` or `'float32'` by default.
 
 If `value` is a `Float64Array`, it is reinterpreted as `uint32` pairs so it can be used by GPU-oriented operations such as `fround()`.
 
-### `GPUTableEvaluator.fromConstant(value, type?): GPUTableEvaluator`
+### `GPUDataEvaluator.fromConstant(value, type?): GPUDataEvaluator`
 
 Creates a constant table with one shared row value. A scalar becomes a one-element row, and an array becomes a row with `value.length` elements.
 
-### `GPUTableEvaluator.fromGPUVector(vector): GPUTableEvaluator`
+### `GPUDataEvaluator.fromGPUVector(vector): GPUDataEvaluator`
 
 Creates an evaluator view over a packed numeric `GPUVector`. The input must have
 one `GPUData` chunk, a fixed non-`vertex-list` `GPUVector.format`, and tightly
 packed rows. The evaluator borrows `vector.data[0].buffer` and does not destroy
 it.
+
+### `GPUDataEvaluator.fromGPUData(data): GPUDataEvaluator`
+
+Creates an evaluator view over one packed numeric `GPUData` chunk. The input
+must have a fixed non-`vertex-list` `GPUData.format` and tightly packed rows.
+The evaluator borrows `data.buffer` and does not destroy it.
+
+### `GPUVectorEvaluator.fromGPUVector(vector): GPUVectorEvaluator`
+
+Creates a chunk-preserving vector evaluator over one packed numeric `GPUVector`.
+Use `.mapGPUData(transform)` to build one `GPUDataEvaluator` transform per
+preserved `GPUData` chunk, then call `.evaluate(device)` to materialize one
+output `GPUVector` with matching chunk boundaries.
 
 ## Properties
 
@@ -111,7 +130,7 @@ Materialized `Buffer` backing the table. Accessing this before `evaluate()` thro
 
 ## Methods
 
-### `constructor(props: GPUTableEvaluatorProps)`
+### `constructor(props: GPUDataEvaluatorProps)`
 
 Creates a table from explicit layout and source information.
 
@@ -135,9 +154,12 @@ Releases any cached GPU buffer and prevents future evaluation.
 
 ## Remarks
 
-- `GPUTableEvaluator` is immutable in shape. To produce a new table, create another `GPUTableEvaluator` or use an operation that returns one.
+- `GPUDataEvaluator` is immutable in shape. To produce a new table, create another `GPUDataEvaluator` or use an operation that returns one.
 - Evaluation is lazy. Creating operation chains does not allocate GPU resources until `evaluate()` is called on an output table.
 - Operation outputs are evaluators backed by immutable materialized buffers, not scratch buffers.
-- `GPUVector` inputs are borrowed through their `GPUData` buffers; operation
-  outputs own their materialized `GPUVector` backing resources.
+- `GPUData` and legacy single-chunk `GPUVector` inputs are borrowed through their
+  `GPUData` buffers; operation outputs own their materialized `GPUVector`
+  backing resources.
+- Streaming code should use `GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(...)`
+  when the same lazy transform must run across every preserved GPUData chunk.
 - Constant tables are useful for broadcasting values across every row of a non-constant input.

--- a/docs/api-reference/gpgpu/gpu-data-evaluator.md
+++ b/docs/api-reference/gpgpu/gpu-data-evaluator.md
@@ -1,40 +1,55 @@
 import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
 
-# GPUDataEvaluator
+# GPU Evaluators
 
 <GPGPUDocsTabs active="gpu-data-evaluator" />
 
-`GPUDataEvaluator` is the single-chunk lazy data container in `@luma.gl/gpgpu`.
-It describes a 2D table of numeric values backed by CPU data, another
-`GPUDataEvaluator`, one packed `GPUData` chunk, a legacy packed single-chunk
-`GPUVector`, or the output of a lazy operation.
+`@luma.gl/gpgpu` has two evaluator layers:
 
-`GPUDataEvaluator` remains a compatibility alias for `GPUDataEvaluator`.
-Use [`GPUVectorEvaluator`](/docs/api-reference/gpgpu/gpu-data-evaluator) when one
-transform should run independently over every `GPUData` chunk in a `GPUVector`
-without packing streaming batches together.
+- `GPUDataEvaluator` runs one lazy transform over one packed fixed-width `GPUData` chunk.
+- `GPUVectorEvaluator` applies one lazy `GPUDataEvaluator` transform independently to every ordered `GPUData` chunk in a `GPUVector`.
 
-Each row contains `size` elements of the same numeric type. Tables can represent tightly packed rows or strided data with a byte `offset` and `stride`.
+There is no `GPUTable` evaluator input path. Streaming code should pass an incoming
+`GPUData` chunk directly to `GPUDataEvaluator` operations, or wrap a `GPUVector`
+with `GPUVectorEvaluator` when the same transform should preserve every existing
+chunk boundary.
+
+![GPU evaluator split](./gpu-evaluator-split.svg)
 
 ## Usage
+
+### One incoming `GPUData`
 
 ```ts
 import {GPUDataEvaluator, add} from '@luma.gl/gpgpu';
 
-const positions = GPUDataEvaluator.fromArray(new Float32Array([
-  0, 0, 0,
-  1, 0, 0,
-  0, 1, 0
-]), {size: 3});
-
 const offset = GPUDataEvaluator.fromConstant([1, 2, 3]);
-const translated = add(positions, offset);
+const translatedChunk = add(incomingGPUData, offset);
 
-await translated.evaluate(device);
-const values = await translated.readValue();
+const translatedVector = await translatedChunk.evaluate(device);
 ```
 
-## Types
+### One `GPUVector`
+
+```ts
+import {GPUDataEvaluator, GPUVectorEvaluator, add} from '@luma.gl/gpgpu';
+
+const offset = GPUDataEvaluator.fromConstant([1, 2, 3]);
+const translatedVector = GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(data =>
+  add(data, offset)
+);
+
+const outputVector = await translatedVector.evaluate(device);
+```
+
+`GPUVectorEvaluator` preserves `vector.data[]` order and chunk boundaries. It does
+not combine streaming batches or pack buffers implicitly.
+
+## `GPUDataEvaluator`
+
+`GPUDataEvaluator` describes a 2D row layout backed by CPU values, one borrowed
+`GPUData` chunk, another `GPUDataEvaluator`, or a lazy `Operation` output. Each
+row contains `size` scalar elements of the same numeric type.
 
 ### `GPUDataEvaluatorProps`
 
@@ -45,121 +60,90 @@ const values = await translated.readValue();
 | `size` | `number` | Number of scalar elements in each row. |
 | `offset?` | `number` | Byte offset to the first element of the first row. Defaults to `0`. |
 | `stride?` | `number` | Byte distance between adjacent rows. Defaults to `ValueType.BYTES_PER_ELEMENT * size`. |
-| `value?` | `TypedArray` | CPU-side data for the table. Required unless `source` is provided. |
+| `normalized?` | `boolean` | Whether integer values are normalized when exposed as vertex formats. |
+| `value?` | `TypedArray` | CPU-side data for the evaluator. |
 | `buffer?` | `Buffer` | Borrowed GPU buffer backing this evaluator. |
 | `gpuData?` | `GPUData` | Borrowed packed numeric GPUData chunk backing this evaluator. |
-| `gpuVector?` | `GPUVector` | Borrowed legacy single-chunk numeric GPUVector resource backing this evaluator. |
 | `format?` | `GPUVectorFormat` | Optional memory format preserved for GPUVector interop. |
-| `source?` | `Operation \| GPUDataEvaluator \| null` | Lazy data source for this table. |
+| `source?` | `Operation \| GPUDataEvaluator \| null` | Lazy source for this evaluator. |
 | `isConstant?` | `boolean` | Whether every row shares the same value. Defaults to `false`. |
 | `length?` | `number` | Row count. Optional when `isConstant` is `true` or `value` is provided. |
 
-## Static Methods
+### Static Methods
 
-### `GPUDataEvaluator.fromArray(value, props?): GPUDataEvaluator`
+#### `GPUDataEvaluator.fromArray(value, props?): GPUDataEvaluator`
 
-Creates a table from a typed array or numeric array. When passed a plain JavaScript array, the method creates a typed array using `props.type` or `'float32'` by default.
+Creates one evaluator from a typed array or numeric array. Plain JavaScript
+arrays use `props.type` or `'float32'` by default. `Float64Array` inputs are
+reinterpreted as `uint32` pairs for GPU-oriented operations such as `fround()`.
 
-If `value` is a `Float64Array`, it is reinterpreted as `uint32` pairs so it can be used by GPU-oriented operations such as `fround()`.
+#### `GPUDataEvaluator.fromConstant(value, type?): GPUDataEvaluator`
 
-### `GPUDataEvaluator.fromConstant(value, type?): GPUDataEvaluator`
+Creates one constant evaluator with a shared row value. A scalar becomes a
+one-element row, and an array becomes a row with `value.length` elements.
 
-Creates a constant table with one shared row value. A scalar becomes a one-element row, and an array becomes a row with `value.length` elements.
+#### `GPUDataEvaluator.fromGPUData(data, options?): GPUDataEvaluator`
 
-### `GPUDataEvaluator.fromGPUVector(vector): GPUDataEvaluator`
+Creates one evaluator view over a packed fixed-width `GPUData` chunk. The input
+must have a non-`vertex-list` `GPUData.format`, matching `rowByteLength`, and
+packed rows. The evaluator borrows `data.buffer` and does not destroy it.
 
-Creates an evaluator view over a packed numeric `GPUVector`. The input must have
-one `GPUData` chunk, a fixed non-`vertex-list` `GPUVector.format`, and tightly
-packed rows. The evaluator borrows `vector.data[0].buffer` and does not destroy
-it.
+### Methods
 
-### `GPUDataEvaluator.fromGPUData(data): GPUDataEvaluator`
+#### `evaluate(device: Device, options?): Promise<GPUVector>`
 
-Creates an evaluator view over one packed numeric `GPUData` chunk. The input
-must have a fixed non-`vertex-list` `GPUData.format` and tightly packed rows.
-The evaluator borrows `data.buffer` and does not destroy it.
+Materializes one single-chunk `GPUVector` on the provided device. Lazy
+dependencies are evaluated before the operation handler writes the output.
 
-### `GPUVectorEvaluator.fromGPUVector(vector): GPUVectorEvaluator`
+#### `readValue(startRow?: number, endRow?: number): Promise<TypedArray>`
 
-Creates a chunk-preserving vector evaluator over one packed numeric `GPUVector`.
-Use `.mapGPUData(transform)` to build one `GPUDataEvaluator` transform per
-preserved `GPUData` chunk, then call `.evaluate(device)` to materialize one
-output `GPUVector` with matching chunk boundaries.
+Reads evaluator contents back to the CPU. This is intended for debugging or
+inspection and may be slower than staying on the GPU.
 
-## Properties
+#### `destroy(): void`
 
-### `type`
+Releases cached GPU storage owned by this evaluator and prevents future
+evaluation.
 
-Scalar element type for each stored value.
+## `GPUVectorEvaluator`
 
-### `size`
+`GPUVectorEvaluator` is the official `GPUVector` path. It wraps ordered
+`GPUDataEvaluator` chunks and materializes one output `GPUVector` with the same
+chunk boundaries.
 
-Number of scalar elements in each row.
+### Static Methods
 
-### `offset`, `stride`
+#### `GPUVectorEvaluator.fromGPUVector(vector): GPUVectorEvaluator`
 
-Byte layout information for reading rows from the underlying data.
+Creates one chunk-preserving evaluator over a fixed-width `GPUVector`. The
+vector must have at least one `GPUData` chunk and must not be interleaved.
 
-### `isConstant`
+#### `GPUVectorEvaluator.fromGPUDataEvaluators(evaluators, options?): GPUVectorEvaluator`
 
-Whether all rows share the same value.
+Creates one vector evaluator from already-built ordered chunk evaluators.
 
-### `length`
+### Methods
 
-Number of rows in the table.
+#### `mapGPUData(transform): GPUVectorEvaluator`
 
-### `byteLength`
+Applies one lazy `GPUDataEvaluator` transform independently to each preserved
+chunk. Use this for row-local streaming transforms that should not repack source
+batches.
 
-Total storage size in bytes.
+#### `evaluate(device: Device, options?): Promise<GPUVector>`
 
-### `ValueType`
+Materializes every chunk evaluator and returns one `GPUVector` with preserved
+chunk order and boundaries.
 
-Typed-array constructor associated with `type`.
+#### `destroy(): void`
 
-### `value`
-
-CPU-side typed array, when available. This may come from construction or from a later `readValue()` call.
-
-### `gpuVector`
-
-Materialized GPUVector resource for the table. Accessing this before `evaluate()` throws.
-
-### `buffer`
-
-Materialized `Buffer` backing the table. Accessing this before `evaluate()` throws.
-
-## Methods
-
-### `constructor(props: GPUDataEvaluatorProps)`
-
-Creates a table from explicit layout and source information.
-
-### `evaluate(device: Device, options?): Promise<GPUVector>`
-
-Materializes the table on the provided device and returns the immutable `GPUVector` backing this evaluator. If the table was created from an operation, all dependencies are evaluated first and the operation is executed lazily at this point.
-
-### `readValue(startRow?: number, endRow?: number): Promise<TypedArray>`
-
-Reads table contents back to the CPU. This is primarily for debugging or inspection and may be slower than staying on the GPU.
-
-When rows are tightly packed, the returned typed array references a contiguous slice. For strided tables, the method copies each row into a compact array before returning it.
-
-### `toString(): string`
-
-Returns the debug id, source description, or class name.
-
-### `destroy(): void`
-
-Releases any cached GPU buffer and prevents future evaluation.
+Releases cached GPU resources owned through child `GPUDataEvaluator` instances.
 
 ## Remarks
 
-- `GPUDataEvaluator` is immutable in shape. To produce a new table, create another `GPUDataEvaluator` or use an operation that returns one.
-- Evaluation is lazy. Creating operation chains does not allocate GPU resources until `evaluate()` is called on an output table.
-- Operation outputs are evaluators backed by immutable materialized buffers, not scratch buffers.
-- `GPUData` and legacy single-chunk `GPUVector` inputs are borrowed through their
-  `GPUData` buffers; operation outputs own their materialized `GPUVector`
-  backing resources.
-- Streaming code should use `GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(...)`
-  when the same lazy transform must run across every preserved GPUData chunk.
-- Constant tables are useful for broadcasting values across every row of a non-constant input.
+- Leaf operations accept `GPUDataEvaluator` or `GPUData`, not `GPUVector`.
+- Use `GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(...)` for vector-wide
+  transforms that should preserve streaming chunks.
+- `GPUDataEvaluator` operation outputs own their materialized single-chunk
+  `GPUVector` backing resource.
+- Borrowed `GPUData` chunks are not destroyed by `GPUDataEvaluator.destroy()`.

--- a/docs/api-reference/gpgpu/gpu-evaluator-split.svg
+++ b/docs/api-reference/gpgpu/gpu-evaluator-split.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 820" role="img" aria-labelledby="title description">
+  <title id="title">GPU evaluator split</title>
+  <desc id="description">
+    GPUDataEvaluator transforms one GPUData chunk, while GPUVectorEvaluator maps a transform over GPUVector chunks without packing them.
+  </desc>
+  <defs>
+    <style>
+      .background { fill: #ffffff; }
+      .title { fill: #111827; font: 700 54px Inter, Arial, sans-serif; }
+      .section { fill: #111827; font: 700 28px Inter, Arial, sans-serif; }
+      .label { fill: #111827; font: 700 23px "SFMono-Regular", Consolas, monospace; }
+      .caption { fill: #4b5563; font: 500 21px Inter, Arial, sans-serif; }
+      .small { fill: #4b5563; font: 600 18px Inter, Arial, sans-serif; }
+      .arrow { fill: none; stroke: #6b7280; stroke-width: 8; stroke-linecap: round; stroke-linejoin: round; }
+      .arrow-head { fill: #6b7280; }
+      .removed { fill: #fee2e2; stroke: #ef4444; stroke-width: 4; }
+      .data { fill: #f3f4f6; stroke: #9ca3af; stroke-width: 3; }
+      .data-evaluator { fill: #dbeafe; stroke: #2563eb; stroke-width: 4; }
+      .vector-evaluator { fill: #dcfce7; stroke: #16a34a; stroke-width: 4; }
+      .vector { fill: #f9fafb; stroke: #6b7280; stroke-width: 4; }
+      .chunk { fill: #e5e7eb; stroke: #9ca3af; stroke-width: 2; }
+      .transform { fill: #ecfeff; stroke: #0891b2; stroke-width: 3; }
+      .legend { fill: #f9fafb; stroke: #d1d5db; stroke-width: 3; }
+      .strike { stroke: #ef4444; stroke-width: 10; stroke-linecap: round; }
+      .green-arrow { fill: none; stroke: #16a34a; stroke-width: 7; stroke-linecap: round; stroke-linejoin: round; }
+    </style>
+  </defs>
+
+  <rect class="background" width="1400" height="820" />
+  <text class="title" x="70" y="82">GPU evaluator split</text>
+
+  <text class="section" x="70" y="155">Removed misleading API</text>
+  <rect class="removed" x="70" y="185" width="360" height="82" rx="22" />
+  <text class="label" x="112" y="237">GPUTableEvaluator</text>
+  <line class="strike" x1="96" y1="253" x2="402" y2="198" />
+  <text class="small" x="460" y="233">No GPUTable input path</text>
+
+  <text class="section" x="70" y="352">GPUData path</text>
+  <rect class="data" x="70" y="390" width="220" height="96" rx="24" />
+  <text class="label" x="116" y="447">GPUData</text>
+  <path class="arrow" d="M 312 438 H 410" />
+  <polygon class="arrow-head" points="410,438 382,420 382,456" />
+  <rect class="data-evaluator" x="430" y="378" width="360" height="120" rx="28" />
+  <text class="label" x="490" y="447">GPUDataEvaluator</text>
+  <path class="arrow" d="M 812 438 H 910" />
+  <polygon class="arrow-head" points="910,438 882,420 882,456" />
+  <rect class="data" x="930" y="390" width="220" height="96" rx="24" />
+  <text class="label" x="976" y="447">GPUData</text>
+  <rect class="transform" x="525" y="515" width="170" height="54" rx="18" />
+  <text class="small" x="560" y="549">transform</text>
+  <text class="caption" x="70" y="557">Runs directly on one incoming GPUData chunk.</text>
+
+  <text class="section" x="70" y="655">GPUVector path</text>
+  <rect class="vector" x="70" y="688" width="340" height="98" rx="24" />
+  <text class="label" x="100" y="724">GPUVector</text>
+  <rect class="chunk" x="100" y="738" width="82" height="28" rx="12" />
+  <rect class="chunk" x="194" y="738" width="82" height="28" rx="12" />
+  <rect class="chunk" x="288" y="738" width="82" height="28" rx="12" />
+  <path class="arrow" d="M 432 737 H 520" />
+  <polygon class="arrow-head" points="520,737 492,719 492,755" />
+  <rect class="vector-evaluator" x="540" y="675" width="390" height="124" rx="28" />
+  <text class="label" x="590" y="744">GPUVectorEvaluator</text>
+  <path class="green-arrow" d="M 952 707 H 1042" />
+  <path class="green-arrow" d="M 952 737 H 1042" />
+  <path class="green-arrow" d="M 952 767 H 1042" />
+  <polygon class="arrow-head" points="1042,707 1018,692 1018,722" />
+  <polygon class="arrow-head" points="1042,737 1018,722 1018,752" />
+  <polygon class="arrow-head" points="1042,767 1018,752 1018,782" />
+  <rect class="vector" x="1060" y="688" width="270" height="98" rx="24" />
+  <text class="label" x="1090" y="724">GPUVector</text>
+  <rect class="chunk" x="1090" y="738" width="62" height="28" rx="12" />
+  <rect class="chunk" x="1164" y="738" width="62" height="28" rx="12" />
+  <rect class="chunk" x="1238" y="738" width="62" height="28" rx="12" />
+
+  <rect class="legend" x="1010" y="165" width="320" height="162" rx="24" />
+  <text class="small" x="1044" y="205">Official APIs</text>
+  <text class="small" x="1044" y="245">GPUDataEvaluator = one GPUData</text>
+  <text class="small" x="1044" y="279">GPUVectorEvaluator = map chunks</text>
+  <text class="caption" x="70" y="812">GPUVectorEvaluator preserves chunk boundaries and does not pack streaming data implicitly.</text>
+</svg>

--- a/docs/api-reference/gpgpu/operations.md
+++ b/docs/api-reference/gpgpu/operations.md
@@ -11,13 +11,14 @@ Each operation returns a new [`GPUDataEvaluator`](/docs/api-reference/gpgpu/gpu-
 ## Common Behavior
 
 - Each operation returns a new `GPUDataEvaluator`.
-- Inputs can be `GPUDataEvaluator` instances, packed numeric `GPUData` chunks,
-  or legacy packed single-chunk numeric `GPUVector` instances.
+- Inputs can be `GPUDataEvaluator` instances or packed numeric `GPUData` chunks.
 - Arithmetic operations can also use scalar literals or literal row values.
 - Multi-input operations deduce output `type`, `length`, and constant-ness from their inputs.
 - Output evaluation is backend-driven through `backendRegistry`.
 - Operations can be chained to build larger compute graphs.
 - Operation result evaluators own their materialized immutable output buffer.
+- Use `GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(...)` to apply the
+  same leaf operation independently across preserved `GPUVector.data[]` chunks.
 - The CPU backend is available by default. If no backend has been registered for
   a WebGL or WebGPU device, the matching backend is loaded automatically on
   first evaluation.
@@ -448,9 +449,8 @@ const result = fround(source);
 ## Remarks
 
 - `add()` and `interleave()` accept multiple arguments and fold from left to right.
-- `GPUData` and legacy single-chunk `GPUVector` inputs are adapted into
-  single-chunk evaluator views through their `GPUData` buffers; those buffers
-  remain externally owned.
+- `GPUData` inputs are adapted into single-chunk evaluator views through their
+  borrowed buffers; those buffers remain externally owned.
 - Use `GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(...)` to apply the
   same lazy transform to every preserved `GPUData` chunk in a streaming vector.
 - `fround()` is specialized and only accepts one input.

--- a/docs/api-reference/gpgpu/operations.md
+++ b/docs/api-reference/gpgpu/operations.md
@@ -6,13 +6,13 @@ import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
 
 This page is the top-level API reference for the lazy operations exported by `@luma.gl/gpgpu`.
 
-Each operation returns a new [`GPUTableEvaluator`](/docs/api-reference/gpgpu/gpu-table). No GPU work is performed until that output table is evaluated.
+Each operation returns a new [`GPUDataEvaluator`](/docs/api-reference/gpgpu/gpu-data-evaluator). No GPU work is performed until that output table is evaluated.
 
 ## Common Behavior
 
-- Each operation returns a new `GPUTableEvaluator`.
-- Inputs can be `GPUTableEvaluator` instances or packed single-chunk numeric
-  `GPUVector` instances.
+- Each operation returns a new `GPUDataEvaluator`.
+- Inputs can be `GPUDataEvaluator` instances, packed numeric `GPUData` chunks,
+  or legacy packed single-chunk numeric `GPUVector` instances.
 - Arithmetic operations can also use scalar literals or literal row values.
 - Multi-input operations deduce output `type`, `length`, and constant-ness from their inputs.
 - Output evaluation is backend-driven through `backendRegistry`.
@@ -45,26 +45,26 @@ The arithmetic API is exported from `@luma.gl/gpgpu` as:
 ### Signatures
 
 ```ts
-type ArithmeticArgument = GPUTableEvaluatorInput | number | number[];
+type ArithmeticArgument = GPUDataEvaluatorInput | number | number[];
 
-add(...args: ArithmeticArgument[]): GPUTableEvaluator
-subtract(...args: ArithmeticArgument[]): GPUTableEvaluator
-multiply(...args: ArithmeticArgument[]): GPUTableEvaluator
-divide(...args: ArithmeticArgument[]): GPUTableEvaluator
+add(...args: ArithmeticArgument[]): GPUDataEvaluator
+subtract(...args: ArithmeticArgument[]): GPUDataEvaluator
+multiply(...args: ArithmeticArgument[]): GPUDataEvaluator
+divide(...args: ArithmeticArgument[]): GPUDataEvaluator
 
-pow(base: ArithmeticArgument, exponent: ArithmeticArgument): GPUTableEvaluator
-sqrt(arg: ArithmeticArgument): GPUTableEvaluator
-abs(arg: ArithmeticArgument): GPUTableEvaluator
-sin(arg: ArithmeticArgument): GPUTableEvaluator
-cos(arg: ArithmeticArgument): GPUTableEvaluator
-tan(arg: ArithmeticArgument): GPUTableEvaluator
-exp(arg: ArithmeticArgument): GPUTableEvaluator
-log(arg: ArithmeticArgument): GPUTableEvaluator
+pow(base: ArithmeticArgument, exponent: ArithmeticArgument): GPUDataEvaluator
+sqrt(arg: ArithmeticArgument): GPUDataEvaluator
+abs(arg: ArithmeticArgument): GPUDataEvaluator
+sin(arg: ArithmeticArgument): GPUDataEvaluator
+cos(arg: ArithmeticArgument): GPUDataEvaluator
+tan(arg: ArithmeticArgument): GPUDataEvaluator
+exp(arg: ArithmeticArgument): GPUDataEvaluator
+log(arg: ArithmeticArgument): GPUDataEvaluator
 ```
 
 ### Behavior
 
-- Arithmetic operations accept `GPUTableEvaluator` inputs, scalar literals, or literal row values such as `[1, 2, 3]`.
+- Arithmetic operations accept `GPUDataEvaluator` inputs, scalar literals, or literal row values such as `[1, 2, 3]`.
 - `add`, `subtract`, `multiply`, and `divide` fold left to right across all arguments.
 - The output row size is the largest row size among the table and literal inputs.
 - Missing elements are treated as `0` for elementwise arithmetic when smaller rows are combined with larger rows.
@@ -73,7 +73,7 @@ log(arg: ArithmeticArgument): GPUTableEvaluator
 ### Example
 
 ```ts
-const xyz = GPUTableEvaluator.fromArray(
+const xyz = GPUDataEvaluator.fromArray(
   new Float32Array([
     1, 2, 3,
     4, 5, 6
@@ -86,7 +86,7 @@ const result = add(xyz, [10, 20, 30], 1);
 
 ## `interleave`
 
-### `interleave(...args: GPUTableEvaluatorInput[]): GPUTableEvaluator`
+### `interleave(...args: GPUDataEvaluatorInput[]): GPUDataEvaluator`
 
 Concatenates each input row in argument order.
 
@@ -105,7 +105,7 @@ The output:
 ### Example
 
 ```ts
-const xyz = GPUTableEvaluator.fromArray(
+const xyz = GPUDataEvaluator.fromArray(
   new Float32Array([
     0, 0, 0,
     1, 0, 0
@@ -113,14 +113,14 @@ const xyz = GPUTableEvaluator.fromArray(
   {size: 3}
 );
 
-const id = GPUTableEvaluator.fromArray(new Float32Array([5, 6]), {size: 1});
+const id = GPUDataEvaluator.fromArray(new Float32Array([5, 6]), {size: 1});
 
 const result = interleave(xyz, id);
 ```
 
 ## `swizzle`
 
-### `swizzle(table: GPUTableEvaluatorInput, columns: number[]): GPUTableEvaluator`
+### `swizzle(table: GPUDataEvaluatorInput, columns: number[]): GPUDataEvaluator`
 
 Builds a new table by selecting specific columns from each input row.
 
@@ -149,7 +149,7 @@ Behavior:
 ### Example
 
 ```ts
-const values = GPUTableEvaluator.fromArray(
+const values = GPUDataEvaluator.fromArray(
   [10, 11, 12, 13, 20, 21, 22, 23],
   {size: 4}
 );
@@ -160,7 +160,7 @@ const reordered = swizzle(values, [2, 0, 2]);
 
 ## `gather`
 
-### `gather(ids: GPUTableEvaluatorInput, sourceValues: GPUTableEvaluatorInput): GPUTableEvaluator`
+### `gather(ids: GPUDataEvaluatorInput, sourceValues: GPUDataEvaluatorInput): GPUDataEvaluator`
 
 Gathers rows from `sourceValues` using 0-based row indices from `ids`.
 
@@ -180,8 +180,8 @@ Behavior:
 ### Example
 
 ```ts
-const ids = GPUTableEvaluator.fromArray([2, 0, 1], {type: 'uint32', size: 1});
-const values = GPUTableEvaluator.fromArray(
+const ids = GPUDataEvaluator.fromArray([2, 0, 1], {type: 'uint32', size: 1});
+const values = GPUDataEvaluator.fromArray(
   [10, 11, 20, 21, 30, 31],
   {size: 2}
 );
@@ -191,7 +191,7 @@ const result = gather(ids, values);
 
 ## `extent`
 
-### `extent(sourceValues: GPUTableEvaluatorInput): GPUTableEvaluator`
+### `extent(sourceValues: GPUDataEvaluatorInput): GPUDataEvaluator`
 
 Computes per-channel extents across all rows in `sourceValues`.
 
@@ -213,7 +213,7 @@ row 1: [min(y), max(y)]
 ### Example
 
 ```ts
-const points = GPUTableEvaluator.fromArray(
+const points = GPUDataEvaluator.fromArray(
   [4, 9, -1, 8, 7, 3, 2, 12],
   {size: 2}
 );
@@ -223,7 +223,7 @@ const result = extent(points);
 
 ## `dot`
 
-### `dot(x: GPUTableEvaluatorInput, y: GPUTableEvaluatorInput): GPUTableEvaluator`
+### `dot(x: GPUDataEvaluatorInput, y: GPUDataEvaluatorInput): GPUDataEvaluator`
 
 Computes the row-wise dot product of `x` and `y`.
 
@@ -242,11 +242,11 @@ Behavior:
 ### Example
 
 ```ts
-const x = GPUTableEvaluator.fromArray(
+const x = GPUDataEvaluator.fromArray(
   [1, 2, 3, 4, 5, 6],
   {size: 3}
 );
-const y = GPUTableEvaluator.fromArray(
+const y = GPUDataEvaluator.fromArray(
   [7, 8, 9, -1, -2, -3],
   {size: 3}
 );
@@ -256,7 +256,7 @@ const result = dot(x, y);
 
 ## `length`
 
-### `length(x: GPUTableEvaluatorInput): GPUTableEvaluator`
+### `length(x: GPUDataEvaluatorInput): GPUDataEvaluator`
 
 Computes the Euclidean row length of `x`.
 
@@ -274,7 +274,7 @@ Behavior:
 ### Example
 
 ```ts
-const points = GPUTableEvaluator.fromArray(
+const points = GPUDataEvaluator.fromArray(
   [3, 4, 5, 12],
   {size: 2}
 );
@@ -284,7 +284,7 @@ const result = length(points);
 
 ## `equalAll`
 
-### `equalAll(x: GPUTableEvaluatorInput, y: GPUTableEvaluatorInput): GPUTableEvaluator`
+### `equalAll(x: GPUDataEvaluatorInput, y: GPUDataEvaluatorInput): GPUDataEvaluator`
 
 Checks row-wise equality across all lanes of `x` and `y`.
 
@@ -309,11 +309,11 @@ Behavior:
 ### Example
 
 ```ts
-const a = GPUTableEvaluator.fromArray(
+const a = GPUDataEvaluator.fromArray(
   [1, 2, 3, 4, 5, 6],
   {size: 3}
 );
-const b = GPUTableEvaluator.fromArray(
+const b = GPUDataEvaluator.fromArray(
   [1, 2, 3, 4, 0, 6],
   {size: 3}
 );
@@ -323,7 +323,7 @@ const result = equalAll(a, b);
 
 ## `sequence`
 
-### `sequence(count: number, start?: number, step?: number): GPUTableEvaluator`
+### `sequence(count: number, start?: number, step?: number): GPUDataEvaluator`
 
 Generates a lazy integer sequence.
 
@@ -350,7 +350,7 @@ const b = sequence(4, 10, 2); // 10, 12, 14, 16
 
 ## `select`
 
-### `select(condition: GPUTableEvaluatorInput, whenTrue: GPUTableEvaluatorInput, whenFalse: GPUTableEvaluatorInput): GPUTableEvaluator`
+### `select(condition: GPUDataEvaluatorInput, whenTrue: GPUDataEvaluatorInput, whenFalse: GPUDataEvaluatorInput): GPUDataEvaluator`
 
 Selects row or lane values from `whenTrue` or `whenFalse` using non-zero condition values.
 
@@ -370,16 +370,16 @@ Behavior:
 ### Example
 
 ```ts
-const condition = GPUTableEvaluator.fromArray([1, 0, 1], {type: 'uint32', size: 1});
-const whenTrue = GPUTableEvaluator.fromArray([10, 11, 20, 21, 30, 31], {size: 2});
-const whenFalse = GPUTableEvaluator.fromArray([100, 101, 200, 201, 300, 301], {size: 2});
+const condition = GPUDataEvaluator.fromArray([1, 0, 1], {type: 'uint32', size: 1});
+const whenTrue = GPUDataEvaluator.fromArray([10, 11, 20, 21, 30, 31], {size: 2});
+const whenFalse = GPUDataEvaluator.fromArray([100, 101, 200, 201, 300, 301], {size: 2});
 
 const result = select(condition, whenTrue, whenFalse);
 ```
 
 ## `segmentedMap`
 
-### `segmentedMap(segments: GPUTableEvaluatorInput, vertexCount: number): GPUTableEvaluator`
+### `segmentedMap(segments: GPUDataEvaluatorInput, vertexCount: number): GPUDataEvaluator`
 
 Maps each vertex index to its containing segment and its offset within that segment.
 
@@ -418,18 +418,18 @@ row 6: [3, 0]
 ### Example
 
 ```ts
-const segments = GPUTableEvaluator.fromArray([0, 3, 5], {type: 'uint32', size: 1});
+const segments = GPUDataEvaluator.fromArray([0, 3, 5], {type: 'uint32', size: 1});
 
 const result = segmentedMap(segments, 7);
 ```
 
 ## `fround`
 
-### `fround(x: GPUTableEvaluatorInput): GPUTableEvaluator`
+### `fround(x: GPUDataEvaluatorInput): GPUDataEvaluator`
 
 Splits float64 values into float32 high and low parts for fp64-style workflows.
 
-`GPUTableEvaluator.fromArray()` represents `Float64Array` input as `uint32` pairs. `fround()` consumes that representation and returns a `float32` table whose row size is doubled:
+`GPUDataEvaluator.fromArray()` represents `Float64Array` input as `uint32` pairs. `fround()` consumes that representation and returns a `float32` table whose row size is doubled:
 
 - the first half of each row stores the high float32 parts
 - the second half stores the low residual parts
@@ -437,7 +437,7 @@ Splits float64 values into float32 high and low parts for fp64-style workflows.
 ### Example
 
 ```ts
-const source = GPUTableEvaluator.fromArray(
+const source = GPUDataEvaluator.fromArray(
   new Float64Array([Math.PI, Math.E]),
   {size: 1}
 );
@@ -448,8 +448,11 @@ const result = fround(source);
 ## Remarks
 
 - `add()` and `interleave()` accept multiple arguments and fold from left to right.
-- `GPUVector` inputs are adapted into evaluator views through
-  `vector.data[0].buffer`; their buffers remain externally owned.
+- `GPUData` and legacy single-chunk `GPUVector` inputs are adapted into
+  single-chunk evaluator views through their `GPUData` buffers; those buffers
+  remain externally owned.
+- Use `GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(...)` to apply the
+  same lazy transform to every preserved `GPUData` chunk in a streaming vector.
 - `fround()` is specialized and only accepts one input.
 - As new operations are added to `@luma.gl/gpgpu`, this page should remain the top-level reference for them.
 - Arithmetic operations can mix tables and literals in the same expression.
@@ -458,5 +461,5 @@ const result = fround(source);
 - `dot()`, `length()`, and `equalAll()` are row-wise operations: they inspect all lanes in each input row and emit one scalar output row.
 - `extent()` is a reduction operation: it collapses many input rows into one `[min, max]` row per channel.
 - `select()` is lane-wise and size-preserving; it uses scalar or per-lane non-zero masks to choose between two inputs.
-- `sequence()` produces data without any table inputs, but still returns a lazy `GPUTableEvaluator`.
+- `sequence()` produces data without any table inputs, but still returns a lazy `GPUDataEvaluator`.
 - `segmentedMap()` is a per-vertex segment-annotation operation, not a segmented reduction.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -166,7 +166,7 @@
         "label": "@luma.gl/gpgpu",
         "items": [
           "api-reference/gpgpu/README",
-          "api-reference/gpgpu/gpu-table",
+          "api-reference/gpgpu/gpu-data-evaluator",
           "api-reference/gpgpu/operations",
           "api-reference/gpgpu/custom-operation",
           "api-reference/gpgpu/clean-evaluate"

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -25,6 +25,10 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
   - `readArrowGPUDataAsync(...)` and `readArrowGPUVectorAsync(...)`
 - Arrow append-in-place helpers and streaming wrapper classes have been removed. Convert each Arrow record batch with `makeGPURecordBatchFromArrowRecordBatch(device, recordBatch, ...)` and retain it with `gpuTable.addBatch(...)`.
 
+**@luma.gl/gpgpu**
+- `GPUTableEvaluator` and `getGPUTableEvaluator()` have been removed. Use `GPUDataEvaluator` and `getGPUDataEvaluator()` for one packed fixed-width `GPUData` chunk.
+- Leaf GPGPU operations no longer adapt `GPUVector` inputs. Use `GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(...)` to apply one leaf transform independently across preserved `GPUVector.data[]` chunks.
+
 ## Upgrading to v9.3
 
 **Potentially breaking behavior**

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -10,7 +10,7 @@ Target Release Date: Q3, 2026
 
 - **`@luma.gl/tables`** - Generic GPU table/runtime, planning, transform, and compute helpers.
 - **`@luma.gl/arrow`** - New module for working with binary columnar data on the GPU.
-- **`@luma.gl/gpgpu`** - New module for lazy `GPUDataEvaluator` operations with CPU/WebGL/WebGPU backends.
+- **`@luma.gl/gpgpu`** - New module for lazy `GPUDataEvaluator` operations and chunk-preserving `GPUVectorEvaluator` transforms with CPU/WebGL/WebGPU backends.
 
 
 **@luma.gl/core**
@@ -41,7 +41,7 @@ Target Release Date: Q3, 2026
 
 **@luma.gl/gpgpu** NEW MODULE
 
-- **`GPUDataEvaluator`** lazy GPU operations with CPU/WebGL/WebGPU backends.
+- **`GPUDataEvaluator`** lazy GPUData operations and **`GPUVectorEvaluator`** chunk-preserving GPUVector transforms with CPU/WebGL/WebGPU backends.
 
 **@luma.gl/arrow** NEW MODULE
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -10,7 +10,7 @@ Target Release Date: Q3, 2026
 
 - **`@luma.gl/tables`** - Generic GPU table/runtime, planning, transform, and compute helpers.
 - **`@luma.gl/arrow`** - New module for working with binary columnar data on the GPU.
-- **`@luma.gl/gpgpu`** - New module for lazy `GPUTableEvaluator` operations with CPU/WebGL/WebGPU backends.
+- **`@luma.gl/gpgpu`** - New module for lazy `GPUDataEvaluator` operations with CPU/WebGL/WebGPU backends.
 
 
 **@luma.gl/core**
@@ -41,7 +41,7 @@ Target Release Date: Q3, 2026
 
 **@luma.gl/gpgpu** NEW MODULE
 
-- **`GPUTableEvaluator`** lazy GPU operations with CPU/WebGL/WebGPU backends.
+- **`GPUDataEvaluator`** lazy GPU operations with CPU/WebGL/WebGPU backends.
 
 **@luma.gl/arrow** NEW MODULE
 

--- a/examples/showcase/gpgpu/index.html
+++ b/examples/showcase/gpgpu/index.html
@@ -213,9 +213,9 @@
 </head>
 <body>
   <main id="app" class="gpgpu-showcase">
-    <h1>@luma.gl/gpgpu table evaluator showcase</h1>
+    <h1>@luma.gl/gpgpu evaluator showcase</h1>
     <p class="subtitle">
-      Arrow-backed source columns are extracted as typed-array views and wrapped in GPUTableEvaluator inputs.
+      Arrow-backed source columns are extracted as typed-array views and wrapped in GPUDataEvaluator inputs.
     </p>
 
     <div class="metadata-grid">

--- a/examples/showcase/gpgpu/src/app.ts
+++ b/examples/showcase/gpgpu/src/app.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {luma, type Device} from '@luma.gl/core';
-import {cleanEvaluate, type GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {cleanEvaluate, type GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 import {makeShowcaseData} from './arrow-data';
@@ -166,7 +166,7 @@ async function runExpression({
 }
 
 async function makeOutputTableColumn(
-  output: GPUTableEvaluator,
+  output: GPUDataEvaluator,
   rowCount: number,
   sourceColumns: TableColumn[]
 ): Promise<TableColumn> {
@@ -208,7 +208,7 @@ async function getEvaluationDevice(): Promise<Device> {
   return evaluationDevicePromise;
 }
 
-function getMetricStartIndicesEvaluator(sourceColumns: TableColumn[]): GPUTableEvaluator {
+function getMetricStartIndicesEvaluator(sourceColumns: TableColumn[]): GPUDataEvaluator {
   const metricsColumn = sourceColumns.find(column => column.id === 'sampleMetrics');
   if (!metricsColumn || metricsColumn.kind !== 'segmented') {
     throw new Error('Cannot display longer output without sampleMetrics start indices');
@@ -217,8 +217,8 @@ function getMetricStartIndicesEvaluator(sourceColumns: TableColumn[]): GPUTableE
 }
 
 async function validateMetricSegmentedOutput(
-  output: GPUTableEvaluator,
-  metricStartIndices: GPUTableEvaluator,
+  output: GPUDataEvaluator,
+  metricStartIndices: GPUDataEvaluator,
   rowCount: number
 ): Promise<void> {
   if (metricStartIndices.length !== rowCount + 1) {
@@ -236,7 +236,7 @@ async function validateMetricSegmentedOutput(
   }
 }
 
-function formatEvaluatorType(evaluator: GPUTableEvaluator): string {
+function formatEvaluatorType(evaluator: GPUDataEvaluator): string {
   return `${evaluator.type}${evaluator.size === 1 ? '' : `x${evaluator.size}`}`;
 }
 

--- a/examples/showcase/gpgpu/src/arrow-data.ts
+++ b/examples/showcase/gpgpu/src/arrow-data.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {getArrowFixedSizeListValues, getArrowVectorBufferSource} from '@luma.gl/arrow';
-import {GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {GPUDataEvaluator} from '@luma.gl/gpgpu';
 import * as arrow from 'apache-arrow';
 import type {ExpressionInputs} from './expression';
 import {formatFixedRow, formatSegmentedRow, type TableColumn} from './table-renderer';
@@ -90,25 +90,22 @@ function makeTableColumnsFromArrowTable(table: ShowcaseArrowTable): TableColumn[
   );
   validateFixedSizeListColumn(coordinatesVector, 'coordinates', arrow.Precision.DOUBLE, 3);
   const coordinateValues = getArrowFixedSizeListValues(coordinatesVector) as Float64Array;
-  const coordinatesEvaluator = GPUTableEvaluator.fromArray(coordinateValues, {
+  const coordinatesEvaluator = GPUDataEvaluator.fromArray(coordinateValues, {
     size: COORDINATE_COMPONENT_COUNT
   });
 
   const rankingVector = getRequiredColumn<arrow.Uint8>(table, 'ranking');
   validateUint8Column(rankingVector, 'ranking');
   const rankingValues = getArrowVectorBufferSource(rankingVector) as Uint8Array;
-  const rankingEvaluator = GPUTableEvaluator.fromArray(rankingValues, {type: 'uint8', size: 1});
+  const rankingEvaluator = GPUDataEvaluator.fromArray(rankingValues, {type: 'uint8', size: 1});
 
   const sampleMetricsVector = getRequiredColumn<arrow.List<arrow.Float32>>(table, 'sampleMetrics');
   const sampleMetrics = getSampleMetricBuffers(sampleMetricsVector);
-  const sampleMetricValuesEvaluator = GPUTableEvaluator.fromArray(sampleMetrics.values, {size: 1});
-  const sampleMetricStartIndicesEvaluator = GPUTableEvaluator.fromArray(
-    sampleMetrics.startIndices,
-    {
-      type: 'uint32',
-      size: 1
-    }
-  );
+  const sampleMetricValuesEvaluator = GPUDataEvaluator.fromArray(sampleMetrics.values, {size: 1});
+  const sampleMetricStartIndicesEvaluator = GPUDataEvaluator.fromArray(sampleMetrics.startIndices, {
+    type: 'uint32',
+    size: 1
+  });
 
   return [
     {

--- a/examples/showcase/gpgpu/src/expression.ts
+++ b/examples/showcase/gpgpu/src/expression.ts
@@ -13,7 +13,7 @@ import {
   extent,
   fround,
   gather,
-  GPUTableEvaluator,
+  GPUDataEvaluator,
   interleave,
   length,
   log,
@@ -42,15 +42,15 @@ import {
 
 export type SegmentedExpressionInput = {
   kind: 'segmented';
-  values: GPUTableEvaluator;
-  startIndices: GPUTableEvaluator;
+  values: GPUDataEvaluator;
+  startIndices: GPUDataEvaluator;
 };
 
-export type ExpressionInput = GPUTableEvaluator | SegmentedExpressionInput;
+export type ExpressionInput = GPUDataEvaluator | SegmentedExpressionInput;
 export type ExpressionInputs = Record<string, ExpressionInput>;
 
-type ExpressionValue = GPUTableEvaluator | SegmentedExpressionInput | number | number[];
-type OperationFunction = (...args: any[]) => GPUTableEvaluator;
+type ExpressionValue = GPUDataEvaluator | SegmentedExpressionInput | number | number[];
+type OperationFunction = (...args: any[]) => GPUDataEvaluator;
 
 const OPERATIONS: Record<string, OperationFunction> = {
   abs,
@@ -86,14 +86,14 @@ const BINARY_OPERATIONS: Record<string, OperationFunction> = {
   '**': pow
 };
 
-export function evaluateExpression(source: string, inputs: ExpressionInputs): GPUTableEvaluator {
+export function evaluateExpression(source: string, inputs: ExpressionInputs): GPUDataEvaluator {
   const expression = parseGPGPUExpression(source);
   const value = evaluateNode(expression, inputs);
-  if (value instanceof GPUTableEvaluator) {
+  if (value instanceof GPUDataEvaluator) {
     return value;
   }
   if (typeof value === 'number' || Array.isArray(value)) {
-    return GPUTableEvaluator.fromConstant(value);
+    return GPUDataEvaluator.fromConstant(value);
   }
   throw new Error('Expression resolves to segmented data; use .values or .startIndices');
 }
@@ -174,7 +174,7 @@ function evaluateUnaryExpression(node: UnaryExpression, inputs: ExpressionInputs
 function evaluateBinaryExpression(
   node: BinaryExpression,
   inputs: ExpressionInputs
-): GPUTableEvaluator {
+): GPUDataEvaluator {
   const operation = BINARY_OPERATIONS[node.operator];
   if (!operation) {
     throw new Error(`Unsupported binary operator ${node.operator}`);
@@ -185,7 +185,7 @@ function evaluateBinaryExpression(
   );
 }
 
-function evaluateCallExpression(node: CallExpression, inputs: ExpressionInputs): GPUTableEvaluator {
+function evaluateCallExpression(node: CallExpression, inputs: ExpressionInputs): GPUDataEvaluator {
   if (node.callee.type !== 'Identifier') {
     throw new Error('Only direct operation calls are supported');
   }
@@ -229,18 +229,18 @@ function evaluateMemberExpression(
   }
 }
 
-function getEvaluatorOrLiteral(value: ExpressionValue): GPUTableEvaluator | number | number[] {
+function getEvaluatorOrLiteral(value: ExpressionValue): GPUDataEvaluator | number | number[] {
   if (isSegmentedInput(value)) {
     throw new Error('Segmented inputs must use .values or .startIndices in this operation');
   }
   return value;
 }
 
-function getSegmentStartEvaluator(value: ExpressionValue | undefined): GPUTableEvaluator {
+function getSegmentStartEvaluator(value: ExpressionValue | undefined): GPUDataEvaluator {
   if (!value) {
     throw new Error('segmentedMap requires a segmented input');
   }
-  if (value instanceof GPUTableEvaluator) {
+  if (value instanceof GPUDataEvaluator) {
     return value;
   }
   if (isSegmentedInput(value)) {
@@ -257,7 +257,5 @@ function getNumberArgument(value: ExpressionValue | undefined, name: string): nu
 }
 
 function isSegmentedInput(value: ExpressionValue): value is SegmentedExpressionInput {
-  return (
-    typeof value === 'object' && !(value instanceof GPUTableEvaluator) && !Array.isArray(value)
-  );
+  return typeof value === 'object' && !(value instanceof GPUDataEvaluator) && !Array.isArray(value);
 }

--- a/examples/showcase/gpgpu/src/table-renderer.ts
+++ b/examples/showcase/gpgpu/src/table-renderer.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {GPUTableEvaluator} from '@luma.gl/gpgpu';
+import type {GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {Virtualizer, observeElementRect, type VirtualItem} from '@tanstack/virtual-core';
 
 const ROW_HEIGHT = 34;
@@ -30,7 +30,7 @@ export type TableValueArray =
 type BaseTableColumn = {
   id: string;
   logicalType: string;
-  evaluator?: GPUTableEvaluator;
+  evaluator?: GPUDataEvaluator;
   getRowText: (rowIndex: number) => string | Promise<string>;
 };
 
@@ -50,13 +50,13 @@ type EvaluatorRowChunkRange = Pick<EvaluatorRowChunk, 'startRow' | 'endRow'>;
 
 export type EvaluatorTableColumn = BaseTableColumn & {
   kind: 'evaluator';
-  evaluator: GPUTableEvaluator;
+  evaluator: GPUDataEvaluator;
 };
 
 export type SegmentedTableColumn = BaseTableColumn & {
   kind: 'segmented';
-  valuesEvaluator: GPUTableEvaluator;
-  startIndicesEvaluator: GPUTableEvaluator;
+  valuesEvaluator: GPUDataEvaluator;
+  startIndicesEvaluator: GPUDataEvaluator;
 };
 
 export type TableColumn = EvaluatorTableColumn | SegmentedTableColumn;
@@ -295,7 +295,7 @@ export class VirtualGPUTableRenderer {
 export function makeEvaluatorTableColumn(
   id: string,
   logicalType: string,
-  evaluator: GPUTableEvaluator
+  evaluator: GPUDataEvaluator
 ): EvaluatorTableColumn {
   const reader = new EvaluatorRowReader(evaluator);
   return {
@@ -310,8 +310,8 @@ export function makeEvaluatorTableColumn(
 export function makeSegmentedEvaluatorTableColumn(
   id: string,
   logicalType: string,
-  valuesEvaluator: GPUTableEvaluator,
-  startIndicesEvaluator: GPUTableEvaluator
+  valuesEvaluator: GPUDataEvaluator,
+  startIndicesEvaluator: GPUDataEvaluator
 ): SegmentedTableColumn {
   const reader = new SegmentedEvaluatorRowReader(valuesEvaluator, startIndicesEvaluator);
   return {
@@ -357,7 +357,7 @@ class EvaluatorRowReader {
   private cachedChunk: EvaluatorRowChunk | null = null;
   private pendingChunk: PendingEvaluatorRowChunk | null = null;
 
-  constructor(private readonly evaluator: GPUTableEvaluator) {}
+  constructor(private readonly evaluator: GPUDataEvaluator) {}
 
   async getRowText(rowIndex: number): Promise<string> {
     const effectiveRowIndex = this.evaluator.isConstant ? 0 : rowIndex;
@@ -404,8 +404,8 @@ class EvaluatorRowReader {
 
 class SegmentedEvaluatorRowReader {
   constructor(
-    private readonly valuesEvaluator: GPUTableEvaluator,
-    private readonly startIndicesEvaluator: GPUTableEvaluator
+    private readonly valuesEvaluator: GPUDataEvaluator,
+    private readonly startIndicesEvaluator: GPUDataEvaluator
   ) {}
 
   async getRowText(rowIndex: number): Promise<string> {

--- a/examples/v10/gpgpu/index.html
+++ b/examples/v10/gpgpu/index.html
@@ -213,9 +213,9 @@
 </head>
 <body>
   <main id="app" class="gpgpu-showcase">
-    <h1>@luma.gl/gpgpu table evaluator showcase</h1>
+    <h1>@luma.gl/gpgpu evaluator showcase</h1>
     <p class="subtitle">
-      Arrow-backed source columns are extracted as typed-array views and wrapped in GPUTableEvaluator inputs.
+      Arrow-backed source columns are extracted as typed-array views and wrapped in GPUDataEvaluator inputs.
     </p>
 
     <div class="metadata-grid">

--- a/examples/v10/gpgpu/src/app.ts
+++ b/examples/v10/gpgpu/src/app.ts
@@ -6,7 +6,7 @@ import {luma, type Device} from '@luma.gl/core';
 import {
   backendRegistry,
   cleanEvaluate,
-  type GPUTableEvaluator,
+  type GPUDataEvaluator,
   webglBackend,
   webgpuBackend
 } from '@luma.gl/gpgpu';
@@ -210,7 +210,7 @@ async function runExpression({
 }
 
 async function makeOutputTableColumn(
-  output: GPUTableEvaluator,
+  output: GPUDataEvaluator,
   rowCount: number,
   sourceColumns: TableColumn[]
 ): Promise<TableColumn> {
@@ -254,7 +254,7 @@ async function getEvaluationDevice(): Promise<Device> {
   return evaluationDevicePromise;
 }
 
-function getMetricStartIndicesEvaluator(sourceColumns: TableColumn[]): GPUTableEvaluator {
+function getMetricStartIndicesEvaluator(sourceColumns: TableColumn[]): GPUDataEvaluator {
   const metricsColumn = sourceColumns.find(column => column.id === 'sampleMetrics');
   if (!metricsColumn || metricsColumn.kind !== 'segmented') {
     throw new Error('Cannot display longer output without sampleMetrics start indices');
@@ -263,8 +263,8 @@ function getMetricStartIndicesEvaluator(sourceColumns: TableColumn[]): GPUTableE
 }
 
 async function validateMetricSegmentedOutput(
-  output: GPUTableEvaluator,
-  metricStartIndices: GPUTableEvaluator,
+  output: GPUDataEvaluator,
+  metricStartIndices: GPUDataEvaluator,
   rowCount: number
 ): Promise<void> {
   if (metricStartIndices.length !== rowCount + 1) {
@@ -282,7 +282,7 @@ async function validateMetricSegmentedOutput(
   }
 }
 
-function formatEvaluatorType(evaluator: GPUTableEvaluator): string {
+function formatEvaluatorType(evaluator: GPUDataEvaluator): string {
   return `${evaluator.type}${evaluator.size === 1 ? '' : `x${evaluator.size}`}`;
 }
 

--- a/examples/v10/gpgpu/src/arrow-data.ts
+++ b/examples/v10/gpgpu/src/arrow-data.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {getArrowFixedSizeListValues, getArrowVectorBufferSource} from '@luma.gl/arrow';
-import {GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {GPUDataEvaluator} from '@luma.gl/gpgpu';
 import * as arrow from 'apache-arrow';
 import type {ExpressionInputs} from './expression';
 import {formatFixedRow, formatSegmentedRow, type TableColumn} from './table-renderer';
@@ -90,25 +90,22 @@ function makeTableColumnsFromArrowTable(table: ShowcaseArrowTable): TableColumn[
   );
   validateFixedSizeListColumn(coordinatesVector, 'coordinates', arrow.Precision.DOUBLE, 3);
   const coordinateValues = getArrowFixedSizeListValues(coordinatesVector) as Float64Array;
-  const coordinatesEvaluator = GPUTableEvaluator.fromArray(coordinateValues, {
+  const coordinatesEvaluator = GPUDataEvaluator.fromArray(coordinateValues, {
     size: COORDINATE_COMPONENT_COUNT
   });
 
   const rankingVector = getRequiredColumn<arrow.Uint8>(table, 'ranking');
   validateUint8Column(rankingVector, 'ranking');
   const rankingValues = getArrowVectorBufferSource(rankingVector) as Uint8Array;
-  const rankingEvaluator = GPUTableEvaluator.fromArray(rankingValues, {type: 'uint8', size: 1});
+  const rankingEvaluator = GPUDataEvaluator.fromArray(rankingValues, {type: 'uint8', size: 1});
 
   const sampleMetricsVector = getRequiredColumn<arrow.List<arrow.Float32>>(table, 'sampleMetrics');
   const sampleMetrics = getSampleMetricBuffers(sampleMetricsVector);
-  const sampleMetricValuesEvaluator = GPUTableEvaluator.fromArray(sampleMetrics.values, {size: 1});
-  const sampleMetricStartIndicesEvaluator = GPUTableEvaluator.fromArray(
-    sampleMetrics.startIndices,
-    {
-      type: 'uint32',
-      size: 1
-    }
-  );
+  const sampleMetricValuesEvaluator = GPUDataEvaluator.fromArray(sampleMetrics.values, {size: 1});
+  const sampleMetricStartIndicesEvaluator = GPUDataEvaluator.fromArray(sampleMetrics.startIndices, {
+    type: 'uint32',
+    size: 1
+  });
 
   return [
     {

--- a/examples/v10/gpgpu/src/expression.ts
+++ b/examples/v10/gpgpu/src/expression.ts
@@ -13,7 +13,7 @@ import {
   extent,
   fround,
   gather,
-  GPUTableEvaluator,
+  GPUDataEvaluator,
   interleave,
   length,
   log,
@@ -42,15 +42,15 @@ import {
 
 export type SegmentedExpressionInput = {
   kind: 'segmented';
-  values: GPUTableEvaluator;
-  startIndices: GPUTableEvaluator;
+  values: GPUDataEvaluator;
+  startIndices: GPUDataEvaluator;
 };
 
-export type ExpressionInput = GPUTableEvaluator | SegmentedExpressionInput;
+export type ExpressionInput = GPUDataEvaluator | SegmentedExpressionInput;
 export type ExpressionInputs = Record<string, ExpressionInput>;
 
-type ExpressionValue = GPUTableEvaluator | SegmentedExpressionInput | number | number[];
-type OperationFunction = (...args: any[]) => GPUTableEvaluator;
+type ExpressionValue = GPUDataEvaluator | SegmentedExpressionInput | number | number[];
+type OperationFunction = (...args: any[]) => GPUDataEvaluator;
 
 const OPERATIONS: Record<string, OperationFunction> = {
   abs,
@@ -86,14 +86,14 @@ const BINARY_OPERATIONS: Record<string, OperationFunction> = {
   '**': pow
 };
 
-export function evaluateExpression(source: string, inputs: ExpressionInputs): GPUTableEvaluator {
+export function evaluateExpression(source: string, inputs: ExpressionInputs): GPUDataEvaluator {
   const expression = parseGPGPUExpression(source);
   const value = evaluateNode(expression, inputs);
-  if (value instanceof GPUTableEvaluator) {
+  if (value instanceof GPUDataEvaluator) {
     return value;
   }
   if (typeof value === 'number' || Array.isArray(value)) {
-    return GPUTableEvaluator.fromConstant(value);
+    return GPUDataEvaluator.fromConstant(value);
   }
   throw new Error('Expression resolves to segmented data; use .values or .startIndices');
 }
@@ -174,7 +174,7 @@ function evaluateUnaryExpression(node: UnaryExpression, inputs: ExpressionInputs
 function evaluateBinaryExpression(
   node: BinaryExpression,
   inputs: ExpressionInputs
-): GPUTableEvaluator {
+): GPUDataEvaluator {
   const operation = BINARY_OPERATIONS[node.operator];
   if (!operation) {
     throw new Error(`Unsupported binary operator ${node.operator}`);
@@ -185,7 +185,7 @@ function evaluateBinaryExpression(
   );
 }
 
-function evaluateCallExpression(node: CallExpression, inputs: ExpressionInputs): GPUTableEvaluator {
+function evaluateCallExpression(node: CallExpression, inputs: ExpressionInputs): GPUDataEvaluator {
   if (node.callee.type !== 'Identifier') {
     throw new Error('Only direct operation calls are supported');
   }
@@ -229,18 +229,18 @@ function evaluateMemberExpression(
   }
 }
 
-function getEvaluatorOrLiteral(value: ExpressionValue): GPUTableEvaluator | number | number[] {
+function getEvaluatorOrLiteral(value: ExpressionValue): GPUDataEvaluator | number | number[] {
   if (isSegmentedInput(value)) {
     throw new Error('Segmented inputs must use .values or .startIndices in this operation');
   }
   return value;
 }
 
-function getSegmentStartEvaluator(value: ExpressionValue | undefined): GPUTableEvaluator {
+function getSegmentStartEvaluator(value: ExpressionValue | undefined): GPUDataEvaluator {
   if (!value) {
     throw new Error('segmentedMap requires a segmented input');
   }
-  if (value instanceof GPUTableEvaluator) {
+  if (value instanceof GPUDataEvaluator) {
     return value;
   }
   if (isSegmentedInput(value)) {
@@ -257,7 +257,5 @@ function getNumberArgument(value: ExpressionValue | undefined, name: string): nu
 }
 
 function isSegmentedInput(value: ExpressionValue): value is SegmentedExpressionInput {
-  return (
-    typeof value === 'object' && !(value instanceof GPUTableEvaluator) && !Array.isArray(value)
-  );
+  return typeof value === 'object' && !(value instanceof GPUDataEvaluator) && !Array.isArray(value);
 }

--- a/examples/v10/gpgpu/src/table-renderer.ts
+++ b/examples/v10/gpgpu/src/table-renderer.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {GPUTableEvaluator} from '@luma.gl/gpgpu';
+import type {GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {Virtualizer, observeElementRect, type VirtualItem} from '@tanstack/virtual-core';
 
 const ROW_HEIGHT = 34;
@@ -30,7 +30,7 @@ export type TableValueArray =
 type BaseTableColumn = {
   id: string;
   logicalType: string;
-  evaluator?: GPUTableEvaluator;
+  evaluator?: GPUDataEvaluator;
   getRowText: (rowIndex: number) => string | Promise<string>;
 };
 
@@ -50,13 +50,13 @@ type EvaluatorRowChunkRange = Pick<EvaluatorRowChunk, 'startRow' | 'endRow'>;
 
 export type EvaluatorTableColumn = BaseTableColumn & {
   kind: 'evaluator';
-  evaluator: GPUTableEvaluator;
+  evaluator: GPUDataEvaluator;
 };
 
 export type SegmentedTableColumn = BaseTableColumn & {
   kind: 'segmented';
-  valuesEvaluator: GPUTableEvaluator;
-  startIndicesEvaluator: GPUTableEvaluator;
+  valuesEvaluator: GPUDataEvaluator;
+  startIndicesEvaluator: GPUDataEvaluator;
 };
 
 export type TableColumn = EvaluatorTableColumn | SegmentedTableColumn;
@@ -295,7 +295,7 @@ export class VirtualGPUTableRenderer {
 export function makeEvaluatorTableColumn(
   id: string,
   logicalType: string,
-  evaluator: GPUTableEvaluator
+  evaluator: GPUDataEvaluator
 ): EvaluatorTableColumn {
   const reader = new EvaluatorRowReader(evaluator);
   return {
@@ -310,8 +310,8 @@ export function makeEvaluatorTableColumn(
 export function makeSegmentedEvaluatorTableColumn(
   id: string,
   logicalType: string,
-  valuesEvaluator: GPUTableEvaluator,
-  startIndicesEvaluator: GPUTableEvaluator
+  valuesEvaluator: GPUDataEvaluator,
+  startIndicesEvaluator: GPUDataEvaluator
 ): SegmentedTableColumn {
   const reader = new SegmentedEvaluatorRowReader(valuesEvaluator, startIndicesEvaluator);
   return {
@@ -357,7 +357,7 @@ class EvaluatorRowReader {
   private cachedChunk: EvaluatorRowChunk | null = null;
   private pendingChunk: PendingEvaluatorRowChunk | null = null;
 
-  constructor(private readonly evaluator: GPUTableEvaluator) {}
+  constructor(private readonly evaluator: GPUDataEvaluator) {}
 
   async getRowText(rowIndex: number): Promise<string> {
     const effectiveRowIndex = this.evaluator.isConstant ? 0 : rowIndex;
@@ -404,8 +404,8 @@ class EvaluatorRowReader {
 
 class SegmentedEvaluatorRowReader {
   constructor(
-    private readonly valuesEvaluator: GPUTableEvaluator,
-    private readonly startIndicesEvaluator: GPUTableEvaluator
+    private readonly valuesEvaluator: GPUDataEvaluator,
+    private readonly startIndicesEvaluator: GPUDataEvaluator
   ) {}
 
   async getRowText(rowIndex: number): Promise<string> {

--- a/modules/gpgpu/src/index.ts
+++ b/modules/gpgpu/src/index.ts
@@ -3,24 +3,19 @@
 // Copyright (c) vis.gl contributors
 
 // Resources
-export {
-  getGPUDataEvaluator,
-  getGPUDataEvaluator,
-  GPUDataEvaluator,
-  GPUDataEvaluator
-} from './operation/gpu-data-evaluator';
+export {getGPUDataEvaluator, GPUDataEvaluator} from './operation/gpu-data-evaluator';
 export type {
   GPUDataEvaluatorEvaluateOptions,
-  GPUDataEvaluatorInput,
-  GPUDataEvaluatorProps,
-  GPUDataEvaluatorEvaluateOptions,
+  GPUDataEvaluatorFromGPUDataOptions,
   GPUDataEvaluatorInput,
   GPUDataEvaluatorProps
 } from './operation/gpu-data-evaluator';
 export {getGPUVectorEvaluator, GPUVectorEvaluator} from './operation/gpu-vector-evaluator';
 export type {
   GPUVectorEvaluatorEvaluateOptions,
+  GPUVectorEvaluatorFromGPUDataEvaluatorsOptions,
   GPUVectorEvaluatorInput,
+  GPUVectorEvaluatorMapGPUDataTransform,
   GPUVectorEvaluatorProps
 } from './operation/gpu-vector-evaluator';
 

--- a/modules/gpgpu/src/index.ts
+++ b/modules/gpgpu/src/index.ts
@@ -3,12 +3,26 @@
 // Copyright (c) vis.gl contributors
 
 // Resources
-export {getGPUTableEvaluator, GPUTableEvaluator} from './operation/gpu-table-evaluator';
+export {
+  getGPUDataEvaluator,
+  getGPUDataEvaluator,
+  GPUDataEvaluator,
+  GPUDataEvaluator
+} from './operation/gpu-data-evaluator';
 export type {
-  GPUTableEvaluatorEvaluateOptions,
-  GPUTableEvaluatorInput,
-  GPUTableEvaluatorProps
-} from './operation/gpu-table-evaluator';
+  GPUDataEvaluatorEvaluateOptions,
+  GPUDataEvaluatorInput,
+  GPUDataEvaluatorProps,
+  GPUDataEvaluatorEvaluateOptions,
+  GPUDataEvaluatorInput,
+  GPUDataEvaluatorProps
+} from './operation/gpu-data-evaluator';
+export {getGPUVectorEvaluator, GPUVectorEvaluator} from './operation/gpu-vector-evaluator';
+export type {
+  GPUVectorEvaluatorEvaluateOptions,
+  GPUVectorEvaluatorInput,
+  GPUVectorEvaluatorProps
+} from './operation/gpu-vector-evaluator';
 
 // Operations
 export {

--- a/modules/gpgpu/src/operation/gpu-data-evaluator.ts
+++ b/modules/gpgpu/src/operation/gpu-data-evaluator.ts
@@ -10,6 +10,7 @@ import {
 } from '@luma.gl/core';
 import {DynamicBuffer} from '@luma.gl/engine';
 import {
+  GPUData,
   GPUVector,
   getDataTypeFromTypedArray,
   getGPUVectorFormatInfo,
@@ -21,10 +22,10 @@ import type {TypedArray, TypedArrayConstructor} from '@math.gl/types';
 import {bufferPool} from '../utils/buffer-pool';
 import type {Operation} from './operation';
 
-type GPUTableEvaluatorBufferOwnership = 'owned' | 'borrowed';
+type GPUDataEvaluatorBufferOwnership = 'owned' | 'borrowed';
 
-/** Evaluation options for {@link GPUTableEvaluator.evaluate}. */
-export type GPUTableEvaluatorEvaluateOptions = {
+/** Evaluation options for {@link GPUDataEvaluator.evaluate}. */
+export type GPUDataEvaluatorEvaluateOptions = {
   /** Output vector name. */
   name?: string;
   /** Memory format for the materialized GPUVector. Defaults to the evaluator's type and size. */
@@ -38,9 +39,9 @@ export type GPUTableEvaluatorEvaluateOptions = {
       };
 };
 
-/** Properties used to construct a {@link GPUTableEvaluator}. */
-export type GPUTableEvaluatorProps = {
-  /** Optional debug name used by {@link GPUTableEvaluator.toString}. */
+/** Properties used to construct a {@link GPUDataEvaluator}. */
+export type GPUDataEvaluatorProps = {
+  /** Optional debug name used by {@link GPUDataEvaluator.toString}. */
   id?: string;
   /** Scalar element type for every stored value. */
   type: SignedDataType;
@@ -60,12 +61,14 @@ export type GPUTableEvaluatorProps = {
   value?: TypedArray;
   /** External GPU buffer that backs this table and is not owned by the evaluator. */
   buffer?: Buffer;
+  /** External GPUData chunk that backs this evaluator and is not owned by it. */
+  gpuData?: GPUData;
   /** External GPUVector resource that backs this evaluator and is not owned by it. */
   gpuVector?: GPUVector;
   /** Optional memory format preserved for GPUVector interop. */
   format?: GPUVectorFormat;
   /** Lazy operation or table whose output initializes this table, required unless `value` is supplied. */
-  source?: Operation | GPUTableEvaluator | null;
+  source?: Operation | GPUDataEvaluator | null;
   /** Whether every row should read the same value. */
   isConstant?: boolean;
   /** Number of logical rows, inferred for constants and CPU-backed tables when omitted. */
@@ -76,10 +79,10 @@ export type GPUTableEvaluatorProps = {
  * Device-agnostic, immutable 2D numeric table used as input and output for lazy GPGPU operations.
  *
  * A table describes row layout and a data source, but does not allocate or run GPU work until
- * {@link GPUTableEvaluator.evaluate} is called. Operation functions such as `add()` return new tables whose
+ * {@link GPUDataEvaluator.evaluate} is called. Operation functions such as `add()` return new tables whose
  * `source` points at the deferred operation.
  */
-export class GPUTableEvaluator {
+export class GPUDataEvaluator {
   /** Scalar element type for each stored value. */
   readonly type: SignedDataType;
   /** Number of scalar elements in each logical row. */
@@ -96,10 +99,10 @@ export class GPUTableEvaluator {
   readonly length: number;
   /** Total bytes needed for the table storage. */
   readonly byteLength: number;
-  /** TypedArray constructor for CPU representation, derived from {@link GPUTableEvaluator.type}. */
+  /** TypedArray constructor for CPU representation, derived from {@link GPUDataEvaluator.type}. */
   readonly ValueType: TypedArrayConstructor;
   /** Operation whose output is used to fill the vector, required unless `value` is supplied */
-  readonly source: Operation | GPUTableEvaluator | null = null;
+  readonly source: Operation | GPUDataEvaluator | null = null;
   /** Optional memory format preserved for GPUVector interop. */
   readonly format?: GPUVectorFormat;
 
@@ -113,7 +116,7 @@ export class GPUTableEvaluator {
   /** Materialized GPU resource backing this evaluator. */
   private _gpuVector?: GPUVector;
   /** Whether this evaluator owns its backing GPU buffer or only borrows another resource's buffer. */
-  private _bufferOwnership: GPUTableEvaluatorBufferOwnership = 'owned';
+  private _bufferOwnership: GPUDataEvaluatorBufferOwnership = 'owned';
 
   /**
    * Constructs a table from a CPU array.
@@ -130,8 +133,8 @@ export class GPUTableEvaluator {
       offset = 0,
       stride = 0,
       normalized = false
-    }: Partial<Pick<GPUTableEvaluatorProps, 'type' | 'size' | 'offset' | 'stride' | 'normalized'>>
-  ): GPUTableEvaluator {
+    }: Partial<Pick<GPUDataEvaluatorProps, 'type' | 'size' | 'offset' | 'stride' | 'normalized'>>
+  ): GPUDataEvaluator {
     let resolvedType = type;
     let typedValue: TypedArray;
     if (Array.isArray(value)) {
@@ -150,7 +153,7 @@ export class GPUTableEvaluator {
       typedValue = value;
     }
     const id = `<${resolvedType} * ${size}>`;
-    return new GPUTableEvaluator({
+    return new GPUDataEvaluator({
       id,
       type: resolvedType,
       size,
@@ -170,7 +173,7 @@ export class GPUTableEvaluator {
   static fromConstant(
     value: number | number[],
     type: SignedDataType = 'float32'
-  ): GPUTableEvaluator {
+  ): GPUDataEvaluator {
     const ArrayType = getTypedArrayFromDataType(type);
     let id: string;
     if (!Array.isArray(value)) {
@@ -179,7 +182,7 @@ export class GPUTableEvaluator {
     } else {
       id = `[${value.join(',')}]`;
     }
-    return new GPUTableEvaluator({
+    return new GPUDataEvaluator({
       id,
       isConstant: true,
       type,
@@ -189,38 +192,64 @@ export class GPUTableEvaluator {
   }
 
   /** Creates a table evaluator view over an existing packed numeric GPUVector. */
-  static fromGPUVector(vector: GPUVector): GPUTableEvaluator {
+  static fromGPUVector(vector: GPUVector): GPUDataEvaluator {
     validatePackedNumericGPUVector(vector);
-    const {type, size} = getGPUTablePropsFromGPUVector(vector);
     const data = getSingleGPUVectorData(vector);
+    const {type, size} = getGPUTablePropsFromGPUData(data);
 
-    return new GPUTableEvaluator({
+    return new GPUDataEvaluator({
       id: vector.name,
       type,
       size,
       offset: data.byteOffset,
-      stride: vector.byteStride,
-      length: vector.length,
+      stride: data.byteStride,
+      length: data.length,
       gpuVector: vector,
-      format: vector.format
+      format: data.format
     });
   }
 
-  /** TODO - Construct a new GPUTableEvaluator from a loaders.gl Table/BatchedTable. */
-  // static from(table: Table, columnName: string | number): GPUTableEvaluator
+  /** Creates a table evaluator view over one packed numeric GPUData chunk. */
+  static fromGPUData(data: GPUData, options: {id?: string} = {}): GPUDataEvaluator {
+    validatePackedNumericGPUData(data);
+    const {type, size} = getGPUTablePropsFromGPUData(data);
+
+    return new GPUDataEvaluator({
+      id: options.id,
+      type,
+      size,
+      offset: data.byteOffset,
+      stride: data.byteStride,
+      length: data.length,
+      gpuData: data,
+      format: data.format
+    });
+  }
+
+  /** TODO - Construct a new GPUDataEvaluator from a loaders.gl Table/BatchedTable. */
+  // static from(table: Table, columnName: string | number): GPUDataEvaluator
 
   /**
    * Creates a table from explicit row layout and source information.
    *
-   * Prefer {@link GPUTableEvaluator.fromArray} or {@link GPUTableEvaluator.fromConstant} for CPU-backed tables.
+   * Prefer {@link GPUDataEvaluator.fromArray} or {@link GPUDataEvaluator.fromConstant} for CPU-backed tables.
    */
-  constructor(props: GPUTableEvaluatorProps) {
-    const {id, value, buffer, gpuVector, format, source = null, isConstant = false} = props;
-    if (!source && !value && !buffer && !gpuVector) {
+  constructor(props: GPUDataEvaluatorProps) {
+    const {
+      id,
+      value,
+      buffer,
+      gpuData,
+      gpuVector,
+      format,
+      source = null,
+      isConstant = false
+    } = props;
+    if (!source && !value && !buffer && !gpuData && !gpuVector) {
       throw new Error('OperationResource must have a value source');
     }
     let {type, size, offset, stride, normalized, length} = props;
-    if (source instanceof GPUTableEvaluator) {
+    if (source instanceof GPUDataEvaluator) {
       type = type ?? source.type;
       size = size ?? source.size;
       offset = offset ?? source.offset;
@@ -234,7 +263,7 @@ export class GPUTableEvaluator {
       length = isConstant ? 1 : length;
     }
     if (!type) {
-      throw new Error('GPUTableEvaluator: type not defined');
+      throw new Error('GPUDataEvaluator: type not defined');
     }
 
     this._id = id;
@@ -251,7 +280,7 @@ export class GPUTableEvaluator {
         length = 1;
       } else {
         if (!value) {
-          throw new Error('GPUTableEvaluator: length not defined');
+          throw new Error('GPUDataEvaluator: length not defined');
         }
         length = Math.ceil(value.byteLength / this.stride);
       }
@@ -261,9 +290,19 @@ export class GPUTableEvaluator {
     this.byteLength = this.stride * length;
     this._value = value;
     this._bufferOwnership =
-      source instanceof GPUTableEvaluator || buffer || gpuVector ? 'borrowed' : 'owned';
+      source instanceof GPUDataEvaluator || buffer || gpuData || gpuVector ? 'borrowed' : 'owned';
     if (gpuVector) {
       this._gpuVector = gpuVector;
+    } else if (gpuData) {
+      this._gpuVector = new GPUVector({
+        type: 'data',
+        name: this._id ?? 'data',
+        format: gpuData.format,
+        data: [gpuData],
+        stride: gpuData.stride,
+        byteStride: gpuData.byteStride,
+        rowByteLength: gpuData.rowByteLength
+      });
     } else if (buffer) {
       this._gpuVector = this.createGPUVectorView({
         buffer,
@@ -276,7 +315,7 @@ export class GPUTableEvaluator {
   /** CPU-side typed array, when available. */
   get value(): TypedArray | undefined {
     return (
-      this._value || (this.source instanceof GPUTableEvaluator ? this.source.value : undefined)
+      this._value || (this.source instanceof GPUDataEvaluator ? this.source.value : undefined)
     );
   }
 
@@ -290,7 +329,7 @@ export class GPUTableEvaluator {
     return this._id;
   }
 
-  /** Materialized GPUVector resource for the table. Only available after {@link GPUTableEvaluator.evaluate} resolves. */
+  /** Materialized GPUVector resource for the table. Only available after {@link GPUDataEvaluator.evaluate} resolves. */
   get gpuVector(): GPUVector {
     if (!this._gpuVector) {
       throw new Error(`${this} not evaluated`);
@@ -298,7 +337,7 @@ export class GPUTableEvaluator {
     return this._gpuVector;
   }
 
-  /** Materialized GPU buffer backing the table. Only available after {@link GPUTableEvaluator.evaluate} resolves. */
+  /** Materialized GPU buffer backing the table. Only available after {@link GPUDataEvaluator.evaluate} resolves. */
   get buffer(): Buffer {
     return getBufferFromGPUVector(this.gpuVector);
   }
@@ -311,17 +350,17 @@ export class GPUTableEvaluator {
    */
   async evaluate(
     device: Device,
-    options: GPUTableEvaluatorEvaluateOptions = {}
+    options: GPUDataEvaluatorEvaluateOptions = {}
   ): Promise<GPUVector> {
     if (this._destroyed) {
-      throw new Error(`GPUTableEvaluator ${this} already destroyed`);
+      throw new Error(`GPUDataEvaluator ${this} already destroyed`);
     }
     if (this._gpuVector) {
       return this._gpuVector;
     }
 
     let buffer: Buffer;
-    if (this.source instanceof GPUTableEvaluator) {
+    if (this.source instanceof GPUDataEvaluator) {
       const sourceGPUVector = await this.source.evaluate(device);
       this._gpuVector = this.createGPUVectorView({
         ...options,
@@ -348,7 +387,7 @@ export class GPUTableEvaluator {
 
   /** Creates a GPUVector view over a materialized backing buffer. */
   private createGPUVectorView(
-    options: GPUTableEvaluatorEvaluateOptions & {buffer: Buffer}
+    options: GPUDataEvaluatorEvaluateOptions & {buffer: Buffer}
   ): GPUVector {
     const name = options.name ?? this._id ?? 'vector';
     const format =
@@ -451,7 +490,7 @@ export class GPUTableEvaluator {
 }
 
 function getRowsFromValue(
-  table: GPUTableEvaluator,
+  table: GPUDataEvaluator,
   value: TypedArray,
   startRow: number,
   endRow: number
@@ -474,17 +513,33 @@ function getRowsFromValue(
   return result;
 }
 
-/** Input accepted by operations that normalize GPUVectors into evaluators. */
-export type GPUTableEvaluatorInput = GPUTableEvaluator | GPUVector;
+/** Input accepted by operations that normalize GPU table storage into evaluators. */
+export type GPUDataEvaluatorInput = GPUDataEvaluator | GPUData | GPUVector;
 
-/** Returns an evaluator, wrapping GPUVector inputs when needed. */
-export function getGPUTableEvaluator(input: GPUTableEvaluatorInput): GPUTableEvaluator {
-  return input instanceof GPUTableEvaluator ? input : GPUTableEvaluator.fromGPUVector(input);
+/** Returns an evaluator, wrapping GPUData and GPUVector inputs when needed. */
+export function getGPUDataEvaluator(input: GPUDataEvaluatorInput): GPUDataEvaluator {
+  if (input instanceof GPUDataEvaluator) {
+    return input;
+  }
+  return input instanceof GPUData
+    ? GPUDataEvaluator.fromGPUData(input)
+    : GPUDataEvaluator.fromGPUVector(input);
+}
+
+/** Preferred name for the single-GPUData lazy evaluator. */
+export {GPUDataEvaluator as GPUDataEvaluator};
+export type GPUDataEvaluatorEvaluateOptions = GPUDataEvaluatorEvaluateOptions;
+export type GPUDataEvaluatorProps = GPUDataEvaluatorProps;
+export type GPUDataEvaluatorInput = GPUDataEvaluator | GPUData;
+
+/** Returns a single-GPUData evaluator, wrapping GPUData inputs when needed. */
+export function getGPUDataEvaluator(input: GPUDataEvaluatorInput): GPUDataEvaluator {
+  return input instanceof GPUDataEvaluator ? input : GPUDataEvaluator.fromGPUData(input);
 }
 
 /** Returns source format only when it exactly matches the requested evaluator layout. */
-export function getCompatibleGPUTableEvaluatorFormat(
-  input: GPUTableEvaluator,
+export function getCompatibleGPUDataEvaluatorFormat(
+  input: GPUDataEvaluator,
   type: SignedDataType,
   size: number,
   normalized: boolean = false
@@ -496,33 +551,46 @@ export function getCompatibleGPUTableEvaluatorFormat(
 function validatePackedNumericGPUVector(vector: GPUVector): void {
   if (vector.bufferLayout) {
     throw new Error(
-      `GPUTableEvaluator.fromGPUVector() does not accept interleaved vector "${vector.name}"`
+      `GPUDataEvaluator.fromGPUVector() does not accept interleaved vector "${vector.name}"`
     );
   }
-  getSingleGPUVectorData(vector);
-  if (!vector.format) {
-    throw new Error('GPUTableEvaluator.fromGPUVector() requires GPUVector format metadata');
+  validatePackedNumericGPUData(getSingleGPUVectorData(vector), 'GPUVector', vector.name);
+}
+
+function validatePackedNumericGPUData(
+  data: GPUData,
+  sourceType: 'GPUData' | 'GPUVector' = 'GPUData',
+  sourceName?: string
+): void {
+  const sourceDescription =
+    sourceType === 'GPUVector'
+      ? `vector "${sourceName}"`
+      : sourceName
+        ? `GPUData "${sourceName}"`
+        : 'GPUData';
+  if (!data.format) {
+    throw new Error(`GPUDataEvaluator.from${sourceType}() requires ${sourceType} format metadata`);
   }
-  if (isVertexListGPUVectorFormat(vector.format)) {
-    throw new Error('GPUTableEvaluator.fromGPUVector() does not support vertex-list input');
+  if (isVertexListGPUVectorFormat(data.format)) {
+    throw new Error(`GPUDataEvaluator.from${sourceType}() does not support vertex-list input`);
   }
-  const formatInfo = getGPUVectorFormatInfo(vector.format);
+  const formatInfo = getGPUVectorFormatInfo(data.format);
   const expectedRowByteLength = formatInfo.byteLength;
-  if (vector.rowByteLength !== expectedRowByteLength) {
+  if (data.rowByteLength !== expectedRowByteLength) {
     throw new Error(
-      `GPUTableEvaluator.fromGPUVector() requires rowByteLength ${expectedRowByteLength} for vector "${vector.name}"`
+      `GPUDataEvaluator.from${sourceType}() requires rowByteLength ${expectedRowByteLength} for ${sourceDescription}`
     );
   }
-  if (vector.byteStride !== vector.rowByteLength) {
-    throw new Error(`GPUTableEvaluator.fromGPUVector() requires packed vector "${vector.name}"`);
+  if (data.byteStride !== data.rowByteLength) {
+    throw new Error(`GPUDataEvaluator.from${sourceType}() requires packed ${sourceDescription}`);
   }
 }
 
-function getGPUTablePropsFromGPUVector(vector: GPUVector): {type: SignedDataType; size: number} {
-  if (!vector.format) {
-    throw new Error('GPUTableEvaluator.fromGPUVector() requires GPUVector format metadata');
+function getGPUTablePropsFromGPUData(data: GPUData): {type: SignedDataType; size: number} {
+  if (!data.format) {
+    throw new Error('GPUDataEvaluator.fromGPUData() requires GPUData format metadata');
   }
-  const formatInfo = getGPUVectorFormatInfo(vector.format);
+  const formatInfo = getGPUVectorFormatInfo(data.format);
   return {type: formatInfo.signedDataType, size: formatInfo.components};
 }
 
@@ -535,26 +603,26 @@ function getBufferFromGPUVector(vector: GPUVector): Buffer {
 function getSingleGPUVectorData(vector: GPUVector) {
   const [data, ...remainingData] = vector.data;
   if (!data || remainingData.length > 0) {
-    throw new Error(`GPUTableEvaluator requires exactly one GPUData chunk for "${vector.name}"`);
+    throw new Error(`GPUDataEvaluator requires exactly one GPUData chunk for "${vector.name}"`);
   }
   return data;
 }
 
-function getInterleavedAttributes(evaluator: GPUTableEvaluator): BufferAttributeLayout[] {
+function getInterleavedAttributes(evaluator: GPUDataEvaluator): BufferAttributeLayout[] {
   const attributes: BufferAttributeLayout[] = [];
   collectInterleavedAttributes(evaluator, attributes, {byteOffset: 0});
   return attributes;
 }
 
 function collectInterleavedAttributes(
-  evaluator: GPUTableEvaluator,
+  evaluator: GPUDataEvaluator,
   attributes: BufferAttributeLayout[],
   state: {byteOffset: number}
 ): void {
   const source = evaluator.source;
-  if (source && !(source instanceof GPUTableEvaluator) && source.name === 'interleave') {
+  if (source && !(source instanceof GPUDataEvaluator) && source.name === 'interleave') {
     for (const input of Object.values(source.inputs)) {
-      if (input instanceof GPUTableEvaluator) {
+      if (input instanceof GPUDataEvaluator) {
         collectInterleavedAttributes(input, attributes, state);
       }
     }

--- a/modules/gpgpu/src/operation/gpu-data-evaluator.ts
+++ b/modules/gpgpu/src/operation/gpu-data-evaluator.ts
@@ -24,13 +24,13 @@ import type {Operation} from './operation';
 
 type GPUDataEvaluatorBufferOwnership = 'owned' | 'borrowed';
 
-/** Evaluation options for {@link GPUDataEvaluator.evaluate}. */
+/** Options for materializing one {@link GPUDataEvaluator}. */
 export type GPUDataEvaluatorEvaluateOptions = {
-  /** Output vector name. */
+  /** Name assigned to the materialized single-chunk `GPUVector`. */
   name?: string;
-  /** Memory format for the materialized GPUVector. Defaults to the evaluator's type and size. */
+  /** Memory format for the materialized `GPUVector`. Defaults to the evaluator layout. */
   format?: GPUVectorFormat;
-  /** Whether to materialize the GPUVector as an interleaved vector. */
+  /** Whether to expose the materialized buffer through an interleaved `GPUVector` view. */
   interleaved?:
     | boolean
     | {
@@ -39,7 +39,13 @@ export type GPUDataEvaluatorEvaluateOptions = {
       };
 };
 
-/** Properties used to construct a {@link GPUDataEvaluator}. */
+/** Options for adapting one existing `GPUData` chunk into a {@link GPUDataEvaluator}. */
+export type GPUDataEvaluatorFromGPUDataOptions = {
+  /** Optional debug name used by {@link GPUDataEvaluator.toString}. */
+  id?: string;
+};
+
+/** Properties used to construct one {@link GPUDataEvaluator}. */
 export type GPUDataEvaluatorProps = {
   /** Optional debug name used by {@link GPUDataEvaluator.toString}. */
   id?: string;
@@ -57,17 +63,15 @@ export type GPUDataEvaluatorProps = {
   stride?: number;
   /** Whether integer values should be normalized when read as float vertex attributes. */
   normalized?: boolean;
-  /** CPU buffer that initializes the table, required unless `source` or `buffer` is supplied. */
+  /** CPU buffer that initializes the evaluator, required unless another source is supplied. */
   value?: TypedArray;
-  /** External GPU buffer that backs this table and is not owned by the evaluator. */
+  /** External GPU buffer that backs this evaluator and is not owned by it. */
   buffer?: Buffer;
   /** External GPUData chunk that backs this evaluator and is not owned by it. */
   gpuData?: GPUData;
-  /** External GPUVector resource that backs this evaluator and is not owned by it. */
-  gpuVector?: GPUVector;
   /** Optional memory format preserved for GPUVector interop. */
   format?: GPUVectorFormat;
-  /** Lazy operation or table whose output initializes this table, required unless `value` is supplied. */
+  /** Lazy operation or evaluator whose output initializes this evaluator. */
   source?: Operation | GPUDataEvaluator | null;
   /** Whether every row should read the same value. */
   isConstant?: boolean;
@@ -76,11 +80,13 @@ export type GPUDataEvaluatorProps = {
 };
 
 /**
- * Device-agnostic, immutable 2D numeric table used as input and output for lazy GPGPU operations.
+ * Device-agnostic, immutable 2D numeric evaluator used by lazy GPGPU operations.
  *
- * A table describes row layout and a data source, but does not allocate or run GPU work until
- * {@link GPUDataEvaluator.evaluate} is called. Operation functions such as `add()` return new tables whose
- * `source` points at the deferred operation.
+ * @remarks
+ * A `GPUDataEvaluator` describes exactly one logical `GPUData` chunk, a CPU value source, or a
+ * deferred operation output. It does not allocate or run GPU work until
+ * {@link GPUDataEvaluator.evaluate} is called. Use `GPUVectorEvaluator` when one transform should
+ * be applied independently across every `GPUData` chunk in a `GPUVector`.
  */
 export class GPUDataEvaluator {
   /** Scalar element type for each stored value. */
@@ -101,17 +107,17 @@ export class GPUDataEvaluator {
   readonly byteLength: number;
   /** TypedArray constructor for CPU representation, derived from {@link GPUDataEvaluator.type}. */
   readonly ValueType: TypedArrayConstructor;
-  /** Operation whose output is used to fill the vector, required unless `value` is supplied */
+  /** Operation or evaluator whose output initializes this evaluator. */
   readonly source: Operation | GPUDataEvaluator | null = null;
   /** Optional memory format preserved for GPUVector interop. */
   readonly format?: GPUVectorFormat;
 
-  /** User-assigned id for easy debugging */
+  /** User-assigned id for easy debugging. */
   protected _id?: string;
-  /** destroy() has been called and no more resources should be created */
+  /** Whether {@link GPUDataEvaluator.destroy} has been called. */
   protected _destroyed: boolean = false;
 
-  /** CPU buffer, either provided by the user or read back from the GPU */
+  /** CPU buffer, either provided by the user or read back from the GPU. */
   protected _value?: TypedArray;
   /** Materialized GPU resource backing this evaluator. */
   private _gpuVector?: GPUVector;
@@ -119,11 +125,15 @@ export class GPUDataEvaluator {
   private _bufferOwnership: GPUDataEvaluatorBufferOwnership = 'owned';
 
   /**
-   * Constructs a table from a CPU array.
+   * Constructs one evaluator from a CPU array.
    *
    * Plain JavaScript arrays are converted to typed arrays using `type` or `float32` by default.
    * `Float64Array` inputs are reinterpreted as `uint32` pairs so they can be consumed by GPU
    * operations such as {@link fround}.
+   *
+   * @param value - CPU values laid out as contiguous rows.
+   * @param props - Scalar type and row layout metadata for `value`.
+   * @returns One lazy evaluator backed by the provided CPU values.
    */
   static fromArray(
     value: TypedArray | number[],
@@ -165,10 +175,11 @@ export class GPUDataEvaluator {
   }
 
   /**
-   * Constructs a constant table whose single row is broadcast across non-constant inputs.
+   * Constructs one constant evaluator whose single row is broadcast across non-constant inputs.
    *
    * @param value - Scalar or row value.
    * @param type - Scalar element type used for the CPU representation.
+   * @returns One lazy evaluator backed by the constant CPU row.
    */
   static fromConstant(
     value: number | number[],
@@ -191,28 +202,19 @@ export class GPUDataEvaluator {
     });
   }
 
-  /** Creates a table evaluator view over an existing packed numeric GPUVector. */
-  static fromGPUVector(vector: GPUVector): GPUDataEvaluator {
-    validatePackedNumericGPUVector(vector);
-    const data = getSingleGPUVectorData(vector);
-    const {type, size} = getGPUTablePropsFromGPUData(data);
-
-    return new GPUDataEvaluator({
-      id: vector.name,
-      type,
-      size,
-      offset: data.byteOffset,
-      stride: data.byteStride,
-      length: data.length,
-      gpuVector: vector,
-      format: data.format
-    });
-  }
-
-  /** Creates a table evaluator view over one packed numeric GPUData chunk. */
-  static fromGPUData(data: GPUData, options: {id?: string} = {}): GPUDataEvaluator {
+  /**
+   * Creates one evaluator view over an existing packed numeric `GPUData` chunk.
+   *
+   * @param data - Packed fixed-width `GPUData` chunk to borrow.
+   * @param options - Optional debug metadata for the borrowed chunk.
+   * @returns One lazy evaluator that borrows `data.buffer`.
+   */
+  static fromGPUData(
+    data: GPUData,
+    options: GPUDataEvaluatorFromGPUDataOptions = {}
+  ): GPUDataEvaluator {
     validatePackedNumericGPUData(data);
-    const {type, size} = getGPUTablePropsFromGPUData(data);
+    const {type, size} = getGPUDataEvaluatorPropsFromGPUData(data);
 
     return new GPUDataEvaluator({
       id: options.id,
@@ -226,27 +228,17 @@ export class GPUDataEvaluator {
     });
   }
 
-  /** TODO - Construct a new GPUDataEvaluator from a loaders.gl Table/BatchedTable. */
-  // static from(table: Table, columnName: string | number): GPUDataEvaluator
-
   /**
-   * Creates a table from explicit row layout and source information.
+   * Creates one evaluator from explicit row layout and source information.
    *
    * Prefer {@link GPUDataEvaluator.fromArray} or {@link GPUDataEvaluator.fromConstant} for CPU-backed tables.
+   *
+   * @param props - Row layout and one value, buffer, GPUData, or deferred source.
    */
   constructor(props: GPUDataEvaluatorProps) {
-    const {
-      id,
-      value,
-      buffer,
-      gpuData,
-      gpuVector,
-      format,
-      source = null,
-      isConstant = false
-    } = props;
-    if (!source && !value && !buffer && !gpuData && !gpuVector) {
-      throw new Error('OperationResource must have a value source');
+    const {id, value, buffer, gpuData, format, source = null, isConstant = false} = props;
+    if (!source && !value && !buffer && !gpuData) {
+      throw new Error('GPUDataEvaluator must have a value source');
     }
     let {type, size, offset, stride, normalized, length} = props;
     if (source instanceof GPUDataEvaluator) {
@@ -290,10 +282,8 @@ export class GPUDataEvaluator {
     this.byteLength = this.stride * length;
     this._value = value;
     this._bufferOwnership =
-      source instanceof GPUDataEvaluator || buffer || gpuData || gpuVector ? 'borrowed' : 'owned';
-    if (gpuVector) {
-      this._gpuVector = gpuVector;
-    } else if (gpuData) {
+      source instanceof GPUDataEvaluator || buffer || gpuData ? 'borrowed' : 'owned';
+    if (gpuData) {
       this._gpuVector = new GPUVector({
         type: 'data',
         name: this._id ?? 'data',
@@ -314,22 +304,20 @@ export class GPUDataEvaluator {
 
   /** CPU-side typed array, when available. */
   get value(): TypedArray | undefined {
-    return (
-      this._value || (this.source instanceof GPUDataEvaluator ? this.source.value : undefined)
-    );
+    return this._value || (this.source instanceof GPUDataEvaluator ? this.source.value : undefined);
   }
 
-  /** Whether a GPUVector has been materialized for this evaluator. */
+  /** Whether a single-chunk `GPUVector` has been materialized for this evaluator. */
   get evaluated(): boolean {
     return Boolean(this._gpuVector);
   }
 
-  /** Optional debug id or source GPUVector name. */
+  /** Optional debug id. */
   get id(): string | undefined {
     return this._id;
   }
 
-  /** Materialized GPUVector resource for the table. Only available after {@link GPUDataEvaluator.evaluate} resolves. */
+  /** Materialized single-chunk `GPUVector` for this evaluator. */
   get gpuVector(): GPUVector {
     if (!this._gpuVector) {
       throw new Error(`${this} not evaluated`);
@@ -337,16 +325,20 @@ export class GPUDataEvaluator {
     return this._gpuVector;
   }
 
-  /** Materialized GPU buffer backing the table. Only available after {@link GPUDataEvaluator.evaluate} resolves. */
+  /** Materialized GPU buffer backing this evaluator. */
   get buffer(): Buffer {
     return getBufferFromGPUVector(this.gpuVector);
   }
 
   /**
-   * Materializes the table on a device and returns the requested output format.
+   * Materializes this evaluator on a device and returns the requested output format.
    *
-   * If the table is operation-backed, dependencies are evaluated first and then the backend
+   * If the evaluator is operation-backed, dependencies are evaluated first and then the backend
    * operation writes into a cached GPU buffer.
+   *
+   * @param device - Device used to materialize the evaluator.
+   * @param options - Output view metadata for the materialized single-chunk `GPUVector`.
+   * @returns The cached or newly materialized single-chunk `GPUVector`.
    */
   async evaluate(
     device: Device,
@@ -385,7 +377,7 @@ export class GPUDataEvaluator {
     return this._gpuVector;
   }
 
-  /** Creates a GPUVector view over a materialized backing buffer. */
+  /** Creates a single-chunk `GPUVector` view over a materialized backing buffer. */
   private createGPUVectorView(
     options: GPUDataEvaluatorEvaluateOptions & {buffer: Buffer}
   ): GPUVector {
@@ -426,10 +418,14 @@ export class GPUDataEvaluator {
   }
 
   /**
-   * Reads table data back to the CPU.
+   * Reads evaluator data back to the CPU.
    *
    * This is intended for debugging and validation. Tightly packed rows return a typed-array view;
    * strided rows are copied into a compact typed array.
+   *
+   * @param startRow - Inclusive first row to read.
+   * @param endRow - Exclusive last row to read.
+   * @returns CPU values for the requested row range.
    */
   async readValue(startRow: number = 0, endRow?: number): Promise<TypedArray> {
     const {ValueType} = this;
@@ -477,8 +473,8 @@ export class GPUDataEvaluator {
     return this._id ?? this.source?.toString() ?? this.constructor.name;
   }
 
-  /** Releases cached GPU storage and prevents future evaluation. */
-  destroy() {
+  /** Releases cached GPU storage owned by this evaluator and prevents future evaluation. */
+  destroy(): void {
     if (this._gpuVector) {
       if (this._bufferOwnership === 'owned') {
         bufferPool.recycle(getBufferFromGPUVector(this._gpuVector));
@@ -513,31 +509,34 @@ function getRowsFromValue(
   return result;
 }
 
-/** Input accepted by operations that normalize GPU table storage into evaluators. */
-export type GPUDataEvaluatorInput = GPUDataEvaluator | GPUData | GPUVector;
+/** Input accepted by leaf operations that normalize one `GPUData` chunk into an evaluator. */
+export type GPUDataEvaluatorInput = GPUDataEvaluator | GPUData;
 
-/** Returns an evaluator, wrapping GPUData and GPUVector inputs when needed. */
+/**
+ * Returns one evaluator, adapting `GPUData` inputs when needed.
+ *
+ * @param input - Existing evaluator or one packed fixed-width `GPUData` chunk.
+ * @returns One `GPUDataEvaluator` for leaf GPGPU operations.
+ */
 export function getGPUDataEvaluator(input: GPUDataEvaluatorInput): GPUDataEvaluator {
   if (input instanceof GPUDataEvaluator) {
     return input;
   }
-  return input instanceof GPUData
-    ? GPUDataEvaluator.fromGPUData(input)
-    : GPUDataEvaluator.fromGPUVector(input);
+  if (input instanceof GPUData) {
+    return GPUDataEvaluator.fromGPUData(input);
+  }
+  throw new Error('getGPUDataEvaluator() requires GPUDataEvaluator or GPUData');
 }
 
-/** Preferred name for the single-GPUData lazy evaluator. */
-export {GPUDataEvaluator as GPUDataEvaluator};
-export type GPUDataEvaluatorEvaluateOptions = GPUDataEvaluatorEvaluateOptions;
-export type GPUDataEvaluatorProps = GPUDataEvaluatorProps;
-export type GPUDataEvaluatorInput = GPUDataEvaluator | GPUData;
-
-/** Returns a single-GPUData evaluator, wrapping GPUData inputs when needed. */
-export function getGPUDataEvaluator(input: GPUDataEvaluatorInput): GPUDataEvaluator {
-  return input instanceof GPUDataEvaluator ? input : GPUDataEvaluator.fromGPUData(input);
-}
-
-/** Returns source format only when it exactly matches the requested evaluator layout. */
+/**
+ * Returns the source format when it exactly matches a requested evaluator layout.
+ *
+ * @param input - Evaluator whose preserved format should be checked.
+ * @param type - Required scalar element type.
+ * @param size - Required scalar component count.
+ * @param normalized - Required normalized integer interpretation.
+ * @returns The compatible source format, or `undefined` when the layout changes.
+ */
 export function getCompatibleGPUDataEvaluatorFormat(
   input: GPUDataEvaluator,
   type: SignedDataType,
@@ -548,45 +547,29 @@ export function getCompatibleGPUDataEvaluatorFormat(
   return input.format === expectedFormat ? input.format : undefined;
 }
 
-function validatePackedNumericGPUVector(vector: GPUVector): void {
-  if (vector.bufferLayout) {
-    throw new Error(
-      `GPUDataEvaluator.fromGPUVector() does not accept interleaved vector "${vector.name}"`
-    );
-  }
-  validatePackedNumericGPUData(getSingleGPUVectorData(vector), 'GPUVector', vector.name);
-}
-
-function validatePackedNumericGPUData(
-  data: GPUData,
-  sourceType: 'GPUData' | 'GPUVector' = 'GPUData',
-  sourceName?: string
-): void {
-  const sourceDescription =
-    sourceType === 'GPUVector'
-      ? `vector "${sourceName}"`
-      : sourceName
-        ? `GPUData "${sourceName}"`
-        : 'GPUData';
+function validatePackedNumericGPUData(data: GPUData): void {
   if (!data.format) {
-    throw new Error(`GPUDataEvaluator.from${sourceType}() requires ${sourceType} format metadata`);
+    throw new Error('GPUDataEvaluator.fromGPUData() requires GPUData format metadata');
   }
   if (isVertexListGPUVectorFormat(data.format)) {
-    throw new Error(`GPUDataEvaluator.from${sourceType}() does not support vertex-list input`);
+    throw new Error('GPUDataEvaluator.fromGPUData() does not support vertex-list input');
   }
   const formatInfo = getGPUVectorFormatInfo(data.format);
   const expectedRowByteLength = formatInfo.byteLength;
   if (data.rowByteLength !== expectedRowByteLength) {
     throw new Error(
-      `GPUDataEvaluator.from${sourceType}() requires rowByteLength ${expectedRowByteLength} for ${sourceDescription}`
+      `GPUDataEvaluator.fromGPUData() requires rowByteLength ${expectedRowByteLength} for GPUData`
     );
   }
   if (data.byteStride !== data.rowByteLength) {
-    throw new Error(`GPUDataEvaluator.from${sourceType}() requires packed ${sourceDescription}`);
+    throw new Error('GPUDataEvaluator.fromGPUData() requires packed GPUData');
   }
 }
 
-function getGPUTablePropsFromGPUData(data: GPUData): {type: SignedDataType; size: number} {
+function getGPUDataEvaluatorPropsFromGPUData(data: GPUData): {
+  type: SignedDataType;
+  size: number;
+} {
   if (!data.format) {
     throw new Error('GPUDataEvaluator.fromGPUData() requires GPUData format metadata');
   }

--- a/modules/gpgpu/src/operation/gpu-vector-evaluator.ts
+++ b/modules/gpgpu/src/operation/gpu-vector-evaluator.ts
@@ -6,27 +6,42 @@ import type {Device} from '@luma.gl/core';
 import {GPUVector, type GPUVectorFormat} from '@luma.gl/tables';
 import {GPUDataEvaluator, type GPUDataEvaluatorEvaluateOptions} from './gpu-data-evaluator';
 
-/** Evaluation options for {@link GPUVectorEvaluator.evaluate}. */
+/** Options for materializing one {@link GPUVectorEvaluator}. */
 export type GPUVectorEvaluatorEvaluateOptions = GPUDataEvaluatorEvaluateOptions;
 
-/** Properties used to construct a {@link GPUVectorEvaluator}. */
+/** Options for constructing one vector evaluator from ordered chunk evaluators. */
+export type GPUVectorEvaluatorFromGPUDataEvaluatorsOptions = {
+  /** Optional debug name used by {@link GPUVectorEvaluator.toString}. */
+  id?: string;
+  /** Optional memory format preserved for the materialized `GPUVector`. */
+  format?: GPUVectorFormat;
+};
+
+/** Callback used by {@link GPUVectorEvaluator.mapGPUData}. */
+export type GPUVectorEvaluatorMapGPUDataTransform = (
+  evaluator: GPUDataEvaluator,
+  chunkIndex: number
+) => GPUDataEvaluator;
+
+/** Properties used to construct one {@link GPUVectorEvaluator}. */
 export type GPUVectorEvaluatorProps = {
   /** Optional debug name used by {@link GPUVectorEvaluator.toString}. */
   id?: string;
   /** Ordered lazy GPUData transforms preserved as GPUVector chunks. */
-  gpuDataEvaluators: GPUDataEvaluator[];
+  gpuDataEvaluators: readonly GPUDataEvaluator[];
   /** Existing GPUVector resource wrapped by this evaluator, when already materialized. */
   gpuVector?: GPUVector;
   /** Optional memory format preserved for GPUVector interop. */
   format?: GPUVectorFormat;
 };
 
-/** Input accepted by helpers that normalize GPUVectors into vector evaluators. */
+/** Input accepted by helpers that normalize `GPUVector` resources into vector evaluators. */
 export type GPUVectorEvaluatorInput = GPUVectorEvaluator | GPUVector;
 
 /**
  * Lazy GPUVector transform that preserves ordered GPUData chunk boundaries.
  *
+ * @remarks
  * Use {@link GPUDataEvaluator} for one incoming GPUData chunk. Use this class
  * when one logical GPUVector should evaluate the same transform independently
  * over every GPUData chunk without packing them together.
@@ -45,7 +60,12 @@ export class GPUVectorEvaluator {
   private readonly _ownsGPUDataEvaluators: boolean;
   private _destroyed = false;
 
-  /** Creates a lazy vector evaluator over one existing packed numeric GPUVector. */
+  /**
+   * Creates one lazy vector evaluator over an existing fixed-width `GPUVector`.
+   *
+   * @param vector - Ordered `GPUData` chunks to preserve.
+   * @returns One evaluator that borrows the existing vector chunks.
+   */
   static fromGPUVector(vector: GPUVector): GPUVectorEvaluator {
     if (vector.bufferLayout) {
       throw new Error(
@@ -66,10 +86,16 @@ export class GPUVectorEvaluator {
     });
   }
 
-  /** Creates a lazy vector evaluator from already-built GPUData evaluators. */
+  /**
+   * Creates one lazy vector evaluator from already-built chunk evaluators.
+   *
+   * @param gpuDataEvaluators - Ordered chunk evaluators to preserve.
+   * @param options - Optional debug id and output format.
+   * @returns One evaluator that materializes the chunk evaluators as a `GPUVector`.
+   */
   static fromGPUDataEvaluators(
-    gpuDataEvaluators: GPUDataEvaluator[],
-    options: {id?: string; format?: GPUVectorFormat} = {}
+    gpuDataEvaluators: readonly GPUDataEvaluator[],
+    options: GPUVectorEvaluatorFromGPUDataEvaluatorsOptions = {}
   ): GPUVectorEvaluator {
     return new GPUVectorEvaluator({
       id: options.id,
@@ -78,7 +104,11 @@ export class GPUVectorEvaluator {
     });
   }
 
-  /** Creates a lazy vector evaluator from ordered GPUData evaluator chunks. */
+  /**
+   * Creates one lazy vector evaluator from ordered chunk evaluators.
+   *
+   * @param props - Ordered chunk evaluators and optional borrowed vector metadata.
+   */
   constructor({id, gpuDataEvaluators, gpuVector, format}: GPUVectorEvaluatorProps) {
     if (gpuDataEvaluators.length === 0) {
       throw new Error('GPUVectorEvaluator requires at least one GPUData evaluator');
@@ -93,12 +123,12 @@ export class GPUVectorEvaluator {
     this._ownsGPUDataEvaluators = !gpuVector;
   }
 
-  /** Whether a GPUVector has been materialized for this evaluator. */
+  /** Whether a `GPUVector` has been materialized for this evaluator. */
   get evaluated(): boolean {
     return Boolean(this._gpuVector);
   }
 
-  /** Materialized GPUVector resource. Only available after {@link GPUVectorEvaluator.evaluate} resolves. */
+  /** Materialized `GPUVector` resource. */
   get gpuVector(): GPUVector {
     if (!this._gpuVector) {
       throw new Error(`${this} not evaluated`);
@@ -106,17 +136,26 @@ export class GPUVectorEvaluator {
     return this._gpuVector;
   }
 
-  /** Applies one lazy GPUData transform independently to every preserved chunk. */
-  mapGPUData(
-    transform: (evaluator: GPUDataEvaluator, chunkIndex: number) => GPUDataEvaluator
-  ): GPUVectorEvaluator {
+  /**
+   * Applies one lazy transform independently to every preserved `GPUData` chunk.
+   *
+   * @param transform - Callback that returns the transformed evaluator for each chunk.
+   * @returns One vector evaluator with the same chunk order and boundaries.
+   */
+  mapGPUData(transform: GPUVectorEvaluatorMapGPUDataTransform): GPUVectorEvaluator {
     return GPUVectorEvaluator.fromGPUDataEvaluators(
       this.gpuDataEvaluators.map((evaluator, chunkIndex) => transform(evaluator, chunkIndex)),
       {id: this.id}
     );
   }
 
-  /** Materializes every GPUData transform and returns one chunk-preserving GPUVector. */
+  /**
+   * Materializes every chunk evaluator and returns one chunk-preserving `GPUVector`.
+   *
+   * @param device - Device used to materialize every chunk evaluator.
+   * @param options - Output view metadata for each materialized chunk.
+   * @returns One `GPUVector` with the original ordered chunk boundaries.
+   */
   async evaluate(
     device: Device,
     options: GPUVectorEvaluatorEvaluateOptions = {}
@@ -147,7 +186,7 @@ export class GPUVectorEvaluator {
     return this._gpuVector;
   }
 
-  /** Releases cached GPU resources owned through child GPUData evaluators. */
+  /** Releases cached GPU resources owned through child `GPUDataEvaluator` instances. */
   destroy(): void {
     if (this._ownsGPUDataEvaluators) {
       for (const evaluator of this.gpuDataEvaluators) {
@@ -164,12 +203,17 @@ export class GPUVectorEvaluator {
   }
 }
 
-/** Returns a vector evaluator, wrapping GPUVector inputs when needed. */
+/**
+ * Returns one vector evaluator, adapting `GPUVector` inputs when needed.
+ *
+ * @param input - Existing evaluator or fixed-width `GPUVector`.
+ * @returns One `GPUVectorEvaluator` that preserves ordered chunk boundaries.
+ */
 export function getGPUVectorEvaluator(input: GPUVectorEvaluatorInput): GPUVectorEvaluator {
   return input instanceof GPUVectorEvaluator ? input : GPUVectorEvaluator.fromGPUVector(input);
 }
 
-function validateMatchingGPUDataEvaluators(gpuDataEvaluators: GPUDataEvaluator[]): void {
+function validateMatchingGPUDataEvaluators(gpuDataEvaluators: readonly GPUDataEvaluator[]): void {
   const firstEvaluator = gpuDataEvaluators[0];
   for (const evaluator of gpuDataEvaluators.slice(1)) {
     if (

--- a/modules/gpgpu/src/operation/gpu-vector-evaluator.ts
+++ b/modules/gpgpu/src/operation/gpu-vector-evaluator.ts
@@ -1,0 +1,192 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Device} from '@luma.gl/core';
+import {GPUVector, type GPUVectorFormat} from '@luma.gl/tables';
+import {GPUDataEvaluator, type GPUDataEvaluatorEvaluateOptions} from './gpu-data-evaluator';
+
+/** Evaluation options for {@link GPUVectorEvaluator.evaluate}. */
+export type GPUVectorEvaluatorEvaluateOptions = GPUDataEvaluatorEvaluateOptions;
+
+/** Properties used to construct a {@link GPUVectorEvaluator}. */
+export type GPUVectorEvaluatorProps = {
+  /** Optional debug name used by {@link GPUVectorEvaluator.toString}. */
+  id?: string;
+  /** Ordered lazy GPUData transforms preserved as GPUVector chunks. */
+  gpuDataEvaluators: GPUDataEvaluator[];
+  /** Existing GPUVector resource wrapped by this evaluator, when already materialized. */
+  gpuVector?: GPUVector;
+  /** Optional memory format preserved for GPUVector interop. */
+  format?: GPUVectorFormat;
+};
+
+/** Input accepted by helpers that normalize GPUVectors into vector evaluators. */
+export type GPUVectorEvaluatorInput = GPUVectorEvaluator | GPUVector;
+
+/**
+ * Lazy GPUVector transform that preserves ordered GPUData chunk boundaries.
+ *
+ * Use {@link GPUDataEvaluator} for one incoming GPUData chunk. Use this class
+ * when one logical GPUVector should evaluate the same transform independently
+ * over every GPUData chunk without packing them together.
+ */
+export class GPUVectorEvaluator {
+  /** Ordered lazy GPUData transforms preserved as GPUVector chunks. */
+  readonly gpuDataEvaluators: readonly GPUDataEvaluator[];
+  /** Optional memory format preserved for GPUVector interop. */
+  readonly format?: GPUVectorFormat;
+  /** Total logical rows across preserved GPUData chunks. */
+  readonly length: number;
+  /** Optional debug id or source GPUVector name. */
+  readonly id?: string;
+
+  private _gpuVector?: GPUVector;
+  private readonly _ownsGPUDataEvaluators: boolean;
+  private _destroyed = false;
+
+  /** Creates a lazy vector evaluator over one existing packed numeric GPUVector. */
+  static fromGPUVector(vector: GPUVector): GPUVectorEvaluator {
+    if (vector.bufferLayout) {
+      throw new Error(
+        `GPUVectorEvaluator.fromGPUVector() does not accept interleaved vector "${vector.name}"`
+      );
+    }
+    if (vector.data.length === 0) {
+      throw new Error(`GPUVectorEvaluator.fromGPUVector() requires GPUData for "${vector.name}"`);
+    }
+
+    return new GPUVectorEvaluator({
+      id: vector.name,
+      gpuDataEvaluators: vector.data.map(data =>
+        GPUDataEvaluator.fromGPUData(data, {id: vector.name})
+      ),
+      gpuVector: vector,
+      format: vector.format
+    });
+  }
+
+  /** Creates a lazy vector evaluator from already-built GPUData evaluators. */
+  static fromGPUDataEvaluators(
+    gpuDataEvaluators: GPUDataEvaluator[],
+    options: {id?: string; format?: GPUVectorFormat} = {}
+  ): GPUVectorEvaluator {
+    return new GPUVectorEvaluator({
+      id: options.id,
+      gpuDataEvaluators,
+      format: options.format
+    });
+  }
+
+  /** Creates a lazy vector evaluator from ordered GPUData evaluator chunks. */
+  constructor({id, gpuDataEvaluators, gpuVector, format}: GPUVectorEvaluatorProps) {
+    if (gpuDataEvaluators.length === 0) {
+      throw new Error('GPUVectorEvaluator requires at least one GPUData evaluator');
+    }
+    validateMatchingGPUDataEvaluators(gpuDataEvaluators);
+
+    this.id = id;
+    this.gpuDataEvaluators = gpuDataEvaluators;
+    this.format = format ?? gpuDataEvaluators[0].format;
+    this.length = gpuDataEvaluators.reduce((length, evaluator) => length + evaluator.length, 0);
+    this._gpuVector = gpuVector;
+    this._ownsGPUDataEvaluators = !gpuVector;
+  }
+
+  /** Whether a GPUVector has been materialized for this evaluator. */
+  get evaluated(): boolean {
+    return Boolean(this._gpuVector);
+  }
+
+  /** Materialized GPUVector resource. Only available after {@link GPUVectorEvaluator.evaluate} resolves. */
+  get gpuVector(): GPUVector {
+    if (!this._gpuVector) {
+      throw new Error(`${this} not evaluated`);
+    }
+    return this._gpuVector;
+  }
+
+  /** Applies one lazy GPUData transform independently to every preserved chunk. */
+  mapGPUData(
+    transform: (evaluator: GPUDataEvaluator, chunkIndex: number) => GPUDataEvaluator
+  ): GPUVectorEvaluator {
+    return GPUVectorEvaluator.fromGPUDataEvaluators(
+      this.gpuDataEvaluators.map((evaluator, chunkIndex) => transform(evaluator, chunkIndex)),
+      {id: this.id}
+    );
+  }
+
+  /** Materializes every GPUData transform and returns one chunk-preserving GPUVector. */
+  async evaluate(
+    device: Device,
+    options: GPUVectorEvaluatorEvaluateOptions = {}
+  ): Promise<GPUVector> {
+    if (this._destroyed) {
+      throw new Error(`GPUVectorEvaluator ${this} already destroyed`);
+    }
+    if (this._gpuVector) {
+      return this._gpuVector;
+    }
+
+    const gpuVectors = await Promise.all(
+      this.gpuDataEvaluators.map(evaluator => evaluator.evaluate(device, options))
+    );
+    const firstVector = gpuVectors[0];
+    const data = gpuVectors.map(getSingleGPUVectorData);
+    const format = options.format ?? this.format ?? firstVector.format;
+    this._gpuVector = new GPUVector({
+      type: 'data',
+      name: options.name ?? this.id ?? 'vector',
+      format,
+      data,
+      stride: firstVector.stride,
+      byteStride: firstVector.byteStride,
+      rowByteLength: firstVector.rowByteLength,
+      bufferLayout: firstVector.bufferLayout
+    });
+    return this._gpuVector;
+  }
+
+  /** Releases cached GPU resources owned through child GPUData evaluators. */
+  destroy(): void {
+    if (this._ownsGPUDataEvaluators) {
+      for (const evaluator of this.gpuDataEvaluators) {
+        evaluator.destroy();
+      }
+    }
+    this._gpuVector = undefined;
+    this._destroyed = true;
+  }
+
+  /** Returns the debug id or class name. */
+  toString(): string {
+    return this.id ?? this.constructor.name;
+  }
+}
+
+/** Returns a vector evaluator, wrapping GPUVector inputs when needed. */
+export function getGPUVectorEvaluator(input: GPUVectorEvaluatorInput): GPUVectorEvaluator {
+  return input instanceof GPUVectorEvaluator ? input : GPUVectorEvaluator.fromGPUVector(input);
+}
+
+function validateMatchingGPUDataEvaluators(gpuDataEvaluators: GPUDataEvaluator[]): void {
+  const firstEvaluator = gpuDataEvaluators[0];
+  for (const evaluator of gpuDataEvaluators.slice(1)) {
+    if (
+      evaluator.type !== firstEvaluator.type ||
+      evaluator.size !== firstEvaluator.size ||
+      evaluator.normalized !== firstEvaluator.normalized ||
+      evaluator.format !== firstEvaluator.format
+    ) {
+      throw new Error('GPUVectorEvaluator requires matching GPUData evaluator layouts');
+    }
+  }
+}
+
+function getSingleGPUVectorData(vector: GPUVector) {
+  const [data, ...remainingData] = vector.data;
+  if (!data || remainingData.length > 0) {
+    throw new Error(`GPUVectorEvaluator requires one GPUData chunk for "${vector.name}"`);
+  }
+  return data;
+}

--- a/modules/gpgpu/src/operation/operation.ts
+++ b/modules/gpgpu/src/operation/operation.ts
@@ -4,7 +4,7 @@
 
 import type {Device, Buffer} from '@luma.gl/core';
 import type {TypedArray} from '@math.gl/types';
-import {GPUTableEvaluator} from './gpu-table-evaluator';
+import {GPUDataEvaluator} from './gpu-data-evaluator';
 import {backendRegistry} from './backend-registry';
 
 /** Backend implementation for a single lazy GPGPU operation. */
@@ -14,7 +14,7 @@ export type OperationHandler<InputsT extends Record<string, any> = any> = (args:
   /** Operation inputs. */
   inputs: InputsT;
   /** Logical output table describing the target layout. */
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
   /** GPU buffer that receives operation output. */
   target: Buffer;
 }) => Promise<OperationHandlerResult>;
@@ -34,18 +34,18 @@ export abstract class Operation<InputsT extends Record<string, any> = Record<str
   /** Input table map for this operation. */
   inputs: InputsT;
   /** Input tables that need evaluation before this operation can run. */
-  dependencies: GPUTableEvaluator[];
+  dependencies: GPUDataEvaluator[];
 
   constructor(inputs: InputsT) {
     this.inputs = inputs;
-    this.dependencies = Object.values(inputs).filter(i => i instanceof GPUTableEvaluator);
+    this.dependencies = Object.values(inputs).filter(i => i instanceof GPUDataEvaluator);
   }
 
   /** Unique identifier of this operation, e.g. 'add' */
   abstract get name(): string;
 
   /** Logical output table produced by this operation. */
-  abstract get output(): GPUTableEvaluator;
+  abstract get output(): GPUDataEvaluator;
 
   /** Human friendly string that describes this operation */
   abstract toString(): string;

--- a/modules/gpgpu/src/operation/operation.ts
+++ b/modules/gpgpu/src/operation/operation.ts
@@ -13,7 +13,7 @@ export type OperationHandler<InputsT extends Record<string, any> = any> = (args:
   device: Device;
   /** Operation inputs. */
   inputs: InputsT;
-  /** Logical output table describing the target layout. */
+  /** Logical output evaluator describing the target layout. */
   output: GPUDataEvaluator;
   /** GPU buffer that receives operation output. */
   target: Buffer;
@@ -28,12 +28,12 @@ export type OperationHandlerResult = {
  * Base class for deferred GPGPU operations.
  *
  * Operations form a lazy dependency graph. Calling {@link Operation.execute} first materializes
- * dependent tables, then dispatches either a CPU handler or a backend-specific GPU handler.
+ * dependent evaluators, then dispatches either a CPU handler or a backend-specific GPU handler.
  */
 export abstract class Operation<InputsT extends Record<string, any> = Record<string, any>> {
-  /** Input table map for this operation. */
+  /** Input evaluator map for this operation. */
   inputs: InputsT;
-  /** Input tables that need evaluation before this operation can run. */
+  /** Input evaluators that need evaluation before this operation can run. */
   dependencies: GPUDataEvaluator[];
 
   constructor(inputs: InputsT) {
@@ -44,7 +44,7 @@ export abstract class Operation<InputsT extends Record<string, any> = Record<str
   /** Unique identifier of this operation, e.g. 'add' */
   abstract get name(): string;
 
-  /** Logical output table produced by this operation. */
+  /** Logical output evaluator produced by this operation. */
   abstract get output(): GPUDataEvaluator;
 
   /** Human friendly string that describes this operation */

--- a/modules/gpgpu/src/operations/arithmetic-operation.ts
+++ b/modules/gpgpu/src/operations/arithmetic-operation.ts
@@ -3,11 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 import {
-  getCompatibleGPUTableEvaluatorFormat,
-  getGPUTableEvaluator,
-  GPUTableEvaluator,
-  type GPUTableEvaluatorInput
-} from '../operation/gpu-table-evaluator';
+  getCompatibleGPUDataEvaluatorFormat,
+  getGPUDataEvaluator,
+  GPUDataEvaluator,
+  type GPUDataEvaluatorInput
+} from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
 import {
   compileExpression,
@@ -33,11 +33,11 @@ export type ArithmeticOp =
 
 export type ArithmeticOperationInputs = {
   expression: Expression<ArithmeticOp>;
-  namedInputs: Record<string, GPUTableEvaluator>;
+  namedInputs: Record<string, GPUDataEvaluator>;
 };
 
-export type ArithmeticArgument = GPUTableEvaluatorInput | number | number[];
-type NormalizedArithmeticArgument = GPUTableEvaluator | number | number[];
+export type ArithmeticArgument = GPUDataEvaluatorInput | number | number[];
+type NormalizedArithmeticArgument = GPUDataEvaluator | number | number[];
 
 export const ARITHMETIC_OPERATIONS: ExpressionOperations<ArithmeticOp> = {
   add: {arity: 2, symbol: 'arithmetic_add'},
@@ -59,11 +59,11 @@ const FLOAT_OUTPUT_OPS = new Set<ArithmeticOp>(['pow', 'sqrt', 'sin', 'cos', 'ta
 export class ArithmeticOperation extends Operation<ArithmeticOperationInputs> {
   name = 'arithmetic';
 
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
   constructor(op: ArithmeticOp, args: ArithmeticArgument[]) {
     const evaluatorArgs = args.map(arg =>
-      isLiteralArgument(arg) ? arg : getGPUTableEvaluator(arg)
+      isLiteralArgument(arg) ? arg : getGPUDataEvaluator(arg)
     );
     const {expression, namedInputs, dependencies} = getMergedExpressionAndInputs(op, evaluatorArgs);
     super({
@@ -74,15 +74,15 @@ export class ArithmeticOperation extends Operation<ArithmeticOperationInputs> {
 
     const {isConstant, type, size, length} = deduceArithmeticOutputProps(op, evaluatorArgs);
     const firstInput = evaluatorArgs.find(
-      (arg): arg is GPUTableEvaluator => arg instanceof GPUTableEvaluator
+      (arg): arg is GPUDataEvaluator => arg instanceof GPUDataEvaluator
     );
-    this.output = new GPUTableEvaluator({
+    this.output = new GPUDataEvaluator({
       isConstant,
       type,
       size,
       length,
       format: firstInput
-        ? getCompatibleGPUTableEvaluatorFormat(firstInput, type, size, firstInput.normalized)
+        ? getCompatibleGPUDataEvaluatorFormat(firstInput, type, size, firstInput.normalized)
         : undefined,
       source: this
     });
@@ -114,12 +114,12 @@ function getMergedExpressionAndInputs(
   args: NormalizedArithmeticArgument[]
 ): {
   expression: Expression<ArithmeticOp>;
-  namedInputs: Record<string, GPUTableEvaluator>;
-  dependencies: GPUTableEvaluator[];
+  namedInputs: Record<string, GPUDataEvaluator>;
+  dependencies: GPUDataEvaluator[];
 } {
   const argExpressions: Expression<ArithmeticOp>[] = [];
-  const namedInputs: Record<string, GPUTableEvaluator> = {};
-  const dependencies = new Set<GPUTableEvaluator>();
+  const namedInputs: Record<string, GPUDataEvaluator> = {};
+  const dependencies = new Set<GPUDataEvaluator>();
   let nextInputIndex = 0;
 
   for (const arg of args) {
@@ -164,7 +164,7 @@ function getMergedExpressionAndInputs(
 
 function deduceArithmeticOutputProps(op: ArithmeticOp, args: NormalizedArithmeticArgument[]) {
   const evaluatorArgs = args.filter(
-    (arg): arg is GPUTableEvaluator => arg instanceof GPUTableEvaluator
+    (arg): arg is GPUDataEvaluator => arg instanceof GPUDataEvaluator
   );
   const literalArgs = args.filter(isLiteralArgument);
 
@@ -199,7 +199,7 @@ function isLiteralArgument(
 }
 
 function getRemappedInputNames(
-  namedInputs: Record<string, GPUTableEvaluator>,
+  namedInputs: Record<string, GPUDataEvaluator>,
   startIndex: number
 ): Record<string, string> {
   const inputNameMap: Record<string, string> = {};

--- a/modules/gpgpu/src/operations/arithmetic.ts
+++ b/modules/gpgpu/src/operations/arithmetic.ts
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {GPUTableEvaluator} from '../operation/gpu-table-evaluator';
-import {getGPUTableEvaluator} from '../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../operation/gpu-data-evaluator';
+import {getGPUDataEvaluator} from '../operation/gpu-data-evaluator';
 import {ArithmeticArgument, ArithmeticOp, ArithmeticOperation} from './arithmetic-operation';
 
 /**
  * Adds corresponding row elements from two or more tables or literals.
  *
  * The returned table is lazy; no CPU or GPU work is performed until
- * {@link GPUTableEvaluator.evaluate} is called on the result.
+ * {@link GPUDataEvaluator.evaluate} is called on the result.
  */
-export function add(...args: ArithmeticArgument[]): GPUTableEvaluator {
+export function add(...args: ArithmeticArgument[]): GPUDataEvaluator {
   return reduceArithmetic('add', args);
 }
 
@@ -20,9 +20,9 @@ export function add(...args: ArithmeticArgument[]): GPUTableEvaluator {
  * Subtracts corresponding row elements from two or more tables or literals.
  *
  * The returned table is lazy; no CPU or GPU work is performed until
- * {@link GPUTableEvaluator.evaluate} is called on the result.
+ * {@link GPUDataEvaluator.evaluate} is called on the result.
  */
-export function subtract(...args: ArithmeticArgument[]): GPUTableEvaluator {
+export function subtract(...args: ArithmeticArgument[]): GPUDataEvaluator {
   return reduceArithmetic('subtract', args);
 }
 
@@ -30,9 +30,9 @@ export function subtract(...args: ArithmeticArgument[]): GPUTableEvaluator {
  * Multiplies corresponding row elements from two or more tables or literals.
  *
  * The returned table is lazy; no CPU or GPU work is performed until
- * {@link GPUTableEvaluator.evaluate} is called on the result.
+ * {@link GPUDataEvaluator.evaluate} is called on the result.
  */
-export function multiply(...args: ArithmeticArgument[]): GPUTableEvaluator {
+export function multiply(...args: ArithmeticArgument[]): GPUDataEvaluator {
   return reduceArithmetic('multiply', args);
 }
 
@@ -40,76 +40,76 @@ export function multiply(...args: ArithmeticArgument[]): GPUTableEvaluator {
  * Divides corresponding row elements from two or more tables or literals.
  *
  * The returned table is lazy; no CPU or GPU work is performed until
- * {@link GPUTableEvaluator.evaluate} is called on the result.
+ * {@link GPUDataEvaluator.evaluate} is called on the result.
  */
-export function divide(...args: ArithmeticArgument[]): GPUTableEvaluator {
+export function divide(...args: ArithmeticArgument[]): GPUDataEvaluator {
   return reduceArithmetic('divide', args);
 }
 
 /**
  * Raises each row element in `base` to the corresponding power in `exponent`.
  */
-export function pow(base: ArithmeticArgument, exponent: ArithmeticArgument): GPUTableEvaluator {
+export function pow(base: ArithmeticArgument, exponent: ArithmeticArgument): GPUDataEvaluator {
   return new ArithmeticOperation('pow', [base, exponent]).output;
 }
 
 /**
  * Computes the square root of each row element.
  */
-export function sqrt(arg: ArithmeticArgument): GPUTableEvaluator {
+export function sqrt(arg: ArithmeticArgument): GPUDataEvaluator {
   return new ArithmeticOperation('sqrt', [arg]).output;
 }
 
 /**
  * Computes the absolute value of each row element.
  */
-export function abs(arg: ArithmeticArgument): GPUTableEvaluator {
+export function abs(arg: ArithmeticArgument): GPUDataEvaluator {
   return new ArithmeticOperation('abs', [arg]).output;
 }
 
 /**
  * Applies sine to each row element.
  */
-export function sin(arg: ArithmeticArgument): GPUTableEvaluator {
+export function sin(arg: ArithmeticArgument): GPUDataEvaluator {
   return new ArithmeticOperation('sin', [arg]).output;
 }
 
 /**
  * Applies cosine to each row element.
  */
-export function cos(arg: ArithmeticArgument): GPUTableEvaluator {
+export function cos(arg: ArithmeticArgument): GPUDataEvaluator {
   return new ArithmeticOperation('cos', [arg]).output;
 }
 
 /**
  * Applies tangent to each row element.
  */
-export function tan(arg: ArithmeticArgument): GPUTableEvaluator {
+export function tan(arg: ArithmeticArgument): GPUDataEvaluator {
   return new ArithmeticOperation('tan', [arg]).output;
 }
 
 /**
  * Applies the natural exponential to each row element.
  */
-export function exp(arg: ArithmeticArgument): GPUTableEvaluator {
+export function exp(arg: ArithmeticArgument): GPUDataEvaluator {
   return new ArithmeticOperation('exp', [arg]).output;
 }
 
 /**
  * Applies the natural logarithm to each row element.
  */
-export function log(arg: ArithmeticArgument): GPUTableEvaluator {
+export function log(arg: ArithmeticArgument): GPUDataEvaluator {
   return new ArithmeticOperation('log', [arg]).output;
 }
 
 function reduceArithmetic(
   op: Extract<ArithmeticOp, 'add' | 'subtract' | 'multiply' | 'divide'>,
   args: ArithmeticArgument[]
-): GPUTableEvaluator {
-  let result: GPUTableEvaluator | number | number[] =
-    typeof args[0] === 'number' || Array.isArray(args[0]) ? args[0] : getGPUTableEvaluator(args[0]);
+): GPUDataEvaluator {
+  let result: GPUDataEvaluator | number | number[] =
+    typeof args[0] === 'number' || Array.isArray(args[0]) ? args[0] : getGPUDataEvaluator(args[0]);
   for (let i = 1; i < args.length; i++) {
     result = new ArithmeticOperation(op, [result, args[i]]).output;
   }
-  return result instanceof GPUTableEvaluator ? result : GPUTableEvaluator.fromConstant(result);
+  return result instanceof GPUDataEvaluator ? result : GPUDataEvaluator.fromConstant(result);
 }

--- a/modules/gpgpu/src/operations/cpu/common.ts
+++ b/modules/gpgpu/src/operations/cpu/common.ts
@@ -3,22 +3,22 @@
 // Copyright (c) vis.gl contributors
 
 import type {Buffer, TypedArray} from '@luma.gl/core';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import type {OperationHandlerResult} from '../../operation/operation';
 
 type CPUTransformProps =
   | {
       elementWise: true;
       func: (...args: number[]) => number;
-      inputs: {[name: string]: GPUTableEvaluator};
-      output: GPUTableEvaluator;
+      inputs: {[name: string]: GPUDataEvaluator};
+      output: GPUDataEvaluator;
       outputBuffer: Buffer;
     }
   | {
       elementWise?: false;
       func: (...args: TypedArray[]) => void;
-      inputs: {[name: string]: GPUTableEvaluator};
-      output: GPUTableEvaluator;
+      inputs: {[name: string]: GPUDataEvaluator};
+      output: GPUDataEvaluator;
       outputBuffer: Buffer;
     };
 
@@ -62,7 +62,7 @@ export function runCPUTransform({
   };
 }
 
-export function getValueAtRow(source: GPUTableEvaluator, index: number): TypedArray {
+export function getValueAtRow(source: GPUDataEvaluator, index: number): TypedArray {
   const value = source.value!;
   const valueSize = source.size;
   const valueOffset = source.offset / source.ValueType.BYTES_PER_ELEMENT;
@@ -82,7 +82,7 @@ export function getValueAtRow(source: GPUTableEvaluator, index: number): TypedAr
   return normalizedRow;
 }
 
-function normalizeValue(value: number, type: GPUTableEvaluator['type']): number {
+function normalizeValue(value: number, type: GPUDataEvaluator['type']): number {
   switch (type) {
     case 'uint8':
       return value / 255;

--- a/modules/gpgpu/src/operations/cpu/dot.ts
+++ b/modules/gpgpu/src/operations/cpu/dot.ts
@@ -3,10 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getValueAtRow} from './common';
 
-export const dot: OperationHandler<{x: GPUTableEvaluator; y: GPUTableEvaluator}> = async ({
+export const dot: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/cpu/equal-all.ts
+++ b/modules/gpgpu/src/operations/cpu/equal-all.ts
@@ -3,10 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getValueAtRow} from './common';
 
-export const equalAll: OperationHandler<{x: GPUTableEvaluator; y: GPUTableEvaluator}> = async ({
+export const equalAll: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/cpu/extent.ts
+++ b/modules/gpgpu/src/operations/cpu/extent.ts
@@ -3,10 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getValueAtRow} from './common';
 
-export const extent: OperationHandler<{sourceValues: GPUTableEvaluator}> = async ({
+export const extent: OperationHandler<{sourceValues: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/cpu/fround.ts
+++ b/modules/gpgpu/src/operations/cpu/fround.ts
@@ -7,11 +7,7 @@ import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runCPUTransform} from './common';
 import type {TypedArray} from '@luma.gl/core';
 
-export const fround: OperationHandler<{x: GPUDataEvaluator}> = async ({
-  inputs,
-  output,
-  target
-}) => {
+export const fround: OperationHandler<{x: GPUDataEvaluator}> = async ({inputs, output, target}) => {
   return runCPUTransform({
     func: (out: TypedArray, x: TypedArray) => {
       const vertexSize = out.length / 2;

--- a/modules/gpgpu/src/operations/cpu/fround.ts
+++ b/modules/gpgpu/src/operations/cpu/fround.ts
@@ -3,11 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runCPUTransform} from './common';
 import type {TypedArray} from '@luma.gl/core';
 
-export const fround: OperationHandler<{x: GPUTableEvaluator}> = async ({
+export const fround: OperationHandler<{x: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/cpu/gather.ts
+++ b/modules/gpgpu/src/operations/cpu/gather.ts
@@ -3,12 +3,12 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getValueAtRow} from './common';
 
 export const gather: OperationHandler<{
-  ids: GPUTableEvaluator;
-  sourceValues: GPUTableEvaluator;
+  ids: GPUDataEvaluator;
+  sourceValues: GPUDataEvaluator;
 }> = async ({inputs, output, target}) => {
   const {ids, sourceValues} = inputs;
   const idsValue = ids.value;

--- a/modules/gpgpu/src/operations/cpu/interleave.ts
+++ b/modules/gpgpu/src/operations/cpu/interleave.ts
@@ -3,11 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runCPUTransform} from './common';
 import type {TypedArray} from '@luma.gl/core';
 
-export const interleave: OperationHandler<{x: GPUTableEvaluator; y: GPUTableEvaluator}> = async ({
+export const interleave: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/cpu/length.ts
+++ b/modules/gpgpu/src/operations/cpu/length.ts
@@ -3,10 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getValueAtRow} from './common';
 
-export const length: OperationHandler<{x: GPUTableEvaluator}> = async ({
+export const length: OperationHandler<{x: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/cpu/length.ts
+++ b/modules/gpgpu/src/operations/cpu/length.ts
@@ -6,11 +6,7 @@ import {OperationHandler} from '../../operation/operation';
 import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getValueAtRow} from './common';
 
-export const length: OperationHandler<{x: GPUDataEvaluator}> = async ({
-  inputs,
-  output,
-  target
-}) => {
+export const length: OperationHandler<{x: GPUDataEvaluator}> = async ({inputs, output, target}) => {
   const {x} = inputs;
   const result = new output.ValueType(output.length);
 

--- a/modules/gpgpu/src/operations/cpu/segmented-map.ts
+++ b/modules/gpgpu/src/operations/cpu/segmented-map.ts
@@ -3,10 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 
 export const segmentedMap: OperationHandler<{
-  segments: GPUTableEvaluator;
+  segments: GPUDataEvaluator;
   vertexCount: number;
 }> = async ({inputs, output, target}) => {
   const {segments, vertexCount} = inputs;
@@ -42,8 +42,8 @@ export const segmentedMap: OperationHandler<{
 };
 
 function validateSegments(
-  segmentStarts: GPUTableEvaluator['value'],
-  segments: GPUTableEvaluator,
+  segmentStarts: GPUDataEvaluator['value'],
+  segments: GPUDataEvaluator,
   vertexCount: number
 ) {
   if (segments.length < 1) {
@@ -71,7 +71,7 @@ function validateSegments(
   }
 }
 
-function getRowOffset(table: GPUTableEvaluator, rowIndex: number): number {
+function getRowOffset(table: GPUDataEvaluator, rowIndex: number): number {
   return (
     table.offset / table.ValueType.BYTES_PER_ELEMENT +
     rowIndex * (table.stride / table.ValueType.BYTES_PER_ELEMENT)

--- a/modules/gpgpu/src/operations/cpu/select.ts
+++ b/modules/gpgpu/src/operations/cpu/select.ts
@@ -3,13 +3,13 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getValueAtRow} from './common';
 
 export const select: OperationHandler<{
-  condition: GPUTableEvaluator;
-  whenTrue: GPUTableEvaluator;
-  whenFalse: GPUTableEvaluator;
+  condition: GPUDataEvaluator;
+  whenTrue: GPUDataEvaluator;
+  whenFalse: GPUDataEvaluator;
 }> = async ({inputs, output, target}) => {
   const {condition, whenTrue, whenFalse} = inputs;
   const result = new output.ValueType(output.length * output.size);

--- a/modules/gpgpu/src/operations/cpu/swizzle.ts
+++ b/modules/gpgpu/src/operations/cpu/swizzle.ts
@@ -4,10 +4,10 @@
 
 import type {TypedArray} from '@luma.gl/core';
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runCPUTransform} from './common';
 
-export const swizzle: OperationHandler<{x: GPUTableEvaluator; columns: number[]}> = async ({
+export const swizzle: OperationHandler<{x: GPUDataEvaluator; columns: number[]}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/dot.ts
+++ b/modules/gpgpu/src/operations/dot.ts
@@ -3,30 +3,30 @@
 // Copyright (c) vis.gl contributors
 
 import {
-  getGPUTableEvaluator,
-  getCompatibleGPUTableEvaluatorFormat,
-  GPUTableEvaluator,
-  type GPUTableEvaluatorInput
-} from '../operation/gpu-table-evaluator';
+  getGPUDataEvaluator,
+  getCompatibleGPUDataEvaluatorFormat,
+  GPUDataEvaluator,
+  type GPUDataEvaluatorInput
+} from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
 import {deduceOutputProps} from '../utils/output-props';
 
-class DotOperation extends Operation<{x: GPUTableEvaluator; y: GPUTableEvaluator}> {
+class DotOperation extends Operation<{x: GPUDataEvaluator; y: GPUDataEvaluator}> {
   name = 'dot';
 
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
-  constructor(x: GPUTableEvaluator, y: GPUTableEvaluator) {
+  constructor(x: GPUDataEvaluator, y: GPUDataEvaluator) {
     super({x, y});
 
     validateMatchingRowSize('dot', x, y);
     const props = deduceOutputProps(x, y);
-    this.output = new GPUTableEvaluator({
+    this.output = new GPUDataEvaluator({
       isConstant: props.isConstant,
       type: 'float32',
       size: 1,
       length: props.length,
-      format: getCompatibleGPUTableEvaluatorFormat(x, 'float32', 1, x.normalized),
+      format: getCompatibleGPUDataEvaluatorFormat(x, 'float32', 1, x.normalized),
       source: this
     });
   }
@@ -37,11 +37,11 @@ class DotOperation extends Operation<{x: GPUTableEvaluator; y: GPUTableEvaluator
   }
 }
 
-export function dot(x: GPUTableEvaluatorInput, y: GPUTableEvaluatorInput): GPUTableEvaluator {
-  return new DotOperation(getGPUTableEvaluator(x), getGPUTableEvaluator(y)).output;
+export function dot(x: GPUDataEvaluatorInput, y: GPUDataEvaluatorInput): GPUDataEvaluator {
+  return new DotOperation(getGPUDataEvaluator(x), getGPUDataEvaluator(y)).output;
 }
 
-function validateMatchingRowSize(name: string, x: GPUTableEvaluator, y: GPUTableEvaluator): void {
+function validateMatchingRowSize(name: string, x: GPUDataEvaluator, y: GPUDataEvaluator): void {
   if (x.size !== y.size) {
     throw new Error(`${name} inputs must have matching row sizes, got ${x.size} and ${y.size}`);
   }

--- a/modules/gpgpu/src/operations/equal-all.ts
+++ b/modules/gpgpu/src/operations/equal-all.ts
@@ -3,24 +3,24 @@
 // Copyright (c) vis.gl contributors
 
 import {
-  getGPUTableEvaluator,
-  GPUTableEvaluator,
-  type GPUTableEvaluatorInput
-} from '../operation/gpu-table-evaluator';
+  getGPUDataEvaluator,
+  GPUDataEvaluator,
+  type GPUDataEvaluatorInput
+} from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
 import {deduceOutputProps} from '../utils/output-props';
 
-class EqualAllOperation extends Operation<{x: GPUTableEvaluator; y: GPUTableEvaluator}> {
+class EqualAllOperation extends Operation<{x: GPUDataEvaluator; y: GPUDataEvaluator}> {
   name = 'equalAll';
 
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
-  constructor(x: GPUTableEvaluator, y: GPUTableEvaluator) {
+  constructor(x: GPUDataEvaluator, y: GPUDataEvaluator) {
     super({x, y});
 
     validateMatchingRowSize('equalAll', x, y);
     const props = deduceOutputProps(x, y);
-    this.output = new GPUTableEvaluator({
+    this.output = new GPUDataEvaluator({
       isConstant: props.isConstant,
       type: 'uint32',
       size: 1,
@@ -35,11 +35,11 @@ class EqualAllOperation extends Operation<{x: GPUTableEvaluator; y: GPUTableEval
   }
 }
 
-export function equalAll(x: GPUTableEvaluatorInput, y: GPUTableEvaluatorInput): GPUTableEvaluator {
-  return new EqualAllOperation(getGPUTableEvaluator(x), getGPUTableEvaluator(y)).output;
+export function equalAll(x: GPUDataEvaluatorInput, y: GPUDataEvaluatorInput): GPUDataEvaluator {
+  return new EqualAllOperation(getGPUDataEvaluator(x), getGPUDataEvaluator(y)).output;
 }
 
-function validateMatchingRowSize(name: string, x: GPUTableEvaluator, y: GPUTableEvaluator): void {
+function validateMatchingRowSize(name: string, x: GPUDataEvaluator, y: GPUDataEvaluator): void {
   if (x.size !== y.size) {
     throw new Error(`${name} inputs must have matching row sizes, got ${x.size} and ${y.size}`);
   }

--- a/modules/gpgpu/src/operations/extent.ts
+++ b/modules/gpgpu/src/operations/extent.ts
@@ -3,24 +3,24 @@
 // Copyright (c) vis.gl contributors
 
 import {
-  getGPUTableEvaluator,
-  GPUTableEvaluator,
-  type GPUTableEvaluatorInput
-} from '../operation/gpu-table-evaluator';
+  getGPUDataEvaluator,
+  GPUDataEvaluator,
+  type GPUDataEvaluatorInput
+} from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
 
 /** Deferred extent reduction operation. */
-class ExtentOperation extends Operation<{sourceValues: GPUTableEvaluator}> {
+class ExtentOperation extends Operation<{sourceValues: GPUDataEvaluator}> {
   /** Operation name used for backend lookup. */
   name = 'extent';
 
   /** Lazy output table for the per-channel extents. */
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
-  constructor(sourceValues: GPUTableEvaluator) {
+  constructor(sourceValues: GPUDataEvaluator) {
     super({sourceValues});
 
-    this.output = new GPUTableEvaluator({
+    this.output = new GPUDataEvaluator({
       type: sourceValues.type,
       size: 2,
       length: sourceValues.size,
@@ -39,8 +39,8 @@ class ExtentOperation extends Operation<{sourceValues: GPUTableEvaluator}> {
  * Computes `[min, max]` pairs for each channel across all rows in `sourceValues`.
  *
  * The returned table is lazy; no CPU or GPU work is performed until
- * {@link GPUTableEvaluator.evaluate} is called on the result.
+ * {@link GPUDataEvaluator.evaluate} is called on the result.
  */
-export function extent(sourceValues: GPUTableEvaluatorInput): GPUTableEvaluator {
-  return new ExtentOperation(getGPUTableEvaluator(sourceValues)).output;
+export function extent(sourceValues: GPUDataEvaluatorInput): GPUDataEvaluator {
+  return new ExtentOperation(getGPUDataEvaluator(sourceValues)).output;
 }

--- a/modules/gpgpu/src/operations/fround.ts
+++ b/modules/gpgpu/src/operations/fround.ts
@@ -4,26 +4,26 @@
 
 import {assert} from '@luma.gl/core';
 import {
-  getGPUTableEvaluator,
-  GPUTableEvaluator,
-  type GPUTableEvaluatorInput
-} from '../operation/gpu-table-evaluator';
+  getGPUDataEvaluator,
+  GPUDataEvaluator,
+  type GPUDataEvaluatorInput
+} from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
 
 /** Deferred float64 split operation. */
-class FroundOperation extends Operation<{x: GPUTableEvaluator}> {
+class FroundOperation extends Operation<{x: GPUDataEvaluator}> {
   /** Operation name used for backend lookup. */
   name = 'fround';
 
   /** Lazy output table for high and low float32 components. */
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
-  constructor(x: GPUTableEvaluator) {
+  constructor(x: GPUDataEvaluator) {
     assert(x.type === 'uint32');
     super({x});
 
     const {isConstant, size, length} = x;
-    this.output = new GPUTableEvaluator({isConstant, type: 'float32', size, length, source: this});
+    this.output = new GPUDataEvaluator({isConstant, type: 'float32', size, length, source: this});
   }
 
   /** Returns a compact expression for debug output. */
@@ -36,10 +36,10 @@ class FroundOperation extends Operation<{x: GPUTableEvaluator}> {
 /**
  * Splits float64 values into high and low float32 components for fp64-style arithmetic.
  *
- * `GPUTableEvaluator.fromArray()` represents `Float64Array` input as `uint32` pairs; `fround()` consumes
+ * `GPUDataEvaluator.fromArray()` represents `Float64Array` input as `uint32` pairs; `fround()` consumes
  * that representation and returns a lazy `float32` table containing high values followed by
  * residual low values.
  */
-export function fround(x: GPUTableEvaluatorInput): GPUTableEvaluator {
-  return new FroundOperation(getGPUTableEvaluator(x)).output;
+export function fround(x: GPUDataEvaluatorInput): GPUDataEvaluator {
+  return new FroundOperation(getGPUDataEvaluator(x)).output;
 }

--- a/modules/gpgpu/src/operations/gather.ts
+++ b/modules/gpgpu/src/operations/gather.ts
@@ -3,24 +3,24 @@
 // Copyright (c) vis.gl contributors
 
 import {
-  getGPUTableEvaluator,
-  GPUTableEvaluator,
-  type GPUTableEvaluatorInput
-} from '../operation/gpu-table-evaluator';
+  getGPUDataEvaluator,
+  GPUDataEvaluator,
+  type GPUDataEvaluatorInput
+} from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
 
 /** Deferred row gather operation. */
-class GatherOperation extends Operation<{ids: GPUTableEvaluator; sourceValues: GPUTableEvaluator}> {
+class GatherOperation extends Operation<{ids: GPUDataEvaluator; sourceValues: GPUDataEvaluator}> {
   /** Operation name used for backend lookup. */
   name = 'gather';
 
   /** Lazy output table for the gathered rows. */
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
-  constructor(ids: GPUTableEvaluator, sourceValues: GPUTableEvaluator) {
+  constructor(ids: GPUDataEvaluator, sourceValues: GPUDataEvaluator) {
     super({ids, sourceValues});
 
-    this.output = new GPUTableEvaluator({
+    this.output = new GPUDataEvaluator({
       isConstant: ids.isConstant,
       type: sourceValues.type,
       size: sourceValues.size,
@@ -41,11 +41,11 @@ class GatherOperation extends Operation<{ids: GPUTableEvaluator; sourceValues: G
  *
  * Each row in `ids` must be a scalar index. Out-of-range indices return a zero row.
  * The returned table is lazy; no CPU or GPU work is performed until
- * {@link GPUTableEvaluator.evaluate} is called on the result.
+ * {@link GPUDataEvaluator.evaluate} is called on the result.
  */
 export function gather(
-  ids: GPUTableEvaluatorInput,
-  sourceValues: GPUTableEvaluatorInput
-): GPUTableEvaluator {
-  return new GatherOperation(getGPUTableEvaluator(ids), getGPUTableEvaluator(sourceValues)).output;
+  ids: GPUDataEvaluatorInput,
+  sourceValues: GPUDataEvaluatorInput
+): GPUDataEvaluator {
+  return new GatherOperation(getGPUDataEvaluator(ids), getGPUDataEvaluator(sourceValues)).output;
 }

--- a/modules/gpgpu/src/operations/interleave.ts
+++ b/modules/gpgpu/src/operations/interleave.ts
@@ -3,26 +3,26 @@
 // Copyright (c) vis.gl contributors
 
 import {
-  getGPUTableEvaluator,
-  GPUTableEvaluator,
-  type GPUTableEvaluatorInput
-} from '../operation/gpu-table-evaluator';
+  getGPUDataEvaluator,
+  GPUDataEvaluator,
+  type GPUDataEvaluatorInput
+} from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
 import {deduceOutputProps} from '../utils/output-props';
 
 /** Deferred row interleave operation. */
-class InterleaveOperation extends Operation<{x: GPUTableEvaluator; y: GPUTableEvaluator}> {
+class InterleaveOperation extends Operation<{x: GPUDataEvaluator; y: GPUDataEvaluator}> {
   /** Operation name used for backend lookup. */
   name = 'interleave';
 
   /** Lazy output table for the interleaved result. */
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
-  constructor(x: GPUTableEvaluator, y: GPUTableEvaluator) {
+  constructor(x: GPUDataEvaluator, y: GPUDataEvaluator) {
     super({x, y});
 
     const {isConstant, type, length} = deduceOutputProps(x, y);
-    this.output = new GPUTableEvaluator({
+    this.output = new GPUDataEvaluator({
       isConstant,
       type,
       size: x.size + y.size,
@@ -42,12 +42,12 @@ class InterleaveOperation extends Operation<{x: GPUTableEvaluator; y: GPUTableEv
  * Concatenates each input row in argument order.
  *
  * The returned table is lazy; no CPU or GPU work is performed until
- * {@link GPUTableEvaluator.evaluate} is called on the result.
+ * {@link GPUDataEvaluator.evaluate} is called on the result.
  */
-export function interleave(...args: GPUTableEvaluatorInput[]): GPUTableEvaluator {
-  let result = getGPUTableEvaluator(args[0]);
+export function interleave(...args: GPUDataEvaluatorInput[]): GPUDataEvaluator {
+  let result = getGPUDataEvaluator(args[0]);
   for (let i = 1; i < args.length; i++) {
-    result = new InterleaveOperation(result, getGPUTableEvaluator(args[i])).output;
+    result = new InterleaveOperation(result, getGPUDataEvaluator(args[i])).output;
   }
   return result;
 }

--- a/modules/gpgpu/src/operations/length.ts
+++ b/modules/gpgpu/src/operations/length.ts
@@ -3,27 +3,27 @@
 // Copyright (c) vis.gl contributors
 
 import {
-  getGPUTableEvaluator,
-  getCompatibleGPUTableEvaluatorFormat,
-  GPUTableEvaluator,
-  type GPUTableEvaluatorInput
-} from '../operation/gpu-table-evaluator';
+  getGPUDataEvaluator,
+  getCompatibleGPUDataEvaluatorFormat,
+  GPUDataEvaluator,
+  type GPUDataEvaluatorInput
+} from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
 
-class LengthOperation extends Operation<{x: GPUTableEvaluator}> {
+class LengthOperation extends Operation<{x: GPUDataEvaluator}> {
   name = 'length';
 
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
-  constructor(x: GPUTableEvaluator) {
+  constructor(x: GPUDataEvaluator) {
     super({x});
 
-    this.output = new GPUTableEvaluator({
+    this.output = new GPUDataEvaluator({
       isConstant: x.isConstant,
       type: 'float32',
       size: 1,
       length: x.length,
-      format: getCompatibleGPUTableEvaluatorFormat(x, 'float32', 1, x.normalized),
+      format: getCompatibleGPUDataEvaluatorFormat(x, 'float32', 1, x.normalized),
       source: this
     });
   }
@@ -33,6 +33,6 @@ class LengthOperation extends Operation<{x: GPUTableEvaluator}> {
   }
 }
 
-export function length(x: GPUTableEvaluatorInput): GPUTableEvaluator {
-  return new LengthOperation(getGPUTableEvaluator(x)).output;
+export function length(x: GPUDataEvaluatorInput): GPUDataEvaluator {
+  return new LengthOperation(getGPUDataEvaluator(x)).output;
 }

--- a/modules/gpgpu/src/operations/segmented-map.ts
+++ b/modules/gpgpu/src/operations/segmented-map.ts
@@ -3,14 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 import {
-  getGPUTableEvaluator,
-  GPUTableEvaluator,
-  type GPUTableEvaluatorInput
-} from '../operation/gpu-table-evaluator';
+  getGPUDataEvaluator,
+  GPUDataEvaluator,
+  type GPUDataEvaluatorInput
+} from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
 
 type SegmentedMapInputs = {
-  segments: GPUTableEvaluator;
+  segments: GPUDataEvaluator;
   vertexCount: number;
 };
 
@@ -20,12 +20,12 @@ class SegmentedMapOperation extends Operation<SegmentedMapInputs> {
   name = 'segmentedMap';
 
   /** Lazy output table for the segmented mapping result. */
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
-  constructor(segments: GPUTableEvaluator, vertexCount: number) {
+  constructor(segments: GPUDataEvaluator, vertexCount: number) {
     super({segments, vertexCount});
 
-    this.output = new GPUTableEvaluator({
+    this.output = new GPUDataEvaluator({
       type: 'uint32',
       size: 2,
       length: vertexCount,
@@ -48,9 +48,9 @@ class SegmentedMapOperation extends Operation<SegmentedMapInputs> {
  * the exclusive end of the final segment.
  */
 export function segmentedMap(
-  segments: GPUTableEvaluatorInput,
+  segments: GPUDataEvaluatorInput,
   vertexCount: number
-): GPUTableEvaluator {
+): GPUDataEvaluator {
   if (!Number.isInteger(vertexCount)) {
     throw new Error(`segmentedMap vertexCount must be an integer, got ${vertexCount}`);
   }
@@ -58,7 +58,7 @@ export function segmentedMap(
     throw new Error(`segmentedMap vertexCount must be non-negative, got ${vertexCount}`);
   }
 
-  const segmentsTable = getGPUTableEvaluator(segments);
+  const segmentsTable = getGPUDataEvaluator(segments);
   if (segmentsTable.length < 1) {
     throw new Error('segmentedMap segments must contain at least one segment start');
   }
@@ -73,7 +73,7 @@ export function segmentedMap(
   return new SegmentedMapOperation(segmentsTable, vertexCount).output;
 }
 
-function validateSegmentsIfAvailable(segments: GPUTableEvaluator, vertexCount: number): void {
+function validateSegmentsIfAvailable(segments: GPUDataEvaluator, vertexCount: number): void {
   const segmentStarts = segments.value;
   if (!segmentStarts) {
     return;
@@ -100,7 +100,7 @@ function validateSegmentsIfAvailable(segments: GPUTableEvaluator, vertexCount: n
   }
 }
 
-function getRowOffset(table: GPUTableEvaluator, rowIndex: number): number {
+function getRowOffset(table: GPUDataEvaluator, rowIndex: number): number {
   return (
     table.offset / table.ValueType.BYTES_PER_ELEMENT +
     rowIndex * (table.stride / table.ValueType.BYTES_PER_ELEMENT)

--- a/modules/gpgpu/src/operations/select.ts
+++ b/modules/gpgpu/src/operations/select.ts
@@ -3,27 +3,27 @@
 // Copyright (c) vis.gl contributors
 
 import {
-  getCompatibleGPUTableEvaluatorFormat,
-  getGPUTableEvaluator,
-  GPUTableEvaluator,
-  type GPUTableEvaluatorInput
-} from '../operation/gpu-table-evaluator';
+  getCompatibleGPUDataEvaluatorFormat,
+  getGPUDataEvaluator,
+  GPUDataEvaluator,
+  type GPUDataEvaluatorInput
+} from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
 import {deduceOutputProps} from '../utils/output-props';
 
 class SelectOperation extends Operation<{
-  condition: GPUTableEvaluator;
-  whenTrue: GPUTableEvaluator;
-  whenFalse: GPUTableEvaluator;
+  condition: GPUDataEvaluator;
+  whenTrue: GPUDataEvaluator;
+  whenFalse: GPUDataEvaluator;
 }> {
   name = 'select';
 
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
   constructor(
-    condition: GPUTableEvaluator,
-    whenTrue: GPUTableEvaluator,
-    whenFalse: GPUTableEvaluator
+    condition: GPUDataEvaluator,
+    whenTrue: GPUDataEvaluator,
+    whenFalse: GPUDataEvaluator
   ) {
     super({condition, whenTrue, whenFalse});
 
@@ -33,14 +33,14 @@ class SelectOperation extends Operation<{
     validateInputSize('select whenTrue', whenTrue.size, valueProps.size);
     validateInputSize('select whenFalse', whenFalse.size, valueProps.size);
 
-    this.output = new GPUTableEvaluator({
+    this.output = new GPUDataEvaluator({
       isConstant: conditionAndLengthProps.isConstant,
       type: valueProps.type,
       size: valueProps.size,
       length: conditionAndLengthProps.length,
       format:
-        getCompatibleGPUTableEvaluatorFormat(whenTrue, valueProps.type, valueProps.size) ??
-        getCompatibleGPUTableEvaluatorFormat(whenFalse, valueProps.type, valueProps.size),
+        getCompatibleGPUDataEvaluatorFormat(whenTrue, valueProps.type, valueProps.size) ??
+        getCompatibleGPUDataEvaluatorFormat(whenFalse, valueProps.type, valueProps.size),
       source: this
     });
   }
@@ -58,14 +58,14 @@ class SelectOperation extends Operation<{
  * output row size. Scalar rows broadcast across lanes.
  */
 export function select(
-  condition: GPUTableEvaluatorInput,
-  whenTrue: GPUTableEvaluatorInput,
-  whenFalse: GPUTableEvaluatorInput
-): GPUTableEvaluator {
+  condition: GPUDataEvaluatorInput,
+  whenTrue: GPUDataEvaluatorInput,
+  whenFalse: GPUDataEvaluatorInput
+): GPUDataEvaluator {
   return new SelectOperation(
-    getGPUTableEvaluator(condition),
-    getGPUTableEvaluator(whenTrue),
-    getGPUTableEvaluator(whenFalse)
+    getGPUDataEvaluator(condition),
+    getGPUDataEvaluator(whenTrue),
+    getGPUDataEvaluator(whenFalse)
   ).output;
 }
 

--- a/modules/gpgpu/src/operations/sequence.ts
+++ b/modules/gpgpu/src/operations/sequence.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {GPUTableEvaluator} from '../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
 
 type SequenceInputs = {
@@ -16,12 +16,12 @@ class SequenceOperation extends Operation<SequenceInputs> {
   name = 'sequence';
 
   /** Lazy output table for the generated sequence. */
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
   constructor(start: number, length: number, step: number) {
     super({start, step});
 
-    this.output = new GPUTableEvaluator({
+    this.output = new GPUDataEvaluator({
       type: 'sint32',
       size: 1,
       length,
@@ -39,7 +39,7 @@ class SequenceOperation extends Operation<SequenceInputs> {
 /**
  * Generates an integer sequence with `count` values starting at `start` and incrementing by `step`.
  */
-export function sequence(count: number, start: number = 0, step: number = 1): GPUTableEvaluator {
+export function sequence(count: number, start: number = 0, step: number = 1): GPUDataEvaluator {
   ensureInteger('count', count);
   ensureInteger('start', start);
   ensureInteger('step', step);

--- a/modules/gpgpu/src/operations/swizzle.ts
+++ b/modules/gpgpu/src/operations/swizzle.ts
@@ -4,21 +4,21 @@
 
 import {type TypedArray} from '@math.gl/types';
 import {
-  getGPUTableEvaluator,
-  GPUTableEvaluator,
-  type GPUTableEvaluatorInput
-} from '../operation/gpu-table-evaluator';
+  getGPUDataEvaluator,
+  GPUDataEvaluator,
+  type GPUDataEvaluatorInput
+} from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
 
-class SwizzleOperation extends Operation<{x: GPUTableEvaluator; columns: number[]}> {
+class SwizzleOperation extends Operation<{x: GPUDataEvaluator; columns: number[]}> {
   name = 'swizzle';
 
-  output: GPUTableEvaluator;
+  output: GPUDataEvaluator;
 
-  constructor(x: GPUTableEvaluator, columns: number[]) {
+  constructor(x: GPUDataEvaluator, columns: number[]) {
     super({x, columns});
 
-    this.output = new GPUTableEvaluator({
+    this.output = new GPUDataEvaluator({
       isConstant: x.isConstant,
       type: x.type,
       size: columns.length,
@@ -34,13 +34,13 @@ class SwizzleOperation extends Operation<{x: GPUTableEvaluator; columns: number[
   }
 }
 
-export function swizzle(table: GPUTableEvaluatorInput, columns: number[]): GPUTableEvaluator {
-  const source = getGPUTableEvaluator(table);
+export function swizzle(table: GPUDataEvaluatorInput, columns: number[]): GPUDataEvaluator {
+  const source = getGPUDataEvaluator(table);
   validateColumns(source, columns);
 
   if (isContinuousColumns(columns)) {
     const startColumn = columns[0];
-    return new GPUTableEvaluator({
+    return new GPUDataEvaluator({
       type: source.type,
       size: columns.length,
       offset: source.offset + startColumn * source.ValueType.BYTES_PER_ELEMENT,
@@ -52,7 +52,7 @@ export function swizzle(table: GPUTableEvaluatorInput, columns: number[]): GPUTa
   }
 
   if (source.value) {
-    return new GPUTableEvaluator({
+    return new GPUDataEvaluator({
       isConstant: source.isConstant,
       type: source.type,
       size: columns.length,
@@ -65,7 +65,7 @@ export function swizzle(table: GPUTableEvaluatorInput, columns: number[]): GPUTa
   return new SwizzleOperation(source, columns).output;
 }
 
-function validateColumns(source: GPUTableEvaluator, columns: number[]): void {
+function validateColumns(source: GPUDataEvaluator, columns: number[]): void {
   if (columns.length === 0) {
     throw new Error('swizzle columns must not be empty');
   }
@@ -89,7 +89,7 @@ function isContinuousColumns(columns: number[]): boolean {
   return true;
 }
 
-function getSwizzledValue(source: GPUTableEvaluator, columns: number[]): TypedArray {
+function getSwizzledValue(source: GPUDataEvaluator, columns: number[]): TypedArray {
   const rowCount = source.isConstant ? 1 : source.length;
   const result = new source.ValueType(rowCount * columns.length) as TypedArray;
   const value = source.value!;

--- a/modules/gpgpu/src/operations/webgl/common/random-access-transform.ts
+++ b/modules/gpgpu/src/operations/webgl/common/random-access-transform.ts
@@ -4,11 +4,11 @@
 
 import {Buffer, SignedDataType, Texture} from '@luma.gl/core';
 import {ShaderModule} from '@luma.gl/shadertools';
-import {GPUTableEvaluator} from '../../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../../operation/gpu-data-evaluator';
 import {getAttributeType, getSamplerType, getTextureFormat} from './helper';
 
 export function getSourceValuesTextureModule(
-  source: GPUTableEvaluator,
+  source: GPUDataEvaluator,
   outputType: SignedDataType,
   textureDataType: SignedDataType
 ): ShaderModule {
@@ -31,7 +31,7 @@ ${body}
 }
 
 export function createTableTexture(
-  source: GPUTableEvaluator,
+  source: GPUDataEvaluator,
   dataType: SignedDataType,
   device: Buffer['device']
 ): Texture {

--- a/modules/gpgpu/src/operations/webgl/common/row-transform.ts
+++ b/modules/gpgpu/src/operations/webgl/common/row-transform.ts
@@ -5,7 +5,7 @@
 import {SignedDataType, Buffer, BufferLayout} from '@luma.gl/core';
 import {BufferTransform} from '@luma.gl/engine';
 import {ShaderModule} from '@luma.gl/shadertools';
-import {GPUTableEvaluator} from '../../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../../operation/gpu-data-evaluator';
 import {bufferPool} from '../../../utils/buffer-pool';
 import {
   getAttributeType,
@@ -29,8 +29,8 @@ export function runRowTransform({
   module: ShaderModule;
   elementWise?: boolean;
   expression?: (laneIndex: number) => string;
-  inputs: {[name: string]: GPUTableEvaluator};
-  output: GPUTableEvaluator;
+  inputs: {[name: string]: GPUDataEvaluator};
+  output: GPUDataEvaluator;
   /** If specified, coerce all parameters to operation to this type.
    * Default to output's data type.
    */
@@ -57,7 +57,7 @@ export function runRowTransform({
     const input = inputs[name];
     modules.push(getInputModule(name, input.type, input.size, input.normalized, operationType));
     bufferLayout.push(getInputBufferLayout(name, input));
-    if (input instanceof GPUTableEvaluator) {
+    if (input instanceof GPUDataEvaluator) {
       inputBuffers[name] = input.buffer;
     } else {
       placeholderBuffer =
@@ -163,7 +163,7 @@ void get_${name}(out TYPE v[${inSize}]) {
   } as ShaderModule;
 }
 
-export function getInputBufferLayout(name: string, source: GPUTableEvaluator): BufferLayout {
+export function getInputBufferLayout(name: string, source: GPUDataEvaluator): BufferLayout {
   const bufferLayout: BufferLayout = {
     name,
     stepMode: source.isConstant ? 'vertex' : 'instance',

--- a/modules/gpgpu/src/operations/webgl/dot.ts
+++ b/modules/gpgpu/src/operations/webgl/dot.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowTransform} from './common/row-transform';
 
 const vs = `\
@@ -16,7 +16,7 @@ void row_dot(in TYPE x[X_LEN], in TYPE y[Y_LEN], out float result[1]) {
 }
 `;
 
-export const dot: OperationHandler<{x: GPUTableEvaluator; y: GPUTableEvaluator}> = async ({
+export const dot: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgl/equal-all.ts
+++ b/modules/gpgpu/src/operations/webgl/equal-all.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowTransform} from './common/row-transform';
 
 const vs = `\
@@ -19,7 +19,7 @@ void equalAll(in TYPE x[X_LEN], in TYPE y[Y_LEN], out uint result[1]) {
 }
 `;
 
-export const equalAll: OperationHandler<{x: GPUTableEvaluator; y: GPUTableEvaluator}> = async ({
+export const equalAll: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgl/extent.ts
+++ b/modules/gpgpu/src/operations/webgl/extent.ts
@@ -5,7 +5,7 @@
 import {Texture} from '@luma.gl/core';
 import {Model} from '@luma.gl/engine';
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {bufferPool} from '../../utils/buffer-pool';
 import {arithmetic} from './arithmetic';
 import {getInputBufferLayout, getInputModule} from './common/row-transform';
@@ -13,7 +13,7 @@ import {getInputBufferLayout, getInputModule} from './common/row-transform';
 const GPGPU_OPERATION_STATS = 'GPGPU Operation Counts';
 const TRANSFORM_RUNS = 'Transform Runs';
 
-export const extent: OperationHandler<{sourceValues: GPUTableEvaluator}> = async ({
+export const extent: OperationHandler<{sourceValues: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target
@@ -141,7 +141,7 @@ void main() {
           ]
         },
         namedInputs: {
-          x: new GPUTableEvaluator({
+          x: new GPUDataEvaluator({
             buffer: intermediateBuffer,
             size: 2,
             type: 'float32',

--- a/modules/gpgpu/src/operations/webgl/fround.ts
+++ b/modules/gpgpu/src/operations/webgl/fround.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowTransform} from './common/row-transform';
 
 function isLittleEndian() {
@@ -189,7 +189,7 @@ void fround(in uint x[X_LEN], out float result[X_LEN]) {
 }
 `;
 
-export const fround: OperationHandler<{x: GPUTableEvaluator}> = async ({
+export const fround: OperationHandler<{x: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgl/fround.ts
+++ b/modules/gpgpu/src/operations/webgl/fround.ts
@@ -189,11 +189,7 @@ void fround(in uint x[X_LEN], out float result[X_LEN]) {
 }
 `;
 
-export const fround: OperationHandler<{x: GPUDataEvaluator}> = async ({
-  inputs,
-  output,
-  target
-}) => {
+export const fround: OperationHandler<{x: GPUDataEvaluator}> = async ({inputs, output, target}) => {
   runRowTransform({
     module: {name: 'fround', vs},
     inputs,

--- a/modules/gpgpu/src/operations/webgl/gather.ts
+++ b/modules/gpgpu/src/operations/webgl/gather.ts
@@ -6,7 +6,7 @@ import {BufferLayout} from '@luma.gl/core';
 import {BufferTransform} from '@luma.gl/engine';
 import {ShaderModule} from '@luma.gl/shadertools';
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {
   getAttributeType,
   getTextureDataType,
@@ -17,8 +17,8 @@ import {getOutputModule} from './common/row-transform';
 import {createTableTexture, getSourceValuesTextureModule} from './common/random-access-transform';
 
 export const gather: OperationHandler<{
-  ids: GPUTableEvaluator;
-  sourceValues: GPUTableEvaluator;
+  ids: GPUDataEvaluator;
+  sourceValues: GPUDataEvaluator;
 }> = async ({inputs, output, target}) => {
   const {ids, sourceValues} = inputs;
   const device = target.device;
@@ -74,7 +74,7 @@ void main() {
   }
 };
 
-function getIdsInputModule(source: GPUTableEvaluator, indexType: string): ShaderModule {
+function getIdsInputModule(source: GPUDataEvaluator, indexType: string): ShaderModule {
   const inputType = getAttributeType(source.type, 1);
   let element = 'aids_0';
   if (source.type !== getSignedDataTypeForScalar(indexType)) {
@@ -92,7 +92,7 @@ void get_ids(out INDEX_TYPE v[1]) {
   } as ShaderModule;
 }
 
-function getIdsBufferLayout(source: GPUTableEvaluator): BufferLayout {
+function getIdsBufferLayout(source: GPUDataEvaluator): BufferLayout {
   return {
     name: 'ids',
     stepMode: source.isConstant ? 'vertex' : 'instance',
@@ -107,7 +107,7 @@ function getIdsBufferLayout(source: GPUTableEvaluator): BufferLayout {
   };
 }
 
-function getGatherModule(outputType: GPUTableEvaluator['type']): ShaderModule {
+function getGatherModule(outputType: GPUDataEvaluator['type']): ShaderModule {
   const zero = getZeroLiteral(outputType);
   return {
     name: 'gather',
@@ -130,7 +130,7 @@ void gather(in INDEX_TYPE ids[1], out TYPE result[RESULT_LEN]) {
   } as ShaderModule;
 }
 
-function getSignedDataTypeForScalar(type: string): GPUTableEvaluator['type'] {
+function getSignedDataTypeForScalar(type: string): GPUDataEvaluator['type'] {
   switch (type) {
     case 'uint':
       return 'uint32';

--- a/modules/gpgpu/src/operations/webgl/interleave.ts
+++ b/modules/gpgpu/src/operations/webgl/interleave.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowTransform} from './common/row-transform';
 
 const vs = `\
@@ -17,7 +17,7 @@ void interleave(in TYPE x[X_LEN], in TYPE y[Y_LEN], out TYPE result[RESULT_LEN])
 }
 `;
 
-export const interleave: OperationHandler<{x: GPUTableEvaluator; y: GPUTableEvaluator}> = async ({
+export const interleave: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgl/length.ts
+++ b/modules/gpgpu/src/operations/webgl/length.ts
@@ -16,11 +16,7 @@ void row_length(in TYPE x[X_LEN], out float result[1]) {
 }
 `;
 
-export const length: OperationHandler<{x: GPUDataEvaluator}> = async ({
-  inputs,
-  output,
-  target
-}) => {
+export const length: OperationHandler<{x: GPUDataEvaluator}> = async ({inputs, output, target}) => {
   runRowTransform({
     module: {name: 'row_length', vs},
     inputs,

--- a/modules/gpgpu/src/operations/webgl/length.ts
+++ b/modules/gpgpu/src/operations/webgl/length.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowTransform} from './common/row-transform';
 
 const vs = `\
@@ -16,7 +16,7 @@ void row_length(in TYPE x[X_LEN], out float result[1]) {
 }
 `;
 
-export const length: OperationHandler<{x: GPUTableEvaluator}> = async ({
+export const length: OperationHandler<{x: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgl/segmented-map.ts
+++ b/modules/gpgpu/src/operations/webgl/segmented-map.ts
@@ -4,13 +4,13 @@
 
 import {BufferTransform} from '@luma.gl/engine';
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {createTableTexture, getSourceValuesTextureModule} from './common/random-access-transform';
 import {getTextureDataType} from './common/helper';
 import {getOutputModule} from './common/row-transform';
 
 export const segmentedMap: OperationHandler<{
-  segments: GPUTableEvaluator;
+  segments: GPUDataEvaluator;
   vertexCount: number;
 }> = async ({inputs, output, target}) => {
   const {segments} = inputs;

--- a/modules/gpgpu/src/operations/webgl/select.ts
+++ b/modules/gpgpu/src/operations/webgl/select.ts
@@ -3,14 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowTransform} from './common/row-transform';
 import {getAttributeType, getZeroLiteral} from './common/helper';
 
 export const select: OperationHandler<{
-  condition: GPUTableEvaluator;
-  whenTrue: GPUTableEvaluator;
-  whenFalse: GPUTableEvaluator;
+  condition: GPUDataEvaluator;
+  whenTrue: GPUDataEvaluator;
+  whenFalse: GPUDataEvaluator;
 }> = async ({inputs, output, target}) => {
   const scalarType = getAttributeType(output.type, 1, output.normalized);
   const zeroLiteral = getZeroLiteral(scalarType);
@@ -43,7 +43,7 @@ export const select: OperationHandler<{
 
 function getLaneExpression(
   name: string,
-  input: GPUTableEvaluator,
+  input: GPUDataEvaluator,
   laneIndex: number,
   zeroLiteral: string
 ): string {

--- a/modules/gpgpu/src/operations/webgl/swizzle.ts
+++ b/modules/gpgpu/src/operations/webgl/swizzle.ts
@@ -3,10 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowTransform} from './common/row-transform';
 
-export const swizzle: OperationHandler<{x: GPUTableEvaluator; columns: number[]}> = async ({
+export const swizzle: OperationHandler<{x: GPUDataEvaluator; columns: number[]}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgpu/common/random-access-transform.ts
+++ b/modules/gpgpu/src/operations/webgpu/common/random-access-transform.ts
@@ -3,19 +3,19 @@
 // Copyright (c) vis.gl contributors
 
 import {SignedDataType} from '@luma.gl/core';
-import {GPUTableEvaluator} from '../../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../../operation/gpu-data-evaluator';
 import {getLiteralValue, getWGSLType, getZeroValue} from './helper';
 
 export const RANDOM_ACCESS_WORKGROUP_SIZE = 64;
 
-export function getInputBinding(name: string, input: GPUTableEvaluator, index: number): string {
+export function getInputBinding(name: string, input: GPUDataEvaluator, index: number): string {
   const inputType = getWGSLType(input.type);
   return `@group(0) @binding(${index}) var<storage, read> ${name}: array<${inputType}>;`;
 }
 
 export function getTableAccessor(
   bindingName: string,
-  input: GPUTableEvaluator,
+  input: GPUDataEvaluator,
   asType: SignedDataType,
   accessorName: string = bindingName
 ): string {
@@ -50,16 +50,16 @@ ${Array.from({length: input.size}, (_, index) =>
 }`;
 }
 
-export function getSourceValuesAccessor(input: GPUTableEvaluator, asType: SignedDataType): string {
+export function getSourceValuesAccessor(input: GPUDataEvaluator, asType: SignedDataType): string {
   return getTableAccessor('sourceValues', input, asType, 'source_values');
 }
 
-export function getOutputBinding(output: GPUTableEvaluator, bindingIndex: number): string {
+export function getOutputBinding(output: GPUDataEvaluator, bindingIndex: number): string {
   const type = getWGSLType(output.type);
   return `@group(0) @binding(${bindingIndex}) var<storage, read_write> result: array<${type}>;`;
 }
 
-export function getOutputWriter(output: GPUTableEvaluator): string {
+export function getOutputWriter(output: GPUDataEvaluator): string {
   const stride = output.stride / output.ValueType.BYTES_PER_ELEMENT;
   const offset = output.offset / output.ValueType.BYTES_PER_ELEMENT;
   const type = getWGSLType(output.type);

--- a/modules/gpgpu/src/operations/webgpu/common/row-transform.ts
+++ b/modules/gpgpu/src/operations/webgpu/common/row-transform.ts
@@ -5,7 +5,7 @@
 import {Buffer, SignedDataType} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {ShaderModule} from '@luma.gl/shadertools';
-import {GPUTableEvaluator} from '../../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../../operation/gpu-data-evaluator';
 import {getWebGPUDispatchLayout, getWebGPUDispatchRowIndex} from './dispatch';
 import {getLiteralValue, getWGSLType, getZeroValue} from './helper';
 
@@ -25,8 +25,8 @@ export function runRowComputation({
   module: ShaderModule;
   elementWise?: boolean;
   expression?: (laneIndex: number) => string;
-  inputs: {[name: string]: GPUTableEvaluator};
-  output: GPUTableEvaluator;
+  inputs: {[name: string]: GPUDataEvaluator};
+  output: GPUDataEvaluator;
   operationType?: SignedDataType;
   outputBuffer: Buffer;
 }): void {
@@ -109,7 +109,7 @@ ${getComputeBlock(module.name, inputs, output, elementWise, expression)}
   computation.destroy();
 }
 
-function getInputBinding(name: string, input: GPUTableEvaluator, index: number): string {
+function getInputBinding(name: string, input: GPUDataEvaluator, index: number): string {
   if (input.isConstant) {
     return '';
   }
@@ -117,7 +117,7 @@ function getInputBinding(name: string, input: GPUTableEvaluator, index: number):
   return `@group(0) @binding(${index}) var<storage, read> ${name}: array<${inputType}>;`;
 }
 
-function getInputAccessor(name: string, input: GPUTableEvaluator, asType: SignedDataType): string {
+function getInputAccessor(name: string, input: GPUDataEvaluator, asType: SignedDataType): string {
   const type = getWGSLType(asType);
   const castToType = input.type === asType ? '' : type;
   const stride = input.stride / input.ValueType.BYTES_PER_ELEMENT;
@@ -141,12 +141,12 @@ ${Array.from({length: input.size}, (_, elementIndex) =>
 }`;
 }
 
-function getOutputBinding(output: GPUTableEvaluator, bindingIndex: number): string {
+function getOutputBinding(output: GPUDataEvaluator, bindingIndex: number): string {
   const type = getWGSLType(output.type);
   return `@group(0) @binding(${bindingIndex}) var<storage, read_write> result: array<${type}>;`;
 }
 
-function getOutputWriter(output: GPUTableEvaluator): string {
+function getOutputWriter(output: GPUDataEvaluator): string {
   const stride = output.stride / output.ValueType.BYTES_PER_ELEMENT;
   const offset = output.offset / output.ValueType.BYTES_PER_ELEMENT;
   const type = getWGSLType(output.type);
@@ -158,8 +158,8 @@ ${Array.from({length: output.size}, (_, elementIndex) => `  result[rowOffset + $
 
 function getComputeBlock(
   operationName: string,
-  inputs: {[name: string]: GPUTableEvaluator},
-  output: GPUTableEvaluator,
+  inputs: {[name: string]: GPUDataEvaluator},
+  output: GPUDataEvaluator,
   elementWise: boolean,
   expression?: (laneIndex: number) => string
 ): string {
@@ -193,7 +193,7 @@ function getComputeBlock(
   return result.trimEnd();
 }
 
-function getConstantValues(input: GPUTableEvaluator, asType: string): string {
+function getConstantValues(input: GPUDataEvaluator, asType: string): string {
   const values = input.value;
   if (!values) {
     throw new Error(`Constant input ${input} is missing CPU values`);

--- a/modules/gpgpu/src/operations/webgpu/dot.ts
+++ b/modules/gpgpu/src/operations/webgpu/dot.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowComputation} from './common/row-transform';
 
 const source = `\
@@ -16,7 +16,7 @@ fn row_dot(x: array<{TYPE}, {X_LEN}>, y: array<{TYPE}, {Y_LEN}>) -> array<f32, 1
 }
 `;
 
-export const dot: OperationHandler<{x: GPUTableEvaluator; y: GPUTableEvaluator}> = async ({
+export const dot: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgpu/equal-all.ts
+++ b/modules/gpgpu/src/operations/webgpu/equal-all.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowComputation} from './common/row-transform';
 
 const source = `\
@@ -19,7 +19,7 @@ fn equalAll(x: array<{TYPE}, {X_LEN}>, y: array<{TYPE}, {Y_LEN}>) -> array<u32, 
 }
 `;
 
-export const equalAll: OperationHandler<{x: GPUTableEvaluator; y: GPUTableEvaluator}> = async ({
+export const equalAll: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgpu/extent.ts
+++ b/modules/gpgpu/src/operations/webgpu/extent.ts
@@ -5,7 +5,7 @@
 import {Buffer} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {bufferPool} from '../../utils/buffer-pool';
 import {getWebGPUDispatchLayout, getWebGPUDispatchWorkgroupIndex} from './common/dispatch';
 import {getWGSLType} from './common/helper';
@@ -19,7 +19,7 @@ import {
 
 type ExtentInputMode = 'raw' | 'partial';
 
-export const extent: OperationHandler<{sourceValues: GPUTableEvaluator}> = async ({
+export const extent: OperationHandler<{sourceValues: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target
@@ -81,7 +81,7 @@ export const extent: OperationHandler<{sourceValues: GPUTableEvaluator}> = async
         break;
       }
 
-      currentInput = new GPUTableEvaluator({
+      currentInput = new GPUDataEvaluator({
         buffer: nextOutputBuffer,
         type: output.type,
         size: 2,
@@ -109,11 +109,11 @@ function runExtentPass({
   outputStride,
   outputOffset
 }: {
-  input: GPUTableEvaluator;
+  input: GPUDataEvaluator;
   inputMode: ExtentInputMode;
   inputGroupCount: number;
   channelCount: number;
-  outputType: GPUTableEvaluator['type'];
+  outputType: GPUDataEvaluator['type'];
   outputBuffer: Buffer;
   outputLength: number;
   outputStride: number;
@@ -124,7 +124,7 @@ function runExtentPass({
     outputLength,
     outputBuffer.device.limits.maxComputeWorkgroupsPerDimension
   );
-  const outputTable = new GPUTableEvaluator({
+  const outputTable = new GPUDataEvaluator({
     buffer: outputBuffer,
     type: outputType,
     size: 2,
@@ -216,7 +216,7 @@ var<workgroup> sharedMax: array<${wgslType}, ${RANDOM_ACCESS_WORKGROUP_SIZE}>;
 
 function getExtentPassFunction(
   inputMode: ExtentInputMode,
-  type: GPUTableEvaluator['type'],
+  type: GPUDataEvaluator['type'],
   channelCount: number,
   inputGroupCount: number
 ): string {
@@ -255,7 +255,7 @@ function getExtentPassFunction(
 }`;
 }
 
-function getExtentInitialValues(type: GPUTableEvaluator['type']): [string, string] {
+function getExtentInitialValues(type: GPUDataEvaluator['type']): [string, string] {
   switch (type) {
     case 'uint32':
       return ['0xffffffffu', '0u'];

--- a/modules/gpgpu/src/operations/webgpu/fround.ts
+++ b/modules/gpgpu/src/operations/webgpu/fround.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowComputation} from './common/row-transform';
 
 function isLittleEndian() {
@@ -154,7 +154,7 @@ fn fround(x: array<u32, {X_LEN}>) -> array<f32, {RESULT_LEN}> {
 }
 `;
 
-export const fround: OperationHandler<{x: GPUTableEvaluator}> = async ({
+export const fround: OperationHandler<{x: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgpu/fround.ts
+++ b/modules/gpgpu/src/operations/webgpu/fround.ts
@@ -154,11 +154,7 @@ fn fround(x: array<u32, {X_LEN}>) -> array<f32, {RESULT_LEN}> {
 }
 `;
 
-export const fround: OperationHandler<{x: GPUDataEvaluator}> = async ({
-  inputs,
-  output,
-  target
-}) => {
+export const fround: OperationHandler<{x: GPUDataEvaluator}> = async ({inputs, output, target}) => {
   runRowComputation({
     module: {name: 'fround', source},
     inputs,

--- a/modules/gpgpu/src/operations/webgpu/gather.ts
+++ b/modules/gpgpu/src/operations/webgpu/gather.ts
@@ -5,7 +5,7 @@
 import {Buffer} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getWebGPUDispatchLayout, getWebGPUDispatchRowIndex} from './common/dispatch';
 import {getLiteralValue, getWGSLType} from './common/helper';
 import {
@@ -18,12 +18,12 @@ import {
 } from './common/random-access-transform';
 
 export const gather: OperationHandler<{
-  ids: GPUTableEvaluator;
-  sourceValues: GPUTableEvaluator;
+  ids: GPUDataEvaluator;
+  sourceValues: GPUDataEvaluator;
 }> = async ({inputs, output, target}) => {
   const {ids, sourceValues} = inputs;
   const idsType = getWGSLType(ids.type);
-  const bindings: {name: string; input: GPUTableEvaluator; index: number}[] = [];
+  const bindings: {name: string; input: GPUDataEvaluator; index: number}[] = [];
   if (!ids.isConstant) {
     bindings.push({name: 'ids', input: ids, index: bindings.length});
   }
@@ -92,7 +92,7 @@ ${getGatherFunction(ids.type, output.type, output.size, sourceValues.length)}
   return {success: true};
 };
 
-function getIdsAccessor(input: GPUTableEvaluator, type: string): string {
+function getIdsAccessor(input: GPUDataEvaluator, type: string): string {
   if (input.isConstant) {
     const values = input.value;
     if (!values) {
@@ -112,8 +112,8 @@ function getIdsAccessor(input: GPUTableEvaluator, type: string): string {
 }
 
 function getGatherFunction(
-  idsType: GPUTableEvaluator['type'],
-  outputType: GPUTableEvaluator['type'],
+  idsType: GPUDataEvaluator['type'],
+  outputType: GPUDataEvaluator['type'],
   outputSize: number,
   sourceLength: number
 ): string {

--- a/modules/gpgpu/src/operations/webgpu/interleave.ts
+++ b/modules/gpgpu/src/operations/webgpu/interleave.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowComputation} from './common/row-transform';
 
 const source = `\
@@ -20,7 +20,7 @@ fn interleave(x: array<{TYPE}, {X_LEN}>, y: array<{TYPE}, {Y_LEN}>) -> array<{TY
 }
 `;
 
-export const interleave: OperationHandler<{x: GPUTableEvaluator; y: GPUTableEvaluator}> = async ({
+export const interleave: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgpu/length.ts
+++ b/modules/gpgpu/src/operations/webgpu/length.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowComputation} from './common/row-transform';
 
 const source = `\
@@ -16,7 +16,7 @@ fn row_length(x: array<{TYPE}, {X_LEN}>) -> array<f32, 1> {
 }
 `;
 
-export const length: OperationHandler<{x: GPUTableEvaluator}> = async ({
+export const length: OperationHandler<{x: GPUDataEvaluator}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgpu/length.ts
+++ b/modules/gpgpu/src/operations/webgpu/length.ts
@@ -16,11 +16,7 @@ fn row_length(x: array<{TYPE}, {X_LEN}>) -> array<f32, 1> {
 }
 `;
 
-export const length: OperationHandler<{x: GPUDataEvaluator}> = async ({
-  inputs,
-  output,
-  target
-}) => {
+export const length: OperationHandler<{x: GPUDataEvaluator}> = async ({inputs, output, target}) => {
   runRowComputation({
     module: {name: 'row_length', source},
     inputs,

--- a/modules/gpgpu/src/operations/webgpu/segmented-map.ts
+++ b/modules/gpgpu/src/operations/webgpu/segmented-map.ts
@@ -5,7 +5,7 @@
 import {Buffer} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getWebGPUDispatchLayout, getWebGPUDispatchRowIndex} from './common/dispatch';
 import {
   getInputBinding,
@@ -16,7 +16,7 @@ import {
 } from './common/random-access-transform';
 
 export const segmentedMap: OperationHandler<{
-  segments: GPUTableEvaluator;
+  segments: GPUDataEvaluator;
   vertexCount: number;
 }> = async ({inputs, output, target}) => {
   const {segments} = inputs;

--- a/modules/gpgpu/src/operations/webgpu/select.ts
+++ b/modules/gpgpu/src/operations/webgpu/select.ts
@@ -3,14 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowComputation} from './common/row-transform';
 import {getZeroValue} from './common/helper';
 
 export const select: OperationHandler<{
-  condition: GPUTableEvaluator;
-  whenTrue: GPUTableEvaluator;
-  whenFalse: GPUTableEvaluator;
+  condition: GPUDataEvaluator;
+  whenTrue: GPUDataEvaluator;
+  whenFalse: GPUDataEvaluator;
 }> = async ({inputs, output, target}) => {
   const zeroLiteral = getZeroValue(output.type);
 
@@ -42,7 +42,7 @@ export const select: OperationHandler<{
 
 function getLaneExpression(
   name: string,
-  input: GPUTableEvaluator,
+  input: GPUDataEvaluator,
   laneIndex: number,
   zeroLiteral: string
 ): string {

--- a/modules/gpgpu/src/operations/webgpu/swizzle.ts
+++ b/modules/gpgpu/src/operations/webgpu/swizzle.ts
@@ -3,10 +3,10 @@
 // Copyright (c) vis.gl contributors
 
 import {OperationHandler} from '../../operation/operation';
-import {GPUTableEvaluator} from '../../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowComputation} from './common/row-transform';
 
-export const swizzle: OperationHandler<{x: GPUTableEvaluator; columns: number[]}> = async ({
+export const swizzle: OperationHandler<{x: GPUDataEvaluator; columns: number[]}> = async ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/utils/clean-evaluate.ts
+++ b/modules/gpgpu/src/utils/clean-evaluate.ts
@@ -3,9 +3,12 @@
 // Copyright (c) vis.gl contributors
 
 import type {Buffer, Device} from '@luma.gl/core';
-import {GPUTableEvaluator} from '../operation/gpu-table-evaluator';
+import {DynamicBuffer} from '@luma.gl/engine';
+import {GPUDataEvaluator} from '../operation/gpu-data-evaluator';
+import {GPUVectorEvaluator} from '../operation/gpu-vector-evaluator';
 
-type EvaluatorResult = GPUTableEvaluator | GPUTableEvaluator[] | Record<string, unknown>;
+type Evaluator = GPUDataEvaluator | GPUVectorEvaluator;
+type EvaluatorResult = Evaluator | Evaluator[] | Record<string, unknown>;
 
 export async function cleanEvaluate<ResultT extends EvaluatorResult>(
   device: Device,
@@ -15,9 +18,9 @@ export async function cleanEvaluate<ResultT extends EvaluatorResult>(
 
   await Promise.all(rootEvaluators.map(evaluator => evaluator.evaluate(device)));
 
-  const preservedBuffers = new Set<Buffer>(rootEvaluators.map(evaluator => evaluator.buffer));
+  const preservedBuffers = new Set<Buffer>(rootEvaluators.flatMap(getEvaluatorBuffers));
 
-  const dependencyEvaluators = new Set<GPUTableEvaluator>();
+  const dependencyEvaluators = new Set<GPUDataEvaluator>();
   for (const evaluator of rootEvaluators) {
     collectDependencies(evaluator, dependencyEvaluators);
   }
@@ -31,9 +34,9 @@ export async function cleanEvaluate<ResultT extends EvaluatorResult>(
   return result;
 }
 
-function collectReferencedEvaluators(value: EvaluatorResult): GPUTableEvaluator[] {
-  const evaluators = new Set<GPUTableEvaluator>();
-  if (value instanceof GPUTableEvaluator) {
+function collectReferencedEvaluators(value: EvaluatorResult): Evaluator[] {
+  const evaluators = new Set<Evaluator>();
+  if (isEvaluator(value)) {
     return [value];
   }
   let valuesArray: unknown[];
@@ -43,7 +46,7 @@ function collectReferencedEvaluators(value: EvaluatorResult): GPUTableEvaluator[
     valuesArray = Object.values(value);
   }
   for (const item of valuesArray) {
-    if (item instanceof GPUTableEvaluator) {
+    if (isEvaluator(item)) {
       evaluators.add(item);
     }
   }
@@ -51,14 +54,21 @@ function collectReferencedEvaluators(value: EvaluatorResult): GPUTableEvaluator[
 }
 
 function collectDependencies(
-  evaluator: GPUTableEvaluator,
-  dependencyEvaluators: Set<GPUTableEvaluator>
+  evaluator: Evaluator,
+  dependencyEvaluators: Set<GPUDataEvaluator>
 ): void {
+  if (evaluator instanceof GPUVectorEvaluator) {
+    for (const gpuDataEvaluator of evaluator.gpuDataEvaluators) {
+      collectDependencies(gpuDataEvaluator, dependencyEvaluators);
+    }
+    return;
+  }
+
   const source = evaluator.source;
   if (!source) {
     return;
   }
-  if (source instanceof GPUTableEvaluator) {
+  if (source instanceof GPUDataEvaluator) {
     if (!dependencyEvaluators.has(source)) {
       dependencyEvaluators.add(source);
       collectDependencies(source, dependencyEvaluators);
@@ -71,4 +81,17 @@ function collectDependencies(
       collectDependencies(dependency, dependencyEvaluators);
     }
   }
+}
+
+function getEvaluatorBuffers(evaluator: Evaluator): Buffer[] {
+  if (evaluator instanceof GPUDataEvaluator) {
+    return [evaluator.buffer];
+  }
+  return evaluator.gpuVector.data.map(data =>
+    data.buffer instanceof DynamicBuffer ? data.buffer.buffer : data.buffer
+  );
+}
+
+function isEvaluator(value: unknown): value is Evaluator {
+  return value instanceof GPUDataEvaluator || value instanceof GPUVectorEvaluator;
 }

--- a/modules/gpgpu/src/utils/clean-evaluate.ts
+++ b/modules/gpgpu/src/utils/clean-evaluate.ts
@@ -10,6 +10,18 @@ import {GPUVectorEvaluator} from '../operation/gpu-vector-evaluator';
 type Evaluator = GPUDataEvaluator | GPUVectorEvaluator;
 type EvaluatorResult = Evaluator | Evaluator[] | Record<string, unknown>;
 
+/**
+ * Materializes result evaluators and destroys unreferenced intermediate GPUData dependencies.
+ *
+ * @param device - Device used to materialize every root evaluator.
+ * @param result - Root evaluator shape that should remain alive after cleanup.
+ * @returns The original result value after its root evaluators have been materialized.
+ *
+ * @remarks
+ * `cleanEvaluate()` only inspects evaluators directly contained in `result`. `GPUVectorEvaluator`
+ * roots are preserved as vectors, while their intermediate `GPUDataEvaluator` dependencies are
+ * cleaned up when their buffers are not shared with a root output.
+ */
 export async function cleanEvaluate<ResultT extends EvaluatorResult>(
   device: Device,
   result: ResultT

--- a/modules/gpgpu/src/utils/output-props.ts
+++ b/modules/gpgpu/src/utils/output-props.ts
@@ -3,9 +3,9 @@
 // Copyright (c) vis.gl contributors
 
 import type {SignedDataType} from '@luma.gl/core';
-import {GPUTableEvaluator} from '../operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../operation/gpu-data-evaluator';
 
-export function deduceOutputProps(...inputs: GPUTableEvaluator[]): {
+export function deduceOutputProps(...inputs: GPUDataEvaluator[]): {
   isConstant: boolean;
   type: SignedDataType;
   size: number;

--- a/modules/gpgpu/test/gpu-vector/gpu-data-evaluator-types.spec.ts
+++ b/modules/gpgpu/test/gpu-vector/gpu-data-evaluator-types.spec.ts
@@ -8,8 +8,8 @@ import {
   extent,
   fround,
   gather,
-  getGPUTableEvaluator,
-  GPUTableEvaluator,
+  getGPUDataEvaluator,
+  GPUDataEvaluator,
   interleave,
   sequence,
   sqrt
@@ -17,9 +17,9 @@ import {
 import type {GPUVector, GPUVectorFormat} from '@luma.gl/tables';
 import {test} from 'vitest';
 
-test('GPUTableEvaluator type inference', () => {});
+test('GPUDataEvaluator type inference', () => {});
 
-export function checkGPUTableEvaluatorTypes(
+export function checkGPUDataEvaluatorTypes(
   device: Device,
   dynamicSize: number,
   float32Vector: GPUVector<'float32'>,
@@ -27,11 +27,11 @@ export function checkGPUTableEvaluatorTypes(
   float32x3Vector: GPUVector<'float32x3'>,
   uint32x4Vector: GPUVector<'uint32x4'>
 ): void {
-  const evaluatorFromVector = GPUTableEvaluator.fromGPUVector(float32x3Vector);
-  evaluatorFromVector satisfies GPUTableEvaluator<'float32x3'>;
+  const evaluatorFromVector = GPUDataEvaluator.fromGPUVector(float32x3Vector);
+  evaluatorFromVector satisfies GPUDataEvaluator<'float32x3'>;
 
-  const evaluatorFromInput = getGPUTableEvaluator(float32x3Vector);
-  evaluatorFromInput satisfies GPUTableEvaluator<'float32x3'>;
+  const evaluatorFromInput = getGPUDataEvaluator(float32x3Vector);
+  evaluatorFromInput satisfies GPUDataEvaluator<'float32x3'>;
 
   const evaluatedVector = evaluatorFromVector.evaluate(device);
   evaluatedVector satisfies Promise<GPUVector<'float32x3'>>;
@@ -43,49 +43,49 @@ export function checkGPUTableEvaluatorTypes(
   evaluatedInterleavedVector satisfies Promise<GPUVector<GPUVectorFormat>>;
 
   const sequenceEvaluator = sequence(4);
-  sequenceEvaluator satisfies GPUTableEvaluator<'sint32'>;
+  sequenceEvaluator satisfies GPUDataEvaluator<'sint32'>;
 
   const gatheredEvaluator = gather(sequenceEvaluator, float32x3Vector);
-  gatheredEvaluator satisfies GPUTableEvaluator<'float32x3'>;
+  gatheredEvaluator satisfies GPUDataEvaluator<'float32x3'>;
 
   const extentEvaluator = extent(float32x3Vector);
-  extentEvaluator satisfies GPUTableEvaluator<'float32x2'>;
+  extentEvaluator satisfies GPUDataEvaluator<'float32x2'>;
 
   const roundedEvaluator = fround(uint32x4Vector);
-  roundedEvaluator satisfies GPUTableEvaluator<'float32x4'>;
+  roundedEvaluator satisfies GPUDataEvaluator<'float32x4'>;
 
-  const float32Evaluator = GPUTableEvaluator.fromGPUVector(float32Vector);
-  const float32x2Evaluator = GPUTableEvaluator.fromGPUVector(float32x2Vector);
-  const float32x3Evaluator = GPUTableEvaluator.fromGPUVector(float32x3Vector);
+  const float32Evaluator = GPUDataEvaluator.fromGPUVector(float32Vector);
+  const float32x2Evaluator = GPUDataEvaluator.fromGPUVector(float32x2Vector);
+  const float32x3Evaluator = GPUDataEvaluator.fromGPUVector(float32x3Vector);
 
   const widenedArithmeticEvaluator = add(float32Evaluator, float32x3Evaluator);
-  widenedArithmeticEvaluator satisfies GPUTableEvaluator<'float32x3'>;
+  widenedArithmeticEvaluator satisfies GPUDataEvaluator<'float32x3'>;
 
   const sqrtEvaluator = sqrt(float32x2Evaluator);
-  sqrtEvaluator satisfies GPUTableEvaluator<'float32x2'>;
+  sqrtEvaluator satisfies GPUDataEvaluator<'float32x2'>;
 
-  const normalizedEvaluator = GPUTableEvaluator.fromArray([0, 0, 0, 255], {
+  const normalizedEvaluator = GPUDataEvaluator.fromArray([0, 0, 0, 255], {
     type: 'uint8',
     size: 4,
     normalized: true
   });
-  normalizedEvaluator satisfies GPUTableEvaluator<'unorm8x4'>;
+  normalizedEvaluator satisfies GPUDataEvaluator<'unorm8x4'>;
 
   const normalizedArithmeticEvaluator = add(normalizedEvaluator, normalizedEvaluator);
-  normalizedArithmeticEvaluator satisfies GPUTableEvaluator<'float32x4'>;
+  normalizedArithmeticEvaluator satisfies GPUDataEvaluator<'float32x4'>;
 
   const representableInterleaveEvaluator = interleave(float32Evaluator, float32x2Evaluator);
-  representableInterleaveEvaluator satisfies GPUTableEvaluator<'float32x3'>;
+  representableInterleaveEvaluator satisfies GPUDataEvaluator<'float32x3'>;
 
   const wideInterleaveEvaluator = interleave(float32x3Evaluator, float32x3Evaluator);
-  wideInterleaveEvaluator satisfies GPUTableEvaluator<GPUVectorFormat>;
+  wideInterleaveEvaluator satisfies GPUDataEvaluator<GPUVectorFormat>;
   const wideInterleaveFormat = wideInterleaveEvaluator.format;
   wideInterleaveFormat satisfies GPUVectorFormat | undefined;
   // @ts-expect-error wide interleave output falls back to broad GPUVectorFormat
   wideInterleaveFormat satisfies 'float32x4' | undefined;
 
-  const dynamicSizeEvaluator = GPUTableEvaluator.fromArray([1, 2, 3], {size: dynamicSize});
-  dynamicSizeEvaluator satisfies GPUTableEvaluator<GPUVectorFormat>;
+  const dynamicSizeEvaluator = GPUDataEvaluator.fromArray([1, 2, 3], {size: dynamicSize});
+  dynamicSizeEvaluator satisfies GPUDataEvaluator<GPUVectorFormat>;
   const dynamicSizeFormat = dynamicSizeEvaluator.format;
   dynamicSizeFormat satisfies GPUVectorFormat | undefined;
   // @ts-expect-error non-literal sizes fall back to broad GPUVectorFormat

--- a/modules/gpgpu/test/gpu-vector/gpu-data-evaluator-types.spec.ts
+++ b/modules/gpgpu/test/gpu-vector/gpu-data-evaluator-types.spec.ts
@@ -10,6 +10,7 @@ import {
   gather,
   getGPUDataEvaluator,
   GPUDataEvaluator,
+  GPUVectorEvaluator,
   interleave,
   sequence,
   sqrt
@@ -27,36 +28,39 @@ export function checkGPUDataEvaluatorTypes(
   float32x3Vector: GPUVector<'float32x3'>,
   uint32x4Vector: GPUVector<'uint32x4'>
 ): void {
-  const evaluatorFromVector = GPUDataEvaluator.fromGPUVector(float32x3Vector);
-  evaluatorFromVector satisfies GPUDataEvaluator<'float32x3'>;
+  const evaluatorFromData = GPUDataEvaluator.fromGPUData(float32x3Vector.data[0]);
+  evaluatorFromData satisfies GPUDataEvaluator<'float32x3'>;
 
-  const evaluatorFromInput = getGPUDataEvaluator(float32x3Vector);
+  const evaluatorFromInput = getGPUDataEvaluator(float32x3Vector.data[0]);
   evaluatorFromInput satisfies GPUDataEvaluator<'float32x3'>;
 
-  const evaluatedVector = evaluatorFromVector.evaluate(device);
+  const evaluatedVector = evaluatorFromData.evaluate(device);
   evaluatedVector satisfies Promise<GPUVector<'float32x3'>>;
 
-  const evaluatedOverrideVector = evaluatorFromVector.evaluate(device, {format: 'float32x2'});
+  const evaluatedOverrideVector = evaluatorFromData.evaluate(device, {format: 'float32x2'});
   evaluatedOverrideVector satisfies Promise<GPUVector<'float32x2'>>;
 
-  const evaluatedInterleavedVector = evaluatorFromVector.evaluate(device, {interleaved: true});
+  const evaluatedInterleavedVector = evaluatorFromData.evaluate(device, {interleaved: true});
   evaluatedInterleavedVector satisfies Promise<GPUVector<GPUVectorFormat>>;
+
+  const vectorEvaluator = GPUVectorEvaluator.fromGPUVector(float32x3Vector);
+  vectorEvaluator satisfies GPUVectorEvaluator;
 
   const sequenceEvaluator = sequence(4);
   sequenceEvaluator satisfies GPUDataEvaluator<'sint32'>;
 
-  const gatheredEvaluator = gather(sequenceEvaluator, float32x3Vector);
+  const gatheredEvaluator = gather(sequenceEvaluator, float32x3Vector.data[0]);
   gatheredEvaluator satisfies GPUDataEvaluator<'float32x3'>;
 
-  const extentEvaluator = extent(float32x3Vector);
+  const extentEvaluator = extent(float32x3Vector.data[0]);
   extentEvaluator satisfies GPUDataEvaluator<'float32x2'>;
 
-  const roundedEvaluator = fround(uint32x4Vector);
+  const roundedEvaluator = fround(uint32x4Vector.data[0]);
   roundedEvaluator satisfies GPUDataEvaluator<'float32x4'>;
 
-  const float32Evaluator = GPUDataEvaluator.fromGPUVector(float32Vector);
-  const float32x2Evaluator = GPUDataEvaluator.fromGPUVector(float32x2Vector);
-  const float32x3Evaluator = GPUDataEvaluator.fromGPUVector(float32x3Vector);
+  const float32Evaluator = GPUDataEvaluator.fromGPUData(float32Vector.data[0]);
+  const float32x2Evaluator = GPUDataEvaluator.fromGPUData(float32x2Vector.data[0]);
+  const float32x3Evaluator = GPUDataEvaluator.fromGPUData(float32x3Vector.data[0]);
 
   const widenedArithmeticEvaluator = add(float32Evaluator, float32x3Evaluator);
   widenedArithmeticEvaluator satisfies GPUDataEvaluator<'float32x3'>;

--- a/modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts
+++ b/modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts
@@ -3,12 +3,12 @@
 // Copyright (c) vis.gl contributors
 
 import {Buffer, NativeFloat16ArrayConstructor, type Device} from '@luma.gl/core';
-import {GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {GPUDataEvaluator, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {GPUVector, type GPUVectorFormat} from '@luma.gl/tables';
 import {NullDevice} from '@luma.gl/test-utils';
 import {expect, test, vi} from 'vitest';
 
-test('GPUTableEvaluator.fromGPUVector accepts packed Float16 vectors', () => {
+test('GPUDataEvaluator.fromGPUVector accepts packed Float16 vectors', () => {
   const device = new NullDevice({});
   const vector2 = makeUint16Vector(device, 'colors16x2', [0x3c00, 0x3800], 2, {
     format: 'float16x2'
@@ -17,8 +17,9 @@ test('GPUTableEvaluator.fromGPUVector accepts packed Float16 vectors', () => {
     format: 'float16x4'
   });
 
-  const evaluator2 = GPUTableEvaluator.fromGPUVector(vector2);
-  const evaluator4 = GPUTableEvaluator.fromGPUVector(vector4);
+  const evaluator2 = GPUDataEvaluator.fromGPUVector(vector2);
+  const evaluator4 = GPUDataEvaluator.fromGPUVector(vector4);
+  const evaluatorFromData = GPUDataEvaluator.fromGPUData(vector4.data[0]);
 
   expect(evaluator2.type).toBe('float16');
   expect(evaluator2.size).toBe(2);
@@ -26,15 +27,19 @@ test('GPUTableEvaluator.fromGPUVector accepts packed Float16 vectors', () => {
   expect(evaluator4.type).toBe('float16');
   expect(evaluator4.size).toBe(4);
   expect(evaluator4.ValueType).toBe(NativeFloat16ArrayConstructor ?? Uint16Array);
+  expect(evaluatorFromData.type).toBe('float16');
+  expect(evaluatorFromData.size).toBe(4);
+  expect(evaluatorFromData.ValueType).toBe(NativeFloat16ArrayConstructor ?? Uint16Array);
 
   evaluator2.destroy();
   evaluator4.destroy();
+  evaluatorFromData.destroy();
   vector2.destroy();
   vector4.destroy();
   device.destroy();
 });
 
-test('GPUTableEvaluator.fromGPUVector validates packed numeric vectors', () => {
+test('GPUDataEvaluator.fromGPUVector validates packed numeric vectors', () => {
   const device = new NullDevice({});
   const vector = makeFloat32Vector(device, 'values', [1, 2, 3, 4], 2);
   const interleaved = new GPUVector({
@@ -56,11 +61,15 @@ test('GPUTableEvaluator.fromGPUVector validates packed numeric vectors', () => {
     rowByteLength: 8
   });
 
-  expect(() => GPUTableEvaluator.fromGPUVector(interleaved)).toThrow(/does not accept interleaved/);
-  expect(() => GPUTableEvaluator.fromGPUVector(mismatchedRowByteLength)).toThrow(
+  expect(() => GPUDataEvaluator.fromGPUVector(interleaved)).toThrow(/does not accept interleaved/);
+  expect(() => GPUDataEvaluator.fromGPUVector(mismatchedRowByteLength)).toThrow(
     /requires rowByteLength 8/
   );
-  expect(() => GPUTableEvaluator.fromGPUVector(unpacked)).toThrow(/requires packed vector/);
+  expect(() => GPUDataEvaluator.fromGPUVector(unpacked)).toThrow(/requires packed vector/);
+  expect(() => GPUDataEvaluator.fromGPUData(mismatchedRowByteLength.data[0])).toThrow(
+    /requires rowByteLength 8/
+  );
+  expect(() => GPUDataEvaluator.fromGPUData(unpacked.data[0])).toThrow(/requires packed GPUData/);
 
   interleaved.destroy();
   mismatchedRowByteLength.destroy();
@@ -69,7 +78,7 @@ test('GPUTableEvaluator.fromGPUVector validates packed numeric vectors', () => {
   device.destroy();
 });
 
-test('GPUTableEvaluator.readValue only reads requested rows from GPU buffers', async () => {
+test('GPUDataEvaluator.readValue only reads requested rows from GPU buffers', async () => {
   const device = new NullDevice({});
   const packed = makeFloat32Vector(device, 'packed-values', [10, 11, 20, 21, 30, 31, 40, 41], 2);
   const strided = makeFloat32Vector(
@@ -83,8 +92,8 @@ test('GPUTableEvaluator.readValue only reads requested rows from GPU buffers', a
     }
   );
 
-  const packedEvaluator = GPUTableEvaluator.fromGPUVector(packed);
-  const stridedEvaluator = new GPUTableEvaluator({
+  const packedEvaluator = GPUDataEvaluator.fromGPUVector(packed);
+  const stridedEvaluator = new GPUDataEvaluator({
     id: 'strided-evaluator',
     type: 'float32',
     size: 2,
@@ -98,7 +107,7 @@ test('GPUTableEvaluator.readValue only reads requested rows from GPU buffers', a
   const stridedBuffer = strided.data[0].buffer;
   const packedReadAsyncSpy = vi.spyOn(packedBuffer, 'readAsync');
   const stridedReadAsyncSpy = vi.spyOn(stridedBuffer, 'readAsync');
-  const unevaluatedEvaluator = GPUTableEvaluator.fromArray([1, 2], {size: 1});
+  const unevaluatedEvaluator = GPUDataEvaluator.fromArray([1, 2], {size: 1});
 
   expect(packedEvaluator.buffer).toBe(packedBuffer);
   expect(stridedEvaluator.buffer).toBe(stridedBuffer);

--- a/modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts
+++ b/modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts
@@ -3,12 +3,12 @@
 // Copyright (c) vis.gl contributors
 
 import {Buffer, NativeFloat16ArrayConstructor, type Device} from '@luma.gl/core';
-import {GPUDataEvaluator, GPUDataEvaluator} from '@luma.gl/gpgpu';
+import {GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {GPUVector, type GPUVectorFormat} from '@luma.gl/tables';
 import {NullDevice} from '@luma.gl/test-utils';
 import {expect, test, vi} from 'vitest';
 
-test('GPUDataEvaluator.fromGPUVector accepts packed Float16 vectors', () => {
+test('GPUDataEvaluator.fromGPUData accepts packed Float16 chunks', () => {
   const device = new NullDevice({});
   const vector2 = makeUint16Vector(device, 'colors16x2', [0x3c00, 0x3800], 2, {
     format: 'float16x2'
@@ -17,9 +17,8 @@ test('GPUDataEvaluator.fromGPUVector accepts packed Float16 vectors', () => {
     format: 'float16x4'
   });
 
-  const evaluator2 = GPUDataEvaluator.fromGPUVector(vector2);
-  const evaluator4 = GPUDataEvaluator.fromGPUVector(vector4);
-  const evaluatorFromData = GPUDataEvaluator.fromGPUData(vector4.data[0]);
+  const evaluator2 = GPUDataEvaluator.fromGPUData(vector2.data[0]);
+  const evaluator4 = GPUDataEvaluator.fromGPUData(vector4.data[0]);
 
   expect(evaluator2.type).toBe('float16');
   expect(evaluator2.size).toBe(2);
@@ -27,29 +26,15 @@ test('GPUDataEvaluator.fromGPUVector accepts packed Float16 vectors', () => {
   expect(evaluator4.type).toBe('float16');
   expect(evaluator4.size).toBe(4);
   expect(evaluator4.ValueType).toBe(NativeFloat16ArrayConstructor ?? Uint16Array);
-  expect(evaluatorFromData.type).toBe('float16');
-  expect(evaluatorFromData.size).toBe(4);
-  expect(evaluatorFromData.ValueType).toBe(NativeFloat16ArrayConstructor ?? Uint16Array);
-
   evaluator2.destroy();
   evaluator4.destroy();
-  evaluatorFromData.destroy();
   vector2.destroy();
   vector4.destroy();
   device.destroy();
 });
 
-test('GPUDataEvaluator.fromGPUVector validates packed numeric vectors', () => {
+test('GPUDataEvaluator.fromGPUData validates packed numeric chunks', () => {
   const device = new NullDevice({});
-  const vector = makeFloat32Vector(device, 'values', [1, 2, 3, 4], 2);
-  const interleaved = new GPUVector({
-    type: 'interleaved',
-    name: 'interleaved-values',
-    buffer: vector.data[0].buffer,
-    length: 2,
-    byteStride: 8,
-    attributes: [{attribute: 'values', format: 'float32x2', byteOffset: 0}]
-  });
   const mismatchedRowByteLength = makeUint16Vector(device, 'bad-row-byte-length', [0, 0, 0, 0], 4, {
     format: 'float16x4',
     byteStride: 4,
@@ -61,20 +46,13 @@ test('GPUDataEvaluator.fromGPUVector validates packed numeric vectors', () => {
     rowByteLength: 8
   });
 
-  expect(() => GPUDataEvaluator.fromGPUVector(interleaved)).toThrow(/does not accept interleaved/);
-  expect(() => GPUDataEvaluator.fromGPUVector(mismatchedRowByteLength)).toThrow(
-    /requires rowByteLength 8/
-  );
-  expect(() => GPUDataEvaluator.fromGPUVector(unpacked)).toThrow(/requires packed vector/);
   expect(() => GPUDataEvaluator.fromGPUData(mismatchedRowByteLength.data[0])).toThrow(
     /requires rowByteLength 8/
   );
   expect(() => GPUDataEvaluator.fromGPUData(unpacked.data[0])).toThrow(/requires packed GPUData/);
 
-  interleaved.destroy();
   mismatchedRowByteLength.destroy();
   unpacked.destroy();
-  vector.destroy();
   device.destroy();
 });
 
@@ -92,7 +70,7 @@ test('GPUDataEvaluator.readValue only reads requested rows from GPU buffers', as
     }
   );
 
-  const packedEvaluator = GPUDataEvaluator.fromGPUVector(packed);
+  const packedEvaluator = GPUDataEvaluator.fromGPUData(packed.data[0]);
   const stridedEvaluator = new GPUDataEvaluator({
     id: 'strided-evaluator',
     type: 'float32',

--- a/modules/gpgpu/test/gpu-vector/gpu-vector-compute.spec.ts
+++ b/modules/gpgpu/test/gpu-vector/gpu-vector-compute.spec.ts
@@ -3,7 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 import {Buffer} from '@luma.gl/core';
-import {add, fround, GPUTableEvaluator, interleave} from '@luma.gl/gpgpu';
+import {
+  add,
+  fround,
+  GPUDataEvaluator,
+  GPUDataEvaluator,
+  GPUVectorEvaluator,
+  interleave
+} from '@luma.gl/gpgpu';
 import {GPUVector, type GPUVectorFormat} from '@luma.gl/tables';
 import {getTestDevice} from '@luma.gl/test-utils';
 import {expect, test} from 'vitest';
@@ -35,6 +42,60 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
     sum.destroy();
     x.destroy();
     y.destroy();
+  });
+
+  test(`GPUData compute#add:${deviceType}`, async t => {
+    const device = await getTestDevice(deviceType);
+    if (!device) {
+      t.annotate(`${deviceType} not available`);
+      return;
+    }
+
+    const x = makeFloat32Vector(device, 'x', [0, 1, 2, 3, 4, 5], 2);
+    const y = makeFloat32Vector(device, 'y', [10, 20, 30, 40, 50, 60], 2);
+    const sum = add(x.data[0], y.data[0]);
+    const result = await sum.evaluate(device, {name: 'sum'});
+
+    expect(result.name).toBe('sum');
+    expect(result.format).toBe(x.format);
+    expect(Array.from(await readFloat32Vector(result))).toEqual([10, 21, 32, 43, 54, 65]);
+
+    sum.destroy();
+    x.destroy();
+    y.destroy();
+  });
+
+  test(`GPUVectorEvaluator compute#mapGPUData:${deviceType}`, async t => {
+    const device = await getTestDevice(deviceType);
+    if (!device) {
+      t.annotate(`${deviceType} not available`);
+      return;
+    }
+
+    const x0 = makeFloat32Vector(device, 'x0', [0, 1, 2, 3], 2);
+    const x1 = makeFloat32Vector(device, 'x1', [4, 5, 6, 7], 2);
+    const vector = new GPUVector({
+      type: 'data',
+      name: 'x',
+      format: 'float32x2',
+      data: [x0.data[0], x1.data[0]]
+    });
+    const offset = GPUDataEvaluator.fromConstant([10, 20]);
+    const transformed = GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(data =>
+      add(data, offset)
+    );
+    const result = await transformed.evaluate(device, {name: 'sum'});
+
+    expect(result.name).toBe('sum');
+    expect(result.data).toHaveLength(2);
+    expect(Array.from(await readFloat32Data(result.data[0]))).toEqual([10, 21, 12, 23]);
+    expect(Array.from(await readFloat32Data(result.data[1]))).toEqual([14, 25, 16, 27]);
+
+    transformed.destroy();
+    offset.destroy();
+    vector.destroy();
+    x0.destroy();
+    x1.destroy();
   });
 
   test(`GPUVector compute#add synthesizes widened output type:${deviceType}`, async t => {
@@ -162,7 +223,7 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
     }
 
     const vector = makeFloat32Vector(device, 'values', [1, 2, 3], 1);
-    const evaluator = GPUTableEvaluator.fromGPUVector(vector);
+    const evaluator = GPUDataEvaluator.fromGPUVector(vector);
     const result = await evaluator.evaluate(device, {name: 'values-view'});
 
     expect(result).toBe(vector);
@@ -233,6 +294,14 @@ function getUint32VectorFormat(stride: number): GPUVectorFormat {
 async function readFloat32Vector(vector: GPUVector): Promise<Float32Array> {
   const readByteLength = (vector.length - 1) * vector.byteStride + vector.rowByteLength;
   const bytes = await getBuffer(vector).readAsync(vector.byteOffset, readByteLength);
+  const arrayBuffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  return new Float32Array(arrayBuffer);
+}
+
+async function readFloat32Data(data: GPUVector['data'][number]): Promise<Float32Array> {
+  const buffer = data.buffer instanceof Buffer ? data.buffer : data.buffer.buffer;
+  const readByteLength = (data.length - 1) * data.byteStride + data.rowByteLength;
+  const bytes = await buffer.readAsync(data.byteOffset, readByteLength);
   const arrayBuffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
   return new Float32Array(arrayBuffer);
 }

--- a/modules/gpgpu/test/gpu-vector/gpu-vector-compute.spec.ts
+++ b/modules/gpgpu/test/gpu-vector/gpu-vector-compute.spec.ts
@@ -3,47 +3,13 @@
 // Copyright (c) vis.gl contributors
 
 import {Buffer} from '@luma.gl/core';
-import {
-  add,
-  fround,
-  GPUDataEvaluator,
-  GPUDataEvaluator,
-  GPUVectorEvaluator,
-  interleave
-} from '@luma.gl/gpgpu';
+import {add, fround, GPUDataEvaluator, GPUVectorEvaluator, interleave} from '@luma.gl/gpgpu';
 import {GPUVector, type GPUVectorFormat} from '@luma.gl/tables';
 import {getTestDevice} from '@luma.gl/test-utils';
 import {expect, test} from 'vitest';
 import '../operations/fixtures';
 
 for (const deviceType of ['webgl', 'webgpu'] as const) {
-  test(`GPUVector compute#add:${deviceType}`, async t => {
-    const device = await getTestDevice(deviceType);
-    if (!device) {
-      t.annotate(`${deviceType} not available`);
-      return;
-    }
-
-    const x = makeFloat32Vector(device, 'x', [0, 1, 2, 3, 4, 5], 2);
-    const y = makeFloat32Vector(device, 'y', [10, 20, 30, 40, 50, 60], 2);
-    const sum = add(x, y);
-    const result = await sum.evaluate(device, {name: 'sum'});
-
-    expect(result.name).toBe('sum');
-    expect(result.format).toBe(x.format);
-    expect(Array.from(await readFloat32Vector(result))).toEqual([10, 21, 32, 43, 54, 65]);
-
-    const xBuffer = getBuffer(x);
-    const sumBuffer = getBuffer(sum.gpuVector);
-    result.destroy();
-    expect(xBuffer.destroyed).toBe(false);
-    expect(sumBuffer.destroyed).toBe(false);
-    expect(Array.from(await sum.readValue())).toEqual([10, 21, 32, 43, 54, 65]);
-    sum.destroy();
-    x.destroy();
-    y.destroy();
-  });
-
   test(`GPUData compute#add:${deviceType}`, async t => {
     const device = await getTestDevice(deviceType);
     if (!device) {
@@ -60,6 +26,12 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
     expect(result.format).toBe(x.format);
     expect(Array.from(await readFloat32Vector(result))).toEqual([10, 21, 32, 43, 54, 65]);
 
+    const xBuffer = getBuffer(x);
+    const sumBuffer = getBuffer(sum.gpuVector);
+    result.destroy();
+    expect(xBuffer.destroyed).toBe(false);
+    expect(sumBuffer.destroyed).toBe(false);
+    expect(Array.from(await sum.readValue())).toEqual([10, 21, 32, 43, 54, 65]);
     sum.destroy();
     x.destroy();
     y.destroy();
@@ -98,7 +70,7 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
     x1.destroy();
   });
 
-  test(`GPUVector compute#add synthesizes widened output type:${deviceType}`, async t => {
+  test(`GPUData compute#add synthesizes widened output type:${deviceType}`, async t => {
     const device = await getTestDevice(deviceType);
     if (!device) {
       t.annotate(`${deviceType} not available`);
@@ -107,7 +79,7 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
 
     const x = makeFloat32Vector(device, 'x', [1, 2, 3], 1);
     const y = makeFloat32Vector(device, 'y', [10, 20, 30, 40, 50, 60], 2);
-    const sum = add(x, y);
+    const sum = add(x.data[0], y.data[0]);
     const result = await sum.evaluate(device, {name: 'sum'});
 
     expect(result.format).toBe('float32x2');
@@ -118,7 +90,7 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
     y.destroy();
   });
 
-  test(`GPUVector compute#lazy evaluator chain:${deviceType}`, async t => {
+  test(`GPUData compute#lazy evaluator chain:${deviceType}`, async t => {
     const device = await getTestDevice(deviceType);
     if (!device) {
       t.annotate(`${deviceType} not available`);
@@ -128,8 +100,8 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
     const x = makeFloat32Vector(device, 'x', [0, 1, 2, 3], 2);
     const y = makeFloat32Vector(device, 'y', [10, 20, 30, 40], 2);
     const z = makeFloat32Vector(device, 'z', [100, 200], 1);
-    const sum = add(x, y);
-    const packed = interleave(sum, z);
+    const sum = add(x.data[0], y.data[0]);
+    const packed = interleave(sum, z.data[0]);
     const result = await packed.evaluate(device, {
       name: 'packed',
       interleaved: {
@@ -162,7 +134,7 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
     z.destroy();
   });
 
-  test(`GPUVector compute#interleave synthesizes flattened attributes:${deviceType}`, async t => {
+  test(`GPUData compute#interleave synthesizes flattened attributes:${deviceType}`, async t => {
     const device = await getTestDevice(deviceType);
     if (!device) {
       t.annotate(`${deviceType} not available`);
@@ -172,7 +144,10 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
     const x = makeFloat32Vector(device, 'x', [1, 2], 1);
     const y = makeFloat32Vector(device, 'y', [10, 20], 1);
     const z = makeFloat32Vector(device, 'z', [100, 200], 1);
-    const packed = interleave(x, y, z);
+    const xEvaluator = GPUDataEvaluator.fromGPUData(x.data[0], {id: x.name});
+    const yEvaluator = GPUDataEvaluator.fromGPUData(y.data[0], {id: y.name});
+    const zEvaluator = GPUDataEvaluator.fromGPUData(z.data[0], {id: z.name});
+    const packed = interleave(xEvaluator, yEvaluator, zEvaluator);
     const result = await packed.evaluate(device, {name: 'packed3', interleaved: true});
 
     expect(result.bufferLayout).toEqual({
@@ -187,12 +162,15 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
     expect(Array.from(await readFloat32Vector(result))).toEqual([1, 10, 100, 2, 20, 200]);
 
     packed.destroy();
+    xEvaluator.destroy();
+    yEvaluator.destroy();
+    zEvaluator.destroy();
     x.destroy();
     y.destroy();
     z.destroy();
   });
 
-  test(`GPUVector compute#fround:${deviceType}`, async t => {
+  test(`GPUData compute#fround:${deviceType}`, async t => {
     const device = await getTestDevice(deviceType);
     if (!device) {
       t.annotate(`${deviceType} not available`);
@@ -201,7 +179,7 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
 
     const values = [Math.PI, -122.123456789, Math.E, 37.987654321];
     const source = makeFloat64Vector(device, 'positions64', values, 2);
-    const rounded = fround(source);
+    const rounded = fround(source.data[0]);
     const result = await rounded.evaluate(device, {name: 'positions32'});
 
     expect(result.name).toBe('positions32');
@@ -215,7 +193,7 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
     source.destroy();
   });
 
-  test(`GPUVector compute#fromGPUVector:${deviceType}`, async t => {
+  test(`GPUData compute#fromGPUData:${deviceType}`, async t => {
     const device = await getTestDevice(deviceType);
     if (!device) {
       t.annotate(`${deviceType} not available`);
@@ -223,10 +201,10 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
     }
 
     const vector = makeFloat32Vector(device, 'values', [1, 2, 3], 1);
-    const evaluator = GPUDataEvaluator.fromGPUVector(vector);
+    const evaluator = GPUDataEvaluator.fromGPUData(vector.data[0], {id: vector.name});
     const result = await evaluator.evaluate(device, {name: 'values-view'});
 
-    expect(result).toBe(vector);
+    expect(result.data[0]).toBe(vector.data[0]);
     expect(result.name).toBe('values');
     expect(Array.from(await readFloat32Vector(result))).toEqual([1, 2, 3]);
     result.destroy();

--- a/modules/gpgpu/test/operations/add.spec.ts
+++ b/modules/gpgpu/test/operations/add.spec.ts
@@ -54,10 +54,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
         expected: {value: [1, 2, 3, 2, 3, 4, 7, 8, 9, 8, 9, 10], type: 'float32', size: 3}
       },
       {
-        eval: add(
-          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
-          1
-        ),
+        eval: add(GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}), 1),
         expected: {value: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], type: 'float32', size: 3}
       },
       {

--- a/modules/gpgpu/test/operations/add.spec.ts
+++ b/modules/gpgpu/test/operations/add.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {add, cleanEvaluate, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {add, cleanEvaluate, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
@@ -16,23 +16,23 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
     });
 
     const TEST_CASES: {
-      eval: GPUTableEvaluator;
+      eval: GPUDataEvaluator;
       expected: TestData;
     }[] = [
       {
         eval: add(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 2}),
-          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 2})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 2}),
+          GPUDataEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 2})
         ),
         expected: {value: [0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16], type: 'float32', size: 2}
       },
       {
         eval: add(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {
             type: 'uint32',
             size: 2
           }),
-          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {
+          GPUDataEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {
             type: 'uint8',
             size: 2
           })
@@ -41,21 +41,21 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: add(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 6}),
-          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 6})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 6}),
+          GPUDataEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 6})
         ),
         expected: {value: [0, 1, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16], type: 'float32', size: 6}
       },
       {
         eval: add(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
-          GPUTableEvaluator.fromArray([1, -1, 1, -1], {size: 1})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
+          GPUDataEvaluator.fromArray([1, -1, 1, -1], {size: 1})
         ),
         expected: {value: [1, 2, 3, 2, 3, 4, 7, 8, 9, 8, 9, 10], type: 'float32', size: 3}
       },
       {
         eval: add(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
           1
         ),
         expected: {value: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], type: 'float32', size: 3}
@@ -66,9 +66,9 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: add(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 2}),
-          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 2}),
-          GPUTableEvaluator.fromArray([1, -1, 1, -1, 1, -1], {type: 'sint8', size: 1})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 2}),
+          GPUDataEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 2}),
+          GPUDataEvaluator.fromArray([1, -1, 1, -1, 1, -1], {type: 'sint8', size: 1})
         ),
         expected: {value: [1, 2, 2, 3, 7, 8, 8, 9, 13, 14, 14, 15], type: 'float32', size: 2}
       }

--- a/modules/gpgpu/test/operations/arithmetic-operation.spec.ts
+++ b/modules/gpgpu/test/operations/arithmetic-operation.spec.ts
@@ -3,23 +3,23 @@
 // Copyright (c) vis.gl contributors
 
 import {expect, test} from 'vitest';
-import {GPUTableEvaluator} from '../../src/operation/gpu-table-evaluator';
+import {GPUDataEvaluator} from '../../src/operation/gpu-data-evaluator';
 import {ArithmeticOperation} from '../../src/operations/arithmetic-operation';
 
 test('GPGPU#ArithmeticOperation#mergeDependenciesAndExpressions', () => {
-  const a = new GPUTableEvaluator({
+  const a = new GPUDataEvaluator({
     id: 'a',
     type: 'float32',
     size: 1,
     value: new Float32Array([1, 2, 3])
   });
-  const b = new GPUTableEvaluator({
+  const b = new GPUDataEvaluator({
     id: 'b',
     type: 'float32',
     size: 1,
     value: new Float32Array([4, 5, 6])
   });
-  const c = new GPUTableEvaluator({
+  const c = new GPUDataEvaluator({
     id: 'c',
     type: 'float32',
     size: 1,
@@ -53,19 +53,19 @@ test('GPGPU#ArithmeticOperation#mergeDependenciesAndExpressions', () => {
 });
 
 test('GPGPU#ArithmeticOperation#toString', () => {
-  const a = new GPUTableEvaluator({
+  const a = new GPUDataEvaluator({
     id: 'a',
     type: 'float32',
     size: 1,
     value: new Float32Array([1])
   });
-  const b = new GPUTableEvaluator({
+  const b = new GPUDataEvaluator({
     id: 'b',
     type: 'float32',
     size: 1,
     value: new Float32Array([2])
   });
-  const two = new GPUTableEvaluator({
+  const two = new GPUDataEvaluator({
     id: '2',
     isConstant: true,
     type: 'float32',
@@ -81,7 +81,7 @@ test('GPGPU#ArithmeticOperation#toString', () => {
 });
 
 test('GPGPU#ArithmeticOperation#literalArgs', () => {
-  const a = new GPUTableEvaluator({
+  const a = new GPUDataEvaluator({
     id: 'a',
     type: 'float32',
     size: 1,
@@ -124,7 +124,7 @@ test('GPGPU#ArithmeticOperation#literalOnlyExpression', () => {
 });
 
 test('GPGPU#ArithmeticOperation#floatOnlyOpsPromoteOutputType', () => {
-  const integers = new GPUTableEvaluator({
+  const integers = new GPUDataEvaluator({
     id: 'integers',
     type: 'uint32',
     size: 1,

--- a/modules/gpgpu/test/operations/arithmetic.spec.ts
+++ b/modules/gpgpu/test/operations/arithmetic.spec.ts
@@ -13,7 +13,7 @@ import {
   log,
   tan,
   cleanEvaluate,
-  GPUTableEvaluator
+  GPUDataEvaluator
 } from '@luma.gl/gpgpu';
 import {
   getTestDevice,
@@ -32,18 +32,18 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
     });
 
     const TEST_CASES: {
-      eval: GPUTableEvaluator;
+      eval: GPUDataEvaluator;
       expected: TestData;
       runCount?: number;
     }[] = [
       {
         // deck.gl position linear interpolation
         eval: (function () {
-          const start = GPUTableEvaluator.fromArray(
+          const start = GPUDataEvaluator.fromArray(
             new Float32Array([0, 0, 0, -1, 1, -1, 2, 4, 6, -100, -101, -102]),
             {size: 3}
           );
-          const end = GPUTableEvaluator.fromArray(
+          const end = GPUDataEvaluator.fromArray(
             new Float32Array([5, 4, 3, 1, -1, 1, -2, -4, -6, -100, -100, -100]),
             {size: 3}
           );
@@ -60,11 +60,11 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       {
         // deck.gl color linear interpolation
         eval: (function () {
-          const start = GPUTableEvaluator.fromArray(
+          const start = GPUDataEvaluator.fromArray(
             new Uint8Array([0, 0, 0, 255, 255, 255, 255, 255, 10, 20, 40, 80, 200, 160, 80, 40]),
             {size: 4, normalized: true}
           );
-          const end = GPUTableEvaluator.fromArray(
+          const end = GPUDataEvaluator.fromArray(
             new Uint8Array([
               255, 255, 255, 255, 0, 0, 255, 255, 100, 100, 100, 100, 0, 180, 200, 0
             ]),
@@ -85,7 +85,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       {
         // web mercator projection
         eval: (function () {
-          const pos = GPUTableEvaluator.fromArray(
+          const pos = GPUDataEvaluator.fromArray(
             new Float32Array([
               -122.4119, 37.7829, -0.11843, 51.5129, -74.01295, 40.7107, -58.4169, -34.6194,
               86.9207, 27.9882, 0, -84.999

--- a/modules/gpgpu/test/operations/divide.spec.ts
+++ b/modules/gpgpu/test/operations/divide.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, divide, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {cleanEvaluate, divide, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
@@ -16,28 +16,28 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
     });
 
     const TEST_CASES: {
-      eval: GPUTableEvaluator;
+      eval: GPUDataEvaluator;
       expected: TestData;
     }[] = [
       {
         eval: divide(
-          GPUTableEvaluator.fromArray([2, 6, 12, 20, 30, 42, 56, 72, 90, 110, 132, 156], {
+          GPUDataEvaluator.fromArray([2, 6, 12, 20, 30, 42, 56, 72, 90, 110, 132, 156], {
             size: 2
           }),
-          GPUTableEvaluator.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {size: 2})
+          GPUDataEvaluator.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {size: 2})
         ),
         expected: {value: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], type: 'float32', size: 2}
       },
       {
         eval: divide(
-          GPUTableEvaluator.fromArray(
+          GPUDataEvaluator.fromArray(
             [8, 27, 64, 125, 216, 343, 512, 729, 1000, 1331, 1728, 2197],
             {
               type: 'uint32',
               size: 2
             }
           ),
-          GPUTableEvaluator.fromArray([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], {
+          GPUDataEvaluator.fromArray([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], {
             type: 'uint8',
             size: 2
           })
@@ -50,17 +50,17 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: divide(
-          GPUTableEvaluator.fromArray([2, 6, 12, 20, 30, 42, 56, 72, 90, 110, 132, 156], {
+          GPUDataEvaluator.fromArray([2, 6, 12, 20, 30, 42, 56, 72, 90, 110, 132, 156], {
             size: 6
           }),
-          GPUTableEvaluator.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {size: 6})
+          GPUDataEvaluator.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {size: 6})
         ),
         expected: {value: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], type: 'float32', size: 6}
       },
       {
         eval: divide(
-          GPUTableEvaluator.fromArray([2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24], {size: 3}),
-          GPUTableEvaluator.fromArray([2, -2, 0.5, -0.5], {size: 1})
+          GPUDataEvaluator.fromArray([2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24], {size: 3}),
+          GPUDataEvaluator.fromArray([2, -2, 0.5, -0.5], {size: 1})
         ),
         expected: {
           value: [1, 2, 3, -4, -5, -6, 28, 32, 36, -40, -44, -48],
@@ -70,7 +70,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: divide(
-          GPUTableEvaluator.fromArray([2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24], {size: 3}),
+          GPUDataEvaluator.fromArray([2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24], {size: 3}),
           [2, 2, 2]
         ),
         expected: {value: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], type: 'float32', size: 3}

--- a/modules/gpgpu/test/operations/divide.spec.ts
+++ b/modules/gpgpu/test/operations/divide.spec.ts
@@ -30,13 +30,10 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: divide(
-          GPUDataEvaluator.fromArray(
-            [8, 27, 64, 125, 216, 343, 512, 729, 1000, 1331, 1728, 2197],
-            {
-              type: 'uint32',
-              size: 2
-            }
-          ),
+          GPUDataEvaluator.fromArray([8, 27, 64, 125, 216, 343, 512, 729, 1000, 1331, 1728, 2197], {
+            type: 'uint32',
+            size: 2
+          }),
           GPUDataEvaluator.fromArray([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], {
             type: 'uint8',
             size: 2

--- a/modules/gpgpu/test/operations/dot.spec.ts
+++ b/modules/gpgpu/test/operations/dot.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, dot, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {cleanEvaluate, dot, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
@@ -15,18 +15,18 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       device = await getTestDevice(deviceType);
     });
 
-    const TEST_CASES: {eval: GPUTableEvaluator; expected: TestData}[] = [
+    const TEST_CASES: {eval: GPUDataEvaluator; expected: TestData}[] = [
       {
         eval: dot(
-          GPUTableEvaluator.fromArray([1, 2, 3, 4, 5, 6], {size: 3}),
-          GPUTableEvaluator.fromArray([7, 8, 9, -1, -2, -3], {size: 3})
+          GPUDataEvaluator.fromArray([1, 2, 3, 4, 5, 6], {size: 3}),
+          GPUDataEvaluator.fromArray([7, 8, 9, -1, -2, -3], {size: 3})
         ),
         expected: {value: [50, -32], type: 'float32', size: 1}
       },
       {
         eval: dot(
-          GPUTableEvaluator.fromConstant([1, 0, -1]),
-          GPUTableEvaluator.fromArray([3, 4, 5, 6, 7, 8], {size: 3})
+          GPUDataEvaluator.fromConstant([1, 0, -1]),
+          GPUDataEvaluator.fromArray([3, 4, 5, 6, 7, 8], {size: 3})
         ),
         expected: {value: [-2, -2], type: 'float32', size: 1}
       }

--- a/modules/gpgpu/test/operations/equal-all.spec.ts
+++ b/modules/gpgpu/test/operations/equal-all.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, equalAll, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {cleanEvaluate, equalAll, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
@@ -15,18 +15,18 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       device = await getTestDevice(deviceType);
     });
 
-    const TEST_CASES: {eval: GPUTableEvaluator; expected: TestData}[] = [
+    const TEST_CASES: {eval: GPUDataEvaluator; expected: TestData}[] = [
       {
         eval: equalAll(
-          GPUTableEvaluator.fromArray([1, 2, 3, 4, 5, 6], {size: 3}),
-          GPUTableEvaluator.fromArray([1, 2, 3, 4, 0, 6], {size: 3})
+          GPUDataEvaluator.fromArray([1, 2, 3, 4, 5, 6], {size: 3}),
+          GPUDataEvaluator.fromArray([1, 2, 3, 4, 0, 6], {size: 3})
         ),
         expected: {value: [1, 0], type: 'uint32', size: 1}
       },
       {
         eval: equalAll(
-          GPUTableEvaluator.fromConstant([2, 4]),
-          GPUTableEvaluator.fromArray([2, 4, 2, 0, 2, 4], {type: 'uint32', size: 2})
+          GPUDataEvaluator.fromConstant([2, 4]),
+          GPUDataEvaluator.fromArray([2, 4, 2, 0, 2, 4], {type: 'uint32', size: 2})
         ),
         expected: {value: [1, 0, 1], type: 'uint32', size: 1}
       }

--- a/modules/gpgpu/test/operations/extent.spec.ts
+++ b/modules/gpgpu/test/operations/extent.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, extent, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {cleanEvaluate, extent, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
@@ -16,19 +16,19 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
     });
 
     const TEST_CASES: {
-      eval: GPUTableEvaluator;
+      eval: GPUDataEvaluator;
       expected: TestData;
     }[] = [
       {
-        eval: extent(GPUTableEvaluator.fromArray([4, 9, -1, 8, 7, 3, 2, 12], {size: 2})),
+        eval: extent(GPUDataEvaluator.fromArray([4, 9, -1, 8, 7, 3, 2, 12], {size: 2})),
         expected: {value: [-1, 7, 3, 12], type: 'float32', size: 2}
       },
       {
-        eval: extent(GPUTableEvaluator.fromArray([8, 2, 13, 5], {type: 'uint32', size: 1})),
+        eval: extent(GPUDataEvaluator.fromArray([8, 2, 13, 5], {type: 'uint32', size: 1})),
         expected: {value: [2, 13], type: 'uint32', size: 2}
       },
       {
-        eval: extent(GPUTableEvaluator.fromConstant([6, -2])),
+        eval: extent(GPUDataEvaluator.fromConstant([6, -2])),
         expected: {value: [6, 6, -2, -2], type: 'float32', size: 2}
       }
     ];

--- a/modules/gpgpu/test/operations/fixtures.ts
+++ b/modules/gpgpu/test/operations/fixtures.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 import {SignedDataType, Device} from '@luma.gl/core';
 import {TypedArray, equals} from '@math.gl/core';
-import {GPUTableEvaluator, backendRegistry} from '@luma.gl/gpgpu';
+import {GPUDataEvaluator, backendRegistry} from '@luma.gl/gpgpu';
 import * as cpuBackend from '@luma.gl/gpgpu/operations/cpu';
 import {Stat} from '@probe.gl/stats';
 import {getTestDevice as _getTestDevice} from '@luma.gl/test-utils';
@@ -25,7 +25,7 @@ export type TestData =
 
 /** Check table value against definition, returns error if any */
 export async function verifyTableValue(
-  table: GPUTableEvaluator,
+  table: GPUDataEvaluator,
   expected: TestData,
   epsilon?: number
 ): Promise<string | null> {
@@ -67,14 +67,14 @@ export async function verifyTableValue(
     .join('\n')}`;
 }
 
-export function isSupportedByWebGPU(...inputs: (GPUTableEvaluator | undefined)[]): boolean {
-  const visitedEvaluators = new Set<GPUTableEvaluator>();
+export function isSupportedByWebGPU(...inputs: (GPUDataEvaluator | undefined)[]): boolean {
+  const visitedEvaluators = new Set<GPUDataEvaluator>();
   return inputs.every(input => isEvaluatorSupportedByWebGPU(input, visitedEvaluators));
 }
 
 function isEvaluatorSupportedByWebGPU(
-  evaluator: GPUTableEvaluator | undefined,
-  visitedEvaluators: Set<GPUTableEvaluator>
+  evaluator: GPUDataEvaluator | undefined,
+  visitedEvaluators: Set<GPUDataEvaluator>
 ): boolean {
   if (!evaluator || visitedEvaluators.has(evaluator)) {
     return true;
@@ -86,7 +86,7 @@ function isEvaluatorSupportedByWebGPU(
 
   const source = evaluator.source;
 
-  if (source instanceof GPUTableEvaluator) {
+  if (source instanceof GPUDataEvaluator) {
     return isEvaluatorSupportedByWebGPU(source, visitedEvaluators);
   }
 

--- a/modules/gpgpu/test/operations/fround.spec.ts
+++ b/modules/gpgpu/test/operations/fround.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, fround, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {cleanEvaluate, fround, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, verifyTableValue} from './fixtures';
 
 function splitFloatsCPU(input: number[], size: number): number[] {
@@ -97,7 +97,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
 
     for (const testCase of TEST_CASES) {
       const output = fround(
-        GPUTableEvaluator.fromArray(new Float64Array(testCase.values), {size: testCase.size})
+        GPUDataEvaluator.fromArray(new Float64Array(testCase.values), {size: testCase.size})
       );
       test(output.toString(), async t => {
         if (!device) {

--- a/modules/gpgpu/test/operations/gather.spec.ts
+++ b/modules/gpgpu/test/operations/gather.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, gather, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {cleanEvaluate, gather, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
@@ -16,34 +16,34 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
     });
 
     const TEST_CASES: {
-      eval: GPUTableEvaluator;
+      eval: GPUDataEvaluator;
       expected: TestData;
     }[] = [
       {
         eval: gather(
-          GPUTableEvaluator.fromArray([2, 0, 1, 3], {type: 'uint32', size: 1}),
-          GPUTableEvaluator.fromArray([10, 11, 20, 21, 30, 31, 40, 41], {size: 2})
+          GPUDataEvaluator.fromArray([2, 0, 1, 3], {type: 'uint32', size: 1}),
+          GPUDataEvaluator.fromArray([10, 11, 20, 21, 30, 31, 40, 41], {size: 2})
         ),
         expected: {value: [30, 31, 10, 11, 20, 21, 40, 41], type: 'float32', size: 2}
       },
       {
         eval: gather(
-          GPUTableEvaluator.fromArray([1, 9, 0, 7], {type: 'uint32', size: 1}),
-          GPUTableEvaluator.fromArray([5, 6, 7, 8, 9, 10], {size: 3})
+          GPUDataEvaluator.fromArray([1, 9, 0, 7], {type: 'uint32', size: 1}),
+          GPUDataEvaluator.fromArray([5, 6, 7, 8, 9, 10], {size: 3})
         ),
         expected: {value: [8, 9, 10, 0, 0, 0, 5, 6, 7, 0, 0, 0], type: 'float32', size: 3}
       },
       {
         eval: gather(
-          GPUTableEvaluator.fromArray([3, 1, 0, 2], {type: 'uint32', size: 1}),
-          GPUTableEvaluator.fromArray([2, 3, 5, 7], {type: 'uint32', size: 1})
+          GPUDataEvaluator.fromArray([3, 1, 0, 2], {type: 'uint32', size: 1}),
+          GPUDataEvaluator.fromArray([2, 3, 5, 7], {type: 'uint32', size: 1})
         ),
         expected: {value: [7, 3, 2, 5], type: 'uint32', size: 1}
       },
       {
         eval: gather(
-          GPUTableEvaluator.fromConstant(2, 'uint32'),
-          GPUTableEvaluator.fromArray([10, 11, 20, 21, 30, 31, 40, 41], {size: 2})
+          GPUDataEvaluator.fromConstant(2, 'uint32'),
+          GPUDataEvaluator.fromArray([10, 11, 20, 21, 30, 31, 40, 41], {size: 2})
         ),
         expected: {constant: [30, 31], type: 'float32', size: 2}
       }

--- a/modules/gpgpu/test/operations/interleave.spec.ts
+++ b/modules/gpgpu/test/operations/interleave.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, interleave, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {cleanEvaluate, interleave, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
@@ -16,13 +16,13 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
     });
 
     const TEST_CASES: {
-      eval: GPUTableEvaluator;
+      eval: GPUDataEvaluator;
       expected: TestData;
     }[] = [
       {
         eval: interleave(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], {size: 2}),
-          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4], {size: 2})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], {size: 2}),
+          GPUDataEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4], {size: 2})
         ),
         expected: {
           value: [0, 1, 0, 0, 2, 3, 1, 1, 4, 5, 2, 2, 6, 7, 3, 3, 8, 9, 4, 4],
@@ -32,8 +32,8 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: interleave(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
-          GPUTableEvaluator.fromArray([1, -1, 1, -1], {size: 1})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
+          GPUDataEvaluator.fromArray([1, -1, 1, -1], {size: 1})
         ),
         expected: {
           value: [0, 1, 2, 1, 3, 4, 5, -1, 6, 7, 8, 1, 9, 10, 11, -1],
@@ -43,16 +43,16 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: interleave(
-          GPUTableEvaluator.fromConstant([0, 1, 2]),
-          GPUTableEvaluator.fromConstant([1, 2, 3])
+          GPUDataEvaluator.fromConstant([0, 1, 2]),
+          GPUDataEvaluator.fromConstant([1, 2, 3])
         ),
         expected: {constant: [0, 1, 2, 1, 2, 3], type: 'float32', size: 6}
       },
       {
         eval: interleave(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 4}),
-          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2], {size: 2}),
-          GPUTableEvaluator.fromArray([1, 2, 1], {type: 'uint32', size: 1})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 4}),
+          GPUDataEvaluator.fromArray([0, 0, 1, 1, 2, 2], {size: 2}),
+          GPUDataEvaluator.fromArray([1, 2, 1], {type: 'uint32', size: 1})
         ),
         expected: {
           value: [0, 1, 2, 3, 0, 0, 1, 4, 5, 6, 7, 1, 1, 2, 8, 9, 10, 11, 2, 2, 1],

--- a/modules/gpgpu/test/operations/length.spec.ts
+++ b/modules/gpgpu/test/operations/length.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, length, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {cleanEvaluate, length, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
@@ -15,13 +15,13 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       device = await getTestDevice(deviceType);
     });
 
-    const TEST_CASES: {eval: GPUTableEvaluator; expected: TestData}[] = [
+    const TEST_CASES: {eval: GPUDataEvaluator; expected: TestData}[] = [
       {
-        eval: length(GPUTableEvaluator.fromArray([3, 4, 5, 12, 8, 15], {size: 2})),
+        eval: length(GPUDataEvaluator.fromArray([3, 4, 5, 12, 8, 15], {size: 2})),
         expected: {value: [5, 13, 17], type: 'float32', size: 1}
       },
       {
-        eval: length(GPUTableEvaluator.fromArray([2, 3, 6, 1, 2, 2, 9, 12, 20], {size: 3})),
+        eval: length(GPUDataEvaluator.fromArray([2, 3, 6, 1, 2, 2, 9, 12, 20], {size: 3})),
         expected: {value: [7, 3, 25], type: 'float32', size: 1}
       }
     ];

--- a/modules/gpgpu/test/operations/multiply.spec.ts
+++ b/modules/gpgpu/test/operations/multiply.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, multiply, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {cleanEvaluate, multiply, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
@@ -16,23 +16,23 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
     });
 
     const TEST_CASES: {
-      eval: GPUTableEvaluator;
+      eval: GPUDataEvaluator;
       expected: TestData;
     }[] = [
       {
         eval: multiply(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 2}),
-          GPUTableEvaluator.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {size: 2})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 2}),
+          GPUDataEvaluator.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {size: 2})
         ),
         expected: {value: [0, 2, 6, 12, 20, 30, 42, 56, 72, 90, 110, 132], type: 'float32', size: 2}
       },
       {
         eval: multiply(
-          GPUTableEvaluator.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {
+          GPUDataEvaluator.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {
             type: 'uint32',
             size: 2
           }),
-          GPUTableEvaluator.fromArray([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], {
+          GPUDataEvaluator.fromArray([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], {
             type: 'uint8',
             size: 2
           })
@@ -45,21 +45,21 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: multiply(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 6}),
-          GPUTableEvaluator.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {size: 6})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 6}),
+          GPUDataEvaluator.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {size: 6})
         ),
         expected: {value: [0, 2, 6, 12, 20, 30, 42, 56, 72, 90, 110, 132], type: 'float32', size: 6}
       },
       {
         eval: multiply(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
-          GPUTableEvaluator.fromArray([2, 2, -1, -1, 0.5, 0.5, -2, -2], {size: 2})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
+          GPUDataEvaluator.fromArray([2, 2, -1, -1, 0.5, 0.5, -2, -2], {size: 2})
         ),
         expected: {value: [0, 2, 0, -3, -4, 0, 3, 3.5, 0, -18, -20, 0], type: 'float32', size: 3}
       },
       {
         eval: multiply(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
           [1, 2, 3]
         ),
         expected: {value: [0, 2, 6, 3, 8, 15, 6, 14, 24, 9, 20, 33], type: 'float32', size: 3}
@@ -70,9 +70,9 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: multiply(
-          GPUTableEvaluator.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {size: 2}),
-          GPUTableEvaluator.fromArray([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], {size: 2}),
-          GPUTableEvaluator.fromArray([2, -1, 2, -1, 2, -1], {type: 'sint8', size: 1})
+          GPUDataEvaluator.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], {size: 2}),
+          GPUDataEvaluator.fromArray([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], {size: 2}),
+          GPUDataEvaluator.fromArray([2, -1, 2, -1, 2, -1], {type: 'sint8', size: 1})
         ),
         expected: {
           value: [4, 12, -12, -20, 60, 84, -56, -72, 180, 220, -132, -156],

--- a/modules/gpgpu/test/operations/segmented-map.spec.ts
+++ b/modules/gpgpu/test/operations/segmented-map.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, segmentedMap, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {cleanEvaluate, segmentedMap, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue} from './fixtures';
 
 const LARGE_SEGMENTS = buildSegmentStarts(
@@ -22,11 +22,11 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
     });
 
     const TEST_CASES: {
-      eval: GPUTableEvaluator;
+      eval: GPUDataEvaluator;
       expected: TestData;
     }[] = [
       {
-        eval: segmentedMap(GPUTableEvaluator.fromArray([0, 3, 5], {type: 'uint32'}), 7),
+        eval: segmentedMap(GPUDataEvaluator.fromArray([0, 3, 5], {type: 'uint32'}), 7),
         expected: {
           value: [0, 0, 0, 1, 0, 2, 1, 0, 1, 1, 2, 0, 2, 1],
           type: 'uint32',
@@ -34,7 +34,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
         }
       },
       {
-        eval: segmentedMap(GPUTableEvaluator.fromArray([0, 3, 3, 6], {type: 'uint32'}), 7),
+        eval: segmentedMap(GPUDataEvaluator.fromArray([0, 3, 3, 6], {type: 'uint32'}), 7),
         expected: {
           value: [0, 0, 0, 1, 0, 2, 2, 0, 2, 1, 2, 2, 3, 0],
           type: 'uint32',
@@ -42,7 +42,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
         }
       },
       {
-        eval: segmentedMap(GPUTableEvaluator.fromArray([0], {type: 'uint32'}), 0),
+        eval: segmentedMap(GPUDataEvaluator.fromArray([0], {type: 'uint32'}), 0),
         expected: {
           value: [],
           type: 'uint32',
@@ -50,7 +50,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
         }
       },
       {
-        eval: segmentedMap(GPUTableEvaluator.fromArray([0], {type: 'uint32'}), 4),
+        eval: segmentedMap(GPUDataEvaluator.fromArray([0], {type: 'uint32'}), 4),
         expected: {
           value: [0, 0, 0, 1, 0, 2, 0, 3],
           type: 'uint32',
@@ -59,7 +59,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: segmentedMap(
-          GPUTableEvaluator.fromArray(LARGE_SEGMENTS, {type: 'uint32'}),
+          GPUDataEvaluator.fromArray(LARGE_SEGMENTS, {type: 'uint32'}),
           LARGE_VERTEX_COUNT
         ),
         expected: {

--- a/modules/gpgpu/test/operations/select.spec.ts
+++ b/modules/gpgpu/test/operations/select.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, select, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {cleanEvaluate, select, GPUDataEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
@@ -15,28 +15,28 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       device = await getTestDevice(deviceType);
     });
 
-    const TEST_CASES: {eval: GPUTableEvaluator; expected: TestData}[] = [
+    const TEST_CASES: {eval: GPUDataEvaluator; expected: TestData}[] = [
       {
         eval: select(
-          GPUTableEvaluator.fromArray([1, 0, 2], {type: 'uint32', size: 1}),
-          GPUTableEvaluator.fromArray([10, 11, 20, 21, 30, 31], {size: 2}),
-          GPUTableEvaluator.fromArray([100, 101, 200, 201, 300, 301], {size: 2})
+          GPUDataEvaluator.fromArray([1, 0, 2], {type: 'uint32', size: 1}),
+          GPUDataEvaluator.fromArray([10, 11, 20, 21, 30, 31], {size: 2}),
+          GPUDataEvaluator.fromArray([100, 101, 200, 201, 300, 301], {size: 2})
         ),
         expected: {value: [10, 11, 200, 201, 30, 31], type: 'float32', size: 2}
       },
       {
         eval: select(
-          GPUTableEvaluator.fromArray([1, 0, 0, 1, 1, 1], {type: 'uint32', size: 2}),
-          GPUTableEvaluator.fromConstant(5, 'uint32'),
-          GPUTableEvaluator.fromArray([10, 11, 20, 21, 30, 31], {type: 'uint32', size: 2})
+          GPUDataEvaluator.fromArray([1, 0, 0, 1, 1, 1], {type: 'uint32', size: 2}),
+          GPUDataEvaluator.fromConstant(5, 'uint32'),
+          GPUDataEvaluator.fromArray([10, 11, 20, 21, 30, 31], {type: 'uint32', size: 2})
         ),
         expected: {value: [5, 11, 20, 5, 5, 5], type: 'uint32', size: 2}
       },
       {
         eval: select(
-          GPUTableEvaluator.fromArray([0, 1, 0, 1], {type: 'uint32', size: 1}),
-          GPUTableEvaluator.fromArray([0.5, 1.5, 2.5, 3.5], {size: 1}),
-          GPUTableEvaluator.fromArray([9, 8, 7, 6], {size: 1})
+          GPUDataEvaluator.fromArray([0, 1, 0, 1], {type: 'uint32', size: 1}),
+          GPUDataEvaluator.fromArray([0.5, 1.5, 2.5, 3.5], {size: 1}),
+          GPUDataEvaluator.fromArray([9, 8, 7, 6], {size: 1})
         ),
         expected: {value: [9, 1.5, 7, 3.5], type: 'float32', size: 1}
       }

--- a/modules/gpgpu/test/operations/sequence.spec.ts
+++ b/modules/gpgpu/test/operations/sequence.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, GPUTableEvaluator, sequence} from '@luma.gl/gpgpu';
+import {cleanEvaluate, GPUDataEvaluator, sequence} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
@@ -15,7 +15,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       device = await getTestDevice(deviceType);
     });
 
-    const TEST_CASES: {eval: GPUTableEvaluator; expected: TestData}[] = [
+    const TEST_CASES: {eval: GPUDataEvaluator; expected: TestData}[] = [
       {
         eval: sequence(5),
         expected: {value: [0, 1, 2, 3, 4], type: 'sint32', size: 1}

--- a/modules/gpgpu/test/operations/subtract.spec.ts
+++ b/modules/gpgpu/test/operations/subtract.spec.ts
@@ -4,7 +4,7 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, GPUTableEvaluator, subtract} from '@luma.gl/gpgpu';
+import {cleanEvaluate, GPUDataEvaluator, subtract} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
@@ -16,23 +16,23 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
     });
 
     const TEST_CASES: {
-      eval: GPUTableEvaluator;
+      eval: GPUDataEvaluator;
       expected: TestData;
     }[] = [
       {
         eval: subtract(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 2}),
-          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 2})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 2}),
+          GPUDataEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 2})
         ),
         expected: {value: [0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6], type: 'float32', size: 2}
       },
       {
         eval: subtract(
-          GPUTableEvaluator.fromArray([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21], {
+          GPUDataEvaluator.fromArray([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21], {
             type: 'uint32',
             size: 2
           }),
-          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {
+          GPUDataEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {
             type: 'uint8',
             size: 2
           })
@@ -45,21 +45,21 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: subtract(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 6}),
-          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 6})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 6}),
+          GPUDataEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 6})
         ),
         expected: {value: [0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6], type: 'float32', size: 6}
       },
       {
         eval: subtract(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
-          GPUTableEvaluator.fromArray([1, -1, 1, -1], {size: 1})
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
+          GPUDataEvaluator.fromArray([1, -1, 1, -1], {size: 1})
         ),
         expected: {value: [-1, 0, 1, 4, 5, 6, 5, 6, 7, 10, 11, 12], type: 'float32', size: 3}
       },
       {
         eval: subtract(
-          GPUTableEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
+          GPUDataEvaluator.fromArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], {size: 3}),
           1
         ),
         expected: {value: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], type: 'float32', size: 3}
@@ -70,9 +70,9 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: subtract(
-          GPUTableEvaluator.fromArray([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21], {size: 2}),
-          GPUTableEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 2}),
-          GPUTableEvaluator.fromArray([1, -1, 1, -1, 1, -1], {type: 'sint8', size: 1})
+          GPUDataEvaluator.fromArray([10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21], {size: 2}),
+          GPUDataEvaluator.fromArray([0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5], {size: 2}),
+          GPUDataEvaluator.fromArray([1, -1, 1, -1, 1, -1], {type: 'sint8', size: 1})
         ),
         expected: {
           value: [9, 10, 12, 13, 11, 12, 14, 15, 13, 14, 16, 17],

--- a/modules/gpgpu/test/operations/swizzle.spec.ts
+++ b/modules/gpgpu/test/operations/swizzle.spec.ts
@@ -4,11 +4,11 @@
 
 import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
-import {cleanEvaluate, GPUTableEvaluator, swizzle} from '@luma.gl/gpgpu';
+import {cleanEvaluate, GPUDataEvaluator, swizzle} from '@luma.gl/gpgpu';
 import {getTestDevice, TestData, verifyTableValue, isSupportedByWebGPU} from './fixtures';
 
 test('GPGPU#swizzle validates columns', () => {
-  const source = GPUTableEvaluator.fromArray([0, 1, 2, 3], {size: 2});
+  const source = GPUDataEvaluator.fromArray([0, 1, 2, 3], {size: 2});
 
   expect(() => swizzle(source, [])).toThrow(/must not be empty/);
   expect(() => swizzle(source, [0.5])).toThrow(/must be integers/);
@@ -17,7 +17,7 @@ test('GPGPU#swizzle validates columns', () => {
 });
 
 test('GPGPU#swizzle creates a source view for contiguous columns', () => {
-  const source = GPUTableEvaluator.fromArray([10, 11, 12, 13, 20, 21, 22, 23], {size: 4});
+  const source = GPUDataEvaluator.fromArray([10, 11, 12, 13, 20, 21, 22, 23], {size: 4});
   const result = swizzle(source, [1, 2]);
 
   expect(result.source).toBe(source);
@@ -29,7 +29,7 @@ test('GPGPU#swizzle creates a source view for contiguous columns', () => {
 });
 
 test('GPGPU#swizzle materializes CPU-backed values for reordered columns', () => {
-  const source = GPUTableEvaluator.fromArray([10, 11, 12, 13, 20, 21, 22, 23], {size: 4});
+  const source = GPUDataEvaluator.fromArray([10, 11, 12, 13, 20, 21, 22, 23], {size: 4});
   const result = swizzle(source, [2, 0, 2]);
 
   expect(result.source).toBe(null);
@@ -44,10 +44,10 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       device = await getTestDevice(deviceType);
     });
 
-    const TEST_CASES: {eval: GPUTableEvaluator; expected: TestData; normalized?: boolean}[] = [
+    const TEST_CASES: {eval: GPUDataEvaluator; expected: TestData; normalized?: boolean}[] = [
       {
         eval: swizzle(
-          GPUTableEvaluator.fromArray([10, 11, 12, 13, 20, 21, 22, 23, 30, 31, 32, 33], {
+          GPUDataEvaluator.fromArray([10, 11, 12, 13, 20, 21, 22, 23, 30, 31, 32, 33], {
             size: 4
           }),
           [1, 2]
@@ -56,7 +56,7 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
       },
       {
         eval: swizzle(
-          GPUTableEvaluator.fromArray([10, 11, 12, 13, 20, 21, 22, 23, 30, 31, 32, 33], {
+          GPUDataEvaluator.fromArray([10, 11, 12, 13, 20, 21, 22, 23, 30, 31, 32, 33], {
             size: 4
           }),
           [2, 0, 2]
@@ -64,12 +64,12 @@ for (const deviceType of ['webgl', 'webgpu', 'cpu'] as const) {
         expected: {value: [12, 10, 12, 22, 20, 22, 32, 30, 32], type: 'float32', size: 3}
       },
       {
-        eval: swizzle(GPUTableEvaluator.fromConstant([4, 5, 6, 7], 'uint32'), [3, 1, 1]),
+        eval: swizzle(GPUDataEvaluator.fromConstant([4, 5, 6, 7], 'uint32'), [3, 1, 1]),
         expected: {constant: [7, 5, 5], type: 'uint32', size: 3}
       },
       {
         eval: swizzle(
-          GPUTableEvaluator.fromArray(new Uint8Array([0, 64, 128, 255, 255, 128, 64, 0]), {
+          GPUDataEvaluator.fromArray(new Uint8Array([0, 64, 128, 255, 255, 128, 64, 0]), {
             type: 'uint8',
             size: 4,
             normalized: true

--- a/modules/gpgpu/test/utils/clean-evaluate.spec.ts
+++ b/modules/gpgpu/test/utils/clean-evaluate.spec.ts
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import {GPUVector} from '@luma.gl/tables';
 import {expect, test} from 'vitest';
-import {add, cleanEvaluate, GPUTableEvaluator} from '@luma.gl/gpgpu';
+import {add, cleanEvaluate, GPUDataEvaluator, GPUVectorEvaluator} from '@luma.gl/gpgpu';
 import {getTestDevice} from '@luma.gl/test-utils';
 import '../operations/fixtures';
 
@@ -14,9 +15,9 @@ test(`GPGPU#cleanEvaluate`, async t => {
     return;
   }
 
-  const x = GPUTableEvaluator.fromArray([1, 2, 3, 4], {type: 'sint32', size: 1});
-  const y = GPUTableEvaluator.fromArray([10, 20, 30, 40], {type: 'sint32', size: 1});
-  const z = GPUTableEvaluator.fromArray([100, 200, 300, 400], {type: 'sint32', size: 1});
+  const x = GPUDataEvaluator.fromArray([1, 2, 3, 4], {type: 'sint32', size: 1});
+  const y = GPUDataEvaluator.fromArray([10, 20, 30, 40], {type: 'sint32', size: 1});
+  const z = GPUDataEvaluator.fromArray([100, 200, 300, 400], {type: 'sint32', size: 1});
 
   const partial = add(x, y);
   const sum = add(partial, z);
@@ -34,4 +35,41 @@ test(`GPGPU#cleanEvaluate`, async t => {
 
   x.destroy();
   sum.destroy();
+});
+
+test(`GPGPU#cleanEvaluate preserves GPUVectorEvaluator outputs`, async t => {
+  const device = await getTestDevice('webgl');
+  if (!device) {
+    t.annotate(`webgl not available`);
+    return;
+  }
+
+  const x0 = GPUDataEvaluator.fromArray([1, 2], {size: 1});
+  const x1 = GPUDataEvaluator.fromArray([3, 4], {size: 1});
+  await Promise.all([x0.evaluate(device), x1.evaluate(device)]);
+  const vector = new GPUVector({
+    type: 'data',
+    name: 'values',
+    format: 'float32',
+    data: [x0.gpuVector.data[0], x1.gpuVector.data[0]]
+  });
+  const offset = GPUDataEvaluator.fromConstant(1);
+  const partials: GPUDataEvaluator[] = [];
+  const sum = GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(data => {
+    const partial = add(data, offset);
+    partials.push(partial);
+    return add(partial, offset);
+  });
+
+  await cleanEvaluate(device, sum);
+
+  expect(sum.gpuVector.data).toHaveLength(2);
+  expect(sum.gpuDataEvaluators.every(evaluator => evaluator.evaluated)).toBe(true);
+  expect(partials.every(evaluator => !evaluator.evaluated)).toBe(true);
+
+  sum.destroy();
+  offset.destroy();
+  vector.destroy();
+  x0.destroy();
+  x1.destroy();
 });

--- a/website/src/components/docs/gpgpu-docs-tabs.tsx
+++ b/website/src/components/docs/gpgpu-docs-tabs.tsx
@@ -13,14 +13,14 @@ type GPGPUDocsTab = {
 /** GPGPU documentation tab identifiers. */
 export type GPGPUDocsTabId =
   | 'overview'
-  | 'gpu-table'
+  | 'gpu-data-evaluator'
   | 'operations'
   | 'custom-operation'
   | 'clean-evaluate';
 
 const GPGPU_DOCS_TABS: GPGPUDocsTab[] = [
   {id: 'overview', label: 'Overview', href: '/docs/api-reference/gpgpu'},
-  {id: 'gpu-table', label: 'GPUTableEvaluator', href: '/docs/api-reference/gpgpu/gpu-table'},
+  {id: 'gpu-data-evaluator', label: 'GPU Evaluators', href: '/docs/api-reference/gpgpu/gpu-data-evaluator'},
   {id: 'operations', label: 'Operations', href: '/docs/api-reference/gpgpu/operations'},
   {
     id: 'custom-operation',

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -496,10 +496,10 @@ export const GPGPUExample: React.FC = () => {
     <ExamplePage style={{background: '#f7f8fb', overflow: 'hidden'}}>
       <style>{GPGPU_EXAMPLE_STYLE}</style>
       <main id="app" className="gpgpu-showcase">
-        <h1>@luma.gl/gpgpu table evaluator showcase</h1>
+        <h1>@luma.gl/gpgpu evaluator showcase</h1>
         <p className="subtitle">
           Arrow-backed source columns are extracted as typed-array views and wrapped in
-          GPUTableEvaluator inputs.
+          GPUDataEvaluator inputs.
         </p>
 
         <div className="metadata-grid">


### PR DESCRIPTION
- The entity that owns the actual GPU buffer in the GPUTable system is `GPUData`. 
- A `GPUVector` holds an array of GPUData (`data: GPUData[]`) so we must be able to perform repeated ops on a list of GPUData in order to complete compute on a vector.
- And streaming use cases incrementally add `GPUData` instances to `GPUVector`s so we need to be able to compute on `GPUData` one by one.

<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/99496a40-e1e0-453a-995d-debdc581bdf0" />

<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/26ad4f69-9f57-43d6-a79f-6068781f0e93" />

