### PR TITLE
docs: Embed more live examples in documentation

### DIFF
--- a/docs/api-reference/arrow/README.mdx
+++ b/docs/api-reference/arrow/README.mdx
@@ -1,4 +1,5 @@
 import {ArrowDocsTabs} from '@site/src/components/docs/arrow-docs-tabs';
+import {ArrowGeoArrowExample} from '@site/src/examples';
 
 # Overview
 
@@ -10,6 +11,8 @@ import {ArrowDocsTabs} from '@site/src/components/docs/arrow-docs-tabs';
 </p>
 
 Apache Arrow utilities for luma.gl.
+
+<ArrowGeoArrowExample embedded showStats={false} />
 
 ## API Reference
 

--- a/docs/api-reference/core/canvas-context.md
+++ b/docs/api-reference/core/canvas-context.md
@@ -1,4 +1,6 @@
 import {CoreDocsTabs} from '@site/src/components/docs/core-docs-tabs';
+import {DeviceTabs} from '@site/src/react-luma';
+import {MultiCanvasExample} from '@site/src/examples';
 
 # CanvasContext
 
@@ -83,6 +85,15 @@ const renderPass = device.beginRenderPass({
   framebuffer: device.getDefaultCanvasContext().getFramebuffer()
 });
 ```
+
+### Multiple presentation contexts
+
+A single device can present into multiple canvases. On WebGPU each canvas is backed by its own
+presentation context. On WebGL the shared device renders through an `OffscreenCanvas` before
+presenting into the visible canvases.
+
+<DeviceTabs />
+<MultiCanvasExample embedded embeddedHeight="auto" showStats={false} />
 
 ### Additional canvas contexts
 

--- a/docs/api-reference/engine/animation/timeline.md
+++ b/docs/api-reference/engine/animation/timeline.md
@@ -1,10 +1,13 @@
 import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+import {AnimationExample} from '@site/src/examples';
 
 # Timeline
 
 <EngineDocsTabs group="animation" active="timeline" />
 
 Manages an animation timeline, with multiple channels that can be running at different rates, durations, etc. Many methods (`play`, `pause`) assume that the `update` method is being called once per frame with a "global time". This automatically done for `AnimationLoop.timeline` object.
+
+<AnimationExample embedded showStats={false} />
 
 ## Parallel Times
 

--- a/docs/api-reference/engine/passes/shader-pass-renderer.md
+++ b/docs/api-reference/engine/passes/shader-pass-renderer.md
@@ -1,4 +1,5 @@
 import {EngineDocsTabs} from '@site/src/components/docs/engine-docs-tabs';
+import {BloomExample} from '@site/src/examples';
 
 # ShaderPassRenderer
 
@@ -11,6 +12,8 @@ Internally it uses [`ClipSpace`](/docs/api-reference/engine/clip-space), [`Backg
 For the descriptor types, see
 [`ShaderPass`](/docs/api-reference/shadertools/shader-pass). For the authoring
 model, see [Shader Passes](/docs/api-guide/shaders/shader-passes).
+
+<BloomExample embedded showStats={false} />
 
 ## Usage
 

--- a/docs/api-reference/gltf/README.md
+++ b/docs/api-reference/gltf/README.md
@@ -1,4 +1,5 @@
 import {GltfDocsTabs} from '@site/src/components/docs/gltf-docs-tabs';
+import {GLTFExample} from '@site/src/examples';
 
 # Overview
 
@@ -6,6 +7,8 @@ import {GltfDocsTabs} from '@site/src/components/docs/gltf-docs-tabs';
 
 The `@luma.gl/gltf` modules utilities for turning glTF data into a
 [luma.gl scenegraph](/docs/api-reference/engine/scenegraph/scenegraph-node) .
+
+<GLTFExample embedded showStats={false} />
 
 ## Installing
 

