### PR TITLE
feat(experimental) Add WebXR support

### DIFF
--- a/.ocularrc.js
+++ b/.ocularrc.js
@@ -43,6 +43,7 @@ const config = {
         'arrow-filtering': '/examples/arrow/arrow-filtering',
         cubemap: '/examples/api/cubemap',
         fp64: '/examples/experimental/fp64',
+        'webxr-kaleidoscope': '/examples/experimental/webxr-kaleidoscope',
         'external-context': '/examples/integrations/external-context',
         'arrow-text-2d': '/examples/arrow/arrow-text-2d',
         'arrow-text-3d': '/examples/arrow/arrow-text-3d',

--- a/docs/api-guide/gpu/video-textures.mdx
+++ b/docs/api-guide/gpu/video-textures.mdx
@@ -1,5 +1,10 @@
 # Working With Video Textures
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
 Video can enter a shader through more than one texture path. The right path depends on whether the application needs portable texture semantics or WebGPU's optimized direct-video sampling path.
 
 ## Choose The Binding Path
@@ -9,6 +14,7 @@ Video can enter a shader through more than one texture path. The right path depe
 | One uploaded image or one copied video frame | [`Texture`](/docs/api-reference/core/resources/texture) | GLSL `sampler2D`, WGSL `texture_2d<f32>` | Concrete GPU allocation with ordinary texture sampling. |
 | Async or replaceable copied texture data | [`DynamicTexture`](/docs/api-reference/engine/dynamic-texture) | GLSL `sampler2D`, WGSL `texture_2d<f32>` | Engine wrapper around a concrete luma `Texture`. |
 | Playing `HTMLVideoElement` or caller-owned `VideoFrame` | [`VideoTexture`](/docs/api-reference/engine/video-texture) | Depends on shader declaration | Engine binding source that resolves the concrete per-draw binding. |
+| WebXR Raw Camera Access view | [`WebXRCameraTexture`](/docs/api-reference/experimental/webxr/webxr-camera-texture) | GLSL `sampler2D` | Experimental WebGL-only binding source around the browser-owned raw camera texture. |
 | Native WebGPU direct-video sampling | [`ExternalTexture`](/docs/api-reference/core/resources/external-texture) | WGSL `texture_external` | Concrete, short-lived WebGPU binding acquired from a video source. |
 
 Use an ordinary `Texture` when the shader needs the normal texture feature set: `textureSample`, repeat address modes, mipmaps, render-target usage, storage usage, or one shader shape shared with non-video textures. A video frame can be copied into such a texture with `Texture.copyExternalImage()`.
@@ -80,6 +86,28 @@ const videoTexture = new VideoTexture(device, {source: video});
 ```
 
 Camera acquisition should be triggered by a user gesture. Wait until the video exposes a current frame before expecting `VideoTexture` to draw; `requestVideoFrameCallback()` is the preferred browser signal when available. Stop the `MediaStream` tracks when the application no longer needs the camera. If the camera should look mirror-like, flip the U texture coordinate in the shader or model UVs.
+
+## WebXR Raw Camera Access
+
+Experimental v10 `WebXRCameraTexture` is the WebXR-specific raw camera path. It is not a `VideoTexture`: the WebXR Raw Camera Access API exposes a browser-owned WebGL texture for one `XRView`, so luma.gl wraps that texture as a borrowed read-only normal texture binding.
+
+```typescript
+import {WebXRCameraTexture} from '@luma.gl/experimental';
+
+const cameraTexture = new WebXRCameraTexture(device, xrWebGLBinding);
+
+session.requestAnimationFrame((time, xrFrame) => {
+  const pose = xrFrame.getViewerPose(referenceSpace);
+  const xrView = pose?.views[0] ?? null;
+
+  cameraTexture.setView(xrView);
+  model.shaderInputs.setProps({
+    bindings: {uTexture: cameraTexture}
+  });
+});
+```
+
+Use a GLSL `sampler2D` binding. WebXR camera textures do not route through core `ExternalTexture` in v10 work in progress, and WebGPU WebXR camera textures remain unsupported until the platform exposes a real WebGPU camera texture API.
 
 ## Practical Rule
 

--- a/docs/api-reference/README.md
+++ b/docs/api-reference/README.md
@@ -16,6 +16,7 @@ If you are looking for `Model`, start with [`@luma.gl/engine`][engine]. The `Mod
 | [`@luma.gl/tables`][tables]           | Optional    | GPU-resident table primitives, batching, table-backed rendering, and table-oriented compute.    |
 | [`@luma.gl/arrow`][arrow]             | Optional    | Apache Arrow adapters for deriving GPU layouts and building GPU table objects from Arrow data.  |
 | [`@luma.gl/text`][text]               | Optional    | Experimental GPUVector-based 2D text renderer models.                                          |
+| [`@luma.gl/experimental`][experimental] | Optional | Experimental v10 work-in-progress APIs, including WebGL-only WebXR helpers.                    |
 | [`@luma.gl/gltf`][gltf]               | Optional    | glTF scenegraph loading and instantiation etc.                                                  |
 | [`@luma.gl/test-utils`][test-utils]   | Optional    | Test setups, in particular support for rendering and comparing images.                          |
 
@@ -28,6 +29,7 @@ If you are looking for `Model`, start with [`@luma.gl/engine`][engine]. The `Mod
 - [`@luma.gl/shadertools`][shadertools] for shader modules and shader assembly.
 - [`@luma.gl/tables`][tables] for `GPUData`, `GPUVector`, `GPURecordBatch`, and `GPUTable`.
 - [`@luma.gl/text`][text] for GPUVector-based 2D text rendering; use [`@luma.gl/arrow`][arrow] for Arrow text conversion.
+- [`@luma.gl/experimental`][experimental] for v10 work-in-progress APIs, including experimental WebXR frame, view, and raw camera helpers.
 - [`@luma.gl/gltf`][gltf] for glTF scenegraph loading and extensions.
 - [`@luma.gl/webgl`][webgl] and [`@luma.gl/webgpu`][webgpu] for backend adapters used by `@luma.gl/core`.
 - [`@luma.gl/webgl/constants`](/docs/api-reference/webgl/constants) when you need raw numeric WebGL enums.
@@ -39,6 +41,7 @@ If you are looking for `Model`, start with [`@luma.gl/engine`][engine]. The `Mod
 [tables]: /docs/api-reference/tables
 [arrow]: /docs/api-reference/arrow
 [text]: /docs/api-reference/text
+[experimental]: /docs/api-reference/experimental
 [gltf]: /docs/api-reference/gltf
 [test-utils]: /docs/api-reference/test-utils
 [engine]: /docs/api-reference/engine

--- a/docs/api-reference/engine/README.md
+++ b/docs/api-reference/engine/README.md
@@ -9,7 +9,7 @@ creating pipelines from shaders, binding buffers and textures, handling redraw s
 
 - [`Model`](/docs/api-reference/engine/model) is the central rendering class and the page most users are looking for when they want the main luma.gl drawing API.
 - [`Materials`](/docs/api-guide/engine/materials) explains what `Material` and `MaterialFactory` represent in the engine layer.
-- [`DynamicBuffer`](/docs/api-reference/engine/dynamic-buffer), [`DynamicTexture`](/docs/api-reference/engine/dynamic-texture), and [`VideoTexture`](/docs/api-reference/engine/video-texture) provide stable engine-level wrappers for GPU resources and live texture sources that can be replaced or initialized over time.
+- [`DynamicBuffer`](/docs/api-reference/engine/dynamic-buffer), [`DynamicTexture`](/docs/api-reference/engine/dynamic-texture), and [`VideoTexture`](/docs/api-reference/engine/video-texture) provide stable engine-level wrappers for GPU resources and live texture sources that can be replaced or initialized over time. Experimental v10 [`@luma.gl/experimental`](/docs/api-reference/experimental) WebXR helpers use the same binding-source path for WebXR Raw Camera Access without making WebXR part of the engine module.
 - [`BufferSchema`](/docs/api-reference/engine/buffer-schema) documents record-oriented field descriptions that lower into shared-buffer vertex layouts and leave room for storage-friendly record design.
 - [`ClipSpace`](/docs/api-reference/engine/clip-space) and [`BackgroundTextureModel`](/docs/api-reference/engine/background-texture-model) provide ready-made fullscreen rendering helpers.
 - [`AnimationLoop`](/docs/api-reference/engine/animation-loop) manages per-frame rendering and animation state.

--- a/docs/api-reference/engine/video-texture.md
+++ b/docs/api-reference/engine/video-texture.md
@@ -1,5 +1,10 @@
 # VideoTexture
 
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
 `VideoTexture` is the engine-level live video binding source. It accepts an `HTMLVideoElement` or `VideoFrame` and resolves the concrete core binding that matches the shader slot used by the current draw.
 
 For the copied-vs-external texture tradeoff, see [Working With Video Textures](/docs/api-guide/gpu/video-textures).
@@ -52,4 +57,4 @@ let color = textureSampleBaseClampToEdge(videoTexture, videoTextureSampler, uv);
 
 - Shader binding type selects the representation. There is no single native external-texture shader declaration shared by GLSL and WGSL.
 - `texture_external` is for base-level clamp-style external sampling. Upload into an ordinary `Texture` when the shader needs mipmaps, repeat addressing, or ordinary `textureSample` semantics.
-- Future copied DOM sources such as HTML-in-Canvas textures and future WebXR camera helpers can use the same `TextureBindingSource` framework without making `VideoTexture` their public API.
+- Future copied DOM sources such as HTML-in-Canvas textures and experimental [`WebXRCameraTexture`](/docs/api-reference/experimental/webxr/webxr-camera-texture) use the same `TextureBindingSource` framework without making `VideoTexture` their public API.

--- a/docs/api-reference/experimental/README.md
+++ b/docs/api-reference/experimental/README.md
@@ -9,6 +9,15 @@ Install the package alongside matching luma.gl core, engine, and shadertools ver
 yarn add @luma.gl/experimental @luma.gl/core @luma.gl/engine @luma.gl/shadertools
 ```
 
+## WebXR
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+- [WebXR](/docs/api-reference/experimental/webxr): WebGL-only session, frame, and raw camera helpers.
+
 ## Order-independent Transparency
 
 - [`ABufferRenderer`](/docs/api-reference/experimental/a-buffer-renderer) captures, sorts, and

--- a/docs/api-reference/experimental/webxr/README.md
+++ b/docs/api-reference/experimental/webxr/README.md
@@ -1,0 +1,16 @@
+# Experimental WebXR
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`@luma.gl/experimental` exposes experimental WebGL-only WebXR helpers. They stay outside `@luma.gl/engine` because WebXR brings its own session lifecycle, frame scheduler, per-view rendering state, raw camera access, and future input/layer/depth APIs.
+
+## Scope
+
+- [`WebXRAnimationFrameProvider`](/docs/api-reference/experimental/webxr/webxr-manager) drives an engine `AnimationLoop` from `XRSession.requestAnimationFrame()`.
+- [`WebXRManager`](/docs/api-reference/experimental/webxr/webxr-manager) prepares an `XRWebGLLayer` and resolves per-view framebuffer, viewport, projection, and view matrix state.
+- [`WebXRCameraTexture`](/docs/api-reference/experimental/webxr/webxr-camera-texture) binds WebXR Raw Camera Access as a borrowed read-only WebGL texture sampled through GLSL `sampler2D`.
+
+WebGPU WebXR camera textures, input sources, hit testing, anchors, depth sensing, and layer abstractions are not part of this v10 work in progress.

--- a/docs/api-reference/experimental/webxr/webxr-camera-texture.md
+++ b/docs/api-reference/experimental/webxr/webxr-camera-texture.md
@@ -1,0 +1,66 @@
+# WebXRCameraTexture
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRCameraTexture` is the experimental `@luma.gl/experimental` binding source for WebXR Raw Camera Access. It wraps the browser-owned camera `WebGLTexture` for one `XRView` as a borrowed read-only luma [`Texture`](/docs/api-reference/core/resources/texture).
+
+## Usage
+
+```typescript
+import {WebXRCameraTexture} from '@luma.gl/experimental';
+
+const cameraTexture = new WebXRCameraTexture(device, xrWebGLBinding);
+
+session.requestAnimationFrame((time, xrFrame) => {
+  const pose = xrFrame.getViewerPose(referenceSpace);
+  const xrView = pose?.views[0] ?? null;
+
+  cameraTexture.setView(xrView);
+  model.shaderInputs.setProps({
+    bindings: {uTexture: cameraTexture}
+  });
+});
+```
+
+Use it through an ordinary GLSL sampler:
+
+```glsl
+uniform sampler2D uTexture;
+vec4 color = texture(uTexture, uv);
+```
+
+## Behavior
+
+- WebGL-only in v10 work in progress.
+- Resolves only ordinary texture bindings such as GLSL `sampler2D`.
+- `setView(view)` selects `view.camera` and advances the source generation for the next draw.
+- `resolveTextureBinding()` calls `XRWebGLBinding.getCameraImage(camera)` at most once per source generation.
+- The returned browser texture is borrowed and read-only. luma.gl does not upload, resize, generate mipmaps, mutate sampler state, or delete the underlying handle.
+- `external-texture` bindings are unsupported for WebXR camera textures in this experimental pass.
+
+## Types
+
+### `WebXRCameraTextureProps`
+
+`WebXRCameraTextureProps` accepts normal texture metadata that does not imply ownership or mutation: `id`, `format`, `usage`, `view`, and `userData`. `sampler`, `data`, size, mip, and handle props are intentionally not accepted.
+
+## Methods
+
+### `constructor(device: Device, xrWebGLBinding: XRWebGLBinding, props?: WebXRCameraTextureProps)`
+
+Creates a WebGL-only WebXR camera binding source.
+
+### `setView(view: XRView | null): void`
+
+Selects the XR view whose raw camera image should be resolved for the next draw. Pass `null` when no raw camera view is available.
+
+### `resolveTextureBinding(bindingLayout: TextureBindingLayout): Texture | null`
+
+Resolves a borrowed normal texture binding for the current camera view. Returns `null` until a camera-backed view is selected.
+
+### `destroy(): void`
+
+Destroys only the luma wrapper. The browser-owned WebXR camera texture remains browser-owned.

--- a/docs/api-reference/experimental/webxr/webxr-manager.md
+++ b/docs/api-reference/experimental/webxr/webxr-manager.md
@@ -1,0 +1,108 @@
+# WebXRManager
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`WebXRManager` is the experimental WebGL-only session and per-view render-state helper for luma.gl. It prepares an `XRWebGLLayer`, requests a reference space, and resolves the framebuffer, viewports, projection matrices, and view matrices for one active `XRFrame`.
+
+## Usage
+
+```typescript
+import {AnimationLoop} from '@luma.gl/engine';
+import {WebXRAnimationFrameProvider, WebXRManager} from '@luma.gl/experimental';
+
+const webXRManager = new WebXRManager(device);
+await webXRManager.setSession(session);
+
+const animationLoop = new AnimationLoop({
+  device,
+  animationFrameProvider: new WebXRAnimationFrameProvider(session),
+  onRender({animationFrame}) {
+    const xrFrame = animationFrame as XRFrame | null;
+    const frameState = xrFrame && webXRManager.getFrameState(xrFrame);
+    if (!frameState) {
+      return;
+    }
+
+    for (const [viewIndex, view] of frameState.views.entries()) {
+      const renderPass = device.beginRenderPass({
+        framebuffer: frameState.framebuffer,
+        parameters: {viewport: view.viewport},
+        clearColor: viewIndex === 0 ? [0, 0, 0, 0] : false,
+        clearDepth: viewIndex === 0 ? 1 : false,
+        clearStencil: false
+      });
+      // Set view.projectionMatrix and view.viewMatrix uniforms, then draw.
+      renderPass.end();
+    }
+  }
+});
+```
+
+## Behavior
+
+- WebGL-only in v10 work in progress.
+- Calls `gl.makeXRCompatible()` before creating the base `XRWebGLLayer`.
+- Uses `XRSession.requestReferenceSpace()` with `local` by default.
+- Treats `XRViewerPose.views` as an arbitrary per-frame view list, not a fixed stereo pair.
+- Exposes `projectionMatrix` from `XRView.projectionMatrix` and `viewMatrix` from `XRView.transform.inverse.matrix`.
+- Wraps `XRWebGLLayer.framebuffer` as a borrowed luma [`Framebuffer`](/docs/api-reference/core/resources/framebuffer) and never deletes the browser-owned framebuffer handle.
+
+## Types
+
+### `WebXRManagerProps`
+
+```ts
+export type WebXRManagerProps = {
+  referenceSpaceType?: XRReferenceSpaceType;
+  layerInit?: XRWebGLLayerInit;
+};
+```
+
+### `WebXRViewState`
+
+```ts
+export type WebXRViewState = {
+  xrView: XRView;
+  eye: XREye;
+  index: number;
+  viewport: [number, number, number, number];
+  projectionMatrix: Float32Array;
+  viewMatrix: Float32Array;
+  camera: XRCamera | null;
+};
+```
+
+### `WebXRFrameState`
+
+```ts
+export type WebXRFrameState = {
+  xrFrame: XRFrame;
+  framebuffer: Framebuffer;
+  views: readonly WebXRViewState[];
+};
+```
+
+## Methods
+
+### `constructor(device: Device, props?: WebXRManagerProps)`
+
+Creates an experimental WebGL-only WebXR manager.
+
+### `setSession(session: XRSession | null, props?: WebXRManagerProps): Promise<this>`
+
+Attaches or clears the current XR session.
+
+### `getFrameState(xrFrame: XRFrame): WebXRFrameState | null`
+
+Resolves frame state for an active XR frame. Returns `null` when no viewer pose is available.
+
+### `clearSession(): void`
+
+Releases luma wrappers for the current session without ending the browser XR session.
+
+### `destroy(): void`
+
+Clears the current session wrappers.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -233,6 +233,22 @@
       },
       {
         "type": "category",
+        "label": "@luma.gl/experimental",
+        "items": [
+          "api-reference/experimental/README",
+          {
+            "type": "category",
+            "label": "WebXR",
+            "items": [
+              "api-reference/experimental/webxr/README",
+              "api-reference/experimental/webxr/webxr-camera-texture",
+              "api-reference/experimental/webxr/webxr-manager"
+            ]
+          }
+        ]
+      },
+      {
+        "type": "category",
         "label": "@luma.gl/shadertools",
         "items": [
           "api-reference/shadertools/README",

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -1,0 +1,437 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Device, NumberArray, Texture, VariableShaderType} from '@luma.gl/core';
+import {UniformStore} from '@luma.gl/core';
+import type {AnimationProps} from '@luma.gl/engine';
+import {AnimationLoopTemplate, Geometry, Model} from '@luma.gl/engine';
+import {
+  WebXRAnimationFrameProvider,
+  WebXRCameraTexture,
+  WebXRManager,
+  type WebXRFrameState
+} from '@luma.gl/experimental';
+import type {WebGLDevice} from '@luma.gl/webgl';
+import {Matrix4} from '@math.gl/core';
+
+export const title = 'Passthrough Kaleidoscope';
+export const description =
+  'Folds WebXR camera frames or a procedural fallback through animated XR shards.';
+
+export type ImmersiveXRSessionMode = 'immersive-ar' | 'immersive-vr';
+
+type AppUniforms = {
+  modelViewProjectionMatrix: NumberArray;
+  time: number;
+  cameraMix: number;
+};
+
+const app: {uniformTypes: Record<keyof AppUniforms, VariableShaderType>} = {
+  uniformTypes: {
+    modelViewProjectionMatrix: 'mat4x4<f32>',
+    time: 'f32',
+    cameraMix: 'f32'
+  }
+};
+
+const vs = /* glsl */ `\
+#version 300 es
+
+in vec3 positions;
+in vec2 texCoords;
+
+uniform appUniforms {
+  mat4 modelViewProjectionMatrix;
+  float time;
+  float cameraMix;
+} app;
+
+out vec2 vUV;
+out float vPulse;
+
+void main(void) {
+  vec3 position = positions;
+  float angle = atan(position.y, position.x);
+  float radius = length(position.xy);
+  position.z += sin(angle * 7.0 - app.time * 2.4) * radius * 0.10;
+  position.z += cos(radius * 13.0 + app.time * 3.1) * 0.045;
+  gl_Position = app.modelViewProjectionMatrix * vec4(position, 1.0);
+  vUV = texCoords;
+  vPulse = 0.5 + 0.5 * sin(angle * 5.0 + radius * 9.0 - app.time * 2.8);
+}
+`;
+
+const fs = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+uniform sampler2D cameraTexture;
+
+uniform appUniforms {
+  mat4 modelViewProjectionMatrix;
+  float time;
+  float cameraMix;
+} app;
+
+in vec2 vUV;
+in float vPulse;
+
+out vec4 fragColor;
+
+const float PI = 3.141592653589793;
+const float TAU = 6.283185307179586;
+
+vec2 kaleidoscopeUv(vec2 uv) {
+  vec2 centered = uv * 2.0 - 1.0;
+  float radius = length(centered);
+  float angle = atan(centered.y, centered.x);
+  float segment = TAU / 8.0;
+  angle = abs(mod(angle + segment * 0.5, segment) - segment * 0.5);
+  return vec2(cos(angle), sin(angle)) * radius * 0.5 + 0.5;
+}
+
+vec3 proceduralColor(vec2 uv) {
+  vec2 centered = uv * 2.0 - 1.0;
+  float radius = length(centered);
+  float angle = atan(centered.y, centered.x);
+  float aurora = 0.5 + 0.5 * sin(angle * 9.0 - radius * 16.0 - app.time * 2.2);
+  float flare = exp(-abs(radius - 0.54) * 18.0);
+  return mix(vec3(0.02, 0.04, 0.14), vec3(0.05, 0.95, 0.88), aurora) +
+    vec3(0.75, 0.12, 1.0) * flare;
+}
+
+void main(void) {
+  vec2 cameraUv = kaleidoscopeUv(vec2(vUV.x, 1.0 - vUV.y));
+  vec3 cameraColor = texture(cameraTexture, cameraUv).rgb;
+  vec3 color = mix(proceduralColor(vUV), cameraColor, app.cameraMix);
+  float shardEdge = smoothstep(0.0, 0.08, min(min(vUV.x, 1.0 - vUV.x), min(vUV.y, 1.0 - vUV.y)));
+  float scan = 0.88 + 0.12 * sin(vUV.y * 100.0 - app.time * 7.0);
+  color = color * scan + vec3(0.08, 0.82, 1.0) * (1.0 - shardEdge) + vec3(0.48, 0.05, 0.92) * vPulse * 0.22;
+  fragColor = vec4(color, 0.92);
+}
+`;
+
+export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
+  static current: AppAnimationLoopTemplate | null = null;
+
+  static info = `\
+  <p>
+  Experimental v10 WebXR work in progress. Enter AR to fold raw camera frames into a ring
+  of animated portal shards when the browser exposes them; enter VR to view the procedural
+  fallback in an Immersive Web Emulator headset.
+  </p>
+  `;
+
+  readonly device: WebGLDevice;
+  readonly animationLoop: AnimationProps['animationLoop'];
+  readonly uniformStore: UniformStore<{app: AppUniforms}>;
+  readonly fallbackTexture: Texture;
+  readonly model: Model;
+  readonly webXRManager: WebXRManager;
+  readonly modelMatrix = new Matrix4();
+  readonly modelViewProjectionMatrix = new Matrix4();
+  readonly viewMatrix = new Matrix4().lookAt({eye: [0, 0, 3.5], center: [0, 0, 0]});
+  readonly xrViewMatrix = new Matrix4();
+
+  cameraTexture: WebXRCameraTexture | null = null;
+  xrSession: XRSession | null = null;
+  xrSessionMode: ImmersiveXRSessionMode | null = null;
+  private _isFinalized = false;
+  private _xrSessionEndListener = () => this._clearXRSession();
+  private _xrSelectEndListener = () => void this.exitXR();
+  private _keyDownListener = (event: KeyboardEvent) => {
+    if (!this.xrSession) {
+      return;
+    }
+    if (event.key === 'Escape' || event.key.toLowerCase() === 'q') {
+      void this.exitXR();
+    }
+  };
+
+  constructor({animationLoop, device}: AnimationProps) {
+    super();
+    if (device.type !== 'webgl') {
+      throw new Error('Passthrough Kaleidoscope requires WebGL2');
+    }
+
+    AppAnimationLoopTemplate.current = this;
+    this.animationLoop = animationLoop;
+    this.device = device as WebGLDevice;
+    this.uniformStore = new UniformStore(device, {app});
+    this.fallbackTexture = device.createTexture({
+      data: new Uint8Array([6, 12, 42, 255]),
+      width: 1,
+      height: 1,
+      format: 'rgba8unorm'
+    });
+    this.webXRManager = new WebXRManager(device);
+    this.model = new Model(device, {
+      id: 'passthrough-kaleidoscope',
+      vs,
+      fs,
+      geometry: makePortalShardGeometry(),
+      bindings: {
+        appUniforms: this.uniformStore.getManagedUniformBuffer('app'),
+        cameraTexture: this.fallbackTexture
+      },
+      parameters: {
+        depthWriteEnabled: true,
+        depthCompare: 'less-equal',
+        blend: true,
+        blendColorOperation: 'add',
+        blendAlphaOperation: 'add',
+        blendColorSrcFactor: 'src-alpha',
+        blendColorDstFactor: 'one-minus-src-alpha',
+        blendAlphaSrcFactor: 'one',
+        blendAlphaDstFactor: 'one-minus-src-alpha'
+      }
+    });
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('keydown', this._keyDownListener);
+    }
+  }
+
+  onFinalize(): void {
+    this._isFinalized = true;
+    if (AppAnimationLoopTemplate.current === this) {
+      AppAnimationLoopTemplate.current = null;
+    }
+    void this.exitAR();
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('keydown', this._keyDownListener);
+    }
+    this.model.destroy();
+    this.fallbackTexture.destroy();
+    this.uniformStore.destroy();
+    this.webXRManager.destroy();
+  }
+
+  onRender({animationFrame, aspect, device, tick}: AnimationProps): void {
+    const time = tick * 0.001;
+    const xrFrame = animationFrame as XRFrame | null;
+    const frameState = xrFrame && this.xrSession ? this.webXRManager.getFrameState(xrFrame) : null;
+
+    if (frameState) {
+      this.renderXRFrame(time, frameState);
+      return;
+    }
+
+    this.renderPreviewFrame(device, aspect, time);
+  }
+
+  async enterAR(): Promise<void> {
+    await this.enterXR('immersive-ar');
+  }
+
+  async enterVR(): Promise<void> {
+    await this.enterXR('immersive-vr');
+  }
+
+  async enterXR(sessionMode: ImmersiveXRSessionMode): Promise<void> {
+    if (this.xrSession) {
+      return;
+    }
+    if (typeof navigator === 'undefined' || !navigator.xr) {
+      throw new Error('WebXR is not supported in this browser');
+    }
+
+    const session = await navigator.xr.requestSession(sessionMode, getXRSessionInit(sessionMode));
+
+    try {
+      await this.webXRManager.setSession(session, {
+        referenceSpaceType: 'local',
+        layerInit: {alpha: sessionMode === 'immersive-ar'}
+      });
+      this.cameraTexture =
+        sessionMode === 'immersive-ar' ? this.createCameraTexture(session) : null;
+      this.xrSession = session;
+      this.xrSessionMode = sessionMode;
+      session.addEventListener('end', this._xrSessionEndListener);
+      session.addEventListener('selectend', this._xrSelectEndListener);
+      this.animationLoop.setProps({
+        animationFrameProvider: new WebXRAnimationFrameProvider(session)
+      });
+    } catch (error) {
+      await session.end().catch(() => {});
+      throw error;
+    }
+  }
+
+  async exitAR(): Promise<void> {
+    await this.exitXR();
+  }
+
+  async exitXR(): Promise<void> {
+    const session = this.xrSession;
+    if (session) {
+      await session.end().catch(() => {});
+    }
+    this._clearXRSession();
+  }
+
+  private renderPreviewFrame(device: Device, aspect: number, time: number): void {
+    this.updateModelMatrix(time, false);
+    this.modelViewProjectionMatrix
+      .perspective({fovy: Math.PI / 3.1, aspect, near: 0.1, far: 20})
+      .multiplyRight(this.viewMatrix)
+      .multiplyRight(this.modelMatrix);
+    this.drawPortal(device.beginRenderPass({clearColor: [0.004, 0.006, 0.025, 1], clearDepth: 1}), {
+      cameraMix: 0,
+      texture: this.fallbackTexture,
+      time
+    });
+  }
+
+  private renderXRFrame(time: number, frameState: WebXRFrameState): void {
+    this.updateModelMatrix(time, true);
+    const clearAlpha = this.xrSessionMode === 'immersive-ar' ? 0 : 1;
+
+    for (const [viewIndex, view] of frameState.views.entries()) {
+      this.modelViewProjectionMatrix
+        .copy(view.projectionMatrix)
+        .multiplyRight(this.xrViewMatrix.copy(view.viewMatrix))
+        .multiplyRight(this.modelMatrix);
+      const cameraTexture = view.camera ? this.cameraTexture : null;
+      cameraTexture?.setView(view.xrView);
+      const renderPass = this.device.beginRenderPass({
+        framebuffer: frameState.framebuffer,
+        parameters: {viewport: view.viewport},
+        clearColor: viewIndex === 0 ? [0.004, 0.006, 0.025, clearAlpha] : false,
+        clearDepth: viewIndex === 0 ? 1 : false,
+        clearStencil: false
+      });
+      this.drawPortal(renderPass, {
+        cameraMix: cameraTexture ? 1 : 0,
+        texture: cameraTexture || this.fallbackTexture,
+        time
+      });
+    }
+  }
+
+  private drawPortal(
+    renderPass: ReturnType<Device['beginRenderPass']>,
+    options: {cameraMix: number; texture: Texture | WebXRCameraTexture; time: number}
+  ): void {
+    this.uniformStore.setUniforms({
+      app: {
+        modelViewProjectionMatrix: this.modelViewProjectionMatrix,
+        time: options.time,
+        cameraMix: options.cameraMix
+      }
+    });
+    this.model.shaderInputs.setProps({bindings: {cameraTexture: options.texture}});
+    this.model.draw(renderPass);
+    renderPass.end();
+  }
+
+  private updateModelMatrix(time: number, isXR: boolean): void {
+    this.modelMatrix.identity();
+    if (isXR) {
+      this.modelMatrix
+        .translate([0, 0, -2.2])
+        .scale([0.82, 0.82, 0.82])
+        .rotateZ(time * 0.22)
+        .rotateX(Math.sin(time * 0.8) * 0.12);
+    } else {
+      this.modelMatrix
+        .rotateZ(time * 0.22)
+        .rotateX(Math.sin(time * 0.8) * 0.24)
+        .rotateY(Math.cos(time * 0.55) * 0.18);
+    }
+  }
+
+  private createCameraTexture(session: XRSession): WebXRCameraTexture | null {
+    if (typeof XRWebGLBinding === 'undefined') {
+      return null;
+    }
+
+    try {
+      const XRWebGLBindingConstructor = XRWebGLBinding as unknown as new (
+        session: XRSession,
+        context: WebGL2RenderingContext
+      ) => XRWebGLBinding;
+      const xrWebGLBinding = new XRWebGLBindingConstructor(session, this.device.gl);
+      return new WebXRCameraTexture(this.device, xrWebGLBinding);
+    } catch {
+      return null;
+    }
+  }
+
+  private _clearXRSession(): void {
+    const session = this.xrSession;
+    session?.removeEventListener('end', this._xrSessionEndListener);
+    session?.removeEventListener('selectend', this._xrSelectEndListener);
+    this.xrSession = null;
+    this.xrSessionMode = null;
+    this.cameraTexture?.destroy();
+    this.cameraTexture = null;
+    this.webXRManager.clearSession();
+    if (!this._isFinalized) {
+      this.animationLoop.setProps({animationFrameProvider: undefined});
+    }
+  }
+}
+
+function getXRSessionInit(sessionMode: ImmersiveXRSessionMode): XRSessionInit {
+  return sessionMode === 'immersive-ar'
+    ? {optionalFeatures: ['camera-access', 'local-floor']}
+    : {optionalFeatures: ['local-floor']};
+}
+
+function makePortalShardGeometry(): Geometry {
+  const positions: number[] = [];
+  const texCoords: number[] = [];
+  const shardCount = 18;
+  const innerRadius = 0.22;
+  const outerRadius = 1.16;
+
+  for (let shardIndex = 0; shardIndex < shardCount; shardIndex++) {
+    const centerAngle = (shardIndex / shardCount) * Math.PI * 2;
+    const halfAngle = (Math.PI / shardCount) * 0.72;
+    const innerLeft = makePolarPoint(innerRadius, centerAngle - halfAngle);
+    const innerRight = makePolarPoint(innerRadius, centerAngle + halfAngle);
+    const outerLeft = makePolarPoint(outerRadius, centerAngle - halfAngle * 0.78);
+    const outerRight = makePolarPoint(outerRadius, centerAngle + halfAngle * 0.78);
+    appendQuad(positions, texCoords, innerLeft, innerRight, outerRight, outerLeft);
+  }
+
+  return new Geometry({
+    topology: 'triangle-list',
+    attributes: {
+      positions: {size: 3, value: new Float32Array(positions)},
+      texCoords: {size: 2, value: new Float32Array(texCoords)}
+    }
+  });
+}
+
+function makePolarPoint(radius: number, angle: number): [number, number, number] {
+  return [Math.cos(angle) * radius, Math.sin(angle) * radius, 0];
+}
+
+function appendQuad(
+  positions: number[],
+  texCoords: number[],
+  bottomLeft: [number, number, number],
+  bottomRight: [number, number, number],
+  topRight: [number, number, number],
+  topLeft: [number, number, number]
+): void {
+  appendVertex(positions, texCoords, bottomLeft, [0, 0]);
+  appendVertex(positions, texCoords, bottomRight, [1, 0]);
+  appendVertex(positions, texCoords, topRight, [1, 1]);
+  appendVertex(positions, texCoords, bottomLeft, [0, 0]);
+  appendVertex(positions, texCoords, topRight, [1, 1]);
+  appendVertex(positions, texCoords, topLeft, [0, 1]);
+}
+
+function appendVertex(
+  positions: number[],
+  texCoords: number[],
+  position: [number, number, number],
+  texCoord: [number, number]
+): void {
+  positions.push(...position);
+  texCoords.push(...texCoord);
+}

--- a/examples/experimental/webxr-kaleidoscope/index.html
+++ b/examples/experimental/webxr-kaleidoscope/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<script type="module">
+  import {makeAnimationLoop} from '@luma.gl/engine';
+  import {webgl2Adapter} from '@luma.gl/webgl';
+  import AnimationLoopTemplate from './app.ts';
+
+  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+    adapters: [webgl2Adapter]
+  });
+  animationLoop.start();
+</script>
+<body></body>

--- a/examples/experimental/webxr-kaleidoscope/package.json
+++ b/examples/experimental/webxr-kaleidoscope/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "luma.gl-examples-experimental-webxr-kaleidoscope",
+  "version": "9.3.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "@luma.gl/core": "~9.3.0",
+    "@luma.gl/engine": "~9.3.0",
+    "@luma.gl/experimental": "~9.3.0",
+    "@luma.gl/webgl": "~9.3.0",
+    "@math.gl/core": "^4.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/examples/experimental/webxr-kaleidoscope/vite.config.ts
+++ b/examples/experimental/webxr-kaleidoscope/vite.config.ts
@@ -1,0 +1,17 @@
+import {defineConfig} from 'vite';
+import fs from 'fs';
+
+export default defineConfig(async () => ({
+  resolve: {alias: await getAliases('@luma.gl', `${__dirname}/../../..`)},
+  server: {open: true}
+}));
+
+/** Run against local source */
+const getAliases = async (frameworkName, frameworkRootDir) => {
+  const modules = await fs.promises.readdir(`${frameworkRootDir}/modules`);
+  const aliases = {};
+  modules.forEach(module => {
+    aliases[`${frameworkName}/${module}`] = `${frameworkRootDir}/modules/${module}/src`;
+  });
+  return aliases;
+};

--- a/modules/experimental/README.md
+++ b/modules/experimental/README.md
@@ -6,6 +6,7 @@ Experimental features for luma.gl.
 These are experimental features that may change or be removed at any time. Use at your own risk.
 :::
 
-The package currently includes experimental order-independent transparency renderers and packed
-pixel-format helpers. See the [luma.gl API reference](https://luma.gl/docs/api-reference/experimental)
-for documentation.
+The package currently includes experimental order-independent transparency renderers, packed
+pixel-format helpers, and v10 work-in-progress WebGL-only WebXR session, frame, and raw camera
+helpers. See the [luma.gl API reference](https://luma.gl/docs/api-reference/experimental) for
+documentation.

--- a/modules/experimental/src/index.ts
+++ b/modules/experimental/src/index.ts
@@ -31,3 +31,5 @@ export type {WBOITPass, WBOITShaderModuleProps, WBOITShaderModuleUniforms} from 
 export {wboit, wboitPlugin} from './oit/wboit';
 export type {WBOITCaptureContext, WBOITRenderOptions, WBOITSupport} from './oit/wboit-renderer';
 export {getWBOITSupport, WBOITRenderer} from './oit/wboit-renderer';
+
+export * from './webxr/index';

--- a/modules/experimental/src/webxr/index.ts
+++ b/modules/experimental/src/webxr/index.ts
@@ -1,0 +1,10 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export type {WebXRRawCameraBinding} from './webxr-types';
+export {WebXRAnimationFrameProvider} from './webxr-animation-frame-provider';
+export type {WebXRCameraTextureProps} from './webxr-camera-texture';
+export {WebXRCameraTexture} from './webxr-camera-texture';
+export type {WebXRFrameState, WebXRManagerProps, WebXRViewState} from './webxr-manager';
+export {WebXRManager} from './webxr-manager';

--- a/modules/experimental/src/webxr/webxr-animation-frame-provider.ts
+++ b/modules/experimental/src/webxr/webxr-animation-frame-provider.ts
@@ -1,0 +1,22 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {AnimationFrameCallback, AnimationFrameProvider} from '@luma.gl/engine';
+
+/** Experimental v10 XRSession-backed animation frame source. */
+export class WebXRAnimationFrameProvider implements AnimationFrameProvider {
+  readonly session: XRSession;
+
+  constructor(session: XRSession) {
+    this.session = session;
+  }
+
+  requestAnimationFrame(callback: AnimationFrameCallback): number {
+    return this.session.requestAnimationFrame((time, xrFrame) => callback(time, xrFrame));
+  }
+
+  cancelAnimationFrame(animationFrameId: number): void {
+    this.session.cancelAnimationFrame(animationFrameId);
+  }
+}

--- a/modules/experimental/src/webxr/webxr-camera-texture.ts
+++ b/modules/experimental/src/webxr/webxr-camera-texture.ts
@@ -1,0 +1,195 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Device, TextureProps} from '@luma.gl/core';
+import {Texture} from '@luma.gl/core';
+import type {TextureBindingLayout, TextureBindingSource} from '@luma.gl/engine';
+import type {WebXRRawCameraBinding} from './webxr-types';
+
+/** Experimental v10 properties for a raw WebXR camera texture source. */
+export type WebXRCameraTextureProps = Omit<
+  TextureProps,
+  | 'data'
+  | '_isHandleBorrowed'
+  | 'dimension'
+  | 'width'
+  | 'height'
+  | 'depth'
+  | 'samples'
+  | 'mipLevels'
+  | 'handle'
+  | 'sampler'
+>;
+
+type ResolvedWebXRCameraTextureProps = Required<WebXRCameraTextureProps>;
+
+/**
+ * Experimental v10 binding source for the WebXR Raw Camera Access texture.
+ *
+ * WebXRCameraTexture is WebGL-only in v10 work in progress and resolves only
+ * ordinary texture bindings such as GLSL sampler2D.
+ */
+export class WebXRCameraTexture implements TextureBindingSource {
+  readonly device: Device;
+  readonly xrWebGLBinding: WebXRRawCameraBinding;
+  readonly id: string;
+  readonly props: Readonly<ResolvedWebXRCameraTextureProps>;
+
+  destroyed = false;
+  generation = 0;
+
+  private _view: XRView | null = null;
+  private _camera: XRCamera | null = null;
+  private _texture: Texture | null = null;
+  private _resolvedGeneration = -1;
+  private _updateTimestamp: number;
+
+  get view(): XRView | null {
+    return this._view;
+  }
+
+  get camera(): XRCamera | null {
+    return this._camera;
+  }
+
+  get isReady(): boolean {
+    return !this.destroyed && this._camera !== null;
+  }
+
+  get updateTimestamp(): number {
+    return this._updateTimestamp;
+  }
+
+  /** Borrowed luma wrapper after the current XR camera frame has been resolved. */
+  get texture(): Texture {
+    if (!this._texture) {
+      throw new Error(`${this} texture has not been resolved yet`);
+    }
+    return this._texture;
+  }
+
+  get [Symbol.toStringTag]() {
+    return 'WebXRCameraTexture';
+  }
+
+  toString(): string {
+    const size = this._camera ? `${this._camera.width}x${this._camera.height}px` : 'unbound';
+    return `WebXRCameraTexture:"${this.id}":${size}:(${this.isReady ? 'ready' : 'not ready'})`;
+  }
+
+  constructor(
+    device: Device,
+    xrWebGLBinding: WebXRRawCameraBinding,
+    props: WebXRCameraTextureProps = {}
+  ) {
+    if (device.type !== 'webgl') {
+      throw new Error('WebXRCameraTexture is only available on WebGL in v10 work in progress');
+    }
+
+    this.device = device;
+    this.xrWebGLBinding = xrWebGLBinding;
+    this.id = props.id || makeWebXRId('webxr-camera-texture');
+    this.props = {
+      ...WebXRCameraTexture.defaultProps,
+      ...props,
+      id: this.id
+    };
+    this._updateTimestamp = this.device.incrementTimestamp();
+  }
+
+  /**
+   * Selects the WebXR view whose raw camera image should be resolved for the next draw.
+   *
+   * Call once for each XR view render. Repeated calls intentionally advance the
+   * generation because the browser may update the camera image each XR frame.
+   */
+  setView(view: XRView | null): void {
+    this._view = view;
+    this._camera = view?.camera ?? null;
+    this._resolvedGeneration = -1;
+    this._touchGeneration();
+  }
+
+  resolveTextureBinding(bindingLayout: TextureBindingLayout): Texture | null {
+    if (bindingLayout.type === 'external-texture') {
+      throw new Error(
+        `${this} does not support external-texture bindings; use an ordinary texture binding`
+      );
+    }
+    if (!this.isReady) {
+      return null;
+    }
+    if (this._resolvedGeneration === this.generation) {
+      return this._texture;
+    }
+
+    const camera = this._camera;
+    if (!camera) {
+      return null;
+    }
+
+    const textureHandle = this.xrWebGLBinding.getCameraImage(camera);
+    if (!textureHandle) {
+      return null;
+    }
+
+    if (
+      !this._texture ||
+      this._texture.props.handle !== textureHandle ||
+      this._texture.width !== camera.width ||
+      this._texture.height !== camera.height
+    ) {
+      this._texture?.destroy();
+      // XRWebGLBinding owns this opaque camera texture. _isHandleBorrowed tells Resource/WebGL to
+      // make a sampler2D-compatible luma wrapper without allocating, uploading, or deleting it.
+      this._texture = this.device.createTexture({
+        id: `${this.id}-texture`,
+        handle: textureHandle,
+        _isHandleBorrowed: true,
+        width: camera.width,
+        height: camera.height,
+        format: this.props.format,
+        usage: this.props.usage,
+        view: this.props.view,
+        userData: this.props.userData
+      });
+    }
+
+    this._resolvedGeneration = this.generation;
+    return this._texture;
+  }
+
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this._texture?.destroy();
+    this._texture = null;
+    this._view = null;
+    this._camera = null;
+    this.destroyed = true;
+    this._touchGeneration();
+  }
+
+  private _touchGeneration(): void {
+    this.generation++;
+    this._updateTimestamp = this.device.incrementTimestamp();
+  }
+
+  static defaultProps: ResolvedWebXRCameraTextureProps = {
+    id: undefined!,
+    format: 'rgba8unorm',
+    usage: Texture.SAMPLE,
+    view: undefined!,
+    userData: undefined!
+  };
+}
+
+const webXRIdCounters: Record<string, number> = {};
+
+function makeWebXRId(id: string): string {
+  webXRIdCounters[id] = webXRIdCounters[id] || 1;
+  const count = webXRIdCounters[id]++;
+  return `${id}-${count}`;
+}

--- a/modules/experimental/src/webxr/webxr-manager.ts
+++ b/modules/experimental/src/webxr/webxr-manager.ts
@@ -1,0 +1,168 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Device, Framebuffer} from '@luma.gl/core';
+
+type WebXRWebGLDevice = Device & {
+  type: 'webgl';
+  gl: WebGL2RenderingContext;
+};
+
+/** Experimental v10 WebXR session setup options. */
+export type WebXRManagerProps = {
+  referenceSpaceType?: XRReferenceSpaceType;
+  layerInit?: XRWebGLLayerInit;
+};
+
+/** Experimental v10 per-view render state for one active XR frame. */
+export type WebXRViewState = {
+  xrView: XRView;
+  eye: XREye;
+  index: number;
+  viewport: [x: number, y: number, width: number, height: number];
+  projectionMatrix: Float32Array;
+  viewMatrix: Float32Array;
+  camera: XRCamera | null;
+};
+
+/** Experimental v10 render state resolved from one active XR frame. */
+export type WebXRFrameState = {
+  xrFrame: XRFrame;
+  framebuffer: Framebuffer;
+  views: readonly WebXRViewState[];
+};
+
+/**
+ * Experimental v10 WebGL-only WebXR session and per-view render-state helper.
+ *
+ * This is intentionally a small work-in-progress surface. It owns XRWebGLLayer
+ * setup and exposes the framebuffer, viewports, and matrices luma.gl callers
+ * need to render each XRView themselves.
+ */
+export class WebXRManager {
+  readonly device: WebXRWebGLDevice;
+  props: Required<WebXRManagerProps>;
+
+  session: XRSession | null = null;
+  referenceSpace: XRReferenceSpace | null = null;
+  baseLayer: XRWebGLLayer | null = null;
+
+  private _framebuffer: Framebuffer | null = null;
+  private _sessionEndListener = () => this.clearSession();
+
+  constructor(device: Device, props: WebXRManagerProps = {}) {
+    if (!isWebXRWebGLDevice(device)) {
+      throw new Error('WebXRManager is only available on WebGL in v10 work in progress');
+    }
+
+    this.device = device;
+    this.props = {...WebXRManager.defaultProps, ...props};
+  }
+
+  async setSession(session: XRSession | null, props: WebXRManagerProps = {}): Promise<this> {
+    this.clearSession();
+    this.props = {...this.props, ...props};
+
+    if (!session) {
+      return this;
+    }
+
+    await this.device.gl.makeXRCompatible();
+
+    const baseLayer = new XRWebGLLayer(session, this.device.gl, this.props.layerInit);
+    await session.updateRenderState({baseLayer});
+    const referenceSpace = await session.requestReferenceSpace(this.props.referenceSpaceType);
+
+    this.session = session;
+    this.referenceSpace = referenceSpace;
+    this.baseLayer = baseLayer;
+    session.addEventListener('end', this._sessionEndListener);
+
+    return this;
+  }
+
+  getFrameState(xrFrame: XRFrame): WebXRFrameState | null {
+    if (!this.session || !this.referenceSpace || !this.baseLayer) {
+      return null;
+    }
+    if (xrFrame.session !== this.session) {
+      throw new Error('XRFrame belongs to a different XRSession');
+    }
+
+    const viewerPose = xrFrame.getViewerPose(this.referenceSpace);
+    if (!viewerPose) {
+      return null;
+    }
+
+    const framebuffer = this._getFramebuffer();
+    const views = viewerPose.views.map((xrView, index) => {
+      const viewport = this.baseLayer?.getViewport(xrView);
+      if (!viewport) {
+        throw new Error('XRWebGLLayer did not provide a viewport for XRView');
+      }
+
+      return {
+        xrView,
+        eye: xrView.eye,
+        index,
+        viewport: [viewport.x, viewport.y, viewport.width, viewport.height],
+        projectionMatrix: xrView.projectionMatrix,
+        viewMatrix: xrView.transform.inverse.matrix,
+        camera: xrView.camera ?? null
+      } satisfies WebXRViewState;
+    });
+
+    return {xrFrame, framebuffer, views};
+  }
+
+  clearSession(): void {
+    this.session?.removeEventListener('end', this._sessionEndListener);
+    this._framebuffer?.destroy();
+    this._framebuffer = null;
+    this.baseLayer = null;
+    this.referenceSpace = null;
+    this.session = null;
+  }
+
+  destroy(): void {
+    this.clearSession();
+  }
+
+  private _getFramebuffer(): Framebuffer {
+    const baseLayer = this.baseLayer;
+    if (!baseLayer) {
+      throw new Error('WebXRManager has no XRWebGLLayer');
+    }
+    const framebufferHandle = baseLayer.framebuffer as WebGLFramebuffer | null | undefined;
+    if (framebufferHandle === undefined) {
+      throw new Error('XRWebGLLayer framebuffer is only available during an active XR frame');
+    }
+
+    if (
+      !this._framebuffer ||
+      this._framebuffer.props.handle !== framebufferHandle ||
+      this._framebuffer.width !== baseLayer.framebufferWidth ||
+      this._framebuffer.height !== baseLayer.framebufferHeight
+    ) {
+      this._framebuffer?.destroy();
+      this._framebuffer = this.device.createFramebuffer({
+        id: 'webxr-framebuffer',
+        handle: framebufferHandle,
+        width: baseLayer.framebufferWidth,
+        height: baseLayer.framebufferHeight
+      });
+    }
+
+    return this._framebuffer;
+  }
+
+  static defaultProps: Required<WebXRManagerProps> = {
+    referenceSpaceType: 'local',
+    layerInit: undefined!
+  };
+}
+
+function isWebXRWebGLDevice(device: Device): device is WebXRWebGLDevice {
+  return device.type === 'webgl' && 'gl' in device;
+}

--- a/modules/experimental/src/webxr/webxr-types.ts
+++ b/modules/experimental/src/webxr/webxr-types.ts
@@ -1,0 +1,122 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/**
+ * Keep luma.gl's v10 work-in-progress WebXR declarations local to experimental.
+ *
+ * @types/webxr does not yet cover raw camera access and also adds ambient draft
+ * WebGL extension overloads to every TypeScript program that installs luma.gl.
+ * This package only needs the session, layer, view, and raw-camera subset below.
+ */
+export {};
+
+declare global {
+  interface Navigator {
+    xr?: XRSystem;
+  }
+
+  interface WebGLContextAttributes {
+    xrCompatible?: boolean;
+  }
+
+  interface WebGLRenderingContextBase {
+    makeXRCompatible(): Promise<void>;
+  }
+
+  type XRSessionMode = 'inline' | 'immersive-vr' | 'immersive-ar';
+  type XRReferenceSpaceType = 'viewer' | 'local' | 'local-floor' | 'bounded-floor' | 'unbounded';
+  type XREye = 'none' | 'left' | 'right';
+  type XRFrameRequestCallback = (time: DOMHighResTimeStamp, frame: XRFrame) => void;
+
+  interface XRSystem extends EventTarget {
+    requestSession(mode: XRSessionMode, options?: XRSessionInit): Promise<XRSession>;
+    isSessionSupported(mode: XRSessionMode): Promise<boolean>;
+  }
+
+  interface XRSessionInit {
+    optionalFeatures?: string[];
+    requiredFeatures?: string[];
+  }
+
+  interface XRRenderStateInit {
+    baseLayer?: XRWebGLLayer;
+  }
+
+  interface XRSession extends EventTarget {
+    cancelAnimationFrame(animationFrameId: number): void;
+    end(): Promise<void>;
+    requestAnimationFrame(callback: XRFrameRequestCallback): number;
+    requestReferenceSpace(type: XRReferenceSpaceType): Promise<XRReferenceSpace>;
+    updateRenderState(renderStateInit?: XRRenderStateInit): Promise<void>;
+  }
+
+  interface XRSpace extends EventTarget {}
+
+  interface XRReferenceSpace extends XRSpace {}
+
+  interface XRFrame {
+    readonly session: XRSession;
+    getViewerPose(referenceSpace: XRReferenceSpace): XRViewerPose | undefined;
+  }
+
+  interface XRViewerPose {
+    readonly views: readonly XRView[];
+  }
+
+  interface XRRigidTransform {
+    readonly matrix: Float32Array;
+    readonly inverse: XRRigidTransform;
+  }
+
+  interface XRCamera {
+    readonly width: number;
+    readonly height: number;
+  }
+
+  interface XRView {
+    readonly eye: XREye;
+    readonly projectionMatrix: Float32Array;
+    readonly transform: XRRigidTransform;
+    readonly camera: XRCamera | null;
+  }
+
+  interface XRViewport {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+  }
+
+  interface XRWebGLLayerInit {
+    antialias?: boolean;
+    depth?: boolean;
+    stencil?: boolean;
+    alpha?: boolean;
+    ignoreDepthValues?: boolean;
+    framebufferScaleFactor?: number;
+  }
+
+  class XRWebGLLayer {
+    constructor(
+      session: XRSession,
+      context: WebGLRenderingContext | WebGL2RenderingContext,
+      layerInit?: XRWebGLLayerInit
+    );
+
+    readonly framebuffer: WebGLFramebuffer | null;
+    readonly framebufferWidth: number;
+    readonly framebufferHeight: number;
+
+    getViewport(view: XRView): XRViewport | undefined;
+  }
+
+  class XRWebGLBinding {
+    constructor(session: XRSession, context: WebGLRenderingContext | WebGL2RenderingContext);
+
+    getCameraImage(camera: XRCamera): WebGLTexture | null;
+  }
+}
+
+/** Experimental v10 raw-camera subset required by WebXRCameraTexture. */
+export type WebXRRawCameraBinding = Pick<XRWebGLBinding, 'getCameraImage'>;

--- a/modules/experimental/test/index.ts
+++ b/modules/experimental/test/index.ts
@@ -6,3 +6,5 @@ import './textures/packed-pixels.spec';
 import './textures/html-texture.spec';
 import './oit/a-buffer-renderer.spec';
 import './oit/wboit-renderer.spec';
+
+import './webxr';

--- a/modules/experimental/test/webxr/index.ts
+++ b/modules/experimental/test/webxr/index.ts
@@ -1,0 +1,7 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import './webxr-animation-frame-provider.spec';
+import './webxr-camera-texture.spec';
+import './webxr-manager.spec';

--- a/modules/experimental/test/webxr/webxr-animation-frame-provider.spec.ts
+++ b/modules/experimental/test/webxr/webxr-animation-frame-provider.spec.ts
@@ -1,0 +1,28 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {WebXRAnimationFrameProvider} from '../../src';
+
+test('webxr#WebXRAnimationFrameProvider delegates to XRSession', t => {
+  let scheduledCallback: XRFrameRequestCallback | null = null;
+  let cancelledAnimationFrameId: number | null = null;
+  const session = {
+    requestAnimationFrame(callback: XRFrameRequestCallback) {
+      scheduledCallback = callback;
+      return 7;
+    },
+    cancelAnimationFrame(animationFrameId: number) {
+      cancelledAnimationFrameId = animationFrameId;
+    }
+  } as XRSession;
+  const animationFrameProvider = new WebXRAnimationFrameProvider(session);
+  const callback = () => {};
+
+  t.equal(animationFrameProvider.requestAnimationFrame(callback), 7, 'delegates frame request');
+  t.ok(scheduledCallback, 'registers XR callback');
+  animationFrameProvider.cancelAnimationFrame(7);
+  t.equal(cancelledAnimationFrameId, 7, 'delegates frame cancellation');
+  t.end();
+});

--- a/modules/experimental/test/webxr/webxr-camera-texture.spec.ts
+++ b/modules/experimental/test/webxr/webxr-camera-texture.spec.ts
@@ -1,0 +1,107 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {getWebGLTestDevice} from '@luma.gl/test-utils';
+import {WebXRCameraTexture} from '../../src';
+
+const TEXTURE_BINDING = {
+  type: 'texture',
+  name: 'cameraTexture',
+  group: 0,
+  location: 0
+} as const;
+
+const EXTERNAL_TEXTURE_BINDING = {
+  type: 'external-texture',
+  name: 'cameraTexture',
+  group: 0,
+  location: 0
+} as const;
+
+test('webxr#WebXRCameraTexture resolves borrowed raw camera textures once per generation', async t => {
+  const device = await getWebGLTestDevice();
+  const {gl} = device;
+  const cameraTextureHandle = gl.createTexture()!;
+  let deleteTextureCallCount = 0;
+  const originalDeleteTexture = gl.deleteTexture.bind(gl);
+  gl.deleteTexture = (texture => {
+    deleteTextureCallCount++;
+    return originalDeleteTexture(texture);
+  }) as typeof gl.deleteTexture;
+  const camera = {width: 4, height: 2} as XRCamera;
+  const view = makeXRView(camera);
+  let getCameraImageCallCount = 0;
+  const xrWebGLBinding = {
+    getCameraImage(receivedCamera: XRCamera) {
+      t.equal(receivedCamera, camera, 'resolves selected XRCamera');
+      getCameraImageCallCount++;
+      return cameraTextureHandle;
+    }
+  } as XRWebGLBinding;
+
+  const webXRCameraTexture = new WebXRCameraTexture(device, xrWebGLBinding);
+
+  try {
+    t.false(webXRCameraTexture.isReady, 'source is not ready before a view is selected');
+    t.equal(
+      webXRCameraTexture.resolveTextureBinding(TEXTURE_BINDING),
+      null,
+      'unbound source does not resolve'
+    );
+
+    webXRCameraTexture.setView(view);
+    const firstGeneration = webXRCameraTexture.generation;
+    const firstResolution = webXRCameraTexture.resolveTextureBinding(TEXTURE_BINDING);
+
+    t.true(webXRCameraTexture.isReady, 'camera-backed view is ready');
+    t.ok(firstResolution, 'camera texture resolves');
+    t.equal(firstResolution?.width, camera.width, 'camera width propagates');
+    t.equal(firstResolution?.height, camera.height, 'camera height propagates');
+    t.equal(firstResolution?.props.handle, cameraTextureHandle, 'borrowed handle is wrapped');
+    t.true(firstResolution?.isHandleBorrowed, 'camera texture handle is borrowed');
+    t.equal(getCameraImageCallCount, 1, 'first generation resolves camera image once');
+    t.equal(
+      webXRCameraTexture.resolveTextureBinding(TEXTURE_BINDING),
+      firstResolution,
+      'same generation reuses borrowed wrapper'
+    );
+    t.equal(getCameraImageCallCount, 1, 'same generation does not reacquire camera image');
+
+    webXRCameraTexture.setView(view);
+    const secondResolution = webXRCameraTexture.resolveTextureBinding(TEXTURE_BINDING);
+
+    t.ok(webXRCameraTexture.generation > firstGeneration, 'new XR view sample advances generation');
+    t.equal(secondResolution, firstResolution, 'same borrowed handle reuses luma wrapper');
+    t.equal(getCameraImageCallCount, 2, 'next generation reacquires camera image once');
+    t.throws(
+      () => webXRCameraTexture.resolveTextureBinding(EXTERNAL_TEXTURE_BINDING),
+      /does not support external-texture bindings/,
+      'WebXR camera texture does not route through ExternalTexture'
+    );
+
+    webXRCameraTexture.setView(null);
+    t.false(webXRCameraTexture.isReady, 'null view clears camera readiness');
+
+    webXRCameraTexture.destroy();
+    t.equal(deleteTextureCallCount, 0, 'destroying wrapper does not delete browser handle');
+  } finally {
+    gl.deleteTexture = originalDeleteTexture;
+    originalDeleteTexture(cameraTextureHandle);
+    device.destroy();
+  }
+
+  t.end();
+});
+
+function makeXRView(camera: XRCamera): XRView {
+  return {
+    camera,
+    eye: 'none',
+    projectionMatrix: new Float32Array(16),
+    transform: {
+      inverse: {matrix: new Float32Array(16)}
+    }
+  } as XRView;
+}

--- a/modules/experimental/test/webxr/webxr-manager.spec.ts
+++ b/modules/experimental/test/webxr/webxr-manager.spec.ts
@@ -1,0 +1,156 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {getWebGLTestDevice} from '@luma.gl/test-utils';
+import {WebXRManager} from '../../src';
+
+test('webxr#WebXRManager resolves WebGL XR frame state without owning XR framebuffer', async t => {
+  const device = await getWebGLTestDevice();
+  const {gl} = device;
+  const xrFramebufferHandle = gl.createFramebuffer()!;
+  const referenceSpace = {} as XRReferenceSpace;
+  const session = makeXRSession(referenceSpace);
+  const leftView = makeXRView('left', 0);
+  const rightView = makeXRView('right', 1);
+  const xrFrame = {
+    session,
+    getViewerPose: (receivedReferenceSpace: XRReferenceSpace) => {
+      t.equal(receivedReferenceSpace, referenceSpace, 'queries configured reference space');
+      return {views: [leftView, rightView]} as XRViewerPose;
+    }
+  } as XRFrame;
+
+  let makeXRCompatibleCallCount = 0;
+  let deleteFramebufferCallCount = 0;
+  const originalMakeXRCompatible = gl.makeXRCompatible;
+  const originalDeleteFramebuffer = gl.deleteFramebuffer.bind(gl);
+  const originalXRWebGLLayer = globalThis.XRWebGLLayer;
+  gl.makeXRCompatible = async () => {
+    makeXRCompatibleCallCount++;
+  };
+  gl.deleteFramebuffer = (framebuffer => {
+    deleteFramebufferCallCount++;
+    return originalDeleteFramebuffer(framebuffer);
+  }) as typeof gl.deleteFramebuffer;
+  globalThis.XRWebGLLayer = class {
+    readonly framebuffer = xrFramebufferHandle;
+    readonly framebufferWidth = 64;
+    readonly framebufferHeight = 32;
+
+    constructor(
+      receivedSession: XRSession,
+      receivedContext: WebGLRenderingContext | WebGL2RenderingContext
+    ) {
+      t.equal(receivedSession, session, 'creates layer for selected session');
+      t.equal(receivedContext, gl, 'creates layer for luma WebGL context');
+    }
+
+    getViewport(view: XRView): XRViewport {
+      return view.eye === 'left'
+        ? ({x: 0, y: 0, width: 32, height: 32} as XRViewport)
+        : ({x: 32, y: 0, width: 32, height: 32} as XRViewport);
+    }
+  } as typeof XRWebGLLayer;
+
+  try {
+    const webXRManager = new WebXRManager(device);
+    await webXRManager.setSession(session);
+    const frameState = webXRManager.getFrameState(xrFrame);
+
+    t.equal(makeXRCompatibleCallCount, 1, 'makes WebGL context XR compatible');
+    t.equal(session.updatedBaseLayer, webXRManager.baseLayer, 'updates session render state');
+    t.ok(frameState, 'active XR frame resolves state');
+    t.equal(frameState?.framebuffer.props.handle, xrFramebufferHandle, 'wraps XR framebuffer');
+    t.deepEqual(frameState?.views[0]?.viewport, [0, 0, 32, 32], 'left viewport resolves');
+    t.deepEqual(frameState?.views[1]?.viewport, [32, 0, 32, 32], 'right viewport resolves');
+    t.equal(frameState?.views[1]?.index, 1, 'view state keeps pose view order');
+    t.equal(frameState?.views[0]?.projectionMatrix, leftView.projectionMatrix, 'keeps projection');
+    t.equal(
+      frameState?.views[0]?.viewMatrix,
+      leftView.transform.inverse.matrix,
+      'uses inverse XR transform as view matrix'
+    );
+
+    webXRManager.destroy();
+    t.equal(deleteFramebufferCallCount, 0, 'destroying wrapper does not delete XR framebuffer');
+  } finally {
+    globalThis.XRWebGLLayer = originalXRWebGLLayer;
+    gl.makeXRCompatible = originalMakeXRCompatible;
+    gl.deleteFramebuffer = originalDeleteFramebuffer;
+    originalDeleteFramebuffer(xrFramebufferHandle);
+    device.destroy();
+  }
+
+  t.end();
+});
+
+test('webxr#WebXRManager accepts null XRWebGLLayer framebuffer handles', async t => {
+  const device = await getWebGLTestDevice();
+  const {gl} = device;
+  const referenceSpace = {} as XRReferenceSpace;
+  const session = makeXRSession(referenceSpace);
+  const view = makeXRView('none', 0);
+  const xrFrame = {
+    session,
+    getViewerPose: () => ({views: [view]}) as XRViewerPose
+  } as XRFrame;
+
+  const originalMakeXRCompatible = gl.makeXRCompatible;
+  const originalXRWebGLLayer = globalThis.XRWebGLLayer;
+  gl.makeXRCompatible = async () => {};
+  globalThis.XRWebGLLayer = class {
+    readonly framebuffer = null;
+    readonly framebufferWidth = 64;
+    readonly framebufferHeight = 32;
+
+    getViewport(): XRViewport {
+      return {x: 0, y: 0, width: 64, height: 32} as XRViewport;
+    }
+  } as typeof XRWebGLLayer;
+
+  try {
+    const webXRManager = new WebXRManager(device);
+    await webXRManager.setSession(session);
+    const frameState = webXRManager.getFrameState(xrFrame);
+
+    t.ok(frameState, 'active XR frame resolves state');
+    t.equal(frameState?.framebuffer.props.handle, null, 'wraps null as the default framebuffer');
+    t.deepEqual(frameState?.views[0]?.viewport, [0, 0, 64, 32], 'viewport still resolves');
+
+    webXRManager.destroy();
+  } finally {
+    globalThis.XRWebGLLayer = originalXRWebGLLayer;
+    gl.makeXRCompatible = originalMakeXRCompatible;
+    device.destroy();
+  }
+
+  t.end();
+});
+
+function makeXRSession(
+  referenceSpace: XRReferenceSpace
+): XRSession & {updatedBaseLayer: XRWebGLLayer | null} {
+  const session = Object.assign(new EventTarget(), {
+    updatedBaseLayer: null,
+    async updateRenderState(renderStateInit: XRRenderStateInit = {}) {
+      session.updatedBaseLayer = renderStateInit.baseLayer || null;
+    },
+    async requestReferenceSpace() {
+      return referenceSpace;
+    }
+  }) as XRSession & {updatedBaseLayer: XRWebGLLayer | null};
+  return session;
+}
+
+function makeXRView(eye: XREye, index: number): XRView {
+  return {
+    camera: null,
+    eye,
+    projectionMatrix: new Float32Array([index + 1]),
+    transform: {
+      inverse: {matrix: new Float32Array([index + 10])}
+    }
+  } as XRView;
+}

--- a/scripts/examples-typecheck.mjs
+++ b/scripts/examples-typecheck.mjs
@@ -20,6 +20,7 @@ const SUPPORTED_EXAMPLE_WORKSPACES = new Set([
   'arrow/arrow-points',
   'arrow/arrow-polygons',
   'experimental/video-texture',
+  'experimental/webxr-kaleidoscope',
   'integrations/hello-react',
   'showcase/dof',
   'showcase/persistence',
@@ -58,6 +59,8 @@ const SHARED_COMPILER_OPTIONS = {
     '@deck.gl-community/arrow-layers/*': ['modules/arrow-layers/src/*'],
     '@math.gl/geoarrow': ['modules/geoarrow/src/index.ts'],
     '@math.gl/geoarrow/*': ['modules/geoarrow/src/*'],
+    '@luma.gl/experimental': ['modules/experimental/src/index.ts'],
+    '@luma.gl/experimental/*': ['modules/experimental/src/*'],
     '@luma.gl/tables': ['modules/tables/src/index.ts'],
     '@luma.gl/tables/*': ['modules/tables/src/*']
   }

--- a/website/content/examples/experimental/webxr-kaleidoscope.mdx
+++ b/website/content/examples/experimental/webxr-kaleidoscope.mdx
@@ -1,0 +1,12 @@
+---
+title: Passthrough Kaleidoscope
+---
+
+<p className="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+import {WebXRKaleidoscopeExample} from '@site/src/examples';
+
+<WebXRKaleidoscopeExample />

--- a/website/content/examples/table-of-contents.json
+++ b/website/content/examples/table-of-contents.json
@@ -60,7 +60,8 @@
       "experimental/html-ui-prism",
       "experimental/fp64",
       "experimental/gpt-2",
-      "experimental/video-texture"
+      "experimental/video-texture",
+      "experimental/webxr-kaleidoscope"
     ]
   },
   {

--- a/website/content/sidebar-examples.js
+++ b/website/content/sidebar-examples.js
@@ -59,7 +59,8 @@ const sidebars = {
         'experimental/html-ui-prism',
         'experimental/fp64',
         'experimental/gpt-2',
-        'experimental/video-texture'
+        'experimental/video-texture',
+        'experimental/webxr-kaleidoscope'
       ]
     },
     {

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -20,6 +20,7 @@ import HTMLUIPrismApp from '../../examples/experimental/html-ui-prism/app';
 import FP64App from '../../examples/experimental/fp64/app';
 import GPT2App from '../../examples/experimental/gpt-2/app';
 import VideoTextureApp from '../../examples/experimental/video-texture/app';
+import WebXRKaleidoscopeApp from '../../examples/experimental/webxr-kaleidoscope/app';
 import {
   initializeGPGPUShowcase,
   type GPGPUShowcaseHandle
@@ -917,6 +918,103 @@ export const VideoTextureExample: React.FC = props => {
           </button>
           {cameraStatus === 'pending' ? <span>Waiting for first frame</span> : null}
           {cameraError ? <span>{cameraError}</span> : null}
+        </div>
+      }
+      {...props}
+    />
+  );
+};
+
+export const WebXRKaleidoscopeExample: React.FC = props => {
+  type XRStatus = 'idle' | 'pending' | 'live' | 'error';
+  type XRMode = 'immersive-ar' | 'immersive-vr';
+
+  const [xrStatus, setXRStatus] = useState<XRStatus>('idle');
+  const [xrMode, setXRMode] = useState<XRMode | null>(null);
+  const [xrError, setXRError] = useState<string | null>(null);
+  const handleXRSession = async (sessionMode: XRMode) => {
+    const app = WebXRKaleidoscopeApp.current;
+    if (!app) {
+      setXRStatus('error');
+      setXRError('Example is still starting');
+      return;
+    }
+
+    setXRStatus('pending');
+    setXRMode(sessionMode);
+    setXRError(null);
+    try {
+      if (xrStatus === 'live' && xrMode === sessionMode) {
+        await app.exitXR();
+        setXRStatus('idle');
+        setXRMode(null);
+      } else {
+        if (xrStatus === 'live') {
+          await app.exitXR();
+        }
+        await app.enterXR(sessionMode);
+        setXRStatus('live');
+        setXRMode(sessionMode);
+      }
+    } catch (error) {
+      setXRStatus('error');
+      setXRMode(null);
+      setXRError(getErrorMessage(error));
+    }
+  };
+  const getXRButtonText = (sessionMode: XRMode) => {
+    const label = sessionMode === 'immersive-vr' ? 'VR' : 'AR';
+    if (xrStatus === 'pending' && xrMode === sessionMode) {
+      return `Starting ${label}`;
+    }
+    if (xrStatus === 'live' && xrMode === sessionMode) {
+      return `Exit ${label}`;
+    }
+    if (xrStatus === 'error' && xrMode === sessionMode) {
+      return `Retry ${label}`;
+    }
+    return `Enter ${label}`;
+  };
+  const getXRButtonStyle = (sessionMode: XRMode): React.CSSProperties => ({
+    border: '1px solid #0f766e',
+    borderRadius: 999,
+    background: xrStatus === 'live' && xrMode === sessionMode ? '#ccfbf1' : '#fff',
+    color: '#0f172a',
+    cursor: xrStatus === 'pending' ? 'default' : 'pointer',
+    font: '600 14px system-ui, sans-serif',
+    padding: '8px 12px'
+  });
+
+  return (
+    <LumaExample
+      id="webxr-kaleidoscope"
+      title="Passthrough Kaleidoscope"
+      directory="experimental"
+      devices={['webgl2']}
+      template={WebXRKaleidoscopeApp}
+      config={exampleConfig}
+      headerControls={
+        <div style={{display: 'flex', alignItems: 'center', gap: 10, marginTop: 12}}>
+          <button
+            type="button"
+            onClick={() => void handleXRSession('immersive-vr')}
+            disabled={xrStatus === 'pending'}
+            style={getXRButtonStyle('immersive-vr')}
+          >
+            {getXRButtonText('immersive-vr')}
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleXRSession('immersive-ar')}
+            disabled={xrStatus === 'pending'}
+            style={getXRButtonStyle('immersive-ar')}
+          >
+            {getXRButtonText('immersive-ar')}
+          </button>
+          {xrStatus === 'pending' ? (
+            <span>Requesting {xrMode === 'immersive-ar' ? 'AR' : 'VR'} session</span>
+          ) : null}
+          {xrError ? <span>{xrError}</span> : null}
         </div>
       }
       {...props}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16054,6 +16054,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"luma.gl-examples-experimental-webxr-kaleidoscope@workspace:examples/experimental/webxr-kaleidoscope":
+  version: 0.0.0-use.local
+  resolution: "luma.gl-examples-experimental-webxr-kaleidoscope@workspace:examples/experimental/webxr-kaleidoscope"
+  dependencies:
+    "@luma.gl/core": "npm:~9.3.0"
+    "@luma.gl/engine": "npm:~9.3.0"
+    "@luma.gl/experimental": "npm:~9.3.0"
+    "@luma.gl/webgl": "npm:~9.3.0"
+    "@math.gl/core": "npm:^4.1.0"
+    typescript: "npm:^5.9.3"
+    vite: "npm:^8.0.0"
+  languageName: unknown
+  linkType: soft
+
 "luma.gl-examples-external-webgl-context@workspace:examples/integrations/external-context":
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-external-webgl-context@workspace:examples/integrations/external-context"


### PR DESCRIPTION
## Goals

- Add the first experimental v10 WebXR integration surface inside `@luma.gl/experimental`.
- Support XR-driven animation, per-view render state, and WebXR Raw Camera Access without making WebXR an engine dependency.
- Provide a concrete WebXR example and documentation while keeping unsupported platform paths explicit.

## Changes

- Added `WebXRAnimationFrameProvider`, `WebXRManager`, local WebXR type declarations, and `WebXRCameraTexture` under `modules/experimental/src/webxr`.
- Built on the generic `AnimationFrameProvider`, direct `ShaderInputs` binding, and borrowed-resource infrastructure landed in #2684. This PR no longer changes `modules/core`, `modules/engine`, or `modules/webgl`.
- Added focused experimental tests for XR frame scheduling, per-view projection/view state, raw camera generation and resolution, and browser-owned texture lifetime.
- Added the experimental Passthrough Kaleidoscope example with optional `camera-access` and a procedural fallback when raw camera access is unavailable.
- Added v10 work-in-progress API docs under `docs/api-reference/experimental/webxr`, plus example and navigation wiring. There is no `@luma.gl/webxr` package or top-level WebXR module documentation.

## Example

<img width="2786" height="1444" alt="Passthrough Kaleidoscope WebXR example" src="https://github.com/user-attachments/assets/3221875c-f7f2-4348-9dd7-8294dda36df8" />

## Verification

- `nvm use`: passed with Node 22.22.1.
- `yarn install`: passed via Corepack with existing peer dependency warnings.
- `yarn lint fix`: passed after the final rebase.
- `yarn build`: passed after the final rebase.
- `yarn test`: passed via `yarn test-node` and `yarn test-headless`; final results were 48 node files passed and 226 headless files passed.
- `yarn examples:typecheck`: passed for all 25 selected workspaces, including `experimental/webxr-kaleidoscope`.
- `yarn website:build`: passed.
- `(cd website && yarn build)`: passed after the final rebase and indexed 1,816 documentation pages.

## Risks

- WebXR support is intentionally WebGL-only and experimental in v10.
- Raw camera textures require a runtime exposing WebXR Raw Camera Access; desktop XR emulation exercises session/view flow but uses the procedural fallback rather than validating camera textures.
- `camera-access` is optional in the example so runtimes without raw camera support can still enter immersive AR when AR itself is available.
