### PR TITLE
fix(gpgpu) buffer size limits

### DIFF
--- a/examples/v10/gpgpu/src/app.ts
+++ b/examples/v10/gpgpu/src/app.ts
@@ -16,8 +16,8 @@ import {
   type TableColumn
 } from './table-renderer';
 
-// The evaluator buffer pool reserves 2x the requested byte length. Five million rows keep the
-// largest default allocation below WebGPU's portable 256 MiB maxBufferSize limit.
+// Keep the default workload conservative for browsers while preserving the ten-million-row
+// stress case through the rows query parameter.
 const DEFAULT_ROW_COUNT = 5_000_000;
 const MAXIMUM_ROW_COUNT = 10_000_000;
 const EXPRESSION_QUERY_PARAMETER = 'expression';

--- a/modules/gpgpu/src/utils/buffer-pool.ts
+++ b/modules/gpgpu/src/utils/buffer-pool.ts
@@ -5,7 +5,6 @@
 import {Device, Buffer} from '@luma.gl/core';
 
 class BufferPool {
-  overAlloc: number = 2;
   poolSize: number = 100;
 
   private bufferPools: Map<Device, Buffer[]>;
@@ -15,12 +14,18 @@ class BufferPool {
   }
 
   createOrReuse(device: Device, byteLength: number): Buffer {
+    if (byteLength > device.limits.maxBufferSize) {
+      throw new Error(
+        `Buffer pool cannot allocate ${byteLength} bytes: device.limits.maxBufferSize is ${device.limits.maxBufferSize}`
+      );
+    }
+
     const pool = this.bufferPools.get(device);
     const i = pool ? pool.findIndex(b => b.byteLength >= byteLength) : -1;
     if (i < 0) {
       return device.createBuffer({
         usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC,
-        byteLength: byteLength * this.overAlloc
+        byteLength
       });
     }
     const [result] = pool!.splice(i, 1);

--- a/modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts
+++ b/modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts
@@ -8,6 +8,41 @@ import {GPUVector, type GPUVectorFormat} from '@luma.gl/tables';
 import {NullDevice} from '@luma.gl/test-utils';
 import {expect, test, vi} from 'vitest';
 
+test('GPUDataEvaluator buffer pool allocates exact sizes and validates device limits', async () => {
+  const device = new NullDevice({});
+  Object.defineProperty(device.limits, 'maxBufferSize', {value: 16});
+
+  const evaluator = GPUDataEvaluator.fromArray(new Uint8Array(8), {type: 'uint8', size: 1});
+  await evaluator.evaluate(device);
+  const buffer = evaluator.buffer;
+
+  expect(buffer.byteLength).toBe(evaluator.byteLength);
+  expect(buffer.byteLength).toBe(8);
+
+  evaluator.destroy();
+
+  const smallerEvaluator = GPUDataEvaluator.fromArray(new Uint8Array(4), {
+    type: 'uint8',
+    size: 1
+  });
+  await smallerEvaluator.evaluate(device);
+
+  expect(smallerEvaluator.buffer).toBe(buffer);
+  expect(smallerEvaluator.buffer.byteLength).toBe(8);
+
+  const oversizedEvaluator = GPUDataEvaluator.fromArray(new Uint8Array(17), {
+    type: 'uint8',
+    size: 1
+  });
+  await expect(oversizedEvaluator.evaluate(device)).rejects.toThrow(
+    'Buffer pool cannot allocate 17 bytes: device.limits.maxBufferSize is 16'
+  );
+
+  smallerEvaluator.destroy();
+  oversizedEvaluator.destroy();
+  device.destroy();
+});
+
 test('GPUDataEvaluator.fromGPUData accepts packed Float16 chunks', () => {
   const device = new NullDevice({});
   const vector2 = makeUint16Vector(device, 'colors16x2', [0x3c00, 0x3800], 2, {


### PR DESCRIPTION
## Summary

- Allocate new GPGPU evaluator buffers at the exact requested byte length instead of reserving 2x.
- Treat `device.limits.maxBufferSize` strictly as a validation ceiling and report an actionable error when the request itself exceeds it.
- Preserve reuse of larger recycled buffers.
- Keep the GPGPU showcase at the conservative five-million-row default and update its now-obsolete allocator comment.
- Add regression coverage for exact allocation, constrained device limits, limit failures, and recycled-buffer reuse.

## Root cause

The June 5 WebGPU feature-level change made portable core limits the default instead of requesting every adapter maximum. That exposed the core device's 256 MiB `maxBufferSize` to the pre-existing evaluator pool, which doubled every new buffer allocation.

At ten million rows, the showcase requested 240 MB and 140 MB evaluator buffers. The pool turned those into 480 MB and 280 MB allocations, exceeding the active core limit. Reducing the default dataset to five million rows avoided that validation failure but retained unnecessary 2x GPU memory pressure.

`maxBufferSize` is an upper bound for one valid allocation, not a memory budget or growth target. WebGL cannot provide a reliable hard limit and uses `Number.MAX_SAFE_INTEGER` as an unknown-limit sentinel, so allocating exact requested sizes is portable across both backends.

## Validation

- `nvm use`
- `env -u YARN_NO_PROXY yarn install`
- `env -u YARN_NO_PROXY yarn test-node modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts` — 4 tests passed
- `env -u YARN_NO_PROXY yarn lint fix`
- `env -u YARN_NO_PROXY yarn build`
- `env -u YARN_NO_PROXY yarn test` — 48 node files passed (2 skipped), 228 headless files passed; 1,218 headless tests passed (25 skipped)
- `env -u YARN_NO_PROXY yarn website:build`
- `env -u YARN_NO_PROXY yarn workspace luma.gl-examples-v10-gpgpu build`
- Browser verification of the standalone production example: 5,000,000 rows initialized, `fround(coordinates)` evaluated successfully, the output column rendered, and no console errors were reported.
