### PR TITLE
revert(engine) Revert renaming of geometry attributes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,13 @@
 - Always import individual symbols from `'apache-arrow'` in `modules/*/src`.
 - It is preferred to use `import * as arrow from 'apache-arrow'` in tests, examples, and docs.
 
+## Geometry attribute naming
+- Built-in engine geometries and `@luma.gl/gltf` geometry use glTF mesh attribute semantics such as `POSITION`, `NORMAL`, and `TEXCOORD_0`.
+- `Geometry.attributes` preserves source keys. Do not camelCase or alias those keys in the CPU geometry container.
+- `bufferLayout`, `GPUGeometry`, and `Model` bindings are shader-facing metadata. Convert source semantics only at adapter and model boundaries.
+- Explicit `bufferLayout` is caller-owned and must not be normalized by `Geometry`.
+- Preserve custom geometry names. When writing glTF custom semantics, follow the glTF `_NAME` convention.
+
 ## GPU table API boundaries
 - `@luma.gl/tables` owns generic GPU concepts only: `GPUData`, `GPUVector`, `GPURecordBatch`, `GPUTable`, `GPUSchema`, and `GPUVectorFormat`.
 - `@luma.gl/tables` and `@luma.gl/gpgpu` should not depend on `apache-arrow`. Arrow conversion, upload, and readback helpers belong in `@luma.gl/arrow`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@
 - `Geometry.attributes` preserves source keys. Do not camelCase or alias those keys in the CPU geometry container.
 - `bufferLayout`, `GPUGeometry`, and `Model` bindings are shader-facing metadata. Convert source semantics only at adapter and model boundaries.
 - Explicit `bufferLayout` is caller-owned and must not be normalized by `Geometry`.
+- When source keys synthesize the same shader attribute, preserve legacy last-input-wins behavior without storing duplicate CPU aliases.
 - Preserve custom geometry names. When writing glTF custom semantics, follow the glTF `_NAME` convention.
 
 ## GPU table API boundaries

--- a/docs/api-reference/engine/geometry/geometries.md
+++ b/docs/api-reference/engine/geometry/geometries.md
@@ -1,6 +1,6 @@
 # Built-in Geometries
 
-`@luma.gl/engine` exports several ready-made geometry classes. All of them extend [`Geometry`](/docs/api-reference/engine/geometry) and populate standard shader attributes such as `positions`, `normals`, and `texCoords`.
+`@luma.gl/engine` exports several ready-made geometry classes. All of them extend [`Geometry`](/docs/api-reference/engine/geometry) and populate standard glTF mesh attribute semantics such as `POSITION`, `NORMAL`, and `TEXCOORD_0`.
 
 ## Overview
 

--- a/docs/api-reference/engine/geometry/geometry.md
+++ b/docs/api-reference/engine/geometry/geometry.md
@@ -70,9 +70,16 @@ Optional index attribute.
 
 ### `attributes`
 
-Named geometry attributes. The constructed `Geometry` stores normalized names: `POSITION` becomes `positions`,
-`NORMAL` becomes `normals`, `TEXCOORD_0` becomes `texCoords`, `TEXCOORD_1` becomes `texCoords1`, and
-`COLOR_0` becomes `colors`.
+Named CPU geometry attributes. `Geometry` preserves the keys supplied to the constructor. Built-in
+geometries and `@luma.gl/gltf` use glTF mesh attribute semantics such as `POSITION`, `NORMAL`, and
+`TEXCOORD_0`; glTF calls these mesh attribute semantics, while each semantic points to accessor data in
+`mesh.primitive.attributes`. See the official [glTF 2.0 specification](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html).
+
+Shader-facing names are separate. Synthesized buffer layouts map supported semantic names at the render
+boundary: `POSITION` becomes `positions`, `NORMAL` becomes `normals`, `TEXCOORD_0` becomes `texCoords`,
+`TEXCOORD_1` becomes `texCoords1`, and `COLOR_0` becomes `colors`. Caller-provided non-glTF names such as
+`positions`, `clipSpacePositions`, and `faceIndex` are preserved as-is. When writing glTF custom semantics,
+use the spec's `_NAME` convention.
 
 For non-interleaved geometry, each attribute key normally names one typed-array attribute. For interleaved
 geometry, the attribute key names the packed buffer, and `bufferLayout` maps that buffer back to shader
