### PR TITLE
feat(core): recognize unsuffixed WebGL x3 vertex formats

### DIFF
--- a/modules/core/src/shadertypes/vertex-types/vertex-format-decoder.ts
+++ b/modules/core/src/shadertypes/vertex-types/vertex-format-decoder.ts
@@ -43,6 +43,8 @@ export class VertexFormatDecoder {
     const type = typeString as NormalizedDataType;
     const components = getVertexFormatComponents(format, componentString);
     const decodedType = getVertexFormatDataTypeInfo(format, type);
+    const unsuffixedWebGLOnly = !webglOnly && isWebGLOnlyVertexFormat(type, components);
+    webglOnly ||= unsuffixedWebGLOnly;
     let expectedFormat: VertexFormat;
     try {
       expectedFormat = webglOnly
@@ -51,7 +53,8 @@ export class VertexFormatDecoder {
     } catch {
       throw new Error(`Unsupported vertex format: ${format}`);
     }
-    if (expectedFormat !== (webglOnly ? format : normalizedFormat)) {
+    const canonicalFormat = webglOnly ? `${normalizedFormat}-webgl` : normalizedFormat;
+    if (expectedFormat !== canonicalFormat) {
       throw new Error(`Unsupported vertex format: ${format}`);
     }
     const result: VertexFormatInfo = {
@@ -100,9 +103,8 @@ export class VertexFormatDecoder {
 
       case 'uint8':
       case 'sint8':
-        // WebGPU does not support 3-component 8 bit formats.
         if (components === 3) {
-          throw new Error(`size: ${components}`);
+          return `${dataType}x3-webgl`;
         }
         return components === 1 ? dataType : `${dataType}x${components}`;
 
@@ -232,8 +234,19 @@ function getWebGLOnlyVertexFormat(
   type: NormalizedDataType,
   components: 1 | 2 | 3 | 4
 ): VertexFormat {
-  if (components !== 3) {
+  if (!isWebGLOnlyVertexFormat(type, components)) {
     throw new Error(`Unsupported vertex format: ${format}`);
+  }
+
+  return `${type}x3-webgl`;
+}
+
+function isWebGLOnlyVertexFormat(
+  type: NormalizedDataType,
+  components: 1 | 2 | 3 | 4
+): type is 'uint8' | 'sint8' | 'unorm8' | 'snorm8' | 'uint16' | 'sint16' | 'unorm16' | 'snorm16' {
+  if (components !== 3) {
+    return false;
   }
 
   switch (type) {
@@ -245,8 +258,8 @@ function getWebGLOnlyVertexFormat(
     case 'sint16':
     case 'unorm16':
     case 'snorm16':
-      return `${type}x3-webgl`;
+      return true;
     default:
-      throw new Error(`Unsupported vertex format: ${format}`);
+      return false;
   }
 }

--- a/modules/core/src/shadertypes/vertex-types/vertex-formats.ts
+++ b/modules/core/src/shadertypes/vertex-types/vertex-formats.ts
@@ -18,14 +18,17 @@ export type VertexFormat =
   // 8 bit integers, note that only 16 bit aligned formats are supported in WebGPU (x2 and x4)
   | 'uint8' // Chrome 133+
   | 'uint8x2'
+  | 'uint8x3' // Unsuffixed alias for uint8x3-webgl
   | 'uint8x3-webgl' // Not in WebGPU
   | 'uint8x4'
   | 'sint8' // Chrome 133+
   | 'sint8x2'
+  | 'sint8x3' // Unsuffixed alias for sint8x3-webgl
   | 'sint8x3-webgl' // Not in WebGPU
   | 'sint8x4'
   | 'unorm8' // Chrome 133+
   | 'unorm8x2'
+  | 'unorm8x3' // Unsuffixed alias for unorm8x3-webgl
   | 'unorm8x3-webgl' // Not in WebGPU
   | 'unorm8x4'
   | 'unorm8x4-bgra' // Chrome 133+
@@ -33,6 +36,7 @@ export type VertexFormat =
   // | 'snorm-10-10-10-2' // Not in WebGPU, DXD12 doesn't support
   | 'snorm8' // Chrome 133+
   | 'snorm8x2'
+  | 'snorm8x3' // Unsuffixed alias for snorm8x3-webgl
   | 'snorm8x3-webgl'
   | 'snorm8x4'
   // 16 bit integers, that only 32 bit aligned formats are supported in WebGPU (x2 and x4)
@@ -41,15 +45,19 @@ export type VertexFormat =
   | 'unorm16' // Chrome 133+
   | 'snorm16' // Chrome 133+
   | 'uint16x2'
+  | 'uint16x3' // Unsuffixed alias for uint16x3-webgl
   | 'uint16x3-webgl' // Not in WebGPU
   | 'uint16x4'
   | 'sint16x2'
+  | 'sint16x3' // Unsuffixed alias for sint16x3-webgl
   | 'sint16x3-webgl' // Not in WebGPU
   | 'sint16x4'
   | 'unorm16x2'
+  | 'unorm16x3' // Unsuffixed alias for unorm16x3-webgl
   | 'unorm16x3-webgl' // Not in WebGPU
   | 'unorm16x4'
   | 'snorm16x2'
+  | 'snorm16x3' // Unsuffixed alias for snorm16x3-webgl
   | 'snorm16x3-webgl' // Not in WebGPU
   | 'snorm16x4'
   // 32 bit integers
@@ -139,20 +147,21 @@ export type VertexFormatComponentsT<T extends VertexFormat> = T extends VertexFo
 
 // Helper types for the above
 
-type VertexFormatUint8 = 'uint8' | 'uint8x2' | 'uint8x3-webgl' | 'uint8x4';
-type VertexFormatSint8 = 'sint8' | 'sint8x2' | 'sint8x3-webgl' | 'sint8x4';
+type VertexFormatUint8 = 'uint8' | 'uint8x2' | 'uint8x3' | 'uint8x3-webgl' | 'uint8x4';
+type VertexFormatSint8 = 'sint8' | 'sint8x2' | 'sint8x3' | 'sint8x3-webgl' | 'sint8x4';
 type VertexFormatUnorm8 =
   | 'unorm8'
   | 'unorm8x2'
+  | 'unorm8x3'
   | 'unorm8x3-webgl'
   | 'unorm8x4'
   | 'unorm8x4-bgra'
   | 'unorm10-10-10-2';
-type VertexFormatSnorm8 = 'snorm8' | 'snorm8x2' | 'snorm8x3-webgl' | 'snorm8x4';
-type VertexFormatUint16 = 'uint16' | 'uint16x2' | 'uint16x3-webgl' | 'uint16x4';
-type VertexFormatSint16 = 'sint16' | 'sint16x2' | 'sint16x3-webgl' | 'sint16x4';
-type VertexFormatUnorm16 = 'unorm16' | 'unorm16x2' | 'unorm16x3-webgl' | 'unorm16x4';
-type VertexFormatSnorm16 = 'snorm16' | 'snorm16x2' | 'snorm16x3-webgl' | 'snorm16x4';
+type VertexFormatSnorm8 = 'snorm8' | 'snorm8x2' | 'snorm8x3' | 'snorm8x3-webgl' | 'snorm8x4';
+type VertexFormatUint16 = 'uint16' | 'uint16x2' | 'uint16x3' | 'uint16x3-webgl' | 'uint16x4';
+type VertexFormatSint16 = 'sint16' | 'sint16x2' | 'sint16x3' | 'sint16x3-webgl' | 'sint16x4';
+type VertexFormatUnorm16 = 'unorm16' | 'unorm16x2' | 'unorm16x3' | 'unorm16x3-webgl' | 'unorm16x4';
+type VertexFormatSnorm16 = 'snorm16' | 'snorm16x2' | 'snorm16x3' | 'snorm16x3-webgl' | 'snorm16x4';
 type VertexFormatUint32 = 'uint32' | 'uint32x2' | 'uint32x3' | 'uint32x4';
 type VertexFormatSint32 = 'sint32' | 'sint32x2' | 'sint32x3' | 'sint32x4';
 type VertexFormatFloat16 = 'float16' | 'float16x2' | 'float16x4';
@@ -172,13 +181,21 @@ type VertexFormat2Components =
   | 'float16x2'
   | 'float32x2';
 type VertexFormat3Components =
+  | 'uint8x3'
   | 'uint8x3-webgl'
+  | 'sint8x3'
   | 'sint8x3-webgl'
+  | 'unorm8x3'
   | 'unorm8x3-webgl'
+  | 'snorm8x3'
   | 'snorm8x3-webgl'
+  | 'uint16x3'
   | 'uint16x3-webgl'
+  | 'sint16x3'
   | 'sint16x3-webgl'
+  | 'unorm16x3'
   | 'unorm16x3-webgl'
+  | 'snorm16x3'
   | 'snorm16x3-webgl'
   | 'uint32x3'
   | 'sint32x3'

--- a/modules/core/test/shadertypes/vertex-format-decoder.spec.ts
+++ b/modules/core/test/shadertypes/vertex-format-decoder.spec.ts
@@ -57,6 +57,22 @@ test('shadertypes#vertexFormatDecoder.getVertexFormatInfo validates parsed forma
     },
     'decodes webgl-only x3 formats'
   );
+  for (const format of [
+    'uint8x3',
+    'sint8x3',
+    'unorm8x3',
+    'snorm8x3',
+    'uint16x3',
+    'sint16x3',
+    'unorm16x3',
+    'snorm16x3'
+  ] as VertexFormat[]) {
+    t.equal(
+      vertexFormatDecoder.getVertexFormatInfo(format).webglOnly,
+      true,
+      `accepts unsuffixed WebGL-only format '${format}'`
+    );
+  }
   t.deepEqual(
     vertexFormatDecoder.getVertexFormatInfo('unorm8x4-bgra'),
     {type: 'unorm8', components: 4, byteLength: 4, integer: false, signed: false, normalized: true},
@@ -107,6 +123,8 @@ const TEST_CASES_2: {
 
   {typedArray: new Int16Array(), size: 3, result: 'sint16x3-webgl'},
   {typedArray: new Uint16Array(), size: 3, result: 'uint16x3-webgl'},
+  {typedArray: new Uint8Array(), size: 3, result: 'uint8x3-webgl'},
+  {typedArray: new Int8Array(), size: 3, result: 'sint8x3-webgl'},
   {typedArray: new Uint16Array(), size: 3, normalized: true, result: 'unorm16x3-webgl'},
   {typedArray: new Int16Array(), size: 3, normalized: true, result: 'snorm16x3-webgl'},
   {typedArray: new Uint8Array(), size: 3, normalized: true, result: 'unorm8x3-webgl'},

--- a/modules/webgpu/src/adapter/helpers/get-vertex-buffer-layout.ts
+++ b/modules/webgpu/src/adapter/helpers/get-vertex-buffer-layout.ts
@@ -11,7 +11,8 @@ import type {
 import {
   getLogicalBufferSlots,
   getMinimumAttributeLocation,
-  resolveLogicalAttributeMappings
+  resolveLogicalAttributeMappings,
+  vertexFormatDecoder
 } from '@luma.gl/core';
 
 /** Describes one physical WebGPU vertex-buffer slot derived from a logical buffer layout. */
@@ -26,7 +27,7 @@ export type ResolvedVertexBufferSlot = {
 
 /** Throw error on any WebGL-only vertex formats. */
 function getWebGPUVertexFormat(format: VertexFormat): GPUVertexFormat {
-  if (format.endsWith('-webgl')) {
+  if (vertexFormatDecoder.getVertexFormatInfo(format).webglOnly) {
     throw new Error(`WebGPU does not support vertex format ${format}`);
   }
   return format as GPUVertexFormat;

--- a/modules/webgpu/test/adapter/helpers/get-vertex-buffer-layout.spec.ts
+++ b/modules/webgpu/test/adapter/helpers/get-vertex-buffer-layout.spec.ts
@@ -222,6 +222,22 @@ test('WebGPU#getVertexBufferLayout preserves explicit zero stride', t => {
   t.end();
 });
 
+test('WebGPU#getVertexBufferLayout rejects unsuffixed WebGL-only formats', t => {
+  t.throws(
+    () =>
+      getVertexBufferLayout(
+        {
+          attributes: [{name: 'colors', location: 0, type: 'vec3<f32>', stepMode: 'vertex'}],
+          bindings: []
+        },
+        [{name: 'colors', format: 'unorm8x3'}]
+      ),
+    /WebGPU does not support vertex format unorm8x3/,
+    'unsuffixed format is recognized before it reaches WebGPU'
+  );
+  t.end();
+});
+
 test('WebGPU#resolveVertexBufferLayouts splits oversized interleaved offsets into repeated bindings', t => {
   const {vertexBufferLayouts, resolvedSlots} = resolveVertexBufferLayouts(
     fp64ShaderLayout,


### PR DESCRIPTION
## Summary

- propose unsuffixed aliases such as `unorm8x3` and `uint16x3` for the existing `-webgl` x3 vertex formats
- make 8-bit x3 format inference return the canonical `uint8x3-webgl` and `sint8x3-webgl` names
- classify unsuffixed aliases as WebGL-only so `device.isVertexFormatSupported()` reports them as unsupported on WebGPU and WebGPU pipeline creation rejects them before they reach the native API

## Motivation

deck.gl derives some attribute format strings from a component type and size. Accepting the resulting unsuffixed x3 names would let it use luma.gl's format decoder and device capability API instead of duplicating WebGPU format rules.

These aliases were not previously declared public constants, so this is intentionally separated from the backwards-compatibility fixes in #2758. It is an independent API proposal: callers can alternatively be required to emit the existing canonical `-webgl` names.

## Validation

- `yarn lint fix`
- `yarn build`
- focused headless tests: 8 passed
- `yarn test`: all 178 node tests pass; the local headless run has the same three unrelated WebGPU failures reproduced on clean `master` (DGGS A5 decoding and the storage-backed arrow polygon test)