### PR TITLE
feat(tables) GPUConstantVector using arrayStride:0

### DIFF
--- a/docs/api-reference/tables/README.mdx
+++ b/docs/api-reference/tables/README.mdx
@@ -15,6 +15,7 @@ GPU-resident table primitives for luma.gl.
 
 - [GPU Table Structure](/docs/api-reference/tables/gpu-table-structure)
 - [GPU Table Lifecycle](/docs/api-reference/tables/gpu-table-lifecycle)
+- [Constant Columns](/docs/api-reference/tables/constant-columns)
 - [GPUTable](/docs/api-reference/tables/gpu-table)
 - [GPURecordBatch](/docs/api-reference/tables/gpu-record-batch)
 - [GPUVector](/docs/api-reference/tables/gpu-vector)
@@ -25,9 +26,9 @@ GPU-resident table primitives for luma.gl.
 - [Supported Arrow Types](/docs/api-reference/arrow/supported-arrow-types)
 
 The `@luma.gl/tables` module owns reusable table-side GPU objects such as
-`GPUData`, `GPUVector`, `GPURecordBatch`, and `GPUTable`, plus structural typing
-types such as `GPUSchema`, `GPUField`, `GPUTypeMap`, `GPUVectorFormat`, and
-`VertexList`. Table-oriented execution helpers include `TableTransform`,
+`GPUData`, `GPUVector`, `GPUConstantVector`, `GPURecordBatch`, and `GPUTable`,
+plus structural typing types such as `GPUSchema`, `GPUField`, `GPUTypeMap`,
+`GPUVectorFormat`, and `VertexList`. Table-oriented execution helpers include `TableTransform`,
 `GPUTableComputation`, `GPUTableBufferPlanner`, and generated-buffer batching
 utilities. `GPUTableModel` renders preserved table batches through one model
 pipeline, while `GPUTableGeometry` exposes a packed static table as ordinary GPU

--- a/docs/api-reference/tables/constant-columns.mdx
+++ b/docs/api-reference/tables/constant-columns.mdx
@@ -1,0 +1,201 @@
+import {TablesDocsTabs} from '@site/src/components/docs/tables-docs-tabs';
+
+# Constant Columns
+
+<TablesDocsTabs active="constants" />
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From: v10" />
+  <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
+</p>
+
+A constant column has one physical value and a logical value for every row in a
+table or record batch. It lets an application use one shader interface for both
+per-row data and constant styling without materializing the same value once per
+row.
+
+Constant columns are a logical table concept. Vertex attributes, WebGL current
+attributes, uniforms, and storage buffers use different physical mechanisms to
+publish that concept to a shader.
+
+## Logical And Physical Size
+
+For a constant color applied to 100,000 rows:
+
+| Property | Value |
+| --- | --- |
+| Logical length | `100000` rows |
+| Format | `unorm8x4` |
+| Physical payload | One 4-byte color |
+| Vertex byte stride | `0` on WebGPU |
+
+Logical length is used for table row alignment and draw counts. Physical byte
+length is used for allocation and memory metrics. Each streamed batch may have
+its own constant value, so one payload is stored per batch rather than once for
+the aggregate table.
+
+## WebGPU Vertex Attributes
+
+`GPUConstantVector` represents a fixed-width constant column as one vertex
+payload with zero byte stride:
+
+```ts
+import {GPUConstantVector} from '@luma.gl/tables';
+
+const colors = GPUConstantVector.fromValue(device, {
+  id: 'point-colors',
+  name: 'colors',
+  format: 'unorm8x4',
+  length: table.numRows,
+  value: new Uint8Array([73, 166, 255, 220])
+});
+```
+
+`GPUConstantVector.fromValue()` creates and owns a vertex buffer containing
+exactly one encoded value. The constructor form wraps an existing `Buffer` or
+`DynamicBuffer` containing one complete value at byte offset zero:
+
+```ts
+const radii = new GPUConstantVector({
+  name: 'radii',
+  buffer,
+  format: 'float32',
+  length: table.numRows,
+  ownsBuffer: false
+});
+```
+
+The shader declaration is identical for constant and per-row columns:
+
+```wgsl
+struct VertexInputs {
+  @location(0) position: vec2<f32>,
+  @location(1) color: vec4<f32>,
+  @location(2) radius: f32,
+};
+```
+
+Only the bound buffer layout changes. With `arrayStride: 0`, every vertex or
+instance reads the same payload row.
+
+### Interleaved Constants
+
+Multiple constant attributes can share one physical buffer:
+
+```text
+constant payload: [color][radius][angle]
+
+buffer layout:
+  byteStride: 0
+  color:  byteOffset 0
+  radius: byteOffset 4
+  angle:  byteOffset 8
+```
+
+Zero stride applies to the entire vertex-buffer binding, not to one attribute
+inside it. Every attribute in a zero-stride interleaved buffer must therefore be
+constant.
+
+To override only some attributes from an existing interleaved row buffer, move
+the overridden attributes into a separate zero-stride buffer layout. Keep the
+remaining per-row attributes in their original nonzero-stride layout. Both
+layouts continue to target the shader's existing attribute locations.
+
+Interleaved constant groups also need an explicit physical payload byte length.
+It is the end of the last attribute payload, including required alignment and
+padding; it is not the zero byte stride.
+
+## WebGL Vertex Attributes
+
+WebGL exposes constant attributes as current generic vertex attribute values:
+
+```ts
+gl.disableVertexAttribArray(location);
+gl.vertexAttrib4fv(location, value);
+```
+
+The disabled array causes every vertex to receive the current value. WebGL2
+also provides integer forms such as `vertexAttribI4i()` and
+`vertexAttribI4ui()`. Matrix inputs occupy multiple attribute locations and
+require one constant value per location.
+
+WebGL's `vertexAttribPointer(..., stride = 0)` does not broadcast one row. In
+WebGL, zero means tightly packed array data. Applications must use the current
+attribute API or materialize repeated values.
+
+The WebGL API does not expose a buffer for a current attribute. Browser and
+driver implementations may use native vertex-input state or emulate the value
+with a small cached buffer. Some ANGLE backends use an internal streamed vertex
+buffer with zero stride, but that allocation is not part of the application's
+WebGL buffer model.
+
+The current attribute API requires a CPU-accessible typed value. An opaque GPU
+buffer cannot be converted into a WebGL current attribute without readback.
+Portable applications should therefore retain the typed constant value as the
+source of truth, even when WebGPU uploads that value into a zero-stride buffer.
+
+The Arrow points integration currently uses materialized vectors as its WebGL
+fallback. Native WebGL current-attribute publication requires a constant-aware
+model or vertex-array binding API in addition to `GPUConstantVector`.
+
+## WebGPU Storage Buffers
+
+Storage buffers do not have bind-time vertex stride state. A one-element
+storage buffer must be paired with shader indexing that selects element zero.
+
+One approach is a uniform row multiplier for each independently constant
+column:
+
+```wgsl
+struct TableColumnModes {
+  colorRowMultiplier: u32,
+  radiusRowMultiplier: u32,
+};
+
+@group(0) @binding(0) var<uniform> columnModes: TableColumnModes;
+@group(0) @binding(1) var<storage, read> colors: array<u32>;
+@group(0) @binding(2) var<storage, read> radii: array<f32>;
+
+fn readColor(logicalRowIndex: u32) -> u32 {
+  return colors[logicalRowIndex * columnModes.colorRowMultiplier];
+}
+
+fn readRadius(logicalRowIndex: u32) -> f32 {
+  return radii[logicalRowIndex * columnModes.radiusRowMultiplier];
+}
+```
+
+Set a multiplier to `0` for a one-element constant buffer and `1` for a normal
+per-row column. In a simple instanced table, `logicalRowIndex` can be
+`instance_index`. Row-geometry renderers should pass their source-row mapping
+instead.
+
+For many booleans, applications can encode the multipliers in a bit mask. If
+all constants are small and consumed together, another option is one uniform
+constant struct rather than several one-element storage buffers.
+
+Storage-buffer constant handling is shader-aware and is not currently
+implemented by `GPUConstantVector`. Do not interpret `byteStride: 0` as storage
+buffer indexing behavior.
+
+## Backend Summary
+
+| Consumption path | Constant representation | Current tables support |
+| --- | --- | --- |
+| WebGPU vertex attribute | One payload row with `arrayStride: 0` | `GPUConstantVector` for fixed-width attributes |
+| WebGPU interleaved vertex attributes | One packed payload row with zero group stride | Planned; requires constant-only grouping and explicit payload size |
+| WebGL vertex attribute | Disabled array plus `vertexAttrib*()` current value | Materialized fallback; native publication requires CPU value bindings |
+| WebGPU storage buffer | One-element buffer plus shader index selection, or a uniform struct | Application/shader managed |
+| WebGL storage buffer | Not available | Not applicable |
+
+## Batching And Packing
+
+Constants are batch-local. Two adjacent batches can use different constant
+values while exposing one aggregate logical column. Consequently,
+`GPUTable.packBatches()` rejects groups containing zero-stride vectors; merging
+them would require either proving their payloads equal or materializing the
+values.
+
+Use `getGPUDataByteLength()` and `getGPUVectorByteLength()` for physical memory
+accounting. They count a zero-stride chunk as one payload row while preserving
+the vector's logical `length` for table validation.

--- a/docs/api-reference/tables/gpu-vector.mdx
+++ b/docs/api-reference/tables/gpu-vector.mdx
@@ -35,6 +35,9 @@ When the input starts as Apache Arrow, prefer
 [`makeGPUVectorFromArrow()`](/docs/api-reference/arrow/supported-arrow-types) from
 `@luma.gl/arrow`.
 
+Use [`GPUConstantVector`](/docs/api-reference/tables/constant-columns) when one
+fixed-width value should be broadcast across the vector's logical rows.
+
 ## Constructor Modes
 
 `GPUVector` uses a discriminated constructor prop union.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -194,6 +194,7 @@
           "api-reference/tables/README",
           "api-reference/tables/gpu-table-structure",
           "api-reference/tables/gpu-table-lifecycle",
+          "api-reference/tables/constant-columns",
           "api-reference/tables/gpu-table",
           "api-reference/tables/gpu-record-batch",
           "api-reference/tables/gpu-vector",

--- a/examples/arrow/arrow-points/arrow-point-renderer.ts
+++ b/examples/arrow/arrow-points/arrow-point-renderer.ts
@@ -30,7 +30,14 @@ import {
 } from '@luma.gl/arrow';
 import type {Device, RenderPass} from '@luma.gl/core';
 import type {PickingManager, PickInfo, PickingShouldPickOptions} from '@luma.gl/engine';
