### PR TITLE
[codex] Add composable FontAtlas builders

### DIFF
--- a/docs/api-reference/text/README.md
+++ b/docs/api-reference/text/README.md
@@ -2,6 +2,18 @@
 
 `@luma.gl/text` provides experimental GPU-only 2D text rendering utilities.
 
+## Font Atlases
+
+`FontAtlas` is the common input format for atlas-backed text. It keeps glyph metrics, baseline and
+line-height data, optional kerning, image pages, and fragment sampling settings together so layout
+and rendering code do not branch on the source font format.
+
+- `buildBitmapFontAtlas()` measures and rasterizes a browser font into a bitmap atlas.
+- `buildSdfFontAtlas()` uses the same measurement and packing path, but rasterizes glyphs as signed
+  distance fields and records the required threshold and smoothing settings.
+
+Both builders cache identical inputs and incrementally add newly requested characters.
+
 `@luma.gl/arrow` owns Arrow source data, source mapping, upload, and Arrow UTF-8/dictionary preparation. It converts Arrow vectors into `GPUVector` objects or prepared GPU state, then constructs renderer models that only know about GPU-resident resources.
 
 ## Public Architecture

--- a/modules/arrow/src/arrow/renderers/text/conversion/convert-arrow-text-vectors.ts
+++ b/modules/arrow/src/arrow/renderers/text/conversion/convert-arrow-text-vectors.ts
@@ -121,6 +121,15 @@ const BITMAP_TEXT_SDF_THRESHOLD = -1;
 const INVALID_DICTIONARY_INDEX = 0xffffffff;
 const STORAGE_RENDER_CONFIG_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT * 4;
 const TEXT_DICTIONARY_RENDER_CONFIG_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT * 4;
