### PR TITLE
feat(experimental): add network packet spraying and composable glass

### DIFF
--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -1,0 +1,99 @@
+import {ShaderLevelDocsTabs} from '@site/src/components/docs/shader-level-docs-tabs';
+
+# Glass Effects
+
+<ShaderLevelDocsTabs active="glass-effects" />
+
+Glass combines transmission, reflection, absorption, surface roughness, and translucent fragment
+ordering. The experimental optical materials package these visual behaviors as reusable WGSL and
+GLSL shader modules, while transparency renderers remain responsible for compositing.
+
+## Optical Building Blocks
+
+| Effect | Implementation | Visible result |
+| --- | --- | --- |
+| Fresnel reflection | Schlick-style view-angle approximation. | Stronger reflections around silhouettes. |
+| Refraction | Samples an independently captured scene-color texture. | Background and packets bend behind the glass surface. |
+| Chromatic dispersion | Offsets red, green, and blue scene-color samples. | Subtle colored separation around refracted features. |
+| Beer-Lambert absorption | Attenuates transmitted light with material color and thickness. | Longer optical paths produce darker, more tinted transmission. |
+| Glossy highlights | Roughness-dependent key and fill light highlights. | Adjustable apparent surface polish. |
+
+[`glassMaterial`](/docs/api-reference/experimental/glass-material) provides the transmissive
+surface model. [`reflectiveMaterial`](/docs/api-reference/experimental/reflective-material)
+provides a lower-cost glossy treatment for links and other non-glass surfaces. Both depend on the
+shared `opticalLighting` shader module.
+
+## Attach a Glass Material
+
+```ts
+import {Model, ShaderInputs} from '@luma.gl/engine';
+import {glassMaterial, glassMaterialPlugin} from '@luma.gl/experimental';
+
+const shaderInputs = new ShaderInputs({glassMaterial});
+
+shaderInputs.setProps({
+  glassMaterial: {
+    viewportSize: [width, height],
+    sceneColorTexture,
+    indexOfRefraction: 1.5,
+    roughness: 0.14,
+    dispersion: 0.022,
+    thickness: 1.05,
+    reflectionStrength: 1
+  }
+});
+
+const model = new Model(device, {
+  source: glassShader,
+  plugins: [glassMaterialPlugin],
+  shaderInputs,
+  geometry
+});
+```
+
+Call the installed shader helper from the fragment entry point:
+
+```wgsl
+let color = glassMaterial_getColor(
+  inputs.normal,
+  inputs.worldPosition,
+  inputs.color,
+  cameraPosition,
+  inputs.position
+);
+```
+
+`inputs.position` must be the fragment's built-in framebuffer position. Keep `viewportSize` in
+physical pixels and update it whenever the scene-color texture is resized.
+
+## Separate Optical Shading From Transparency
+
+A material computes the appearance of one fragment; a transparency strategy decides how many
+fragments combine at one pixel. Compose `glassMaterialPlugin` with `aBufferPlugin` on supported
+WebGPU devices, `wboitPlugin` where weighted blending is available, or camera-depth-sorted alpha
+blending as the fallback.
+
+Render the opaque scene and capture a separate sampleable scene-color texture before shading
+glass. Do not sample the same WebGPU texture that is currently attached as a render target.
+
+See [Transparency](/docs/api-guide/shaders/transparency) for render ordering, opaque-depth
+handling, and backend selection.
+
+## Current Quality Boundary
+
+These materials are advanced raster approximations, not a complete physically based transmission
+system. In particular, the current implementation does not provide:
+
+- Depth-derived or backface-derived per-pixel thickness.
+- GGX or other energy-conserving microfacet reflection and transmission.
+- Roughness-dependent blurred transmission or filtered environment probes.
+- Multiple refraction events, internal reflections, total internal reflection, or caustics.
+- Off-screen background recovery or geometry-aware refracted-ray tracing.
+
+Those capabilities require additional depth, normal, backface, environment, or ray-tracing data
+and should be introduced as explicitly composable modules or render passes rather than hidden in
+an individual showcase.
+
+For a complete application, see
+[Network Packet Spraying](/examples/showcase/packet-spraying), which combines glass switches,
+reflective network links, exact or approximate transparency, and interactive camera controls.

--- a/docs/api-guide/shaders/rendering-techniques.md
+++ b/docs/api-guide/shaders/rendering-techniques.md
@@ -180,6 +180,11 @@ light shadows.
 Both resolve into the same shader-pass color chain, so later bloom, temporal AA, or display
 effects remain composable.
 
+For opaque-depth handling, sorted-alpha fallbacks, scene-color capture, and backend selection,
+see [Transparency](/docs/api-guide/shaders/transparency). Refractive and reflective surface
+shading is separate from fragment ordering; see [Glass Effects](/docs/api-guide/shaders/glass-effects)
+for composable material modules and their current quality limits.
+
 ## Bloom, Blur, and Depth of Field
 
 | Technique | Public entry point | Choose it when | Avoid confusing it with |

--- a/docs/api-guide/shaders/transparency.md
+++ b/docs/api-guide/shaders/transparency.md
@@ -1,0 +1,84 @@
+import {ShaderLevelDocsTabs} from '@site/src/components/docs/shader-level-docs-tabs';
+
+# Transparency
+
+<ShaderLevelDocsTabs active="transparency" />
+
+Transparency has two independent concerns: how each surface is shaded and how overlapping
+fragments are ordered. Fresnel reflection or refraction does not fix incorrect fragment ordering,
+and an order-independent transparency renderer does not automatically create realistic glass.
+
+## Choose a Compositing Strategy
+
+| Strategy | Backends | Strength | Limitation |
+| --- | --- | --- | --- |
+| Sorted alpha blending | WebGPU and WebGL 2 | Minimal memory and broad compatibility. | Object-level sorting cannot correctly resolve intersecting or deeply overlapping surfaces. |
+| Weighted-blended OIT | WebGPU and supported WebGL 2 | Order-independent accumulation at bounded memory cost. | Fragment colors and depths are combined approximately. |
+| A-buffer OIT | WebGPU | Per-pixel fragment capture and depth-sorted resolve. | Storage use grows with the configured fragment budget. |
+
+[`WBOITRenderer`](/docs/api-reference/experimental/wboit-renderer) provides weighted-blended
+transparency. [`ABufferRenderer`](/docs/api-reference/experimental/a-buffer-renderer) provides
+per-pixel linked-list capture and ordered compositing.
+
+When neither OIT path is available, sort transparent objects or instances back to front relative
+to the active camera, disable depth writes, and leave opaque-depth testing enabled. Resort whenever
+the view or object positions change.
+
+## Render Opaque Geometry First
+
+Render opaque geometry into the scene color and depth targets before drawing transparent surfaces.
+Transparent fragments must continue to respect the opaque depth buffer so hidden glass does not
+appear through nearer solid geometry.
+
+For weighted blending and A-buffer rendering, pass the existing opaque color and depth targets to
+the selected renderer, then resolve translucent capture over the opaque scene. The resulting color
+can continue through the normal shader-pass chain.
+
+## Capture Scene Color Before Refraction
+
+Screen-space transmission needs a stable texture containing previously rendered scene color.
+Create or copy that texture before the translucent pass:
+
+1. Render opaque scene geometry.
+2. Resolve or copy the opaque color attachment into a separate sampleable texture.
+3. Render refractive transparent geometry while sampling that texture.
+4. Resolve the transparency renderer, if one is used.
+5. Apply later fullscreen effects and present the composed scene.
+
+WebGPU does not permit a texture to be sampled while it is also bound as the active render target.
+Use a distinct scene-color texture rather than sampling the current attachment directly.
+
+## Compose Surface Materials and OIT
+
+Optical materials shade the surface first; the transparency plugin captures the resulting color:
+
+```ts
+import {ShaderInputs} from '@luma.gl/engine';
+import {
+  aBuffer,
+  aBufferPlugin,
+  glassMaterial,
+  glassMaterialPlugin
+} from '@luma.gl/experimental';
+
+const shaderInputs = new ShaderInputs({glassMaterial, aBuffer});
+
+shaderInputs.setProps({
+  glassMaterial: {
+    viewportSize: [width, height],
+    sceneColorTexture,
+    indexOfRefraction: 1.5
+  },
+  aBuffer: captureProperties
+});
+
+const plugins = [glassMaterialPlugin, aBufferPlugin];
+```
+
+The fragment shader calls `glassMaterial_getColor(...)` and then passes that result to
+`aBuffer_captureStraightColor(...)`. For weighted blending, replace the A-buffer module and plugin
+with `wboit` and `wboitPlugin`.
+
+See [Glass Effects](/docs/api-guide/shaders/glass-effects) for the material model and
+[Rendering Techniques and Tradeoffs](/docs/api-guide/shaders/rendering-techniques) for broader
+renderer selection.

--- a/docs/api-reference/experimental/README.md
+++ b/docs/api-reference/experimental/README.md
@@ -80,6 +80,18 @@ Compare A-buffer, weighted-blended, and ordinary alpha blending on the same over
 
 <OITExample embedded showStats={false} />
 
+## Optical Materials
+
+[`glassMaterial`](/docs/api-reference/experimental/glass-material) provides portable WGSL and GLSL
+screen-space refraction, Schlick Fresnel reflection, chromatic dispersion, and Beer-Lambert
+absorption. [`reflectiveMaterial`](/docs/api-reference/experimental/reflective-material) adds
+lightweight glossy highlights and Fresnel-weighted environment reflection for other surfaces.
+
+Both modules share `opticalLighting`, expose a `ShaderPlugin`, and can be composed with sorted
+alpha, weighted-blended OIT, or A-buffer OIT. The [Transparency](/docs/api-guide/shaders/transparency)
+and [Glass Effects](/docs/api-guide/shaders/glass-effects) guides describe their render ordering,
+backend constraints, and physically based limitations.
+
 ## Hybrid Shadows
 
 [`ShadowMapRenderer`](/docs/api-reference/experimental/shadow-map-renderer) provides WebGPU-only

--- a/docs/api-reference/experimental/glass-material.md
+++ b/docs/api-reference/experimental/glass-material.md
@@ -1,0 +1,80 @@
+import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-tabs';
+
+# Glass Material
+
+<ExperimentalDocsTabs active="glass-material" />
+
+`glassMaterial` is an experimental cross-backend shader module for refractive translucent surfaces.
+It combines captured scene-color transmission, Schlick Fresnel reflection, chromatic dispersion,
+Beer-Lambert absorption, and roughness-dependent highlights.
+
+```ts
+import {
+  glassMaterial,
+  glassMaterialPlugin,
+  opticalLighting,
+  type GlassMaterialBindings,
+  type GlassMaterialProps,
+  type GlassMaterialUniforms
+} from '@luma.gl/experimental';
+```
+
+## Properties
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `viewportSize` | `[number, number]` | `[1, 1]` | Scene-color texture dimensions in physical pixels. |
+| `sceneColorTexture` | `Texture` | Required for rendering. | Opaque scene color captured before translucent geometry. |
+| `indexOfRefraction` | `number` | `1.48` | Optical refraction index; ordinary glass is approximately `1.5`. |
+| `roughness` | `number` | `0.14` | Surface roughness between zero and one. |
+| `dispersion` | `number` | `0.022` | Separation of red, green, and blue transmission samples. |
+| `thickness` | `number` | `1.05` | Approximate optical distance used for transmission and absorption. |
+| `reflectionStrength` | `number` | `1` | Multiplier for environment reflection and highlights. |
+
+## Shader Helper
+
+```wgsl
+fn glassMaterial_getColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  baseColor: vec4<f32>,
+  cameraPosition: vec3<f32>,
+  fragmentPosition: vec4<f32>
+) -> vec4<f32>
+```
+
+GLSL exposes the equivalent `vec4 glassMaterial_getColor(...)` function. Add
+`glassMaterialPlugin` to the model so the helper and its shared `opticalLighting` dependency are
+installed before compilation.
+
+## Usage
+
+```ts
+import {Model, ShaderInputs} from '@luma.gl/engine';
+import {glassMaterial, glassMaterialPlugin} from '@luma.gl/experimental';
+
+const shaderInputs = new ShaderInputs({glassMaterial});
+
+shaderInputs.setProps({
+  glassMaterial: {
+    viewportSize: [width, height],
+    sceneColorTexture,
+    indexOfRefraction: 1.5,
+    thickness: 1
+  }
+});
+
+const model = new Model(device, {
+  source: glassShader,
+  plugins: [glassMaterialPlugin],
+  shaderInputs,
+  geometry
+});
+```
+
+Capture scene color into a separate texture before drawing glass. Sampling the active render
+attachment creates an invalid feedback loop on WebGPU.
+
+For OIT composition and quality limitations, see
+[Transparency](/docs/api-guide/shaders/transparency) and
+[Glass Effects](/docs/api-guide/shaders/glass-effects).

--- a/docs/api-reference/experimental/reflective-material.md
+++ b/docs/api-reference/experimental/reflective-material.md
@@ -1,0 +1,69 @@
+import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-tabs';
+
+# Reflective Material
+
+<ExperimentalDocsTabs active="reflective-material" />
+
+`reflectiveMaterial` is a lightweight cross-backend shader module for glossy surfaces. It combines
+Fresnel-weighted environment reflection with roughness-adjusted key and fill highlights, without
+requiring the captured scene-color texture used by `glassMaterial`.
+
+```ts
+import {
+  reflectiveMaterial,
+  reflectiveMaterialPlugin,
+  type ReflectiveMaterialProps,
+  type ReflectiveMaterialUniforms
+} from '@luma.gl/experimental';
+```
+
+## Properties
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `roughness` | `number` | `0.62` | Surface roughness between zero and one. |
+| `reflectionStrength` | `number` | `0.32` | Intensity of Fresnel-weighted environment reflection. |
+| `specularStrength` | `number` | `0.42` | Intensity of key and fill highlights. |
+| `opacityScale` | `number` | `1` | Multiplier applied to the incoming surface opacity. |
+
+## Shader Helper
+
+```wgsl
+fn reflectiveMaterial_getColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  baseColor: vec4<f32>,
+  cameraPosition: vec3<f32>
+) -> vec4<f32>
+```
+
+GLSL exposes the equivalent `vec4 reflectiveMaterial_getColor(...)` function. Install
+`reflectiveMaterialPlugin` when creating the model so the helper and shared optical-lighting
+dependency are present in the assembled shader.
+
+```ts
+import {Model, ShaderInputs} from '@luma.gl/engine';
+import {reflectiveMaterial, reflectiveMaterialPlugin} from '@luma.gl/experimental';
+
+const shaderInputs = new ShaderInputs({reflectiveMaterial});
+
+shaderInputs.setProps({
+  reflectiveMaterial: {
+    roughness: 0.45,
+    reflectionStrength: 0.3,
+    specularStrength: 0.35,
+    opacityScale: 0.6
+  }
+});
+
+const model = new Model(device, {
+  source: reflectiveShader,
+  plugins: [reflectiveMaterialPlugin],
+  shaderInputs,
+  geometry
+});
+```
+
+For refractive surfaces and transparency composition, see
+[`glassMaterial`](/docs/api-reference/experimental/glass-material) and
+[Glass Effects](/docs/api-guide/shaders/glass-effects).

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -80,7 +80,9 @@
           "api-guide/shaders/writing-customizable-shaders",
           "api-guide/shaders/writing-portable-shaders",
           "api-guide/shaders/shader-passes",
