### PR TITLE
[codex] Add Arrow temporal timeline playback

### DIFF
--- a/docs/api-reference/arrow/arrow-conversion.mdx
+++ b/docs/api-reference/arrow/arrow-conversion.mdx
@@ -88,6 +88,45 @@ valid absolute value when no origin is stored, and uses origin `0` for
 durations. Raw Arrow inputs use CPU fallback where WebGPU is unavailable;
 GPU-resident temporal inputs use WebGPU compute.
 
+`ArrowTimeline` accepts an Apache Arrow temporal `DataType`: `Date`, `Time`,
+`Timestamp`, or `Duration`. It derives playback scale from that type. Timeline
+controls and optional loop ranges use absolute `number` or `bigint` values in
+the selected Arrow temporal domain. Numeric Arrow types such as `Float32` are
+not valid timeline domains.
+
+```ts
+import {ArrowTimeline} from '@luma.gl/arrow';
+import * as arrow from 'apache-arrow';
+
+const epochMilliseconds = 1_700_000_000_000n;
+const timeline = new ArrowTimeline({
+  dataType: new arrow.TimestampMillisecond(),
+  initialTime: epochMilliseconds + 2_500n,
+  range: [epochMilliseconds, epochMilliseconds + 10_000n],
+  playbackRate: 0.24,
+  loop: true
+});
+```
+
+The `DataType` describes the scalar comparison domain, not a particular Arrow
+`Field` or column name. A consuming layer subtracts the prepared column's
+persisted origin before uploading the relative `f32` value. A layer backed by a
+numeric measure such as an XYZM coordinate supplies its own origin and scale
+mapping from the temporal domain into that column. This preserves exact
+microsecond and nanosecond epoch values until origin subtraction, while reusing
+the layer's existing temporal attribute or buffer without another shader
+binding. Layers with typed temporal columns can warn on a known `DataType`
+mismatch and continue rendering.
+
+For example, an XYZM layer whose M values are seconds relative to the epoch can
+use `timelineOrigin: epochMilliseconds` and `timelineScale: 0.001` with the
+millisecond timestamp timeline above. The mapping belongs to the layer because
+the numeric M component is not the timeline's Arrow temporal domain.
+
+The resulting relative value still needs to fit the visualization's required
+`f32` precision. Millisecond detail across centuries requires a nearby origin
+or a split high/low temporal representation.
+
 ## Global Grid Columns
 
 DGGS helpers keep compact global grid keys on the GPU. `convertDggsCellIdsToGPUKeys()`

--- a/examples/deck/arrow-path-layer/app.ts
+++ b/examples/deck/arrow-path-layer/app.ts
@@ -2,21 +2,33 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Deck, OrthographicView} from '@deck.gl/core';
+import {OrthographicView} from '@deck.gl/core';
 import {ArrowPathLayer} from '@deck.gl-community/arrow-layers';
+import {ArrowTimeline} from '@luma.gl/arrow';
+import * as arrow from 'apache-arrow';
 import {ArrowDeck} from '../arrow-deck';
 import {getDeckExampleProps, type DeckExampleDeviceOptions} from '../deck-example-device';
 import {getArrowLayerTooltip} from '../arrow-layer-tooltip';
 import {ArrowPathDataSource, type ArrowPathDataSourceUpdate} from './arrow-path-data-source';
