### PR TITLE
fix: WebGPU example and HTML texture usage

### DIFF
--- a/examples/v10/gpgpu/src/app.ts
+++ b/examples/v10/gpgpu/src/app.ts
@@ -16,22 +16,31 @@ import {
   type TableColumn
 } from './table-renderer';
 
-const DEFAULT_ROW_COUNT = 10_000_000;
+// The evaluator buffer pool reserves 2x the requested byte length. Five million rows keep the
+// largest default allocation below WebGPU's portable 256 MiB maxBufferSize limit.
+const DEFAULT_ROW_COUNT = 5_000_000;
 const MAXIMUM_ROW_COUNT = 10_000_000;
 const EXPRESSION_QUERY_PARAMETER = 'expression';
-
-let evaluationDevicePromise: Promise<Device> | null = null;
 
 export type GPGPUShowcaseHandle = {
   destroy: () => void;
 };
 
-export function initializeGPGPUShowcase(): GPGPUShowcaseHandle {
+export type GPGPUShowcaseProps = {
+  /** Reuse a caller-owned device, such as the device selected by the website DeviceTabs. */
+  device?: Device;
+};
+
+export function initializeGPGPUShowcase(props: GPGPUShowcaseProps = {}): GPGPUShowcaseHandle {
   const root = document.getElementById('app');
   if (!root) {
     throw new Error('GPGPU showcase requires #app');
   }
 
+  const evaluationDevicePromise = props.device
+    ? Promise.resolve(props.device)
+    : createEvaluationDevice();
+  const ownsEvaluationDevice = !props.device;
   const elements = getRenderedTableElements();
   const expressionElements = getExpressionElements();
   const requestedExpression = getRequestedExpression();
@@ -61,8 +70,9 @@ export function initializeGPGPUShowcase(): GPGPUShowcaseHandle {
     }
     renderer?.destroy();
     renderer = null;
-    void evaluationDevicePromise?.then(device => device.destroy());
-    evaluationDevicePromise = null;
+    if (ownsEvaluationDevice) {
+      void evaluationDevicePromise.then(device => device.destroy());
+    }
   };
 
   if (requestedExpression !== null) {
@@ -100,6 +110,7 @@ export function initializeGPGPUShowcase(): GPGPUShowcaseHandle {
         renderer,
         sourceColumns: data.columns,
         expressionInputs: data.expressionInputs,
+        evaluationDevicePromise,
         persistExpression: true
       });
     };
@@ -112,6 +123,7 @@ export function initializeGPGPUShowcase(): GPGPUShowcaseHandle {
         renderer: tableRenderer,
         sourceColumns: data.columns,
         expressionInputs: data.expressionInputs,
+        evaluationDevicePromise,
         persistExpression: false
       });
     }
