### PR TITLE
fix(core): use content-box observer and Math.floor in css-dpr mode

### DIFF
--- a/modules/core/src/adapter/canvas-observer.ts
+++ b/modules/core/src/adapter/canvas-observer.ts
@@ -5,6 +5,7 @@
 type CanvasObserverProps = {
   canvas?: HTMLCanvasElement;
   trackPosition: boolean;
+  resizeObserverBox?: ResizeObserverBoxOptions;
   onResize: (entries: ResizeObserverEntry[]) => void;
   onIntersection: (entries: IntersectionObserverEntry[]) => void;
   onDevicePixelRatioChange: () => void;
@@ -48,8 +49,9 @@ export class CanvasObserver {
     this._resizeObserver ||= new ResizeObserver(entries => this.props.onResize(entries));
 
     this._intersectionObserver.observe(this.props.canvas);
+    const box = this.props.resizeObserverBox || 'device-pixel-content-box';
     try {
-      this._resizeObserver.observe(this.props.canvas, {box: 'device-pixel-content-box'});
+      this._resizeObserver.observe(this.props.canvas, {box});
     } catch {
       this._resizeObserver.observe(this.props.canvas, {box: 'content-box'});
     }

--- a/modules/core/src/adapter/canvas-observer.ts
+++ b/modules/core/src/adapter/canvas-observer.ts
@@ -2,23 +2,33 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+/** Options and callbacks used by {@link CanvasObserver}. */
 type CanvasObserverProps = {
+  /** HTML canvas element whose DOM lifecycle should be observed. */
   canvas?: HTMLCanvasElement;
+  /** Whether to poll for canvas position changes. */
   trackPosition: boolean;
+  /** ResizeObserver box type passed to `observe()`. Defaults to `'device-pixel-content-box'`. */
   resizeObserverBox?: ResizeObserverBoxOptions;
+  /** Called with ResizeObserver entries for the observed canvas. */
   onResize: (entries: ResizeObserverEntry[]) => void;
+  /** Called with IntersectionObserver entries for the observed canvas. */
   onIntersection: (entries: IntersectionObserverEntry[]) => void;
+  /** Called when the window device pixel ratio may have changed. */
   onDevicePixelRatioChange: () => void;
+  /** Called while canvas position tracking is enabled. */
   onPositionChange: () => void;
 };
 
 /**
  * Internal DOM observer orchestration for HTML canvas surfaces.
  *
+ * @remarks
  * CanvasSurface owns the tracked state and device callback dispatch. This helper only manages
  * browser observers, timers, and polling loops, then reports events through callbacks.
  */
 export class CanvasObserver {
+  /** Observer options and event callbacks. */
   readonly props: CanvasObserverProps;
 
   private _resizeObserver: ResizeObserver | undefined;
@@ -29,14 +39,21 @@ export class CanvasObserver {
   private _trackPositionInterval: ReturnType<typeof setInterval> | null = null;
   private _started = false;
 
+  /** Whether the DOM observers and polling loops have been started. */
   get started(): boolean {
     return this._started;
   }
 
+  /**
+   * Creates an observer coordinator for one HTML canvas.
+   *
+   * @param props - Observer options and event callbacks.
+   */
   constructor(props: CanvasObserverProps) {
     this.props = props;
   }
 
+  /** Starts DOM observation and optional position polling. */
   start(): void {
     if (this._started || !this.props.canvas) {
       return;
@@ -63,6 +80,7 @@ export class CanvasObserver {
     }
   }
 
+  /** Stops DOM observation, media-query listeners, and position polling. */
   stop(): void {
     if (!this._started) {
       return;
@@ -92,6 +110,7 @@ export class CanvasObserver {
     this._intersectionObserver?.disconnect();
   }
 
+  /** Reports the current device pixel ratio and arms the media query for its next change. */
   private _refreshDevicePixelRatio(): void {
     if (!this._started) {
       return;
@@ -113,6 +132,11 @@ export class CanvasObserver {
     );
   }
 
+  /**
+   * Starts periodic position callbacks while the observer remains active.
+   *
+   * @param intervalMs - Poll interval in milliseconds.
+   */
   private _trackPosition(intervalMs: number = 100): void {
     if (this._trackPositionInterval) {
       return;

--- a/modules/core/src/adapter/canvas-observer.ts
+++ b/modules/core/src/adapter/canvas-observer.ts
@@ -8,7 +8,7 @@ type CanvasObserverProps = {
   canvas?: HTMLCanvasElement;
   /** Whether to poll for canvas position changes. */
   trackPosition: boolean;
-  /** ResizeObserver box type passed to `observe()`. Defaults to `'device-pixel-content-box'`. */
+  /** ResizeObserver box type passed to `observe()`. */
   resizeObserverBox: ResizeObserverBoxOptions;
   /** Called with ResizeObserver entries for the observed canvas. */
   onResize: (entries: ResizeObserverEntry[]) => void;

--- a/modules/core/src/adapter/canvas-observer.ts
+++ b/modules/core/src/adapter/canvas-observer.ts
@@ -9,7 +9,7 @@ type CanvasObserverProps = {
   /** Whether to poll for canvas position changes. */
   trackPosition: boolean;
   /** ResizeObserver box type passed to `observe()`. Defaults to `'device-pixel-content-box'`. */
-  resizeObserverBox?: ResizeObserverBoxOptions;
+  resizeObserverBox: ResizeObserverBoxOptions;
   /** Called with ResizeObserver entries for the observed canvas. */
   onResize: (entries: ResizeObserverEntry[]) => void;
   /** Called with IntersectionObserver entries for the observed canvas. */
@@ -66,7 +66,7 @@ export class CanvasObserver {
     this._resizeObserver ||= new ResizeObserver(entries => this.props.onResize(entries));
 
     this._intersectionObserver.observe(this.props.canvas);
-    const box = this.props.resizeObserverBox || 'device-pixel-content-box';
+    const box = this.props.resizeObserverBox;
     try {
       this._resizeObserver.observe(this.props.canvas, {box});
     } catch {

--- a/modules/core/src/adapter/canvas-surface.ts
+++ b/modules/core/src/adapter/canvas-surface.ts
@@ -181,7 +181,7 @@ export abstract class CanvasSurface {
     this._canvasObserver = new CanvasObserver({
       canvas: this.htmlCanvas,
       trackPosition: this.props.trackPosition,
-      resizeObserverBox: this.props.pixelSizeSource === 'css-dpr' ? 'content-box' : undefined,
+      resizeObserverBox: this.props.pixelSizeSource === 'css-dpr' ? 'content-box' : 'device-pixel-content-box',
       onResize: entries => this._handleResize(entries),
       onIntersection: entries => this._handleIntersection(entries),
       onDevicePixelRatioChange: () => this._observeDevicePixelRatio(),

--- a/modules/core/src/adapter/canvas-surface.ts
+++ b/modules/core/src/adapter/canvas-surface.ts
@@ -34,8 +34,8 @@ export type CanvasContextProps = {
    *
    * - `'exact'` uses `ResizeObserver.devicePixelContentBoxSize` when available to match the
    *   browser's exact physical pixel coverage.
-   * - `'css-dpr'` uses `Math.round(cssSize * devicePixelRatio)` to match overlays and external
-   *   canvases that still rely on legacy CSS-size times DPR rounding.
+   * - `'css-dpr'` uses `Math.floor(cssSize * devicePixelRatio)` to match overlays and external
+   *   canvases that size their drawing buffer via implicit truncation (e.g. `canvas.width = css * dpr`).
    */
   pixelSizeSource?: 'exact' | 'css-dpr';
   /** Whether to track window resizes. */
@@ -176,6 +176,7 @@ export abstract class CanvasSurface {
     this._canvasObserver = new CanvasObserver({
       canvas: this.htmlCanvas,
       trackPosition: this.props.trackPosition,
+      resizeObserverBox: this.props.pixelSizeSource === 'css-dpr' ? 'content-box' : undefined,
       onResize: entries => this._handleResize(entries),
       onIntersection: entries => this._handleIntersection(entries),
       onDevicePixelRatioChange: () => this._observeDevicePixelRatio(),
@@ -398,8 +399,8 @@ export abstract class CanvasSurface {
     if (this.props.pixelSizeSource === 'css-dpr') {
       const devicePixelRatio = this.getDevicePixelRatio();
       return {
-        devicePixelWidth: Math.round(contentBoxSize.inlineSize * devicePixelRatio),
-        devicePixelHeight: Math.round(contentBoxSize.blockSize * devicePixelRatio)
+        devicePixelWidth: Math.floor(contentBoxSize.inlineSize * devicePixelRatio),
+        devicePixelHeight: Math.floor(contentBoxSize.blockSize * devicePixelRatio)
       };
     }
 
@@ -433,6 +434,17 @@ export abstract class CanvasSurface {
     }
     const oldRatio = this.devicePixelRatio;
     this.devicePixelRatio = window.devicePixelRatio;
+
+    if (this.props.pixelSizeSource === 'css-dpr') {
+      // In css-dpr mode the ResizeObserver watches content-box, which won't fire on a pure DPR
+      // change (CSS size unchanged). Recalculate the drawing buffer from the new DPR here.
+      const dpr = this.getDevicePixelRatio();
+      this.devicePixelWidth = Math.floor(this.cssWidth * dpr);
+      this.devicePixelHeight = Math.floor(this.cssHeight * dpr);
+      this._updateDrawingBufferSize();
+      const oldPixelSize = this.getDevicePixelSize();
+      this.device.props.onResize(this as CanvasContext | PresentationContext, {oldPixelSize});
+    }
 
     this.updatePosition();
 

--- a/modules/core/src/adapter/canvas-surface.ts
+++ b/modules/core/src/adapter/canvas-surface.ts
@@ -438,11 +438,18 @@ export abstract class CanvasSurface {
     if (this.props.pixelSizeSource === 'css-dpr') {
       // In css-dpr mode the ResizeObserver watches content-box, which won't fire on a pure DPR
       // change (CSS size unchanged). Recalculate the drawing buffer from the new DPR here.
-      const dpr = this.getDevicePixelRatio();
-      this.devicePixelWidth = Math.floor(this.cssWidth * dpr);
-      this.devicePixelHeight = Math.floor(this.cssHeight * dpr);
-      this._updateDrawingBufferSize();
       const oldPixelSize = this.getDevicePixelSize();
+      const dpr = this.getDevicePixelRatio();
+      const [maxDevicePixelWidth, maxDevicePixelHeight] = this.getMaxDrawingBufferSize();
+      this.devicePixelWidth = Math.max(
+        1,
+        Math.min(Math.floor(this.cssWidth * dpr), maxDevicePixelWidth)
+      );
+      this.devicePixelHeight = Math.max(
+        1,
+        Math.min(Math.floor(this.cssHeight * dpr), maxDevicePixelHeight)
+      );
+      this._updateDrawingBufferSize();
       this.device.props.onResize(this as CanvasContext | PresentationContext, {oldPixelSize});
     }
 

--- a/modules/core/src/adapter/canvas-surface.ts
+++ b/modules/core/src/adapter/canvas-surface.ts
@@ -53,6 +53,11 @@ export type MutableCanvasContextProps = {
   useDevicePixels?: boolean | number;
 };
 
+type DevicePixelSize = {
+  devicePixelWidth: number;
+  devicePixelHeight: number;
+};
+
 /**
  * Shared tracked-canvas lifecycle used by both renderable and presentation contexts.
  * - Creates a new canvas or looks up a canvas from the DOM
@@ -358,11 +363,7 @@ export abstract class CanvasSurface {
 
     const oldPixelSize = this.getDevicePixelSize();
 
-    const {devicePixelWidth, devicePixelHeight} = this._getDevicePixelSizeFromResizeEntry(entry);
-
-    const [maxDevicePixelWidth, maxDevicePixelHeight] = this.getMaxDrawingBufferSize();
-    this.devicePixelWidth = Math.max(1, Math.min(devicePixelWidth, maxDevicePixelWidth));
-    this.devicePixelHeight = Math.max(1, Math.min(devicePixelHeight, maxDevicePixelHeight));
+    this._setDevicePixelSize(this._getDevicePixelSizeFromResizeEntry(entry));
 
     this._updateDrawingBufferSize();
 
@@ -390,18 +391,14 @@ export abstract class CanvasSurface {
     this.updatePosition();
   }
 
-  protected _getDevicePixelSizeFromResizeEntry(entry: ResizeObserverEntry): {
-    devicePixelWidth: number;
-    devicePixelHeight: number;
-  } {
+  protected _getDevicePixelSizeFromResizeEntry(entry: ResizeObserverEntry): DevicePixelSize {
     const contentBoxSize = assertDefined(entry.contentBoxSize?.[0]);
 
     if (this.props.pixelSizeSource === 'css-dpr') {
-      const devicePixelRatio = this.getDevicePixelRatio();
-      return {
-        devicePixelWidth: Math.floor(contentBoxSize.inlineSize * devicePixelRatio),
-        devicePixelHeight: Math.floor(contentBoxSize.blockSize * devicePixelRatio)
-      };
+      return this._getDevicePixelSizeFromCSSSize(
+        contentBoxSize.inlineSize,
+        contentBoxSize.blockSize
+      );
     }
 
     return {
@@ -412,6 +409,20 @@ export abstract class CanvasSurface {
         entry.devicePixelContentBoxSize?.[0]?.blockSize ||
         contentBoxSize.blockSize * devicePixelRatio
     };
+  }
+
+  protected _getDevicePixelSizeFromCSSSize(cssWidth: number, cssHeight: number): DevicePixelSize {
+    const devicePixelRatio = this.getDevicePixelRatio();
+    return {
+      devicePixelWidth: Math.floor(cssWidth * devicePixelRatio),
+      devicePixelHeight: Math.floor(cssHeight * devicePixelRatio)
+    };
+  }
+
+  protected _setDevicePixelSize({devicePixelWidth, devicePixelHeight}: DevicePixelSize): void {
+    const [maxDevicePixelWidth, maxDevicePixelHeight] = this.getMaxDrawingBufferSize();
+    this.devicePixelWidth = Math.max(1, Math.min(devicePixelWidth, maxDevicePixelWidth));
+    this.devicePixelHeight = Math.max(1, Math.min(devicePixelHeight, maxDevicePixelHeight));
   }
 
   _resizeDrawingBufferIfNeeded() {
@@ -439,16 +450,7 @@ export abstract class CanvasSurface {
       // In css-dpr mode the ResizeObserver watches content-box, which won't fire on a pure DPR
       // change (CSS size unchanged). Recalculate the drawing buffer from the new DPR here.
       const oldPixelSize = this.getDevicePixelSize();
-      const dpr = this.getDevicePixelRatio();
-      const [maxDevicePixelWidth, maxDevicePixelHeight] = this.getMaxDrawingBufferSize();
-      this.devicePixelWidth = Math.max(
-        1,
-        Math.min(Math.floor(this.cssWidth * dpr), maxDevicePixelWidth)
-      );
-      this.devicePixelHeight = Math.max(
-        1,
-        Math.min(Math.floor(this.cssHeight * dpr), maxDevicePixelHeight)
-      );
+      this._setDevicePixelSize(this._getDevicePixelSizeFromCSSSize(this.cssWidth, this.cssHeight));
       this._updateDrawingBufferSize();
       this.device.props.onResize(this as CanvasContext | PresentationContext, {oldPixelSize});
     }

--- a/modules/core/src/adapter/canvas-surface.ts
+++ b/modules/core/src/adapter/canvas-surface.ts
@@ -181,7 +181,8 @@ export abstract class CanvasSurface {
     this._canvasObserver = new CanvasObserver({
       canvas: this.htmlCanvas,
       trackPosition: this.props.trackPosition,
-      resizeObserverBox: this.props.pixelSizeSource === 'css-dpr' ? 'content-box' : 'device-pixel-content-box',
+      resizeObserverBox:
+        this.props.pixelSizeSource === 'css-dpr' ? 'content-box' : 'device-pixel-content-box',
       onResize: entries => this._handleResize(entries),
       onIntersection: entries => this._handleIntersection(entries),
       onDevicePixelRatioChange: () => this._observeDevicePixelRatio(),

--- a/modules/core/test/adapter/canvas-context.spec.ts
+++ b/modules/core/test/adapter/canvas-context.spec.ts
@@ -375,6 +375,18 @@ test('CanvasContext#_observeDevicePixelRatio recalculates drawing buffer in css-
 
   // Simulate a DPR change to 1.5 (browser zoom)
   resizeCalls = 0;
+  let lastOldPixelSize: [number, number] | undefined;
+  // @ts-expect-error read only
+  canvasContext.device = {
+    ...canvasContext.device,
+    props: {
+      ...canvasContext.device.props,
+      onResize: (_ctx: any, {oldPixelSize}: {oldPixelSize: [number, number]}) => {
+        resizeCalls++;
+        lastOldPixelSize = oldPixelSize;
+      }
+    }
+  };
   canvasContext.getDevicePixelRatio = () => 1.5;
   // Mark the observer as started so _observeDevicePixelRatio doesn't bail
   (canvasContext as any)._canvasObserver = {started: true};
@@ -386,6 +398,53 @@ test('CanvasContext#_observeDevicePixelRatio recalculates drawing buffer in css-
     'DPR change recalculates device pixel size using Math.floor(css * newDpr)'
   );
   t.equal(resizeCalls, 1, 'onResize is called when DPR changes in css-dpr mode');
+  t.deepEqual(lastOldPixelSize, [800, 600], 'onResize receives the previous pixel size');
+
+  t.end();
+});
+
+test('CanvasContext#_observeDevicePixelRatio clamps to max texture size in css-dpr mode', t => {
+  if (!isBrowser()) {
+    t.end();
+    return;
+  }
+
+  const canvasContext = new TestCanvasContext({pixelSizeSource: 'css-dpr'}, false);
+  // @ts-expect-error read only
+  canvasContext.device = {
+    limits: {maxTextureDimension2D: 2048},
+    props: {
+      onResize: () => {},
+      onDevicePixelRatioChange: () => {},
+      onVisibilityChange: () => {},
+      onPositionChange: () => {}
+    }
+  };
+
+  // Set up a large canvas (1500x1200 CSS) at DPR 2 = 3000x2400 which exceeds 2048
+  canvasContext.getDevicePixelRatio = () => 2;
+  (canvasContext as any)._handleResize([
+    {
+      target: canvasContext.canvas,
+      contentBoxSize: [{inlineSize: 1500, blockSize: 1200}]
+    }
+  ]);
+  t.deepEqual(
+    canvasContext.getDevicePixelSize(),
+    [2048, 2048],
+    'initial size clamped by _handleResize'
+  );
+
+  // Now simulate a DPR change to 3 (4500x3600 unclamped)
+  canvasContext.getDevicePixelRatio = () => 3;
+  (canvasContext as any)._canvasObserver = {started: true};
+  (canvasContext as any)._observeDevicePixelRatio();
+
+  t.deepEqual(
+    canvasContext.getDevicePixelSize(),
+    [2048, 2048],
+    'DPR change clamps pixel size to maxTextureDimension2D'
+  );
 
   t.end();
 });

--- a/modules/core/test/adapter/canvas-context.spec.ts
+++ b/modules/core/test/adapter/canvas-context.spec.ts
@@ -342,6 +342,54 @@ test('CanvasContext#_handleResize keeps numeric useDevicePixels override across 
   t.end();
 });
 
+test('CanvasContext#_observeDevicePixelRatio recalculates drawing buffer in css-dpr mode', t => {
+  if (!isBrowser()) {
+    t.end();
+    return;
+  }
+
+  const canvasContext = new TestCanvasContext({pixelSizeSource: 'css-dpr'}, false);
+  let resizeCalls = 0;
+  // @ts-expect-error read only
+  canvasContext.device = {
+    limits: {maxTextureDimension2D: 4096},
+    props: {
+      onResize: () => {
+        resizeCalls++;
+      },
+      onDevicePixelRatioChange: () => {},
+      onVisibilityChange: () => {},
+      onPositionChange: () => {}
+    }
+  };
+
+  // Simulate an initial resize at DPR 2
+  canvasContext.getDevicePixelRatio = () => 2;
+  (canvasContext as any)._handleResize([
+    {
+      target: canvasContext.canvas,
+      contentBoxSize: [{inlineSize: 400, blockSize: 300}]
+    }
+  ]);
+  t.deepEqual(canvasContext.getDevicePixelSize(), [800, 600], 'initial size at DPR 2');
+
+  // Simulate a DPR change to 1.5 (browser zoom)
+  resizeCalls = 0;
+  canvasContext.getDevicePixelRatio = () => 1.5;
+  // Mark the observer as started so _observeDevicePixelRatio doesn't bail
+  (canvasContext as any)._canvasObserver = {started: true};
+  (canvasContext as any)._observeDevicePixelRatio();
+
+  t.deepEqual(
+    canvasContext.getDevicePixelSize(),
+    [600, 450],
+    'DPR change recalculates device pixel size using Math.floor(css * newDpr)'
+  );
+  t.equal(resizeCalls, 1, 'onResize is called when DPR changes in css-dpr mode');
+
+  t.end();
+});
+
 test('CanvasContext#_startObservers defers DOM observation until explicitly started', t => {
   if (!isBrowser()) {
     t.end();

--- a/modules/core/test/adapter/canvas-context.spec.ts
+++ b/modules/core/test/adapter/canvas-context.spec.ts
@@ -281,7 +281,7 @@ test('CanvasContext#_handleResize supports css-dpr compatibility sizing', t => {
     (canvasContext as any)._handleResize([
       {
         target: canvasContext.canvas,
-        contentBoxSize: [{inlineSize: 100.2, blockSize: 50.2}],
+        contentBoxSize: [{inlineSize: 100.4, blockSize: 50.4}],
         devicePixelContentBoxSize: [{inlineSize: 151, blockSize: 76}]
       }
     ]);
@@ -289,7 +289,7 @@ test('CanvasContext#_handleResize supports css-dpr compatibility sizing', t => {
     t.deepEqual(
       canvasContext.getDevicePixelSize(),
       [150, 75],
-      'css-dpr mode rounds css size times DPR and ignores exact observer size'
+      'css-dpr mode floors css size times DPR and ignores exact observer size'
     );
     t.deepEqual(
       canvasContext.getDrawingBufferSize(),

--- a/modules/core/test/adapter/canvas-observer.spec.ts
+++ b/modules/core/test/adapter/canvas-observer.spec.ts
@@ -86,6 +86,7 @@ test('CanvasObserver#start is idempotent and stop is idempotent', t => {
     const observer = new CanvasObserver({
       canvas: document.createElement('canvas'),
       trackPosition: false,
+      resizeObserverBox: 'device-pixel-content-box',
       onResize: () => {},
       onIntersection: () => {},
       onDevicePixelRatioChange: () => {},
@@ -147,6 +148,7 @@ test('CanvasObserver#trackPosition polling stops after stop', t => {
     const observer = new CanvasObserver({
       canvas: document.createElement('canvas'),
       trackPosition: true,
+      resizeObserverBox: 'device-pixel-content-box',
       onResize: () => {},
       onIntersection: () => {},
       onDevicePixelRatioChange: () => {},
@@ -173,7 +175,7 @@ test('CanvasObserver#trackPosition polling stops after stop', t => {
   t.end();
 });
 
-test('CanvasObserver#resizeObserverBox defaults to device-pixel-content-box', t => {
+test('CanvasObserver#resizeObserverBox uses device-pixel-content-box when specified', t => {
   if (!isBrowser()) {
     t.end();
     return;
@@ -202,6 +204,7 @@ test('CanvasObserver#resizeObserverBox defaults to device-pixel-content-box', t 
     const observer = new CanvasObserver({
       canvas: document.createElement('canvas'),
       trackPosition: false,
+      resizeObserverBox: 'device-pixel-content-box',
       onResize: () => {},
       onIntersection: () => {},
       onDevicePixelRatioChange: () => {},
@@ -209,7 +212,7 @@ test('CanvasObserver#resizeObserverBox defaults to device-pixel-content-box', t 
     });
 
     observer.start();
-    t.equal(observedBox, 'device-pixel-content-box', 'defaults to device-pixel-content-box');
+    t.equal(observedBox, 'device-pixel-content-box', 'uses device-pixel-content-box');
     observer.stop();
   } finally {
     restoreGlobals(globalScope, originals);
@@ -300,6 +303,7 @@ test('CanvasObserver#start is a no-op without an HTML canvas', t => {
   try {
     const observer = new CanvasObserver({
       trackPosition: true,
+      resizeObserverBox: 'device-pixel-content-box',
       onResize: () => {},
       onIntersection: () => {},
       onDevicePixelRatioChange: () => {},

--- a/modules/core/test/adapter/canvas-observer.spec.ts
+++ b/modules/core/test/adapter/canvas-observer.spec.ts
@@ -173,6 +173,97 @@ test('CanvasObserver#trackPosition polling stops after stop', t => {
   t.end();
 });
 
+test('CanvasObserver#resizeObserverBox defaults to device-pixel-content-box', t => {
+  if (!isBrowser()) {
+    t.end();
+    return;
+  }
+
+  const globalScope = globalThis;
+  const originals = getOriginalGlobals(globalScope);
+  let observedBox: string | undefined;
+
+  globalScope.ResizeObserver = class {
+    constructor(_callback: ResizeObserverCallback) {}
+    observe(_target: Element, options?: ResizeObserverOptions) {
+      observedBox = options?.box;
+    }
+    disconnect() {}
+  } as typeof ResizeObserver;
+  globalScope.IntersectionObserver = class {
+    constructor(_callback: IntersectionObserverCallback) {}
+    observe() {}
+    disconnect() {}
+  } as typeof IntersectionObserver;
+  globalScope.setTimeout = (callback: TimerHandler, delay?: number) =>
+    originals.setTimeout.call(globalScope, callback, delay);
+
+  try {
+    const observer = new CanvasObserver({
+      canvas: document.createElement('canvas'),
+      trackPosition: false,
+      onResize: () => {},
+      onIntersection: () => {},
+      onDevicePixelRatioChange: () => {},
+      onPositionChange: () => {}
+    });
+
+    observer.start();
+    t.equal(observedBox, 'device-pixel-content-box', 'defaults to device-pixel-content-box');
+    observer.stop();
+  } finally {
+    restoreGlobals(globalScope, originals);
+  }
+
+  t.end();
+});
+
+test('CanvasObserver#resizeObserverBox uses content-box when specified', t => {
+  if (!isBrowser()) {
+    t.end();
+    return;
+  }
+
+  const globalScope = globalThis;
+  const originals = getOriginalGlobals(globalScope);
+  let observedBox: string | undefined;
+
+  globalScope.ResizeObserver = class {
+    constructor(_callback: ResizeObserverCallback) {}
+    observe(_target: Element, options?: ResizeObserverOptions) {
+      observedBox = options?.box;
+    }
+    disconnect() {}
+  } as typeof ResizeObserver;
+  globalScope.IntersectionObserver = class {
+    constructor(_callback: IntersectionObserverCallback) {}
+    observe() {}
+    disconnect() {}
+  } as typeof IntersectionObserver;
+  globalScope.setTimeout = (callback: TimerHandler, delay?: number) =>
+    originals.setTimeout.call(globalScope, callback, delay);
+
+  try {
+    const observer = new CanvasObserver({
+      canvas: document.createElement('canvas'),
+      trackPosition: false,
+      resizeObserverBox: 'content-box',
+      onResize: () => {},
+      onIntersection: () => {},
+      onDevicePixelRatioChange: () => {},
+      onPositionChange: () => {}
+    });
+
+    observer.start();
+    t.equal(observedBox, 'content-box', 'uses content-box when resizeObserverBox is set');
+    observer.stop();
+  } finally {
+    restoreGlobals(globalScope, originals);
+  }
+
+  t.end();
+});
+
 test('CanvasObserver#start is a no-op without an HTML canvas', t => {
   if (!isBrowser()) {
     t.end();


### PR DESCRIPTION
## Summary

Fixes #2675 — basemap misalignment at fractional browser zoom levels when using `pixelSizeSource: 'css-dpr'`.

Three changes to canvas-surface/canvas-observer:

- **Observer box type**: When `pixelSizeSource` is `'css-dpr'`, observe `content-box` instead of `device-pixel-content-box`. During browser zoom transitions, `device-pixel-content-box` fires with intermediate physical pixel sizes that don't match the basemap's canvas size calculation, causing a large visible shift.
- **Math.floor**: Matches MapLibre's [`Math.floor(pixelRatio * width)`](https://github.com/maplibre/maplibre-gl-js/blob/main/src/ui/map.ts#L3459) and is equivalent to Mapbox's [`pixelRatio * Math.ceil(width)`](https://github.com/mapbox/mapbox-gl-js/blob/main/src/ui/map.ts#L4291) for integer CSS sizes (ceil is a no-op, then canvas.width assignment truncates).
- **DPR change handler**: Since `content-box` won't fire when only DPR changes (CSS size stays the same during browser zoom), `_observeDevicePixelRatio` now recalculates and resizes the drawing buffer in css-dpr mode.

Also adds a `resizeObserverBox` prop to `CanvasObserver` so `CanvasSurface` can control which box type is observed.

## Test plan

- [x] Added regression tests for `CanvasObserver` box selection (defaults to `device-pixel-content-box`, uses `content-box` when specified)
- [x] Added regression test for `_observeDevicePixelRatio` recalculating the drawing buffer in css-dpr mode
- [x] Existing `canvas-context.spec.ts` test already verifies `Math.floor` behavior in css-dpr mode
- [x] Manually verified fix at 50% and 25% browser zoom with deck.gl MapboxOverlay in overlaid mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default-adjacent canvas resize/DPR behavior for css-dpr overlays (core rendering path) but is mode-scoped and covered by new tests; exact mode is unchanged.
> 
> **Overview**
> Fixes basemap/overlay misalignment when `pixelSizeSource: 'css-dpr'` is used at fractional browser zoom (e.g. deck.gl `MapboxOverlay`).
> 
> In **css-dpr** mode, `CanvasSurface` now drives `ResizeObserver` with **`content-box`** (via new `resizeObserverBox` on `CanvasObserver`) instead of `device-pixel-content-box`, avoiding intermediate physical sizes during zoom that disagree with the basemap. Device pixels are derived with **`Math.floor(css × DPR)`** rather than `Math.round`, matching MapLibre-style buffer sizing and implicit `canvas.width` truncation.
> 
> Because **content-box** resize events do not fire when only DPR changes, **`_observeDevicePixelRatio`** now recomputes the drawing buffer, applies max-texture clamping, and fires **`onResize`** in css-dpr mode. Regression tests cover observer box selection, DPR-only updates, and clamping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76f9f22765fd6b863f0c45b4fd7b56473d6c2b20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->