### PR TITLE
feat(effects): Add temporally stabilized screen-space reflections

### DIFF
--- a/docs/api-guide/shaders/rendering-techniques.md
+++ b/docs/api-guide/shaders/rendering-techniques.md
@@ -1,0 +1,226 @@
+import {ShaderLevelDocsTabs} from '@site/src/components/docs/shader-level-docs-tabs';
+
+# Rendering Techniques and Tradeoffs
+
+<ShaderLevelDocsTabs active="rendering-techniques" />
+
+luma.gl deliberately provides several approaches to similar visual problems. A cheap effect,
+a higher-quality effect, a material shader, and a scene-aware fullscreen pipeline are not
+interchangeable just because they all produce reflections, shadows, blur, or ambient occlusion.
+
+Choose the technique by identifying which data it needs, what information it cannot see, and
+whether its cost scales with scene geometry, visible pixels, light count, or temporal history.
+
+## Quick Selection
+
+| Goal | Start with | Upgrade when | Important constraint |
+| --- | --- | --- | --- |
+| Stable environment reflections | `pbrMaterial` with `ibl` and `loadPBREnvironment()` | Add screen-space reflections for nearby animated scene detail. | Environment maps do not automatically capture the current local scene. |
+| Dynamic reflections of visible geometry | `createSSRShaderPassPipeline()` | Increase tracing resolution, ray samples, and temporal history quality. | Screen-space rays cannot reflect geometry outside the current depth/color buffers. |
+| Low-cost contact darkening | `createSSAOShaderPassPipeline()` | Switch to GTAO when contact quality and temporal stability matter. | Use SSAO **or** GTAO; stacking both normally double-darkens surfaces. |
+| Higher-quality ambient visibility | `createGTAOShaderPassPipeline()` | Tune radius, history, and denoising for the scene scale. | Requires coherent depth, view normals, velocity, and projection matrices. |
+| A modest number of local lights | `createDeferredLightingShaderPassPipeline()` | Switch to clustered lighting when many lights overlap the scene. | The baseline shader supports at most 64 point lights. |
+| Hundreds of local lights | `ClusteredLightGrid` plus `createClusteredDeferredLightingShaderPassPipeline()` | Tune grid dimensions, light ranges, and per-cluster capacity. | Overflow stays correct but can fall back to a more expensive full light scan. |
+| Sun, spot, or point-light visibility | `ShadowMapRenderer` | Add contact shadows for missing near-surface detail. | Light-space shadows need caster geometry; they are not a color-only effect. |
+| Tiny near-surface shadow detail | `createContactShadowShaderPassPipeline()` | Combine with stable cascaded or local-light shadow maps. | Camera-space contact rays cannot see occluders outside the current depth buffer. |
+| Fast transparent layering | `WBOITRenderer` | Use `ABufferRenderer` when exact fragment ordering is more important. | Weighted blending approximates heavily overlapping transparent layers. |
+| Broad cinematic glow | `bloomShaderPassPipeline` | Keep the single `bloom` pass for simpler, cheaper glow. | Bloom operates on color; it is not reflected lighting or global illumination. |
+
+## Reflections: Environment Maps Versus Screen-Space Rays
+
+The two reflection mechanisms answer different questions.
+
+| | Image-based lighting | Screen-space reflections |
+| --- | --- | --- |
+| Public entry points | `pbrMaterial`, `ibl`, `loadPBREnvironment()` | `createSSRShaderPassPipeline()` |
+| Where it runs | Inside material shading. | After opaque lighting, as an ordered fullscreen pipeline. |
+| Reflected source | Prefiltered diffuse/specular environment cubemaps and a BRDF lookup texture. | The already-lit scene color and scene depth visible to the current camera. |
+| Off-screen environment | Supported through the cubemap. | Unavailable unless the application supplies another fallback. |
+| Moving local geometry and lights | Only if the environment map is recaptured externally. | Visible changes appear automatically in the traced scene color. |
+| Roughness response | Specular environment mip levels approximate broader glossy lobes. | Roughness jitters rays and controls depth/normal-aware denoising. |
+| Typical cost | A small, predictable number of material texture samples. | Visible reflection pixels × ray samples, plus history and denoising passes. |
+| Temporal behavior | Stable when the environment texture is stable. | Velocity reprojection and linear-depth disocclusion rejection stabilize noise. |
+| Backend | The PBR shader path supports WebGPU and WebGL 2. | The current advanced SSR pipeline is WebGPU-first. |
+
+These techniques are usually complementary: image-based lighting supplies a stable off-screen
+fallback, while screen-space reflections add dynamic nearby objects and lights. Avoid blindly
+adding both full-strength contributions; use reflection confidence, Fresnel, roughness, or a
+material-specific blend to prevent counting the same reflected energy twice.
+
+Planar reflections and ray-traced reflections are different techniques again. luma.gl exposes
+the render-target, camera, and shader building blocks needed for an application-owned planar
+reflection pass, but does not currently provide a packaged planar-reflection renderer or a
+hardware ray-tracing pipeline. Neither should be confused with the implemented SSR pipeline.
+
+### One SSR Implementation, Multiple Examples
+
+[Effects: Visualization City](/examples/experimental/advanced-effects) and
+[Deferred Rendering: Material Lab](/examples/experimental/deferred-rendering) use the **same**
+exported `createSSRShaderPassPipeline()`. They are examples of one implementation in different
+render stacks, not competing copies of the reflection algorithm.
+
+- Visualization City selects approximately 35%, 50%, or 100% tracing resolution from its quality
+  preset and combines reflections with light-space shadows, SSAO, fog, and temporal AA.
+- Material Lab traces at full resolution to showcase polished floors, chrome accents, roughness
+  variation, reflection-confidence diagnostics, and clustered animated lights.
+- `ssrTrace`, `ssrTemporal`, `ssrDepthHistoryCopy`, `ssrSpatial`, and `ssrComposite` are the
+  reusable stages of that same pipeline, exposed for applications that need custom composition.
+
+The default `createSSRShaderPassPipeline()` uses half-resolution internal targets. Raising
+`resolutionScale` increases ray-tracing and history memory approximately with the square of the
+scale. Increasing `sampleCount` increases ray work approximately linearly. Longer ray distances
+usually require more samples to avoid visible marching bands. Temporal history and bilateral
+denoising improve stability, but are not substitutes for adequate ray density.
+
+## Ambient Occlusion: SSAO Versus GTAO
+
+Both techniques estimate visibility from the current depth buffer; neither traces off-screen
+geometry or computes full global illumination.
+
+| | SSAO | GTAO |
+| --- | --- | --- |
+| Public entry point | `createSSAOShaderPassPipeline()` | `createGTAOShaderPassPipeline()` |
+| Main estimator | A compact depth-neighborhood sample kernel. | A multi-direction horizon search in reconstructed view space. |
+| Pipeline stages | Evaluate, horizontal blur, vertical blur, composite. | Evaluate, temporal reprojection, depth-history capture, two blur passes, composite. |
+| Required inputs | Depth, with optional supplied view normals. | Depth, view normals, velocity, and camera projection/inverse projection. |
+| History targets | None. | Persistent AO and previous-depth targets. |
+| Main strength | Smaller setup cost and an inexpensive contact-darkening option. | Better grounding, larger-scale creases, and steadier animated results. |
+| Typical tradeoff | More visible noise or less faithful horizon detail. | More samples, texture memory, and temporal-history management. |
+
+Use one AO estimator per stack. GTAO is usually the higher-quality replacement for SSAO, not a
+second layer to multiply on top of it. Reset history after camera cuts, resize events, or changes
+that invalidate scene velocity.
+
+## Lighting: Baseline Deferred Versus Clustered Deferred
+
+Both lighting resolves consume the same `GBuffer` material attachments and emit HDR color into
+the normal ordered `previous` chain.
+
+| | Baseline deferred lighting | Clustered deferred lighting |
+| --- | --- | --- |
+| Public entry point | `createDeferredLightingShaderPassPipeline()` | `ClusteredLightGrid` and `createClusteredDeferredLightingShaderPassPipeline()` |
+| Maximum point lights | 64. | 512 in the current implementation. |
+| Per-pixel light work | Checks every active point light. | Normally checks only the lights assigned to the pixel's screen/depth cluster. |
+| Additional setup | One fixed-capacity point-light storage buffer. | Compute-built cluster count/index buffers plus the same point-light buffer. |
+| Best fit | Smaller scenes, simpler integration, or modest light counts. | Large dynamic light counts with reasonably localized light ranges. |
+| Failure mode | Cost grows with every active light, even when most do not affect the pixel. | Dense or oversized lights saturate clusters and trigger a slower correctness fallback. |
+
+Clustering changes the common-case cost from roughly **visible pixels × all lights** to
+**light binning + visible pixels × nearby lights**. It does not make lighting free: a scene in
+which every light overlaps every cluster still has substantial work. The occupancy debug view
+shows whether cluster dimensions, retained capacity, or light ranges should be adjusted.
+
+## Shadows: Light-Space Maps Versus Screen-Space Contacts
+
+`ShadowMapRenderer` renders directional cascades, spot-light maps, or point-light cube maps from
+the lights' point of view. It can account for off-screen casters and should modulate the matching
+direct-light contribution during scene shading.
+
+`createContactShadowShaderPassPipeline()` traces short rays through the camera depth buffer. It
+recovers fine contact detail that finite-resolution shadow maps can miss, but cannot see
+off-screen or hidden occluders. Its composition must affect the associated direct-light term,
+not ambient or emissive color.
+
+Use shadow maps as the primary visibility solution and contact shadows as an optional refinement.
+SSAO/GTAO are ambient-visibility estimators, not replacements for either directional or local
+light shadows.
+
+## Transparency: Weighted Blending Versus A-Buffer
+
+| | Weighted blended OIT | A-buffer OIT |
+| --- | --- | --- |
+| Public entry point | `WBOITRenderer` | `ABufferRenderer` |
+| Backend | WebGPU or WebGL 2 with supported floating-point blending. | WebGPU with fragment-stage storage buffers. |
+| Fragment order | Weighted approximation without per-pixel sorting. | Captures bounded per-pixel fragment lists and sorts them during resolve. |
+| Memory | Fixed accumulation/revealage targets independent of layer count. | Scales with configured fragment storage and per-pixel limits. |
+| Best fit | Broad compatibility and many translucent fragments at predictable cost. | Intersections and layering where more accurate depth ordering matters. |
+| Limitation | Strongly overlapping layers can blend inaccurately. | Over-capacity fragments are dropped or require bounded capture slices. |
+
+Both resolve into the same shader-pass color chain, so later bloom, temporal AA, or display
+effects remain composable.
+
+## Bloom, Blur, and Depth of Field
+
+| Technique | Public entry point | Choose it when | Avoid confusing it with |
+| --- | --- | --- | --- |
+| Compact bloom | `bloom` | A lightweight single-pass highlight glow is sufficient. | Multiscale bloom or physically based reflected light. |
+| Multiscale bloom | `bloomShaderPassPipeline` | Highlights should spread across several image scales with softer falloff. | A duplicate bloom layer; normally choose this **instead of** `bloom`. |
+| Gaussian blur | `gaussianBlur` | A smooth, general-purpose image blur is needed. | Depth-aware filtering or camera lens simulation. |
+| Triangle blur | `triangleBlur` | A simpler separable smoothing kernel is sufficient. | A Gaussian distribution or edge-preserving bilateral blur. |
+| Edge-preserving blur | `depthAwareBlurShaderPassPipeline` | Depth discontinuities must stay sharp while denoising. | Lens depth of field; this pass filters by depth similarity. |
+| Lens depth of field | `dofShaderPassPipeline` | Blur should vary with focus distance and scene depth. | The low-level `dof` pass, which represents one separable blur axis. |
+| Motion blur | `createMotionBlurShaderPassPipeline()` | Real screen-space velocity should produce motion streaks. | `zoomBlur`, which intentionally applies a stylized radial effect. |
+
+For bloom and depth of field, the pipeline owns the appropriate intermediate targets and ordering.
+The low-level pass remains useful when building a custom pipeline, but does not need to be added
+alongside its own complete pipeline.
+
+## Antialiasing: FXAA, TAA, and Multisampling
+
+- `fxaa` smooths a resolved image in one frame and does not require scene velocity or persistent
+  history. It is a useful low-cost final-image option.
+- `createTAAShaderPassPipeline()` accumulates a jittered scene over time using depth, velocity,
+  and persistent history. It handles subpixel shimmer more effectively but can ghost if motion
+  vectors or disocclusion rejection are wrong.
+- Multisampling and supersampling address coverage during geometry rendering rather than replacing
+  a final-image postprocess. Managed offscreen multisample resolve remains a separate GPU API
+  concern.
+
+For backend-specific constraints and combined ordering, see
+[Antialiasing and Multisampling](/docs/api-guide/gpu/gpu-antialiasing).
+
+## Compose by Contract, Not by Visual Name
+
+A representative WebGPU stack is:
+
+```ts
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {
+  bloomShaderPassPipeline,
+  createGTAOShaderPassPipeline,
+  createSSRShaderPassPipeline,
+  createTAAShaderPassPipeline
+} from '@luma.gl/effects';
+import {createClusteredDeferredLightingShaderPassPipeline} from '@luma.gl/experimental';
+
+const renderer = new ShaderPassRenderer(device, {
+  shaderPasses: [
+    createClusteredDeferredLightingShaderPassPipeline(),
+    createGTAOShaderPassPipeline({resolutionScale: 0.5}),
+    createSSRShaderPassPipeline({resolutionScale: 0.5}),
+    createTAAShaderPassPipeline(),
+    bloomShaderPassPipeline
+  ],
+  colorFormat: 'rgba16float'
+});
+
+renderer.renderToScreen({
+  sourceTexture: gBuffer.colorTexture,
+  bindings: {
+    ...gBuffer.getShaderPassBindings(),
+    baseColorMetallicTexture: gBuffer.getExtraColorTexture('baseColorMetallic'),
+    emissiveOcclusionTexture: gBuffer.getExtraColorTexture('emissiveOcclusion'),
+    pointLights,
+    ...clusteredLightGrid.getShaderPassBindings()
+  },
+  uniforms: {
+    clusteredDeferredLighting: {
+      inverseProjectionMatrix,
+      ...clusteredLightGrid.getShaderPassUniforms(nearPlane, farPlane)
+    },
+    gtaoEvaluate: {projectionMatrix, inverseProjectionMatrix},
+    gtaoTemporal: {inverseProjectionMatrix},
+    ssrTrace: {projectionMatrix, inverseProjectionMatrix},
+    ssrTemporal: {inverseProjectionMatrix}
+  }
+});
+```
+
+The application still owns geometry, light updates, cluster encoding, shadow-map rendering,
+camera matrices, and presentation. `GBuffer` standardizes surface attachments, while
+`ShaderPassRenderer` manages ordered color routing, intermediate targets, and temporal history.
+
+For the underlying execution model, see [Shader Passes](/docs/api-guide/shaders/shader-passes).
+For complete live stacks, compare
+[Effects: Visualization City](/examples/experimental/advanced-effects) and
+[Deferred Rendering: Material Lab](/examples/experimental/deferred-rendering).