-          "api-guide/shaders/rendering-techniques"
+          "api-guide/shaders/rendering-techniques",
+          "api-guide/shaders/transparency",
+          "api-guide/shaders/glass-effects"
         ]
       },
       {
@@ -185,6 +187,8 @@
           "api-reference/experimental/deferred-lighting",
           "api-reference/experimental/clustered-lighting",
           "api-reference/experimental/shadow-map-renderer",
+          "api-reference/experimental/glass-material",
+          "api-reference/experimental/reflective-material",
           {
             "type": "category",
             "label": "GPU Primitives",

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -1,0 +1,1730 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Texture} from '@luma.gl/core';
+import type {Buffer, Device, Framebuffer, RenderPipelineParameters} from '@luma.gl/core';
+import type {AnimationProps, Geometry} from '@luma.gl/engine';
+import {
+  AnimationLoopTemplate,
+  BackgroundTextureModel,
+  colorPicking,
+  CubeGeometry,
+  CylinderGeometry,
+  Model,
+  PickingManager,
+  ShaderInputs,
+  SphereGeometry
+} from '@luma.gl/engine';
+import {
+  ABufferRenderer,
+  OrbitControls,
+  WBOITRenderer,
+  aBuffer,
+  aBufferPlugin,
+  glassMaterial,
+  glassMaterialPlugin,
+  getABufferSupport,
+  getWBOITSupport,
+  reflectiveMaterial,
+  reflectiveMaterialPlugin,
+  type ABufferShaderModuleProps,
+  type GlassMaterialProps,
+  type ReflectiveMaterialProps,
+  type WBOITShaderModuleProps,
+  wboit,
+  wboitPlugin
+} from '@luma.gl/experimental';
+import type {ShaderModule, ShaderPlugin} from '@luma.gl/shadertools';
+import {Matrix4, radians} from '@math.gl/core';
+import {
+  type Panel,
+  type SettingsChangeDescriptor,
+  type SettingsSchema
+} from '@deck.gl-community/panels';
+import {
+  ExamplePanelManager,
+  ExampleSettingsPanelManager,
+  getChangedSetting,
+  makeExamplePanelHostHtml,
+  makeExampleTabbedPanel,
+  makeHtmlCustomPanel
+} from '../../example-panels';
+
+type Vector3 = [number, number, number];
+type Color = [number, number, number, number];
+type TransparencyMode = 'a-buffer' | 'weighted-blended' | 'sorted-alpha';
+
+type AppUniforms = {
+  cameraPosition: Vector3;
+  projectionMatrix: Matrix4;
+  viewMatrix: Matrix4;
+};
+
+type Packet = {
+  alpha: number;
+  color: Color;
+  launchTime: number;
+  route: Route;
+  scale: number;
+};
+
+type NetworkLink = {
+  color: Color;
+  end: Vector3;
+  endInset: number;
+  start: Vector3;
+  startInset: number;
+};
+
+type Conversation = {
+  color: Color;
+  destinationHostIndex: number;
+  sourceHostIndex: number;
+};
+
+type ConversationRoute = {
+  conversationIndex: number;
+  route: Route;
+};
+
+type Route = {
+  cumulativeLengths: number[];
+  points: Vector3[];
+  totalLength: number;
+};
+
+type GlassInstance = {
+  color: Color;
+  matrix: Matrix4;
+  position: Vector3;
+};
+
+type PickableNetworkNode = {
+  description: string;
+  detail: string;
+  role: string;
+  title: string;
+};
+
+type NetworkNodePickRequest = {
+  canvasPosition: [number, number];
+  clientPosition: [number, number];
+  pointerSequence: number;
+};
+
+const appShaderModule: ShaderModule<AppUniforms> = {
+  name: 'app',
+  uniformTypes: {
+    cameraPosition: 'vec3<f32>',
+    projectionMatrix: 'mat4x4<f32>',
+    viewMatrix: 'mat4x4<f32>'
+  }
+};
+
+const WGSL_SHADER = /* wgsl */ `\
+struct AppUniforms {
+  cameraPosition: vec3<f32>,
+  projectionMatrix: mat4x4<f32>,
+  viewMatrix: mat4x4<f32>,
+};
+
+@group(0) @binding(auto) var<uniform> app: AppUniforms;
+
+struct VertexInputs {
+  @location(0) positions: vec3<f32>,
+  @location(1) normals: vec3<f32>,
+  @location(2) instanceModelMatrixCol0: vec4<f32>,
+  @location(3) instanceModelMatrixCol1: vec4<f32>,
+  @location(4) instanceModelMatrixCol2: vec4<f32>,
+  @location(5) instanceModelMatrixCol3: vec4<f32>,
+  @location(6) instanceColor: vec4<f32>,
+};
+
+struct VertexOutputs {
+  @builtin(position) position: vec4<f32>,
+  @location(0) normal: vec3<f32>,
+  @location(1) color: vec4<f32>,
+  @location(2) worldPosition: vec3<f32>,
+};
+
+@vertex
+fn vertexMain(inputs: VertexInputs) -> VertexOutputs {
+  let modelMatrix = mat4x4<f32>(
+    inputs.instanceModelMatrixCol0,
+    inputs.instanceModelMatrixCol1,
+    inputs.instanceModelMatrixCol2,
+    inputs.instanceModelMatrixCol3
+  );
+  let worldPosition = modelMatrix * vec4<f32>(inputs.positions, 1.0);
+
+  var outputs: VertexOutputs;
+  outputs.position = app.projectionMatrix * app.viewMatrix * worldPosition;
+  let normalMatrix = mat3x3<f32>(
+    cross(modelMatrix[1].xyz, modelMatrix[2].xyz),
+    cross(modelMatrix[2].xyz, modelMatrix[0].xyz),
+    cross(modelMatrix[0].xyz, modelMatrix[1].xyz)
+  );
+  outputs.normal = normalize(normalMatrix * inputs.normals);
+  outputs.color = inputs.instanceColor;
+  outputs.worldPosition = worldPosition.xyz;
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs: VertexOutputs) -> @location(0) vec4<f32> {
+  let lightDirection = normalize(vec3<f32>(0.4, 0.8, 0.65));
+  let light = 0.28 + 0.72 * max(dot(normalize(inputs.normal), lightDirection), 0.0);
+  return vec4<f32>(inputs.color.rgb * light, inputs.color.a);
+}
+`;
+
+const REFLECTIVE_WGSL_SHADER = /* wgsl */ `${WGSL_SHADER}
+@fragment
+fn fragmentReflective(inputs: VertexOutputs) -> @location(0) vec4<f32> {
+  return reflectiveMaterial_getColor(
+    inputs.normal,
+    inputs.worldPosition,
+    inputs.color,
+    app.cameraPosition
+  );
+}
+`;
+
+const GLASS_WGSL_SHADER = /* wgsl */ `${WGSL_SHADER}
+@fragment
+fn fragmentGlass(inputs: VertexOutputs) -> @location(0) vec4<f32> {
+  let color = glassMaterial_getColor(
+    inputs.normal,
+    inputs.worldPosition,
+    inputs.color,
+    app.cameraPosition,
+    inputs.position
+  );
+#if A_BUFFER_ENABLED
+  return aBuffer_captureStraightColor(color, inputs.position);
+#else
+#if WBOIT_ENABLED
+  return wboit_captureStraightColor(color, inputs.position);
+#else
+  return color;
+#endif
+#endif
+}
+`;
+
+const PICKING_WGSL_SHADER = /* wgsl */ `${WGSL_SHADER}
+@fragment
+fn fragmentPicking(inputs: VertexOutputs) -> @location(0) vec4<f32> {
+  return picking_getPickingColor(i32(inputs.color.r));
+}
+`;
+
+const VERTEX_SHADER = /* glsl */ `\
+#version 300 es
+
+in vec3 positions;
+in vec3 normals;
+in vec4 instanceModelMatrixCol0;
+in vec4 instanceModelMatrixCol1;
+in vec4 instanceModelMatrixCol2;
+in vec4 instanceModelMatrixCol3;
+in vec4 instanceColor;
+
+uniform appUniforms {
+  vec3 cameraPosition;
+  mat4 projectionMatrix;
+  mat4 viewMatrix;
+} app;
+
+out vec3 vNormal;
+out vec4 vColor;
+out vec3 vWorldPosition;
+
+void main(void) {
+  mat4 modelMatrix = mat4(
+    instanceModelMatrixCol0,
+    instanceModelMatrixCol1,
+    instanceModelMatrixCol2,
+    instanceModelMatrixCol3
+  );
+  vec4 worldPosition = modelMatrix * vec4(positions, 1.0);
+  gl_Position = app.projectionMatrix * app.viewMatrix * worldPosition;
+  mat3 normalMatrix = mat3(
+    cross(modelMatrix[1].xyz, modelMatrix[2].xyz),
+    cross(modelMatrix[2].xyz, modelMatrix[0].xyz),
+    cross(modelMatrix[0].xyz, modelMatrix[1].xyz)
+  );
+  vNormal = normalize(normalMatrix * normals);
+  vColor = instanceColor;
+  vWorldPosition = worldPosition.xyz;
+}
+`;
+
+const PICKING_VERTEX_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+precision highp int;
+
+in vec3 positions;
+in vec4 instanceModelMatrixCol0;
+in vec4 instanceModelMatrixCol1;
+in vec4 instanceModelMatrixCol2;
+in vec4 instanceModelMatrixCol3;
+in vec4 instanceColor;
+
+uniform appUniforms {
+  vec3 cameraPosition;
+  mat4 projectionMatrix;
+  mat4 viewMatrix;
+} app;
+
+void main(void) {
+  mat4 modelMatrix = mat4(
+    instanceModelMatrixCol0,
+    instanceModelMatrixCol1,
+    instanceModelMatrixCol2,
+    instanceModelMatrixCol3
+  );
+  gl_Position = app.projectionMatrix * app.viewMatrix * modelMatrix * vec4(positions, 1.0);
+  picking_setObjectIndex(int(instanceColor.r));
+}
+`;
+
+const PICKING_FRAGMENT_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+precision highp int;
+
+out vec4 fragColor;
+
+void main(void) {
+  fragColor = picking_getPickingColor();
+}
+`;
+
+const GLASS_FRAGMENT_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+uniform appUniforms {
+  vec3 cameraPosition;
+  mat4 projectionMatrix;
+  mat4 viewMatrix;
+} app;
+
+in vec3 vNormal;
+in vec4 vColor;
+in vec3 vWorldPosition;
+out vec4 fragColor;
+
+void main(void) {
+  vec4 color = glassMaterial_getColor(
+    vNormal,
+    vWorldPosition,
+    vColor,
+    app.cameraPosition,
+    gl_FragCoord
+  );
+#if WBOIT_ENABLED
+  fragColor = wboit_captureStraightColor(color, gl_FragCoord);
+#else
+  fragColor = color;
+#endif
+}
+`;
+
+const FRAGMENT_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+in vec3 vNormal;
+in vec4 vColor;
+out vec4 fragColor;
+
+void main(void) {
+  vec3 lightDirection = normalize(vec3(0.4, 0.8, 0.65));
+  float light = 0.28 + 0.72 * max(dot(normalize(vNormal), lightDirection), 0.0);
+  fragColor = vec4(vColor.rgb * light, vColor.a);
+}
+`;
+
+const REFLECTIVE_FRAGMENT_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+uniform appUniforms {
+  vec3 cameraPosition;
+  mat4 projectionMatrix;
+  mat4 viewMatrix;
+} app;
+
+in vec3 vNormal;
+in vec4 vColor;
+in vec3 vWorldPosition;
+out vec4 fragColor;
+
+void main(void) {
+  fragColor = reflectiveMaterial_getColor(
+    vNormal,
+    vWorldPosition,
+    vColor,
+    app.cameraPosition
+  );
+}
+`;
+
+const INSTANCE_BUFFER_LAYOUT = [
+  {
+    name: 'instanceModelMatrices',
+    stepMode: 'instance' as const,
+    byteStride: 64,
+    attributes: [
+      {attribute: 'instanceModelMatrixCol0', format: 'float32x4' as const, byteOffset: 0},
+      {attribute: 'instanceModelMatrixCol1', format: 'float32x4' as const, byteOffset: 16},
+      {attribute: 'instanceModelMatrixCol2', format: 'float32x4' as const, byteOffset: 32},
+      {attribute: 'instanceModelMatrixCol3', format: 'float32x4' as const, byteOffset: 48}
+    ]
+  },
+  {name: 'instanceColor', format: 'float32x4' as const, stepMode: 'instance' as const}
+];
+
+const HOST_X_POSITIONS = [-3.6, -1.2, 1.2, 3.6];
+const HOST_Z_POSITIONS = [2.4, 0.8, -0.8, -2.4];
+const HOST_Y = -2.75;
+const HOST_HALF_EXTENTS: Vector3 = [0.42, 0.27, 0.32];
+const LEAF_Y = -1.05;
+const LEAF_SWITCH_RADIUS = 0.42;
+const AGGREGATION_Y = 0.35;
+const AGGREGATION_SWITCH_RADIUS = 0.4;
+const SPINE_Y = 2.05;
+const SPINE_SWITCH_RADIUS = 0.55;
+const TRAFFIC_COLORS: Color[] = [
+  [1, 0.16, 0.1, 1],
+  [0.08, 1, 0.34, 1]
+];
+const PACKETS_PER_BURST = 24;
+const BURST_PACKET_INTERVAL = 0.14;
+const BURST_CYCLE_DURATION = 11;
+const PACKET_TRAVEL_SPEED = 3.4;
+
+const HOST_POSITIONS: Vector3[] = HOST_Z_POSITIONS.flatMap(zPosition =>
+  HOST_X_POSITIONS.map(xPosition => [xPosition, HOST_Y, zPosition] as Vector3)
+);
+const LEAF_POSITIONS: Vector3[] = [0.85, -0.85].flatMap(zPosition =>
+  HOST_X_POSITIONS.map(xPosition => [xPosition, LEAF_Y, zPosition] as Vector3)
+);
+const AGGREGATION_POSITIONS: Vector3[] = [0.85, -0.85].flatMap(zPosition =>
+  HOST_X_POSITIONS.map(xPosition => [xPosition, AGGREGATION_Y, zPosition] as Vector3)
+);
+const SPINE_POSITIONS: Vector3[] = HOST_Z_POSITIONS.map(zPosition => [0, SPINE_Y, zPosition]);
+const CONVERSATIONS: Conversation[] = [
+  {sourceHostIndex: 3, destinationHostIndex: 8, color: TRAFFIC_COLORS[0]},
+  {sourceHostIndex: 7, destinationHostIndex: 12, color: TRAFFIC_COLORS[1]}
+];
+
+const TRANSPARENT_PARAMETERS = {
+  blend: true,
+  blendColorOperation: 'add',
+  blendColorSrcFactor: 'src-alpha',
+  blendColorDstFactor: 'one-minus-src-alpha',
+  blendAlphaOperation: 'add',
+  blendAlphaSrcFactor: 'one',
+  blendAlphaDstFactor: 'one-minus-src-alpha',
+  depthWriteEnabled: false,
+  depthCompare: 'less-equal',
+  cullMode: 'none'
+} as const satisfies RenderPipelineParameters;
+
+const networkNodePickingPlugin = {
+  name: 'networkNodePicking',
+  modules: [colorPicking as ShaderModule]
+} as const satisfies ShaderPlugin;
+
+class InstancedMesh<
+  ShaderProps extends Partial<Record<string, Record<string, unknown>>> = {app: AppUniforms}
+> {
+  readonly colorBuffer: Buffer;
+  readonly matrixBuffer: Buffer;
+  readonly model: Model;
+
+  constructor(
+    device: Device,
+    shaderInputs: ShaderInputs<ShaderProps>,
+    {
+      id,
+      geometry,
+      matrices,
+      colors,
+      transparent = false,
+      glass = false,
+      pickable = false,
+      reflective = false,
+      sceneTexture,
+      transparencyMode
+    }: {
+      id: string;
+      geometry: Geometry;
+      matrices: Float32Array;
+      colors: Float32Array;
+      transparent?: boolean;
+      glass?: boolean;
+      pickable?: boolean;
+      reflective?: boolean;
+      sceneTexture?: Texture;
+      transparencyMode?: TransparencyMode;
+    }
+  ) {
+    const usesABuffer = transparencyMode === 'a-buffer';
+    const usesWeightedBlending = transparencyMode === 'weighted-blended';
+    this.matrixBuffer = device.createBuffer(matrices);
+    this.colorBuffer = device.createBuffer(colors);
+    this.model = new Model(device, {
+      id,
+      source: pickable
+        ? PICKING_WGSL_SHADER
+        : glass
+          ? GLASS_WGSL_SHADER
+          : reflective
+            ? REFLECTIVE_WGSL_SHADER
+            : WGSL_SHADER,
+      vs: pickable ? PICKING_VERTEX_SHADER : VERTEX_SHADER,
+      fs: pickable
+        ? PICKING_FRAGMENT_SHADER
+        : glass
+          ? GLASS_FRAGMENT_SHADER
+          : reflective
+            ? REFLECTIVE_FRAGMENT_SHADER
+            : FRAGMENT_SHADER,
+      fragmentEntryPoint: pickable
+        ? 'fragmentPicking'
+        : glass
+          ? 'fragmentGlass'
+          : reflective
+            ? 'fragmentReflective'
+            : 'fragmentMain',
+      shaderInputs,
+      defines: {
+        A_BUFFER_ENABLED: usesABuffer ? 1 : 0,
+        WBOIT_ENABLED: usesWeightedBlending ? 1 : 0
+      },
+      plugins: [
+        ...(pickable ? [networkNodePickingPlugin] : []),
+        ...(glass ? [glassMaterialPlugin] : []),
+        ...(reflective ? [reflectiveMaterialPlugin] : []),
+        ...(usesABuffer ? [aBufferPlugin] : []),
+        ...(usesWeightedBlending ? [wboitPlugin] : [])
+      ],
+      geometry,
+      instanceCount: colors.length / 4,
+      bufferLayout: INSTANCE_BUFFER_LAYOUT,
+      attributes: {
+        instanceModelMatrices: this.matrixBuffer,
+        instanceColor: this.colorBuffer
+      },
+      ...(sceneTexture ? {bindings: {glassSceneColorTexture: sceneTexture}} : {}),
+      ...(pickable
+        ? {
+            colorAttachmentFormats: ['rgba8unorm' as const],
+            depthStencilAttachmentFormat: 'depth24plus' as const
+          }
+        : {}),
+      parameters:
+        transparent || glass
+          ? TRANSPARENT_PARAMETERS
+          : {
+              depthWriteEnabled: true,
+              depthCompare: 'less-equal',
+              cullMode: 'back'
+            }
+    });
+  }
+
+  updateMatrices(matrices: Float32Array): void {
+    this.matrixBuffer.write(matrices);
+  }
+
+  updateInstances(matrices: Float32Array, colors: Float32Array): void {
+    this.matrixBuffer.write(matrices);
+    this.colorBuffer.write(colors);
+  }
+
+  destroy(): void {
+    this.model.destroy();
+    this.matrixBuffer.destroy();
+    this.colorBuffer.destroy();
+  }
+}
+
+class NetworkNodePopup {
+  private readonly popupElement: HTMLDivElement;
+  private readonly titleElement: HTMLDivElement;
+  private readonly roleElement: HTMLDivElement;
+  private readonly descriptionElement: HTMLParagraphElement;
+  private readonly detailElement: HTMLParagraphElement;
+
+  constructor(canvas: HTMLCanvasElement) {
+    this.popupElement = document.createElement('div');
+    this.popupElement.setAttribute('data-packet-spraying-node-popup', '');
+    this.popupElement.setAttribute('role', 'tooltip');
+    this.popupElement.setAttribute('aria-label', 'Network node details');
+    Object.assign(this.popupElement.style, {
+      position: 'fixed',
+      zIndex: '20',
+      display: 'none',
+      width: 'min(280px, calc(100vw - 32px))',
+      padding: '14px 16px',
+      border: '1px solid rgba(132, 161, 205, 0.3)',
+      borderRadius: '8px',
+      background: 'rgba(11, 16, 27, 0.95)',
+      boxShadow: '0 14px 36px rgba(0, 0, 0, 0.36)',
+      color: '#f4f7fb',
+      font: '13px/1.5 system-ui, sans-serif',
+      pointerEvents: 'none'
+    });
+
+    this.titleElement = document.createElement('div');
+    Object.assign(this.titleElement.style, {fontSize: '15px', fontWeight: '650'});
+
+    this.roleElement = document.createElement('div');
+    Object.assign(this.roleElement.style, {
+      marginTop: '2px',
+      color: '#82acf2',
+      fontSize: '12px'
+    });
+
+    this.descriptionElement = document.createElement('p');
+    Object.assign(this.descriptionElement.style, {margin: '10px 0 6px'});
+
+    this.detailElement = document.createElement('p');
+    Object.assign(this.detailElement.style, {margin: '0', color: '#c5d0df'});
+
+    this.popupElement.append(
+      this.titleElement,
+      this.roleElement,
+      this.descriptionElement,
+      this.detailElement
+    );
+    (canvas.parentElement || document.body).appendChild(this.popupElement);
+  }
+
+  show(node: PickableNetworkNode, clientPosition: [number, number]): void {
+    this.titleElement.textContent = node.title;
+    this.roleElement.textContent = node.role;
+    this.descriptionElement.textContent = node.description;
+    this.detailElement.textContent = node.detail;
+    this.popupElement.style.display = 'block';
+
+    const maximumLeft = Math.max(12, window.innerWidth - this.popupElement.offsetWidth - 12);
+    const maximumTop = Math.max(12, window.innerHeight - this.popupElement.offsetHeight - 12);
+    this.popupElement.style.left = `${Math.min(clientPosition[0] + 14, maximumLeft)}px`;
+    this.popupElement.style.top = `${Math.min(clientPosition[1] + 14, maximumTop)}px`;
+  }
+
+  readonly hide = (): void => {
+    this.popupElement.style.display = 'none';
+  };
+
+  destroy(): void {
+    this.popupElement.remove();
+  }
+}
+
+export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTemplate {
+  static info = makeExamplePanelHostHtml();
+
+  readonly shaderInputs = new ShaderInputs<{app: AppUniforms}>({app: appShaderModule});
+  readonly reflectiveShaderInputs = new ShaderInputs<{
+    app: AppUniforms;
+    reflectiveMaterial: ReflectiveMaterialProps;
+  }>({app: appShaderModule, reflectiveMaterial});
+  readonly glassShaderInputs = new ShaderInputs<{
+    app: AppUniforms;
+    glassMaterial: GlassMaterialProps;
+  }>({app: appShaderModule, glassMaterial});
+  readonly aBufferShaderInputs = new ShaderInputs<{
+    app: AppUniforms;
+    glassMaterial: GlassMaterialProps;
+    aBuffer: ABufferShaderModuleProps;
+  }>({app: appShaderModule, glassMaterial, aBuffer});
+  readonly weightedBlendedShaderInputs = new ShaderInputs<{
+    app: AppUniforms;
+    glassMaterial: GlassMaterialProps;
+    wboit: WBOITShaderModuleProps;
+  }>({app: appShaderModule, glassMaterial, wboit});
+  readonly pickingShaderInputs = new ShaderInputs<{
+    app: AppUniforms;
+    picking: typeof colorPicking.props;
+  }>({app: appShaderModule, picking: colorPicking});
+  readonly settingsPanel: ExampleSettingsPanelManager;
+  readonly panels: ExamplePanelManager;
+  readonly sceneFramebuffer: Framebuffer;
+  readonly sceneBackground: BackgroundTextureModel;
+  readonly aBufferRenderer: ABufferRenderer | null;
+  readonly weightedBlendedRenderer: WBOITRenderer | null;
+  sceneTexture: Texture;
+  refractionTexture: Texture;
+  readonly links: InstancedMesh<{
+    app: AppUniforms;
+    reflectiveMaterial: ReflectiveMaterialProps;
+  }>;
+  readonly hosts: InstancedMesh;
+  readonly pickingHosts: InstancedMesh<{
+    app: AppUniforms;
+    picking: typeof colorPicking.props;
+  }>;
+  readonly pickingSwitches: InstancedMesh<{
+    app: AppUniforms;
+    picking: typeof colorPicking.props;
+  }>;
+  readonly pickingManager: PickingManager;
+  readonly pickableNodes: PickableNetworkNode[];
+  readonly glassInstances: GlassInstance[];
+  readonly sortedGlass: InstancedMesh<{
+    app: AppUniforms;
+    glassMaterial: GlassMaterialProps;
+  }>;
+  readonly aBufferGlass: InstancedMesh<{
+    app: AppUniforms;
+    glassMaterial: GlassMaterialProps;
+    aBuffer: ABufferShaderModuleProps;
+  }> | null;
+  readonly weightedBlendedGlass: InstancedMesh<{
+    app: AppUniforms;
+    glassMaterial: GlassMaterialProps;
+    wboit: WBOITShaderModuleProps;
+  }> | null;
+  readonly packets: InstancedMesh;
+  readonly packetDefinitions: Packet[];
+  readonly packetMatrices: Float32Array;
+  orbitControls: OrbitControls | null = null;
+  nodePopup: NetworkNodePopup | null = null;
+
+  private canvas: HTMLCanvasElement | null = null;
+  private pendingPickRequest: NetworkNodePickRequest | null = null;
+  private pickingInProgress = false;
+  private pointerSequence = 0;
+
+  transparencyMode: TransparencyMode;
+  speed = 0.85;
+  orbit = 0.08;
+  glassIndexOfRefraction = 1.48;
+  glassRoughness = 0.14;
+  glassDispersion = 0.022;
+  glassThickness = 1.05;
+
+  constructor({device, width, height}: AnimationProps) {
+    super();
+
+    const supportsABuffer = getABufferSupport(device).supported;
+    const supportsWeightedBlending = getWBOITSupport(device).supported;
+    this.transparencyMode = supportsABuffer
+      ? 'a-buffer'
+      : supportsWeightedBlending
+        ? 'weighted-blended'
+        : 'sorted-alpha';
+    this.aBufferRenderer = supportsABuffer
+      ? new ABufferRenderer(device, {
+          averageFragmentsPerPixel: 6,
+          maxFragmentsPerPixel: 20,
+          maxBufferByteLength: 64 * 1024 * 1024
+        })
+      : null;
+    this.weightedBlendedRenderer = supportsWeightedBlending ? new WBOITRenderer(device) : null;
+    this.sceneTexture = makeSceneTexture(device, width, height);
+    this.refractionTexture = makeRefractionTexture(device, width, height);
+    this.sceneFramebuffer = device.createFramebuffer({
+      id: 'packet-spraying-scene-framebuffer',
+      width,
+      height,
+      colorAttachments: [this.sceneTexture],
+      depthStencilAttachment: 'depth24plus'
+    });
+    this.sceneBackground = new BackgroundTextureModel(device, {
+      id: 'packet-spraying-scene-background',
+      backgroundTexture: this.sceneTexture,
+      flipY: device.type === 'webgpu'
+    });
+
+    const conversationRoutes = makeConversationRoutes();
+    const links = makeLinks(conversationRoutes);
+    this.links = new InstancedMesh(device, this.reflectiveShaderInputs, {
+      id: 'packet-spraying-links',
+      geometry: new CylinderGeometry({radius: 1, height: 1, nradial: 16, nvertical: 1}),
+      matrices: flattenMatrices(links.map(link => makeLinkMatrix(link, 0.07))),
+      colors: flattenColors(links.map(({color}) => color)),
+      transparent: true,
+      reflective: true
+    });
+
+    this.hosts = new InstancedMesh(device, this.shaderInputs, {
+      id: 'packet-spraying-hosts',
+      geometry: new CubeGeometry({indices: true}),
+      matrices: flattenMatrices(
+        HOST_POSITIONS.map(position => makeObjectMatrix(position, HOST_HALF_EXTENTS))
+      ),
+      colors: flattenColors(HOST_POSITIONS.map(() => [0.18, 0.4, 0.92, 1]))
+    });
+
+    this.glassInstances = makeGlassInstances();
+    this.pickableNodes = makePickableNetworkNodes();
+    this.pickingManager = new PickingManager(device, {
+      shaderInputs: this.pickingShaderInputs,
+      mode: 'color'
+    });
+    this.pickingHosts = new InstancedMesh(device, this.pickingShaderInputs, {
+      id: 'packet-spraying-picking-hosts',
+      geometry: new CubeGeometry({indices: true}),
+      matrices: flattenMatrices(
+        HOST_POSITIONS.map(position => makeObjectMatrix(position, HOST_HALF_EXTENTS))
+      ),
+      colors: flattenColors(HOST_POSITIONS.map((_, index) => [index, 0, 0, 1])),
+      pickable: true
+    });
+    this.pickingSwitches = new InstancedMesh(device, this.pickingShaderInputs, {
+      id: 'packet-spraying-picking-switches',
+      geometry: new SphereGeometry({radius: 1, nlat: 16, nlong: 24}),
+      matrices: flattenMatrices(this.glassInstances.map(instance => instance.matrix)),
+      colors: flattenColors(
+        this.glassInstances.map((_, index) => [HOST_POSITIONS.length + index, 0, 0, 1])
+      ),
+      pickable: true
+    });
+    const glassMatrices = flattenMatrices(this.glassInstances.map(instance => instance.matrix));
+    const glassColors = flattenColors(this.glassInstances.map(instance => instance.color));
+    const makeGlassMeshOptions = (id: string, transparencyMode: TransparencyMode) => ({
+      id,
+      geometry: new SphereGeometry({radius: 1, nlat: 16, nlong: 24}),
+      matrices: glassMatrices,
+      colors: glassColors,
+      glass: true,
+      sceneTexture: this.refractionTexture,
+      transparencyMode
+    });
+    this.sortedGlass = new InstancedMesh(
+      device,
+      this.glassShaderInputs,
+      makeGlassMeshOptions('packet-spraying-sorted-glass', 'sorted-alpha')
+    );
+    this.aBufferGlass = supportsABuffer
+      ? new InstancedMesh(
+          device,
+          this.aBufferShaderInputs,
+          makeGlassMeshOptions('packet-spraying-a-buffer-glass', 'a-buffer')
+        )
+      : null;
+    this.weightedBlendedGlass = supportsWeightedBlending
+      ? new InstancedMesh(
+          device,
+          this.weightedBlendedShaderInputs,
+          makeGlassMeshOptions('packet-spraying-weighted-glass', 'weighted-blended')
+        )
+      : null;
+
+    this.packetDefinitions = makePackets(conversationRoutes);
+    this.packetMatrices = new Float32Array(this.packetDefinitions.length * 16);
+    this.updatePacketMatrices(0);
+    this.packets = new InstancedMesh(device, this.shaderInputs, {
+      id: 'packet-spraying-packets',
+      geometry: new SphereGeometry({radius: 1, nlat: 8, nlong: 12}),
+      matrices: this.packetMatrices,
+      colors: flattenColors(
+        this.packetDefinitions.map(packet => [
+          packet.color[0],
+          packet.color[1],
+          packet.color[2],
+          packet.alpha
+        ])
+      )
+    });
+
+    this.settingsPanel = new ExampleSettingsPanelManager({
+      id: 'packet-spraying-settings',
+      schema: makeSettingsSchema(supportsABuffer, supportsWeightedBlending),
+      settings: {
+        transparencyMode: this.transparencyMode,
+        speed: this.speed,
+        orbit: this.orbit,
+        glassIndexOfRefraction: this.glassIndexOfRefraction,
+        glassRoughness: this.glassRoughness,
+        glassDispersion: this.glassDispersion,
+        glassThickness: this.glassThickness
+      },
+      onSettingsChange: this.handleSettingsChange
+    });
+    this.panels = new ExamplePanelManager({panel: this.makePanel()});
+    this.panels.mount();
+  }
+
+  override async onInitialize({canvas}: AnimationProps): Promise<void> {
+    if (canvas instanceof HTMLCanvasElement) {
+      this.canvas = canvas;
+      this.nodePopup = new NetworkNodePopup(canvas);
+      this.orbitControls = new OrbitControls(canvas, {
+        target: [0, -0.9, 0],
+        distance: 12.7,
+        yaw: 0.52,
+        pitch: 0.59,
+        minDistance: 6,
+        maxDistance: 25,
+        minPitch: 0.12,
+        maxPitch: 1.3,
+        autoRotate: this.orbit > 0,
+        autoRotateSpeed: this.orbit
+      });
+      canvas.addEventListener('pointermove', this.handlePointerMove);
+      canvas.addEventListener('pointerdown', this.handlePointerDown);
+      canvas.addEventListener('pointerleave', this.handlePointerLeave);
+    }
+  }
+
+  override onRender({device, width, height, aspect, time}: AnimationProps): void {
+    this.resizeSceneFramebuffer(width, height);
+    const animationTime = time / 1000;
+    this.updatePacketMatrices(animationTime * this.speed);
+    this.packets.updateMatrices(this.packetMatrices);
+
+    this.orbitControls?.update(time);
+    const eye: Vector3 = this.orbitControls?.getEyePosition() || [5.2, 6.2, 9.1];
+    const uniforms: AppUniforms = {
+      cameraPosition: eye,
+      projectionMatrix: new Matrix4().perspective({
+        fovy: radians(aspect < 1 ? 60 : 50),
+        aspect,
+        near: 0.1,
+        far: 60
+      }),
+      viewMatrix: new Matrix4().lookAt({eye, center: [0, -0.9, 0], up: [0, 1, 0]})
+    };
+    const glassMaterialProps: GlassMaterialProps = {
+      viewportSize: [width, height],
+      sceneColorTexture: this.refractionTexture,
+      indexOfRefraction: this.glassIndexOfRefraction,
+      roughness: this.glassRoughness,
+      dispersion: this.glassDispersion,
+      thickness: this.glassThickness
+    };
+    this.shaderInputs.setProps({app: uniforms});
+    this.reflectiveShaderInputs.setProps({app: uniforms, reflectiveMaterial: {}});
+    this.glassShaderInputs.setProps({app: uniforms, glassMaterial: glassMaterialProps});
+
+    this.hosts.model.predraw(device.commandEncoder);
+    this.packets.model.predraw(device.commandEncoder);
+    this.links.model.predraw(device.commandEncoder);
+    const sceneRenderPass = device.beginRenderPass({
+      framebuffer: this.sceneFramebuffer,
+      clearColor: [0.003, 0.006, 0.012, 1],
+      clearDepth: 1
+    });
+    this.hosts.model.draw(sceneRenderPass);
+    this.packets.model.draw(sceneRenderPass);
+    this.links.model.draw(sceneRenderPass);
+    sceneRenderPass.end();
+
+    device.commandEncoder.copyTextureToTexture({
+      sourceTexture: this.sceneTexture,
+      destinationTexture: this.refractionTexture
+    });
+
+    let outputTexture = this.sceneTexture;
+    if (this.transparencyMode === 'a-buffer' && this.aBufferRenderer && this.aBufferGlass) {
+      outputTexture = this.aBufferRenderer.render({
+        sourceTexture: this.sceneTexture,
+        opaqueDepthTexture: this.sceneFramebuffer.depthStencilAttachment!,
+        prepareTranslucent: ({commandEncoder, shaderModuleProps, captureParameters}) => {
+          this.aBufferShaderInputs.setProps({
+            app: uniforms,
+            glassMaterial: glassMaterialProps,
+            aBuffer: shaderModuleProps
+          });
+          this.aBufferGlass?.model.setParameters({...TRANSPARENT_PARAMETERS, ...captureParameters});
+          this.aBufferGlass?.model.predraw(commandEncoder);
+        },
+        drawTranslucent: renderPass => {
+          this.aBufferGlass?.model.draw(renderPass);
+        }
+      });
+    } else if (
+      this.transparencyMode === 'weighted-blended' &&
+      this.weightedBlendedRenderer &&
+      this.weightedBlendedGlass
+    ) {
+      outputTexture = this.weightedBlendedRenderer.render({
+        sourceTexture: this.sceneTexture,
+        prepareOpaqueDepth: commandEncoder => {
+          this.hosts.model.predraw(commandEncoder);
+          this.packets.model.predraw(commandEncoder);
+        },
+        drawOpaqueDepth: renderPass => {
+          this.hosts.model.draw(renderPass);
+          this.packets.model.draw(renderPass);
+        },
+        prepareTranslucent: ({commandEncoder, shaderModuleProps, captureParameters}) => {
+          this.weightedBlendedShaderInputs.setProps({
+            app: uniforms,
+            glassMaterial: glassMaterialProps,
+            wboit: shaderModuleProps
+          });
+          this.weightedBlendedGlass?.model.setParameters({
+            ...TRANSPARENT_PARAMETERS,
+            ...captureParameters
+          });
+          this.weightedBlendedGlass?.model.predraw(commandEncoder);
+        },
+        drawTranslucent: renderPass => {
+          this.weightedBlendedGlass?.model.draw(renderPass);
+        }
+      });
+    } else {
+      this.sortGlassInstances(eye);
+      this.sortedGlass.model.predraw(device.commandEncoder);
+      const glassRenderPass = device.beginRenderPass({
+        framebuffer: this.sceneFramebuffer,
+        clearColor: false,
+        clearDepth: false
+      });
+      this.sortedGlass.model.draw(glassRenderPass);
+      glassRenderPass.end();
+    }
+
+    this.sceneBackground.setProps({backgroundTexture: outputTexture});
+    this.sceneBackground.predraw(device.commandEncoder);
+    const renderPass = device.beginRenderPass({
+      clearColor: [0.003, 0.006, 0.012, 1],
+      clearDepth: 1
+    });
+    this.sceneBackground.draw(renderPass);
+    renderPass.end();
+
+    this.pickHoveredNode(device, uniforms);
+  }
+
+  override onFinalize(): void {
+    this.canvas?.removeEventListener('pointermove', this.handlePointerMove);
+    this.canvas?.removeEventListener('pointerdown', this.handlePointerDown);
+    this.canvas?.removeEventListener('pointerleave', this.handlePointerLeave);
+    this.nodePopup?.destroy();
+    this.settingsPanel.finalize();
+    this.panels.finalize();
+    this.orbitControls?.destroy();
+    this.links.destroy();
+    this.hosts.destroy();
+    this.pickingHosts.destroy();
+    this.pickingSwitches.destroy();
+    this.pickingManager.destroy();
+    this.sortedGlass.destroy();
+    this.aBufferGlass?.destroy();
+    this.weightedBlendedGlass?.destroy();
+    this.packets.destroy();
+    this.sceneBackground.destroy();
+    this.aBufferRenderer?.destroy();
+    this.weightedBlendedRenderer?.destroy();
+    this.shaderInputs.destroy();
+    this.reflectiveShaderInputs.destroy();
+    this.pickingShaderInputs.destroy();
+    this.glassShaderInputs.destroy();
+    this.aBufferShaderInputs.destroy();
+    this.weightedBlendedShaderInputs.destroy();
+    this.sceneFramebuffer.destroy();
+    this.sceneTexture.destroy();
+    this.refractionTexture.destroy();
+  }
+
+  private pickHoveredNode(device: Device, uniforms: AppUniforms): void {
+    if (!this.pendingPickRequest || this.pickingInProgress) {
+      return;
+    }
+
+    const pickRequest = this.pendingPickRequest;
+    this.pendingPickRequest = null;
+    if (!this.pickingManager.shouldPick(pickRequest.canvasPosition)) {
+      return;
+    }
+
+    this.pickingInProgress = true;
+    this.pickingShaderInputs.setProps({
+      app: uniforms,
+      picking: {indexMode: 'attribute', batchIndex: 0}
+    });
+    this.pickingHosts.model.predraw(device.commandEncoder);
+    this.pickingSwitches.model.predraw(device.commandEncoder);
+    const pickingPass = this.pickingManager.beginRenderPass();
+    this.pickingHosts.model.draw(pickingPass);
+    this.pickingSwitches.model.draw(pickingPass);
+    pickingPass.end();
+
+    // WebGPU texture readback submits its own encoder, so let the animation loop submit first.
+    void Promise.resolve()
+      .then(() => this.pickingManager.updatePickInfo(pickRequest.canvasPosition))
+      .then(pickInfo => {
+        if (pickRequest.pointerSequence !== this.pointerSequence) {
+          return;
+        }
+
+        const objectIndex = pickInfo?.objectIndex;
+        const node =
+          objectIndex === null || objectIndex === undefined
+            ? undefined
+            : this.pickableNodes[objectIndex];
+        if (node) {
+          this.nodePopup?.show(node, pickRequest.clientPosition);
+          if (this.canvas) {
+            this.canvas.style.cursor = 'pointer';
+          }
+        } else {
+          this.nodePopup?.hide();
+          if (this.canvas) {
+            this.canvas.style.cursor = 'grab';
+          }
+        }
+      })
+      .finally(() => {
+        this.pickingInProgress = false;
+      });
+  }
+
+  private readonly handlePointerMove = (event: PointerEvent): void => {
+    if (!this.canvas || event.buttons !== 0) {
+      this.handlePointerLeave();
+      return;
+    }
+
+    const bounds = this.canvas.getBoundingClientRect();
+    this.pendingPickRequest = {
+      canvasPosition: [event.clientX - bounds.left, event.clientY - bounds.top],
+      clientPosition: [event.clientX, event.clientY],
+      pointerSequence: ++this.pointerSequence
+    };
+  };
+
+  private readonly handlePointerDown = (): void => {
+    this.handlePointerLeave();
+  };
+
+  private readonly handlePointerLeave = (): void => {
+    this.pointerSequence++;
+    this.pendingPickRequest = null;
+    this.pickingManager.clearPickState();
+    this.nodePopup?.hide();
+  };
+
+  private resizeSceneFramebuffer(width: number, height: number): void {
+    if (this.sceneFramebuffer.width === width && this.sceneFramebuffer.height === height) {
+      return;
+    }
+
+    const previousSceneTexture = this.sceneTexture;
+    const previousRefractionTexture = this.refractionTexture;
+    this.sceneFramebuffer.resize({width, height});
+    this.sceneTexture = this.sceneFramebuffer.colorAttachments[0].texture;
+    this.refractionTexture = makeRefractionTexture(this.sceneTexture.device, width, height);
+    this.sortedGlass.model.setBindings({glassSceneColorTexture: this.refractionTexture});
+    this.aBufferGlass?.model.setBindings({glassSceneColorTexture: this.refractionTexture});
+    this.weightedBlendedGlass?.model.setBindings({glassSceneColorTexture: this.refractionTexture});
+    previousSceneTexture.destroy();
+    previousRefractionTexture.destroy();
+  }
+
+  private sortGlassInstances(cameraPosition: Vector3): void {
+    const sortedInstances = [...this.glassInstances].sort(
+      (first, second) =>
+        getDistanceSquared(second.position, cameraPosition) -
+        getDistanceSquared(first.position, cameraPosition)
+    );
+    this.sortedGlass.updateInstances(
+      flattenMatrices(sortedInstances.map(instance => instance.matrix)),
+      flattenColors(sortedInstances.map(instance => instance.color))
+    );
+  }
+
+  private updatePacketMatrices(animationTime: number): void {
+    for (let packetIndex = 0; packetIndex < this.packetDefinitions.length; packetIndex++) {
+      const packet = this.packetDefinitions[packetIndex];
+      const packetAge = wrap(animationTime - packet.launchTime, BURST_CYCLE_DURATION);
+      const packetDistance = packetAge * PACKET_TRAVEL_SPEED;
+      const position: Vector3 =
+        packetDistance <= packet.route.totalLength
+          ? getPointAlongRoute(packet.route, packetDistance / packet.route.totalLength)
+          : [0, -100, 0];
+      const matrix = makeObjectMatrix(position, [packet.scale, packet.scale, packet.scale]);
+      this.packetMatrices.set(matrix, packetIndex * 16);
+    }
+  }
+
+  private makePanel(): Panel {
+    return makeExampleTabbedPanel({
+      id: 'packet-spraying-info',
+      title: 'Network Packet Spraying',
+      panels: [
+        makeHtmlCustomPanel({
+          id: 'packet-spraying-overview',
+          title: 'Overview',
+          html: PACKET_SPRAYING_OVERVIEW_HTML
+        }),
+        this.settingsPanel.makePanel(),
+        makeHtmlCustomPanel({
+          id: 'packet-spraying-mrc',
+          title: 'MRC Explained',
+          html: PACKET_SPRAYING_BACKGROUND_HTML
+        })
+      ]
+    });
+  }
+
+  private readonly handleSettingsChange = (
+    _settings: Record<string, unknown>,
+    changedSettings?: SettingsChangeDescriptor[]
+  ): void => {
+    const transparencyMode = getChangedSetting(changedSettings, 'transparencyMode')?.nextValue;
+    if (isTransparencyMode(transparencyMode)) {
+      this.transparencyMode = transparencyMode;
+    }
+
+    const speed = getChangedSetting(changedSettings, 'speed')?.nextValue;
+    if (typeof speed === 'number') {
+      this.speed = speed;
+    }
+
+    const orbit = getChangedSetting(changedSettings, 'orbit')?.nextValue;
+    if (typeof orbit === 'number') {
+      this.orbit = orbit;
+      if (this.orbitControls) {
+        this.orbitControls.props.autoRotateSpeed = orbit;
+        this.orbitControls.setAutoRotate(orbit > 0);
+      }
+    }
+
+    const glassIndexOfRefraction = getChangedSetting(
+      changedSettings,
+      'glassIndexOfRefraction'
+    )?.nextValue;
+    if (typeof glassIndexOfRefraction === 'number') {
+      this.glassIndexOfRefraction = glassIndexOfRefraction;
+    }
+
+    const glassRoughness = getChangedSetting(changedSettings, 'glassRoughness')?.nextValue;
+    if (typeof glassRoughness === 'number') {
+      this.glassRoughness = glassRoughness;
+    }
+
+    const glassDispersion = getChangedSetting(changedSettings, 'glassDispersion')?.nextValue;
+    if (typeof glassDispersion === 'number') {
+      this.glassDispersion = glassDispersion;
+    }
+
+    const glassThickness = getChangedSetting(changedSettings, 'glassThickness')?.nextValue;
+    if (typeof glassThickness === 'number') {
+      this.glassThickness = glassThickness;
+    }
+  };
+}
+
+const PACKET_SPRAYING_ARTICLE_URL = 'https://openai.com/index/mrc-supercomputer-networking/';
+
+const PACKET_SPRAYING_OVERVIEW_HTML = `\
+<p><strong>Two conversations, many routes.</strong> The two servers on the right send independent red and green transfers to two destination servers on the left.</p>
+<p>Packets enter their local Tier 0 switch as separate streams. Once the streams meet, the switch forwards alternating red and green packets across four representative independent network planes. The destination-side switches separate the traffic again and deliver each color to its intended server.</p>
+<p>Blue cubes are servers, glass spheres are switches, and faint tubes show the available fabric links. Only the links needed by the two conversations carry moving packets.</p>
+<p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Read OpenAI's supercomputer networking and MRC article</a></p>`;
+
+const PACKET_SPRAYING_BACKGROUND_HTML = `\
+<p><strong>Multipath Reliable Connection (MRC)</strong> extends RDMA over Converged Ethernet so a single transfer is no longer pinned to one network path.</p>
+<p><strong>How the two conversations mix:</strong> the red source talks to one destination, and the green source talks to another. Their packets can share the same switch-to-switch link, interleaving one red packet with one green packet before being separated near their destinations.</p>
+<p><strong>Planes and packet spraying:</strong> a high-bandwidth network interface can be split across multiple independent physical planes. In the article's example, an 800 Gb/s interface becomes eight 100 Gb/s connections. This visualization shows four representative paths; each conversation sprays successive packets across all four instead of waiting behind one busy link.</p>
+<p><strong>Throughput:</strong> using many paths at once balances traffic, avoids persistent hot spots, and reduces worst-case transfer latency. That matters for synchronous AI training because an entire GPU group can wait for its slowest communication.</p>
+<p><strong>Resilience:</strong> if a link, plane, or switch fails, the sender quickly retires the affected path and keeps using the remaining ones. Losing one of eight interface links reduces peak physical bandwidth by one eighth instead of crashing the training job.</p>
+<p><strong>Source routing:</strong> MRC uses IPv6 Segment Routing (SRv6) to encode a packet's chosen switch sequence. This allows static switch configuration, rapid rerouting, and a simpler control plane without waiting for dynamic routing convergence.</p>
+<p><strong>Rendering:</strong> this example composes reusable glass and reflective-material shader modules with exact A-buffer OIT, weighted-blended OIT, or depth-sorted alpha blending.</p>
+<p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Supercomputer networking to accelerate large scale AI training</a></p>`;
+
+function makeLinks(conversationRoutes: ConversationRoute[]): NetworkLink[] {
+  const links: NetworkLink[] = [];
+  const activeLinkKeys = new Set<string>();
+
+  for (const {route} of conversationRoutes) {
+    for (let pointIndex = 0; pointIndex < route.points.length - 1; pointIndex++) {
+      activeLinkKeys.add(makeLinkKey(route.points[pointIndex], route.points[pointIndex + 1]));
+    }
+  }
+
+  for (let hostIndex = 0; hostIndex < HOST_POSITIONS.length; hostIndex++) {
+    const rowIndex = Math.floor(hostIndex / HOST_X_POSITIONS.length);
+    const columnIndex = hostIndex % HOST_X_POSITIONS.length;
+    const leafRowOffset = rowIndex < 2 ? 0 : HOST_X_POSITIONS.length;
+    const start = HOST_POSITIONS[hostIndex];
+    const end = LEAF_POSITIONS[leafRowOffset + columnIndex];
+    links.push({
+      start,
+      end,
+      startInset: getBoxSurfaceDistance(start, end, HOST_HALF_EXTENTS),
+      endInset: LEAF_SWITCH_RADIUS,
+      color: activeLinkKeys.has(makeLinkKey(start, end))
+        ? [0.43, 0.61, 0.91, 0.2]
+        : [0.3, 0.42, 0.66, 0.045]
+    });
+  }
+
+  for (let rowIndex = 0; rowIndex < 2; rowIndex++) {
+    const rowOffset = rowIndex * HOST_X_POSITIONS.length;
+    for (let leafColumnIndex = 0; leafColumnIndex < HOST_X_POSITIONS.length; leafColumnIndex++) {
+      for (
+        let aggregationColumnIndex = 0;
+        aggregationColumnIndex < HOST_X_POSITIONS.length;
+        aggregationColumnIndex++
+      ) {
+        const start = LEAF_POSITIONS[rowOffset + leafColumnIndex];
+        const end = AGGREGATION_POSITIONS[rowOffset + aggregationColumnIndex];
+        links.push({
+          start,
+          end,
+          startInset: LEAF_SWITCH_RADIUS,
+          endInset: AGGREGATION_SWITCH_RADIUS,
+          color: activeLinkKeys.has(makeLinkKey(start, end))
+            ? [0.45, 0.61, 0.91, 0.18]
+            : [0.3, 0.42, 0.66, 0.038]
+        });
+      }
+    }
+  }
+
+  for (const aggregationPosition of AGGREGATION_POSITIONS) {
+    for (let spineIndex = 0; spineIndex < SPINE_POSITIONS.length; spineIndex++) {
+      const end = SPINE_POSITIONS[spineIndex];
+      links.push({
+        start: aggregationPosition,
+        end,
+        startInset: AGGREGATION_SWITCH_RADIUS,
+        endInset: SPINE_SWITCH_RADIUS,
+        color: activeLinkKeys.has(makeLinkKey(aggregationPosition, end))
+          ? [0.47, 0.64, 0.93, 0.16]
+          : [0.3, 0.42, 0.66, 0.034]
+      });
+    }
+  }
+
+  return links;
+}
+
+function makeGlassInstances(): GlassInstance[] {
+  const makeInstance = (position: Vector3, radius: number, color: Color): GlassInstance => ({
+    position,
+    matrix: makeObjectMatrix(position, [radius, radius, radius]),
+    color
+  });
+
+  return [
+    ...LEAF_POSITIONS.map(position =>
+      makeInstance(position, LEAF_SWITCH_RADIUS, [0.28, 0.48, 0.82, 0.3])
+    ),
+    ...AGGREGATION_POSITIONS.map(position =>
+      makeInstance(position, AGGREGATION_SWITCH_RADIUS, [0.3, 0.5, 0.86, 0.3])
+    ),
+    ...SPINE_POSITIONS.map(position =>
+      makeInstance(position, SPINE_SWITCH_RADIUS, [0.3, 0.5, 0.9, 0.34])
+    )
+  ];
+}
+
+function makePickableNetworkNodes(): PickableNetworkNode[] {
+  const servers = HOST_POSITIONS.map((_, hostIndex) => {
+    const sourceConversationIndex = CONVERSATIONS.findIndex(
+      conversation => conversation.sourceHostIndex === hostIndex
+    );
+    const destinationConversationIndex = CONVERSATIONS.findIndex(
+      conversation => conversation.destinationHostIndex === hostIndex
+    );
+    const rowIndex = Math.floor(hostIndex / HOST_X_POSITIONS.length) + 1;
+    const columnIndex = (hostIndex % HOST_X_POSITIONS.length) + 1;
+
+    if (sourceConversationIndex >= 0) {
+      const trafficColor = sourceConversationIndex === 0 ? 'red' : 'green';
+      return {
+        title: `Server ${hostIndex + 1}`,
+        role: `${trafficColor.toUpperCase()} source / grid row ${rowIndex}, column ${columnIndex}`,
+        description: `This server originates the ${trafficColor} transfer and sends its packets to a local Tier 0 switch.`,
+        detail:
+          'The outgoing stream is sprayed across independent network planes after meeting the other conversation.'
+      };
+    }
+
+    if (destinationConversationIndex >= 0) {
+      const trafficColor = destinationConversationIndex === 0 ? 'red' : 'green';
+      return {
+        title: `Server ${hostIndex + 1}`,
+        role: `${trafficColor.toUpperCase()} destination / grid row ${rowIndex}, column ${columnIndex}`,
+        description: `This server receives the ${trafficColor} transfer after the destination-side switches separate the interleaved streams.`,
+        detail:
+          'MRC writes each packet to its final memory address, so packets can arrive through different paths and out of order.'
+      };
+    }
+
+    return {
+      title: `Server ${hostIndex + 1}`,
+      role: `Available compute server / grid row ${rowIndex}, column ${columnIndex}`,
+      description:
+        'This server represents another GPU host connected to the same resilient network fabric.',
+      detail:
+        'It is not part of the two active conversations, so its links do not carry moving packets.'
+    };
+  });
+
+  const leafSwitches = LEAF_POSITIONS.map((_, switchIndex) => {
+    const side = switchIndex < HOST_X_POSITIONS.length ? 'source' : 'destination';
+    const columnIndex = (switchIndex % HOST_X_POSITIONS.length) + 1;
+    return {
+      title: `Tier 0 access switch ${switchIndex + 1}`,
+      role: `${side.toUpperCase()} side / server column ${columnIndex}`,
+      description:
+        side === 'source'
+          ? 'This switch gathers outgoing server traffic and forwards packets toward the independent planes.'
+          : 'This switch separates returning red and green packets and delivers each stream to the correct destination server.',
+      detail:
+        'Multiple local servers share the access tier; only the active source and destination paths carry packets.'
+    };
+  });
+
+  const aggregationSwitches = AGGREGATION_POSITIONS.map((_, switchIndex) => {
+    const planeIndex = (switchIndex % HOST_X_POSITIONS.length) + 1;
+    const side = switchIndex < HOST_X_POSITIONS.length ? 'ingress' : 'egress';
+    return {
+      title: `Plane ${planeIndex} ${side} switch`,
+      role: `Tier 1 switch / independent network plane ${planeIndex}`,
+      description:
+        side === 'ingress'
+          ? 'This ingress switch accepts alternating red and green packets from the source-side access tier.'
+          : 'This egress switch receives the mixed packet stream and forwards each packet toward its destination.',
+      detail: `Plane ${planeIndex} can continue carrying traffic independently of the other planes.`
+    };
+  });
+
+  const spineSwitches = SPINE_POSITIONS.map((_, switchIndex) => ({
+    title: `Spine switch ${switchIndex + 1}`,
+    role: `Fabric backbone / independent network plane ${switchIndex + 1}`,
+    description:
+      'This spine connects the ingress and egress sides of one independent routing plane.',
+    detail:
+      'Both conversations can share this path, interleaving one red packet with one green packet while other planes carry additional packets.'
+  }));
+
+  return [...servers, ...leafSwitches, ...aggregationSwitches, ...spineSwitches];
+}
+
+function makeConversationRoutes(): ConversationRoute[] {
+  const conversationRoutes: ConversationRoute[] = [];
+  for (let conversationIndex = 0; conversationIndex < CONVERSATIONS.length; conversationIndex++) {
+    const conversation = CONVERSATIONS[conversationIndex];
+    const sourceColumnIndex = conversation.sourceHostIndex % HOST_X_POSITIONS.length;
+    const destinationColumnIndex = conversation.destinationHostIndex % HOST_X_POSITIONS.length;
+    for (let spineIndex = 0; spineIndex < SPINE_POSITIONS.length; spineIndex++) {
+      conversationRoutes.push({
+        conversationIndex,
+        route: makeRoute([
+          HOST_POSITIONS[conversation.sourceHostIndex],
+          LEAF_POSITIONS[sourceColumnIndex],
+          AGGREGATION_POSITIONS[spineIndex],
+          SPINE_POSITIONS[spineIndex],
+          AGGREGATION_POSITIONS[HOST_X_POSITIONS.length + spineIndex],
+          LEAF_POSITIONS[HOST_X_POSITIONS.length + destinationColumnIndex],
+          HOST_POSITIONS[conversation.destinationHostIndex]
+        ])
+      });
+    }
+  }
+
+  return conversationRoutes;
+}
+
+function makePackets(conversationRoutes: ConversationRoute[]): Packet[] {
+  const packets: Packet[] = [];
+
+  for (let conversationIndex = 0; conversationIndex < CONVERSATIONS.length; conversationIndex++) {
+    const conversation = CONVERSATIONS[conversationIndex];
+    const routes = conversationRoutes.filter(
+      route => route.conversationIndex === conversationIndex
+    );
+    for (let packetIndex = 0; packetIndex < PACKETS_PER_BURST; packetIndex++) {
+      const {route} = routes[packetIndex % routes.length];
+      const sourceTravelTime = getDistance(route.points[0], route.points[1]) / PACKET_TRAVEL_SPEED;
+      const launchTime =
+        1 +
+        packetIndex * BURST_PACKET_INTERVAL +
+        (conversationIndex * BURST_PACKET_INTERVAL) / CONVERSATIONS.length -
+        sourceTravelTime;
+      packets.push({
+        route,
+        color: conversation.color,
+        launchTime,
+        scale: 0.115,
+        alpha: 1
+      });
+    }
+  }
+
+  return packets;
+}
+
+function makeLinkKey(start: Vector3, end: Vector3): string {
+  const startKey = start.join(',');
+  const endKey = end.join(',');
+  return startKey < endKey ? `${startKey}:${endKey}` : `${endKey}:${startKey}`;
+}
+
+function makeSceneTexture(device: Device, width: number, height: number): Texture {
+  return device.createTexture({
+    id: 'packet-spraying-scene-color',
+    format: device.type === 'webgpu' ? device.preferredColorFormat : 'rgba8unorm',
+    width,
+    height,
+    usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_SRC,
+    sampler: {
+      minFilter: 'linear',
+      magFilter: 'linear',
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'clamp-to-edge'
+    }
+  });
+}
+
+function makeRefractionTexture(device: Device, width: number, height: number): Texture {
+  return device.createTexture({
+    id: 'packet-spraying-refraction-color',
+    format: device.type === 'webgpu' ? device.preferredColorFormat : 'rgba8unorm',
+    width,
+    height,
+    usage: Texture.SAMPLE | Texture.COPY_DST,
+    sampler: {
+      minFilter: 'linear',
+      magFilter: 'linear',
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'clamp-to-edge'
+    }
+  });
+}
+
+function makeRoute(points: Vector3[]): Route {
+  const cumulativeLengths = [0];
+  let totalLength = 0;
+  for (let pointIndex = 1; pointIndex < points.length; pointIndex++) {
+    totalLength += getDistance(points[pointIndex - 1], points[pointIndex]);
+    cumulativeLengths.push(totalLength);
+  }
+  return {points, cumulativeLengths, totalLength};
+}
+
+function getPointAlongRoute(route: Route, progress: number): Vector3 {
+  const distance = progress * route.totalLength;
+  let segmentIndex = 0;
+  while (
+    segmentIndex < route.cumulativeLengths.length - 2 &&
+    route.cumulativeLengths[segmentIndex + 1] < distance
+  ) {
+    segmentIndex++;
+  }
+
+  const startDistance = route.cumulativeLengths[segmentIndex];
+  const endDistance = route.cumulativeLengths[segmentIndex + 1];
+  const segmentProgress = (distance - startDistance) / (endDistance - startDistance);
+  const start = route.points[segmentIndex];
+  const end = route.points[segmentIndex + 1];
+  return [
+    start[0] + (end[0] - start[0]) * segmentProgress,
+    start[1] + (end[1] - start[1]) * segmentProgress,
+    start[2] + (end[2] - start[2]) * segmentProgress
+  ];
+}
+
+function makeObjectMatrix(position: Vector3, scale: Vector3): Matrix4 {
+  return new Matrix4().translate(position).scale(scale);
+}
+
+function makeLinkMatrix(link: NetworkLink, radius: number): Matrix4 {
+  const distance = getDistance(link.start, link.end);
+  const direction: Vector3 = [
+    (link.end[0] - link.start[0]) / distance,
+    (link.end[1] - link.start[1]) / distance,
+    (link.end[2] - link.start[2]) / distance
+  ];
+  const start: Vector3 = [
+    link.start[0] + direction[0] * link.startInset,
+    link.start[1] + direction[1] * link.startInset,
+    link.start[2] + direction[2] * link.startInset
+  ];
+  const end: Vector3 = [
+    link.end[0] - direction[0] * link.endInset,
+    link.end[1] - direction[1] * link.endInset,
+    link.end[2] - direction[2] * link.endInset
+  ];
+  return makeSegmentMatrix(start, end, radius);
+}
+
+function makeSegmentMatrix(start: Vector3, end: Vector3, radius: number): Matrix4 {
+  const direction: Vector3 = [end[0] - start[0], end[1] - start[1], end[2] - start[2]];
+  const length = Math.hypot(direction[0], direction[1], direction[2]);
+  const normalizedDirection: Vector3 = [
+    direction[0] / length,
+    direction[1] / length,
+    direction[2] / length
+  ];
+  const midpoint: Vector3 = [
+    (start[0] + end[0]) / 2,
+    (start[1] + end[1]) / 2,
+    (start[2] + end[2]) / 2
+  ];
+  const rotationAxis: Vector3 = [normalizedDirection[2], 0, -normalizedDirection[0]];
+  const axisLength = Math.hypot(rotationAxis[0], rotationAxis[2]);
+  const matrix = new Matrix4().translate(midpoint);
+
+  if (axisLength > 0.00001) {
+    matrix.rotateAxis(Math.acos(normalizedDirection[1]), [
+      rotationAxis[0] / axisLength,
+      0,
+      rotationAxis[2] / axisLength
+    ]);
+  } else if (normalizedDirection[1] < 0) {
+    matrix.rotateX(Math.PI);
+  }
+
+  return matrix.scale([radius, length, radius]);
+}
+
+function flattenMatrices(matrices: Matrix4[]): Float32Array {
+  const values = new Float32Array(matrices.length * 16);
+  matrices.forEach((matrix, matrixIndex) => values.set(matrix, matrixIndex * 16));
+  return values;
+}
+
+function flattenColors(colors: Color[]): Float32Array {
+  return new Float32Array(colors.flat());
+}
+
+function getDistance(start: Vector3, end: Vector3): number {
+  return Math.hypot(end[0] - start[0], end[1] - start[1], end[2] - start[2]);
+}
+
+function getDistanceSquared(start: Vector3, end: Vector3): number {
+  const differenceX = end[0] - start[0];
+  const differenceY = end[1] - start[1];
+  const differenceZ = end[2] - start[2];
+  return differenceX * differenceX + differenceY * differenceY + differenceZ * differenceZ;
+}
+
+function getBoxSurfaceDistance(start: Vector3, end: Vector3, halfExtents: Vector3): number {
+  const distance = getDistance(start, end);
+  const direction: Vector3 = [
+    (end[0] - start[0]) / distance,
+    (end[1] - start[1]) / distance,
+    (end[2] - start[2]) / distance
+  ];
+  return Math.min(
+    direction[0] === 0 ? Infinity : halfExtents[0] / Math.abs(direction[0]),
+    direction[1] === 0 ? Infinity : halfExtents[1] / Math.abs(direction[1]),
+    direction[2] === 0 ? Infinity : halfExtents[2] / Math.abs(direction[2])
+  );
+}
+
+function wrap(value: number, limit: number): number {
+  return ((value % limit) + limit) % limit;
+}
+
+function isTransparencyMode(value: unknown): value is TransparencyMode {
+  return value === 'a-buffer' || value === 'weighted-blended' || value === 'sorted-alpha';
+}
+
+function makeSettingsSchema(
+  supportsABuffer: boolean,
+  supportsWeightedBlending: boolean
+): SettingsSchema {
+  return {
+    title: 'Settings',
+    sections: [
+      {
+        id: 'rendering',
+        name: 'Rendering',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'transparencyMode',
+            label: 'Transparency',
+            type: 'select',
+            persist: 'none',
+            options: [
+              ...(supportsABuffer ? [{label: 'Exact A-buffer OIT', value: 'a-buffer'}] : []),
+              ...(supportsWeightedBlending
+                ? [{label: 'Weighted blended OIT', value: 'weighted-blended'}]
+                : []),
+              {label: 'Depth-sorted alpha', value: 'sorted-alpha'}
+            ]
+          }
+        ]
+      },
+      {
+        id: 'animation',
+        name: 'Animation',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'speed',
+            label: 'Packet Speed',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2,
+            step: 0.05
+          },
+          {
+            name: 'orbit',
+            label: 'Camera Orbit',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 0.5,
+            step: 0.01
+          }
+        ]
+      },
+      {
+        id: 'glass',
+        name: 'Glass Material',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'glassIndexOfRefraction',
+            label: 'Index of Refraction',
+            type: 'number',
+            persist: 'none',
+            min: 1.01,
+            max: 2.2,
+            step: 0.01
+          },
+          {
+            name: 'glassRoughness',
+            label: 'Roughness',
+            type: 'number',
+            persist: 'none',
+            min: 0.02,
+            max: 0.8,
+            step: 0.01
+          },
+          {
+            name: 'glassDispersion',
+            label: 'Chromatic Dispersion',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 0.08,
+            step: 0.002
+          },
+          {
+            name: 'glassThickness',
+            label: 'Thickness',
+            type: 'number',
+            persist: 'none',
+            min: 0.2,
+            max: 2.5,
+            step: 0.05
+          }
+        ]
+      }
+    ]
+  };
+}

