### PR TITLE
Fix v9.4 alpha peer dependency ranges

### DIFF
--- a/examples/experimental/bloom/package.json
+++ b/examples/experimental/bloom/package.json
@@ -9,12 +9,12 @@
   },
   "dependencies": {
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
-    "@luma.gl/core": "9.3.2",
-    "@luma.gl/effects": "9.3.2",
-    "@luma.gl/engine": "9.3.2",
-    "@luma.gl/shadertools": "9.3.2",
-    "@luma.gl/webgl": "9.3.2",
-    "@luma.gl/webgpu": "9.3.2"
+    "@luma.gl/core": "9.4.0-alpha.1",
+    "@luma.gl/effects": "9.4.0-alpha.1",
+    "@luma.gl/engine": "9.4.0-alpha.1",
+    "@luma.gl/shadertools": "9.4.0-alpha.1",
+    "@luma.gl/webgl": "9.4.0-alpha.1",
+    "@luma.gl/webgpu": "9.4.0-alpha.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/examples/experimental/html-ui-prism/package.json
+++ b/examples/experimental/html-ui-prism/package.json
@@ -9,12 +9,12 @@
   },
   "dependencies": {
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
-    "@luma.gl/core": "9.3.2",
-    "@luma.gl/engine": "9.3.2",
+    "@luma.gl/core": "9.4.0-alpha.1",
+    "@luma.gl/engine": "9.4.0-alpha.1",
     "@luma.gl/experimental": "workspace:*",
-    "@luma.gl/shadertools": "9.3.2",
-    "@luma.gl/webgl": "9.3.2",
-    "@luma.gl/webgpu": "9.3.2",
+    "@luma.gl/shadertools": "9.4.0-alpha.1",
+    "@luma.gl/webgl": "9.4.0-alpha.1",
+    "@luma.gl/webgpu": "9.4.0-alpha.1",
     "@math.gl/core": "^4.1.0"
   },
   "devDependencies": {

--- a/examples/showcase/globe/package.json
+++ b/examples/showcase/globe/package.json
@@ -9,11 +9,11 @@
   },
   "dependencies": {
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
-    "@luma.gl/core": "9.3.2",
-    "@luma.gl/engine": "9.3.2",
-    "@luma.gl/shadertools": "9.3.2",
-    "@luma.gl/webgl": "9.3.2",
-    "@luma.gl/webgpu": "9.3.2",
+    "@luma.gl/core": "9.4.0-alpha.1",
+    "@luma.gl/engine": "9.4.0-alpha.1",
+    "@luma.gl/shadertools": "9.4.0-alpha.1",
+    "@luma.gl/webgl": "9.4.0-alpha.1",
+    "@luma.gl/webgpu": "9.4.0-alpha.1",
     "@math.gl/core": "^4.1.0"
   },
   "devDependencies": {

--- a/modules/effects/package.json
+++ b/modules/effects/package.json
@@ -46,7 +46,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/shadertools": "~9.3.0"
+    "@luma.gl/shadertools": "~9.4.0-alpha.1"
   },
   "dependencies": {
     "@math.gl/core": "^4.1.0",

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -40,8 +40,8 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "~9.3.0",
-    "@luma.gl/shadertools": "~9.3.0"
+    "@luma.gl/core": "~9.4.0-alpha.1",
+    "@luma.gl/shadertools": "~9.4.0-alpha.1"
   },
   "dependencies": {
     "@math.gl/core": "^4.1.0",

--- a/modules/experimental/package.json
+++ b/modules/experimental/package.json
@@ -41,9 +41,9 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "~9.3.0",
-    "@luma.gl/engine": "~9.3.0",
-    "@luma.gl/shadertools": "~9.3.0"
+    "@luma.gl/core": "~9.4.0-alpha.1",
+    "@luma.gl/engine": "~9.4.0-alpha.1",
+    "@luma.gl/shadertools": "~9.4.0-alpha.1"
   },
   "dependencies": {
     "@luma.gl/tables": "9.4.0-alpha.1",

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -40,9 +40,9 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "~9.3.0",
-    "@luma.gl/engine": "~9.3.0",
-    "@luma.gl/shadertools": "~9.3.0"
+    "@luma.gl/core": "~9.4.0-alpha.1",
+    "@luma.gl/engine": "~9.4.0-alpha.1",
+    "@luma.gl/shadertools": "~9.4.0-alpha.1"
   },
   "dependencies": {
     "@loaders.gl/core": "~4.4.2",

--- a/modules/gpgpu/package.json
+++ b/modules/gpgpu/package.json
@@ -53,10 +53,10 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "~9.3.0",
-    "@luma.gl/engine": "~9.3.0",
-    "@luma.gl/shadertools": "~9.3.0",
-    "@luma.gl/webgpu": "~9.3.0"
+    "@luma.gl/core": "~9.4.0-alpha.1",
+    "@luma.gl/engine": "~9.4.0-alpha.1",
+    "@luma.gl/shadertools": "~9.4.0-alpha.1",
+    "@luma.gl/webgpu": "~9.4.0-alpha.1"
   },
   "dependencies": {
     "@luma.gl/tables": "9.4.0-alpha.1",

--- a/modules/shadertools/package.json
+++ b/modules/shadertools/package.json
@@ -46,7 +46,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "~9.3.0"
+    "@luma.gl/core": "~9.4.0-alpha.1"
   },
   "dependencies": {
     "@math.gl/core": "^4.1.0",

--- a/modules/test-utils/package.json
+++ b/modules/test-utils/package.json
@@ -36,11 +36,11 @@
     "pre-build": "echo test utils has no bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "~9.3.0",
-    "@luma.gl/engine": "~9.3.0",
-    "@luma.gl/shadertools": "~9.3.0",
-    "@luma.gl/webgl": "~9.3.0",
-    "@luma.gl/webgpu": "~9.3.0"
+    "@luma.gl/core": "~9.4.0-alpha.1",
+    "@luma.gl/engine": "~9.4.0-alpha.1",
+    "@luma.gl/shadertools": "~9.4.0-alpha.1",
+    "@luma.gl/webgl": "~9.4.0-alpha.1",
+    "@luma.gl/webgpu": "~9.4.0-alpha.1"
   },
   "dependencies": {
     "@probe.gl/env": "^4.1.1",

--- a/modules/text/package.json
+++ b/modules/text/package.json
@@ -49,7 +49,7 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@luma.gl/engine": "~9.3.0"
+    "@luma.gl/engine": "~9.4.0-alpha.1"
   },
   "dependencies": {
     "@luma.gl/core": "9.4.0-alpha.1",

--- a/modules/webgl/package.json
+++ b/modules/webgl/package.json
@@ -55,7 +55,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "~9.3.0"
+    "@luma.gl/core": "~9.4.0-alpha.1"
   },
   "dependencies": {
     "@math.gl/types": "^4.1.0",

--- a/modules/webgpu/package.json
+++ b/modules/webgpu/package.json
@@ -37,7 +37,7 @@
     "prepublishOnly": "npm run build-minified-bundle && npm run build-dev-bundle"
   },
   "peerDependencies": {
-    "@luma.gl/core": "~9.3.0"
+    "@luma.gl/core": "~9.4.0-alpha.1"
   },
   "dependencies": {
     "@probe.gl/env": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4679,18 +4679,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@luma.gl/effects@npm:9.3.2":
-  version: 9.3.2
-  resolution: "@luma.gl/effects@npm:9.3.2"
-  dependencies:
-    "@math.gl/core": "npm:^4.1.0"
-    "@math.gl/types": "npm:^4.1.0"
-  peerDependencies:
-    "@luma.gl/shadertools": ~9.3.0
-  checksum: 10c0/e81c66a06324495ae9a5e099c70d9a11c6f380e8f0f84b1153831dde3861946e1848e94a5e8a3120a43cc8dd420393df17cffc94aee6d131563fd1405a8b6896
-  languageName: node
-  linkType: hard
-
 "@luma.gl/effects@npm:9.4.0-alpha.1, @luma.gl/effects@workspace:modules/effects":
   version: 0.0.0-use.local
   resolution: "@luma.gl/effects@workspace:modules/effects"
@@ -4698,7 +4686,7 @@ __metadata:
     "@math.gl/core": "npm:^4.1.0"
     "@math.gl/types": "npm:^4.1.0"
   peerDependencies:
-    "@luma.gl/shadertools": ~9.3.0
+    "@luma.gl/shadertools": ~9.4.0-alpha.1
   languageName: unknown
   linkType: soft
 
@@ -4711,8 +4699,8 @@ __metadata:
     "@probe.gl/log": "npm:^4.1.1"
     "@probe.gl/stats": "npm:^4.1.1"
   peerDependencies:
-    "@luma.gl/core": ~9.3.0
-    "@luma.gl/shadertools": ~9.3.0
+    "@luma.gl/core": ~9.4.0-alpha.1
+    "@luma.gl/shadertools": ~9.4.0-alpha.1
   languageName: unknown
   linkType: soft
 
@@ -4724,9 +4712,9 @@ __metadata:
     "@math.gl/core": "npm:^4.1.0"
     "@math.gl/types": "npm:^4.1.0"
   peerDependencies:
-    "@luma.gl/core": ~9.3.0
-    "@luma.gl/engine": ~9.3.0
-    "@luma.gl/shadertools": ~9.3.0
+    "@luma.gl/core": ~9.4.0-alpha.1
+    "@luma.gl/engine": ~9.4.0-alpha.1
+    "@luma.gl/shadertools": ~9.4.0-alpha.1
   languageName: unknown
   linkType: soft
 
@@ -4739,9 +4727,9 @@ __metadata:
     "@loaders.gl/textures": "npm:~4.4.2"
     "@math.gl/core": "npm:^4.1.0"
   peerDependencies:
-    "@luma.gl/core": ~9.3.0
-    "@luma.gl/engine": ~9.3.0
-    "@luma.gl/shadertools": ~9.3.0
+    "@luma.gl/core": ~9.4.0-alpha.1
+    "@luma.gl/engine": ~9.4.0-alpha.1
+    "@luma.gl/shadertools": ~9.4.0-alpha.1
   languageName: unknown
   linkType: soft
 
@@ -4755,10 +4743,10 @@ __metadata:
     "@probe.gl/log": "npm:^4.0.8"
     "@probe.gl/stats": "npm:^4.0.8"
   peerDependencies:
-    "@luma.gl/core": ~9.3.0
-    "@luma.gl/engine": ~9.3.0
-    "@luma.gl/shadertools": ~9.3.0
-    "@luma.gl/webgpu": ~9.3.0
+    "@luma.gl/core": ~9.4.0-alpha.1
+    "@luma.gl/engine": ~9.4.0-alpha.1
+    "@luma.gl/shadertools": ~9.4.0-alpha.1
+    "@luma.gl/webgpu": ~9.4.0-alpha.1
   languageName: unknown
   linkType: soft
 
@@ -4769,7 +4757,7 @@ __metadata:
     "@math.gl/core": "npm:^4.1.0"
     "@math.gl/types": "npm:^4.1.0"
   peerDependencies:
-    "@luma.gl/core": ~9.3.0
+    "@luma.gl/core": ~9.4.0-alpha.1
   languageName: unknown
   linkType: soft
 
@@ -4789,11 +4777,11 @@ __metadata:
     "@probe.gl/env": "npm:^4.1.1"
     "@probe.gl/stats": "npm:^4.1.1"
   peerDependencies:
-    "@luma.gl/core": ~9.3.0
-    "@luma.gl/engine": ~9.3.0
-    "@luma.gl/shadertools": ~9.3.0
-    "@luma.gl/webgl": ~9.3.0
-    "@luma.gl/webgpu": ~9.3.0
+    "@luma.gl/core": ~9.4.0-alpha.1
+    "@luma.gl/engine": ~9.4.0-alpha.1
+    "@luma.gl/shadertools": ~9.4.0-alpha.1
+    "@luma.gl/webgl": ~9.4.0-alpha.1
+    "@luma.gl/webgpu": ~9.4.0-alpha.1
   languageName: unknown
   linkType: soft
 
@@ -4807,7 +4795,7 @@ __metadata:
     "@math.gl/core": "npm:^4.1.0"
     "@math.gl/polygon": "npm:^4.1.0"
   peerDependencies:
-    "@luma.gl/engine": ~9.3.0
+    "@luma.gl/engine": ~9.4.0-alpha.1
   languageName: unknown
   linkType: soft
 
@@ -4818,22 +4806,9 @@ __metadata:
     "@math.gl/types": "npm:^4.1.0"
     "@probe.gl/env": "npm:^4.1.1"
   peerDependencies:
-    "@luma.gl/core": ~9.3.0
+    "@luma.gl/core": ~9.4.0-alpha.1
   languageName: unknown
   linkType: soft
-
-"@luma.gl/webgpu@npm:9.3.2":
-  version: 9.3.2
-  resolution: "@luma.gl/webgpu@npm:9.3.2"
-  dependencies:
-    "@probe.gl/env": "npm:^4.1.1"
-    "@webgpu/types": "npm:^0.1.69"
-    wgsl_reflect: "npm:^1.2.3"
-  peerDependencies:
-    "@luma.gl/core": ~9.3.0
-  checksum: 10c0/b1784afd4675be0c921cc9db229bd4f37c2e37f6517733711d29df02d57502b037adfd6558a75b1526ef2e3b1d78669f8255f5379f9d953f59e603a72b056919
-  languageName: node
-  linkType: hard
 
 "@luma.gl/webgpu@npm:9.4.0-alpha.1, @luma.gl/webgpu@workspace:modules/webgpu":
   version: 0.0.0-use.local
@@ -4843,7 +4818,7 @@ __metadata:
     "@webgpu/types": "npm:^0.1.69"
     wgsl_reflect: "npm:^1.2.3"
   peerDependencies:
-    "@luma.gl/core": ~9.3.0
+    "@luma.gl/core": ~9.4.0-alpha.1
   languageName: unknown
   linkType: soft
 
@@ -16184,12 +16159,12 @@ __metadata:
   resolution: "luma.gl-examples-experimental-bloom@workspace:examples/experimental/bloom"
   dependencies:
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
-    "@luma.gl/core": "npm:9.3.2"
-    "@luma.gl/effects": "npm:9.3.2"
-    "@luma.gl/engine": "npm:9.3.2"
-    "@luma.gl/shadertools": "npm:9.3.2"
-    "@luma.gl/webgl": "npm:9.3.2"
-    "@luma.gl/webgpu": "npm:9.3.2"
+    "@luma.gl/core": "npm:9.4.0-alpha.1"
+    "@luma.gl/effects": "npm:9.4.0-alpha.1"
+    "@luma.gl/engine": "npm:9.4.0-alpha.1"
+    "@luma.gl/shadertools": "npm:9.4.0-alpha.1"
+    "@luma.gl/webgl": "npm:9.4.0-alpha.1"
+    "@luma.gl/webgpu": "npm:9.4.0-alpha.1"
     typescript: "npm:^5.9.3"
     vite: "npm:^8.0.0"
   languageName: unknown
@@ -16303,12 +16278,12 @@ __metadata:
   resolution: "luma.gl-examples-experimental-html-ui-prism@workspace:examples/experimental/html-ui-prism"
   dependencies:
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
-    "@luma.gl/core": "npm:9.3.2"
-    "@luma.gl/engine": "npm:9.3.2"
+    "@luma.gl/core": "npm:9.4.0-alpha.1"
+    "@luma.gl/engine": "npm:9.4.0-alpha.1"
     "@luma.gl/experimental": "workspace:*"
-    "@luma.gl/shadertools": "npm:9.3.2"
-    "@luma.gl/webgl": "npm:9.3.2"
-    "@luma.gl/webgpu": "npm:9.3.2"
+    "@luma.gl/shadertools": "npm:9.4.0-alpha.1"
+    "@luma.gl/webgl": "npm:9.4.0-alpha.1"
+    "@luma.gl/webgpu": "npm:9.4.0-alpha.1"
     "@math.gl/core": "npm:^4.1.0"
     typescript: "npm:^5.9.3"
     vite: "npm:^8.0.0"
@@ -16635,11 +16610,11 @@ __metadata:
   resolution: "luma.gl-examples-showcase-globe@workspace:examples/showcase/globe"
   dependencies:
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
-    "@luma.gl/core": "npm:9.3.2"
-    "@luma.gl/engine": "npm:9.3.2"
-    "@luma.gl/shadertools": "npm:9.3.2"
-    "@luma.gl/webgl": "npm:9.3.2"
-    "@luma.gl/webgpu": "npm:9.3.2"
+    "@luma.gl/core": "npm:9.4.0-alpha.1"
+    "@luma.gl/engine": "npm:9.4.0-alpha.1"
+    "@luma.gl/shadertools": "npm:9.4.0-alpha.1"
+    "@luma.gl/webgl": "npm:9.4.0-alpha.1"
+    "@luma.gl/webgpu": "npm:9.4.0-alpha.1"
     "@math.gl/core": "npm:^4.1.0"
     typescript: "npm:^5.9.3"
     vite: "npm:^8.0.0"


### PR DESCRIPTION
## Goals

- Correct the v9.4 prerelease package metadata so internal luma peers accept the v9.4 alpha packages.
- Remove the resulting luma peer-range warnings from Yarn installs.
- Keep examples consistently pinned to the v9.4 prerelease.

## Changes

- Updated internal luma peer ranges from `~9.3.0` to `~9.4.0-alpha.1`.
- Updated the remaining bloom, HTML UI prism, and globe examples from v9.3.2 dependencies to v9.4.0-alpha.1.
- Regenerated the Yarn lockfile, removing the obsolete published v9.3.2 effects and WebGPU resolutions.

## Verification

- `nvm use`: could not run because `nvm` is not installed in this shell; used `fnm` to select the repository's Node v22.22.1 instead.
- `yarn install --immutable`: passed; no `YN0060` warnings remain for luma packages. Unrelated pre-existing peer warnings remain.
- `yarn lint fix`: passed with no fixes required.
- `yarn build`: passed.
- `yarn test`: node suite passed (178 passed, 2 skipped). The headless suite reproduced the three failures already documented in the v9.4 alpha release audit:
  - storage-backed Arrow polygon model is not drawable because `polygonViewportUniforms` is absent from the shader layout;
  - A5 GPU boundary longitude is `NaN`;
  - A5 WGSL boundary longitude is `NaN`.
- `yarn website:build`: passed.
- `(cd website && yarn build)`: passed.
- `git diff --check`: passed.

## Release note

After merge, run the normal prerelease versioning and publishing flow to create v9.4.0-alpha.2. This PR does not publish or tag the release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and lockfile changes; no application or library source changes in the diff.
> 
> **Overview**
> Aligns **v9.4.0-alpha.1** package metadata so internal `@luma.gl/*` **peerDependencies** use `~9.4.0-alpha.1` instead of `~9.3.0` across effects, engine, experimental, gltf, gpgpu, shadertools, test-utils, text, webgl, and webgpu.
> 
> Updates the **bloom**, **html-ui-prism**, and **globe** examples from pinned **9.3.2** `@luma.gl/*` dependencies to **9.4.0-alpha.1**. **yarn.lock** is refreshed so workspace entries match the new peer ranges and obsolete **9.3.2** published resolutions for effects and webgpu are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d3552d29c6c057365e50c0a997cef46cb554c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->