### PR TITLE
feat(experimental) Add multi-chunk GPU reduction

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -60,6 +60,23 @@ Imports every fixed-width `GPUData` chunk without packing and returns a `GraphVe
 order, vector metadata, per-chunk offsets, and shared backing buffers are preserved. Interleaved and
 variable-length vectors require explicit adapters and are rejected.
 
+## Primitive multi-chunk support
+
+The multi-chunk column means that the primitive directly accepts a `GraphVectorView` and computes
+one globally correct result across its ordered `GraphDataView` chunks. A ❌ primitive still accepts
+its documented atomic graph resources; callers must select, adapt, or explicitly pack chunks.
+
+| Primitive | Primary graph input | Multi-chunk `GraphVectorView` |
+| --- | --- | :---: |
+| `GPUScan` | `GraphDataView<'uint32'>` | ❌ |
+| `GPUCompaction` | Input and flag `GraphDataView`s | ❌ |
+| `GPUSort` | Key and value `GraphDataView`s | ❌ |
+| `GPUReduction` | Scalar `GraphDataView` or `GraphVectorView` | ✅ |
+| `GPUHistogram` | Scalar `GraphDataView` | ❌ |
+| `GPUGridBinning` | Position `GraphDataView` | ❌ |
+| `GPUIndexPickingTarget` | Texture and readback resources | ❌ |
+| `DrawCommandBuffer` | Indirect command buffer | ❌ |
+
 ## Texture APIs
 
 ### `importTexture(descriptor, defaultTexture?)`

--- a/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
@@ -5,7 +5,7 @@ import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-do
 <GPUPrimitivesDocsTabs active="reduction" />
 
 `GPUReduction` records a deterministic hierarchical reduction over a packed `uint32`, `sint32`,
-or `float32` graph view.
+or `float32` graph data view or fixed-width graph vector.
 
 ```ts
 new GPUReduction({input: values, output: extent, operation: 'extent'}).addToGraph(graph);