--- a/examples/showcase/packet-spraying/index.html
+++ b/examples/showcase/packet-spraying/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script type="module">
+    import {makeAnimationLoop} from '@luma.gl/engine';
+    import {webgl2Adapter} from '@luma.gl/webgl';
+    import {webgpuAdapter} from '@luma.gl/webgpu';
+    import AnimationLoopTemplate from './app.ts';
+
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
+      adapters: [webgpuAdapter, webgl2Adapter]
+    });
+    animationLoop.start();
+  </script>
+  <style>
+    html,
+    body {
+      height: 100%;
+    }
+
+    body {
+      background: #010207;
+      margin: 0;
+      overflow: hidden;
+    }
+
+    canvas {
+      height: 100% !important;
+      width: 100% !important;
+    }
+
+  </style>
+</head>
+<body>
+</body>

--- a/examples/showcase/packet-spraying/package.json
+++ b/examples/showcase/packet-spraying/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "luma.gl-examples-showcase-packet-spraying",
+  "version": "9.4.0-alpha.1",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "tsc && vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
+    "@luma.gl/core": "9.4.0-alpha.1",
+    "@luma.gl/engine": "9.4.0-alpha.1",
+    "@luma.gl/experimental": "9.4.0-alpha.1",
+    "@luma.gl/shadertools": "9.4.0-alpha.1",
+    "@luma.gl/webgl": "9.4.0-alpha.1",
+    "@luma.gl/webgpu": "9.4.0-alpha.1",
+    "@math.gl/core": "^4.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3",
+    "vite": "^8.0.0"
+  }
+}

