### PR TITLE
feat(tables,gpgpu): add strided GPUDataView inputs

### DIFF
--- a/docs/api-reference/gpgpu/README.md
+++ b/docs/api-reference/gpgpu/README.md
@@ -101,7 +101,7 @@ registering CPU handlers for another device type.
 
 - [`Operations`](/docs/api-reference/gpgpu/operations) documents the supported lazy compute operations such as `add()`, `interleave()`, and `fround()`.
 - [`Custom Operations`](/docs/api-reference/gpgpu/custom-operation) shows how to define lazy operations and register backend handlers.
-- [`GPU Evaluators`](/docs/api-reference/gpgpu/gpu-data-evaluator) documents `GPUDataEvaluator` for one packed `GPUData` chunk and `GPUVectorEvaluator` for chunk-preserving `GPUVector.data[]` transforms.
+- [`GPU Evaluators`](/docs/api-reference/gpgpu/gpu-data-evaluator) documents `GPUDataEvaluator` for one fixed-width `GPUData` or borrowed strided `GPUDataView`, and `GPUVectorEvaluator` for chunk-preserving `GPUVector.data[]` transforms.
 - [`cleanEvaluate`](/docs/api-reference/gpgpu/clean-evaluate) evaluates final result tables and cleans up intermediate dependencies in one step.
 
 ## Related Engine APIs

--- a/docs/api-reference/gpgpu/gpu-data-evaluator.md
+++ b/docs/api-reference/gpgpu/gpu-data-evaluator.md
@@ -6,11 +6,11 @@ import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
 
 `@luma.gl/gpgpu` has two evaluator layers:
 
-- `GPUDataEvaluator` runs one lazy transform over one packed fixed-width `GPUData` chunk.
+- `GPUDataEvaluator` runs one lazy transform over one fixed-width `GPUData` chunk or `GPUDataView`.
 - `GPUVectorEvaluator` applies one lazy `GPUDataEvaluator` transform independently to every ordered `GPUData` chunk in a `GPUVector`.
 
 There is no `GPUTable` evaluator input path. Streaming code should pass an incoming
-`GPUData` chunk directly to `GPUDataEvaluator` operations, or wrap a `GPUVector`
+`GPUData` chunk or borrowed `GPUDataView` directly to `GPUDataEvaluator` operations, or wrap a `GPUVector`
 with `GPUVectorEvaluator` when the same transform should preserve every existing
 chunk boundary.
 
@@ -45,10 +45,31 @@ const outputVector = await translatedVector.evaluate(device);
 `GPUVectorEvaluator` preserves `vector.data[]` order and chunk boundaries. It does
 not combine streaming batches or pack buffers implicitly.
 
+### Interleaved attribute input
+
+```ts
+import {add} from '@luma.gl/gpgpu';
+import {makeGPUDataViewFromAttribute} from '@luma.gl/tables';
+
+const positions = makeGPUDataViewFromAttribute({
+  buffer: interleavedBuffer,
+  bufferLayout,
+  attributeName: 'positions',
+  length: instanceCount
+});
+
+const translatedPositions = add(positions, [10, 0, 0]);
+const packedOutput = await translatedPositions.evaluate(device);
+```
+
+Input views retain their offset and stride, so multiple attributes may borrow
+the same interleaved buffer. Operation results remain newly materialized packed
+outputs; evaluating into an interleaved destination is not implicit.
+
 ## `GPUDataEvaluator`
 
 `GPUDataEvaluator` describes a 2D row layout backed by CPU values, one borrowed
-`GPUData` chunk, another `GPUDataEvaluator`, or a lazy `Operation` output. Each
+`GPUData` chunk, borrowed `GPUDataView`, another `GPUDataEvaluator`, or a lazy `Operation` output. Each
 row contains `size` scalar elements of the same numeric type.
 
 ### `GPUDataEvaluatorProps`
@@ -62,8 +83,8 @@ row contains `size` scalar elements of the same numeric type.
 | `stride?` | `number` | Byte distance between adjacent rows. Defaults to `ValueType.BYTES_PER_ELEMENT * size`. |
 | `normalized?` | `boolean` | Whether integer values are normalized when exposed as vertex formats. |
 | `value?` | `TypedArray` | CPU-side data for the evaluator. |
-| `buffer?` | `Buffer` | Borrowed GPU buffer backing this evaluator. |
-| `gpuData?` | `GPUData` | Borrowed packed numeric GPUData chunk backing this evaluator. |
+| `buffer?` | `Buffer \| DynamicBuffer` | Borrowed GPU buffer backing this evaluator. |
+| `gpuData?` | `GPUData` | Borrowed fixed-width GPUData chunk backing this evaluator. |
 | `format?` | `GPUVectorFormat` | Optional memory format preserved for GPUVector interop. |
 | `source?` | `Operation \| GPUDataEvaluator \| null` | Lazy source for this evaluator. |
 | `isConstant?` | `boolean` | Whether every row shares the same value. Defaults to `false`. |
@@ -84,9 +105,20 @@ one-element row, and an array becomes a row with `value.length` elements.
 
 #### `GPUDataEvaluator.fromGPUData(data, options?): GPUDataEvaluator`
 
-Creates one evaluator view over a packed fixed-width `GPUData` chunk. The input
-must have a non-`vertex-list` `GPUData.format`, matching `rowByteLength`, and
-packed rows. The evaluator borrows `data.buffer` and does not destroy it.
+Creates one evaluator view over a fixed-width `GPUData` chunk. The input
+must have a fixed-width `GPUData.format` and matching `rowByteLength`. Strided
+rows are preserved. The evaluator borrows `data.buffer` and does not destroy it.
+
+#### `GPUDataEvaluator.fromGPUDataView(view, options?): GPUDataEvaluator`
+
+Creates an evaluator over a borrowed fixed-width `GPUDataView`, preserving its
+format, length, byte offset, and byte stride. Existing operations accept views
+directly through `GPUDataEvaluatorInput`.
+
+CPU, WebGL, and WebGPU support strided 32-bit component formats. Other formats
+remain subject to backend capabilities; unsupported WebGPU storage types fail
+explicitly rather than being repacked. Offsets and strides must be aligned to
+the stored scalar component width.
 
 ### Methods
 
