### PR TITLE
RFC: simplify CanvasContext drawing buffer sizing

### DIFF
--- a/dev-docs/RFCs/vNext/canvas-context-configuration-rfc.md
+++ b/dev-docs/RFCs/vNext/canvas-context-configuration-rfc.md
@@ -1,21 +1,19 @@
-# RFC: Explicit CanvasContext Drawing-Buffer Sizing
+# RFC: Explicit CanvasContext Drawing-Buffer Tracking
 
 * **Date**: July 2026
 * **Status**: Draft
 
 ## Summary
 
-This RFC proposes fresh, non-overloaded `CanvasContext` properties:
+This RFC proposes fresh `CanvasContext` properties that describe the application's intended
+canvas integration:
 
 ```ts
-export type DrawingBufferSizingMode =
-  | 'manual'
-  | 'track-device-pixels'
-  | 'track-css-pixels';
+export type DrawingBufferSizeTracking = 'none' | 'canvas' | 'external-canvas';
 
 export type CanvasContextProps = {
-  drawingBufferSizingMode?: DrawingBufferSizingMode;
-  trackCanvas?: HTMLCanvasElement | OffscreenCanvas | null;
+  drawingBufferSizeTracking?: DrawingBufferSizeTracking;
+  drawingBufferSizeSource?: HTMLCanvasElement | OffscreenCanvas | null;
   pixelRatio?: number;
 };
 ```