-import {MEASURE_SWEEP_DURATION} from '../../arrow/arrow-lines/arrow-line-data';
+import {
+  getTemporalCurrentTimeMilliseconds,
+  MEASURE_SWEEP_DURATION,
+  TEMPORAL_EPOCH_MILLISECONDS,
+  TEMPORAL_MILLISECONDS_PER_MEASURE_UNIT
+} from '../../arrow/arrow-lines/arrow-line-data';
 
 /** Creates the standalone or website-hosted Deck path-layer example. */
 export function createArrowPathLayerDeck(
   parent?: HTMLDivElement,
   options: DeckExampleDeviceOptions = {}
 ) {
-  let activeUpdate: ArrowPathDataSourceUpdate | null = null;
-  let animationStartMilliseconds: number | null = null;
+  const timeline = new ArrowTimeline({
+    dataType: new arrow.TimestampMillisecond(),
+    initialTime: getTimelineTime(MEASURE_SWEEP_DURATION * 0.25),
+    range: [getTimelineTime(0), getTimelineTime(MEASURE_SWEEP_DURATION)],
+    playbackRate: 0.24,
+    loop: true
+  });
 
   const deck = new ArrowDeck({
     parent,
@@ -27,53 +39,51 @@ export function createArrowPathLayerDeck(
     getTooltip: getArrowLayerTooltip,
     layers: [],
     onLoad: ({device}) => dataSource.initialize(device),
-    onBeforeRender: ({deck}) => {
-      const update = activeUpdate;
-      if (update?.animate && update.temporalEnabled) {
-        const timeMilliseconds = performance.now();
-        animationStartMilliseconds ??= timeMilliseconds;
-        const elapsedSeconds = (timeMilliseconds - animationStartMilliseconds) / 1000;
-        const currentTime =
-          (MEASURE_SWEEP_DURATION * 0.25 + elapsedSeconds * 0.24) % MEASURE_SWEEP_DURATION;
-        setPathLayer(deck, update, currentTime);
-      }
-    },
     onFinalize: () => dataSource.finalize()
   });
 
   const dataSource = new ArrowPathDataSource({
     onDataUpdated: (update: ArrowPathDataSourceUpdate) => {
-      activeUpdate = update;
-      animationStartMilliseconds = null;
-      setPathLayer(deck, update, update.currentTime);
+      timeline.pause();
+      timeline.setTime(
+        getTimelineTime(
+          update.animate && update.temporalEnabled
+            ? MEASURE_SWEEP_DURATION * 0.25
+            : update.currentTime
+        )
+      );
+      if (update.animate && update.temporalEnabled) timeline.play();
+      deck.setProps({layers: [makePathLayer(update, timeline)]});
     }
   });
 
   return deck;
 }
 
-function setPathLayer(
-  deck: Deck<OrthographicView>,
+function makePathLayer(
   dataSource: ArrowPathDataSourceUpdate,
-  currentTime: number | undefined
-): void {
-  deck.setProps({
-    layers: [
-      new ArrowPathLayer({
-        id: 'arrow-paths',
-        pickable: true,
-        model: dataSource.model ?? 'auto',
-        data: dataSource.asyncIterator,
-        paths: 'paths',
-        color: dataSource.colorColumn
-          ? {source: 'colors', nullValue: [199, 219, 245, 235]}
-          : [199, 219, 245, 235],
-        width: dataSource.widthColumn ? {source: 'widths', nullValue: 0.0035} : 0.0035,
-        currentTime,
-        trailLength: dataSource.trailLength,
-        temporalEnabled: dataSource.temporalEnabled,
-        ...dataSource.layerProps
-      })
-    ]
+  timeline: ArrowTimeline
+): ArrowPathLayer {
+  return new ArrowPathLayer({
+    id: 'arrow-paths',
+    pickable: true,
+    model: dataSource.model ?? 'auto',
+    data: dataSource.asyncIterator,
+    paths: 'paths',
+    color: dataSource.colorColumn
+      ? {source: 'colors', nullValue: [199, 219, 245, 235]}
+      : [199, 219, 245, 235],
+    width: dataSource.widthColumn ? {source: 'widths', nullValue: 0.0035} : 0.0035,
+    currentTime: dataSource.currentTime,
+    timeline: dataSource.temporalEnabled ? timeline : undefined,
+    timelineOrigin: TEMPORAL_EPOCH_MILLISECONDS,
+    timelineScale: 1 / TEMPORAL_MILLISECONDS_PER_MEASURE_UNIT,
+    trailLength: dataSource.trailLength,
+    temporalEnabled: dataSource.temporalEnabled,
+    ...dataSource.layerProps
   });
+}
+
+function getTimelineTime(measureTime: number): bigint {
+  return TEMPORAL_EPOCH_MILLISECONDS + BigInt(getTemporalCurrentTimeMilliseconds(measureTime));
 }

--- a/modules/arrow-layers/src/layers/arrow-path-layer.ts
+++ b/modules/arrow-layers/src/layers/arrow-path-layer.ts
@@ -14,6 +14,8 @@ import {
 } from '@deck.gl/core';
 import {
   ArrowPathRenderer,
+  type ArrowTimeline,
+  type ArrowTimelineTime,
   getArrowRecordBatchAsyncIterator,
   readArrowGPUVectorAsync,
   resolveArrowPathSourceVectors,
@@ -29,7 +31,7 @@ import {
   type ShaderLayout,
   type TypedArray
 } from '@luma.gl/core';
-import type {Model} from '@luma.gl/engine';
+import type {Model, Timeline} from '@luma.gl/engine';
 import {
   GPUConstant,
   GPUVector,
@@ -259,7 +261,8 @@ fn vertexMain(inputs: PathVertexInputs, @builtin(vertex_index) vertexIndex: u32)
     0.0,
     1.0,
     inputs.temporalEnabled < 0.5 ||
-      (endMeasure >= inputs.currentTime - inputs.trailLength && startMeasure <= inputs.currentTime)
+      (endMeasure >= inputs.currentTime - inputs.trailLength &&
+        startMeasure <= inputs.currentTime)
   );
   return outputs;
 }
@@ -404,7 +407,8 @@ fn vertexMain(
     0.0,
     1.0,
     inputs.temporalEnabled < 0.5 ||
-      (endMeasure >= inputs.currentTime - inputs.trailLength && startMeasure <= inputs.currentTime)
+      (endMeasure >= inputs.currentTime - inputs.trailLength &&
+        startMeasure <= inputs.currentTime)
   );
   return outputs;
 }
@@ -439,6 +443,12 @@ export type ArrowPathLayerProps = Omit<LayerProps, 'data'> &
     width?: ArrowPathWidthInput;
     /** Current path measure used by temporal trail filtering. */
     currentTime?: number;
+    /** Unit-aware playback and mapping driven by Deck's existing timeline clock. */
+    timeline?: ArrowTimeline;
+    /** Absolute timeline value corresponding to path measure zero. Defaults to zero. */
+    timelineOrigin?: ArrowTimelineTime;
+    /** Path measure units represented by one timeline unit. Defaults to one. */
+    timelineScale?: number;
     /** Visible temporal trail length in path measure units. */
     trailLength?: number;
     /** Enables temporal filtering against the fourth coordinate component. */
@@ -460,6 +470,8 @@ type ArrowPathLayerState = {
   loadVersion: number;
   sourceInitialized: boolean;
   gpuVectorSourceCache: Map<GPUVector, Promise<Vector>>;
+  timeline: ArrowTimeline | null;
+  detachTimeline: (() => void) | null;
 };
 
 /** deck.gl layer that converts and appends Arrow path batches without materializing the stream. */
@@ -487,12 +499,18 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
       batches: [],
       loadVersion: 0,
       sourceInitialized: false,
-      gpuVectorSourceCache: new Map()
+      gpuVectorSourceCache: new Map(),
+      timeline: null,
+      detachTimeline: null
     } satisfies ArrowPathLayerState);
+    this.attachTimeline(this.props.timeline);
   }
 
   override updateState({props, oldProps, changeFlags}: UpdateParameters<this>): void {
     const state = this.getLayerState();
+    if (props.timeline !== oldProps.timeline) {
+      this.attachTimeline(props.timeline);
+    }
     const sourceChanged =
       !state.sourceInitialized ||
       changeFlags.dataChanged ||
@@ -507,11 +525,14 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
     }
     if (
       props.currentTime !== oldProps.currentTime ||
+      props.timeline !== oldProps.timeline ||
+      props.timelineOrigin !== oldProps.timelineOrigin ||
+      props.timelineScale !== oldProps.timelineScale ||
       props.trailLength !== oldProps.trailLength ||
       props.temporalEnabled !== oldProps.temporalEnabled
     ) {
       for (const batch of state.batches) {
-        updateDeckPathTemporalStyle(batch, props);
+        updateDeckPathTemporalStyle(batch, props, this.context.timeline);
       }
       this.setNeedsRedraw();
     }
@@ -548,13 +569,16 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
 
   override finalizeState(context: LayerContext): void {
     const state = this.getLayerState();
+    state.detachTimeline?.();
     state.loadVersion++;
     destroyPathBatches(state.batches);
     this.setState({
       batches: [],
       loadVersion: state.loadVersion,
       sourceInitialized: true,
-      gpuVectorSourceCache: new Map()
+      gpuVectorSourceCache: new Map(),
+      timeline: null,
+      detachTimeline: null
     } satisfies ArrowPathLayerState);
     super.finalizeState(context);
   }
@@ -703,9 +727,9 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
       hasWidths: model === 'storage' || Boolean(sourceVectors.widths),
       color: colorNullValue,
       width: widthNullValue,
