### PR TITLE
feat(effects): Add temporally stabilized GTAO

### DIFF
--- a/docs/api-guide/shaders/shader-passes.md
+++ b/docs/api-guide/shaders/shader-passes.md
@@ -69,16 +69,16 @@ surface attachments without owning scene traversal or material shading. Multiple
 | Render-stack value | Producer | Consumers |
 | --- | --- | --- |
 | `sourceTexture` | `GBuffer.colorTexture` | Every shader pass through `previous` or `original`. |
-| `depthTexture` | `GBuffer.depthTexture` | DOF, depth-aware blur, SSAO, SSR, outlines, contact shadows, TAA, motion blur, fog. |
-| `normalTexture` | `GBuffer.normalRoughnessTexture` | SSAO, SSR, normal-aware outlines, contact-shadow filtering. |
-| `velocityTexture` | `GBuffer.velocityTexture` | TAA and motion blur. |
+| `depthTexture` | `GBuffer.depthTexture` | DOF, depth-aware blur, SSAO, GTAO, SSR, outlines, contact shadows, TAA, motion blur, fog. |
+| `normalTexture` | `GBuffer.normalRoughnessTexture` | SSAO, GTAO, SSR, normal-aware outlines, contact-shadow filtering. |
+| `velocityTexture` | `GBuffer.velocityTexture` | GTAO temporal reprojection, TAA, and motion blur. |
 | named extras | `GBuffer.getExtraColorTexture(name)` | Application-specific material, debug, lighting, or resolve passes. |
 
 ```ts
 import {ShaderPassRenderer} from '@luma.gl/engine';
 import {
   createMotionBlurShaderPassPipeline,
-  createSSAOShaderPassPipeline,
+  createGTAOShaderPassPipeline,
   createSSRShaderPassPipeline,
   createTAAShaderPassPipeline
 } from '@luma.gl/effects';
@@ -101,7 +101,7 @@ scenePass.end();
 
 const effects = new ShaderPassRenderer(device, {
   shaderPasses: [
-    createSSAOShaderPassPipeline({normalSource: 'normal-texture'}),
+    createGTAOShaderPassPipeline(),
     createSSRShaderPassPipeline(),
     createTAAShaderPassPipeline(),
     createMotionBlurShaderPassPipeline()
@@ -123,7 +123,7 @@ lighting result into the same ordered color chain:
 const renderer = new ShaderPassRenderer(device, {
   shaderPasses: [
     createDeferredLightingShaderPassPipeline(),
-    createSSAOShaderPassPipeline({normalSource: 'normal-texture'}),
+    createGTAOShaderPassPipeline(),
     createSSRShaderPassPipeline(),
     createTAAShaderPassPipeline()
   ]
@@ -139,7 +139,7 @@ while preserving the same effect-facing depth, normal, velocity, and scene-color
 | --- | --- | --- |
 | Geometry and opaque surface capture | MRT scene color, normal-roughness, velocity, depth, material extras | Establish one coherent surface snapshot. |
 | Opaque lighting resolve | Deferred PBR lighting, contact shadows, other direct-light corrections | These still need unwarped depth, normals, and material terms. |
-| Surface effects | SSAO, SSR, fog, outlines, depth-aware blur | These consume the original semantic attachments. |
+| Surface effects | SSAO, GTAO, SSR, fog, outlines, depth-aware blur | These consume the original semantic attachments. |
 | Transparency resolve | WBOIT or A-buffer resolve pipeline | Resolve translucent geometry before temporal accumulation when it should participate in TAA. |
 | Temporal effects | TAA, then motion blur | Reproject the composed image before display-space processing. |
 | Display effects | Bloom, color adjustment, vignette, tone mapping | These operate on final color and usually do not need scene attachments. |
@@ -166,9 +166,10 @@ effects without creating a second postprocessing system.
 The [Advanced Effects example](/examples/experimental/advanced-effects) shows the full MRT surface
 pass feeding shadows, SSAO, SSR, fog, outlines, TAA, motion blur, and debug views.
 
-The [Deferred Material Lab](/examples/experimental/deferred-rendering) shows the earlier opaque
-phase: one five-target geometry pass, depth reconstruction, directional lighting, animated
-storage-buffer point lights, tone mapping, and direct G-buffer debug views.
+The [Deferred Material Lab](/examples/experimental/deferred-rendering) shows the opaque phase and
+its first screen-space consumer: one five-target geometry pass, depth reconstruction, clustered
+directional/point lighting, temporally stabilized GTAO, tone mapping, and direct G-buffer/AO debug
+views.
 
 ## When To Use Shader Passes
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -94,7 +94,7 @@ Target Release Date: Q3, 2026
 
 **@luma.gl/effects**
 
-- **Advanced screen-space effects** - New WebGPU-first composable pipelines provide depth-aware blur, SSAO, outlines, temporal AA, motion blur, screen-space reflections, and volumetric fog. They share strict ordered composition with existing effects such as bloom and depth of field.
+- **Advanced screen-space effects** - New WebGPU-first composable pipelines provide depth-aware blur, SSAO, temporally stabilized GTAO, outlines, temporal AA, motion blur, screen-space reflections, and volumetric fog. They share strict ordered composition with existing effects such as bloom and depth of field.
 - **[Visualization City](/examples/experimental/advanced-effects)** - New MRT showcase combines the complete effect stack with presets, quality levels, debug views, and before/after comparison.
 
 

--- a/examples/experimental/deferred-rendering/app.ts
+++ b/examples/experimental/deferred-rendering/app.ts
@@ -12,6 +12,7 @@ import {
   ShaderPassRenderer,
   SphereGeometry
 } from '@luma.gl/engine';
+import {createGTAOShaderPassPipeline} from '@luma.gl/effects';
 import {
   ClusteredLightGrid,
   createClusteredDeferredLightingShaderPassPipeline,
@@ -56,7 +57,8 @@ type DebugView =
   | 'Metallic'
   | 'Emissive'
   | 'Depth'
-  | 'Cluster Occupancy';
+  | 'Cluster Occupancy'
+  | 'Ambient Occlusion';
 
 type DeferredRenderingSettings = {
   debugView: DebugView;
@@ -64,6 +66,9 @@ type DeferredRenderingSettings = {
   animate: boolean;
   exposure: number;
   sunIntensity: number;
+  ambientOcclusionRadius: number;
+  ambientOcclusionIntensity: number;
+  ambientOcclusionStrength: number;
 };
 
 const DEFAULT_SETTINGS: DeferredRenderingSettings = {
@@ -71,13 +76,17 @@ const DEFAULT_SETTINGS: DeferredRenderingSettings = {
   pointLightCount: 256,
   animate: true,
   exposure: 1.15,
-  sunIntensity: 2.8
+  sunIntensity: 2.8,
+  ambientOcclusionRadius: 2.2,
+  ambientOcclusionIntensity: 3.2,
+  ambientOcclusionStrength: 0.68
 };
 
 const DEFERRED_RENDERING_BACKGROUND_HTML = `
 <p><b>Why deferred rendering scales:</b> forward shading repeats material work for every light that touches every draw. Here the geometry pass writes base color, metalness, roughness, emissive, normal, velocity, and depth once; the fullscreen resolve reuses those screen-space values for lighting.</p>
 <p><b>Why clustering wins:</b> a WebGPU compute stage projects each view-space light sphere into a <code>16 × 9 × 24</code> screen/log-depth grid. Each pixel reconstructs its view position from depth, finds one cluster, and normally evaluates only that short local list instead of all 512 lights.</p>
