### PR TITLE
feat(experimental) Extract and document GPU command graph internals

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -38,6 +38,17 @@ const compiled = graph.compile();
 compiled.encode(device.commandEncoder, {parameters: {time}});
 ```
 
+## Lifecycle and ownership
+
+A graph definition is mutable until `compile()` is called. Compilation freezes the definition,
+infers a stable node order, plans transient allocation reuse, creates physical transients, and calls
+each node's `compile` callback once. The returned `CompiledGPUCommandGraph` can then be encoded
+repeatedly with different parameters and compatible imported-resource replacements.
+
+Imported buffers, textures, `GPUData`, and `GPUVector` chunks are borrowed. The compiled graph owns
+only node-created resources, physical transients, and cached texture views/framebuffers. Calling
+`destroy()` releases those owned resources and never destroys an import.
+
 ## Buffer APIs
 
 ### `importBuffer(descriptor, defaultBuffer?)`
@@ -118,6 +129,44 @@ dependency.
 Executable contexts expose `getBuffer()`, `getTexture()`, and `getTextureView()`. Concrete texture
 views and framebuffers are cached for repeated encodings and rebuilt when an imported texture is
 replaced.
+
+## Hazards and scheduling
+
+A hazard is an ordering requirement caused by accesses to the same physical resource. The compiler
+adds dependencies for read-after-write, write-after-read, and write-after-write access. Read-after-
+read access does not require ordering.
+
+Buffer hazards are tracked at `GraphBufferHandle` granularity. Consequently, distinct
+`GraphDataView`s that share a handle alias even when their byte ranges do not overlap. A
+`GraphVectorView` is not itself a node resource; primitives declare uses of its individual data
+views, which map back to their physical buffer handles.
+
+Texture hazards are more precise: two `GraphTextureView` uses alias only when their aspect, mip,
+and array-layer ranges overlap. A `GraphTextureHandle` use covers the complete texture.
+
+Explicit `dependsOn` edges are combined with inferred resource edges. Compilation rejects missing
+dependency IDs and cycles. Independent nodes retain declaration order, making the compiled schedule
+stable.
+
+## Compilation
+
+The compiler performs four steps:
+
+1. Infer hazards and topologically order nodes.
+2. Compute inclusive first/last use indices for every referenced transient.
+3. Reuse compatible physical allocations across non-overlapping lifetimes.
+4. Create physical resources and invoke node `compile` callbacks in scheduled order.
+
+Buffer reuse grows an allocation to the maximum required capacity and unions usage flags. Texture
+reuse requires equal format, extent, dimension, mip count, and sample count; usage flags are
+unioned. If node compilation throws, already-created node resources and transients are destroyed
+before the error is rethrown.
+
+The implementation keeps dependencies one-directional: `gpu-command-graph-types.ts` owns shared
+handles, views, node contracts, executable contexts, and statistics;
+`gpu-command-graph-compiler.ts` consumes those contracts to produce a compilation; and
+`gpu-command-graph.ts` owns graph construction and encoding. The compiler never imports the graph
+implementation.
 
 ## `CompiledGPUCommandGraph`
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
@@ -33,6 +33,30 @@ behavior as an empty data view.
 Integer sums wrap to 32 bits. Floating sums use a fixed 256-way tree. Floating minimum, maximum,
 and extent ignore NaN and infinity. Empty inputs and all-invalid floating inputs produce zero.
 
+## Reduction hierarchy
+
+The reduction is planned in levels. Each level dispatches one 256-thread workgroup for every group
+of at most 256 input rows, producing one partial row per workgroup. The next level consumes those
+partial rows. For example, 100,000 input rows produce 391 partial rows, then 2, then 1.
+
+| Stage | Input | Output |
+| --- | --- | --- |
+| First level | Packed scalar rows | One partial row per 256 input rows |
+| Intermediate levels | Previous partial rows | One partial row per 256 input rows |
+| Finalize | One partial row | Caller-owned output view |
+
+`extent` represents each partial row as two adjacent values: minimum and maximum. Floating-point
+`min`, `max`, and `extent` carry a parallel `uint32` validity row so that NaN and infinity can be
+ignored without choosing a sentinel value. The finalize pass maps a result with no finite values to
+zero.
+
+For a multi-chunk vector, each non-empty chunk gets its own hierarchy. The last level of each chunk
+writes directly into one slot of a shared partial view. A merge hierarchy then reduces those slots.
+Empty chunks add no passes and do not change the result.
+
+All intermediate views are graph-owned transients. Their declared node uses let the command-graph
+compiler infer ordering and reuse physical scratch allocations when lifetimes do not overlap.
+
 ## `addToGraph(graph)`
 
 Declares reduction levels and a final normalization pass. It does not compile, encode, submit,

--- a/modules/experimental/src/gpu-primitives/draw-command-buffer.ts
+++ b/modules/experimental/src/gpu-primitives/draw-command-buffer.ts
@@ -9,41 +9,75 @@ const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 const DRAW_RECORD_WORDS = 4;
 const DRAW_INDEXED_RECORD_WORDS = 5;
 
+/** CPU description of one WebGPU `drawIndirect` record. */
 export type DrawCommand = {
+  /** Number of vertices drawn by each instance. */
   vertexCount: number;
+  /** Number of instances. Defaults to `1`. */
   instanceCount?: number;
+  /** First vertex. Defaults to `0`. */
   firstVertex?: number;
+  /** First instance. Defaults to `0`. */
   firstInstance?: number;
 };
 
+/** CPU description of one WebGPU `drawIndexedIndirect` record. */
 export type DrawIndexedCommand = {
+  /** Number of indices drawn by each instance. */
   indexCount: number;
+  /** Number of instances. Defaults to `1`. */
   instanceCount?: number;
+  /** First index. Defaults to `0`. */
   firstIndex?: number;
+  /** Signed vertex offset added to each index. Defaults to `0`. */
   baseVertex?: number;
+  /** First instance. Defaults to `0`. */
   firstInstance?: number;
 };
 
+/** Properties for one typed WebGPU indirect-command buffer. */
 export type DrawCommandBufferProps = {
+  /** Buffer identifier. */
   id?: string;
+  /** Indirect record layout. */
   type: 'draw' | 'draw-indexed';
+  /** Record capacity. Defaults to `commands.length`. */
   capacity?: number;
+  /** Optional initial CPU records. Unspecified capacity slots are zero-filled. */
   commands?: DrawCommand[] | DrawIndexedCommand[];
+  /** Optional compatible caller-supplied buffer. */
   buffer?: Buffer;
+  /** Whether `destroy()` should destroy a supplied buffer. Defaults to `false`. */
   ownsBuffer?: boolean;
 };
 
-/** Typed owner or borrower of WebGPU indirect draw records. */
+/**
+ * Typed owner or borrower of WebGPU indirect draw records.
+ *
+ * The backing buffer supports storage, indirect, and copy access so compute primitives can update
+ * counts before a render pass consumes the same records.
+ */
 export class DrawCommandBuffer {
+  /** WebGPU device owning the backing buffer. */
   readonly device: Device;
+  /** Buffer identifier. */
   readonly id: string;
+  /** Indirect record layout. */
   readonly type: 'draw' | 'draw-indexed';
+  /** Maximum record count. */
   readonly capacity: number;
+  /** Byte size of one indirect record. */
   readonly recordByteLength: number;
+  /** Concrete storage/indirect buffer. */
   readonly buffer: Buffer;
   private ownsBuffer: boolean;
   private destroyed = false;
 
+  /**
+   * Creates or adopts an indirect-command buffer and optionally uploads initial records.
+   *
+   * @throws If the device, capacity, initial values, or supplied buffer are incompatible.
+   */
   constructor(device: Device, props: DrawCommandBufferProps) {
     if (device.type !== 'webgpu') {
       throw new Error('DrawCommandBuffer requires a WebGPU device');
@@ -94,11 +128,13 @@ export class DrawCommandBuffer {
     }
   }
 
+  /** Returns the byte offset of one indirect record after validating its index. */
   getCommandByteOffset(commandIndex: number): number {
     this.validateCommandIndex(commandIndex);
     return commandIndex * this.recordByteLength;
   }
 
+  /** Returns the byte offset of one record's GPU-writable `instanceCount` field. */
   getInstanceCountByteOffset(commandIndex: number): number {
     return this.getCommandByteOffset(commandIndex) + UINT32_BYTE_LENGTH;
   }
@@ -145,6 +181,7 @@ export class DrawCommandBuffer {
   }
 }
 
+/** Encodes validated CPU command descriptions into little-endian WebGPU indirect records. */
 function makeCommandData(
   type: 'draw' | 'draw-indexed',
   capacity: number,
@@ -174,6 +211,7 @@ function makeCommandData(
   return new Uint32Array(data);
 }
 
+/** Validates and writes one unsigned indirect-record component. */
 function setUint32(view: DataView, byteOffset: number, value: number, name: string): void {
   if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
     throw new Error(`DrawCommandBuffer ${name} must be a uint32 value`);
@@ -181,6 +219,7 @@ function setUint32(view: DataView, byteOffset: number, value: number, name: stri
   view.setUint32(byteOffset, value, true);
 }
 
+/** Validates and writes one signed indirect-record component. */
 function setInt32(view: DataView, byteOffset: number, value: number, name: string): void {
   if (!Number.isSafeInteger(value) || value < -0x80000000 || value > 0x7fffffff) {
     throw new Error(`DrawCommandBuffer ${name} must be an int32 value`);

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph-compiler.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph-compiler.ts
@@ -1,0 +1,594 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, Texture, textureFormatDecoder} from '@luma.gl/core';
+import type {Device, TextureFormat} from '@luma.gl/core';
+import type {
+  GPUCommandGraphComputeExecutable,
+  GPUCommandGraphCopyExecutable,
+  GPUCommandGraphNode,
+  GPUCommandGraphRenderExecutable,
+  GPUCommandGraphStats,
+  GraphBufferHandle,
+  GraphBufferUsage,
+  GraphBufferUse,
+  GraphDataView,
+  GraphResourceUse,
+  GraphTextureAspect,
+  GraphTextureDimension,
+  GraphTextureHandle,
+  GraphTextureUse,
+  GraphTextureUsage,
+  GraphTextureView
+} from './gpu-command-graph-types';
+
+/** A graph node paired with the reusable executable produced by its compile callback. @internal */
+export type CompiledNode<Parameters> = {
+  /** Scheduled node definition. */
+  node: GPUCommandGraphNode<Parameters>;
+  /** Reusable node state and encode callback. */
+  executable:
+    | GPUCommandGraphComputeExecutable<Parameters>
+    | GPUCommandGraphRenderExecutable<Parameters>
+    | GPUCommandGraphCopyExecutable<Parameters>;
+};
+
+/** One physical buffer allocation shared by logical transients with disjoint lifetimes. @internal */
+export type BufferTransientAllocation = {
+  /** Maximum capacity required by any assigned handle. */
+  byteLength: number;
+  /** Union of usage flags required by assigned handles. */
+  usage: number;
+  /** Last scheduled node index using the most recently assigned handle. */
+  lastUse: number;
+  /** Logical handles assigned to this allocation in lifetime order. */
+  handles: GraphBufferHandle[];
+  /** Physical buffer created during compilation. */
+  buffer?: Buffer;
+};
+
+type TransientTextureDescriptor = {
+  id: string;
+  format: TextureFormat;
+  width: number;
+  height: number;
+  usage: number;
+  dimension: GraphTextureDimension;
+  depth: number;
+  mipLevels: number;
+  samples: number;
+};
+
+/** One physical texture allocation shared by compatible transients with disjoint lifetimes. @internal */
+export type TextureTransientAllocation = {
+  /** Descriptor shared by every assigned handle, with their usage flags combined. */
+  descriptor: TransientTextureDescriptor;
+  /** Estimated physical allocation size used for statistics. */
+  byteLength: number;
+  /** Last scheduled node index using the most recently assigned handle. */
+  lastUse: number;
+  /** Logical handles assigned to this allocation in lifetime order. */
+  handles: GraphTextureHandle[];
+  /** Physical texture created during compilation. */
+  texture?: Texture;
+};
+
+/** Complete immutable input for constructing a `CompiledGPUCommandGraph`. @internal */
+export type GPUCommandGraphCompilation<Parameters> = {
+  /** Device owning compiled resources. */
+  device: Device;
+  /** Graph identifier. */
+  id: string;
+  /** Snapshot of logical buffer resources. */
+  buffers: Map<string, GraphBufferHandle>;
+  /** Snapshot of logical texture resources. */
+  textures: Map<string, GraphTextureHandle>;
+  /** Nodes and executables in stable topological order. */
+  compiledNodes: CompiledNode<Parameters>[];
+  /** Logical-to-physical transient buffer mapping. */
+  transientBuffers: Map<GraphBufferHandle, Buffer>;
+  /** Logical-to-physical transient texture mapping. */
+  transientTextures: Map<GraphTextureHandle, Texture>;
+  /** Physical buffer allocation plan retained for destruction. */
+  bufferTransientAllocations: BufferTransientAllocation[];
+  /** Physical texture allocation plan retained for destruction. */
+  textureTransientAllocations: TextureTransientAllocation[];
+  /** Scheduling and allocation statistics. */
+  stats: GPUCommandGraphStats;
+};
+
+/**
+ * Compiles scheduling, transient allocations, and executable node resources.
+ *
+ * Compilation proceeds in four phases: infer a stable topological node order, plan allocation
+ * reuse from transient lifetimes, create physical resources, then invoke node compile callbacks.
+ * If a callback fails, every executable and physical resource created so far is destroyed before
+ * the error is rethrown.
+ *
+ * @internal
+ */
+export function compileGPUCommandGraph<Parameters>(props: {
+  device: Device;
+  id: string;
+  buffers: Map<string, GraphBufferHandle>;
+  textures: Map<string, GraphTextureHandle>;
+  nodes: GPUCommandGraphNode<Parameters>[];
+}): GPUCommandGraphCompilation<Parameters> {
+  const nodeOrder = getNodeOrder(props.nodes);
+  const bufferPlan = getBufferTransientAllocationPlan(nodeOrder, props.buffers.values());
+  const texturePlan = getTextureTransientAllocationPlan(nodeOrder, props.textures.values());
+  const transientBuffers = new Map<GraphBufferHandle, Buffer>();
+  const transientTextures = new Map<GraphTextureHandle, Texture>();
+
+  for (const allocation of bufferPlan) {
+    allocation.buffer = props.device.createBuffer({
+      id: `${props.id}-transient-buffer-${bufferPlan.indexOf(allocation)}`,
+      byteLength: allocation.byteLength,
+      usage: allocation.usage
+    });
+    for (const handle of allocation.handles) {
+      transientBuffers.set(handle, allocation.buffer);
+    }
+  }
+  for (const allocation of texturePlan) {
+    allocation.texture = props.device.createTexture({
+      ...allocation.descriptor,
+      id: `${props.id}-transient-texture-${texturePlan.indexOf(allocation)}`
+    });
+    for (const handle of allocation.handles) {
+      transientTextures.set(handle, allocation.texture);
+    }
+  }
+
+  const compiledNodes: CompiledNode<Parameters>[] = [];
+  try {
+    for (const node of nodeOrder) {
+      compiledNodes.push({node, executable: node.compile({device: props.device})});
+    }
+  } catch (error) {
+    for (const compiledNode of compiledNodes) {
+      compiledNode.executable.destroy?.();
+    }
+    for (const allocation of bufferPlan) {
+      allocation.buffer?.destroy();
+    }
+    for (const allocation of texturePlan) {
+      allocation.texture?.destroy();
+    }
+    throw error;
+  }
+
+  const logicalTransientBytes = Array.from(props.buffers.values())
+    .filter(buffer => buffer.transient)
+    .reduce((sum, buffer) => sum + buffer.byteLength, 0);
+  const physicalTransientBytes = bufferPlan.reduce(
+    (sum, allocation) => sum + allocation.byteLength,
+    0
+  );
+  const reusedTransientBytes = Math.max(0, logicalTransientBytes - physicalTransientBytes);
+  const logicalTransientTextureBytes = Array.from(props.textures.values())
+    .filter(texture => texture.transient)
+    .reduce((sum, texture) => sum + getTextureByteLength(texture), 0);
+  const physicalTransientTextureBytes = texturePlan.reduce(
+    (sum, allocation) => sum + allocation.byteLength,
+    0
+  );
+  const reusedTransientTextureBytes = Math.max(
+    0,
+    logicalTransientTextureBytes - physicalTransientTextureBytes
+  );
+  const stats: GPUCommandGraphStats = {
+    nodeOrder: nodeOrder.map(node => node.id),
+    logicalTransientBufferCount: Array.from(props.buffers.values()).filter(
+      buffer => buffer.transient
+    ).length,
+    physicalTransientBufferCount: bufferPlan.length,
+    logicalTransientBytes,
+    physicalTransientBytes,
+    reusedTransientBytes,
+    reusePercentage:
+      logicalTransientBytes > 0 ? (reusedTransientBytes / logicalTransientBytes) * 100 : 0,
+    logicalTransientTextureCount: Array.from(props.textures.values()).filter(
+      texture => texture.transient
+    ).length,
+    physicalTransientTextureCount: texturePlan.length,
+    logicalTransientTextureBytes,
+    physicalTransientTextureBytes,
+    reusedTransientTextureBytes,
+    textureReusePercentage:
+      logicalTransientTextureBytes > 0
+        ? (reusedTransientTextureBytes / logicalTransientTextureBytes) * 100
+        : 0
+  };
+
+  return {
+    device: props.device,
+    id: props.id,
+    buffers: new Map(props.buffers),
+    textures: new Map(props.textures),
+    compiledNodes,
+    transientBuffers,
+    transientTextures,
+    bufferTransientAllocations: bufferPlan,
+    textureTransientAllocations: texturePlan,
+    stats
+  };
+}
+
+/** Returns the underlying logical buffer for either a handle or typed data view. @internal */
+export function getBufferHandle(buffer: GraphBufferHandle | GraphDataView): GraphBufferHandle {
+  return 'buffer' in buffer ? buffer.buffer : buffer;
+}
+
+/** Returns the underlying logical texture for either a handle or subresource view. @internal */
+export function getTextureHandle(
+  texture: GraphTextureHandle | GraphTextureView
+): GraphTextureHandle {
+  return 'texture' in texture ? texture.texture : texture;
+}
+
+/** Narrows a declared resource use to a buffer use. @internal */
+export function isGraphBufferUse(resource: GraphResourceUse): resource is GraphBufferUse {
+  return 'buffer' in resource;
+}
+
+/** Returns whether an access observes existing buffer contents. */
+function isBufferReadUsage(usage: GraphBufferUsage): boolean {
+  return (
+    usage === 'storage-read' ||
+    usage === 'storage-read-write' ||
+    usage === 'uniform' ||
+    usage === 'copy-source' ||
+    usage === 'indirect' ||
+    usage === 'vertex' ||
+    usage === 'index'
+  );
+}
+
+/** Returns whether an access changes buffer contents. */
+function isBufferWriteUsage(usage: GraphBufferUsage): boolean {
+  return (
+    usage === 'storage-write' || usage === 'storage-read-write' || usage === 'copy-destination'
+  );
+}
+
+/** Returns whether an access observes existing texture contents. */
+function isTextureReadUsage(usage: GraphTextureUsage): boolean {
+  return (
+    usage === 'sampled' ||
+    usage === 'storage-read' ||
+    usage === 'storage-read-write' ||
+    usage === 'render-attachment' ||
+    usage === 'copy-source'
+  );
+}
+
+/** Returns whether an access may change texture contents. */
+function isTextureWriteUsage(usage: GraphTextureUsage): boolean {
+  return (
+    usage === 'storage-write' ||
+    usage === 'storage-read-write' ||
+    usage === 'render-attachment' ||
+    usage === 'copy-destination'
+  );
+}
+
+/**
+ * Infers hazards and returns a stable topological node order.
+ *
+ * Buffer hazards are conservative at whole-handle granularity. Texture hazards use overlapping
+ * aspect, mip, and layer ranges. Explicit dependencies and inferred hazards share the same graph;
+ * nodes that are otherwise independent retain insertion order.
+ */
+function getNodeOrder<Parameters>(
+  nodes: GPUCommandGraphNode<Parameters>[]
+): GPUCommandGraphNode<Parameters>[] {
+  const nodeById = new Map(nodes.map(node => [node.id, node]));
+  const dependencies = new Map<string, Set<string>>();
+  const lastBufferWriter = new Map<GraphBufferHandle, string>();
+  const activeBufferReaders = new Map<GraphBufferHandle, Set<string>>();
+  const textureHistory = new Map<
+    GraphTextureHandle,
+    {nodeId: string; resource: GraphTextureUse}[]
+  >();
+
+  for (const node of nodes) {
+    const nodeDependencies = new Set(node.dependsOn ?? []);
+    for (const dependency of nodeDependencies) {
+      if (!nodeById.has(dependency)) {
+        throw new Error(
+          `GPUCommandGraph node "${node.id}" depends on missing node "${dependency}"`
+        );
+      }
+    }
+    for (const resource of node.resources ?? []) {
+      if (isGraphBufferUse(resource)) {
+        const handle = getBufferHandle(resource.buffer);
+        if (isBufferReadUsage(resource.usage)) {
+          const writer = lastBufferWriter.get(handle);
+          if (writer) {
+            nodeDependencies.add(writer);
+          }
+          const readers = activeBufferReaders.get(handle) ?? new Set<string>();
+          readers.add(node.id);
+          activeBufferReaders.set(handle, readers);
+        }
+        if (isBufferWriteUsage(resource.usage)) {
+          const writer = lastBufferWriter.get(handle);
+          if (writer) {
+            nodeDependencies.add(writer);
+          }
+          for (const reader of activeBufferReaders.get(handle) ?? []) {
+            if (reader !== node.id) {
+              nodeDependencies.add(reader);
+            }
+          }
+          activeBufferReaders.set(handle, new Set());
+          lastBufferWriter.set(handle, node.id);
+        }
+      } else {
+        const handle = getTextureHandle(resource.texture);
+        const history = textureHistory.get(handle) ?? [];
+        for (const previous of history) {
+          if (
+            previous.nodeId !== node.id &&
+            textureUsesOverlap(previous.resource, resource) &&
+            ((isTextureReadUsage(resource.usage) && isTextureWriteUsage(previous.resource.usage)) ||
+              (isTextureWriteUsage(resource.usage) &&
+                (isTextureReadUsage(previous.resource.usage) ||
+                  isTextureWriteUsage(previous.resource.usage))))
+          ) {
+            nodeDependencies.add(previous.nodeId);
+          }
+        }
+        history.push({nodeId: node.id, resource});
+        textureHistory.set(handle, history);
+      }
+    }
+    nodeDependencies.delete(node.id);
+    dependencies.set(node.id, nodeDependencies);
+  }
+
+  const insertionIndex = new Map(nodes.map((node, index) => [node.id, index]));
+  const remaining = new Map(
+    Array.from(dependencies, ([id, values]) => [id, new Set(values)] as const)
+  );
+  const ordered: GPUCommandGraphNode<Parameters>[] = [];
+  while (remaining.size > 0) {
+    const ready = Array.from(remaining)
+      .filter(([, values]) => values.size === 0)
+      .map(([id]) => id)
+      .sort((left, right) => insertionIndex.get(left)! - insertionIndex.get(right)!);
+    if (ready.length === 0) {
+      throw new Error('GPUCommandGraph contains a dependency cycle');
+    }
+    for (const id of ready) {
+      ordered.push(nodeById.get(id)!);
+      remaining.delete(id);
+      for (const values of remaining.values()) {
+        values.delete(id);
+      }
+    }
+  }
+  return ordered;
+}
+
+/** Returns whether two uses refer to overlapping subresources of the same logical texture. */
+function textureUsesOverlap(left: GraphTextureUse, right: GraphTextureUse): boolean {
+  const leftHandle = getTextureHandle(left.texture);
+  const rightHandle = getTextureHandle(right.texture);
+  if (leftHandle !== rightHandle) {
+    return false;
+  }
+  const leftRange = getTextureSubresourceRange(left.texture);
+  const rightRange = getTextureSubresourceRange(right.texture);
+  return (
+    aspectsOverlap(leftRange.aspect, rightRange.aspect) &&
+    intervalsOverlap(
+      leftRange.baseMipLevel,
+      leftRange.mipLevelCount,
+      rightRange.baseMipLevel,
+      rightRange.mipLevelCount
+    ) &&
+    intervalsOverlap(
+      leftRange.baseArrayLayer,
+      leftRange.arrayLayerCount,
+      rightRange.baseArrayLayer,
+      rightRange.arrayLayerCount
+    )
+  );
+}
+
+/** Normalizes a whole texture or view to the range used for hazard overlap tests. */
+function getTextureSubresourceRange(texture: GraphTextureHandle | GraphTextureView): {
+  aspect: GraphTextureAspect;
+  baseMipLevel: number;
+  mipLevelCount: number;
+  baseArrayLayer: number;
+  arrayLayerCount: number;
+} {
+  if ('texture' in texture) {
+    return texture;
+  }
+  return {
+    aspect: 'all',
+    baseMipLevel: 0,
+    mipLevelCount: texture.mipLevels,
+    baseArrayLayer: 0,
+    arrayLayerCount: texture.dimension === '3d' ? 1 : texture.depth
+  };
+}
+
+/** Returns whether two depth/stencil aspect selections overlap. */
+function aspectsOverlap(left: GraphTextureAspect, right: GraphTextureAspect): boolean {
+  return left === 'all' || right === 'all' || left === right;
+}
+
+/** Returns whether two half-open integer intervals overlap. */
+function intervalsOverlap(
+  leftStart: number,
+  leftCount: number,
+  rightStart: number,
+  rightCount: number
+): boolean {
+  return leftStart < rightStart + rightCount && rightStart < leftStart + leftCount;
+}
+
+/**
+ * Assigns transient buffers to reusable physical allocations.
+ *
+ * The earliest available allocation is selected by smallest capacity. Capacity grows to the
+ * largest assigned handle and usage flags are combined across all assigned handles.
+ */
+function getBufferTransientAllocationPlan<Parameters>(
+  nodes: GPUCommandGraphNode<Parameters>[],
+  buffers: Iterable<GraphBufferHandle>
+): BufferTransientAllocation[] {
+  const lifetimes = getResourceLifetimes(nodes, resource =>
+    isGraphBufferUse(resource) ? getBufferHandle(resource.buffer) : null
+  );
+  const allocations: BufferTransientAllocation[] = [];
+  const transientBuffers = Array.from(buffers)
+    .filter(buffer => buffer.transient)
+    .map(buffer => ({buffer, lifetime: lifetimes.get(buffer)}))
+    .sort(
+      (left, right) =>
+        (left.lifetime?.firstUse ?? Number.MAX_SAFE_INTEGER) -
+        (right.lifetime?.firstUse ?? Number.MAX_SAFE_INTEGER)
+    );
+
+  for (const {buffer, lifetime} of transientBuffers) {
+    if (!lifetime) {
+      continue;
+    }
+    let allocation = allocations
+      .filter(candidate => candidate.lastUse < lifetime.firstUse)
+      .sort((left, right) => left.byteLength - right.byteLength)[0];
+    if (!allocation) {
+      allocation = {byteLength: 0, usage: 0, lastUse: -1, handles: []};
+      allocations.push(allocation);
+    }
+    allocation.byteLength = Math.max(allocation.byteLength, buffer.byteLength);
+    allocation.usage |= buffer.usage;
+    allocation.lastUse = lifetime.lastUse;
+    allocation.handles.push(buffer);
+  }
+  return allocations;
+}
+
+/**
+ * Assigns transient textures to descriptor-compatible physical allocations with disjoint
+ * lifetimes. Unlike buffers, texture extent and sampling properties cannot grow during reuse.
+ */
+function getTextureTransientAllocationPlan<Parameters>(
+  nodes: GPUCommandGraphNode<Parameters>[],
+  textures: Iterable<GraphTextureHandle>
+): TextureTransientAllocation[] {
+  const lifetimes = getResourceLifetimes(nodes, resource =>
+    isGraphBufferUse(resource) ? null : getTextureHandle(resource.texture)
+  );
+  const allocations: TextureTransientAllocation[] = [];
+  const transientTextures = Array.from(textures)
+    .filter(texture => texture.transient)
+    .map(texture => ({texture, lifetime: lifetimes.get(texture)}))
+    .sort(
+      (left, right) =>
+        (left.lifetime?.firstUse ?? Number.MAX_SAFE_INTEGER) -
+        (right.lifetime?.firstUse ?? Number.MAX_SAFE_INTEGER)
+    );
+
+  for (const {texture, lifetime} of transientTextures) {
+    if (!lifetime) {
+      continue;
+    }
+    let allocation = allocations.find(
+      candidate =>
+        candidate.lastUse < lifetime.firstUse &&
+        areTextureDescriptorsCompatible(candidate.descriptor, texture)
+    );
+    if (!allocation) {
+      const descriptor = getNormalizedTextureDescriptor(texture);
+      allocation = {
+        descriptor,
+        byteLength: getTextureByteLength(texture),
+        lastUse: -1,
+        handles: []
+      };
+      allocations.push(allocation);
+    }
+    allocation.descriptor.usage |= texture.usage;
+    allocation.lastUse = lifetime.lastUse;
+    allocation.handles.push(texture);
+  }
+  return allocations;
+}
+
+/** Returns inclusive first/last scheduled use indices for each referenced transient resource. */
+function getResourceLifetimes<Parameters, Resource extends object>(
+  nodes: GPUCommandGraphNode<Parameters>[],
+  getResource: (resource: GraphResourceUse) => Resource | null
+): Map<Resource, {firstUse: number; lastUse: number}> {
+  const lifetimes = new Map<Resource, {firstUse: number; lastUse: number}>();
+  nodes.forEach((node, nodeIndex) => {
+    for (const resourceUse of node.resources ?? []) {
+      const resource = getResource(resourceUse);
+      if (!resource || !('transient' in resource) || !resource.transient) {
+        continue;
+      }
+      const lifetime = lifetimes.get(resource);
+      if (lifetime) {
+        lifetime.lastUse = nodeIndex;
+      } else {
+        lifetimes.set(resource, {firstUse: nodeIndex, lastUse: nodeIndex});
+      }
+    }
+  });
+  return lifetimes;
+}
+
+/** Copies a logical texture handle into the mutable physical-allocation descriptor. */
+function getNormalizedTextureDescriptor(texture: GraphTextureHandle): TransientTextureDescriptor {
+  return {
+    id: texture.id,
+    format: texture.format,
+    width: texture.width,
+    height: texture.height,
+    usage: texture.usage,
+    dimension: texture.dimension,
+    depth: texture.depth,
+    mipLevels: texture.mipLevels,
+    samples: texture.samples
+  };
+}
+
+/** Returns whether a logical texture can reuse an existing physical texture allocation. */
+function areTextureDescriptorsCompatible(
+  descriptor: TransientTextureDescriptor,
+  texture: GraphTextureHandle
+): boolean {
+  return (
+    descriptor.format === texture.format &&
+    descriptor.width === texture.width &&
+    descriptor.height === texture.height &&
+    descriptor.dimension === texture.dimension &&
+    descriptor.depth === texture.depth &&
+    descriptor.mipLevels === texture.mipLevels &&
+    descriptor.samples === texture.samples
+  );
+}
+
+/** Estimates all mip and sample storage for texture reuse statistics. */
+function getTextureByteLength(texture: GraphTextureHandle): number {
+  let byteLength = 0;
+  for (let mipLevel = 0; mipLevel < texture.mipLevels; mipLevel++) {
+    byteLength += textureFormatDecoder.computeMemoryLayout({
+      format: texture.format,
+      width: Math.max(1, texture.width >> mipLevel),
+      height: texture.dimension === '1d' ? 1 : Math.max(1, texture.height >> mipLevel),
+      depth: texture.dimension === '3d' ? Math.max(1, texture.depth >> mipLevel) : texture.depth,
+      byteAlignment: 1
+    }).byteLength;
+  }
+  return byteLength * texture.samples;
+}

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph-types.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph-types.ts
@@ -1,0 +1,505 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  Buffer,
+  CommandEncoder,
+  ComputePass,
+  Device,
+  RenderPass,
+  RenderPassProps,
+  Texture,
+  TextureFormat,
+  TextureView
+} from '@luma.gl/core';
+import type {DynamicBuffer, DynamicTexture} from '@luma.gl/engine';
+import type {GPUVectorFormat} from '@luma.gl/tables';
+
+/** Internal identity shared by graph-owned handles without importing the graph implementation. */
+export type GPUCommandGraphOwner = {
+  readonly id: string;
+};
+
+/**
+ * Access mode for a buffer used by a command-graph node.
+ *
+ * The compiler uses this declaration to infer read-after-write, write-after-read, and
+ * write-after-write dependencies. It also validates that the physical buffer has the required
+ * WebGPU usage flag.
+ */
+export type GraphBufferUsage =
+  | 'storage-read'
+  | 'storage-write'
+  | 'storage-read-write'
+  | 'uniform'
+  | 'copy-source'
+  | 'copy-destination'
+  | 'indirect'
+  | 'vertex'
+  | 'index';
+
+/**
+ * Access mode for a texture or texture view used by a command-graph node.
+ *
+ * Texture hazards are inferred only when the declared mip, layer, and aspect ranges overlap.
+ */
+export type GraphTextureUsage =
+  | 'sampled'
+  | 'storage-read'
+  | 'storage-write'
+  | 'storage-read-write'
+  | 'render-attachment'
+  | 'copy-source'
+  | 'copy-destination';
+
+/** Caller-owned buffer accepted as a fixed or per-encoding graph import. */
+export type GraphImportedBuffer = Buffer | DynamicBuffer;
+
+/** Caller-owned texture accepted as a fixed or per-encoding graph import. */
+export type GraphImportedTexture = Texture | DynamicTexture;
+
+/** Descriptor for one imported or transient graph buffer. */
+export type GraphBufferDescriptor = {
+  /** Graph-wide resource identifier. */
+  id: string;
+  /** Required capacity in bytes. */
+  byteLength: number;
+  /** Bitwise union of the required luma.gl buffer usage flags. */
+  usage: number;
+};
+
+/** Logical texture dimension supported by the command graph. */
+export type GraphTextureDimension = '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
+
+/** Depth/stencil aspect selected by a {@link GraphTextureView}. */
+export type GraphTextureAspect = 'all' | 'stencil-only' | 'depth-only';
+
+/** Descriptor for one fixed-size imported or transient graph texture. */
+export type GraphTextureDescriptor<Format extends TextureFormat = TextureFormat> = {
+  /** Graph-wide resource identifier. */
+  id: string;
+  /** Physical texel format. */
+  format: Format;
+  /** Width of mip level zero. */
+  width: number;
+  /** Height of mip level zero. */
+  height: number;
+  /** Bitwise union of the required luma.gl texture usage flags. */
+  usage: number;
+  /** Texture dimension. Defaults to `'2d'`. */
+  dimension?: GraphTextureDimension;
+  /** Array-layer count or depth for a 3D texture. Defaults to `1`. */
+  depth?: number;
+  /** Number of mip levels. Defaults to `1`. */
+  mipLevels?: number;
+  /** Multisample count. Defaults to `1`. */
+  samples?: number;
+};
+
+/** Fully defaulted texture descriptor used by graph internals. @internal */
+export type NormalizedGraphTextureDescriptor<Format extends TextureFormat = TextureFormat> = {
+  id: string;
+  format: Format;
+  width: number;
+  height: number;
+  usage: number;
+  dimension: GraphTextureDimension;
+  depth: number;
+  mipLevels: number;
+  samples: number;
+};
+
+/**
+ * Opaque logical buffer tracked by a `GPUCommandGraph`.
+ *
+ * A handle describes capacity, usage, and ownership but does not expose a concrete buffer. The
+ * concrete buffer is resolved while encoding a {@link CompiledGPUCommandGraph}.
+ */
+export class GraphBufferHandle {
+  /** Graph-wide resource identifier. */
+  readonly id: string;
+  /** Required capacity in bytes. */
+  readonly byteLength: number;
+  /** Required luma.gl buffer usage flags. */
+  readonly usage: number;
+  /** Whether the graph owns and may alias the physical allocation. */
+  readonly transient: boolean;
+  /** @internal */
+  readonly graph: GPUCommandGraphOwner;
+  /** @internal */
+  readonly defaultBuffer?: GraphImportedBuffer;
+
+  /** @internal */
+  constructor(
+    graph: GPUCommandGraphOwner,
+    descriptor: GraphBufferDescriptor,
+    transient: boolean,
+    defaultBuffer?: GraphImportedBuffer
+  ) {
+    this.graph = graph;
+    this.id = descriptor.id;
+    this.byteLength = descriptor.byteLength;
+    this.usage = descriptor.usage;
+    this.transient = transient;
+    this.defaultBuffer = defaultBuffer;
+  }
+}
+
+/**
+ * Typed logical range within one {@link GraphBufferHandle}.
+ *
+ * A data view mirrors one fixed-width `GPUData` chunk: it carries layout metadata but does not own
+ * the underlying buffer. Hazards remain buffer-granular, so two views of the same handle alias.
+ */
+export class GraphDataView<T extends GPUVectorFormat = GPUVectorFormat> {
+  /** Logical buffer containing the range. */
+  readonly buffer: GraphBufferHandle;
+  /** Stored GPU value format. */
+  readonly format: T;
+  /** Number of logical rows. */
+  readonly length: number;
+  /** Byte offset of the first row in the logical buffer. */
+  readonly byteOffset: number;
+  /** Byte distance between consecutive rows. */
+  readonly byteStride: number;
+  /** Number of bytes occupied by one row. */
+  readonly rowByteLength: number;
+
+  /** @internal */
+  constructor(
+    buffer: GraphBufferHandle,
+    props: {
+      format: T;
+      length: number;
+      byteOffset: number;
+      byteStride: number;
+      rowByteLength: number;
+    }
+  ) {
+    this.buffer = buffer;
+    this.format = props.format;
+    this.length = props.length;
+    this.byteOffset = props.byteOffset;
+    this.byteStride = props.byteStride;
+    this.rowByteLength = props.rowByteLength;
+  }
+}
+
+/**
+ * Ordered graph data views that preserve one fixed-width `GPUVector`'s chunk boundaries.
+ *
+ * A vector view is metadata and an ordered list only. Nodes declare uses of individual
+ * {@link GraphDataView} chunks so that the compiler continues to track physical buffer hazards.
+ */
+export class GraphVectorView<T extends GPUVectorFormat = GPUVectorFormat> {
+  /** Identifier supplied to `GPUCommandGraph.importGPUVector`. */
+  readonly id: string;
+  /** Source vector name. */
+  readonly name: string;
+  /** Canonical format shared by every chunk. */
+  readonly format: T;
+  /** Total logical row count across all chunks. */
+  readonly length: number;
+  /** Total flattened value count across all chunks. */
+  readonly valueLength: number;
+  /** Source vector stride in format components. */
+  readonly stride: number;
+  /** Source vector byte stride. */
+  readonly byteStride: number;
+  /** Source vector bytes occupied by one row. */
+  readonly rowByteLength: number;
+  /** Imported chunks in source order. */
+  readonly data: readonly GraphDataView<T>[];
+
+  /** @internal */
+  constructor(props: {
+    id: string;
+    name: string;
+    format: T;
+    length: number;
+    valueLength: number;
+    stride: number;
+    byteStride: number;
+    rowByteLength: number;
+    data: readonly GraphDataView<T>[];
+  }) {
+    this.id = props.id;
+    this.name = props.name;
+    this.format = props.format;
+    this.length = props.length;
+    this.valueLength = props.valueLength;
+    this.stride = props.stride;
+    this.byteStride = props.byteStride;
+    this.rowByteLength = props.rowByteLength;
+    this.data = props.data;
+  }
+}
+
+/**
+ * Opaque logical texture tracked by a `GPUCommandGraph`.
+ *
+ * The descriptor is fixed at graph construction. Imported textures must match it exactly at each
+ * encoding; transient textures are created and owned by the compiled graph.
+ */
+export class GraphTextureHandle<Format extends TextureFormat = TextureFormat> {
+  /** Graph-wide resource identifier. */
+  readonly id: string;
+  /** Physical texel format. */
+  readonly format: Format;
+  /** Width of mip level zero. */
+  readonly width: number;
+  /** Height of mip level zero. */
+  readonly height: number;
+  /** Required luma.gl texture usage flags. */
+  readonly usage: number;
+  /** Logical texture dimension. */
+  readonly dimension: GraphTextureDimension;
+  /** Array-layer count or depth for a 3D texture. */
+  readonly depth: number;
+  /** Number of mip levels. */
+  readonly mipLevels: number;
+  /** Multisample count. */
+  readonly samples: number;
+  /** Whether the graph owns and may alias the physical allocation. */
+  readonly transient: boolean;
+  /** @internal */
+  readonly graph: GPUCommandGraphOwner;
+  /** @internal */
+  readonly defaultTexture?: GraphImportedTexture;
+
+  /** @internal */
+  constructor(
+    graph: GPUCommandGraphOwner,
+    descriptor: NormalizedGraphTextureDescriptor<Format>,
+    transient: boolean,
+    defaultTexture?: GraphImportedTexture
+  ) {
+    this.graph = graph;
+    this.id = descriptor.id;
+    this.format = descriptor.format;
+    this.width = descriptor.width;
+    this.height = descriptor.height;
+    this.usage = descriptor.usage;
+    this.dimension = descriptor.dimension;
+    this.depth = descriptor.depth;
+    this.mipLevels = descriptor.mipLevels;
+    this.samples = descriptor.samples;
+    this.transient = transient;
+    this.defaultTexture = defaultTexture;
+  }
+}
+
+/** Subresource range selected by `GPUCommandGraph.createTextureView`. */
+export type GraphTextureViewProps = {
+  /** View dimension. Defaults to the dimension implied by the texture. */
+  dimension?: GraphTextureDimension;
+  /** Depth/stencil aspect. Defaults to `'all'`. */
+  aspect?: GraphTextureAspect;
+  /** First visible mip level. Defaults to `0`. */
+  baseMipLevel?: number;
+  /** Number of visible mip levels. Defaults to all remaining levels. */
+  mipLevelCount?: number;
+  /** First visible array layer. Defaults to `0`. */
+  baseArrayLayer?: number;
+  /** Number of visible array layers. Defaults to all remaining layers. */
+  arrayLayerCount?: number;
+};
+
+/** Logical mip, layer, and aspect range within one graph texture. */
+export class GraphTextureView<Format extends TextureFormat = TextureFormat> {
+  /** Logical texture containing the selected range. */
+  readonly texture: GraphTextureHandle<Format>;
+  /** Physical texel format inherited from the texture. */
+  readonly format: Format;
+  /** View dimension. */
+  readonly dimension: GraphTextureDimension;
+  /** Selected depth/stencil aspect. */
+  readonly aspect: GraphTextureAspect;
+  /** First selected mip level. */
+  readonly baseMipLevel: number;
+  /** Number of selected mip levels. */
+  readonly mipLevelCount: number;
+  /** First selected array layer. */
+  readonly baseArrayLayer: number;
+  /** Number of selected array layers. */
+  readonly arrayLayerCount: number;
+  /** Width of the first selected mip. */
+  readonly width: number;
+  /** Height of the first selected mip. */
+  readonly height: number;
+  /** Depth or layer count of the selected range. */
+  readonly depth: number;
+
+  /** @internal */
+  constructor(
+    texture: GraphTextureHandle<Format>,
+    props: Required<GraphTextureViewProps> & {width: number; height: number; depth: number}
+  ) {
+    this.texture = texture;
+    this.format = texture.format;
+    this.dimension = props.dimension;
+    this.aspect = props.aspect;
+    this.baseMipLevel = props.baseMipLevel;
+    this.mipLevelCount = props.mipLevelCount;
+    this.baseArrayLayer = props.baseArrayLayer;
+    this.arrayLayerCount = props.arrayLayerCount;
+    this.width = props.width;
+    this.height = props.height;
+    this.depth = props.depth;
+  }
+}
+
+/** One buffer use declared by a graph node. */
+export type GraphBufferUse = {
+  /** Whole logical buffer or typed range whose physical buffer is used. */
+  buffer: GraphBufferHandle | GraphDataView;
+  /** Access performed by the node. */
+  usage: GraphBufferUsage;
+};
+
+/** One texture or texture-view use declared by a graph node. */
+export type GraphTextureUse = {
+  /** Whole logical texture or selected subresource range used by the node. */
+  texture: GraphTextureHandle | GraphTextureView;
+  /** Access performed by the node. */
+  usage: GraphTextureUsage;
+};
+
+/** One resource use declared by a graph node. */
+export type GraphResourceUse = GraphBufferUse | GraphTextureUse;
+
+/** Graph-owned texture attachments resolved into a framebuffer for a render node. */
+export type GraphRenderPassAttachments = {
+  /** Color attachment views in render-target order. */
+  colorAttachments: GraphTextureView[];
+  /** Optional depth/stencil attachment view. */
+  depthStencilAttachment?: GraphTextureView;
+};
+
+/** Context available while compiling one graph node. */
+export type GPUCommandGraphCompileContext = {
+  /** WebGPU device that owns the graph. */
+  device: Device;
+};
+
+/** Context shared by every executable graph node. */
+export type GPUCommandGraphEncodeContext<Parameters> = {
+  /** Caller-owned encoder receiving the graph's commands. */
+  commandEncoder: CommandEncoder;
+  /** Per-encoding application parameters. */
+  parameters: Parameters;
+  /** Resolves a logical buffer or data view to its concrete buffer. */
+  getBuffer: (buffer: GraphBufferHandle | GraphDataView) => Buffer;
+  /** Resolves a logical texture or view to its concrete texture. */
+  getTexture: (texture: GraphTextureHandle | GraphTextureView) => Texture;
+  /** Resolves and caches the concrete texture view for a logical texture or view. */
+  getTextureView: (texture: GraphTextureHandle | GraphTextureView) => TextureView;
+};
+
+/** Compiled compute-pass callback. */
+export type GPUCommandGraphComputeExecutable<Parameters> = {
+  /** Records commands into the compute pass opened by the graph. */
+  encode: (context: GPUCommandGraphEncodeContext<Parameters> & {computePass: ComputePass}) => void;
+  /** Releases node-owned compiled resources. */
+  destroy?: () => void;
+};
+
+/** Compiled render-pass callback. */
+export type GPUCommandGraphRenderExecutable<Parameters> = {
+  /** Returns per-encoding render-pass options other than graph-declared attachments. */
+  getRenderPassProps?: (context: GPUCommandGraphEncodeContext<Parameters>) => RenderPassProps;
+  /** Records commands into the render pass opened by the graph. */
+  encode: (context: GPUCommandGraphEncodeContext<Parameters> & {renderPass: RenderPass}) => void;
+  /** Releases node-owned compiled resources. */
+  destroy?: () => void;
+};
+
+/** Compiled command-encoder callback used for copies and other pass-independent commands. */
+export type GPUCommandGraphCopyExecutable<Parameters> = {
+  /** Records commands directly into the caller-owned encoder. */
+  encode: (context: GPUCommandGraphEncodeContext<Parameters>) => void;
+  /** Releases node-owned compiled resources. */
+  destroy?: () => void;
+};
+
+type GPUCommandGraphNodeBase = {
+  /** Graph-wide node identifier. */
+  id: string;
+  /** Resources read or written by the node, used for validation and hazard inference. */
+  resources?: GraphResourceUse[];
+  /** Explicit predecessor node identifiers in addition to inferred resource dependencies. */
+  dependsOn?: string[];
+};
+
+/** Compute node compiled once and encoded into a graph-owned compute pass. */
+export type GPUCommandGraphComputeNode<Parameters> = GPUCommandGraphNodeBase & {
+  /** Node discriminator. */
+  type: 'compute';
+  /** Creates reusable node resources and the encode callback. */
+  compile: (context: GPUCommandGraphCompileContext) => GPUCommandGraphComputeExecutable<Parameters>;
+};
+
+/** Render node compiled once and encoded into a graph-owned render pass. */
+export type GPUCommandGraphRenderNode<Parameters> = GPUCommandGraphNodeBase & {
+  /** Node discriminator. */
+  type: 'render';
+  /** Optional graph-managed render attachments. */
+  attachments?: GraphRenderPassAttachments;
+  /** Creates reusable node resources and the encode callback. */
+  compile: (context: GPUCommandGraphCompileContext) => GPUCommandGraphRenderExecutable<Parameters>;
+};
+
+/** Copy or pass-independent node compiled once and encoded directly on the command encoder. */
+export type GPUCommandGraphCopyNode<Parameters> = GPUCommandGraphNodeBase & {
+  /** Node discriminator. */
+  type: 'copy';
+  /** Creates reusable node resources and the encode callback. */
+  compile: (context: GPUCommandGraphCompileContext) => GPUCommandGraphCopyExecutable<Parameters>;
+};
+
+/** Any node accepted by a `GPUCommandGraph`. */
+export type GPUCommandGraphNode<Parameters> =
+  | GPUCommandGraphComputeNode<Parameters>
+  | GPUCommandGraphRenderNode<Parameters>
+  | GPUCommandGraphCopyNode<Parameters>;
+
+/** Resource-allocation and scheduling statistics for one compiled graph. */
+export type GPUCommandGraphStats = {
+  /** Stable topological node order used for encoding. */
+  nodeOrder: string[];
+  /** Number of logical transient buffer handles used by nodes. */
+  logicalTransientBufferCount: number;
+  /** Number of physical transient buffers allocated after lifetime reuse. */
+  physicalTransientBufferCount: number;
+  /** Sum of the capacities of logical transient buffers. */
+  logicalTransientBytes: number;
+  /** Sum of physical transient buffer allocation capacities. */
+  physicalTransientBytes: number;
+  /** Logical buffer bytes avoided through allocation reuse. */
+  reusedTransientBytes: number;
+  /** Percentage of logical buffer bytes avoided through reuse. */
+  reusePercentage: number;
+  /** Number of logical transient texture handles used by nodes. */
+  logicalTransientTextureCount: number;
+  /** Number of physical transient textures allocated after lifetime reuse. */
+  physicalTransientTextureCount: number;
+  /** Estimated bytes across all logical transient textures. */
+  logicalTransientTextureBytes: number;
+  /** Estimated bytes across physical transient texture allocations. */
+  physicalTransientTextureBytes: number;
+  /** Estimated logical texture bytes avoided through allocation reuse. */
+  reusedTransientTextureBytes: number;
+  /** Percentage of estimated logical texture bytes avoided through reuse. */
+  textureReusePercentage: number;
+};
+
+/** Options supplied while encoding one compiled graph. */
+export type GPUCommandGraphEncodeOptions<Parameters> = {
+  /** Application data forwarded to every node encode callback. */
+  parameters: Parameters;
+  /** Per-encoding imported-buffer replacements keyed by graph resource ID. */
+  buffers?: Record<string, GraphImportedBuffer>;
+  /** Per-encoding imported-texture replacements keyed by graph resource ID. */
+  textures?: Record<string, GraphImportedTexture>;
+};

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
@@ -2,17 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, Texture, textureFormatDecoder} from '@luma.gl/core';
-import type {
-  CommandEncoder,
-  ComputePass,
-  Device,
-  Framebuffer,
-  RenderPass,
-  RenderPassProps,
-  TextureFormat,
-  TextureView
-} from '@luma.gl/core';
+import {Buffer, Texture} from '@luma.gl/core';
+import type {CommandEncoder, Device, Framebuffer, TextureFormat, TextureView} from '@luma.gl/core';
 import {DynamicBuffer, DynamicTexture} from '@luma.gl/engine';
 import {
   GPUData,
@@ -22,371 +13,79 @@ import {
   isValueListGPUVectorFormat,
   isVertexListGPUVectorFormat
 } from '@luma.gl/tables';
+import {
+  compileGPUCommandGraph,
+  getBufferHandle,
+  getTextureHandle,
+  isGraphBufferUse,
+  type BufferTransientAllocation,
+  type CompiledNode,
+  type GPUCommandGraphCompilation,
+  type TextureTransientAllocation
+} from './gpu-command-graph-compiler';
+import {
+  GraphBufferHandle,
+  GraphDataView,
+  GraphTextureHandle,
+  GraphTextureView,
+  GraphVectorView
+} from './gpu-command-graph-types';
+import type {
+  GPUCommandGraphComputeExecutable,
+  GPUCommandGraphComputeNode,
+  GPUCommandGraphCopyExecutable,
+  GPUCommandGraphCopyNode,
+  GPUCommandGraphEncodeContext,
+  GPUCommandGraphEncodeOptions,
+  GPUCommandGraphNode,
+  GPUCommandGraphRenderExecutable,
+  GPUCommandGraphRenderNode,
+  GPUCommandGraphStats,
+  GraphBufferDescriptor,
+  GraphBufferUsage,
+  GraphImportedBuffer,
+  GraphImportedTexture,
+  GraphRenderPassAttachments,
+  GraphTextureDescriptor,
+  GraphTextureUsage,
+  GraphTextureUse,
+  GraphTextureViewProps,
+  NormalizedGraphTextureDescriptor
+} from './gpu-command-graph-types';
 
-/** GPU buffer use declared by one graph node. */
-export type GraphBufferUsage =
-  | 'storage-read'
-  | 'storage-write'
-  | 'storage-read-write'
-  | 'uniform'
-  | 'copy-source'
-  | 'copy-destination'
-  | 'indirect'
-  | 'vertex'
-  | 'index';
-
-/** GPU texture use declared by one graph node. */
-export type GraphTextureUsage =
-  | 'sampled'
-  | 'storage-read'
-  | 'storage-write'
-  | 'storage-read-write'
-  | 'render-attachment'
-  | 'copy-source'
-  | 'copy-destination';
-
-/** Buffer accepted as a fixed or per-encoding graph import. */
-export type GraphImportedBuffer = Buffer | DynamicBuffer;
-
-/** Texture accepted as a fixed or per-encoding graph import. */
-export type GraphImportedTexture = Texture | DynamicTexture;
-
-/** Descriptor for one imported or transient graph buffer. */
-export type GraphBufferDescriptor = {
-  id: string;
-  byteLength: number;
-  usage: number;
-};
-
-export type GraphTextureDimension = '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
-export type GraphTextureAspect = 'all' | 'stencil-only' | 'depth-only';
-
-/** Descriptor for one fixed-size imported or transient graph texture. */
-export type GraphTextureDescriptor<Format extends TextureFormat = TextureFormat> = {
-  id: string;
-  format: Format;
-  width: number;
-  height: number;
-  usage: number;
-  dimension?: GraphTextureDimension;
-  depth?: number;
-  mipLevels?: number;
-  samples?: number;
-};
-
-type NormalizedGraphTextureDescriptor<Format extends TextureFormat = TextureFormat> = {
-  id: string;
-  format: Format;
-  width: number;
-  height: number;
-  usage: number;
-  dimension: GraphTextureDimension;
-  depth: number;
-  mipLevels: number;
-  samples: number;
-};
-
-/** Opaque logical buffer tracked by a {@link GPUCommandGraph}. */
-export class GraphBufferHandle {
-  readonly id: string;
-  readonly byteLength: number;
-  readonly usage: number;
-  readonly transient: boolean;
-  /** @internal */
-  readonly graph: GPUCommandGraph<any>;
-  /** @internal */
-  readonly defaultBuffer?: GraphImportedBuffer;
-
-  /** @internal */
-  constructor(
-    graph: GPUCommandGraph<any>,
-    descriptor: GraphBufferDescriptor,
-    transient: boolean,
-    defaultBuffer?: GraphImportedBuffer
-  ) {
-    this.graph = graph;
-    this.id = descriptor.id;
-    this.byteLength = descriptor.byteLength;
-    this.usage = descriptor.usage;
-    this.transient = transient;
-    this.defaultBuffer = defaultBuffer;
-  }
-}
-
-/** Typed logical range within one graph buffer. */
-export class GraphDataView<T extends GPUVectorFormat = GPUVectorFormat> {
-  readonly buffer: GraphBufferHandle;
-  readonly format: T;
-  readonly length: number;
-  readonly byteOffset: number;
-  readonly byteStride: number;
-  readonly rowByteLength: number;
-
-  /** @internal */
-  constructor(
-    buffer: GraphBufferHandle,
-    props: {
-      format: T;
-      length: number;
-      byteOffset: number;
-      byteStride: number;
-      rowByteLength: number;
-    }
-  ) {
-    this.buffer = buffer;
-    this.format = props.format;
-    this.length = props.length;
-    this.byteOffset = props.byteOffset;
-    this.byteStride = props.byteStride;
-    this.rowByteLength = props.rowByteLength;
-  }
-}
-
-/** Ordered graph data views that preserve one fixed-width GPUVector's chunk boundaries. */
-export class GraphVectorView<T extends GPUVectorFormat = GPUVectorFormat> {
-  readonly id: string;
-  readonly name: string;
-  readonly format: T;
-  readonly length: number;
-  readonly valueLength: number;
-  readonly stride: number;
-  readonly byteStride: number;
-  readonly rowByteLength: number;
-  readonly data: readonly GraphDataView<T>[];
-
-  /** @internal */
-  constructor(props: {
-    id: string;
-    name: string;
-    format: T;
-    length: number;
-    valueLength: number;
-    stride: number;
-    byteStride: number;
-    rowByteLength: number;
-    data: readonly GraphDataView<T>[];
-  }) {
-    this.id = props.id;
-    this.name = props.name;
-    this.format = props.format;
-    this.length = props.length;
-    this.valueLength = props.valueLength;
-    this.stride = props.stride;
-    this.byteStride = props.byteStride;
-    this.rowByteLength = props.rowByteLength;
-    this.data = props.data;
-  }
-}
-
-/** Opaque logical texture tracked by a {@link GPUCommandGraph}. */
-export class GraphTextureHandle<Format extends TextureFormat = TextureFormat> {
-  readonly id: string;
-  readonly format: Format;
-  readonly width: number;
-  readonly height: number;
-  readonly usage: number;
-  readonly dimension: GraphTextureDimension;
-  readonly depth: number;
-  readonly mipLevels: number;
-  readonly samples: number;
-  readonly transient: boolean;
-  /** @internal */
-  readonly graph: GPUCommandGraph<any>;
-  /** @internal */
-  readonly defaultTexture?: GraphImportedTexture;
-
-  /** @internal */
-  constructor(
-    graph: GPUCommandGraph<any>,
-    descriptor: NormalizedGraphTextureDescriptor<Format>,
-    transient: boolean,
-    defaultTexture?: GraphImportedTexture
-  ) {
-    this.graph = graph;
-    this.id = descriptor.id;
-    this.format = descriptor.format;
-    this.width = descriptor.width;
-    this.height = descriptor.height;
-    this.usage = descriptor.usage;
-    this.dimension = descriptor.dimension;
-    this.depth = descriptor.depth;
-    this.mipLevels = descriptor.mipLevels;
-    this.samples = descriptor.samples;
-    this.transient = transient;
-    this.defaultTexture = defaultTexture;
-  }
-}
-
-export type GraphTextureViewProps = {
-  dimension?: GraphTextureDimension;
-  aspect?: GraphTextureAspect;
-  baseMipLevel?: number;
-  mipLevelCount?: number;
-  baseArrayLayer?: number;
-  arrayLayerCount?: number;
-};
-
-/** Logical mip, layer, and aspect range within one graph texture. */
-export class GraphTextureView<Format extends TextureFormat = TextureFormat> {
-  readonly texture: GraphTextureHandle<Format>;
-  readonly format: Format;
-  readonly dimension: GraphTextureDimension;
-  readonly aspect: GraphTextureAspect;
-  readonly baseMipLevel: number;
-  readonly mipLevelCount: number;
-  readonly baseArrayLayer: number;
-  readonly arrayLayerCount: number;
-  readonly width: number;
-  readonly height: number;
-  readonly depth: number;
-
-  /** @internal */
-  constructor(
-    texture: GraphTextureHandle<Format>,
-    props: Required<GraphTextureViewProps> & {width: number; height: number; depth: number}
-  ) {
-    this.texture = texture;
-    this.format = texture.format;
-    this.dimension = props.dimension;
-    this.aspect = props.aspect;
-    this.baseMipLevel = props.baseMipLevel;
-    this.mipLevelCount = props.mipLevelCount;
-    this.baseArrayLayer = props.baseArrayLayer;
-    this.arrayLayerCount = props.arrayLayerCount;
-    this.width = props.width;
-    this.height = props.height;
-    this.depth = props.depth;
-  }
-}
-
-/** One buffer use declared by a graph node. */
-export type GraphBufferUse = {
-  buffer: GraphBufferHandle | GraphDataView;
-  usage: GraphBufferUsage;
-};
-
-/** One texture or texture-view use declared by a graph node. */
-export type GraphTextureUse = {
-  texture: GraphTextureHandle | GraphTextureView;
-  usage: GraphTextureUsage;
-};
-
-/** One resource use declared by a graph node. */
-export type GraphResourceUse = GraphBufferUse | GraphTextureUse;
-
-/** Graph-owned texture attachments resolved into a framebuffer for a render node. */
-export type GraphRenderPassAttachments = {
-  colorAttachments: GraphTextureView[];
-  depthStencilAttachment?: GraphTextureView;
-};
-
-/** Context available while compiling one graph node. */
-export type GPUCommandGraphCompileContext = {
-  device: Device;
-};
-
-/** Context shared by every executable graph node. */
-export type GPUCommandGraphEncodeContext<Parameters> = {
-  commandEncoder: CommandEncoder;
-  parameters: Parameters;
-  getBuffer: (buffer: GraphBufferHandle | GraphDataView) => Buffer;
-  getTexture: (texture: GraphTextureHandle | GraphTextureView) => Texture;
-  getTextureView: (texture: GraphTextureHandle | GraphTextureView) => TextureView;
-};
-
-/** Compiled compute-pass callback. */
-export type GPUCommandGraphComputeExecutable<Parameters> = {
-  encode: (context: GPUCommandGraphEncodeContext<Parameters> & {computePass: ComputePass}) => void;
-  destroy?: () => void;
-};
-
-/** Compiled render-pass callback. */
-export type GPUCommandGraphRenderExecutable<Parameters> = {
-  getRenderPassProps?: (context: GPUCommandGraphEncodeContext<Parameters>) => RenderPassProps;
-  encode: (context: GPUCommandGraphEncodeContext<Parameters> & {renderPass: RenderPass}) => void;
-  destroy?: () => void;
-};
-
-/** Compiled command-encoder callback used for copies and other pass-independent commands. */
-export type GPUCommandGraphCopyExecutable<Parameters> = {
-  encode: (context: GPUCommandGraphEncodeContext<Parameters>) => void;
-  destroy?: () => void;
-};
-
-type GPUCommandGraphNodeBase = {
-  id: string;
-  resources?: GraphResourceUse[];
-  dependsOn?: string[];
-};
-
-export type GPUCommandGraphComputeNode<Parameters> = GPUCommandGraphNodeBase & {
-  type: 'compute';
-  compile: (context: GPUCommandGraphCompileContext) => GPUCommandGraphComputeExecutable<Parameters>;
-};
-
-export type GPUCommandGraphRenderNode<Parameters> = GPUCommandGraphNodeBase & {
-  type: 'render';
-  attachments?: GraphRenderPassAttachments;
-  compile: (context: GPUCommandGraphCompileContext) => GPUCommandGraphRenderExecutable<Parameters>;
-};
-
-export type GPUCommandGraphCopyNode<Parameters> = GPUCommandGraphNodeBase & {
-  type: 'copy';
-  compile: (context: GPUCommandGraphCompileContext) => GPUCommandGraphCopyExecutable<Parameters>;
-};
-
-export type GPUCommandGraphNode<Parameters> =
-  | GPUCommandGraphComputeNode<Parameters>
-  | GPUCommandGraphRenderNode<Parameters>
-  | GPUCommandGraphCopyNode<Parameters>;
-
-/** Resource-allocation and scheduling statistics for one compiled graph. */
-export type GPUCommandGraphStats = {
-  nodeOrder: string[];
-  logicalTransientBufferCount: number;
-  physicalTransientBufferCount: number;
-  logicalTransientBytes: number;
-  physicalTransientBytes: number;
-  reusedTransientBytes: number;
-  reusePercentage: number;
-  logicalTransientTextureCount: number;
-  physicalTransientTextureCount: number;
-  logicalTransientTextureBytes: number;
-  physicalTransientTextureBytes: number;
-  reusedTransientTextureBytes: number;
-  textureReusePercentage: number;
-};
-
-/** Options supplied while encoding one compiled graph. */
-export type GPUCommandGraphEncodeOptions<Parameters> = {
-  parameters: Parameters;
-  buffers?: Record<string, GraphImportedBuffer>;
-  textures?: Record<string, GraphImportedTexture>;
-};
-
-type CompiledNode<Parameters> = {
-  node: GPUCommandGraphNode<Parameters>;
-  executable:
-    | GPUCommandGraphComputeExecutable<Parameters>
-    | GPUCommandGraphRenderExecutable<Parameters>
-    | GPUCommandGraphCopyExecutable<Parameters>;
-};
-
-type BufferTransientAllocation = {
-  byteLength: number;
-  usage: number;
-  lastUse: number;
-  handles: GraphBufferHandle[];
-  buffer?: Buffer;
-};
-
-type TextureTransientAllocation = {
-  descriptor: NormalizedGraphTextureDescriptor;
-  byteLength: number;
-  lastUse: number;
-  handles: GraphTextureHandle[];
-  texture?: Texture;
-};
+export {
+  GraphBufferHandle,
+  GraphDataView,
+  GraphTextureHandle,
+  GraphTextureView,
+  GraphVectorView
+} from './gpu-command-graph-types';
+export type {
+  GPUCommandGraphCompileContext,
+  GPUCommandGraphComputeExecutable,
+  GPUCommandGraphComputeNode,
+  GPUCommandGraphCopyExecutable,
+  GPUCommandGraphCopyNode,
+  GPUCommandGraphEncodeContext,
+  GPUCommandGraphEncodeOptions,
+  GPUCommandGraphNode,
+  GPUCommandGraphRenderExecutable,
+  GPUCommandGraphRenderNode,
+  GPUCommandGraphStats,
+  GraphBufferDescriptor,
+  GraphBufferUsage,
+  GraphBufferUse,
+  GraphImportedBuffer,
+  GraphImportedTexture,
+  GraphRenderPassAttachments,
+  GraphResourceUse,
+  GraphTextureAspect,
+  GraphTextureDescriptor,
+  GraphTextureDimension,
+  GraphTextureUsage,
+  GraphTextureUse,
+  GraphTextureViewProps
+} from './gpu-command-graph-types';
 
 type CachedTextureView = {
   logicalView: GraphTextureView;
@@ -408,7 +107,9 @@ type CachedFramebuffer = {
  * but encoding and submission remain controlled by the application.
  */
 export class GPUCommandGraph<Parameters = void> {
+  /** WebGPU device that owns compilation and transient resources. */
   readonly device: Device;
+  /** Identifier used as a prefix for graph-owned GPU resources. */
   readonly id: string;
 
   private readonly buffers = new Map<string, GraphBufferHandle>();
@@ -418,6 +119,13 @@ export class GPUCommandGraph<Parameters = void> {
   private readonly nodeIds = new Set<string>();
   private compiled = false;
 
+  /**
+   * Creates a mutable graph definition.
+   *
+   * @param device WebGPU device used to compile and execute the graph.
+   * @param props Optional graph identity.
+   * @throws If `device` is not a WebGPU device.
+   */
   constructor(device: Device, props: {id?: string} = {}) {
     if (device.type !== 'webgpu') {
       throw new Error('GPUCommandGraph requires a WebGPU device');
@@ -426,7 +134,13 @@ export class GPUCommandGraph<Parameters = void> {
     this.id = props.id ?? 'gpu-command-graph';
   }
 
-  /** Declares a caller-owned buffer that can be supplied now or for each encoding. */
+  /**
+   * Declares a caller-owned buffer that can be supplied now or for each encoding.
+   *
+   * @param descriptor Required capacity and usage.
+   * @param defaultBuffer Optional default binding used when an encoding supplies no override.
+   * @returns An opaque logical handle used by graph nodes and data views.
+   */
   importBuffer(
     descriptor: GraphBufferDescriptor,
     defaultBuffer?: GraphImportedBuffer
@@ -439,14 +153,22 @@ export class GPUCommandGraph<Parameters = void> {
     return this.addBuffer(new GraphBufferHandle(this, descriptor, false, defaultBuffer));
   }
 
-  /** Declares one graph-owned scratch buffer. */
+  /**
+   * Declares one graph-owned scratch buffer.
+   *
+   * Compatible transient buffers with disjoint compiled lifetimes may share a physical allocation.
+   */
   createTransientBuffer(descriptor: GraphBufferDescriptor): GraphBufferHandle {
     this.assertMutable();
     validateGraphBufferDescriptor(descriptor);
     return this.addBuffer(new GraphBufferHandle(this, descriptor, true));
   }
 
-  /** Creates one typed range over a graph buffer. */
+  /**
+   * Creates one typed range over a graph buffer.
+   *
+   * The view is non-owning. Its layout is validated against the logical buffer capacity.
+   */
   createDataView<T extends GPUVectorFormat>(
     buffer: GraphBufferHandle,
     props: {
@@ -477,12 +199,21 @@ export class GPUCommandGraph<Parameters = void> {
     });
   }
 
-  /** Imports one borrowed GPUData range and returns its typed graph view. */
+  /**
+   * Imports one borrowed `GPUData` chunk and returns a typed view preserving its layout.
+   *
+   * The graph never destroys the imported buffer.
+   */
   importGPUData<T extends GPUVectorFormat>(id: string, data: GPUData<T>): GraphDataView<T> {
     return this.importGPUDataView(id, data);
   }
 
-  /** Imports all chunks of one fixed-width GPUVector without packing them. */
+  /**
+   * Imports all chunks of one fixed-width `GPUVector` without packing them.
+   *
+   * Shared physical buffers map to one graph handle while each chunk retains its own offset and
+   * layout. Interleaved and variable-length vectors are rejected.
+   */
   importGPUVector<T extends GPUVectorFormat>(id: string, vector: GPUVector<T>): GraphVectorView<T> {
     if (vector.bufferLayout) {
       throw new Error(`GPUCommandGraph import "${id}" does not accept interleaved GPUVector data`);
@@ -514,7 +245,11 @@ export class GPUCommandGraph<Parameters = void> {
     });
   }
 
-  /** Declares a caller-owned fixed-size texture that can be supplied now or while encoding. */
+  /**
+   * Declares a caller-owned fixed-size texture supplied now or while encoding.
+   *
+   * Replacements must exactly match format, dimension, extent, mip count, and sample count.
+   */
   importTexture<Format extends TextureFormat>(
     descriptor: GraphTextureDescriptor<Format>,
     defaultTexture?: GraphImportedTexture
@@ -529,7 +264,11 @@ export class GPUCommandGraph<Parameters = void> {
     );
   }
 
-  /** Declares one graph-owned fixed-size transient texture. */
+  /**
+   * Declares one graph-owned fixed-size transient texture.
+   *
+   * Descriptor-compatible textures with disjoint compiled lifetimes may share an allocation.
+   */
   createTransientTexture<Format extends TextureFormat>(
     descriptor: GraphTextureDescriptor<Format>
   ): GraphTextureHandle<Format> {
@@ -538,7 +277,11 @@ export class GPUCommandGraph<Parameters = void> {
     return this.addTexture(new GraphTextureHandle(this, normalizedDescriptor, true));
   }
 
-  /** Creates one logical mip, layer, and aspect range over a graph texture. */
+  /**
+   * Creates one logical mip, layer, and aspect range over a graph texture.
+   *
+   * The normalized range is used for texture hazard inference and concrete view creation.
+   */
   createTextureView<Format extends TextureFormat>(
     texture: GraphTextureHandle<Format>,
     props: GraphTextureViewProps = {}
@@ -548,10 +291,22 @@ export class GPUCommandGraph<Parameters = void> {
     return new GraphTextureView(texture, normalizedProps);
   }
 
+  /**
+   * Adds a compute node.
+   *
+   * The graph opens and closes the compute pass; the compiled executable only records commands.
+   * Declared resource uses participate in automatic dependency inference.
+   */
   addComputePass(node: Omit<GPUCommandGraphComputeNode<Parameters>, 'type'>): void {
     this.addNode({...node, type: 'compute'});
   }
 
+  /**
+   * Adds a render node.
+   *
+   * Graph attachments are validated, added to the node's resource uses, and resolved to a cached
+   * framebuffer at encode time. The graph opens and closes the render pass.
+   */
   addRenderPass(node: Omit<GPUCommandGraphRenderNode<Parameters>, 'type'>): void {
     if (node.attachments) {
       this.validateRenderAttachments(node.id, node.attachments);
@@ -579,113 +334,34 @@ export class GPUCommandGraph<Parameters = void> {
     });
   }
 
+  /**
+   * Adds a copy or pass-independent node.
+   *
+   * Its executable records directly into the caller-owned command encoder.
+   */
   addCopyPass(node: Omit<GPUCommandGraphCopyNode<Parameters>, 'type'>): void {
     this.addNode({...node, type: 'copy'});
   }
 
-  /** Compiles scheduling, transient allocations, and executable node resources. */
+  /**
+   * Compiles scheduling, transient allocations, and executable node resources.
+   *
+   * Compilation freezes this graph. A graph can be compiled only once.
+   *
+   * @returns An executable graph that owns compiled node state and transient allocations.
+   */
   compile(): CompiledGPUCommandGraph<Parameters> {
     this.assertMutable();
     this.compiled = true;
-    const nodeOrder = getNodeOrder(this.nodes);
-    const bufferPlan = getBufferTransientAllocationPlan(nodeOrder, this.buffers.values());
-    const texturePlan = getTextureTransientAllocationPlan(nodeOrder, this.textures.values());
-    const transientBuffers = new Map<GraphBufferHandle, Buffer>();
-    const transientTextures = new Map<GraphTextureHandle, Texture>();
-
-    for (const allocation of bufferPlan) {
-      allocation.buffer = this.device.createBuffer({
-        id: `${this.id}-transient-buffer-${bufferPlan.indexOf(allocation)}`,
-        byteLength: allocation.byteLength,
-        usage: allocation.usage
-      });
-      for (const handle of allocation.handles) {
-        transientBuffers.set(handle, allocation.buffer);
-      }
-    }
-    for (const allocation of texturePlan) {
-      allocation.texture = this.device.createTexture({
-        ...allocation.descriptor,
-        id: `${this.id}-transient-texture-${texturePlan.indexOf(allocation)}`
-      });
-      for (const handle of allocation.handles) {
-        transientTextures.set(handle, allocation.texture);
-      }
-    }
-
-    const compiledNodes: CompiledNode<Parameters>[] = [];
-    try {
-      for (const node of nodeOrder) {
-        compiledNodes.push({node, executable: node.compile({device: this.device})});
-      }
-    } catch (error) {
-      for (const compiledNode of compiledNodes) {
-        compiledNode.executable.destroy?.();
-      }
-      for (const allocation of bufferPlan) {
-        allocation.buffer?.destroy();
-      }
-      for (const allocation of texturePlan) {
-        allocation.texture?.destroy();
-      }
-      throw error;
-    }
-
-    const logicalTransientBytes = Array.from(this.buffers.values())
-      .filter(buffer => buffer.transient)
-      .reduce((sum, buffer) => sum + buffer.byteLength, 0);
-    const physicalTransientBytes = bufferPlan.reduce(
-      (sum, allocation) => sum + allocation.byteLength,
-      0
+    return new CompiledGPUCommandGraph(
+      compileGPUCommandGraph({
+        device: this.device,
+        id: this.id,
+        buffers: this.buffers,
+        textures: this.textures,
+        nodes: this.nodes
+      })
     );
-    const reusedTransientBytes = Math.max(0, logicalTransientBytes - physicalTransientBytes);
-    const logicalTransientTextureBytes = Array.from(this.textures.values())
-      .filter(texture => texture.transient)
-      .reduce((sum, texture) => sum + getTextureByteLength(texture), 0);
-    const physicalTransientTextureBytes = texturePlan.reduce(
-      (sum, allocation) => sum + allocation.byteLength,
-      0
-    );
-    const reusedTransientTextureBytes = Math.max(
-      0,
-      logicalTransientTextureBytes - physicalTransientTextureBytes
-    );
-    const stats: GPUCommandGraphStats = {
-      nodeOrder: nodeOrder.map(node => node.id),
-      logicalTransientBufferCount: Array.from(this.buffers.values()).filter(
-        buffer => buffer.transient
-      ).length,
-      physicalTransientBufferCount: bufferPlan.length,
-      logicalTransientBytes,
-      physicalTransientBytes,
-      reusedTransientBytes,
-      reusePercentage:
-        logicalTransientBytes > 0 ? (reusedTransientBytes / logicalTransientBytes) * 100 : 0,
-      logicalTransientTextureCount: Array.from(this.textures.values()).filter(
-        texture => texture.transient
-      ).length,
-      physicalTransientTextureCount: texturePlan.length,
-      logicalTransientTextureBytes,
-      physicalTransientTextureBytes,
-      reusedTransientTextureBytes,
-      textureReusePercentage:
-        logicalTransientTextureBytes > 0
-          ? (reusedTransientTextureBytes / logicalTransientTextureBytes) * 100
-          : 0
-    };
-
-    return new CompiledGPUCommandGraph({
-      device: this.device,
-      id: this.id,
-      buffers: new Map(this.buffers),
-      textures: new Map(this.textures),
-      compiledNodes,
-      transientBuffers,
-      transientTextures,
-      bufferTransientAllocations: bufferPlan,
-      textureTransientAllocations: texturePlan,
-      stats
-    });
   }
 
   private addNode(node: GPUCommandGraphNode<Parameters>): void {
@@ -808,10 +484,18 @@ export class GPUCommandGraph<Parameters = void> {
   }
 }
 
-/** Executable, fixed-capacity command graph. */
+/**
+ * Executable, fixed-capacity command graph.
+ *
+ * The compiled graph owns transient allocations, compiled node state, and cached views and
+ * framebuffers. Imported buffers and textures remain caller-owned.
+ */
 export class CompiledGPUCommandGraph<Parameters = void> {
+  /** WebGPU device that owns the compiled resources. */
   readonly device: Device;
+  /** Identifier inherited from the graph definition. */
   readonly id: string;
+  /** Scheduling and transient-allocation statistics. */
   readonly stats: GPUCommandGraphStats;
 
   private readonly buffers: Map<string, GraphBufferHandle>;
@@ -826,18 +510,7 @@ export class CompiledGPUCommandGraph<Parameters = void> {
   private destroyed = false;
 
   /** @internal */
-  constructor(props: {
-    device: Device;
-    id: string;
-    buffers: Map<string, GraphBufferHandle>;
-    textures: Map<string, GraphTextureHandle>;
-    compiledNodes: CompiledNode<Parameters>[];
-    transientBuffers: Map<GraphBufferHandle, Buffer>;
-    transientTextures: Map<GraphTextureHandle, Texture>;
-    bufferTransientAllocations: BufferTransientAllocation[];
-    textureTransientAllocations: TextureTransientAllocation[];
-    stats: GPUCommandGraphStats;
-  }) {
+  constructor(props: GPUCommandGraphCompilation<Parameters>) {
     this.device = props.device;
     this.id = props.id;
     this.buffers = props.buffers;
@@ -850,7 +523,15 @@ export class CompiledGPUCommandGraph<Parameters = void> {
     this.stats = props.stats;
   }
 
-  /** Records every graph node into a caller-owned command encoder. */
+  /**
+   * Records every graph node into a caller-owned command encoder.
+   *
+   * Imported resources are resolved from per-encoding overrides first, then from defaults supplied
+   * at graph construction. This method records only; it does not finish or submit the encoder.
+   *
+   * @param commandEncoder Encoder that receives all graph commands.
+   * @param options Per-encoding parameters and optional imported-resource replacements.
+   */
   encode(commandEncoder: CommandEncoder, options: GPUCommandGraphEncodeOptions<Parameters>): void {
     if (this.destroyed) {
       throw new Error(`CompiledGPUCommandGraph "${this.id}" has been destroyed`);
@@ -962,7 +643,11 @@ export class CompiledGPUCommandGraph<Parameters = void> {
     }
   }
 
-  /** Releases compiled node resources and graph-owned transient resources. */
+  /**
+   * Releases compiled node state, cached views and framebuffers, and graph-owned transients.
+   *
+   * Imported resources are borrowed and are never destroyed. Repeated calls are safe.
+   */
   destroy(): void {
     if (this.destroyed) {
       return;
@@ -1071,18 +756,12 @@ export class CompiledGPUCommandGraph<Parameters = void> {
   }
 }
 
-function getBufferHandle(buffer: GraphBufferHandle | GraphDataView): GraphBufferHandle {
-  return buffer instanceof GraphDataView ? buffer.buffer : buffer;
-}
-
-function getTextureHandle(texture: GraphTextureHandle | GraphTextureView): GraphTextureHandle {
-  return texture instanceof GraphTextureView ? texture.texture : texture;
-}
-
+/** Unwraps a dynamic import to the concrete buffer used for validation and encoding. */
 function getCoreBuffer(buffer: GraphImportedBuffer): Buffer {
   return buffer instanceof DynamicBuffer ? buffer.buffer : buffer;
 }
 
+/** Unwraps a ready dynamic import to the concrete texture used for validation and encoding. */
 function getCoreTexture(texture: GraphImportedTexture): Texture {
   if (texture instanceof DynamicTexture) {
     if (!texture.isReady) {
@@ -1093,10 +772,7 @@ function getCoreTexture(texture: GraphImportedTexture): Texture {
   return texture;
 }
 
-function isGraphBufferUse(resource: GraphResourceUse): resource is GraphBufferUse {
-  return 'buffer' in resource;
-}
-
+/** Validates graph identity, capacity, and usage fields for a logical buffer. */
 function validateGraphBufferDescriptor(descriptor: GraphBufferDescriptor): void {
   if (!descriptor.id) {
     throw new Error('GPUCommandGraph buffer id is required');
@@ -1109,6 +785,7 @@ function validateGraphBufferDescriptor(descriptor: GraphBufferDescriptor): void 
   }
 }
 
+/** Applies texture defaults and validates limits and dimension-specific invariants. */
 function normalizeGraphTextureDescriptor<Format extends TextureFormat>(
   descriptor: GraphTextureDescriptor<Format>,
   device: Device
@@ -1168,6 +845,7 @@ function normalizeGraphTextureDescriptor<Format extends TextureFormat>(
   };
 }
 
+/** Applies view defaults, validates subresource bounds, and computes the selected extent. */
 function normalizeGraphTextureView<Format extends TextureFormat>(
   texture: GraphTextureHandle<Format>,
   props: GraphTextureViewProps
@@ -1216,6 +894,7 @@ function normalizeGraphTextureView<Format extends TextureFormat>(
   };
 }
 
+/** Validates a strided logical range against its buffer capacity. */
 function validateGraphDataView(
   buffer: GraphBufferHandle,
   props: {length: number; byteOffset: number; byteStride: number; rowByteLength: number}
@@ -1238,6 +917,7 @@ function validateGraphDataView(
   }
 }
 
+/** Validates an imported buffer's device, capacity, and usage against its logical descriptor. */
 function validateImportedBuffer(
   importedBuffer: GraphImportedBuffer,
   descriptor: Pick<GraphBufferDescriptor, 'id' | 'byteLength' | 'usage'>,
@@ -1255,6 +935,7 @@ function validateImportedBuffer(
   }
 }
 
+/** Validates an imported texture's exact shape and format plus required usage flags. */
 function validateImportedTexture(
   importedTexture: GraphImportedTexture,
   descriptor: NormalizedGraphTextureDescriptor,
@@ -1284,6 +965,7 @@ function validateImportedTexture(
   }
 }
 
+/** Checks that a logical buffer descriptor permits a node's declared access mode. */
 function validateBufferUseAgainstDescriptor(
   buffer: GraphBufferHandle,
   usage: GraphBufferUsage
@@ -1296,6 +978,7 @@ function validateBufferUseAgainstDescriptor(
   }
 }
 
+/** Checks that a logical texture descriptor permits a node's declared access mode. */
 function validateTextureUseAgainstDescriptor(
   texture: GraphTextureHandle,
   usage: GraphTextureUsage
@@ -1308,6 +991,7 @@ function validateTextureUseAgainstDescriptor(
   }
 }
 
+/** Validates view restrictions imposed by the declared texture access mode. */
 function validateTextureViewForUsage(
   textureOrView: GraphTextureHandle | GraphTextureView,
   usage: GraphTextureUsage
@@ -1321,6 +1005,7 @@ function validateTextureViewForUsage(
   }
 }
 
+/** Maps a graph access mode to its required luma.gl buffer usage flag. */
 function getRequiredBufferUsage(usage: GraphBufferUsage): number {
   switch (usage) {
     case 'storage-read':
@@ -1342,6 +1027,7 @@ function getRequiredBufferUsage(usage: GraphBufferUsage): number {
   }
 }
 
+/** Maps a graph access mode to its required luma.gl texture usage flag. */
 function getRequiredTextureUsage(usage: GraphTextureUsage): number {
   switch (usage) {
     case 'sampled':
@@ -1359,339 +1045,7 @@ function getRequiredTextureUsage(usage: GraphTextureUsage): number {
   }
 }
 
-function isBufferReadUsage(usage: GraphBufferUsage): boolean {
-  return (
-    usage === 'storage-read' ||
-    usage === 'storage-read-write' ||
-    usage === 'uniform' ||
-    usage === 'copy-source' ||
-    usage === 'indirect' ||
-    usage === 'vertex' ||
-    usage === 'index'
-  );
-}
-
-function isBufferWriteUsage(usage: GraphBufferUsage): boolean {
-  return (
-    usage === 'storage-write' || usage === 'storage-read-write' || usage === 'copy-destination'
-  );
-}
-
-function isTextureReadUsage(usage: GraphTextureUsage): boolean {
-  return (
-    usage === 'sampled' ||
-    usage === 'storage-read' ||
-    usage === 'storage-read-write' ||
-    usage === 'render-attachment' ||
-    usage === 'copy-source'
-  );
-}
-
-function isTextureWriteUsage(usage: GraphTextureUsage): boolean {
-  return (
-    usage === 'storage-write' ||
-    usage === 'storage-read-write' ||
-    usage === 'render-attachment' ||
-    usage === 'copy-destination'
-  );
-}
-
-function getNodeOrder<Parameters>(
-  nodes: GPUCommandGraphNode<Parameters>[]
-): GPUCommandGraphNode<Parameters>[] {
-  const nodeById = new Map(nodes.map(node => [node.id, node]));
-  const dependencies = new Map<string, Set<string>>();
-  const lastBufferWriter = new Map<GraphBufferHandle, string>();
-  const activeBufferReaders = new Map<GraphBufferHandle, Set<string>>();
-  const textureHistory = new Map<
-    GraphTextureHandle,
-    {nodeId: string; resource: GraphTextureUse}[]
-  >();
-
-  for (const node of nodes) {
-    const nodeDependencies = new Set(node.dependsOn ?? []);
-    for (const dependency of nodeDependencies) {
-      if (!nodeById.has(dependency)) {
-        throw new Error(
-          `GPUCommandGraph node "${node.id}" depends on missing node "${dependency}"`
-        );
-      }
-    }
-    for (const resource of node.resources ?? []) {
-      if (isGraphBufferUse(resource)) {
-        const handle = getBufferHandle(resource.buffer);
-        if (isBufferReadUsage(resource.usage)) {
-          const writer = lastBufferWriter.get(handle);
-          if (writer) {
-            nodeDependencies.add(writer);
-          }
-          const readers = activeBufferReaders.get(handle) ?? new Set<string>();
-          readers.add(node.id);
-          activeBufferReaders.set(handle, readers);
-        }
-        if (isBufferWriteUsage(resource.usage)) {
-          const writer = lastBufferWriter.get(handle);
-          if (writer) {
-            nodeDependencies.add(writer);
-          }
-          for (const reader of activeBufferReaders.get(handle) ?? []) {
-            if (reader !== node.id) {
-              nodeDependencies.add(reader);
-            }
-          }
-          activeBufferReaders.set(handle, new Set());
-          lastBufferWriter.set(handle, node.id);
-        }
-      } else {
-        const handle = getTextureHandle(resource.texture);
-        const history = textureHistory.get(handle) ?? [];
-        for (const previous of history) {
-          if (
-            previous.nodeId !== node.id &&
-            textureUsesOverlap(previous.resource, resource) &&
-            ((isTextureReadUsage(resource.usage) && isTextureWriteUsage(previous.resource.usage)) ||
-              (isTextureWriteUsage(resource.usage) &&
-                (isTextureReadUsage(previous.resource.usage) ||
-                  isTextureWriteUsage(previous.resource.usage))))
-          ) {
-            nodeDependencies.add(previous.nodeId);
-          }
-        }
-        history.push({nodeId: node.id, resource});
-        textureHistory.set(handle, history);
-      }
-    }
-    nodeDependencies.delete(node.id);
-    dependencies.set(node.id, nodeDependencies);
-  }
-
-  const insertionIndex = new Map(nodes.map((node, index) => [node.id, index]));
-  const remaining = new Map(
-    Array.from(dependencies, ([id, values]) => [id, new Set(values)] as const)
-  );
-  const ordered: GPUCommandGraphNode<Parameters>[] = [];
-  while (remaining.size > 0) {
-    const ready = Array.from(remaining)
-      .filter(([, values]) => values.size === 0)
-      .map(([id]) => id)
-      .sort((left, right) => insertionIndex.get(left)! - insertionIndex.get(right)!);
-    if (ready.length === 0) {
-      throw new Error('GPUCommandGraph contains a dependency cycle');
-    }
-    for (const id of ready) {
-      ordered.push(nodeById.get(id)!);
-      remaining.delete(id);
-      for (const values of remaining.values()) {
-        values.delete(id);
-      }
-    }
-  }
-  return ordered;
-}
-
-function textureUsesOverlap(left: GraphTextureUse, right: GraphTextureUse): boolean {
-  const leftHandle = getTextureHandle(left.texture);
-  const rightHandle = getTextureHandle(right.texture);
-  if (leftHandle !== rightHandle) {
-    return false;
-  }
-  const leftRange = getTextureSubresourceRange(left.texture);
-  const rightRange = getTextureSubresourceRange(right.texture);
-  return (
-    aspectsOverlap(leftRange.aspect, rightRange.aspect) &&
-    intervalsOverlap(
-      leftRange.baseMipLevel,
-      leftRange.mipLevelCount,
-      rightRange.baseMipLevel,
-      rightRange.mipLevelCount
-    ) &&
-    intervalsOverlap(
-      leftRange.baseArrayLayer,
-      leftRange.arrayLayerCount,
-      rightRange.baseArrayLayer,
-      rightRange.arrayLayerCount
-    )
-  );
-}
-
-function getTextureSubresourceRange(texture: GraphTextureHandle | GraphTextureView): {
-  aspect: GraphTextureAspect;
-  baseMipLevel: number;
-  mipLevelCount: number;
-  baseArrayLayer: number;
-  arrayLayerCount: number;
-} {
-  if (texture instanceof GraphTextureView) {
-    return texture;
-  }
-  return {
-    aspect: 'all',
-    baseMipLevel: 0,
-    mipLevelCount: texture.mipLevels,
-    baseArrayLayer: 0,
-    arrayLayerCount: texture.dimension === '3d' ? 1 : texture.depth
-  };
-}
-
-function aspectsOverlap(left: GraphTextureAspect, right: GraphTextureAspect): boolean {
-  return left === 'all' || right === 'all' || left === right;
-}
-
-function intervalsOverlap(
-  leftStart: number,
-  leftCount: number,
-  rightStart: number,
-  rightCount: number
-): boolean {
-  return leftStart < rightStart + rightCount && rightStart < leftStart + leftCount;
-}
-
-function getBufferTransientAllocationPlan<Parameters>(
-  nodes: GPUCommandGraphNode<Parameters>[],
-  buffers: Iterable<GraphBufferHandle>
-): BufferTransientAllocation[] {
-  const lifetimes = getResourceLifetimes(nodes, resource =>
-    isGraphBufferUse(resource) ? getBufferHandle(resource.buffer) : null
-  );
-  const allocations: BufferTransientAllocation[] = [];
-  const transientBuffers = Array.from(buffers)
-    .filter(buffer => buffer.transient)
-    .map(buffer => ({buffer, lifetime: lifetimes.get(buffer)}))
-    .sort(
-      (left, right) =>
-        (left.lifetime?.firstUse ?? Number.MAX_SAFE_INTEGER) -
-        (right.lifetime?.firstUse ?? Number.MAX_SAFE_INTEGER)
-    );
-
-  for (const {buffer, lifetime} of transientBuffers) {
-    if (!lifetime) {
-      continue;
-    }
-    let allocation = allocations
-      .filter(candidate => candidate.lastUse < lifetime.firstUse)
-      .sort((left, right) => left.byteLength - right.byteLength)[0];
-    if (!allocation) {
-      allocation = {byteLength: 0, usage: 0, lastUse: -1, handles: []};
-      allocations.push(allocation);
-    }
-    allocation.byteLength = Math.max(allocation.byteLength, buffer.byteLength);
-    allocation.usage |= buffer.usage;
-    allocation.lastUse = lifetime.lastUse;
-    allocation.handles.push(buffer);
-  }
-  return allocations;
-}
-
-function getTextureTransientAllocationPlan<Parameters>(
-  nodes: GPUCommandGraphNode<Parameters>[],
-  textures: Iterable<GraphTextureHandle>
-): TextureTransientAllocation[] {
-  const lifetimes = getResourceLifetimes(nodes, resource =>
-    isGraphBufferUse(resource) ? null : getTextureHandle(resource.texture)
-  );
-  const allocations: TextureTransientAllocation[] = [];
-  const transientTextures = Array.from(textures)
-    .filter(texture => texture.transient)
-    .map(texture => ({texture, lifetime: lifetimes.get(texture)}))
-    .sort(
-      (left, right) =>
-        (left.lifetime?.firstUse ?? Number.MAX_SAFE_INTEGER) -
-        (right.lifetime?.firstUse ?? Number.MAX_SAFE_INTEGER)
-    );
-
-  for (const {texture, lifetime} of transientTextures) {
-    if (!lifetime) {
-      continue;
-    }
-    let allocation = allocations.find(
-      candidate =>
-        candidate.lastUse < lifetime.firstUse &&
-        areTextureDescriptorsCompatible(candidate.descriptor, texture)
-    );
-    if (!allocation) {
-      const descriptor = getNormalizedTextureDescriptor(texture);
-      allocation = {
-        descriptor,
-        byteLength: getTextureByteLength(texture),
-        lastUse: -1,
-        handles: []
-      };
-      allocations.push(allocation);
-    }
-    allocation.descriptor.usage |= texture.usage;
-    allocation.lastUse = lifetime.lastUse;
-    allocation.handles.push(texture);
-  }
-  return allocations;
-}
-
-function getResourceLifetimes<Parameters, Resource extends object>(
-  nodes: GPUCommandGraphNode<Parameters>[],
-  getResource: (resource: GraphResourceUse) => Resource | null
-): Map<Resource, {firstUse: number; lastUse: number}> {
-  const lifetimes = new Map<Resource, {firstUse: number; lastUse: number}>();
-  nodes.forEach((node, nodeIndex) => {
-    for (const resourceUse of node.resources ?? []) {
-      const resource = getResource(resourceUse);
-      if (!resource || !('transient' in resource) || !resource.transient) {
-        continue;
-      }
-      const lifetime = lifetimes.get(resource);
-      if (lifetime) {
-        lifetime.lastUse = nodeIndex;
-      } else {
-        lifetimes.set(resource, {firstUse: nodeIndex, lastUse: nodeIndex});
-      }
-    }
-  });
-  return lifetimes;
-}
-
-function getNormalizedTextureDescriptor(
-  texture: GraphTextureHandle
-): NormalizedGraphTextureDescriptor {
-  return {
-    id: texture.id,
-    format: texture.format,
-    width: texture.width,
-    height: texture.height,
-    usage: texture.usage,
-    dimension: texture.dimension,
-    depth: texture.depth,
-    mipLevels: texture.mipLevels,
-    samples: texture.samples
-  };
-}
-
-function areTextureDescriptorsCompatible(
-  descriptor: NormalizedGraphTextureDescriptor,
-  texture: GraphTextureHandle
-): boolean {
-  return (
-    descriptor.format === texture.format &&
-    descriptor.width === texture.width &&
-    descriptor.height === texture.height &&
-    descriptor.dimension === texture.dimension &&
-    descriptor.depth === texture.depth &&
-    descriptor.mipLevels === texture.mipLevels &&
-    descriptor.samples === texture.samples
-  );
-}
-
-function getTextureByteLength(texture: GraphTextureHandle): number {
-  let byteLength = 0;
-  for (let mipLevel = 0; mipLevel < texture.mipLevels; mipLevel++) {
-    byteLength += textureFormatDecoder.computeMemoryLayout({
-      format: texture.format,
-      width: Math.max(1, texture.width >> mipLevel),
-      height: texture.dimension === '1d' ? 1 : Math.max(1, texture.height >> mipLevel),
-      depth: texture.dimension === '3d' ? Math.max(1, texture.depth >> mipLevel) : texture.depth,
-      byteAlignment: 1
-    }).byteLength;
-  }
-  return byteLength * texture.samples;
-}
-
+/** Returns whether a logical view is exactly the texture's default full-resource view. */
 function isDefaultGraphTextureView(view: GraphTextureView): boolean {
   const texture = view.texture;
   return (

--- a/modules/experimental/src/gpu-primitives/gpu-compaction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-compaction.ts
@@ -19,23 +19,45 @@ const COMPACTION_WORKGROUP_SIZE = 256;
 /** Packed uint32 graph data accepted by {@link GPUCompaction}. */
 export type GPUCompactionInput = GraphDataView<'uint32'> | GraphVectorView<'uint32'>;
 
-/** Properties for stable graph-native selection by uint32 flags. */
+/** Properties for one graph-native stable compaction. */
 export type GPUCompactionProps = {
+  /** Prefix for generated graph node and transient resource IDs. */
   id?: string;
+  /** Packed source values as one data view or an ordered vector. */
   input: GPUCompactionInput;
+  /** Matching packed selection flags; zero rejects and any non-zero value accepts. */
   flags: GPUCompactionInput;
+  /** Caller-owned destination with matching view kind and sufficient capacity or topology. */
   output: GPUCompactionInput;
+  /** Caller-owned view whose first row receives the accepted value count. */
   count: GraphDataView<'uint32'>;
 };
 
-/** Stable graph-composed compaction of uint32 values selected by 0/1 flags. */
+/**
+ * Stable graph-composed compaction of `uint32` values selected by flags.
+ *
+ * An exclusive {@link GPUScan} converts flags to output offsets. A scatter pass then preserves
+ * source order while writing accepted values and the final accepted count. Vector inputs are one
+ * logical sequence whose selected values fill the existing output topology.
+ */
 export class GPUCompaction {
+  /** Prefix for generated graph node and transient resource IDs. */
   readonly id: string;
+  /** Packed source values or ordered source vector. */
   readonly input: GPUCompactionInput;
+  /** Packed selection flags with the same view kind and topology as the input. */
   readonly flags: GPUCompactionInput;
+  /** Caller-owned compacted destination with matching view kind. */
   readonly output: GPUCompactionInput;
+  /** Caller-owned accepted-count destination. */
   readonly count: GraphDataView<'uint32'>;
 
+  /**
+   * Creates and validates a stable compaction description.
+   *
+   * @throws If views are not packed `uint32` data, input/flag lengths differ, or an output lacks
+   * capacity.
+   */
   constructor(props: GPUCompactionProps) {
     this.id = props.id ?? 'gpu-compaction';
     this.input = props.input;
@@ -69,7 +91,12 @@ export class GPUCompaction {
     }
   }
 
-  /** Adds scan and scatter passes to the target graph. */
+  /**
+   * Adds scan and scatter passes to the target graph.
+   *
+   * Empty input adds only a pass that writes a zero count. This method does not submit or read back
+   * commands.
+   */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
     for (const view of [
       ...getCompactionChunks(this.input),
@@ -87,72 +114,16 @@ export class GPUCompaction {
       return;
     }
 
-    if (
-      this.input instanceof GraphVectorView &&
-      this.flags instanceof GraphVectorView &&
-      this.output instanceof GraphVectorView
-    ) {
-      addVectorCompaction(graph, this.id, this.input, this.flags, this.output, this.count);
-    } else {
-      const input = this.input as GraphDataView<'uint32'>;
-      const flags = this.flags as GraphDataView<'uint32'>;
-      const output = this.output as GraphDataView<'uint32'>;
-      const offsets = createTransientView(graph, `${this.id}-offsets`, 'uint32', input.length);
-      new GPUScan({id: `${this.id}-scan`, input: flags, output: offsets}).addToGraph(graph);
-      addScatterPass(graph, {
-        id: `${this.id}-scatter`,
-        input,
-        flags,
-        offsets,
-        output,
-        count: this.count
-      });
-    }
+    const offsets =
+      this.flags instanceof GraphVectorView
+        ? createTransientVectorView(graph, `${this.id}-offsets`, this.flags)
+        : createTransientView(graph, `${this.id}-offsets`, 'uint32', this.flags.length);
+    new GPUScan({id: `${this.id}-scan`, input: this.flags, output: offsets}).addToGraph(graph);
+    addScatterPasses(graph, this.id, this.input, this.flags, offsets, this.output, this.count);
   }
 }
 
-function addVectorCompaction<Parameters>(
-  graph: GPUCommandGraph<Parameters>,
-  id: string,
-  input: GraphVectorView<'uint32'>,
-  flags: GraphVectorView<'uint32'>,
-  output: GraphVectorView<'uint32'>,
-  count: GraphDataView<'uint32'>
-): void {
-  const offsets = createTransientVectorView(graph, `${id}-offsets`, flags);
-  new GPUScan({id: `${id}-scan`, input: flags, output: offsets}).addToGraph(graph);
-
-  let outputStart = 0;
-  for (let outputChunkIndex = 0; outputChunkIndex < output.data.length; outputChunkIndex++) {
-    const outputChunk = output.data[outputChunkIndex];
-    const outputEnd = outputStart + outputChunk.length;
-    if (outputChunk.length > 0) {
-      for (let inputChunkIndex = 0; inputChunkIndex < input.data.length; inputChunkIndex++) {
-        if (input.data[inputChunkIndex].length > 0) {
-          addVectorScatterPass(graph, {
-            id: `${id}-scatter-input-${inputChunkIndex}-output-${outputChunkIndex}`,
-            input: input.data[inputChunkIndex],
-            flags: flags.data[inputChunkIndex],
-            offsets: offsets.data[inputChunkIndex],
-            output: outputChunk,
-            outputStart,
-            outputEnd
-          });
-        }
-      }
-    }
-    outputStart = outputEnd;
-  }
-
-  const lastChunkIndex = findLastNonEmptyChunk(input);
-  addCountPass(graph, {
-    id: `${id}-write-count`,
-    flags: flags.data[lastChunkIndex],
-    offsets: offsets.data[lastChunkIndex],
-    count
-  });
-}
-
+/** Writes the required zero count for an empty input. */
 function addClearCountPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
@@ -183,7 +154,58 @@ function addClearCountPass<Parameters>(
   });
 }
 
-function addVectorScatterPass<Parameters>(
+/** Routes every non-empty input chunk through each non-empty logical output range. */
+function addScatterPasses<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  input: GPUCompactionInput,
+  flags: GPUCompactionInput,
+  offsets: GPUCompactionInput,
+  output: GPUCompactionInput,
+  count: GraphDataView<'uint32'>
+): void {
+  const inputChunks = getCompactionChunks(input);
+  const flagChunks = getCompactionChunks(flags);
+  const offsetChunks = getCompactionChunks(offsets);
+  const outputChunks = getCompactionChunks(output);
+  const inputChunkIndices = inputChunks
+    .map((chunk, chunkIndex) => (chunk.length > 0 ? chunkIndex : -1))
+    .filter(chunkIndex => chunkIndex >= 0);
+  const outputChunkIndices = outputChunks
+    .map((chunk, chunkIndex) => (chunk.length > 0 ? chunkIndex : -1))
+    .filter(chunkIndex => chunkIndex >= 0);
+  const countInputChunkIndex = inputChunkIndices[inputChunkIndices.length - 1];
+  const countOutputChunkIndex = outputChunkIndices[outputChunkIndices.length - 1];
+  const isVector = input instanceof GraphVectorView;
+
+  let outputStart = 0;
+  for (let outputChunkIndex = 0; outputChunkIndex < outputChunks.length; outputChunkIndex++) {
+    const outputChunk = outputChunks[outputChunkIndex];
+    const outputEnd = outputStart + outputChunk.length;
+    if (outputChunk.length > 0) {
+      for (const inputChunkIndex of inputChunkIndices) {
+        const writesCount =
+          inputChunkIndex === countInputChunkIndex && outputChunkIndex === countOutputChunkIndex;
+        addScatterPass(graph, {
+          id: isVector
+            ? `${id}-scatter-input-${inputChunkIndex}-output-${outputChunkIndex}`
+            : `${id}-scatter`,
+          input: inputChunks[inputChunkIndex],
+          flags: flagChunks[inputChunkIndex],
+          offsets: offsetChunks[inputChunkIndex],
+          output: outputChunk,
+          outputStart,
+          outputEnd,
+          count: writesCount ? count : undefined
+        });
+      }
+    }
+    outputStart = outputEnd;
+  }
+}
+
+/** Scatters one input chunk into one logical output range and optionally writes the total count. */
+function addScatterPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   props: {
     id: string;
@@ -193,8 +215,17 @@ function addVectorScatterPass<Parameters>(
     output: GraphDataView<'uint32'>;
     outputStart: number;
     outputEnd: number;
+    count?: GraphDataView<'uint32'>;
   }
 ): void {
+  const countBinding = props.count
+    ? '@group(0) @binding(4) var<storage, read_write> outputCount: array<u32>;'
+    : '';
+  const countWrite = props.count
+    ? `if (index == ELEMENT_COUNT - 1u) {
+    outputCount[COUNT_OFFSET] = outputIndex + flag;
+  }`
+    : '';
   const source = /* wgsl */ `
 const ELEMENT_COUNT: u32 = ${props.input.length}u;
 const INPUT_OFFSET: u32 = ${getViewElementOffset(props.input)}u;
