### PR TITLE
chore(tables) Clean up of GPUTable and GPURecordBatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@
 - When asked to "get ready for merge", create a copyable Markdown description of the changes versus `master`.
 - Start that Markdown description with `Goals` and `Changes` sections, then include verification, risks, follow-up notes, or other merge-relevant sections when useful.
 - In the verification section, explicitly call out the AGENTS.md checks that were run or could not be run: `nvm use`, `yarn install`, `yarn build`, `yarn test`, `yarn lint fix`, `yarn website:build`, and `(cd website && yarn build)`.
+- Run `yarn build` after the final code and formatting changes, and treat it as a required pre-merge gate. It compiles every module with `tspc` and catches cross-package TypeScript API breakage that `yarn test-node` does not cover.
+- Do not rely on `yarn test-node` as a substitute for `yarn build`; run both when table or shared package APIs change.
  
 ## Code style
 - TypeScript strict mode

--- a/docs/api-guide/gpu/README.md
+++ b/docs/api-guide/gpu/README.md
@@ -7,5 +7,6 @@
 - [GPU command encoding](/docs/api-guide/gpu/gpu-commands) - Decide when to use immediate resource helpers versus explicit `CommandEncoder` recording.
 - [GPU resource management](/docs/api-guide/gpu/gpu-resources) - Create `Shader`, `RenderPipeline`, `RenderPass` etc. objects.
 - [GPU binding management](/docs/api-guide/gpu/gpu-bindings) - Make attribute buffers, uniforms, textures, samplers available to GPU shaders.
+- [Tabular data in WGSL](/docs/api-guide/gpu/tabular-data-in-wgsl) - Map logical table columns to vertex attributes or WebGPU storage arrays and structs.
 - [Shader execution / rendering](/docs/api-guide/gpu/gpu-rendering) - Drawing into textures, running compute shaders.
 - [GPU parameter management](/docs/api-guide/gpu/gpu-parameters) - Configuring blending, clipping, depth tests etc.

--- a/docs/api-guide/gpu/gpu-attributes.md
+++ b/docs/api-guide/gpu/gpu-attributes.md
@@ -4,6 +4,9 @@
 Note that while **attributes** is a structured and performant mechanism to provide columnar data to shaders that works on both WebGPU and WebGL, they are rather rigid and have a number of limitations. In WebGPU a more significantly more flexible approach is to use [storage buffers](./gpu-storage-buffers).
 :::
 
+For a WGSL-focused comparison of attribute columns, interleaved rows, storage
+arrays, and storage structs, see [Tabular Data in WGSL](./tabular-data-in-wgsl).
+
 The traditional 3D GPU execution model is that shaders work on vertexes, each vertex having a number of unique values such as position, normal, texture coordinates etc. 
 
 In this model, the purpose of GPU vertex **attributes** is to 

--- a/docs/api-guide/gpu/gpu-memory-layouts.md
+++ b/docs/api-guide/gpu/gpu-memory-layouts.md
@@ -2,6 +2,9 @@
 
 GPU buffers are byte ranges. A layout describes how shader-visible rows and columns are mapped onto those bytes.
 
+For the WGSL-facing difference between vertex-fetch layouts and storage-buffer
+layouts, see [Tabular Data in WGSL](./tabular-data-in-wgsl).
+
 When one logical GPU record needs several named field views, use the
 record-oriented [`BufferSchema`](./buffer-schemas) helpers in `@luma.gl/engine`
 instead of hand-writing every shared-buffer attribute offset.

--- a/docs/api-guide/gpu/gpu-storage-buffers.md
+++ b/docs/api-guide/gpu/gpu-storage-buffers.md
@@ -5,6 +5,10 @@ be read or written as ordinary WGSL arrays and structs. They are not available i
 WebGL, so applications that need cross-backend rendering should still understand
 the attribute path described in [Attributes](./gpu-attributes).
 
+For a side-by-side treatment of tabular columns through attributes and storage,
+including packed integers and storage alignment, see
+[Tabular Data in WGSL](./tabular-data-in-wgsl).
+
 ## Storage Buffer Basics
 
 Declare storage bindings in the shader layout:
@@ -136,6 +140,7 @@ batch-by-batch before dispatch.
 ## Related References
 
 - [Attributes](./gpu-attributes)
+- [Tabular Data in WGSL](./tabular-data-in-wgsl)
 - [Buffer Schemas and Columnar Records](./buffer-schemas)
 - [Supported Arrow Types](/docs/api-reference/arrow/supported-arrow-types)
 - [GPU Table Lifecycle](/docs/api-reference/tables/gpu-table-lifecycle)

--- a/docs/api-guide/gpu/tabular-data-in-wgsl.md
+++ b/docs/api-guide/gpu/tabular-data-in-wgsl.md
@@ -1,0 +1,302 @@
+# Tabular Data in WGSL
+
+Many GPU workloads start with tabular data: each logical row describes one
+vertex, instance, particle, glyph, path, or record, and each column supplies one
+value used by the shader.
+
+WGSL exposes two substantially different ways to read those rows:
+
+- **vertex attributes** map columns through the render pipeline's vertex-fetch
+  hardware;
+- **storage buffers** map bytes directly to WGSL arrays, matrices, and structs.
+
+The same source table can use both paths, but the memory contracts are not
+interchangeable. Vertex fetch converts from `VertexFormat` into shader values.
+Storage access reads the declared WGSL storage type without vertex-format
+conversion.
+
+## One Table, Two Shader Interfaces
+
+| Question | Vertex attributes | Storage buffers |
+| --- | --- | --- |
+| Shader declaration | `@location` fields in a vertex input struct | `var<storage>` binding |
+| Application layout | `ShaderLayout.attributes` plus `BufferLayout` | Binding plus WGSL storage type |
+| Natural table shape | One attribute per column, optionally interleaved | One `array<T>` per column or one `array<Struct>` |
+| Type vocabulary | `VertexFormat` for bytes, attribute shader type for the value | WGSL host-shareable storage type |
+| Conversion | Vertex fetch can normalize or widen values | No implicit conversion |
+| Backends | WebGPU and WebGL | WebGPU only |
+
+Use attributes when rows naturally drive a render draw and portability to WebGL
+matters. Use storage buffers when the shader needs arbitrary indexing, writes,
+variable-length data through offsets, matrices, or record structs.
+
+## Mapping Columns to Attributes
+
+A columnar vertex table usually binds one buffer per column:
+
+```ts
+const shaderLayout = {
+  attributes: [
+    {name: 'positions', location: 0, type: 'vec3<f32>'},
+    {name: 'colors', location: 1, type: 'vec4<f32>'}
+  ],
+  bindings: []
+};
+
+const bufferLayout = [
+  {name: 'positions', format: 'float32x3'},
+  {name: 'colors', format: 'unorm8x4'}
+];
+```
+
+The corresponding WGSL vertex input sees shader values, not the source byte
+formats:
+
+```wgsl
+struct VertexInputs {
+  @location(0) position: vec3<f32>,
+  @location(1) color: vec4<f32>,
+};
+```
+
+`colors` can occupy four bytes per row as `unorm8x4`; vertex fetch converts
+those bytes to `vec4<f32>` values in the range `[0, 1]`.
+
+### Interleaved Attribute Rows
+
+Several logical columns can share one row-major buffer:
+
+```ts
+const bufferLayout = [
+  {
+    name: 'instances',
+    byteStride: 16,
+    attributes: [
+      {attribute: 'instancePositions', format: 'float32x3', byteOffset: 0},
+      {attribute: 'instanceColors', format: 'unorm8x4', byteOffset: 12}
+    ]
+  }
+];
+```
+
+Each row occupies 16 bytes:
+
+```text
+byte offset:  0                       12          16
+              | position: float32x3 | color: u8x4 |
+```
+
+The shader still receives separate `@location` fields. The interleaved
+structure belongs to `BufferLayout`, not to the WGSL vertex input type.
+
+## Constant Columns
+
+A logical table column does not always need one stored value per row. If every
+row receives the same value, keep that value as a constant until a pipeline
+actually consumes it. The lowering is different for attributes and storage.
+
+### Attribute Constants
+
+Attribute fetch can broadcast one stored value across every vertex or instance.
+On WebGPU, bind a one-value buffer through a vertex buffer layout whose array
+stride is `0`:
+
+```ts
+const bufferLayout = [
+  {name: 'instanceColors', format: 'float32x4', byteStride: 0}
+];
+```
+
+The buffer contains one `float32x4` value. Because the stride is zero, vertex
+fetch reads the same bytes for every row.
+
+WebGL does not use zero-stride vertex buffers for this. Its equivalent is an
+indirect constant-attribute binding: disable the vertex attribute array and set
+the attribute location's global constant value. In luma.gl, model-level
+`constantAttributes` and `setConstantAttributes()` provide that path.
+
+This lowering should happen outside the logical table column. A table can keep
+one typed constant value without owning a buffer; a render consumer can choose
+the WebGPU zero-stride buffer or the WebGL constant-attribute path when it binds
+the table.
+
+### Storage Constants
+
+Storage arrays do not have an equivalent to a zero array stride. A declaration
+such as `array<vec4<f32>>` advances by the WGSL storage stride whenever the
+shader indexes a new element. Binding one value does not make
+`values[rowIndex]` safe for every row.
+
+Storage constants therefore need explicit shader support. The simplest pattern
+is a separate uniform or one-element storage binding and an accessor that does
+not index by row:
+
+```wgsl
+struct TableConstants {
+  color: vec4<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> tableConstants: TableConstants;
+
+fn readColor(_rowIndex: u32) -> vec4<f32> {
+  return tableConstants.color;
+}
+```
+
+When one shader supports both a real column and a constant, put the choice
+behind the same accessor:
+
+```wgsl
+struct TableConfig {
+  useConstantColor: u32,
+  constantColor: vec4<f32>,
+};
+
+@group(0) @binding(0)
+var<uniform> tableConfig: TableConfig;
+
+@group(0) @binding(1)
+var<storage, read> colors: array<vec4<f32>>;
+
+fn readColor(rowIndex: u32) -> vec4<f32> {
+  if (tableConfig.useConstantColor != 0u) {
+    return tableConfig.constantColor;
+  }
+  return colors[rowIndex];
+}
+```
+
+An `override` value or a generated shader variant can remove that branch when
+the source kind is known while creating the pipeline. The important rule is
+that storage constant semantics live in shader accessors or shader variants,
+not in a fake strided storage array.
+
+## Mapping Columns to Storage Buffers
+
+Storage bindings expose ordinary WGSL arrays. A columnar table can bind each
+column separately:
+
+```wgsl
+@group(0) @binding(0)
+var<storage, read> positions: array<vec2<f32>>;
+
+@group(0) @binding(1)
+var<storage, read> colors: array<u32>;
+```
+
+The shader chooses the storage element type. The producer must upload bytes
+whose alignment and stride match that type exactly.
+
+Storage buffers also support row-oriented records:
+
+```wgsl
+struct InstanceRecord {
+  position: vec3<f32>,
+  color: u32,
+};
+
+@group(0) @binding(0)
+var<storage, read> instances: array<InstanceRecord>;
+```
+
+This is the storage equivalent of an interleaved table: `instances[rowIndex]`
+selects one row, and `.position` or `.color` selects a field.
+
+## Packed 8- and 16-Bit Integers
+
+There is no portable WGSL `u8`, `i8`, `u16`, or `i16` storage scalar type today.
+For 8- or 16-bit data, bind packed words as `array<u32>` and use shifts and
+masks to extract logical values:
+
+```wgsl
+@group(0) @binding(0)
+var<storage, read> packedValues: array<u32>;
+
+fn readU8(index: u32) -> u32 {
+  let word = packedValues[index / 4u];
+  let shift = (index % 4u) * 8u;
+  return (word >> shift) & 0xffu;
+}
+
+fn readU16(index: u32) -> u32 {
+  let word = packedValues[index / 2u];
+  let shift = (index % 2u) * 16u;
+  return (word >> shift) & 0xffffu;
+}
+```
+
+Signed values require sign extension after extraction. Normalized values require
+an explicit conversion, for example `f32(readU8(index)) / 255.0`.
+
+Vertex formats such as `uint8x4`, `unorm8x4`, and `uint16x2` only get their
+special decoding through vertex fetch. A storage shader reading the same four
+bytes as `u32` receives one packed word.
+
+## Storage Alignment and Stride
+
+Storage arrays follow WGSL host-shareable layout rules. Do not infer their
+stride from a similarly named `VertexFormat`.
+
+For example, `float32x3` describes a 12-byte vertex payload. In storage,
+`array<vec3<f32>>` has a 16-byte element stride because `vec3<f32>` has
+16-byte alignment:
+
+```text
+array<vec3<f32>>
+
+row 0: bytes  0..11 value, bytes 12..15 padding
+row 1: bytes 16..27 value, bytes 28..31 padding
+row 2: bytes 32..43 value, bytes 44..47 padding
+```
+
+See the [WGSL storage layout rules](https://www.w3.org/TR/2026/CRD-WGSL-20260513/)
+for alignment, member offsets, structure size, and array stride.
+
+Matrices and structs have the same requirement. A storage
+`array<mat4x4<f32>>` uses the WGSL matrix-column layout; it is not described by
+one `float32x4` vertex format unless the application also supplies the correct
+64-byte row stride.
+
+## Sharing One Row Layout
+
+One physical row can sometimes support both attribute and storage access:
+
+```wgsl
+struct InstanceRecord {
+  position: vec3<f32>,
+  packedColor: u32,
+};
+```
+
+The canonical storage layout places `position` at byte offset `0`,
+`packedColor` at byte offset `12`, and the next record at byte offset `16`.
+The same bytes can be exposed as attributes:
+
+```ts
+{
+  name: 'instances',
+  byteStride: 16,
+  attributes: [
+    {attribute: 'instancePositions', format: 'float32x3', byteOffset: 0},
+    {attribute: 'instanceColors', format: 'unorm8x4', byteOffset: 12}
+  ]
+}
+```
+
+The interpretations remain different:
+
+- the attribute shader receives `instanceColors` as normalized `vec4<f32>`;
+- the storage shader receives `packedColor` as raw `u32` and must unpack it.
+
+Design shared layouts from the storage rules first, then describe compatible
+attribute views over those bytes. Do not assume an arbitrary interleaved
+attribute buffer is a valid WGSL storage struct.
+
+## Related References
+
+- [GPU Memory Layouts](./gpu-memory-layouts)
+- [Attributes](./gpu-attributes)
+- [Storage Buffers](./gpu-storage-buffers)
+- [Buffer Schemas and Columnar Records](./buffer-schemas)
+- [GPU Table Lifecycle](/docs/api-reference/tables/gpu-table-lifecycle)

--- a/docs/api-reference/arrow/supported-arrow-types.mdx
+++ b/docs/api-reference/arrow/supported-arrow-types.mdx
@@ -433,14 +433,13 @@ example](/examples/arrow/arrow-dggs-polygons).
 `GPURecordBatch` and `GPUTable` also select Arrow columns referenced by shader
 bindings of type `'storage'` or `'read-only-storage'`. Selected storage columns:
 
-- appear in `gpuVectors` by binding name;
-- appear in `bindings` by binding name;
+- appear in batch-local `gpuData` and table-level `gpuVectors` by binding name;
 - contribute fields to the GPU-facing Arrow schema;
 - are rebound batch-by-batch by `GPUTableModel.drawBatches(renderPass)`.
 
 This keeps table-backed WebGPU render paths compact. A column such as
-`instanceModelMatrix` can be uploaded once through the table machinery and bound
-directly to a WGSL storage array without four separate matrix-column bindings.
+`instanceModelMatrix` can be uploaded once through the table machinery and
+bound directly to a WGSL storage array without four separate matrix-column bindings.
 
 Storage-selected columns and attribute-selected columns must use distinct shader
 input names. A single name cannot be both an attribute and a storage binding in

--- a/docs/api-reference/tables/gpu-record-batch.mdx
+++ b/docs/api-reference/tables/gpu-record-batch.mdx
@@ -9,10 +9,10 @@ import {TablesDocsTabs} from '@site/src/components/docs/tables-docs-tabs';
   <img src="https://img.shields.io/badge/Status-Work--In--Progress-orange.svg?style=flat-square" alt="Status: Work-In-Progress" />
 </p>
 
-`GPURecordBatch` represents one preserved GPU batch. It owns batch-local
-[`GPUVector`](/docs/api-reference/tables/gpu-vector) objects,
-[`GPUSchema`](/docs/api-reference/tables/gpu-schema) metadata, model-ready
-attributes, and WebGPU storage bindings.
+`GPURecordBatch` represents one immutable preserved GPU batch. It owns one
+batch-local [`GPUData`](/docs/api-reference/tables/gpu-data) chunk per selected column,
+[`GPUSchema`](/docs/api-reference/tables/gpu-schema) metadata, and buffer-layout
+metadata.
 
 ## Usage
 
