### PR TITLE
website: Improve example browsing and InfoBox panels

### DIFF
--- a/.ocularrc.js
+++ b/.ocularrc.js
@@ -77,6 +77,24 @@ const config = {
       softwareGpu: Boolean(process.env.CI),
       // CI runners intermittently close Chromium under high parallel WebGL/WebGPU load.
       fileParallelism: !process.env.CI,
+      // Istanbul instruments only the product source allowlist before browser execution.
+      // This keeps generated bundles, source maps, examples, and large fixtures out of the
+      // transient coverage chunks that can exhaust smaller GitHub-hosted runner disks.
+      coverage: {
+        provider: 'istanbul',
+        include: ['modules/**/src/**/*.{js,ts,tsx}'],
+        exclude: [
+          '**/*.d.ts',
+          '**/*.map',
+          '**/*.{bundle,min}.{js,ts}',
+          '**/{build,coverage,dist,node_modules,vendor,vendored}/**',
+          'examples/**',
+          'website/**',
+          'test/**',
+          'modules/**/test/**'
+        ],
+        excludeAfterRemap: true
+      },
       // Repo-owned exclusions that should not live in reusable devtools code.
       excludePatterns: [
         '**/*.disabled.*',

--- a/dev-modules/devtools-extensions/get-vitest-config.mjs
+++ b/dev-modules/devtools-extensions/get-vitest-config.mjs
@@ -25,6 +25,7 @@ export async function getVitestConfig(options = {}) {
   const browserName = vitestConfig.browserName || 'chromium';
   const testTimeout = vitestConfig.testTimeout || 60_000;
   const fileParallelism = vitestConfig.fileParallelism;
+  const coverageConfig = vitestConfig.coverage || {};
   const softwareGpu = Boolean(vitestConfig.softwareGpu);
   const tsconfigAliases = getTsconfigAliases(tsconfigProjects);
 
@@ -104,8 +105,11 @@ export async function getVitestConfig(options = {}) {
         }
       ],
       coverage: {
-        provider: 'v8',
-        reporter: ['text', 'lcov']
+        provider: coverageConfig.provider || 'v8',
+        reporter: coverageConfig.reporter || ['text', 'lcov'],
+        include: coverageConfig.include,
+        exclude: coverageConfig.exclude,
+        excludeAfterRemap: coverageConfig.excludeAfterRemap
       }
     }
   });

--- a/dev-modules/devtools-extensions/package.json
+++ b/dev-modules/devtools-extensions/package.json
@@ -25,6 +25,7 @@
     "@biomejs/biome": "^2.4.8",
     "@vitest/browser": "^4.0.18",
     "@vitest/browser-playwright": "^4.0.18",
+    "@vitest/coverage-istanbul": "4.1.0",
     "@vitest/coverage-v8": "^4.0.18",
     "playwright": "^1.56.1",
     "vite": "^8.0.0",

--- a/examples/arrow/arrow-columns/app.ts
+++ b/examples/arrow/arrow-columns/app.ts
@@ -12,11 +12,7 @@ import {
   getDefaultColumnRendererMetricDefaults
 } from './arrow-column-renderer';
 import {formatArrowColumnRendererMetrics} from './arrow-column-metrics';
-import {
-  ArrowColumnRendererControlPanel,
-  makeArrowColumnRendererControlPanelHtml,
-  type ArrowColumnTransparencyMode
-} from './control-panel';
+import {ArrowColumnRendererControlPanel, type ArrowColumnTransparencyMode} from './control-panel';
 import {ArrowExamplePanelManager, makeArrowExamplePanelHostHtml} from '../arrow-example-panels';
 
 export const title = 'DGGS + time';
@@ -39,7 +35,8 @@ export default class ArrowColumnRendererAnimationLoopTemplate extends AnimationL
     }
   });
   readonly panels = new ArrowExamplePanelManager({
-    descriptionHtml: makeArrowColumnRendererControlPanelHtml()
+    descriptionPanel: () => this.controlPanel.makeDescriptionPanel(),
+    settingsPanel: () => this.controlPanel.makeSettingsPanel()
   });
   layer: ArrowColumnRenderer | null = null;
   isFinalized = false;