+
+/** Returns the image accepted by the current single-page text renderers. */
+function getSinglePageFontAtlasData(fontAtlas: FontAtlas): FontAtlas['pages'][number] {
+  if (fontAtlas.pages.length !== 1) {
+    throw new Error('This text renderer requires a FontAtlas with exactly one image page');
+  }
+  return fontAtlas.pages[0];
+}
+
 /** Resolved atlas mapping and layout metrics shared by attribute and storage conversion. */
 export type ResolvedCharacterMapping = {
   /** Character-to-atlas-frame mapping used while generating glyph records. */
@@ -1337,7 +1346,7 @@ function makeArrowTextModelProps(
   const atlasTexture = mappingState.fontAtlas
     ? new DynamicTexture(device, {
         id: `${props.id || 'arrow-text-model'}-atlas`,
-        data: mappingState.fontAtlas.data
+        data: getSinglePageFontAtlasData(mappingState.fontAtlas)
       })
     : undefined;
 
@@ -1547,7 +1556,7 @@ export function createArrowTextStorageState(
   const atlasTexture = mappingState.fontAtlas
     ? new DynamicTexture(device, {
         id: `${props.id || 'arrow-text-storage-model'}-atlas`,
-        data: mappingState.fontAtlas.data
+        data: getSinglePageFontAtlasData(mappingState.fontAtlas)
       })
     : undefined;
   const useGpuUtf8Decode = Boolean(
@@ -1896,7 +1905,7 @@ export function createTextStorageStateFromGPUVectors(
   const atlasTexture = mappingState.fontAtlas
     ? new DynamicTexture(device, {
         id: `${props.id || 'text-storage-model'}-atlas`,
-        data: mappingState.fontAtlas.data
+        data: getSinglePageFontAtlasData(mappingState.fontAtlas)
       })
     : undefined;
   const glyphDefinitions = buildGpuUtf8GlyphDefinitions({
@@ -2115,7 +2124,7 @@ export function createArrowTextDictionaryStorageState(
   const atlasTexture = mappingState.fontAtlas
     ? new DynamicTexture(device, {
         id: `${props.id || 'arrow-text-dictionary-storage-model'}-atlas`,
-        data: mappingState.fontAtlas.data
+        data: getSinglePageFontAtlasData(mappingState.fontAtlas)
       })
     : undefined;
 

--- a/modules/text/README.md
+++ b/modules/text/README.md
@@ -2,6 +2,9 @@
 
 Experimental 2D text utilities for luma.gl. The package contains:
 
+- `FontAtlas`, the normalized glyph metrics, image pages, and sampling settings used by
+  atlas-backed text.
+- `buildBitmapFontAtlas()` and `buildSdfFontAtlas()`, explicit browser-font atlas builders.
 - GPU-only text input schemas and preparation primitives.
 - `TextAttributeModel`, a one-line label renderer that renders prepared attribute vertex buffers.
 - `TextStorageModel`, a WebGPU-only renderer that renders prepared storage-backed glyph state.

--- a/modules/text/src/text-2d/atlas/browser-font-atlas.ts
+++ b/modules/text/src/text-2d/atlas/browser-font-atlas.ts
@@ -1,0 +1,266 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+// Adapted from deck.gl text atlas utilities under the MIT License.
+
+/* global document, ImageData, OffscreenCanvas */
+import {log} from '@luma.gl/core';
+import {buildMapping} from './text-utils';
+import type {FontAtlas, FontAtlasRenderSettings} from './font-atlas';
+import LRUCache from './lru-cache';
+
+/** Character collection accepted by browser-backed font atlas builders. */
+export type FontAtlasCharacterSet = Set<string> | string[] | string;
+
+/** Shared browser font and packing options used by bitmap and SDF builders. */
+export type BrowserFontAtlasSettings = {
+  /** CSS font-family expression used by canvas text measurement. */
+  fontFamily?: string;
+  /** CSS font weight used by canvas text measurement and rasterization. */
+  fontWeight?: string | number;
+  /** Characters that must be available in the resulting atlas. */
+  characterSet?: FontAtlasCharacterSet;
+  /** Rasterization size in pixels. */
+  fontSize?: number;
+  /** Empty pixels reserved around every packed glyph. */
+  buffer?: number;
+};
+
+/** Browser font settings after defaults have been applied. */
+export type ResolvedBrowserFontAtlasSettings = Required<BrowserFontAtlasSettings>;
+
+/** Glyph measurement and rasterization callbacks used by the shared packing implementation. */
+export type BrowserFontRenderer = {
+  /** Measures either one glyph or the font-wide ascent and descent when no glyph is supplied. */
+  measure(character?: string): {
+    advance: number;
+    width: number;
+    ascent: number;
+    descent: number;
+  };
+  /** Rasterizes one glyph and reports how its image is offset from the measured frame. */
+  draw(character: string): {
+    data: ImageData;
+    left?: number;
+    top?: number;
+  };
+};
+
+type BrowserFontAtlasBuildOptions = {
+  settings: ResolvedBrowserFontAtlasSettings;
+  cacheKey: string;
+  renderSettings: FontAtlasRenderSettings;
+  createRenderer?: (defaultMeasure: BrowserFontRenderer['measure']) => BrowserFontRenderer;
+};
+
+const DEFAULT_BROWSER_FONT_ATLAS_SETTINGS: ResolvedBrowserFontAtlasSettings = {
+  fontFamily: 'Monaco, monospace',
+  fontWeight: 'normal',
+  characterSet: getDefaultCharacterSet(),
+  fontSize: 64,
+  buffer: 4
+};
+const MAX_CANVAS_WIDTH = 1024;
+const DEFAULT_ASCENT = 0.9;
+const DEFAULT_DESCENT = 0.3;
+const CACHE_LIMIT = 3;
+
+let cache = new LRUCache<FontAtlas>(CACHE_LIMIT);
+
+/** Increases the process-wide generated atlas LRU capacity. */
+export function setGeneratedFontAtlasCacheLimit(limit: number): void {
+  log.assert(Number.isFinite(limit) && limit >= CACHE_LIMIT, 'Invalid cache limit');
+  cache = new LRUCache(limit);
+}
+
+/** Applies stable browser-font defaults without constructing an atlas. */
+export function resolveBrowserFontAtlasSettings(
+  props: BrowserFontAtlasSettings
+): ResolvedBrowserFontAtlasSettings {
+  return {...DEFAULT_BROWSER_FONT_ATLAS_SETTINGS, ...props};
+}
+
+/** Packs and rasterizes a browser font using a source-specific glyph renderer. */
+export function buildBrowserFontAtlas(options: BrowserFontAtlasBuildOptions): FontAtlas {
+  const {settings, cacheKey, renderSettings} = options;
+  const characterSet = getNewCharacters(cacheKey, settings.characterSet);
+  const cachedFontAtlas = cache.get(cacheKey);
+  if (cachedFontAtlas && characterSet.size === 0) {
+    return {...cachedFontAtlas, renderSettings};
+  }
+
+  const fontAtlas = buildGeneratedFontAtlas(options, characterSet, cachedFontAtlas);
+  cache.set(cacheKey, fontAtlas);
+  return fontAtlas;
+}
+
+function buildGeneratedFontAtlas(
+  options: BrowserFontAtlasBuildOptions,
+  characterSet: Set<string>,
+  cachedFontAtlas?: FontAtlas
+): FontAtlas {
+  const {settings, renderSettings, createRenderer} = options;
+  const {fontFamily, fontWeight, fontSize, buffer} = settings;
+  let canvas = cachedFontAtlas?.pages[0] as HTMLCanvasElement | OffscreenCanvas | undefined;
+  if (!canvas) {
+    canvas = createAtlasCanvas(MAX_CANVAS_WIDTH);
+    canvas.width = MAX_CANVAS_WIDTH;
+  }
+  const context = canvas.getContext('2d', {willReadFrequently: true});
+  if (!context) {
+    throw new Error('Font atlas builders require a 2D canvas context');
+  }
+  setTextStyle(context, fontFamily, fontSize, fontWeight);
+  const defaultMeasure = (character?: string) => measureText(context, fontSize, character);
+  const renderer = createRenderer?.(defaultMeasure);
+
+  const {mapping, canvasHeight, xOffset, yOffsetMin, yOffsetMax} = buildMapping({
+    measureText: character => (renderer ? renderer.measure(character) : defaultMeasure(character)),
+    buffer,
+    characterSet,
+    maxCanvasWidth: MAX_CANVAS_WIDTH,
+    ...(cachedFontAtlas && {
+      mapping: cachedFontAtlas.mapping,
+      xOffset: cachedFontAtlas.xOffset,
+      yOffsetMin: cachedFontAtlas.yOffsetMin,
+      yOffsetMax: cachedFontAtlas.yOffsetMax
+    })
+  });
+
+  if (canvas.height !== canvasHeight) {
+    const imageData =
+      canvas.height > 0 ? context.getImageData(0, 0, canvas.width, canvas.height) : null;
+    canvas.height = canvasHeight;
+    if (imageData) {
+      context.putImageData(imageData, 0, 0);
+    }
+  }
+  setTextStyle(context, fontFamily, fontSize, fontWeight);
+  drawCharacters(context, characterSet, mapping, renderer);
+
+  const fontMetrics = renderer ? renderer.measure() : defaultMeasure();
+  return {
+    baselineOffset: (fontMetrics.ascent - fontMetrics.descent) / 2,
+    lineHeight: fontSize,
+    xOffset,
+    yOffsetMin,
+    yOffsetMax,
+    mapping,
+    renderSettings,
+    pages: [canvas],
+    width: canvas.width,
+    height: canvas.height
+  };
+}
+
+function drawCharacters(
+  context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  characterSet: Set<string>,
+  mapping: FontAtlas['mapping'],
+  renderer: BrowserFontRenderer | undefined
+): void {
+  if (!renderer) {
+    for (const character of characterSet) {
+      const frame = mapping[character];
+      context.fillText(character, frame.x, frame.y + frame.anchorY);
+    }
+    return;
+  }
+
+  for (const character of characterSet) {
+    const frame = mapping[character];
+    const {data, left = 0, top = 0} = renderer.draw(character);
+    const x = frame.x - left;
+    const y = frame.y - top;
+    const x0 = Math.max(0, Math.round(x));
+    const y0 = Math.max(0, Math.round(y));
+    const width = Math.min(data.width, context.canvas.width - x0);
+    const height = Math.min(data.height, context.canvas.height - y0);
+    context.putImageData(data, x0, y0, 0, 0, width, height);
+    frame.x += x0 - x;
+    frame.y += y0 - y;
+  }
+}
+
+function getNewCharacters(cacheKey: string, characterSet: FontAtlasCharacterSet): Set<string> {
+  const newCharacterSet =
+    typeof characterSet === 'string' ? new Set(Array.from(characterSet)) : new Set(characterSet);
+  const cachedFontAtlas = cache.get(cacheKey);
+  if (!cachedFontAtlas) {
+    return newCharacterSet;
+  }
+  for (const character in cachedFontAtlas.mapping) {
+    newCharacterSet.delete(character);
+  }
+  return newCharacterSet;
+}
+
+function setTextStyle(
+  context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  fontFamily: string,
+  fontSize: number,
+  fontWeight: string | number
+): void {
+  context.font = `${fontWeight} ${fontSize}px ${fontFamily}`;
+  context.fillStyle = '#000';
+  context.textBaseline = 'alphabetic';
+  context.textAlign = 'left';
+}
+
+function measureText(
+  context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+  fontSize: number,
+  character: string | undefined
+): ReturnType<BrowserFontRenderer['measure']> {
+  if (character === undefined) {
+    const fontMetrics = context.measureText('A');
+    if (fontMetrics.fontBoundingBoxAscent) {
+      return {
+        advance: 0,
+        width: 0,
+        ascent: Math.ceil(fontMetrics.fontBoundingBoxAscent),
+        descent: Math.ceil(fontMetrics.fontBoundingBoxDescent)
+      };
+    }
+    return {
+      advance: 0,
+      width: 0,
+      ascent: fontSize * DEFAULT_ASCENT,
+      descent: fontSize * DEFAULT_DESCENT
+    };
+  }
+
+  const metrics = context.measureText(character);
+  if (!metrics.actualBoundingBoxAscent) {
+    return {
+      advance: metrics.width,
+      width: metrics.width,
+      ascent: fontSize * DEFAULT_ASCENT,
+      descent: fontSize * DEFAULT_DESCENT
+    };
+  }
+  return {
+    advance: metrics.width,
+    width: Math.ceil(metrics.actualBoundingBoxRight - metrics.actualBoundingBoxLeft),
+    ascent: Math.ceil(metrics.actualBoundingBoxAscent),
+    descent: Math.ceil(metrics.actualBoundingBoxDescent)
+  };
+}
+
+function createAtlasCanvas(width: number): HTMLCanvasElement | OffscreenCanvas {
+  if (typeof OffscreenCanvas !== 'undefined') {
+    return new OffscreenCanvas(width, 0);
+  }
+  if (typeof document === 'undefined') {
+    throw new Error('Font atlas builders require OffscreenCanvas or a browser-like document');
+  }
+  return document.createElement('canvas');
+}
+
+function getDefaultCharacterSet(): string[] {
+  const characterSet: string[] = [];
+  for (let code = 32; code < 128; code++) {
+    characterSet.push(String.fromCharCode(code));
+  }
+  return characterSet;
+}

--- a/modules/text/src/text-2d/atlas/font-atlas-manager.ts
+++ b/modules/text/src/text-2d/atlas/font-atlas-manager.ts
@@ -7,7 +7,10 @@
 import TinySDF from '@mapbox/tiny-sdf';
 import {log} from '@luma.gl/core';
 import {buildMapping, type CharacterMapping} from './text-utils';
+import type {FontAtlas} from './font-atlas';
 import LRUCache from './lru-cache';
+
+export type {FontAtlas} from './font-atlas';
 
 function getDefaultCharacterSet(): string[] {
   const characterSet: string[] = [];
@@ -59,17 +62,6 @@ const MAX_CANVAS_WIDTH = 1024;
 const DEFAULT_ASCENT = 0.9;
 const DEFAULT_DESCENT = 0.3;
 const CACHE_LIMIT = 3;
-
-export type FontAtlas = {
-  baselineOffset: number;
-  xOffset: number;
-  yOffsetMin: number;
-  yOffsetMax: number;
-  mapping: CharacterMapping;
-  data: HTMLCanvasElement | OffscreenCanvas;
-  width: number;
-  height: number;
-};
 
 export type FontAtlasBuildMetrics = Readonly<{
   cacheStatus: 'hit' | 'rebuild' | 'incremental';
@@ -222,7 +214,9 @@ export default class FontAtlasManager {
         glyphCount: 0,
         atlasWidth: cachedFontAtlas.width,
         atlasHeight: cachedFontAtlas.height,
-        usedOffscreenCanvas: isOffscreenCanvas(cachedFontAtlas.data)
+        usedOffscreenCanvas: isOffscreenCanvas(
+          cachedFontAtlas.pages[0] as HTMLCanvasElement | OffscreenCanvas
+        )
       };
       return;
     }
@@ -241,7 +235,7 @@ export default class FontAtlasManager {
   ): {atlas: FontAtlas; metrics: FontAtlasBuildMetrics} {
     const totalBuildStartTime = getNow();
     const {fontFamily, fontWeight, fontSize, buffer, sdf} = this.props;
-    let canvas = cachedFontAtlas?.data;
+    let canvas = cachedFontAtlas?.pages[0] as HTMLCanvasElement | OffscreenCanvas | undefined;
     let canvasPreparationTimeMs = 0;
     if (!canvas) {
       const canvasPreparationStartTime = getNow();
@@ -325,11 +319,15 @@ export default class FontAtlasManager {
     const fontMetrics = renderer ? renderer.measure() : defaultMeasure();
     const atlas = {
       baselineOffset: (fontMetrics.ascent - fontMetrics.descent) / 2,
+      lineHeight: fontSize,
       xOffset,
       yOffsetMin,
       yOffsetMax,
       mapping,
-      data: canvas,
+      renderSettings: sdf
+        ? {mode: 'sdf' as const, threshold: 1 - this.props.cutoff, smoothing: this.props.smoothing}
+        : {mode: 'bitmap' as const, threshold: 0, smoothing: 0},
+      pages: [canvas],
       width: canvas.width,
       height: canvas.height
     };
@@ -345,7 +343,7 @@ export default class FontAtlasManager {
         glyphCount: characterSet.size,
         atlasWidth: atlas.width,
         atlasHeight: atlas.height,
-        usedOffscreenCanvas: isOffscreenCanvas(atlas.data)
+        usedOffscreenCanvas: isOffscreenCanvas(atlas.pages[0])
       }
     };
   }

--- a/modules/text/src/text-2d/atlas/font-atlas.ts
+++ b/modules/text/src/text-2d/atlas/font-atlas.ts
@@ -1,0 +1,51 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ExternalImage} from '@luma.gl/core';
+import type {CharacterMapping, TextKerning} from './text-utils';
+
+/** Sampling algorithm used to recover glyph coverage from an atlas page. */
+export type FontAtlasRenderMode = 'bitmap' | 'sdf';
+
+/** Fragment-stage parameters associated with one font atlas. */
+export type FontAtlasRenderSettings = {
+  /** Atlas encoding interpreted by the text fragment shader. */
+  mode: FontAtlasRenderMode;
+  /** Coverage boundary used by distance-field sampling. Ignored for bitmap atlases. */
+  threshold: number;
+  /** Width of the distance-field transition. Ignored for bitmap atlases. */
+  smoothing: number;
+};
+
+/**
+ * Renderer-independent description of an atlas-backed font.
+ *
+ * Builders normalize browser bitmap fonts, browser SDF fonts, and externally generated font
+ * descriptors into this shape. Layout and rendering code can therefore consume glyph metrics and
+ * image pages without knowing how the atlas was produced.
+ */
+export type FontAtlas = {
+  /** Vertical offset from the line origin to the font baseline, in atlas pixels. */
+  baselineOffset: number;
+  /** Recommended distance between adjacent text baselines, in atlas pixels. */
+  lineHeight: number;
+  /** Horizontal packing cursor retained when a generated atlas is extended. */
+  xOffset: number;
+  /** Smallest packed glyph y offset retained when a generated atlas is extended. */
+  yOffsetMin: number;
+  /** Largest packed glyph y offset retained when a generated atlas is extended. */
+  yOffsetMax: number;
+  /** Unicode character to glyph frame and advance mapping. */
+  mapping: CharacterMapping;
+  /** Optional pair-kerning table for layout engines that support kerning. */
+  kerning?: TextKerning;
+  /** Sampling parameters that travel with the atlas instead of renderer-specific props. */
+  renderSettings: FontAtlasRenderSettings;
+  /** One or more equally sized image pages. Glyph mappings select pages by array layer. */
+  pages: readonly ExternalImage[];
+  /** Width of every atlas page in pixels. */
+  width: number;
+  /** Height of every atlas page in pixels. */
+  height: number;
+};

--- a/modules/text/src/text-2d/atlas/text-utils.ts
+++ b/modules/text/src/text-2d/atlas/text-utils.ts
@@ -14,12 +14,67 @@ export type Character = {
   y: number;
   width: number;
   height: number;
+  /** Atlas array layer. Omitted by one-page generated atlases. */
+  atlasPage?: number;
   anchorX: number;
   anchorY: number;
+  /** Glyph quad origin relative to the current pen. Defaults to `anchorX`. */
+  layoutOffsetX?: number;
+  /** Glyph quad vertical offset relative to the line baseline. Defaults to zero. */
+  layoutOffsetY?: number;
   advance: number;
 };
 
+/** Unicode character to glyph frame and advance mapping. */
 export type CharacterMapping = Record<string, Character>;
+
+/** One pair-kerning adjustment expressed as Unicode code points and font units. */
+export type TextKerningPair = Readonly<{
+  first: number;
+  second: number;
+  amount: number;
+}>;
+
+/** Pair-kerning data in both serializable and constant-time lookup forms. */
+export type TextKerning = Readonly<{
+  pairs: readonly TextKerningPair[];
+  lookup: ReadonlyMap<number, number>;
+}>;
+
+const TEXT_KERNING_CODE_POINT_BASE = 0x110000;
+
+/** Returns the pair-kerning adjustment between two Unicode code points. */
+export function getTextKerningOffset(
+  kerning: TextKerning | undefined,
+  firstCodePoint: number | undefined,
+  secondCodePoint: number
+): number {
+  return firstCodePoint === undefined
+    ? 0
+    : (kerning?.lookup.get(firstCodePoint * TEXT_KERNING_CODE_POINT_BASE + secondCodePoint) ?? 0);
+}
+
+/** Creates an immutable kerning descriptor and lookup table, or `undefined` for no pairs. */
+export function createTextKerning(pairs: readonly TextKerningPair[]): TextKerning | undefined {
+  if (pairs.length === 0) {
+    return undefined;
+  }
+  const lookup = new Map<number, number>();
+  for (const pair of pairs) {
+    lookup.set(pair.first * TEXT_KERNING_CODE_POINT_BASE + pair.second, pair.amount);
+  }
+  return {pairs, lookup};
+}
+
+/** Returns a glyph's atlas array layer, defaulting legacy mappings to page zero. */
+export function getCharacterAtlasPage(character: Character): number {
+  return character.atlasPage ?? 0;
+}
+
+/** Returns the glyph quad offset used by baseline-aware layout. */
+export function getCharacterLayoutOffset(character: Character): [number, number] {
+  return [character.layoutOffsetX ?? character.anchorX, character.layoutOffsetY ?? 0];
+}
 
 export function nextPowOfTwo(number: number): number {
   return number === 0 ? 0 : Math.pow(2, Math.ceil(Math.log2(number)));

--- a/modules/text/src/text-2d/build-bitmap-font-atlas.ts
+++ b/modules/text/src/text-2d/build-bitmap-font-atlas.ts
@@ -1,0 +1,29 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  buildBrowserFontAtlas,
+  resolveBrowserFontAtlasSettings,
+  type BrowserFontAtlasSettings
+} from './atlas/browser-font-atlas';
+import type {FontAtlas} from './atlas/font-atlas';
+
+/** Browser font and packing options accepted by {@link buildBitmapFontAtlas}. */
+export type BitmapFontAtlasSettings = BrowserFontAtlasSettings;
+
+/**
+ * Builds a browser-font bitmap atlas in the common {@link FontAtlas} format.
+ *
+ * Repeated calls with the same font settings reuse the generated canvas. Supplying additional
+ * characters incrementally extends that canvas and its mapping.
+ */
+export function buildBitmapFontAtlas(props: BitmapFontAtlasSettings = {}): FontAtlas {
+  const settings = resolveBrowserFontAtlasSettings(props);
+  const {fontFamily, fontWeight, fontSize, buffer} = settings;
+  return buildBrowserFontAtlas({
+    settings,
+    cacheKey: `bitmap ${fontFamily} ${fontWeight} ${fontSize} ${buffer}`,
+    renderSettings: {mode: 'bitmap', threshold: 0, smoothing: 0}
+  });
+}

--- a/modules/text/src/text-2d/build-sdf-font-atlas.ts
+++ b/modules/text/src/text-2d/build-sdf-font-atlas.ts
@@ -1,0 +1,95 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/* global ImageData */
+import TinySDF from '@mapbox/tiny-sdf';
+import {
+  buildBrowserFontAtlas,
+  resolveBrowserFontAtlasSettings,
+  type BrowserFontAtlasSettings,
+  type BrowserFontRenderer
+} from './atlas/browser-font-atlas';
+import type {FontAtlas} from './atlas/font-atlas';
+
+/** Browser font, packing, and distance-field options accepted by {@link buildSdfFontAtlas}. */
+export type SdfFontAtlasSettings = BrowserFontAtlasSettings & {
+  /** TinySDF cutoff used while generating glyph distance values. */
+  cutoff?: number;
+  /** TinySDF search radius in pixels. */
+  radius?: number;
+  /** Fragment-stage transition width stored with the resulting atlas. */
+  smoothing?: number;
+};
+
+const DEFAULT_SDF_FONT_ATLAS_SETTINGS: Required<
+  Pick<SdfFontAtlasSettings, 'cutoff' | 'radius' | 'smoothing'>
+> = {
+  cutoff: 0.25,
+  radius: 12,
+  smoothing: 0.1
+};
+
+/**
+ * Builds a browser-font signed-distance-field atlas in the common {@link FontAtlas} format.
+ *
+ * Font measurement and packing are shared with the bitmap builder; only glyph rasterization and
+ * the attached fragment sampling settings differ.
+ */
+export function buildSdfFontAtlas(props: SdfFontAtlasSettings = {}): FontAtlas {
+  const {cutoff, radius, smoothing} = {...DEFAULT_SDF_FONT_ATLAS_SETTINGS, ...props};
+  const settings = resolveBrowserFontAtlasSettings(props);
+  const {fontFamily, fontWeight, fontSize, buffer} = settings;
+  return buildBrowserFontAtlas({
+    settings,
+    cacheKey: `sdf ${fontFamily} ${fontWeight} ${fontSize} ${buffer} ${radius} ${cutoff}`,
+    renderSettings: {
+      mode: 'sdf',
+      threshold: 1 - cutoff,
+      smoothing: Math.max(0, smoothing)
+    },
+    createRenderer: defaultMeasure => ({
+      measure: defaultMeasure,
+      draw: createSdfGlyphRenderer({
+        fontFamily,
+        fontWeight,
+        fontSize,
+        buffer,
+        radius,
+        cutoff
+      })
+    })
+  });
+}
+
+function createSdfGlyphRenderer({
+  fontSize,
+  buffer,
+  radius,
+  cutoff,
+  fontFamily,
+  fontWeight
+}: Required<
+  Pick<
+    SdfFontAtlasSettings,
+    'fontSize' | 'buffer' | 'radius' | 'cutoff' | 'fontFamily' | 'fontWeight'
+  >
+>): BrowserFontRenderer['draw'] {
+  const tinySdf = new TinySDF({
+    fontSize,
+    buffer,
+    radius,
+    cutoff,
+    fontFamily,
+    fontWeight: `${fontWeight}`
+  });
+
+  return (character: string) => {
+    const {data, width, height} = tinySdf.draw(character);
+    const imageData = new ImageData(width, height);
+    for (let index = 0; index < data.length; index++) {
+      imageData.data[4 * index + 3] = data[index];
+    }
+    return {data: imageData, left: buffer, top: buffer};
+  };
+}

--- a/modules/text/src/text-2d/index.ts
+++ b/modules/text/src/text-2d/index.ts
@@ -6,11 +6,16 @@ export {
   default as FontAtlasManager,
   DEFAULT_FONT_SETTINGS,
   setFontAtlasCacheLimit,
-  type FontAtlas,
   type FontAtlasBuildMetrics,
   type FontRenderer,
   type FontSettings
 } from './atlas/font-atlas-manager';
+export {type FontAtlas} from './atlas/font-atlas';
+export {
+  buildBitmapFontAtlas,
+  type BitmapFontAtlasSettings
+} from './build-bitmap-font-atlas';
+export {buildSdfFontAtlas, type SdfFontAtlasSettings} from './build-sdf-font-atlas';
 export {
   autoWrapping,
   buildMapping,

--- a/modules/text/test/text-2d/font-atlas-builders.spec.ts
+++ b/modules/text/test/text-2d/font-atlas-builders.spec.ts
@@ -1,0 +1,76 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {isBrowser} from '@probe.gl/env';
+import {
+  buildBitmapFontAtlas,
+  buildSdfFontAtlas,
+  type BitmapFontAtlasSettings,
+  type FontAtlas
+} from '../../src';
+
+function createFontAtlasSettings(
+  fontFamily: string,
+  props: BitmapFontAtlasSettings = {}
+): BitmapFontAtlasSettings {
+  return {
+    fontFamily,
+    fontSize: 16,
+    buffer: 2,
+    characterSet: 'AB',
+    ...props
+  };
+}
+
+function assertCommonFontAtlasShape(t: any, fontAtlas: FontAtlas, label: string): void {
+  t.equal(fontAtlas.lineHeight, 16, `${label} retains line-height metadata`);
+  t.equal(fontAtlas.pages.length, 1, `${label} exposes image pages`);
+  t.equal(fontAtlas.width, fontAtlas.pages[0]?.width, `${label} reports its page width`);
+  t.equal(fontAtlas.height, fontAtlas.pages[0]?.height, `${label} reports its page height`);
+  t.deepEqual(Object.keys(fontAtlas.mapping), ['A', 'B'], `${label} maps requested glyphs`);
+}
+
+test('bitmap and SDF builders return the common FontAtlas format', t => {
+  if (!isBrowser()) {
+    t.end();
+    return;
+  }
+
+  const bitmapFontAtlas = buildBitmapFontAtlas(
+    createFontAtlasSettings('font-atlas-builder-bitmap')
+  );
+  const sdfFontAtlas = buildSdfFontAtlas(createFontAtlasSettings('font-atlas-builder-sdf'));
+
+  assertCommonFontAtlasShape(t, bitmapFontAtlas, 'bitmap atlas');
+  assertCommonFontAtlasShape(t, sdfFontAtlas, 'SDF atlas');
+  t.equal(bitmapFontAtlas.renderSettings.mode, 'bitmap', 'bitmap mode travels with its atlas');
+  t.deepEqual(
+    bitmapFontAtlas.renderSettings,
+    {mode: 'bitmap', threshold: 0, smoothing: 0},
+    'bitmap sampling needs no renderer-specific settings'
+  );
+  t.equal(sdfFontAtlas.renderSettings.mode, 'sdf', 'SDF mode travels with its atlas');
+  t.equal(sdfFontAtlas.renderSettings.threshold, 0.75, 'SDF cutoff becomes a sampling threshold');
+  t.end();
+});
+
+test('browser font builders cache and incrementally extend atlases', t => {
+  if (!isBrowser()) {
+    t.end();
+    return;
+  }
+
+  const fontFamily = 'font-atlas-builder-cache';
+  const initialAtlas = buildBitmapFontAtlas(createFontAtlasSettings(fontFamily));
+  const cachedAtlas = buildBitmapFontAtlas(createFontAtlasSettings(fontFamily));
+  const extendedAtlas = buildBitmapFontAtlas(
+    createFontAtlasSettings(fontFamily, {characterSet: 'ABC'})
+  );
+
+  t.equal(cachedAtlas.pages[0], initialAtlas.pages[0], 'equal inputs reuse the atlas page');
+  t.equal(extendedAtlas.pages[0], initialAtlas.pages[0], 'new glyphs extend the cached page');
+  t.deepEqual(Object.keys(extendedAtlas.mapping), ['A', 'B', 'C'], 'extension adds new glyphs');
+  t.end();
+});

--- a/modules/text/test/text-2d/font-atlas-manager.spec.ts
+++ b/modules/text/test/text-2d/font-atlas-manager.spec.ts
@@ -63,7 +63,7 @@ test('FontAtlasManager prefers OffscreenCanvas and records rebuild metrics', t =
   const manager = new FontAtlasManager();
   manager.setProps(createFontSettings('font-atlas-offscreen'));
 
-  t.ok(manager.atlas?.data instanceof OffscreenCanvas, 'OffscreenCanvas backs the atlas');
+  t.ok(manager.atlas?.pages[0] instanceof OffscreenCanvas, 'OffscreenCanvas backs the atlas');
   t.equal(manager.metrics?.cacheStatus, 'rebuild', 'first atlas build is a rebuild');
   t.equal(manager.metrics?.usedOffscreenCanvas, true, 'metrics report the selected backend');
   t.equal(manager.metrics?.glyphCount, 2, 'metrics report processed glyph count');
@@ -86,7 +86,7 @@ test('FontAtlasManager falls back to DOM canvas and reports cache hits', t => {
     const cachedManager = new FontAtlasManager();
     cachedManager.setProps(props);
 
-    t.ok(cachedManager.atlas?.data instanceof HTMLCanvasElement, 'DOM canvas backs the atlas');
+    t.ok(cachedManager.atlas?.pages[0] instanceof HTMLCanvasElement, 'DOM canvas backs the atlas');
     t.equal(
       cachedManager.metrics?.cacheStatus,
       'hit',


### PR DESCRIPTION
## Stack

1. **#2715 - FontAtlas builders** (this stack base)
2. **#2717 - Renderer adoption**
3. **#2718 - WebGPU draw offsets**
4. **#2719 - Text - Space Crawl**
5. **#2714 - MSDF support**

Review and merge from top to bottom. Each PR is based on the preceding branch.

## Changes

- Defines the renderer-independent `FontAtlas` contract with glyph mapping, line metrics, kerning, pages, dimensions, and render settings.
- Adds explicit `buildBitmapFontAtlas` and `buildSdfFontAtlas` entry points.
- Shares browser-font measurement, packing, canvas, and cache helpers while keeping bitmap and SDF rasterization separate.
- Adds public TSDoc, module documentation, and focused builder tests.

This layer does not add MSDF and does not migrate renderers. The existing manager delegates to the builders only to keep this foundation independently buildable; #2717 removes it when renderers adopt explicit `FontAtlas` input.

## Verification

- `yarn build`
- Focused builder and manager headless tests
- Commit hook: 166 passed, 2 skipped