### PR TITLE
feat(effects): integrate analytic GTAO ambient composition

### DIFF
--- a/docs/api-guide/shaders/rendering-techniques.md
+++ b/docs/api-guide/shaders/rendering-techniques.md
@@ -100,16 +100,23 @@ geometry or computes full global illumination.
 | | SSAO | GTAO |
 | --- | --- | --- |
 | Public entry point | `createSSAOShaderPassPipeline()` | `createGTAOShaderPassPipeline()` |
-| Main estimator | A compact depth-neighborhood sample kernel. | A multi-direction horizon search in reconstructed view space. |
+| Main estimator | A compact depth-neighborhood sample kernel. | Analytic cosine-weighted integration between signed view-space horizon angles. |
 | Pipeline stages | Evaluate, horizontal blur, vertical blur, composite. | Evaluate, temporal reprojection, depth-history capture, two blur passes, composite. |
-| Required inputs | Depth, with optional supplied view normals. | Depth, view normals, velocity, and camera projection/inverse projection. |
+| Required inputs | Depth, with optional supplied view normals. | Depth, view normals, velocity, projection matrices, and an optional isolated ambient-light texture. |
 | History targets | None. | Persistent AO and previous-depth targets. |
-| Main strength | Smaller setup cost and an inexpensive contact-darkening option. | Better grounding, larger-scale creases, and steadier animated results. |
+| Main strength | Smaller setup cost and an inexpensive contact-darkening option. | Integrated horizon visibility, frame-varying sampling, stable history, and optional ambient-only composition. |
 | Typical tradeoff | More visible noise or less faithful horizon detail. | More samples, texture memory, and temporal-history management. |
 
 Use one AO estimator per stack. GTAO is usually the higher-quality replacement for SSAO, not a
 second layer to multiply on top of it. Reset history after camera cuts, resize events, or changes
 that invalidate scene velocity.
+
+`createGTAOShaderPassPipeline()` retains its backward-compatible full-color composite. Select
+`createGTAOShaderPassPipeline({composition: 'ambient-only'})` when the application can bind an
+`ambientLightingTexture` containing the isolated linear ambient contribution. The ambient-only
+path preserves direct lighting and emissive color instead of darkening the entire resolved image.
+Deferred applications can create that texture with
+`createDeferredAmbientLightingShaderPassPipeline()` from `@luma.gl/experimental`.
 
 ## Indirect Lighting: Ambient Occlusion, SSGI, and SSR
 