@@ -81,8 +88,8 @@ attributes.
 ### `bufferLayout`
 
 The buffer layout for the geometry attributes. It is always populated on constructed `Geometry` instances.
-If omitted, the constructor creates one layout entry for each normalized attribute. Explicit `bufferLayout`
-entries are normalized with the same semantic-name rules used for `attributes`.
+If omitted, the constructor creates one shader-facing layout entry for each attribute. Explicit
+`bufferLayout` entries are preserved unchanged.
 
 ### `userData`
 
@@ -92,7 +99,7 @@ Application-owned metadata.
 
 ### `constructor(props: GeometryProps)`
 
-Creates a geometry object and normalizes raw typed arrays into `GeometryAttribute` records.
+Creates a geometry object and wraps raw typed arrays into `GeometryAttribute` records.
 
 ### `getVertexCount(): number`
 

--- a/docs/api-reference/engine/geometry/geometry.md
+++ b/docs/api-reference/engine/geometry/geometry.md
@@ -79,7 +79,9 @@ Shader-facing names are separate. Synthesized buffer layouts map supported seman
 boundary: `POSITION` becomes `positions`, `NORMAL` becomes `normals`, `TEXCOORD_0` becomes `texCoords`,
 `TEXCOORD_1` becomes `texCoords1`, and `COLOR_0` becomes `colors`. Caller-provided non-glTF names such as
 `positions`, `clipSpacePositions`, and `faceIndex` are preserved as-is. When writing glTF custom semantics,
-use the spec's `_NAME` convention.
+use the spec's `_NAME` convention. If constructor input contains both a semantic key and its supported
+shader-facing name, the later key wins so built-in geometry attribute overrides keep their legacy behavior
+without storing duplicate CPU aliases.
 
 For non-interleaved geometry, each attribute key normally names one typed-array attribute. For interleaved
 geometry, the attribute key names the packed buffer, and `bufferLayout` maps that buffer back to shader

--- a/docs/api-reference/engine/geometry/gpu-geometry.md
+++ b/docs/api-reference/engine/geometry/gpu-geometry.md
@@ -53,7 +53,8 @@ Optional index buffer.
 
 ### `attributes`
 
-Named vertex buffers. Keys match `bufferLayout[].name`.
+Named vertex buffers. Keys match `bufferLayout[].name`; these are GPU buffer binding names, not
+necessarily the source keys stored in CPU `Geometry.attributes`.
 
 ### `userData`
 

--- a/docs/api-reference/gltf/README.md
+++ b/docs/api-reference/gltf/README.md
@@ -159,6 +159,12 @@ Normally this is called automatically by parseGLTF/createScenegraphsFromGLTF
 but it can be invoked directly when applications need to construct a
 material programmatically.
 
+Parsed glTF primitive geometry preserves glTF mesh attribute semantics in
+`Geometry.attributes`, for example `POSITION`, `NORMAL`, and `TEXCOORD_0`. In the glTF 2.0
+specification, `mesh.primitive.attributes` maps those semantic keys to accessor indices; luma.gl
+stores the decoded typed-array data under the same semantic keys and maps them to shader-facing names
+only at render-layout boundaries. See the official [glTF 2.0 specification](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html).
+
 ## Relationship to other modules
 
 - Relies on `@loaders.gl/gltf` for reading .gltf/.glb scene files.

--- a/examples/arrow/arrow-instancing/arrow-instanced-mesh-renderer.ts
+++ b/examples/arrow/arrow-instancing/arrow-instanced-mesh-renderer.ts
@@ -252,8 +252,8 @@ class InstancedCube extends GPUTableModel {
       topology: 'triangle-list',
       indices: cubeGeometry.indices!,
       attributes: {
-        positions: cubeGeometry.attributes.positions!,
-        normals: cubeGeometry.attributes.normals!
+        POSITION: cubeGeometry.attributes.POSITION!,
+        NORMAL: cubeGeometry.attributes.NORMAL!
       }
     });
 

