### PR TITLE
feat(examples): add mediabunny video file source to video-texture example

### DIFF
--- a/examples/api/video-texture/app.ts
+++ b/examples/api/video-texture/app.ts
@@ -7,6 +7,7 @@ import {UniformStore} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, CylinderGeometry, Model, VideoTexture} from '@luma.gl/engine';
 import {Matrix4} from '@math.gl/core';
+import {Input, ALL_FORMATS, BlobSource, VideoSampleSink} from 'mediabunny';
 
 export const title = 'Video Texture';
 export const description = 'Wraps a live video texture around a rotating cylinder.';
@@ -23,6 +24,15 @@ type LiveVideoSource = {
   drawFrame: (time: number) => void;
   destroy: () => void;
 };
+
+type MediabunnySource = {
+  input: Input;
+  sink: VideoSampleSink;
+  currentFrame: VideoFrame | null;
+  duration: number;
+};
+
+const VIDEO_URL = 'https://assets.mixkit.co/videos/188/188-720.mp4';
 
 const app: {uniformTypes: Record<keyof AppUniforms, VariableShaderType>} = {
   uniformTypes: {
@@ -151,11 +161,19 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly modelViewProjectionMatrix = new Matrix4();
   readonly viewMatrix = new Matrix4().lookAt({eye: [0, 0.1, 4.4], center: [0, 0, 0]});
   readonly uniformStore: UniformStore<{app: AppUniforms}>;
-  videoSource: LiveVideoSource;
+  videoSource: LiveVideoSource | null;
   readonly videoTexture: VideoTexture;
   readonly model: Model;
   private _isFinalized = false;
   private _videoFlipX = 0;
+  private _mediabunnySource: MediabunnySource | null = null;
+  private _scrubberContainer: HTMLDivElement | null = null;
+  private _scrubber: HTMLInputElement | null = null;
+  private _timeDisplay: HTMLSpanElement | null = null;
+  private _playButton: HTMLButtonElement | null = null;
+  private _seekGeneration = 0;
+  private _playing = false;
+  private _playbackAbort: AbortController | null = null;
 
   constructor({device}: AnimationProps) {
     super();
@@ -198,13 +216,15 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     }
     this.model.destroy();
     this.videoTexture.destroy();
-    this.videoSource.destroy();
+    this._teardownMediabunny();
+    this.videoSource?.destroy();
     this.uniformStore.destroy();
+    this._scrubberContainer?.remove();
   }
 
   onRender({device, aspect, tick}: AnimationProps): void {
     const time = tick * 0.001;
-    this.videoSource.drawFrame(time);
+    this.videoSource?.drawFrame(time);
     this.modelMatrix
       .identity()
       .rotateX(-0.12 + Math.sin(time * 0.9) * 0.08)
@@ -238,11 +258,190 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       return;
     }
 
+    this._teardownMediabunny();
     const previousVideoSource = this.videoSource;
     this.videoSource = cameraVideoSource;
     this.videoTexture.setSource(cameraVideoSource.video);
     this._videoFlipX = 1;
-    previousVideoSource.destroy();
+    previousVideoSource?.destroy();
+    this._hideScrubber();
+  }
+
+  async useMediabunny(): Promise<void> {
+    const response = await fetch(VIDEO_URL);
+    const blob = await response.blob();
+    const input = new Input({
+      formats: ALL_FORMATS,
+      source: new BlobSource(blob)
+    });
+    const videoTrack = await input.getPrimaryVideoTrack();
+    if (!videoTrack) {
+      throw new Error('No video track found in media file');
+    }
+    const sink = new VideoSampleSink(videoTrack);
+    const duration = (await videoTrack.getDurationFromMetadata()) ?? 596;
+
+    if (this._isFinalized) {
+      input.dispose();
+      return;
+    }
+
+    this._teardownMediabunny();
+    this._mediabunnySource = {input, sink, currentFrame: null, duration};
+
+    this.videoSource?.destroy();
+    this.videoSource = null;
+
+    this._videoFlipX = 0;
+    this._showScrubber(duration);
+    await this._seekMediabunny(0);
+  }
+
+  private async _seekMediabunny(timeSeconds: number): Promise<void> {
+    const src = this._mediabunnySource;
+    if (!src) return;
+
+    const generation = ++this._seekGeneration;
+    const sample = await src.sink.getSample(timeSeconds);
+    if (!sample || generation !== this._seekGeneration) {
+      sample?.close();
+      return;
+    }
+
+    const frame = sample.toVideoFrame();
+    sample.close();
+    if (generation !== this._seekGeneration) {
+      frame.close();
+      return;
+    }
+
+    const previousFrame = src.currentFrame;
+    src.currentFrame = frame;
+    this.videoTexture.setSource(frame);
+    previousFrame?.close();
+  }
+
+  private _startPlayback(fromTime = 0): void {
+    this._stopPlayback();
+    const src = this._mediabunnySource;
+    if (!src) return;
+
+    this._playing = true;
+    if (this._playButton) this._playButton.textContent = '⏸';
+    const abort = new AbortController();
+    this._playbackAbort = abort;
+
+    (async () => {
+      let lastFrameTime = performance.now();
+      for await (const sample of src.sink.samples(fromTime)) {
+        if (abort.signal.aborted) {
+          sample.close();
+          break;
+        }
+        const frame = sample.toVideoFrame();
+        const frameDuration = (sample.duration ?? 1 / 30) * 1000;
+        sample.close();
+
+        const elapsed = performance.now() - lastFrameTime;
+        if (elapsed < frameDuration) {
+          await new Promise(r => setTimeout(r, frameDuration - elapsed));
+        }
+        if (abort.signal.aborted) {
+          frame.close();
+          break;
+        }
+
+        lastFrameTime = performance.now();
+        const previousFrame = src.currentFrame;
+        src.currentFrame = frame;
+        this.videoTexture.setSource(frame);
+        previousFrame?.close();
+
+        if (this._scrubber) {
+          this._scrubber.value = String(sample.timestamp);
+          this._updateTimeDisplay(sample.timestamp);
+        }
+      }
+      if (!abort.signal.aborted) {
+        this._playing = false;
+        if (this._playButton) this._playButton.textContent = '▶';
+      }
+    })();
+  }
+
+  private _stopPlayback(): void {
+    this._playbackAbort?.abort();
+    this._playbackAbort = null;
+    this._playing = false;
+    if (this._playButton) this._playButton.textContent = '▶';
+  }
+
+  private _teardownMediabunny(): void {
+    this._stopPlayback();
+    if (this._mediabunnySource) {
+      this._mediabunnySource.currentFrame?.close();
+      this._mediabunnySource.input.dispose();
+      this._mediabunnySource = null;
+    }
+  }
+
+  private _showScrubber(duration: number): void {
+    if (!this._scrubberContainer) {
+      this._scrubberContainer = document.createElement('div');
+      this._scrubberContainer.style.cssText =
+        'position:fixed;bottom:24px;left:50%;transform:translateX(-50%);' +
+        'display:flex;align-items:center;gap:10px;padding:8px 16px;' +
+        'background:rgba(0,0,0,0.75);border-radius:8px;z-index:1000;';
+
+      this._playButton = document.createElement('button');
+      this._playButton.textContent = '▶';
+      this._playButton.style.cssText =
+        'background:none;border:none;color:#fff;font-size:18px;cursor:pointer;padding:0 4px;';
+      this._playButton.addEventListener('click', () => {
+        if (this._playing) {
+          this._stopPlayback();
+        } else {
+          const fromTime = Number(this._scrubber?.value ?? 0);
+          this._startPlayback(fromTime);
+        }
+      });
+
+      this._scrubber = document.createElement('input');
+      this._scrubber.type = 'range';
+      this._scrubber.min = '0';
+      this._scrubber.step = 'any';
+      this._scrubber.style.cssText = 'width:320px;cursor:pointer;';
+      this._scrubber.addEventListener('input', () => {
+        this._stopPlayback();
+        const timeSec = Number(this._scrubber!.value);
+        this._seekMediabunny(timeSec);
+        this._updateTimeDisplay(timeSec);
+      });
+
+      this._timeDisplay = document.createElement('span');
+      this._timeDisplay.style.cssText = 'color:#fff;font:12px monospace;min-width:80px;';
+
+      this._scrubberContainer.append(this._playButton, this._scrubber, this._timeDisplay);
+      document.body.appendChild(this._scrubberContainer);
+    }
+    this._scrubber!.max = String(duration);
+    this._scrubber!.value = '0';
+    this._updateTimeDisplay(0);
+    this._scrubberContainer.style.display = 'flex';
+  }
+
+  private _hideScrubber(): void {
+    if (this._scrubberContainer) {
+      this._scrubberContainer.style.display = 'none';
+    }
+  }
+
+  private _updateTimeDisplay(timeSec: number): void {
+    if (!this._timeDisplay) return;
+    const m = Math.floor(timeSec / 60);
+    const s = Math.floor(timeSec % 60);
+    const ms = Math.floor((timeSec % 1) * 100);
+    this._timeDisplay.textContent = `${m}:${String(s).padStart(2, '0')}.${String(ms).padStart(2, '0')}`;
   }
 }
 

