### PR TITLE
[codex] Rename graph buffer views to graph data views

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -41,7 +41,7 @@ indirect draw arguments
 pre-recorded render commands
 ```
 
-The implementation consists of `GPUCommandGraph`, typed graph buffer views, `GPUScan`,
+The implementation consists of `GPUCommandGraph`, typed graph data views, `GPUScan`,
 `GPUCompaction`, `GPUSort`, `GPUReduction`, `GPUHistogram`, `GPUGridBinning`, and
 `DrawCommandBuffer`. The accompanying trace viewer runs filtering and compaction over up to four
 million spans, while the sort and data-analysis examples demonstrate composable buffer-native
@@ -270,7 +270,7 @@ A `GraphBufferHandle` describes a complete logical allocation. It has an ID, a r
 length, a union of buffer usage flags, and an imported or transient lifetime. It is opaque: users
 do not construct handles directly.
 
-A `GraphBufferView<T>` describes a typed range within a handle. Its format uses
+A `GraphDataView<T>` describes a typed range within a handle. Its format uses
 `GPUVectorFormat`, and it records logical length, byte offset, byte stride, and row byte length.
 Views let algorithms bind a subrange without losing table-oriented metadata.
 
@@ -286,7 +286,7 @@ const sourceBuffer = graph.importBuffer(
   source
 );
 
-const sourceIds = graph.createBufferView(sourceBuffer, {
+const sourceIds = graph.createDataView(sourceBuffer, {
   format: 'uint32',
   length: objectCount
 });
@@ -812,7 +812,7 @@ The intended v10 layering is:
 ```text
 @luma.gl/engine
   GPUData, GPUVector, GPUTable
-  GPUCommandGraph and graph buffer views
+  GPUCommandGraph and graph data views
   DrawCommandBuffer
   compute/render kernel integration
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -45,9 +45,9 @@ construction, or the caller may provide a compatible override to each encoding.
 Declares graph-owned scratch storage. Compatible logical transients with non-overlapping lifetimes
 may share one physical buffer.
 
-### `createBufferView(handle, props)`
+### `createDataView(handle, props)`
 
-Creates a `GraphBufferView<T extends GPUVectorFormat>` with `format`, `length`, `byteOffset`,
+Creates a `GraphDataView<T extends GPUVectorFormat>` with `format`, `length`, `byteOffset`,
 `byteStride`, and `rowByteLength` metadata.
 
 ### `importGPUData(id, data)`