--- a/docs/api-guide/shaders/shader-passes.md
+++ b/docs/api-guide/shaders/shader-passes.md
@@ -71,7 +71,7 @@ surface attachments without owning scene traversal or material shading. Multiple
 | `sourceTexture` | `GBuffer.colorTexture` | Every shader pass through `previous` or `original`. |
 | `depthTexture` | `GBuffer.depthTexture` | DOF, depth-aware blur, SSAO, GTAO, SSR, outlines, contact shadows, TAA, motion blur, fog. |
 | `normalTexture` | `GBuffer.normalRoughnessTexture` | SSAO, GTAO, SSR, normal-aware outlines, contact-shadow filtering. |
-| `velocityTexture` | `GBuffer.velocityTexture` | GTAO temporal reprojection, TAA, and motion blur. |
+| `velocityTexture` | `GBuffer.velocityTexture` | GTAO/SSR temporal reprojection, TAA, and motion blur. |
 | named extras | `GBuffer.getExtraColorTexture(name)` | Application-specific material, debug, lighting, or resolve passes. |
 
 ```ts
@@ -133,6 +133,27 @@ const renderer = new ShaderPassRenderer(device, {
 More specialized clustered-lighting or visibility-buffer workflows can replace the first resolve
 while preserving the same effect-facing depth, normal, velocity, and scene-color contract.
 
+### Screen-space reflection composition
+
+`createSSRShaderPassPipeline()` consumes the already-lit `previous` color plus the shared depth,
+normal/roughness, and velocity attachments. Its six explicit stages demonstrate how a complex
+effect remains one composable pipeline:
+
+1. Trace stochastic, roughness-aware reflection rays against the G-buffer depth at half
+   resolution.
+2. Reproject persistent reflection history with screen-space velocity and reject depth
+   disocclusions.
+3. Save current depth into the reflection history target for the next frame.
+4. Denoise reflection radiance horizontally using roughness, scene depth, and normals.
+5. Repeat the depth/normal-aware denoising vertically.
+6. Composite the stabilized HDR reflection into `previous`, or expose reflection/confidence debug
+   views.
+
+Mirror-like materials retain narrow highlights, while rough surfaces accumulate wider glossy
+lobes. Because tracing samples existing scene color, its cost depends on visible pixels and ray
+steps instead of drawing every reflected object again. Off-screen geometry cannot contribute;
+screen-edge confidence fades reduce the resulting discontinuities.
+
 ### Recommended ordering
 
 | Phase | Typical work | Why |
@@ -166,9 +187,9 @@ effects without creating a second postprocessing system.
 The [Advanced Effects example](/examples/experimental/advanced-effects) shows the full MRT surface
 pass feeding shadows, SSAO, SSR, fog, outlines, TAA, motion blur, and debug views.
 
-The [Deferred Material Lab](/examples/experimental/deferred-rendering) shows the opaque phase and
-its first screen-space consumer: one five-target geometry pass, depth reconstruction, clustered
-directional/point lighting, temporally stabilized GTAO, tone mapping, and direct G-buffer/AO debug
+The [Deferred Material Lab](/examples/experimental/deferred-rendering) shows one five-target
+geometry pass feeding clustered directional/point lighting, temporally stabilized GTAO,
+roughness-aware screen-space reflections, tone mapping, and direct G-buffer/AO/reflection debug
 views.
 
 ## When To Use Shader Passes

--- a/docs/api-guide/shaders/shader-passes.md
+++ b/docs/api-guide/shaders/shader-passes.md
@@ -133,6 +133,10 @@ const renderer = new ShaderPassRenderer(device, {
 More specialized clustered-lighting or visibility-buffer workflows can replace the first resolve
 while preserving the same effect-facing depth, normal, velocity, and scene-color contract.
 
+For side-by-side choices between reflections, ambient occlusion, light assignment, shadows,
+transparency, blur, and temporal effects, see
+[Rendering Techniques and Tradeoffs](/docs/api-guide/shaders/rendering-techniques).
+
 ### Screen-space reflection composition
 
 `createSSRShaderPassPipeline()` consumes the already-lit `previous` color plus the shared depth,

--- a/docs/api-reference/shadertools/shader-passes/image-processing.mdx
+++ b/docs/api-reference/shadertools/shader-passes/image-processing.mdx
@@ -9,6 +9,10 @@ postprocessing system. In luma.gl, run them through
 The older `Pass` classes from luma.gl v7 are not the current execution API.
 :::
 
+For guidance on similar-looking alternatives, including single-pass versus multiscale bloom,
+SSAO versus GTAO, environment-map versus screen-space reflections, and FXAA versus temporal AA,
+see [Rendering Techniques and Tradeoffs](/docs/api-guide/shaders/rendering-techniques).
+
 ## Attribution
 
 Most of these image post processing effects (and this documentation page) are forked from Evan Wallace's [glfx](https://github.com/evanw/glfx.js) library and have just been repackaged as luma.gl shader modules / shader passes.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -79,7 +79,8 @@
           "api-guide/shaders/shader-assembly",
           "api-guide/shaders/writing-customizable-shaders",
           "api-guide/shaders/writing-portable-shaders",
-          "api-guide/shaders/shader-passes"
+          "api-guide/shaders/shader-passes",
+          "api-guide/shaders/rendering-techniques"
         ]
       },
       {

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -94,7 +94,7 @@ Target Release Date: Q3, 2026
 
 **@luma.gl/effects**
 
-- **Advanced screen-space effects** - New WebGPU-first composable pipelines provide depth-aware blur, SSAO, temporally stabilized GTAO, outlines, temporal AA, motion blur, screen-space reflections, and volumetric fog. They share strict ordered composition with existing effects such as bloom and depth of field.
+- **Advanced screen-space effects** - New WebGPU-first composable pipelines provide depth-aware blur, SSAO, temporally stabilized GTAO, outlines, temporal AA, motion blur, roughness-aware temporally stabilized screen-space reflections, and volumetric fog. They share strict ordered composition with existing effects such as bloom and depth of field.
 - **[Visualization City](/examples/experimental/advanced-effects)** - New MRT showcase combines the complete effect stack with presets, quality levels, debug views, and before/after comparison.
 
 

--- a/examples/experimental/advanced-effects/app.ts
+++ b/examples/experimental/advanced-effects/app.ts
@@ -692,6 +692,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
                 ? 56
                 : 36
         },
+        ssrTemporal: {inverseProjectionMatrix},
         ssrComposite: {debugMode: this.settings.debugView === 'Reflections' ? 1 : 0},
         volumetricFog: {
           density: this.settings.preset === 'Foggy Depth' ? 0.2 : 0.08,

--- a/examples/experimental/advanced-effects/app.ts
+++ b/examples/experimental/advanced-effects/app.ts
@@ -684,6 +684,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           intensity: this.settings.preset === 'Reflective Night' ? 1.8 : 1.35,
           maxDistance: this.settings.shadowQuality === 'low' ? 55 : 95,
           thickness: this.settings.shadowQuality === 'cinematic' ? 0.48 : 0.72,
+          frameIndex: this.frameIndex,
           sampleCount:
             this.settings.shadowQuality === 'low'
               ? 20

--- a/examples/experimental/deferred-rendering/app.ts
+++ b/examples/experimental/deferred-rendering/app.ts
@@ -19,6 +19,7 @@ import {
   GBuffer,
   makeDeferredPointLightBufferData,
   MAX_CLUSTERED_POINT_LIGHTS,
+  OrbitControls,
   type DeferredPointLight
 } from '@luma.gl/experimental';
 import type {ShaderModule, ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
@@ -66,6 +67,7 @@ type DeferredRenderingSettings = {
   debugView: DebugView;
   pointLightCount: number;
   animate: boolean;
+  autoOrbitCamera: boolean;
   exposure: number;
   sunIntensity: number;
   ambientOcclusionRadius: number;
@@ -82,6 +84,7 @@ const DEFAULT_SETTINGS: DeferredRenderingSettings = {
   debugView: 'Final',
   pointLightCount: 256,
   animate: true,
+  autoOrbitCamera: true,
   exposure: 1.15,
   sunIntensity: 2.8,
   ambientOcclusionRadius: 2.2,
@@ -476,6 +479,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly clusteredLightGrid: ClusteredLightGrid;
   readonly panels: ExamplePanelManager;
   readonly settingsPanel: ExampleSettingsPanelManager;
+  orbitControls: OrbitControls | null = null;
   sceneGBuffer: GBuffer;
   renderer: ShaderPassRenderer;
   settings: DeferredRenderingSettings = {...DEFAULT_SETTINGS};
@@ -529,6 +533,23 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.panels.mount();
   }
 
+  override async onInitialize({canvas}: AnimationProps): Promise<void> {
+    if (canvas instanceof HTMLCanvasElement) {
+      this.orbitControls = new OrbitControls(canvas, {
+        target: [0, 0.9, 0],
+        distance: 20,
+        yaw: 0,
+        pitch: 0.44,
+        minDistance: 6,
+        maxDistance: 42,
+        minPitch: 0.06,
+        maxPitch: 1.38,
+        autoRotate: this.settings.autoOrbitCamera,
+        autoRotateSpeed: 0.08
+      });
+    }
+  }
+
   onRender({device, width, height, aspect, tick}: AnimationProps): void {
     if (this.framebufferSize[0] !== width || this.framebufferSize[1] !== height) {
       this.framebufferSize = [width, height];
@@ -538,12 +559,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     }
 
     const time = this.settings.animate ? tick / 1000 : 1.8;
-    const cameraAngle = this.settings.animate ? time * 0.08 : 0.72;
-    const eye: NumberArray3 = [
-      Math.sin(cameraAngle) * 18,
-      9.5 + Math.sin(cameraAngle * 0.7) * 1.2,
-      Math.cos(cameraAngle) * 18
-    ];
+    this.orbitControls?.update(tick);
+    const eye: NumberArray3 = this.orbitControls?.getEyePosition() || [0, 9.5, 18];
     const projectionMatrix = new Matrix4().perspective({
       fovy: radians(47),
       aspect,
@@ -677,6 +694,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   onFinalize(): void {
     this.settingsPanel.finalize();
     this.panels.finalize();
+    this.orbitControls?.destroy();
     this.materialSpheres.destroy();
     this.floor.destroy();
     this.reflectionFeatures.destroy();
@@ -695,7 +713,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         makeHtmlCustomPanel({
           id: 'deferred-rendering-description',
           title: 'Overview',
-          html: '<p><b>One geometry pass. Hundreds of lights. Reflections everywhere.</b></p><p>Each sphere writes base color, metalness, roughness, emissive, normal, velocity, and depth once. A WebGPU compute pass bins animated lights into screen/depth clusters before the fullscreen Cook-Torrance resolve evaluates only the current pixel cluster.</p><p>Temporally stabilized GTAO grounds the contacts, then roughness-aware screen-space reflection rays bounce that same lit scene across polished floors, chrome frames, and the moving material grid. Switch Debug View to inspect the actual G-buffer, AO, reflection radiance, and reflection confidence.</p>'
+          html: '<p><b>One geometry pass. Hundreds of lights. Reflections everywhere.</b></p><p>Each sphere writes base color, metalness, roughness, emissive, normal, velocity, and depth once. A WebGPU compute pass bins animated lights into screen/depth clusters before the fullscreen Cook-Torrance resolve evaluates only the current pixel cluster.</p><p>Temporally stabilized GTAO grounds the contacts, then roughness-aware screen-space reflection rays bounce that same lit scene across polished floors, chrome frames, and the moving material grid.</p><p>Drag the canvas to orbit, use the mouse wheel or trackpad to zoom, and disable <b>Auto Orbit</b> to inspect one material or reflection closely. Switch Debug View to inspect the actual G-buffer, AO, reflection radiance, and reflection confidence.</p>'
         }),
         this.settingsPanel.makePanel(),
         makeHtmlCustomPanel({
@@ -712,6 +730,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     _changedSettings?: SettingsChangeDescriptor[]
   ): void => {
     this.settings = {...this.settings, ...(nextSettings as DeferredRenderingSettings)};
+    this.orbitControls?.setAutoRotate(this.settings.autoOrbitCamera);
   };
 }
 
@@ -970,6 +989,19 @@ function makeSettingsSchema(): SettingsSchema {
             min: 0.2,
             max: 2.5,
             step: 0.05
+          }
+        ]
+      },
+      {
+        id: 'camera',
+        name: 'Camera',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'autoOrbitCamera',
+            label: 'Auto Orbit',
+            type: 'boolean',
+            persist: 'none'
           }
         ]
       },

--- a/examples/experimental/deferred-rendering/app.ts
+++ b/examples/experimental/deferred-rendering/app.ts
@@ -668,7 +668,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           maxRoughness: 0.9,
           frameIndex: this.frameIndex
         },
-        ssrTemporal: {historyWeight: this.settings.reflectionHistoryWeight},
+        ssrTemporal: {
+          inverseProjectionMatrix,
+          historyWeight: this.settings.reflectionHistoryWeight
+        },
         ssrComposite: {
           strength: this.settings.reflectionStrength,
           debugMode:

--- a/examples/experimental/deferred-rendering/app.ts
+++ b/examples/experimental/deferred-rendering/app.ts
@@ -739,7 +739,7 @@ function createRenderer(device: Device): ShaderPassRenderer {
     shaderPasses: [
       createClusteredDeferredLightingShaderPassPipeline(),
       createGTAOShaderPassPipeline(),
-      createSSRShaderPassPipeline(),
+      createSSRShaderPassPipeline({resolutionScale: 1}),
       deferredDisplayPipeline
     ],
     colorFormat: 'rgba16float',
@@ -857,7 +857,7 @@ function makeLightMarkerData(): SurfaceInstanceData {
     const color = LIGHT_COLORS[lightIndex % LIGHT_COLORS.length]!;
     scales.push(0.095, 0.095, 0.095);
     baseColors.push(color[0], color[1], color[2], 1);
-    materials.push(0.18, 0);
+    materials.push(0.98, 0);
     emissiveColors.push(color[0], color[1], color[2]);
   }
   return {

--- a/examples/experimental/deferred-rendering/app.ts
+++ b/examples/experimental/deferred-rendering/app.ts
@@ -12,7 +12,7 @@ import {
   ShaderPassRenderer,
   SphereGeometry
 } from '@luma.gl/engine';
-import {createGTAOShaderPassPipeline} from '@luma.gl/effects';
+import {createGTAOShaderPassPipeline, createSSRShaderPassPipeline} from '@luma.gl/effects';
 import {
   ClusteredLightGrid,
   createClusteredDeferredLightingShaderPassPipeline,
@@ -58,7 +58,9 @@ type DebugView =
   | 'Emissive'
   | 'Depth'
   | 'Cluster Occupancy'
-  | 'Ambient Occlusion';
+  | 'Ambient Occlusion'
+  | 'Reflections'
+  | 'Reflection Confidence';
 
 type DeferredRenderingSettings = {
   debugView: DebugView;
@@ -69,6 +71,11 @@ type DeferredRenderingSettings = {
   ambientOcclusionRadius: number;
   ambientOcclusionIntensity: number;
   ambientOcclusionStrength: number;
+  reflectionStrength: number;
+  reflectionIntensity: number;
+  reflectionMaxDistance: number;
+  reflectionSampleCount: number;
+  reflectionHistoryWeight: number;
 };
 
 const DEFAULT_SETTINGS: DeferredRenderingSettings = {
@@ -79,15 +86,21 @@ const DEFAULT_SETTINGS: DeferredRenderingSettings = {
   sunIntensity: 2.8,
   ambientOcclusionRadius: 2.2,
   ambientOcclusionIntensity: 3.2,
-  ambientOcclusionStrength: 0.68
+  ambientOcclusionStrength: 0.68,
+  reflectionStrength: 1.15,
+  reflectionIntensity: 1.8,
+  reflectionMaxDistance: 26,
+  reflectionSampleCount: 56,
+  reflectionHistoryWeight: 0.84
 };
 
 const DEFERRED_RENDERING_BACKGROUND_HTML = `
 <p><b>Why deferred rendering scales:</b> forward shading repeats material work for every light that touches every draw. Here the geometry pass writes base color, metalness, roughness, emissive, normal, velocity, and depth once; the fullscreen resolve reuses those screen-space values for lighting.</p>
 <p><b>Why clustering wins:</b> a WebGPU compute stage projects each view-space light sphere into a <code>16 × 9 × 24</code> screen/log-depth grid. Each pixel reconstructs its view position from depth, finds one cluster, and normally evaluates only that short local list instead of all 512 lights.</p>
 <p><b>Why GTAO belongs after lighting:</b> a half-resolution horizon search reuses the same depth and view normals to estimate ambient visibility around contacts. G-buffer velocity reprojects the previous AO result, depth rejects disocclusions, and a depth-aware blur removes remaining half-resolution noise before the AO is composed into lit color.</p>
