### PR TITLE
docs: Improve documentation onboarding and examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ lerna-debug.log
 TODO
 
 .docusaurus
+docs/api-reference/generated/
 
 # editor files
 .idea

--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -1,206 +1,112 @@
-# Overview
+# luma.gl Documentation
 
-<p className="badges" style={{textAlign: 'center'}}>
+luma.gl is a TypeScript toolkit for high-performance GPU rendering and compute on the
+web. It provides one application-facing API with pluggable WebGPU and WebGL2 backends,
+plus higher-level building blocks for models, animation, shader composition, and GPU
+data processing.
+
+<p className="badges">
   <a href="https://www.npmjs.com/package/@luma.gl/core">
-    <img src="https://img.shields.io/npm/v/@luma.gl/core.svg?style=flat-square&label=npm%20package" alt="npm package version" />
-  </a>
-  {' '}
+    <img src="https://img.shields.io/npm/v/@luma.gl/core.svg?style=flat-square&label=npm" alt="npm package version" />
+  </a>{' '}
   <a href="https://github.com/visgl/luma.gl/blob/master/LICENSE">
     <img src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square" alt="MIT license" />
-  </a>
-  {' '}
-  <a href="https://www.npmjs.com/package/@luma.gl/core">
-    <img src="https://img.shields.io/npm/dm/@luma.gl/core.svg?style=flat-square&label=downloads" alt="npm downloads" />
-  </a>
-  {' '}
-  <a href="https://coveralls.io/github/visgl/luma.gl?branch=master">
-    <img src="https://img.shields.io/coveralls/visgl/luma.gl.svg?style=flat-square&label=coverage" alt="coverage" />
-  </a>
-  {' '}
+  </a>{' '}
   <a href="https://www.typescriptlang.org/">
-    <img src="https://img.shields.io/badge/typescript-5.9.3-3178C6.svg?style=flat-square&labelColor=555555&color=3178C6" alt="TypeScript 5.9.3" />
+    <img src="https://img.shields.io/badge/TypeScript-strict-3178C6.svg?style=flat-square" alt="TypeScript strict mode" />
   </a>
 </p>
 
