### PR TITLE
[codex] Add graph-native GPU data analysis

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -844,6 +844,14 @@ produces normal graph output that can feed another reduction. `GPUGridBinning` a
 atomic accumulation strategy to packed positions and row-major cells. All three keep input,
 output, submission, and readback ownership with the caller.
 
+## Implemented textures and picking
+
+`GPUCommandGraph` schedules logical texture views across sampled, storage, render-attachment, and
+copy roles. Compatible non-overlapping transient textures reuse physical allocations, while mip,
+layer, and aspect ranges keep hazards precise. `GPUIndexPickingTarget` uses those resources for
+integer object and batch IDs, leaving rendering, submission, staging-buffer selection, and explicit
+readback with the application.
+
 ## Future primitives
 
 The proposed architecture extends beyond the implemented proof.
@@ -854,25 +862,12 @@ The trace predicate is application-owned. Reusable visibility workflows can stan
 inputs such as bounding spheres, axis-aligned boxes, time ranges, LOD thresholds, and selection
 masks. Their output should remain compacted stable IDs plus counts, not a renderer-specific object.
 
-### Picking
-
-A picking graph can share visible IDs and stable object identity with rendering. Integer render
-targets avoid color encoding on WebGPU. Region reduction can keep more work on the GPU, while the
-application explicitly chooses when to read the final pick result.
-
 ### Spatial indexes
 
 WebGPU does not currently expose a native acceleration-structure object comparable to ray-tracing
 APIs. luma.gl should name concrete library-built structures such as `GPUGridIndex` or `GPUBVH`.
 They are storage-buffer data structures with construction and traversal algorithms, not magical
 backend resources.
-
-### Textures and attachments
-
-A complete graph will add logical texture views, sampled/storage access, render attachments,
-copy roles, mip and layer ranges, and compatibility-aware transient reuse. Texture aliasing has
-more format and usage constraints than buffers and should be added from measured render workflows
-rather than guessed into the first compiler.
 
 ### GPUScene
 
@@ -919,6 +914,7 @@ close enough to WebGPU that developers can reason about cost, ordering, and owne
 - [`GPUReduction`](/docs/api-reference/experimental/gpu-primitives/gpu-reduction)
 - [`GPUHistogram`](/docs/api-reference/experimental/gpu-primitives/gpu-histogram)
 - [`GPUGridBinning`](/docs/api-reference/experimental/gpu-primitives/gpu-grid-binning)
+- [`GPUIndexPickingTarget`](/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target)
 - [`DrawCommandBuffer`](/docs/api-reference/experimental/gpu-primitives/draw-command-buffer)
 - [GPU commands](/docs/api-guide/gpu/gpu-commands)
 - [GPU tables](/docs/api-guide/gpu/gpu-tables)

--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1,5 +1,5 @@
 import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
-import {GPUFrustumCullingExample, GPUTraceViewerExample} from '@site/src/examples';
+import {GPUDataAnalysisExample, GPUFrustumCullingExample, GPUTraceViewerExample} from '@site/src/examples';
 
 # GPU Primitives and Command Graphs
 
@@ -42,9 +42,10 @@ pre-recorded render commands
 ```
 
 The implementation consists of `GPUCommandGraph`, typed graph buffer views, `GPUScan`,
-`GPUCompaction`, `GPUSort`, and `DrawCommandBuffer`. The accompanying trace viewer runs filtering
-and compaction over up to four million spans, while the GPU sort example demonstrates stable
-paired sorting. The implementation is intentionally experimental: it is concrete enough to
+`GPUCompaction`, `GPUSort`, `GPUReduction`, `GPUHistogram`, `GPUGridBinning`, and
+`DrawCommandBuffer`. The accompanying trace viewer runs filtering and compaction over up to four
+million spans, while the sort and data-analysis examples demonstrate composable buffer-native
+algorithms. The implementation is intentionally experimental: it is concrete enough to
 measure and use, but small enough that its API can still respond to experience.
 
 <GPUTraceViewerExample embedded />
@@ -57,6 +58,12 @@ timing with compiled graph allocation statistics. Together, the examples demonst
 is not specific to trace data or two-dimensional rendering.
 
 <GPUFrustumCullingExample embedded />
+
+The data-analysis example composes extent reduction, histogram counting, histogram-count
+reduction, and grid binning in one reusable graph. It uploads Arrow columns and keeps compilation,
+submission, validation readback, and transient-allocation diagnostics explicit.
+
+<GPUDataAnalysisExample embedded />
 
 ## Why primitives instead of effects?
 
@@ -153,9 +160,9 @@ pipelines would confuse multi-pass algorithms with `GPUComputePipeline`.
 
 Algorithms provide data semantics across one or more kernels. `GPUScan` promises an exclusive
 prefix sum. `GPUCompaction` promises stable selection. `GPUSort` promises stable paired `uint32`
-ordering while choosing bitonic sort for smaller vectors and radix sort for larger ones. Future
-`GPUReduction` and `GPUHistogram` objects should likewise promise results and constraints rather
-than a fixed implementation.
+ordering while choosing bitonic sort for smaller vectors and radix sort for larger ones.
+`GPUReduction`, `GPUHistogram`, and `GPUGridBinning` promise aggregate and binning results while
+selecting hierarchical and atomic implementations internally.
 
 The first algorithms are deliberately typed and curated. Arbitrary WGSL callbacks for compare,
 combine, and predicate functions are attractive, but they significantly expand validation,
@@ -825,26 +832,21 @@ gpgpu because they are optional computation capabilities rather than core resour
 Graduation should happen only after at least two independent consumers use the graph. The trace
 viewer proves two-dimensional filtering and rendering. The frustum-culling field adds a second
 consumer with bounding-sphere visibility, indexed indirect drawing, and a moving three-dimensional
-camera. Additional consumers should still exercise different patterns such as text expansion, path
-tessellation, histogramming, or scientific reduction.
+camera. The data-analysis example adds a third consumer based on Arrow columns, scientific
+reduction, histogram composition, and spatial counts. Additional consumers should still exercise
+different patterns such as text expansion or path tessellation.
+
+## Implemented data analysis
+
+`GPUReduction` collapses packed scalar rows with explicit empty, overflow, floating-point order,
+and non-finite policies. `GPUHistogram` accepts literal, GPU-resident, or inferred domains and
+produces normal graph output that can feed another reduction. `GPUGridBinning` applies the same
+atomic accumulation strategy to packed positions and row-major cells. All three keep input,
+output, submission, and readback ownership with the caller.
 
 ## Future primitives
 
 The proposed architecture extends beyond the implemented proof.
-
-### Reduction
-
-`GPUReduction` should collapse rows using precise operations such as sum, minimum, maximum, and
-extent. It needs policies for empty inputs, floating-point order, NaN handling, overflow, channel
-layout, and deterministic versus fastest execution. Existing gpgpu extent code provides a useful
-starting point.
-
-### Histogram and binning
-
-Histograms are foundational for scientific visualization, color-domain selection, density maps,
-and trace summaries. A useful API must distinguish fixed bins, computed domains, weighted values,
-and contention strategies. Histogram output should be a normal graph view that can feed reduction
-or rendering.
 
 ### Visibility
 
@@ -914,6 +916,9 @@ close enough to WebGPU that developers can reason about cost, ordering, and owne
 - [`GPUScan`](/docs/api-reference/experimental/gpu-primitives/gpu-scan)
 - [`GPUCompaction`](/docs/api-reference/experimental/gpu-primitives/gpu-compaction)
 - [`GPUSort`](/docs/api-reference/experimental/gpu-primitives/gpu-sort)
+- [`GPUReduction`](/docs/api-reference/experimental/gpu-primitives/gpu-reduction)
+- [`GPUHistogram`](/docs/api-reference/experimental/gpu-primitives/gpu-histogram)
+- [`GPUGridBinning`](/docs/api-reference/experimental/gpu-primitives/gpu-grid-binning)
 - [`DrawCommandBuffer`](/docs/api-reference/experimental/gpu-primitives/draw-command-buffer)
 - [GPU commands](/docs/api-guide/gpu/gpu-commands)
 - [GPU tables](/docs/api-guide/gpu/gpu-tables)

--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -4,9 +4,9 @@ import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-do
 
 <GPUPrimitivesDocsTabs active="command-graph" />
 
-`GPUCommandGraph<Parameters>` declares fixed-capacity WebGPU buffer resources and ordered compute,
-render, and copy nodes. `compile()` returns a `CompiledGPUCommandGraph` that owns transient buffers
-and node resources but borrows every import.
+`GPUCommandGraph<Parameters>` declares fixed-capacity WebGPU buffer and texture resources plus
+ordered compute, render, and copy nodes. `compile()` returns a `CompiledGPUCommandGraph` that owns
+transient resources and node state but borrows every import.
 
 ```ts
 const graph = new GPUCommandGraph<{time: number}>(device, {id: 'simulation'});
@@ -59,31 +59,58 @@ Imports the backing allocation and preserves the supplied `GPUData` range.
 Imports a packed vector containing exactly one `GPUData` chunk. Multi-chunk and interleaved vectors
 are rejected in the current experiment.
 
+## Texture APIs
+
+### `importTexture(descriptor, defaultTexture?)`
+
+Declares a caller-owned `Texture` or ready `DynamicTexture`. Texture descriptors are exact rather
+than capacity-based: format, dimension, extent, mip count, and sample count must match at every
+encoding, while concrete usage must contain every declared flag. Recompile canvas-sized graphs
+after a device-pixel resize.
+
+### `createTransientTexture(descriptor)`
+
+Declares graph-owned texture storage. Non-overlapping logical textures reuse one physical texture
+when their descriptors match apart from ID and usage. The allocation is created with the union of
+their usage flags.
+
+### `createTextureView(texture, props?)`
+
+Creates a `GraphTextureView` with normalized aspect, mip, and array-layer ranges. Texture hazards
+are inferred only between overlapping ranges. Handle-level uses conservatively cover the complete
+texture.
+
 ## Node APIs
 
 - `addComputePass(node)` compiles an executable callback that receives a graph-owned `ComputePass`.
-- `addRenderPass(node)` may resolve `RenderPassProps` for each encoding and receives a graph-owned
-  `RenderPass`.
+- `addRenderPass(node)` may declare graph texture `attachments`, resolve other `RenderPassProps`
+  for each encoding, and receives a graph-owned `RenderPass`.
 - `addCopyPass(node)` records directly on the caller's `CommandEncoder`.
 
-Nodes declare resource uses with `storage-read`, `storage-write`, `storage-read-write`, `uniform`,
-`copy-source`, `copy-destination`, `indirect`, `vertex`, or `index`. `dependsOn` adds explicit
-ordering where buffers do not express the dependency.
+Buffer nodes declare storage, uniform, copy, indirect, vertex, and index uses. Texture nodes declare
+`sampled`, storage, render-attachment, and copy uses. Render attachments are automatically treated
+as read-write resources. `dependsOn` adds explicit ordering where resources do not express the
+dependency.
+
+Executable contexts expose `getBuffer()`, `getTexture()`, and `getTextureView()`. Concrete texture
+views and framebuffers are cached for repeated encodings and rebuilt when an imported texture is
+replaced.
 
 ## `CompiledGPUCommandGraph`
 
 ### `encode(commandEncoder, options)`
 
 Records every compiled node. `options.parameters` is forwarded to callbacks. `options.buffers` may
-override imported resources by ID if capacity and usage remain compatible.
+override imported buffers by ID if capacity and usage remain compatible. `options.textures`
+overrides exact-size imported textures.
 
 `encode()` never submits, maps, reads, or grows resources.
 
 ### `stats`
 
-Reports node order, logical and physical transient counts and bytes, bytes reused, and reuse
-percentage.
+Reports node order and separate buffer and texture transient counts, bytes, and reuse percentages.
 
 ### `destroy()`
 
-Destroys compiled node resources and physical transients. Imported buffers remain caller-owned.
+Destroys compiled node resources, cached views/framebuffers, and physical transients. Imported
+buffers and textures remain caller-owned.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-grid-binning.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-grid-binning.md
@@ -1,0 +1,34 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
+# GPUGridBinning
+
+<GPUPrimitivesDocsTabs active="grid-binning" />
+
+`GPUGridBinning` counts packed `float32x2` positions into a row-major two-dimensional grid.
+
+```ts
+new GPUGridBinning({
+  positions,
+  output: cellCounts,
+  gridSize: [32, 16],
+  bounds: [-180, -90, 180, 90]
+}).addToGraph(graph);
+```
+
+## Constructor
+
+```ts
+type GPUGridBinningProps = {
+  id?: string;
+  positions: GraphBufferView<'float32x2'>;
+  output: GraphBufferView<'uint32'>;
+  gridSize: readonly [number, number];
+  bounds: readonly [number, number, number, number] | GraphBufferView<'float32x4'>;
+};
+```
+
+`output.length` must equal `width * height`. Non-finite and out-of-bounds positions are ignored;
+exact maximum coordinates enter the final column or row. Each encoding clears the output. Up to
+256 cells use workgroup-local atomics, and larger grids use direct global atomics.
+
+This first API accumulates counts only. Weighted and floating-point cell aggregates are deferred.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-histogram.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-histogram.md
@@ -1,0 +1,30 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
+# GPUHistogram
+
+<GPUPrimitivesDocsTabs active="histogram" />
+
+`GPUHistogram` counts packed scalar values into a caller-owned `uint32` output view. The output
+length defines the bin count.
+
+```ts
+new GPUHistogram({input: values, output: counts, domain: 'auto'}).addToGraph(graph);
+```
+
+## Constructor
+
+```ts
+type GPUHistogramProps<T extends 'uint32' | 'sint32' | 'float32'> = {
+  id?: string;
+  input: GraphBufferView<T>;
+  output: GraphBufferView<'uint32'>;
+  domain: readonly [number, number] | GraphBufferView<T> | 'auto';
+};
+```
+
+`'auto'` inserts a `GPUReduction` extent. Values outside the domain and non-finite floats are
+ignored. An exact maximum enters the final bin. For a degenerate domain, matching values enter bin
+zero. Counts wrap as `uint32`.
+
+Every encoding clears the output before accumulation, so a compiled graph is safely reusable.
+Up to 256 bins use workgroup-local atomics; larger histograms use direct global atomics.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target.md
@@ -1,0 +1,48 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
+# GPUIndexPickingTarget
+
+<GPUPrimitivesDocsTabs active="index-picking" />
+
+`GPUIndexPickingTarget` declares fixed-size WebGPU attachments for integer object picking and adds
+an explicit single-pixel texture-to-buffer copy. It does not render, submit, map buffers, manage
+highlight state, or own application UI.
+
+```ts
+const target = new GPUIndexPickingTarget(graph, {
+  id: 'objects',
+  width,
+  height,
+  readbackBuffer
+});
+
+graph.addRenderPass({
+  id: 'render-picking',
+  attachments: target.attachments,
+  compile: () => ({
+    getRenderPassProps: () => target.renderPassProps,
+    encode: ({renderPass}) => pickingModel.draw(renderPass)
+  })
+});
+
+target.addReadbackPass({
+  after: 'render-picking',
+  getPixel: parameters => parameters.pickPixel
+});
+```
+
+The target uses `rgba8unorm`, `rg32sint`, and `depth24plus` attachments. The integer attachment
+stores `(objectIndex, batchIndex)` and clears both components to `-1`. Picking models therefore
+declare color formats `['rgba8unorm', 'rg32sint']`, depth format `depth24plus`, and write stable IDs
+to fragment location 1. The existing `indexPicking` shader module supplies this convention.
+
+The readback buffer is exactly 256 bytes with `COPY_DST | MAP_READ`, matching WebGPU copy-row
+alignment. After the caller submits the encoder, read its first eight bytes and pass them to
+`decodeGPUIndexPickInfo()`. Supplying different `buffers` overrides while encoding permits
+concurrent requests without writing a mapped staging buffer.
+
+Coordinates are integer WebGPU device pixels with a top-left origin. The helper validates them
+against its compiled extent. Recreate and recompile the target after a canvas resize.
+
+The helper intentionally handles one pixel. Region reduction, color fallback, automatic staging
+rings, submission, callbacks, highlighting, and tooltips remain application policy.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
@@ -1,0 +1,34 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
+# GPUReduction
+
+<GPUPrimitivesDocsTabs active="reduction" />
+
+`GPUReduction` records a deterministic hierarchical reduction over a packed `uint32`, `sint32`,
+or `float32` graph view.
+
+```ts
+new GPUReduction({input: values, output: extent, operation: 'extent'}).addToGraph(graph);
+```
+
+## Constructor
+
+```ts
+type GPUReductionProps<T extends 'uint32' | 'sint32' | 'float32'> = {
+  id?: string;
+  input: GraphBufferView<T>;
+  output: GraphBufferView<T>;
+  operation: 'sum' | 'min' | 'max' | 'extent';
+};
+```
+
+`sum`, `min`, and `max` require one output row; `extent` writes `[minimum, maximum]` and requires
+two. Inputs and outputs use separate caller-owned buffers. Hierarchical scratch is graph-owned.
+
+Integer sums wrap to 32 bits. Floating sums use a fixed 256-way tree. Floating minimum, maximum,
+and extent ignore NaN and infinity. Empty inputs and all-invalid floating inputs produce zero.
+
+## `addToGraph(graph)`
+
+Declares reduction levels and a final normalization pass. It does not compile, encode, submit,
+map, or destroy imported buffers.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -184,6 +184,9 @@
               "api-reference/experimental/gpu-primitives/gpu-scan",
               "api-reference/experimental/gpu-primitives/gpu-compaction",
               "api-reference/experimental/gpu-primitives/gpu-sort",
+              "api-reference/experimental/gpu-primitives/gpu-reduction",
+              "api-reference/experimental/gpu-primitives/gpu-histogram",
+              "api-reference/experimental/gpu-primitives/gpu-grid-binning",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]
           },
@@ -258,6 +261,9 @@
               "api-reference/experimental/gpu-primitives/gpu-scan",
               "api-reference/experimental/gpu-primitives/gpu-compaction",
               "api-reference/experimental/gpu-primitives/gpu-sort",
+              "api-reference/experimental/gpu-primitives/gpu-reduction",
+              "api-reference/experimental/gpu-primitives/gpu-histogram",
+              "api-reference/experimental/gpu-primitives/gpu-grid-binning",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]
           },

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -22,6 +22,7 @@ Target Release Date: Q3, 2026
 - **GPU command graphs** - Experimental WebGPU command graphs compile explicit buffer hazards, fixed capacities, node resources, and transient-buffer reuse while leaving encoding and submission under application control.
 - **GPU scan, compaction, and indirect drawing** - Typed graph views compose hierarchical `uint32` scan, stable ID compaction, and GPU-written `DrawCommandBuffer` instance counts. The [GPU Trace Viewer](/examples/experimental/gpu-trace-viewer) demonstrates the path over up to four million spans, while [GPU Frustum Culling](/examples/experimental/gpu-frustum-culling) applies it to indexed indirect rendering of a 3D instance field.
 - **Graph-native GPU sort** - `GPUSort` stably orders paired packed `uint32` keys and values in either direction, automatically selecting bitonic or binary LSD radix passes. The [GPU Sort example](/examples/experimental/gpu-sort) exposes graph compilation and transient reuse.
+- **Graph-native GPU data analysis** - `GPUReduction`, `GPUHistogram`, and `GPUGridBinning` add deterministic scalar aggregates, reusable histogram counts, and row-major spatial counts. The [GPU Data Analysis example](/examples/experimental/gpu-data-analysis) composes the operations without hidden submission or readback.
 - **Hybrid shadows** - `ShadowMapRenderer`, the group-2 `shadow` WGSL module, and the contact-shadow shader-pass pipeline add WebGPU cascaded directional, spot, and point-light shadows with PCSS filtering. Visualization City demonstrates the complete ordered stack.
 
 **@luma.gl/engine**

--- a/examples/experimental/gpu-data-analysis/index.html
+++ b/examples/experimental/gpu-data-analysis/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Graph-native GPU data analysis</title>
+</head>
+<body style="margin: 0">
+  <main id="gpu-data-analysis-app"></main>
+  <script type="module">
+    import {initializeGPUDataAnalysisExample} from './src/app.ts';
+    initializeGPUDataAnalysisExample();
+  </script>
+</body>