@@ -141,9 +173,10 @@ Releases cached GPU resources owned through child `GPUDataEvaluator` instances.
 
 ## Remarks
 
-- Leaf operations accept `GPUDataEvaluator` or `GPUData`, not `GPUVector`.
+- Leaf operations accept `GPUDataEvaluator`, `GPUData`, or `GPUDataView`, not `GPUVector`.
 - Use `GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(...)` for vector-wide
   transforms that should preserve streaming chunks.
 - `GPUDataEvaluator` operation outputs own their materialized single-chunk
   `GPUVector` backing resource.
 - Borrowed `GPUData` chunks are not destroyed by `GPUDataEvaluator.destroy()`.
+- Borrowed `GPUDataView` buffers are not destroyed by `GPUDataEvaluator.destroy()`.

--- a/docs/api-reference/gpgpu/operations.md
+++ b/docs/api-reference/gpgpu/operations.md
@@ -11,12 +11,15 @@ Each operation returns a new [`GPUDataEvaluator`](/docs/api-reference/gpgpu/gpu-
 ## Common Behavior
 
 - Each operation returns a new `GPUDataEvaluator`.
-- Inputs can be `GPUDataEvaluator` instances or packed numeric `GPUData` chunks.
+- Inputs can be `GPUDataEvaluator` instances, fixed-width `GPUData` chunks, or borrowed
+  `GPUDataView` values, including strided attributes in interleaved buffers.
 - Arithmetic operations can also use scalar literals or literal row values.
 - Multi-input operations deduce output `type`, `length`, and constant-ness from their inputs.
 - Output evaluation is backend-driven through `backendRegistry`.
 - Operations can be chained to build larger compute graphs.
 - Operation result evaluators own their materialized immutable output buffer.
+- Strided inputs do not make outputs strided; operation results are packed unless an operation
+  explicitly documents another layout.
 - Use `GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(...)` to apply the
   same leaf operation independently across preserved `GPUVector.data[]` chunks.
 - The CPU backend is available by default. If no backend has been registered for

--- a/docs/api-reference/tables/gpu-data.mdx
+++ b/docs/api-reference/tables/gpu-data.mdx
@@ -14,6 +14,10 @@ lowest-level storage object in `@luma.gl/tables`: each `GPUData` owns or borrows
 its own `Buffer` or `DynamicBuffer`, and higher-level table objects refer to
 buffers through `GPUData`.
 
+`GPUDataView` is the non-owning physical counterpart: one fixed-width format,
+value count, byte offset, and byte stride over any buffer-like resource. It does
+not carry logical list topology, validity, adapter metadata, or ownership.
+
 ## Usage
 
 ```ts
@@ -32,6 +36,36 @@ When the input starts as Apache Arrow, prefer
 [`makeGPUDataFromArrowData()`](/docs/api-reference/arrow/supported-arrow-types) from
 `@luma.gl/arrow`; it uploads Arrow values into GPU buffers and fills in the
 required format, layout, and readback metadata.
+
+## GPUDataView
+
+```ts
+import {GPUDataView, makeGPUDataViewFromAttribute} from '@luma.gl/tables';
+
+const positions = new GPUDataView({
+  buffer,
+  format: 'float32x3',
+  length: vertexCount,
+  byteOffset: 4,
+  byteStride: 16
+});
+
+const colors = makeGPUDataViewFromAttribute({
+  buffer,
+  bufferLayout,
+  attributeName: 'colors',
+  length: vertexCount
+});
+```
+
+`GPUDataView` derives `elementByteLength` from its fixed-width format and
+`byteLength` from its value count and stride. Construction rejects invalid or
+out-of-bounds ranges. Destroying a view is unnecessary because views never own
+their buffers.
+
+`makeGPUDataViewFromAttribute()` resolves one named attribute from an explicit
+interleaved `BufferLayout`, combines the caller's base and attribute offsets, and
+returns a borrowed strided view without allocating or copying GPU storage.
 
 ## Constructor
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -52,6 +52,7 @@ Target Release Date: Q3, 2026
 **@luma.gl/gpgpu** NEW MODULE
 
 - **`GPUDataEvaluator`** lazy GPUData operations and **`GPUVectorEvaluator`** chunk-preserving GPUVector transforms with CPU/WebGL/WebGPU backends.
+- **Interleaved GPGPU inputs** - Borrowed `GPUDataView` values expose fixed-width strided attributes over shared buffers, allowing existing lazy operations to read interleaved data while continuing to produce packed outputs.
 
 **@luma.gl/arrow** NEW MODULE
 

--- a/modules/gpgpu/src/index.ts
+++ b/modules/gpgpu/src/index.ts
@@ -7,6 +7,7 @@ export {getGPUDataEvaluator, GPUDataEvaluator} from './operation/gpu-data-evalua
 export type {
   GPUDataEvaluatorEvaluateOptions,
   GPUDataEvaluatorFromGPUDataOptions,
+  GPUDataEvaluatorFromGPUDataViewOptions,
   GPUDataEvaluatorInput,
   GPUDataEvaluatorProps
 } from './operation/gpu-data-evaluator';

--- a/modules/gpgpu/src/operation/gpu-data-evaluator.ts
+++ b/modules/gpgpu/src/operation/gpu-data-evaluator.ts
@@ -13,8 +13,10 @@ import {
 import {DynamicBuffer} from '@luma.gl/engine';
 import {
   GPUData,
+  GPUDataView,
   GPUVector,
   getGPUVectorFormatInfo,
+  isValueListGPUVectorFormat,
   isVertexListGPUVectorFormat,
   type GPUVectorFormat
 } from '@luma.gl/tables';
@@ -45,6 +47,12 @@ export type GPUDataEvaluatorFromGPUDataOptions = {
   id?: string;
 };
 
+/** Options for adapting one existing {@link GPUDataView} into an evaluator. */
+export type GPUDataEvaluatorFromGPUDataViewOptions = {
+  /** Optional debug name used by {@link GPUDataEvaluator.toString}. */
+  id?: string;
+};
+
 /** Properties used to construct one {@link GPUDataEvaluator}. */
 export type GPUDataEvaluatorProps = {
   /** Optional debug name used by {@link GPUDataEvaluator.toString}. */
@@ -66,7 +74,7 @@ export type GPUDataEvaluatorProps = {
   /** CPU buffer that initializes the evaluator, required unless another source is supplied. */
   value?: TypedArray;
   /** External GPU buffer that backs this evaluator and is not owned by it. */
-  buffer?: Buffer;
+  buffer?: Buffer | DynamicBuffer;
   /** External GPUData chunk that backs this evaluator and is not owned by it. */
   gpuData?: GPUData;
   /** Optional memory format preserved for GPUVector interop. */
@@ -203,9 +211,9 @@ export class GPUDataEvaluator {
   }
 
   /**
-   * Creates one evaluator view over an existing packed numeric `GPUData` chunk.
+   * Creates one evaluator view over an existing fixed-width `GPUData` chunk.
    *
-   * @param data - Packed fixed-width `GPUData` chunk to borrow.
+   * @param data - Fixed-width `GPUData` chunk to borrow.
    * @param options - Optional debug metadata for the borrowed chunk.
    * @returns One lazy evaluator that borrows `data.buffer`.
    */
@@ -213,18 +221,36 @@ export class GPUDataEvaluator {
     data: GPUData,
     options: GPUDataEvaluatorFromGPUDataOptions = {}
   ): GPUDataEvaluator {
-    validatePackedNumericGPUData(data);
-    const {type, size} = getGPUDataEvaluatorPropsFromGPUData(data);
-
-    return new GPUDataEvaluator({
-      id: options.id,
-      type,
-      size,
-      offset: data.byteOffset,
-      stride: data.byteStride,
+    validateFixedWidthGPUData(data);
+    const view = new GPUDataView({
+      buffer: data.buffer,
+      format: data.format as VertexFormat,
       length: data.length,
-      gpuData: data,
-      format: data.format
+      byteOffset: data.byteOffset,
+      byteStride: data.byteStride
+    });
+    return new GPUDataEvaluator({
+      ...getGPUDataEvaluatorPropsFromGPUDataView(view),
+      id: options.id,
+      gpuData: data
+    });
+  }
+
+  /**
+   * Creates one evaluator over an existing borrowed fixed-width strided data view.
+   *
+   * @param view - Physical value view to borrow without copying.
+   * @param options - Optional debug metadata for the borrowed view.
+   * @returns One evaluator preserving the view's format, offset, stride, and length.
+   */
+  static fromGPUDataView(
+    view: GPUDataView,
+    options: GPUDataEvaluatorFromGPUDataViewOptions = {}
+  ): GPUDataEvaluator {
+    return new GPUDataEvaluator({
+      ...getGPUDataEvaluatorPropsFromGPUDataView(view),
+      id: options.id,
+      buffer: view.buffer
     });
   }
 
@@ -279,7 +305,8 @@ export class GPUDataEvaluator {
     }
     this.isConstant = isConstant;
     this.length = length;
-    this.byteLength = this.stride * length;
+    const rowByteLength = this.ValueType.BYTES_PER_ELEMENT * this.size;
+    this.byteLength = length === 0 ? 0 : (length - 1) * this.stride + rowByteLength;
     this._value = value;
     this._bufferOwnership =
       source instanceof GPUDataEvaluator || buffer || gpuData ? 'borrowed' : 'owned';
@@ -379,7 +406,7 @@ export class GPUDataEvaluator {
 
   /** Creates a single-chunk `GPUVector` view over a materialized backing buffer. */
   private createGPUVectorView(
-    options: GPUDataEvaluatorEvaluateOptions & {buffer: Buffer}
+    options: GPUDataEvaluatorEvaluateOptions & {buffer: Buffer | DynamicBuffer}
   ): GPUVector {
     const name = options.name ?? this._id ?? 'vector';
     const format =
@@ -468,6 +495,25 @@ export class GPUDataEvaluator {
     return new ValueType(compactBytes.buffer);
   }
 
+  /** Loads the complete backing buffer into the CPU value cache for CPU operation handlers. @internal */
+  async ensureCPUValue(): Promise<TypedArray> {
+    const existingValue = this.value;
+    if (existingValue) {
+      return existingValue;
+    }
+    const bytes = await this.buffer.readAsync(0, this.offset + this.byteLength);
+    if (bytes.byteLength % this.ValueType.BYTES_PER_ELEMENT !== 0) {
+      throw new Error(`${this} backing buffer byte length is not aligned to its scalar type`);
+    }
+    const copiedBytes = bytes.slice();
+    this._value = new this.ValueType(
+      copiedBytes.buffer,
+      copiedBytes.byteOffset,
+      copiedBytes.byteLength / this.ValueType.BYTES_PER_ELEMENT
+    ) as TypedArray;
+    return this._value;
+  }
+
   /** Returns the debug id, source description, or class name. */
   toString(): string {
     return this._id ?? this.source?.toString() ?? this.constructor.name;
@@ -509,13 +555,13 @@ function getRowsFromValue(
   return result;
 }
 
-/** Input accepted by leaf operations that normalize one `GPUData` chunk into an evaluator. */
-export type GPUDataEvaluatorInput = GPUDataEvaluator | GPUData;
+/** Input accepted by leaf operations that normalize one fixed-width value view into an evaluator. */
+export type GPUDataEvaluatorInput = GPUDataEvaluator | GPUData | GPUDataView;
 
 /**
  * Returns one evaluator, adapting `GPUData` inputs when needed.
  *
- * @param input - Existing evaluator or one packed fixed-width `GPUData` chunk.
+ * @param input - Existing evaluator, fixed-width `GPUData`, or borrowed `GPUDataView`.
  * @returns One `GPUDataEvaluator` for leaf GPGPU operations.
  */
 export function getGPUDataEvaluator(input: GPUDataEvaluatorInput): GPUDataEvaluator {
@@ -525,7 +571,10 @@ export function getGPUDataEvaluator(input: GPUDataEvaluatorInput): GPUDataEvalua
   if (input instanceof GPUData) {
     return GPUDataEvaluator.fromGPUData(input);
   }
-  throw new Error('getGPUDataEvaluator() requires GPUDataEvaluator or GPUData');
+  if (input instanceof GPUDataView) {
+    return GPUDataEvaluator.fromGPUDataView(input);
+  }
+  throw new Error('getGPUDataEvaluator() requires GPUDataEvaluator, GPUData, or GPUDataView');
 }
 
 /**
@@ -547,12 +596,12 @@ export function getCompatibleGPUDataEvaluatorFormat(
   return input.format === expectedFormat ? input.format : undefined;
 }
 
-function validatePackedNumericGPUData(data: GPUData): void {
+function validateFixedWidthGPUData(data: GPUData): void {
   if (!data.format) {
     throw new Error('GPUDataEvaluator.fromGPUData() requires GPUData format metadata');
   }
-  if (isVertexListGPUVectorFormat(data.format)) {
-    throw new Error('GPUDataEvaluator.fromGPUData() does not support vertex-list input');
+  if (isVertexListGPUVectorFormat(data.format) || isValueListGPUVectorFormat(data.format)) {
+    throw new Error('GPUDataEvaluator.fromGPUData() does not support variable-length input');
   }
   const formatInfo = getGPUVectorFormatInfo(data.format);
   const expectedRowByteLength = formatInfo.byteLength;
@@ -561,20 +610,41 @@ function validatePackedNumericGPUData(data: GPUData): void {
       `GPUDataEvaluator.fromGPUData() requires rowByteLength ${expectedRowByteLength} for GPUData`
     );
   }
-  if (data.byteStride !== data.rowByteLength) {
-    throw new Error('GPUDataEvaluator.fromGPUData() requires packed GPUData');
-  }
 }
 
-function getGPUDataEvaluatorPropsFromGPUData(data: GPUData): {
-  type: SignedDataType;
-  size: number;
-} {
-  if (!data.format) {
-    throw new Error('GPUDataEvaluator.fromGPUData() requires GPUData format metadata');
+function getGPUDataEvaluatorPropsFromGPUDataView(
+  view: GPUDataView
+): Pick<
+  GPUDataEvaluatorProps,
+  'type' | 'size' | 'offset' | 'stride' | 'normalized' | 'length' | 'format'
+> {
+  const formatInfo = getGPUVectorFormatInfo(view.format);
+  const ValueType = getTypedArrayFromDataType(formatInfo.signedDataType);
+  const evaluatorRowByteLength = ValueType.BYTES_PER_ELEMENT * formatInfo.components;
+  if (formatInfo.byteLength !== evaluatorRowByteLength) {
+    throw new Error(
+      `GPUDataEvaluator does not support packed vertex format ${view.format}: ` +
+        `${formatInfo.byteLength} physical bytes cannot expose ${formatInfo.components} ` +
+        `${formatInfo.signedDataType} components`
+    );
   }
-  const formatInfo = getGPUVectorFormatInfo(data.format);
-  return {type: formatInfo.signedDataType, size: formatInfo.components};
+  if (
+    view.byteOffset % ValueType.BYTES_PER_ELEMENT !== 0 ||
+    view.byteStride % ValueType.BYTES_PER_ELEMENT !== 0
+  ) {
+    throw new Error(
+      `GPUDataEvaluator requires ${view.format} offset and stride aligned to ${ValueType.BYTES_PER_ELEMENT} bytes`
+    );
+  }
+  return {
+    type: formatInfo.signedDataType,
+    size: formatInfo.components,
+    offset: view.byteOffset,
+    stride: view.byteStride,
+    normalized: formatInfo.normalized,
+    length: view.length,
+    format: view.format
+  };
 }
 
 /** Returns the concrete Buffer for a GPUVector, unwrapping DynamicBuffer when needed. */

--- a/modules/gpgpu/src/operation/operation.ts
+++ b/modules/gpgpu/src/operation/operation.ts
@@ -57,6 +57,11 @@ export abstract class Operation<InputsT extends Record<string, any> = Record<str
       await dep.evaluate(device);
     }
     const handlerRegistry = this.shouldExecuteOnCPU() ? 'cpu' : device.type;
+    if (handlerRegistry === 'cpu' || device.type === 'null') {
+      for (const dependency of this.dependencies) {
+        await dependency.ensureCPUValue();
+      }
+    }
     const handler = await backendRegistry.get(handlerRegistry, this.name);
     return handler({
       device: target.device,

--- a/modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts
+++ b/modules/gpgpu/test/gpu-vector/gpu-data-evaluator.node.spec.ts
@@ -68,7 +68,7 @@ test('GPUDataEvaluator.fromGPUData accepts packed Float16 chunks', () => {
   device.destroy();
 });
 
-test('GPUDataEvaluator.fromGPUData validates packed numeric chunks', () => {
+test('GPUDataEvaluator.fromGPUData validates fixed-width chunks and preserves strides', () => {
   const device = new NullDevice({});
   const mismatchedRowByteLength = makeUint16Vector(device, 'bad-row-byte-length', [0, 0, 0, 0], 4, {
     format: 'float16x4',
@@ -84,8 +84,11 @@ test('GPUDataEvaluator.fromGPUData validates packed numeric chunks', () => {
   expect(() => GPUDataEvaluator.fromGPUData(mismatchedRowByteLength.data[0])).toThrow(
     /requires rowByteLength 8/
   );
-  expect(() => GPUDataEvaluator.fromGPUData(unpacked.data[0])).toThrow(/requires packed GPUData/);
+  const stridedEvaluator = GPUDataEvaluator.fromGPUData(unpacked.data[0]);
+  expect(stridedEvaluator.stride).toBe(12);
+  expect(stridedEvaluator.byteLength).toBe(8);
 
+  stridedEvaluator.destroy();
   mismatchedRowByteLength.destroy();
   unpacked.destroy();
   device.destroy();

--- a/modules/gpgpu/test/operations/gpu-data-view.node.spec.ts
+++ b/modules/gpgpu/test/operations/gpu-data-view.node.spec.ts
@@ -1,0 +1,80 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {expect, test} from 'vitest';
+import {Buffer} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import {add, backendRegistry, GPUDataEvaluator} from '@luma.gl/gpgpu';
+import * as cpuBackend from '@luma.gl/gpgpu/operations/cpu';
+import {GPUData, GPUDataView} from '@luma.gl/tables';
+import {NullDevice} from '@luma.gl/test-utils';
+
+backendRegistry.add('null', cpuBackend);
+
+test('GPUDataEvaluator rejects packed vertex formats', () => {
+  const device = new NullDevice({});
+  const buffer = device.createBuffer({byteLength: 4});
+  const view = new GPUDataView({
+    buffer,
+    format: 'unorm10-10-10-2',
+    length: 1
+  });
+
+  expect(() => GPUDataEvaluator.fromGPUDataView(view)).toThrow(
+    /does not support packed vertex format unorm10-10-10-2/
+  );
+
+  buffer.destroy();
+  device.destroy();
+});
+
+test('GPUDataEvaluator preserves GPUDataView and DynamicBuffer strided layouts', async () => {
+  const device = new NullDevice({});
+  const source = new Float32Array([1, 2, 99, 3, 4, 99]);
+  const dynamicBuffer = new DynamicBuffer(device, {
+    data: source,
+    usage: Buffer.VERTEX | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  const view = new GPUDataView({
+    buffer: dynamicBuffer,
+    format: 'float32x2',
+    length: 2,
+    byteStride: 12
+  });
+  const viewEvaluator = GPUDataEvaluator.fromGPUDataView(view);
+  const dataEvaluator = GPUDataEvaluator.fromGPUData(
+    new GPUData({
+      buffer: dynamicBuffer,
+      format: 'float32x2',
+      length: 2,
+      byteStride: 12,
+      rowByteLength: 8
+    })
+  );
+  const misalignedView = new GPUDataView({
+    buffer: dynamicBuffer,
+    format: 'float32',
+    length: 1,
+    byteOffset: 2
+  });
+
+  expect(Array.from(await viewEvaluator.readValue())).toEqual([1, 2, 3, 4]);
+  expect(Array.from(await dataEvaluator.readValue())).toEqual([1, 2, 3, 4]);
+  expect(() => GPUDataEvaluator.fromGPUDataView(misalignedView)).toThrow(/aligned to 4 bytes/);
+
+  const firstBuffer = dynamicBuffer.buffer;
+  const replacementSource = new Float32Array([5, 6, 99, 7, 8, 99]);
+  dynamicBuffer.resize({byteLength: 32});
+  dynamicBuffer.write(replacementSource);
+  expect(dynamicBuffer.buffer).not.toBe(firstBuffer);
+
+  const result = add(view, 10);
+  await result.evaluate(device);
+  expect(Array.from(await result.readValue())).toEqual([15, 16, 17, 18]);
+
+  viewEvaluator.destroy();
+  dataEvaluator.destroy();
+  result.destroy();
+  dynamicBuffer.destroy();
+});

--- a/modules/gpgpu/test/operations/gpu-data-view.spec.ts
+++ b/modules/gpgpu/test/operations/gpu-data-view.spec.ts
@@ -1,0 +1,155 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {beforeEach, describe, expect, test} from 'vitest';
+import {Buffer, type Device} from '@luma.gl/core';
+import {add, gather} from '@luma.gl/gpgpu';
+import {GPUDataView, makeGPUDataViewFromAttribute} from '@luma.gl/tables';
+import {getTestDevice, verifyTableValue} from './fixtures';
+
+for (const deviceType of ['webgl', 'webgpu'] as const) {
+  describe(`GPGPU#GPUDataView#execute:${deviceType}`, () => {
+    let device: Device | null;
+
+    beforeEach(async () => {
+      device = await getTestDevice(deviceType);
+    });
+
+    test('arithmetic reads two strided views sharing one interleaved buffer', async t => {
+      if (!device) {
+        t.skip(`${deviceType} not available`);
+        return;
+      }
+
+      const source = new Float32Array([1, 2, 10, 20, 3, 4, 30, 40, 5, 6, 50, 60]);
+      const buffer = device.createBuffer({
+        data: source,
+        usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+      });
+      const bufferLayout = {
+        name: 'pairs',
+        byteStride: 16,
+        attributes: [
+          {attribute: 'left', format: 'float32x2' as const, byteOffset: 0},
+          {attribute: 'right', format: 'float32x2' as const, byteOffset: 8}
+        ]
+      };
+      const left = makeGPUDataViewFromAttribute({
+        buffer,
+        bufferLayout,
+        attributeName: 'left',
+        length: 3
+      });
+      const right = makeGPUDataViewFromAttribute({
+        buffer,
+        bufferLayout,
+        attributeName: 'right',
+        length: 3
+      });
+      const result = add(left, right);
+
+      await result.evaluate(device);
+      expect(result.offset).toBe(0);
+      expect(result.stride).toBe(8);
+      expect(result.byteLength).toBe(24);
+      expect(
+        await verifyTableValue(result, {
+          value: [11, 22, 33, 44, 55, 66],
+          type: 'float32',
+          size: 2
+        })
+      ).toBe(null);
+      expect(Array.from(await buffer.readAsync())).toEqual(
+        Array.from(new Uint8Array(source.buffer, source.byteOffset, source.byteLength))
+      );
+
+      result.destroy();
+      buffer.destroy();
+    });
+
+    test('gather reads strided indices and values from one interleaved buffer', async t => {
+      if (!device) {
+        t.skip(`${deviceType} not available`);
+        return;
+      }
+
+      const bytes = new ArrayBuffer(48);
+      const values = [
+        [10, 11],
+        [20, 21],
+        [30, 31],
+        [40, 41]
+      ];
+      const indices = [2, 0, 3, 1];
+      const dataView = new DataView(bytes);
+      for (let rowIndex = 0; rowIndex < values.length; rowIndex++) {
+        const rowByteOffset = rowIndex * 12;
+        dataView.setFloat32(rowByteOffset, values[rowIndex][0], true);
+        dataView.setFloat32(rowByteOffset + 4, values[rowIndex][1], true);
+        dataView.setUint32(rowByteOffset + 8, indices[rowIndex], true);
+      }
+      const buffer = device.createBuffer({
+        data: new Uint8Array(bytes),
+        usage: Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+      });
+      const bufferLayout = {
+        name: 'indexed-values',
+        byteStride: 12,
+        attributes: [
+          {attribute: 'values', format: 'float32x2' as const, byteOffset: 0},
+          {attribute: 'indices', format: 'uint32' as const, byteOffset: 8}
+        ]
+      };
+      const valuesView = makeGPUDataViewFromAttribute({
+        buffer,
+        bufferLayout,
+        attributeName: 'values',
+        length: 4
+      });
+      const indicesView = makeGPUDataViewFromAttribute({
+        buffer,
+        bufferLayout,
+        attributeName: 'indices',
+        length: 4
+      });
+      const result = gather(indicesView, valuesView);
+
+      await result.evaluate(device);
+      expect(
+        await verifyTableValue(result, {
+          value: [30, 31, 10, 11, 40, 41, 20, 21],
+          type: 'float32',
+          size: 2
+        })
+      ).toBe(null);
+
+      result.destroy();
+      buffer.destroy();
+    });
+  });
+}
+
+describe('GPGPU#GPUDataView', () => {
+  test.each([
+    'uint8x2',
+    'unorm8x4'
+  ] as const)('WebGPU reports unsupported %s storage formats', async (format, t) => {
+    const device = await getTestDevice('webgpu');
+    if (!device) {
+      t.skip('webgpu not available');
+      return;
+    }
+
+    const buffer = device.createBuffer({
+      data: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+      usage: Buffer.STORAGE | Buffer.COPY_SRC
+    });
+    const result = add(new GPUDataView({buffer, format, length: 2}), 1);
+
+    await expect(result.evaluate(device)).rejects.toThrow(/only support 32-bit/);
+
+    result.destroy();
+    buffer.destroy();
+  });
+});