+<p><b>Where the reflections come from:</b> stochastic screen-space rays bounce from the same view normals into already-lit scene color. Rough surfaces widen the reflection cone; velocity and depth history stabilize animated highlights, while depth/normal-aware denoising preserves sharp mirrors and produces soft glossy lobes.</p>
 <p><b>Work changes shape:</b> the expensive path becomes roughly geometry + visible pixels × lights in the local cluster, instead of objects × every light. The same G-buffer also feeds GTAO, SSR, fog, outline, temporal, and motion effects without redrawing material geometry.</p>
-<p><b>Correctness at the limit:</b> candidate bits are compacted in stable light-index order. If a cluster exceeds its retained list, that pixel falls back to the full fixed-size light buffer rather than showing tile-shaped truncation; the <b>Cluster Occupancy</b> view shows where that slower fallback is being requested.</p>
+<p><b>Correctness at the limit:</b> candidate bits are compacted in stable light-index order. If a cluster exceeds its retained list, that pixel falls back to the active light prefix rather than showing tile-shaped truncation; <b>Cluster Occupancy</b>, <b>Reflections</b>, and <b>Reflection Confidence</b> expose exactly where work or uncertain screen-space hits accumulate.</p>
 `;
 
 type DeferredSurfaceUniforms = {
@@ -296,6 +309,10 @@ fn deferredDisplay_sampleColor(
       255.0;
     return vec4f(deferredDisplay_toneMap(emissive), 1.0);
   }
+  if (deferredDisplay.debugMode > 8.5) {
+    let color = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord, 0).rgb;
+    return vec4f(deferredDisplay_toneMap(color), 1.0);
+  }
   if (deferredDisplay.debugMode > 7.5) {
     let color = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord, 0).rgb;
     return vec4f(color, 1.0);
@@ -453,6 +470,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly device: Device;
   readonly materialSpheres: InstancedSurfaceModel;
   readonly floor: InstancedSurfaceModel;
+  readonly reflectionFeatures: InstancedSurfaceModel;
   readonly lightMarkers: InstancedSurfaceModel;
   readonly pointLightBuffer: Buffer;
   readonly clusteredLightGrid: ClusteredLightGrid;
@@ -477,6 +495,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       id: 'deferred-material-floor',
       geometry: new CubeGeometry({indices: true}),
       data: makeFloorData()
+    });
+    this.reflectionFeatures = new InstancedSurfaceModel(device, {
+      id: 'deferred-reflection-features',
+      geometry: new CubeGeometry({indices: true}),
+      data: makeReflectionFeatureData()
     });
     this.lightMarkers = new InstancedSurfaceModel(device, {
       id: 'deferred-light-markers',
@@ -541,6 +564,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     };
     this.materialSpheres.setUniforms(surfaceUniforms);
     this.floor.setUniforms(surfaceUniforms);
+    this.reflectionFeatures.setUniforms(surfaceUniforms);
     this.lightMarkers.setUniforms(surfaceUniforms);
 
     const activeLightCount = Math.min(
@@ -572,6 +596,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       clearDepth: 1
     });
     this.floor.model.draw(renderPass);
+    this.reflectionFeatures.model.draw(renderPass);
     this.materialSpheres.model.draw(renderPass);
     this.lightMarkers.model.draw(renderPass);
     renderPass.end();
@@ -615,6 +640,27 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           strength: this.settings.ambientOcclusionStrength,
           debugMode: this.settings.debugView === 'Ambient Occlusion' ? 1 : 0
         },
+        ssrTrace: {
+          projectionMatrix,
+          inverseProjectionMatrix,
+          intensity:
+            this.settings.debugView === 'Ambient Occlusion' ? 0 : this.settings.reflectionIntensity,
+          maxDistance: this.settings.reflectionMaxDistance,
+          thickness: 0.32,
+          sampleCount: this.settings.reflectionSampleCount,
+          maxRoughness: 0.9,
+          frameIndex: this.frameIndex
+        },
+        ssrTemporal: {historyWeight: this.settings.reflectionHistoryWeight},
+        ssrComposite: {
+          strength: this.settings.reflectionStrength,
+          debugMode:
+            this.settings.debugView === 'Reflections'
+              ? 1
+              : this.settings.debugView === 'Reflection Confidence'
+                ? 2
+                : 0
+        },
         deferredDisplay: {
           inverseProjectionMatrix,
           debugMode: getDebugMode(this.settings.debugView),
@@ -633,6 +679,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.panels.finalize();
     this.materialSpheres.destroy();
     this.floor.destroy();
+    this.reflectionFeatures.destroy();
     this.lightMarkers.destroy();
     this.pointLightBuffer.destroy();
     this.clusteredLightGrid.destroy();
@@ -648,7 +695,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         makeHtmlCustomPanel({
           id: 'deferred-rendering-description',
           title: 'Overview',
-          html: '<p><b>One geometry pass. Hundreds of lights.</b></p><p>Each sphere writes base color, metalness, roughness, emissive, normal, velocity, and depth once. A WebGPU compute pass bins animated lights into screen/depth clusters before the fullscreen Cook-Torrance resolve evaluates only the current pixel cluster.</p><p>A temporally stabilized GTAO pass then turns the same depth, normals, and velocity into grounded contact shading without redrawing geometry. Switch Debug View to inspect the actual G-buffer and AO contracts.</p>'
+          html: '<p><b>One geometry pass. Hundreds of lights. Reflections everywhere.</b></p><p>Each sphere writes base color, metalness, roughness, emissive, normal, velocity, and depth once. A WebGPU compute pass bins animated lights into screen/depth clusters before the fullscreen Cook-Torrance resolve evaluates only the current pixel cluster.</p><p>Temporally stabilized GTAO grounds the contacts, then roughness-aware screen-space reflection rays bounce that same lit scene across polished floors, chrome frames, and the moving material grid. Switch Debug View to inspect the actual G-buffer, AO, reflection radiance, and reflection confidence.</p>'
         }),
         this.settingsPanel.makePanel(),
         makeHtmlCustomPanel({
@@ -673,6 +720,7 @@ function createRenderer(device: Device): ShaderPassRenderer {
     shaderPasses: [
       createClusteredDeferredLightingShaderPassPipeline(),
       createGTAOShaderPassPipeline(),
+      createSSRShaderPassPipeline(),
       deferredDisplayPipeline
     ],
     colorFormat: 'rgba16float',
@@ -728,10 +776,54 @@ function makeFloorData(): SurfaceInstanceData {
   return {
     positions: new Float32Array([0, -0.32, 0]),
     scales: new Float32Array([18, 0.35, 18]),
-    baseColors: new Float32Array([0.028, 0.04, 0.065, 1]),
-    materials: new Float32Array([0.72, 0.08]),
-    emissiveColors: new Float32Array([0.001, 0.002, 0.008]),
+    baseColors: new Float32Array([0.11, 0.14, 0.2, 1]),
+    materials: new Float32Array([0.12, 0.82]),
+    emissiveColors: new Float32Array([0.002, 0.004, 0.012]),
     instanceCount: 1
+  };
+}
+
+function makeReflectionFeatureData(): SurfaceInstanceData {
+  const featurePositions: NumberArray3[] = [
+    [-8.3, 1.8, -8.1],
+    [8.3, 1.8, -8.1],
+    [-8.3, 1.8, 8.1],
+    [8.3, 1.8, 8.1],
+    [0, 0.075, -8.35],
+    [0, 0.075, 8.35]
+  ];
+  const positions: number[] = [];
+  const scales: number[] = [];
+  const baseColors: number[] = [];
+  const materials: number[] = [];
+  const emissiveColors: number[] = [];
+
+  for (const [featureIndex, featurePosition] of featurePositions.entries()) {
+    const isFloorAccent = featureIndex >= 4;
+    const accentColor = LIGHT_COLORS[(featureIndex + 1) % LIGHT_COLORS.length]!;
+    positions.push(...featurePosition);
+    scales.push(...(isFloorAccent ? [7.6, 0.028, 0.16] : [0.28, 1.9, 0.28]));
+    baseColors.push(
+      0.55 + accentColor[0] * 0.3,
+      0.55 + accentColor[1] * 0.3,
+      0.6 + accentColor[2] * 0.25,
+      1
+    );
+    materials.push(isFloorAccent ? 0.06 : 0.09, 0.96);
+    emissiveColors.push(
+      accentColor[0] * (isFloorAccent ? 0.18 : 0.045),
+      accentColor[1] * (isFloorAccent ? 0.18 : 0.045),
+      accentColor[2] * (isFloorAccent ? 0.18 : 0.045)
+    );
+  }
+
+  return {
+    positions: new Float32Array(positions),
+    scales: new Float32Array(scales),
+    baseColors: new Float32Array(baseColors),
+    materials: new Float32Array(materials),
+    emissiveColors: new Float32Array(emissiveColors),
+    instanceCount: featurePositions.length
   };
 }
 
@@ -744,7 +836,7 @@ function makeLightMarkerData(): SurfaceInstanceData {
   for (let lightIndex = 0; lightIndex < MAX_EXAMPLE_POINT_LIGHTS; lightIndex++) {
     positions[lightIndex * 3 + 1] = -1000;
     const color = LIGHT_COLORS[lightIndex % LIGHT_COLORS.length]!;
-    scales.push(0.075, 0.075, 0.075);
+    scales.push(0.095, 0.095, 0.095);
     baseColors.push(color[0], color[1], color[2], 1);
     materials.push(0.18, 0);
     emissiveColors.push(color[0], color[1], color[2]);
@@ -833,6 +925,10 @@ function getDebugMode(debugView: DebugView): number {
       return 7;
     case 'Ambient Occlusion':
       return 8;
+    case 'Reflections':
+      return 9;
+    case 'Reflection Confidence':
+      return 10;
     default:
       return 0;
   }
@@ -861,7 +957,9 @@ function makeSettingsSchema(): SettingsSchema {
               'Emissive',
               'Depth',
               'Cluster Occupancy',
-              'Ambient Occlusion'
+              'Ambient Occlusion',
+              'Reflections',
+              'Reflection Confidence'
             ]
           },
           {
@@ -937,6 +1035,58 @@ function makeSettingsSchema(): SettingsSchema {
             min: 0,
             max: 1,
             step: 0.02
+          }
+        ]
+      },
+      {
+        id: 'reflections',
+        name: 'Screen-space Reflections',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'reflectionStrength',
+            label: 'SSR Strength',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2,
+            step: 0.05
+          },
+          {
+            name: 'reflectionIntensity',
+            label: 'SSR Intensity',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 3,
+            step: 0.05
+          },
+          {
+            name: 'reflectionMaxDistance',
+            label: 'SSR Distance',
+            type: 'number',
+            persist: 'none',
+            min: 4,
+            max: 80,
+            step: 1
+          },
+          {
+            name: 'reflectionSampleCount',
+            label: 'SSR Samples',
+            type: 'number',
+            persist: 'none',
+            min: 8,
+            max: 96,
+            step: 1
+          },
+          {
+            name: 'reflectionHistoryWeight',
+            label: 'SSR History',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 0.97,
+            step: 0.01
           }
         ]
       }

--- a/modules/effects/README.md
+++ b/modules/effects/README.md
@@ -14,4 +14,5 @@ Notable exports include:
 - `dof` and `dofShaderPassPipeline`
 - `createGTAOShaderPassPipeline` and `createSSRShaderPassPipeline`
 
-See [luma.gl](http://luma.gl) for documentation.
+See [Rendering Techniques and Tradeoffs](https://luma.gl/docs/api-guide/shaders/rendering-techniques)
+for comparisons between related effects, their GPU inputs, backend support, and composition order.

--- a/modules/effects/README.md
+++ b/modules/effects/README.md
@@ -2,14 +2,16 @@
 
 A set of ShaderPasses implementing post processing effects for luma.gl
 
-Advanced WebGPU-first scene-aware pipelines include SSAO, temporally stabilized GTAO, scene
-outlines, temporal AA, motion blur, screen-space reflections, volumetric fog, and reusable
-depth-aware blur. Applications keep ownership of scene rendering and provide matching color,
-depth, normal/roughness, and velocity textures to `ShaderPassRenderer`.
+Advanced WebGPU-first scene-aware pipelines include SSAO, temporally stabilized GTAO,
+roughness-aware screen-space reflections with temporal reprojection and bilateral denoising,
+scene outlines, temporal AA, motion blur, volumetric fog, and reusable depth-aware blur.
+Applications keep ownership of scene rendering and provide matching color, depth,
+normal/roughness, and velocity textures to `ShaderPassRenderer`.
 
 Notable exports include:
 
 - `bloom` and `bloomShaderPassPipeline`
 - `dof` and `dofShaderPassPipeline`
+- `createGTAOShaderPassPipeline` and `createSSRShaderPassPipeline`
 
 See [luma.gl](http://luma.gl) for documentation.

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -132,7 +132,15 @@ export {
 } from './passes/screen-space/gtao';
 export type {OutlineShaderPassPipelineOptions} from './passes/screen-space/outlines';
 export {createOutlineShaderPassPipeline} from './passes/screen-space/outlines';
-export {createSSRShaderPassPipeline} from './passes/screen-space/screen-space-reflections';
+export type {SSRShaderPassPipelineOptions} from './passes/screen-space/screen-space-reflections';
+export {
+  createSSRShaderPassPipeline,
+  ssrComposite,
+  ssrDepthHistoryCopy,
+  ssrSpatial,
+  ssrTemporal,
+  ssrTrace
+} from './passes/screen-space/screen-space-reflections';
 export type {SSAOShaderPassPipelineOptions} from './passes/screen-space/ssao';
 export {createSSAOShaderPassPipeline} from './passes/screen-space/ssao';
 export {createTAAShaderPassPipeline} from './passes/screen-space/temporal-antialiasing';

--- a/modules/effects/src/passes/screen-space/screen-space-reflections.ts
+++ b/modules/effects/src/passes/screen-space/screen-space-reflections.ts
@@ -24,6 +24,7 @@ type SSRTraceUniforms = {
 };
 
 type SSRTemporalUniforms = {
+  inverseProjectionMatrix: Readonly<NumberArray16>;
   historyWeight: number;
   depthThreshold: number;
 };
@@ -253,6 +254,7 @@ export const ssrTemporal = {
   name: 'ssrTemporal',
   source: /* wgsl */ `\
 struct SSRTemporalUniforms {
+  inverseProjectionMatrix: mat4x4f,
   historyWeight: f32,
   depthThreshold: f32,
 };