--- a/examples/experimental/gpu-data-analysis/package.json
+++ b/examples/experimental/gpu-data-analysis/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "luma.gl-examples-experimental-gpu-data-analysis",
+  "version": "9.3.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "vite",
+    "build": "tsc && vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "@luma.gl/arrow": "~9.3.0",
+    "@luma.gl/core": "~9.3.0",
+    "@luma.gl/engine": "~9.3.0",
+    "@luma.gl/experimental": "~9.3.0",
+    "@luma.gl/shadertools": "~9.3.0",
+    "@luma.gl/tables": "~9.3.0",
+    "@luma.gl/text": "~9.3.0",
+    "@luma.gl/webgpu": "~9.3.0",
+    "apache-arrow": "^17.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/examples/experimental/gpu-data-analysis/src/app.ts
+++ b/examples/experimental/gpu-data-analysis/src/app.ts
@@ -1,0 +1,370 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {makeArrowFixedSizeListVector, makeGPUVectorFromArrow} from '@luma.gl/arrow';
+import {Buffer, luma, type Device} from '@luma.gl/core';
+import {
+  GPUCommandGraph,
+  GPUGridBinning,
+  GPUHistogram,
+  GPUReduction,
+  type CompiledGPUCommandGraph
+} from '@luma.gl/experimental';
+import type {GPUVector} from '@luma.gl/tables';
+import {webgpuAdapter} from '@luma.gl/webgpu';
+import * as arrow from 'apache-arrow';
+
+const APP_ID = 'gpu-data-analysis-app';
+const STYLE_ID = 'gpu-data-analysis-style';
+const DATASET_LENGTHS = {small: 4096, medium: 65_537, large: 262_144} as const;
+
+type ExampleResources = {
+  compiled: CompiledGPUCommandGraph;
+  values: GPUVector<'float32'>;
+  positions: GPUVector<'float32x2'>;
+  outputs: Buffer[];
+};
+
+type ExampleElements = {
+  bins: HTMLSelectElement;
+  compileTime: HTMLElement;
+  dataset: HTMLSelectElement;
+  grid: HTMLSelectElement;
+  heatmap: HTMLElement;
+  histogram: HTMLElement;
+  nodes: HTMLElement;
+  reuse: HTMLElement;
+  run: HTMLButtonElement;
+  status: HTMLElement;
+  validation: HTMLElement;
+};
+
+/** Cleanup handle returned by {@link initializeGPUDataAnalysisExample}. */
+export type GPUDataAnalysisExampleHandle = {destroy: () => void};
+
+/** Mounts the graph-native GPU data-analysis example into `#gpu-data-analysis-app`. */
+export function initializeGPUDataAnalysisExample(): GPUDataAnalysisExampleHandle {
+  const root = document.getElementById(APP_ID);
+  if (!root) throw new Error(`GPU data-analysis example requires #${APP_ID}`);
+  ensureStyles();
+  root.innerHTML = EXAMPLE_HTML;
+  const example = new GPUDataAnalysisExample(root);
+  void example.initialize();
+  return {destroy: () => example.destroy()};
+}
+
+class GPUDataAnalysisExample {
+  private readonly elements: ExampleElements;
+  private device: Device | null = null;
+  private resources: ExampleResources | null = null;
+  private destroyed = false;
+  private runVersion = 0;
+
+  private readonly handleRun = (): void => void this.run();
+
+  constructor(root: HTMLElement) {
+    this.elements = getElements(root);
+    for (const element of [
+      this.elements.run,
+      this.elements.dataset,
+      this.elements.bins,
+      this.elements.grid
+    ]) {
+      element.addEventListener('change', this.handleRun);
+    }
+    this.elements.run.addEventListener('click', this.handleRun);
+  }
+
+  async initialize(): Promise<void> {
+    this.setStatus('Requesting a WebGPU device...');
+    try {
+      this.device = await luma.createDevice({
+        type: 'webgpu',
+        adapters: [webgpuAdapter],
+        createCanvasContext: true
+      });
+      await this.run();
+    } catch (error) {
+      this.setStatus(getErrorMessage(error), true);
+    }
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.elements.run.removeEventListener('click', this.handleRun);
+    for (const element of [this.elements.dataset, this.elements.bins, this.elements.grid]) {
+      element.removeEventListener('change', this.handleRun);
+    }
+    this.releaseResources();
+    this.device?.destroy();
+    this.device = null;
+  }
+
+  private async run(): Promise<void> {
+    if (!this.device || this.destroyed) return;
+    const version = ++this.runVersion;
+    this.elements.run.disabled = true;
+    this.setStatus('Uploading Arrow columns and compiling the graph...');
+    const length = DATASET_LENGTHS[this.elements.dataset.value as keyof typeof DATASET_LENGTHS];
+    const binCount = Number(this.elements.bins.value);
+    const gridWidth = Number(this.elements.grid.value);
+    const {values, positions} = makeDataset(length);
+    let nextResources: ExampleResources | null = null;
+
+    try {
+      const arrowValues = arrow.makeVector({type: new arrow.Float32(), data: values});
+      const arrowPositions = makeArrowFixedSizeListVector(new arrow.Float32(), 2, positions);
+      const gpuValues = makeGPUVectorFromArrow(this.device, arrowValues, {
+        name: 'analysis-values',
+        format: 'float32'
+      });
+      const gpuPositions = makeGPUVectorFromArrow(this.device, arrowPositions, {
+        name: 'analysis-positions',
+        format: 'float32x2'
+      });
+      const extentBuffer = makeOutputBuffer(this.device, 'extent', 2);
+      const histogramBuffer = makeOutputBuffer(this.device, 'histogram', binCount);
+      const totalBuffer = makeOutputBuffer(this.device, 'histogram-total', 1);
+      const gridBuffer = makeOutputBuffer(this.device, 'grid', gridWidth * gridWidth);
+      const outputs = [extentBuffer, histogramBuffer, totalBuffer, gridBuffer];
+      const graph = new GPUCommandGraph(this.device, {id: 'gpu-data-analysis-example'});
+      const valuesView = graph.importGPUVector('values', gpuValues);
+      const positionsView = graph.importGPUVector('positions', gpuPositions);
+      const extent = importOutput(graph, extentBuffer, 'extent', 'float32', 2);
+      const histogram = importOutput(graph, histogramBuffer, 'histogram', 'uint32', binCount);
+      const total = importOutput(graph, totalBuffer, 'total', 'uint32', 1);
+      const grid = importOutput(graph, gridBuffer, 'grid', 'uint32', gridWidth * gridWidth);
+      new GPUReduction({
+        id: 'extent',
+        input: valuesView,
+        output: extent,
+        operation: 'extent'
+      }).addToGraph(graph);
+      new GPUHistogram({
+        id: 'histogram',
+        input: valuesView,
+        output: histogram,
+        domain: extent
+      }).addToGraph(graph);
+      new GPUReduction({
+        id: 'histogram-total',
+        input: histogram,
+        output: total,
+        operation: 'sum'
+      }).addToGraph(graph);
+      new GPUGridBinning({
+        id: 'grid',
+        positions: positionsView,
+        output: grid,
+        gridSize: [gridWidth, gridWidth],
+        bounds: [-1, -1, 1, 1]
+      }).addToGraph(graph);
+      const compileStart = performance.now();
+      const compiled = graph.compile();
+      const compileTime = performance.now() - compileStart;
+      nextResources = {compiled, values: gpuValues, positions: gpuPositions, outputs};
+
+      const commandEncoder = this.device.createCommandEncoder({id: 'gpu-data-analysis-example'});
+      compiled.encode(commandEncoder, {parameters: undefined});
+      compiled.encode(commandEncoder, {parameters: undefined});
+      this.device.submit(commandEncoder.finish());
+      const [extentBytes, histogramBytes, totalBytes, gridBytes] = await Promise.all(
+        outputs.map(buffer => buffer.readAsync())
+      );
+      const gpuExtent = Array.from(new Float32Array(extentBytes.buffer, extentBytes.byteOffset, 2));
+      const gpuHistogram = Array.from(
+        new Uint32Array(histogramBytes.buffer, histogramBytes.byteOffset, binCount)
+      );
+      const gpuTotal = new Uint32Array(totalBytes.buffer, totalBytes.byteOffset, 1)[0];
+      const gpuGrid = Array.from(
+        new Uint32Array(gridBytes.buffer, gridBytes.byteOffset, gridWidth * gridWidth)
+      );
+      if (this.destroyed || version !== this.runVersion) {
+        destroyResources(nextResources);
+        return;
+      }
+      const reference = analyzeOnCPU(values, positions, binCount, gridWidth);
+      const valid =
+        gpuExtent.every((value, index) => Math.abs(value - reference.extent[index]) < 1e-5) &&
+        gpuHistogram.every((value, index) => value === reference.histogram[index]) &&
+        gpuGrid.every((value, index) => value === reference.grid[index]) &&
+        gpuTotal === length;
+      this.releaseResources();
+      this.resources = nextResources;
+      nextResources = null;
+      this.elements.nodes.textContent = String(compiled.stats.nodeOrder.length);
+      this.elements.reuse.textContent = `${compiled.stats.reusePercentage.toFixed(1)}%`;
+      this.elements.compileTime.textContent = `${compileTime.toFixed(1)} ms`;
+      this.elements.validation.textContent = valid
+        ? `${gpuTotal.toLocaleString()} rows verified after two encodings`
+        : 'GPU/CPU mismatch';
+      this.elements.validation.dataset.state = valid ? 'ok' : 'error';
+      renderHistogram(this.elements.histogram, gpuHistogram);
+      renderGrid(this.elements.heatmap, gpuGrid, gridWidth);
+      this.setStatus(
+        `Extent [${gpuExtent.map(value => value.toFixed(3)).join(', ')}] · ${binCount} bins · ${gridWidth}×${gridWidth} cells`
+      );
+    } catch (error) {
+      destroyResources(nextResources);
+      this.setStatus(getErrorMessage(error), true);
+    } finally {
+      if (!this.destroyed && version === this.runVersion) this.elements.run.disabled = false;
+    }
+  }
+
+  private releaseResources(): void {
+    destroyResources(this.resources);
+    this.resources = null;
+  }
+
+  private setStatus(message: string, error = false): void {
+    this.elements.status.textContent = message;
+    this.elements.status.dataset.state = error ? 'error' : 'ok';
+  }
+}
+
+function makeDataset(length: number): {values: Float32Array; positions: Float32Array} {
+  let state = 0x5eed1234;
+  const random = (): number => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+  const values = new Float32Array(length);
+  const positions = new Float32Array(length * 2);
+  for (let index = 0; index < length; index++) {
+    const x = random() * 2 - 1;
+    const y = random() * 2 - 1;
+    positions[index * 2] = x;
+    positions[index * 2 + 1] = y;
+    values[index] = Math.fround(Math.sin(x * 4) + Math.cos(y * 6) + (random() - 0.5) * 0.35);
+  }
+  return {values, positions};
+}
+
+function analyzeOnCPU(
+  values: Float32Array,
+  positions: Float32Array,
+  binCount: number,
+  gridWidth: number
+): {extent: [number, number]; histogram: number[]; grid: number[]} {
+  let minimum = Number.POSITIVE_INFINITY;
+  let maximum = Number.NEGATIVE_INFINITY;
+  for (const value of values) {
+    minimum = Math.min(minimum, value);
+    maximum = Math.max(maximum, value);
+  }
+  const histogram = Array.from({length: binCount}, () => 0);
+  for (const value of values) {
+    const bin =
+      value === maximum ? binCount - 1 : getFloat32Coordinate(value, minimum, maximum, binCount);
+    histogram[bin]++;
+  }
+  const grid = Array.from({length: gridWidth * gridWidth}, () => 0);
+  for (let index = 0; index < values.length; index++) {
+    const x = positions[index * 2];
+    const y = positions[index * 2 + 1];
+    const column = getFloat32Coordinate(x, -1, 1, gridWidth);
+    const row = getFloat32Coordinate(y, -1, 1, gridWidth);
+    grid[row * gridWidth + column]++;
+  }
+  return {extent: [minimum, maximum], histogram, grid};
+}
+
+function getFloat32Coordinate(
+  value: number,
+  minimum: number,
+  maximum: number,
+  size: number
+): number {
+  if (value === maximum) return size - 1;
+  const numerator = Math.fround(Math.fround(value) - Math.fround(minimum));
+  const denominator = Math.fround(Math.fround(maximum) - Math.fround(minimum));
+  const ratio = Math.fround(numerator / denominator);
+  return Math.min(Math.floor(Math.fround(ratio * Math.fround(size))), size - 1);
+}
+
+function makeOutputBuffer(device: Device, id: string, length: number): Buffer {
+  return device.createBuffer({
+    id,
+    byteLength: Math.max(length, 1) * 4,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+}
+
+function importOutput<T extends 'float32' | 'uint32'>(
+  graph: GPUCommandGraph,
+  buffer: Buffer,
+  id: string,
+  format: T,
+  length: number
+) {
+  const handle = graph.importBuffer(
+    {id, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return graph.createBufferView(handle, {format, length});
+}
+
+function renderHistogram(element: HTMLElement, counts: number[]): void {
+  const maximum = Math.max(...counts, 1);
+  element.innerHTML = counts
+    .map(
+      count => `<i style="height:${Math.max(2, (count / maximum) * 100)}%" title="${count}"></i>`
+    )
+    .join('');
+}
+
+function renderGrid(element: HTMLElement, counts: number[], width: number): void {
+  const maximum = Math.max(...counts, 1);
+  element.style.gridTemplateColumns = `repeat(${width},1fr)`;
+  element.innerHTML = counts
+    .map(count => `<i style="opacity:${0.08 + (count / maximum) * 0.92}" title="${count}"></i>`)
+    .join('');
+}
+
+function destroyResources(resources: ExampleResources | null): void {
+  if (!resources) return;
+  resources.compiled.destroy();
+  resources.values.destroy();
+  resources.positions.destroy();
+  for (const output of resources.outputs) output.destroy();
+}
+
+function getElements(root: HTMLElement): ExampleElements {
+  const get = <T extends HTMLElement>(selector: string): T => {
+    const element = root.querySelector<T>(selector);
+    if (!element) throw new Error(`Missing GPU data-analysis element ${selector}`);
+    return element;
+  };
+  return {
+    bins: get('[data-bins]'),
+    compileTime: get('[data-compile-time]'),
+    dataset: get('[data-dataset]'),
+    grid: get('[data-grid]'),
+    heatmap: get('[data-heatmap]'),
+    histogram: get('[data-histogram]'),
+    nodes: get('[data-nodes]'),
+    reuse: get('[data-reuse]'),
+    run: get('[data-run]'),
+    status: get('[data-status]'),
+    validation: get('[data-validation]')
+  };
+}
+
+function ensureStyles(): void {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = STYLES;
+  document.head.appendChild(style);
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+const EXAMPLE_HTML = `<main class="analysis-example"><header><p>EXPERIMENTAL · WEBGPU</p><h1>Command-graph data analysis</h1><span>Extent → histogram → count reduction, composed with spatial grid binning.</span></header><section class="controls"><label>Dataset<select data-dataset><option value="small">4K rows</option><option value="medium" selected>65K rows</option><option value="large">262K rows</option></select></label><label>Histogram bins<select data-bins><option>16</option><option selected>64</option><option>300</option></select></label><label>Grid<select data-grid><option>8</option><option selected>16</option><option>17</option></select></label><button data-run>Run graph</button></section><p class="status" data-status></p><section class="metrics"><article><span>Nodes</span><strong data-nodes>—</strong></article><article><span>Compile</span><strong data-compile-time>—</strong></article><article><span>Transient reuse</span><strong data-reuse>—</strong></article><article><span>Validation</span><strong data-validation>—</strong></article></section><section class="visuals"><article><h2>Histogram</h2><div class="histogram" data-histogram></div></article><article><h2>Grid heatmap</h2><div class="heatmap" data-heatmap></div></article></section></main>`;
+
+const STYLES = `.analysis-example{min-height:100%;box-sizing:border-box;padding:30px;color:#172033;background:radial-gradient(circle at 90% 0,#d9f4ea,transparent 35%),#f6f8fb;font-family:Inter,ui-sans-serif,system-ui}.analysis-example *{box-sizing:border-box}.analysis-example>header,.analysis-example>section,.analysis-example>.status{max-width:1120px;margin-left:auto;margin-right:auto}.analysis-example header p{margin:0;color:#08745b;font-size:12px;font-weight:800;letter-spacing:.13em}.analysis-example h1{margin:5px 0;font-size:clamp(30px,5vw,52px);letter-spacing:-.04em}.analysis-example header span{color:#5d687b}.controls{display:flex;flex-wrap:wrap;gap:12px;align-items:end;margin-top:24px;padding:16px;border:1px solid #ccd6df;border-radius:15px;background:#fff}.controls label{display:grid;gap:5px;color:#596579;font-size:12px;font-weight:700}.controls select,.controls button{height:40px;padding:0 12px;border:1px solid #aebdcc;border-radius:8px;background:#fff;color:#172033}.controls button{background:#08745b;color:#fff;border-color:#08745b;font-weight:700}.status{padding:10px 2px;color:#596579}.status[data-state=error],[data-validation][data-state=error]{color:#b42318}.metrics{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}.metrics article,.visuals article{padding:16px;border:1px solid #d5dde6;border-radius:14px;background:#fff;box-shadow:0 10px 30px #25324a0a}.metrics span{display:block;color:#667085;font-size:12px}.metrics strong{display:block;margin-top:7px;font-size:18px}.visuals{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px}.visuals h2{margin:0 0 12px;font-size:16px}.histogram{height:250px;display:flex;align-items:end;gap:2px;border-bottom:1px solid #b8c3cf}.histogram i{display:block;flex:1;min-width:1px;background:#2da98a;border-radius:2px 2px 0 0}.heatmap{height:250px;aspect-ratio:1;display:grid;gap:1px;margin:auto;background:#e8edf1}.heatmap i{display:block;background:#315cc5}@media(max-width:760px){.analysis-example{padding:18px}.metrics{grid-template-columns:1fr 1fr}.visuals{grid-template-columns:1fr}}`;

--- a/examples/experimental/gpu-data-analysis/tsconfig.json
+++ b/examples/experimental/gpu-data-analysis/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "baseUrl": "../../..",
+    "typeRoots": ["../../../node_modules/@webgpu/types", "../../../node_modules/@types"],
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "paths": {
+      "@luma.gl/arrow": ["modules/arrow/src/index.ts"],
+      "@luma.gl/arrow/*": ["modules/arrow/src/*"],
+      "@luma.gl/core": ["modules/core/src/index.ts"],
+      "@luma.gl/core/*": ["modules/core/src/*"],
+      "@luma.gl/engine": ["modules/engine/src/index.ts"],
+      "@luma.gl/engine/*": ["modules/engine/src/*"],
+      "@luma.gl/experimental": ["modules/experimental/src/index.ts"],
+      "@luma.gl/experimental/*": ["modules/experimental/src/*"],
+      "@luma.gl/shadertools": ["modules/shadertools/src/index.ts"],
+      "@luma.gl/shadertools/*": ["modules/shadertools/src/*"],
+      "@luma.gl/tables": ["modules/tables/src/index.ts"],
+      "@luma.gl/tables/*": ["modules/tables/src/*"],
+      "@luma.gl/text": ["modules/text/src/index.ts"],
+      "@luma.gl/text/*": ["modules/text/src/*"],
+      "@luma.gl/webgpu": ["modules/webgpu/src/index.ts"],
+      "@luma.gl/webgpu/*": ["modules/webgpu/src/*"]
+    }
+  },
+  "include": ["."]
+}

--- a/examples/experimental/gpu-data-analysis/vite.config.ts
+++ b/examples/experimental/gpu-data-analysis/vite.config.ts
@@ -1,0 +1,15 @@
+import {defineConfig} from 'vite';
+
+const alias = {
+  '@luma.gl/arrow': `${__dirname}/../../../modules/arrow/src`,
+  '@math.gl/geoarrow': `${__dirname}/../../../modules/geoarrow/src`,
+  '@luma.gl/core': `${__dirname}/../../../modules/core/src`,
+  '@luma.gl/engine': `${__dirname}/../../../modules/engine/src`,
+  '@luma.gl/experimental': `${__dirname}/../../../modules/experimental/src`,
+  '@luma.gl/shadertools': `${__dirname}/../../../modules/shadertools/src`,
+  '@luma.gl/tables': `${__dirname}/../../../modules/tables/src`,
+  '@luma.gl/text': `${__dirname}/../../../modules/text/src`,
+  '@luma.gl/webgpu': `${__dirname}/../../../modules/webgpu/src`
+};
+
+export default defineConfig({resolve: {alias}, server: {open: true}});

--- a/examples/experimental/gpu-frustum-culling/app.ts
+++ b/examples/experimental/gpu-frustum-culling/app.ts
@@ -6,9 +6,12 @@ import {Buffer, type Device, type RenderBundle} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Computation, CubeGeometry, Model} from '@luma.gl/engine';
 import {
+  decodeGPUIndexPickInfo,
   DrawCommandBuffer,
   GPUCommandGraph,
   GPUCompaction,
+  GPUIndexPickingTarget,
+  INDEX_PICKING_READBACK_BYTE_LENGTH,
   type CompiledGPUCommandGraph
 } from '@luma.gl/experimental';
 import {Matrix4} from '@math.gl/core';
@@ -19,7 +22,11 @@ import {
   makeHtmlCustomPanel
 } from '../../example-panels';
 import {makeCullingInstances} from './culling-data';
-import {CULLING_RENDER_SHADER, getFrustumCullingShader} from './culling-shaders';
+import {
+  CULLING_PICKING_SHADER,
+  CULLING_RENDER_SHADER,
+  getFrustumCullingShader
+} from './culling-shaders';
 
 export const title = 'GPU Frustum Culling';
 export const description =
@@ -36,6 +43,10 @@ const FIELD_FOV = Math.PI / 3;
 
 type CullingGraphResources = {
   compiled: CompiledGPUCommandGraph<CullingGraphParameters>;
+  pickingCompiled: CompiledGPUCommandGraph<PickingGraphParameters>;
+  pickingReadbackId: string;
+  pickingWidth: number;
+  pickingHeight: number;
   drawCommands: DrawCommandBuffer;
   instances: Buffer;
   visibleIds: Buffer;
@@ -50,12 +61,18 @@ type CullingGraphParameters = {
   overviewViewport?: Viewport;
 };
 
+type PickingGraphParameters = {
+  perspectiveViewport: Viewport;
+  pixel: readonly [number, number];
+};
+
 export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoopTemplate {
   static info = makeExamplePanelHostHtml();
   static props = {createFramebuffer: true, debug: true};
 
   readonly device: Device;
   readonly model: Model;
+  readonly pickingModel: Model;
   readonly uniformBuffer: Buffer;
   readonly overviewUniformBuffer: Buffer;
   readonly panels: ExamplePanelManager;
@@ -72,6 +89,8 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
   private lastPointer: [number, number] = [0, 0];
   private sampledVisibleCount = 0;
   private countReadPending = false;
+  private pickedObjectIndex: number | null = null;
+  private pickReadPendingCount = 0;
   private frameIndex = 0;
   private encodeTimeMilliseconds = 0;
   private compileTimeMilliseconds = 0;
@@ -123,6 +142,29 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
         depthWriteEnabled: true
       }
     });
+    this.pickingModel = new Model(device, {
+      id: 'gpu-frustum-culling-picking-model',
+      source: CULLING_PICKING_SHADER,
+      geometry: new CubeGeometry({id: 'gpu-frustum-culling-picking-cube', indices: true}),
+      colorAttachmentFormats: ['rgba8unorm', 'rg32sint'],
+      depthStencilAttachmentFormat: 'depth24plus',
+      shaderLayout: {
+        attributes: [
+          {name: 'positions', location: 0, type: 'vec3<f32>'},
+          {name: 'normals', location: 1, type: 'vec3<f32>'}
+        ],
+        bindings: [
+          {name: 'instances', type: 'read-only-storage', group: 0, location: 0},
+          {name: 'visibleIds', type: 'read-only-storage', group: 0, location: 1},
+          {name: 'uniforms', type: 'uniform', group: 0, location: 2}
+        ]
+      },
+      parameters: {
+        cullMode: 'back',
+        depthCompare: 'less-equal',
+        depthWriteEnabled: true
+      }
+    });
     this.panels = new ExamplePanelManager({panel: this.makePanel()});
     this.rebuild(DEFAULT_CAPACITY);
     this.panels.mount();
@@ -140,10 +182,25 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
     }
   }
 
-  override onRender({animationLoop, device, time, width, height}: AnimationProps): void {
-    const resources = this.resources;
+  override onRender({
+    animationLoop,
+    device,
+    time,
+    width,
+    height,
+    _mousePosition
+  }: AnimationProps): void {
+    let resources = this.resources;
     if (!resources) {
       return;
+    }
+    const deviceSize = device.getDefaultCanvasContext().getDevicePixelSize();
+    if (resources.pickingWidth !== deviceSize[0] || resources.pickingHeight !== deviceSize[1]) {
+      this.rebuild(this.capacity);
+      resources = this.resources;
+      if (!resources) {
+        return;
+      }
     }
     if (this.autoOrbit) {
       this.yaw = 0.72 + time * 0.00008;
@@ -152,6 +209,20 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
     this.writeUniforms(viewports);
     const encodeStart = performance.now();
     resources.compiled.encode(device.commandEncoder, {parameters: viewports});
+    if (_mousePosition && this.frameIndex % 4 === 0 && this.pickReadPendingCount < 2) {
+      const pixel = this.getPickingPixel(_mousePosition as [number, number], resources);
+      const readbackBuffer = device.createBuffer({
+        id: `gpu-frustum-culling-pick-${this.frameIndex}`,
+        byteLength: INDEX_PICKING_READBACK_BYTE_LENGTH,
+        usage: Buffer.COPY_DST | Buffer.MAP_READ
+      });
+      resources.pickingCompiled.encode(device.commandEncoder, {
+        parameters: {perspectiveViewport: viewports.perspectiveViewport, pixel},
+        buffers: {[resources.pickingReadbackId]: readbackBuffer}
+      });
+      this.pickReadPendingCount++;
+      queueMicrotask(() => void this.readPickingResult(readbackBuffer));
+    }
     this.encodeTimeMilliseconds = performance.now() - encodeStart;
     this.framesPerSecond = animationLoop.frameRate.getSampleHz();
     this.cpuFrameTimeMilliseconds = animationLoop.cpuTime.getSampleAverageTime();
@@ -175,6 +246,7 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
     }
     this.panels.finalize();
     this.destroyResources();
+    this.pickingModel.destroy();
     this.model.destroy();
     this.uniformBuffer.destroy();
     this.overviewUniformBuffer.destroy();
@@ -221,8 +293,22 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
       perspectiveRenderBundle,
       overviewRenderBundle
     );
+    const deviceSize = this.device.getDefaultCanvasContext().getDevicePixelSize();
+    const pickingWidth = Math.max(1, deviceSize[0]);
+    const pickingHeight = Math.max(1, deviceSize[1]);
+    const picking = this.createPickingGraph(
+      pickingWidth,
+      pickingHeight,
+      instances,
+      visibleIds,
+      drawCommands
+    );
     this.resources = {
       compiled,
+      pickingCompiled: picking.compiled,
+      pickingReadbackId: picking.readbackId,
+      pickingWidth,
+      pickingHeight,
       drawCommands,
       instances,
       visibleIds,
@@ -230,6 +316,7 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
       overviewRenderBundle
     };
     this.sampledVisibleCount = 0;
+    this.pickedObjectIndex = null;
     this.compileTimeMilliseconds = performance.now() - compileStart;
     this.updateInspector();
   }
@@ -369,6 +456,87 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
     return graph.compile();
   }
 
+  private createPickingGraph(
+    width: number,
+    height: number,
+    instancesBuffer: Buffer,
+    visibleIdsBuffer: Buffer,
+    drawCommands: DrawCommandBuffer
+  ): {
+    compiled: CompiledGPUCommandGraph<PickingGraphParameters>;
+    readbackId: string;
+  } {
+    const graph = new GPUCommandGraph<PickingGraphParameters>(this.device, {
+      id: 'gpu-frustum-culling-picking-graph'
+    });
+    const instances = graph.importBuffer(
+      {
+        id: 'picking-instances',
+        byteLength: instancesBuffer.byteLength,
+        usage: instancesBuffer.usage
+      },
+      instancesBuffer
+    );
+    const visibleIds = graph.importBuffer(
+      {
+        id: 'picking-visible-ids',
+        byteLength: visibleIdsBuffer.byteLength,
+        usage: visibleIdsBuffer.usage
+      },
+      visibleIdsBuffer
+    );
+    const uniforms = graph.importBuffer(
+      {
+        id: 'picking-uniforms',
+        byteLength: this.uniformBuffer.byteLength,
+        usage: this.uniformBuffer.usage
+      },
+      this.uniformBuffer
+    );
+    const drawCommandBuffer = graph.importBuffer(
+      {
+        id: 'picking-draw-command',
+        byteLength: drawCommands.buffer.byteLength,
+        usage: drawCommands.buffer.usage
+      },
+      drawCommands.buffer
+    );
+    const target = new GPUIndexPickingTarget(graph, {
+      id: 'visible-instance-picking',
+      width,
+      height
+    });
+    graph.addRenderPass({
+      id: 'render-visible-instance-picking',
+      attachments: target.attachments,
+      resources: [
+        {buffer: instances, usage: 'storage-read'},
+        {buffer: visibleIds, usage: 'storage-read'},
+        {buffer: uniforms, usage: 'uniform'},
+        {buffer: drawCommandBuffer, usage: 'indirect'}
+      ],
+      compile: () => ({
+        getRenderPassProps: () => target.renderPassProps,
+        encode: ({parameters, renderPass, getBuffer}) => {
+          renderPass.setParameters({viewport: parameters.perspectiveViewport});
+          renderPass.setPipeline(this.pickingModel.pipeline);
+          renderPass.setVertexArray(this.pickingModel.vertexArray);
+          renderPass.setBindings({
+            instances: getBuffer(instances),
+            visibleIds: getBuffer(visibleIds),
+            uniforms: getBuffer(uniforms)
+          });
+          drawCommands.draw(renderPass, 0);
+        }
+      })
+    });
+    target.addReadbackPass({
+      after: 'render-visible-instance-picking',
+      getPixel: parameters => parameters.pixel
+    });
+    return {compiled: graph.compile(), readbackId: target.readback.id};
+  }
+
   private createRenderBundle(
     id: string,
     instances: Buffer,
@@ -469,7 +637,7 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
         FIELD_NEAR_PLANE,
         FIELD_FAR_PLANE,
         cullingEnabled ? 1 : 0,
-        0,
+        this.pickedObjectIndex === null ? 0 : this.pickedObjectIndex + 1,
         0,
         0
       ],
@@ -494,11 +662,36 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
     }
   }
 