--- a/docs/api-guide/shaders/shader-passes.md
+++ b/docs/api-guide/shaders/shader-passes.md
@@ -136,6 +136,44 @@ const renderer = new ShaderPassRenderer(device, {
 More specialized clustered-lighting or visibility-buffer workflows can replace the first resolve
 while preserving the same effect-facing depth, normal, velocity, and scene-color contract.
 
+GTAO defaults to its backward-compatible full-color composite. Deferred applications that can
+isolate ambient light should request the physically accurate ambient-only mode instead:
+
+```ts
+import {createGTAOShaderPassPipeline} from '@luma.gl/effects';
+import {createDeferredAmbientLightingShaderPassPipeline} from '@luma.gl/experimental';
+
+const ambientRenderer = new ShaderPassRenderer(device, {
+  shaderPasses: [createDeferredAmbientLightingShaderPassPipeline()]
+});
+const ambientLightingTexture = ambientRenderer.renderToTexture({
+  sourceTexture: gBuffer.colorTexture,
+  bindings: {
+    depthTexture: gBuffer.depthTexture,
+    baseColorMetallicTexture: gBuffer.getExtraColorTexture('baseColorMetallic'),
+    emissiveOcclusionTexture: gBuffer.getExtraColorTexture('emissiveOcclusion')
+  },
+  uniforms: {deferredAmbientLighting: {ambientColor: [0.04, 0.04, 0.05]}}
+});
+
+const effects = new ShaderPassRenderer(device, {
+  shaderPasses: [
+    createDeferredLightingShaderPassPipeline(),
+    createGTAOShaderPassPipeline({composition: 'ambient-only'})
+  ]
+});
+
+effects.renderToScreen({
+  sourceTexture: gBuffer.colorTexture,
+  bindings: {...gBuffer.getShaderPassBindings(), ambientLightingTexture}
+});
+```
+
+Ambient-only composition subtracts `ambientLightingTexture * (1 - visibility)` from the lit
+scene. Direct light, material emission, and alpha therefore remain unchanged. The separate
+ambient texture is an explicit application-owned integration boundary; the effect does not
+depend on hidden cross-pipeline render targets.
+
 For side-by-side choices between reflections, ambient occlusion, light assignment, shadows,
 transparency, blur, and temporal effects, see
 [Rendering Techniques and Tradeoffs](/docs/api-guide/shaders/rendering-techniques).

--- a/examples/experimental/deferred-rendering/app.ts
+++ b/examples/experimental/deferred-rendering/app.ts
@@ -19,6 +19,7 @@ import {
 } from '@luma.gl/effects';
 import {
   ClusteredLightGrid,
+  createDeferredAmbientLightingShaderPassPipeline,
   createClusteredDeferredLightingShaderPassPipeline,
   GBuffer,
   makeDeferredPointLightBufferData,
@@ -120,7 +121,7 @@ const DEFAULT_SETTINGS: DeferredRenderingSettings = {
 const DEFERRED_RENDERING_BACKGROUND_HTML = `
 <p><b>Why deferred rendering scales:</b> forward shading repeats material work for every light that touches every draw. Here the geometry pass writes base color, metalness, roughness, emissive, normal, velocity, and depth once; the fullscreen resolve reuses those screen-space values for lighting.</p>
 <p><b>Why clustering wins:</b> a WebGPU compute stage projects each view-space light sphere into a <code>16 × 9 × 24</code> screen/log-depth grid. Each pixel reconstructs its view position from depth, finds one cluster, and normally evaluates only that short local list instead of all 512 lights.</p>
-<p><b>Why GTAO belongs after lighting:</b> a half-resolution horizon search reuses the same depth and view normals to estimate ambient visibility around contacts. G-buffer velocity reprojects the previous AO result, depth rejects disocclusions, and a depth-aware blur removes remaining half-resolution noise before the AO is composed into lit color.</p>
+<p><b>Why GTAO belongs after lighting:</b> a half-resolution analytic horizon integral reuses the same depth and view normals to estimate ambient visibility around contacts. G-buffer velocity reprojects the previous AO result, depth rejects disocclusions, and a depth-aware blur removes remaining half-resolution noise before the AO affects only the isolated ambient contribution, preserving direct light and emissive surfaces.</p>
 <p><b>Where colored bounce comes from:</b> cosine-weighted hemisphere rays gather already-lit radiance from nearby visible surfaces. Cyan, magenta, and amber emitter panels transfer their color onto neighboring walls, floors, and matte materials; velocity, linear-depth rejection, and bilateral filtering stabilize the diffuse bounce.</p>
 <p><b>Where the reflections come from:</b> stochastic screen-space rays bounce from the same view normals into already-lit scene color. Rough surfaces widen the reflection cone; velocity and depth history stabilize animated highlights, while depth/normal-aware denoising preserves sharp mirrors and produces soft glossy lobes.</p>
 <p><b>Why HDR changes the image:</b> floating-point G-buffer and lighting passes retain radiance above SDR white. On compatible displays, a Display P3, <code>rgba16float</code>, extended-tone-mapping canvas preserves those concentrated specular highlights and emissive panels instead of clipping them.</p>
@@ -521,6 +522,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly settingsPanel: ExampleSettingsPanelManager;
   orbitControls: OrbitControls | null = null;
   sceneGBuffer: GBuffer;
+  ambientLightingRenderer: ShaderPassRenderer;
   renderer: ShaderPassRenderer;
   settings: DeferredRenderingSettings = {...DEFAULT_SETTINGS};
   framebufferSize: [number, number];
@@ -565,6 +567,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       maxLightCount: MAX_CLUSTERED_POINT_LIGHTS
     });
     this.sceneGBuffer = createSceneGBuffer(device, width, height);
+    this.ambientLightingRenderer = createAmbientLightingRenderer(device);
+    this.ambientLightingRenderer.resize([width, height]);
     this.renderer = createRenderer(device);
     this.renderer.resize([width, height]);
     this.framebufferSize = [width, height];
@@ -604,6 +608,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     if (this.framebufferSize[0] !== width || this.framebufferSize[1] !== height) {
       this.framebufferSize = [width, height];
       this.sceneGBuffer.resize({width, height});
+      this.ambientLightingRenderer.resize([width, height]);
       this.renderer.resize([width, height]);
       this.frameIndex = 0;
     }
@@ -680,6 +685,21 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const normalTexture = this.sceneGBuffer.normalRoughnessTexture;
     const baseColorMetallicTexture = this.sceneGBuffer.getExtraColorTexture('baseColorMetallic');
     const emissiveOcclusionTexture = this.sceneGBuffer.getExtraColorTexture('emissiveOcclusion');
+    const ambientColor: NumberArray3 = [0.028, 0.034, 0.055];
+    const ambientLightingTexture = this.ambientLightingRenderer.renderToTexture({
+      sourceTexture: this.sceneGBuffer.colorTexture,
+      bindings: {
+        depthTexture: this.sceneGBuffer.depthTexture,
+        baseColorMetallicTexture,
+        emissiveOcclusionTexture
+      },
+      uniforms: {
+        deferredAmbientLighting: {ambientColor}
+      }
+    });
+    if (!ambientLightingTexture) {
+      return;
+    }
     const directionalLightDirectionView = normalize3(
       viewMatrix.transformAsVector([0.42, 0.82, 0.38]) as NumberArray3
     );
@@ -692,13 +712,14 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         velocityTexture: this.sceneGBuffer.velocityTexture,
         baseColorMetallicTexture,
         emissiveOcclusionTexture,
+        ambientLightingTexture,
         pointLights: this.pointLightBuffer,
         ...this.clusteredLightGrid.getShaderPassBindings()
       },
       uniforms: {
         clusteredDeferredLighting: {
           inverseProjectionMatrix,
-          ambientColor: [0.028, 0.034, 0.055],
+          ambientColor,
           directionalLightDirectionView,
           directionalLightColor: [1, 0.86, 0.68],
           directionalLightIntensity: this.settings.sunIntensity,
@@ -712,7 +733,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           frameIndex: this.frameIndex
         },
         gtaoTemporal: {inverseProjectionMatrix},
-        gtaoComposite: {
+        gtaoAmbientComposite: {
           strength: this.settings.ambientOcclusionStrength,
           debugMode: this.settings.debugView === 'Ambient Occlusion' ? 1 : 0
         },
@@ -799,6 +820,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.lightMarkers.destroy();
     this.pointLightBuffer.destroy();
     this.clusteredLightGrid.destroy();
+    this.ambientLightingRenderer.destroy();
     this.renderer.destroy();
     this.sceneGBuffer.destroy();
   }
@@ -863,11 +885,19 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   }
 }
 
+function createAmbientLightingRenderer(device: Device): ShaderPassRenderer {
+  return new ShaderPassRenderer(device, {
+    shaderPasses: [createDeferredAmbientLightingShaderPassPipeline()],
+    colorFormat: 'rgba16float',
+    flipY: true
+  });
+}
+
 function createRenderer(device: Device): ShaderPassRenderer {
   return new ShaderPassRenderer(device, {
     shaderPasses: [
       createClusteredDeferredLightingShaderPassPipeline(),
-      createGTAOShaderPassPipeline(),
+      createGTAOShaderPassPipeline({composition: 'ambient-only'}),
       createSSGIShaderPassPipeline(),
       createSSRShaderPassPipeline({resolutionScale: 0.75}),
       deferredDisplayPipeline

--- a/modules/effects/README.md
+++ b/modules/effects/README.md
@@ -8,6 +8,8 @@ reflections with temporal reprojection and bilateral denoising, scene outlines, 
 motion blur, volumetric fog, and reusable depth-aware blur.
 Applications keep ownership of scene rendering and provide matching color, depth,
 normal/roughness, and velocity textures to `ShaderPassRenderer`.
+GTAO additionally supports `composition: 'ambient-only'` with an explicit
+`ambientLightingTexture`, preserving direct lighting and emissive scene contributions.
 
 Notable exports include:
 

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -130,6 +130,7 @@ export {createMotionBlurShaderPassPipeline} from './passes/screen-space/motion-b
 export type {GTAOShaderPassPipelineOptions} from './passes/screen-space/gtao';
 export {
   createGTAOShaderPassPipeline,
+  gtaoAmbientComposite,
   gtaoComposite,
   gtaoDepthHistoryCopy,
   gtaoEvaluate,

--- a/modules/effects/src/passes/screen-space/gtao.ts
+++ b/modules/effects/src/passes/screen-space/gtao.ts
@@ -11,6 +11,8 @@ import {depthAwareBlur} from './depth-aware-blur';
 export type GTAOShaderPassPipelineOptions = {
   /** Fractional AO evaluation resolution. Defaults to half resolution. */
   resolutionScale?: number;
+  /** Apply visibility to the full image or only to a separately supplied ambient-light texture. */
+  composition?: 'color' | 'ambient-only';
 };
 
 type GTAOEvaluateUniforms = {
@@ -31,6 +33,10 @@ type GTAOTemporalUniforms = {
 type GTAOCompositeUniforms = {
   strength: number;
   debugMode: number;
+};
+
+type GTAOAmbientCompositeBindings = {
+  ambientLightingTexture?: Texture;
 };
 
 type GTAOBindings = {
@@ -80,19 +86,26 @@ fn gtaoEvaluate_hash(value: vec2f) -> f32 {
 
 fn gtaoEvaluate_sampleHorizon(
   centerPosition: vec3f,
-  normal: vec3f,
+  viewDirection: vec3f,
+  sliceDirection: vec3f,
   sceneCoord: vec2f,
   direction: vec2f,
   side: f32,
   radiusPixels: f32,
-  depthDimensions: vec2f
+  depthDimensions: vec2f,
+  radialJitter: f32
 ) -> f32 {
-  var horizon = 0.0;
+  let hemisphereEdge = side * GTAO_PI * 0.5;
+  var horizon = hemisphereEdge;
   for (var stepIndex: i32 = 1; stepIndex <= GTAO_STEPS_PER_SIDE; stepIndex++) {
     let fraction = f32(stepIndex) / f32(GTAO_STEPS_PER_SIDE);
-    let jitteredFraction = (f32(stepIndex) - 0.35) / f32(GTAO_STEPS_PER_SIDE);
+    let jitteredFraction =
+      (f32(stepIndex) - 1.0 + radialJitter) / f32(GTAO_STEPS_PER_SIDE);
     let sampleOffset = direction * side * radiusPixels * jitteredFraction / depthDimensions;
-    let sampleCoord = clamp(sceneCoord + sampleOffset, vec2f(0.0), vec2f(1.0));
+    let sampleCoord = sceneCoord + sampleOffset;
+    if (any(sampleCoord < vec2f(0.0)) || any(sampleCoord > vec2f(1.0))) {
+      continue;
+    }
     let sampleDepth = textureSampleLevel(depthTexture, depthTextureSampler, sampleCoord, 0);
     if (sampleDepth >= 0.99999) {
       continue;
@@ -103,12 +116,46 @@ fn gtaoEvaluate_sampleHorizon(
     if (distanceToSample <= 0.0001 || distanceToSample >= gtaoEvaluate.radius) {
       continue;
     }
-    let hemisphere = max(dot(normal, delta / distanceToSample) - gtaoEvaluate.bias, 0.0);
+    let sampleDirection = delta / distanceToSample;
+    let sliceProjection = dot(sampleDirection, sliceDirection);
+    if (sliceProjection * side <= 0.0) {
+      continue;
+    }
+    let sampleAngle = atan2(sliceProjection, dot(sampleDirection, viewDirection));
+    let biasedAngle = sampleAngle + side * gtaoEvaluate.bias;
+    let boundedAngle = select(
+      clamp(biasedAngle, -GTAO_PI * 0.5, 0.0),
+      clamp(biasedAngle, 0.0, GTAO_PI * 0.5),
+      side > 0.0
+    );
     let distanceFalloff = 1.0 - smoothstep(gtaoEvaluate.radius * 0.35, gtaoEvaluate.radius, distanceToSample);
     let stepFalloff = 1.0 - fraction * 0.15;
-    horizon = max(horizon, hemisphere * distanceFalloff * stepFalloff);
+    let weightedAngle = mix(hemisphereEdge, boundedAngle, distanceFalloff * stepFalloff);
+    horizon = select(max(horizon, weightedAngle), min(horizon, weightedAngle), side > 0.0);
   }
   return horizon;
+}
+
+fn gtaoEvaluate_integrateSlice(
+  negativeHorizon: f32,
+  positiveHorizon: f32,
+  normalAngle: f32
+) -> f32 {
+  let lowerHemisphere = normalAngle - GTAO_PI * 0.5;
+  let upperHemisphere = normalAngle + GTAO_PI * 0.5;
+  let visibleLower = clamp(negativeHorizon, lowerHemisphere, upperHemisphere);
+  let visibleUpper = clamp(positiveHorizon, lowerHemisphere, upperHemisphere);
+  let unoccludedLower = clamp(-GTAO_PI * 0.5, lowerHemisphere, upperHemisphere);
+  let unoccludedUpper = clamp(GTAO_PI * 0.5, lowerHemisphere, upperHemisphere);
+  let visibilityIntegral = max(
+    sin(visibleUpper - normalAngle) - sin(visibleLower - normalAngle),
+    0.0
+  );
+  let hemisphereIntegral = max(
+    sin(unoccludedUpper - normalAngle) - sin(unoccludedLower - normalAngle),
+    0.0001
+  );
+  return clamp(visibilityIntegral / hemisphereIntegral, 0.0, 1.0);
 }
 
 fn gtaoEvaluate_sampleColor(
@@ -132,35 +179,71 @@ fn gtaoEvaluate_sampleColor(
     max(-centerPosition.z, 0.0001) * depthDimensions.y * 0.5;
   let radiusPixels = clamp(projectedRadius, 2.0, 72.0);
   let pixelCoordinate = sceneCoord * depthDimensions;
-  let rotation = gtaoEvaluate_hash(floor(pixelCoordinate)) * GTAO_PI;
+  let frameOffset = vec2f(gtaoEvaluate.frameIndex * 0.754877666, gtaoEvaluate.frameIndex * 0.569840291);
+  let rotation = gtaoEvaluate_hash(floor(pixelCoordinate) + frameOffset) * GTAO_PI;
+  let radialJitter = 0.25 + gtaoEvaluate_hash(floor(pixelCoordinate) + frameOffset.yx + 17.0) * 0.75;
+  let viewDirection = normalize(-centerPosition);
 
-  var accumulatedOcclusion = 0.0;
+  var accumulatedVisibility = 0.0;
+  var accumulatedWeight = 0.0;
   for (var sliceIndex: i32 = 0; sliceIndex < GTAO_SLICE_COUNT; sliceIndex++) {
     let angle = rotation + f32(sliceIndex) * GTAO_PI / f32(GTAO_SLICE_COUNT);
     let direction = vec2f(cos(angle), sin(angle));
+    let sliceSampleCoord = clamp(sceneCoord + direction / depthDimensions, vec2f(0.0), vec2f(1.0));
+    let slicePosition = gtaoEvaluate_reconstructViewPosition(sliceSampleCoord, depth);
+    let sliceDelta = slicePosition - centerPosition;
+    if (length(sliceDelta) <= 0.00001) {
+      continue;
+    }
+    let slicePlaneNormal = normalize(cross(sliceDelta, viewDirection));
+    let sliceDirection = normalize(cross(viewDirection, slicePlaneNormal));
+    let projectedNormal = normal - slicePlaneNormal * dot(normal, slicePlaneNormal);
+    let projectedNormalLength = length(projectedNormal);
+    if (projectedNormalLength <= 0.00001) {
+      continue;
+    }
+    let normalizedProjectedNormal = projectedNormal / projectedNormalLength;
+    let normalAngle = atan2(
+      dot(normalizedProjectedNormal, sliceDirection),
+      dot(normalizedProjectedNormal, viewDirection)
+    );
     let positiveHorizon = gtaoEvaluate_sampleHorizon(
       centerPosition,
-      normal,
+      viewDirection,
+      sliceDirection,
       sceneCoord,
       direction,
       1.0,
       radiusPixels,
-      depthDimensions
+      depthDimensions,
+      radialJitter
     );
     let negativeHorizon = gtaoEvaluate_sampleHorizon(
       centerPosition,
-      normal,
+      viewDirection,
+      sliceDirection,
       sceneCoord,
       direction,
       -1.0,
       radiusPixels,
-      depthDimensions
+      depthDimensions,
+      radialJitter
     );
-    accumulatedOcclusion += positiveHorizon * positiveHorizon + negativeHorizon * negativeHorizon;
+    let sliceVisibility = gtaoEvaluate_integrateSlice(
+      negativeHorizon,
+      positiveHorizon,
+      normalAngle
+    );
+    accumulatedVisibility += sliceVisibility * projectedNormalLength;
+    accumulatedWeight += projectedNormalLength;
   }
 
-  let normalizedOcclusion = accumulatedOcclusion / f32(GTAO_SLICE_COUNT * 2);
-  let visibility = clamp(1.0 - normalizedOcclusion * gtaoEvaluate.intensity, 0.0, 1.0);
+  let integratedVisibility = accumulatedVisibility / max(accumulatedWeight, 0.0001);
+  let visibility = clamp(
+    1.0 - (1.0 - integratedVisibility) * gtaoEvaluate.intensity,
+    0.0,
+    1.0
+  );
   return vec4f(vec3f(visibility), 1.0);
 }`,
   bindingLayout: [
@@ -359,6 +442,70 @@ fn gtaoComposite_sampleColor(
   passes: [{sampler: true}]
 } as const satisfies ShaderPass<Partial<GTAOCompositeUniforms>, GTAOCompositeUniforms>;
 
+/** Applies ambient visibility without darkening direct lighting or emissive scene color. */
+export const gtaoAmbientComposite = {
+  name: 'gtaoAmbientComposite',
+  source: /* wgsl */ `\
+struct GTAOAmbientCompositeUniforms {
+  strength: f32,
+  debugMode: f32,
+};
+
+@group(0) @binding(auto) var<uniform> gtaoAmbientComposite: GTAOAmbientCompositeUniforms;
+@group(0) @binding(auto) var ambientOcclusionTexture: texture_2d<f32>;
+@group(0) @binding(auto) var ambientOcclusionTextureSampler: sampler;
+@group(0) @binding(auto) var ambientLightingTexture: texture_2d<f32>;
+@group(0) @binding(auto) var ambientLightingTextureSampler: sampler;
+
+fn gtaoAmbientComposite_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let color = textureSample(sourceTexture, sourceTextureSampler, texCoord);
+  let visibility = textureSample(
+    ambientOcclusionTexture,
+    ambientOcclusionTextureSampler,
+    texCoord
+  ).r;
+  if (gtaoAmbientComposite.debugMode > 0.5) {
+    return vec4f(vec3f(visibility), 1.0);
+  }
+  let ambientLighting = textureSample(
+    ambientLightingTexture,
+    ambientLightingTextureSampler,
+    texCoord
+  ).rgb;
+  let ambientVisibility = mix(
+    1.0,
+    visibility,
+    clamp(gtaoAmbientComposite.strength, 0.0, 1.0)
+  );
+  return vec4f(color.rgb + ambientLighting * (ambientVisibility - 1.0), color.a);
+}`,
+  bindingLayout: [
+    {name: 'ambientOcclusionTexture', group: 0},
+    {name: 'ambientLightingTexture', group: 0}
+  ],
+  props: {} as Partial<GTAOCompositeUniforms> & GTAOAmbientCompositeBindings,
+  uniforms: {} as GTAOCompositeUniforms,
+  bindings: {} as GTAOAmbientCompositeBindings,
+  uniformTypes: {
+    strength: 'f32',
+    debugMode: 'f32'
+  },
+  propTypes: {
+    strength: {value: 0.68, min: 0, max: 1},
+    debugMode: {value: 0, min: 0, max: 1, private: true}
+  },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  Partial<GTAOCompositeUniforms> & GTAOAmbientCompositeBindings,
+  GTAOCompositeUniforms,
+  GTAOAmbientCompositeBindings
+>;
+
 /** Creates a temporally stabilized horizon-based ambient-occlusion pipeline. */
 export function createGTAOShaderPassPipeline(
   options: GTAOShaderPassPipelineOptions = {}
@@ -366,6 +513,7 @@ export function createGTAOShaderPassPipeline(
   'gtaoRaw' | 'gtaoHistory' | 'gtaoHistoryDepth' | 'gtaoScratch' | 'gtaoBlurred'
 > {
   const scale = options.resolutionScale || 0.5;
+  const composite = options.composition === 'ambient-only' ? gtaoAmbientComposite : gtaoComposite;
   return {
     name: 'gtaoShaderPassPipeline',
     renderTargets: {
@@ -418,7 +566,7 @@ export function createGTAOShaderPassPipeline(
         uniforms: {direction: [0, 1], radius: 3, spatialSigma: 2.5, depthSigma: 0.008}
       },
       {
-        shaderPass: gtaoComposite,
+        shaderPass: composite,
         inputs: {sourceTexture: 'previous', ambientOcclusionTexture: 'gtaoBlurred'},
         output: 'previous'
       }

--- a/modules/effects/test/passes/advanced-effects.spec.ts
+++ b/modules/effects/test/passes/advanced-effects.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {Texture} from '@luma.gl/core';
+import {Buffer, Texture} from '@luma.gl/core';
 import {ShaderPassRenderer} from '@luma.gl/engine';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import {
@@ -19,6 +19,8 @@ import {
   createVolumetricFogShaderPassPipeline,
   depthAwareBlurShaderPassPipeline,
   dofShaderPassPipeline,
+  gtaoAmbientComposite,
+  gtaoEvaluate,
   gtaoTemporal,
   ssgiTemporal,
   ssrTemporal
@@ -55,6 +57,25 @@ test('advanced effects expose composable pipeline shapes', testCase => {
     gtaoTemporal.uniformTypes.inverseProjectionMatrix,
     'mat4x4<f32>',
     'GTAO temporal rejection reconstructs linear view-space depth'
+  );
+  testCase.ok(
+    gtaoEvaluate.source.includes('gtaoEvaluate_integrateSlice'),
+    'GTAO integrates cosine-weighted visibility between signed horizon angles'
+  );
+  testCase.ok(
+    gtaoEvaluate.source.includes('gtaoEvaluate.frameIndex *'),
+    'GTAO rotates and jitters horizon samples across animation frames'
+  );
+
+  const ambientOnlyGTAO = createGTAOShaderPassPipeline({composition: 'ambient-only'});
+  testCase.equal(
+    ambientOnlyGTAO.steps[5].shaderPass,
+    gtaoAmbientComposite,
+    'ambient-only GTAO selects the composable ambient-light correction'
+  );
+  testCase.ok(
+    gtaoAmbientComposite.bindingLayout.some(binding => binding.name === 'ambientLightingTexture'),
+    'ambient-only composition explicitly consumes the isolated ambient contribution'
   );
 
   const globalIllumination = createSSGIShaderPassPipeline({resolutionScale: 0.5});
@@ -148,6 +169,95 @@ test('advanced effects expose composable pipeline shapes', testCase => {
     'mat4x4<f32>',
     'SSR temporal rejection reconstructs linear view-space depth'
   );
+  testCase.end();
+});
+
+test('ambient-only GTAO preserves non-ambient scene lighting on WebGPU', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU unavailable, skipping ambient-only composition execution');
+    testCase.end();
+    return;
+  }
+
+  const width = 4;
+  const height = 4;
+  const textureProperties = {
+    format: 'rgba8unorm' as const,
+    width,
+    height,
+    usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_DST
+  };
+  const sourceTexture = device.createTexture({id: 'gtao-ambient-source', ...textureProperties});
+  const ambientLightingTexture = device.createTexture({
+    id: 'gtao-ambient-lighting',
+    ...textureProperties
+  });
+  const ambientOcclusionTexture = device.createTexture({
+    id: 'gtao-ambient-visibility',
+    ...textureProperties
+  });
+  const framebuffer = device.createFramebuffer({
+    id: 'gtao-ambient-inputs',
+    width,
+    height,
+    colorAttachments: [sourceTexture, ambientLightingTexture, ambientOcclusionTexture]
+  });
+  const renderer = new ShaderPassRenderer(device, {
+    shaderPasses: [gtaoAmbientComposite],
+    colorFormat: 'rgba8unorm',
+    flipY: false
+  });
+  renderer.resize([width, height]);
+
+  try {
+    const renderPass = device.beginRenderPass({
+      framebuffer,
+      clearColors: [
+        new Float32Array([0.8, 0.6, 0.4, 1]),
+        new Float32Array([0.2, 0.1, 0.05, 1]),
+        new Float32Array([0.25, 0.25, 0.25, 1])
+      ]
+    });
+    renderPass.end();
+
+    const outputTexture = renderer.renderToTexture({
+      sourceTexture,
+      bindings: {ambientLightingTexture, ambientOcclusionTexture},
+      uniforms: {gtaoAmbientComposite: {strength: 1}}
+    });
+    device.submit();
+
+    testCase.ok(outputTexture, 'ambient-only composition produces a scene-color texture');
+    if (outputTexture) {
+      const layout = outputTexture.computeMemoryLayout({width: 1, height: 1});
+      const readbackBuffer = device.createBuffer({
+        byteLength: layout.byteLength,
+        usage: Buffer.COPY_DST | Buffer.MAP_READ
+      });
+      try {
+        outputTexture.readBuffer({width: 1, height: 1}, readbackBuffer);
+        const outputBytes = await readbackBuffer.readAsync(0, layout.byteLength);
+        const pixel = new Uint8Array(outputBytes.buffer, outputBytes.byteOffset, 4);
+        const expected = [0.65, 0.525, 0.3625];
+        for (let channel = 0; channel < expected.length; channel++) {
+          testCase.ok(
+            Math.abs(pixel[channel]! / 255 - expected[channel]!) < 0.015,
+            `channel ${channel} preserves direct/emissive light while occluding ambient`
+          );
+        }
+      } finally {
+        readbackBuffer.destroy();
+      }
+    }
+  } finally {
+    renderer.destroy();
+    framebuffer.destroy();
+    sourceTexture.destroy();
+    ambientLightingTexture.destroy();
+    ambientOcclusionTexture.destroy();
+  }
+
   testCase.end();
 });
 

--- a/modules/effects/test/passes/postprocessing-wgsl.spec.ts
+++ b/modules/effects/test/passes/postprocessing-wgsl.spec.ts
@@ -77,6 +77,7 @@ const PLATFORM_INFO = {
 const ADVANCED_SHADER_PASSES = [
   createSSAOShaderPassPipeline({normalSource: 'normal-texture'}),
   createGTAOShaderPassPipeline(),
+  createGTAOShaderPassPipeline({composition: 'ambient-only'}),
   createSSGIShaderPassPipeline(),
   createOutlineShaderPassPipeline({normalSource: 'normal-texture'}),
   createTAAShaderPassPipeline(),

--- a/modules/experimental/src/index.ts
+++ b/modules/experimental/src/index.ts
@@ -117,6 +117,11 @@ export type {
   GBufferShaderPassBindings
 } from './rendering/g-buffer';
 export {GBuffer} from './rendering/g-buffer';
+export type {DeferredAmbientLightingProps} from './rendering/deferred-ambient-lighting';
+export {
+  createDeferredAmbientLightingShaderPassPipeline,
+  deferredAmbientLighting
+} from './rendering/deferred-ambient-lighting';
 export type {DeferredLightingProps, DeferredPointLight} from './rendering/deferred-lighting';
 export {
   createDeferredLightingShaderPassPipeline,

--- a/modules/experimental/src/rendering/deferred-ambient-lighting.ts
+++ b/modules/experimental/src/rendering/deferred-ambient-lighting.ts
@@ -1,0 +1,94 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Texture} from '@luma.gl/core';
+import type {NumberArray3} from '@math.gl/core';
+import type {ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
+
+type DeferredAmbientLightingUniforms = {
+  ambientColor: Readonly<NumberArray3>;
+};
+
+type DeferredAmbientLightingBindings = {
+  depthTexture?: Texture;
+  baseColorMetallicTexture?: Texture;
+  emissiveOcclusionTexture?: Texture;
+};
+
+/** CPU-side uniforms and G-buffer bindings needed to isolate deferred ambient lighting. */
+export type DeferredAmbientLightingProps = Partial<DeferredAmbientLightingUniforms> &
+  DeferredAmbientLightingBindings;
+
+/** Extracts only the ambient contribution consumed by ambient-only screen-space effects. */
+export const deferredAmbientLighting = {
+  name: 'deferredAmbientLighting',
+  source: /* wgsl */ `\
+struct DeferredAmbientLightingUniforms {
+  ambientColor: vec3f,
+};
+
+@group(0) @binding(auto) var<uniform> deferredAmbientLighting: DeferredAmbientLightingUniforms;
+@group(0) @binding(auto) var depthTexture: texture_depth_2d;
+@group(0) @binding(auto) var depthTextureSampler: sampler;
+@group(0) @binding(auto) var baseColorMetallicTexture: texture_2d<f32>;
+@group(0) @binding(auto) var baseColorMetallicTextureSampler: sampler;
+@group(0) @binding(auto) var emissiveOcclusionTexture: texture_2d<u32>;
+
+fn deferredAmbientLighting_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let depth = textureSampleLevel(depthTexture, depthTextureSampler, texCoord, 0);
+  if (depth >= 0.99999) {
+    return vec4f(0.0);
+  }
+  let baseColor = textureSampleLevel(
+    baseColorMetallicTexture,
+    baseColorMetallicTextureSampler,
+    texCoord,
+    0
+  ).rgb;
+  let materialCoordinates = vec2i(
+    clamp(texCoord * texSize, vec2f(0.0), texSize - vec2f(1.0))
+  );
+  let materialOcclusion = f32(textureLoad(emissiveOcclusionTexture, materialCoordinates, 0).a) /
+    255.0;
+  return vec4f(baseColor * deferredAmbientLighting.ambientColor * materialOcclusion, 1.0);
+}`,
+  bindingLayout: [
+    {name: 'depthTexture', group: 0},
+    {name: 'baseColorMetallicTexture', group: 0},
+    {name: 'emissiveOcclusionTexture', group: 0}
+  ],
+  props: {} as DeferredAmbientLightingProps,
+  uniforms: {} as DeferredAmbientLightingUniforms,
+  bindings: {} as DeferredAmbientLightingBindings,
+  uniformTypes: {
+    ambientColor: 'vec3<f32>'
+  },
+  propTypes: {
+    ambientColor: {value: [0.04, 0.04, 0.05], private: true}
+  },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  DeferredAmbientLightingProps,
+  DeferredAmbientLightingUniforms,
+  DeferredAmbientLightingBindings
+>;
+
+/** Creates a reusable fullscreen ambient-light extraction pass over deferred G-buffer material. */
+export function createDeferredAmbientLightingShaderPassPipeline(): ShaderPassPipeline {
+  return {
+    name: 'deferredAmbientLightingShaderPassPipeline',
+    steps: [
+      {
+        shaderPass: deferredAmbientLighting,
+        inputs: {sourceTexture: 'previous'},
+        output: 'previous'
+      }
+    ]
+  };
+}

--- a/modules/experimental/test/rendering/deferred-lighting.spec.ts
+++ b/modules/experimental/test/rendering/deferred-lighting.spec.ts
@@ -6,7 +6,9 @@ import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {Buffer, Texture} from '@luma.gl/core';
 import {ShaderPassRenderer} from '@luma.gl/engine';
 import {
+  createDeferredAmbientLightingShaderPassPipeline,
   createDeferredLightingShaderPassPipeline,
+  deferredAmbientLighting,
   makeDeferredPointLightBufferData,
   MAX_DEFERRED_POINT_LIGHTS
 } from '@luma.gl/experimental';
@@ -63,6 +65,26 @@ test('deferred lighting exposes one composable fullscreen resolve', testCase => 
   );
   testCase.equal(pipeline.steps[0].output, 'previous', 'lighting composes into the color chain');
   testCase.equal(MAX_DEFERRED_POINT_LIGHTS, 64, 'the exported capacity matches the WGSL loop');
+  testCase.end();
+});
+
+test('deferred ambient lighting isolates the material ambient contribution', testCase => {
+  const pipeline = createDeferredAmbientLightingShaderPassPipeline();
+  testCase.equal(pipeline.steps.length, 1, 'ambient extraction remains one composable pass');
+  testCase.equal(
+    pipeline.steps[0].shaderPass,
+    deferredAmbientLighting,
+    'the pipeline exposes the reusable deferred ambient-light shader'
+  );
+  testCase.equal(
+    deferredAmbientLighting.uniformTypes.ambientColor,
+    'vec3<f32>',
+    'ambient extraction uses the same linear ambient color as the lighting resolve'
+  );
+  testCase.ok(
+    deferredAmbientLighting.source.includes('baseColor * deferredAmbientLighting.ambientColor'),
+    'ambient extraction excludes direct lighting and emissive radiance'
+  );
   testCase.end();
 });
 

--- a/website/content/examples/experimental/deferred-rendering.mdx
+++ b/website/content/examples/experimental/deferred-rendering.mdx
@@ -68,10 +68,14 @@ velocity, and depth channels plus two named material extras:
 screen/log-depth grid. `createClusteredDeferredLightingShaderPassPipeline()` then reads those
 material targets plus the current pixel's bounded cluster list, reconstructs view-space position
 from depth, evaluates Cook-Torrance direct lighting, and writes HDR color back into the normal
-ordered shader-pass chain. `createGTAOShaderPassPipeline()` then performs a half-resolution
-horizon search over the unchanged depth and view-normal attachments, reprojects the previous AO
-result through the velocity buffer, rejects disocclusions with depth history, and applies a
-depth-aware separable blur before compositing ambient visibility into lit color.
+ordered shader-pass chain. `createDeferredAmbientLightingShaderPassPipeline()` separately extracts
+the linear ambient contribution from the same material attachments.
+`createGTAOShaderPassPipeline({composition: 'ambient-only'})` then analytically integrates
+half-resolution horizon angles over the unchanged depth and view-normal attachments, rotates and
+jitters sampling across animation frames, reprojects the previous AO result through the velocity
+buffer, rejects disocclusions with depth history, and applies a depth-aware separable blur. Its
+final composite attenuates only the isolated ambient contribution, leaving directional and point
+lights plus emissive materials untouched.
 `createSSGIShaderPassPipeline()` traces cosine-weighted hemisphere rays through that lit scene,
 gathers nearby colored radiance, reprojects indirect-light history, rejects disocclusions in
 linearized view depth, and applies two depth/normal-aware denoising passes before composing the


### PR DESCRIPTION
## Goals
- Replace the existing horizon-inspired heuristic with analytic, cosine-weighted GTAO visibility.
- Preserve direct and emissive lighting through an additive, backward-compatible ambient-only composition mode.

## Changes
- Integrate signed positive/negative horizon angles per view-space slice and rotate/jitter samples with `frameIndex`.
- Add `composition: 'ambient-only'` and export `gtaoAmbientComposite`, while retaining the existing whole-color composite by default.
- Add reusable `deferredAmbientLighting` extraction and update the deferred-rendering example to bind isolated ambient radiance.
- Extend WGSL compilation, compositing behavior, pipeline-shape, deferred integration, and documentation coverage.

## Verification
- `env -u YARN_NO_PROXY corepack yarn lint fix`
- `env -u YARN_NO_PROXY corepack yarn lint`
- `env -u YARN_NO_PROXY corepack yarn test-node` — 178 passed, 2 skipped.
- `env -u YARN_NO_PROXY corepack yarn build` — all packages compile.
- `env -u YARN_NO_PROXY corepack yarn examples:typecheck` — all 31 example workspaces pass.
- `env -u YARN_NO_PROXY corepack yarn website:build` — production client, server, and search index build.
- `env -u YARN_NO_PROXY corepack yarn test-headless modules/effects/test/passes/advanced-effects.spec.ts modules/effects/test/passes/postprocessing-wgsl.spec.ts modules/experimental/test/rendering/deferred-lighting.spec.ts` — 8 Chromium/WebGPU tests pass.
- `env -u YARN_NO_PROXY corepack yarn test` runs 178 node tests and 1,303 headless cases; one unchanged, reproducible existing failure remains in `modules/arrow-layers/test/layers/arrow-layers.spec.ts` (`polygonViewportUniforms` missing / polygon storage instances not drawable). The affected Arrow files have no diff from `master`.
