### PR TITLE
doc: expand navigation tabs

### DIFF
--- a/docs/api-guide/engine/materials.md
+++ b/docs/api-guide/engine/materials.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # Materials
+
+<EngineDocsTabs group="model" active="materials" />
 
 In luma.gl, a `Material` describes reusable surface state for one shading model
 or material schema. A `MaterialFactory` defines that schema and creates

--- a/docs/api-guide/engine/shader-inputs.md
+++ b/docs/api-guide/engine/shader-inputs.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # Shader Inputs
+
+<EngineDocsTabs group="model" active="shader-inputs-guide" />
 
 `ShaderInputs` is the engine-side bridge between shader-module props and the
 uniform buffers or bindings consumed by a [`Model`](/docs/api-reference/engine/model)

--- a/docs/api-guide/gpu/README.md
+++ b/docs/api-guide/gpu/README.md
@@ -1,4 +1,8 @@
+import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
+
 # Overview
+
+<GpuGuideDocsTabs group="execution" active="overview" />
 
 - [GPU initialization](/docs/api-guide/gpu/gpu-initialization) - Open a GPU device and query its capabilities.
 - [GPU memory management](/docs/api-guide/gpu/gpu-memory) - Create, upload memory to and read from [Buffers](/docs/api-guide/gpu/gpu-buffers), [Textures](/docs/api-guide/gpu/gpu-textures) etc.

--- a/docs/api-guide/gpu/gpu-attributes.md
+++ b/docs/api-guide/gpu/gpu-attributes.md
@@ -1,4 +1,8 @@
+import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
+
 # Attributes
+
+<GpuGuideDocsTabs group="shader-data" active="attributes" />
 
 :::info
 Note that while **attributes** is a structured and performant mechanism to provide columnar data to shaders that works on both WebGPU and WebGL, they are rather rigid and have a number of limitations. In WebGPU a more significantly more flexible approach is to use [storage buffers](./gpu-storage-buffers).

--- a/docs/api-guide/gpu/gpu-bindings.md
+++ b/docs/api-guide/gpu/gpu-bindings.md
@@ -1,4 +1,8 @@
+import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
+
 # Bind Groups and Bindings
+
+<GpuGuideDocsTabs group="shader-data" active="bindings" />
 
 luma.gl uses the term **binding** for GPU resources that shaders read through
 named binding declarations: uniform buffers, storage buffers, textures, and

--- a/docs/api-guide/gpu/gpu-initialization.md
+++ b/docs/api-guide/gpu/gpu-initialization.md
@@ -1,6 +1,9 @@
 import {AdapterBackendGraphic} from '@site/src/components/docs/adapter-backend-graphic';
+import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
 
 # GPU Initialization
+
+<GpuGuideDocsTabs group="execution" active="initialization" />
 
 ## Adapter
 

--- a/docs/api-guide/gpu/gpu-parameters.md
+++ b/docs/api-guide/gpu/gpu-parameters.md
@@ -1,4 +1,8 @@
+import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
+
 # Using GPU Parameters
+
+<GpuGuideDocsTabs group="execution" active="parameters" />
 
 luma.gl provides a unified API for controlling GPU parameters providing control of GPU pipeline features such as culling, depth and stencil buffers, blending, clipping etc.
 

--- a/docs/api-guide/gpu/gpu-rendering.md
+++ b/docs/api-guide/gpu/gpu-rendering.md
@@ -1,4 +1,8 @@
+import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
+
 # How GPU Rendering Works
+
+<GpuGuideDocsTabs group="execution" active="rendering" />
 
 See also [Issuing GPU Commands](/docs/api-guide/gpu/gpu-commands) for how render passes relate to `CommandEncoder`, `CommandBuffer`, and `device.submit()` on WebGL and WebGPU.
 

--- a/docs/api-guide/gpu/gpu-resources.md
+++ b/docs/api-guide/gpu/gpu-resources.md
@@ -1,4 +1,8 @@
+import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
+
 # GPU Resources
+
+<GpuGuideDocsTabs group="execution" active="resources" />
 
 A key role of the `Device` class is to let the application create GPU resources. 
 The main GPU resources that luma.gl applications will typically be creating directly are 

--- a/docs/api-guide/gpu/gpu-textures.mdx
+++ b/docs/api-guide/gpu/gpu-textures.mdx
@@ -1,6 +1,9 @@
 import {DeviceTabs, Format as Ft, Filter as L, Render as R} from '@site/src/react-luma';
+import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
 
 # Using GPU Textures
+
+<GpuGuideDocsTabs group="shader-data" active="textures" />
 
 See also [Issuing GPU Commands](/docs/api-guide/gpu/gpu-commands) for the difference between immediate texture helpers such as `writeData()` and explicit `CommandEncoder` copy operations.
 

--- a/docs/api-guide/gpu/gpu-uniforms.md
+++ b/docs/api-guide/gpu/gpu-uniforms.md
@@ -1,4 +1,8 @@
+import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
+
 # Uniforms
+
+<GpuGuideDocsTabs group="shader-data" active="uniforms" />
 
 Uniforms are shader variables whose values can be set from JavaScript.
 

--- a/docs/api-guide/gpu/tabular-data-in-wgsl.md
+++ b/docs/api-guide/gpu/tabular-data-in-wgsl.md
@@ -1,4 +1,8 @@
+import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
+
 # Tabular Data in WGSL
+
+<GpuGuideDocsTabs group="shader-data" active="tabular-data" />
 
 Many GPU workloads start with tabular data: each logical row describes one
 vertex, instance, particle, glyph, path, or record, and each column supplies one

