### PR TITLE
[codex] Document GPU picking and command-graph roadmap

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -836,7 +836,22 @@ camera. The data-analysis example adds a third consumer based on Arrow columns, 
 reduction, histogram composition, and spatial counts. Additional consumers should still exercise
 different patterns such as text expansion or path tessellation.
 
-## Implemented data analysis
+## Roadmap status
+
+The command-graph foundation and the first texture/picking milestone are implemented. The broader
+GPU application platform is not complete yet.
+
+Completed milestones include:
+
+- Fixed-capacity buffer and logical-texture scheduling across compute, render, and copy nodes.
+- Buffer and texture hazard inference, imported-resource overrides, graph-owned attachments,
+  transient allocation reuse, ownership validation, and allocation statistics.
+- Exclusive scan, stable compaction, paired sort, scalar reduction, histogram counting, spatial
+  grid binning, and GPU-written indirect draw commands.
+- Single-pixel integer object and batch picking through `GPUIndexPickingTarget`.
+- Independent trace-viewer, frustum-culling/picking, and GPU data-analysis consumers.
+
+### Implemented data analysis
 
 `GPUReduction` collapses packed scalar rows with explicit empty, overflow, floating-point order,
 and non-finite policies. `GPUHistogram` accepts literal, GPU-resident, or inferred domains and
@@ -844,7 +859,7 @@ produces normal graph output that can feed another reduction. `GPUGridBinning` a
 atomic accumulation strategy to packed positions and row-major cells. All three keep input,
 output, submission, and readback ownership with the caller.
 
-## Implemented textures and picking
+### Implemented textures and picking
 
 `GPUCommandGraph` schedules logical texture views across sampled, storage, render-attachment, and
 copy roles. Compatible non-overlapping transient textures reuse physical allocations, while mip,
@@ -852,15 +867,17 @@ layer, and aspect ranges keep hazards precise. `GPUIndexPickingTarget` uses thos
 integer object and batch IDs, leaving rendering, submission, staging-buffer selection, and explicit
 readback with the application.
 
-## Future primitives
+## Remaining roadmap
 
-The proposed architecture extends beyond the implemented proof.
+The proposed architecture extends beyond the implemented foundation in the following areas.
 
-### Visibility
+### Reusable visibility workflows
 
-The trace predicate is application-owned. Reusable visibility workflows can standardize common
-inputs such as bounding spheres, axis-aligned boxes, time ranges, LOD thresholds, and selection
-masks. Their output should remain compacted stable IDs plus counts, not a renderer-specific object.
+Visibility is proven by the trace viewer and frustum-culling example, but each predicate remains
+application-owned. Reusable workflows can standardize common inputs such as bounding spheres,
+axis-aligned boxes, time ranges, LOD thresholds, and selection masks. Their output should remain
+compacted stable IDs plus counts, not a renderer-specific object. General application-defined
+predicates should wait for a deliberate shader-callback or shader-extension protocol.
 
 ### Spatial indexes
 
@@ -875,6 +892,28 @@ A future `GPUScene` should be a flat draw database: stable object IDs, bounds, t
 membership, geometry references, and command slots. It should not duplicate a game-engine scene
 graph. CPU scene graphs can update a GPU draw database, while table-oriented applications can
 construct the same database directly.
+
+### Picking and texture expansion
+
+The current picking target intentionally handles one device pixel and one integer object/batch
+contract. Region picking, color-encoded fallback, automatic staging-buffer rings, and higher-level
+callback, highlight, and tooltip policies remain future workflow layers. Texture scheduling still
+needs contracts for multisampled resolve targets, swapchain imports, and external textures before
+those resources can participate in the same logical hazard and lifetime model.
+
+### Richer algorithm variants
+
+The first algorithms favor narrow, measurable contracts. Future variants include inclusive,
+segmented, floating-point, and custom associative scans; weighted and floating-point grid
+aggregates; irregular-edge, categorical, sparse, and multidimensional histograms; and batch-aware
+algorithms that preserve multi-chunk table structure without implicit concatenation.
+
+### API graduation
+
+The graph and algorithms remain in `@luma.gl/experimental`. After their resource, shader-extension,
+and package-dependency contracts stabilize, graph infrastructure and typed views should graduate to
+`@luma.gl/engine`, while optional algorithms should move to `@luma.gl/gpgpu`. Graduation includes an
+API and dependency audit rather than only moving files between packages.
 
 ## What is intentionally not automatic
 