-luma.gl is a modern GPU toolkit for the Web, focused on processing and visualization of big data.
-It is considered a foundational framework in the [deck.gl ecosystem](https://www.openvisualization.org/projects).
-
-<center>
-  <a href="https://www.w3.org/TR/webgpu/">
-    <img
-      style={{height: 80, marginRight: 30}}
-      src="https://raw.githubusercontent.com/gpuweb/gpuweb/3b3a1632ff1ad6a573330a58710e341bb9d65576/logo/webgpu-horizontal.svg"
-    />
+<div className="docs-api-card-grid">
+  <a className="docs-api-card" href="/docs/getting-started">
+    <span className="docs-api-card__kind">New to luma.gl</span>
+    <strong>Get a canvas running</strong>
+    <span>Create a Vite project, select WebGPU with WebGL2 fallback, and render your first frame.</span>
+    <span className="docs-api-card__meta">About ten minutes</span>
   </a>
-  <a href="https://registry.khronos.org/webgl/specs/latest/2.0/">
-    <img
-      style={{height: 80, marginRight: 40}}
-      src="https://raw.github.com/visgl/deck.gl-data/master/images/whats-new/webgl2.jpg"
-    />
+  <a className="docs-api-card" href="/docs/tutorials">
+    <span className="docs-api-card__kind">Learn</span>
+    <strong>Follow the fundamentals</strong>
+    <span>Build from a triangle to textured geometry, instancing, reusable shaders, and GPU transforms.</span>
+    <span className="docs-api-card__meta">Live, backend-switchable examples</span>
   </a>
-  <a href="https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html">
-    <img
-      style={{height: 80}}
-      src="https://raw.github.com/visgl/deck.gl-data/master/images/gltf.png"
-    />
+  <a className="docs-api-card" href="/docs/api-guide">
+    <span className="docs-api-card__kind">Design and concepts</span>
+    <strong>Browse the API guides</strong>
+    <span>Understand the Engine, portable GPU, and Shader APIs before choosing individual resources.</span>
+    <span className="docs-api-card__meta">Task-oriented explanations</span>
   </a>
-</center>
-<center>
-  <i>luma.gl supports the latest web GPU standards from W3C and Khronos.</i>
-</center>
-
-&nbsp;
-
-<center>
-  <a href="https://openvisualization.org">
-    <img
-      style={{height: 80}}
-      src="https://raw.github.com/visgl/deck.gl-data/master/images/logos/openjsf-color-textg.png"
-    />
+  <a className="docs-api-card" href="/docs/api-reference">
+    <span className="docs-api-card__kind">Look up details</span>
+    <strong>Use the API reference</strong>
+    <span>Find packages, classes, resource methods, accepted formats, and backend-specific behavior.</span>
+    <span className="docs-api-card__meta">Organized by npm package</span>
   </a>
-</center>
-<center>
-  <i>luma.gl is an OpenJS Foundation / Linux Foundation project.</i>
-</center>
+</div>
 
-&nbsp;
+## Why luma.gl?
 
-This documentation describes luma.gl **v9.3**. See our [**release notes**](/docs/whats-new) to learn what is new.
-Docs for older versions are available on github:
-**[v9.2](https://github.com/visgl/luma.gl/blob/9.2-release/docs/README.md)**,
-**[v9.1](https://github.com/visgl/luma.gl/blob/9.1-release/docs/README.md)**,
-**[v9.0](https://github.com/visgl/luma.gl/blob/9.0-release/docs/README.md)**,
-**[v8.5](https://github.com/visgl/luma.gl/blob/8.5-release/docs/README.md)**,
-**[v7.3](https://github.com/visgl/luma.gl/blob/7.3-release/docs/README.md)**,
-**[v6.4](https://github.com/visgl/luma.gl/blob/6.4-release/docs/README.md)**.
+- **Portable GPU API** — write against luma.gl resources and select WebGPU, WebGL2, or
+  both at application startup.
+- **Low-level access without raw-API duplication** — retain explicit buffers, textures,
+  shaders, bindings, passes, and pipelines while sharing most application code.
+- **Engine building blocks** — use `Model`, `AnimationLoop`, geometry, transforms, and
+  scenegraph helpers when raw resource management is unnecessary.
+- **Composable shaders** — package shader functions, typed inputs, hooks, and injections
+  into reusable modules and plugins.
+- **Visualization-scale data** — luma.gl is the rendering foundation for deck.gl and
+  includes dedicated support for GPU tables and Apache Arrow workflows.
 
-## Highlights
+## Is luma.gl the right level?
 
-luma.gl is a modern GPU toolkit for the Web, created to facilitate processing and visualization of big data.
+| Choose | When |
+| --- | --- |
+| **luma.gl** | You are building a renderer, GPU compute workflow, visualization framework, or custom GPU feature and want explicit resource control. |
+| [deck.gl](https://deck.gl) | You need high-level geospatial or large-data visualization layers, picking, cameras, and interaction. |
+| Three.js or Babylon.js | You need a general-purpose scene engine with a large asset and material ecosystem. |
+| Raw WebGPU | You need exact control over one backend and do not need luma.gl's portability, lifecycle, or shader tooling. |
 
-- **Rendering and Compute** - for computing and rendering with GPUs in JavaScript.
-- **WebGPU and WebGL2** - support one or both via luma's pluggable backends.
-- **Engine-level classes** - `Model`, `AnimationLoop`, `BufferTransform`, `TextureTransform` and `Computation`, as well as scenegraph support.
-- **glTF and PBR** support for glTF models and physically based rendering.
-- **Shader management system** - supports shader modules, dependencies, injection, transpilation etc.
-- **Shader module library** - Pre-optimized modules for compute, visual effects and post processing.
-- **TypeScript** - All APIs are rigorously typed.
+## Three cooperating APIs
 
-luma.gl offers extensive support for 3D math and data loading through companion vis.gl frameworks:
+### Engine API
 
-- [**loaders.gl**](https://loaders.gl) - wide range of 3D and geospatial data format standards.
-- [**math.gl**](https://uber-web.github.io/math.gl/docs) - a variety of high precision geospatial and 3D math logic.
+The Engine API provides `Model`, `AnimationLoop`, geometry, scenegraph, dynamic texture,
+and GPU transformation helpers. It is the recommended starting point for applications.
 
-luma.gl is a great foundation for building higher-level GPU frameworks. The primary example is
+### Portable GPU API
 
-- [**deck.gl**](https://deck.gl) - geospatial GPU visualization and compute via a high-performance functional programming API.
+The Core API exposes devices, buffers, textures, shaders, bindings, pipelines, and
+render or compute passes. `@luma.gl/webgpu` and `@luma.gl/webgl` provide the concrete
+backends.
 
-## API Philosophy
+### Shader API
 
-Many 3D / GPU libraries provide portable, higher level "3D engine" type abstractions
-that shield the user from the details of how the GPU works. This is great for
-many use cases but not always ideal.
+Shadertools assembles WGSL and GLSL from reusable shader modules and application-defined
+hooks. It is used by luma.gl, deck.gl, and custom renderers.
 
-In contrast, luma.gl is designed to give developers full access to GPU programming and
-allow you to work directly with shaders and GPU data structures.
-luma.gl offers APIs that are similar to the underlying WebGPU and WebGL APIs.
-This maximizes knowledge reuse, as well as your understanding of what is actually happening under the hood.
+Read [A Tale of Three APIs](/docs/api-guide) for the detailed object model.
 
-For more information, refer to [luma.gl API philosophy](/docs/api-guide/background/api-design).
+## Supported environments
 
-## Supported Environments
+luma.gl targets current evergreen browsers. WebGPU feature availability varies by
+browser and platform; WebGL2 provides the compatibility path for portable rendering.
+Compute shaders, storage textures, and some advanced features remain WebGPU-only.
 
-luma.gl supports recent versions of the most commonly used evergreen browsers (i.e. Chrome, Firefox, Safari, Edge).
+Node.js can be used when the host supplies a WebGPU or WebGL implementation, but browser
+image, canvas, and video APIs require environment-specific replacements.
 
-- **Mobile browsers** should be supported (assuming the mobile browser is an updated evergreen browser), though CPU and GPU memory limits will be lower.
-- Pre-chrome **Edge** is not supported, and IE11 is absolutely not supported.
-- Running on top of **software emulated GPUs** is possible but known to have occasional issues. Check your Chrome settings to make sure you are not using the SwiftShader.
-- Running in **virtual machines** is not officially supported. It may or may not work. 
-- Running under **Node.js** may be possible if your Node.js environment can create WebGPU or WebGL contexts. Note that additional work may be required to load images into textures etc.
+## Project and releases
 
-Most luma.gl development is done on desktop Chrome on MacBooks.
-In case you think you have found an issue and want to check if it is specific to your environment,
-it could be worth testing if you can reproduce your issue on Chrome before you report the bug.
+This documentation describes luma.gl **v9.3**. See [What's New](/docs/whats-new) for
+current features and the [Upgrade Guide](/docs/upgrade-guide) for breaking changes.
 
-If you have a confirmed bug that affects a supported environment, feel free to [open an issue](https://github.com/visgl/luma.gl/issues).
-However, if you are not yet sure, please help us keep issue noise down and start in the [discussions](https://github.com/visgl/luma.gl/discussions).
-If you can provide a fix, you are welcome to open a pull request. It often makes sense to discuss before surprising maintainers with a big PR.
+luma.gl is an MIT-licensed OpenJS Foundation project governed by the vis.gl community.
+Use [GitHub Discussions](https://github.com/visgl/luma.gl/discussions) for design and
+usage questions, and [GitHub Issues](https://github.com/visgl/luma.gl/issues) for
+confirmed bugs.
 
-## Showcases
-
-Some examples of applications built on top of luma.gl:
-
-|         <img style={{width: 250, height: 250}} src="https://deck.gl/images/showcase/kepler-gl.jpg" />         |             <img style={{width: 250, height: 250}} src="https://deck.gl/images/showcase/avs.jpg" />              | <img style={{width: 250, height: 250}} src="https://deck.gl/images/showcase/viv.jpg" /> |
-| :-----------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------: |
-| <center><b>kepler.gl</b><p><i>open source geospatial analysis tool for large-scale data sets</i></p></center> | <center><b>AVS / streetscape.gl</b><p><i>A visualization toolkit for autonomy and robotics data</i></p></center> |  <center><b>VIV</b><p><i>Visualization of cellular biological samples</i></p></center>  |
-
-- [kepler.gl](https://kepler.gl/) ([GitHub](https://github.com/keplergl/kepler.gl))
-- [deck.gl](http://deck.gl/#/) ([GitHub](https://github.com/visgl/deck.gl)) a WebGL-powered framework for visual exploratory data analysis of large data sets
-- [avs.auto](https://avs.auto/#/) and [streetscape.gl](https://github.com/uber/streetscape.gl)
-
-## Open Governance
-
-luma.gl is provided under MIT license and is under open governance as a part of:
-
-- The [OpenJS foundation](https://openvisualization.org).
-- The [vis.gl framework suite](https://vis.gl).
-
-## Learning Resources
-
-To learn more for learning and discussions.
-
-- check out the [vis.gl Medium blog](https://medium.com/vis-gl).
-- join the community in the [OpenJS Slack workspace](https://www.openvisualization.org/#get-involved)
-  If you wish to contribute in a structured way, beyond isolated PRs, or join the open governance activities,
-  start by joining the forums above and introduce yourself.
-
-## Primary Contributors
-
-luma.gl is developed and maintained by the vis.gl community but has benefitted from the support of various companies:
- 
-- From 2021 onwards, luma.gl has been developed and maintained by [**Foursquare**](https://location.foursquare.com/products/studio/).
-- From 2019-2021, luma.gl was developed and maintained by [**Unfolded**](https://unfolded.ai).
-- From 2015-2019, luma.gl was created and developed by [**Uber**](https://uber.com).
-
-<p style={{marginTop: -60, marginBottom: -20, marginLeft: 30}}>
-  <a href="https://location.foursquare.com/products/studio/">
-    <img
-      style={{height: 160}}
-      src="https://raw.github.com/visgl/deck.gl-data/master/images/logos/foursquare.png"
-    />
-  </a> 
-</p>
-
-<a href="https://unfolded.ai">
-  <img
-    style={{height: 50, marginLeft: 20}}
-    src="https://raw.github.com/visgl/deck.gl-data/master/images/logos/unfolded.png"
-  />
-</a> 
-
-&nbsp;
-
-<a href="https://uber.com">
-  <img
-    style={{height: 100}}
-    src="https://raw.github.com/visgl/deck.gl-data/master/images/logos/uber-black.jpg"
-  />
-</a> 
-
-
-## History
-
-luma.gl was originally created at Uber in 2015 as an open source project to support deck.gl.
-
-- 2022: luma.gl was accepted into the OpenJS foundation together with the vis.gl framework stack.
-- 2019: Uber put luma.gl under open governance in the Linux Foundation.
-- 2015: luma.gl started out as a fork of the [PhiloGL](https://github.com/senchalabs/philogl) WebGL library.
-
-## Roadmap
-
-luma.gl keeps evolving based on the needs of vis.gl frameworks and applications.
-We share information about the direction of luma.gl in the following ways:
-
-- **[Blog](https://medium.com/@vis.gl)** - We use the vis.gl blog to share information about what we are doing.
-- **[Github Issues](https://github.com/visgl/luma.gl/issues)** - The traditional way to start or join a discussion.
-- **[RFCs](https://github.com/visgl/luma.gl/tree/master/dev-docs/RFCs)** - RFCs are technical writeups that describe proposed features in upcoming releases.
+Older documentation remains available in the corresponding GitHub release branches:
+[v9.2](https://github.com/visgl/luma.gl/blob/9.2-release/docs/README.md),
+[v9.1](https://github.com/visgl/luma.gl/blob/9.1-release/docs/README.md),
+[v9.0](https://github.com/visgl/luma.gl/blob/9.0-release/docs/README.md), and
+[v8.5](https://github.com/visgl/luma.gl/blob/8.5-release/docs/README.md).

--- a/docs/api-reference/core/README.md
+++ b/docs/api-reference/core/README.md
@@ -4,6 +4,10 @@ The `@luma.gl/core` module provides an abstract API that enables application cod
 to portably work with both WebGPU and WebGL. The main export is the `Device` class
 which provides methods for creating GPU resources such as `Buffer`, `Texture`, `Shader` etc.
 
+The pages in this section provide curated explanations and portability guidance. For
+the exact public TypeScript declarations, overloads, inheritance, and source locations,
+use the [generated `@luma.gl/core` API index](/docs/api-reference/generated/core).
+
 ## Installing adapters
 
 The `@luma.gl/core` module is not usable on its own. A device adapter module must

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,0 @@
-# Getting Started
-
-Refer to the developer guide to learn how to [install luma.gl](/docs/developer-guide/installing).
-
-Then the [tutorials](/docs/tutorials) could be a good place to start to get a quick sense for the API.

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,0 +1,154 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Getting Started
+
+luma.gl is a TypeScript toolkit for applications that need direct, portable access to
+WebGPU and WebGL2. This guide creates a small rendering project that tries WebGPU first
+and falls back to WebGL2.
+
+## Prerequisites
+
+- A current Node.js LTS release
+- A browser with WebGPU or WebGL2 support
+- Basic TypeScript knowledge
+
+:::tip
+
+If your goal is a geospatial visualization rather than a GPU framework or custom
+renderer, start with [deck.gl](https://deck.gl) instead. deck.gl is built on luma.gl and
+provides higher-level layers, cameras, and interaction.
+
+:::
+
+## Create a project
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm" label="npm" default>
+
+```bash
+npm create vite@latest luma-demo -- --template vanilla-ts
+cd luma-demo
+npm install @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl
+```
+
+  </TabItem>
+  <TabItem value="yarn" label="yarn">
+
+```bash
+yarn create vite luma-demo --template vanilla-ts
+cd luma-demo
+yarn add @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl
+```
+
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+
+```bash
+pnpm create vite luma-demo --template vanilla-ts
+cd luma-demo
+pnpm add @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl
+```
+
+  </TabItem>
+</Tabs>
+
+Replace `src/main.ts` with:
+
+```typescript
+import {AnimationLoopTemplate, type AnimationProps, makeAnimationLoop} from '@luma.gl/engine';
+import {webgpuAdapter} from '@luma.gl/webgpu';
+import {webgl2Adapter} from '@luma.gl/webgl';
+
+class App extends AnimationLoopTemplate {
+  override onRender({device}: AnimationProps): void {
+    const renderPass = device.beginRenderPass({
+      clearColor: [0.05, 0.08, 0.14, 1]
+    });
+    renderPass.end();
+  }
+}
+
+makeAnimationLoop(App, {
+  adapters: [webgpuAdapter, webgl2Adapter]
+}).start();
+```
+
+Start the development server:
+
+<Tabs groupId="package-manager">
+  <TabItem value="npm" label="npm" default>
+
+```bash
+npm run dev
+```
+
+  </TabItem>
+  <TabItem value="yarn" label="yarn">
+
+```bash
+yarn dev
+```
+
+  </TabItem>
+  <TabItem value="pnpm" label="pnpm">
+
+```bash
+pnpm dev
+```
+
+  </TabItem>
+</Tabs>
+
+You should see a dark canvas. luma.gl creates the best available device, begins a render
+pass each frame, and presents the result to the page.
+
+## Choose a learning path
+
+<div className="docs-api-card-grid">
+  <a className="docs-api-card" href="/docs/tutorials/hello-triangle">
+    <span className="docs-api-card__kind">Recommended</span>
+    <strong>Rendering with the Engine API</strong>
+    <span>Draw a triangle, add geometry and textures, then move on to instancing and reusable shaders.</span>
+    <span className="docs-api-card__meta">Start with Model and AnimationLoop</span>
+  </a>
+  <a className="docs-api-card" href="/docs/api-guide/gpu">
+    <span className="docs-api-card__kind">Lower level</span>
+    <strong>GPU resources and compute</strong>
+    <span>Work directly with devices, buffers, textures, bindings, command encoders, and compute passes.</span>
+    <span className="docs-api-card__meta">Start with the portable GPU API</span>
+  </a>
+</div>
+
+## How backend selection works
+
+The application supplies both adapters in preference order. A WebGPU-capable browser
+uses `webgpuAdapter`; other supported browsers fall back to `webgl2Adapter`. Application
+code continues to use the same luma.gl `Device`, resource, and render-pass APIs.
+
+Use only `webgpuAdapter` when your application depends on compute shaders, storage
+textures, or another WebGPU-only feature. The documentation marks backend-specific
+features explicitly.
+
+## Troubleshooting
+
+### The canvas is blank
+
+Check the browser console first. Confirm that `src/main.ts` is imported by `index.html`
+and that the canvas is not hidden by application CSS.
+
+### WebGPU is unavailable
+
+The example should fall back to WebGL2. To debug WebGPU specifically, consult the
+[WebGPU and WebGL comparison](/docs/api-guide/background/webgpu-vs-webgl) and inspect
+the selected device in your browser developer tools.
+
+### TypeScript cannot resolve a package
+
+Install all three packages shown above. `@luma.gl/engine` provides `AnimationLoop` and
+`Model`; `@luma.gl/webgpu` and `@luma.gl/webgl` provide the concrete device adapters.
+
+## Next step
+
+Continue with [Hello Triangle](/docs/tutorials/hello-triangle), where the empty render
+pass becomes a complete portable draw call.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -1,12 +1,9 @@
 [
   "README",
   "getting-started",
-  "whats-new",
-  "upgrade-guide",
-  "faq",
   {
     "type": "category",
-    "label": "Tutorials",
+    "label": "Fundamentals",
     "items": [
       "tutorials/README",
       "tutorials/hello-triangle",
@@ -22,6 +19,9 @@
       "tutorials/whats-next"
     ]
   },
+  "faq",
+  "whats-new",
+  "upgrade-guide",
   {
     "type": "category",
     "label": "API Guide",

--- a/docs/tutorials/README.mdx
+++ b/docs/tutorials/README.mdx
@@ -1,151 +1,64 @@
 import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
-# Setup
+# Fundamentals
 
 <TutorialDocsTabs group="fundamentals" active="setup" />
 
-These tutorials use the current luma.gl v9.3 API. The runnable sources in
-[`examples/tutorials`](https://github.com/visgl/luma.gl/tree/master/examples/tutorials)
-remain the canonical reference for the code shown on these pages.
+This course builds a portable renderer one concept at a time. Every lesson includes a
+live example that can switch between WebGPU and WebGL2 when both backends support the
+feature. The files shown on each page are loaded from the runnable examples in this
+repository, so the documentation and tested code stay in sync.
 
-This tutorial will walk you through setting up a basic development project for luma.gl applications using [Vite](https://vitejs.dev/) tooling. Later tutorials will build on this one, so we recommend going through it first.
+Before starting, complete [Getting Started](/docs/getting-started). Familiarity with
+TypeScript and basic GPU concepts is helpful; the tutorials explain the luma.gl object
+model as it is introduced.
 
-**Note:** It is assumed for these tutorials that you have some basic knowledge of GPU APIs and JavaScript programming.
+## Rendering foundations
 
-## A Minimal Application
+<div className="docs-api-card-grid">
+  <a className="docs-api-card" href="/docs/tutorials/hello-triangle">
+    <span className="docs-api-card__kind">1 · Beginner</span>
+    <strong>Hello Triangle</strong>
+    <span>Create a Model, supply portable shaders, and issue a draw inside a render pass.</span>
+    <span className="docs-api-card__meta">Model · shaders · render passes</span>
+  </a>
+  <a className="docs-api-card" href="/docs/tutorials/hello-cube">
+    <span className="docs-api-card__kind">2 · Beginner</span>
+    <strong>Hello Cube</strong>
+    <span>Add geometry, textures, depth testing, and uniforms that update every frame.</span>
+    <span className="docs-api-card__meta">Geometry · textures · uniforms</span>
+  </a>
+  <a className="docs-api-card" href="/docs/tutorials/hello-instancing">
+    <span className="docs-api-card__kind">3 · Intermediate</span>
+    <strong>Hello Instancing</strong>
+    <span>Draw many copies of one geometry using per-instance attributes.</span>
+    <span className="docs-api-card__meta">Buffers · layouts · instancing</span>
+  </a>
+  <a className="docs-api-card" href="/docs/tutorials/lighting">
+    <span className="docs-api-card__kind">4 · Intermediate</span>
+    <strong>Lighting</strong>
+    <span>Compose reusable shader functionality and supply material inputs.</span>
+    <span className="docs-api-card__meta">Shader modules · materials</span>
+  </a>
+</div>
 
-Create a new folder on your file system to store your new project.
-Then let's create a file `app.ts` in the project root folder and add the following to it:
+## Reusable shaders
 
-```typescript
-import type {AnimationProps} from '@luma.gl/engine';
-import {AnimationLoopTemplate} from '@luma.gl/engine';
+- [Shader Modules](/docs/tutorials/shader-modules) package reusable shader code and typed inputs.
+- [Shader Hooks](/docs/tutorials/shader-hooks) expose deliberate extension points.
+- [Shader Plugins](/docs/tutorials/shader-plugins) combine modules, injections, and application configuration.
 
-export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
-  override onRender({device}: AnimationProps) {
-    const renderPass = device.beginRenderPass({
-      clearColor: [0, 0, 0, 1],
-      clearDepth: 1
-    });
-    renderPass.end();
-  }
-}
-```
+## GPU-driven updates
 
-This will be the basic structure of most luma.gl applications. `AnimationLoopTemplate`
-provides the lifecycle hooks, while the page entry point chooses the rendering
-backend and starts the loop.
+- [Transform](/docs/tutorials/transform) runs data transformations on portable GPU resources.
+- [Transform Feedback](/docs/tutorials/transform-feedback) demonstrates the WebGL2-specific feedback path.
+- [External WebGL Context](/docs/tutorials/external-webgl-context) integrates luma.gl with an existing renderer.
 
-Now create an `index.html` file to bootstrap the application:
+## What the examples guarantee
 
-```html
-<!doctype html>
-<script type="module">
-  import {makeAnimationLoop} from '@luma.gl/engine';
-  import {webgpuAdapter} from '@luma.gl/webgpu';
-  import {webgl2Adapter} from '@luma.gl/webgl';
-  import AppAnimationLoopTemplate from './app.ts';
+- Tutorial application sources are typechecked by the repository test setup.
+- The backend selector reflects the backends supported by each example.
+- Full source links point to the same files rendered in the documentation.
 
-  makeAnimationLoop(AppAnimationLoopTemplate, {
-    adapters: [webgpuAdapter, webgl2Adapter]
-  }).start();
-</script>
-<body style="margin: 0;"></body>
-```
-
-When the page loads, luma.gl will try `webgpuAdapter` first and fall back to
-`webgl2Adapter` when WebGPU is unavailable.
-
-## Build Tooling
-
-We will need the following files in the project folder:
-
-```
-- package.json
-- vite.config.ts
-- app.ts
-- index.html
-```
-
-From the command line, first run
-
-```bash
-mkdir luma-demo
-cd luma-demo
-npm init -y
-```
-
-to set up our project directory and initialize npm.
-
-Next run
-
-```bash
-npm i @luma.gl/engine @luma.gl/webgl @luma.gl/webgpu
-npm i -D vite typescript
-```
-
-to install our dependencies.
-
-Open the file `package.json` (created when we initialized npm), and add the following to the `scripts` block:
-
-```json
-{
-  "scripts": {
-    "start": "vite",
-    "build": "tsc && vite build",
-    "serve": "vite preview"
-  },
-  "dependencies": {
-    "@luma.gl/engine": "9.3.0-alpha.6",
-    "@luma.gl/webgl": "9.3.0-alpha.6",
-    "@luma.gl/webgpu": "9.3.0-alpha.6"
-  },
-  "devDependencies": {
-    "typescript": "^5.5.0",
-    "vite": "^8.0.0"
-  }
-}
-```
-
-The full contents of the `package.json` should be the following (dependency version numbers might differ):
-
-```json
-{
-  "name": "luma-demo",
-  "version": "1.0.0",
-  "private": true,
-  "scripts": {
-    "start": "vite",
-    "build": "tsc && vite build",
-    "serve": "vite preview"
-  },
-  "dependencies": {
-    "@luma.gl/engine": "9.3.0-alpha.6",
-    "@luma.gl/webgl": "9.3.0-alpha.6",
-    "@luma.gl/webgpu": "9.3.0-alpha.6"
-  },
-  "devDependencies": {
-    "typescript": "^5.5.0",
-    "vite": "^8.0.0"
-  }
-}
-```
-
-Create a file [`vite.config.ts`](https://vitejs.dev/config/) in the project root and add the following to it:
-
-```typescript
-import {defineConfig} from 'vite';
-
-export default defineConfig({
-  server: {open: true}
-});
-```
-
-and run
-
-```bash
-npm start
-```
-
-from the command line. If all went well, a tab should open in your default browser,
-and you should see a black canvas fill the page.
+After the course, use [What's Next?](/docs/tutorials/whats-next) to choose a deeper API
+guide or a larger example.

--- a/docs/tutorials/hello-cube.mdx
+++ b/docs/tutorials/hello-cube.mdx
@@ -1,201 +1,52 @@
 import {DeviceTabs} from '@site/src/react-luma';
 import {HelloCubeExample} from '@site/src/examples';
+import {ExampleSource} from '@site/src/components/docs/example-source';
 import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 # Hello Cube
 
 <TutorialDocsTabs group="fundamentals" active="hello-cube" />
 
-This tutorial demonstrates how to render a spinning textured cube using luma.gl's cross-platform rendering APIs.
+**Goal:** expand the triangle model with geometry, a sampled texture, depth testing,
+and uniforms that change every frame.
 
 <DeviceTabs />
 <HelloCubeExample showHeader={false} showStats={false} />
 
-It is assumed you've set up your development environment as described in [Setup](/docs/tutorials).
+## From a draw to a scene object
 
-The cube shaders sample from a 2D texture and apply a model-view-projection
-matrix. A `UniformStore` tracks that matrix so it can be updated every frame as
-the cube rotates. The texture is loaded asynchronously and bound through the
-model's `bindings` property along with the uniform buffer.
+`CubeGeometry` supplies positions, texture coordinates, and indices. `Model` converts
+that geometry into GPU buffers and associates the attributes with the locations declared
+by the WGSL and GLSL vertex shaders.
 
-The complete source for this example is shown below. It builds a `Model` with WGSL
-and GLSL shaders, manages uniforms with a `UniformStore`, and draws a `CubeGeometry`
-inside an `AnimationLoopTemplate`.
+A `DynamicTexture` begins loading the image immediately. The model binds it by name, so
+the WebGPU shader's `@binding(auto)` declarations and the WebGL2 sampler uniform can use
+the same JavaScript binding object.
 
-In WGSL, the example uses `@binding(auto)`, so the JavaScript side only needs
-to provide bindings by name.
+## Updating uniforms
 
-```typescript
-import type {NumberArray, VariableShaderType} from '@luma.gl/core';
-import {Texture, UniformStore} from '@luma.gl/core';
-import {
-  AnimationLoopTemplate,
-  makeAnimationLoop,
-  type AnimationProps,
-  Model,
-  CubeGeometry,
-  loadImageBitmap,
-  DynamicTexture
-} from '@luma.gl/engine';
-import {webgl2Adapter} from '@luma.gl/webgl';
-import {webgpuAdapter} from '@luma.gl/webgpu';
+The model-view-projection matrix changes every frame as the cube rotates. `UniformStore`
+maintains the typed CPU values and the corresponding managed GPU uniform buffer. The
+frame performs three steps:
 
-import {Matrix4} from '@math.gl/core';
+1. Recalculate the matrix for the current aspect ratio and animation tick.
+2. Call `setUniforms` with the new value.
+3. Draw the model in a pass with color and depth attachments.
 
-const WGSL_SHADER = /* WGSL */ `
-struct Uniforms {
-  modelViewProjectionMatrix : mat4x4<f32>,
-};
+Depth writes and `less-equal` comparison ensure the cube's hidden faces do not overwrite
+nearer surfaces.
 
-@group(0) @binding(auto) var<uniform> app : Uniforms;
-@group(0) @binding(auto) var uTexture : texture_2d<f32>;
-@group(0) @binding(auto) var uTextureSampler : sampler;
+<ExampleSource example="tutorials/hello-cube" />
 
-struct VertexInputs {
-  @location(0) positions : vec4<f32>,
-  @location(1) texCoords : vec2<f32>
-};
+## Common problems
 
-struct FragmentInputs {
-  @builtin(position) Position : vec4<f32>,
-  @location(0) fragUV : vec2<f32>,
-  @location(1) fragPosition: vec4<f32>,
-}
+- A black cube usually indicates that the image failed to load; check the asset URL.
+- Distorted faces usually indicate an attribute layout that does not match the shader.
+- Missing faces or incorrect overlap often means depth testing or the depth attachment is
+  absent.
 
-@vertex
-fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
-  var outputs : FragmentInputs;
-  outputs.Position = app.modelViewProjectionMatrix * inputs.positions;
-  outputs.fragUV = inputs.texCoords;
-  outputs.fragPosition = 0.5 * (inputs.positions + vec4(1.0, 1.0, 1.0, 1.0));
-  return outputs;
-}
+## Summary
 
-@fragment
-fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
-  return textureSample(uTexture, uTextureSampler, inputs.fragUV);
-}
-`;
-
-// GLSL
-const VS_GLSL = /* glsl */ `
-#version 300 es
-#define SHADER_NAME cube-vs
-
-uniform appUniforms {
-  mat4 modelViewProjectionMatrix;
-} app;
-
-layout(location=0) in vec3 positions;
-layout(location=1) in vec2 texCoords;
-
-out vec2 fragUV;
-out vec4 fragPosition;
-
-void main() {
-  gl_Position = app.modelViewProjectionMatrix * vec4(positions, 1.0);
-  fragUV = texCoords;
-  fragPosition = 0.5 * (vec4(positions, 1.) + vec4(1., 1., 1., 1.));
-}
-`;
-
-const FS_GLSL = /* glsl */ `
-#version 300 es
-#define SHADER_NAME cube-fs
-precision highp float;
-
-uniform sampler2D uTexture;
-
-in vec2 fragUV;
-in vec4 fragPosition;
-
-layout (location=0) out vec4 fragColor;
-
-void main() {
-  fragColor = texture(uTexture, vec2(fragUV.x, 1.0 - fragUV.y));
-}
-`;
-
-type AppUniforms = {
-  mvpMatrix: NumberArray;
-};
-
-const app: {uniformTypes: Record<keyof AppUniforms, VariableShaderType>} = {
-  uniformTypes: {
-    mvpMatrix: 'mat4x4<f32>'
-  }
-};
-
-const eyePosition = [0, 0, -4];
-
-class AppAnimationLoopTemplate extends AnimationLoopTemplate {
-  mvpMatrix = new Matrix4();
-  viewMatrix = new Matrix4().lookAt({eye: eyePosition});
-  model: Model;
-  uniformStore = new UniformStore<{app: AppUniforms}>({app});
-
-  constructor({device}: AnimationProps) {
-    super();
-
-    const texture = new DynamicTexture(device, {
-      usage: Texture.TEXTURE | Texture.RENDER_ATTACHMENT | Texture.COPY_DST,
-      data: loadImageBitmap('vis-logo.png'),
-      flipY: true,
-      mipmaps: true,
-      sampler: device.createSampler({
-        minFilter: 'linear',
-        magFilter: 'linear',
-        mipmapFilter: 'linear'
-      })
-    });
-
-    this.model = new Model(device, {
-      id: 'rotating-cube',
-      source: WGSL_SHADER,
-      vs: VS_GLSL,
-      fs: FS_GLSL,
-      geometry: new CubeGeometry({indices: false}),
-      bindings: {
-        app: this.uniformStore.getManagedUniformBuffer(device, 'app'),
-        uTexture: texture
-      },
-      parameters: {
-        depthWriteEnabled: true,
-        depthCompare: 'less-equal'
-      }
-    });
-  }
-
-  onFinalize() {
-    this.model.destroy();
-    this.uniformStore.destroy();
-  }
-
-  onRender({device, aspect, tick}: AnimationProps) {
-    this.mvpMatrix
-      .perspective({fovy: Math.PI / 3, aspect})
-      .multiplyRight(this.viewMatrix)
-      .rotateX(tick * 0.01)
-      .rotateY(tick * 0.013);
-
-    this.uniformStore.setUniforms({
-      app: {mvpMatrix: this.mvpMatrix}
-    });
-
-    const renderPass = device.beginRenderPass({clearColor: [0, 0, 0, 1], clearDepth: 1});
-    this.model.draw(renderPass);
-    renderPass.end();
-  }
-}
-
-const animationLoop = makeAnimationLoop(AppAnimationLoopTemplate, {
-  adapters: [webgpuAdapter, webgl2Adapter]
-});
-animationLoop.start();
-```
-
-During rendering the animation loop recalculates the matrix, updates the uniform
-buffer and draws the cube inside a render pass. The fragment shader samples the
-bound texture to shade each face.
-
-Running the application will display a rotating cube textured with the vis.gl logo.
+You combined geometry, asynchronous texture data, bindings, uniforms, and depth state in
+one reusable model. Next, [Hello Instancing](/docs/tutorials/hello-instancing) draws many
+objects with one model and one draw call.

--- a/docs/tutorials/hello-instancing.mdx
+++ b/docs/tutorials/hello-instancing.mdx
@@ -1,183 +1,47 @@
 import {DeviceTabs} from '@site/src/react-luma';
 import {HelloInstancingExample} from '@site/src/examples';
+import {ExampleSource} from '@site/src/components/docs/example-source';
 import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 # Hello Instancing
 
 <TutorialDocsTabs group="fundamentals" active="hello-instancing" />
 
-This tutorial illustrates _instanced_ drawing with luma.gl using both WGSL and GLSL shaders and also shows how a custom luma.gl _shader module_ can be used to pass colors.
+**Goal:** draw multiple copies of one geometry with one model and one draw call.
 
 <DeviceTabs />
 <HelloInstancingExample showHeader={false} showStats={false} />
 
-It is assumed you've set up your development environment as described in [Setup](/docs/tutorials).
+## Shared and per-instance data
 
-_Instancing_ lets the GPU draw many copies of the same geometry with a single draw call. When rendering many similar geometries this can be significant speedups.
+Instancing separates attributes by update frequency:
 
-In this sample, each triangle shares the same vertex data while per-instance
-attributes provide unique colors and offsets. A small `color` shader module passes
-those colors from the vertex shader to the fragment shader.
+- Vertex positions use the default `vertex` step mode and repeat for every instance.
+- Colors and offsets use `stepMode: 'instance'`, so the GPU advances those values once
+  per triangle rather than once per vertex.
 
-The code below creates a `Model` with per-instance attributes to draw four colored
-triangles inside an `AnimationLoopTemplate`.
+The model sets `vertexCount: 3` and `instanceCount: 4`. The resulting draw processes the
+same three positions four times, pairing each copy with a different color and offset.
 
-A luma.gl shader module essentially contains some shader code fragments that will be inserted into our vertex and fragment shaders. Shader modules usually define shader functions that implement generic functionality that can be reused in different shader programs.
+## Buffer layout is the contract
 
-In this case, we're defining a minimal shader module to pass a color from the vertex shader to the fragment shader. This module also demonstrates a common convention in luma.gl to prefix function and variable names in a shader module with the name of the module to avoid name collisions.
+`bufferLayout` maps JavaScript buffer names to shader attributes and describes the stored
+format. A layout mismatch can read the correct bytes with the wrong stride or component
+count, so keep memory formats such as `float32x2` separate from shader-facing types.
 
-Now let's update our vertex and fragment shaders to use the shader module functions:
+The example includes both WGSL and GLSL. The portable application constructs identical
+buffers and bindings for either backend.
 
-```typescript
-import {Buffer} from '@luma.gl/core';
-import {AnimationLoopTemplate, AnimationProps, Model, makeAnimationLoop} from '@luma.gl/engine';
-import {webgl2Adapter} from '@luma.gl/webgl';
-import {webgpuAdapter} from '@luma.gl/webgpu';
+<ExampleSource example="tutorials/hello-instancing" />
 
-const colorShaderModule = {
-  name: 'color',
-  source: /* wgsl */ `
-  // TODO: wgsl not yet implemented
-  // struct ColorVaryings {
-  //   color: vec3<f32>,
-  // };
+## When to use instancing
 
-  // @vertex
-  // fn color_setColor(color: vec3f, input: ColorVaryings) -> ColorVaryings {
-  //   var output = input;
-  //   output.color = color;
-  //   return output;
-  // }
+Instancing is a strong fit when many objects share geometry and shader logic but differ
+in transforms, colors, picking identifiers, or other small records. It reduces draw-call
+overhead and avoids duplicating shared vertex data.
 
-  // @fragment
-  // fn color_getColor(input: ColorVaryings) -> vec4<f32> {
-  //   return vec4<f32>(input.color, 1.0);
-  // }
-  `,
-  vs: /* glsl */ `
-out vec3 color_vColor;
+## Summary
 
-void color_setColor(vec3 color) {
-  color_vColor = color;
-}
-  `,
-  fs: /* glsl */ `
-in vec3 color_vColor;
-
-vec3 color_getColor() {
-  return color_vColor;
-}
-  `
-};
-
-const source = /* wgsl */ `
-struct VertexInputs {
-  @location(0) position: vec2<f32>,
-  @location(1) instanceColor: vec3<f32>,
-  @location(2) instanceOffset: vec2<f32>,
-};
-
-struct FragmentInputs {
-  @builtin(position) Position: vec4<f32>,
-  @location(0) color: vec3<f32>,
-}
-
-@vertex
-fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
-  var outputs: FragmentInputs;
-  outputs.color = inputs.instanceColor;
-  outputs.Position = vec4<f32>(inputs.position + inputs.instanceOffset, 0.0, 1.0);
-  return outputs;
-}
-
-@fragment
-fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
-  return vec4<f32>(inputs.color, 1.0);
-}
-`;
-
-const vs = /* glsl */ `
-#version 300 es
-in vec2 position;
-in vec3 instanceColor;
-in vec2 instanceOffset;
-
-void main() {
-  color_setColor(instanceColor);
-  gl_Position = vec4(position + instanceOffset, 0.0, 1.0);
-}
-`;
-
-const fs = /* glsl */ `
-#version 300 es
-out vec4 fragColor;
-void main() {
-  fragColor = vec4(color_getColor(), 1.0);
-}
-`;
-
-class AppAnimationLoopTemplate extends AnimationLoopTemplate {
-  model: Model;
-  positionBuffer: Buffer;
-  colorBuffer: Buffer;
-  offsetBuffer: Buffer;
-
-  constructor({device}: AnimationProps) {
-    super();
-
-    this.positionBuffer = device.createBuffer(new Float32Array([-0.2, -0.2, 0.2, -0.2, 0.0, 0.2]));
-    this.colorBuffer = device.createBuffer(
-      new Float32Array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0])
-    );
-    this.offsetBuffer = device.createBuffer(
-      new Float32Array([0.5, 0.5, -0.5, 0.5, 0.5, -0.5, -0.5, -0.5])
-    );
-
-    this.model = new Model(device, {
-      source,
-      vs,
-      fs,
-      modules: [colorShaderModule],
-      bufferLayout: [
-        {name: 'position', format: 'float32x2'},
-        {name: 'instanceColor', format: 'float32x3', stepMode: 'instance'},
-        {name: 'instanceOffset', format: 'float32x2', stepMode: 'instance'}
-      ],
-      attributes: {
-        position: this.positionBuffer,
-        instanceColor: this.colorBuffer,
-        instanceOffset: this.offsetBuffer
-      },
-      vertexCount: 3,
-      instanceCount: 4,
-      parameters: {
-        depthWriteEnabled: true,
-        depthCompare: 'less-equal'
-      }
-    });
-  }
-
-  onFinalize() {
-    this.model.destroy();
-    this.positionBuffer.destroy();
-    this.colorBuffer.destroy();
-    this.offsetBuffer.destroy();
-  }
-
-  onRender({device}: AnimationProps) {
-    const renderPass = device.beginRenderPass({clearColor: [0, 0, 0, 1]});
-    this.model.draw(renderPass);
-    renderPass.end();
-  }
-}
-
-const animationLoop = makeAnimationLoop(AppAnimationLoopTemplate, {
-  adapters: [webgpuAdapter, webgl2Adapter]
-});
-animationLoop.start();
-```
-
-Note that geometry vertex positions are stored once in one separate GPU buffer, while two additional buffers supply
-per-instance colors and offsets. The buffer layout marks those attributes with `stepMode: 'instance'` so they advance once per triangle. A single draw call then renders four instances in different screen quadrants.
-
-Running the application will draw four colored triangles using instancing.
+You used per-vertex and per-instance buffers in one model. Continue with
+[Shader Modules](/docs/tutorials/shader-modules) to package shader behavior for reuse,
+or [Lighting](/docs/tutorials/lighting) to apply that composition to materials.

--- a/docs/tutorials/hello-triangle.mdx
+++ b/docs/tutorials/hello-triangle.mdx
@@ -1,99 +1,51 @@
 import {DeviceTabs} from '@site/src/react-luma';
 import {HelloTriangleExample} from '@site/src/examples';
+import {ExampleSource} from '@site/src/components/docs/example-source';
 import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 # Hello Triangle
 
 <TutorialDocsTabs group="fundamentals" active="hello-triangle" />
 
-This tutorial demonstrates how to draw a triangle using luma.gl's cross-platform rendering APIs.
+**Goal:** create one `Model` and issue a portable draw call. Complete
+[Getting Started](/docs/getting-started) before this lesson.
 
 <DeviceTabs />
 <HelloTriangleExample showHeader={false} showStats={false} />
 
-It is assumed you've set up your development environment as described in [Setup](/docs/tutorials).
+The example should display a red triangle. Switch backends above the canvas to verify
+that the same application code runs with WebGPU and WebGL2.
 
-We create a `Model` to render the triangle. This will be a recurring theme in all our tutorials. A `Model` can be thought of as gathering all the WebGL/WebGPU pieces necessary for a single draw call: render pipelines (shader programs), attribute buffers, uniforms, texture bindings etc.
+## The mental model
 
-The program uses a tiny vertex shader that relies on the built-in `vertex_index` to look up clip-space positions for the three vertices. A matching fragment shader fills the triangle with a solid color. Both WGSL and GLSL versions are provided so the example runs on WebGPU and WebGL without changes.
+A `Model` gathers the state required for one draw: shaders, topology, vertex and
+instance counts, buffer layouts, attributes, bindings, and render parameters. It is a
+durable object; the animation loop draws it into a short-lived `RenderPass` each frame.
 
-The complete source for this example is shown below. It creates a `Model` with both WGSL and GLSL shaders and renders it inside an `AnimationLoopTemplate`. The animation loop simply opens a render pass, draws the model and ends the pass each frame.
+This first model does not need a vertex buffer. Both shaders use the built-in vertex
+index to select three clip-space positions. The WebGPU backend consumes WGSL and the
+WebGL2 backend consumes GLSL, while the model and render loop are shared.
 
-```typescript
-import {AnimationLoopTemplate, AnimationProps, makeAnimationLoop, Model} from '@luma.gl/engine';
-import {webgl2Adapter} from '@luma.gl/webgl';
-import {webgpuAdapter} from '@luma.gl/webgpu';
+## Follow the frame
 
-const WGSL_SHADER = /* WGSL */ `
-@vertex
-fn vertexMain(@builtin(vertex_index) vertexIndex : u32) -> @builtin(position) vec4<f32> {
-  var positions = array<vec2<f32>, 3>(vec2(0.0, 0.5), vec2(-0.5, -0.5), vec2(0.5, -0.5));
-  return vec4<f32>(positions[vertexIndex], 0.0, 1.0);
-}
+1. `makeAnimationLoop` creates the best available device from the supplied adapters.
+2. The animation loop constructs the application with that device.
+3. `onRender` begins a render pass and clears its color attachment.
+4. `model.draw(renderPass)` records the draw.
+5. Ending the pass allows the device to submit and present the frame.
 
-@fragment
-fn fragmentMain() -> @location(0) vec4<f32> {
-  return vec4<f32>(1.0, 0.0, 0.0, 1.0);
-}
-`;
+<ExampleSource example="tutorials/hello-triangle" />
 
-const VS_GLSL = /* glsl */ `
-#version 300 es
-const vec2 pos[3] = vec2[3](vec2(0.0f, 0.5f), vec2(-0.5f, -0.5f), vec2(0.5f, -0.5f));
-void main() {
-  gl_Position = vec4(pos[gl_VertexID], 0.0, 1.0);
-}
-`;
+## Common problems
 
-const FS_GLSL = /* glsl */ `
-#version 300 es
-precision highp float;
-layout(location = 0) out vec4 outColor;
-void main() {
-  outColor = vec4(1.0, 0.0, 0.0, 1.0);
-}
-`;
+- A shader compilation error normally identifies WGSL or GLSL source and line number in
+  the browser console.
+- A blank canvas with no error often means the model was not drawn inside an active pass.
+- If only one backend fails, use the backend selector to isolate the shader or feature
+  that is not portable.
 
-class AppAnimationLoopTemplate extends AnimationLoopTemplate {
-  model: Model;
+## Summary
 
-  constructor({device}: AnimationProps) {
-    super();
-    this.model = new Model(device, {
-      source: WGSL_SHADER,
-      vs: VS_GLSL,
-      fs: FS_GLSL,
-      topology: 'triangle-list',
-      vertexCount: 3,
-      shaderLayout: {
-        attributes: [],
-        bindings: []
-      },
-      parameters: {
-        depthFormat: 'depth24plus'
-      }
-    });
-  }
-
-  override onFinalize() {
-    this.model.destroy();
-  }
-
-  override onRender({device}: AnimationProps) {
-    const renderPass = device.beginRenderPass({clearColor: [1, 1, 1, 1]});
-    this.model.draw(renderPass);
-    renderPass.end();
-  }
-}
-
-const animationLoop = makeAnimationLoop(AppAnimationLoopTemplate, {
-  adapters: [webgpuAdapter, webgl2Adapter]
-});
-animationLoop.start();
-```
-
-The vertex shader uses built-in indices, so no vertex buffers are needed for this
-minimal example. The render loop clears the canvas and draws the model every
-frame.
-
-When the application runs you should see a red triangle rendered on a white background.
+You created a model, provided backend-appropriate shaders, and drew it through the same
+render-pass API. Next, [Hello Cube](/docs/tutorials/hello-cube) adds geometry, textures,
+depth testing, and uniforms.

--- a/website/content/examples/experimental/gpt-2.mdx
+++ b/website/content/examples/experimental/gpt-2.mdx
@@ -1,5 +1,12 @@
 ---
 title: GPT-2 Transformer
+description: Run GPT-2 inference with WebGPU compute pipelines and GPU-resident model data.
+sidebar_custom_props:
+  description: Run GPT-2 inference with WebGPU compute pipelines and GPU-resident model data.
+  backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [compute, data]
 ---
 
 import {GPT2Example} from '@site/src/examples';

--- a/website/content/examples/tutorials/hello-cube.mdx
+++ b/website/content/examples/tutorials/hello-cube.mdx
@@ -1,5 +1,12 @@
 ---
 title: Hello Cube
+description: Render textured geometry with uniforms, depth testing, and animation.
+sidebar_custom_props:
+  description: Add indexed geometry, textures, depth testing, and animated uniforms.
+  backends: [webgpu, webgl2]
+  difficulty: beginner
+  maturity: stable
+  topics: [fundamentals, rendering, textures]
 ---
 
 import {HelloCubeExample} from '@site/src/examples';

--- a/website/content/examples/tutorials/hello-instancing.mdx
+++ b/website/content/examples/tutorials/hello-instancing.mdx
@@ -1,5 +1,12 @@
 ---
 title: Hello Instancing
+description: Draw multiple objects efficiently with per-instance attributes.
+sidebar_custom_props:
+  description: Render many objects efficiently with instanced attributes and one model.
+  backends: [webgpu, webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [fundamentals, rendering]
 ---
 
 import {HelloInstancingExample} from '@site/src/examples';

--- a/website/content/examples/tutorials/hello-triangle.mdx
+++ b/website/content/examples/tutorials/hello-triangle.mdx
@@ -1,5 +1,12 @@
 ---
 title: Hello Triangle
+description: Draw a first portable triangle with a Model and backend-specific shaders.
+sidebar_custom_props:
+  description: Draw a first portable triangle with a Model and backend-specific shaders.
+  backends: [webgpu, webgl2]
+  difficulty: beginner
+  maturity: stable
+  topics: [fundamentals, rendering]
 ---
 
 import {HelloTriangleExample} from '@site/src/examples';

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -85,20 +85,41 @@ module.exports = {
   ...baseConfig,
   baseUrl: websiteBaseUrl,
   staticDirectories: [...staticDirectories, '.generated/example-assets'],
-  plugins: basePlugins.map((plugin) => {
-    if (Array.isArray(plugin) && plugin[0] === '@cmfcmf/docusaurus-search-local') {
-      return [
-        plugin[0],
-        {
-          ...plugin[1],
-          indexDocs: true,
-          indexBlog: false,
-          indexPages: true
+  plugins: [
+    ...basePlugins.map((plugin) => {
+      if (Array.isArray(plugin) && plugin[0] === '@cmfcmf/docusaurus-search-local') {
+        return [
+          plugin[0],
+          {
+            ...plugin[1],
+            indexDocs: true,
+            indexBlog: false,
+            indexPages: true
+          }
+        ];
+      }
+      return plugin;
+    }),
+    [
+      'docusaurus-plugin-typedoc',
+      {
+        id: 'core-api-reference',
+        name: '@luma.gl/core generated API',
+        entryPoints: ['../modules/core/src/index.ts'],
+        tsconfig: '../modules/core/tsconfig.json',
+        out: '../docs/api-reference/generated/core',
+        docsPath: '../docs',
+        readme: 'none',
+        excludeInternal: true,
+        excludePrivate: true,
+        excludeProtected: true,
+        gitRevision: 'master',
+        sidebar: {
+          autoConfiguration: false
         }
-      ];
-    }
-    return plugin;
-  }),
+      }
+    ]
+  ],
   future: {
     v4: true
   },

--- a/website/package.json
+++ b/website/package.json
@@ -25,6 +25,7 @@
     "@docusaurus/core": "^3.9.2",
     "@probe.gl/stats": "^4.1.1",
     "@probe.gl/stats-widget": "^4.1.1",
+    "@stackblitz/sdk": "^1.11.0",
     "@vis.gl/docusaurus-website": "1.0.0-alpha.21",
     "clsx": "^1.1.1",
     "maplibre-gl": "^5.13.0",
@@ -35,7 +36,11 @@
   "devDependencies": {
     "@cmfcmf/docusaurus-search-local": "^2.0.0",
     "@docusaurus/tsconfig": "^3.9.2",
-    "docusaurus-mdx-checker": "^3.0.0"
+    "docusaurus-mdx-checker": "^3.0.0",
+    "docusaurus-plugin-typedoc": "^1.4.2",
+    "typedoc": "^0.28.19",
+    "typedoc-plugin-markdown": "^4.10.0",
+    "typescript": "5.9.3"
   },
   "browserslist": [
     ">0.2% and supports async-functions",

--- a/website/scripts/sync-example-assets.mjs
+++ b/website/scripts/sync-example-assets.mjs
@@ -35,7 +35,12 @@ const ASSET_EXTENSIONS = new Set([
 ]);
 
 const SKIPPED_DIRECTORY_NAMES = new Set(['dist', 'node_modules']);
-const EXAMPLE_SOURCE_FILE_NAMES = new Set(['app.ts', 'app.tsx']);
+const EXAMPLE_SOURCE_FILE_NAMES = new Set([
+  'app.ts',
+  'app.tsx',
+  'index.html',
+  'package.json'
+]);
 
 function syncExampleAssets() {
   rmSync(path.resolve(websiteDirectory, '.generated', 'example-assets'), {

--- a/website/src/components/docs/example-source.tsx
+++ b/website/src/components/docs/example-source.tsx
@@ -1,0 +1,104 @@
+import React, {type ReactNode, useEffect, useMemo, useState} from 'react';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import CodeBlock from '@theme/CodeBlock';
+
+type SourceFile = {
+  path: string;
+  source: string;
+};
+
+const DEFAULT_FILES = ['app.ts', 'app.tsx', 'index.html', 'package.json'];
+
+/** Renders canonical files copied from an example during the website build. */
+export function ExampleSource({
+  example,
+  files = DEFAULT_FILES,
+  title = 'Runnable source'
+}: {
+  example: string;
+  files?: string[];
+  title?: string;
+}): ReactNode {
+  const baseUrl = useBaseUrl('/example-assets/');
+  const filesKey = files.join('|');
+  const requestedFiles = useMemo(() => files, [filesKey]);
+  const [sourceFiles, setSourceFiles] = useState<SourceFile[]>([]);
+  const [activePath, setActivePath] = useState(files[0] || '');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    setSourceFiles([]);
+    setError(null);
+
+    void Promise.all(
+      requestedFiles.map(async path => {
+        const response = await fetch(`${baseUrl}${example}/${path}`, {
+          signal: abortController.signal
+        });
+        return response.ok ? {path, source: await response.text()} : null;
+      })
+    )
+      .then(results => {
+        const availableFiles = results.filter((file): file is SourceFile => Boolean(file));
+        if (availableFiles.length === 0) {
+          setError('Unable to load the example source.');
+          return;
+        }
+        setSourceFiles(availableFiles);
+        setActivePath(availableFiles[0].path);
+      })
+      .catch(fetchError => {
+        if (!abortController.signal.aborted) {
+          setError(fetchError instanceof Error ? fetchError.message : 'Unable to load the source.');
+        }
+      });
+
+    return () => abortController.abort();
+  }, [baseUrl, example, requestedFiles]);
+
+  const activeFile = sourceFiles.find(file => file.path === activePath) || sourceFiles[0];
+
+  return (
+    <section className="docs-example-source" aria-label={title}>
+      <div className="docs-example-source__header">
+        <strong>{title}</strong>
+        <a href={`https://github.com/visgl/luma.gl/tree/master/examples/${example}`}>
+          View on GitHub
+        </a>
+      </div>
+      {sourceFiles.length > 1 ? (
+        <div className="docs-example-source__tabs" role="tablist" aria-label="Source files">
+          {sourceFiles.map(file => (
+            <button
+              key={file.path}
+              type="button"
+              role="tab"
+              aria-selected={file.path === activeFile?.path}
+              className={file.path === activeFile?.path ? 'is-active' : undefined}
+              onClick={() => setActivePath(file.path)}
+            >
+              {file.path}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      {error ? <p className="docs-example-source__error">{error}</p> : null}
+      {activeFile ? (
+        <CodeBlock language={getSourceLanguage(activeFile.path)}>{activeFile.source}</CodeBlock>
+      ) : error ? null : (
+        <CodeBlock language="typescript">{'// Loading canonical example source…'}</CodeBlock>
+      )}
+    </section>
+  );
+}
+
+function getSourceLanguage(path: string): string {
+  if (path.endsWith('.html')) {
+    return 'html';
+  }
+  if (path.endsWith('.json')) {
+    return 'json';
+  }
+  return path.endsWith('.tsx') ? 'tsx' : 'typescript';
+}

--- a/website/src/components/examples-index.tsx
+++ b/website/src/components/examples-index.tsx
@@ -1,16 +1,26 @@
-import React from 'react';
-// @ts-expect-error Internal Docusaurus API
+import React, {useEffect, useMemo, useState} from 'react';
 import {useDocsSidebar} from '@docusaurus/plugin-content-docs/client';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import styled from 'styled-components';
 
-const isMobile = '@media screen and (min-width: 768px)';
+type ExampleBackend = 'webgpu' | 'webgl2';
+type ExampleDifficulty = 'beginner' | 'intermediate' | 'advanced';
+type ExampleMaturity = 'stable' | 'experimental';
 
-type SidebarDocItem = {
-  type?: string;
+type ExampleCustomProps = {
+  backends?: ExampleBackend[];
+  description?: string;
+  difficulty?: ExampleDifficulty;
+  maturity?: ExampleMaturity;
+  topics?: string[];
+};
+
+export type SidebarDocItem = {
+  type?: 'doc' | 'link';
   label: string;
   href?: string;
   docId?: string;
+  customProps?: ExampleCustomProps;
 };
 
 type SidebarCategoryItem = {
@@ -24,139 +34,352 @@ type SidebarRoot = {
   items: Array<SidebarDocItem | SidebarCategoryItem>;
 };
 
+type CatalogItem = SidebarDocItem & {
+  backends: ExampleBackend[];
+  category: string;
+  description: string;
+  difficulty: ExampleDifficulty;
+  maturity: ExampleMaturity;
+  topics: string[];
+};
+
 type ExamplesIndexProps = {
   getThumbnail: (item: SidebarDocItem) => string;
 };
 
-const ExampleHeader = styled.div`
-  font: bold 20px/28px var(--ifm-font-family-base);
-  color: var(--ifm-color-gray-800);
-  margin: 0 20px;
-  border-bottom: 1px solid 20px;
-  display: inline-block;
-  padding: 20px 20px 4px 0;
-`;
-
 const MainExamples = styled.main`
-  padding: 16px 0;
+  padding: 1rem 0 2rem;
 `;
 
-const ExamplesGroup = styled.main`
-  display: flex;
-  flex-wrap: wrap;
-  padding: 16px;
-`;
+const CatalogControls = styled.div`
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(14rem, 2fr) repeat(4, minmax(8rem, 1fr));
+  margin: 0 1rem 1.5rem;
+  padding: 1rem;
 
-const ExampleCard = styled.a`
-  cursor: pointer;
-  text-decoration: none;
-  width: 50%;
-  max-width: 240px;
-  line-height: 0;
-  outline: none;
-  padding: 4px;
-  position: relative;
-
-  img {
-    transition-property: filter;
-    transition-duration: var(--ifm-transition-slow);
-    transition-timing-function: var(--ifm-transition-timing-default);
+  input,
+  select {
+    background: var(--ifm-background-color);
+    border: 1px solid var(--ifm-color-emphasis-300);
+    border-radius: 8px;
+    color: var(--ifm-font-color-base);
+    font: inherit;
+    min-height: 2.65rem;
+    padding: 0.55rem 0.7rem;
+    width: 100%;
   }
 
-  &:hover {
-    box-shadow: var(--ifm-global-shadow-md);
-  }
+  @media screen and (max-width: 996px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
 
-  &:hover img {
-    filter: contrast(0.2);
-  }
-
-  ${isMobile} {
-    width: 33%;
-    min-width: 200px;
-  }
-
-  @media screen and (max-width: 632px) {
-    width: 50%;
-  }
-`;
-
-const ExampleTitle = styled.div`
-  position: absolute;
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  color: var(--ifm-color-white);
-  font-size: 1.5em;
-  text-align: center;
-  line-height: initial;
-  width: 90%;
-  height: 90%;
-  top: 5%;
-  left: 5%;
-  border: solid 1px var(--ifm-color-white);
-  opacity: 0;
-  transition-property: opacity;
-  transition-duration: var(--ifm-transition-slow);
-  transition-timing-function: var(--ifm-transition-timing-default);
-
-  &:hover {
-    opacity: 1;
-  }
-`;
-
-function getItemKey(item: SidebarDocItem | SidebarCategoryItem, parentKey: string): string {
-  if (item.type === 'category') {
-    return `${parentKey}/category:${item.label}`;
-  }
-
-  return `${parentKey}/doc:${item.href || item.docId || item.label}`;
-}
-
-function renderItem(item: SidebarDocItem, getThumbnail: (item: SidebarDocItem) => string) {
-  const imageUrl = useBaseUrl(getThumbnail(item));
-  const {label, href} = item;
-
-  return (
-    <ExampleCard key={href || item.docId || label} href={href}>
-      <img width="100%" src={imageUrl} alt={label} />
-      <ExampleTitle>
-        <span>{label}</span>
-      </ExampleTitle>
-    </ExampleCard>
-  );
-}
-
-function renderCategory(
-  category: SidebarRoot | SidebarCategoryItem,
-  getThumbnail: (item: SidebarDocItem) => string,
-  parentKey = 'root'
-) {
-  const pages: SidebarDocItem[] = [];
-  const categories: SidebarCategoryItem[] = [];
-
-  for (const item of category.items) {
-    if (item.type === 'category') {
-      categories.push(item);
-    } else if (item.docId !== 'index') {
-      pages.push(item);
+    input {
+      grid-column: 1 / -1;
     }
   }
 
-  return (
-    <React.Fragment key={parentKey}>
-      {category.label ? <ExampleHeader>{category.label}</ExampleHeader> : null}
-      {pages.length > 0 ? (
-        <ExamplesGroup>{pages.map(item => renderItem(item, getThumbnail))}</ExamplesGroup>
-      ) : null}
-      {categories.map(item =>
-        renderCategory(item, getThumbnail, getItemKey(item, parentKey))
-      )}
-    </React.Fragment>
-  );
-}
+  @media screen and (max-width: 520px) {
+    grid-template-columns: 1fr;
+
+    input {
+      grid-column: auto;
+    }
+  }
+`;
+
+const ResultsSummary = styled.p`
+  color: var(--ifm-color-emphasis-700);
+  margin: 0 1rem 1rem;
+`;
+
+const ExampleSection = styled.section`
+  margin: 0 1rem 2rem;
+`;
+
+const ExampleHeader = styled.h2`
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  margin: 0 0 1rem;
+  padding-bottom: 0.45rem;
+`;
+
+const ExamplesGroup = styled.div`
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+`;
+
+const ExampleCard = styled.a`
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 10px;
+  color: var(--ifm-font-color-base);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+  text-decoration: none;
+  transition: border-color var(--ifm-transition-fast), box-shadow var(--ifm-transition-fast),
+    transform var(--ifm-transition-fast);
+
+  &:hover,
+  &:focus-visible {
+    border-color: var(--ifm-color-primary);
+    box-shadow: var(--ifm-global-shadow-md);
+    color: var(--ifm-font-color-base);
+    text-decoration: none;
+    transform: translateY(-2px);
+  }
+
+  img {
+    aspect-ratio: 16 / 9;
+    background: var(--ifm-color-emphasis-100);
+    object-fit: cover;
+    width: 100%;
+  }
+`;
+
+const CardBody = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 0.9rem;
+
+  h3 {
+    font-size: 1.08rem;
+    margin: 0;
+  }
+
+  p {
+    color: var(--ifm-color-emphasis-700);
+    font-size: 0.9rem;
+    line-height: 1.45;
+    margin: 0;
+  }
+`;
+
+const Badges = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: auto;
+`;
+
+const Badge = styled.span`
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 999px;
+  color: var(--ifm-color-emphasis-800);
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.18rem 0.45rem;
+`;
 
 export function ExamplesIndex({getThumbnail}: ExamplesIndexProps) {
   const sidebar = useDocsSidebar() as SidebarRoot;
-  return <MainExamples>{renderCategory(sidebar, getThumbnail)}</MainExamples>;
+  const baseUrl = useBaseUrl('/');
+  const catalog = useMemo(() => buildCatalog(sidebar), [sidebar]);
+  const topics = useMemo(
+    () => [...new Set(catalog.flatMap(item => item.topics))].sort(),
+    [catalog]
+  );
+  const [query, setQuery] = useState('');
+  const [backend, setBackend] = useState('all');
+  const [difficulty, setDifficulty] = useState('all');
+  const [maturity, setMaturity] = useState('all');
+  const [topic, setTopic] = useState('all');
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  useEffect(() => {
+    const parameters = new URLSearchParams(window.location.search);
+    setQuery(parameters.get('q') || '');
+    setBackend(parameters.get('backend') || 'all');
+    setDifficulty(parameters.get('difficulty') || 'all');
+    setMaturity(parameters.get('maturity') || 'all');
+    setTopic(parameters.get('topic') || 'all');
+    setIsInitialized(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isInitialized) {
+      return;
+    }
+    const parameters = new URLSearchParams();
+    if (query) parameters.set('q', query);
+    if (backend !== 'all') parameters.set('backend', backend);
+    if (difficulty !== 'all') parameters.set('difficulty', difficulty);
+    if (maturity !== 'all') parameters.set('maturity', maturity);
+    if (topic !== 'all') parameters.set('topic', topic);
+    const search = parameters.toString();
+    window.history.replaceState(null, '', `${window.location.pathname}${search ? `?${search}` : ''}`);
+  }, [backend, difficulty, isInitialized, maturity, query, topic]);
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const filteredCatalog = catalog.filter(item => {
+    const searchableText = [item.label, item.description, item.category, ...item.topics]
+      .join(' ')
+      .toLowerCase();
+    return (
+      (!normalizedQuery || searchableText.includes(normalizedQuery)) &&
+      (backend === 'all' || item.backends.includes(backend as ExampleBackend)) &&
+      (difficulty === 'all' || item.difficulty === difficulty) &&
+      (maturity === 'all' || item.maturity === maturity) &&
+      (topic === 'all' || item.topics.includes(topic))
+    );
+  });
+  const categories = groupByCategory(filteredCatalog);
+
+  return (
+    <MainExamples>
+      <CatalogControls aria-label="Filter examples">
+        <input
+          type="search"
+          value={query}
+          onChange={event => setQuery(event.target.value)}
+          placeholder="Search examples, APIs, and topics…"
+          aria-label="Search examples"
+        />
+        <FilterSelect label="Backend" value={backend} onChange={setBackend} options={['webgpu', 'webgl2']} />
+        <FilterSelect
+          label="Difficulty"
+          value={difficulty}
+          onChange={setDifficulty}
+          options={['beginner', 'intermediate', 'advanced']}
+        />
+        <FilterSelect
+          label="Maturity"
+          value={maturity}
+          onChange={setMaturity}
+          options={['stable', 'experimental']}
+        />
+        <FilterSelect label="Topic" value={topic} onChange={setTopic} options={topics} />
+      </CatalogControls>
+      <ResultsSummary aria-live="polite">
+        Showing {filteredCatalog.length} of {catalog.length} examples
+      </ResultsSummary>
+      {categories.map(([category, items]) => (
+        <ExampleSection key={category}>
+          <ExampleHeader>{category}</ExampleHeader>
+          <ExamplesGroup>
+            {items.map(item => {
+              const thumbnail = getThumbnail(item);
+              const imageUrl = `${baseUrl}${thumbnail.replace(/^\//, '')}`;
+              return (
+                <ExampleCard key={item.href || item.docId || item.label} href={item.href}>
+                  <img src={imageUrl} alt="" />
+                  <CardBody>
+                    <h3>{item.label}</h3>
+                    <p>{item.description}</p>
+                    <Badges>
+                      {item.backends.map(value => <Badge key={value}>{value}</Badge>)}
+                      <Badge>{item.difficulty}</Badge>
+                      {item.maturity === 'experimental' ? <Badge>experimental</Badge> : null}
+                    </Badges>
+                  </CardBody>
+                </ExampleCard>
+              );
+            })}
+          </ExamplesGroup>
+        </ExampleSection>
+      ))}
+      {filteredCatalog.length === 0 ? (
+        <ResultsSummary>No examples match the selected filters.</ResultsSummary>
+      ) : null}
+    </MainExamples>
+  );
+}
+
+function FilterSelect({
+  label,
+  value,
+  onChange,
+  options
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: string[];
+}) {
+  return (
+    <select aria-label={label} value={value} onChange={event => onChange(event.target.value)}>
+      <option value="all">{getAllOptionsLabel(label)}</option>
+      {options.map(option => <option key={option} value={option}>{formatLabel(option)}</option>)}
+    </select>
+  );
+}
+
+function buildCatalog(sidebar: SidebarRoot): CatalogItem[] {
+  const catalog: CatalogItem[] = [];
+
+  const visit = (items: Array<SidebarDocItem | SidebarCategoryItem>, category = 'Examples') => {
+    for (const item of items) {
+      if (item.type === 'category') {
+        visit(item.items, item.label);
+      } else if (item.docId !== 'index') {
+        catalog.push(normalizeItem(item, category));
+      }
+    }
+  };
+
+  visit(sidebar.items);
+  return catalog;
+}
+
+function normalizeItem(item: SidebarDocItem, category: string): CatalogItem {
+  const customProps = item.customProps || {};
+  const topic = getDefaultTopic(category);
+  return {
+    ...item,
+    backends: customProps.backends || getDefaultBackends(category),
+    category,
+    description: customProps.description || `${item.label} — ${category.toLowerCase()} example.`,
+    difficulty: customProps.difficulty || getDefaultDifficulty(category),
+    maturity: customProps.maturity || (category === 'Experimental' ? 'experimental' : 'stable'),
+    topics: customProps.topics || [topic]
+  };
+}
+
+function getDefaultBackends(category: string): ExampleBackend[] {
+  return category.includes('GPU Data') ? ['webgpu'] : ['webgpu', 'webgl2'];
+}
+
+function getDefaultDifficulty(category: string): ExampleDifficulty {
+  if (category === 'Tutorials') return 'beginner';
+  if (category === 'Experimental' || category.includes('Arrow')) return 'advanced';
+  return 'intermediate';
+}
+
+function getDefaultTopic(category: string): string {
+  if (category === 'Tutorials') return 'fundamentals';
+  if (category === 'Integrations') return 'integration';
+  if (category.includes('GPU Data') || category.includes('Arrow')) return 'data';
+  if (category === 'API') return 'api';
+  return 'rendering';
+}
+
+function groupByCategory(items: CatalogItem[]): Array<[string, CatalogItem[]]> {
+  const groups = new Map<string, CatalogItem[]>();
+  for (const item of items) {
+    const group = groups.get(item.category) || [];
+    group.push(item);
+    groups.set(item.category, group);
+  }
+  return [...groups.entries()];
+}
+
+function formatLabel(value: string): string {
+  return value === 'webgpu' ? 'WebGPU' : value === 'webgl2' ? 'WebGL2' : `${value[0].toUpperCase()}${value.slice(1)}`;
+}
+
+function getAllOptionsLabel(label: string): string {
+  const labels: Record<string, string> = {
+    Backend: 'All backends',
+    Difficulty: 'All difficulties',
+    Maturity: 'All maturity levels',
+    Topic: 'All topics'
+  };
+  return labels[label] || `All ${label.toLowerCase()} options`;
 }

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -256,6 +256,56 @@ html[data-theme='dark'] .markdown .docs-markdown-table__table th code {
   line-height: 1.4;
 }
 
+.markdown .docs-example-source {
+  border: 1px solid var(--docs-table-border);
+  border-radius: 10px;
+  margin: 1.5rem 0;
+  overflow: hidden;
+}
+
+.markdown .docs-example-source__header {
+  align-items: center;
+  background: var(--docs-table-shell-background);
+  display: flex;
+  justify-content: space-between;
+  padding: 0.8rem 1rem;
+}
+
+.markdown .docs-example-source__tabs {
+  background: var(--docs-table-shell-background);
+  display: flex;
+  gap: 0.25rem;
+  overflow-x: auto;
+  padding: 0 0.75rem;
+}
+
+.markdown .docs-example-source__tabs button {
+  background: transparent;
+  border: 0;
+  border-bottom: 3px solid transparent;
+  color: var(--ifm-font-color-base);
+  cursor: pointer;
+  font: inherit;
+  padding: 0.65rem 0.75rem;
+  white-space: nowrap;
+}
+
+.markdown .docs-example-source__tabs button.is-active {
+  border-bottom-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+}
+
+.markdown .docs-example-source > div[class*='codeBlockContainer'] {
+  border-radius: 0;
+  margin: 0;
+}
+
+.markdown .docs-example-source__error {
+  color: var(--ifm-color-danger-dark);
+  margin: 1rem;
+}
+
 html[data-theme='dark'] .markdown .docs-api-card__kind,
 html[data-theme='dark'] .markdown .docs-api-card__meta {
   color: rgba(226, 232, 240, 0.72);

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -1357,6 +1357,7 @@ export const HelloTriangleExample: React.FC = props => (
     template={HelloTriangleApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     {...props}
   />
 );
@@ -1372,6 +1373,7 @@ export const HelloTriangleGeometryExample: React.FC = props => (
     template={HelloTriangleGeometryApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     {...props}
   />
 );
@@ -1383,6 +1385,7 @@ export const HelloCubeExample: React.FC = props => (
     template={HelloCubeApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     {...props}
   />
 );
@@ -1394,6 +1397,7 @@ export const InstancedCubesExample: React.FC = props => (
     template={InstancedCubesApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     {...props}
   />
 );
@@ -1405,6 +1409,7 @@ export const TwoCubesExample: React.FC = props => (
     template={TwoCubesApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     {...props}
   />
 );
@@ -1416,6 +1421,7 @@ export const LightingExample: React.FC = props => (
     template={LightingApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     {...props}
   />
 );
@@ -1427,6 +1433,7 @@ export const HelloGLTFExample: React.FC = props => (
     template={HelloGLTFApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     {...props}
   />
 );
@@ -1438,6 +1445,7 @@ export const HelloInstancingExample: React.FC = props => (
     template={HelloInstancingApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     {...props}
   />
 );
@@ -1449,6 +1457,7 @@ export const ShaderHooksExample: React.FC = props => (
     template={ShaderHooksApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     {...props}
   />
 );
@@ -1460,6 +1469,7 @@ export const ShaderPluginsExample: React.FC = props => (
     template={ShaderPluginsApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     {...props}
   />
 );
@@ -1471,6 +1481,7 @@ export const ShaderModulesExample: React.FC = props => (
     template={ShaderModulesApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     {...props}
   />
 );
@@ -1482,6 +1493,7 @@ export const TransformFeedbackExample: React.FC = props => (
     template={TransformFeedbackApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     devices={['webgl2']}
     {...props}
   />
@@ -1494,6 +1506,7 @@ export const TransformExample: React.FC = props => (
     template={TransformApp}
     config={exampleConfig}
     showStats={false}
+    stackBlitz
     devices={['webgl2']}
     {...props}
   />

--- a/website/src/react-luma/components/info-box.tsx
+++ b/website/src/react-luma/components/info-box.tsx
@@ -36,7 +36,9 @@ export type ExampleInfoProps = {
   directory?: string;
   id?: string;
   sourceDirectory?: string;
+  sourceFiles?: string[];
   sourcePath?: string;
+  stackBlitz?: boolean;
   title?: string;
 };
 
@@ -63,6 +65,11 @@ type InfoBoxResizeState = {
   startY: number;
   startWidth: number;
   startHeight: number;
+};
+
+type ExampleSourceFile = {
+  path: string;
+  source: string;
 };
 
 /** Panel-framework mount for the website InfoBox chrome and panel content. */
@@ -121,17 +128,17 @@ function InfoBoxView(props: InfoBoxViewProps) {
   const sourceUrl = getExampleSourceUrl(props);
   const sourcePaths = React.useMemo(
     () => getExampleSourcePaths(props),
-    [props.directory, props.id, props.sourceDirectory, props.sourcePath]
+    [props.directory, props.id, props.sourceDirectory, props.sourceFiles, props.sourcePath]
   );
   const sourcePathsKey = sourcePaths.join('|');
   const title = getExampleTitle(props.id, props.title);
   const [isCollapsed, setIsCollapsed] = useState(() => isInfoBoxCollapsedByDefault);
   const [activeTab, setActiveTab] = useState<'info' | 'source'>('info');
+  const [activeSourcePath, setActiveSourcePath] = useState('');
   const [infoBoxSize, setInfoBoxSize] = useState<InfoBoxSize | null>(null);
   const [sourceResult, setSourceResult] = useState<{
     key: string;
-    path?: string;
-    source?: string;
+    files?: ExampleSourceFile[];
     error?: string;
   } | null>(null);
   const infoBoxRef = useRef<HTMLDivElement | null>(null);
@@ -152,9 +159,10 @@ function InfoBoxView(props: InfoBoxViewProps) {
     }
 
     const abortController = new AbortController();
-    void fetchExampleSource(props.websiteBaseUrl, sourcePaths, abortController.signal)
-      .then(({path, source}) => {
-        setSourceResult({key: sourcePathsKey, path, source});
+    void fetchExampleSources(props.websiteBaseUrl, sourcePaths, abortController.signal)
+      .then(files => {
+        setSourceResult({key: sourcePathsKey, files});
+        setActiveSourcePath(files[0]?.path || '');
       })
       .catch(error => {
         if (!abortController.signal.aborted) {
@@ -269,11 +277,14 @@ function InfoBoxView(props: InfoBoxViewProps) {
     event.preventDefault();
   };
 
+  const activeSourceFile =
+    currentSourceResult?.files?.find(file => file.path === activeSourcePath) ||
+    currentSourceResult?.files?.[0];
   const sourceContent = currentSourceResult?.error ? (
     <p style={{margin: 0, color: '#b00020'}}>{currentSourceResult.error}</p>
   ) : (
-    <CodeBlock language={currentSourceResult?.path?.endsWith('.tsx') ? 'tsx' : 'typescript'}>
-      {currentSourceResult?.source ?? '// Loading source…'}
+    <CodeBlock language={getSourceLanguage(activeSourceFile?.path)}>
+      {activeSourceFile?.source ?? '// Loading source…'}
     </CodeBlock>
   );
 
@@ -398,6 +409,63 @@ function InfoBoxView(props: InfoBoxViewProps) {
               background: '#f6f8fa'
             }}
           >
+            {currentSourceResult?.files && currentSourceResult.files.length > 0 ? (
+              <div
+                role="tablist"
+                aria-label="Example source files"
+                style={{
+                  alignItems: 'center',
+                  background: '#eef2f6',
+                  display: 'flex',
+                  gap: 4,
+                  overflowX: 'auto',
+                  padding: '8px'
+                }}
+              >
+                {currentSourceResult.files.map(file => (
+                  <button
+                    key={file.path}
+                    type="button"
+                    role="tab"
+                    aria-selected={file.path === activeSourceFile?.path}
+                    onClick={() => setActiveSourcePath(file.path)}
+                    style={{
+                      background: file.path === activeSourceFile?.path ? '#fff' : 'transparent',
+                      border: '1px solid #cbd5e1',
+                      borderRadius: 5,
+                      color: '#0f172a',
+                      cursor: 'pointer',
+                      fontSize: 12,
+                      fontWeight: file.path === activeSourceFile?.path ? 700 : 500,
+                      padding: '4px 8px',
+                      whiteSpace: 'nowrap'
+                    }}
+                  >
+                    {file.path.split('/').at(-1)}
+                  </button>
+                ))}
+                {props.stackBlitz ? (
+                  <button
+                    type="button"
+                    onClick={() => void openExampleInStackBlitz(title, currentSourceResult.files || [])}
+                    style={{
+                      background: '#146ef5',
+                      border: 0,
+                      borderRadius: 5,
+                      color: '#fff',
+                      cursor: 'pointer',
+                      fontSize: 12,
+                      fontWeight: 700,
+                      marginLeft: 'auto',
+                      padding: '5px 9px',
+                      whiteSpace: 'nowrap'
+                    }}
+                  >
+                    Edit in StackBlitz
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
             {sourceContent}
           </div>
         ) : null}
@@ -489,35 +557,94 @@ function getExampleSourceUrl(props: ExampleInfoProps): string | null {
 }
 
 function getExampleSourcePaths(props: ExampleInfoProps): string[] {
+  if (props.sourceFiles && props.sourceFiles.length > 0) {
+    const sourceRoot = getExampleSourceRoot(props);
+    return sourceRoot ? props.sourceFiles.map(file => `${sourceRoot}/${file}`) : props.sourceFiles;
+  }
+
   if (props.sourcePath) {
     const sourcePath = props.sourcePath.replace(/^\/?examples\//, '').replace(/^\//, '');
     if (/\.(?:[cm]?[jt]sx?)$/.test(sourcePath)) {
       return [sourcePath];
     }
-    return [`${sourcePath}/app.ts`, `${sourcePath}/app.tsx`];
+    return [
+      `${sourcePath}/app.ts`,
+      `${sourcePath}/app.tsx`,
+      `${sourcePath}/index.html`,
+      `${sourcePath}/package.json`
+    ];
   }
 
   if (props.id && (props.sourceDirectory || props.directory)) {
     const sourceDirectory = props.sourceDirectory || props.directory;
-    return [`${sourceDirectory}/${props.id}/app.ts`, `${sourceDirectory}/${props.id}/app.tsx`];
+    return [
+      `${sourceDirectory}/${props.id}/app.ts`,
+      `${sourceDirectory}/${props.id}/app.tsx`,
+      `${sourceDirectory}/${props.id}/index.html`,
+      `${sourceDirectory}/${props.id}/package.json`
+    ];
   }
 
   return [];
 }
 
-async function fetchExampleSource(
+function getExampleSourceRoot(props: ExampleInfoProps): string | null {
+  if (props.sourcePath) {
+    return props.sourcePath.replace(/^\/?examples\//, '').replace(/^\//, '');
+  }
+  if (props.id && (props.sourceDirectory || props.directory)) {
+    return `${props.sourceDirectory || props.directory}/${props.id}`;
+  }
+  return null;
+}
+
+async function fetchExampleSources(
   websiteBaseUrl: string,
   sourcePaths: readonly string[],
   signal: AbortSignal
-): Promise<{path: string; source: string}> {
+): Promise<ExampleSourceFile[]> {
+  const sourceFiles: ExampleSourceFile[] = [];
   for (const sourcePath of sourcePaths) {
     const response = await fetch(`${websiteBaseUrl}example-assets/${sourcePath}`, {signal});
     if (response.ok) {
-      return {path: sourcePath, source: await response.text()};
+      sourceFiles.push({path: sourcePath, source: await response.text()});
     }
   }
 
-  throw new Error('Unable to load source code.');
+  if (sourceFiles.length === 0) {
+    throw new Error('Unable to load source code.');
+  }
+  return sourceFiles;
+}
+
+function getSourceLanguage(path?: string): string {
+  if (path?.endsWith('.tsx')) return 'tsx';
+  if (path?.endsWith('.html')) return 'html';
+  if (path?.endsWith('.json')) return 'json';
+  return 'typescript';
+}
+
+async function openExampleInStackBlitz(
+  title: string,
+  sourceFiles: ExampleSourceFile[]
+): Promise<void> {
+  const {default: sdk} = await import('@stackblitz/sdk');
+  const files = Object.fromEntries(
+    sourceFiles.map(file => [file.path.split('/').at(-1) || file.path, file.source])
+  );
+  await sdk.openProject(
+    {
+      title: `luma.gl: ${title}`,
+      description: 'Runnable luma.gl example from the official documentation.',
+      template: 'node',
+      files
+    },
+    {
+      newWindow: true,
+      openFile: files['app.tsx'] ? 'app.tsx' : 'app.ts',
+      startScript: 'start'
+    }
+  );
 }
 
 function getExampleTitle(id?: string, title?: string): string {

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -50,7 +50,9 @@ type LumaExampleProps = React.PropsWithChildren<{
   config: unknown;
   directory?: string;
   sourceDirectory?: string;
+  sourceFiles?: string[];
   sourcePath?: string;
+  stackBlitz?: boolean;
   style?: CSSProperties;
   container?: string;
   panel?: boolean;
@@ -137,7 +139,9 @@ export const ExampleHeader: FC<ExampleHeaderProps> = (props: ExampleHeaderProps)
         title={props.title}
         directory={props.directory}
         sourceDirectory={props.sourceDirectory}
+        sourceFiles={props.sourceFiles}
         sourcePath={props.sourcePath}
+        stackBlitz={props.stackBlitz}
         style={{pointerEvents: 'auto'}}
       >
         {props.children}
@@ -321,7 +325,9 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
           title={props.title}
           directory={props.directory}
           sourceDirectory={props.sourceDirectory}
+          sourceFiles={props.sourceFiles}
           sourcePath={props.sourcePath}
+          stackBlitz={props.stackBlitz}
           devices={props.devices}
         >
           {info && props.templateInfoPlacement !== 'page' ? (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3835,6 +3835,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gerrit0/mini-shiki@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@gerrit0/mini-shiki@npm:3.23.0"
+  dependencies:
+    "@shikijs/engine-oniguruma": "npm:^3.23.0"
+    "@shikijs/langs": "npm:^3.23.0"
+    "@shikijs/themes": "npm:^3.23.0"
+    "@shikijs/types": "npm:^3.23.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+  checksum: 10c0/f9663e0e179edd2d7733207843f1bceda24311ab7b5495d50e0531305129fba8663388784c80645383ac6ae5e3a97c138faefeea8c328e7664da882f4ecb1c3a
+  languageName: node
+  linkType: hard
+
 "@hapi/hoek@npm:^9.0.0, @hapi/hoek@npm:^9.3.0":
   version: 9.3.0
   resolution: "@hapi/hoek@npm:9.3.0"
@@ -6112,6 +6125,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shikijs/engine-oniguruma@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@shikijs/engine-oniguruma@npm:3.23.0"
+  dependencies:
+    "@shikijs/types": "npm:3.23.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+  checksum: 10c0/40dbda7aef55d5946c45b8cfe56f484eadb611f9f7c9eb77ff21f0dfce2bcc775686a61eda9e06401ddd71195945a522293f51d6522fce49244b1a6b9c0f61f7
+  languageName: node
+  linkType: hard
+
+"@shikijs/langs@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@shikijs/langs@npm:3.23.0"
+  dependencies:
+    "@shikijs/types": "npm:3.23.0"
+  checksum: 10c0/513b90cfee0fa167d2063b7fbc2318b303a604f2e1fa156aa8b4659b49792401531a74acf68de622ecfff15738e1947a46cfe92a32fcd6a4ee5e70bcf1d06c66
+  languageName: node
+  linkType: hard
+
+"@shikijs/themes@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@shikijs/themes@npm:3.23.0"
+  dependencies:
+    "@shikijs/types": "npm:3.23.0"
+  checksum: 10c0/5c99036d4a765765018f9106a354ebe5ccac204c69f00e3cda265828d493f005412659213f6574fa0e187c7d4437b3327bd6dad2e2146b2c472d2bf493d790dd
+  languageName: node
+  linkType: hard
+
+"@shikijs/types@npm:3.23.0, @shikijs/types@npm:^3.23.0":
+  version: 3.23.0
+  resolution: "@shikijs/types@npm:3.23.0"
+  dependencies:
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 10c0/bd0d1593f830a6b4e55c77871ec1b95cc44855d6e0e26282a948a3c58827237826e4110af27eb4d3231361f1e182c4410434a1dc15ec40aea988dc92dc97e9d6
+  languageName: node
+  linkType: hard
+
+"@shikijs/vscode-textmate@npm:^10.0.2":
+  version: 10.0.2
+  resolution: "@shikijs/vscode-textmate@npm:10.0.2"
+  checksum: 10c0/36b682d691088ec244de292dc8f91b808f95c89466af421cf84cbab92230f03c8348649c14b3251991b10ce632b0c715e416e992dd5f28ff3221dc2693fd9462
+  languageName: node
+  linkType: hard
+
 "@sideway/address@npm:^4.1.5":
   version: 4.1.5
   resolution: "@sideway/address@npm:4.1.5"
@@ -6222,6 +6280,13 @@ __metadata:
     micromark-util-character: "npm:^1.1.0"
     micromark-util-symbol: "npm:^1.0.1"
   checksum: 10c0/b8da9d8f560740959c421d3ce5be43952eace1c95cb65402d9473a15e66463346a37fb5f121a6b22a83af51e8845b0b4ff3c321f14ce31bd58fb126acf6c8ed9
+  languageName: node
+  linkType: hard
+
+"@stackblitz/sdk@npm:^1.11.0":
+  version: 1.11.0
+  resolution: "@stackblitz/sdk@npm:1.11.0"
+  checksum: 10c0/53a3303bf3572d69f31de220c1f23bc727d68f7113fa3cca0e792158b81deb9455d639df28759701af3761af611c1488a98ff16ab66bc3fdc4a08dc9e6bc7174
   languageName: node
   linkType: hard
 
@@ -6665,7 +6730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/hast@npm:^3.0.0":
+"@types/hast@npm:^3.0.0, @types/hast@npm:^3.0.4":
   version: 3.0.4
   resolution: "@types/hast@npm:3.0.4"
   dependencies:
@@ -8596,6 +8661,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"balanced-match@npm:^4.0.2":
+  version: 4.0.4
+  resolution: "balanced-match@npm:4.0.4"
+  checksum: 10c0/07e86102a3eb2ee2a6a1a89164f29d0dbaebd28f2ca3f5ca786f36b8b23d9e417eb3be45a4acf754f837be5ac0a2317de90d3fcb7f4f4dc95720a1f36b26a17b
+  languageName: node
+  linkType: hard
+
 "base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -8757,6 +8829,15 @@ __metadata:
   dependencies:
     balanced-match: "npm:^1.0.0"
   checksum: 10c0/b358f2fe060e2d7a87aa015979ecea07f3c37d4018f8d6deb5bd4c229ad3a0384fe6029bb76cd8be63c81e516ee52d1a0673edbe2023d53a5191732ae3c3e49f
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^5.0.5":
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
   languageName: node
   linkType: hard
 
@@ -10769,6 +10850,17 @@ __metadata:
   bin:
     docusaurus-mdx-checker: src/cli.js
   checksum: 10c0/fe199c026a544f7e5ea8db6c7dbb1c06a7612b6fb6420a4333c096c6662325dc881d8abb8c70bac7006e7a8e01b6937e3f7c67c263f635cce6a81b6a7b9d74b6
+  languageName: node
+  linkType: hard
+
+"docusaurus-plugin-typedoc@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "docusaurus-plugin-typedoc@npm:1.4.2"
+  dependencies:
+    typedoc-docusaurus-theme: "npm:^1.4.0"
+  peerDependencies:
+    typedoc-plugin-markdown: ">=4.8.0"
+  checksum: 10c0/d0e43c2c22bce69cac0ea3ed7e358c0ea66ce02137f89362f5cc122ad58308ac7436547cff60e26bf0dd8fd408787e738dd380f1cd3f0950c1f1c059b11fef45
   languageName: node
   linkType: hard
 
@@ -15410,6 +15502,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"linkify-it@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "linkify-it@npm:5.0.1"
+  dependencies:
+    uc.micro: "npm:^2.0.0"
+  checksum: 10c0/d06d04f1ed03be131740fc900a5e74ea1f49886b052213599e306d469d5ffe2303db76dd8f771de9f28e2b0b38852de22ec46ae597d245f8b66439b0ceb19b10
+  languageName: node
+  linkType: hard
+
 "load-json-file@npm:6.2.0":
   version: 6.2.0
   resolution: "load-json-file@npm:6.2.0"
@@ -16644,6 +16745,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lunr@npm:^2.3.9":
+  version: 2.3.9
+  resolution: "lunr@npm:2.3.9"
+  checksum: 10c0/77d7dbb4fbd602aac161e2b50887d8eda28c0fa3b799159cee380fbb311f1e614219126ecbbd2c3a9c685f1720a8109b3c1ca85cc893c39b6c9cc6a62a1d8a8b
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.25.3":
   version: 0.25.9
   resolution: "magic-string@npm:0.25.9"
@@ -16817,6 +16925,22 @@ __metadata:
   version: 2.0.0
   resolution: "markdown-extensions@npm:2.0.0"
   checksum: 10c0/406139da2aa0d5ebad86195c8e8c02412f873c452b4c087ae7bc767af37956141be449998223bb379eea179b5fd38dfa610602b6f29c22ddab5d51e627a7e41d
+  languageName: node
+  linkType: hard
+
+"markdown-it@npm:^14.1.1":
+  version: 14.2.0
+  resolution: "markdown-it@npm:14.2.0"
+  dependencies:
+    argparse: "npm:^2.0.1"
+    entities: "npm:^4.4.0"
+    linkify-it: "npm:^5.0.1"
+    mdurl: "npm:^2.0.0"
+    punycode.js: "npm:^2.3.1"
+    uc.micro: "npm:^2.1.0"
+  bin:
+    markdown-it: bin/markdown-it.mjs
+  checksum: 10c0/1d3a50061d2fe4efbcf317aac853dbee6892ed6f5a217570eead723f2ef2dd1c9baaeef5a687cd283480c45c2d20724a73e84a9ed72843cf7b3b719067af40ef
   languageName: node
   linkType: hard
 
@@ -17143,6 +17267,13 @@ __metadata:
   version: 2.0.30
   resolution: "mdn-data@npm:2.0.30"
   checksum: 10c0/a2c472ea16cee3911ae742593715aa4c634eb3d4b9f1e6ada0902aa90df13dcbb7285d19435f3ff213ebaa3b2e0c0265c1eb0e3fb278fda7f8919f046a410cd9
+  languageName: node
+  linkType: hard
+
+"mdurl@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdurl@npm:2.0.0"
+  checksum: 10c0/633db522272f75ce4788440669137c77540d74a83e9015666a9557a152c02e245b192edc20bc90ae953bbab727503994a53b236b4d9c99bdaee594d0e7dd2ce0
   languageName: node
   linkType: hard
 
@@ -17892,6 +18023,15 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^2.0.1"
   checksum: 10c0/85f407dcd38ac3e180f425e86553911d101455ca3ad5544d6a7cec16286657e4f8a9aa6695803025c55e31e35a91a2252b5dc8e7d527211278b8b65b4dbd5eac
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.2.5":
+  version: 10.2.5
+  resolution: "minimatch@npm:10.2.5"
+  dependencies:
+    brace-expansion: "npm:^5.0.5"
+  checksum: 10c0/6bb058bd6324104b9ec2f763476a35386d05079c1f5fe4fbf1f324a25237cd4534d6813ecd71f48208f4e635c1221899bef94c3c89f7df55698fe373aaae20fd
   languageName: node
   linkType: hard
 
@@ -20723,6 +20863,13 @@ __metadata:
   dependencies:
     punycode: "npm:^2.3.1"
   checksum: 10c0/d8d45a99e4ca62ca12ac3c373e63d80d2368d38892daa40cfddaa1eb908be98cd549ac059783ef3a56cfd96d57ae8e2fd9ae53d1378d90d42bc661ff924e102a
+  languageName: node
+  linkType: hard
+
+"punycode.js@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "punycode.js@npm:2.3.1"
+  checksum: 10c0/1d12c1c0e06127fa5db56bd7fdf698daf9a78104456a6b67326877afc21feaa821257b171539caedd2f0524027fa38e67b13dd094159c8d70b6d26d2bea4dfdb
   languageName: node
   linkType: hard
 
@@ -23931,6 +24078,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typedoc-docusaurus-theme@npm:^1.4.0":
+  version: 1.4.2
+  resolution: "typedoc-docusaurus-theme@npm:1.4.2"
+  peerDependencies:
+    typedoc-plugin-markdown: ">=4.8.0"
+  checksum: 10c0/eb853ae181684492632d6240ec3f604503cb8f7f30ef945935b3220cfb5ca717bde3a61c96a8b50ede091e8ca66b4afc8c165b4ecd5270e3b69a784aef64dbef
+  languageName: node
+  linkType: hard
+
+"typedoc-plugin-markdown@npm:^4.10.0":
+  version: 4.12.0
+  resolution: "typedoc-plugin-markdown@npm:4.12.0"
+  peerDependencies:
+    typedoc: 0.28.x
+  checksum: 10c0/2977f5c3d98f778e02952ab2e6d47d0ec5245a84f459dc6727d34698e78d1837211a01ce568529671681d4f67117476a45caba33097de5f88d2feeb0d443507d
+  languageName: node
+  linkType: hard
+
+"typedoc@npm:^0.28.19":
+  version: 0.28.19
+  resolution: "typedoc@npm:0.28.19"
+  dependencies:
+    "@gerrit0/mini-shiki": "npm:^3.23.0"
+    lunr: "npm:^2.3.9"
+    markdown-it: "npm:^14.1.1"
+    minimatch: "npm:^10.2.5"
+    yaml: "npm:^2.8.3"
+  peerDependencies:
+    typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
+  bin:
+    typedoc: bin/typedoc
+  checksum: 10c0/a46ea8ec4e661320dacf27f1d68595bdf9d671383f20060b590f212e6ebbf9a65d4962e698e8a43804a14add1f04a3528381c338801350dc03ddc6baf33fb898
+  languageName: node
+  linkType: hard
+
 "typescript-eslint@npm:^7.7.0":
   version: 7.18.0
   resolution: "typescript-eslint@npm:7.18.0"
@@ -23978,6 +24160,13 @@ __metadata:
   version: 7.3.0
   resolution: "typical@npm:7.3.0"
   checksum: 10c0/bee697a88e1dd0447bc1cf7f6e875eaa2b0fb2cccb338b7b261e315f7df84a66402864bfc326d6b3117c50475afd1d49eda03d846a6299ad25f211035bfab3b1
+  languageName: node
+  linkType: hard
+
+"uc.micro@npm:^2.0.0, uc.micro@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "uc.micro@npm:2.1.0"
+  checksum: 10c0/8862eddb412dda76f15db8ad1c640ccc2f47cdf8252a4a30be908d535602c8d33f9855dfcccb8b8837855c1ce1eaa563f7fa7ebe3c98fd0794351aab9b9c55fa
   languageName: node
   linkType: hard
 
@@ -24928,12 +25117,17 @@ __metadata:
     "@docusaurus/tsconfig": "npm:^3.9.2"
     "@probe.gl/stats": "npm:^4.1.1"
     "@probe.gl/stats-widget": "npm:^4.1.1"
+    "@stackblitz/sdk": "npm:^1.11.0"
     "@vis.gl/docusaurus-website": "npm:1.0.0-alpha.21"
     clsx: "npm:^1.1.1"
     docusaurus-mdx-checker: "npm:^3.0.0"
+    docusaurus-plugin-typedoc: "npm:^1.4.2"
     maplibre-gl: "npm:^5.13.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
+    typedoc: "npm:^0.28.19"
+    typedoc-plugin-markdown: "npm:^4.10.0"
+    typescript: "npm:5.9.3"
     zustand: "npm:^4.1.5"
   languageName: unknown
   linkType: soft
@@ -25391,6 +25585,15 @@ __metadata:
   bin:
     yaml: bin.mjs
   checksum: 10c0/ee2126398ab7d1fdde566b4013b68e36930b9e6d8e68b6db356875c99614c10d678b6f45597a145ff6d63814961221fc305bf9242af8bf7450177f8a68537590
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.8.3":
+  version: 2.9.0
+  resolution: "yaml@npm:2.9.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changed

- Reworked the documentation overview and Getting Started flow around clear rendering and compute learning paths.
- Reframed the first Fundamentals tutorials with mental models, common failure modes, summaries, live examples, and canonical runnable source.
- Added a searchable examples catalog with backend, difficulty, maturity, and topic filters persisted in the URL.
- Extended example pages with multi-file source tabs and an Edit in StackBlitz action.
- Added a build-generated `@luma.gl/core` API reference pilot using TypeDoc.

## Why

TypeGPU's documentation offers a strong progression from product positioning to a focused quickstart, inspectable examples, and generated reference material. This adopts those patterns while retaining luma.gl's existing Docusaurus site and backend-switchable live examples.

## Impact

New users get a shorter path to a working project and clearer guidance on whether luma.gl is the right abstraction. Existing users can search and filter examples, inspect complete runnable source, open examples in StackBlitz, and browse generated core API pages.

Generated API Markdown is intentionally ignored and recreated during the website build.

## Validation

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test`
  - 48 node test files passed; 165 tests passed
  - 229 browser test files passed; 1,223 tests passed
- `yarn website:build`
- `(cd website && yarn build)`
- 459 MDX files compiled successfully
- Browser smoke-tested the overview, onboarding, tutorials, example filters, multi-file source panel, StackBlitz action, and generated API pages with no console errors

## Notes

TypeDoc currently emits non-fatal warnings for existing `@note` and `@todo` tags.