--- a/examples/api/multi-canvas/app.tsx
+++ b/examples/api/multi-canvas/app.tsx
@@ -164,41 +164,36 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     const {initializationError, isReady} = this.state;
 
     return (
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 20,
-          padding: '72px 20px 20px'
-        }}
-      >
+      <div className="multi-canvas-example">
         {initializationError ? (
           <p style={{color: '#b00020', margin: 0}}>{initializationError}</p>
         ) : null}
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-            gridTemplateRows: 'auto auto',
-            gap: 20,
-            alignItems: 'start'
-          }}
-        >
-          <ExamplePaneCopy
+        <div className="multi-canvas-example-grid">
+          <ExamplePane
+            canvasRef={this.canvasRefs[0]}
             description={CONCENTRIC_WAVES_DESCRIPTION}
+            isReady={isReady}
             title={CONCENTRIC_WAVES_TITLE}
           />
-          <ExamplePaneCopy description={ANIMATED_NOISE_DESCRIPTION} title={ANIMATED_NOISE_TITLE} />
-          <ExamplePaneCanvas canvasRef={this.canvasRefs[0]} isReady={isReady} />
-          <ExamplePaneCanvas canvasRef={this.canvasRefs[1]} isReady={isReady} />
+          <ExamplePane
+            canvasRef={this.canvasRefs[1]}
+            description={ANIMATED_NOISE_DESCRIPTION}
+            isReady={isReady}
+            title={ANIMATED_NOISE_TITLE}
+          />
         </div>
       </div>
     );
   }
 }
 