--- a/docs/api-guide/gpu/video-textures.mdx
+++ b/docs/api-guide/gpu/video-textures.mdx
@@ -1,4 +1,8 @@
+import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
+
 # Working With Video Textures
+
+<GpuGuideDocsTabs group="shader-data" active="video-textures" />
 
 <p class="badges">
   <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />

--- a/docs/api-reference/engine/background-texture-model.md
+++ b/docs/api-reference/engine/background-texture-model.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # BackgroundTextureModel
+
+<EngineDocsTabs group="fullscreen" active="background-texture-model" />
 
 `BackgroundTextureModel` is a specialized [`ClipSpace`](/docs/api-reference/engine/clip-space) that renders one texture across the screen while preserving aspect ratio.
 

--- a/docs/api-reference/engine/clip-space.md
+++ b/docs/api-reference/engine/clip-space.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # ClipSpace
+
+<EngineDocsTabs group="fullscreen" active="clip-space" />
 
 `ClipSpace` is a convenience subclass of [`Model`](/docs/api-reference/engine/model) that draws a fullscreen quad in clip space.
 

--- a/docs/api-reference/engine/dynamic-buffer.md
+++ b/docs/api-reference/engine/dynamic-buffer.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # DynamicBuffer
+
+<EngineDocsTabs group="dynamic-resources" active="dynamic-buffer" />
 
 <p class="badges">
   <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />

--- a/docs/api-reference/engine/dynamic-texture.md
+++ b/docs/api-reference/engine/dynamic-texture.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # DynamicTexture
+
+<EngineDocsTabs group="dynamic-resources" active="dynamic-texture" />
 
 <p class="badges">
   <img src="https://img.shields.io/badge/From-v9.3-blue.svg?style=flat-square" alt="From-v9.3" />

--- a/docs/api-reference/engine/load-image-bitmap.md
+++ b/docs/api-reference/engine/load-image-bitmap.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # loadImageBitmap
+
+<EngineDocsTabs group="dynamic-resources" active="load-image-bitmap" />
 
 A simple small utility to load images from URLs. The loaded `ImageBitmaps` can be used to create textures.
 

--- a/docs/api-reference/engine/model.md
+++ b/docs/api-reference/engine/model.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # Model
+
+<EngineDocsTabs group="model" active="model" />
 
 `Model` is the main engine-level rendering class in luma.gl.
 It assembles shaders, manages geometry and bindings, reuses immutable cached

--- a/docs/api-reference/engine/passes/shader-pass-renderer.md
+++ b/docs/api-reference/engine/passes/shader-pass-renderer.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # ShaderPassRenderer
+
+<EngineDocsTabs group="fullscreen" active="shader-pass-renderer" />
 
 `ShaderPassRenderer` applies one or more `ShaderPass` or `ShaderPassPipeline` definitions to a source texture and either renders the result back to a texture or draws it to the screen.
 

--- a/docs/api-reference/engine/shader-inputs.md
+++ b/docs/api-reference/engine/shader-inputs.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # ShaderInputs
+
+<EngineDocsTabs group="model" active="shader-inputs" />
 
 `ShaderInputs` stores per-module uniform values and binding values for shader modules.
 It is the glue between engine classes like [`Model`](/docs/api-reference/engine/model) and [`Computation`](/docs/api-reference/engine/compute/computation) and the uniform layouts defined by `@luma.gl/shadertools` modules.

--- a/docs/api-reference/engine/video-texture.md
+++ b/docs/api-reference/engine/video-texture.md
@@ -1,4 +1,8 @@
+import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+
 # VideoTexture
+
+<EngineDocsTabs group="dynamic-resources" active="video-texture" />
 
 <p class="badges">
   <img src="https://img.shields.io/badge/From-v10-blue.svg?style=flat-square" alt="From-v10" />

--- a/docs/api-reference/experimental/README.md
+++ b/docs/api-reference/experimental/README.md
@@ -1,4 +1,8 @@
+import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-tabs';
+
 # @luma.gl/experimental
+
+<ExperimentalDocsTabs active="overview" />
 
 `@luma.gl/experimental` publishes incubating luma.gl APIs that are usable by applications but may
 change or be removed without the compatibility guarantees applied to stable modules.

--- a/docs/api-reference/experimental/a-buffer-renderer.md
+++ b/docs/api-reference/experimental/a-buffer-renderer.md
@@ -1,4 +1,8 @@
+import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-tabs';
+
 # ABufferRenderer
+
+<ExperimentalDocsTabs active="a-buffer-renderer" />
 
 `ABufferRenderer` provides experimental WebGPU-only order-independent transparency for models that append final fragment colors into the `aBuffer` shader module.
 

--- a/docs/api-reference/experimental/wboit-renderer.md
+++ b/docs/api-reference/experimental/wboit-renderer.md
@@ -1,4 +1,8 @@
+import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-tabs';
+
 # WBOITRenderer
+
+<ExperimentalDocsTabs active="wboit-renderer" />
 
 `WBOITRenderer` implements weighted blended order-independent transparency on WebGPU and WebGL2.
 It owns floating-point accumulation and revealage targets, records the required passes, and

--- a/docs/api-reference/gltf/README.md
+++ b/docs/api-reference/gltf/README.md
@@ -1,4 +1,8 @@
+import {GltfDocsTabs} from '@site/src/components/docs/gltf-docs-tabs';
+
 # Overview
