### PR TITLE
[codex] add documentation navigation tabs

### DIFF
--- a/docs/api-guide/engine/scenegraph.md
+++ b/docs/api-guide/engine/scenegraph.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # Scenegraphs
+
+<EngineDocsTabs group="scenegraph" active="scenegraphs" />
 
 The luma.gl engine provides a set of Scenegraph classes to organize `Model`s into a hierarchy.
 

--- a/docs/api-guide/engine/transforms.md
+++ b/docs/api-guide/engine/transforms.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # GPU Computations
+
+<EngineDocsTabs group="compute" active="gpu-computations" />
 
 Some operations can be very efficiently executed on the GPU.
 

--- a/docs/api-guide/gpu/buffer-schemas.md
+++ b/docs/api-guide/gpu/buffer-schemas.md
@@ -1,4 +1,8 @@
+import {GpuMemoryDocsTabs} from '@site/src/components/docs/gpu-memory-docs-tabs';
+
 # Buffer Schemas and Columnar Records
+
+<GpuMemoryDocsTabs active="buffer-schemas" />
 
 Columnar GPU workflows often start with separate typed columns, but shaders do
 not always consume those columns one-for-one. Common cases include:

--- a/docs/api-guide/gpu/gpu-buffers.md
+++ b/docs/api-guide/gpu/gpu-buffers.md
@@ -1,6 +1,9 @@
 import {Limit as L} from '@site/src/react-luma';
+import {GpuMemoryDocsTabs} from '@site/src/components/docs/gpu-memory-docs-tabs';
 
 # Using GPU Buffers
+
+<GpuMemoryDocsTabs active="gpu-buffers" />
 
 See also [Issuing GPU Commands](/docs/api-guide/gpu/gpu-commands) for guidance on when buffer operations should use immediate resource helpers versus explicit command encoding.
 

--- a/docs/api-guide/gpu/gpu-memory-layouts.md
+++ b/docs/api-guide/gpu/gpu-memory-layouts.md
@@ -1,4 +1,8 @@
+import {GpuMemoryDocsTabs} from '@site/src/components/docs/gpu-memory-docs-tabs';
+
 # GPU Memory Layouts
+
+<GpuMemoryDocsTabs active="gpu-memory-layouts" />
 
 GPU buffers are byte ranges. A layout describes how shader-visible rows and columns are mapped onto those bytes.
 

--- a/docs/api-guide/gpu/gpu-memory.md
+++ b/docs/api-guide/gpu/gpu-memory.md
@@ -1,4 +1,8 @@
+import {GpuMemoryDocsTabs} from '@site/src/components/docs/gpu-memory-docs-tabs';
+
 # GPU Memory
+
+<GpuMemoryDocsTabs active="gpu-memory" />
 
 Memory on GPU is managed through [Buffer](/docs/api-guide/gpu/gpu-buffers) and [Texture](/docs/api-guide/gpu/gpu-textures) resources.
 

--- a/docs/api-guide/gpu/gpu-storage-buffers.md
+++ b/docs/api-guide/gpu/gpu-storage-buffers.md
@@ -1,4 +1,8 @@
+import {GpuMemoryDocsTabs} from '@site/src/components/docs/gpu-memory-docs-tabs';
+
 # Storage Buffers
+
+<GpuMemoryDocsTabs active="gpu-storage-buffers" />
 
 Storage buffers are the flexible WebGPU path for shader-visible data that should
 be read or written as ordinary WGSL arrays and structs. They are not available in

--- a/docs/api-reference/core/bindings.md
+++ b/docs/api-reference/core/bindings.md
@@ -1,4 +1,8 @@
+import {CoreDocsTabs} from '@site/src/components/docs/core-docs-tabs';
+
 # Bindings
+
+<CoreDocsTabs group="layouts" active="bindings" />
 
 Bindings are the GPU resources that shader code accesses through declared
 binding points:

