### PR TITLE
feat(experimental) Import fixed-width GPUVector chunks into command graphs

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -292,10 +292,10 @@ const sourceIds = graph.createDataView(sourceBuffer, {
 });
 ```
 
-`importGPUData()` preserves a `GPUData` range. `importGPUVector()` accepts a packed vector with one
-chunk in this experiment. Multi-chunk vectors require a batching policy: preserve chunks as
-separate graph invocations, expose a graph array, or explicitly pack them. The proof does not
-choose silently. It rejects multi-chunk and interleaved vectors with a clear error.
+`importGPUData()` preserves one `GPUData` range. `importGPUVector()` preserves every fixed-width
+chunk as an ordered `GraphVectorView`. The graph does not choose an execution policy for that
+collection: algorithms consume individual `GraphDataView` chunks unless they explicitly document
+vector-aware semantics. Interleaved and variable-length vectors require dedicated adapters.
 
 Formats and shader value types remain distinct. `GPUVectorFormat` describes stored bytes such as
 `uint32`, `float32x3`, or `unorm8x4`. WGSL declarations describe values such as `u32` and
@@ -650,13 +650,14 @@ WGSL. This is how compaction can legally write the `instanceCount` at byte offse
 copy pass. The graph view continues to describe the precise four-byte field; binding adaptation
 belongs to the kernel that knows its storage layout.
 
-`GPUVector` adds chunking. The initial adapter accepts exactly one packed chunk because chunk
-semantics affect scheduling. Concatenating chunks would allocate and copy implicitly. Treating
-chunks as one contiguous binding would be incorrect. Flattening them into multiple dispatches can
-change algorithm results: a global scan needs carry values between chunks, while independent
-per-batch scans do not. Rejection makes the unresolved policy visible.
+`GPUVector` adds chunking. Importing a fixed-width vector returns a `GraphVectorView` containing one
+`GraphDataView` per source chunk. The graph preserves chunk order and shared physical allocations;
+it does not concatenate, copy, or dispatch work automatically. Algorithms still declare atomic
+`GraphDataView` resources, so accepting a `GraphVectorView` is an explicit algorithm-level choice.
+Interleaved and variable-length vectors remain rejected until dedicated adapters define attribute
+and topology semantics.
 
-A future batch-aware graph API can offer explicit choices. A map-style algorithm may instantiate a
+A batch-aware graph API can offer explicit choices. A map-style algorithm may instantiate a
 graph fragment for every chunk. A streaming scan may produce a per-chunk total, scan those totals,
 then add carries. An application that truly needs contiguous storage can call a named packing
 operation and account for its allocation. All three are useful, and none should be selected merely

--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -56,8 +56,9 @@ Imports the backing allocation and preserves the supplied `GPUData` range.
 
 ### `importGPUVector(id, vector)`
 
-Imports a packed vector containing exactly one `GPUData` chunk. Multi-chunk and interleaved vectors
-are rejected in the current experiment.
+Imports every fixed-width `GPUData` chunk without packing and returns a `GraphVectorView`. Chunk
+order, vector metadata, per-chunk offsets, and shared backing buffers are preserved. Interleaved and
+variable-length vectors require explicit adapters and are rejected.
 
 ## Texture APIs
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-sort.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-sort.md
@@ -11,8 +11,10 @@ packed `uint32` graph views without submitting commands or reading results back 
 import {GPUCommandGraph, GPUSort} from '@luma.gl/experimental';
 
 const graph = new GPUCommandGraph(device, {id: 'sort-records'});
-const keys = graph.importGPUVector('keys', keyVector);
-const values = graph.importGPUVector('values', rowIdVector);
+const keyChunks = graph.importGPUVector('keys', keyVector);
+const valueChunks = graph.importGPUVector('values', rowIdVector);
+const keys = keyChunks.data[0]!;
+const values = valueChunks.data[0]!;
 const outputKeyHandle = graph.importBuffer(
   {id: 'output-keys', byteLength, usage: outputKeyBuffer.usage},
   outputKeyBuffer

--- a/examples/experimental/gpu-data-analysis/src/app.ts
+++ b/examples/experimental/gpu-data-analysis/src/app.ts
@@ -130,8 +130,18 @@ class GPUDataAnalysisExample {
       const gridBuffer = makeOutputBuffer(this.device, 'grid', gridWidth * gridWidth);
       const outputs = [extentBuffer, histogramBuffer, totalBuffer, gridBuffer];
       const graph = new GPUCommandGraph(this.device, {id: 'gpu-data-analysis-example'});
-      const valuesView = graph.importGPUVector('values', gpuValues);
-      const positionsView = graph.importGPUVector('positions', gpuPositions);
+      const valuesImport = graph.importGPUVector('values', gpuValues);
+      const positionsImport = graph.importGPUVector('positions', gpuPositions);
+      const valuesView = valuesImport.data[0];
+      const positionsView = positionsImport.data[0];
+      if (
+        !valuesView ||
+        valuesImport.data.length !== 1 ||
+        !positionsView ||
+        positionsImport.data.length !== 1
+      ) {
+        throw new Error('GPU data analysis requires single-chunk input vectors');
+      }
       const extent = importOutput(graph, extentBuffer, 'extent', 'float32', 2);
       const histogram = importOutput(graph, histogramBuffer, 'histogram', 'uint32', binCount);
       const total = importOutput(graph, totalBuffer, 'total', 'uint32', 1);

--- a/examples/experimental/gpu-sort/src/app.ts
+++ b/examples/experimental/gpu-sort/src/app.ts
@@ -166,8 +166,18 @@ class GPUSortExample {
         usage: Buffer.STORAGE | Buffer.COPY_SRC
       });
       const graph = new GPUCommandGraph(this.device, {id: 'gpu-sort-example'});
-      const keyView = graph.importGPUVector('keys', inputKeys);
-      const valueView = graph.importGPUVector('values', inputValues);
+      const keysImport = graph.importGPUVector('keys', inputKeys);
+      const valuesImport = graph.importGPUVector('values', inputValues);
+      const keyView = keysImport.data[0];
+      const valueView = valuesImport.data[0];
+      if (
+        !keyView ||
+        keysImport.data.length !== 1 ||
+        !valueView ||
+        valuesImport.data.length !== 1
+      ) {
+        throw new Error('GPU sort requires single-chunk input vectors');
+      }
       const outputKeyHandle = graph.importBuffer(
         {id: 'output-keys', byteLength, usage: outputKeys.usage},
         outputKeys

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
@@ -18,7 +18,9 @@ import {
   GPUData,
   type GPUVector,
   type GPUVectorFormat,
-  getGPUVectorFormatInfo
+  getGPUVectorFormatInfo,
+  isValueListGPUVectorFormat,
+  isVertexListGPUVectorFormat
 } from '@luma.gl/tables';
 
 /** GPU buffer use declared by one graph node. */
@@ -137,6 +139,42 @@ export class GraphDataView<T extends GPUVectorFormat = GPUVectorFormat> {
     this.byteOffset = props.byteOffset;
     this.byteStride = props.byteStride;
     this.rowByteLength = props.rowByteLength;
+  }
+}
+
+/** Ordered graph data views that preserve one fixed-width GPUVector's chunk boundaries. */
+export class GraphVectorView<T extends GPUVectorFormat = GPUVectorFormat> {
+  readonly id: string;
+  readonly name: string;
+  readonly format: T;
+  readonly length: number;
+  readonly valueLength: number;
+  readonly stride: number;
+  readonly byteStride: number;
+  readonly rowByteLength: number;
+  readonly data: readonly GraphDataView<T>[];
+
+  /** @internal */
+  constructor(props: {
+    id: string;
+    name: string;
+    format: T;
+    length: number;
+    valueLength: number;
+    stride: number;
+    byteStride: number;
+    rowByteLength: number;
+    data: readonly GraphDataView<T>[];
+  }) {
+    this.id = props.id;
+    this.name = props.name;
+    this.format = props.format;
+    this.length = props.length;
+    this.valueLength = props.valueLength;
+    this.stride = props.stride;
+    this.byteStride = props.byteStride;
+    this.rowByteLength = props.rowByteLength;
+    this.data = props.data;
   }
 }
 
@@ -375,6 +413,7 @@ export class GPUCommandGraph<Parameters = void> {
 
   private readonly buffers = new Map<string, GraphBufferHandle>();
   private readonly textures = new Map<string, GraphTextureHandle>();
+  private readonly tableBufferHandles = new Map<Buffer, GraphBufferHandle>();
   private readonly nodes: GPUCommandGraphNode<Parameters>[] = [];
   private readonly nodeIds = new Set<string>();
   private compiled = false;
@@ -440,33 +479,39 @@ export class GPUCommandGraph<Parameters = void> {
 
   /** Imports one borrowed GPUData range and returns its typed graph view. */
   importGPUData<T extends GPUVectorFormat>(id: string, data: GPUData<T>): GraphDataView<T> {
-    if (!data.format) {
-      throw new Error(`GPUCommandGraph import "${id}" requires GPUData.format`);
-    }
-    const coreBuffer = getCoreBuffer(data.buffer);
-    const handle = this.importBuffer(
-      {id, byteLength: coreBuffer.byteLength, usage: coreBuffer.usage},
-      data.buffer
-    );
-    return this.createDataView(handle, {
-      format: data.format,
-      length: data.length,
-      byteOffset: data.byteOffset,
-      byteStride: data.byteStride,
-      rowByteLength: data.rowByteLength
-    });
+    return this.importGPUDataView(id, data);
   }
 
-  /** Imports one packed, single-chunk GPUVector. */
-  importGPUVector<T extends GPUVectorFormat>(id: string, vector: GPUVector<T>): GraphDataView<T> {
-    const [data, ...remainingData] = vector.data;
-    if (!data || remainingData.length > 0) {
-      throw new Error(`GPUCommandGraph import "${id}" requires exactly one GPUVector chunk`);
-    }
+  /** Imports all chunks of one fixed-width GPUVector without packing them. */
+  importGPUVector<T extends GPUVectorFormat>(id: string, vector: GPUVector<T>): GraphVectorView<T> {
     if (vector.bufferLayout) {
       throw new Error(`GPUCommandGraph import "${id}" does not accept interleaved GPUVector data`);
     }
-    return this.importGPUData(id, data);
+    const format = vector.format ?? vector.data[0]?.format;
+    if (!format) {
+      throw new Error(`GPUCommandGraph import "${id}" requires GPUVector.format`);
+    }
+    if (isVertexListGPUVectorFormat(format) || isValueListGPUVectorFormat(format)) {
+      throw new Error(`GPUCommandGraph import "${id}" requires a fixed-width GPUVector format`);
+    }
+    const data = vector.data.map((chunk, chunkIndex) => {
+      if (chunk.format !== format) {
+        throw new Error(`GPUCommandGraph import "${id}" requires matching GPUVector chunk formats`);
+      }
+      const chunkId = vector.data.length === 1 ? id : `${id}-chunk-${chunkIndex}`;
+      return this.importGPUDataView(chunkId, chunk);
+    });
+    return new GraphVectorView({
+      id,
+      name: vector.name,
+      format,
+      length: vector.length,
+      valueLength: vector.valueLength,
+      stride: vector.stride,
+      byteStride: vector.byteStride,
+      rowByteLength: vector.rowByteLength,
+      data
+    });
   }
 
   /** Declares a caller-owned fixed-size texture that can be supplied now or while encoding. */
@@ -683,6 +728,31 @@ export class GPUCommandGraph<Parameters = void> {
     }
     this.textures.set(texture.id, texture);
     return texture;
+  }
+
+  private importGPUDataView<T extends GPUVectorFormat>(
+    id: string,
+    data: GPUData<T>
+  ): GraphDataView<T> {
+    if (!data.format) {
+      throw new Error(`GPUCommandGraph import "${id}" requires GPUData.format`);
+    }
+    const coreBuffer = getCoreBuffer(data.buffer);
+    let handle = this.tableBufferHandles.get(coreBuffer);
+    if (!handle) {
+      handle = this.importBuffer(
+        {id, byteLength: coreBuffer.byteLength, usage: coreBuffer.usage},
+        data.buffer
+      );
+      this.tableBufferHandles.set(coreBuffer, handle);
+    }
+    return this.createDataView(handle, {
+      format: data.format,
+      length: data.length,
+      byteOffset: data.byteOffset,
+      byteStride: data.byteStride,
+      rowByteLength: data.rowByteLength
+    });
   }
 
   private assertBuffer(buffer: GraphBufferHandle): void {

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -8,7 +8,8 @@ export {
   GraphBufferHandle,
   GraphDataView,
   GraphTextureHandle,
-  GraphTextureView
+  GraphTextureView,
+  GraphVectorView
 } from './gpu-command-graph';
 export type {
   GPUCommandGraphCompileContext,

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
@@ -6,6 +6,7 @@ import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {Buffer, type Device, Texture} from '@luma.gl/core';
 import {DynamicBuffer, Model} from '@luma.gl/engine';
 import {DrawCommandBuffer, GPUCommandGraph, GPUCompaction, GPUScan} from '@luma.gl/experimental';
+import {GPUData, GPUVector} from '@luma.gl/tables';
 import {getNullTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
 
 test('GPUCommandGraph compiles dependencies and reuses transient buffers', async t => {
@@ -76,6 +77,140 @@ test('GPUCommandGraph rejects explicit dependency cycles', async t => {
     compile: () => ({encode: () => {}})
   });
   t.throws(() => graph.compile(), /dependency cycle/, 'cycle is rejected');
+  t.end();
+});
+
+test('GPUCommandGraph preserves fixed-width GPUVector chunks and borrowed ownership', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const sharedBuffer = device.createBuffer({byteLength: 16, usage: Buffer.STORAGE});
+  const trailingBuffer = device.createBuffer({byteLength: 8, usage: Buffer.STORAGE});
+  const firstChunk = new GPUData({
+    buffer: sharedBuffer,
+    format: 'uint32',
+    length: 2,
+    byteOffset: 0,
+    ownsBuffer: true
+  });
+  const secondChunk = new GPUData({
+    buffer: sharedBuffer,
+    format: 'uint32',
+    length: 2,
+    byteOffset: 8
+  });
+  const thirdChunk = new GPUData({
+    buffer: trailingBuffer,
+    format: 'uint32',
+    length: 2,
+    ownsBuffer: true
+  });
+  const vector = new GPUVector({
+    type: 'data',
+    name: 'values',
+    format: 'uint32',
+    data: [firstChunk, secondChunk, thirdChunk],
+    ownsData: true
+  });
+  const graph = new GPUCommandGraph(device, {id: 'gpu-vector-import-test'});
+  const firstView = graph.importGPUData('first-data', firstChunk);
+  const vectorView = graph.importGPUVector('values', vector);
+
+  t.equal(firstView.format, 'uint32', 'GPUData format is preserved');
+  t.equal(firstView.length, 2, 'GPUData length is preserved');
+  t.equal(firstView.byteOffset, 0, 'GPUData byte offset is preserved');
+  t.equal(firstView.byteStride, 4, 'GPUData byte stride is preserved');
+  t.equal(vectorView.name, 'values', 'GPUVector name is preserved');
+  t.equal(vectorView.length, 6, 'GPUVector row count is preserved');
+  t.equal(vectorView.data.length, 3, 'GPUVector chunk count is preserved');
+  t.equal(vectorView.data[0].buffer, firstView.buffer, 'reuses an already imported table buffer');
+  t.equal(vectorView.data[0].buffer, vectorView.data[1].buffer, 'shared chunks share one handle');
+  t.notEqual(
+    vectorView.data[1].buffer,
+    vectorView.data[2].buffer,
+    'distinct buffers stay distinct'
+  );
+  t.equal(vectorView.data[1].byteOffset, 8, 'per-chunk byte offsets are preserved');
+
+  graph.addCopyPass({
+    id: 'read-first-chunk',
+    dependsOn: ['gate'],
+    resources: [{buffer: vectorView.data[0], usage: 'storage-read'}],
+    compile: () => ({encode: () => {}})
+  });
+  graph.addCopyPass({
+    id: 'write-second-chunk',
+    resources: [{buffer: vectorView.data[1], usage: 'storage-write'}],
+    compile: () => ({encode: () => {}})
+  });
+  graph.addCopyPass({id: 'gate', compile: () => ({encode: () => {}})});
+  const compiled = graph.compile();
+  t.deepEqual(
+    compiled.stats.nodeOrder,
+    ['gate', 'read-first-chunk', 'write-second-chunk'],
+    'hazards are inferred through the shared physical buffer handle'
+  );
+
+  compiled.destroy();
+  t.notOk(sharedBuffer.destroyed, 'compiled graph does not destroy borrowed shared storage');
+  t.notOk(trailingBuffer.destroyed, 'compiled graph does not destroy borrowed trailing storage');
+  vector.destroy();
+  t.ok(sharedBuffer.destroyed, 'GPUVector retains shared-buffer ownership');
+  t.ok(trailingBuffer.destroyed, 'GPUVector retains trailing-buffer ownership');
+  t.end();
+});
+
+test('GPUCommandGraph rejects interleaved and variable-length GPUVector imports', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const interleaved = new GPUVector({
+    type: 'interleaved',
+    name: 'interleaved',
+    buffer: device.createBuffer({byteLength: 16, usage: Buffer.STORAGE}),
+    length: 2,
+    byteStride: 8,
+    attributes: [{attribute: 'value', format: 'uint32', byteOffset: 0}],
+    ownsBuffer: true
+  });
+  const listData = new GPUData({
+    buffer: device.createBuffer({byteLength: 8, usage: Buffer.STORAGE}),
+    format: 'value-list<uint32>',
+    length: 1,
+    valueLength: 2,
+    valueOffsets: new Int32Array([0, 2]),
+    ownsBuffer: true
+  });
+  const variableLength = new GPUVector({
+    type: 'data',
+    name: 'variable-length',
+    format: 'value-list<uint32>',
+    data: [listData],
+    ownsData: true
+  });
+  const graph = new GPUCommandGraph(device);
+
+  t.throws(
+    () => graph.importGPUVector('interleaved', interleaved),
+    /does not accept interleaved/,
+    'interleaved vectors require an explicit attribute adapter'
+  );
+  t.throws(
+    () => graph.importGPUVector('variable-length', variableLength),
+    /fixed-width GPUVector format/,
+    'variable-length vectors require an explicit topology adapter'
+  );
+
+  interleaved.destroy();
+  variableLength.destroy();
   t.end();
 });
 


### PR DESCRIPTION
## Goals

- Align `GPUCommandGraph` imports with the table model where a `GPUVector` is an ordered list of `GPUData` chunks.
- Preserve chunk boundaries and borrowed ownership without implicit packing or new graph-owned table outputs.

## Changes

- Add `GraphVectorView<T>` with vector metadata and `readonly data: GraphDataView<T>[]`.
- Update `importGPUVector()` to import every fixed-width chunk without allocation or packing.
- Deduplicate shared physical table buffers while preserving per-chunk offsets and layouts.
- Keep graph resources and hazards buffer-atomic: nodes still declare individual `GraphDataView` uses.
- Explicitly reject interleaved and variable-length vectors.
- Keep existing single-chunk primitives explicit at their example integration boundaries.
- Add coverage for metadata, chunk order, shared-buffer hazards, unsupported layouts, and borrowed ownership.

## Verification

- `nvm use`
- `yarn install --immutable`
- `yarn lint fix`
- `yarn build`
- `yarn examples:typecheck`
- `yarn test` (166 node tests passed, 2 skipped; 1,240 browser tests passed, 25 skipped)
- `yarn website:build`
- `(cd website && yarn build)`

## Scope

This PR is based directly on `master` after #2713. It does not extract the command-graph compiler, add graph-owned GPUData/GPUVector outputs, implement encode-time replacement, add interleaved adapters, or make scan/sort/compaction/reduction primitives multi-chunk aware. Those remain separate focused follow-ups.