--- a/website/content/examples/experimental/gpu-frustum-culling.mdx
+++ b/website/content/examples/experimental/gpu-frustum-culling.mdx
@@ -7,6 +7,11 @@ import {GPUFrustumCullingExample} from '@site/src/examples';
 
 <GPUFrustumCullingExample />
 
+Move the pointer over the perspective view to pick an instance. The selected cube is highlighted and
+the inspector reports its original source ID, even though the visible IDs have been compacted into a
+different draw order. Drag to orbit, scroll to zoom, change the instance capacity, and toggle the
+overhead comparison view to see the same indirect draw from two cameras.
+
 This example applies the experimental command-graph primitives to a conventional 3D workload. A
 compute node tests instance bounding spheres against the camera frustum, `GPUCompaction` preserves
 the visible source IDs in stable order, and its result count lands directly in an indexed
@@ -16,9 +21,14 @@ list and indirect command through an interactive perspective camera and a fixed 
 making the culling result visible without running visibility twice. Disable the overview to measure
 a single-render baseline.
 
+Picking runs through a second graph that owns transient color, signed-integer ID, and depth textures.
+It renders the compacted source IDs, copies one cursor pixel into a caller-owned staging buffer, and
+decodes the result only after submission. Resizing recompiles the fixed-size picking graph, while
+overlapping requests use separate staging buffers rather than hidden readback state.
+
 The inspector reports sampled visibility, frame rate, CPU frame and graph-encoding time, optional
-GPU frame time, graph node order, and logical-versus-physical transient memory. GPU timing is shown
-only when the browser exposes WebGPU timestamp queries.
+GPU frame time, picked source ID, graph node order, buffer reuse, and physical-versus-logical picking
+texture counts. GPU timing is shown only when the browser exposes WebGPU timestamp queries.
 
 The design follows the GPU-driven pattern demonstrated by the
 [WebGPU Bundle Culling sample](https://webgpu.github.io/webgpu-samples/?sample=bundleCulling) and


### PR DESCRIPTION
Goals

- Make the graph-native integer picking capability merged in #2709 immediately discoverable and testable.
- Clearly distinguish the completed command-graph foundation from the remaining platform roadmap.
- Show that picking preserves original source identity after GPU visibility compaction.

Changes

- Add concise interaction instructions for hover picking, highlighting, camera controls, capacity changes, and the comparison view.
- Explain the second command graph's transient color, signed-integer ID, and depth attachments.
- Document explicit caller-owned staging buffers, resize-driven recompilation, and overlapping readback requests.
- Add a roadmap status section covering completed scheduling, algorithms, picking, and independent consumers.
- Track reusable visibility workflows, spatial indexes, `GPUScene`, picking/texture expansion, richer algorithm variants, and API graduation as remaining work.
- Preserve explicit submission, readback, capacity, and application-policy boundaries as intentional non-goals.

Verification

- `nvm use` — passed (Node 22.22.1).
- `yarn install` — passed; existing peer-dependency warnings only.
- `yarn build` — passed for the implementation merged in #2709.
- `yarn test` — passed for the implementation merged in #2709 (166 node tests and 1,238 headless tests passed; 27 skipped).
- `yarn lint fix` — passed after the final documentation update.
- `yarn website:build` — passed after the roadmap update.
- `(cd website && yarn build)` — passed on this clean follow-up branch after refreshing dependencies.
- Repository pre-commit checks passed: formatting, lint, and 166 node tests.
- Production preview manually verified: 250K instances rendered, hover picking returned a stable compacted source ID, highlighting updated, and graph buffer/texture statistics were visible.