-import {GPUTable, type GPURecordBatch, type GPUTableModel, type GPUVector} from '@luma.gl/tables';
+import {
+  GPUConstantVector,
+  GPUTable,
+  getGPUVectorByteLength,
+  type GPURecordBatch,
+  type GPUTableModel,
+  type GPUVector
+} from '@luma.gl/tables';
 import * as arrow from 'apache-arrow';
 import {
   createPointModel,
@@ -493,16 +500,36 @@ export async function convertArrowPointColumnsToGPUVectors(
     timeOrigin: options.timeOrigin,
     id: `${id}-event-times`
   });
-  const pointRadii = makeGPUVectorFromArrow(
-    device,
-    radii ?? makeConstantRadiusVector(rowCount, options.radius ?? DEFAULT_POINT_RENDERER_RADIUS),
-    {name: 'radii', id: `${id}-radii`, format: 'float32'}
-  );
-  const pointColors = makeGPUVectorFromArrow(
-    device,
-    colors ?? makeConstantColorVector(rowCount, options.color ?? DEFAULT_POINT_RENDERER_COLOR),
-    {name: 'colors', id: `${id}-colors`, format: 'unorm8x4'}
-  );
+  const radius = options.radius ?? DEFAULT_POINT_RENDERER_RADIUS;
+  const pointRadii =
+    !radii && device.type === 'webgpu'
+      ? GPUConstantVector.fromValue(device, {
+          name: 'radii',
+          id: `${id}-radii`,
+          format: 'float32',
+          length: rowCount,
+          value: new Float32Array([radius])
+        })
+      : makeGPUVectorFromArrow(device, radii ?? makeConstantRadiusVector(rowCount, radius), {
+          name: 'radii',
+          id: `${id}-radii`,
+          format: 'float32'
+        });
+  const color = options.color ?? DEFAULT_POINT_RENDERER_COLOR;
+  const pointColors =
+    !colors && device.type === 'webgpu'
+      ? GPUConstantVector.fromValue(device, {
+          name: 'colors',
+          id: `${id}-colors`,
+          format: 'unorm8x4',
+          length: rowCount,
+          value: new Uint8Array(color)
+        })
+      : makeGPUVectorFromArrow(device, colors ?? makeConstantColorVector(rowCount, color), {
+          name: 'colors',
+          id: `${id}-colors`,
+          format: 'unorm8x4'
+        });
   const rowIndices = makeArrowRowIndexGPUVector(device, {
     rowCount,
     rowIndexOffset,
@@ -846,10 +873,6 @@ function makeConstantColorVector(
     values.set(color, rowIndex * 4);
   }
   return makeArrowFixedSizeListVector(new arrow.Uint8(), 4, values);
-}
-
-function getGPUVectorByteLength(vector: GPUVector): number {
-  return vector.length * vector.byteStride;
 }
 
 function hasPointSource(props: ArrowPointRendererProps): boolean {

--- a/examples/arrow/arrow-temporal-starfield/app.ts
+++ b/examples/arrow/arrow-temporal-starfield/app.ts
@@ -10,7 +10,8 @@ import {
   makeTemporalStarfieldRecordBatches,
   STAR_COUNT,
   STREAMING_STARFIELD_BATCH_COUNT,
-  STREAMING_STARFIELD_ROWS_PER_BATCH
+  STREAMING_STARFIELD_ROWS_PER_BATCH,
+  type TemporalStarfieldStyleKind
 } from './arrow-temporal-starfield-data';
 import {
   ArrowTemporalStarfieldRenderer,
@@ -40,6 +41,8 @@ export default class ArrowTemporalStarfieldAnimationLoopTemplate extends Animati
   });
   activeRenderMode: 'attributes' | 'storage';
   activeTimeColumn: 'timestamp' | 'xyzm' = 'timestamp';
+  activeStarSizeKind: TemporalStarfieldStyleKind = 'constant';
+  activeEventColorKind: TemporalStarfieldStyleKind = 'constant';
   layer: ArrowTemporalStarfieldRenderer | null = null;
   inputRequestVersion = 0;
   isFinalized = false;
@@ -57,11 +60,15 @@ export default class ArrowTemporalStarfieldAnimationLoopTemplate extends Animati
       initialState: {
         renderMode: this.activeRenderMode,
         timeColumn: this.activeTimeColumn,
+        starSizeKind: this.activeStarSizeKind,
+        eventColorKind: this.activeEventColorKind,
         supportsStorage
       },
       handlers: {
         onRenderModeChange: this.handleRenderModeSelection,
-        onTimeColumnChange: this.handleTimeColumnSelection
+        onTimeColumnChange: this.handleTimeColumnSelection,
+        onStarSizeKindChange: this.handleStarSizeKindSelection,
+        onEventColorKindChange: this.handleEventColorKindSelection
       },
       onRefresh: () => this.panels.refresh()
     });
@@ -70,7 +77,9 @@ export default class ArrowTemporalStarfieldAnimationLoopTemplate extends Animati
   override async onInitialize(): Promise<void> {
     this.layer = new ArrowTemporalStarfieldRenderer(this.device, {
       renderMode: this.activeRenderMode,
-      timeColumn: this.activeTimeColumn
+      timeColumn: this.activeTimeColumn,
+      starSizeColumn: this.activeStarSizeKind === 'constant' ? null : 'starSizes',
+      eventColorColumn: this.activeEventColorKind === 'constant' ? null : 'eventColors'
     });
     this.panels.mount();
     this.controlPanel.initialize();
@@ -120,6 +129,24 @@ export default class ArrowTemporalStarfieldAnimationLoopTemplate extends Animati
     this.startStreamingStarfield();
   };
 