@@ -57,8 +54,6 @@ export default class ArrowColumnRendererAnimationLoopTemplate extends AnimationL
 
   override async onInitialize(): Promise<void> {
     this.panels.mount();
-    this.controlPanel.initialize();
-    this.controlPanel.setTransparencyMode(this.transparencyMode);
     this.controlPanel.setStatus('Loading deck.gl CSV');
     this.controlPanel.setMetrics(
       formatArrowColumnRendererMetrics(getDefaultColumnRendererMetricDefaults())

--- a/examples/arrow/arrow-columns/control-panel.ts
+++ b/examples/arrow/arrow-columns/control-panel.ts
@@ -128,7 +128,7 @@ export class ArrowColumnRendererControlPanel {
     _settings: Record<string, unknown>,
     changedSettings?: SettingsChangeDescriptor[]
   ): void => {
-    const transparencyMode = getChangedSetting(changedSettings, 'transparencyMode')?.value;
+    const transparencyMode = getChangedSetting(changedSettings, 'transparencyMode')?.nextValue;
     if (isTransparencyMode(transparencyMode)) {
       this.options.onTransparencyModeChange?.(transparencyMode);
     }

--- a/examples/arrow/arrow-columns/control-panel.ts
+++ b/examples/arrow/arrow-columns/control-panel.ts
@@ -2,6 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import type {Panel, SettingsChangeDescriptor, SettingsSchema} from '@deck.gl-community/panels';
+import {
+  ExampleSettingsPanelManager,
+  getChangedSetting,
+  makeHtmlCustomPanel
+} from '../../example-panels';
 import type {ArrowColumnRendererFormattedMetrics} from './arrow-column-metrics';
 
 const STATUS_ID = 'arrow-columns-status';
@@ -15,7 +21,6 @@ const MAX_COUNT_ID = 'arrow-columns-max-count';
 const GPU_BYTES_ID = 'arrow-columns-gpu-bytes';
 const ARROW_BUILD_TIME_ID = 'arrow-columns-arrow-build-time';
 const GEOMETRY_DECODE_TIME_ID = 'arrow-columns-geometry-decode-time';
-const TRANSPARENCY_MODE_ID = 'arrow-columns-transparency-mode';
 
 export type ArrowColumnTransparencyMode = 'a-buffer' | 'weighted-blended' | 'alpha-blending';
 
@@ -25,7 +30,8 @@ export type ArrowColumnRendererControlPanelOptions = {
 
 export class ArrowColumnRendererControlPanel {
   private readonly options: ArrowColumnRendererControlPanelOptions;
-  private transparencyModeSelector: HTMLSelectElement | null = null;
+  private readonly settingsPanel: ExampleSettingsPanelManager;
+  private rootElement: HTMLElement | null = null;
   private statusLabel: HTMLElement | null = null;
   private sourceRowsLabel: HTMLElement | null = null;
   private aggregateRowsLabel: HTMLElement | null = null;
@@ -40,31 +46,51 @@ export class ArrowColumnRendererControlPanel {
 
   constructor(options: ArrowColumnRendererControlPanelOptions = {}) {
     this.options = options;
+    this.settingsPanel = new ExampleSettingsPanelManager({
+      id: 'arrow-columns-settings',
+      schema: makeArrowColumnRendererSettingsSchema(),
+      settings: {transparencyMode: 'a-buffer'},
+      onSettingsChange: this.handleSettingsChange
+    });
   }
 
-  initialize(): void {
-    if (!this.transparencyModeSelector) {
-      this.transparencyModeSelector = document.getElementById(
-        TRANSPARENCY_MODE_ID
-      ) as HTMLSelectElement | null;
-      this.transparencyModeSelector?.addEventListener('change', this.handleTransparencyModeChange);
-    }
-    this.statusLabel ??= document.getElementById(STATUS_ID);
-    this.sourceRowsLabel ??= document.getElementById(SOURCE_ROWS_ID);
-    this.aggregateRowsLabel ??= document.getElementById(AGGREGATE_ROWS_ID);
-    this.decodedCellsLabel ??= document.getElementById(DECODED_CELLS_ID);
-    this.h3ResolutionLabel ??= document.getElementById(H3_RESOLUTION_ID);
-    this.timeBucketsLabel ??= document.getElementById(TIME_BUCKETS_ID);
-    this.activeBucketLabel ??= document.getElementById(ACTIVE_BUCKET_ID);
-    this.maxCountLabel ??= document.getElementById(MAX_COUNT_ID);
-    this.gpuBytesLabel ??= document.getElementById(GPU_BYTES_ID);
-    this.arrowBuildTimeLabel ??= document.getElementById(ARROW_BUILD_TIME_ID);
-    this.geometryDecodeTimeLabel ??= document.getElementById(GEOMETRY_DECODE_TIME_ID);
+  makeDescriptionPanel(): Panel {
+    return makeHtmlCustomPanel({
+      id: 'arrow-columns-description',
+      title: 'Description',
+      html: makeArrowColumnRendererControlPanelHtml(),
+      onRender: rootElement => {
+        this.rootElement = rootElement;
+        this.statusLabel = getElement(rootElement, STATUS_ID);
+        this.sourceRowsLabel = getElement(rootElement, SOURCE_ROWS_ID);
+        this.aggregateRowsLabel = getElement(rootElement, AGGREGATE_ROWS_ID);
+        this.decodedCellsLabel = getElement(rootElement, DECODED_CELLS_ID);
+        this.h3ResolutionLabel = getElement(rootElement, H3_RESOLUTION_ID);
+        this.timeBucketsLabel = getElement(rootElement, TIME_BUCKETS_ID);
+        this.activeBucketLabel = getElement(rootElement, ACTIVE_BUCKET_ID);
+        this.maxCountLabel = getElement(rootElement, MAX_COUNT_ID);
+        this.gpuBytesLabel = getElement(rootElement, GPU_BYTES_ID);
+        this.arrowBuildTimeLabel = getElement(rootElement, ARROW_BUILD_TIME_ID);
+        this.geometryDecodeTimeLabel = getElement(rootElement, GEOMETRY_DECODE_TIME_ID);
+        return () => {
+          this.rootElement = null;
+          this.clearLabels();
+        };
+      }
+    });
+  }
+
+  makeSettingsPanel(): Panel {
+    return this.settingsPanel.makePanel();
   }
 
   destroy(): void {
-    this.transparencyModeSelector?.removeEventListener('change', this.handleTransparencyModeChange);
-    this.transparencyModeSelector = null;
+    this.settingsPanel.finalize();
+    this.rootElement = null;
+    this.clearLabels();
+  }
+
+  private clearLabels(): void {
     this.statusLabel = null;
     this.sourceRowsLabel = null;
     this.aggregateRowsLabel = null;
@@ -80,12 +106,6 @@ export class ArrowColumnRendererControlPanel {
 
   setStatus(status: string): void {
     setText(this.statusLabel, status);
-  }
-
-  setTransparencyMode(mode: ArrowColumnTransparencyMode): void {
-    if (this.transparencyModeSelector) {
-      this.transparencyModeSelector.value = mode;
-    }
   }
 
   setActiveTimeBucket(activeTimeBucket: string): void {
@@ -104,15 +124,40 @@ export class ArrowColumnRendererControlPanel {
     setText(this.geometryDecodeTimeLabel, metrics.geometryDecodeTime);
   }
 
-  private handleTransparencyModeChange = (event: Event): void => {
-    const mode = (event.target as HTMLSelectElement).value;
-    this.options.onTransparencyModeChange?.(
-      mode === 'weighted-blended'
-        ? 'weighted-blended'
-        : mode === 'alpha-blending'
-          ? 'alpha-blending'
-          : 'a-buffer'
-    );
+  private readonly handleSettingsChange = (
+    _settings: Record<string, unknown>,
+    changedSettings?: SettingsChangeDescriptor[]
+  ): void => {
+    const transparencyMode = getChangedSetting(changedSettings, 'transparencyMode')?.value;
+    if (isTransparencyMode(transparencyMode)) {
+      this.options.onTransparencyModeChange?.(transparencyMode);
+    }
+  };
+}
+
+export function makeArrowColumnRendererSettingsSchema(): SettingsSchema {
+  return {
+    title: 'Settings',
+    sections: [
+      {
+        id: 'renderer',
+        name: 'Renderer',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'transparencyMode',
+            label: 'Transparency',
+            type: 'select',
+            persist: 'none',
+            options: [
+              {label: 'A-buffer OIT', value: 'a-buffer'},
+              {label: 'Weighted blended OIT', value: 'weighted-blended'},
+              {label: 'Standard alpha blending', value: 'alpha-blending'}
+            ]
+          }
+        ]
+      }
+    ]
   };
 }
 
@@ -120,14 +165,6 @@ export function makeArrowColumnRendererControlPanelHtml(): string {
   return `\
   <div style="box-sizing: border-box; width: 100%; padding: 14px 16px; border: 1px solid #d0d7de; border-radius: 8px; background: #fff; color: #0f172a; font: 14px/1.4 system-ui, sans-serif;">
     <h3 style="margin: 0 0 10px; color: #0f172a; font-size: 13px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.03em;">Arrow H3 Columns</h3>
-    <label for="${TRANSPARENCY_MODE_ID}" style="display: grid; gap: 5px; margin-bottom: 10px; font-weight: 600;">
-      <span>Transparency</span>
-      <select id="${TRANSPARENCY_MODE_ID}" style="width: 100%; padding: 7px 9px; border: 1px solid #cbd5e1; border-radius: 6px; background: #fff; color: #0f172a; font: inherit;">
-        <option value="a-buffer">A-buffer OIT</option>
-        <option value="weighted-blended">Weighted blended OIT</option>
-        <option value="alpha-blending">Standard alpha blending</option>
-      </select>
-    </label>
     ${makeMetricRow('Status', STATUS_ID)}
     ${makeMetricRow('Source CSV rows', SOURCE_ROWS_ID)}
     ${makeMetricRow('Arrow aggregate rows', AGGREGATE_ROWS_ID)}
@@ -151,4 +188,12 @@ function setText(element: HTMLElement | null, value: string): void {
   if (element) {
     element.textContent = value;
   }
+}
+
+function getElement(rootElement: HTMLElement, id: string): HTMLElement | null {
+  return rootElement.querySelector<HTMLElement>(`#${id}`);
+}
+
+function isTransparencyMode(value: unknown): value is ArrowColumnTransparencyMode {
+  return value === 'a-buffer' || value === 'weighted-blended' || value === 'alpha-blending';
 }

--- a/examples/arrow/arrow-example-panels.ts
+++ b/examples/arrow/arrow-example-panels.ts
@@ -17,6 +17,7 @@ import {
   makeExampleContentPanel,
   makeHtmlCustomPanel,
   makeExamplePanelHostHtml,
+  makeExampleTabbedPanel,
   renderExamplePanel
 } from '../example-panels';
 
@@ -168,7 +169,7 @@ export class ArrowExamplePanelManager {
 
     renderExamplePanel(
       this.hostElement,
-      new TabbedPanel({
+      makeExampleTabbedPanel({
         id: 'arrow-example-root-tabs',
         title: 'Arrow example',
         tabListLayout: 'wrap',

--- a/examples/example-panels.ts
+++ b/examples/example-panels.ts
@@ -7,6 +7,7 @@ import {
   PanelThemeScope,
   SettingsManager,
   SettingsPanel,
+  TabbedPanel,
   type Panel,
   type SettingsChangeDescriptor,
   type SettingsManagerLocalStorageConfig,
@@ -14,12 +15,16 @@ import {
   type SettingsSchema,
   type SettingDescriptor,
   type SettingValue,
-  type SettingsState
+  type SettingsState,
+  type TabbedPanelProps
 } from '@deck.gl-community/panels';
 import {Fragment, h, render} from 'preact';
+import {useEffect, useState} from 'preact/hooks';
 
 const EXAMPLE_PANEL_HOST_ID = 'example-panel-host';
 const EXAMPLE_SETTINGS_PANEL_ATTRIBUTE = 'data-example-settings-panel';
+const EXAMPLE_SOURCE_PANEL_ID = 'example-source';
+const EXAMPLES_PATH_PREFIX = '/examples/';
 const MODEL_SETTING_NAMES = new Set(['modelKind', 'renderMode']);
 const EXAMPLE_PANEL_STYLE = `
 [data-example-panel-host] [aria-hidden='true'] {
@@ -43,6 +48,11 @@ export type ExampleSettingsPanelProps = {
   settings: SettingsState;
   onSettingsChange?: SettingsManagerOnChange;
   localStorageConfig?: SettingsManagerLocalStorageConfig;
+};
+
+type ExampleSourceResult = {
+  source?: string;
+  error?: string;
 };
 
 /** Returns the InfoBox host used by panel-backed example content. */
@@ -103,6 +113,112 @@ export function makeExampleContentPanel({
       return () => render(null, rootElement);
     }
   });
+}
+
+/** Creates a community tabbed panel with the website source viewer appended when available. */
+export function makeExampleTabbedPanel(props: TabbedPanelProps): Panel {
+  const hasSourcePanel = props.panels.some(panel => panel.id === EXAMPLE_SOURCE_PANEL_ID);
+  const panels =
+    isWebsiteExample() && !hasSourcePanel
+      ? [...props.panels, makeExampleSourcePanel()]
+      : props.panels;
+  return new TabbedPanel({...props, panels});
+}
+
+function makeExampleSourcePanel(): Panel {
+  return makeExampleContentPanel({
+    id: EXAMPLE_SOURCE_PANEL_ID,
+    title: 'Source',
+    content: h(ExampleSourcePanelContent, {})
+  });
+}
+
+function ExampleSourcePanelContent() {
+  const [sourceResult, setSourceResult] = useState<ExampleSourceResult>({});
+
+  useEffect(() => {
+    const sourcePaths = getCurrentExampleSourcePaths();
+    if (sourcePaths.length === 0) {
+      setSourceResult({error: 'Unable to determine source code path.'});
+      return;
+    }
+
+    const abortController = new AbortController();
+    void fetchCurrentExampleSource(sourcePaths, abortController.signal)
+      .then(source => setSourceResult({source}))
+      .catch(error => {
+        if (!abortController.signal.aborted) {
+          setSourceResult({
+            error: error instanceof Error ? error.message : 'Unable to load source code.'
+          });
+        }
+      });
+
+    return () => abortController.abort();
+  }, []);
+
+  if (sourceResult.error) {
+    return h('p', {style: {margin: 0, color: '#b00020'}}, sourceResult.error);
+  }
+
+  return h(
+    'pre',
+    {
+      style: {
+        margin: 0,
+        padding: '12px',
+        maxWidth: '100%',
+        overflow: 'auto',
+        background: '#f6f8fa',
+        color: '#24292f',
+        font: '12px/1.45 ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace',
+        whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word'
+      }
+    },
+    h('code', {}, sourceResult.source ?? '// Loading source…')
+  );
+}
+
+function isWebsiteExample(): boolean {
+  return typeof window !== 'undefined' && Boolean((window as Window & {website?: boolean}).website);
+}
+
+function getCurrentExampleSourcePaths(): string[] {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  const examplesPathIndex = window.location.pathname.indexOf(EXAMPLES_PATH_PREFIX);
+  if (examplesPathIndex < 0) {
+    return [];
+  }
+
+  const sourceDirectory = window.location.pathname
+    .slice(examplesPathIndex + EXAMPLES_PATH_PREFIX.length)
+    .replace(/\/+$/, '');
+  if (!sourceDirectory) {
+    return [];
+  }
+
+  return [`${sourceDirectory}/app.ts`, `${sourceDirectory}/app.tsx`];
+}
+
+async function fetchCurrentExampleSource(
+  sourcePaths: readonly string[],
+  signal: AbortSignal
+): Promise<string> {
+  const examplesPathIndex = window.location.pathname.indexOf(EXAMPLES_PATH_PREFIX);
+  const websiteBasePath = window.location.pathname.slice(0, examplesPathIndex + 1);
+
+  for (const sourcePath of sourcePaths) {
+    const response = await fetch(`${websiteBasePath}example-assets/${sourcePath}`, {signal});
+    if (response.ok) {
+      return response.text();
+    }
+  }
+
+  throw new Error('Unable to load source code.');
 }
 
 /** Owns one panel-backed InfoBox surface for an example. */

--- a/examples/experimental/a-buffer/app.ts
+++ b/examples/experimental/a-buffer/app.ts
@@ -19,23 +19,21 @@ import {
 } from '@luma.gl/experimental';
 import type {ShaderModule} from '@luma.gl/shadertools';
 import {Matrix4, radians} from '@math.gl/core';
+import {type SettingsChangeDescriptor, type SettingsSchema} from '@deck.gl-community/panels';
+import {
+  ExamplePanelManager,
+  ExampleSettingsPanelManager,
+  getChangedSetting,
+  makeExamplePanelHostHtml,
+  makeHtmlCustomPanel,
+  makeExampleTabbedPanel
+} from '../../example-panels';
 
 const OPAQUE_INSTANCE_COUNT = 2;
 const TRANSLUCENT_INSTANCE_COUNT = 7;
 const ORBIT_DURATION_SECONDS = 90;
-const MODE_SELECT_ID = 'a-buffer-mode';
-const OPACITY_INPUT_ID = 'a-buffer-opacity';
-const OPACITY_OUTPUT_ID = 'a-buffer-opacity-value';
-const SPHERE_SIZE_INPUT_ID = 'a-buffer-sphere-size';
-const SPHERE_SIZE_OUTPUT_ID = 'a-buffer-sphere-size-value';
-const ROTATION_INPUT_ID = 'a-buffer-rotation';
-const CONTROLS_TAB_ID = 'a-buffer-controls-tab';
-const DETAILS_TAB_ID = 'a-buffer-details-tab';
-const CONTROLS_PANEL_ID = 'a-buffer-controls-panel';
-const DETAILS_PANEL_ID = 'a-buffer-details-panel';
 
 type TransparencyMode = 'a-buffer' | 'weighted-blended' | 'alpha-blending';
-type InfoTab = 'controls' | 'details';
 
 type SceneUniforms = {
   viewProjectionMatrix: Matrix4;
@@ -215,44 +213,7 @@ const TRANSLUCENT_PARAMETERS = {
 } as const satisfies RenderPipelineParameters;
 
 export default class OrderIndependentTransparencyExample extends AnimationLoopTemplate {
-  static info = `\
-<div style="display: grid; gap: 12px; min-width: 260px; color: #0f172a; font: 13px/1.4 system-ui, sans-serif;">
-  <div role="tablist" aria-label="Order-independent transparency example information" style="display: flex; gap: 6px; padding-bottom: 10px; border-bottom: 1px solid #e2e8f0;">
-    <button id="${CONTROLS_TAB_ID}" type="button" role="tab" aria-controls="${CONTROLS_PANEL_ID}" aria-selected="true" data-a-buffer-info-tab="controls" style="padding: 5px 9px; border: 1px solid #7dd3fc; border-radius: 999px; background: #e0f2fe; color: #0369a1; cursor: pointer; font: 600 12px/1 system-ui, sans-serif;">Controls</button>
-    <button id="${DETAILS_TAB_ID}" type="button" role="tab" aria-controls="${DETAILS_PANEL_ID}" aria-selected="false" tabindex="-1" data-a-buffer-info-tab="details" style="padding: 5px 9px; border: 1px solid #cbd5e1; border-radius: 999px; background: #fff; color: #334155; cursor: pointer; font: 600 12px/1 system-ui, sans-serif;">Details</button>
-  </div>
-  <section id="${CONTROLS_PANEL_ID}" role="tabpanel" aria-labelledby="${CONTROLS_TAB_ID}" data-a-buffer-info-panel="controls" style="display: grid; gap: 12px;">
-    <p style="margin: 0;">Compare exact per-pixel linked-list OIT, approximate weighted blended OIT, and unsorted alpha blending on the same interleaved scene.</p>
-    <label style="display: grid; gap: 5px; font-weight: 600;">
-      <span>Transparency</span>
-      <select id="${MODE_SELECT_ID}" style="padding: 7px 9px; border: 1px solid #cbd5e1; border-radius: 6px; background: #fff; color: #0f172a; font: inherit;">
-        <option value="a-buffer">A-buffer OIT</option>
-        <option value="weighted-blended">Weighted blended OIT</option>
-        <option value="alpha-blending">Standard alpha blending</option>
-      </select>
-    </label>
-    <label style="display: grid; gap: 5px; font-weight: 600;">
-      <span style="display: flex; justify-content: space-between; gap: 12px;">Opacity <output id="${OPACITY_OUTPUT_ID}">0.34</output></span>
-      <input id="${OPACITY_INPUT_ID}" type="range" min="0.1" max="0.7" step="0.01" value="0.34" style="width: 100%; margin: 0;">
-    </label>
-    <label style="display: grid; gap: 5px; font-weight: 600;">
-      <span style="display: flex; justify-content: space-between; gap: 12px;">Sphere size <output id="${SPHERE_SIZE_OUTPUT_ID}">6.5</output></span>
-      <input id="${SPHERE_SIZE_INPUT_ID}" type="range" min="3" max="10" step="0.1" value="6.5" style="width: 100%; margin: 0;">
-    </label>
-    <label style="display: flex; align-items: center; gap: 8px; font-weight: 600;">
-      <input id="${ROTATION_INPUT_ID}" type="checkbox" checked>
-      Rotate camera
-    </label>
-  </section>
-  <section id="${DETAILS_PANEL_ID}" role="tabpanel" aria-labelledby="${DETAILS_TAB_ID}" aria-hidden="true" data-a-buffer-info-panel="details" hidden style="display: none; gap: 10px; color: #334155;">
-    <p style="margin: 0;">The dropdown renders the same unsorted translucent spheres with three different blending strategies.</p>
-    <div style="display: grid; gap: 8px;">
-      <div><strong style="color: #0f172a;">A-buffer OIT</strong><br>Captures every translucent fragment into GPU storage, sorts fragments per pixel, then composites them back-to-front. It is the most accurate option here and is available on WebGPU.</div>
-      <div><strong style="color: #0f172a;">Weighted blended OIT</strong><br>Accumulates weighted color and revealage into floating-point offscreen targets, then composites once. It avoids sorting and works on WebGPU or WebGL2 when float render-target blending is available, but it is approximate.</div>
-      <div><strong style="color: #0f172a;">Standard alpha blending</strong><br>Blends translucent draws directly into the framebuffer in submission order. It is the cheapest fallback, but unsorted overlaps produce visibly incorrect results.</div>
-    </div>
-  </section>
-</div>`;
+  static info = makeExamplePanelHostHtml();
 
   static props = {useDevicePixels: true, createFramebuffer: true};
 
@@ -275,6 +236,8 @@ export default class OrderIndependentTransparencyExample extends AnimationLoopTe
   readonly alphaModel: Model;
   readonly wboitModel: Model | null;
   readonly aBufferModel: Model | null;
+  readonly settingsPanel: ExampleSettingsPanelManager;
+  readonly panels: ExamplePanelManager;
 
   transparencyMode: TransparencyMode = 'a-buffer';
   opacity = 0.34;
@@ -282,7 +245,6 @@ export default class OrderIndependentTransparencyExample extends AnimationLoopTe
   rotationEnabled = true;
   orbitRadians = Math.PI / 6;
   lastRenderTimeSeconds: number | null = null;
-  controlCleanup: Array<() => void> = [];
 
   constructor({device}: AnimationProps) {
     super();
@@ -291,6 +253,31 @@ export default class OrderIndependentTransparencyExample extends AnimationLoopTe
     this.supportsABuffer = getABufferSupport(device).supported;
     this.supportsWeightedBlendedOit = getWBOITSupport(device).supported;
     this.transparencyMode = this.getDefaultTransparencyMode();
+    this.settingsPanel = new ExampleSettingsPanelManager({
+      id: 'a-buffer-settings',
+      schema: makeABufferSettingsSchema(this.supportsABuffer, this.supportsWeightedBlendedOit),
+      settings: {
+        transparencyMode: this.transparencyMode,
+        opacity: this.opacity,
+        sphereSize: this.sphereSize,
+        rotationEnabled: this.rotationEnabled
+      },
+      onSettingsChange: this.handleSettingsChange
+    });
+    this.panels = new ExamplePanelManager({
+      panel: makeExampleTabbedPanel({
+        id: 'a-buffer-tabs',
+        title: 'Order-independent transparency',
+        panels: [
+          makeHtmlCustomPanel({
+            id: 'a-buffer-description',
+            title: 'Description',
+            html: A_BUFFER_DESCRIPTION_HTML
+          }),
+          this.settingsPanel.makePanel()
+        ]
+      })
+    });
     this.aBufferRenderer = this.supportsABuffer
       ? new ABufferRenderer(device, {
           averageFragmentsPerPixel: 4,
@@ -332,7 +319,7 @@ export default class OrderIndependentTransparencyExample extends AnimationLoopTe
   }
 
   override async onInitialize(): Promise<void> {
-    this.initializeControls();
+    this.panels.mount();
   }
 
   override onRender({aspect, time}: AnimationProps): void {
@@ -402,10 +389,8 @@ export default class OrderIndependentTransparencyExample extends AnimationLoopTe
   }
 
   override onFinalize(): void {
-    for (const cleanup of this.controlCleanup) {
-      cleanup();
-    }
-    this.controlCleanup = [];
+    this.panels.finalize();
+    this.settingsPanel.finalize();
     this.opaqueModel.destroy();
     this.alphaModel.destroy();
     this.wboitModel?.destroy();
@@ -495,121 +480,89 @@ export default class OrderIndependentTransparencyExample extends AnimationLoopTe
     return projectionMatrix.multiplyRight(viewMatrix);
   }
 
-  private initializeControls(): void {
-    this.initializeInfoTabs();
+  private readonly handleSettingsChange = (
+    _settings: Record<string, unknown>,
+    changedSettings?: SettingsChangeDescriptor[]
+  ): void => {
+    const transparencyMode = getChangedSetting(changedSettings, 'transparencyMode')?.value;
+    const opacity = getChangedSetting(changedSettings, 'opacity')?.value;
+    const sphereSize = getChangedSetting(changedSettings, 'sphereSize')?.value;
+    const rotationEnabled = getChangedSetting(changedSettings, 'rotationEnabled')?.value;
 
-    const modeSelect = document.getElementById(MODE_SELECT_ID) as HTMLSelectElement | null;
-    const opacityInput = document.getElementById(OPACITY_INPUT_ID) as HTMLInputElement | null;
-    const opacityOutput = document.getElementById(OPACITY_OUTPUT_ID);
-    const sphereSizeInput = document.getElementById(
-      SPHERE_SIZE_INPUT_ID
-    ) as HTMLInputElement | null;
-    const sphereSizeOutput = document.getElementById(SPHERE_SIZE_OUTPUT_ID);
-    const rotationInput = document.getElementById(ROTATION_INPUT_ID) as HTMLInputElement | null;
-
-    if (modeSelect) {
-      setTransparencyOptionSupported(modeSelect, 'a-buffer', this.supportsABuffer);
-      setTransparencyOptionSupported(
-        modeSelect,
-        'weighted-blended',
-        this.supportsWeightedBlendedOit
-      );
-      modeSelect.value = this.transparencyMode;
-
-      const handleModeChange = () => {
-        if (modeSelect.value === 'weighted-blended') {
-          this.transparencyMode = 'weighted-blended';
-          return;
-        }
-        this.transparencyMode =
-          modeSelect.value === 'alpha-blending' ? 'alpha-blending' : 'a-buffer';
-      };
-      modeSelect.addEventListener('change', handleModeChange);
-      this.controlCleanup.push(() => modeSelect.removeEventListener('change', handleModeChange));
+    if (isTransparencyMode(transparencyMode)) {
+      this.transparencyMode = transparencyMode;
     }
-    if (opacityInput) {
-      const handleOpacityInput = () => {
-        this.opacity = Number(opacityInput.value);
-        if (opacityOutput) {
-          opacityOutput.textContent = this.opacity.toFixed(2);
-        }
-      };
-      opacityInput.addEventListener('input', handleOpacityInput);
-      this.controlCleanup.push(() => opacityInput.removeEventListener('input', handleOpacityInput));
+    if (typeof opacity === 'number') {
+      this.opacity = opacity;
     }
-    if (sphereSizeInput) {
-      const handleSphereSizeInput = () => {
-        this.sphereSize = Number(sphereSizeInput.value);
-        if (sphereSizeOutput) {
-          sphereSizeOutput.textContent = this.sphereSize.toFixed(1);
-        }
-      };
-      sphereSizeInput.addEventListener('input', handleSphereSizeInput);
-      this.controlCleanup.push(() =>
-        sphereSizeInput.removeEventListener('input', handleSphereSizeInput)
-      );
+    if (typeof sphereSize === 'number') {
+      this.sphereSize = sphereSize;
     }
-    if (rotationInput) {
-      const handleRotationChange = () => {
-        this.rotationEnabled = rotationInput.checked;
-      };
-      rotationInput.addEventListener('change', handleRotationChange);
-      this.controlCleanup.push(() =>
-        rotationInput.removeEventListener('change', handleRotationChange)
-      );
+    if (typeof rotationEnabled === 'boolean') {
+      this.rotationEnabled = rotationEnabled;
     }
-  }
-
-  private initializeInfoTabs(): void {
-    const tabs = Array.from(
-      document.querySelectorAll<HTMLButtonElement>('[data-a-buffer-info-tab]')
-    );
-    const panels = Array.from(document.querySelectorAll<HTMLElement>('[data-a-buffer-info-panel]'));
-
-    const setActiveInfoTab = (activeTab: InfoTab) => {
-      for (const tab of tabs) {
-        const isActive = getInfoTab(tab) === activeTab;
-        tab.setAttribute('aria-selected', String(isActive));
-        tab.tabIndex = isActive ? 0 : -1;
-        tab.style.background = isActive ? '#e0f2fe' : '#fff';
-        tab.style.borderColor = isActive ? '#7dd3fc' : '#cbd5e1';
-        tab.style.color = isActive ? '#0369a1' : '#334155';
-      }
-      for (const panel of panels) {
-        const isActive = getInfoTab(panel) === activeTab;
-        panel.hidden = !isActive;
-        panel.setAttribute('aria-hidden', String(!isActive));
-        panel.style.display = isActive ? 'grid' : 'none';
-      }
-    };
-
-    for (const tab of tabs) {
-      const infoTab = getInfoTab(tab);
-      if (!infoTab) {
-        continue;
-      }
-      const handleTabClick = () => setActiveInfoTab(infoTab);
-      tab.addEventListener('click', handleTabClick);
-      this.controlCleanup.push(() => tab.removeEventListener('click', handleTabClick));
-    }
-
-    setActiveInfoTab('controls');
-  }
+  };
 }
 
-function getInfoTab(element: HTMLElement): InfoTab | null {
-  const infoTab = element.dataset.aBufferInfoTab ?? element.dataset.aBufferInfoPanel;
-  return infoTab === 'controls' || infoTab === 'details' ? infoTab : null;
+function makeABufferSettingsSchema(
+  supportsABuffer: boolean,
+  supportsWeightedBlendedOit: boolean
+): SettingsSchema {
+  return {
+    title: 'Settings',
+    sections: [
+      {
+        id: 'rendering',
+        name: 'Rendering',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'transparencyMode',
+            label: 'Transparency',
+            type: 'select',
+            persist: 'none',
+            options: [
+              ...(supportsABuffer ? [{label: 'A-buffer OIT', value: 'a-buffer'}] : []),
+              ...(supportsWeightedBlendedOit
+                ? [{label: 'Weighted blended OIT', value: 'weighted-blended'}]
+                : []),
+              {label: 'Standard alpha blending', value: 'alpha-blending'}
+            ]
+          },
+          {
+            name: 'opacity',
+            label: 'Opacity',
+            type: 'range',
+            min: 0.1,
+            max: 0.7,
+            step: 0.01,
+            persist: 'none'
+          },
+          {
+            name: 'sphereSize',
+            label: 'Sphere size',
+            type: 'range',
+            min: 3,
+            max: 10,
+            step: 0.1,
+            persist: 'none'
+          },
+          {name: 'rotationEnabled', label: 'Rotate camera', type: 'boolean', persist: 'none'}
+        ]
+      }
+    ]
+  };
 }
 
-function setTransparencyOptionSupported(
-  modeSelect: HTMLSelectElement,
-  mode: TransparencyMode,
-  supported: boolean
-): void {
-  const option = modeSelect.querySelector<HTMLOptionElement>(`option[value="${mode}"]`);
-  if (option) {
-    option.disabled = !supported;
-    option.hidden = !supported;
-  }
+function isTransparencyMode(value: unknown): value is TransparencyMode {
+  return value === 'a-buffer' || value === 'weighted-blended' || value === 'alpha-blending';
 }
+
+const A_BUFFER_DESCRIPTION_HTML = `\
+<p>Compare exact per-pixel linked-list OIT, approximate weighted blended OIT, and unsorted alpha blending on the same interleaved scene.</p>
+<p>The dropdown renders the same unsorted translucent spheres with three different blending strategies.</p>
+<div style="display: grid; gap: 8px;">
+  <div><strong>A-buffer OIT</strong><br>Captures every translucent fragment into GPU storage, sorts fragments per pixel, then composites them back-to-front. It is the most accurate option here and is available on WebGPU.</div>
+  <div><strong>Weighted blended OIT</strong><br>Accumulates weighted color and revealage into floating-point offscreen targets, then composites once. It avoids sorting and works on WebGPU or WebGL2 when float render-target blending is available, but it is approximate.</div>
+  <div><strong>Standard alpha blending</strong><br>Blends translucent draws directly into the framebuffer in submission order. It is the cheapest fallback, but unsorted overlaps produce visibly incorrect results.</div>
+</div>`;

--- a/examples/experimental/fp64/app.tsx
+++ b/examples/experimental/fp64/app.tsx
@@ -301,7 +301,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     _settings: Record<string, unknown>,
     changedSettings?: SettingsChangeDescriptor[]
   ): void => {
-    const selectedPresetId = getChangedSetting(changedSettings, 'selectedPresetId')?.value;
+    const selectedPresetId = getChangedSetting(changedSettings, 'selectedPresetId')?.nextValue;
     if (isZoomPresetId(selectedPresetId)) {
       this.setState({selectedPresetId});
     }

--- a/examples/experimental/fp64/app.tsx
+++ b/examples/experimental/fp64/app.tsx
@@ -10,6 +10,12 @@ import {Model, ShaderInputs} from '@luma.gl/engine';
 import {fp64arithmetic, type ShaderModule} from '@luma.gl/shadertools';
 import {webgl2Adapter} from '@luma.gl/webgl';
 import {webgpuAdapter} from '@luma.gl/webgpu';
+import type {SettingsChangeDescriptor, SettingsSchema} from '@deck.gl-community/panels';
+import {
+  ExamplePanelManager,
+  ExampleSettingsPanelManager,
+  getChangedSetting
+} from '../../example-panels';
 
 type AppProps = {
   device?: Device | null;
@@ -88,6 +94,7 @@ const ZOOM_PRESETS: Record<ZoomPresetId, ZoomPreset> = {
   }
 };
 const DEFAULT_PRESET_ID: ZoomPresetId = 'seahorse';
+const FP64_SETTINGS_HOST_ID = 'fp64-settings-host';
 
 export default class App extends React.PureComponent<AppProps, AppState> {
   readonly canvasRefs = [
@@ -100,6 +107,8 @@ export default class App extends React.PureComponent<AppProps, AppState> {
   private ownsDevice = false;
   private initializationGeneration = 0;
   private isComponentMounted = false;
+  readonly settingsPanel: ExampleSettingsPanelManager;
+  readonly panels: ExamplePanelManager;
 
   constructor(props: AppProps) {
     super(props);
@@ -110,10 +119,21 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       isReady: false,
       selectedPresetId: DEFAULT_PRESET_ID
     };
+    this.settingsPanel = new ExampleSettingsPanelManager({
+      id: 'fp64-settings',
+      schema: makeFP64SettingsSchema(),
+      settings: {selectedPresetId: DEFAULT_PRESET_ID},
+      onSettingsChange: this.handleSettingsChange
+    });
+    this.panels = new ExamplePanelManager({
+      hostId: FP64_SETTINGS_HOST_ID,
+      panel: this.settingsPanel.makePanel()
+    });
   }
 
   override async componentDidMount(): Promise<void> {
     this.isComponentMounted = true;
+    this.panels.mount();
     await this.initialize();
   }
 
@@ -137,6 +157,8 @@ export default class App extends React.PureComponent<AppProps, AppState> {
   override componentWillUnmount(): void {
     this.isComponentMounted = false;
     this.initializationGeneration++;
+    this.panels.finalize();
+    this.settingsPanel.finalize();
     this.destroyResources();
   }
 
@@ -214,6 +236,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
         {initializationError ? (
           <p style={{color: '#b00020', margin: 0}}>{initializationError}</p>
         ) : null}
+        <div id={FP64_SETTINGS_HOST_ID} />
         <div
           style={{
             display: 'grid',
@@ -223,40 +246,8 @@ export default class App extends React.PureComponent<AppProps, AppState> {
             alignItems: 'start'
           }}
         >
-          {visualizationSpecs.map((visualization, index) => (
+          {visualizationSpecs.map(visualization => (
             <ExamplePaneCopy
-              control={
-                index === 0 ? (
-                  <label
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      gap: 6,
-                      marginTop: 12,
-                      maxWidth: 220
-                    }}
-                  >
-                    <span style={{fontSize: 13, fontWeight: 600}}>Zoom target</span>
-                    <select
-                      onChange={this.handlePresetChange}
-                      value={selectedPresetId}
-                      style={{
-                        border: '1px solid #c7cad1',
-                        borderRadius: 8,
-                        padding: '8px 10px',
-                        font: 'inherit',
-                        background: '#fff'
-                      }}
-                    >
-                      {Object.entries(ZOOM_PRESETS).map(([presetId, preset]) => (
-                        <option key={presetId} value={presetId}>
-                          {preset.label}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                ) : undefined
-              }
               description={visualization.description}
               key={`${visualization.kind}-copy`}
               title={visualization.title}
@@ -306,8 +297,14 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     });
   }
 
-  private handlePresetChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
-    this.setState({selectedPresetId: event.target.value as ZoomPresetId});
+  private readonly handleSettingsChange = (
+    _settings: Record<string, unknown>,
+    changedSettings?: SettingsChangeDescriptor[]
+  ): void => {
+    const selectedPresetId = getChangedSetting(changedSettings, 'selectedPresetId')?.value;
+    if (isZoomPresetId(selectedPresetId)) {
+      this.setState({selectedPresetId});
+    }
   };
 
   private handleFrame = (pixelScale: number): void => {
@@ -316,6 +313,35 @@ export default class App extends React.PureComponent<AppProps, AppState> {
       this.setState({currentZoomLabel});
     }
   };
+}
+
+function makeFP64SettingsSchema(): SettingsSchema {
+  return {
+    title: 'Settings',
+    sections: [
+      {
+        id: 'view',
+        name: 'View',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'selectedPresetId',
+            label: 'Zoom target',
+            type: 'select',
+            persist: 'none',
+            options: Object.entries(ZOOM_PRESETS).map(([value, preset]) => ({
+              label: preset.label,
+              value
+            }))
+          }
+        ]
+      }
+    ]
+  };
+}
+
+function isZoomPresetId(value: unknown): value is ZoomPresetId {
+  return value === 'seahorse' || value === 'elephant';
 }
 
 export function renderToDOM(
@@ -553,12 +579,8 @@ function getOverlayLines(zoomPreset: ZoomPreset, currentZoomLabel: string): stri
   ];
 }
 
-function ExamplePaneCopy(props: {
-  control?: React.ReactNode;
-  description: string;
-  title: string;
-}): React.ReactNode {
-  const {control, description, title} = props;
+function ExamplePaneCopy(props: {description: string; title: string}): React.ReactNode {
+  const {description, title} = props;
 
   return (
     <div
@@ -577,7 +599,6 @@ function ExamplePaneCopy(props: {
       >
         <h3 style={{marginTop: 0, marginBottom: 6}}>{title}</h3>
         <p style={{margin: 0, lineHeight: 1.45}}>{description}</p>
-        {control}
       </div>
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@vis.gl/ts-plugins": "^1.0.2",
     "@vitest/browser": "^4.0.18",
     "@vitest/browser-playwright": "^4.0.18",
+    "@vitest/coverage-istanbul": "4.1.0",
     "@vitest/coverage-v8": "^4.0.18",
     "a5-js": "^0.8.0",
     "h3-js": "^4.4.0",

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -1056,13 +1056,15 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   width: 100%;
 }
 
-body:has(.luma-example-page) .theme-doc-sidebar-container {
-  display: none;
-}
+@media screen and (max-width: 996px) {
+  body:has(.luma-example-page) .theme-doc-sidebar-container {
+    display: none;
+  }
 
-body:has(.luma-example-page) .theme-doc-sidebar-container + main {
-  width: 100%;
-  max-width: none;
+  body:has(.luma-example-page) .theme-doc-sidebar-container + main {
+    width: 100%;
+    max-width: none;
+  }
 }
 
 body:has(.luma-example-page) .theme-layout-footer,

--- a/website/src/react-luma/components/example-stats.tsx
+++ b/website/src/react-luma/components/example-stats.tsx
@@ -1,0 +1,268 @@
+import React, {type CSSProperties, type FC, useEffect, useRef} from 'react';
+import {Device, luma} from '@luma.gl/core';
+import type {Stat, Stats} from '@probe.gl/stats';
+import {StatsWidget} from '@probe.gl/stats-widget';
+
+const STAT_STYLES = {
+  position: 'relative',
+  fontSize: '12px',
+  color: '#fff',
+  background: '#000',
+  padding: '8px',
+  opacity: 0.8,
+  borderRadius: '8px',
+  fontFamily: 'monospace'
+};
+
+const STATS_CONTAINER_STYLE: CSSProperties = {
+  position: 'absolute',
+  right: '12px',
+  bottom: '12px',
+  zIndex: 10,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+  maxHeight: 'calc(100% - 24px)',
+  overflowY: 'auto',
+  overflowX: 'hidden',
+  alignItems: 'flex-end'
+};
+
+const GPU_TIME_AND_MEMORY_STATS_FORMATTERS = {
+  'CPU Time': (stat: Stat) => `${stat.name}: ${stat.getSampleAverageTime().toFixed(2)}ms`,
+  'GPU Time': (stat: Stat) => `${stat.name}: ${stat.getSampleAverageTime().toFixed(2)}ms`,
+  'GPU Memory': 'memory',
+  'Buffer Memory': 'memory',
+  'Texture Memory': 'memory',
+  'External Buffer Memory': 'memory',
+  'External Texture Memory': 'memory',
+  'Swap Chain Texture': 'memory'
+} as const;
+
+const FRAME_RATE_SAMPLE_COUNT = 60;
+const statsWidgetCollapsedStateByTitle: Record<string, boolean> = {};
+
+type StatFormatter = (stat: Stat) => string;
+type FrameRateController = {
+  formatFrameRate: StatFormatter;
+  start: () => void;
+  stop: () => void;
+  update: () => void;
+};
+
+type ExampleStatsProps = {
+  device?: Device | null;
+  trackSwapChainTextureMemory?: boolean;
+  style?: CSSProperties;
+};
+
+/** Stats widgets shared by React examples and animation-loop examples. */
+export const ExampleStats: FC<ExampleStatsProps> = (props: ExampleStatsProps) => {
+  const statsPanelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const statsPanelElement = statsPanelRef.current;
+    if (!statsPanelElement) {
+      return;
+    }
+
+    const resourceCounts = luma.stats.get('GPU Resource Counts');
+    const gpuTimeAndMemoryStats = luma.stats.get('GPU Time and Memory');
+    const frameRateController = createFrameRateController(gpuTimeAndMemoryStats);
+    const swapChainTextureStat = gpuTimeAndMemoryStats.get('Swap Chain Texture');
+    const gpuMemoryStat = gpuTimeAndMemoryStats.get('GPU Memory');
+    let previousSwapChainTextureMemory = 0;
+
+    const updateSwapChainTextureMemory = () => {
+      if (!props.trackSwapChainTextureMemory || !props.device) {
+        return;
+      }
+
+      const nextSwapChainTextureMemory = getDefaultCanvasColorTextureByteLength(props.device);
+      const delta = nextSwapChainTextureMemory - previousSwapChainTextureMemory;
+      if (delta > 0) {
+        swapChainTextureStat.addCount(delta);
+        gpuMemoryStat.addCount(delta);
+      } else if (delta < 0) {
+        swapChainTextureStat.subtractCount(-delta);
+        gpuMemoryStat.subtractCount(-delta);
+      }
+      previousSwapChainTextureMemory = nextSwapChainTextureMemory;
+    };
+
+    statsPanelElement.replaceChildren();
+    frameRateController.start();
+    updateSwapChainTextureMemory();
+
+    const statsWidgets = [
+      new StatsWidget(gpuTimeAndMemoryStats, {
+        title: getStatsTitle(gpuTimeAndMemoryStats),
+        container: statsPanelElement,
+        css: STAT_STYLES,
+        formatters: getGpuTimeAndMemoryStatFormatters(
+          props.device ?? null,
+          frameRateController.formatFrameRate
+        )
+      }),
+      new StatsWidget(resourceCounts, {
+        title: getStatsTitle(resourceCounts),
+        container: statsPanelElement,
+        css: STAT_STYLES
+      })
+    ];
+
+    for (const statsWidget of statsWidgets) {
+      statsWidget.setCollapsed(getStatsWidgetCollapsedState(statsWidget));
+    }
+
+    const updateStatsWidgets = () => {
+      updateSwapChainTextureMemory();
+      frameRateController.update();
+      for (const statsWidget of statsWidgets) {
+        statsWidget.update();
+      }
+    };
+
+    updateStatsWidgets();
+    const statsIntervalId = window.setInterval(updateStatsWidgets, 250);
+
+    return () => {
+      window.clearInterval(statsIntervalId);
+      frameRateController.stop();
+      if (previousSwapChainTextureMemory > 0) {
+        swapChainTextureStat.subtractCount(previousSwapChainTextureMemory);
+        gpuMemoryStat.subtractCount(previousSwapChainTextureMemory);
+      }
+      for (const statsWidget of statsWidgets) {
+        storeStatsWidgetCollapsedState(statsWidget);
+        statsWidget.remove();
+      }
+      statsPanelElement.replaceChildren();
+    };
+  }, [props.device, props.trackSwapChainTextureMemory]);
+
+  return <div ref={statsPanelRef} style={{...STATS_CONTAINER_STYLE, ...props.style}} />;
+};
+
+function getStatsTitle(stats: Stats): string {
+  return stats.id === 'GPU Time and Memory' ? 'GPU Time & Memory' : stats.id;
+}
+
+function getStatsWidgetCollapsedState(statsWidget: StatsWidget): boolean {
+  return statsWidget.title ? (statsWidgetCollapsedStateByTitle[statsWidget.title] ?? true) : true;
+}
+
+function storeStatsWidgetCollapsedState(statsWidget: StatsWidget): void {
+  if (statsWidget.title) {
+    statsWidgetCollapsedStateByTitle[statsWidget.title] = statsWidget.collapsed;
+  }
+}
+
+function getGpuTimeAndMemoryStatFormatters(
+  device: Device | null,
+  frameRateFormatter: StatFormatter
+): Record<string, string | StatFormatter> {
+  return {
+    'Frame Rate': frameRateFormatter,
+    ...GPU_TIME_AND_MEMORY_STATS_FORMATTERS,
+    Adapter: () => `Adapter: ${getAdapterLabel(device)}`,
+    GPU: () => `GPU: ${device?.info.gpu || 'unknown'}`,
+    'GPU Type': () => `GPU Type: ${device?.info.gpuType || 'unknown'}`,
+    'GPU Backend': () => `GPU Backend: ${device?.info.gpuBackend || 'unknown'}`
+  };
+}
+
+function getAdapterLabel(device: Device | null): string {
+  switch (device?.type) {
+    case 'webgl':
+      return 'WebGL 2';
+    case 'webgpu':
+      return 'WebGPU';
+    default:
+      return 'Unknown';
+  }
+}
+
+function createFrameRateController(stats: Stats): FrameRateController {
+  const frameRateStat = stats.get('Frame Rate');
+  const cpuTimeStat = stats.get('CPU Time');
+  const gpuTimeStat = stats.get('GPU Time');
+  const frameDurations: number[] = [];
+  let frameDurationTotal = 0;
+  let previousFrameTimestamp = 0;
+  let currentFrameRate = 0;
+  let animationFrameId: number | null = null;
+
+  const reset = () => {
+    frameDurations.length = 0;
+    frameDurationTotal = 0;
+    previousFrameTimestamp = 0;
+    currentFrameRate = 0;
+    frameRateStat.reset();
+  };
+
+  const getAverageFrameDuration = () =>
+    frameDurations.length > 0 ? frameDurationTotal / frameDurations.length : 0;
+
+  const getStatDuration = (stat: Stat) => {
+    const sampleAverageTime = stat.getSampleAverageTime();
+    return sampleAverageTime > 0 ? sampleAverageTime : stat.getAverageTime();
+  };
+
+  const updateFrameRateStat = () => {
+    const estimatedFrameDuration = Math.max(
+      getAverageFrameDuration(),
+      getStatDuration(cpuTimeStat),
+      getStatDuration(gpuTimeStat)
+    );
+    currentFrameRate = estimatedFrameDuration > 0 ? 1000 / estimatedFrameDuration : 0;
+    frameRateStat.count = currentFrameRate;
+    frameRateStat.lastTiming = estimatedFrameDuration;
+    frameRateStat.lastSampleTime = estimatedFrameDuration;
+    frameRateStat.lastSampleCount = currentFrameRate;
+  };
+
+  const trackFrame = (timestamp: number) => {
+    if (previousFrameTimestamp > 0) {
+      const frameDuration = timestamp - previousFrameTimestamp;
+      if (frameDuration > 0) {
+        frameDurations.push(frameDuration);
+        frameDurationTotal += frameDuration;
+        if (frameDurations.length > FRAME_RATE_SAMPLE_COUNT) {
+          frameDurationTotal -= frameDurations.shift() || 0;
+        }
+      }
+    }
+
+    previousFrameTimestamp = timestamp;
+    animationFrameId = window.requestAnimationFrame(trackFrame);
+  };
+
+  return {
+    formatFrameRate: stat =>
+      `${stat.name}: ${currentFrameRate.toFixed(currentFrameRate >= 10 ? 0 : 1)}fps`,
+    start: () => {
+      reset();
+      animationFrameId = window.requestAnimationFrame(trackFrame);
+    },
+    stop: () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+        animationFrameId = null;
+      }
+      reset();
+    },
+    update: updateFrameRateStat
+  };
+}
+
+function getDefaultCanvasColorTextureByteLength(device: Device): number {
+  const canvasContext = device.canvasContext;
+  if (!canvasContext) {
+    return 0;
+  }
+
+  const [width, height] = canvasContext.getDrawingBufferSize();
+  const formatInfo = device.getTextureFormatInfo(device.preferredColorFormat);
+  return width * height * (formatInfo.bytesPerPixel || 0);
+}

--- a/website/src/react-luma/components/info-box.tsx
+++ b/website/src/react-luma/components/info-box.tsx
@@ -1,0 +1,535 @@
+import React, {CSSProperties, FC, useEffect, useRef, useState} from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import CodeBlock from '@theme/CodeBlock';
+import {PanelContainer, type Panel, type PanelPlacement} from '@deck.gl-community/panels';
+import {createRoot, type Root} from 'react-dom/client';
+import {
+  configurePanelHostElement,
+  renderExamplePanel
+} from '../../../../examples/example-panels';
+
+const GITHUB_TREE = 'https://github.com/visgl/luma.gl/tree/master';
+const INFO_BOX_DEFAULT_WIDTH = 420;
+const INFO_BOX_MIN_WIDTH = 280;
+const INFO_BOX_MIN_HEIGHT = 160;
+const INFO_BOX_VIEWPORT_RIGHT_MARGIN = 20;
+const INFO_BOX_VIEWPORT_BOTTOM_MARGIN = 12;
+const INFO_BOX_KEYBOARD_RESIZE_STEP = 10;
+const INFO_BOX_LARGE_KEYBOARD_RESIZE_STEP = 30;
+const INFO_BOX_STYLE: CSSProperties = {
+  boxSizing: 'border-box',
+  boxShadow: '0 12px 32px rgba(0, 0, 0, 0.28)',
+  backgroundColor: 'rgba(255, 255, 255, 0.96)',
+  borderRadius: 12,
+  color: '#111',
+  width: 420,
+  minWidth: 0,
+  maxWidth: 'calc(100vw - 40px)',
+  overflow: 'hidden',
+  padding: '10px 16px',
+  zIndex: 10
+};
+
+let isInfoBoxCollapsedByDefault = true;
+
+export type ExampleInfoProps = {
+  directory?: string;
+  id?: string;
+  sourceDirectory?: string;
+  sourcePath?: string;
+  title?: string;
+};
+
+export type InfoBoxProps = React.PropsWithChildren<
+  ExampleInfoProps & {
+    html?: string;
+    panel?: Panel;
+    style?: CSSProperties;
+  }
+>;
+
+type InfoBoxViewProps = InfoBoxProps & {
+  websiteBaseUrl: string;
+};
+
+type InfoBoxSize = {
+  width: number;
+  height: number;
+};
+
+type InfoBoxResizeState = {
+  pointerId: number;
+  startX: number;
+  startY: number;
+  startWidth: number;
+  startHeight: number;
+};
+
+/** Panel-framework mount for the website InfoBox chrome and panel content. */
+export class InfoBoxPanelContainer extends PanelContainer {
+  className = 'luma-info-box-panel-container';
+  placement: PanelPlacement = 'top-left';
+  private infoBoxProps: InfoBoxViewProps;
+  private hostElement: HTMLElement | null = null;
+  private reactRoot: Root | null = null;
+
+  constructor(props: InfoBoxViewProps) {
+    super({panel: props.panel, placement: 'top-left'});
+    this.infoBoxProps = props;
+  }
+
+  setInfoBoxProps(props: InfoBoxViewProps): void {
+    this.infoBoxProps = props;
+    this.setProps({panel: props.panel});
+  }
+
+  renderReact(): React.ReactElement {
+    return <InfoBoxView {...this.infoBoxProps} />;
+  }
+
+  override onRenderHTML(rootElement: HTMLElement): void {
+    if (this.hostElement !== rootElement) {
+      this.reactRoot?.unmount();
+      this.hostElement = rootElement;
+      this.reactRoot = createRoot(rootElement);
+    }
+    this.reactRoot?.render(this.renderReact());
+  }
+
+  override onRemove(): void {
+    this.reactRoot?.unmount();
+    this.reactRoot = null;
+    this.hostElement = null;
+  }
+}
+
+/** React adapter that mounts the panel-backed InfoBox into Docusaurus content. */
+export const InfoBox: FC<InfoBoxProps> = (props: InfoBoxProps) => {
+  const {siteConfig} = useDocusaurusContext();
+  const websiteBaseUrl = siteConfig.baseUrl.endsWith('/')
+    ? siteConfig.baseUrl
+    : `${siteConfig.baseUrl}/`;
+  const containerRef = useRef<InfoBoxPanelContainer | null>(null);
+  const infoBoxProps = {...props, websiteBaseUrl};
+
+  containerRef.current ||= new InfoBoxPanelContainer(infoBoxProps);
+  containerRef.current.setInfoBoxProps(infoBoxProps);
+  return containerRef.current.renderReact();
+};
+
+function InfoBoxView(props: InfoBoxViewProps) {
+  const sourceUrl = getExampleSourceUrl(props);
+  const sourcePaths = React.useMemo(
+    () => getExampleSourcePaths(props),
+    [props.directory, props.id, props.sourceDirectory, props.sourcePath]
+  );
+  const sourcePathsKey = sourcePaths.join('|');
+  const title = getExampleTitle(props.id, props.title);
+  const [isCollapsed, setIsCollapsed] = useState(() => isInfoBoxCollapsedByDefault);
+  const [activeTab, setActiveTab] = useState<'info' | 'source'>('info');
+  const [infoBoxSize, setInfoBoxSize] = useState<InfoBoxSize | null>(null);
+  const [sourceResult, setSourceResult] = useState<{
+    key: string;
+    path?: string;
+    source?: string;
+    error?: string;
+  } | null>(null);
+  const infoBoxRef = useRef<HTMLDivElement | null>(null);
+  const infoContentRef = useRef<HTMLDivElement | null>(null);
+  const panelHostRef = useRef<HTMLDivElement | null>(null);
+  const resizeStateRef = useRef<InfoBoxResizeState | null>(null);
+  const [hasPanelTabs, setHasPanelTabs] = useState(false);
+  const toggleCollapsed = () => setIsCollapsed(value => !value);
+  const currentSourceResult = sourceResult?.key === sourcePathsKey ? sourceResult : null;
+
+  useEffect(() => {
+    isInfoBoxCollapsedByDefault = isCollapsed;
+  }, [isCollapsed]);
+
+  useEffect(() => {
+    if (activeTab !== 'source' || sourcePaths.length === 0 || currentSourceResult) {
+      return;
+    }
+
+    const abortController = new AbortController();
+    void fetchExampleSource(props.websiteBaseUrl, sourcePaths, abortController.signal)
+      .then(({path, source}) => {
+        setSourceResult({key: sourcePathsKey, path, source});
+      })
+      .catch(error => {
+        if (!abortController.signal.aborted) {
+          setSourceResult({
+            key: sourcePathsKey,
+            error: error instanceof Error ? error.message : 'Unable to load source code.'
+          });
+        }
+      });
+
+    return () => abortController.abort();
+  }, [activeTab, currentSourceResult, props.websiteBaseUrl, sourcePaths, sourcePathsKey]);
+
+  useEffect(() => {
+    const infoContentElement = infoContentRef.current;
+    if (!infoContentElement || sourcePaths.length === 0) {
+      setHasPanelTabs(false);
+      return;
+    }
+
+    const updateHasPanelTabs = () => {
+      setHasPanelTabs(Boolean(infoContentElement.querySelector('[data-panel-tabs]')));
+    };
+
+    updateHasPanelTabs();
+    const observer = new MutationObserver(updateHasPanelTabs);
+    observer.observe(infoContentElement, {childList: true, subtree: true});
+    return () => observer.disconnect();
+  }, [sourcePaths.length]);
+
+  useEffect(() => {
+    const panelHostElement = panelHostRef.current;
+    if (!panelHostElement || !props.panel) {
+      return;
+    }
+
+    configurePanelHostElement(panelHostElement);
+    renderExamplePanel(panelHostElement, props.panel);
+    return () => renderExamplePanel(panelHostElement, null);
+  }, [props.panel]);
+
+  const handleResizePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
+    const infoBoxElement = infoBoxRef.current;
+    if (!infoBoxElement) {
+      return;
+    }
+
+    const rect = infoBoxElement.getBoundingClientRect();
+    resizeStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      startWidth: rect.width,
+      startHeight: rect.height
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    event.preventDefault();
+  };
+
+  const handleResizePointerMove = (event: React.PointerEvent<HTMLButtonElement>) => {
+    const infoBoxElement = infoBoxRef.current;
+    const resizeState = resizeStateRef.current;
+    if (!infoBoxElement || !resizeState || resizeState.pointerId !== event.pointerId) {
+      return;
+    }
+
+    setInfoBoxSize(
+      clampInfoBoxSize(
+        infoBoxElement,
+        resizeState.startWidth + event.clientX - resizeState.startX,
+        resizeState.startHeight + event.clientY - resizeState.startY
+      )
+    );
+  };
+
+  const finishResize = (event: React.PointerEvent<HTMLButtonElement>) => {
+    if (resizeStateRef.current?.pointerId !== event.pointerId) {
+      return;
+    }
+
+    resizeStateRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const handleResizeKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    const infoBoxElement = infoBoxRef.current;
+    if (!infoBoxElement) {
+      return;
+    }
+
+    const resizeStep = event.shiftKey
+      ? INFO_BOX_LARGE_KEYBOARD_RESIZE_STEP
+      : INFO_BOX_KEYBOARD_RESIZE_STEP;
+    const widthDelta =
+      event.key === 'ArrowLeft' ? -resizeStep : event.key === 'ArrowRight' ? resizeStep : 0;
+    const heightDelta =
+      event.key === 'ArrowUp' ? -resizeStep : event.key === 'ArrowDown' ? resizeStep : 0;
+    if (widthDelta === 0 && heightDelta === 0) {
+      return;
+    }
+
+    const rect = infoBoxElement.getBoundingClientRect();
+    setInfoBoxSize(currentSize =>
+      clampInfoBoxSize(
+        infoBoxElement,
+        (currentSize?.width ?? rect.width) + widthDelta,
+        (currentSize?.height ?? rect.height) + heightDelta
+      )
+    );
+    event.preventDefault();
+  };
+
+  const sourceContent = currentSourceResult?.error ? (
+    <p style={{margin: 0, color: '#b00020'}}>{currentSourceResult.error}</p>
+  ) : (
+    <CodeBlock language={currentSourceResult?.path?.endsWith('.tsx') ? 'tsx' : 'typescript'}>
+      {currentSourceResult?.source ?? '// Loading source…'}
+    </CodeBlock>
+  );
+
+  return (
+    <div
+      ref={infoBoxRef}
+      style={{
+        ...INFO_BOX_STYLE,
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative',
+        width: infoBoxSize?.width ?? INFO_BOX_DEFAULT_WIDTH,
+        height: isCollapsed ? undefined : infoBoxSize?.height,
+        maxHeight: isCollapsed ? undefined : 'calc(100vh - var(--ifm-navbar-height) - 24px)',
+        ...props.style
+      }}
+    >
+      <div style={{display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 12}}>
+        <button
+          type="button"
+          aria-label={isCollapsed ? 'Expand info box' : 'Collapse info box'}
+          onClick={toggleCollapsed}
+          style={{
+            minWidth: 0,
+            flex: '1 1 auto',
+            padding: 0,
+            border: 'none',
+            background: 'transparent',
+            textAlign: 'left',
+            cursor: 'pointer',
+            color: 'inherit'
+          }}
+        >
+          {title ? <h3 style={{marginTop: 0, marginBottom: 0}}>{title}</h3> : null}
+        </button>
+        <div style={{display: 'flex', alignItems: 'center', gap: 24, flexShrink: 0}}>
+          {sourceUrl ? (
+            <a href={sourceUrl} target="_blank" rel="noreferrer">
+              GitHub
+            </a>
+          ) : null}
+          <button
+            type="button"
+            aria-label={isCollapsed ? 'Expand info box' : 'Collapse info box'}
+            onClick={toggleCollapsed}
+            style={{
+              flexShrink: 0,
+              border: '1px solid #d0d7de',
+              background: '#fff',
+              borderRadius: 999,
+              minWidth: 56,
+              padding: '0 12px',
+              height: 28,
+              fontSize: 14,
+              lineHeight: 1,
+              whiteSpace: 'nowrap',
+              cursor: 'pointer'
+            }}
+          >
+            {isCollapsed ? 'Info' : 'Hide'}
+          </button>
+        </div>
+      </div>
+      <div
+        hidden={isCollapsed}
+        aria-hidden={isCollapsed}
+        style={{
+          marginTop: isCollapsed ? 0 : 12,
+          minWidth: 0,
+          minHeight: 0,
+          flex: '1 1 auto',
+          display: isCollapsed ? 'none' : 'flex',
+          flexDirection: 'column',
+          overflowY: 'auto'
+        }}
+      >
+        {sourcePaths.length > 0 && !hasPanelTabs ? (
+          <div role="tablist" aria-label="Example information" style={{display: 'flex', gap: 4, marginBottom: 12}}>
+            {(['info', 'source'] as const).map(tab => (
+              <button
+                key={tab}
+                type="button"
+                role="tab"
+                aria-selected={activeTab === tab}
+                onClick={() => setActiveTab(tab)}
+                style={{
+                  border: '1px solid #cbd5e1',
+                  borderRadius: 6,
+                  padding: '4px 9px',
+                  background: activeTab === tab ? '#e2e8f0' : '#fff',
+                  color: '#0f172a',
+                  cursor: 'pointer',
+                  fontSize: 12,
+                  fontWeight: activeTab === tab ? 700 : 500
+                }}
+              >
+                {tab === 'info' ? 'Info' : 'Source'}
+              </button>
+            ))}
+          </div>
+        ) : null}
+        <div
+          ref={infoContentRef}
+          hidden={!hasPanelTabs && activeTab !== 'info'}
+          aria-hidden={!hasPanelTabs && activeTab !== 'info'}
+          style={{minWidth: 0, minHeight: 0, flex: '1 1 auto', overflow: 'auto'}}
+        >
+          {props.html ? <div dangerouslySetInnerHTML={{__html: props.html}} /> : null}
+          {props.children}
+          {props.panel ? <div ref={panelHostRef} /> : null}
+        </div>
+        {sourcePaths.length > 0 && !hasPanelTabs ? (
+          <div
+            hidden={activeTab !== 'source'}
+            aria-hidden={activeTab !== 'source'}
+            style={{
+              minWidth: 0,
+              minHeight: 0,
+              flex: '1 1 auto',
+              maxWidth: '100%',
+              overflow: 'auto',
+              background: '#f6f8fa'
+            }}
+          >
+            {sourceContent}
+          </div>
+        ) : null}
+      </div>
+      {!isCollapsed ? (
+        <button
+          type="button"
+          aria-label="Resize info box"
+          title="Resize info box"
+          onPointerDown={handleResizePointerDown}
+          onPointerMove={handleResizePointerMove}
+          onPointerUp={finishResize}
+          onPointerCancel={finishResize}
+          onKeyDown={handleResizeKeyDown}
+          style={{
+            position: 'absolute',
+            right: 6,
+            bottom: 6,
+            zIndex: 100,
+            display: 'grid',
+            placeItems: 'center',
+            width: 28,
+            height: 28,
+            padding: 0,
+            border: '1px solid #94a3b8',
+            borderRadius: 6,
+            background: '#e2e8f0',
+            boxShadow: '0 1px 3px rgba(15, 23, 42, 0.18)',
+            color: '#334155',
+            cursor: 'nwse-resize',
+            fontSize: 19,
+            lineHeight: 1,
+            touchAction: 'none',
+            userSelect: 'none'
+          }}
+        >
+          <svg aria-hidden="true" viewBox="0 0 16 16" width="16" height="16">
+            <path
+              d="M4 14L14 4M9 14L14 9M13 14L14 13"
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeWidth="1.75"
+            />
+          </svg>
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function getInfoBoxSizeBounds(infoBoxElement: HTMLElement): {
+  minWidth: number;
+  minHeight: number;
+  maxWidth: number;
+  maxHeight: number;
+} {
+  const rect = infoBoxElement.getBoundingClientRect();
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+  const maxWidth = Math.max(1, viewportWidth - rect.left - INFO_BOX_VIEWPORT_RIGHT_MARGIN);
+  const maxHeight = Math.max(1, viewportHeight - rect.top - INFO_BOX_VIEWPORT_BOTTOM_MARGIN);
+
+  return {
+    minWidth: Math.min(INFO_BOX_MIN_WIDTH, maxWidth),
+    minHeight: Math.min(INFO_BOX_MIN_HEIGHT, maxHeight),
+    maxWidth,
+    maxHeight
+  };
+}
+
+function clampInfoBoxSize(infoBoxElement: HTMLElement, width: number, height: number): InfoBoxSize {
+  const {minWidth, minHeight, maxWidth, maxHeight} = getInfoBoxSizeBounds(infoBoxElement);
+  return {
+    width: Math.min(maxWidth, Math.max(minWidth, width)),
+    height: Math.min(maxHeight, Math.max(minHeight, height))
+  };
+}
+
+function getExampleSourceUrl(props: ExampleInfoProps): string | null {
+  if (props.sourcePath) {
+    return `${GITHUB_TREE}/${props.sourcePath}`;
+  }
+  if (props.id && (props.sourceDirectory || props.directory)) {
+    const sourceDirectory = props.sourceDirectory || props.directory;
+    return `${GITHUB_TREE}/examples/${sourceDirectory}/${props.id}`;
+  }
+  return null;
+}
+
+function getExampleSourcePaths(props: ExampleInfoProps): string[] {
+  if (props.sourcePath) {
+    const sourcePath = props.sourcePath.replace(/^\/?examples\//, '').replace(/^\//, '');
+    if (/\.(?:[cm]?[jt]sx?)$/.test(sourcePath)) {
+      return [sourcePath];
+    }
+    return [`${sourcePath}/app.ts`, `${sourcePath}/app.tsx`];
+  }
+
+  if (props.id && (props.sourceDirectory || props.directory)) {
+    const sourceDirectory = props.sourceDirectory || props.directory;
+    return [`${sourceDirectory}/${props.id}/app.ts`, `${sourceDirectory}/${props.id}/app.tsx`];
+  }
+
+  return [];
+}
+
+async function fetchExampleSource(
+  websiteBaseUrl: string,
+  sourcePaths: readonly string[],
+  signal: AbortSignal
+): Promise<{path: string; source: string}> {
+  for (const sourcePath of sourcePaths) {
+    const response = await fetch(`${websiteBaseUrl}example-assets/${sourcePath}`, {signal});
+    if (response.ok) {
+      return {path: sourcePath, source: await response.text()};
+    }
+  }
+
+  throw new Error('Unable to load source code.');
+}
+
+function getExampleTitle(id?: string, title?: string): string {
+  if (title) {
+    return title;
+  }
+  if (id) {
+    return id.split('-').map(capitalizeFirstLetter).join(' ');
+  }
+  return '';
+}
+
+function capitalizeFirstLetter(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -1,16 +1,10 @@
 import React, {CSSProperties, FC, useEffect, useRef, useState} from 'react'; // eslint-disable-line
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import CodeBlock from '@theme/CodeBlock';
-import type {Panel} from '@deck.gl-community/panels';
 import {Device, luma} from '@luma.gl/core';
 import {AnimationLoopTemplate, AnimationLoop, makeAnimationLoop, setPathPrefix} from '@luma.gl/engine';
-import {StatsWidget} from '@probe.gl/stats-widget';
-import type {Stat, Stats} from '@probe.gl/stats';
-import {
-  configurePanelHostElement,
-  renderExamplePanel
-} from '../../../../examples/example-panels';
 import {DeviceTabs, type DeviceTabSelection} from './device-tabs';
+import {ExampleStats} from './example-stats';
+import {InfoBox, type ExampleInfoProps} from './info-box';
 import {
   clearActiveCpuHotspotProfilerDevice,
   setActiveCpuHotspotProfilerDevice
@@ -27,9 +21,6 @@ import {
   useStore
 } from '../store/device-store';
 
-const GITHUB_TREE = 'https://github.com/visgl/luma.gl/tree/master';
-let isInfoBoxCollapsedByDefault = true;
-const statsWidgetCollapsedStateByTitle: Record<string, boolean> = {};
 let currentLumaExampleTask: Promise<void> = Promise.resolve();
 
 // WORKAROUND FOR luma.gl VRDisplay
@@ -50,186 +41,6 @@ const STYLES = {
     height: '100vh'
   }
 };
-
-const STAT_STYLES = {
-  position: 'relative',
-  fontSize: '12px',
-  color: '#fff',
-  background: '#000',
-  padding: '8px',
-  opacity: 0.8,
-  borderRadius: '8px',
-  fontFamily: 'monospace'
-};
-
-const GPU_TIME_AND_MEMORY_STATS_FORMATTERS = {
-  'CPU Time': (stat: Stat) => `${stat.name}: ${stat.getSampleAverageTime().toFixed(2)}ms`,
-  'GPU Time': (stat: Stat) => `${stat.name}: ${stat.getSampleAverageTime().toFixed(2)}ms`,
-  'GPU Memory': 'memory',
-  'Buffer Memory': 'memory',
-  'Texture Memory': 'memory',
-  'External Buffer Memory': 'memory',
-  'External Texture Memory': 'memory',
-  'Swap Chain Texture': 'memory'
-} as const;
-
-type StatFormatter = (stat: Stat) => string;
-type FrameRateController = {
-  formatFrameRate: StatFormatter;
-  start: () => void;
-  stop: () => void;
-  update: () => void;
-};
-
-const FRAME_RATE_SAMPLE_COUNT = 60;
-
-function getStatsTitle(stats: Stats): string {
-  const title = stats.id;
-  if (title === 'GPU Time and Memory') {
-    return 'GPU Time & Memory';
-  }
-  return title;
-}
-
-function initializeGpuTimeAndMemoryStats() {
-  return luma.stats.get('GPU Time and Memory');
-}
-
-function getStatsWidgetCollapsedState(statsWidget: StatsWidget): boolean {
-  return statsWidget.title ? (statsWidgetCollapsedStateByTitle[statsWidget.title] ?? true) : true;
-}
-
-function storeStatsWidgetCollapsedState(statsWidget: StatsWidget): void {
-  if (statsWidget.title) {
-    statsWidgetCollapsedStateByTitle[statsWidget.title] = statsWidget.collapsed;
-  }
-}
-
-function getAdapterLabel(device: Device | null): string {
-  switch (device?.type) {
-    case 'webgl':
-      return 'WebGL 2';
-    case 'webgpu':
-      return 'WebGPU';
-    default:
-      return 'Unknown';
-  }
-}
-
-function getGpuLabel(device: Device | null): string {
-  return device?.info.gpu || 'unknown';
-}
-
-function getGpuTypeLabel(device: Device | null): string {
-  return device?.info.gpuType || 'unknown';
-}
-
-function getGpuBackendLabel(device: Device | null): string {
-  return device?.info.gpuBackend || 'unknown';
-}
-
-function getGpuTimeAndMemoryStatFormatters(
-  device: Device | null,
-  frameRateFormatter?: StatFormatter
-): Record<string, string | StatFormatter> {
-  return {
-    'Frame Rate':
-      frameRateFormatter || ((stat: Stat) => `${stat.name}: ${Math.round(stat.count)}fps`),
-    ...GPU_TIME_AND_MEMORY_STATS_FORMATTERS,
-    Adapter: () => `Adapter: ${getAdapterLabel(device)}`,
-    GPU: () => `GPU: ${getGpuLabel(device)}`,
-    'GPU Type': () => `GPU Type: ${getGpuTypeLabel(device)}`,
-    'GPU Backend': () => `GPU Backend: ${getGpuBackendLabel(device)}`
-  };
-}
-
-function createFrameRateController(stats: Stats): FrameRateController {
-  const frameRateStat = stats.get('Frame Rate');
-  const cpuTimeStat = stats.get('CPU Time');
-  const gpuTimeStat = stats.get('GPU Time');
-  const frameDurations: number[] = [];
-  let frameDurationTotal = 0;
-  let previousFrameTimestamp = 0;
-  let currentFrameRate = 0;
-  let animationFrameId: number | null = null;
-
-  const reset = () => {
-    frameDurations.length = 0;
-    frameDurationTotal = 0;
-    previousFrameTimestamp = 0;
-    currentFrameRate = 0;
-    frameRateStat.reset();
-  };
-
-  const getAverageFrameDuration = () =>
-    frameDurations.length > 0 ? frameDurationTotal / frameDurations.length : 0;
-
-  const getStatDuration = (stat: Stat) => {
-    const sampleAverageTime = stat.getSampleAverageTime();
-    if (sampleAverageTime > 0) {
-      return sampleAverageTime;
-    }
-
-    return stat.getAverageTime();
-  };
-
-  const updateFrameRateStat = () => {
-    const estimatedFrameDuration = Math.max(
-      getAverageFrameDuration(),
-      getStatDuration(cpuTimeStat),
-      getStatDuration(gpuTimeStat)
-    );
-    currentFrameRate = estimatedFrameDuration > 0 ? 1000 / estimatedFrameDuration : 0;
-    frameRateStat.count = currentFrameRate;
-    frameRateStat.lastTiming = estimatedFrameDuration;
-    frameRateStat.lastSampleTime = estimatedFrameDuration;
-    frameRateStat.lastSampleCount = currentFrameRate;
-  };
-
-  const trackFrame = (timestamp: number) => {
-    if (previousFrameTimestamp > 0) {
-      const frameDuration = timestamp - previousFrameTimestamp;
-      if (frameDuration > 0) {
-        frameDurations.push(frameDuration);
-        frameDurationTotal += frameDuration;
-        if (frameDurations.length > FRAME_RATE_SAMPLE_COUNT) {
-          frameDurationTotal -= frameDurations.shift() || 0;
-        }
-      }
-    }
-
-    previousFrameTimestamp = timestamp;
-    animationFrameId = window.requestAnimationFrame(trackFrame);
-  };
-
-  return {
-    formatFrameRate: stat =>
-      `${stat.name}: ${currentFrameRate.toFixed(currentFrameRate >= 10 ? 0 : 1)}fps`,
-    start: () => {
-      reset();
-      animationFrameId = window.requestAnimationFrame(trackFrame);
-    },
-    stop: () => {
-      if (animationFrameId !== null) {
-        window.cancelAnimationFrame(animationFrameId);
-        animationFrameId = null;
-      }
-      reset();
-    },
-    update: updateFrameRateStat
-  };
-}
-
-function getDefaultCanvasColorTextureByteLength(device: Device): number {
-  const canvasContext = device.canvasContext;
-  if (!canvasContext) {
-    return 0;
-  }
-
-  const [width, height] = canvasContext.getDrawingBufferSize();
-  const formatInfo = device.getTextureFormatInfo(device.preferredColorFormat);
-  return width * height * (formatInfo.bytesPerPixel || 0);
-}
 
 type LumaExampleProps = React.PropsWithChildren<{
   className?: string;
@@ -287,89 +98,6 @@ const EXAMPLE_HEADER_STYLE: CSSProperties = {
   pointerEvents: 'none'
 };
 
-const EXAMPLE_INFO_STYLE: CSSProperties = {
-  boxSizing: 'border-box',
-  boxShadow: '0 12px 32px rgba(0, 0, 0, 0.28)',
-  backgroundColor: 'rgba(255, 255, 255, 0.96)',
-  borderRadius: 12,
-  color: '#111',
-  width: 420,
-  minWidth: 0,
-  maxWidth: 'calc(100vw - 40px)',
-  overflow: 'hidden',
-  padding: '10px 16px',
-  zIndex: 10
-};
-
-const INFO_BOX_DEFAULT_WIDTH = 420;
-const INFO_BOX_MIN_WIDTH = 280;
-const INFO_BOX_MIN_HEIGHT = 160;
-const INFO_BOX_VIEWPORT_RIGHT_MARGIN = 20;
-const INFO_BOX_VIEWPORT_BOTTOM_MARGIN = 12;
-const INFO_BOX_KEYBOARD_RESIZE_STEP = 10;
-const INFO_BOX_LARGE_KEYBOARD_RESIZE_STEP = 30;
-
-type InfoBoxSize = {
-  width: number;
-  height: number;
-};
-
-type InfoBoxResizeState = {
-  pointerId: number;
-  startX: number;
-  startY: number;
-  startWidth: number;
-  startHeight: number;
-};
-
-type ExampleInfoProps = {
-  directory?: string;
-  id?: string;
-  sourceDirectory?: string;
-  sourcePath?: string;
-  title?: string;
-};
-
-type InfoBoxProps = React.PropsWithChildren<
-  ExampleInfoProps & {
-    html?: string;
-    panel?: Panel;
-    style?: CSSProperties;
-  }
->;
-
-function getInfoBoxSizeBounds(infoBoxElement: HTMLElement): {
-  minWidth: number;
-  minHeight: number;
-  maxWidth: number;
-  maxHeight: number;
-} {
-  const rect = infoBoxElement.getBoundingClientRect();
-  const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
-  const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
-  const maxWidth = Math.max(1, viewportWidth - rect.left - INFO_BOX_VIEWPORT_RIGHT_MARGIN);
-  const maxHeight = Math.max(1, viewportHeight - rect.top - INFO_BOX_VIEWPORT_BOTTOM_MARGIN);
-
-  return {
-    minWidth: Math.min(INFO_BOX_MIN_WIDTH, maxWidth),
-    minHeight: Math.min(INFO_BOX_MIN_HEIGHT, maxHeight),
-    maxWidth,
-    maxHeight
-  };
-}
-
-function clampInfoBoxSize(
-  infoBoxElement: HTMLElement,
-  width: number,
-  height: number
-): InfoBoxSize {
-  const {minWidth, minHeight, maxWidth, maxHeight} = getInfoBoxSizeBounds(infoBoxElement);
-  return {
-    width: Math.min(maxWidth, Math.max(minWidth, width)),
-    height: Math.min(maxHeight, Math.max(minHeight, height))
-  };
-}
-
 type ExamplePageProps = React.PropsWithChildren<{
   className?: string;
   style?: CSSProperties;
@@ -388,331 +116,6 @@ type ReactExampleProps<P> = {
   className?: string;
   style?: CSSProperties;
   showStats?: boolean;
-};
-
-export const InfoBox: FC<InfoBoxProps> = (props: InfoBoxProps) => {
-  const {siteConfig} = useDocusaurusContext();
-  const websiteBaseUrl = siteConfig.baseUrl.endsWith('/') ? siteConfig.baseUrl : `${siteConfig.baseUrl}/`;
-  const sourceUrl = getExampleSourceUrl(props);
-  const sourcePaths = React.useMemo(
-    () => getExampleSourcePaths(props),
-    [props.directory, props.id, props.sourceDirectory, props.sourcePath]
-  );
-  const sourcePathsKey = sourcePaths.join('|');
-  const title = getExampleTitle(props.id, props.title);
-  const [isCollapsed, setIsCollapsed] = useState(() => isInfoBoxCollapsedByDefault);
-  const [activeTab, setActiveTab] = useState<'info' | 'source'>('info');
-  const [infoBoxSize, setInfoBoxSize] = useState<InfoBoxSize | null>(null);
-  const [sourceResult, setSourceResult] = useState<{
-    key: string;
-    path?: string;
-    source?: string;
-    error?: string;
-  } | null>(null);
-  const infoBoxRef = useRef<HTMLDivElement | null>(null);
-  const panelHostRef = useRef<HTMLDivElement | null>(null);
-  const resizeStateRef = useRef<InfoBoxResizeState | null>(null);
-  const toggleCollapsed = () => setIsCollapsed(value => !value);
-  const currentSourceResult = sourceResult?.key === sourcePathsKey ? sourceResult : null;
-
-  useEffect(() => {
-    isInfoBoxCollapsedByDefault = isCollapsed;
-  }, [isCollapsed]);
-
-  useEffect(() => {
-    if (activeTab !== 'source' || sourcePaths.length === 0 || currentSourceResult) {
-      return;
-    }
-
-    const abortController = new AbortController();
-    void fetchExampleSource(websiteBaseUrl, sourcePaths, abortController.signal)
-      .then(({path, source}) => {
-        setSourceResult({key: sourcePathsKey, path, source});
-      })
-      .catch(error => {
-        if (!abortController.signal.aborted) {
-          setSourceResult({
-            key: sourcePathsKey,
-            error: error instanceof Error ? error.message : 'Unable to load source code.'
-          });
-        }
-      });
-
-    return () => abortController.abort();
-  }, [activeTab, currentSourceResult, sourcePaths, sourcePathsKey, websiteBaseUrl]);
-
-  useEffect(() => {
-    const panelHostElement = panelHostRef.current;
-    if (!panelHostElement || !props.panel) {
-      return;
-    }
-
-    configurePanelHostElement(panelHostElement);
-    renderExamplePanel(panelHostElement, props.panel);
-    return () => renderExamplePanel(panelHostElement, null);
-  }, [props.panel]);
-
-  const handleResizePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
-    const infoBoxElement = infoBoxRef.current;
-    if (!infoBoxElement) {
-      return;
-    }
-
-    const rect = infoBoxElement.getBoundingClientRect();
-    resizeStateRef.current = {
-      pointerId: event.pointerId,
-      startX: event.clientX,
-      startY: event.clientY,
-      startWidth: rect.width,
-      startHeight: rect.height
-    };
-    event.currentTarget.setPointerCapture(event.pointerId);
-    event.preventDefault();
-  };
-
-  const handleResizePointerMove = (event: React.PointerEvent<HTMLButtonElement>) => {
-    const infoBoxElement = infoBoxRef.current;
-    const resizeState = resizeStateRef.current;
-    if (!infoBoxElement || !resizeState || resizeState.pointerId !== event.pointerId) {
-      return;
-    }
-
-    setInfoBoxSize(
-      clampInfoBoxSize(
-        infoBoxElement,
-        resizeState.startWidth + event.clientX - resizeState.startX,
-        resizeState.startHeight + event.clientY - resizeState.startY
-      )
-    );
-  };
-
-  const finishResize = (event: React.PointerEvent<HTMLButtonElement>) => {
-    if (resizeStateRef.current?.pointerId !== event.pointerId) {
-      return;
-    }
-
-    resizeStateRef.current = null;
-    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-      event.currentTarget.releasePointerCapture(event.pointerId);
-    }
-  };
-
-  const handleResizeKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-    const infoBoxElement = infoBoxRef.current;
-    if (!infoBoxElement) {
-      return;
-    }
-
-    const resizeStep = event.shiftKey
-      ? INFO_BOX_LARGE_KEYBOARD_RESIZE_STEP
-      : INFO_BOX_KEYBOARD_RESIZE_STEP;
-    const widthDelta =
-      event.key === 'ArrowLeft' ? -resizeStep : event.key === 'ArrowRight' ? resizeStep : 0;
-    const heightDelta =
-      event.key === 'ArrowUp' ? -resizeStep : event.key === 'ArrowDown' ? resizeStep : 0;
-    if (widthDelta === 0 && heightDelta === 0) {
-      return;
-    }
-
-    const rect = infoBoxElement.getBoundingClientRect();
-    setInfoBoxSize(currentSize =>
-      clampInfoBoxSize(
-        infoBoxElement,
-        (currentSize?.width ?? rect.width) + widthDelta,
-        (currentSize?.height ?? rect.height) + heightDelta
-      )
-    );
-    event.preventDefault();
-  };
-
-  return (
-    <div
-      ref={infoBoxRef}
-      style={{
-        ...EXAMPLE_INFO_STYLE,
-        display: 'flex',
-        flexDirection: 'column',
-        position: 'relative',
-        width: infoBoxSize?.width ?? INFO_BOX_DEFAULT_WIDTH,
-        height: isCollapsed ? undefined : infoBoxSize?.height,
-        maxHeight: isCollapsed ? undefined : 'calc(100vh - var(--ifm-navbar-height) - 24px)',
-        ...props.style
-      }}
-    >
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'flex-start',
-          justifyContent: 'space-between',
-          gap: 12
-        }}
-      >
-        <button
-          type="button"
-          aria-label={isCollapsed ? 'Expand info box' : 'Collapse info box'}
-          onClick={toggleCollapsed}
-          style={{
-            minWidth: 0,
-            flex: '1 1 auto',
-            padding: 0,
-            border: 'none',
-            background: 'transparent',
-            textAlign: 'left',
-            cursor: 'pointer',
-            color: 'inherit'
-          }}
-        >
-          {title ? <h3 style={{marginTop: 0, marginBottom: 0}}>{title}</h3> : null}
-        </button>
-        <div style={{display: 'flex', alignItems: 'center', gap: 24, flexShrink: 0}}>
-          {sourceUrl ? (
-            <a href={sourceUrl} target="_blank" rel="noreferrer">
-              Source code
-            </a>
-          ) : null}
-          <button
-            type="button"
-            aria-label={isCollapsed ? 'Expand info box' : 'Collapse info box'}
-            onClick={toggleCollapsed}
-            style={{
-              flexShrink: 0,
-              border: '1px solid #d0d7de',
-              background: '#fff',
-              borderRadius: 999,
-              minWidth: 56,
-              padding: '0 12px',
-              height: 28,
-              fontSize: 14,
-              lineHeight: 1,
-              whiteSpace: 'nowrap',
-              cursor: 'pointer'
-            }}
-          >
-            {isCollapsed ? 'Info' : 'Hide'}
-          </button>
-        </div>
-      </div>
-      <div
-        hidden={isCollapsed}
-        aria-hidden={isCollapsed}
-        style={{
-          marginTop: isCollapsed ? 0 : 12,
-          minWidth: 0,
-          minHeight: 0,
-          flex: '1 1 auto',
-          display: isCollapsed ? 'none' : 'flex',
-          flexDirection: 'column',
-          overflowY: 'auto'
-        }}
-      >
-        {sourcePaths.length > 0 ? (
-          <div
-            role="tablist"
-            aria-label="Example information"
-            style={{display: 'flex', gap: 4, marginBottom: 12}}
-          >
-            {(['info', 'source'] as const).map(tab => (
-              <button
-                key={tab}
-                type="button"
-                role="tab"
-                aria-selected={activeTab === tab}
-                onClick={() => setActiveTab(tab)}
-                style={{
-                  border: '1px solid #cbd5e1',
-                  borderRadius: 6,
-                  padding: '4px 9px',
-                  background: activeTab === tab ? '#e2e8f0' : '#fff',
-                  color: '#0f172a',
-                  cursor: 'pointer',
-                  fontSize: 12,
-                  fontWeight: activeTab === tab ? 700 : 500
-                }}
-              >
-                {tab === 'info' ? 'Info' : 'Source'}
-              </button>
-            ))}
-          </div>
-        ) : null}
-        <div
-          hidden={activeTab !== 'info'}
-          aria-hidden={activeTab !== 'info'}
-          style={{minWidth: 0, minHeight: 0, flex: '1 1 auto', overflow: 'auto'}}
-        >
-          {props.html ? <div dangerouslySetInnerHTML={{__html: props.html}} /> : null}
-          {props.children}
-          {props.panel ? <div ref={panelHostRef} /> : null}
-        </div>
-        {sourcePaths.length > 0 ? (
-          <div
-            hidden={activeTab !== 'source'}
-            aria-hidden={activeTab !== 'source'}
-            style={{
-              minWidth: 0,
-              minHeight: 0,
-              flex: '1 1 auto',
-              maxWidth: '100%',
-              overflow: 'auto',
-              background: '#f6f8fa'
-            }}
-          >
-            {currentSourceResult?.error ? (
-              <p style={{margin: 0, color: '#b00020'}}>{currentSourceResult.error}</p>
-            ) : (
-              <CodeBlock
-                language={currentSourceResult?.path?.endsWith('.tsx') ? 'tsx' : 'typescript'}
-              >
-                {currentSourceResult?.source ?? '// Loading source…'}
-              </CodeBlock>
-            )}
-          </div>
-        ) : null}
-      </div>
-      {!isCollapsed ? (
-        <button
-          type="button"
-          aria-label="Resize info box"
-          title="Resize info box"
-          onPointerDown={handleResizePointerDown}
-          onPointerMove={handleResizePointerMove}
-          onPointerUp={finishResize}
-          onPointerCancel={finishResize}
-          onKeyDown={handleResizeKeyDown}
-          style={{
-            position: 'absolute',
-            right: 6,
-            bottom: 6,
-            zIndex: 100,
-            display: 'grid',
-            placeItems: 'center',
-            width: 28,
-            height: 28,
-            padding: 0,
-            border: '1px solid #94a3b8',
-            borderRadius: 6,
-            background: '#e2e8f0',
-            boxShadow: '0 1px 3px rgba(15, 23, 42, 0.18)',
-            color: '#334155',
-            cursor: 'nwse-resize',
-            fontSize: 19,
-            lineHeight: 1,
-            touchAction: 'none',
-            userSelect: 'none'
-          }}
-        >
-          <svg aria-hidden="true" viewBox="0 0 16 16" width="16" height="16">
-            <path
-              d="M4 14L14 4M9 14L14 9M13 14L14 13"
-              fill="none"
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeWidth="1.75"
-            />
-          </svg>
-        </button>
-      ) : null}
-    </div>
-  );
 };
 
 export const ExamplePage: FC<ExamplePageProps> = (props: ExamplePageProps) => {
@@ -746,78 +149,10 @@ export const ExampleHeader: FC<ExampleHeaderProps> = (props: ExampleHeaderProps)
 
 export function ReactExample<P>(props: ReactExampleProps<P>) {
   const Component = props.component;
-  const statsPanelRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (props.showStats === false || !statsPanelRef.current) {
-      return;
-    }
-
-    const resourceCounts = luma.stats.get('GPU Resource Counts');
-    const gpuTimeAndMemoryStats = initializeGpuTimeAndMemoryStats();
-    const frameRateController = createFrameRateController(gpuTimeAndMemoryStats);
-    statsPanelRef.current.replaceChildren();
-    frameRateController.start();
-
-    const statsWidgets = [
-      new StatsWidget(gpuTimeAndMemoryStats, {
-        title: getStatsTitle(gpuTimeAndMemoryStats),
-        container: statsPanelRef.current,
-        css: STAT_STYLES,
-        formatters: getGpuTimeAndMemoryStatFormatters(null, frameRateController.formatFrameRate)
-      }),
-      new StatsWidget(resourceCounts, {
-        title: getStatsTitle(resourceCounts),
-        container: statsPanelRef.current,
-        css: STAT_STYLES
-      })
-    ];
-
-    for (const statsWidget of statsWidgets) {
-      statsWidget.setCollapsed(getStatsWidgetCollapsedState(statsWidget));
-    }
-
-    const updateStatsWidget = () => {
-      frameRateController.update();
-      for (const statsWidget of statsWidgets) {
-        statsWidget.update();
-      }
-    };
-
-    updateStatsWidget();
-    const statsIntervalId = window.setInterval(updateStatsWidget, 250);
-
-    return () => {
-      window.clearInterval(statsIntervalId);
-      frameRateController.stop();
-      for (const statsWidget of statsWidgets) {
-        storeStatsWidgetCollapsedState(statsWidget);
-        statsWidget.remove();
-      }
-      statsPanelRef.current?.replaceChildren();
-    };
-  }, [props.showStats]);
 
   return (
     <ExamplePage className={props.className} style={props.style}>
-      {props.showStats !== false ? (
-        <div
-          ref={statsPanelRef}
-          style={{
-            position: 'absolute',
-            right: '12px',
-            bottom: '12px',
-            zIndex: 10,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '8px',
-            maxHeight: 'calc(100% - 24px)',
-            overflowY: 'auto',
-            overflowX: 'hidden',
-            alignItems: 'flex-end'
-          }}
-        />
-      ) : null}
+      {props.showStats !== false ? <ExampleStats /> : null}
       <Component {...props.componentProps} />
     </ExamplePage>
   );
@@ -831,8 +166,6 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
 
   /** Each example maintains an animation loop */
   const canvasContainerRef = useRef<HTMLDivElement | null>(null);
-  const statsContainerRef = useRef<HTMLDivElement | null>(null);
-  const statsPanelRef = useRef<HTMLDivElement | null>(null);
 
   /** Type type of the device (WebGL, WebGPU, ...) */
   const deviceType = useStore(store => store.deviceType);
@@ -893,12 +226,8 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
 
     let isCancelled = false;
     let animationLoop: AnimationLoop | null = null;
-    let statsWidgets: StatsWidget[] = [];
-    let statsIntervalId: number | null = null;
-    let previousSwapChainTextureMemory = 0;
     const defaultCanvasContext = effectiveDevice.getDefaultCanvasContext();
     const deviceCanvas = defaultCanvasContext.canvas;
-    let frameRateController: FrameRateController | null = null;
     const asyncCreateLoop = async () => {
       // Ensure the example can find its locally served assets before example construction starts.
       if (props.directory) {
@@ -925,67 +254,6 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
       });
       animationLoop.frameRate.setSampleSize(1);
 
-      if (showStats && statsPanelRef.current) {
-        const resourceCounts = luma.stats.get('GPU Resource Counts');
-        const gpuTimeAndMemoryStats = initializeGpuTimeAndMemoryStats();
-        const swapChainTextureStat = gpuTimeAndMemoryStats.get('Swap Chain Texture');
-        const gpuMemoryStat = gpuTimeAndMemoryStats.get('GPU Memory');
-        frameRateController = createFrameRateController(gpuTimeAndMemoryStats);
-        statsPanelRef.current.replaceChildren();
-        frameRateController.start();
-
-        const updateSwapChainTextureMemory = (nextSwapChainTextureMemory: number) => {
-          const delta = nextSwapChainTextureMemory - previousSwapChainTextureMemory;
-          if (delta > 0) {
-            swapChainTextureStat.addCount(delta);
-            gpuMemoryStat.addCount(delta);
-          } else if (delta < 0) {
-            swapChainTextureStat.subtractCount(-delta);
-            gpuMemoryStat.subtractCount(-delta);
-          }
-          previousSwapChainTextureMemory = nextSwapChainTextureMemory;
-        };
-
-        if (effectiveDevice) {
-          updateSwapChainTextureMemory(getDefaultCanvasColorTextureByteLength(effectiveDevice));
-        }
-
-        statsWidgets = [
-          new StatsWidget(gpuTimeAndMemoryStats, {
-            title: getStatsTitle(gpuTimeAndMemoryStats),
-            container: statsPanelRef.current,
-            css: STAT_STYLES,
-            formatters: getGpuTimeAndMemoryStatFormatters(
-              effectiveDevice,
-              frameRateController.formatFrameRate
-            )
-          }),
-          new StatsWidget(resourceCounts, {
-            title: getStatsTitle(resourceCounts),
-            container: statsPanelRef.current,
-            css: STAT_STYLES
-          })
-        ];
-        for (const statsWidget of statsWidgets) {
-          statsWidget.setCollapsed(getStatsWidgetCollapsedState(statsWidget));
-        }
-
-        const updateStatsWidget = () => {
-          if (effectiveDevice) {
-            updateSwapChainTextureMemory(getDefaultCanvasColorTextureByteLength(effectiveDevice));
-          }
-
-          frameRateController?.update();
-
-          for (const statsWidget of statsWidgets) {
-            statsWidget.update();
-          }
-        };
-
-        updateStatsWidget();
-        statsIntervalId = window.setInterval(updateStatsWidget, 250);
-      }
-
       if (animationLoop) {
         await animationLoop.start();
       }
@@ -1010,26 +278,6 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
 
       currentLumaExampleTask = currentLumaExampleTask
         .then(() => {
-          if (statsIntervalId !== null) {
-            window.clearInterval(statsIntervalId);
-            statsIntervalId = null;
-          }
-          frameRateController?.stop();
-          frameRateController = null;
-          if (previousSwapChainTextureMemory > 0) {
-            const gpuTimeAndMemoryStats = luma.stats.get('GPU Time and Memory');
-            gpuTimeAndMemoryStats
-              .get('Swap Chain Texture')
-              .subtractCount(previousSwapChainTextureMemory);
-            gpuTimeAndMemoryStats.get('GPU Memory').subtractCount(previousSwapChainTextureMemory);
-            previousSwapChainTextureMemory = 0;
-          }
-          for (const statsWidget of statsWidgets) {
-            storeStatsWidgetCollapsedState(statsWidget);
-            statsWidget.remove();
-          }
-          statsPanelRef.current?.replaceChildren();
-          statsWidgets = [];
           if (animationLoop) {
             if (!effectiveDevice.isLost) {
               effectiveDevice.submit();
@@ -1049,7 +297,6 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
   }, [
     effectiveDeviceType,
     effectiveDevice,
-    showStats,
     props.template,
     props.directory,
     props.id,
@@ -1089,24 +336,9 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
           dangerouslySetInnerHTML={{__html: info}}
         />
       ) : null}
-      <div ref={statsContainerRef} style={{minHeight: 0, position: 'absolute', inset: 0}}>
+      <div style={{minHeight: 0, position: 'absolute', inset: 0}}>
         {showStats ? (
-          <div
-            ref={statsPanelRef}
-            style={{
-              position: 'absolute',
-              right: '12px',
-              bottom: '12px',
-              zIndex: 10,
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '8px',
-              maxHeight: 'calc(100% - 24px)',
-              overflowY: 'auto',
-              overflowX: 'hidden',
-              alignItems: 'flex-end'
-            }}
-          />
+          <ExampleStats device={effectiveDevice} trackSwapChainTextureMemory />
         ) : null}
         <div
           key={effectiveDeviceType || deviceType}
@@ -1120,59 +352,6 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
     </ExamplePage>
   );
 };
-
-function getExampleSourceUrl(props: {
-  directory?: string;
-  id?: string;
-  sourceDirectory?: string;
-  sourcePath?: string;
-}): string | null {
-  if (props.sourcePath) {
-    return `${GITHUB_TREE}/${props.sourcePath}`;
-  }
-  if (props.id && (props.sourceDirectory || props.directory)) {
-    const sourceDirectory = props.sourceDirectory || props.directory;
-    return `${GITHUB_TREE}/examples/${sourceDirectory}/${props.id}`;
-  }
-  return null;
-}
-
-function getExampleSourcePaths(props: {
-  directory?: string;
-  id?: string;
-  sourceDirectory?: string;
-  sourcePath?: string;
-}): string[] {
-  if (props.sourcePath) {
-    const sourcePath = props.sourcePath.replace(/^\/?examples\//, '').replace(/^\//, '');
-    if (/\.(?:[cm]?[jt]sx?)$/.test(sourcePath)) {
-      return [sourcePath];
-    }
-    return [`${sourcePath}/app.ts`, `${sourcePath}/app.tsx`];
-  }
-
-  if (props.id && (props.sourceDirectory || props.directory)) {
-    const sourceDirectory = props.sourceDirectory || props.directory;
-    return [`${sourceDirectory}/${props.id}/app.ts`, `${sourceDirectory}/${props.id}/app.tsx`];
-  }
-
-  return [];
-}
-
-async function fetchExampleSource(
-  websiteBaseUrl: string,
-  sourcePaths: readonly string[],
-  signal: AbortSignal
-): Promise<{path: string; source: string}> {
-  for (const sourcePath of sourcePaths) {
-    const response = await fetch(`${websiteBaseUrl}example-assets/${sourcePath}`, {signal});
-    if (response.ok) {
-      return {path: sourcePath, source: await response.text()};
-    }
-  }
-
-  throw new Error('Unable to load source code.');
-}
 
 function getRequestedDeviceTypes(
   devices?: DeviceTabSelection[]
@@ -1198,23 +377,4 @@ function getRequestedDeviceTypes(
   }
 
   return requestedDeviceTypes;
-}
-
-function getExampleTitle(id?: string, title?: string): string {
-  if (title) {
-    return title;
-  }
-  if (id) {
-    return capitalizeFirstLetters(id);
-  }
-  return '';
-}
-
-function capitalizeFirstLetters(string: string) {
-  const strings = string.split('-');
-  return strings.map(capitalizeFirstLetter).join(' ');
-}
-
-function capitalizeFirstLetter(string: string) {
-  return string.charAt(0).toUpperCase() + string.slice(1);
 }

--- a/website/src/react-luma/index.ts
+++ b/website/src/react-luma/index.ts
@@ -22,6 +22,7 @@ export {
 // Examples
 export {ExamplePage} from './components/luma-example';
 export {ExampleHeader} from './components/luma-example';
-export {InfoBox} from './components/luma-example';
+export {ExampleStats} from './components/example-stats';
+export {InfoBox} from './components/info-box';
 export {LumaExample} from './components/luma-example';
 export {ReactExample} from './components/luma-example';

--- a/yarn.lock
+++ b/yarn.lock
@@ -435,10 +435,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10c0/169fc2080169a40c1760155eaaaf739bcb882df0bec76a83adbda5493645bc17270a3434b8848c494b1933e96fe1d147370001e3cda09a39f43ae30f08ef2069
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.28.6, @babel/compat-data@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/compat-data@npm:7.29.0"
   checksum: 10c0/08f348554989d23aa801bf1405aa34b15e841c0d52d79da7e524285c77a5f9d298e70e11d91cc578d8e2c9542efc586d50c5f5cf8e1915b254a9dcf786913a94
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/compat-data@npm:7.29.7"
+  checksum: 10c0/47913f05e08a45a1c9df38c02b4b49e391005085b489432647a1abe112e5d9c75e3be8ea5972b7f6da4ec5d1339922ceb9ea02b8a25d4ed1cb8636e5261f344e
   languageName: node
   linkType: hard
 
@@ -465,6 +483,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:^7.29.0":
+  version: 7.29.7
+  resolution: "@babel/core@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-compilation-targets": "npm:^7.29.7"
+    "@babel/helper-module-transforms": "npm:^7.29.7"
+    "@babel/helpers": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    "@jridgewell/remapping": "npm:^2.3.5"
+    convert-source-map: "npm:^2.0.0"
+    debug: "npm:^4.1.0"
+    gensync: "npm:^1.0.0-beta.2"
+    json5: "npm:^2.2.3"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/112fb09c24de7a1de64d1de2c31fe65c4e6af4cb2fb6e6d99ea5373e6fc51e75b88581c0efae4c4c68f119a02a988c7106e95011a41530a2fb8ed793c7eaa07b
+  languageName: node
+  linkType: hard
+
 "@babel/generator@npm:^7.25.9, @babel/generator@npm:^7.29.0":
   version: 7.29.1
   resolution: "@babel/generator@npm:7.29.1"
@@ -475,6 +516,19 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.28"
     jsesc: "npm:^3.0.2"
   checksum: 10c0/349086e6876258ef3fb2823030fee0f6c0eb9c3ebe35fc572e16997f8c030d765f636ddc6299edae63e760ea6658f8ee9a2edfa6d6b24c9a80c917916b973551
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/generator@npm:7.29.7"
+  dependencies:
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10c0/9bf72b01b5bd0ea5b1288a0e37dbd360bff2f2b1ce73342c0d40fb3db2ec3dc004ada5ffa925c5e12939a416eed59e600d562b8ecd938ce0d27dfd0eb6c6c2b7
   languageName: node
   linkType: hard
 
@@ -497,6 +551,19 @@ __metadata:
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
   checksum: 10c0/3fcdf3b1b857a1578e99d20508859dbd3f22f3c87b8a0f3dc540627b4be539bae7f6e61e49d931542fe5b557545347272bbdacd7f58a5c77025a18b745593a50
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-compilation-targets@npm:7.29.7"
+  dependencies:
+    "@babel/compat-data": "npm:^7.29.7"
+    "@babel/helper-validator-option": "npm:^7.29.7"
+    browserslist: "npm:^4.24.0"
+    lru-cache: "npm:^5.1.1"
+    semver: "npm:^6.3.1"
+  checksum: 10c0/4c15fd4c69a0a7047799a28a88460c19cede0a0ee8af994ea169114986f4af48b92c7393a4a3fee0456c11a656eece3448a6ed06354453d6c27cccf17195453b
   languageName: node
   linkType: hard
 
@@ -552,6 +619,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-globals@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-globals@npm:7.29.7"
+  checksum: 10c0/f38417c40b1129a1b2b519ca961b9040c8827d1444fd74068702286b91b77089431dc76b6b9d5c1496e5da2a4f3ad329c6946e688ba3fa0d1d0b3d2b4f34f36a
+  languageName: node
+  linkType: hard
+
 "@babel/helper-member-expression-to-functions@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-member-expression-to-functions@npm:7.28.5"
@@ -572,6 +646,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-imports@npm:7.29.7"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/6adf60d97356027413342a092f818d9678c4f5caff716a33e3284b5ae14e47a9e88059d421dde4ee4894691260039a12602c0e7becadc175602194b40dfa345d
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.27.1, @babel/helper-module-transforms@npm:^7.28.6":
   version: 7.28.6
   resolution: "@babel/helper-module-transforms@npm:7.28.6"
@@ -582,6 +666,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 10c0/6f03e14fc30b287ce0b839474b5f271e72837d0cafe6b172d759184d998fbee3903a035e81e07c2c596449e504f453463d58baa65b6f40a37ded5bec74620b2b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-transforms@npm:7.29.7"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10c0/ee5a2172c24a42be696836f4b0d947489c9729d8adf5821885cf77d1ad5333e3c447368e9a71f67df1099570490553dccf9f888ef0a92a48aa63cb086bd8c7e1
   languageName: node
   linkType: hard
 
@@ -644,6 +741,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-string-parser@npm:7.29.7"
+  checksum: 10c0/194bc0f1716e396d5ffde56ad6119745fb9557662c98611590e5e454906783a4ccb21ce93056b8eb69a4909044834e45d96e50ac695bbe9e3221648fe033c06c
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-validator-identifier@npm:7.24.7"
@@ -658,10 +762,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 10c0/4795354e7ae0dcafa72de1cd04ec51252dc1498517170beaf019e03effc5b7bf13c6b21a3949a77e07b8125be7f106ed1131350d8ebd4566ae874094a726d62b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-validator-option@npm:7.27.1"
   checksum: 10c0/6fec5f006eba40001a20f26b1ef5dbbda377b7b68c8ad518c05baa9af3f396e780bdfded24c4eef95d14bb7b8fd56192a6ed38d5d439b97d10efc5f1a191d148
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-option@npm:7.29.7"
+  checksum: 10c0/d2a06c6d0ac40ba4a2f219fc2cab249c7a94bacdb2686273b7f9598571c908809b48468ff588915a346e6cc7296f60b581023d1d498b747fed06f779d335c2cc
   languageName: node
   linkType: hard
 
@@ -686,6 +804,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helpers@npm:7.29.7"
+  dependencies:
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/218e8d10953647c9f44775f5a022b227a182674853b5ea8631889deb7e1a3e4bc870388aaecf59bb8bd92a87f9a96220ed3f70a35bffec6bcf9169ecb67891ac
+  languageName: node
+  linkType: hard
+
 "@babel/highlight@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/highlight@npm:7.24.7"
@@ -706,6 +834,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10c0/333b2aa761264b91577a74bee86141ef733f9f9f6d4fc52548e4847dc35dfbf821f58c46832c637bfa761a6d9909d6a68f7d1ed59e17e4ffbb958dc510c17b62
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/parser@npm:7.29.7"
+  dependencies:
+    "@babel/types": "npm:^7.29.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/65133038f80b54a714d6027cb77cee3f9a6b5c4c6842ce674301e13947cbcbfa8055e63acaf1b84c085d34226a14425b2c2b97b829e0e226d2e8f1299942a51d
   languageName: node
   linkType: hard
 
@@ -1687,6 +1826,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/template@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10c0/8bb7f900dcab0e9e1c5ffbc33ca10e0d26b7b2e2ca804becb73ee771b9c4ed6e2908a4ae4a14c08560febb45d2b6b9a173955e42ad404d05f8b04840a14d9c58
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.25.9, @babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.28.5, @babel/traverse@npm:^7.28.6, @babel/traverse@npm:^7.29.0, @babel/traverse@npm:^7.4.5":
   version: 7.29.0
   resolution: "@babel/traverse@npm:7.29.0"
@@ -1702,6 +1852,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/traverse@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-globals": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    debug: "npm:^4.3.1"
+  checksum: 10c0/e256a1fbdb956555b76f3c285b1e453f6bedec8b3afb61751d99d933efd11c7d79caf5ddf2493570058a9f7deaa1b48324380d7c1aa1443fd9508becbf56331a
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.21.3, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.5, @babel/types@npm:^7.28.6, @babel/types@npm:^7.29.0, @babel/types@npm:^7.4.4":
   version: 7.29.0
   resolution: "@babel/types@npm:7.29.0"
@@ -1709,6 +1874,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
   checksum: 10c0/23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/types@npm:7.29.7"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: 10c0/b6623994c69717fa27294f5fa46d59140338e2d86c6c1c13085c84ef7d53086ee357fbf4fe9abe3dd3da75734dc77c4c0df2f90fb29e667558bb3b3fb705e88f
   languageName: node
   linkType: hard
 
@@ -3768,7 +3943,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.12":
+"@jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.13":
   version: 0.3.13
   resolution: "@jridgewell/gen-mapping@npm:0.3.13"
   dependencies:
@@ -3837,6 +4012,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/trace-mapping@npm:0.3.31, @jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.25, @jridgewell/trace-mapping@npm:^0.3.28, @jridgewell/trace-mapping@npm:^0.3.31":
+  version: 0.3.31
+  resolution: "@jridgewell/trace-mapping@npm:0.3.31"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.1.0"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
+  checksum: 10c0/4b30ec8cd56c5fd9a661f088230af01e0c1a3888d11ffb6b47639700f71225be21d1f7e168048d6d4f9449207b978a235c07c8f15c07705685d16dc06280e9d9
+  languageName: node
+  linkType: hard
+
 "@jridgewell/trace-mapping@npm:0.3.9":
   version: 0.3.9
   resolution: "@jridgewell/trace-mapping@npm:0.3.9"
@@ -3854,16 +4039,6 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
   checksum: 10c0/3d1ce6ebc69df9682a5a8896b414c6537e428a1d68b02fcc8363b04284a8ca0df04d0ee3013132252ab14f2527bc13bea6526a912ecb5658f0e39fd2860b4df4
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.25, @jridgewell/trace-mapping@npm:^0.3.28, @jridgewell/trace-mapping@npm:^0.3.31":
-  version: 0.3.31
-  resolution: "@jridgewell/trace-mapping@npm:0.3.31"
-  dependencies:
-    "@jridgewell/resolve-uri": "npm:^3.1.0"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
-  checksum: 10c0/4b30ec8cd56c5fd9a661f088230af01e0c1a3888d11ffb6b47639700f71225be21d1f7e168048d6d4f9449207b978a235c07c8f15c07705685d16dc06280e9d9
   languageName: node
   linkType: hard
 
@@ -4476,6 +4651,7 @@ __metadata:
     "@biomejs/biome": "npm:^2.4.8"
     "@vitest/browser": "npm:^4.0.18"
     "@vitest/browser-playwright": "npm:^4.0.18"
+    "@vitest/coverage-istanbul": "npm:4.1.0"
     "@vitest/coverage-v8": "npm:^4.0.18"
     playwright: "npm:^1.56.1"
     vite: "npm:^8.0.0"
@@ -7201,6 +7377,26 @@ __metadata:
   peerDependencies:
     vitest: 4.1.0
   checksum: 10c0/33b35cea63f392b6afafb6636bebe7ff0d234b1c120ec74a97462c7a7cbdbc67f415a5f0f95651f4074d53bfe12d4ff3ae8f16ba79045226df6365c77f950e18
+  languageName: node
+  linkType: hard
+
+"@vitest/coverage-istanbul@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@vitest/coverage-istanbul@npm:4.1.0"
+  dependencies:
+    "@babel/core": "npm:^7.29.0"
+    "@istanbuljs/schema": "npm:^0.1.3"
+    "@jridgewell/gen-mapping": "npm:^0.3.13"
+    "@jridgewell/trace-mapping": "npm:0.3.31"
+    istanbul-lib-coverage: "npm:^3.2.2"
+    istanbul-lib-report: "npm:^3.0.1"
+    istanbul-reports: "npm:^3.2.0"
+    magicast: "npm:^0.5.2"
+    obug: "npm:^2.1.1"
+    tinyrainbow: "npm:^3.0.3"
+  peerDependencies:
+    vitest: 4.1.0
+  checksum: 10c0/674d3f6a1b411a2f1d48e5fd6d2bc50d30e16b1e540737492d9f5238b57cf999fb93c316744f2acd661369277438f969fd1a6e8195cdd36ee2fe01b7531f6e98
   languageName: node
   linkType: hard
 
@@ -16366,6 +16562,7 @@ __metadata:
     "@vis.gl/ts-plugins": "npm:^1.0.2"
     "@vitest/browser": "npm:^4.0.18"
     "@vitest/browser-playwright": "npm:^4.0.18"
+    "@vitest/coverage-istanbul": "npm:4.1.0"
     "@vitest/coverage-v8": "npm:^4.0.18"
     a5-js: "npm:^0.8.0"
     h3-js: "npm:^4.4.0"


### PR DESCRIPTION
Goals

- Keep the examples sidebar visible on desktop while preserving the full-width canvas layout below Docusaurus's 997px breakpoint.
- Integrate source browsing into tabbed InfoBoxes without a second tab header.
- Reduce example app boilerplate by building InfoBoxes and stats on reusable panel/component abstractions.
- Keep browser coverage within the disk budget of smaller GitHub-hosted runners.

Changes

- Restored the standard left examples sidebar at desktop widths and retained the sidebar-hidden layout below 997px.
- Extracted the example InfoBox into its own panel-backed component using the community panels module and `TabbedContainerPanel`.
- Added source code as the final InfoBox tab and renamed the external header link to GitHub.
- Updated example panels to use the shared community-panel framework, including the Arrow columns, a-buffer, and fp64 examples.
- Extracted GPU timing, memory, frame-rate, widget state, and swap-chain accounting into a reusable `ExampleStats` component shared by React and animation-loop examples.
- Kept the full-height canvas, hidden footer, example header behavior, examples index, and docs table of contents unchanged.
- Added repo-configurable coverage settings to the shared Vitest factory.
- Switched CI coverage to Istanbul instrumentation with a `modules/**/src` allowlist and explicit exclusions for maps, generated bundles, vendored dependencies, examples, website files, and test fixtures. This prevents those files from entering transient browser coverage chunks.

Verification

- ✅ `nvm use`
- ✅ `yarn install` (completed with existing peer-dependency warnings)
- ⚠️ `yarn build` (failed while building WebGPU because `@luma.gl/constants/dist/index.cjs` was not found after the build pipeline removed package `dist` directories; unrelated to the website files in this PR)
- ✅ `yarn test`
- ⚠️ `yarn lint fix` was not run as a whole-worktree mutation because unrelated table/docs changes are present; equivalent targeted Biome formatting was applied to the scoped example files, and the commit hook's full Biome checks passed with no fixes.
- ✅ `yarn website:build`
- ✅ `(cd website && yarn build)`
- ✅ `CI=1 yarn test-coverage` with Istanbul; all 219 headless files passed and transient coverage peaked at about 777 MB locally.
- ✅ `yarn lint`
- ✅ `yarn test-node`
- ✅ `./node_modules/.bin/tsc --noEmit -p website/tsconfig.json` before generated build assets were created
- ⚠️ The same standalone TypeScript check after generation exhausted Node heap at both 4 GB and 8 GB; both production website builds completed successfully.

Risks

- The InfoBox now owns source loading and panel hosting, so regressions would most likely affect source-tab loading or panel sizing.
- Stats lifecycle moved out of the animation-loop effect; the component preserves widget collapsed state and removes swap-chain memory counts on cleanup.
- Istanbul and V8 can differ slightly in branch accounting; the source allowlist intentionally focuses reported coverage on product modules.

Follow-up

- Investigate the repository-wide `yarn build` package-dist resolution failure separately from this website PR.
- Consider excluding generated website assets from the standalone TypeScript project to avoid post-build heap exhaustion.