--- a/examples/showcase/packet-spraying/tsconfig.json
+++ b/examples/showcase/packet-spraying/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["."]
+}

--- a/examples/showcase/packet-spraying/vite.config.ts
+++ b/examples/showcase/packet-spraying/vite.config.ts
@@ -1,0 +1,16 @@
+import {defineConfig} from 'vite';
+
+const alias = {
+  '@luma.gl/core': `${__dirname}/../../../modules/core/src`,
+  '@luma.gl/engine': `${__dirname}/../../../modules/engine/src`,
+  '@luma.gl/experimental': `${__dirname}/../../../modules/experimental/src`,
+  '@luma.gl/shadertools': `${__dirname}/../../../modules/shadertools/src`,
+  '@luma.gl/webgl/constants': `${__dirname}/../../../modules/webgl/src/constants`,
+  '@luma.gl/webgl': `${__dirname}/../../../modules/webgl/src`,
+  '@luma.gl/webgpu': `${__dirname}/../../../modules/webgpu/src`
+};
+
+export default defineConfig({
+  resolve: {alias},
+  server: {open: true}
+});

--- a/modules/experimental/README.md
+++ b/modules/experimental/README.md
@@ -8,6 +8,7 @@ These are experimental features that may change or be removed at any time. Use a
 
 The package currently includes experimental GPU command graphs and data-parallel primitives such
 as scan, compaction, and stable key/value sort,