+
+<GltfDocsTabs active="overview" />
 
 The `@luma.gl/gltf` modules utilities for turning glTF data into a
 [luma.gl scenegraph](/docs/api-reference/engine/scenegraph/scenegraph-node) .

--- a/docs/api-reference/gltf/gltf-extensions.mdx
+++ b/docs/api-reference/gltf/gltf-extensions.mdx
@@ -2,6 +2,8 @@
 sidebar_label: Extension Support
 ---
 
+import {GltfDocsTabs} from '@site/src/components/docs/gltf-docs-tabs';
+
 export const GLTF_EXTENSION_SPEC_BASE_URL =
   'https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0';
 
@@ -86,6 +88,8 @@ export const SupportRow = ({name, support, fromVersion, children}) => (
 );
 
 # glTF Extension Support
+
+<GltfDocsTabs active="extensions" />
 
 <p className="badges">
   <FromVersionBadge version="9.3" />

--- a/docs/api-reference/shadertools/shader-modules/dirlight.md
+++ b/docs/api-reference/shadertools/shader-modules/dirlight.md
@@ -1,4 +1,8 @@
+import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
+
 # dirlight
+
+<ShaderModuleDocsTabs group="lighting" active="dirlight" />
 
 The `dirlight` shader module is a lightweight alternative to the full
 [`lighting`](/docs/api-reference/shadertools/shader-modules/lighting) module.

--- a/docs/api-reference/shadertools/shader-modules/fp32.md
+++ b/docs/api-reference/shadertools/shader-modules/fp32.md
@@ -1,4 +1,8 @@
+import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
+
 # fp32 (32-bit Floating Point)
+
+<ShaderModuleDocsTabs group="precision" active="fp32" />
 
 Provides "improved" 32-bit math support to GPU shaders on certain platforms,
 mainly compensating for non-IEEE compliant "fast-math" functions that

--- a/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
@@ -1,4 +1,8 @@
+import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
+
 # fp64arithmetic
+
+<ShaderModuleDocsTabs group="precision" active="fp64-arithmetic" />
 
 The `fp64arithmetic` shader module provides the low-level double-single
 arithmetic used by [`fp64`](/docs/api-reference/shadertools/shader-modules/fp64).

--- a/docs/api-reference/shadertools/shader-modules/fp64.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64.md
@@ -1,4 +1,8 @@
+import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
+
 # fp64 (64-bit Floating Point)
+
+<ShaderModuleDocsTabs group="precision" active="fp64" />
 
 Provides basic 64-bit math support in GPU shaders:
 

--- a/docs/api-reference/shadertools/shader-modules/gouraud-material.md
+++ b/docs/api-reference/shadertools/shader-modules/gouraud-material.md
@@ -1,4 +1,8 @@
+import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
+
 # gouraudMaterial
+
+<ShaderModuleDocsTabs group="lighting" active="gouraud-material" />
 
 The `gouraudMaterial` shader module provides functions to apply Gouraud shading
 with a simple specular model per vertex. It is typically faster than

--- a/docs/api-reference/shadertools/shader-modules/lambert-material.md
+++ b/docs/api-reference/shadertools/shader-modules/lambert-material.md
@@ -1,4 +1,8 @@
+import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
+
 # lambertMaterial
+
+<ShaderModuleDocsTabs group="lighting" active="lambert-material" />
 
 This `lambertMaterial` shader module provides a diffuse-only matte material
 model. It applies Lambert shading per fragment using the shared

--- a/docs/api-reference/shadertools/shader-modules/lighting.md
+++ b/docs/api-reference/shadertools/shader-modules/lighting.md
@@ -1,4 +1,8 @@
+import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
+
 # lighting
+
+<ShaderModuleDocsTabs group="lighting" active="lighting" />
 
 The `lighting` shader module collects scene lighting into a single uniform block
 that can be shared across draw calls. It is the common light source module used

--- a/docs/api-reference/shadertools/shader-modules/pbr-material.md
+++ b/docs/api-reference/shadertools/shader-modules/pbr-material.md
@@ -1,4 +1,8 @@
+import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
+
 # pbrMaterial
+
+<ShaderModuleDocsTabs group="lighting" active="pbr-material" />
 
 Implements Physically Based Shading of a microfacet surface defined by a glTF material.
 

--- a/docs/api-reference/shadertools/shader-modules/phong-material.md
+++ b/docs/api-reference/shadertools/shader-modules/phong-material.md
@@ -1,4 +1,8 @@
+import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
+
 # phongMaterial
+
+<ShaderModuleDocsTabs group="lighting" active="phong-material" />
 
 This `phongMaterial` shader module provides functions to apply Phong shading
 with a simple specular model per fragment. It is a good default when you want

--- a/docs/api-reference/test-utils/README.md
+++ b/docs/api-reference/test-utils/README.md
@@ -1,3 +1,7 @@
+import {TestUtilsDocsTabs} from '@site/src/components/docs/test-utils-docs-tabs';
+
 # Overview
+
+<TestUtilsDocsTabs active="overview" />
 
 `@luma.gl/test-utils` contains support for testing luma.gl programs.

--- a/docs/api-reference/test-utils/snapshot-test-runner.md
+++ b/docs/api-reference/test-utils/snapshot-test-runner.md
@@ -1,4 +1,8 @@
+import {TestUtilsDocsTabs} from '@site/src/components/docs/test-utils-docs-tabs';
+
 # SnapshotTestRunner
+
+<TestUtilsDocsTabs active="snapshot-test-runner" />
 
 Client-side utility for browser-based WebGL render tests.
 

