### PR TITLE
[codex] Embed live examples in documentation

### DIFF
--- a/docs/api-guide/gpu/video-textures.mdx
+++ b/docs/api-guide/gpu/video-textures.mdx
@@ -1,4 +1,5 @@
 import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
+import {VideoTextureExample} from '@site/src/examples';
 
 # Working With Video Textures
 
@@ -10,6 +11,10 @@ import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
 </p>
 
 Video can enter a shader through more than one texture path. The right path depends on whether the application needs portable texture semantics or WebGPU's optimized direct-video sampling path.
+
+The example starts with a generated video source. Camera access remains optional and is only requested from the button:
+
+<VideoTextureExample embedded showStats={false} />
 
 ## Choose The Binding Path
 

--- a/docs/api-guide/shaders/shader-passes.md
+++ b/docs/api-guide/shaders/shader-passes.md
@@ -1,4 +1,5 @@
 import {ShaderLevelDocsTabs} from '@site/src/components/docs/shader-level-docs-tabs';
+import {PostprocessingExample} from '@site/src/examples';
 
 # Shader Passes
 
@@ -7,6 +8,10 @@ import {ShaderLevelDocsTabs} from '@site/src/components/docs/shader-level-docs-t
 A shader pass is a shader module that can run as a fullscreen texture-processing
 stage. The pass descriptor lives in `@luma.gl/shadertools`; the renderer that
 executes pass chains lives in `@luma.gl/engine` as `ShaderPassRenderer`.
+
+Choose an effect and adjust its parameters to see a shader pass update the source texture live:
+
+<PostprocessingExample embedded showStats={false} />
 
 ## Components
 

--- a/docs/api-reference/core/resources/texture.md
+++ b/docs/api-reference/core/resources/texture.md
@@ -1,4 +1,5 @@
 import {CoreDocsTabs} from '@site/src/components/docs/core-docs-tabs';
+import {Texture3DExample} from '@site/src/examples';
 
 # Texture
 
@@ -123,6 +124,10 @@ Note that the allowed combinations are very limited, especially in WebGPU.
 | `3d`         | ✅      | ✅      | Holds a "stack" of textures which enables 3D interpolation.          |
 | `cube`       | ✅      | ✅      | Holds 6 textures representing sides of a cube.                       |
 | `cube-array` | ✅      | ❌      | Holds an array where every 6 textures represent the sides of a cube. |
+
+The example below uploads procedural volume data to a `3d` texture and samples through its depth:
+
+<Texture3DExample embedded showStats={false} />
 
 
 ## ExternalImage

--- a/docs/api-reference/core/texture-formats.mdx
+++ b/docs/api-reference/core/texture-formats.mdx
@@ -1,5 +1,6 @@
 import {CoreDocsTabs} from '@site/src/components/docs/core-docs-tabs';
 import {DeviceTabs, Format as Ft, Filter as L, Render as R} from '@site/src/react-luma';
+import {TextureTesterExample} from '@site/src/examples';
 
 # Texture Formats
 