-      currentTime: props.currentTime ?? 0,
+      currentTime: getDeckPathCurrentTime(props, this.context.timeline),
       trailLength: props.trailLength ?? 0,
-      temporalEnabled: props.temporalEnabled ?? false
+      temporalEnabled: props.temporalEnabled ?? Boolean(props.timeline)
     });
     let renderModel: Model;
     try {
@@ -831,6 +855,20 @@ export class ArrowPathLayer extends Layer<ArrowPathLayerProps> {
       `${this.id}: ArrowPathLayer ${inputName} column "${source}" is missing; using ${inputName} default ${JSON.stringify(defaultValue)}`
     )();
     return undefined;
+  }
+
+  private attachTimeline(timeline: ArrowTimeline | undefined): void {
+    const state = this.getLayerState();
+    state.detachTimeline?.();
+    state.timeline = timeline ?? null;
+    state.detachTimeline = timeline
+      ? timeline.attach(this.context.timeline, () => {
+          for (const batch of this.getLayerState().batches) {
+            updateDeckPathTemporalStyle(batch, this.props, this.context.timeline);
+          }
+          this.setNeedsRedraw();
+        })
+      : null;
   }
 
   private getLayerState(): ArrowPathLayerState {
@@ -1002,7 +1040,11 @@ function createDeckPathConstantStyle(
     }
   }
 