@@ -16,7 +16,7 @@ new GPUReduction({input: values, output: extent, operation: 'extent'}).addToGrap
 ```ts
 type GPUReductionProps<T extends 'uint32' | 'sint32' | 'float32'> = {
   id?: string;
-  input: GraphDataView<T>;
+  input: GraphDataView<T> | GraphVectorView<T>;
   output: GraphDataView<T>;
   operation: 'sum' | 'min' | 'max' | 'extent';
 };
@@ -24,6 +24,11 @@ type GPUReductionProps<T extends 'uint32' | 'sint32' | 'float32'> = {
 
 `sum`, `min`, and `max` require one output row; `extent` writes `[minimum, maximum]` and requires
 two. Inputs and outputs use separate caller-owned buffers. Hierarchical scratch is graph-owned.
+
+For a `GraphVectorView`, each non-empty `GraphDataView` chunk is reduced independently into
+graph-owned partial storage, followed by one global reduction. Chunk order and storage remain
+unchanged; no input is packed or concatenated. An all-empty vector follows the same zero-result
+behavior as an empty data view.
 
 Integer sums wrap to 32 bits. Floating sums use a fixed 256-way tree. Floating minimum, maximum,
 and extent ignore NaN and infinity. Empty inputs and all-invalid floating inputs produce zero.

--- a/modules/experimental/src/gpu-primitives/gpu-reduction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-reduction.ts
@@ -4,7 +4,12 @@
 
 import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-command-graph';
+import {
+  GPUCommandGraph,
+  GraphVectorView,
+  type GraphBufferUse,
+  type GraphDataView
+} from './gpu-command-graph';
 import {
   createTransientView,
   getViewBinding,
@@ -19,23 +24,28 @@ const SCALAR_FORMATS = ['uint32', 'sint32', 'float32'] as const;
 /** Operation performed by {@link GPUReduction}. */
 export type GPUReductionOperation = 'sum' | 'min' | 'max' | 'extent';
 
+/** One scalar chunk or an ordered scalar vector reduced by {@link GPUReduction}. */
+export type GPUReductionInput<T extends GPUScalarFormat = GPUScalarFormat> =
+  | GraphDataView<T>
+  | GraphVectorView<T>;
+
 /** Properties for a graph-native scalar reduction. */
 export type GPUReductionProps<T extends GPUScalarFormat = GPUScalarFormat> = {
   id?: string;
-  input: GraphDataView<T>;
+  input: GPUReductionInput<T>;
   output: GraphDataView<T>;
   operation: GPUReductionOperation;
 };
 
 /**
- * Hierarchical reduction over packed 32-bit scalar graph views.
+ * Hierarchical reduction over packed 32-bit scalar graph data views and vectors.
  *
  * @remarks Inputs and outputs are caller-owned. Hierarchical scratch is graph-owned, and adding
  * the reduction to a graph never submits work or reads data back.
  */
 export class GPUReduction<T extends GPUScalarFormat = GPUScalarFormat> {
   readonly id: string;
-  readonly input: GraphDataView<T>;
+  readonly input: GPUReductionInput<T>;
   readonly output: GraphDataView<T>;
   readonly operation: GPUReductionOperation;
 
@@ -44,7 +54,13 @@ export class GPUReduction<T extends GPUScalarFormat = GPUScalarFormat> {
     this.input = props.input;
     this.output = props.output;
     this.operation = props.operation;
-    validatePackedView(this.input, SCALAR_FORMATS, `${this.id} input`);
+    for (const [chunkIndex, input] of getReductionInputs(this.input).entries()) {
+      const name = this.input instanceof GraphVectorView ? ` input chunk ${chunkIndex}` : ' input';
+      validatePackedView(input, SCALAR_FORMATS, `${this.id}${name}`);
+      if (input.format !== this.input.format) {
+        throw new Error(`${this.id}${name} format must match the input format`);
+      }
+    }
     validatePackedView(this.output, SCALAR_FORMATS, `${this.id} output`);
     if (this.input.format !== this.output.format) {
       throw new Error(`${this.id} input and output formats must match`);
@@ -56,17 +72,19 @@ export class GPUReduction<T extends GPUScalarFormat = GPUScalarFormat> {
     if (this.output.length !== outputLength) {
       throw new Error(`${this.id} ${this.operation} output must contain ${outputLength} row(s)`);
     }
-    if (this.input.buffer === this.output.buffer) {
-      throw new Error(`${this.id} input and output must use separate buffers`);
+    if (getReductionInputs(this.input).some(input => input.buffer === this.output.buffer)) {
+      throw new Error(`${this.id} inputs and output must use separate buffers`);
     }
   }
 
   /** Adds hierarchical reduction passes and hidden scratch to a command graph. */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
-    if (this.input.buffer.graph !== graph || this.output.buffer.graph !== graph) {
+    const inputs = getReductionInputs(this.input);
+    if (inputs.some(input => input.buffer.graph !== graph) || this.output.buffer.graph !== graph) {
       throw new Error(`${this.id} views must belong to the target graph`);
     }
-    if (this.input.length === 0) {
+    const nonEmptyInputs = inputs.filter(input => input.length > 0);
+    if (nonEmptyInputs.length === 0) {
       addClearReductionPass(graph, this.id, this.output);
       return;
     }
@@ -74,57 +92,165 @@ export class GPUReduction<T extends GPUScalarFormat = GPUScalarFormat> {
     const valuesPerRow = this.operation === 'extent' ? 2 : 1;
     const needsValidity =
       this.input.format === 'float32' && ['min', 'max', 'extent'].includes(this.operation);
-    let inputValues: GraphDataView<T> = this.input;
-    let inputValidity: GraphDataView<'uint32'> | undefined;
-    let inputLength = this.input.length;
-    let levelIndex = 0;
+    let reductionResult: ReductionResult<T>;
 
-    while (true) {
-      const outputLength = Math.ceil(inputLength / REDUCTION_WORKGROUP_SIZE);
-      const outputValues = createTransientView(
-        graph,
-        `${this.id}-level-${levelIndex}-values`,
-        this.input.format,
-        outputLength * valuesPerRow
-      ) as GraphDataView<T>;
-      const outputValidity = needsValidity
-        ? createTransientView(
-            graph,
-            `${this.id}-level-${levelIndex}-validity`,
-            'uint32',
-            outputLength
-          )
-        : undefined;
-      addReductionLevelPass(graph, {
-        id: `${this.id}-level-${levelIndex}`,
+    if (nonEmptyInputs.length === 1) {
+      reductionResult = addReductionLevels(graph, {
+        id: this.id,
         format: this.input.format,
         operation: this.operation,
-        inputValues,
-        inputValidity,
-        outputValues,
-        outputValidity,
-        inputLength,
+        inputValues: nonEmptyInputs[0],
+        inputLength: nonEmptyInputs[0].length,
         valuesPerRow,
-        firstLevel: levelIndex === 0
+        firstLevel: true,
+        needsValidity
       });
-      inputValues = outputValues;
-      inputValidity = outputValidity;
-      inputLength = outputLength;
-      levelIndex++;
-      if (inputLength === 1) {
-        break;
-      }
+    } else {
+      const partialValues = createTransientView(
+        graph,
+        `${this.id}-chunk-values`,
+        this.input.format,
+        nonEmptyInputs.length * valuesPerRow
+      ) as GraphDataView<T>;
+      const partialValidity = needsValidity
+        ? createTransientView(graph, `${this.id}-chunk-validity`, 'uint32', nonEmptyInputs.length)
+        : undefined;
+
+      nonEmptyInputs.forEach((input, partialIndex) => {
+        addReductionLevels(graph, {
+          id: `${this.id}-chunk-${partialIndex}`,
+          format: this.input.format,
+          operation: this.operation,
+          inputValues: input,
+          inputLength: input.length,
+          valuesPerRow,
+          firstLevel: true,
+          needsValidity,
+          finalValues: createPackedSubview(
+            graph,
+            partialValues,
+            partialIndex * valuesPerRow,
+            valuesPerRow
+          ),
+          finalValidity: partialValidity
+            ? createPackedSubview(graph, partialValidity, partialIndex, 1)
+            : undefined
+        });
+      });
+
+      reductionResult = addReductionLevels(graph, {
+        id: `${this.id}-merge`,
+        format: this.input.format,
+        operation: this.operation,
+        inputValues: partialValues,
+        inputValidity: partialValidity,
+        inputLength: nonEmptyInputs.length,
+        valuesPerRow,
+        firstLevel: false,
+        needsValidity
+      });
     }
 
     addFinalizeReductionPass(graph, {
       id: `${this.id}-finalize`,
       format: this.input.format,
-      inputValues,
-      inputValidity,
+      inputValues: reductionResult.values,
+      inputValidity: reductionResult.validity,
       output: this.output,
       valuesPerRow
     });
   }
+}
+
+type ReductionResult<T extends GPUScalarFormat> = {
+  values: GraphDataView<T>;
+  validity?: GraphDataView<'uint32'>;
+};
+
+function addReductionLevels<Parameters, T extends GPUScalarFormat>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    format: T;
+    operation: GPUReductionOperation;
+    inputValues: GraphDataView<T>;
+    inputValidity?: GraphDataView<'uint32'>;
+    inputLength: number;
+    valuesPerRow: number;
+    firstLevel: boolean;
+    needsValidity: boolean;
+    finalValues?: GraphDataView<T>;
+    finalValidity?: GraphDataView<'uint32'>;
+  }
+): ReductionResult<T> {
+  let inputValues = props.inputValues;
+  let inputValidity = props.inputValidity;
+  let inputLength = props.inputLength;
+  let levelIndex = 0;
+
+  while (true) {
+    const outputLength = Math.ceil(inputLength / REDUCTION_WORKGROUP_SIZE);
+    const isFinalLevel = outputLength === 1;
+    const outputValues =
+      isFinalLevel && props.finalValues
+        ? props.finalValues
+        : (createTransientView(
+            graph,
+            `${props.id}-level-${levelIndex}-values`,
+            props.format,
+            outputLength * props.valuesPerRow
+          ) as GraphDataView<T>);
+    const outputValidity = props.needsValidity
+      ? isFinalLevel && props.finalValidity
+        ? props.finalValidity
+        : createTransientView(
+            graph,
+            `${props.id}-level-${levelIndex}-validity`,
+            'uint32',
+            outputLength
+          )
+      : undefined;
+    addReductionLevelPass(graph, {
+      id: `${props.id}-level-${levelIndex}`,
+      format: props.format,
+      operation: props.operation,
+      inputValues,
+      inputValidity,
+      outputValues,
+      outputValidity,
+      inputLength,
+      valuesPerRow: props.valuesPerRow,
+      firstLevel: props.firstLevel && levelIndex === 0
+    });
+    inputValues = outputValues;
+    inputValidity = outputValidity;
+    inputLength = outputLength;
+    levelIndex++;
+    if (inputLength === 1) {
+      break;
+    }
+  }
+
+  return {values: inputValues, validity: inputValidity};
+}
+
+function createPackedSubview<T extends GPUScalarFormat, Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  view: GraphDataView<T>,
+  elementOffset: number,
+  length: number
+): GraphDataView<T> {
+  return graph.createDataView(view.buffer, {
+    format: view.format,
+    length,
+    byteOffset: view.byteOffset + elementOffset * view.rowByteLength
+  });
+}
+
+function getReductionInputs<T extends GPUScalarFormat>(
+  input: GPUReductionInput<T>
+): readonly GraphDataView<T>[] {
+  return input instanceof GraphVectorView ? input.data : [input];
 }
 
 function addReductionLevelPass<Parameters, T extends GPUScalarFormat>(

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -47,7 +47,7 @@ export {GPUSort} from './gpu-sort';
 export type {GPUSortAlgorithm, GPUSortDirection, GPUSortProps} from './gpu-sort';
 
 export {GPUReduction} from './gpu-reduction';
-export type {GPUReductionOperation, GPUReductionProps} from './gpu-reduction';
+export type {GPUReductionInput, GPUReductionOperation, GPUReductionProps} from './gpu-reduction';
 
 export {GPUHistogram} from './gpu-histogram';
 export type {GPUHistogramDomain, GPUHistogramProps} from './gpu-histogram';

--- a/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
@@ -12,7 +12,7 @@ import {
   type GPUReductionOperation
 } from '@luma.gl/experimental';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
-import type {GPUVectorFormat} from '@luma.gl/tables';
+import {GPUData, GPUVector, type GPUVectorFormat} from '@luma.gl/tables';
 
 test('GPUReduction handles operations, formats, hierarchy, and invalid floats', async t => {
   const device = await getWebGPUTestDevice();
@@ -55,6 +55,62 @@ test('GPUReduction handles operations, formats, hierarchy, and invalid floats', 
     [0]
   );
   t.deepEqual(await runReduction(device, new Float32Array(0), 'float32', 'extent'), [0, 0]);
+  t.end();
+});
+
+test('GPUReduction combines fixed-width GPUVector chunks', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  t.deepEqual(
+    await runVectorReduction(
+      device,
+      [Uint32Array.from([7, 3]), new Uint32Array(0), Uint32Array.from([9, 4])],
+      'uint32',
+      'sum'
+    ),
+    [23],
+    'sum combines non-empty chunks and skips empty chunks'
+  );
+  t.deepEqual(
+    await runVectorReduction(
+      device,
+      [Uint32Array.from([7, 3]), Uint32Array.from([9, 4])],
+      'uint32',
+      'extent'
+    ),
+    [3, 9],
+    'extent combines per-chunk minima and maxima'
+  );
+  t.deepEqual(
+    await runVectorReduction(
+      device,
+      [Float32Array.from([Number.NaN, Number.POSITIVE_INFINITY]), Float32Array.from([4, -2])],
+      'float32',
+      'min'
+    ),
+    [-2],
+    'invalid-only chunks do not inject zero into a valid floating reduction'
+  );
+  t.deepEqual(
+    await runVectorReduction(
+      device,
+      [Float32Array.from([Number.NaN]), Float32Array.from([Number.NEGATIVE_INFINITY])],
+      'float32',
+      'max'
+    ),
+    [0],
+    'all-invalid floating chunks produce zero'
+  );
+  t.deepEqual(
+    await runVectorReduction(device, [new Int32Array(0), new Int32Array(0)], 'sint32', 'extent'),
+    [0, 0],
+    'an all-empty vector produces zero'
+  );
   t.end();
 });
 
@@ -290,6 +346,44 @@ async function runReduction(
   const result = Array.from(new ResultArray(bytes.buffer, bytes.byteOffset, outputLength));
   compiled.destroy();
   inputBuffer.destroy();
+  outputBuffer.destroy();
+  return result;
+}
+
+async function runVectorReduction(
+  device: Device,
+  chunks: ScalarArray[],
+  format: ScalarFormat,
+  operation: GPUReductionOperation
+): Promise<number[]> {
+  const outputLength = operation === 'extent' ? 2 : 1;
+  const inputBuffers = chunks.map(chunk => createInputBuffer(device, chunk));
+  const vector = new GPUVector({
+    type: 'data',
+    name: 'input',
+    format,
+    data: chunks.map(
+      (chunk, index) =>
+        new GPUData({buffer: inputBuffers[index], format, length: chunk.length, ownsBuffer: false})
+    ),
+    ownsData: false
+  });
+  const outputBuffer = createOutputBuffer(device, outputLength);
+  const graph = new GPUCommandGraph(device);
+  const input = graph.importGPUVector('input', vector);
+  const output = importView(graph, 'output', outputBuffer, format, outputLength);
+  new GPUReduction({input, output, operation}).addToGraph(graph);
+  const compiled = graph.compile();
+  const commandEncoder = device.createCommandEncoder({id: 'vector-reduction-test'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+  const bytes = await outputBuffer.readAsync();
+  const ResultArray =
+    format === 'uint32' ? Uint32Array : format === 'sint32' ? Int32Array : Float32Array;
+  const result = Array.from(new ResultArray(bytes.buffer, bytes.byteOffset, outputLength));
+  compiled.destroy();
+  vector.destroy();
+  for (const buffer of inputBuffers) buffer.destroy();
   outputBuffer.destroy();
   return result;
 }


### PR DESCRIPTION
## Goals

- Make the first command-graph primitive consume a fixed-width multi-chunk `GPUVector` without packing or changing chunk boundaries.
- Produce one globally correct reduction result while preserving graph-owned scratch and caller-owned inputs/outputs.

## Changes

- Allow `GPUReduction.input` to be a scalar `GraphDataView` or `GraphVectorView`.
- Reduce each non-empty chunk into graph-owned partial storage, then reduce the partials into one global result.
- Preserve floating-point validity across chunk partials for `min`, `max`, and `extent`.
- Keep graph node resources atomic: every node declares individual `GraphDataView` uses.
- Handle empty chunks, all-empty vectors, and all-invalid floating chunks explicitly.
- Add WebGPU coverage for multi-chunk sum, extent, invalid floats, and empty vectors.
- Add a command-graph primitive capability table showing current multi-chunk support with ✅/❌ markers.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn examples:typecheck` (28 workspaces)
- `yarn test` (166 node tests passed, 2 skipped; 1,241 browser tests passed, 25 skipped)
- `yarn test-browser modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts` (6 passed)
- `yarn website:build`
- `(cd website && yarn build)`

## Scope

This PR is based directly on `master` after #2720. It does not add multi-chunk scan, compaction, sort, histogram, or grid-binning behavior, and it does not change the command-graph compiler or import ownership model.