@@ -203,20 +234,24 @@ const OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.offsets)}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
 const OUTPUT_START: u32 = ${props.outputStart}u;
 const OUTPUT_END: u32 = ${props.outputEnd}u;
+${props.count ? `const COUNT_OFFSET: u32 = ${getViewElementOffset(props.count)}u;` : ''}
 @group(0) @binding(0) var<storage, read> inputValues: array<u32>;
 @group(0) @binding(1) var<storage, read> flags: array<u32>;
 @group(0) @binding(2) var<storage, read> offsets: array<u32>;
 @group(0) @binding(3) var<storage, read_write> outputValues: array<u32>;
+${countBinding}
 
 @compute @workgroup_size(${COMPACTION_WORKGROUP_SIZE}) fn main(
   @builtin(global_invocation_id) globalId: vec3<u32>
 ) {
   let index = globalId.x;
-  if (index >= ELEMENT_COUNT || min(flags[FLAGS_OFFSET + index], 1u) == 0u) { return; }
+  if (index >= ELEMENT_COUNT) { return; }
+  let flag = min(flags[FLAGS_OFFSET + index], 1u);
   let outputIndex = offsets[OFFSETS_OFFSET + index];
-  if (outputIndex >= OUTPUT_START && outputIndex < OUTPUT_END) {
+  if (flag != 0u && outputIndex >= OUTPUT_START && outputIndex < OUTPUT_END) {
     outputValues[OUTPUT_OFFSET + outputIndex - OUTPUT_START] = inputValues[INPUT_OFFSET + index];
   }
+  ${countWrite}
 }`;
   addCompactionPass(graph, {
     id: props.id,
@@ -225,52 +260,21 @@ const OUTPUT_END: u32 = ${props.outputEnd}u;
       {buffer: props.input, usage: 'storage-read'},
       {buffer: props.flags, usage: 'storage-read'},
       {buffer: props.offsets, usage: 'storage-read'},
-      {buffer: props.output, usage: 'storage-write'}
+      {buffer: props.output, usage: 'storage-write'},
+      ...(props.count ? [{buffer: props.count, usage: 'storage-write'} as const] : [])
     ],
     bindings: {
       inputValues: props.input,
       flags: props.flags,
       offsets: props.offsets,
-      outputValues: props.output
+      outputValues: props.output,
+      ...(props.count ? {outputCount: props.count} : {})
     },
     dispatchCount: Math.ceil(props.input.length / COMPACTION_WORKGROUP_SIZE)
   });
 }
 
-function addCountPass<Parameters>(
-  graph: GPUCommandGraph<Parameters>,
-  props: {
-    id: string;
-    flags: GraphDataView<'uint32'>;
-    offsets: GraphDataView<'uint32'>;
-    count: GraphDataView<'uint32'>;
-  }
-): void {
-  const lastIndex = props.flags.length - 1;
-  const source = /* wgsl */ `
-const FLAGS_OFFSET: u32 = ${getViewElementOffset(props.flags)}u;
-const OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.offsets)}u;
-const COUNT_OFFSET: u32 = ${getViewElementOffset(props.count)}u;
-@group(0) @binding(0) var<storage, read> flags: array<u32>;
-@group(0) @binding(1) var<storage, read> offsets: array<u32>;
-@group(0) @binding(2) var<storage, read_write> outputCount: array<u32>;
-@compute @workgroup_size(1) fn main() {
-  outputCount[COUNT_OFFSET] = offsets[OFFSETS_OFFSET + ${lastIndex}u] +
-    min(flags[FLAGS_OFFSET + ${lastIndex}u], 1u);
-}`;
-  addCompactionPass(graph, {
-    id: props.id,
-    source,
-    resources: [
-      {buffer: props.flags, usage: 'storage-read'},
-      {buffer: props.offsets, usage: 'storage-read'},
-      {buffer: props.count, usage: 'storage-write'}
-    ],
-    bindings: {flags: props.flags, offsets: props.offsets, outputCount: props.count},
-    dispatchCount: 1
-  });
-}
-
+/** Adds a storage-only computation pass used by compaction kernels. */
 function addCompactionPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   props: {
@@ -315,99 +319,14 @@ function addCompactionPass<Parameters>(
   });
 }
 
-function addScatterPass<Parameters>(
-  graph: GPUCommandGraph<Parameters>,
-  props: {
-    id: string;
-    input: GraphDataView<'uint32'>;
-    flags: GraphDataView<'uint32'>;
-    offsets: GraphDataView<'uint32'>;
-    output: GraphDataView<'uint32'>;
-    count: GraphDataView<'uint32'>;
-  }
-): void {
-  const length = props.input.length;
-  const source = /* wgsl */ `
-const ELEMENT_COUNT: u32 = ${length}u;
-const INPUT_OFFSET: u32 = ${getViewElementOffset(props.input)}u;
-const FLAGS_OFFSET: u32 = ${getViewElementOffset(props.flags)}u;
-const OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.offsets)}u;
-const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
-const COUNT_OFFSET: u32 = ${getViewElementOffset(props.count)}u;
-@group(0) @binding(0) var<storage, read> inputValues: array<u32>;
-@group(0) @binding(1) var<storage, read> flags: array<u32>;
-@group(0) @binding(2) var<storage, read> offsets: array<u32>;
-@group(0) @binding(3) var<storage, read_write> outputValues: array<u32>;
-@group(0) @binding(4) var<storage, read_write> outputCount: array<u32>;
-
-@compute @workgroup_size(${COMPACTION_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) globalId: vec3<u32>
-) {
-  let index = globalId.x;
-  if (index >= ELEMENT_COUNT) { return; }
-  let flag = min(flags[FLAGS_OFFSET + index], 1u);
-  if (flag != 0u) {
-    outputValues[OUTPUT_OFFSET + offsets[OFFSETS_OFFSET + index]] = inputValues[INPUT_OFFSET + index];
-  }
-  if (index == ELEMENT_COUNT - 1u) {
-    outputCount[COUNT_OFFSET] = offsets[OFFSETS_OFFSET + index] + flag;
-  }
-}`;
-  graph.addComputePass({
-    id: props.id,
-    resources: [
-      {buffer: props.input, usage: 'storage-read'},
-      {buffer: props.flags, usage: 'storage-read'},
-      {buffer: props.offsets, usage: 'storage-read'},
-      {buffer: props.output, usage: 'storage-write'},
-      {buffer: props.count, usage: 'storage-write'}
-    ],
-    compile: ({device}) => {
-      const computation = new Computation(device, {
-        id: props.id,
-        source,
-        shaderLayout: {
-          bindings: [
-            {name: 'inputValues', type: 'storage', group: 0, location: 0},
-            {name: 'flags', type: 'storage', group: 0, location: 1},
-            {name: 'offsets', type: 'storage', group: 0, location: 2},
-            {name: 'outputValues', type: 'storage', group: 0, location: 3},
-            {name: 'outputCount', type: 'storage', group: 0, location: 4}
-          ]
-        }
-      });
-      return {
-        encode: ({computePass, getBuffer}) => {
-          computation.setBindings({
-            inputValues: getViewBinding(props.input, getBuffer),
-            flags: getViewBinding(props.flags, getBuffer),
-            offsets: getViewBinding(props.offsets, getBuffer),
-            outputValues: getViewBinding(props.output, getBuffer),
-            outputCount: getViewBinding(props.count, getBuffer)
-          });
-          computation.dispatch(computePass, Math.ceil(length / COMPACTION_WORKGROUP_SIZE));
-        },
-        destroy: () => computation.destroy()
-      };
-    }
-  });
-}
-
+/** Normalizes one compaction input or vector into its ordered atomic chunks. */
 function getCompactionChunks(input: GPUCompactionInput): readonly GraphDataView<'uint32'>[] {
   return input instanceof GraphVectorView ? input.data : [input];
 }
 
+/** Validates every atomic chunk accepted by a compaction input. */
 function validateCompactionInput(input: GPUCompactionInput, name: string): void {
   for (const chunk of getCompactionChunks(input)) {
     validatePackedUint32View(chunk, name);
   }
-}
-
-function findLastNonEmptyChunk(input: GraphVectorView<'uint32'>): number {
-  for (let chunkIndex = input.data.length - 1; chunkIndex >= 0; chunkIndex--) {
-    if (input.data[chunkIndex].length > 0) {
-      return chunkIndex;
-    }
-  }
-  throw new Error('GPUCompaction requires a non-empty chunk');
 }

--- a/modules/experimental/src/gpu-primitives/gpu-grid-binning.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-grid-binning.ts
@@ -20,7 +20,7 @@ import {
 const GRID_WORKGROUP_SIZE = 256;
 const MAXIMUM_LOCAL_CELL_COUNT = 256;
 
-/** Bounds accepted by {@link GPUGridBinning}. */
+/** Literal `[minX, minY, maxX, maxY]` bounds or one GPU-resident `float32x4` row. */
 export type GPUGridBinningBounds =
   | readonly [number, number, number, number]
   | GraphDataView<'float32x4'>;
@@ -30,21 +30,42 @@ export type GPUGridBinningPositions = GraphDataView<'float32x2'> | GraphVectorVi
 
 /** Properties for graph-native two-dimensional grid counting. */
 export type GPUGridBinningProps = {
+  /** Prefix for generated graph node IDs. */
   id?: string;
+  /** One packed position view or an ordered vector of packed position chunks. */
   positions: GPUGridBinningPositions;
+  /** Caller-owned row-major cell counts. */
   output: GraphDataView<'uint32'>;
+  /** Positive integer `[width, height]` cell dimensions. */
   gridSize: readonly [number, number];
+  /** Inclusive literal or GPU-resident spatial bounds. */
   bounds: GPUGridBinningBounds;
 };
 
-/** Graph-native row-major count accumulation for packed float32x2 positions. */
+/**
+ * Graph-native row-major count accumulation for packed `float32x2` positions.
+ *
+ * Output is cleared on every encoding. Grids with up to 256 cells use workgroup-local atomics;
+ * larger grids use global atomics. Non-finite and out-of-bounds positions are ignored, while exact
+ * maximum boundaries enter the final row or column.
+ */
 export class GPUGridBinning {
+  /** Prefix for generated graph node IDs. */
   readonly id: string;
+  /** Packed two-dimensional positions or ordered position vector. */
   readonly positions: GPUGridBinningPositions;
+  /** Caller-owned row-major cell counts. */
   readonly output: GraphDataView<'uint32'>;
+  /** Positive integer grid dimensions. */
   readonly gridSize: readonly [number, number];
+  /** Literal or GPU-resident spatial bounds. */
   readonly bounds: GPUGridBinningBounds;
 
+  /**
+   * Creates and validates a two-dimensional grid-binning description.
+   *
+   * @throws If view layouts, grid dimensions, output length, ownership, or bounds are invalid.
+   */
   constructor(props: GPUGridBinningProps) {
     this.id = props.id ?? 'gpu-grid-binning';
     this.positions = props.positions;
@@ -91,7 +112,11 @@ export class GPUGridBinning {
     }
   }
 
-  /** Adds output clearing and grid accumulation nodes to a graph. */
+  /**
+   * Adds one output-clear pass and, for non-empty input, one accumulation pass to a graph.
+   *
+   * This method declares work only and does not submit or read back commands.
+   */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
     if (
       getPositionChunks(this.positions).some(chunk => chunk.buffer.graph !== graph) ||
@@ -120,6 +145,7 @@ export class GPUGridBinning {
   }
 }
 
+/** Clears every output cell before accumulation for the current graph encoding. */
 function addClearGridPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
@@ -144,6 +170,7 @@ const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
   });
 }
 
+/** Adds the local- or global-atomic row-major grid accumulation pass. */
 function addGridPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   binning: {
@@ -242,6 +269,7 @@ fn getCoordinate(value: f32, minimum: f32, maximum: f32, size: u32) -> u32 {
   });
 }
 
+/** Wraps generated WGSL in a graph compute node with deferred physical buffer resolution. */
 function addComputationPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   props: {
@@ -283,10 +311,12 @@ function addComputationPass<Parameters>(
   });
 }
 
+/** Formats a finite JavaScript number as a WGSL `f32` literal. */
 function getFloatLiteral(value: number): string {
   return Number.isInteger(value) ? `${value}.0` : `${value}`;
 }
 
+/** Narrows grid bounds to their GPU-resident `float32x4` view form. */
 function isGPUGridBoundsView(bounds: GPUGridBinningBounds): bounds is GraphDataView<'float32x4'> {
   return !Array.isArray(bounds);
 }

--- a/modules/experimental/src/gpu-primitives/gpu-histogram.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-histogram.ts
@@ -24,7 +24,10 @@ const HISTOGRAM_WORKGROUP_SIZE = 256;
 const MAXIMUM_LOCAL_BIN_COUNT = 256;
 const SCALAR_FORMATS = ['uint32', 'sint32', 'float32'] as const;
 
-/** Domain accepted by {@link GPUHistogram}. */
+/**
+ * Domain accepted by {@link GPUHistogram}: a literal pair, a two-row GPU view, or an automatically
+ * inferred extent.
+ */
 export type GPUHistogramDomain<T extends GPUScalarFormat = GPUScalarFormat> =
   | readonly [number, number]
   | GraphDataView<T>
@@ -37,19 +40,39 @@ export type GPUHistogramInput<T extends GPUScalarFormat = GPUScalarFormat> =
 
 /** Properties for graph-native scalar histogram counting. */
 export type GPUHistogramProps<T extends GPUScalarFormat = GPUScalarFormat> = {
+  /** Prefix for generated graph node and transient resource IDs. */
   id?: string;
+  /** Packed scalar chunk or ordered vector of packed scalar chunks. */
   input: GPUHistogramInput<T>;
+  /** Caller-owned `uint32` counts; its length defines the bin count. */
   output: GraphDataView<'uint32'>;
+  /** Inclusive input domain or `'auto'` for a graph-native extent reduction. */
   domain: GPUHistogramDomain<T>;
 };
 
-/** Graph-native histogram counting for packed 32-bit scalar values. */
+/**
+ * Graph-native histogram counting for packed 32-bit scalar values.
+ *
+ * Output is cleared on every encoding. Up to 256 bins use workgroup-local atomics before merging;
+ * larger outputs accumulate directly with global atomics. Values outside the inclusive domain and
+ * non-finite floating-point values are ignored.
+ */
 export class GPUHistogram<T extends GPUScalarFormat = GPUScalarFormat> {
+  /** Prefix for generated graph node and transient resource IDs. */
   readonly id: string;
+  /** Packed scalar chunk or ordered vector of packed scalar chunks. */
   readonly input: GPUHistogramInput<T>;
+  /** Caller-owned bin counts. */
   readonly output: GraphDataView<'uint32'>;
+  /** Literal, GPU-resident, or automatically inferred domain. */
   readonly domain: GPUHistogramDomain<T>;
 
+  /**
+   * Creates and validates a scalar histogram description.
+   *
+   * @throws If views are not packed supported formats, output is empty, formats mismatch, buffers
+   * alias unsafely, or a literal/GPU domain is invalid.
+   */
   constructor(props: GPUHistogramProps<T>) {
     this.id = props.id ?? 'gpu-histogram';
     this.input = props.input;
@@ -82,7 +105,13 @@ export class GPUHistogram<T extends GPUScalarFormat = GPUScalarFormat> {
     }
   }
 
-  /** Adds domain inference, output clearing, and accumulation nodes to a graph. */
+  /**
+   * Adds optional domain inference, one output-clear pass, and one accumulation pass per non-empty
+   * input chunk to a graph.
+   *
+   * Automatic domains compose a {@link GPUReduction} extent. Empty inputs still clear output but
+   * add no accumulation pass.
+   */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
     const inputs = getHistogramInputs(this.input);
     if (inputs.some(input => input.buffer.graph !== graph) || this.output.buffer.graph !== graph) {
@@ -126,12 +155,14 @@ export class GPUHistogram<T extends GPUScalarFormat = GPUScalarFormat> {
   }
 }
 
+/** Normalizes a scalar data view or vector view into its ordered chunk list. */
 function getHistogramInputs<T extends GPUScalarFormat>(
   input: GPUHistogramInput<T>
 ): readonly GraphDataView<T>[] {
   return input instanceof GraphVectorView ? input.data : [input];
 }
 
+/** Clears every output bin before accumulation for the current graph encoding. */
 function addClearHistogramPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
@@ -156,6 +187,7 @@ const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
   });
 }
 
+/** Adds the local- or global-atomic histogram accumulation pass. */
 function addHistogramPass<Parameters, T extends GPUScalarFormat>(
   graph: GPUCommandGraph<Parameters>,
   props: {
@@ -292,6 +324,7 @@ ${integerBinningFunction}
   });
 }
 
+/** Wraps generated WGSL in a graph compute node with deferred physical buffer resolution. */
 function addComputationPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   props: {
@@ -333,6 +366,7 @@ function addComputationPass<Parameters>(
   });
 }
 
+/** Validates a finite ordered literal domain and the selected scalar format's numeric range. */
 function validateLiteralDomain(
   domain: readonly number[],
   format: GPUScalarFormat,
@@ -350,16 +384,19 @@ function validateLiteralDomain(
   }
 }
 
+/** Narrows a histogram domain to its GPU-resident two-row view form. */
 function isGPUHistogramDomainView<T extends GPUScalarFormat>(
   domain: GPUHistogramDomain<T>
 ): domain is GraphDataView<T> {
   return domain !== 'auto' && !Array.isArray(domain);
 }
 
+/** Returns the WGSL scalar type corresponding to a supported GPU storage format. */
 function getShaderType(format: GPUScalarFormat): 'u32' | 'i32' | 'f32' {
   return format === 'uint32' ? 'u32' : format === 'sint32' ? 'i32' : 'f32';
 }
 
+/** Formats a JavaScript number as a type-correct WGSL scalar literal. */
 function getLiteral(value: number, format: GPUScalarFormat): string {
   if (format === 'uint32') return `${value}u`;
   if (format === 'sint32') return `${value}`;

--- a/modules/experimental/src/gpu-primitives/gpu-index-picking-target.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-index-picking-target.ts
@@ -12,18 +12,25 @@ import {
   type GraphTextureView
 } from './gpu-command-graph';
 
-const INDEX_PICKING_READBACK_BYTE_LENGTH = 256;
+/** WebGPU-aligned byte capacity required by the single-pixel picking readback buffer. */
+export const INDEX_PICKING_READBACK_BYTE_LENGTH = 256;
 const INDEX_PICKING_INVALID_INDEX = -1;
 
+/** Properties for one fixed-size graph-native index-picking target. */
 export type GPUIndexPickingTargetProps = {
+  /** Prefix for logical texture, buffer, and node IDs. */
   id?: string;
+  /** Target width in device pixels. */
   width: number;
+  /** Target height in device pixels. */
   height: number;
   /** Optional caller-owned default. Per-encoding graph buffer overrides remain supported. */
   readbackBuffer?: Buffer;
 };
 
+/** Properties for the target's optional single-pixel readback copy node. */
 export type GPUIndexPickingReadbackProps<Parameters> = {
+  /** Copy node ID. Defaults to the target ID plus `-readback`. */
   id?: string;
   /** Render node that must complete before the texture-to-buffer copy. */
   after: string;
@@ -38,19 +45,33 @@ export type GPUIndexPickingReadbackProps<Parameters> = {
  * command submission, staging buffers, readback timing, decoded state, and highlighting.
  */
 export class GPUIndexPickingTarget<Parameters = void> {
+  /** Prefix for logical texture, buffer, and node IDs. */
   readonly id: string;
+  /** Target width in device pixels. */
   readonly width: number;
+  /** Target height in device pixels. */
   readonly height: number;
+  /** Normalized color attachment available to the application render node. */
   readonly colorAttachment: GraphTextureView<'rgba8unorm'>;
+  /** Signed object/batch index attachment copied during readback. */
   readonly indexAttachment: GraphTextureView<'rg32sint'>;
+  /** Depth attachment shared by the picking render node. */
   readonly depthStencilAttachment: GraphTextureView<'depth24plus'>;
+  /** Complete attachment set for `GPUCommandGraph.addRenderPass`. */
   readonly attachments: GraphRenderPassAttachments;
+  /** Clear values matching the color, index, and depth attachments. */
   readonly renderPassProps: Pick<RenderPassProps, 'clearColors' | 'clearDepth'>;
+  /** Borrowed logical handle for the caller-owned readback buffer. */
   readonly readback: GraphBufferHandle;
 
   private readonly graph: GPUCommandGraph<Parameters>;
   private readbackPassAdded = false;
 
+  /**
+   * Declares fixed-size transient attachments and one imported readback buffer in `graph`.
+   *
+   * @throws If width or height is not a positive safe integer.
+   */
   constructor(graph: GPUCommandGraph<Parameters>, props: GPUIndexPickingTargetProps) {
     validatePickingTargetSize(props.width, props.height);
     this.graph = graph;
@@ -104,7 +125,12 @@ export class GPUIndexPickingTarget<Parameters = void> {
     );
   }
 
-  /** Adds one explicit single-pixel texture-to-buffer copy after the picking render node. */
+  /**
+   * Adds one explicit single-pixel texture-to-buffer copy after the picking render node.
+   *
+   * The pixel callback runs for each encoding, allowing pointer coordinates to arrive through graph
+   * parameters. At most one readback pass may be added per target.
+   */
   addReadbackPass(props: GPUIndexPickingReadbackProps<Parameters>): void {
     if (this.readbackPassAdded) {
       throw new Error(`${this.id} readback pass has already been added`);
@@ -139,7 +165,11 @@ export class GPUIndexPickingTarget<Parameters = void> {
   }
 }
 
-/** Decodes the first `rg32sint` texel copied into a picking readback buffer. */
+/**
+ * Decodes the first `rg32sint` texel copied into a picking readback buffer.
+ *
+ * The clear sentinel `[-1, -1]` maps to null object and batch indices.
+ */
 export function decodeGPUIndexPickInfo(data: ArrayBuffer | ArrayBufferView): PickInfo {
   const byteOffset = ArrayBuffer.isView(data) ? data.byteOffset : 0;
   const byteLength = ArrayBuffer.isView(data) ? data.byteLength : data.byteLength;
@@ -156,12 +186,14 @@ export function decodeGPUIndexPickInfo(data: ArrayBuffer | ArrayBufferView): Pic
   };
 }
 
+/** Validates the fixed attachment extent. */
 function validatePickingTargetSize(width: number, height: number): void {
   if (!Number.isSafeInteger(width) || width <= 0 || !Number.isSafeInteger(height) || height <= 0) {
     throw new Error('GPUIndexPickingTarget requires positive integer width and height');
   }
 }
 
+/** Validates an encode-time device-pixel coordinate against the attachment extent. */
 function validatePickingPixel(x: number, y: number, width: number, height: number): void {
   if (
     !Number.isSafeInteger(x) ||
@@ -176,5 +208,3 @@ function validatePickingPixel(x: number, y: number, width: number, height: numbe
     );
   }
 }
-
-export {INDEX_PICKING_READBACK_BYTE_LENGTH};

--- a/modules/experimental/src/gpu-primitives/gpu-reduction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-reduction.ts
@@ -21,34 +21,61 @@ import {
 const REDUCTION_WORKGROUP_SIZE = 256;
 const SCALAR_FORMATS = ['uint32', 'sint32', 'float32'] as const;
 
-/** Operation performed by {@link GPUReduction}. */
+/**
+ * Operation performed by {@link GPUReduction}.
+ *
+ * `sum`, `min`, and `max` produce one row. `extent` produces two rows containing the minimum and
+ * maximum respectively.
+ */
 export type GPUReductionOperation = 'sum' | 'min' | 'max' | 'extent';
 
-/** One scalar chunk or an ordered scalar vector reduced by {@link GPUReduction}. */
+/**
+ * One packed scalar chunk or an ordered, fixed-width scalar vector reduced by
+ * {@link GPUReduction}.
+ */
 export type GPUReductionInput<T extends GPUScalarFormat = GPUScalarFormat> =
   | GraphDataView<T>
   | GraphVectorView<T>;
 
 /** Properties for a graph-native scalar reduction. */
 export type GPUReductionProps<T extends GPUScalarFormat = GPUScalarFormat> = {
+  /** Prefix for generated graph node and transient resource IDs. */
   id?: string;
+  /** Packed scalar data view or ordered vector of packed scalar chunks. */
   input: GPUReductionInput<T>;
+  /** Caller-owned result view: one row, or two rows for `extent`. */
   output: GraphDataView<T>;
+  /** Aggregate to compute. */
   operation: GPUReductionOperation;
 };
 
 /**
  * Hierarchical reduction over packed 32-bit scalar graph data views and vectors.
  *
- * @remarks Inputs and outputs are caller-owned. Hierarchical scratch is graph-owned, and adding
- * the reduction to a graph never submits work or reads data back.
+ * Each 256-thread workgroup reduces at most 256 input rows to one partial row. Additional levels
+ * repeat that process until one row remains. Multi-chunk vectors first produce one partial per
+ * non-empty chunk, then reduce those partials to one global result.
+ *
+ * @remarks Inputs and outputs are caller-owned. Hierarchical scratch is graph-owned. Adding the
+ * reduction to a graph only declares nodes and resources; it does not compile, encode, submit,
+ * map, or read data back.
  */
 export class GPUReduction<T extends GPUScalarFormat = GPUScalarFormat> {
+  /** Prefix for generated graph node and transient resource IDs. */
   readonly id: string;
+  /** Scalar input chunk or vector. */
   readonly input: GPUReductionInput<T>;
+  /** Caller-owned result view. */
   readonly output: GraphDataView<T>;
+  /** Aggregate computed by this reduction. */
   readonly operation: GPUReductionOperation;
 
+  /**
+   * Creates and validates a graph-native reduction description.
+   *
+   * @throws If views are not packed 32-bit scalar data, formats differ, the output has the wrong
+   * length, or input and output use the same physical graph buffer.
+   */
   constructor(props: GPUReductionProps<T>) {
     this.id = props.id ?? 'gpu-reduction';
     this.input = props.input;
@@ -77,7 +104,16 @@ export class GPUReduction<T extends GPUScalarFormat = GPUScalarFormat> {
     }
   }
 
-  /** Adds hierarchical reduction passes and hidden scratch to a command graph. */
+  /**
+   * Adds hierarchical reduction passes and graph-owned scratch to a command graph.
+   *
+   * Empty inputs add a one-thread clear pass. A single non-empty chunk is reduced directly.
+   * Multiple non-empty chunks are reduced independently, then their partial rows are merged. A
+   * final pass converts an invalid floating-point min/max/extent result to zero and writes the
+   * caller-owned output.
+   *
+   * @param graph Mutable graph that owns all input/output handles and generated scratch.
+   */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
     const inputs = getReductionInputs(this.input);
     if (inputs.some(input => input.buffer.graph !== graph) || this.output.buffer.graph !== graph) {
@@ -163,77 +199,101 @@ export class GPUReduction<T extends GPUScalarFormat = GPUScalarFormat> {
 }
 
 type ReductionResult<T extends GPUScalarFormat> = {
+  /** One packed row for sum/min/max, or two packed components for extent. */
   values: GraphDataView<T>;
+  /** One row indicating whether a finite min/max/extent value was observed. */
   validity?: GraphDataView<'uint32'>;
 };
 
+type ReductionLevelsProps<T extends GPUScalarFormat> = {
+  /** Prefix for generated level node and resource IDs. */
+  id: string;
+  /** Scalar format of all value views. */
+  format: T;
+  /** Aggregate computed at every level. */
+  operation: GPUReductionOperation;
+  /** Packed values consumed by the first generated level. */
+  inputValues: GraphDataView<T>;
+  /** Optional validity rows paired with already-reduced input rows. */
+  inputValidity?: GraphDataView<'uint32'>;
+  /** Number of logical rows consumed by the first generated level. */
+  inputLength: number;
+  /** Components in each partial row: two for extent, otherwise one. */
+  valuesPerRow: number;
+  /** Whether the first level reads raw scalar rows instead of partial rows. */
+  firstLevel: boolean;
+  /** Whether levels must preserve finite-value validity. */
+  needsValidity: boolean;
+  /** Optional destination for the last level's value row. */
+  finalValues?: GraphDataView<T>;
+  /** Optional destination for the last level's validity row. */
+  finalValidity?: GraphDataView<'uint32'>;
+};
+
+/**
+ * Adds a complete hierarchy that reduces `inputLength` rows to one partial row.
+ *
+ * Level `n` consumes the views produced by level `n - 1`. Each level emits
+ * `ceil(currentLength / 256)` rows, so the hierarchy always converges. Intermediate levels allocate
+ * graph-owned views. When supplied, `finalValues` and `finalValidity` replace only the last
+ * allocation; multi-chunk reduction uses that facility to write each chunk's partial directly into
+ * its slot in the shared merge input.
+ */
 function addReductionLevels<Parameters, T extends GPUScalarFormat>(
   graph: GPUCommandGraph<Parameters>,
-  props: {
-    id: string;
-    format: T;
-    operation: GPUReductionOperation;
-    inputValues: GraphDataView<T>;
-    inputValidity?: GraphDataView<'uint32'>;
-    inputLength: number;
-    valuesPerRow: number;
-    firstLevel: boolean;
-    needsValidity: boolean;
-    finalValues?: GraphDataView<T>;
-    finalValidity?: GraphDataView<'uint32'>;
-  }
+  props: ReductionLevelsProps<T>
 ): ReductionResult<T> {
-  let inputValues = props.inputValues;
-  let inputValidity = props.inputValidity;
-  let inputLength = props.inputLength;
+  let currentValues = props.inputValues;
+  let currentValidity = props.inputValidity;
+  let currentLength = props.inputLength;
   let levelIndex = 0;
 
-  while (true) {
-    const outputLength = Math.ceil(inputLength / REDUCTION_WORKGROUP_SIZE);
-    const isFinalLevel = outputLength === 1;
-    const outputValues =
-      isFinalLevel && props.finalValues
+  // One workgroup produces one next-level row. The last level is therefore the first level whose
+  // output contains exactly one row.
+  while (currentLength > 1 || levelIndex === 0) {
+    const nextLength = Math.ceil(currentLength / REDUCTION_WORKGROUP_SIZE);
+    const isLastLevel = nextLength === 1;
+    const nextValues =
+      isLastLevel && props.finalValues
         ? props.finalValues
         : (createTransientView(
             graph,
             `${props.id}-level-${levelIndex}-values`,
             props.format,
-            outputLength * props.valuesPerRow
+            nextLength * props.valuesPerRow
           ) as GraphDataView<T>);
-    const outputValidity = props.needsValidity
-      ? isFinalLevel && props.finalValidity
+    const nextValidity = props.needsValidity
+      ? isLastLevel && props.finalValidity
         ? props.finalValidity
         : createTransientView(
             graph,
             `${props.id}-level-${levelIndex}-validity`,
             'uint32',
-            outputLength
+            nextLength
           )
       : undefined;
     addReductionLevelPass(graph, {
       id: `${props.id}-level-${levelIndex}`,
       format: props.format,
       operation: props.operation,
-      inputValues,
-      inputValidity,
-      outputValues,
-      outputValidity,
-      inputLength,
+      inputValues: currentValues,
+      inputValidity: currentValidity,
+      outputValues: nextValues,
+      outputValidity: nextValidity,
+      inputLength: currentLength,
       valuesPerRow: props.valuesPerRow,
       firstLevel: props.firstLevel && levelIndex === 0
     });
-    inputValues = outputValues;
-    inputValidity = outputValidity;
-    inputLength = outputLength;
+    currentValues = nextValues;
+    currentValidity = nextValidity;
+    currentLength = nextLength;
     levelIndex++;
-    if (inputLength === 1) {
-      break;
-    }
   }
 
-  return {values: inputValues, validity: inputValidity};
+  return {values: currentValues, validity: currentValidity};
 }
 
+/** Creates a packed logical slice without allocating or changing hazard granularity. */
 function createPackedSubview<T extends GPUScalarFormat, Parameters>(
   graph: GPUCommandGraph<Parameters>,
   view: GraphDataView<T>,
@@ -247,12 +307,14 @@ function createPackedSubview<T extends GPUScalarFormat, Parameters>(
   });
 }
 
+/** Normalizes a single data view or vector view into its ordered chunk list. */
 function getReductionInputs<T extends GPUScalarFormat>(
   input: GPUReductionInput<T>
 ): readonly GraphDataView<T>[] {
   return input instanceof GraphVectorView ? input.data : [input];
 }
 
+/** Adds one 256-way reduction level from raw or already-reduced rows. */
 function addReductionLevelPass<Parameters, T extends GPUScalarFormat>(
   graph: GPUCommandGraph<Parameters>,
   props: {
@@ -370,6 +432,7 @@ var<workgroup> validityScratch: array<u32, ${REDUCTION_WORKGROUP_SIZE}>;
   });
 }
 
+/** Copies the single partial row to caller output and maps an invalid aggregate to zero. */
 function addFinalizeReductionPass<Parameters, T extends GPUScalarFormat>(
   graph: GPUCommandGraph<Parameters>,
   props: {
@@ -417,6 +480,7 @@ ${props.inputValidity ? '@group(0) @binding(1) var<storage, read> inputValidity:
   });
 }
 
+/** Writes the documented zero result for an input with no rows. */
 function addClearReductionPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
@@ -438,6 +502,7 @@ function addClearReductionPass<Parameters>(
   });
 }
 
+/** Wraps generated WGSL in a graph compute node with deferred physical buffer resolution. */
 function addComputationPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   props: {
@@ -480,10 +545,12 @@ function addComputationPass<Parameters>(
   });
 }
 
+/** Returns the WGSL scalar type corresponding to a supported GPU storage format. */
 function getShaderType(format: GPUScalarFormat): 'u32' | 'i32' | 'f32' {
   return format === 'uint32' ? 'u32' : format === 'sint32' ? 'i32' : 'f32';
 }
 
+/** Returns a type-correct WGSL zero literal for a supported GPU storage format. */
 function getZeroLiteral(format: GPUScalarFormat): string {
   return format === 'uint32' ? '0u' : format === 'sint32' ? '0' : '0.0';
 }

--- a/modules/experimental/src/gpu-primitives/gpu-scan.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-scan.ts
@@ -18,19 +18,37 @@ const SCAN_WORKGROUP_SIZE = 256;
 /** Packed uint32 graph data accepted by {@link GPUScan}. */
 export type GPUScanInput = GraphDataView<'uint32'> | GraphVectorView<'uint32'>;
 
-/** Properties for a graph-native exclusive prefix sum. */
+/** Properties for one graph-native exclusive prefix sum. */
 export type GPUScanProps = {
+  /** Prefix for generated graph node and transient resource IDs. */
   id?: string;
+  /** One packed unsigned data view or an ordered vector of packed chunks. */
   input: GPUScanInput;
+  /** Caller-owned destination with matching view kind and sufficient capacity or topology. */
   output: GPUScanInput;
 };
 
-/** Hierarchical exclusive prefix sum over packed uint32 graph data. */
+/**
+ * Hierarchical exclusive prefix sum over packed `uint32` graph data.
+ *
+ * Each 256-thread block writes local exclusive offsets and, when necessary, one block sum. Higher
+ * levels scan those block sums before reverse-order offset passes add the parent offsets back into
+ * every lower level. Vector inputs are one logical sequence whose carries cross chunk boundaries
+ * without changing caller-visible topology. Arithmetic wraps modulo 2^32.
+ */
 export class GPUScan {
+  /** Prefix for generated graph node and transient resource IDs. */
   readonly id: string;
+  /** Packed unsigned source data or ordered source vector. */
   readonly input: GPUScanInput;
+  /** Caller-owned exclusive-prefix destination with matching view kind. */
   readonly output: GPUScanInput;
 
+  /**
+   * Creates and validates an exclusive scan description.
+   *
+   * @throws If either view is not packed `uint32` data or the output is shorter than the input.
+   */
   constructor(props: GPUScanProps) {
     this.id = props.id ?? 'gpu-scan';
     this.input = props.input;
@@ -49,78 +67,90 @@ export class GPUScan {
     }
   }
 
-  /** Adds local scans, vector carry propagation, and scratch buffers to a graph. */
+  /**
+   * Adds local scan hierarchies, vector carry propagation, and graph-owned scratch.
+   *
+   * Empty inputs add no nodes. This method declares work only; it does not compile, encode, submit,
+   * or read data back.
+   */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
     validateScanOwnership(graph, this.input, this.id);
     validateScanOwnership(graph, this.output, this.id);
-    if (this.input instanceof GraphVectorView && this.output instanceof GraphVectorView) {
-      addVectorScan(graph, this.id, this.input, this.output);
-    } else {
-      addScanLevels(
-        graph,
-        this.id,
-        this.input as GraphDataView<'uint32'>,
-        this.output as GraphDataView<'uint32'>
-      );
-    }
+    addChunkedScan(graph, this.id, this.input, this.output);
   }
 }
 
-function addVectorScan<Parameters>(
+/** Normalizes atomic and vector inputs and adds the required local scans and vector carries. */
+function addChunkedScan<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
-  input: GraphVectorView<'uint32'>,
-  output: GraphVectorView<'uint32'>
+  input: GPUScanInput,
+  output: GPUScanInput
 ): void {
-  if (input.length === 0) {
+  const inputChunks = getScanChunks(input);
+  const outputChunks = getScanChunks(output);
+  const nonEmptyChunks = inputChunks
+    .map((inputChunk, chunkIndex) => ({
+      chunkIndex,
+      input: inputChunk,
+      output: outputChunks[chunkIndex]
+    }))
+    .filter(chunk => chunk.input.length > 0);
+  if (nonEmptyChunks.length === 0) {
     return;
   }
-  if (input.data.length === 1) {
-    addScanLevels(graph, `${id}-chunk-0`, input.data[0], output.data[0]);
+  const isVector = input instanceof GraphVectorView;
+  if (nonEmptyChunks.length === 1) {
+    const chunk = nonEmptyChunks[0];
+    addScanLevels(
+      graph,
+      isVector ? `${id}-chunk-${chunk.chunkIndex}` : id,
+      chunk.input,
+      chunk.output
+    );
     return;
   }
 
-  const chunkTotals = createTransientView(graph, `${id}-chunk-totals`, 'uint32', input.data.length);
+  const chunkTotals = createTransientView(
+    graph,
+    `${id}-chunk-totals`,
+    'uint32',
+    nonEmptyChunks.length
+  );
   const chunkOffsets = createTransientView(
     graph,
     `${id}-chunk-offsets`,
     'uint32',
-    input.data.length
+    nonEmptyChunks.length
   );
-  addClearPass(graph, `${id}-clear-chunk-totals`, chunkTotals);
-  for (let chunkIndex = 0; chunkIndex < input.data.length; chunkIndex++) {
-    const inputChunk = input.data[chunkIndex];
-    if (inputChunk.length === 0) {
-      continue;
-    }
-    const outputChunk = output.data[chunkIndex];
-    addScanLevels(graph, `${id}-chunk-${chunkIndex}`, inputChunk, outputChunk);
-    addChunkTotalPass(graph, {
-      id: `${id}-chunk-${chunkIndex}-total`,
-      input: inputChunk,
-      output: outputChunk,
-      chunkTotals,
-      chunkIndex
-    });
-  }
+  nonEmptyChunks.forEach((chunk, partialIndex) => {
+    addScanLevels(
+      graph,
+      `${id}-chunk-${chunk.chunkIndex}`,
+      chunk.input,
+      chunk.output,
+      createPackedSubview(graph, chunkTotals, partialIndex)
+    );
+  });
   addScanLevels(graph, `${id}-chunk-carries`, chunkTotals, chunkOffsets);
-  for (let chunkIndex = 0; chunkIndex < output.data.length; chunkIndex++) {
-    if (output.data[chunkIndex].length > 0) {
-      addChunkCarryPass(graph, {
-        id: `${id}-chunk-${chunkIndex}-add-carry`,
-        output: output.data[chunkIndex],
-        chunkOffsets,
-        chunkIndex
-      });
-    }
-  }
+  nonEmptyChunks.forEach((chunk, partialIndex) => {
+    addOffsetPass(graph, {
+      id: `${id}-chunk-${chunk.chunkIndex}-add-carry`,
+      output: chunk.output,
+      offsets: chunkOffsets,
+      length: chunk.output.length,
+      offsetIndex: partialIndex
+    });
+  });
 }
 
+/** Adds every hierarchical level required to scan one non-empty packed data view. */
 function addScanLevels<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
   input: GraphDataView<'uint32'>,
-  output: GraphDataView<'uint32'>
+  output: GraphDataView<'uint32'>,
+  finalSum?: GraphDataView<'uint32'>
 ): void {
   if (input.length === 0) {
     return;
@@ -153,6 +183,7 @@ function addScanLevels<Parameters>(
       input: levelInput,
       output: levelOutput,
       blockSums,
+      finalSum: blockSums ? undefined : finalSum,
       length: levelLength,
       blockCount
     });
@@ -176,156 +207,29 @@ function addScanLevels<Parameters>(
 
   for (let index = levels.length - 2; index >= 0; index--) {
     const level = levels[index];
-    addBlockOffsetPass(graph, {
+    addOffsetPass(graph, {
       id: `${id}-level-${index}-add-offsets`,
       output: level.output,
-      blockOffsets: level.blockOffsets!,
+      offsets: level.blockOffsets!,
       length: level.length
     });
   }
 }
 
-function addClearPass<Parameters>(
+/** Returns one packed row within a transient view without allocating another buffer. */
+function createPackedSubview<Parameters>(
   graph: GPUCommandGraph<Parameters>,
-  id: string,
-  output: GraphDataView<'uint32'>
-): void {
-  const source = /* wgsl */ `
-const ELEMENT_COUNT: u32 = ${output.length}u;
-const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
-@group(0) @binding(0) var<storage, read_write> outputValues: array<u32>;
-@compute @workgroup_size(${SCAN_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) globalId: vec3<u32>
-) {
-  if (globalId.x < ELEMENT_COUNT) { outputValues[OUTPUT_OFFSET + globalId.x] = 0u; }
-}`;
-  addSimpleScanPass(graph, {
-    id,
-    source,
-    resources: [{buffer: output, usage: 'storage-write'}],
-    bindings: {outputValues: output},
-    dispatchCount: Math.ceil(output.length / SCAN_WORKGROUP_SIZE)
+  view: GraphDataView<'uint32'>,
+  index: number
+): GraphDataView<'uint32'> {
+  return graph.createDataView(view.buffer, {
+    format: 'uint32',
+    length: 1,
+    byteOffset: view.byteOffset + index * view.rowByteLength
   });
 }
 
-function addChunkTotalPass<Parameters>(
-  graph: GPUCommandGraph<Parameters>,
-  props: {
-    id: string;
-    input: GraphDataView<'uint32'>;
-    output: GraphDataView<'uint32'>;
-    chunkTotals: GraphDataView<'uint32'>;
-    chunkIndex: number;
-  }
-): void {
-  const lastIndex = props.input.length - 1;
-  const source = /* wgsl */ `
-const INPUT_OFFSET: u32 = ${getViewElementOffset(props.input)}u;
-const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
-const TOTALS_OFFSET: u32 = ${getViewElementOffset(props.chunkTotals)}u;
-@group(0) @binding(0) var<storage, read> inputValues: array<u32>;
-@group(0) @binding(1) var<storage, read> outputValues: array<u32>;
-@group(0) @binding(2) var<storage, read_write> chunkTotals: array<u32>;
-@compute @workgroup_size(1) fn main() {
-  chunkTotals[TOTALS_OFFSET + ${props.chunkIndex}u] =
-    outputValues[OUTPUT_OFFSET + ${lastIndex}u] + inputValues[INPUT_OFFSET + ${lastIndex}u];
-}`;
-  addSimpleScanPass(graph, {
-    id: props.id,
-    source,
-    resources: [
-      {buffer: props.input, usage: 'storage-read'},
-      {buffer: props.output, usage: 'storage-read'},
-      {buffer: props.chunkTotals, usage: 'storage-write'}
-    ],
-    bindings: {
-      inputValues: props.input,
-      outputValues: props.output,
-      chunkTotals: props.chunkTotals
-    },
-    dispatchCount: 1
-  });
-}
-
-function addChunkCarryPass<Parameters>(
-  graph: GPUCommandGraph<Parameters>,
-  props: {
-    id: string;
-    output: GraphDataView<'uint32'>;
-    chunkOffsets: GraphDataView<'uint32'>;
-    chunkIndex: number;
-  }
-): void {
-  const source = /* wgsl */ `
-const ELEMENT_COUNT: u32 = ${props.output.length}u;
-const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
-const OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.chunkOffsets)}u;
-@group(0) @binding(0) var<storage, read_write> outputValues: array<u32>;
-@group(0) @binding(1) var<storage, read> chunkOffsets: array<u32>;
-@compute @workgroup_size(${SCAN_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) globalId: vec3<u32>
-) {
-  if (globalId.x < ELEMENT_COUNT) {
-    outputValues[OUTPUT_OFFSET + globalId.x] = outputValues[OUTPUT_OFFSET + globalId.x] +
-      chunkOffsets[OFFSETS_OFFSET + ${props.chunkIndex}u];
-  }
-}`;
-  addSimpleScanPass(graph, {
-    id: props.id,
-    source,
-    resources: [
-      {buffer: props.output, usage: 'storage-read-write'},
-      {buffer: props.chunkOffsets, usage: 'storage-read'}
-    ],
-    bindings: {outputValues: props.output, chunkOffsets: props.chunkOffsets},
-    dispatchCount: Math.ceil(props.output.length / SCAN_WORKGROUP_SIZE)
-  });
-}
-
-function addSimpleScanPass<Parameters>(
-  graph: GPUCommandGraph<Parameters>,
-  props: {
-    id: string;
-    source: string;
-    resources: Array<{
-      buffer: GraphDataView;
-      usage: 'storage-read' | 'storage-write' | 'storage-read-write';
-    }>;
-    bindings: Record<string, GraphDataView>;
-    dispatchCount: number;
-  }
-): void {
-  graph.addComputePass({
-    id: props.id,
-    resources: props.resources,
-    compile: ({device}) => {
-      const computation = new Computation(device, {
-        id: props.id,
-        source: props.source,
-        shaderLayout: {
-          bindings: Object.keys(props.bindings).map((name, location) => ({
-            name,
-            type: 'storage' as const,
-            group: 0,
-            location
-          }))
-        }
-      });
-      return {
-        encode: ({computePass, getBuffer}) => {
-          const bindings: Record<string, Binding> = {};
-          for (const [name, view] of Object.entries(props.bindings)) {
-            bindings[name] = getViewBinding(view, getBuffer);
-          }
-          computation.setBindings(bindings);
-          computation.dispatch(computePass, props.dispatchCount);
-        },
-        destroy: () => computation.destroy()
-      };
-    }
-  });
-}
-
+/** Validates every atomic chunk accepted by a scan input. */
 function validateScanInput(input: GPUScanInput, name: string): void {
   const chunks = input instanceof GraphVectorView ? input.data : [input];
   for (const chunk of chunks) {
@@ -333,6 +237,12 @@ function validateScanInput(input: GPUScanInput, name: string): void {
   }
 }
 
+/** Normalizes one data view or vector into its ordered atomic chunks. */
+function getScanChunks(input: GPUScanInput): readonly GraphDataView<'uint32'>[] {
+  return input instanceof GraphVectorView ? input.data : [input];
+}
+
+/** Verifies that every scan chunk belongs to the graph receiving the operation. */
 function validateScanOwnership<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   input: GPUScanInput,
@@ -344,6 +254,7 @@ function validateScanOwnership<Parameters>(
   }
 }
 
+/** Adds one block-local exclusive scan level and optionally writes one sum per block. */
 function addBlockScanPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   props: {
@@ -351,21 +262,28 @@ function addBlockScanPass<Parameters>(
     input: GraphDataView<'uint32'>;
     output: GraphDataView<'uint32'>;
     blockSums?: GraphDataView<'uint32'>;
+    finalSum?: GraphDataView<'uint32'>;
     length: number;
     blockCount: number;
   }
 ): void {
-  const blockSumBinding = props.blockSums
-    ? '@group(0) @binding(2) var<storage, read_write> blockSums: array<u32>;'
+  const sumOutput = props.blockSums ?? props.finalSum;
+  const sumBinding = sumOutput
+    ? '@group(0) @binding(2) var<storage, read_write> sumValues: array<u32>;'
     : '';
+  const sumWrite = props.blockSums
+    ? 'sumValues[SUM_OFFSET + workgroupId.x] = scratch[255u];'
+    : props.finalSum
+      ? 'sumValues[SUM_OFFSET] = scratch[255u];'
+      : '';
   const source = /* wgsl */ `
 const ELEMENT_COUNT: u32 = ${props.length}u;
 const INPUT_OFFSET: u32 = ${getViewElementOffset(props.input)}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