@@ -50,32 +48,67 @@ The individual properties are overloaded or interact through implicit precedence
 
 These interactions leak into higher-level integrations. [deck.gl
 #10370](https://github.com/visgl/deck.gl/pull/10370) must merge nested
-`deviceProps.createCanvasContext` objects and narrow the boolean/object union to select legacy
-CSS-DPR sizing. [deck.gl #10332](https://github.com/visgl/deck.gl/pull/10332) demonstrates the
-branching required to interpret and forward `useDevicePixels: boolean | number`.
+`deviceProps.createCanvasContext` objects and narrow the boolean/object union to reproduce a
+basemap's CSS/DPR sizing algorithm. [deck.gl
+#10332](https://github.com/visgl/deck.gl/pull/10332) demonstrates the branching required to
+interpret and forward `useDevicePixels: boolean | number`.
 
-The proposed API directly represents the two canvas-integration behaviors used by deck.gl:
+That is a symptom of an abstraction mismatch. deck.gl has two concrete integration behaviors:
 
 - **Interleaved:** attach to an externally owned context and canvas. The external renderer changes
   the drawing-buffer dimensions; luma.gl reads them but never writes them.
 - **Overlaid:** render to a separate luma.gl canvas whose drawing-buffer dimensions mirror the
   basemap canvas.
 
-The lower-level self-sizing properties remain useful for standalone canvases, but deck.gl no
-longer needs to reproduce the basemap's CSS/DPR sizing algorithm to implement either integration.
+luma.gl currently exposes lower-level sizing algorithms, leaving deck.gl to reconstruct these
+behaviors. The proposed API represents drawing-buffer ownership and source directly.
 
 ## Proposal
 
-### Track another canvas
+### Drawing-buffer tracking
 
-`trackCanvas` makes another canvas's actual `width` and `height` authoritative:
+`drawingBufferSizeTracking` selects where the target drawing-buffer dimensions come from:
+
+| Tracking | Size source | Does luma.gl write the target `width` and `height`? | `pixelRatio` |
+| --- | --- | --- | --- |
+| `'none'` | Application | Never | Not allowed |
+| `'canvas'` | Target canvas CSS/physical size | Yes, when size changes | Optional fixed ratio |
+| `'external-canvas'` | `drawingBufferSizeSource.width/height` | Yes, unless source is target | Not allowed |
+
+The default is `'canvas'`, preserving standalone canvas auto-sizing. With no `pixelRatio`, luma.gl
+uses `ResizeObserver.devicePixelContentBoxSize` when available and falls back to content-box size
+multiplied by browser DPR. With a numeric `pixelRatio`, luma.gl observes the content box and uses
+`Math.floor(cssSize * pixelRatio)`. A ratio must be finite and greater than zero.
+
+```ts
+// The application owns absolute drawing-buffer dimensions.
+{drawingBufferSizeTracking: 'none'}
+
+// Track the target canvas at its exact physical pixel coverage when available.
+{drawingBufferSizeTracking: 'canvas'}
+
+// Disable device-pixel scaling while continuing to track target CSS resizes.
+{drawingBufferSizeTracking: 'canvas', pixelRatio: 1}
+
+// Use a fixed pixel ratio while continuing to track target CSS resizes.
+{drawingBufferSizeTracking: 'canvas', pixelRatio: 1.5}
+```
+
+In `'none'` mode, target canvas CSS size, position, visibility, and DPR observation continue.
+Resize callbacks still run, but luma.gl does not change the drawing buffer automatically.
+
+### Track an external canvas
+
+`'external-canvas'` tracking makes another canvas's actual backing-store `width` and `height`
+authoritative:
 
 ```ts
 await luma.createDevice({
   createCanvasContext: true,
   canvasContextProps: {
     canvas: overlayCanvas,
-    trackCanvas: map.getCanvas()
+    drawingBufferSizeTracking: 'external-canvas',
+    drawingBufferSizeSource: map.getCanvas()
   }
 });
 ```
@@ -85,52 +118,26 @@ the source canvas with its cached dimensions. It resizes the target only when th
 does not read CSS layout, use `getBoundingClientRect()`, poll with a timer, or depend on observer
 callback ordering.
 
-When `trackCanvas` is supplied, `drawingBufferSizingMode` defaults to `'manual'`.
-`trackCanvas` is incompatible with an automatic sizing mode or `pixelRatio`, because the tracked
-canvas already supplies authoritative dimensions.
+If the source canvas is the target canvas itself, luma.gl updates only its size bookkeeping and
+never writes the canvas. This is the default behavior for an attached WebGL context: the external
+owner remains responsible for resizing the shared canvas.
 
-If the tracked canvas is the target canvas itself, luma.gl updates only its size bookkeeping. This
-is the default behavior for an attached WebGL context: the external owner remains responsible for
-resizing the shared canvas.
+`drawingBufferSizeSource` is required with `'external-canvas'` and is invalid with the other
+tracking values. `pixelRatio` is invalid because the source already supplies authoritative pixel
+dimensions.
 
-### Drawing-buffer sizing
+### What is not tracked
 
-`drawingBufferSizingMode` selects the resizing and observation behavior:
+The new properties govern only drawing-buffer dimensions: the integer `canvas.width` and
+`canvas.height` backing-store properties.
 
-| Mode | ResizeObserver box | Drawing-buffer size |
-| --- | --- | --- |
-| `'manual'` | `device-pixel-content-box` | Never changed automatically |
-| `'track-device-pixels'` | `device-pixel-content-box` | Exact reported physical size |
-| `'track-css-pixels'` | `content-box` | CSS size × `pixelRatio ?? window.devicePixelRatio` |
+An external source's CSS box, style, position, transforms, borders, scroll state, and containing
+block are not mirrored. An overlaid target belongs to its own layout hierarchy, so copying those
+properties could force layout, introduce feedback loops, and still fail to align canvases in
+different coordinate systems. The target canvas continues to use its own existing observation for
+CSS-size bookkeeping, callbacks, visibility, position, and CSS-to-device coordinate conversion.
 
-The default is `'track-device-pixels'`, preserving current default behavior. If the browser does
-not support `device-pixel-content-box`, luma.gl falls back to content-box dimensions multiplied by
-the browser DPR.
-
-`pixelRatio` is only valid with `'track-css-pixels'`. It must be finite and greater than zero.
-
-```ts
-// An external owner controls absolute drawing-buffer dimensions.
-{drawingBufferSizingMode: 'manual'}
-
-// Mirror another canvas's actual drawing-buffer dimensions.
-{trackCanvas: map.getCanvas()}
-
-// Track exact physical pixels using the newer ResizeObserver API.
-{drawingBufferSizingMode: 'track-device-pixels'}
-
-// Track CSS dimensions using the browser DPR.
-{drawingBufferSizingMode: 'track-css-pixels'}
-
-// Disable device-pixel scaling.
-{drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 1}
-
-// Use a fixed pixel ratio while continuing to follow CSS resizes.
-{drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 1.5}
-```
-
-In manual mode, canvas size, position, visibility, and DPR observation continue. Resize callbacks
-still run, but luma.gl does not call `setDrawingBufferSize()` automatically.
+Layout alignment remains the responsibility of deck.gl or the host application.
 
 ### Dynamic configuration
 
@@ -138,24 +145,27 @@ The new properties are mutable:
 
 ```ts
 canvasContext.setProps({
-  drawingBufferSizingMode: 'track-css-pixels',
+  drawingBufferSizeTracking: 'canvas',
   pixelRatio: 1.5
 });
 ```
 
-Changing between `track-css-pixels` and `track-device-pixels` re-registers the active
-`ResizeObserver` with the corresponding box. Setting `pixelRatio: undefined` while in
-`track-css-pixels` mode resumes browser DPR tracking. Changing to manual mode leaves the current
-drawing-buffer size unchanged.
+Setting `pixelRatio: undefined` while tracking `'canvas'` resumes exact device-pixel observation
+with browser-DPR fallback. This re-registers the active `ResizeObserver` with the appropriate box.
+Changing to `'none'` leaves the current drawing-buffer size unchanged.
 
-`trackCanvas` can be replaced dynamically. Clearing it leaves the context in manual mode and
-preserves the current size; an application can supply an automatic sizing mode in the same update
-to resume self-sizing:
+The external source can be replaced dynamically. A transition between external and target-canvas
+tracking is explicit:
 
 ```ts
 canvasContext.setProps({
-  trackCanvas: null,
-  drawingBufferSizingMode: 'track-device-pixels'
+  drawingBufferSizeTracking: 'external-canvas',
+  drawingBufferSizeSource: map.getCanvas()
+});
+
+canvasContext.setProps({
+  drawingBufferSizeTracking: 'canvas',
+  drawingBufferSizeSource: null
 });
 ```
 
@@ -176,7 +186,8 @@ Preferred usage is:
 await luma.createDevice({
   createCanvasContext: true,
   canvasContextProps: {
-    drawingBufferSizingMode: 'track-css-pixels'
+    drawingBufferSizeTracking: 'canvas',
+    pixelRatio: 1
   }
 });
 ```
@@ -185,29 +196,74 @@ If the deprecated object form of `createCanvasContext` and `canvasContextProps` 
 they are shallow-merged and `canvasContextProps` wins.
 
 Attaching an existing WebGL context necessarily creates a luma.gl `CanvasContext`. It defaults to
-manual sizing and tracks the attached canvas itself because the creator of the WebGL context owns
-its dimensions. `canvasContextProps` can explicitly override that default.
+`'external-canvas'` with the attached canvas as `drawingBufferSizeSource`. Because source and target
+are the same object, luma.gl reads externally owned dimensions but never writes them. Explicit
+`canvasContextProps` override this default.
 
 ## Compatibility and precedence
 
-If `trackCanvas` is supplied, it is authoritative and automatic sizing properties are rejected.
-Otherwise, if `drawingBufferSizingMode` is supplied, the new sizing properties are authoritative
-and the three legacy sizing properties are ignored. Supplying `pixelRatio` requires an explicit
-`drawingBufferSizingMode: 'track-css-pixels'`.
+If any new drawing-buffer property is supplied, the new properties are authoritative and the
+three legacy sizing properties are ignored. Supplying `pixelRatio` or `drawingBufferSizeSource`
+requires an explicit compatible `drawingBufferSizeTracking` value.
 
-When the new mode is absent, legacy properties normalize as follows:
+When the new properties are absent, legacy properties normalize as follows:
 
-| Legacy configuration | New equivalent |
+| Legacy configuration | Normalized behavior |
 | --- | --- |
-| `autoResize: false` | `drawingBufferSizingMode: 'manual'` |
-| `useDevicePixels: false` | `drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 1` |
-| `useDevicePixels: number` | `drawingBufferSizingMode: 'track-css-pixels', pixelRatio: number` |
-| `useDevicePixels: true`, `pixelSizeSource: 'exact'` | `drawingBufferSizingMode: 'track-device-pixels'` |
-| `useDevicePixels: true`, `pixelSizeSource: 'css-dpr'` | `drawingBufferSizingMode: 'track-css-pixels'` |
+| `autoResize: false` | `drawingBufferSizeTracking: 'none'` |
+| `useDevicePixels: false` | `'canvas'` tracking with `pixelRatio: 1` |
+| `useDevicePixels: number` | `'canvas'` tracking with that fixed ratio |
+| `useDevicePixels: true`, `pixelSizeSource: 'exact'` | `'canvas'` tracking using exact physical size |
+| `useDevicePixels: true`, `pixelSizeSource: 'css-dpr'` | `'canvas'` compatibility path using content-box × live browser DPR |
+
+The legacy CSS-DPR algorithm is intentionally not a separate value in the fresh API. Its primary
+integration use case—matching another renderer's backing store—is represented more directly and
+reliably by `'external-canvas'`. It remains available through legacy normalization while v9
+compatibility is required.
 
 Legacy `CanvasContext.setProps({useDevicePixels})` remains functional for contexts created with
 legacy configuration. Once a context is configured with the new properties, later legacy sizing
 updates are ignored.
+
+## Migration
+
+### Standalone canvas
+
+```ts
+// Before
+{autoResize: true, useDevicePixels: 1}
+
+// After
+{drawingBufferSizeTracking: 'canvas', pixelRatio: 1}
+```
+
+### Externally sized attached context
+
+```ts
+// Before
+{autoResize: false}
+
+// After
+{
+  drawingBufferSizeTracking: 'external-canvas',
+  drawingBufferSizeSource: gl.canvas
+}
+```
+
+WebGL attachment supplies the latter configuration automatically.
+
+### Overlay matching another canvas
+
+```ts
+// Before: reproduce the source renderer's sizing algorithm
+{autoResize: true, useDevicePixels: true, pixelSizeSource: 'css-dpr'}
+
+// After: use the source renderer's actual result
+{
+  drawingBufferSizeTracking: 'external-canvas',
+  drawingBufferSizeSource: map.getCanvas()
+}
+```
 
 ## Deprecation
 
@@ -223,40 +279,52 @@ The proposed v10 API retains `createCanvasContext?: boolean`, adds
 
 ## Alternatives considered
 
-### Keep `useDevicePixels: boolean | number`
+### Expose ResizeObserver algorithms as modes
 
-This preserves the smallest API but continues to require runtime type checks throughout
-applications and integration layers.
+Values such as `track-device-pixels` and `track-css-pixels` precisely describe implementation
+choices but do not describe the integration the application is trying to implement. They also
+leave overlay libraries responsible for reproducing an external renderer's algorithm.
+
+### Use `track-none`, `track-canvas`, and `track-external-canvas`
+
+The `track-` prefix makes the values readable in isolation, but repeats the word already present
+in `drawingBufferSizeTracking`. The shorter values form complete phrases at the call site:
+`drawingBufferSizeTracking: 'external-canvas'`.
+
+### Add `drawingBufferSize`
+
+A `[width, height]` property reads clearly next to `'none'`, but duplicates the existing
+`setDrawingBufferSize(width, height)` imperative API and raises update/ownership questions. Manual
+owners can set the canvas or call that method directly. This RFC keeps tracking policy separate
+from one-time size mutation.
 
 ### Add a policy object
 
 A discriminated policy object can encode every valid state statically, but adds nesting to the
-common configuration path. The proposed flat mode and optional ratio remain explicit without
-requiring another object.
-
-### Use ResizeObserver box names as modes
-
-Names such as `content-box` and `device-pixel-content-box` map directly to browser terminology,
-but expose an implementation detail and become misleading when exact device-pixel observation is
-unsupported. The proposed names describe the stable application-facing behavior: track device
-pixels, track CSS pixels, or leave sizing under manual ownership.
-
-### Keep `autoResize` as an independent switch
-
-Ownership and sizing source are technically independent, but supporting every combination
-recreates the current precedence problem. Manual sizing is instead a first-class mode.
+common configuration path. The proposed flat tracking, source, and optional ratio remain explicit
+without requiring another object.
 
 ## Proof of concept
 
 The accompanying implementation:
 
-- tracks another canvas's actual dimensions at size-query and render boundaries;
-- normalizes legacy properties into the new sizing model;
-- supports dynamic mode and ratio updates;
-- reconfigures active resize observation;
+- implements `none`, target-canvas, and external-canvas drawing-buffer tracking;
+- checks an external canvas's backing-store dimensions at size-query and render boundaries;
+- retains legacy exact and CSS-DPR algorithms through normalization;
+- supports dynamic tracking, source, and ratio updates;
+- reconfigures active resize observation when the target sizing algorithm changes;
 - adds `DeviceProps.canvasContextProps`;
 - defaults attached WebGL contexts to read-only self-tracking; and
 - exercises new, legacy, dynamic, and attachment behavior in tests.
 
 The proof of concept intentionally leaves stable API documentation and release notes unchanged
 until the proposal is accepted.
+
+## Open questions
+
+- Should `drawingBufferSizeSource` accept only a canvas, or a smaller structural
+  `{width: number; height: number}` source?
+- Should `'none'` stop exact-device-pixel observation entirely, or retain current device-pixel
+  bookkeeping and callbacks as the PoC does?
+- Is the compatibility-only legacy CSS-DPR path sufficient for v9, given that new overlay
+  integrations can track the external backing store directly?

--- a/dev-docs/RFCs/vNext/canvas-context-configuration-rfc.md
+++ b/dev-docs/RFCs/vNext/canvas-context-configuration-rfc.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-This RFC proposes two new `CanvasContext` properties:
+This RFC proposes fresh, non-overloaded `CanvasContext` properties:
 
 ```ts
 export type DrawingBufferSizingMode =
@@ -15,6 +15,7 @@ export type DrawingBufferSizingMode =
 
 export type CanvasContextProps = {
   drawingBufferSizingMode?: DrawingBufferSizingMode;
+  trackCanvas?: HTMLCanvasElement | OffscreenCanvas | null;
   pixelRatio?: number;
 };
 ```
@@ -53,11 +54,44 @@ These interactions leak into higher-level integrations. [deck.gl
 CSS-DPR sizing. [deck.gl #10332](https://github.com/visgl/deck.gl/pull/10332) demonstrates the
 branching required to interpret and forward `useDevicePixels: boolean | number`.
 
-The proposed API starts from the choice the application actually needs to make: who owns
-drawing-buffer resizing, whether luma.gl tracks device or CSS pixels, and whether a fixed ratio
-replaces the browser DPR.
+The proposed API directly represents the two canvas-integration behaviors used by deck.gl:
+
+- **Interleaved:** attach to an externally owned context and canvas. The external renderer changes
+  the drawing-buffer dimensions; luma.gl reads them but never writes them.
+- **Overlaid:** render to a separate luma.gl canvas whose drawing-buffer dimensions mirror the
+  basemap canvas.
+
+The lower-level self-sizing properties remain useful for standalone canvases, but deck.gl no
+longer needs to reproduce the basemap's CSS/DPR sizing algorithm to implement either integration.
 
 ## Proposal
+
+### Track another canvas
+
+`trackCanvas` makes another canvas's actual `width` and `height` authoritative:
+
+```ts
+await luma.createDevice({
+  createCanvasContext: true,
+  canvasContextProps: {
+    canvas: overlayCanvas,
+    trackCanvas: map.getCanvas()
+  }
+});
+```
+
+Before reporting or using the drawing-buffer size, luma.gl compares two integer properties from
+the source canvas with its cached dimensions. It resizes the target only when they differ. This
+does not read CSS layout, use `getBoundingClientRect()`, poll with a timer, or depend on observer
+callback ordering.
+
+When `trackCanvas` is supplied, `drawingBufferSizingMode` defaults to `'manual'`.
+`trackCanvas` is incompatible with an automatic sizing mode or `pixelRatio`, because the tracked
+canvas already supplies authoritative dimensions.
+
+If the tracked canvas is the target canvas itself, luma.gl updates only its size bookkeeping. This
+is the default behavior for an attached WebGL context: the external owner remains responsible for
+resizing the shared canvas.
 
 ### Drawing-buffer sizing
 
@@ -79,6 +113,9 @@ the browser DPR.
 // An external owner controls absolute drawing-buffer dimensions.
 {drawingBufferSizingMode: 'manual'}
 
+// Mirror another canvas's actual drawing-buffer dimensions.
+{trackCanvas: map.getCanvas()}
+
 // Track exact physical pixels using the newer ResizeObserver API.
 {drawingBufferSizingMode: 'track-device-pixels'}
 
@@ -97,7 +134,7 @@ still run, but luma.gl does not call `setDrawingBufferSize()` automatically.
 
 ### Dynamic configuration
 
-Both new properties are mutable:
+The new properties are mutable:
 
 ```ts
 canvasContext.setProps({
@@ -110,6 +147,17 @@ Changing between `track-css-pixels` and `track-device-pixels` re-registers the a
 `ResizeObserver` with the corresponding box. Setting `pixelRatio: undefined` while in
 `track-css-pixels` mode resumes browser DPR tracking. Changing to manual mode leaves the current
 drawing-buffer size unchanged.
+
+`trackCanvas` can be replaced dynamically. Clearing it leaves the context in manual mode and
+preserves the current size; an application can supply an automatic sizing mode in the same update
+to resume self-sizing:
+
+```ts
+canvasContext.setProps({
+  trackCanvas: null,
+  drawingBufferSizingMode: 'track-device-pixels'
+});
+```
 
 ### Default canvas-context configuration
 
@@ -137,13 +185,14 @@ If the deprecated object form of `createCanvasContext` and `canvasContextProps` 
 they are shallow-merged and `canvasContextProps` wins.
 
 Attaching an existing WebGL context necessarily creates a luma.gl `CanvasContext`. It defaults to
-manual sizing because the creator of the WebGL context owns its canvas. `canvasContextProps` can
-explicitly override that default.
+manual sizing and tracks the attached canvas itself because the creator of the WebGL context owns
+its dimensions. `canvasContextProps` can explicitly override that default.
 
 ## Compatibility and precedence
 
-If `drawingBufferSizingMode` is supplied, the new sizing properties are authoritative and the
-three legacy sizing properties are ignored. Supplying `pixelRatio` requires an explicit
+If `trackCanvas` is supplied, it is authoritative and automatic sizing properties are rejected.
+Otherwise, if `drawingBufferSizingMode` is supplied, the new sizing properties are authoritative
+and the three legacy sizing properties are ignored. Supplying `pixelRatio` requires an explicit
 `drawingBufferSizingMode: 'track-css-pixels'`.
 
 When the new mode is absent, legacy properties normalize as follows:
@@ -201,11 +250,12 @@ recreates the current precedence problem. Manual sizing is instead a first-class
 
 The accompanying implementation:
 
+- tracks another canvas's actual dimensions at size-query and render boundaries;
 - normalizes legacy properties into the new sizing model;
 - supports dynamic mode and ratio updates;
 - reconfigures active resize observation;
 - adds `DeviceProps.canvasContextProps`;
-- defaults attached WebGL contexts to manual sizing; and
+- defaults attached WebGL contexts to read-only self-tracking; and
 - exercises new, legacy, dynamic, and attachment behavior in tests.
 
 The proof of concept intentionally leaves stable API documentation and release notes unchanged

--- a/dev-docs/RFCs/vNext/canvas-context-configuration-rfc.md
+++ b/dev-docs/RFCs/vNext/canvas-context-configuration-rfc.md
@@ -1,0 +1,212 @@
+# RFC: Explicit CanvasContext Drawing-Buffer Sizing
+
+* **Date**: July 2026
+* **Status**: Draft
+
+## Summary
+
+This RFC proposes two new `CanvasContext` properties:
+
+```ts
+export type DrawingBufferSizingMode =
+  | 'manual'
+  | 'track-device-pixels'
+  | 'track-css-pixels';
+
+export type CanvasContextProps = {
+  drawingBufferSizingMode?: DrawingBufferSizingMode;
+  pixelRatio?: number;
+};
+```
+
+The properties replace the overlapping responsibilities of `autoResize`, `useDevicePixels`, and
+`pixelSizeSource`. The old properties remain supported and are deprecated in luma.gl v9, with
+removal proposed for v10.
+
+The RFC also proposes `DeviceProps.canvasContextProps` as the preferred way to configure a
+device's default or attached canvas context. The boolean form of `createCanvasContext` remains,
+while its `CanvasContextProps` object form is deprecated.
+
+## Motivation
+
+Canvas sizing currently requires applications and integration libraries to combine three
+properties:
+
+```ts
+createCanvasContext: {
+  autoResize: true,
+  useDevicePixels: true,
+  pixelSizeSource: 'css-dpr'
+}
+```
+
+The individual properties are overloaded or interact through implicit precedence:
+
+- `autoResize` controls whether luma.gl owns drawing-buffer resizing.
+- `useDevicePixels` accepts `true`, `false`, or a number, combining a mode and a value.
+- `pixelSizeSource` changes the meaning of `useDevicePixels: true`.
+- `DeviceProps.createCanvasContext` accepts a boolean or a configuration object.
+
+These interactions leak into higher-level integrations. [deck.gl
+#10370](https://github.com/visgl/deck.gl/pull/10370) must merge nested
+`deviceProps.createCanvasContext` objects and narrow the boolean/object union to select legacy
+CSS-DPR sizing. [deck.gl #10332](https://github.com/visgl/deck.gl/pull/10332) demonstrates the
+branching required to interpret and forward `useDevicePixels: boolean | number`.
+
+The proposed API starts from the choice the application actually needs to make: who owns
+drawing-buffer resizing, whether luma.gl tracks device or CSS pixels, and whether a fixed ratio
+replaces the browser DPR.
+
+## Proposal
+
+### Drawing-buffer sizing
+
+`drawingBufferSizingMode` selects the resizing and observation behavior:
+
+| Mode | ResizeObserver box | Drawing-buffer size |
+| --- | --- | --- |
+| `'manual'` | `device-pixel-content-box` | Never changed automatically |
+| `'track-device-pixels'` | `device-pixel-content-box` | Exact reported physical size |
+| `'track-css-pixels'` | `content-box` | CSS size × `pixelRatio ?? window.devicePixelRatio` |
+
+The default is `'track-device-pixels'`, preserving current default behavior. If the browser does
+not support `device-pixel-content-box`, luma.gl falls back to content-box dimensions multiplied by
+the browser DPR.
+
+`pixelRatio` is only valid with `'track-css-pixels'`. It must be finite and greater than zero.
+
+```ts
+// An external owner controls absolute drawing-buffer dimensions.
+{drawingBufferSizingMode: 'manual'}
+
+// Track exact physical pixels using the newer ResizeObserver API.
+{drawingBufferSizingMode: 'track-device-pixels'}
+
+// Track CSS dimensions using the browser DPR.
+{drawingBufferSizingMode: 'track-css-pixels'}
+
+// Disable device-pixel scaling.
+{drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 1}
+
+// Use a fixed pixel ratio while continuing to follow CSS resizes.
+{drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 1.5}
+```
+
+In manual mode, canvas size, position, visibility, and DPR observation continue. Resize callbacks
+still run, but luma.gl does not call `setDrawingBufferSize()` automatically.
+
+### Dynamic configuration
+
+Both new properties are mutable:
+
+```ts
+canvasContext.setProps({
+  drawingBufferSizingMode: 'track-css-pixels',
+  pixelRatio: 1.5
+});
+```
+
+Changing between `track-css-pixels` and `track-device-pixels` re-registers the active
+`ResizeObserver` with the corresponding box. Setting `pixelRatio: undefined` while in
+`track-css-pixels` mode resumes browser DPR tracking. Changing to manual mode leaves the current
+drawing-buffer size unchanged.
+
+### Default canvas-context configuration
+
+Device creation gains a separate configuration property:
+
+```ts
+export type DeviceProps = {
+  createCanvasContext?: boolean | CanvasContextProps;
+  canvasContextProps?: CanvasContextProps;
+};
+```
+
+Preferred usage is:
+
+```ts
+await luma.createDevice({
+  createCanvasContext: true,
+  canvasContextProps: {
+    drawingBufferSizingMode: 'track-css-pixels'
+  }
+});
+```
+
+If the deprecated object form of `createCanvasContext` and `canvasContextProps` are both supplied,
+they are shallow-merged and `canvasContextProps` wins.
+
+Attaching an existing WebGL context necessarily creates a luma.gl `CanvasContext`. It defaults to
+manual sizing because the creator of the WebGL context owns its canvas. `canvasContextProps` can
+explicitly override that default.
+
+## Compatibility and precedence
+
+If `drawingBufferSizingMode` is supplied, the new sizing properties are authoritative and the
+three legacy sizing properties are ignored. Supplying `pixelRatio` requires an explicit
+`drawingBufferSizingMode: 'track-css-pixels'`.
+
+When the new mode is absent, legacy properties normalize as follows:
+
+| Legacy configuration | New equivalent |
+| --- | --- |
+| `autoResize: false` | `drawingBufferSizingMode: 'manual'` |
+| `useDevicePixels: false` | `drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 1` |
+| `useDevicePixels: number` | `drawingBufferSizingMode: 'track-css-pixels', pixelRatio: number` |
+| `useDevicePixels: true`, `pixelSizeSource: 'exact'` | `drawingBufferSizingMode: 'track-device-pixels'` |
+| `useDevicePixels: true`, `pixelSizeSource: 'css-dpr'` | `drawingBufferSizingMode: 'track-css-pixels'` |
+
+Legacy `CanvasContext.setProps({useDevicePixels})` remains functional for contexts created with
+legacy configuration. Once a context is configured with the new properties, later legacy sizing
+updates are ignored.
+
+## Deprecation
+
+The following remain supported in v9 but are marked deprecated:
+
+- `CanvasContextProps.autoResize`
+- `CanvasContextProps.useDevicePixels`
+- `CanvasContextProps.pixelSizeSource`
+- The `CanvasContextProps` object form of `DeviceProps.createCanvasContext`
+
+The proposed v10 API retains `createCanvasContext?: boolean`, adds
+`canvasContextProps?: CanvasContextProps`, and removes the deprecated sizing properties.
+
+## Alternatives considered
+
+### Keep `useDevicePixels: boolean | number`
+
+This preserves the smallest API but continues to require runtime type checks throughout
+applications and integration layers.
+
+### Add a policy object
+
+A discriminated policy object can encode every valid state statically, but adds nesting to the
+common configuration path. The proposed flat mode and optional ratio remain explicit without
+requiring another object.
+
+### Use ResizeObserver box names as modes
+
+Names such as `content-box` and `device-pixel-content-box` map directly to browser terminology,
+but expose an implementation detail and become misleading when exact device-pixel observation is
+unsupported. The proposed names describe the stable application-facing behavior: track device
+pixels, track CSS pixels, or leave sizing under manual ownership.
+
+### Keep `autoResize` as an independent switch
+
+Ownership and sizing source are technically independent, but supporting every combination
+recreates the current precedence problem. Manual sizing is instead a first-class mode.
+
+## Proof of concept
+
+The accompanying implementation:
+
+- normalizes legacy properties into the new sizing model;
+- supports dynamic mode and ratio updates;
+- reconfigures active resize observation;
+- adds `DeviceProps.canvasContextProps`;
+- defaults attached WebGL contexts to manual sizing; and
+- exercises new, legacy, dynamic, and attachment behavior in tests.
+
+The proof of concept intentionally leaves stable API documentation and release notes unchanged
+until the proposal is accepted.

--- a/modules/core/src/adapter/canvas-context.ts
+++ b/modules/core/src/adapter/canvas-context.ts
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-export type {CanvasContextProps, MutableCanvasContextProps} from './canvas-surface';
+export type {
+  CanvasContextProps,
+  DrawingBufferSizingMode,
+  MutableCanvasContextProps
+} from './canvas-surface';
 import {CanvasSurface} from './canvas-surface';
 
 /**

--- a/modules/core/src/adapter/canvas-context.ts
+++ b/modules/core/src/adapter/canvas-context.ts
@@ -4,7 +4,7 @@
 
 export type {
   CanvasContextProps,
-  DrawingBufferSizingMode,
+  DrawingBufferSizeTracking,
   MutableCanvasContextProps
 } from './canvas-surface';
 import {CanvasSurface} from './canvas-surface';

--- a/modules/core/src/adapter/canvas-observer.ts
+++ b/modules/core/src/adapter/canvas-observer.ts
@@ -53,6 +53,18 @@ export class CanvasObserver {
     this.props = props;
   }
 
+  /** Changes the observed resize box and re-registers an active ResizeObserver. */
+  setResizeObserverBox(resizeObserverBox: ResizeObserverBoxOptions): void {
+    if (resizeObserverBox === this.props.resizeObserverBox) {
+      return;
+    }
+    this.props.resizeObserverBox = resizeObserverBox;
+    if (this._started) {
+      this._resizeObserver?.disconnect();
+      this._observeResize();
+    }
+  }
+
   /** Starts DOM observation and optional position polling. */
   start(): void {
     if (this._started || !this.props.canvas) {
@@ -66,12 +78,7 @@ export class CanvasObserver {
     this._resizeObserver ||= new ResizeObserver(entries => this.props.onResize(entries));
 
     this._intersectionObserver.observe(this.props.canvas);
-    const box = this.props.resizeObserverBox;
-    try {
-      this._resizeObserver.observe(this.props.canvas, {box});
-    } catch {
-      this._resizeObserver.observe(this.props.canvas, {box: 'content-box'});
-    }
+    this._observeResize();
 
     this._observeDevicePixelRatioTimeout = setTimeout(() => this._refreshDevicePixelRatio(), 0);
 
@@ -130,6 +137,19 @@ export class CanvasObserver {
       this._handleDevicePixelRatioChange,
       {once: true}
     );
+  }
+
+  /** Registers the ResizeObserver with the currently configured box. */
+  private _observeResize(): void {
+    if (!this.props.canvas || !this._resizeObserver) {
+      return;
+    }
+    const box = this.props.resizeObserverBox;
+    try {
+      this._resizeObserver.observe(this.props.canvas, {box});
+    } catch {
+      this._resizeObserver.observe(this.props.canvas, {box: 'content-box'});
+    }
   }
 
   /**

--- a/modules/core/src/adapter/canvas-surface.ts
+++ b/modules/core/src/adapter/canvas-surface.ts
@@ -14,12 +14,12 @@ import {withResolvers} from '../utils/promise-utils';
 import {assert, assertDefined} from '../utils/assert';
 
 /**
- * Selects how luma.gl sizes a canvas drawing buffer.
- * - `manual`: the application or an attached context owns the size.
- * - `track-device-pixels`: follow the canvas's exact physical pixel coverage when available.
- * - `track-css-pixels`: multiply the canvas's CSS dimensions by `pixelRatio` or the browser DPR.
+ * Selects what luma.gl tracks when sizing a canvas drawing buffer.
+ * - `none`: the application owns the drawing-buffer size.
+ * - `canvas`: derive the drawing-buffer size from the target canvas's CSS size.
+ * - `external-canvas`: mirror another canvas's drawing-buffer dimensions.
  */
-export type DrawingBufferSizingMode = 'manual' | 'track-device-pixels' | 'track-css-pixels';
+export type DrawingBufferSizeTracking = 'none' | 'canvas' | 'external-canvas';
 
 /** Properties for a CanvasContext */
 export type CanvasContextProps = {
@@ -35,19 +35,19 @@ export type CanvasContextProps = {
   height?: number;
   /** Visibility (only used if new canvas is created). */
   visible?: boolean;
-  /** How luma.gl should resize the drawing buffer. */
-  drawingBufferSizingMode?: DrawingBufferSizingMode;
+  /** What luma.gl should track when sizing the drawing buffer. */
+  drawingBufferSizeTracking?: DrawingBufferSizeTracking;
   /**
    * Canvas whose drawing-buffer dimensions should be mirrored before each draw.
-   * When supplied, `drawingBufferSizingMode` defaults to `manual`.
+   * Required when `drawingBufferSizeTracking` is `'external-canvas'`.
    */
-  trackCanvas?: HTMLCanvasElement | OffscreenCanvas | null;
-  /** Fixed ratio applied to CSS dimensions. Only valid in `track-css-pixels` mode. */
+  drawingBufferSizeSource?: HTMLCanvasElement | OffscreenCanvas | null;
+  /** Fixed ratio applied to CSS dimensions. Only valid with `'canvas'` tracking. */
   pixelRatio?: number;
   /**
    * Whether to size the drawing buffer to the pixel size during auto resize. If a number is
    * provided it is used as a static pixel ratio.
-   * @deprecated Use `drawingBufferSizingMode` and `pixelRatio`.
+   * @deprecated Use `drawingBufferSizeTracking` and `pixelRatio`.
    */
   useDevicePixels?: boolean | number;
   /**
@@ -57,12 +57,12 @@ export type CanvasContextProps = {
    *   browser's exact physical pixel coverage.
    * - `'css-dpr'` uses `Math.floor(cssSize * devicePixelRatio)` to match overlays and external
    *   canvases that size their drawing buffer via implicit truncation (e.g. `canvas.width = css * dpr`).
-   * @deprecated Use `drawingBufferSizingMode`.
+   * @deprecated Use `drawingBufferSizeTracking`.
    */
   pixelSizeSource?: 'exact' | 'css-dpr';
   /**
    * Whether to track window resizes.
-   * @deprecated Use `drawingBufferSizingMode: 'manual'`.
+   * @deprecated Use `drawingBufferSizeTracking: 'none'`.
    */
   autoResize?: boolean;
   /** @see https://developer.mozilla.org/en-US/docs/Web/API/GPUCanvasContext/configure#alphamode */
@@ -78,16 +78,16 @@ export type CanvasContextProps = {
 };
 
 export type MutableCanvasContextProps = {
-  /** How luma.gl should resize the drawing buffer. */
-  drawingBufferSizingMode?: DrawingBufferSizingMode;
+  /** What luma.gl should track when sizing the drawing buffer. */
+  drawingBufferSizeTracking?: DrawingBufferSizeTracking;
   /** Canvas whose drawing-buffer dimensions should be mirrored before each draw. */
-  trackCanvas?: HTMLCanvasElement | OffscreenCanvas | null;
-  /** Fixed ratio applied to CSS dimensions. Only valid in `track-css-pixels` mode. */
+  drawingBufferSizeSource?: HTMLCanvasElement | OffscreenCanvas | null;
+  /** Fixed ratio applied to CSS dimensions. Only valid with `'canvas'` tracking. */
   pixelRatio?: number;
   /**
    * Whether to size the drawing buffer to the pixel size during auto resize. If a number is
    * provided it is used as a static pixel ratio.
-   * @deprecated Use `drawingBufferSizingMode` and `pixelRatio`.
+   * @deprecated Use `drawingBufferSizeTracking` and `pixelRatio`.
    */
   useDevicePixels?: boolean | number;
 };
@@ -95,6 +95,15 @@ export type MutableCanvasContextProps = {
 type DevicePixelSize = {
   devicePixelWidth: number;
   devicePixelHeight: number;
+};
+
+type PixelSizeSource = 'exact' | 'css-dpr';
+
+type NormalizedDrawingBufferSizeProps = {
+  drawingBufferSizeTracking: DrawingBufferSizeTracking;
+  drawingBufferSizeSource: HTMLCanvasElement | OffscreenCanvas | null;
+  pixelRatio: number | undefined;
+  pixelSizeSource: PixelSizeSource;
 };
 
 /**
@@ -118,8 +127,8 @@ export abstract class CanvasSurface {
     canvas: null,
     width: 800,
     height: 600,
-    drawingBufferSizingMode: 'track-device-pixels',
-    trackCanvas: null,
+    drawingBufferSizeTracking: 'canvas',
+    drawingBufferSizeSource: null,
     pixelRatio: undefined!,
     useDevicePixels: true,
     pixelSizeSource: 'exact',
@@ -164,9 +173,9 @@ export abstract class CanvasSurface {
   /** Exact height of canvas in physical pixels (tracked by a ResizeObserver) */
   devicePixelHeight: number;
 
-  /** Width of the drawing buffer, maintained according to drawingBufferSizingMode. */
+  /** Width of the drawing buffer, maintained according to drawingBufferSizeTracking. */
   drawingBufferWidth: number;
-  /** Height of the drawing buffer, maintained according to drawingBufferSizingMode. */
+  /** Height of the drawing buffer, maintained according to drawingBufferSizeTracking. */
   drawingBufferHeight: number;
 
   /** Resolves when the canvas is initialized, i.e. when the ResizeObserver has updated the pixel size */
@@ -178,6 +187,8 @@ export abstract class CanvasSurface {
   protected destroyed = false;
   /** Whether deprecated sizing props still control the normalized sizing configuration. */
   protected _usesLegacyDrawingBufferSizing: boolean;
+  /** Internal pixel-size algorithm retained to normalize legacy `pixelSizeSource`. */
+  protected _pixelSizeSource: PixelSizeSource;
   /** Whether the drawing buffer size needs to be resized (deferred resizing to avoid flicker) */
   protected _needsDrawingBufferResize: boolean = true;
 
@@ -189,11 +200,18 @@ export abstract class CanvasSurface {
 
   constructor(props?: CanvasContextProps) {
     this._usesLegacyDrawingBufferSizing =
-      !props?.trackCanvas &&
-      props?.drawingBufferSizingMode === undefined &&
+      props?.drawingBufferSizeTracking === undefined &&
+      props?.drawingBufferSizeSource === undefined &&
       props?.pixelRatio === undefined;
-    const drawingBufferSizingProps = normalizeDrawingBufferSizingProps(props);
-    this.props = {...CanvasSurface.defaultProps, ...props, ...drawingBufferSizingProps};
+    const drawingBufferSizeProps = normalizeDrawingBufferSizeProps(props);
+    this._pixelSizeSource = drawingBufferSizeProps.pixelSizeSource;
+    this.props = {
+      ...CanvasSurface.defaultProps,
+      ...props,
+      drawingBufferSizeTracking: drawingBufferSizeProps.drawingBufferSizeTracking,
+      drawingBufferSizeSource: drawingBufferSizeProps.drawingBufferSizeSource,
+      pixelRatio: drawingBufferSizeProps.pixelRatio!
+    };
     props = this.props;
 
     this.initialized = this._initializedResolvers.promise;
@@ -232,7 +250,7 @@ export abstract class CanvasSurface {
     this._canvasObserver = new CanvasObserver({
       canvas: this.htmlCanvas,
       trackPosition: this.props.trackPosition,
-      resizeObserverBox: getResizeObserverBox(this.props.drawingBufferSizingMode),
+      resizeObserverBox: getResizeObserverBox(this._pixelSizeSource),
       onResize: entries => this._handleResize(entries),
       onIntersection: entries => this._handleIntersection(entries),
       onDevicePixelRatioChange: () => this._observeDevicePixelRatio(),
@@ -250,43 +268,48 @@ export abstract class CanvasSurface {
   }
 
   setProps(props: MutableCanvasContextProps): this {
-    const hasTrackCanvas = 'trackCanvas' in props;
-    const trackCanvas = hasTrackCanvas ? props.trackCanvas : this.props.trackCanvas;
-    if (trackCanvas) {
-      validateTrackCanvasProps(trackCanvas, props.drawingBufferSizingMode, props.pixelRatio);
-      this.props.trackCanvas = trackCanvas;
-      this._usesLegacyDrawingBufferSizing = false;
-      this._setDrawingBufferSizingProps('manual', undefined);
-      this._syncTrackedCanvasSize();
-      return this;
-    }
-    if (hasTrackCanvas) {
-      this.props.trackCanvas = trackCanvas!;
-      this._usesLegacyDrawingBufferSizing = false;
-    }
-
-    const hasNewDrawingBufferSizingProps =
-      'drawingBufferSizingMode' in props || 'pixelRatio' in props;
-    if (hasNewDrawingBufferSizingProps) {
+    const hasNewDrawingBufferSizeProps =
+      'drawingBufferSizeTracking' in props ||
+      'drawingBufferSizeSource' in props ||
+      'pixelRatio' in props;
+    if (hasNewDrawingBufferSizeProps) {
       const previousUsesLegacyDrawingBufferSizing = this._usesLegacyDrawingBufferSizing;
-      const drawingBufferSizingMode =
-        props.drawingBufferSizingMode ?? this.props.drawingBufferSizingMode;
+      const drawingBufferSizeTracking =
+        props.drawingBufferSizeTracking ?? this.props.drawingBufferSizeTracking;
+      let drawingBufferSizeSource =
+        'drawingBufferSizeSource' in props
+          ? props.drawingBufferSizeSource
+          : this.props.drawingBufferSizeSource;
+      if ('drawingBufferSizeTracking' in props && drawingBufferSizeTracking !== 'external-canvas') {
+        drawingBufferSizeSource = props.drawingBufferSizeSource;
+      }
       let pixelRatio = 'pixelRatio' in props ? props.pixelRatio : this.props.pixelRatio;
       if (
-        'drawingBufferSizingMode' in props &&
-        (drawingBufferSizingMode !== 'track-css-pixels' || previousUsesLegacyDrawingBufferSizing)
+        'drawingBufferSizeTracking' in props &&
+        (drawingBufferSizeTracking !== 'canvas' || previousUsesLegacyDrawingBufferSizing)
       ) {
         pixelRatio = props.pixelRatio;
       }
-      validateDrawingBufferSizingProps(drawingBufferSizingMode, pixelRatio);
+      validateDrawingBufferSizeProps(
+        drawingBufferSizeTracking,
+        drawingBufferSizeSource,
+        pixelRatio
+      );
       this._usesLegacyDrawingBufferSizing = false;
-      this._setDrawingBufferSizingProps(drawingBufferSizingMode, pixelRatio);
+      this._setDrawingBufferSizeProps(
+        drawingBufferSizeTracking,
+        drawingBufferSizeSource,
+        pixelRatio,
+        pixelRatio === undefined ? 'exact' : 'css-dpr'
+      );
     } else if ('useDevicePixels' in props && this._usesLegacyDrawingBufferSizing) {
       this.props.useDevicePixels = props.useDevicePixels ?? false;
-      const drawingBufferSizingProps = normalizeLegacyDrawingBufferSizingProps(this.props);
-      this._setDrawingBufferSizingProps(
-        drawingBufferSizingProps.drawingBufferSizingMode,
-        drawingBufferSizingProps.pixelRatio
+      const drawingBufferSizeProps = normalizeLegacyDrawingBufferSizeProps(this.props);
+      this._setDrawingBufferSizeProps(
+        drawingBufferSizeProps.drawingBufferSizeTracking,
+        drawingBufferSizeProps.drawingBufferSizeSource,
+        drawingBufferSizeProps.pixelRatio,
+        drawingBufferSizeProps.pixelSizeSource
       );
     }
     return this;
@@ -309,12 +332,12 @@ export abstract class CanvasSurface {
   }
 
   getDevicePixelSize(): [number, number] {
-    this._syncTrackedCanvasSize();
+    this._syncDrawingBufferSizeSource();
     return [this.devicePixelWidth, this.devicePixelHeight];
   }
 
   getDrawingBufferSize(): [number, number] {
-    this._syncTrackedCanvasSize();
+    this._syncDrawingBufferSizeSource();
     return [this.drawingBufferWidth, this.drawingBufferHeight];
   }
 
@@ -451,7 +474,11 @@ export abstract class CanvasSurface {
 
     const oldPixelSize = this.getDevicePixelSize();
 
-    this._setDevicePixelSize(this._getDevicePixelSizeFromResizeEntry(entry));
+    if (this.props.drawingBufferSizeTracking === 'external-canvas') {
+      this._syncDrawingBufferSizeSource();
+    } else {
+      this._setDevicePixelSize(this._getDevicePixelSizeFromResizeEntry(entry));
+    }
 
     this._updateDrawingBufferSize();
 
@@ -459,15 +486,17 @@ export abstract class CanvasSurface {
   }
 
   protected _updateDrawingBufferSize() {
-    switch (this.props.drawingBufferSizingMode) {
-      case 'manual':
+    switch (this.props.drawingBufferSizeTracking) {
+      case 'none':
+      case 'external-canvas':
         break;
-      case 'track-device-pixels':
-        this.setDrawingBufferSize(this.devicePixelWidth, this.devicePixelHeight);
-        break;
-      case 'track-css-pixels': {
-        const pixelRatio = this.props.pixelRatio ?? this.getDevicePixelRatio();
-        this.setDrawingBufferSize(this.cssWidth * pixelRatio, this.cssHeight * pixelRatio);
+      case 'canvas': {
+        if (this.props.pixelRatio === undefined && this._pixelSizeSource === 'exact') {
+          this.setDrawingBufferSize(this.devicePixelWidth, this.devicePixelHeight);
+        } else {
+          const pixelRatio = this.props.pixelRatio ?? this.getDevicePixelRatio();
+          this.setDrawingBufferSize(this.cssWidth * pixelRatio, this.cssHeight * pixelRatio);
+        }
         break;
       }
     }
@@ -481,7 +510,7 @@ export abstract class CanvasSurface {
   protected _getDevicePixelSizeFromResizeEntry(entry: ResizeObserverEntry): DevicePixelSize {
     const contentBoxSize = assertDefined(entry.contentBoxSize?.[0]);
 
-    if (this.props.drawingBufferSizingMode === 'track-css-pixels') {
+    if (this._pixelSizeSource === 'css-dpr') {
       return this._getDevicePixelSizeFromCSSSize(
         contentBoxSize.inlineSize,
         contentBoxSize.blockSize
@@ -512,20 +541,25 @@ export abstract class CanvasSurface {
     this.devicePixelHeight = Math.max(1, Math.min(devicePixelHeight, maxDevicePixelHeight));
   }
 
-  protected _setDrawingBufferSizingProps(
-    drawingBufferSizingMode: DrawingBufferSizingMode,
-    pixelRatio: number | undefined
+  protected _setDrawingBufferSizeProps(
+    drawingBufferSizeTracking: DrawingBufferSizeTracking,
+    drawingBufferSizeSource: HTMLCanvasElement | OffscreenCanvas | null | undefined,
+    pixelRatio: number | undefined,
+    pixelSizeSource: PixelSizeSource
   ): void {
-    validateDrawingBufferSizingProps(drawingBufferSizingMode, pixelRatio);
-    this.props.drawingBufferSizingMode = drawingBufferSizingMode;
+    validateDrawingBufferSizeProps(drawingBufferSizeTracking, drawingBufferSizeSource, pixelRatio);
+    this.props.drawingBufferSizeTracking = drawingBufferSizeTracking;
+    this.props.drawingBufferSizeSource = drawingBufferSizeSource ?? null;
     this.props.pixelRatio = pixelRatio!;
-    this._canvasObserver.setResizeObserverBox(getResizeObserverBox(drawingBufferSizingMode));
+    this._pixelSizeSource = pixelSizeSource;
+    this._canvasObserver.setResizeObserverBox(getResizeObserverBox(pixelSizeSource));
     this._setDevicePixelSize(this._getDevicePixelSizeFromCSSSize(this.cssWidth, this.cssHeight));
     this._updateDrawingBufferSize();
+    this._syncDrawingBufferSizeSource();
   }
 
   _resizeDrawingBufferIfNeeded() {
-    this._syncTrackedCanvasSize();
+    this._syncDrawingBufferSizeSource();
     if (this._needsDrawingBufferResize) {
       this._needsDrawingBufferResize = false;
       const sizeChanged =
@@ -546,8 +580,8 @@ export abstract class CanvasSurface {
     const oldRatio = this.devicePixelRatio;
     this.devicePixelRatio = window.devicePixelRatio;
 
-    if (this.props.drawingBufferSizingMode === 'track-css-pixels') {
-      // In track-css-pixels mode the ResizeObserver won't fire on a pure DPR change (CSS size
+    if (this._pixelSizeSource === 'css-dpr') {
+      // With content-box observation the ResizeObserver won't fire on a pure DPR change (CSS size
       // unchanged). Recalculate the drawing buffer from the new DPR here.
       const oldPixelSize = this.getDevicePixelSize();
       this._setDevicePixelSize(this._getDevicePixelSizeFromCSSSize(this.cssWidth, this.cssHeight));
@@ -582,19 +616,21 @@ export abstract class CanvasSurface {
     }
   }
 
-  /** Synchronizes drawing-buffer bookkeeping with a tracked source canvas without reading layout. */
-  protected _syncTrackedCanvasSize(): void {
-    const trackCanvas = this.props.trackCanvas;
-    if (!trackCanvas) {
+  /** Synchronizes drawing-buffer bookkeeping with an external source without reading layout. */
+  protected _syncDrawingBufferSizeSource(): void {
+    if (this.props.drawingBufferSizeTracking !== 'external-canvas') {
       return;
     }
+    const drawingBufferSizeSource = this.props.drawingBufferSizeSource;
+    // External-canvas tracking is validated to always have a source.
+    assert(drawingBufferSizeSource);
 
-    const width = trackCanvas.width;
-    const height = trackCanvas.height;
+    const width = drawingBufferSizeSource.width;
+    const height = drawingBufferSizeSource.height;
     this.devicePixelWidth = width;
     this.devicePixelHeight = height;
 
-    if (trackCanvas === this.canvas) {
+    if (drawingBufferSizeSource === this.canvas) {
       this.drawingBufferWidth = width;
       this.drawingBufferHeight = height;
       this._needsDrawingBufferResize = false;
@@ -609,72 +645,86 @@ export abstract class CanvasSurface {
   }
 }
 
-function normalizeDrawingBufferSizingProps(
+function normalizeDrawingBufferSizeProps(
   props: CanvasContextProps = {}
-): Required<Pick<CanvasContextProps, 'drawingBufferSizingMode' | 'pixelRatio'>> {
-  if (props.trackCanvas) {
-    validateTrackCanvasProps(props.trackCanvas, props.drawingBufferSizingMode, props.pixelRatio);
-    return {drawingBufferSizingMode: 'manual', pixelRatio: undefined!};
-  }
-  if (props.drawingBufferSizingMode !== undefined || props.pixelRatio !== undefined) {
-    // Supplying a fixed ratio requires explicitly opting into CSS-pixel tracking.
-    assert(props.drawingBufferSizingMode !== undefined);
-    validateDrawingBufferSizingProps(props.drawingBufferSizingMode, props.pixelRatio);
+): NormalizedDrawingBufferSizeProps {
+  if (
+    props.drawingBufferSizeTracking !== undefined ||
+    props.drawingBufferSizeSource !== undefined ||
+    props.pixelRatio !== undefined
+  ) {
+    // A source or fixed ratio requires an explicit tracking behavior.
+    assert(props.drawingBufferSizeTracking !== undefined);
+    validateDrawingBufferSizeProps(
+      props.drawingBufferSizeTracking,
+      props.drawingBufferSizeSource,
+      props.pixelRatio
+    );
     return {
-      drawingBufferSizingMode: props.drawingBufferSizingMode,
-      pixelRatio: props.pixelRatio!
+      drawingBufferSizeTracking: props.drawingBufferSizeTracking,
+      drawingBufferSizeSource: props.drawingBufferSizeSource ?? null,
+      pixelRatio: props.pixelRatio,
+      pixelSizeSource: props.pixelRatio === undefined ? 'exact' : 'css-dpr'
     };
   }
-  return normalizeLegacyDrawingBufferSizingProps(props);
+  return normalizeLegacyDrawingBufferSizeProps(props);
 }
 
-function validateTrackCanvasProps(
-  trackCanvas: HTMLCanvasElement | OffscreenCanvas,
-  drawingBufferSizingMode: DrawingBufferSizingMode | undefined,
-  pixelRatio: number | undefined
-): void {
-  // Tracking a source canvas owns sizing and is only compatible with manual observation.
-  assert(trackCanvas && (!drawingBufferSizingMode || drawingBufferSizingMode === 'manual'));
-  // A pixel ratio would conflict with the tracked canvas's authoritative dimensions.
-  assert(pixelRatio === undefined);
-}
-
-function normalizeLegacyDrawingBufferSizingProps(
+function normalizeLegacyDrawingBufferSizeProps(
   props: Pick<CanvasContextProps, 'autoResize' | 'useDevicePixels' | 'pixelSizeSource'>
-): Required<Pick<CanvasContextProps, 'drawingBufferSizingMode' | 'pixelRatio'>> {
+): NormalizedDrawingBufferSizeProps {
   if (props.autoResize === false) {
-    return {drawingBufferSizingMode: 'manual', pixelRatio: undefined!};
+    return {
+      drawingBufferSizeTracking: 'none',
+      drawingBufferSizeSource: null,
+      pixelRatio: undefined,
+      pixelSizeSource: 'exact'
+    };
   }
   if (typeof props.useDevicePixels === 'number') {
-    validateDrawingBufferSizingProps('track-css-pixels', props.useDevicePixels);
-    return {drawingBufferSizingMode: 'track-css-pixels', pixelRatio: props.useDevicePixels};
+    validateDrawingBufferSizeProps('canvas', null, props.useDevicePixels);
+    return {
+      drawingBufferSizeTracking: 'canvas',
+      drawingBufferSizeSource: null,
+      pixelRatio: props.useDevicePixels,
+      pixelSizeSource: 'css-dpr'
+    };
   }
   if (props.useDevicePixels === false) {
-    return {drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 1};
+    return {
+      drawingBufferSizeTracking: 'canvas',
+      drawingBufferSizeSource: null,
+      pixelRatio: 1,
+      pixelSizeSource: 'css-dpr'
+    };
   }
   return {
-    drawingBufferSizingMode:
-      props.pixelSizeSource === 'css-dpr' ? 'track-css-pixels' : 'track-device-pixels',
-    pixelRatio: undefined!
+    drawingBufferSizeTracking: 'canvas',
+    drawingBufferSizeSource: null,
+    pixelRatio: undefined,
+    pixelSizeSource: props.pixelSizeSource === 'css-dpr' ? 'css-dpr' : 'exact'
   };
 }
 
-function validateDrawingBufferSizingProps(
-  drawingBufferSizingMode: DrawingBufferSizingMode,
+function validateDrawingBufferSizeProps(
+  drawingBufferSizeTracking: DrawingBufferSizeTracking,
+  drawingBufferSizeSource: HTMLCanvasElement | OffscreenCanvas | null | undefined,
   pixelRatio: number | undefined
 ): void {
-  // Fixed pixel ratios are only defined for CSS-pixel tracking.
-  assert(pixelRatio === undefined || drawingBufferSizingMode === 'track-css-pixels');
+  // External tracking requires exactly one authoritative size source.
+  assert(
+    drawingBufferSizeTracking === 'external-canvas'
+      ? Boolean(drawingBufferSizeSource)
+      : !drawingBufferSizeSource
+  );
+  // Fixed pixel ratios are only defined when deriving size from the target canvas.
+  assert(pixelRatio === undefined || drawingBufferSizeTracking === 'canvas');
   // Drawing buffer dimensions require a positive finite scale.
   assert(pixelRatio === undefined || (Number.isFinite(pixelRatio) && pixelRatio > 0));
 }
 
-function getResizeObserverBox(
-  drawingBufferSizingMode: DrawingBufferSizingMode
-): ResizeObserverBoxOptions {
-  return drawingBufferSizingMode === 'track-css-pixels'
-    ? 'content-box'
-    : 'device-pixel-content-box';
+function getResizeObserverBox(pixelSizeSource: PixelSizeSource): ResizeObserverBoxOptions {
+  return pixelSizeSource === 'css-dpr' ? 'content-box' : 'device-pixel-content-box';
 }
 
 function getContainer(container: HTMLElement | string | null): HTMLElement {

--- a/modules/core/src/adapter/canvas-surface.ts
+++ b/modules/core/src/adapter/canvas-surface.ts
@@ -11,7 +11,10 @@ import type {Framebuffer} from './resources/framebuffer';
 import type {TextureFormatDepthStencil} from '../shadertypes/texture-types/texture-formats';
 import {uid} from '../utils/uid';
 import {withResolvers} from '../utils/promise-utils';
-import {assertDefined} from '../utils/assert';
+import {assert, assertDefined} from '../utils/assert';
+
+/** Selects how a canvas drawing buffer is resized. */
+export type DrawingBufferSizingMode = 'manual' | 'track-device-pixels' | 'track-css-pixels';
 
 /** Properties for a CanvasContext */
 export type CanvasContextProps = {
@@ -27,7 +30,15 @@ export type CanvasContextProps = {
   height?: number;
   /** Visibility (only used if new canvas is created). */
   visible?: boolean;
-  /** Whether to size the drawing buffer to the pixel size during auto resize. If a number is provided it is used as a static pixel ratio */
+  /** How luma.gl should resize the drawing buffer. */
+  drawingBufferSizingMode?: DrawingBufferSizingMode;
+  /** Fixed ratio applied to CSS dimensions. Only valid in `track-css-pixels` mode. */
+  pixelRatio?: number;
+  /**
+   * Whether to size the drawing buffer to the pixel size during auto resize. If a number is
+   * provided it is used as a static pixel ratio.
+   * @deprecated Use `drawingBufferSizingMode` and `pixelRatio`.
+   */
   useDevicePixels?: boolean | number;
   /**
    * How to derive the tracked device pixel size for HTML canvases when auto-resizing.
@@ -36,9 +47,13 @@ export type CanvasContextProps = {
    *   browser's exact physical pixel coverage.
    * - `'css-dpr'` uses `Math.floor(cssSize * devicePixelRatio)` to match overlays and external
    *   canvases that size their drawing buffer via implicit truncation (e.g. `canvas.width = css * dpr`).
+   * @deprecated Use `drawingBufferSizingMode`.
    */
   pixelSizeSource?: 'exact' | 'css-dpr';
-  /** Whether to track window resizes. */
+  /**
+   * Whether to track window resizes.
+   * @deprecated Use `drawingBufferSizingMode: 'manual'`.
+   */
   autoResize?: boolean;
   /** @see https://developer.mozilla.org/en-US/docs/Web/API/GPUCanvasContext/configure#alphamode */
   alphaMode?: 'opaque' | 'premultiplied';
@@ -53,7 +68,15 @@ export type CanvasContextProps = {
 };
 
 export type MutableCanvasContextProps = {
-  /** Whether to size the drawing buffer to the pixel size during auto resize. If a number is provided it is used as a static pixel ratio */
+  /** How luma.gl should resize the drawing buffer. */
+  drawingBufferSizingMode?: DrawingBufferSizingMode;
+  /** Fixed ratio applied to CSS dimensions. Only valid in `track-css-pixels` mode. */
+  pixelRatio?: number;
+  /**
+   * Whether to size the drawing buffer to the pixel size during auto resize. If a number is
+   * provided it is used as a static pixel ratio.
+   * @deprecated Use `drawingBufferSizingMode` and `pixelRatio`.
+   */
   useDevicePixels?: boolean | number;
 };
 
@@ -83,6 +106,8 @@ export abstract class CanvasSurface {
     canvas: null,
     width: 800,
     height: 600,
+    drawingBufferSizingMode: 'track-device-pixels',
+    pixelRatio: undefined!,
     useDevicePixels: true,
     pixelSizeSource: 'exact',
     autoResize: true,
@@ -126,9 +151,9 @@ export abstract class CanvasSurface {
   /** Exact height of canvas in physical pixels (tracked by a ResizeObserver) */
   devicePixelHeight: number;
 
-  /** Width of drawing buffer: automatically tracks this.pixelWidth if props.autoResize is true */
+  /** Width of the drawing buffer, maintained according to drawingBufferSizingMode. */
   drawingBufferWidth: number;
-  /** Height of drawing buffer: automatically tracks this.pixelHeight if props.autoResize is true */
+  /** Height of the drawing buffer, maintained according to drawingBufferSizingMode. */
   drawingBufferHeight: number;
 
   /** Resolves when the canvas is initialized, i.e. when the ResizeObserver has updated the pixel size */
@@ -138,6 +163,8 @@ export abstract class CanvasSurface {
   protected _position: [number, number] = [0, 0];
   /** Whether this canvas context has been destroyed */
   protected destroyed = false;
+  /** Whether deprecated sizing props still control the normalized sizing configuration. */
+  protected _usesLegacyDrawingBufferSizing: boolean;
   /** Whether the drawing buffer size needs to be resized (deferred resizing to avoid flicker) */
   protected _needsDrawingBufferResize: boolean = true;
 
@@ -148,7 +175,10 @@ export abstract class CanvasSurface {
   }
 
   constructor(props?: CanvasContextProps) {
-    this.props = {...CanvasSurface.defaultProps, ...props};
+    this._usesLegacyDrawingBufferSizing =
+      props?.drawingBufferSizingMode === undefined && props?.pixelRatio === undefined;
+    const drawingBufferSizingProps = normalizeDrawingBufferSizingProps(props);
+    this.props = {...CanvasSurface.defaultProps, ...props, ...drawingBufferSizingProps};
     props = this.props;
 
     this.initialized = this._initializedResolvers.promise;
@@ -187,8 +217,7 @@ export abstract class CanvasSurface {
     this._canvasObserver = new CanvasObserver({
       canvas: this.htmlCanvas,
       trackPosition: this.props.trackPosition,
-      resizeObserverBox:
-        this.props.pixelSizeSource === 'css-dpr' ? 'content-box' : 'device-pixel-content-box',
+      resizeObserverBox: getResizeObserverBox(this.props.drawingBufferSizingMode),
       onResize: entries => this._handleResize(entries),
       onIntersection: entries => this._handleIntersection(entries),
       onDevicePixelRatioChange: () => this._observeDevicePixelRatio(),
@@ -206,9 +235,29 @@ export abstract class CanvasSurface {
   }
 
   setProps(props: MutableCanvasContextProps): this {
-    if ('useDevicePixels' in props) {
-      this.props.useDevicePixels = props.useDevicePixels || false;
-      this._updateDrawingBufferSize();
+    const hasNewDrawingBufferSizingProps =
+      'drawingBufferSizingMode' in props || 'pixelRatio' in props;
+    if (hasNewDrawingBufferSizingProps) {
+      const previousUsesLegacyDrawingBufferSizing = this._usesLegacyDrawingBufferSizing;
+      const drawingBufferSizingMode =
+        props.drawingBufferSizingMode ?? this.props.drawingBufferSizingMode;
+      let pixelRatio = 'pixelRatio' in props ? props.pixelRatio : this.props.pixelRatio;
+      if (
+        'drawingBufferSizingMode' in props &&
+        (drawingBufferSizingMode !== 'track-css-pixels' || previousUsesLegacyDrawingBufferSizing)
+      ) {
+        pixelRatio = props.pixelRatio;
+      }
+      validateDrawingBufferSizingProps(drawingBufferSizingMode, pixelRatio);
+      this._usesLegacyDrawingBufferSizing = false;
+      this._setDrawingBufferSizingProps(drawingBufferSizingMode, pixelRatio);
+    } else if ('useDevicePixels' in props && this._usesLegacyDrawingBufferSizing) {
+      this.props.useDevicePixels = props.useDevicePixels ?? false;
+      const drawingBufferSizingProps = normalizeLegacyDrawingBufferSizingProps(this.props);
+      this._setDrawingBufferSizingProps(
+        drawingBufferSizingProps.drawingBufferSizingMode,
+        drawingBufferSizingProps.pixelRatio
+      );
     }
     return this;
   }
@@ -378,17 +427,16 @@ export abstract class CanvasSurface {
   }
 
   protected _updateDrawingBufferSize() {
-    if (this.props.autoResize) {
-      if (typeof this.props.useDevicePixels === 'number') {
-        const devicePixelRatio = this.props.useDevicePixels;
-        this.setDrawingBufferSize(
-          this.cssWidth * devicePixelRatio,
-          this.cssHeight * devicePixelRatio
-        );
-      } else if (this.props.useDevicePixels) {
+    switch (this.props.drawingBufferSizingMode) {
+      case 'manual':
+        break;
+      case 'track-device-pixels':
         this.setDrawingBufferSize(this.devicePixelWidth, this.devicePixelHeight);
-      } else {
-        this.setDrawingBufferSize(this.cssWidth, this.cssHeight);
+        break;
+      case 'track-css-pixels': {
+        const pixelRatio = this.props.pixelRatio ?? this.getDevicePixelRatio();
+        this.setDrawingBufferSize(this.cssWidth * pixelRatio, this.cssHeight * pixelRatio);
+        break;
       }
     }
 
@@ -401,7 +449,7 @@ export abstract class CanvasSurface {
   protected _getDevicePixelSizeFromResizeEntry(entry: ResizeObserverEntry): DevicePixelSize {
     const contentBoxSize = assertDefined(entry.contentBoxSize?.[0]);
 
-    if (this.props.pixelSizeSource === 'css-dpr') {
+    if (this.props.drawingBufferSizingMode === 'track-css-pixels') {
       return this._getDevicePixelSizeFromCSSSize(
         contentBoxSize.inlineSize,
         contentBoxSize.blockSize
@@ -432,6 +480,18 @@ export abstract class CanvasSurface {
     this.devicePixelHeight = Math.max(1, Math.min(devicePixelHeight, maxDevicePixelHeight));
   }
 
+  protected _setDrawingBufferSizingProps(
+    drawingBufferSizingMode: DrawingBufferSizingMode,
+    pixelRatio: number | undefined
+  ): void {
+    validateDrawingBufferSizingProps(drawingBufferSizingMode, pixelRatio);
+    this.props.drawingBufferSizingMode = drawingBufferSizingMode;
+    this.props.pixelRatio = pixelRatio!;
+    this._canvasObserver.setResizeObserverBox(getResizeObserverBox(drawingBufferSizingMode));
+    this._setDevicePixelSize(this._getDevicePixelSizeFromCSSSize(this.cssWidth, this.cssHeight));
+    this._updateDrawingBufferSize();
+  }
+
   _resizeDrawingBufferIfNeeded() {
     if (this._needsDrawingBufferResize) {
       this._needsDrawingBufferResize = false;
@@ -453,9 +513,9 @@ export abstract class CanvasSurface {
     const oldRatio = this.devicePixelRatio;
     this.devicePixelRatio = window.devicePixelRatio;
 
-    if (this.props.pixelSizeSource === 'css-dpr') {
-      // In css-dpr mode the ResizeObserver watches content-box, which won't fire on a pure DPR
-      // change (CSS size unchanged). Recalculate the drawing buffer from the new DPR here.
+    if (this.props.drawingBufferSizingMode === 'track-css-pixels') {
+      // In track-css-pixels mode the ResizeObserver won't fire on a pure DPR change (CSS size
+      // unchanged). Recalculate the drawing buffer from the new DPR here.
       const oldPixelSize = this.getDevicePixelSize();
       this._setDevicePixelSize(this._getDevicePixelSizeFromCSSSize(this.cssWidth, this.cssHeight));
       this._updateDrawingBufferSize();
@@ -488,6 +548,59 @@ export abstract class CanvasSurface {
       }
     }
   }
+}
+
+function normalizeDrawingBufferSizingProps(
+  props: CanvasContextProps = {}
+): Required<Pick<CanvasContextProps, 'drawingBufferSizingMode' | 'pixelRatio'>> {
+  if (props.drawingBufferSizingMode !== undefined || props.pixelRatio !== undefined) {
+    // Supplying a fixed ratio requires explicitly opting into CSS-pixel tracking.
+    assert(props.drawingBufferSizingMode !== undefined);
+    validateDrawingBufferSizingProps(props.drawingBufferSizingMode, props.pixelRatio);
+    return {
+      drawingBufferSizingMode: props.drawingBufferSizingMode,
+      pixelRatio: props.pixelRatio!
+    };
+  }
+  return normalizeLegacyDrawingBufferSizingProps(props);
+}
+
+function normalizeLegacyDrawingBufferSizingProps(
+  props: Pick<CanvasContextProps, 'autoResize' | 'useDevicePixels' | 'pixelSizeSource'>
+): Required<Pick<CanvasContextProps, 'drawingBufferSizingMode' | 'pixelRatio'>> {
+  if (props.autoResize === false) {
+    return {drawingBufferSizingMode: 'manual', pixelRatio: undefined!};
+  }
+  if (typeof props.useDevicePixels === 'number') {
+    validateDrawingBufferSizingProps('track-css-pixels', props.useDevicePixels);
+    return {drawingBufferSizingMode: 'track-css-pixels', pixelRatio: props.useDevicePixels};
+  }
+  if (props.useDevicePixels === false) {
+    return {drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 1};
+  }
+  return {
+    drawingBufferSizingMode:
+      props.pixelSizeSource === 'css-dpr' ? 'track-css-pixels' : 'track-device-pixels',
+    pixelRatio: undefined!
+  };
+}
+
+function validateDrawingBufferSizingProps(
+  drawingBufferSizingMode: DrawingBufferSizingMode,
+  pixelRatio: number | undefined
+): void {
+  // Fixed pixel ratios are only defined for CSS-pixel tracking.
+  assert(pixelRatio === undefined || drawingBufferSizingMode === 'track-css-pixels');
+  // Drawing buffer dimensions require a positive finite scale.
+  assert(pixelRatio === undefined || (Number.isFinite(pixelRatio) && pixelRatio > 0));
+}
+
+function getResizeObserverBox(
+  drawingBufferSizingMode: DrawingBufferSizingMode
+): ResizeObserverBoxOptions {
+  return drawingBufferSizingMode === 'track-css-pixels'
+    ? 'content-box'
+    : 'device-pixel-content-box';
 }
 
 function getContainer(container: HTMLElement | string | null): HTMLElement {

--- a/modules/core/src/adapter/canvas-surface.ts
+++ b/modules/core/src/adapter/canvas-surface.ts
@@ -13,7 +13,12 @@ import {uid} from '../utils/uid';
 import {withResolvers} from '../utils/promise-utils';
 import {assert, assertDefined} from '../utils/assert';
 
-/** Selects how a canvas drawing buffer is resized. */
+/**
+ * Selects how luma.gl sizes a canvas drawing buffer.
+ * - `manual`: the application or an attached context owns the size.
+ * - `track-device-pixels`: follow the canvas's exact physical pixel coverage when available.
+ * - `track-css-pixels`: multiply the canvas's CSS dimensions by `pixelRatio` or the browser DPR.
+ */
 export type DrawingBufferSizingMode = 'manual' | 'track-device-pixels' | 'track-css-pixels';
 
 /** Properties for a CanvasContext */
@@ -32,6 +37,11 @@ export type CanvasContextProps = {
   visible?: boolean;
   /** How luma.gl should resize the drawing buffer. */
   drawingBufferSizingMode?: DrawingBufferSizingMode;
+  /**
+   * Canvas whose drawing-buffer dimensions should be mirrored before each draw.
+   * When supplied, `drawingBufferSizingMode` defaults to `manual`.
+   */
+  trackCanvas?: HTMLCanvasElement | OffscreenCanvas | null;
   /** Fixed ratio applied to CSS dimensions. Only valid in `track-css-pixels` mode. */
   pixelRatio?: number;
   /**
@@ -70,6 +80,8 @@ export type CanvasContextProps = {
 export type MutableCanvasContextProps = {
   /** How luma.gl should resize the drawing buffer. */
   drawingBufferSizingMode?: DrawingBufferSizingMode;
+  /** Canvas whose drawing-buffer dimensions should be mirrored before each draw. */
+  trackCanvas?: HTMLCanvasElement | OffscreenCanvas | null;
   /** Fixed ratio applied to CSS dimensions. Only valid in `track-css-pixels` mode. */
   pixelRatio?: number;
   /**
@@ -107,6 +119,7 @@ export abstract class CanvasSurface {
     width: 800,
     height: 600,
     drawingBufferSizingMode: 'track-device-pixels',
+    trackCanvas: null,
     pixelRatio: undefined!,
     useDevicePixels: true,
     pixelSizeSource: 'exact',
@@ -176,7 +189,9 @@ export abstract class CanvasSurface {
 
   constructor(props?: CanvasContextProps) {
     this._usesLegacyDrawingBufferSizing =
-      props?.drawingBufferSizingMode === undefined && props?.pixelRatio === undefined;
+      !props?.trackCanvas &&
+      props?.drawingBufferSizingMode === undefined &&
+      props?.pixelRatio === undefined;
     const drawingBufferSizingProps = normalizeDrawingBufferSizingProps(props);
     this.props = {...CanvasSurface.defaultProps, ...props, ...drawingBufferSizingProps};
     props = this.props;
@@ -235,6 +250,21 @@ export abstract class CanvasSurface {
   }
 
   setProps(props: MutableCanvasContextProps): this {
+    const hasTrackCanvas = 'trackCanvas' in props;
+    const trackCanvas = hasTrackCanvas ? props.trackCanvas : this.props.trackCanvas;
+    if (trackCanvas) {
+      validateTrackCanvasProps(trackCanvas, props.drawingBufferSizingMode, props.pixelRatio);
+      this.props.trackCanvas = trackCanvas;
+      this._usesLegacyDrawingBufferSizing = false;
+      this._setDrawingBufferSizingProps('manual', undefined);
+      this._syncTrackedCanvasSize();
+      return this;
+    }
+    if (hasTrackCanvas) {
+      this.props.trackCanvas = trackCanvas!;
+      this._usesLegacyDrawingBufferSizing = false;
+    }
+
     const hasNewDrawingBufferSizingProps =
       'drawingBufferSizingMode' in props || 'pixelRatio' in props;
     if (hasNewDrawingBufferSizingProps) {
@@ -279,10 +309,12 @@ export abstract class CanvasSurface {
   }
 
   getDevicePixelSize(): [number, number] {
+    this._syncTrackedCanvasSize();
     return [this.devicePixelWidth, this.devicePixelHeight];
   }
 
   getDrawingBufferSize(): [number, number] {
+    this._syncTrackedCanvasSize();
     return [this.drawingBufferWidth, this.drawingBufferHeight];
   }
 
@@ -493,6 +525,7 @@ export abstract class CanvasSurface {
   }
 
   _resizeDrawingBufferIfNeeded() {
+    this._syncTrackedCanvasSize();
     if (this._needsDrawingBufferResize) {
       this._needsDrawingBufferResize = false;
       const sizeChanged =
@@ -548,11 +581,41 @@ export abstract class CanvasSurface {
       }
     }
   }
+
+  /** Synchronizes drawing-buffer bookkeeping with a tracked source canvas without reading layout. */
+  protected _syncTrackedCanvasSize(): void {
+    const trackCanvas = this.props.trackCanvas;
+    if (!trackCanvas) {
+      return;
+    }
+
+    const width = trackCanvas.width;
+    const height = trackCanvas.height;
+    this.devicePixelWidth = width;
+    this.devicePixelHeight = height;
+
+    if (trackCanvas === this.canvas) {
+      this.drawingBufferWidth = width;
+      this.drawingBufferHeight = height;
+      this._needsDrawingBufferResize = false;
+    } else if (
+      width !== this.drawingBufferWidth ||
+      height !== this.drawingBufferHeight ||
+      width !== this.canvas.width ||
+      height !== this.canvas.height
+    ) {
+      this.setDrawingBufferSize(width, height);
+    }
+  }
 }
 
 function normalizeDrawingBufferSizingProps(
   props: CanvasContextProps = {}
 ): Required<Pick<CanvasContextProps, 'drawingBufferSizingMode' | 'pixelRatio'>> {
+  if (props.trackCanvas) {
+    validateTrackCanvasProps(props.trackCanvas, props.drawingBufferSizingMode, props.pixelRatio);
+    return {drawingBufferSizingMode: 'manual', pixelRatio: undefined!};
+  }
   if (props.drawingBufferSizingMode !== undefined || props.pixelRatio !== undefined) {
     // Supplying a fixed ratio requires explicitly opting into CSS-pixel tracking.
     assert(props.drawingBufferSizingMode !== undefined);
@@ -563,6 +626,17 @@ function normalizeDrawingBufferSizingProps(
     };
   }
   return normalizeLegacyDrawingBufferSizingProps(props);
+}
+
+function validateTrackCanvasProps(
+  trackCanvas: HTMLCanvasElement | OffscreenCanvas,
+  drawingBufferSizingMode: DrawingBufferSizingMode | undefined,
+  pixelRatio: number | undefined
+): void {
+  // Tracking a source canvas owns sizing and is only compatible with manual observation.
+  assert(trackCanvas && (!drawingBufferSizingMode || drawingBufferSizingMode === 'manual'));
+  // A pixel ratio would conflict with the tracked canvas's authoritative dimensions.
+  assert(pixelRatio === undefined);
 }
 
 function normalizeLegacyDrawingBufferSizingProps(

--- a/modules/core/src/adapter/canvas-surface.ts
+++ b/modules/core/src/adapter/canvas-surface.ts
@@ -303,7 +303,8 @@ export abstract class CanvasSurface {
         pixelRatio === undefined ? 'exact' : 'css-dpr'
       );
     } else if ('useDevicePixels' in props && this._usesLegacyDrawingBufferSizing) {
-      this.props.useDevicePixels = props.useDevicePixels ?? false;
+      // Preserve the legacy setter's falsy-value normalization (notably numeric `0`).
+      this.props.useDevicePixels = props.useDevicePixels || false;
       const drawingBufferSizeProps = normalizeLegacyDrawingBufferSizeProps(this.props);
       this._setDrawingBufferSizeProps(
         drawingBufferSizeProps.drawingBufferSizeTracking,

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -362,8 +362,14 @@ export type DeviceTextureFormatCapabilities = {
 export type DeviceProps = {
   /** string id for debugging. Stored on the object, used in logging and set on underlying GPU objects when feasible. */
   id?: string;
-  /** Properties for creating a default canvas context */
-  createCanvasContext?: CanvasContextProps | true;
+  /**
+   * Whether to create a default canvas context.
+   * Supplying a `CanvasContextProps` object is deprecated; set this to `true` and use
+   * `canvasContextProps` instead.
+   */
+  createCanvasContext?: CanvasContextProps | boolean;
+  /** Properties for creating or attaching the default canvas context. */
+  canvasContextProps?: CanvasContextProps;
   /** Control which type of GPU is preferred on systems with both integrated and discrete GPU. Defaults to "high-performance" / discrete GPU. */
   powerPreference?: 'default' | 'high-performance' | 'low-power';
   /** Hints that device creation should fail if no hardware GPU is available (if the system performance is "low"). */
@@ -493,6 +499,7 @@ export abstract class Device {
     failIfMajorPerformanceCaveat: false,
     featureLevel: undefined!,
     createCanvasContext: undefined!,
+    canvasContextProps: undefined!,
     // WebGL specific
     webgl: {},
 
@@ -1044,7 +1051,12 @@ or create a device with the 'debug: true' prop.`;
 
   /** Helper to get the canvas context props */
   static _getCanvasContextProps(props: DeviceProps): CanvasContextProps | undefined {
-    return props.createCanvasContext === true ? {} : props.createCanvasContext;
+    if (!props.createCanvasContext) {
+      return undefined;
+    }
+    const legacyCanvasContextProps =
+      props.createCanvasContext === true ? {} : props.createCanvasContext;
+    return {...legacyCanvasContextProps, ...props.canvasContextProps};
   }
 
   protected _getDeviceTextureFormatCapabilities(

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -20,7 +20,11 @@ export type {
 } from './adapter/device';
 export {Device, DeviceFeatures, DeviceLimits, isHTMLInCanvasSupported} from './adapter/device';
 
-export type {CanvasContextProps} from './adapter/canvas-context';
+export type {
+  CanvasContextProps,
+  DrawingBufferSizingMode,
+  MutableCanvasContextProps
+} from './adapter/canvas-context';
 export {CanvasContext} from './adapter/canvas-context';
 export type {PresentationContextProps} from './adapter/presentation-context';
 export {PresentationContext} from './adapter/presentation-context';

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -22,7 +22,7 @@ export {Device, DeviceFeatures, DeviceLimits, isHTMLInCanvasSupported} from './a
 
 export type {
   CanvasContextProps,
-  DrawingBufferSizingMode,
+  DrawingBufferSizeTracking,
   MutableCanvasContextProps
 } from './adapter/canvas-context';
 export {CanvasContext} from './adapter/canvas-context';

--- a/modules/core/test/adapter/canvas-context.spec.ts
+++ b/modules/core/test/adapter/canvas-context.spec.ts
@@ -360,6 +360,282 @@ test('CanvasContext#_handleResize keeps numeric useDevicePixels override across 
   t.end();
 });
 
+test('CanvasContext#drawingBufferSizingMode supports explicit automatic and manual sizing', t => {
+  if (!isBrowser()) {
+    t.end();
+    return;
+  }
+
+  const exactCanvasContext = new TestCanvasContext(
+    {drawingBufferSizingMode: 'track-device-pixels'},
+    false
+  );
+  (exactCanvasContext as any)._handleResize([
+    {
+      target: exactCanvasContext.canvas,
+      contentBoxSize: [{inlineSize: 100.4, blockSize: 50.4}],
+      devicePixelContentBoxSize: [{inlineSize: 151, blockSize: 76}]
+    }
+  ]);
+  t.deepEqual(
+    exactCanvasContext.getDrawingBufferSize(),
+    [151, 76],
+    'track-device-pixels mode uses exact physical dimensions'
+  );
+
+  const fallbackCanvasContext = new TestCanvasContext(
+    {drawingBufferSizingMode: 'track-device-pixels'},
+    false
+  );
+  (fallbackCanvasContext as any)._handleResize([
+    {
+      target: fallbackCanvasContext.canvas,
+      contentBoxSize: [{inlineSize: 100.4, blockSize: 50.4}]
+    }
+  ]);
+  t.deepEqual(
+    fallbackCanvasContext.getDrawingBufferSize(),
+    [Math.floor(100.4 * window.devicePixelRatio), Math.floor(50.4 * window.devicePixelRatio)],
+    'track-device-pixels falls back to CSS dimensions times browser DPR'
+  );
+
+  const contentBoxCanvasContext = new TestCanvasContext(
+    {drawingBufferSizingMode: 'track-css-pixels'},
+    false
+  );
+  contentBoxCanvasContext.getDevicePixelRatio = () => 1.5;
+  (contentBoxCanvasContext as any)._handleResize([
+    {
+      target: contentBoxCanvasContext.canvas,
+      contentBoxSize: [{inlineSize: 100.4, blockSize: 50.4}],
+      devicePixelContentBoxSize: [{inlineSize: 151, blockSize: 76}]
+    }
+  ]);
+  t.deepEqual(
+    contentBoxCanvasContext.getDrawingBufferSize(),
+    [150, 75],
+    'track-css-pixels mode uses CSS dimensions times browser DPR'
+  );
+
+  const fixedRatioCanvasContext = new TestCanvasContext(
+    {drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 1},
+    false
+  );
+  fixedRatioCanvasContext.getDevicePixelRatio = () => 2;
+  (fixedRatioCanvasContext as any)._handleResize([
+    {
+      target: fixedRatioCanvasContext.canvas,
+      contentBoxSize: [{inlineSize: 100.4, blockSize: 50.4}]
+    }
+  ]);
+  t.deepEqual(
+    fixedRatioCanvasContext.getDrawingBufferSize(),
+    [100, 50],
+    'pixelRatio overrides browser DPR in track-css-pixels mode'
+  );
+
+  const manualCanvasContext = new TestCanvasContext({drawingBufferSizingMode: 'manual'}, false);
+  const {calls, device} = createCanvasContextSpyDevice();
+  // @ts-expect-error read only
+  manualCanvasContext.device = device;
+  const originalDrawingBufferSize = manualCanvasContext.getDrawingBufferSize();
+  (manualCanvasContext as any)._handleResize([
+    {
+      target: manualCanvasContext.canvas,
+      contentBoxSize: [{inlineSize: 100, blockSize: 50}],
+      devicePixelContentBoxSize: [{inlineSize: 200, blockSize: 100}]
+    }
+  ]);
+  t.deepEqual(
+    manualCanvasContext.getDrawingBufferSize(),
+    originalDrawingBufferSize,
+    'manual mode observes resize without changing the drawing buffer'
+  );
+  t.equal(calls.onResize, 1, 'manual mode continues to emit resize callbacks');
+
+  t.end();
+});
+
+test('CanvasContext#setProps updates drawing buffer sizing and observer mode', t => {
+  if (!isBrowser()) {
+    t.end();
+    return;
+  }
+
+  const canvasContext = new TestCanvasContext(
+    {drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 1},
+    false
+  );
+  canvasContext.getDevicePixelRatio = () => 1.5;
+  (canvasContext as any)._handleResize([
+    {
+      target: canvasContext.canvas,
+      contentBoxSize: [{inlineSize: 100, blockSize: 50}]
+    }
+  ]);
+
+  canvasContext.setProps({pixelRatio: 2});
+  t.deepEqual(
+    canvasContext.getDrawingBufferSize(),
+    [200, 100],
+    'dynamic fixed ratio is applied immediately'
+  );
+
+  canvasContext.setProps({pixelRatio: undefined});
+  t.deepEqual(
+    canvasContext.getDrawingBufferSize(),
+    [150, 75],
+    'clearing the fixed ratio resumes browser DPR'
+  );
+
+  canvasContext.setProps({drawingBufferSizingMode: 'track-device-pixels'});
+  t.equal(
+    (canvasContext as any)._canvasObserver.props.resizeObserverBox,
+    'device-pixel-content-box',
+    'switching mode reconfigures the observer box'
+  );
+  (canvasContext as any)._handleResize([
+    {
+      target: canvasContext.canvas,
+      contentBoxSize: [{inlineSize: 100, blockSize: 50}],
+      devicePixelContentBoxSize: [{inlineSize: 151, blockSize: 76}]
+    }
+  ]);
+  t.deepEqual(
+    canvasContext.getDrawingBufferSize(),
+    [151, 76],
+    'exact observer dimensions are used after switching mode'
+  );
+
+  canvasContext.setProps({drawingBufferSizingMode: 'manual'});
+  (canvasContext as any)._handleResize([
+    {
+      target: canvasContext.canvas,
+      contentBoxSize: [{inlineSize: 200, blockSize: 100}],
+      devicePixelContentBoxSize: [{inlineSize: 300, blockSize: 150}]
+    }
+  ]);
+  t.deepEqual(
+    canvasContext.getDrawingBufferSize(),
+    [151, 76],
+    'switching to manual mode stops automatic drawing buffer changes'
+  );
+
+  t.end();
+});
+
+test('CanvasContext#new drawing buffer sizing props override and validate legacy props', t => {
+  if (!isBrowser()) {
+    t.end();
+    return;
+  }
+
+  const legacyCSSCanvasContext = new TestCanvasContext({useDevicePixels: false}, false);
+  t.equal(
+    legacyCSSCanvasContext.props.drawingBufferSizingMode,
+    'track-css-pixels',
+    'legacy false normalizes to track-css-pixels mode'
+  );
+  t.equal(legacyCSSCanvasContext.props.pixelRatio, 1, 'legacy false normalizes to ratio 1');
+
+  const legacyNumericCanvasContext = new TestCanvasContext({useDevicePixels: 1.5}, false);
+  t.equal(
+    legacyNumericCanvasContext.props.drawingBufferSizingMode,
+    'track-css-pixels',
+    'legacy numeric ratio normalizes to track-css-pixels mode'
+  );
+  t.equal(legacyNumericCanvasContext.props.pixelRatio, 1.5, 'legacy numeric ratio is preserved');
+
+  const legacyExactCanvasContext = new TestCanvasContext(
+    {useDevicePixels: true, pixelSizeSource: 'exact'},
+    false
+  );
+  t.equal(
+    legacyExactCanvasContext.props.drawingBufferSizingMode,
+    'track-device-pixels',
+    'legacy exact sizing normalizes to track-device-pixels mode'
+  );
+
+  const legacyCSSDPRCanvasContext = new TestCanvasContext(
+    {useDevicePixels: true, pixelSizeSource: 'css-dpr'},
+    false
+  );
+  t.equal(
+    legacyCSSDPRCanvasContext.props.drawingBufferSizingMode,
+    'track-css-pixels',
+    'legacy CSS-DPR sizing normalizes to track-css-pixels mode'
+  );
+  t.equal(
+    legacyCSSDPRCanvasContext.props.pixelRatio,
+    undefined,
+    'legacy CSS-DPR sizing continues tracking the browser DPR'
+  );
+
+  const legacyManualCanvasContext = new TestCanvasContext({autoResize: false}, false);
+  t.equal(
+    legacyManualCanvasContext.props.drawingBufferSizingMode,
+    'manual',
+    'legacy autoResize false normalizes to manual mode'
+  );
+
+  const newCanvasContext = new TestCanvasContext(
+    {
+      drawingBufferSizingMode: 'track-css-pixels',
+      autoResize: false,
+      useDevicePixels: false,
+      pixelSizeSource: 'exact'
+    },
+    false
+  );
+  newCanvasContext.getDevicePixelRatio = () => 2;
+  (newCanvasContext as any)._handleResize([
+    {
+      target: newCanvasContext.canvas,
+      contentBoxSize: [{inlineSize: 100, blockSize: 50}]
+    }
+  ]);
+  t.deepEqual(
+    newCanvasContext.getDrawingBufferSize(),
+    [200, 100],
+    'new track-css-pixels mode ignores conflicting legacy sizing props'
+  );
+  newCanvasContext.setProps({useDevicePixels: 1});
+  t.equal(
+    newCanvasContext.props.pixelRatio,
+    undefined,
+    'legacy updates are ignored after selecting the new sizing API'
+  );
+
+  t.throws(
+    () =>
+      new TestCanvasContext({drawingBufferSizingMode: 'track-device-pixels', pixelRatio: 2}, false),
+    /assertion failed/,
+    'pixelRatio is rejected outside track-css-pixels mode'
+  );
+  t.throws(
+    () =>
+      new TestCanvasContext({drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 0}, false),
+    /assertion failed/,
+    'non-positive pixelRatio is rejected'
+  );
+  t.throws(
+    () =>
+      new TestCanvasContext(
+        {drawingBufferSizingMode: 'track-css-pixels', pixelRatio: Infinity},
+        false
+      ),
+    /assertion failed/,
+    'non-finite pixelRatio is rejected'
+  );
+  t.throws(
+    () => new TestCanvasContext({useDevicePixels: 0}, false),
+    /assertion failed/,
+    'invalid legacy numeric ratio is rejected'
+  );
+
+  t.end();
+});
+
 test('CanvasContext#_observeDevicePixelRatio recalculates drawing buffer in css-dpr mode', t => {
   if (!isBrowser()) {
     t.end();

--- a/modules/core/test/adapter/canvas-context.spec.ts
+++ b/modules/core/test/adapter/canvas-context.spec.ts
@@ -11,6 +11,7 @@ import {getTestDevices, getWebGLTestDevice} from '@luma.gl/test-utils';
 /** Mock CanvasContext */
 class TestCanvasContext extends CanvasContext {
   handle = null;
+  configureCalls = 0;
   [Symbol.toStringTag] = 'TestCanvasContext';
   // @ts-expect-error
   readonly device = {
@@ -32,7 +33,7 @@ class TestCanvasContext extends CanvasContext {
     throw new Error('test');
   }
   protected override _configureDevice(): void {
-    // Mock update device
+    this.configureCalls++;
   }
 }
 
@@ -456,6 +457,87 @@ test('CanvasContext#drawingBufferSizingMode supports explicit automatic and manu
   t.end();
 });
 
+test('CanvasContext#trackCanvas mirrors source dimensions before drawing', t => {
+  if (!isBrowser()) {
+    t.end();
+    return;
+  }
+
+  const sourceCanvas = document.createElement('canvas');
+  sourceCanvas.width = 320;
+  sourceCanvas.height = 180;
+  const canvasContext = new TestCanvasContext({trackCanvas: sourceCanvas}, false);
+
+  t.equal(
+    canvasContext.props.drawingBufferSizingMode,
+    'manual',
+    'tracking a canvas selects manual observer sizing'
+  );
+  t.deepEqual(
+    canvasContext.getDrawingBufferSize(),
+    [320, 180],
+    'tracked dimensions are exposed without waiting for an observer callback'
+  );
+  t.deepEqual(
+    canvasContext.getDevicePixelSize(),
+    [320, 180],
+    'tracked dimensions are authoritative for device-pixel consumers'
+  );
+
+  sourceCanvas.width = 640;
+  sourceCanvas.height = 360;
+  t.throws(
+    () => canvasContext.getCurrentFramebuffer(),
+    /test/,
+    'framebuffer acquisition continues after synchronizing the tracked canvas'
+  );
+  t.deepEqual(
+    [canvasContext.canvas.width, canvasContext.canvas.height],
+    [640, 360],
+    'tracked dimensions are applied immediately before drawing'
+  );
+  t.equal(canvasContext.configureCalls, 1, 'the target is configured once for a changed size');
+  t.throws(() => canvasContext.getCurrentFramebuffer(), /test/, 'the next draw still proceeds');
+  t.equal(
+    canvasContext.configureCalls,
+    1,
+    'unchanged tracked dimensions do not reconfigure the target'
+  );
+
+  const attachedCanvas = document.createElement('canvas');
+  const attachedCanvasContext = new TestCanvasContext(
+    {canvas: attachedCanvas, trackCanvas: attachedCanvas},
+    false
+  );
+  attachedCanvas.width = 512;
+  attachedCanvas.height = 256;
+  t.deepEqual(
+    attachedCanvasContext.getDrawingBufferSize(),
+    [512, 256],
+    'tracking the target itself follows externally owned drawing-buffer changes'
+  );
+
+  t.throws(
+    () =>
+      new TestCanvasContext(
+        {
+          trackCanvas: sourceCanvas,
+          drawingBufferSizingMode: 'track-css-pixels'
+        },
+        false
+      ),
+    /assertion failed/,
+    'trackCanvas rejects conflicting automatic sizing'
+  );
+  t.throws(
+    () => new TestCanvasContext({trackCanvas: sourceCanvas, pixelRatio: 2}, false),
+    /assertion failed/,
+    'trackCanvas rejects a conflicting pixel ratio'
+  );
+
+  t.end();
+});
+
 test('CanvasContext#setProps updates drawing buffer sizing and observer mode', t => {
   if (!isBrowser()) {
     t.end();
@@ -519,6 +601,28 @@ test('CanvasContext#setProps updates drawing buffer sizing and observer mode', t
     canvasContext.getDrawingBufferSize(),
     [151, 76],
     'switching to manual mode stops automatic drawing buffer changes'
+  );
+
+  const sourceCanvas = document.createElement('canvas');
+  sourceCanvas.width = 240;
+  sourceCanvas.height = 120;
+  canvasContext.setProps({trackCanvas: sourceCanvas});
+  t.deepEqual(
+    canvasContext.getDrawingBufferSize(),
+    [240, 120],
+    'trackCanvas can take ownership dynamically'
+  );
+
+  canvasContext.setProps({
+    trackCanvas: null,
+    drawingBufferSizingMode: 'track-css-pixels',
+    pixelRatio: 1
+  });
+  t.equal(canvasContext.props.trackCanvas, null, 'tracked canvas can be cleared dynamically');
+  t.equal(
+    canvasContext.props.drawingBufferSizingMode,
+    'track-css-pixels',
+    'automatic sizing can resume when trackCanvas is cleared'
   );
 
   t.end();

--- a/modules/core/test/adapter/canvas-context.spec.ts
+++ b/modules/core/test/adapter/canvas-context.spec.ts
@@ -691,6 +691,18 @@ test('CanvasContext#new drawing buffer sizing props override and validate legacy
     'legacy autoResize false normalizes to no tracking'
   );
 
+  legacyNumericCanvasContext.setProps({useDevicePixels: 0});
+  t.equal(
+    legacyNumericCanvasContext.props.useDevicePixels,
+    false,
+    'legacy setProps preserves falsy numeric normalization'
+  );
+  t.equal(
+    legacyNumericCanvasContext.props.pixelRatio,
+    1,
+    'legacy setProps treats a falsy numeric ratio as non-device-pixel sizing'
+  );
+
   const newCanvasContext = new TestCanvasContext(
     {
       drawingBufferSizeTracking: 'canvas',

--- a/modules/core/test/adapter/canvas-context.spec.ts
+++ b/modules/core/test/adapter/canvas-context.spec.ts
@@ -361,16 +361,13 @@ test('CanvasContext#_handleResize keeps numeric useDevicePixels override across 
   t.end();
 });
 
-test('CanvasContext#drawingBufferSizingMode supports explicit automatic and manual sizing', t => {
+test('CanvasContext#drawingBufferSizeTracking supports canvas, external, and no tracking', t => {
   if (!isBrowser()) {
     t.end();
     return;
   }
 
-  const exactCanvasContext = new TestCanvasContext(
-    {drawingBufferSizingMode: 'track-device-pixels'},
-    false
-  );
+  const exactCanvasContext = new TestCanvasContext({drawingBufferSizeTracking: 'canvas'}, false);
   (exactCanvasContext as any)._handleResize([
     {
       target: exactCanvasContext.canvas,
@@ -381,13 +378,10 @@ test('CanvasContext#drawingBufferSizingMode supports explicit automatic and manu
   t.deepEqual(
     exactCanvasContext.getDrawingBufferSize(),
     [151, 76],
-    'track-device-pixels mode uses exact physical dimensions'
+    'canvas tracking uses exact physical dimensions when available'
   );
 
-  const fallbackCanvasContext = new TestCanvasContext(
-    {drawingBufferSizingMode: 'track-device-pixels'},
-    false
-  );
+  const fallbackCanvasContext = new TestCanvasContext({drawingBufferSizeTracking: 'canvas'}, false);
   (fallbackCanvasContext as any)._handleResize([
     {
       target: fallbackCanvasContext.canvas,
@@ -397,29 +391,11 @@ test('CanvasContext#drawingBufferSizingMode supports explicit automatic and manu
   t.deepEqual(
     fallbackCanvasContext.getDrawingBufferSize(),
     [Math.floor(100.4 * window.devicePixelRatio), Math.floor(50.4 * window.devicePixelRatio)],
-    'track-device-pixels falls back to CSS dimensions times browser DPR'
-  );
-
-  const contentBoxCanvasContext = new TestCanvasContext(
-    {drawingBufferSizingMode: 'track-css-pixels'},
-    false
-  );
-  contentBoxCanvasContext.getDevicePixelRatio = () => 1.5;
-  (contentBoxCanvasContext as any)._handleResize([
-    {
-      target: contentBoxCanvasContext.canvas,
-      contentBoxSize: [{inlineSize: 100.4, blockSize: 50.4}],
-      devicePixelContentBoxSize: [{inlineSize: 151, blockSize: 76}]
-    }
-  ]);
-  t.deepEqual(
-    contentBoxCanvasContext.getDrawingBufferSize(),
-    [150, 75],
-    'track-css-pixels mode uses CSS dimensions times browser DPR'
+    'canvas tracking falls back to CSS dimensions times browser DPR'
   );
 
   const fixedRatioCanvasContext = new TestCanvasContext(
-    {drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 1},
+    {drawingBufferSizeTracking: 'canvas', pixelRatio: 1},
     false
   );
   fixedRatioCanvasContext.getDevicePixelRatio = () => 2;
@@ -432,10 +408,10 @@ test('CanvasContext#drawingBufferSizingMode supports explicit automatic and manu
   t.deepEqual(
     fixedRatioCanvasContext.getDrawingBufferSize(),
     [100, 50],
-    'pixelRatio overrides browser DPR in track-css-pixels mode'
+    'pixelRatio overrides browser DPR in canvas tracking mode'
   );
 
-  const manualCanvasContext = new TestCanvasContext({drawingBufferSizingMode: 'manual'}, false);
+  const manualCanvasContext = new TestCanvasContext({drawingBufferSizeTracking: 'none'}, false);
   const {calls, device} = createCanvasContextSpyDevice();
   // @ts-expect-error read only
   manualCanvasContext.device = device;
@@ -457,7 +433,7 @@ test('CanvasContext#drawingBufferSizingMode supports explicit automatic and manu
   t.end();
 });
 
-test('CanvasContext#trackCanvas mirrors source dimensions before drawing', t => {
+test('CanvasContext#external-canvas tracking mirrors source dimensions before drawing', t => {
   if (!isBrowser()) {
     t.end();
     return;
@@ -466,12 +442,18 @@ test('CanvasContext#trackCanvas mirrors source dimensions before drawing', t => 
   const sourceCanvas = document.createElement('canvas');
   sourceCanvas.width = 320;
   sourceCanvas.height = 180;
-  const canvasContext = new TestCanvasContext({trackCanvas: sourceCanvas}, false);
+  const canvasContext = new TestCanvasContext(
+    {
+      drawingBufferSizeTracking: 'external-canvas',
+      drawingBufferSizeSource: sourceCanvas
+    },
+    false
+  );
 
   t.equal(
-    canvasContext.props.drawingBufferSizingMode,
-    'manual',
-    'tracking a canvas selects manual observer sizing'
+    canvasContext.props.drawingBufferSizeTracking,
+    'external-canvas',
+    'external canvas tracking is explicit'
   );
   t.deepEqual(
     canvasContext.getDrawingBufferSize(),
@@ -506,7 +488,11 @@ test('CanvasContext#trackCanvas mirrors source dimensions before drawing', t => 
 
   const attachedCanvas = document.createElement('canvas');
   const attachedCanvasContext = new TestCanvasContext(
-    {canvas: attachedCanvas, trackCanvas: attachedCanvas},
+    {
+      canvas: attachedCanvas,
+      drawingBufferSizeTracking: 'external-canvas',
+      drawingBufferSizeSource: attachedCanvas
+    },
     false
   );
   attachedCanvas.width = 512;
@@ -521,18 +507,36 @@ test('CanvasContext#trackCanvas mirrors source dimensions before drawing', t => 
     () =>
       new TestCanvasContext(
         {
-          trackCanvas: sourceCanvas,
-          drawingBufferSizingMode: 'track-css-pixels'
+          drawingBufferSizeSource: sourceCanvas,
+          drawingBufferSizeTracking: 'canvas'
         },
         false
       ),
     /assertion failed/,
-    'trackCanvas rejects conflicting automatic sizing'
+    'canvas tracking rejects an external source'
   );
   t.throws(
-    () => new TestCanvasContext({trackCanvas: sourceCanvas, pixelRatio: 2}, false),
+    () =>
+      new TestCanvasContext(
+        {
+          drawingBufferSizeTracking: 'external-canvas',
+          drawingBufferSizeSource: sourceCanvas,
+          pixelRatio: 2
+        },
+        false
+      ),
     /assertion failed/,
-    'trackCanvas rejects a conflicting pixel ratio'
+    'external canvas tracking rejects a conflicting pixel ratio'
+  );
+  t.throws(
+    () => new TestCanvasContext({drawingBufferSizeTracking: 'external-canvas'}, false),
+    /assertion failed/,
+    'external canvas tracking requires a source'
+  );
+  t.throws(
+    () => new TestCanvasContext({drawingBufferSizeSource: sourceCanvas}, false),
+    /assertion failed/,
+    'an external source requires an explicit tracking behavior'
   );
 
   t.end();
@@ -545,7 +549,7 @@ test('CanvasContext#setProps updates drawing buffer sizing and observer mode', t
   }
 
   const canvasContext = new TestCanvasContext(
-    {drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 1},
+    {drawingBufferSizeTracking: 'canvas', pixelRatio: 1},
     false
   );
   canvasContext.getDevicePixelRatio = () => 1.5;
@@ -567,14 +571,12 @@ test('CanvasContext#setProps updates drawing buffer sizing and observer mode', t
   t.deepEqual(
     canvasContext.getDrawingBufferSize(),
     [150, 75],
-    'clearing the fixed ratio resumes browser DPR'
+    'clearing the fixed ratio resumes exact device-pixel tracking'
   );
-
-  canvasContext.setProps({drawingBufferSizingMode: 'track-device-pixels'});
   t.equal(
     (canvasContext as any)._canvasObserver.props.resizeObserverBox,
     'device-pixel-content-box',
-    'switching mode reconfigures the observer box'
+    'clearing pixelRatio reconfigures the observer box'
   );
   (canvasContext as any)._handleResize([
     {
@@ -589,7 +591,7 @@ test('CanvasContext#setProps updates drawing buffer sizing and observer mode', t
     'exact observer dimensions are used after switching mode'
   );
 
-  canvasContext.setProps({drawingBufferSizingMode: 'manual'});
+  canvasContext.setProps({drawingBufferSizeTracking: 'none'});
   (canvasContext as any)._handleResize([
     {
       target: canvasContext.canvas,
@@ -606,23 +608,30 @@ test('CanvasContext#setProps updates drawing buffer sizing and observer mode', t
   const sourceCanvas = document.createElement('canvas');
   sourceCanvas.width = 240;
   sourceCanvas.height = 120;
-  canvasContext.setProps({trackCanvas: sourceCanvas});
+  canvasContext.setProps({
+    drawingBufferSizeTracking: 'external-canvas',
+    drawingBufferSizeSource: sourceCanvas
+  });
   t.deepEqual(
     canvasContext.getDrawingBufferSize(),
     [240, 120],
-    'trackCanvas can take ownership dynamically'
+    'external canvas tracking can take ownership dynamically'
   );
 
   canvasContext.setProps({
-    trackCanvas: null,
-    drawingBufferSizingMode: 'track-css-pixels',
+    drawingBufferSizeSource: null,
+    drawingBufferSizeTracking: 'canvas',
     pixelRatio: 1
   });
-  t.equal(canvasContext.props.trackCanvas, null, 'tracked canvas can be cleared dynamically');
   t.equal(
-    canvasContext.props.drawingBufferSizingMode,
-    'track-css-pixels',
-    'automatic sizing can resume when trackCanvas is cleared'
+    canvasContext.props.drawingBufferSizeSource,
+    null,
+    'external size source can be cleared dynamically'
+  );
+  t.equal(
+    canvasContext.props.drawingBufferSizeTracking,
+    'canvas',
+    'canvas tracking can resume when the external source is cleared'
   );
 
   t.end();
@@ -636,17 +645,17 @@ test('CanvasContext#new drawing buffer sizing props override and validate legacy
 
   const legacyCSSCanvasContext = new TestCanvasContext({useDevicePixels: false}, false);
   t.equal(
-    legacyCSSCanvasContext.props.drawingBufferSizingMode,
-    'track-css-pixels',
-    'legacy false normalizes to track-css-pixels mode'
+    legacyCSSCanvasContext.props.drawingBufferSizeTracking,
+    'canvas',
+    'legacy false normalizes to canvas tracking'
   );
   t.equal(legacyCSSCanvasContext.props.pixelRatio, 1, 'legacy false normalizes to ratio 1');
 
   const legacyNumericCanvasContext = new TestCanvasContext({useDevicePixels: 1.5}, false);
   t.equal(
-    legacyNumericCanvasContext.props.drawingBufferSizingMode,
-    'track-css-pixels',
-    'legacy numeric ratio normalizes to track-css-pixels mode'
+    legacyNumericCanvasContext.props.drawingBufferSizeTracking,
+    'canvas',
+    'legacy numeric ratio normalizes to canvas tracking'
   );
   t.equal(legacyNumericCanvasContext.props.pixelRatio, 1.5, 'legacy numeric ratio is preserved');
 
@@ -655,9 +664,9 @@ test('CanvasContext#new drawing buffer sizing props override and validate legacy
     false
   );
   t.equal(
-    legacyExactCanvasContext.props.drawingBufferSizingMode,
-    'track-device-pixels',
-    'legacy exact sizing normalizes to track-device-pixels mode'
+    legacyExactCanvasContext.props.drawingBufferSizeTracking,
+    'canvas',
+    'legacy exact sizing normalizes to canvas tracking'
   );
 
   const legacyCSSDPRCanvasContext = new TestCanvasContext(
@@ -665,9 +674,9 @@ test('CanvasContext#new drawing buffer sizing props override and validate legacy
     false
   );
   t.equal(
-    legacyCSSDPRCanvasContext.props.drawingBufferSizingMode,
-    'track-css-pixels',
-    'legacy CSS-DPR sizing normalizes to track-css-pixels mode'
+    legacyCSSDPRCanvasContext.props.drawingBufferSizeTracking,
+    'canvas',
+    'legacy CSS-DPR sizing normalizes to canvas tracking'
   );
   t.equal(
     legacyCSSDPRCanvasContext.props.pixelRatio,
@@ -677,14 +686,14 @@ test('CanvasContext#new drawing buffer sizing props override and validate legacy
 
   const legacyManualCanvasContext = new TestCanvasContext({autoResize: false}, false);
   t.equal(
-    legacyManualCanvasContext.props.drawingBufferSizingMode,
-    'manual',
-    'legacy autoResize false normalizes to manual mode'
+    legacyManualCanvasContext.props.drawingBufferSizeTracking,
+    'none',
+    'legacy autoResize false normalizes to no tracking'
   );
 
   const newCanvasContext = new TestCanvasContext(
     {
-      drawingBufferSizingMode: 'track-css-pixels',
+      drawingBufferSizeTracking: 'canvas',
       autoResize: false,
       useDevicePixels: false,
       pixelSizeSource: 'exact'
@@ -695,13 +704,14 @@ test('CanvasContext#new drawing buffer sizing props override and validate legacy
   (newCanvasContext as any)._handleResize([
     {
       target: newCanvasContext.canvas,
-      contentBoxSize: [{inlineSize: 100, blockSize: 50}]
+      contentBoxSize: [{inlineSize: 100, blockSize: 50}],
+      devicePixelContentBoxSize: [{inlineSize: 200, blockSize: 100}]
     }
   ]);
   t.deepEqual(
     newCanvasContext.getDrawingBufferSize(),
     [200, 100],
-    'new track-css-pixels mode ignores conflicting legacy sizing props'
+    'new canvas tracking ignores conflicting legacy sizing props'
   );
   newCanvasContext.setProps({useDevicePixels: 1});
   t.equal(
@@ -711,23 +721,22 @@ test('CanvasContext#new drawing buffer sizing props override and validate legacy
   );
 
   t.throws(
-    () =>
-      new TestCanvasContext({drawingBufferSizingMode: 'track-device-pixels', pixelRatio: 2}, false),
+    () => new TestCanvasContext({drawingBufferSizeTracking: 'none', pixelRatio: 2}, false),
     /assertion failed/,
-    'pixelRatio is rejected outside track-css-pixels mode'
+    'pixelRatio is rejected outside canvas tracking'
   );
   t.throws(
-    () =>
-      new TestCanvasContext({drawingBufferSizingMode: 'track-css-pixels', pixelRatio: 0}, false),
+    () => new TestCanvasContext({pixelRatio: 2}, false),
+    /assertion failed/,
+    'pixelRatio requires explicit canvas tracking'
+  );
+  t.throws(
+    () => new TestCanvasContext({drawingBufferSizeTracking: 'canvas', pixelRatio: 0}, false),
     /assertion failed/,
     'non-positive pixelRatio is rejected'
   );
   t.throws(
-    () =>
-      new TestCanvasContext(
-        {drawingBufferSizingMode: 'track-css-pixels', pixelRatio: Infinity},
-        false
-      ),
+    () => new TestCanvasContext({drawingBufferSizeTracking: 'canvas', pixelRatio: Infinity}, false),
     /assertion failed/,
     'non-finite pixelRatio is rejected'
   );

--- a/modules/core/test/adapter/canvas-observer.spec.ts
+++ b/modules/core/test/adapter/canvas-observer.spec.ts
@@ -267,6 +267,64 @@ test('CanvasObserver#resizeObserverBox uses content-box when specified', t => {
   t.end();
 });
 
+test('CanvasObserver#setResizeObserverBox reobserves an active canvas', t => {
+  if (!isBrowser()) {
+    t.end();
+    return;
+  }
+
+  const globalScope = globalThis;
+  const originals = getOriginalGlobals(globalScope);
+  const observedBoxes: Array<ResizeObserverBoxOptions | undefined> = [];
+  let resizeDisconnectCalls = 0;
+
+  globalScope.ResizeObserver = class {
+    constructor(_callback: ResizeObserverCallback) {}
+    observe(_target: Element, options?: ResizeObserverOptions) {
+      observedBoxes.push(options?.box);
+    }
+    disconnect() {
+      resizeDisconnectCalls++;
+    }
+  } as typeof ResizeObserver;
+  globalScope.IntersectionObserver = class {
+    constructor(_callback: IntersectionObserverCallback) {}
+    observe() {}
+    disconnect() {}
+  } as typeof IntersectionObserver;
+  globalScope.setTimeout = (callback: TimerHandler, delay?: number) =>
+    originals.setTimeout.call(globalScope, callback, delay);
+
+  try {
+    const observer = new CanvasObserver({
+      canvas: document.createElement('canvas'),
+      trackPosition: false,
+      resizeObserverBox: 'device-pixel-content-box',
+      onResize: () => {},
+      onIntersection: () => {},
+      onDevicePixelRatioChange: () => {},
+      onPositionChange: () => {}
+    });
+
+    observer.start();
+    observer.setResizeObserverBox('device-pixel-content-box');
+    observer.setResizeObserverBox('content-box');
+
+    t.deepEqual(
+      observedBoxes,
+      ['device-pixel-content-box', 'content-box'],
+      'changing the resize box reobserves the canvas exactly once'
+    );
+    t.equal(resizeDisconnectCalls, 1, 'changing the resize box disconnects the old observation');
+
+    observer.stop();
+  } finally {
+    restoreGlobals(globalScope, originals);
+  }
+
+  t.end();
+});
+
 test('CanvasObserver#start is a no-op without an HTML canvas', t => {
   if (!isBrowser()) {
     t.end();

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -23,6 +23,53 @@ test('luma#attachDevice forwards canvas context compatibility props', async t =>
   t.end();
 });
 
+test('luma#canvasContextProps configures and overrides the default canvas context', async t => {
+  const device = await luma.createDevice({
+    type: 'null',
+    adapters: [nullAdapter],
+    createCanvasContext: {
+      width: 4,
+      drawingBufferSizingMode: 'manual'
+    },
+    canvasContextProps: {
+      width: 8,
+      drawingBufferSizingMode: 'track-css-pixels',
+      pixelRatio: 1
+    }
+  });
+  const canvasContext = device.getDefaultCanvasContext();
+
+  t.equal(canvasContext.props.width, 8, 'canvasContextProps overrides legacy object props');
+  t.equal(
+    canvasContext.props.drawingBufferSizingMode,
+    'track-css-pixels',
+    'preferred sizing mode is forwarded'
+  );
+  t.equal(canvasContext.props.pixelRatio, 1, 'preferred pixel ratio is forwarded');
+  t.end();
+});
+
+test('luma#createDevice uses canvasContextProps when createCanvasContext is true', async t => {
+  const device = await luma.createDevice({
+    type: 'null',
+    adapters: [nullAdapter],
+    createCanvasContext: true,
+    canvasContextProps: {
+      drawingBufferSizingMode: 'track-css-pixels',
+      pixelRatio: 1.5
+    }
+  });
+  const canvasContext = device.getDefaultCanvasContext();
+
+  t.equal(
+    canvasContext.props.drawingBufferSizingMode,
+    'track-css-pixels',
+    'sizing mode is forwarded'
+  );
+  t.equal(canvasContext.props.pixelRatio, 1.5, 'pixel ratio is forwarded');
+  t.end();
+});
+
 test('luma#createDevice', async t => {
   const device = await luma.createDevice({type: 'null', adapters: [nullAdapter]});
   t.equal(device.type, 'null', 'info.vendor ok');

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -29,11 +29,11 @@ test('luma#canvasContextProps configures and overrides the default canvas contex
     adapters: [nullAdapter],
     createCanvasContext: {
       width: 4,
-      drawingBufferSizingMode: 'manual'
+      drawingBufferSizeTracking: 'none'
     },
     canvasContextProps: {
       width: 8,
-      drawingBufferSizingMode: 'track-css-pixels',
+      drawingBufferSizeTracking: 'canvas',
       pixelRatio: 1
     }
   });
@@ -41,9 +41,9 @@ test('luma#canvasContextProps configures and overrides the default canvas contex
 
   t.equal(canvasContext.props.width, 8, 'canvasContextProps overrides legacy object props');
   t.equal(
-    canvasContext.props.drawingBufferSizingMode,
-    'track-css-pixels',
-    'preferred sizing mode is forwarded'
+    canvasContext.props.drawingBufferSizeTracking,
+    'canvas',
+    'preferred tracking behavior is forwarded'
   );
   t.equal(canvasContext.props.pixelRatio, 1, 'preferred pixel ratio is forwarded');
   t.end();
@@ -55,16 +55,16 @@ test('luma#createDevice uses canvasContextProps when createCanvasContext is true
     adapters: [nullAdapter],
     createCanvasContext: true,
     canvasContextProps: {
-      drawingBufferSizingMode: 'track-css-pixels',
+      drawingBufferSizeTracking: 'canvas',
       pixelRatio: 1.5
     }
   });
   const canvasContext = device.getDefaultCanvasContext();
 
   t.equal(
-    canvasContext.props.drawingBufferSizingMode,
-    'track-css-pixels',
-    'sizing mode is forwarded'
+    canvasContext.props.drawingBufferSizeTracking,
+    'canvas',
+    'tracking behavior is forwarded'
   );
   t.equal(canvasContext.props.pixelRatio, 1.5, 'pixel ratio is forwarded');
   t.end();

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -66,17 +66,22 @@ export class WebGLAdapter extends Adapter {
     const legacyCanvasContextProps =
       typeof props.createCanvasContext === 'object' ? props.createCanvasContext : {};
     const canvasContextProps = {...legacyCanvasContextProps, ...props.canvasContextProps};
+    const hasExplicitDrawingBufferTracking =
+      canvasContextProps.drawingBufferSizeTracking !== undefined ||
+      canvasContextProps.drawingBufferSizeSource !== undefined;
     const usesAutomaticDrawingBufferSizing =
-      (canvasContextProps.drawingBufferSizingMode !== undefined &&
-        canvasContextProps.drawingBufferSizingMode !== 'manual') ||
+      canvasContextProps.drawingBufferSizeTracking === 'canvas' ||
       canvasContextProps.pixelRatio !== undefined ||
-      canvasContextProps.autoResize === true;
-    const trackCanvas =
-      'trackCanvas' in canvasContextProps
-        ? canvasContextProps.trackCanvas
-        : usesAutomaticDrawingBufferSizing
-          ? null
-          : gl.canvas;
+      canvasContextProps.autoResize === true ||
+      canvasContextProps.useDevicePixels !== undefined ||
+      canvasContextProps.pixelSizeSource !== undefined;
+    const attachedContextDefaults =
+      hasExplicitDrawingBufferTracking || usesAutomaticDrawingBufferSizing
+        ? {}
+        : {
+            drawingBufferSizeTracking: 'external-canvas' as const,
+            drawingBufferSizeSource: gl.canvas
+          };
 
     // We create a new device using the provided WebGL context and its canvas
     // The external owner resizes the attached canvas; luma.gl mirrors its current dimensions.
@@ -87,7 +92,7 @@ export class WebGLAdapter extends Adapter {
       canvasContextProps: {
         canvas: gl.canvas,
         autoResize: false,
-        trackCanvas,
+        ...attachedContextDefaults,
         ...canvasContextProps
       }
     });

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -65,9 +65,21 @@ export class WebGLAdapter extends Adapter {
 
     const legacyCanvasContextProps =
       typeof props.createCanvasContext === 'object' ? props.createCanvasContext : {};
+    const canvasContextProps = {...legacyCanvasContextProps, ...props.canvasContextProps};
+    const usesAutomaticDrawingBufferSizing =
+      (canvasContextProps.drawingBufferSizingMode !== undefined &&
+        canvasContextProps.drawingBufferSizingMode !== 'manual') ||
+      canvasContextProps.pixelRatio !== undefined ||
+      canvasContextProps.autoResize === true;
+    const trackCanvas =
+      'trackCanvas' in canvasContextProps
+        ? canvasContextProps.trackCanvas
+        : usesAutomaticDrawingBufferSizing
+          ? null
+          : gl.canvas;
 
     // We create a new device using the provided WebGL context and its canvas
-    // Assume that whoever created the external context will be handling resizes.
+    // The external owner resizes the attached canvas; luma.gl mirrors its current dimensions.
     return new WebGLDevice({
       ...props,
       _handle: gl,
@@ -75,8 +87,8 @@ export class WebGLAdapter extends Adapter {
       canvasContextProps: {
         canvas: gl.canvas,
         autoResize: false,
-        ...legacyCanvasContextProps,
-        ...props.canvasContextProps
+        trackCanvas,
+        ...canvasContextProps
       }
     });
   }

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -63,14 +63,21 @@ export class WebGLAdapter extends Adapter {
       throw new Error('Invalid WebGL2RenderingContext');
     }
 
-    const createCanvasContext = props.createCanvasContext === true ? {} : props.createCanvasContext;
+    const legacyCanvasContextProps =
+      typeof props.createCanvasContext === 'object' ? props.createCanvasContext : {};
 
     // We create a new device using the provided WebGL context and its canvas
     // Assume that whoever created the external context will be handling resizes.
     return new WebGLDevice({
       ...props,
       _handle: gl,
-      createCanvasContext: {canvas: gl.canvas, autoResize: false, ...createCanvasContext}
+      createCanvasContext: true,
+      canvasContextProps: {
+        canvas: gl.canvas,
+        autoResize: false,
+        ...legacyCanvasContextProps,
+        ...props.canvasContextProps
+      }
     });
   }
 

--- a/modules/webgl/test/adapter/webgl-adapter.spec.ts
+++ b/modules/webgl/test/adapter/webgl-adapter.spec.ts
@@ -17,7 +17,7 @@ test('WebGLAdapter imports from the ESM package entry without circular init erro
   t.equal(webglModule.WebGLDevice.name, 'WebGLDevice', 'exports the WebGL device class');
 });
 
-test('WebGLAdapter#attach uses manual sizing by default and accepts canvasContextProps', async t => {
+test('WebGLAdapter#attach tracks its external canvas by default and accepts canvasContextProps', async t => {
   if (!isBrowser()) {
     t.end();
     return;
@@ -34,12 +34,12 @@ test('WebGLAdapter#attach uses manual sizing by default and accepts canvasContex
   const defaultDevice = await webgl2Adapter.attach(defaultGL);
   const defaultCanvasContext = defaultDevice.getDefaultCanvasContext();
   t.equal(
-    defaultCanvasContext.props.drawingBufferSizingMode,
-    'manual',
-    'attached WebGL contexts default to manual drawing buffer sizing'
+    defaultCanvasContext.props.drawingBufferSizeTracking,
+    'external-canvas',
+    'attached WebGL contexts default to external canvas tracking'
   );
   t.equal(
-    defaultCanvasContext.props.trackCanvas,
+    defaultCanvasContext.props.drawingBufferSizeSource,
     defaultCanvas,
     'attached WebGL contexts track their externally owned canvas'
   );
@@ -62,19 +62,19 @@ test('WebGLAdapter#attach uses manual sizing by default and accepts canvasContex
 
   const configuredDevice = await webgl2Adapter.attach(configuredGL, {
     canvasContextProps: {
-      drawingBufferSizingMode: 'track-css-pixels',
+      drawingBufferSizeTracking: 'canvas',
       pixelRatio: 1
     }
   });
   const configuredCanvasContext = configuredDevice.getDefaultCanvasContext();
   t.equal(
-    configuredCanvasContext.props.drawingBufferSizingMode,
-    'track-css-pixels',
+    configuredCanvasContext.props.drawingBufferSizeTracking,
+    'canvas',
     'canvasContextProps overrides the attached context default'
   );
   t.equal(configuredCanvasContext.props.pixelRatio, 1, 'pixel ratio is forwarded on attach');
   t.equal(
-    configuredCanvasContext.props.trackCanvas,
+    configuredCanvasContext.props.drawingBufferSizeSource,
     null,
     'explicit automatic sizing disables attached-canvas tracking'
   );

--- a/modules/webgl/test/adapter/webgl-adapter.spec.ts
+++ b/modules/webgl/test/adapter/webgl-adapter.spec.ts
@@ -3,6 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {isBrowser} from '@probe.gl/env';
+import {webgl2Adapter} from '@luma.gl/webgl';
 
 test('WebGLAdapter imports from the ESM package entry without circular init errors', async t => {
   t.plan(2);
@@ -13,4 +15,52 @@ test('WebGLAdapter imports from the ESM package entry without circular init erro
 
   t.equal(webglModule.webgl2Adapter.type, 'webgl', 'exports a WebGL adapter instance');
   t.equal(webglModule.WebGLDevice.name, 'WebGLDevice', 'exports the WebGL device class');
+});
+
+test('WebGLAdapter#attach uses manual sizing by default and accepts canvasContextProps', async t => {
+  if (!isBrowser()) {
+    t.end();
+    return;
+  }
+
+  const defaultCanvas = document.createElement('canvas');
+  const defaultGL = defaultCanvas.getContext('webgl2');
+  if (!defaultGL) {
+    t.comment('WebGL2 unavailable, skipped attached context sizing test');
+    t.end();
+    return;
+  }
+
+  const defaultDevice = await webgl2Adapter.attach(defaultGL);
+  t.equal(
+    defaultDevice.getDefaultCanvasContext().props.drawingBufferSizingMode,
+    'manual',
+    'attached WebGL contexts default to manual drawing buffer sizing'
+  );
+  defaultDevice.destroy();
+
+  const configuredCanvas = document.createElement('canvas');
+  const configuredGL = configuredCanvas.getContext('webgl2');
+  if (!configuredGL) {
+    t.comment('Second WebGL2 context unavailable, skipped preferred props assertion');
+    t.end();
+    return;
+  }
+
+  const configuredDevice = await webgl2Adapter.attach(configuredGL, {
+    canvasContextProps: {
+      drawingBufferSizingMode: 'track-css-pixels',
+      pixelRatio: 1
+    }
+  });
+  const configuredCanvasContext = configuredDevice.getDefaultCanvasContext();
+  t.equal(
+    configuredCanvasContext.props.drawingBufferSizingMode,
+    'track-css-pixels',
+    'canvasContextProps overrides the attached context default'
+  );
+  t.equal(configuredCanvasContext.props.pixelRatio, 1, 'pixel ratio is forwarded on attach');
+  configuredDevice.destroy();
+
+  t.end();
 });

--- a/modules/webgl/test/adapter/webgl-adapter.spec.ts
+++ b/modules/webgl/test/adapter/webgl-adapter.spec.ts
@@ -32,10 +32,23 @@ test('WebGLAdapter#attach uses manual sizing by default and accepts canvasContex
   }
 
   const defaultDevice = await webgl2Adapter.attach(defaultGL);
+  const defaultCanvasContext = defaultDevice.getDefaultCanvasContext();
   t.equal(
-    defaultDevice.getDefaultCanvasContext().props.drawingBufferSizingMode,
+    defaultCanvasContext.props.drawingBufferSizingMode,
     'manual',
     'attached WebGL contexts default to manual drawing buffer sizing'
+  );
+  t.equal(
+    defaultCanvasContext.props.trackCanvas,
+    defaultCanvas,
+    'attached WebGL contexts track their externally owned canvas'
+  );
+  defaultCanvas.width = 320;
+  defaultCanvas.height = 180;
+  t.deepEqual(
+    defaultCanvasContext.getDrawingBufferSize(),
+    [320, 180],
+    'attached context dimensions follow external canvas changes before use'
   );
   defaultDevice.destroy();
 
@@ -60,6 +73,11 @@ test('WebGLAdapter#attach uses manual sizing by default and accepts canvasContex
     'canvasContextProps overrides the attached context default'
   );
   t.equal(configuredCanvasContext.props.pixelRatio, 1, 'pixel ratio is forwarded on attach');
+  t.equal(
+    configuredCanvasContext.props.trackCanvas,
+    null,
+    'explicit automatic sizing disables attached-canvas tracking'
+  );
   configuredDevice.destroy();
 
   t.end();


### PR DESCRIPTION
## Motivation

deck.gl's canvas integrations are behavior-oriented:

- **Interleaved:** attach to an externally owned canvas/context and read its drawing-buffer size without writing it.
- **Overlaid:** render to a separate canvas whose drawing-buffer size follows the basemap canvas.

luma.gl currently exposes lower-level, overlapping sizing controls (`autoResize`, `useDevicePixels`, `pixelSizeSource`, and the boolean/object `createCanvasContext` union). This makes deck.gl reconstruct those behaviors through configuration merging and sizing-algorithm selection in [deck.gl #10370](https://github.com/visgl/deck.gl/pull/10370) and [deck.gl #10332](https://github.com/visgl/deck.gl/pull/10332).

This draft proposes fresh props that describe drawing-buffer ownership and source directly, deprecates the overloaded legacy props, and includes a tested proof of concept.

## Proposal

`drawingBufferSizeTracking` selects where the target drawing-buffer dimensions come from:

| Value | Behavior |
| --- | --- |
| `'none'` | The application owns the drawing-buffer size; luma.gl never changes it. |
| `'canvas'` | luma.gl derives the drawing-buffer size from the target canvas and resizes it when needed. |
| `'external-canvas'` | luma.gl mirrors `drawingBufferSizeSource.width/height`; if source and target are the same canvas, luma.gl only reads. |

The setting controls only the drawing buffer (`canvas.width` and `canvas.height`). It does not copy an external canvas's CSS size, style, position, transforms, borders, scroll state, or containing block. The target's existing CSS-size, position, visibility, and callback observation remains separate.

The default is `'canvas'`. With no fixed ratio it uses exact device-pixel observation when supported, falling back to CSS size × browser DPR. A numeric `pixelRatio` selects content-box sizing at that fixed ratio.

## API

```ts
export type DrawingBufferSizeTracking =
  | 'none'
  | 'canvas'
  | 'external-canvas';

export type CanvasContextProps = {
  drawingBufferSizeTracking?: DrawingBufferSizeTracking;
  drawingBufferSizeSource?: HTMLCanvasElement | OffscreenCanvas | null;
  pixelRatio?: number;

  /** @deprecated */
  autoResize?: boolean;
  /** @deprecated */
  useDevicePixels?: boolean | number;
  /** @deprecated */
  pixelSizeSource?: 'exact' | 'css-dpr';
};

export type DeviceProps = {
  createCanvasContext?: boolean | CanvasContextProps;
  canvasContextProps?: CanvasContextProps;
};
```

Validation is deliberately explicit:

- `drawingBufferSizeSource` is required for `'external-canvas'` and invalid for the other values.
- `pixelRatio` is valid only for `'canvas'`, must be finite and positive, and requires an explicit tracking value.
- New drawing-buffer props take precedence over legacy sizing props.
- `CanvasContext.setProps()` supports dynamic tracking, source, and ratio transitions and reconfigures the observer box when needed.

`canvasContextProps` is the preferred default/attached-context configuration. If the deprecated object form of `createCanvasContext` is also supplied, it is merged first and `canvasContextProps` wins.

## Migration

| Existing configuration | Preferred configuration |
| --- | --- |
| `autoResize: false` | `drawingBufferSizeTracking: 'none'` |
| `useDevicePixels: false` | `drawingBufferSizeTracking: 'canvas', pixelRatio: 1` |
| numeric `useDevicePixels` | `drawingBufferSizeTracking: 'canvas', pixelRatio: number` |
| exact automatic sizing | `drawingBufferSizeTracking: 'canvas'` |
| reproduce another renderer's CSS/DPR algorithm | `drawingBufferSizeTracking: 'external-canvas'` plus that canvas as `drawingBufferSizeSource` |

The legacy CSS × live browser-DPR algorithm remains supported internally through v9 normalization, but is intentionally not a separate value in the fresh API. Its main integration use case is represented more directly by tracking the external backing store.

The RFC proposes deprecation in v9 and removal of `autoResize`, `useDevicePixels`, `pixelSizeSource`, and object-form `createCanvasContext` in v10.

## PoC Implementation

The PoC:

- implements all three tracking behaviors in the shared `CanvasSurface`, covering both `CanvasContext` and `PresentationContext`;
- reads an external canvas's two integer backing-store dimensions at size-query and render boundaries;
- changes the target only when those dimensions differ, avoiding layout reads, polling, and observer-ordering dependencies;
- retains legacy exact and CSS-DPR behavior through internal normalization;
- supports dynamic tracking/source/ratio changes;
- adds and tests `DeviceProps.canvasContextProps` precedence; and
- leaves stable API docs and release notes unchanged while the RFC is under review.

The durable proposal is in `dev-docs/RFCs/vNext/canvas-context-configuration-rfc.md`.

## External Contexts

WebGL attachment defaults to:

```ts
{
  drawingBufferSizeTracking: 'external-canvas',
  drawingBufferSizeSource: gl.canvas
}
```

Because source and target are the same object, luma.gl updates bookkeeping before use but never writes the externally owned canvas. Explicit `canvasContextProps` can select target-canvas sizing or no tracking instead.

For an overlaid deck.gl canvas:

```ts
{
  canvas: overlayCanvas,
  drawingBufferSizeTracking: 'external-canvas',
  drawingBufferSizeSource: map.getCanvas()
}
```

This copies only the basemap canvas's actual drawing-buffer dimensions. Layout alignment remains the responsibility of deck.gl/the host application.

## Validation

- `nvm use` — Node v22.22.1
- `yarn lint fix` — passed
- Focused CanvasContext/CanvasObserver/device/WebGL attachment suite — 4 files, 44 tests passed
- `yarn build` — passed
- `yarn test` node phase — 53 files passed, 2 skipped; 195 tests passed, 2 skipped
- `yarn test` headless phase — 235 files passed; 1291 tests passed, 25 skipped; 3 known unrelated WebGPU/DGGS failures remain:
  - `modules/shadertools/test/modules/geospatial/dggs.spec.ts` (A5 produces NaN)
  - `modules/arrow/test/arrow/dggs-gpu-polygons.spec.ts` (A5 produces NaN)
  - `modules/arrow-layers/test/layers/arrow-layers.spec.ts` (storage-backed instances are not drawable)

## Open Questions

- Should `drawingBufferSizeSource` remain canvas-only or accept a structural `{width, height}` source?
- Should `'none'` retain current exact-device-pixel bookkeeping and callbacks, as the PoC does?
- Is the compatibility-only legacy CSS-DPR path sufficient for v9 now that new overlays can track the external backing store directly?