@@ -159,6 +171,7 @@ async function runExpression({
   renderer,
   sourceColumns,
   expressionInputs,
+  evaluationDevicePromise,
   persistExpression
 }: {
   expression: string;
@@ -166,6 +179,7 @@ async function runExpression({
   renderer: VirtualGPUTableRenderer;
   sourceColumns: Parameters<VirtualGPUTableRenderer['setColumns']>[0];
   expressionInputs: Parameters<typeof evaluateExpression>[1];
+  evaluationDevicePromise: Promise<Device>;
   persistExpression: boolean;
 }): Promise<void> {
   let evaluationStartedAt: number | null = null;
@@ -182,7 +196,7 @@ async function runExpression({
     messageElement.textContent = 'Evaluating expression...';
     const output = evaluateExpression(trimmedExpression, expressionInputs);
 
-    const device = await getEvaluationDevice();
+    const device = await evaluationDevicePromise;
     await cleanEvaluate(device, {
       ...expressionInputs,
       output
@@ -227,23 +241,20 @@ async function makeOutputTableColumn(
   );
 }
 
-async function getEvaluationDevice(): Promise<Device> {
-  if (!evaluationDevicePromise) {
-    evaluationDevicePromise = luma.createDevice({
-      adapters: [webgpuAdapter, webgl2Adapter],
-      createCanvasContext:
-        typeof OffscreenCanvas === 'undefined'
-          ? true
-          : {
-              canvas: new OffscreenCanvas(1, 1),
-              width: 1,
-              height: 1,
-              autoResize: false,
-              useDevicePixels: false
-            }
-    });
-  }
-  return evaluationDevicePromise;
+async function createEvaluationDevice(): Promise<Device> {
+  return await luma.createDevice({
+    adapters: [webgpuAdapter, webgl2Adapter],
+    createCanvasContext:
+      typeof OffscreenCanvas === 'undefined'
+        ? true
+        : {
+            canvas: new OffscreenCanvas(1, 1),
+            width: 1,
+            height: 1,
+            autoResize: false,
+            useDevicePixels: false
+          }
+  });
 }
 
 function getMetricStartIndicesEvaluator(sourceColumns: TableColumn[]): GPUDataEvaluator {

--- a/modules/experimental/src/textures/html-texture.ts
+++ b/modules/experimental/src/textures/html-texture.ts
@@ -79,7 +79,7 @@ export class HTMLTexture implements TextureBindingSource {
       sampler = {},
       sourceHeight,
       sourceWidth,
-      usage = Texture.SAMPLE | Texture.COPY_DST,
+      usage = Texture.SAMPLE | Texture.COPY_DST | Texture.RENDER,
       width
     } = props;
     assertElementIsCanvasChild(canvas, element);

--- a/modules/experimental/test/textures/html-texture.spec.ts
+++ b/modules/experimental/test/textures/html-texture.spec.ts
@@ -75,7 +75,7 @@ test('HTMLTexture configures paint cycle and tracks DOM uploads', async t => {
   t.equal(fakeCanvas.requestPaintCount, 1, 'constructor requests the first paint');
   t.equal(
     texture.texture.props.usage,
-    Texture.SAMPLE | Texture.COPY_DST,
+    Texture.SAMPLE | Texture.COPY_DST | Texture.RENDER,
     'default texture usage supports WebGPU element-image copies'
   );
   t.equal(

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -1,7 +1,15 @@
 //
 
 import React, {useEffect, useMemo, useRef, useState} from 'react';
-import {ExampleHeader, ExamplePage, InfoBox, LumaExample, ReactExample, useStore} from './react-luma';
+import {
+  DeviceTabs,
+  ExampleHeader,
+  ExamplePage,
+  InfoBox,
+  LumaExample,
+  ReactExample,
+  useStore
+} from './react-luma';
 
 import {makeHtmlCustomPanel} from '../../examples/example-panels';
 import AnimationApp from '../../examples/api/animation/app';
@@ -651,11 +659,18 @@ export const ArrowDggsPolygonsExample: React.FC = props => (
 
 export const GPGPUExample: React.FC = () => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const deviceType = useStore(store => store.deviceType);
+  const device = useStore(store => store.device);
 
   useEffect(() => {
+    if (!deviceType?.startsWith('webgpu-') || !device) {
+      return;
+    }
+
     let handle: GPGPUShowcaseHandle | null = null;
     try {
-      handle = initializeGPGPUShowcase();
+      setErrorMessage(null);
+      handle = initializeGPGPUShowcase({device});
     } catch (error) {
       setErrorMessage(getErrorMessage(error));
       logError('Failed to initialize GPGPU example', error);
@@ -664,12 +679,13 @@ export const GPGPUExample: React.FC = () => {
     return () => {
       handle?.destroy();
     };
-  }, []);
+  }, [deviceType, device]);
 
   return (
     <ExamplePage style={{background: '#f7f8fb', overflow: 'hidden'}}>
       <style>{GPGPU_EXAMPLE_STYLE}</style>
       <main id="app" className="gpgpu-showcase">
+        <DeviceTabs devices={['webgpu']} style={{marginBottom: 16}} />
         <h1>@luma.gl/gpgpu evaluator showcase</h1>
         <p className="subtitle">
           Arrow-backed source columns are extracted as typed-array views and wrapped in


### PR DESCRIPTION
## Summary

- Make the GPGPU showcase reuse the website's selected WebGPU device and render CORE/MAX/COMPAT DeviceTabs.
- Reduce the default showcase dataset to five million rows so the evaluator buffer pool's 2x allocation stays below the portable 256 MiB WebGPU buffer limit.
- Preserve the ten-million-row stress case through the existing `?rows=` override.
- Add `Texture.RENDER` to HTMLTexture's default usage and update its expectation.

## Root cause

The GPGPU page initialized its own default WebGPU device instead of using the website device store, so it did not expose DeviceTabs and always received core WebGPU limits. Its ten-million-row dataset requested 240 MB and 140 MB evaluator buffers; the pool over-allocates by 2x, producing 480 MB and 280 MB allocations that exceed the core device's 256 MiB `maxBufferSize`.

HTMLTexture's default usage omitted the render capability required by WebGPU element-image copy paths.

## Validation

- `nvm use`
- `yarn lint fix`
- `yarn build`
- `yarn test` (48 Node test files passed; 226 headless browser test files passed)
- Local browser verification of `/examples/v10/gpgpu`: DeviceTabs rendered, 5,000,000 rows generated, and no console errors were captured.
- `yarn website:build`: client and server compiled successfully, then the existing local-search post-step failed because `website/build/docs.html` was missing.