+  private getPickingPixel(
+    mousePosition: [number, number],
+    resources: CullingGraphResources
+  ): readonly [number, number] {
+    const devicePixels = this.device
+      .getDefaultCanvasContext()
+      .cssToDevicePixels(mousePosition, false);
+    return [
+      Math.max(0, Math.min(resources.pickingWidth - 1, devicePixels.x)),
+      Math.max(0, Math.min(resources.pickingHeight - 1, devicePixels.y))
+    ];
+  }
+
+  private async readPickingResult(readbackBuffer: Buffer): Promise<void> {
+    try {
+      const bytes = await readbackBuffer.readAsync(0, 8);
+      this.pickedObjectIndex = decodeGPUIndexPickInfo(bytes).objectIndex;
+      this.updateInspector();
+    } finally {
+      readbackBuffer.destroy();
+      this.pickReadPendingCount--;
+    }
+  }
+
   private destroyResources(): void {
     if (!this.resources) {
       return;
     }
     this.resources.compiled.destroy();
+    this.resources.pickingCompiled.destroy();
     this.resources.perspectiveRenderBundle.destroy();
     this.resources.overviewRenderBundle.destroy();
     this.resources.drawCommands.destroy();
@@ -515,7 +708,7 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
         makeHtmlCustomPanel({
           id: 'gpu-frustum-culling-overview',
           title: '',
-          html: `<p style="margin:0;line-height:1.45">A command graph tests bounding spheres, stably compacts visible IDs, writes one indexed indirect command, and replays a fixed render bundle.</p>`
+          html: `<p style="margin:0;line-height:1.45">A command graph tests bounding spheres, stably compacts visible IDs, writes one indexed indirect command, and replays a fixed render bundle. A second graph renders those stable source IDs into transient integer picking attachments.</p>`
         }),
         makeHtmlCustomPanel({
           id: 'gpu-frustum-culling-controls',
@@ -550,7 +743,7 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
       <label><input type="checkbox" data-comparison checked> Perspective + overview</label>
       <label><input type="checkbox" data-auto-orbit checked> Auto-orbit camera</label>
       <button type="button" data-reset>Reset camera</button>
-      <small>Drag the perspective view to orbit. Use the wheel to zoom. The overview replays the same GPU-culled indirect draw; disable it for a single-render baseline.</small>
+      <small>Move the pointer over the perspective view to pick and highlight a GPU-compacted source ID. Drag to orbit and use the wheel to zoom. The overview replays the same indirect draw.</small>
     </div>`;
   }
 
@@ -608,11 +801,13 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
         <span>CPU frame</span><strong>${this.cpuFrameTimeMilliseconds.toFixed(2)} ms</strong>
         <span>GPU frame</span><strong>${formatGpuTime(this.device, this.gpuFrameTimeMilliseconds)}</strong>
         <span>Sampled visible</span><strong>${formatCount(this.sampledVisibleCount)} (${visiblePercentage.toFixed(1)}%)</strong>
+        <span>Picked source ID</span><strong>${this.pickedObjectIndex ?? 'none'}</strong>
         <span>CPU graph encode</span><strong>${this.encodeTimeMilliseconds.toFixed(2)} ms</strong>
         <span>Logical scratch</span><strong>${formatBytes(stats.logicalTransientBytes)}</strong>
         <span>Physical scratch</span><strong>${formatBytes(stats.physicalTransientBytes)}</strong>
         <span>Transient reuse</span><strong>${stats.reusePercentage.toFixed(0)}%</strong>
         <span>Physical allocations</span><strong>${stats.physicalTransientBufferCount}/${stats.logicalTransientBufferCount}</strong>
+        <span>Picking textures</span><strong>${this.resources?.pickingCompiled.stats.physicalTransientTextureCount}/${this.resources?.pickingCompiled.stats.logicalTransientTextureCount}</strong>
       </div>`;
     }
     if (this.nodesElement) {

--- a/examples/experimental/gpu-frustum-culling/culling-shaders.ts
+++ b/examples/experimental/gpu-frustum-culling/culling-shaders.ts
@@ -41,7 +41,8 @@ struct VertexOutput {
   var output: VertexOutput;
   output.position = uniforms.viewProjectionMatrix * vec4<f32>(worldPosition, 1.0);
   output.normal = inputs.normals;
-  output.color = instance.color;
+  let highlighted = uniforms.options.y > 0.5 && sourceIndex == u32(uniforms.options.y - 1.0);
+  output.color = select(instance.color, vec4<f32>(1.0, 0.85, 0.15, 1.0), highlighted);
   return output;
 }
 
@@ -49,6 +50,59 @@ struct VertexOutput {
   let lightDirection = normalize(vec3<f32>(0.42, 0.82, 0.36));
   let diffuse = max(dot(normalize(input.normal), lightDirection), 0.18);
   return vec4<f32>(input.color.rgb * diffuse, input.color.a);
+}`;
+
+export const CULLING_PICKING_SHADER = /* wgsl */ `
+struct CullingInstance {
+  positionRadius: vec4<f32>,
+  color: vec4<f32>,
+};
+
+struct CullingUniforms {
+  viewProjectionMatrix: mat4x4<f32>,
+  viewMatrix: mat4x4<f32>,
+  frustum: vec4<f32>,
+  options: vec4<f32>,
+};
+
+@group(0) @binding(0) var<storage, read> instances: array<CullingInstance>;
+@group(0) @binding(1) var<storage, read> visibleIds: array<u32>;
+@group(0) @binding(2) var<uniform> uniforms: CullingUniforms;
+
+struct VertexInputs {
+  @location(0) positions: vec4<f32>,
+  @location(1) normals: vec3<f32>,
+};
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) @interpolate(flat) sourceIndex: u32,
+};
+
+struct FragmentOutput {
+  @location(0) color: vec4<f32>,
+  @location(1) indices: vec2<i32>,
+};
+
+@vertex fn vertexMain(
+  inputs: VertexInputs,
+  @builtin(instance_index) instanceIndex: u32
+) -> VertexOutput {
+  let sourceIndex = visibleIds[instanceIndex];
+  let instance = instances[sourceIndex];
+  let worldPosition = inputs.positions.xyz * instance.positionRadius.w * 1.35 +
+    instance.positionRadius.xyz;
+  var output: VertexOutput;
+  output.position = uniforms.viewProjectionMatrix * vec4<f32>(worldPosition, 1.0);
+  output.sourceIndex = sourceIndex;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutput) -> FragmentOutput {
+  var output: FragmentOutput;
+  output.color = vec4<f32>(0.0);
+  output.indices = vec2<i32>(i32(input.sourceIndex), 0);
+  return output;
 }`;
 
 export function getFrustumCullingShader(instanceCount: number): string {

--- a/modules/core/src/adapter/types/attachments.ts
+++ b/modules/core/src/adapter/types/attachments.ts
@@ -40,7 +40,7 @@ type StorageTextureBindingLayout = {
   /** The index of the binding point in the compiled and linked shader */
   location?: number;
   visibility: number;
-  access?: 'write-only';
+  access?: 'write-only' | 'read-only' | 'read-write';
   format: TextureFormat;
   viewDimension?: '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
 };

--- a/modules/core/src/adapter/types/shader-layout.ts
+++ b/modules/core/src/adapter/types/shader-layout.ts
@@ -166,7 +166,7 @@ export type StorageTextureBindingLayout = {
   location: number;
   /** Which shader stages can access this binding */
   visibility?: number;
-  access?: 'write-only';
+  access?: 'write-only' | 'read-only' | 'read-write';
   format: TextureFormat;
   viewDimension?: '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
 };

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
@@ -2,9 +2,18 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer} from '@luma.gl/core';
-import type {CommandEncoder, ComputePass, Device, RenderPass, RenderPassProps} from '@luma.gl/core';
-import {DynamicBuffer} from '@luma.gl/engine';
+import {Buffer, Texture, textureFormatDecoder} from '@luma.gl/core';
+import type {
+  CommandEncoder,
+  ComputePass,
+  Device,
+  Framebuffer,
+  RenderPass,
+  RenderPassProps,
+  TextureFormat,
+  TextureView
+} from '@luma.gl/core';
+import {DynamicBuffer, DynamicTexture} from '@luma.gl/engine';
 import {
   GPUData,
   type GPUVector,
@@ -24,14 +33,55 @@ export type GraphBufferUsage =
   | 'vertex'
   | 'index';
 
+/** GPU texture use declared by one graph node. */
+export type GraphTextureUsage =
+  | 'sampled'
+  | 'storage-read'
+  | 'storage-write'
+  | 'storage-read-write'
+  | 'render-attachment'
+  | 'copy-source'
+  | 'copy-destination';
+
 /** Buffer accepted as a fixed or per-encoding graph import. */
 export type GraphImportedBuffer = Buffer | DynamicBuffer;
+
+/** Texture accepted as a fixed or per-encoding graph import. */
+export type GraphImportedTexture = Texture | DynamicTexture;
 
 /** Descriptor for one imported or transient graph buffer. */
 export type GraphBufferDescriptor = {
   id: string;
   byteLength: number;
   usage: number;
+};
+
+export type GraphTextureDimension = '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
+export type GraphTextureAspect = 'all' | 'stencil-only' | 'depth-only';
+
+/** Descriptor for one fixed-size imported or transient graph texture. */
+export type GraphTextureDescriptor<Format extends TextureFormat = TextureFormat> = {
+  id: string;
+  format: Format;
+  width: number;
+  height: number;
+  usage: number;
+  dimension?: GraphTextureDimension;
+  depth?: number;
+  mipLevels?: number;
+  samples?: number;
+};
+
+type NormalizedGraphTextureDescriptor<Format extends TextureFormat = TextureFormat> = {
+  id: string;
+  format: Format;
+  width: number;
+  height: number;
+  usage: number;
+  dimension: GraphTextureDimension;
+  depth: number;
+  mipLevels: number;
+  samples: number;
 };
 
 /** Opaque logical buffer tracked by a {@link GPUCommandGraph}. */
@@ -90,10 +140,106 @@ export class GraphBufferView<T extends GPUVectorFormat = GPUVectorFormat> {
   }
 }
 
-/** One resource use declared by a graph node. */
+/** Opaque logical texture tracked by a {@link GPUCommandGraph}. */
+export class GraphTextureHandle<Format extends TextureFormat = TextureFormat> {
+  readonly id: string;
+  readonly format: Format;
+  readonly width: number;
+  readonly height: number;
+  readonly usage: number;
+  readonly dimension: GraphTextureDimension;
+  readonly depth: number;
+  readonly mipLevels: number;
+  readonly samples: number;
+  readonly transient: boolean;
+  /** @internal */
+  readonly graph: GPUCommandGraph<any>;
+  /** @internal */
+  readonly defaultTexture?: GraphImportedTexture;
+
+  /** @internal */
+  constructor(
+    graph: GPUCommandGraph<any>,
+    descriptor: NormalizedGraphTextureDescriptor<Format>,
+    transient: boolean,
+    defaultTexture?: GraphImportedTexture
+  ) {
+    this.graph = graph;
+    this.id = descriptor.id;
+    this.format = descriptor.format;
+    this.width = descriptor.width;
+    this.height = descriptor.height;
+    this.usage = descriptor.usage;
+    this.dimension = descriptor.dimension;
+    this.depth = descriptor.depth;
+    this.mipLevels = descriptor.mipLevels;
+    this.samples = descriptor.samples;
+    this.transient = transient;
+    this.defaultTexture = defaultTexture;
+  }
+}
+
+export type GraphTextureViewProps = {
+  dimension?: GraphTextureDimension;
+  aspect?: GraphTextureAspect;
+  baseMipLevel?: number;
+  mipLevelCount?: number;
+  baseArrayLayer?: number;
+  arrayLayerCount?: number;
+};
+
+/** Logical mip, layer, and aspect range within one graph texture. */
+export class GraphTextureView<Format extends TextureFormat = TextureFormat> {
+  readonly texture: GraphTextureHandle<Format>;
+  readonly format: Format;
+  readonly dimension: GraphTextureDimension;
+  readonly aspect: GraphTextureAspect;
+  readonly baseMipLevel: number;
+  readonly mipLevelCount: number;
+  readonly baseArrayLayer: number;
+  readonly arrayLayerCount: number;
+  readonly width: number;
+  readonly height: number;
+  readonly depth: number;
+
+  /** @internal */
+  constructor(
+    texture: GraphTextureHandle<Format>,
+    props: Required<GraphTextureViewProps> & {width: number; height: number; depth: number}
+  ) {
+    this.texture = texture;
+    this.format = texture.format;
+    this.dimension = props.dimension;
+    this.aspect = props.aspect;
+    this.baseMipLevel = props.baseMipLevel;
+    this.mipLevelCount = props.mipLevelCount;
+    this.baseArrayLayer = props.baseArrayLayer;
+    this.arrayLayerCount = props.arrayLayerCount;
+    this.width = props.width;
+    this.height = props.height;
+    this.depth = props.depth;
+  }
+}
+
+/** One buffer use declared by a graph node. */
 export type GraphBufferUse = {
   buffer: GraphBufferHandle | GraphBufferView;
   usage: GraphBufferUsage;
+};
+
+/** One texture or texture-view use declared by a graph node. */
+export type GraphTextureUse = {
+  texture: GraphTextureHandle | GraphTextureView;
+  usage: GraphTextureUsage;
+};
+
+/** One resource use declared by a graph node. */
+export type GraphResourceUse = GraphBufferUse | GraphTextureUse;
+
+/** Graph-owned texture attachments resolved into a framebuffer for a render node. */
+export type GraphRenderPassAttachments = {
+  colorAttachments: GraphTextureView[];
+  depthStencilAttachment?: GraphTextureView;
 };
 
 /** Context available while compiling one graph node. */
@@ -106,6 +252,8 @@ export type GPUCommandGraphEncodeContext<Parameters> = {
   commandEncoder: CommandEncoder;
   parameters: Parameters;
   getBuffer: (buffer: GraphBufferHandle | GraphBufferView) => Buffer;
+  getTexture: (texture: GraphTextureHandle | GraphTextureView) => Texture;
+  getTextureView: (texture: GraphTextureHandle | GraphTextureView) => TextureView;
 };
 
 /** Compiled compute-pass callback. */
@@ -129,7 +277,7 @@ export type GPUCommandGraphCopyExecutable<Parameters> = {
 
 type GPUCommandGraphNodeBase = {
   id: string;
-  resources?: GraphBufferUse[];
+  resources?: GraphResourceUse[];
   dependsOn?: string[];
 };
 
@@ -140,6 +288,7 @@ export type GPUCommandGraphComputeNode<Parameters> = GPUCommandGraphNodeBase & {
 
 export type GPUCommandGraphRenderNode<Parameters> = GPUCommandGraphNodeBase & {
   type: 'render';
+  attachments?: GraphRenderPassAttachments;
   compile: (context: GPUCommandGraphCompileContext) => GPUCommandGraphRenderExecutable<Parameters>;
 };
 
@@ -162,12 +311,19 @@ export type GPUCommandGraphStats = {
   physicalTransientBytes: number;
   reusedTransientBytes: number;
   reusePercentage: number;
+  logicalTransientTextureCount: number;
+  physicalTransientTextureCount: number;
+  logicalTransientTextureBytes: number;
+  physicalTransientTextureBytes: number;
+  reusedTransientTextureBytes: number;
+  textureReusePercentage: number;
 };
 
 /** Options supplied while encoding one compiled graph. */
 export type GPUCommandGraphEncodeOptions<Parameters> = {
   parameters: Parameters;
   buffers?: Record<string, GraphImportedBuffer>;
+  textures?: Record<string, GraphImportedTexture>;
 };
 
 type CompiledNode<Parameters> = {
@@ -178,7 +334,7 @@ type CompiledNode<Parameters> = {
     | GPUCommandGraphCopyExecutable<Parameters>;
 };
 
-type TransientAllocation = {
+type BufferTransientAllocation = {
   byteLength: number;
   usage: number;
   lastUse: number;
@@ -186,8 +342,29 @@ type TransientAllocation = {
   buffer?: Buffer;
 };
 
+type TextureTransientAllocation = {
+  descriptor: NormalizedGraphTextureDescriptor;
+  byteLength: number;
+  lastUse: number;
+  handles: GraphTextureHandle[];
+  texture?: Texture;
+};
+
+type CachedTextureView = {
+  logicalView: GraphTextureView;
+  texture: Texture;
+  view: TextureView;
+};
+
+type CachedFramebuffer = {
+  nodeId: string;
+  colorAttachments: TextureView[];
+  depthStencilAttachment?: TextureView;
+  framebuffer: Framebuffer;
+};
+
 /**
- * Declarative WebGPU command graph with explicit buffer access and ownership.
+ * Declarative WebGPU command graph with explicit resource access and ownership.
  *
  * The graph compiles resource hazards, transient lifetimes, and node resources,
  * but encoding and submission remain controlled by the application.
@@ -197,6 +374,7 @@ export class GPUCommandGraph<Parameters = void> {
   readonly id: string;
 
   private readonly buffers = new Map<string, GraphBufferHandle>();
+  private readonly textures = new Map<string, GraphTextureHandle>();
   private readonly nodes: GPUCommandGraphNode<Parameters>[] = [];
   private readonly nodeIds = new Set<string>();
   private compiled = false;
@@ -291,12 +469,69 @@ export class GPUCommandGraph<Parameters = void> {
     return this.importGPUData(id, data);
   }
 
+  /** Declares a caller-owned fixed-size texture that can be supplied now or while encoding. */
+  importTexture<Format extends TextureFormat>(
+    descriptor: GraphTextureDescriptor<Format>,
+    defaultTexture?: GraphImportedTexture
+  ): GraphTextureHandle<Format> {
+    this.assertMutable();
+    const normalizedDescriptor = normalizeGraphTextureDescriptor(descriptor, this.device);
+    if (defaultTexture) {
+      validateImportedTexture(defaultTexture, normalizedDescriptor, this.device);
+    }
+    return this.addTexture(
+      new GraphTextureHandle(this, normalizedDescriptor, false, defaultTexture)
+    );
+  }
+
+  /** Declares one graph-owned fixed-size transient texture. */
+  createTransientTexture<Format extends TextureFormat>(
+    descriptor: GraphTextureDescriptor<Format>
+  ): GraphTextureHandle<Format> {
+    this.assertMutable();
+    const normalizedDescriptor = normalizeGraphTextureDescriptor(descriptor, this.device);
+    return this.addTexture(new GraphTextureHandle(this, normalizedDescriptor, true));
+  }
+
+  /** Creates one logical mip, layer, and aspect range over a graph texture. */
+  createTextureView<Format extends TextureFormat>(
+    texture: GraphTextureHandle<Format>,
+    props: GraphTextureViewProps = {}
+  ): GraphTextureView<Format> {
+    this.assertTexture(texture);
+    const normalizedProps = normalizeGraphTextureView(texture, props);
+    return new GraphTextureView(texture, normalizedProps);
+  }
+
   addComputePass(node: Omit<GPUCommandGraphComputeNode<Parameters>, 'type'>): void {
     this.addNode({...node, type: 'compute'});
   }
 
   addRenderPass(node: Omit<GPUCommandGraphRenderNode<Parameters>, 'type'>): void {
-    this.addNode({...node, type: 'render'});
+    if (node.attachments) {
+      this.validateRenderAttachments(node.id, node.attachments);
+    }
+    const attachmentUses: GraphTextureUse[] = node.attachments
+      ? [
+          ...node.attachments.colorAttachments.map(texture => ({
+            texture,
+            usage: 'render-attachment' as const
+          })),
+          ...(node.attachments.depthStencilAttachment
+            ? [
+                {
+                  texture: node.attachments.depthStencilAttachment,
+                  usage: 'render-attachment' as const
+                }
+              ]
+            : [])
+        ]
+      : [];
+    this.addNode({
+      ...node,
+      resources: [...(node.resources ?? []), ...attachmentUses],
+      type: 'render'
+    });
   }
 
   addCopyPass(node: Omit<GPUCommandGraphCopyNode<Parameters>, 'type'>): void {
@@ -308,16 +543,28 @@ export class GPUCommandGraph<Parameters = void> {
     this.assertMutable();
     this.compiled = true;
     const nodeOrder = getNodeOrder(this.nodes);
-    const transientPlan = getTransientAllocationPlan(nodeOrder, this.buffers.values());
+    const bufferPlan = getBufferTransientAllocationPlan(nodeOrder, this.buffers.values());
+    const texturePlan = getTextureTransientAllocationPlan(nodeOrder, this.textures.values());
     const transientBuffers = new Map<GraphBufferHandle, Buffer>();
-    for (const allocation of transientPlan) {
+    const transientTextures = new Map<GraphTextureHandle, Texture>();
+
+    for (const allocation of bufferPlan) {
       allocation.buffer = this.device.createBuffer({
-        id: `${this.id}-transient-${transientPlan.indexOf(allocation)}`,
+        id: `${this.id}-transient-buffer-${bufferPlan.indexOf(allocation)}`,
         byteLength: allocation.byteLength,
         usage: allocation.usage
       });
       for (const handle of allocation.handles) {
         transientBuffers.set(handle, allocation.buffer);
+      }
+    }
+    for (const allocation of texturePlan) {
+      allocation.texture = this.device.createTexture({
+        ...allocation.descriptor,
+        id: `${this.id}-transient-texture-${texturePlan.indexOf(allocation)}`
+      });
+      for (const handle of allocation.handles) {
+        transientTextures.set(handle, allocation.texture);
       }
     }
 
@@ -330,8 +577,11 @@ export class GPUCommandGraph<Parameters = void> {
       for (const compiledNode of compiledNodes) {
         compiledNode.executable.destroy?.();
       }
-      for (const allocation of transientPlan) {
+      for (const allocation of bufferPlan) {
         allocation.buffer?.destroy();
+      }
+      for (const allocation of texturePlan) {
+        allocation.texture?.destroy();
       }
       throw error;
     }
@@ -339,31 +589,56 @@ export class GPUCommandGraph<Parameters = void> {
     const logicalTransientBytes = Array.from(this.buffers.values())
       .filter(buffer => buffer.transient)
       .reduce((sum, buffer) => sum + buffer.byteLength, 0);
-    const physicalTransientBytes = transientPlan.reduce(
+    const physicalTransientBytes = bufferPlan.reduce(
       (sum, allocation) => sum + allocation.byteLength,
       0
     );
     const reusedTransientBytes = Math.max(0, logicalTransientBytes - physicalTransientBytes);
+    const logicalTransientTextureBytes = Array.from(this.textures.values())
+      .filter(texture => texture.transient)
+      .reduce((sum, texture) => sum + getTextureByteLength(texture), 0);
+    const physicalTransientTextureBytes = texturePlan.reduce(
+      (sum, allocation) => sum + allocation.byteLength,
+      0
+    );
+    const reusedTransientTextureBytes = Math.max(
+      0,
+      logicalTransientTextureBytes - physicalTransientTextureBytes
+    );
     const stats: GPUCommandGraphStats = {
       nodeOrder: nodeOrder.map(node => node.id),
       logicalTransientBufferCount: Array.from(this.buffers.values()).filter(
         buffer => buffer.transient
       ).length,
-      physicalTransientBufferCount: transientPlan.length,
+      physicalTransientBufferCount: bufferPlan.length,
       logicalTransientBytes,
       physicalTransientBytes,
       reusedTransientBytes,
       reusePercentage:
-        logicalTransientBytes > 0 ? (reusedTransientBytes / logicalTransientBytes) * 100 : 0
+        logicalTransientBytes > 0 ? (reusedTransientBytes / logicalTransientBytes) * 100 : 0,
+      logicalTransientTextureCount: Array.from(this.textures.values()).filter(
+        texture => texture.transient
+      ).length,
+      physicalTransientTextureCount: texturePlan.length,
+      logicalTransientTextureBytes,
+      physicalTransientTextureBytes,
+      reusedTransientTextureBytes,
+      textureReusePercentage:
+        logicalTransientTextureBytes > 0
+          ? (reusedTransientTextureBytes / logicalTransientTextureBytes) * 100
+          : 0
     };
 
     return new CompiledGPUCommandGraph({
       device: this.device,
       id: this.id,
       buffers: new Map(this.buffers),
+      textures: new Map(this.textures),
       compiledNodes,
       transientBuffers,
-      transientAllocations: transientPlan,
+      transientTextures,
+      bufferTransientAllocations: bufferPlan,
+      textureTransientAllocations: texturePlan,
       stats
     });
   }
@@ -377,20 +652,37 @@ export class GPUCommandGraph<Parameters = void> {
       throw new Error(`GPUCommandGraph node id "${node.id}" is already in use`);
     }
     for (const resource of node.resources ?? []) {
-      const buffer = getHandle(resource.buffer);
-      this.assertBuffer(buffer);
-      validateUseAgainstDescriptor(buffer, resource.usage);
+      if (isGraphBufferUse(resource)) {
+        const buffer = getBufferHandle(resource.buffer);
+        this.assertBuffer(buffer);
+        validateBufferUseAgainstDescriptor(buffer, resource.usage);
+      } else {
+        const texture = getTextureHandle(resource.texture);
+        this.assertTexture(texture);
+        validateTextureUseAgainstDescriptor(texture, resource.usage);
+        validateTextureViewForUsage(resource.texture, resource.usage);
+      }
     }
     this.nodeIds.add(node.id);
     this.nodes.push(node);
   }
 
   private addBuffer(buffer: GraphBufferHandle): GraphBufferHandle {
-    if (this.buffers.has(buffer.id)) {
-      throw new Error(`GPUCommandGraph buffer id "${buffer.id}" is already in use`);
+    if (this.buffers.has(buffer.id) || this.textures.has(buffer.id)) {
+      throw new Error(`GPUCommandGraph resource id "${buffer.id}" is already in use`);
     }
     this.buffers.set(buffer.id, buffer);
     return buffer;
+  }
+
+  private addTexture<Format extends TextureFormat>(
+    texture: GraphTextureHandle<Format>
+  ): GraphTextureHandle<Format> {
+    if (this.buffers.has(texture.id) || this.textures.has(texture.id)) {
+      throw new Error(`GPUCommandGraph resource id "${texture.id}" is already in use`);
+    }
+    this.textures.set(texture.id, texture);
+    return texture;
   }
 
   private assertBuffer(buffer: GraphBufferHandle): void {
@@ -399,9 +691,49 @@ export class GPUCommandGraph<Parameters = void> {
     }
   }
 
+  private assertTexture(texture: GraphTextureHandle): void {
+    if (texture.graph !== this || this.textures.get(texture.id) !== texture) {
+      throw new Error(`Graph texture "${texture.id}" does not belong to ${this.id}`);
+    }
+  }
+
   private assertMutable(): void {
     if (this.compiled) {
       throw new Error(`GPUCommandGraph "${this.id}" has already been compiled`);
+    }
+  }
+
+  private validateRenderAttachments(id: string, attachments: GraphRenderPassAttachments): void {
+    if (attachments.colorAttachments.length === 0 && !attachments.depthStencilAttachment) {
+      throw new Error(`GPUCommandGraph render node "${id}" requires at least one attachment`);
+    }
+    const allAttachments = [
+      ...attachments.colorAttachments,
+      ...(attachments.depthStencilAttachment ? [attachments.depthStencilAttachment] : [])
+    ];
+    for (const attachment of allAttachments) {
+      this.assertTexture(attachment.texture);
+      if (
+        attachment.dimension !== '2d' ||
+        attachment.mipLevelCount !== 1 ||
+        attachment.arrayLayerCount !== 1
+      ) {
+        throw new Error(
+          `GPUCommandGraph render node "${id}" attachments must be single-mip, single-layer 2d views`
+        );
+      }
+    }
+    const [first, ...remaining] = allAttachments;
+    for (const attachment of remaining) {
+      if (
+        attachment.width !== first.width ||
+        attachment.height !== first.height ||
+        attachment.texture.samples !== first.texture.samples
+      ) {
+        throw new Error(
+          `GPUCommandGraph render node "${id}" attachments must have matching extent and samples`
+        );
+      }
     }
   }
 }
@@ -413,9 +745,14 @@ export class CompiledGPUCommandGraph<Parameters = void> {
   readonly stats: GPUCommandGraphStats;
 
   private readonly buffers: Map<string, GraphBufferHandle>;
+  private readonly textures: Map<string, GraphTextureHandle>;
   private readonly compiledNodes: CompiledNode<Parameters>[];
   private readonly transientBuffers: Map<GraphBufferHandle, Buffer>;
-  private readonly transientAllocations: TransientAllocation[];
+  private readonly transientTextures: Map<GraphTextureHandle, Texture>;
+  private readonly bufferTransientAllocations: BufferTransientAllocation[];
+  private readonly textureTransientAllocations: TextureTransientAllocation[];
+  private readonly cachedTextureViews: CachedTextureView[] = [];
+  private readonly cachedFramebuffers: CachedFramebuffer[] = [];
   private destroyed = false;
 
   /** @internal */
@@ -423,17 +760,23 @@ export class CompiledGPUCommandGraph<Parameters = void> {
     device: Device;
     id: string;
     buffers: Map<string, GraphBufferHandle>;
+    textures: Map<string, GraphTextureHandle>;
     compiledNodes: CompiledNode<Parameters>[];
     transientBuffers: Map<GraphBufferHandle, Buffer>;
-    transientAllocations: TransientAllocation[];
+    transientTextures: Map<GraphTextureHandle, Texture>;
+    bufferTransientAllocations: BufferTransientAllocation[];
+    textureTransientAllocations: TextureTransientAllocation[];
     stats: GPUCommandGraphStats;
   }) {
     this.device = props.device;
     this.id = props.id;
     this.buffers = props.buffers;
+    this.textures = props.textures;
     this.compiledNodes = props.compiledNodes;
     this.transientBuffers = props.transientBuffers;
-    this.transientAllocations = props.transientAllocations;
+    this.transientTextures = props.transientTextures;
+    this.bufferTransientAllocations = props.bufferTransientAllocations;
+    this.textureTransientAllocations = props.textureTransientAllocations;
     this.stats = props.stats;
   }
 
@@ -447,8 +790,9 @@ export class CompiledGPUCommandGraph<Parameters = void> {
     }
 
     const importedBuffers = this.resolveImportedBuffers(options.buffers ?? {});
+    const importedTextures = this.resolveImportedTextures(options.textures ?? {});
     const getBuffer = (bufferOrView: GraphBufferHandle | GraphBufferView): Buffer => {
-      const handle = getHandle(bufferOrView);
+      const handle = getBufferHandle(bufferOrView);
       const buffer = handle.transient
         ? this.transientBuffers.get(handle)
         : importedBuffers.get(handle);
@@ -457,11 +801,46 @@ export class CompiledGPUCommandGraph<Parameters = void> {
       }
       return buffer;
     };
+    const getTexture = (textureOrView: GraphTextureHandle | GraphTextureView): Texture => {
+      const handle = getTextureHandle(textureOrView);
+      const texture = handle.transient
+        ? this.transientTextures.get(handle)
+        : importedTextures.get(handle);
+      if (!texture) {
+        throw new Error(`GPUCommandGraph texture "${handle.id}" is not bound`);
+      }
+      return texture;
+    };
+    const getTextureView = (textureOrView: GraphTextureHandle | GraphTextureView): TextureView => {
+      const texture = getTexture(textureOrView);
+      if (textureOrView instanceof GraphTextureHandle || isDefaultGraphTextureView(textureOrView)) {
+        return texture.view;
+      }
+      const cached = this.cachedTextureViews.find(
+        entry => entry.logicalView === textureOrView && entry.texture === texture
+      );
+      if (cached) {
+        return cached.view;
+      }
+      const view = texture.createView({
+        format: textureOrView.format,
+        dimension: textureOrView.dimension,
+        aspect: textureOrView.aspect,
+        baseMipLevel: textureOrView.baseMipLevel,
+        mipLevelCount: textureOrView.mipLevelCount,
+        baseArrayLayer: textureOrView.baseArrayLayer,
+        arrayLayerCount: textureOrView.arrayLayerCount
+      });
+      this.cachedTextureViews.push({logicalView: textureOrView, texture, view});
+      return view;
+    };
 
     const baseContext: GPUCommandGraphEncodeContext<Parameters> = {
       commandEncoder,
       parameters: options.parameters,
-      getBuffer
+      getBuffer,
+      getTexture,
+      getTextureView
     };
 
     for (const {node, executable} of this.compiledNodes) {
@@ -482,9 +861,21 @@ export class CompiledGPUCommandGraph<Parameters = void> {
         }
         case 'render': {
           const renderExecutable = executable as GPUCommandGraphRenderExecutable<Parameters>;
-          const renderPass = commandEncoder.beginRenderPass(
-            renderExecutable.getRenderPassProps?.(baseContext) ?? {id: node.id}
-          );
+          const renderPassProps = renderExecutable.getRenderPassProps?.(baseContext) ?? {
+            id: node.id
+          };
+          if (node.attachments && renderPassProps.framebuffer !== undefined) {
+            throw new Error(
+              `GPUCommandGraph render node "${node.id}" cannot supply framebuffer with graph attachments`
+            );
+          }
+          const framebuffer = node.attachments
+            ? this.getFramebuffer(node.id, node.attachments, getTextureView)
+            : undefined;
+          const renderPass = commandEncoder.beginRenderPass({
+            ...renderPassProps,
+            ...(framebuffer ? {framebuffer} : {})
+          });
           renderPass.pushDebugGroup(node.id);
           try {
             renderExecutable.encode({...baseContext, renderPass});
@@ -501,7 +892,7 @@ export class CompiledGPUCommandGraph<Parameters = void> {
     }
   }
 
-  /** Releases compiled node resources and graph-owned transient buffers. */
+  /** Releases compiled node resources and graph-owned transient resources. */
   destroy(): void {
     if (this.destroyed) {
       return;
@@ -509,8 +900,17 @@ export class CompiledGPUCommandGraph<Parameters = void> {
     for (const {executable} of this.compiledNodes) {
       executable.destroy?.();
     }
-    for (const allocation of this.transientAllocations) {
+    for (const cached of this.cachedFramebuffers) {
+      cached.framebuffer.destroy();
+    }
+    for (const cached of this.cachedTextureViews) {
+      cached.view.destroy();
+    }
+    for (const allocation of this.bufferTransientAllocations) {
       allocation.buffer?.destroy();
+    }
+    for (const allocation of this.textureTransientAllocations) {
+      allocation.texture?.destroy();
     }
     this.destroyed = true;
   }
@@ -538,14 +938,93 @@ export class CompiledGPUCommandGraph<Parameters = void> {
     }
     return resolved;
   }
+
+  private resolveImportedTextures(
+    overrides: Record<string, GraphImportedTexture>
+  ): Map<GraphTextureHandle, Texture> {
+    const resolved = new Map<GraphTextureHandle, Texture>();
+    for (const [id, handle] of this.textures) {
+      if (handle.transient) {
+        continue;
+      }
+      const importedTexture = overrides[id] ?? handle.defaultTexture;
+      if (!importedTexture) {
+        throw new Error(`GPUCommandGraph imported texture "${id}" is required`);
+      }
+      validateImportedTexture(importedTexture, handle, this.device);
+      resolved.set(handle, getCoreTexture(importedTexture));
+    }
+    for (const id of Object.keys(overrides)) {
+      const handle = this.textures.get(id);
+      if (!handle || handle.transient) {
+        throw new Error(`GPUCommandGraph has no imported texture named "${id}"`);
+      }
+    }
+    return resolved;
+  }
+
+  private getFramebuffer(
+    nodeId: string,
+    attachments: GraphRenderPassAttachments,
+    getTextureView: (texture: GraphTextureView) => TextureView
+  ): Framebuffer {
+    const colorAttachments = attachments.colorAttachments.map(getTextureView);
+    const depthStencilAttachment = attachments.depthStencilAttachment
+      ? getTextureView(attachments.depthStencilAttachment)
+      : undefined;
+    const cached = this.cachedFramebuffers.find(
+      entry =>
+        entry.nodeId === nodeId &&
+        entry.depthStencilAttachment === depthStencilAttachment &&
+        entry.colorAttachments.length === colorAttachments.length &&
+        entry.colorAttachments.every((view, index) => view === colorAttachments[index])
+    );
+    if (cached) {
+      return cached.framebuffer;
+    }
+    const firstLogicalAttachment =
+      attachments.colorAttachments[0] ?? attachments.depthStencilAttachment!;
+    const framebuffer = this.device.createFramebuffer({
+      id: `${this.id}-${nodeId}-framebuffer-${this.cachedFramebuffers.length}`,
+      width: firstLogicalAttachment.width,
+      height: firstLogicalAttachment.height,
+      colorAttachments,
+      depthStencilAttachment: depthStencilAttachment ?? null
+    });
+    this.cachedFramebuffers.push({
+      nodeId,
+      colorAttachments,
+      depthStencilAttachment,
+      framebuffer
+    });
+    return framebuffer;
+  }
 }
 
-function getHandle(buffer: GraphBufferHandle | GraphBufferView): GraphBufferHandle {
+function getBufferHandle(buffer: GraphBufferHandle | GraphBufferView): GraphBufferHandle {
   return buffer instanceof GraphBufferView ? buffer.buffer : buffer;
+}
+
+function getTextureHandle(texture: GraphTextureHandle | GraphTextureView): GraphTextureHandle {
+  return texture instanceof GraphTextureView ? texture.texture : texture;
 }
 
 function getCoreBuffer(buffer: GraphImportedBuffer): Buffer {
   return buffer instanceof DynamicBuffer ? buffer.buffer : buffer;
+}
+
+function getCoreTexture(texture: GraphImportedTexture): Texture {
+  if (texture instanceof DynamicTexture) {
+    if (!texture.isReady) {
+      throw new Error(`GPUCommandGraph dynamic texture "${texture.id}" is not ready`);
+    }
+    return texture.texture;
+  }
+  return texture;
+}
+
+function isGraphBufferUse(resource: GraphResourceUse): resource is GraphBufferUse {
+  return 'buffer' in resource;
 }
 
 function validateGraphBufferDescriptor(descriptor: GraphBufferDescriptor): void {
@@ -558,6 +1037,113 @@ function validateGraphBufferDescriptor(descriptor: GraphBufferDescriptor): void 
   if (!Number.isSafeInteger(descriptor.usage) || descriptor.usage <= 0) {
     throw new Error(`GPUCommandGraph buffer "${descriptor.id}" requires buffer usage flags`);
   }
+}
+
+function normalizeGraphTextureDescriptor<Format extends TextureFormat>(
+  descriptor: GraphTextureDescriptor<Format>,
+  device: Device
+): NormalizedGraphTextureDescriptor<Format> {
+  if (!descriptor.id) {
+    throw new Error('GPUCommandGraph texture id is required');
+  }
+  const dimension = descriptor.dimension ?? '2d';
+  const depth = dimension === 'cube' ? 6 : (descriptor.depth ?? 1);
+  const mipLevels = descriptor.mipLevels ?? 1;
+  const samples = descriptor.samples ?? 1;
+  for (const [name, value] of Object.entries({
+    width: descriptor.width,
+    height: descriptor.height,
+    depth,
+    mipLevels,
+    samples
+  })) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new Error(
+        `GPUCommandGraph texture "${descriptor.id}" ${name} must be a positive safe integer`
+      );
+    }
+  }
+  if (!Number.isSafeInteger(descriptor.usage) || descriptor.usage <= 0) {
+    throw new Error(`GPUCommandGraph texture "${descriptor.id}" requires texture usage flags`);
+  }
+  if (!device.isTextureFormatSupported(descriptor.format)) {
+    throw new Error(
+      `GPUCommandGraph texture "${descriptor.id}" format ${descriptor.format} is unsupported`
+    );
+  }
+  if (dimension === '1d' && (descriptor.height !== 1 || depth !== 1)) {
+    throw new Error(`GPUCommandGraph 1d texture "${descriptor.id}" requires height and depth 1`);
+  }
+  if (dimension === 'cube' && descriptor.width !== descriptor.height) {
+    throw new Error(`GPUCommandGraph cube texture "${descriptor.id}" must be square`);
+  }
+  if (dimension === 'cube-array' && (descriptor.width !== descriptor.height || depth % 6 !== 0)) {
+    throw new Error(
+      `GPUCommandGraph cube-array texture "${descriptor.id}" must be square with depth divisible by 6`
+    );
+  }
+  if (mipLevels > device.getMipLevelCount(descriptor.width, descriptor.height, depth)) {
+    throw new Error(`GPUCommandGraph texture "${descriptor.id}" declares too many mip levels`);
+  }
+  return {
+    id: descriptor.id,
+    format: descriptor.format,
+    width: descriptor.width,
+    height: descriptor.height,
+    usage: descriptor.usage,
+    dimension,
+    depth,
+    mipLevels,
+    samples
+  };
+}
+
+function normalizeGraphTextureView<Format extends TextureFormat>(
+  texture: GraphTextureHandle<Format>,
+  props: GraphTextureViewProps
+): Required<GraphTextureViewProps> & {width: number; height: number; depth: number} {
+  const dimension = props.dimension ?? texture.dimension;
+  const aspect = props.aspect ?? 'all';
+  const baseMipLevel = props.baseMipLevel ?? 0;
+  const mipLevelCount = props.mipLevelCount ?? texture.mipLevels - baseMipLevel;
+  const baseArrayLayer = props.baseArrayLayer ?? 0;
+  const maximumArrayLayerCount = texture.dimension === '3d' ? 1 : texture.depth;
+  const arrayLayerCount = props.arrayLayerCount ?? maximumArrayLayerCount - baseArrayLayer;
+  for (const [name, value] of Object.entries({
+    baseMipLevel,
+    mipLevelCount,
+    baseArrayLayer,
+    arrayLayerCount
+  })) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(`Graph texture view ${name} must be a non-negative safe integer`);
+    }
+  }
+  if (mipLevelCount === 0 || baseMipLevel + mipLevelCount > texture.mipLevels) {
+    throw new Error(`Graph texture view exceeds texture "${texture.id}" mip levels`);
+  }
+  if (
+    arrayLayerCount === 0 ||
+    baseArrayLayer + arrayLayerCount > maximumArrayLayerCount ||
+    (texture.dimension === '3d' && (baseArrayLayer !== 0 || arrayLayerCount !== 1))
+  ) {
+    throw new Error(`Graph texture view exceeds texture "${texture.id}" array layers`);
+  }
+  const width = Math.max(1, texture.width >> baseMipLevel);
+  const height = texture.dimension === '1d' ? 1 : Math.max(1, texture.height >> baseMipLevel);
+  const depth =
+    texture.dimension === '3d' ? Math.max(1, texture.depth >> baseMipLevel) : arrayLayerCount;
+  return {
+    dimension,
+    aspect,
+    baseMipLevel,
+    mipLevelCount,
+    baseArrayLayer,
+    arrayLayerCount,
+    width,
+    height,
+    depth
+  };
 }
 
 function validateGraphBufferView(
@@ -599,12 +1185,69 @@ function validateImportedBuffer(
   }
 }
 
-function validateUseAgainstDescriptor(buffer: GraphBufferHandle, usage: GraphBufferUsage): void {
+function validateImportedTexture(
+  importedTexture: GraphImportedTexture,
+  descriptor: NormalizedGraphTextureDescriptor,
+  device: Device
+): void {
+  const texture = getCoreTexture(importedTexture);
+  if (texture.device !== device) {
+    throw new Error(`GPUCommandGraph texture "${descriptor.id}" belongs to another device`);
+  }
+  for (const [name, expected, actual] of [
+    ['format', descriptor.format, texture.format],
+    ['dimension', descriptor.dimension, texture.dimension],
+    ['width', descriptor.width, texture.width],
+    ['height', descriptor.height, texture.height],
+    ['depth', descriptor.depth, texture.depth],
+    ['mipLevels', descriptor.mipLevels, texture.mipLevels],
+    ['samples', descriptor.samples, texture.samples]
+  ] as const) {
+    if (actual !== expected) {
+      throw new Error(
+        `GPUCommandGraph texture "${descriptor.id}" has incompatible ${name} (${actual} !== ${expected})`
+      );
+    }
+  }
+  if ((texture.props.usage & descriptor.usage) !== descriptor.usage) {
+    throw new Error(`GPUCommandGraph texture "${descriptor.id}" has incompatible usage flags`);
+  }
+}
+
+function validateBufferUseAgainstDescriptor(
+  buffer: GraphBufferHandle,
+  usage: GraphBufferUsage
+): void {
   const requiredUsage = getRequiredBufferUsage(usage);
   if ((buffer.usage & requiredUsage) !== requiredUsage) {
     throw new Error(
       `GPUCommandGraph buffer "${buffer.id}" does not declare usage required by ${usage}`
     );
+  }
+}
+
+function validateTextureUseAgainstDescriptor(
+  texture: GraphTextureHandle,
+  usage: GraphTextureUsage
+): void {
+  const requiredUsage = getRequiredTextureUsage(usage);
+  if ((texture.usage & requiredUsage) !== requiredUsage) {
+    throw new Error(
+      `GPUCommandGraph texture "${texture.id}" does not declare usage required by ${usage}`
+    );
+  }
+}
+
+function validateTextureViewForUsage(
+  textureOrView: GraphTextureHandle | GraphTextureView,
+  usage: GraphTextureUsage
+): void {
+  if (
+    textureOrView instanceof GraphTextureView &&
+    usage.startsWith('storage-') &&
+    textureOrView.mipLevelCount !== 1
+  ) {
+    throw new Error('GPUCommandGraph storage texture views must contain exactly one mip level');
   }
 }
 
@@ -629,7 +1272,24 @@ function getRequiredBufferUsage(usage: GraphBufferUsage): number {
   }
 }
 
-function isReadUsage(usage: GraphBufferUsage): boolean {
+function getRequiredTextureUsage(usage: GraphTextureUsage): number {
+  switch (usage) {
+    case 'sampled':
+      return Texture.SAMPLE;
+    case 'storage-read':
+    case 'storage-write':
+    case 'storage-read-write':
+      return Texture.STORAGE;
+    case 'render-attachment':
+      return Texture.RENDER;
+    case 'copy-source':
+      return Texture.COPY_SRC;
+    case 'copy-destination':
+      return Texture.COPY_DST;
+  }
+}
+
+function isBufferReadUsage(usage: GraphBufferUsage): boolean {
   return (
     usage === 'storage-read' ||
     usage === 'storage-read-write' ||
@@ -641,9 +1301,28 @@ function isReadUsage(usage: GraphBufferUsage): boolean {
   );
 }
 
-function isWriteUsage(usage: GraphBufferUsage): boolean {
+function isBufferWriteUsage(usage: GraphBufferUsage): boolean {
   return (
     usage === 'storage-write' || usage === 'storage-read-write' || usage === 'copy-destination'
+  );
+}
+
+function isTextureReadUsage(usage: GraphTextureUsage): boolean {
+  return (
+    usage === 'sampled' ||
+    usage === 'storage-read' ||
+    usage === 'storage-read-write' ||
+    usage === 'render-attachment' ||
+    usage === 'copy-source'
+  );
+}
+
+function isTextureWriteUsage(usage: GraphTextureUsage): boolean {
+  return (
+    usage === 'storage-write' ||
+    usage === 'storage-read-write' ||
+    usage === 'render-attachment' ||
+    usage === 'copy-destination'
   );
 }
 
@@ -652,8 +1331,12 @@ function getNodeOrder<Parameters>(
 ): GPUCommandGraphNode<Parameters>[] {
   const nodeById = new Map(nodes.map(node => [node.id, node]));
   const dependencies = new Map<string, Set<string>>();
-  const lastWriter = new Map<GraphBufferHandle, string>();
-  const activeReaders = new Map<GraphBufferHandle, Set<string>>();
+  const lastBufferWriter = new Map<GraphBufferHandle, string>();
+  const activeBufferReaders = new Map<GraphBufferHandle, Set<string>>();
+  const textureHistory = new Map<
+    GraphTextureHandle,
+    {nodeId: string; resource: GraphTextureUse}[]
+  >();
 
   for (const node of nodes) {
     const nodeDependencies = new Set(node.dependsOn ?? []);
@@ -665,28 +1348,47 @@ function getNodeOrder<Parameters>(
       }
     }
     for (const resource of node.resources ?? []) {
-      const handle = getHandle(resource.buffer);
-      if (isReadUsage(resource.usage)) {
-        const writer = lastWriter.get(handle);
-        if (writer) {
-          nodeDependencies.add(writer);
+      if (isGraphBufferUse(resource)) {
+        const handle = getBufferHandle(resource.buffer);
+        if (isBufferReadUsage(resource.usage)) {
+          const writer = lastBufferWriter.get(handle);
+          if (writer) {
+            nodeDependencies.add(writer);
+          }
+          const readers = activeBufferReaders.get(handle) ?? new Set<string>();
+          readers.add(node.id);
+          activeBufferReaders.set(handle, readers);
         }
-        const readers = activeReaders.get(handle) ?? new Set<string>();
-        readers.add(node.id);
-        activeReaders.set(handle, readers);
-      }
-      if (isWriteUsage(resource.usage)) {
-        const writer = lastWriter.get(handle);
-        if (writer) {
-          nodeDependencies.add(writer);
+        if (isBufferWriteUsage(resource.usage)) {
+          const writer = lastBufferWriter.get(handle);
+          if (writer) {
+            nodeDependencies.add(writer);
+          }
+          for (const reader of activeBufferReaders.get(handle) ?? []) {
+            if (reader !== node.id) {
+              nodeDependencies.add(reader);
+            }
+          }
+          activeBufferReaders.set(handle, new Set());
+          lastBufferWriter.set(handle, node.id);
         }
-        for (const reader of activeReaders.get(handle) ?? []) {
-          if (reader !== node.id) {
-            nodeDependencies.add(reader);
+      } else {
+        const handle = getTextureHandle(resource.texture);
+        const history = textureHistory.get(handle) ?? [];
+        for (const previous of history) {
+          if (
+            previous.nodeId !== node.id &&
+            textureUsesOverlap(previous.resource, resource) &&
+            ((isTextureReadUsage(resource.usage) && isTextureWriteUsage(previous.resource.usage)) ||
+              (isTextureWriteUsage(resource.usage) &&
+                (isTextureReadUsage(previous.resource.usage) ||
+                  isTextureWriteUsage(previous.resource.usage))))
+          ) {
+            nodeDependencies.add(previous.nodeId);
           }
         }
-        activeReaders.set(handle, new Set());
-        lastWriter.set(handle, node.id);
+        history.push({nodeId: node.id, resource});
+        textureHistory.set(handle, history);
       }
     }
     nodeDependencies.delete(node.id);
@@ -717,27 +1419,71 @@ function getNodeOrder<Parameters>(
   return ordered;
 }
 
-function getTransientAllocationPlan<Parameters>(
+function textureUsesOverlap(left: GraphTextureUse, right: GraphTextureUse): boolean {
+  const leftHandle = getTextureHandle(left.texture);
+  const rightHandle = getTextureHandle(right.texture);
+  if (leftHandle !== rightHandle) {
+    return false;
+  }
+  const leftRange = getTextureSubresourceRange(left.texture);
+  const rightRange = getTextureSubresourceRange(right.texture);
+  return (
+    aspectsOverlap(leftRange.aspect, rightRange.aspect) &&
+    intervalsOverlap(
+      leftRange.baseMipLevel,
+      leftRange.mipLevelCount,
+      rightRange.baseMipLevel,
+      rightRange.mipLevelCount
+    ) &&
+    intervalsOverlap(
+      leftRange.baseArrayLayer,
+      leftRange.arrayLayerCount,
+      rightRange.baseArrayLayer,
+      rightRange.arrayLayerCount
+    )
+  );
+}
+
+function getTextureSubresourceRange(texture: GraphTextureHandle | GraphTextureView): {
+  aspect: GraphTextureAspect;
+  baseMipLevel: number;
+  mipLevelCount: number;
+  baseArrayLayer: number;
+  arrayLayerCount: number;
+} {
+  if (texture instanceof GraphTextureView) {
+    return texture;
+  }
+  return {
+    aspect: 'all',
+    baseMipLevel: 0,
+    mipLevelCount: texture.mipLevels,
+    baseArrayLayer: 0,
+    arrayLayerCount: texture.dimension === '3d' ? 1 : texture.depth
+  };
+}
+
+function aspectsOverlap(left: GraphTextureAspect, right: GraphTextureAspect): boolean {
+  return left === 'all' || right === 'all' || left === right;
+}
+
+function intervalsOverlap(
+  leftStart: number,
+  leftCount: number,
+  rightStart: number,
+  rightCount: number
+): boolean {
+  return leftStart < rightStart + rightCount && rightStart < leftStart + leftCount;
+}
+
+function getBufferTransientAllocationPlan<Parameters>(
   nodes: GPUCommandGraphNode<Parameters>[],
   buffers: Iterable<GraphBufferHandle>
-): TransientAllocation[] {
-  const lifetimes = new Map<GraphBufferHandle, {firstUse: number; lastUse: number}>();
-  nodes.forEach((node, nodeIndex) => {
-    for (const resource of node.resources ?? []) {
-      const handle = getHandle(resource.buffer);
-      if (!handle.transient) {
-        continue;
-      }
-      const lifetime = lifetimes.get(handle);
-      if (lifetime) {
-        lifetime.lastUse = nodeIndex;
-      } else {
-        lifetimes.set(handle, {firstUse: nodeIndex, lastUse: nodeIndex});
-      }
-    }
-  });
-
-  const allocations: TransientAllocation[] = [];
+): BufferTransientAllocation[] {
+  const lifetimes = getResourceLifetimes(nodes, resource =>
+    isGraphBufferUse(resource) ? getBufferHandle(resource.buffer) : null
+  );
+  const allocations: BufferTransientAllocation[] = [];
   const transientBuffers = Array.from(buffers)
     .filter(buffer => buffer.transient)
     .map(buffer => ({buffer, lifetime: lifetimes.get(buffer)}))
@@ -764,4 +1510,126 @@ function getTransientAllocationPlan<Parameters>(
     allocation.handles.push(buffer);
   }
   return allocations;
+}
+
+function getTextureTransientAllocationPlan<Parameters>(
+  nodes: GPUCommandGraphNode<Parameters>[],
+  textures: Iterable<GraphTextureHandle>
+): TextureTransientAllocation[] {
+  const lifetimes = getResourceLifetimes(nodes, resource =>
+    isGraphBufferUse(resource) ? null : getTextureHandle(resource.texture)
+  );
+  const allocations: TextureTransientAllocation[] = [];
+  const transientTextures = Array.from(textures)
+    .filter(texture => texture.transient)
+    .map(texture => ({texture, lifetime: lifetimes.get(texture)}))
+    .sort(
+      (left, right) =>
+        (left.lifetime?.firstUse ?? Number.MAX_SAFE_INTEGER) -
+        (right.lifetime?.firstUse ?? Number.MAX_SAFE_INTEGER)
+    );
+
+  for (const {texture, lifetime} of transientTextures) {
+    if (!lifetime) {
+      continue;
+    }
+    let allocation = allocations.find(
+      candidate =>
+        candidate.lastUse < lifetime.firstUse &&
+        areTextureDescriptorsCompatible(candidate.descriptor, texture)
+    );
+    if (!allocation) {
+      const descriptor = getNormalizedTextureDescriptor(texture);
+      allocation = {
+        descriptor,
+        byteLength: getTextureByteLength(texture),
+        lastUse: -1,
+        handles: []
+      };
+      allocations.push(allocation);
+    }
+    allocation.descriptor.usage |= texture.usage;
+    allocation.lastUse = lifetime.lastUse;
+    allocation.handles.push(texture);
+  }
+  return allocations;
+}
+
+function getResourceLifetimes<Parameters, Resource extends object>(
+  nodes: GPUCommandGraphNode<Parameters>[],
+  getResource: (resource: GraphResourceUse) => Resource | null
+): Map<Resource, {firstUse: number; lastUse: number}> {
+  const lifetimes = new Map<Resource, {firstUse: number; lastUse: number}>();
+  nodes.forEach((node, nodeIndex) => {
+    for (const resourceUse of node.resources ?? []) {
+      const resource = getResource(resourceUse);
+      if (!resource || !('transient' in resource) || !resource.transient) {
+        continue;
+      }
+      const lifetime = lifetimes.get(resource);
+      if (lifetime) {
+        lifetime.lastUse = nodeIndex;
+      } else {
+        lifetimes.set(resource, {firstUse: nodeIndex, lastUse: nodeIndex});
+      }
+    }
+  });
+  return lifetimes;
+}
+
+function getNormalizedTextureDescriptor(
+  texture: GraphTextureHandle
+): NormalizedGraphTextureDescriptor {
+  return {
+    id: texture.id,
+    format: texture.format,
+    width: texture.width,
+    height: texture.height,
+    usage: texture.usage,
+    dimension: texture.dimension,
+    depth: texture.depth,
+    mipLevels: texture.mipLevels,
+    samples: texture.samples
+  };
+}
+
+function areTextureDescriptorsCompatible(
+  descriptor: NormalizedGraphTextureDescriptor,
+  texture: GraphTextureHandle
+): boolean {
+  return (
+    descriptor.format === texture.format &&
+    descriptor.width === texture.width &&
+    descriptor.height === texture.height &&
+    descriptor.dimension === texture.dimension &&
+    descriptor.depth === texture.depth &&
+    descriptor.mipLevels === texture.mipLevels &&
+    descriptor.samples === texture.samples
+  );
+}
+
+function getTextureByteLength(texture: GraphTextureHandle): number {
+  let byteLength = 0;
+  for (let mipLevel = 0; mipLevel < texture.mipLevels; mipLevel++) {
+    byteLength += textureFormatDecoder.computeMemoryLayout({
+      format: texture.format,
+      width: Math.max(1, texture.width >> mipLevel),
+      height: texture.dimension === '1d' ? 1 : Math.max(1, texture.height >> mipLevel),
+      depth: texture.dimension === '3d' ? Math.max(1, texture.depth >> mipLevel) : texture.depth,
+      byteAlignment: 1
+    }).byteLength;
+  }
+  return byteLength * texture.samples;
+}
+
+function isDefaultGraphTextureView(view: GraphTextureView): boolean {
+  const texture = view.texture;
+  return (
+    view.dimension === texture.dimension &&
+    view.aspect === 'all' &&
+    view.baseMipLevel === 0 &&
+    view.mipLevelCount === texture.mipLevels &&
+    view.baseArrayLayer === 0 &&
+    view.arrayLayerCount === (texture.dimension === '3d' ? 1 : texture.depth)
+  );
 }

--- a/modules/experimental/src/gpu-primitives/gpu-compaction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-compaction.ts
@@ -2,13 +2,17 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {GPUCommandGraph, type GraphBufferView} from './gpu-command-graph';
-import {GPUScan, getViewBinding, getViewElementOffset, validatePackedUint32View} from './gpu-scan';
+import {GPUScan} from './gpu-scan';
+import {
+  createTransientView,
+  getViewBinding,
+  getViewElementOffset,
+  validatePackedUint32View
+} from './graph-buffer-view-utils';
 
 const COMPACTION_WORKGROUP_SIZE = 256;
-const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 
 export type GPUCompactionProps = {
   id?: string;
@@ -60,15 +64,7 @@ export class GPUCompaction {
       return;
     }
 
-    const offsetsBuffer = graph.createTransientBuffer({
-      id: `${this.id}-offsets`,
-      byteLength: this.input.length * UINT32_BYTE_LENGTH,
-      usage: Buffer.STORAGE
-    });
-    const offsets = graph.createBufferView(offsetsBuffer, {
-      format: 'uint32',
-      length: this.input.length
-    });
+    const offsets = createTransientView(graph, `${this.id}-offsets`, 'uint32', this.input.length);
     new GPUScan({
       id: `${this.id}-scan`,
       input: this.flags,

--- a/modules/experimental/src/gpu-primitives/gpu-grid-binning.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-grid-binning.ts
@@ -1,0 +1,262 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {type Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphBufferUse, type GraphBufferView} from './gpu-command-graph';
+import {
+  getViewBinding,
+  getViewElementOffset,
+  validatePackedUint32View,
+  validatePackedView
+} from './graph-buffer-view-utils';
+
+const GRID_WORKGROUP_SIZE = 256;
+const MAXIMUM_LOCAL_CELL_COUNT = 256;
+
+/** Bounds accepted by {@link GPUGridBinning}. */
+export type GPUGridBinningBounds =
+  | readonly [number, number, number, number]
+  | GraphBufferView<'float32x4'>;
+
+/** Properties for graph-native two-dimensional grid counting. */
+export type GPUGridBinningProps = {
+  id?: string;
+  positions: GraphBufferView<'float32x2'>;
+  output: GraphBufferView<'uint32'>;
+  gridSize: readonly [number, number];
+  bounds: GPUGridBinningBounds;
+};
+
+/** Graph-native row-major count accumulation for packed float32x2 positions. */
+export class GPUGridBinning {
+  readonly id: string;
+  readonly positions: GraphBufferView<'float32x2'>;
+  readonly output: GraphBufferView<'uint32'>;
+  readonly gridSize: readonly [number, number];
+  readonly bounds: GPUGridBinningBounds;
+
+  constructor(props: GPUGridBinningProps) {
+    this.id = props.id ?? 'gpu-grid-binning';
+    this.positions = props.positions;
+    this.output = props.output;
+    this.gridSize = props.gridSize;
+    this.bounds = props.bounds;
+    validatePackedView(this.positions, ['float32x2'], `${this.id} positions`);
+    validatePackedUint32View(this.output, `${this.id} output`);
+    const [width, height] = this.gridSize;
+    if (
+      !Number.isSafeInteger(width) ||
+      !Number.isSafeInteger(height) ||
+      width <= 0 ||
+      height <= 0
+    ) {
+      throw new Error(`${this.id} gridSize must contain two positive integers`);
+    }
+    if (this.output.length !== width * height) {
+      throw new Error(`${this.id} output.length must equal gridSize width * height`);
+    }
+    if (this.positions.buffer === this.output.buffer) {
+      throw new Error(`${this.id} positions and output must use separate buffers`);
+    }
+    if (Array.isArray(this.bounds)) {
+      const [minimumX, minimumY, maximumX, maximumY] = this.bounds;
+      if (
+        this.bounds.length !== 4 ||
+        !this.bounds.every(Number.isFinite) ||
+        minimumX > maximumX ||
+        minimumY > maximumY
+      ) {
+        throw new Error(`${this.id} literal bounds must be finite [minX, minY, maxX, maxY]`);
+      }
+    } else if (isGPUGridBoundsView(this.bounds)) {
+      validatePackedView(this.bounds, ['float32x4'], `${this.id} bounds`);
+      if (this.bounds.length !== 1) {
+        throw new Error(`${this.id} GPU bounds must contain one float32x4 row`);
+      }
+      if (this.bounds.buffer === this.output.buffer) {
+        throw new Error(`${this.id} bounds and output must use separate buffers`);
+      }
+    }
+  }
+
+  /** Adds output clearing and grid accumulation nodes to a graph. */
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    if (this.positions.buffer.graph !== graph || this.output.buffer.graph !== graph) {
+      throw new Error(`${this.id} views must belong to the target graph`);
+    }
+    if (isGPUGridBoundsView(this.bounds) && this.bounds.buffer.graph !== graph) {
+      throw new Error(`${this.id} bounds must belong to the target graph`);
+    }
+    addClearGridPass(graph, this.id, this.output);
+    if (this.positions.length > 0) {
+      addGridPass(graph, this);
+    }
+  }
+}
+
+function addClearGridPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  output: GraphBufferView<'uint32'>
+): void {
+  const passId = `${id}-clear`;
+  const source = /* wgsl */ `
+const CELL_COUNT: u32 = ${output.length}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
+@group(0) @binding(0) var<storage, read_write> outputCounts: array<atomic<u32>>;
+@compute @workgroup_size(${GRID_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  if (globalId.x < CELL_COUNT) { atomicStore(&outputCounts[OUTPUT_OFFSET + globalId.x], 0u); }
+}`;
+  addComputationPass(graph, {
+    id: passId,
+    source,
+    resources: [{buffer: output, usage: 'storage-write'}],
+    bindings: {outputCounts: output},
+    dispatchCount: Math.ceil(output.length / GRID_WORKGROUP_SIZE)
+  });
+}
+
+function addGridPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  binning: GPUGridBinning
+): void {
+  const [width, height] = binning.gridSize;
+  const local = binning.output.length <= MAXIMUM_LOCAL_CELL_COUNT;
+  const gpuBounds = isGPUGridBoundsView(binning.bounds);
+  const literalBounds = binning.bounds as readonly [number, number, number, number];
+  const boundsBinding = gpuBounds
+    ? '@group(0) @binding(1) var<storage, read> boundsValues: array<f32>;'
+    : '';
+  const outputBinding = gpuBounds ? 2 : 1;
+  const boundsInitialization = gpuBounds
+    ? `let minimumX = boundsValues[BOUNDS_OFFSET];
+  let minimumY = boundsValues[BOUNDS_OFFSET + 1u];
+  let maximumX = boundsValues[BOUNDS_OFFSET + 2u];
+  let maximumY = boundsValues[BOUNDS_OFFSET + 3u];`
+    : `let minimumX = ${getFloatLiteral(literalBounds[0])};
+  let minimumY = ${getFloatLiteral(literalBounds[1])};
+  let maximumX = ${getFloatLiteral(literalBounds[2])};
+  let maximumY = ${getFloatLiteral(literalBounds[3])};`;
+  const accumulation = local
+    ? `if (accepted) { atomicAdd(&localCounts[cellIndex], 1u); }
+  workgroupBarrier();
+  if (lane < CELL_COUNT) {
+    atomicAdd(&outputCounts[OUTPUT_OFFSET + lane], atomicLoad(&localCounts[lane]));
+  }`
+    : 'if (accepted) { atomicAdd(&outputCounts[OUTPUT_OFFSET + cellIndex], 1u); }';
+  const source = /* wgsl */ `
+const ELEMENT_COUNT: u32 = ${binning.positions.length}u;
+const WIDTH: u32 = ${width}u;
+const HEIGHT: u32 = ${height}u;
+const CELL_COUNT: u32 = ${binning.output.length}u;
+const POSITIONS_OFFSET: u32 = ${getViewElementOffset(binning.positions)}u;
+${gpuBounds ? `const BOUNDS_OFFSET: u32 = ${getViewElementOffset(binning.bounds as GraphBufferView)}u;` : ''}
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(binning.output)}u;
+@group(0) @binding(0) var<storage, read> positions: array<f32>;
+${boundsBinding}
+@group(0) @binding(${outputBinding}) var<storage, read_write> outputCounts: array<atomic<u32>>;
+${local ? `var<workgroup> localCounts: array<atomic<u32>, ${binning.output.length}>;` : ''}
+
+fn getCoordinate(value: f32, minimum: f32, maximum: f32, size: u32) -> u32 {
+  if (maximum == minimum || value == minimum) { return 0u; }
+  if (value == maximum) { return size - 1u; }
+  return min(u32((value - minimum) / (maximum - minimum) * f32(size)), size - 1u);
+}
+
+@compute @workgroup_size(${GRID_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>
+) {
+  let index = globalId.x;
+  let lane = localId.x;
+  ${boundsInitialization}
+  ${local ? 'if (lane < CELL_COUNT) { atomicStore(&localCounts[lane], 0u); }\n  workgroupBarrier();' : ''}
+  var accepted = false;
+  var cellIndex = 0u;
+  if (index < ELEMENT_COUNT && maximumX >= minimumX && maximumY >= minimumY) {
+    let x = positions[POSITIONS_OFFSET + index * 2u];
+    let y = positions[POSITIONS_OFFSET + index * 2u + 1u];
+    let finite = x == x && y == y && abs(x) <= 3.402823466e+38 && abs(y) <= 3.402823466e+38;
+    let inX = x >= minimumX && x <= maximumX && (maximumX != minimumX || x == minimumX);
+    let inY = y >= minimumY && y <= maximumY && (maximumY != minimumY || y == minimumY);
+    if (finite && inX && inY) {
+      accepted = true;
+      let column = getCoordinate(x, minimumX, maximumX, WIDTH);
+      let row = getCoordinate(y, minimumY, maximumY, HEIGHT);
+      cellIndex = row * WIDTH + column;
+    }
+  }
+  ${accumulation}
+}`;
+  const resources: GraphBufferUse[] = [
+    {buffer: binning.positions, usage: 'storage-read'},
+    ...(gpuBounds
+      ? ([{buffer: binning.bounds as GraphBufferView, usage: 'storage-read'}] as GraphBufferUse[])
+      : []),
+    {buffer: binning.output, usage: 'storage-read-write'}
+  ];
+  addComputationPass(graph, {
+    id: `${binning.id}-${local ? 'local' : 'global'}`,
+    source,
+    resources,
+    bindings: {
+      positions: binning.positions,
+      ...(gpuBounds ? {boundsValues: binning.bounds as GraphBufferView} : {}),
+      outputCounts: binning.output
+    },
+    dispatchCount: Math.ceil(binning.positions.length / GRID_WORKGROUP_SIZE)
+  });
+}
+
+function addComputationPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    source: string;
+    resources: GraphBufferUse[];
+    bindings: Record<string, GraphBufferView>;
+    dispatchCount: number;
+  }
+): void {
+  graph.addComputePass({
+    id: props.id,
+    resources: props.resources,
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: props.id,
+        source: props.source,
+        shaderLayout: {
+          bindings: Object.keys(props.bindings).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const [name, view] of Object.entries(props.bindings)) {
+            bindings[name] = getViewBinding(view, getBuffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatch(computePass, props.dispatchCount);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function getFloatLiteral(value: number): string {
+  return Number.isInteger(value) ? `${value}.0` : `${value}`;
+}
+
+function isGPUGridBoundsView(bounds: GPUGridBinningBounds): bounds is GraphBufferView<'float32x4'> {
+  return !Array.isArray(bounds);
+}

--- a/modules/experimental/src/gpu-primitives/gpu-histogram.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-histogram.ts
@@ -150,6 +150,52 @@ function addHistogramPass<Parameters, T extends GPUScalarFormat>(
   let maximum: ${shaderType} = ${getLiteral(literalDomain[1], props.input.format)};`;
   const finiteCondition =
     props.input.format === 'float32' ? 'value == value && abs(value) <= 3.402823466e+38' : 'true';
+  const integerMultiplierBitCount = 32 - Math.clz32(props.output.length);
+  const integerBinningFunction =
+    props.input.format === 'float32'
+      ? ''
+      : `fn multiplyDivideFloor(numerator: u32, multiplier: u32, denominator: u32) -> u32 {
+  var quotient = 0u;
+  var remainder = 0u;
+  var bitIndex = ${integerMultiplierBitCount}u;
+  loop {
+    bitIndex = bitIndex - 1u;
+    // Double and add modulo denominator without overflowing u32.
+    let doubledThreshold = denominator - remainder;
+    if (remainder >= doubledThreshold) {
+      remainder = remainder - doubledThreshold;
+      quotient = quotient * 2u + 1u;
+    } else {
+      remainder = remainder * 2u;
+      quotient = quotient * 2u;
+    }
+    if (((multiplier >> bitIndex) & 1u) != 0u) {
+      let additionThreshold = denominator - numerator;
+      if (remainder >= additionThreshold) {
+        remainder = remainder - additionThreshold;
+        quotient = quotient + 1u;
+      } else {
+        remainder = remainder + numerator;
+      }
+    }
+    if (bitIndex == 0u) { break; }
+  }
+  return quotient;
+}`;
+  const binCalculation =
+    props.input.format === 'float32'
+      ? `let ratio = (value - minimum) / (maximum - minimum);
+          binIndex = min(u32(ratio * f32(BIN_COUNT)), BIN_COUNT - 1u);`
+      : props.input.format === 'uint32'
+        ? 'binIndex = multiplyDivideFloor(value - minimum, BIN_COUNT, maximum - minimum);'
+        : `let orderedValue = bitcast<u32>(value) ^ 0x80000000u;
+          let orderedMinimum = bitcast<u32>(minimum) ^ 0x80000000u;
+          let orderedMaximum = bitcast<u32>(maximum) ^ 0x80000000u;
+          binIndex = multiplyDivideFloor(
+            orderedValue - orderedMinimum,
+            BIN_COUNT,
+            orderedMaximum - orderedMinimum
+          );`;
   const accumulation = local
     ? `if (accepted) { atomicAdd(&localCounts[binIndex], 1u); }
   workgroupBarrier();
@@ -167,6 +213,7 @@ const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
 ${domainBinding}
 @group(0) @binding(${outputBinding}) var<storage, read_write> outputCounts: array<atomic<u32>>;
 ${local ? `var<workgroup> localCounts: array<atomic<u32>, ${props.output.length}>;` : ''}
+${integerBinningFunction}
 
 @compute @workgroup_size(${HISTOGRAM_WORKGROUP_SIZE}) fn main(
   @builtin(global_invocation_id) globalId: vec3<u32>,
@@ -188,8 +235,7 @@ ${local ? `var<workgroup> localCounts: array<atomic<u32>, ${props.output.length}
         if (value == maximum) {
           binIndex = BIN_COUNT - 1u;
         } else {
-          let ratio = (f32(value) - f32(minimum)) / (f32(maximum) - f32(minimum));
-          binIndex = min(u32(ratio * f32(BIN_COUNT)), BIN_COUNT - 1u);
+          ${binCalculation}
         }
       }
     }