--- a/examples/api/video-texture/index.html
+++ b/examples/api/video-texture/index.html
@@ -9,5 +9,17 @@
     adapters: [webgpuAdapter, webgl2Adapter]
   });
   animationLoop.start();
+
+  document.getElementById('use-mediabunny').addEventListener('click', () => {
+    AnimationLoopTemplate.current?.useMediabunny();
+  });
+  document.getElementById('use-camera').addEventListener('click', () => {
+    AnimationLoopTemplate.current?.useCamera();
+  });
 </script>
-<body></body>
+<body>
+  <div style="position:fixed;top:12px;left:12px;z-index:1000;display:flex;gap:8px;">
+    <button id="use-mediabunny" style="padding:6px 12px;cursor:pointer;">Video File</button>
+    <button id="use-camera" style="padding:6px 12px;cursor:pointer;">Camera</button>
+  </div>
+</body>

--- a/examples/api/video-texture/package.json
+++ b/examples/api/video-texture/package.json
@@ -12,7 +12,8 @@
     "@luma.gl/engine": "~9.3.0",
     "@luma.gl/webgl": "~9.3.0",
     "@luma.gl/webgpu": "~9.3.0",
-    "@math.gl/core": "^4.1.0"
+    "@math.gl/core": "^4.1.0",
+    "mediabunny": "^1.50.8"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6626,6 +6626,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/dom-mediacapture-transform@npm:^0.1.11":
+  version: 0.1.12
+  resolution: "@types/dom-mediacapture-transform@npm:0.1.12"
+  dependencies:
+    "@types/dom-webcodecs": "npm:*"
+  checksum: 10c0/340d31b37dd12c4c145d9cb1e10057376bcbefeb32833bb829a9cea430e04ddc6f5a942479f92ad9f33adb8ee0fe208675cb1f3f1ad501c8e8c50f0a14cd496c
+  languageName: node
+  linkType: hard
+
+"@types/dom-webcodecs@npm:*":
+  version: 0.1.18
+  resolution: "@types/dom-webcodecs@npm:0.1.18"
+  checksum: 10c0/dcf0a36869bddb6ec1534039911bd5517985c03503da6d6cfea4ef26480c763f91b2ef4f03dcc7b3c8a68740efc1ed93b0f63a865823877eb8675f98a772f67d
+  languageName: node
+  linkType: hard
+
+"@types/dom-webcodecs@npm:0.1.13":
+  version: 0.1.13
+  resolution: "@types/dom-webcodecs@npm:0.1.13"
+  checksum: 10c0/16683fd0330fdfbb867affec1c18fd493d88433a4ec66257579adc5d07b07e9492268b4401e9017b7388b13750722365b0392b375e39c84e74f564d5b4f634a4
+  languageName: node
+  linkType: hard
+
 "@types/eslint-scope@npm:^3.7.7":
   version: 3.7.7
   resolution: "@types/eslint-scope@npm:3.7.7"