--- a/docs/api-reference/webgl/README.md
+++ b/docs/api-reference/webgl/README.md
@@ -1,4 +1,8 @@
+import {WebGLDocsTabs} from '@site/src/components/docs/webgl-docs-tabs';
+
 # @luma.gl/webgl
+
+<WebGLDocsTabs active="overview" />
 
 ## WebGL Device Adapter
 

--- a/docs/api-reference/webgl/constants.md
+++ b/docs/api-reference/webgl/constants.md
@@ -1,4 +1,8 @@
+import {WebGLDocsTabs} from '@site/src/components/docs/webgl-docs-tabs';
+
 # `@luma.gl/webgl/constants`
+
+<WebGLDocsTabs active="constants" />
 
 <p class="badges">
   <img src="https://img.shields.io/badge/From-v9.3-blue.svg?style=flat-square" alt="From-v9.3" />

--- a/docs/developer-guide/README.md
+++ b/docs/developer-guide/README.md
@@ -1,4 +1,8 @@
+import {DeveloperDocsTabs} from '@site/src/components/docs/developer-docs-tabs';
+
 # Developer Guide
+
+<DeveloperDocsTabs active="overview" />
 
 This developer guide focuses on the practicalities of developing with the luma.gl framework,
 such as installing, debugging, profiling, bundling etc.

--- a/docs/developer-guide/bundling.md
+++ b/docs/developer-guide/bundling.md
@@ -1,4 +1,8 @@
+import {DeveloperDocsTabs} from '@site/src/components/docs/developer-docs-tabs';
+
 # Bundling
+
+<DeveloperDocsTabs active="bundling" />
 
 ## Optimizing for Bundle Size
 

--- a/docs/developer-guide/contributing.md
+++ b/docs/developer-guide/contributing.md
@@ -1,4 +1,8 @@
+import {DeveloperDocsTabs} from '@site/src/components/docs/developer-docs-tabs';
+
 # Contributing
+
+<DeveloperDocsTabs active="contributing" />
 
 luma.gl welcomes contributions from the community. Smaller fixes 
 

--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -1,4 +1,8 @@
+import {DeveloperDocsTabs} from '@site/src/components/docs/developer-docs-tabs';
+
 # Debugging
+
+<DeveloperDocsTabs active="debugging" />
 
 ## Why GPU Debugging can be hard
 

--- a/docs/developer-guide/editing.md
+++ b/docs/developer-guide/editing.md
@@ -1,4 +1,8 @@
+import {DeveloperDocsTabs} from '@site/src/components/docs/developer-docs-tabs';
+
 # Editing
+
+<DeveloperDocsTabs active="editing" />
 
 ## Shader Syntax Highlighting
 