--- a/docs/api-reference/core/buffer-layout.md
+++ b/docs/api-reference/core/buffer-layout.md
@@ -1,4 +1,8 @@
+import {CoreDocsTabs} from '@site/src/components/docs/core-docs-tabs';
+
 # BufferLayout
+
+<CoreDocsTabs group="layouts" active="buffer-layout" />
 
 The bufferLayout type provides information about how the application is planning to 
 map the attributes in its pipelines to the memory in GPU buffers. 

--- a/docs/api-reference/core/canvas-context.md
+++ b/docs/api-reference/core/canvas-context.md
@@ -1,4 +1,8 @@
+import {CoreDocsTabs} from '@site/src/components/docs/core-docs-tabs';
+
 # CanvasContext
+
+<CoreDocsTabs group="presentation" active="canvas-context" />
 
 A `CanvasContext` holds a connection between a GPU `Device` and canvas, (either an HTML `<canvas />` element, aka `HTMLCanvasELement`, or an `OffscreenCanvas`).
 

--- a/docs/api-reference/core/presentation-context.md
+++ b/docs/api-reference/core/presentation-context.md
@@ -1,4 +1,8 @@
+import {CoreDocsTabs} from '@site/src/components/docs/core-docs-tabs';
+
 # PresentationContext
+
+<CoreDocsTabs group="presentation" active="presentation-context" />
 
 <p class="badges">
   <img src="https://img.shields.io/badge/From-v9.3-blue.svg?style=flat-square" alt="From-v9.3" />

--- a/docs/api-reference/core/resources/framebuffer.md
+++ b/docs/api-reference/core/resources/framebuffer.md
@@ -1,4 +1,8 @@
+import {CoreDocsTabs} from '@site/src/components/docs/core-docs-tabs';
+
 # Framebuffer
+
+<CoreDocsTabs group="presentation" active="framebuffer" />
 
 A `Framebuffer` holds textures that will be used as render targets for `RenderPipeline`s 
 together with additional information on how the `RenderPipeline` should use the various attached textures:

--- a/docs/api-reference/core/shader-block-layout.md
+++ b/docs/api-reference/core/shader-block-layout.md
@@ -1,4 +1,8 @@
+import {CoreDocsTabs} from '@site/src/components/docs/core-docs-tabs';
+
 # ShaderBlockLayout
+
+<CoreDocsTabs group="layouts" active="shader-block-layout" />
 
 `ShaderBlockLayout` is the portable description of how luma.gl packs uniform-style
 and storage-style shader blocks on the CPU before uploading them to GPU buffers.

--- a/docs/api-reference/core/shader-layout.md
+++ b/docs/api-reference/core/shader-layout.md
@@ -1,4 +1,8 @@
+import {CoreDocsTabs} from '@site/src/components/docs/core-docs-tabs';
+
 # ShaderLayout
+
+<CoreDocsTabs group="layouts" active="shader-layout" />
 
 A `ShaderLayout` describes the static interface of a shader pipeline:
 

--- a/docs/api-reference/core/uniform-store.md
+++ b/docs/api-reference/core/uniform-store.md
@@ -1,4 +1,8 @@
+import {CoreDocsTabs} from '@site/src/components/docs/core-docs-tabs';
+
 # UniformStore
+
+<CoreDocsTabs group="layouts" active="uniform-store" />
 
 A uniform store holds uniform values for a set of different uniform buffers, 
 It can optionally creates managed uniform buffers for those

--- a/docs/api-reference/engine/animation-loop-template.md
+++ b/docs/api-reference/engine/animation-loop-template.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # AnimationLoopTemplate
+
+<EngineDocsTabs group="animation" active="animation-loop-template" />
 
 `AnimationLoopTemplate` is a small abstract base class for applications that prefer a class-based render lifecycle on top of [`AnimationLoop`](/docs/api-reference/engine/animation-loop).
 

