### PR TITLE
feat(experimental) Add multi-chunk GPU histogram

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -72,7 +72,7 @@ its documented atomic graph resources; callers must select, adapt, or explicitly
 | `GPUCompaction` | Input and flag `GraphDataView`s | ❌ |
 | `GPUSort` | Key and value `GraphDataView`s | ❌ |
 | `GPUReduction` | Scalar `GraphDataView` or `GraphVectorView` | ✅ |
-| `GPUHistogram` | Scalar `GraphDataView` | ❌ |
+| `GPUHistogram` | Scalar `GraphDataView` or `GraphVectorView` | ✅ |
 | `GPUGridBinning` | Position `GraphDataView` | ❌ |
 | `GPUIndexPickingTarget` | Texture and readback resources | ❌ |
 | `DrawCommandBuffer` | Indirect command buffer | ❌ |

--- a/docs/api-reference/experimental/gpu-primitives/gpu-histogram.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-histogram.md
@@ -16,15 +16,19 @@ new GPUHistogram({input: values, output: counts, domain: 'auto'}).addToGraph(gra
 ```ts
 type GPUHistogramProps<T extends 'uint32' | 'sint32' | 'float32'> = {
   id?: string;
-  input: GraphDataView<T>;
+  input: GraphDataView<T> | GraphVectorView<T>;
   output: GraphDataView<'uint32'>;
   domain: readonly [number, number] | GraphDataView<T> | 'auto';
 };
 ```
 
-`'auto'` inserts a `GPUReduction` extent. Values outside the domain and non-finite floats are
-ignored. An exact maximum enters the final bin. For a degenerate domain, matching values enter bin
-zero. Counts wrap as `uint32`.
+For a `GraphVectorView`, the histogram preserves the ordered input topology: it does not pack,
+concatenate, or rewrite chunks. The output is cleared once, then each non-empty `GraphDataView`
+chunk accumulates into the same bins in source order. Empty chunks add no accumulation pass.
+
+`'auto'` inserts one multi-chunk `GPUReduction` extent, so its domain covers every non-empty chunk.
+Values outside the domain and non-finite floats are ignored. An exact maximum enters the final bin.
+For a degenerate domain, matching values enter bin zero. Counts wrap as `uint32`.
 
 Every encoding clears the output before accumulation, so a compiled graph is safely reusable.
 Up to 256 bins use workgroup-local atomics; larger histograms use direct global atomics.

--- a/modules/experimental/src/gpu-primitives/gpu-histogram.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-histogram.ts
@@ -4,7 +4,12 @@
 
 import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-command-graph';
+import {
+  GPUCommandGraph,
+  GraphVectorView,
+  type GraphBufferUse,
+  type GraphDataView
+} from './gpu-command-graph';
 import {
   createTransientView,
   getViewBinding,
@@ -25,10 +30,15 @@ export type GPUHistogramDomain<T extends GPUScalarFormat = GPUScalarFormat> =
   | GraphDataView<T>
   | 'auto';
 
+/** One scalar chunk or an ordered scalar vector counted by {@link GPUHistogram}. */
+export type GPUHistogramInput<T extends GPUScalarFormat = GPUScalarFormat> =
+  | GraphDataView<T>
+  | GraphVectorView<T>;
+
 /** Properties for graph-native scalar histogram counting. */
 export type GPUHistogramProps<T extends GPUScalarFormat = GPUScalarFormat> = {
   id?: string;
-  input: GraphDataView<T>;
+  input: GPUHistogramInput<T>;
   output: GraphDataView<'uint32'>;
   domain: GPUHistogramDomain<T>;
 };
@@ -36,7 +46,7 @@ export type GPUHistogramProps<T extends GPUScalarFormat = GPUScalarFormat> = {
 /** Graph-native histogram counting for packed 32-bit scalar values. */
 export class GPUHistogram<T extends GPUScalarFormat = GPUScalarFormat> {
   readonly id: string;
-  readonly input: GraphDataView<T>;
+  readonly input: GPUHistogramInput<T>;
   readonly output: GraphDataView<'uint32'>;
   readonly domain: GPUHistogramDomain<T>;
 
@@ -45,12 +55,18 @@ export class GPUHistogram<T extends GPUScalarFormat = GPUScalarFormat> {
     this.input = props.input;
     this.output = props.output;
     this.domain = props.domain;
-    validatePackedView(this.input, SCALAR_FORMATS, `${this.id} input`);
+    for (const [chunkIndex, input] of getHistogramInputs(this.input).entries()) {
+      const name = this.input instanceof GraphVectorView ? ` input chunk ${chunkIndex}` : ' input';
+      validatePackedView(input, SCALAR_FORMATS, `${this.id}${name}`);
+      if (input.format !== this.input.format) {
+        throw new Error(`${this.id}${name} format must match the input format`);
+      }
+    }
     validatePackedUint32View(this.output, `${this.id} output`);
     if (this.output.length === 0) {
       throw new Error(`${this.id} output must contain at least one bin`);
     }
-    if (this.input.buffer === this.output.buffer) {
+    if (getHistogramInputs(this.input).some(input => input.buffer === this.output.buffer)) {
       throw new Error(`${this.id} input and output must use separate buffers`);
     }
     if (isGPUHistogramDomainView(this.domain)) {
@@ -68,7 +84,8 @@ export class GPUHistogram<T extends GPUScalarFormat = GPUScalarFormat> {
 
   /** Adds domain inference, output clearing, and accumulation nodes to a graph. */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
-    if (this.input.buffer.graph !== graph || this.output.buffer.graph !== graph) {
+    const inputs = getHistogramInputs(this.input);
+    if (inputs.some(input => input.buffer.graph !== graph) || this.output.buffer.graph !== graph) {
       throw new Error(`${this.id} views must belong to the target graph`);
     }
     let domain = this.domain;
@@ -91,15 +108,28 @@ export class GPUHistogram<T extends GPUScalarFormat = GPUScalarFormat> {
       domain = inferredDomain;
     }
     addClearHistogramPass(graph, this.id, this.output);
-    if (this.input.length > 0) {
+    const accumulationPath = this.output.length <= MAXIMUM_LOCAL_BIN_COUNT ? 'local' : 'global';
+    inputs.forEach((input, chunkIndex) => {
+      if (input.length === 0) {
+        return;
+      }
       addHistogramPass(graph, {
-        id: `${this.id}-${this.output.length <= MAXIMUM_LOCAL_BIN_COUNT ? 'local' : 'global'}`,
-        input: this.input,
+        id:
+          this.input instanceof GraphVectorView
+            ? `${this.id}-chunk-${chunkIndex}-${accumulationPath}`
+            : `${this.id}-${accumulationPath}`,
+        input,
         output: this.output,
         domain
       });
-    }
+    });
   }
+}
+
+function getHistogramInputs<T extends GPUScalarFormat>(
+  input: GPUHistogramInput<T>
+): readonly GraphDataView<T>[] {
+  return input instanceof GraphVectorView ? input.data : [input];
 }
 
 function addClearHistogramPass<Parameters>(

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -50,7 +50,7 @@ export {GPUReduction} from './gpu-reduction';
 export type {GPUReductionInput, GPUReductionOperation, GPUReductionProps} from './gpu-reduction';
 
 export {GPUHistogram} from './gpu-histogram';
-export type {GPUHistogramDomain, GPUHistogramProps} from './gpu-histogram';
+export type {GPUHistogramDomain, GPUHistogramInput, GPUHistogramProps} from './gpu-histogram';
 
 export {GPUGridBinning} from './gpu-grid-binning';
 export type {GPUGridBinningBounds, GPUGridBinningProps} from './gpu-grid-binning';

--- a/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
@@ -203,6 +203,63 @@ test('GPUHistogram supports literal, GPU, and automatic domains', async t => {
   t.end();
 });
 
+test('GPUHistogram accumulates fixed-width GPUVector chunks after one clear', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const literal = await runVectorHistogram(
+    device,
+    [Uint32Array.from([0, 1]), new Uint32Array(0), Uint32Array.from([2, 3, 3])],
+    'uint32',
+    4,
+    [0, 3]
+  );
+  t.deepEqual(literal.counts, [1, 1, 1, 2], 'every non-empty chunk contributes counts');
+  t.deepEqual(
+    literal.nodeOrder,
+    ['gpu-histogram-clear', 'gpu-histogram-chunk-0-local', 'gpu-histogram-chunk-2-local'],
+    'one clear precedes ordered per-chunk accumulation and empty chunks keep their source index'
+  );
+  t.equal(
+    literal.logicalTransientBufferCount,
+    0,
+    'a literal-domain histogram does not pack or concatenate input chunks'
+  );
+
+  const automatic = await runVectorHistogram(
+    device,
+    [
+      Float32Array.from([Number.NaN, Number.POSITIVE_INFINITY]),
+      Float32Array.from([-2, 0]),
+      Float32Array.from([4, 6])
+    ],
+    'float32',
+    4,
+    'auto'
+  );
+  t.deepEqual(
+    automatic.counts,
+    [1, 1, 0, 2],
+    'automatic domain reduction spans all chunks and ignores non-finite values'
+  );
+
+  const globalValues = [
+    Uint32Array.from({length: 150}, (_, index) => index),
+    Uint32Array.from({length: 150}, (_, index) => index + 150)
+  ];
+  const global = await runVectorHistogram(device, globalValues, 'uint32', 300, [0, 299]);
+  t.deepEqual(
+    global.counts,
+    Array.from({length: 300}, () => 1),
+    'the global atomic path accumulates every chunk'
+  );
+  t.end();
+});
+
 test('GPUHistogram clears counts for every graph encoding and composes with reduction', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -420,6 +477,42 @@ async function runHistogram(
   outputBuffer.destroy();
   domainBuffer?.destroy();
   return result;
+}
+
+async function runVectorHistogram(
+  device: Device,
+  chunks: ScalarArray[],
+  format: ScalarFormat,
+  binCount: number,
+  domain: readonly [number, number] | 'auto'
+): Promise<{counts: number[]; nodeOrder: string[]; logicalTransientBufferCount: number}> {
+  const inputBuffers = chunks.map(chunk => createInputBuffer(device, chunk));
+  const vector = new GPUVector({
+    type: 'data',
+    name: 'input',
+    format,
+    data: chunks.map(
+      (chunk, index) =>
+        new GPUData({buffer: inputBuffers[index], format, length: chunk.length, ownsBuffer: false})
+    ),
+    ownsData: false
+  });
+  const outputBuffer = createOutputBuffer(device, binCount);
+  const graph = new GPUCommandGraph(device);
+  const input = graph.importGPUVector('input', vector);
+  const output = importView(graph, 'output', outputBuffer, 'uint32', binCount);
+  new GPUHistogram({input, output, domain}).addToGraph(graph);
+  const compiled = graph.compile();
+  const commandEncoder = device.createCommandEncoder({id: 'vector-histogram-test'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+  const counts = await readUint32(outputBuffer, binCount);
+  const {nodeOrder, logicalTransientBufferCount} = compiled.stats;
+  compiled.destroy();
+  vector.destroy();
+  for (const buffer of inputBuffers) buffer.destroy();
+  outputBuffer.destroy();
+  return {counts, nodeOrder, logicalTransientBufferCount};
 }
 
 async function runGrid(


### PR DESCRIPTION
## Goals

- Let `GPUHistogram` consume fixed-width `GraphVectorView` inputs without packing or changing chunk boundaries.
- Clear output once, then accumulate every non-empty chunk into the shared bins.
- Infer automatic domains across the complete vector with multi-chunk `GPUReduction`.

## Changes

- Add and export `GPUHistogramInput<T> = GraphDataView<T> | GraphVectorView<T>`.
- Validate every vector chunk while retaining its format, layout, order, and source index.
- Add one clear node followed by one local/global accumulation node per non-empty chunk.
- Pass the original vector view to `GPUReduction` for automatic extent calculation.
- Mark `GPUHistogram` as multi-chunk capable and document its topology-preserving behavior.
- Test literal and automatic domains, empty chunks, one-clear scheduling, no implicit packing, and both local and global atomic paths.

## Verification

- `nvm use`
- `yarn install --immutable`
- `yarn lint fix`
- `yarn build`
- `yarn test` — 167 node tests and 1,246 browser tests passed
- Focused GPU data-analysis tests — 7 passed
- `yarn examples:typecheck` — 28 example workspaces passed
- `yarn website:build`
- `(cd website && yarn build)`

## Scope

This PR adds only multi-chunk histogram semantics. It does not pack inputs, change vector topology, or add generic vector-level hazards.
