### PR TITLE
feat(experimental): Add clustered deferred lighting

### DIFF
--- a/docs/api-reference/experimental/README.md
+++ b/docs/api-reference/experimental/README.md
@@ -38,6 +38,11 @@ picking, or debug data.
 consumer of those targets. It reconstructs view position from depth and resolves a directional
 light plus a fixed-capacity storage buffer of point lights from two named material attachments.
 
+[`ClusteredLightGrid`](/docs/api-reference/experimental/clustered-lighting) scales the same
+material contract to hundreds of local lights. A WebGPU compute pass bins view-space light spheres
+into screen/depth clusters, and `clusteredDeferredLighting` evaluates only the current pixel's
+bounded light list.
+
 The [Shader Passes guide](/docs/api-guide/shaders/shader-passes) explains how a scene render,
 `GBuffer` bindings, deferred lighting, ordered `ShaderPassPipeline` effects, temporal history, and
 OIT resolve pipelines compose into one render stack.

--- a/docs/api-reference/experimental/clustered-lighting.md
+++ b/docs/api-reference/experimental/clustered-lighting.md
@@ -1,0 +1,137 @@
+import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-tabs';
+import {DeferredRenderingExample} from '@site/src/examples';
+
+# Clustered Lighting
+
+<ExperimentalDocsTabs active="clustered-lighting" />
+
+`ClusteredLightGrid` is an experimental WebGPU-only compute stage for many-light deferred
+rendering. It projects view-space point-light spheres into a fixed screen/depth grid, atomically
+marks candidate-light bit masks, compacts one stable bounded light-index list per cluster, and
+lets `clusteredDeferredLighting` evaluate only the list for the current pixel.
+
+The first implementation intentionally keeps the contract small and composable:
+
+- geometry still writes the ordinary `GBuffer` material attachments;
+- point-light records still use `makeDeferredPointLightBufferData()`;
+- one compute pass owns cluster binning;
+- one fullscreen shader-pass pipeline owns lighting;
+- later effects still consume the unchanged scene color, depth, normal, and velocity channels.
+
+<DeferredRenderingExample embedded showStats={false} />
+
+## Cluster contract
+
+The default grid is `16 × 9 × 24`: normalized screen x/y tiles plus logarithmic view-depth
+slices between the camera near and far planes. Each cluster retains up to 64 light indices.
+`MAX_CLUSTERED_POINT_LIGHTS` is 512.
+
+`ClusteredLightGrid` owns two storage buffers:
+
+| Binding | Payload |
+| --- | --- |
+| `clusterLightCounts` | Candidate count for each cluster. Values may exceed the retained capacity so debug views can expose overflow pressure. |
+| `clusterLightIndices` | Fixed-stride light-index list: `clusterIndex * maxLightsPerCluster + slot`. |
+
+The fullscreen resolve uses the compact list while it fits. Overflow is compacted in stable
+light-index order, then saturated pixels fall back to checking the full fixed-size point-light
+buffer so the image stays correct instead of exposing cluster-shaped truncation artifacts. That
+fallback is intentionally slower and makes the occupancy debug view useful for tuning dimensions,
+light ranges, and retained capacity.
+
+## Usage
+
+```ts
+import {Buffer} from '@luma.gl/core';
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {
+  ClusteredLightGrid,
+  createClusteredDeferredLightingShaderPassPipeline,
+  makeDeferredPointLightBufferData,
+  MAX_CLUSTERED_POINT_LIGHTS
+} from '@luma.gl/experimental';
+
+const pointLights = device.createBuffer({
+  data: makeDeferredPointLightBufferData([], MAX_CLUSTERED_POINT_LIGHTS),
+  usage: Buffer.STORAGE | Buffer.COPY_DST
+});
+
+const clusteredLightGrid = new ClusteredLightGrid(device, {
+  maxLightCount: MAX_CLUSTERED_POINT_LIGHTS
+});
+
+pointLights.write(makeDeferredPointLightBufferData(viewLights, MAX_CLUSTERED_POINT_LIGHTS));
+clusteredLightGrid.encode(device.commandEncoder, {
+  pointLights,
+  pointLightCount: viewLights.length,
+  projectionMatrix,
+  nearPlane,
+  farPlane
+});
+
+const renderer = new ShaderPassRenderer(device, {
+  shaderPasses: [createClusteredDeferredLightingShaderPassPipeline()],
+  colorFormat: 'rgba16float'
+});
+
+renderer.renderToScreen({
+  sourceTexture: gBuffer.colorTexture,
+  bindings: {
+    depthTexture: gBuffer.depthTexture,
+    normalTexture: gBuffer.normalRoughnessTexture,
+    baseColorMetallicTexture: gBuffer.getExtraColorTexture('baseColorMetallic'),
+    emissiveOcclusionTexture: gBuffer.getExtraColorTexture('emissiveOcclusion'),
+    pointLights,
+    ...clusteredLightGrid.getShaderPassBindings()
+  },
+  uniforms: {
+    clusteredDeferredLighting: {
+      inverseProjectionMatrix,
+      ambientColor,
+      directionalLightDirectionView,
+      directionalLightColor,
+      directionalLightIntensity,
+      ...clusteredLightGrid.getShaderPassUniforms(nearPlane, farPlane)
+    }
+  }
+});
+```
+
+Point-light positions are view-space values. Rebuild the grid after updating the light buffer and
+before encoding the fullscreen resolve. The grid does not own the `GBuffer`, renderer, material
+packing, camera, or point-light buffer.
+
+## API
+
+### `new ClusteredLightGrid(device, props?)`
+
+Creates the count/index storage buffers and the two compute kernels that clear and repopulate them.
+The optional props are `clusterDimensions`, `maxLightsPerCluster`, `maxLightCount`, and
+`id`.
+
+### `encode(commandEncoder, options): void`
+
+Encodes clear and binning dispatches into the supplied command encoder. `options` contains the
+point-light buffer and active count plus the projection matrix and near/far planes.
+
+### `getShaderPassBindings()`
+
+Returns `clusterLightCounts` and `clusterLightIndices` for
+`clusteredDeferredLighting`.
+
+### `getShaderPassUniforms(nearPlane, farPlane)`
+
+Returns the dimensions, retained capacity, and logarithmic depth-range uniforms needed by the
+fullscreen resolve.
+
+### `createClusteredDeferredLightingShaderPassPipeline()`
+
+Returns a one-step `ShaderPassPipeline` that resolves the current cluster's point-light list into
+the ordered `previous` color chain.
+
+## Related pages
+
+- [Deferred Lighting](/docs/api-reference/experimental/deferred-lighting) documents the shared
+  G-buffer material contract and the fixed 64-light baseline resolve.
+- [GBuffer](/docs/api-reference/experimental/g-buffer) owns the scene MRT attachments.
+- [Shader Passes](/docs/api-guide/shaders/shader-passes) explains ordered fullscreen composition.

--- a/docs/api-reference/experimental/clustered-lighting.md
+++ b/docs/api-reference/experimental/clustered-lighting.md
@@ -34,10 +34,10 @@ slices between the camera near and far planes. Each cluster retains up to 64 lig
 | `clusterLightIndices` | Fixed-stride light-index list: `clusterIndex * maxLightsPerCluster + slot`. |
 
 The fullscreen resolve uses the compact list while it fits. Overflow is compacted in stable
-light-index order, then saturated pixels fall back to checking the full fixed-size point-light
-buffer so the image stays correct instead of exposing cluster-shaped truncation artifacts. That
-fallback is intentionally slower and makes the occupancy debug view useful for tuning dimensions,
-light ranges, and retained capacity.
+light-index order, then saturated pixels fall back to checking the active prefix of the fixed-size
+point-light buffer so the image stays correct instead of exposing cluster-shaped truncation
+artifacts or reusing stale light records. That fallback is intentionally slower and makes the
+occupancy debug view useful for tuning dimensions, light ranges, and retained capacity.
 
 ## Usage
 
@@ -121,8 +121,8 @@ Returns `clusterLightCounts` and `clusterLightIndices` for
 
 ### `getShaderPassUniforms(nearPlane, farPlane)`
 
-Returns the dimensions, retained capacity, and logarithmic depth-range uniforms needed by the
-fullscreen resolve.
+Returns the dimensions, retained capacity, active point-light count from the latest `encode()`,
+and logarithmic depth-range uniforms needed by the fullscreen resolve.
 
 ### `createClusteredDeferredLightingShaderPassPipeline()`
 

--- a/docs/api-reference/experimental/deferred-lighting.md
+++ b/docs/api-reference/experimental/deferred-lighting.md
@@ -129,6 +129,8 @@ across frames. `MAX_DEFERRED_POINT_LIGHTS` is 64 and matches the shader loop bou
 
 - [`GBuffer`](/docs/api-reference/experimental/g-buffer) owns the MRT attachments and standard
   depth, normal, and velocity bindings.
+- [Clustered Lighting](/docs/api-reference/experimental/clustered-lighting) reuses the same
+  material attachments with compute-built light lists for hundreds of local lights.
 - [Shader Passes](/docs/api-guide/shaders/shader-passes) explains the ordered composable render
   stack.
 - [Advanced Effects](/examples/experimental/advanced-effects) shows the broader scene-aware and

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -182,6 +182,7 @@
           "api-reference/experimental/README",
           "api-reference/experimental/g-buffer",
           "api-reference/experimental/deferred-lighting",
+          "api-reference/experimental/clustered-lighting",
           "api-reference/experimental/shadow-map-renderer",
           {
             "type": "category",
@@ -262,6 +263,7 @@
           "api-reference/experimental/README",
           "api-reference/experimental/g-buffer",
           "api-reference/experimental/deferred-lighting",
+          "api-reference/experimental/clustered-lighting",
           "api-reference/experimental/shadow-map-renderer",
           {
             "type": "category",

--- a/examples/experimental/a-buffer/app.ts
+++ b/examples/experimental/a-buffer/app.ts
@@ -282,7 +282,12 @@ export default class OrderIndependentTransparencyExample extends AnimationLoopTe
             title: 'Description',
             html: A_BUFFER_DESCRIPTION_HTML
           }),
-          this.settingsPanel.makePanel()
+          this.settingsPanel.makePanel(),
+          makeHtmlCustomPanel({
+            id: 'a-buffer-background',
+            title: 'Background',
+            html: A_BUFFER_BACKGROUND_HTML
+          })
         ]
       })
     });
@@ -602,6 +607,12 @@ const A_BUFFER_DESCRIPTION_HTML = `\
   <div><strong>Weighted blended OIT</strong><br>Accumulates weighted color and revealage into floating-point offscreen targets, then composites once. It avoids sorting and works on WebGPU or WebGL2 when float render-target blending is available, but it is approximate.</div>
   <div><strong>Standard alpha blending</strong><br>Blends translucent draws directly into the framebuffer in submission order. It is the cheapest fallback, but unsorted overlaps produce visibly incorrect results.</div>
 </div>`;