@@ -15756,6 +15779,7 @@ __metadata:
     "@luma.gl/webgl": "npm:~9.3.0"
     "@luma.gl/webgpu": "npm:~9.3.0"
     "@math.gl/core": "npm:^4.1.0"
+    mediabunny: "npm:^1.50.8"
     typescript: "npm:^5.9.3"
     vite: "npm:^8.0.0"
   languageName: unknown
@@ -17296,6 +17320,16 @@ __metadata:
   version: 0.3.0
   resolution: "media-typer@npm:0.3.0"
   checksum: 10c0/d160f31246907e79fed398470285f21bafb45a62869dc469b1c8877f3f064f5eabc4bcc122f9479b8b605bc5c76187d7871cf84c4ee3ecd3e487da1993279928
+  languageName: node
+  linkType: hard
+
+"mediabunny@npm:^1.50.8":
+  version: 1.50.8
+  resolution: "mediabunny@npm:1.50.8"
+  dependencies:
+    "@types/dom-mediacapture-transform": "npm:^0.1.11"
+    "@types/dom-webcodecs": "npm:0.1.13"
+  checksum: 10c0/8a14a346df1255653f01224db6197e278e91a6b8f46e65fe84968f3f87647650e450154b3f1ab1602c15a6def98d2e673b466d5e218554ff9005dae78d9bdf32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/4d9ab3d7-aa98-49ba-b6e6-46132cb21ed5

#### Background

The VideoTexture PR (#2737) noted that a mediabunny-powered scrubbing example was deferred. This adds it as an alternate source in the existing video-texture example, demonstrating frame-accurate random-access and smooth playback via WebCodecs — the key use case for VideoTexture beyond simple HTMLVideoElement streaming.

#### Change List
- Add mediabunny `BlobSource` + `VideoSampleSink` as a switchable video source alongside the existing procedural and camera sources
- Implement frame-accurate scrubbing with generation-based seek cancellation for responsive slider interaction
- Implement smooth sequential playback using mediabunny's `samples()` async iterator with frame-rate pacing
- Add source-switching buttons ("Video File" / "Camera") and a playback scrubber UI (play/pause + range slider + timecode)
- Manage `VideoFrame` lifecycle correctly — keep current frame open through draw, close only on replacement

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the video-texture example and a new optional dependency; no engine or core library behavior is modified.
> 
> **Overview**
> Adds a **Video File** path to the video-texture example using **mediabunny** (`BlobSource` + `VideoSampleSink`) so `VideoTexture` can be driven by decoded `VideoFrame`s instead of only procedural canvas or camera `HTMLVideoElement` sources.
> 
> `useMediabunny()` fetches a remote MP4, wires frames through `videoTexture.setSource(frame)`, and shows a fixed scrubber UI (play/pause, range slider, timecode). Seeks use a generation counter so stale async samples are dropped; playback walks `sink.samples()` with simple frame pacing and `AbortController` cancellation. Switching to camera tears down mediabunny, closes frames, and hides the scrubber; finalize cleans up DOM and mediabunny state. **index.html** adds **Video File** / **Camera** buttons; **package.json** / lockfile add the `mediabunny` dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d67691a2ffb47058580812593c9af09002507f69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->