-order-independent transparency renderers, packed pixel-format helpers, and v10 work-in-progress
-WebGL-only WebXR session, frame, and raw camera helpers. See the
+order-independent transparency renderers, composable cross-backend glass and reflective-material
+shader modules, packed pixel-format helpers, and v10 work-in-progress WebGL-only WebXR session,
+frame, and raw camera helpers. See the
 [luma.gl API reference](https://luma.gl/docs/api-reference/experimental) for documentation.

--- a/modules/experimental/src/index.ts
+++ b/modules/experimental/src/index.ts
@@ -9,6 +9,19 @@ export {TEXTURE_FORMAT_PIXEL_DECODERS} from './textures/packed-pixels';
 export type {HTMLTextureProps} from './textures/html-texture';
 export {HTMLTexture} from './textures/html-texture';
 
+export {opticalLighting} from './materials/optical-lighting';
+export type {
+  GlassMaterialBindings,
+  GlassMaterialProps,
+  GlassMaterialUniforms
+} from './materials/glass-material';
+export {glassMaterial, glassMaterialPlugin} from './materials/glass-material';
+export type {
+  ReflectiveMaterialProps,
+  ReflectiveMaterialUniforms
+} from './materials/reflective-material';
+export {reflectiveMaterial, reflectiveMaterialPlugin} from './materials/reflective-material';
+
 export type {
   ABufferShaderModuleBindings,
   ABufferShaderModuleProps,

--- a/modules/experimental/src/materials/glass-material.ts
+++ b/modules/experimental/src/materials/glass-material.ts
@@ -1,0 +1,244 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Texture} from '@luma.gl/core';
+import type {ShaderModule, ShaderPlugin} from '@luma.gl/shadertools';
+import {opticalLighting} from './optical-lighting';
+
+/** Runtime properties for the portable refractive glass shader module. */
+export type GlassMaterialProps = {
+  /** Size of the rendered scene texture in physical pixels. */
+  viewportSize?: [number, number];
+  /** Scene color rendered before translucent glass geometry. */
+  sceneColorTexture?: Texture;
+  /** Optical index of refraction. Ordinary glass is approximately 1.5. */
+  indexOfRefraction?: number;
+  /** Surface roughness in the inclusive zero-to-one range. */
+  roughness?: number;
+  /** Separation of red, green, and blue refraction samples. */
+  dispersion?: number;
+  /** Optical distance used for refraction offset and absorption. */
+  thickness?: number;
+  /** Multiplier applied to environment reflections and specular highlights. */
+  reflectionStrength?: number;
+};
+
+/** Uniform values consumed by {@link glassMaterial}. */
+export type GlassMaterialUniforms = {
+  viewportSize: [number, number];
+  indexOfRefraction: number;
+  roughness: number;
+  dispersion: number;
+  thickness: number;
+  reflectionStrength: number;
+};
+
+/** Texture bindings consumed by {@link glassMaterial}. */
+export type GlassMaterialBindings = {
+  glassSceneColorTexture?: Texture;
+};
+
+const SHADER_STAGE_FRAGMENT = 0x2;
+
+const GLASS_MATERIAL_WGSL = /* wgsl */ `\
+struct GlassMaterialUniforms {
+  viewportSize: vec2<f32>,
+  indexOfRefraction: f32,
+  roughness: f32,
+  dispersion: f32,
+  thickness: f32,
+  reflectionStrength: f32,
+};
+
+@group(0) @binding(auto) var<uniform> glassMaterial: GlassMaterialUniforms;
+@group(0) @binding(auto) var glassSceneColorTexture: texture_2d<f32>;
+@group(0) @binding(auto) var glassSceneColorTextureSampler: sampler;
+
+fn glassMaterial_getColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  baseColor: vec4<f32>,
+  cameraPosition: vec3<f32>,
+  fragmentPosition: vec4<f32>
+) -> vec4<f32> {
+  let viewDirection = normalize(cameraPosition - worldPosition);
+  let normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  let viewAlignment = clamp(dot(normalFacingCamera, viewDirection), 0.0, 1.0);
+  let indexOfRefraction = max(glassMaterial.indexOfRefraction, 1.001);
+  let baseReflectance = pow((indexOfRefraction - 1.0) / (indexOfRefraction + 1.0), 2.0);
+  let fresnel = opticalLighting_getFresnel(viewAlignment, baseReflectance, 5.0);
+  let thickness = glassMaterial.thickness * (0.32 + pow(1.0 - viewAlignment, 1.8));
+  let refractionDirection = refract(-viewDirection, normalFacingCamera, 1.0 / indexOfRefraction);
+  let screenCoordinate = fragmentPosition.xy / glassMaterial.viewportSize;
+  let refractionOffset = refractionDirection.xy * thickness * 0.085;
+  let dispersionOffset = normalFacingCamera.xy * glassMaterial.dispersion * thickness;
+  let refractedRed = textureSampleLevel(
+    glassSceneColorTexture,
+    glassSceneColorTextureSampler,
+    clamp(screenCoordinate + refractionOffset + dispersionOffset, vec2<f32>(0.001), vec2<f32>(0.999)),
+    0.0
+  ).r;
+  let refractedGreen = textureSampleLevel(
+    glassSceneColorTexture,
+    glassSceneColorTextureSampler,
+    clamp(screenCoordinate + refractionOffset, vec2<f32>(0.001), vec2<f32>(0.999)),
+    0.0
+  ).g;
+  let refractedBlue = textureSampleLevel(
+    glassSceneColorTexture,
+    glassSceneColorTextureSampler,
+    clamp(screenCoordinate + refractionOffset - dispersionOffset, vec2<f32>(0.001), vec2<f32>(0.999)),
+    0.0
+  ).b;
+  let absorption = exp(-(vec3<f32>(0.11, 0.065, 0.035) + (1.0 - baseColor.rgb) * 0.32) * thickness);
+  let transmittedColor = vec3<f32>(refractedRed, refractedGreen, refractedBlue) * absorption;
+  let reflectionDirection = reflect(-viewDirection, normalFacingCamera);
+  let environmentColor = opticalLighting_sampleEnvironment(
+    reflectionDirection,
+    vec3<f32>(0.035, 0.065, 0.12),
+    vec3<f32>(0.38, 0.57, 0.82),
+    0.28
+  );
+  let keyHalfVector = normalize(opticalLighting_getKeyLight() + viewDirection);
+  let fillHalfVector = normalize(opticalLighting_getFillLight() + viewDirection);
+  let specularExponent = mix(160.0, 20.0, clamp(glassMaterial.roughness, 0.0, 1.0));
+  let keySpecular = pow(max(dot(normalFacingCamera, keyHalfVector), 0.0), specularExponent);
+  let fillSpecular = pow(max(dot(normalFacingCamera, fillHalfVector), 0.0), specularExponent * 0.65);
+  let rim = pow(1.0 - viewAlignment, 2.2);
+  let reflection = (
+    environmentColor * (fresnel + rim * 0.42) + baseColor.rgb * rim * 0.28 +
+    vec3<f32>(1.0, 0.95, 0.86) * keySpecular * 0.9 +
+    vec3<f32>(0.35, 0.62, 1.0) * fillSpecular * 0.45
+  ) * glassMaterial.reflectionStrength;
+  let color = transmittedColor * (1.0 - fresnel) + reflection;
+  let opacity = clamp(
+    0.26 + fresnel * 0.58 + rim * 0.22 + (keySpecular + fillSpecular) * 0.24,
+    0.16,
+    0.9
+  );
+  return vec4<f32>(color, opacity);
+}
+`;
+
+const GLASS_MATERIAL_GLSL = /* glsl */ `\
+layout(std140) uniform glassMaterialUniforms {
+  vec2 viewportSize;
+  float indexOfRefraction;
+  float roughness;
+  float dispersion;
+  float thickness;
+  float reflectionStrength;
+} glassMaterial;
+
+uniform sampler2D glassSceneColorTexture;
+
+vec4 glassMaterial_getColor(
+  vec3 normal,
+  vec3 worldPosition,
+  vec4 baseColor,
+  vec3 cameraPosition,
+  vec4 fragmentPosition
+) {
+  vec3 viewDirection = normalize(cameraPosition - worldPosition);
+  vec3 normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  float viewAlignment = clamp(dot(normalFacingCamera, viewDirection), 0.0, 1.0);
+  float indexOfRefraction = max(glassMaterial.indexOfRefraction, 1.001);
+  float baseReflectance = pow((indexOfRefraction - 1.0) / (indexOfRefraction + 1.0), 2.0);
+  float fresnel = opticalLighting_getFresnel(viewAlignment, baseReflectance, 5.0);
+  float thickness = glassMaterial.thickness * (0.32 + pow(1.0 - viewAlignment, 1.8));
+  vec3 refractionDirection = refract(-viewDirection, normalFacingCamera, 1.0 / indexOfRefraction);
+  vec2 screenCoordinate = fragmentPosition.xy / glassMaterial.viewportSize;
+  vec2 refractionOffset = refractionDirection.xy * thickness * 0.085;
+  vec2 dispersionOffset = normalFacingCamera.xy * glassMaterial.dispersion * thickness;
+  float refractedRed = texture(
+    glassSceneColorTexture,
+    clamp(screenCoordinate + refractionOffset + dispersionOffset, vec2(0.001), vec2(0.999))
+  ).r;
+  float refractedGreen = texture(
+    glassSceneColorTexture,
+    clamp(screenCoordinate + refractionOffset, vec2(0.001), vec2(0.999))
+  ).g;
+  float refractedBlue = texture(
+    glassSceneColorTexture,
+    clamp(screenCoordinate + refractionOffset - dispersionOffset, vec2(0.001), vec2(0.999))
+  ).b;
+  vec3 absorption = exp(-(vec3(0.11, 0.065, 0.035) + (1.0 - baseColor.rgb) * 0.32) * thickness);
+  vec3 transmittedColor = vec3(refractedRed, refractedGreen, refractedBlue) * absorption;
+  vec3 reflectionDirection = reflect(-viewDirection, normalFacingCamera);
+  vec3 environmentColor = opticalLighting_sampleEnvironment(
+    reflectionDirection,
+    vec3(0.035, 0.065, 0.12),
+    vec3(0.38, 0.57, 0.82),
+    0.28
+  );
+  vec3 keyHalfVector = normalize(opticalLighting_getKeyLight() + viewDirection);
+  vec3 fillHalfVector = normalize(opticalLighting_getFillLight() + viewDirection);
+  float specularExponent = mix(160.0, 20.0, clamp(glassMaterial.roughness, 0.0, 1.0));
+  float keySpecular = pow(max(dot(normalFacingCamera, keyHalfVector), 0.0), specularExponent);
+  float fillSpecular = pow(max(dot(normalFacingCamera, fillHalfVector), 0.0), specularExponent * 0.65);
+  float rim = pow(1.0 - viewAlignment, 2.2);
+  vec3 reflection = (
+    environmentColor * (fresnel + rim * 0.42) + baseColor.rgb * rim * 0.28 +
+    vec3(1.0, 0.95, 0.86) * keySpecular * 0.9 +
+    vec3(0.35, 0.62, 1.0) * fillSpecular * 0.45
+  ) * glassMaterial.reflectionStrength;
+  vec3 color = transmittedColor * (1.0 - fresnel) + reflection;
+  float opacity = clamp(
+    0.26 + fresnel * 0.58 + rim * 0.22 + (keySpecular + fillSpecular) * 0.24,
+    0.16,
+    0.9
+  );
+  return vec4(color, opacity);
+}
+`;
+
+function getGlassMaterialUniforms(
+  props: Partial<GlassMaterialProps> = {},
+  previousUniforms?: GlassMaterialUniforms
+): Partial<GlassMaterialUniforms & GlassMaterialBindings> {
+  return {
+    viewportSize: props.viewportSize ?? previousUniforms?.viewportSize ?? [1, 1],
+    indexOfRefraction: props.indexOfRefraction ?? previousUniforms?.indexOfRefraction ?? 1.48,
+    roughness: props.roughness ?? previousUniforms?.roughness ?? 0.14,
+    dispersion: props.dispersion ?? previousUniforms?.dispersion ?? 0.022,
+    thickness: props.thickness ?? previousUniforms?.thickness ?? 1.05,
+    reflectionStrength: props.reflectionStrength ?? previousUniforms?.reflectionStrength ?? 1,
+    ...(props.sceneColorTexture ? {glassSceneColorTexture: props.sceneColorTexture} : {})
+  };
+}
+
+/** Portable refractive glass with Fresnel reflection, dispersion, and Beer-Lambert absorption. */
+export const glassMaterial = {
+  name: 'glassMaterial',
+  source: GLASS_MATERIAL_WGSL,
+  fs: GLASS_MATERIAL_GLSL,
+  dependencies: [opticalLighting],
+  bindingLayout: [
+    {name: 'glassSceneColorTexture', group: 0, visibility: SHADER_STAGE_FRAGMENT},
+    {name: 'glassSceneColorTextureSampler', group: 0, visibility: SHADER_STAGE_FRAGMENT}
+  ],
+  uniformTypes: {
+    viewportSize: 'vec2<f32>',
+    indexOfRefraction: 'f32',
+    roughness: 'f32',
+    dispersion: 'f32',
+    thickness: 'f32',
+    reflectionStrength: 'f32'
+  },
+  defaultUniforms: {
+    viewportSize: [1, 1],
+    indexOfRefraction: 1.48,
+    roughness: 0.14,
+    dispersion: 0.022,
+    thickness: 1.05,
+    reflectionStrength: 1
+  },
+  getUniforms: getGlassMaterialUniforms
+} as const satisfies ShaderModule<GlassMaterialProps, GlassMaterialUniforms, GlassMaterialBindings>;
+
+/** Installs the portable glass material and its shared optical-lighting dependency. */
+export const glassMaterialPlugin = {
+  name: 'glassMaterial',
+  modules: [glassMaterial as ShaderModule]
+} as const satisfies ShaderPlugin;

--- a/modules/experimental/src/materials/optical-lighting.ts
+++ b/modules/experimental/src/materials/optical-lighting.ts
@@ -1,0 +1,82 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ShaderModule} from '@luma.gl/shadertools';
+
+const OPTICAL_LIGHTING_WGSL = /* wgsl */ `\
+fn opticalLighting_faceNormal(normal: vec3<f32>, viewDirection: vec3<f32>) -> vec3<f32> {
+  return select(-normal, normal, dot(normal, viewDirection) >= 0.0);
+}
+
+fn opticalLighting_getFresnel(
+  viewAlignment: f32,
+  baseReflectance: f32,
+  exponent: f32
+) -> f32 {
+  return baseReflectance + (1.0 - baseReflectance) *
+    pow(1.0 - clamp(viewAlignment, 0.0, 1.0), exponent);
+}
+
+fn opticalLighting_getKeyLight() -> vec3<f32> {
+  return normalize(vec3<f32>(-0.45, 0.82, 0.34));
+}
+
+fn opticalLighting_getFillLight() -> vec3<f32> {
+  return normalize(vec3<f32>(0.62, 0.35, -0.7));
+}
+
+fn opticalLighting_sampleEnvironment(
+  reflectionDirection: vec3<f32>,
+  shadowColor: vec3<f32>,
+  highlightColor: vec3<f32>,
+  horizonStrength: f32
+) -> vec3<f32> {
+  let horizon = pow(1.0 - abs(reflectionDirection.y), 4.0);
+  return mix(
+    shadowColor,
+    highlightColor,
+    clamp(reflectionDirection.y * 0.5 + 0.5 + horizon * horizonStrength, 0.0, 1.0)
+  );
+}
+`;
+
+const OPTICAL_LIGHTING_GLSL = /* glsl */ `\
+vec3 opticalLighting_faceNormal(vec3 normal, vec3 viewDirection) {
+  return dot(normal, viewDirection) >= 0.0 ? normal : -normal;
+}
+
+float opticalLighting_getFresnel(float viewAlignment, float baseReflectance, float exponent) {
+  return baseReflectance + (1.0 - baseReflectance) *
+    pow(1.0 - clamp(viewAlignment, 0.0, 1.0), exponent);
+}
+
+vec3 opticalLighting_getKeyLight() {
+  return normalize(vec3(-0.45, 0.82, 0.34));
+}
+
+vec3 opticalLighting_getFillLight() {
+  return normalize(vec3(0.62, 0.35, -0.7));
+}
+
+vec3 opticalLighting_sampleEnvironment(
+  vec3 reflectionDirection,
+  vec3 shadowColor,
+  vec3 highlightColor,
+  float horizonStrength
+) {
+  float horizon = pow(1.0 - abs(reflectionDirection.y), 4.0);
+  return mix(
+    shadowColor,
+    highlightColor,
+    clamp(reflectionDirection.y * 0.5 + 0.5 + horizon * horizonStrength, 0.0, 1.0)
+  );
+}
+`;
+
+/** Shared portable Fresnel, normal-facing, lighting, and environment-reflection helpers. */
+export const opticalLighting = {
+  name: 'opticalLighting',
+  source: OPTICAL_LIGHTING_WGSL,
+  fs: OPTICAL_LIGHTING_GLSL
+} as const satisfies ShaderModule;