-${props.blockSums ? `const BLOCK_SUMS_OFFSET: u32 = ${getViewElementOffset(props.blockSums)}u;` : ''}
+${sumOutput ? `const SUM_OFFSET: u32 = ${getViewElementOffset(sumOutput)}u;` : ''}
 @group(0) @binding(0) var<storage, read> inputValues: array<u32>;
 @group(0) @binding(1) var<storage, read_write> outputValues: array<u32>;
-${blockSumBinding}
+${sumBinding}
 var<workgroup> scratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;
 
 @compute @workgroup_size(${SCAN_WORKGROUP_SIZE}) fn main(
@@ -395,7 +313,7 @@ var<workgroup> scratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;
   }
 
   if (lane == ${SCAN_WORKGROUP_SIZE - 1}u) {
-    ${props.blockSums ? 'blockSums[BLOCK_SUMS_OFFSET + workgroupId.x] = scratch[255u];' : ''}
+    ${sumWrite}
   }
   if (index < ELEMENT_COUNT) {
     outputValues[OUTPUT_OFFSET + index] = scratch[lane] - inputValue;
@@ -407,7 +325,7 @@ var<workgroup> scratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;
     resources: [
       {buffer: props.input, usage: 'storage-read'},
       {buffer: props.output, usage: 'storage-write'},
-      ...(props.blockSums ? [{buffer: props.blockSums, usage: 'storage-write'} as const] : [])
+      ...(sumOutput ? [{buffer: sumOutput, usage: 'storage-write'} as const] : [])
     ],
     compile: ({device}) => {
       const computation = new Computation(device, {
@@ -417,8 +335,8 @@ var<workgroup> scratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;
           bindings: [
             {name: 'inputValues', type: 'storage', group: 0, location: 0},
             {name: 'outputValues', type: 'storage', group: 0, location: 1},
-            ...(props.blockSums
-              ? [{name: 'blockSums', type: 'storage' as const, group: 0, location: 2}]
+            ...(sumOutput
+              ? [{name: 'sumValues', type: 'storage' as const, group: 0, location: 2}]
               : [])
           ]
         }
@@ -429,8 +347,8 @@ var<workgroup> scratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;
             inputValues: getViewBinding(props.input, getBuffer),
             outputValues: getViewBinding(props.output, getBuffer)
           };
-          if (props.blockSums) {
-            bindings['blockSums'] = getViewBinding(props.blockSums, getBuffer);
+          if (sumOutput) {
+            bindings['sumValues'] = getViewBinding(sumOutput, getBuffer);
           }
           computation.setBindings(bindings);
           computation.dispatch(computePass, props.blockCount);
@@ -441,35 +359,39 @@ var<workgroup> scratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;
   });
 }
 
-function addBlockOffsetPass<Parameters>(
+/** Adds a scanned block offset or one vector carry into an output view. */
+function addOffsetPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   props: {
     id: string;
     output: GraphDataView<'uint32'>;
-    blockOffsets: GraphDataView<'uint32'>;
+    offsets: GraphDataView<'uint32'>;
     length: number;
+    offsetIndex?: number;
   }
 ): void {
+  const offsetIndex =
+    props.offsetIndex === undefined ? `index / ${SCAN_WORKGROUP_SIZE}u` : `${props.offsetIndex}u`;
   const source = /* wgsl */ `
 const ELEMENT_COUNT: u32 = ${props.length}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
-const BLOCK_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.blockOffsets)}u;
+const OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.offsets)}u;
 @group(0) @binding(0) var<storage, read_write> outputValues: array<u32>;
-@group(0) @binding(1) var<storage, read> blockOffsets: array<u32>;
+@group(0) @binding(1) var<storage, read> offsets: array<u32>;
 
 @compute @workgroup_size(${SCAN_WORKGROUP_SIZE}) fn main(
   @builtin(global_invocation_id) globalId: vec3<u32>
 ) {
   let index = globalId.x;
   if (index < ELEMENT_COUNT) {
-    outputValues[OUTPUT_OFFSET + index] = outputValues[OUTPUT_OFFSET + index] + blockOffsets[BLOCK_OFFSETS_OFFSET + index / ${SCAN_WORKGROUP_SIZE}u];
+    outputValues[OUTPUT_OFFSET + index] = outputValues[OUTPUT_OFFSET + index] + offsets[OFFSETS_OFFSET + ${offsetIndex}];
   }
 }`;
   graph.addComputePass({
     id: props.id,
     resources: [
       {buffer: props.output, usage: 'storage-read-write'},
-      {buffer: props.blockOffsets, usage: 'storage-read'}
+      {buffer: props.offsets, usage: 'storage-read'}
     ],
     compile: ({device}) => {
       const computation = new Computation(device, {
@@ -478,7 +400,7 @@ const BLOCK_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.blockOffsets)}u;
         shaderLayout: {
           bindings: [
             {name: 'outputValues', type: 'storage', group: 0, location: 0},
-            {name: 'blockOffsets', type: 'storage', group: 0, location: 1}
+            {name: 'offsets', type: 'storage', group: 0, location: 1}
           ]
         }
       });
@@ -486,7 +408,7 @@ const BLOCK_OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.blockOffsets)}u;
         encode: ({computePass, getBuffer}) => {
           computation.setBindings({
             outputValues: getViewBinding(props.output, getBuffer),
-            blockOffsets: getViewBinding(props.blockOffsets, getBuffer)
+            offsets: getViewBinding(props.offsets, getBuffer)
           });
           computation.dispatch(computePass, Math.ceil(props.length / SCAN_WORKGROUP_SIZE));
         },

--- a/modules/experimental/src/gpu-primitives/gpu-sort.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-sort.ts
@@ -27,12 +27,19 @@ export type GPUSortDirection = 'ascending' | 'descending';
 
 /** Properties for one graph-native stable uint32 key/value sort. */
 export type GPUSortProps = {
+  /** Prefix for generated graph node and transient resource IDs. */
   id?: string;
+  /** Packed unsigned sort keys. */
   keys: GraphDataView<'uint32'>;
+  /** Packed payload values paired row-for-row with `keys`. */
   values: GraphDataView<'uint32'>;
+  /** Caller-owned sorted key destination. */
   outputKeys: GraphDataView<'uint32'>;
+  /** Caller-owned payload destination permuted with the keys. */
   outputValues: GraphDataView<'uint32'>;
+  /** Requested implementation. Defaults to `'auto'`. */
   algorithm?: GPUSortAlgorithm;
+  /** Requested final order. Defaults to `'ascending'`. */
   direction?: GPUSortDirection;
 };
 
@@ -50,15 +57,29 @@ type BitonicStage = {
  * control of graph compilation, command encoding, submission, and optional readback.
  */
 export class GPUSort {
+  /** Prefix for generated graph node and transient resource IDs. */
   readonly id: string;
+  /** Packed unsigned sort keys. */
   readonly keys: GraphDataView<'uint32'>;
+  /** Packed payload values paired with the keys. */
   readonly values: GraphDataView<'uint32'>;
+  /** Caller-owned sorted key destination. */
   readonly outputKeys: GraphDataView<'uint32'>;
+  /** Caller-owned sorted payload destination. */
   readonly outputValues: GraphDataView<'uint32'>;
+  /** Algorithm requested by the caller. */
   readonly algorithm: GPUSortAlgorithm;
+  /** Final key ordering. */
   readonly direction: GPUSortDirection;
+  /** Concrete implementation selected after resolving `'auto'`. */
   readonly resolvedAlgorithm: Exclude<GPUSortAlgorithm, 'auto'>;
 
+  /**
+   * Creates and validates an out-of-place stable sort description.
+   *
+   * @throws If views are not packed `uint32` data, lengths differ, writable buffers alias, or an
+   * option or row count is unsupported.
+   */
   constructor(props: GPUSortProps) {
     this.id = props.id ?? 'gpu-sort';
     this.keys = props.keys;
@@ -102,7 +123,12 @@ export class GPUSort {
         : this.algorithm;
   }
 
-  /** Adds the selected sort implementation and its scratch buffers to a command graph. */
+  /**
+   * Adds the selected sort implementation and graph-owned scratch to a command graph.
+   *
+   * Empty inputs add no nodes; one-row inputs add one copy pass. This method does not compile,
+   * encode, submit, or read back commands.
+   */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
     for (const view of [this.keys, this.values, this.outputKeys, this.outputValues]) {
       if (view.buffer.graph !== graph) {
@@ -124,6 +150,7 @@ export class GPUSort {
   }
 }
 
+/** Enforces out-of-place writes and distinct writable destinations. */
 function validateSeparateWritableBuffers(sort: GPUSort): void {
   if (
     sort.outputKeys.buffer === sort.outputValues.buffer ||
@@ -136,6 +163,7 @@ function validateSeparateWritableBuffers(sort: GPUSort): void {
   }
 }
 
+/** Copies a one-row key/value pair without allocating sort scratch. */
 function addCopyPairPass<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GPUSort): void {
   const source = /* wgsl */ `
 const KEYS_OFFSET: u32 = ${getViewElementOffset(sort.keys)}u;
@@ -170,6 +198,7 @@ const OUTPUT_VALUES_OFFSET: u32 = ${getViewElementOffset(sort.outputValues)}u;
   });
 }
 
+/** Adds padded-index initialization, every bitonic stage, and the final stable gather. */
 function addBitonicSort<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GPUSort): void {
   const paddedLength = getNextPowerOfTwo(sort.keys.length);
   const indicesA = createTransientView(
@@ -195,6 +224,7 @@ function addBitonicSort<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GP
   addBitonicGatherPass(graph, sort, currentIndices);
 }
 
+/** Initializes logical indices and invalid padding for a power-of-two bitonic network. */
 function addBitonicInitializePass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   sort: GPUSort,
@@ -225,6 +255,7 @@ const INDICES_OFFSET: u32 = ${getViewElementOffset(indices)}u;
   });
 }
 
+/** Adds one compare/exchange stage of the stable bitonic sorting network. */
 function addBitonicStagePass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   sort: GPUSort,
@@ -293,6 +324,7 @@ fn comes_before(leftIndex: u32, rightIndex: u32) -> bool {
   });
 }
 
+/** Gathers keys and payloads through the final sorted logical-index permutation. */
 function addBitonicGatherPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   sort: GPUSort,
@@ -341,6 +373,7 @@ const OUTPUT_VALUES_OFFSET: u32 = ${getViewElementOffset(sort.outputValues)}u;
   });
 }
 
+/** Adds 32 stable least-significant-bit radix partitions and the final output copy if needed. */
 function addRadixSort<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GPUSort): void {
   const scratchKeys = createTransientView(
     graph,
@@ -394,6 +427,7 @@ function addRadixSort<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GPUS
   }
 }
 
+/** Classifies one key bit into packed zero/one flags for the radix prefix scan. */
 function addRadixClassifyPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   sort: GPUSort,
@@ -431,6 +465,7 @@ const FLAGS_OFFSET: u32 = ${getViewElementOffset(flags)}u;
   });
 }
 
+/** Stably scatters key/value pairs according to one scanned radix bit. */
 function addRadixScatterPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   sort: GPUSort,
@@ -487,6 +522,7 @@ const OUTPUT_VALUES_OFFSET: u32 = ${getViewElementOffset(outputValues)}u;
   });
 }
 
+/** Returns the smallest power of two greater than or equal to `length`. */
 function getNextPowerOfTwo(length: number): number {
   let paddedLength = 1;
   while (paddedLength < length) {
@@ -495,6 +531,7 @@ function getNextPowerOfTwo(length: number): number {
   return paddedLength;
 }
 
+/** Enumerates compare/exchange stages for a complete bitonic network. */
 function getBitonicStages(paddedLength: number): BitonicStage[] {
   const stages: BitonicStage[] = [];
   for (let blockWidth = 2; blockWidth <= paddedLength; blockWidth *= 2) {
@@ -505,6 +542,7 @@ function getBitonicStages(paddedLength: number): BitonicStage[] {
   return stages;
 }
 
+/** Wraps generated WGSL in a graph compute node with deferred physical buffer resolution. */
 function addComputationPass<GraphParameters>(
   graph: GPUCommandGraph<GraphParameters>,
   props: {

--- a/modules/experimental/src/gpu-primitives/graph-data-view-utils.ts
+++ b/modules/experimental/src/gpu-primitives/graph-data-view-utils.ts
@@ -9,10 +9,17 @@ import {GPUCommandGraph, GraphVectorView, type GraphDataView} from './gpu-comman
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 const STORAGE_BINDING_ALIGNMENT = 256;
 
-/** @internal */
+/** Packed 32-bit scalar formats supported by graph-native analysis primitives. @internal */
 export type GPUScalarFormat = 'uint32' | 'sint32' | 'float32';
 
-/** @internal */
+/**
+ * Validates that a view has one of the requested formats and a packed, uint32-aligned layout.
+ *
+ * Packed primitive shaders index storage buffers in 32-bit components, so they cannot consume
+ * interleaved rows or arbitrary byte offsets.
+ *
+ * @internal
+ */
 export function validatePackedView<T extends GPUVectorFormat>(
   view: GraphDataView,
   formats: readonly T[],
@@ -29,12 +36,19 @@ export function validatePackedView<T extends GPUVectorFormat>(
   }
 }
 
-/** @internal */
+/** Validates a packed `uint32` view used for flags, counts, or indices. @internal */
 export function validatePackedUint32View(view: GraphDataView, name: string): void {
   validatePackedView(view, ['uint32'], name);
 }
 
-/** @internal */
+/**
+ * Returns the aligned storage-buffer binding that contains a logical data view.
+ *
+ * WebGPU storage bindings begin at 256-byte-aligned offsets. Generated shaders add the component
+ * offset from {@link getViewElementOffset} to reach the view's actual first row.
+ *
+ * @internal
+ */
 export function getViewBinding(
   view: GraphDataView,
   getBuffer: (view: GraphDataView) => Buffer
@@ -53,12 +67,12 @@ export function getViewBinding(
   };
 }
 
-/** Offset in 32-bit components from the aligned storage binding. @internal */
+/** Returns the view offset in 32-bit components from its aligned storage binding. @internal */
 export function getViewElementOffset(view: GraphDataView): number {
   return (view.byteOffset % STORAGE_BINDING_ALIGNMENT) / UINT32_BYTE_LENGTH;
 }
 
-/** @internal */
+/** Creates a packed graph-owned transient buffer and a typed view spanning it. @internal */
 export function createTransientView<T extends GPUVectorFormat, Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
@@ -80,6 +94,14 @@ export function createTransientVectorView<T extends GPUVectorFormat, Parameters>
   id: string,
   template: GraphVectorView<T>
 ): GraphVectorView<T> {
+  let emptyChunk: GraphDataView<T> | undefined;
+  const data = template.data.map((chunk, chunkIndex) => {
+    if (chunk.length === 0) {
+      emptyChunk ??= createTransientView(graph, `${id}-empty`, template.format, 0);
+      return emptyChunk;
+    }
+    return createTransientView(graph, `${id}-chunk-${chunkIndex}`, template.format, chunk.length);
+  });
   return new GraphVectorView({
     id,
     name: id,
@@ -89,9 +111,7 @@ export function createTransientVectorView<T extends GPUVectorFormat, Parameters>
     stride: template.stride,
     byteStride: template.byteStride,
     rowByteLength: template.rowByteLength,
-    data: template.data.map((chunk, chunkIndex) =>
-      createTransientView(graph, `${id}-chunk-${chunkIndex}`, template.format, chunk.length)
-    )
+    data
   });
 }
 

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
@@ -457,11 +457,15 @@ test('GPUScan propagates carries across GPUVector chunks without changing topolo
     Uint32Array.from([7, 8])
   ];
   const result = await runVectorScan(device, chunks);
-  t.equal(result.length, 3, 'output preserves all source chunks');
-  t.equal(result[0].length, 300, 'first chunk length is preserved');
-  t.deepEqual(result[1], [], 'empty middle chunk is preserved');
-  t.equal(result[0][299], 299, 'hierarchical local scan completes within the first chunk');
-  t.deepEqual(result[2], [300, 307], 'later chunks receive the sum of all preceding chunks');
+  t.equal(result.chunks.length, 3, 'output preserves all source chunks');
+  t.equal(result.chunks[0].length, 300, 'first chunk length is preserved');
+  t.deepEqual(result.chunks[1], [], 'empty middle chunk is preserved');
+  t.equal(result.chunks[0][299], 299, 'hierarchical local scan completes within the first chunk');
+  t.deepEqual(result.chunks[2], [300, 307], 'later chunks receive the sum of all preceding chunks');
+  t.notOk(
+    result.nodeOrder.some(id => id.includes('clear-chunk-totals') || id.endsWith('-total')),
+    'final local scan levels write compact chunk totals without separate passes'
+  );
   t.end();
 });
 
@@ -589,17 +593,36 @@ test('GPUCompaction preserves GPUVector topology while selecting across chunks',
 
   const result = await runVectorCompaction(
     device,
-    [Uint32Array.from([10, 11, 12]), new Uint32Array(0), Uint32Array.from([20, 21, 22])],
-    [Uint32Array.from([1, 0, 1]), new Uint32Array(0), Uint32Array.from([1, 1, 0])]
+    [
+      Uint32Array.from([10, 11, 12]),
+      new Uint32Array(0),
+      new Uint32Array(0),
+      Uint32Array.from([20, 21, 22])
+    ],
+    [
+      Uint32Array.from([1, 0, 1]),
+      new Uint32Array(0),
+      new Uint32Array(0),
+      Uint32Array.from([1, 1, 0])
+    ]
   );
   t.equal(result.count, 4, 'count spans the complete logical vector');
   t.deepEqual(
     result.chunks.map(chunk => chunk.length),
-    [3, 0, 3],
+    [3, 0, 0, 3],
     'output chunk boundaries remain intact'
   );
   t.deepEqual(result.chunks[0], [10, 12, 20], 'selection crosses into the first output chunk');
-  t.equal(result.chunks[2][0], 21, 'selection continues in the next non-empty output chunk');
+  t.equal(result.chunks[3][0], 21, 'selection continues in the next non-empty output chunk');
+  t.notOk(
+    result.nodeOrder.some(id => id.endsWith('-write-count')),
+    'the final scatter writes the vector-wide count without a separate pass'
+  );
+  t.equal(
+    result.logicalTransientBufferCount,
+    5,
+    'zero-length offset chunks share one transient backing view'
+  );
   t.end();
 });
 
@@ -691,47 +714,27 @@ async function readPixels(texture: Texture, width: number, height: number): Prom
   }
 }
 
-async function runVectorScan(device: Device, chunks: Uint32Array[]): Promise<number[][]> {
-  const inputBuffers = chunks.map(chunk =>
-    device.createBuffer({
-      data: chunk.length > 0 ? chunk : new Uint32Array(1),
-      usage: Buffer.STORAGE | Buffer.COPY_DST
-    })
-  );
-  const outputBuffers = chunks.map(chunk =>
-    device.createBuffer({
-      byteLength: Math.max(chunk.length, 1) * Uint32Array.BYTES_PER_ELEMENT,
-      usage: Buffer.STORAGE | Buffer.COPY_SRC
-    })
-  );
-  const inputVector = createUint32Vector(
-    'input',
-    inputBuffers,
-    chunks.map(chunk => chunk.length)
-  );
-  const outputVector = createUint32Vector(
-    'output',
-    outputBuffers,
-    chunks.map(chunk => chunk.length)
-  );
+async function runVectorScan(
+  device: Device,
+  chunks: Uint32Array[]
+): Promise<{chunks: number[][]; nodeOrder: string[]}> {
+  const inputFixture = createUint32VectorFixture(device, 'input', chunks);
+  const outputFixture = createUint32VectorFixture(device, 'output', chunks, 0);
   const graph = new GPUCommandGraph(device, {id: 'vector-scan'});
-  const input = graph.importGPUVector('input', inputVector);
-  const output = graph.importGPUVector('output', outputVector);
+  const input = graph.importGPUVector('input', inputFixture.vector);
+  const output = graph.importGPUVector('output', outputFixture.vector);
   new GPUScan({input, output}).addToGraph(graph);
   const compiled = graph.compile();
   const commandEncoder = device.createCommandEncoder({id: 'vector-scan-encoder'});
   compiled.encode(commandEncoder, {parameters: undefined});
   device.submit(commandEncoder.finish());
-  const result = await Promise.all(
-    outputBuffers.map(async (buffer, chunkIndex) => {
-      const bytes = await buffer.readAsync();
-      return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, chunks[chunkIndex].length));
-    })
-  );
+  const result = {
+    chunks: await readUint32VectorFixture(outputFixture),
+    nodeOrder: compiled.stats.nodeOrder
+  };
   compiled.destroy();
-  inputVector.destroy();
-  outputVector.destroy();
-  for (const buffer of [...inputBuffers, ...outputBuffers]) buffer.destroy();
+  destroyUint32VectorFixture(inputFixture);
+  destroyUint32VectorFixture(outputFixture);
   return result;
 }
 
@@ -739,37 +742,23 @@ async function runVectorCompaction(
   device: Device,
   valueChunks: Uint32Array[],
   flagChunks: Uint32Array[]
-): Promise<{chunks: number[][]; count: number}> {
-  const valueBuffers = valueChunks.map(chunk =>
-    device.createBuffer({
-      data: chunk.length > 0 ? chunk : new Uint32Array(1),
-      usage: Buffer.STORAGE | Buffer.COPY_DST
-    })
-  );
-  const flagBuffers = flagChunks.map(chunk =>
-    device.createBuffer({
-      data: chunk.length > 0 ? chunk : new Uint32Array(1),
-      usage: Buffer.STORAGE | Buffer.COPY_DST
-    })
-  );
-  const outputBuffers = valueChunks.map(chunk =>
-    device.createBuffer({
-      data: Uint32Array.from({length: Math.max(chunk.length, 1)}, () => 0xffffffff),
-      usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
-    })
-  );
+): Promise<{
+  chunks: number[][];
+  count: number;
+  nodeOrder: string[];
+  logicalTransientBufferCount: number;
+}> {
+  const valuesFixture = createUint32VectorFixture(device, 'values', valueChunks);
+  const flagsFixture = createUint32VectorFixture(device, 'flags', flagChunks);
+  const outputFixture = createUint32VectorFixture(device, 'output', valueChunks, 0xffffffff);
   const countBuffer = device.createBuffer({
     byteLength: Uint32Array.BYTES_PER_ELEMENT,
     usage: Buffer.STORAGE | Buffer.COPY_SRC
   });
-  const lengths = valueChunks.map(chunk => chunk.length);
-  const valuesVector = createUint32Vector('values', valueBuffers, lengths);
-  const flagsVector = createUint32Vector('flags', flagBuffers, lengths);
-  const outputVector = createUint32Vector('output', outputBuffers, lengths);
   const graph = new GPUCommandGraph(device, {id: 'vector-compaction'});
-  const values = graph.importGPUVector('values', valuesVector);
-  const flags = graph.importGPUVector('flags', flagsVector);
-  const output = graph.importGPUVector('output', outputVector);
+  const values = graph.importGPUVector('values', valuesFixture.vector);
+  const flags = graph.importGPUVector('flags', flagsFixture.vector);
+  const output = graph.importGPUVector('output', outputFixture.vector);
   const countHandle = graph.importBuffer(
     {id: 'count', byteLength: countBuffer.byteLength, usage: countBuffer.usage},
     countBuffer
@@ -781,34 +770,48 @@ async function runVectorCompaction(
   compiled.encode(commandEncoder, {parameters: undefined});
   device.submit(commandEncoder.finish());
   const [chunks, countBytes] = await Promise.all([
-    Promise.all(
-      outputBuffers.map(async (buffer, chunkIndex) => {
-        const bytes = await buffer.readAsync();
-        return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, lengths[chunkIndex]));
-      })
-    ),
+    readUint32VectorFixture(outputFixture),
     countBuffer.readAsync()
   ]);
   const result = {
     chunks,
-    count: new Uint32Array(countBytes.buffer, countBytes.byteOffset, 1)[0]
+    count: new Uint32Array(countBytes.buffer, countBytes.byteOffset, 1)[0],
+    nodeOrder: compiled.stats.nodeOrder,
+    logicalTransientBufferCount: compiled.stats.logicalTransientBufferCount
   };
   compiled.destroy();
-  valuesVector.destroy();
-  flagsVector.destroy();
-  outputVector.destroy();
-  for (const buffer of [...valueBuffers, ...flagBuffers, ...outputBuffers, countBuffer]) {
-    buffer.destroy();
-  }
+  destroyUint32VectorFixture(valuesFixture);
+  destroyUint32VectorFixture(flagsFixture);
+  destroyUint32VectorFixture(outputFixture);
+  countBuffer.destroy();
   return result;
 }
 
-function createUint32Vector(
+type Uint32VectorFixture = {
+  vector: GPUVector<'uint32'>;
+  buffers: Buffer[];
+  lengths: number[];
+};
+
+function createUint32VectorFixture(
+  device: Device,
   name: string,
-  buffers: Buffer[],
-  lengths: number[]
-): GPUVector<'uint32'> {
-  return new GPUVector({
+  chunks: Uint32Array[],
+  fill?: number
+): Uint32VectorFixture {
+  const lengths = chunks.map(chunk => chunk.length);
+  const buffers = chunks.map(chunk =>
+    device.createBuffer({
+      data:
+        fill === undefined
+          ? chunk.length > 0
+            ? chunk
+            : new Uint32Array(1)
+          : Uint32Array.from({length: Math.max(chunk.length, 1)}, () => fill),
+      usage: Buffer.STORAGE | Buffer.COPY_DST | (fill === undefined ? 0 : Buffer.COPY_SRC)
+    })
+  );
+  const vector = new GPUVector({
     type: 'data',
     name,
     format: 'uint32',
@@ -823,6 +826,23 @@ function createUint32Vector(
     ),
     ownsData: false
   });
+  return {vector, buffers, lengths};
+}
+
+async function readUint32VectorFixture(fixture: Uint32VectorFixture): Promise<number[][]> {
+  return Promise.all(
+    fixture.buffers.map(async (buffer, chunkIndex) => {
+      const bytes = await buffer.readAsync();
+      return Array.from(
+        new Uint32Array(bytes.buffer, bytes.byteOffset, fixture.lengths[chunkIndex])
+      );
+    })
+  );
+}
+
+function destroyUint32VectorFixture(fixture: Uint32VectorFixture): void {
+  fixture.vector.destroy();
+  for (const buffer of fixture.buffers) buffer.destroy();
 }
 
 async function runCompaction(


### PR DESCRIPTION
## Goals

- Separate shared command-graph contracts, compilation internals, and graph construction/encoding without circular implementation imports.
- Make the command graph and every exported primitive/operation understandable from source and API documentation.
- Preserve the landed multi-chunk scan and compaction behavior while simplifying their execution paths and graph passes.

## Changes

- Add private `gpu-command-graph-types.ts` for handles, views, resource uses, node contracts, executable contexts, and statistics.
- Move scheduling, hazard inference, texture overlap, transient lifetime/allocation planning, physical resource creation, cleanup-on-failure, and compile statistics into private `gpu-command-graph-compiler.ts`.
- Keep dependencies one-directional: the compiler consumes shared types and never imports the graph implementation.
- Keep `GPUCommandGraph.compile()` as the public delegation point with package exports and runtime behavior preserved.
- Add comprehensive TSDoc to the graph core, compiler, shared helpers, scan, compaction, sort, reduction, histogram, grid binning, index picking, and indirect draw command buffers.
- Document lifecycle, ownership, hazards, compiler phases, implementation boundaries, and reduction hierarchy in the API guides.
- Normalize scalar and vector scan/compaction execution, remove redundant chunk-total clearing and count passes, and reuse empty transient views without changing public APIs or chunk topology.

## Verification

- `nvm use`
- `yarn install --immutable`
- `yarn lint fix`
- `yarn build`
- `yarn test` — 168 node tests and 1,253 browser tests passed; 27 skipped
- Focused command-graph and GPU data-analysis tests — 20 passed
- `yarn examples:typecheck` — 28 example workspaces passed
- `yarn website:build`
- `(cd website && yarn build)`

## Scope

This is an extraction, dependency cleanup, documentation, readability, and internal pass-reduction refactor. It adds no new public API, table/GPGPU integration, or new primitive behavior. It is rebased on the landed multi-chunk primitive work in #2726.