-<p><b>Work changes shape:</b> the expensive path becomes roughly geometry + visible pixels × lights in the local cluster, instead of objects × every light. The same G-buffer also feeds later SSAO, SSR, fog, outline, temporal, and motion effects without redrawing material geometry.</p>
+<p><b>Why GTAO belongs after lighting:</b> a half-resolution horizon search reuses the same depth and view normals to estimate ambient visibility around contacts. G-buffer velocity reprojects the previous AO result, depth rejects disocclusions, and a depth-aware blur removes remaining half-resolution noise before the AO is composed into lit color.</p>
+<p><b>Work changes shape:</b> the expensive path becomes roughly geometry + visible pixels × lights in the local cluster, instead of objects × every light. The same G-buffer also feeds GTAO, SSR, fog, outline, temporal, and motion effects without redrawing material geometry.</p>
 <p><b>Correctness at the limit:</b> candidate bits are compacted in stable light-index order. If a cluster exceeds its retained list, that pixel falls back to the full fixed-size light buffer rather than showing tile-shaped truncation; the <b>Cluster Occupancy</b> view shows where that slower fallback is being requested.</p>
 `;
 
@@ -286,6 +295,10 @@ fn deferredDisplay_sampleColor(
     let emissive = vec3f(textureLoad(emissiveOcclusionTexture, emissiveCoordinates, 0).rgb) /
       255.0;
     return vec4f(deferredDisplay_toneMap(emissive), 1.0);
+  }
+  if (deferredDisplay.debugMode > 7.5) {
+    let color = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord, 0).rgb;
+    return vec4f(color, 1.0);
   }
   if (deferredDisplay.debugMode > 5.5) {
     let depth = textureSampleLevel(depthTexture, depthTextureSampler, texCoord, 0);
@@ -575,6 +588,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       bindings: {
         depthTexture: this.sceneGBuffer.depthTexture,
         normalTexture,
+        velocityTexture: this.sceneGBuffer.velocityTexture,
         baseColorMetallicTexture,
         emissiveOcclusionTexture,
         pointLights: this.pointLightBuffer,
@@ -588,6 +602,17 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           directionalLightColor: [1, 0.86, 0.68],
           directionalLightIntensity: this.settings.sunIntensity,
           ...clusterUniforms
+        },
+        gtaoEvaluate: {
+          projectionMatrix,
+          inverseProjectionMatrix,
+          radius: this.settings.ambientOcclusionRadius,
+          intensity: this.settings.ambientOcclusionIntensity,
+          frameIndex: this.frameIndex
+        },
+        gtaoComposite: {
+          strength: this.settings.ambientOcclusionStrength,
+          debugMode: this.settings.debugView === 'Ambient Occlusion' ? 1 : 0
         },
         deferredDisplay: {
           inverseProjectionMatrix,
@@ -622,7 +647,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         makeHtmlCustomPanel({
           id: 'deferred-rendering-description',
           title: 'Overview',
-          html: '<p><b>One geometry pass. Hundreds of lights.</b></p><p>Each sphere writes base color, metalness, roughness, emissive, normal, velocity, and depth once. A WebGPU compute pass bins animated lights into screen/depth clusters before the fullscreen Cook-Torrance resolve evaluates only the current pixel cluster.</p><p>Switch Debug View to inspect the actual G-buffer contract.</p>'
+          html: '<p><b>One geometry pass. Hundreds of lights.</b></p><p>Each sphere writes base color, metalness, roughness, emissive, normal, velocity, and depth once. A WebGPU compute pass bins animated lights into screen/depth clusters before the fullscreen Cook-Torrance resolve evaluates only the current pixel cluster.</p><p>A temporally stabilized GTAO pass then turns the same depth, normals, and velocity into grounded contact shading without redrawing geometry. Switch Debug View to inspect the actual G-buffer and AO contracts.</p>'
         }),
         this.settingsPanel.makePanel(),
         makeHtmlCustomPanel({
@@ -644,7 +669,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
 function createRenderer(device: Device): ShaderPassRenderer {
   return new ShaderPassRenderer(device, {
-    shaderPasses: [createClusteredDeferredLightingShaderPassPipeline(), deferredDisplayPipeline],
+    shaderPasses: [
+      createClusteredDeferredLightingShaderPassPipeline(),
+      createGTAOShaderPassPipeline(),
+      deferredDisplayPipeline
+    ],
     colorFormat: 'rgba16float',
     flipY: true
   });
@@ -801,6 +830,8 @@ function getDebugMode(debugView: DebugView): number {
       return 6;
     case 'Cluster Occupancy':
       return 7;
+    case 'Ambient Occlusion':
+      return 8;
     default:
       return 0;
   }
@@ -828,7 +859,8 @@ function makeSettingsSchema(): SettingsSchema {
               'Metallic',
               'Emissive',
               'Depth',
-              'Cluster Occupancy'
+              'Cluster Occupancy',
+              'Ambient Occlusion'
             ]
           },
           {
@@ -870,6 +902,40 @@ function makeSettingsSchema(): SettingsSchema {
             label: 'Animate Lights',
             type: 'boolean',
             persist: 'none'
+          }
+        ]
+      },
+      {
+        id: 'ambient-occlusion',
+        name: 'Ambient Occlusion',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'ambientOcclusionRadius',
+            label: 'GTAO Radius',
+            type: 'number',
+            persist: 'none',
+            min: 0.2,
+            max: 8,
+            step: 0.1
+          },
+          {
+            name: 'ambientOcclusionIntensity',
+            label: 'GTAO Intensity',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 8,
+            step: 0.1
+          },
+          {
+            name: 'ambientOcclusionStrength',
+            label: 'GTAO Strength',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1,
+            step: 0.02
           }
         ]
       }

--- a/examples/experimental/deferred-rendering/app.ts
+++ b/examples/experimental/deferred-rendering/app.ts
@@ -610,6 +610,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           intensity: this.settings.ambientOcclusionIntensity,
           frameIndex: this.frameIndex
         },
+        gtaoTemporal: {inverseProjectionMatrix},
         gtaoComposite: {
           strength: this.settings.ambientOcclusionStrength,
           debugMode: this.settings.debugView === 'Ambient Occlusion' ? 1 : 0

--- a/modules/effects/README.md
+++ b/modules/effects/README.md
@@ -2,10 +2,10 @@
 
 A set of ShaderPasses implementing post processing effects for luma.gl
 
-Advanced WebGPU-first scene-aware pipelines include SSAO, scene outlines, temporal AA, motion
-blur, screen-space reflections, volumetric fog, and reusable depth-aware blur. Applications keep
-ownership of scene rendering and provide matching color, depth, normal/roughness, and velocity
-textures to `ShaderPassRenderer`.
+Advanced WebGPU-first scene-aware pipelines include SSAO, temporally stabilized GTAO, scene
+outlines, temporal AA, motion blur, screen-space reflections, volumetric fog, and reusable
+depth-aware blur. Applications keep ownership of scene rendering and provide matching color,
+depth, normal/roughness, and velocity textures to `ShaderPassRenderer`.
 
 Notable exports include:
 

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -122,6 +122,14 @@ export {
   depthAwareBlurShaderPassPipeline
 } from './passes/screen-space/depth-aware-blur';
 export {createMotionBlurShaderPassPipeline} from './passes/screen-space/motion-blur';
+export type {GTAOShaderPassPipelineOptions} from './passes/screen-space/gtao';
+export {
+  createGTAOShaderPassPipeline,
+  gtaoComposite,
+  gtaoDepthHistoryCopy,
+  gtaoEvaluate,
+  gtaoTemporal
+} from './passes/screen-space/gtao';
 export type {OutlineShaderPassPipelineOptions} from './passes/screen-space/outlines';
 export {createOutlineShaderPassPipeline} from './passes/screen-space/outlines';
 export {createSSRShaderPassPipeline} from './passes/screen-space/screen-space-reflections';

--- a/modules/effects/src/passes/screen-space/gtao.ts
+++ b/modules/effects/src/passes/screen-space/gtao.ts
@@ -1,0 +1,413 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Texture} from '@luma.gl/core';
+import type {ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
+import {Matrix4} from '@math.gl/core';
+import {depthAwareBlur} from './depth-aware-blur';
+
+/** Construction options for the horizon-based GTAO pipeline. */
+export type GTAOShaderPassPipelineOptions = {
+  /** Fractional AO evaluation resolution. Defaults to half resolution. */
+  resolutionScale?: number;
+};
+
+type GTAOEvaluateUniforms = {
+  projectionMatrix: Matrix4;
+  inverseProjectionMatrix: Matrix4;
+  radius: number;
+  bias: number;
+  intensity: number;
+  frameIndex: number;
+};
+
+type GTAOTemporalUniforms = {
+  historyWeight: number;
+  depthThreshold: number;
+};
+
+type GTAOCompositeUniforms = {
+  strength: number;
+  debugMode: number;
+};
+
+type GTAOBindings = {
+  depthTexture?: Texture;
+  normalTexture?: Texture;
+};
+
+type GTAOTemporalBindings = {
+  depthTexture?: Texture;
+  velocityTexture?: Texture;
+  historyTexture?: Texture;
+  previousDepthTexture?: Texture;
+};
+
+/** Half-resolution horizon search over G-buffer depth and view normals. */
+export const gtaoEvaluate = {
+  name: 'gtaoEvaluate',
+  source: /* wgsl */ `\
+const GTAO_PI: f32 = 3.141592653589793;
+const GTAO_SLICE_COUNT: i32 = 4;
+const GTAO_STEPS_PER_SIDE: i32 = 6;
+
+struct GTAOEvaluateUniforms {
+  projectionMatrix: mat4x4f,
+  inverseProjectionMatrix: mat4x4f,
+  radius: f32,
+  bias: f32,
+  intensity: f32,
+  frameIndex: f32,
+};
+
+@group(0) @binding(auto) var<uniform> gtaoEvaluate: GTAOEvaluateUniforms;
+@group(0) @binding(auto) var depthTexture: texture_depth_2d;
+@group(0) @binding(auto) var depthTextureSampler: sampler;
+@group(0) @binding(auto) var normalTexture: texture_2d<f32>;
+@group(0) @binding(auto) var normalTextureSampler: sampler;
+
+fn gtaoEvaluate_reconstructViewPosition(uv: vec2f, depth: f32) -> vec3f {
+  let clip = vec4f(uv.x * 2.0 - 1.0, 1.0 - uv.y * 2.0, depth, 1.0);
+  let viewPosition = gtaoEvaluate.inverseProjectionMatrix * clip;
+  return viewPosition.xyz / max(viewPosition.w, 0.00001);
+}
+
+fn gtaoEvaluate_hash(value: vec2f) -> f32 {
+  return fract(sin(dot(value, vec2f(12.9898, 78.233))) * 43758.5453);
+}
+
+fn gtaoEvaluate_sampleHorizon(
+  centerPosition: vec3f,
+  normal: vec3f,
+  sceneCoord: vec2f,
+  direction: vec2f,
+  side: f32,
+  radiusPixels: f32,
+  depthDimensions: vec2f
+) -> f32 {
+  var horizon = 0.0;
+  for (var stepIndex: i32 = 1; stepIndex <= GTAO_STEPS_PER_SIDE; stepIndex++) {
+    let fraction = f32(stepIndex) / f32(GTAO_STEPS_PER_SIDE);
+    let jitteredFraction = (f32(stepIndex) - 0.35) / f32(GTAO_STEPS_PER_SIDE);
+    let sampleOffset = direction * side * radiusPixels * jitteredFraction / depthDimensions;
+    let sampleCoord = clamp(sceneCoord + sampleOffset, vec2f(0.0), vec2f(1.0));
+    let sampleDepth = textureSampleLevel(depthTexture, depthTextureSampler, sampleCoord, 0);
+    if (sampleDepth >= 0.99999) {
+      continue;
+    }
+    let samplePosition = gtaoEvaluate_reconstructViewPosition(sampleCoord, sampleDepth);
+    let delta = samplePosition - centerPosition;
+    let distanceToSample = length(delta);
+    if (distanceToSample <= 0.0001 || distanceToSample >= gtaoEvaluate.radius) {
+      continue;
+    }
+    let hemisphere = max(dot(normal, delta / distanceToSample) - gtaoEvaluate.bias, 0.0);
+    let distanceFalloff = 1.0 - smoothstep(gtaoEvaluate.radius * 0.35, gtaoEvaluate.radius, distanceToSample);
+    let stepFalloff = 1.0 - fraction * 0.15;
+    horizon = max(horizon, hemisphere * distanceFalloff * stepFalloff);
+  }
+  return horizon;
+}
+
+fn gtaoEvaluate_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let sceneCoord = texCoord;
+  let depth = textureSampleLevel(depthTexture, depthTextureSampler, sceneCoord, 0);
+  if (depth >= 0.99999) {
+    return vec4f(1.0);
+  }
+
+  let centerPosition = gtaoEvaluate_reconstructViewPosition(sceneCoord, depth);
+  let normalSample = textureSampleLevel(normalTexture, normalTextureSampler, sceneCoord, 0);
+  let normal = normalize(normalSample.xyz * 2.0 - 1.0);
+  let depthDimensions = vec2f(textureDimensions(depthTexture));
+  let focalLength = abs(gtaoEvaluate.projectionMatrix[1][1]);
+  let projectedRadius = gtaoEvaluate.radius * focalLength /
+    max(-centerPosition.z, 0.0001) * depthDimensions.y * 0.5;
+  let radiusPixels = clamp(projectedRadius, 2.0, 72.0);
+  let pixelCoordinate = sceneCoord * depthDimensions;
+  let rotation = (
+    gtaoEvaluate_hash(floor(pixelCoordinate) + vec2f(gtaoEvaluate.frameIndex * 0.754877)) *
+    GTAO_PI
+  );
+
+  var accumulatedOcclusion = 0.0;
+  for (var sliceIndex: i32 = 0; sliceIndex < GTAO_SLICE_COUNT; sliceIndex++) {
+    let angle = rotation + f32(sliceIndex) * GTAO_PI / f32(GTAO_SLICE_COUNT);
+    let direction = vec2f(cos(angle), sin(angle));
+    let positiveHorizon = gtaoEvaluate_sampleHorizon(
+      centerPosition,
+      normal,
+      sceneCoord,
+      direction,
+      1.0,
+      radiusPixels,
+      depthDimensions
+    );
+    let negativeHorizon = gtaoEvaluate_sampleHorizon(
+      centerPosition,
+      normal,
+      sceneCoord,
+      direction,
+      -1.0,
+      radiusPixels,
+      depthDimensions
+    );
+    accumulatedOcclusion += positiveHorizon * positiveHorizon + negativeHorizon * negativeHorizon;
+  }
+
+  let normalizedOcclusion = accumulatedOcclusion / f32(GTAO_SLICE_COUNT * 2);
+  let visibility = clamp(1.0 - normalizedOcclusion * gtaoEvaluate.intensity, 0.0, 1.0);
+  return vec4f(vec3f(visibility), 1.0);
+}`,
+  bindingLayout: [
+    {name: 'depthTexture', group: 0},
+    {name: 'normalTexture', group: 0}
+  ],
+  props: {} as Partial<GTAOEvaluateUniforms> & GTAOBindings,
+  uniforms: {} as GTAOEvaluateUniforms,
+  bindings: {} as GTAOBindings,
+  uniformTypes: {
+    projectionMatrix: 'mat4x4<f32>',
+    inverseProjectionMatrix: 'mat4x4<f32>',
+    radius: 'f32',
+    bias: 'f32',
+    intensity: 'f32',
+    frameIndex: 'f32'
+  },
+  propTypes: {
+    projectionMatrix: {value: new Matrix4(), private: true},
+    inverseProjectionMatrix: {value: new Matrix4(), private: true},
+    radius: {value: 2.2, min: 0.1, softMax: 8},
+    bias: {value: 0.04, min: 0, softMax: 0.25},
+    intensity: {value: 3.2, min: 0, softMax: 8},
+    frameIndex: {value: 0, private: true}
+  },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  Partial<GTAOEvaluateUniforms> & GTAOBindings,
+  GTAOEvaluateUniforms,
+  GTAOBindings
+>;
+
+/** Reprojects the previous AO result with G-buffer velocity and rejects disocclusions by depth. */
+export const gtaoTemporal = {
+  name: 'gtaoTemporal',
+  source: /* wgsl */ `\
+struct GTAOTemporalUniforms {
+  historyWeight: f32,
+  depthThreshold: f32,
+};
+
+@group(0) @binding(auto) var<uniform> gtaoTemporal: GTAOTemporalUniforms;
+@group(0) @binding(auto) var historyTexture: texture_2d<f32>;
+@group(0) @binding(auto) var historyTextureSampler: sampler;
+@group(0) @binding(auto) var velocityTexture: texture_2d<f32>;
+@group(0) @binding(auto) var velocityTextureSampler: sampler;
+@group(0) @binding(auto) var depthTexture: texture_depth_2d;
+@group(0) @binding(auto) var depthTextureSampler: sampler;
+@group(0) @binding(auto) var previousDepthTexture: texture_2d<f32>;
+@group(0) @binding(auto) var previousDepthTextureSampler: sampler;
+
+fn gtaoTemporal_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let current = textureSample(sourceTexture, sourceTextureSampler, texCoord);
+  let velocity = textureSample(velocityTexture, velocityTextureSampler, texCoord).xy;
+  let previousCoord = texCoord - velocity;
+  let validCoord = all(previousCoord >= vec2f(0.0)) && all(previousCoord <= vec2f(1.0));
+  let clampedPreviousCoord = clamp(previousCoord, vec2f(0.0), vec2f(1.0));
+  let currentDepth = textureSample(depthTexture, depthTextureSampler, texCoord);
+  let previousDepth = textureSample(
+    previousDepthTexture,
+    previousDepthTextureSampler,
+    clampedPreviousCoord
+  ).r;
+  let validDepth = abs(previousDepth - currentDepth) < gtaoTemporal.depthThreshold;
+
+  let texel = 1.0 / vec2f(textureDimensions(sourceTexture));
+  var minimumVisibility = current.r;
+  var maximumVisibility = current.r;
+  for (var y: i32 = -1; y <= 1; y++) {
+    for (var x: i32 = -1; x <= 1; x++) {
+      let sampleVisibility = textureSample(
+        sourceTexture,
+        sourceTextureSampler,
+        texCoord + vec2f(f32(x), f32(y)) * texel
+      ).r;
+      minimumVisibility = min(minimumVisibility, sampleVisibility);
+      maximumVisibility = max(maximumVisibility, sampleVisibility);
+    }
+  }
+  let historyVisibility = clamp(
+    textureSample(historyTexture, historyTextureSampler, clampedPreviousCoord).r,
+    minimumVisibility,
+    maximumVisibility
+  );
+  let historyWeight = select(0.0, gtaoTemporal.historyWeight, validCoord && validDepth);
+  let visibility = mix(current.r, historyVisibility, historyWeight);
+  return vec4f(vec3f(visibility), 1.0);
+}`,
+  bindingLayout: [
+    {name: 'historyTexture', group: 0},
+    {name: 'velocityTexture', group: 0},
+    {name: 'depthTexture', group: 0},
+    {name: 'previousDepthTexture', group: 0}
+  ],
+  props: {} as Partial<GTAOTemporalUniforms> & GTAOTemporalBindings,
+  uniforms: {} as GTAOTemporalUniforms,
+  bindings: {} as GTAOTemporalBindings,
+  uniformTypes: {
+    historyWeight: 'f32',
+    depthThreshold: 'f32'
+  },
+  propTypes: {
+    historyWeight: {value: 0.88, min: 0, max: 0.97},
+    depthThreshold: {value: 0.015, min: 0.0001, softMax: 0.1}
+  },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  Partial<GTAOTemporalUniforms> & GTAOTemporalBindings,
+  GTAOTemporalUniforms,
+  GTAOTemporalBindings
+>;
+
+/** Stores the current hardware depth for next-frame temporal disocclusion rejection. */
+export const gtaoDepthHistoryCopy = {
+  name: 'gtaoDepthHistoryCopy',
+  source: /* wgsl */ `\
+@group(0) @binding(auto) var depthTexture: texture_depth_2d;
+@group(0) @binding(auto) var depthTextureSampler: sampler;
+
+fn gtaoDepthHistoryCopy_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let depth = textureSample(depthTexture, depthTextureSampler, texCoord);
+  return vec4f(depth, 0.0, 0.0, 1.0);
+}`,
+  bindingLayout: [{name: 'depthTexture', group: 0}],
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass;
+
+/** Multiplies the lit color by denoised ambient visibility, or exposes it as a debug view. */
+export const gtaoComposite = {
+  name: 'gtaoComposite',
+  source: /* wgsl */ `\
+struct GTAOCompositeUniforms {
+  strength: f32,
+  debugMode: f32,
+};
+
+@group(0) @binding(auto) var<uniform> gtaoComposite: GTAOCompositeUniforms;
+@group(0) @binding(auto) var ambientOcclusionTexture: texture_2d<f32>;
+@group(0) @binding(auto) var ambientOcclusionTextureSampler: sampler;
+
+fn gtaoComposite_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let color = textureSample(sourceTexture, sourceTextureSampler, texCoord);
+  let visibility = textureSample(
+    ambientOcclusionTexture,
+    ambientOcclusionTextureSampler,
+    texCoord
+  ).r;
+  if (gtaoComposite.debugMode > 0.5) {
+    return vec4f(vec3f(visibility), 1.0);
+  }
+  let ambientVisibility = mix(1.0, visibility, clamp(gtaoComposite.strength, 0.0, 1.0));
+  return vec4f(color.rgb * ambientVisibility, color.a);
+}`,
+  bindingLayout: [{name: 'ambientOcclusionTexture', group: 0}],
+  props: {} as Partial<GTAOCompositeUniforms>,
+  uniforms: {} as GTAOCompositeUniforms,
+  uniformTypes: {
+    strength: 'f32',
+    debugMode: 'f32'
+  },
+  propTypes: {
+    strength: {value: 0.68, min: 0, max: 1},
+    debugMode: {value: 0, min: 0, max: 1, private: true}
+  },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<Partial<GTAOCompositeUniforms>, GTAOCompositeUniforms>;
+
+/** Creates a temporally stabilized horizon-based ambient-occlusion pipeline. */
+export function createGTAOShaderPassPipeline(
+  options: GTAOShaderPassPipelineOptions = {}
+): ShaderPassPipeline<
+  'gtaoRaw' | 'gtaoHistory' | 'gtaoHistoryDepth' | 'gtaoScratch' | 'gtaoBlurred'
+> {
+  const scale = options.resolutionScale || 0.5;
+  return {
+    name: 'gtaoShaderPassPipeline',
+    renderTargets: {
+      gtaoRaw: {scale: [scale, scale], format: 'rgba8unorm'},
+      gtaoHistory: {
+        scale: [scale, scale],
+        format: 'rgba8unorm',
+        lifetime: 'history',
+        initialize: {clearColor: [1, 1, 1, 1]}
+      },
+      gtaoHistoryDepth: {
+        scale: [scale, scale],
+        format: 'rgba16float',
+        lifetime: 'history',
+        initialize: {clearColor: [1, 0, 0, 1]}
+      },
+      gtaoScratch: {scale: [scale, scale], format: 'rgba8unorm'},
+      gtaoBlurred: {scale: [scale, scale], format: 'rgba8unorm'}
+    },
+    steps: [
+      {
+        shaderPass: gtaoEvaluate,
+        inputs: {sourceTexture: 'previous'},
+        output: 'gtaoRaw'
+      },
+      {
+        shaderPass: gtaoTemporal,
+        inputs: {
+          sourceTexture: 'gtaoRaw',
+          historyTexture: 'gtaoHistory',
+          previousDepthTexture: 'gtaoHistoryDepth'
+        },
+        output: 'gtaoHistory'
+      },
+      {
+        shaderPass: gtaoDepthHistoryCopy,
+        inputs: {sourceTexture: 'previous'},
+        output: 'gtaoHistoryDepth'
+      },
+      {
+        shaderPass: depthAwareBlur,
+        inputs: {sourceTexture: 'gtaoHistory'},
+        output: 'gtaoScratch',
+        uniforms: {direction: [1, 0], radius: 3, spatialSigma: 2.5, depthSigma: 0.008}
+      },
+      {
+        shaderPass: depthAwareBlur,
+        inputs: {sourceTexture: 'gtaoScratch'},
+        output: 'gtaoBlurred',
+        uniforms: {direction: [0, 1], radius: 3, spatialSigma: 2.5, depthSigma: 0.008}
+      },
+      {
+        shaderPass: gtaoComposite,
+        inputs: {sourceTexture: 'previous', ambientOcclusionTexture: 'gtaoBlurred'},
+        output: 'previous'
+      }
+    ]
+  };
+}

--- a/modules/effects/src/passes/screen-space/gtao.ts
+++ b/modules/effects/src/passes/screen-space/gtao.ts
@@ -23,6 +23,7 @@ type GTAOEvaluateUniforms = {
 };
 
 type GTAOTemporalUniforms = {
+  inverseProjectionMatrix: Matrix4;
   historyWeight: number;
   depthThreshold: number;
 };
@@ -200,6 +201,7 @@ export const gtaoTemporal = {
   name: 'gtaoTemporal',
   source: /* wgsl */ `\
 struct GTAOTemporalUniforms {
+  inverseProjectionMatrix: mat4x4f,
   historyWeight: f32,
   depthThreshold: f32,
 };