@@ -9,4 +13,3 @@ If you are using vscode, the
 [vscode-glsl-literal](https://marketplace.visualstudio.com/items?itemName=boyswan.glsl-literal) and 
 [vscode-wgsl-literal](https://marketplace.visualstudio.com/items?itemName=ggsimm.wgsl-literal) 
 vscode extensions can be used to regain syntax highlighting.
-

--- a/docs/developer-guide/profiling.md
+++ b/docs/developer-guide/profiling.md
@@ -1,4 +1,8 @@
+import {DeveloperDocsTabs} from '@site/src/components/docs/developer-docs-tabs';
+
 # Profiling
+
+<DeveloperDocsTabs active="profiling" />
 
 GPU programming is all about performance, so having tools to systematically
 measure the performance impact of code changes is critical. luma.gl offers

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -1,4 +1,8 @@
+import {DeveloperDocsTabs} from '@site/src/components/docs/developer-docs-tabs';
+
 # Testing
+
+<DeveloperDocsTabs active="testing" />
 
 The primary test runner is Vitest.
 

--- a/docs/tutorials/README.mdx
+++ b/docs/tutorials/README.mdx
@@ -1,4 +1,8 @@
+import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
+
 # Setup
+
+<TutorialDocsTabs group="fundamentals" active="setup" />
 
 These tutorials use the current luma.gl v9.3 API. The runnable sources in
 [`examples/tutorials`](https://github.com/visgl/luma.gl/tree/master/examples/tutorials)

--- a/docs/tutorials/hello-cube.mdx
+++ b/docs/tutorials/hello-cube.mdx
@@ -1,7 +1,10 @@
 import {DeviceTabs} from '@site/src/react-luma';
 import {HelloCubeExample} from '@site/src/examples';
+import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 # Hello Cube
+
+<TutorialDocsTabs group="fundamentals" active="hello-cube" />
 
 This tutorial demonstrates how to render a spinning textured cube using luma.gl's cross-platform rendering APIs.
 

--- a/docs/tutorials/hello-instancing.mdx
+++ b/docs/tutorials/hello-instancing.mdx
@@ -1,7 +1,10 @@
 import {DeviceTabs} from '@site/src/react-luma';
 import {HelloInstancingExample} from '@site/src/examples';
+import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 # Hello Instancing
+
+<TutorialDocsTabs group="fundamentals" active="hello-instancing" />
 
 This tutorial illustrates _instanced_ drawing with luma.gl using both WGSL and GLSL shaders and also shows how a custom luma.gl _shader module_ can be used to pass colors.
 

--- a/docs/tutorials/hello-triangle.mdx
+++ b/docs/tutorials/hello-triangle.mdx
@@ -1,7 +1,10 @@
 import {DeviceTabs} from '@site/src/react-luma';
 import {HelloTriangleExample} from '@site/src/examples';
+import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 # Hello Triangle
+
+<TutorialDocsTabs group="fundamentals" active="hello-triangle" />
 
 This tutorial demonstrates how to draw a triangle using luma.gl's cross-platform rendering APIs.
 

--- a/docs/tutorials/lighting.mdx
+++ b/docs/tutorials/lighting.mdx
@@ -1,7 +1,10 @@
 import {DeviceTabs} from '@site/src/react-luma';
 import {LightingExample} from '@site/src/examples';
+import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 # Lighting
+
+<TutorialDocsTabs group="shaders" active="lighting" />
 
 Add Phong shading to a textured cube using luma.gl's shader module system.
 

--- a/docs/tutorials/shader-hooks.mdx
+++ b/docs/tutorials/shader-hooks.mdx
@@ -1,7 +1,10 @@
 import {DeviceTabs} from '@site/src/react-luma';
 import {ShaderHooksExample} from '@site/src/examples';
+import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 # Shader Hooks
+
+<TutorialDocsTabs group="shaders" active="shader-hooks" />
 
 Shader hooks let shader modules inject code into designated points in a shader. This example defines an `OFFSET_POSITION` hook that two modules use to shift geometry left or right.
 

--- a/docs/tutorials/shader-modules.mdx
+++ b/docs/tutorials/shader-modules.mdx
@@ -1,7 +1,10 @@
 import {DeviceTabs} from '@site/src/react-luma';
 import {ShaderModulesExample} from '@site/src/examples';
+import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 # Shader Modules
+
+<TutorialDocsTabs group="shaders" active="shader-modules" />
 
 This tutorial shows how to build reusable shader functionality with luma.gl's shader modules. The example below defines a custom `color` module that converts HSV to RGB and adds moving highlight bands to two different models.
 

--- a/docs/tutorials/shader-plugins.mdx
+++ b/docs/tutorials/shader-plugins.mdx
@@ -1,7 +1,10 @@
 import {DeviceTabs} from '@site/src/react-luma';
 import {ShaderPluginsExample} from '@site/src/examples';
+import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 # Shader Plugins
+
+<TutorialDocsTabs group="shaders" active="shader-plugins" />
 
 `ShaderPlugin` packages reusable shader behavior that can be attached to a `Model` or `Computation`. This example renders a grid of triangles from one base shader pair. One plugin adds procedural fill patterns, while `clipShaderPlugin` adds portable whole-instance and per-fragment clipping.
 

--- a/docs/tutorials/transform-feedback.mdx
+++ b/docs/tutorials/transform-feedback.mdx
@@ -1,7 +1,10 @@
 import {DeviceTabs} from '@site/src/react-luma';
 import {TransformFeedbackExample} from '@site/src/examples';
+import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 # Transform Feedback
+
+<TutorialDocsTabs group="transforms" active="transform-feedback" />
 
 This tutorial demonstrates animating geometry using transform feedback via the `BufferTransform` class. A compute shader rotates triangle vertices on the GPU each frame.
 

--- a/docs/tutorials/transform.mdx
+++ b/docs/tutorials/transform.mdx
@@ -1,7 +1,10 @@
 import {DeviceTabs} from '@site/src/react-luma';
 import {TransformExample} from '@site/src/examples';
+import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 # Transform
+
+<TutorialDocsTabs group="transforms" active="transform" />
 
 This tutorial uses `BufferTransform` to update per-instance data on the GPU and render thousands of wandering triangles. The compute shader runs in a transform feedback pass before each draw.
 

--- a/website/src/components/docs/developer-docs-tabs.tsx
+++ b/website/src/components/docs/developer-docs-tabs.tsx
@@ -1,0 +1,50 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type DeveloperDocsTab = {
+  id: DeveloperDocsTabId;
+  label: string;
+  href: string;
+};
+
+/** Developer documentation tab identifiers. */
+export type DeveloperDocsTabId =
+  | 'overview'
+  | 'contributing'
+  | 'editing'
+  | 'testing'
+  | 'debugging'
+  | 'profiling'
+  | 'bundling';
+
+const DEVELOPER_DOCS_TABS: DeveloperDocsTab[] = [
+  {id: 'overview', label: 'Overview', href: '/docs/developer-guide'},
+  {id: 'contributing', label: 'Contributing', href: '/docs/developer-guide/contributing'},
+  {id: 'editing', label: 'Editing', href: '/docs/developer-guide/editing'},
+  {id: 'testing', label: 'Testing', href: '/docs/developer-guide/testing'},
+  {id: 'debugging', label: 'Debugging', href: '/docs/developer-guide/debugging'},
+  {id: 'profiling', label: 'Profiling', href: '/docs/developer-guide/profiling'},
+  {id: 'bundling', label: 'Bundling', href: '/docs/developer-guide/bundling'}
+];
+
+/** Renders page links with the same visual treatment as tabs for developer documentation pages. */
+export function DeveloperDocsTabs({active}: {active: DeveloperDocsTabId}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="Developer documentation sections">
+      {DEVELOPER_DOCS_TABS.map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/website/src/components/docs/engine-docs-tabs.tsx
+++ b/website/src/components/docs/engine-docs-tabs.tsx
@@ -27,10 +27,28 @@ export type EngineDocsTabId =
   | 'animation-loop'
   | 'animation-loop-template'
   | 'key-frames'
-  | 'timeline';
+  | 'timeline'
+  | 'dynamic-buffer'
+  | 'dynamic-texture'
+  | 'video-texture'
+  | 'load-image-bitmap'
+  | 'clip-space'
+  | 'background-texture-model'
+  | 'shader-pass-renderer'
+  | 'model'
+  | 'shader-inputs-guide'
+  | 'shader-inputs'
+  | 'materials';
 
 /** Engine documentation tab group identifiers. */
-export type EngineDocsTabGroupId = 'geometry' | 'scenegraph' | 'compute' | 'animation';
+export type EngineDocsTabGroupId =
+  | 'geometry'
+  | 'scenegraph'
+  | 'compute'
+  | 'animation'
+  | 'dynamic-resources'
+  | 'fullscreen'
+  | 'model';
 
 const ENGINE_DOCS_TABS: Record<EngineDocsTabGroupId, EngineDocsTab[]> = {
   geometry: [
@@ -100,6 +118,39 @@ const ENGINE_DOCS_TABS: Record<EngineDocsTabGroupId, EngineDocsTab[]> = {
       href: '/docs/api-reference/engine/animation/key-frames'
     },
     {id: 'timeline', label: 'Timeline', href: '/docs/api-reference/engine/animation/timeline'}
+  ],
+  'dynamic-resources': [
+    {id: 'dynamic-buffer', label: 'DynamicBuffer', href: '/docs/api-reference/engine/dynamic-buffer'},
+    {
+      id: 'dynamic-texture',
+      label: 'DynamicTexture',
+      href: '/docs/api-reference/engine/dynamic-texture'
+    },
+    {id: 'video-texture', label: 'VideoTexture', href: '/docs/api-reference/engine/video-texture'},
+    {
+      id: 'load-image-bitmap',
+      label: 'loadImageBitmap',
+      href: '/docs/api-reference/engine/load-image-bitmap'
+    }
+  ],
+  fullscreen: [
+    {id: 'clip-space', label: 'ClipSpace', href: '/docs/api-reference/engine/clip-space'},
+    {
+      id: 'background-texture-model',
+      label: 'BackgroundTextureModel',
+      href: '/docs/api-reference/engine/background-texture-model'
+    },
+    {
+      id: 'shader-pass-renderer',
+      label: 'ShaderPassRenderer',
+      href: '/docs/api-reference/engine/passes/shader-pass-renderer'
+    }
+  ],
+  model: [
+    {id: 'model', label: 'Model', href: '/docs/api-reference/engine/model'},
+    {id: 'shader-inputs-guide', label: 'Shader Inputs', href: '/docs/api-guide/engine/shader-inputs'},
+    {id: 'shader-inputs', label: 'ShaderInputs', href: '/docs/api-reference/engine/shader-inputs'},
+    {id: 'materials', label: 'Materials', href: '/docs/api-guide/engine/materials'}
   ]
 };
 

--- a/website/src/components/docs/experimental-docs-tabs.tsx
+++ b/website/src/components/docs/experimental-docs-tabs.tsx
@@ -1,0 +1,43 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type ExperimentalDocsTab = {id: ExperimentalDocsTabId; label: string; href: string};
+
+/** Experimental documentation tab identifiers. */
+export type ExperimentalDocsTabId = 'overview' | 'a-buffer-renderer' | 'wboit-renderer';
+
+const EXPERIMENTAL_DOCS_TABS: ExperimentalDocsTab[] = [
+  {id: 'overview', label: 'Overview', href: '/docs/api-reference/experimental'},
+  {
+    id: 'a-buffer-renderer',
+    label: 'ABufferRenderer',
+    href: '/docs/api-reference/experimental/a-buffer-renderer'
+  },
+  {
+    id: 'wboit-renderer',
+    label: 'WBOITRenderer',
+    href: '/docs/api-reference/experimental/wboit-renderer'
+  }
+];
+
+/** Renders page links with the same visual treatment as tabs for experimental documentation pages. */
+export function ExperimentalDocsTabs({active}: {active: ExperimentalDocsTabId}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="Experimental documentation sections">
+      {EXPERIMENTAL_DOCS_TABS.map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/website/src/components/docs/gltf-docs-tabs.tsx
+++ b/website/src/components/docs/gltf-docs-tabs.tsx
@@ -1,0 +1,34 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type GltfDocsTab = {id: GltfDocsTabId; label: string; href: string};
+
+/** glTF documentation tab identifiers. */
+export type GltfDocsTabId = 'overview' | 'extensions';
+
+const GLTF_DOCS_TABS: GltfDocsTab[] = [
+  {id: 'overview', label: 'Overview', href: '/docs/api-reference/gltf'},
+  {id: 'extensions', label: 'Extensions', href: '/docs/api-reference/gltf/gltf-extensions'}
+];
+
+/** Renders page links with the same visual treatment as tabs for glTF documentation pages. */
+export function GltfDocsTabs({active}: {active: GltfDocsTabId}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="glTF documentation sections">
+      {GLTF_DOCS_TABS.map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/website/src/components/docs/gpu-guide-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-guide-docs-tabs.tsx
@@ -1,0 +1,71 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type GpuGuideDocsTab = {
+  id: GpuGuideDocsTabId;
+  label: string;
+  href: string;
+};
+
+/** GPU guide documentation tab identifiers. */
+export type GpuGuideDocsTabId =
+  | 'overview'
+  | 'initialization'
+  | 'resources'
+  | 'rendering'
+  | 'parameters'
+  | 'bindings'
+  | 'attributes'
+  | 'uniforms'
+  | 'textures'
+  | 'video-textures'
+  | 'tabular-data';
+
+/** GPU guide documentation tab group identifiers. */
+export type GpuGuideDocsTabGroupId = 'execution' | 'shader-data';
+
+const GPU_GUIDE_DOCS_TABS: Record<GpuGuideDocsTabGroupId, GpuGuideDocsTab[]> = {
+  execution: [
+    {id: 'overview', label: 'Overview', href: '/docs/api-guide/gpu'},
+    {id: 'initialization', label: 'Initialization', href: '/docs/api-guide/gpu/gpu-initialization'},
+    {id: 'resources', label: 'Resources', href: '/docs/api-guide/gpu/gpu-resources'},
+    {id: 'rendering', label: 'Rendering', href: '/docs/api-guide/gpu/gpu-rendering'},
+    {id: 'parameters', label: 'Parameters', href: '/docs/api-guide/gpu/gpu-parameters'}
+  ],
+  'shader-data': [
+    {id: 'bindings', label: 'Bindings', href: '/docs/api-guide/gpu/gpu-bindings'},
+    {id: 'attributes', label: 'Attributes', href: '/docs/api-guide/gpu/gpu-attributes'},
+    {id: 'uniforms', label: 'Uniforms', href: '/docs/api-guide/gpu/gpu-uniforms'},
+    {id: 'textures', label: 'Textures', href: '/docs/api-guide/gpu/gpu-textures'},
+    {id: 'video-textures', label: 'Video Textures', href: '/docs/api-guide/gpu/video-textures'},
+    {id: 'tabular-data', label: 'Tabular Data', href: '/docs/api-guide/gpu/tabular-data-in-wgsl'}
+  ]
+};
+
+/** Renders page links with the same visual treatment as tabs for related GPU guide pages. */
+export function GpuGuideDocsTabs({
+  group,
+  active
+}: {
+  group: GpuGuideDocsTabGroupId;
+  active: GpuGuideDocsTabId;
+}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="GPU guide documentation sections">
+      {GPU_GUIDE_DOCS_TABS[group].map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/website/src/components/docs/shader-module-docs-tabs.tsx
+++ b/website/src/components/docs/shader-module-docs-tabs.tsx
@@ -1,0 +1,87 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type ShaderModuleDocsTab = {
+  id: ShaderModuleDocsTabId;
+  label: string;
+  href: string;
+};
+
+/** Built-in shader module documentation tab identifiers. */
+export type ShaderModuleDocsTabId =
+  | 'fp32'
+  | 'fp64'
+  | 'fp64-arithmetic'
+  | 'lighting'
+  | 'dirlight'
+  | 'lambert-material'
+  | 'gouraud-material'
+  | 'phong-material'
+  | 'pbr-material';
+
+/** Built-in shader module documentation tab group identifiers. */
+export type ShaderModuleDocsTabGroupId = 'precision' | 'lighting';
+
+const SHADER_MODULE_DOCS_TABS: Record<ShaderModuleDocsTabGroupId, ShaderModuleDocsTab[]> = {
+  precision: [
+    {id: 'fp32', label: 'fp32', href: '/docs/api-reference/shadertools/shader-modules/fp32'},
+    {id: 'fp64', label: 'fp64', href: '/docs/api-reference/shadertools/shader-modules/fp64'},
+    {
+      id: 'fp64-arithmetic',
+      label: 'fp64arithmetic',
+      href: '/docs/api-reference/shadertools/shader-modules/fp64-arithmetic'
+    }
+  ],
+  lighting: [
+    {id: 'lighting', label: 'lighting', href: '/docs/api-reference/shadertools/shader-modules/lighting'},
+    {id: 'dirlight', label: 'dirlight', href: '/docs/api-reference/shadertools/shader-modules/dirlight'},
+    {
+      id: 'lambert-material',
+      label: 'lambertMaterial',
+      href: '/docs/api-reference/shadertools/shader-modules/lambert-material'
+    },
+    {
+      id: 'gouraud-material',
+      label: 'gouraudMaterial',
+      href: '/docs/api-reference/shadertools/shader-modules/gouraud-material'
+    },
+    {
+      id: 'phong-material',
+      label: 'phongMaterial',
+      href: '/docs/api-reference/shadertools/shader-modules/phong-material'
+    },
+    {
+      id: 'pbr-material',
+      label: 'pbrMaterial',
+      href: '/docs/api-reference/shadertools/shader-modules/pbr-material'
+    }
+  ]
+};
+
+/** Renders page links with the same visual treatment as tabs for built-in shader modules. */
+export function ShaderModuleDocsTabs({
+  group,
+  active
+}: {
+  group: ShaderModuleDocsTabGroupId;
+  active: ShaderModuleDocsTabId;
+}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="Built-in shader module documentation sections">
+      {SHADER_MODULE_DOCS_TABS[group].map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/website/src/components/docs/test-utils-docs-tabs.tsx
+++ b/website/src/components/docs/test-utils-docs-tabs.tsx
@@ -1,0 +1,38 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type TestUtilsDocsTab = {id: TestUtilsDocsTabId; label: string; href: string};
+
+/** Test utilities documentation tab identifiers. */
+export type TestUtilsDocsTabId = 'overview' | 'snapshot-test-runner';
+
+const TEST_UTILS_DOCS_TABS: TestUtilsDocsTab[] = [
+  {id: 'overview', label: 'Overview', href: '/docs/api-reference/test-utils'},
+  {
+    id: 'snapshot-test-runner',
+    label: 'SnapshotTestRunner',
+    href: '/docs/api-reference/test-utils/snapshot-test-runner'
+  }
+];
+
+/** Renders page links with the same visual treatment as tabs for test utilities documentation pages. */
+export function TestUtilsDocsTabs({active}: {active: TestUtilsDocsTabId}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="Test utilities documentation sections">
+      {TEST_UTILS_DOCS_TABS.map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/website/src/components/docs/tutorial-docs-tabs.tsx
+++ b/website/src/components/docs/tutorial-docs-tabs.tsx
@@ -1,0 +1,75 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type TutorialDocsTab = {
+  id: TutorialDocsTabId;
+  label: string;
+  href: string;
+};
+
+/** Tutorial documentation tab identifiers. */
+export type TutorialDocsTabId =
+  | 'setup'
+  | 'hello-triangle'
+  | 'hello-cube'
+  | 'hello-instancing'
+  | 'shader-modules'
+  | 'shader-hooks'
+  | 'shader-plugins'
+  | 'lighting'
+  | 'transform'
+  | 'transform-feedback';
+
+/** Tutorial documentation tab group identifiers. */
+export type TutorialDocsTabGroupId = 'fundamentals' | 'shaders' | 'transforms';
+
+const TUTORIAL_DOCS_TABS: Record<TutorialDocsTabGroupId, TutorialDocsTab[]> = {
+  fundamentals: [
+    {id: 'setup', label: 'Setup', href: '/docs/tutorials'},
+    {id: 'hello-triangle', label: 'Triangle', href: '/docs/tutorials/hello-triangle'},
+    {id: 'hello-cube', label: 'Cube', href: '/docs/tutorials/hello-cube'},
+    {id: 'hello-instancing', label: 'Instancing', href: '/docs/tutorials/hello-instancing'}
+  ],
+  shaders: [
+    {id: 'shader-modules', label: 'Modules', href: '/docs/tutorials/shader-modules'},
+    {id: 'shader-hooks', label: 'Hooks', href: '/docs/tutorials/shader-hooks'},
+    {id: 'shader-plugins', label: 'Plugins', href: '/docs/tutorials/shader-plugins'},
+    {id: 'lighting', label: 'Lighting', href: '/docs/tutorials/lighting'}
+  ],
+  transforms: [
+    {id: 'transform', label: 'Transform', href: '/docs/tutorials/transform'},
+    {
+      id: 'transform-feedback',
+      label: 'Transform Feedback',
+      href: '/docs/tutorials/transform-feedback'
+    }
+  ]
+};
+
+/** Renders page links with the same visual treatment as tabs for related tutorials. */
+export function TutorialDocsTabs({
+  group,
+  active
+}: {
+  group: TutorialDocsTabGroupId;
+  active: TutorialDocsTabId;
+}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="Tutorial documentation sections">
+      {TUTORIAL_DOCS_TABS[group].map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/website/src/components/docs/webgl-docs-tabs.tsx
+++ b/website/src/components/docs/webgl-docs-tabs.tsx
@@ -1,0 +1,34 @@
+import React, {type ReactNode} from 'react';
+import Link from '@docusaurus/Link';
+
+type WebGLDocsTab = {id: WebGLDocsTabId; label: string; href: string};
+
+/** WebGL documentation tab identifiers. */
+export type WebGLDocsTabId = 'overview' | 'constants';
+
+const WEBGL_DOCS_TABS: WebGLDocsTab[] = [
+  {id: 'overview', label: 'Overview', href: '/docs/api-reference/webgl'},
+  {id: 'constants', label: 'Constants', href: '/docs/api-reference/webgl/constants'}
+];
+
+/** Renders page links with the same visual treatment as tabs for WebGL documentation pages. */
+export function WebGLDocsTabs({active}: {active: WebGLDocsTabId}): ReactNode {
+  return (
+    <nav className="docs-page-tabs" aria-label="WebGL documentation sections">
+      {WEBGL_DOCS_TABS.map(tab => (
+        <Link
+          key={tab.id}
+          className={
+            tab.id === active
+              ? 'docs-page-tabs__tab docs-page-tabs__tab--active'
+              : 'docs-page-tabs__tab'
+          }
+          to={tab.href}
+          aria-current={tab.id === active ? 'page' : undefined}
+        >
+          {tab.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

- add page-level DocTabs navigation to 97 related documentation pages
- add grouped navigation for engine geometry, scenegraph, compute, animation, dynamic resources, fullscreen rendering, and model composition
- add guide navigation for GPU memory, GPU execution, GPU shader data, tutorials, developer workflow, and legacy docs
- add reference navigation for Shadertools, built-in shader modules, experimental renderers, WebGL, glTF, and test utilities
- extend Core DocTabs with layouts/bindings and presentation groups
- preserve existing routes, sidebar structure, and page content

## Why

Related documentation pages were discoverable from the sidebar but lacked local navigation once a reader landed on a page. These tab groups make adjacent guides and API references easier to move between while preserving the existing information architecture.

## Validation

- `nvm use`
- `env -u YARN_NO_PROXY yarn install`
- `env -u YARN_NO_PROXY yarn lint fix`
- `env -u YARN_NO_PROXY yarn build`
- `env -u YARN_NO_PROXY yarn test` (rerun with elevated local Playwright process/cache access after a sandboxed Chromium launch aborted)
- `env -u YARN_NO_PROXY yarn website:build`
- `(cd website && env -u YARN_NO_PROXY yarn build)`
- spot-checked generated pages for every DocTabs component family, confirming one navigation landmark and one active tab