--- a/examples/arrow/arrow-mesh-geometry/arrow-mesh-geometry-renderer.ts
+++ b/examples/arrow/arrow-mesh-geometry/arrow-mesh-geometry-renderer.ts
@@ -239,7 +239,7 @@ function makeArrowMeshTable(
   faceColors: arrow.Vector<arrow.FixedSizeList<arrow.Float32>>
 ): ArrowMeshTable {
   const cubeGeometry = new CubeGeometry({indices: true});
-  const cubePositions = cubeGeometry.attributes.positions?.value;
+  const cubePositions = cubeGeometry.attributes.POSITION?.value;
   const cubeFaceIndices = cubeGeometry.attributes.faceIndex?.value;
   const cubeIndices = cubeGeometry.indices?.value;
 

--- a/examples/showcase/instancing/app.ts
+++ b/examples/showcase/instancing/app.ts
@@ -260,8 +260,8 @@ class InstancedCube extends Model {
       topology: 'triangle-list',
       indices: cubeGeometry.indices!,
       attributes: {
-        positions: cubeGeometry.attributes.positions!,
-        normals: cubeGeometry.attributes.normals!
+        POSITION: cubeGeometry.attributes.POSITION!,
+        NORMAL: cubeGeometry.attributes.NORMAL!
       }
     });
 

--- a/modules/engine/src/geometry/geometry-utils.ts
+++ b/modules/engine/src/geometry/geometry-utils.ts
@@ -201,10 +201,7 @@ function getInterleavedSourceAttributes(
   attributeNames?: string[]
 ): Array<[string, GeometryAttribute | undefined]> {
   if (attributeNames) {
-    return attributeNames.map(attributeName => {
-      const normalizedAttributeName = getGeometryShaderAttributeName(attributeName);
-      return [normalizedAttributeName, geometry.attributes[normalizedAttributeName]];
-    });
+    return attributeNames.map(attributeName => [attributeName, geometry.attributes[attributeName]]);
   }
   return Object.entries(geometry.attributes);
 }