+
+const A_BUFFER_BACKGROUND_HTML = `\
+<p><b>Why transparency is hard:</b> ordinary alpha blending is order dependent. Correct color requires fragments for the same pixel to be composited back-to-front, but draw submission order rarely matches depth order for intersecting translucent geometry.</p>
+<p><b>A-buffer OIT:</b> the capture pass stores each translucent fragment's color and depth in GPU storage. A resolve pass gathers the fragments for one pixel, sorts them by depth, and composites them back-to-front. The result is exact up to the configured per-pixel storage budget.</p>
+<p><b>Weighted blended OIT:</b> instead of sorting, two blended render targets accumulate weighted color and revealage. The final resolve estimates the transparent stack in one pass. It is usually faster and more portable, but dense overlaps can reveal the approximation.</p>
+<p><b>Performance trade-off:</b> A-buffer quality costs storage, atomics, and per-pixel sorting; weighted blending costs extra attachments and bandwidth; ordinary alpha blending is cheapest but makes correctness the caller's draw-order problem.</p>`;
 
 function createSceneFramebuffer(device: Device, width: number, height: number): Framebuffer {
   const colorTexture = device.createTexture({

--- a/examples/experimental/advanced-effects/app.ts
+++ b/examples/experimental/advanced-effects/app.ts
@@ -30,7 +30,6 @@ import {
 import type {ShaderModule, ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
 import {Matrix4, radians, type NumberArray3} from '@math.gl/core';
 import {
-  ColumnPanel,
   type Panel,
   type SettingsChangeDescriptor,
   type SettingsSchema
@@ -40,6 +39,7 @@ import {
   ExampleSettingsPanelManager,
   getChangedSetting,
   makeExamplePanelHostHtml,
+  makeExampleTabbedPanel,
   makeHtmlCustomPanel
 } from '../../example-panels';
 import {ComparisonSplitter} from './comparison-splitter';
@@ -200,6 +200,13 @@ const DEFAULT_SETTINGS: AdvancedEffectsSettings = {
   pointShadowsEnabled: true,
   contactShadowsEnabled: true
 };
+
+const ADVANCED_EFFECTS_BACKGROUND_HTML = `
+<p><b>Hybrid render stack:</b> the city first writes a shared G-buffer with scene color, depth, normals, and velocity. Shadow maps handle geometric visibility from directional, spot, and point lights; screen-space passes then reuse the same buffers for contact shadows, ambient occlusion, reflections, fog, outlines, temporal antialiasing, and motion blur.</p>
+<p><b>Why this is composable:</b> each fullscreen effect declares the textures it reads and writes into an ordered <code>ShaderPassPipeline</code>. Effects can be toggled or reordered without changing the scene draw, while depth/normal/velocity-aware passes avoid treating the image as a flat bitmap.</p>
+<p><b>Where the GPU work goes:</b> shadow maps trade extra light-view geometry passes for stable long-range occlusion. Screen-space effects trade texture bandwidth and fullscreen pixels for details that would be expensive to model with more scene geometry or rays. TAA and motion blur additionally consume frame history and velocity.</p>
+<p><b>What to watch:</b> debug views expose the intermediate contracts. The comparison split shows the cost/quality boundary between the base draw and the composed stack.</p>
+`;
 
 type CityUniforms = {
   viewProjectionMatrix: Matrix4;
@@ -751,16 +758,21 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   }
 
   private makePanel(): Panel {
-    return new ColumnPanel({
-      id: 'advanced-effects-controls',
+    return makeExampleTabbedPanel({
+      id: 'advanced-effects-tabs',
       title: 'Visualization City',
       panels: [
         makeHtmlCustomPanel({
           id: 'advanced-effects-description',
-          title: '',
+          title: 'Overview',
           html: '<p><b>Hybrid shadows + screen-space rendering</b></p><p>Drag the divider to compare the unshadowed city with cascaded sun, spot, point, and contact shadows followed by SSAO, SSR, fog, outlines, TAA, and motion blur.</p>'
         }),
-        this.settingsPanel.makePanel()
+        this.settingsPanel.makePanel(),
+        makeHtmlCustomPanel({
+          id: 'advanced-effects-background',
+          title: 'Background',
+          html: ADVANCED_EFFECTS_BACKGROUND_HTML
+        })
       ]
     });
   }

--- a/examples/experimental/antialiasing/app.ts
+++ b/examples/experimental/antialiasing/app.ts
@@ -15,16 +15,12 @@ import {
   ShaderPassRenderer
 } from '@luma.gl/engine';
 import type {ShaderModule} from '@luma.gl/shadertools';
-import {
-  ColumnPanel,
-  type Panel,
-  type SettingsSchema,
-  type SettingsState
-} from '@deck.gl-community/panels';
+import {type Panel, type SettingsSchema, type SettingsState} from '@deck.gl-community/panels';
 import {
   ExamplePanelManager,
   ExampleSettingsPanelManager,
   makeExamplePanelHostHtml,
+  makeExampleTabbedPanel,
   makeHtmlCustomPanel
 } from '../../example-panels';
 import {ComparisonSplitter} from '../../experimental/advanced-effects/comparison-splitter';
@@ -128,6 +124,13 @@ const DEFAULT_SETTINGS: AntialiasingSettings = {
   zoom: 1,
   split: 0.5
 };
+
+const ANTIALIASING_BACKGROUND_HTML = `
+<p><b>Aliasing is under-sampling:</b> one pixel sample cannot represent thin geometry, diagonal edges, alpha cutouts, or minified texture detail that changes faster than the pixel grid.</p>
+<p><b>FXAA:</b> a fullscreen shader detects high-contrast edges in the finished image and smooths along them. It is cheap and works after any render path, but it cannot recover hidden subpixel geometry or texture detail.</p>
+<p><b>Supersampling:</b> render the scene into a 2× or 4× larger offscreen target, then filter down once. It improves geometry, shading, and texture aliasing together, but pixel cost grows with area: 2× per axis means roughly 4× fragments; 4× means roughly 16×.</p>
+<p><b>Texture sampling:</b> mipmaps choose prefiltered resolution for minification and anisotropy spends extra samples along steep texture footprints. These solve texture-frequency aliasing, complementing edge antialiasing rather than replacing it.</p>
+`;
 
 const appShaderModule = {
   name: 'app',
@@ -579,16 +582,21 @@ export default class AntialiasingAnimationLoopTemplate extends AnimationLoopTemp
   }
 
   private makePanel(): Panel {
-    return new ColumnPanel({
-      id: 'antialiasing-controls',
-      title: 'Controls',
+    return makeExampleTabbedPanel({
+      id: 'antialiasing-tabs',
+      title: 'Antialiasing Techniques',
       panels: [
         makeHtmlCustomPanel({
           id: 'antialiasing-description',
-          title: '',
+          title: 'Overview',
           html: makeDescriptionHtml(this.settings, this.effectiveSupersampleScale)
         }),
-        this.settingsPanel.makePanel()
+        this.settingsPanel.makePanel(),
+        makeHtmlCustomPanel({
+          id: 'antialiasing-background',
+          title: 'Background',
+          html: ANTIALIASING_BACKGROUND_HTML
+        })
       ]
     });
   }

--- a/examples/experimental/bloom/app.ts
+++ b/examples/experimental/bloom/app.ts
@@ -13,7 +13,6 @@ import {Device} from '@luma.gl/core';
 import {bloom, bloomShaderPassPipeline} from '@luma.gl/effects';
 import type {ShaderPassPipeline} from '@luma.gl/shadertools';
 import {
-  ColumnPanel,
   type Panel,
   type SettingsChangeDescriptor,
   type SettingsSchema
@@ -23,6 +22,7 @@ import {
   ExampleSettingsPanelManager,
   getChangedSetting,
   makeExamplePanelHostHtml,
+  makeExampleTabbedPanel,
   makeHtmlCustomPanel
 } from '../../example-panels';
 
@@ -31,6 +31,13 @@ const BLOOM_UNIFORMS = {
   intensity: 1.8,
   radius: 8
 } as const;
+
+const BLOOM_BACKGROUND_HTML = `
+<p><b>Bloom is an HDR post-process:</b> the scene is rendered first, then a bright-pass threshold extracts only energetic pixels into a smaller offscreen texture.</p>
+<p><b>Why multiple blur stages:</b> separable horizontal/vertical blurs and downsampled targets spread highlights over a wide radius with far fewer texture reads than one huge full-resolution kernel. The blurred pyramid is then recomposed over the original image.</p>
+<p><b>Performance model:</b> cost is mostly fullscreen texture bandwidth, not scene complexity. Lower-resolution blur targets make glow radius cheap, while threshold and intensity control how much energy enters and returns from the bloom chain.</p>
+<p><b>What to inspect:</b> raise threshold to isolate only the brightest source pixels, increase radius to expose the blur footprint, and adjust intensity to see the final additive recomposition.</p>
+`;
 
 type BloomState = Record<'threshold' | 'intensity' | 'radius', number>;
 type ShaderPropType = NonNullable<typeof bloom.propTypes>[string];
@@ -103,16 +110,21 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   }
 
   private makePanel(): Panel {
-    return new ColumnPanel({
-      id: 'bloom-controls',
-      title: 'Controls',
+    return makeExampleTabbedPanel({
+      id: 'bloom-tabs',
+      title: 'Effects: Bloom',
       panels: [
         makeHtmlCustomPanel({
           id: 'bloom-description',
-          title: '',
+          title: 'Overview',
           html: '<p>Experimental bloom pipeline demo using extracted highlights, multi-stage blur targets, and final recomposition.</p>'
         }),
-        this.settingsPanel.makePanel()
+        this.settingsPanel.makePanel(),
+        makeHtmlCustomPanel({
+          id: 'bloom-background',
+          title: 'Background',
+          html: BLOOM_BACKGROUND_HTML
+        })
       ]
     });
   }

--- a/examples/experimental/deferred-rendering/app.ts
+++ b/examples/experimental/deferred-rendering/app.ts
@@ -13,16 +13,16 @@ import {
   SphereGeometry
 } from '@luma.gl/engine';
 import {
-  createDeferredLightingShaderPassPipeline,
+  ClusteredLightGrid,
+  createClusteredDeferredLightingShaderPassPipeline,
   GBuffer,
   makeDeferredPointLightBufferData,
-  MAX_DEFERRED_POINT_LIGHTS,
+  MAX_CLUSTERED_POINT_LIGHTS,
   type DeferredPointLight
 } from '@luma.gl/experimental';
 import type {ShaderModule, ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
 import {Matrix4, radians, type NumberArray3} from '@math.gl/core';
 import {
-  ColumnPanel,
   type Panel,
   type SettingsChangeDescriptor,
   type SettingsSchema
@@ -31,13 +31,14 @@ import {
   ExamplePanelManager,
   ExampleSettingsPanelManager,
   makeExamplePanelHostHtml,
+  makeExampleTabbedPanel,
   makeHtmlCustomPanel
 } from '../../example-panels';
 
 const NEAR_PLANE = 0.1;
 const FAR_PLANE = 100;
 const GRID_SIZE = 7;
-const MAX_EXAMPLE_POINT_LIGHTS = 32;
+const MAX_EXAMPLE_POINT_LIGHTS = MAX_CLUSTERED_POINT_LIGHTS;
 const LIGHT_COLORS: readonly NumberArray3[] = [
   [1, 0.18, 0.08],
   [0.18, 0.55, 1],
@@ -54,7 +55,8 @@ type DebugView =
   | 'Roughness'
   | 'Metallic'
   | 'Emissive'
-  | 'Depth';
+  | 'Depth'
+  | 'Cluster Occupancy';
 
 type DeferredRenderingSettings = {
   debugView: DebugView;
@@ -66,11 +68,18 @@ type DeferredRenderingSettings = {
 
 const DEFAULT_SETTINGS: DeferredRenderingSettings = {
   debugView: 'Final',
-  pointLightCount: 18,
+  pointLightCount: 256,
   animate: true,
   exposure: 1.15,
   sunIntensity: 2.8
 };
+
+const DEFERRED_RENDERING_BACKGROUND_HTML = `
+<p><b>Why deferred rendering scales:</b> forward shading repeats material work for every light that touches every draw. Here the geometry pass writes base color, metalness, roughness, emissive, normal, velocity, and depth once; the fullscreen resolve reuses those screen-space values for lighting.</p>
+<p><b>Why clustering wins:</b> a WebGPU compute stage projects each view-space light sphere into a <code>16 × 9 × 24</code> screen/log-depth grid. Each pixel reconstructs its view position from depth, finds one cluster, and normally evaluates only that short local list instead of all 512 lights.</p>
+<p><b>Work changes shape:</b> the expensive path becomes roughly geometry + visible pixels × lights in the local cluster, instead of objects × every light. The same G-buffer also feeds later SSAO, SSR, fog, outline, temporal, and motion effects without redrawing material geometry.</p>
+<p><b>Correctness at the limit:</b> candidate bits are compacted in stable light-index order. If a cluster exceeds its retained list, that pixel falls back to the full fixed-size light buffer rather than showing tile-shaped truncation; the <b>Cluster Occupancy</b> view shows where that slower fallback is being requested.</p>
+`;
 
 type DeferredSurfaceUniforms = {
   viewProjectionMatrix: Matrix4;
@@ -159,8 +168,15 @@ fn fragmentMain(inputs: FragmentInputs) -> FragmentOutputs {
 }`;
 
 type DeferredDisplayUniforms = {
+  inverseProjectionMatrix: Matrix4;
   debugMode: number;
   exposure: number;
+  clusterCountX: number;
+  clusterCountY: number;
+  clusterCountZ: number;
+  maxLightsPerCluster: number;
+  clusterNearPlane: number;
+  clusterFarPlane: number;
 };
 
 type DeferredDisplayBindings = {
@@ -168,14 +184,22 @@ type DeferredDisplayBindings = {
   normalTexture?: Texture;
   baseColorMetallicTexture?: Texture;
   emissiveOcclusionTexture?: Texture;
+  clusterLightCounts?: Buffer;
 };
 
 const deferredDisplay = {
   name: 'deferredDisplay',
   source: /* wgsl */ `\
 struct DeferredDisplayUniforms {
+  inverseProjectionMatrix: mat4x4f,
   debugMode: f32,
   exposure: f32,
+  clusterCountX: u32,
+  clusterCountY: u32,
+  clusterCountZ: u32,
+  maxLightsPerCluster: u32,
+  clusterNearPlane: f32,
+  clusterFarPlane: f32,
 };
 @group(0) @binding(auto) var<uniform> deferredDisplay: DeferredDisplayUniforms;
 @group(0) @binding(auto) var depthTexture: texture_depth_2d;
@@ -185,12 +209,54 @@ struct DeferredDisplayUniforms {
 @group(0) @binding(auto) var baseColorMetallicTexture: texture_2d<f32>;
 @group(0) @binding(auto) var baseColorMetallicTextureSampler: sampler;
 @group(0) @binding(auto) var emissiveOcclusionTexture: texture_2d<u32>;
+@group(0) @binding(auto) var<storage, read> clusterLightCounts: array<u32>;
 
 fn deferredDisplay_toneMap(color: vec3f) -> vec3f {
   let exposed = max(color * deferredDisplay.exposure, vec3f(0.0));
   let mapped = (exposed * (2.51 * exposed + 0.03)) /
     (exposed * (2.43 * exposed + 0.59) + 0.14);
   return pow(clamp(mapped, vec3f(0.0), vec3f(1.0)), vec3f(1.0 / 2.2));
+}
+
+fn deferredDisplay_reconstructViewPosition(uv: vec2f, depth: f32) -> vec3f {
+  let clip = vec4f(uv.x * 2.0 - 1.0, 1.0 - uv.y * 2.0, depth, 1.0);
+  let viewPosition = deferredDisplay.inverseProjectionMatrix * clip;
+  return viewPosition.xyz / max(viewPosition.w, 0.00001);
+}
+
+fn deferredDisplay_getClusterIndex(texCoord: vec2f, viewPosition: vec3f) -> u32 {
+  let tileX = min(
+    u32(clamp(texCoord.x, 0.0, 0.999999) * f32(deferredDisplay.clusterCountX)),
+    deferredDisplay.clusterCountX - 1u
+  );
+  let tileY = min(
+    u32(clamp(texCoord.y, 0.0, 0.999999) * f32(deferredDisplay.clusterCountY)),
+    deferredDisplay.clusterCountY - 1u
+  );
+  let viewDepth = clamp(
+    -viewPosition.z,
+    deferredDisplay.clusterNearPlane,
+    deferredDisplay.clusterFarPlane
+  );
+  let normalizedDepth = clamp(
+    log(viewDepth / deferredDisplay.clusterNearPlane) /
+      log(deferredDisplay.clusterFarPlane / deferredDisplay.clusterNearPlane),
+    0.0,
+    0.999999
+  );
+  let depthSlice = min(
+    u32(normalizedDepth * f32(deferredDisplay.clusterCountZ)),
+    deferredDisplay.clusterCountZ - 1u
+  );
+  return (depthSlice * deferredDisplay.clusterCountY + tileY) *
+    deferredDisplay.clusterCountX + tileX;
+}
+
+fn deferredDisplay_heatMap(value: f32) -> vec3f {
+  let cold = vec3f(0.04, 0.08, 0.35);
+  let warm = vec3f(0.95, 0.18, 0.08);
+  let hot = vec3f(1.0, 0.92, 0.22);
+  return mix(mix(cold, warm, clamp(value * 2.0, 0.0, 1.0)), hot, clamp(value * 2.0 - 1.0, 0.0, 1.0));
 }
 
 fn deferredDisplay_sampleColor(
@@ -223,6 +289,19 @@ fn deferredDisplay_sampleColor(
   }
   if (deferredDisplay.debugMode > 5.5) {
     let depth = textureSampleLevel(depthTexture, depthTextureSampler, texCoord, 0);
+    if (deferredDisplay.debugMode > 6.5) {
+      if (depth >= 0.99999) {
+        return vec4f(0.0, 0.0, 0.0, 1.0);
+      }
+      let viewPosition = deferredDisplay_reconstructViewPosition(texCoord, depth);
+      let clusterIndex = deferredDisplay_getClusterIndex(texCoord, viewPosition);
+      let occupancy = clamp(
+        f32(clusterLightCounts[clusterIndex]) / f32(max(deferredDisplay.maxLightsPerCluster, 1u)),
+        0.0,
+        1.0
+      );
+      return vec4f(deferredDisplay_heatMap(occupancy), 1.0);
+    }
     return vec4f(vec3f(pow(depth, 24.0)), 1.0);
   }
   let color = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord, 0).rgb;
@@ -232,14 +311,32 @@ fn deferredDisplay_sampleColor(
     {name: 'depthTexture', group: 0},
     {name: 'normalTexture', group: 0},
     {name: 'baseColorMetallicTexture', group: 0},
-    {name: 'emissiveOcclusionTexture', group: 0}
+    {name: 'emissiveOcclusionTexture', group: 0},
+    {name: 'clusterLightCounts', group: 0}
   ],
   uniforms: {} as DeferredDisplayUniforms,
   bindings: {} as DeferredDisplayBindings,
-  uniformTypes: {debugMode: 'f32', exposure: 'f32'},
+  uniformTypes: {
+    inverseProjectionMatrix: 'mat4x4<f32>',
+    debugMode: 'f32',
+    exposure: 'f32',
+    clusterCountX: 'u32',
+    clusterCountY: 'u32',
+    clusterCountZ: 'u32',
+    maxLightsPerCluster: 'u32',
+    clusterNearPlane: 'f32',
+    clusterFarPlane: 'f32'
+  },
   propTypes: {
+    inverseProjectionMatrix: {value: new Matrix4(), private: true},
     debugMode: {value: 0, private: true},
-    exposure: {value: DEFAULT_SETTINGS.exposure, min: 0.1, softMax: 3}
+    exposure: {value: DEFAULT_SETTINGS.exposure, min: 0.1, softMax: 3},
+    clusterCountX: {value: 16, private: true},
+    clusterCountY: {value: 9, private: true},
+    clusterCountZ: {value: 24, private: true},
+    maxLightsPerCluster: {value: 64, private: true},
+    clusterNearPlane: {value: NEAR_PLANE, private: true},
+    clusterFarPlane: {value: FAR_PLANE, private: true}
   },
   passes: [{sampler: true}]
 } as const satisfies ShaderPass<
@@ -345,6 +442,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly floor: InstancedSurfaceModel;
   readonly lightMarkers: InstancedSurfaceModel;
   readonly pointLightBuffer: Buffer;
+  readonly clusteredLightGrid: ClusteredLightGrid;
   readonly panels: ExamplePanelManager;
   readonly settingsPanel: ExampleSettingsPanelManager;
   sceneGBuffer: GBuffer;
@@ -374,8 +472,12 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     });
     this.pointLightBuffer = device.createBuffer({
       id: 'deferred-point-lights',
-      data: makeDeferredPointLightBufferData([], MAX_DEFERRED_POINT_LIGHTS),
+      data: makeDeferredPointLightBufferData([], MAX_CLUSTERED_POINT_LIGHTS),
       usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    this.clusteredLightGrid = new ClusteredLightGrid(device, {
+      id: 'deferred-clustered-lights',
+      maxLightCount: MAX_CLUSTERED_POINT_LIGHTS
     });
     this.sceneGBuffer = createSceneGBuffer(device, width, height);
     this.renderer = createRenderer(device);
@@ -434,9 +536,16 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     );
     const lightState = makeAnimatedPointLights(time, activeLightCount, viewMatrix);
     this.pointLightBuffer.write(
-      makeDeferredPointLightBufferData(lightState.viewLights, MAX_DEFERRED_POINT_LIGHTS)
+      makeDeferredPointLightBufferData(lightState.viewLights, MAX_CLUSTERED_POINT_LIGHTS)
     );
     this.lightMarkers.positionBuffer.write(lightState.markerPositions);
+    this.clusteredLightGrid.encode(device.commandEncoder, {
+      pointLights: this.pointLightBuffer,
+      pointLightCount: activeLightCount,
+      projectionMatrix,
+      nearPlane: NEAR_PLANE,
+      farPlane: FAR_PLANE
+    });
 
     const renderPass = device.beginRenderPass({
       framebuffer: this.sceneGBuffer.framebuffer,
@@ -460,6 +569,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const directionalLightDirectionView = normalize3(
       viewMatrix.transformAsVector([0.42, 0.82, 0.38]) as NumberArray3
     );
+    const clusterUniforms = this.clusteredLightGrid.getShaderPassUniforms(NEAR_PLANE, FAR_PLANE);
     this.renderer.renderToScreen({
       sourceTexture: this.sceneGBuffer.colorTexture,
       bindings: {
@@ -467,20 +577,23 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         normalTexture,
         baseColorMetallicTexture,
         emissiveOcclusionTexture,
-        pointLights: this.pointLightBuffer
+        pointLights: this.pointLightBuffer,
+        ...this.clusteredLightGrid.getShaderPassBindings()
       },
       uniforms: {
-        deferredLighting: {
+        clusteredDeferredLighting: {
           inverseProjectionMatrix,
           ambientColor: [0.028, 0.034, 0.055],
           directionalLightDirectionView,
           directionalLightColor: [1, 0.86, 0.68],
           directionalLightIntensity: this.settings.sunIntensity,
-          pointLightCount: activeLightCount
+          ...clusterUniforms
         },
         deferredDisplay: {
+          inverseProjectionMatrix,
           debugMode: getDebugMode(this.settings.debugView),
-          exposure: this.settings.exposure
+          exposure: this.settings.exposure,
+          ...clusterUniforms
         }
       }
     });
@@ -496,21 +609,27 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.floor.destroy();
     this.lightMarkers.destroy();
     this.pointLightBuffer.destroy();
+    this.clusteredLightGrid.destroy();
     this.renderer.destroy();
     this.sceneGBuffer.destroy();
   }
 
   private makePanel(): Panel {
-    return new ColumnPanel({
-      id: 'deferred-rendering-controls',
+    return makeExampleTabbedPanel({
+      id: 'deferred-rendering-tabs',
       title: 'Deferred Material Lab',
       panels: [
         makeHtmlCustomPanel({
           id: 'deferred-rendering-description',
-          title: '',
-          html: '<p><b>One geometry pass. Dozens of lights.</b></p><p>Each sphere writes base color, metalness, roughness, emissive, normal, velocity, and depth once. A fullscreen Cook-Torrance resolve reconstructs view position from depth and evaluates the animated storage-buffer lights.</p><p>Switch Debug View to inspect the actual G-buffer contract.</p>'
+          title: 'Overview',
+          html: '<p><b>One geometry pass. Hundreds of lights.</b></p><p>Each sphere writes base color, metalness, roughness, emissive, normal, velocity, and depth once. A WebGPU compute pass bins animated lights into screen/depth clusters before the fullscreen Cook-Torrance resolve evaluates only the current pixel cluster.</p><p>Switch Debug View to inspect the actual G-buffer contract.</p>'
         }),
-        this.settingsPanel.makePanel()
+        this.settingsPanel.makePanel(),
+        makeHtmlCustomPanel({
+          id: 'deferred-rendering-background',
+          title: 'Background',
+          html: DEFERRED_RENDERING_BACKGROUND_HTML
+        })
       ]
     });
   }
@@ -525,7 +644,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
 function createRenderer(device: Device): ShaderPassRenderer {
   return new ShaderPassRenderer(device, {
-    shaderPasses: [createDeferredLightingShaderPassPipeline(), deferredDisplayPipeline],
+    shaderPasses: [createClusteredDeferredLightingShaderPassPipeline(), deferredDisplayPipeline],
     colorFormat: 'rgba16float',
     flipY: true
   });
@@ -595,7 +714,7 @@ function makeLightMarkerData(): SurfaceInstanceData {
   for (let lightIndex = 0; lightIndex < MAX_EXAMPLE_POINT_LIGHTS; lightIndex++) {
     positions[lightIndex * 3 + 1] = -1000;
     const color = LIGHT_COLORS[lightIndex % LIGHT_COLORS.length]!;
-    scales.push(0.14, 0.14, 0.14);
+    scales.push(0.075, 0.075, 0.075);
     baseColors.push(color[0], color[1], color[2], 1);
     materials.push(0.18, 0);
     emissiveColors.push(color[0], color[1], color[2]);
@@ -624,22 +743,25 @@ function makeAnimatedPointLights(
       continue;
     }
 
-    const ring = lightIndex % 2;
-    const ringCount = Math.max(1, Math.ceil(lightCount / 2));
-    const angle = (lightIndex / ringCount) * Math.PI * 2 + time * (ring === 0 ? 0.42 : -0.31);
-    const radius = ring === 0 ? 8.4 : 5.2;
+    const ring = lightIndex % 8;
+    const ringCount = Math.max(1, Math.ceil(lightCount / 8));
+    const angle =
+      (Math.floor(lightIndex / 8) / ringCount) * Math.PI * 2 +
+      ring * 0.41 +
+      time * (ring % 2 === 0 ? 0.42 : -0.31);
+    const radius = 3.4 + ring * 1.45;
     const worldPosition: NumberArray3 = [
       Math.cos(angle) * radius,
-      2.2 + ring * 2.2 + Math.sin(time * 1.7 + lightIndex) * 0.75,
+      0.9 + (ring % 4) * 1.1 + Math.sin(time * 1.7 + lightIndex) * 0.48,
       Math.sin(angle) * radius
     ];
     const color = LIGHT_COLORS[lightIndex % LIGHT_COLORS.length]!;
     markerPositions.set(worldPosition, offset);
     viewLights.push({
       position: viewMatrix.transformAsPoint(worldPosition) as [number, number, number],
-      range: ring === 0 ? 7.8 : 6.2,
+      range: 3.6 + (ring % 3) * 0.55,
       color: [color[0], color[1], color[2]],
-      intensity: ring === 0 ? 15 : 11
+      intensity: 7.5 + (ring % 3) * 1.2
     });
   }
   return {viewLights, markerPositions};
@@ -677,6 +799,8 @@ function getDebugMode(debugView: DebugView): number {
       return 5;
     case 'Depth':
       return 6;
+    case 'Cluster Occupancy':
+      return 7;
     default:
       return 0;
   }
@@ -703,7 +827,8 @@ function makeSettingsSchema(): SettingsSchema {
               'Roughness',
               'Metallic',
               'Emissive',
-              'Depth'
+              'Depth',
+              'Cluster Occupancy'
             ]
           },
           {

--- a/modules/experimental/src/index.ts
+++ b/modules/experimental/src/index.ts
@@ -77,6 +77,21 @@ export {
   makeDeferredPointLightBufferData,
   MAX_DEFERRED_POINT_LIGHTS
 } from './rendering/deferred-lighting';
+export type {
+  ClusteredDeferredLightingProps,
+  ClusteredLightGridBindings,
+  ClusteredLightGridEncodeOptions,
+  ClusteredLightGridProps,
+  ClusteredLightGridShaderPassUniforms
+} from './rendering/clustered-lighting';
+export {
+  ClusteredLightGrid,
+  clusteredDeferredLighting,
+  createClusteredDeferredLightingShaderPassPipeline,
+  DEFAULT_CLUSTER_DIMENSIONS,
+  DEFAULT_MAX_LIGHTS_PER_CLUSTER,
+  MAX_CLUSTERED_POINT_LIGHTS
+} from './rendering/clustered-lighting';
 
 export type {OrbitControlsProps, OrbitPosition} from './controls/orbit-controls';
 export {OrbitControls} from './controls/orbit-controls';

--- a/modules/experimental/src/rendering/clustered-lighting.ts
+++ b/modules/experimental/src/rendering/clustered-lighting.ts
@@ -1,0 +1,771 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CommandEncoder, Device} from '@luma.gl/core';
+import {Buffer} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import type {Matrix4Like, NumberArray3, NumberArray16} from '@math.gl/core';
+import type {ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
+
+export const MAX_CLUSTERED_POINT_LIGHTS = 512;
+export const DEFAULT_CLUSTER_DIMENSIONS = [16, 9, 24] as const;
+export const DEFAULT_MAX_LIGHTS_PER_CLUSTER = 64;
+
+const CLUSTER_WORKGROUP_SIZE = 64;
+const CLUSTERED_LIGHT_GRID_UNIFORM_BYTE_LENGTH = 80;
+const IDENTITY_MATRIX: NumberArray16 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+/** Construction props for the fixed-capacity WebGPU light-cluster grid. */
+export type ClusteredLightGridProps = {
+  /** Optional debug-resource prefix. */
+  id?: string;
+  /** Screen-x, screen-y, and logarithmic depth-slice counts. */
+  clusterDimensions?: readonly [number, number, number];
+  /** Maximum retained light indices in one cluster. */
+  maxLightsPerCluster?: number;
+  /** Maximum point-light records accepted by encode(). */
+  maxLightCount?: number;
+};
+
+/** Per-frame camera and light inputs used to rebuild the cluster lists. */
+export type ClusteredLightGridEncodeOptions = {
+  /** Fixed-size view-space DeferredPointLight storage buffer. */
+  pointLights: Buffer;
+  /** Active prefix length in pointLights. */
+  pointLightCount: number;
+  /** Camera projection used to conservatively project light spheres into screen tiles. */
+  projectionMatrix: Readonly<Matrix4Like>;
+  /** Positive view-space near plane. */
+  nearPlane: number;
+  /** Positive view-space far plane. */
+  farPlane: number;
+};
+
+/** Storage bindings consumed by clusteredDeferredLighting. */
+export type ClusteredLightGridBindings = {
+  clusterLightCounts: Buffer;
+  clusterLightIndices: Buffer;
+};
+
+/** Uniform values consumed by clusteredDeferredLighting to locate one pixel's cluster. */
+export type ClusteredLightGridShaderPassUniforms = {
+  clusterCountX: number;
+  clusterCountY: number;
+  clusterCountZ: number;
+  maxLightsPerCluster: number;
+  clusterNearPlane: number;
+  clusterFarPlane: number;
+};
+
+/**
+ * Builds fixed-capacity screen/depth light lists entirely on WebGPU.
+ *
+ * One compute invocation projects each view-space point-light sphere into the overlapping
+ * x/y/z cluster range and atomically marks its light bit. A second compute dispatch compacts
+ * each bit mask in stable light-index order. Indices beyond maxLightsPerCluster are
+ * intentionally dropped so the fullscreen lighting pass has a predictable loop bound without
+ * nondeterministic overflow shimmer.
+ */
+export class ClusteredLightGrid {
+  readonly device: Device;
+  readonly id: string;
+  readonly clusterDimensions: readonly [number, number, number];
+  readonly maxLightsPerCluster: number;
+  readonly maxLightCount: number;
+  readonly clusterCount: number;
+  readonly clusterLightCounts: Buffer;
+  readonly clusterLightIndices: Buffer;
+
+  private readonly clusterLightBitMask: Buffer;
+  private readonly uniformBuffer: Buffer;
+  private readonly clearComputation: Computation;
+  private readonly binningComputation: Computation;
+  private readonly compactComputation: Computation;
+
+  constructor(device: Device, props: ClusteredLightGridProps = {}) {
+    if (device.type !== 'webgpu') {
+      throw new Error('ClusteredLightGrid requires WebGPU.');
+    }
+
+    this.device = device;
+    this.id = props.id || 'clustered-light-grid';
+    this.clusterDimensions = props.clusterDimensions ?? DEFAULT_CLUSTER_DIMENSIONS;
+    this.maxLightsPerCluster = props.maxLightsPerCluster ?? DEFAULT_MAX_LIGHTS_PER_CLUSTER;
+    this.maxLightCount = props.maxLightCount ?? MAX_CLUSTERED_POINT_LIGHTS;
+    validateClusteredLightGridProps(
+      this.clusterDimensions,
+      this.maxLightsPerCluster,
+      this.maxLightCount
+    );
+    this.clusterCount =
+      this.clusterDimensions[0] * this.clusterDimensions[1] * this.clusterDimensions[2];
+
+    this.clusterLightCounts = device.createBuffer({
+      id: `${this.id}-counts`,
+      byteLength: this.clusterCount * Uint32Array.BYTES_PER_ELEMENT,
+      usage: Buffer.STORAGE | Buffer.COPY_SRC
+    });
+    this.clusterLightIndices = device.createBuffer({
+      id: `${this.id}-indices`,
+      byteLength: this.clusterCount * this.maxLightsPerCluster * Uint32Array.BYTES_PER_ELEMENT,
+      usage: Buffer.STORAGE | Buffer.COPY_SRC
+    });
+    const lightWordCount = getLightWordCount(this.maxLightCount);
+    this.clusterLightBitMask = device.createBuffer({
+      id: `${this.id}-light-mask`,
+      byteLength: this.clusterCount * lightWordCount * Uint32Array.BYTES_PER_ELEMENT,
+      usage: Buffer.STORAGE
+    });
+    this.uniformBuffer = device.createBuffer({
+      id: `${this.id}-uniforms`,
+      byteLength: CLUSTERED_LIGHT_GRID_UNIFORM_BYTE_LENGTH,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+
+    this.clearComputation = new Computation(device, {
+      id: `${this.id}-clear`,
+      source: getClearClusterLightBitMaskSource(this.clusterCount, lightWordCount),
+      shaderLayout: {
+        bindings: [{name: 'clusterLightBitMask', type: 'storage', group: 0, location: 0}]
+      }
+    });
+    this.clearComputation.setBindings({clusterLightBitMask: this.clusterLightBitMask});
+
+    this.binningComputation = new Computation(device, {
+      id: `${this.id}-bin`,
+      source: getClusterBinningSource(this.clusterDimensions, this.maxLightCount),
+      shaderLayout: {
+        bindings: [
+          {name: 'pointLights', type: 'read-only-storage', group: 0, location: 0},
+          {name: 'clusterLightBitMask', type: 'storage', group: 0, location: 1},
+          {name: 'clusteredLightGrid', type: 'uniform', group: 0, location: 2}
+        ]
+      }
+    });
+    this.compactComputation = new Computation(device, {
+      id: `${this.id}-compact`,
+      source: getCompactClusterLightListsSource(
+        this.clusterCount,
+        lightWordCount,
+        this.maxLightsPerCluster,
+        this.maxLightCount
+      ),
+      shaderLayout: {
+        bindings: [
+          {name: 'clusterLightBitMask', type: 'storage', group: 0, location: 0},
+          {name: 'clusterLightCounts', type: 'storage', group: 0, location: 1},
+          {name: 'clusterLightIndices', type: 'storage', group: 0, location: 2}
+        ]
+      }
+    });
+  }
+
+  /** Rebuilds cluster counts and light-index lists on the supplied command encoder. */
+  encode(commandEncoder: CommandEncoder, options: ClusteredLightGridEncodeOptions): void {
+    validateClusteredLightGridEncodeOptions(options, this.maxLightCount);
+    this.uniformBuffer.write(makeClusteredLightGridUniformData(options));
+    this.binningComputation.setBindings({
+      pointLights: options.pointLights,
+      clusterLightBitMask: this.clusterLightBitMask,
+      clusteredLightGrid: this.uniformBuffer
+    });
+    this.compactComputation.setBindings({
+      clusterLightBitMask: this.clusterLightBitMask,
+      clusterLightCounts: this.clusterLightCounts,
+      clusterLightIndices: this.clusterLightIndices
+    });
+    this.clearComputation.predraw(commandEncoder);
+    this.binningComputation.predraw(commandEncoder);
+    this.compactComputation.predraw(commandEncoder);
+
+    const computePass = commandEncoder.beginComputePass({id: `${this.id}-build`});
+    this.clearComputation.dispatch(
+      computePass,
+      Math.ceil(
+        (this.clusterCount * getLightWordCount(this.maxLightCount)) / CLUSTER_WORKGROUP_SIZE
+      )
+    );
+    this.binningComputation.dispatch(
+      computePass,
+      Math.max(1, Math.ceil(options.pointLightCount / CLUSTER_WORKGROUP_SIZE))
+    );
+    this.compactComputation.dispatch(
+      computePass,
+      Math.ceil(this.clusterCount / CLUSTER_WORKGROUP_SIZE)
+    );
+    computePass.end();
+  }
+
+  /** Returns the storage bindings consumed by clusteredDeferredLighting. */
+  getShaderPassBindings(): ClusteredLightGridBindings {
+    return {
+      clusterLightCounts: this.clusterLightCounts,
+      clusterLightIndices: this.clusterLightIndices
+    };
+  }
+
+  /** Returns the scalar uniforms consumed by clusteredDeferredLighting. */
+  getShaderPassUniforms(nearPlane: number, farPlane: number): ClusteredLightGridShaderPassUniforms {
+    validateDepthRange(nearPlane, farPlane);
+    return {
+      clusterCountX: this.clusterDimensions[0],
+      clusterCountY: this.clusterDimensions[1],
+      clusterCountZ: this.clusterDimensions[2],
+      maxLightsPerCluster: this.maxLightsPerCluster,
+      clusterNearPlane: nearPlane,
+      clusterFarPlane: farPlane
+    };
+  }
+
+  destroy(): void {
+    this.clearComputation.destroy();
+    this.binningComputation.destroy();
+    this.compactComputation.destroy();
+    this.uniformBuffer.destroy();
+    this.clusterLightBitMask.destroy();
+    this.clusterLightCounts.destroy();
+    this.clusterLightIndices.destroy();
+  }
+}
+
+type ClusteredDeferredLightingUniforms = ClusteredLightGridShaderPassUniforms & {
+  inverseProjectionMatrix: Readonly<NumberArray16>;
+  ambientColor: Readonly<NumberArray3>;
+  directionalLightDirectionView: Readonly<NumberArray3>;
+  directionalLightColor: Readonly<NumberArray3>;
+  directionalLightIntensity: number;
+};
+
+type ClusteredDeferredLightingBindings = ClusteredLightGridBindings & {
+  depthTexture?: import('@luma.gl/core').Texture;
+  normalTexture?: import('@luma.gl/core').Texture;
+  baseColorMetallicTexture?: import('@luma.gl/core').Texture;
+  emissiveOcclusionTexture?: import('@luma.gl/core').Texture;
+  pointLights?: Buffer;
+};
+
+/** CPU-side uniforms and resource bindings consumed by clusteredDeferredLighting. */
+export type ClusteredDeferredLightingProps = Partial<ClusteredDeferredLightingUniforms> &
+  ClusteredDeferredLightingBindings;
+
+/** Fullscreen Cook-Torrance lighting resolve over per-cluster point-light lists. */
+export const clusteredDeferredLighting = {
+  name: 'clusteredDeferredLighting',
+  source: `\
+const CLUSTERED_DEFERRED_LIGHTING_PI: f32 = 3.141592653589793;
+
+struct ClusteredDeferredLightingUniforms {
+  inverseProjectionMatrix: mat4x4f,
+  ambientColor: vec3f,
+  directionalLightDirectionView: vec3f,
+  directionalLightColor: vec3f,
+  directionalLightIntensity: f32,
+  clusterCountX: u32,
+  clusterCountY: u32,
+  clusterCountZ: u32,
+  maxLightsPerCluster: u32,
+  clusterNearPlane: f32,
+  clusterFarPlane: f32,
+};
+
+struct ClusteredDeferredPointLight {
+  positionRange: vec4f,
+  colorIntensity: vec4f,
+};
+
+@group(0) @binding(auto) var<uniform> clusteredDeferredLighting: ClusteredDeferredLightingUniforms;
+@group(0) @binding(auto) var depthTexture: texture_depth_2d;
+@group(0) @binding(auto) var depthTextureSampler: sampler;
+@group(0) @binding(auto) var normalTexture: texture_2d<f32>;
+@group(0) @binding(auto) var normalTextureSampler: sampler;
+@group(0) @binding(auto) var baseColorMetallicTexture: texture_2d<f32>;
+@group(0) @binding(auto) var baseColorMetallicTextureSampler: sampler;
+@group(0) @binding(auto) var emissiveOcclusionTexture: texture_2d<u32>;
+@group(0) @binding(auto) var<storage, read> pointLights: array<ClusteredDeferredPointLight>;
+@group(0) @binding(auto) var<storage, read> clusterLightCounts: array<u32>;
+@group(0) @binding(auto) var<storage, read> clusterLightIndices: array<u32>;
+
+fn clusteredDeferredLighting_reconstructViewPosition(uv: vec2f, depth: f32) -> vec3f {
+  let clip = vec4f(uv.x * 2.0 - 1.0, 1.0 - uv.y * 2.0, depth, 1.0);
+  let viewPosition = clusteredDeferredLighting.inverseProjectionMatrix * clip;
+  return viewPosition.xyz / max(viewPosition.w, 0.00001);
+}
+
+fn clusteredDeferredLighting_distributionGGX(
+  normal: vec3f,
+  halfVector: vec3f,
+  roughness: f32
+) -> f32 {
+  let alpha = roughness * roughness;
+  let alphaSquared = alpha * alpha;
+  let normalDotHalf = max(dot(normal, halfVector), 0.0);
+  let normalDotHalfSquared = normalDotHalf * normalDotHalf;
+  let denominator = normalDotHalfSquared * (alphaSquared - 1.0) + 1.0;
+  return alphaSquared /
+    max(CLUSTERED_DEFERRED_LIGHTING_PI * denominator * denominator, 0.0001);
+}
+
+fn clusteredDeferredLighting_geometrySchlickGGX(
+  normalDotDirection: f32,
+  roughness: f32
+) -> f32 {
+  let radius = roughness + 1.0;
+  let k = radius * radius / 8.0;
+  return normalDotDirection / max(normalDotDirection * (1.0 - k) + k, 0.0001);
+}
+
+fn clusteredDeferredLighting_geometrySmith(
+  normal: vec3f,
+  viewDirection: vec3f,
+  lightDirection: vec3f,
+  roughness: f32
+) -> f32 {
+  let normalDotView = max(dot(normal, viewDirection), 0.0);
+  let normalDotLight = max(dot(normal, lightDirection), 0.0);
+  return clusteredDeferredLighting_geometrySchlickGGX(normalDotView, roughness) *
+    clusteredDeferredLighting_geometrySchlickGGX(normalDotLight, roughness);
+}
+
+fn clusteredDeferredLighting_fresnelSchlick(cosine: f32, baseReflectance: vec3f) -> vec3f {
+  return baseReflectance + (vec3f(1.0) - baseReflectance) * pow(1.0 - cosine, 5.0);
+}
+
+fn clusteredDeferredLighting_evaluateLight(
+  normal: vec3f,
+  viewDirection: vec3f,
+  lightDirection: vec3f,
+  radiance: vec3f,
+  baseColor: vec3f,
+  metallic: f32,
+  roughness: f32
+) -> vec3f {
+  let normalDotLight = max(dot(normal, lightDirection), 0.0);
+  if (normalDotLight <= 0.0) {
+    return vec3f(0.0);
+  }
+  let halfVector = normalize(viewDirection + lightDirection);
+  let baseReflectance = mix(vec3f(0.04), baseColor, metallic);
+  let fresnel = clusteredDeferredLighting_fresnelSchlick(
+    max(dot(halfVector, viewDirection), 0.0),
+    baseReflectance
+  );
+  let distribution = clusteredDeferredLighting_distributionGGX(normal, halfVector, roughness);
+  let geometry = clusteredDeferredLighting_geometrySmith(
+    normal,
+    viewDirection,
+    lightDirection,
+    roughness
+  );
+  let normalDotView = max(dot(normal, viewDirection), 0.0);
+  let specular = distribution * geometry * fresnel /
+    max(4.0 * normalDotView * normalDotLight, 0.0001);
+  let diffuseWeight = (vec3f(1.0) - fresnel) * (1.0 - metallic);
+  let diffuse = diffuseWeight * baseColor / CLUSTERED_DEFERRED_LIGHTING_PI;
+  return (diffuse + specular) * radiance * normalDotLight;
+}
+
+fn clusteredDeferredLighting_evaluatePointLight(
+  light: ClusteredDeferredPointLight,
+  viewPosition: vec3f,
+  normal: vec3f,
+  viewDirection: vec3f,
+  baseColor: vec3f,
+  metallic: f32,
+  roughness: f32
+) -> vec3f {
+  let toLight = light.positionRange.xyz - viewPosition;
+  let distance = length(toLight);
+  if (distance >= light.positionRange.w || distance <= 0.0001) {
+    return vec3f(0.0);
+  }
+  let lightDirection = toLight / distance;
+  let rangeFade = pow(clamp(1.0 - distance / light.positionRange.w, 0.0, 1.0), 2.0);
+  let attenuation = rangeFade / max(1.0, distance * distance * 0.06);
+  let radiance = light.colorIntensity.rgb * light.colorIntensity.a * attenuation;
+  return clusteredDeferredLighting_evaluateLight(
+    normal,
+    viewDirection,
+    lightDirection,
+    radiance,
+    baseColor,
+    metallic,
+    roughness
+  );
+}
+
+fn clusteredDeferredLighting_getClusterIndex(texCoord: vec2f, viewPosition: vec3f) -> u32 {
+  let tileX = min(
+    u32(clamp(texCoord.x, 0.0, 0.999999) * f32(clusteredDeferredLighting.clusterCountX)),
+    clusteredDeferredLighting.clusterCountX - 1u
+  );
+  let tileY = min(
+    u32(clamp(texCoord.y, 0.0, 0.999999) * f32(clusteredDeferredLighting.clusterCountY)),
+    clusteredDeferredLighting.clusterCountY - 1u
+  );
+  let viewDepth = clamp(
+    -viewPosition.z,
+    clusteredDeferredLighting.clusterNearPlane,
+    clusteredDeferredLighting.clusterFarPlane
+  );
+  let normalizedDepth = clamp(
+    log(viewDepth / clusteredDeferredLighting.clusterNearPlane) /
+      log(clusteredDeferredLighting.clusterFarPlane / clusteredDeferredLighting.clusterNearPlane),
+    0.0,
+    0.999999
+  );
+  let depthSlice = min(
+    u32(normalizedDepth * f32(clusteredDeferredLighting.clusterCountZ)),
+    clusteredDeferredLighting.clusterCountZ - 1u
+  );
+  return (depthSlice * clusteredDeferredLighting.clusterCountY + tileY) *
+    clusteredDeferredLighting.clusterCountX + tileX;
+}
+
+fn clusteredDeferredLighting_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let sceneCoord = texCoord;
+  let depth = textureSampleLevel(depthTexture, depthTextureSampler, sceneCoord, 0);
+  if (depth >= 0.99999) {
+    return textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord, 0);
+  }
+
+  let normalRoughness = textureSampleLevel(normalTexture, normalTextureSampler, sceneCoord, 0);
+  let normal = normalize(normalRoughness.rgb * 2.0 - 1.0);
+  let roughness = clamp(normalRoughness.a, 0.045, 1.0);
+  let baseColorMetallic = textureSampleLevel(
+    baseColorMetallicTexture,
+    baseColorMetallicTextureSampler,
+    sceneCoord,
+    0
+  );
+  let baseColor = max(baseColorMetallic.rgb, vec3f(0.0));
+  let metallic = clamp(baseColorMetallic.a, 0.0, 1.0);
+  let emissiveOcclusionCoordinates = vec2i(
+    clamp(sceneCoord * texSize, vec2f(0.0), texSize - vec2f(1.0))
+  );
+  let emissiveOcclusion = vec4f(
+    textureLoad(emissiveOcclusionTexture, emissiveOcclusionCoordinates, 0)
+  ) / 255.0;
+  let emissive = max(emissiveOcclusion.rgb, vec3f(0.0));
+  let occlusion = clamp(emissiveOcclusion.a, 0.0, 1.0);
+  let viewPosition = clusteredDeferredLighting_reconstructViewPosition(sceneCoord, depth);
+  let viewDirection = normalize(-viewPosition);
+
+  var color = baseColor * clusteredDeferredLighting.ambientColor * occlusion + emissive;
+  let directionalLightDirection = normalize(
+    clusteredDeferredLighting.directionalLightDirectionView
+  );
+  color += clusteredDeferredLighting_evaluateLight(
+    normal,
+    viewDirection,
+    directionalLightDirection,
+    clusteredDeferredLighting.directionalLightColor *
+      clusteredDeferredLighting.directionalLightIntensity,
+    baseColor,
+    metallic,
+    roughness
+  );
+
+  let clusterIndex = clusteredDeferredLighting_getClusterIndex(sceneCoord, viewPosition);
+  let candidateLightCount = clusterLightCounts[clusterIndex];
+  if (candidateLightCount > clusteredDeferredLighting.maxLightsPerCluster) {
+    for (var lightIndex = 0u; lightIndex < arrayLength(&pointLights); lightIndex++) {
+      color += clusteredDeferredLighting_evaluatePointLight(
+        pointLights[lightIndex],
+        viewPosition,
+        normal,
+        viewDirection,
+        baseColor,
+        metallic,
+        roughness
+      );
+    }
+  } else {
+    let indexOffset = clusterIndex * clusteredDeferredLighting.maxLightsPerCluster;
+    for (var clusterLightIndex = 0u; clusterLightIndex < candidateLightCount; clusterLightIndex++) {
+      let lightIndex = clusterLightIndices[indexOffset + clusterLightIndex];
+      if (lightIndex >= arrayLength(&pointLights)) {
+        continue;
+      }
+      color += clusteredDeferredLighting_evaluatePointLight(
+        pointLights[lightIndex],
+        viewPosition,
+        normal,
+        viewDirection,
+        baseColor,
+        metallic,
+        roughness
+      );
+    }
+  }
+
+  return vec4f(color, 1.0);
+}`,
+  bindingLayout: [
+    {name: 'depthTexture', group: 0},
+    {name: 'normalTexture', group: 0},
+    {name: 'baseColorMetallicTexture', group: 0},
+    {name: 'emissiveOcclusionTexture', group: 0},
+    {name: 'pointLights', group: 0},
+    {name: 'clusterLightCounts', group: 0},
+    {name: 'clusterLightIndices', group: 0}
+  ],
+  props: {} as ClusteredDeferredLightingProps,
+  uniforms: {} as ClusteredDeferredLightingUniforms,
+  bindings: {} as ClusteredDeferredLightingBindings,
+  uniformTypes: {
+    inverseProjectionMatrix: 'mat4x4<f32>',
+    ambientColor: 'vec3<f32>',
+    directionalLightDirectionView: 'vec3<f32>',
+    directionalLightColor: 'vec3<f32>',
+    directionalLightIntensity: 'f32',
+    clusterCountX: 'u32',
+    clusterCountY: 'u32',
+    clusterCountZ: 'u32',
+    maxLightsPerCluster: 'u32',
+    clusterNearPlane: 'f32',
+    clusterFarPlane: 'f32'
+  },
+  propTypes: {
+    inverseProjectionMatrix: {value: IDENTITY_MATRIX, private: true},
+    ambientColor: {value: [0.04, 0.04, 0.05], private: true},
+    directionalLightDirectionView: {value: [0.3, 0.75, 0.55], private: true},
+    directionalLightColor: {value: [1, 0.95, 0.86], private: true},
+    directionalLightIntensity: {value: 2.5, min: 0, softMax: 8},
+    clusterCountX: {value: DEFAULT_CLUSTER_DIMENSIONS[0], private: true},
+    clusterCountY: {value: DEFAULT_CLUSTER_DIMENSIONS[1], private: true},
+    clusterCountZ: {value: DEFAULT_CLUSTER_DIMENSIONS[2], private: true},
+    maxLightsPerCluster: {value: DEFAULT_MAX_LIGHTS_PER_CLUSTER, private: true},
+    clusterNearPlane: {value: 0.1, private: true},
+    clusterFarPlane: {value: 100, private: true}
+  },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  ClusteredDeferredLightingProps,
+  ClusteredDeferredLightingUniforms,
+  ClusteredDeferredLightingBindings
+>;
+
+/** Creates a fullscreen clustered deferred-lighting step for the previous color chain. */
+export function createClusteredDeferredLightingShaderPassPipeline(): ShaderPassPipeline {
+  return {
+    name: 'clusteredDeferredLightingShaderPassPipeline',
+    steps: [
+      {
+        shaderPass: clusteredDeferredLighting,
+        inputs: {sourceTexture: 'previous'},
+        output: 'previous'
+      }
+    ]
+  };
+}
+
+function getClearClusterLightBitMaskSource(clusterCount: number, lightWordCount: number): string {
+  return `\
+const CLUSTER_LIGHT_MASK_WORD_COUNT: u32 = ${clusterCount * lightWordCount}u;
+@group(0) @binding(0) var<storage, read_write> clusterLightBitMask: array<atomic<u32>>;
+@compute @workgroup_size(${CLUSTER_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  if (globalId.x < CLUSTER_LIGHT_MASK_WORD_COUNT) {
+    atomicStore(&clusterLightBitMask[globalId.x], 0u);
+  }
+}`;
+}
+
+function getClusterBinningSource(
+  clusterDimensions: readonly [number, number, number],
+  maxLightCount: number
+): string {
+  return `\
+const CLUSTER_COUNT_X: u32 = ${clusterDimensions[0]}u;
+const CLUSTER_COUNT_Y: u32 = ${clusterDimensions[1]}u;
+const CLUSTER_COUNT_Z: u32 = ${clusterDimensions[2]}u;
+const MAX_LIGHT_COUNT: u32 = ${maxLightCount}u;
+const LIGHT_WORD_COUNT: u32 = ${getLightWordCount(maxLightCount)}u;
+
+struct ClusteredLightGridUniforms {
+  projectionMatrix: mat4x4f,
+  depthRange: vec2f,
+  lightCount: u32,
+  padding: u32,
+};
+
+struct ClusteredLightGridPointLight {
+  positionRange: vec4f,
+  colorIntensity: vec4f,
+};
+
+@group(0) @binding(0) var<storage, read> pointLights: array<ClusteredLightGridPointLight>;
+@group(0) @binding(1) var<storage, read_write> clusterLightBitMask: array<atomic<u32>>;
+@group(0) @binding(2) var<uniform> clusteredLightGrid: ClusteredLightGridUniforms;
+
+fn clusteredLightGrid_getCoordinate(value: f32, size: u32) -> u32 {
+  return min(u32(clamp(value, 0.0, 0.999999) * f32(size)), size - 1u);
+}
+
+fn clusteredLightGrid_getDepthSlice(distance: f32) -> u32 {
+  let normalizedDepth = clamp(
+    log(distance / clusteredLightGrid.depthRange.x) /
+      log(clusteredLightGrid.depthRange.y / clusteredLightGrid.depthRange.x),
+    0.0,
+    0.999999
+  );
+  return min(u32(normalizedDepth * f32(CLUSTER_COUNT_Z)), CLUSTER_COUNT_Z - 1u);
+}
+
+@compute @workgroup_size(${CLUSTER_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  let lightIndex = globalId.x;
+  let lightCount = min(clusteredLightGrid.lightCount, min(MAX_LIGHT_COUNT, arrayLength(&pointLights)));
+  if (lightIndex >= lightCount) {
+    return;
+  }
+
+  let light = pointLights[lightIndex];
+  let viewDepth = -light.positionRange.z;
+  let minimumDepth = max(clusteredLightGrid.depthRange.x, viewDepth - light.positionRange.w);
+  let maximumDepth = min(clusteredLightGrid.depthRange.y, viewDepth + light.positionRange.w);
+  if (maximumDepth < clusteredLightGrid.depthRange.x ||
+      minimumDepth > clusteredLightGrid.depthRange.y ||
+      maximumDepth < minimumDepth) {
+    return;
+  }
+
+  let centerClip = clusteredLightGrid.projectionMatrix * vec4f(light.positionRange.xyz, 1.0);
+  if (centerClip.w <= 0.0) {
+    return;
+  }
+  let centerNdc = centerClip.xy / centerClip.w;
+  let radiusNdc = vec2f(
+    abs(clusteredLightGrid.projectionMatrix[0][0]) * light.positionRange.w /
+      max(minimumDepth, clusteredLightGrid.depthRange.x),
+    abs(clusteredLightGrid.projectionMatrix[1][1]) * light.positionRange.w /
+      max(minimumDepth, clusteredLightGrid.depthRange.x)
+  );
+  let centerUv = vec2f(centerNdc.x * 0.5 + 0.5, 0.5 - centerNdc.y * 0.5);
+  let radiusUv = radiusNdc * 0.5;
+  let unclampedMinimumUv = centerUv - radiusUv;
+  let unclampedMaximumUv = centerUv + radiusUv;
+  if (unclampedMaximumUv.x < 0.0 || unclampedMinimumUv.x > 1.0 ||
+      unclampedMaximumUv.y < 0.0 || unclampedMinimumUv.y > 1.0) {
+    return;
+  }
+
+  let minimumUv = clamp(unclampedMinimumUv, vec2f(0.0), vec2f(0.999999));
+  let maximumUv = clamp(unclampedMaximumUv, vec2f(0.0), vec2f(0.999999));
+  let minimumX = clusteredLightGrid_getCoordinate(minimumUv.x, CLUSTER_COUNT_X);
+  let maximumX = clusteredLightGrid_getCoordinate(maximumUv.x, CLUSTER_COUNT_X);
+  let minimumY = clusteredLightGrid_getCoordinate(minimumUv.y, CLUSTER_COUNT_Y);
+  let maximumY = clusteredLightGrid_getCoordinate(maximumUv.y, CLUSTER_COUNT_Y);
+  let minimumZ = clusteredLightGrid_getDepthSlice(minimumDepth);
+  let maximumZ = clusteredLightGrid_getDepthSlice(maximumDepth);
+  let lightWordIndex = lightIndex / 32u;
+  let lightBit = 1u << (lightIndex % 32u);
+
+  for (var depthSlice = minimumZ; depthSlice <= maximumZ; depthSlice++) {
+    for (var tileY = minimumY; tileY <= maximumY; tileY++) {
+      for (var tileX = minimumX; tileX <= maximumX; tileX++) {
+        let clusterIndex = (depthSlice * CLUSTER_COUNT_Y + tileY) * CLUSTER_COUNT_X + tileX;
+        atomicOr(&clusterLightBitMask[clusterIndex * LIGHT_WORD_COUNT + lightWordIndex], lightBit);
+      }
+    }
+  }
+}`;
+}
+
+function getCompactClusterLightListsSource(
+  clusterCount: number,
+  lightWordCount: number,
+  maxLightsPerCluster: number,
+  maxLightCount: number
+): string {
+  return `\
+const CLUSTER_COUNT: u32 = ${clusterCount}u;
+const LIGHT_WORD_COUNT: u32 = ${lightWordCount}u;
+const MAX_LIGHTS_PER_CLUSTER: u32 = ${maxLightsPerCluster}u;
+const MAX_LIGHT_COUNT: u32 = ${maxLightCount}u;
+
+@group(0) @binding(0) var<storage, read_write> clusterLightBitMask: array<atomic<u32>>;
+@group(0) @binding(1) var<storage, read_write> clusterLightCounts: array<u32>;
+@group(0) @binding(2) var<storage, read_write> clusterLightIndices: array<u32>;
+
+@compute @workgroup_size(${CLUSTER_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  let clusterIndex = globalId.x;
+  if (clusterIndex >= CLUSTER_COUNT) {
+    return;
+  }
+
+  let maskOffset = clusterIndex * LIGHT_WORD_COUNT;
+  let indexOffset = clusterIndex * MAX_LIGHTS_PER_CLUSTER;
+  var lightCount = 0u;
+  for (var lightIndex = 0u; lightIndex < MAX_LIGHT_COUNT; lightIndex++) {
+    let lightWord = atomicLoad(&clusterLightBitMask[maskOffset + lightIndex / 32u]);
+    let lightBit = 1u << (lightIndex % 32u);
+    if ((lightWord & lightBit) != 0u) {
+      if (lightCount < MAX_LIGHTS_PER_CLUSTER) {
+        clusterLightIndices[indexOffset + lightCount] = lightIndex;
+      }
+      lightCount += 1u;
+    }
+  }
+  clusterLightCounts[clusterIndex] = lightCount;
+}`;
+}
+
+function getLightWordCount(maxLightCount: number): number {
+  return Math.ceil(maxLightCount / 32);
+}
+
+function makeClusteredLightGridUniformData(options: ClusteredLightGridEncodeOptions): ArrayBuffer {
+  const data = new ArrayBuffer(CLUSTERED_LIGHT_GRID_UNIFORM_BYTE_LENGTH);
+  const floatValues = new Float32Array(data);
+  floatValues.set(options.projectionMatrix, 0);
+  floatValues[16] = options.nearPlane;
+  floatValues[17] = options.farPlane;
+  new Uint32Array(data)[18] = options.pointLightCount;
+  return data;
+}
+
+function validateClusteredLightGridProps(
+  clusterDimensions: readonly [number, number, number],
+  maxLightsPerCluster: number,
+  maxLightCount: number
+): void {
+  if (
+    clusterDimensions.some(dimension => !Number.isSafeInteger(dimension) || dimension < 1) ||
+    !Number.isSafeInteger(maxLightsPerCluster) ||
+    maxLightsPerCluster < 1 ||
+    !Number.isSafeInteger(maxLightCount) ||
+    maxLightCount < 1
+  ) {
+    throw new Error('Cluster dimensions and capacities must be positive safe integers.');
+  }
+}
+
+function validateClusteredLightGridEncodeOptions(
+  options: ClusteredLightGridEncodeOptions,
+  maxLightCount: number
+): void {
+  if (!Number.isSafeInteger(options.pointLightCount) || options.pointLightCount < 0) {
+    throw new Error('Point light count must be a non-negative safe integer.');
+  }
+  if (options.pointLightCount > maxLightCount) {
+    throw new Error('Point light count exceeds ClusteredLightGrid capacity.');
+  }
+  validateDepthRange(options.nearPlane, options.farPlane);
+}
+
+function validateDepthRange(nearPlane: number, farPlane: number): void {
+  if (!(nearPlane > 0) || !(farPlane > nearPlane)) {
+    throw new Error('Cluster depth range requires 0 < nearPlane < farPlane.');
+  }
+}

--- a/modules/experimental/src/rendering/clustered-lighting.ts
+++ b/modules/experimental/src/rendering/clustered-lighting.ts
@@ -54,6 +54,7 @@ export type ClusteredLightGridShaderPassUniforms = {
   clusterCountY: number;
   clusterCountZ: number;
   maxLightsPerCluster: number;
+  pointLightCount: number;
   clusterNearPlane: number;
   clusterFarPlane: number;
 };
@@ -82,6 +83,7 @@ export class ClusteredLightGrid {
   private readonly clearComputation: Computation;
   private readonly binningComputation: Computation;
   private readonly compactComputation: Computation;
+  private activePointLightCount = 0;
 
   constructor(device: Device, props: ClusteredLightGridProps = {}) {
     if (device.type !== 'webgpu') {
@@ -164,6 +166,7 @@ export class ClusteredLightGrid {
   /** Rebuilds cluster counts and light-index lists on the supplied command encoder. */
   encode(commandEncoder: CommandEncoder, options: ClusteredLightGridEncodeOptions): void {
     validateClusteredLightGridEncodeOptions(options, this.maxLightCount);
+    this.activePointLightCount = options.pointLightCount;
     this.uniformBuffer.write(makeClusteredLightGridUniformData(options));
     this.binningComputation.setBindings({
       pointLights: options.pointLights,
@@ -213,6 +216,7 @@ export class ClusteredLightGrid {
       clusterCountY: this.clusterDimensions[1],
       clusterCountZ: this.clusterDimensions[2],
       maxLightsPerCluster: this.maxLightsPerCluster,
+      pointLightCount: this.activePointLightCount,
       clusterNearPlane: nearPlane,
       clusterFarPlane: farPlane
     };
@@ -265,6 +269,7 @@ struct ClusteredDeferredLightingUniforms {
   clusterCountY: u32,
   clusterCountZ: u32,
   maxLightsPerCluster: u32,
+  pointLightCount: u32,
   clusterNearPlane: f32,
   clusterFarPlane: f32,
 };
@@ -474,7 +479,11 @@ fn clusteredDeferredLighting_sampleColor(
   let clusterIndex = clusteredDeferredLighting_getClusterIndex(sceneCoord, viewPosition);
   let candidateLightCount = clusterLightCounts[clusterIndex];
   if (candidateLightCount > clusteredDeferredLighting.maxLightsPerCluster) {
-    for (var lightIndex = 0u; lightIndex < arrayLength(&pointLights); lightIndex++) {
+    let activePointLightCount = min(
+      clusteredDeferredLighting.pointLightCount,
+      arrayLength(&pointLights)
+    );
+    for (var lightIndex = 0u; lightIndex < activePointLightCount; lightIndex++) {
       color += clusteredDeferredLighting_evaluatePointLight(
         pointLights[lightIndex],
         viewPosition,
@@ -528,6 +537,7 @@ fn clusteredDeferredLighting_sampleColor(
     clusterCountY: 'u32',
     clusterCountZ: 'u32',
     maxLightsPerCluster: 'u32',
+    pointLightCount: 'u32',
     clusterNearPlane: 'f32',
     clusterFarPlane: 'f32'
   },
@@ -541,6 +551,7 @@ fn clusteredDeferredLighting_sampleColor(
     clusterCountY: {value: DEFAULT_CLUSTER_DIMENSIONS[1], private: true},
     clusterCountZ: {value: DEFAULT_CLUSTER_DIMENSIONS[2], private: true},
     maxLightsPerCluster: {value: DEFAULT_MAX_LIGHTS_PER_CLUSTER, private: true},
+    pointLightCount: {value: 0, private: true},
     clusterNearPlane: {value: 0.1, private: true},
     clusterFarPlane: {value: 100, private: true}
   },
@@ -639,27 +650,33 @@ fn clusteredLightGrid_getDepthSlice(distance: f32) -> u32 {
   }
 
   let centerClip = clusteredLightGrid.projectionMatrix * vec4f(light.positionRange.xyz, 1.0);
-  if (centerClip.w <= 0.0) {
-    return;
-  }
-  let centerNdc = centerClip.xy / centerClip.w;
-  let radiusNdc = vec2f(
-    abs(clusteredLightGrid.projectionMatrix[0][0]) * light.positionRange.w /
-      max(minimumDepth, clusteredLightGrid.depthRange.x),
-    abs(clusteredLightGrid.projectionMatrix[1][1]) * light.positionRange.w /
-      max(minimumDepth, clusteredLightGrid.depthRange.x)
-  );
-  let centerUv = vec2f(centerNdc.x * 0.5 + 0.5, 0.5 - centerNdc.y * 0.5);
-  let radiusUv = radiusNdc * 0.5;
-  let unclampedMinimumUv = centerUv - radiusUv;
-  let unclampedMaximumUv = centerUv + radiusUv;
-  if (unclampedMaximumUv.x < 0.0 || unclampedMinimumUv.x > 1.0 ||
-      unclampedMaximumUv.y < 0.0 || unclampedMinimumUv.y > 1.0) {
-    return;
-  }
+  let isOrthographicProjection = abs(clusteredLightGrid.projectionMatrix[3][3]) > 0.5;
+  var minimumUv = vec2f(0.0);
+  var maximumUv = vec2f(0.999999);
+  if (centerClip.w > 0.0) {
+    let centerNdc = centerClip.xy / centerClip.w;
+    let projectionScale = vec2f(
+      abs(clusteredLightGrid.projectionMatrix[0][0]),
+      abs(clusteredLightGrid.projectionMatrix[1][1])
+    );
+    let radiusNdc = select(
+      projectionScale * light.positionRange.w /
+        max(minimumDepth, clusteredLightGrid.depthRange.x),
+      projectionScale * light.positionRange.w,
+      isOrthographicProjection
+    );
+    let centerUv = vec2f(centerNdc.x * 0.5 + 0.5, 0.5 - centerNdc.y * 0.5);
+    let radiusUv = radiusNdc * 0.5;
+    let unclampedMinimumUv = centerUv - radiusUv;
+    let unclampedMaximumUv = centerUv + radiusUv;
+    if (unclampedMaximumUv.x < 0.0 || unclampedMinimumUv.x > 1.0 ||
+        unclampedMaximumUv.y < 0.0 || unclampedMinimumUv.y > 1.0) {
+      return;
+    }
 
-  let minimumUv = clamp(unclampedMinimumUv, vec2f(0.0), vec2f(0.999999));
-  let maximumUv = clamp(unclampedMaximumUv, vec2f(0.0), vec2f(0.999999));
+    minimumUv = clamp(unclampedMinimumUv, vec2f(0.0), vec2f(0.999999));
+    maximumUv = clamp(unclampedMaximumUv, vec2f(0.0), vec2f(0.999999));
+  }
   let minimumX = clusteredLightGrid_getCoordinate(minimumUv.x, CLUSTER_COUNT_X);
   let maximumX = clusteredLightGrid_getCoordinate(maximumUv.x, CLUSTER_COUNT_X);
   let minimumY = clusteredLightGrid_getCoordinate(minimumUv.y, CLUSTER_COUNT_Y);

--- a/modules/experimental/test/rendering/clustered-lighting.spec.ts
+++ b/modules/experimental/test/rendering/clustered-lighting.spec.ts
@@ -1,0 +1,197 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {Buffer, Texture} from '@luma.gl/core';
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {
+  ClusteredLightGrid,
+  createClusteredDeferredLightingShaderPassPipeline,
+  makeDeferredPointLightBufferData,
+  MAX_CLUSTERED_POINT_LIGHTS,
+  type DeferredPointLight
+} from '@luma.gl/experimental';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {Matrix4, radians} from '@math.gl/core';
+
+test('clustered lighting exposes one composable fullscreen resolve', testCase => {
+  const pipeline = createClusteredDeferredLightingShaderPassPipeline();
+  testCase.equal(pipeline.steps.length, 1, 'the resolve is one fullscreen pass');
+  testCase.equal(
+    pipeline.steps[0].shaderPass.name,
+    'clusteredDeferredLighting',
+    'the pipeline exposes the clustered-lighting pass'
+  );
+  testCase.equal(pipeline.steps[0].output, 'previous', 'lighting composes into the color chain');
+  testCase.equal(MAX_CLUSTERED_POINT_LIGHTS, 512, 'the exported cluster capacity is explicit');
+  testCase.end();
+});
+
+test('clustered light grid bins lights and resolves materials on WebGPU', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const width = 4;
+  const height = 4;
+  const projectionMatrix = new Matrix4().perspective({
+    fovy: radians(45),
+    aspect: 1,
+    near: 0.1,
+    far: 20
+  });
+  const clusteredTestLights: DeferredPointLight[] = Array.from({length: 8}, (_, lightIndex) => ({
+    position: [0, 0, -4],
+    range: 2,
+    color: [1, 0.4 + lightIndex * 0.01, 0.2],
+    intensity: 4
+  }));
+  const pointLights = device.createBuffer({
+    id: 'clustered-lighting-point-lights',
+    data: makeDeferredPointLightBufferData(clusteredTestLights, 8),
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  const clusteredLightGrid = new ClusteredLightGrid(device, {
+    id: 'clustered-lighting-test-grid',
+    clusterDimensions: [1, 1, 1],
+    maxLightsPerCluster: 2,
+    maxLightCount: 8
+  });
+  const sourceTexture = device.createTexture({
+    id: 'clustered-lighting-source',
+    format: 'rgba16float',
+    width,
+    height,
+    usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_DST
+  });
+  const normalTexture = device.createTexture({
+    id: 'clustered-lighting-normal',
+    format: 'rgba8unorm',
+    width,
+    height,
+    usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_DST
+  });
+  const baseColorMetallicTexture = device.createTexture({
+    id: 'clustered-lighting-base-color-metallic',
+    format: 'rgba8unorm',
+    width,
+    height,
+    usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_DST
+  });
+  const emissiveOcclusionTexture = device.createTexture({
+    id: 'clustered-lighting-emissive-occlusion',
+    format: 'rgba8uint',
+    width,
+    height,
+    usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_DST
+  });
+  const depthTexture = device.createTexture({
+    id: 'clustered-lighting-depth',
+    format: 'depth24plus',
+    width,
+    height,
+    usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_DST
+  });
+  const sceneFramebuffer = device.createFramebuffer({
+    id: 'clustered-lighting-scene',
+    width,
+    height,
+    colorAttachments: [
+      sourceTexture,
+      normalTexture,
+      baseColorMetallicTexture,
+      emissiveOcclusionTexture
+    ],
+    depthStencilAttachment: depthTexture
+  });
+  const renderer = new ShaderPassRenderer(device, {
+    shaderPasses: [createClusteredDeferredLightingShaderPassPipeline()],
+    colorFormat: 'rgba16float',
+    flipY: false
+  });
+  renderer.resize([width, height]);
+
+  try {
+    clusteredLightGrid.encode(device.commandEncoder, {
+      pointLights,
+      pointLightCount: clusteredTestLights.length,
+      projectionMatrix,
+      nearPlane: 0.1,
+      farPlane: 20
+    });
+    const sceneRenderPass = device.beginRenderPass({
+      framebuffer: sceneFramebuffer,
+      clearColors: [
+        new Float32Array([0.01, 0.01, 0.01, 1]),
+        new Float32Array([0.5, 0.5, 1, 0.4]),
+        new Float32Array([0.72, 0.12, 0.08, 0.35]),
+        new Float32Array([5, 3, 0, 255])
+      ],
+      clearDepth: 0.5
+    });
+    sceneRenderPass.end();
+
+    const outputTexture = renderer.renderToTexture({
+      sourceTexture,
+      bindings: {
+        depthTexture,
+        normalTexture,
+        baseColorMetallicTexture,
+        emissiveOcclusionTexture,
+        pointLights,
+        ...clusteredLightGrid.getShaderPassBindings()
+      },
+      uniforms: {
+        clusteredDeferredLighting: {
+          inverseProjectionMatrix: new Matrix4(projectionMatrix).invert(),
+          ambientColor: [0.04, 0.04, 0.05],
+          directionalLightDirectionView: [0.2, 0.7, -0.5],
+          directionalLightColor: [1, 0.95, 0.9],
+          directionalLightIntensity: 2,
+          ...clusteredLightGrid.getShaderPassUniforms(0.1, 20)
+        }
+      }
+    });
+    device.submit();
+
+    const clusterCountBytes = await clusteredLightGrid.clusterLightCounts.readAsync();
+    const clusterIndexBytes = await clusteredLightGrid.clusterLightIndices.readAsync();
+    const clusterCounts = new Uint32Array(
+      clusterCountBytes.buffer,
+      clusterCountBytes.byteOffset,
+      clusterCountBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+    );
+    const clusterLightIndices = new Uint32Array(
+      clusterIndexBytes.buffer,
+      clusterIndexBytes.byteOffset,
+      clusterIndexBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+    );
+    testCase.equal(
+      clusterCounts[0],
+      clusteredTestLights.length,
+      'the compute pass preserves overflow pressure for debugging'
+    );
+    testCase.deepEqual(
+      Array.from(clusterLightIndices.slice(0, 2)),
+      [0, 1],
+      'overflow compaction retains a deterministic light-index prefix'
+    );
+    testCase.ok(outputTexture, 'the clustered material G-buffer resolves through the pass');
+  } finally {
+    renderer.destroy();
+    sceneFramebuffer.destroy();
+    sourceTexture.destroy();
+    normalTexture.destroy();
+    baseColorMetallicTexture.destroy();
+    emissiveOcclusionTexture.destroy();
+    depthTexture.destroy();
+    clusteredLightGrid.destroy();
+    pointLights.destroy();
+  }
+
+  testCase.end();
+});

--- a/modules/experimental/test/rendering/clustered-lighting.spec.ts
+++ b/modules/experimental/test/rendering/clustered-lighting.spec.ts
@@ -28,6 +28,95 @@ test('clustered lighting exposes one composable fullscreen resolve', testCase =>
   testCase.end();
 });
 
+test('clustered light grid conservatively bins camera-plane and orthographic lights', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const pointLights = device.createBuffer({
+    id: 'clustered-lighting-projection-point-lights',
+    data: makeDeferredPointLightBufferData(
+      [{position: [0, 0, 0.25], range: 0.5, color: [1, 1, 1], intensity: 1}],
+      1
+    ),
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  const clusteredLightGrid = new ClusteredLightGrid(device, {
+    id: 'clustered-lighting-projection-test-grid',
+    clusterDimensions: [4, 4, 1],
+    maxLightsPerCluster: 1,
+    maxLightCount: 1
+  });
+
+  try {
+    clusteredLightGrid.encode(device.commandEncoder, {
+      pointLights,
+      pointLightCount: 1,
+      projectionMatrix: new Matrix4().perspective({
+        fovy: radians(45),
+        aspect: 1,
+        near: 0.1,
+        far: 20
+      }),
+      nearPlane: 0.1,
+      farPlane: 20
+    });
+    device.submit();
+
+    const perspectiveClusterCounts = await readClusterLightCounts(
+      clusteredLightGrid.clusterLightCounts
+    );
+    testCase.ok(
+      perspectiveClusterCounts.every(clusterCount => clusterCount === 1),
+      'a visible sphere centered behind the camera conservatively covers every screen tile'
+    );
+
+    pointLights.write(
+      makeDeferredPointLightBufferData(
+        [{position: [0.49, 0, -10], range: 0.3, color: [1, 1, 1], intensity: 1}],
+        1
+      )
+    );
+    clusteredLightGrid.encode(device.commandEncoder, {
+      pointLights,
+      pointLightCount: 1,
+      projectionMatrix: new Matrix4().ortho({
+        left: -1,
+        right: 1,
+        bottom: -1,
+        top: 1,
+        near: 0.1,
+        far: 20
+      }),
+      nearPlane: 0.1,
+      farPlane: 20
+    });
+    device.submit();
+
+    const orthographicClusterCounts = await readClusterLightCounts(
+      clusteredLightGrid.clusterLightCounts
+    );
+    testCase.equal(
+      orthographicClusterCounts[2 * 4 + 3],
+      1,
+      'orthographic light bounds retain their world-space radius at far depths'
+    );
+    testCase.equal(
+      orthographicClusterCounts[2 * 4 + 1],
+      0,
+      'orthographic light bounds do not expand into unrelated screen tiles'
+    );
+  } finally {
+    clusteredLightGrid.destroy();
+    pointLights.destroy();
+  }
+
+  testCase.end();
+});
+
 test('clustered light grid bins lights and resolves materials on WebGPU', async testCase => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -44,8 +133,8 @@ test('clustered light grid bins lights and resolves materials on WebGPU', async 
     near: 0.1,
     far: 20
   });
-  const clusteredTestLights: DeferredPointLight[] = Array.from({length: 8}, (_, lightIndex) => ({
-    position: [0, 0, -4],
+  const clusteredTestLights: DeferredPointLight[] = Array.from({length: 4}, (_, lightIndex) => ({
+    position: [0, 0, -0.1],
     range: 2,
     color: [1, 0.4 + lightIndex * 0.01, 0.2],
     intensity: 4
@@ -135,36 +224,34 @@ test('clustered light grid bins lights and resolves materials on WebGPU', async 
     });
     sceneRenderPass.end();
 
-    const outputTexture = renderer.renderToTexture({
-      sourceTexture,
-      bindings: {
-        depthTexture,
-        normalTexture,
-        baseColorMetallicTexture,
-        emissiveOcclusionTexture,
-        pointLights,
-        ...clusteredLightGrid.getShaderPassBindings()
-      },
-      uniforms: {
-        clusteredDeferredLighting: {
-          inverseProjectionMatrix: new Matrix4(projectionMatrix).invert(),
-          ambientColor: [0.04, 0.04, 0.05],
-          directionalLightDirectionView: [0.2, 0.7, -0.5],
-          directionalLightColor: [1, 0.95, 0.9],
-          directionalLightIntensity: 2,
-          ...clusteredLightGrid.getShaderPassUniforms(0.1, 20)
+    const renderClusteredLighting = () =>
+      renderer.renderToTexture({
+        sourceTexture,
+        bindings: {
+          depthTexture,
+          normalTexture,
+          baseColorMetallicTexture,
+          emissiveOcclusionTexture,
+          pointLights,
+          ...clusteredLightGrid.getShaderPassBindings()
+        },
+        uniforms: {
+          clusteredDeferredLighting: {
+            inverseProjectionMatrix: new Matrix4(projectionMatrix).invert(),
+            ambientColor: [0.04, 0.04, 0.05],
+            directionalLightDirectionView: [0.2, 0.7, -0.5],
+            directionalLightColor: [1, 0.95, 0.9],
+            directionalLightIntensity: 2,
+            ...clusteredLightGrid.getShaderPassUniforms(0.1, 20)
+          }
         }
-      }
-    });
+      });
+
+    const outputTexture = renderClusteredLighting();
     device.submit();
 
-    const clusterCountBytes = await clusteredLightGrid.clusterLightCounts.readAsync();
+    const clusterCounts = await readClusterLightCounts(clusteredLightGrid.clusterLightCounts);
     const clusterIndexBytes = await clusteredLightGrid.clusterLightIndices.readAsync();
-    const clusterCounts = new Uint32Array(
-      clusterCountBytes.buffer,
-      clusterCountBytes.byteOffset,
-      clusterCountBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
-    );
     const clusterLightIndices = new Uint32Array(
       clusterIndexBytes.buffer,
       clusterIndexBytes.byteOffset,
@@ -180,7 +267,42 @@ test('clustered light grid bins lights and resolves materials on WebGPU', async 
       [0, 1],
       'overflow compaction retains a deterministic light-index prefix'
     );
+    testCase.equal(
+      clusteredLightGrid.getShaderPassUniforms(0.1, 20).pointLightCount,
+      clusteredTestLights.length,
+      'the fullscreen resolve receives the active point-light prefix'
+    );
     testCase.ok(outputTexture, 'the clustered material G-buffer resolves through the pass');
+
+    if (outputTexture) {
+      const originalOutput = await readTexturePixel(outputTexture);
+      const inactiveLights: DeferredPointLight[] = Array.from({length: 4}, () => ({
+        position: [0, 0, -0.1],
+        range: 2,
+        color: [0, 1, 0],
+        intensity: 100
+      }));
+      pointLights.write(
+        makeDeferredPointLightBufferData([...clusteredTestLights, ...inactiveLights], 8)
+      );
+      clusteredLightGrid.encode(device.commandEncoder, {
+        pointLights,
+        pointLightCount: clusteredTestLights.length,
+        projectionMatrix,
+        nearPlane: 0.1,
+        farPlane: 20
+      });
+      const outputWithInactiveLights = renderClusteredLighting();
+      device.submit();
+
+      if (outputWithInactiveLights) {
+        testCase.deepEqual(
+          Array.from(await readTexturePixel(outputWithInactiveLights)),
+          Array.from(originalOutput),
+          'overflow fallback ignores stale light records beyond the active prefix'
+        );
+      }
+    }
   } finally {
     renderer.destroy();
     sceneFramebuffer.destroy();
@@ -195,3 +317,27 @@ test('clustered light grid bins lights and resolves materials on WebGPU', async 
 
   testCase.end();
 });
+
+async function readClusterLightCounts(clusterLightCounts: Buffer): Promise<Uint32Array> {
+  const clusterCountBytes = await clusterLightCounts.readAsync();
+  return new Uint32Array(
+    clusterCountBytes.buffer,
+    clusterCountBytes.byteOffset,
+    clusterCountBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+  );
+}
+
+async function readTexturePixel(texture: Texture): Promise<Uint8Array> {
+  const layout = texture.computeMemoryLayout({width: 1, height: 1});
+  const readbackBuffer = texture.device.createBuffer({
+    byteLength: layout.byteLength,
+    usage: Buffer.COPY_DST | Buffer.MAP_READ
+  });
+  try {
+    texture.readBuffer({width: 1, height: 1}, readbackBuffer);
+    const pixelBytes = await readbackBuffer.readAsync(0, layout.byteLength);
+    return new Uint8Array(pixelBytes.buffer, pixelBytes.byteOffset, 8).slice();
+  } finally {
+    readbackBuffer.destroy();
+  }
+}

--- a/website/content/examples/experimental/deferred-rendering.mdx
+++ b/website/content/examples/experimental/deferred-rendering.mdx
@@ -15,8 +15,8 @@ import {DeferredRenderingExample} from '@site/src/examples';
 >
   <div>
     A WebGPU-only material laboratory that writes five surface targets once, then reconstructs
-    view position from depth and resolves a directional light plus animated storage-buffer point
-    lights in one fullscreen pass.
+    view position from depth and resolves a directional light plus hundreds of compute-clustered
+    storage-buffer point lights in one fullscreen pass.
   </div>
 </ExampleHeader>
 
@@ -28,10 +28,11 @@ import {DeferredRenderingExample} from '@site/src/examples';
 - Rows increase metalness while changing the base material family, so dielectric diffuse response
   gives way to colored metallic reflections.
 - The orbiting emissive markers are the same point lights consumed by the deferred resolve. Raise
-  **Point Lights** to stress a larger fixed-capacity storage buffer without redrawing the material
+  **Point Lights** toward 512 to stress compute-built cluster lists without redrawing the material
   geometry.
 - **Base Color**, **Normals**, **Roughness**, **Metallic**, **Emissive**, and **Depth** expose the
-  actual G-buffer channels rather than a recreated diagnostic view.
+  actual G-buffer channels rather than a recreated diagnostic view. **Cluster Occupancy** shows
+  the per-pixel cluster list pressure as a cold-to-hot heatmap.
 
 ## Render stack
 
@@ -43,10 +44,12 @@ velocity, and depth channels plus two named material extras:
 | `baseColorMetallic` | Linear base color in RGB and metalness in A. |
 | `emissiveOcclusion` | Linear emissive color in RGB and ambient occlusion in A. |
 
-`createDeferredLightingShaderPassPipeline()` then reads those material targets, reconstructs
-view-space position from depth, evaluates Cook-Torrance direct lighting, and writes HDR color back
-into the normal ordered shader-pass chain. A final display pass tone maps the result or selects a
-G-buffer debug view.
+`ClusteredLightGrid` first bins each view-space point-light sphere into a `16 × 9 × 24`
+screen/log-depth grid. `createClusteredDeferredLightingShaderPassPipeline()` then reads those
+material targets plus the current pixel's bounded cluster list, reconstructs view-space position
+from depth, evaluates Cook-Torrance direct lighting, and writes HDR color back into the normal
+ordered shader-pass chain. A final display pass tone maps the result or selects a G-buffer/cluster
+debug view.
 
 The point-light positions are transformed to view space on the CPU and packed with
 `makeDeferredPointLightBufferData()` into two `vec4f` records per light:
@@ -56,5 +59,5 @@ position.xyz, range, color.rgb, intensity
 ```
 
 That fixed representation keeps the example focused on the deferred boundary: geometry owns
-material capture, the fullscreen pass owns lighting, and later effects can consume the unchanged
-depth, normal, velocity, and scene-color contract.
+material capture, compute owns light assignment, the fullscreen pass owns lighting, and later
+effects can consume the unchanged depth, normal, velocity, and scene-color contract.

--- a/website/src/components/docs/experimental-docs-tabs.tsx
+++ b/website/src/components/docs/experimental-docs-tabs.tsx
@@ -8,6 +8,7 @@ export type ExperimentalDocsTabId =
   | 'overview'
   | 'g-buffer'
   | 'deferred-lighting'
+  | 'clustered-lighting'
   | 'shadow-map-renderer'
   | 'a-buffer-renderer'
   | 'wboit-renderer';
@@ -19,6 +20,11 @@ const EXPERIMENTAL_DOCS_TABS: ExperimentalDocsTab[] = [
     id: 'deferred-lighting',
     label: 'Deferred Lighting',
     href: '/docs/api-reference/experimental/deferred-lighting'
+  },
+  {
+    id: 'clustered-lighting',
+    label: 'Clustered Lighting',
+    href: '/docs/api-reference/experimental/clustered-lighting'
   },
   {
     id: 'shadow-map-renderer',


### PR DESCRIPTION
## Goals

- Scale the deferred renderer from dozens to hundreds of local lights with a composable WebGPU-only clustered-lighting stage.
- Keep the Material Lab visually correct at the 512-light stress setting and make the GPU techniques discoverable from example infoboxes.

## Changes

- Adds `ClusteredLightGrid`, `clusteredDeferredLighting`, and `createClusteredDeferredLightingShaderPassPipeline()` in `@luma.gl/experimental`.
- Builds a 16 × 9 × 24 screen/log-depth grid on WebGPU: light-centric bitmask binning, stable compaction, bounded per-cluster lists, and a full-buffer correctness fallback for saturated pixels.
- Upgrades Deferred Rendering: Material Lab to 256 lights by default, up to 512, with smaller emissive markers and a Cluster Occupancy debug view.
- Adds clustered-lighting API docs, exports, docs tabs, and render-stack documentation.
- Adds Background infobox panels explaining GPU techniques for deferred rendering, Visualization City, Bloom, Antialiasing Techniques, and Order-independent Transparency.
- Adds a headless WebGPU test covering cluster overflow count preservation, deterministic retained indices, and the clustered fullscreen resolve.

## Verification

- `nvm use` — could not run: `nvm: command not found` in this shell.
- `yarn install` — passed via `corepack yarn install --frozen-lockfile` (existing peer warnings only).
- `yarn lint fix` — passed.
- `yarn build` — passed after final code and formatting changes.
- `yarn test-headless modules/experimental/test/rendering/clustered-lighting.spec.ts` — passed (2 tests).
- `yarn test` — node suite passed (51 files, 178 tests); headless passed 235 files / 1272 tests with one pre-existing unrelated failure in `modules/arrow-layers/test/layers/arrow-layers.spec.ts` (`arrow-polygons-storage-test has drawable storage-backed instances`, missing `polygonViewportUniforms`).
- `yarn website:build` — passed.
- `(cd website && yarn build)` — passed.
- `(cd examples/experimental/deferred-rendering && yarn build)` — passed.
- Chrome visual check — 512-light Final view has no tile artifacts or WebGPU errors; with animation paused, two captured frames were byte-identical. Verified the Deferred Rendering Background panel content.

## Stack

- Base: `codex/deferred-rendering` / #2750.
- This PR should merge after #2750.