@@ -213,6 +215,12 @@ struct GTAOTemporalUniforms {
 @group(0) @binding(auto) var depthTextureSampler: sampler;
 @group(0) @binding(auto) var previousDepthTexture: texture_2d<f32>;
 @group(0) @binding(auto) var previousDepthTextureSampler: sampler;
+
+fn gtaoTemporal_reconstructViewDepth(texCoord: vec2f, depth: f32) -> f32 {
+  let clip = vec4f(texCoord.x * 2.0 - 1.0, 1.0 - texCoord.y * 2.0, depth, 1.0);
+  let viewPosition = gtaoTemporal.inverseProjectionMatrix * clip;
+  return abs(viewPosition.z / max(abs(viewPosition.w), 0.00001));
+}
 
 fn gtaoTemporal_sampleColor(
   sourceTexture: texture_2d<f32>,
@@ -231,7 +239,14 @@ fn gtaoTemporal_sampleColor(
     previousDepthTextureSampler,
     clampedPreviousCoord
   ).r;
-  let validDepth = abs(previousDepth - currentDepth) < gtaoTemporal.depthThreshold;
+  let currentViewDepth = gtaoTemporal_reconstructViewDepth(texCoord, currentDepth);
+  let previousViewDepth = gtaoTemporal_reconstructViewDepth(
+    clampedPreviousCoord,
+    previousDepth
+  );
+  let relativeDepthDifference = abs(previousViewDepth - currentViewDepth) /
+    max(currentViewDepth, 0.0001);
+  let validDepth = relativeDepthDifference < gtaoTemporal.depthThreshold;
 
   let texel = 1.0 / vec2f(textureDimensions(sourceTexture));
   var minimumVisibility = current.r;
@@ -266,10 +281,12 @@ fn gtaoTemporal_sampleColor(
   uniforms: {} as GTAOTemporalUniforms,
   bindings: {} as GTAOTemporalBindings,
   uniformTypes: {
+    inverseProjectionMatrix: 'mat4x4<f32>',
     historyWeight: 'f32',
     depthThreshold: 'f32'
   },
   propTypes: {
+    inverseProjectionMatrix: {value: new Matrix4(), private: true},
     historyWeight: {value: 0.88, min: 0, max: 0.97},
     depthThreshold: {value: 0.015, min: 0.0001, softMax: 0.1}
   },

--- a/modules/effects/test/passes/advanced-effects.spec.ts
+++ b/modules/effects/test/passes/advanced-effects.spec.ts
@@ -10,6 +10,7 @@ import {
   bloomShaderPassPipeline,
   brightnessContrast,
   createMotionBlurShaderPassPipeline,
+  createGTAOShaderPassPipeline,
   createOutlineShaderPassPipeline,
   createSSAOShaderPassPipeline,
   createSSRShaderPassPipeline,
@@ -30,6 +31,21 @@ test('advanced effects expose composable pipeline shapes', testCase => {
     ssao.steps[0].inputs?.normalTexture,
     undefined,
     'normal-texture mode consumes the external normal binding'
+  );
+
+  const gtao = createGTAOShaderPassPipeline({resolutionScale: 0.5});
+  testCase.equal(gtao.steps.length, 6, 'GTAO evaluates, stabilizes, denoises, and composites');
+  testCase.deepEqual(gtao.renderTargets?.gtaoRaw.scale, [0.5, 0.5], 'GTAO honors scale');
+  testCase.equal(gtao.renderTargets?.gtaoHistory.lifetime, 'history', 'GTAO retains AO history');
+  testCase.equal(
+    gtao.renderTargets?.gtaoHistoryDepth.lifetime,
+    'history',
+    'GTAO retains depth history for disocclusion rejection'
+  );
+  testCase.equal(
+    gtao.steps[1].inputs?.historyTexture,
+    gtao.steps[1].output,
+    'GTAO intentionally reprojects one logical history target'
   );
 
   const reconstructedSSAO = createSSAOShaderPassPipeline();
@@ -112,6 +128,7 @@ test('advanced effects compose in order with existing effects', async testCase =
   const mixedEffectStack = [
     brightnessContrast,
     createSSAOShaderPassPipeline({normalSource: 'normal-texture'}),
+    createGTAOShaderPassPipeline(),
     bloomShaderPassPipeline,
     dofShaderPassPipeline,
     createTAAShaderPassPipeline(),
@@ -169,6 +186,9 @@ test('advanced effects compose in order with existing effects', async testCase =
     );
     testCase.ok(hasBinding('ssaoEvaluate', 'depthTexture'), 'SSAO receives scene depth');
     testCase.ok(hasBinding('ssaoEvaluate', 'normalTexture'), 'SSAO receives scene normals');
+    testCase.ok(hasBinding('gtaoEvaluate', 'depthTexture'), 'GTAO receives scene depth');
+    testCase.ok(hasBinding('gtaoEvaluate', 'normalTexture'), 'GTAO receives scene normals');
+    testCase.ok(hasBinding('gtaoTemporal', 'velocityTexture'), 'GTAO receives scene velocity');
     testCase.notOk(
       hasBinding('bloomExtract', 'velocityTexture'),
       'bloom does not receive scene velocity'

--- a/modules/effects/test/passes/advanced-effects.spec.ts
+++ b/modules/effects/test/passes/advanced-effects.spec.ts
@@ -17,7 +17,8 @@ import {
   createTAAShaderPassPipeline,
   createVolumetricFogShaderPassPipeline,
   depthAwareBlurShaderPassPipeline,
-  dofShaderPassPipeline
+  dofShaderPassPipeline,
+  gtaoTemporal
 } from '../../src';
 
 test('advanced effects expose composable pipeline shapes', testCase => {
@@ -46,6 +47,11 @@ test('advanced effects expose composable pipeline shapes', testCase => {
     gtao.steps[1].inputs?.historyTexture,
     gtao.steps[1].output,
     'GTAO intentionally reprojects one logical history target'
+  );
+  testCase.equal(
+    gtaoTemporal.uniformTypes.inverseProjectionMatrix,
+    'mat4x4<f32>',
+    'GTAO temporal rejection reconstructs linear view-space depth'
   );
 
   const reconstructedSSAO = createSSAOShaderPassPipeline();

--- a/modules/effects/test/passes/postprocessing-wgsl.spec.ts
+++ b/modules/effects/test/passes/postprocessing-wgsl.spec.ts
@@ -10,6 +10,7 @@ import {
   brightnessContrast,
   bulgePinch,
   colorHalftone,
+  createGTAOShaderPassPipeline,
   createMotionBlurShaderPassPipeline,
   createOutlineShaderPassPipeline,
   createSSAOShaderPassPipeline,
@@ -74,6 +75,7 @@ const PLATFORM_INFO = {
 
 const ADVANCED_SHADER_PASSES = [
   createSSAOShaderPassPipeline({normalSource: 'normal-texture'}),
+  createGTAOShaderPassPipeline(),
   createOutlineShaderPassPipeline({normalSource: 'normal-texture'}),
   createTAAShaderPassPipeline(),
   createMotionBlurShaderPassPipeline(),

--- a/website/content/examples/experimental/deferred-rendering.mdx
+++ b/website/content/examples/experimental/deferred-rendering.mdx
@@ -16,7 +16,8 @@ import {DeferredRenderingExample} from '@site/src/examples';
   <div>
     A WebGPU-only material laboratory that writes five surface targets once, then reconstructs
     view position from depth and resolves a directional light plus hundreds of compute-clustered
-    storage-buffer point lights in one fullscreen pass.
+    storage-buffer point lights in one fullscreen pass. A temporally stabilized GTAO pass then
+    reuses the same depth, normals, and velocity for grounded contact shading.
   </div>
 </ExampleHeader>
 
@@ -32,7 +33,10 @@ import {DeferredRenderingExample} from '@site/src/examples';
   geometry.
 - **Base Color**, **Normals**, **Roughness**, **Metallic**, **Emissive**, and **Depth** expose the
   actual G-buffer channels rather than a recreated diagnostic view. **Cluster Occupancy** shows
-  the per-pixel cluster list pressure as a cold-to-hot heatmap.
+  the per-pixel cluster list pressure as a cold-to-hot heatmap. **Ambient Occlusion** exposes the
+  denoised, temporally reprojected GTAO visibility buffer.
+- Raise **GTAO Radius** to make larger-scale creases visible, then use **GTAO Intensity** and
+  **GTAO Strength** to separate visibility estimation from how strongly it affects lit color.
 
 ## Render stack
 
@@ -48,8 +52,11 @@ velocity, and depth channels plus two named material extras:
 screen/log-depth grid. `createClusteredDeferredLightingShaderPassPipeline()` then reads those
 material targets plus the current pixel's bounded cluster list, reconstructs view-space position
 from depth, evaluates Cook-Torrance direct lighting, and writes HDR color back into the normal
-ordered shader-pass chain. A final display pass tone maps the result or selects a G-buffer/cluster
-debug view.
+ordered shader-pass chain. `createGTAOShaderPassPipeline()` then performs a half-resolution
+horizon search over the unchanged depth and view-normal attachments, reprojects the previous AO
+result through the velocity buffer, rejects disocclusions with depth history, and applies a
+depth-aware separable blur before compositing ambient visibility into lit color. A final display
+pass tone maps the result or selects a G-buffer/cluster/AO debug view.
 
 The point-light positions are transformed to view space on the CPU and packed with
 `makeDeferredPointLightBufferData()` into two `vec4f` records per light:
@@ -59,5 +66,5 @@ position.xyz, range, color.rgb, intensity
 ```
 
 That fixed representation keeps the example focused on the deferred boundary: geometry owns
-material capture, compute owns light assignment, the fullscreen pass owns lighting, and later
-effects can consume the unchanged depth, normal, velocity, and scene-color contract.
+material capture, compute owns light assignment, the lighting pass owns direct light, and later
+effects such as GTAO can consume the unchanged depth, normal, velocity, and scene-color contract.


### PR DESCRIPTION
## Goals

- Add a higher-quality, composable ambient-occlusion stage on top of the clustered deferred renderer.
- Demonstrate how the shared G-buffer supports temporal screen-space effects without redrawing scene geometry.

## Changes

- Adds `createGTAOShaderPassPipeline()` and reusable GTAO evaluation, temporal reprojection, depth-history, and composition shader passes in `@luma.gl/effects`.
- Evaluates horizon-based ambient visibility at half resolution using the G-buffer depth and view-normal attachments.
- Reprojects AO through the velocity buffer, reconstructs current and historical view-space depths for perspective-correct disocclusion rejection, clamps history to the current neighborhood, and denoises with separable depth-aware blur.
- Upgrades Deferred Rendering: Material Lab with GTAO radius/intensity/strength controls, an Ambient Occlusion debug view, and expanded Background/render-stack explanations.
- Updates public exports, package documentation, release notes, and focused integration/WGSL compilation coverage.

## Verification

- `yarn lint fix` — passed.
- `yarn build` — passed against current `master`.
- `yarn test-headless modules/effects/test/passes/advanced-effects.spec.ts modules/effects/test/passes/postprocessing-wgsl.spec.ts` — passed (2 files, 3 tests).
- `yarn website:build` — previously passed.
- Live browser verification — final composition and Ambient Occlusion debug view render without WebGPU console errors.

## Stack

- Base: `master`; clustered deferred lighting (#2751) has already merged.
- Follow-up reflections work: #2753, submitted as a separately reviewable stacked PR.