--- a/modules/engine/src/geometry/geometry.ts
+++ b/modules/engine/src/geometry/geometry.ts
@@ -18,12 +18,13 @@ export type GeometryProps = {
   topology: 'point-list' | 'line-list' | 'line-strip' | 'triangle-list' | 'triangle-strip';
   /** Draw vertex count. Auto-calculated from attributes or indices when omitted. */
   vertexCount?: number;
-  /** CPU attributes, keyed by shader attribute name or supported glTF-style semantic name. */
+  /** CPU attributes, keyed by caller-provided names such as glTF mesh attribute semantics. */
   attributes: Record<string, GeometryAttributeInput>;
   /**
    * Maps geometry buffers to shader attributes.
    *
-   * If omitted, the constructor creates one buffer layout entry for each normalized attribute.
+   * If omitted, the constructor creates one shader-facing buffer layout entry for each attribute.
+   * Explicit buffer layouts are preserved unchanged.
    */
   bufferLayout?: BufferLayout[];
   /** Optional index data. Indices are always stored separately from vertex attributes. */
@@ -50,9 +51,9 @@ export type GeometryAttribute = {
  * CPU-side geometry container.
  *
  * `Geometry` stores typed-array vertex data, optional index data, and an always-populated
- * `bufferLayout` that describes how its attributes map to shader inputs. Attribute names are
- * normalized once in the constructor so glTF-style names such as `POSITION` and `TEXCOORD_0`
- * become shader names such as `positions` and `texCoords`.
+ * `bufferLayout` that describes how its attributes map to shader inputs. CPU attribute names are
+ * preserved as supplied; synthesized buffer layouts map supported glTF-style names such as
+ * `POSITION` and `TEXCOORD_0` to default shader names such as `positions` and `texCoords`.
  */
 export class Geometry {
   /** Application-provided or generated identifier. */
@@ -67,7 +68,7 @@ export class Geometry {
   /** Optional index attribute. */
   readonly indices?: GeometryAttribute;
 
-  /** CPU attributes, keyed by normalized buffer or shader attribute name. */
+  /** CPU attributes, keyed by caller-provided source attribute name. */
   readonly attributes: Record<string, GeometryAttribute | undefined>;
 
   /** Buffer layout matching the geometry attributes. Always populated. */
@@ -76,7 +77,7 @@ export class Geometry {
   /** Application-owned metadata. */
   userData: Record<string, unknown> = {};
 
-  /** Creates a CPU geometry and normalizes attributes plus buffer layout metadata. */
+  /** Creates a CPU geometry and wraps raw typed arrays into attribute records. */
   constructor(props: GeometryProps) {
     const {attributes = {}, indices = null, vertexCount = null} = props;
 
@@ -112,8 +113,7 @@ export class Geometry {
         }
         this.indices = attribute;
       } else {
-        const normalizedAttributeName = getGeometryShaderAttributeName(attributeName);
-        this.attributes[normalizedAttributeName] = attribute;
+        this.attributes[attributeName] = attribute;
       }
     }
 
@@ -123,9 +123,8 @@ export class Geometry {
     }
 
     this.vertexCount = vertexCount || this._calculateVertexCount(this.attributes, this.indices);
-    this.bufferLayout = props.bufferLayout
-      ? normalizeGeometryBufferLayout(props.bufferLayout)
-      : getBufferLayoutFromGeometryAttributes(this.attributes);
+    this.bufferLayout =
+      props.bufferLayout || getBufferLayoutFromGeometryAttributes(this.attributes);
   }
 
   /** Returns the resolved draw vertex count. */
@@ -174,8 +173,9 @@ export class Geometry {
 }
 
 /**
- * Converts supported geometry semantic names to shader attribute names.
+ * Converts supported geometry semantic names to default shader attribute names.
  *
+ * Use this only at render-layout boundaries. CPU `Geometry.attributes` preserves source names.
  * Names that do not have a built-in mapping are returned unchanged.
  */
 export function getGeometryShaderAttributeName(attributeName: string): string {
@@ -199,35 +199,18 @@ function getBufferLayoutFromGeometryAttributes(
   attributes: Record<string, GeometryAttribute | undefined>
 ): BufferLayout[] {
   const bufferLayout: BufferLayout[] = [];
-  for (const [name, attribute] of Object.entries(attributes)) {
+  for (const [attributeName, attribute] of Object.entries(attributes)) {
     if (!attribute) {
       continue; // eslint-disable-line no-continue
     }
     const {value, size, normalized} = attribute;
     if (size === undefined) {
-      throw new Error(`Attribute ${name} is missing a size`);
+      throw new Error(`Attribute ${attributeName} is missing a size`);
     }
     bufferLayout.push({
-      name,
+      name: getGeometryShaderAttributeName(attributeName),
       format: vertexFormatDecoder.getVertexFormatFromAttribute(value, size, normalized)
     });
   }
   return bufferLayout;
-}
-
-function normalizeGeometryBufferLayout(bufferLayout: BufferLayout[]): BufferLayout[] {
-  return bufferLayout.map(layout =>
-    layout.attributes
-      ? {
-          ...layout,
-          attributes: layout.attributes.map(attribute => ({
-            ...attribute,
-            attribute: getGeometryShaderAttributeName(attribute.attribute)
-          }))
-        }
-      : {
-          ...layout,
-          name: getGeometryShaderAttributeName(layout.name)
-        }
-  );
 }

--- a/modules/engine/src/geometry/geometry.ts
+++ b/modules/engine/src/geometry/geometry.ts
@@ -113,6 +113,13 @@ export class Geometry {
         }
         this.indices = attribute;
       } else {
+        const shaderAttributeName = getGeometryShaderAttributeName(attributeName);
+        const storedAttributeName = Object.keys(this.attributes).find(
+          name => getGeometryShaderAttributeName(name) === shaderAttributeName
+        );
+        if (storedAttributeName) {
+          delete this.attributes[storedAttributeName];
+        }
         this.attributes[attributeName] = attribute;
       }
     }

--- a/modules/engine/src/geometry/gpu-geometry.ts
+++ b/modules/engine/src/geometry/gpu-geometry.ts
@@ -4,7 +4,7 @@
 
 import type {PrimitiveTopology, BufferLayout} from '@luma.gl/core';
 import {Device, Buffer} from '@luma.gl/core';
-import type {Geometry} from '../geometry/geometry';
+import {type Geometry, getGeometryShaderAttributeName} from '../geometry/geometry';
 import {makeInterleavedGeometry} from './geometry-utils';
 import {uid} from '../utils/uid';
 
@@ -147,8 +147,11 @@ export function getAttributeBuffersFromGeometry(
 ): {attributes: Record<string, Buffer>; bufferLayout: BufferLayout[]; vertexCount: number} {
   const attributes: Record<string, Buffer> = {};
   for (const [attributeName, attribute] of Object.entries(geometry.attributes)) {
+    const name =
+      geometry.bufferLayout.find(bufferLayout => bufferLayout.name === attributeName)?.name ||
+      getGeometryShaderAttributeName(attributeName);
     if (attribute) {
-      attributes[attributeName] = device.createBuffer({
+      attributes[name] = device.createBuffer({
         data: attribute.value,
         id: `${attributeName}-buffer`
       });

--- a/modules/engine/test/geometry/geometries.spec.shared.ts
+++ b/modules/engine/test/geometry/geometries.spec.shared.ts
@@ -73,9 +73,9 @@ export function registerGeometriesTests(test: TapeTestFunction): void {
 
         const attributes = geometry.attributes;
 
-        t.ok(checkAttribute(attributes.positions), `${name}: positions is Float32Array`);
-        t.ok(checkAttribute(attributes.normals), `${name}: normals is Float32Array`);
-        t.ok(checkAttribute(attributes.texCoords), `${name}: texCoords is Float32Array`);
+        t.ok(checkAttribute(attributes.POSITION), `${name}: POSITION is Float32Array`);
+        t.ok(checkAttribute(attributes.NORMAL), `${name}: NORMAL is Float32Array`);
+        t.ok(checkAttribute(attributes.TEXCOORD_0), `${name}: TEXCOORD_0 is Float32Array`);
         t.ok(geometry.bufferLayout.length > 0, `${name}: bufferLayout is populated`);
         if (geometry.indices) {
           t.ok(

--- a/modules/engine/test/geometry/geometry.spec.ts
+++ b/modules/engine/test/geometry/geometry.spec.ts
@@ -106,5 +106,23 @@ test('Geometry#constructor preserves source attribute and explicit layout names'
   t.ok(geometry.attributes.POSITION, 'semantic attribute name is preserved');
   t.notOk(geometry.attributes.positions, 'semantic attribute has no shader-name alias');
   t.deepEqual(geometry.bufferLayout, [{name: 'POSITION', format: 'float32x3'}]);
+
+  const positions = {value: new Float32Array([1, 1, 1]), size: 3};
+  const geometryWithShaderNameOverride = new Geometry({
+    topology: 'triangle-list',
+    attributes: {
+      POSITION: {value: new Float32Array([0, 0, 0]), size: 3},
+      positions
+    }
+  });
+
+  t.notOk(
+    geometryWithShaderNameOverride.attributes.POSITION,
+    'shader-name override replaces semantic'
+  );
+  t.is(geometryWithShaderNameOverride.attributes.positions, positions, 'shader-name override wins');
+  t.deepEqual(geometryWithShaderNameOverride.bufferLayout, [
+    {name: 'positions', format: 'float32x3'}
+  ]);
   t.end();
 });

--- a/modules/engine/test/geometry/geometry.spec.ts
+++ b/modules/engine/test/geometry/geometry.spec.ts
@@ -94,7 +94,7 @@ test('Geometry#constructor', t => {
   t.end();
 });
 
-test('Geometry#constructor normalizes explicit bufferLayout', t => {
+test('Geometry#constructor preserves source attribute and explicit layout names', t => {
   const geometry = new Geometry({
     topology: 'triangle-list',
     attributes: {
@@ -103,11 +103,8 @@ test('Geometry#constructor normalizes explicit bufferLayout', t => {
     bufferLayout: [{name: 'POSITION', format: 'float32x3'}]
   });
 
-  t.ok(geometry.attributes.positions, 'attribute name is normalized');
-  t.deepEqual(
-    geometry.bufferLayout,
-    [{name: 'positions', format: 'float32x3'}],
-    'shorthand bufferLayout name is normalized'
-  );
+  t.ok(geometry.attributes.POSITION, 'semantic attribute name is preserved');
+  t.notOk(geometry.attributes.positions, 'semantic attribute has no shader-name alias');
+  t.deepEqual(geometry.bufferLayout, [{name: 'POSITION', format: 'float32x3'}]);
   t.end();
 });


### PR DESCRIPTION
<img width="1672" height="941" alt="image" src="https://github.com/user-attachments/assets/cc3d37ef-ca3d-41dd-a6e3-7325009c8be0" />
