### PR TITLE
Add antialiasing guide and example

### DIFF
--- a/docs/api-guide/gpu/README.md
+++ b/docs/api-guide/gpu/README.md
@@ -15,4 +15,5 @@ import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
 - [GPU binding management](/docs/api-guide/gpu/gpu-bindings) - Make attribute buffers, uniforms, textures, samplers available to GPU shaders.
 - [Tabular data in WGSL](/docs/api-guide/gpu/tabular-data-in-wgsl) - Map logical table columns to vertex attributes or WebGPU storage arrays and structs.
 - [Shader execution / rendering](/docs/api-guide/gpu/gpu-rendering) - Drawing into textures, running compute shaders.
+- [Antialiasing and multisampling](/docs/api-guide/gpu/gpu-antialiasing) - Choose between canvas antialiasing, MSAA, supersampling, postprocess AA, and texture filtering.
 - [GPU parameter management](/docs/api-guide/gpu/gpu-parameters) - Configuring blending, clipping, depth tests etc.

--- a/docs/api-guide/gpu/gpu-antialiasing.mdx
+++ b/docs/api-guide/gpu/gpu-antialiasing.mdx
@@ -1,0 +1,262 @@
+import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
+import {AntialiasingExample} from '@site/src/examples';
+
+# Antialiasing and Multisampling
+
+<GpuGuideDocsTabs group="execution" active="antialiasing" />
+
+Aliasing is not one problem with one switch. A jagged triangle edge, a shimmering checkerboard,
+an alpha-cutout leaf, a noisy shadow boundary, and a depth-aware postprocess halo come from
+different sampling problems and need different fixes.
+
+Start by identifying which artifact is aliasing:
+
+| Artifact | First technique to try | Why |
+| --- | --- | --- |
+| Geometry edges on a WebGL canvas | Request `webgl.antialias` | The browser can antialias the default drawing buffer. |
+| Geometry edges in an offscreen pass | MSAA or supersampling | Offscreen color and depth attachments need their own sampling strategy. |
+| A final image with isolated jagged edges | FXAA | A single postprocess pass smooths contrast edges without changing scene rendering. |
+| Motion shimmer or subpixel geometry | TAA | Jitter, history, velocity, and depth accumulate information across frames. |
+| Minified or oblique textures | Mipmaps and anisotropy | Texture filters address texel-frequency aliasing, not polygon coverage. |
+| Alpha-cutout edges | Alpha-to-coverage or analytic coverage | A binary `discard` creates hard coverage edges. |
+| Depth and shadow edges | Matching multisampled depth, depth-aware filtering, or PCF | Visibility and shadow maps alias independently from final color. |
+
+## Where Antialiasing Fits
+
+<style>{`
+  .docs-antialiasing-flow {
+    display: grid;
+    gap: 12px;
+    margin: 18px 0;
+  }
+  .docs-antialiasing-flow__row {
+    align-items: center;
+    display: grid;
+    gap: 8px;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+  .docs-antialiasing-flow__node {
+    background: var(--ifm-color-emphasis-100);
+    border: 1px solid var(--ifm-color-emphasis-300);
+    border-radius: 8px;
+    min-height: 54px;
+    padding: 10px;
+    text-align: center;
+  }
+  .docs-antialiasing-flow__node--accent {
+    border-color: var(--ifm-color-primary);
+  }
+  .docs-antialiasing-flow__arrow {
+    color: var(--ifm-color-primary);
+    font-size: 20px;
+    text-align: center;
+  }
+  .docs-antialiasing-flow__caption {
+    color: var(--ifm-color-emphasis-700);
+    font-size: 0.9em;
+    margin: 0;
+  }
+  @media (max-width: 700px) {
+    .docs-antialiasing-flow__row {
+      grid-template-columns: 1fr;
+    }
+    .docs-antialiasing-flow__arrow {
+      transform: rotate(90deg);
+    }
+  }
+`}</style>
+
+<div className="docs-antialiasing-flow" role="figure" aria-label="Antialiasing render flow">
+  <div className="docs-antialiasing-flow__row">
+    <div className="docs-antialiasing-flow__node">Geometry, alpha cutouts, textures</div>
+    <div className="docs-antialiasing-flow__arrow" aria-hidden="true">→</div>
+    <div className="docs-antialiasing-flow__node docs-antialiasing-flow__node--accent">
+      Raster coverage<br /><code>MSAA</code> or supersampling
+    </div>
+    <div className="docs-antialiasing-flow__arrow" aria-hidden="true">→</div>
+  </div>
+  <div className="docs-antialiasing-flow__row">
+    <div className="docs-antialiasing-flow__node">Resolved color texture</div>
+    <div className="docs-antialiasing-flow__arrow" aria-hidden="true">→</div>
+    <div className="docs-antialiasing-flow__node docs-antialiasing-flow__node--accent">
+      Postprocess<br /><code>FXAA</code> or <code>TAA</code>
+    </div>
+    <div className="docs-antialiasing-flow__arrow" aria-hidden="true">→</div>
+  </div>
+  <div className="docs-antialiasing-flow__row">
+    <div className="docs-antialiasing-flow__node">Canvas presentation</div>
+    <div className="docs-antialiasing-flow__arrow" aria-hidden="true">←</div>
+    <div className="docs-antialiasing-flow__node">Sampleable depth, normals, velocity, shadows</div>
+    <div className="docs-antialiasing-flow__arrow" aria-hidden="true">←</div>
+  </div>
+  <p className="docs-antialiasing-flow__caption">
+    Depth participates in scene visibility during rasterization, then often becomes a separate
+    sampled input for later effects.
+  </p>
+</div>
+
+The best result is often a combination: correct device-pixel resolution, mipmapped textures,
+coverage antialiasing for geometry, then a postprocess pass only where it adds value.
+
+## Try Common Techniques
+
+The comparison below keeps the left half as the single-sample baseline and applies the selected
+technique on the right. It intentionally uses techniques available through the portable luma.gl
+API today; canvas-context antialiasing, raw WebGL MSAA, and TAA are explained in later sections.
+
+<AntialiasingExample embedded showStats={false} />
+
+## Resolution and Supersampling
+
+Before adding an AA algorithm, make sure the drawing buffer matches the intended display
+resolution. A canvas rendered at CSS-pixel resolution on a high-DPI display will look soft or
+jagged even when other settings are correct. Use
+[`CanvasContext`](/docs/api-reference/core/canvas-context) sizing controls to choose device pixels
+or an explicit render scale.
+
+Supersampling renders the scene into a larger texture and downsamples it with a filter. It is
+portable and handles geometry, shader, and texture detail together, but it scales color, depth,
+and fragment-shader cost with the number of rendered pixels. Use it as a quality fallback or for
+small targets rather than as the default for a large scene.
+
+## WebGL Canvas Antialiasing
+
+WebGL exposes `antialias` as a context-creation attribute:
+
+```ts
+const device = await luma.createDevice({
+  type: 'webgl2',
+  createCanvasContext: true,
+  webgl: {antialias: true}
+});
+```
+
+This is a request for the default drawing buffer only. The browser chooses the technique and
+quality, and the actual value may differ from the requested one. Inspect the created context when
+the distinction matters:
+
+```ts
+const gl = device.gl as WebGL2RenderingContext;
+const antialias = gl.getContextAttributes()?.antialias;
+```
+
+The request does not antialias textures attached to application-created framebuffers. The WebGL
+specification describes `antialias` as a best-effort drawing-buffer request, not a requirement.
+See the [WebGL context attributes specification](https://registry.khronos.org/webgl/specs/latest/1.0/).
+
+## Explicit Multisampling
+
+Multisample antialiasing stores more than one coverage/depth/color sample per pixel during
+rasterization, then resolves those samples into a normal single-sample image. It usually improves
+polygon and alpha-to-coverage edges without running the fragment shader once for every
+supersampled pixel.
+
+| Backend | Canvas path | Offscreen path | luma.gl status |
+| --- | --- | --- | --- |
+| WebGL 2 | `webgl.antialias` controls the default drawing buffer. | Render to multisampled renderbuffers, then `blitFramebuffer` into textures. | No managed offscreen resolve path yet; `Texture.samples` is ignored by `WEBGLTexture`. |
+| WebGPU | No context-level antialias switch. | Render into a multisampled `GPUTexture`, use a matching pipeline sample count, and provide a single-sample resolve target. | `Texture.samples` and pipeline `sampleCount` reach WebGPU, but luma.gl does not yet expose a complete managed resolve workflow. |
+
+For the raw WebGL sequence, see the
+[WebGL2Samples `fbo_multisample` example](https://webglsamples.org/WebGL2Samples/samples/fbo_multisample.html).
+For WebGPU concepts and sample-count constraints, see the
+[WebGPU multisampling guide](https://webgpufundamentals.org/webgpu/lessons/webgpu-multisampling.html)
+and the [WebGPU specification](https://gpuweb.github.io/gpuweb/).
+
+:::caution Proposed API, not implemented
+
+[RFC #2741](https://github.com/visgl/luma.gl/issues/2741) proposes a framebuffer-level
+request for color-only offscreen MSAA:
+
+```ts
+const colorTexture = device.createTexture({
+  width,
+  height,
+  format: 'rgba8unorm',
+  usage: Texture.RENDER | Texture.SAMPLE
+});
+
+const framebuffer = device.createFramebuffer({
+  width,
+  height,
+  samples: 4,
+  colorAttachments: [colorTexture]
+});
+```
+
+Under that proposal, the color texture remains single-sampled and sampleable. WebGL would render
+into private multisampled renderbuffers and resolve into the supplied texture when
+`RenderPass.end()` is called. The first scope is color-only and rejects depth/stencil attachments.
+
+:::
+
+## Depth, Stencil, and Shadows
+
+Depth is part of antialiasing in two different ways:
+
+- During scene rendering, depth and stencil tests determine which covered samples survive. A
+  multisampled color attachment needs depth/stencil attachments with the same sample count to keep
+  visibility correct at polygon boundaries.
+- After scene rendering, many effects sample a depth texture. DOF, SSAO, SSR, outlines, motion
+  blur, and TAA generally expect an ordinary single-sample depth texture. A multisampled depth
+  attachment cannot silently replace that input; the application needs a resolve, per-sample
+  shader access, or a separate single-sample depth path.
+
+The current luma.gl effects use sampleable depth textures for these later passes. For example,
+[`ShaderPassRenderer`](/docs/api-reference/engine/passes/shader-pass-renderer) accepts
+application-owned depth bindings for scene-aware effects, while the
+[Depth of Field example](/examples/showcase/dof) renders a texture-backed depth attachment before
+sampling it.
+
+Shadow maps are another depth image and have their own aliasing. Increasing shadow-map
+resolution, filtering comparisons such as PCF, stabilizing cascades, and temporal filtering can
+reduce shadow-edge shimmer; scene MSAA alone does not fix a low-resolution or unstable shadow map.
+
+## Alpha Cutouts and Transparency
+
+Alpha testing with `discard` creates a hard coverage edge. With multisampling enabled,
+`sampleAlphaToCoverageEnabled` can convert fragment alpha into a sample coverage mask, which is
+often useful for foliage, fences, and similar cutouts. It is not a replacement for correct
+transparency ordering or blending, and it does little without multiple samples.
+
+For analytic shapes such as circles, lines, and signed-distance-field text, shader-computed
+coverage with a smooth transition can be more precise than postprocessing. Prefer geometry or
+shader-level coverage when the primitive has a known mathematical boundary.
+
+## Postprocess and Temporal Antialiasing
+
+FXAA is a single-frame screen-space pass. It is cheap, works after a resolved color image, and
+helps high-contrast jagged edges, but it can soften details and cannot recover information that was
+never rasterized.
+
+TAA accumulates samples over time. It is better at subpixel motion and shimmer, but it requires a
+jittered projection, history buffers, velocity, and depth rejection to avoid ghosting. luma.gl
+exports [`fxaa`](/docs/api-guide/shaders/shader-passes) for WebGL and WebGPU shader-pass chains and
+`createTAAShaderPassPipeline()` for the WebGPU-oriented advanced-effects path. See the
+[Advanced Effects example](/examples/experimental/advanced-effects) for TAA combined with depth,
+velocity, SSAO, SSR, and motion blur.
+
+When combining techniques, resolve MSAA before a normal texture-sampling postprocess. Apply FXAA
+near the end of the color chain. Apply TAA where its history, depth, and velocity represent the
+same jittered scene.
+
+## Texture Aliasing
+
+Texture minification is not fixed by canvas antialiasing or MSAA. Use linear filtering for
+magnification, generate mipmaps for distant texture sampling, choose trilinear mipmap filtering
+when transitions between mip levels are visible, and raise anisotropy for oblique surfaces.
+
+See [GPU Textures](/docs/api-guide/gpu/gpu-textures#mipmaps) and
+[`Sampler`](/docs/api-reference/core/resources/sampler) for the concrete luma.gl texture and
+sampler settings.
+
+## Practical Recipes
+
+| Situation | Recommended stack |
+| --- | --- |
+| Simple WebGL canvas scene | Device pixels + `webgl.antialias` + mipmapped textures. |
+| Portable offscreen effect today | Single-sample render target + appropriate texture filtering + FXAA or carefully chosen supersampling. |
+| WebGPU scene with explicit MSAA | Matching multisampled color/depth attachments and pipeline sample count, then resolve before ordinary postprocessing. |
+| Thin moving geometry | Stable device-pixel sizing, then TAA or supersampling; FXAA alone may still shimmer. |
+| Alpha-cutout foliage | MSAA + alpha-to-coverage where available, with texture mipmaps and correct blending. |
+| Depth-aware postprocessing | Keep a deliberate sampleable depth path and treat depth discontinuities as effect inputs, not just color edges. |
+| Shadow shimmer | Improve shadow-map sampling/resolution/stability; combine with TAA only after the shadow path is stable. |

--- a/docs/api-guide/gpu/gpu-parameters.md
+++ b/docs/api-guide/gpu/gpu-parameters.md
@@ -59,7 +59,7 @@ Describes luma.gl setting names and values
 0. Vertex Fetch (buffers)
 1. Vertex Shader
 2. Primitive assembly (`topology`)
-3. Rasterization (multisampling parameters)
+3. Rasterization ([multisampling parameters](/docs/api-guide/gpu/gpu-antialiasing))
 4. Fragment shader `Framebuffer`
 5. Stencil test and operation (stencil parameters)
 6. Depth test and write (depth parameters)

--- a/docs/api-guide/gpu/gpu-rendering.md
+++ b/docs/api-guide/gpu/gpu-rendering.md
@@ -6,6 +6,8 @@ import {GpuGuideDocsTabs} from '@site/src/components/docs/gpu-guide-docs-tabs';
 
 See also [Issuing GPU Commands](/docs/api-guide/gpu/gpu-commands) for how render passes relate to `CommandEncoder`, `CommandBuffer`, and `device.submit()` on WebGL and WebGPU.
 
+See [Antialiasing and Multisampling](/docs/api-guide/gpu/gpu-antialiasing) for how canvas, offscreen, depth, texture, and postprocess sampling choices fit into this render flow.
+
 :::info
 Note that the luma.gl documentation includes a series of tutorials that explain how to render with the luma.gl API.
 :::

--- a/docs/api-guide/gpu/gpu-textures.mdx
+++ b/docs/api-guide/gpu/gpu-textures.mdx
@@ -87,6 +87,11 @@ A primary purpose of textures is to allow the GPU to read from them.
 ### Filtering
 
 Texture formats that are filterable which means that during sampling texel values can be interpolated by the GPU for better results.
+
+Texture filtering solves texture minification and magnification aliasing. It is separate from
+polygon coverage antialiasing; see
+[Antialiasing and Multisampling](/docs/api-guide/gpu/gpu-antialiasing) for how the techniques fit
+together.
 Sampling is a highly configuratble process that is specified using by binding a separate `Sampler` object for each texture.
 
 Sampling can be specified separately for

--- a/docs/api-guide/shaders/shader-passes.md
+++ b/docs/api-guide/shaders/shader-passes.md
@@ -59,6 +59,9 @@ the application applies the same transform to those auxiliary attachments.
 - Reusable effects that should be configured as shader modules but executed by
   an engine-owned pass renderer.
 
+For FXAA, TAA, and the ordering between resolved render targets and postprocessing, see
+[Antialiasing and Multisampling](/docs/api-guide/gpu/gpu-antialiasing).
+
 Do not use shader passes for ordinary geometry shading. Use `Model` with
 modules or plugins when the shader participates in a model's vertex and
 fragment pipeline.

--- a/docs/api-reference/core/device.md
+++ b/docs/api-reference/core/device.md
@@ -111,7 +111,7 @@ For detailed control over WebGL context can specify what [`WebGLContextAttribute
 | ---------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------ |
 | `webgl.preserveDrawingBuffers?: boolean` | `true`  | Default render target buffers will preserve their values until overwritten. Useful for screen capture. |
 | `webgl.alpha?: boolean`                  | `true`  | Default render target has an alpha buffer.                                                             |
-| `webgl.antialias?: boolean`              | `true`  | Boolean that indicates whether or not to perform anti-aliasing.                                        |
+| `webgl.antialias?: boolean`              | `true`  | Best-effort request to antialias the WebGL default drawing buffer. See [Antialiasing and Multisampling](/docs/api-guide/gpu/gpu-antialiasing). |
 | `webgl.depth?: boolean`                  | `true`  | Default render target has a depth buffer of at least `16` bits.                                        |
 | `webgl.premultipliedAlpha?: boolean`     | `true`  | The page compositor will assume the drawing buffer contains colors with pre-multiplied alpha.          |
 | `webgl.stencil?: boolean`                | `false` | Default render target has a stencil buffer of at least `8` bits.                                       |

--- a/docs/api-reference/core/resources/framebuffer.md
+++ b/docs/api-reference/core/resources/framebuffer.md
@@ -78,6 +78,15 @@ const screenRenderPass = device.beginRenderPass();
 model2.draw({renderPass: screenRenderPass, ...});
 ```
 
+:::caution
+
+luma.gl does not yet expose a managed offscreen MSAA resolve path. For the current WebGL and
+WebGPU landscape, and the proposed color-only framebuffer API, see
+[Antialiasing and Multisampling](/docs/api-guide/gpu/gpu-antialiasing) and
+[RFC #2741](https://github.com/visgl/luma.gl/issues/2741).
+
+:::
+
 ## Overview
 
 ### Framebuffer Attachment Values

--- a/docs/api-reference/core/resources/texture.md
+++ b/docs/api-reference/core/resources/texture.md
@@ -96,13 +96,23 @@ model.draw({
 | `depth?` | `number` | `1` | Depth or array layer count for 3D textures and texture arrays. |
 | `usage?` | `number` | `Texture.SAMPLE \| Texture.RENDER \| Texture.COPY_DST` | Bit mask that declares how the texture will be used. See [Usage](#usage). |
 | `mipLevels?` | `number` | `1` | Number of mip levels allocated for the texture. |
-| `samples?` | `number` | backend default | Multisample count for renderable textures. Provide values >1 to request MSAA. |
+| `samples?` | `number` | backend default | WebGPU sample count for a true multisampled render attachment. WebGL textures remain single-sampled; see [Antialiasing and Multisampling](/docs/api-guide/gpu/gpu-antialiasing). |
 | `sampler?` | `Sampler \| SamplerProps` | `{}` | Sampler instance or props used to create the texture's default sampler. |
 | `view?` | `TextureViewProps` | backend default | Props used when creating the default texture view. |
 
 ### Usage
 
 Usage expresses two things: the texture type and which operations can be performed.
+
+:::caution
+
+`Texture.samples` does not provide a portable “render, resolve, then sample” workflow today.
+WebGL ignores it when allocating textures, and WebGPU multisampled textures need a compatible
+pipeline and explicit resolve path. See
+[Antialiasing and Multisampling](/docs/api-guide/gpu/gpu-antialiasing) and
+[RFC #2741](https://github.com/visgl/luma.gl/issues/2741).
+
+:::
 
 Note that the allowed combinations are very limited, especially in WebGPU.
 

--- a/examples/showcase/antialiasing/app.ts
+++ b/examples/showcase/antialiasing/app.ts
@@ -1,0 +1,772 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Framebuffer, SamplerProps, Texture} from '@luma.gl/core';
+import {Texture as TextureResource, UniformStore} from '@luma.gl/core';
+import {fxaa} from '@luma.gl/effects';
+import type {AnimationProps} from '@luma.gl/engine';
+import {
+  AnimationLoopTemplate,
+  ClipSpace,
+  DynamicTexture,
+  Geometry,
+  Model,
+  ShaderPassRenderer
+} from '@luma.gl/engine';
+import type {ShaderModule} from '@luma.gl/shadertools';
+import {
+  ColumnPanel,
+  type Panel,
+  type SettingsSchema,
+  type SettingsState
+} from '@deck.gl-community/panels';
+import {
+  ExamplePanelManager,
+  ExampleSettingsPanelManager,
+  makeExamplePanelHostHtml,
+  makeHtmlCustomPanel
+} from '../../example-panels';
+
+export const title = 'Antialiasing Techniques';
+export const description =
+  'Compare single-sample rendering, FXAA, supersampling, and texture sampling modes.';
+
+const TECHNIQUES = ['None', 'FXAA', '2x supersampling', '4x supersampling'] as const;
+const TEXTURE_SAMPLING_MODES = ['Nearest', 'Linear', 'Linear + mipmaps', 'Anisotropic'] as const;
+const OUTPUT_MODES = ['Color', 'Depth visualization'] as const;
+
+type Technique = (typeof TECHNIQUES)[number];
+type TextureSamplingMode = (typeof TEXTURE_SAMPLING_MODES)[number];
+type OutputMode = (typeof OUTPUT_MODES)[number];
+
+type AntialiasingSettings = {
+  technique: Technique;
+  textureSampling: TextureSamplingMode;
+  animate: boolean;
+  output: OutputMode;
+};
+
+type AppUniforms = {
+  time: number;
+  viewMode: number;
+};
+
+type RenderTarget = {
+  framebuffer: Framebuffer;
+  colorTexture: Texture;
+  depthTexture: Texture;
+  width: number;
+  height: number;
+};
+
+const DEFAULT_SETTINGS: AntialiasingSettings = {
+  technique: 'FXAA',
+  textureSampling: 'Linear + mipmaps',
+  animate: true,
+  output: 'Color'
+};
+
+const appShaderModule = {
+  name: 'app',
+  uniformTypes: {
+    time: 'f32',
+    viewMode: 'f32'
+  }
+} as const satisfies ShaderModule<AppUniforms>;
+
+const SCENE_WGSL = /* wgsl */ `\
+struct AppUniforms {
+  time: f32,
+  viewMode: f32,
+};
+
+@group(0) @binding(auto) var<uniform> app: AppUniforms;
+@group(0) @binding(auto) var checkerTexture: texture_2d<f32>;
+@group(0) @binding(auto) var checkerTextureSampler: sampler;
+
+struct VertexInputs {
+  @location(0) positions: vec3<f32>,
+  @location(1) texCoords: vec2<f32>,
+  @location(2) kinds: f32,
+};
+
+struct VertexOutputs {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+  @location(1) @interpolate(flat) kind: f32,
+};
+
+@vertex
+fn vertexMain(inputs: VertexInputs) -> VertexOutputs {
+  let offset = vec2<f32>(
+    sin(app.time * 1.1 + inputs.kinds * 2.7) * 0.025,
+    cos(app.time * 0.8 + inputs.kinds * 1.9) * 0.018
+  );
+  var outputs: VertexOutputs;
+  outputs.position = vec4<f32>(inputs.positions.xy + offset, inputs.positions.z, 1.0);
+  outputs.uv = inputs.texCoords;
+  outputs.kind = inputs.kinds;
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs: VertexOutputs) -> @location(0) vec4<f32> {
+  let checker = textureSample(checkerTexture, checkerTextureSampler, inputs.uv);
+
+  if (app.viewMode > 0.5) {
+    let depth = 1.0 - inputs.position.z;
+    return vec4<f32>(vec3<f32>(depth), 1.0);
+  }
+
+  if (inputs.kind < 0.5) {
+    return vec4<f32>(0.98, 0.22, 0.16, 1.0);
+  }
+  if (inputs.kind < 1.5) {
+    return vec4<f32>(0.08, 0.74, 0.95, 1.0);
+  }
+
+  if (inputs.kind < 2.5) {
+    return vec4<f32>(checker.rgb, 1.0);
+  }
+
+  if (checker.a < 0.5) {
+    discard;
+  }
+  return vec4<f32>(mix(checker.rgb, vec3<f32>(1.0, 0.82, 0.12), 0.55), 1.0);
+}
+`;
+
+const SCENE_VERTEX_SHADER = /* glsl */ `\
+#version 300 es
+
+layout(location = 0) in vec3 positions;
+layout(location = 1) in vec2 texCoords;
+layout(location = 2) in float kinds;
+
+uniform appUniforms {
+  float time;
+  float viewMode;
+} app;
+
+out vec2 uv;
+flat out float kind;
+
+void main(void) {
+  vec2 offset = vec2(
+    sin(app.time * 1.1 + kinds * 2.7) * 0.025,
+    cos(app.time * 0.8 + kinds * 1.9) * 0.018
+  );
+  gl_Position = vec4(positions.xy + offset, positions.z, 1.0);
+  uv = texCoords;
+  kind = kinds;
+}
+`;
+
+const SCENE_FRAGMENT_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+uniform sampler2D checkerTexture;
+uniform appUniforms {
+  float time;
+  float viewMode;
+} app;
+
+in vec2 uv;
+flat in float kind;
+
+out vec4 fragColor;
+
+void main(void) {
+  if (app.viewMode > 0.5) {
+    float depth = 1.0 - gl_FragCoord.z;
+    fragColor = vec4(vec3(depth), 1.0);
+    return;
+  }
+
+  if (kind < 0.5) {
+    fragColor = vec4(0.98, 0.22, 0.16, 1.0);
+    return;
+  }
+  if (kind < 1.5) {
+    fragColor = vec4(0.08, 0.74, 0.95, 1.0);
+    return;
+  }
+
+  vec4 checker = texture(checkerTexture, uv);
+  if (kind < 2.5) {
+    fragColor = vec4(checker.rgb, 1.0);
+    return;
+  }
+
+  if (checker.a < 0.5) {
+    discard;
+  }
+  fragColor = vec4(mix(checker.rgb, vec3(1.0, 0.82, 0.12), 0.55), 1.0);
+}
+`;
+
+const COMPARISON_WGSL = /* wgsl */ `\
+@group(0) @binding(auto) var baselineTexture: texture_2d<f32>;
+@group(0) @binding(auto) var baselineTextureSampler: sampler;
+@group(0) @binding(auto) var techniqueTexture: texture_2d<f32>;
+@group(0) @binding(auto) var techniqueTextureSampler: sampler;
+
+@fragment
+fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
+  let baselineColor = textureSample(baselineTexture, baselineTextureSampler, inputs.uv);
+  let techniqueColor = textureSample(techniqueTexture, techniqueTextureSampler, inputs.uv);
+  let separator = abs(inputs.uv.x - 0.5) < 0.0025;
+  if (separator) {
+    return vec4<f32>(1.0, 0.85, 0.2, 1.0);
+  }
+  if (inputs.uv.x < 0.5) {
+    return baselineColor;
+  }
+  return techniqueColor;
+}
+`;
+
+const COMPARISON_FRAGMENT_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+uniform sampler2D baselineTexture;
+uniform sampler2D techniqueTexture;
+
+in vec2 uv;
+out vec4 fragColor;
+
+void main(void) {
+  if (abs(uv.x - 0.5) < 0.0025) {
+    fragColor = vec4(1.0, 0.85, 0.2, 1.0);
+    return;
+  }
+  fragColor = uv.x < 0.5 ? texture(baselineTexture, uv) : texture(techniqueTexture, uv);
+}
+`;
+
+export default class AntialiasingAnimationLoopTemplate extends AnimationLoopTemplate {
+  static info = makeExamplePanelHostHtml();
+
+  private readonly device: AnimationProps['device'];
+  private readonly sceneModel: Model;
+  private readonly comparisonModel: ClipSpace;
+  private readonly uniformStore: UniformStore<{app: AppUniforms}>;
+  private readonly fxaaRenderer: ShaderPassRenderer;
+  private readonly checkerTextures: Record<TextureSamplingMode, DynamicTexture>;
+  private readonly settingsPanel: ExampleSettingsPanelManager;
+  private readonly panels: ExamplePanelManager;
+
+  private settings: AntialiasingSettings = {...DEFAULT_SETTINGS};
+  private baselineTarget: RenderTarget | null = null;
+  private supersampledTarget: RenderTarget | null = null;
+  private frozenTime = 0;
+
+  constructor({device}: AnimationProps) {
+    super();
+    this.device = device;
+    this.uniformStore = new UniformStore(device, {app: appShaderModule});
+    this.checkerTextures = makeCheckerTextures(device);
+    this.sceneModel = new Model(device, {
+      id: 'antialiasing-scene',
+      source: SCENE_WGSL,
+      vs: SCENE_VERTEX_SHADER,
+      fs: SCENE_FRAGMENT_SHADER,
+      geometry: makeSceneGeometry(),
+      bindings: {
+        app: this.uniformStore.getManagedUniformBuffer('app'),
+        checkerTexture: this.checkerTextures[this.settings.textureSampling]
+      },
+      parameters: {
+        depthWriteEnabled: true,
+        depthCompare: 'less-equal',
+        depthFormat: 'depth24plus'
+      }
+    });
+    this.comparisonModel = new ClipSpace(device, {
+      id: 'antialiasing-comparison',
+      source: COMPARISON_WGSL,
+      fs: COMPARISON_FRAGMENT_SHADER,
+      bindings: {
+        baselineTexture: this.checkerTextures.Nearest,
+        techniqueTexture: this.checkerTextures.Nearest
+      }
+    });
+    this.fxaaRenderer = new ShaderPassRenderer(device, {shaderPasses: [fxaa]});
+    this.settingsPanel = new ExampleSettingsPanelManager({
+      id: 'antialiasing-settings',
+      schema: makeSettingsSchema(),
+      settings: makeSettingsState(this.settings),
+      onSettingsChange: this.handleSettingsChange
+    });
+    this.panels = new ExamplePanelManager({panel: this.makePanel()});
+    this.panels.mount();
+  }
+
+  onFinalize(): void {
+    this.destroyTargets();
+    this.sceneModel.destroy();
+    this.comparisonModel.destroy();
+    this.uniformStore.destroy();
+    this.fxaaRenderer.destroy();
+    for (const checkerTexture of Object.values(this.checkerTextures)) {
+      checkerTexture.destroy();
+    }
+    this.settingsPanel.finalize();
+    this.panels.finalize();
+  }
+
+  onRender({device, width, height, tick}: AnimationProps): void {
+    const checkerTexture = this.checkerTextures[this.settings.textureSampling];
+    if (!checkerTexture.isReady) {
+      return;
+    }
+
+    this.ensureTargets(width, height);
+    if (!this.baselineTarget) {
+      return;
+    }
+
+    if (this.settings.animate) {
+      this.frozenTime = tick / 1000;
+    }
+    this.uniformStore.setUniforms({
+      app: {
+        time: this.frozenTime,
+        viewMode: this.settings.output === 'Depth visualization' ? 1 : 0
+      }
+    });
+    this.sceneModel.setBindings({checkerTexture});
+
+    this.renderScene(this.baselineTarget);
+    let techniqueTexture = this.baselineTarget.colorTexture;
+    const supersampleScale = getSupersampleScale(this.settings.technique);
+
+    if (supersampleScale > 1 && this.supersampledTarget) {
+      this.renderScene(this.supersampledTarget);
+      techniqueTexture = this.supersampledTarget.colorTexture;
+    } else if (this.settings.technique === 'FXAA') {
+      this.fxaaRenderer.resize([width, height]);
+      techniqueTexture =
+        this.fxaaRenderer.renderToTexture({sourceTexture: this.baselineTarget.colorTexture}) ||
+        this.baselineTarget.colorTexture;
+    }
+
+    this.comparisonModel.setBindings({
+      baselineTexture: this.baselineTarget.colorTexture,
+      techniqueTexture
+    });
+    const renderPass = device.beginRenderPass({clearColor: [0.02, 0.02, 0.03, 1]});
+    this.comparisonModel.draw(renderPass);
+    renderPass.end();
+  }
+
+  private renderScene(renderTarget: RenderTarget): void {
+    const renderPass = this.device.beginRenderPass({
+      framebuffer: renderTarget.framebuffer,
+      clearColor: [0.02, 0.02, 0.03, 1],
+      clearDepth: 1
+    });
+    this.sceneModel.draw(renderPass);
+    renderPass.end();
+  }
+
+  private ensureTargets(width: number, height: number): void {
+    if (
+      !this.baselineTarget ||
+      this.baselineTarget.width !== width ||
+      this.baselineTarget.height !== height
+    ) {
+      destroyRenderTarget(this.baselineTarget);
+      this.baselineTarget = createRenderTarget(this.device, width, height, 'baseline');
+    }
+
+    const supersampleScale = getSupersampleScale(this.settings.technique);
+    if (supersampleScale === 1) {
+      destroyRenderTarget(this.supersampledTarget);
+      this.supersampledTarget = null;
+      return;
+    }
+
+    const supersampledWidth = Math.max(1, Math.round(width * supersampleScale));
+    const supersampledHeight = Math.max(1, Math.round(height * supersampleScale));
+    if (
+      !this.supersampledTarget ||
+      this.supersampledTarget.width !== supersampledWidth ||
+      this.supersampledTarget.height !== supersampledHeight
+    ) {
+      destroyRenderTarget(this.supersampledTarget);
+      this.supersampledTarget = createRenderTarget(
+        this.device,
+        supersampledWidth,
+        supersampledHeight,
+        'supersampled'
+      );
+    }
+  }
+
+  private destroyTargets(): void {
+    destroyRenderTarget(this.baselineTarget);
+    destroyRenderTarget(this.supersampledTarget);
+    this.baselineTarget = null;
+    this.supersampledTarget = null;
+  }
+
+  private makePanel(): Panel {
+    return new ColumnPanel({
+      id: 'antialiasing-controls',
+      title: 'Controls',
+      panels: [
+        makeHtmlCustomPanel({
+          id: 'antialiasing-description',
+          title: '',
+          html: makeDescriptionHtml(this.settings)
+        }),
+        this.settingsPanel.makePanel()
+      ]
+    });
+  }
+
+  private readonly handleSettingsChange = (settings: SettingsState): void => {
+    this.settings = {
+      technique: isTechnique(settings.technique) ? settings.technique : this.settings.technique,
+      textureSampling: isTextureSamplingMode(settings.textureSampling)
+        ? settings.textureSampling
+        : this.settings.textureSampling,
+      animate: typeof settings.animate === 'boolean' ? settings.animate : this.settings.animate,
+      output: isOutputMode(settings.output) ? settings.output : this.settings.output
+    };
+    this.panels.setPanel(this.makePanel());
+  };
+}
+
+function createRenderTarget(
+  device: AnimationProps['device'],
+  width: number,
+  height: number,
+  id: string
+): RenderTarget {
+  const colorTexture = device.createTexture({
+    id: 'antialiasing-' + id + '-color',
+    format: 'rgba8unorm',
+    width,
+    height,
+    usage: TextureResource.SAMPLE | TextureResource.RENDER | TextureResource.COPY_DST,
+    sampler: {
+      minFilter: 'linear',
+      magFilter: 'linear',
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'clamp-to-edge'
+    }
+  });
+  const depthTexture = device.createTexture({
+    id: 'antialiasing-' + id + '-depth',
+    format: 'depth24plus',
+    width,
+    height,
+    usage: TextureResource.RENDER
+  });
+  const framebuffer = device.createFramebuffer({
+    id: 'antialiasing-' + id + '-framebuffer',
+    width,
+    height,
+    colorAttachments: [colorTexture],
+    depthStencilAttachment: depthTexture
+  });
+  return {framebuffer, colorTexture, depthTexture, width, height};
+}
+
+function destroyRenderTarget(renderTarget: RenderTarget | null): void {
+  if (!renderTarget) {
+    return;
+  }
+  renderTarget.framebuffer.destroy();
+  renderTarget.colorTexture.destroy();
+  renderTarget.depthTexture.destroy();
+}
+
+function makeCheckerTextures(
+  device: AnimationProps['device']
+): Record<TextureSamplingMode, DynamicTexture> {
+  const textureData = makeCheckerTextureData(64);
+  return {
+    Nearest: makeCheckerTexture(device, 'nearest', textureData, {
+      minFilter: 'nearest',
+      magFilter: 'nearest',
+      mipmapFilter: 'none'
+    }),
+    Linear: makeCheckerTexture(device, 'linear', textureData, {
+      minFilter: 'linear',
+      magFilter: 'linear',
+      mipmapFilter: 'none'
+    }),
+    'Linear + mipmaps': makeCheckerTexture(device, 'mipmaps', textureData, {
+      minFilter: 'linear',
+      magFilter: 'linear',
+      mipmapFilter: 'linear'
+    }),
+    Anisotropic: makeCheckerTexture(device, 'anisotropic', textureData, {
+      minFilter: 'linear',
+      magFilter: 'linear',
+      mipmapFilter: 'linear',
+      maxAnisotropy: 8
+    })
+  };
+}
+
+function makeCheckerTexture(
+  device: AnimationProps['device'],
+  id: string,
+  textureData: {data: Uint8Array; width: number; height: number},
+  sampler: SamplerProps
+): DynamicTexture {
+  return new DynamicTexture(device, {
+    id: 'antialiasing-checker-' + id,
+    format: 'rgba8unorm',
+    width: textureData.width,
+    height: textureData.height,
+    data: textureData,
+    mipmaps: true,
+    mipLevels: 'auto',
+    sampler: {
+      ...sampler,
+      addressModeU: 'repeat',
+      addressModeV: 'repeat'
+    }
+  });
+}
+
+function makeCheckerTextureData(size: number): {data: Uint8Array; width: number; height: number} {
+  const data = new Uint8Array(size * size * 4);
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const index = (y * size + x) * 4;
+      const checker = (Math.floor(x / 4) + Math.floor(y / 4)) % 2 === 0;
+      const stripe = (x + y) % 16 < 8;
+      data[index] = checker ? 238 : 18;
+      data[index + 1] = stripe ? 238 : 48;
+      data[index + 2] = checker ? 255 : 24;
+      data[index + 3] = Math.hypot(x - size / 2, y - size / 2) < size * 0.42 ? 255 : 0;
+    }
+  }
+  return {data, width: size, height: size};
+}
+
+function makeSceneGeometry(): Geometry {
+  const positions: number[] = [];
+  const texCoords: number[] = [];
+  const kinds: number[] = [];
+
+  appendTriangle(
+    positions,
+    texCoords,
+    kinds,
+    [
+      [-0.98, -0.78, 0.78],
+      [-0.1, 0.82, 0.78],
+      [0.0, -0.78, 0.78]
+    ],
+    0
+  );
+  appendTriangle(
+    positions,
+    texCoords,
+    kinds,
+    [
+      [-0.84, -0.62, 0.24],
+      [-0.28, 0.64, 0.24],
+      [-0.06, -0.62, 0.24]
+    ],
+    1
+  );
+  appendTriangle(
+    positions,
+    texCoords,
+    kinds,
+    [
+      [0.02, -0.78, 0.78],
+      [0.9, 0.82, 0.78],
+      [1.0, -0.78, 0.78]
+    ],
+    0
+  );
+  appendTriangle(
+    positions,
+    texCoords,
+    kinds,
+    [
+      [0.16, -0.62, 0.24],
+      [0.72, 0.64, 0.24],
+      [0.94, -0.62, 0.24]
+    ],
+    1
+  );
+  appendQuad(
+    positions,
+    texCoords,
+    kinds,
+    [
+      [-1.0, -0.98, 0.68],
+      [1.0, -0.98, 0.68],
+      [0.7, -0.28, 0.68],
+      [-0.7, -0.28, 0.68]
+    ],
+    [
+      [0, 0],
+      [48, 0],
+      [48, 12],
+      [0, 12]
+    ],
+    2
+  );
+  appendQuad(
+    positions,
+    texCoords,
+    kinds,
+    [
+      [-0.94, 0.12, 0.12],
+      [-0.34, 0.12, 0.12],
+      [-0.28, 0.74, 0.12],
+      [-0.88, 0.74, 0.12]
+    ],
+    [
+      [0, 0],
+      [4, 0],
+      [4, 4],
+      [0, 4]
+    ],
+    3
+  );
+  appendQuad(
+    positions,
+    texCoords,
+    kinds,
+    [
+      [0.06, 0.12, 0.12],
+      [0.66, 0.12, 0.12],
+      [0.72, 0.74, 0.12],
+      [0.12, 0.74, 0.12]
+    ],
+    [
+      [0, 0],
+      [4, 0],
+      [4, 4],
+      [0, 4]
+    ],
+    3
+  );
+
+  return new Geometry({
+    topology: 'triangle-list',
+    attributes: {
+      positions: {size: 3, value: new Float32Array(positions)},
+      texCoords: {size: 2, value: new Float32Array(texCoords)},
+      kinds: {size: 1, value: new Float32Array(kinds)}
+    }
+  });
+}
+
+function appendTriangle(
+  positions: number[],
+  texCoords: number[],
+  kinds: number[],
+  vertices: [number, number, number][],
+  kind: number
+): void {
+  for (const vertex of vertices) {
+    positions.push(...vertex);
+    texCoords.push(0, 0);
+    kinds.push(kind);
+  }
+}
+
+function appendQuad(
+  positions: number[],
+  texCoords: number[],
+  kinds: number[],
+  vertices: [number, number, number][],
+  textureCoordinates: [number, number][],
+  kind: number
+): void {
+  const indices = [0, 1, 2, 0, 2, 3];
+  for (const index of indices) {
+    positions.push(...vertices[index]);
+    texCoords.push(...textureCoordinates[index]);
+    kinds.push(kind);
+  }
+}
+
+function getSupersampleScale(technique: Technique): 1 | 2 | 4 {
+  switch (technique) {
+    case '2x supersampling':
+      return 2;
+    case '4x supersampling':
+      return 4;
+    default:
+      return 1;
+  }
+}
+
+function makeSettingsSchema(): SettingsSchema {
+  return {
+    title: 'Antialiasing',
+    sections: [
+      {
+        id: 'comparison',
+        name: 'Comparison',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'technique',
+            label: 'Right side',
+            type: 'select',
+            persist: 'none',
+            options: [...TECHNIQUES]
+          },
+          {
+            name: 'textureSampling',
+            label: 'Texture sampling',
+            type: 'select',
+            persist: 'none',
+            options: [...TEXTURE_SAMPLING_MODES]
+          },
+          {
+            name: 'output',
+            label: 'Output',
+            type: 'select',
+            persist: 'none',
+            options: [...OUTPUT_MODES]
+          },
+          {name: 'animate', label: 'Animate scene', type: 'boolean', persist: 'none'}
+        ]
+      }
+    ]
+  };
+}
+
+function makeSettingsState(settings: AntialiasingSettings): SettingsState {
+  return {...settings};
+}
+
+function makeDescriptionHtml(settings: AntialiasingSettings): string {
+  return (
+    '<p><b>Left:</b> single-sample baseline. <b>Right:</b> ' +
+    settings.technique +
+    '.</p><p>The scene combines thin geometry, minified texture detail, alpha cutouts, and depth discontinuities. ' +
+    'Canvas antialiasing and explicit MSAA are documented separately because they are not portable runtime toggles.</p>'
+  );
+}
+
+function isTechnique(value: unknown): value is Technique {
+  return typeof value === 'string' && TECHNIQUES.includes(value as Technique);
+}
+
+function isTextureSamplingMode(value: unknown): value is TextureSamplingMode {
+  return typeof value === 'string' && TEXTURE_SAMPLING_MODES.includes(value as TextureSamplingMode);
+}
+
+function isOutputMode(value: unknown): value is OutputMode {
+  return typeof value === 'string' && OUTPUT_MODES.includes(value as OutputMode);
+}

--- a/examples/showcase/antialiasing/index.html
+++ b/examples/showcase/antialiasing/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<head>
+  <style>
+    body {
+      background: black;
+      margin: 0;
+    }
+  </style>
+</head>
+<script type="module">
+  import {luma} from '@luma.gl/core';
+  import {webgl2Adapter} from '@luma.gl/webgl';
+  import {webgpuAdapter} from '@luma.gl/webgpu';
+  import {makeAnimationLoop} from '@luma.gl/engine';
+  import AnimationLoopTemplate from './app.ts';
+
+  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+    adapters: [webgpuAdapter, webgl2Adapter]
+  });
+  animationLoop.start();
+</script>
+<body>
+</body>

--- a/examples/showcase/antialiasing/package.json
+++ b/examples/showcase/antialiasing/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "luma.gl-examples-antialiasing",
+  "version": "9.3.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "vite",
+    "build": "tsc && vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
+    "@luma.gl/core": "~9.3.0",
+    "@luma.gl/effects": "~9.3.0",
+    "@luma.gl/engine": "~9.3.0",
+    "@luma.gl/shadertools": "~9.3.0",
+    "@luma.gl/webgl": "~9.3.0",
+    "@luma.gl/webgpu": "~9.3.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/examples/showcase/antialiasing/tsconfig.json
+++ b/examples/showcase/antialiasing/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["."]
+}

--- a/examples/showcase/antialiasing/vite.config.ts
+++ b/examples/showcase/antialiasing/vite.config.ts
@@ -1,0 +1,12 @@
+import {defineConfig} from 'vite';
+
+const alias = {
+  '@luma.gl/core': `${__dirname}/../../../modules/core/src`,
+  '@luma.gl/effects': `${__dirname}/../../../modules/effects/src`,
+  '@luma.gl/engine': `${__dirname}/../../../modules/engine/src`,
+  '@luma.gl/shadertools': `${__dirname}/../../../modules/shadertools/src`,
+  '@luma.gl/webgl': `${__dirname}/../../../modules/webgl/src`,
+  '@luma.gl/webgpu': `${__dirname}/../../../modules/webgpu/src`
+};
+
+export default defineConfig({resolve: {alias}, server: {open: true}});

--- a/scripts/examples-typecheck.mjs
+++ b/scripts/examples-typecheck.mjs
@@ -25,6 +25,7 @@ const SUPPORTED_EXAMPLE_WORKSPACES = new Set([
   'api/video-texture',
   'experimental/webxr-kaleidoscope',
   'integrations/hello-react',
+  'showcase/antialiasing',
   'showcase/dof',
   'showcase/persistence',
   'tutorials/hello-instanced-cubes',

--- a/website/src/components/docs/gpu-guide-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-guide-docs-tabs.tsx
@@ -14,6 +14,7 @@ export type GpuGuideDocsTabId =
   | 'resources'
   | 'data-processing'
   | 'rendering'
+  | 'antialiasing'
   | 'parameters'
   | 'bindings'
   | 'attributes'
@@ -36,6 +37,11 @@ const GPU_GUIDE_DOCS_TABS: Record<GpuGuideDocsTabGroupId, GpuGuideDocsTab[]> = {
       href: '/docs/api-guide/gpu/gpu-data-processing'
     },
     {id: 'rendering', label: 'Rendering', href: '/docs/api-guide/gpu/gpu-rendering'},
+    {
+      id: 'antialiasing',
+      label: 'Antialiasing',
+      href: '/docs/api-guide/gpu/gpu-antialiasing'
+    },
     {id: 'parameters', label: 'Parameters', href: '/docs/api-guide/gpu/gpu-parameters'}
   ],
   'shader-data': [

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -74,6 +74,7 @@ import RenderBundlesApp from '../../examples/api/render-bundles/app';
 import TextSpaceCrawlApp from '../../examples/experimental/text-space-crawl/app';
 import PersistenceApp from '../../examples/showcase/persistence/app';
 import PostprocessingApp from '../../examples/showcase/postprocessing/app';
+import AntialiasingApp from '../../examples/showcase/antialiasing/app';
 import GlobeApp from '../../examples/showcase/globe/app';
 // import WanderingApp from '../../examples/showcase/wandering/app';
 
@@ -904,6 +905,17 @@ export const PostprocessingExample: React.FC<WebsiteExampleProps> = props => (
     id="postprocessing"
     directory="showcase"
     template={PostprocessingApp}
+    config={exampleConfig}
+    {...props}
+  />
+);
+
+export const AntialiasingExample: React.FC<WebsiteExampleProps> = props => (
+  <LumaExample
+    id="antialiasing"
+    title="Antialiasing Techniques"
+    directory="showcase"
+    template={AntialiasingApp}
     config={exampleConfig}
     {...props}
   />

--- a/yarn.lock
+++ b/yarn.lock
@@ -15770,6 +15770,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"luma.gl-examples-antialiasing@workspace:examples/showcase/antialiasing":
+  version: 0.0.0-use.local
+  resolution: "luma.gl-examples-antialiasing@workspace:examples/showcase/antialiasing"
+  dependencies:
+    "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
+    "@luma.gl/core": "npm:~9.3.0"
+    "@luma.gl/effects": "npm:~9.3.0"
+    "@luma.gl/engine": "npm:~9.3.0"
+    "@luma.gl/shadertools": "npm:~9.3.0"
+    "@luma.gl/webgl": "npm:~9.3.0"
+    "@luma.gl/webgpu": "npm:~9.3.0"
+    typescript: "npm:^5.9.3"
+    vite: "npm:^8.0.0"
+  languageName: unknown
+  linkType: soft
+
 "luma.gl-examples-api-video-texture@workspace:examples/api/video-texture":
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-api-video-texture@workspace:examples/api/video-texture"


### PR DESCRIPTION
## What changed

- Added a new GPU guide page that maps antialiasing and multisampling across WebGL canvas antialiasing, explicit WebGL/WebGPU MSAA, supersampling, FXAA/TAA, texture filtering, alpha cutouts, depth-aware effects, and shadow maps.
- Added a runnable embedded comparison example with single-sample baseline, FXAA, 2x/4x supersampling, texture sampling modes, depth visualization, and WebGPU/WebGL2 support.
- Added GPU-guide navigation and cross-links from rendering, parameters, textures, shader passes, and relevant core resource references.
- Clarified the current luma.gl boundary for offscreen multisampling and linked the proposed color-only resolve workflow in RFC #2741.

## Why

Issue #2702 exposed one piece of a broader topic: antialiasing is not a single switch. The guide gives users a decision framework for choosing the right technique and makes the limits of the current portable API explicit while the RFC is discussed.

## Validation

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn examples:typecheck`
- `yarn workspace luma.gl-examples-antialiasing build`
- `yarn build`
- `yarn website:build`
- `(cd website && yarn build)`
- pre-commit `test-fast`: 51 test files passed, 2 skipped
- Browser smoke test of the built docs page: verified WebGPU rendering, opened controls, and switched the comparison to 2x supersampling without new example-specific runtime errors

## Related

- RFC #2741