--- a/modules/experimental/src/materials/reflective-material.ts
+++ b/modules/experimental/src/materials/reflective-material.ts
@@ -1,0 +1,160 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ShaderModule, ShaderPlugin} from '@luma.gl/shadertools';
+import {opticalLighting} from './optical-lighting';
+
+/** Runtime properties for the portable reflective-surface shader module. */
+export type ReflectiveMaterialProps = {
+  /** Surface roughness in the inclusive zero-to-one range. */
+  roughness?: number;
+  /** Intensity of environment reflections around the Fresnel rim. */
+  reflectionStrength?: number;
+  /** Intensity of the key and fill light specular highlights. */
+  specularStrength?: number;
+  /** Multiplier applied to the incoming material opacity. */
+  opacityScale?: number;
+};
+
+/** Uniform values consumed by {@link reflectiveMaterial}. */
+export type ReflectiveMaterialUniforms = Required<ReflectiveMaterialProps>;
+
+const REFLECTIVE_MATERIAL_WGSL = /* wgsl */ `\
+struct ReflectiveMaterialUniforms {
+  roughness: f32,
+  reflectionStrength: f32,
+  specularStrength: f32,
+  opacityScale: f32,
+};
+
+@group(0) @binding(auto) var<uniform> reflectiveMaterial: ReflectiveMaterialUniforms;
+
+fn reflectiveMaterial_getColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  baseColor: vec4<f32>,
+  cameraPosition: vec3<f32>
+) -> vec4<f32> {
+  let viewDirection = normalize(cameraPosition - worldPosition);
+  let normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  let viewAlignment = clamp(dot(normalFacingCamera, viewDirection), 0.0, 1.0);
+  let fresnel = opticalLighting_getFresnel(viewAlignment, 0.08, 4.0);
+  let keyLight = opticalLighting_getKeyLight();
+  let fillLight = opticalLighting_getFillLight();
+  let keyHalfVector = normalize(keyLight + viewDirection);
+  let fillHalfVector = normalize(fillLight + viewDirection);
+  let diffuse = 0.36 + 0.64 * max(dot(normalFacingCamera, keyLight), 0.0);
+  let specularExponent = mix(96.0, 12.0, clamp(reflectiveMaterial.roughness, 0.0, 1.0));
+  let keySpecular = pow(max(dot(normalFacingCamera, keyHalfVector), 0.0), specularExponent);
+  let fillSpecular = pow(
+    max(dot(normalFacingCamera, fillHalfVector), 0.0),
+    specularExponent * 0.545
+  );
+  let reflectedColor = opticalLighting_sampleEnvironment(
+    normalFacingCamera,
+    vec3<f32>(0.08, 0.14, 0.25),
+    vec3<f32>(0.52, 0.7, 0.95),
+    0.0
+  );
+  let color = baseColor.rgb * diffuse +
+    reflectedColor * fresnel * reflectiveMaterial.reflectionStrength +
+    vec3<f32>(1.0, 0.94, 0.8) * keySpecular * reflectiveMaterial.specularStrength +
+    vec3<f32>(0.4, 0.67, 1.0) * fillSpecular * reflectiveMaterial.specularStrength * 0.524;
+  let opacity = clamp(
+    baseColor.a * reflectiveMaterial.opacityScale *
+      (0.85 + fresnel * 0.2 + (keySpecular + fillSpecular) * 0.35),
+    0.0,
+    0.72
+  );
+  return vec4<f32>(color, opacity);
+}
+`;
+
+const REFLECTIVE_MATERIAL_GLSL = /* glsl */ `\
+layout(std140) uniform reflectiveMaterialUniforms {
+  float roughness;
+  float reflectionStrength;
+  float specularStrength;
+  float opacityScale;
+} reflectiveMaterial;
+
+vec4 reflectiveMaterial_getColor(
+  vec3 normal,
+  vec3 worldPosition,
+  vec4 baseColor,
+  vec3 cameraPosition
+) {
+  vec3 viewDirection = normalize(cameraPosition - worldPosition);
+  vec3 normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  float viewAlignment = clamp(dot(normalFacingCamera, viewDirection), 0.0, 1.0);
+  float fresnel = opticalLighting_getFresnel(viewAlignment, 0.08, 4.0);
+  vec3 keyLight = opticalLighting_getKeyLight();
+  vec3 fillLight = opticalLighting_getFillLight();
+  vec3 keyHalfVector = normalize(keyLight + viewDirection);
+  vec3 fillHalfVector = normalize(fillLight + viewDirection);
+  float diffuse = 0.36 + 0.64 * max(dot(normalFacingCamera, keyLight), 0.0);
+  float specularExponent = mix(96.0, 12.0, clamp(reflectiveMaterial.roughness, 0.0, 1.0));
+  float keySpecular = pow(max(dot(normalFacingCamera, keyHalfVector), 0.0), specularExponent);
+  float fillSpecular = pow(
+    max(dot(normalFacingCamera, fillHalfVector), 0.0),
+    specularExponent * 0.545
+  );
+  vec3 reflectedColor = opticalLighting_sampleEnvironment(
+    normalFacingCamera,
+    vec3(0.08, 0.14, 0.25),
+    vec3(0.52, 0.7, 0.95),
+    0.0
+  );
+  vec3 color = baseColor.rgb * diffuse +
+    reflectedColor * fresnel * reflectiveMaterial.reflectionStrength +
+    vec3(1.0, 0.94, 0.8) * keySpecular * reflectiveMaterial.specularStrength +
+    vec3(0.4, 0.67, 1.0) * fillSpecular * reflectiveMaterial.specularStrength * 0.524;
+  float opacity = clamp(
+    baseColor.a * reflectiveMaterial.opacityScale *
+      (0.85 + fresnel * 0.2 + (keySpecular + fillSpecular) * 0.35),
+    0.0,
+    0.72
+  );
+  return vec4(color, opacity);
+}
+`;
+
+function getReflectiveMaterialUniforms(
+  props: Partial<ReflectiveMaterialProps> = {},
+  previousUniforms?: ReflectiveMaterialUniforms
+): ReflectiveMaterialUniforms {
+  return {
+    roughness: props.roughness ?? previousUniforms?.roughness ?? 0.62,
+    reflectionStrength: props.reflectionStrength ?? previousUniforms?.reflectionStrength ?? 0.32,
+    specularStrength: props.specularStrength ?? previousUniforms?.specularStrength ?? 0.42,
+    opacityScale: props.opacityScale ?? previousUniforms?.opacityScale ?? 1
+  };
+}
+
+/** Portable glossy surface shading with Fresnel edges and key/fill specular highlights. */
+export const reflectiveMaterial = {
+  name: 'reflectiveMaterial',
+  source: REFLECTIVE_MATERIAL_WGSL,
+  fs: REFLECTIVE_MATERIAL_GLSL,
+  dependencies: [opticalLighting],
+  uniformTypes: {
+    roughness: 'f32',
+    reflectionStrength: 'f32',
+    specularStrength: 'f32',
+    opacityScale: 'f32'
+  },
+  defaultUniforms: {
+    roughness: 0.62,
+    reflectionStrength: 0.32,
+    specularStrength: 0.42,
+    opacityScale: 1
+  },
+  getUniforms: getReflectiveMaterialUniforms
+} as const satisfies ShaderModule<ReflectiveMaterialProps, ReflectiveMaterialUniforms, {}>;
+
+/** Installs portable reflective surface shading and shared optical-lighting helpers. */
+export const reflectiveMaterialPlugin = {
+  name: 'reflectiveMaterial',
+  modules: [reflectiveMaterial as ShaderModule]
+} as const satisfies ShaderPlugin;