-  const temporalValues = makeDeckPathTemporalValues({currentTime, trailLength, temporalEnabled});
+  const temporalValues = makeDeckPathTemporalValues({
+    currentTime,
+    trailLength,
+    temporalEnabled
+  });
   bufferLayout.push({
     name: CONSTANT_PATH_TEMPORAL_BUFFER,
     byteStride: 0,
@@ -1026,11 +1068,15 @@ function createDeckPathConstantStyle(
   return {bufferLayout, attributes, constantAttributes, buffers, temporalBuffer};
 }
 
-function updateDeckPathTemporalStyle(batch: ArrowPathLayerBatch, props: ArrowPathLayerProps): void {
+function updateDeckPathTemporalStyle(
+  batch: ArrowPathLayerBatch,
+  props: ArrowPathLayerProps,
+  deckTimeline: Timeline
+): void {
   const temporalValues = makeDeckPathTemporalValues({
-    currentTime: props.currentTime ?? 0,
+    currentTime: getDeckPathCurrentTime(props, deckTimeline),
     trailLength: props.trailLength ?? 0,
-    temporalEnabled: props.temporalEnabled ?? false
+    temporalEnabled: props.temporalEnabled ?? Boolean(props.timeline)
   });
   if (batch.model.device.type === 'webgl') {
     batch.model.setConstantAttributes({
@@ -1053,6 +1099,15 @@ function makeDeckPathTemporalValues({
   temporalEnabled: boolean;
 }): Float32Array {
   return new Float32Array([currentTime, trailLength, temporalEnabled ? 1 : 0]);
+}
+
+function getDeckPathCurrentTime(props: ArrowPathLayerProps, deckTimeline: Timeline): number {
+  if (!props.timeline) return props.currentTime ?? 0;
+  const timelineScale = props.timelineScale ?? 1;
+  if (!Number.isFinite(timelineScale)) {
+    throw new Error('ArrowPathLayer timelineScale must be finite');
+  }
+  return props.timeline.getRelativeTime(props.timelineOrigin ?? 0, deckTimeline) * timelineScale;
 }
 
 function resolveDeckPathModel(

--- a/modules/arrow-layers/test/layers/arrow-layers.spec.ts
+++ b/modules/arrow-layers/test/layers/arrow-layers.spec.ts
@@ -6,11 +6,12 @@ import {Deck, OrthographicView, type Layer, type PickingInfo} from '@deck.gl/cor
 import {ArrowPathLayer, ArrowPolygonLayer, ArrowTextLayer} from '@deck.gl-community/arrow-layers';
 import {makeGPUVectorFromArrow} from '@luma.gl/arrow';
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {ArrowTimeline} from '@luma.gl/arrow';
 import type {Device} from '@luma.gl/core';
-import type {Model} from '@luma.gl/engine';
+import type {Model, Timeline} from '@luma.gl/engine';
 import {buildBitmapFontAtlas} from '@luma.gl/text';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import {Table, vectorFromArray, type RecordBatch} from 'apache-arrow';
+import * as arrow from 'apache-arrow';
 import {afterAll} from 'vitest';
 import {
   makeArrowLineRecordBatches,
@@ -49,7 +50,7 @@ test('Arrow deck layers return source row indices from Deck picking', async t =>
   const constantPathLayer = new ArrowPathLayer({
     id: 'arrow-paths-constant-picking-test',
     pickable: true,
-    data: new Table({paths: pathSource.sourceVectors.paths}),
+    data: new arrow.Table({paths: pathSource.sourceVectors.paths}),
     paths: 'paths',
     color: [255, 180, 90, 255],
     width: 0.004,
@@ -58,7 +59,7 @@ test('Arrow deck layers return source row indices from Deck picking', async t =>
       constantPathDataError = error;
     }
   });
-  const nullablePathColors = vectorFromArray(
+  const nullablePathColors = arrow.vectorFromArray(
     Array.from({length: pathSource.sourceVectors.paths.length}, (_, rowIndex) =>
       rowIndex % 2 === 0 ? [20, 120, 240, 255] : null
     ),
@@ -68,7 +69,7 @@ test('Arrow deck layers return source row indices from Deck picking', async t =>
   const nullablePathLayer = new ArrowPathLayer({
     id: 'arrow-paths-nullable-color-test',
     pickable: true,
-    data: new Table({paths: pathSource.sourceVectors.paths, colors: nullablePathColors}),
+    data: new arrow.Table({paths: pathSource.sourceVectors.paths, colors: nullablePathColors}),
     paths: 'paths',
     color: {source: 'colors', nullValue: [255, 80, 40, 255]},
     width: 0.004,
@@ -81,7 +82,7 @@ test('Arrow deck layers return source row indices from Deck picking', async t =>
   const missingPathStyleLayer = new ArrowPathLayer({
     id: 'arrow-paths-missing-style-test',
     pickable: true,
-    data: new Table({paths: pathSource.sourceVectors.paths}),
+    data: new arrow.Table({paths: pathSource.sourceVectors.paths}),
     paths: 'paths',
     color: 'missingColors',
     width: {source: 'missingWidths', nullValue: 0.004},
@@ -93,7 +94,7 @@ test('Arrow deck layers return source row indices from Deck picking', async t =>
   const polygonSource = makeArrowPolygonExampleData('10k-stream', 'polygon', 'row-colors');
   const polygonBatch = polygonSource.recordBatches[0]!;
   const polygonColors = polygonBatch.getChild('colors')!;
-  const nullablePolygonColors = vectorFromArray(
+  const nullablePolygonColors = arrow.vectorFromArray(
     Array.from({length: polygonColors.length}, (_, rowIndex) =>
       rowIndex % 2 === 0 ? polygonColors.get(rowIndex) : null
     ),
@@ -102,7 +103,7 @@ test('Arrow deck layers return source row indices from Deck picking', async t =>
   const polygonLayer = new ArrowPolygonLayer({
     id: 'arrow-polygons-picking-test',
     pickable: true,
-    data: new Table({
+    data: new arrow.Table({
       polygons: polygonBatch.getChild('polygons')!,
       colors: nullablePolygonColors
     }),
@@ -122,7 +123,7 @@ test('Arrow deck layers return source row indices from Deck picking', async t =>
   const missingPolygonColorLayer = new ArrowPolygonLayer({
     id: 'arrow-polygons-missing-color-test',
     pickable: true,
-    data: new Table({polygons: polygonBatch.getChild('polygons')!}),
+    data: new arrow.Table({polygons: polygonBatch.getChild('polygons')!}),
     polygons: 'polygons',
     color: {source: 'missingColors', nullValue: [255, 80, 40, 255]},
     tessellated: polygonSource.tessellated,
@@ -137,7 +138,7 @@ test('Arrow deck layers return source row indices from Deck picking', async t =>
     {clipRects: true, angles: true, sizes: true}
   );
   const slicedTextColors = textSource.colors!.slice(190, 210);
-  const nullableTextColors = vectorFromArray(
+  const nullableTextColors = arrow.vectorFromArray(
     Array.from({length: slicedTextColors.length}, (_, rowIndex) =>
       rowIndex % 2 === 0 ? slicedTextColors.get(rowIndex) : null
     ),
@@ -180,7 +181,7 @@ test('Arrow deck layers return source row indices from Deck picking', async t =>
   const missingTextColorLayer = new ArrowTextLayer({
     id: 'arrow-text-missing-color-test',
     pickable: true,
-    data: new Table({
+    data: new arrow.Table({
       positions: textSource.positions.slice(190, 210),
       texts: textSource.texts.slice(190, 210)
     }),
@@ -393,6 +394,74 @@ test('ArrowPathLayer storage draws streamed batches incrementally and preserves 
     }
     callerColorVector.destroy();
   }
+  t.end();
+});
+
+test('ArrowPathLayer timeline invalidates an existing layer and cleans up its subscription', async t => {
+  const source = makeArrowLineSourceData(
+    {pathCount: 12, pointCount: 8, label: 'timeline test paths'},
+    'lines',
+    'float32',
+    'row-colors',
+    'xyzm'
+  );
+  const timelineOrigin = 1_700_000_000_000n;
+  const timeline = new ArrowTimeline({
+    dataType: new arrow.TimestampMillisecond(),
+    initialTime: timelineOrigin + 1_000n,
+    range: [timelineOrigin, timelineOrigin + 10_000n],
+    playbackRate: 0.24,
+    loop: true
+  });
+  const layer = new ArrowPathLayer({
+    id: 'arrow-path-timeline-test',
+    data: makeArrowLineRecordBatches(source),
+    model: 'attribute',
+    timeline,
+    timelineOrigin,
+    timelineScale: 0.001,
+    trailLength: 1
+  });
+  const parent = document.createElement('div');
+  parent.style.width = `${TEST_VIEWPORT_WIDTH}px`;
+  parent.style.height = `${TEST_VIEWPORT_HEIGHT}px`;
+  document.body.append(parent);
+  const deck = new Deck({
+    parent,
+    width: TEST_VIEWPORT_WIDTH,
+    height: TEST_VIEWPORT_HEIGHT,
+    views: new OrthographicView({id: 'main'}),
+    initialViewState: {target: [0, 0], zoom: 8},
+    layers: [layer]
+  });
+
+  let deckTimeline: Timeline | undefined;
+  try {
+    const model = await waitForLayerModel(layer);
+    deckTimeline = layer.context.timeline;
+    await waitForPipeline(model);
+    deck.needsRedraw({clearRedrawFlags: true});
+
+    timeline.setTime(timelineOrigin + 2_000n);
+    t.equal(
+      (model.vertexArray.attributes[7] as Float32Array)[0],
+      2,
+      'seek updates the existing time attribute'
+    );
+    timeline.play();
+    deckTimeline.setTime(deckTimeline.getTime() + 1_000);
+    t.ok(
+      Math.abs((model.vertexArray.attributes[7] as Float32Array)[0] - 2.24) < 0.00001,
+      'timeline advancement updates the existing time attribute'
+    );
+    t.ok(deck.needsRedraw(), 'timeline changes request a redraw');
+    t.equal(layer.getModels()[0], model, 'timeline advancement preserves the existing model');
+    t.equal(deckTimeline.animations.size, 1, 'layer attaches one timeline animation');
+  } finally {
+    deck.finalize();
+    parent.remove();
+  }
+  t.equal(deckTimeline?.animations.size, 0, 'layer finalization removes the timeline animation');
   t.end();
 });
 
@@ -652,9 +721,9 @@ async function waitForModelCount(
 }
 
 async function* makeControlledPathStream(
-  recordBatches: RecordBatch[],
+  recordBatches: arrow.RecordBatch[],
   secondBatchReady: Promise<void>
-): AsyncGenerator<RecordBatch> {
+): AsyncGenerator<arrow.RecordBatch> {
   const firstBatch = recordBatches[0];
   const secondBatch = recordBatches[1];
   if (firstBatch) {

--- a/modules/arrow/src/arrow/animation/arrow-timeline.ts
+++ b/modules/arrow/src/arrow/animation/arrow-timeline.ts
@@ -1,0 +1,381 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Timeline} from '@luma.gl/engine';
+import {DataType, type Date_, type Duration, type Time, type Timestamp} from 'apache-arrow';
+import {
+  getArrowTemporalVectorInfo,
+  type ArrowTemporalUnit
+} from '../vectors/arrow-temporal-gpu-vector';
+
+/** Arrow temporal scalar types supported as timeline value domains. */
+export type ArrowTimelineDataType = Date_ | Time | Timestamp | Duration;
+
+/** Exact Arrow-domain values accepted by timeline controls. */
+export type ArrowTimelineTime = number | bigint;
+
+/** Construction options for an Arrow timeline. */
+export type ArrowTimelineProps<DataTypeT extends ArrowTimelineDataType = ArrowTimelineDataType> = {
+  /** Arrow temporal scalar type used by the values compared with this timeline. */
+  dataType: DataTypeT;
+  /** Initial absolute Arrow-domain value. Defaults to zero in the type's value representation. */
+  initialTime?: ArrowTimelineTime;
+  /** Optional absolute half-open interval used for wrapping. */
+  range?: readonly [ArrowTimelineTime, ArrowTimelineTime];
+  /** Whether to wrap within `range`. Defaults to true when a range is supplied. */
+  loop?: boolean;
+  /** Initial playback multiplier. */
+  playbackRate?: number;
+};
+
+/** Timeline notifications distinguish frame invalidation from mapping changes. */
+export type ArrowTimelineUpdate = {
+  type: 'time' | 'mapping';
+};
+
+type TimelineAttachment = {
+  animationHandle: number;
+  timelineTimeSeconds: number;
+  anchorTimelineTimeSeconds: number;
+  anchorCurrentTime: ArrowTimelineTime;
+  subscribers: Set<(update: ArrowTimelineUpdate) => void>;
+};
+
+type ArrowTimelineDataTypeInfo = {
+  unitsPerSecond: number;
+  usesBigInt: boolean;
+};
+
+const UNIT_SCALES: Record<ArrowTemporalUnit, number> = {
+  day: 1 / 86_400,
+  second: 1,
+  millisecond: 1_000,
+  microsecond: 1_000_000,
+  nanosecond: 1_000_000_000
+};
+
+/**
+ * Returns the number of values advanced per second for an Arrow temporal type.
+ *
+ * @param dataType - Scalar Arrow `Date`, `Time`, `Timestamp`, or `Duration` type.
+ * @returns Arrow-domain units advanced by one second at playback rate `1`.
+ * @throws If `dataType` is not a supported scalar temporal type.
+ */
+export function getArrowTimelineUnitsPerSecond(dataType: ArrowTimelineDataType): number {
+  return getArrowTimelineDataTypeInfo(dataType).unitsPerSecond;
+}
+
+/**
+ * Returns a description when two Arrow value domains are incompatible, otherwise `null`.
+ * List temporal columns are compared using their scalar leaf type.
+ *
+ * @param timelineDataType - Scalar temporal type configured on the timeline.
+ * @param columnDataType - Scalar or list-wrapped Arrow type used by the consuming column.
+ * @returns A mismatch description, or `null` when the temporal domains are compatible.
+ */
+export function getArrowTimelineDataTypeMismatch(
+  timelineDataType: ArrowTimelineDataType,
+  columnDataType: DataType
+): string | null {
+  const timelineTemporalInfo = getArrowTemporalVectorInfo({type: timelineDataType});
+  const columnTemporalInfo = getArrowTemporalVectorInfo({type: columnDataType});
+  if (timelineTemporalInfo || columnTemporalInfo) {
+    if (!timelineTemporalInfo || !columnTemporalInfo) {
+      return `${timelineDataType} is not compatible with ${columnDataType}`;
+    }
+    const mismatchFields: string[] = [];
+    if (timelineTemporalInfo.kind !== columnTemporalInfo.kind) mismatchFields.push('kind');
+    if (timelineTemporalInfo.unit !== columnTemporalInfo.unit) mismatchFields.push('unit');
+    if (timelineTemporalInfo.bitWidth !== columnTemporalInfo.bitWidth) {
+      mismatchFields.push('bit width');
+    }
+    if (
+      timelineTemporalInfo.kind === 'timestamp' &&
+      (timelineTemporalInfo.timezone ?? null) !== (columnTemporalInfo.timezone ?? null)
+    ) {
+      mismatchFields.push('timezone');
+    }
+    return mismatchFields.length > 0
+      ? `${timelineDataType} and ${columnDataType} differ in ${mismatchFields.join(', ')}`
+      : null;
+  }
+
+  return `${timelineDataType} is not compatible with ${columnDataType}`;
+}
+
+/**
+ * Device-independent playback state and mapping for Arrow temporal layers.
+ *
+ * Absolute Arrow values stay as numbers or bigints until a consuming layer subtracts its
+ * prepared column origin. The timeline owns no data sources, layers, Deck instances, or GPU
+ * resources.
+ *
+ * @example Timestamp playback with an absolute looping range
+ * ```ts
+ * const timeline = new ArrowTimeline({
+ *   dataType: new arrow.TimestampMillisecond(),
+ *   initialTime: 1_700_000_000_000n,
+ *   range: [1_700_000_000_000n, 1_700_000_010_000n]
+ * });
+ * ```
+ */
+export class ArrowTimeline<DataTypeT extends ArrowTimelineDataType = ArrowTimelineDataType> {
+  readonly dataType: DataTypeT;
+  readonly unitsPerSecond: number;
+  readonly range?: readonly [ArrowTimelineTime, ArrowTimelineTime];
+  readonly loop: boolean;
+
+  private readonly usesBigInt: boolean;
+  private playbackRate: number;
+  private playing = false;
+  private currentTime: ArrowTimelineTime;
+  private readonly attachments = new Map<Timeline, TimelineAttachment>();
+
+  /**
+   * Creates temporal playback state without allocating GPU or layer resources.
+   *
+   * @param props - Temporal domain, initial value, optional looping range, and playback rate.
+   * @throws If the data type is not temporal, the range is invalid, or a 64-bit value is unsafe.
+   */
+  constructor(props: ArrowTimelineProps<DataTypeT>) {
+    const dataTypeInfo = getArrowTimelineDataTypeInfo(props.dataType);
+    this.dataType = props.dataType;
+    this.unitsPerSecond = dataTypeInfo.unitsPerSecond;
+    this.usesBigInt = dataTypeInfo.usesBigInt;
+    this.currentTime = this.normalizeTime(
+      props.initialTime ?? (this.usesBigInt ? 0n : 0),
+      'initialTime'
+    );
+    this.range = props.range
+      ? [
+          this.normalizeTime(props.range[0], 'range start'),
+          this.normalizeTime(props.range[1], 'range end')
+        ]
+      : undefined;
+    if (this.range && compareTimelineTimes(this.range[1], this.range[0]) <= 0) {
+      throw new Error('ArrowTimeline range end must be greater than range start');
+    }
+    this.loop = props.loop ?? this.range !== undefined;
+    if (this.loop && !this.range) {
+      throw new Error('ArrowTimeline loop requires a range');
+    }
+    this.playbackRate = validatePlaybackRate(props.playbackRate ?? 1);
+  }
+
+  /** Starts advancing against attached Deck timelines. */
+  play(): void {
+    if (!this.playing) {
+      this.playing = true;
+      this.notify({type: 'mapping'});
+    }
+  }
+
+  /** Freezes the current absolute Arrow-domain value. */
+  pause(): void {
+    if (this.playing) {
+      this.captureAttachmentTimes();
+      this.playing = false;
+      this.notify({type: 'mapping'});
+    }
+  }
+
+  /** Seeks to an absolute Arrow-domain value. */
+  setTime(time: ArrowTimelineTime): void {
+    const normalizedTime = this.normalizeTime(time, 'time');
+    this.currentTime = normalizedTime;
+    for (const attachment of this.attachments.values()) {
+      attachment.anchorCurrentTime = normalizedTime;
+      attachment.anchorTimelineTimeSeconds = attachment.timelineTimeSeconds;
+    }
+    this.notify({type: 'mapping'});
+  }
+
+  /** Changes the playback multiplier without discontinuity. */
+  setPlaybackRate(playbackRate: number): void {
+    const validatedRate = validatePlaybackRate(playbackRate);
+    if (validatedRate !== this.playbackRate) {
+      this.captureAttachmentTimes();
+      this.playbackRate = validatedRate;
+      this.notify({type: 'mapping'});
+    }
+  }
+
+  /**
+   * Returns the current absolute Arrow-domain value.
+   *
+   * @param timeline - Attached luma.gl timeline to sample. The first attachment is used by default.
+   */
+  getTime(timeline?: Timeline): ArrowTimelineTime {
+    const attachment = timeline
+      ? this.attachments.get(timeline)
+      : this.attachments.values().next().value;
+    const time = attachment ? this.getAttachmentTime(attachment) : this.currentTime;
+    return this.wrapTime(time);
+  }
+
+  /**
+   * Returns a GPU-ready value relative to a prepared Arrow column origin.
+   *
+   * Bigint subtraction happens before number conversion so epoch-scale values retain their exact
+   * offset. The caller remains responsible for ensuring the relative value has sufficient `f32`
+   * precision for rendering.
+   *
+   * @param origin - Absolute origin persisted for the consuming temporal column.
+   * @param timeline - Attached luma.gl timeline to sample. The first attachment is used by default.
+   * @returns Timeline time relative to `origin`, in the Arrow type's native unit.
+   * @throws If the relative value cannot be represented as a finite JavaScript number.
+   */
+  getRelativeTime(origin: ArrowTimelineTime, timeline?: Timeline): number {
+    const normalizedOrigin = this.normalizeTime(origin, 'origin');
+    const time = this.getTime(timeline);
+    const relativeTime =
+      typeof time === 'bigint'
+        ? Number(time - (normalizedOrigin as bigint))
+        : time - (normalizedOrigin as number);
+    if (!Number.isFinite(relativeTime)) {
+      throw new Error('ArrowTimeline relative time cannot be represented as a finite number');
+    }
+    return relativeTime;
+  }
+
+  /**
+   * Attaches to an existing luma.gl timeline.
+   *
+   * @param timeline - Deck's existing luma.gl timeline.
+   * @param subscriber - Callback invoked when time or playback mapping changes.
+   * @returns An idempotent callback that removes this subscription.
+   */
+  attach(timeline: Timeline, subscriber: (update: ArrowTimelineUpdate) => void): () => void {
+    let attachment = this.attachments.get(timeline);
+    if (!attachment) {
+      const initialTimeSeconds = timeline.getTime() / 1000;
+      const initialCurrentTime = this.getTime();
+      attachment = {
+        animationHandle: -1,
+        timelineTimeSeconds: initialTimeSeconds,
+        anchorTimelineTimeSeconds: initialTimeSeconds,
+        anchorCurrentTime: initialCurrentTime,
+        subscribers: new Set()
+      };
+      this.attachments.set(timeline, attachment);
+      attachment.animationHandle = timeline.attachAnimation({
+        setTime: timeMilliseconds => {
+          attachment!.timelineTimeSeconds = timeMilliseconds / 1000;
+          if (this.playing) {
+            for (const callback of attachment!.subscribers) callback({type: 'time'});
+          }
+        }
+      });
+    }
+    attachment.subscribers.add(subscriber);
+    subscriber({type: 'mapping'});
+
+    let detached = false;
+    return () => {
+      if (detached) return;
+      detached = true;
+      const activeAttachment = this.attachments.get(timeline);
+      if (!activeAttachment) return;
+      activeAttachment.subscribers.delete(subscriber);
+      if (activeAttachment.subscribers.size === 0) {
+        this.currentTime = this.wrapTime(this.getAttachmentTime(activeAttachment));
+        timeline.detachAnimation(activeAttachment.animationHandle);
+        this.attachments.delete(timeline);
+      }
+    };
+  }
+
+  private captureAttachmentTimes(): void {
+    let capturedTime: ArrowTimelineTime | undefined;
+    for (const attachment of this.attachments.values()) {
+      const time = this.wrapTime(this.getAttachmentTime(attachment));
+      attachment.anchorCurrentTime = time;
+      attachment.anchorTimelineTimeSeconds = attachment.timelineTimeSeconds;
+      capturedTime ??= time;
+    }
+    if (capturedTime !== undefined) this.currentTime = capturedTime;
+  }
+
+  private getAttachmentTime(attachment: TimelineAttachment): ArrowTimelineTime {
+    if (!this.playing) return attachment.anchorCurrentTime;
+    const elapsedUnits =
+      (attachment.timelineTimeSeconds - attachment.anchorTimelineTimeSeconds) *
+      this.unitsPerSecond *
+      this.playbackRate;
+    if (!Number.isFinite(elapsedUnits)) {
+      throw new Error('ArrowTimeline elapsed time must be finite');
+    }
+    return typeof attachment.anchorCurrentTime === 'bigint'
+      ? attachment.anchorCurrentTime + BigInt(Math.trunc(elapsedUnits))
+      : attachment.anchorCurrentTime + elapsedUnits;
+  }
+
+  private wrapTime(time: ArrowTimelineTime): ArrowTimelineTime {
+    if (!this.loop || !this.range) return time;
+    const [start, end] = this.range;
+    if (typeof time === 'bigint') {
+      const bigintStart = start as bigint;
+      const duration = (end as bigint) - bigintStart;
+      return bigintStart + ((((time - bigintStart) % duration) + duration) % duration);
+    }
+    const numberStart = start as number;
+    const duration = (end as number) - numberStart;
+    return numberStart + ((((time - numberStart) % duration) + duration) % duration);
+  }
+
+  private normalizeTime(time: ArrowTimelineTime, name: string): ArrowTimelineTime {
+    if (this.usesBigInt) {
+      if (typeof time === 'bigint') return time;
+      if (!Number.isSafeInteger(time)) {
+        throw new Error(`ArrowTimeline ${name} must be a bigint or safe integer`);
+      }
+      return BigInt(time);
+    }
+    if (typeof time === 'bigint') {
+      const numberTime = Number(time);
+      if (!Number.isSafeInteger(numberTime)) {
+        throw new Error(`ArrowTimeline ${name} bigint cannot be represented safely as a number`);
+      }
+      return numberTime;
+    }
+    if (!Number.isFinite(time)) {
+      throw new Error(`ArrowTimeline ${name} must be finite`);
+    }
+    return time;
+  }
+
+  private notify(update: ArrowTimelineUpdate): void {
+    for (const attachment of this.attachments.values()) {
+      for (const subscriber of attachment.subscribers) subscriber(update);
+    }
+  }
+}
+
+function getArrowTimelineDataTypeInfo(dataType: ArrowTimelineDataType): ArrowTimelineDataTypeInfo {
+  if (DataType.isList(dataType)) {
+    throw new Error('ArrowTimeline dataType must be a scalar Arrow DataType');
+  }
+  const temporalInfo = getArrowTemporalVectorInfo({type: dataType});
+  if (!temporalInfo) {
+    throw new Error('ArrowTimeline dataType must be Date, Time, Timestamp, or Duration');
+  }
+  return {
+    unitsPerSecond: UNIT_SCALES[temporalInfo.unit],
+    usesBigInt: temporalInfo.bitWidth === 64
+  };
+}
+
+function compareTimelineTimes(left: ArrowTimelineTime, right: ArrowTimelineTime): number {
+  if (typeof left === 'bigint') {
+    return left < (right as bigint) ? -1 : left > (right as bigint) ? 1 : 0;
+  }
+  return left < (right as number) ? -1 : left > (right as number) ? 1 : 0;
+}
+
+function validatePlaybackRate(playbackRate: number): number {
+  if (!Number.isFinite(playbackRate)) {
+    throw new Error('ArrowTimeline playbackRate must be finite');
+  }
+  return playbackRate;
+}

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -11,6 +11,15 @@ export {
   type MakeGPUTextDataFromArrowProps
 } from './arrow/renderers/text/conversion/make-gpu-text-data-from-arrow';
 export {
+  ArrowTimeline,
+  getArrowTimelineDataTypeMismatch,
+  getArrowTimelineUnitsPerSecond,
+  type ArrowTimelineDataType,
+  type ArrowTimelineProps,
+  type ArrowTimelineTime,
+  type ArrowTimelineUpdate
+} from './arrow/animation/arrow-timeline';
+export {
   getArrowListNestingLevel,
   isNumericArrowType
   // isInstanceArrowType,

--- a/modules/arrow/test/arrow/arrow-timeline.node.spec.ts
+++ b/modules/arrow/test/arrow/arrow-timeline.node.spec.ts
@@ -1,0 +1,182 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {
+  ArrowTimeline,
+  getArrowTimelineDataTypeMismatch,
+  getArrowTimelineUnitsPerSecond
+} from '@luma.gl/arrow';
+import {Timeline} from '@luma.gl/engine';
+import * as arrow from 'apache-arrow';
+
+test('ArrowTimeline derives scales from Arrow temporal DataTypes', t => {
+  const cases: Array<[arrow.Date_ | arrow.Time | arrow.Timestamp | arrow.Duration, number]> = [
+    [new arrow.DateDay(), 1 / 86_400],
+    [new arrow.DateMillisecond(), 1_000],
+    [new arrow.TimeSecond(), 1],
+    [new arrow.TimeMillisecond(), 1_000],
+    [new arrow.TimeMicrosecond(), 1_000_000],
+    [new arrow.TimeNanosecond(), 1_000_000_000],
+    [new arrow.TimestampSecond(), 1],
+    [new arrow.TimestampMillisecond(), 1_000],
+    [new arrow.TimestampMicrosecond(), 1_000_000],
+    [new arrow.TimestampNanosecond(), 1_000_000_000],
+    [new arrow.DurationSecond(), 1],
+    [new arrow.DurationMillisecond(), 1_000],
+    [new arrow.DurationMicrosecond(), 1_000_000],
+    [new arrow.DurationNanosecond(), 1_000_000_000]
+  ];
+  for (const [dataType, unitsPerSecond] of cases) {
+    t.equal(
+      getArrowTimelineUnitsPerSecond(dataType),
+      unitsPerSecond,
+      `${dataType} derives ${unitsPerSecond} units per second`
+    );
+  }
+  t.end();
+});
+
+test('ArrowTimeline validates DataType-specific construction options', t => {
+  t.throws(
+    () =>
+      new ArrowTimeline({
+        dataType: new arrow.Float32() as unknown as arrow.Timestamp
+      }),
+    /Date, Time, Timestamp, or Duration/,
+    'numeric Arrow DataTypes are rejected'
+  );
+  t.throws(
+    () => new ArrowTimeline({dataType: new arrow.DurationSecond(), loop: true}),
+    /loop requires a range/,
+    'looping requires an absolute interval'
+  );
+  t.throws(
+    () =>
+      new ArrowTimeline({
+        dataType: new arrow.DurationSecond(),
+        range: [2n, 2n]
+      }),
+    /range end must be greater/,
+    'range must be increasing'
+  );
+  t.throws(
+    () =>
+      new ArrowTimeline({
+        dataType: new arrow.TimestampNanosecond(),
+        initialTime: Number.MAX_SAFE_INTEGER + 1
+      }),
+    /bigint or safe integer/,
+    'unsafe 64-bit numbers are rejected'
+  );
+  t.end();
+});
+
+test('ArrowTimeline plays, pauses, seeks, scales, wraps, and cleans up', t => {
+  const deckTimeline = new Timeline();
+  const timeline = new ArrowTimeline({
+    dataType: new arrow.DurationSecond(),
+    initialTime: 2n,
+    range: [0n, 10n],
+    playbackRate: 2
+  });
+  const updates: string[] = [];
+  const detach = timeline.attach(deckTimeline, update => updates.push(update.type));
+
+  timeline.play();
+  deckTimeline.setTime(2_000);
+  t.equal(timeline.getTime(deckTimeline), 6n, 'play advances in Arrow duration units');
+
+  timeline.pause();
+  deckTimeline.setTime(4_000);
+  t.equal(timeline.getTime(deckTimeline), 6n, 'pause freezes time');
+
+  timeline.setTime(9n);
+  timeline.setPlaybackRate(2);
+  timeline.play();
+  deckTimeline.setTime(5_000);
+  t.equal(timeline.getTime(deckTimeline), 1n, 'seek, rate, and explicit range wrap are applied');
+  t.ok(updates.includes('time'), 'timeline advancement invalidates subscribers');
+  t.ok(updates.includes('mapping'), 'control changes invalidate subscribers');
+
+  detach();
+  detach();
+  t.equal(deckTimeline.animations.size, 0, 'cleanup detaches from the Deck timeline once');
+  t.end();
+});
+
+test('ArrowTimeline preserves absolute bigint precision until origin subtraction', t => {
+  const origin = 9_007_199_254_740_993_000n;
+  const deckTimeline = new Timeline();
+  const timeline = new ArrowTimeline({
+    dataType: new arrow.TimestampNanosecond(),
+    initialTime: origin + 900_000n,
+    range: [origin, origin + 1_000_000n]
+  });
+  timeline.attach(deckTimeline, () => {});
+
+  timeline.setTime(origin + 125n);
+  t.equal(timeline.getTime(), origin + 125n, 'absolute timestamp remains a bigint');
+  t.equal(timeline.getRelativeTime(origin), 125, 'origin is subtracted before number conversion');
+
+  timeline.setTime(origin + 900_000n);
+  timeline.play();
+  deckTimeline.setTime(0.2);
+  t.equal(
+    timeline.getTime(deckTimeline),
+    origin + 100_000n,
+    'bigint advancement wraps within the absolute half-open range'
+  );
+  t.equal(
+    timeline.getRelativeTime(origin, deckTimeline),
+    100_000,
+    'wrapped timestamp converts to a relative GPU value'
+  );
+  t.end();
+});
+
+test('ArrowTimeline reports Arrow DataType compatibility differences', t => {
+  t.equal(
+    getArrowTimelineDataTypeMismatch(
+      new arrow.TimestampMillisecond(),
+      new arrow.TimestampMillisecond()
+    ),
+    null,
+    'matching temporal types are compatible'
+  );
+  t.ok(
+    getArrowTimelineDataTypeMismatch(
+      new arrow.TimestampMillisecond(),
+      new arrow.TimestampMicrosecond()
+    )?.includes('unit'),
+    'temporal unit mismatch is described'
+  );
+  t.ok(
+    getArrowTimelineDataTypeMismatch(
+      new arrow.TimestampMillisecond('UTC'),
+      new arrow.TimestampMillisecond('America/New_York')
+    )?.includes('timezone'),
+    'timestamp timezone mismatch is described'
+  );
+  t.ok(
+    getArrowTimelineDataTypeMismatch(new arrow.TimestampMillisecond(), new arrow.Float32()),
+    'temporal and numeric domains are incompatible'
+  );
+  t.end();
+});
+
+test('ArrowTimeline supports absolute manual time without an attached timeline', t => {
+  const timeline = new ArrowTimeline({
+    dataType: new arrow.TimestampMicrosecond(),
+    initialTime: 1_700_000_000_000_000n
+  });
+  timeline.setTime(1_700_000_000_000_125n);
+  t.equal(timeline.getTime(), 1_700_000_000_000_125n, 'manual absolute time is retained');
+  t.equal(
+    timeline.getRelativeTime(1_700_000_000_000_000n),
+    125,
+    'manual absolute time converts relative to a column origin'
+  );
+  t.end();
+});


### PR DESCRIPTION
## What changed

- Add `ArrowTimeline`, a device-independent playback state for Apache Arrow temporal scalar domains: `Date`, `Time`, `Timestamp`, and `Duration`.
- Derive timeline units-per-second from the Arrow temporal `DataType`; numeric types such as `Float32` are intentionally rejected.
- Keep absolute 64-bit temporal values as `bigint`, subtract a prepared column origin exactly, and only then convert the relative value for the GPU-facing `f32`.
- Support absolute initial time, seek, play/pause, playback rate, and optional half-open wrapping ranges.
- Let `ArrowPathLayer` subscribe through its existing `LayerContext.timeline`, update its existing zero-stride `currentTime` attribute/buffer, and request redraws without replacing the layer or model.
- Keep XYZM path measures as a layer concern: `timelineOrigin` and `timelineScale` map the temporal timeline domain into the numeric M domain.
- Preserve manual `currentTime` behavior when no timeline is supplied.
- Update the Arrow path example to construct the layer only when data/settings change instead of on every animation frame.
- Document the temporal-only API, timestamp precision behavior, and XYZM origin/scale mapping, with complete public TSDoc for the new timeline surface.

## Why

Reconstructing `ArrowPathLayer` every frame is unnecessary and disruptive for streamed Arrow data. The layer already has a temporal constant attribute on WebGL and a zero-stride temporal buffer on WebGPU, so timeline advancement can update that existing value in place. This preserves layer and GPU model instances and allocates no new shader binding.

Using an Arrow temporal `DataType` makes the comparison domain explicit and gives timestamps and durations the correct playback scale. Epoch-scale values remain exact until a consuming layer subtracts its column origin, avoiding the precision loss that would result from converting absolute timestamps directly to `f32`.

## Base

The Arrow renderer prerequisite landed in `master` via #2710. This branch is rebased onto current `master` at `30d8c7ace` and contains one timeline commit touching seven files.

## Validation

- `nvm use`
- `yarn install`
- `yarn lint fix`
- Targeted TypeDoc/TSDoc validation with warnings treated as errors
- `yarn build`
- Local node tests: 178 passed, 2 skipped
- GitHub Actions headless coverage: 1,261 passed, 25 skipped across 234 files
- GitHub Actions node tests: 178 passed, 2 skipped
- GitHub Actions examples build/lint/typecheck: passed
- GitHub Actions website build: passed
- Coveralls upload: passed
- Arrow layer lifecycle coverage verifies that seek and timeline advancement update the existing temporal attribute while preserving the model instance and cleaning up the subscription.