+  handleStarSizeKindSelection = (starSizeKind: TemporalStarfieldStyleKind): void => {
+    if (starSizeKind === this.activeStarSizeKind) {
+      return;
+    }
+    this.activeStarSizeKind = starSizeKind;
+    this.controlPanel.syncControls({starSizeKind});
+    this.startStreamingStarfield();
+  };
+
+  handleEventColorKindSelection = (eventColorKind: TemporalStarfieldStyleKind): void => {
+    if (eventColorKind === this.activeEventColorKind) {
+      return;
+    }
+    this.activeEventColorKind = eventColorKind;
+    this.controlPanel.syncControls({eventColorKind});
+    this.startStreamingStarfield();
+  };
+
   private startStreamingStarfield(): void {
     const layer = this.layer;
     if (!layer) {
@@ -131,7 +158,9 @@ export default class ArrowTemporalStarfieldAnimationLoopTemplate extends Animati
     const recordBatches = makeTemporalStarfieldRecordBatches(
       STAR_COUNT,
       STREAMING_STARFIELD_ROWS_PER_BATCH,
-      this.activeTimeColumn
+      this.activeTimeColumn,
+      this.activeStarSizeKind,
+      this.activeEventColorKind
     );
     this.activeStarfieldTableStream = this.panels.beginLoadedTableStream({
       id: 'temporal-starfield-source',
@@ -141,6 +170,8 @@ export default class ArrowTemporalStarfieldAnimationLoopTemplate extends Animati
     });
 
     layer.setProps({
+      starSizeColumn: this.activeStarSizeKind === 'constant' ? null : 'starSizes',
+      eventColorColumn: this.activeEventColorKind === 'constant' ? null : 'eventColors',
       data: createStreamingTemporalStarfieldRecordBatchIterator(recordBatches),
       onDataBatch: this.handleStreamingStarfieldBatch
     });

--- a/examples/arrow/arrow-temporal-starfield/arrow-temporal-starfield-data.ts
+++ b/examples/arrow/arrow-temporal-starfield/arrow-temporal-starfield-data.ts
@@ -14,6 +14,8 @@ export const CURRENT_TIME_RATE_MILLISECONDS_PER_SECOND = 3_200;
 export const SOURCE_TIMESTAMP_ORIGIN_MILLISECONDS = Date.UTC(2026, 4, 22, 21);
 export const TAU = Math.PI * 2;
 
+export type TemporalStarfieldStyleKind = 'constant' | 'column';
+
 export type TemporalStarfieldSourceVectors = {
   eventStarts: arrow.Vector<arrow.TimestampMillisecond>;
   eventDurations: arrow.Vector<arrow.DurationMillisecond>;
@@ -92,7 +94,9 @@ export function makeTemporalStarfieldRows(
 
 export function makeTemporalStarfieldTable(
   starRows: TemporalStarfieldRows = makeTemporalStarfieldRows(),
-  timeColumn: 'timestamp' | 'xyzm' = 'timestamp'
+  timeColumn: 'timestamp' | 'xyzm' = 'timestamp',
+  starSizeKind: TemporalStarfieldStyleKind = 'column',
+  eventColorKind: TemporalStarfieldStyleKind = 'column'
 ): arrow.Table {
   const columns: Record<string, arrow.Vector> = {
     positions:
@@ -104,9 +108,7 @@ export function makeTemporalStarfieldTable(
           )
         : makeArrowFixedSizeListVector(new arrow.Float32(), 2, starRows.positions),
     eventDurations: makeTemporalVector(new arrow.DurationMillisecond(), starRows.eventDurations),
-    pulsePeriods: makeTemporalVector(new arrow.DurationMillisecond(), starRows.pulsePeriods),
-    starSizes: makeFloat32Vector(starRows.starSizes),
-    eventColors: makeArrowFixedSizeListVector(new arrow.Uint8(), 4, starRows.eventColors)
+    pulsePeriods: makeTemporalVector(new arrow.DurationMillisecond(), starRows.pulsePeriods)
   };
   if (timeColumn === 'timestamp') {
     columns.eventStarts = makeTemporalVector(
@@ -114,20 +116,30 @@ export function makeTemporalStarfieldTable(
       starRows.eventStarts
     );
   }
+  if (starSizeKind === 'column') {
+    columns.starSizes = makeFloat32Vector(starRows.starSizes);
+  }
+  if (eventColorKind === 'column') {
+    columns.eventColors = makeArrowFixedSizeListVector(new arrow.Uint8(), 4, starRows.eventColors);
+  }
   return new arrow.Table(columns);
 }
 
 export function makeTemporalStarfieldRecordBatches(
   starCount = STAR_COUNT,
   rowsPerBatch = starCount,
-  timeColumn: 'timestamp' | 'xyzm' = 'timestamp'
+  timeColumn: 'timestamp' | 'xyzm' = 'timestamp',
+  starSizeKind: TemporalStarfieldStyleKind = 'column',
+  eventColorKind: TemporalStarfieldStyleKind = 'column'
 ): arrow.RecordBatch[] {
   const recordBatches: arrow.RecordBatch[] = [];
   for (let starStart = 0; starStart < starCount; starStart += rowsPerBatch) {
     const batchStarCount = Math.min(rowsPerBatch, starCount - starStart);
     const recordBatch = makeTemporalStarfieldTable(
       makeTemporalStarfieldRows(starStart, batchStarCount),
-      timeColumn
+      timeColumn,
+      starSizeKind,
+      eventColorKind
     ).batches[0];
     if (recordBatch) {
       recordBatches.push(recordBatch);

--- a/examples/arrow/arrow-temporal-starfield/arrow-temporal-starfield-renderer.ts
+++ b/examples/arrow/arrow-temporal-starfield/arrow-temporal-starfield-renderer.ts
@@ -12,10 +12,11 @@ import {
   type ArrowRecordBatchSource,
   type PreparedArrowTemporalGPUVector
 } from '@luma.gl/arrow';
-import {type Buffer, type CommandEncoder, type Device, type RenderPass} from '@luma.gl/core';
+import {Buffer, type CommandEncoder, type Device, type RenderPass} from '@luma.gl/core';
 import {type DynamicBuffer, Model, ShaderInputs} from '@luma.gl/engine';
 import {
   GPURenderable,
+  GPUConstantVector,
   GPURecordBatch,
   GPUTable,
   GPUTableModel,
@@ -50,6 +51,14 @@ export type ArrowTemporalStarfieldRendererProps = {
   renderMode?: 'attributes' | 'storage';
   /** Source time representation used for event starts. */
   timeColumn?: 'timestamp' | 'xyzm';
+  /** Arrow size column. Set to `null` to broadcast `starSize`. */
+  starSizeColumn?: string | null;
+  /** Arrow color column. Set to `null` to broadcast `eventColor`. */
+  eventColorColumn?: string | null;
+  /** Constant star size used when `starSizeColumn` is null. */
+  starSize?: number;
+  /** Constant RGBA8 color used when `eventColorColumn` is null. */
+  eventColor?: [number, number, number, number];
   /** Optional Arrow source table, record-batch iterable, or async record-batch iterator. */
   data?: ArrowRecordBatchSource;
   /** Synthetic clock rate used to advance the star pulse timeline. */
@@ -82,6 +91,10 @@ export type ArrowTemporalStarfieldRendererLabels = {
   positionsColumn: string;
   /** Active event-start column label. */
   eventStartsColumn: string;
+  /** Active star-size column or constant label. */
+  starSizesColumn: string;
+  /** Active event-color column or constant label. */
+  eventColorsColumn: string;
   /** Timestamp origin label. */
   timestampOrigin: string;
   /** Duration origin label. */
@@ -109,10 +122,22 @@ type TemporalStarfieldTableInput = {
   destroy: () => void;
 };
 
-type TemporalStarfieldGPURecordBatchInput = {
+export type TemporalStarfieldGPURecordBatchInput = {
   gpuRecordBatch: GPURecordBatch<GPUTypeMap>;
   temporalColumns: PreparedTemporalColumns;
   timestampOriginMilliseconds: number;
+};
+
+export type TemporalStarfieldStyleOptions = {
+  starSizeColumn: string | null;
+  eventColorColumn: string | null;
+  starSize: number;
+  eventColor: [number, number, number, number];
+};
+
+export type TemporalStarfieldPreparationOptions = {
+  /** Prefer WebGPU compute for temporal conversion when available. */
+  preferTemporalGPU?: boolean;
 };
 
 type TemporalStarfieldRecordBatchVectors = {
@@ -120,8 +145,8 @@ type TemporalStarfieldRecordBatchVectors = {
   eventStarts: arrow.Vector<arrow.TimestampMillisecond> | null;
   eventDurations: arrow.Vector<arrow.DurationMillisecond>;
   pulsePeriods: arrow.Vector<arrow.DurationMillisecond>;
-  starSizes: arrow.Vector<arrow.Float32>;
-  eventColors: arrow.Vector<arrow.FixedSizeList<arrow.Uint8>>;
+  starSizes: arrow.Vector<arrow.Float32> | null;
+  eventColors: arrow.Vector<arrow.FixedSizeList<arrow.Uint8>> | null;
 };
 
 type ActiveTemporalStarfieldModel = GPUTableModel | Model;
@@ -135,6 +160,10 @@ const DEFAULT_TEMPORAL_STARFIELD_PROPS = {
     'currentTimeRateMillisecondsPerSecond' | 'initialTimestampMilliseconds'
   >
 >;
+export const DEFAULT_TEMPORAL_STARFIELD_STAR_SIZE = 0.01;
+export const DEFAULT_TEMPORAL_STARFIELD_EVENT_COLOR: [number, number, number, number] = [
+  104, 168, 255, 255
+];
 const TEMPORAL_STARFIELD_VERTEX_STORAGE_BUFFER_COUNT = 6;
 
 /** Example layer that renders timestamp/duration Arrow columns as blinking star instances. */
@@ -176,7 +205,13 @@ export class ArrowTemporalStarfieldRenderer extends GPURenderable<[RenderPass, {
   async initialize(): Promise<void> {
     this.replaceData(
       this.props.data ??
-        makeTemporalStarfieldRecordBatches(undefined, undefined, this.activeTimeColumn),
+        makeTemporalStarfieldRecordBatches(
+          undefined,
+          undefined,
+          this.activeTimeColumn,
+          this.props.starSizeColumn === null ? 'constant' : 'column',
+          this.props.eventColorColumn === null ? 'constant' : 'column'
+        ),
       true
     );
   }
@@ -205,7 +240,9 @@ export class ArrowTemporalStarfieldRenderer extends GPURenderable<[RenderPass, {
 
     this.shaderInputs.setProps({
       temporalStarfield: {
-        currentTimestamp: this.currentTimestampMilliseconds
+        currentTimestamp: this.currentTimestampMilliseconds,
+        starSizeRowMultiplier: 1,
+        eventColorRowMultiplier: 1
       }
     });
 
@@ -278,6 +315,16 @@ export class ArrowTemporalStarfieldRenderer extends GPURenderable<[RenderPass, {
         this.activeTimeColumn === 'xyzm'
           ? 'eventStarts: M coordinate from positions'
           : 'eventStarts: TimestampMillisecond',
+      starSizesColumn:
+        this.props.starSizeColumn === null
+          ? `starSizes: Constant Float32 ${this.props.starSize ?? DEFAULT_TEMPORAL_STARFIELD_STAR_SIZE}`
+          : `${this.props.starSizeColumn ?? 'starSizes'}: Float32`,
+      eventColorsColumn:
+        this.props.eventColorColumn === null
+          ? `eventColors: Constant RGBA8 [${(
+              this.props.eventColor ?? DEFAULT_TEMPORAL_STARFIELD_EVENT_COLOR
+            ).join(', ')}]`
+          : `${this.props.eventColorColumn ?? 'eventColors'}: FixedSizeList<Uint8, 4>`,
       timestampOrigin: formatTimestampOriginMilliseconds(
         temporalColumns.eventStarts.originMilliseconds
       ),
@@ -362,7 +409,17 @@ export class ArrowTemporalStarfieldRenderer extends GPURenderable<[RenderPass, {
           this.device,
           recordBatch,
           context.batchIndex,
-          this.activeTimeColumn
+          this.activeTimeColumn,
+          {
+            starSizeColumn:
+              this.props.starSizeColumn === undefined ? 'starSizes' : this.props.starSizeColumn,
+            eventColorColumn:
+              this.props.eventColorColumn === undefined
+                ? 'eventColors'
+                : this.props.eventColorColumn,
+            starSize: this.props.starSize ?? DEFAULT_TEMPORAL_STARFIELD_STAR_SIZE,
+            eventColor: this.props.eventColor ?? DEFAULT_TEMPORAL_STARFIELD_EVENT_COLOR
+          }
         ),
       appendBatch: batchInput => this.addGPURecordBatchInput(batchInput),
       destroyBatch: batchInput => batchInput.gpuRecordBatch.destroy(),
@@ -407,6 +464,9 @@ export class ArrowTemporalStarfieldRenderer extends GPURenderable<[RenderPass, {
       if (batch.numRows === 0) {
         continue;
       }
+      this.shaderInputs.setProps({
+        temporalStarfield: getTemporalStarfieldStorageRowMultipliers(batch)
+      });
       this.starModel.setBindings(getTemporalStarfieldStorageBindings(batch));
       this.starModel.setInstanceCount(batch.numRows);
       this.starModel.draw(renderPass);
@@ -457,14 +517,25 @@ function createTemporalStarfieldTableInput(
   };
 }
 
-async function makeTemporalStarfieldGPURecordBatchInput(
+export async function makeTemporalStarfieldGPURecordBatchInput(
   device: Device,
   recordBatch: arrow.RecordBatch,
   batchIndex: number,
-  timeColumn: 'timestamp' | 'xyzm'
+  timeColumn: 'timestamp' | 'xyzm',
+  styleOptions: TemporalStarfieldStyleOptions = {
+    starSizeColumn: 'starSizes',
+    eventColorColumn: 'eventColors',
+    starSize: DEFAULT_TEMPORAL_STARFIELD_STAR_SIZE,
+    eventColor: DEFAULT_TEMPORAL_STARFIELD_EVENT_COLOR
+  },
+  preparationOptions: TemporalStarfieldPreparationOptions = {}
 ): Promise<TemporalStarfieldGPURecordBatchInput> {
   const sourceTable = new arrow.Table([recordBatch]);
-  const sourceVectors = getTemporalStarfieldRecordBatchVectors(sourceTable, timeColumn);
+  const sourceVectors = getTemporalStarfieldRecordBatchVectors(
+    sourceTable,
+    timeColumn,
+    styleOptions
+  );
   const preparedDurationColumns = await convertArrowTemporalToGPUVectors(
     device,
     {
@@ -473,8 +544,14 @@ async function makeTemporalStarfieldGPURecordBatchInput(
     },
     {
       columns: {
-        eventDurations: {id: `arrow-temporal-starfield-event-durations-${batchIndex}`},
-        pulsePeriods: {id: `arrow-temporal-starfield-pulse-periods-${batchIndex}`}
+        eventDurations: {
+          id: `arrow-temporal-starfield-event-durations-${batchIndex}`,
+          preferGPU: preparationOptions.preferTemporalGPU
+        },
+        pulsePeriods: {
+          id: `arrow-temporal-starfield-pulse-periods-${batchIndex}`,
+          preferGPU: preparationOptions.preferTemporalGPU
+        }
       }
     }
   );
@@ -498,7 +575,8 @@ async function makeTemporalStarfieldGPURecordBatchInput(
       preparedEventStarts = await convertTimestampEventStartsToGPUVector(
         device,
         getRequiredTimestampVector(sourceVectors.eventStarts),
-        batchIndex
+        batchIndex,
+        preparationOptions.preferTemporalGPU
       );
     }
     positions = makeGPUVectorFromArrow(device, modelPositions, {
@@ -506,16 +584,20 @@ async function makeTemporalStarfieldGPURecordBatchInput(
       id: `arrow-temporal-starfield-positions-${batchIndex}`,
       format: 'float32x2'
     });
-    starSizes = makeGPUVectorFromArrow(device, sourceVectors.starSizes, {
-      name: 'starSizes',
-      id: `arrow-temporal-starfield-star-sizes-${batchIndex}`,
-      format: 'float32'
-    });
-    eventColors = makeGPUVectorFromArrow(device, sourceVectors.eventColors, {
-      name: 'eventColors',
-      id: `arrow-temporal-starfield-event-colors-${batchIndex}`,
-      format: 'unorm8x4'
-    });
+    starSizes = makeTemporalStarfieldStarSizesGPUVector(
+      device,
+      sourceVectors.starSizes,
+      recordBatch.numRows,
+      styleOptions.starSize,
+      batchIndex
+    );
+    eventColors = makeTemporalStarfieldEventColorsGPUVector(
+      device,
+      sourceVectors.eventColors,
+      recordBatch.numRows,
+      styleOptions.eventColor,
+      batchIndex
+    );
     const temporalColumns: PreparedTemporalColumns = {
       eventStarts: preparedEventStarts,
       eventDurations: preparedDurationColumns.eventDurations,
@@ -550,7 +632,8 @@ async function makeTemporalStarfieldGPURecordBatchInput(
 
 function getTemporalStarfieldRecordBatchVectors(
   table: arrow.Table,
-  timeColumn: 'timestamp' | 'xyzm'
+  timeColumn: 'timestamp' | 'xyzm',
+  styleOptions: {starSizeColumn: string | null; eventColorColumn: string | null}
 ): TemporalStarfieldRecordBatchVectors {
   return {
     positions: getRequiredArrowVector(table, 'positions'),
@@ -560,9 +643,83 @@ function getTemporalStarfieldRecordBatchVectors(
         : (table.getChild('eventStarts') as arrow.Vector<arrow.TimestampMillisecond> | null),
     eventDurations: getRequiredArrowVector(table, 'eventDurations'),
     pulsePeriods: getRequiredArrowVector(table, 'pulsePeriods'),
-    starSizes: getRequiredArrowVector(table, 'starSizes'),
-    eventColors: getRequiredArrowVector(table, 'eventColors')
+    starSizes: styleOptions.starSizeColumn
+      ? getRequiredArrowVector(table, styleOptions.starSizeColumn)
+      : null,
+    eventColors: styleOptions.eventColorColumn
+      ? getRequiredArrowVector(table, styleOptions.eventColorColumn)
+      : null
   };
+}
+
+function makeTemporalStarfieldStarSizesGPUVector(
+  device: Device,
+  starSizes: arrow.Vector<arrow.Float32> | null,
+  rowCount: number,
+  starSize: number,
+  batchIndex: number
+): GPUVector<'float32'> {
+  const id = `arrow-temporal-starfield-star-sizes-${batchIndex}`;
+  if (!starSizes && device.type === 'webgpu') {
+    return GPUConstantVector.fromValue(device, {
+      name: 'starSizes',
+      id,
+      format: 'float32',
+      length: rowCount,
+      value: new Float32Array([starSize]),
+      usage: Buffer.STORAGE
+    });
+  }
+  return makeGPUVectorFromArrow(
+    device,
+    starSizes ?? makeConstantStarSizesVector(rowCount, starSize),
+    {name: 'starSizes', id, format: 'float32'}
+  );
+}
+
+function makeTemporalStarfieldEventColorsGPUVector(
+  device: Device,
+  eventColors: arrow.Vector<arrow.FixedSizeList<arrow.Uint8>> | null,
+  rowCount: number,
+  eventColor: [number, number, number, number],
+  batchIndex: number
+): GPUVector<'unorm8x4'> {
+  const id = `arrow-temporal-starfield-event-colors-${batchIndex}`;
+  if (!eventColors && device.type === 'webgpu') {
+    return GPUConstantVector.fromValue(device, {
+      name: 'eventColors',
+      id,
+      format: 'unorm8x4',
+      length: rowCount,
+      value: new Uint8Array(eventColor),
+      usage: Buffer.STORAGE
+    });
+  }
+  return makeGPUVectorFromArrow(
+    device,
+    eventColors ?? makeConstantEventColorsVector(rowCount, eventColor),
+    {name: 'eventColors', id, format: 'unorm8x4'}
+  );
+}
+
+function makeConstantStarSizesVector(
+  rowCount: number,
+  starSize: number
+): arrow.Vector<arrow.Float32> {
+  const values = new Float32Array(rowCount);
+  values.fill(starSize);
+  return makeFloat32Vector(values);
+}
+
+function makeConstantEventColorsVector(
+  rowCount: number,
+  eventColor: [number, number, number, number]
+): arrow.Vector<arrow.FixedSizeList<arrow.Uint8>> {
+  const values = new Uint8Array(rowCount * 4);
+  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+    values.set(eventColor, rowIndex * 4);
+  }
+  return makeArrowFixedSizeListVector(new arrow.Uint8(), 4, values);
 }
 
 function getRequiredArrowVector<T extends arrow.DataType>(
@@ -588,7 +745,8 @@ function getRequiredTimestampVector(
 async function convertTimestampEventStartsToGPUVector(
   device: Device,
   eventStarts: arrow.Vector<arrow.TimestampMillisecond>,
-  batchIndex: number
+  batchIndex: number,
+  preferGPU?: boolean
 ): Promise<PreparedEventStartsColumn> {
   const preparedColumns = await convertArrowTemporalToGPUVectors(
     device,
@@ -597,7 +755,8 @@ async function convertTimestampEventStartsToGPUVector(
       columns: {
         eventStarts: {
           id: `arrow-temporal-starfield-event-starts-${batchIndex}`,
-          origin: SOURCE_TIMESTAMP_ORIGIN_MILLISECONDS
+          origin: SOURCE_TIMESTAMP_ORIGIN_MILLISECONDS,
+          preferGPU
         }
       }
     }
@@ -688,6 +847,25 @@ function getTemporalStarfieldStorageBindings(
     eventColors: getGPUVectorBuffer(
       getRequiredGPUVector(temporalStarfieldTable, 'eventColors', 'Temporal starfield table')
     )
+  };
+}
+
+function getTemporalStarfieldStorageRowMultipliers(
+  temporalStarfieldTable: GPUTable<GPUTypeMap> | GPURecordBatch<GPUTypeMap>
+): {starSizeRowMultiplier: number; eventColorRowMultiplier: number} {
+  const starSizes = getRequiredGPUVector(
+    temporalStarfieldTable,
+    'starSizes',
+    'Temporal starfield table'
+  );
+  const eventColors = getRequiredGPUVector(
+    temporalStarfieldTable,
+    'eventColors',
+    'Temporal starfield table'
+  );
+  return {
+    starSizeRowMultiplier: starSizes instanceof GPUConstantVector ? 0 : 1,
+    eventColorRowMultiplier: eventColors instanceof GPUConstantVector ? 0 : 1
   };
 }
 

--- a/examples/arrow/arrow-temporal-starfield/arrow-temporal-starfield-shaders.ts
+++ b/examples/arrow/arrow-temporal-starfield/arrow-temporal-starfield-shaders.ts
@@ -8,12 +8,16 @@ import {TAU} from './arrow-temporal-starfield-data';
 
 type TemporalStarfieldUniforms = {
   currentTimestamp: number;
+  starSizeRowMultiplier: number;
+  eventColorRowMultiplier: number;
 };
 
 export const temporalStarfield: ShaderModule<TemporalStarfieldUniforms> = {
   name: 'temporalStarfield',
   uniformTypes: {
-    currentTimestamp: 'f32'
+    currentTimestamp: 'f32',
+    starSizeRowMultiplier: 'u32',
+    eventColorRowMultiplier: 'u32'
   }
 };
 
@@ -55,6 +59,8 @@ export const RENDER_PARAMETERS = {
 export const STAR_ATTRIBUTE_WGSL_SHADER = /* wgsl */ `\
 struct TemporalStarfieldUniforms {
   currentTimestamp : f32,
+  starSizeRowMultiplier : u32,
+  eventColorRowMultiplier : u32,
 };
 
 @group(0) @binding(auto) var<uniform> temporalStarfield : TemporalStarfieldUniforms;
@@ -163,6 +169,8 @@ fn fragmentMain(inputs : FragmentInputs) -> @location(0) vec4<f32> {
 export const STAR_STORAGE_WGSL_SHADER = /* wgsl */ `\
 struct TemporalStarfieldUniforms {
   currentTimestamp : f32,
+  starSizeRowMultiplier : u32,
+  eventColorRowMultiplier : u32,
 };
 
 @group(0) @binding(auto) var<uniform> temporalStarfield : TemporalStarfieldUniforms;
@@ -239,14 +247,16 @@ fn vertexMain(inputs : VertexInputs) -> FragmentInputs {
   let eventStart = eventStarts[starIndex];
   let eventDuration = eventDurations[starIndex];
   let pulsePeriod = pulsePeriods[starIndex];
-  let eventColor = unpack4x8unorm(eventColors[starIndex]);
+  let eventColorIndex = starIndex * temporalStarfield.eventColorRowMultiplier;
+  let starSizeIndex = starIndex * temporalStarfield.starSizeRowMultiplier;
+  let eventColor = unpack4x8unorm(eventColors[eventColorIndex]);
   let visibility = getStarVisibility(
     temporalStarfield.currentTimestamp,
     eventStart,
     eventDuration
   );
   let pulse = getStarPulse(temporalStarfield.currentTimestamp, eventStart, pulsePeriod);
-  let starSize = starSizes[starIndex] * max(visibility, 0.0) * mix(0.72, 2.4, pulse);
+  let starSize = starSizes[starSizeIndex] * max(visibility, 0.0) * mix(0.72, 2.4, pulse);
   let starPosition = getStarPosition(positions[starIndex], temporalStarfield.currentTimestamp);
 
   outputs.Position = vec4<f32>(starPosition + corner * starSize, 0.0, 1.0);
@@ -283,6 +293,8 @@ in vec4 eventColors;
 
 uniform temporalStarfieldUniforms {
   float currentTimestamp;
+  uint starSizeRowMultiplier;
+  uint eventColorRowMultiplier;
 } temporalStarfield;
 
 out vec4 vColor;

--- a/examples/arrow/arrow-temporal-starfield/control-panel.ts
+++ b/examples/arrow/arrow-temporal-starfield/control-panel.ts
@@ -12,6 +12,11 @@ import {
   getChangedSetting,
   makeHtmlCustomPanel
 } from '../../example-panels';
+import type {TemporalStarfieldStyleKind} from './arrow-temporal-starfield-data';
+import {
+  DEFAULT_TEMPORAL_STARFIELD_EVENT_COLOR,
+  DEFAULT_TEMPORAL_STARFIELD_STAR_SIZE
+} from './arrow-temporal-starfield-renderer';
 
 const STREAMING_BATCH_STATUS_ROW_ID = 'arrow-temporal-starfield-streaming-status-row';
 const STREAMING_BATCH_FILL_ID = 'arrow-temporal-starfield-streaming-fill';
@@ -20,6 +25,8 @@ const PREPARATION_PATH_ID = 'arrow-temporal-starfield-preparation-path';
 const CURRENT_TIMESTAMP_ID = 'arrow-temporal-starfield-current-timestamp';
 const POSITIONS_COLUMN_ID = 'arrow-temporal-starfield-positions-column';
 const EVENT_STARTS_COLUMN_ID = 'arrow-temporal-starfield-event-starts-column';
+const STAR_SIZES_COLUMN_ID = 'arrow-temporal-starfield-star-sizes-column';
+const EVENT_COLORS_COLUMN_ID = 'arrow-temporal-starfield-event-colors-column';
 const TIMESTAMP_ORIGIN_ID = 'arrow-temporal-starfield-timestamp-origin';
 const DURATION_ORIGIN_ID = 'arrow-temporal-starfield-duration-origin';
 const PULSE_PERIOD_ORIGIN_ID = 'arrow-temporal-starfield-pulse-period-origin';
@@ -27,6 +34,8 @@ const PULSE_PERIOD_ORIGIN_ID = 'arrow-temporal-starfield-pulse-period-origin';
 export type ArrowTemporalStarfieldControlPanelState = {
   renderMode: 'attributes' | 'storage';
   timeColumn: 'timestamp' | 'xyzm';
+  starSizeKind: TemporalStarfieldStyleKind;
+  eventColorKind: TemporalStarfieldStyleKind;
   supportsStorage: boolean;
 };
 
@@ -35,6 +44,8 @@ export type ArrowTemporalStarfieldControlPanelLabels = {
   currentTimestamp: string;
   positionsColumn: string;
   eventStartsColumn: string;
+  starSizesColumn: string;
+  eventColorsColumn: string;
   timestampOrigin: string;
   durationOrigin: string;
   pulsePeriodOrigin: string;
@@ -43,6 +54,8 @@ export type ArrowTemporalStarfieldControlPanelLabels = {
 export type ArrowTemporalStarfieldControlPanelHandlers = {
   onRenderModeChange: (renderMode: 'attributes' | 'storage') => void;
   onTimeColumnChange: (timeColumn: 'timestamp' | 'xyzm') => void;
+  onStarSizeKindChange: (starSizeKind: TemporalStarfieldStyleKind) => void;
+  onEventColorKindChange: (eventColorKind: TemporalStarfieldStyleKind) => void;
 };
 
 export type ArrowTemporalStarfieldControlPanelOptions = {
@@ -138,6 +151,14 @@ export class ArrowTemporalStarfieldControlPanel {
     if (isTemporalStarfieldRenderMode(renderMode)) {
       this.handlers.onRenderModeChange(renderMode);
     }
+    const starSizeKind = getChangedSetting(changedSettings, 'starSizeKind')?.nextValue;
+    if (isTemporalStarfieldStyleKind(starSizeKind)) {
+      this.handlers.onStarSizeKindChange(starSizeKind);
+    }
+    const eventColorKind = getChangedSetting(changedSettings, 'eventColorKind')?.nextValue;
+    if (isTemporalStarfieldStyleKind(eventColorKind)) {
+      this.handlers.onEventColorKindChange(eventColorKind);
+    }
   };
 
   private render(): void {
@@ -150,6 +171,8 @@ export class ArrowTemporalStarfieldControlPanel {
     setTextContent(this.rootElement, CURRENT_TIMESTAMP_ID, this.labels.currentTimestamp);
     setTextContent(this.rootElement, POSITIONS_COLUMN_ID, this.labels.positionsColumn);
     setTextContent(this.rootElement, EVENT_STARTS_COLUMN_ID, this.labels.eventStartsColumn);
+    setTextContent(this.rootElement, STAR_SIZES_COLUMN_ID, this.labels.starSizesColumn);
+    setTextContent(this.rootElement, EVENT_COLORS_COLUMN_ID, this.labels.eventColorsColumn);
     setTextContent(this.rootElement, TIMESTAMP_ORIGIN_ID, this.labels.timestampOrigin);
     setTextContent(this.rootElement, DURATION_ORIGIN_ID, this.labels.durationOrigin);
     setTextContent(this.rootElement, PULSE_PERIOD_ORIGIN_ID, this.labels.pulsePeriodOrigin);
@@ -186,6 +209,32 @@ export function makeArrowTemporalStarfieldSettingsSchema(
               {label: 'Attributes', value: 'attributes'},
               ...(state.supportsStorage ? [{label: 'Storage', value: 'storage'}] : [])
             ]
+          },
+          {
+            name: 'starSizeKind',
+            label: 'Sizes',
+            type: 'select',
+            persist: 'none',
+            options: [
+              {
+                label: `Constant Float32 ${DEFAULT_TEMPORAL_STARFIELD_STAR_SIZE}`,
+                value: 'constant'
+              },
+              {label: 'Row - Float32', value: 'column'}
+            ]
+          },
+          {
+            name: 'eventColorKind',
+            label: 'Colors',
+            type: 'select',
+            persist: 'none',
+            options: [
+              {
+                label: `Constant RGBA8 [${DEFAULT_TEMPORAL_STARFIELD_EVENT_COLOR.join(', ')}]`,
+                value: 'constant'
+              },
+              {label: 'Row - FixedSizeList<Uint8, 4>', value: 'column'}
+            ]
           }
         ]
       }
@@ -205,6 +254,8 @@ export function makeArrowTemporalStarfieldControlPanelHtml(): string {
     <code id="${EVENT_STARTS_COLUMN_ID}">eventStarts: TimestampMillisecond</code><span><code>Float32 millisecond</code><br><span id="${TIMESTAMP_ORIGIN_ID}"></span></span>
     <code>eventDurations: DurationMillisecond</code><span><code>Float32 millisecond</code><br><span id="${DURATION_ORIGIN_ID}"></span></span>
     <code>pulsePeriods: DurationMillisecond</code><span><code>Float32 millisecond</code><br><span id="${PULSE_PERIOD_ORIGIN_ID}"></span></span>
+    <code id="${STAR_SIZES_COLUMN_ID}">starSizes: Float32</code><span><code>Float32</code></span>
+    <code id="${EVENT_COLORS_COLUMN_ID}">eventColors: FixedSizeList&lt;Uint8, 4&gt;</code><span><code>unorm8x4</code></span>
   </div>
   `;
 }
@@ -256,6 +307,10 @@ function isTemporalStarfieldRenderMode(value: unknown): value is 'attributes' | 
 
 function isTemporalStarfieldTimeColumn(value: unknown): value is 'timestamp' | 'xyzm' {
   return value === 'timestamp' || value === 'xyzm';
+}
+
+function isTemporalStarfieldStyleKind(value: unknown): value is TemporalStarfieldStyleKind {
+  return value === 'constant' || value === 'column';
 }
 
 function setTextContent(

--- a/modules/arrow/test/arrow/arrow-renderer-preparation.node.spec.ts
+++ b/modules/arrow/test/arrow/arrow-renderer-preparation.node.spec.ts
@@ -24,6 +24,9 @@ import {
   ArrowPointRenderer,
   prepareArrowPointInput
 } from '../../../../examples/arrow/arrow-points/arrow-point-renderer';
+import {makeTemporalStarfieldRecordBatches} from '../../../../examples/arrow/arrow-temporal-starfield/arrow-temporal-starfield-data';
+import {makeTemporalStarfieldGPURecordBatchInput} from '../../../../examples/arrow/arrow-temporal-starfield/arrow-temporal-starfield-renderer';
+import {STAR_STORAGE_WGSL_SHADER} from '../../../../examples/arrow/arrow-temporal-starfield/arrow-temporal-starfield-shaders';
 
 type PathArrowType = arrow.List<arrow.FixedSizeList<arrow.Float32>>;
 
@@ -102,6 +105,56 @@ test('prepareArrowPointInput uses zero-stride style constants on WebGPU', async 
   t.equal(prepared.stylingGpuByteLength, 8, 'reports only materialized constant payloads');
 
   prepared.destroy();
+  t.end();
+});
+
+test('temporal starfield constants support attribute and storage models', async t => {
+  const device = makeTestDevice('webgpu');
+  const recordBatch = makeTemporalStarfieldRecordBatches(
+    3,
+    3,
+    'timestamp',
+    'constant',
+    'constant'
+  )[0];
+  if (!recordBatch) {
+    throw new Error('Expected a temporal starfield record batch');
+  }
+  t.notOk(recordBatch.getChild('starSizes'), 'constant size is omitted from the Arrow batch');
+  t.notOk(recordBatch.getChild('eventColors'), 'constant color is omitted from the Arrow batch');
+  const prepared = await makeTemporalStarfieldGPURecordBatchInput(
+    device,
+    recordBatch,
+    0,
+    'timestamp',
+    {
+      starSizeColumn: null,
+      eventColorColumn: null,
+      starSize: 0.01,
+      eventColor: [104, 168, 255, 255]
+    },
+    {preferTemporalGPU: false}
+  );
+  const {starSizes, eventColors} = prepared.gpuRecordBatch.gpuVectors;
+
+  t.ok(starSizes instanceof GPUConstantVector, 'uses a constant star-size vector');
+  t.ok(eventColors instanceof GPUConstantVector, 'uses a constant event-color vector');
+  t.equal(starSizes.length, 3, 'star size retains the logical row count');
+  t.equal(eventColors.length, 3, 'event color retains the logical row count');
+  t.equal(starSizes.data[0]?.buffer.byteLength, 4, 'stores one star-size payload');
+  t.equal(eventColors.data[0]?.buffer.byteLength, 4, 'stores one event-color payload');
+  t.ok(starSizes.data[0]?.buffer.usage & Buffer.STORAGE, 'star size can bind as storage');
+  t.ok(eventColors.data[0]?.buffer.usage & Buffer.STORAGE, 'event color can bind as storage');
+  t.ok(
+    STAR_STORAGE_WGSL_SHADER.includes('starIndex * temporalStarfield.starSizeRowMultiplier'),
+    'storage shader redirects constant sizes to row zero'
+  );
+  t.ok(
+    STAR_STORAGE_WGSL_SHADER.includes('starIndex * temporalStarfield.eventColorRowMultiplier'),
+    'storage shader redirects constant colors to row zero'
+  );
+
+  prepared.gpuRecordBatch.destroy();
   t.end();
 });
 

--- a/modules/arrow/test/arrow/arrow-renderer-preparation.node.spec.ts
+++ b/modules/arrow/test/arrow/arrow-renderer-preparation.node.spec.ts
@@ -11,8 +11,8 @@ import {
   prepareArrowPolygonInput,
   resolveArrowPickInfo
 } from '@luma.gl/arrow';
-import {Buffer} from '@luma.gl/core';
-import type {GPUData} from '@luma.gl/tables';
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUConstantVector, type GPUData} from '@luma.gl/tables';
 import {NullDevice} from '@luma.gl/test-utils';
 import * as arrow from 'apache-arrow';
 import {
@@ -50,6 +50,10 @@ test('prepareArrowPointInput preserves rows, batch layout, row offsets, and owne
     'records point source row metadata'
   );
   t.deepEqual(Array.from(rowIndices), [5, 6], 'applies the row index offset');
+  t.notOk(
+    prepared.table.gpuVectors.colors instanceof GPUConstantVector,
+    'null device retains the materialized constant fallback'
+  );
   t.equal(
     prepared.stylingGpuByteLength,
     8,
@@ -70,6 +74,34 @@ test('prepareArrowPointInput preserves rows, batch layout, row offsets, and owne
 
   prepared.destroy();
   t.ok(positionsBuffer.destroyed, 'destroy releases owned point buffers');
+  t.end();
+});
+
+test('prepareArrowPointInput uses zero-stride style constants on WebGPU', async t => {
+  const device = makeTestDevice('webgpu');
+  const positions = makeArrowFixedSizeListVector(
+    new arrow.Float32(),
+    2,
+    new Float32Array([0, 0, 1, 1])
+  );
+  const prepared = await prepareArrowPointInput(
+    device,
+    {positions, colors: null, radii: null},
+    {id: 'point-constant-vector-test'}
+  );
+  const {colors, radii} = prepared.table.gpuVectors;
+
+  t.ok(colors instanceof GPUConstantVector, 'uses a constant color vector');
+  t.ok(radii instanceof GPUConstantVector, 'uses a constant radius vector');
+  t.equal(colors.byteStride, 0, 'color vector broadcasts with zero stride');
+  t.equal(radii.byteStride, 0, 'radius vector broadcasts with zero stride');
+  t.equal(colors.length, 2, 'constant color retains logical point rows');
+  t.equal(radii.length, 2, 'constant radius retains logical point rows');
+  t.equal(colors.data[0]?.buffer.byteLength, 4, 'stores one RGBA8 value');
+  t.equal(radii.data[0]?.buffer.byteLength, 4, 'stores one Float32 value');
+  t.equal(prepared.stylingGpuByteLength, 8, 'reports only materialized constant payloads');
+
+  prepared.destroy();
   t.end();
 });
 
@@ -615,6 +647,13 @@ function makeRecordBatchIterator(
       return recordBatch ? {done: false, value: recordBatch} : {done: true, value: undefined};
     }
   };
+}
+
+function makeTestDevice(type: Device['type']): Device {
+  const device = new NullDevice({});
+  const testDevice = Object.create(device);
+  Object.defineProperty(testDevice, 'type', {value: type});
+  return testDevice;
 }
 
 function waitForPointBatches(

--- a/modules/core/src/adapter-utils/buffer-layout-utils.ts
+++ b/modules/core/src/adapter-utils/buffer-layout-utils.ts
@@ -149,7 +149,7 @@ export function resolveLogicalAttributeMappings(
         stepMode: layout.stepMode,
         vertexFormat: layout.format,
         byteOffset: 0,
-        byteStride: layout.byteStride || 0
+        byteStride
       });
     }
   }
@@ -171,8 +171,10 @@ export function resolveLogicalAttributeMappings(
         bufferName: bufferMapping?.bufferName || attribute.name,
         location: attribute.location,
         vertexFormat,
-        byteOffset: bufferMapping?.byteOffset || 0,
-        byteStride: bufferMapping?.byteStride || 0,
+        byteOffset: bufferMapping?.byteOffset ?? 0,
+        byteStride:
+          bufferMapping?.byteStride ??
+          vertexFormatDecoder.getVertexFormatInfo(vertexFormat).byteLength,
         stepMode:
           bufferMapping?.stepMode ||
           attribute.stepMode ||

--- a/modules/core/test/adapter-utils/buffer-layout-utils.spec.ts
+++ b/modules/core/test/adapter-utils/buffer-layout-utils.spec.ts
@@ -58,7 +58,7 @@ test('resolveLogicalAttributeMappings resolves interleaved, shorthand, and defau
       location: 2,
       vertexFormat: 'float32x3',
       byteOffset: 0,
-      byteStride: 0,
+      byteStride: 12,
       stepMode: 'vertex'
     },
     {
@@ -67,10 +67,23 @@ test('resolveLogicalAttributeMappings resolves interleaved, shorthand, and defau
       location: 3,
       vertexFormat: 'float32x4',
       byteOffset: 0,
-      byteStride: 0,
+      byteStride: 16,
       stepMode: 'vertex'
     }
   ]);
+  t.end();
+});
+
+test('resolveLogicalAttributeMappings preserves explicit zero byte stride', t => {
+  const mappings = resolveLogicalAttributeMappings(shaderLayout, [
+    {name: 'colors', format: 'float32x4', byteStride: 0}
+  ]);
+
+  t.equal(
+    mappings.find(mapping => mapping.attributeName === 'colors')?.byteStride,
+    0,
+    'explicit zero stride is not replaced by the packed format size'
+  );
   t.end();
 });
 

--- a/modules/tables/src/index.ts
+++ b/modules/tables/src/index.ts
@@ -18,6 +18,13 @@ export {
   type GPUVectorFromInterleavedProps
 } from './table/gpu-vector';
 export {
+  GPUConstantVector,
+  type GPUConstantVectorFromValueProps,
+  type GPUConstantVectorProps
+} from './table/gpu-constant-vector';
+export {
+  getGPUDataByteLength,
+  getGPUVectorByteLength,
   getGPUVectorBuffer,
   getGPUVectorData,
   getRequiredGPUVector

--- a/modules/tables/src/table/gpu-constant-vector.ts
+++ b/modules/tables/src/table/gpu-constant-vector.ts
@@ -1,0 +1,123 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device, type VertexFormat} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import {GPUVector, type GPUVectorBufferProps} from './gpu-vector';
+import {getGPUVectorFormatInfo} from './gpu-vector-format';
+
+/** Props for wrapping one fixed-width GPU value as a logical constant vector. */
+export type GPUConstantVectorProps<T extends VertexFormat = VertexFormat> = {
+  /** Stable vector name. */
+  name: string;
+  /** Existing buffer containing one complete value at byte offset zero. */
+  buffer: Buffer | DynamicBuffer;
+  /** Fixed-width memory format of the constant value. */
+  format: T;
+  /** Number of logical rows across which the value is broadcast. */
+  length: number;
+  /** Whether this vector should destroy the wrapped buffer. */
+  ownsBuffer?: boolean;
+  /** Optional adapter-owned metadata; core tables do not inspect this value. */
+  dataType?: unknown;
+};
+
+/** Props for allocating an owned constant vector from one typed value. */
+export type GPUConstantVectorFromValueProps<T extends VertexFormat = VertexFormat> = Omit<
+  GPUVectorBufferProps,
+  'byteOffset' | 'indexType'
+> & {
+  /** Stable vector name. */
+  name: string;
+  /** Fixed-width memory format of the constant value. */
+  format: T;
+  /** Number of logical rows across which the value is broadcast. */
+  length: number;
+  /** Exactly one encoded value matching `format`. */
+  value: ArrayBufferView;
+  /** Optional adapter-owned metadata; core tables do not inspect this value. */
+  dataType?: unknown;
+};
+
+/**
+ * One fixed-width GPU value broadcast across a logical vector row range.
+ *
+ * The backing buffer stores one payload row. A zero byte stride publishes that
+ * row as a constant vertex attribute on backends that support zero-stride input.
+ */
+export class GPUConstantVector<T extends VertexFormat = VertexFormat> extends GPUVector<T> {
+  /** Identifies this vector as a broadcast constant. */
+  readonly isConstant = true;
+
+  constructor(props: GPUConstantVectorProps<T>) {
+    const formatInfo = validateConstantVectorProps(props);
+    super({
+      type: 'buffer',
+      name: props.name,
+      buffer: props.buffer,
+      format: props.format,
+      length: props.length,
+      valueLength: props.length,
+      stride: formatInfo.components,
+      byteStride: 0,
+      rowByteLength: formatInfo.byteLength,
+      ownsBuffer: props.ownsBuffer,
+      dataType: props.dataType
+    });
+  }
+
+  /** Allocates and owns a one-value vertex buffer for a broadcast constant. */
+  static fromValue<T extends VertexFormat>(
+    device: Device,
+    props: GPUConstantVectorFromValueProps<T>
+  ): GPUConstantVector<T> {
+    const {name, format, length, value, dataType, usage = 0, ...bufferProps} = props;
+    const formatInfo = validateConstantFormat(format, length);
+    if (value.byteLength !== formatInfo.byteLength) {
+      throw new Error(
+        `GPUConstantVector value byteLength ${value.byteLength} must match ${format} byteLength ${formatInfo.byteLength}`
+      );
+    }
+
+    const buffer = device.createBuffer({
+      ...bufferProps,
+      usage: usage | Buffer.VERTEX | Buffer.COPY_DST | Buffer.COPY_SRC,
+      data: value
+    });
+    return new GPUConstantVector({
+      name,
+      buffer,
+      format,
+      length,
+      ownsBuffer: true,
+      dataType
+    });
+  }
+}
+
+function validateConstantVectorProps<T extends VertexFormat>(
+  props: GPUConstantVectorProps<T>
+): ReturnType<typeof getGPUVectorFormatInfo> {
+  const formatInfo = validateConstantFormat(props.format, props.length);
+  if (props.buffer.byteLength < formatInfo.byteLength) {
+    throw new Error(
+      `GPUConstantVector buffer byteLength ${props.buffer.byteLength} must contain one ${props.format} value (${formatInfo.byteLength} bytes)`
+    );
+  }
+  return formatInfo;
+}
+
+function validateConstantFormat<T extends VertexFormat>(
+  format: T,
+  length: number
+): ReturnType<typeof getGPUVectorFormatInfo> {
+  if (!Number.isInteger(length) || length < 0) {
+    throw new Error('GPUConstantVector length must be a non-negative integer');
+  }
+  const formatInfo = getGPUVectorFormatInfo(format);
+  if (formatInfo.vertexList || formatInfo.valueList) {
+    throw new Error('GPUConstantVector requires a fixed-width vertex format');
+  }
+  return formatInfo;
+}

--- a/modules/tables/src/table/gpu-table.ts
+++ b/modules/tables/src/table/gpu-table.ts
@@ -10,6 +10,7 @@ import {GPUVector} from './gpu-vector';
 import {GPURecordBatch, type GPURecordBatchSourceInfo} from './gpu-record-batch';
 import {createGPUVectorCollection} from './gpu-vector-collection';
 import {GPU_TABLE_INDEX_COLUMN_NAME} from './gpu-schema';
+import {getGPUVectorByteLength} from './gpu-vector-utils';
 
 type GPUVectorMap<T extends GPUTypeMap = GPUTypeMap> = {
   [Name in keyof T & string]: GPUVector<T[Name]>;
@@ -133,6 +134,13 @@ export class GPUTable<T extends GPUTypeMap = GPUTypeMap> {
     }
     if (this.batches.some(batch => batch.gpuVectors[GPU_TABLE_INDEX_COLUMN_NAME])) {
       throw new Error('GPUTable.packBatches() does not support indexed tables');
+    }
+    if (
+      this.batches.some(batch =>
+        Object.values(batch.gpuVectors).some(vector => vector.byteStride === 0)
+      )
+    ) {
+      throw new Error('GPUTable.packBatches() does not support constant GPU vectors');
     }
 
     const batchGroups = createGPUPackGroups(this.batches, options.minBatchSize);
@@ -559,7 +567,7 @@ function getGPURecordBatchDevice<T extends GPUTypeMap>(batch: GPURecordBatch<T>)
 }
 
 function getGPUVectorPackedByteLength(vector: GPUVector): number {
-  return vector.data.reduce((byteLength, data) => byteLength + data.length * data.byteStride, 0);
+  return getGPUVectorByteLength(vector);
 }
 
 function getGPUDataCopyByteLength(data: GPUData): number {

--- a/modules/tables/src/table/gpu-vector-utils.ts
+++ b/modules/tables/src/table/gpu-vector-utils.ts
@@ -9,6 +9,22 @@ import type {GPURecordBatch} from './gpu-record-batch';
 import type {GPUTable} from './gpu-table';
 import type {GPUVector} from './gpu-vector';
 
+/** Returns the materialized payload byte length of one GPU data chunk. */
+export function getGPUDataByteLength(data: GPUData): number {
+  if (data.byteStride === 0) {
+    return data.rowByteLength;
+  }
+  if (data.length === 0) {
+    return 0;
+  }
+  return data.length * data.byteStride;
+}
+
+/** Returns the materialized payload byte length across all chunks in a GPU vector. */
+export function getGPUVectorByteLength(vector: GPUVector): number {
+  return vector.data.reduce((byteLength, data) => byteLength + getGPUDataByteLength(data), 0);
+}
+
 /** Returns the single GPUData chunk for APIs that require contiguous GPU vector storage. */
 export function getGPUVectorData(vector: GPUVector): GPUData {
   const [data, ...remainingData] = vector.data;

--- a/modules/tables/test/table/gpu-vector-format.node.spec.ts
+++ b/modules/tables/test/table/gpu-vector-format.node.spec.ts
@@ -4,11 +4,14 @@
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {
+  GPUConstantVector,
   GPUData,
   GPURecordBatch,
   GPUVector,
   GPUTable,
+  getGPUDataByteLength,
   getGPUVectorBuffer,
+  getGPUVectorByteLength,
   getGPUVectorElementFormat,
   getGPUVectorFormatInfo,
   getGPUVectorData,
@@ -87,6 +90,132 @@ test('GPUVector accepts format as canonical metadata and synthesizes table layou
   t.equal(colors.format, 'unorm8x4', 'stores the canonical GPUVector format');
   t.notOk('type' in colors, 'drops the deprecated type alias');
   t.equal(table.bufferLayout[0].format, 'unorm8x4', 'table layout uses GPUVector.format');
+
+  table.destroy();
+  t.end();
+});
+
+test('GPUConstantVector broadcasts one physical value across logical table rows', t => {
+  const device = new NullDevice({});
+  const positions = new GPUVector({
+    type: 'buffer',
+    name: 'positions',
+    buffer: device.createBuffer({data: new Float32Array(6)}),
+    format: 'float32x2',
+    length: 3,
+    ownsBuffer: true
+  });
+  const colors = GPUConstantVector.fromValue(device, {
+    name: 'colors',
+    format: 'unorm8x4',
+    length: 3,
+    value: new Uint8Array([10, 20, 30, 255])
+  });
+  const colorData = getGPUVectorData(colors);
+  const colorBuffer = colorData.buffer;
+  const table = new GPUTable({vectors: {positions, colors}});
+
+  t.ok(colors.isConstant, 'marks the specialized vector as constant');
+  t.equal(colors.length, 3, 'retains the logical row count');
+  t.equal(colorData.length, 3, 'retains logical rows on the backing GPUData view');
+  t.equal(colors.byteStride, 0, 'uses zero byte stride for broadcast vertex input');
+  t.equal(colors.rowByteLength, 4, 'retains the physical payload size');
+  t.equal(colorBuffer.byteLength, 4, 'allocates one physical value');
+  t.equal(getGPUDataByteLength(colorData), 4, 'reports one materialized data payload');
+  t.equal(getGPUVectorByteLength(colors), 4, 'reports one materialized vector payload');
+  t.equal(table.numRows, 3, 'constant vector aligns with ordinary table rows');
+  t.equal(table.bufferLayout.find(layout => layout.name === 'colors')?.byteStride, 0);
+
+  table.destroy();
+  t.ok(colorBuffer.destroyed, 'fromValue creates an owned buffer');
+  t.end();
+});
+
+test('GPUConstantVector wraps borrowed buffers and validates its invariant', t => {
+  const device = new NullDevice({});
+  const borrowedBuffer = device.createBuffer({byteLength: 8});
+  const shortBuffer = device.createBuffer({byteLength: 4});
+  const borrowed = new GPUConstantVector({
+    name: 'offsets',
+    buffer: borrowedBuffer,
+    format: 'float32x2',
+    length: 5
+  });
+
+  borrowed.destroy();
+  t.notOk(borrowedBuffer.destroyed, 'borrowed constant buffer remains caller-owned');
+  t.throws(
+    () =>
+      new GPUConstantVector({
+        name: 'invalidLength',
+        buffer: borrowedBuffer,
+        format: 'float32',
+        length: -1
+      }),
+    /length must be a non-negative integer/
+  );
+  t.throws(
+    () =>
+      new GPUConstantVector({
+        name: 'shortBuffer',
+        buffer: shortBuffer,
+        format: 'float32x2',
+        length: 1
+      }),
+    /must contain one float32x2 value/
+  );
+  t.throws(
+    () =>
+      GPUConstantVector.fromValue(device, {
+        name: 'wrongValueSize',
+        format: 'float32x2',
+        length: 1,
+        value: new Float32Array([1])
+      }),
+    /value byteLength 4 must match float32x2 byteLength 8/
+  );
+  t.throws(
+    () =>
+      new GPUConstantVector({
+        name: 'variableLength',
+        buffer: borrowedBuffer,
+        format: 'vertex-list<float32>' as never,
+        length: 1
+      }),
+    /requires a fixed-width vertex format/
+  );
+
+  borrowedBuffer.destroy();
+  shortBuffer.destroy();
+  t.end();
+});
+
+test('GPUTable rejects packing constant vectors across batches', t => {
+  const device = new NullDevice({});
+  const makeBatch = (value: number): GPURecordBatch =>
+    new GPURecordBatch({
+      vectors: {
+        values: GPUConstantVector.fromValue(device, {
+          name: 'values',
+          format: 'float32',
+          length: 1,
+          value: new Float32Array([value])
+        })
+      }
+    });
+  const firstBatch = makeBatch(1);
+  const secondBatch = makeBatch(2);
+  const table = new GPUTable({
+    batches: [firstBatch, secondBatch],
+    schema: firstBatch.schema,
+    bufferLayout: firstBatch.bufferLayout
+  });
+
+  t.throws(
+    () => table.packBatches(),
+    /does not support constant GPU vectors/,
+    'does not merge potentially different per-batch constants'
+  );
 
   table.destroy();
   t.end();

--- a/modules/webgpu/src/adapter/helpers/get-vertex-buffer-layout.ts
+++ b/modules/webgpu/src/adapter/helpers/get-vertex-buffer-layout.ts
@@ -11,8 +11,7 @@ import type {
 import {
   getLogicalBufferSlots,
   getMinimumAttributeLocation,
-  resolveLogicalAttributeMappings,
-  vertexFormatDecoder
+  resolveLogicalAttributeMappings
 } from '@luma.gl/core';
 
 /** Describes one physical WebGPU vertex-buffer slot derived from a logical buffer layout. */
@@ -151,12 +150,10 @@ function groupMappingsByBuffer(
 }
 
 /**
- * Returns the effective byte stride for a logical attribute mapping.
+ * Returns the resolved byte stride for a logical attribute mapping.
  * @param mapping One backend-agnostic logical attribute mapping.
- * @returns The mapping stride, or the packed vertex-format size when unmapped.
+ * @returns The resolved mapping stride, including an explicit zero.
  */
 function getResolvedByteStride(mapping: LogicalAttributeMapping): number {
-  return (
-    mapping.byteStride || vertexFormatDecoder.getVertexFormatInfo(mapping.vertexFormat).byteLength
-  );
+  return mapping.byteStride;
 }

--- a/modules/webgpu/test/adapter/helpers/get-vertex-buffer-layout.spec.ts
+++ b/modules/webgpu/test/adapter/helpers/get-vertex-buffer-layout.spec.ts
@@ -201,6 +201,29 @@ test('WebGPU#getVertexBufferLayout', t => {
   t.end();
 });
 
+test('WebGPU#getVertexBufferLayout preserves zero stride constants', t => {
+  const constantShaderLayout: ShaderLayout = {
+    attributes: [{name: 'colors', location: 0, type: 'vec4<f32>', stepMode: 'instance'}],
+    bindings: []
+  };
+  const vertexBufferLayout = getVertexBufferLayout(constantShaderLayout, [
+    {name: 'colors', format: 'unorm8x4', byteStride: 0}
+  ]);
+
+  t.deepEqual(
+    vertexBufferLayout,
+    [
+      {
+        arrayStride: 0,
+        stepMode: 'instance',
+        attributes: [{format: 'unorm8x4', offset: 0, shaderLocation: 0}]
+      }
+    ],
+    'explicit zero byte stride reaches the WebGPU pipeline layout'
+  );
+  t.end();
+});
+
 test('WebGPU#resolveVertexBufferLayouts splits oversized interleaved offsets into repeated bindings', t => {
   const {vertexBufferLayouts, resolvedSlots} = resolveVertexBufferLayouts(
     fp64ShaderLayout,

--- a/modules/webgpu/test/adapter/resources/webgpu-vertex-array.spec.ts
+++ b/modules/webgpu/test/adapter/resources/webgpu-vertex-array.spec.ts
@@ -3,8 +3,34 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {Buffer, type ShaderLayout, type BufferLayout} from '@luma.gl/core';
+import {Buffer, Texture, type ShaderLayout, type BufferLayout} from '@luma.gl/core';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+const CONSTANT_ATTRIBUTE_SOURCE = /* WGSL */ `
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec4<f32>
+};
+
+@vertex fn vertexMain(
+  @builtin(vertex_index) vertexIndex: u32,
+  @location(0) color: vec4<f32>
+) -> VertexOutput {
+  var positions = array<vec2<f32>, 3>(
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>(3.0, -1.0),
+    vec2<f32>(-1.0, 3.0)
+  );
+  var output: VertexOutput;
+  output.position = vec4<f32>(positions[vertexIndex], 0.0, 1.0);
+  output.color = color;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  return input.color;
+}
+`;
 
 test('WebGPUVertexArray rebinds split vertex layouts with repeated buffers and binding offsets', async t => {
   const webgpuDevice = await getWebGPUTestDevice();
@@ -117,5 +143,89 @@ test('WebGPUVertexArray keeps simple single-slot bindings unchanged', async t =>
 
   buffer.destroy();
   vertexArray.destroy();
+  t.end();
+});
+
+test('WebGPUVertexArray broadcasts a one-row zero-stride attribute across instances', async t => {
+  const webgpuDevice = await getWebGPUTestDevice();
+
+  if (!webgpuDevice) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const shaderLayout: ShaderLayout = {
+    attributes: [{name: 'color', location: 0, type: 'vec4<f32>', stepMode: 'instance'}],
+    bindings: []
+  };
+  const bufferLayout: BufferLayout[] = [
+    {name: 'color', format: 'unorm8x4', byteStride: 0, stepMode: 'instance'}
+  ];
+  const shader = webgpuDevice.createShader({source: CONSTANT_ATTRIBUTE_SOURCE});
+  const renderPipeline = webgpuDevice.createRenderPipeline({
+    vs: shader,
+    fs: shader,
+    shaderLayout,
+    bufferLayout,
+    topology: 'triangle-list',
+    colorAttachmentFormats: ['rgba8unorm']
+  });
+  const vertexArray = webgpuDevice.createVertexArray({shaderLayout, bufferLayout});
+  const colorBuffer = webgpuDevice.createBuffer({
+    data: new Uint8Array([51, 102, 153, 255]),
+    usage: Buffer.VERTEX | Buffer.COPY_DST
+  });
+  const colorTexture = webgpuDevice.createTexture({
+    width: 1,
+    height: 1,
+    format: 'rgba8unorm',
+    usage: Texture.RENDER_ATTACHMENT | Texture.COPY_SRC
+  });
+  const framebuffer = webgpuDevice.createFramebuffer({
+    width: 1,
+    height: 1,
+    colorAttachments: [colorTexture]
+  });
+  vertexArray.setBuffer(0, colorBuffer);
+
+  webgpuDevice.handle.pushErrorScope('validation');
+  const renderPass = webgpuDevice.beginRenderPass({framebuffer, clearColor: [0, 0, 0, 0]});
+  t.ok(
+    renderPipeline.draw({renderPass, vertexArray, vertexCount: 3, instanceCount: 3}),
+    'records a multi-instance draw using a four-byte attribute buffer'
+  );
+  renderPass.end();
+  webgpuDevice.submit();
+  const validationError = await webgpuDevice.handle.popErrorScope();
+  t.equal(validationError, null, 'draw-time buffer length validation accepts zero stride');
+
+  const memoryLayout = colorTexture.computeMemoryLayout({width: 1, height: 1});
+  const readBuffer = webgpuDevice.createBuffer({
+    byteLength: memoryLayout.byteLength,
+    usage: Buffer.COPY_DST | Buffer.COPY_SRC
+  });
+  const commandEncoder = webgpuDevice.createCommandEncoder();
+  commandEncoder.copyTextureToBuffer({
+    sourceTexture: colorTexture,
+    width: 1,
+    height: 1,
+    destinationBuffer: readBuffer
+  });
+  webgpuDevice.submit(commandEncoder.finish());
+  const pixels = new Uint8Array(await readBuffer.readAsync(0, memoryLayout.byteLength));
+  t.deepEqual(
+    Array.from(pixels.slice(0, 4)),
+    [51, 102, 153, 255],
+    'all instances read the one stored constant color'
+  );
+
+  readBuffer.destroy();
+  framebuffer.destroy();
+  colorTexture.destroy();
+  colorBuffer.destroy();
+  vertexArray.destroy();
+  renderPipeline.destroy();
+  shader.destroy();
   t.end();
 });

--- a/website/src/components/docs/tables-docs-tabs.tsx
+++ b/website/src/components/docs/tables-docs-tabs.tsx
@@ -15,6 +15,7 @@ export type TablesDocsTabId =
   | 'overview'
   | 'structure'
   | 'lifecycle'
+  | 'constants'
   | 'table'
   | 'record-batch'
   | 'vector'
@@ -27,6 +28,7 @@ const TABLES_DOCS_TABS: TablesDocsTab[] = [
   {id: 'overview', label: 'Overview', href: '/docs/api-reference/tables'},
   {id: 'structure', label: 'Structure', href: '/docs/api-reference/tables/gpu-table-structure'},
   {id: 'lifecycle', label: 'Lifecycle', href: '/docs/api-reference/tables/gpu-table-lifecycle'},
+  {id: 'constants', label: 'Constants', href: '/docs/api-reference/tables/constant-columns'},
   {id: 'table', label: 'GPUTable', href: '/docs/api-reference/tables/gpu-table'},
   {id: 'record-batch', label: 'GPURecordBatch', href: '/docs/api-reference/tables/gpu-record-batch'},
   {id: 'vector', label: 'GPUVector', href: '/docs/api-reference/tables/gpu-vector'},


### PR DESCRIPTION
## Goals

Add a fixed-width `GPUConstantVector` that represents many logical rows with one physical value, supports zero-stride WebGPU vertex attributes, and establishes a practical constant-column pattern for storage-buffer models.

## Changes

- Export `GPUConstantVector` from `@luma.gl/tables`, including wrapped-buffer and `fromValue()` construction.
- Validate fixed-width formats, logical lengths, payload sizes, and ownership.
- Preserve explicit zero stride through generic layout resolution and WebGPU vertex buffer layout synthesis.
- Add physical GPU byte-length helpers that count zero-stride chunks as one payload row.
- Keep table row validation logical and reject packed groups containing constants.
- Use constant color/radius vectors in Arrow points on WebGPU while retaining materialized fallbacks elsewhere.
- Extend the Arrow Temporal Starfield example with constant size and color selectors, defaulting to constant-backed GPU columns while omitting those columns from generated Arrow batches.
- Support those constants in both Temporal Starfield models: attributes use zero stride, while storage buffers use per-column `instanceIndex * rowMultiplier` indexing with `0` for constants and `1` for row columns.
- Allocate constant style buffers with both vertex and storage usage and retain materialized WebGL/null-device fallbacks.
- Document constant-column semantics, backend representations, interleaving constraints, WebGL CPU-value requirements, and the WebGPU storage row-multiplier pattern.
- Add tables, core, WebGPU layout, draw-time validation, Arrow preparation, and storage-example coverage.

## Verification

- `nvm use`: the noninteractive shell did not expose the function; active Node `v22.22.1` was verified against `.nvmrc` with `nvm-exec`.
- `yarn install`: passed with existing peer-dependency warnings.
- `yarn build`: passed.
- `yarn test`: passed (`152` node tests plus the headless browser phase).
- `yarn test-node`: passed (`152` passed, `2` skipped).
- `yarn test-browser`: passed after rerunning Chromium with the required macOS permissions.
- `yarn lint fix`: passed.
- `yarn website:build`: passed.
- `(cd website && yarn build)`: passed.
- `yarn --cwd examples/arrow/arrow-temporal-starfield build`: passed.
- Live WebGPU Temporal Starfield smoke test: constant-backed storage batches rendered without application errors.

## Risks

- Storage-buffer consumers must explicitly apply the row multiplier; `GPUConstantVector` does not alter storage indexing automatically.
- Mixed constant and row-backed semantics for the same column across batches are not supported by the shared table layout.

## Stack

This is PR 2 of 2 and targets `codex/arrow-points-constant-style-controls`. Review this PR as the `GPUConstantVector`, `arrayStride: 0`, and storage constant-column implementation layer.