--- a/docs/api-reference/experimental/gpu-primitives/gpu-grid-binning.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-grid-binning.md
@@ -20,10 +20,10 @@ new GPUGridBinning({
 ```ts
 type GPUGridBinningProps = {
   id?: string;
-  positions: GraphBufferView<'float32x2'>;
-  output: GraphBufferView<'uint32'>;
+  positions: GraphDataView<'float32x2'>;
+  output: GraphDataView<'uint32'>;
   gridSize: readonly [number, number];
-  bounds: readonly [number, number, number, number] | GraphBufferView<'float32x4'>;
+  bounds: readonly [number, number, number, number] | GraphDataView<'float32x4'>;
 };
 ```
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-histogram.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-histogram.md
@@ -16,9 +16,9 @@ new GPUHistogram({input: values, output: counts, domain: 'auto'}).addToGraph(gra
 ```ts
 type GPUHistogramProps<T extends 'uint32' | 'sint32' | 'float32'> = {
   id?: string;
-  input: GraphBufferView<T>;
-  output: GraphBufferView<'uint32'>;
-  domain: readonly [number, number] | GraphBufferView<T> | 'auto';
+  input: GraphDataView<T>;
+  output: GraphDataView<'uint32'>;
+  domain: readonly [number, number] | GraphDataView<T> | 'auto';
 };
 ```
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
@@ -16,8 +16,8 @@ new GPUReduction({input: values, output: extent, operation: 'extent'}).addToGrap
 ```ts
 type GPUReductionProps<T extends 'uint32' | 'sint32' | 'float32'> = {
   id?: string;
-  input: GraphBufferView<T>;
-  output: GraphBufferView<T>;
+  input: GraphDataView<T>;
+  output: GraphDataView<T>;
   operation: 'sum' | 'min' | 'max' | 'extent';
 };
 ```

--- a/docs/api-reference/experimental/gpu-primitives/gpu-scan.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-scan.md
@@ -14,7 +14,7 @@ new GPUScan({
 }).addToGraph(graph);
 ```
 
-Both views must be packed, four-byte-aligned `GraphBufferView<'uint32'>` values. The output must
+Both views must be packed, four-byte-aligned `GraphDataView<'uint32'>` values. The output must
 contain at least as many rows as the input.
 
 For input `[1, 0, 1, 1]`, the output is `[0, 1, 1, 2]`.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-sort.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-sort.md
@@ -25,8 +25,8 @@ const outputValueHandle = graph.importBuffer(
 const sort = new GPUSort({
   keys,
   values,
-  outputKeys: graph.createBufferView(outputKeyHandle, {format: 'uint32', length}),
-  outputValues: graph.createBufferView(outputValueHandle, {format: 'uint32', length}),
+  outputKeys: graph.createDataView(outputKeyHandle, {format: 'uint32', length}),
+  outputValues: graph.createDataView(outputValueHandle, {format: 'uint32', length}),
   algorithm: 'auto',
   direction: 'ascending'
 });
@@ -45,10 +45,10 @@ device.submit(commandEncoder.finish());
 ```ts
 type GPUSortProps = {
   id?: string;
-  keys: GraphBufferView<'uint32'>;
-  values: GraphBufferView<'uint32'>;
-  outputKeys: GraphBufferView<'uint32'>;
-  outputValues: GraphBufferView<'uint32'>;
+  keys: GraphDataView<'uint32'>;
+  values: GraphDataView<'uint32'>;
+  outputKeys: GraphDataView<'uint32'>;
+  outputValues: GraphDataView<'uint32'>;
   algorithm?: 'auto' | 'bitonic' | 'radix';
   direction?: 'ascending' | 'descending';
 };

--- a/examples/experimental/gpu-data-analysis/src/app.ts
+++ b/examples/experimental/gpu-data-analysis/src/app.ts
@@ -304,7 +304,7 @@ function importOutput<T extends 'float32' | 'uint32'>(
     {id, byteLength: buffer.byteLength, usage: buffer.usage},
     buffer
   );
-  return graph.createBufferView(handle, {format, length});
+  return graph.createDataView(handle, {format, length});
 }
 
 function renderHistogram(element: HTMLElement, counts: number[]): void {

--- a/examples/experimental/gpu-frustum-culling/app.ts
+++ b/examples/experimental/gpu-frustum-culling/app.ts
@@ -370,13 +370,13 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
       byteLength: capacity * UINT32_BYTE_LENGTH,
       usage: Buffer.STORAGE
     });
-    const flags = graph.createBufferView(flagsBuffer, {format: 'uint32', length: capacity});
-    const sourceIds = graph.createBufferView(sourceIdsBuffer, {format: 'uint32', length: capacity});
-    const visibleIdView = graph.createBufferView(visibleIds, {
+    const flags = graph.createDataView(flagsBuffer, {format: 'uint32', length: capacity});
+    const sourceIds = graph.createDataView(sourceIdsBuffer, {format: 'uint32', length: capacity});
+    const visibleIdView = graph.createDataView(visibleIds, {
       format: 'uint32',
       length: capacity
     });
-    const instanceCount = graph.createBufferView(drawCommandBuffer, {
+    const instanceCount = graph.createDataView(drawCommandBuffer, {
       format: 'uint32',
       length: 1,
       byteOffset: drawCommands.getInstanceCountByteOffset(0)

--- a/examples/experimental/gpu-sort/src/app.ts
+++ b/examples/experimental/gpu-sort/src/app.ts
@@ -179,8 +179,8 @@ class GPUSortExample {
       const sort = new GPUSort({
         keys: keyView,
         values: valueView,
-        outputKeys: graph.createBufferView(outputKeyHandle, {format: 'uint32', length}),
-        outputValues: graph.createBufferView(outputValueHandle, {format: 'uint32', length}),
+        outputKeys: graph.createDataView(outputKeyHandle, {format: 'uint32', length}),
+        outputValues: graph.createDataView(outputValueHandle, {format: 'uint32', length}),
         algorithm,
         direction
       });

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -253,16 +253,16 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         byteLength: group.count * UINT32_BYTE_LENGTH,
         usage: Buffer.STORAGE
       });
-      const flags = graph.createBufferView(flagsBuffer, {format: 'uint32', length: group.count});
-      const sourceIds = graph.createBufferView(sourceIdsBuffer, {
+      const flags = graph.createDataView(flagsBuffer, {format: 'uint32', length: group.count});
+      const sourceIds = graph.createDataView(sourceIdsBuffer, {
         format: 'uint32',
         length: group.count
       });
-      const visibleIdView = graph.createBufferView(visibleIds, {
+      const visibleIdView = graph.createDataView(visibleIds, {
         format: 'uint32',
         length: group.count
       });
-      const count = graph.createBufferView(drawCommandHandle, {
+      const count = graph.createDataView(drawCommandHandle, {
         format: 'uint32',
         length: 1,
         byteOffset: drawCommands.getInstanceCountByteOffset(groupIndex)

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
@@ -112,7 +112,7 @@ export class GraphBufferHandle {
 }
 
 /** Typed logical range within one graph buffer. */
-export class GraphBufferView<T extends GPUVectorFormat = GPUVectorFormat> {
+export class GraphDataView<T extends GPUVectorFormat = GPUVectorFormat> {
   readonly buffer: GraphBufferHandle;
   readonly format: T;
   readonly length: number;
@@ -223,7 +223,7 @@ export class GraphTextureView<Format extends TextureFormat = TextureFormat> {
 
 /** One buffer use declared by a graph node. */
 export type GraphBufferUse = {
-  buffer: GraphBufferHandle | GraphBufferView;
+  buffer: GraphBufferHandle | GraphDataView;
   usage: GraphBufferUsage;
 };
 
@@ -251,7 +251,7 @@ export type GPUCommandGraphCompileContext = {
 export type GPUCommandGraphEncodeContext<Parameters> = {
   commandEncoder: CommandEncoder;
   parameters: Parameters;
-  getBuffer: (buffer: GraphBufferHandle | GraphBufferView) => Buffer;
+  getBuffer: (buffer: GraphBufferHandle | GraphDataView) => Buffer;
   getTexture: (texture: GraphTextureHandle | GraphTextureView) => Texture;
   getTextureView: (texture: GraphTextureHandle | GraphTextureView) => TextureView;
 };
@@ -408,7 +408,7 @@ export class GPUCommandGraph<Parameters = void> {
   }
 
   /** Creates one typed range over a graph buffer. */
-  createBufferView<T extends GPUVectorFormat>(
+  createDataView<T extends GPUVectorFormat>(
     buffer: GraphBufferHandle,
     props: {
       format: T;
@@ -417,19 +417,19 @@ export class GPUCommandGraph<Parameters = void> {
       byteStride?: number;
       rowByteLength?: number;
     }
-  ): GraphBufferView<T> {
+  ): GraphDataView<T> {
     this.assertBuffer(buffer);
     const formatInfo = getGPUVectorFormatInfo(props.format);
     const byteOffset = props.byteOffset ?? 0;
     const rowByteLength = props.rowByteLength ?? formatInfo.byteLength;
     const byteStride = props.byteStride ?? rowByteLength;
-    validateGraphBufferView(buffer, {
+    validateGraphDataView(buffer, {
       length: props.length,
       byteOffset,
       byteStride,
       rowByteLength
     });
-    return new GraphBufferView(buffer, {
+    return new GraphDataView(buffer, {
       format: props.format,
       length: props.length,
       byteOffset,
@@ -439,7 +439,7 @@ export class GPUCommandGraph<Parameters = void> {
   }
 
   /** Imports one borrowed GPUData range and returns its typed graph view. */
-  importGPUData<T extends GPUVectorFormat>(id: string, data: GPUData<T>): GraphBufferView<T> {
+  importGPUData<T extends GPUVectorFormat>(id: string, data: GPUData<T>): GraphDataView<T> {
     if (!data.format) {
       throw new Error(`GPUCommandGraph import "${id}" requires GPUData.format`);
     }
@@ -448,7 +448,7 @@ export class GPUCommandGraph<Parameters = void> {
       {id, byteLength: coreBuffer.byteLength, usage: coreBuffer.usage},
       data.buffer
     );
-    return this.createBufferView(handle, {
+    return this.createDataView(handle, {
       format: data.format,
       length: data.length,
       byteOffset: data.byteOffset,
@@ -458,7 +458,7 @@ export class GPUCommandGraph<Parameters = void> {
   }
 
   /** Imports one packed, single-chunk GPUVector. */
-  importGPUVector<T extends GPUVectorFormat>(id: string, vector: GPUVector<T>): GraphBufferView<T> {
+  importGPUVector<T extends GPUVectorFormat>(id: string, vector: GPUVector<T>): GraphDataView<T> {
     const [data, ...remainingData] = vector.data;
     if (!data || remainingData.length > 0) {
       throw new Error(`GPUCommandGraph import "${id}" requires exactly one GPUVector chunk`);
@@ -791,7 +791,7 @@ export class CompiledGPUCommandGraph<Parameters = void> {
 
     const importedBuffers = this.resolveImportedBuffers(options.buffers ?? {});
     const importedTextures = this.resolveImportedTextures(options.textures ?? {});
-    const getBuffer = (bufferOrView: GraphBufferHandle | GraphBufferView): Buffer => {
+    const getBuffer = (bufferOrView: GraphBufferHandle | GraphDataView): Buffer => {
       const handle = getBufferHandle(bufferOrView);
       const buffer = handle.transient
         ? this.transientBuffers.get(handle)
@@ -1001,8 +1001,8 @@ export class CompiledGPUCommandGraph<Parameters = void> {
   }
 }
 
-function getBufferHandle(buffer: GraphBufferHandle | GraphBufferView): GraphBufferHandle {
-  return buffer instanceof GraphBufferView ? buffer.buffer : buffer;
+function getBufferHandle(buffer: GraphBufferHandle | GraphDataView): GraphBufferHandle {
+  return buffer instanceof GraphDataView ? buffer.buffer : buffer;
 }
 
 function getTextureHandle(texture: GraphTextureHandle | GraphTextureView): GraphTextureHandle {
@@ -1146,25 +1146,25 @@ function normalizeGraphTextureView<Format extends TextureFormat>(
   };
 }
 
-function validateGraphBufferView(
+function validateGraphDataView(
   buffer: GraphBufferHandle,
   props: {length: number; byteOffset: number; byteStride: number; rowByteLength: number}
 ): void {
   for (const [name, value] of Object.entries(props)) {
     if (!Number.isSafeInteger(value) || value < 0) {
-      throw new Error(`Graph buffer view ${name} must be a non-negative safe integer`);
+      throw new Error(`Graph data view ${name} must be a non-negative safe integer`);
     }
   }
   if (props.length > 1 && props.byteStride === 0) {
-    throw new Error('Graph buffer view byteStride must be positive for multiple rows');
+    throw new Error('Graph data view byteStride must be positive for multiple rows');
   }
   if (props.rowByteLength > props.byteStride && props.length > 1) {
-    throw new Error('Graph buffer view rowByteLength cannot exceed byteStride');
+    throw new Error('Graph data view rowByteLength cannot exceed byteStride');
   }
   const byteLength =
     props.length === 0 ? 0 : (props.length - 1) * props.byteStride + props.rowByteLength;
   if (props.byteOffset + byteLength > buffer.byteLength) {
-    throw new Error(`Graph buffer view exceeds buffer "${buffer.id}" byte length`);
+    throw new Error(`Graph data view exceeds buffer "${buffer.id}" byte length`);
   }
 }
 

--- a/modules/experimental/src/gpu-primitives/gpu-compaction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-compaction.ts
@@ -3,32 +3,32 @@
 // Copyright (c) vis.gl contributors
 
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphBufferView} from './gpu-command-graph';
+import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
 import {GPUScan} from './gpu-scan';
 import {
   createTransientView,
   getViewBinding,
   getViewElementOffset,
   validatePackedUint32View
-} from './graph-buffer-view-utils';
+} from './graph-data-view-utils';
 
 const COMPACTION_WORKGROUP_SIZE = 256;
 
 export type GPUCompactionProps = {
   id?: string;
-  input: GraphBufferView<'uint32'>;
-  flags: GraphBufferView<'uint32'>;
-  output: GraphBufferView<'uint32'>;
-  count: GraphBufferView<'uint32'>;
+  input: GraphDataView<'uint32'>;
+  flags: GraphDataView<'uint32'>;
+  output: GraphDataView<'uint32'>;
+  count: GraphDataView<'uint32'>;
 };
 
 /** Stable graph-composed compaction of uint32 values selected by 0/1 flags. */
 export class GPUCompaction {
   readonly id: string;
-  readonly input: GraphBufferView<'uint32'>;
-  readonly flags: GraphBufferView<'uint32'>;
-  readonly output: GraphBufferView<'uint32'>;
-  readonly count: GraphBufferView<'uint32'>;
+  readonly input: GraphDataView<'uint32'>;
+  readonly flags: GraphDataView<'uint32'>;
+  readonly output: GraphDataView<'uint32'>;
+  readonly count: GraphDataView<'uint32'>;
 
   constructor(props: GPUCompactionProps) {
     this.id = props.id ?? 'gpu-compaction';
@@ -84,7 +84,7 @@ export class GPUCompaction {
 function addClearCountPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
-  count: GraphBufferView<'uint32'>
+  count: GraphDataView<'uint32'>
 ): void {
   const passId = `${id}-clear-count`;
   graph.addComputePass({
@@ -115,11 +115,11 @@ function addScatterPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   props: {
     id: string;
-    input: GraphBufferView<'uint32'>;
-    flags: GraphBufferView<'uint32'>;
-    offsets: GraphBufferView<'uint32'>;
-    output: GraphBufferView<'uint32'>;
-    count: GraphBufferView<'uint32'>;
+    input: GraphDataView<'uint32'>;
+    flags: GraphDataView<'uint32'>;
+    offsets: GraphDataView<'uint32'>;
+    output: GraphDataView<'uint32'>;
+    count: GraphDataView<'uint32'>;
   }
 ): void {
   const length = props.input.length;

--- a/modules/experimental/src/gpu-primitives/gpu-grid-binning.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-grid-binning.ts
@@ -4,13 +4,13 @@
 
 import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphBufferUse, type GraphBufferView} from './gpu-command-graph';
+import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-command-graph';
 import {
   getViewBinding,
   getViewElementOffset,
   validatePackedUint32View,
   validatePackedView
-} from './graph-buffer-view-utils';
+} from './graph-data-view-utils';
 
 const GRID_WORKGROUP_SIZE = 256;
 const MAXIMUM_LOCAL_CELL_COUNT = 256;
@@ -18,13 +18,13 @@ const MAXIMUM_LOCAL_CELL_COUNT = 256;
 /** Bounds accepted by {@link GPUGridBinning}. */
 export type GPUGridBinningBounds =
   | readonly [number, number, number, number]
-  | GraphBufferView<'float32x4'>;
+  | GraphDataView<'float32x4'>;
 
 /** Properties for graph-native two-dimensional grid counting. */
 export type GPUGridBinningProps = {
   id?: string;
-  positions: GraphBufferView<'float32x2'>;
-  output: GraphBufferView<'uint32'>;
+  positions: GraphDataView<'float32x2'>;
+  output: GraphDataView<'uint32'>;
   gridSize: readonly [number, number];
   bounds: GPUGridBinningBounds;
 };
@@ -32,8 +32,8 @@ export type GPUGridBinningProps = {
 /** Graph-native row-major count accumulation for packed float32x2 positions. */
 export class GPUGridBinning {
   readonly id: string;
-  readonly positions: GraphBufferView<'float32x2'>;
-  readonly output: GraphBufferView<'uint32'>;
+  readonly positions: GraphDataView<'float32x2'>;
+  readonly output: GraphDataView<'uint32'>;
   readonly gridSize: readonly [number, number];
   readonly bounds: GPUGridBinningBounds;
 
@@ -99,7 +99,7 @@ export class GPUGridBinning {
 function addClearGridPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
-  output: GraphBufferView<'uint32'>
+  output: GraphDataView<'uint32'>
 ): void {
   const passId = `${id}-clear`;
   const source = /* wgsl */ `
@@ -154,7 +154,7 @@ const WIDTH: u32 = ${width}u;
 const HEIGHT: u32 = ${height}u;
 const CELL_COUNT: u32 = ${binning.output.length}u;
 const POSITIONS_OFFSET: u32 = ${getViewElementOffset(binning.positions)}u;
-${gpuBounds ? `const BOUNDS_OFFSET: u32 = ${getViewElementOffset(binning.bounds as GraphBufferView)}u;` : ''}
+${gpuBounds ? `const BOUNDS_OFFSET: u32 = ${getViewElementOffset(binning.bounds as GraphDataView)}u;` : ''}
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(binning.output)}u;
 @group(0) @binding(0) var<storage, read> positions: array<f32>;
 ${boundsBinding}
@@ -195,7 +195,7 @@ fn getCoordinate(value: f32, minimum: f32, maximum: f32, size: u32) -> u32 {
   const resources: GraphBufferUse[] = [
     {buffer: binning.positions, usage: 'storage-read'},
     ...(gpuBounds
-      ? ([{buffer: binning.bounds as GraphBufferView, usage: 'storage-read'}] as GraphBufferUse[])
+      ? ([{buffer: binning.bounds as GraphDataView, usage: 'storage-read'}] as GraphBufferUse[])
       : []),
     {buffer: binning.output, usage: 'storage-read-write'}
   ];
@@ -205,7 +205,7 @@ fn getCoordinate(value: f32, minimum: f32, maximum: f32, size: u32) -> u32 {
     resources,
     bindings: {
       positions: binning.positions,
-      ...(gpuBounds ? {boundsValues: binning.bounds as GraphBufferView} : {}),
+      ...(gpuBounds ? {boundsValues: binning.bounds as GraphDataView} : {}),
       outputCounts: binning.output
     },
     dispatchCount: Math.ceil(binning.positions.length / GRID_WORKGROUP_SIZE)
@@ -218,7 +218,7 @@ function addComputationPass<Parameters>(
     id: string;
     source: string;
     resources: GraphBufferUse[];
-    bindings: Record<string, GraphBufferView>;
+    bindings: Record<string, GraphDataView>;
     dispatchCount: number;
   }
 ): void {
@@ -257,6 +257,6 @@ function getFloatLiteral(value: number): string {
   return Number.isInteger(value) ? `${value}.0` : `${value}`;
 }
 
-function isGPUGridBoundsView(bounds: GPUGridBinningBounds): bounds is GraphBufferView<'float32x4'> {
+function isGPUGridBoundsView(bounds: GPUGridBinningBounds): bounds is GraphDataView<'float32x4'> {
   return !Array.isArray(bounds);
 }

--- a/modules/experimental/src/gpu-primitives/gpu-histogram.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-histogram.ts
@@ -4,7 +4,7 @@
 
 import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphBufferUse, type GraphBufferView} from './gpu-command-graph';
+import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-command-graph';
 import {
   createTransientView,
   getViewBinding,
@@ -12,7 +12,7 @@ import {
   type GPUScalarFormat,
   validatePackedUint32View,
   validatePackedView
-} from './graph-buffer-view-utils';
+} from './graph-data-view-utils';
 import {GPUReduction} from './gpu-reduction';
 
 const HISTOGRAM_WORKGROUP_SIZE = 256;
@@ -22,22 +22,22 @@ const SCALAR_FORMATS = ['uint32', 'sint32', 'float32'] as const;
 /** Domain accepted by {@link GPUHistogram}. */
 export type GPUHistogramDomain<T extends GPUScalarFormat = GPUScalarFormat> =
   | readonly [number, number]
-  | GraphBufferView<T>
+  | GraphDataView<T>
   | 'auto';
 
 /** Properties for graph-native scalar histogram counting. */
 export type GPUHistogramProps<T extends GPUScalarFormat = GPUScalarFormat> = {
   id?: string;
-  input: GraphBufferView<T>;
-  output: GraphBufferView<'uint32'>;
+  input: GraphDataView<T>;
+  output: GraphDataView<'uint32'>;
   domain: GPUHistogramDomain<T>;
 };
 
 /** Graph-native histogram counting for packed 32-bit scalar values. */
 export class GPUHistogram<T extends GPUScalarFormat = GPUScalarFormat> {
   readonly id: string;
-  readonly input: GraphBufferView<T>;
-  readonly output: GraphBufferView<'uint32'>;
+  readonly input: GraphDataView<T>;
+  readonly output: GraphDataView<'uint32'>;
   readonly domain: GPUHistogramDomain<T>;
 
   constructor(props: GPUHistogramProps<T>) {
@@ -81,7 +81,7 @@ export class GPUHistogram<T extends GPUScalarFormat = GPUScalarFormat> {
         `${this.id}-auto-domain`,
         this.input.format,
         2
-      ) as GraphBufferView<T>;
+      ) as GraphDataView<T>;
       new GPUReduction({
         id: `${this.id}-extent`,
         input: this.input,
@@ -105,7 +105,7 @@ export class GPUHistogram<T extends GPUScalarFormat = GPUScalarFormat> {
 function addClearHistogramPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
-  output: GraphBufferView<'uint32'>
+  output: GraphDataView<'uint32'>
 ): void {
   const passId = `${id}-clear`;
   const source = /* wgsl */ `
@@ -130,9 +130,9 @@ function addHistogramPass<Parameters, T extends GPUScalarFormat>(
   graph: GPUCommandGraph<Parameters>,
   props: {
     id: string;
-    input: GraphBufferView<T>;
-    output: GraphBufferView<'uint32'>;
-    domain: readonly [number, number] | GraphBufferView<T>;
+    input: GraphDataView<T>;
+    output: GraphDataView<'uint32'>;
+    domain: readonly [number, number] | GraphDataView<T>;
   }
 ): void {
   const local = props.output.length <= MAXIMUM_LOCAL_BIN_COUNT;
@@ -207,7 +207,7 @@ function addHistogramPass<Parameters, T extends GPUScalarFormat>(
 const ELEMENT_COUNT: u32 = ${props.input.length}u;
 const BIN_COUNT: u32 = ${props.output.length}u;
 const INPUT_OFFSET: u32 = ${getViewElementOffset(props.input)}u;
-${gpuDomain ? `const DOMAIN_OFFSET: u32 = ${getViewElementOffset(props.domain as GraphBufferView)}u;` : ''}
+${gpuDomain ? `const DOMAIN_OFFSET: u32 = ${getViewElementOffset(props.domain as GraphDataView)}u;` : ''}
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
 @group(0) @binding(0) var<storage, read> inputValues: array<${shaderType}>;
 ${domainBinding}
@@ -245,7 +245,7 @@ ${integerBinningFunction}
   const resources: GraphBufferUse[] = [
     {buffer: props.input, usage: 'storage-read'},
     ...(gpuDomain
-      ? ([{buffer: props.domain as GraphBufferView, usage: 'storage-read'}] as GraphBufferUse[])
+      ? ([{buffer: props.domain as GraphDataView, usage: 'storage-read'}] as GraphBufferUse[])
       : []),
     {buffer: props.output, usage: 'storage-read-write'}
   ];
@@ -255,7 +255,7 @@ ${integerBinningFunction}
     resources,
     bindings: {
       inputValues: props.input,
-      ...(gpuDomain ? {domainValues: props.domain as GraphBufferView} : {}),
+      ...(gpuDomain ? {domainValues: props.domain as GraphDataView} : {}),
       outputCounts: props.output
     },
     dispatchCount: Math.ceil(props.input.length / HISTOGRAM_WORKGROUP_SIZE)
@@ -268,7 +268,7 @@ function addComputationPass<Parameters>(
     id: string;
     source: string;
     resources: GraphBufferUse[];
-    bindings: Record<string, GraphBufferView>;
+    bindings: Record<string, GraphDataView>;
     dispatchCount: number;
   }
 ): void {
@@ -322,7 +322,7 @@ function validateLiteralDomain(
 
 function isGPUHistogramDomainView<T extends GPUScalarFormat>(
   domain: GPUHistogramDomain<T>
-): domain is GraphBufferView<T> {
+): domain is GraphDataView<T> {
   return domain !== 'auto' && !Array.isArray(domain);
 }
 

--- a/modules/experimental/src/gpu-primitives/gpu-reduction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-reduction.ts
@@ -4,14 +4,14 @@
 
 import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphBufferUse, type GraphBufferView} from './gpu-command-graph';
+import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-command-graph';
 import {
   createTransientView,
   getViewBinding,
   getViewElementOffset,
   type GPUScalarFormat,
   validatePackedView
-} from './graph-buffer-view-utils';
+} from './graph-data-view-utils';
 
 const REDUCTION_WORKGROUP_SIZE = 256;
 const SCALAR_FORMATS = ['uint32', 'sint32', 'float32'] as const;
@@ -22,8 +22,8 @@ export type GPUReductionOperation = 'sum' | 'min' | 'max' | 'extent';
 /** Properties for a graph-native scalar reduction. */
 export type GPUReductionProps<T extends GPUScalarFormat = GPUScalarFormat> = {
   id?: string;
-  input: GraphBufferView<T>;
-  output: GraphBufferView<T>;
+  input: GraphDataView<T>;
+  output: GraphDataView<T>;
   operation: GPUReductionOperation;
 };
 
@@ -35,8 +35,8 @@ export type GPUReductionProps<T extends GPUScalarFormat = GPUScalarFormat> = {
  */
 export class GPUReduction<T extends GPUScalarFormat = GPUScalarFormat> {
   readonly id: string;
-  readonly input: GraphBufferView<T>;
-  readonly output: GraphBufferView<T>;
+  readonly input: GraphDataView<T>;
+  readonly output: GraphDataView<T>;
   readonly operation: GPUReductionOperation;
 
   constructor(props: GPUReductionProps<T>) {
@@ -74,8 +74,8 @@ export class GPUReduction<T extends GPUScalarFormat = GPUScalarFormat> {
     const valuesPerRow = this.operation === 'extent' ? 2 : 1;
     const needsValidity =
       this.input.format === 'float32' && ['min', 'max', 'extent'].includes(this.operation);
-    let inputValues: GraphBufferView<T> = this.input;
-    let inputValidity: GraphBufferView<'uint32'> | undefined;
+    let inputValues: GraphDataView<T> = this.input;
+    let inputValidity: GraphDataView<'uint32'> | undefined;
     let inputLength = this.input.length;
     let levelIndex = 0;
 
@@ -86,7 +86,7 @@ export class GPUReduction<T extends GPUScalarFormat = GPUScalarFormat> {
         `${this.id}-level-${levelIndex}-values`,
         this.input.format,
         outputLength * valuesPerRow
-      ) as GraphBufferView<T>;
+      ) as GraphDataView<T>;
       const outputValidity = needsValidity
         ? createTransientView(
             graph,
@@ -133,10 +133,10 @@ function addReductionLevelPass<Parameters, T extends GPUScalarFormat>(
     id: string;
     format: T;
     operation: GPUReductionOperation;
-    inputValues: GraphBufferView<T>;
-    inputValidity?: GraphBufferView<'uint32'>;
-    outputValues: GraphBufferView<T>;
-    outputValidity?: GraphBufferView<'uint32'>;
+    inputValues: GraphDataView<T>;
+    inputValidity?: GraphDataView<'uint32'>;
+    outputValues: GraphDataView<T>;
+    outputValidity?: GraphDataView<'uint32'>;
     inputLength: number;
     valuesPerRow: number;
     firstLevel: boolean;
@@ -231,7 +231,7 @@ var<workgroup> validityScratch: array<u32, ${REDUCTION_WORKGROUP_SIZE}>;
       ? ([{buffer: props.outputValidity, usage: 'storage-write'}] as GraphBufferUse[])
       : [])
   ];
-  const bindings: Record<string, GraphBufferView> = {inputValues: props.inputValues};
+  const bindings: Record<string, GraphDataView> = {inputValues: props.inputValues};
   if (props.inputValidity) bindings['inputValidity'] = props.inputValidity;
   bindings['outputValues'] = props.outputValues;
   if (props.outputValidity) bindings['outputValidity'] = props.outputValidity;
@@ -249,9 +249,9 @@ function addFinalizeReductionPass<Parameters, T extends GPUScalarFormat>(
   props: {
     id: string;
     format: T;
-    inputValues: GraphBufferView<T>;
-    inputValidity?: GraphBufferView<'uint32'>;
-    output: GraphBufferView<T>;
+    inputValues: GraphDataView<T>;
+    inputValidity?: GraphDataView<'uint32'>;
+    output: GraphDataView<T>;
     valuesPerRow: number;
   }
 ): void {
@@ -294,7 +294,7 @@ ${props.inputValidity ? '@group(0) @binding(1) var<storage, read> inputValidity:
 function addClearReductionPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
-  output: GraphBufferView<GPUScalarFormat>
+  output: GraphDataView<GPUScalarFormat>
 ): void {
   const passId = `${id}-clear`;
   const shaderType = getShaderType(output.format);
@@ -318,7 +318,7 @@ function addComputationPass<Parameters>(
     id: string;
     source: string;
     resources: GraphBufferUse[];
-    bindings: Record<string, GraphBufferView>;
+    bindings: Record<string, GraphDataView>;
     dispatchCount: number;
   }
 ): void {

--- a/modules/experimental/src/gpu-primitives/gpu-scan.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-scan.ts
@@ -4,27 +4,27 @@
 
 import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphBufferView} from './gpu-command-graph';
+import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
 import {
   createTransientView,
   getViewBinding,
   getViewElementOffset,
   validatePackedUint32View
-} from './graph-buffer-view-utils';
+} from './graph-data-view-utils';
 
 const SCAN_WORKGROUP_SIZE = 256;
 
 export type GPUScanProps = {
   id?: string;
-  input: GraphBufferView<'uint32'>;
-  output: GraphBufferView<'uint32'>;
+  input: GraphDataView<'uint32'>;
+  output: GraphDataView<'uint32'>;
 };
 
 /** Hierarchical exclusive prefix sum over packed uint32 graph buffers. */
 export class GPUScan {
   readonly id: string;
-  readonly input: GraphBufferView<'uint32'>;
-  readonly output: GraphBufferView<'uint32'>;
+  readonly input: GraphDataView<'uint32'>;
+  readonly output: GraphDataView<'uint32'>;
 
   constructor(props: GPUScanProps) {
     this.id = props.id ?? 'gpu-scan';
@@ -47,9 +47,9 @@ export class GPUScan {
     }
 
     const levels: Array<{
-      output: GraphBufferView<'uint32'>;
+      output: GraphDataView<'uint32'>;
       length: number;
-      blockOffsets?: GraphBufferView<'uint32'>;
+      blockOffsets?: GraphDataView<'uint32'>;
     }> = [];
     let levelInput = this.input;
     let levelOutput = this.output;
@@ -58,7 +58,7 @@ export class GPUScan {
 
     while (true) {
       const blockCount = Math.ceil(levelLength / SCAN_WORKGROUP_SIZE);
-      let blockSums: GraphBufferView<'uint32'> | undefined;
+      let blockSums: GraphDataView<'uint32'> | undefined;
       if (blockCount > 1) {
         blockSums = createTransientView(
           graph,
@@ -110,9 +110,9 @@ function addBlockScanPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   props: {
     id: string;
-    input: GraphBufferView<'uint32'>;
-    output: GraphBufferView<'uint32'>;
-    blockSums?: GraphBufferView<'uint32'>;
+    input: GraphDataView<'uint32'>;
+    output: GraphDataView<'uint32'>;
+    blockSums?: GraphDataView<'uint32'>;
     length: number;
     blockCount: number;
   }
@@ -207,8 +207,8 @@ function addBlockOffsetPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   props: {
     id: string;
-    output: GraphBufferView<'uint32'>;
-    blockOffsets: GraphBufferView<'uint32'>;
+    output: GraphDataView<'uint32'>;
+    blockOffsets: GraphDataView<'uint32'>;
     length: number;
   }
 ): void {

--- a/modules/experimental/src/gpu-primitives/gpu-sort.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-sort.ts
@@ -4,14 +4,14 @@
 
 import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphBufferUse, type GraphBufferView} from './gpu-command-graph';
+import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-command-graph';
 import {GPUScan} from './gpu-scan';
 import {
   createTransientView,
   getViewBinding,
   getViewElementOffset,
   validatePackedUint32View
-} from './graph-buffer-view-utils';
+} from './graph-data-view-utils';
 
 const BITONIC_WORKGROUP_SIZE = 256;
 const RADIX_WORKGROUP_SIZE = 256;
@@ -28,10 +28,10 @@ export type GPUSortDirection = 'ascending' | 'descending';
 /** Properties for one graph-native stable uint32 key/value sort. */
 export type GPUSortProps = {
   id?: string;
-  keys: GraphBufferView<'uint32'>;
-  values: GraphBufferView<'uint32'>;
-  outputKeys: GraphBufferView<'uint32'>;
-  outputValues: GraphBufferView<'uint32'>;
+  keys: GraphDataView<'uint32'>;
+  values: GraphDataView<'uint32'>;
+  outputKeys: GraphDataView<'uint32'>;
+  outputValues: GraphDataView<'uint32'>;
   algorithm?: GPUSortAlgorithm;
   direction?: GPUSortDirection;
 };
@@ -51,10 +51,10 @@ type BitonicStage = {
  */
 export class GPUSort {
   readonly id: string;
-  readonly keys: GraphBufferView<'uint32'>;
-  readonly values: GraphBufferView<'uint32'>;
-  readonly outputKeys: GraphBufferView<'uint32'>;
-  readonly outputValues: GraphBufferView<'uint32'>;
+  readonly keys: GraphDataView<'uint32'>;
+  readonly values: GraphDataView<'uint32'>;
+  readonly outputKeys: GraphDataView<'uint32'>;
+  readonly outputValues: GraphDataView<'uint32'>;
   readonly algorithm: GPUSortAlgorithm;
   readonly direction: GPUSortDirection;
   readonly resolvedAlgorithm: Exclude<GPUSortAlgorithm, 'auto'>;
@@ -198,7 +198,7 @@ function addBitonicSort<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GP
 function addBitonicInitializePass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   sort: GPUSort,
-  indices: GraphBufferView<'uint32'>,
+  indices: GraphDataView<'uint32'>,
   paddedLength: number
 ): void {
   const source = /* wgsl */ `
@@ -228,8 +228,8 @@ const INDICES_OFFSET: u32 = ${getViewElementOffset(indices)}u;
 function addBitonicStagePass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   sort: GPUSort,
-  indicesIn: GraphBufferView<'uint32'>,
-  indicesOut: GraphBufferView<'uint32'>,
+  indicesIn: GraphDataView<'uint32'>,
+  indicesOut: GraphDataView<'uint32'>,
   paddedLength: number,
   stage: BitonicStage
 ): void {
@@ -296,7 +296,7 @@ fn comes_before(leftIndex: u32, rightIndex: u32) -> bool {
 function addBitonicGatherPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   sort: GPUSort,
-  indices: GraphBufferView<'uint32'>
+  indices: GraphDataView<'uint32'>
 ): void {
   const source = /* wgsl */ `
 const LOGICAL_LENGTH: u32 = ${sort.keys.length}u;
@@ -397,8 +397,8 @@ function addRadixSort<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GPUS
 function addRadixClassifyPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   sort: GPUSort,
-  keys: GraphBufferView<'uint32'>,
-  flags: GraphBufferView<'uint32'>,
+  keys: GraphDataView<'uint32'>,
+  flags: GraphDataView<'uint32'>,
   bit: number
 ): void {
   const firstBit = sort.direction === 'ascending' ? 0 : 1;
@@ -434,12 +434,12 @@ const FLAGS_OFFSET: u32 = ${getViewElementOffset(flags)}u;
 function addRadixScatterPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   sort: GPUSort,
-  keys: GraphBufferView<'uint32'>,
-  values: GraphBufferView<'uint32'>,
-  flags: GraphBufferView<'uint32'>,
-  offsets: GraphBufferView<'uint32'>,
-  outputKeys: GraphBufferView<'uint32'>,
-  outputValues: GraphBufferView<'uint32'>,
+  keys: GraphDataView<'uint32'>,
+  values: GraphDataView<'uint32'>,
+  flags: GraphDataView<'uint32'>,
+  offsets: GraphDataView<'uint32'>,
+  outputKeys: GraphDataView<'uint32'>,
+  outputValues: GraphDataView<'uint32'>,
   bit: number
 ): void {
   const lastIndex = sort.keys.length - 1;
@@ -511,7 +511,7 @@ function addComputationPass<GraphParameters>(
     id: string;
     source: string;
     resources: GraphBufferUse[];
-    bindings: Record<string, GraphBufferView>;
+    bindings: Record<string, GraphDataView>;
     dispatchCount: number;
   }
 ): void {

--- a/modules/experimental/src/gpu-primitives/graph-data-view-utils.ts
+++ b/modules/experimental/src/gpu-primitives/graph-data-view-utils.ts
@@ -4,7 +4,7 @@
 
 import {Buffer, type Binding} from '@luma.gl/core';
 import {getGPUVectorFormatInfo, type GPUVectorFormat} from '@luma.gl/tables';
-import {GPUCommandGraph, type GraphBufferView} from './gpu-command-graph';
+import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
 
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 const STORAGE_BINDING_ALIGNMENT = 256;
@@ -14,10 +14,10 @@ export type GPUScalarFormat = 'uint32' | 'sint32' | 'float32';
 
 /** @internal */
 export function validatePackedView<T extends GPUVectorFormat>(
-  view: GraphBufferView,
+  view: GraphDataView,
   formats: readonly T[],
   name: string
-): asserts view is GraphBufferView<T> {
+): asserts view is GraphDataView<T> {
   const formatInfo = getGPUVectorFormatInfo(view.format);
   if (
     !formats.includes(view.format as T) ||
@@ -30,14 +30,14 @@ export function validatePackedView<T extends GPUVectorFormat>(
 }
 
 /** @internal */
-export function validatePackedUint32View(view: GraphBufferView, name: string): void {
+export function validatePackedUint32View(view: GraphDataView, name: string): void {
   validatePackedView(view, ['uint32'], name);
 }
 
 /** @internal */
 export function getViewBinding(
-  view: GraphBufferView,
-  getBuffer: (view: GraphBufferView) => Buffer
+  view: GraphDataView,
+  getBuffer: (view: GraphDataView) => Buffer
 ): Binding {
   const alignedByteOffset =
     Math.floor(view.byteOffset / STORAGE_BINDING_ALIGNMENT) * STORAGE_BINDING_ALIGNMENT;
@@ -54,7 +54,7 @@ export function getViewBinding(
 }
 
 /** Offset in 32-bit components from the aligned storage binding. @internal */
-export function getViewElementOffset(view: GraphBufferView): number {
+export function getViewElementOffset(view: GraphDataView): number {
   return (view.byteOffset % STORAGE_BINDING_ALIGNMENT) / UINT32_BYTE_LENGTH;
 }
 
@@ -64,12 +64,12 @@ export function createTransientView<T extends GPUVectorFormat, Parameters>(
   id: string,
   format: T,
   length: number
-): GraphBufferView<T> {
+): GraphDataView<T> {
   const formatInfo = getGPUVectorFormatInfo(format);
   const buffer = graph.createTransientBuffer({
     id,
     byteLength: Math.max(length, 1) * formatInfo.byteLength,
     usage: Buffer.STORAGE
   });
-  return graph.createBufferView(buffer, {format, length});
+  return graph.createDataView(buffer, {format, length});
 }

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -6,7 +6,7 @@ export {
   CompiledGPUCommandGraph,
   GPUCommandGraph,
   GraphBufferHandle,
-  GraphBufferView,
+  GraphDataView,
   GraphTextureHandle,
   GraphTextureView
 } from './gpu-command-graph';

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
@@ -116,7 +116,7 @@ test('GPUCommandGraph validates resources and overlapping lifetimes', async t =>
     /does not declare usage/,
     'node uses must be compatible with descriptors'
   );
-  const unaligned = validationGraph.createBufferView(copyOnly, {
+  const unaligned = validationGraph.createDataView(copyOnly, {
     format: 'uint32',
     length: 1,
     byteOffset: 2
@@ -128,7 +128,7 @@ test('GPUCommandGraph validates resources and overlapping lifetimes', async t =>
   );
   t.throws(
     () =>
-      validationGraph.createBufferView(copyOnly, {
+      validationGraph.createDataView(copyOnly, {
         format: 'uint32',
         length: 4,
         byteOffset: 4
@@ -285,8 +285,8 @@ test('GPUScan computes exclusive uint32 prefixes', async t => {
       {id: 'output', byteLength: outputBuffer.byteLength, usage: outputBuffer.usage},
       outputBuffer
     );
-    const input = graph.createBufferView(inputHandle, {format: 'uint32', length});
-    const output = graph.createBufferView(outputHandle, {format: 'uint32', length});
+    const input = graph.createDataView(inputHandle, {format: 'uint32', length});
+    const output = graph.createDataView(outputHandle, {format: 'uint32', length});
     new GPUScan({input, output}).addToGraph(graph);
     const compiled = graph.compile();
     const commandEncoder = device.createCommandEncoder({id: `scan-${length}-encoder`});
@@ -346,15 +346,15 @@ test('GPUCompaction preserves selected order and writes indirect instance count'
     {id: 'output', byteLength: outputBuffer.byteLength, usage: outputBuffer.usage},
     outputBuffer
   );
-  const valuesView = graph.createBufferView(valuesHandle, {
+  const valuesView = graph.createDataView(valuesHandle, {
     format: 'uint32',
     length: values.length
   });
-  const flagsView = graph.createBufferView(flagsHandle, {
+  const flagsView = graph.createDataView(flagsHandle, {
     format: 'uint32',
     length: flags.length
   });
-  const outputView = graph.createBufferView(outputHandle, {
+  const outputView = graph.createDataView(outputHandle, {
     format: 'uint32',
     length: values.length
   });
@@ -550,10 +550,10 @@ async function runCompaction(
     countBuffer
   );
   new GPUCompaction({
-    input: graph.createBufferView(valuesHandle, {format: 'uint32', length: values.length}),
-    flags: graph.createBufferView(flagsHandle, {format: 'uint32', length: flags.length}),
-    output: graph.createBufferView(outputHandle, {format: 'uint32', length: values.length}),
-    count: graph.createBufferView(countHandle, {format: 'uint32', length: 1})
+    input: graph.createDataView(valuesHandle, {format: 'uint32', length: values.length}),
+    flags: graph.createDataView(flagsHandle, {format: 'uint32', length: flags.length}),
+    output: graph.createDataView(outputHandle, {format: 'uint32', length: values.length}),
+    count: graph.createDataView(countHandle, {format: 'uint32', length: 1})
   }).addToGraph(graph);
   const compiled = graph.compile();
   const commandEncoder = device.createCommandEncoder({id: `compaction-${id}-encoder`});

--- a/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
@@ -237,9 +237,9 @@ test('GPU data analysis primitives validate layouts and ownership', async t => {
     byteLength: 64,
     usage: Buffer.STORAGE
   });
-  const input = graph.createBufferView(inputHandle, {format: 'uint32', length: 4});
-  const one = graph.createBufferView(outputHandle, {format: 'uint32', length: 1});
-  const two = graph.createBufferView(outputHandle, {format: 'uint32', length: 2});
+  const input = graph.createDataView(inputHandle, {format: 'uint32', length: 4});
+  const one = graph.createDataView(outputHandle, {format: 'uint32', length: 1});
+  const two = graph.createDataView(outputHandle, {format: 'uint32', length: 2});
   t.throws(
     () => new GPUReduction({input, output: two, operation: 'sum'}),
     /must contain 1 row/,
@@ -255,7 +255,7 @@ test('GPU data analysis primitives validate layouts and ownership', async t => {
     /finite \[min, max\]/,
     'inverted literal histogram domain is rejected'
   );
-  const positions = graph.createBufferView(inputHandle, {format: 'float32x2', length: 4});
+  const positions = graph.createDataView(inputHandle, {format: 'float32x2', length: 4});
   t.throws(
     () => new GPUGridBinning({positions, output: two, gridSize: [2, 2], bounds: [0, 0, 1, 1]}),
     /output.length/,
@@ -394,7 +394,7 @@ function importView<T extends GPUVectorFormat>(
     {id, byteLength: buffer.byteLength, usage: buffer.usage},
     buffer
   );
-  return graph.createBufferView(handle, {format, length});
+  return graph.createDataView(handle, {format, length});
 }
 
 async function readUint32(buffer: Buffer, length: number): Promise<number[]> {

--- a/modules/experimental/test/gpu-primitives/gpu-sort.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-sort.spec.ts
@@ -133,16 +133,16 @@ test('GPUSort validates layouts, lengths, graph ownership, and output buffers', 
     byteLength: 32,
     usage: Buffer.STORAGE
   });
-  const keys = graph.createBufferView(keysHandle, {format: 'uint32', length: 4});
-  const values = graph.createBufferView(valuesHandle, {format: 'uint32', length: 4});
-  const outputKeys = graph.createBufferView(outputKeysHandle, {format: 'uint32', length: 4});
-  const outputValues = graph.createBufferView(outputValuesHandle, {format: 'uint32', length: 4});
+  const keys = graph.createDataView(keysHandle, {format: 'uint32', length: 4});
+  const values = graph.createDataView(valuesHandle, {format: 'uint32', length: 4});
+  const outputKeys = graph.createDataView(outputKeysHandle, {format: 'uint32', length: 4});
+  const outputValues = graph.createDataView(outputValuesHandle, {format: 'uint32', length: 4});
 
   t.throws(
     () =>
       new GPUSort({
         keys,
-        values: graph.createBufferView(valuesHandle, {format: 'uint32', length: 3}),
+        values: graph.createDataView(valuesHandle, {format: 'uint32', length: 3}),
         outputKeys,
         outputValues
       }),
@@ -154,7 +154,7 @@ test('GPUSort validates layouts, lengths, graph ownership, and output buffers', 
     /separate buffers/,
     'input/output alias is rejected'
   );
-  const unaligned = graph.createBufferView(outputKeysHandle, {
+  const unaligned = graph.createDataView(outputKeysHandle, {
     format: 'uint32',
     length: 1,
     byteOffset: 2
@@ -253,7 +253,7 @@ function importView(graph: GPUCommandGraph, id: string, buffer: Buffer, length: 
     {id, byteLength: buffer.byteLength, usage: buffer.usage},
     buffer
   );
-  return graph.createBufferView(handle, {format: 'uint32', length});
+  return graph.createDataView(handle, {format: 'uint32', length});
 }
 
 function makeUncompiledSort(
@@ -265,7 +265,7 @@ function makeUncompiledSort(
   const byteLength = Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT;
   const createView = (id: string) => {
     const handle = graph.createTransientBuffer({id, byteLength, usage: Buffer.STORAGE});
-    return graph.createBufferView(handle, {format: 'uint32', length});
+    return graph.createDataView(handle, {format: 'uint32', length});
   };
   return new GPUSort({
     keys: createView('keys'),


### PR DESCRIPTION
## Goals

- Align command-graph terminology with the tables model, where one `GPUData` represents one typed buffer range.
- Keep raw graph allocations and hazard tracking explicitly buffer-oriented.

## Changes

- Rename `GraphBufferView` to `GraphDataView`.
- Rename `createBufferView()` to `createDataView()`.
- Update primitives, examples, tests, utility naming, and API documentation.
- Preserve `GraphBufferHandle`, `GraphBufferUse`, scheduling, ownership, and runtime behavior.

## Verification

- `nvm use`
- `yarn install --immutable`
- `yarn lint fix`
- `yarn build`
- `yarn examples:typecheck`
- `yarn test`
- `yarn website:build`
- `(cd website && yarn build)`

## Follow-up

Fixed-width multi-chunk `GPUVector` imports will be proposed separately without primitive algorithm changes.