-function ExamplePaneCopy(props: {description: string; title: string}): React.ReactNode {
-  const {description, title} = props;
+function ExamplePane(props: {
+  canvasRef: React.RefObject<HTMLCanvasElement>;
+  description: string;
+  isReady: boolean;
+  title: string;
+}): React.ReactNode {
+  const {canvasRef, description, isReady, title} = props;
 
   return (
     <div
@@ -218,23 +213,6 @@ function ExamplePaneCopy(props: {description: string; title: string}): React.Rea
         <h3 style={{marginTop: 0, marginBottom: 6}}>{title}</h3>
         <p style={{margin: 0, lineHeight: 1.45}}>{description}</p>
       </div>
-    </div>
-  );
-}
-
-function ExamplePaneCanvas(props: {
-  canvasRef: React.RefObject<HTMLCanvasElement>;
-  isReady: boolean;
-}): React.ReactNode {
-  const {canvasRef, isReady} = props;
-
-  return (
-    <div
-      style={{
-        minWidth: 0,
-        width: '100%'
-      }}
-    >
       <canvas
         ref={canvasRef}
         width={CANVAS_WIDTH}

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -1150,11 +1150,33 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   margin-top: 0;
 }
 
+.multi-canvas-example {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 72px 20px 20px;
+}
+
+.multi-canvas-example-grid {
+  align-items: start;
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.markdown .docs-embedded-example .multi-canvas-example {
+  padding: 20px;
+}
+
 @media screen and (max-width: 640px) {
   .markdown .docs-embedded-example {
     border-radius: 8px;
     margin-left: calc(-1 * var(--ifm-spacing-horizontal));
     width: calc(100% + 2 * var(--ifm-spacing-horizontal));
+  }
+
+  .markdown .docs-embedded-example .multi-canvas-example-grid {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -495,7 +495,7 @@ const GPGPU_EXAMPLE_STYLE = `
 
 // Showcase Examples
 
-export const GLTFExample: React.FC = props => (
+export const GLTFExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample
     id="gltf"
     title="glTF"
@@ -598,7 +598,7 @@ export const ArrowFloat64PrecisionExample: React.FC = props => (
   />
 );
 
-export const ArrowGeoArrowExample: React.FC = props => (
+export const ArrowGeoArrowExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample
     id="arrow-geoarrow"
     title="GeoArrow"
@@ -925,7 +925,7 @@ export const OITExample: React.FC<WebsiteExampleProps> = props => (
   />
 );
 
-export const BloomExample: React.FC = props => (
+export const BloomExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample
     id="bloom"
     title="Bloom"
@@ -1172,7 +1172,7 @@ export const ArrowParticlesExample: React.FC = props => (
 
 // API Examples
 
-export const AnimationExample: React.FC = props => (
+export const AnimationExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample
     id="animation"
     directory="api"
@@ -1194,22 +1194,34 @@ export const CubemapExample: React.FC<WebsiteExampleProps> = props => (
   />
 );
 
-export const MultiCanvasExample: React.FC = () => {
+export const MultiCanvasExample: React.FC<WebsiteExampleProps> = props => {
   const deviceType = useStore(store => store.deviceType);
   const presentationDevice = useStore(store => store.presentationDevice);
   const presentationDeviceError = useStore(store => store.presentationDeviceError);
+  const exampleDisplayProps: ExampleDisplayProps = {
+    className: props.className,
+    embedded: props.embedded,
+    embeddedHeight: props.embeddedHeight,
+    style: props.style
+  };
 
   if (presentationDeviceError) {
-    return <div>{presentationDeviceError}</div>;
+    return (
+      <ExamplePage {...exampleDisplayProps}>
+        <div>{presentationDeviceError}</div>
+      </ExamplePage>
+    );
   }
 
   return deviceType && presentationDevice ? (
     <ReactExample
       component={MultiCanvasApp}
       componentProps={{deviceType: getExampleDeviceType(presentationDevice), presentationDevice}}
+      showStats={props.showStats}
+      {...exampleDisplayProps}
     />
   ) : (
-    <ExamplePage>
+    <ExamplePage {...exampleDisplayProps}>
       <div>Initializing device...</div>
     </ExamplePage>
   );


### PR DESCRIPTION
## Goals

- Continue making luma.gl documentation more interactive by placing focused live examples beside the APIs they explain.
- Preserve normal documentation navigation, responsive behavior, and standalone example routes.

## Changes

- Embed the glTF showcase in the `@luma.gl/gltf` overview.
- Embed Bloom in the `ShaderPassRenderer` reference.
- Embed the multi-channel animation example in the `Timeline` reference.
- Embed GeoArrow in the `@luma.gl/arrow` overview.
- Add a multiple-presentation-contexts section and the Multi Canvas example to `CanvasContext`.
- Make the Multi Canvas wrapper use the shared embedded-example API, including content-sized rendering, contained error/loading states, and optional stats.
- Pair each Multi Canvas description with its canvas and add a single-column mobile layout while retaining the standalone route's two-column layout.
- Add explicit embedded-example prop types to the five reused example wrappers.

## Verification

- `nvm use` — passed with Node v22.22.1.
- `yarn install` — passed with the injected `YARN_NO_PROXY` setting removed because Yarn 4 rejects the legacy `noProxy` environment configuration.
- `yarn lint fix` — passed; no formatting changes required.
- `yarn build` — passed.
- `yarn workspace website-docusaurus check` — passed; all 466 MDX files compiled.
- `yarn website:build` — passed.
- `(cd website && yarn build)` — passed.
- Pre-commit `test-fast` — passed: 48 files passed, 2 skipped; 167 tests passed, 2 skipped.
- Desktop and 390 px mobile browser checks covered all five documentation pages, docs sidebar/footer retention, backend switching, asset rendering, overflow containment, and the unchanged standalone Multi Canvas route.
- Full `yarn test` was not run for this documentation-focused change.
- `yarn workspace website-docusaurus lint` could not complete: TypeScript exhausted both 4 GB and 8 GB Node heaps before emitting diagnostics. Production website builds and MDX compilation passed.

## Risks

- These pages now initialize additional GPU examples and local assets when visited.
- Rendering still depends on the browser and selected backend supporting the underlying standalone example.

## Follow-ups

- Consider migrating older tutorial embeds to the shared `embedded` layout in a separate cleanup.