@@ -20,9 +20,9 @@ attributes, and WebGPU storage bindings.
 import {GPURecordBatch} from '@luma.gl/tables';
 
 const batch = new GPURecordBatch({
-  vectors: {
-    positions,
-    colors
+  gpuData: {
+    positions: positions.data[0],
+    colors: colors.data[0]
   }
 });
 ```
@@ -37,13 +37,12 @@ When the source is an Arrow `RecordBatch`, prefer
 
 | Prop | Type | Default | Meaning |
 | --- | --- | --- | --- |
-| `vectors` | `Record<string, GPUVector> \| GPUVector[]` | Required | Batch-local GPU vectors keyed by name or supplied as named vectors. |
+| `gpuData` | `Record<string, GPUData>` | Required | One batch-local GPU data chunk keyed by selected column name. |
 | `bufferLayout` | `BufferLayout[]` | Derived | Precomputed batch buffer layouts. |
 | `fields` | `GPUField[]` | Derived | Selected schema fields. |
-| `numRows` | `number` | Derived | Explicit row count for intentionally vector-less batches. |
+| `numRows` | `number` | Derived | Explicit row count for intentionally data-less batches. |
 | `metadata` | `Map<string, string>` | `undefined` | Batch-level schema metadata. |
 | `nullCount` | `number` | `0` | Number of null rows retained in batch metadata. |
-| `bindings` | `Record<string, Buffer \| DynamicBuffer>` | `{}` | Model-ready storage bindings keyed by shader binding name. |
 
 ## Properties
 
@@ -54,40 +53,26 @@ When the source is an Arrow `RecordBatch`, prefer
 | `numCols` | `number` | Number of selected GPU columns. |
 | `nullCount` | `number` | Number of null rows retained in metadata. |
 | `bufferLayout` | `BufferLayout[]` | Buffer layouts derived by the producing adapter. |
-| `gpuVectors` | `Record<string, GPUVector>` | Batch-local vectors keyed by shader/table column name. |
-| `attributes` | `Record<string, Buffer \| DynamicBuffer>` | Model-ready attribute buffers keyed by buffer layout name. |
-| `bindings` | `Record<string, Buffer \| DynamicBuffer>` | Model-ready storage bindings keyed by shader binding name. |
+| `gpuData` | `Record<string, GPUData>` | Batch-local data chunks keyed by shader/table column name. |
 
 ## Reserved Draw Columns
 
-`gpuVectors.indices` is reserved for batch-local indexed rendering. It is a
-`vertex-list<uint32>` vector whose flattened `valueLength` is the index count
-for this batch. The vector remains part of `gpuVectors` and `schema`, but it is
+`gpuData.indices` is reserved for batch-local indexed rendering. It is a
+`vertex-list<uint32>` chunk whose flattened `valueLength` is the index count
+for this batch. The chunk remains part of `gpuData` and `schema`, but it is
 not emitted as an attribute buffer layout; its single `GPUData` buffer must be
 created with `Buffer.INDEX` usage so `GPUTableModel` can bind it as the model
 index buffer.
 
 ## Methods
 
-### `appendRows(numRows, nullCount?): this`
-
-Adds logical row and null counts after an adapter appends into batch-local
-vectors.
-
-### `resetRows(): this`
-
-Clears logical row and null counts while retaining vectors and allocations.
-
-### `resetLastBatch(): this`
-
-Clears appendable vector payloads plus batch row/null counts while retaining
-allocations.
-
 ### `destroy(): void`
 
-Destroys every owned `GPUVector` retained by this batch.
+Destroys every retained `GPUData` chunk. Each chunk destroys its buffer only
+when it owns that buffer.
 
 ## Notes
 
-`GPURecordBatch` is the natural unit for preserved source batches. Rendering and
-compute helpers can rebind `attributes` and `bindings` one batch at a time.
+`GPURecordBatch` mirrors Arrow `RecordBatch`: each selected column contributes
+one batch-local data chunk. Multi-chunk logical columns are table-level
+`GPUVector` views built by `GPUTable`.

--- a/docs/api-reference/tables/gpu-schema.mdx
+++ b/docs/api-reference/tables/gpu-schema.mdx
@@ -87,9 +87,8 @@ with
 Table-backed indexed rendering reserves the GPU table column name `indices`.
 It is a draw column, not a shader attribute:
 
-- `gpuVectors.indices` stays in the table or batch schema and vector map;
-- `indices` is excluded from synthesized `bufferLayout` entries and
-  `attributes`;
+- table-level `gpuVectors.indices` and batch-local `gpuData.indices` stay in the schema;
+- `indices` is excluded from synthesized `bufferLayout` entries;
 - `GPUTableModel` binds it through `Model.setIndexBuffer()` instead of matching
   it against `ShaderLayout.attributes`.
 
@@ -113,8 +112,8 @@ management. The objects that need lifecycle management are GPU resource owners:
 - [`GPUData`](/docs/api-reference/tables/gpu-data) owns or borrows one buffer.
 - [`GPUVector`](/docs/api-reference/tables/gpu-vector) owns or borrows ordered
   `GPUData` chunks.
-- [`GPURecordBatch`](/docs/api-reference/tables/gpu-record-batch) owns
-  batch-local vectors.
+- [`GPURecordBatch`](/docs/api-reference/tables/gpu-record-batch) owns one
+  batch-local `GPUData` chunk per selected column.
 - [`GPUTable`](/docs/api-reference/tables/gpu-table) owns preserved batches.
 
 Keeping schema as plain data lets Arrow, gpgpu, generated-geometry, and

--- a/docs/api-reference/tables/gpu-table-lifecycle.mdx
+++ b/docs/api-reference/tables/gpu-table-lifecycle.mdx
@@ -25,15 +25,15 @@ sources after extracting the buffer data and metadata they need.
 
 The object model is batch-preserving by default:
 
-- `GPUTable.batches[]` contains real GPU record batches with batch-local
-  buffers.
+- `GPUTable.batches[]` contains real GPU record batches with one batch-local
+  `GPUData` chunk per selected column.
 - Table-level `gpuVectors` aggregate those batch-local chunks through
   `GPUVector.data[]`.
 - `GPUData` is the chunk primitive. It owns or borrows one `Buffer` or
   `DynamicBuffer`.
 - `GPUTableModel.drawBatches(renderPass)` draws preserved GPU batches by reusing one
-  compatible layout/pipeline and rebinding each batch's attribute buffers,
-  bindings, and reserved `indices` index buffer when present.
+  compatible layout/pipeline and deriving each batch's attribute buffers and
+  reserved `indices` index buffer from its `gpuData`.
 
 This means a multi-batch Arrow table stays multi-batch after GPU upload. If the
 application prefers fewer draw units, it packs explicitly:
@@ -48,9 +48,9 @@ gpuTable.packBatches();
 gpuTable.packBatches({minBatchSize: 50_000});
 ```
 
-Packing mutates the table in place. It rebuilds `batches[]`, table-level
-`gpuVectors`, and `attributes`, then destroys only superseded GPU buffers that
-were owned by the removed batches. Borrowed external buffers are not destroyed.
+Packing mutates the table in place. It rebuilds `batches[]` and table-level
+`gpuVectors`, then destroys only superseded GPU buffers that were owned by the
+removed batches. Borrowed external buffers are not destroyed.
 Indexed tables are rejected because packed index buffers would need their
 batch-local vertex indices rebased.
 
@@ -110,7 +110,7 @@ method signatures live on the individual reference pages:
 | --- | --- | --- |
 | `GPUData` | One GPU buffer plus row/stride metadata and buffer ownership. | [GPUData](/docs/api-reference/tables/gpu-data) |
 | `GPUVector` | One logical column over ordered `GPUData[]` chunks. | [GPUVector](/docs/api-reference/tables/gpu-vector) |
-| `GPURecordBatch` | One preserved batch with batch-local vectors, attributes, and bindings. | [GPURecordBatch](/docs/api-reference/tables/gpu-record-batch) |
+| `GPURecordBatch` | One immutable preserved batch with batch-local data chunks and layout metadata. | [GPURecordBatch](/docs/api-reference/tables/gpu-record-batch) |
 | `GPUTable` | Table-level owner that preserves batches, exposes aggregate vectors, and controls packing/detach/destruction. | [GPUTable](/docs/api-reference/tables/gpu-table) |
 | `GPUSchema` | Selected-column metadata with `GPUVectorFormat` fields. | [GPUSchema](/docs/api-reference/tables/gpu-schema) |
 

--- a/docs/api-reference/tables/gpu-table-structure.mdx
+++ b/docs/api-reference/tables/gpu-table-structure.mdx
@@ -22,15 +22,15 @@ the GPU resource model: `GPUTable`, `GPURecordBatch`, `GPUVector`, and
 
 | GPU object | Role | Important state |
 | --- | --- | --- |
-| [`GPUTable`](/docs/api-reference/tables/gpu-table) | Table-level owner and mutation surface. | `schema`, `bufferLayout`, `gpuVectors`, `attributes`, `bindings`, `batches[]` |
-| [`GPURecordBatch`](/docs/api-reference/tables/gpu-record-batch) | One preserved GPU batch with batch-local vectors. | `schema`, `numRows`, `bufferLayout`, `gpuVectors`, `attributes`, `bindings` |
+| [`GPUTable`](/docs/api-reference/tables/gpu-table) | Table-level owner and mutation surface. | `schema`, `bufferLayout`, `gpuVectors`, `batches[]` |
+| [`GPURecordBatch`](/docs/api-reference/tables/gpu-record-batch) | One preserved GPU batch with one data chunk per column. | `schema`, `numRows`, `bufferLayout`, `gpuData` |
 | [`GPUVector`](/docs/api-reference/tables/gpu-vector) | One logical typed column over one or more GPU data chunks. | `name`, `format`, `length`, `valueLength`, `stride`, `byteStride`, `data[]` |
 | [`GPUData`](/docs/api-reference/tables/gpu-data) | One GPU buffer plus typed row metadata. | `buffer`, `format`, `length`, `valueLength`, `byteOffset`, `byteStride`, `rowByteLength`, `ownsBuffer` |
 | [`GPUSchema`](/docs/api-reference/tables/gpu-schema) | Plain selected-column schema metadata. | `fields`, `metadata` |
 
 The table is intentionally batch-preserving. When an Arrow table has multiple
 record batches, `makeGPUTableFromArrowTable()` creates one `GPURecordBatch` per source
-batch. Table-level `gpuVectors` aggregate the batch-local chunks so code can
+batch. Table-level `gpuVectors` aggregate the batch-local `gpuData` chunks so code can
 reason about one logical column, while batch-aware render and compute paths can
 still bind one physical batch at a time.
 
@@ -42,7 +42,7 @@ semantics are not identical.
 | Arrow JS object | Similarity | GPU table difference |
 | --- | --- | --- |
 | `Table` | Like `GPUTable`, it is a schema plus row-aligned columns and batches. | `GPUTable` is a GPU resource owner. It has no row-object API and must be destroyed or detached intentionally. |
-| `RecordBatch` | Like `GPURecordBatch`, it preserves one row range across all selected columns. | `GPURecordBatch` also publishes model-ready `attributes` and WebGPU `bindings`. |
+| `RecordBatch` | Like `GPURecordBatch`, it preserves one row range across all selected columns. | `GPURecordBatch` retains one GPU-resident `GPUData` chunk per selected column plus layout metadata. |
 | `Vector` | Like `GPUVector`, it is one logical column that can span chunks. | `GPUVector` may be backed by GPU buffers, dynamic appendable storage, interleaved rows, or aggregate chunk views. |
 | `Data` | Like `GPUData`, it is one typed chunk. | `GPUData` owns or borrows a GPU buffer, not a CPU typed-array view. It can only be read back through adapter-specific paths. |
 | `Schema` and `Field` | Both models retain selected-column metadata. | `GPUSchema` is a plain type with `GPUField.format`; Arrow-specific metadata is adapter-owned. |
@@ -69,7 +69,7 @@ GPU tables cannot rely on that model:
   `DynamicBuffer` only when `ownsBuffer` is true.
 - `GPUVector` owns or borrows ordered `GPUData[]` chunks. It does not own raw
   buffers directly.
-- `GPURecordBatch.destroy()` destroys the batch-local vectors it retains.
+- `GPURecordBatch.destroy()` destroys the batch-local data chunks it retains.
 - `GPUTable.destroy()` destroys the preserved batches it still owns.
 - Borrowed external buffers are not destroyed unless ownership was explicitly
   requested or transferred.
@@ -77,12 +77,10 @@ GPU tables cannot rely on that model:
   return ownership to the caller instead of destroying them.
 - `packBatches()` allocates replacement packed buffers, swaps the table to those
   new batches, and destroys superseded owned batch storage.
-- `resetLastBatch()` clears appendable logical rows while retaining GPU
-  allocation capacity for reuse.
 
 This ownership model is why `GPUTable` is a mutation and lifecycle surface, not
 just a data view. The application decides when to preserve source batches, pack
-them, detach live resources, append into dynamic storage, or destroy the current
+them, detach live resources, or destroy the current
 GPU representation.
 
 ## Single-Chunk Binding and Aggregate Vectors

--- a/docs/api-reference/tables/gpu-table.mdx
+++ b/docs/api-reference/tables/gpu-table.mdx
@@ -13,7 +13,7 @@ import {TablesDocsTabs} from '@site/src/components/docs/tables-docs-tabs';
 columns. It preserves real
 [`GPURecordBatch`](/docs/api-reference/tables/gpu-record-batch) objects, exposes
 aggregate [`GPUVector`](/docs/api-reference/tables/gpu-vector) views, and
-controls packing, detaching, selection, reset, and destruction.
+controls packing, detaching, selection, and destruction.
 
 ## Usage
 
@@ -49,15 +49,13 @@ When the source is an Arrow `Table`, prefer
 | `nullCount` | `number` | Aggregate null row count. |
 | `bufferLayout` | `BufferLayout[]` | Buffer layout shared by compatible preserved batches. |
 | `gpuVectors` | `Record<string, GPUVector>` | Aggregate vectors keyed by table/shader column name. |
-| `attributes` | `Record<string, Buffer \| DynamicBuffer>` | Attribute buffers for the first directly drawable batch. |
-| `bindings` | `Record<string, Buffer \| DynamicBuffer>` | Storage bindings for the first directly bindable batch. |
 | `batches` | `GPURecordBatch[]` | Preserved batch-local GPU storage. |
 
 ## Reserved Draw Columns
 
 `gpuVectors.indices` is the reserved indexed-draw column. It is not an
 attribute; preserved batches own their batch-local `vertex-list<uint32>` index
-vectors, and `GPUTableModel.drawBatches()` binds each batch index buffer before
+data chunks, and `GPUTableModel.drawBatches()` binds each batch index buffer before
 drawing. Indexed tables keep indices batch-local, so every preserved batch in an
 indexed table must contain `indices`.
 
@@ -83,13 +81,9 @@ Recomputes aggregate row counts and aggregate vector chunk lists from preserved
 batches. Existing aggregate vectors are extended with new `GPUData` chunks when
 possible.
 
-### `resetLastBatch(): this`
-
-Clears only the trailing appendable GPU batch while retaining its allocations.
-
 ### `select(...columnNames): this`
 
-Destructively keeps only the requested columns. Dropped batch-local vectors are
+Destructively keeps only the requested columns. Dropped batch-local data chunks are
 destroyed.
 
 ### `detachVector(columnName): GPUVector`
@@ -104,7 +98,7 @@ defaults to `batches.length`.
 
 ### `destroy(): void`
 
-Destroys retained GPU batches and follows their vector-level ownership graphs.
+Destroys retained GPU batches and their owned data chunks.
 
 ## Ownership
 

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -69,7 +69,8 @@
           "api-guide/gpu/gpu-bindings",
           "api-guide/gpu/gpu-attributes",
           "api-guide/gpu/gpu-uniforms",
-          "api-guide/gpu/gpu-storage-buffers"
+          "api-guide/gpu/gpu-storage-buffers",
+          "api-guide/gpu/tabular-data-in-wgsl"
         ]
       },
       {

--- a/examples/arrow/arrow-columns/arrow-column-renderer.ts
+++ b/examples/arrow/arrow-columns/arrow-column-renderer.ts
@@ -29,6 +29,7 @@ import {
   GPURecordBatch,
   GPUTable,
   getGPUVectorBuffer,
+  getGPUVectorData,
   getRequiredGPUVector,
   type GPUTypeMap,
   type GPUVector
@@ -511,10 +512,11 @@ async function makeArrowColumnTableInput(
       ([name, vector]) => new arrow.Field(name, getRequiredArrowGPUVectorDataType(vector), false)
     );
     const batch = new GPURecordBatch<GPUTypeMap>({
-      vectors,
+      gpuData: Object.fromEntries(
+        Object.entries(vectors).map(([name, vector]) => [name, getGPUVectorData(vector)])
+      ),
       fields,
-      bufferLayout: [],
-      bindings: getColumnVectorBindings(vectors)
+      bufferLayout: []
     });
     const table = new GPUTable<GPUTypeMap>({
       batches: [batch],

--- a/examples/arrow/arrow-instancing/arrow-instanced-mesh-renderer.ts
+++ b/examples/arrow/arrow-instancing/arrow-instanced-mesh-renderer.ts
@@ -23,7 +23,7 @@ import {
   type PickingManager
 } from '@luma.gl/engine';
 import {dirlight, ShaderModule} from '@luma.gl/shadertools';
-import {GPURenderable, GPUTable, GPUTableModel} from '@luma.gl/tables';
+import {GPURenderable, GPUTable, GPUTableModel, getGPUDataBuffersForLayout} from '@luma.gl/tables';
 import {Matrix4} from '@math.gl/core';
 import * as arrow from 'apache-arrow';
 
@@ -269,7 +269,7 @@ class InstancedCube extends GPUTableModel {
       bufferLayout: instanceBufferLayout,
       instanceCount: this.instanceCount,
       geometry: pickingGeometry,
-      attributes: this.table!.attributes,
+      attributes: getInstanceTableAttributes(this.table!),
       colorAttachmentFormats: ['rgba8unorm', 'rg32sint'],
       depthStencilAttachmentFormat: 'depth24plus',
       parameters: {
@@ -354,7 +354,7 @@ export class ArrowInstancedMeshRenderer extends GPURenderable<
     this.instanceArrowTable = makeInstanceArrowTable(props.instancesPerSide);
     this.cube.setInstanceTable(this.instanceArrowTable);
     if (this.pickingCube) {
-      this.pickingCube.setAttributes(this.cube.table!.attributes);
+      this.pickingCube.setAttributes(getInstanceTableAttributes(this.cube.table!));
       this.pickingCube.setInstanceCount(this.cube.instanceCount);
     }
   }
@@ -412,4 +412,12 @@ export class ArrowInstancedMeshRenderer extends GPURenderable<
       shaderInputs: this.shaderInputs
     });
   }
+}
+
+function getInstanceTableAttributes(table: GPUTable) {
+  const batch = table.batches[0];
+  if (!batch) {
+    throw new Error('Arrow instancing requires one GPU table batch');
+  }
+  return getGPUDataBuffersForLayout(batch.bufferLayout, batch.gpuData);
 }

--- a/examples/arrow/arrow-particles/arrow-particle-renderer.ts
+++ b/examples/arrow/arrow-particles/arrow-particle-renderer.ts
@@ -19,7 +19,7 @@ import {
   GPURecordBatch,
   GPUTable,
   getGPUVectorBuffer,
-  getRequiredGPUVector,
+  type GPUData,
   type GPUVector,
   TableTransform
 } from '@luma.gl/tables';
@@ -217,18 +217,18 @@ export class ArrowParticleRenderer extends GPURenderable<[RenderPass]> {
       if (batch.numRows === 0) {
         continue;
       }
-      const positions = getRequiredGPUVector(
+      const positions = getRequiredBatchGPUData(
         batch,
         'particlePositions',
         'ArrowParticleRenderer GPU batch'
       );
       const renderValues = this.getParticleRenderBatchValues(batch);
       if (this.device.type === 'webgpu') {
-        this.model.setBindings({particlePositions: getGPUVectorBuffer(positions)});
+        this.model.setBindings({particlePositions: positions.buffer});
         this.model.setAttributes({particleColors: getGPUVectorBuffer(renderValues.colors)});
       } else {
         this.model.setAttributes({
-          particlePositions: getGPUVectorBuffer(positions),
+          particlePositions: positions.buffer,
           particleColors: getGPUVectorBuffer(renderValues.colors)
         });
       }
@@ -355,7 +355,7 @@ export class ArrowParticleRenderer extends GPURenderable<[RenderPass]> {
     if (!firstBatch) {
       return;
     }
-    const firstPositions = getRequiredGPUVector(
+    const firstPositions = getRequiredBatchGPUData(
       firstBatch,
       'particlePositions',
       'ArrowParticleRenderer GPU batch'
@@ -375,7 +375,7 @@ export class ArrowParticleRenderer extends GPURenderable<[RenderPass]> {
         source: WEBGPU_RENDER_SHADER,
         shaderLayout: RENDER_SHADER_LAYOUT,
         bindings: {
-          particlePositions: getGPUVectorBuffer(firstPositions)
+          particlePositions: firstPositions.buffer
         },
         attributes: {
           particleColors: getGPUVectorBuffer(firstRenderValues.colors)
@@ -402,7 +402,7 @@ export class ArrowParticleRenderer extends GPURenderable<[RenderPass]> {
       fs: WEBGL_RENDER_FRAGMENT_SHADER,
       shaderLayout: WEBGL_RENDER_SHADER_LAYOUT,
       attributes: {
-        particlePositions: getGPUVectorBuffer(firstPositions),
+        particlePositions: firstPositions.buffer,
         particleColors: getGPUVectorBuffer(firstRenderValues.colors)
       },
       bufferLayout: [
@@ -422,12 +422,16 @@ export class ArrowParticleRenderer extends GPURenderable<[RenderPass]> {
       if (!initialValues) {
         continue;
       }
-      getGPUVectorBuffer(
-        getRequiredGPUVector(batch, 'particlePositions', 'ArrowParticleRenderer GPU batch')
-      ).write(initialValues.positions);
-      getGPUVectorBuffer(
-        getRequiredGPUVector(batch, 'particleVelocities', 'ArrowParticleRenderer GPU batch')
-      ).write(initialValues.velocities);
+      getRequiredBatchGPUData(
+        batch,
+        'particlePositions',
+        'ArrowParticleRenderer GPU batch'
+      ).buffer.write(initialValues.positions);
+      getRequiredBatchGPUData(
+        batch,
+        'particleVelocities',
+        'ArrowParticleRenderer GPU batch'
+      ).buffer.write(initialValues.velocities);
     }
   }
 
@@ -437,12 +441,12 @@ export class ArrowParticleRenderer extends GPURenderable<[RenderPass]> {
       return outputBuffers;
     }
 
-    const positions = getRequiredGPUVector(
+    const positions = getRequiredBatchGPUData(
       batch,
       'particlePositions',
       'ArrowParticleRenderer GPU batch'
     );
-    const velocities = getRequiredGPUVector(
+    const velocities = getRequiredBatchGPUData(
       batch,
       'particleVelocities',
       'ArrowParticleRenderer GPU batch'
@@ -455,15 +459,11 @@ export class ArrowParticleRenderer extends GPURenderable<[RenderPass]> {
     return outputBuffers;
   }
 
-  private createTransformOutputBuffer(
-    batch: GPURecordBatch,
-    vector: GPUVector,
-    label: string
-  ): Buffer {
+  private createTransformOutputBuffer(batch: GPURecordBatch, data: GPUData, label: string): Buffer {
     return this.device.createBuffer({
       id: `arrow-particles-${label}-output-${this.particleTable?.batches.indexOf(batch) ?? 0}`,
       usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST,
-      byteLength: Math.max(1, vector.length * vector.byteStride)
+      byteLength: Math.max(1, data.length * data.byteStride)
     });
   }
 
@@ -479,7 +479,7 @@ export class ArrowParticleRenderer extends GPURenderable<[RenderPass]> {
       copyCount += copyOutputToBatchVector({
         commandEncoder,
         sourceBuffer: outputBuffers.nextParticlePositions,
-        targetVector: getRequiredGPUVector(
+        targetData: getRequiredBatchGPUData(
           batch,
           'particlePositions',
           'ArrowParticleRenderer GPU batch'
@@ -488,7 +488,7 @@ export class ArrowParticleRenderer extends GPURenderable<[RenderPass]> {
       copyCount += copyOutputToBatchVector({
         commandEncoder,
         sourceBuffer: outputBuffers.nextParticleVelocities,
-        targetVector: getRequiredGPUVector(
+        targetData: getRequiredBatchGPUData(
           batch,
           'particleVelocities',
           'ArrowParticleRenderer GPU batch'
@@ -634,22 +634,34 @@ function destroyPreparedParticleBatch(preparedBatch: PreparedParticleBatch): voi
 function copyOutputToBatchVector({
   commandEncoder,
   sourceBuffer,
-  targetVector
+  targetData
 }: {
   commandEncoder: ReturnType<Device['createCommandEncoder']>;
   sourceBuffer: Buffer;
-  targetVector: GPUVector;
+  targetData: GPUData;
 }): number {
-  const size = targetVector.length * targetVector.byteStride;
+  const size = targetData.length * targetData.byteStride;
   if (size === 0) {
     return 0;
   }
   commandEncoder.copyBufferToBuffer({
     sourceBuffer,
-    destinationBuffer: getConcreteBuffer(getGPUVectorBuffer(targetVector)),
+    destinationBuffer: getConcreteBuffer(targetData.buffer),
     size
   });
   return 1;
+}
+
+function getRequiredBatchGPUData(
+  batch: GPURecordBatch,
+  columnName: string,
+  ownerName: string
+): GPUData {
+  const data = batch.gpuData[columnName];
+  if (!data) {
+    throw new Error(`${ownerName} is missing GPUData "${columnName}"`);
+  }
+  return data;
 }
 
 function getConcreteBuffer(buffer: Buffer | DynamicBuffer): Buffer {

--- a/examples/arrow/arrow-temporal-starfield/arrow-temporal-starfield-renderer.ts
+++ b/examples/arrow/arrow-temporal-starfield/arrow-temporal-starfield-renderer.ts
@@ -20,6 +20,7 @@ import {
   GPUTable,
   GPUTableModel,
   getGPUVectorBuffer,
+  getGPUVectorData,
   getRequiredGPUVector,
   type GPUTypeMap,
   type GPUVector
@@ -522,14 +523,16 @@ async function makeTemporalStarfieldGPURecordBatchInput(
       pulsePeriods: preparedDurationColumns.pulsePeriods
     };
     const gpuRecordBatch = new GPURecordBatch<GPUTypeMap>({
-      vectors: {
-        positions,
-        eventStarts: temporalColumns.eventStarts.vector,
-        eventDurations: getPreparedScalarTemporalVector(temporalColumns.eventDurations),
-        pulsePeriods: getPreparedScalarTemporalVector(temporalColumns.pulsePeriods),
-        starSizes,
-        eventColors
-      }
+      gpuData: Object.fromEntries(
+        Object.entries({
+          positions,
+          eventStarts: temporalColumns.eventStarts.vector,
+          eventDurations: getPreparedScalarTemporalVector(temporalColumns.eventDurations),
+          pulsePeriods: getPreparedScalarTemporalVector(temporalColumns.pulsePeriods),
+          starSizes,
+          eventColors
+        }).map(([name, vector]) => [name, getGPUVectorData(vector)])
+      )
     });
 
     return {

--- a/examples/arrow/arrow-text-3d/arrow-text-3d-renderer.ts
+++ b/examples/arrow/arrow-text-3d/arrow-text-3d-renderer.ts
@@ -18,7 +18,7 @@ import {
   type Text3DBounds,
   type Text3DGlyphAtlasOptions
 } from '@luma.gl/text/text-3d';
-import type {GPUTable} from '@luma.gl/tables';
+import {getGPUDataBuffersForLayout, type GPUTable} from '@luma.gl/tables';
 import type {Matrix4, NumberArray4, NumberArray16} from '@math.gl/core';
 import {
   makeArrowText3DGlyphData,
@@ -245,7 +245,7 @@ export class ArrowText3DRenderer {
       shaderLayout: ARROW_TEXT_3D_SHADER_LAYOUT,
       geometry: glyphAtlas.geometry,
       bufferLayout: this.glyphInstanceTable.bufferLayout,
-      attributes: firstGlyphBatch.attributes,
+      attributes: getGPUDataBuffersForLayout(firstGlyphBatch.bufferLayout, firstGlyphBatch.gpuData),
       instanceCount: firstGlyphBatch.numRows,
       parameters: {
         depthWriteEnabled: true,
@@ -323,7 +323,9 @@ function drawArrowText3DGlyphRanges(
     if (!glyphInstanceBatch) {
       throw new Error('Arrow 3D text draw range is missing its grouped glyph instance batch');
     }
-    model.setAttributes(glyphInstanceBatch.attributes);
+    model.setAttributes(
+      getGPUDataBuffersForLayout(glyphInstanceBatch.bufferLayout, glyphInstanceBatch.gpuData)
+    );
     model.setInstanceCount(glyphDrawRange.instanceCount);
     const drawValidationError = drawableModel.vertexArray.getDrawValidationError();
     if (drawValidationError) {

--- a/modules/arrow/src/arrow/engine/arrow-geometry.ts
+++ b/modules/arrow/src/arrow/engine/arrow-geometry.ts
@@ -10,7 +10,13 @@ import {
   type VertexFormat,
   vertexFormatDecoder
 } from '@luma.gl/core';
-import {GPURecordBatch, GPUTable, GPUTableGeometry, GPUVector} from '@luma.gl/tables';
+import {
+  GPURecordBatch,
+  GPUTable,
+  GPUTableGeometry,
+  GPUVector,
+  getGPUVectorData
+} from '@luma.gl/tables';
 import {Binary, DataType, Float, Int, Precision, Table, Vector} from 'apache-arrow';
 import type {ArrowMeshTable, ArrowMeshTopology} from './arrow-mesh-types';
 
@@ -466,7 +472,10 @@ function createSeparateGPUTable(
 }
 
 function createGeometryGPUTable(vectors: GPUVector[], bufferLayout: BufferLayout[]): GPUTable {
-  const batch = new GPURecordBatch({vectors, bufferLayout});
+  const gpuData = Object.fromEntries(
+    vectors.map(vector => [vector.name, getGPUVectorData(vector)])
+  );
+  const batch = new GPURecordBatch({gpuData, bufferLayout});
   return new GPUTable({
     batches: [batch],
     schema: batch.schema,

--- a/modules/arrow/src/arrow/gpu/arrow-gpu-table-adapters.ts
+++ b/modules/arrow/src/arrow/gpu/arrow-gpu-table-adapters.ts
@@ -16,6 +16,7 @@ import {
   GPUTable,
   GPUVector,
   type GPURecordBatchSourceInfo,
+  type GPUField,
   type GPUVectorBufferProps,
   type GPUVectorFormat,
   type ValueList,
@@ -34,7 +35,6 @@ import {
   List,
   Precision,
   RecordBatch,
-  Schema,
   Table,
   Uint16,
   Uint32,
@@ -416,25 +416,25 @@ export function makeGPURecordBatchFromArrowRecordBatch(
     arrowPaths: options.arrowPaths,
     allowWebGLOnlyFormats: options.allowWebGLOnlyFormats
   });
-  const fields: Field[] = [];
-  const vectors: Record<string, GPUVector> = {};
-  const bindings: Record<string, Buffer | DynamicBuffer> = {};
+  const fields: GPUField[] = [];
+  const gpuData: Record<string, GPUData> = {};
   const selectedNames = new Set<string>();
 
   for (const layout of bufferLayout) {
     const arrowPath = options.arrowPaths?.[layout.name] || layout.name;
     const vector = getArrowVectorByPath(table, arrowPath);
     const sourceField = getArrowFieldByPath(table, arrowPath);
-    const gpuVector = makeGPUVectorFromArrow(device, vector as Vector, {
+    gpuData[layout.name] = makeGPUDataFromArrowRecordBatchVector(device, vector as Vector, {
       ...options.bufferProps,
-      name: layout.name,
       format: layout.format
     });
-    fields.push(
-      new Field(layout.name, vector.type, sourceField.nullable, new Map(sourceField.metadata))
-    );
+    fields.push({
+      name: layout.name,
+      format: gpuData[layout.name].format,
+      nullable: sourceField.nullable,
+      metadata: new Map(sourceField.metadata)
+    });
     selectedNames.add(layout.name);
-    vectors[layout.name] = gpuVector;
   }
 
   for (const storageBinding of getArrowStorageBindings(options.shaderLayout)) {
@@ -449,32 +449,59 @@ export function makeGPURecordBatchFromArrowRecordBatch(
     if (!vector || !sourceField) {
       continue;
     }
-    const gpuVector = makeGPUVectorFromArrow(device, vector as Vector, {
-      ...options.bufferProps,
-      name: storageBinding.name
-    });
-    fields.push(
-      new Field(
-        storageBinding.name,
-        vector.type,
-        sourceField.nullable,
-        new Map(sourceField.metadata)
-      )
+    gpuData[storageBinding.name] = makeGPUDataFromArrowRecordBatchVector(
+      device,
+      vector as Vector,
+      options.bufferProps
     );
+    fields.push({
+      name: storageBinding.name,
+      format: gpuData[storageBinding.name].format,
+      nullable: sourceField.nullable,
+      metadata: new Map(sourceField.metadata)
+    });
     selectedNames.add(storageBinding.name);
-    vectors[storageBinding.name] = gpuVector;
-    bindings[storageBinding.name] = getSingleGPUVectorDataBuffer(gpuVector, storageBinding.name);
   }
 
   return new GPURecordBatch({
-    vectors,
+    gpuData,
     bufferLayout,
     fields,
     numRows: recordBatch.numRows,
     metadata: new Map(recordBatch.schema.metadata),
     sourceInfo: options.sourceInfo,
-    nullCount: recordBatch.nullCount,
-    bindings
+    nullCount: recordBatch.nullCount
+  });
+}
+
+function makeGPUDataFromArrowRecordBatchVector(
+  device: Device,
+  vector: Vector,
+  props: ArrowGPUDataProps = {}
+): GPUData {
+  const arrowType = vector.type;
+  const matrixInfo = getArrowMatrixVectorInfo(vector);
+  const isCanonicalFloat32Matrix = matrixInfo && isCanonicalFloat32ArrowMatrixInfo(matrixInfo);
+  const requiresChunkedUpload =
+    DataType.isUtf8(arrowType) ||
+    isArrowUtf8DictionaryType(arrowType) ||
+    isVariableLengthAttributeArrowType(arrowType);
+  if (matrixInfo && !isCanonicalFloat32Matrix) {
+    throw new Error(
+      'GPUVector matrix columns require canonical Float32 column-major wgsl-storage values; use convertArrowMatrixToGPUVector() first'
+    );
+  }
+  if (!isInstanceArrowType(arrowType) && !isCanonicalFloat32Matrix && !requiresChunkedUpload) {
+    throw new Error(`GPUVector does not support Arrow type ${arrowType}`);
+  }
+
+  const [data, ...remainingData] = vector.data;
+  if (!data || remainingData.length > 0) {
+    throw new Error('Arrow RecordBatch columns require exactly one Arrow Data chunk');
+  }
+  return makeGPUDataFromArrowData(device, data, {
+    ...props,
+    format: props.format ?? (matrixInfo ? 'float32x4' : getGPUVectorFormatForArrowType(arrowType))
   });
 }
 
@@ -505,22 +532,19 @@ export function makeGPUTableFromArrowTable(
       arrowPaths: options.arrowPaths,
       allowWebGLOnlyFormats: options.allowWebGLOnlyFormats
     });
-  const schema =
-    firstBatch?.schema ??
-    new Schema(
-      bufferLayout.map(layout => {
-        const arrowPath = options.arrowPaths?.[layout.name] || layout.name;
-        const vector = getArrowVectorByPath(table, arrowPath);
-        const sourceField = getArrowFieldByPath(table, arrowPath);
-        return new Field(
-          layout.name,
-          vector.type,
-          sourceField.nullable,
-          new Map(sourceField.metadata)
-        );
-      }),
-      new Map(table.schema.metadata)
-    );
+  const schema = firstBatch?.schema ?? {
+    fields: bufferLayout.map(layout => {
+      const arrowPath = options.arrowPaths?.[layout.name] || layout.name;
+      const sourceField = getArrowFieldByPath(table, arrowPath);
+      return {
+        name: layout.name,
+        format: layout.format as GPUVectorFormat,
+        nullable: sourceField.nullable,
+        metadata: new Map(sourceField.metadata)
+      };
+    }),
+    metadata: new Map(table.schema.metadata)
+  };
 
   return new GPUTable({
     batches,
@@ -545,19 +569,6 @@ export async function readArrowGPUVectorAsync<T extends DataType>(
   }
   const data = await Promise.all(vector.data.map(chunk => readArrowGPUDataAsync<T>(chunk)));
   return new Vector(data) as Vector<T>;
-}
-
-function getSingleGPUVectorDataBuffer(
-  vector: GPUVector,
-  bindingName: string
-): Buffer | DynamicBuffer {
-  const [data, ...remainingData] = vector.data;
-  if (!data || remainingData.length > 0) {
-    throw new Error(
-      `GPURecordBatch storage binding "${bindingName}" requires exactly one GPUData chunk`
-    );
-  }
-  return data.buffer;
 }
 
 function getArrowStorageBindings(shaderLayout: ShaderLayout): Array<{name: string}> {

--- a/modules/arrow/src/arrow/renderers/text/renderers/arrow-text-picking.ts
+++ b/modules/arrow/src/arrow/renderers/text/renderers/arrow-text-picking.ts
@@ -9,6 +9,7 @@ import {
   supportsArrowIndexPicking
 } from '../../../engine/arrow-picking';
 import {indexPicking, Model, type PickingManager, type ShaderInputs} from '@luma.gl/engine';
+import {getGPUDataBuffersForLayout, type GPUTable} from '@luma.gl/tables';
 import {TextAttributeModel, TextDictionaryModel, TextStorageModel} from '@luma.gl/text';
 import type {ArrowTextRendererActiveModel} from './arrow-text-renderer';
 import {
@@ -90,7 +91,7 @@ export function createArrowTextPickingModel(
     shaderLayout: TEXT_SHADER_LAYOUT,
     bufferLayout: textModel.bufferLayout,
     attributes: {
-      ...textModel.table!.attributes,
+      ...getArrowTextPickingTableAttributes(textModel.table),
       expandedGlyphVertexData: textModel.expandedGlyphVertexData
     },
     instanceCount: textModel.instanceCount,
@@ -130,7 +131,7 @@ function drawArrowTextPickingBatches(
       throw new Error('Arrow text picking requires aligned GPU and glyph render batches');
     }
     pickingModel.setAttributes({
-      ...gpuBatch.attributes,
+      ...getGPUDataBuffersForLayout(gpuBatch.bufferLayout, gpuBatch.gpuData),
       expandedGlyphVertexData: renderBatch.expandedGlyphVertexData
     });
     pickingModel.setInstanceCount(renderBatch.glyphCount);
@@ -138,8 +139,15 @@ function drawArrowTextPickingBatches(
     pickingModel.draw(pickingPass);
   }
   pickingModel.setAttributes({
-    ...(textModel.table?.attributes || {}),
+    ...getArrowTextPickingTableAttributes(textModel.table),
     expandedGlyphVertexData: textModel.expandedGlyphVertexData
   });
   pickingModel.setInstanceCount(textModel.glyphLayout.glyphCount);
+}
+
+function getArrowTextPickingTableAttributes(
+  table: GPUTable | undefined
+): ReturnType<typeof getGPUDataBuffersForLayout> {
+  const firstBatch = table?.batches[0];
+  return firstBatch ? getGPUDataBuffersForLayout(firstBatch.bufferLayout, firstBatch.gpuData) : {};
 }

--- a/modules/arrow/test/arrow/arrow-model.spec.ts
+++ b/modules/arrow/test/arrow/arrow-model.spec.ts
@@ -76,7 +76,7 @@ test('makeGPUTableFromArrowTable converts Arrow tables for GPUTableModel renderi
     shaderLayout: SHADER_LAYOUT,
     table
   });
-  const positionsBuffer = table.batches[0].gpuVectors.positions.data[0].buffer;
+  const positionsBuffer = table.batches[0].gpuData.positions.buffer;
 
   t.ok(table instanceof GPUTable, 'creates a GPUTable');
   t.deepEqual(
@@ -89,7 +89,7 @@ test('makeGPUTableFromArrowTable converts Arrow tables for GPUTableModel renderi
   );
   t.equal(
     model.vertexArray.attributes[0],
-    getConcreteTestBuffer(table.attributes.positions),
+    getConcreteTestBuffer(table.batches[0].gpuData.positions.buffer),
     'sets Model vertex array attributes from GPU table buffers'
   );
   t.equal(model.instanceCount, arrowTable.numRows, 'infers instanceCount from table row count');
@@ -121,7 +121,7 @@ test('makeGPUTableFromArrowTable converts scalar filter values to float32 attrib
   t.end();
 });
 
-test('makeGPUTableFromArrowTable exposes Arrow table rows as storage bindings', t => {
+test('makeGPUTableFromArrowTable derives model storage bindings from batch GPUData', t => {
   const device = new NullDevice({});
   const arrowTable = makeArrowModelTable();
   const table = makeGPUTableFromArrowTable(device, arrowTable, {
@@ -134,14 +134,14 @@ test('makeGPUTableFromArrowTable exposes Arrow table rows as storage bindings', 
     shaderLayout: STORAGE_SHADER_LAYOUT,
     table
   });
-  const colorsBuffer = table.batches[0].gpuVectors.colors.data[0].buffer;
+  const colorsBuffer = table.batches[0].gpuData.colors.buffer;
 
   t.deepEqual(
     table.schema.fields.map(field => field.name),
     ['positions', 'colors'],
     'keeps attribute and storage columns in the selected GPU schema'
   );
-  t.equal(table.bindings.colors, colorsBuffer, 'table exposes storage rows as a named binding');
+  t.notOk('bindings' in table, 'table does not cache storage bindings');
   t.equal(model.bindings.colors, colorsBuffer, 'model receives storage bindings from the table');
 
   model.destroy();
@@ -213,7 +213,7 @@ test('GPUTableModel updates converted GPU table props', t => {
   );
   t.equal(
     model.vertexArray.attributes[0],
-    getConcreteTestBuffer(nextTable.attributes.positions),
+    getConcreteTestBuffer(nextTable.batches[0].gpuData.positions.buffer),
     'sets vertex array attributes from the updated GPU table buffers'
   );
 
@@ -271,7 +271,7 @@ test('GPUTableModel.drawBatches draws preserved converted Arrow table batches', 
   const previousPipeline = model.pipeline;
   const previousBufferLayout = model.bufferLayout;
   const positionsBuffers = table.batches.map(batch =>
-    getConcreteTestBuffer(batch.gpuVectors.positions.data[0].buffer)
+    getConcreteTestBuffer(batch.gpuData.positions.buffer)
   );
   const drawCalls: {
     instanceCount?: number;
@@ -304,7 +304,7 @@ test('GPUTableModel.drawBatches draws preserved converted Arrow table batches', 
   t.equal(model.instanceCount, arrowTable.numRows, 'restores the table-level inferred row count');
   t.equal(
     model.vertexArray.attributes[0],
-    getConcreteTestBuffer(table.attributes.positions),
+    getConcreteTestBuffer(table.batches[0].gpuData.positions.buffer),
     'restores table-level model attributes after batched drawing'
   );
 

--- a/modules/arrow/test/arrow/plain-gpu-table.spec.ts
+++ b/modules/arrow/test/arrow/plain-gpu-table.spec.ts
@@ -359,13 +359,18 @@ test('GPUTable static batches bind UTF-8 storage through batch GPUData buffers',
 
   t.equal(
     gpuTable.batches[0].gpuData.texts.buffer,
-    gpuTable.batches[0].gpuData.texts.buffer,
+    gpuTable.gpuVectors.texts.data[0].buffer,
     'batch-local UTF-8 storage binding resolves through GPUData'
   );
   t.equal(gpuTable.gpuVectors.texts.data.length, 2, 'keeps UTF-8 aggregate chunk boundaries');
   t.ok(
     arrow.DataType.isUtf8(gpuTable.gpuVectors.texts.dataType as arrow.DataType),
     'aggregate UTF-8 vectors preserve adapter data type metadata'
+  );
+  t.throws(
+    () => gpuTable.packBatches(),
+    /does not support variable-length GPUData "texts"/,
+    'generic packing rejects variable-length storage payloads instead of truncating them'
   );
 
   gpuTable.destroy();

--- a/modules/arrow/test/arrow/plain-gpu-table.spec.ts
+++ b/modules/arrow/test/arrow/plain-gpu-table.spec.ts
@@ -62,16 +62,16 @@ test('GPUTable creates GPU vectors from shader-compatible Arrow table columns', 
     'preserves same-name field metadata'
   );
   t.equal(
-    gpuTable.attributes.positions,
-    gpuTable.batches[0].gpuVectors.positions.data[0].buffer,
+    gpuTable.batches[0].gpuData.positions.buffer,
+    gpuTable.batches[0].gpuData.positions.buffer,
     'exposes positions as a Model attribute buffer'
   );
   t.equal(
-    gpuTable.attributes.colors,
-    gpuTable.batches[0].gpuVectors.colors.data[0].buffer,
+    gpuTable.batches[0].gpuData.colors.buffer,
+    gpuTable.batches[0].gpuData.colors.buffer,
     'exposes colors as a Model attribute buffer'
   );
-  t.notOk(gpuTable.attributes.missing, 'skips missing table columns');
+  t.notOk('attributes' in gpuTable, 'does not cache derived attribute buffers');
 
   gpuTable.destroy();
   t.end();
@@ -95,7 +95,7 @@ test('GPUTable maps shader attributes through Arrow paths', t => {
     [{name: 'instanceColors', format: 'unorm8x4'}],
     'derives buffer layouts from explicit Arrow paths'
   );
-  t.ok(gpuTable.attributes.instanceColors, 'exposes renamed shader attribute buffer');
+  t.ok(gpuTable.batches[0].gpuData.instanceColors, 'retains renamed shader attribute data');
   t.deepEqual(
     gpuTable.schema.fields.map(field => field.name),
     ['instanceColors'],
@@ -107,16 +107,16 @@ test('GPUTable maps shader attributes through Arrow paths', t => {
     'renamed GPU schema field preserves source field metadata'
   );
   t.equal(
-    gpuTable.schema.fields[0].type,
-    table.getChild('colors')?.type,
-    'renamed GPU schema field preserves source field type'
+    gpuTable.schema.fields[0].format,
+    'unorm8x4',
+    'renamed GPU schema field preserves GPU memory format'
   );
 
   gpuTable.destroy();
   t.end();
 });
 
-test('GPUTable exposes storage-selected Arrow columns as bindings', t => {
+test('GPUTable exposes storage-selected Arrow columns as GPUData', t => {
   const device = new NullDevice({});
   const table = makeGpuMetadataTable();
   const shaderLayout: ShaderLayout = {
@@ -133,11 +133,11 @@ test('GPUTable exposes storage-selected Arrow columns as bindings', t => {
   );
   t.equal(gpuTable.numCols, 1, 'storage-backed selected columns count toward table columns');
   t.equal(
-    gpuTable.bindings.positions,
-    gpuTable.batches[0].gpuVectors.positions.data[0].buffer,
+    gpuTable.batches[0].gpuData.positions.buffer,
+    gpuTable.batches[0].gpuData.positions.buffer,
     'exposes the batch-local GPUData buffer as a model-ready storage binding'
   );
-  t.notOk(gpuTable.attributes.positions, 'does not expose storage-only columns as attributes');
+  t.notOk('bindings' in gpuTable, 'does not cache storage bindings');
 
   gpuTable.destroy();
   t.end();
@@ -208,18 +208,18 @@ test('GPUTable preserves record batch boundaries with real batch-owned GPU buffe
     'retains table buffer layout metadata on GPU batches'
   );
   t.notEqual(
-    gpuTable.batches[1].gpuVectors.positions.data[0].buffer,
-    gpuTable.batches[0].gpuVectors.positions.data[0].buffer,
+    gpuTable.batches[1].gpuData.positions.buffer,
+    gpuTable.batches[0].gpuData.positions.buffer,
     'record batches keep separate GPU buffers'
   );
   t.equal(
     gpuTable.gpuVectors.positions.data[0].buffer,
-    gpuTable.batches[0].gpuVectors.positions.data[0].buffer,
+    gpuTable.batches[0].gpuData.positions.buffer,
     'aggregate vectors expose the first batch chunk'
   );
   t.equal(
     gpuTable.gpuVectors.positions.data[1].buffer,
-    gpuTable.batches[1].gpuVectors.positions.data[0].buffer,
+    gpuTable.batches[1].gpuData.positions.buffer,
     'aggregate vectors expose the second batch chunk'
   );
   t.equal(gpuTable.gpuVectors.positions.data.length, 2, 'aggregate vector has no direct buffer');
@@ -241,8 +241,8 @@ test('GPUTable packBatches collapses owned batches in place', t => {
     bindings: []
   };
   const gpuTable = makeGPUTableFromArrowTable(device, table, {shaderLayout});
-  const firstPositionsBuffer = gpuTable.batches[0].gpuVectors.positions.data[0].buffer;
-  const secondPositionsBuffer = gpuTable.batches[1].gpuVectors.positions.data[0].buffer;
+  const firstPositionsBuffer = gpuTable.batches[0].gpuData.positions.buffer;
+  const secondPositionsBuffer = gpuTable.batches[1].gpuData.positions.buffer;
 
   gpuTable.packBatches();
 
@@ -254,8 +254,8 @@ test('GPUTable packBatches collapses owned batches in place', t => {
     'packed vectors preserve adapter data type metadata'
   );
   t.equal(
-    gpuTable.attributes.positions,
-    gpuTable.batches[0].gpuVectors.positions.data[0].buffer,
+    gpuTable.batches[0].gpuData.positions.buffer,
+    gpuTable.batches[0].gpuData.positions.buffer,
     'updates direct table attributes to the packed batch buffer'
   );
   t.ok(firstPositionsBuffer.destroyed, 'destroys the first superseded owned batch buffer');
@@ -313,7 +313,7 @@ test('GPUTable addBatch appends an already-owned GPU record batch in place', t =
     shaderLayout,
     sourceInfo: {sourceBatchIndex: 1, sourceRowIndexOffset: 2, sourceRowCount: 2}
   });
-  const appendedPositionsBuffer = gpuRecordBatch.gpuVectors.positions.data[0].buffer;
+  const appendedPositionsBuffer = gpuRecordBatch.gpuData.positions.buffer;
 
   gpuTable.addBatch(gpuRecordBatch);
 
@@ -358,8 +358,8 @@ test('GPUTable static batches bind UTF-8 storage through batch GPUData buffers',
   const gpuTable = makeGPUTableFromArrowTable(device, sourceTable, {shaderLayout});
 
   t.equal(
-    gpuTable.bindings.texts,
-    gpuTable.batches[0].gpuVectors.texts.data[0].buffer,
+    gpuTable.batches[0].gpuData.texts.buffer,
+    gpuTable.batches[0].gpuData.texts.buffer,
     'batch-local UTF-8 storage binding resolves through GPUData'
   );
   t.equal(gpuTable.gpuVectors.texts.data.length, 2, 'keeps UTF-8 aggregate chunk boundaries');
@@ -372,7 +372,7 @@ test('GPUTable static batches bind UTF-8 storage through batch GPUData buffers',
   t.end();
 });
 
-test('GPUTable select keeps requested columns and destroys dropped batch vectors', t => {
+test('GPUTable select keeps requested columns and destroys dropped batch data', t => {
   const device = new NullDevice({});
   const table = makeGpuMetadataTable();
   const shaderLayout: ShaderLayout = {
@@ -383,7 +383,7 @@ test('GPUTable select keeps requested columns and destroys dropped batch vectors
     bindings: []
   };
   const gpuTable = makeGPUTableFromArrowTable(device, table, {shaderLayout});
-  const droppedColorsBuffer = gpuTable.batches[0].gpuVectors.colors.data[0].buffer;
+  const droppedColorsBuffer = gpuTable.batches[0].gpuData.colors.buffer;
 
   gpuTable.select('positions');
 
@@ -405,7 +405,7 @@ test('GPUTable select keeps requested columns and destroys dropped batch vectors
   t.end();
 });
 
-test('GPUTable select prunes dropped storage bindings', t => {
+test('GPUTable select prunes dropped storage data', t => {
   const device = new NullDevice({});
   const positions = makeArrowFixedSizeListVector(
     new arrow.Float32(),
@@ -419,15 +419,14 @@ test('GPUTable select prunes dropped storage bindings', t => {
     bindings: [{name: 'texts', type: 'read-only-storage', group: 0, location: 0}]
   };
   const gpuTable = makeGPUTableFromArrowTable(device, table, {shaderLayout});
-  const droppedTextsBuffer = gpuTable.batches[0].gpuVectors.texts.data[0].buffer;
+  const droppedTextsBuffer = gpuTable.batches[0].gpuData.texts.buffer;
 
-  t.ok(gpuTable.bindings.texts, 'starts with the storage binding exposed on the table');
+  t.ok(gpuTable.batches[0].gpuData.texts, 'starts with batch-local storage data');
 
   gpuTable.select('positions');
 
   t.notOk(gpuTable.gpuVectors.texts, 'removes the dropped aggregate storage vector');
-  t.notOk(gpuTable.bindings.texts, 'removes the dropped table storage binding');
-  t.notOk(gpuTable.batches[0].bindings.texts, 'removes the dropped batch storage binding');
+  t.notOk(gpuTable.batches[0].gpuData.texts, 'removes dropped batch storage data');
   t.ok(droppedTextsBuffer.destroyed, 'destroys the dropped storage vector buffer');
 
   gpuTable.destroy();
@@ -447,7 +446,7 @@ test('GPUTable detachVector removes one live column and transfers its ownership'
     bindings: []
   };
   const gpuTable = makeGPUTableFromArrowTable(device, table, {shaderLayout});
-  const colorsBuffers = gpuTable.batches.map(batch => batch.gpuVectors.colors.data[0].buffer);
+  const colorsBuffers = gpuTable.batches.map(batch => batch.gpuData.colors.buffer);
 
   const detachedColors = gpuTable.detachVector('colors');
 
@@ -488,7 +487,7 @@ test('GPUTable detachBatches removes a live batch range and restitches aggregate
     bindings: []
   };
   const gpuTable = makeGPUTableFromArrowTable(device, table, {shaderLayout});
-  const detachedBatchBuffer = gpuTable.batches[1].gpuVectors.positions.data[0].buffer;
+  const detachedBatchBuffer = gpuTable.batches[1].gpuData.positions.buffer;
 
   const detachedBatches = gpuTable.detachBatches({first: 1, last: 2});
 
@@ -504,7 +503,7 @@ test('GPUTable detachBatches removes a live batch range and restitches aggregate
   t.end();
 });
 
-test('GPURecordBatch creates GPU vectors from one Arrow record batch', t => {
+test('GPURecordBatch creates GPUData from one Arrow record batch', t => {
   const device = new NullDevice({});
   const recordBatch = makeGpuMetadataTable().batches[0];
   const shaderLayout: ShaderLayout = {
@@ -522,7 +521,7 @@ test('GPURecordBatch creates GPU vectors from one Arrow record batch', t => {
     ['positions'],
     'selects shader-compatible fields'
   );
-  t.ok(gpuRecordBatch.attributes.positions, 'exposes model-ready attributes');
+  t.ok(gpuRecordBatch.gpuData.positions, 'retains batch-local attribute data');
 
   gpuRecordBatch.destroy();
   t.end();
@@ -569,8 +568,8 @@ test('GPUTable creates metadata from existing GPU vectors', t => {
     ],
     'synthesizes buffer layouts for regular vectors'
   );
-  t.equal(gpuTable.attributes.positions, positions.data[0].buffer, 'maps positions attribute');
-  t.equal(gpuTable.attributes.weights, weights.data[0].buffer, 'maps weights attribute');
+  t.equal(gpuTable.batches[0].gpuData.positions.buffer, positions.data[0].buffer);
+  t.equal(gpuTable.batches[0].gpuData.weights.buffer, weights.data[0].buffer);
 
   gpuTable.destroy();
   t.end();
@@ -610,8 +609,8 @@ test('GPUTable creates metadata from interleaved GPU vectors', t => {
     ],
     'uses interleaved buffer layout from vector'
   );
-  t.deepEqual(Object.keys(gpuTable.attributes), ['instances'], 'keeps shared layout buffer');
-  t.equal(gpuTable.attributes.instances, instances.data[0].buffer, 'maps layout to shared buffer');
+  t.deepEqual(Object.keys(gpuTable.batches[0].gpuData), ['instances'], 'keeps shared layout data');
+  t.equal(gpuTable.batches[0].gpuData.instances.buffer, instances.data[0].buffer);
 
   gpuTable.destroy();
   t.end();

--- a/modules/tables/src/engine/gpu-table-model.ts
+++ b/modules/tables/src/engine/gpu-table-model.ts
@@ -173,6 +173,11 @@ export class GPUTableModel extends Model {
       getBufferLayoutNames(nextTable.bufferLayout),
       'buffer layout'
     );
+    assertNoDuplicateNames(
+      Object.keys(this.tableState.explicitBindings),
+      Object.keys(getGPUTableDrawBindings(nextTable, this.tableState.tableBindingNames)),
+      'binding'
+    );
     this.setBufferLayout([...this.tableState.explicitBufferLayout, ...nextTable.bufferLayout]);
     this.setAttributes({
       ...this.tableState.explicitAttributes,
@@ -324,6 +329,11 @@ function getGPUTableModelConstructorState(
     getBufferLayoutNames(explicitBufferLayout),
     getBufferLayoutNames(table.bufferLayout),
     'buffer layout'
+  );
+  assertNoDuplicateNames(
+    Object.keys(explicitBindings),
+    Object.keys(getGPUTableDrawBindings(table, tableBindingNames)),
+    'binding'
   );
   assertNoExplicitIndexBuffer(table, explicitIndexBuffer);
   validateGPUTableIndexBatches(table);

--- a/modules/tables/src/engine/gpu-table-model.ts
+++ b/modules/tables/src/engine/gpu-table-model.ts
@@ -13,6 +13,7 @@ import {DynamicBuffer, Model, type ModelProps} from '@luma.gl/engine';
 import type {GPURecordBatch} from '../table/gpu-record-batch';
 import {GPU_TABLE_INDEX_COLUMN_NAME} from '../table/gpu-schema';
 import {GPUTable} from '../table/gpu-table';
+import {getGPUDataBuffersForLayout} from '../table/gpu-vector-utils';
 
 /** Controls which Model draw count mirrors the current GPU table row count. */
 export type GPUTableModelCount = 'instance' | 'vertex' | 'none';
@@ -33,6 +34,7 @@ export type GPUTableModelDrawBatchesOptions = {
 type GPUTableModelState = {
   explicitAttributes: NonNullable<ModelProps['attributes']>;
   explicitBindings: NonNullable<ModelProps['bindings']>;
+  tableBindingNames: string[];
   explicitBufferLayout: BufferLayout[];
   explicitIndexBuffer: Buffer | DynamicBuffer | null;
   explicitIndexCount: number | undefined;
@@ -131,11 +133,11 @@ export class GPUTableModel extends Model {
         );
         this.setAttributes({
           ...this.tableState.explicitAttributes,
-          ...batch.attributes
+          ...getGPUTableDrawAttributes(batch)
         });
         this.setBindings({
           ...this.tableState.explicitBindings,
-          ...batch.bindings
+          ...getGPUTableDrawBindings(batch, this.tableState.tableBindingNames)
         });
         this.setTableDrawState(batch);
         options.onBatch?.(batch, batchIndex);
@@ -145,11 +147,11 @@ export class GPUTableModel extends Model {
       this.drawingTableBatches = false;
       this.setAttributes({
         ...this.tableState.explicitAttributes,
-        ...table.attributes
+        ...getGPUTableDrawAttributes(table)
       });
       this.setBindings({
         ...this.tableState.explicitBindings,
-        ...table.bindings
+        ...getGPUTableDrawBindings(table, this.tableState.tableBindingNames)
       });
       this.setTableDrawState(table);
     }
@@ -163,7 +165,7 @@ export class GPUTableModel extends Model {
     validateGPUTableIndexBatches(nextTable);
     assertNoDuplicateNames(
       Object.keys(this.tableState.explicitAttributes),
-      Object.keys(nextTable.attributes),
+      getBufferLayoutNames(nextTable.bufferLayout),
       'attribute'
     );
     assertNoDuplicateNames(
@@ -171,20 +173,14 @@ export class GPUTableModel extends Model {
       getBufferLayoutNames(nextTable.bufferLayout),
       'buffer layout'
     );
-    assertNoDuplicateNames(
-      Object.keys(this.tableState.explicitBindings),
-      Object.keys(nextTable.bindings),
-      'binding'
-    );
-
     this.setBufferLayout([...this.tableState.explicitBufferLayout, ...nextTable.bufferLayout]);
     this.setAttributes({
       ...this.tableState.explicitAttributes,
-      ...nextTable.attributes
+      ...getGPUTableDrawAttributes(nextTable)
     });
     this.setBindings({
       ...this.tableState.explicitBindings,
-      ...nextTable.bindings
+      ...getGPUTableDrawBindings(nextTable, this.tableState.tableBindingNames)
     });
     this.setTableDrawState(nextTable);
     this.table = nextTable;
@@ -285,6 +281,9 @@ function getGPUTableModelConstructorState(
   const {table, tableCount = 'instance', ...modelProps} = props;
   const explicitAttributes = modelProps.attributes || {};
   const explicitBindings = modelProps.bindings || {};
+  const tableBindingNames = (modelProps.shaderLayout?.bindings || [])
+    .filter(binding => binding.type === 'storage' || binding.type === 'read-only-storage')
+    .map(binding => binding.name);
   const explicitBufferLayout = modelProps.bufferLayout || [];
   const explicitIndexBuffer = modelProps.indexBuffer ?? null;
   const explicitIndexCount = modelProps.indexCount;
@@ -303,6 +302,7 @@ function getGPUTableModelConstructorState(
       state: {
         explicitAttributes,
         explicitBindings,
+        tableBindingNames,
         explicitBufferLayout,
         explicitIndexBuffer,
         explicitIndexCount,
@@ -317,7 +317,7 @@ function getGPUTableModelConstructorState(
 
   assertNoDuplicateNames(
     Object.keys(explicitAttributes),
-    Object.keys(table.attributes),
+    getBufferLayoutNames(table.bufferLayout),
     'attribute'
   );
   assertNoDuplicateNames(
@@ -325,7 +325,6 @@ function getGPUTableModelConstructorState(
     getBufferLayoutNames(table.bufferLayout),
     'buffer layout'
   );
-  assertNoDuplicateNames(Object.keys(explicitBindings), Object.keys(table.bindings), 'binding');
   assertNoExplicitIndexBuffer(table, explicitIndexBuffer);
   validateGPUTableIndexBatches(table);
 
@@ -334,6 +333,7 @@ function getGPUTableModelConstructorState(
     state: {
       explicitAttributes,
       explicitBindings,
+      tableBindingNames,
       explicitBufferLayout,
       explicitIndexBuffer,
       explicitIndexCount,
@@ -346,12 +346,43 @@ function getGPUTableModelConstructorState(
     modelProps: {
       ...modelProps,
       bufferLayout: [...explicitBufferLayout, ...table.bufferLayout],
-      attributes: {...explicitAttributes, ...table.attributes},
-      bindings: {...explicitBindings, ...table.bindings},
+      attributes: {...explicitAttributes, ...getGPUTableDrawAttributes(table)},
+      bindings: {
+        ...explicitBindings,
+        ...getGPUTableDrawBindings(table, tableBindingNames)
+      },
       ...(inferInstanceCount ? {instanceCount: table.numRows} : {}),
       ...(inferVertexCount ? {vertexCount: table.numRows} : {})
     }
   };
+}
+
+function getGPUTableDrawBindings(
+  source: GPUTableDrawSource,
+  bindingNames: string[]
+): Record<string, Buffer | DynamicBuffer> {
+  const batch = source instanceof GPUTable ? source.batches[0] : source;
+  if (!batch) {
+    return {};
+  }
+  const bindings: Record<string, Buffer | DynamicBuffer> = {};
+  for (const bindingName of bindingNames) {
+    const data = batch.gpuData[bindingName];
+    if (data) {
+      bindings[bindingName] = data.buffer;
+    }
+  }
+  return bindings;
+}
+
+function getGPUTableDrawAttributes(
+  source: GPUTableDrawSource
+): Record<string, Buffer | DynamicBuffer> {
+  const attributeSource = source instanceof GPUTable ? source.batches[0] : source;
+  if (!attributeSource) {
+    return {};
+  }
+  return getGPUDataBuffersForLayout(attributeSource.bufferLayout, attributeSource.gpuData);
 }
 
 function getBufferLayoutNames(bufferLayout: BufferLayout[]): string[] {
@@ -385,7 +416,7 @@ function assertNoExplicitIndexBuffer(
 function validateGPUTableIndexBatches(table: GPUTable): void {
   const tableHasIndices = Boolean(table.gpuVectors[GPU_TABLE_INDEX_COLUMN_NAME]);
   for (const batch of table.batches) {
-    const batchHasIndices = Boolean(batch.gpuVectors[GPU_TABLE_INDEX_COLUMN_NAME]);
+    const batchHasIndices = Boolean(batch.gpuData[GPU_TABLE_INDEX_COLUMN_NAME]);
     if (batchHasIndices !== tableHasIndices) {
       throw new Error('GPUTableModel indexed tables require every batch to include indices');
     }
@@ -394,19 +425,24 @@ function validateGPUTableIndexBatches(table: GPUTable): void {
 }
 
 function getGPUTableIndexDrawState(source: GPUTableDrawSource): GPUTableIndexDrawState | null {
-  const indexVector = source.gpuVectors[GPU_TABLE_INDEX_COLUMN_NAME];
-  if (!indexVector) {
+  const indexData =
+    source instanceof GPUTable
+      ? source.gpuVectors[GPU_TABLE_INDEX_COLUMN_NAME]?.data[0]
+      : source.gpuData[GPU_TABLE_INDEX_COLUMN_NAME];
+  if (!indexData) {
     return null;
   }
   if (source instanceof GPUTable && source.batches.length > 1) {
     return null;
   }
-  if (indexVector.format !== 'vertex-list<uint32>') {
+  if (indexData.format !== 'vertex-list<uint32>') {
     throw new Error('GPUTableModel indices column requires vertex-list<uint32> format');
   }
 
-  const [indexData, ...remainingIndexData] = indexVector.data;
-  if (!indexData || remainingIndexData.length > 0) {
+  if (
+    source instanceof GPUTable &&
+    source.gpuVectors[GPU_TABLE_INDEX_COLUMN_NAME].data.length !== 1
+  ) {
     throw new Error('GPUTableModel indices column requires exactly one GPUData chunk');
   }
   const indexBuffer = indexData.buffer;
@@ -420,7 +456,7 @@ function getGPUTableIndexDrawState(source: GPUTableDrawSource): GPUTableIndexDra
   }
   return {
     indexBuffer,
-    indexCount: indexVector.valueLength,
+    indexCount: indexData.valueLength,
     firstVertex: indexData.byteOffset,
     firstIndex: indexData.byteOffset / indexByteStride
   };

--- a/modules/tables/src/engine/gpu-table-transform.ts
+++ b/modules/tables/src/engine/gpu-table-transform.ts
@@ -8,6 +8,7 @@ import type {GPUData} from '../table/gpu-data';
 import {GPUVector} from '../table/gpu-vector';
 import {GPURecordBatch} from '../table/gpu-record-batch';
 import {GPUTable} from '../table/gpu-table';
+import {getGPUDataBuffersForLayout} from '../table/gpu-vector-utils';
 
 type TableTransformBufferMap = NonNullable<Parameters<BufferTransform['run']>[0]>['outputBuffers'];
 type TableTransformRunOptions = Parameters<BufferTransform['run']>[0];
@@ -142,7 +143,7 @@ export class TableTransform extends BufferTransform {
         );
         this.model.setAttributes({
           ...this.explicitAttributes,
-          ...batch.attributes
+          ...getTableTransformAttributes(batch)
         });
         if (this.inferVertexCount) {
           this.model.setVertexCount(batch.numRows);
@@ -165,7 +166,7 @@ export class TableTransform extends BufferTransform {
     } finally {
       this.model.setAttributes({
         ...this.explicitAttributes,
-        ...this.table.attributes
+        ...getTableTransformAttributes(this.table)
       });
       if (this.inferVertexCount) {
         this.model.setVertexCount(this.table.numRows);
@@ -256,7 +257,7 @@ function getTableTransformState(device: Device, props: TableTransformProps): Tab
   try {
     assertNoDuplicateNames(
       Object.keys(explicitAttributes),
-      Object.keys(table.attributes),
+      getBufferLayoutNames(table.bufferLayout),
       'attribute'
     );
     assertNoDuplicateNames(
@@ -285,11 +286,21 @@ function getTableTransformState(device: Device, props: TableTransformProps): Tab
     transformProps: {
       ...transformProps,
       ...(transformOutputs ? {outputs: transformOutputs} : {}),
-      attributes: {...explicitAttributes, ...table.attributes},
+      attributes: {...explicitAttributes, ...getTableTransformAttributes(table)},
       bufferLayout: [...explicitBufferLayout, ...table.bufferLayout],
       ...(inferVertexCount ? {vertexCount: table.numRows} : {})
     }
   };
+}
+
+function getTableTransformAttributes(
+  source: GPUTable | GPURecordBatch
+): Record<string, Buffer | DynamicBuffer> {
+  const attributeSource = source instanceof GPUTable ? source.batches[0] : source;
+  if (!attributeSource) {
+    return {};
+  }
+  return getGPUDataBuffersForLayout(attributeSource.bufferLayout, attributeSource.gpuData);
 }
 
 function getInitialTable(props: {table?: GPUTable; inputVectors?: TableTransformInputVectors}): {

--- a/modules/tables/src/index.ts
+++ b/modules/tables/src/index.ts
@@ -20,6 +20,8 @@ export {
 export {
   getGPUVectorBuffer,
   getGPUVectorData,
+  getGPUDataBuffersForLayout,
+  getGPUVectorBuffersForLayout,
   getRequiredGPUVector
 } from './table/gpu-vector-utils';
 export {
@@ -47,7 +49,8 @@ export {
 } from './table/gpu-vector-collection';
 export {
   GPURecordBatch,
-  type GPURecordBatchFromVectorsProps,
+  type GPUDataMap,
+  type GPURecordBatchFromDataProps,
   type GPURecordBatchProps,
   type GPURecordBatchSourceInfo
 } from './table/gpu-record-batch';

--- a/modules/tables/src/models/path/path-attribute-model.ts
+++ b/modules/tables/src/models/path/path-attribute-model.ts
@@ -12,6 +12,7 @@ import {
 import {GPUTableModel, type GPUTableModelProps} from '../../engine/gpu-table-model';
 import type {GPUTable} from '../../table/gpu-table';
 import type {GPUVector} from '../../table/gpu-vector';
+import {getGPUDataBuffersForLayout} from '../../table/gpu-vector-utils';
 import {isVertexListGPUVectorFormat, type VertexList} from '../../table/gpu-vector-format';
 import type {GeneratedBufferBatch} from '../../utils/generated-buffer-batches';
 import {
@@ -269,7 +270,9 @@ export class PathAttributeModel extends GPUTableModel {
       for (const [batchIndex, renderBatch] of this.renderBatches.entries()) {
         const tableBatch = tableBatches[batchIndex];
         this.setAttributes({
-          ...(tableBatch?.attributes || {}),
+          ...(tableBatch
+            ? getGPUDataBuffersForLayout(tableBatch.bufferLayout, tableBatch.gpuData)
+            : {}),
           ...getPathAttributeModelBatchAttributes(this.pathShaderLayout, renderBatch)
         });
         this.setInstanceCount(renderBatch.segmentCount);
@@ -277,7 +280,7 @@ export class PathAttributeModel extends GPUTableModel {
       }
     } finally {
       this.setAttributes({
-        ...(this.table?.attributes || {}),
+        ...getPathTableAttributes(this.table),
         ...getPathAttributeModelAttributes(this.pathShaderLayout, {
           expandedPathVertexData: this.expandedPathVertexData,
           pathViewOriginData: this.pathViewOriginData
@@ -297,6 +300,14 @@ export class PathAttributeModel extends GPUTableModel {
       this.ownsPathTable = false;
     }
   }
+}
+
+function getPathTableAttributes(table?: GPUTable): ReturnType<typeof getGPUDataBuffersForLayout> {
+  const firstBatch = table?.batches[0];
+  if (!firstBatch) {
+    return {};
+  }
+  return getGPUDataBuffersForLayout(firstBatch.bufferLayout, firstBatch.gpuData);
 }
 
 function preparePathAttributeModel(props: PathAttributeModelProps): PreparedPathAttributeModel {

--- a/modules/tables/src/models/polygon/polygon-attribute-model.ts
+++ b/modules/tables/src/models/polygon/polygon-attribute-model.ts
@@ -8,7 +8,7 @@ import {GPUTableModel, type GPUTableModelProps} from '../../engine/gpu-table-mod
 import {GPURecordBatch} from '../../table/gpu-record-batch';
 import type {GPUTypeMap} from '../../table/gpu-schema';
 import {GPUTable} from '../../table/gpu-table';
-import type {GPUVector} from '../../table/gpu-vector';
+import {getGPUVectorData} from '../../table/gpu-vector-utils';
 import {
   assertPolygonGPUVectorInputs,
   POLYGON_GPU_INPUT_SCHEMA,
@@ -126,7 +126,9 @@ function createPolygonAttributeRecordBatch(props: PolygonBatchProps): GPURecordB
   const {sourceInfo, nullCount = 0, ...vectors} = props;
   assertPolygonGPUVectorInputs('PolygonAttributeModel', vectors);
   return new GPURecordBatch<GPUTypeMap>({
-    vectors: vectors as Record<string, GPUVector>,
+    gpuData: Object.fromEntries(
+      Object.entries(vectors).map(([name, vector]) => [name, getGPUVectorData(vector)])
+    ),
     bufferLayout: getPolygonAttributeBufferLayout(vectors),
     sourceInfo,
     nullCount

--- a/modules/tables/src/models/polygon/polygon-storage-model.ts
+++ b/modules/tables/src/models/polygon/polygon-storage-model.ts
@@ -104,6 +104,10 @@ function preparePolygonStorageModel(
       ] as never,
       shaderLayout: POLYGON_STORAGE_SHADER_LAYOUT,
       shaderInputs,
+      bindings: {
+        ...(modelProps.bindings || {}),
+        ...getPolygonStorageBindings({positions, colors, rowIndices, indices})
+      },
       table,
       tableCount: 'none',
       topology: 'triangle-list',
@@ -131,9 +135,10 @@ function createPolygonStorageRecordBatch(props: PolygonBatchProps): GPURecordBat
   const {sourceInfo, nullCount = 0, ...vectors} = props;
   assertPolygonGPUVectorInputs('PolygonStorageModel', vectors);
   return new GPURecordBatch<GPUTypeMap>({
-    vectors: vectors as Record<string, GPUVector>,
+    gpuData: Object.fromEntries(
+      Object.entries(vectors).map(([name, vector]) => [name, getGPUVectorData(vector)])
+    ),
     bufferLayout: [],
-    bindings: getPolygonStorageBindings(vectors),
     sourceInfo,
     nullCount
   });

--- a/modules/tables/src/table/gpu-record-batch.ts
+++ b/modules/tables/src/table/gpu-record-batch.ts
@@ -2,14 +2,19 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {type Binding, type Buffer, type BufferLayout} from '@luma.gl/core';
-import type {DynamicBuffer} from '@luma.gl/engine';
+import type {BufferLayout, VertexFormat} from '@luma.gl/core';
+import type {GPUData} from './gpu-data';
 import type {GPUField, GPUSchema, GPUTypeMap} from './gpu-schema';
-import {GPUVector} from './gpu-vector';
-import {createGPUVectorCollection} from './gpu-vector-collection';
+import {isGPUTableIndexColumnName} from './gpu-schema';
+import {
+  getGPUVectorElementFormat,
+  isValueListGPUVectorFormat,
+  isVertexListGPUVectorFormat
+} from './gpu-vector-format';
 
-type GPUVectorMap<T extends GPUTypeMap = GPUTypeMap> = {
-  [Name in keyof T & string]: GPUVector<T[Name]>;
+/** Batch-local GPU data keyed by selected table column name. */
+export type GPUDataMap<T extends GPUTypeMap = GPUTypeMap> = {
+  [Name in keyof T & string]: GPUData<T[Name]>;
 };
 
 /** Generic source-row identity for a GPU record batch. */
@@ -22,15 +27,15 @@ export type GPURecordBatchSourceInfo = {
   sourceRowCount: number;
 };
 
-/** Props for constructing a GPU record batch from existing vectors and metadata. */
-export type GPURecordBatchFromVectorsProps<T extends GPUTypeMap = GPUTypeMap> = {
-  /** GPU vectors keyed by name, or a list of named GPU vectors. */
-  vectors: GPUVectorMap<T> | Record<string, GPUVector> | GPUVector[];
+/** Props for constructing one immutable GPU record batch from GPU data chunks. */
+export type GPURecordBatchFromDataProps<T extends GPUTypeMap = GPUTypeMap> = {
+  /** One batch-local GPU data chunk keyed by selected column name. */
+  gpuData: GPUDataMap<T> | Record<string, GPUData>;
   /** Optional precomputed batch buffer layouts. */
   bufferLayout?: BufferLayout[];
-  /** Optional selected schema fields. Defaults to fields synthesized from vector names and formats. */
+  /** Optional selected schema fields. Defaults to fields synthesized from data names and formats. */
   fields?: GPUField[];
-  /** Explicit row count for intentionally vector-less batches. */
+  /** Explicit row count for intentionally data-less batches. */
   numRows?: number;
   /** Optional batch-level schema metadata. */
   metadata?: Map<string, string>;
@@ -38,15 +43,12 @@ export type GPURecordBatchFromVectorsProps<T extends GPUTypeMap = GPUTypeMap> = 
   sourceInfo?: GPURecordBatchSourceInfo;
   /** Number of null rows in the generated GPU record batch. */
   nullCount?: number;
-  /** Optional model-ready storage bindings keyed by shader binding name. */
-  bindings?: Record<string, Binding | DynamicBuffer>;
 };
 
 /** Generic record-batch construction props. */
-export type GPURecordBatchProps<T extends GPUTypeMap = GPUTypeMap> =
-  GPURecordBatchFromVectorsProps<T>;
+export type GPURecordBatchProps<T extends GPUTypeMap = GPUTypeMap> = GPURecordBatchFromDataProps<T>;
 
-/** GPU memory and schema metadata for one selected record batch. */
+/** Immutable GPU memory and schema metadata for one selected record batch. */
 export class GPURecordBatch<T extends GPUTypeMap = GPUTypeMap> {
   /** GPU-facing schema for the selected columns. */
   schema: GPUSchema<T>;
@@ -58,74 +60,140 @@ export class GPURecordBatch<T extends GPUTypeMap = GPUTypeMap> {
   nullCount: number;
   /** Buffer layout derived by the producing adapter. */
   readonly bufferLayout: BufferLayout[] = [];
-  /** GPU vectors keyed by shader/table column name. */
-  readonly gpuVectors: Record<string, GPUVector> = {};
-  /** Model-ready attribute buffers keyed by buffer layout name. */
-  readonly attributes: Record<string, Buffer | DynamicBuffer> = {};
-  /** Model-ready storage bindings keyed by shader binding name. */
-  readonly bindings: Record<string, Binding | DynamicBuffer> = {};
+  /** One batch-local GPU data chunk keyed by shader/table column name. */
+  readonly gpuData: Record<string, GPUData> = {};
   /** Optional source-row identity retained from the producing table/stream. */
   readonly sourceInfo?: GPURecordBatchSourceInfo;
 
-  /** Creates one GPU record batch from named GPU vectors and optional schema metadata. */
+  /** Creates one immutable GPU record batch from named GPU data chunks. */
   constructor({
-    vectors,
+    gpuData,
     bufferLayout,
     fields,
     numRows,
     metadata,
     sourceInfo,
-    nullCount = 0,
-    bindings = {}
-  }: GPURecordBatchFromVectorsProps<T>) {
-    const vectorCollection = createGPUVectorCollection<T>({
-      ownerName: 'GPURecordBatch',
-      vectors,
-      bufferLayout,
-      fields,
-      numRows
-    });
-
-    this.numRows = vectorCollection.numRows;
+    nullCount = 0
+  }: GPURecordBatchFromDataProps<T>) {
+    this.numRows = getGPUDataCollectionRowCount(gpuData, numRows);
     this.nullCount = nullCount;
-    Object.assign(this.gpuVectors, vectorCollection.gpuVectors);
-    Object.assign(this.attributes, vectorCollection.attributes);
-    Object.assign(this.bindings, bindings);
-    this.bufferLayout.push(...vectorCollection.bufferLayout);
+    Object.assign(this.gpuData, gpuData);
+    this.bufferLayout.push(...getGPUDataCollectionBufferLayout(gpuData, bufferLayout));
+    const resolvedFields = getGPUDataCollectionFields(gpuData, fields, this.bufferLayout);
     this.schema = {
-      fields: vectorCollection.fields,
+      fields: resolvedFields,
       metadata: metadata ?? new Map()
     };
-    this.numCols = vectorCollection.fields.length;
+    this.numCols = resolvedFields.length;
     this.sourceInfo = sourceInfo ? {...sourceInfo} : undefined;
   }
 
-  /** Adds logical row/null counts after an adapter appends into batch-local vectors. */
-  appendRows(numRows: number, nullCount = 0): this {
-    this.numRows += numRows;
-    this.nullCount += nullCount;
-    return this;
-  }
-
-  /** Clears logical row/null counts while retaining vectors and allocations. */
-  resetRows(): this {
-    this.numRows = 0;
-    this.nullCount = 0;
-    return this;
-  }
-
-  /** Clears appendable vector payloads plus batch row/null counts while retaining allocations. */
-  resetLastBatch(): this {
-    for (const gpuVector of Object.values(this.gpuVectors)) {
-      gpuVector.resetLastBatch();
-    }
-    return this.resetRows();
-  }
-
-  /** Destroys every owned GPU vector retained by this batch. */
+  /** Destroys every owned GPU data chunk retained by this batch. */
   destroy(): void {
-    for (const gpuVector of Object.values(this.gpuVectors)) {
-      gpuVector.destroy();
+    for (const data of Object.values(this.gpuData)) {
+      data.destroy();
     }
   }
+}
+
+function getGPUDataCollectionRowCount(
+  gpuData: Record<string, GPUData>,
+  explicitNumRows?: number
+): number {
+  const firstData = Object.values(gpuData)[0];
+  if (!firstData) {
+    return explicitNumRows ?? 0;
+  }
+
+  const numRows = explicitNumRows ?? firstData.length;
+  const mismatchedData = Object.values(gpuData).find(data => data.length !== numRows);
+  if (mismatchedData) {
+    throw new Error('GPURecordBatch requires matching GPUData row counts');
+  }
+  return numRows;
+}
+
+function getGPUDataCollectionBufferLayout(
+  gpuData: Record<string, GPUData>,
+  explicitBufferLayout?: BufferLayout[]
+): BufferLayout[] {
+  if (explicitBufferLayout) {
+    for (const layout of explicitBufferLayout) {
+      if (isGPUTableIndexColumnName(layout.name)) {
+        throw new Error(
+          `GPURecordBatch buffer layout cannot include reserved index column "${layout.name}"`
+        );
+      }
+      if (!gpuData[layout.name]) {
+        throw new Error(`GPURecordBatch buffer layout references missing GPUData "${layout.name}"`);
+      }
+    }
+    return explicitBufferLayout;
+  }
+
+  return Object.entries(gpuData).flatMap(([name, data]) =>
+    isGPUTableIndexColumnName(name) ? [] : synthesizeGPUDataBufferLayout(name, data)
+  );
+}
+
+function synthesizeGPUDataBufferLayout(name: string, data: GPUData): BufferLayout[] {
+  if (!data.format) {
+    throw new Error(
+      `GPURecordBatch cannot synthesize a buffer layout for GPUData "${name}" without a format`
+    );
+  }
+  if (isVertexListGPUVectorFormat(data.format)) {
+    throw new Error(
+      `GPURecordBatch cannot synthesize a generic buffer layout for vertex-list GPUData "${name}"`
+    );
+  }
+  if (isValueListGPUVectorFormat(data.format)) {
+    throw new Error(
+      `GPURecordBatch cannot synthesize a generic buffer layout for value-list GPUData "${name}"`
+    );
+  }
+  return [
+    {
+      name,
+      byteStride: data.byteStride,
+      format: getGPUVectorElementFormat(data.format) as VertexFormat
+    }
+  ];
+}
+
+function getGPUDataCollectionFields(
+  gpuData: Record<string, GPUData>,
+  explicitFields: GPUField[] | undefined,
+  bufferLayout: BufferLayout[]
+): GPUField[] {
+  if (explicitFields) {
+    for (const field of explicitFields) {
+      if (!gpuData[field.name]) {
+        throw new Error(`GPURecordBatch schema references missing GPUData "${field.name}"`);
+      }
+    }
+    return explicitFields;
+  }
+
+  const layoutNames = new Set(bufferLayout.map(layout => layout.name));
+  return Object.entries(gpuData).map(([name, data]) => {
+    if (!data.format) {
+      if (layoutNames.has(name)) {
+        return {
+          name,
+          nullable: false,
+          metadata: new Map()
+        };
+      }
+      throw new Error(
+        `GPURecordBatch cannot synthesize a schema field for GPUData "${name}" without a format`
+      );
+    }
+    return {
+      name,
+      format: data.format,
+      nullable: false,
+      metadata: new Map()
+    };
+  });
 }

--- a/modules/tables/src/table/gpu-table.ts
+++ b/modules/tables/src/table/gpu-table.ts
@@ -10,6 +10,7 @@ import {GPUVector} from './gpu-vector';
 import {GPURecordBatch, type GPURecordBatchSourceInfo} from './gpu-record-batch';
 import {createGPUVectorCollection} from './gpu-vector-collection';
 import {GPU_TABLE_INDEX_COLUMN_NAME} from './gpu-schema';
+import {isValueListGPUVectorFormat, isVertexListGPUVectorFormat} from './gpu-vector-format';
 
 type GPUVectorMap<T extends GPUTypeMap = GPUTypeMap> = {
   [Name in keyof T & string]: GPUVector<T[Name]>;
@@ -391,6 +392,17 @@ function createPackedGPURecordBatch(
     const firstData = sourceData[0];
     if (!firstData) {
       throw new Error(`GPUTable batch is missing GPUData "${columnName}"`);
+    }
+    if (
+      sourceData.some(
+        data =>
+          data.format &&
+          (isValueListGPUVectorFormat(data.format) || isVertexListGPUVectorFormat(data.format))
+      )
+    ) {
+      throw new Error(
+        `GPUTable.packBatches() does not support variable-length GPUData "${columnName}"`
+      );
     }
 
     const byteLength = sourceData.reduce(

--- a/modules/tables/src/table/gpu-table.ts
+++ b/modules/tables/src/table/gpu-table.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, type Binding, type BufferLayout} from '@luma.gl/core';
+import {Buffer, type BufferLayout} from '@luma.gl/core';
 import {DynamicBuffer} from '@luma.gl/engine';
 import type {GPUField, GPUSchema, GPUTypeMap} from './gpu-schema';
-import type {GPUData} from './gpu-data';
+import {GPUData} from './gpu-data';
 import {GPUVector} from './gpu-vector';
 import {GPURecordBatch, type GPURecordBatchSourceInfo} from './gpu-record-batch';
 import {createGPUVectorCollection} from './gpu-vector-collection';
@@ -19,8 +19,6 @@ type GPUVectorMap<T extends GPUTypeMap = GPUTypeMap> = {
 export type GPUTableFromVectorsProps<T extends GPUTypeMap = GPUTypeMap> = {
   /** GPU vectors keyed by name, or a list of named GPU vectors. */
   vectors: GPUVectorMap<T> | Record<string, GPUVector> | GPUVector[];
-  /** Optional model-ready storage bindings keyed by shader binding name. */
-  bindings?: Record<string, Binding | DynamicBuffer>;
   /** Optional table-level schema metadata. */
   metadata?: Map<string, string>;
   /** Optional source-row identity forwarded to the generated one-batch GPU table. */
@@ -72,16 +70,13 @@ export class GPUTable<T extends GPUTypeMap = GPUTypeMap> {
   numCols: number;
   /** Number of null rows retained in table metadata. */
   nullCount: number;
-  /** Buffer layout shared by preserved record batches. */
-  readonly bufferLayout: BufferLayout[] = [];
   /** GPU vectors keyed by table/shader column name. */
   readonly gpuVectors: Record<string, GPUVector> = {};
-  /** Model-ready attribute buffers keyed by buffer layout name. */
-  readonly attributes: Record<string, Buffer | DynamicBuffer> = {};
-  /** Model-ready storage bindings keyed by shader binding name. */
-  readonly bindings: Record<string, Binding | DynamicBuffer> = {};
   /** Preserved batch-local GPU storage. */
   readonly batches: GPURecordBatch[] = [];
+
+  /** Buffer layout shared by preserved record batches. */
+  readonly bufferLayout: BufferLayout[] = [];
 
   /** Creates one logical GPU table from vectors or already-preserved GPU record batches. */
   constructor(props: GPUTableProps<T>) {
@@ -99,16 +94,15 @@ export class GPUTable<T extends GPUTypeMap = GPUTypeMap> {
       return;
     }
 
-    const {vectors, bindings = {}, metadata, sourceInfo, nullCount = 0} = props;
+    const {vectors, metadata, sourceInfo, nullCount = 0} = props;
     const vectorCollection = createGPUVectorCollection<T>({
       ownerName: 'GPUTable',
       vectors
     });
     const batch: GPURecordBatch = new GPURecordBatch<GPUTypeMap>({
-      vectors: vectorCollection.gpuVectors as GPUVectorMap<T>,
+      gpuData: getSingleGPUVectorDataMap(vectorCollection.gpuVectors as GPUVectorMap<T>),
       bufferLayout: vectorCollection.bufferLayout,
       fields: vectorCollection.fields,
-      bindings,
       metadata,
       sourceInfo,
       nullCount
@@ -131,7 +125,7 @@ export class GPUTable<T extends GPUTypeMap = GPUTypeMap> {
     if (this.batches.length <= 1) {
       return this;
     }
-    if (this.batches.some(batch => batch.gpuVectors[GPU_TABLE_INDEX_COLUMN_NAME])) {
+    if (this.batches.some(batch => batch.gpuData[GPU_TABLE_INDEX_COLUMN_NAME])) {
       throw new Error('GPUTable.packBatches() does not support indexed tables');
     }
 
@@ -179,27 +173,17 @@ export class GPUTable<T extends GPUTypeMap = GPUTypeMap> {
     return this;
   }
 
-  /** Clears only the trailing appendable GPU batch while retaining its allocations. */
-  resetLastBatch(): this {
-    const lastBatch = this.batches[this.batches.length - 1];
-    if (!lastBatch) {
-      throw new Error('GPUTable.resetLastBatch() requires an existing trailing batch');
-    }
-    lastBatch.resetLastBatch();
-    return this.refreshFromBatches();
-  }
-
-  /** Keeps only the requested columns and destroys the dropped batch-local vectors. */
+  /** Keeps only the requested columns and destroys the dropped batch-local data. */
   select(...columnNames: string[]): this {
     const selectedColumnNames = normalizeSelectedColumnNames(this, columnNames);
     const selectedColumnSet = new Set(selectedColumnNames);
 
     for (const batch of this.batches) {
-      const droppedVectors = Object.entries(batch.gpuVectors)
+      const droppedData = Object.entries(batch.gpuData)
         .filter(([name]) => !selectedColumnSet.has(name))
-        .map(([, vector]) => vector);
-      for (const vector of droppedVectors) {
-        vector.destroy();
+        .map(([, data]) => data);
+      for (const data of droppedData) {
+        data.destroy();
       }
       rebuildGPURecordBatchColumns(batch, selectedColumnNames);
     }
@@ -209,36 +193,26 @@ export class GPUTable<T extends GPUTypeMap = GPUTypeMap> {
     return this;
   }
 
-  /** Removes one column and returns an aggregate GPU vector that owns detached batch vectors. */
+  /** Removes one column and returns an aggregate GPU vector that owns detached batch data. */
   detachVector(columnName: string): GPUVector {
     assertGPUTableColumn(this, columnName);
-    const detachedVectors = this.batches.map(batch => batch.gpuVectors[columnName]);
-    const firstVector = detachedVectors[0];
-    if (!firstVector) {
+    const detachedData = this.batches.map(batch => batch.gpuData[columnName]);
+    const firstData = detachedData[0];
+    if (!firstData) {
       throw new Error(`GPUTable.detachVector() column "${columnName}" has no GPU data`);
     }
-    if (!firstVector.format) {
-      throw new Error(`GPUTable.detachVector() column "${columnName}" has no GPUVector format`);
-    }
-
     const detachedVector = new GPUVector({
       type: 'data',
       name: columnName,
-      dataType: firstVector.dataType,
-      format: firstVector.format,
-      data: [...firstVector.data],
-      stride: firstVector.stride,
-      byteStride: firstVector.byteStride,
-      rowByteLength: firstVector.rowByteLength,
-      bufferLayout: firstVector.bufferLayout
+      dataType: firstData.dataType,
+      format: firstData.format,
+      data: detachedData,
+      stride: firstData.stride,
+      byteStride: firstData.byteStride,
+      rowByteLength: firstData.rowByteLength,
+      bufferLayout: getColumnBufferLayout(this.bufferLayout, columnName),
+      ownsData: true
     });
-    for (const batchVector of detachedVectors.slice(1)) {
-      for (const data of batchVector.data) {
-        detachedVector.addData(data);
-      }
-    }
-    detachedVector.retainOwnedVectors(detachedVectors);
-
     const remainingColumnNames = this.schema.fields
       .map(field => field.name)
       .filter(name => name !== columnName);
@@ -283,54 +257,18 @@ export class GPUTable<T extends GPUTypeMap = GPUTypeMap> {
     for (const name of Object.keys(this.gpuVectors)) {
       delete this.gpuVectors[name];
     }
-    for (const name of Object.keys(this.attributes)) {
-      delete this.attributes[name];
-    }
-    for (const name of Object.keys(this.bindings)) {
-      delete this.bindings[name];
-    }
-
     const firstBatch = this.batches[0];
     if (!firstBatch) {
       return;
     }
-    if (this.batches.length === 1) {
-      Object.assign(this.gpuVectors, firstBatch.gpuVectors);
-      Object.assign(this.attributes, firstBatch.attributes);
-      Object.assign(this.bindings, firstBatch.bindings);
-      return;
+    for (const columnName of Object.keys(firstBatch.gpuData)) {
+      const batchData = getBatchColumnData(this.batches, columnName);
+      this.gpuVectors[columnName] = createAggregateGPUVector(
+        columnName,
+        batchData,
+        getColumnBufferLayout(this.bufferLayout, columnName)
+      );
     }
-
-    for (const vectorName of Object.keys(firstBatch.gpuVectors)) {
-      const batchVectors = this.batches.map(batch => batch.gpuVectors[vectorName]);
-      const firstVector = batchVectors[0];
-      if (!firstVector) {
-        throw new Error(`GPUTable batch is missing GPU vector "${vectorName}"`);
-      }
-      if (!firstVector.format) {
-        throw new Error(`GPUTable aggregate vector "${vectorName}" has no GPUVector format`);
-      }
-      const aggregateVector = new GPUVector({
-        type: 'data',
-        name: vectorName,
-        dataType: firstVector.dataType,
-        format: firstVector.format,
-        data: [...firstVector.data],
-        stride: firstVector.stride,
-        byteStride: firstVector.byteStride,
-        rowByteLength: firstVector.rowByteLength,
-        bufferLayout: firstVector.bufferLayout
-      });
-      for (const batchVector of batchVectors.slice(1)) {
-        for (const data of batchVector.data) {
-          aggregateVector.addData(data);
-        }
-      }
-      this.gpuVectors[vectorName] = aggregateVector;
-    }
-
-    Object.assign(this.attributes, firstBatch.attributes);
-    Object.assign(this.bindings, firstBatch.bindings);
   }
 
   private trySynchronizeAggregateVectors(): boolean {
@@ -339,76 +277,75 @@ export class GPUTable<T extends GPUTypeMap = GPUTypeMap> {
       return false;
     }
 
-    for (const vectorName of Object.keys(firstBatch.gpuVectors)) {
-      const aggregateVector = this.gpuVectors[vectorName];
-      const batchVectors = this.batches.map(batch => batch.gpuVectors[vectorName]);
-      if (
-        !aggregateVector ||
-        isBatchLocalAggregateVector(aggregateVector, vectorName, this.batches) ||
-        !canSynchronizeAggregateVector(aggregateVector, batchVectors)
-      ) {
+    for (const columnName of Object.keys(firstBatch.gpuData)) {
+      const aggregateVector = this.gpuVectors[columnName];
+      const batchData = getBatchColumnData(this.batches, columnName);
+      if (!aggregateVector || !canSynchronizeAggregateVector(aggregateVector, batchData)) {
         return false;
       }
     }
 
-    for (const vectorName of Object.keys(firstBatch.gpuVectors)) {
-      const aggregateVector = this.gpuVectors[vectorName];
-      const batchData = getBatchVectorData(this.batches.map(batch => batch.gpuVectors[vectorName]));
+    for (const columnName of Object.keys(firstBatch.gpuData)) {
+      const aggregateVector = this.gpuVectors[columnName];
+      const batchData = getBatchColumnData(this.batches, columnName);
       for (const data of batchData.slice(aggregateVector.data.length)) {
         aggregateVector.addData(data);
       }
     }
 
-    for (const name of Object.keys(this.attributes)) {
-      delete this.attributes[name];
-    }
-    for (const name of Object.keys(this.bindings)) {
-      delete this.bindings[name];
-    }
-    Object.assign(this.attributes, firstBatch.attributes);
-    Object.assign(this.bindings, firstBatch.bindings);
     return true;
   }
 }
 
-function isBatchLocalAggregateVector(
-  aggregateVector: GPUVector,
-  vectorName: string,
-  batches: GPURecordBatch[]
-): boolean {
-  return batches.some(batch => batch.gpuVectors[vectorName] === aggregateVector);
-}
-
-function canSynchronizeAggregateVector(
-  aggregateVector: GPUVector,
-  batchVectors: Array<GPUVector | undefined>
-): batchVectors is GPUVector[] {
-  const firstVector = batchVectors[0];
-  if (!firstVector) {
+function canSynchronizeAggregateVector(aggregateVector: GPUVector, batchData: GPUData[]): boolean {
+  const firstData = batchData[0];
+  if (!firstData) {
     return false;
   }
   if (
-    aggregateVector.format !== firstVector.format ||
-    aggregateVector.stride !== firstVector.stride ||
-    aggregateVector.byteStride !== firstVector.byteStride ||
-    aggregateVector.rowByteLength !== firstVector.rowByteLength ||
-    aggregateVector.bufferLayout !== firstVector.bufferLayout
+    aggregateVector.format !== firstData.format ||
+    aggregateVector.stride !== firstData.stride ||
+    aggregateVector.byteStride !== firstData.byteStride ||
+    aggregateVector.rowByteLength !== firstData.rowByteLength
   ) {
     return false;
   }
-  if (batchVectors.some(vector => !vector)) {
-    return false;
-  }
-
-  const batchData = getBatchVectorData(batchVectors as GPUVector[]);
   if (aggregateVector.data.length > batchData.length) {
     return false;
   }
   return aggregateVector.data.every((data, index) => data === batchData[index]);
 }
 
-function getBatchVectorData(batchVectors: GPUVector[]): GPUData[] {
-  return batchVectors.flatMap(vector => vector.data);
+function getBatchColumnData(batches: GPURecordBatch[], columnName: string): GPUData[] {
+  return batches.map(batch => {
+    const data = batch.gpuData[columnName];
+    if (!data) {
+      throw new Error(`GPUTable batch is missing GPUData "${columnName}"`);
+    }
+    return data;
+  });
+}
+
+function createAggregateGPUVector(
+  columnName: string,
+  data: GPUData[],
+  bufferLayout?: BufferLayout
+): GPUVector {
+  const firstData = data[0];
+  if (!firstData) {
+    throw new Error(`GPUTable aggregate vector "${columnName}" requires GPUData`);
+  }
+  return new GPUVector({
+    type: 'data',
+    name: columnName,
+    dataType: firstData.dataType,
+    format: firstData.format,
+    data,
+    stride: firstData.stride,
+    byteStride: firstData.byteStride,
+    rowByteLength: firstData.rowByteLength,
+    bufferLayout
+  });
 }
 
 function createGPUPackGroups(batches: GPURecordBatch[], minBatchSize?: number): GPURecordBatch[][] {
@@ -447,17 +384,17 @@ function createPackedGPURecordBatch(
   const firstBatch = batchGroup[0];
   const device = getGPURecordBatchDevice(firstBatch);
   const commandEncoder = device.createCommandEncoder();
-  const packedVectors: Record<string, GPUVector> = {};
+  const packedData: Record<string, GPUData> = {};
 
-  for (const layout of bufferLayout) {
-    const sourceVectors = batchGroup.map(batch => batch.gpuVectors[layout.name]);
-    const firstVector = sourceVectors[0];
-    if (!firstVector) {
-      throw new Error(`GPUTable batch is missing GPU vector "${layout.name}"`);
+  for (const columnName of Object.keys(firstBatch.gpuData)) {
+    const sourceData = batchGroup.map(batch => batch.gpuData[columnName]);
+    const firstData = sourceData[0];
+    if (!firstData) {
+      throw new Error(`GPUTable batch is missing GPUData "${columnName}"`);
     }
 
-    const byteLength = sourceVectors.reduce(
-      (totalByteLength, vector) => totalByteLength + getGPUVectorPackedByteLength(vector),
+    const byteLength = sourceData.reduce(
+      (totalByteLength, data) => totalByteLength + data.length * data.byteStride,
       0
     );
     const buffer = device.createBuffer({
@@ -465,52 +402,37 @@ function createPackedGPURecordBatch(
       byteLength
     });
     let destinationOffset = 0;
-    for (const vector of sourceVectors) {
-      for (const data of vector.data) {
-        const copyByteLength = getGPUDataCopyByteLength(data);
-        if (copyByteLength === 0) {
-          continue;
-        }
-        commandEncoder.copyBufferToBuffer({
-          sourceBuffer: getGPUDataConcreteBuffer(data),
-          sourceOffset: data.byteOffset,
-          destinationBuffer: buffer,
-          destinationOffset,
-          size: copyByteLength
-        });
-        destinationOffset += data.length * data.byteStride;
+    for (const data of sourceData) {
+      const copyByteLength = getGPUDataCopyByteLength(data);
+      if (copyByteLength === 0) {
+        continue;
       }
+      commandEncoder.copyBufferToBuffer({
+        sourceBuffer: getGPUDataConcreteBuffer(data),
+        sourceOffset: data.byteOffset,
+        destinationBuffer: buffer,
+        destinationOffset,
+        size: copyByteLength
+      });
+      destinationOffset += data.length * data.byteStride;
     }
 
-    packedVectors[layout.name] = firstVector.bufferLayout
-      ? new GPUVector({
-          type: 'interleaved',
-          name: firstVector.name,
-          buffer,
-          dataType: firstVector.dataType,
-          format: firstVector.format,
-          length: sourceVectors.reduce((length, vector) => length + vector.length, 0),
-          byteStride: firstVector.byteStride,
-          attributes: firstVector.bufferLayout.attributes ?? [],
-          ownsBuffer: true
-        })
-      : new GPUVector({
-          type: 'buffer',
-          name: firstVector.name,
-          buffer,
-          dataType: firstVector.dataType,
-          format: requireGPUVectorFormat(firstVector),
-          length: sourceVectors.reduce((length, vector) => length + vector.length, 0),
-          stride: firstVector.stride,
-          byteStride: firstVector.byteStride,
-          rowByteLength: firstVector.rowByteLength,
-          ownsBuffer: true
-        });
+    packedData[columnName] = new GPUData({
+      buffer,
+      dataType: firstData.dataType,
+      format: firstData.format,
+      length: sourceData.reduce((length, data) => length + data.length, 0),
+      valueLength: sourceData.reduce((length, data) => length + data.valueLength, 0),
+      stride: firstData.stride,
+      byteStride: firstData.byteStride,
+      rowByteLength: firstData.rowByteLength,
+      ownsBuffer: true
+    });
   }
 
   device.submit(commandEncoder.finish());
   return new GPURecordBatch({
-    vectors: packedVectors,
+    gpuData: packedData,
     bufferLayout,
     fields: schema.fields,
     metadata: new Map(schema.metadata),
@@ -550,16 +472,11 @@ function getPackedGPURecordBatchSourceInfo(
 }
 
 function getGPURecordBatchDevice<T extends GPUTypeMap>(batch: GPURecordBatch<T>) {
-  const firstVector = Object.values(batch.gpuVectors)[0];
-  const firstData = firstVector?.data[0];
+  const firstData = Object.values(batch.gpuData)[0];
   if (!firstData) {
     throw new Error('GPUTable cannot pack an empty GPU record batch');
   }
   return firstData.buffer.device;
-}
-
-function getGPUVectorPackedByteLength(vector: GPUVector): number {
-  return vector.data.reduce((byteLength, data) => byteLength + data.length * data.byteStride, 0);
 }
 
 function getGPUDataCopyByteLength(data: GPUData): number {
@@ -571,13 +488,6 @@ function getGPUDataCopyByteLength(data: GPUData): number {
 
 function getGPUDataConcreteBuffer(data: GPUData): Buffer {
   return data.buffer instanceof DynamicBuffer ? data.buffer.buffer : data.buffer;
-}
-
-function requireGPUVectorFormat(vector: GPUVector) {
-  if (!vector.format) {
-    throw new Error(`GPUVector "${vector.name}" requires a format`);
-  }
-  return vector.format;
 }
 
 function assertCompatibleGPURecordBatch<T extends GPUTypeMap>(
@@ -668,30 +578,11 @@ function rebuildGPURecordBatchColumns<T extends GPUTypeMap>(
     .map(columnName => batch.schema.fields.find(field => field.name === columnName))
     .filter((field): field is GPUField => Boolean(field));
 
-  for (const name of Object.keys(batch.gpuVectors)) {
+  for (const name of Object.keys(batch.gpuData)) {
     if (!selectedColumnSet.has(name)) {
-      delete batch.gpuVectors[name];
+      delete batch.gpuData[name];
     }
   }
-  for (const name of Object.keys(batch.bindings)) {
-    if (!selectedColumnSet.has(name)) {
-      delete batch.bindings[name];
-    }
-  }
-  for (const name of Object.keys(batch.attributes)) {
-    delete batch.attributes[name];
-  }
-  for (const layout of selectedLayouts) {
-    const vector = batch.gpuVectors[layout.name];
-    if (!vector) {
-      throw new Error(`GPURecordBatch column "${layout.name}" has no GPU vector`);
-    }
-    if (vector.data.length === 0) {
-      continue;
-    }
-    batch.attributes[layout.name] = getSingleGPUVectorDataBuffer(vector, layout.name);
-  }
-
   batch.bufferLayout.splice(0, batch.bufferLayout.length, ...selectedLayouts);
   batch.schema = {
     fields: selectedFields,
@@ -700,15 +591,23 @@ function rebuildGPURecordBatchColumns<T extends GPUTypeMap>(
   batch.numCols = selectedFields.length;
 }
 
-function getSingleGPUVectorDataBuffer(
-  vector: GPUVector,
-  attributeName: string
-): Buffer | DynamicBuffer {
-  const [data, ...remainingData] = vector.data;
-  if (!data || remainingData.length > 0) {
-    throw new Error(
-      `GPURecordBatch attribute "${attributeName}" requires exactly one GPUData chunk`
-    );
+function getSingleGPUVectorDataMap(gpuVectors: Record<string, GPUVector>): Record<string, GPUData> {
+  const gpuData: Record<string, GPUData> = {};
+  for (const [columnName, vector] of Object.entries(gpuVectors)) {
+    const [data, ...remainingData] = vector.data;
+    if (!data || remainingData.length > 0) {
+      throw new Error(
+        `GPUTable vectors constructor requires exactly one GPUData chunk for "${columnName}"`
+      );
+    }
+    gpuData[columnName] = data;
   }
-  return data.buffer;
+  return gpuData;
+}
+
+function getColumnBufferLayout(
+  bufferLayout: BufferLayout[],
+  columnName: string
+): BufferLayout | undefined {
+  return bufferLayout.find(layout => layout.name === columnName);
 }

--- a/modules/tables/src/table/gpu-table.ts
+++ b/modules/tables/src/table/gpu-table.ts
@@ -609,5 +609,6 @@ function getColumnBufferLayout(
   bufferLayout: BufferLayout[],
   columnName: string
 ): BufferLayout | undefined {
-  return bufferLayout.find(layout => layout.name === columnName);
+  const layout = bufferLayout.find(candidateLayout => candidateLayout.name === columnName);
+  return layout?.attributes ? layout : undefined;
 }

--- a/modules/tables/src/table/gpu-vector-collection.ts
+++ b/modules/tables/src/table/gpu-vector-collection.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, type BufferLayout, type VertexFormat} from '@luma.gl/core';
-import type {DynamicBuffer} from '@luma.gl/engine';
+import type {BufferLayout, VertexFormat} from '@luma.gl/core';
 import type {GPUField, GPUTypeMap} from './gpu-schema';
 import {GPUVector} from './gpu-vector';
 import {
@@ -17,10 +16,10 @@ type GPUVectorMap<T extends GPUTypeMap = GPUTypeMap> = {
   [Name in keyof T & string]: GPUVector<T[Name]>;
 };
 
-/** Options for normalizing named GPU vectors into table/batch columns. */
+/** Options for normalizing named GPU vectors into table columns. */
 export type GPUVectorCollectionProps<T extends GPUTypeMap = GPUTypeMap> = {
   /** Name of the owning structure, used in errors. */
-  ownerName: 'GPUTable' | 'GPURecordBatch';
+  ownerName: 'GPUTable';
   /** GPU vectors keyed by name, or a list of already-named GPU vectors. */
   vectors: GPUVectorMap<T> | Record<string, GPUVector> | GPUVector[];
   /** Optional precomputed buffer layouts. */
@@ -31,12 +30,10 @@ export type GPUVectorCollectionProps<T extends GPUTypeMap = GPUTypeMap> = {
   numRows?: number;
 };
 
-/** Normalized GPU vector collection metadata shared by GPUTable and GPURecordBatch. */
+/** Normalized GPU vector collection metadata used by GPUTable vector construction. */
 export type GPUVectorCollection<T extends GPUTypeMap = GPUTypeMap> = {
   /** GPU vectors keyed by shader/table column name. */
   gpuVectors: GPUVectorMap<T> | Record<string, GPUVector>;
-  /** Model-ready attribute buffers keyed by buffer layout name. */
-  attributes: Record<string, Buffer | DynamicBuffer>;
   /** Buffer layouts for fixed vectors. */
   bufferLayout: BufferLayout[];
   /** Schema fields for selected vectors. */
@@ -53,11 +50,9 @@ export function createGPUVectorCollection<T extends GPUTypeMap = GPUTypeMap>(
   const numRows = getGPUVectorCollectionRowCount(gpuVectors, props.numRows);
   const bufferLayout = getGPUVectorCollectionBufferLayout(props, gpuVectors);
   const fields = getGPUVectorCollectionFields(props, gpuVectors);
-  const attributes = getGPUVectorCollectionAttributes(bufferLayout, gpuVectors);
 
   return {
     gpuVectors: gpuVectors as GPUVectorMap<T>,
-    attributes,
     bufferLayout,
     fields,
     numRows
@@ -180,33 +175,4 @@ function getGPUVectorCollectionFields<T extends GPUTypeMap>(
       metadata: new Map()
     };
   });
-}
-
-function getGPUVectorCollectionAttributes(
-  bufferLayout: BufferLayout[],
-  gpuVectors: Record<string, GPUVector>
-): Record<string, Buffer | DynamicBuffer> {
-  const attributes: Record<string, Buffer | DynamicBuffer> = {};
-  for (const layout of bufferLayout) {
-    const vector = gpuVectors[layout.name];
-    if (!vector) {
-      throw new Error(`Buffer layout references missing GPU vector "${layout.name}"`);
-    }
-    if (vector.data.length === 0) {
-      continue;
-    }
-    attributes[layout.name] = getSingleGPUVectorDataBuffer(vector, layout.name);
-  }
-  return attributes;
-}
-
-function getSingleGPUVectorDataBuffer(
-  vector: GPUVector,
-  attributeName: string
-): Buffer | DynamicBuffer {
-  const [data, ...remainingData] = vector.data;
-  if (!data || remainingData.length > 0) {
-    throw new Error(`Attribute "${attributeName}" requires exactly one GPUData chunk`);
-  }
-  return data.buffer;
 }

--- a/modules/tables/src/table/gpu-vector-utils.ts
+++ b/modules/tables/src/table/gpu-vector-utils.ts
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Buffer} from '@luma.gl/core';
+import type {Buffer, BufferLayout} from '@luma.gl/core';
 import type {DynamicBuffer} from '@luma.gl/engine';
 import type {GPUData} from './gpu-data';
-import type {GPURecordBatch} from './gpu-record-batch';
 import type {GPUTable} from './gpu-table';
 import type {GPUVector} from './gpu-vector';
 
@@ -23,13 +22,48 @@ export function getGPUVectorBuffer(vector: GPUVector): Buffer | DynamicBuffer {
   return getGPUVectorData(vector).buffer;
 }
 
-/** Returns a required GPU vector from a table or record batch by column name. */
+/** Derives model-ready attribute buffers from layout metadata and GPU vector storage. */
+export function getGPUVectorBuffersForLayout(
+  bufferLayout: BufferLayout[],
+  gpuVectors: Record<string, GPUVector>
+): Record<string, Buffer | DynamicBuffer> {
+  const buffers: Record<string, Buffer | DynamicBuffer> = {};
+  for (const layout of bufferLayout) {
+    const vector = gpuVectors[layout.name];
+    if (!vector) {
+      throw new Error(`Buffer layout references missing GPU vector "${layout.name}"`);
+    }
+    if (vector.data.length === 0) {
+      continue;
+    }
+    buffers[layout.name] = getGPUVectorBuffer(vector);
+  }
+  return buffers;
+}
+
+/** Derives model-ready attribute buffers from layout metadata and batch-local GPU data. */
+export function getGPUDataBuffersForLayout(
+  bufferLayout: BufferLayout[],
+  gpuData: Record<string, GPUData>
+): Record<string, Buffer | DynamicBuffer> {
+  const buffers: Record<string, Buffer | DynamicBuffer> = {};
+  for (const layout of bufferLayout) {
+    const data = gpuData[layout.name];
+    if (!data) {
+      throw new Error(`Buffer layout references missing GPUData "${layout.name}"`);
+    }
+    buffers[layout.name] = data.buffer;
+  }
+  return buffers;
+}
+
+/** Returns a required GPU vector from a table by column name. */
 export function getRequiredGPUVector(
-  tableOrBatch: GPUTable | GPURecordBatch,
+  table: GPUTable,
   columnName: string,
   ownerName = 'GPU table'
 ): GPUVector {
-  const vector = tableOrBatch.gpuVectors[columnName];
+  const vector = table.gpuVectors[columnName];
   if (!vector) {
     throw new Error(`${ownerName} is missing GPU vector "${columnName}"`);
   }

--- a/modules/tables/src/table/gpu-vector.ts
+++ b/modules/tables/src/table/gpu-vector.ts
@@ -250,21 +250,27 @@ export class GPUVector<T extends GPUVectorFormat = GPUVectorFormat> {
       }
 
       case 'data': {
+        const format = props.format ?? getFirstGPUVectorDataFormat(props.data);
+        const formatInfo = format ? getGPUVectorFormatInfo(format) : undefined;
         const {
           name,
-          format = getFirstGPUVectorDataFormat(props.data),
           data,
-          stride = data[0]?.stride ?? getGPUVectorFormatInfo(format).components,
+          stride = data[0]?.stride ?? formatInfo?.components ?? 1,
           valueLength = data.reduce(
             (totalValueLength, chunk) => totalValueLength + chunk.valueLength,
             0
           ),
-          byteStride = data[0]?.byteStride ?? getGPUVectorFormatInfo(format).byteLength,
-          rowByteLength = data[0]?.rowByteLength ?? getGPUVectorFormatInfo(format).byteLength,
+          byteStride = data[0]?.byteStride ?? formatInfo?.byteLength,
+          rowByteLength = data[0]?.rowByteLength ?? formatInfo?.byteLength,
           bufferLayout,
           ownsData = false
         } = props;
-        validateGPUVectorDataFormats(data, format);
+        if (byteStride === undefined || rowByteLength === undefined) {
+          throw new Error('GPUVector requires format or explicit byte layout metadata');
+        }
+        if (format) {
+          validateGPUVectorDataFormats(data, format);
+        }
         this.name = name;
         this.dataType = props.dataType;
         this.format = format;
@@ -418,12 +424,8 @@ function getResolvedGPUVectorLayout<T extends GPUVectorFormat>(props: {
   };
 }
 
-function getFirstGPUVectorDataFormat<T extends GPUVectorFormat>(data: GPUData<T>[]): T {
-  const format = data[0]?.format;
-  if (!format) {
-    throw new Error('GPUVector requires format or at least one GPUData chunk');
-  }
-  return format;
+function getFirstGPUVectorDataFormat<T extends GPUVectorFormat>(data: GPUData<T>[]): T | undefined {
+  return data[0]?.format;
 }
 
 function validateGPUVectorDataFormats<T extends GPUVectorFormat>(

--- a/modules/tables/test/table/gpu-table-geometry.node.spec.ts
+++ b/modules/tables/test/table/gpu-table-geometry.node.spec.ts
@@ -37,8 +37,8 @@ test('GPUTableGeometry validates indexed and multi-batch geometry contracts', t 
     data: new Uint16Array([0, 1, 2])
   });
   const batches = [
-    new GPURecordBatch({vectors: {positions: makePositionsVector(device, 1)}}),
-    new GPURecordBatch({vectors: {positions: makePositionsVector(device, 2)}})
+    new GPURecordBatch({gpuData: {positions: makePositionsVector(device, 1).data[0]}}),
+    new GPURecordBatch({gpuData: {positions: makePositionsVector(device, 2).data[0]}})
   ];
   const batchedTable = new GPUTable({
     batches,
@@ -63,7 +63,7 @@ test('GPUTableGeometry validates indexed and multi-batch geometry contracts', t 
   t.end();
 });
 
-test('GPUTableGeometry rejects appendable DynamicBuffer attributes', t => {
+test('GPUTable rejects appendable vectors without batch-local GPUData', t => {
   const device = new NullDevice({});
   const positions = new GPUVector({
     type: 'appendable',
@@ -73,15 +73,13 @@ test('GPUTableGeometry rejects appendable DynamicBuffer attributes', t => {
     stride: 2,
     byteStride: Float32Array.BYTES_PER_ELEMENT * 2
   });
-  const table = new GPUTable({vectors: {positions}});
-
   t.throws(
-    () => new GPUTableGeometry({table, topology: 'triangle-list'}),
-    /static single-buffer attributes/,
-    'geometry conversion documents the static-buffer-only contract'
+    () => new GPUTable({vectors: {positions}}),
+    /requires exactly one GPUData chunk/,
+    'immutable record batches require materialized GPUData'
   );
 
-  table.destroy();
+  positions.destroy();
   t.end();
 });
 

--- a/modules/tables/test/table/gpu-table-model.node.spec.ts
+++ b/modules/tables/test/table/gpu-table-model.node.spec.ts
@@ -129,7 +129,7 @@ test('GPUTableModel merges explicit model state and rejects duplicate table inpu
   );
   t.equal(
     model.vertexArray.attributes[1],
-    table.attributes['positions'],
+    table.batches[0].gpuData.positions.buffer,
     'adds table attributes after explicit model bindings'
   );
 
@@ -167,7 +167,7 @@ test('GPUTableModel binds interleaved table buffers by layout name', t => {
     table
   });
 
-  t.deepEqual(Object.keys(table.attributes), ['matrices'], 'keeps the layout-named buffer');
+  t.notOk('attributes' in table, 'does not cache derived attribute buffers on the table');
   t.equal(
     model.vertexArray.attributes[0],
     matrixBuffer,
@@ -189,7 +189,7 @@ test('GPUTableModel draws preserved batches and restores table-level bindings', 
   const table = makeBatchedPositionsTable(device, [1, 2]);
   const model = makeTableModel(device, table);
   const renderPass = device.getDefaultRenderPass();
-  const batchBuffers = table.batches.map(batch => batch.gpuVectors['positions'].data[0].buffer);
+  const batchBuffers = table.batches.map(batch => batch.gpuData['positions'].buffer);
   const drawCalls: Array<{instanceCount?: number; buffer?: unknown}> = [];
   const draw = model.pipeline.draw.bind(model.pipeline);
 
@@ -214,7 +214,7 @@ test('GPUTableModel draws preserved batches and restores table-level bindings', 
   );
   t.equal(
     model.vertexArray.attributes[0],
-    table.attributes['positions'],
+    batchBuffers[0],
     'restores table-level attribute buffers after batched drawing'
   );
 
@@ -364,7 +364,7 @@ test('GPUTableModel draws preserved indexed batches and restores aggregate state
   const model = makeTableModel(device, table, {tableCount: 'none'});
   const renderPass = device.getDefaultRenderPass();
   const batchIndexBuffers = table.batches.map(
-    batch => batch.gpuVectors[GPU_TABLE_INDEX_COLUMN_NAME].data[0].buffer
+    batch => batch.gpuData[GPU_TABLE_INDEX_COLUMN_NAME].buffer
   );
   const drawCalls: Array<{indexBuffer?: unknown; vertexCount?: number; indexCount?: number}> = [];
   const draw = model.pipeline.draw.bind(model.pipeline);
@@ -416,30 +416,14 @@ test('GPUTableModel requires reserved table indices to use INDEX buffers', t => 
   t.end();
 });
 
-test('GPUTableModel refreshes inferred counts when a table row count changes', t => {
-  const device = new NullDevice({});
-  const table = makePositionsTable(device, 1);
-  const model = makeTableModel(device, table);
-
-  table.batches[0].appendRows(3);
-  table.refreshFromBatches();
-  model.needsRedraw();
-
-  t.equal(model.instanceCount, 4, 'syncs inferred row counts before redraw checks');
-
-  model.destroy();
-  table.destroy();
-  t.end();
-});
-
 test('GPUTable preserves source-row metadata across batch operations', t => {
   const device = new NullDevice({});
   const firstBatch = new GPURecordBatch({
-    vectors: {positions: makePositionsVector(device, 1)},
+    gpuData: {positions: makePositionsVector(device, 1).data[0]},
     sourceInfo: {sourceBatchIndex: 0, sourceRowIndexOffset: 10, sourceRowCount: 1}
   });
   const secondBatch = new GPURecordBatch({
-    vectors: {positions: makePositionsVector(device, 2)},
+    gpuData: {positions: makePositionsVector(device, 2).data[0]},
     sourceInfo: {sourceBatchIndex: 1, sourceRowIndexOffset: 11, sourceRowCount: 2}
   });
   const table = new GPUTable({
@@ -585,7 +569,7 @@ function makeBatchedPositionsTable(device: NullDevice, rowCounts: number[]): GPU
   let sourceRowIndexOffset = 0;
   const batches = rowCounts.map((rowCount, sourceBatchIndex) => {
     const batch = new GPURecordBatch({
-      vectors: {positions: makePositionsVector(device, rowCount)},
+      gpuData: {positions: makePositionsVector(device, rowCount).data[0]},
       sourceInfo: {sourceBatchIndex, sourceRowIndexOffset, sourceRowCount: rowCount}
     });
     sourceRowIndexOffset += rowCount;
@@ -605,9 +589,9 @@ function makeBatchedIndexedPositionsTable(
   const batches = batchProps.map(
     ({rowCount, indices}) =>
       new GPURecordBatch({
-        vectors: {
-          positions: makePositionsVector(device, rowCount),
-          [GPU_TABLE_INDEX_COLUMN_NAME]: makeIndicesVector(device, rowCount, indices)
+        gpuData: {
+          positions: makePositionsVector(device, rowCount).data[0],
+          [GPU_TABLE_INDEX_COLUMN_NAME]: makeIndicesVector(device, rowCount, indices).data[0]
         }
       })
   );
@@ -622,7 +606,7 @@ function makeContiguousSourceBatchedPositionsTable(device: NullDevice): GPUTable
   let sourceRowIndexOffset = 0;
   const batches = [1, 2].map(rowCount => {
     const batch = new GPURecordBatch({
-      vectors: {positions: makePositionsVector(device, rowCount)},
+      gpuData: {positions: makePositionsVector(device, rowCount).data[0]},
       sourceInfo: {sourceBatchIndex: 0, sourceRowIndexOffset, sourceRowCount: rowCount}
     });
     sourceRowIndexOffset += rowCount;

--- a/modules/tables/test/table/gpu-vector-format.node.spec.ts
+++ b/modules/tables/test/table/gpu-vector-format.node.spec.ts
@@ -235,15 +235,19 @@ test('GPUVector table helpers expose single-chunk vectors and required columns',
     data: [firstData, secondData],
     ownsData: false
   });
-  const batch = new GPURecordBatch({vectors: {positions}});
+  const batch = new GPURecordBatch({gpuData: {positions: positions.data[0]}});
   const table = new GPUTable({
     batches: [batch],
     schema: batch.schema,
     bufferLayout: batch.bufferLayout
   });
 
-  t.equal(getRequiredGPUVector(table, 'positions'), positions, 'finds a table vector by name');
-  t.equal(getRequiredGPUVector(batch, 'positions'), positions, 'finds a batch vector by name');
+  t.equal(
+    getRequiredGPUVector(table, 'positions'),
+    table.gpuVectors.positions,
+    'finds the table aggregate vector by name'
+  );
+  t.equal(batch.gpuData.positions, firstData, 'record batch retains one GPUData per column');
   t.equal(getGPUVectorData(positions), firstData, 'returns the single retained GPUData chunk');
   t.equal(getGPUVectorBuffer(positions), firstData.buffer, 'returns the single retained buffer');
   t.throws(
@@ -264,7 +268,95 @@ test('GPUVector table helpers expose single-chunk vectors and required columns',
   t.end();
 });
 
-test('GPUTable forwards vector-construction bindings to its generated record batch', t => {
+test('GPURecordBatch owns one row-aligned GPUData chunk per column', t => {
+  const device = new NullDevice({});
+  const positionsBuffer = device.createBuffer({byteLength: 16});
+  const colorsBuffer = device.createBuffer({byteLength: 8});
+  const positions = new GPUData({
+    buffer: positionsBuffer,
+    format: 'float32x2',
+    length: 2,
+    byteStride: 8,
+    ownsBuffer: true
+  });
+  const colors = new GPUData({
+    buffer: colorsBuffer,
+    format: 'unorm8x4',
+    length: 2,
+    byteStride: 4,
+    ownsBuffer: true
+  });
+  const mismatchedColorsBuffer = device.createBuffer({byteLength: 4});
+  const mismatchedColors = new GPUData({
+    buffer: mismatchedColorsBuffer,
+    format: 'unorm8x4',
+    length: 1,
+    byteStride: 4,
+    ownsBuffer: true
+  });
+  const batch = new GPURecordBatch({gpuData: {positions, colors}});
+
+  t.equal(batch.numRows, 2, 'derives rows from GPUData length');
+  t.deepEqual(
+    batch.schema.fields.map(field => field.name),
+    ['positions', 'colors'],
+    'synthesizes fields from keyed GPUData'
+  );
+  t.equal(batch.gpuData.positions, positions, 'retains the keyed data chunk');
+  t.throws(
+    () =>
+      new GPURecordBatch({
+        gpuData: {
+          positions,
+          colors: mismatchedColors
+        }
+      }),
+    /matching GPUData row counts/,
+    'rejects mismatched column lengths'
+  );
+
+  batch.destroy();
+  mismatchedColors.destroy();
+  t.ok(positionsBuffer.destroyed, 'destroys owned position data');
+  t.ok(colorsBuffer.destroyed, 'destroys owned color data');
+  t.end();
+});
+
+test('GPURecordBatch accepts explicit layouts for format-less interleaved GPUData', t => {
+  const device = new NullDevice({});
+  const data = new GPUData({
+    buffer: device.createBuffer({byteLength: 32}),
+    length: 2,
+    stride: 16,
+    byteStride: 16,
+    rowByteLength: 16,
+    ownsBuffer: true
+  });
+  const batch = new GPURecordBatch({
+    gpuData: {interleaved: data},
+    bufferLayout: [
+      {
+        name: 'interleaved',
+        byteStride: 16,
+        attributes: [
+          {attribute: 'positions', format: 'float32x2', byteOffset: 0},
+          {attribute: 'colors', format: 'unorm8x4', byteOffset: 8}
+        ]
+      }
+    ]
+  });
+  const emptyBatch = new GPURecordBatch({gpuData: {}, numRows: 0});
+
+  t.equal(batch.numRows, 2, 'derives interleaved row count from GPUData');
+  t.equal(batch.schema.fields[0].format, undefined, 'keeps format-less interleaved field');
+  t.equal(emptyBatch.numRows, 0, 'accepts explicit empty batches');
+
+  batch.destroy();
+  emptyBatch.destroy();
+  t.end();
+});
+
+test('GPUTable keeps storage in GPU vectors instead of cached bindings', t => {
   const device = new NullDevice({});
   const positions = new GPUVector({
     type: 'buffer',
@@ -285,17 +377,11 @@ test('GPUTable forwards vector-construction bindings to its generated record bat
     byteStride: 4,
     ownsBuffer: true
   });
-  const table = new GPUTable({
-    vectors: {positions, weights},
-    bindings: {weights: weightsBuffer}
-  });
+  const table = new GPUTable({vectors: {positions, weights}});
 
-  t.equal(table.bindings.weights, weightsBuffer, 'exposes the forwarded binding on the table');
-  t.equal(
-    table.batches[0].bindings.weights,
-    weightsBuffer,
-    'forwards bindings to the generated record batch'
-  );
+  t.notOk('bindings' in table, 'does not cache bindings on the table');
+  t.notOk('bindings' in table.batches[0], 'does not cache bindings on the batch');
+  t.equal(table.gpuVectors.weights.data[0].buffer, weightsBuffer, 'keeps storage on GPUData');
 
   table.destroy();
   t.end();

--- a/modules/tables/test/table/polygon-model.node.spec.ts
+++ b/modules/tables/test/table/polygon-model.node.spec.ts
@@ -61,7 +61,7 @@ test('PolygonAttributeModel consumes flattened vertex-list values through explic
   });
 
   t.equal(model.table?.numRows, 1, 'keeps one logical source polygon row');
-  t.equal(model.table?.batches[0]?.gpuVectors.positions.format, 'vertex-list<float32x4>');
+  t.equal(model.table?.batches[0]?.gpuData.positions.format, 'vertex-list<float32x4>');
   t.equal(model.vertexCount, 3, 'uses flattened reserved index valueLength for indexed draw count');
   t.deepEqual(
     model.table?.bufferLayout.map(layout => layout.name),
@@ -173,9 +173,10 @@ test('PolygonStorageModel binds flattened polygon vectors as storage', async t =
   t.deepEqual(model.table?.bufferLayout, [], 'does not synthesize vertex attributes');
   t.equal(model.vertexCount, 3, 'uses flattened reserved index valueLength for indexed draws');
   t.equal(model.indexCount, 3, 'plumbs flattened reserved index valueLength to Model.draw');
-  t.ok(model.table?.bindings.polygonPositions, 'binds prepared positions as storage');
-  t.ok(model.table?.bindings.polygonColors, 'binds prepared colors as storage');
-  t.ok(model.table?.bindings.polygonRowIndices, 'binds prepared row indices as storage');
+  t.notOk('bindings' in model.table!, 'does not cache model bindings on the table');
+  t.ok(model.bindings.polygonPositions, 'binds prepared positions as storage');
+  t.ok(model.bindings.polygonColors, 'binds prepared colors as storage');
+  t.ok(model.bindings.polygonRowIndices, 'binds prepared row indices as storage');
 
   model.destroy();
   destroyPolygonGPUVectors(vectors);

--- a/modules/text/src/text-2d/models/text-attribute-model.ts
+++ b/modules/text/src/text-2d/models/text-attribute-model.ts
@@ -4,7 +4,12 @@
 
 import {type Buffer, type Device, type RenderPass} from '@luma.gl/core';
 import {DynamicTexture, type ModelProps} from '@luma.gl/engine';
-import {GPUTableModel, type GPUTableModelProps, type GPUTable} from '@luma.gl/tables';
+import {
+  GPUTableModel,
+  getGPUDataBuffersForLayout,
+  type GPUTableModelProps,
+  type GPUTable
+} from '@luma.gl/tables';
 import FontAtlasManager from '../atlas/font-atlas-manager';
 import type {TextGlyphLayout} from '../model-utils/gpu-text-types';
 import {EXPANDED_GLYPH_VERTEX_DATA} from '../model-utils/text-shaders';
@@ -145,15 +150,18 @@ export class TextAttributeModel extends GPUTableModel {
           throw new Error('TextAttributeModel is missing a GPU render batch');
         }
         this.setAttributes({
-          ...gpuBatch.attributes,
+          ...getGPUDataBuffersForLayout(gpuBatch.bufferLayout, gpuBatch.gpuData),
           [EXPANDED_GLYPH_VERTEX_DATA]: renderBatch.expandedGlyphVertexData
         });
         this.setInstanceCount(renderBatch.glyphCount);
         drawSuccess = super.draw(renderPass) && drawSuccess;
       }
     } finally {
+      const firstGpuBatch = gpuTable.batches[0];
       this.setAttributes({
-        ...(gpuTable.attributes || {}),
+        ...(firstGpuBatch
+          ? getGPUDataBuffersForLayout(firstGpuBatch.bufferLayout, firstGpuBatch.gpuData)
+          : {}),
         [EXPANDED_GLYPH_VERTEX_DATA]: this.expandedGlyphVertexData
       });
       this.setInstanceCount(this.glyphLayout.glyphCount);

--- a/website/src/components/docs/gpu-table-structure-graphic.tsx
+++ b/website/src/components/docs/gpu-table-structure-graphic.tsx
@@ -6,8 +6,8 @@ const gpuTableDetails = ['schema', 'bufferLayout', 'gpuVectors', 'batches[]'];
 const gpuDataDetails = ['type', 'length', 'byteOffset', 'byteStride', 'ownsBuffer'];
 const memorySteps = [
   ['GPUTable', 'owns batches'],
-  ['GPURecordBatch', 'owns batch-local vectors'],
-  ['GPUVector', 'owns or borrows data chunks'],
+  ['GPURecordBatch', 'owns batch-local data chunks'],
+  ['GPUVector', 'table-level aggregate view'],
   ['GPUData', 'owns or borrows DynamicBuffer']
 ];
 


### PR DESCRIPTION
## Goals

- Make `GPURecordBatch` mirror Arrow `RecordBatch` ownership: one batch-local `GPUData` chunk per selected column.
- Keep multi-chunk logical columns as table-level `GPUVector` aggregate views.
- Document how tabular columns map to WGSL attributes, storage buffers, and constants.

## Changes

- Replaced `GPURecordBatch({vectors})` with the hard-cutover `GPURecordBatch({gpuData})` API and exported `GPUDataMap` / `GPURecordBatchFromDataProps`.
- Removed batch-local `gpuVectors`, cached table/batch attributes and bindings, and mutable batch append/reset methods.
- Updated `GPUTable` aggregation, selection, detach, packing, lifecycle, and indexed-draw handling to operate on batch-local `GPUData`.
- Updated model, transform, geometry, path, polygon, Arrow adapter, example, and test consumers to derive bindable resources from `GPUData`.
- Updated the text attribute model to derive per-batch buffers from `GPUData` instead of removed cached `attributes`.
- Updated Arrow text picking to derive table and batch attribute buffers from `GPUData`.
- Updated Arrow instancing, particles, and 3D text examples to derive batch buffers from `GPUData`.
- Preserved interleaved-only `bufferLayout` metadata on aggregate vectors and validate explicit storage-binding collisions against GPUData-derived bindings.
- Reject generic packing for variable-length `value-list` and `vertex-list` GPUData so flattened payloads are never silently truncated.
- Changed Arrow RecordBatch upload to create one `GPUData` directly from each selected Arrow child chunk.
- Added coverage for row-count validation, format-less interleaved layouts, destruction ownership, aggregation, packing, selection, detaching, and multi-batch drawing.
- Added the Tabular Data in WGSL guide, including attribute/storage mappings, packed 8/16-bit storage access, WGSL `vec3` storage stride, and constant handling.

## Verification

- `nvm use`
- `yarn install`
- `yarn build`
- `(cd modules/text && npx tspc --declaration --declarationMap --sourceMap --outDir dist --project tsconfig.json)`
- `(cd modules/arrow && npx tspc --declaration --declarationMap --sourceMap --outDir dist --project tsconfig.json)`
- `yarn test`
- `yarn test-node`
- `yarn test-headless`
- `yarn examples:typecheck`
- `(cd examples/arrow/arrow-particles && npx tsc --project tsconfig.json --noEmit)`
- `yarn lint fix`
- `yarn lint`
- `yarn website:build`
- `(cd website && yarn build)`
- Pre-commit hook: 45 node test files passed, 2 skipped; 148 tests passed, 2 skipped.
- Added `AGENTS.md` guidance requiring the final `yarn build` gate after formatting and explicitly warning that `yarn test-node` does not cover cross-package `tspc` builds.

## Risks

- This is an intentional breaking API cutover: callers must replace batch `{vectors}` construction and `batch.gpuVectors` reads with `{gpuData}` and `batch.gpuData`.
- `GPUTable({vectors})` now requires each supplied vector to contain exactly one materialized `GPUData` chunk because the generated record batch is immutable.

## Follow-up

- `GPUConstant` integration remains separate from this change.