@@ -266,6 +268,12 @@ struct SSRTemporalUniforms {
 @group(0) @binding(auto) var depthTextureSampler: sampler;
 @group(0) @binding(auto) var previousDepthTexture: texture_2d<f32>;
 @group(0) @binding(auto) var previousDepthTextureSampler: sampler;
+
+fn ssrTemporal_reconstructViewDepth(texCoord: vec2f, depth: f32) -> f32 {
+  let clip = vec4f(texCoord.x * 2.0 - 1.0, 1.0 - texCoord.y * 2.0, depth, 1.0);
+  let viewPosition = ssrTemporal.inverseProjectionMatrix * clip;
+  return abs(viewPosition.z / max(abs(viewPosition.w), 0.00001));
+}
 
 fn ssrTemporal_sampleColor(
   sourceTexture: texture_2d<f32>,
@@ -290,7 +298,11 @@ fn ssrTemporal_sampleColor(
     clampedPreviousCoord,
     0
   ).r;
-  let validDepth = abs(previousDepth - currentDepth) < ssrTemporal.depthThreshold;
+  let currentViewDepth = ssrTemporal_reconstructViewDepth(texCoord, currentDepth);
+  let previousViewDepth = ssrTemporal_reconstructViewDepth(clampedPreviousCoord, previousDepth);
+  let relativeDepthDifference = abs(previousViewDepth - currentViewDepth) /
+    max(currentViewDepth, 0.0001);
+  let validDepth = relativeDepthDifference < ssrTemporal.depthThreshold;
 
   let texel = 1.0 / vec2f(textureDimensions(sourceTexture));
   var minimumReflection = current;
@@ -333,10 +345,12 @@ fn ssrTemporal_sampleColor(
   uniforms: {} as SSRTemporalUniforms,
   bindings: {} as SSRTemporalBindings,
   uniformTypes: {
+    inverseProjectionMatrix: 'mat4x4<f32>',
     historyWeight: 'f32',
     depthThreshold: 'f32'
   },
   propTypes: {
+    inverseProjectionMatrix: {value: IDENTITY_MATRIX, private: true},
     historyWeight: {value: 0.86, min: 0, max: 0.97},
     depthThreshold: {value: 0.018, min: 0.0001, softMax: 0.1}
   },

--- a/modules/effects/src/passes/screen-space/screen-space-reflections.ts
+++ b/modules/effects/src/passes/screen-space/screen-space-reflections.ts
@@ -134,17 +134,23 @@ fn ssrTrace_sampleColor(
   let reflectedRay = normalize(
     mirrorDirection + (tangent * cos(noiseAngle) + bitangent * sin(noiseAngle)) * roughnessCone
   );
+  let rayOrigin = viewPosition + normal * max(ssrTrace.thickness * 0.12, 0.025);
 
   var reflection = vec3f(0.0);
   var confidence = 0.0;
   var previousTravel = 0.06;
+  var previousDepthDelta = -ssrTrace.thickness;
+  let minimumSampleCount = ceil(
+    ssrTrace.maxDistance / max(ssrTrace.thickness * 0.72, 0.12)
+  );
+  let effectiveSampleCount = min(96.0, max(ssrTrace.sampleCount, minimumSampleCount));
   for (var sampleIndex: i32 = 1; sampleIndex <= 96; sampleIndex++) {
-    if (f32(sampleIndex) > ssrTrace.sampleCount) {
+    if (f32(sampleIndex) > effectiveSampleCount) {
       break;
     }
-    let fraction = (f32(sampleIndex) - noise * 0.42) / max(ssrTrace.sampleCount, 1.0);
+    let fraction = (f32(sampleIndex) - noise * 0.42) / max(effectiveSampleCount, 1.0);
     let travel = 0.08 + pow(max(fraction, 0.0), 1.3) * ssrTrace.maxDistance;
-    let rayPosition = viewPosition + reflectedRay * travel;
+    let rayPosition = rayOrigin + reflectedRay * travel;
     if (rayPosition.z >= -0.04) {
       break;
     }
@@ -155,18 +161,27 @@ fn ssrTrace_sampleColor(
     let sampleDepth = textureSampleLevel(depthTexture, depthTextureSampler, sampleCoord, 0);
     if (sampleDepth >= 0.99999) {
       previousTravel = travel;
+      previousDepthDelta = -ssrTrace.thickness;
       continue;
     }
     let scenePosition = ssrTrace_reconstructViewPosition(sampleCoord, sampleDepth);
     let depthDelta = (-rayPosition.z) - (-scenePosition.z);
-    let hitThickness = ssrTrace.thickness + travel * 0.018;
-    if (depthDelta >= 0.0 && depthDelta < hitThickness) {
+    let rayStepLength = max(travel - previousTravel, 0.001);
+    let hitThickness = max(ssrTrace.thickness, rayStepLength * 1.2) + travel * 0.008;
+    let candidateNormal = normalize(
+      textureSampleLevel(normalTexture, normalTextureSampler, sampleCoord, 0).rgb * 2.0 - 1.0
+    );
+    let entersCandidateSurface = dot(reflectedRay, candidateNormal) < -0.015;
+    let crossesCandidateSurface = previousDepthDelta <= 0.0 && depthDelta >= 0.0;
+    let screenTravelPixels = length((sampleCoord - sceneCoord) * texSize);
+    if (crossesCandidateSurface && depthDelta < hitThickness &&
+        entersCandidateSurface && screenTravelPixels > 1.25) {
       var nearTravel = previousTravel;
       var farTravel = travel;
       var hitCoord = sampleCoord;
       for (var refinementIndex: i32 = 0; refinementIndex < 5; refinementIndex++) {
         let refinedTravel = (nearTravel + farTravel) * 0.5;
-        let refinedPosition = viewPosition + reflectedRay * refinedTravel;
+        let refinedPosition = rayOrigin + reflectedRay * refinedTravel;
         let refinedCoord = ssrTrace_projectViewPosition(refinedPosition);
         let refinedDepth = textureSampleLevel(depthTexture, depthTextureSampler, refinedCoord, 0);
         let refinedScenePosition = ssrTrace_reconstructViewPosition(refinedCoord, refinedDepth);
@@ -194,6 +209,7 @@ fn ssrTrace_sampleColor(
       break;
     }
     previousTravel = travel;
+    previousDepthDelta = select(-ssrTrace.thickness, depthDelta, entersCandidateSurface);
   }
 
   return vec4f(reflection, clamp(confidence, 0.0, 1.0));
@@ -376,16 +392,27 @@ fn ssrSpatial_sampleColor(
   let centerReflection = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord, 0);
   let centerNormalRoughness = textureSampleLevel(normalTexture, normalTextureSampler, texCoord, 0);
   let roughness = clamp(centerNormalRoughness.a, 0.0, 1.0);
-  let radius = clamp(roughness * roughness * ssrSpatial.maxRadius, 0.0, 6.0);
-  if (radius < 0.55 || centerReflection.a <= 0.001) {
+  let centerDepth = textureSampleLevel(depthTexture, depthTextureSampler, texCoord, 0);
+  if (centerDepth >= 0.99999) {
+    return vec4f(0.0);
+  }
+  let hasCenterReflection = centerReflection.a > 0.001;
+  if (!hasCenterReflection && roughness >= 0.28) {
     return centerReflection;
   }
+  let minimumRadius = select(5.0, 0.95, hasCenterReflection);
+  let radius = clamp(
+    max(roughness * roughness * ssrSpatial.maxRadius, minimumRadius),
+    minimumRadius,
+    6.0
+  );
 
-  let centerDepth = textureSampleLevel(depthTexture, depthTextureSampler, texCoord, 0);
   let centerNormal = normalize(centerNormalRoughness.rgb * 2.0 - 1.0);
   let texel = ssrSpatial.direction / vec2f(textureDimensions(sourceTexture));
-  var reflection = centerReflection;
-  var totalWeight = 1.0;
+  let centerWeight = select(0.0, 1.0, hasCenterReflection);
+  var reflection = centerReflection * centerWeight;
+  var totalWeight = centerWeight;
+  var supportingSampleCount = 0u;
   for (var sampleIndex: i32 = 1; sampleIndex <= 6; sampleIndex++) {
     if (f32(sampleIndex) > ceil(radius)) {
       break;
@@ -409,12 +436,22 @@ fn ssrSpatial_sampleColor(
       let distanceWeight = exp(
         -f32(sampleIndex * sampleIndex) / max(2.0 * radius * radius, 0.1)
       );
-      let weight = depthWeight * normalWeight * distanceWeight;
-      reflection += textureSampleLevel(sourceTexture, sourceTextureSampler, sampleCoord, 0) * weight;
+      let sampleReflection = textureSampleLevel(sourceTexture, sourceTextureSampler, sampleCoord, 0);
+      let confidenceWeight = smoothstep(0.001, 0.12, sampleReflection.a);
+      let belongsToSamePlane = dot(centerNormal, sampleNormal) > 0.9995;
+      let surfaceWeight = select(0.0, 1.0, hasCenterReflection || belongsToSamePlane);
+      let weight = depthWeight * normalWeight * distanceWeight * confidenceWeight * surfaceWeight;
+      if (weight > 0.001) {
+        supportingSampleCount += 1u;
+      }
+      reflection += sampleReflection * weight;
       totalWeight += weight;
     }
   }
 
+  if ((!hasCenterReflection && supportingSampleCount < 2u) || totalWeight <= 0.0001) {
+    return centerReflection;
+  }
   return reflection / totalWeight;
 }`,
   bindingLayout: [

--- a/modules/effects/src/passes/screen-space/screen-space-reflections.ts
+++ b/modules/effects/src/passes/screen-space/screen-space-reflections.ts
@@ -2,140 +2,547 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import type {Texture} from '@luma.gl/core';
 import type {ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
+import type {NumberArray16} from '@math.gl/core';
 
-type SSRUniforms = {
-  projectionMatrix: number[];
-  inverseProjectionMatrix: number[];
+/** Construction options for temporally stabilized screen-space reflections. */
+export type SSRShaderPassPipelineOptions = {
+  /** Fractional ray-tracing, history, and denoising resolution. Defaults to half resolution. */
+  resolutionScale?: number;
+};
+
+type SSRTraceUniforms = {
+  projectionMatrix: Readonly<NumberArray16>;
+  inverseProjectionMatrix: Readonly<NumberArray16>;
   intensity: number;
   maxDistance: number;
   thickness: number;
   sampleCount: number;
+  maxRoughness: number;
+  frameIndex: number;
 };
 
-const IDENTITY_MATRIX = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+type SSRTemporalUniforms = {
+  historyWeight: number;
+  depthThreshold: number;
+};
 
+type SSRSpatialUniforms = {
+  direction: [number, number];
+  maxRadius: number;
+  depthSigma: number;
+};
+
+type SSRCompositeUniforms = {
+  strength: number;
+  debugMode: number;
+};
+
+type SSRTraceBindings = {
+  depthTexture?: Texture;
+  normalTexture?: Texture;
+};
+
+type SSRTemporalBindings = {
+  depthTexture?: Texture;
+  velocityTexture?: Texture;
+  historyTexture?: Texture;
+  previousDepthTexture?: Texture;
+};
+
+type SSRSpatialBindings = {
+  depthTexture?: Texture;
+  normalTexture?: Texture;
+};
+
+const IDENTITY_MATRIX: NumberArray16 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+/** Stochastically traces roughness-aware reflection rays through G-buffer depth. */
 export const ssrTrace = {
   name: 'ssrTrace',
   source: /* wgsl */ `\
-struct ssrTraceUniforms {
+const SSR_TWO_PI: f32 = 6.283185307179586;
+
+struct SSRTraceUniforms {
   projectionMatrix: mat4x4f,
   inverseProjectionMatrix: mat4x4f,
   intensity: f32,
   maxDistance: f32,
   thickness: f32,
   sampleCount: f32,
+  maxRoughness: f32,
+  frameIndex: f32,
 };
-@group(0) @binding(auto) var<uniform> ssrTrace: ssrTraceUniforms;
+
+@group(0) @binding(auto) var<uniform> ssrTrace: SSRTraceUniforms;
 @group(0) @binding(auto) var depthTexture: texture_depth_2d;
 @group(0) @binding(auto) var depthTextureSampler: sampler;
 @group(0) @binding(auto) var normalTexture: texture_2d<f32>;
 @group(0) @binding(auto) var normalTextureSampler: sampler;
 
-fn ssrReconstructViewPosition(uv: vec2f, depth: f32) -> vec3f {
+fn ssrTrace_reconstructViewPosition(uv: vec2f, depth: f32) -> vec3f {
   let clip = vec4f(uv.x * 2.0 - 1.0, 1.0 - uv.y * 2.0, depth, 1.0);
-  let view = ssrTrace.inverseProjectionMatrix * clip;
-  return view.xyz / max(view.w, 0.00001);
+  let viewPosition = ssrTrace.inverseProjectionMatrix * clip;
+  return viewPosition.xyz / max(viewPosition.w, 0.00001);
 }
 
-fn ssrProjectViewPosition(position: vec3f) -> vec2f {
+fn ssrTrace_projectViewPosition(position: vec3f) -> vec2f {
   let clip = ssrTrace.projectionMatrix * vec4f(position, 1.0);
-  let ndc = clip.xy / max(clip.w, 0.00001);
-  return vec2f(ndc.x * 0.5 + 0.5, 0.5 - ndc.y * 0.5);
+  let normalizedDeviceCoordinate = clip.xy / max(clip.w, 0.00001);
+  return vec2f(
+    normalizedDeviceCoordinate.x * 0.5 + 0.5,
+    0.5 - normalizedDeviceCoordinate.y * 0.5
+  );
+}
+
+fn ssrTrace_hash(value: vec2f) -> f32 {
+  return fract(sin(dot(value, vec2f(12.9898, 78.233))) * 43758.5453);
 }
 
 fn ssrTrace_sampleColor(
-  sourceTexture: texture_2d<f32>, sourceTextureSampler: sampler, texSize: vec2f, texCoord: vec2f
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
 ) -> vec4f {
   let sceneCoord = texCoord;
-  let normalRoughness = textureSampleLevel(normalTexture, normalTextureSampler, sceneCoord, 0.0);
+  let normalRoughness = textureSampleLevel(normalTexture, normalTextureSampler, sceneCoord, 0);
   let normal = normalize(normalRoughness.xyz * 2.0 - 1.0);
-  let roughness = normalRoughness.a;
+  let roughness = clamp(normalRoughness.a, 0.0, 1.0);
   let centerDepth = textureSampleLevel(depthTexture, depthTextureSampler, sceneCoord, 0);
-  if (centerDepth >= 0.99999 || roughness >= 0.92) { return vec4f(0.0); }
+  if (centerDepth >= 0.99999 || roughness >= ssrTrace.maxRoughness) {
+    return vec4f(0.0);
+  }
 
-  let viewPosition = ssrReconstructViewPosition(sceneCoord, centerDepth);
-  let incident = normalize(viewPosition);
-  let reflectedRay = normalize(reflect(incident, normal));
-  if (reflectedRay.z >= -0.001) { return vec4f(0.0); }
+  let viewPosition = ssrTrace_reconstructViewPosition(sceneCoord, centerDepth);
+  let incidentDirection = normalize(viewPosition);
+  let mirrorDirection = normalize(reflect(incidentDirection, normal));
+  let pixelCoordinate = floor(sceneCoord * vec2f(textureDimensions(depthTexture)));
+  let noise = ssrTrace_hash(
+    pixelCoordinate + vec2f(ssrTrace.frameIndex * 0.754877, ssrTrace.frameIndex * 0.56984)
+  );
+  let noiseAngle = noise * SSR_TWO_PI;
+  let referenceAxis = select(
+    vec3f(0.0, 1.0, 0.0),
+    vec3f(1.0, 0.0, 0.0),
+    abs(mirrorDirection.y) > 0.9
+  );
+  let tangent = normalize(cross(referenceAxis, mirrorDirection));
+  let bitangent = normalize(cross(mirrorDirection, tangent));
+  let roughnessCone = roughness * roughness * 0.32;
+  let reflectedRay = normalize(
+    mirrorDirection + (tangent * cos(noiseAngle) + bitangent * sin(noiseAngle)) * roughnessCone
+  );
 
   var reflection = vec3f(0.0);
   var confidence = 0.0;
-  var previousTravel = 0.12;
-  for (var index: i32 = 1; index <= 64; index++) {
-    if (f32(index) > ssrTrace.sampleCount) { break; }
-    let fraction = f32(index) / max(ssrTrace.sampleCount, 1.0);
-    let travel = 0.12 + pow(fraction, 1.35) * ssrTrace.maxDistance;
+  var previousTravel = 0.06;
+  for (var sampleIndex: i32 = 1; sampleIndex <= 96; sampleIndex++) {
+    if (f32(sampleIndex) > ssrTrace.sampleCount) {
+      break;
+    }
+    let fraction = (f32(sampleIndex) - noise * 0.42) / max(ssrTrace.sampleCount, 1.0);
+    let travel = 0.08 + pow(max(fraction, 0.0), 1.3) * ssrTrace.maxDistance;
     let rayPosition = viewPosition + reflectedRay * travel;
-    let sampleUv = ssrProjectViewPosition(rayPosition);
-    if (any(sampleUv <= vec2f(0.0)) || any(sampleUv >= vec2f(1.0))) { break; }
-    let sampleDepth = textureSampleLevel(depthTexture, depthTextureSampler, sampleUv, 0);
-    if (sampleDepth >= 0.99999) { previousTravel = travel; continue; }
-    let scenePosition = ssrReconstructViewPosition(sampleUv, sampleDepth);
+    if (rayPosition.z >= -0.04) {
+      break;
+    }
+    let sampleCoord = ssrTrace_projectViewPosition(rayPosition);
+    if (any(sampleCoord <= vec2f(0.0)) || any(sampleCoord >= vec2f(1.0))) {
+      break;
+    }
+    let sampleDepth = textureSampleLevel(depthTexture, depthTextureSampler, sampleCoord, 0);
+    if (sampleDepth >= 0.99999) {
+      previousTravel = travel;
+      continue;
+    }
+    let scenePosition = ssrTrace_reconstructViewPosition(sampleCoord, sampleDepth);
     let depthDelta = (-rayPosition.z) - (-scenePosition.z);
-    let hitThickness = ssrTrace.thickness + travel * 0.012;
+    let hitThickness = ssrTrace.thickness + travel * 0.018;
     if (depthDelta >= 0.0 && depthDelta < hitThickness) {
       var nearTravel = previousTravel;
       var farTravel = travel;
-      var hitUv = sampleUv;
-      for (var refinement: i32 = 0; refinement < 5; refinement++) {
+      var hitCoord = sampleCoord;
+      for (var refinementIndex: i32 = 0; refinementIndex < 5; refinementIndex++) {
         let refinedTravel = (nearTravel + farTravel) * 0.5;
         let refinedPosition = viewPosition + reflectedRay * refinedTravel;
-        let refinedUv = ssrProjectViewPosition(refinedPosition);
-        let refinedDepth = textureSampleLevel(depthTexture, depthTextureSampler, refinedUv, 0);
-        let refinedScene = ssrReconstructViewPosition(refinedUv, refinedDepth);
-        if ((-refinedPosition.z) - (-refinedScene.z) >= 0.0) {
+        let refinedCoord = ssrTrace_projectViewPosition(refinedPosition);
+        let refinedDepth = textureSampleLevel(depthTexture, depthTextureSampler, refinedCoord, 0);
+        let refinedScenePosition = ssrTrace_reconstructViewPosition(refinedCoord, refinedDepth);
+        if ((-refinedPosition.z) - (-refinedScenePosition.z) >= 0.0) {
           farTravel = refinedTravel;
-          hitUv = refinedUv;
+          hitCoord = refinedCoord;
         } else {
           nearTravel = refinedTravel;
         }
       }
-      reflection = textureSampleLevel(sourceTexture, sourceTextureSampler, hitUv, roughness * 3.0).rgb;
-      let edge = min(min(hitUv.x, hitUv.y), min(1.0 - hitUv.x, 1.0 - hitUv.y));
-      let fresnel = mix(0.35, 1.0, pow(1.0 - max(dot(-incident, normal), 0.0), 5.0));
-      let roughnessFade = pow(1.0 - roughness, 2.0);
+      reflection = textureSampleLevel(sourceTexture, sourceTextureSampler, hitCoord, 0).rgb;
+      let screenEdge = min(
+        min(hitCoord.x, hitCoord.y),
+        min(1.0 - hitCoord.x, 1.0 - hitCoord.y)
+      );
+      let fresnel = mix(
+        0.32,
+        1.0,
+        pow(1.0 - max(dot(-incidentDirection, normal), 0.0), 5.0)
+      );
+      let roughnessFade = pow(1.0 - roughness / max(ssrTrace.maxRoughness, 0.001), 1.5);
       let distanceFade = 1.0 - clamp(farTravel / ssrTrace.maxDistance, 0.0, 1.0);
-      confidence = smoothstep(0.0, 0.1, edge) * roughnessFade * fresnel * distanceFade * ssrTrace.intensity;
+      confidence = smoothstep(0.0, 0.09, screenEdge) * roughnessFade * fresnel *
+        distanceFade * ssrTrace.intensity;
       break;
     }
     previousTravel = travel;
   }
+
   return vec4f(reflection, clamp(confidence, 0.0, 1.0));
 }`,
   bindingLayout: [
     {name: 'depthTexture', group: 0},
     {name: 'normalTexture', group: 0}
   ],
-  uniforms: {} as SSRUniforms,
+  props: {} as Partial<SSRTraceUniforms> & SSRTraceBindings,
+  uniforms: {} as SSRTraceUniforms,
+  bindings: {} as SSRTraceBindings,
   uniformTypes: {
     projectionMatrix: 'mat4x4<f32>',
     inverseProjectionMatrix: 'mat4x4<f32>',
     intensity: 'f32',
     maxDistance: 'f32',
     thickness: 'f32',
-    sampleCount: 'f32'
+    sampleCount: 'f32',
+    maxRoughness: 'f32',
+    frameIndex: 'f32'
   },
   propTypes: {
     projectionMatrix: {value: IDENTITY_MATRIX, private: true},
     inverseProjectionMatrix: {value: IDENTITY_MATRIX, private: true},
-    intensity: {value: 1.25, min: 0, softMax: 3},
-    maxDistance: {value: 90, min: 1, softMax: 180},
-    thickness: {value: 0.65, min: 0.02, softMax: 3},
-    sampleCount: {value: 40, min: 8, max: 64}
+    intensity: {value: 1.35, min: 0, softMax: 4},
+    maxDistance: {value: 60, min: 1, softMax: 180},
+    thickness: {value: 0.45, min: 0.02, softMax: 3},
+    sampleCount: {value: 48, min: 8, max: 96},
+    maxRoughness: {value: 0.88, min: 0.1, max: 1},
+    frameIndex: {value: 0, private: true}
   },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  Partial<SSRTraceUniforms> & SSRTraceBindings,
+  SSRTraceUniforms,
+  SSRTraceBindings
+>;
+
+/** Reprojects previous-frame reflection radiance with velocity and rejects disocclusions. */
+export const ssrTemporal = {
+  name: 'ssrTemporal',
+  source: /* wgsl */ `\
+struct SSRTemporalUniforms {
+  historyWeight: f32,
+  depthThreshold: f32,
+};
+
+@group(0) @binding(auto) var<uniform> ssrTemporal: SSRTemporalUniforms;
+@group(0) @binding(auto) var historyTexture: texture_2d<f32>;
+@group(0) @binding(auto) var historyTextureSampler: sampler;
+@group(0) @binding(auto) var velocityTexture: texture_2d<f32>;
+@group(0) @binding(auto) var velocityTextureSampler: sampler;
+@group(0) @binding(auto) var depthTexture: texture_depth_2d;
+@group(0) @binding(auto) var depthTextureSampler: sampler;
+@group(0) @binding(auto) var previousDepthTexture: texture_2d<f32>;
+@group(0) @binding(auto) var previousDepthTextureSampler: sampler;
+
+fn ssrTemporal_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let current = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord, 0);
+  let currentDepth = textureSampleLevel(depthTexture, depthTextureSampler, texCoord, 0);
+  if (currentDepth >= 0.99999) {
+    return vec4f(0.0);
+  }
+
+  let velocity = textureSampleLevel(velocityTexture, velocityTextureSampler, texCoord, 0).xy;
+  let previousCoord = texCoord - velocity;
+  let validCoordinate = all(previousCoord >= vec2f(0.0)) &&
+    all(previousCoord <= vec2f(1.0));
+  let clampedPreviousCoord = clamp(previousCoord, vec2f(0.0), vec2f(1.0));
+  let previousDepth = textureSampleLevel(
+    previousDepthTexture,
+    previousDepthTextureSampler,
+    clampedPreviousCoord,
+    0
+  ).r;
+  let validDepth = abs(previousDepth - currentDepth) < ssrTemporal.depthThreshold;
+
+  let texel = 1.0 / vec2f(textureDimensions(sourceTexture));
+  var minimumReflection = current;
+  var maximumReflection = current;
+  for (var sampleY: i32 = -1; sampleY <= 1; sampleY++) {
+    for (var sampleX: i32 = -1; sampleX <= 1; sampleX++) {
+      let sampleCoord = clamp(
+        texCoord + vec2f(f32(sampleX), f32(sampleY)) * texel,
+        vec2f(0.0),
+        vec2f(1.0)
+      );
+      let neighborhoodReflection = textureSampleLevel(
+        sourceTexture,
+        sourceTextureSampler,
+        sampleCoord,
+        0
+      );
+      minimumReflection = min(minimumReflection, neighborhoodReflection);
+      maximumReflection = max(maximumReflection, neighborhoodReflection);
+    }
+  }
+
+  let historyReflection = clamp(
+    textureSampleLevel(historyTexture, historyTextureSampler, clampedPreviousCoord, 0),
+    minimumReflection,
+    maximumReflection
+  );
+  let validHistory = validCoordinate && validDepth && current.a > 0.001 &&
+    historyReflection.a > 0.001;
+  let historyWeight = select(0.0, ssrTemporal.historyWeight, validHistory);
+  return mix(current, historyReflection, historyWeight);
+}`,
+  bindingLayout: [
+    {name: 'historyTexture', group: 0},
+    {name: 'velocityTexture', group: 0},
+    {name: 'depthTexture', group: 0},
+    {name: 'previousDepthTexture', group: 0}
+  ],
+  props: {} as Partial<SSRTemporalUniforms> & SSRTemporalBindings,
+  uniforms: {} as SSRTemporalUniforms,
+  bindings: {} as SSRTemporalBindings,
+  uniformTypes: {
+    historyWeight: 'f32',
+    depthThreshold: 'f32'
+  },
+  propTypes: {
+    historyWeight: {value: 0.86, min: 0, max: 0.97},
+    depthThreshold: {value: 0.018, min: 0.0001, softMax: 0.1}
+  },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  Partial<SSRTemporalUniforms> & SSRTemporalBindings,
+  SSRTemporalUniforms,
+  SSRTemporalBindings
+>;
+
+/** Saves the current scene depth for next-frame reflection disocclusion rejection. */
+export const ssrDepthHistoryCopy = {
+  name: 'ssrDepthHistoryCopy',
+  source: /* wgsl */ `\
+@group(0) @binding(auto) var depthTexture: texture_depth_2d;
+@group(0) @binding(auto) var depthTextureSampler: sampler;
+
+fn ssrDepthHistoryCopy_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let depth = textureSampleLevel(depthTexture, depthTextureSampler, texCoord, 0);
+  return vec4f(depth, 0.0, 0.0, 1.0);
+}`,
+  bindingLayout: [{name: 'depthTexture', group: 0}],
   passes: [{sampler: true}]
 } as const satisfies ShaderPass;
 
+/** Applies roughness-adaptive, depth/normal-aware reflection denoising in one direction. */
+export const ssrSpatial = {
+  name: 'ssrSpatial',
+  source: /* wgsl */ `\
+struct SSRSpatialUniforms {
+  direction: vec2f,
+  maxRadius: f32,
+  depthSigma: f32,
+};
+
+@group(0) @binding(auto) var<uniform> ssrSpatial: SSRSpatialUniforms;
+@group(0) @binding(auto) var depthTexture: texture_depth_2d;
+@group(0) @binding(auto) var depthTextureSampler: sampler;
+@group(0) @binding(auto) var normalTexture: texture_2d<f32>;
+@group(0) @binding(auto) var normalTextureSampler: sampler;
+
+fn ssrSpatial_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let centerReflection = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord, 0);
+  let centerNormalRoughness = textureSampleLevel(normalTexture, normalTextureSampler, texCoord, 0);
+  let roughness = clamp(centerNormalRoughness.a, 0.0, 1.0);
+  let radius = clamp(roughness * roughness * ssrSpatial.maxRadius, 0.0, 6.0);
+  if (radius < 0.55 || centerReflection.a <= 0.001) {
+    return centerReflection;
+  }
+
+  let centerDepth = textureSampleLevel(depthTexture, depthTextureSampler, texCoord, 0);
+  let centerNormal = normalize(centerNormalRoughness.rgb * 2.0 - 1.0);
+  let texel = ssrSpatial.direction / vec2f(textureDimensions(sourceTexture));
+  var reflection = centerReflection;
+  var totalWeight = 1.0;
+  for (var sampleIndex: i32 = 1; sampleIndex <= 6; sampleIndex++) {
+    if (f32(sampleIndex) > ceil(radius)) {
+      break;
+    }
+    for (var side: i32 = -1; side <= 1; side += 2) {
+      let sampleCoord = clamp(
+        texCoord + texel * f32(sampleIndex * side),
+        vec2f(0.0),
+        vec2f(1.0)
+      );
+      let sampleDepth = textureSampleLevel(depthTexture, depthTextureSampler, sampleCoord, 0);
+      let sampleNormal = normalize(
+        textureSampleLevel(normalTexture, normalTextureSampler, sampleCoord, 0).rgb * 2.0 - 1.0
+      );
+      let depthDelta = abs(sampleDepth - centerDepth);
+      let depthWeight = exp(
+        -(depthDelta * depthDelta) /
+          max(2.0 * ssrSpatial.depthSigma * ssrSpatial.depthSigma, 0.000001)
+      );
+      let normalWeight = pow(max(dot(centerNormal, sampleNormal), 0.0), 16.0);
+      let distanceWeight = exp(
+        -f32(sampleIndex * sampleIndex) / max(2.0 * radius * radius, 0.1)
+      );
+      let weight = depthWeight * normalWeight * distanceWeight;
+      reflection += textureSampleLevel(sourceTexture, sourceTextureSampler, sampleCoord, 0) * weight;
+      totalWeight += weight;
+    }
+  }
+
+  return reflection / totalWeight;
+}`,
+  bindingLayout: [
+    {name: 'depthTexture', group: 0},
+    {name: 'normalTexture', group: 0}
+  ],
+  props: {} as Partial<SSRSpatialUniforms> & SSRSpatialBindings,
+  uniforms: {} as SSRSpatialUniforms,
+  bindings: {} as SSRSpatialBindings,
+  uniformTypes: {
+    direction: 'vec2<f32>',
+    maxRadius: 'f32',
+    depthSigma: 'f32'
+  },
+  propTypes: {
+    direction: {value: [1, 0]},
+    maxRadius: {value: 5, min: 0, max: 8},
+    depthSigma: {value: 0.012, min: 0.0001, softMax: 0.1}
+  },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  Partial<SSRSpatialUniforms> & SSRSpatialBindings,
+  SSRSpatialUniforms,
+  SSRSpatialBindings
+>;
+
+/** Composes stabilized reflection radiance or exposes reflection/confidence debug views. */
+export const ssrComposite = {
+  name: 'ssrComposite',
+  source: /* wgsl */ `\
+struct SSRCompositeUniforms {
+  strength: f32,
+  debugMode: f32,
+};
+
+@group(0) @binding(auto) var<uniform> ssrComposite: SSRCompositeUniforms;
+@group(0) @binding(auto) var reflectionTexture: texture_2d<f32>;
+@group(0) @binding(auto) var reflectionTextureSampler: sampler;
+
+fn ssrComposite_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let color = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord, 0);
+  let reflection = textureSampleLevel(reflectionTexture, reflectionTextureSampler, texCoord, 0);
+  if (ssrComposite.debugMode > 1.5) {
+    let confidence = clamp(reflection.a, 0.0, 1.0);
+    let lowConfidence = vec3f(0.045, 0.08, 0.22);
+    let highConfidence = vec3f(1.0, 0.7, 0.16);
+    return vec4f(mix(lowConfidence, highConfidence, confidence), 1.0);
+  }
+  if (ssrComposite.debugMode > 0.5) {
+    return vec4f(reflection.rgb * reflection.a, 1.0);
+  }
+  let reflectionWeight = clamp(reflection.a * ssrComposite.strength, 0.0, 1.0);
+  return vec4f(color.rgb + reflection.rgb * reflectionWeight, color.a);
+}`,
+  bindingLayout: [{name: 'reflectionTexture', group: 0}],
+  props: {} as Partial<SSRCompositeUniforms>,
+  uniforms: {} as SSRCompositeUniforms,
+  uniformTypes: {strength: 'f32', debugMode: 'f32'},
+  propTypes: {
+    strength: {value: 1, min: 0, softMax: 2},
+    debugMode: {value: 0, min: 0, max: 2, private: true}
+  },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<Partial<SSRCompositeUniforms>, SSRCompositeUniforms>;
+
+/** Creates a roughness-aware, temporally stabilized screen-space reflection pipeline. */
 export function createSSRShaderPassPipeline(
-  options: {resolutionScale?: number} = {}
-): ShaderPassPipeline<'ssrReflection'> {
+  options: SSRShaderPassPipelineOptions = {}
+): ShaderPassPipeline<
+  'ssrRaw' | 'ssrHistory' | 'ssrHistoryDepth' | 'ssrScratch' | 'ssrReflection'
+> {
   const scale = options.resolutionScale || 0.5;
   return {
     name: 'ssrShaderPassPipeline',
-    renderTargets: {ssrReflection: {scale: [scale, scale], format: 'rgba16float'}},
+    renderTargets: {
+      ssrRaw: {scale: [scale, scale], format: 'rgba16float'},
+      ssrHistory: {
+        scale: [scale, scale],
+        format: 'rgba16float',
+        lifetime: 'history',
+        initialize: {clearColor: [0, 0, 0, 0]}
+      },
+      ssrHistoryDepth: {
+        scale: [scale, scale],
+        format: 'rgba16float',
+        lifetime: 'history',
+        initialize: {clearColor: [1, 0, 0, 1]}
+      },
+      ssrScratch: {scale: [scale, scale], format: 'rgba16float'},
+      ssrReflection: {scale: [scale, scale], format: 'rgba16float'}
+    },
     steps: [
-      {shaderPass: ssrTrace, inputs: {sourceTexture: 'previous'}, output: 'ssrReflection'},
+      {
+        shaderPass: ssrTrace,
+        inputs: {sourceTexture: 'previous'},
+        output: 'ssrRaw'
+      },
+      {
+        shaderPass: ssrTemporal,
+        inputs: {
+          sourceTexture: 'ssrRaw',
+          historyTexture: 'ssrHistory',
+          previousDepthTexture: 'ssrHistoryDepth'
+        },
+        output: 'ssrHistory'
+      },
+      {
+        shaderPass: ssrDepthHistoryCopy,
+        inputs: {sourceTexture: 'previous'},
+        output: 'ssrHistoryDepth'
+      },
+      {
+        shaderPass: ssrSpatial,
+        inputs: {sourceTexture: 'ssrHistory'},
+        output: 'ssrScratch',
+        uniforms: {direction: [1, 0]}
+      },
+      {
+        shaderPass: ssrSpatial,
+        inputs: {sourceTexture: 'ssrScratch'},
+        output: 'ssrReflection',
+        uniforms: {direction: [0, 1]}
+      },
       {
         shaderPass: ssrComposite,
         inputs: {sourceTexture: 'previous', reflectionTexture: 'ssrReflection'},
@@ -144,26 +551,3 @@ export function createSSRShaderPassPipeline(
     ]
   };
 }
-
-export const ssrComposite = {
-  name: 'ssrComposite',
-  source: /* wgsl */ `\
-struct ssrCompositeUniforms {
-  debugMode: f32,
-};
-@group(0) @binding(auto) var<uniform> ssrComposite: ssrCompositeUniforms;
-@group(0) @binding(auto) var reflectionTexture: texture_2d<f32>;
-@group(0) @binding(auto) var reflectionTextureSampler: sampler;
-fn ssrComposite_sampleColor(
-  sourceTexture: texture_2d<f32>, sourceTextureSampler: sampler, texSize: vec2f, texCoord: vec2f
-) -> vec4f {
-  let color = textureSample(sourceTexture, sourceTextureSampler, texCoord);
-  let reflection = textureSample(reflectionTexture, reflectionTextureSampler, texCoord);
-  if (ssrComposite.debugMode > 0.5) { return vec4f(reflection.rgb, 1.0); }
-  return vec4f(mix(color.rgb, color.rgb + reflection.rgb, reflection.a), color.a);
-}`,
-  bindingLayout: [{name: 'reflectionTexture', group: 0}],
-  uniformTypes: {debugMode: 'f32'},
-  propTypes: {debugMode: {value: 0, min: 0, max: 1, private: true}},
-  passes: [{sampler: true}]
-} as const satisfies ShaderPass;

--- a/modules/effects/test/passes/advanced-effects.spec.ts
+++ b/modules/effects/test/passes/advanced-effects.spec.ts
@@ -18,7 +18,8 @@ import {
   createVolumetricFogShaderPassPipeline,
   depthAwareBlurShaderPassPipeline,
   dofShaderPassPipeline,
-  gtaoTemporal
+  gtaoTemporal,
+  ssrTemporal
 } from '../../src';
 
 test('advanced effects expose composable pipeline shapes', testCase => {
@@ -107,6 +108,11 @@ test('advanced effects expose composable pipeline shapes', testCase => {
     reflections.steps[1].inputs?.historyTexture,
     reflections.steps[1].output,
     'SSR intentionally reprojects one logical reflection history target'
+  );
+  testCase.equal(
+    ssrTemporal.uniformTypes.inverseProjectionMatrix,
+    'mat4x4<f32>',
+    'SSR temporal rejection reconstructs linear view-space depth'
   );
   testCase.end();
 });

--- a/modules/effects/test/passes/advanced-effects.spec.ts
+++ b/modules/effects/test/passes/advanced-effects.spec.ts
@@ -82,7 +82,32 @@ test('advanced effects expose composable pipeline shapes', testCase => {
 
   testCase.equal(depthAwareBlurShaderPassPipeline.steps.length, 2, 'depth blur is separable');
   testCase.equal(createMotionBlurShaderPassPipeline().steps.length, 1, 'motion blur is one stage');
-  testCase.equal(createSSRShaderPassPipeline().steps.length, 2, 'SSR traces then composites');
+  const reflections = createSSRShaderPassPipeline({resolutionScale: 0.5});
+  testCase.equal(
+    reflections.steps.length,
+    6,
+    'SSR traces, stabilizes, denoises twice, and composites'
+  );
+  testCase.deepEqual(
+    reflections.renderTargets?.ssrRaw.scale,
+    [0.5, 0.5],
+    'SSR honors the requested tracing resolution'
+  );
+  testCase.equal(
+    reflections.renderTargets?.ssrHistory.lifetime,
+    'history',
+    'SSR retains reflection radiance history'
+  );
+  testCase.equal(
+    reflections.renderTargets?.ssrHistoryDepth.lifetime,
+    'history',
+    'SSR retains depth history for disocclusion rejection'
+  );
+  testCase.equal(
+    reflections.steps[1].inputs?.historyTexture,
+    reflections.steps[1].output,
+    'SSR intentionally reprojects one logical reflection history target'
+  );
   testCase.end();
 });
 
@@ -135,6 +160,7 @@ test('advanced effects compose in order with existing effects', async testCase =
     brightnessContrast,
     createSSAOShaderPassPipeline({normalSource: 'normal-texture'}),
     createGTAOShaderPassPipeline(),
+    createSSRShaderPassPipeline(),
     bloomShaderPassPipeline,
     dofShaderPassPipeline,
     createTAAShaderPassPipeline(),
@@ -195,6 +221,13 @@ test('advanced effects compose in order with existing effects', async testCase =
     testCase.ok(hasBinding('gtaoEvaluate', 'depthTexture'), 'GTAO receives scene depth');
     testCase.ok(hasBinding('gtaoEvaluate', 'normalTexture'), 'GTAO receives scene normals');
     testCase.ok(hasBinding('gtaoTemporal', 'velocityTexture'), 'GTAO receives scene velocity');
+    testCase.ok(hasBinding('ssrTrace', 'depthTexture'), 'SSR tracing receives scene depth');
+    testCase.ok(hasBinding('ssrTrace', 'normalTexture'), 'SSR tracing receives scene normals');
+    testCase.ok(
+      hasBinding('ssrTemporal', 'velocityTexture'),
+      'SSR history receives scene velocity'
+    );
+    testCase.ok(hasBinding('ssrSpatial', 'normalTexture'), 'SSR denoising receives scene normals');
     testCase.notOk(
       hasBinding('bloomExtract', 'velocityTexture'),
       'bloom does not receive scene velocity'

--- a/website/content/examples/experimental/advanced-effects.mdx
+++ b/website/content/examples/experimental/advanced-effects.mdx
@@ -75,3 +75,7 @@ The advanced effects extend the existing catalog rather than duplicating it:
 The depth, normal, and velocity attachments continue to describe the original scene geometry.
 Place coordinate-warping effects after the scene-aware stack unless the application transforms all
 of those attachments in the same way.
+
+For side-by-side comparisons of the shared SSR pipeline, SSAO versus GTAO, shadow and
+transparency approaches, and other related effects, see
+[Rendering Techniques and Tradeoffs](/docs/api-guide/shaders/rendering-techniques).

--- a/website/content/examples/experimental/deferred-rendering.mdx
+++ b/website/content/examples/experimental/deferred-rendering.mdx
@@ -79,3 +79,7 @@ That fixed representation keeps the example focused on the deferred boundary: ge
 material capture, compute owns light assignment, the lighting pass owns direct light, and later
 effects such as GTAO and SSR consume the unchanged depth, normal, velocity, and scene-color
 contract without drawing the reflective geometry a second time.
+
+For a comparison with environment-map reflections, SSAO, baseline deferred lighting, and other
+composable effect alternatives, see
+[Rendering Techniques and Tradeoffs](/docs/api-guide/shaders/rendering-techniques).

--- a/website/content/examples/experimental/deferred-rendering.mdx
+++ b/website/content/examples/experimental/deferred-rendering.mdx
@@ -26,6 +26,8 @@ import {DeferredRenderingExample} from '@site/src/examples';
 
 ## What to inspect
 
+- Drag the canvas to orbit the scene and use the mouse wheel or trackpad to zoom. Disable
+  **Auto Orbit** to inspect individual materials, chrome accents, or reflected light paths.
 - Columns increase roughness from mirror-like highlights to broad matte lobes.
 - Rows increase metalness while changing the base material family, so dielectric diffuse response
   gives way to colored metallic reflections.

--- a/website/content/examples/experimental/deferred-rendering.mdx
+++ b/website/content/examples/experimental/deferred-rendering.mdx
@@ -16,8 +16,9 @@ import {DeferredRenderingExample} from '@site/src/examples';
   <div>
     A WebGPU-only material laboratory that writes five surface targets once, then reconstructs
     view position from depth and resolves a directional light plus hundreds of compute-clustered
-    storage-buffer point lights in one fullscreen pass. A temporally stabilized GTAO pass then
-    reuses the same depth, normals, and velocity for grounded contact shading.
+    storage-buffer point lights in one fullscreen pass. Temporally stabilized GTAO grounds the
+    contacts, then stochastic screen-space reflections bounce the animated scene across polished
+    floors, chrome accents, and glossy-to-mirror materials.
   </div>
 </ExampleHeader>
 
@@ -34,9 +35,13 @@ import {DeferredRenderingExample} from '@site/src/examples';
 - **Base Color**, **Normals**, **Roughness**, **Metallic**, **Emissive**, and **Depth** expose the
   actual G-buffer channels rather than a recreated diagnostic view. **Cluster Occupancy** shows
   the per-pixel cluster list pressure as a cold-to-hot heatmap. **Ambient Occlusion** exposes the
-  denoised, temporally reprojected GTAO visibility buffer.
+  denoised, temporally reprojected GTAO visibility buffer. **Reflections** isolates reflected HDR
+  radiance, while **Reflection Confidence** makes screen-edge and roughness falloff visible.
 - Raise **GTAO Radius** to make larger-scale creases visible, then use **GTAO Intensity** and
   **GTAO Strength** to separate visibility estimation from how strongly it affects lit color.
+- Adjust **SSR Strength**, **SSR Intensity**, **SSR Distance**, and **SSR Samples** to compare
+  mirror-sharp hits against rough glossy lobes. **SSR History** shows the temporal trade-off
+  between responsive animated highlights and stable low-noise reflections.
 
 ## Render stack
 
@@ -55,8 +60,11 @@ from depth, evaluates Cook-Torrance direct lighting, and writes HDR color back i
 ordered shader-pass chain. `createGTAOShaderPassPipeline()` then performs a half-resolution
 horizon search over the unchanged depth and view-normal attachments, reprojects the previous AO
 result through the velocity buffer, rejects disocclusions with depth history, and applies a
-depth-aware separable blur before compositing ambient visibility into lit color. A final display
-pass tone maps the result or selects a G-buffer/cluster/AO debug view.
+depth-aware separable blur before compositing ambient visibility into lit color.
+`createSSRShaderPassPipeline()` then launches roughness-jittered reflection rays into the lit
+scene, reprojects reflection history through G-buffer velocity, rejects depth disocclusions,
+applies a roughness-adaptive depth/normal-aware blur, and adds the result back into `previous`.
+A final display pass tone maps the result or selects a G-buffer/cluster/AO/reflection debug view.
 
 The point-light positions are transformed to view space on the CPU and packed with
 `makeDeferredPointLightBufferData()` into two `vec4f` records per light:
@@ -67,4 +75,5 @@ position.xyz, range, color.rgb, intensity
 
 That fixed representation keeps the example focused on the deferred boundary: geometry owns
 material capture, compute owns light assignment, the lighting pass owns direct light, and later
-effects such as GTAO can consume the unchanged depth, normal, velocity, and scene-color contract.
+effects such as GTAO and SSR consume the unchanged depth, normal, velocity, and scene-color
+contract without drawing the reflective geometry a second time.

--- a/website/src/components/docs/shader-level-docs-tabs.tsx
+++ b/website/src/components/docs/shader-level-docs-tabs.tsx
@@ -16,7 +16,8 @@ export type ShaderLevelDocsTabId =
   | 'shader-assembly'
   | 'writing-portable-shaders'
   | 'writing-customizable-shaders'
-  | 'shader-passes';
+  | 'shader-passes'
+  | 'rendering-techniques';
 
 const SHADER_LEVEL_DOCS_TABS: ShaderLevelDocsTab[] = [
   {id: 'overview', label: 'Overview', href: '/docs/api-guide/shaders'},
@@ -35,7 +36,12 @@ const SHADER_LEVEL_DOCS_TABS: ShaderLevelDocsTab[] = [
     label: 'Portable Shaders',
     href: '/docs/api-guide/shaders/writing-portable-shaders'
   },
-  {id: 'shader-passes', label: 'Shader Passes', href: '/docs/api-guide/shaders/shader-passes'}
+  {id: 'shader-passes', label: 'Shader Passes', href: '/docs/api-guide/shaders/shader-passes'},
+  {
+    id: 'rendering-techniques',
+    label: 'Rendering Techniques',
+    href: '/docs/api-guide/shaders/rendering-techniques'
+  }
 ];
 
 /**


### PR DESCRIPTION
## Goals

- Add reusable, composable screen-space reflections on top of deferred lighting and temporally stabilized GTAO.
- Make Deferred Rendering: Material Lab an interactive, visually compelling showcase for reflective materials and modern WebGPU rendering techniques.

## Changes

- Expands `createSSRShaderPassPipeline()` into six composable stages: stochastic roughness-aware ray tracing, velocity-based temporal reprojection, depth history, two depth/normal-aware denoising passes, and confidence-aware HDR composition.
- Exports reusable SSR shader passes and typed pipeline options for integration into arbitrary ordered effect stacks.
- Uses adaptive ray density, origin bias, surface-facing rejection, adaptive hit thickness, and plane-aware denoising to reduce reflection banding and self-intersection artifacts.
- Reconstructs linear view-space depth before accepting reflection history, preventing stale reflections from leaking across perspective-compressed surfaces.
- Upgrades the material laboratory with reflective flooring, chrome accents, glossy-to-mirror materials, animated clustered lights, reflection-radiance and confidence debug views, and live SSR quality controls.
- Integrates shared `OrbitControls`, mouse/trackpad zoom, and an independent Auto Orbit toggle so visitors can inspect materials and reflection paths.
- Adds a discoverable Rendering Techniques and Tradeoffs guide comparing environment-map versus screen-space reflections, SSAO versus GTAO, baseline versus clustered lighting, shadow approaches, transparency, bloom/blur variants, and FXAA versus TAA.
- Documents that Visualization City and Material Lab reuse the same SSR implementation, and supplies perspective-correct reflection-history uniforms in both examples.
- Updates rendering-stack documentation, website navigation/example guidance, release notes, and focused GPU integration/compilation coverage.

## Stack

- Base: `master`; GTAO (#2752) has already merged.
- This PR contains only the additional reflections, orbit-controls integration, technique comparisons, and reflection-specific quality improvements.

## Verification

- `yarn lint fix` — passed.
- `yarn build` — passed.
- `yarn test-headless modules/effects/test/passes/advanced-effects.spec.ts modules/effects/test/passes/postprocessing-wgsl.spec.ts modules/experimental/test/controls/orbit-controls.spec.ts modules/experimental/test/rendering/clustered-lighting.spec.ts` — passed (4 files, 7 tests).
- `yarn website:build` — passed.
- Live WebGPU visual verification — drag/zoom orbiting, AO/reflection/confidence debug views, and distance/sample stress controls.