--- a/docs/api-reference/engine/animation-loop.md
+++ b/docs/api-reference/engine/animation-loop.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # AnimationLoop
+
+<EngineDocsTabs group="animation" active="animation-loop" />
 
 `AnimationLoop` manages a render loop around a luma.gl [`Device`](/docs/api-reference/core/device).
 It resolves the device, tracks frame timing, builds [`AnimationProps`](#animationprops), and invokes application callbacks for initialization, per-frame rendering, and teardown.

--- a/docs/api-reference/engine/animation/key-frames.md
+++ b/docs/api-reference/engine/animation/key-frames.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # KeyFrames
+
+<EngineDocsTabs group="animation" active="key-frames" />
 
 Manages key frame animation data. Associates time points with arbitrary data and provides methods to access key times and data, and an interpolation factor, based on the current time.
 

--- a/docs/api-reference/engine/animation/timeline.md
+++ b/docs/api-reference/engine/animation/timeline.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # Timeline
+
+<EngineDocsTabs group="animation" active="timeline" />
 
 Manages an animation timeline, with multiple channels that can be running at different rates, durations, etc. Many methods (`play`, `pause`) assume that the `update` method is being called once per frame with a "global time". This automatically done for `AnimationLoop.timeline` object.
 

--- a/docs/api-reference/engine/compute/buffer-transform.md
+++ b/docs/api-reference/engine/compute/buffer-transform.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # BufferTransform
+
+<EngineDocsTabs group="compute" active="buffer-transform" />
 
 `BufferTransform` is the engine wrapper for WebGL transform-feedback workflows.
 It internally builds a [`Model`](/docs/api-reference/engine/model) plus a `TransformFeedback` object and uses them to run buffer-to-buffer transforms.

--- a/docs/api-reference/engine/compute/computation.md
+++ b/docs/api-reference/engine/compute/computation.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # Computation
+
+<EngineDocsTabs group="compute" active="computation" />
 
 <p className="badges">
   <img src="https://img.shields.io/badge/WebGPU-yes-brightgreen.svg?style=flat-square" alt="WebGPU supported" />

--- a/docs/api-reference/engine/compute/swap.md
+++ b/docs/api-reference/engine/compute/swap.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # Swap
+
+<EngineDocsTabs group="compute" active="swap" />
 
 `Swap` is a small double-buffering helper for pairs of GPU resources.
 It is used by higher-level engine utilities such as [`ShaderPassRenderer`](/docs/api-reference/engine/passes/shader-pass-renderer) and is also exported directly for application code.

--- a/docs/api-reference/engine/compute/texture-transform.md
+++ b/docs/api-reference/engine/compute/texture-transform.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # TextureTransform
+
+<EngineDocsTabs group="compute" active="texture-transform" />
 
 `TextureTransform` is the engine helper for texture-to-texture transform passes.
 It builds an internal [`Model`](/docs/api-reference/engine/model), manages a framebuffer for the target texture, and renders into that texture.

--- a/docs/api-reference/engine/geometry/geometries.md
+++ b/docs/api-reference/engine/geometry/geometries.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # Built-in Geometries
+
+<EngineDocsTabs group="geometry" active="built-in-geometries" />
 
 `@luma.gl/engine` exports several ready-made geometry classes. All of them extend [`Geometry`](/docs/api-reference/engine/geometry) and populate standard glTF mesh attribute semantics such as `POSITION`, `NORMAL`, and `TEXCOORD_0`.
 

--- a/docs/api-reference/engine/geometry/geometry.md
+++ b/docs/api-reference/engine/geometry/geometry.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # Geometry
+
+<EngineDocsTabs group="geometry" active="geometry" />
 
 `Geometry` is the CPU-side geometry container used by engine classes.
 It stores typed-array attributes, optional indices, and a `bufferLayout`.

--- a/docs/api-reference/engine/geometry/gpu-geometry.md
+++ b/docs/api-reference/engine/geometry/gpu-geometry.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # GPUGeometry
+
+<EngineDocsTabs group="geometry" active="gpu-geometry" />
 
 `GPUGeometry` is the GPU-backed counterpart to [`Geometry`](/docs/api-reference/engine/geometry).
 It stores already-created luma.gl `Buffer` objects plus the corresponding `bufferLayout` metadata.

--- a/docs/api-reference/engine/scenegraph/group-node.md
+++ b/docs/api-reference/engine/scenegraph/group-node.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # GroupNode
+
+<EngineDocsTabs group="scenegraph" active="group-node" />
 
 `GroupNode` extends [`ScenegraphNode`](/docs/api-reference/engine/scenegraph/scenegraph-node) with child-node management and traversal helpers.
 

--- a/docs/api-reference/engine/scenegraph/model-node.md
+++ b/docs/api-reference/engine/scenegraph/model-node.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # ModelNode
+
+<EngineDocsTabs group="scenegraph" active="model-node" />
 
 `ModelNode` extends [`ScenegraphNode`](/docs/api-reference/engine/scenegraph/scenegraph-node) with a [`Model`](/docs/api-reference/engine/model) and optional bounds / managed resources.
 

--- a/docs/api-reference/engine/scenegraph/scenegraph-node.md
+++ b/docs/api-reference/engine/scenegraph/scenegraph-node.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # ScenegraphNode
+
+<EngineDocsTabs group="scenegraph" active="scenegraph-node" />
 
 `ScenegraphNode` is the base class for engine scenegraph objects.
 It stores an id, transform state, a model matrix, and utility methods for updating that transform.

--- a/docs/api-reference/shadertools/README.md
+++ b/docs/api-reference/shadertools/README.md
@@ -1,4 +1,8 @@
+import {ShadertoolsDocsTabs} from '@site/src/components/docs/shadertools-docs-tabs';
+
 # Overview
+
+<ShadertoolsDocsTabs active="overview" />
 
 `@luma.gl/shadertools` provides textual shader assembly utilities and the
 shader descriptors used by luma.gl engine classes. It does not compile shaders

--- a/docs/api-reference/shadertools/shader-assembler.md
+++ b/docs/api-reference/shadertools/shader-assembler.md
@@ -1,4 +1,8 @@
+import {ShadertoolsDocsTabs} from '@site/src/components/docs/shadertools-docs-tabs';
+
 # ShaderAssembler
+
+<ShadertoolsDocsTabs active="shader-assembler" />
 
 `ShaderAssembler` combines application shader source with shadertools modules,
 hook functions, and injections before luma.gl creates shader resources. Use

--- a/docs/api-reference/shadertools/shader-conventions.md
+++ b/docs/api-reference/shadertools/shader-conventions.md
@@ -1,4 +1,8 @@
+import {ShadertoolsDocsTabs} from '@site/src/components/docs/shadertools-docs-tabs';
+
 # Shader Module Conventions
+
+<ShadertoolsDocsTabs active="shader-conventions" />
 
 :::caution
 This describes informal conventions that luma.gl applies to its shaders. 

--- a/docs/api-reference/shadertools/shader-info.md
+++ b/docs/api-reference/shadertools/shader-info.md
@@ -1,4 +1,8 @@
+import {ShadertoolsDocsTabs} from '@site/src/components/docs/shadertools-docs-tabs';
+
 # Shader Parsing
+
+<ShadertoolsDocsTabs active="shader-info" />
 
 It is sometimes useful to be able to inspect shader source code
 

--- a/docs/api-reference/shadertools/shader-module.md
+++ b/docs/api-reference/shadertools/shader-module.md
@@ -1,4 +1,8 @@
+import {ShadertoolsDocsTabs} from '@site/src/components/docs/shadertools-docs-tabs';
+
 # ShaderModule
+
+<ShadertoolsDocsTabs active="shader-module" />
 
 `ShaderModule` is the reusable shader feature descriptor used by
 `@luma.gl/shadertools`. A module may contribute WGSL and/or GLSL source,

--- a/docs/api-reference/shadertools/shader-pass.md
+++ b/docs/api-reference/shadertools/shader-pass.md
@@ -1,4 +1,8 @@
+import {ShadertoolsDocsTabs} from '@site/src/components/docs/shadertools-docs-tabs';
+
 # ShaderPass
+
+<ShadertoolsDocsTabs active="shader-pass" />
 
 `ShaderPass` is a [`ShaderModule`](/docs/api-reference/shadertools/shader-module)
 that can be executed as a standalone fullscreen texture-processing stage.

--- a/docs/api-reference/shadertools/shader-plugin.md
+++ b/docs/api-reference/shadertools/shader-plugin.md
@@ -1,4 +1,8 @@
+import {ShadertoolsDocsTabs} from '@site/src/components/docs/shadertools-docs-tabs';
+
 # ShaderPlugin
+
+<ShadertoolsDocsTabs active="shader-plugin" />
 
 `ShaderPlugin` groups reusable shader assembly contributions that can be
 attached to [`Model`](/docs/api-reference/engine/model) and

--- a/docs/api-reference/shadertools/wgsl-support.md
+++ b/docs/api-reference/shadertools/wgsl-support.md
@@ -1,4 +1,8 @@
+import {ShadertoolsDocsTabs} from '@site/src/components/docs/shadertools-docs-tabs';
+
 # WGSL Support
+
+<ShadertoolsDocsTabs active="wgsl-support" />
 
 `@luma.gl/shadertools` supports WGSL shader assembly in addition to GLSL.
 For cross-backend authoring guidance, see

--- a/docs/legacy/legacy-upgrade-guide.md
+++ b/docs/legacy/legacy-upgrade-guide.md
@@ -1,4 +1,8 @@
+import {LegacyDocsTabs} from '@site/src/components/docs/legacy-docs-tabs';
+
 # Legacy Upgrade Guide
+
+<LegacyDocsTabs active="legacy-upgrade-guide" />
 
 :::info
 This page contains upgrade guides for older luma.gl releases (up through v8.5). For upgrading to luma.gl v9, refer to the main [Upgrade Guide](/docs/upgrade-guide).

--- a/docs/legacy/legacy-whats-new.md
+++ b/docs/legacy/legacy-whats-new.md
@@ -1,4 +1,8 @@
+import {LegacyDocsTabs} from '@site/src/components/docs/legacy-docs-tabs';
+
 # Legacy What's New
+
+<LegacyDocsTabs active="legacy-whats-new" />
 
 :::info
 This page contains release notes for older luma.gl releases (up through v8.5). For luma.gl v9, refer to the main [Whats' New](/docs/whats-new) page.

--- a/docs/legacy/porting-guide.md
+++ b/docs/legacy/porting-guide.md
@@ -1,4 +1,8 @@
+import {LegacyDocsTabs} from '@site/src/components/docs/legacy-docs-tabs';
+
 # Porting Guide
+
+<LegacyDocsTabs active="porting-guide" />
 
 Given that the changes in the v9 API are quite extensive, this separate porting guide is provided to hopefully help plan the upgrade process.
 

--- a/website/src/components/docs/core-docs-tabs.tsx
+++ b/website/src/components/docs/core-docs-tabs.tsx
@@ -34,7 +34,15 @@ export type CoreDocsTabId =
   | 'texture'
   | 'texture-view'
   | 'sampler'
-  | 'external-texture';
+  | 'external-texture'
+  | 'shader-layout'
+  | 'bindings'
+  | 'shader-block-layout'
+  | 'buffer-layout'
+  | 'uniform-store'
+  | 'canvas-context'
+  | 'presentation-context'
+  | 'framebuffer';
 
 /** Core documentation tab group identifiers. */
 export type CoreDocsTabGroupId =
@@ -42,7 +50,9 @@ export type CoreDocsTabGroupId =
   | 'shader-types'
   | 'commands'
   | 'pipelines'
-  | 'textures';
+  | 'textures'
+  | 'layouts'
+  | 'presentation';
 
 const CORE_DOCS_TABS: Record<CoreDocsTabGroupId, CoreDocsTab[]> = {
   device: [
@@ -132,6 +142,30 @@ const CORE_DOCS_TABS: Record<CoreDocsTabGroupId, CoreDocsTab[]> = {
       id: 'external-texture',
       label: 'ExternalTexture',
       href: '/docs/api-reference/core/resources/external-texture'
+    }
+  ],
+  layouts: [
+    {id: 'shader-layout', label: 'ShaderLayout', href: '/docs/api-reference/core/shader-layout'},
+    {id: 'bindings', label: 'Bindings', href: '/docs/api-reference/core/bindings'},
+    {
+      id: 'shader-block-layout',
+      label: 'ShaderBlockLayout',
+      href: '/docs/api-reference/core/shader-block-layout'
+    },
+    {id: 'buffer-layout', label: 'BufferLayout', href: '/docs/api-reference/core/buffer-layout'},
+    {id: 'uniform-store', label: 'UniformStore', href: '/docs/api-reference/core/uniform-store'}
+  ],
+  presentation: [
+    {id: 'canvas-context', label: 'CanvasContext', href: '/docs/api-reference/core/canvas-context'},
+    {
+      id: 'presentation-context',
+      label: 'PresentationContext',
+      href: '/docs/api-reference/core/presentation-context'
+    },
+    {
+      id: 'framebuffer',
+      label: 'Framebuffer',
+      href: '/docs/api-reference/core/resources/framebuffer'
     }
   ]
 };

--- a/website/src/components/docs/engine-docs-tabs.tsx
+++ b/website/src/components/docs/engine-docs-tabs.tsx
@@ -1,0 +1,134 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type EngineDocsTab = {
+  /** Stable tab identifier. */
+  id: EngineDocsTabId;
+  /** User-facing tab label. */
+  label: string;
+  /** Documentation page URL. */
+  href: string;
+};
+
+/** Engine documentation tab identifiers. */
+export type EngineDocsTabId =
+  | 'geometry'
+  | 'gpu-geometry'
+  | 'built-in-geometries'
+  | 'scenegraphs'
+  | 'scenegraph-node'
+  | 'group-node'
+  | 'model-node'
+  | 'gpu-computations'
+  | 'computation'
+  | 'buffer-transform'
+  | 'texture-transform'
+  | 'swap'
+  | 'animation-loop'
+  | 'animation-loop-template'
+  | 'key-frames'
+  | 'timeline';
+
+/** Engine documentation tab group identifiers. */
+export type EngineDocsTabGroupId = 'geometry' | 'scenegraph' | 'compute' | 'animation';
+
+const ENGINE_DOCS_TABS: Record<EngineDocsTabGroupId, EngineDocsTab[]> = {
+  geometry: [
+    {id: 'geometry', label: 'Geometry', href: '/docs/api-reference/engine/geometry'},
+    {
+      id: 'gpu-geometry',
+      label: 'GPUGeometry',
+      href: '/docs/api-reference/engine/geometry/gpu-geometry'
+    },
+    {
+      id: 'built-in-geometries',
+      label: 'Built-ins',
+      href: '/docs/api-reference/engine/geometry/geometries'
+    }
+  ],
+  scenegraph: [
+    {id: 'scenegraphs', label: 'Scenegraphs', href: '/docs/api-guide/engine/scenegraph'},
+    {
+      id: 'scenegraph-node',
+      label: 'ScenegraphNode',
+      href: '/docs/api-reference/engine/scenegraph/scenegraph-node'
+    },
+    {
+      id: 'group-node',
+      label: 'GroupNode',
+      href: '/docs/api-reference/engine/scenegraph/group-node'
+    },
+    {
+      id: 'model-node',
+      label: 'ModelNode',
+      href: '/docs/api-reference/engine/scenegraph/model-node'
+    }
+  ],
+  compute: [
+    {id: 'gpu-computations', label: 'GPU Computations', href: '/docs/api-guide/engine/transforms'},
+    {
+      id: 'computation',
+      label: 'Computation',
+      href: '/docs/api-reference/engine/compute/computation'
+    },
+    {
+      id: 'buffer-transform',
+      label: 'BufferTransform',
+      href: '/docs/api-reference/engine/compute/buffer-transform'
+    },
+    {
+      id: 'texture-transform',
+      label: 'TextureTransform',
+      href: '/docs/api-reference/engine/compute/texture-transform'
+    },
+    {id: 'swap', label: 'Swap', href: '/docs/api-reference/engine/compute/swap'}
+  ],
+  animation: [
+    {
+      id: 'animation-loop',
+      label: 'AnimationLoop',
+      href: '/docs/api-reference/engine/animation-loop'
+    },
+    {
+      id: 'animation-loop-template',
+      label: 'Template',
+      href: '/docs/api-reference/engine/animation-loop-template'
+    },
+    {
+      id: 'key-frames',
+      label: 'KeyFrames',
+      href: '/docs/api-reference/engine/animation/key-frames'
+    },
+    {id: 'timeline', label: 'Timeline', href: '/docs/api-reference/engine/animation/timeline'}
+  ]
+};
+
+/**
+ * Renders page links with the same visual treatment as tabs for related engine documentation pages.
+ */
+export function EngineDocsTabs({
+  group,
+  active
+}: {
+  group: EngineDocsTabGroupId;
+  active: EngineDocsTabId;
+}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="Engine documentation sections">
+      {ENGINE_DOCS_TABS[group].map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/website/src/components/docs/gpu-memory-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-memory-docs-tabs.tsx
@@ -1,0 +1,63 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type GpuMemoryDocsTab = {
+  /** Stable tab identifier. */
+  id: GpuMemoryDocsTabId;
+  /** User-facing tab label. */
+  label: string;
+  /** Documentation page URL. */
+  href: string;
+};
+
+/** GPU memory documentation tab identifiers. */
+export type GpuMemoryDocsTabId =
+  | 'gpu-memory'
+  | 'gpu-buffers'
+  | 'gpu-memory-layouts'
+  | 'buffer-schemas'
+  | 'gpu-storage-buffers';
+
+const GPU_MEMORY_DOCS_TABS: GpuMemoryDocsTab[] = [
+  {id: 'gpu-memory', label: 'GPU Memory', href: '/docs/api-guide/gpu/gpu-memory'},
+  {id: 'gpu-buffers', label: 'GPU Buffers', href: '/docs/api-guide/gpu/gpu-buffers'},
+  {
+    id: 'gpu-memory-layouts',
+    label: 'Memory Layouts',
+    href: '/docs/api-guide/gpu/gpu-memory-layouts'
+  },
+  {
+    id: 'buffer-schemas',
+    label: 'Buffer Schemas',
+    href: '/docs/api-guide/gpu/buffer-schemas'
+  },
+  {
+    id: 'gpu-storage-buffers',
+    label: 'Storage Buffers',
+    href: '/docs/api-guide/gpu/gpu-storage-buffers'
+  }
+];
+
+/**
+ * Renders page links with the same visual treatment as tabs for GPU memory guide pages.
+ */
+export function GpuMemoryDocsTabs({active}: {active: GpuMemoryDocsTabId}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="GPU memory documentation sections">
+      {GPU_MEMORY_DOCS_TABS.map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/website/src/components/docs/legacy-docs-tabs.tsx
+++ b/website/src/components/docs/legacy-docs-tabs.tsx
@@ -1,0 +1,44 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type LegacyDocsTab = {
+  /** Stable tab identifier. */
+  id: LegacyDocsTabId;
+  /** User-facing tab label. */
+  label: string;
+  /** Documentation page URL. */
+  href: string;
+};
+
+/** Legacy documentation tab identifiers. */
+export type LegacyDocsTabId = 'porting-guide' | 'legacy-upgrade-guide' | 'legacy-whats-new';
+
+const LEGACY_DOCS_TABS: LegacyDocsTab[] = [
+  {id: 'porting-guide', label: 'Porting', href: '/docs/legacy/porting-guide'},
+  {id: 'legacy-upgrade-guide', label: 'Upgrade', href: '/docs/legacy/legacy-upgrade-guide'},
+  {id: 'legacy-whats-new', label: "What's New", href: '/docs/legacy/legacy-whats-new'}
+];
+
+/**
+ * Renders page links with the same visual treatment as tabs for legacy documentation pages.
+ */
+export function LegacyDocsTabs({active}: {active: LegacyDocsTabId}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="Legacy documentation sections">
+      {LEGACY_DOCS_TABS.map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/website/src/components/docs/shadertools-docs-tabs.tsx
+++ b/website/src/components/docs/shadertools-docs-tabs.tsx
@@ -1,0 +1,85 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type ShadertoolsDocsTab = {
+  /** Stable tab identifier. */
+  id: ShadertoolsDocsTabId;
+  /** User-facing tab label. */
+  label: string;
+  /** Documentation page URL. */
+  href: string;
+};
+
+/** Shadertools documentation tab identifiers. */
+export type ShadertoolsDocsTabId =
+  | 'overview'
+  | 'shader-module'
+  | 'shader-plugin'
+  | 'shader-pass'
+  | 'shader-assembler'
+  | 'shader-info'
+  | 'wgsl-support'
+  | 'shader-conventions';
+
+const SHADERTOOLS_DOCS_TABS: ShadertoolsDocsTab[] = [
+  {id: 'overview', label: 'Overview', href: '/docs/api-reference/shadertools'},
+  {
+    id: 'shader-module',
+    label: 'ShaderModule',
+    href: '/docs/api-reference/shadertools/shader-module'
+  },
+  {
+    id: 'shader-plugin',
+    label: 'ShaderPlugin',
+    href: '/docs/api-reference/shadertools/shader-plugin'
+  },
+  {
+    id: 'shader-pass',
+    label: 'ShaderPass',
+    href: '/docs/api-reference/shadertools/shader-pass'
+  },
+  {
+    id: 'shader-assembler',
+    label: 'ShaderAssembler',
+    href: '/docs/api-reference/shadertools/shader-assembler'
+  },
+  {
+    id: 'shader-info',
+    label: 'Shader Parsing',
+    href: '/docs/api-reference/shadertools/shader-info'
+  },
+  {
+    id: 'wgsl-support',
+    label: 'WGSL',
+    href: '/docs/api-reference/shadertools/wgsl-support'
+  },
+  {
+    id: 'shader-conventions',
+    label: 'Conventions',
+    href: '/docs/api-reference/shadertools/shader-conventions'
+  }
+];
+
+/**
+ * Renders page links with the same visual treatment as tabs for Shadertools documentation pages.
+ */
+export function ShadertoolsDocsTabs({active}: {active: ShadertoolsDocsTabId}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="Shadertools documentation sections">
+      {SHADERTOOLS_DOCS_TABS.map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

- add page-level DocTabs navigation to 97 related documentation pages
- add grouped navigation for engine geometry, scenegraph, compute, animation, dynamic resources, fullscreen rendering, and model composition
- add guide navigation for GPU memory, GPU execution, GPU shader data, tutorials, developer workflow, and legacy docs
- add reference navigation for Shadertools, built-in shader modules, experimental renderers, WebGL, glTF, and test utilities
- extend Core DocTabs with layouts/bindings and presentation groups
- preserve existing routes, sidebar structure, and page content

## Why

Related documentation pages were discoverable from the sidebar but lacked local navigation once a reader landed on a page. These tab groups make adjacent guides and API references easier to move between while preserving the existing information architecture.

## Validation

- `nvm use`
- `env -u YARN_NO_PROXY yarn install`
- `env -u YARN_NO_PROXY yarn lint fix`
- `env -u YARN_NO_PROXY yarn build`
- `env -u YARN_NO_PROXY yarn test` (rerun with elevated local Playwright process/cache access after a sandboxed Chromium launch aborted)
- `env -u YARN_NO_PROXY yarn website:build`
- `(cd website && env -u YARN_NO_PROXY yarn build)`
- spot-checked generated pages for every DocTabs component family, confirming one navigation landmark and one active tab
