### PR TITLE
Add deferred binding infrastructure

### DIFF
--- a/docs/api-reference/engine/animation-loop.md
+++ b/docs/api-reference/engine/animation-loop.md
@@ -51,6 +51,7 @@ export type AnimationLoopProps = {
   onError?: (reason: Error) => void;
   stats?: Stats;
   autoResizeViewport?: boolean;
+  animationFrameProvider?: AnimationFrameProvider;
 };
 ```
 
@@ -73,6 +74,7 @@ Important fields include:
 | `tick`, `tock` | `number` | Frame counters. |
 | `needsRedraw` | `false \| string` | Last redraw reason, if any. |
 | `timeline` | `Timeline \| null` | Attached timeline, if any. |
+| `animationFrame` | `unknown \| null` | Experimental frame payload from a custom animation frame provider. |
 | `_mousePosition` | `[number, number] \| null` | Experimental mouse position. |
 
 ## Properties
@@ -115,7 +117,7 @@ Deprecated alias for `destroy()`.
 
 Calls `onError` and stores the error internally to prevent repeated rendering.
 
-### `setProps(props: {autoResizeViewport?: boolean}): this`
+### `setProps(props: {autoResizeViewport?: boolean; animationFrameProvider?: AnimationFrameProvider}): this`
 
 Updates mutable loop settings.
 
@@ -135,7 +137,7 @@ Initializes the device if needed, calls `onInitialize`, and starts requesting an
 
 Stops the loop and calls `onFinalize` if initialization completed successfully.
 
-### `redraw(time?: number): this`
+### `redraw(time?: number, animationFrame?: unknown | null): this`
 
 Runs a single frame immediately without waiting for `requestAnimationFrame`.
 
@@ -159,3 +161,31 @@ Triggers a redraw and returns the current HTML canvas as a data URL.
 
 - `AnimationLoop` expects the application to create and destroy its own GPU resources in `onInitialize` and `onFinalize`.
 - If you prefer a class-based lifecycle, use [`AnimationLoopTemplate`](/docs/api-reference/engine/animation-loop-template) together with `makeAnimationLoop()`.
+
+## Experimental Frame Provider
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+`AnimationLoop` accepts an experimental `animationFrameProvider` for schedulers that carry a per-frame payload. During those frames, `AnimationProps.animationFrame` contains the provider payload; it is `null` for ordinary browser frames.
+
+```typescript
+const animationFrameProvider = {
+  requestAnimationFrame(callback) {
+    return customScheduler.requestAnimationFrame((time, frame) => callback(time, frame));
+  },
+  cancelAnimationFrame(animationFrameId) {
+    customScheduler.cancelAnimationFrame(animationFrameId);
+  }
+};
+
+const animationLoop = new AnimationLoop({
+  device,
+  animationFrameProvider,
+  onRender({animationFrame}) {
+    // Inspect provider-specific frame state here.
+  }
+});
+```

--- a/modules/core/src/adapter/resources/resource.ts
+++ b/modules/core/src/adapter/resources/resource.ts
@@ -82,6 +82,11 @@ export type ResourceProps = {
   id?: string;
   /** Handle for the underlying resources (WebGL object or WebGPU handle) */
   handle?: unknown;
+  /**
+   * @internal Opaque externally owned handle. luma.gl may reference this handle but must not
+   * initialize, mutate, or destroy it.
+   */
+  _isHandleBorrowed?: boolean;
   /** User provided data stored on this resource  */
   userData?: {[key: string]: any};
 };
@@ -94,6 +99,7 @@ export abstract class Resource<Props extends ResourceProps> {
   static defaultProps: Required<ResourceProps> = {
     id: 'undefined',
     handle: undefined,
+    _isHandleBorrowed: false,
     userData: undefined!
   };
 
@@ -129,6 +135,18 @@ export abstract class Resource<Props extends ResourceProps> {
   private allocatedBytesName: string | null = null;
   /** Attached resources will be destroyed when this resource is destroyed. Tracks auto-created "sub" resources. */
   private _attachedResources = new Set<Resource<ResourceProps>>();
+
+  /** Whether luma.gl created and owns the underlying resource handle. */
+  get ownsHandle(): boolean {
+    return (
+      (this.props.handle === undefined || this.props.handle === null) && !this.isHandleBorrowed
+    );
+  }
+
+  /** Whether luma.gl may only reference the opaque externally owned resource handle. */
+  get isHandleBorrowed(): boolean {
+    return Boolean(this.props._isHandleBorrowed);
+  }
 
   /**
    * Create a new Resource. Called from Subclass

--- a/modules/engine/src/animation-loop/animation-loop.ts
+++ b/modules/engine/src/animation-loop/animation-loop.ts
@@ -14,6 +14,20 @@ import {Stats, Stat} from '@probe.gl/stats';
 let statIdCounter = 0;
 const ANIMATION_LOOP_STATS = 'Animation Loop';
 
+/** Experimental v10 callback shape for browser or custom animation frames. */
+export type AnimationFrameCallback = (time: DOMHighResTimeStamp, animationFrame?: unknown) => void;
+
+/** Experimental v10 work-in-progress animation frame source. */
+export interface AnimationFrameProvider {
+  requestAnimationFrame(callback: AnimationFrameCallback): number;
+  cancelAnimationFrame(animationFrameId: number): void;
+}
+
+const defaultAnimationFrameProvider: AnimationFrameProvider = {
+  requestAnimationFrame: callback => requestAnimationFramePolyfill(callback),
+  cancelAnimationFrame: animationFrameId => cancelAnimationFramePolyfill(animationFrameId)
+};
+
 /** AnimationLoop properties */
 export type AnimationLoopProps = {
   device: Device | Promise<Device>;
@@ -28,11 +42,15 @@ export type AnimationLoopProps = {
 
   // view parameters - TODO move to CanvasContext?
   autoResizeViewport?: boolean;
+  /** Experimental v10 work-in-progress frame source. */
+  animationFrameProvider?: AnimationFrameProvider;
 };
 
 export type MutableAnimationLoopProps = {
   // view parameters
   autoResizeViewport?: boolean;
+  /** Experimental v10 work-in-progress frame source. */
+  animationFrameProvider?: AnimationFrameProvider;
 };
 
 /** Convenient animation loop */
@@ -52,7 +70,8 @@ export class AnimationLoop {
     stats: undefined!,
 
     // view parameters
-    autoResizeViewport: false
+    autoResizeViewport: false,
+    animationFrameProvider: defaultAnimationFrameProvider
   } as const satisfies Readonly<Required<AnimationLoopProps>>;
 
   device: Device | null = null;
@@ -99,7 +118,10 @@ export class AnimationLoop {
     this.cpuTime = this.stats.get('CPU Time');
     this.gpuTime = this.stats.get('GPU Time');
 
-    this.setProps({autoResizeViewport: props.autoResizeViewport});
+    this.setProps({
+      autoResizeViewport: props.autoResizeViewport,
+      animationFrameProvider: props.animationFrameProvider
+    });
 
     // Bind methods
     this.start = this.start.bind(this);
@@ -141,6 +163,19 @@ export class AnimationLoop {
   setProps(props: MutableAnimationLoopProps): this {
     if ('autoResizeViewport' in props) {
       this.props.autoResizeViewport = props.autoResizeViewport || false;
+    }
+    if ('animationFrameProvider' in props) {
+      const animationFrameProvider = props.animationFrameProvider || defaultAnimationFrameProvider;
+      if (animationFrameProvider !== this.props.animationFrameProvider) {
+        const animationFrameWasScheduled = this._animationFrameId !== null;
+        if (animationFrameWasScheduled) {
+          this._cancelAnimationFrame();
+        }
+        this.props.animationFrameProvider = animationFrameProvider;
+        if (animationFrameWasScheduled) {
+          this._requestAnimationFrame();
+        }
+      }
     }
     return this;
   }
@@ -208,7 +243,7 @@ export class AnimationLoop {
   }
 
   /** Explicitly draw a frame */
-  redraw(time?: number): this {
+  redraw(time?: number, animationFrame: unknown | null = null): this {
     if (this.device?.isLost || this._error) {
       return this;
     }
@@ -216,6 +251,9 @@ export class AnimationLoop {
     this._beginFrameTimers(time);
 
     this._setupFrame();
+    if (this.animationProps) {
+      this.animationProps.animationFrame = animationFrame;
+    }
     this._updateAnimationProps();
 
     this._renderFrame(this._getAnimationProps());
@@ -301,13 +339,9 @@ export class AnimationLoop {
       return;
     }
 
-    // VR display has a separate animation frame to sync with headset
-    // TODO WebVR API discontinued, replaced by WebXR: https://immersive-web.github.io/webxr/
-    // See https://developer.mozilla.org/en-US/docs/Web/API/VRDisplay/requestAnimationFrame
-    // if (this.display && this.display.requestAnimationFrame) {
-    //   this._animationFrameId = this.display.requestAnimationFrame(this._animationFrame.bind(this));
-    // }
-    this._animationFrameId = requestAnimationFramePolyfill(this._animationFrame.bind(this));
+    this._animationFrameId = this.props.animationFrameProvider.requestAnimationFrame(
+      this._animationFrame.bind(this)
+    );
   }
 
   _cancelAnimationFrame(): void {
@@ -315,21 +349,15 @@ export class AnimationLoop {
       return;
     }
 
-    // VR display has a separate animation frame to sync with headset
-    // TODO WebVR API discontinued, replaced by WebXR: https://immersive-web.github.io/webxr/
-    // See https://developer.mozilla.org/en-US/docs/Web/API/VRDisplay/requestAnimationFrame
-    // if (this.display && this.display.cancelAnimationFramePolyfill) {
-    //   this.display.cancelAnimationFrame(this._animationFrameId);
-    // }
-    cancelAnimationFramePolyfill(this._animationFrameId);
+    this.props.animationFrameProvider.cancelAnimationFrame(this._animationFrameId);
     this._animationFrameId = null;
   }
 
-  _animationFrame(time: number): void {
+  _animationFrame(time: number, animationFrame?: unknown): void {
     if (!this._running) {
       return;
     }
-    this.redraw(time);
+    this.redraw(time, animationFrame ?? null);
     this._requestAnimationFrame();
   }
 
@@ -396,6 +424,7 @@ export class AnimationLoop {
       tock: 0,
 
       // Experimental
+      animationFrame: null,
       _mousePosition: null // Event props
     };
   }

--- a/modules/engine/src/animation-loop/animation-props.ts
+++ b/modules/engine/src/animation-loop/animation-props.ts
@@ -29,5 +29,7 @@ export type AnimationProps = {
   timeline: Timeline | null;
 
   // Experimental
+  /** Experimental v10 work-in-progress frame payload from a custom animation frame provider. */
+  animationFrame: unknown | null;
   _mousePosition?: [number, number] | null; // [offsetX, offsetY],
 };

--- a/modules/engine/src/index.ts
+++ b/modules/engine/src/index.ts
@@ -13,7 +13,11 @@ export type {AnimationProps} from './animation-loop/animation-props';
 
 export {AnimationLoopTemplate} from './animation-loop/animation-loop-template';
 
-export type {AnimationLoopProps} from './animation-loop/animation-loop';
+export type {
+  AnimationFrameCallback,
+  AnimationFrameProvider,
+  AnimationLoopProps
+} from './animation-loop/animation-loop';
 export {AnimationLoop} from './animation-loop/animation-loop';
 
 export type {MakeAnimationLoopProps} from './animation-loop/make-animation-loop';
@@ -78,6 +82,7 @@ export type {TruncatedConeGeometryProps} from './geometries/truncated-cone-geome
 export {TruncatedConeGeometry} from './geometries/truncated-cone-geometry';
 
 export {ShaderInputs} from './shader-inputs';
+export type {ShaderInputBinding, ShaderInputsProps} from './shader-inputs';
 export {
   getAttributeLayoutFromBufferSchema,
   type AttributeLayoutFromBufferSchemaOptions,
@@ -118,7 +123,10 @@ export type {
 
 export type {DynamicTextureProps} from './dynamic-texture/dynamic-texture';
 export {DynamicTexture} from './dynamic-texture/dynamic-texture';
-export type {TextureBindingSource} from './dynamic-texture/texture-binding-source';
+export type {
+  TextureBindingLayout,
+  TextureBindingSource
+} from './dynamic-texture/texture-binding-source';
 export type {VideoTextureProps, VideoTextureSource} from './dynamic-texture/video-texture';
 export {VideoTexture} from './dynamic-texture/video-texture';
 export type {

--- a/modules/engine/src/shader-inputs.ts
+++ b/modules/engine/src/shader-inputs.ts
@@ -20,6 +20,13 @@ export type ShaderInputsOptions = {
   disableWarnings?: boolean;
 };
 
+export type ShaderInputsProps<
+  ShaderPropsT extends Partial<Record<string, Record<string, unknown>>>
+> = Partial<{[P in keyof ShaderPropsT]?: Partial<ShaderPropsT[P]>}> & {
+  /** Shader resource bindings that are not owned by a shader module. */
+  bindings?: Record<string, ShaderInputBinding>;
+};
+
 type ShaderInputsModule = Pick<
   ShaderModule<any, any, any>,
   'bindingLayout' | 'defaultUniforms' | 'dependencies' | 'getUniforms' | 'name' | 'uniformTypes'
@@ -49,6 +56,8 @@ export class ShaderInputs<
   moduleUniforms: Record<keyof ShaderPropsT, Record<string, ShaderModuleUniformValue>>;
   /** Stores resource bindings for each module. */
   moduleBindings: Record<keyof ShaderPropsT, Record<string, ShaderInputBinding>>;
+  /** Stores shader resource bindings that are not owned by a shader module. */
+  directBindings: Record<string, ShaderInputBinding> = {};
   /** Tracks if uniforms have changed */
   // moduleUniformsChanged: Record<keyof ShaderPropsT, false | string>;
 
@@ -101,8 +110,16 @@ export class ShaderInputs<
   /**
    * Set module props
    */
-  setProps(props: Partial<{[P in keyof ShaderPropsT]?: Partial<ShaderPropsT[P]>}>): void {
+  setProps(props: ShaderInputsProps<ShaderPropsT>): void {
+    if (props.bindings) {
+      Object.assign(this.directBindings, props.bindings);
+    }
+
     for (const name of Object.keys(props)) {
+      if (name === 'bindings') {
+        continue;
+      }
+
       const moduleName = name as keyof ShaderPropsT;
       const moduleProps = props[moduleName] || {};
       const module = this.modules[moduleName];
@@ -170,6 +187,7 @@ export class ShaderInputs<
     for (const moduleBindings of Object.values(this.moduleBindings)) {
       Object.assign(bindings, moduleBindings);
     }
+    Object.assign(bindings, this.directBindings);
     return bindings;
   }
 

--- a/modules/engine/test/lib/animation-loop.spec.ts
+++ b/modules/engine/test/lib/animation-loop.spec.ts
@@ -105,6 +105,43 @@ test('engine#AnimationLoop redraw', async t => {
   }).start();
 });
 
+test('engine#AnimationLoop passes frame payload from custom animation frame provider', async t => {
+  const device = await getWebGLTestDevice();
+  const animationFrame = {};
+  let scheduledCallback: ((time: DOMHighResTimeStamp, animationFrame?: unknown) => void) | null =
+    null;
+  let cancelAnimationFrameCallCount = 0;
+  const animationFrameProvider = {
+    requestAnimationFrame(callback: (time: DOMHighResTimeStamp, animationFrame?: unknown) => void) {
+      scheduledCallback = callback;
+      return 1;
+    },
+    cancelAnimationFrame() {
+      cancelAnimationFrameCallCount++;
+    }
+  };
+  const animationLoop = new AnimationLoop({
+    device,
+    animationFrameProvider,
+    onRender: ({animationLoop, animationFrame: receivedAnimationFrame}) => {
+      t.equal(
+        receivedAnimationFrame,
+        animationFrame,
+        'onRender receives frame payload from frame provider'
+      );
+      animationLoop.stop();
+    }
+  });
+
+  await animationLoop.start();
+  scheduledCallback?.(123, animationFrame);
+
+  t.equal(cancelAnimationFrameCallCount, 1, 'stopping cancels scheduled custom frame');
+  animationLoop.destroy();
+  device.destroy();
+  t.end();
+});
+
 test('engine#AnimationLoop should not call initialize more than once', async t => {
   const device = await getWebGLTestDevice();
 

--- a/modules/engine/test/shader-inputs-types.spec.ts
+++ b/modules/engine/test/shader-inputs-types.spec.ts
@@ -91,6 +91,12 @@ export function verifyCompositeShaderInputTypes(): void {
   });
 
   shaderInputs.setProps({
+    bindings: {
+      cameraTexture: {} as Texture
+    }
+  });
+
+  shaderInputs.setProps({
     composite: {
       lights: [{position: [1, 2, 3], intensity: 1}]
     }

--- a/modules/engine/test/shader-inputs.spec.ts
+++ b/modules/engine/test/shader-inputs.spec.ts
@@ -187,6 +187,28 @@ test('ShaderInputs#bindings', t => {
   });
 });
 
+test('ShaderInputs#direct bindings', t => {
+  const shaderInputs = new ShaderInputs({});
+  const cameraTexture = 'CAMERA_TEXTURE' as unknown as Texture;
+  const nextCameraTexture = 'NEXT_CAMERA_TEXTURE' as unknown as Texture;
+
+  shaderInputs.setProps({bindings: {cameraTexture}});
+  t.deepEqual(
+    shaderInputs.getBindingValues(),
+    {cameraTexture: 'CAMERA_TEXTURE'},
+    'direct binding is available to the model'
+  );
+
+  shaderInputs.setProps({bindings: {cameraTexture: nextCameraTexture}});
+  t.deepEqual(
+    shaderInputs.getBindingValues(),
+    {cameraTexture: 'NEXT_CAMERA_TEXTURE'},
+    'direct binding can be updated'
+  );
+
+  t.end();
+});
+
 test('ShaderInputs#getModuleBindingValues', t => {
   type FirstModuleProps = {firstTexture: Texture};
   type SecondModuleProps = {secondTexture: Texture};

--- a/modules/webgl/src/adapter/resources/webgl-texture.ts
+++ b/modules/webgl/src/adapter/resources/webgl-texture.ts
@@ -97,44 +97,54 @@ export class WEBGLTexture extends Texture {
     this.glType = formatInfo.type;
     this.compressed = formatInfo.compressed;
 
+    if (this.isHandleBorrowed && this.props.handle === undefined) {
+      throw new Error('Borrowed WebGL textures require a texture handle');
+    }
+
     this.handle = this.props.handle || this.gl.createTexture();
     this.device._setWebGLDebugMetadata(this.handle, this, {spector: this.props});
 
-    /**
-     * Use WebGL immutable texture storage to allocate and clear texture memory.
-     * - texStorage2D should be considered a preferred alternative to texImage2D. It may have lower memory costs than texImage2D in some implementations.
-     * - Once texStorage*D has been called, the texture is immutable and can only be updated with texSubImage*(), not texImage()
-     * @see https://registry.khronos.org/webgl/specs/latest/2.0/ WebGL 2 spec section 3.7.6
-     */
-    this.gl.bindTexture(this.glTarget, this.handle);
-    const {dimension, width, height, depth, mipLevels, glTarget, glInternalFormat} = this;
-    if (!this.compressed) {
-      switch (dimension) {
-        case '2d':
-        case 'cube':
-          this.gl.texStorage2D(glTarget, mipLevels, glInternalFormat, width, height);
-          break;
-        case '2d-array':
-        case '3d':
-          this.gl.texStorage3D(glTarget, mipLevels, glInternalFormat, width, height, depth);
-          break;
-        default:
-          throw new Error(dimension);
+    if (!this.isHandleBorrowed) {
+      // Opaque borrowed WebGLTexture handles are binding-only. Allocating storage, uploading
+      // pixels, or changing sampler state would mutate a resource owned outside luma.gl.
+      /**
+       * Use WebGL immutable texture storage to allocate and clear texture memory.
+       * - texStorage2D should be considered a preferred alternative to texImage2D. It may have lower memory costs than texImage2D in some implementations.
+       * - Once texStorage*D has been called, the texture is immutable and can only be updated with texSubImage*(), not texImage()
+       * @see https://registry.khronos.org/webgl/specs/latest/2.0/ WebGL 2 spec section 3.7.6
+       */
+      this.gl.bindTexture(this.glTarget, this.handle);
+      const {dimension, width, height, depth, mipLevels, glTarget, glInternalFormat} = this;
+      if (!this.compressed) {
+        switch (dimension) {
+          case '2d':
+          case 'cube':
+            this.gl.texStorage2D(glTarget, mipLevels, glInternalFormat, width, height);
+            break;
+          case '2d-array':
+          case '3d':
+            this.gl.texStorage3D(glTarget, mipLevels, glInternalFormat, width, height, depth);
+            break;
+          default:
+            throw new Error(dimension);
+        }
       }
+      this.gl.bindTexture(this.glTarget, null);
+
+      // Set data
+      this._initializeData(props.data);
     }
-    this.gl.bindTexture(this.glTarget, null);
 
-    // Set data
-    this._initializeData(props.data);
-
-    if (!this.props.handle) {
+    if (this.ownsHandle) {
       this.trackAllocatedMemory(this.getAllocatedByteLength(), 'Texture');
     } else {
       this.trackReferencedMemory(this.getAllocatedByteLength(), 'Texture');
     }
 
-    // Set texture sampler parameters
-    this.setSampler(this.props.sampler);
+    if (!this.isHandleBorrowed) {
+      // Set texture sampler parameters
+      this.setSampler(this.props.sampler);
+    }
     // @ts-ignore TODO - fix types
     this.view = new WEBGLTextureView(this.device, {...this.props, texture: this});
 
@@ -149,7 +159,7 @@ export class WEBGLTexture extends Texture {
       this._framebufferAttachmentKey = null;
 
       this.removeStats();
-      if (!this.props.handle) {
+      if (this.ownsHandle) {
         this.gl.deleteTexture(this.handle);
         this.trackDeallocatedMemory('Texture');
       } else {
@@ -164,7 +174,21 @@ export class WEBGLTexture extends Texture {
     return new WEBGLTextureView(this.device, {...props, texture: this});
   }
 
+  override clone(size?: {width: number; height: number}): Texture {
+    // Texture.clone({width, height}) is luma.gl's resize path. A borrowed handle keeps the
+    // externally provided dimensions, so a resized wrapper would lie about the sampled texture.
+    if (
+      this.isHandleBorrowed &&
+      size &&
+      (size.width !== this.width || size.height !== this.height)
+    ) {
+      throw new Error(`Cannot resize borrowed read-only ${this}`);
+    }
+    return super.clone(size);
+  }
+
   override setSampler(sampler: Sampler | SamplerProps = {}): void {
+    this._assertWritable('set sampler parameters on');
     super.setSampler(sampler);
     // Apply sampler parameters to texture
     const parameters = convertSamplerParametersToWebGL(this.sampler.props);
@@ -172,6 +196,7 @@ export class WEBGLTexture extends Texture {
   }
 
   copyExternalImage(options_: CopyExternalImageOptions): {width: number; height: number} {
+    this._assertWritable('copy external image data into');
     const options = this._normalizeCopyExternalImageOptions(options_);
 
     if (options.sourceX || options.sourceY) {
@@ -211,6 +236,7 @@ export class WEBGLTexture extends Texture {
   }
 
   copyElementImage(options_: CopyElementImageOptions): {width: number; height: number} {
+    this._assertWritable('copy element image data into');
     const options = this._normalizeCopyElementImageOptions(options_);
     const {glFormat} = this;
     const {
@@ -324,6 +350,7 @@ export class WEBGLTexture extends Texture {
   }
 
   writeBuffer(buffer: Buffer, options_: TextureWriteOptions = {}) {
+    this._assertWritable('write buffer data into');
     const options = this._normalizeTextureWriteOptions(options_);
     const {width, height, depthOrArrayLayers, mipLevel, byteOffset, x, y, z} = options;
     const {glFormat, glType, compressed} = this;
@@ -388,6 +415,7 @@ export class WEBGLTexture extends Texture {
     data: ArrayBuffer | SharedArrayBuffer | ArrayBufferView,
     options_: TextureWriteOptions = {}
   ): void {
+    this._assertWritable('write data into');
     const options = this._normalizeTextureWriteOptions(options_);
 
     const typedArray = ArrayBuffer.isView(data) ? data : new Uint8Array(data);
@@ -654,6 +682,7 @@ export class WEBGLTexture extends Texture {
    * @note - this is used by the DynamicTexture class to generate mipmaps on WebGL
    */
   override generateMipmapsWebGL(options?: {force?: boolean}): void {
+    this._assertWritable('generate mipmaps for');
     const isFilterableAndRenderable =
       this.device.isTextureFormatRenderable(this.props.format) &&
       this.device.isTextureFormatFilterable(this.props.format);
@@ -751,6 +780,13 @@ export class WEBGLTexture extends Texture {
 
     gl.bindTexture(this.glTarget, null);
     return _textureUnit;
+  }
+
+  private _assertWritable(operation: string): void {
+    if (this.isHandleBorrowed) {
+      // Borrowed WebGL texture handles are binding-only; every luma.gl texture mutation API is not.
+      throw new Error(`Cannot ${operation} borrowed read-only ${this}`);
+    }
   }
 }
 

--- a/modules/webgl/test/adapter/resources/webgl-texture.spec.ts
+++ b/modules/webgl/test/adapter/resources/webgl-texture.spec.ts
@@ -1,0 +1,90 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {getWebGLTestDevice} from '@luma.gl/test-utils';
+
+test('WEBGLTexture keeps borrowed handles read-only', async t => {
+  const device = await getWebGLTestDevice();
+  const {gl} = device;
+  const textureHandle = gl.createTexture()!;
+  const methodCallCounts = {
+    deleteTexture: 0,
+    generateMipmap: 0,
+    texParameteri: 0,
+    texStorage2D: 0
+  };
+  const originalDeleteTexture = gl.deleteTexture.bind(gl);
+  const originalGenerateMipmap = gl.generateMipmap.bind(gl);
+  const originalTexParameteri = gl.texParameteri.bind(gl);
+  const originalTexStorage2D = gl.texStorage2D.bind(gl);
+  gl.deleteTexture = (texture => {
+    methodCallCounts.deleteTexture++;
+    return originalDeleteTexture(texture);
+  }) as typeof gl.deleteTexture;
+  gl.generateMipmap = (target => {
+    methodCallCounts.generateMipmap++;
+    return originalGenerateMipmap(target);
+  }) as typeof gl.generateMipmap;
+  gl.texParameteri = ((target, parameterName, parameterValue) => {
+    methodCallCounts.texParameteri++;
+    return originalTexParameteri(target, parameterName, parameterValue);
+  }) as typeof gl.texParameteri;
+  gl.texStorage2D = ((target, levels, internalFormat, width, height) => {
+    methodCallCounts.texStorage2D++;
+    return originalTexStorage2D(target, levels, internalFormat, width, height);
+  }) as typeof gl.texStorage2D;
+
+  try {
+    t.throws(
+      () => device.createTexture({_isHandleBorrowed: true, width: 1, height: 1}),
+      /require.*texture handle/,
+      'borrowed wrapper requires an external texture handle'
+    );
+
+    const texture = device.createTexture({
+      handle: textureHandle,
+      _isHandleBorrowed: true,
+      width: 4,
+      height: 2
+    });
+
+    t.true(texture.isHandleBorrowed, 'resource records borrowed handle ownership');
+    t.false(texture.ownsHandle, 'resource does not own borrowed handle');
+    t.equal(methodCallCounts.texStorage2D, 0, 'borrowed wrapper does not allocate storage');
+    t.equal(methodCallCounts.texParameteri, 0, 'borrowed wrapper does not mutate sampler state');
+    t.throws(
+      () => texture.generateMipmapsWebGL(),
+      /borrowed read-only/,
+      'borrowed wrapper rejects mipmap generation'
+    );
+    t.throws(
+      () => texture.copyElementImage({} as never),
+      /borrowed read-only/,
+      'borrowed wrapper rejects element uploads'
+    );
+    t.throws(
+      () => texture.clone({width: 8, height: 4}),
+      /resize borrowed read-only/,
+      'borrowed wrapper rejects resize-like clones'
+    );
+    t.equal(methodCallCounts.generateMipmap, 0, 'rejected mipmap generation does not touch GL');
+
+    texture.destroy();
+    t.equal(
+      methodCallCounts.deleteTexture,
+      0,
+      'destroying wrapper does not delete borrowed handle'
+    );
+  } finally {
+    gl.deleteTexture = originalDeleteTexture;
+    gl.generateMipmap = originalGenerateMipmap;
+    gl.texParameteri = originalTexParameteri;
+    gl.texStorage2D = originalTexStorage2D;
+    originalDeleteTexture(textureHandle);
+    device.destroy();
+  }
+
+  t.end();
+});

--- a/modules/webgl/test/index.ts
+++ b/modules/webgl/test/index.ts
@@ -34,3 +34,4 @@ import './adapter/resources/webgl-vertex-array.spec';
 import './adapter/resources/webgl-transform-feedback.spec';
 import './adapter/resources/webgl-render-pass.spec';
 import './adapter/resources/webgl-render-pipeline.spec';
+import './adapter/resources/webgl-texture.spec';


### PR DESCRIPTION
## Goals
- Extract the generic resource, binding, and frame scheduling infrastructure needed by future deferred texture sources before WebXR.

## Changes
- Move opaque borrowed-handle state to ResourceProps and expose generic handle ownership helpers.
- Add a WebGL borrowed read-only texture wrapper path with a focused backend test.
- Add direct ShaderInputs bindings and experimental AnimationFrameProvider payload support.

## Verification
- nvm use
- yarn install
- yarn lint fix
- yarn build
- yarn test-node
- yarn test-headless