### PR TITLE
[codex] Rename experimental examples

### DIFF
--- a/examples/experimental/html-ui-prism/app.ts
+++ b/examples/experimental/html-ui-prism/app.ts
@@ -21,7 +21,7 @@ import {
   renderExamplePanel
 } from '../../example-panels';
 
-export const title = 'HTML UI Prism';
+export const title = 'HTML-in-Canvas Prism';
 export const description = 'Renders live panel-backed DOM surfaces on a rotating GPU prism.';
 
 const FACE_TEXTURE_SIZE = 640;

--- a/examples/experimental/video-texture/app.ts
+++ b/examples/experimental/video-texture/app.ts
@@ -8,7 +8,7 @@ import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, CylinderGeometry, Model, VideoTexture} from '@luma.gl/engine';
 import {Matrix4} from '@math.gl/core';
 
-export const title = 'Video Texture Beacon';
+export const title = 'Video Texture';
 export const description = 'Wraps a live video texture around a rotating cylinder.';
 
 type AppUniforms = {

--- a/examples/experimental/webxr-kaleidoscope/app.ts
+++ b/examples/experimental/webxr-kaleidoscope/app.ts
@@ -15,7 +15,7 @@ import {
 import type {WebGLDevice} from '@luma.gl/webgl';
 import {Matrix4} from '@math.gl/core';
 
-export const title = 'Passthrough Kaleidoscope';
+export const title = 'WebXR Kaleidoscope';
 export const description =
   'Folds WebXR camera frames or a procedural fallback through animated XR shards.';
 
@@ -152,7 +152,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   constructor({animationLoop, device}: AnimationProps) {
     super();
     if (device.type !== 'webgl') {
-      throw new Error('Passthrough Kaleidoscope requires WebGL2');
+      throw new Error('WebXR Kaleidoscope requires WebGL2');
     }
 
     AppAnimationLoopTemplate.current = this;

--- a/website/content/examples/experimental/html-ui-prism.mdx
+++ b/website/content/examples/experimental/html-ui-prism.mdx
@@ -1,5 +1,5 @@
 ---
-title: HTML UI Prism
+title: HTML-in-Canvas Prism
 ---
 
 import {ExampleHeader} from '@site/src/react-luma';

--- a/website/content/examples/experimental/webxr-kaleidoscope.mdx
+++ b/website/content/examples/experimental/webxr-kaleidoscope.mdx
@@ -1,5 +1,5 @@
 ---
-title: Passthrough Kaleidoscope
+title: WebXR Kaleidoscope
 ---
 
 <p className="badges">

--- a/website/content/examples/table-of-contents.json
+++ b/website/content/examples/table-of-contents.json
@@ -57,10 +57,10 @@
     "items": [
       "experimental/a-buffer",
       "experimental/bloom",
-      "experimental/html-ui-prism",
       "experimental/fp64",
       "experimental/gpt-2",
       "experimental/video-texture",
+      "experimental/html-ui-prism",
       "experimental/webxr-kaleidoscope"
     ]
   },

--- a/website/content/sidebar-examples.js
+++ b/website/content/sidebar-examples.js
@@ -56,10 +56,10 @@ const sidebars = {
       items: [
         'experimental/a-buffer',
         'experimental/bloom',
-        'experimental/html-ui-prism',
         'experimental/fp64',
         'experimental/gpt-2',
         'experimental/video-texture',
+        'experimental/html-ui-prism',
         'experimental/webxr-kaleidoscope'
       ]
     },

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -883,7 +883,7 @@ export const VideoTextureExample: React.FC = props => {
   return (
     <LumaExample
       id="video-texture"
-      title="Video Texture Beacon"
+      title="Video Texture"
       directory="experimental"
       template={VideoTextureApp}
       config={exampleConfig}
@@ -988,7 +988,7 @@ export const WebXRKaleidoscopeExample: React.FC = props => {
   return (
     <LumaExample
       id="webxr-kaleidoscope"
-      title="Passthrough Kaleidoscope"
+      title="WebXR Kaleidoscope"
       directory="experimental"
       devices={['webgl2']}
       template={WebXRKaleidoscopeApp}
@@ -1035,7 +1035,7 @@ function getCameraErrorMessage(error: unknown): string {
 export const HTMLUIPrismExample: React.FC = props => (
   <LumaExample
     id="html-ui-prism"
-    title="HTML UI Prism"
+    title="HTML-in-Canvas Prism"
     directory="experimental"
     template={HTMLUIPrismApp}
     config={exampleConfig}


### PR DESCRIPTION
## Summary

- Reorder the Experimental examples so the bottom entries are Video Texture, HTML-in-Canvas Prism, and WebXR Kaleidoscope.
- Rename the HTML UI Prism and Passthrough Kaleidoscope labels across the website sidebar, table of contents, MDX frontmatter, React example wrappers, and example app title constants.
- Update the WebXR Kaleidoscope WebGL2 requirement error message to match the new title.

## Validation

- `yarn lint fix`
- Commit hook: lint checks and test suite passed during `git commit`.