--- a/modules/experimental/src/gpu-primitives/gpu-histogram.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-histogram.ts
@@ -1,0 +1,291 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {type Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphBufferUse, type GraphBufferView} from './gpu-command-graph';
+import {
+  createTransientView,
+  getViewBinding,
+  getViewElementOffset,
+  type GPUScalarFormat,
+  validatePackedUint32View,
+  validatePackedView
+} from './graph-buffer-view-utils';
+import {GPUReduction} from './gpu-reduction';
+
+const HISTOGRAM_WORKGROUP_SIZE = 256;
+const MAXIMUM_LOCAL_BIN_COUNT = 256;
+const SCALAR_FORMATS = ['uint32', 'sint32', 'float32'] as const;
+
+/** Domain accepted by {@link GPUHistogram}. */
+export type GPUHistogramDomain<T extends GPUScalarFormat = GPUScalarFormat> =
+  | readonly [number, number]
+  | GraphBufferView<T>
+  | 'auto';
+
+/** Properties for graph-native scalar histogram counting. */
+export type GPUHistogramProps<T extends GPUScalarFormat = GPUScalarFormat> = {
+  id?: string;
+  input: GraphBufferView<T>;
+  output: GraphBufferView<'uint32'>;
+  domain: GPUHistogramDomain<T>;
+};
+
+/** Graph-native histogram counting for packed 32-bit scalar values. */
+export class GPUHistogram<T extends GPUScalarFormat = GPUScalarFormat> {
+  readonly id: string;
+  readonly input: GraphBufferView<T>;
+  readonly output: GraphBufferView<'uint32'>;
+  readonly domain: GPUHistogramDomain<T>;
+
+  constructor(props: GPUHistogramProps<T>) {
+    this.id = props.id ?? 'gpu-histogram';
+    this.input = props.input;
+    this.output = props.output;
+    this.domain = props.domain;
+    validatePackedView(this.input, SCALAR_FORMATS, `${this.id} input`);
+    validatePackedUint32View(this.output, `${this.id} output`);
+    if (this.output.length === 0) {
+      throw new Error(`${this.id} output must contain at least one bin`);
+    }
+    if (this.input.buffer === this.output.buffer) {
+      throw new Error(`${this.id} input and output must use separate buffers`);
+    }
+    if (isGPUHistogramDomainView(this.domain)) {
+      validatePackedView(this.domain, SCALAR_FORMATS, `${this.id} domain`);
+      if (this.domain.format !== this.input.format || this.domain.length !== 2) {
+        throw new Error(`${this.id} GPU domain must contain two ${this.input.format} rows`);
+      }
+      if (this.domain.buffer === this.output.buffer) {
+        throw new Error(`${this.id} domain and output must use separate buffers`);
+      }
+    } else if (Array.isArray(this.domain)) {
+      validateLiteralDomain(this.domain, this.input.format, this.id);
+    }
+  }
+
+  /** Adds domain inference, output clearing, and accumulation nodes to a graph. */
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    if (this.input.buffer.graph !== graph || this.output.buffer.graph !== graph) {
+      throw new Error(`${this.id} views must belong to the target graph`);
+    }
+    let domain = this.domain;
+    if (isGPUHistogramDomainView(domain) && domain.buffer.graph !== graph) {
+      throw new Error(`${this.id} domain must belong to the target graph`);
+    }
+    if (domain === 'auto') {
+      const inferredDomain = createTransientView(
+        graph,
+        `${this.id}-auto-domain`,
+        this.input.format,
+        2
+      ) as GraphBufferView<T>;
+      new GPUReduction({
+        id: `${this.id}-extent`,
+        input: this.input,
+        output: inferredDomain,
+        operation: 'extent'
+      }).addToGraph(graph);
+      domain = inferredDomain;
+    }
+    addClearHistogramPass(graph, this.id, this.output);
+    if (this.input.length > 0) {
+      addHistogramPass(graph, {
+        id: `${this.id}-${this.output.length <= MAXIMUM_LOCAL_BIN_COUNT ? 'local' : 'global'}`,
+        input: this.input,
+        output: this.output,
+        domain
+      });
+    }
+  }
+}
+
+function addClearHistogramPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  output: GraphBufferView<'uint32'>
+): void {
+  const passId = `${id}-clear`;
+  const source = /* wgsl */ `
+const BIN_COUNT: u32 = ${output.length}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
+@group(0) @binding(0) var<storage, read_write> outputCounts: array<atomic<u32>>;
+@compute @workgroup_size(${HISTOGRAM_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  if (globalId.x < BIN_COUNT) { atomicStore(&outputCounts[OUTPUT_OFFSET + globalId.x], 0u); }
+}`;
+  addComputationPass(graph, {
+    id: passId,
+    source,
+    resources: [{buffer: output, usage: 'storage-write'}],
+    bindings: {outputCounts: output},
+    dispatchCount: Math.ceil(output.length / HISTOGRAM_WORKGROUP_SIZE)
+  });
+}
+
+function addHistogramPass<Parameters, T extends GPUScalarFormat>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    input: GraphBufferView<T>;
+    output: GraphBufferView<'uint32'>;
+    domain: readonly [number, number] | GraphBufferView<T>;
+  }
+): void {
+  const local = props.output.length <= MAXIMUM_LOCAL_BIN_COUNT;
+  const shaderType = getShaderType(props.input.format);
+  const gpuDomain = isGPUHistogramDomainView(props.domain);
+  const literalDomain = props.domain as readonly [number, number];
+  const domainBinding = gpuDomain
+    ? '@group(0) @binding(1) var<storage, read> domainValues: array<' + shaderType + '>;'
+    : '';
+  const outputBinding = gpuDomain ? 2 : 1;
+  const domainInitialization = gpuDomain
+    ? `let minimum: ${shaderType} = domainValues[DOMAIN_OFFSET];
+  let maximum: ${shaderType} = domainValues[DOMAIN_OFFSET + 1u];`
+    : `let minimum: ${shaderType} = ${getLiteral(literalDomain[0], props.input.format)};
+  let maximum: ${shaderType} = ${getLiteral(literalDomain[1], props.input.format)};`;
+  const finiteCondition =
+    props.input.format === 'float32' ? 'value == value && abs(value) <= 3.402823466e+38' : 'true';
+  const accumulation = local
+    ? `if (accepted) { atomicAdd(&localCounts[binIndex], 1u); }
+  workgroupBarrier();
+  if (lane < BIN_COUNT) {
+    atomicAdd(&outputCounts[OUTPUT_OFFSET + lane], atomicLoad(&localCounts[lane]));
+  }`
+    : 'if (accepted) { atomicAdd(&outputCounts[OUTPUT_OFFSET + binIndex], 1u); }';
+  const source = /* wgsl */ `
+const ELEMENT_COUNT: u32 = ${props.input.length}u;
+const BIN_COUNT: u32 = ${props.output.length}u;
+const INPUT_OFFSET: u32 = ${getViewElementOffset(props.input)}u;
+${gpuDomain ? `const DOMAIN_OFFSET: u32 = ${getViewElementOffset(props.domain as GraphBufferView)}u;` : ''}
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
+@group(0) @binding(0) var<storage, read> inputValues: array<${shaderType}>;
+${domainBinding}
+@group(0) @binding(${outputBinding}) var<storage, read_write> outputCounts: array<atomic<u32>>;
+${local ? `var<workgroup> localCounts: array<atomic<u32>, ${props.output.length}>;` : ''}
+
+@compute @workgroup_size(${HISTOGRAM_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>
+) {
+  let index = globalId.x;
+  let lane = localId.x;
+  ${domainInitialization}
+  ${local ? 'if (lane < BIN_COUNT) { atomicStore(&localCounts[lane], 0u); }\n  workgroupBarrier();' : ''}
+  var accepted = false;
+  var binIndex = 0u;
+  if (index < ELEMENT_COUNT && maximum >= minimum) {
+    let value = inputValues[INPUT_OFFSET + index];
+    if (${finiteCondition} && value >= minimum && value <= maximum) {
+      if (maximum == minimum) {
+        accepted = value == minimum;
+      } else {
+        accepted = true;
+        if (value == maximum) {
+          binIndex = BIN_COUNT - 1u;
+        } else {
+          let ratio = (f32(value) - f32(minimum)) / (f32(maximum) - f32(minimum));
+          binIndex = min(u32(ratio * f32(BIN_COUNT)), BIN_COUNT - 1u);
+        }
+      }
+    }
+  }
+  ${accumulation}
+}`;
+  const resources: GraphBufferUse[] = [
+    {buffer: props.input, usage: 'storage-read'},
+    ...(gpuDomain
+      ? ([{buffer: props.domain as GraphBufferView, usage: 'storage-read'}] as GraphBufferUse[])
+      : []),
+    {buffer: props.output, usage: 'storage-read-write'}
+  ];
+  addComputationPass(graph, {
+    id: props.id,
+    source,
+    resources,
+    bindings: {
+      inputValues: props.input,
+      ...(gpuDomain ? {domainValues: props.domain as GraphBufferView} : {}),
+      outputCounts: props.output
+    },
+    dispatchCount: Math.ceil(props.input.length / HISTOGRAM_WORKGROUP_SIZE)
+  });
+}
+
+function addComputationPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    source: string;
+    resources: GraphBufferUse[];
+    bindings: Record<string, GraphBufferView>;
+    dispatchCount: number;
+  }
+): void {
+  graph.addComputePass({
+    id: props.id,
+    resources: props.resources,
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: props.id,
+        source: props.source,
+        shaderLayout: {
+          bindings: Object.keys(props.bindings).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const [name, view] of Object.entries(props.bindings)) {
+            bindings[name] = getViewBinding(view, getBuffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatch(computePass, props.dispatchCount);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function validateLiteralDomain(
+  domain: readonly number[],
+  format: GPUScalarFormat,
+  id: string
+): void {
+  if (domain.length !== 2 || !domain.every(Number.isFinite) || domain[0] > domain[1]) {
+    throw new Error(`${id} literal domain must be a finite [min, max] pair`);
+  }
+  if (format !== 'float32') {
+    const minimum = format === 'uint32' ? 0 : -0x80000000;
+    const maximum = format === 'uint32' ? 0xffffffff : 0x7fffffff;
+    if (!domain.every(value => Number.isInteger(value) && value >= minimum && value <= maximum)) {
+      throw new Error(`${id} literal domain values must fit ${format}`);
+    }
+  }
+}
+
+function isGPUHistogramDomainView<T extends GPUScalarFormat>(
+  domain: GPUHistogramDomain<T>
+): domain is GraphBufferView<T> {
+  return domain !== 'auto' && !Array.isArray(domain);
+}
+
+function getShaderType(format: GPUScalarFormat): 'u32' | 'i32' | 'f32' {
+  return format === 'uint32' ? 'u32' : format === 'sint32' ? 'i32' : 'f32';
+}
+
+function getLiteral(value: number, format: GPUScalarFormat): string {
+  if (format === 'uint32') return `${value}u`;
+  if (format === 'sint32') return `${value}`;
+  return Number.isInteger(value) ? `${value}.0` : `${value}`;
+}

--- a/modules/experimental/src/gpu-primitives/gpu-index-picking-target.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-index-picking-target.ts
@@ -1,0 +1,180 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, Texture} from '@luma.gl/core';
+import type {RenderPassProps} from '@luma.gl/core';
+import type {PickInfo} from '@luma.gl/engine';
+import {
+  GPUCommandGraph,
+  type GraphBufferHandle,
+  type GraphRenderPassAttachments,
+  type GraphTextureView
+} from './gpu-command-graph';
+
+const INDEX_PICKING_READBACK_BYTE_LENGTH = 256;
+const INDEX_PICKING_INVALID_INDEX = -1;
+
+export type GPUIndexPickingTargetProps = {
+  id?: string;
+  width: number;
+  height: number;
+  /** Optional caller-owned default. Per-encoding graph buffer overrides remain supported. */
+  readbackBuffer?: Buffer;
+};
+
+export type GPUIndexPickingReadbackProps<Parameters> = {
+  id?: string;
+  /** Render node that must complete before the texture-to-buffer copy. */
+  after: string;
+  /** Returns a WebGPU device-pixel coordinate for this encoding. */
+  getPixel: (parameters: Parameters) => readonly [number, number];
+};
+
+/**
+ * Fixed-size graph texture target for WebGPU integer object picking.
+ *
+ * The helper owns only logical graph declarations. Applications retain ownership of rendering,
+ * command submission, staging buffers, readback timing, decoded state, and highlighting.
+ */
+export class GPUIndexPickingTarget<Parameters = void> {
+  readonly id: string;
+  readonly width: number;
+  readonly height: number;
+  readonly colorAttachment: GraphTextureView<'rgba8unorm'>;
+  readonly indexAttachment: GraphTextureView<'rg32sint'>;
+  readonly depthStencilAttachment: GraphTextureView<'depth24plus'>;
+  readonly attachments: GraphRenderPassAttachments;
+  readonly renderPassProps: Pick<RenderPassProps, 'clearColors' | 'clearDepth'>;
+  readonly readback: GraphBufferHandle;
+
+  private readonly graph: GPUCommandGraph<Parameters>;
+  private readbackPassAdded = false;
+
+  constructor(graph: GPUCommandGraph<Parameters>, props: GPUIndexPickingTargetProps) {
+    validatePickingTargetSize(props.width, props.height);
+    this.graph = graph;
+    this.id = props.id ?? 'gpu-index-picking';
+    this.width = props.width;
+    this.height = props.height;
+
+    const colorTexture = graph.createTransientTexture({
+      id: `${this.id}-color`,
+      format: 'rgba8unorm',
+      width: this.width,
+      height: this.height,
+      usage: Texture.RENDER
+    });
+    const indexTexture = graph.createTransientTexture({
+      id: `${this.id}-indices`,
+      format: 'rg32sint',
+      width: this.width,
+      height: this.height,
+      usage: Texture.RENDER | Texture.COPY_SRC
+    });
+    const depthStencilTexture = graph.createTransientTexture({
+      id: `${this.id}-depth`,
+      format: 'depth24plus',
+      width: this.width,
+      height: this.height,
+      usage: Texture.RENDER
+    });
+
+    this.colorAttachment = graph.createTextureView(colorTexture);
+    this.indexAttachment = graph.createTextureView(indexTexture);
+    this.depthStencilAttachment = graph.createTextureView(depthStencilTexture);
+    this.attachments = {
+      colorAttachments: [this.colorAttachment, this.indexAttachment],
+      depthStencilAttachment: this.depthStencilAttachment
+    };
+    this.renderPassProps = {
+      clearColors: [
+        new Float32Array([0, 0, 0, 0]),
+        new Int32Array([INDEX_PICKING_INVALID_INDEX, INDEX_PICKING_INVALID_INDEX, 0, 0])
+      ],
+      clearDepth: 1
+    };
+    this.readback = graph.importBuffer(
+      {
+        id: `${this.id}-readback`,
+        byteLength: INDEX_PICKING_READBACK_BYTE_LENGTH,
+        usage: Buffer.COPY_DST | Buffer.MAP_READ
+      },
+      props.readbackBuffer
+    );
+  }
+
+  /** Adds one explicit single-pixel texture-to-buffer copy after the picking render node. */
+  addReadbackPass(props: GPUIndexPickingReadbackProps<Parameters>): void {
+    if (this.readbackPassAdded) {
+      throw new Error(`${this.id} readback pass has already been added`);
+    }
+    this.readbackPassAdded = true;
+    this.graph.addCopyPass({
+      id: props.id ?? `${this.id}-readback`,
+      dependsOn: [props.after],
+      resources: [
+        {texture: this.indexAttachment, usage: 'copy-source'},
+        {buffer: this.readback, usage: 'copy-destination'}
+      ],
+      compile: () => ({
+        encode: ({commandEncoder, parameters, getBuffer, getTexture}) => {
+          const [x, y] = props.getPixel(parameters);
+          validatePickingPixel(x, y, this.width, this.height);
+          commandEncoder.copyTextureToBuffer({
+            sourceTexture: getTexture(this.indexAttachment),
+            mipLevel: this.indexAttachment.baseMipLevel,
+            origin: [x, y, this.indexAttachment.baseArrayLayer],
+            width: 1,
+            height: 1,
+            depthOrArrayLayers: 1,
+            destinationBuffer: getBuffer(this.readback),
+            byteOffset: 0,
+            bytesPerRow: INDEX_PICKING_READBACK_BYTE_LENGTH,
+            rowsPerImage: 1
+          });
+        }
+      })
+    });
+  }
+}
+
+/** Decodes the first `rg32sint` texel copied into a picking readback buffer. */
+export function decodeGPUIndexPickInfo(data: ArrayBuffer | ArrayBufferView): PickInfo {
+  const byteOffset = ArrayBuffer.isView(data) ? data.byteOffset : 0;
+  const byteLength = ArrayBuffer.isView(data) ? data.byteLength : data.byteLength;
+  const buffer = ArrayBuffer.isView(data) ? data.buffer : data;
+  if (byteLength < Int32Array.BYTES_PER_ELEMENT * 2) {
+    throw new Error('GPU index picking readback requires at least eight bytes');
+  }
+  const view = new DataView(buffer, byteOffset, byteLength);
+  const objectIndex = view.getInt32(0, true);
+  const batchIndex = view.getInt32(Int32Array.BYTES_PER_ELEMENT, true);
+  return {
+    objectIndex: objectIndex === INDEX_PICKING_INVALID_INDEX ? null : objectIndex,
+    batchIndex: batchIndex === INDEX_PICKING_INVALID_INDEX ? null : batchIndex
+  };
+}
+
+function validatePickingTargetSize(width: number, height: number): void {
+  if (!Number.isSafeInteger(width) || width <= 0 || !Number.isSafeInteger(height) || height <= 0) {
+    throw new Error('GPUIndexPickingTarget requires positive integer width and height');
+  }
+}
+
+function validatePickingPixel(x: number, y: number, width: number, height: number): void {
+  if (
+    !Number.isSafeInteger(x) ||
+    !Number.isSafeInteger(y) ||
+    x < 0 ||
+    y < 0 ||
+    x >= width ||
+    y >= height
+  ) {
+    throw new Error(
+      `GPUIndexPickingTarget pixel [${x}, ${y}] is outside ${width}x${height} target`
+    );
+  }
+}
+
+export {INDEX_PICKING_READBACK_BYTE_LENGTH};

--- a/modules/experimental/src/gpu-primitives/gpu-reduction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-reduction.ts
@@ -1,0 +1,363 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {type Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphBufferUse, type GraphBufferView} from './gpu-command-graph';
+import {
+  createTransientView,
+  getViewBinding,
+  getViewElementOffset,
+  type GPUScalarFormat,
+  validatePackedView
+} from './graph-buffer-view-utils';
+
+const REDUCTION_WORKGROUP_SIZE = 256;
+const SCALAR_FORMATS = ['uint32', 'sint32', 'float32'] as const;
+
+/** Operation performed by {@link GPUReduction}. */
+export type GPUReductionOperation = 'sum' | 'min' | 'max' | 'extent';
+
+/** Properties for a graph-native scalar reduction. */
+export type GPUReductionProps<T extends GPUScalarFormat = GPUScalarFormat> = {
+  id?: string;
+  input: GraphBufferView<T>;
+  output: GraphBufferView<T>;
+  operation: GPUReductionOperation;
+};
+
+/**
+ * Hierarchical reduction over packed 32-bit scalar graph views.
+ *
+ * @remarks Inputs and outputs are caller-owned. Hierarchical scratch is graph-owned, and adding
+ * the reduction to a graph never submits work or reads data back.
+ */
+export class GPUReduction<T extends GPUScalarFormat = GPUScalarFormat> {
+  readonly id: string;
+  readonly input: GraphBufferView<T>;
+  readonly output: GraphBufferView<T>;
+  readonly operation: GPUReductionOperation;
+
+  constructor(props: GPUReductionProps<T>) {
+    this.id = props.id ?? 'gpu-reduction';
+    this.input = props.input;
+    this.output = props.output;
+    this.operation = props.operation;
+    validatePackedView(this.input, SCALAR_FORMATS, `${this.id} input`);
+    validatePackedView(this.output, SCALAR_FORMATS, `${this.id} output`);
+    if (this.input.format !== this.output.format) {
+      throw new Error(`${this.id} input and output formats must match`);
+    }
+    if (!['sum', 'min', 'max', 'extent'].includes(this.operation)) {
+      throw new Error(`${this.id} operation must be sum, min, max, or extent`);
+    }
+    const outputLength = this.operation === 'extent' ? 2 : 1;
+    if (this.output.length !== outputLength) {
+      throw new Error(`${this.id} ${this.operation} output must contain ${outputLength} row(s)`);
+    }
+    if (this.input.buffer === this.output.buffer) {
+      throw new Error(`${this.id} input and output must use separate buffers`);
+    }
+  }
+
+  /** Adds hierarchical reduction passes and hidden scratch to a command graph. */
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    if (this.input.buffer.graph !== graph || this.output.buffer.graph !== graph) {
+      throw new Error(`${this.id} views must belong to the target graph`);
+    }
+    if (this.input.length === 0) {
+      addClearReductionPass(graph, this.id, this.output);
+      return;
+    }
+
+    const valuesPerRow = this.operation === 'extent' ? 2 : 1;
+    const needsValidity =
+      this.input.format === 'float32' && ['min', 'max', 'extent'].includes(this.operation);
+    let inputValues: GraphBufferView<T> = this.input;
+    let inputValidity: GraphBufferView<'uint32'> | undefined;
+    let inputLength = this.input.length;
+    let levelIndex = 0;
+
+    while (true) {
+      const outputLength = Math.ceil(inputLength / REDUCTION_WORKGROUP_SIZE);
+      const outputValues = createTransientView(
+        graph,
+        `${this.id}-level-${levelIndex}-values`,
+        this.input.format,
+        outputLength * valuesPerRow
+      ) as GraphBufferView<T>;
+      const outputValidity = needsValidity
+        ? createTransientView(
+            graph,
+            `${this.id}-level-${levelIndex}-validity`,
+            'uint32',
+            outputLength
+          )
+        : undefined;
+      addReductionLevelPass(graph, {
+        id: `${this.id}-level-${levelIndex}`,
+        format: this.input.format,
+        operation: this.operation,
+        inputValues,
+        inputValidity,
+        outputValues,
+        outputValidity,
+        inputLength,
+        valuesPerRow,
+        firstLevel: levelIndex === 0
+      });
+      inputValues = outputValues;
+      inputValidity = outputValidity;
+      inputLength = outputLength;
+      levelIndex++;
+      if (inputLength === 1) {
+        break;
+      }
+    }
+
+    addFinalizeReductionPass(graph, {
+      id: `${this.id}-finalize`,
+      format: this.input.format,
+      inputValues,
+      inputValidity,
+      output: this.output,
+      valuesPerRow
+    });
+  }
+}
+
+function addReductionLevelPass<Parameters, T extends GPUScalarFormat>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    format: T;
+    operation: GPUReductionOperation;
+    inputValues: GraphBufferView<T>;
+    inputValidity?: GraphBufferView<'uint32'>;
+    outputValues: GraphBufferView<T>;
+    outputValidity?: GraphBufferView<'uint32'>;
+    inputLength: number;
+    valuesPerRow: number;
+    firstLevel: boolean;
+  }
+): void {
+  const shaderType = getShaderType(props.format);
+  const zero = getZeroLiteral(props.format);
+  const isSum = props.operation === 'sum';
+  const isExtent = props.operation === 'extent';
+  const validityBinding = props.inputValidity
+    ? '@group(0) @binding(1) var<storage, read> inputValidity: array<u32>;'
+    : '';
+  const outputValuesBinding = props.inputValidity ? 2 : 1;
+  const outputValidityBinding = outputValuesBinding + 1;
+  const finiteExpression =
+    props.format === 'float32' ? 'value == value && abs(value) <= 3.402823466e+38' : 'true';
+  const readFirst = props.firstLevel
+    ? `value = inputValues[INPUT_OFFSET + index];
+    secondValue = value;
+    valid = select(0u, 1u, ${finiteExpression});`
+    : `value = inputValues[INPUT_OFFSET + index * VALUES_PER_ROW];
+    secondValue = inputValues[INPUT_OFFSET + index * VALUES_PER_ROW + ${isExtent ? '1u' : '0u'}];
+    ${props.inputValidity ? 'valid = inputValidity[VALIDITY_OFFSET + index];' : 'valid = 1u;'}`;
+  const combine = isSum
+    ? 'firstScratch[lane] = firstScratch[lane] + firstScratch[lane + stride];'
+    : `let rightValid = validityScratch[lane + stride];
+      if (rightValid != 0u) {
+        if (validityScratch[lane] == 0u) {
+          firstScratch[lane] = firstScratch[lane + stride];
+          secondScratch[lane] = secondScratch[lane + stride];
+        } else {
+          firstScratch[lane] = ${props.operation === 'max' ? 'max' : 'min'}(firstScratch[lane], firstScratch[lane + stride]);
+          secondScratch[lane] = ${isExtent ? 'max' : props.operation === 'max' ? 'max' : 'min'}(secondScratch[lane], secondScratch[lane + stride]);
+        }
+        validityScratch[lane] = 1u;
+      }`;
+  const source = /* wgsl */ `
+const ELEMENT_COUNT: u32 = ${props.inputLength}u;
+const VALUES_PER_ROW: u32 = ${props.valuesPerRow}u;
+const INPUT_OFFSET: u32 = ${getViewElementOffset(props.inputValues)}u;
+${props.inputValidity ? `const VALIDITY_OFFSET: u32 = ${getViewElementOffset(props.inputValidity)}u;` : ''}
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.outputValues)}u;
+${props.outputValidity ? `const OUTPUT_VALIDITY_OFFSET: u32 = ${getViewElementOffset(props.outputValidity)}u;` : ''}
+@group(0) @binding(0) var<storage, read> inputValues: array<${shaderType}>;
+${validityBinding}
+@group(0) @binding(${outputValuesBinding}) var<storage, read_write> outputValues: array<${shaderType}>;
+${props.outputValidity ? `@group(0) @binding(${outputValidityBinding}) var<storage, read_write> outputValidity: array<u32>;` : ''}
+var<workgroup> firstScratch: array<${shaderType}, ${REDUCTION_WORKGROUP_SIZE}>;
+var<workgroup> secondScratch: array<${shaderType}, ${REDUCTION_WORKGROUP_SIZE}>;
+var<workgroup> validityScratch: array<u32, ${REDUCTION_WORKGROUP_SIZE}>;
+
+@compute @workgroup_size(${REDUCTION_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let index = globalId.x;
+  let lane = localId.x;
+  var value = ${zero};
+  var secondValue = ${zero};
+  var valid = 0u;
+  if (index < ELEMENT_COUNT) {
+    ${readFirst}
+  }
+  firstScratch[lane] = value;
+  secondScratch[lane] = secondValue;
+  validityScratch[lane] = valid;
+  workgroupBarrier();
+  var stride = ${REDUCTION_WORKGROUP_SIZE / 2}u;
+  loop {
+    if (lane < stride) {
+      ${combine}
+    }
+    workgroupBarrier();
+    if (stride == 1u) { break; }
+    stride = stride / 2u;
+  }
+  if (lane == 0u) {
+    outputValues[OUTPUT_OFFSET + workgroupId.x * VALUES_PER_ROW] = firstScratch[0];
+    ${isExtent ? 'outputValues[OUTPUT_OFFSET + workgroupId.x * VALUES_PER_ROW + 1u] = secondScratch[0];' : ''}
+    ${props.outputValidity ? 'outputValidity[OUTPUT_VALIDITY_OFFSET + workgroupId.x] = validityScratch[0];' : ''}
+  }
+}`;
+
+  const resources: GraphBufferUse[] = [
+    {buffer: props.inputValues, usage: 'storage-read'},
+    ...(props.inputValidity
+      ? ([{buffer: props.inputValidity, usage: 'storage-read'}] as GraphBufferUse[])
+      : []),
+    {buffer: props.outputValues, usage: 'storage-write'},
+    ...(props.outputValidity
+      ? ([{buffer: props.outputValidity, usage: 'storage-write'}] as GraphBufferUse[])
+      : [])
+  ];
+  const bindings: Record<string, GraphBufferView> = {inputValues: props.inputValues};
+  if (props.inputValidity) bindings['inputValidity'] = props.inputValidity;
+  bindings['outputValues'] = props.outputValues;
+  if (props.outputValidity) bindings['outputValidity'] = props.outputValidity;
+  addComputationPass(graph, {
+    id: props.id,
+    source,
+    resources,
+    bindings,
+    dispatchCount: Math.ceil(props.inputLength / REDUCTION_WORKGROUP_SIZE)
+  });
+}
+
+function addFinalizeReductionPass<Parameters, T extends GPUScalarFormat>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    format: T;
+    inputValues: GraphBufferView<T>;
+    inputValidity?: GraphBufferView<'uint32'>;
+    output: GraphBufferView<T>;
+    valuesPerRow: number;
+  }
+): void {
+  const shaderType = getShaderType(props.format);
+  const zero = getZeroLiteral(props.format);
+  const outputLines = Array.from({length: props.valuesPerRow}, (_, index) => {
+    const value = `inputValues[INPUT_OFFSET + ${index}u]`;
+    return `outputValues[OUTPUT_OFFSET + ${index}u] = ${props.inputValidity ? `select(${zero}, ${value}, valid)` : value};`;
+  }).join('\n  ');
+  const source = /* wgsl */ `
+const INPUT_OFFSET: u32 = ${getViewElementOffset(props.inputValues)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
+${props.inputValidity ? `const VALIDITY_OFFSET: u32 = ${getViewElementOffset(props.inputValidity)}u;` : ''}
+@group(0) @binding(0) var<storage, read> inputValues: array<${shaderType}>;
+${props.inputValidity ? '@group(0) @binding(1) var<storage, read> inputValidity: array<u32>;' : ''}
+@group(0) @binding(${props.inputValidity ? 2 : 1}) var<storage, read_write> outputValues: array<${shaderType}>;
+@compute @workgroup_size(1) fn main() {
+  ${props.inputValidity ? 'let valid = inputValidity[VALIDITY_OFFSET] != 0u;' : ''}
+  ${outputLines}
+}`;
+  addComputationPass(graph, {
+    id: props.id,
+    source,
+    resources: [
+      {buffer: props.inputValues, usage: 'storage-read'},
+      ...(props.inputValidity
+        ? ([{buffer: props.inputValidity, usage: 'storage-read'}] as GraphBufferUse[])
+        : []),
+      {buffer: props.output, usage: 'storage-write'}
+    ],
+    bindings: {
+      inputValues: props.inputValues,
+      ...(props.inputValidity ? {inputValidity: props.inputValidity} : {}),
+      outputValues: props.output
+    },
+    dispatchCount: 1
+  });
+}
+
+function addClearReductionPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  output: GraphBufferView<GPUScalarFormat>
+): void {
+  const passId = `${id}-clear`;
+  const shaderType = getShaderType(output.format);
+  const zero = getZeroLiteral(output.format);
+  addComputationPass(graph, {
+    id: passId,
+    source: `const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
+@group(0) @binding(0) var<storage, read_write> outputValues: array<${shaderType}>;
+@compute @workgroup_size(1) fn main() {
+  for (var index = 0u; index < ${output.length}u; index++) { outputValues[OUTPUT_OFFSET + index] = ${zero}; }
+}`,
+    resources: [{buffer: output, usage: 'storage-write'}],
+    bindings: {outputValues: output},
+    dispatchCount: 1
+  });
+}
+
+function addComputationPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    source: string;
+    resources: GraphBufferUse[];
+    bindings: Record<string, GraphBufferView>;
+    dispatchCount: number;
+  }
+): void {
+  graph.addComputePass({
+    id: props.id,
+    resources: props.resources,
+    compile: ({device}) => {
+      const bindingNames = Object.keys(props.bindings);
+      const computation = new Computation(device, {
+        id: props.id,
+        source: props.source,
+        shaderLayout: {
+          bindings: bindingNames.map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const [name, view] of Object.entries(props.bindings)) {
+            bindings[name] = getViewBinding(view, getBuffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatch(computePass, props.dispatchCount);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function getShaderType(format: GPUScalarFormat): 'u32' | 'i32' | 'f32' {
+  return format === 'uint32' ? 'u32' : format === 'sint32' ? 'i32' : 'f32';
+}
+
+function getZeroLiteral(format: GPUScalarFormat): string {
+  return format === 'uint32' ? '0u' : format === 'sint32' ? '0' : '0.0';
+}

--- a/modules/experimental/src/gpu-primitives/gpu-scan.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-scan.ts
@@ -2,13 +2,17 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, type Binding} from '@luma.gl/core';
+import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {GPUCommandGraph, type GraphBufferView} from './gpu-command-graph';
+import {
+  createTransientView,
+  getViewBinding,
+  getViewElementOffset,
+  validatePackedUint32View
+} from './graph-buffer-view-utils';
 
 const SCAN_WORKGROUP_SIZE = 256;
-const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
-const STORAGE_BINDING_ALIGNMENT = 256;
 
 export type GPUScanProps = {
   id?: string;
@@ -56,15 +60,12 @@ export class GPUScan {
       const blockCount = Math.ceil(levelLength / SCAN_WORKGROUP_SIZE);
       let blockSums: GraphBufferView<'uint32'> | undefined;
       if (blockCount > 1) {
-        const blockSumsBuffer = graph.createTransientBuffer({
-          id: `${this.id}-level-${levelIndex}-block-sums`,
-          byteLength: blockCount * UINT32_BYTE_LENGTH,
-          usage: Buffer.STORAGE
-        });
-        blockSums = graph.createBufferView(blockSumsBuffer, {
-          format: 'uint32',
-          length: blockCount
-        });
+        blockSums = createTransientView(
+          graph,
+          `${this.id}-level-${levelIndex}-block-sums`,
+          'uint32',
+          blockCount
+        );
       }
 
       addBlockScanPass(graph, {
@@ -80,15 +81,12 @@ export class GPUScan {
       if (!blockSums) {
         break;
       }
-      const blockOffsetsBuffer = graph.createTransientBuffer({
-        id: `${this.id}-level-${levelIndex}-block-offsets`,
-        byteLength: blockCount * UINT32_BYTE_LENGTH,
-        usage: Buffer.STORAGE
-      });
-      const blockOffsets = graph.createBufferView(blockOffsetsBuffer, {
-        format: 'uint32',
-        length: blockCount
-      });
+      const blockOffsets = createTransientView(
+        graph,
+        `${this.id}-level-${levelIndex}-block-offsets`,
+        'uint32',
+        blockCount
+      );
       levels[levels.length - 1].blockOffsets = blockOffsets;
       levelInput = blockSums;
       levelOutput = blockOffsets;
@@ -258,36 +256,4 @@ const BLOCK_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.blockOffsets)}u;
       };
     }
   });
-}
-
-/** @internal */
-export function validatePackedUint32View(view: GraphBufferView, name: string): void {
-  if (
-    view.format !== 'uint32' ||
-    view.byteStride !== UINT32_BYTE_LENGTH ||
-    view.rowByteLength !== UINT32_BYTE_LENGTH ||
-    view.byteOffset % UINT32_BYTE_LENGTH !== 0
-  ) {
-    throw new Error(`${name} must be packed, uint32-aligned GPU data`);
-  }
-}
-
-/** @internal */
-export function getViewBinding(
-  view: GraphBufferView,
-  getBuffer: (view: GraphBufferView) => Buffer
-): Binding {
-  const alignedByteOffset =
-    Math.floor(view.byteOffset / STORAGE_BINDING_ALIGNMENT) * STORAGE_BINDING_ALIGNMENT;
-  const prefixByteLength = view.byteOffset - alignedByteOffset;
-  return {
-    buffer: getBuffer(view),
-    offset: alignedByteOffset,
-    size: prefixByteLength + Math.max(view.length * view.byteStride, view.rowByteLength)
-  };
-}
-
-/** @internal */
-export function getViewElementOffset(view: GraphBufferView): number {
-  return (view.byteOffset % STORAGE_BINDING_ALIGNMENT) / UINT32_BYTE_LENGTH;
 }

--- a/modules/experimental/src/gpu-primitives/gpu-sort.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-sort.ts
@@ -2,14 +2,19 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, type Binding} from '@luma.gl/core';
+import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
 import {GPUCommandGraph, type GraphBufferUse, type GraphBufferView} from './gpu-command-graph';
-import {GPUScan, getViewBinding, getViewElementOffset, validatePackedUint32View} from './gpu-scan';
+import {GPUScan} from './gpu-scan';
+import {
+  createTransientView,
+  getViewBinding,
+  getViewElementOffset,
+  validatePackedUint32View
+} from './graph-buffer-view-utils';
 
 const BITONIC_WORKGROUP_SIZE = 256;
 const RADIX_WORKGROUP_SIZE = 256;
-const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 const INVALID_INDEX = 0xffffffff;
 const MAXIMUM_LOGICAL_LENGTH = 0x80000000;
 const AUTO_BITONIC_MAXIMUM_LENGTH = 65_536;
@@ -167,8 +172,18 @@ const OUTPUT_VALUES_OFFSET: u32 = ${getViewElementOffset(sort.outputValues)}u;
 
 function addBitonicSort<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GPUSort): void {
   const paddedLength = getNextPowerOfTwo(sort.keys.length);
-  const indicesA = createTransientUint32View(graph, `${sort.id}-bitonic-indices-a`, paddedLength);
-  const indicesB = createTransientUint32View(graph, `${sort.id}-bitonic-indices-b`, paddedLength);
+  const indicesA = createTransientView(
+    graph,
+    `${sort.id}-bitonic-indices-a`,
+    'uint32',
+    paddedLength
+  );
+  const indicesB = createTransientView(
+    graph,
+    `${sort.id}-bitonic-indices-b`,
+    'uint32',
+    paddedLength
+  );
   addBitonicInitializePass(graph, sort, indicesA, paddedLength);
 
   let currentIndices = indicesA;
@@ -327,28 +342,32 @@ const OUTPUT_VALUES_OFFSET: u32 = ${getViewElementOffset(sort.outputValues)}u;
 }
 
 function addRadixSort<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GPUSort): void {
-  const scratchKeys = createTransientUint32View(
+  const scratchKeys = createTransientView(
     graph,
     `${sort.id}-radix-scratch-keys`,
+    'uint32',
     sort.keys.length
   );
-  const scratchValues = createTransientUint32View(
+  const scratchValues = createTransientView(
     graph,
     `${sort.id}-radix-scratch-values`,
+    'uint32',
     sort.keys.length
   );
   let currentKeys = sort.keys;
   let currentValues = sort.values;
 
   for (let bit = 0; bit < 32; bit++) {
-    const flags = createTransientUint32View(
+    const flags = createTransientView(
       graph,
       `${sort.id}-radix-bit-${bit}-flags`,
+      'uint32',
       sort.keys.length
     );
-    const offsets = createTransientUint32View(
+    const offsets = createTransientView(
       graph,
       `${sort.id}-radix-bit-${bit}-offsets`,
+      'uint32',
       sort.keys.length
     );
     const nextKeys = bit % 2 === 0 ? scratchKeys : sort.outputKeys;
@@ -466,19 +485,6 @@ const OUTPUT_VALUES_OFFSET: u32 = ${getViewElementOffset(outputValues)}u;
     bindings: {keys, values, flags, offsets, outputKeys, outputValues},
     dispatchCount: Math.ceil(sort.keys.length / RADIX_WORKGROUP_SIZE)
   });
-}
-
-function createTransientUint32View<Parameters>(
-  graph: GPUCommandGraph<Parameters>,
-  id: string,
-  length: number
-): GraphBufferView<'uint32'> {
-  const buffer = graph.createTransientBuffer({
-    id,
-    byteLength: Math.max(length, 1) * UINT32_BYTE_LENGTH,
-    usage: Buffer.STORAGE
-  });
-  return graph.createBufferView(buffer, {format: 'uint32', length});
 }
 
 function getNextPowerOfTwo(length: number): number {

--- a/modules/experimental/src/gpu-primitives/graph-buffer-view-utils.ts
+++ b/modules/experimental/src/gpu-primitives/graph-buffer-view-utils.ts
@@ -1,0 +1,75 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Binding} from '@luma.gl/core';
+import {getGPUVectorFormatInfo, type GPUVectorFormat} from '@luma.gl/tables';
+import {GPUCommandGraph, type GraphBufferView} from './gpu-command-graph';
+
+const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
+const STORAGE_BINDING_ALIGNMENT = 256;
+
+/** @internal */
+export type GPUScalarFormat = 'uint32' | 'sint32' | 'float32';
+
+/** @internal */
+export function validatePackedView<T extends GPUVectorFormat>(
+  view: GraphBufferView,
+  formats: readonly T[],
+  name: string
+): asserts view is GraphBufferView<T> {
+  const formatInfo = getGPUVectorFormatInfo(view.format);
+  if (
+    !formats.includes(view.format as T) ||
+    view.byteStride !== formatInfo.byteLength ||
+    view.rowByteLength !== formatInfo.byteLength ||
+    view.byteOffset % UINT32_BYTE_LENGTH !== 0
+  ) {
+    throw new Error(`${name} must be packed, uint32-aligned ${formats.join(' or ')} GPU data`);
+  }
+}
+
+/** @internal */
+export function validatePackedUint32View(view: GraphBufferView, name: string): void {
+  validatePackedView(view, ['uint32'], name);
+}
+
+/** @internal */
+export function getViewBinding(
+  view: GraphBufferView,
+  getBuffer: (view: GraphBufferView) => Buffer
+): Binding {
+  const alignedByteOffset =
+    Math.floor(view.byteOffset / STORAGE_BINDING_ALIGNMENT) * STORAGE_BINDING_ALIGNMENT;
+  const prefixByteLength = view.byteOffset - alignedByteOffset;
+  const viewByteLength =
+    view.length === 0
+      ? view.rowByteLength
+      : (view.length - 1) * view.byteStride + view.rowByteLength;
+  return {
+    buffer: getBuffer(view),
+    offset: alignedByteOffset,
+    size: prefixByteLength + Math.max(viewByteLength, view.rowByteLength)
+  };
+}
+
+/** Offset in 32-bit components from the aligned storage binding. @internal */
+export function getViewElementOffset(view: GraphBufferView): number {
+  return (view.byteOffset % STORAGE_BINDING_ALIGNMENT) / UINT32_BYTE_LENGTH;
+}
+
+/** @internal */
+export function createTransientView<T extends GPUVectorFormat, Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  format: T,
+  length: number
+): GraphBufferView<T> {
+  const formatInfo = getGPUVectorFormatInfo(format);
+  const buffer = graph.createTransientBuffer({
+    id,
+    byteLength: Math.max(length, 1) * formatInfo.byteLength,
+    usage: Buffer.STORAGE
+  });
+  return graph.createBufferView(buffer, {format, length});
+}

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -34,6 +34,15 @@ export type {GPUCompactionProps} from './gpu-compaction';
 export {GPUSort} from './gpu-sort';
 export type {GPUSortAlgorithm, GPUSortDirection, GPUSortProps} from './gpu-sort';
 
+export {GPUReduction} from './gpu-reduction';
+export type {GPUReductionOperation, GPUReductionProps} from './gpu-reduction';
+
+export {GPUHistogram} from './gpu-histogram';
+export type {GPUHistogramDomain, GPUHistogramProps} from './gpu-histogram';
+
+export {GPUGridBinning} from './gpu-grid-binning';
+export type {GPUGridBinningBounds, GPUGridBinningProps} from './gpu-grid-binning';
+
 export {DrawCommandBuffer} from './draw-command-buffer';
 export type {
   DrawCommand,

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -6,7 +6,9 @@ export {
   CompiledGPUCommandGraph,
   GPUCommandGraph,
   GraphBufferHandle,
-  GraphBufferView
+  GraphBufferView,
+  GraphTextureHandle,
+  GraphTextureView
 } from './gpu-command-graph';
 export type {
   GPUCommandGraphCompileContext,
@@ -23,7 +25,16 @@ export type {
   GraphBufferDescriptor,
   GraphBufferUsage,
   GraphBufferUse,
-  GraphImportedBuffer
+  GraphImportedBuffer,
+  GraphImportedTexture,
+  GraphRenderPassAttachments,
+  GraphResourceUse,
+  GraphTextureAspect,
+  GraphTextureDescriptor,
+  GraphTextureDimension,
+  GraphTextureUsage,
+  GraphTextureUse,
+  GraphTextureViewProps
 } from './gpu-command-graph';
 
 export {GPUScan} from './gpu-scan';
@@ -42,6 +53,16 @@ export type {GPUHistogramDomain, GPUHistogramProps} from './gpu-histogram';
 
 export {GPUGridBinning} from './gpu-grid-binning';
 export type {GPUGridBinningBounds, GPUGridBinningProps} from './gpu-grid-binning';
+
+export {
+  decodeGPUIndexPickInfo,
+  GPUIndexPickingTarget,
+  INDEX_PICKING_READBACK_BYTE_LENGTH
+} from './gpu-index-picking-target';
+export type {
+  GPUIndexPickingReadbackProps,
+  GPUIndexPickingTargetProps
+} from './gpu-index-picking-target';
 
 export {DrawCommandBuffer} from './draw-command-buffer';
 export type {

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
@@ -1,0 +1,535 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {Buffer, Texture, type Device} from '@luma.gl/core';
+import {Computation, Model} from '@luma.gl/engine';
+import {
+  decodeGPUIndexPickInfo,
+  GPUCommandGraph,
+  GPUIndexPickingTarget,
+  INDEX_PICKING_READBACK_BYTE_LENGTH
+} from '@luma.gl/experimental';
+import {getNullTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+test('GPUCommandGraph validates texture descriptors, views, and imports', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const graph = new GPUCommandGraph(device, {id: 'texture-validation'});
+  t.throws(
+    () =>
+      graph.createTransientTexture({
+        id: 'invalid-size',
+        format: 'rgba8unorm',
+        width: 0,
+        height: 4,
+        usage: Texture.RENDER
+      }),
+    /positive safe integer/,
+    'zero texture extent is rejected'
+  );
+  const mipTexture = graph.createTransientTexture({
+    id: 'mips',
+    format: 'rgba8unorm',
+    width: 8,
+    height: 8,
+    mipLevels: 4,
+    usage: Texture.SAMPLE | Texture.STORAGE
+  });
+  const mipTwo = graph.createTextureView(mipTexture, {
+    baseMipLevel: 2,
+    mipLevelCount: 1
+  });
+  t.equal(mipTwo.width, 2, 'view width reflects base mip');
+  t.equal(mipTwo.height, 2, 'view height reflects base mip');
+  t.throws(
+    () => graph.createTextureView(mipTexture, {baseMipLevel: 4, mipLevelCount: 1}),
+    /exceeds.*mip levels/,
+    'view outside mip range is rejected'
+  );
+  t.throws(
+    () =>
+      graph.addComputePass({
+        id: 'wrong-usage',
+        resources: [{texture: mipTwo, usage: 'render-attachment'}],
+        compile: () => ({encode: () => {}})
+      }),
+    /does not declare usage/,
+    'node texture role must be declared by the descriptor'
+  );
+
+  const importedTexture = device.createTexture({
+    id: 'imported-texture',
+    width: 4,
+    height: 4,
+    format: 'rgba8unorm',
+    usage: Texture.SAMPLE
+  });
+  const importGraph = new GPUCommandGraph(device, {id: 'texture-import'});
+  const imported = importGraph.importTexture(
+    {
+      id: 'imported',
+      width: 4,
+      height: 4,
+      format: 'rgba8unorm',
+      usage: Texture.SAMPLE
+    },
+    importedTexture
+  );
+  const importedView = importGraph.createTextureView(imported);
+  const resolvedViews: unknown[] = [];
+  importGraph.addComputePass({
+    id: 'observe',
+    resources: [{texture: importedView, usage: 'sampled'}],
+    compile: () => ({
+      encode: ({getTextureView}) => void resolvedViews.push(getTextureView(importedView))
+    })
+  });
+  const compiled = importGraph.compile();
+  compiled.encode(device.createCommandEncoder({id: 'texture-import-first'}), {
+    parameters: undefined
+  });
+  compiled.encode(device.createCommandEncoder({id: 'texture-import-second'}), {
+    parameters: undefined
+  });
+  t.equal(resolvedViews[0], resolvedViews[1], 'concrete texture view is cached across encodes');
+  const replacement = device.createTexture({
+    id: 'replacement-texture',
+    width: 4,
+    height: 4,
+    format: 'rgba8unorm',
+    usage: Texture.SAMPLE
+  });
+  compiled.encode(device.createCommandEncoder({id: 'texture-import-replacement'}), {
+    parameters: undefined,
+    textures: {imported: replacement}
+  });
+  t.notEqual(resolvedViews[1], resolvedViews[2], 'replacement texture resolves a distinct view');
+  const wrongSize = device.createTexture({
+    id: 'wrong-size-texture',
+    width: 8,
+    height: 4,
+    format: 'rgba8unorm',
+    usage: Texture.SAMPLE
+  });
+  t.throws(
+    () =>
+      compiled.encode(device.createCommandEncoder({id: 'texture-import-invalid'}), {
+        parameters: undefined,
+        textures: {imported: wrongSize}
+      }),
+    /incompatible width/,
+    'fixed-size import rejects resized replacement'
+  );
+  compiled.destroy();
+  t.notOk(importedTexture.destroyed, 'compiled graph leaves imported texture alive');
+  importedTexture.destroy();
+  replacement.destroy();
+  wrongSize.destroy();
+  t.end();
+});
+
+test('GPUCommandGraph tracks texture subresources and reuses compatible transients', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const disjointGraph = new GPUCommandGraph(device, {id: 'disjoint-subresources'});
+  const disjointTexture = disjointGraph.createTransientTexture({
+    id: 'mipped',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    mipLevels: 2,
+    usage: Texture.STORAGE
+  });
+  const mipZero = disjointGraph.createTextureView(disjointTexture, {
+    baseMipLevel: 0,
+    mipLevelCount: 1
+  });
+  const mipOne = disjointGraph.createTextureView(disjointTexture, {
+    baseMipLevel: 1,
+    mipLevelCount: 1
+  });
+  disjointGraph.addComputePass({
+    id: 'read-mip-one',
+    dependsOn: ['write-mip-zero'],
+    resources: [{texture: mipOne, usage: 'storage-read'}],
+    compile: () => ({encode: () => {}})
+  });
+  disjointGraph.addComputePass({
+    id: 'write-mip-zero',
+    resources: [{texture: mipZero, usage: 'storage-write'}],
+    compile: () => ({encode: () => {}})
+  });
+  const disjointCompiled = disjointGraph.compile();
+  t.deepEqual(
+    disjointCompiled.stats.nodeOrder,
+    ['write-mip-zero', 'read-mip-one'],
+    'disjoint subresources do not create a reverse hazard cycle'
+  );
+  disjointCompiled.destroy();
+
+  const overlapGraph = new GPUCommandGraph(device, {id: 'overlap-subresources'});
+  const overlapTexture = overlapGraph.createTransientTexture({
+    id: 'mipped',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    mipLevels: 2,
+    usage: Texture.STORAGE
+  });
+  const overlapMip = overlapGraph.createTextureView(overlapTexture, {
+    baseMipLevel: 0,
+    mipLevelCount: 1
+  });
+  overlapGraph.addComputePass({
+    id: 'read',
+    dependsOn: ['write'],
+    resources: [{texture: overlapMip, usage: 'storage-read'}],
+    compile: () => ({encode: () => {}})
+  });
+  overlapGraph.addComputePass({
+    id: 'write',
+    resources: [{texture: overlapMip, usage: 'storage-write'}],
+    compile: () => ({encode: () => {}})
+  });
+  t.throws(() => overlapGraph.compile(), /dependency cycle/, 'overlapping view hazard is detected');
+
+  const reuseGraph = new GPUCommandGraph(device, {id: 'texture-reuse'});
+  const first = reuseGraph.createTransientTexture({
+    id: 'first',
+    format: 'rgba8unorm',
+    width: 8,
+    height: 8,
+    usage: Texture.STORAGE | Texture.SAMPLE
+  });
+  const second = reuseGraph.createTransientTexture({
+    id: 'second',
+    format: 'rgba8unorm',
+    width: 8,
+    height: 8,
+    usage: Texture.STORAGE | Texture.SAMPLE
+  });
+  reuseGraph.addComputePass({
+    id: 'write-first',
+    resources: [{texture: first, usage: 'storage-write'}],
+    compile: () => ({encode: () => {}})
+  });
+  reuseGraph.addComputePass({
+    id: 'read-first',
+    resources: [{texture: first, usage: 'sampled'}],
+    compile: () => ({encode: () => {}})
+  });
+  reuseGraph.addComputePass({
+    id: 'write-second',
+    dependsOn: ['read-first'],
+    resources: [{texture: second, usage: 'storage-write'}],
+    compile: () => ({encode: () => {}})
+  });
+  reuseGraph.addComputePass({
+    id: 'read-second',
+    resources: [{texture: second, usage: 'sampled'}],
+    compile: () => ({encode: () => {}})
+  });
+  const reused = reuseGraph.compile();
+  t.equal(reused.stats.logicalTransientTextureCount, 2, 'two logical textures are tracked');
+  t.equal(reused.stats.physicalTransientTextureCount, 1, 'compatible lifetimes share texture');
+  t.ok(reused.stats.reusedTransientTextureBytes > 0, 'texture reuse reports saved bytes');
+  reused.destroy();
+  t.end();
+});
+
+test('GPUCommandGraph composes storage texture output with sampled rendering', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const graph = new GPUCommandGraph(device, {id: 'storage-sampled'});
+  const storageTexture = graph.createTransientTexture({
+    id: 'storage',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.STORAGE | Texture.SAMPLE
+  });
+  const outputTexture = device.createTexture({
+    id: 'sampled-output',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER | Texture.COPY_SRC
+  });
+  const outputHandle = graph.importTexture(
+    {
+      id: 'output',
+      format: 'rgba8unorm',
+      width: 4,
+      height: 4,
+      usage: outputTexture.props.usage
+    },
+    outputTexture
+  );
+  const storageView = graph.createTextureView(storageTexture);
+  const outputView = graph.createTextureView(outputHandle);
+  graph.addComputePass({
+    id: 'write-storage',
+    resources: [{texture: storageView, usage: 'storage-write'}],
+    compile: ({device: compileDevice}) => {
+      const computation = new Computation(compileDevice, {
+        id: 'write-storage-computation',
+        source: `@group(0) @binding(0) var image: texture_storage_2d<rgba8unorm, write>;
+@compute @workgroup_size(1) fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+  textureStore(image, vec2<i32>(id.xy), vec4<f32>(1.0, 0.25, 0.0, 1.0));
+}`,
+        shaderLayout: {
+          bindings: [
+            {
+              name: 'image',
+              type: 'storage',
+              group: 0,
+              location: 0,
+              access: 'write-only',
+              format: 'rgba8unorm'
+            }
+          ]
+        }
+      });
+      return {
+        encode: ({computePass, getTextureView}) => {
+          computation.setBindings({image: getTextureView(storageView)});
+          computation.dispatch(computePass, 4, 4, 1);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+  graph.addRenderPass({
+    id: 'sample-storage',
+    attachments: {colorAttachments: [outputView]},
+    resources: [{texture: storageView, usage: 'sampled'}],
+    compile: ({device: compileDevice}) => {
+      const model = new Model(compileDevice, {
+        id: 'sample-storage-model',
+        source: `@group(0) @binding(0) var image: texture_2d<f32>;
+@vertex fn vertexMain(@builtin(vertex_index) index: u32) -> @builtin(position) vec4<f32> {
+  let positions = array<vec2<f32>, 3>(vec2(-1.0, -1.0), vec2(3.0, -1.0), vec2(-1.0, 3.0));
+  return vec4(positions[index], 0.0, 1.0);
+}
+@fragment fn fragmentMain(@builtin(position) position: vec4<f32>) -> @location(0) vec4<f32> {
+  return textureLoad(image, vec2<i32>(position.xy), 0);
+}`,
+        vertexCount: 3,
+        colorAttachmentFormats: ['rgba8unorm'],
+        shaderLayout: {
+          attributes: [],
+          bindings: [
+            {
+              name: 'image',
+              type: 'texture',
+              group: 0,
+              location: 0,
+              sampleType: 'float'
+            }
+          ]
+        }
+      });
+      return {
+        encode: ({renderPass, getTextureView}) => {
+          model.setBindings({image: getTextureView(storageView)});
+          model.draw(renderPass);
+        },
+        destroy: () => model.destroy()
+      };
+    }
+  });
+  const compiled = graph.compile();
+  const commandEncoder = device.createCommandEncoder({id: 'storage-sampled'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+  const pixels = await readPixels(outputTexture, 4, 4);
+  t.ok(pixels[0] > 240 && pixels[1] > 50, 'sampled render observes storage texture writes');
+  compiled.destroy();
+  t.notOk(outputTexture.destroyed, 'imported output texture remains caller-owned');
+  outputTexture.destroy();
+  t.end();
+});
+
+test('GPUIndexPickingTarget renders stable integer IDs and copies dynamic pixels', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const defaultReadback = makePickingReadbackBuffer(device, 'picking-readback-default');
+  const graph = new GPUCommandGraph<{pixel: readonly [number, number]}>(device, {
+    id: 'index-picking'
+  });
+  const target = new GPUIndexPickingTarget(graph, {
+    id: 'pick',
+    width: 4,
+    height: 4,
+    readbackBuffer: defaultReadback
+  });
+  graph.addRenderPass({
+    id: 'pick-render',
+    attachments: target.attachments,
+    compile: ({device: compileDevice}) => {
+      const model = new Model(compileDevice, {
+        id: 'index-picking-model',
+        source: `struct FragmentOutputs {
+  @location(0) color: vec4<f32>,
+  @location(1) indices: vec2<i32>,
+};
+@vertex fn vertexMain(@builtin(vertex_index) index: u32) -> @builtin(position) vec4<f32> {
+  let positions = array<vec2<f32>, 3>(vec2(-1.0, -1.0), vec2(3.0, -1.0), vec2(-1.0, 3.0));
+  return vec4(positions[index], 0.0, 1.0);
+}
+@fragment fn fragmentMain(@builtin(position) position: vec4<f32>) -> FragmentOutputs {
+  if (position.y >= 3.0) { discard; }
+  var output: FragmentOutputs;
+  output.color = vec4(0.0);
+  output.indices = vec2<i32>(select(7, 9, position.x >= 2.0), 3);
+  return output;
+}`,
+        vertexCount: 3,
+        colorAttachmentFormats: ['rgba8unorm', 'rg32sint'],
+        depthStencilAttachmentFormat: 'depth24plus'
+      });
+      return {
+        getRenderPassProps: () => target.renderPassProps,
+        encode: ({renderPass}) => model.draw(renderPass),
+        destroy: () => model.destroy()
+      };
+    }
+  });
+  target.addReadbackPass({after: 'pick-render', getPixel: parameters => parameters.pixel});
+  const compiled = graph.compile();
+  await encodePick(device, compiled, [0, 0]);
+  t.deepEqual(
+    decodeGPUIndexPickInfo(await defaultReadback.readAsync(0, 8)),
+    {objectIndex: 7, batchIndex: 3},
+    'left pixel returns first stable ID'
+  );
+  const replacementReadback = makePickingReadbackBuffer(device, 'picking-readback-replacement');
+  await encodePick(device, compiled, [3, 0], replacementReadback, target.readback.id);
+  t.deepEqual(
+    decodeGPUIndexPickInfo(await replacementReadback.readAsync(0, 8)),
+    {objectIndex: 9, batchIndex: 3},
+    'per-encoding staging override returns second stable ID'
+  );
+  const backgroundReadback = makePickingReadbackBuffer(device, 'picking-readback-background');
+  await encodePick(device, compiled, [1, 3], backgroundReadback, target.readback.id);
+  t.deepEqual(
+    decodeGPUIndexPickInfo(await backgroundReadback.readAsync(0, 8)),
+    {objectIndex: null, batchIndex: null},
+    'cleared background decodes to no pick'
+  );
+  t.throws(
+    () =>
+      compiled.encode(device.createCommandEncoder({id: 'picking-out-of-range'}), {
+        parameters: {pixel: [4, 0]}
+      }),
+    /outside 4x4 target/,
+    'out-of-range dynamic pixel is rejected'
+  );
+  compiled.destroy();
+  t.notOk(defaultReadback.destroyed, 'compiled graph preserves caller-owned staging buffer');
+  defaultReadback.destroy();
+  replacementReadback.destroy();
+  backgroundReadback.destroy();
+  t.end();
+});
+
+function makePickingReadbackBuffer(device: Device, id: string): Buffer {
+  return device.createBuffer({
+    id,
+    byteLength: INDEX_PICKING_READBACK_BYTE_LENGTH,
+    usage: Buffer.COPY_DST | Buffer.MAP_READ
+  });
+}
+
+async function encodePick(
+  device: Device,
+  compiled: ReturnType<GPUCommandGraph<{pixel: readonly [number, number]}>['compile']>,
+  pixel: readonly [number, number],
+  readbackBuffer?: Buffer,
+  readbackId?: string
+): Promise<void> {
+  const commandEncoder = device.createCommandEncoder({id: `pick-${pixel[0]}-${pixel[1]}`});
+  compiled.encode(commandEncoder, {
+    parameters: {pixel},
+    ...(readbackBuffer && readbackId ? {buffers: {[readbackId]: readbackBuffer}} : {})
+  });
+  device.submit(commandEncoder.finish());
+}
+
+async function readPixels(texture: Texture, width: number, height: number): Promise<Uint8Array> {
+  const layout = texture.computeMemoryLayout({width, height});
+  const buffer = texture.device.createBuffer({
+    byteLength: layout.byteLength,
+    usage: Buffer.COPY_DST | Buffer.MAP_READ
+  });
+  try {
+    texture.readBuffer({width, height}, buffer);
+    const paddedPixels = await buffer.readAsync(0, layout.byteLength);
+    const pixels = new Uint8Array(width * height * 4);
+    for (let row = 0; row < height; row++) {
+      pixels.set(
+        new Uint8Array(
+          paddedPixels.buffer,
+          paddedPixels.byteOffset + row * layout.bytesPerRow,
+          width * 4
+        ),
+        row * width * 4
+      );
+    }
+    return pixels;
+  } finally {
+    buffer.destroy();
+  }
+}
+
+test('GPUCommandGraph rejects texture imports from another device', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const nullDevice = await getNullTestDevice();
+  const wrongDeviceTexture = nullDevice.createTexture({
+    width: 4,
+    height: 4,
+    format: 'rgba8unorm',
+    usage: Texture.SAMPLE
+  });
+  const graph = new GPUCommandGraph(device);
+  t.throws(
+    () =>
+      graph.importTexture(
+        {
+          id: 'wrong-device',
+          width: 4,
+          height: 4,
+          format: 'rgba8unorm',
+          usage: Texture.SAMPLE
+        },
+        wrongDeviceTexture
+      ),
+    /another device/,
+    'wrong-device texture import is rejected'
+  );
+  wrongDeviceTexture.destroy();
+  t.end();
+});

--- a/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
@@ -72,6 +72,47 @@ test('GPUHistogram supports literal, GPU, and automatic domains', async t => {
     'literal uint32 domain includes exact maximum in final bin'
   );
   t.deepEqual(
+    await runHistogram(
+      device,
+      Uint32Array.from([0, 0x7fffffff, 0x80000000, 0xffffffff]),
+      'uint32',
+      2,
+      [0, 0xffffffff]
+    ),
+    [2, 2],
+    'full-range uint32 bin boundaries stay in integer space'
+  );
+  t.deepEqual(
+    await runHistogram(
+      device,
+      Int32Array.from([-0x80000000, -1, 0, 0x7fffffff]),
+      'sint32',
+      2,
+      [-0x80000000, 0x7fffffff]
+    ),
+    [2, 2],
+    'full-range sint32 bin boundaries stay in integer space'
+  );
+  let randomState = 0x1234abcd;
+  const fullRangeValues = Uint32Array.from({length: 1025}, (_, index) => {
+    randomState = (Math.imul(randomState, 1664525) + 1013904223) >>> 0;
+    return index === 1024 ? 0xffffffff : randomState;
+  });
+  const fullRangeBinCount = 257;
+  const expectedFullRangeCounts = Array.from({length: fullRangeBinCount}, () => 0);
+  for (const value of fullRangeValues) {
+    const binIndex =
+      value === 0xffffffff
+        ? fullRangeBinCount - 1
+        : Number((BigInt(value) * BigInt(fullRangeBinCount)) / 0xffffffffn);
+    expectedFullRangeCounts[binIndex]++;
+  }
+  t.deepEqual(
+    await runHistogram(device, fullRangeValues, 'uint32', fullRangeBinCount, [0, 0xffffffff]),
+    expectedFullRangeCounts,
+    'wide integer multiply/divide matches an exact BigInt reference above 256 bins'
+  );
+  t.deepEqual(
     await runHistogram(device, Int32Array.from([-2, -1, 0, 1, 2]), 'sint32', 2, [-2, 2], true),
     [2, 3],
     'GPU sint32 domain is accepted'

--- a/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
@@ -1,0 +1,362 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {Buffer, type Device} from '@luma.gl/core';
+import {
+  GPUCommandGraph,
+  GPUGridBinning,
+  GPUHistogram,
+  GPUReduction,
+  type GPUReductionOperation
+} from '@luma.gl/experimental';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import type {GPUVectorFormat} from '@luma.gl/tables';
+
+test('GPUReduction handles operations, formats, hierarchy, and invalid floats', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  t.deepEqual(await runReduction(device, Uint32Array.from([0xffffffff, 2]), 'uint32', 'sum'), [1]);
+  t.deepEqual(await runReduction(device, Uint32Array.from([7, 3, 9, 3]), 'uint32', 'min'), [3]);
+  t.deepEqual(await runReduction(device, Uint32Array.from([7, 3, 9, 3]), 'uint32', 'max'), [9]);
+  t.deepEqual(
+    await runReduction(device, Uint32Array.from([7, 3, 9, 3]), 'uint32', 'extent'),
+    [3, 9]
+  );
+  t.deepEqual(await runReduction(device, Int32Array.from([-7, 3, -2]), 'sint32', 'sum'), [-6]);
+  t.deepEqual(await runReduction(device, Int32Array.from([-7, 3, -2]), 'sint32', 'min'), [-7]);
+  t.deepEqual(await runReduction(device, Int32Array.from([-7, 3, -2]), 'sint32', 'max'), [3]);
+  t.deepEqual(
+    await runReduction(device, Int32Array.from([-7, 3, -2]), 'sint32', 'extent'),
+    [-7, 3]
+  );
+  const hierarchical = Uint32Array.from({length: 513}, (_, index) => index % 11);
+  t.deepEqual(await runReduction(device, hierarchical, 'uint32', 'sum'), [2551]);
+
+  const invalidFloats = Float32Array.from([Number.NaN, 4, Number.POSITIVE_INFINITY, -2]);
+  const floatSum = await runReduction(device, Float32Array.from([0.1, 0.2, 0.3]), 'float32', 'sum');
+  t.ok(Math.abs(floatSum[0] - 0.6) < 1e-6, 'float sum uses the fixed reduction tree');
+  t.deepEqual(await runReduction(device, invalidFloats, 'float32', 'min'), [-2]);
+  t.deepEqual(await runReduction(device, invalidFloats, 'float32', 'max'), [4]);
+  t.deepEqual(await runReduction(device, invalidFloats, 'float32', 'extent'), [-2, 4]);
+  t.deepEqual(
+    await runReduction(
+      device,
+      Float32Array.from([Number.NaN, Number.NEGATIVE_INFINITY]),
+      'float32',
+      'min'
+    ),
+    [0]
+  );
+  t.deepEqual(await runReduction(device, new Float32Array(0), 'float32', 'extent'), [0, 0]);
+  t.end();
+});
+
+test('GPUHistogram supports literal, GPU, and automatic domains', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  t.deepEqual(
+    await runHistogram(device, Uint32Array.from([0, 1, 2, 3, 4, 4, 5]), 'uint32', 4, [0, 4]),
+    [1, 1, 1, 3],
+    'literal uint32 domain includes exact maximum in final bin'
+  );
+  t.deepEqual(
+    await runHistogram(device, Int32Array.from([-2, -1, 0, 1, 2]), 'sint32', 2, [-2, 2], true),
+    [2, 3],
+    'GPU sint32 domain is accepted'
+  );
+  t.deepEqual(
+    await runHistogram(
+      device,
+      Float32Array.from([Number.NaN, -1, 0, 1, Number.POSITIVE_INFINITY]),
+      'float32',
+      2,
+      'auto'
+    ),
+    [1, 2],
+    'automatic float domain ignores non-finite values'
+  );
+  t.deepEqual(
+    await runHistogram(device, Uint32Array.from([7, 7, 8]), 'uint32', 3, [7, 7]),
+    [2, 0, 0],
+    'degenerate domain counts matching values in bin zero'
+  );
+  t.deepEqual(
+    await runHistogram(device, new Float32Array(0), 'float32', 4, 'auto'),
+    [0, 0, 0, 0],
+    'empty automatic histogram is cleared'
+  );
+  const globalValues = Uint32Array.from({length: 300}, (_, index) => index);
+  t.deepEqual(
+    await runHistogram(device, globalValues, 'uint32', 300, [0, 299]),
+    Array.from({length: 300}, () => 1),
+    'more than 256 bins uses the global atomic path'
+  );
+  t.end();
+});
+
+test('GPUHistogram clears counts for every graph encoding and composes with reduction', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const values = Uint32Array.from([0, 1, 1, 2, 3, 3, 3]);
+  const inputBuffer = createInputBuffer(device, values);
+  const countsBuffer = createOutputBuffer(device, 4);
+  const totalBuffer = createOutputBuffer(device, 1);
+  const graph = new GPUCommandGraph(device, {id: 'histogram-composition'});
+  const input = importView(graph, 'values', inputBuffer, 'uint32', values.length);
+  const counts = importView(graph, 'counts', countsBuffer, 'uint32', 4);
+  const total = importView(graph, 'total', totalBuffer, 'uint32', 1);
+  new GPUHistogram({input, output: counts, domain: [0, 3]}).addToGraph(graph);
+  new GPUReduction({input: counts, output: total, operation: 'sum'}).addToGraph(graph);
+  const compiled = graph.compile();
+  const commandEncoder = device.createCommandEncoder({id: 'histogram-repeat'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+  t.deepEqual(await readUint32(countsBuffer, 4), [1, 2, 1, 3], 'second encoding resets output');
+  t.deepEqual(await readUint32(totalBuffer, 1), [7], 'reduced count equals accepted rows');
+  compiled.destroy();
+  t.notOk(inputBuffer.destroyed, 'compiled graph preserves imported input');
+  t.notOk(countsBuffer.destroyed, 'compiled graph preserves imported output');
+  inputBuffer.destroy();
+  countsBuffer.destroy();
+  totalBuffer.destroy();
+  t.end();
+});
+
+test('GPUGridBinning handles literal/GPU bounds, boundaries, and both atomic paths', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const positions = Float32Array.from([0, 0, 1, 0, 0, 1, 2, 2, 2, 2, -1, 0, Number.NaN, 1]);
+  t.deepEqual(
+    await runGrid(device, positions, [2, 2], [0, 0, 2, 2]),
+    [1, 1, 1, 2],
+    'row-major cells include exact maximum boundaries'
+  );
+  t.deepEqual(
+    await runGrid(device, positions, [2, 2], [0, 0, 2, 2], true),
+    [1, 1, 1, 2],
+    'GPU bounds view is accepted'
+  );
+  const globalPositions = new Float32Array(17 * 17 * 2);
+  for (let row = 0; row < 17; row++) {
+    for (let column = 0; column < 17; column++) {
+      const index = row * 17 + column;
+      globalPositions[index * 2] = column;
+      globalPositions[index * 2 + 1] = row;
+    }
+  }
+  t.deepEqual(
+    await runGrid(device, globalPositions, [17, 17], [0, 0, 16, 16]),
+    Array.from({length: 289}, () => 1),
+    'more than 256 cells uses the global atomic path'
+  );
+  t.deepEqual(
+    await runGrid(device, new Float32Array(0), [2, 2], [0, 0, 1, 1]),
+    [0, 0, 0, 0],
+    'empty grid is cleared'
+  );
+  t.end();
+});
+
+test('GPU data analysis primitives validate layouts and ownership', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const graph = new GPUCommandGraph(device);
+  const inputHandle = graph.createTransientBuffer({
+    id: 'input',
+    byteLength: 64,
+    usage: Buffer.STORAGE
+  });
+  const outputHandle = graph.createTransientBuffer({
+    id: 'output',
+    byteLength: 64,
+    usage: Buffer.STORAGE
+  });
+  const input = graph.createBufferView(inputHandle, {format: 'uint32', length: 4});
+  const one = graph.createBufferView(outputHandle, {format: 'uint32', length: 1});
+  const two = graph.createBufferView(outputHandle, {format: 'uint32', length: 2});
+  t.throws(
+    () => new GPUReduction({input, output: two, operation: 'sum'}),
+    /must contain 1 row/,
+    'scalar reduction requires one output row'
+  );
+  t.throws(
+    () => new GPUReduction({input, output: one, operation: 'extent'}),
+    /must contain 2 row/,
+    'extent requires two output rows'
+  );
+  t.throws(
+    () => new GPUHistogram({input, output: two, domain: [2, 1]}),
+    /finite \[min, max\]/,
+    'inverted literal histogram domain is rejected'
+  );
+  const positions = graph.createBufferView(inputHandle, {format: 'float32x2', length: 4});
+  t.throws(
+    () => new GPUGridBinning({positions, output: two, gridSize: [2, 2], bounds: [0, 0, 1, 1]}),
+    /output.length/,
+    'grid output layout is validated'
+  );
+  t.end();
+});
+
+type ScalarFormat = 'uint32' | 'sint32' | 'float32';
+type ScalarArray = Uint32Array | Int32Array | Float32Array;
+
+async function runReduction(
+  device: Device,
+  values: ScalarArray,
+  format: ScalarFormat,
+  operation: GPUReductionOperation
+): Promise<number[]> {
+  const outputLength = operation === 'extent' ? 2 : 1;
+  const inputBuffer = createInputBuffer(device, values);
+  const outputBuffer = createOutputBuffer(device, outputLength);
+  const graph = new GPUCommandGraph(device);
+  const input = importView(graph, 'input', inputBuffer, format, values.length);
+  const output = importView(graph, 'output', outputBuffer, format, outputLength);
+  new GPUReduction({input, output, operation}).addToGraph(graph);
+  const compiled = graph.compile();
+  const commandEncoder = device.createCommandEncoder({id: 'reduction-test'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+  const bytes = await outputBuffer.readAsync();
+  const ResultArray =
+    format === 'uint32' ? Uint32Array : format === 'sint32' ? Int32Array : Float32Array;
+  const result = Array.from(new ResultArray(bytes.buffer, bytes.byteOffset, outputLength));
+  compiled.destroy();
+  inputBuffer.destroy();
+  outputBuffer.destroy();
+  return result;
+}
+
+async function runHistogram(
+  device: Device,
+  values: ScalarArray,
+  format: ScalarFormat,
+  binCount: number,
+  domain: readonly [number, number] | 'auto',
+  gpuDomain = false
+): Promise<number[]> {
+  const inputBuffer = createInputBuffer(device, values);
+  const outputBuffer = createOutputBuffer(device, binCount);
+  const graph = new GPUCommandGraph(device);
+  const input = importView(graph, 'input', inputBuffer, format, values.length);
+  const output = importView(graph, 'output', outputBuffer, 'uint32', binCount);
+  let histogramDomain: typeof domain | ReturnType<typeof importView> = domain;
+  let domainBuffer: Buffer | undefined;
+  if (gpuDomain && domain !== 'auto') {
+    const DomainArray =
+      format === 'uint32' ? Uint32Array : format === 'sint32' ? Int32Array : Float32Array;
+    domainBuffer = createInputBuffer(device, DomainArray.from(domain));
+    histogramDomain = importView(graph, 'domain', domainBuffer, format, 2);
+  }
+  new GPUHistogram({input, output, domain: histogramDomain as never}).addToGraph(graph);
+  const compiled = graph.compile();
+  const commandEncoder = device.createCommandEncoder({id: 'histogram-test'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+  const result = await readUint32(outputBuffer, binCount);
+  compiled.destroy();
+  inputBuffer.destroy();
+  outputBuffer.destroy();
+  domainBuffer?.destroy();
+  return result;
+}
+
+async function runGrid(
+  device: Device,
+  positions: Float32Array,
+  gridSize: readonly [number, number],
+  bounds: readonly [number, number, number, number],
+  gpuBounds = false
+): Promise<number[]> {
+  const positionsBuffer = createInputBuffer(device, positions);
+  const outputBuffer = createOutputBuffer(device, gridSize[0] * gridSize[1]);
+  const graph = new GPUCommandGraph(device);
+  const positionsView = importView(
+    graph,
+    'positions',
+    positionsBuffer,
+    'float32x2',
+    positions.length / 2
+  );
+  const output = importView(graph, 'output', outputBuffer, 'uint32', gridSize[0] * gridSize[1]);
+  let gridBounds: typeof bounds | ReturnType<typeof importView> = bounds;
+  let boundsBuffer: Buffer | undefined;
+  if (gpuBounds) {
+    boundsBuffer = createInputBuffer(device, Float32Array.from(bounds));
+    gridBounds = importView(graph, 'bounds', boundsBuffer, 'float32x4', 1);
+  }
+  new GPUGridBinning({
+    positions: positionsView as never,
+    output,
+    gridSize,
+    bounds: gridBounds as never
+  }).addToGraph(graph);
+  const compiled = graph.compile();
+  const commandEncoder = device.createCommandEncoder({id: 'grid-test'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+  const result = await readUint32(outputBuffer, output.length);
+  compiled.destroy();
+  positionsBuffer.destroy();
+  outputBuffer.destroy();
+  boundsBuffer?.destroy();
+  return result;
+}
+
+function createInputBuffer(device: Device, values: ScalarArray): Buffer {
+  const data = values.length > 0 ? values : new Uint32Array(1);
+  return device.createBuffer({data, usage: Buffer.STORAGE | Buffer.COPY_DST});
+}
+
+function createOutputBuffer(device: Device, length: number): Buffer {
+  return device.createBuffer({
+    byteLength: Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+}
+
+function importView<T extends GPUVectorFormat>(
+  graph: GPUCommandGraph,
+  id: string,
+  buffer: Buffer,
+  format: T,
+  length: number
+) {
+  const handle = graph.importBuffer(
+    {id, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return graph.createBufferView(handle, {format, length});
+}
+
+async function readUint32(buffer: Buffer, length: number): Promise<number[]> {
+  const bytes = await buffer.readAsync();
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, length));
+}

--- a/modules/experimental/test/index.ts
+++ b/modules/experimental/test/index.ts
@@ -11,5 +11,6 @@ import './shadows/shadow-wgsl.spec';
 
 import './webxr';
 import './gpu-primitives/gpu-command-graph.spec';
+import './gpu-primitives/gpu-command-graph-textures.spec';
 import './gpu-primitives/gpu-sort.spec';
 import './gpu-primitives/gpu-data-analysis.spec';

--- a/modules/experimental/test/index.ts
+++ b/modules/experimental/test/index.ts
@@ -12,3 +12,4 @@ import './shadows/shadow-wgsl.spec';
 import './webxr';
 import './gpu-primitives/gpu-command-graph.spec';
 import './gpu-primitives/gpu-sort.spec';
+import './gpu-primitives/gpu-data-analysis.spec';

--- a/website/content/examples/experimental/gpu-data-analysis.mdx
+++ b/website/content/examples/experimental/gpu-data-analysis.mdx
@@ -1,0 +1,8 @@
+---
+title: Graph-native GPU data analysis
+sidebar_label: GPU data analysis
+---
+
+import {GPUDataAnalysisExample} from '@site/src/examples';
+
+<GPUDataAnalysisExample />

--- a/website/content/examples/index.mdx
+++ b/website/content/examples/index.mdx
@@ -8,7 +8,7 @@ import {ExamplesIndex} from '@site/src/components/examples-index';
     if (exampleName === 'arrow/arrow-text-3d') {
       return '/images/examples/experimental/text-3d.jpg'
     }
-    if (exampleName === 'v10/gpgpu' || exampleName === 'experimental/gpu-sort') {
+    if (exampleName === 'v10/gpgpu' || exampleName === 'experimental/gpu-sort' || exampleName === 'experimental/gpu-data-analysis') {
       return '/images/examples/gpu-tables/gpu-vector-storage-particles.jpg'
     }
     return `/images/examples/${exampleName}.jpg`

--- a/website/content/examples/table-of-contents.json
+++ b/website/content/examples/table-of-contents.json
@@ -80,6 +80,7 @@
       "experimental/gpu-frustum-culling",
       "experimental/gpu-trace-viewer",
       "experimental/gpu-sort",
+      "experimental/gpu-data-analysis",
       "experimental/html-ui-prism",
       "experimental/webxr-kaleidoscope"
     ]

--- a/website/content/sidebar-examples.js
+++ b/website/content/sidebar-examples.js
@@ -64,6 +64,7 @@ const sidebars = {
         'experimental/gpu-frustum-culling',
         'experimental/gpu-trace-viewer',
         'experimental/gpu-sort',
+        'experimental/gpu-data-analysis',
         'experimental/html-ui-prism',
         'experimental/webxr-kaleidoscope'
       ]

--- a/website/src/components/docs/gpu-primitives-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-primitives-docs-tabs.tsx
@@ -10,6 +10,7 @@ export type GPUPrimitivesDocsTabId =
   | 'reduction'
   | 'histogram'
   | 'grid-binning'
+  | 'index-picking'
   | 'draw-command-buffer';
 
 const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
@@ -52,6 +53,11 @@ const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
     id: 'grid-binning',
     label: 'Grid Binning',
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-grid-binning'
+  },
+  {
+    id: 'index-picking',
+    label: 'Picking',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target'
   },
   {
     id: 'draw-command-buffer',

--- a/website/src/components/docs/gpu-primitives-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-primitives-docs-tabs.tsx
@@ -7,6 +7,9 @@ export type GPUPrimitivesDocsTabId =
   | 'scan'
   | 'compaction'
   | 'sort'
+  | 'reduction'
+  | 'histogram'
+  | 'grid-binning'
   | 'draw-command-buffer';
 
 const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
@@ -34,6 +37,21 @@ const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
     id: 'sort',
     label: 'Sort',
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-sort'
+  },
+  {
+    id: 'reduction',
+    label: 'Reduction',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-reduction'
+  },
+  {
+    id: 'histogram',
+    label: 'Histogram',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-histogram'
+  },
+  {
+    id: 'grid-binning',
+    label: 'Grid Binning',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-grid-binning'
   },
   {
     id: 'draw-command-buffer',

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -31,6 +31,10 @@ import {
   initializeGPUSortExample,
   type GPUSortExampleHandle
 } from '../../examples/experimental/gpu-sort/src/app';
+import {
+  initializeGPUDataAnalysisExample,
+  type GPUDataAnalysisExampleHandle
+} from '../../examples/experimental/gpu-data-analysis/src/app';
 import FP64App from '../../examples/experimental/fp64/app';
 import GPT2App from '../../examples/experimental/gpt-2/app';
 import VideoTextureApp from '../../examples/experimental/video-texture/app';
@@ -774,6 +778,33 @@ export const GPUSortExample: React.FC = () => {
   return (
     <ExamplePage style={{background: '#f7f8fb', overflow: 'hidden'}}>
       <main id="gpu-sort-app" />
+      {errorMessage ? (
+        <p role="alert" style={{padding: 22}}>
+          {errorMessage}
+        </p>
+      ) : null}
+    </ExamplePage>
+  );
+};
+
+/** Docusaurus wrapper for the graph-native data-analysis example. */
+export const GPUDataAnalysisExample: React.FC = () => {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let handle: GPUDataAnalysisExampleHandle | null = null;
+    try {
+      handle = initializeGPUDataAnalysisExample();
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+      logError('Failed to initialize GPU data-analysis example', error);
+    }
+    return () => handle?.destroy();
+  }, []);
+
+  return (
+    <ExamplePage style={{background: '#f6f8fb', overflow: 'hidden'}}>
+      <main id="gpu-data-analysis-app" />
       {errorMessage ? (
         <p role="alert" style={{padding: 22}}>
           {errorMessage}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16042,6 +16042,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"luma.gl-examples-experimental-gpu-data-analysis@workspace:examples/experimental/gpu-data-analysis":
+  version: 0.0.0-use.local
+  resolution: "luma.gl-examples-experimental-gpu-data-analysis@workspace:examples/experimental/gpu-data-analysis"
+  dependencies:
+    "@luma.gl/arrow": "npm:~9.3.0"
+    "@luma.gl/core": "npm:~9.3.0"
+    "@luma.gl/engine": "npm:~9.3.0"
+    "@luma.gl/experimental": "npm:~9.3.0"
+    "@luma.gl/shadertools": "npm:~9.3.0"
+    "@luma.gl/tables": "npm:~9.3.0"
+    "@luma.gl/text": "npm:~9.3.0"
+    "@luma.gl/webgpu": "npm:~9.3.0"
+    apache-arrow: "npm:^17.0.0"
+    typescript: "npm:^5.9.3"
+    vite: "npm:^8.0.0"
+  languageName: unknown
+  linkType: soft
+
 "luma.gl-examples-experimental-gpu-frustum-culling@workspace:examples/experimental/gpu-frustum-culling":
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-experimental-gpu-frustum-culling@workspace:examples/experimental/gpu-frustum-culling"


### PR DESCRIPTION
## Goals

- Add the next buffer-native command-graph data-analysis primitives after sort.
- Keep input/output ownership, encoding, submission, and readback explicit.
- Preserve the existing lazy `@luma.gl/gpgpu` operations while the graph-native APIs mature in `@luma.gl/experimental`.

## Changes

- Adds `GPUReduction` for packed `uint32`, `sint32`, and `float32` sum/min/max/extent operations with deterministic hierarchical scratch and explicit empty/all-invalid normalization.
- Adds `GPUHistogram` with literal, GPU-resident, and automatic extent domains, per-encoding clears, local atomics through 256 bins, and global atomics above 256 bins. Integer formats use exact overflow-safe integer bin arithmetic across their full 32-bit ranges.
- Adds count-only `GPUGridBinning` for packed `float32x2` positions with literal/GPU bounds, row-major output, exact maximum-bound handling, and local/global atomic paths.
- Extracts shared packed-view validation, aligned storage bindings, element offsets, and transient view creation; migrates scan, compaction, and sort to the shared helpers without public API changes.
- Adds focused WebGPU coverage for formats, edge cases, hierarchy, invalid values, domain modes, repeated encoding, composition, ownership, and both atomic strategies.
- Adds the Arrow-backed GPU Data Analysis example, API reference tabs, website navigation, release notes, roadmap updates, dependencies, and lockfile entries.

## Verification

- `nvm use` — passed with Node 22.22.1.
- `yarn install` — passed; Yarn reported the repository's existing peer-dependency warnings.
- `yarn lint fix` — passed after final changes; 1,167 files checked with no remaining fixes.
- `yarn build` — passed after final formatting across all modules.
- `yarn test` — passed after final formatting: 48 node files / 166 tests passed (2 files and 2 tests skipped), plus 232 headless files / 1,233 tests passed (25 skipped).
- Focused WebGPU regression suite — passed: 3 files / 18 tests covering command graph, sort/helper regressions, reduction, histogram, and grid binning.
- Integer precision regression — passed full-range `uint32` and `sint32` midpoint cases plus 1,025 pseudo-random full-range `uint32` values across 257 bins against an exact `BigInt` reference.
- `(cd examples/experimental/gpu-data-analysis && yarn build)` — passed (TypeScript and Vite production build).
- `yarn website:build` — passed and generated the complete Docusaurus site.
- `(cd website && yarn build)` — passed and generated the complete Docusaurus site.
- Browser QA — passed in the in-app WebGPU browser for the 4,096-row local-atomic path (16 bins, 8×8 grid), the 65,537-row default path, and the 262,144-row global-atomic path (300 bins, 17×17 grid), each encoded twice and validated against CPU references. No browser warnings or errors were recorded.
- Merge-base audit — fetched `origin/master`; the branch was current before commit and is an independent PR because graph-native sort is already merged.

## Risks

- These APIs are experimental and WebGPU-only.
- Floating sums intentionally use a fixed hierarchical tree and can differ from sequential CPU accumulation.
- Atomic count outputs wrap as `uint32`; highly contended workloads should be profiled on target adapters.

## Follow-up

- Defer weighted histograms, floating-point/grid aggregates, vector reductions, spatial indexes, generic shader callbacks, graph textures/attachments, visibility, picking, and `GPUScene` until their contracts are designed and measured.