@@ -215,6 +216,10 @@ For more information on compressed textures, see e.g. [Compressed Textures in 20
 | `texture-compression-pvrtc-webgl` | PowerVR chipsets.                         | iPhone, iPad, certain Android    |                                          |
 | `texture-compression-atc-webgl`   | Adreno GPUs                               | Qualcomm Snapdragon devices.     |                                          |
 | `texture-compression-etc1-webgl`  | Ericsson Compression                      | Older ETC compression.           |                                          |
+
+The live capability sampler loads representative Basis/KTX2, BC/DXT, ASTC, and ETC assets. Unsupported cards are expected and reflect the formats exposed by the selected backend and GPU.
+
+<TextureTesterExample embedded />
 
 ## Supercompressed Textures
 

--- a/docs/api-reference/engine/dynamic-texture.md
+++ b/docs/api-reference/engine/dynamic-texture.md
@@ -1,4 +1,5 @@
 import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+import {CubemapExample} from '@site/src/examples';
 
 # DynamicTexture
 
@@ -10,6 +11,10 @@ import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
 
 `DynamicTexture` is the engine-level convenience wrapper around core [`Texture`](/docs/api-reference/core/resources/texture) resources.
 It adds async initialization, resizing, mipmap generation, and helpers for more complex texture layouts while still producing a normal `Texture`, `Sampler`, and `TextureView` once ready.
+
+This cubemap loads six faces asynchronously, generates mipmaps, and samples the result for both the room and the reflective object:
+
+<CubemapExample embedded showStats={false} />
 
 ## Usage
 

--- a/docs/api-reference/experimental/README.md
+++ b/docs/api-reference/experimental/README.md
@@ -1,4 +1,5 @@
 import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-tabs';
+import {OITExample} from '@site/src/examples';
 
 # @luma.gl/experimental
 
@@ -44,6 +45,10 @@ compaction, stable key/value sorting, and GPU-written indirect draw commands.
 
 Both renderers leave scene models, shader inputs, command submission, and fallback selection under
 application control.
+
+Compare A-buffer, weighted-blended, and ordinary alpha blending on the same overlapping scene:
+
+<OITExample embedded showStats={false} />
 
 ## Hybrid Shadows
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -1,4 +1,5 @@
 import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+import {GPUDataAnalysisExample} from '@site/src/examples';
 
 # GPUCommandGraph
 
@@ -7,6 +8,10 @@ import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-do
 `GPUCommandGraph<Parameters>` declares fixed-capacity WebGPU buffer and texture resources plus
 ordered compute, render, and copy nodes. `compile()` returns a `CompiledGPUCommandGraph` that owns
 transient resources and node state but borrows every import.
+
+This example composes reduction, histogram, and grid-binning nodes in one reusable graph:
+
+<GPUDataAnalysisExample embedded />
 
 ```ts
 const graph = new GPUCommandGraph<{time: number}>(device, {id: 'simulation'});

--- a/docs/api-reference/experimental/gpu-primitives/gpu-sort.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-sort.md
@@ -1,4 +1,5 @@
 import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+import {GPUSortExample} from '@site/src/examples';
 
 # GPUSort
 
@@ -6,6 +7,10 @@ import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-do
 
 `GPUSort` adds a stable, out-of-place key/value sort to a `GPUCommandGraph`. It sorts paired
 packed `uint32` graph views without submitting commands or reading results back to the CPU.
+
+The live example exposes dataset size, algorithm selection, sort direction, graph statistics, and result validation:
+
+<GPUSortExample embedded />
 
 ```ts
 import {GPUCommandGraph, GPUSort} from '@luma.gl/experimental';

--- a/docs/api-reference/shadertools/shader-modules/fp64.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64.md
@@ -1,4 +1,5 @@
 import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
+import {FP64Example} from '@site/src/examples';
 
 # fp64 (64-bit Floating Point)
 
@@ -18,6 +19,10 @@ Provides basic 64-bit math support in GPU shaders:
 | vec2 `sin_fp64`(vec2 a)         |             |
 | vec2 `cos_fp64`(vec2 a)         |             |
 | vec2 `tan_fp64`(vec2 a)         |             |
+
+The side-by-side Mandelbrot views show where fp32 loses detail as the animated zoom deepens:
+
+<FP64Example embedded />
 
 ## Precision
 

--- a/examples/api/texture-tester/app.tsx
+++ b/examples/api/texture-tester/app.tsx
@@ -16,6 +16,7 @@ import {CompressedTexture, createModel} from './components/compressed-texture';
 export type DeviceType = 'webgl' | 'webgpu';
 
 type AppProps = {
+  compact?: boolean;
   deviceType?: DeviceType;
   device?: Device | null;
   presentationDevice?: Device | null;
@@ -133,14 +134,15 @@ export default class App extends React.PureComponent<AppProps, AppState> {
 
   render() {
     const {device, model, initializationError} = this.state;
+    const {compact = false} = this.props;
     return (
-      <div>
+      <div className={compact ? 'texture-tester-compact' : undefined}>
         {initializationError ? <div>{initializationError}</div> : null}
         {!initializationError && !device ? <div>Initializing device...</div> : null}
         {device && model ? (
           <>
-            <TexturesBlocks device={device} model={model} />
-            <TextureUploaderCard device={device} model={model} />
+            <TexturesBlocks compact={compact} device={device} model={model} />
+            {!compact ? <TextureUploaderCard device={device} model={model} /> : null}
           </>
         ) : null}
       </div>
@@ -232,18 +234,39 @@ class TextureUploaderCard extends React.PureComponent<
   }
 }
 
-function TexturesBlocks(props: {device: Device; model: Model}) {
-  const {device, model} = props;
+const COMPACT_TEXTURE_SOURCES = new Set([
+  'kodim20.basis',
+  'kodim23.ktx2',
+  'shannon-dxt5.dds',
+  'shannon-astc-4x4.pvr',
+  'shannon-etc1.pvr'
+]);
 
-  return IMAGES_DATA.map((imagesData, index) => {
-    return (
-      <div key={index}>
-        <TexturesHeader imagesData={imagesData} />
-        <TexturesDescription imagesData={imagesData} />
-        <TexturesList device={device} model={model} images={imagesData.images} />
-      </div>
-    );
-  });
+function TexturesBlocks(props: {compact: boolean; device: Device; model: Model}) {
+  const {compact, device, model} = props;
+  const imageGroups = compact
+    ? IMAGES_DATA.map(imagesData => ({
+        ...imagesData,
+        images: imagesData.images.filter(image => COMPACT_TEXTURE_SOURCES.has(image.src))
+      })).filter(imagesData => imagesData.images.length > 0)
+    : IMAGES_DATA;
+
+  return (
+    <div className={compact ? 'texture-format-grid' : undefined}>
+      {imageGroups.map(imagesData => (
+        <section key={imagesData.formatName}>
+          <TexturesHeader imagesData={imagesData} />
+          <TexturesDescription imagesData={imagesData} />
+          <TexturesList
+            compact={compact}
+            device={device}
+            model={model}
+            images={imagesData.images}
+          />
+        </section>
+      ))}
+    </div>
+  );
 }
 
 function TexturesHeader(props: {imagesData: TextureFormatsInfo}) {
@@ -292,12 +315,23 @@ function TexturesDescription(props: {imagesData: TextureFormatsInfo}) {
   );
 }
 
-function TexturesList(props: {device: Device; model: Model; images: TextureFormatsInfo['images']}) {
-  const {device, model, images} = props;
+function TexturesList(props: {
+  compact?: boolean;
+  device: Device;
+  model: Model;
+  images: TextureFormatsInfo['images'];
+}) {
+  const {compact = false, device, model, images} = props;
   return (
     <div style={{display: 'flex', flexWrap: 'wrap', alignItems: 'flex-start'}}>
       {images.map((image, index) => (
-        <CompressedTexture key={index} image={image} device={device} model={model} />
+        <CompressedTexture
+          key={index}
+          image={image}
+          device={device}
+          model={model}
+          size={compact ? 192 : undefined}
+        />
       ))}
     </div>
   );

--- a/examples/api/texture-tester/components/compressed-texture.tsx
+++ b/examples/api/texture-tester/components/compressed-texture.tsx
@@ -128,6 +128,7 @@ type CompressedTextureProps = {
   device: Device;
   image: TextureSource;
   model: Model;
+  size?: number;
 };
 
 type TextureStat = {
@@ -721,6 +722,7 @@ export class CompressedTexture extends React.PureComponent<
 
   render() {
     const {isReady, textureError, textureFormatLabel} = this.state;
+    const size = this.props.size ?? 256;
     const textureLabel = this.getTextureLabel();
 
     return (
@@ -731,8 +733,8 @@ export class CompressedTexture extends React.PureComponent<
           alignItems: 'flex-start',
           justifyContent: 'flex-start',
           verticalAlign: 'top',
-          height: 256,
-          width: 256,
+          height: size,
+          width: size,
           border: '1px solid black',
           margin: '1em',
           position: 'relative',

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -1106,6 +1106,58 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   width: 100%;
 }
 
+.markdown .docs-embedded-example {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  box-sizing: border-box;
+  margin: 1rem 0 2rem;
+  overflow: hidden;
+  width: 100%;
+}
+
+.markdown .docs-embedded-example--content {
+  overflow: visible;
+}
+
+.markdown .texture-tester-embedded-header {
+  align-items: flex-start;
+  background: var(--ifm-background-surface-color);
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 1rem;
+}
+
+.markdown .texture-tester-compact {
+  padding: 1rem;
+}
+
+.markdown .texture-tester-compact .texture-format-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(206px, 1fr));
+}
+
+.markdown .texture-tester-compact .texture-format-grid > section {
+  min-width: 0;
+}
+
+.markdown .texture-tester-compact .texture-format-grid h2 {
+  font-size: 1rem;
+  line-height: 1.35;
+  margin-top: 0;
+}
+
+@media screen and (max-width: 640px) {
+  .markdown .docs-embedded-example {
+    border-radius: 8px;
+    margin-left: calc(-1 * var(--ifm-spacing-horizontal));
+    width: calc(100% + 2 * var(--ifm-spacing-horizontal));
+  }
+}
+
 @media screen and (max-width: 996px) {
   body:has(.luma-example-page) .theme-doc-sidebar-container {
     display: none;

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -8,6 +8,7 @@ import {
   InfoBox,
   LumaExample,
   ReactExample,
+  type ExampleDisplayProps,
   useStore
 } from './react-luma';
 
@@ -92,6 +93,13 @@ import {createArrowPolygonLayerDeck} from '../../examples/deck/arrow-polygon-lay
 import {createArrowTextLayerDeck} from '../../examples/deck/arrow-text-layer/app';
 
 const exampleConfig = {};
+
+type WebsiteExampleProps = ExampleDisplayProps & {
+  panel?: boolean;
+  showHeader?: boolean;
+  showStats?: boolean;
+  templateInfoPlacement?: 'header' | 'page';
+};
 
 type DeckExampleHandle = {
   finalize: () => void;
@@ -758,7 +766,7 @@ export const GPGPUExample: React.FC = () => {
 };
 
 /** Docusaurus wrapper for the graph-native paired GPU sort example. */
-export const GPUSortExample: React.FC = () => {
+export const GPUSortExample: React.FC<WebsiteExampleProps> = ({embeddedHeight, ...props}) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
@@ -776,7 +784,11 @@ export const GPUSortExample: React.FC = () => {
   }, []);
 
   return (
-    <ExamplePage style={{background: '#f7f8fb', overflow: 'hidden'}}>
+    <ExamplePage
+      {...props}
+      embeddedHeight={embeddedHeight ?? (props.embedded ? 720 : undefined)}
+      style={{background: '#f7f8fb', overflow: 'auto', ...props.style}}
+    >
       <main id="gpu-sort-app" />
       {errorMessage ? (
         <p role="alert" style={{padding: 22}}>
@@ -788,7 +800,10 @@ export const GPUSortExample: React.FC = () => {
 };
 
 /** Docusaurus wrapper for the graph-native data-analysis example. */
-export const GPUDataAnalysisExample: React.FC = () => {
+export const GPUDataAnalysisExample: React.FC<WebsiteExampleProps> = ({
+  embeddedHeight,
+  ...props
+}) => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
@@ -803,7 +818,11 @@ export const GPUDataAnalysisExample: React.FC = () => {
   }, []);
 
   return (
-    <ExamplePage style={{background: '#f6f8fb', overflow: 'hidden'}}>
+    <ExamplePage
+      {...props}
+      embeddedHeight={embeddedHeight ?? (props.embedded ? 720 : undefined)}
+      style={{background: '#f6f8fb', overflow: 'auto', ...props.style}}
+    >
       <main id="gpu-data-analysis-app" />
       {errorMessage ? (
         <p role="alert" style={{padding: 22}}>
@@ -850,7 +869,7 @@ export const PersistenceExample: React.FC = props => (
   />
 );
 
-export const PostprocessingExample: React.FC = props => (
+export const PostprocessingExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample
     id="postprocessing"
     directory="showcase"
@@ -894,7 +913,7 @@ export const AdvancedEffectsExample: React.FC = props => (
   />
 );
 
-export const OITExample: React.FC = props => (
+export const OITExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample
     id="a-buffer"
     title="Order-independent Transparency"
@@ -917,7 +936,7 @@ export const BloomExample: React.FC = props => (
   />
 );
 
-export const VideoTextureExample: React.FC = props => {
+export const VideoTextureExample: React.FC<WebsiteExampleProps> = props => {
   const [cameraStatus, setCameraStatus] = useState<'idle' | 'pending' | 'live' | 'error'>('idle');
   const [cameraError, setCameraError] = useState<string | null>(null);
   const [isCameraBlocked, setIsCameraBlocked] = useState(false);
@@ -1164,7 +1183,7 @@ export const AnimationExample: React.FC = props => (
   />
 );
 
-export const CubemapExample: React.FC = props => (
+export const CubemapExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample
     id="cubemap"
     title="Texture Cube"
@@ -1196,7 +1215,7 @@ export const MultiCanvasExample: React.FC = () => {
   );
 };
 
-export const FP64Example: React.FC = () => {
+export const FP64Example: React.FC<WebsiteExampleProps> = ({embeddedHeight, ...props}) => {
   const deviceType = useStore(store => store.deviceType);
   const presentationDevice = useStore(store => store.presentationDevice);
   const presentationDeviceError = useStore(store => store.presentationDeviceError);
@@ -1206,15 +1225,25 @@ export const FP64Example: React.FC = () => {
   }
 
   return deviceType && presentationDevice ? (
-    <ReactExample component={FP64App} componentProps={{presentationDevice}} showStats={false} />
+    <ReactExample
+      {...props}
+      component={FP64App}
+      componentProps={{presentationDevice}}
+      embeddedHeight={embeddedHeight ?? (props.embedded ? 720 : undefined)}
+      showStats={false}
+      style={{overflow: 'auto', ...props.style}}
+    />
   ) : (
-    <ExamplePage>
+    <ExamplePage
+      {...props}
+      embeddedHeight={embeddedHeight ?? (props.embedded ? 720 : undefined)}
+    >
       <div>Initializing device...</div>
     </ExamplePage>
   );
 };
 
-export const Texture3DExample: React.FC = props => (
+export const Texture3DExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample
     id="texture-3d"
     directory="api-3d"
@@ -1225,24 +1254,47 @@ export const Texture3DExample: React.FC = props => (
   />
 );
 
-export const TextureTesterExample: React.FC = () => {
+export const TextureTesterExample: React.FC<WebsiteExampleProps> = ({
+  embeddedHeight,
+  ...props
+}) => {
   const deviceType = useStore(store => store.deviceType);
   const presentationDevice = useStore(store => store.presentationDevice);
   const presentationDeviceError = useStore(store => store.presentationDeviceError);
 
   return (
     <ExamplePage
+      {...props}
+      className={
+        props.className ||
+        (props.embedded ? 'docs-embedded-example docs-embedded-example--content' : undefined)
+      }
+      embeddedHeight={embeddedHeight ?? (props.embedded ? 'auto' : undefined)}
       style={{
         width: '100%',
-        height: '100%',
-        overflowY: 'auto',
-        overflowX: 'hidden'
+        height: props.embedded ? 'auto' : '100%',
+        overflowX: 'hidden',
+        overflowY: props.embedded ? 'visible' : 'auto',
+        ...props.style
       }}
     >
+      {props.embedded ? (
+        <div className="texture-tester-embedded-header">
+          <div>
+            <strong>Compressed texture support on this device</strong>
+            <div>Hover a preview for upload, format, and memory details.</div>
+          </div>
+          <DeviceTabs
+            devices={['webgpu', 'webgl2']}
+            style={{maxWidth: '100%', overflowX: 'auto'}}
+          />
+        </div>
+      ) : null}
       {presentationDeviceError ? (
         <div>{presentationDeviceError}</div>
       ) : deviceType && presentationDevice ? (
         <TextureTesterApp
+          compact={props.embedded}
           deviceType={getExampleDeviceType(presentationDevice)}
           presentationDevice={presentationDevice}
         />
@@ -1253,9 +1305,8 @@ export const TextureTesterExample: React.FC = () => {
   );
 };
 
-export const RenderBundlesExample: React.FC<{embedded?: boolean}> = ({embedded = false}) => (
+export const RenderBundlesExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample
-    className={embedded ? 'render-bundles-embedded-example' : undefined}
     id="render-bundles"
     title="Render Bundles"
     directory="api"
@@ -1263,18 +1314,7 @@ export const RenderBundlesExample: React.FC<{embedded?: boolean}> = ({embedded =
     config={exampleConfig}
     devices={['webgpu']}
     showStats
-    style={
-      embedded
-        ? {
-            boxSizing: 'border-box',
-            height: '560px',
-            minHeight: '560px',
-            margin: '1rem 0 2rem',
-            border: '1px solid var(--ifm-color-emphasis-300)',
-            borderRadius: '8px'
-          }
-        : undefined
-    }
+    {...props}
   />
 );
 

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -42,8 +42,15 @@ const STYLES = {
   }
 };
 
-type LumaExampleProps = React.PropsWithChildren<{
+export type ExampleDisplayProps = {
   className?: string;
+  embedded?: boolean;
+  embeddedHeight?: CSSProperties['height'];
+  style?: CSSProperties;
+};
+
+export type LumaExampleProps = React.PropsWithChildren<
+  ExampleDisplayProps & {
   id?: string;
   title?: string;
   template: Function;
@@ -53,7 +60,6 @@ type LumaExampleProps = React.PropsWithChildren<{
   sourceFiles?: string[];
   sourcePath?: string;
   stackBlitz?: boolean;
-  style?: CSSProperties;
   container?: string;
   panel?: boolean;
   showHeader?: boolean;
@@ -61,7 +67,8 @@ type LumaExampleProps = React.PropsWithChildren<{
   devices?: DeviceTabSelection[];
   templateInfoPlacement?: 'header' | 'page';
   headerControls?: React.ReactNode;
-}>;
+  }
+>;
 
 const defaultProps = {
   name: 'luma-example'
@@ -100,10 +107,7 @@ const EXAMPLE_HEADER_STYLE: CSSProperties = {
   pointerEvents: 'none'
 };
 
-type ExamplePageProps = React.PropsWithChildren<{
-  className?: string;
-  style?: CSSProperties;
-}>;
+export type ExamplePageProps = React.PropsWithChildren<ExampleDisplayProps>;
 
 type ExampleHeaderProps = React.PropsWithChildren<
   ExampleInfoProps & {
@@ -115,16 +119,24 @@ type ExampleHeaderProps = React.PropsWithChildren<
 type ReactExampleProps<P> = {
   component: React.ComponentType<P>;
   componentProps: P;
-  className?: string;
-  style?: CSSProperties;
   showStats?: boolean;
-};
+} & ExampleDisplayProps;
 
 export const ExamplePage: FC<ExamplePageProps> = (props: ExamplePageProps) => {
+  const embeddedHeight = props.embeddedHeight ?? 560;
+  const embeddedStyle: CSSProperties | undefined = props.embedded
+    ? {
+        height: embeddedHeight,
+        minHeight: embeddedHeight === 'auto' ? 0 : embeddedHeight
+      }
+    : undefined;
+
   return (
     <div
-      className={props.className || 'luma-example-page'}
-      style={{...EXAMPLE_CONTAINER_STYLE, ...props.style}}
+      className={
+        props.className || (props.embedded ? 'docs-embedded-example' : 'luma-example-page')
+      }
+      style={{...EXAMPLE_CONTAINER_STYLE, ...embeddedStyle, ...props.style}}
     >
       {props.children}
     </div>
@@ -146,7 +158,10 @@ export const ExampleHeader: FC<ExampleHeaderProps> = (props: ExampleHeaderProps)
       >
         {props.children}
       </InfoBox>
-      <DeviceTabs devices={props.devices} style={{flexShrink: 0, pointerEvents: 'auto'}} />
+      <DeviceTabs
+        devices={props.devices}
+        style={{flexShrink: 1, maxWidth: '100%', overflowX: 'auto', pointerEvents: 'auto'}}
+      />
     </div>
   );
 };
@@ -155,7 +170,12 @@ export function ReactExample<P>(props: ReactExampleProps<P>) {
   const Component = props.component;
 
   return (
-    <ExamplePage className={props.className} style={props.style}>
+    <ExamplePage
+      className={props.className}
+      embedded={props.embedded}
+      embeddedHeight={props.embeddedHeight}
+      style={props.style}
+    >
       {props.showStats !== false ? <ExampleStats /> : null}
       <Component {...props.componentProps} />
     </ExamplePage>
@@ -314,6 +334,8 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
   return (
     <ExamplePage
       className={props.className}
+      embedded={props.embedded}
+      embeddedHeight={props.embeddedHeight}
       style={{
         overflow: 'hidden',
         ...props.style

--- a/website/src/react-luma/index.ts
+++ b/website/src/react-luma/index.ts
@@ -22,6 +22,11 @@ export {
 // Examples
 export {ExamplePage} from './components/luma-example';
 export {ExampleHeader} from './components/luma-example';
+export type {
+  ExampleDisplayProps,
+  ExamplePageProps,
+  LumaExampleProps
+} from './components/luma-example';
 export {ExampleStats} from './components/example-stats';
 export {InfoBox} from './components/info-box';
 export {LumaExample} from './components/luma-example';


### PR DESCRIPTION
## Goals

- Bring more of luma.gl's interactive examples directly into the documentation pages that explain their APIs.
- Keep embedded examples responsive and contained without changing their full-page routes.
- Add a compact compressed-texture capability sampler that is useful inline without loading the entire texture catalog.

## Changes

- Add shared `embedded` and `embeddedHeight` presentation support to `ExamplePage`, `LumaExample`, and `ReactExample`, including responsive backend controls and content-sized embeds.
- Embed Postprocessing, Video Texture, GPU Sort, GPU Data Analysis, OIT, FP64, Cube Texture, and 3D Texture examples in their relevant guides and API references.
- Add a compact Texture Tester mode with representative Basis/KTX2, BC/DXT, ASTC, and ETC previews, per-device support feedback, and no uploader or full catalog.
- Migrate the Render Bundles documentation example to the shared embedded presentation.

## Verification

- `nvm use` — passed with Node v22.22.1.
- `yarn install` — passed after unsetting the injected `YARN_NO_PROXY` variable, which Yarn 4 otherwise interprets as the removed `noProxy` setting.
- `yarn lint fix` — passed; no final formatting changes required.
- `yarn build` — passed after the final rebase.
- `yarn test` — passed after the final rebase: 48 Node test files passed with 167 tests passed and 2 skipped; 234 headless test files passed with 1,247 tests passed and 25 skipped.
- `yarn website:build` — passed after the final rebase.
- `(cd website && yarn build)` — passed after the final rebase.
- `yarn workspace website-docusaurus check` — passed; all 466 MDX files compiled.
- Browser QA — passed on desktop and 390px mobile layouts across all nine embedded pages. Verified sidebar/footer retention, responsive backend controls, GPU Sort interaction and validation, compressed-texture success/unsupported states, clean navigation, and unchanged full-page example routes.

## Risks and Follow-ups

- The compact texture sampler uses the existing loaders.gl-hosted sample assets, so network failures appear as per-card errors rather than breaking the page.
- The standalone website TypeScript command still reports the repository's existing cross-workspace example/type baseline errors. The root TypeScript build and both production website builds pass.
- A follow-up wave could embed the glTF, ShaderPlugin filtering, DGGS Global Grids, and MapLibre external-context examples.