--- a/modules/experimental/test/materials/optical-materials.node.spec.ts
+++ b/modules/experimental/test/materials/optical-materials.node.spec.ts
@@ -1,0 +1,180 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {
+  aBuffer,
+  glassMaterial,
+  glassMaterialPlugin,
+  opticalLighting,
+  reflectiveMaterial,
+  reflectiveMaterialPlugin,
+  wboit
+} from '@luma.gl/experimental';
+import {ShaderAssembler} from '@luma.gl/shadertools';
+import {WgslReflect} from 'wgsl_reflect';
+
+const PLATFORM_INFO = {
+  type: 'webgpu' as const,
+  shaderLanguage: 'wgsl' as const,
+  shaderLanguageVersion: 300 as const,
+  gpu: 'test',
+  features: new Set<string>()
+};
+
+const OPTICAL_MATERIAL_SHADER = /* wgsl */ `\
+struct VertexOutputs {
+  @builtin(position) position: vec4<f32>,
+  @location(0) worldPosition: vec3<f32>,
+};
+
+@vertex
+fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> VertexOutputs {
+  let positions = array<vec2<f32>, 3>(
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>(3.0, -1.0),
+    vec2<f32>(-1.0, 3.0)
+  );
+  var outputs: VertexOutputs;
+  outputs.position = vec4<f32>(positions[vertexIndex], 0.5, 1.0);
+  outputs.worldPosition = vec3<f32>(0.0);
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs: VertexOutputs) -> @location(0) vec4<f32> {
+  let normal = vec3<f32>(0.0, 1.0, 0.0);
+  let cameraPosition = vec3<f32>(0.0, 2.0, 4.0);
+  let glassColor = glassMaterial_getColor(
+    normal,
+    inputs.worldPosition,
+    vec4<f32>(0.4, 0.6, 0.9, 0.5),
+    cameraPosition,
+    inputs.position
+  );
+  let reflectedColor = reflectiveMaterial_getColor(
+    normal,
+    inputs.worldPosition,
+    vec4<f32>(0.2, 0.4, 0.8, 0.6),
+    cameraPosition
+  );
+  return mix(glassColor, reflectedColor, 0.25);
+}
+`;
+
+test('optical material modules expose portable shared shader helpers', testCase => {
+  testCase.equal(glassMaterialPlugin.name, 'glassMaterial', 'glass plugin has a stable name');
+  testCase.deepEqual(glassMaterialPlugin.modules, [glassMaterial], 'glass plugin installs glass');
+  testCase.equal(
+    reflectiveMaterialPlugin.name,
+    'reflectiveMaterial',
+    'reflective plugin has a stable name'
+  );
+  testCase.deepEqual(
+    reflectiveMaterialPlugin.modules,
+    [reflectiveMaterial],
+    'reflective plugin installs reflective shading'
+  );
+  testCase.deepEqual(
+    glassMaterial.dependencies,
+    [opticalLighting],
+    'glass reuses shared optical lighting'
+  );
+  testCase.deepEqual(
+    reflectiveMaterial.dependencies,
+    [opticalLighting],
+    'reflective shading reuses shared optical lighting'
+  );
+  testCase.match(opticalLighting.source, /fn opticalLighting_getFresnel/, 'WGSL helpers exist');
+  testCase.match(opticalLighting.fs, /float opticalLighting_getFresnel/, 'GLSL helpers exist');
+  testCase.end();
+});
+
+test('optical materials retain defaults while applying partial updates', testCase => {
+  const initialGlassUniforms = glassMaterial.getUniforms({});
+  testCase.deepEqual(
+    initialGlassUniforms,
+    {
+      viewportSize: [1, 1],
+      indexOfRefraction: 1.48,
+      roughness: 0.14,
+      dispersion: 0.022,
+      thickness: 1.05,
+      reflectionStrength: 1
+    },
+    'glass uniforms expose stable defaults'
+  );
+
+  const updatedGlassUniforms = glassMaterial.getUniforms(
+    {indexOfRefraction: 1.6, thickness: 1.8},
+    initialGlassUniforms
+  );
+  testCase.equal(updatedGlassUniforms.indexOfRefraction, 1.6, 'glass refraction updates');
+  testCase.equal(updatedGlassUniforms.thickness, 1.8, 'glass thickness updates');
+  testCase.equal(updatedGlassUniforms.roughness, 0.14, 'glass roughness is retained');
+
+  const initialReflectiveUniforms = reflectiveMaterial.getUniforms({});
+  testCase.deepEqual(
+    initialReflectiveUniforms,
+    {roughness: 0.62, reflectionStrength: 0.32, specularStrength: 0.42, opacityScale: 1},
+    'reflective uniforms expose stable defaults'
+  );
+
+  const updatedReflectiveUniforms = reflectiveMaterial.getUniforms(
+    {roughness: 0.35, opacityScale: 0.5},
+    initialReflectiveUniforms
+  );
+  testCase.equal(updatedReflectiveUniforms.roughness, 0.35, 'reflective roughness updates');
+  testCase.equal(updatedReflectiveUniforms.opacityScale, 0.5, 'reflective opacity updates');
+  testCase.equal(
+    updatedReflectiveUniforms.specularStrength,
+    0.42,
+    'reflective specular strength is retained'
+  );
+  testCase.end();
+});
+
+test('optical materials compose once with both transparency modules', testCase => {
+  const assembler = new ShaderAssembler();
+  const assembledShader = assembler.assembleWGSLShader({
+    platformInfo: PLATFORM_INFO,
+    source: OPTICAL_MATERIAL_SHADER,
+    modules: [glassMaterial, reflectiveMaterial, aBuffer, wboit]
+  });
+  const reflectedShader = new WgslReflect(assembledShader.source);
+  const resources = [
+    ...reflectedShader.uniforms,
+    ...reflectedShader.textures,
+    ...reflectedShader.samplers
+  ];
+
+  testCase.equal(
+    assembledShader.source.match(/fn opticalLighting_getFresnel\(/g)?.length,
+    1,
+    'shared Fresnel helpers are emitted once'
+  );
+  testCase.ok(
+    resources.some(resource => resource.name === 'glassSceneColorTexture'),
+    'glass scene-color texture is reflected'
+  );
+  testCase.ok(
+    resources.some(resource => resource.name === 'glassSceneColorTextureSampler'),
+    'glass scene-color sampler is reflected'
+  );
+  testCase.ok(
+    resources.some(resource => resource.name === 'glassMaterial'),
+    'glass material uniforms are reflected'
+  );
+  testCase.ok(
+    resources.some(resource => resource.name === 'reflectiveMaterial'),
+    'reflective material uniforms are reflected'
+  );
+  testCase.match(assembledShader.source, /fn aBuffer_captureStraightColor/, 'A-buffer composes');
+  testCase.match(
+    assembledShader.source,
+    /fn wboit_captureStraightColor/,
+    'weighted-blended OIT composes'
+  );
+  testCase.end();
+});

--- a/scripts/examples-typecheck.mjs
+++ b/scripts/examples-typecheck.mjs
@@ -29,6 +29,7 @@ const SUPPORTED_EXAMPLE_WORKSPACES = new Set([
   'integrations/hello-react',
   'experimental/antialiasing',
   'showcase/dof',
+  'showcase/packet-spraying',
   'showcase/persistence',
   'tutorials/hello-instanced-cubes',
   'tutorials/hello-instancing',

--- a/website/content/examples/showcase/packet-spraying.mdx
+++ b/website/content/examples/showcase/packet-spraying.mdx
@@ -1,0 +1,22 @@
+---
+title: Network Packet Spraying
+---
+
+import {ExampleHeader} from '@site/src/react-luma';
+import {PacketSprayingExample} from '@site/src/examples';
+
+<ExampleHeader
+  id="packet-spraying"
+  title="Network Packet Spraying"
+  directory="showcase"
+  devices={['webgl2', 'webgpu']}
+>
+  <div>
+    Two servers send red and green transfers to two destination servers. Their packets interleave
+    on shared links, spread across independent network planes, and separate again at their
+    destinations. The example demonstrates the throughput and resilience advantages of Multipath
+    Reliable Connection (MRC), alongside reusable glass materials and order-independent transparency.
+  </div>
+</ExampleHeader>
+
+<PacketSprayingExample />

--- a/website/content/examples/table-of-contents.json
+++ b/website/content/examples/table-of-contents.json
@@ -10,6 +10,7 @@
     "items": [
       "showcase/gltf",
       "showcase/globe",
+      "showcase/packet-spraying",
       {
         "type": "doc",
         "id": "showcase/postprocessing",

--- a/website/src/components/docs/experimental-docs-tabs.tsx
+++ b/website/src/components/docs/experimental-docs-tabs.tsx
@@ -10,6 +10,8 @@ export type ExperimentalDocsTabId =
   | 'deferred-lighting'
   | 'clustered-lighting'
   | 'shadow-map-renderer'
+  | 'glass-material'
+  | 'reflective-material'
   | 'a-buffer-renderer'
   | 'wboit-renderer';
 
@@ -30,6 +32,16 @@ const EXPERIMENTAL_DOCS_TABS: ExperimentalDocsTab[] = [
     id: 'shadow-map-renderer',
     label: 'ShadowMapRenderer',
     href: '/docs/api-reference/experimental/shadow-map-renderer'
+  },
+  {
+    id: 'glass-material',
+    label: 'Glass Material',
+    href: '/docs/api-reference/experimental/glass-material'
+  },
+  {
+    id: 'reflective-material',
+    label: 'Reflective Material',
+    href: '/docs/api-reference/experimental/reflective-material'
   },
   {
     id: 'a-buffer-renderer',

--- a/website/src/components/docs/shader-level-docs-tabs.tsx
+++ b/website/src/components/docs/shader-level-docs-tabs.tsx
@@ -17,7 +17,9 @@ export type ShaderLevelDocsTabId =
   | 'writing-portable-shaders'
   | 'writing-customizable-shaders'
   | 'shader-passes'
-  | 'rendering-techniques';
+  | 'rendering-techniques'
+  | 'transparency'
+  | 'glass-effects';
 
 const SHADER_LEVEL_DOCS_TABS: ShaderLevelDocsTab[] = [
   {id: 'overview', label: 'Overview', href: '/docs/api-guide/shaders'},
@@ -41,7 +43,9 @@ const SHADER_LEVEL_DOCS_TABS: ShaderLevelDocsTab[] = [
     id: 'rendering-techniques',
     label: 'Rendering Techniques',
     href: '/docs/api-guide/shaders/rendering-techniques'
-  }
+  },
+  {id: 'transparency', label: 'Transparency', href: '/docs/api-guide/shaders/transparency'},
+  {id: 'glass-effects', label: 'Glass Effects', href: '/docs/api-guide/shaders/glass-effects'}
 ];
 
 /**

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -80,6 +80,7 @@ import PersistenceApp from '../../examples/showcase/persistence/app';
 import PostprocessingApp from '../../examples/showcase/postprocessing/app';
 import AntialiasingApp from '../../examples/experimental/antialiasing/app';
 import GlobeApp from '../../examples/showcase/globe/app';
+import PacketSprayingApp from '../../examples/showcase/packet-spraying/app';
 // import WanderingApp from '../../examples/showcase/wandering/app';
 
 import HelloTriangleGeometryApp from '../../examples/tutorials/hello-triangle-geometry/app';
@@ -931,6 +932,17 @@ export const GlobeExample: React.FC = props => (
     title="Globe"
     directory="showcase"
     template={GlobeApp}
+    config={exampleConfig}
+    {...props}
+  />
+);
+
+export const PacketSprayingExample: React.FC = props => (
+  <LumaExample
+    id="packet-spraying"
+    title="Network Packet Spraying"
+    directory="showcase"
+    template={PacketSprayingApp}
     config={exampleConfig}
     {...props}
   />

--- a/yarn.lock
+++ b/yarn.lock
@@ -16621,6 +16621,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"luma.gl-examples-showcase-packet-spraying@workspace:examples/showcase/packet-spraying":
+  version: 0.0.0-use.local
+  resolution: "luma.gl-examples-showcase-packet-spraying@workspace:examples/showcase/packet-spraying"
+  dependencies:
+    "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
+    "@luma.gl/core": "npm:9.4.0-alpha.1"
+    "@luma.gl/engine": "npm:9.4.0-alpha.1"
+    "@luma.gl/experimental": "npm:9.4.0-alpha.1"
+    "@luma.gl/shadertools": "npm:9.4.0-alpha.1"
+    "@luma.gl/webgl": "npm:9.4.0-alpha.1"
+    "@luma.gl/webgpu": "npm:9.4.0-alpha.1"
+    "@math.gl/core": "npm:^4.1.0"
+    typescript: "npm:^5.9.3"
+    vite: "npm:^8.0.0"
+  languageName: unknown
+  linkType: soft
+
 "luma.gl-examples-text-space-crawl@workspace:examples/experimental/text-space-crawl":
   version: 0.0.0-use.local
   resolution: "luma.gl-examples-text-space-crawl@workspace:examples/experimental/text-space-crawl"


### PR DESCRIPTION
## Goals

- Demonstrate Multipath Reliable Connection (MRC) packet spraying with a topology and traffic pattern inspired by OpenAI's [supercomputer networking article](https://openai.com/index/mrc-supercomputer-networking/).
- Add reusable, portable optical-material and postprocessing primitives that work across WebGPU and WebGL.
- Keep the network diagram readable while showing resilient multi-plane routing, alternating red/green traffic, physically motivated glass, and restrained emissive lighting.

## Changes

- Add reusable `emissiveMaterial` and `opticalPointLights` shader modules and plugins, including matching WGSL/GLSL implementations and a fixed 16-light portable uniform layout.
- Extend reusable glass and reflective materials with optional nearby-light shading while preserving their existing helper signatures.
- Support configurable color attachment formats in A-buffer and weighted-blended transparency renderers so HDR values survive translucent compositing.
- Add an exported ACES tone-mapping shader pass and configurable linear samplers for named shader-pass render targets.
- Correct multiscale bloom filtering and avoid alpha-related blur amplification that previously produced square halos.
- Render small saturated red/green emissive packets, selective bloom, dynamic colored switch/link reflections, and muted metallic red/green endpoint servers.
- Preserve alternating packet traffic, a 4x4 server grid, independent network planes, optional orbit controls, hover picking, and WebGPU/WebGL fallbacks.
- Document glass, transparency, reflective shading, HDR, selective bloom, tone mapping, and the MRC showcase.

## Verification

- `nvm use`: unavailable in this shell; the active Node version is `v22.22.1`.
- `yarn install`: passed using `env -u YARN_NO_PROXY corepack yarn install`.
- `yarn build`: passed using `env -u YARN_NO_PROXY corepack yarn build` after the final code and formatting changes.
- `yarn lint fix`: passed using `env -u YARN_NO_PROXY corepack yarn lint fix`.
- `yarn test-node`: passed, **185 tests** with two skipped.
- Focused Chromium GPU tests: passed, **27 tests** covering A-buffer/WBOIT HDR output, bloom, tone mapping, and linear shader-pass target samplers.
- `yarn examples:typecheck`: passed for **32 example workspaces**.
- Packet-spraying standalone production build: passed.
- `yarn website:build`: passed.
- `(cd website && yarn build)`: passed.
- WebGPU and WebGL browser screenshots/canvas-pixel checks: passed with no page or console errors; hover explanations passed for servers, access switches, plane switches, and spine switches.
- `yarn test`: Node suite passed and the browser suite reported **1,281 passing, 25 skipped, and one existing unrelated failure** in `modules/arrow-layers/test/layers/arrow-layers.spec.ts` (`polygonViewportUniforms` missing from the Arrow polygon WebGPU shader layout). The same Arrow failure was present before these changes.

## Follow-up

- Resolve the pre-existing Arrow polygon WebGPU test failure independently of this optical-material/showcase change.
- More advanced depth-derived thickness, caustics, environment probes, and ray-traced transmission remain separate future work.
