### PR TITLE
feat(engine,effects): add depth-sorted HDR glass showcase

### DIFF
--- a/docs/api-guide/engine/scenegraph.md
+++ b/docs/api-guide/engine/scenegraph.md
@@ -38,3 +38,42 @@ This maps well to luma.gl's binding ownership model:
 - group `0` is typically model or draw-local engine state,
 - group `2` is typically scene-shared state such as lighting or IBL,
 - group `3` is material state that can be reused across many renderable nodes.
+
+## Instanced Bounds And Depth Sorting
+
+An instanced model can remain one renderable scenegraph node while providing all of its instance
+transforms for aggregate bounds:
+
+```ts
+import {GroupNode, ModelNode} from '@luma.gl/engine';
+
+const switches = new ModelNode({
+  model: switchModel,
+  bounds: [
+    [-1, -1, -1],
+    [1, 1, 1]
+  ],
+  instanceMatrices: switchTransforms
+});
+
+const scene = new GroupNode({children: [switches]});
+
+scene.traverseDepthSorted(
+  node => {
+    if (node instanceof ModelNode) {
+      node.draw(renderPass);
+    }
+  },
+  {viewMatrix, order: 'back-to-front'}
+);
+```
+
+`ModelNode` calculates one bounding box enclosing every transformed instance. `GroupNode` combines
+those bounds with ancestor and leaf transforms, orders nodes by their camera-space bounding-box
+centers, and still visits the instanced model only once.
+
+This is useful when translucent objects naturally divide into a small number of semantic groups.
+For example, the glass showcase renders its spine switches and two network planes as three instanced
+models, sorts those models back to front, and refreshes the refraction source between groups. This
+improves layered transmission without replacing per-group order-independent transparency or
+requiring one draw call per switch.

--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -29,6 +29,11 @@ portable, bounded local lighting. Emission makes an object bright; point lightin
 illuminate nearby surfaces; bloom spreads the brightest pixels in screen space. These effects can
 be combined independently.
 
+For moving emitters, `emissiveMaterial_getTrailColor(...)` applies a smooth axial falloff to a
+velocity-aligned mesh. A tapered cone behind each packet produces directional bloom without
+blurring stationary glass, links, or neighboring packet colors. Brief additive switch-arrival
+flashes can share the same emissive material while bounded point lights illuminate nearby surfaces.
+
 ## Attach a Glass Material
 
 ```ts

--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -17,11 +17,17 @@ GLSL shader modules, while transparency renderers remain responsible for composi
 | Chromatic dispersion | Offsets red, green, and blue scene-color samples. | Subtle colored separation around refracted features. |
 | Beer-Lambert absorption | Attenuates transmitted light with material color and thickness. | Longer optical paths produce darker, more tinted transmission. |
 | Glossy highlights | Roughness-dependent key and fill light highlights. | Adjustable apparent surface polish. |
+| Localized point lights | Evaluates a bounded array of nearby colored light sources. | Moving emissive objects tint adjacent glass and reflective surfaces. |
 
 [`glassMaterial`](/docs/api-reference/experimental/glass-material) provides the transmissive
 surface model. [`reflectiveMaterial`](/docs/api-reference/experimental/reflective-material)
 provides a lower-cost glossy treatment for links and other non-glass surfaces. Both depend on the
 shared `opticalLighting` shader module.
+
+`emissiveMaterial` provides self-illuminated geometry, while `opticalPointLights` supplies
+portable, bounded local lighting. Emission makes an object bright; point lighting makes it
+illuminate nearby surfaces; bloom spreads the brightest pixels in screen space. These effects can
+be combined independently.
 
 ## Attach a Glass Material
 
@@ -78,6 +84,21 @@ glass. Do not sample the same WebGPU texture that is currently attached as a ren
 
 See [Transparency](/docs/api-guide/shaders/transparency) for render ordering, opaque-depth
 handling, and backend selection.
+
+## Emissive Light, HDR, and Bloom
+
+Render emissive objects into an `rgba16float` scene attachment when the device supports rendering
+and filtering that format. Preserve the same color format through transparency resolves so packet
+cores and specular highlights can exceed display brightness until postprocessing.
+
+Use `bloomShaderPassPipeline` after opaque and translucent composition, followed by filmic
+`toneMapping`. Keep the bloom threshold above ordinary scene brightness to avoid glowing inactive
+links or the entire glass silhouette. When floating-point scene color is unavailable, fall back to
+the preferred display format and reduce the extraction threshold.
+
+`glassMaterial_getIlluminatedColor(...)` and `reflectiveMaterial_getIlluminatedColor(...)` combine
+their existing optical response with `opticalPointLights`. Existing `getColor(...)` helpers remain
+appropriate when no dynamic local lights are needed.
 
 ## Current Quality Boundary
 

--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -12,11 +12,17 @@ GLSL shader modules, while transparency renderers remain responsible for composi
 
 | Effect | Implementation | Visible result |
 | --- | --- | --- |
-| Fresnel reflection | Schlick-style view-angle approximation. | Stronger reflections around silhouettes. |
-| Refraction | Samples an independently captured scene-color texture. | Background and packets bend behind the glass surface. |
+| Fresnel reflection | Adjustable Schlick-style grazing-angle response. | Sculpted, luminous reflections around silhouettes. |
+| Refraction | Projects Snell's refracted ray into camera-aligned screen space and samples an independently captured scene-color texture. | Background links and packets visibly bend and magnify behind polished or frosted glass. |
+| Backface thickness | Rasterizes sphere backfaces into a normal-and-depth texture and linearizes the front-to-back depth difference. | Glass centers and silhouettes acquire different optical path lengths. |
+| Two-surface transmission | Applies analytic entry and exit refraction while checking opaque scene depth. | Background bends convincingly without distorting geometry in front of the glass. |
+| Studio environment | Samples a generated equirectangular environment along the reflected viewing direction. | Polished surfaces receive camera-responsive studio reflections. |
 | Chromatic dispersion | Offsets red, green, and blue scene-color samples. | Subtle colored separation around refracted features. |
 | Beer-Lambert absorption | Attenuates transmitted light with material color and thickness. | Longer optical paths produce darker, more tinted transmission. |
-| Glossy highlights | Roughness-dependent key and fill light highlights. | Adjustable apparent surface polish. |
+| GGX microfacets | Shared distribution and visibility helpers shade key and fill lights. | Roughness-dependent, camera-responsive polished highlights. |
+| Clearcoat | Adds a second narrow microfacet lobe above the base surface. | Crisp, bright reflections that make the outer shell readable. |
+| Internal reflection | Approximates a colored secondary environment bounce inside the shell. | A softer inner Fresnel band and greater visible depth. |
+| Thin-film interference | Applies restrained wavelength-dependent color near grazing angles. | Subtle spectral variation without coloring the whole object. |
 | Localized point lights | Evaluates a bounded array of nearby colored light sources. | Moving emissive objects tint adjacent glass and reflective surfaces. |
 
 [`glassMaterial`](/docs/api-reference/experimental/glass-material) provides the transmissive
@@ -50,7 +56,13 @@ shaderInputs.setProps({
     roughness: 0.14,
     dispersion: 0.022,
     thickness: 1.05,
-    reflectionStrength: 1
+    refractionStrength: 1,
+    reflectionStrength: 1,
+    fresnelStrength: 1.2,
+    clearcoatStrength: 0.8,
+    iridescenceStrength: 0.12,
+    internalReflectionStrength: 0.5,
+    transmissionStrength: 1
   }
 });
 
@@ -76,6 +88,42 @@ let color = glassMaterial_getColor(
 
 `inputs.position` must be the fragment's built-in framebuffer position. Keep `viewportSize` in
 physical pixels and update it whenever the scene-color texture is resized.
+
+`refractionStrength` controls the lens displacement independently of material thickness. The
+refracted ray is projected into the current camera basis, so links and other background geometry
+remain correctly distorted as the camera orbits. Transmission coverage is kept high enough that
+the displaced scene remains visible instead of being overwhelmed by the original background during
+translucent compositing.
+
+## Add Rasterized Volume Transmission
+
+`glassTransmissionPlugin` extends `glassMaterialPlugin` without changing the existing glass helper
+or adding iterative ray tracing. Render outward-facing sphere backfaces into an RGBA texture whose
+RGB channels contain the encoded world normal and whose alpha channel contains framebuffer depth.
+The opaque scene depth must remain available as a sampleable depth texture.
+
+```ts
+import {glassTransmission, glassTransmissionPlugin} from '@luma.gl/experimental';
+
+const shaderInputs = new ShaderInputs({glassMaterial, glassTransmission});
+
+shaderInputs.setProps({
+  glassTransmission: {
+    viewportSize: [width, height],
+    depthRange: [0.1, 60],
+    sceneDepthTexture,
+    backfaceTexture,
+    environmentTexture,
+    environmentIntensity: 1.25,
+    thicknessStrength: 1
+  }
+});
+```
+
+Call `glassTransmission_getColor(...)`, or install `opticalPointLightsPlugin` and call
+`glassTransmission_getIlluminatedColor(...)`. These helpers retain the base glass material while
+adding depth-derived thickness, analytic entry/exit refraction, foreground-depth rejection,
+total-internal-reflection handling, and sampled equirectangular environment reflections.
 
 ## Separate Optical Shading From Transparency
 
@@ -110,10 +158,9 @@ appropriate when no dynamic local lights are needed.
 These materials are advanced raster approximations, not a complete physically based transmission
 system. In particular, the current implementation does not provide:
 
-- Depth-derived or backface-derived per-pixel thickness.
-- GGX or other energy-conserving microfacet reflection and transmission.
-- Roughness-dependent blurred transmission or filtered environment probes.
-- Multiple refraction events, internal reflections, total internal reflection, or caustics.
+- Full energy-conserving multiple-scattering or microfacet transmission.
+- Filtered environment probes and geometry-aware rough transmission.
+- Physically traced multiple refraction events or caustics.
 - Off-screen background recovery or geometry-aware refracted-ray tracing.
 
 Those capabilities require additional depth, normal, backface, environment, or ray-tracing data

--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -116,5 +116,5 @@ and should be introduced as explicitly composable modules or render passes rathe
 an individual showcase.
 
 For a complete application, see
-[Network Packet Spraying](/examples/showcase/packet-spraying), which combines glass switches,
+[Effects: Glass - Network Packet Spraying](/examples/showcase/packet-spraying), which combines glass switches,
 reflective network links, exact or approximate transparency, and interactive camera controls.

--- a/docs/api-guide/shaders/transparency.md
+++ b/docs/api-guide/shaders/transparency.md
@@ -34,6 +34,12 @@ For weighted blending and A-buffer rendering, pass the existing opaque color and
 the selected renderer, then resolve translucent capture over the opaque scene. The resulting color
 can continue through the normal shader-pass chain.
 
+When opaque objects emit HDR light, configure the transparency renderer with
+`colorFormat: 'rgba16float'` whenever the device supports rendering and filtering that format.
+Otherwise an intermediate resolve can clamp values above `1.0` before bloom or tone mapping sees
+them. Both `ABufferRenderer` and `WBOITRenderer` accept an optional output color format while
+retaining their existing display-format defaults.
+
 ## Capture Scene Color Before Refraction
 
 Screen-space transmission needs a stable texture containing previously rendered scene color.
@@ -43,7 +49,7 @@ Create or copy that texture before the translucent pass:
 2. Resolve or copy the opaque color attachment into a separate sampleable texture.
 3. Render refractive transparent geometry while sampling that texture.
 4. Resolve the transparency renderer, if one is used.
-5. Apply later fullscreen effects and present the composed scene.
+5. Apply bloom to the resolved HDR scene, tone-map the result, and present the composed scene.
 
 WebGPU does not permit a texture to be sampled while it is also bound as the active render target.
 Use a distinct scene-color texture rather than sampling the current attachment directly.
@@ -77,7 +83,8 @@ const plugins = [glassMaterialPlugin, aBufferPlugin];
 
 The fragment shader calls `glassMaterial_getColor(...)` and then passes that result to
 `aBuffer_captureStraightColor(...)`. For weighted blending, replace the A-buffer module and plugin
-with `wboit` and `wboitPlugin`.
+with `wboit` and `wboitPlugin`. Use `glassMaterial_getIlluminatedColor(...)` with
+`opticalPointLightsPlugin` when nearby emissive objects should illuminate the translucent surface.
 
 See [Glass Effects](/docs/api-guide/shaders/glass-effects) for the material model and
 [Rendering Techniques and Tradeoffs](/docs/api-guide/shaders/rendering-techniques) for broader

--- a/docs/api-reference/engine/passes/shader-pass-renderer.md
+++ b/docs/api-reference/engine/passes/shader-pass-renderer.md
@@ -62,6 +62,12 @@ type ShaderPassPipeline<TargetNameT extends string = string> = {
   steps: ShaderPassPipelineStep<TargetNameT>[];
 };
 
+type ShaderPassRenderTarget = {
+  scale?: [number, number];
+  format?: TextureFormat;
+  sampler?: SamplerProps;
+};
+
 type ShaderPassPipelineStep<TargetNameT extends string = string> = {
   shaderPass: ShaderPass;
   inputs?: Record<string, ShaderPassInputSource<TargetNameT>>;
@@ -193,6 +199,10 @@ Destroys owned pass renderers, swap framebuffers, and texture model.
 Resizes the internal swap framebuffers and all pipeline render targets to match the provided size or the current canvas size.
 
 Named targets respect their declared `scale`. For example, a target with `scale: [0.5, 0.5]` is resized to half width and half height.
+
+Set `sampler: {minFilter: 'linear', magFilter: 'linear'}` on downsampled color targets when they
+will be upsampled later. Linear sampling prevents block-shaped bloom halos while leaving existing
+nearest-sampled passes unchanged.
 
 Resizing invalidates history targets whose allocation size changes.
 

--- a/docs/api-reference/engine/scenegraph/group-node.md
+++ b/docs/api-reference/engine/scenegraph/group-node.md
@@ -23,6 +23,18 @@ group.add(childNodeA, childNodeB);
 export type GroupNodeProps = ScenegraphNodeProps & {
   children?: ScenegraphNode[];
 };
+
+export type DepthSortedTraversalOptions = {
+  viewMatrix: NumericArray;
+  worldMatrix?: NumericArray;
+  order?: 'back-to-front' | 'front-to-back';
+};
+
+export type DepthSortedTraversalContext = {
+  worldMatrix: Matrix4;
+  bounds: [number[], number[]] | null;
+  depth: number;
+};
 ```
 
 ## Properties
@@ -43,7 +55,8 @@ Creates a group from node props plus optional children.
 
 ### `getBounds(): [number[], number[]] | null`
 
-Returns world-space bounds aggregated from all descendants that provide bounds.
+Returns world-space bounds aggregated from all descendants that provide bounds, including nested
+group transforms, leaf transforms, and every transformed bounding-box corner.
 
 ### `destroy(): void`
 
@@ -64,6 +77,26 @@ Clears all children.
 ### `traverse(visitor, {worldMatrix} = {})`
 
 Traverses descendants depth-first and calls the visitor for non-group leaf nodes.
+
+### `traverseDepthSorted(visitor, options)`
+
+Flattens leaf descendants and visits them in camera-depth order using their aggregate bounding-box
+centers. The default order is `back-to-front`; set `order: 'front-to-back'` for opaque rendering or
+other front-first workflows.
+
+```ts
+group.traverseDepthSorted(
+  (node, {worldMatrix, bounds, depth}) => {
+    if (node instanceof ModelNode) {
+      node.draw(renderPass);
+    }
+  },
+  {viewMatrix, order: 'back-to-front'}
+);
+```
+
+The visitor's `worldMatrix` includes both ancestor transforms and the leaf node transform. Sorting
+is stable for equal depths and preserves instanced models as a single visited node and draw.
 
 ### `preorderTraversal(visitor, {worldMatrix} = {})`
 

--- a/docs/api-reference/engine/scenegraph/model-node.md
+++ b/docs/api-reference/engine/scenegraph/model-node.md
@@ -15,6 +15,7 @@ export type ModelNodeProps = ScenegraphNodeProps & {
   model: Model;
   managedResources?: any[];
   bounds?: [[number, number, number], [number, number, number]];
+  instanceMatrices?: readonly NumericArray[];
 };
 ```
 
@@ -26,7 +27,14 @@ The model drawn by this node.
 
 ### `bounds`
 
-Optional bounds returned by `getBounds()`.
+Optional local bounds for one model instance. When `instanceMatrices` is provided, the constructor
+transforms all eight corners by every instance matrix and stores their aggregate bounding box.
+
+### `instanceMatrices`
+
+Optional transforms corresponding to the model's instanced draw. Providing these matrices lets a
+single `ModelNode` participate in scenegraph bounds and depth sorting without splitting its draw
+into individual nodes. An empty instance list has no bounds.
 
 ### `managedResources`
 
@@ -44,7 +52,7 @@ Destroys the model and any managed resources.
 
 ### `getBounds(): [number[], number[]] | null`
 
-Returns the configured bounds.
+Returns the configured local bounds, or aggregate local bounds across all configured instances.
 
 ### `draw(renderPass: RenderPass): boolean`
 

--- a/docs/api-reference/experimental/README.md
+++ b/docs/api-reference/experimental/README.md
@@ -88,9 +88,14 @@ absorption. [`reflectiveMaterial`](/docs/api-reference/experimental/reflective-m
 lightweight glossy highlights and Fresnel-weighted environment reflection for other surfaces.
 
 Both modules share `opticalLighting`, expose a `ShaderPlugin`, and can be composed with sorted
-alpha, weighted-blended OIT, or A-buffer OIT. The [Transparency](/docs/api-guide/shaders/transparency)
-and [Glass Effects](/docs/api-guide/shaders/glass-effects) guides describe their render ordering,
-backend constraints, and physically based limitations.
+alpha, weighted-blended OIT, or A-buffer OIT. `emissiveMaterial` shades self-illuminated objects,
+and `opticalPointLights` supplies a bounded, portable array of moving colored lights for the
+illuminated glass and reflective helpers. HDR transparency output can then feed reusable bloom
+and tone-mapping shader passes.
+
+The [Transparency](/docs/api-guide/shaders/transparency) and
+[Glass Effects](/docs/api-guide/shaders/glass-effects) guides describe render ordering, backend
+constraints, local lighting, and physically based limitations.
 
 ## Hybrid Shadows
 

--- a/docs/api-reference/experimental/a-buffer-renderer.md
+++ b/docs/api-reference/experimental/a-buffer-renderer.md
@@ -109,8 +109,10 @@ slice so storage buffers can be reused without allocating full-frame fragment st
 
 ## Rendering Model
 
-Each captured fragment occupies 12 bytes: packed premultiplied RGBA8 color, depth, and a linked-list
-pointer. Head pointers use a zero sentinel and fragment pointers are one-based.
+Each captured fragment occupies 16 bytes: premultiplied RGBA color stored as two packed half-float
+pairs, depth, and a linked-list pointer. Half-float storage preserves translucent HDR highlights
+above `1.0` instead of clipping them before resolve. Head pointers use a zero sentinel and fragment
+pointers are one-based.
 
 For each horizontal slice, the renderer:
 
@@ -128,8 +130,8 @@ If storage capacity is exhausted, additional fragments are dropped. If a pixel c
 - `ABufferRenderer` requires WebGPU and single-sample source color/depth textures. Source color
   must include `Texture.SAMPLE | Texture.RENDER`; opaque depth must include `Texture.SAMPLE`.
 - `colorFormat` controls the resolved output texture and defaults to the canvas-preferred format.
-  Set it to a supported, filterable `rgba16float` format to preserve HDR source color through
-  translucent compositing before bloom or tone mapping.
+  Set it to a supported, filterable `rgba16float` format to preserve both opaque HDR source color
+  and captured translucent HDR highlights through compositing before bloom or tone mapping.
 - The base pass depth texture is sampled during translucent capture so fragments behind opaque geometry are rejected before linked-list storage writes.
 - The renderer does not submit the device command encoder; the surrounding render loop keeps that responsibility.
 - `prepareTranslucent` runs once per horizontal capture slice. Update A-buffer shader props and call `Model.predraw()` there before the render pass opens.

--- a/docs/api-reference/experimental/a-buffer-renderer.md
+++ b/docs/api-reference/experimental/a-buffer-renderer.md
@@ -28,7 +28,8 @@ const shaderInputs = new ShaderInputs({aBuffer});
 const renderer = new ABufferRenderer(device, {
   averageFragmentsPerPixel: 4,
   maxFragmentsPerPixel: 12,
-  maxBufferByteLength: 64 * 1024 * 1024
+  maxBufferByteLength: 64 * 1024 * 1024,
+  colorFormat: 'rgba16float'
 });
 
 const model = new Model(device, {
@@ -87,6 +88,7 @@ export type ABufferRendererProps = {
   averageFragmentsPerPixel?: number;
   maxFragmentsPerPixel?: number;
   maxBufferByteLength?: number;
+  colorFormat?: TextureFormatColor;
 };
 
 export type ABufferRenderOptions = {
@@ -125,6 +127,9 @@ If storage capacity is exhausted, additional fragments are dropped. If a pixel c
 
 - `ABufferRenderer` requires WebGPU and single-sample source color/depth textures. Source color
   must include `Texture.SAMPLE | Texture.RENDER`; opaque depth must include `Texture.SAMPLE`.
+- `colorFormat` controls the resolved output texture and defaults to the canvas-preferred format.
+  Set it to a supported, filterable `rgba16float` format to preserve HDR source color through
+  translucent compositing before bloom or tone mapping.
 - The base pass depth texture is sampled during translucent capture so fragments behind opaque geometry are rejected before linked-list storage writes.
 - The renderer does not submit the device command encoder; the surrounding render loop keeps that responsibility.
 - `prepareTranslucent` runs once per horizontal capture slice. Update A-buffer shader props and call `Model.predraw()` there before the render pass opens.

--- a/docs/api-reference/experimental/glass-material.md
+++ b/docs/api-reference/experimental/glass-material.md
@@ -12,6 +12,8 @@ Beer-Lambert absorption, and roughness-dependent highlights.
 import {
   glassMaterial,
   glassMaterialPlugin,
+  glassTransmission,
+  glassTransmissionPlugin,
   opticalLighting,
   type GlassMaterialBindings,
   type GlassMaterialProps,
@@ -29,7 +31,13 @@ import {
 | `roughness` | `number` | `0.14` | Surface roughness between zero and one. |
 | `dispersion` | `number` | `0.022` | Separation of red, green, and blue transmission samples. |
 | `thickness` | `number` | `1.05` | Approximate optical distance used for transmission and absorption. |
+| `refractionStrength` | `number` | `1` | Camera-aligned background lens displacement. |
 | `reflectionStrength` | `number` | `1` | Multiplier for environment reflection and highlights. |
+| `fresnelStrength` | `number` | `1` | Grazing-angle reflection multiplier. |
+| `clearcoatStrength` | `number` | `0.7` | Secondary polished surface highlight. |
+| `iridescenceStrength` | `number` | `0.1` | Thin-film spectral edge variation. |
+| `internalReflectionStrength` | `number` | `0.42` | Internal environment-bounce multiplier. |
+| `transmissionStrength` | `number` | `1` | Amount of transmitted scene color. |
 
 ## Shader Helper
 
@@ -52,6 +60,26 @@ For surfaces illuminated by nearby moving lights, install `opticalPointLightsPlu
 Bind `opticalPointLights` through `ShaderInputs` with up to `MAX_OPTICAL_POINT_LIGHTS` world-space
 light positions, colors, radii, and intensities. The original `glassMaterial_getColor(...)`
 remains available for scenes without dynamic local lights.
+
+## Rasterized Volume Extension
+
+Install `glassTransmissionPlugin` to add depth-aware, two-surface transmission without changing
+existing `glassMaterial_getColor(...)` consumers.
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `viewportSize` | `[number, number]` | `[1, 1]` | Dimensions shared by the scene and backface textures. |
+| `depthRange` | `[number, number]` | `[0.1, 100]` | Near and far perspective clip planes. |
+| `sceneDepthTexture` | `Texture` | Required for rendering. | Sampleable opaque-scene depth attachment. |
+| `backfaceTexture` | `Texture` | Required for rendering. | Encoded world-space backface normals and depth. |
+| `environmentTexture` | `Texture` | Required for rendering. | Equirectangular studio or HDR environment. |
+| `environmentIntensity` | `number` | `1` | Environment reflection multiplier. |
+| `thicknessStrength` | `number` | `1` | Measured optical-path multiplier. |
+| `depthBias` | `number` | `0.00008` | Foreground depth-comparison tolerance. |
+
+Use `glassTransmission_getColor(...)`, or add `opticalPointLightsPlugin` and use
+`glassTransmission_getIlluminatedColor(...)` for localized illumination. Both are available in
+matching WGSL and GLSL forms.
 
 ## Usage
 

--- a/docs/api-reference/experimental/glass-material.md
+++ b/docs/api-reference/experimental/glass-material.md
@@ -47,6 +47,12 @@ GLSL exposes the equivalent `vec4 glassMaterial_getColor(...)` function. Add
 `glassMaterialPlugin` to the model so the helper and its shared `opticalLighting` dependency are
 installed before compilation.
 
+For surfaces illuminated by nearby moving lights, install `opticalPointLightsPlugin` alongside
+`glassMaterialPlugin` and call `glassMaterial_getIlluminatedColor(...)` with the same arguments.
+Bind `opticalPointLights` through `ShaderInputs` with up to `MAX_OPTICAL_POINT_LIGHTS` world-space
+light positions, colors, radii, and intensities. The original `glassMaterial_getColor(...)`
+remains available for scenes without dynamic local lights.
+
 ## Usage
 
 ```ts

--- a/docs/api-reference/experimental/reflective-material.md
+++ b/docs/api-reference/experimental/reflective-material.md
@@ -41,6 +41,11 @@ GLSL exposes the equivalent `vec4 reflectiveMaterial_getColor(...)` function. In
 `reflectiveMaterialPlugin` when creating the model so the helper and shared optical-lighting
 dependency are present in the assembled shader.
 
+Install `opticalPointLightsPlugin` as well and call
+`reflectiveMaterial_getIlluminatedColor(...)` to add bounded world-space point lights. Its
+arguments match `reflectiveMaterial_getColor(...)`, and the original helper retains its existing
+behavior when dynamic local lighting is unnecessary.
+
 ```ts
 import {Model, ShaderInputs} from '@luma.gl/engine';
 import {reflectiveMaterial, reflectiveMaterialPlugin} from '@luma.gl/experimental';

--- a/docs/api-reference/experimental/reflective-material.md
+++ b/docs/api-reference/experimental/reflective-material.md
@@ -8,6 +8,10 @@ import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-
 Fresnel-weighted environment reflection with roughness-adjusted key and fill highlights, without
 requiring the captured scene-color texture used by `glassMaterial`.
 
+Environment reflections follow the camera-reflected view direction as the viewpoint moves. Output
+opacity is clamped to the full zero-to-one range, allowing translucent links and fully opaque
+metallic surfaces to share the same material.
+
 ```ts
 import {
   reflectiveMaterial,

--- a/docs/api-reference/experimental/wboit-renderer.md
+++ b/docs/api-reference/experimental/wboit-renderer.md
@@ -27,7 +27,7 @@ const model = new Model(device, {
   plugins: [wboitPlugin],
   shaderInputs
 });
-const renderer = new WBOITRenderer(device);
+const renderer = new WBOITRenderer(device, {colorFormat: 'rgba16float'});
 
 // Render opaque color and depth into an application-owned scene framebuffer first.
 opaqueModel.predraw(device.commandEncoder);
@@ -105,6 +105,10 @@ The approximation can lose depth detail in scenes with many strongly overlapping
 ```ts
 export type WBOITPass = 'accumulation' | 'revealage';
 
+export type WBOITRendererProps = {
+  colorFormat?: TextureFormatColor;
+};
+
 export type WBOITRenderOptions = {
   sourceTexture: Texture;
   prepareOpaqueDepth?: (commandEncoder: CommandEncoder) => void;
@@ -114,5 +118,8 @@ export type WBOITRenderOptions = {
 };
 ```
 
-`sourceTexture` must include `Texture.SAMPLE` usage. The renderer records commands but does not
-submit the device command encoder.
+`sourceTexture` must include `Texture.SAMPLE` usage. `colorFormat` selects the resolved output
+format and defaults to the canvas-preferred format; set it to a supported, filterable
+`rgba16float` format to retain HDR color for later bloom or tone mapping. Existing
+`new WBOITRenderer(device)` calls remain valid. The renderer records commands but does not submit
+the device command encoder.

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -700,7 +700,6 @@ class NetworkNodePopup {
 export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTemplate {
   static info = makeExamplePanelHostHtml();
 
-  readonly shaderInputs = new ShaderInputs<{app: AppUniforms}>({app: appShaderModule});
   readonly reflectiveShaderInputs = new ShaderInputs<{
     app: AppUniforms;
     opticalPointLights: OpticalPointLightsProps;
@@ -829,7 +828,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         : 'sorted-alpha';
     this.aBufferRenderer = supportsABuffer
       ? new ABufferRenderer(device, {
-          averageFragmentsPerPixel: 6,
+          averageFragmentsPerPixel: 4,
           maxFragmentsPerPixel: 20,
           maxBufferByteLength: 64 * 1024 * 1024,
           colorFormat: this.sceneColorFormat
@@ -1017,7 +1016,6 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       lights: this.makePacketLights(),
       intensity: this.packetLightIntensity
     };
-    this.shaderInputs.setProps({app: uniforms});
     this.emissiveShaderInputs.setProps({
       app: uniforms,
       emissiveMaterial: {intensity: this.packetEmission, rimStrength: 0.32}
@@ -1162,9 +1160,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.postprocessingRenderer.destroy();
     this.aBufferRenderer?.destroy();
     this.weightedBlendedRenderer?.destroy();
-    this.shaderInputs.destroy();
     this.emissiveShaderInputs.destroy();
     this.reflectiveShaderInputs.destroy();
+    this.metallicShaderInputs.destroy();
     this.pickingShaderInputs.destroy();
     this.glassShaderInputs.destroy();
     this.aBufferShaderInputs.destroy();
@@ -1353,7 +1351,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private makePanel(): Panel {
     return makeExampleTabbedPanel({
       id: 'packet-spraying-info',
-      title: 'Network Packet Spraying',
+      title: 'Effects: Glass',
       panels: [
         makeHtmlCustomPanel({
           id: 'packet-spraying-overview',
@@ -1454,6 +1452,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 const PACKET_SPRAYING_ARTICLE_URL = 'https://openai.com/index/mrc-supercomputer-networking/';
 
 const PACKET_SPRAYING_OVERVIEW_HTML = `\
+<p><strong>Network Packet Spraying</strong></p>
 <p><strong>Two conversations, many routes.</strong> The two servers on the right send independent red and green transfers to two destination servers on the left.</p>
 <p>Packets enter their local Tier 0 switch as separate streams. Once the streams meet, the switch forwards alternating red and green packets across four representative independent network planes. The destination-side switches separate the traffic again and deliver each color to its intended server.</p>
 <p>Muted red and green cubes identify each conversation's source and destination; blue cubes are inactive servers. Glass spheres are switches, and faint tubes show the available fabric links. Emissive packets cast localized colored light onto nearby switches and active links, with restrained multiscale bloom.</p>

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -21,7 +21,8 @@ import {
   PickingManager,
   ShaderPassRenderer,
   ShaderInputs,
-  SphereGeometry
+  SphereGeometry,
+  TruncatedConeGeometry
 } from '@luma.gl/engine';
 import {
   ABufferRenderer,
@@ -64,9 +65,46 @@ import {
   makeExampleTabbedPanel,
   makeHtmlCustomPanel
 } from '../../example-panels';
+import {
+  AGGREGATION_POSITIONS,
+  AGGREGATION_SWITCH_RADIUS,
+  BURST_CYCLE_DURATION,
+  CONVERSATIONS,
+  HOST_HALF_EXTENTS,
+  HOST_POSITIONS,
+  HOST_Y,
+  LEAF_POSITIONS,
+  LEAF_SWITCH_RADIUS,
+  PACKET_TRAVEL_SPEED,
+  SPINE_POSITIONS,
+  SPINE_SWITCH_RADIUS,
+  SWITCH_POSITIONS,
+  getActivePlaneCount,
+  getDistance,
+  getDistanceSquared,
+  getHealthyConversationRoutes,
+  getPointAlongRoute,
+  getRouteSegmentStartDistance,
+  isFailedSwitchPosition,
+  makeActiveLinkKeys,
+  makeConversationRoutes,
+  makeHostColor,
+  makeLinkColor,
+  makeLinkKey,
+  makeLinks,
+  makePackets,
+  makePickableNetworkNodes,
+  makeSwitchArrivals,
+  reroutePackets,
+  type Color,
+  type ConversationRoute,
+  type NetworkLink,
+  type Packet,
+  type PickableNetworkNode,
+  type SwitchArrival,
+  type Vector3
+} from './network';
 
-type Vector3 = [number, number, number];
-type Color = [number, number, number, number];
 type TransparencyMode = 'a-buffer' | 'weighted-blended' | 'sorted-alpha';
 
 type AppUniforms = {
@@ -75,53 +113,14 @@ type AppUniforms = {
   viewMatrix: Matrix4;
 };
 
-type Packet = {
-  alpha: number;
-  color: Color;
-  launchTime: number;
-  route: Route;
-  scale: number;
-};
-
-type NetworkLink = {
-  color: Color;
-  end: Vector3;
-  endInset: number;
-  start: Vector3;
-  startInset: number;
-};
-
-type Conversation = {
-  color: Color;
-  destinationHostIndex: number;
-  sourceHostIndex: number;
-};
-
-type ConversationRoute = {
-  conversationIndex: number;
-  route: Route;
-};
-
-type Route = {
-  cumulativeLengths: number[];
-  points: Vector3[];
-  totalLength: number;
-};
-
 type GlassInstance = {
   color: Color;
   matrix: Matrix4;
   position: Vector3;
 };
 
-type PickableNetworkNode = {
-  description: string;
-  detail: string;
-  role: string;
-  title: string;
-};
-
 type NetworkNodePickRequest = {
+  action: 'hover' | 'toggle-switch';
   canvasPosition: [number, number];
   clientPosition: [number, number];
   pointerSequence: number;
@@ -160,6 +159,7 @@ struct VertexOutputs {
   @location(0) normal: vec3<f32>,
   @location(1) color: vec4<f32>,
   @location(2) worldPosition: vec3<f32>,
+  @location(3) localPosition: vec3<f32>,
 };
 
 @vertex
@@ -182,6 +182,7 @@ fn vertexMain(inputs: VertexInputs) -> VertexOutputs {
   outputs.normal = normalize(normalMatrix * inputs.normals);
   outputs.color = inputs.instanceColor;
   outputs.worldPosition = worldPosition.xyz;
+  outputs.localPosition = inputs.positions;
   return outputs;
 }
 
@@ -222,16 +223,32 @@ fn fragmentEmissive(inputs: VertexOutputs) -> @location(0) vec4<f32> {
 }
 `;
 
+const TRAIL_WGSL_SHADER = /* wgsl */ `${WGSL_SHADER}
+@fragment
+fn fragmentTrail(inputs: VertexOutputs) -> @location(0) vec4<f32> {
+  return emissiveMaterial_getTrailColor(
+    inputs.normal,
+    inputs.worldPosition,
+    inputs.color,
+    app.cameraPosition,
+    inputs.localPosition.y + 0.5,
+    1.0
+  );
+}
+`;
+
 const GLASS_WGSL_SHADER = /* wgsl */ `${WGSL_SHADER}
 @fragment
 fn fragmentGlass(inputs: VertexOutputs) -> @location(0) vec4<f32> {
-  let color = glassMaterial_getIlluminatedColor(
+  let glassColor = glassMaterial_getIlluminatedColor(
     inputs.normal,
     inputs.worldPosition,
     inputs.color,
     app.cameraPosition,
     inputs.position
   );
+  let failureTint = smoothstep(0.44, 0.54, inputs.color.a);
+  let color = vec4<f32>(glassColor.rgb + inputs.color.rgb * failureTint * 0.46, glassColor.a);
 #if A_BUFFER_ENABLED
   return aBuffer_captureStraightColor(color, inputs.position);
 #else
@@ -271,6 +288,7 @@ uniform appUniforms {
 out vec3 vNormal;
 out vec4 vColor;
 out vec3 vWorldPosition;
+out vec3 vLocalPosition;
 
 void main(void) {
   mat4 modelMatrix = mat4(
@@ -289,6 +307,7 @@ void main(void) {
   vNormal = normalize(normalMatrix * normals);
   vColor = instanceColor;
   vWorldPosition = worldPosition.xyz;
+  vLocalPosition = positions;
 }
 `;
 
@@ -350,13 +369,15 @@ in vec3 vWorldPosition;
 out vec4 fragColor;
 
 void main(void) {
-  vec4 color = glassMaterial_getIlluminatedColor(
+  vec4 glassColor = glassMaterial_getIlluminatedColor(
     vNormal,
     vWorldPosition,
     vColor,
     app.cameraPosition,
     gl_FragCoord
   );
+  float failureTint = smoothstep(0.44, 0.54, vColor.a);
+  vec4 color = vec4(glassColor.rgb + vColor.rgb * failureTint * 0.46, glassColor.a);
 #if WBOIT_ENABLED
   fragColor = wboit_captureStraightColor(color, gl_FragCoord);
 #else
@@ -430,6 +451,34 @@ void main(void) {
 }
 `;
 
+const TRAIL_FRAGMENT_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+uniform appUniforms {
+  vec3 cameraPosition;
+  mat4 projectionMatrix;
+  mat4 viewMatrix;
+} app;
+
+in vec3 vNormal;
+in vec4 vColor;
+in vec3 vWorldPosition;
+in vec3 vLocalPosition;
+out vec4 fragColor;
+
+void main(void) {
+  fragColor = emissiveMaterial_getTrailColor(
+    vNormal,
+    vWorldPosition,
+    vColor,
+    app.cameraPosition,
+    vLocalPosition.y + 0.5,
+    1.0
+  );
+}
+`;
+
 const INSTANCE_BUFFER_LAYOUT = [
   {
     name: 'instanceModelMatrices',
@@ -445,39 +494,10 @@ const INSTANCE_BUFFER_LAYOUT = [
   {name: 'instanceColor', format: 'float32x4' as const, stepMode: 'instance' as const}
 ];
 
-const HOST_X_POSITIONS = [-3.6, -1.2, 1.2, 3.6];
-const HOST_Z_POSITIONS = [2.4, 0.8, -0.8, -2.4];
-const HOST_Y = -2.75;
-const HOST_HALF_EXTENTS: Vector3 = [0.42, 0.27, 0.32];
-const LEAF_Y = -1.05;
-const LEAF_SWITCH_RADIUS = 0.42;
-const AGGREGATION_Y = 0.35;
-const AGGREGATION_SWITCH_RADIUS = 0.4;
-const SPINE_Y = 2.05;
-const SPINE_SWITCH_RADIUS = 0.55;
-const TRAFFIC_COLORS: Color[] = [
-  [1, 0, 0, 1],
-  [0, 1, 0, 1]
-];
-const PACKETS_PER_BURST = 24;
-const BURST_PACKET_INTERVAL = 0.14;
-const BURST_CYCLE_DURATION = 11;
-const PACKET_TRAVEL_SPEED = 3.4;
-
-const HOST_POSITIONS: Vector3[] = HOST_Z_POSITIONS.flatMap(zPosition =>
-  HOST_X_POSITIONS.map(xPosition => [xPosition, HOST_Y, zPosition] as Vector3)
-);
-const LEAF_POSITIONS: Vector3[] = [0.85, -0.85].flatMap(zPosition =>
-  HOST_X_POSITIONS.map(xPosition => [xPosition, LEAF_Y, zPosition] as Vector3)
-);
-const AGGREGATION_POSITIONS: Vector3[] = [0.85, -0.85].flatMap(zPosition =>
-  HOST_X_POSITIONS.map(xPosition => [xPosition, AGGREGATION_Y, zPosition] as Vector3)
-);
-const SPINE_POSITIONS: Vector3[] = HOST_Z_POSITIONS.map(zPosition => [0, SPINE_Y, zPosition]);
-const CONVERSATIONS: Conversation[] = [
-  {sourceHostIndex: 3, destinationHostIndex: 8, color: TRAFFIC_COLORS[0]},
-  {sourceHostIndex: 7, destinationHostIndex: 12, color: TRAFFIC_COLORS[1]}
-];
+const PACKET_TRAIL_RADIUS = 0.033;
+const SWITCH_FLASH_DURATION = 0.16;
+const MAX_SWITCH_FLASH_LIGHTS = 6;
+const FAILED_SWITCH_COLOR: Color = [1, 0.34, 0.07, 0.56];
 
 const TRANSPARENT_PARAMETERS = {
   blend: true,
@@ -487,6 +507,19 @@ const TRANSPARENT_PARAMETERS = {
   blendAlphaOperation: 'add',
   blendAlphaSrcFactor: 'one',
   blendAlphaDstFactor: 'one-minus-src-alpha',
+  depthWriteEnabled: false,
+  depthCompare: 'less-equal',
+  cullMode: 'none'
+} as const satisfies RenderPipelineParameters;
+
+const ADDITIVE_PARAMETERS = {
+  blend: true,
+  blendColorOperation: 'add',
+  blendColorSrcFactor: 'src-alpha',
+  blendColorDstFactor: 'one',
+  blendAlphaOperation: 'add',
+  blendAlphaSrcFactor: 'zero',
+  blendAlphaDstFactor: 'one',
   depthWriteEnabled: false,
   depthCompare: 'less-equal',
   cullMode: 'none'
@@ -513,8 +546,10 @@ class InstancedMesh<
       matrices,
       colors,
       transparent = false,
+      additive = false,
       glass = false,
       emissive = false,
+      trail = false,
       pickable = false,
       reflective = false,
       sceneTexture,
@@ -525,8 +560,10 @@ class InstancedMesh<
       matrices: Float32Array;
       colors: Float32Array;
       transparent?: boolean;
+      additive?: boolean;
       glass?: boolean;
       emissive?: boolean;
+      trail?: boolean;
       pickable?: boolean;
       reflective?: boolean;
       sceneTexture?: Texture;
@@ -545,9 +582,11 @@ class InstancedMesh<
           ? GLASS_WGSL_SHADER
           : reflective
             ? REFLECTIVE_WGSL_SHADER
-            : emissive
-              ? EMISSIVE_WGSL_SHADER
-              : WGSL_SHADER,
+            : trail
+              ? TRAIL_WGSL_SHADER
+              : emissive
+                ? EMISSIVE_WGSL_SHADER
+                : WGSL_SHADER,
       vs: pickable ? PICKING_VERTEX_SHADER : VERTEX_SHADER,
       fs: pickable
         ? PICKING_FRAGMENT_SHADER
@@ -555,18 +594,22 @@ class InstancedMesh<
           ? GLASS_FRAGMENT_SHADER
           : reflective
             ? REFLECTIVE_FRAGMENT_SHADER
-            : emissive
-              ? EMISSIVE_FRAGMENT_SHADER
-              : FRAGMENT_SHADER,
+            : trail
+              ? TRAIL_FRAGMENT_SHADER
+              : emissive
+                ? EMISSIVE_FRAGMENT_SHADER
+                : FRAGMENT_SHADER,
       fragmentEntryPoint: pickable
         ? 'fragmentPicking'
         : glass
           ? 'fragmentGlass'
           : reflective
             ? 'fragmentReflective'
-            : emissive
-              ? 'fragmentEmissive'
-              : 'fragmentMain',
+            : trail
+              ? 'fragmentTrail'
+              : emissive
+                ? 'fragmentEmissive'
+                : 'fragmentMain',
       shaderInputs,
       defines: {
         A_BUFFER_ENABLED: usesABuffer ? 1 : 0,
@@ -578,7 +621,7 @@ class InstancedMesh<
         ...(glass || reflective ? [opticalPointLightsPlugin] : []),
         ...(glass ? [glassMaterialPlugin] : []),
         ...(reflective ? [reflectiveMaterialPlugin] : []),
-        ...(emissive ? [emissiveMaterialPlugin] : []),
+        ...(emissive || trail ? [emissiveMaterialPlugin] : []),
         ...(usesABuffer ? [aBufferPlugin] : []),
         ...(usesWeightedBlending ? [wboitPlugin] : [])
       ],
@@ -596,8 +639,9 @@ class InstancedMesh<
             depthStencilAttachmentFormat: 'depth24plus' as const
           }
         : {}),
-      parameters:
-        transparent || glass
+      parameters: additive
+        ? ADDITIVE_PARAMETERS
+        : transparent || glass
           ? TRANSPARENT_PARAMETERS
           : {
               depthWriteEnabled: true,
@@ -678,6 +722,7 @@ class NetworkNodePopup {
   show(node: PickableNetworkNode, clientPosition: [number, number]): void {
     this.titleElement.textContent = node.title;
     this.roleElement.textContent = node.role;
+    this.roleElement.style.color = node.status === 'offline' ? '#ffad52' : '#82acf2';
     this.descriptionElement.textContent = node.description;
     this.detailElement.textContent = node.detail;
     this.popupElement.style.display = 'block';
@@ -765,6 +810,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly pickingManager: PickingManager;
   readonly pickableNodes: PickableNetworkNode[];
   readonly glassInstances: GlassInstance[];
+  readonly originalGlassColors: Color[];
+  readonly failedSwitchIndices = new Set<number>();
+  readonly conversationRoutes: ConversationRoute[];
+  readonly networkLinks: NetworkLink[];
   readonly sortedGlass: InstancedMesh<{
     app: AppUniforms;
     glassMaterial: GlassMaterialProps;
@@ -786,14 +835,29 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     app: AppUniforms;
     emissiveMaterial: EmissiveMaterialProps;
   }>;
+  readonly packetTrails: InstancedMesh<{
+    app: AppUniforms;
+    emissiveMaterial: EmissiveMaterialProps;
+  }>;
+  readonly switchFlashes: InstancedMesh<{
+    app: AppUniforms;
+    emissiveMaterial: EmissiveMaterialProps;
+  }>;
   readonly packetDefinitions: Packet[];
   readonly packetMatrices: Float32Array;
+  readonly packetTrailMatrices: Float32Array;
+  readonly packetTrailColors: Float32Array;
+  switchArrivalEvents: SwitchArrival[];
+  readonly switchFlashMatrices: Float32Array;
+  readonly switchFlashColors: Float32Array;
+  readonly switchFlashStrengths: Float32Array;
   orbitControls: OrbitControls | null = null;
   nodePopup: NetworkNodePopup | null = null;
 
   private canvas: HTMLCanvasElement | null = null;
   private pendingPickRequest: NetworkNodePickRequest | null = null;
   private pickingInProgress = false;
+  private pointerDownPosition: [number, number] | null = null;
   private pointerSequence = 0;
 
   transparencyMode: TransparencyMode;
@@ -804,6 +868,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   glassDispersion = 0.022;
   glassThickness = 1.05;
   packetEmission = 5.2;
+  packetTrailLength = 0.19;
+  packetTrailIntensity = 0.55;
+  switchFlashIntensity = 0.8;
   packetLightIntensity = 0.66;
   packetLightRadius = 1.05;
   bloomIntensity = 1.7;
@@ -851,13 +918,13 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       colorFormat: this.sceneColorFormat
     });
 
-    const conversationRoutes = makeConversationRoutes();
-    const links = makeLinks(conversationRoutes);
+    this.conversationRoutes = makeConversationRoutes();
+    this.networkLinks = makeLinks(this.conversationRoutes);
     this.links = new InstancedMesh(device, this.reflectiveShaderInputs, {
       id: 'packet-spraying-links',
       geometry: new CylinderGeometry({radius: 1, height: 1, nradial: 16, nvertical: 1}),
-      matrices: flattenMatrices(links.map(link => makeLinkMatrix(link, 0.09))),
-      colors: flattenColors(links.map(({color}) => color)),
+      matrices: flattenMatrices(this.networkLinks.map(link => makeLinkMatrix(link, 0.09))),
+      colors: flattenColors(this.networkLinks.map(({color}) => color)),
       transparent: true,
       reflective: true
     });
@@ -873,6 +940,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     });
 
     this.glassInstances = makeGlassInstances();
+    this.originalGlassColors = this.glassInstances.map(instance => [...instance.color] as Color);
     this.pickableNodes = makePickableNetworkNodes();
     this.pickingManager = new PickingManager(device, {
       shaderInputs: this.pickingShaderInputs,
@@ -927,9 +995,18 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         )
       : null;
 
-    this.packetDefinitions = makePackets(conversationRoutes);
+    this.packetDefinitions = makePackets(this.conversationRoutes);
     this.packetMatrices = new Float32Array(this.packetDefinitions.length * 16);
-    this.updatePacketMatrices(0);
+    this.packetTrailMatrices = new Float32Array(this.packetDefinitions.length * 16);
+    this.packetTrailColors = flattenColors(
+      this.packetDefinitions.map(packet => makeBalancedEmissionColor(packet.color, 0.42))
+    );
+    this.switchArrivalEvents = makeSwitchArrivals(this.packetDefinitions);
+    const switchFlashCount = this.glassInstances.length * CONVERSATIONS.length;
+    this.switchFlashMatrices = new Float32Array(switchFlashCount * 16);
+    this.switchFlashColors = new Float32Array(switchFlashCount * 4);
+    this.switchFlashStrengths = new Float32Array(switchFlashCount);
+    this.updatePacketVisuals(0);
     this.packets = new InstancedMesh(device, this.emissiveShaderInputs, {
       id: 'packet-spraying-packets',
       geometry: new SphereGeometry({radius: 1, nlat: 8, nlong: 12}),
@@ -937,6 +1014,28 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       colors: flattenColors(
         this.packetDefinitions.map(packet => makeBalancedEmissionColor(packet.color, packet.alpha))
       ),
+      emissive: true
+    });
+    this.packetTrails = new InstancedMesh(device, this.emissiveShaderInputs, {
+      id: 'packet-spraying-packet-trails',
+      geometry: new TruncatedConeGeometry({
+        bottomRadius: 0.14,
+        topRadius: 1,
+        height: 1,
+        nradial: 10,
+        nvertical: 3
+      }),
+      matrices: this.packetTrailMatrices,
+      colors: this.packetTrailColors,
+      additive: true,
+      trail: true
+    });
+    this.switchFlashes = new InstancedMesh(device, this.emissiveShaderInputs, {
+      id: 'packet-spraying-switch-arrival-flashes',
+      geometry: new SphereGeometry({radius: 1, nlat: 8, nlong: 12}),
+      matrices: this.switchFlashMatrices,
+      colors: this.switchFlashColors,
+      additive: true,
       emissive: true
     });
 
@@ -952,6 +1051,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         glassDispersion: this.glassDispersion,
         glassThickness: this.glassThickness,
         packetEmission: this.packetEmission,
+        packetTrailLength: this.packetTrailLength,
+        packetTrailIntensity: this.packetTrailIntensity,
+        switchFlashIntensity: this.switchFlashIntensity,
         packetLightIntensity: this.packetLightIntensity,
         packetLightRadius: this.packetLightRadius,
         bloomIntensity: this.bloomIntensity,
@@ -983,14 +1085,18 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       canvas.addEventListener('pointermove', this.handlePointerMove);
       canvas.addEventListener('pointerdown', this.handlePointerDown);
       canvas.addEventListener('pointerleave', this.handlePointerLeave);
+      canvas.addEventListener('click', this.handleSwitchClick);
+      this.updateFailureAccessibility();
     }
   }
 
   override onRender({device, width, height, aspect, time}: AnimationProps): void {
     this.resizeSceneFramebuffer(width, height);
     const animationTime = time / 1000;
-    this.updatePacketMatrices(animationTime * this.speed);
+    this.updatePacketVisuals(animationTime * this.speed);
     this.packets.updateMatrices(this.packetMatrices);
+    this.packetTrails.updateInstances(this.packetTrailMatrices, this.packetTrailColors);
+    this.switchFlashes.updateInstances(this.switchFlashMatrices, this.switchFlashColors);
 
     this.orbitControls?.update(time);
     const eye: Vector3 = this.orbitControls?.getEyePosition() || [5.2, 6.2, 9.1];
@@ -1043,6 +1149,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
     this.hosts.model.predraw(device.commandEncoder);
     this.packets.model.predraw(device.commandEncoder);
+    this.packetTrails.model.predraw(device.commandEncoder);
+    this.switchFlashes.model.predraw(device.commandEncoder);
     this.links.model.predraw(device.commandEncoder);
     const sceneRenderPass = device.beginRenderPass({
       framebuffer: this.sceneFramebuffer,
@@ -1051,6 +1159,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     });
     this.hosts.model.draw(sceneRenderPass);
     this.packets.model.draw(sceneRenderPass);
+    this.packetTrails.model.draw(sceneRenderPass);
+    this.switchFlashes.model.draw(sceneRenderPass);
     this.links.model.draw(sceneRenderPass);
     sceneRenderPass.end();
 
@@ -1144,6 +1254,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.canvas?.removeEventListener('pointermove', this.handlePointerMove);
     this.canvas?.removeEventListener('pointerdown', this.handlePointerDown);
     this.canvas?.removeEventListener('pointerleave', this.handlePointerLeave);
+    this.canvas?.removeEventListener('click', this.handleSwitchClick);
     this.nodePopup?.destroy();
     this.settingsPanel.finalize();
     this.panels.finalize();
@@ -1157,6 +1268,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.aBufferGlass?.destroy();
     this.weightedBlendedGlass?.destroy();
     this.packets.destroy();
+    this.packetTrails.destroy();
+    this.switchFlashes.destroy();
     this.postprocessingRenderer.destroy();
     this.aBufferRenderer?.destroy();
     this.weightedBlendedRenderer?.destroy();
@@ -1179,7 +1292,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
     const pickRequest = this.pendingPickRequest;
     this.pendingPickRequest = null;
-    if (!this.pickingManager.shouldPick(pickRequest.canvasPosition)) {
+    if (
+      pickRequest.action === 'hover' &&
+      !this.pickingManager.shouldPick(pickRequest.canvasPosition)
+    ) {
       return;
     }
 
@@ -1204,10 +1320,21 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         }
 
         const objectIndex = pickInfo?.objectIndex;
+        if (
+          pickRequest.action === 'toggle-switch' &&
+          objectIndex !== null &&
+          objectIndex !== undefined
+        ) {
+          const switchIndex = objectIndex - HOST_POSITIONS.length;
+          if (switchIndex >= 0 && switchIndex < this.glassInstances.length) {
+            this.toggleSwitchFailure(switchIndex);
+          }
+        }
+
         const node =
           objectIndex === null || objectIndex === undefined
             ? undefined
-            : this.pickableNodes[objectIndex];
+            : this.getPickableNode(objectIndex);
         if (node) {
           this.nodePopup?.show(node, pickRequest.clientPosition);
           if (this.canvas) {
@@ -1233,14 +1360,37 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
     const bounds = this.canvas.getBoundingClientRect();
     this.pendingPickRequest = {
+      action: 'hover',
       canvasPosition: [event.clientX - bounds.left, event.clientY - bounds.top],
       clientPosition: [event.clientX, event.clientY],
       pointerSequence: ++this.pointerSequence
     };
   };
 
-  private readonly handlePointerDown = (): void => {
+  private readonly handlePointerDown = (event: PointerEvent): void => {
+    this.pointerDownPosition = [event.clientX, event.clientY];
     this.handlePointerLeave();
+  };
+
+  private readonly handleSwitchClick = (event: MouseEvent): void => {
+    const pointerDownPosition = this.pointerDownPosition;
+    this.pointerDownPosition = null;
+    if (
+      !this.canvas ||
+      event.button !== 0 ||
+      !pointerDownPosition ||
+      Math.hypot(event.clientX - pointerDownPosition[0], event.clientY - pointerDownPosition[1]) > 5
+    ) {
+      return;
+    }
+
+    const bounds = this.canvas.getBoundingClientRect();
+    this.pendingPickRequest = {
+      action: 'toggle-switch',
+      canvasPosition: [event.clientX - bounds.left, event.clientY - bounds.top],
+      clientPosition: [event.clientX, event.clientY],
+      pointerSequence: ++this.pointerSequence
+    };
   };
 
   private readonly handlePointerLeave = (): void => {
@@ -1249,6 +1399,97 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.pickingManager.clearPickState();
     this.nodePopup?.hide();
   };
+
+  private getPickableNode(objectIndex: number): PickableNetworkNode | undefined {
+    const node = this.pickableNodes[objectIndex];
+    if (!node || objectIndex < HOST_POSITIONS.length) {
+      return node;
+    }
+
+    const switchIndex = objectIndex - HOST_POSITIONS.length;
+    if (this.failedSwitchIndices.has(switchIndex)) {
+      return {
+        ...node,
+        role: `OFFLINE / ${node.role}`,
+        description:
+          'This switch is unavailable. MRC immediately removes every affected route and sprays packets across the remaining healthy paths.',
+        detail: 'Click again to restore this switch and return its paths to service.',
+        status: 'offline'
+      };
+    }
+
+    return {
+      ...node,
+      detail: `${node.detail} Click to simulate a switch failure.`,
+      status: 'online'
+    };
+  }
+
+  private toggleSwitchFailure(switchIndex: number): void {
+    if (this.failedSwitchIndices.has(switchIndex)) {
+      this.failedSwitchIndices.delete(switchIndex);
+      this.glassInstances[switchIndex].color = [...this.originalGlassColors[switchIndex]] as Color;
+    } else {
+      this.failedSwitchIndices.add(switchIndex);
+      this.glassInstances[switchIndex].color = [...FAILED_SWITCH_COLOR];
+    }
+
+    this.updateSwitchColors();
+    this.updateHealthyRoutes();
+    this.updateFailureAccessibility();
+  }
+
+  private updateSwitchColors(): void {
+    const matrices = flattenMatrices(this.glassInstances.map(instance => instance.matrix));
+    const colors = flattenColors(this.glassInstances.map(instance => instance.color));
+    this.sortedGlass.updateInstances(matrices, colors);
+    this.aBufferGlass?.updateInstances(matrices, colors);
+    this.weightedBlendedGlass?.updateInstances(matrices, colors);
+  }
+
+  private updateHealthyRoutes(): void {
+    const healthyRoutes = getHealthyConversationRoutes(
+      this.conversationRoutes,
+      this.failedSwitchIndices
+    );
+    reroutePackets(this.packetDefinitions, healthyRoutes);
+    this.switchArrivalEvents = makeSwitchArrivals(this.packetDefinitions);
+    const activeLinkKeys = makeActiveLinkKeys(healthyRoutes);
+
+    for (const link of this.networkLinks) {
+      const failed =
+        isFailedSwitchPosition(link.start, this.failedSwitchIndices) ||
+        isFailedSwitchPosition(link.end, this.failedSwitchIndices);
+      link.color = makeLinkColor(
+        link.start,
+        activeLinkKeys.has(makeLinkKey(link.start, link.end)),
+        failed
+      );
+    }
+    this.links.updateInstances(
+      flattenMatrices(this.networkLinks.map(link => makeLinkMatrix(link, 0.09))),
+      flattenColors(this.networkLinks.map(link => link.color))
+    );
+  }
+
+  private updateFailureAccessibility(): void {
+    if (!this.canvas) {
+      return;
+    }
+
+    const failedCount = this.failedSwitchIndices.size;
+    const activePlaneCount = getActivePlaneCount(
+      getHealthyConversationRoutes(this.conversationRoutes, this.failedSwitchIndices)
+    );
+    this.canvas.dataset.packetSprayingFailedSwitches = String(failedCount);
+    this.canvas.dataset.packetSprayingActivePlanes = String(activePlaneCount);
+    this.canvas.setAttribute(
+      'aria-label',
+      failedCount === 0
+        ? 'Network packet spraying: all switches online'
+        : `Network packet spraying: ${failedCount} switch${failedCount === 1 ? '' : 'es'} offline, ${activePlaneCount} healthy network plane${activePlaneCount === 1 ? '' : 's'}`
+    );
+  }
 
   private resizeSceneFramebuffer(width: number, height: number): void {
     if (this.sceneFramebuffer.width === width && this.sceneFramebuffer.height === height) {
@@ -1285,17 +1526,89 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     );
   }
 
-  private updatePacketMatrices(animationTime: number): void {
+  private updatePacketVisuals(animationTime: number): void {
+    this.switchFlashStrengths.fill(0);
+
     for (let packetIndex = 0; packetIndex < this.packetDefinitions.length; packetIndex++) {
       const packet = this.packetDefinitions[packetIndex];
       const packetAge = wrap(animationTime - packet.launchTime, BURST_CYCLE_DURATION);
       const packetDistance = packetAge * PACKET_TRAVEL_SPEED;
-      const position: Vector3 =
-        packetDistance <= packet.route.totalLength
-          ? getPointAlongRoute(packet.route, packetDistance / packet.route.totalLength)
-          : [0, -100, 0];
+      const packetIsVisible = packet.enabled && packetDistance <= packet.route.totalLength;
+      const position: Vector3 = packetIsVisible
+        ? getPointAlongRoute(packet.route, packetDistance / packet.route.totalLength)
+        : [0, -100, 0];
       const matrix = makeObjectMatrix(position, [packet.scale, packet.scale, packet.scale]);
       this.packetMatrices.set(matrix, packetIndex * 16);
+
+      const trailStartDistance = Math.max(
+        getRouteSegmentStartDistance(packet.route, packetDistance),
+        packetDistance - this.packetTrailLength
+      );
+      const trailLength = packetDistance - trailStartDistance;
+      const trailMatrix =
+        packetIsVisible && this.packetTrailIntensity > 0 && trailLength > 0.012
+          ? makeSegmentMatrix(
+              getPointAlongRoute(packet.route, trailStartDistance / packet.route.totalLength),
+              position,
+              PACKET_TRAIL_RADIUS
+            )
+          : makeObjectMatrix([0, -100, 0], [0.001, 0.001, 0.001]);
+      this.packetTrailMatrices.set(trailMatrix, packetIndex * 16);
+      const trailColor = makeBalancedEmissionColor(packet.color, 0.48);
+      const colorOffset = packetIndex * 4;
+      this.packetTrailColors.set(
+        [
+          trailColor[0] * this.packetTrailIntensity,
+          trailColor[1] * this.packetTrailIntensity,
+          trailColor[2] * this.packetTrailIntensity,
+          trailColor[3]
+        ],
+        colorOffset
+      );
+    }
+
+    for (const arrival of this.switchArrivalEvents) {
+      const arrivalAge = wrap(animationTime - arrival.arrivalTime, BURST_CYCLE_DURATION);
+      if (arrivalAge >= SWITCH_FLASH_DURATION) {
+        continue;
+      }
+
+      const attack = smoothstep(0, 0.018, arrivalAge);
+      const decay = Math.exp(-arrivalAge * 15);
+      const flashIndex = arrival.switchIndex * CONVERSATIONS.length + arrival.conversationIndex;
+      this.switchFlashStrengths[flashIndex] = Math.min(
+        1,
+        this.switchFlashStrengths[flashIndex] + attack * decay
+      );
+    }
+
+    for (let switchIndex = 0; switchIndex < this.glassInstances.length; switchIndex++) {
+      const glassInstance = this.glassInstances[switchIndex];
+      for (
+        let conversationIndex = 0;
+        conversationIndex < CONVERSATIONS.length;
+        conversationIndex++
+      ) {
+        const flashIndex = switchIndex * CONVERSATIONS.length + conversationIndex;
+        const flashStrength = this.switchFlashStrengths[flashIndex] * this.switchFlashIntensity;
+        const flashRadius = 0.055 + Math.min(flashStrength, 1) * 0.085;
+        const flashMatrix =
+          flashStrength > 0.01
+            ? makeObjectMatrix(glassInstance.position, [flashRadius, flashRadius, flashRadius])
+            : makeObjectMatrix([0, -100, 0], [0.001, 0.001, 0.001]);
+        this.switchFlashMatrices.set(flashMatrix, flashIndex * 16);
+
+        const flashColor = makeBalancedEmissionColor(CONVERSATIONS[conversationIndex].color, 1);
+        this.switchFlashColors.set(
+          [
+            flashColor[0] * flashStrength * 0.32,
+            flashColor[1] * flashStrength * 0.32,
+            flashColor[2] * flashStrength * 0.32,
+            Math.min(flashStrength * 0.58, 0.55)
+          ],
+          flashIndex * 4
+        );
+      }
     }
   }
 
@@ -1304,9 +1617,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       return [];
     }
 
-    const switchPositions = [...LEAF_POSITIONS, ...AGGREGATION_POSITIONS, ...SPINE_POSITIONS];
     const candidatesByRoute = new Map<
-      Route,
+      Packet['route'],
       {color: Vector3; position: Vector3; switchDistance: number}[]
     >();
 
@@ -1327,25 +1639,60 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         color: [packet.color[0], packet.color[1], packet.color[2]],
         position,
         switchDistance: Math.min(
-          ...switchPositions.map(switchPosition => getDistanceSquared(position, switchPosition))
+          ...SWITCH_POSITIONS.map(switchPosition => getDistanceSquared(position, switchPosition))
         )
       });
       candidatesByRoute.set(packet.route, candidates);
     }
 
     const lights: OpticalPointLight[] = [];
+    const secondaryLights: OpticalPointLight[] = [];
     for (const candidates of candidatesByRoute.values()) {
       candidates.sort((first, second) => first.switchDistance - second.switchDistance);
-      for (const candidate of candidates.slice(0, 2)) {
-        lights.push({
+      for (const [candidateIndex, candidate] of candidates.slice(0, 2).entries()) {
+        const light = {
           position: candidate.position,
           color: candidate.color,
           intensity: 1,
           radius: this.packetLightRadius
+        };
+        if (candidateIndex === 0) {
+          lights.push(light);
+        } else {
+          secondaryLights.push(light);
+        }
+      }
+    }
+
+    const switchFlashLights: OpticalPointLight[] = [];
+    for (let switchIndex = 0; switchIndex < this.glassInstances.length; switchIndex++) {
+      for (
+        let conversationIndex = 0;
+        conversationIndex < CONVERSATIONS.length;
+        conversationIndex++
+      ) {
+        const flashIndex = switchIndex * CONVERSATIONS.length + conversationIndex;
+        const flashStrength = this.switchFlashStrengths[flashIndex] * this.switchFlashIntensity;
+        if (flashStrength <= 0.08) {
+          continue;
+        }
+
+        const color = CONVERSATIONS[conversationIndex].color;
+        switchFlashLights.push({
+          position: this.glassInstances[switchIndex].position,
+          color: [color[0], color[1], color[2]],
+          intensity: flashStrength * 1.7,
+          radius: this.packetLightRadius * 0.8
         });
       }
     }
-    return lights.slice(0, 16);
+
+    switchFlashLights.sort((first, second) => (second.intensity || 0) - (first.intensity || 0));
+    return [
+      ...lights,
+      ...switchFlashLights.slice(0, MAX_SWITCH_FLASH_LIGHTS),
+      ...secondaryLights
+    ].slice(0, 16);
   }
 
   private makePanel(): Panel {
@@ -1419,6 +1766,27 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.packetEmission = packetEmission;
     }
 
+    const packetTrailLength = getChangedSetting(changedSettings, 'packetTrailLength')?.nextValue;
+    if (typeof packetTrailLength === 'number') {
+      this.packetTrailLength = packetTrailLength;
+    }
+
+    const packetTrailIntensity = getChangedSetting(
+      changedSettings,
+      'packetTrailIntensity'
+    )?.nextValue;
+    if (typeof packetTrailIntensity === 'number') {
+      this.packetTrailIntensity = packetTrailIntensity;
+    }
+
+    const switchFlashIntensity = getChangedSetting(
+      changedSettings,
+      'switchFlashIntensity'
+    )?.nextValue;
+    if (typeof switchFlashIntensity === 'number') {
+      this.switchFlashIntensity = switchFlashIntensity;
+    }
+
     const packetLightIntensity = getChangedSetting(
       changedSettings,
       'packetLightIntensity'
@@ -1455,7 +1823,8 @@ const PACKET_SPRAYING_OVERVIEW_HTML = `\
 <p><strong>Network Packet Spraying</strong></p>
 <p><strong>Two conversations, many routes.</strong> The two servers on the right send independent red and green transfers to two destination servers on the left.</p>
 <p>Packets enter their local Tier 0 switch as separate streams. Once the streams meet, the switch forwards alternating red and green packets across four representative independent network planes. The destination-side switches separate the traffic again and deliver each color to its intended server.</p>
-<p>Muted red and green cubes identify each conversation's source and destination; blue cubes are inactive servers. Glass spheres are switches, and faint tubes show the available fabric links. Emissive packets cast localized colored light onto nearby switches and active links, with restrained multiscale bloom.</p>
+<p>Click a glass switch to simulate a failure. Its sphere turns orange, affected links dim, and packets immediately respray across the remaining healthy routes. Click the switch again to restore it.</p>
+<p>Muted red and green cubes identify each conversation's source and destination; blue cubes are inactive servers. Glass spheres are switches, and faint tubes show the available fabric links. Emissive packets leave short directional trails, briefly illuminate arriving switches, and cast localized colored light onto nearby surfaces.</p>
 <p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Read OpenAI's supercomputer networking and MRC article</a></p>`;
 
 const PACKET_SPRAYING_BACKGROUND_HTML = `\
@@ -1465,76 +1834,8 @@ const PACKET_SPRAYING_BACKGROUND_HTML = `\
 <p><strong>Throughput:</strong> using many paths at once balances traffic, avoids persistent hot spots, and reduces worst-case transfer latency. That matters for synchronous AI training because an entire GPU group can wait for its slowest communication.</p>
 <p><strong>Resilience:</strong> if a link, plane, or switch fails, the sender quickly retires the affected path and keeps using the remaining ones. Losing one of eight interface links reduces peak physical bandwidth by one eighth instead of crashing the training job.</p>
 <p><strong>Source routing:</strong> MRC uses IPv6 Segment Routing (SRv6) to encode a packet's chosen switch sequence. This allows static switch configuration, rapid rerouting, and a simpler control plane without waiting for dynamic routing convergence.</p>
-<p><strong>Rendering:</strong> reusable emissive materials and bounded point lights illuminate refractive glass and reflective links. Floating-point scene color preserves bright packet cores through exact A-buffer OIT, weighted-blended OIT, or depth-sorted alpha blending before multiscale bloom and filmic tone mapping.</p>
+<p><strong>Rendering:</strong> reusable emissive materials shade compact packet cores, velocity-aligned trails, and switch-arrival flashes; bounded point lights illuminate refractive glass and reflective links. Floating-point scene color preserves the directional highlights through exact A-buffer OIT, weighted-blended OIT, or depth-sorted alpha blending before multiscale bloom and filmic tone mapping.</p>
 <p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Supercomputer networking to accelerate large scale AI training</a></p>`;
-
-function makeLinks(conversationRoutes: ConversationRoute[]): NetworkLink[] {
-  const links: NetworkLink[] = [];
-  const activeLinkKeys = new Set<string>();
-
-  for (const {route} of conversationRoutes) {
-    for (let pointIndex = 0; pointIndex < route.points.length - 1; pointIndex++) {
-      activeLinkKeys.add(makeLinkKey(route.points[pointIndex], route.points[pointIndex + 1]));
-    }
-  }
-
-  for (let hostIndex = 0; hostIndex < HOST_POSITIONS.length; hostIndex++) {
-    const rowIndex = Math.floor(hostIndex / HOST_X_POSITIONS.length);
-    const columnIndex = hostIndex % HOST_X_POSITIONS.length;
-    const leafRowOffset = rowIndex < 2 ? 0 : HOST_X_POSITIONS.length;
-    const start = HOST_POSITIONS[hostIndex];
-    const end = LEAF_POSITIONS[leafRowOffset + columnIndex];
-    links.push({
-      start,
-      end,
-      startInset: getBoxSurfaceDistance(start, end, HOST_HALF_EXTENTS),
-      endInset: LEAF_SWITCH_RADIUS,
-      color: activeLinkKeys.has(makeLinkKey(start, end))
-        ? [0.43, 0.61, 0.91, 0.2]
-        : [0.3, 0.42, 0.66, 0.045]
-    });
-  }
-
-  for (let rowIndex = 0; rowIndex < 2; rowIndex++) {
-    const rowOffset = rowIndex * HOST_X_POSITIONS.length;
-    for (let leafColumnIndex = 0; leafColumnIndex < HOST_X_POSITIONS.length; leafColumnIndex++) {
-      for (
-        let aggregationColumnIndex = 0;
-        aggregationColumnIndex < HOST_X_POSITIONS.length;
-        aggregationColumnIndex++
-      ) {
-        const start = LEAF_POSITIONS[rowOffset + leafColumnIndex];
-        const end = AGGREGATION_POSITIONS[rowOffset + aggregationColumnIndex];
-        links.push({
-          start,
-          end,
-          startInset: LEAF_SWITCH_RADIUS,
-          endInset: AGGREGATION_SWITCH_RADIUS,
-          color: activeLinkKeys.has(makeLinkKey(start, end))
-            ? [0.45, 0.61, 0.91, 0.18]
-            : [0.3, 0.42, 0.66, 0.038]
-        });
-      }
-    }
-  }
-
-  for (const aggregationPosition of AGGREGATION_POSITIONS) {
-    for (let spineIndex = 0; spineIndex < SPINE_POSITIONS.length; spineIndex++) {
-      const end = SPINE_POSITIONS[spineIndex];
-      links.push({
-        start: aggregationPosition,
-        end,
-        startInset: AGGREGATION_SWITCH_RADIUS,
-        endInset: SPINE_SWITCH_RADIUS,
-        color: activeLinkKeys.has(makeLinkKey(aggregationPosition, end))
-          ? [0.47, 0.64, 0.93, 0.16]
-          : [0.3, 0.42, 0.66, 0.034]
-      });
-    }
-  }
-
-  return links;
-}
 
 function makeGlassInstances(): GlassInstance[] {
   const makeInstance = (position: Vector3, radius: number, color: Color): GlassInstance => ({
@@ -1554,164 +1855,6 @@ function makeGlassInstances(): GlassInstance[] {
       makeInstance(position, SPINE_SWITCH_RADIUS, [0.3, 0.5, 0.9, 0.34])
     )
   ];
-}
-
-function makePickableNetworkNodes(): PickableNetworkNode[] {
-  const servers = HOST_POSITIONS.map((_, hostIndex) => {
-    const sourceConversationIndex = CONVERSATIONS.findIndex(
-      conversation => conversation.sourceHostIndex === hostIndex
-    );
-    const destinationConversationIndex = CONVERSATIONS.findIndex(
-      conversation => conversation.destinationHostIndex === hostIndex
-    );
-    const rowIndex = Math.floor(hostIndex / HOST_X_POSITIONS.length) + 1;
-    const columnIndex = (hostIndex % HOST_X_POSITIONS.length) + 1;
-
-    if (sourceConversationIndex >= 0) {
-      const trafficColor = sourceConversationIndex === 0 ? 'red' : 'green';
-      return {
-        title: `Server ${hostIndex + 1}`,
-        role: `${trafficColor.toUpperCase()} source / grid row ${rowIndex}, column ${columnIndex}`,
-        description: `This server originates the ${trafficColor} transfer and sends its packets to a local Tier 0 switch.`,
-        detail:
-          'The outgoing stream is sprayed across independent network planes after meeting the other conversation.'
-      };
-    }
-
-    if (destinationConversationIndex >= 0) {
-      const trafficColor = destinationConversationIndex === 0 ? 'red' : 'green';
-      return {
-        title: `Server ${hostIndex + 1}`,
-        role: `${trafficColor.toUpperCase()} destination / grid row ${rowIndex}, column ${columnIndex}`,
-        description: `This server receives the ${trafficColor} transfer after the destination-side switches separate the interleaved streams.`,
-        detail:
-          'MRC writes each packet to its final memory address, so packets can arrive through different paths and out of order.'
-      };
-    }
-
-    return {
-      title: `Server ${hostIndex + 1}`,
-      role: `Available compute server / grid row ${rowIndex}, column ${columnIndex}`,
-      description:
-        'This server represents another GPU host connected to the same resilient network fabric.',
-      detail:
-        'It is not part of the two active conversations, so its links do not carry moving packets.'
-    };
-  });
-
-  const leafSwitches = LEAF_POSITIONS.map((_, switchIndex) => {
-    const side = switchIndex < HOST_X_POSITIONS.length ? 'source' : 'destination';
-    const columnIndex = (switchIndex % HOST_X_POSITIONS.length) + 1;
-    return {
-      title: `Tier 0 access switch ${switchIndex + 1}`,
-      role: `${side.toUpperCase()} side / server column ${columnIndex}`,
-      description:
-        side === 'source'
-          ? 'This switch gathers outgoing server traffic and forwards packets toward the independent planes.'
-          : 'This switch separates returning red and green packets and delivers each stream to the correct destination server.',
-      detail:
-        'Multiple local servers share the access tier; only the active source and destination paths carry packets.'
-    };
-  });
-
-  const aggregationSwitches = AGGREGATION_POSITIONS.map((_, switchIndex) => {
-    const planeIndex = (switchIndex % HOST_X_POSITIONS.length) + 1;
-    const side = switchIndex < HOST_X_POSITIONS.length ? 'ingress' : 'egress';
-    return {
-      title: `Plane ${planeIndex} ${side} switch`,
-      role: `Tier 1 switch / independent network plane ${planeIndex}`,
-      description:
-        side === 'ingress'
-          ? 'This ingress switch accepts alternating red and green packets from the source-side access tier.'
-          : 'This egress switch receives the mixed packet stream and forwards each packet toward its destination.',
-      detail: `Plane ${planeIndex} can continue carrying traffic independently of the other planes.`
-    };
-  });
-
-  const spineSwitches = SPINE_POSITIONS.map((_, switchIndex) => ({
-    title: `Spine switch ${switchIndex + 1}`,
-    role: `Fabric backbone / independent network plane ${switchIndex + 1}`,
-    description:
-      'This spine connects the ingress and egress sides of one independent routing plane.',
-    detail:
-      'Both conversations can share this path, interleaving one red packet with one green packet while other planes carry additional packets.'
-  }));
-
-  return [...servers, ...leafSwitches, ...aggregationSwitches, ...spineSwitches];
-}
-
-function makeConversationRoutes(): ConversationRoute[] {
-  const conversationRoutes: ConversationRoute[] = [];
-  for (let conversationIndex = 0; conversationIndex < CONVERSATIONS.length; conversationIndex++) {
-    const conversation = CONVERSATIONS[conversationIndex];
-    const sourceColumnIndex = conversation.sourceHostIndex % HOST_X_POSITIONS.length;
-    const destinationColumnIndex = conversation.destinationHostIndex % HOST_X_POSITIONS.length;
-    for (let spineIndex = 0; spineIndex < SPINE_POSITIONS.length; spineIndex++) {
-      conversationRoutes.push({
-        conversationIndex,
-        route: makeRoute([
-          HOST_POSITIONS[conversation.sourceHostIndex],
-          LEAF_POSITIONS[sourceColumnIndex],
-          AGGREGATION_POSITIONS[spineIndex],
-          SPINE_POSITIONS[spineIndex],
-          AGGREGATION_POSITIONS[HOST_X_POSITIONS.length + spineIndex],
-          LEAF_POSITIONS[HOST_X_POSITIONS.length + destinationColumnIndex],
-          HOST_POSITIONS[conversation.destinationHostIndex]
-        ])
-      });
-    }
-  }
-
-  return conversationRoutes;
-}
-
-function makePackets(conversationRoutes: ConversationRoute[]): Packet[] {
-  const packets: Packet[] = [];
-
-  for (let conversationIndex = 0; conversationIndex < CONVERSATIONS.length; conversationIndex++) {
-    const conversation = CONVERSATIONS[conversationIndex];
-    const routes = conversationRoutes.filter(
-      route => route.conversationIndex === conversationIndex
-    );
-    for (let packetIndex = 0; packetIndex < PACKETS_PER_BURST; packetIndex++) {
-      const {route} = routes[packetIndex % routes.length];
-      const sourceTravelTime = getDistance(route.points[0], route.points[1]) / PACKET_TRAVEL_SPEED;
-      const launchTime =
-        1 +
-        packetIndex * BURST_PACKET_INTERVAL +
-        (conversationIndex * BURST_PACKET_INTERVAL) / CONVERSATIONS.length -
-        sourceTravelTime;
-      packets.push({
-        route,
-        color: conversation.color,
-        launchTime,
-        scale: 0.05,
-        alpha: 1
-      });
-    }
-  }
-
-  return packets;
-}
-
-function makeHostColor(hostIndex: number): Color {
-  const conversationIndex = CONVERSATIONS.findIndex(
-    conversation =>
-      conversation.sourceHostIndex === hostIndex || conversation.destinationHostIndex === hostIndex
-  );
-  if (conversationIndex === 0) {
-    return [0.48, 0.09, 0.08, 1];
-  }
-  if (conversationIndex === 1) {
-    return [0.07, 0.38, 0.1, 1];
-  }
-  return [0.18, 0.4, 0.92, 1];
-}
-
-function makeLinkKey(start: Vector3, end: Vector3): string {
-  const startKey = start.join(',');
-  const endKey = end.join(',');
-  return startKey < endKey ? `${startKey}:${endKey}` : `${endKey}:${startKey}`;
 }
 
 function makeBalancedEmissionColor(color: Color, alpha: number): Color {
@@ -1787,38 +1930,6 @@ function makeRefractionTexture(
   });
 }
 
-function makeRoute(points: Vector3[]): Route {
-  const cumulativeLengths = [0];
-  let totalLength = 0;
-  for (let pointIndex = 1; pointIndex < points.length; pointIndex++) {
-    totalLength += getDistance(points[pointIndex - 1], points[pointIndex]);
-    cumulativeLengths.push(totalLength);
-  }
-  return {points, cumulativeLengths, totalLength};
-}
-
-function getPointAlongRoute(route: Route, progress: number): Vector3 {
-  const distance = progress * route.totalLength;
-  let segmentIndex = 0;
-  while (
-    segmentIndex < route.cumulativeLengths.length - 2 &&
-    route.cumulativeLengths[segmentIndex + 1] < distance
-  ) {
-    segmentIndex++;
-  }
-
-  const startDistance = route.cumulativeLengths[segmentIndex];
-  const endDistance = route.cumulativeLengths[segmentIndex + 1];
-  const segmentProgress = (distance - startDistance) / (endDistance - startDistance);
-  const start = route.points[segmentIndex];
-  const end = route.points[segmentIndex + 1];
-  return [
-    start[0] + (end[0] - start[0]) * segmentProgress,
-    start[1] + (end[1] - start[1]) * segmentProgress,
-    start[2] + (end[2] - start[2]) * segmentProgress
-  ];
-}
-
 function makeObjectMatrix(position: Vector3, scale: Vector3): Matrix4 {
   return new Matrix4().translate(position).scale(scale);
 }
@@ -1883,33 +1994,13 @@ function flattenColors(colors: Color[]): Float32Array {
   return new Float32Array(colors.flat());
 }
 
-function getDistance(start: Vector3, end: Vector3): number {
-  return Math.hypot(end[0] - start[0], end[1] - start[1], end[2] - start[2]);
-}
-
-function getDistanceSquared(start: Vector3, end: Vector3): number {
-  const differenceX = end[0] - start[0];
-  const differenceY = end[1] - start[1];
-  const differenceZ = end[2] - start[2];
-  return differenceX * differenceX + differenceY * differenceY + differenceZ * differenceZ;
-}
-
-function getBoxSurfaceDistance(start: Vector3, end: Vector3, halfExtents: Vector3): number {
-  const distance = getDistance(start, end);
-  const direction: Vector3 = [
-    (end[0] - start[0]) / distance,
-    (end[1] - start[1]) / distance,
-    (end[2] - start[2]) / distance
-  ];
-  return Math.min(
-    direction[0] === 0 ? Infinity : halfExtents[0] / Math.abs(direction[0]),
-    direction[1] === 0 ? Infinity : halfExtents[1] / Math.abs(direction[1]),
-    direction[2] === 0 ? Infinity : halfExtents[2] / Math.abs(direction[2])
-  );
-}
-
 function wrap(value: number, limit: number): number {
   return ((value % limit) + limit) % limit;
+}
+
+function smoothstep(edgeStart: number, edgeEnd: number, value: number): number {
+  const progress = Math.max(0, Math.min(1, (value - edgeStart) / (edgeEnd - edgeStart)));
+  return progress * progress * (3 - 2 * progress);
 }
 
 function isTransparencyMode(value: unknown): value is TransparencyMode {
@@ -1981,6 +2072,33 @@ function makeSettingsSchema(
             min: 0,
             max: 8,
             step: 0.1
+          },
+          {
+            name: 'packetTrailLength',
+            label: 'Packet Trail Length',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 0.35,
+            step: 0.01
+          },
+          {
+            name: 'packetTrailIntensity',
+            label: 'Packet Trail Intensity',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1.5,
+            step: 0.05
+          },
+          {
+            name: 'switchFlashIntensity',
+            label: 'Switch Arrival Flash',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1.5,
+            step: 0.05
           },
           {
             name: 'packetLightIntensity',

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -3,16 +3,23 @@
 // Copyright (c) vis.gl contributors
 
 import {Texture} from '@luma.gl/core';
-import type {Buffer, Device, Framebuffer, RenderPipelineParameters} from '@luma.gl/core';
+import type {
+  Buffer,
+  Device,
+  Framebuffer,
+  RenderPipelineParameters,
+  TextureFormatColor
+} from '@luma.gl/core';
+import {bloomShaderPassPipeline, toneMapping} from '@luma.gl/effects';
 import type {AnimationProps, Geometry} from '@luma.gl/engine';
 import {
   AnimationLoopTemplate,
-  BackgroundTextureModel,
   colorPicking,
   CubeGeometry,
   CylinderGeometry,
   Model,
   PickingManager,
+  ShaderPassRenderer,
   ShaderInputs,
   SphereGeometry
 } from '@luma.gl/engine';
@@ -22,20 +29,27 @@ import {
   WBOITRenderer,
   aBuffer,
   aBufferPlugin,
+  emissiveMaterial,
+  emissiveMaterialPlugin,
   glassMaterial,
   glassMaterialPlugin,
   getABufferSupport,
   getWBOITSupport,
+  opticalPointLights,
+  opticalPointLightsPlugin,
   reflectiveMaterial,
   reflectiveMaterialPlugin,
   type ABufferShaderModuleProps,
+  type EmissiveMaterialProps,
   type GlassMaterialProps,
+  type OpticalPointLight,
+  type OpticalPointLightsProps,
   type ReflectiveMaterialProps,
   type WBOITShaderModuleProps,
   wboit,
   wboitPlugin
 } from '@luma.gl/experimental';
-import type {ShaderModule, ShaderPlugin} from '@luma.gl/shadertools';
+import type {ShaderModule, ShaderPassPipeline, ShaderPlugin} from '@luma.gl/shadertools';
 import {Matrix4, radians} from '@math.gl/core';
 import {
   type Panel,
@@ -182,7 +196,24 @@ fn fragmentMain(inputs: VertexOutputs) -> @location(0) vec4<f32> {
 const REFLECTIVE_WGSL_SHADER = /* wgsl */ `${WGSL_SHADER}
 @fragment
 fn fragmentReflective(inputs: VertexOutputs) -> @location(0) vec4<f32> {
-  return reflectiveMaterial_getColor(
+  let color = reflectiveMaterial_getIlluminatedColor(
+    inputs.normal,
+    inputs.worldPosition,
+    inputs.color,
+    app.cameraPosition
+  );
+#if OPAQUE_REFLECTIVE
+  return vec4<f32>(color.rgb, inputs.color.a);
+#else
+  return color;
+#endif
+}
+`;
+
+const EMISSIVE_WGSL_SHADER = /* wgsl */ `${WGSL_SHADER}
+@fragment
+fn fragmentEmissive(inputs: VertexOutputs) -> @location(0) vec4<f32> {
+  return emissiveMaterial_getColor(
     inputs.normal,
     inputs.worldPosition,
     inputs.color,
@@ -194,7 +225,7 @@ fn fragmentReflective(inputs: VertexOutputs) -> @location(0) vec4<f32> {
 const GLASS_WGSL_SHADER = /* wgsl */ `${WGSL_SHADER}
 @fragment
 fn fragmentGlass(inputs: VertexOutputs) -> @location(0) vec4<f32> {
-  let color = glassMaterial_getColor(
+  let color = glassMaterial_getIlluminatedColor(
     inputs.normal,
     inputs.worldPosition,
     inputs.color,
@@ -319,7 +350,7 @@ in vec3 vWorldPosition;
 out vec4 fragColor;
 
 void main(void) {
-  vec4 color = glassMaterial_getColor(
+  vec4 color = glassMaterial_getIlluminatedColor(
     vNormal,
     vWorldPosition,
     vColor,
@@ -365,12 +396,37 @@ in vec3 vWorldPosition;
 out vec4 fragColor;
 
 void main(void) {
-  fragColor = reflectiveMaterial_getColor(
+  vec4 color = reflectiveMaterial_getIlluminatedColor(
     vNormal,
     vWorldPosition,
     vColor,
     app.cameraPosition
   );
+#if OPAQUE_REFLECTIVE
+  fragColor = vec4(color.rgb, vColor.a);
+#else
+  fragColor = color;
+#endif
+}
+`;
+
+const EMISSIVE_FRAGMENT_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+uniform appUniforms {
+  vec3 cameraPosition;
+  mat4 projectionMatrix;
+  mat4 viewMatrix;
+} app;
+
+in vec3 vNormal;
+in vec4 vColor;
+in vec3 vWorldPosition;
+out vec4 fragColor;
+
+void main(void) {
+  fragColor = emissiveMaterial_getColor(vNormal, vWorldPosition, vColor, app.cameraPosition);
 }
 `;
 
@@ -400,8 +456,8 @@ const AGGREGATION_SWITCH_RADIUS = 0.4;
 const SPINE_Y = 2.05;
 const SPINE_SWITCH_RADIUS = 0.55;
 const TRAFFIC_COLORS: Color[] = [
-  [1, 0.16, 0.1, 1],
-  [0.08, 1, 0.34, 1]
+  [1, 0, 0, 1],
+  [0, 1, 0, 1]
 ];
 const PACKETS_PER_BURST = 24;
 const BURST_PACKET_INTERVAL = 0.14;
@@ -458,6 +514,7 @@ class InstancedMesh<
       colors,
       transparent = false,
       glass = false,
+      emissive = false,
       pickable = false,
       reflective = false,
       sceneTexture,
@@ -469,6 +526,7 @@ class InstancedMesh<
       colors: Float32Array;
       transparent?: boolean;
       glass?: boolean;
+      emissive?: boolean;
       pickable?: boolean;
       reflective?: boolean;
       sceneTexture?: Texture;
@@ -487,7 +545,9 @@ class InstancedMesh<
           ? GLASS_WGSL_SHADER
           : reflective
             ? REFLECTIVE_WGSL_SHADER
-            : WGSL_SHADER,
+            : emissive
+              ? EMISSIVE_WGSL_SHADER
+              : WGSL_SHADER,
       vs: pickable ? PICKING_VERTEX_SHADER : VERTEX_SHADER,
       fs: pickable
         ? PICKING_FRAGMENT_SHADER
@@ -495,23 +555,30 @@ class InstancedMesh<
           ? GLASS_FRAGMENT_SHADER
           : reflective
             ? REFLECTIVE_FRAGMENT_SHADER
-            : FRAGMENT_SHADER,
+            : emissive
+              ? EMISSIVE_FRAGMENT_SHADER
+              : FRAGMENT_SHADER,
       fragmentEntryPoint: pickable
         ? 'fragmentPicking'
         : glass
           ? 'fragmentGlass'
           : reflective
             ? 'fragmentReflective'
-            : 'fragmentMain',
+            : emissive
+              ? 'fragmentEmissive'
+              : 'fragmentMain',
       shaderInputs,
       defines: {
         A_BUFFER_ENABLED: usesABuffer ? 1 : 0,
-        WBOIT_ENABLED: usesWeightedBlending ? 1 : 0
+        WBOIT_ENABLED: usesWeightedBlending ? 1 : 0,
+        OPAQUE_REFLECTIVE: reflective && !transparent ? 1 : 0
       },
       plugins: [
         ...(pickable ? [networkNodePickingPlugin] : []),
+        ...(glass || reflective ? [opticalPointLightsPlugin] : []),
         ...(glass ? [glassMaterialPlugin] : []),
         ...(reflective ? [reflectiveMaterialPlugin] : []),
+        ...(emissive ? [emissiveMaterialPlugin] : []),
         ...(usesABuffer ? [aBufferPlugin] : []),
         ...(usesWeightedBlending ? [wboitPlugin] : [])
       ],
@@ -636,39 +703,58 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly shaderInputs = new ShaderInputs<{app: AppUniforms}>({app: appShaderModule});
   readonly reflectiveShaderInputs = new ShaderInputs<{
     app: AppUniforms;
+    opticalPointLights: OpticalPointLightsProps;
     reflectiveMaterial: ReflectiveMaterialProps;
-  }>({app: appShaderModule, reflectiveMaterial});
+  }>({app: appShaderModule, opticalPointLights, reflectiveMaterial});
+  readonly metallicShaderInputs = new ShaderInputs<{
+    app: AppUniforms;
+    opticalPointLights: OpticalPointLightsProps;
+    reflectiveMaterial: ReflectiveMaterialProps;
+  }>({app: appShaderModule, opticalPointLights, reflectiveMaterial});
+  readonly emissiveShaderInputs = new ShaderInputs<{
+    app: AppUniforms;
+    emissiveMaterial: EmissiveMaterialProps;
+  }>({app: appShaderModule, emissiveMaterial});
   readonly glassShaderInputs = new ShaderInputs<{
     app: AppUniforms;
     glassMaterial: GlassMaterialProps;
-  }>({app: appShaderModule, glassMaterial});
+    opticalPointLights: OpticalPointLightsProps;
+  }>({app: appShaderModule, glassMaterial, opticalPointLights});
   readonly aBufferShaderInputs = new ShaderInputs<{
     app: AppUniforms;
     glassMaterial: GlassMaterialProps;
+    opticalPointLights: OpticalPointLightsProps;
     aBuffer: ABufferShaderModuleProps;
-  }>({app: appShaderModule, glassMaterial, aBuffer});
+  }>({app: appShaderModule, glassMaterial, opticalPointLights, aBuffer});
   readonly weightedBlendedShaderInputs = new ShaderInputs<{
     app: AppUniforms;
     glassMaterial: GlassMaterialProps;
+    opticalPointLights: OpticalPointLightsProps;
     wboit: WBOITShaderModuleProps;
-  }>({app: appShaderModule, glassMaterial, wboit});
+  }>({app: appShaderModule, glassMaterial, opticalPointLights, wboit});
   readonly pickingShaderInputs = new ShaderInputs<{
     app: AppUniforms;
     picking: typeof colorPicking.props;
   }>({app: appShaderModule, picking: colorPicking});
   readonly settingsPanel: ExampleSettingsPanelManager;
   readonly panels: ExamplePanelManager;
+  readonly sceneColorFormat: TextureFormatColor;
   readonly sceneFramebuffer: Framebuffer;
-  readonly sceneBackground: BackgroundTextureModel;
+  readonly postprocessingRenderer: ShaderPassRenderer;
   readonly aBufferRenderer: ABufferRenderer | null;
   readonly weightedBlendedRenderer: WBOITRenderer | null;
   sceneTexture: Texture;
   refractionTexture: Texture;
   readonly links: InstancedMesh<{
     app: AppUniforms;
+    opticalPointLights: OpticalPointLightsProps;
     reflectiveMaterial: ReflectiveMaterialProps;
   }>;
-  readonly hosts: InstancedMesh;
+  readonly hosts: InstancedMesh<{
+    app: AppUniforms;
+    opticalPointLights: OpticalPointLightsProps;
+    reflectiveMaterial: ReflectiveMaterialProps;
+  }>;
   readonly pickingHosts: InstancedMesh<{
     app: AppUniforms;
     picking: typeof colorPicking.props;
@@ -683,18 +769,24 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly sortedGlass: InstancedMesh<{
     app: AppUniforms;
     glassMaterial: GlassMaterialProps;
+    opticalPointLights: OpticalPointLightsProps;
   }>;
   readonly aBufferGlass: InstancedMesh<{
     app: AppUniforms;
     glassMaterial: GlassMaterialProps;
+    opticalPointLights: OpticalPointLightsProps;
     aBuffer: ABufferShaderModuleProps;
   }> | null;
   readonly weightedBlendedGlass: InstancedMesh<{
     app: AppUniforms;
     glassMaterial: GlassMaterialProps;
+    opticalPointLights: OpticalPointLightsProps;
     wboit: WBOITShaderModuleProps;
   }> | null;
-  readonly packets: InstancedMesh;
+  readonly packets: InstancedMesh<{
+    app: AppUniforms;
+    emissiveMaterial: EmissiveMaterialProps;
+  }>;
   readonly packetDefinitions: Packet[];
   readonly packetMatrices: Float32Array;
   orbitControls: OrbitControls | null = null;
@@ -712,10 +804,22 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   glassRoughness = 0.14;
   glassDispersion = 0.022;
   glassThickness = 1.05;
+  packetEmission = 5.2;
+  packetLightIntensity = 0.66;
+  packetLightRadius = 1.05;
+  bloomIntensity = 1.7;
+  bloomThreshold = 0.42;
+  exposure = 0.96;
 
   constructor({device, width, height}: AnimationProps) {
     super();
 
+    const requestedOrbit = new URLSearchParams(window.location.search).get('orbit');
+    if (requestedOrbit !== null && Number.isFinite(Number(requestedOrbit))) {
+      this.orbit = Math.max(0, Math.min(Number(requestedOrbit), 0.5));
+    }
+
+    this.sceneColorFormat = getSceneColorFormat(device);
     const supportsABuffer = getABufferSupport(device).supported;
     const supportsWeightedBlending = getWBOITSupport(device).supported;
     this.transparencyMode = supportsABuffer
@@ -727,12 +831,15 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       ? new ABufferRenderer(device, {
           averageFragmentsPerPixel: 6,
           maxFragmentsPerPixel: 20,
-          maxBufferByteLength: 64 * 1024 * 1024
+          maxBufferByteLength: 64 * 1024 * 1024,
+          colorFormat: this.sceneColorFormat
         })
       : null;
-    this.weightedBlendedRenderer = supportsWeightedBlending ? new WBOITRenderer(device) : null;
-    this.sceneTexture = makeSceneTexture(device, width, height);
-    this.refractionTexture = makeRefractionTexture(device, width, height);
+    this.weightedBlendedRenderer = supportsWeightedBlending
+      ? new WBOITRenderer(device, {colorFormat: this.sceneColorFormat})
+      : null;
+    this.sceneTexture = makeSceneTexture(device, width, height, this.sceneColorFormat);
+    this.refractionTexture = makeRefractionTexture(device, width, height, this.sceneColorFormat);
     this.sceneFramebuffer = device.createFramebuffer({
       id: 'packet-spraying-scene-framebuffer',
       width,
@@ -740,10 +847,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       colorAttachments: [this.sceneTexture],
       depthStencilAttachment: 'depth24plus'
     });
-    this.sceneBackground = new BackgroundTextureModel(device, {
-      id: 'packet-spraying-scene-background',
-      backgroundTexture: this.sceneTexture,
-      flipY: device.type === 'webgpu'
+    this.postprocessingRenderer = new ShaderPassRenderer(device, {
+      shaderPasses: [makeBloomPipeline(this.sceneColorFormat), toneMapping],
+      colorFormat: this.sceneColorFormat
     });
 
     const conversationRoutes = makeConversationRoutes();
@@ -751,19 +857,20 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.links = new InstancedMesh(device, this.reflectiveShaderInputs, {
       id: 'packet-spraying-links',
       geometry: new CylinderGeometry({radius: 1, height: 1, nradial: 16, nvertical: 1}),
-      matrices: flattenMatrices(links.map(link => makeLinkMatrix(link, 0.07))),
+      matrices: flattenMatrices(links.map(link => makeLinkMatrix(link, 0.09))),
       colors: flattenColors(links.map(({color}) => color)),
       transparent: true,
       reflective: true
     });
 
-    this.hosts = new InstancedMesh(device, this.shaderInputs, {
+    this.hosts = new InstancedMesh(device, this.metallicShaderInputs, {
       id: 'packet-spraying-hosts',
       geometry: new CubeGeometry({indices: true}),
       matrices: flattenMatrices(
         HOST_POSITIONS.map(position => makeObjectMatrix(position, HOST_HALF_EXTENTS))
       ),
-      colors: flattenColors(HOST_POSITIONS.map(() => [0.18, 0.4, 0.92, 1]))
+      colors: flattenColors(HOST_POSITIONS.map((_, hostIndex) => makeHostColor(hostIndex))),
+      reflective: true
     });
 
     this.glassInstances = makeGlassInstances();
@@ -824,18 +931,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.packetDefinitions = makePackets(conversationRoutes);
     this.packetMatrices = new Float32Array(this.packetDefinitions.length * 16);
     this.updatePacketMatrices(0);
-    this.packets = new InstancedMesh(device, this.shaderInputs, {
+    this.packets = new InstancedMesh(device, this.emissiveShaderInputs, {
       id: 'packet-spraying-packets',
       geometry: new SphereGeometry({radius: 1, nlat: 8, nlong: 12}),
       matrices: this.packetMatrices,
       colors: flattenColors(
-        this.packetDefinitions.map(packet => [
-          packet.color[0],
-          packet.color[1],
-          packet.color[2],
-          packet.alpha
-        ])
-      )
+        this.packetDefinitions.map(packet => makeBalancedEmissionColor(packet.color, packet.alpha))
+      ),
+      emissive: true
     });
 
     this.settingsPanel = new ExampleSettingsPanelManager({
@@ -848,7 +951,13 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         glassIndexOfRefraction: this.glassIndexOfRefraction,
         glassRoughness: this.glassRoughness,
         glassDispersion: this.glassDispersion,
-        glassThickness: this.glassThickness
+        glassThickness: this.glassThickness,
+        packetEmission: this.packetEmission,
+        packetLightIntensity: this.packetLightIntensity,
+        packetLightRadius: this.packetLightRadius,
+        bloomIntensity: this.bloomIntensity,
+        bloomThreshold: this.bloomThreshold,
+        exposure: this.exposure
       },
       onSettingsChange: this.handleSettingsChange
     });
@@ -904,9 +1013,35 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       dispersion: this.glassDispersion,
       thickness: this.glassThickness
     };
+    const pointLightProps: OpticalPointLightsProps = {
+      lights: this.makePacketLights(),
+      intensity: this.packetLightIntensity
+    };
     this.shaderInputs.setProps({app: uniforms});
-    this.reflectiveShaderInputs.setProps({app: uniforms, reflectiveMaterial: {}});
-    this.glassShaderInputs.setProps({app: uniforms, glassMaterial: glassMaterialProps});
+    this.emissiveShaderInputs.setProps({
+      app: uniforms,
+      emissiveMaterial: {intensity: this.packetEmission, rimStrength: 0.32}
+    });
+    this.reflectiveShaderInputs.setProps({
+      app: uniforms,
+      reflectiveMaterial: {},
+      opticalPointLights: pointLightProps
+    });
+    this.metallicShaderInputs.setProps({
+      app: uniforms,
+      reflectiveMaterial: {
+        roughness: 0.32,
+        reflectionStrength: 0.26,
+        specularStrength: 0.58,
+        opacityScale: 1
+      },
+      opticalPointLights: pointLightProps
+    });
+    this.glassShaderInputs.setProps({
+      app: uniforms,
+      glassMaterial: glassMaterialProps,
+      opticalPointLights: pointLightProps
+    });
 
     this.hosts.model.predraw(device.commandEncoder);
     this.packets.model.predraw(device.commandEncoder);
@@ -935,6 +1070,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
           this.aBufferShaderInputs.setProps({
             app: uniforms,
             glassMaterial: glassMaterialProps,
+            opticalPointLights: pointLightProps,
             aBuffer: shaderModuleProps
           });
           this.aBufferGlass?.model.setParameters({...TRANSPARENT_PARAMETERS, ...captureParameters});
@@ -963,6 +1099,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
           this.weightedBlendedShaderInputs.setProps({
             app: uniforms,
             glassMaterial: glassMaterialProps,
+            opticalPointLights: pointLightProps,
             wboit: shaderModuleProps
           });
           this.weightedBlendedGlass?.model.setParameters({
@@ -987,14 +1124,20 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       glassRenderPass.end();
     }
 
-    this.sceneBackground.setProps({backgroundTexture: outputTexture});
-    this.sceneBackground.predraw(device.commandEncoder);
-    const renderPass = device.beginRenderPass({
-      clearColor: [0.003, 0.006, 0.012, 1],
-      clearDepth: 1
+    this.postprocessingRenderer.renderToScreen({
+      sourceTexture: outputTexture,
+      uniforms: {
+        bloomExtract: {
+          threshold:
+            this.sceneColorFormat === 'rgba16float'
+              ? this.bloomThreshold
+              : Math.min(this.bloomThreshold, 0.38)
+        },
+        bloomBlur: {radius: 4},
+        bloomComposite: {intensity: this.bloomIntensity},
+        toneMapping: {exposure: this.exposure}
+      }
     });
-    this.sceneBackground.draw(renderPass);
-    renderPass.end();
 
     this.pickHoveredNode(device, uniforms);
   }
@@ -1016,10 +1159,11 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.aBufferGlass?.destroy();
     this.weightedBlendedGlass?.destroy();
     this.packets.destroy();
-    this.sceneBackground.destroy();
+    this.postprocessingRenderer.destroy();
     this.aBufferRenderer?.destroy();
     this.weightedBlendedRenderer?.destroy();
     this.shaderInputs.destroy();
+    this.emissiveShaderInputs.destroy();
     this.reflectiveShaderInputs.destroy();
     this.pickingShaderInputs.destroy();
     this.glassShaderInputs.destroy();
@@ -1117,7 +1261,13 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     const previousRefractionTexture = this.refractionTexture;
     this.sceneFramebuffer.resize({width, height});
     this.sceneTexture = this.sceneFramebuffer.colorAttachments[0].texture;
-    this.refractionTexture = makeRefractionTexture(this.sceneTexture.device, width, height);
+    this.refractionTexture = makeRefractionTexture(
+      this.sceneTexture.device,
+      width,
+      height,
+      this.sceneColorFormat
+    );
+    this.postprocessingRenderer.resize([width, height]);
     this.sortedGlass.model.setBindings({glassSceneColorTexture: this.refractionTexture});
     this.aBufferGlass?.model.setBindings({glassSceneColorTexture: this.refractionTexture});
     this.weightedBlendedGlass?.model.setBindings({glassSceneColorTexture: this.refractionTexture});
@@ -1149,6 +1299,55 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       const matrix = makeObjectMatrix(position, [packet.scale, packet.scale, packet.scale]);
       this.packetMatrices.set(matrix, packetIndex * 16);
     }
+  }
+
+  private makePacketLights(): OpticalPointLight[] {
+    if (this.packetLightIntensity <= 0 || this.packetLightRadius <= 0) {
+      return [];
+    }
+
+    const switchPositions = [...LEAF_POSITIONS, ...AGGREGATION_POSITIONS, ...SPINE_POSITIONS];
+    const candidatesByRoute = new Map<
+      Route,
+      {color: Vector3; position: Vector3; switchDistance: number}[]
+    >();
+
+    for (let packetIndex = 0; packetIndex < this.packetDefinitions.length; packetIndex++) {
+      const matrixOffset = packetIndex * 16;
+      const position: Vector3 = [
+        this.packetMatrices[matrixOffset + 12],
+        this.packetMatrices[matrixOffset + 13],
+        this.packetMatrices[matrixOffset + 14]
+      ];
+      if (position[1] < HOST_Y - 1) {
+        continue;
+      }
+
+      const packet = this.packetDefinitions[packetIndex];
+      const candidates = candidatesByRoute.get(packet.route) || [];
+      candidates.push({
+        color: [packet.color[0], packet.color[1], packet.color[2]],
+        position,
+        switchDistance: Math.min(
+          ...switchPositions.map(switchPosition => getDistanceSquared(position, switchPosition))
+        )
+      });
+      candidatesByRoute.set(packet.route, candidates);
+    }
+
+    const lights: OpticalPointLight[] = [];
+    for (const candidates of candidatesByRoute.values()) {
+      candidates.sort((first, second) => first.switchDistance - second.switchDistance);
+      for (const candidate of candidates.slice(0, 2)) {
+        lights.push({
+          position: candidate.position,
+          color: candidate.color,
+          intensity: 1,
+          radius: this.packetLightRadius
+        });
+      }
+    }
+    return lights.slice(0, 16);
   }
 
   private makePanel(): Panel {
@@ -1216,6 +1415,39 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     if (typeof glassThickness === 'number') {
       this.glassThickness = glassThickness;
     }
+
+    const packetEmission = getChangedSetting(changedSettings, 'packetEmission')?.nextValue;
+    if (typeof packetEmission === 'number') {
+      this.packetEmission = packetEmission;
+    }
+
+    const packetLightIntensity = getChangedSetting(
+      changedSettings,
+      'packetLightIntensity'
+    )?.nextValue;
+    if (typeof packetLightIntensity === 'number') {
+      this.packetLightIntensity = packetLightIntensity;
+    }
+
+    const packetLightRadius = getChangedSetting(changedSettings, 'packetLightRadius')?.nextValue;
+    if (typeof packetLightRadius === 'number') {
+      this.packetLightRadius = packetLightRadius;
+    }
+
+    const bloomIntensity = getChangedSetting(changedSettings, 'bloomIntensity')?.nextValue;
+    if (typeof bloomIntensity === 'number') {
+      this.bloomIntensity = bloomIntensity;
+    }
+
+    const bloomThreshold = getChangedSetting(changedSettings, 'bloomThreshold')?.nextValue;
+    if (typeof bloomThreshold === 'number') {
+      this.bloomThreshold = bloomThreshold;
+    }
+
+    const exposure = getChangedSetting(changedSettings, 'exposure')?.nextValue;
+    if (typeof exposure === 'number') {
+      this.exposure = exposure;
+    }
   };
 }
 
@@ -1224,7 +1456,7 @@ const PACKET_SPRAYING_ARTICLE_URL = 'https://openai.com/index/mrc-supercomputer-
 const PACKET_SPRAYING_OVERVIEW_HTML = `\
 <p><strong>Two conversations, many routes.</strong> The two servers on the right send independent red and green transfers to two destination servers on the left.</p>
 <p>Packets enter their local Tier 0 switch as separate streams. Once the streams meet, the switch forwards alternating red and green packets across four representative independent network planes. The destination-side switches separate the traffic again and deliver each color to its intended server.</p>
-<p>Blue cubes are servers, glass spheres are switches, and faint tubes show the available fabric links. Only the links needed by the two conversations carry moving packets.</p>
+<p>Muted red and green cubes identify each conversation's source and destination; blue cubes are inactive servers. Glass spheres are switches, and faint tubes show the available fabric links. Emissive packets cast localized colored light onto nearby switches and active links, with restrained multiscale bloom.</p>
 <p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Read OpenAI's supercomputer networking and MRC article</a></p>`;
 
 const PACKET_SPRAYING_BACKGROUND_HTML = `\
@@ -1234,7 +1466,7 @@ const PACKET_SPRAYING_BACKGROUND_HTML = `\
 <p><strong>Throughput:</strong> using many paths at once balances traffic, avoids persistent hot spots, and reduces worst-case transfer latency. That matters for synchronous AI training because an entire GPU group can wait for its slowest communication.</p>
 <p><strong>Resilience:</strong> if a link, plane, or switch fails, the sender quickly retires the affected path and keeps using the remaining ones. Losing one of eight interface links reduces peak physical bandwidth by one eighth instead of crashing the training job.</p>
 <p><strong>Source routing:</strong> MRC uses IPv6 Segment Routing (SRv6) to encode a packet's chosen switch sequence. This allows static switch configuration, rapid rerouting, and a simpler control plane without waiting for dynamic routing convergence.</p>
-<p><strong>Rendering:</strong> this example composes reusable glass and reflective-material shader modules with exact A-buffer OIT, weighted-blended OIT, or depth-sorted alpha blending.</p>
+<p><strong>Rendering:</strong> reusable emissive materials and bounded point lights illuminate refractive glass and reflective links. Floating-point scene color preserves bright packet cores through exact A-buffer OIT, weighted-blended OIT, or depth-sorted alpha blending before multiscale bloom and filmic tone mapping.</p>
 <p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Supercomputer networking to accelerate large scale AI training</a></p>`;
 
 function makeLinks(conversationRoutes: ConversationRoute[]): NetworkLink[] {
@@ -1454,7 +1686,7 @@ function makePackets(conversationRoutes: ConversationRoute[]): Packet[] {
         route,
         color: conversation.color,
         launchTime,
-        scale: 0.115,
+        scale: 0.05,
         alpha: 1
       });
     }
@@ -1463,16 +1695,66 @@ function makePackets(conversationRoutes: ConversationRoute[]): Packet[] {
   return packets;
 }
 
+function makeHostColor(hostIndex: number): Color {
+  const conversationIndex = CONVERSATIONS.findIndex(
+    conversation =>
+      conversation.sourceHostIndex === hostIndex || conversation.destinationHostIndex === hostIndex
+  );
+  if (conversationIndex === 0) {
+    return [0.48, 0.09, 0.08, 1];
+  }
+  if (conversationIndex === 1) {
+    return [0.07, 0.38, 0.1, 1];
+  }
+  return [0.18, 0.4, 0.92, 1];
+}
+
 function makeLinkKey(start: Vector3, end: Vector3): string {
   const startKey = start.join(',');
   const endKey = end.join(',');
   return startKey < endKey ? `${startKey}:${endKey}` : `${endKey}:${startKey}`;
 }
 
-function makeSceneTexture(device: Device, width: number, height: number): Texture {
+function makeBalancedEmissionColor(color: Color, alpha: number): Color {
+  const luminance = color[0] * 0.2126 + color[1] * 0.7152 + color[2] * 0.0722;
+  const brightnessScale = 0.45 / Math.max(luminance, 0.2);
+  return [
+    color[0] * brightnessScale,
+    color[1] * brightnessScale,
+    color[2] * brightnessScale,
+    alpha
+  ];
+}
+
+function makeBloomPipeline(colorFormat: TextureFormatColor): ShaderPassPipeline {
+  return {
+    ...bloomShaderPassPipeline,
+    renderTargets: Object.fromEntries(
+      Object.entries(bloomShaderPassPipeline.renderTargets).map(([targetName, renderTarget]) => [
+        targetName,
+        {...renderTarget, format: colorFormat}
+      ])
+    )
+  };
+}
+
+function getSceneColorFormat(device: Device): TextureFormatColor {
+  const floatingPointCapabilities = device.getTextureFormatCapabilities('rgba16float');
+  if (floatingPointCapabilities.render && floatingPointCapabilities.filter) {
+    return 'rgba16float';
+  }
+  return device.type === 'webgpu' ? device.preferredColorFormat : 'rgba8unorm';
+}
+
+function makeSceneTexture(
+  device: Device,
+  width: number,
+  height: number,
+  format: TextureFormatColor
+): Texture {
   return device.createTexture({
     id: 'packet-spraying-scene-color',
-    format: device.type === 'webgpu' ? device.preferredColorFormat : 'rgba8unorm',
+    format,
     width,
     height,
     usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_SRC,
@@ -1485,10 +1767,15 @@ function makeSceneTexture(device: Device, width: number, height: number): Textur
   });
 }
 
-function makeRefractionTexture(device: Device, width: number, height: number): Texture {
+function makeRefractionTexture(
+  device: Device,
+  width: number,
+  height: number,
+  format: TextureFormatColor
+): Texture {
   return device.createTexture({
     id: 'packet-spraying-refraction-color',
-    format: device.type === 'webgpu' ? device.preferredColorFormat : 'rgba8unorm',
+    format,
     width,
     height,
     usage: Texture.SAMPLE | Texture.COPY_DST,
@@ -1679,6 +1966,67 @@ function makeSettingsSchema(
             min: 0,
             max: 0.5,
             step: 0.01
+          }
+        ]
+      },
+      {
+        id: 'packet-lighting',
+        name: 'Emissive Packets',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'packetEmission',
+            label: 'Packet Emission',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 8,
+            step: 0.1
+          },
+          {
+            name: 'packetLightIntensity',
+            label: 'Local Light Intensity',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2,
+            step: 0.05
+          },
+          {
+            name: 'packetLightRadius',
+            label: 'Local Light Radius',
+            type: 'number',
+            persist: 'none',
+            min: 0.2,
+            max: 2.5,
+            step: 0.05
+          },
+          {
+            name: 'bloomIntensity',
+            label: 'Bloom Intensity',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2.5,
+            step: 0.02
+          },
+          {
+            name: 'bloomThreshold',
+            label: 'Bloom Threshold',
+            type: 'number',
+            persist: 'none',
+            min: 0.2,
+            max: 2.5,
+            step: 0.02
+          },
+          {
+            name: 'exposure',
+            label: 'Exposure',
+            type: 'number',
+            persist: 'none',
+            min: 0.25,
+            max: 2.5,
+            step: 0.05
           }
         ]
       },

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -69,7 +69,9 @@ import {
   AGGREGATION_POSITIONS,
   AGGREGATION_SWITCH_RADIUS,
   BURST_CYCLE_DURATION,
+  CONGESTION_TRIM_INTERVAL,
   CONVERSATIONS,
+  FAILURE_DETECTION_DELAY,
   HOST_HALF_EXTENTS,
   HOST_POSITIONS,
   HOST_Y,
@@ -78,6 +80,7 @@ import {
   PACKET_TRAVEL_SPEED,
   SPINE_POSITIONS,
   SPINE_SWITCH_RADIUS,
+  SWITCH_PROBE_INTERVAL,
   SWITCH_POSITIONS,
   getActivePlaneCount,
   getDistance,
@@ -94,11 +97,15 @@ import {
   makeLinks,
   makePackets,
   makePickableNetworkNodes,
+  makeSwitchPacketEvents,
+  makeSwitchProbeEvent,
   makeSwitchArrivals,
   reroutePackets,
   type Color,
   type ConversationRoute,
   type NetworkLink,
+  type NetworkPacketEvent,
+  type NetworkScenario,
   type Packet,
   type PickableNetworkNode,
   type SwitchArrival,
@@ -497,7 +504,10 @@ const INSTANCE_BUFFER_LAYOUT = [
 const PACKET_TRAIL_RADIUS = 0.033;
 const SWITCH_FLASH_DURATION = 0.16;
 const MAX_SWITCH_FLASH_LIGHTS = 6;
-const FAILED_SWITCH_COLOR: Color = [1, 0.34, 0.07, 0.56];
+const MAX_STORY_PACKET_INSTANCES = 160;
+const CONGESTED_SWITCH_COLOR: Color = [1, 0.42, 0.065, 0.56];
+const DETECTING_SWITCH_COLOR: Color = [1, 0.21, 0.035, 0.59];
+const FAILED_SWITCH_COLOR: Color = [1, 0.065, 0.035, 0.59];
 
 const TRANSPARENT_PARAMETERS = {
   blend: true,
@@ -722,7 +732,12 @@ class NetworkNodePopup {
   show(node: PickableNetworkNode, clientPosition: [number, number]): void {
     this.titleElement.textContent = node.title;
     this.roleElement.textContent = node.role;
-    this.roleElement.style.color = node.status === 'offline' ? '#ffad52' : '#82acf2';
+    this.roleElement.style.color =
+      node.status === 'offline'
+        ? '#ff665a'
+        : node.status === 'congested' || node.status === 'detecting'
+          ? '#ffad52'
+          : '#82acf2';
     this.descriptionElement.textContent = node.description;
     this.detailElement.textContent = node.detail;
     this.popupElement.style.display = 'block';
@@ -811,6 +826,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly pickableNodes: PickableNetworkNode[];
   readonly glassInstances: GlassInstance[];
   readonly originalGlassColors: Color[];
+  readonly congestedSwitchIndices = new Set<number>();
   readonly failedSwitchIndices = new Set<number>();
   readonly conversationRoutes: ConversationRoute[];
   readonly networkLinks: NetworkLink[];
@@ -843,6 +859,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     app: AppUniforms;
     emissiveMaterial: EmissiveMaterialProps;
   }>;
+  readonly storyPackets: InstancedMesh<{
+    app: AppUniforms;
+    emissiveMaterial: EmissiveMaterialProps;
+  }>;
   readonly packetDefinitions: Packet[];
   readonly packetMatrices: Float32Array;
   readonly packetTrailMatrices: Float32Array;
@@ -851,11 +871,20 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly switchFlashMatrices: Float32Array;
   readonly switchFlashColors: Float32Array;
   readonly switchFlashStrengths: Float32Array;
+  readonly storyPacketMatrices = new Float32Array(MAX_STORY_PACKET_INSTANCES * 16);
+  readonly storyPacketColors = new Float32Array(MAX_STORY_PACKET_INSTANCES * 4);
+  readonly networkPacketEvents: NetworkPacketEvent[] = [];
   orbitControls: OrbitControls | null = null;
   nodePopup: NetworkNodePopup | null = null;
 
   private canvas: HTMLCanvasElement | null = null;
   private pendingPickRequest: NetworkNodePickRequest | null = null;
+  private readonly detectingSwitchTimes = new Map<number, number>();
+  private readonly nextCongestionTrimTimes = new Map<number, number>();
+  private readonly nextSwitchProbeTimes = new Map<number, number>();
+  private animationTime = 0;
+  private droppedPacketCount = 0;
+  private trimmedPacketCount = 0;
   private pickingInProgress = false;
   private pointerDownPosition: [number, number] | null = null;
   private pointerSequence = 0;
@@ -1038,6 +1067,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       additive: true,
       emissive: true
     });
+    this.storyPackets = new InstancedMesh(device, this.emissiveShaderInputs, {
+      id: 'packet-spraying-network-story-packets',
+      geometry: new SphereGeometry({radius: 1, nlat: 8, nlong: 12}),
+      matrices: this.storyPacketMatrices,
+      colors: this.storyPacketColors,
+      additive: true,
+      emissive: true
+    });
 
     this.settingsPanel = new ExampleSettingsPanelManager({
       id: 'packet-spraying-settings',
@@ -1092,11 +1129,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
   override onRender({device, width, height, aspect, time}: AnimationProps): void {
     this.resizeSceneFramebuffer(width, height);
-    const animationTime = time / 1000;
-    this.updatePacketVisuals(animationTime * this.speed);
+    this.animationTime = (time / 1000) * this.speed;
+    this.updateSwitchStoryState(this.animationTime);
+    this.updatePacketVisuals(this.animationTime);
+    this.updateStoryPacketVisuals(this.animationTime);
     this.packets.updateMatrices(this.packetMatrices);
     this.packetTrails.updateInstances(this.packetTrailMatrices, this.packetTrailColors);
     this.switchFlashes.updateInstances(this.switchFlashMatrices, this.switchFlashColors);
+    this.storyPackets.updateInstances(this.storyPacketMatrices, this.storyPacketColors);
 
     this.orbitControls?.update(time);
     const eye: Vector3 = this.orbitControls?.getEyePosition() || [5.2, 6.2, 9.1];
@@ -1151,6 +1191,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.packets.model.predraw(device.commandEncoder);
     this.packetTrails.model.predraw(device.commandEncoder);
     this.switchFlashes.model.predraw(device.commandEncoder);
+    this.storyPackets.model.predraw(device.commandEncoder);
     this.links.model.predraw(device.commandEncoder);
     const sceneRenderPass = device.beginRenderPass({
       framebuffer: this.sceneFramebuffer,
@@ -1161,6 +1202,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.packets.model.draw(sceneRenderPass);
     this.packetTrails.model.draw(sceneRenderPass);
     this.switchFlashes.model.draw(sceneRenderPass);
+    this.storyPackets.model.draw(sceneRenderPass);
     this.links.model.draw(sceneRenderPass);
     sceneRenderPass.end();
 
@@ -1270,6 +1312,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.packets.destroy();
     this.packetTrails.destroy();
     this.switchFlashes.destroy();
+    this.storyPackets.destroy();
     this.postprocessingRenderer.destroy();
     this.aBufferRenderer?.destroy();
     this.weightedBlendedRenderer?.destroy();
@@ -1327,7 +1370,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         ) {
           const switchIndex = objectIndex - HOST_POSITIONS.length;
           if (switchIndex >= 0 && switchIndex < this.glassInstances.length) {
-            this.toggleSwitchFailure(switchIndex);
+            this.advanceSwitchState(switchIndex);
           }
         }
 
@@ -1410,33 +1453,126 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     if (this.failedSwitchIndices.has(switchIndex)) {
       return {
         ...node,
-        role: `OFFLINE / ${node.role}`,
+        role: `FAILED / ${node.role}`,
         description:
-          'This switch is unavailable. MRC immediately removes every affected route and sprays packets across the remaining healthy paths.',
+          'This switch dropped in-flight packets. MRC retired its paths, retransmitted the missing data, and now sends occasional recovery probes.',
         detail: 'Click again to restore this switch and return its paths to service.',
         status: 'offline'
       };
     }
 
+    if (this.detectingSwitchTimes.has(switchIndex)) {
+      return {
+        ...node,
+        role: `FAILURE DETECTED / ${node.role}`,
+        description:
+          'Packets reaching this switch are briefly lost while MRC detects the fault and prepares healthy replacement routes.',
+        detail: 'The affected plane will be retired after the packet-loss detection interval.',
+        status: 'detecting'
+      };
+    }
+
+    if (this.congestedSwitchIndices.has(switchIndex)) {
+      return {
+        ...node,
+        role: `CONGESTED / ${node.role}`,
+        description:
+          'This switch trims overloaded packet payloads while forwarding their small headers, allowing senders to retransmit through other paths.',
+        detail: 'Click again to fail this switch and demonstrate path retirement.',
+        status: 'congested'
+      };
+    }
+
     return {
       ...node,
-      detail: `${node.detail} Click to simulate a switch failure.`,
+      detail: `${node.detail} Click to introduce congestion.`,
       status: 'online'
     };
   }
 
-  private toggleSwitchFailure(switchIndex: number): void {
+  private advanceSwitchState(switchIndex: number): void {
     if (this.failedSwitchIndices.has(switchIndex)) {
       this.failedSwitchIndices.delete(switchIndex);
+      this.nextSwitchProbeTimes.delete(switchIndex);
       this.glassInstances[switchIndex].color = [...this.originalGlassColors[switchIndex]] as Color;
+    } else if (this.detectingSwitchTimes.has(switchIndex)) {
+      this.completeSwitchFailure(switchIndex);
+      return;
+    } else if (this.congestedSwitchIndices.has(switchIndex)) {
+      this.congestedSwitchIndices.delete(switchIndex);
+      this.nextCongestionTrimTimes.delete(switchIndex);
+      this.detectingSwitchTimes.set(switchIndex, this.animationTime + FAILURE_DETECTION_DELAY);
+      this.glassInstances[switchIndex].color = [...DETECTING_SWITCH_COLOR];
+      this.enqueueSwitchPacketEvents(switchIndex, 'failure', this.animationTime);
     } else {
-      this.failedSwitchIndices.add(switchIndex);
-      this.glassInstances[switchIndex].color = [...FAILED_SWITCH_COLOR];
+      this.congestedSwitchIndices.add(switchIndex);
+      this.nextCongestionTrimTimes.set(switchIndex, this.animationTime);
+      this.glassInstances[switchIndex].color = [...CONGESTED_SWITCH_COLOR];
     }
 
     this.updateSwitchColors();
     this.updateHealthyRoutes();
     this.updateFailureAccessibility();
+  }
+
+  private completeSwitchFailure(switchIndex: number): void {
+    this.detectingSwitchTimes.delete(switchIndex);
+    this.failedSwitchIndices.add(switchIndex);
+    this.nextSwitchProbeTimes.set(switchIndex, this.animationTime + SWITCH_PROBE_INTERVAL);
+    this.glassInstances[switchIndex].color = [...FAILED_SWITCH_COLOR];
+    this.updateSwitchColors();
+    this.updateHealthyRoutes();
+    this.updateFailureAccessibility();
+  }
+
+  private enqueueSwitchPacketEvents(
+    switchIndex: number,
+    scenario: NetworkScenario,
+    startedAt: number
+  ): void {
+    const events = makeSwitchPacketEvents({
+      packets: this.packetDefinitions,
+      conversationRoutes: this.conversationRoutes,
+      scenario,
+      startedAt,
+      switchIndex
+    });
+    this.networkPacketEvents.push(...events);
+    this.droppedPacketCount += events.filter(event => event.kind === 'dropped-payload').length;
+    this.trimmedPacketCount += events.filter(event => event.kind === 'trimmed-payload').length;
+  }
+
+  private updateSwitchStoryState(animationTime: number): void {
+    for (const [switchIndex, detectionTime] of this.detectingSwitchTimes) {
+      if (animationTime >= detectionTime) {
+        this.completeSwitchFailure(switchIndex);
+      }
+    }
+
+    for (const [switchIndex, nextTrimTime] of this.nextCongestionTrimTimes) {
+      if (animationTime >= nextTrimTime) {
+        this.enqueueSwitchPacketEvents(switchIndex, 'congestion', nextTrimTime);
+        this.nextCongestionTrimTimes.set(switchIndex, nextTrimTime + CONGESTION_TRIM_INTERVAL);
+        this.updateFailureAccessibility();
+      }
+    }
+
+    for (const [switchIndex, nextProbeTime] of this.nextSwitchProbeTimes) {
+      if (animationTime >= nextProbeTime) {
+        const probe = makeSwitchProbeEvent(this.conversationRoutes, switchIndex, nextProbeTime);
+        if (probe) {
+          this.networkPacketEvents.push(probe);
+        }
+        this.nextSwitchProbeTimes.set(switchIndex, nextProbeTime + SWITCH_PROBE_INTERVAL);
+      }
+    }
+
+    for (let eventIndex = this.networkPacketEvents.length - 1; eventIndex >= 0; eventIndex--) {
+      const event = this.networkPacketEvents[eventIndex];
+      if (animationTime > event.startedAt + event.duration) {
+        this.networkPacketEvents.splice(eventIndex, 1);
+      }
+    }
   }
 
   private updateSwitchColors(): void {
@@ -1460,10 +1596,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       const failed =
         isFailedSwitchPosition(link.start, this.failedSwitchIndices) ||
         isFailedSwitchPosition(link.end, this.failedSwitchIndices);
+      const congested =
+        isFailedSwitchPosition(link.start, this.congestedSwitchIndices) ||
+        isFailedSwitchPosition(link.end, this.congestedSwitchIndices);
       link.color = makeLinkColor(
         link.start,
         activeLinkKeys.has(makeLinkKey(link.start, link.end)),
-        failed
+        failed,
+        congested
       );
     }
     this.links.updateInstances(
@@ -1477,17 +1617,21 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       return;
     }
 
+    const congestedCount = this.congestedSwitchIndices.size;
     const failedCount = this.failedSwitchIndices.size;
     const activePlaneCount = getActivePlaneCount(
       getHealthyConversationRoutes(this.conversationRoutes, this.failedSwitchIndices)
     );
+    this.canvas.dataset.packetSprayingCongestedSwitches = String(congestedCount);
     this.canvas.dataset.packetSprayingFailedSwitches = String(failedCount);
     this.canvas.dataset.packetSprayingActivePlanes = String(activePlaneCount);
+    this.canvas.dataset.packetSprayingDroppedPackets = String(this.droppedPacketCount);
+    this.canvas.dataset.packetSprayingTrimmedPackets = String(this.trimmedPacketCount);
     this.canvas.setAttribute(
       'aria-label',
-      failedCount === 0
+      failedCount === 0 && congestedCount === 0
         ? 'Network packet spraying: all switches online'
-        : `Network packet spraying: ${failedCount} switch${failedCount === 1 ? '' : 'es'} offline, ${activePlaneCount} healthy network plane${activePlaneCount === 1 ? '' : 's'}`
+        : `Network packet spraying: ${congestedCount} congested, ${failedCount} failed, ${activePlaneCount} healthy network plane${activePlaneCount === 1 ? '' : 's'}`
     );
   }
 
@@ -1524,6 +1668,98 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       flattenMatrices(sortedInstances.map(instance => instance.matrix)),
       flattenColors(sortedInstances.map(instance => instance.color))
     );
+  }
+
+  private updateStoryPacketVisuals(animationTime: number): void {
+    this.storyPacketMatrices.fill(0);
+    this.storyPacketColors.fill(0);
+    let instanceIndex = 0;
+
+    const addParticle = (position: Vector3, radius: number, color: Color): void => {
+      if (instanceIndex >= MAX_STORY_PACKET_INSTANCES) {
+        return;
+      }
+      this.storyPacketMatrices.set(
+        makeObjectMatrix(position, [radius, radius, radius]),
+        instanceIndex * 16
+      );
+      this.storyPacketColors.set(color, instanceIndex * 4);
+      instanceIndex++;
+    };
+
+    for (const event of this.networkPacketEvents) {
+      const age = animationTime - event.startedAt;
+      if (age < 0 || age > event.duration) {
+        continue;
+      }
+
+      const switchPosition = SWITCH_POSITIONS[event.switchIndex];
+      const routePointIndex = event.route.points.indexOf(switchPosition);
+      if (!switchPosition || routePointIndex < 0) {
+        continue;
+      }
+
+      if (event.kind === 'dropped-payload' || event.kind === 'trimmed-payload') {
+        const progress = age / event.duration;
+        const fragmentCount = event.kind === 'dropped-payload' ? 8 : 6;
+        const spread = (event.kind === 'dropped-payload' ? 1.15 : 0.78) * age;
+        const fragmentRadius =
+          (event.kind === 'dropped-payload' ? 0.036 : 0.028) * (1 - progress * 0.8);
+        const fragmentColor = makeBalancedEmissionColor(
+          event.color,
+          Math.max(0, (1 - progress) * 0.82)
+        );
+
+        for (let fragmentIndex = 0; fragmentIndex < fragmentCount; fragmentIndex++) {
+          const angle =
+            fragmentIndex * 2.399963 + event.conversationIndex * 0.74 + event.switchIndex * 0.33;
+          const elevation = (fragmentIndex % 3) * 0.34 - 0.3;
+          addParticle(
+            [
+              switchPosition[0] + Math.cos(angle) * spread,
+              switchPosition[1] + elevation * spread - age * age * 0.46,
+              switchPosition[2] + Math.sin(angle) * spread
+            ],
+            fragmentRadius,
+            fragmentColor
+          );
+        }
+        continue;
+      }
+
+      if (event.kind === 'trimmed-header') {
+        const startDistance = event.route.cumulativeLengths[routePointIndex];
+        const distance = Math.min(
+          event.route.totalLength,
+          startDistance + age * PACKET_TRAVEL_SPEED
+        );
+        addParticle(
+          getPointAlongRoute(event.route, distance / event.route.totalLength),
+          0.024,
+          makeBalancedEmissionColor(event.color, 0.76)
+        );
+        continue;
+      }
+
+      if (event.kind === 'retransmission') {
+        const distance = Math.min(event.route.totalLength, age * PACKET_TRAVEL_SPEED * 1.16);
+        addParticle(
+          getPointAlongRoute(event.route, distance / event.route.totalLength),
+          0.046,
+          makeBalancedEmissionColor(event.color, 0.92)
+        );
+        continue;
+      }
+
+      const startDistance = event.route.cumulativeLengths[Math.max(0, routePointIndex - 1)];
+      const endDistance = event.route.cumulativeLengths[routePointIndex];
+      const distance = startDistance + (endDistance - startDistance) * (age / event.duration);
+      addParticle(
+        getPointAlongRoute(event.route, distance / event.route.totalLength),
+        0.021,
+        event.color
+      );
+    }
   }
 
   private updatePacketVisuals(animationTime: number): void {
@@ -1823,7 +2059,8 @@ const PACKET_SPRAYING_OVERVIEW_HTML = `\
 <p><strong>Network Packet Spraying</strong></p>
 <p><strong>Two conversations, many routes.</strong> The two servers on the right send independent red and green transfers to two destination servers on the left.</p>
 <p>Packets enter their local Tier 0 switch as separate streams. Once the streams meet, the switch forwards alternating red and green packets across four representative independent network planes. The destination-side switches separate the traffic again and deliver each color to its intended server.</p>
-<p>Click a glass switch to simulate a failure. Its sphere turns orange, affected links dim, and packets immediately respray across the remaining healthy routes. Click the switch again to restore it.</p>
+<p>Click any glass switch to move it through three states: healthy, orange and congested, red and failed, then healthy again.</p>
+<p>An orange switch trims overloaded packet payloads while their smaller headers continue. A red switch briefly loses in-flight packets before MRC retires the failed plane, retransmits over healthy routes, and sends occasional recovery probes.</p>
 <p>Muted red and green cubes identify each conversation's source and destination; blue cubes are inactive servers. Glass spheres are switches, and faint tubes show the available fabric links. Emissive packets leave short directional trails, briefly illuminate arriving switches, and cast localized colored light onto nearby surfaces.</p>
 <p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Read OpenAI's supercomputer networking and MRC article</a></p>`;
 
@@ -1832,7 +2069,8 @@ const PACKET_SPRAYING_BACKGROUND_HTML = `\
 <p><strong>How the two conversations mix:</strong> the red source talks to one destination, and the green source talks to another. Their packets can share the same switch-to-switch link, interleaving one red packet with one green packet before being separated near their destinations.</p>
 <p><strong>Planes and packet spraying:</strong> a high-bandwidth network interface can be split across multiple independent physical planes. In the article's example, an 800 Gb/s interface becomes eight 100 Gb/s connections. This visualization shows four representative paths; each conversation sprays successive packets across all four instead of waiting behind one busy link.</p>
 <p><strong>Throughput:</strong> using many paths at once balances traffic, avoids persistent hot spots, and reduces worst-case transfer latency. That matters for synchronous AI training because an entire GPU group can wait for its slowest communication.</p>
-<p><strong>Resilience:</strong> if a link, plane, or switch fails, the sender quickly retires the affected path and keeps using the remaining ones. Losing one of eight interface links reduces peak physical bandwidth by one eighth instead of crashing the training job.</p>
+<p><strong>Congestion and packet trimming:</strong> if a switch cannot forward an entire packet, it can discard the payload while delivering a small header. The destination uses that header to request a retransmission without confusing congestion for a permanent network failure.</p>
+<p><strong>Resilience:</strong> if a link, plane, or switch fails, only packets already committed to that path are lost. The sender retires the affected route, retransmits through surviving planes, and occasionally probes the failed path for recovery. Losing one of eight interface links reduces peak physical bandwidth by one eighth instead of crashing the training job.</p>
 <p><strong>Source routing:</strong> MRC uses IPv6 Segment Routing (SRv6) to encode a packet's chosen switch sequence. This allows static switch configuration, rapid rerouting, and a simpler control plane without waiting for dynamic routing convergence.</p>
 <p><strong>Rendering:</strong> reusable emissive materials shade compact packet cores, velocity-aligned trails, and switch-arrival flashes; bounded point lights illuminate refractive glass and reflective links. Floating-point scene color preserves the directional highlights through exact A-buffer OIT, weighted-blended OIT, or depth-sorted alpha blending before multiscale bloom and filmic tone mapping.</p>
 <p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Supercomputer networking to accelerate large scale AI training</a></p>`;

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -17,7 +17,9 @@ import {
   colorPicking,
   CubeGeometry,
   CylinderGeometry,
+  GroupNode,
   Model,
+  ModelNode,
   PickingManager,
   ShaderPassRenderer,
   ShaderInputs,
@@ -34,6 +36,8 @@ import {
   emissiveMaterialPlugin,
   glassMaterial,
   glassMaterialPlugin,
+  glassTransmission,
+  glassTransmissionPlugin,
   getABufferSupport,
   getWBOITSupport,
   opticalPointLights,
@@ -43,6 +47,7 @@ import {
   type ABufferShaderModuleProps,
   type EmissiveMaterialProps,
   type GlassMaterialProps,
+  type GlassTransmissionProps,
   type OpticalPointLight,
   type OpticalPointLightsProps,
   type ReflectiveMaterialProps,
@@ -99,6 +104,7 @@ import {
   makePickableNetworkNodes,
   makeSwitchPacketEvents,
   makeSwitchProbeEvent,
+  makeSwitchGroups,
   makeSwitchArrivals,
   reroutePackets,
   type Color,
@@ -106,6 +112,7 @@ import {
   type NetworkLink,
   type NetworkPacketEvent,
   type NetworkScenario,
+  type NetworkSwitchGroupId,
   type Packet,
   type PickableNetworkNode,
   type SwitchArrival,
@@ -124,6 +131,33 @@ type GlassInstance = {
   color: Color;
   matrix: Matrix4;
   position: Vector3;
+};
+
+type GlassRenderGroup = {
+  id: NetworkSwitchGroupId;
+  instances: GlassInstance[];
+  node: ModelNode;
+  backfaces: InstancedMesh<{app: AppUniforms}>;
+  sorted: InstancedMesh<{
+    app: AppUniforms;
+    glassMaterial: GlassMaterialProps;
+    glassTransmission: GlassTransmissionProps;
+    opticalPointLights: OpticalPointLightsProps;
+  }>;
+  aBuffer: InstancedMesh<{
+    app: AppUniforms;
+    glassMaterial: GlassMaterialProps;
+    glassTransmission: GlassTransmissionProps;
+    opticalPointLights: OpticalPointLightsProps;
+    aBuffer: ABufferShaderModuleProps;
+  }> | null;
+  weightedBlended: InstancedMesh<{
+    app: AppUniforms;
+    glassMaterial: GlassMaterialProps;
+    glassTransmission: GlassTransmissionProps;
+    opticalPointLights: OpticalPointLightsProps;
+    wboit: WBOITShaderModuleProps;
+  }> | null;
 };
 
 type NetworkNodePickRequest = {
@@ -247,7 +281,7 @@ fn fragmentTrail(inputs: VertexOutputs) -> @location(0) vec4<f32> {
 const GLASS_WGSL_SHADER = /* wgsl */ `${WGSL_SHADER}
 @fragment
 fn fragmentGlass(inputs: VertexOutputs) -> @location(0) vec4<f32> {
-  let glassColor = glassMaterial_getIlluminatedColor(
+  let glassColor = glassTransmission_getIlluminatedColor(
     inputs.normal,
     inputs.worldPosition,
     inputs.color,
@@ -265,6 +299,14 @@ fn fragmentGlass(inputs: VertexOutputs) -> @location(0) vec4<f32> {
   return color;
 #endif
 #endif
+}
+`;
+
+const GLASS_BACKFACE_WGSL_SHADER = /* wgsl */ `${WGSL_SHADER}
+@fragment
+fn fragmentGlassBackface(inputs: VertexOutputs) -> @location(0) vec4<f32> {
+  let encodedNormal = normalize(inputs.normal) * 0.5 + vec3<f32>(0.5);
+  return vec4<f32>(encodedNormal, inputs.position.z);
 }
 `;
 
@@ -376,7 +418,7 @@ in vec3 vWorldPosition;
 out vec4 fragColor;
 
 void main(void) {
-  vec4 glassColor = glassMaterial_getIlluminatedColor(
+  vec4 glassColor = glassTransmission_getIlluminatedColor(
     vNormal,
     vWorldPosition,
     vColor,
@@ -390,6 +432,18 @@ void main(void) {
 #else
   fragColor = color;
 #endif
+}
+`;
+
+const GLASS_BACKFACE_FRAGMENT_SHADER = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+in vec3 vNormal;
+out vec4 fragColor;
+
+void main(void) {
+  fragColor = vec4(normalize(vNormal) * 0.5 + vec3(0.5), gl_FragCoord.z);
 }
 `;
 
@@ -522,6 +576,11 @@ const TRANSPARENT_PARAMETERS = {
   cullMode: 'none'
 } as const satisfies RenderPipelineParameters;
 
+const GLASS_PARAMETERS = {
+  ...TRANSPARENT_PARAMETERS,
+  cullMode: 'back'
+} as const satisfies RenderPipelineParameters;
+
 const ADDITIVE_PARAMETERS = {
   blend: true,
   blendColorOperation: 'add',
@@ -562,7 +621,12 @@ class InstancedMesh<
       trail = false,
       pickable = false,
       reflective = false,
+      backface = false,
       sceneTexture,
+      sceneDepthTexture,
+      backfaceTexture,
+      environmentTexture,
+      colorAttachmentFormat,
       transparencyMode
     }: {
       id: string;
@@ -576,7 +640,12 @@ class InstancedMesh<
       trail?: boolean;
       pickable?: boolean;
       reflective?: boolean;
+      backface?: boolean;
       sceneTexture?: Texture;
+      sceneDepthTexture?: Texture;
+      backfaceTexture?: Texture;
+      environmentTexture?: Texture;
+      colorAttachmentFormat?: TextureFormatColor;
       transparencyMode?: TransparencyMode;
     }
   ) {
@@ -588,38 +657,44 @@ class InstancedMesh<
       id,
       source: pickable
         ? PICKING_WGSL_SHADER
-        : glass
-          ? GLASS_WGSL_SHADER
-          : reflective
-            ? REFLECTIVE_WGSL_SHADER
-            : trail
-              ? TRAIL_WGSL_SHADER
-              : emissive
-                ? EMISSIVE_WGSL_SHADER
-                : WGSL_SHADER,
+        : backface
+          ? GLASS_BACKFACE_WGSL_SHADER
+          : glass
+            ? GLASS_WGSL_SHADER
+            : reflective
+              ? REFLECTIVE_WGSL_SHADER
+              : trail
+                ? TRAIL_WGSL_SHADER
+                : emissive
+                  ? EMISSIVE_WGSL_SHADER
+                  : WGSL_SHADER,
       vs: pickable ? PICKING_VERTEX_SHADER : VERTEX_SHADER,
       fs: pickable
         ? PICKING_FRAGMENT_SHADER
-        : glass
-          ? GLASS_FRAGMENT_SHADER
-          : reflective
-            ? REFLECTIVE_FRAGMENT_SHADER
-            : trail
-              ? TRAIL_FRAGMENT_SHADER
-              : emissive
-                ? EMISSIVE_FRAGMENT_SHADER
-                : FRAGMENT_SHADER,
+        : backface
+          ? GLASS_BACKFACE_FRAGMENT_SHADER
+          : glass
+            ? GLASS_FRAGMENT_SHADER
+            : reflective
+              ? REFLECTIVE_FRAGMENT_SHADER
+              : trail
+                ? TRAIL_FRAGMENT_SHADER
+                : emissive
+                  ? EMISSIVE_FRAGMENT_SHADER
+                  : FRAGMENT_SHADER,
       fragmentEntryPoint: pickable
         ? 'fragmentPicking'
-        : glass
-          ? 'fragmentGlass'
-          : reflective
-            ? 'fragmentReflective'
-            : trail
-              ? 'fragmentTrail'
-              : emissive
-                ? 'fragmentEmissive'
-                : 'fragmentMain',
+        : backface
+          ? 'fragmentGlassBackface'
+          : glass
+            ? 'fragmentGlass'
+            : reflective
+              ? 'fragmentReflective'
+              : trail
+                ? 'fragmentTrail'
+                : emissive
+                  ? 'fragmentEmissive'
+                  : 'fragmentMain',
       shaderInputs,
       defines: {
         A_BUFFER_ENABLED: usesABuffer ? 1 : 0,
@@ -630,6 +705,7 @@ class InstancedMesh<
         ...(pickable ? [networkNodePickingPlugin] : []),
         ...(glass || reflective ? [opticalPointLightsPlugin] : []),
         ...(glass ? [glassMaterialPlugin] : []),
+        ...(glass ? [glassTransmissionPlugin] : []),
         ...(reflective ? [reflectiveMaterialPlugin] : []),
         ...(emissive || trail ? [emissiveMaterialPlugin] : []),
         ...(usesABuffer ? [aBufferPlugin] : []),
@@ -642,22 +718,45 @@ class InstancedMesh<
         instanceModelMatrices: this.matrixBuffer,
         instanceColor: this.colorBuffer
       },
-      ...(sceneTexture ? {bindings: {glassSceneColorTexture: sceneTexture}} : {}),
+      ...(sceneTexture
+        ? {
+            bindings: {
+              glassSceneColorTexture: sceneTexture,
+              ...(sceneDepthTexture ? {glassSceneDepthTexture: sceneDepthTexture} : {}),
+              ...(backfaceTexture ? {glassBackfaceTexture: backfaceTexture} : {}),
+              ...(environmentTexture ? {glassEnvironmentTexture: environmentTexture} : {})
+            }
+          }
+        : {}),
       ...(pickable
         ? {
             colorAttachmentFormats: ['rgba8unorm' as const],
             depthStencilAttachmentFormat: 'depth24plus' as const
           }
         : {}),
+      ...(backface && colorAttachmentFormat
+        ? {
+            colorAttachmentFormats: [colorAttachmentFormat],
+            depthStencilAttachmentFormat: 'depth24plus' as const
+          }
+        : {}),
       parameters: additive
         ? ADDITIVE_PARAMETERS
-        : transparent || glass
-          ? TRANSPARENT_PARAMETERS
-          : {
+        : backface
+          ? {
               depthWriteEnabled: true,
-              depthCompare: 'less-equal',
-              cullMode: 'back'
+              depthCompare: 'greater-equal',
+              cullMode: 'front'
             }
+          : glass
+            ? GLASS_PARAMETERS
+            : transparent
+              ? TRANSPARENT_PARAMETERS
+              : {
+                  depthWriteEnabled: true,
+                  depthCompare: 'less-equal',
+                  cullMode: 'back'
+                }
     });
   }
 
@@ -760,6 +859,7 @@ class NetworkNodePopup {
 export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTemplate {
   static info = makeExamplePanelHostHtml();
 
+  readonly backfaceShaderInputs = new ShaderInputs<{app: AppUniforms}>({app: appShaderModule});
   readonly reflectiveShaderInputs = new ShaderInputs<{
     app: AppUniforms;
     opticalPointLights: OpticalPointLightsProps;
@@ -777,20 +877,23 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly glassShaderInputs = new ShaderInputs<{
     app: AppUniforms;
     glassMaterial: GlassMaterialProps;
+    glassTransmission: GlassTransmissionProps;
     opticalPointLights: OpticalPointLightsProps;
-  }>({app: appShaderModule, glassMaterial, opticalPointLights});
+  }>({app: appShaderModule, glassMaterial, glassTransmission, opticalPointLights});
   readonly aBufferShaderInputs = new ShaderInputs<{
     app: AppUniforms;
     glassMaterial: GlassMaterialProps;
+    glassTransmission: GlassTransmissionProps;
     opticalPointLights: OpticalPointLightsProps;
     aBuffer: ABufferShaderModuleProps;
-  }>({app: appShaderModule, glassMaterial, opticalPointLights, aBuffer});
+  }>({app: appShaderModule, glassMaterial, glassTransmission, opticalPointLights, aBuffer});
   readonly weightedBlendedShaderInputs = new ShaderInputs<{
     app: AppUniforms;
     glassMaterial: GlassMaterialProps;
+    glassTransmission: GlassTransmissionProps;
     opticalPointLights: OpticalPointLightsProps;
     wboit: WBOITShaderModuleProps;
-  }>({app: appShaderModule, glassMaterial, opticalPointLights, wboit});
+  }>({app: appShaderModule, glassMaterial, glassTransmission, opticalPointLights, wboit});
   readonly pickingShaderInputs = new ShaderInputs<{
     app: AppUniforms;
     picking: typeof colorPicking.props;
@@ -799,11 +902,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly panels: ExamplePanelManager;
   readonly sceneColorFormat: TextureFormatColor;
   readonly sceneFramebuffer: Framebuffer;
+  readonly glassBackfaceFramebuffer: Framebuffer;
   readonly postprocessingRenderer: ShaderPassRenderer;
   readonly aBufferRenderer: ABufferRenderer | null;
   readonly weightedBlendedRenderer: WBOITRenderer | null;
   sceneTexture: Texture;
   refractionTexture: Texture;
+  glassBackfaceTexture: Texture;
+  readonly environmentTexture: Texture;
   readonly links: InstancedMesh<{
     app: AppUniforms;
     opticalPointLights: OpticalPointLightsProps;
@@ -825,28 +931,13 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly pickingManager: PickingManager;
   readonly pickableNodes: PickableNetworkNode[];
   readonly glassInstances: GlassInstance[];
+  readonly glassGroups: GlassRenderGroup[];
+  readonly glassScenegraph: GroupNode;
   readonly originalGlassColors: Color[];
   readonly congestedSwitchIndices = new Set<number>();
   readonly failedSwitchIndices = new Set<number>();
   readonly conversationRoutes: ConversationRoute[];
   readonly networkLinks: NetworkLink[];
-  readonly sortedGlass: InstancedMesh<{
-    app: AppUniforms;
-    glassMaterial: GlassMaterialProps;
-    opticalPointLights: OpticalPointLightsProps;
-  }>;
-  readonly aBufferGlass: InstancedMesh<{
-    app: AppUniforms;
-    glassMaterial: GlassMaterialProps;
-    opticalPointLights: OpticalPointLightsProps;
-    aBuffer: ABufferShaderModuleProps;
-  }> | null;
-  readonly weightedBlendedGlass: InstancedMesh<{
-    app: AppUniforms;
-    glassMaterial: GlassMaterialProps;
-    opticalPointLights: OpticalPointLightsProps;
-    wboit: WBOITShaderModuleProps;
-  }> | null;
   readonly packets: InstancedMesh<{
     app: AppUniforms;
     emissiveMaterial: EmissiveMaterialProps;
@@ -893,9 +984,17 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   speed = 0.85;
   orbit = 0.08;
   glassIndexOfRefraction = 1.48;
-  glassRoughness = 0.14;
-  glassDispersion = 0.022;
-  glassThickness = 1.05;
+  glassRoughness = 0.11;
+  glassDispersion = 0.026;
+  glassThickness = 1.16;
+  glassRefractionStrength = 1.32;
+  glassFresnelStrength = 1.28;
+  glassClearcoatStrength = 1.15;
+  glassIridescenceStrength = 0.16;
+  glassInternalReflectionStrength = 0.72;
+  glassTransmissionStrength = 1.12;
+  glassEnvironmentIntensity = 1.25;
+  glassVolumeThickness = 1;
   packetEmission = 5.2;
   packetTrailLength = 0.19;
   packetTrailIntensity = 0.55;
@@ -942,6 +1041,15 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       colorAttachments: [this.sceneTexture],
       depthStencilAttachment: 'depth24plus'
     });
+    this.glassBackfaceTexture = makeBackfaceTexture(device, width, height, this.sceneColorFormat);
+    this.glassBackfaceFramebuffer = device.createFramebuffer({
+      id: 'packet-spraying-glass-backface-framebuffer',
+      width,
+      height,
+      colorAttachments: [this.glassBackfaceTexture],
+      depthStencilAttachment: 'depth24plus'
+    });
+    this.environmentTexture = makeStudioEnvironmentTexture(device);
     this.postprocessingRenderer = new ShaderPassRenderer(device, {
       shaderPasses: [makeBloomPipeline(this.sceneColorFormat), toneMapping],
       colorFormat: this.sceneColorFormat
@@ -993,36 +1101,70 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       ),
       pickable: true
     });
-    const glassMatrices = flattenMatrices(this.glassInstances.map(instance => instance.matrix));
-    const glassColors = flattenColors(this.glassInstances.map(instance => instance.color));
-    const makeGlassMeshOptions = (id: string, transparencyMode: TransparencyMode) => ({
-      id,
-      geometry: new SphereGeometry({radius: 1, nlat: 16, nlong: 24}),
-      matrices: glassMatrices,
-      colors: glassColors,
-      glass: true,
-      sceneTexture: this.refractionTexture,
-      transparencyMode
+    this.glassGroups = makeSwitchGroups().map(({id, switchIndices}): GlassRenderGroup => {
+      const instances = switchIndices.map(switchIndex => this.glassInstances[switchIndex]);
+      const matrices = flattenMatrices(instances.map(instance => instance.matrix));
+      const colors = flattenColors(instances.map(instance => instance.color));
+      const makeGlassMeshOptions = (mode: string, transparencyMode: TransparencyMode) => ({
+        id: `packet-spraying-${id}-${mode}-glass`,
+        geometry: new SphereGeometry({radius: 1, nlat: 16, nlong: 24}),
+        matrices,
+        colors,
+        glass: true,
+        sceneTexture: this.refractionTexture,
+        sceneDepthTexture: this.sceneFramebuffer.depthStencilAttachment!.texture,
+        backfaceTexture: this.glassBackfaceTexture,
+        environmentTexture: this.environmentTexture,
+        transparencyMode
+      });
+
+      const sorted = new InstancedMesh(
+        device,
+        this.glassShaderInputs,
+        makeGlassMeshOptions('sorted', 'sorted-alpha')
+      );
+
+      return {
+        id,
+        instances,
+        node: new ModelNode({
+          id,
+          model: sorted.model,
+          bounds: [
+            [-1, -1, -1],
+            [1, 1, 1]
+          ],
+          instanceMatrices: instances.map(instance => instance.matrix)
+        }),
+        backfaces: new InstancedMesh(device, this.backfaceShaderInputs, {
+          id: `packet-spraying-${id}-glass-backfaces`,
+          geometry: new SphereGeometry({radius: 1, nlat: 16, nlong: 24}),
+          matrices,
+          colors,
+          backface: true,
+          colorAttachmentFormat: this.sceneColorFormat
+        }),
+        sorted,
+        aBuffer: supportsABuffer
+          ? new InstancedMesh(
+              device,
+              this.aBufferShaderInputs,
+              makeGlassMeshOptions('a-buffer', 'a-buffer')
+            )
+          : null,
+        weightedBlended: supportsWeightedBlending
+          ? new InstancedMesh(
+              device,
+              this.weightedBlendedShaderInputs,
+              makeGlassMeshOptions('weighted', 'weighted-blended')
+            )
+          : null
+      };
     });
-    this.sortedGlass = new InstancedMesh(
-      device,
-      this.glassShaderInputs,
-      makeGlassMeshOptions('packet-spraying-sorted-glass', 'sorted-alpha')
-    );
-    this.aBufferGlass = supportsABuffer
-      ? new InstancedMesh(
-          device,
-          this.aBufferShaderInputs,
-          makeGlassMeshOptions('packet-spraying-a-buffer-glass', 'a-buffer')
-        )
-      : null;
-    this.weightedBlendedGlass = supportsWeightedBlending
-      ? new InstancedMesh(
-          device,
-          this.weightedBlendedShaderInputs,
-          makeGlassMeshOptions('packet-spraying-weighted-glass', 'weighted-blended')
-        )
-      : null;
+    this.glassScenegraph = new GroupNode({
+      id: 'packet-spraying-glass-scenegraph',
+      children: this.glassGroups.map(group => group.node)
+    });
 
     this.packetDefinitions = makePackets(this.conversationRoutes);
     this.packetMatrices = new Float32Array(this.packetDefinitions.length * 16);
@@ -1087,6 +1229,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         glassRoughness: this.glassRoughness,
         glassDispersion: this.glassDispersion,
         glassThickness: this.glassThickness,
+        glassRefractionStrength: this.glassRefractionStrength,
+        glassFresnelStrength: this.glassFresnelStrength,
+        glassClearcoatStrength: this.glassClearcoatStrength,
+        glassIridescenceStrength: this.glassIridescenceStrength,
+        glassInternalReflectionStrength: this.glassInternalReflectionStrength,
+        glassTransmissionStrength: this.glassTransmissionStrength,
+        glassEnvironmentIntensity: this.glassEnvironmentIntensity,
+        glassVolumeThickness: this.glassVolumeThickness,
         packetEmission: this.packetEmission,
         packetTrailLength: this.packetTrailLength,
         packetTrailIntensity: this.packetTrailIntensity,
@@ -1103,9 +1253,15 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.panels.mount();
   }
 
-  override async onInitialize({canvas}: AnimationProps): Promise<void> {
+  override async onInitialize({canvas, device}: AnimationProps): Promise<void> {
     if (canvas instanceof HTMLCanvasElement) {
       this.canvas = canvas;
+      canvas.dataset.packetSprayingDevice = device.info.type;
+      canvas.dataset.packetSprayingGpu = device.info.gpu;
+      canvas.dataset.packetSprayingGpuArchitecture = device.info.gpuArchitecture || '';
+      canvas.dataset.packetSprayingAdapterVendor = device.info.vendor;
+      canvas.dataset.packetSprayingFallback = String(Boolean(device.info.fallback));
+      canvas.dataset.packetSprayingGlassGroups = this.glassGroups.map(group => group.id).join(',');
       this.nodePopup = new NetworkNodePopup(canvas);
       this.orbitControls = new OrbitControls(canvas, {
         target: [0, -0.9, 0],
@@ -1156,7 +1312,22 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       indexOfRefraction: this.glassIndexOfRefraction,
       roughness: this.glassRoughness,
       dispersion: this.glassDispersion,
-      thickness: this.glassThickness
+      thickness: this.glassThickness,
+      refractionStrength: this.glassRefractionStrength,
+      fresnelStrength: this.glassFresnelStrength,
+      clearcoatStrength: this.glassClearcoatStrength,
+      iridescenceStrength: this.glassIridescenceStrength,
+      internalReflectionStrength: this.glassInternalReflectionStrength,
+      transmissionStrength: this.glassTransmissionStrength
+    };
+    const glassTransmissionProps: GlassTransmissionProps = {
+      viewportSize: [width, height],
+      depthRange: [0.1, 60],
+      sceneDepthTexture: this.sceneFramebuffer.depthStencilAttachment!.texture,
+      backfaceTexture: this.glassBackfaceTexture,
+      environmentTexture: this.environmentTexture,
+      environmentIntensity: this.glassEnvironmentIntensity,
+      thicknessStrength: this.glassVolumeThickness
     };
     const pointLightProps: OpticalPointLightsProps = {
       lights: this.makePacketLights(),
@@ -1184,8 +1355,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.glassShaderInputs.setProps({
       app: uniforms,
       glassMaterial: glassMaterialProps,
+      glassTransmission: glassTransmissionProps,
       opticalPointLights: pointLightProps
     });
+    this.backfaceShaderInputs.setProps({app: uniforms});
 
     this.hosts.model.predraw(device.commandEncoder);
     this.packets.model.predraw(device.commandEncoder);
@@ -1206,72 +1379,92 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.links.model.draw(sceneRenderPass);
     sceneRenderPass.end();
 
-    device.commandEncoder.copyTextureToTexture({
-      sourceTexture: this.sceneTexture,
-      destinationTexture: this.refractionTexture
-    });
-
     let outputTexture = this.sceneTexture;
-    if (this.transparencyMode === 'a-buffer' && this.aBufferRenderer && this.aBufferGlass) {
-      outputTexture = this.aBufferRenderer.render({
-        sourceTexture: this.sceneTexture,
-        opaqueDepthTexture: this.sceneFramebuffer.depthStencilAttachment!,
-        prepareTranslucent: ({commandEncoder, shaderModuleProps, captureParameters}) => {
-          this.aBufferShaderInputs.setProps({
-            app: uniforms,
-            glassMaterial: glassMaterialProps,
-            opticalPointLights: pointLightProps,
-            aBuffer: shaderModuleProps
-          });
-          this.aBufferGlass?.model.setParameters({...TRANSPARENT_PARAMETERS, ...captureParameters});
-          this.aBufferGlass?.model.predraw(commandEncoder);
-        },
-        drawTranslucent: renderPass => {
-          this.aBufferGlass?.model.draw(renderPass);
-        }
+    const sortedGroups = this.sortGlassGroups(uniforms.viewMatrix);
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingGlassGroupOrder = sortedGroups
+        .map(group => group.id)
+        .join(',');
+    }
+
+    for (const group of sortedGroups) {
+      group.backfaces.model.predraw(device.commandEncoder);
+      const backfaceRenderPass = device.beginRenderPass({
+        framebuffer: this.glassBackfaceFramebuffer,
+        clearColor: [0, 0, 0, 0],
+        clearDepth: 0
       });
-    } else if (
-      this.transparencyMode === 'weighted-blended' &&
-      this.weightedBlendedRenderer &&
-      this.weightedBlendedGlass
-    ) {
-      outputTexture = this.weightedBlendedRenderer.render({
-        sourceTexture: this.sceneTexture,
-        prepareOpaqueDepth: commandEncoder => {
-          this.hosts.model.predraw(commandEncoder);
-          this.packets.model.predraw(commandEncoder);
-        },
-        drawOpaqueDepth: renderPass => {
-          this.hosts.model.draw(renderPass);
-          this.packets.model.draw(renderPass);
-        },
-        prepareTranslucent: ({commandEncoder, shaderModuleProps, captureParameters}) => {
-          this.weightedBlendedShaderInputs.setProps({
-            app: uniforms,
-            glassMaterial: glassMaterialProps,
-            opticalPointLights: pointLightProps,
-            wboit: shaderModuleProps
-          });
-          this.weightedBlendedGlass?.model.setParameters({
-            ...TRANSPARENT_PARAMETERS,
-            ...captureParameters
-          });
-          this.weightedBlendedGlass?.model.predraw(commandEncoder);
-        },
-        drawTranslucent: renderPass => {
-          this.weightedBlendedGlass?.model.draw(renderPass);
-        }
+      group.backfaces.model.draw(backfaceRenderPass);
+      backfaceRenderPass.end();
+
+      device.commandEncoder.copyTextureToTexture({
+        sourceTexture: outputTexture,
+        destinationTexture: this.refractionTexture
       });
-    } else {
-      this.sortGlassInstances(eye);
-      this.sortedGlass.model.predraw(device.commandEncoder);
-      const glassRenderPass = device.beginRenderPass({
-        framebuffer: this.sceneFramebuffer,
-        clearColor: false,
-        clearDepth: false
-      });
-      this.sortedGlass.model.draw(glassRenderPass);
-      glassRenderPass.end();
+
+      if (this.transparencyMode === 'a-buffer' && this.aBufferRenderer && group.aBuffer) {
+        outputTexture = this.aBufferRenderer.render({
+          sourceTexture: outputTexture,
+          opaqueDepthTexture: this.sceneFramebuffer.depthStencilAttachment!,
+          prepareTranslucent: ({commandEncoder, shaderModuleProps, captureParameters}) => {
+            this.aBufferShaderInputs.setProps({
+              app: uniforms,
+              glassMaterial: glassMaterialProps,
+              glassTransmission: glassTransmissionProps,
+              opticalPointLights: pointLightProps,
+              aBuffer: shaderModuleProps
+            });
+            group.aBuffer?.model.setParameters({...GLASS_PARAMETERS, ...captureParameters});
+            group.aBuffer?.model.predraw(commandEncoder);
+          },
+          drawTranslucent: renderPass => {
+            group.aBuffer?.model.draw(renderPass);
+          }
+        });
+      } else if (
+        this.transparencyMode === 'weighted-blended' &&
+        this.weightedBlendedRenderer &&
+        group.weightedBlended
+      ) {
+        outputTexture = this.weightedBlendedRenderer.render({
+          sourceTexture: outputTexture,
+          prepareOpaqueDepth: commandEncoder => {
+            this.hosts.model.predraw(commandEncoder);
+            this.packets.model.predraw(commandEncoder);
+          },
+          drawOpaqueDepth: renderPass => {
+            this.hosts.model.draw(renderPass);
+            this.packets.model.draw(renderPass);
+          },
+          prepareTranslucent: ({commandEncoder, shaderModuleProps, captureParameters}) => {
+            this.weightedBlendedShaderInputs.setProps({
+              app: uniforms,
+              glassMaterial: glassMaterialProps,
+              glassTransmission: glassTransmissionProps,
+              opticalPointLights: pointLightProps,
+              wboit: shaderModuleProps
+            });
+            group.weightedBlended?.model.setParameters({
+              ...GLASS_PARAMETERS,
+              ...captureParameters
+            });
+            group.weightedBlended?.model.predraw(commandEncoder);
+          },
+          drawTranslucent: renderPass => {
+            group.weightedBlended?.model.draw(renderPass);
+          }
+        });
+      } else {
+        this.sortGlassInstances(group, eye);
+        group.sorted.model.predraw(device.commandEncoder);
+        const glassRenderPass = device.beginRenderPass({
+          framebuffer: this.sceneFramebuffer,
+          clearColor: false,
+          clearDepth: false
+        });
+        group.sorted.model.draw(glassRenderPass);
+        glassRenderPass.end();
+      }
     }
 
     this.postprocessingRenderer.renderToScreen({
@@ -1306,9 +1499,13 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.pickingHosts.destroy();
     this.pickingSwitches.destroy();
     this.pickingManager.destroy();
-    this.sortedGlass.destroy();
-    this.aBufferGlass?.destroy();
-    this.weightedBlendedGlass?.destroy();
+    this.glassScenegraph.removeAll();
+    for (const group of this.glassGroups) {
+      group.backfaces.destroy();
+      group.sorted.destroy();
+      group.aBuffer?.destroy();
+      group.weightedBlended?.destroy();
+    }
     this.packets.destroy();
     this.packetTrails.destroy();
     this.switchFlashes.destroy();
@@ -1316,6 +1513,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.postprocessingRenderer.destroy();
     this.aBufferRenderer?.destroy();
     this.weightedBlendedRenderer?.destroy();
+    this.backfaceShaderInputs.destroy();
     this.emissiveShaderInputs.destroy();
     this.reflectiveShaderInputs.destroy();
     this.metallicShaderInputs.destroy();
@@ -1323,9 +1521,12 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.glassShaderInputs.destroy();
     this.aBufferShaderInputs.destroy();
     this.weightedBlendedShaderInputs.destroy();
+    this.glassBackfaceFramebuffer.destroy();
     this.sceneFramebuffer.destroy();
     this.sceneTexture.destroy();
     this.refractionTexture.destroy();
+    this.glassBackfaceTexture.destroy();
+    this.environmentTexture.destroy();
   }
 
   private pickHoveredNode(device: Device, uniforms: AppUniforms): void {
@@ -1576,11 +1777,13 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   }
 
   private updateSwitchColors(): void {
-    const matrices = flattenMatrices(this.glassInstances.map(instance => instance.matrix));
-    const colors = flattenColors(this.glassInstances.map(instance => instance.color));
-    this.sortedGlass.updateInstances(matrices, colors);
-    this.aBufferGlass?.updateInstances(matrices, colors);
-    this.weightedBlendedGlass?.updateInstances(matrices, colors);
+    for (const group of this.glassGroups) {
+      const matrices = flattenMatrices(group.instances.map(instance => instance.matrix));
+      const colors = flattenColors(group.instances.map(instance => instance.color));
+      group.sorted.updateInstances(matrices, colors);
+      group.aBuffer?.updateInstances(matrices, colors);
+      group.weightedBlended?.updateInstances(matrices, colors);
+    }
   }
 
   private updateHealthyRoutes(): void {
@@ -1642,8 +1845,11 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
     const previousSceneTexture = this.sceneTexture;
     const previousRefractionTexture = this.refractionTexture;
+    const previousBackfaceTexture = this.glassBackfaceTexture;
     this.sceneFramebuffer.resize({width, height});
+    this.glassBackfaceFramebuffer.resize({width, height});
     this.sceneTexture = this.sceneFramebuffer.colorAttachments[0].texture;
+    this.glassBackfaceTexture = this.glassBackfaceFramebuffer.colorAttachments[0].texture;
     this.refractionTexture = makeRefractionTexture(
       this.sceneTexture.device,
       width,
@@ -1651,20 +1857,45 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.sceneColorFormat
     );
     this.postprocessingRenderer.resize([width, height]);
-    this.sortedGlass.model.setBindings({glassSceneColorTexture: this.refractionTexture});
-    this.aBufferGlass?.model.setBindings({glassSceneColorTexture: this.refractionTexture});
-    this.weightedBlendedGlass?.model.setBindings({glassSceneColorTexture: this.refractionTexture});
+    const glassBindings = {
+      glassSceneColorTexture: this.refractionTexture,
+      glassSceneDepthTexture: this.sceneFramebuffer.depthStencilAttachment!.texture,
+      glassBackfaceTexture: this.glassBackfaceTexture,
+      glassEnvironmentTexture: this.environmentTexture
+    };
+    for (const group of this.glassGroups) {
+      group.sorted.model.setBindings(glassBindings);
+      group.aBuffer?.model.setBindings(glassBindings);
+      group.weightedBlended?.model.setBindings(glassBindings);
+    }
     previousSceneTexture.destroy();
     previousRefractionTexture.destroy();
+    previousBackfaceTexture.destroy();
   }
 
-  private sortGlassInstances(cameraPosition: Vector3): void {
-    const sortedInstances = [...this.glassInstances].sort(
+  private sortGlassGroups(viewMatrix: Matrix4): GlassRenderGroup[] {
+    const sortedGroups: GlassRenderGroup[] = [];
+
+    this.glassScenegraph.traverseDepthSorted(
+      node => {
+        const group = this.glassGroups.find(candidate => candidate.node === node);
+        if (group) {
+          sortedGroups.push(group);
+        }
+      },
+      {viewMatrix}
+    );
+
+    return sortedGroups;
+  }
+
+  private sortGlassInstances(group: GlassRenderGroup, cameraPosition: Vector3): void {
+    const sortedInstances = [...group.instances].sort(
       (first, second) =>
         getDistanceSquared(second.position, cameraPosition) -
         getDistanceSquared(first.position, cameraPosition)
     );
-    this.sortedGlass.updateInstances(
+    group.sorted.updateInstances(
       flattenMatrices(sortedInstances.map(instance => instance.matrix)),
       flattenColors(sortedInstances.map(instance => instance.color))
     );
@@ -1997,6 +2228,70 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.glassThickness = glassThickness;
     }
 
+    const glassRefractionStrength = getChangedSetting(
+      changedSettings,
+      'glassRefractionStrength'
+    )?.nextValue;
+    if (typeof glassRefractionStrength === 'number') {
+      this.glassRefractionStrength = glassRefractionStrength;
+    }
+
+    const glassFresnelStrength = getChangedSetting(
+      changedSettings,
+      'glassFresnelStrength'
+    )?.nextValue;
+    if (typeof glassFresnelStrength === 'number') {
+      this.glassFresnelStrength = glassFresnelStrength;
+    }
+
+    const glassClearcoatStrength = getChangedSetting(
+      changedSettings,
+      'glassClearcoatStrength'
+    )?.nextValue;
+    if (typeof glassClearcoatStrength === 'number') {
+      this.glassClearcoatStrength = glassClearcoatStrength;
+    }
+
+    const glassIridescenceStrength = getChangedSetting(
+      changedSettings,
+      'glassIridescenceStrength'
+    )?.nextValue;
+    if (typeof glassIridescenceStrength === 'number') {
+      this.glassIridescenceStrength = glassIridescenceStrength;
+    }
+
+    const glassInternalReflectionStrength = getChangedSetting(
+      changedSettings,
+      'glassInternalReflectionStrength'
+    )?.nextValue;
+    if (typeof glassInternalReflectionStrength === 'number') {
+      this.glassInternalReflectionStrength = glassInternalReflectionStrength;
+    }
+
+    const glassTransmissionStrength = getChangedSetting(
+      changedSettings,
+      'glassTransmissionStrength'
+    )?.nextValue;
+    if (typeof glassTransmissionStrength === 'number') {
+      this.glassTransmissionStrength = glassTransmissionStrength;
+    }
+
+    const glassEnvironmentIntensity = getChangedSetting(
+      changedSettings,
+      'glassEnvironmentIntensity'
+    )?.nextValue;
+    if (typeof glassEnvironmentIntensity === 'number') {
+      this.glassEnvironmentIntensity = glassEnvironmentIntensity;
+    }
+
+    const glassVolumeThickness = getChangedSetting(
+      changedSettings,
+      'glassVolumeThickness'
+    )?.nextValue;
+    if (typeof glassVolumeThickness === 'number') {
+      this.glassVolumeThickness = glassVolumeThickness;
+    }
+
     const packetEmission = getChangedSetting(changedSettings, 'packetEmission')?.nextValue;
     if (typeof packetEmission === 'number') {
       this.packetEmission = packetEmission;
@@ -2072,7 +2367,7 @@ const PACKET_SPRAYING_BACKGROUND_HTML = `\
 <p><strong>Congestion and packet trimming:</strong> if a switch cannot forward an entire packet, it can discard the payload while delivering a small header. The destination uses that header to request a retransmission without confusing congestion for a permanent network failure.</p>
 <p><strong>Resilience:</strong> if a link, plane, or switch fails, only packets already committed to that path are lost. The sender retires the affected route, retransmits through surviving planes, and occasionally probes the failed path for recovery. Losing one of eight interface links reduces peak physical bandwidth by one eighth instead of crashing the training job.</p>
 <p><strong>Source routing:</strong> MRC uses IPv6 Segment Routing (SRv6) to encode a packet's chosen switch sequence. This allows static switch configuration, rapid rerouting, and a simpler control plane without waiting for dynamic routing convergence.</p>
-<p><strong>Rendering:</strong> reusable emissive materials shade compact packet cores, velocity-aligned trails, and switch-arrival flashes; bounded point lights illuminate refractive glass and reflective links. Floating-point scene color preserves the directional highlights through exact A-buffer OIT, weighted-blended OIT, or depth-sorted alpha blending before multiscale bloom and filmic tone mapping.</p>
+<p><strong>Rendering:</strong> reusable glass materials combine grazing-angle Fresnel reflection, GGX microfacet highlights, clearcoat, internal shell reflection, thin-film iridescence, and roughness-aware chromatic transmission. Emissive packet cores, directional trails, and switch flashes illuminate the glass through bounded point lights. Floating-point scene color preserves those highlights through exact A-buffer OIT, weighted-blended OIT, or depth-sorted alpha blending before multiscale bloom and filmic tone mapping.</p>
 <p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Supercomputer networking to accelerate large scale AI training</a></p>`;
 
 function makeGlassInstances(): GlassInstance[] {
@@ -2166,6 +2461,93 @@ function makeRefractionTexture(
       addressModeV: 'clamp-to-edge'
     }
   });
+}
+
+function makeBackfaceTexture(
+  device: Device,
+  width: number,
+  height: number,
+  format: TextureFormatColor
+): Texture {
+  return device.createTexture({
+    id: 'packet-spraying-glass-backfaces',
+    format,
+    width,
+    height,
+    usage: Texture.SAMPLE | Texture.RENDER,
+    sampler: {
+      minFilter: 'linear',
+      magFilter: 'linear',
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'clamp-to-edge'
+    }
+  });
+}
+
+function makeStudioEnvironmentTexture(device: Device): Texture {
+  const width = 256;
+  const height = 128;
+  const pixels = new Uint8Array(width * height * 4);
+  const studioLights = [
+    {direction: [-0.58, 0.64, 0.5], color: [1, 0.92, 0.78], width: 0.11},
+    {direction: [0.72, 0.24, -0.58], color: [0.35, 0.62, 1], width: 0.16},
+    {direction: [0.05, 0.94, 0.33], color: [0.78, 0.88, 1], width: 0.085},
+    {direction: [-0.8, -0.12, -0.58], color: [0.42, 0.35, 0.8], width: 0.2}
+  ];
+
+  for (let row = 0; row < height; row++) {
+    const elevation = (row / (height - 1)) * Math.PI;
+    for (let column = 0; column < width; column++) {
+      const azimuth = (column / (width - 1) - 0.5) * Math.PI * 2;
+      const direction: Vector3 = [
+        Math.cos(azimuth) * Math.sin(elevation),
+        Math.cos(elevation),
+        Math.sin(azimuth) * Math.sin(elevation)
+      ];
+      const horizon = Math.pow(1 - Math.abs(direction[1]), 8);
+      const sky = Math.max(direction[1], 0);
+      const color: Vector3 = [
+        0.035 + sky * 0.065 + horizon * 0.09,
+        0.045 + sky * 0.085 + horizon * 0.12,
+        0.075 + sky * 0.16 + horizon * 0.19
+      ];
+
+      for (const light of studioLights) {
+        const alignment = Math.max(
+          direction[0] * light.direction[0] +
+            direction[1] * light.direction[1] +
+            direction[2] * light.direction[2],
+          0
+        );
+        const intensity = Math.pow(alignment, 1 / light.width ** 2);
+        color[0] += light.color[0] * intensity * 0.78;
+        color[1] += light.color[1] * intensity * 0.78;
+        color[2] += light.color[2] * intensity * 0.78;
+      }
+
+      const pixelOffset = (row * width + column) * 4;
+      pixels[pixelOffset] = Math.round(Math.min(color[0], 1) * 255);
+      pixels[pixelOffset + 1] = Math.round(Math.min(color[1], 1) * 255);
+      pixels[pixelOffset + 2] = Math.round(Math.min(color[2], 1) * 255);
+      pixels[pixelOffset + 3] = 255;
+    }
+  }
+
+  const environmentTexture = device.createTexture({
+    id: 'packet-spraying-studio-environment',
+    width,
+    height,
+    format: 'rgba8unorm',
+    usage: Texture.SAMPLE | Texture.COPY_DST,
+    sampler: {
+      minFilter: 'linear',
+      magFilter: 'linear',
+      addressModeU: 'repeat',
+      addressModeV: 'clamp-to-edge'
+    }
+  });
+  environmentTexture.writeData(pixels);
+  return environmentTexture;
 }
 
 function makeObjectMatrix(position: Vector3, scale: Vector3): Matrix4 {
@@ -2424,6 +2806,78 @@ function makeSettingsSchema(
             persist: 'none',
             min: 0.2,
             max: 2.5,
+            step: 0.05
+          },
+          {
+            name: 'glassRefractionStrength',
+            label: 'Lens Distortion',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2.5,
+            step: 0.05
+          },
+          {
+            name: 'glassFresnelStrength',
+            label: 'Fresnel Edge',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2.5,
+            step: 0.05
+          },
+          {
+            name: 'glassClearcoatStrength',
+            label: 'Clearcoat Highlight',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2.5,
+            step: 0.05
+          },
+          {
+            name: 'glassIridescenceStrength',
+            label: 'Spectral Edge',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 0.6,
+            step: 0.01
+          },
+          {
+            name: 'glassInternalReflectionStrength',
+            label: 'Internal Reflection',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2,
+            step: 0.05
+          },
+          {
+            name: 'glassTransmissionStrength',
+            label: 'Transmission',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1.6,
+            step: 0.05
+          },
+          {
+            name: 'glassEnvironmentIntensity',
+            label: 'Studio Reflections',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 3,
+            step: 0.05
+          },
+          {
+            name: 'glassVolumeThickness',
+            label: 'Volume Thickness',
+            type: 'number',
+            persist: 'none',
+            min: 0.2,
+            max: 2,
             step: 0.05
           }
         ]

--- a/examples/showcase/packet-spraying/index.html
+++ b/examples/showcase/packet-spraying/index.html
@@ -7,9 +7,14 @@
     import {webgpuAdapter} from '@luma.gl/webgpu';
     import AnimationLoopTemplate from './app.ts';
 
-    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-      adapters: [webgpuAdapter, webgl2Adapter]
-    });
+    const requestedDevice = new URLSearchParams(window.location.search).get('device');
+    const adapters =
+      requestedDevice === 'webgl'
+        ? [webgl2Adapter]
+        : requestedDevice === 'webgpu'
+          ? [webgpuAdapter]
+          : [webgpuAdapter, webgl2Adapter];
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters});
     animationLoop.start();
   </script>
   <style>

--- a/examples/showcase/packet-spraying/network.ts
+++ b/examples/showcase/packet-spraying/network.ts
@@ -1,0 +1,477 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export type Vector3 = [number, number, number];
+export type Color = [number, number, number, number];
+
+export type Packet = {
+  alpha: number;
+  color: Color;
+  conversationIndex: number;
+  enabled: boolean;
+  launchTime: number;
+  preferredRouteIndex: number;
+  route: Route;
+  scale: number;
+};
+
+export type SwitchArrival = {
+  arrivalTime: number;
+  conversationIndex: number;
+  switchIndex: number;
+};
+
+export type NetworkLink = {
+  color: Color;
+  end: Vector3;
+  endInset: number;
+  start: Vector3;
+  startInset: number;
+};
+
+export type Conversation = {
+  color: Color;
+  destinationHostIndex: number;
+  sourceHostIndex: number;
+};
+
+export type ConversationRoute = {
+  conversationIndex: number;
+  route: Route;
+};
+
+export type Route = {
+  cumulativeLengths: number[];
+  points: Vector3[];
+  totalLength: number;
+};
+
+export type PickableNetworkNode = {
+  description: string;
+  detail: string;
+  role: string;
+  status?: 'offline' | 'online';
+  title: string;
+};
+
+export const HOST_X_POSITIONS = [-3.6, -1.2, 1.2, 3.6];
+export const HOST_Z_POSITIONS = [2.4, 0.8, -0.8, -2.4];
+export const HOST_Y = -2.75;
+export const HOST_HALF_EXTENTS: Vector3 = [0.42, 0.27, 0.32];
+export const LEAF_Y = -1.05;
+export const LEAF_SWITCH_RADIUS = 0.42;
+export const AGGREGATION_Y = 0.35;
+export const AGGREGATION_SWITCH_RADIUS = 0.4;
+export const SPINE_Y = 2.05;
+export const SPINE_SWITCH_RADIUS = 0.55;
+
+const TRAFFIC_COLORS: Color[] = [
+  [1, 0, 0, 1],
+  [0, 1, 0, 1]
+];
+const PACKETS_PER_BURST = 24;
+const BURST_PACKET_INTERVAL = 0.14;
+
+export const BURST_CYCLE_DURATION = 11;
+export const PACKET_TRAVEL_SPEED = 3.4;
+
+export const HOST_POSITIONS: Vector3[] = HOST_Z_POSITIONS.flatMap(zPosition =>
+  HOST_X_POSITIONS.map(xPosition => [xPosition, HOST_Y, zPosition] as Vector3)
+);
+export const LEAF_POSITIONS: Vector3[] = [0.85, -0.85].flatMap(zPosition =>
+  HOST_X_POSITIONS.map(xPosition => [xPosition, LEAF_Y, zPosition] as Vector3)
+);
+export const AGGREGATION_POSITIONS: Vector3[] = [0.85, -0.85].flatMap(zPosition =>
+  HOST_X_POSITIONS.map(xPosition => [xPosition, AGGREGATION_Y, zPosition] as Vector3)
+);
+export const SPINE_POSITIONS: Vector3[] = HOST_Z_POSITIONS.map(zPosition => [
+  0,
+  SPINE_Y,
+  zPosition
+]);
+export const SWITCH_POSITIONS: Vector3[] = [
+  ...LEAF_POSITIONS,
+  ...AGGREGATION_POSITIONS,
+  ...SPINE_POSITIONS
+];
+export const CONVERSATIONS: Conversation[] = [
+  {sourceHostIndex: 3, destinationHostIndex: 8, color: TRAFFIC_COLORS[0]},
+  {sourceHostIndex: 7, destinationHostIndex: 12, color: TRAFFIC_COLORS[1]}
+];
+
+const SWITCH_INDICES_BY_POSITION = new Map(
+  SWITCH_POSITIONS.map((position, switchIndex) => [position.join(','), switchIndex])
+);
+
+export function makeConversationRoutes(): ConversationRoute[] {
+  const conversationRoutes: ConversationRoute[] = [];
+  for (let conversationIndex = 0; conversationIndex < CONVERSATIONS.length; conversationIndex++) {
+    const conversation = CONVERSATIONS[conversationIndex];
+    const sourceColumnIndex = conversation.sourceHostIndex % HOST_X_POSITIONS.length;
+    const destinationColumnIndex = conversation.destinationHostIndex % HOST_X_POSITIONS.length;
+    for (let spineIndex = 0; spineIndex < SPINE_POSITIONS.length; spineIndex++) {
+      conversationRoutes.push({
+        conversationIndex,
+        route: makeRoute([
+          HOST_POSITIONS[conversation.sourceHostIndex],
+          LEAF_POSITIONS[sourceColumnIndex],
+          AGGREGATION_POSITIONS[spineIndex],
+          SPINE_POSITIONS[spineIndex],
+          AGGREGATION_POSITIONS[HOST_X_POSITIONS.length + spineIndex],
+          LEAF_POSITIONS[HOST_X_POSITIONS.length + destinationColumnIndex],
+          HOST_POSITIONS[conversation.destinationHostIndex]
+        ])
+      });
+    }
+  }
+
+  return conversationRoutes;
+}
+
+export function makePackets(conversationRoutes: ConversationRoute[]): Packet[] {
+  const packets: Packet[] = [];
+
+  for (let conversationIndex = 0; conversationIndex < CONVERSATIONS.length; conversationIndex++) {
+    const conversation = CONVERSATIONS[conversationIndex];
+    const routes = conversationRoutes.filter(
+      route => route.conversationIndex === conversationIndex
+    );
+    for (let packetIndex = 0; packetIndex < PACKETS_PER_BURST; packetIndex++) {
+      const {route} = routes[packetIndex % routes.length];
+      const sourceTravelTime = getDistance(route.points[0], route.points[1]) / PACKET_TRAVEL_SPEED;
+      const launchTime =
+        1 +
+        packetIndex * BURST_PACKET_INTERVAL +
+        (conversationIndex * BURST_PACKET_INTERVAL) / CONVERSATIONS.length -
+        sourceTravelTime;
+      packets.push({
+        route,
+        color: conversation.color,
+        conversationIndex,
+        enabled: true,
+        launchTime,
+        preferredRouteIndex: packetIndex,
+        scale: 0.05,
+        alpha: 1
+      });
+    }
+  }
+
+  return packets;
+}
+
+export function makeSwitchArrivals(packets: Packet[]): SwitchArrival[] {
+  const arrivals: SwitchArrival[] = [];
+
+  for (const packet of packets) {
+    if (!packet.enabled) {
+      continue;
+    }
+    for (let pointIndex = 1; pointIndex < packet.route.points.length - 1; pointIndex++) {
+      const switchIndex = SWITCH_INDICES_BY_POSITION.get(packet.route.points[pointIndex].join(','));
+      if (switchIndex === undefined) {
+        continue;
+      }
+
+      arrivals.push({
+        arrivalTime:
+          packet.launchTime + packet.route.cumulativeLengths[pointIndex] / PACKET_TRAVEL_SPEED,
+        conversationIndex: packet.conversationIndex,
+        switchIndex
+      });
+    }
+  }
+
+  return arrivals;
+}
+
+export function getHealthyConversationRoutes(
+  conversationRoutes: ConversationRoute[],
+  failedSwitchIndices: ReadonlySet<number>
+): ConversationRoute[] {
+  return conversationRoutes.filter(({route}) =>
+    route.points.every(position => !isFailedSwitchPosition(position, failedSwitchIndices))
+  );
+}
+
+export function reroutePackets(packets: Packet[], healthyRoutes: ConversationRoute[]): void {
+  for (const packet of packets) {
+    const conversationRoutes = healthyRoutes.filter(
+      route => route.conversationIndex === packet.conversationIndex
+    );
+    packet.enabled = conversationRoutes.length > 0;
+    if (packet.enabled) {
+      packet.route =
+        conversationRoutes[packet.preferredRouteIndex % conversationRoutes.length].route;
+    }
+  }
+}
+
+export function isFailedSwitchPosition(
+  position: Vector3,
+  failedSwitchIndices: ReadonlySet<number>
+): boolean {
+  const switchIndex = SWITCH_INDICES_BY_POSITION.get(position.join(','));
+  return switchIndex !== undefined && failedSwitchIndices.has(switchIndex);
+}
+
+export function getActivePlaneCount(conversationRoutes: ConversationRoute[]): number {
+  return new Set(conversationRoutes.map(({route}) => route.points[3].join(','))).size;
+}
+
+export function makeActiveLinkKeys(conversationRoutes: ConversationRoute[]): Set<string> {
+  const activeLinkKeys = new Set<string>();
+
+  for (const {route} of conversationRoutes) {
+    for (let pointIndex = 0; pointIndex < route.points.length - 1; pointIndex++) {
+      activeLinkKeys.add(makeLinkKey(route.points[pointIndex], route.points[pointIndex + 1]));
+    }
+  }
+
+  return activeLinkKeys;
+}
+
+export function makeLinks(conversationRoutes: ConversationRoute[]): NetworkLink[] {
+  const links: NetworkLink[] = [];
+  const activeLinkKeys = makeActiveLinkKeys(conversationRoutes);
+
+  for (let hostIndex = 0; hostIndex < HOST_POSITIONS.length; hostIndex++) {
+    const rowIndex = Math.floor(hostIndex / HOST_X_POSITIONS.length);
+    const columnIndex = hostIndex % HOST_X_POSITIONS.length;
+    const leafRowOffset = rowIndex < 2 ? 0 : HOST_X_POSITIONS.length;
+    const start = HOST_POSITIONS[hostIndex];
+    const end = LEAF_POSITIONS[leafRowOffset + columnIndex];
+    links.push({
+      start,
+      end,
+      startInset: getBoxSurfaceDistance(start, end, HOST_HALF_EXTENTS),
+      endInset: LEAF_SWITCH_RADIUS,
+      color: makeLinkColor(start, activeLinkKeys.has(makeLinkKey(start, end)))
+    });
+  }
+
+  for (let rowIndex = 0; rowIndex < 2; rowIndex++) {
+    const rowOffset = rowIndex * HOST_X_POSITIONS.length;
+    for (let leafColumnIndex = 0; leafColumnIndex < HOST_X_POSITIONS.length; leafColumnIndex++) {
+      for (
+        let aggregationColumnIndex = 0;
+        aggregationColumnIndex < HOST_X_POSITIONS.length;
+        aggregationColumnIndex++
+      ) {
+        const start = LEAF_POSITIONS[rowOffset + leafColumnIndex];
+        const end = AGGREGATION_POSITIONS[rowOffset + aggregationColumnIndex];
+        links.push({
+          start,
+          end,
+          startInset: LEAF_SWITCH_RADIUS,
+          endInset: AGGREGATION_SWITCH_RADIUS,
+          color: makeLinkColor(start, activeLinkKeys.has(makeLinkKey(start, end)))
+        });
+      }
+    }
+  }
+
+  for (const aggregationPosition of AGGREGATION_POSITIONS) {
+    for (let spineIndex = 0; spineIndex < SPINE_POSITIONS.length; spineIndex++) {
+      const end = SPINE_POSITIONS[spineIndex];
+      links.push({
+        start: aggregationPosition,
+        end,
+        startInset: AGGREGATION_SWITCH_RADIUS,
+        endInset: SPINE_SWITCH_RADIUS,
+        color: makeLinkColor(
+          aggregationPosition,
+          activeLinkKeys.has(makeLinkKey(aggregationPosition, end))
+        )
+      });
+    }
+  }
+
+  return links;
+}
+
+export function makeLinkColor(start: Vector3, active: boolean, failed = false): Color {
+  if (failed) {
+    return [0.86, 0.32, 0.08, 0.085];
+  }
+  if (start[1] === HOST_Y) {
+    return active ? [0.43, 0.61, 0.91, 0.2] : [0.3, 0.42, 0.66, 0.045];
+  }
+  if (start[1] === LEAF_Y) {
+    return active ? [0.45, 0.61, 0.91, 0.18] : [0.3, 0.42, 0.66, 0.038];
+  }
+  return active ? [0.47, 0.64, 0.93, 0.16] : [0.3, 0.42, 0.66, 0.034];
+}
+
+export function makePickableNetworkNodes(): PickableNetworkNode[] {
+  const servers = HOST_POSITIONS.map((_, hostIndex) => {
+    const sourceConversationIndex = CONVERSATIONS.findIndex(
+      conversation => conversation.sourceHostIndex === hostIndex
+    );
+    const destinationConversationIndex = CONVERSATIONS.findIndex(
+      conversation => conversation.destinationHostIndex === hostIndex
+    );
+    const rowIndex = Math.floor(hostIndex / HOST_X_POSITIONS.length) + 1;
+    const columnIndex = (hostIndex % HOST_X_POSITIONS.length) + 1;
+
+    if (sourceConversationIndex >= 0) {
+      const trafficColor = sourceConversationIndex === 0 ? 'red' : 'green';
+      return {
+        title: `Server ${hostIndex + 1}`,
+        role: `${trafficColor.toUpperCase()} source / grid row ${rowIndex}, column ${columnIndex}`,
+        description: `This server originates the ${trafficColor} transfer and sends its packets to a local Tier 0 switch.`,
+        detail:
+          'The outgoing stream is sprayed across independent network planes after meeting the other conversation.'
+      };
+    }
+
+    if (destinationConversationIndex >= 0) {
+      const trafficColor = destinationConversationIndex === 0 ? 'red' : 'green';
+      return {
+        title: `Server ${hostIndex + 1}`,
+        role: `${trafficColor.toUpperCase()} destination / grid row ${rowIndex}, column ${columnIndex}`,
+        description: `This server receives the ${trafficColor} transfer after the destination-side switches separate the interleaved streams.`,
+        detail:
+          'MRC writes each packet to its final memory address, so packets can arrive through different paths and out of order.'
+      };
+    }
+
+    return {
+      title: `Server ${hostIndex + 1}`,
+      role: `Available compute server / grid row ${rowIndex}, column ${columnIndex}`,
+      description:
+        'This server represents another GPU host connected to the same resilient network fabric.',
+      detail:
+        'It is not part of the two active conversations, so its links do not carry moving packets.'
+    };
+  });
+
+  const leafSwitches = LEAF_POSITIONS.map((_, switchIndex) => {
+    const side = switchIndex < HOST_X_POSITIONS.length ? 'source' : 'destination';
+    const columnIndex = (switchIndex % HOST_X_POSITIONS.length) + 1;
+    return {
+      title: `Tier 0 access switch ${switchIndex + 1}`,
+      role: `${side.toUpperCase()} side / server column ${columnIndex}`,
+      description:
+        side === 'source'
+          ? 'This switch gathers outgoing server traffic and forwards packets toward the independent planes.'
+          : 'This switch separates returning red and green packets and delivers each stream to the correct destination server.',
+      detail:
+        'Multiple local servers share the access tier; only the active source and destination paths carry packets.'
+    };
+  });
+
+  const aggregationSwitches = AGGREGATION_POSITIONS.map((_, switchIndex) => {
+    const planeIndex = (switchIndex % HOST_X_POSITIONS.length) + 1;
+    const side = switchIndex < HOST_X_POSITIONS.length ? 'ingress' : 'egress';
+    return {
+      title: `Plane ${planeIndex} ${side} switch`,
+      role: `Tier 1 switch / independent network plane ${planeIndex}`,
+      description:
+        side === 'ingress'
+          ? 'This ingress switch accepts alternating red and green packets from the source-side access tier.'
+          : 'This egress switch receives the mixed packet stream and forwards each packet toward its destination.',
+      detail: `Plane ${planeIndex} can continue carrying traffic independently of the other planes.`
+    };
+  });
+
+  const spineSwitches = SPINE_POSITIONS.map((_, switchIndex) => ({
+    title: `Spine switch ${switchIndex + 1}`,
+    role: `Fabric backbone / independent network plane ${switchIndex + 1}`,
+    description:
+      'This spine connects the ingress and egress sides of one independent routing plane.',
+    detail:
+      'Both conversations can share this path, interleaving one red packet with one green packet while other planes carry additional packets.'
+  }));
+
+  return [...servers, ...leafSwitches, ...aggregationSwitches, ...spineSwitches];
+}
+
+export function makeHostColor(hostIndex: number): Color {
+  const conversationIndex = CONVERSATIONS.findIndex(
+    conversation =>
+      conversation.sourceHostIndex === hostIndex || conversation.destinationHostIndex === hostIndex
+  );
+  if (conversationIndex === 0) {
+    return [0.48, 0.09, 0.08, 1];
+  }
+  if (conversationIndex === 1) {
+    return [0.07, 0.38, 0.1, 1];
+  }
+  return [0.18, 0.4, 0.92, 1];
+}
+
+export function makeLinkKey(start: Vector3, end: Vector3): string {
+  const startKey = start.join(',');
+  const endKey = end.join(',');
+  return startKey < endKey ? `${startKey}:${endKey}` : `${endKey}:${startKey}`;
+}
+
+export function getPointAlongRoute(route: Route, progress: number): Vector3 {
+  const distance = progress * route.totalLength;
+  let segmentIndex = 0;
+  while (
+    segmentIndex < route.cumulativeLengths.length - 2 &&
+    route.cumulativeLengths[segmentIndex + 1] < distance
+  ) {
+    segmentIndex++;
+  }
+
+  const startDistance = route.cumulativeLengths[segmentIndex];
+  const endDistance = route.cumulativeLengths[segmentIndex + 1];
+  const segmentProgress = (distance - startDistance) / (endDistance - startDistance);
+  const start = route.points[segmentIndex];
+  const end = route.points[segmentIndex + 1];
+  return [
+    start[0] + (end[0] - start[0]) * segmentProgress,
+    start[1] + (end[1] - start[1]) * segmentProgress,
+    start[2] + (end[2] - start[2]) * segmentProgress
+  ];
+}
+
+export function getRouteSegmentStartDistance(route: Route, distance: number): number {
+  let segmentIndex = 0;
+  while (
+    segmentIndex < route.cumulativeLengths.length - 2 &&
+    route.cumulativeLengths[segmentIndex + 1] < distance
+  ) {
+    segmentIndex++;
+  }
+  return route.cumulativeLengths[segmentIndex];
+}
+
+export function getDistance(start: Vector3, end: Vector3): number {
+  return Math.hypot(end[0] - start[0], end[1] - start[1], end[2] - start[2]);
+}
+
+export function getDistanceSquared(start: Vector3, end: Vector3): number {
+  const differenceX = end[0] - start[0];
+  const differenceY = end[1] - start[1];
+  const differenceZ = end[2] - start[2];
+  return differenceX * differenceX + differenceY * differenceY + differenceZ * differenceZ;
+}
+
+function makeRoute(points: Vector3[]): Route {
+  const cumulativeLengths = [0];
+  let totalLength = 0;
+  for (let pointIndex = 1; pointIndex < points.length; pointIndex++) {
+    totalLength += getDistance(points[pointIndex - 1], points[pointIndex]);
+    cumulativeLengths.push(totalLength);
+  }
+  return {points, cumulativeLengths, totalLength};
+}
+
+function getBoxSurfaceDistance(start: Vector3, end: Vector3, halfExtents: Vector3): number {
+  const distance = getDistance(start, end);
+  const direction: Vector3 = [
+    (end[0] - start[0]) / distance,
+    (end[1] - start[1]) / distance,
+    (end[2] - start[2]) / distance
+  ];
+  return Math.min(
+    direction[0] === 0 ? Infinity : halfExtents[0] / Math.abs(direction[0]),
+    direction[1] === 0 ? Infinity : halfExtents[1] / Math.abs(direction[1]),
+    direction[2] === 0 ? Infinity : halfExtents[2] / Math.abs(direction[2])
+  );
+}

--- a/examples/showcase/packet-spraying/network.ts
+++ b/examples/showcase/packet-spraying/network.ts
@@ -74,6 +74,13 @@ export type PickableNetworkNode = {
   title: string;
 };
 
+export type NetworkSwitchGroupId = 'spine' | 'plane-1' | 'plane-2';
+
+export type NetworkSwitchGroup = {
+  id: NetworkSwitchGroupId;
+  switchIndices: number[];
+};
+
 export const HOST_X_POSITIONS = [-3.6, -1.2, 1.2, 3.6];
 export const HOST_Z_POSITIONS = [2.4, 0.8, -0.8, -2.4];
 export const HOST_Y = -2.75;
@@ -117,6 +124,42 @@ export const SWITCH_POSITIONS: Vector3[] = [
   ...AGGREGATION_POSITIONS,
   ...SPINE_POSITIONS
 ];
+
+/** Keeps semantic switch planes intact while allowing camera-depth-ordered glass composition. */
+export function makeSwitchGroups(): NetworkSwitchGroup[] {
+  const leafPlaneWidth = LEAF_POSITIONS.length / 2;
+  const aggregationPlaneWidth = AGGREGATION_POSITIONS.length / 2;
+  const aggregationOffset = LEAF_POSITIONS.length;
+  const spineOffset = aggregationOffset + AGGREGATION_POSITIONS.length;
+
+  return [
+    {
+      id: 'spine',
+      switchIndices: SPINE_POSITIONS.map((_, switchIndex) => spineOffset + switchIndex)
+    },
+    {
+      id: 'plane-1',
+      switchIndices: [
+        ...Array.from({length: leafPlaneWidth}, (_, switchIndex) => switchIndex),
+        ...Array.from(
+          {length: aggregationPlaneWidth},
+          (_, switchIndex) => aggregationOffset + switchIndex
+        )
+      ]
+    },
+    {
+      id: 'plane-2',
+      switchIndices: [
+        ...Array.from({length: leafPlaneWidth}, (_, switchIndex) => leafPlaneWidth + switchIndex),
+        ...Array.from(
+          {length: aggregationPlaneWidth},
+          (_, switchIndex) => aggregationOffset + aggregationPlaneWidth + switchIndex
+        )
+      ]
+    }
+  ];
+}
+
 export const CONVERSATIONS: Conversation[] = [
   {sourceHostIndex: 3, destinationHostIndex: 8, color: TRAFFIC_COLORS[0]},
   {sourceHostIndex: 7, destinationHostIndex: 12, color: TRAFFIC_COLORS[1]}

--- a/examples/showcase/packet-spraying/network.ts
+++ b/examples/showcase/packet-spraying/network.ts
@@ -16,6 +16,25 @@ export type Packet = {
   scale: number;
 };
 
+export type NetworkScenario = 'failure' | 'congestion';
+
+export type NetworkPacketEventKind =
+  | 'dropped-payload'
+  | 'trimmed-payload'
+  | 'trimmed-header'
+  | 'retransmission'
+  | 'probe';
+
+export type NetworkPacketEvent = {
+  color: Color;
+  conversationIndex: number;
+  duration: number;
+  kind: NetworkPacketEventKind;
+  route: Route;
+  startedAt: number;
+  switchIndex: number;
+};
+
 export type SwitchArrival = {
   arrivalTime: number;
   conversationIndex: number;
@@ -51,7 +70,7 @@ export type PickableNetworkNode = {
   description: string;
   detail: string;
   role: string;
-  status?: 'offline' | 'online';
+  status?: 'congested' | 'detecting' | 'offline' | 'online';
   title: string;
 };
 
@@ -74,7 +93,10 @@ const PACKETS_PER_BURST = 24;
 const BURST_PACKET_INTERVAL = 0.14;
 
 export const BURST_CYCLE_DURATION = 11;
+export const CONGESTION_TRIM_INTERVAL = 1.35;
+export const FAILURE_DETECTION_DELAY = 0.52;
 export const PACKET_TRAVEL_SPEED = 3.4;
+export const SWITCH_PROBE_INTERVAL = 2.2;
 
 export const HOST_POSITIONS: Vector3[] = HOST_Z_POSITIONS.flatMap(zPosition =>
   HOST_X_POSITIONS.map(xPosition => [xPosition, HOST_Y, zPosition] as Vector3)
@@ -186,8 +208,120 @@ export function makeSwitchArrivals(packets: Packet[]): SwitchArrival[] {
   return arrivals;
 }
 
+export function makeSwitchPacketEvents({
+  packets,
+  conversationRoutes,
+  scenario,
+  startedAt,
+  switchIndex
+}: {
+  packets: readonly Packet[];
+  conversationRoutes: readonly ConversationRoute[];
+  scenario: NetworkScenario;
+  startedAt: number;
+  switchIndex: number;
+}): NetworkPacketEvent[] {
+  const switchPosition = SWITCH_POSITIONS[switchIndex];
+  if (!switchPosition) {
+    return [];
+  }
+
+  const affectedPackets = packets.filter(packet =>
+    packet.route.points.some(position => position === switchPosition)
+  );
+  const alternateRoutes = getHealthyConversationRoutes(conversationRoutes, new Set([switchIndex]));
+  const events: NetworkPacketEvent[] = [];
+  const packetsPerConversation = scenario === 'failure' ? 2 : 1;
+
+  for (let sequenceIndex = 0; sequenceIndex < packetsPerConversation; sequenceIndex++) {
+    for (let conversationIndex = 0; conversationIndex < CONVERSATIONS.length; conversationIndex++) {
+      const affectedPacket = affectedPackets.find(
+        packet =>
+          packet.conversationIndex === conversationIndex &&
+          Math.floor(packet.preferredRouteIndex / SPINE_POSITIONS.length) === sequenceIndex
+      );
+      if (!affectedPacket) {
+        continue;
+      }
+
+      const eventIndex = sequenceIndex * CONVERSATIONS.length + conversationIndex;
+      const eventStartedAt = startedAt + 0.08 + eventIndex * 0.085;
+      const baseEvent = {
+        color: affectedPacket.color,
+        conversationIndex,
+        route: affectedPacket.route,
+        switchIndex
+      };
+
+      if (scenario === 'failure') {
+        events.push({
+          ...baseEvent,
+          duration: 0.68,
+          kind: 'dropped-payload',
+          startedAt: eventStartedAt
+        });
+      } else {
+        events.push({
+          ...baseEvent,
+          duration: 0.58,
+          kind: 'trimmed-payload',
+          startedAt: eventStartedAt
+        });
+        events.push({
+          ...baseEvent,
+          duration: 1.05,
+          kind: 'trimmed-header',
+          startedAt: eventStartedAt
+        });
+      }
+
+      const alternateRoute = alternateRoutes.find(
+        candidate => candidate.conversationIndex === conversationIndex
+      );
+      if (alternateRoute) {
+        events.push({
+          ...baseEvent,
+          duration: alternateRoute.route.totalLength / (PACKET_TRAVEL_SPEED * 1.16),
+          kind: 'retransmission',
+          route: alternateRoute.route,
+          startedAt:
+            startedAt +
+            (scenario === 'failure' ? FAILURE_DETECTION_DELAY + 0.08 : 0.42) +
+            eventIndex * 0.085
+        });
+      }
+    }
+  }
+
+  return events;
+}
+
+export function makeSwitchProbeEvent(
+  conversationRoutes: readonly ConversationRoute[],
+  switchIndex: number,
+  startedAt: number
+): NetworkPacketEvent | null {
+  const switchPosition = SWITCH_POSITIONS[switchIndex];
+  const conversationRoute = conversationRoutes.find(({route}) =>
+    route.points.some(position => position === switchPosition)
+  );
+  if (!conversationRoute) {
+    return null;
+  }
+
+  return {
+    color: [0.35, 0.7, 1, 0.76],
+    conversationIndex: conversationRoute.conversationIndex,
+    duration: 0.66,
+    kind: 'probe',
+    route: conversationRoute.route,
+    startedAt,
+    switchIndex
+  };
+}
+
 export function getHealthyConversationRoutes(
-  conversationRoutes: ConversationRoute[],
+  conversationRoutes: readonly ConversationRoute[],
   failedSwitchIndices: ReadonlySet<number>
 ): ConversationRoute[] {
   return conversationRoutes.filter(({route}) =>
@@ -291,9 +425,17 @@ export function makeLinks(conversationRoutes: ConversationRoute[]): NetworkLink[
   return links;
 }
 
-export function makeLinkColor(start: Vector3, active: boolean, failed = false): Color {
+export function makeLinkColor(
+  start: Vector3,
+  active: boolean,
+  failed = false,
+  congested = false
+): Color {
   if (failed) {
     return [0.86, 0.32, 0.08, 0.085];
+  }
+  if (congested) {
+    return [0.92, 0.24, 0.1, active ? 0.16 : 0.07];
   }
   if (start[1] === HOST_Y) {
     return active ? [0.43, 0.61, 0.91, 0.2] : [0.3, 0.42, 0.66, 0.045];

--- a/examples/showcase/packet-spraying/package.json
+++ b/examples/showcase/packet-spraying/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
     "@luma.gl/core": "9.4.0-alpha.1",
+    "@luma.gl/effects": "9.4.0-alpha.1",
     "@luma.gl/engine": "9.4.0-alpha.1",
     "@luma.gl/experimental": "9.4.0-alpha.1",
     "@luma.gl/shadertools": "9.4.0-alpha.1",

--- a/examples/showcase/packet-spraying/vite.config.ts
+++ b/examples/showcase/packet-spraying/vite.config.ts
@@ -2,6 +2,7 @@ import {defineConfig} from 'vite';
 
 const alias = {
   '@luma.gl/core': `${__dirname}/../../../modules/core/src`,
+  '@luma.gl/effects': `${__dirname}/../../../modules/effects/src`,
   '@luma.gl/engine': `${__dirname}/../../../modules/engine/src`,
   '@luma.gl/experimental': `${__dirname}/../../../modules/experimental/src`,
   '@luma.gl/shadertools': `${__dirname}/../../../modules/shadertools/src`,

--- a/modules/effects/README.md
+++ b/modules/effects/README.md
@@ -12,9 +12,29 @@ normal/roughness, and velocity textures to `ShaderPassRenderer`.
 Notable exports include:
 
 - `bloom` and `bloomShaderPassPipeline`
+- `toneMapping`, `ToneMappingProps`, and `ToneMappingUniforms`
 - `dof` and `dofShaderPassPipeline`
 - `createGTAOShaderPassPipeline`, `createSSGIShaderPassPipeline`, and
   `createSSRShaderPassPipeline`
+
+`toneMapping` applies an ACES filmic curve after exposure and preserves the source alpha channel.
+Place it after bloom or other HDR effects so bright highlights roll off before presentation:
+
+```typescript
+import {ShaderPassRenderer} from '@luma.gl/engine';
+import {bloomShaderPassPipeline, toneMapping} from '@luma.gl/effects';
+
+const renderer = new ShaderPassRenderer(device, {
+  shaderPasses: [bloomShaderPassPipeline, toneMapping]
+});
+
+renderer.renderToScreen({
+  sourceTexture,
+  uniforms: {
+    toneMapping: {exposure: 1}
+  }
+});
+```
 
 See [Rendering Techniques and Tradeoffs](https://luma.gl/docs/api-guide/shaders/rendering-techniques)
 for comparisons between related effects, their GPU inputs, backend support, and composition order.

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -26,6 +26,11 @@ export {persistenceEffect} from './passes/postprocessing/image-adjust-filters/pe
 export type {SepiaProps, SepiaUniforms} from './passes/postprocessing/image-adjust-filters/sepia';
 export {sepia} from './passes/postprocessing/image-adjust-filters/sepia';
 export type {
+  ToneMappingProps,
+  ToneMappingUniforms
+} from './passes/postprocessing/image-adjust-filters/tone-mapping';
+export {toneMapping} from './passes/postprocessing/image-adjust-filters/tone-mapping';
+export type {
   VibranceProps,
   VibranceUniforms
 } from './passes/postprocessing/image-adjust-filters/vibrance';

--- a/modules/effects/src/passes/postprocessing/image-adjust-filters/tone-mapping.ts
+++ b/modules/effects/src/passes/postprocessing/image-adjust-filters/tone-mapping.ts
@@ -1,0 +1,65 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ShaderPass} from '@luma.gl/shadertools';
+
+const source = /* wgsl */ `\
+struct toneMappingUniforms {
+  exposure: f32,
+};
+
+@group(0) @binding(auto) var<uniform> toneMapping: toneMappingUniforms;
+
+fn toneMapping_filterColor_ext(color: vec4f, texSize: vec2f, texCoords: vec2f) -> vec4f {
+  let exposedColor = max(color.rgb * toneMapping.exposure, vec3f(0.0));
+  let numerator = exposedColor * (2.51 * exposedColor + vec3f(0.03));
+  let denominator = exposedColor * (2.43 * exposedColor + vec3f(0.59)) + vec3f(0.14);
+  let mappedColor = clamp(numerator / denominator, vec3f(0.0), vec3f(1.0));
+  return vec4f(mappedColor, color.a);
+}
+`;
+
+const fs = /* glsl */ `\
+layout(std140) uniform toneMappingUniforms {
+  float exposure;
+} toneMapping;
+
+vec4 toneMapping_filterColor_ext(vec4 color, vec2 texSize, vec2 texCoords) {
+  vec3 exposedColor = max(color.rgb * toneMapping.exposure, vec3(0.0));
+  vec3 numerator = exposedColor * (2.51 * exposedColor + vec3(0.03));
+  vec3 denominator = exposedColor * (2.43 * exposedColor + vec3(0.59)) + vec3(0.14);
+  vec3 mappedColor = clamp(numerator / denominator, vec3(0.0), vec3(1.0));
+  return vec4(mappedColor, color.a);
+}
+`;
+
+export type ToneMappingProps = {
+  /** Linear exposure multiplier applied before the ACES filmic curve. */
+  exposure?: number;
+};
+
+export type ToneMappingUniforms = {
+  exposure: number;
+};
+
+/** Maps high-dynamic-range scene colors into display range with an ACES filmic curve. */
+export const toneMapping = {
+  name: 'toneMapping',
+  source,
+  fs,
+
+  props: {} as ToneMappingProps,
+  uniforms: {} as ToneMappingUniforms,
+  uniformTypes: {
+    exposure: 'f32'
+  },
+  defaultUniforms: {
+    exposure: 1
+  },
+  propTypes: {
+    exposure: {format: 'f32', value: 1, min: 0, max: 10}
+  },
+
+  passes: [{filter: true}]
+} as const satisfies ShaderPass<ToneMappingProps, ToneMappingUniforms>;

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
@@ -258,10 +258,9 @@ fn bloomComposite_sampleColor(
   texCoord: vec2f
 ) -> vec4f {
   let sourceColor = textureSample(sourceTexture, sourceTextureSampler, texCoord);
-  let renderTargetCoord = shaderPassRenderer_getRenderTargetUV(texCoord);
-  let halfGlow = textureSample(glowHalf, glowHalfSampler, renderTargetCoord).rgb;
-  let quarterGlow = textureSample(glowQuarter, glowQuarterSampler, renderTargetCoord).rgb;
-  let eighthGlow = textureSample(glowEighth, glowEighthSampler, renderTargetCoord).rgb;
+  let halfGlow = textureSample(glowHalf, glowHalfSampler, texCoord).rgb;
+  let quarterGlow = textureSample(glowQuarter, glowQuarterSampler, texCoord).rgb;
+  let eighthGlow = textureSample(glowEighth, glowEighthSampler, texCoord).rgb;
   let glowColor = halfGlow * 0.50 + quarterGlow * 0.32 + eighthGlow * 0.18;
   return vec4f(sourceColor.rgb + glowColor * bloomComposite.intensity, sourceColor.a);
 }
@@ -277,10 +276,9 @@ uniform sampler2D glowEighth;
 
 vec4 bloomComposite_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoord) {
   vec4 sourceColor = texture(sourceTexture, texCoord);
-  vec2 renderTargetCoord = shaderPassRenderer_getRenderTargetUV(texCoord);
-  vec3 halfGlow = texture(glowHalf, renderTargetCoord).rgb;
-  vec3 quarterGlow = texture(glowQuarter, renderTargetCoord).rgb;
-  vec3 eighthGlow = texture(glowEighth, renderTargetCoord).rgb;
+  vec3 halfGlow = texture(glowHalf, texCoord).rgb;
+  vec3 quarterGlow = texture(glowQuarter, texCoord).rgb;
+  vec3 eighthGlow = texture(glowEighth, texCoord).rgb;
   vec3 glowColor = halfGlow * 0.50 + quarterGlow * 0.32 + eighthGlow * 0.18;
   return vec4(sourceColor.rgb + glowColor * bloomComposite.intensity, sourceColor.a);
 }

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
@@ -7,6 +7,7 @@ import type {ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
 import type {BloomProps, BloomUniforms} from './bloom';
 
 const MAX_BLOOM_BLUR_RADIUS = 24;
+const BLOOM_TARGET_SAMPLER = {minFilter: 'linear', magFilter: 'linear'} as const;
 
 type BloomTargetName =
   | 'extractHalf'
@@ -83,7 +84,7 @@ struct bloomBlurUniforms {
 @group(0) @binding(auto) var<uniform> bloomBlur: bloomBlurUniforms;
 
 fn bloomBlur_applySample(color: vec4f) -> vec4f {
-  return vec4f(color.rgb * vec3f(color.a), color.a);
+  return color;
 }
 
 fn bloomBlur_getEffectiveRadius() -> f32 {
@@ -147,10 +148,7 @@ fn bloomBlur_sampleColor(
     totalWeight += combinedWeight * 2.0;
   }
 
-  color /= totalWeight;
-  let unpremultipliedRgb = color.rgb / vec3f(color.a + 0.00001);
-
-  return vec4f(unpremultipliedRgb, color.a);
+  return color / totalWeight;
 }
 `,
   fs: /* glsl */ `
@@ -163,7 +161,7 @@ layout(std140) uniform bloomBlurUniforms {
 } bloomBlur;
 
 vec4 bloomBlur_applySample(vec4 color) {
-  return vec4(color.rgb * color.a, color.a);
+  return color;
 }
 
 float bloomBlur_getEffectiveRadius() {
@@ -215,8 +213,6 @@ vec4 bloomBlur_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoord)
   }
 
   color /= totalWeight;
-  color.rgb /= color.a + 0.00001;
-
   return color;
 }
 `,
@@ -317,15 +313,15 @@ vec4 bloomComposite_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texC
 export const bloomShaderPassPipeline = {
   name: 'bloomShaderPassPipeline',
   renderTargets: {
-    extractHalf: {scale: [0.5, 0.5]},
-    blurHalfScratch: {scale: [0.5, 0.5]},
-    blurHalf: {scale: [0.5, 0.5]},
-    extractQuarter: {scale: [0.25, 0.25]},
-    blurQuarterScratch: {scale: [0.25, 0.25]},
-    blurQuarter: {scale: [0.25, 0.25]},
-    extractEighth: {scale: [0.125, 0.125]},
-    blurEighthScratch: {scale: [0.125, 0.125]},
-    blurEighth: {scale: [0.125, 0.125]}
+    extractHalf: {scale: [0.5, 0.5], sampler: BLOOM_TARGET_SAMPLER},
+    blurHalfScratch: {scale: [0.5, 0.5], sampler: BLOOM_TARGET_SAMPLER},
+    blurHalf: {scale: [0.5, 0.5], sampler: BLOOM_TARGET_SAMPLER},
+    extractQuarter: {scale: [0.25, 0.25], sampler: BLOOM_TARGET_SAMPLER},
+    blurQuarterScratch: {scale: [0.25, 0.25], sampler: BLOOM_TARGET_SAMPLER},
+    blurQuarter: {scale: [0.25, 0.25], sampler: BLOOM_TARGET_SAMPLER},
+    extractEighth: {scale: [0.125, 0.125], sampler: BLOOM_TARGET_SAMPLER},
+    blurEighthScratch: {scale: [0.125, 0.125], sampler: BLOOM_TARGET_SAMPLER},
+    blurEighth: {scale: [0.125, 0.125], sampler: BLOOM_TARGET_SAMPLER}
   },
   steps: [
     {

--- a/modules/effects/test/passes/image-adjust-filters/tone-mapping.spec.ts
+++ b/modules/effects/test/passes/image-adjust-filters/tone-mapping.spec.ts
@@ -1,0 +1,106 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {toneMapping} from '@luma.gl/effects';
+import {getShaderModuleUniforms, ShaderAssembler, type PlatformInfo} from '@luma.gl/shadertools';
+import {WgslReflect} from 'wgsl_reflect';
+
+const WEBGL_PLATFORM_INFO: PlatformInfo = {
+  type: 'webgl',
+  gpu: 'test',
+  shaderLanguage: 'glsl',
+  shaderLanguageVersion: 300,
+  features: new Set()
+};
+
+const WEBGPU_PLATFORM_INFO: PlatformInfo = {
+  type: 'webgpu',
+  gpu: 'test',
+  shaderLanguage: 'wgsl',
+  shaderLanguageVersion: 300,
+  features: new Set()
+};
+
+const VERTEX_SHADER_GLSL = /* glsl */ `\
+#version 300 es
+in vec4 positions;
+
+void main() {
+  gl_Position = positions;
+}
+`;
+
+const FRAGMENT_SHADER_GLSL = /* glsl */ `\
+#version 300 es
+precision highp float;
+out vec4 fragmentColor;
+
+void main() {
+  fragmentColor = toneMapping_filterColor_ext(vec4(4.0, 2.0, 1.0, 0.5), vec2(1.0), vec2(0.5));
+}
+`;
+
+const FRAGMENT_SHADER_WGSL = /* wgsl */ `\
+@fragment
+fn fragmentMain() -> @location(0) vec4f {
+  return toneMapping_filterColor_ext(vec4f(4.0, 2.0, 1.0, 0.5), vec2f(1.0), vec2f(0.5));
+}
+`;
+
+test('toneMapping#defaults', testCase => {
+  const defaultUniforms = getShaderModuleUniforms(toneMapping, {}, {});
+  const overriddenUniforms = getShaderModuleUniforms(toneMapping, {exposure: 2.5}, {});
+
+  testCase.equal(defaultUniforms.exposure, 1, 'exposure defaults to one');
+  testCase.equal(overriddenUniforms.exposure, 2.5, 'exposure accepts caller configuration');
+  testCase.deepEqual(toneMapping.passes, [{filter: true}], 'runs as one fullscreen filter pass');
+  testCase.end();
+});
+
+test('toneMapping#cross-backend shader sources', testCase => {
+  for (const shaderSource of [toneMapping.source, toneMapping.fs]) {
+    testCase.ok(shaderSource.includes('2.51'), 'includes the ACES numerator coefficient');
+    testCase.ok(shaderSource.includes('2.43'), 'includes the ACES denominator coefficient');
+    testCase.ok(shaderSource.includes('toneMapping.exposure'), 'applies configurable exposure');
+    testCase.ok(shaderSource.includes('color.a'), 'preserves input alpha');
+  }
+  testCase.end();
+});
+
+test('toneMapping#WGSL assembly', testCase => {
+  const shaderAssembler = new ShaderAssembler();
+  const assembledShader = shaderAssembler.assembleWGSLShader({
+    platformInfo: WEBGPU_PLATFORM_INFO,
+    source: FRAGMENT_SHADER_WGSL,
+    modules: [toneMapping]
+  });
+
+  testCase.ok(
+    assembledShader.source.includes('fn toneMapping_filterColor_ext('),
+    'assembles the WGSL filter entrypoint'
+  );
+  testCase.ok(new WgslReflect(assembledShader.source), 'assembled WGSL parses successfully');
+  testCase.end();
+});
+
+test('toneMapping#GLSL assembly', testCase => {
+  const shaderAssembler = new ShaderAssembler();
+  const assembledShaders = shaderAssembler.assembleGLSLShaderPair({
+    platformInfo: WEBGL_PLATFORM_INFO,
+    vs: VERTEX_SHADER_GLSL,
+    fs: FRAGMENT_SHADER_GLSL,
+    modules: [toneMapping]
+  });
+
+  testCase.ok(
+    assembledShaders.fs.includes('vec4 toneMapping_filterColor_ext('),
+    'assembles the GLSL filter entrypoint'
+  );
+  testCase.ok(
+    assembledShaders.fs.includes('layout(std140) uniform toneMappingUniforms'),
+    'assembles the portable exposure uniform block'
+  );
+  testCase.end();
+});

--- a/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
+++ b/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
@@ -29,5 +29,18 @@ test('bloomShaderPassPipeline#routing', t => {
       'bloom extraction consumes the preceding effect output'
     );
   }
+  for (const target of Object.values(bloomShaderPassPipeline.renderTargets)) {
+    t.equal(target.sampler.minFilter, 'linear', 'bloom intermediates use linear minification');
+    t.equal(target.sampler.magFilter, 'linear', 'bloom intermediates use linear magnification');
+  }
+  const blurPass = bloomShaderPassPipeline.steps.find(
+    step => step.shaderPass.name === 'bloomBlur'
+  )?.shaderPass;
+  t.ok(blurPass, 'multiscale bloom includes a separable blur');
+  t.match(blurPass?.source || '', /return color \/ totalWeight/, 'blur preserves smooth falloff');
+  t.notOk(
+    /unpremultipliedRgb/.test(blurPass?.source || ''),
+    'blur does not amplify tiny alpha into square halos'
+  );
   t.end();
 });

--- a/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
+++ b/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
@@ -42,5 +42,24 @@ test('bloomShaderPassPipeline#routing', t => {
     /unpremultipliedRgb/.test(blurPass?.source || ''),
     'blur does not amplify tiny alpha into square halos'
   );
+
+  const compositePass = bloomShaderPassPipeline.steps.find(
+    step => step.shaderPass.name === 'bloomComposite'
+  )?.shaderPass;
+  t.ok(compositePass, 'multiscale bloom includes a glow composite');
+  t.match(
+    compositePass?.source || '',
+    /textureSample\(glowHalf, glowHalfSampler, texCoord\)/,
+    'WGSL composites glow in the same orientation as the scene'
+  );
+  t.match(
+    compositePass?.fs || '',
+    /texture\(glowHalf, texCoord\)/,
+    'GLSL composites glow in the same orientation as the scene'
+  );
+  t.notOk(
+    /shaderPassRenderer_getRenderTargetUV/.test(compositePass?.fs || ''),
+    'GLSL does not vertically mirror named bloom targets'
+  );
   t.end();
 });

--- a/modules/engine/src/index.ts
+++ b/modules/engine/src/index.ts
@@ -53,6 +53,12 @@ export {DirectionalLightModel} from './models/directional-light-model';
 
 // Scenegraph Core nodes
 export {ScenegraphNode} from './scenegraph/scenegraph-node';
+export type {ScenegraphBounds} from './scenegraph/scenegraph-bounds';
+export type {
+  DepthSortedTraversalContext,
+  DepthSortedTraversalOptions,
+  GroupNodeProps
+} from './scenegraph/group-node';
 export {GroupNode} from './scenegraph/group-node';
 export type {ModelNodeProps} from './scenegraph/model-node';
 export {ModelNode} from './scenegraph/model-node';

--- a/modules/engine/src/passes/shader-pass-renderer.ts
+++ b/modules/engine/src/passes/shader-pass-renderer.ts
@@ -765,7 +765,8 @@ function createTargetResources(
     width: targetSize[0],
     height: targetSize[1],
     format: spec.format || device.preferredColorFormat,
-    usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_SRC | Texture.COPY_DST
+    usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_SRC | Texture.COPY_DST,
+    ...(spec.sampler ? {sampler: spec.sampler} : {})
   });
   const framebuffer = device.createFramebuffer({
     id: `${name}-framebuffer`,

--- a/modules/engine/src/scenegraph/group-node.ts
+++ b/modules/engine/src/scenegraph/group-node.ts
@@ -3,11 +3,32 @@
 // Copyright (c) vis.gl contributors
 
 import {Matrix4, Vector3} from '@math.gl/core';
+import type {NumericArray} from '@math.gl/core';
 import {log} from '@luma.gl/core';
 import {ScenegraphNode, ScenegraphNodeProps} from './scenegraph-node';
+import {
+  areScenegraphBoundsDefined,
+  expandScenegraphBounds,
+  makeEmptyScenegraphBounds
+} from './scenegraph-bounds';
+import type {ScenegraphBounds} from './scenegraph-bounds';
 
 export type GroupNodeProps = ScenegraphNodeProps & {
   children?: ScenegraphNode[];
+};
+
+/** Camera-relative ordering options for a flattened scenegraph traversal. */
+export type DepthSortedTraversalOptions = {
+  viewMatrix: NumericArray;
+  worldMatrix?: NumericArray;
+  order?: 'back-to-front' | 'front-to-back';
+};
+
+/** Model transform, local aggregate bounds, and positive camera depth for one visited node. */
+export type DepthSortedTraversalContext = {
+  worldMatrix: Matrix4;
+  bounds: [number[], number[]] | null;
+  depth: number;
 };
 
 export class GroupNode extends ScenegraphNode {
@@ -27,39 +48,18 @@ export class GroupNode extends ScenegraphNode {
     this.children = children;
   }
 
-  override getBounds(): [number[], number[]] | null {
-    const result: [number[], number[]] = [
-      [Infinity, Infinity, Infinity],
-      [-Infinity, -Infinity, -Infinity]
-    ];
+  override getBounds(): ScenegraphBounds | null {
+    const result = makeEmptyScenegraphBounds();
 
     this.traverse((node, {worldMatrix}) => {
       const bounds = node.getBounds();
       if (!bounds) {
         return;
       }
-      const [min, max] = bounds;
-      const center = new Vector3(min).add(max).divide([2, 2, 2]);
-      worldMatrix.transformAsPoint(center, center);
-      const halfSize = new Vector3(max).subtract(min).divide([2, 2, 2]);
-      worldMatrix.transformAsVector(halfSize, halfSize);
-
-      for (let v = 0; v < 8; v++) {
-        // Test all 8 corners of the box
-        const position = new Vector3(v & 0b001 ? -1 : 1, v & 0b010 ? -1 : 1, v & 0b100 ? -1 : 1)
-          .multiply(halfSize)
-          .add(center);
-
-        for (let i = 0; i < 3; i++) {
-          result[0][i] = Math.min(result[0][i], position[i]);
-          result[1][i] = Math.max(result[1][i], position[i]);
-        }
-      }
+      const nodeWorldMatrix = new Matrix4(worldMatrix).multiplyRight(node.matrix);
+      expandScenegraphBounds(result, bounds, nodeWorldMatrix);
     });
-    if (!Number.isFinite(result[0][0])) {
-      return null;
-    }
-    return result;
+    return areScenegraphBoundsDefined(result) ? result : null;
   }
 
   override destroy(): void {
@@ -106,6 +106,43 @@ export class GroupNode extends ScenegraphNode {
       } else {
         visitor(child, {worldMatrix: modelMatrix});
       }
+    }
+  }
+
+  /** Visits leaf nodes ordered by the camera-space centers of their aggregate bounds. */
+  traverseDepthSorted(
+    visitor: (node: ScenegraphNode, context: DepthSortedTraversalContext) => void,
+    {viewMatrix, worldMatrix = new Matrix4(), order = 'back-to-front'}: DepthSortedTraversalOptions
+  ): void {
+    const cameraMatrix = new Matrix4(viewMatrix);
+    const nodes: {node: ScenegraphNode; context: DepthSortedTraversalContext; index: number}[] = [];
+
+    this.traverse(
+      (node, context) => {
+        const bounds = node.getBounds();
+        const center = bounds
+          ? new Vector3(bounds[0]).add(bounds[1]).divide([2, 2, 2])
+          : new Vector3();
+        const nodeWorldMatrix = new Matrix4(context.worldMatrix).multiplyRight(node.matrix);
+        nodeWorldMatrix.transformAsPoint(center, center);
+        cameraMatrix.transformAsPoint(center, center);
+        nodes.push({
+          node,
+          context: {worldMatrix: nodeWorldMatrix, bounds, depth: -center[2]},
+          index: nodes.length
+        });
+      },
+      {worldMatrix: new Matrix4(worldMatrix)}
+    );
+
+    const direction = order === 'back-to-front' ? -1 : 1;
+    nodes.sort(
+      (first, second) =>
+        direction * (first.context.depth - second.context.depth) || first.index - second.index
+    );
+
+    for (const {node, context} of nodes) {
+      visitor(node, context);
     }
   }
 

--- a/modules/engine/src/scenegraph/model-node.ts
+++ b/modules/engine/src/scenegraph/model-node.ts
@@ -3,18 +3,29 @@
 // Copyright (c) vis.gl contributors
 
 import {RenderPass} from '@luma.gl/core';
+import type {NumericArray} from '@math.gl/core';
 import {ScenegraphNode, ScenegraphNodeProps} from './scenegraph-node';
+import {
+  areScenegraphBoundsDefined,
+  expandScenegraphBounds,
+  makeEmptyScenegraphBounds
+} from './scenegraph-bounds';
+import type {ScenegraphBounds} from './scenegraph-bounds';
 import {Model} from '../model/model';
 
 export type ModelNodeProps = ScenegraphNodeProps & {
   model: Model;
   managedResources?: any[];
-  bounds?: [[number, number, number], [number, number, number]];
+  /** Bounds of one model instance before instance and node transforms. */
+  bounds?: ScenegraphBounds;
+  /** Optional per-instance transforms used to calculate aggregate local bounds. */
+  instanceMatrices?: readonly NumericArray[];
 };
 
 export class ModelNode extends ScenegraphNode {
   readonly model: Model;
-  bounds: [[number, number, number], [number, number, number]] | null = null;
+  readonly instanceMatrices: readonly NumericArray[] | null;
+  bounds: ScenegraphBounds | null = null;
   managedResources: any[];
 
   // TODO - is this used? override callbacks to make sure we call them with this
@@ -28,7 +39,12 @@ export class ModelNode extends ScenegraphNode {
     // Create new Model or used supplied Model
     this.model = props.model;
     this.managedResources = props.managedResources || [];
-    this.bounds = props.bounds || null;
+    this.instanceMatrices = props.instanceMatrices || null;
+    this.bounds = props.bounds
+      ? this.instanceMatrices
+        ? getInstancedScenegraphBounds(props.bounds, this.instanceMatrices)
+        : props.bounds
+      : null;
     this.setProps(props);
   }
 
@@ -51,4 +67,17 @@ export class ModelNode extends ScenegraphNode {
     // Return value indicates if something was actually drawn
     return this.model.draw(renderPass);
   }
+}
+
+function getInstancedScenegraphBounds(
+  bounds: ScenegraphBounds,
+  instanceMatrices: readonly NumericArray[]
+): ScenegraphBounds | null {
+  const instancedBounds = makeEmptyScenegraphBounds();
+
+  for (const instanceMatrix of instanceMatrices) {
+    expandScenegraphBounds(instancedBounds, bounds, instanceMatrix);
+  }
+
+  return areScenegraphBoundsDefined(instancedBounds) ? instancedBounds : null;
 }

--- a/modules/engine/src/scenegraph/scenegraph-bounds.ts
+++ b/modules/engine/src/scenegraph/scenegraph-bounds.ts
@@ -1,0 +1,48 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Matrix4, Vector3} from '@math.gl/core';
+import type {NumericArray} from '@math.gl/core';
+
+/** Axis-aligned bounds in a scenegraph node's local coordinate system. */
+export type ScenegraphBounds = [[number, number, number], [number, number, number]];
+
+export function makeEmptyScenegraphBounds(): ScenegraphBounds {
+  return [
+    [Infinity, Infinity, Infinity],
+    [-Infinity, -Infinity, -Infinity]
+  ];
+}
+
+export function expandScenegraphBounds(
+  targetBounds: ScenegraphBounds,
+  sourceBounds: [number[], number[]],
+  transform: NumericArray
+): void {
+  const transformMatrix = new Matrix4(transform);
+
+  for (let cornerIndex = 0; cornerIndex < 8; cornerIndex++) {
+    const corner = new Vector3(
+      sourceBounds[cornerIndex & 0b001 ? 1 : 0][0],
+      sourceBounds[cornerIndex & 0b010 ? 1 : 0][1],
+      sourceBounds[cornerIndex & 0b100 ? 1 : 0][2]
+    );
+    transformMatrix.transformAsPoint(corner, corner);
+
+    for (let componentIndex = 0; componentIndex < 3; componentIndex++) {
+      targetBounds[0][componentIndex] = Math.min(
+        targetBounds[0][componentIndex],
+        corner[componentIndex]
+      );
+      targetBounds[1][componentIndex] = Math.max(
+        targetBounds[1][componentIndex],
+        corner[componentIndex]
+      );
+    }
+  }
+}
+
+export function areScenegraphBoundsDefined(bounds: ScenegraphBounds): boolean {
+  return Number.isFinite(bounds[0][0]);
+}

--- a/modules/engine/test/passes/shader-pass-renderer.spec.ts
+++ b/modules/engine/test/passes/shader-pass-renderer.spec.ts
@@ -163,7 +163,7 @@ const stagedPipeline: ShaderPassPipeline<'extract' | 'blurred'> = {
   name: 'stagedPipeline',
   renderTargets: {
     extract: {},
-    blurred: {scale: [0.5, 0.5]}
+    blurred: {scale: [0.5, 0.5], sampler: {minFilter: 'linear', magFilter: 'linear'}}
   },
   steps: [
     {
@@ -610,6 +610,11 @@ test('ShaderPassRenderer supports ShaderPassPipeline targets', async t => {
     >;
     t.equal(pipelineTargets.extract.texture.width, 4, 'resizes full-size pipeline target width');
     t.equal(pipelineTargets.blurred.texture.height, 2, 'resizes scaled pipeline target height');
+    t.equal(
+      pipelineTargets.blurred.texture.sampler?.props.minFilter,
+      'linear',
+      'applies named target sampler configuration'
+    );
 
     renderer.destroy();
     sourceTexture.destroy();

--- a/modules/engine/test/scenegraph/group-node.spec.ts
+++ b/modules/engine/test/scenegraph/group-node.spec.ts
@@ -140,3 +140,103 @@ test('GroupNode#getBounds', async t => {
   );
   t.end();
 });
+
+test('GroupNode#getBounds applies leaf transforms and rotated box corners', async t => {
+  const device = await getWebGLTestDevice();
+  const model = new Model(device, {vs: DUMMY_VS, fs: DUMMY_FS});
+  const node = new ModelNode({
+    model,
+    bounds: [
+      [-1, -2, -1],
+      [1, 2, 1]
+    ],
+    matrix: new Matrix4().translate([3, 0, 0]).rotateZ(Math.PI / 4)
+  });
+  const group = new GroupNode({
+    matrix: new Matrix4().translate([0, 2, 0]),
+    children: [node]
+  });
+  const bounds = group.getBounds();
+  const rotatedHalfExtent = 3 / Math.sqrt(2);
+
+  t.ok(bounds, 'transformed model contributes bounds');
+  t.ok(
+    Math.abs(bounds![0][0] - (3 - rotatedHalfExtent)) < 0.000001 &&
+      Math.abs(bounds![1][0] - (3 + rotatedHalfExtent)) < 0.000001,
+    'all rotated horizontal corners contribute to the aggregate bounds'
+  );
+  t.ok(
+    Math.abs(bounds![0][1] - (2 - rotatedHalfExtent)) < 0.000001 &&
+      Math.abs(bounds![1][1] - (2 + rotatedHalfExtent)) < 0.000001,
+    'leaf and parent transforms are included in world-space bounds'
+  );
+
+  group.destroy();
+  t.end();
+});
+
+test('GroupNode#traverseDepthSorted orders transformed leaf bounds by camera depth', async t => {
+  const nearNode = new ScenegraphNode({
+    id: 'near',
+    matrix: new Matrix4().translate([0, 0, -2])
+  });
+  const middleNode = new ScenegraphNode({
+    id: 'middle',
+    matrix: new Matrix4().translate([0, 0, -3])
+  });
+  const farNode = new ScenegraphNode({
+    id: 'far',
+    matrix: new Matrix4().translate([0, 0, -9])
+  });
+
+  for (const node of [nearNode, middleNode, farNode]) {
+    node.getBounds = () => [
+      [-1, -1, -1],
+      [1, 1, 1]
+    ];
+  }
+
+  const group = new GroupNode({
+    children: [
+      nearNode,
+      new GroupNode({matrix: new Matrix4().translate([0, 0, -2]), children: [middleNode]}),
+      farNode
+    ]
+  });
+  const backToFrontIds: string[] = [];
+  const depths: number[] = [];
+
+  group.traverseDepthSorted(
+    (node, context) => {
+      backToFrontIds.push(node.id);
+      depths.push(context.depth);
+    },
+    {viewMatrix: new Matrix4()}
+  );
+
+  t.deepEqual(
+    backToFrontIds,
+    ['far', 'middle', 'near'],
+    'default traversal visits far nodes first'
+  );
+  t.deepEqual(depths, [9, 5, 2], 'nested and leaf transforms contribute to camera depth');
+
+  const frontToBackIds: string[] = [];
+  group.traverseDepthSorted((node: ScenegraphNode) => frontToBackIds.push(node.id), {
+    viewMatrix: new Matrix4(),
+    order: 'front-to-back'
+  });
+  t.deepEqual(frontToBackIds, ['near', 'middle', 'far'], 'front-to-back traversal is available');
+
+  const reverseViewIds: string[] = [];
+  group.traverseDepthSorted((node: ScenegraphNode) => reverseViewIds.push(node.id), {
+    viewMatrix: new Matrix4().lookAt({eye: [0, 0, -20], center: [0, 0, 0], up: [0, 1, 0]})
+  });
+  t.deepEqual(
+    reverseViewIds,
+    ['near', 'middle', 'far'],
+    'camera direction determines ordering instead of fixed world-space depth'
+  );
+
+  t.end();
+});

--- a/modules/engine/test/scenegraph/model-node.spec.ts
+++ b/modules/engine/test/scenegraph/model-node.spec.ts
@@ -6,6 +6,7 @@ import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {getWebGLTestDevice} from '@luma.gl/test-utils';
 // import {makeSpy} from '@probe.gl/test-utils';
 import {Model, ModelNode} from '@luma.gl/engine';
+import {Matrix4} from '@math.gl/core';
 
 export const DUMMY_VS = `\
 #version 300 es
@@ -43,5 +44,44 @@ test('ModelNode#setProps', async t => {
     'setProps updates position on scenegraph node'
   );
 
+  t.end();
+});
+
+test('ModelNode#getBounds combines transformed instance bounds', async t => {
+  const device = await getWebGLTestDevice();
+  const model = new Model(device, {vs: DUMMY_VS, fs: DUMMY_FS});
+  const node = new ModelNode({
+    model,
+    bounds: [
+      [-1, -1, -1],
+      [1, 1, 1]
+    ],
+    instanceMatrices: [
+      new Matrix4().translate([-2, 0, 1]).scale([1, 2, 1]),
+      new Matrix4().translate([3, 1, -2]).scale([0.5, 1, 2])
+    ]
+  });
+
+  t.deepEqual(
+    node.getBounds(),
+    [
+      [-3, -2, -4],
+      [3.5, 2, 2]
+    ],
+    'one model node exposes aggregate bounds for every transformed instance'
+  );
+
+  const emptyNode = new ModelNode({
+    model: new Model(device, {vs: DUMMY_VS, fs: DUMMY_FS}),
+    bounds: [
+      [-1, -1, -1],
+      [1, 1, 1]
+    ],
+    instanceMatrices: []
+  });
+  t.equal(emptyNode.getBounds(), null, 'an empty instanced model has no visible bounds');
+
+  node.destroy();
+  emptyNode.destroy();
   t.end();
 });

--- a/modules/experimental/src/index.ts
+++ b/modules/experimental/src/index.ts
@@ -33,6 +33,12 @@ export type {
 } from './materials/glass-material';
 export {glassMaterial, glassMaterialPlugin} from './materials/glass-material';
 export type {
+  GlassTransmissionBindings,
+  GlassTransmissionProps,
+  GlassTransmissionUniforms
+} from './materials/glass-transmission';
+export {glassTransmission, glassTransmissionPlugin} from './materials/glass-transmission';
+export type {
   ReflectiveMaterialProps,
   ReflectiveMaterialUniforms
 } from './materials/reflective-material';

--- a/modules/experimental/src/index.ts
+++ b/modules/experimental/src/index.ts
@@ -11,6 +11,22 @@ export {HTMLTexture} from './textures/html-texture';
 
 export {opticalLighting} from './materials/optical-lighting';
 export type {
+  OpticalPointLight,
+  OpticalPointLightUniform,
+  OpticalPointLightsProps,
+  OpticalPointLightsUniforms
+} from './materials/optical-point-lights';
+export {
+  MAX_OPTICAL_POINT_LIGHTS,
+  opticalPointLights,
+  opticalPointLightsPlugin
+} from './materials/optical-point-lights';
+export type {
+  EmissiveMaterialProps,
+  EmissiveMaterialUniforms
+} from './materials/emissive-material';
+export {emissiveMaterial, emissiveMaterialPlugin} from './materials/emissive-material';
+export type {
   GlassMaterialBindings,
   GlassMaterialProps,
   GlassMaterialUniforms
@@ -57,6 +73,7 @@ export type {
   WBOITCaptureContext,
   WBOITCaptureOptions,
   WBOITRenderOptions,
+  WBOITRendererProps,
   WBOITSupport
 } from './oit/wboit-renderer';
 export {getWBOITSupport, WBOITRenderer} from './oit/wboit-renderer';

--- a/modules/experimental/src/materials/emissive-material.ts
+++ b/modules/experimental/src/materials/emissive-material.ts
@@ -37,6 +37,19 @@ fn emissiveMaterial_getColor(
   let emission = emissiveMaterial.intensity * (1.0 + emissiveMaterial.rimStrength * rim);
   return vec4<f32>(baseColor.rgb * emission, baseColor.a);
 }
+
+fn emissiveMaterial_getTrailColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  baseColor: vec4<f32>,
+  cameraPosition: vec3<f32>,
+  trailProgress: f32,
+  trailStrength: f32
+) -> vec4<f32> {
+  let emission = emissiveMaterial_getColor(normal, worldPosition, baseColor, cameraPosition);
+  let fade = pow(smoothstep(0.0, 1.0, trailProgress), 1.5);
+  return vec4<f32>(emission.rgb * fade * trailStrength, emission.a * fade);
+}
 `;
 
 const EMISSIVE_MATERIAL_GLSL = /* glsl */ `\
@@ -57,6 +70,19 @@ vec4 emissiveMaterial_getColor(
   float rim = pow(1.0 - viewAlignment, 2.0);
   float emission = emissiveMaterial.intensity * (1.0 + emissiveMaterial.rimStrength * rim);
   return vec4(baseColor.rgb * emission, baseColor.a);
+}
+
+vec4 emissiveMaterial_getTrailColor(
+  vec3 normal,
+  vec3 worldPosition,
+  vec4 baseColor,
+  vec3 cameraPosition,
+  float trailProgress,
+  float trailStrength
+) {
+  vec4 emission = emissiveMaterial_getColor(normal, worldPosition, baseColor, cameraPosition);
+  float fade = pow(smoothstep(0.0, 1.0, trailProgress), 1.5);
+  return vec4(emission.rgb * fade * trailStrength, emission.a * fade);
 }
 `;
 

--- a/modules/experimental/src/materials/emissive-material.ts
+++ b/modules/experimental/src/materials/emissive-material.ts
@@ -1,0 +1,94 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ShaderModule, ShaderPlugin} from '@luma.gl/shadertools';
+import {opticalLighting} from './optical-lighting';
+
+/** Runtime properties for luminous surfaces rendered into an HDR scene. */
+export type EmissiveMaterialProps = {
+  /** Multiplier applied to the incoming surface color. */
+  intensity?: number;
+  /** Additional emission around silhouettes facing away from the camera. */
+  rimStrength?: number;
+};
+
+/** Uniform values consumed by {@link emissiveMaterial}. */
+export type EmissiveMaterialUniforms = Required<EmissiveMaterialProps>;
+
+const EMISSIVE_MATERIAL_WGSL = /* wgsl */ `\
+struct emissiveMaterialUniforms {
+  intensity: f32,
+  rimStrength: f32,
+};
+
+@group(0) @binding(auto) var<uniform> emissiveMaterial: emissiveMaterialUniforms;
+
+fn emissiveMaterial_getColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  baseColor: vec4<f32>,
+  cameraPosition: vec3<f32>
+) -> vec4<f32> {
+  let viewDirection = normalize(cameraPosition - worldPosition);
+  let normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  let viewAlignment = clamp(dot(normalFacingCamera, viewDirection), 0.0, 1.0);
+  let rim = pow(1.0 - viewAlignment, 2.0);
+  let emission = emissiveMaterial.intensity * (1.0 + emissiveMaterial.rimStrength * rim);
+  return vec4<f32>(baseColor.rgb * emission, baseColor.a);
+}
+`;
+
+const EMISSIVE_MATERIAL_GLSL = /* glsl */ `\
+layout(std140) uniform emissiveMaterialUniforms {
+  float intensity;
+  float rimStrength;
+} emissiveMaterial;
+
+vec4 emissiveMaterial_getColor(
+  vec3 normal,
+  vec3 worldPosition,
+  vec4 baseColor,
+  vec3 cameraPosition
+) {
+  vec3 viewDirection = normalize(cameraPosition - worldPosition);
+  vec3 normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  float viewAlignment = clamp(dot(normalFacingCamera, viewDirection), 0.0, 1.0);
+  float rim = pow(1.0 - viewAlignment, 2.0);
+  float emission = emissiveMaterial.intensity * (1.0 + emissiveMaterial.rimStrength * rim);
+  return vec4(baseColor.rgb * emission, baseColor.a);
+}
+`;
+
+function getEmissiveMaterialUniforms(
+  props: Partial<EmissiveMaterialProps> = {},
+  previousUniforms?: EmissiveMaterialUniforms
+): EmissiveMaterialUniforms {
+  return {
+    intensity: props.intensity ?? previousUniforms?.intensity ?? 1,
+    rimStrength: props.rimStrength ?? previousUniforms?.rimStrength ?? 0.35
+  };
+}
+
+/** Portable emissive surface shading with a controllable camera-facing rim. */
+export const emissiveMaterial = {
+  name: 'emissiveMaterial',
+  source: EMISSIVE_MATERIAL_WGSL,
+  fs: EMISSIVE_MATERIAL_GLSL,
+  dependencies: [opticalLighting],
+  uniformTypes: {
+    intensity: 'f32',
+    rimStrength: 'f32'
+  },
+  defaultUniforms: {
+    intensity: 1,
+    rimStrength: 0.35
+  },
+  getUniforms: getEmissiveMaterialUniforms
+} as const satisfies ShaderModule<EmissiveMaterialProps, EmissiveMaterialUniforms, {}>;
+
+/** Installs portable emissive shading and shared optical-lighting helpers. */
+export const emissiveMaterialPlugin = {
+  name: 'emissiveMaterial',
+  modules: [emissiveMaterial as ShaderModule]
+} as const satisfies ShaderPlugin;

--- a/modules/experimental/src/materials/glass-material.ts
+++ b/modules/experimental/src/materials/glass-material.ts
@@ -20,8 +20,20 @@ export type GlassMaterialProps = {
   dispersion?: number;
   /** Optical distance used for refraction offset and absorption. */
   thickness?: number;
+  /** Multiplier applied to camera-aligned screen-space lens distortion. */
+  refractionStrength?: number;
   /** Multiplier applied to environment reflections and specular highlights. */
   reflectionStrength?: number;
+  /** Multiplier applied to physically motivated grazing-angle reflection. */
+  fresnelStrength?: number;
+  /** Strength of the secondary polished surface coating. */
+  clearcoatStrength?: number;
+  /** Strength of the subtle wavelength-dependent edge interference. */
+  iridescenceStrength?: number;
+  /** Strength of the curved internal shell reflection. */
+  internalReflectionStrength?: number;
+  /** Amount of the scene that remains visible through the glass body. */
+  transmissionStrength?: number;
 };
 
 /** Uniform values consumed by {@link glassMaterial}. */
@@ -31,7 +43,13 @@ export type GlassMaterialUniforms = {
   roughness: number;
   dispersion: number;
   thickness: number;
+  refractionStrength: number;
   reflectionStrength: number;
+  fresnelStrength: number;
+  clearcoatStrength: number;
+  iridescenceStrength: number;
+  internalReflectionStrength: number;
+  transmissionStrength: number;
 };
 
 /** Texture bindings consumed by {@link glassMaterial}. */
@@ -48,31 +66,24 @@ struct GlassMaterialUniforms {
   roughness: f32,
   dispersion: f32,
   thickness: f32,
+  refractionStrength: f32,
   reflectionStrength: f32,
+  fresnelStrength: f32,
+  clearcoatStrength: f32,
+  iridescenceStrength: f32,
+  internalReflectionStrength: f32,
+  transmissionStrength: f32,
 };
 
 @group(0) @binding(auto) var<uniform> glassMaterial: GlassMaterialUniforms;
 @group(0) @binding(auto) var glassSceneColorTexture: texture_2d<f32>;
 @group(0) @binding(auto) var glassSceneColorTextureSampler: sampler;
 
-fn glassMaterial_getColor(
-  normal: vec3<f32>,
-  worldPosition: vec3<f32>,
-  baseColor: vec4<f32>,
-  cameraPosition: vec3<f32>,
-  fragmentPosition: vec4<f32>
-) -> vec4<f32> {
-  let viewDirection = normalize(cameraPosition - worldPosition);
-  let normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
-  let viewAlignment = clamp(dot(normalFacingCamera, viewDirection), 0.0, 1.0);
-  let indexOfRefraction = max(glassMaterial.indexOfRefraction, 1.001);
-  let baseReflectance = pow((indexOfRefraction - 1.0) / (indexOfRefraction + 1.0), 2.0);
-  let fresnel = opticalLighting_getFresnel(viewAlignment, baseReflectance, 5.0);
-  let thickness = glassMaterial.thickness * (0.32 + pow(1.0 - viewAlignment, 1.8));
-  let refractionDirection = refract(-viewDirection, normalFacingCamera, 1.0 / indexOfRefraction);
-  let screenCoordinate = fragmentPosition.xy / glassMaterial.viewportSize;
-  let refractionOffset = refractionDirection.xy * thickness * 0.085;
-  let dispersionOffset = normalFacingCamera.xy * glassMaterial.dispersion * thickness;
+fn glassMaterial_sampleTransmission(
+  screenCoordinate: vec2<f32>,
+  refractionOffset: vec2<f32>,
+  dispersionOffset: vec2<f32>
+) -> vec3<f32> {
   let refractedRed = textureSampleLevel(
     glassSceneColorTexture,
     glassSceneColorTextureSampler,
@@ -91,8 +102,79 @@ fn glassMaterial_getColor(
     clamp(screenCoordinate + refractionOffset - dispersionOffset, vec2<f32>(0.001), vec2<f32>(0.999)),
     0.0
   ).b;
-  let absorption = exp(-(vec3<f32>(0.11, 0.065, 0.035) + (1.0 - baseColor.rgb) * 0.32) * thickness);
-  let transmittedColor = vec3<f32>(refractedRed, refractedGreen, refractedBlue) * absorption;
+  return vec3<f32>(refractedRed, refractedGreen, refractedBlue);
+}
+
+fn glassMaterial_getColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  baseColor: vec4<f32>,
+  cameraPosition: vec3<f32>,
+  fragmentPosition: vec4<f32>
+) -> vec4<f32> {
+  let viewDirection = normalize(cameraPosition - worldPosition);
+  let normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  let viewAlignment = clamp(dot(normalFacingCamera, viewDirection), 0.0, 1.0);
+  let indexOfRefraction = max(glassMaterial.indexOfRefraction, 1.001);
+  let baseReflectance = pow((indexOfRefraction - 1.0) / (indexOfRefraction + 1.0), 2.0);
+  let fresnel = clamp(
+    opticalLighting_getFresnel(viewAlignment, baseReflectance, 5.0) * glassMaterial.fresnelStrength,
+    0.0,
+    0.98
+  );
+  let thickness = glassMaterial.thickness * mix(0.18, 1.0, sqrt(viewAlignment));
+  let refractionDirection = refract(-viewDirection, normalFacingCamera, 1.0 / indexOfRefraction);
+  let screenCoordinate = fragmentPosition.xy / glassMaterial.viewportSize;
+  let cameraUpAxis = select(
+    vec3<f32>(0.0, 1.0, 0.0),
+    vec3<f32>(0.0, 0.0, 1.0),
+    abs(viewDirection.y) > 0.96
+  );
+  let cameraRight = normalize(cross(cameraUpAxis, viewDirection));
+  let cameraUp = normalize(cross(viewDirection, cameraRight));
+  let viewportAspect = glassMaterial.viewportSize.x / max(glassMaterial.viewportSize.y, 1.0);
+  let rayDeflection = refractionDirection + viewDirection;
+  let screenDeflection = vec2<f32>(
+    dot(rayDeflection, cameraRight) / viewportAspect,
+    -dot(rayDeflection, cameraUp)
+  );
+  let screenNormal = vec2<f32>(
+    dot(normalFacingCamera, cameraRight) / viewportAspect,
+    -dot(normalFacingCamera, cameraUp)
+  );
+  let surfaceCurvature = sqrt(max(1.0 - viewAlignment * viewAlignment, 0.0));
+  let refractionOffset = screenDeflection * glassMaterial.thickness *
+    glassMaterial.refractionStrength * mix(0.085, 0.22, surfaceCurvature);
+  let dispersionOffset = screenNormal * glassMaterial.dispersion *
+    mix(0.12, 0.48, surfaceCurvature);
+  let blurOffset = vec2<f32>(-screenNormal.y, screenNormal.x) *
+    glassMaterial.roughness * glassMaterial.thickness * 0.018;
+  let centralTransmission = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    refractionOffset,
+    dispersionOffset
+  );
+  let roughnessBlend = smoothstep(0.04, 0.72, glassMaterial.roughness);
+  var softenedTransmission = centralTransmission;
+  if (glassMaterial.roughness > 0.16) {
+    let blurredForward = textureSampleLevel(
+      glassSceneColorTexture,
+      glassSceneColorTextureSampler,
+      clamp(screenCoordinate + refractionOffset + blurOffset, vec2<f32>(0.001), vec2<f32>(0.999)),
+      0.0
+    ).rgb;
+    let blurredBackward = textureSampleLevel(
+      glassSceneColorTexture,
+      glassSceneColorTextureSampler,
+      clamp(screenCoordinate + refractionOffset - blurOffset, vec2<f32>(0.001), vec2<f32>(0.999)),
+      0.0
+    ).rgb;
+    softenedTransmission = (blurredForward + blurredBackward) * 0.5;
+  }
+  let absorption = exp(-(vec3<f32>(0.075, 0.045, 0.022) +
+    (1.0 - baseColor.rgb) * 0.24) * thickness);
+  let transmittedColor = mix(centralTransmission, softenedTransmission, roughnessBlend) *
+    absorption * glassMaterial.transmissionStrength;
   let reflectionDirection = reflect(-viewDirection, normalFacingCamera);
   let environmentColor = opticalLighting_sampleEnvironment(
     reflectionDirection,
@@ -100,22 +182,62 @@ fn glassMaterial_getColor(
     vec3<f32>(0.38, 0.57, 0.82),
     0.28
   );
-  let keyHalfVector = normalize(opticalLighting_getKeyLight() + viewDirection);
-  let fillHalfVector = normalize(opticalLighting_getFillLight() + viewDirection);
-  let specularExponent = mix(160.0, 20.0, clamp(glassMaterial.roughness, 0.0, 1.0));
-  let keySpecular = pow(max(dot(normalFacingCamera, keyHalfVector), 0.0), specularExponent);
-  let fillSpecular = pow(max(dot(normalFacingCamera, fillHalfVector), 0.0), specularExponent * 0.65);
-  let rim = pow(1.0 - viewAlignment, 2.2);
+  let keySpecular = opticalLighting_getMicrofacetSpecular(
+    normalFacingCamera,
+    viewDirection,
+    opticalLighting_getKeyLight(),
+    glassMaterial.roughness
+  );
+  let fillSpecular = opticalLighting_getMicrofacetSpecular(
+    normalFacingCamera,
+    viewDirection,
+    opticalLighting_getFillLight(),
+    min(glassMaterial.roughness + 0.14, 1.0)
+  );
+  let clearcoat = opticalLighting_getMicrofacetSpecular(
+    normalFacingCamera,
+    viewDirection,
+    normalize(vec3<f32>(-0.24, 0.92, 0.31)),
+    0.075
+  ) * glassMaterial.clearcoatStrength;
+  let rim = pow(1.0 - viewAlignment, 2.25);
+  let innerRim = pow(1.0 - viewAlignment, 2.8) * pow(viewAlignment, 0.35);
+  let internalDirection = reflect(refractionDirection, -normalFacingCamera);
+  let internalReflection = opticalLighting_sampleEnvironment(
+    internalDirection,
+    vec3<f32>(0.045, 0.07, 0.12),
+    vec3<f32>(0.24, 0.48, 0.78),
+    0.42
+  ) * innerRim * glassMaterial.internalReflectionStrength;
+  let interferencePhase = glassMaterial.thickness * (1.0 - viewAlignment) * 12.0;
+  let iridescence = (vec3<f32>(0.5) + vec3<f32>(0.5) * cos(
+    vec3<f32>(interferencePhase) + vec3<f32>(0.0, 2.094, 4.189)
+  )) * rim * glassMaterial.iridescenceStrength;
+  let studioRibbon = pow(
+    max(dot(reflectionDirection, normalize(vec3<f32>(-0.3, 0.86, 0.42))), 0.0),
+    mix(52.0, 16.0, glassMaterial.roughness)
+  );
+  let glassBody = baseColor.rgb * (0.045 + viewAlignment * 0.105) +
+    environmentColor * viewAlignment * 0.11;
   let reflection = (
-    environmentColor * (fresnel + rim * 0.42) + baseColor.rgb * rim * 0.28 +
-    vec3<f32>(1.0, 0.95, 0.86) * keySpecular * 0.9 +
-    vec3<f32>(0.35, 0.62, 1.0) * fillSpecular * 0.45
+    environmentColor * (fresnel + rim * 0.65) + baseColor.rgb * rim * 0.32 +
+    vec3<f32>(1.0, 0.96, 0.88) * min(keySpecular, 3.0) * 0.34 +
+    vec3<f32>(0.34, 0.66, 1.0) * min(fillSpecular, 2.0) * 0.24 +
+    vec3<f32>(1.0, 0.97, 0.9) * min(clearcoat, 3.0) * 0.3 +
+    vec3<f32>(0.82, 0.9, 1.0) * studioRibbon * 0.32 +
+    internalReflection + iridescence + glassBody
   ) * glassMaterial.reflectionStrength;
   let color = transmittedColor * (1.0 - fresnel) + reflection;
+  let transmissionCoverage = mix(
+    0.38,
+    0.74,
+    smoothstep(0.12, 0.95, glassMaterial.refractionStrength)
+  );
   let opacity = clamp(
-    0.26 + fresnel * 0.58 + rim * 0.22 + (keySpecular + fillSpecular) * 0.24,
-    0.16,
-    0.9
+    transmissionCoverage + fresnel * 0.28 + rim * 0.19 +
+      min(keySpecular + fillSpecular + clearcoat, 2.0) * 0.07,
+    0.2,
+    0.98
   );
   return vec4<f32>(color, opacity);
 }
@@ -151,10 +273,36 @@ layout(std140) uniform glassMaterialUniforms {
   float roughness;
   float dispersion;
   float thickness;
+  float refractionStrength;
   float reflectionStrength;
+  float fresnelStrength;
+  float clearcoatStrength;
+  float iridescenceStrength;
+  float internalReflectionStrength;
+  float transmissionStrength;
 } glassMaterial;
 
 uniform sampler2D glassSceneColorTexture;
+
+vec3 glassMaterial_sampleTransmission(
+  vec2 screenCoordinate,
+  vec2 refractionOffset,
+  vec2 dispersionOffset
+) {
+  float refractedRed = texture(
+    glassSceneColorTexture,
+    clamp(screenCoordinate + refractionOffset + dispersionOffset, vec2(0.001), vec2(0.999))
+  ).r;
+  float refractedGreen = texture(
+    glassSceneColorTexture,
+    clamp(screenCoordinate + refractionOffset, vec2(0.001), vec2(0.999))
+  ).g;
+  float refractedBlue = texture(
+    glassSceneColorTexture,
+    clamp(screenCoordinate + refractionOffset - dispersionOffset, vec2(0.001), vec2(0.999))
+  ).b;
+  return vec3(refractedRed, refractedGreen, refractedBlue);
+}
 
 vec4 glassMaterial_getColor(
   vec3 normal,
@@ -168,26 +316,58 @@ vec4 glassMaterial_getColor(
   float viewAlignment = clamp(dot(normalFacingCamera, viewDirection), 0.0, 1.0);
   float indexOfRefraction = max(glassMaterial.indexOfRefraction, 1.001);
   float baseReflectance = pow((indexOfRefraction - 1.0) / (indexOfRefraction + 1.0), 2.0);
-  float fresnel = opticalLighting_getFresnel(viewAlignment, baseReflectance, 5.0);
-  float thickness = glassMaterial.thickness * (0.32 + pow(1.0 - viewAlignment, 1.8));
+  float fresnel = clamp(
+    opticalLighting_getFresnel(viewAlignment, baseReflectance, 5.0) * glassMaterial.fresnelStrength,
+    0.0,
+    0.98
+  );
+  float thickness = glassMaterial.thickness * mix(0.18, 1.0, sqrt(viewAlignment));
   vec3 refractionDirection = refract(-viewDirection, normalFacingCamera, 1.0 / indexOfRefraction);
   vec2 screenCoordinate = fragmentPosition.xy / glassMaterial.viewportSize;
-  vec2 refractionOffset = refractionDirection.xy * thickness * 0.085;
-  vec2 dispersionOffset = normalFacingCamera.xy * glassMaterial.dispersion * thickness;
-  float refractedRed = texture(
-    glassSceneColorTexture,
-    clamp(screenCoordinate + refractionOffset + dispersionOffset, vec2(0.001), vec2(0.999))
-  ).r;
-  float refractedGreen = texture(
-    glassSceneColorTexture,
-    clamp(screenCoordinate + refractionOffset, vec2(0.001), vec2(0.999))
-  ).g;
-  float refractedBlue = texture(
-    glassSceneColorTexture,
-    clamp(screenCoordinate + refractionOffset - dispersionOffset, vec2(0.001), vec2(0.999))
-  ).b;
-  vec3 absorption = exp(-(vec3(0.11, 0.065, 0.035) + (1.0 - baseColor.rgb) * 0.32) * thickness);
-  vec3 transmittedColor = vec3(refractedRed, refractedGreen, refractedBlue) * absorption;
+  vec3 cameraUpAxis = abs(viewDirection.y) > 0.96
+    ? vec3(0.0, 0.0, 1.0)
+    : vec3(0.0, 1.0, 0.0);
+  vec3 cameraRight = normalize(cross(cameraUpAxis, viewDirection));
+  vec3 cameraUp = normalize(cross(viewDirection, cameraRight));
+  float viewportAspect = glassMaterial.viewportSize.x / max(glassMaterial.viewportSize.y, 1.0);
+  vec3 rayDeflection = refractionDirection + viewDirection;
+  vec2 screenDeflection = vec2(
+    dot(rayDeflection, cameraRight) / viewportAspect,
+    dot(rayDeflection, cameraUp)
+  );
+  vec2 screenNormal = vec2(
+    dot(normalFacingCamera, cameraRight) / viewportAspect,
+    dot(normalFacingCamera, cameraUp)
+  );
+  float surfaceCurvature = sqrt(max(1.0 - viewAlignment * viewAlignment, 0.0));
+  vec2 refractionOffset = screenDeflection * glassMaterial.thickness *
+    glassMaterial.refractionStrength * mix(0.085, 0.22, surfaceCurvature);
+  vec2 dispersionOffset = screenNormal * glassMaterial.dispersion *
+    mix(0.12, 0.48, surfaceCurvature);
+  vec2 blurOffset = vec2(-screenNormal.y, screenNormal.x) *
+    glassMaterial.roughness * glassMaterial.thickness * 0.018;
+  vec3 centralTransmission = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    refractionOffset,
+    dispersionOffset
+  );
+  float roughnessBlend = smoothstep(0.04, 0.72, glassMaterial.roughness);
+  vec3 softenedTransmission = centralTransmission;
+  if (glassMaterial.roughness > 0.16) {
+    vec3 blurredForward = texture(
+      glassSceneColorTexture,
+      clamp(screenCoordinate + refractionOffset + blurOffset, vec2(0.001), vec2(0.999))
+    ).rgb;
+    vec3 blurredBackward = texture(
+      glassSceneColorTexture,
+      clamp(screenCoordinate + refractionOffset - blurOffset, vec2(0.001), vec2(0.999))
+    ).rgb;
+    softenedTransmission = (blurredForward + blurredBackward) * 0.5;
+  }
+  vec3 absorption = exp(-(vec3(0.075, 0.045, 0.022) +
+    (1.0 - baseColor.rgb) * 0.24) * thickness);
+  vec3 transmittedColor = mix(centralTransmission, softenedTransmission, roughnessBlend) *
+    absorption * glassMaterial.transmissionStrength;
   vec3 reflectionDirection = reflect(-viewDirection, normalFacingCamera);
   vec3 environmentColor = opticalLighting_sampleEnvironment(
     reflectionDirection,
@@ -195,22 +375,62 @@ vec4 glassMaterial_getColor(
     vec3(0.38, 0.57, 0.82),
     0.28
   );
-  vec3 keyHalfVector = normalize(opticalLighting_getKeyLight() + viewDirection);
-  vec3 fillHalfVector = normalize(opticalLighting_getFillLight() + viewDirection);
-  float specularExponent = mix(160.0, 20.0, clamp(glassMaterial.roughness, 0.0, 1.0));
-  float keySpecular = pow(max(dot(normalFacingCamera, keyHalfVector), 0.0), specularExponent);
-  float fillSpecular = pow(max(dot(normalFacingCamera, fillHalfVector), 0.0), specularExponent * 0.65);
-  float rim = pow(1.0 - viewAlignment, 2.2);
+  float keySpecular = opticalLighting_getMicrofacetSpecular(
+    normalFacingCamera,
+    viewDirection,
+    opticalLighting_getKeyLight(),
+    glassMaterial.roughness
+  );
+  float fillSpecular = opticalLighting_getMicrofacetSpecular(
+    normalFacingCamera,
+    viewDirection,
+    opticalLighting_getFillLight(),
+    min(glassMaterial.roughness + 0.14, 1.0)
+  );
+  float clearcoat = opticalLighting_getMicrofacetSpecular(
+    normalFacingCamera,
+    viewDirection,
+    normalize(vec3(-0.24, 0.92, 0.31)),
+    0.075
+  ) * glassMaterial.clearcoatStrength;
+  float rim = pow(1.0 - viewAlignment, 2.25);
+  float innerRim = pow(1.0 - viewAlignment, 2.8) * pow(viewAlignment, 0.35);
+  vec3 internalDirection = reflect(refractionDirection, -normalFacingCamera);
+  vec3 internalReflection = opticalLighting_sampleEnvironment(
+    internalDirection,
+    vec3(0.045, 0.07, 0.12),
+    vec3(0.24, 0.48, 0.78),
+    0.42
+  ) * innerRim * glassMaterial.internalReflectionStrength;
+  float interferencePhase = glassMaterial.thickness * (1.0 - viewAlignment) * 12.0;
+  vec3 iridescence = (vec3(0.5) + vec3(0.5) * cos(
+    vec3(interferencePhase) + vec3(0.0, 2.094, 4.189)
+  )) * rim * glassMaterial.iridescenceStrength;
+  float studioRibbon = pow(
+    max(dot(reflectionDirection, normalize(vec3(-0.3, 0.86, 0.42))), 0.0),
+    mix(52.0, 16.0, glassMaterial.roughness)
+  );
+  vec3 glassBody = baseColor.rgb * (0.045 + viewAlignment * 0.105) +
+    environmentColor * viewAlignment * 0.11;
   vec3 reflection = (
-    environmentColor * (fresnel + rim * 0.42) + baseColor.rgb * rim * 0.28 +
-    vec3(1.0, 0.95, 0.86) * keySpecular * 0.9 +
-    vec3(0.35, 0.62, 1.0) * fillSpecular * 0.45
+    environmentColor * (fresnel + rim * 0.65) + baseColor.rgb * rim * 0.32 +
+    vec3(1.0, 0.96, 0.88) * min(keySpecular, 3.0) * 0.34 +
+    vec3(0.34, 0.66, 1.0) * min(fillSpecular, 2.0) * 0.24 +
+    vec3(1.0, 0.97, 0.9) * min(clearcoat, 3.0) * 0.3 +
+    vec3(0.82, 0.9, 1.0) * studioRibbon * 0.32 +
+    internalReflection + iridescence + glassBody
   ) * glassMaterial.reflectionStrength;
   vec3 color = transmittedColor * (1.0 - fresnel) + reflection;
+  float transmissionCoverage = mix(
+    0.38,
+    0.74,
+    smoothstep(0.12, 0.95, glassMaterial.refractionStrength)
+  );
   float opacity = clamp(
-    0.26 + fresnel * 0.58 + rim * 0.22 + (keySpecular + fillSpecular) * 0.24,
-    0.16,
-    0.9
+    transmissionCoverage + fresnel * 0.28 + rim * 0.19 +
+      min(keySpecular + fillSpecular + clearcoat, 2.0) * 0.07,
+    0.2,
+    0.98
   );
   return vec4(color, opacity);
 }
@@ -251,7 +471,14 @@ function getGlassMaterialUniforms(
     roughness: props.roughness ?? previousUniforms?.roughness ?? 0.14,
     dispersion: props.dispersion ?? previousUniforms?.dispersion ?? 0.022,
     thickness: props.thickness ?? previousUniforms?.thickness ?? 1.05,
+    refractionStrength: props.refractionStrength ?? previousUniforms?.refractionStrength ?? 1,
     reflectionStrength: props.reflectionStrength ?? previousUniforms?.reflectionStrength ?? 1,
+    fresnelStrength: props.fresnelStrength ?? previousUniforms?.fresnelStrength ?? 1,
+    clearcoatStrength: props.clearcoatStrength ?? previousUniforms?.clearcoatStrength ?? 0.7,
+    iridescenceStrength: props.iridescenceStrength ?? previousUniforms?.iridescenceStrength ?? 0.1,
+    internalReflectionStrength:
+      props.internalReflectionStrength ?? previousUniforms?.internalReflectionStrength ?? 0.42,
+    transmissionStrength: props.transmissionStrength ?? previousUniforms?.transmissionStrength ?? 1,
     ...(props.sceneColorTexture ? {glassSceneColorTexture: props.sceneColorTexture} : {})
   };
 }
@@ -272,7 +499,13 @@ export const glassMaterial = {
     roughness: 'f32',
     dispersion: 'f32',
     thickness: 'f32',
-    reflectionStrength: 'f32'
+    refractionStrength: 'f32',
+    reflectionStrength: 'f32',
+    fresnelStrength: 'f32',
+    clearcoatStrength: 'f32',
+    iridescenceStrength: 'f32',
+    internalReflectionStrength: 'f32',
+    transmissionStrength: 'f32'
   },
   defaultUniforms: {
     viewportSize: [1, 1],
@@ -280,7 +513,13 @@ export const glassMaterial = {
     roughness: 0.14,
     dispersion: 0.022,
     thickness: 1.05,
-    reflectionStrength: 1
+    refractionStrength: 1,
+    reflectionStrength: 1,
+    fresnelStrength: 1,
+    clearcoatStrength: 0.7,
+    iridescenceStrength: 0.1,
+    internalReflectionStrength: 0.42,
+    transmissionStrength: 1
   },
   getUniforms: getGlassMaterialUniforms
 } as const satisfies ShaderModule<GlassMaterialProps, GlassMaterialUniforms, GlassMaterialBindings>;

--- a/modules/experimental/src/materials/glass-material.ts
+++ b/modules/experimental/src/materials/glass-material.ts
@@ -119,6 +119,29 @@ fn glassMaterial_getColor(
   );
   return vec4<f32>(color, opacity);
 }
+
+#ifdef LUMA_OPTICAL_POINT_LIGHTS
+fn glassMaterial_getIlluminatedColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  baseColor: vec4<f32>,
+  cameraPosition: vec3<f32>,
+  fragmentPosition: vec4<f32>
+) -> vec4<f32> {
+  let glassColor = glassMaterial_getColor(
+    normal,
+    worldPosition,
+    baseColor,
+    cameraPosition,
+    fragmentPosition
+  );
+  let pointLightColor = opticalPointLights_getColor(normal, worldPosition, cameraPosition);
+  return vec4<f32>(
+    glassColor.rgb + pointLightColor * glassMaterial.reflectionStrength,
+    glassColor.a
+  );
+}
+#endif
 `;
 
 const GLASS_MATERIAL_GLSL = /* glsl */ `\
@@ -191,6 +214,31 @@ vec4 glassMaterial_getColor(
   );
   return vec4(color, opacity);
 }
+
+#ifdef LUMA_OPTICAL_POINT_LIGHTS
+vec3 opticalPointLights_getColor(vec3 normal, vec3 worldPosition, vec3 cameraPosition);
+
+vec4 glassMaterial_getIlluminatedColor(
+  vec3 normal,
+  vec3 worldPosition,
+  vec4 baseColor,
+  vec3 cameraPosition,
+  vec4 fragmentPosition
+) {
+  vec4 glassColor = glassMaterial_getColor(
+    normal,
+    worldPosition,
+    baseColor,
+    cameraPosition,
+    fragmentPosition
+  );
+  vec3 pointLightColor = opticalPointLights_getColor(normal, worldPosition, cameraPosition);
+  return vec4(
+    glassColor.rgb + pointLightColor * glassMaterial.reflectionStrength,
+    glassColor.a
+  );
+}
+#endif
 `;
 
 function getGlassMaterialUniforms(

--- a/modules/experimental/src/materials/glass-transmission.ts
+++ b/modules/experimental/src/materials/glass-transmission.ts
@@ -1,0 +1,439 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Texture} from '@luma.gl/core';
+import type {ShaderModule, ShaderPlugin} from '@luma.gl/shadertools';
+import {glassMaterial} from './glass-material';
+
+/** Optional rasterized volume inputs layered on top of {@link glassMaterial}. */
+export type GlassTransmissionProps = {
+  /** Dimensions shared by opaque scene color, opaque depth, and glass backfaces. */
+  viewportSize?: [number, number];
+  /** Near and far perspective clip planes used to recover linear optical thickness. */
+  depthRange?: [number, number];
+  /** Sampleable depth attachment from the opaque scene pass. */
+  sceneDepthTexture?: Texture;
+  /** Encoded backface world normals and normalized framebuffer depth. */
+  backfaceTexture?: Texture;
+  /** Equirectangular studio or HDR environment map. */
+  environmentTexture?: Texture;
+  /** Multiplier applied to sampled environment reflections. */
+  environmentIntensity?: number;
+  /** Multiplier applied to the measured front-to-back optical path. */
+  thicknessStrength?: number;
+  /** Normalized-depth tolerance used to preserve foreground geometry. */
+  depthBias?: number;
+};
+
+/** Uniform values consumed by {@link glassTransmission}. */
+export type GlassTransmissionUniforms = {
+  viewportSize: [number, number];
+  depthRange: [number, number];
+  environmentIntensity: number;
+  thicknessStrength: number;
+  depthBias: number;
+};
+
+/** Rasterized volume textures consumed by {@link glassTransmission}. */
+export type GlassTransmissionBindings = {
+  glassSceneDepthTexture?: Texture;
+  glassBackfaceTexture?: Texture;
+  glassEnvironmentTexture?: Texture;
+};
+
+const SHADER_STAGE_FRAGMENT = 0x2;
+
+const GLASS_TRANSMISSION_WGSL = /* wgsl */ `\
+struct glassTransmissionUniforms {
+  viewportSize: vec2<f32>,
+  depthRange: vec2<f32>,
+  environmentIntensity: f32,
+  thicknessStrength: f32,
+  depthBias: f32,
+};
+
+@group(0) @binding(auto) var<uniform> glassTransmission: glassTransmissionUniforms;
+@group(0) @binding(auto) var glassSceneDepthTexture: texture_depth_2d;
+@group(0) @binding(auto) var glassBackfaceTexture: texture_2d<f32>;
+@group(0) @binding(auto) var glassBackfaceTextureSampler: sampler;
+@group(0) @binding(auto) var glassEnvironmentTexture: texture_2d<f32>;
+@group(0) @binding(auto) var glassEnvironmentTextureSampler: sampler;
+
+fn glassTransmission_linearizeDepth(depth: f32) -> f32 {
+  let nearPlane = glassTransmission.depthRange.x;
+  let farPlane = glassTransmission.depthRange.y;
+  return nearPlane * farPlane /
+    max(farPlane - depth * (farPlane - nearPlane), 0.0001);
+}
+
+fn glassTransmission_sampleDepth(screenCoordinate: vec2<f32>) -> f32 {
+  let pixelCoordinate = vec2<i32>(clamp(
+    screenCoordinate * glassTransmission.viewportSize,
+    vec2<f32>(0.0),
+    glassTransmission.viewportSize - vec2<f32>(1.0)
+  ));
+  return textureLoad(glassSceneDepthTexture, pixelCoordinate, 0);
+}
+
+fn glassTransmission_sampleEnvironment(reflectionDirection: vec3<f32>) -> vec3<f32> {
+  let normalizedDirection = normalize(reflectionDirection);
+  let environmentCoordinate = vec2<f32>(
+    atan2(normalizedDirection.z, normalizedDirection.x) * 0.15915494 + 0.5,
+    acos(clamp(normalizedDirection.y, -1.0, 1.0)) * 0.31830989
+  );
+  let blurOffset = vec2<f32>(0.018, 0.011) * glassMaterial.roughness;
+  let centered = textureSampleLevel(
+    glassEnvironmentTexture,
+    glassEnvironmentTextureSampler,
+    environmentCoordinate,
+    0.0
+  ).rgb;
+  let forward = textureSampleLevel(
+    glassEnvironmentTexture,
+    glassEnvironmentTextureSampler,
+    environmentCoordinate + blurOffset,
+    0.0
+  ).rgb;
+  let backward = textureSampleLevel(
+    glassEnvironmentTexture,
+    glassEnvironmentTextureSampler,
+    environmentCoordinate - blurOffset,
+    0.0
+  ).rgb;
+  return mix(
+    centered,
+    (centered + forward + backward) / 3.0,
+    smoothstep(0.08, 0.7, glassMaterial.roughness)
+  ) * glassTransmission.environmentIntensity;
+}
+
+fn glassTransmission_getColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  baseColor: vec4<f32>,
+  cameraPosition: vec3<f32>,
+  fragmentPosition: vec4<f32>
+) -> vec4<f32> {
+  let surfaceColor = glassMaterial_getColor(
+    normal,
+    worldPosition,
+    baseColor,
+    cameraPosition,
+    fragmentPosition
+  );
+  let viewDirection = normalize(cameraPosition - worldPosition);
+  let frontNormal = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  let screenCoordinate = fragmentPosition.xy / glassTransmission.viewportSize;
+  let backface = textureSampleLevel(
+    glassBackfaceTexture,
+    glassBackfaceTextureSampler,
+    clamp(screenCoordinate, vec2<f32>(0.001), vec2<f32>(0.999)),
+    0.0
+  );
+  let frontDepth = glassTransmission_linearizeDepth(fragmentPosition.z);
+  let backDepth = glassTransmission_linearizeDepth(backface.a);
+  let hasBackface = backface.a > fragmentPosition.z + 0.00001;
+  let measuredThickness = select(
+    glassMaterial.thickness * 0.4,
+    clamp(backDepth - frontDepth, 0.04, glassMaterial.thickness * 1.65),
+    hasBackface
+  ) * glassTransmission.thicknessStrength;
+  let backNormal = select(-frontNormal, normalize(backface.rgb * 2.0 - 1.0), hasBackface);
+  let entryDirection = refract(
+    -viewDirection,
+    frontNormal,
+    1.0 / max(glassMaterial.indexOfRefraction, 1.001)
+  );
+  let exitDirection = refract(entryDirection, -backNormal, glassMaterial.indexOfRefraction);
+  let hasExitRay = dot(exitDirection, exitDirection) > 0.0001;
+  let transmittedDirection = select(reflect(entryDirection, -backNormal), exitDirection, hasExitRay);
+  let cameraUpAxis = select(
+    vec3<f32>(0.0, 1.0, 0.0),
+    vec3<f32>(0.0, 0.0, 1.0),
+    abs(viewDirection.y) > 0.96
+  );
+  let cameraRight = normalize(cross(cameraUpAxis, viewDirection));
+  let cameraUp = normalize(cross(viewDirection, cameraRight));
+  let viewportAspect = glassTransmission.viewportSize.x /
+    max(glassTransmission.viewportSize.y, 1.0);
+  let combinedDeflection = (entryDirection + viewDirection) * 0.68 +
+    (transmittedDirection + viewDirection) * 0.32;
+  let projectedDeflection = vec2<f32>(
+    dot(combinedDeflection, cameraRight) / viewportAspect,
+    -dot(combinedDeflection, cameraUp)
+  );
+  let proposedOffset = projectedDeflection * measuredThickness *
+    glassMaterial.refractionStrength * 0.18;
+  let proposedCoordinate = clamp(
+    screenCoordinate + proposedOffset,
+    vec2<f32>(0.001),
+    vec2<f32>(0.999)
+  );
+  let sampledDepth = glassTransmission_sampleDepth(proposedCoordinate);
+  let foregroundOcclusion = sampledDepth + glassTransmission.depthBias < fragmentPosition.z;
+  let safeOffset = select(proposedOffset, vec2<f32>(0.0), foregroundOcclusion);
+  let projectedNormal = vec2<f32>(
+    dot(frontNormal, cameraRight) / viewportAspect,
+    -dot(frontNormal, cameraUp)
+  );
+  let dispersionOffset = projectedNormal * glassMaterial.dispersion *
+    measuredThickness * 0.3;
+  let transmittedColor = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    safeOffset,
+    dispersionOffset
+  );
+  let absorption = exp(-(
+    vec3<f32>(0.1, 0.065, 0.032) + (1.0 - baseColor.rgb) * 0.22
+  ) * measuredThickness);
+  let reflectionDirection = reflect(-viewDirection, frontNormal);
+  let environmentReflection = glassTransmission_sampleEnvironment(reflectionDirection);
+  let viewAlignment = clamp(dot(frontNormal, viewDirection), 0.0, 1.0);
+  let fresnel = opticalLighting_getFresnel(viewAlignment, 0.04, 5.0);
+  let internalReflection = glassTransmission_sampleEnvironment(
+    reflect(entryDirection, -backNormal)
+  ) * select(0.18, 0.42, !hasExitRay);
+  let opticalColor = transmittedColor * absorption * glassMaterial.transmissionStrength +
+    environmentReflection * (0.09 + fresnel * 0.65) +
+    internalReflection * pow(1.0 - viewAlignment, 2.0);
+  return vec4<f32>(mix(surfaceColor.rgb, opticalColor, 0.64), surfaceColor.a);
+}
+
+#ifdef LUMA_OPTICAL_POINT_LIGHTS
+fn glassTransmission_getIlluminatedColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  baseColor: vec4<f32>,
+  cameraPosition: vec3<f32>,
+  fragmentPosition: vec4<f32>
+) -> vec4<f32> {
+  let transmittedColor = glassTransmission_getColor(
+    normal,
+    worldPosition,
+    baseColor,
+    cameraPosition,
+    fragmentPosition
+  );
+  let pointLightColor = opticalPointLights_getColor(normal, worldPosition, cameraPosition);
+  return vec4<f32>(
+    transmittedColor.rgb + pointLightColor * glassMaterial.reflectionStrength,
+    transmittedColor.a
+  );
+}
+#endif
+`;
+
+const GLASS_TRANSMISSION_GLSL = /* glsl */ `\
+layout(std140) uniform glassTransmissionUniforms {
+  vec2 viewportSize;
+  vec2 depthRange;
+  float environmentIntensity;
+  float thicknessStrength;
+  float depthBias;
+} glassTransmission;
+
+uniform sampler2D glassSceneDepthTexture;
+uniform sampler2D glassBackfaceTexture;
+uniform sampler2D glassEnvironmentTexture;
+
+float glassTransmission_linearizeDepth(float depth) {
+  float nearPlane = glassTransmission.depthRange.x;
+  float farPlane = glassTransmission.depthRange.y;
+  return nearPlane * farPlane /
+    max(farPlane - depth * (farPlane - nearPlane), 0.0001);
+}
+
+float glassTransmission_sampleDepth(vec2 screenCoordinate) {
+  return texture(
+    glassSceneDepthTexture,
+    clamp(screenCoordinate, vec2(0.001), vec2(0.999))
+  ).r;
+}
+
+vec3 glassTransmission_sampleEnvironment(vec3 reflectionDirection) {
+  vec3 normalizedDirection = normalize(reflectionDirection);
+  vec2 environmentCoordinate = vec2(
+    atan(normalizedDirection.z, normalizedDirection.x) * 0.15915494 + 0.5,
+    acos(clamp(normalizedDirection.y, -1.0, 1.0)) * 0.31830989
+  );
+  vec2 blurOffset = vec2(0.018, 0.011) * glassMaterial.roughness;
+  vec3 centered = texture(glassEnvironmentTexture, environmentCoordinate).rgb;
+  vec3 forward = texture(glassEnvironmentTexture, environmentCoordinate + blurOffset).rgb;
+  vec3 backward = texture(glassEnvironmentTexture, environmentCoordinate - blurOffset).rgb;
+  return mix(
+    centered,
+    (centered + forward + backward) / 3.0,
+    smoothstep(0.08, 0.7, glassMaterial.roughness)
+  ) * glassTransmission.environmentIntensity;
+}
+
+vec4 glassTransmission_getColor(
+  vec3 normal,
+  vec3 worldPosition,
+  vec4 baseColor,
+  vec3 cameraPosition,
+  vec4 fragmentPosition
+) {
+  vec4 surfaceColor = glassMaterial_getColor(
+    normal,
+    worldPosition,
+    baseColor,
+    cameraPosition,
+    fragmentPosition
+  );
+  vec3 viewDirection = normalize(cameraPosition - worldPosition);
+  vec3 frontNormal = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  vec2 screenCoordinate = fragmentPosition.xy / glassTransmission.viewportSize;
+  vec4 backface = texture(
+    glassBackfaceTexture,
+    clamp(screenCoordinate, vec2(0.001), vec2(0.999))
+  );
+  float frontDepth = glassTransmission_linearizeDepth(fragmentPosition.z);
+  float backDepth = glassTransmission_linearizeDepth(backface.a);
+  bool hasBackface = backface.a > fragmentPosition.z + 0.00001;
+  float measuredThickness = (
+    hasBackface
+      ? clamp(backDepth - frontDepth, 0.04, glassMaterial.thickness * 1.65)
+      : glassMaterial.thickness * 0.4
+  ) * glassTransmission.thicknessStrength;
+  vec3 backNormal = hasBackface ? normalize(backface.rgb * 2.0 - 1.0) : -frontNormal;
+  vec3 entryDirection = refract(
+    -viewDirection,
+    frontNormal,
+    1.0 / max(glassMaterial.indexOfRefraction, 1.001)
+  );
+  vec3 exitDirection = refract(entryDirection, -backNormal, glassMaterial.indexOfRefraction);
+  bool hasExitRay = dot(exitDirection, exitDirection) > 0.0001;
+  vec3 transmittedDirection = hasExitRay
+    ? exitDirection
+    : reflect(entryDirection, -backNormal);
+  vec3 cameraUpAxis = abs(viewDirection.y) > 0.96
+    ? vec3(0.0, 0.0, 1.0)
+    : vec3(0.0, 1.0, 0.0);
+  vec3 cameraRight = normalize(cross(cameraUpAxis, viewDirection));
+  vec3 cameraUp = normalize(cross(viewDirection, cameraRight));
+  float viewportAspect = glassTransmission.viewportSize.x /
+    max(glassTransmission.viewportSize.y, 1.0);
+  vec3 combinedDeflection = (entryDirection + viewDirection) * 0.68 +
+    (transmittedDirection + viewDirection) * 0.32;
+  vec2 projectedDeflection = vec2(
+    dot(combinedDeflection, cameraRight) / viewportAspect,
+    dot(combinedDeflection, cameraUp)
+  );
+  vec2 proposedOffset = projectedDeflection * measuredThickness *
+    glassMaterial.refractionStrength * 0.18;
+  vec2 proposedCoordinate = clamp(
+    screenCoordinate + proposedOffset,
+    vec2(0.001),
+    vec2(0.999)
+  );
+  float sampledDepth = glassTransmission_sampleDepth(proposedCoordinate);
+  bool foregroundOcclusion = sampledDepth + glassTransmission.depthBias < fragmentPosition.z;
+  vec2 safeOffset = foregroundOcclusion ? vec2(0.0) : proposedOffset;
+  vec2 projectedNormal = vec2(
+    dot(frontNormal, cameraRight) / viewportAspect,
+    dot(frontNormal, cameraUp)
+  );
+  vec2 dispersionOffset = projectedNormal * glassMaterial.dispersion *
+    measuredThickness * 0.3;
+  vec3 transmittedColor = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    safeOffset,
+    dispersionOffset
+  );
+  vec3 absorption = exp(-(
+    vec3(0.1, 0.065, 0.032) + (1.0 - baseColor.rgb) * 0.22
+  ) * measuredThickness);
+  vec3 reflectionDirection = reflect(-viewDirection, frontNormal);
+  vec3 environmentReflection = glassTransmission_sampleEnvironment(reflectionDirection);
+  float viewAlignment = clamp(dot(frontNormal, viewDirection), 0.0, 1.0);
+  float fresnel = opticalLighting_getFresnel(viewAlignment, 0.04, 5.0);
+  vec3 internalReflection = glassTransmission_sampleEnvironment(
+    reflect(entryDirection, -backNormal)
+  ) * (hasExitRay ? 0.18 : 0.42);
+  vec3 opticalColor = transmittedColor * absorption * glassMaterial.transmissionStrength +
+    environmentReflection * (0.09 + fresnel * 0.65) +
+    internalReflection * pow(1.0 - viewAlignment, 2.0);
+  return vec4(mix(surfaceColor.rgb, opticalColor, 0.64), surfaceColor.a);
+}
+
+#ifdef LUMA_OPTICAL_POINT_LIGHTS
+vec4 glassTransmission_getIlluminatedColor(
+  vec3 normal,
+  vec3 worldPosition,
+  vec4 baseColor,
+  vec3 cameraPosition,
+  vec4 fragmentPosition
+) {
+  vec4 transmittedColor = glassTransmission_getColor(
+    normal,
+    worldPosition,
+    baseColor,
+    cameraPosition,
+    fragmentPosition
+  );
+  vec3 pointLightColor = opticalPointLights_getColor(normal, worldPosition, cameraPosition);
+  return vec4(
+    transmittedColor.rgb + pointLightColor * glassMaterial.reflectionStrength,
+    transmittedColor.a
+  );
+}
+#endif
+`;
+
+function getGlassTransmissionUniforms(
+  props: Partial<GlassTransmissionProps> = {},
+  previousUniforms?: GlassTransmissionUniforms
+): Partial<GlassTransmissionUniforms & GlassTransmissionBindings> {
+  return {
+    viewportSize: props.viewportSize ?? previousUniforms?.viewportSize ?? [1, 1],
+    depthRange: props.depthRange ?? previousUniforms?.depthRange ?? [0.1, 100],
+    environmentIntensity: props.environmentIntensity ?? previousUniforms?.environmentIntensity ?? 1,
+    thicknessStrength: props.thicknessStrength ?? previousUniforms?.thicknessStrength ?? 1,
+    depthBias: props.depthBias ?? previousUniforms?.depthBias ?? 0.00008,
+    ...(props.sceneDepthTexture ? {glassSceneDepthTexture: props.sceneDepthTexture} : {}),
+    ...(props.backfaceTexture ? {glassBackfaceTexture: props.backfaceTexture} : {}),
+    ...(props.environmentTexture ? {glassEnvironmentTexture: props.environmentTexture} : {})
+  };
+}
+
+/** Optional backface-thickness, depth-aware transmission, and environment-map glass extension. */
+export const glassTransmission = {
+  name: 'glassTransmission',
+  source: GLASS_TRANSMISSION_WGSL,
+  fs: GLASS_TRANSMISSION_GLSL,
+  dependencies: [glassMaterial],
+  bindingLayout: [
+    {name: 'glassSceneDepthTexture', group: 0, visibility: SHADER_STAGE_FRAGMENT},
+    {name: 'glassBackfaceTexture', group: 0, visibility: SHADER_STAGE_FRAGMENT},
+    {name: 'glassBackfaceTextureSampler', group: 0, visibility: SHADER_STAGE_FRAGMENT},
+    {name: 'glassEnvironmentTexture', group: 0, visibility: SHADER_STAGE_FRAGMENT},
+    {name: 'glassEnvironmentTextureSampler', group: 0, visibility: SHADER_STAGE_FRAGMENT}
+  ],
+  uniformTypes: {
+    viewportSize: 'vec2<f32>',
+    depthRange: 'vec2<f32>',
+    environmentIntensity: 'f32',
+    thicknessStrength: 'f32',
+    depthBias: 'f32'
+  },
+  defaultUniforms: {
+    viewportSize: [1, 1],
+    depthRange: [0.1, 100],
+    environmentIntensity: 1,
+    thicknessStrength: 1,
+    depthBias: 0.00008
+  },
+  getUniforms: getGlassTransmissionUniforms
+} as const satisfies ShaderModule<
+  GlassTransmissionProps,
+  GlassTransmissionUniforms,
+  GlassTransmissionBindings
+>;
+
+/** Installs the optional rasterized transmission extension and its glass-material dependency. */
+export const glassTransmissionPlugin = {
+  name: 'glassTransmission',
+  modules: [glassTransmission as ShaderModule]
+} as const satisfies ShaderPlugin;

--- a/modules/experimental/src/materials/optical-lighting.ts
+++ b/modules/experimental/src/materials/optical-lighting.ts
@@ -18,6 +18,30 @@ fn opticalLighting_getFresnel(
     pow(1.0 - clamp(viewAlignment, 0.0, 1.0), exponent);
 }
 
+fn opticalLighting_getMicrofacetSpecular(
+  normal: vec3<f32>,
+  viewDirection: vec3<f32>,
+  lightDirection: vec3<f32>,
+  roughness: f32
+) -> f32 {
+  let halfDirection = normalize(viewDirection + lightDirection);
+  let normalAlignment = max(dot(normal, viewDirection), 0.001);
+  let lightAlignment = max(dot(normal, lightDirection), 0.0);
+  let halfAlignment = max(dot(normal, halfDirection), 0.0);
+  let alpha = max(roughness * roughness, 0.045);
+  let alphaSquared = alpha * alpha;
+  let distributionDenominator = halfAlignment * halfAlignment * (alphaSquared - 1.0) + 1.0;
+  let distribution = alphaSquared /
+    max(3.14159265 * distributionDenominator * distributionDenominator, 0.001);
+  let visibilityFactor = pow(roughness + 1.0, 2.0) * 0.125;
+  let viewVisibility = normalAlignment /
+    (normalAlignment * (1.0 - visibilityFactor) + visibilityFactor);
+  let lightVisibility = lightAlignment /
+    (lightAlignment * (1.0 - visibilityFactor) + visibilityFactor);
+  return distribution * viewVisibility * lightVisibility * lightAlignment /
+    max(4.0 * normalAlignment * lightAlignment, 0.001);
+}
+
 fn opticalLighting_getKeyLight() -> vec3<f32> {
   return normalize(vec3<f32>(-0.45, 0.82, 0.34));
 }
@@ -49,6 +73,30 @@ vec3 opticalLighting_faceNormal(vec3 normal, vec3 viewDirection) {
 float opticalLighting_getFresnel(float viewAlignment, float baseReflectance, float exponent) {
   return baseReflectance + (1.0 - baseReflectance) *
     pow(1.0 - clamp(viewAlignment, 0.0, 1.0), exponent);
+}
+
+float opticalLighting_getMicrofacetSpecular(
+  vec3 normal,
+  vec3 viewDirection,
+  vec3 lightDirection,
+  float roughness
+) {
+  vec3 halfDirection = normalize(viewDirection + lightDirection);
+  float normalAlignment = max(dot(normal, viewDirection), 0.001);
+  float lightAlignment = max(dot(normal, lightDirection), 0.0);
+  float halfAlignment = max(dot(normal, halfDirection), 0.0);
+  float alpha = max(roughness * roughness, 0.045);
+  float alphaSquared = alpha * alpha;
+  float distributionDenominator = halfAlignment * halfAlignment * (alphaSquared - 1.0) + 1.0;
+  float distribution = alphaSquared /
+    max(3.14159265 * distributionDenominator * distributionDenominator, 0.001);
+  float visibilityFactor = pow(roughness + 1.0, 2.0) * 0.125;
+  float viewVisibility = normalAlignment /
+    (normalAlignment * (1.0 - visibilityFactor) + visibilityFactor);
+  float lightVisibility = lightAlignment /
+    (lightAlignment * (1.0 - visibilityFactor) + visibilityFactor);
+  return distribution * viewVisibility * lightVisibility * lightAlignment /
+    max(4.0 * normalAlignment * lightAlignment, 0.001);
 }
 
 vec3 opticalLighting_getKeyLight() {

--- a/modules/experimental/src/materials/optical-point-lights.ts
+++ b/modules/experimental/src/materials/optical-point-lights.ts
@@ -1,0 +1,208 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ShaderModule, ShaderPlugin} from '@luma.gl/shadertools';
+import {opticalLighting} from './optical-lighting';
+
+/** Maximum number of local lights carried by the portable fixed-size uniform block. */
+export const MAX_OPTICAL_POINT_LIGHTS = 16;
+
+/** Local colored light emitted from a world-space position. */
+export type OpticalPointLight = {
+  /** Position in the same world-space coordinate system as the illuminated geometry. */
+  position: [number, number, number];
+  /** Linear RGB light color. */
+  color: [number, number, number];
+  /** Optional per-light intensity multiplier. */
+  intensity?: number;
+  /** World-space distance at which illumination falls smoothly to zero. */
+  radius?: number;
+};
+
+/** Runtime properties for a bounded set of local optical lights. */
+export type OpticalPointLightsProps = {
+  /** Active local lights; additional lights beyond the fixed capacity are ignored. */
+  lights?: readonly OpticalPointLight[];
+  /** Multiplier applied to the complete set of lights. */
+  intensity?: number;
+};
+
+/** One packed entry in the cross-backend optical-light uniform array. */
+export type OpticalPointLightUniform = {
+  position: [number, number, number];
+  radius: number;
+  color: [number, number, number];
+  intensity: number;
+};
+
+/** Uniform values consumed by {@link opticalPointLights}. */
+export type OpticalPointLightsUniforms = {
+  lightCount: number;
+  intensity: number;
+  lights: readonly OpticalPointLightUniform[];
+};
+
+const OPTICAL_POINT_LIGHT_UNIFORM_TYPE = {
+  position: 'vec3<f32>',
+  radius: 'f32',
+  color: 'vec3<f32>',
+  intensity: 'f32'
+} as const;
+
+const OPTICAL_POINT_LIGHTS_WGSL = /* wgsl */ `\
+struct OpticalPointLightUniform {
+  position: vec3<f32>,
+  radius: f32,
+  color: vec3<f32>,
+  intensity: f32,
+};
+
+struct opticalPointLightsUniforms {
+  lightCount: i32,
+  intensity: f32,
+  lights: array<OpticalPointLightUniform, ${MAX_OPTICAL_POINT_LIGHTS}>,
+};
+
+@group(0) @binding(auto) var<uniform> opticalPointLights: opticalPointLightsUniforms;
+
+fn opticalPointLights_getColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  cameraPosition: vec3<f32>
+) -> vec3<f32> {
+  let viewDirection = normalize(cameraPosition - worldPosition);
+  let normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  var accumulatedColor = vec3<f32>(0.0);
+
+  for (var lightIndex = 0; lightIndex < ${MAX_OPTICAL_POINT_LIGHTS}; lightIndex++) {
+    if (lightIndex >= opticalPointLights.lightCount) {
+      break;
+    }
+
+    let light = opticalPointLights.lights[lightIndex];
+    let lightOffset = light.position - worldPosition;
+    let distanceSquared = dot(lightOffset, lightOffset);
+    let radius = max(light.radius, 0.0001);
+    let normalizedDistance = clamp(sqrt(distanceSquared) / radius, 0.0, 1.0);
+    let attenuation = pow(1.0 - normalizedDistance * normalizedDistance, 2.0);
+    let lightDirection = lightOffset * inverseSqrt(max(distanceSquared, 0.00001));
+    let halfVector = normalize(lightDirection + viewDirection + vec3<f32>(0.00001));
+    let diffuse = max(dot(normalFacingCamera, lightDirection), 0.0);
+    let specular = pow(max(dot(normalFacingCamera, halfVector), 0.0), 28.0);
+    let surfaceResponse = 0.08 + diffuse * 0.52 + specular * 0.4;
+    accumulatedColor += light.color * light.intensity * attenuation * surfaceResponse;
+  }
+
+  return accumulatedColor * opticalPointLights.intensity;
+}
+`;
+
+const OPTICAL_POINT_LIGHTS_GLSL = /* glsl */ `\
+struct OpticalPointLightUniform {
+  vec3 position;
+  float radius;
+  vec3 color;
+  float intensity;
+};
+
+layout(std140) uniform opticalPointLightsUniforms {
+  int lightCount;
+  float intensity;
+  OpticalPointLightUniform lights[${MAX_OPTICAL_POINT_LIGHTS}];
+} opticalPointLights;
+
+vec3 opticalPointLights_getColor(
+  vec3 normal,
+  vec3 worldPosition,
+  vec3 cameraPosition
+) {
+  vec3 viewDirection = normalize(cameraPosition - worldPosition);
+  vec3 normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  vec3 accumulatedColor = vec3(0.0);
+
+  for (int lightIndex = 0; lightIndex < ${MAX_OPTICAL_POINT_LIGHTS}; lightIndex++) {
+    if (lightIndex >= opticalPointLights.lightCount) {
+      break;
+    }
+
+    OpticalPointLightUniform light = opticalPointLights.lights[lightIndex];
+    vec3 lightOffset = light.position - worldPosition;
+    float distanceSquared = dot(lightOffset, lightOffset);
+    float radius = max(light.radius, 0.0001);
+    float normalizedDistance = clamp(sqrt(distanceSquared) / radius, 0.0, 1.0);
+    float attenuation = pow(1.0 - normalizedDistance * normalizedDistance, 2.0);
+    vec3 lightDirection = lightOffset * inversesqrt(max(distanceSquared, 0.00001));
+    vec3 halfVector = normalize(lightDirection + viewDirection + vec3(0.00001));
+    float diffuse = max(dot(normalFacingCamera, lightDirection), 0.0);
+    float specular = pow(max(dot(normalFacingCamera, halfVector), 0.0), 28.0);
+    float surfaceResponse = 0.08 + diffuse * 0.52 + specular * 0.4;
+    accumulatedColor += light.color * light.intensity * attenuation * surfaceResponse;
+  }
+
+  return accumulatedColor * opticalPointLights.intensity;
+}
+`;
+
+function getOpticalPointLightsUniforms(
+  props: Partial<OpticalPointLightsProps> = {},
+  previousUniforms?: OpticalPointLightsUniforms
+): OpticalPointLightsUniforms {
+  const suppliedLights = props.lights;
+
+  return {
+    lightCount: suppliedLights
+      ? Math.min(suppliedLights.length, MAX_OPTICAL_POINT_LIGHTS)
+      : (previousUniforms?.lightCount ?? 0),
+    intensity: props.intensity ?? previousUniforms?.intensity ?? 1,
+    lights: suppliedLights
+      ? makeOpticalPointLightUniforms(suppliedLights)
+      : (previousUniforms?.lights ?? makeOpticalPointLightUniforms([]))
+  };
+}
+
+function makeOpticalPointLightUniforms(
+  lights: readonly OpticalPointLight[]
+): OpticalPointLightUniform[] {
+  return Array.from({length: MAX_OPTICAL_POINT_LIGHTS}, (_, lightIndex) => {
+    const light = lights[lightIndex];
+
+    return light
+      ? {
+          position: light.position,
+          radius: light.radius ?? 1,
+          color: light.color,
+          intensity: light.intensity ?? 1
+        }
+      : {
+          position: [0, 0, 0],
+          radius: 1,
+          color: [0, 0, 0],
+          intensity: 0
+        };
+  });
+}
+
+/** Portable bounded point lights for glass and reflective optical materials. */
+export const opticalPointLights = {
+  name: 'opticalPointLights',
+  source: OPTICAL_POINT_LIGHTS_WGSL,
+  fs: OPTICAL_POINT_LIGHTS_GLSL,
+  defines: {
+    LUMA_OPTICAL_POINT_LIGHTS: true
+  },
+  dependencies: [opticalLighting],
+  uniformTypes: {
+    lightCount: 'i32',
+    intensity: 'f32',
+    lights: [OPTICAL_POINT_LIGHT_UNIFORM_TYPE, MAX_OPTICAL_POINT_LIGHTS]
+  },
+  defaultUniforms: getOpticalPointLightsUniforms(),
+  getUniforms: getOpticalPointLightsUniforms
+} as const satisfies ShaderModule<OpticalPointLightsProps, OpticalPointLightsUniforms, {}>;
+
+/** Explicitly installs bounded point lights and enables illuminated material helpers. */
+export const opticalPointLightsPlugin = {
+  name: 'opticalPointLights',
+  modules: [opticalPointLights as ShaderModule]
+} as const satisfies ShaderPlugin;

--- a/modules/experimental/src/materials/reflective-material.ts
+++ b/modules/experimental/src/materials/reflective-material.ts
@@ -51,8 +51,9 @@ fn reflectiveMaterial_getColor(
     max(dot(normalFacingCamera, fillHalfVector), 0.0),
     specularExponent * 0.545
   );
+  let reflectionDirection = reflect(-viewDirection, normalFacingCamera);
   let reflectedColor = opticalLighting_sampleEnvironment(
-    normalFacingCamera,
+    reflectionDirection,
     vec3<f32>(0.08, 0.14, 0.25),
     vec3<f32>(0.52, 0.7, 0.95),
     0.0
@@ -65,7 +66,7 @@ fn reflectiveMaterial_getColor(
     baseColor.a * reflectiveMaterial.opacityScale *
       (0.85 + fresnel * 0.2 + (keySpecular + fillSpecular) * 0.35),
     0.0,
-    0.72
+    1.0
   );
   return vec4<f32>(color, opacity);
 }
@@ -121,8 +122,9 @@ vec4 reflectiveMaterial_getColor(
     max(dot(normalFacingCamera, fillHalfVector), 0.0),
     specularExponent * 0.545
   );
+  vec3 reflectionDirection = reflect(-viewDirection, normalFacingCamera);
   vec3 reflectedColor = opticalLighting_sampleEnvironment(
-    normalFacingCamera,
+    reflectionDirection,
     vec3(0.08, 0.14, 0.25),
     vec3(0.52, 0.7, 0.95),
     0.0
@@ -135,7 +137,7 @@ vec4 reflectiveMaterial_getColor(
     baseColor.a * reflectiveMaterial.opacityScale *
       (0.85 + fresnel * 0.2 + (keySpecular + fillSpecular) * 0.35),
     0.0,
-    0.72
+    1.0
   );
   return vec4(color, opacity);
 }

--- a/modules/experimental/src/materials/reflective-material.ts
+++ b/modules/experimental/src/materials/reflective-material.ts
@@ -69,6 +69,27 @@ fn reflectiveMaterial_getColor(
   );
   return vec4<f32>(color, opacity);
 }
+
+#ifdef LUMA_OPTICAL_POINT_LIGHTS
+fn reflectiveMaterial_getIlluminatedColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  baseColor: vec4<f32>,
+  cameraPosition: vec3<f32>
+) -> vec4<f32> {
+  let reflectedColor = reflectiveMaterial_getColor(
+    normal,
+    worldPosition,
+    baseColor,
+    cameraPosition
+  );
+  let pointLightColor = opticalPointLights_getColor(normal, worldPosition, cameraPosition);
+  return vec4<f32>(
+    reflectedColor.rgb + pointLightColor * reflectiveMaterial.specularStrength,
+    reflectedColor.a
+  );
+}
+#endif
 `;
 
 const REFLECTIVE_MATERIAL_GLSL = /* glsl */ `\
@@ -118,6 +139,29 @@ vec4 reflectiveMaterial_getColor(
   );
   return vec4(color, opacity);
 }
+
+#ifdef LUMA_OPTICAL_POINT_LIGHTS
+vec3 opticalPointLights_getColor(vec3 normal, vec3 worldPosition, vec3 cameraPosition);
+
+vec4 reflectiveMaterial_getIlluminatedColor(
+  vec3 normal,
+  vec3 worldPosition,
+  vec4 baseColor,
+  vec3 cameraPosition
+) {
+  vec4 reflectedColor = reflectiveMaterial_getColor(
+    normal,
+    worldPosition,
+    baseColor,
+    cameraPosition
+  );
+  vec3 pointLightColor = opticalPointLights_getColor(normal, worldPosition, cameraPosition);
+  return vec4(
+    reflectedColor.rgb + pointLightColor * reflectiveMaterial.specularStrength,
+    reflectedColor.a
+  );
+}
+#endif
 `;
 
 function getReflectiveMaterialUniforms(

--- a/modules/experimental/src/oit/a-buffer-renderer.ts
+++ b/modules/experimental/src/oit/a-buffer-renderer.ts
@@ -18,7 +18,7 @@ import {createABufferResolveShaderPassPipeline} from './a-buffer-resolve-shader-
 
 const A_BUFFER_HEAD_POINTER_HEADER_BYTE_LENGTH = 8;
 const A_BUFFER_HEAD_POINTER_BYTE_LENGTH = 4;
-const A_BUFFER_FRAGMENT_BYTE_LENGTH = 12;
+const A_BUFFER_FRAGMENT_BYTE_LENGTH = 16;
 const DEFAULT_AVERAGE_FRAGMENTS_PER_PIXEL = 4;
 const DEFAULT_MAX_FRAGMENTS_PER_PIXEL = 12;
 let nextABufferResourceId = 0;

--- a/modules/experimental/src/oit/a-buffer-renderer.ts
+++ b/modules/experimental/src/oit/a-buffer-renderer.ts
@@ -9,6 +9,7 @@ import {
   type RenderPass,
   type RenderPipelineParameters,
   Texture,
+  type TextureFormatColor,
   type TextureView
 } from '@luma.gl/core';
 import {ShaderPassRenderer} from '@luma.gl/engine';
@@ -34,6 +35,8 @@ export type ABufferRendererProps = {
   maxFragmentsPerPixel?: number;
   /** Maximum size of each A-buffer storage buffer in bytes. Smaller values force more slices. */
   maxBufferByteLength?: number;
+  /** Format of the resolved color texture. Defaults to the canvas-preferred format. */
+  colorFormat?: TextureFormatColor;
 };
 
 /** Result returned by {@link getABufferSupport}. */
@@ -85,7 +88,7 @@ export type ABufferRenderOptions = {
   drawTranslucent: (renderPass: RenderPass) => void;
 };
 
-type ResolvedABufferRendererProps = Required<ABufferRendererProps>;
+type ResolvedABufferRendererProps = Required<Omit<ABufferRendererProps, 'colorFormat'>>;
 
 /**
  * Captures exact order-independent transparency and resolves each slice through a ShaderPassPipeline.
@@ -133,6 +136,7 @@ export class ABufferRenderer {
     this.device = device;
     this.props = resolveABufferRendererProps(props);
     this.resolveRenderer = new ShaderPassRenderer(device, {
+      colorFormat: props.colorFormat,
       shaderPasses: [
         createABufferResolveShaderPassPipeline({
           maxFragmentsPerPixel: this.props.maxFragmentsPerPixel

--- a/modules/experimental/src/oit/a-buffer-resolve-shader-pass-pipeline.ts
+++ b/modules/experimental/src/oit/a-buffer-resolve-shader-pass-pipeline.ts
@@ -51,7 +51,8 @@ struct ABufferHeadPointers {
 };
 
 struct ABufferFragment {
-  color: u32,
+  colorRedGreen: u32,
+  colorBlueAlpha: u32,
   depth: f32,
   next: u32,
 };
@@ -123,7 +124,11 @@ fn aBufferResolve_sampleColor(
   var transparentColor = vec4<f32>(0.0);
   var compositeIndex = 0u;
   while (compositeIndex < fragmentCount) {
-    let fragmentColor = unpack4x8unorm(capturedFragments[compositeIndex].color);
+    let capturedFragment = capturedFragments[compositeIndex];
+    let fragmentColor = vec4<f32>(
+      unpack2x16float(capturedFragment.colorRedGreen),
+      unpack2x16float(capturedFragment.colorBlueAlpha)
+    );
     transparentColor = fragmentColor + transparentColor * (1.0 - fragmentColor.a);
     compositeIndex += 1u;
   }

--- a/modules/experimental/src/oit/a-buffer.ts
+++ b/modules/experimental/src/oit/a-buffer.ts
@@ -59,7 +59,8 @@ struct ABufferHeadPointers {
 };
 
 struct ABufferFragment {
-  color: u32,
+  colorRedGreen: u32,
+  colorBlueAlpha: u32,
   depth: f32,
   next: u32,
 };
@@ -107,8 +108,13 @@ fn aBuffer_capturePremultipliedColor(
 
   let fragmentPointer = fragmentIndex + 1u;
   let nextFragmentPointer = atomicExchange(&headPointers.heads[pixelIndex], fragmentPointer);
+  let packedColor = vec4<f32>(
+    clamp(color.rgb, vec3<f32>(0.0), vec3<f32>(65504.0)),
+    clamp(color.a, 0.0, 1.0)
+  );
   fragments.fragments[fragmentIndex] = ABufferFragment(
-    pack4x8unorm(clamp(color, vec4<f32>(0.0), vec4<f32>(1.0))),
+    pack2x16float(packedColor.rg),
+    pack2x16float(packedColor.ba),
     fragmentPosition.z,
     nextFragmentPointer
   );

--- a/modules/experimental/src/oit/wboit-renderer.ts
+++ b/modules/experimental/src/oit/wboit-renderer.ts
@@ -8,7 +8,8 @@ import {
   type Framebuffer,
   type RenderPass,
   type RenderPipelineParameters,
-  Texture
+  Texture,
+  type TextureFormatColor
 } from '@luma.gl/core';
 import {ShaderPassRenderer} from '@luma.gl/engine';
 import {type WBOITPass, type WBOITShaderModuleProps} from './wboit';
@@ -19,6 +20,12 @@ import {
 
 const WBOIT_COLOR_FORMAT = 'rgba16float';
 let nextWBOITResourceId = 0;
+
+/** Construction options for {@link WBOITRenderer}. */
+export type WBOITRendererProps = {
+  /** Format of the resolved color texture. Defaults to the canvas-preferred format. */
+  colorFormat?: TextureFormatColor;
+};
 
 /** Result returned by {@link getWBOITSupport}. */
 export type WBOITSupport = {
@@ -113,7 +120,7 @@ export class WBOITRenderer {
   private readonly resolveRenderer: ShaderPassRenderer;
 
   /** Creates a renderer and validates floating-point render-target blending support. */
-  constructor(device: Device) {
+  constructor(device: Device, props: WBOITRendererProps = {}) {
     const support = getWBOITSupport(device);
     if (!support.supported) {
       throw new Error(support.reason);
@@ -122,6 +129,7 @@ export class WBOITRenderer {
     this.device = device;
     this.renderTargets = createWBOITRenderTargets(device, 1, 1);
     this.resolveRenderer = new ShaderPassRenderer(device, {
+      colorFormat: props.colorFormat,
       shaderPasses: [createWBOITResolveShaderPassPipeline()]
     });
   }

--- a/modules/experimental/test/materials/optical-materials.node.spec.ts
+++ b/modules/experimental/test/materials/optical-materials.node.spec.ts
@@ -3,21 +3,36 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {makeShaderBlockLayout} from '@luma.gl/core';
 import {
   aBuffer,
+  emissiveMaterial,
+  emissiveMaterialPlugin,
   glassMaterial,
   glassMaterialPlugin,
+  MAX_OPTICAL_POINT_LIGHTS,
   opticalLighting,
+  type OpticalPointLight,
+  opticalPointLights,
+  opticalPointLightsPlugin,
   reflectiveMaterial,
   reflectiveMaterialPlugin,
   wboit
 } from '@luma.gl/experimental';
-import {ShaderAssembler} from '@luma.gl/shadertools';
+import {getShaderModuleUniformLayoutValidationResult, ShaderAssembler} from '@luma.gl/shadertools';
 import {WgslReflect} from 'wgsl_reflect';
 
 const PLATFORM_INFO = {
   type: 'webgpu' as const,
   shaderLanguage: 'wgsl' as const,
+  shaderLanguageVersion: 300 as const,
+  gpu: 'test',
+  features: new Set<string>()
+};
+
+const GLSL_PLATFORM_INFO = {
+  type: 'webgl' as const,
+  shaderLanguage: 'glsl' as const,
   shaderLanguageVersion: 300 as const,
   gpu: 'test',
   features: new Set<string>()
@@ -63,6 +78,28 @@ fn fragmentMain(inputs: VertexOutputs) -> @location(0) vec4<f32> {
 }
 `;
 
+const ILLUMINATED_OPTICAL_MATERIAL_SHADER = OPTICAL_MATERIAL_SHADER.replace(
+  'glassMaterial_getColor(',
+  'glassMaterial_getIlluminatedColor('
+)
+  .replace('reflectiveMaterial_getColor(', 'reflectiveMaterial_getIlluminatedColor(')
+  .replace(
+    '  return mix(glassColor, reflectedColor, 0.25);',
+    `  let emittedColor = emissiveMaterial_getColor(
+    normal,
+    inputs.worldPosition,
+    vec4<f32>(1.0, 0.2, 0.1, 1.0),
+    cameraPosition
+  );
+  let pointLightColor = opticalPointLights_getColor(
+    normal,
+    inputs.worldPosition,
+    cameraPosition
+  );
+  return mix(glassColor, reflectedColor, 0.25) + emittedColor * 0.2 +
+    vec4<f32>(pointLightColor, 0.0);`
+  );
+
 test('optical material modules expose portable shared shader helpers', testCase => {
   testCase.equal(glassMaterialPlugin.name, 'glassMaterial', 'glass plugin has a stable name');
   testCase.deepEqual(glassMaterialPlugin.modules, [glassMaterial], 'glass plugin installs glass');
@@ -76,6 +113,26 @@ test('optical material modules expose portable shared shader helpers', testCase 
     [reflectiveMaterial],
     'reflective plugin installs reflective shading'
   );
+  testCase.equal(
+    emissiveMaterialPlugin.name,
+    'emissiveMaterial',
+    'emissive plugin has a stable name'
+  );
+  testCase.deepEqual(
+    emissiveMaterialPlugin.modules,
+    [emissiveMaterial],
+    'emissive plugin installs emissive shading'
+  );
+  testCase.equal(
+    opticalPointLightsPlugin.name,
+    'opticalPointLights',
+    'point-light plugin has a stable name'
+  );
+  testCase.deepEqual(
+    opticalPointLightsPlugin.modules,
+    [opticalPointLights],
+    'point-light plugin installs local lighting explicitly'
+  );
   testCase.deepEqual(
     glassMaterial.dependencies,
     [opticalLighting],
@@ -86,8 +143,31 @@ test('optical material modules expose portable shared shader helpers', testCase 
     [opticalLighting],
     'reflective shading reuses shared optical lighting'
   );
+  testCase.deepEqual(
+    emissiveMaterial.dependencies,
+    [opticalLighting],
+    'emissive shading reuses shared optical lighting'
+  );
+  testCase.deepEqual(
+    opticalPointLights.dependencies,
+    [opticalLighting],
+    'point-light shading reuses shared optical lighting'
+  );
+  testCase.equal(MAX_OPTICAL_POINT_LIGHTS, 16, 'point lights have a portable fixed capacity');
   testCase.match(opticalLighting.source, /fn opticalLighting_getFresnel/, 'WGSL helpers exist');
   testCase.match(opticalLighting.fs, /float opticalLighting_getFresnel/, 'GLSL helpers exist');
+  testCase.match(emissiveMaterial.source, /fn emissiveMaterial_getColor/, 'WGSL emission exists');
+  testCase.match(emissiveMaterial.fs, /vec4 emissiveMaterial_getColor/, 'GLSL emission exists');
+  testCase.match(
+    opticalPointLights.source,
+    /fn opticalPointLights_getColor/,
+    'WGSL point-light helper exists'
+  );
+  testCase.match(
+    opticalPointLights.fs,
+    /vec3 opticalPointLights_getColor/,
+    'GLSL point-light helper exists'
+  );
   testCase.end();
 });
 
@@ -132,10 +212,114 @@ test('optical materials retain defaults while applying partial updates', testCas
     0.42,
     'reflective specular strength is retained'
   );
+
+  const initialEmissiveUniforms = emissiveMaterial.getUniforms({});
+  testCase.deepEqual(
+    initialEmissiveUniforms,
+    {intensity: 1, rimStrength: 0.35},
+    'emissive uniforms expose stable defaults'
+  );
+
+  const updatedEmissiveUniforms = emissiveMaterial.getUniforms(
+    {intensity: 2.5},
+    initialEmissiveUniforms
+  );
+  testCase.equal(updatedEmissiveUniforms.intensity, 2.5, 'emissive intensity updates');
+  testCase.equal(updatedEmissiveUniforms.rimStrength, 0.35, 'emissive rim strength is retained');
   testCase.end();
 });
 
-test('optical materials compose once with both transparency modules', testCase => {
+test('optical point lights pack and retain a bounded portable uniform array', testCase => {
+  const initialUniforms = opticalPointLights.getUniforms({});
+  testCase.equal(initialUniforms.lightCount, 0, 'point lights start disabled');
+  testCase.equal(initialUniforms.intensity, 1, 'point lights expose a stable global intensity');
+  testCase.equal(
+    initialUniforms.lights.length,
+    MAX_OPTICAL_POINT_LIGHTS,
+    'default lights occupy every fixed uniform slot'
+  );
+  testCase.ok(
+    initialUniforms.lights.every(light => light.intensity === 0),
+    'unused light slots do not illuminate existing materials'
+  );
+
+  const suppliedLights = Array.from(
+    {length: MAX_OPTICAL_POINT_LIGHTS + 2},
+    (_, lightIndex): OpticalPointLight => ({
+      position: [lightIndex, lightIndex + 1, lightIndex + 2],
+      color: [1, lightIndex % 2, 0],
+      ...(lightIndex === 1 ? {intensity: 2.5, radius: 3.5} : {})
+    })
+  );
+  const packedUniforms = opticalPointLights.getUniforms({lights: suppliedLights, intensity: 0.6});
+
+  testCase.equal(
+    packedUniforms.lightCount,
+    MAX_OPTICAL_POINT_LIGHTS,
+    'additional lights beyond the fixed capacity are ignored'
+  );
+  testCase.equal(packedUniforms.intensity, 0.6, 'global intensity is configurable');
+  testCase.deepEqual(
+    packedUniforms.lights[0],
+    {position: [0, 1, 2], radius: 1, color: [1, 0, 0], intensity: 1},
+    'point-light defaults are packed in portable field order'
+  );
+  testCase.deepEqual(
+    packedUniforms.lights[1],
+    {position: [1, 2, 3], radius: 3.5, color: [1, 1, 0], intensity: 2.5},
+    'per-light radius and intensity are preserved'
+  );
+
+  const updatedUniforms = opticalPointLights.getUniforms({intensity: 1.4}, packedUniforms);
+  testCase.equal(updatedUniforms.intensity, 1.4, 'global intensity updates independently');
+  testCase.equal(updatedUniforms.lightCount, 16, 'partial updates preserve active lights');
+  testCase.equal(updatedUniforms.lights, packedUniforms.lights, 'packed light arrays are reused');
+
+  const clearedUniforms = opticalPointLights.getUniforms({lights: []}, updatedUniforms);
+  testCase.equal(clearedUniforms.lightCount, 0, 'an explicit empty light list clears illumination');
+  testCase.ok(
+    clearedUniforms.lights.every(light => light.intensity === 0),
+    'cleared light slots are reset'
+  );
+  testCase.end();
+});
+
+test('optical materials expose matching WGSL and GLSL uniform layouts', testCase => {
+  for (const shaderModule of [emissiveMaterial, opticalPointLights]) {
+    const wgslValidation = getShaderModuleUniformLayoutValidationResult(shaderModule, 'wgsl');
+    const fragmentValidation = getShaderModuleUniformLayoutValidationResult(
+      shaderModule,
+      'fragment'
+    );
+
+    testCase.ok(wgslValidation?.matches, `${shaderModule.name} WGSL uniform layout matches`);
+    testCase.ok(fragmentValidation?.matches, `${shaderModule.name} GLSL uniform layout matches`);
+  }
+
+  const shaderBlockLayout = makeShaderBlockLayout(opticalPointLights.uniformTypes);
+  const shaderBlockFieldNames = Object.keys(shaderBlockLayout.fields);
+  testCase.equal(shaderBlockLayout.byteLength, 528, '16 structured lights occupy 528 bytes');
+  testCase.deepEqual(
+    shaderBlockFieldNames.slice(0, 6),
+    [
+      'lightCount',
+      'intensity',
+      'lights[0].position',
+      'lights[0].radius',
+      'lights[0].color',
+      'lights[0].intensity'
+    ],
+    'uniform block keeps its explicit count and structured light field order'
+  );
+  testCase.deepEqual(
+    shaderBlockFieldNames.slice(-4),
+    ['lights[15].position', 'lights[15].radius', 'lights[15].color', 'lights[15].intensity'],
+    'uniform block includes the final fixed-capacity light'
+  );
+  testCase.end();
+});
+
+test('existing optical materials compose without the optional point-light module', testCase => {
   const assembler = new ShaderAssembler();
   const assembledShader = assembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
@@ -170,11 +354,137 @@ test('optical materials compose once with both transparency modules', testCase =
     resources.some(resource => resource.name === 'reflectiveMaterial'),
     'reflective material uniforms are reflected'
   );
+  testCase.notOk(
+    resources.some(resource => resource.name === 'opticalPointLights'),
+    'existing glass and reflective plugins do not install optional point lights'
+  );
+  testCase.notOk(
+    /fn glassMaterial_getIlluminatedColor/.test(assembledShader.source),
+    'illuminated glass is omitted until the light plugin is installed'
+  );
+  testCase.notOk(
+    /fn reflectiveMaterial_getIlluminatedColor/.test(assembledShader.source),
+    'illuminated reflections are omitted until the light plugin is installed'
+  );
   testCase.match(assembledShader.source, /fn aBuffer_captureStraightColor/, 'A-buffer composes');
   testCase.match(
     assembledShader.source,
     /fn wboit_captureStraightColor/,
     'weighted-blended OIT composes'
   );
+  testCase.end();
+});
+
+test('illuminated optical materials compose once with emission and transparency', testCase => {
+  const assembler = new ShaderAssembler();
+  const assembledShader = assembler.assembleWGSLShader({
+    platformInfo: PLATFORM_INFO,
+    source: ILLUMINATED_OPTICAL_MATERIAL_SHADER,
+    modules: [
+      glassMaterial,
+      reflectiveMaterial,
+      emissiveMaterial,
+      opticalPointLights,
+      aBuffer,
+      wboit
+    ]
+  });
+  const reflectedShader = new WgslReflect(assembledShader.source);
+
+  testCase.equal(
+    assembledShader.source.match(/fn opticalLighting_getFresnel\(/g)?.length,
+    1,
+    'shared optical-lighting helpers remain deduplicated'
+  );
+  testCase.equal(
+    assembledShader.source.match(/fn opticalPointLights_getColor\(/g)?.length,
+    1,
+    'point-light helper is emitted once'
+  );
+  testCase.match(
+    assembledShader.source,
+    /fn glassMaterial_getIlluminatedColor/,
+    'illuminated glass helper is enabled'
+  );
+  testCase.match(
+    assembledShader.source,
+    /fn reflectiveMaterial_getIlluminatedColor/,
+    'illuminated reflective helper is enabled'
+  );
+  testCase.match(
+    assembledShader.source,
+    /fn emissiveMaterial_getColor/,
+    'emissive helper composes with optical materials'
+  );
+  testCase.match(
+    assembledShader.source,
+    /lights: array<OpticalPointLightUniform, 16>/,
+    'WGSL exposes a fixed 16-light uniform array'
+  );
+  testCase.ok(
+    reflectedShader.uniforms.some(resource => resource.name === 'opticalPointLights'),
+    'point-light uniforms are reflected'
+  );
+  testCase.ok(
+    reflectedShader.uniforms.some(resource => resource.name === 'emissiveMaterial'),
+    'emissive material uniforms are reflected'
+  );
+  testCase.end();
+});
+
+test('illuminated optical helpers assemble for GLSL', testCase => {
+  const assembler = new ShaderAssembler();
+  const assembledShader = assembler.assembleGLSLShaderPair({
+    platformInfo: GLSL_PLATFORM_INFO,
+    vs: `#version 300 es
+in vec4 positions;
+void main(void) {
+  gl_Position = positions;
+}
+`,
+    fs: `#version 300 es
+precision highp float;
+out vec4 fragmentColor;
+void main(void) {
+  vec3 normal = vec3(0.0, 1.0, 0.0);
+  vec3 worldPosition = vec3(0.0);
+  vec3 cameraPosition = vec3(0.0, 2.0, 4.0);
+  vec4 baseColor = vec4(0.4, 0.6, 0.9, 0.5);
+  vec4 glassColor = glassMaterial_getIlluminatedColor(
+    normal,
+    worldPosition,
+    baseColor,
+    cameraPosition,
+    gl_FragCoord
+  );
+  vec4 reflectedColor = reflectiveMaterial_getIlluminatedColor(
+    normal,
+    worldPosition,
+    baseColor,
+    cameraPosition
+  );
+  fragmentColor = mix(glassColor, reflectedColor, 0.25) +
+    emissiveMaterial_getColor(normal, worldPosition, baseColor, cameraPosition);
+}
+`,
+    modules: [glassMaterial, reflectiveMaterial, emissiveMaterial, opticalPointLights]
+  });
+
+  testCase.match(
+    assembledShader.fs,
+    /OpticalPointLightUniform lights\[16\]/,
+    'GLSL exposes a fixed 16-light uniform array'
+  );
+  testCase.match(
+    assembledShader.fs,
+    /vec4 glassMaterial_getIlluminatedColor/,
+    'GLSL illuminated glass composes'
+  );
+  testCase.match(
+    assembledShader.fs,
+    /vec4 reflectiveMaterial_getIlluminatedColor/,
+    'GLSL illuminated reflections compose'
+  );
+  testCase.match(assembledShader.fs, /vec4 emissiveMaterial_getColor/, 'GLSL emission composes');
   testCase.end();
 });

--- a/modules/experimental/test/materials/optical-materials.node.spec.ts
+++ b/modules/experimental/test/materials/optical-materials.node.spec.ts
@@ -229,6 +229,40 @@ test('optical materials retain defaults while applying partial updates', testCas
   testCase.end();
 });
 
+test('reflective materials follow the reflected view direction and preserve opaque alpha', testCase => {
+  testCase.match(
+    reflectiveMaterial.source,
+    /let reflectionDirection = reflect\(-viewDirection, normalFacingCamera\);/,
+    'WGSL environment reflections follow the camera-reflected view ray'
+  );
+  testCase.match(
+    reflectiveMaterial.fs,
+    /vec3 reflectionDirection = reflect\(-viewDirection, normalFacingCamera\);/,
+    'GLSL environment reflections follow the camera-reflected view ray'
+  );
+  testCase.match(
+    reflectiveMaterial.source,
+    /opticalLighting_sampleEnvironment\(\s*reflectionDirection,/,
+    'WGSL samples the environment along the reflected ray'
+  );
+  testCase.match(
+    reflectiveMaterial.fs,
+    /opticalLighting_sampleEnvironment\(\s*reflectionDirection,/,
+    'GLSL samples the environment along the reflected ray'
+  );
+  testCase.match(
+    reflectiveMaterial.source,
+    /let opacity = clamp\([\s\S]*?0\.0,\s*1\.0\s*\);/,
+    'WGSL reflective opacity supports the complete zero-to-one alpha range'
+  );
+  testCase.match(
+    reflectiveMaterial.fs,
+    /float opacity = clamp\([\s\S]*?0\.0,\s*1\.0\s*\);/,
+    'GLSL reflective opacity supports the complete zero-to-one alpha range'
+  );
+  testCase.end();
+});
+
 test('optical point lights pack and retain a bounded portable uniform array', testCase => {
   const initialUniforms = opticalPointLights.getUniforms({});
   testCase.equal(initialUniforms.lightCount, 0, 'point lights start disabled');

--- a/modules/experimental/test/materials/optical-materials.node.spec.ts
+++ b/modules/experimental/test/materials/optical-materials.node.spec.ts
@@ -96,7 +96,15 @@ const ILLUMINATED_OPTICAL_MATERIAL_SHADER = OPTICAL_MATERIAL_SHADER.replace(
     inputs.worldPosition,
     cameraPosition
   );
-  return mix(glassColor, reflectedColor, 0.25) + emittedColor * 0.2 +
+  let trailColor = emissiveMaterial_getTrailColor(
+    normal,
+    inputs.worldPosition,
+    vec4<f32>(0.2, 1.0, 0.1, 0.5),
+    cameraPosition,
+    0.65,
+    0.5
+  );
+  return mix(glassColor, reflectedColor, 0.25) + emittedColor * 0.2 + trailColor * 0.1 +
     vec4<f32>(pointLightColor, 0.0);`
   );
 
@@ -158,6 +166,26 @@ test('optical material modules expose portable shared shader helpers', testCase 
   testCase.match(opticalLighting.fs, /float opticalLighting_getFresnel/, 'GLSL helpers exist');
   testCase.match(emissiveMaterial.source, /fn emissiveMaterial_getColor/, 'WGSL emission exists');
   testCase.match(emissiveMaterial.fs, /vec4 emissiveMaterial_getColor/, 'GLSL emission exists');
+  testCase.match(
+    emissiveMaterial.source,
+    /fn emissiveMaterial_getTrailColor/,
+    'WGSL directional emission exists'
+  );
+  testCase.match(
+    emissiveMaterial.fs,
+    /vec4 emissiveMaterial_getTrailColor/,
+    'GLSL directional emission exists'
+  );
+  testCase.match(
+    emissiveMaterial.source,
+    /pow\(smoothstep\(0\.0, 1\.0, trailProgress\), 1\.5\)/,
+    'WGSL trails fade toward the packet tail'
+  );
+  testCase.match(
+    emissiveMaterial.fs,
+    /pow\(smoothstep\(0\.0, 1\.0, trailProgress\), 1\.5\)/,
+    'GLSL trails fade toward the packet tail'
+  );
   testCase.match(
     opticalPointLights.source,
     /fn opticalPointLights_getColor/,
@@ -452,6 +480,11 @@ test('illuminated optical materials compose once with emission and transparency'
   );
   testCase.match(
     assembledShader.source,
+    /fn emissiveMaterial_getTrailColor/,
+    'directional emissive helper composes with optical materials'
+  );
+  testCase.match(
+    assembledShader.source,
     /lights: array<OpticalPointLightUniform, 16>/,
     'WGSL exposes a fixed 16-light uniform array'
   );
@@ -498,7 +531,8 @@ void main(void) {
     cameraPosition
   );
   fragmentColor = mix(glassColor, reflectedColor, 0.25) +
-    emissiveMaterial_getColor(normal, worldPosition, baseColor, cameraPosition);
+    emissiveMaterial_getColor(normal, worldPosition, baseColor, cameraPosition) +
+    emissiveMaterial_getTrailColor(normal, worldPosition, baseColor, cameraPosition, 0.65, 0.5);
 }
 `,
     modules: [glassMaterial, reflectiveMaterial, emissiveMaterial, opticalPointLights]
@@ -520,5 +554,10 @@ void main(void) {
     'GLSL illuminated reflections compose'
   );
   testCase.match(assembledShader.fs, /vec4 emissiveMaterial_getColor/, 'GLSL emission composes');
+  testCase.match(
+    assembledShader.fs,
+    /vec4 emissiveMaterial_getTrailColor/,
+    'GLSL directional emission composes'
+  );
   testCase.end();
 });

--- a/modules/experimental/test/materials/optical-materials.node.spec.ts
+++ b/modules/experimental/test/materials/optical-materials.node.spec.ts
@@ -10,6 +10,8 @@ import {
   emissiveMaterialPlugin,
   glassMaterial,
   glassMaterialPlugin,
+  glassTransmission,
+  glassTransmissionPlugin,
   MAX_OPTICAL_POINT_LIGHTS,
   opticalLighting,
   type OpticalPointLight,
@@ -112,6 +114,16 @@ test('optical material modules expose portable shared shader helpers', testCase 
   testCase.equal(glassMaterialPlugin.name, 'glassMaterial', 'glass plugin has a stable name');
   testCase.deepEqual(glassMaterialPlugin.modules, [glassMaterial], 'glass plugin installs glass');
   testCase.equal(
+    glassTransmissionPlugin.name,
+    'glassTransmission',
+    'rasterized transmission plugin has a stable name'
+  );
+  testCase.deepEqual(
+    glassTransmissionPlugin.modules,
+    [glassTransmission],
+    'rasterized transmission plugin installs its optional extension'
+  );
+  testCase.equal(
     reflectiveMaterialPlugin.name,
     'reflectiveMaterial',
     'reflective plugin has a stable name'
@@ -147,6 +159,11 @@ test('optical material modules expose portable shared shader helpers', testCase 
     'glass reuses shared optical lighting'
   );
   testCase.deepEqual(
+    glassTransmission.dependencies,
+    [glassMaterial],
+    'rasterized transmission composes the existing glass material'
+  );
+  testCase.deepEqual(
     reflectiveMaterial.dependencies,
     [opticalLighting],
     'reflective shading reuses shared optical lighting'
@@ -164,6 +181,16 @@ test('optical material modules expose portable shared shader helpers', testCase 
   testCase.equal(MAX_OPTICAL_POINT_LIGHTS, 16, 'point lights have a portable fixed capacity');
   testCase.match(opticalLighting.source, /fn opticalLighting_getFresnel/, 'WGSL helpers exist');
   testCase.match(opticalLighting.fs, /float opticalLighting_getFresnel/, 'GLSL helpers exist');
+  testCase.match(
+    opticalLighting.source,
+    /fn opticalLighting_getMicrofacetSpecular/,
+    'WGSL exposes GGX microfacet highlights'
+  );
+  testCase.match(
+    opticalLighting.fs,
+    /float opticalLighting_getMicrofacetSpecular/,
+    'GLSL exposes GGX microfacet highlights'
+  );
   testCase.match(emissiveMaterial.source, /fn emissiveMaterial_getColor/, 'WGSL emission exists');
   testCase.match(emissiveMaterial.fs, /vec4 emissiveMaterial_getColor/, 'GLSL emission exists');
   testCase.match(
@@ -209,7 +236,13 @@ test('optical materials retain defaults while applying partial updates', testCas
       roughness: 0.14,
       dispersion: 0.022,
       thickness: 1.05,
-      reflectionStrength: 1
+      refractionStrength: 1,
+      reflectionStrength: 1,
+      fresnelStrength: 1,
+      clearcoatStrength: 0.7,
+      iridescenceStrength: 0.1,
+      internalReflectionStrength: 0.42,
+      transmissionStrength: 1
     },
     'glass uniforms expose stable defaults'
   );
@@ -221,6 +254,61 @@ test('optical materials retain defaults while applying partial updates', testCas
   testCase.equal(updatedGlassUniforms.indexOfRefraction, 1.6, 'glass refraction updates');
   testCase.equal(updatedGlassUniforms.thickness, 1.8, 'glass thickness updates');
   testCase.equal(updatedGlassUniforms.roughness, 0.14, 'glass roughness is retained');
+  testCase.equal(updatedGlassUniforms.refractionStrength, 1, 'lens distortion is retained');
+  testCase.equal(updatedGlassUniforms.clearcoatStrength, 0.7, 'glass clearcoat is retained');
+
+  const cinematicGlassUniforms = glassMaterial.getUniforms(
+    {fresnelStrength: 1.4, iridescenceStrength: 0.25, transmissionStrength: 1.1},
+    updatedGlassUniforms
+  );
+  testCase.equal(cinematicGlassUniforms.fresnelStrength, 1.4, 'Fresnel edges are configurable');
+  testCase.equal(
+    cinematicGlassUniforms.iridescenceStrength,
+    0.25,
+    'spectral edge highlights are configurable'
+  );
+  testCase.equal(
+    cinematicGlassUniforms.transmissionStrength,
+    1.1,
+    'glass transmission is configurable'
+  );
+  testCase.equal(
+    cinematicGlassUniforms.internalReflectionStrength,
+    0.42,
+    'internal reflection is retained across partial updates'
+  );
+
+  const initialTransmissionUniforms = glassTransmission.getUniforms({});
+  testCase.deepEqual(
+    initialTransmissionUniforms,
+    {
+      viewportSize: [1, 1],
+      depthRange: [0.1, 100],
+      environmentIntensity: 1,
+      thicknessStrength: 1,
+      depthBias: 0.00008
+    },
+    'rasterized transmission exposes stable optical defaults'
+  );
+  const updatedTransmissionUniforms = glassTransmission.getUniforms(
+    {environmentIntensity: 1.6, thicknessStrength: 1.25},
+    initialTransmissionUniforms
+  );
+  testCase.equal(
+    updatedTransmissionUniforms.environmentIntensity,
+    1.6,
+    'environment reflections remain adjustable'
+  );
+  testCase.equal(
+    updatedTransmissionUniforms.thicknessStrength,
+    1.25,
+    'backface-derived thickness remains adjustable'
+  );
+  testCase.equal(
+    updatedTransmissionUniforms.depthBias,
+    0.00008,
+    'foreground-depth tolerance is retained'
+  );
 
   const initialReflectiveUniforms = reflectiveMaterial.getUniforms({});
   testCase.deepEqual(
@@ -291,6 +379,100 @@ test('reflective materials follow the reflected view direction and preserve opaq
   testCase.end();
 });
 
+test('glass materials compose portable clearcoat, spectral rims, and soft transmission', testCase => {
+  for (const [shaderSource, language] of [
+    [glassMaterial.source, 'WGSL'],
+    [glassMaterial.fs, 'GLSL']
+  ] as const) {
+    testCase.match(
+      shaderSource,
+      /glassMaterial_sampleTransmission/,
+      `${language} isolates reusable chromatic transmission sampling`
+    );
+    testCase.match(
+      shaderSource,
+      /rayDeflection = refractionDirection \+ viewDirection/,
+      `${language} distorts the background using the actual refracted ray`
+    );
+    testCase.match(
+      shaderSource,
+      /cameraRight/,
+      `${language} projects refraction into camera-aligned screen coordinates`
+    );
+    testCase.match(
+      shaderSource,
+      /refractionStrength/,
+      `${language} exposes adjustable lens distortion`
+    );
+    testCase.match(
+      shaderSource,
+      /transmissionCoverage/,
+      `${language} preserves displaced background instead of blending it away`
+    );
+    testCase.match(
+      shaderSource,
+      /opticalLighting_getMicrofacetSpecular/,
+      `${language} shades glass with GGX microfacet highlights`
+    );
+    testCase.match(shaderSource, /clearcoatStrength/, `${language} supports a clearcoat lobe`);
+    testCase.match(
+      shaderSource,
+      /internalReflectionStrength/,
+      `${language} supports internal shell reflection`
+    );
+    testCase.match(
+      shaderSource,
+      /iridescenceStrength/,
+      `${language} supports restrained spectral rim interference`
+    );
+    testCase.match(
+      shaderSource,
+      /softenedTransmission/,
+      `${language} softens refraction according to surface roughness`
+    );
+    testCase.match(
+      shaderSource,
+      /studioRibbon/,
+      `${language} adds camera-responsive studio-light reflections`
+    );
+    testCase.match(shaderSource, /glassBody/, `${language} retains a visible tinted glass body`);
+  }
+  testCase.end();
+});
+
+test('rasterized glass transmission composes thickness, depth, and environment maps', testCase => {
+  for (const [shaderSource, language] of [
+    [glassTransmission.source, 'WGSL'],
+    [glassTransmission.fs, 'GLSL']
+  ] as const) {
+    testCase.match(shaderSource, /glassBackfaceTexture/, `${language} samples sphere backfaces`);
+    testCase.match(shaderSource, /glassSceneDepthTexture/, `${language} samples opaque depth`);
+    testCase.match(
+      shaderSource,
+      /glassEnvironmentTexture/,
+      `${language} samples a studio environment map`
+    );
+    testCase.match(
+      shaderSource,
+      /glassTransmission_linearizeDepth/,
+      `${language} measures optical thickness in linear view depth`
+    );
+    testCase.match(shaderSource, /entryDirection = refract/, `${language} refracts at entry`);
+    testCase.match(shaderSource, /exitDirection = refract/, `${language} refracts at exit`);
+    testCase.match(
+      shaderSource,
+      /foregroundOcclusion/,
+      `${language} preserves opaque foreground geometry`
+    );
+    testCase.match(
+      shaderSource,
+      /hasExitRay/,
+      `${language} handles total internal reflection without ray marching`
+    );
+  }
+  testCase.end();
+});
+
 test('optical point lights pack and retain a bounded portable uniform array', testCase => {
   const initialUniforms = opticalPointLights.getUniforms({});
   testCase.equal(initialUniforms.lightCount, 0, 'point lights start disabled');
@@ -347,7 +529,7 @@ test('optical point lights pack and retain a bounded portable uniform array', te
 });
 
 test('optical materials expose matching WGSL and GLSL uniform layouts', testCase => {
-  for (const shaderModule of [emissiveMaterial, opticalPointLights]) {
+  for (const shaderModule of [emissiveMaterial, opticalPointLights, glassTransmission]) {
     const wgslValidation = getShaderModuleUniformLayoutValidationResult(shaderModule, 'wgsl');
     const fragmentValidation = getShaderModuleUniformLayoutValidationResult(
       shaderModule,
@@ -377,6 +559,42 @@ test('optical materials expose matching WGSL and GLSL uniform layouts', testCase
     shaderBlockFieldNames.slice(-4),
     ['lights[15].position', 'lights[15].radius', 'lights[15].color', 'lights[15].intensity'],
     'uniform block includes the final fixed-capacity light'
+  );
+  testCase.end();
+});
+
+test('rasterized glass transmission assembles portable optical and depth bindings', testCase => {
+  const assembler = new ShaderAssembler();
+  const transmissionShader = ILLUMINATED_OPTICAL_MATERIAL_SHADER.replace(
+    'glassMaterial_getIlluminatedColor(',
+    'glassTransmission_getIlluminatedColor('
+  );
+  const assembledShader = assembler.assembleWGSLShader({
+    platformInfo: PLATFORM_INFO,
+    source: transmissionShader,
+    modules: [glassTransmission, reflectiveMaterial, emissiveMaterial, opticalPointLights]
+  });
+  const reflectedShader = new WgslReflect(assembledShader.source);
+  const textureNames = reflectedShader.textures.map(texture => texture.name);
+
+  testCase.equal(
+    assembledShader.source.match(/fn glassMaterial_getColor\(/g)?.length,
+    1,
+    'existing glass helpers are installed once'
+  );
+  testCase.match(
+    assembledShader.source,
+    /fn glassTransmission_getIlluminatedColor/,
+    'rasterized transmission composes with local point lights'
+  );
+  testCase.ok(textureNames.includes('glassSceneDepthTexture'), 'opaque-depth binding is reflected');
+  testCase.ok(
+    textureNames.includes('glassBackfaceTexture'),
+    'backface-normal and depth binding is reflected'
+  );
+  testCase.ok(
+    textureNames.includes('glassEnvironmentTexture'),
+    'studio environment binding is reflected'
   );
   testCase.end();
 });

--- a/modules/experimental/test/oit/a-buffer-renderer.node.spec.ts
+++ b/modules/experimental/test/oit/a-buffer-renderer.node.spec.ts
@@ -34,6 +34,17 @@ test('aBuffer plugin exposes the WGSL module only', t => {
     /textureLoad\(opaqueDepthTexture, fragmentCoordinates, 0\)/,
     'capture explicitly tests opaque depth before storing fragments'
   );
+  t.match(
+    aBuffer.source,
+    /pack2x16float\(packedColor\.rg\)/,
+    'capture preserves HDR red and green channels in packed half floats'
+  );
+  t.match(
+    aBuffer.source,
+    /pack2x16float\(packedColor\.ba\)/,
+    'capture preserves HDR blue and alpha channels in packed half floats'
+  );
+  t.notOk(/pack4x8unorm/.test(aBuffer.source), 'capture does not clamp HDR color to RGBA8');
   t.end();
 });
 
@@ -45,6 +56,16 @@ test('A-buffer resolve is packaged as a ShaderPassPipeline', t => {
     pipeline.steps[0].inputs,
     {sourceTexture: 'previous'},
     'resolve composites over the previous color'
+  );
+  t.match(
+    pipeline.steps[0].shaderPass.source,
+    /unpack2x16float\(capturedFragment\.colorRedGreen\)/,
+    'resolve restores HDR red and green channels'
+  );
+  t.match(
+    pipeline.steps[0].shaderPass.source,
+    /unpack2x16float\(capturedFragment\.colorBlueAlpha\)/,
+    'resolve restores HDR blue and alpha channels'
   );
   t.throws(
     () => createABufferResolveShaderPassPipeline({maxFragmentsPerPixel: 0}),
@@ -68,12 +89,12 @@ test('getABufferSlicePlan fits fragments inside storage limits', t => {
     {
       width: 100,
       height: 50,
-      sliceHeight: 5,
-      sliceCount: 10,
-      maxSlicePixelCount: 500,
-      fragmentCapacity: 2000,
-      headPointerByteLength: 2008,
-      fragmentByteLength: 24_000
+      sliceHeight: 3,
+      sliceCount: 17,
+      maxSlicePixelCount: 300,
+      fragmentCapacity: 1200,
+      headPointerByteLength: 1208,
+      fragmentByteLength: 19_200
     },
     'slice plan budgets fragment storage and scanline slices'
   );
@@ -145,7 +166,7 @@ test('ABufferRenderer composites bounded-memory slices', async t => {
   const renderer = new ABufferRenderer(device, {
     averageFragmentsPerPixel: 1,
     maxFragmentsPerPixel: 2,
-    maxBufferByteLength: 24
+    maxBufferByteLength: 32
   });
   const referenceRenderer = new ABufferRenderer(device, {
     averageFragmentsPerPixel: 1,

--- a/modules/experimental/test/oit/a-buffer-renderer.spec.ts
+++ b/modules/experimental/test/oit/a-buffer-renderer.spec.ts
@@ -3,10 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {Texture} from '@luma.gl/core';
-import {Model, ShaderPassRenderer} from '@luma.gl/engine';
+import {Buffer, Texture} from '@luma.gl/core';
+import {Model, ShaderInputs, ShaderPassRenderer} from '@luma.gl/engine';
 import {
   ABufferRenderer,
+  aBuffer,
   aBufferPlugin,
   createABufferResolveShaderPassPipeline
 } from '@luma.gl/experimental';
@@ -90,7 +91,7 @@ test('A-buffer resolve ShaderPassPipeline compiles on WebGPU', async t => {
   t.end();
 });
 
-test('ABufferRenderer preserves the configured rgba16float resolve format', async t => {
+test('ABufferRenderer preserves HDR translucent fragments in rgba16float outputs', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {
     t.comment('WebGPU is not available');
@@ -117,16 +118,49 @@ test('ABufferRenderer preserves the configured rgba16float resolve format', asyn
     format: 'depth24plus',
     usage: Texture.SAMPLE | Texture.RENDER
   });
+  const framebuffer = device.createFramebuffer({
+    width: 1,
+    height: 1,
+    colorAttachments: [sourceTexture],
+    depthStencilAttachment: opaqueDepthTexture
+  });
+  const shaderInputs = new ShaderInputs({aBuffer});
+  const model = new Model(device, {
+    id: 'a-buffer-hdr-fragment-capture',
+    source: A_BUFFER_MODEL_SHADER.replace(
+      'vec4<f32>(1.0, 0.0, 0.0, 0.5)',
+      'vec4<f32>(4.0, 0.4, 0.0, 0.5)'
+    ),
+    plugins: [aBufferPlugin],
+    shaderInputs,
+    vertexCount: 3
+  });
+  const opaquePass = device.beginRenderPass({
+    framebuffer,
+    clearColor: [0.25, 0.25, 0, 1],
+    clearDepth: 1
+  });
+  opaquePass.end();
   const renderer = new ABufferRenderer(device, {colorFormat: 'rgba16float'});
   const outputTexture = renderer.render({
     sourceTexture,
     opaqueDepthTexture: opaqueDepthTexture.view,
-    prepareTranslucent: () => {},
-    drawTranslucent: () => {}
+    prepareTranslucent: ({commandEncoder, shaderModuleProps, captureParameters}) => {
+      shaderInputs.setProps({aBuffer: shaderModuleProps});
+      model.setParameters(captureParameters);
+      model.predraw(commandEncoder);
+    },
+    drawTranslucent: renderPass => model.draw(renderPass)
   });
   device.submit();
+  const outputColor = await readHalfFloatColor(outputTexture);
 
   t.equal(outputTexture.format, 'rgba16float', 'resolved output retains the requested HDR format');
+  t.ok(outputColor[0] > 2, 'translucent HDR red survives capture and resolve without clipping');
+  t.ok(
+    outputColor[1] > 0.3 && outputColor[1] < 0.4,
+    'lower-intensity translucent channels retain their original proportions'
+  );
   t.deepEqual(
     renderer.props,
     {
@@ -137,8 +171,44 @@ test('ABufferRenderer preserves the configured rgba16float resolve format', asyn
     'optional output format does not alter existing resolved capture properties'
   );
 
+  model.destroy();
+  shaderInputs.destroy();
   renderer.destroy();
+  framebuffer.destroy();
   sourceTexture.destroy();
   opaqueDepthTexture.destroy();
   t.end();
 });
+
+async function readHalfFloatColor(texture: Texture): Promise<number[]> {
+  const layout = texture.computeMemoryLayout({width: 1, height: 1});
+  const buffer = texture.device.createBuffer({
+    byteLength: layout.byteLength,
+    usage: Buffer.COPY_DST | Buffer.MAP_READ
+  });
+
+  try {
+    texture.readBuffer({width: 1, height: 1}, buffer);
+    const result = await buffer.readAsync(0, layout.byteLength);
+    const view = new DataView(result.buffer, result.byteOffset, result.byteLength);
+    return Array.from({length: 4}, (_, channelIndex) =>
+      decodeHalfFloat(view.getUint16(channelIndex * 2, true))
+    );
+  } finally {
+    buffer.destroy();
+  }
+}
+
+function decodeHalfFloat(value: number): number {
+  const sign = value & 0x8000 ? -1 : 1;
+  const exponent = (value >> 10) & 0x1f;
+  const fraction = value & 0x03ff;
+
+  if (exponent === 0) {
+    return sign * 2 ** -14 * (fraction / 1024);
+  }
+  if (exponent === 0x1f) {
+    return fraction === 0 ? sign * Number.POSITIVE_INFINITY : Number.NaN;
+  }
+  return sign * 2 ** (exponent - 15) * (1 + fraction / 1024);
+}

--- a/modules/experimental/test/oit/a-buffer-renderer.spec.ts
+++ b/modules/experimental/test/oit/a-buffer-renderer.spec.ts
@@ -3,8 +3,13 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {Texture} from '@luma.gl/core';
 import {Model, ShaderPassRenderer} from '@luma.gl/engine';
-import {aBufferPlugin, createABufferResolveShaderPassPipeline} from '@luma.gl/experimental';
+import {
+  ABufferRenderer,
+  aBufferPlugin,
+  createABufferResolveShaderPassPipeline
+} from '@luma.gl/experimental';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
 const SHADER_STAGE_FRAGMENT = 0x2;
@@ -82,5 +87,58 @@ test('A-buffer resolve ShaderPassPipeline compiles on WebGPU', async t => {
     'resolve pipeline creates a WebGPU fullscreen model'
   );
   renderer.destroy();
+  t.end();
+});
+
+test('ABufferRenderer preserves the configured rgba16float resolve format', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const capabilities = device.getTextureFormatCapabilities('rgba16float');
+  if (!capabilities.render || !capabilities.filter) {
+    t.comment('Renderable, filterable rgba16float textures are not available');
+    t.end();
+    return;
+  }
+
+  const sourceTexture = device.createTexture({
+    width: 1,
+    height: 1,
+    format: 'rgba16float',
+    usage: Texture.SAMPLE | Texture.RENDER
+  });
+  const opaqueDepthTexture = device.createTexture({
+    width: 1,
+    height: 1,
+    format: 'depth24plus',
+    usage: Texture.SAMPLE | Texture.RENDER
+  });
+  const renderer = new ABufferRenderer(device, {colorFormat: 'rgba16float'});
+  const outputTexture = renderer.render({
+    sourceTexture,
+    opaqueDepthTexture: opaqueDepthTexture.view,
+    prepareTranslucent: () => {},
+    drawTranslucent: () => {}
+  });
+  device.submit();
+
+  t.equal(outputTexture.format, 'rgba16float', 'resolved output retains the requested HDR format');
+  t.deepEqual(
+    renderer.props,
+    {
+      averageFragmentsPerPixel: 4,
+      maxFragmentsPerPixel: 12,
+      maxBufferByteLength: Number.MAX_SAFE_INTEGER
+    },
+    'optional output format does not alter existing resolved capture properties'
+  );
+
+  renderer.destroy();
+  sourceTexture.destroy();
+  opaqueDepthTexture.destroy();
   t.end();
 });

--- a/modules/experimental/test/oit/wboit-renderer.spec.ts
+++ b/modules/experimental/test/oit/wboit-renderer.spec.ts
@@ -3,7 +3,13 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {Buffer, type Device, type Framebuffer, Texture} from '@luma.gl/core';
+import {
+  Buffer,
+  type Device,
+  type Framebuffer,
+  Texture,
+  type TextureFormatColor
+} from '@luma.gl/core';
 import {Model, ShaderInputs} from '@luma.gl/engine';
 import {
   WBOITRenderer,
@@ -93,6 +99,49 @@ test('WBOITRenderer is order independent and rejects fragments behind opaque dep
   }
 
   t.ok(testedDeviceCount > 0, 'at least one WBOIT backend was tested');
+  t.end();
+});
+
+test('WBOITRenderer preserves the configured rgba16float resolve format', async t => {
+  let testedDeviceCount = 0;
+
+  for (const device of await getTestDevices()) {
+    const capabilities = device.getTextureFormatCapabilities('rgba16float');
+    if (!getWBOITSupport(device).supported || !capabilities.filter) {
+      t.comment(`${device.type} does not support filterable rgba16float resolve textures`);
+      continue;
+    }
+
+    testedDeviceCount += 1;
+    const {framebuffer, colorTexture} = createFramebuffer(device, 1, 1, 'rgba16float');
+    const renderer = new WBOITRenderer(device, {colorFormat: 'rgba16float'});
+    const opaquePass = device.beginRenderPass({
+      framebuffer,
+      clearColor: [2, 0.5, 0.25, 1],
+      clearDepth: 1
+    });
+    opaquePass.end();
+
+    const outputTexture = renderer.render({
+      sourceTexture: colorTexture,
+      drawOpaqueDepth: () => {},
+      prepareTranslucent: () => {},
+      drawTranslucent: () => {}
+    });
+    device.submit();
+
+    t.equal(
+      outputTexture.format,
+      'rgba16float',
+      `${device.type} resolved output retains the requested HDR format`
+    );
+
+    renderer.destroy();
+    framebuffer.destroy();
+    colorTexture.destroy();
+  }
+
+  t.ok(testedDeviceCount > 0, 'at least one HDR-capable WBOIT backend was tested');
   t.end();
 });
 
@@ -194,12 +243,13 @@ async function renderOpaqueOcclusion(
 function createFramebuffer(
   device: Device,
   width: number,
-  height: number
+  height: number,
+  colorFormat: TextureFormatColor = 'rgba8unorm'
 ): {framebuffer: Framebuffer; colorTexture: Texture} {
   const colorTexture = device.createTexture({
     width,
     height,
-    format: 'rgba8unorm',
+    format: colorFormat,
     usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_SRC
   });
   const framebuffer = device.createFramebuffer({

--- a/modules/shadertools/src/lib/shader-module/shader-pass.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-pass.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {Binding, TextureFormat} from '@luma.gl/core';
+import type {Binding, SamplerProps, TextureFormat} from '@luma.gl/core';
 import type {PickBindings, PickUniforms, ShaderModule} from './shader-module';
 import type {UniformValue} from '../utils/uniform-types';
 
@@ -11,6 +11,8 @@ export type ShaderPassRenderTarget = {
   scale?: [number, number];
   /** Render target format. Defaults to the device preferred color format. */
   format?: TextureFormat;
+  /** Optional sampling behavior when later passes read this target. */
+  sampler?: SamplerProps;
   /** Resource lifetime. History targets retain their last successfully rendered value. */
   lifetime?: 'transient' | 'history';
   /** Initial value used after construction, resize, or an explicit history reset. */

--- a/test/examples/packet-spraying-network.node.spec.ts
+++ b/test/examples/packet-spraying-network.node.spec.ts
@@ -1,0 +1,133 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {
+  AGGREGATION_POSITIONS,
+  CONVERSATIONS,
+  HOST_POSITIONS,
+  LEAF_POSITIONS,
+  PACKET_TRAVEL_SPEED,
+  SPINE_POSITIONS,
+  SWITCH_POSITIONS,
+  getActivePlaneCount,
+  getDistance,
+  getHealthyConversationRoutes,
+  isFailedSwitchPosition,
+  makeConversationRoutes,
+  makeLinks,
+  makePackets,
+  makePickableNetworkNodes,
+  makeSwitchArrivals,
+  reroutePackets
+} from '../../examples/showcase/packet-spraying/network';
+
+test('packet-spraying network defines an independent four-plane topology', testCase => {
+  const routes = makeConversationRoutes();
+  const packets = makePackets(routes);
+
+  testCase.equal(HOST_POSITIONS.length, 16, 'the server layer contains a four-by-four grid');
+  testCase.equal(LEAF_POSITIONS.length, 8, 'the access layer contains two rows of four switches');
+  testCase.equal(
+    AGGREGATION_POSITIONS.length,
+    8,
+    'the plane layer contains two rows of four switches'
+  );
+  testCase.equal(SPINE_POSITIONS.length, 4, 'the backbone contains four independent spines');
+  testCase.equal(SWITCH_POSITIONS.length, 20, 'all switch positions have stable picking indices');
+  testCase.equal(routes.length, 8, 'two conversations each have four independent routes');
+  testCase.equal(getActivePlaneCount(routes), 4, 'all four planes start available');
+  testCase.equal(packets.length, 48, 'each conversation contributes one 24-packet burst');
+  testCase.equal(makeLinks(routes).length, 80, 'network links preserve the complete fabric');
+  testCase.equal(
+    makePickableNetworkNodes().length,
+    HOST_POSITIONS.length + SWITCH_POSITIONS.length,
+    'every server and switch has an explanatory picking record'
+  );
+  testCase.equal(
+    makeSwitchArrivals(packets).length,
+    packets.length * 5,
+    'each packet produces arrivals at its five intermediate switches'
+  );
+
+  const redPacket = packets.find(packet => packet.conversationIndex === 0)!;
+  const greenPacket = packets.find(packet => packet.conversationIndex === 1)!;
+  const redAccessArrival =
+    redPacket.launchTime +
+    getDistance(redPacket.route.points[0], redPacket.route.points[1]) / PACKET_TRAVEL_SPEED;
+  const greenAccessArrival =
+    greenPacket.launchTime +
+    getDistance(greenPacket.route.points[0], greenPacket.route.points[1]) / PACKET_TRAVEL_SPEED;
+  testCase.ok(
+    Math.abs(greenAccessArrival - redAccessArrival - 0.07) < 0.00001,
+    'red and green conversations arrive half a packet interval apart'
+  );
+  testCase.end();
+});
+
+test('packet-spraying traffic immediately avoids and restores failed planes', testCase => {
+  const routes = makeConversationRoutes();
+  const packets = makePackets(routes);
+  const failedSpineIndex = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length;
+  const failedSwitches = new Set([failedSpineIndex]);
+  const healthyRoutes = getHealthyConversationRoutes(routes, failedSwitches);
+
+  testCase.equal(healthyRoutes.length, 6, 'one failed spine removes one route per conversation');
+  testCase.equal(getActivePlaneCount(healthyRoutes), 3, 'three healthy planes remain online');
+  testCase.ok(
+    isFailedSwitchPosition(SPINE_POSITIONS[0], failedSwitches),
+    'the failed spine is recognized from its world-space position'
+  );
+
+  reroutePackets(packets, healthyRoutes);
+  testCase.ok(
+    packets.every(packet => packet.enabled),
+    'both conversations remain active'
+  );
+  testCase.ok(
+    packets.every(packet =>
+      packet.route.points.every(position => !isFailedSwitchPosition(position, failedSwitches))
+    ),
+    'no packet continues through the failed switch'
+  );
+  for (let conversationIndex = 0; conversationIndex < CONVERSATIONS.length; conversationIndex++) {
+    const packetsByPlane = new Map<string, number>();
+    for (const packet of packets.filter(packet => packet.conversationIndex === conversationIndex)) {
+      const planeKey = packet.route.points[3].join(',');
+      packetsByPlane.set(planeKey, (packetsByPlane.get(planeKey) || 0) + 1);
+    }
+    testCase.deepEqual(
+      [...packetsByPlane.values()],
+      [8, 8, 8],
+      `conversation ${conversationIndex + 1} balances traffic across the remaining planes`
+    );
+  }
+
+  failedSwitches.clear();
+  const restoredRoutes = getHealthyConversationRoutes(routes, failedSwitches);
+  reroutePackets(packets, restoredRoutes);
+  testCase.equal(getActivePlaneCount(restoredRoutes), 4, 'restoring the switch restores its plane');
+  testCase.equal(
+    new Set(packets.map(packet => packet.route.points[3].join(','))).size,
+    4,
+    'packets resume using all four paths'
+  );
+  testCase.end();
+});
+
+test('packet-spraying stops a conversation when its only access switch fails', testCase => {
+  const routes = makeConversationRoutes();
+  const packets = makePackets(routes);
+  const failedAccessSwitches = new Set([3]);
+  const healthyRoutes = getHealthyConversationRoutes(routes, failedAccessSwitches);
+
+  reroutePackets(packets, healthyRoutes);
+  testCase.equal(healthyRoutes.length, 0, 'both conversations share the failed access switch');
+  testCase.ok(
+    packets.every(packet => !packet.enabled),
+    'unreachable packets are hidden'
+  );
+  testCase.equal(makeSwitchArrivals(packets).length, 0, 'disabled traffic cannot flash switches');
+  testCase.end();
+});

--- a/test/examples/packet-spraying-network.node.spec.ts
+++ b/test/examples/packet-spraying-network.node.spec.ts
@@ -5,6 +5,7 @@
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {
   AGGREGATION_POSITIONS,
+  FAILURE_DETECTION_DELAY,
   CONVERSATIONS,
   HOST_POSITIONS,
   LEAF_POSITIONS,
@@ -19,6 +20,8 @@ import {
   makeLinks,
   makePackets,
   makePickableNetworkNodes,
+  makeSwitchPacketEvents,
+  makeSwitchProbeEvent,
   makeSwitchArrivals,
   reroutePackets
 } from '../../examples/showcase/packet-spraying/network';
@@ -129,5 +132,79 @@ test('packet-spraying stops a conversation when its only access switch fails', t
     'unreachable packets are hidden'
   );
   testCase.equal(makeSwitchArrivals(packets).length, 0, 'disabled traffic cannot flash switches');
+  testCase.end();
+});
+
+test('packet-spraying failure drops packets before retransmitting on healthy planes', testCase => {
+  const routes = makeConversationRoutes();
+  const packets = makePackets(routes);
+  const failedSpineIndex = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length;
+  const startedAt = 12;
+  const events = makeSwitchPacketEvents({
+    packets,
+    conversationRoutes: routes,
+    scenario: 'failure',
+    startedAt,
+    switchIndex: failedSpineIndex
+  });
+  const droppedPackets = events.filter(event => event.kind === 'dropped-payload');
+  const retransmittedPackets = events.filter(event => event.kind === 'retransmission');
+
+  testCase.equal(droppedPackets.length, 4, 'both conversations lose two in-flight packets');
+  testCase.equal(retransmittedPackets.length, 4, 'each lost packet receives a retransmission');
+  testCase.deepEqual(
+    droppedPackets.map(event => event.conversationIndex),
+    [0, 1, 0, 1],
+    'dropped red and green packets preserve their interleaved ordering'
+  );
+  testCase.ok(
+    droppedPackets.every(event => event.startedAt < startedAt + FAILURE_DETECTION_DELAY),
+    'packets are only lost during the brief failure-detection window'
+  );
+  testCase.ok(
+    retransmittedPackets.every(event => event.startedAt >= startedAt + FAILURE_DETECTION_DELAY),
+    'retransmissions begin once the failed path is retired'
+  );
+  testCase.ok(
+    retransmittedPackets.every(event =>
+      event.route.points.every(position => position !== SPINE_POSITIONS[0])
+    ),
+    'retransmissions take healthy independent network planes'
+  );
+  testCase.end();
+});
+
+test('packet-spraying congestion trims payloads while preserving packet headers', testCase => {
+  const routes = makeConversationRoutes();
+  const packets = makePackets(routes);
+  const congestedSpineIndex = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length;
+  const events = makeSwitchPacketEvents({
+    packets,
+    conversationRoutes: routes,
+    scenario: 'congestion',
+    startedAt: 8,
+    switchIndex: congestedSpineIndex
+  });
+
+  testCase.equal(
+    events.filter(event => event.kind === 'trimmed-payload').length,
+    2,
+    'each conversation sheds one congested payload'
+  );
+  testCase.equal(
+    events.filter(event => event.kind === 'trimmed-header').length,
+    2,
+    'each trimmed payload retains a forwarding header'
+  );
+  testCase.equal(
+    events.filter(event => event.kind === 'retransmission').length,
+    2,
+    'trim notifications trigger retransmissions through other planes'
+  );
+  testCase.equal(getActivePlaneCount(routes), 4, 'congestion does not retire the plane');
+
+  const probe = makeSwitchProbeEvent(routes, congestedSpineIndex, 15);
+  testCase.equal(probe?.kind, 'probe', 'failed paths can be tested with a control probe');
+  testCase.equal(probe?.switchIndex, congestedSpineIndex, 'the probe targets the affected switch');
   testCase.end();
 });

--- a/test/examples/packet-spraying-network.node.spec.ts
+++ b/test/examples/packet-spraying-network.node.spec.ts
@@ -22,6 +22,7 @@ import {
   makePickableNetworkNodes,
   makeSwitchPacketEvents,
   makeSwitchProbeEvent,
+  makeSwitchGroups,
   makeSwitchArrivals,
   reroutePackets
 } from '../../examples/showcase/packet-spraying/network';
@@ -65,6 +66,35 @@ test('packet-spraying network defines an independent four-plane topology', testC
   testCase.ok(
     Math.abs(greenAccessArrival - redAccessArrival - 0.07) < 0.00001,
     'red and green conversations arrive half a packet interval apart'
+  );
+  testCase.end();
+});
+
+test('packet-spraying switches form spine and two complete physical-plane groups', testCase => {
+  const groups = makeSwitchGroups();
+
+  testCase.deepEqual(
+    groups.map(group => group.id),
+    ['spine', 'plane-1', 'plane-2'],
+    'semantic switch groups identify the spine and both planes'
+  );
+  testCase.deepEqual(
+    groups.map(group => group.switchIndices.length),
+    [4, 8, 8],
+    'spines contain four switches and each plane contains its access and aggregation switches'
+  );
+  testCase.deepEqual(
+    groups.flatMap(group => group.switchIndices).sort((first, second) => first - second),
+    SWITCH_POSITIONS.map((_, switchIndex) => switchIndex),
+    'every pickable switch belongs to exactly one rendering group'
+  );
+  testCase.ok(
+    groups[1].switchIndices.every(switchIndex => SWITCH_POSITIONS[switchIndex][2] > 0),
+    'the first physical plane keeps its positive-depth switch row together'
+  );
+  testCase.ok(
+    groups[2].switchIndices.every(switchIndex => SWITCH_POSITIONS[switchIndex][2] < 0),
+    'the second physical plane keeps its negative-depth switch row together'
   );
   testCase.end();
 });

--- a/website/content/examples/showcase/packet-spraying.mdx
+++ b/website/content/examples/showcase/packet-spraying.mdx
@@ -14,8 +14,10 @@ import {PacketSprayingExample} from '@site/src/examples';
   <div>
     Two servers send red and green transfers to two destination servers. Their packets interleave
     on shared links, spread across independent network planes, and separate again at their
-    destinations. The example demonstrates the throughput and resilience advantages of Multipath
-    Reliable Connection (MRC), alongside reusable glass materials and order-independent transparency.
+    destinations. Emissive packets illuminate nearby glass switches, metallic server cubes, and
+    reflective links before selective bloom and filmic tone mapping. The example demonstrates the
+    throughput and resilience advantages of Multipath Reliable Connection (MRC), alongside reusable
+    optical materials and order-independent transparency.
   </div>
 </ExampleHeader>
 

--- a/website/content/examples/showcase/packet-spraying.mdx
+++ b/website/content/examples/showcase/packet-spraying.mdx
@@ -1,5 +1,5 @@
 ---
-title: Network Packet Spraying
+title: 'Effects: Glass'
 ---
 
 import {ExampleHeader} from '@site/src/react-luma';
@@ -7,7 +7,8 @@ import {PacketSprayingExample} from '@site/src/examples';
 
 <ExampleHeader
   id="packet-spraying"
-  title="Network Packet Spraying"
+  title="Effects: Glass"
+  subtitle="Network Packet Spraying"
   directory="showcase"
   devices={['webgl2', 'webgpu']}
 >

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -940,7 +940,8 @@ export const GlobeExample: React.FC = props => (
 export const PacketSprayingExample: React.FC = props => (
   <LumaExample
     id="packet-spraying"
-    title="Network Packet Spraying"
+    title="Effects: Glass"
+    subtitle="Network Packet Spraying"
     directory="showcase"
     template={PacketSprayingApp}
     config={exampleConfig}

--- a/website/src/react-luma/components/info-box.tsx
+++ b/website/src/react-luma/components/info-box.tsx
@@ -39,6 +39,7 @@ export type ExampleInfoProps = {
   sourceFiles?: string[];
   sourcePath?: string;
   stackBlitz?: boolean;
+  subtitle?: string;
   title?: string;
 };
 
@@ -319,6 +320,11 @@ function InfoBoxView(props: InfoBoxViewProps) {
           }}
         >
           {title ? <h3 style={{marginTop: 0, marginBottom: 0}}>{title}</h3> : null}
+          {props.subtitle ? (
+            <div style={{color: '#596579', fontSize: 12, lineHeight: 1.35, marginTop: 2}}>
+              {props.subtitle}
+            </div>
+          ) : null}
         </button>
         <div style={{display: 'flex', alignItems: 'center', gap: 24, flexShrink: 0}}>
           {sourceUrl ? (

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -53,6 +53,7 @@ export type LumaExampleProps = React.PropsWithChildren<
   ExampleDisplayProps & {
   id?: string;
   title?: string;
+  subtitle?: string;
   template: Function;
   config: unknown;
   directory?: string;
@@ -149,6 +150,7 @@ export const ExampleHeader: FC<ExampleHeaderProps> = (props: ExampleHeaderProps)
       <InfoBox
         id={props.id}
         title={props.title}
+        subtitle={props.subtitle}
         directory={props.directory}
         sourceDirectory={props.sourceDirectory}
         sourceFiles={props.sourceFiles}
@@ -345,6 +347,7 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
         <ExampleHeader
           id={props.id}
           title={props.title}
+          subtitle={props.subtitle}
           directory={props.directory}
           sourceDirectory={props.sourceDirectory}
           sourceFiles={props.sourceFiles}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16627,6 +16627,7 @@ __metadata:
   dependencies:
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
     "@luma.gl/core": "npm:9.4.0-alpha.1"
+    "@luma.gl/effects": "npm:9.4.0-alpha.1"
     "@luma.gl/engine": "npm:9.4.0-alpha.1"
     "@luma.gl/experimental": "npm:9.4.0-alpha.1"
     "@luma.gl/shadertools": "npm:9.4.0-alpha.1"


### PR DESCRIPTION
## Goals

- Demonstrate reusable state-of-the-art glass effects through Multipath Reliable Connection (MRC) packet spraying inspired by OpenAI's [supercomputer networking article](https://openai.com/index/mrc-supercomputer-networking/).
- Add reusable, portable optical-material and postprocessing primitives that work across WebGPU and WebGL.
- Keep the network diagram readable while showing resilient multi-plane routing, alternating red/green traffic, physically motivated glass, restrained emissive lighting, and interactive congestion/failure recovery.

## Changes

- Add reusable `emissiveMaterial` and `opticalPointLights` shader modules and plugins, including matching WGSL/GLSL implementations and a fixed 16-light portable uniform layout.
- Add reusable WGSL/GLSL emissive trail shading, tapered velocity-aligned packet trails, and localized switch-arrival flashes while preserving alternating red/green packet colors.
- Extend reusable glass and reflective materials with optional nearby-light shading while preserving their existing helper signatures.
- Add a reusable `glassTransmission` shader module with screen-space dual-surface refraction, backface-derived thickness, depth-aware distortion, roughness-aware chromatic dispersion, and studio-environment reflections for matching WebGPU/WGSL and WebGL/GLSL pipelines.
- Extend `ModelNode` with optional `instanceMatrices` and aggregate transformed bounds so one instanced model can participate in scenegraph culling and ordering without one node per instance.
- Add `GroupNode.traverseDepthSorted()` with stable back-to-front/front-to-back camera-space traversal and correct descendant/leaf transforms; fix rotated bounding boxes by transforming all eight corners.
- Split glass switches into semantic `spine`, `plane-1`, and `plane-2` scenegraph groups, depth-sort those instanced groups every frame, and refresh the refraction source between groups for layered transmission.
- Correct reflective environment sampling to follow the camera-reflected view ray and preserve the full opacity range for opaque metallic surfaces.
- Support configurable color attachment formats in A-buffer and weighted-blended transparency renderers so HDR values survive translucent compositing.
- Store exact A-buffer translucent fragments as two packed half-float pairs, preserving highlights above `1.0` through capture and resolve; update the 16-byte fragment allocation and bounded slice planning accordingly.
- Add an exported ACES tone-mapping shader pass and configurable linear samplers for named shader-pass render targets.
- Correct multiscale bloom filtering and avoid alpha-related blur amplification that previously produced square halos.
- Correct vertically mirrored named-target bloom sampling on WebGL so colored bloom remains aligned with its emissive packets.
- Render small saturated red/green emissive packets, selective bloom, dynamic colored switch/link reflections, and muted metallic red/green endpoint servers.
- Cycle clicked switches through **healthy → orange/congested → red/failed → healthy** without adding extra mode controls.
- Visualize congestion through periodically scattered payload fragments, smaller continuing packet headers, and alternate-path retransmissions while preserving all four network planes.
- Visualize failures through a brief packet-loss detection window, alternating red/green dropped-packet fragments, path retirement, retransmissions over the three surviving planes, and occasional recovery probes.
- Extract network topology, server/switch roles, route construction, packet scheduling, disruption events, link classification, and failure-aware packet redistribution into a dedicated `network.ts` module with focused standalone tests.
- Prevent orbit-drag gestures from accidentally toggling switches.
- Preserve alternating packet traffic, a 4x4 server grid, independent network planes, optional orbit controls, hover picking, and WebGPU/WebGL fallbacks.
- Rename the example to **Effects: Glass**, display **Network Packet Spraying** as its visible subtitle, and add optional nonbreaking subtitle support to shared example headers.
- Reduce showcase A-buffer over-allocation, remove an unused shader-input allocation, and release metallic shader inputs during teardown.
- Document glass, transparency, reflective shading, HDR, selective bloom, tone mapping, and the MRC showcase.

## Verification

- `nvm use`: unavailable in this shell; the active Node version is `v22.22.1`.
- `yarn install`: passed using `env -u YARN_NO_PROXY corepack yarn install`.
- `yarn build`: passed using `env -u YARN_NO_PROXY corepack yarn build` after the final code and formatting changes.
- `yarn lint fix`: passed using `env -u YARN_NO_PROXY corepack yarn lint fix`.
- `yarn test-node`: passed, **195 tests** with two skipped, including network topology, red/green arrival interleaving, congestion trimming, alternating packet loss, balanced failed-plane redistribution, restore behavior, camera-relative WGSL/GLSL reflections, and opaque reflective materials.
- Focused Chromium GPU tests: passed, including **15 scenegraph tests** covering aggregate instance bounds, rotated boxes, nested transforms, back-to-front/front-to-back traversal, and camera-direction changes; earlier bloom/shader-pass regression checks also passed.
- `yarn examples:typecheck`: passed for **32 example workspaces**.
- Packet-spraying standalone production build: passed.
- `yarn website:build`: passed.
- `(cd website && yarn build)`: passed on the previous revision.
- WebGPU and WebGL browser screenshots/canvas-pixel checks: passed on real Apple Metal hardware (`fallback=false`), with all three glass groups present, live group reordering under camera orbit, and visible red/green packet highlights. Previous interaction checks verified **healthy → congested with four planes and trimmed packets → failed with three planes and dropped packets → healthy with four restored planes**.
- GitHub Actions: all required checks passed on the previous revision (`test`, `examples`, and `website`); new checks are expected to run on commit `015769447`.
- `yarn test`: the current full run passed **195 Node tests** and **1,285 browser tests** with 25 skipped; one independently reproducible, unrelated failure remains in `modules/arrow-layers/test/layers/arrow-layers.spec.ts` (`arrow-polygons-storage-test has drawable storage-backed instances`). The Arrow layer does not import the scenegraph and is unchanged in this branch; rerunning that file alone reproduces the same failure.

## Follow-up

- Resolve the pre-existing Arrow polygon WebGPU test failure independently of this optical-material/showcase change.
- Caustics, dynamic environment probes, and ray-traced transmission remain separate future work.
