### PR TITLE
feat(gpgpu) add GPU sort (WebGPU bitonic argsort)

### DIFF
--- a/docs/api-reference/gpgpu/README.md
+++ b/docs/api-reference/gpgpu/README.md
@@ -9,6 +9,7 @@ The `@luma.gl/gpgpu` module performs GPU-based data transformation.
 ## API Reference
 
 - [`Operations`](/docs/api-reference/gpgpu/operations)
+- [`Bitonic Argsort`](/docs/api-reference/gpgpu/bitonic-argsort)
 - [`Custom Operations`](/docs/api-reference/gpgpu/custom-operation)
 - [`GPU Evaluators`](/docs/api-reference/gpgpu/gpu-data-evaluator)
 - [`cleanEvaluate`](/docs/api-reference/gpgpu/clean-evaluate)
@@ -94,12 +95,21 @@ backendRegistry.add('webgl', {
 See [`Custom Operations`](/docs/api-reference/gpgpu/custom-operation) for a full
 operation and backend handler example.
 
+The WebGPU endpoint also exports direct helpers that do not participate in lazy
+backend dispatch. Use [`BitonicArgsort`](/docs/api-reference/gpgpu/bitonic-argsort)
+when a packed `GPUVector<'uint32'>` needs stable sorted row indices kept in GPU
+storage. When those keys start as Apache Arrow data, upload the Arrow vector
+with `makeGPUVectorFromArrow(...)` from `@luma.gl/arrow` before passing the
+resulting `GPUVector` to the sorter. See the runnable
+[Bitonic argsort example](/examples/v10/gpgpu-bitonic-sort).
+
 The CPU backend can be imported from `@luma.gl/gpgpu/cpu` when explicitly
 registering CPU handlers for another device type.
 
 ## Concepts
 
 - [`Operations`](/docs/api-reference/gpgpu/operations) documents the supported lazy compute operations such as `add()`, `interleave()`, and `fround()`.
+- [`Bitonic Argsort`](/docs/api-reference/gpgpu/bitonic-argsort) documents the direct WebGPU argsort helper for packed `GPUVector<'uint32'>` keys.
 - [`Custom Operations`](/docs/api-reference/gpgpu/custom-operation) shows how to define lazy operations and register backend handlers.
 - [`GPU Evaluators`](/docs/api-reference/gpgpu/gpu-data-evaluator) documents `GPUDataEvaluator` for one packed `GPUData` chunk and `GPUVectorEvaluator` for chunk-preserving `GPUVector.data[]` transforms.
 - [`cleanEvaluate`](/docs/api-reference/gpgpu/clean-evaluate) evaluates final result tables and cleans up intermediate dependencies in one step.

--- a/docs/api-reference/gpgpu/bitonic-argsort.md
+++ b/docs/api-reference/gpgpu/bitonic-argsort.md
@@ -1,0 +1,90 @@
+import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
+
+# Bitonic Argsort
+
+<GPGPUDocsTabs active="bitonic-argsort" />
+
+`BitonicArgsort` is a WebGPU-only helper exported from `@luma.gl/gpgpu/webgpu`. It
+sorts one packed `GPUVector<'uint32'>` of keys and returns a new
+`GPUVector<'uint32'>` of source row indices in stable ascending key order.
+Argsort returns row indices; it does not reorder or replace the input key vector.
+
+Use this helper when the sorted row indices need to remain in GPU storage. It is
+not a lazy `GPUDataEvaluator` operation and it is not available from the WebGL or
+CPU endpoints. Arrow conversion remains in `@luma.gl/arrow`; the GPGPU helper
+accepts the shared table-layer `GPUVector` type only.
+
+## Arrow To GPUVector
+
+```ts
+import {makeGPUVectorFromArrow} from '@luma.gl/arrow';
+import {luma} from '@luma.gl/core';
+import {BitonicArgsort} from '@luma.gl/gpgpu/webgpu';
+import type {GPUVector} from '@luma.gl/tables';
+import {webgpuAdapter} from '@luma.gl/webgpu';
+import * as arrow from 'apache-arrow';
+
+const device = await luma.createDevice({
+  type: 'webgpu',
+  adapters: [webgpuAdapter]
+});
+const sortKeyVector = arrow.vectorFromArray([13, 3, 8, 3, 10, 1], new arrow.Uint32());
+const sortKeys = makeGPUVectorFromArrow(device, sortKeyVector, {
+  name: 'sortKeys',
+  format: 'uint32'
+});
+const sorter = new BitonicArgsort(device);
+const sortedRowIndices: GPUVector<'uint32'> = sorter.sortGPUVector(sortKeys);
+
+sortedRowIndices.destroy();
+sortKeys.destroy();
+sorter.destroy();
+device.destroy();
+```
+
+The runnable [Bitonic argsort example](/examples/v10/gpgpu-bitonic-sort) builds an
+Apache Arrow `Uint32` column, uploads it with `makeGPUVectorFromArrow(...)`, and
+uses the returned GPU row-index vector as the real result while visualizing
+bitonic passes locally for teaching.
+
+## API
+
+### `new BitonicArgsort(device)`
+
+Creates one reusable sorter for a WebGPU device. The sorter owns internal scratch
+buffers and releases them from `destroy()`.
+
+### `sortGPUVector(keys)`
+
+Returns source row indices ordered by ascending `uint32` key value. Equal keys
+preserve source row order by comparing `(key, sourceRowIndex)` tuples.
+
+`keys` must be one packed contiguous `GPUVector<'uint32'>` chunk with `uint32`
+row storage on the sorter's device. Multi-chunk vectors are rejected instead of
+being packed implicitly. Non-power-of-two row counts are padded internally with
+invalid sentinels that sort after real rows.
+
+The returned vector owns its output buffer and should be destroyed by the caller.
+The input vector remains caller-owned and unchanged.
+
+### `destroy()`
+
+Releases scratch buffers owned by the sorter. Returned output vectors are
+caller-owned and are not destroyed by the sorter.
+
+## Input Contract
+
+| Requirement | Behavior |
+| --- | --- |
+| Device | `keys` must belong to the same WebGPU device passed to the sorter. |
+| Format | `keys.format` and its single `GPUData` chunk must be `uint32`. |
+| Storage | The one input chunk must be packed, aligned `uint32` row storage covering every vector row. |
+| Chunks | Exactly one contiguous input chunk is supported in v1. |
+| Length | Zero rows are valid; lengths above `0x80000000` rows are rejected. |
+
+## Ownership
+
+- The sorter owns reusable internal scratch buffers only.
+- The caller owns `keys` before and after sorting.
+- Each call returns a new caller-owned `GPUVector<'uint32'>`.
+- `destroy()` releases sorter scratch buffers but does not destroy prior outputs.

--- a/docs/api-reference/gpgpu/operations.md
+++ b/docs/api-reference/gpgpu/operations.md
@@ -8,6 +8,9 @@ This page is the top-level API reference for the lazy operations exported by `@l
 
 Each operation returns a new [`GPUDataEvaluator`](/docs/api-reference/gpgpu/gpu-data-evaluator). No GPU work is performed until that output table is evaluated.
 
+For final-result WebGPU argsort that returns sorted row indices directly as a
+`GPUVector<'uint32'>`, see [`BitonicArgsort`](/docs/api-reference/gpgpu/bitonic-argsort).
+
 ## Common Behavior
 
 - Each operation returns a new `GPUDataEvaluator`.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -169,6 +169,7 @@
           "api-reference/gpgpu/README",
           "api-reference/gpgpu/gpu-data-evaluator",
           "api-reference/gpgpu/operations",
+          "api-reference/gpgpu/bitonic-argsort",
           "api-reference/gpgpu/custom-operation",
           "api-reference/gpgpu/clean-evaluate"
         ]

--- a/examples/v10/gpgpu-bitonic-sort/index.html
+++ b/examples/v10/gpgpu-bitonic-sort/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<head>
+  <style>
+    :root {
+      color-scheme: light;
+      background: #f7f8fb;
+      color: #16202f;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    body {
+      margin: 0;
+      background: #f7f8fb;
+    }
+  </style>
+</head>
+<body>
+  <main id="bitonic-argsort-app"></main>
+  <script type="module">
+    import {initializeBitonicArgsortExample} from './src/app.ts';
+    initializeBitonicArgsortExample();
+  </script>
+</body>

--- a/examples/v10/gpgpu-bitonic-sort/package.json
+++ b/examples/v10/gpgpu-bitonic-sort/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "luma.gl-examples-v10-gpgpu-bitonic-sort",
+  "version": "9.3.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "vite",
+    "build": "tsc && vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "@luma.gl/arrow": "~9.3.0",
+    "@luma.gl/core": "~9.3.0",
+    "@luma.gl/engine": "~9.3.0",
+    "@luma.gl/gpgpu": "~9.3.0",
+    "@luma.gl/shadertools": "~9.3.0",
+    "@luma.gl/tables": "~9.3.0",
+    "@luma.gl/webgpu": "~9.3.0",
+    "apache-arrow": "^17.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/examples/v10/gpgpu-bitonic-sort/src/app.ts
+++ b/examples/v10/gpgpu-bitonic-sort/src/app.ts
@@ -1,0 +1,954 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {makeGPUVectorFromArrow} from '@luma.gl/arrow';
+import {luma, type Device} from '@luma.gl/core';
+import {BitonicArgsort} from '@luma.gl/gpgpu/webgpu';
+import {getGPUVectorData, type GPUVector} from '@luma.gl/tables';
+import {webgpuAdapter} from '@luma.gl/webgpu';
+import * as arrow from 'apache-arrow';
+
+const APP_ID = 'bitonic-argsort-app';
+const APP_CLASS_NAME = 'bitonic-argsort-example';
+const STYLE_ID = 'bitonic-argsort-example-style';
+const INVALID_INDEX = 0xffffffff;
+const ORIGINAL_SORT_KEYS = new Uint32Array([13, 3, 8, 3, 10, 1, 12, 6, 1, 15, 5, 10, 0, 7, 14, 4]);
+const STEP_INTERVAL_MILLISECONDS = 360;
+
+type BitonicArgsortArrowColumns = {
+  sortKey: arrow.Uint32;
+};
+
+type BitonicArgsortArrowTable = arrow.Table<BitonicArgsortArrowColumns>;
+
+type BitonicPass = {
+  blockWidth: number;
+  compareStride: number;
+};
+
+type BitonicPair = {
+  ascending: boolean;
+  leftPosition: number;
+  leftRowIndex: number;
+  rightPosition: number;
+  rightRowIndex: number;
+  swapped: boolean;
+};
+
+type BitonicArgsortExampleElements = {
+  arrowRows: HTMLElement;
+  currentPass: HTMLElement;
+  gpuOutput: HTMLElement;
+  gpuStatus: HTMLElement;
+  inputVector: HTMLElement;
+  outputVector: HTMLElement;
+  pairList: HTMLElement;
+  resetButton: HTMLButtonElement;
+  runButton: HTMLButtonElement;
+  sequence: HTMLElement;
+  shuffleButton: HTMLButtonElement;
+  sortedRows: HTMLElement;
+  status: HTMLElement;
+  stepButton: HTMLButtonElement;
+};
+
+/** Cleanup handle returned by {@link initializeBitonicArgsortExample}. */
+export type BitonicArgsortExampleHandle = {
+  /** Releases event handlers, GPU vectors, scratch buffers, and the example device. */
+  destroy: () => void;
+};
+
+/**
+ * Mounts the Arrow-backed BitonicArgsort teaching example into `#bitonic-argsort-app`.
+ *
+ * @returns Cleanup handle for the mounted example.
+ * @throws If the required root element is missing.
+ */
+export function initializeBitonicArgsortExample(): BitonicArgsortExampleHandle {
+  const root = document.getElementById(APP_ID);
+  if (!root) {
+    throw new Error(`Bitonic argsort example requires #${APP_ID}`);
+  }
+
+  ensureStyles();
+  root.classList.add(APP_CLASS_NAME);
+  root.innerHTML = BITONIC_ARGSORT_EXAMPLE_HTML;
+  const example = new BitonicArgsortExample(root);
+  void example.initialize();
+  return {destroy: () => example.destroy()};
+}
+
+class BitonicArgsortExample {
+  readonly root: HTMLElement;
+  readonly elements: BitonicArgsortExampleElements;
+
+  private arrowTable: BitonicArgsortArrowTable;
+  private currentRowIndices: number[];
+  private currentPassIndex = 0;
+  private device: Device | null = null;
+  private gpuRunVersion = 0;
+  private gpuSortKeys: GPUVector<'uint32'> | null = null;
+  private gpuSortedRowIndices: GPUVector<'uint32'> | null = null;
+  private isDestroyed = false;
+  private isRunning = false;
+  private lastAnimationTimestamp = 0;
+  private lastPairs: BitonicPair[] = [];
+  private requestAnimationFrameId: number | null = null;
+  private sortKeys: Uint32Array = ORIGINAL_SORT_KEYS.slice();
+  private sorter: BitonicArgsort | null = null;
+  private sortedRowIndices: number[] = [];
+
+  private readonly passes = makeBitonicPasses(ORIGINAL_SORT_KEYS.length);
+  private readonly handleReset = (): void => this.replaceSortKeys(ORIGINAL_SORT_KEYS.slice());
+  private readonly handleRun = (): void => {
+    if (this.currentPassIndex >= this.passes.length) {
+      this.resetVisualization();
+    }
+    void this.refreshGPUResult();
+    this.startAnimation();
+  };
+  private readonly handleShuffle = (): void => this.replaceSortKeys(shuffleSortKeys(this.sortKeys));
+  private readonly handleStep = (): void => {
+    this.stopAnimation();
+    this.step();
+  };
+
+  constructor(root: HTMLElement) {
+    this.root = root;
+    this.elements = getExampleElements(root);
+    this.arrowTable = makeArrowSortTable(this.sortKeys);
+    this.currentRowIndices = makeInitialRowIndices(this.sortKeys.length);
+    this.bindControls();
+    this.render();
+  }
+
+  async initialize(): Promise<void> {
+    this.setStatus('Requesting WebGPU device...');
+    try {
+      const device = await createWebGPUDevice();
+      if (this.isDestroyed) {
+        device.destroy();
+        return;
+      }
+
+      this.device = device;
+      this.sorter = new BitonicArgsort(device);
+      this.setStatus('Uploading Arrow Uint32 keys to GPU storage...');
+      await this.refreshGPUResult();
+    } catch (error) {
+      this.setStatus(getErrorMessage(error), true);
+    }
+  }
+
+  destroy(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+
+    this.isDestroyed = true;
+    this.stopAnimation();
+    this.elements.resetButton.removeEventListener('click', this.handleReset);
+    this.elements.runButton.removeEventListener('click', this.handleRun);
+    this.elements.shuffleButton.removeEventListener('click', this.handleShuffle);
+    this.elements.stepButton.removeEventListener('click', this.handleStep);
+    this.releaseGPUVectors();
+    this.sorter?.destroy();
+    this.sorter = null;
+    this.device?.destroy();
+    this.device = null;
+  }
+
+  private bindControls(): void {
+    this.elements.resetButton.addEventListener('click', this.handleReset);
+    this.elements.runButton.addEventListener('click', this.handleRun);
+    this.elements.shuffleButton.addEventListener('click', this.handleShuffle);
+    this.elements.stepButton.addEventListener('click', this.handleStep);
+  }
+
+  private replaceSortKeys(sortKeys: Uint32Array): void {
+    this.stopAnimation();
+    this.sortKeys = sortKeys;
+    this.arrowTable = makeArrowSortTable(this.sortKeys);
+    this.sortedRowIndices = [];
+    this.resetVisualization();
+    void this.refreshGPUResult();
+  }
+
+  private resetVisualization(): void {
+    this.currentPassIndex = 0;
+    this.currentRowIndices = makeInitialRowIndices(this.sortKeys.length);
+    this.lastPairs = [];
+    this.render();
+  }
+
+  private async refreshGPUResult(): Promise<void> {
+    if (!this.device || !this.sorter) {
+      this.render();
+      return;
+    }
+
+    const gpuRunVersion = ++this.gpuRunVersion;
+    this.elements.gpuStatus.textContent = 'Running BitonicArgsort.sortGPUVector()...';
+    this.renderControls();
+
+    let nextSortKeys: GPUVector<'uint32'> | null = null;
+    let nextSortedRowIndices: GPUVector<'uint32'> | null = null;
+    try {
+      const sortKeyVector = getRequiredSortKeyVector(this.arrowTable);
+      nextSortKeys = makeGPUVectorFromArrow(this.device, sortKeyVector, {
+        name: 'sortKeys',
+        format: 'uint32'
+      });
+      nextSortedRowIndices = this.sorter.sortGPUVector(nextSortKeys);
+      const sortedRowIndices = await readUint32GPUVector(nextSortedRowIndices);
+      if (this.isDestroyed || gpuRunVersion !== this.gpuRunVersion) {
+        nextSortedRowIndices.destroy();
+        nextSortKeys.destroy();
+        return;
+      }
+
+      this.releaseGPUVectors();
+      this.gpuSortKeys = nextSortKeys;
+      this.gpuSortedRowIndices = nextSortedRowIndices;
+      nextSortKeys = null;
+      nextSortedRowIndices = null;
+      this.sortedRowIndices = Array.from(sortedRowIndices);
+      this.elements.gpuStatus.textContent =
+        "GPU result materialized as GPUVector<'uint32'> row indices.";
+      this.setStatus('Arrow Uint32 keys uploaded and argsorted on WebGPU.');
+      this.render();
+    } catch (error) {
+      nextSortedRowIndices?.destroy();
+      nextSortKeys?.destroy();
+      this.elements.gpuStatus.textContent = getErrorMessage(error);
+      this.setStatus(getErrorMessage(error), true);
+    }
+  }
+
+  private releaseGPUVectors(): void {
+    this.gpuSortedRowIndices?.destroy();
+    this.gpuSortedRowIndices = null;
+    this.gpuSortKeys?.destroy();
+    this.gpuSortKeys = null;
+  }
+
+  private startAnimation(): void {
+    if (this.isRunning || this.currentPassIndex >= this.passes.length) {
+      return;
+    }
+
+    this.isRunning = true;
+    this.lastAnimationTimestamp = 0;
+    this.renderControls();
+    this.requestAnimationFrameId = window.requestAnimationFrame(timestamp =>
+      this.animate(timestamp)
+    );
+  }
+
+  private animate(timestamp: number): void {
+    if (!this.isRunning || this.isDestroyed) {
+      return;
+    }
+
+    if (
+      this.lastAnimationTimestamp === 0 ||
+      timestamp - this.lastAnimationTimestamp >= STEP_INTERVAL_MILLISECONDS
+    ) {
+      this.step();
+      this.lastAnimationTimestamp = timestamp;
+    }
+
+    if (this.isRunning) {
+      this.requestAnimationFrameId = window.requestAnimationFrame(nextTimestamp =>
+        this.animate(nextTimestamp)
+      );
+    }
+  }
+
+  private stopAnimation(): void {
+    if (this.requestAnimationFrameId !== null) {
+      window.cancelAnimationFrame(this.requestAnimationFrameId);
+      this.requestAnimationFrameId = null;
+    }
+    this.isRunning = false;
+    this.lastAnimationTimestamp = 0;
+    this.renderControls();
+  }
+
+  private step(): void {
+    const pass = this.passes[this.currentPassIndex];
+    if (!pass) {
+      this.stopAnimation();
+      return;
+    }
+
+    const {nextRowIndices, pairs} = applyBitonicPass(this.sortKeys, this.currentRowIndices, pass);
+    this.currentRowIndices = nextRowIndices;
+    this.lastPairs = pairs;
+    this.currentPassIndex++;
+    if (this.currentPassIndex >= this.passes.length) {
+      this.stopAnimation();
+    }
+    this.render();
+  }
+
+  private render(): void {
+    this.elements.arrowRows.textContent = String(this.arrowTable.numRows);
+    this.elements.inputVector.textContent = "GPUVector<'uint32'>";
+    this.elements.outputVector.textContent = "GPUVector<'uint32'>";
+    this.elements.currentPass.textContent = getPassLabel(
+      this.currentPassIndex,
+      this.passes,
+      this.lastPairs.length > 0
+    );
+    this.elements.gpuOutput.textContent =
+      this.sortedRowIndices.length === 0 ? 'Run pending' : `[${this.sortedRowIndices.join(', ')}]`;
+    this.elements.sortedRows.textContent =
+      this.sortedRowIndices.length === 0
+        ? 'Run pending'
+        : this.sortedRowIndices
+            .map(rowIndex => `row ${rowIndex}: key ${this.sortKeys[rowIndex]}`)
+            .join(' | ');
+    renderSequence(this.elements.sequence, this.sortKeys, this.currentRowIndices, this.lastPairs);
+    renderPairs(this.elements.pairList, this.sortKeys, this.lastPairs);
+    this.renderControls();
+  }
+
+  private renderControls(): void {
+    const hasDevice = Boolean(this.device && this.sorter);
+    const hasRemainingPasses = this.currentPassIndex < this.passes.length;
+    this.elements.runButton.disabled = !hasDevice || this.isRunning;
+    this.elements.runButton.textContent = this.isRunning ? 'Running' : 'Run';
+    this.elements.stepButton.disabled = !hasDevice || this.isRunning || !hasRemainingPasses;
+    this.elements.shuffleButton.disabled = !hasDevice || this.isRunning;
+    this.elements.resetButton.disabled = !hasDevice || this.isRunning;
+  }
+
+  private setStatus(message: string, isError = false): void {
+    this.elements.status.textContent = message;
+    this.elements.status.dataset['state'] = isError ? 'error' : 'ready';
+  }
+}
+
+async function createWebGPUDevice(): Promise<Device> {
+  return await luma.createDevice({
+    type: 'webgpu',
+    adapters: [webgpuAdapter],
+    createCanvasContext:
+      typeof OffscreenCanvas === 'undefined'
+        ? true
+        : {
+            canvas: new OffscreenCanvas(1, 1),
+            width: 1,
+            height: 1,
+            autoResize: false,
+            useDevicePixels: false
+          }
+  });
+}
+
+function getExampleElements(root: HTMLElement): BitonicArgsortExampleElements {
+  return {
+    arrowRows: getRequiredElement(root, '[data-arrow-rows]'),
+    currentPass: getRequiredElement(root, '[data-current-pass]'),
+    gpuOutput: getRequiredElement(root, '[data-gpu-output]'),
+    gpuStatus: getRequiredElement(root, '[data-gpu-status]'),
+    inputVector: getRequiredElement(root, '[data-input-vector]'),
+    outputVector: getRequiredElement(root, '[data-output-vector]'),
+    pairList: getRequiredElement(root, '[data-pair-list]'),
+    resetButton: getRequiredElement(root, '[data-reset]'),
+    runButton: getRequiredElement(root, '[data-run]'),
+    sequence: getRequiredElement(root, '[data-sequence]'),
+    shuffleButton: getRequiredElement(root, '[data-shuffle]'),
+    sortedRows: getRequiredElement(root, '[data-sorted-rows]'),
+    status: getRequiredElement(root, '[data-status]'),
+    stepButton: getRequiredElement(root, '[data-step]')
+  };
+}
+
+function getRequiredElement<T extends HTMLElement>(root: HTMLElement, selector: string): T {
+  const element = root.querySelector<T>(selector);
+  if (!element) {
+    throw new Error(`Bitonic argsort example is missing ${selector}`);
+  }
+  return element;
+}
+
+function makeArrowSortTable(sortKeys: Uint32Array): BitonicArgsortArrowTable {
+  return new arrow.Table<BitonicArgsortArrowColumns>({
+    sortKey: makeUint32Vector(sortKeys)
+  });
+}
+
+function makeUint32Vector(values: Uint32Array): arrow.Vector<arrow.Uint32> {
+  const type = new arrow.Uint32();
+  const data = new arrow.Data(type, 0, values.length, 0, {[arrow.BufferType.DATA]: values});
+  return new arrow.Vector([data]);
+}
+
+function getRequiredSortKeyVector(table: BitonicArgsortArrowTable): arrow.Vector<arrow.Uint32> {
+  const vector = table.getChild('sortKey');
+  if (
+    !vector ||
+    !arrow.DataType.isInt(vector.type) ||
+    vector.type.isSigned ||
+    vector.type.bitWidth !== 32
+  ) {
+    throw new Error('Bitonic argsort example requires an Arrow Uint32 sortKey column');
+  }
+  return vector as arrow.Vector<arrow.Uint32>;
+}
+
+async function readUint32GPUVector(vector: GPUVector<'uint32'>): Promise<Uint32Array> {
+  if (vector.length === 0) {
+    return new Uint32Array(0);
+  }
+
+  const data = getGPUVectorData(vector);
+  const bytes = await data.buffer.readAsync(
+    data.byteOffset,
+    vector.length * Uint32Array.BYTES_PER_ELEMENT
+  );
+  return new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length).slice();
+}
+
+function makeBitonicPasses(length: number): BitonicPass[] {
+  const passes: BitonicPass[] = [];
+  const paddedLength = getNextPowerOfTwo(length);
+  for (let blockWidth = 2; blockWidth <= paddedLength; blockWidth *= 2) {
+    for (let compareStride = blockWidth / 2; compareStride >= 1; compareStride /= 2) {
+      passes.push({blockWidth, compareStride});
+    }
+  }
+  return passes;
+}
+
+function applyBitonicPass(
+  sortKeys: Uint32Array,
+  currentRowIndices: number[],
+  pass: BitonicPass
+): {nextRowIndices: number[]; pairs: BitonicPair[]} {
+  const nextRowIndices = currentRowIndices.slice();
+  const pairs: BitonicPair[] = [];
+
+  for (let leftPosition = 0; leftPosition < currentRowIndices.length; leftPosition++) {
+    const rightPosition = leftPosition ^ pass.compareStride;
+    if (rightPosition <= leftPosition) {
+      continue;
+    }
+
+    const ascending = (leftPosition & pass.blockWidth) === 0;
+    const leftRowIndex = currentRowIndices[leftPosition];
+    const rightRowIndex = currentRowIndices[rightPosition];
+    const swapped = ascending
+      ? comesBefore(sortKeys, rightRowIndex, leftRowIndex)
+      : comesBefore(sortKeys, leftRowIndex, rightRowIndex);
+    if (swapped) {
+      nextRowIndices[leftPosition] = rightRowIndex;
+      nextRowIndices[rightPosition] = leftRowIndex;
+    }
+    pairs.push({ascending, leftPosition, leftRowIndex, rightPosition, rightRowIndex, swapped});
+  }
+
+  return {nextRowIndices, pairs};
+}
+
+function comesBefore(sortKeys: Uint32Array, leftRowIndex: number, rightRowIndex: number): boolean {
+  const leftValid = isValidRowIndex(sortKeys, leftRowIndex);
+  const rightValid = isValidRowIndex(sortKeys, rightRowIndex);
+  if (leftValid !== rightValid) {
+    return leftValid;
+  }
+  if (!leftValid) {
+    return false;
+  }
+
+  const leftKey = sortKeys[leftRowIndex];
+  const rightKey = sortKeys[rightRowIndex];
+  return leftKey < rightKey || (leftKey === rightKey && leftRowIndex < rightRowIndex);
+}
+
+function isValidRowIndex(sortKeys: Uint32Array, rowIndex: number): boolean {
+  return rowIndex !== INVALID_INDEX && rowIndex >= 0 && rowIndex < sortKeys.length;
+}
+
+function makeInitialRowIndices(length: number): number[] {
+  const paddedLength = getNextPowerOfTwo(length);
+  return Array.from({length: paddedLength}, (_, rowIndex) =>
+    rowIndex < length ? rowIndex : INVALID_INDEX
+  );
+}
+
+function getNextPowerOfTwo(length: number): number {
+  let paddedLength = 1;
+  while (paddedLength < Math.max(length, 1)) {
+    paddedLength *= 2;
+  }
+  return paddedLength;
+}
+
+function shuffleSortKeys(sortKeys: Uint32Array): Uint32Array {
+  const shuffledSortKeys = sortKeys.slice();
+  for (let rowIndex = shuffledSortKeys.length - 1; rowIndex > 0; rowIndex--) {
+    const swapIndex = Math.floor(Math.random() * (rowIndex + 1));
+    [shuffledSortKeys[rowIndex], shuffledSortKeys[swapIndex]] = [
+      shuffledSortKeys[swapIndex],
+      shuffledSortKeys[rowIndex]
+    ];
+  }
+  return shuffledSortKeys;
+}
+
+function getPassLabel(
+  currentPassIndex: number,
+  passes: BitonicPass[],
+  hasCompletedPass: boolean
+): string {
+  if (currentPassIndex >= passes.length) {
+    return `Complete (${passes.length}/${passes.length})`;
+  }
+
+  const passIndex = hasCompletedPass ? currentPassIndex - 1 : currentPassIndex;
+  const pass = passes[passIndex];
+  const passState = hasCompletedPass ? 'Completed' : 'Next';
+  return `${passState} ${passIndex + 1}/${passes.length}: block ${pass.blockWidth}, stride ${pass.compareStride}`;
+}
+
+function renderSequence(
+  sequence: HTMLElement,
+  sortKeys: Uint32Array,
+  rowIndices: number[],
+  pairs: BitonicPair[]
+): void {
+  const highlightedPositions = new Set<number>();
+  const swappedPositions = new Set<number>();
+  for (const pair of pairs) {
+    highlightedPositions.add(pair.leftPosition);
+    highlightedPositions.add(pair.rightPosition);
+    if (pair.swapped) {
+      swappedPositions.add(pair.leftPosition);
+      swappedPositions.add(pair.rightPosition);
+    }
+  }
+
+  const maximumKey = sortKeys.reduce(
+    (currentMaximumKey, sortKey) => Math.max(currentMaximumKey, sortKey),
+    1
+  );
+  const fragment = document.createDocumentFragment();
+  for (let position = 0; position < rowIndices.length; position++) {
+    const rowIndex = rowIndices[position];
+    const cell = document.createElement('div');
+    cell.className = 'sort-cell';
+    if (highlightedPositions.has(position)) {
+      cell.classList.add('sort-cell--compared');
+    }
+    if (swappedPositions.has(position)) {
+      cell.classList.add('sort-cell--swapped');
+    }
+
+    const key = isValidRowIndex(sortKeys, rowIndex) ? sortKeys[rowIndex] : 0;
+    cell.style.setProperty('--bar-height', `${Math.max((key / maximumKey) * 100, 8)}%`);
+    cell.appendChild(makeElement('div', 'sort-bar'));
+    cell.appendChild(
+      makeElement('strong', 'sort-key', isValidRowIndex(sortKeys, rowIndex) ? String(key) : '-')
+    );
+    cell.appendChild(
+      makeElement(
+        'span',
+        'sort-row',
+        isValidRowIndex(sortKeys, rowIndex) ? `row ${rowIndex}` : 'pad'
+      )
+    );
+    fragment.appendChild(cell);
+  }
+  sequence.replaceChildren(fragment);
+}
+
+function renderPairs(pairList: HTMLElement, sortKeys: Uint32Array, pairs: BitonicPair[]): void {
+  if (pairs.length === 0) {
+    pairList.textContent = 'Step to expose compare/swap pairs.';
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  for (const pair of pairs) {
+    const direction = pair.ascending ? 'ascending' : 'descending';
+    const action = pair.swapped ? 'swap' : 'keep';
+    fragment.appendChild(
+      makeElement(
+        'div',
+        `pair ${pair.swapped ? 'pair--swapped' : ''}`,
+        `${pair.leftPosition} <-> ${pair.rightPosition} ${direction}: ${formatRowKey(sortKeys, pair.leftRowIndex)} / ${formatRowKey(sortKeys, pair.rightRowIndex)} ${action}`
+      )
+    );
+  }
+  pairList.replaceChildren(fragment);
+}
+
+function formatRowKey(sortKeys: Uint32Array, rowIndex: number): string {
+  return isValidRowIndex(sortKeys, rowIndex)
+    ? `row ${rowIndex} key ${sortKeys[rowIndex]}`
+    : 'padding';
+}
+
+function makeElement<K extends keyof HTMLElementTagNameMap>(
+  tagName: K,
+  className: string,
+  textContent?: string
+): HTMLElementTagNameMap[K] {
+  const element = document.createElement(tagName);
+  element.className = className;
+  if (textContent !== undefined) {
+    element.textContent = textContent;
+  }
+  return element;
+}
+
+function ensureStyles(): void {
+  if (document.getElementById(STYLE_ID)) {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = BITONIC_ARGSORT_EXAMPLE_STYLE;
+  document.head.appendChild(style);
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Static markup for the BitonicArgsort teaching example. */
+export const BITONIC_ARGSORT_EXAMPLE_HTML = `
+  <header class="bitonic-header">
+    <p class="bitonic-eyebrow">@luma.gl/gpgpu/webgpu</p>
+    <h1>Bitonic argsort</h1>
+    <p class="bitonic-subtitle">
+      An Apache Arrow Uint32 sortKey column uploads to GPU storage, then BitonicArgsort returns stable source row indices as GPUVector&lt;'uint32'&gt;.
+    </p>
+  </header>
+
+  <section class="metric-grid" aria-label="Bitonic argsort metadata">
+    <div class="metric">
+      <span>Arrow rows</span>
+      <strong data-arrow-rows>-</strong>
+    </div>
+    <div class="metric">
+      <span>Input vector</span>
+      <strong data-input-vector>-</strong>
+    </div>
+    <div class="metric">
+      <span>Output vector</span>
+      <strong data-output-vector>-</strong>
+    </div>
+    <div class="metric">
+      <span>Network pass</span>
+      <strong data-current-pass>-</strong>
+    </div>
+  </section>
+
+  <section class="toolbar" aria-label="Bitonic argsort controls">
+    <button type="button" data-shuffle>Shuffle</button>
+    <button type="button" data-step>Step</button>
+    <button type="button" data-run>Run</button>
+    <button type="button" data-reset>Reset</button>
+    <p data-status>Preparing example...</p>
+  </section>
+
+  <section class="sort-stage" aria-label="Bitonic sort network visualization">
+    <div class="stage-header">
+      <h2>Current network state</h2>
+      <p data-gpu-status>Waiting for WebGPU...</p>
+    </div>
+    <div class="sort-sequence" data-sequence></div>
+    <div class="pair-list" data-pair-list></div>
+  </section>
+
+  <section class="output-grid" aria-label="Bitonic argsort output">
+    <div class="output-panel">
+      <h2>GPUVector output</h2>
+      <code data-gpu-output>Run pending</code>
+    </div>
+    <div class="output-panel">
+      <h2>Sorted rows</h2>
+      <p data-sorted-rows>Run pending</p>
+    </div>
+  </section>
+`;
+
+/** Example-local styles for the BitonicArgsort teaching example. */
+export const BITONIC_ARGSORT_EXAMPLE_STYLE = `
+  .bitonic-argsort-example {
+    box-sizing: border-box;
+    min-height: 100%;
+    padding: 22px;
+    background: #f7f8fb;
+    color: #16202f;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+
+  .bitonic-argsort-example * {
+    box-sizing: border-box;
+  }
+
+  .bitonic-argsort-example h1,
+  .bitonic-argsort-example h2,
+  .bitonic-argsort-example p {
+    margin: 0;
+  }
+
+  .bitonic-argsort-example .bitonic-header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 7px;
+    margin-bottom: 16px;
+  }
+
+  .bitonic-argsort-example .bitonic-eyebrow {
+    color: #4b6b9b;
+    font-size: 12px;
+    font-weight: 720;
+    text-transform: uppercase;
+  }
+
+  .bitonic-argsort-example h1 {
+    font-size: 28px;
+    line-height: 1.1;
+  }
+
+  .bitonic-argsort-example .bitonic-subtitle {
+    max-width: 900px;
+    color: #5b6678;
+    font-size: 14px;
+    line-height: 1.45;
+  }
+
+  .bitonic-argsort-example .metric-grid,
+  .bitonic-argsort-example .output-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .bitonic-argsort-example .metric,
+  .bitonic-argsort-example .sort-stage,
+  .bitonic-argsort-example .output-panel {
+    border: 1px solid #d9dee8;
+    border-radius: 8px;
+    background: #fff;
+  }
+
+  .bitonic-argsort-example .metric {
+    padding: 10px 12px;
+  }
+
+  .bitonic-argsort-example .metric span,
+  .bitonic-argsort-example .stage-header p,
+  .bitonic-argsort-example .toolbar p,
+  .bitonic-argsort-example .sort-row,
+  .bitonic-argsort-example .pair,
+  .bitonic-argsort-example .output-panel p {
+    color: #697386;
+    font-size: 12px;
+  }
+
+  .bitonic-argsort-example .metric strong {
+    display: block;
+    margin-top: 3px;
+    overflow-wrap: anywhere;
+    font-size: 14px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .bitonic-argsort-example .toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 14px 0;
+  }
+
+  .bitonic-argsort-example button {
+    border: 1px solid #cfd6e2;
+    border-radius: 8px;
+    background: #fff;
+    color: inherit;
+    cursor: pointer;
+    font: 600 13px/1.2 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    padding: 9px 12px;
+  }
+
+  .bitonic-argsort-example button:hover:not(:disabled) {
+    background: #eef4ff;
+    border-color: #9db6df;
+  }
+
+  .bitonic-argsort-example button:disabled {
+    color: #8b95a5;
+    cursor: default;
+  }
+
+  .bitonic-argsort-example .toolbar p {
+    min-width: 0;
+    margin-left: 6px;
+    line-height: 1.35;
+  }
+
+  .bitonic-argsort-example .toolbar p[data-state="error"] {
+    color: #b42318;
+  }
+
+  .bitonic-argsort-example .sort-stage {
+    padding: 14px;
+  }
+
+  .bitonic-argsort-example .stage-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .bitonic-argsort-example h2 {
+    font-size: 15px;
+    line-height: 1.25;
+  }
+
+  .bitonic-argsort-example .sort-sequence {
+    display: grid;
+    grid-template-columns: repeat(16, minmax(0, 1fr));
+    gap: 7px;
+    align-items: end;
+    min-height: 204px;
+    padding: 10px;
+    border: 1px solid #e4e8f0;
+    border-radius: 8px;
+    background: #fbfcfe;
+  }
+
+  .bitonic-argsort-example .sort-cell {
+    display: grid;
+    min-width: 0;
+    min-height: 176px;
+    align-content: end;
+    gap: 5px;
+    border: 1px solid #d7deea;
+    border-radius: 8px;
+    background: #fff;
+    padding: 7px;
+    transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+  }
+
+  .bitonic-argsort-example .sort-cell--compared {
+    border-color: #4f7ac6;
+    background: #eef4ff;
+  }
+
+  .bitonic-argsort-example .sort-cell--swapped {
+    border-color: #0f8a5f;
+    background: #eaf8f1;
+    transform: translateY(-4px);
+  }
+
+  .bitonic-argsort-example .sort-bar {
+    height: var(--bar-height);
+    min-height: 10px;
+    border-radius: 6px 6px 3px 3px;
+    background: linear-gradient(180deg, #5f8bd2 0%, #294c88 100%);
+  }
+
+  .bitonic-argsort-example .sort-key {
+    font-size: 15px;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+  }
+
+  .bitonic-argsort-example .sort-row {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .bitonic-argsort-example .pair-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 7px;
+    margin-top: 12px;
+  }
+
+  .bitonic-argsort-example .pair {
+    border: 1px solid #e4e8f0;
+    border-radius: 7px;
+    background: #fbfcfe;
+    padding: 7px 8px;
+    font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+    line-height: 1.35;
+  }
+
+  .bitonic-argsort-example .pair--swapped {
+    border-color: #a7dfc7;
+    background: #f0fbf6;
+    color: #126346;
+  }
+
+  .bitonic-argsort-example .output-grid {
+    grid-template-columns: minmax(0, 0.9fr) minmax(260px, 1.1fr);
+    margin-top: 12px;
+  }
+
+  .bitonic-argsort-example .output-panel {
+    min-width: 0;
+    padding: 12px;
+  }
+
+  .bitonic-argsort-example .output-panel code,
+  .bitonic-argsort-example .output-panel p {
+    display: block;
+    margin-top: 8px;
+    overflow-wrap: anywhere;
+    font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+  }
+
+  @media (max-width: 900px) {
+    .bitonic-argsort-example {
+      padding: 14px;
+    }
+
+    .bitonic-argsort-example .metric-grid,
+    .bitonic-argsort-example .output-grid,
+    .bitonic-argsort-example .pair-list {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .bitonic-argsort-example .toolbar,
+    .bitonic-argsort-example .stage-header {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .bitonic-argsort-example .toolbar p {
+      margin-left: 0;
+    }
+
+    .bitonic-argsort-example .sort-sequence {
+      grid-template-columns: repeat(8, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 560px) {
+    .bitonic-argsort-example .metric-grid,
+    .bitonic-argsort-example .output-grid,
+    .bitonic-argsort-example .pair-list {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .bitonic-argsort-example .sort-sequence {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+`;

--- a/examples/v10/gpgpu-bitonic-sort/tsconfig.json
+++ b/examples/v10/gpgpu-bitonic-sort/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  "compilerOptions": {
+    "baseUrl": "../../..",
+    "typeRoots": ["../../../node_modules/@webgpu/types", "../../../node_modules/@types"],
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": false,
+    "paths": {
+      "@luma.gl/arrow": ["modules/arrow/src/index.ts"],
+      "@luma.gl/arrow/*": ["modules/arrow/src/*"],
+      "@luma.gl/core": ["modules/core/src/index.ts"],
+      "@luma.gl/core/*": ["modules/core/src/*"],
+      "@luma.gl/engine": ["modules/engine/src/index.ts"],
+      "@luma.gl/engine/*": ["modules/engine/src/*"],
+      "@luma.gl/gpgpu": ["modules/gpgpu/src/index.ts"],
+      "@luma.gl/gpgpu/*": ["modules/gpgpu/src/*"],
+      "@luma.gl/shadertools": ["modules/shadertools/src/index.ts"],
+      "@luma.gl/shadertools/*": ["modules/shadertools/src/*"],
+      "@luma.gl/tables": ["modules/tables/src/index.ts"],
+      "@luma.gl/tables/*": ["modules/tables/src/*"],
+      "@luma.gl/webgpu": ["modules/webgpu/src/index.ts"],
+      "@luma.gl/webgpu/*": ["modules/webgpu/src/*"]
+    }
+  },
+  "include": ["."]
+}

--- a/examples/v10/gpgpu-bitonic-sort/vite.config.ts
+++ b/examples/v10/gpgpu-bitonic-sort/vite.config.ts
@@ -1,0 +1,22 @@
+import {defineConfig} from 'vite';
+
+const alias = {
+  '@luma.gl/arrow': `${__dirname}/../../../modules/arrow/src`,
+  '@math.gl/geoarrow': `${__dirname}/../../../modules/geoarrow/src`,
+  '@luma.gl/core': `${__dirname}/../../../modules/core/src`,
+  '@luma.gl/engine': `${__dirname}/../../../modules/engine/src`,
+  '@luma.gl/experimental': `${__dirname}/../../../modules/experimental/src`,
+  '@luma.gl/gltf': `${__dirname}/../../../modules/gltf/src`,
+  '@luma.gl/gpgpu': `${__dirname}/../../../modules/gpgpu/src`,
+  '@luma.gl/shadertools': `${__dirname}/../../../modules/shadertools/src`,
+  '@luma.gl/tables': `${__dirname}/../../../modules/tables/src`,
+  '@luma.gl/text': `${__dirname}/../../../modules/text/src`,
+  '@luma.gl/webgl/constants': `${__dirname}/../../../modules/webgl/src/constants`,
+  '@luma.gl/webgl': `${__dirname}/../../../modules/webgl/src`,
+  '@luma.gl/webgpu': `${__dirname}/../../../modules/webgpu/src`
+};
+
+export default defineConfig({
+  resolve: {alias},
+  server: {open: true}
+});

--- a/modules/gpgpu/src/operation/backend-registry.ts
+++ b/modules/gpgpu/src/operation/backend-registry.ts
@@ -6,8 +6,13 @@ import {log} from '@luma.gl/core';
 import type {OperationHandler} from './operation';
 import * as cpuBackend from '../operations/cpu/index';
 
-/** Map from operation names to backend-specific operation handlers. */
-export type BackendModule = Record<string, OperationHandler>;
+/**
+ * Backend endpoint exports keyed by operation name, plus optional endpoint-specific helpers.
+ *
+ * Lazy operation lookup resolves only the requested operation name. Direct endpoint helpers such
+ * as `BitonicArgsort` can share the endpoint without being registered as lazy operations.
+ */
+export type BackendModule = Record<string, unknown>;
 
 /**
  * Registry for operation backends keyed by luma.gl device type.
@@ -59,10 +64,11 @@ class BackendRegistry {
       }
     }
     const resolvedModule = await module;
-    if (!(operationName in resolvedModule)) {
+    const operationHandler = resolvedModule[operationName];
+    if (typeof operationHandler !== 'function') {
       throw new Error(`${deviceType} backend does not implement ${operationName}`);
     }
-    return resolvedModule[operationName];
+    return operationHandler as OperationHandler;
   }
 
   /** Removes all registered backend modules. Primarily intended for tests. */

--- a/modules/gpgpu/src/operations/webgpu/bitonic-argsort.ts
+++ b/modules/gpgpu/src/operations/webgpu/bitonic-argsort.ts
@@ -1,0 +1,440 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type ComputePass, type Device} from '@luma.gl/core';
+import {Computation, DynamicBuffer} from '@luma.gl/engine';
+import {GPUVector, getGPUVectorData} from '@luma.gl/tables';
+import {getWebGPUDispatchLayout, getWebGPUDispatchRowIndex} from './common/dispatch';
+
+const BITONIC_WORKGROUP_SIZE = 64;
+const INVALID_INDEX = 0xffffffff;
+const MAXIMUM_LOGICAL_LENGTH = 0x80000000;
+const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
+const BITONIC_BUFFER_USAGE = Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC;
+
+type BitonicArgsortStage = {
+  blockWidth: number;
+  compareStride: number;
+};
+
+/**
+ * WebGPU-only stable argsort for one packed `GPUVector<'uint32'>`.
+ *
+ * @remarks
+ * `BitonicArgsort` sorts `(key, sourceRowIndex)` tuples in ascending order, so equal keys keep
+ * their original row order. The helper is final-result oriented: it returns sorted source row
+ * indices and keeps bitonic scratch buffers internal for reuse across calls.
+ *
+ * The helper is intentionally Arrow-agnostic. Use `@luma.gl/arrow` adapters before calling this
+ * class when the source keys start as an Arrow vector.
+ */
+export class BitonicArgsort {
+  /** WebGPU device used for compute dispatch and owned scratch buffers. */
+  readonly device: Device;
+
+  private scratchBuffers: [Buffer, Buffer] | null = null;
+  private scratchPaddedLength = 0;
+  private isDestroyed = false;
+
+  /**
+   * Creates one reusable bitonic argsort helper for a WebGPU device.
+   *
+   * @param device - WebGPU device that owns input, scratch, and output buffers.
+   * @throws If `device` is not a WebGPU device.
+   */
+  constructor(device: Device) {
+    if (device.type !== 'webgpu') {
+      throw new Error('BitonicArgsort requires a WebGPU device');
+    }
+
+    this.device = device;
+  }
+
+  /**
+   * Returns source row indices ordered by ascending `uint32` key value.
+   *
+   * @remarks
+   * Equal keys keep their source row order. Non-power-of-two row counts are padded internally
+   * with invalid sentinels that sort after real rows. The returned vector owns its output buffer;
+   * destroying the sorter does not destroy previously returned vectors.
+   *
+   * @param keys - One contiguous packed `GPUVector<'uint32'>` chunk on this sorter's device.
+   * @returns Caller-owned `GPUVector<'uint32'>` containing stable sorted source row indices.
+   * @throws If the sorter has been destroyed or `keys` is not one packed, aligned, same-device
+   * `uint32` chunk covering every vector row.
+   */
+  sortGPUVector(keys: GPUVector<'uint32'>): GPUVector<'uint32'> {
+    this.assertUsable();
+    const input = getPackedUint32Input(keys, this.device);
+    const outputBuffer = this.device.createBuffer({
+      id: `${keys.name}-sorted-row-indices`,
+      byteLength: Math.max(keys.length, 1) * UINT32_BYTE_LENGTH,
+      usage: BITONIC_BUFFER_USAGE
+    });
+    const output = new GPUVector({
+      type: 'buffer',
+      name: `${keys.name}-sorted-row-indices`,
+      buffer: outputBuffer,
+      format: 'uint32',
+      length: keys.length,
+      ownsBuffer: true
+    });
+
+    if (keys.length === 0) {
+      return output;
+    }
+
+    const paddedLength = getNextPowerOfTwo(keys.length);
+    const scratchBuffers = this.getScratchBuffers(paddedLength);
+    const dispatchLayout = getWebGPUDispatchLayout(
+      Math.ceil(paddedLength / BITONIC_WORKGROUP_SIZE),
+      this.device.limits.maxComputeWorkgroupsPerDimension
+    );
+    const computations: Computation[] = [];
+
+    try {
+      const initializeComputation = makeInitializeComputation(
+        this.device,
+        keys.length,
+        paddedLength,
+        dispatchLayout
+      );
+      computations.push(initializeComputation);
+
+      const stages = getBitonicArgsortStages(paddedLength);
+      for (const stage of stages) {
+        computations.push(
+          makeSortStageComputation(this.device, {
+            dispatchLayout,
+            keysByteOffset: input.keysByteOffset,
+            logicalLength: keys.length,
+            paddedLength,
+            stage
+          })
+        );
+      }
+
+      const copyComputation = makeCopyComputation(this.device, keys.length, dispatchLayout);
+      computations.push(copyComputation);
+
+      const computePass = this.device.beginComputePass({});
+      try {
+        dispatchComputation(initializeComputation, computePass, dispatchLayout, {
+          indicesOut: scratchBuffers[0]
+        });
+
+        let currentIndices = scratchBuffers[0];
+        let nextIndices = scratchBuffers[1];
+        for (let stageIndex = 0; stageIndex < stages.length; stageIndex++) {
+          const stageComputation = computations[stageIndex + 1];
+          dispatchComputation(stageComputation, computePass, dispatchLayout, {
+            keys: input.buffer,
+            indicesIn: currentIndices,
+            indicesOut: nextIndices
+          });
+          [currentIndices, nextIndices] = [nextIndices, currentIndices];
+        }
+
+        dispatchComputation(copyComputation, computePass, dispatchLayout, {
+          indicesIn: currentIndices,
+          indicesOut: outputBuffer
+        });
+      } finally {
+        computePass.end();
+      }
+      this.device.submit();
+    } catch (error) {
+      output.destroy();
+      throw error;
+    } finally {
+      for (const computation of computations) {
+        computation.destroy();
+      }
+    }
+
+    return output;
+  }
+
+  /**
+   * Releases scratch buffers owned by this sorter.
+   *
+   * @remarks
+   * Calling `destroy()` more than once is a no-op. Output vectors returned by
+   * {@link BitonicArgsort.sortGPUVector} remain caller-owned.
+   */
+  destroy(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+
+    this.destroyScratchBuffers();
+    this.isDestroyed = true;
+  }
+
+  private assertUsable(): void {
+    if (this.isDestroyed) {
+      throw new Error('BitonicArgsort has been destroyed');
+    }
+  }
+
+  private getScratchBuffers(paddedLength: number): [Buffer, Buffer] {
+    if (this.scratchBuffers && this.scratchPaddedLength >= paddedLength) {
+      return this.scratchBuffers;
+    }
+
+    this.destroyScratchBuffers();
+    const byteLength = paddedLength * UINT32_BYTE_LENGTH;
+    this.scratchBuffers = [
+      this.device.createBuffer({
+        id: 'bitonic-argsort-indices-a',
+        byteLength,
+        usage: BITONIC_BUFFER_USAGE
+      }),
+      this.device.createBuffer({
+        id: 'bitonic-argsort-indices-b',
+        byteLength,
+        usage: BITONIC_BUFFER_USAGE
+      })
+    ];
+    this.scratchPaddedLength = paddedLength;
+    return this.scratchBuffers;
+  }
+
+  private destroyScratchBuffers(): void {
+    if (!this.scratchBuffers) {
+      return;
+    }
+
+    for (const buffer of this.scratchBuffers) {
+      buffer.destroy();
+    }
+    this.scratchBuffers = null;
+    this.scratchPaddedLength = 0;
+  }
+}
+
+function getPackedUint32Input(
+  keys: GPUVector<'uint32'>,
+  device: Device
+): {buffer: Buffer; keysByteOffset: number} {
+  if (!Number.isSafeInteger(keys.length) || keys.length < 0) {
+    throw new Error('BitonicArgsort.sortGPUVector() requires a non-negative safe integer length');
+  }
+  if (keys.length > MAXIMUM_LOGICAL_LENGTH) {
+    throw new Error(
+      `BitonicArgsort.sortGPUVector() supports at most ${MAXIMUM_LOGICAL_LENGTH} rows`
+    );
+  }
+  if (keys.format !== 'uint32') {
+    throw new Error('BitonicArgsort.sortGPUVector() requires GPUVector<"uint32"> keys');
+  }
+
+  const data = getGPUVectorData(keys);
+  if (
+    data.format !== 'uint32' ||
+    data.stride !== 1 ||
+    data.byteStride !== UINT32_BYTE_LENGTH ||
+    data.rowByteLength !== UINT32_BYTE_LENGTH
+  ) {
+    throw new Error('BitonicArgsort.sortGPUVector() requires packed uint32 key storage');
+  }
+  if (data.length !== keys.length) {
+    throw new Error('BitonicArgsort.sortGPUVector() key chunk must cover every vector row');
+  }
+  if (data.byteOffset % UINT32_BYTE_LENGTH !== 0) {
+    throw new Error('BitonicArgsort.sortGPUVector() requires uint32-aligned key storage');
+  }
+
+  const buffer = getCoreBuffer(data.buffer);
+  if (buffer.device !== device) {
+    throw new Error('BitonicArgsort.sortGPUVector() keys must belong to the sorter device');
+  }
+  const requiredByteLength = data.byteOffset + keys.length * UINT32_BYTE_LENGTH;
+  if (requiredByteLength > buffer.byteLength) {
+    throw new Error('BitonicArgsort.sortGPUVector() key storage is smaller than vector length');
+  }
+
+  return {buffer, keysByteOffset: data.byteOffset / UINT32_BYTE_LENGTH};
+}
+
+function getCoreBuffer(buffer: Buffer | DynamicBuffer): Buffer {
+  return buffer instanceof DynamicBuffer ? buffer.buffer : buffer;
+}
+
+function getNextPowerOfTwo(length: number): number {
+  let paddedLength = 1;
+  while (paddedLength < length) {
+    paddedLength *= 2;
+  }
+  return paddedLength;
+}
+
+function getBitonicArgsortStages(paddedLength: number): BitonicArgsortStage[] {
+  const stages: BitonicArgsortStage[] = [];
+  for (let blockWidth = 2; blockWidth <= paddedLength; blockWidth *= 2) {
+    for (let compareStride = blockWidth / 2; compareStride >= 1; compareStride /= 2) {
+      stages.push({blockWidth, compareStride});
+    }
+  }
+  return stages;
+}
+
+function makeInitializeComputation(
+  device: Device,
+  logicalLength: number,
+  paddedLength: number,
+  dispatchLayout: ReturnType<typeof getWebGPUDispatchLayout>
+): Computation {
+  return new Computation(device, {
+    id: 'bitonic-argsort-initialize',
+    source: /* wgsl */ `
+const INVALID_INDEX: u32 = ${INVALID_INDEX}u;
+const LOGICAL_LENGTH: u32 = ${logicalLength}u;
+const PADDED_LENGTH: u32 = ${paddedLength}u;
+@group(0) @binding(0) var<storage, read_write> indicesOut: array<u32>;
+
+@compute @workgroup_size(${BITONIC_WORKGROUP_SIZE}) fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>
+) {
+  let rowIndex = ${getWebGPUDispatchRowIndex(dispatchLayout, BITONIC_WORKGROUP_SIZE)};
+  if (rowIndex >= PADDED_LENGTH) {
+    return;
+  }
+
+  indicesOut[rowIndex] = select(INVALID_INDEX, rowIndex, rowIndex < LOGICAL_LENGTH);
+}
+`,
+    shaderLayout: {
+      bindings: [{name: 'indicesOut', type: 'storage', group: 0, location: 0}]
+    }
+  });
+}
+
+function makeSortStageComputation(
+  device: Device,
+  {
+    dispatchLayout,
+    keysByteOffset,
+    logicalLength,
+    paddedLength,
+    stage
+  }: {
+    dispatchLayout: ReturnType<typeof getWebGPUDispatchLayout>;
+    keysByteOffset: number;
+    logicalLength: number;
+    paddedLength: number;
+    stage: BitonicArgsortStage;
+  }
+): Computation {
+  return new Computation(device, {
+    id: `bitonic-argsort-sort-${stage.blockWidth}-${stage.compareStride}`,
+    source: /* wgsl */ `
+const INVALID_INDEX: u32 = ${INVALID_INDEX}u;
+const KEY_ROW_OFFSET: u32 = ${keysByteOffset}u;
+const LOGICAL_LENGTH: u32 = ${logicalLength}u;
+const PADDED_LENGTH: u32 = ${paddedLength}u;
+const BLOCK_WIDTH: u32 = ${stage.blockWidth}u;
+const COMPARE_STRIDE: u32 = ${stage.compareStride}u;
+@group(0) @binding(0) var<storage, read> keys: array<u32>;
+@group(0) @binding(1) var<storage, read> indicesIn: array<u32>;
+@group(0) @binding(2) var<storage, read_write> indicesOut: array<u32>;
+
+fn is_valid_index(index: u32) -> bool {
+  return index != INVALID_INDEX && index < LOGICAL_LENGTH;
+}
+
+fn comes_before(leftIndex: u32, rightIndex: u32) -> bool {
+  let leftValid = is_valid_index(leftIndex);
+  let rightValid = is_valid_index(rightIndex);
+  if (leftValid != rightValid) {
+    return leftValid;
+  }
+  if (!leftValid) {
+    return false;
+  }
+
+  let leftKey = keys[KEY_ROW_OFFSET + leftIndex];
+  let rightKey = keys[KEY_ROW_OFFSET + rightIndex];
+  return leftKey < rightKey || (leftKey == rightKey && leftIndex < rightIndex);
+}
+
+@compute @workgroup_size(${BITONIC_WORKGROUP_SIZE}) fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>
+) {
+  let rowIndex = ${getWebGPUDispatchRowIndex(dispatchLayout, BITONIC_WORKGROUP_SIZE)};
+  if (rowIndex >= PADDED_LENGTH) {
+    return;
+  }
+
+  let partnerIndex = rowIndex ^ COMPARE_STRIDE;
+  if (partnerIndex <= rowIndex) {
+    return;
+  }
+
+  let leftIndex = indicesIn[rowIndex];
+  let rightIndex = indicesIn[partnerIndex];
+  let ascending = (rowIndex & BLOCK_WIDTH) == 0u;
+  let shouldSwap = select(
+    comes_before(leftIndex, rightIndex),
+    comes_before(rightIndex, leftIndex),
+    ascending
+  );
+  indicesOut[rowIndex] = select(leftIndex, rightIndex, shouldSwap);
+  indicesOut[partnerIndex] = select(rightIndex, leftIndex, shouldSwap);
+}
+`,
+    shaderLayout: {
+      bindings: [
+        {name: 'keys', type: 'read-only-storage', group: 0, location: 0},
+        {name: 'indicesIn', type: 'read-only-storage', group: 0, location: 1},
+        {name: 'indicesOut', type: 'storage', group: 0, location: 2}
+      ]
+    }
+  });
+}
+
+function makeCopyComputation(
+  device: Device,
+  logicalLength: number,
+  dispatchLayout: ReturnType<typeof getWebGPUDispatchLayout>
+): Computation {
+  return new Computation(device, {
+    id: 'bitonic-argsort-copy',
+    source: /* wgsl */ `
+const LOGICAL_LENGTH: u32 = ${logicalLength}u;
+@group(0) @binding(0) var<storage, read> indicesIn: array<u32>;
+@group(0) @binding(1) var<storage, read_write> indicesOut: array<u32>;
+
+@compute @workgroup_size(${BITONIC_WORKGROUP_SIZE}) fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>
+) {
+  let rowIndex = ${getWebGPUDispatchRowIndex(dispatchLayout, BITONIC_WORKGROUP_SIZE)};
+  if (rowIndex >= LOGICAL_LENGTH) {
+    return;
+  }
+
+  indicesOut[rowIndex] = indicesIn[rowIndex];
+}
+`,
+    shaderLayout: {
+      bindings: [
+        {name: 'indicesIn', type: 'read-only-storage', group: 0, location: 0},
+        {name: 'indicesOut', type: 'storage', group: 0, location: 1}
+      ]
+    }
+  });
+}
+
+function dispatchComputation(
+  computation: Computation,
+  computePass: ComputePass,
+  dispatchLayout: ReturnType<typeof getWebGPUDispatchLayout>,
+  bindings: Parameters<Computation['setBindings']>[0]
+): void {
+  computation.setBindings(bindings);
+  computation.dispatch(computePass, dispatchLayout.x, dispatchLayout.y, dispatchLayout.z);
+}

--- a/modules/gpgpu/src/operations/webgpu/index.ts
+++ b/modules/gpgpu/src/operations/webgpu/index.ts
@@ -1,4 +1,5 @@
 import {arithmetic} from './arithmetic';
+import {BitonicArgsort} from './bitonic-argsort';
 import {dot} from './dot';
 import {equalAll} from './equal-all';
 import {extent} from './extent';
@@ -11,9 +12,10 @@ import {select} from './select';
 import {sequence} from './sequence';
 import {swizzle} from './swizzle';
 
-/** WebGPU backend for built-in GPGPU operations, implemented with compute pipelines. */
+/** WebGPU backend handlers and direct WebGPU-only GPGPU helpers. */
 export {
   arithmetic,
+  BitonicArgsort,
   dot,
   equalAll,
   extent,

--- a/modules/gpgpu/src/webgpu.ts
+++ b/modules/gpgpu/src/webgpu.ts
@@ -1,0 +1,6 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** WebGPU GPGPU backend handlers and direct WebGPU-only helpers. */
+export * from './operations/webgpu/index';

--- a/modules/gpgpu/test/gpu-vector/bitonic-argsort.spec.ts
+++ b/modules/gpgpu/test/gpu-vector/bitonic-argsort.spec.ts
@@ -1,0 +1,203 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {BitonicArgsort} from '@luma.gl/gpgpu/webgpu';
+import {GPUVector, type GPUVectorFormat} from '@luma.gl/tables';
+import {getTestDevice} from '@luma.gl/test-utils';
+import {beforeEach, describe, expect, test} from 'vitest';
+
+describe('BitonicArgsort', () => {
+  let device: Device | null;
+
+  beforeEach(async () => {
+    device = await getTestDevice('webgpu');
+  });
+
+  test('sorts power-of-two uint32 keys', async t => {
+    if (!device) {
+      t.skip('webgpu not available');
+      return;
+    }
+
+    const sorter = new BitonicArgsort(device);
+    const keys = makeUint32Vector(device, 'keys', [7, 2, 5, 1, 6, 0, 4, 3]);
+    const sortedRowIndices = sorter.sortGPUVector(keys);
+
+    expect(sortedRowIndices.format).toBe('uint32');
+    expect(Array.from(await readUint32Vector(sortedRowIndices))).toEqual([5, 3, 1, 7, 6, 2, 4, 0]);
+
+    sortedRowIndices.destroy();
+    keys.destroy();
+    sorter.destroy();
+  });
+
+  test('sorts non-power-of-two uint32 keys', async t => {
+    if (!device) {
+      t.skip('webgpu not available');
+      return;
+    }
+
+    const sorter = new BitonicArgsort(device);
+    const values = [9, 4, 6, 2, 8, 1, 7];
+    const keys = makeUint32Vector(device, 'keys', values);
+    const sortedRowIndices = sorter.sortGPUVector(keys);
+
+    expect(Array.from(await readUint32Vector(sortedRowIndices))).toEqual(getStableArgsort(values));
+
+    sortedRowIndices.destroy();
+    keys.destroy();
+    sorter.destroy();
+  });
+
+  test('preserves source row order for duplicate keys', async t => {
+    if (!device) {
+      t.skip('webgpu not available');
+      return;
+    }
+
+    const sorter = new BitonicArgsort(device);
+    const values = [4, 1, 4, 2, 1, 4, 2];
+    const keys = makeUint32Vector(device, 'keys', values);
+    const sortedRowIndices = sorter.sortGPUVector(keys);
+
+    expect(Array.from(await readUint32Vector(sortedRowIndices))).toEqual([1, 4, 3, 6, 0, 2, 5]);
+
+    sortedRowIndices.destroy();
+    keys.destroy();
+    sorter.destroy();
+  });
+
+  test('returns an empty uint32 vector for zero rows', async t => {
+    if (!device) {
+      t.skip('webgpu not available');
+      return;
+    }
+
+    const sorter = new BitonicArgsort(device);
+    const keys = makeUint32Vector(device, 'keys', []);
+    const sortedRowIndices = sorter.sortGPUVector(keys);
+
+    expect(sortedRowIndices.length).toBe(0);
+    expect(sortedRowIndices.format).toBe('uint32');
+    expect(Array.from(await readUint32Vector(sortedRowIndices))).toEqual([]);
+
+    sortedRowIndices.destroy();
+    keys.destroy();
+    sorter.destroy();
+  });
+
+  test('reuses one sorter across different lengths', async t => {
+    if (!device) {
+      t.skip('webgpu not available');
+      return;
+    }
+
+    const sorter = new BitonicArgsort(device);
+    const shortKeys = makeUint32Vector(device, 'short-keys', [3, 0, 2, 1]);
+    const shortSortedRowIndices = sorter.sortGPUVector(shortKeys);
+    expect(Array.from(await readUint32Vector(shortSortedRowIndices))).toEqual([1, 3, 2, 0]);
+
+    const longValues = [10, 3, 8, 3, 2, 9, 1, 7, 6];
+    const longKeys = makeUint32Vector(device, 'long-keys', longValues);
+    const longSortedRowIndices = sorter.sortGPUVector(longKeys);
+    expect(Array.from(await readUint32Vector(longSortedRowIndices))).toEqual(
+      getStableArgsort(longValues)
+    );
+
+    longSortedRowIndices.destroy();
+    longKeys.destroy();
+    shortSortedRowIndices.destroy();
+    shortKeys.destroy();
+    sorter.destroy();
+  });
+
+  test('rejects non-uint32 key vectors', t => {
+    if (!device) {
+      t.skip('webgpu not available');
+      return;
+    }
+
+    const sorter = new BitonicArgsort(device);
+    const keys = makeVector(device, 'keys', new Float32Array([3, 2, 1]), 'float32');
+
+    expect(() => sorter.sortGPUVector(keys as unknown as GPUVector<'uint32'>)).toThrow(
+      'GPUVector<"uint32">'
+    );
+
+    keys.destroy();
+    sorter.destroy();
+  });
+
+  test('rejects multi-chunk key vectors', t => {
+    if (!device) {
+      t.skip('webgpu not available');
+      return;
+    }
+
+    const sorter = new BitonicArgsort(device);
+    const firstChunk = makeUint32Vector(device, 'keys-0', [3, 2]);
+    const secondChunk = makeUint32Vector(device, 'keys-1', [1, 0]);
+    const keys = new GPUVector({
+      type: 'data',
+      name: 'keys',
+      format: 'uint32',
+      data: [firstChunk.data[0], secondChunk.data[0]],
+      ownsData: false
+    });
+
+    expect(() => sorter.sortGPUVector(keys)).toThrow('requires exactly one GPUData chunk');
+
+    keys.destroy();
+    firstChunk.destroy();
+    secondChunk.destroy();
+    sorter.destroy();
+  });
+});
+
+function makeUint32Vector(device: Device, name: string, values: number[]): GPUVector<'uint32'> {
+  return makeVector(device, name, new Uint32Array(values), 'uint32');
+}
+
+function makeVector<T extends GPUVectorFormat>(
+  device: Device,
+  name: string,
+  values: Uint32Array | Float32Array,
+  format: T
+): GPUVector<T> {
+  const buffer = device.createBuffer({
+    id: name,
+    byteLength: Math.max(values.byteLength, Uint32Array.BYTES_PER_ELEMENT),
+    usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
+    data: values
+  });
+  return new GPUVector({
+    type: 'buffer',
+    name,
+    buffer,
+    format,
+    length: values.length,
+    ownsBuffer: true
+  });
+}
+
+async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<Uint32Array> {
+  if (vector.length === 0) {
+    return new Uint32Array(0);
+  }
+
+  const data = vector.data[0];
+  const bytes = await data.buffer.readAsync(
+    data.byteOffset,
+    vector.length * Uint32Array.BYTES_PER_ELEMENT
+  );
+  return new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length).slice();
+}
+
+function getStableArgsort(values: number[]): number[] {
+  return values
+    .map((value, rowIndex) => ({rowIndex, value}))
+    .sort((left, right) => left.value - right.value || left.rowIndex - right.rowIndex)
+    .map(({rowIndex}) => rowIndex);
+}

--- a/website/content/examples/index.mdx
+++ b/website/content/examples/index.mdx
@@ -8,7 +8,7 @@ import {ExamplesIndex} from '@site/src/components/examples-index';
     if (exampleName === 'arrow/arrow-text-3d') {
       return '/images/examples/experimental/text-3d.jpg'
     }
-    if (exampleName === 'v10/gpgpu') {
+    if (exampleName === 'v10/gpgpu' || exampleName === 'v10/gpgpu-bitonic-sort') {
       return '/images/examples/gpu-tables/gpu-vector-storage-particles.jpg'
     }
     return `/images/examples/${exampleName}.jpg`

--- a/website/content/examples/table-of-contents.json
+++ b/website/content/examples/table-of-contents.json
@@ -62,7 +62,7 @@
   {
     "type": "category",
     "label": "GPU Data - luma v10",
-    "items": ["v10/gpgpu"]
+    "items": ["v10/gpgpu", "v10/gpgpu-bitonic-sort"]
   },
   {
     "type": "category",

--- a/website/content/examples/v10/gpgpu-bitonic-sort.mdx
+++ b/website/content/examples/v10/gpgpu-bitonic-sort.mdx
@@ -1,0 +1,8 @@
+---
+title: Bitonic argsort
+sidebar_label: Bitonic argsort
+---
+
+import {GPGPUBitonicSortExample} from '@site/src/examples';
+
+<GPGPUBitonicSortExample />

--- a/website/content/sidebar-examples.js
+++ b/website/content/sidebar-examples.js
@@ -62,7 +62,7 @@ const sidebars = {
     {
       type: 'category',
       label: 'GPU Data - luma v10',
-      items: ['v10/gpgpu']
+      items: ['v10/gpgpu', 'v10/gpgpu-bitonic-sort']
     },
     {
       type: 'category',

--- a/website/src/components/docs/gpgpu-docs-tabs.tsx
+++ b/website/src/components/docs/gpgpu-docs-tabs.tsx
@@ -15,6 +15,7 @@ export type GPGPUDocsTabId =
   | 'overview'
   | 'gpu-data-evaluator'
   | 'operations'
+  | 'bitonic-argsort'
   | 'custom-operation'
   | 'clean-evaluate';
 
@@ -22,6 +23,7 @@ const GPGPU_DOCS_TABS: GPGPUDocsTab[] = [
   {id: 'overview', label: 'Overview', href: '/docs/api-reference/gpgpu'},
   {id: 'gpu-data-evaluator', label: 'GPU Evaluators', href: '/docs/api-reference/gpgpu/gpu-data-evaluator'},
   {id: 'operations', label: 'Operations', href: '/docs/api-reference/gpgpu/operations'},
+  {id: 'bitonic-argsort', label: 'Bitonic Argsort', href: '/docs/api-reference/gpgpu/bitonic-argsort'},
   {
     id: 'custom-operation',
     label: 'Custom Operations',

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -20,6 +20,10 @@ import {
   initializeGPGPUShowcase,
   type GPGPUShowcaseHandle
 } from '../../examples/v10/gpgpu/src/app';
+import {
+  initializeBitonicArgsortExample,
+  type BitonicArgsortExampleHandle
+} from '../../examples/v10/gpgpu-bitonic-sort/src/app';
 import ArrowParticlesApp from '../../examples/arrow/arrow-particles/app';
 import MultiCanvasApp from '../../examples/api/multi-canvas/app';
 import Texture3DApp from '../../examples/api/texture-3d/app';
@@ -513,6 +517,36 @@ export const GPGPUExample: React.FC = () => {
           </div>
         </section>
       </main>
+    </ExamplePage>
+  );
+};
+
+/** Docusaurus wrapper for the Arrow-backed BitonicArgsort GPGPU example. */
+export const GPGPUBitonicSortExample: React.FC = () => {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let handle: BitonicArgsortExampleHandle | null = null;
+    try {
+      handle = initializeBitonicArgsortExample();
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+      logError('Failed to initialize bitonic argsort example', error);
+    }
+
+    return () => {
+      handle?.destroy();
+    };
+  }, []);
+
+  return (
+    <ExamplePage style={{background: '#f7f8fb', overflow: 'hidden'}}>
+      <main id="bitonic-argsort-app" />
+      {errorMessage ? (
+        <p role="alert" style={{padding: 22}}>
+          {errorMessage}
+        </p>
+      ) : null}
     </ExamplePage>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -16071,6 +16071,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"luma.gl-examples-v10-gpgpu-bitonic-sort@workspace:examples/v10/gpgpu-bitonic-sort":
+  version: 0.0.0-use.local
+  resolution: "luma.gl-examples-v10-gpgpu-bitonic-sort@workspace:examples/v10/gpgpu-bitonic-sort"
+  dependencies:
+    "@luma.gl/arrow": "npm:~9.3.0"
+    "@luma.gl/core": "npm:~9.3.0"
+    "@luma.gl/engine": "npm:~9.3.0"
+    "@luma.gl/gpgpu": "npm:~9.3.0"
+    "@luma.gl/shadertools": "npm:~9.3.0"
+    "@luma.gl/tables": "npm:~9.3.0"
+    "@luma.gl/webgpu": "npm:~9.3.0"
+    apache-arrow: "npm:^17.0.0"
+    typescript: "npm:^5.9.3"
+    vite: "npm:^8.0.0"
+  languageName: unknown
+  linkType: soft
+
 "luma.gl-examples-v10-gpgpu@workspace:examples/v10/gpgpu":
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-v10-gpgpu@workspace:examples/v10/gpgpu"


### PR DESCRIPTION
Goals
- Add a WebGPU-only stable argsort helper for packed `GPUVector<'uint32'>` sort keys.

Changes
- Export `BitonicArgsort` from `@luma.gl/gpgpu/webgpu`; it sorts `(key, sourceIndex)` tuples, supports non-power-of-two padding, rejects wrong formats and multi-chunk vectors, returns an owned row-index `GPUVector<'uint32'>`, and reuses internal scratch buffers.
- Add focused WebGPU specs for sorted output, duplicate-key stability, non-power-of-two input, zero-length input, reuse, wrong format, and multi-chunk rejection.
- Add TSDoc and GPGPU API documentation, including an Arrow upload example and input/ownership contract.
- Add a runnable sample-like GPGPU Bitonic argsort example with Arrow-derived `Uint32` keys, Shuffle/Step/Run/Reset controls, visible compare/swap passes, and final GPU row-index output.
- Add `modules/gpgpu/src/webgpu.ts` so source-resolved `@luma.gl/gpgpu/webgpu` imports work in the website/example build.

Verification
- `nvm use` could not run: `nvm` is not available in this shell.
- `yarn install` passed via Corepack; it reported existing peer dependency warnings.
- `yarn build` passed.
- `yarn workspace luma.gl-examples-v10-gpgpu-bitonic-sort build` passed.
- `yarn test` partially passed: the node phase passed (`43 passed | 2 skipped` files; `139 passed | 2 skipped` tests), then the Vitest Playwright Chromium launcher aborted with `SIGABRT` before browser tests loaded.
- `yarn lint fix` passed.
- `yarn website:build` passed; it reported existing old `v10/gpgpu` backend export warnings.
- `(cd website && yarn build)` passed; it reported the same existing warnings plus nonfatal `pyenv`/Docusaurus update-check warnings.
- `git diff --check master...HEAD` passed.

Risks
- Local browser/WebGPU spec execution remains blocked by the Playwright Chromium launcher abort noted above; the focused spec is present but was not executed by `yarn test` here.
- `BitonicArgsort` v1 intentionally accepts only one packed `uint32` chunk; Arrow packing stays explicit in `@luma.gl/arrow`.

Excluded Scope
- Order-independent transparency/A-buffer changes are on a separate branch/PR and are not in this diff.