### PR TITLE
feat(text) Fix WebGPU non-indexed draw offsets

### DIFF
--- a/modules/arrow/src/arrow/renderers/text/conversion/convert-arrow-text-vectors.ts
+++ b/modules/arrow/src/arrow/renderers/text/conversion/convert-arrow-text-vectors.ts
@@ -1355,6 +1355,7 @@ export function createArrowTextRenderTable(
   const generatedGlyphColumnNames = new Set([
     GLYPH_OFFSETS_COLUMN,
     GLYPH_FRAMES_COLUMN,
+    GLYPH_PAGES_COLUMN,
     GLYPH_CLIP_RECTS_COLUMN,
     ROW_INDICES_COLUMN
   ]);

--- a/modules/text/test/text-2d/convert-arrow-text-vectors.spec.ts
+++ b/modules/text/test/text-2d/convert-arrow-text-vectors.spec.ts
@@ -254,6 +254,17 @@ test('TextAttributeModel derives from GPUTableModel and rebuilds glyph instance 
     false,
     'model-ready attribute props are flat'
   );
+  const renderTableFieldNames =
+    modelProps.modelProps.table?.schema.fields.map(field => field.name) ?? [];
+  t.deepEqual(
+    renderTableFieldNames.filter(fieldName =>
+      ['glyphOffsets', 'glyphFrames', 'glyphPages', 'glyphClipRects', 'rowIndices'].includes(
+        fieldName
+      )
+    ),
+    [],
+    'generated glyph attributes are supplied only by expandedGlyphVertexData'
+  );
   const model = new TextAttributeModel(device, modelProps);
 
   t.equal(model.instanceCount, 3, 'instance count uses generated glyph rows');

--- a/modules/webgpu/src/adapter/resources/webgpu-render-pass.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-render-pass.ts
@@ -196,7 +196,7 @@ export class WebGPURenderPass extends RenderPass {
       this.handle.draw(
         options.vertexCount || 0,
         options.instanceCount || 1,
-        options.firstIndex,
+        options.firstVertex,
         options.firstInstance
       );
     }

--- a/modules/webgpu/test/adapter/resources/webgpu-render-pass.spec.ts
+++ b/modules/webgpu/test/adapter/resources/webgpu-render-pass.spec.ts
@@ -84,6 +84,25 @@ test('WebGPU indirect draw methods forward native buffers and byte offsets', t =
   t.end();
 });
 
+test('WebGPU non-indexed draws forward firstVertex', t => {
+  const calls: unknown[][] = [];
+  const handle = {
+    draw: (...args: unknown[]) => calls.push(args)
+  };
+  const renderPass = Object.create(WebGPURenderPass.prototype) as WebGPURenderPass;
+  const pipeline = {shaderLayout: {bindings: []}};
+  const vertexArray = {
+    bindBeforeRender: () => {},
+    unbindAfterRender: () => {}
+  };
+  Object.assign(renderPass, {handle, pipeline, vertexArray});
+
+  renderPass.draw({vertexCount: 12, instanceCount: 3, firstVertex: 7, firstIndex: 19});
+
+  t.deepEqual(calls, [[12, 3, 7, undefined]], 'draw() uses firstVertex for non-indexed draws');
+  t.end();
+});
+
 function makeRenderPass(props: RenderPassProps): {
   getRenderPassDescriptor: (framebuffer: any) => GPURenderPassDescriptor;
 } {


### PR DESCRIPTION
## Stack

1. **#2715 - FontAtlas builders** (this stack base)
2. **#2717 - Renderer adoption**
3. **#2718 - WebGPU draw offsets**
4. **#2719 - Text - Space Crawl**
5. **#2714 - MSDF support**

Review and merge from top to bottom. Each PR is based on the preceding branch.

## Changes

- Forwards `firstVertex` for WebGPU non-indexed draws instead of incorrectly reusing `firstIndex`.
- Adds a focused regression test.

This engine fix is isolated from the text API refactor.

## Verification

- 3 focused WebGPU render-pass tests
- `yarn build` on the complete stack
- Commit hook: 167 passed, 2 skipped