--- a/modules/tables/src/index.ts
+++ b/modules/tables/src/index.ts
@@ -12,6 +12,13 @@ export {
   type GPUDataReadbackMetadata
 } from './table/gpu-data';
 export {
+  GPUDataView,
+  makeGPUDataViewFromAttribute,
+  type GPUDataViewBuffer,
+  type GPUDataViewFromAttributeProps,
+  type GPUDataViewProps
+} from './table/gpu-data-view';
+export {
   GPUVector,
   type GPUVectorBufferProps,
   type GPUVectorCreateProps,

--- a/modules/tables/src/table/gpu-data-view.ts
+++ b/modules/tables/src/table/gpu-data-view.ts
@@ -1,0 +1,155 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  vertexFormatDecoder,
+  type Buffer,
+  type BufferLayout,
+  type VertexFormat
+} from '@luma.gl/core';
+import type {DynamicBuffer} from '@luma.gl/engine';
+
+/** Minimal backing resource required by a {@link GPUDataView}. */
+export type GPUDataViewBuffer = {
+  /** Number of addressable bytes in the backing resource. */
+  readonly byteLength: number;
+};
+
+/** Properties for one fixed-width strided view over a GPU buffer-like resource. */
+export type GPUDataViewProps<
+  Format extends VertexFormat = VertexFormat,
+  BufferType extends GPUDataViewBuffer = Buffer | DynamicBuffer
+> = {
+  /** Buffer-like resource containing the values. */
+  buffer: BufferType;
+  /** Canonical fixed-width memory format for one value. */
+  format: Format;
+  /** Number of fixed-width values in the view. */
+  length: number;
+  /** Byte offset of the first value. Defaults to zero. */
+  byteOffset?: number;
+  /** Byte distance between consecutive values. Defaults to the format byte length. */
+  byteStride?: number;
+};
+
+/** Properties for deriving a fixed-width view from one buffer-layout attribute. */
+export type GPUDataViewFromAttributeProps<
+  BufferType extends GPUDataViewBuffer = Buffer | DynamicBuffer
+> = {
+  /** Buffer-like resource described by `bufferLayout`. */
+  buffer: BufferType;
+  /** Layout containing the requested attribute. */
+  bufferLayout: BufferLayout;
+  /** Attribute name to expose as a view. */
+  attributeName: string;
+  /** Number of attribute values in the view. */
+  length: number;
+  /** Additional byte offset applied before the attribute offset. Defaults to zero. */
+  byteOffset?: number;
+};
+
+/**
+ * Borrowed fixed-width strided view over a GPU buffer-like resource.
+ *
+ * A data view describes physical values only. It does not own its backing resource and carries no
+ * logical list topology, validity, or adapter metadata.
+ */
+export class GPUDataView<
+  Format extends VertexFormat = VertexFormat,
+  BufferType extends GPUDataViewBuffer = Buffer | DynamicBuffer
+> {
+  /** Buffer-like resource containing the values. */
+  readonly buffer: BufferType;
+  /** Canonical fixed-width memory format for one value. */
+  readonly format: Format;
+  /** Number of fixed-width values in the view. */
+  readonly length: number;
+  /** Byte offset of the first value. */
+  readonly byteOffset: number;
+  /** Byte distance between consecutive values. */
+  readonly byteStride: number;
+
+  constructor(props: GPUDataViewProps<Format, BufferType>) {
+    const elementByteLength = vertexFormatDecoder.getVertexFormatInfo(props.format).byteLength;
+    const byteOffset = props.byteOffset ?? 0;
+    const byteStride = props.byteStride ?? elementByteLength;
+
+    validateSafeNonNegativeInteger(props.length, 'GPUDataView length');
+    validateSafeNonNegativeInteger(byteOffset, 'GPUDataView byteOffset');
+    validateSafeNonNegativeInteger(byteStride, 'GPUDataView byteStride');
+    if (byteStride < elementByteLength) {
+      throw new Error(
+        `GPUDataView byteStride ${byteStride} is smaller than ${props.format} byte length ${elementByteLength}`
+      );
+    }
+
+    const byteLength = props.length === 0 ? 0 : (props.length - 1) * byteStride + elementByteLength;
+    const endByteOffset = byteOffset + byteLength;
+    if (!Number.isSafeInteger(byteLength) || !Number.isSafeInteger(endByteOffset)) {
+      throw new Error('GPUDataView byte range must use safe integers');
+    }
+    if (endByteOffset > props.buffer.byteLength) {
+      throw new Error('GPUDataView exceeds its backing buffer byte length');
+    }
+
+    this.buffer = props.buffer;
+    this.format = props.format;
+    this.length = props.length;
+    this.byteOffset = byteOffset;
+    this.byteStride = byteStride;
+  }
+
+  /** Number of bytes occupied by one fixed-width value. */
+  get elementByteLength(): number {
+    return vertexFormatDecoder.getVertexFormatInfo(this.format).byteLength;
+  }
+
+  /** Number of bytes from the first value through the final value payload. */
+  get byteLength(): number {
+    return this.length === 0 ? 0 : (this.length - 1) * this.byteStride + this.elementByteLength;
+  }
+}
+
+/**
+ * Creates a borrowed fixed-width view of one attribute in a buffer layout.
+ *
+ * The returned view combines the caller's base offset with the attribute offset and uses the
+ * layout's row stride. No GPU storage is allocated or copied.
+ */
+export function makeGPUDataViewFromAttribute<BufferType extends GPUDataViewBuffer>({
+  buffer,
+  bufferLayout,
+  attributeName,
+  length,
+  byteOffset = 0
+}: GPUDataViewFromAttributeProps<BufferType>): GPUDataView<VertexFormat, BufferType> {
+  const attribute = bufferLayout.attributes?.find(
+    candidate => candidate.attribute === attributeName
+  );
+  if (!attribute) {
+    throw new Error(
+      `Buffer layout "${bufferLayout.name}" does not contain attribute "${attributeName}"`
+    );
+  }
+  if (!attribute.format) {
+    throw new Error(`Buffer layout attribute "${attributeName}" requires a format`);
+  }
+  if (bufferLayout.byteStride === undefined) {
+    throw new Error(`Buffer layout "${bufferLayout.name}" requires byteStride for attribute views`);
+  }
+
+  return new GPUDataView({
+    buffer,
+    format: attribute.format,
+    length,
+    byteOffset: byteOffset + attribute.byteOffset,
+    byteStride: bufferLayout.byteStride
+  });
+}
+
+function validateSafeNonNegativeInteger(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative safe integer`);
+  }
+}

--- a/modules/tables/test/table/gpu-data-view.node.spec.ts
+++ b/modules/tables/test/table/gpu-data-view.node.spec.ts
@@ -1,0 +1,150 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import type {BufferLayout} from '@luma.gl/core';
+import {GPUDataView, makeGPUDataViewFromAttribute} from '@luma.gl/tables';
+import {NullDevice} from '@luma.gl/test-utils';
+
+test('GPUDataView validates and derives packed and strided ranges', t => {
+  const device = new NullDevice({});
+  const buffer = device.createBuffer({byteLength: 64});
+  const packed = new GPUDataView({buffer, format: 'float32x2', length: 3});
+  const strided = new GPUDataView({
+    buffer,
+    format: 'float32x3',
+    length: 2,
+    byteOffset: 4,
+    byteStride: 16
+  });
+  const empty = new GPUDataView({
+    buffer,
+    format: 'uint32',
+    length: 0,
+    byteOffset: buffer.byteLength
+  });
+
+  t.equal(packed.byteStride, 8, 'defaults stride to the format byte length');
+  t.equal(packed.elementByteLength, 8, 'derives the element byte length');
+  t.equal(packed.byteLength, 24, 'derives the packed occupied byte length');
+  t.equal(strided.elementByteLength, 12, 'derives a strided element payload');
+  t.equal(strided.byteLength, 28, 'includes inter-row padding in the occupied byte length');
+  t.equal(empty.byteLength, 0, 'accepts an empty view at the end of the buffer');
+
+  t.throws(
+    () => new GPUDataView({buffer, format: 'uint32', length: -1}),
+    /length must be a non-negative safe integer/,
+    'rejects negative lengths'
+  );
+  t.throws(
+    () => new GPUDataView({buffer, format: 'uint32', length: 1, byteOffset: -1}),
+    /byteOffset must be a non-negative safe integer/,
+    'rejects negative offsets'
+  );
+  t.throws(
+    () => new GPUDataView({buffer, format: 'float32x2', length: 2, byteStride: 4}),
+    /smaller than float32x2 byte length/,
+    'rejects overlapping values'
+  );
+  t.throws(
+    () =>
+      new GPUDataView({
+        buffer,
+        format: 'uint32',
+        length: Number.MAX_SAFE_INTEGER,
+        byteStride: Number.MAX_SAFE_INTEGER
+      }),
+    /byte range must use safe integers/,
+    'rejects unsafe computed ranges'
+  );
+  t.throws(
+    () =>
+      new GPUDataView({
+        buffer,
+        format: 'float32x4',
+        length: 2,
+        byteOffset: 48,
+        byteStride: 16
+      }),
+    /exceeds its backing buffer/,
+    'rejects ranges beyond the backing buffer'
+  );
+
+  buffer.destroy();
+  t.end();
+});
+
+test('makeGPUDataViewFromAttribute exposes borrowed interleaved attributes', t => {
+  const device = new NullDevice({});
+  const buffer = device.createBuffer({byteLength: 40});
+  const bufferLayout: BufferLayout = {
+    name: 'vertices',
+    byteStride: 16,
+    attributes: [
+      {attribute: 'positions', format: 'float32x3', byteOffset: 0},
+      {attribute: 'featureIds', format: 'uint32', byteOffset: 12}
+    ]
+  };
+  const positions = makeGPUDataViewFromAttribute({
+    buffer,
+    bufferLayout,
+    attributeName: 'positions',
+    length: 2,
+    byteOffset: 4
+  });
+  const featureIds = makeGPUDataViewFromAttribute({
+    buffer,
+    bufferLayout,
+    attributeName: 'featureIds',
+    length: 2,
+    byteOffset: 4
+  });
+
+  t.equal(positions.buffer, buffer, 'positions borrow the source buffer');
+  t.equal(featureIds.buffer, buffer, 'feature ids borrow the same source buffer');
+  t.equal(positions.format, 'float32x3', 'preserves the attribute format');
+  t.equal(positions.byteOffset, 4, 'applies the base and attribute offsets');
+  t.equal(featureIds.byteOffset, 16, 'applies the second attribute offset');
+  t.equal(featureIds.byteStride, 16, 'applies the interleaved row stride');
+
+  t.throws(
+    () =>
+      makeGPUDataViewFromAttribute({
+        buffer,
+        bufferLayout,
+        attributeName: 'missing',
+        length: 1
+      }),
+    /does not contain attribute "missing"/,
+    'rejects missing attributes'
+  );
+  t.throws(
+    () =>
+      makeGPUDataViewFromAttribute({
+        buffer,
+        bufferLayout: {...bufferLayout, byteStride: undefined},
+        attributeName: 'positions',
+        length: 1
+      }),
+    /requires byteStride/,
+    'requires an explicit interleaved stride'
+  );
+  t.throws(
+    () =>
+      makeGPUDataViewFromAttribute({
+        buffer,
+        bufferLayout: {
+          ...bufferLayout,
+          attributes: [{attribute: 'positions', byteOffset: 0} as never]
+        },
+        attributeName: 'positions',
+        length: 1
+      }),
+    /requires a format/,
+    'rejects attributes without runtime format metadata'
+  );
+
+  buffer.destroy();
+  t.end();
+});


### PR DESCRIPTION
## Goals

- Introduce a validated, borrowed `GPUDataView` for fixed-width physical buffer ranges.
- Let existing GPGPU operations consume packed, padded, sliced, and interleaved table data without copying.
- Keep operation outputs packed and preserve existing `GPUData` identity and ownership behavior.

## Changes

- Add and export `GPUDataView` plus `makeGPUDataViewFromAttribute()`.
- Validate formats, safe offsets and lengths, strides, and complete occupied ranges against the backing `Buffer` or `DynamicBuffer`.
- Extend `GPUDataEvaluatorInput`, `fromGPUDataView()`, and `getGPUDataEvaluator()` for strided views.
- Remove the packed-only restriction from `fromGPUData()` while retaining the original borrowed `GPUData` chunk.
- Resolve the current `DynamicBuffer` backing buffer during execution and correct occupied-byte calculations.
- Cover interleaved arithmetic and gather inputs on WebGL/WebGPU, CPU/null evaluation, shared buffers, packed outputs, unchanged sources, validation failures, and unsupported WebGPU storage formats.
- Document the tables and GPGPU APIs and add a release-note entry.

## Verification

- `nvm use`
- `yarn install --immutable`
- `yarn lint fix`
- `yarn build`
- Targeted tables and GPGPU node/headless tests
- `yarn test` — 171 node tests passed; 1,263 headless tests passed
- `yarn examples:typecheck`
- `yarn website:build`
- `(cd website && yarn build)`

The website builds retain the repository's existing TypeDoc warnings for unknown `@note` and `@todo` tags.

## Scope

This PR intentionally does not include the `GPUData.values` redesign, command-graph aliasing, `graph.add()`, strided outputs, interleaved packing, or GPUVector attribute projection helpers.