### PR TITLE
feat(experimental): add optical caustics and guided network storytelling

### DIFF
--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -22,18 +22,23 @@ GLSL shader modules, while transparency renderers remain responsible for composi
 | GGX microfacets | Shared distribution and visibility helpers shade key and fill lights. | Roughness-dependent, camera-responsive polished highlights. |
 | Clearcoat | Adds a second narrow microfacet lobe above the base surface. | Crisp, bright reflections that make the outer shell readable. |
 | Internal reflection | Approximates a colored secondary environment bounce inside the shell. | A softer inner Fresnel band and greater visible depth. |
+| Multiple internal bounces | Reflects the refracted ray against both measured shell surfaces before sampling the studio environment again. | A second curved highlight suggests the depth of polished solid glass. |
 | Thin-film interference | Applies restrained wavelength-dependent color near grazing angles. | Subtle spectral variation without coloring the whole object. |
 | Localized point lights | Evaluates a bounded array of nearby colored light sources. | Moving emissive objects tint adjacent glass and reflective surfaces. |
+| Dynamic scene reflections | Samples captured opaque scene color along a curved screen-space reflection offset. | Moving packets and active links appear as localized reflections on glass switches. |
+| Focused raster caustics | Projects bounded colored glass-lens contributions onto nearby reflective receivers. | Active switches concentrate moving red and green light onto adjacent links and servers. |
+| Fault-driven distortion | Modulates refraction and narrow internal filaments only on warm fault-tinted glass. | Congested and failed switches acquire subtle animated optical instability. |
 
 [`glassMaterial`](/docs/api-reference/experimental/glass-material) provides the transmissive
 surface model. [`reflectiveMaterial`](/docs/api-reference/experimental/reflective-material)
 provides a lower-cost glossy treatment for links and other non-glass surfaces. Both depend on the
 shared `opticalLighting` shader module.
 
-`emissiveMaterial` provides self-illuminated geometry, while `opticalPointLights` supplies
-portable, bounded local lighting. Emission makes an object bright; point lighting makes it
-illuminate nearby surfaces; bloom spreads the brightest pixels in screen space. These effects can
-be combined independently.
+`emissiveMaterial` provides self-illuminated geometry, `opticalPointLights` supplies portable,
+bounded local lighting, and `opticalCaustics` approximates focused light cast through nearby glass.
+Emission makes an object bright; point lighting illuminates nearby surfaces; caustics concentrate
+light around a focusing lens; bloom spreads the brightest pixels in screen space. These effects
+can be combined independently.
 
 For moving emitters, `emissiveMaterial_getTrailColor(...)` applies a smooth axial falloff to a
 velocity-aligned mesh. A tapered cone behind each packet produces directional bloom without
@@ -115,7 +120,11 @@ shaderInputs.setProps({
     backfaceTexture,
     environmentTexture,
     environmentIntensity: 1.25,
-    thicknessStrength: 1
+    thicknessStrength: 1,
+    dynamicReflectionStrength: 0.38,
+    secondaryBounceStrength: 0.55,
+    faultDistortionStrength: 0.42,
+    time: animationTime
   }
 });
 ```
@@ -123,7 +132,37 @@ shaderInputs.setProps({
 Call `glassTransmission_getColor(...)`, or install `opticalPointLightsPlugin` and call
 `glassTransmission_getIlluminatedColor(...)`. These helpers retain the base glass material while
 adding depth-derived thickness, analytic entry/exit refraction, foreground-depth rejection,
-total-internal-reflection handling, and sampled equirectangular environment reflections.
+total-internal-reflection handling, sampled equirectangular environment reflections, optional
+screen-space scene reflections, secondary internal bounces, and fault-tinted optical distortion.
+The additional controls default to zero so existing transmission consumers retain their appearance.
+
+## Add Focused Raster Caustics
+
+`opticalCausticsPlugin` installs an independent bounded lens array. Register the module alongside
+the receiving material, update nearby lens colors from actual scene lights, and add the returned
+RGB contribution to the receiver's fragment color.
+
+```ts
+import {
+  MAX_OPTICAL_CAUSTIC_LENSES,
+  opticalCaustics,
+  opticalCausticsPlugin
+} from '@luma.gl/experimental';
+
+const shaderInputs = new ShaderInputs({reflectiveMaterial, opticalCaustics});
+
+shaderInputs.setProps({
+  opticalCaustics: {
+    intensity: 0.48,
+    focus: 1.15,
+    lenses: nearbyGlassLenses.slice(0, MAX_OPTICAL_CAUSTIC_LENSES)
+  }
+});
+```
+
+Both WGSL and GLSL expose `opticalCaustics_getColor(normal, worldPosition, cameraPosition)`.
+Caustics are receiver-local raster approximations; they do not require ray tracing, additional
+framebuffers, or installation on unrelated scene geometry.
 
 ## Separate Optical Shading From Transparency
 
@@ -160,7 +199,8 @@ system. In particular, the current implementation does not provide:
 
 - Full energy-conserving multiple-scattering or microfacet transmission.
 - Filtered environment probes and geometry-aware rough transmission.
-- Physically traced multiple refraction events or caustics.
+- Physically traced multiple refraction events or caustics; the available focused-light module is
+  an intentionally bounded raster approximation.
 - Off-screen background recovery or geometry-aware refracted-ray tracing.
 
 Those capabilities require additional depth, normal, backface, environment, or ray-tracing data

--- a/docs/api-reference/experimental/glass-material.md
+++ b/docs/api-reference/experimental/glass-material.md
@@ -76,10 +76,20 @@ existing `glassMaterial_getColor(...)` consumers.
 | `environmentIntensity` | `number` | `1` | Environment reflection multiplier. |
 | `thicknessStrength` | `number` | `1` | Measured optical-path multiplier. |
 | `depthBias` | `number` | `0.00008` | Foreground depth-comparison tolerance. |
+| `dynamicReflectionStrength` | `number` | `0` | Captured-scene reflection strength for nearby moving objects. |
+| `secondaryBounceStrength` | `number` | `0` | Additional reflected environment bounce inside the glass shell. |
+| `faultDistortionStrength` | `number` | `0` | Animated lens distortion and internal filaments on warm fault-tinted glass. |
+| `time` | `number` | `0` | Animation clock for optional fault-driven surface effects. |
 
 Use `glassTransmission_getColor(...)`, or add `opticalPointLightsPlugin` and use
 `glassTransmission_getIlluminatedColor(...)` for localized illumination. Both are available in
 matching WGSL and GLSL forms.
+
+`opticalCausticsPlugin` separately adds a bounded array of focused glass lenses for nearby
+reflective receiver surfaces. Call `opticalCaustics_getColor(normal, worldPosition,
+cameraPosition)` and add its RGB result to the receiver's existing material color. At most
+`MAX_OPTICAL_CAUSTIC_LENSES` entries are uploaded, and each entry specifies a world-space
+`position`, `radius`, `color`, and optional `intensity`.
 
 ## Usage
 

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -40,6 +40,9 @@ import {
   glassTransmissionPlugin,
   getABufferSupport,
   getWBOITSupport,
+  MAX_OPTICAL_CAUSTIC_LENSES,
+  opticalCaustics,
+  opticalCausticsPlugin,
   opticalPointLights,
   opticalPointLightsPlugin,
   reflectiveMaterial,
@@ -48,6 +51,8 @@ import {
   type EmissiveMaterialProps,
   type GlassMaterialProps,
   type GlassTransmissionProps,
+  type OpticalCausticLens,
+  type OpticalCausticsProps,
   type OpticalPointLight,
   type OpticalPointLightsProps,
   type ReflectiveMaterialProps,
@@ -99,6 +104,7 @@ import {
   makeHostColor,
   makeLinkColor,
   makeLinkKey,
+  makeLinkTraffic,
   makeLinks,
   makePackets,
   makePickableNetworkNodes,
@@ -118,6 +124,14 @@ import {
   type SwitchArrival,
   type Vector3
 } from './network';
+import {
+  getNetworkStoryChapter,
+  getWrappedStoryChapterIndex,
+  GUIDED_STORY_SWITCH_INDEX,
+  NETWORK_STORY_CHAPTERS,
+  type NetworkStoryCamera,
+  type NetworkStoryChapter
+} from './story';
 
 type TransparencyMode = 'a-buffer' | 'weighted-blended' | 'sorted-alpha';
 
@@ -238,12 +252,18 @@ fn fragmentMain(inputs: VertexOutputs) -> @location(0) vec4<f32> {
 const REFLECTIVE_WGSL_SHADER = /* wgsl */ `${WGSL_SHADER}
 @fragment
 fn fragmentReflective(inputs: VertexOutputs) -> @location(0) vec4<f32> {
-  let color = reflectiveMaterial_getIlluminatedColor(
+  let reflectiveColor = reflectiveMaterial_getIlluminatedColor(
     inputs.normal,
     inputs.worldPosition,
     inputs.color,
     app.cameraPosition
   );
+  let causticColor = opticalCaustics_getColor(
+    inputs.normal,
+    inputs.worldPosition,
+    app.cameraPosition
+  );
+  let color = vec4<f32>(reflectiveColor.rgb + causticColor, reflectiveColor.a);
 #if OPAQUE_REFLECTIVE
   return vec4<f32>(color.rgb, inputs.color.a);
 #else
@@ -478,12 +498,18 @@ in vec3 vWorldPosition;
 out vec4 fragColor;
 
 void main(void) {
-  vec4 color = reflectiveMaterial_getIlluminatedColor(
+  vec4 reflectiveColor = reflectiveMaterial_getIlluminatedColor(
     vNormal,
     vWorldPosition,
     vColor,
     app.cameraPosition
   );
+  vec3 causticColor = opticalCaustics_getColor(
+    vNormal,
+    vWorldPosition,
+    app.cameraPosition
+  );
+  vec4 color = vec4(reflectiveColor.rgb + causticColor, reflectiveColor.a);
 #if OPAQUE_REFLECTIVE
   fragColor = vec4(color.rgb, vColor.a);
 #else
@@ -557,6 +583,7 @@ const INSTANCE_BUFFER_LAYOUT = [
 
 const PACKET_TRAIL_RADIUS = 0.033;
 const SWITCH_FLASH_DURATION = 0.16;
+const SWITCH_RIPPLE_DURATION = 0.38;
 const MAX_SWITCH_FLASH_LIGHTS = 6;
 const MAX_STORY_PACKET_INSTANCES = 160;
 const CONGESTED_SWITCH_COLOR: Color = [1, 0.42, 0.065, 0.56];
@@ -704,6 +731,7 @@ class InstancedMesh<
       plugins: [
         ...(pickable ? [networkNodePickingPlugin] : []),
         ...(glass || reflective ? [opticalPointLightsPlugin] : []),
+        ...(reflective ? [opticalCausticsPlugin] : []),
         ...(glass ? [glassMaterialPlugin] : []),
         ...(glass ? [glassTransmissionPlugin] : []),
         ...(reflective ? [reflectiveMaterialPlugin] : []),
@@ -766,6 +794,10 @@ class InstancedMesh<
 
   updateInstances(matrices: Float32Array, colors: Float32Array): void {
     this.matrixBuffer.write(matrices);
+    this.colorBuffer.write(colors);
+  }
+
+  updateColors(colors: Float32Array): void {
     this.colorBuffer.write(colors);
   }
 
@@ -836,7 +868,9 @@ class NetworkNodePopup {
         ? '#ff665a'
         : node.status === 'congested' || node.status === 'detecting'
           ? '#ffad52'
-          : '#82acf2';
+          : node.status === 'probing'
+            ? '#73d3ff'
+            : '#82acf2';
     this.descriptionElement.textContent = node.description;
     this.detailElement.textContent = node.detail;
     this.popupElement.style.display = 'block';
@@ -856,20 +890,158 @@ class NetworkNodePopup {
   }
 }
 
+class NetworkStoryControls {
+  private readonly rootElement: HTMLDivElement;
+  private readonly titleElement: HTMLDivElement;
+  private readonly descriptionElement: HTMLParagraphElement;
+  private readonly chapterPositionElement: HTMLSpanElement;
+  private readonly playbackButton: HTMLButtonElement;
+
+  constructor(
+    canvas: HTMLCanvasElement,
+    {
+      onNext,
+      onPrevious,
+      onTogglePlayback
+    }: {
+      onNext: () => void;
+      onPrevious: () => void;
+      onTogglePlayback: () => void;
+    }
+  ) {
+    this.rootElement = document.createElement('div');
+    this.rootElement.dataset.networkStoryControls = '';
+    this.rootElement.setAttribute('role', 'region');
+    this.rootElement.setAttribute('aria-label', 'Network packet spraying guided tour');
+    Object.assign(this.rootElement.style, {
+      position: 'fixed',
+      left: '18px',
+      bottom: '18px',
+      zIndex: '15',
+      width: 'min(360px, calc(100vw - 36px))',
+      padding: '14px 16px',
+      boxSizing: 'border-box',
+      border: '1px solid rgba(126, 157, 205, 0.26)',
+      borderRadius: '8px',
+      background: 'rgba(8, 12, 20, 0.86)',
+      backdropFilter: 'blur(12px)',
+      color: '#eff4fd',
+      font: '13px/1.45 system-ui, sans-serif'
+    });
+
+    const headingElement = document.createElement('div');
+    headingElement.textContent = 'GUIDED NETWORK TOUR';
+    Object.assign(headingElement.style, {
+      color: '#88a9d6',
+      fontSize: '10px',
+      fontWeight: '650'
+    });
+
+    this.titleElement = document.createElement('div');
+    this.titleElement.setAttribute('aria-live', 'polite');
+    Object.assign(this.titleElement.style, {
+      marginTop: '5px',
+      fontSize: '15px',
+      fontWeight: '650'
+    });
+
+    this.descriptionElement = document.createElement('p');
+    Object.assign(this.descriptionElement.style, {
+      margin: '6px 0 12px',
+      color: '#bcc9dc'
+    });
+
+    const actionsElement = document.createElement('div');
+    Object.assign(actionsElement.style, {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '7px'
+    });
+
+    const previousButton = this.makeButton('Back', 'Previous story chapter', onPrevious);
+    previousButton.dataset.networkStoryPrevious = '';
+    this.playbackButton = this.makeButton('Play', 'Play guided network tour', onTogglePlayback);
+    this.playbackButton.dataset.networkStoryPlayback = '';
+    const nextButton = this.makeButton('Next', 'Next story chapter', onNext);
+    nextButton.dataset.networkStoryNext = '';
+    this.chapterPositionElement = document.createElement('span');
+    Object.assign(this.chapterPositionElement.style, {
+      marginLeft: 'auto',
+      color: '#90a2bd',
+      fontSize: '12px'
+    });
+
+    actionsElement.append(
+      previousButton,
+      this.playbackButton,
+      nextButton,
+      this.chapterPositionElement
+    );
+    this.rootElement.append(
+      headingElement,
+      this.titleElement,
+      this.descriptionElement,
+      actionsElement
+    );
+    (canvas.parentElement || document.body).appendChild(this.rootElement);
+  }
+
+  update(chapter: NetworkStoryChapter, chapterIndex: number, isPlaying: boolean): void {
+    this.titleElement.textContent = chapter.title;
+    this.descriptionElement.textContent = chapter.description;
+    this.chapterPositionElement.textContent = `${chapterIndex + 1} / ${NETWORK_STORY_CHAPTERS.length}`;
+    this.playbackButton.textContent = isPlaying ? 'Pause' : 'Play';
+    this.playbackButton.setAttribute(
+      'aria-label',
+      isPlaying ? 'Pause guided network tour' : 'Play guided network tour'
+    );
+    this.rootElement.dataset.networkStoryChapter = chapter.id;
+    this.rootElement.dataset.networkStoryPlaying = String(isPlaying);
+  }
+
+  destroy(): void {
+    this.rootElement.remove();
+  }
+
+  private makeButton(
+    label: string,
+    accessibleLabel: string,
+    onClick: () => void
+  ): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    button.setAttribute('aria-label', accessibleLabel);
+    Object.assign(button.style, {
+      padding: '5px 10px',
+      border: '1px solid rgba(140, 169, 211, 0.3)',
+      borderRadius: '5px',
+      background: 'rgba(30, 41, 58, 0.75)',
+      color: '#edf3fc',
+      cursor: 'pointer',
+      font: '12px system-ui, sans-serif'
+    });
+    button.addEventListener('click', onClick);
+    return button;
+  }
+}
+
 export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTemplate {
   static info = makeExamplePanelHostHtml();
 
   readonly backfaceShaderInputs = new ShaderInputs<{app: AppUniforms}>({app: appShaderModule});
   readonly reflectiveShaderInputs = new ShaderInputs<{
     app: AppUniforms;
+    opticalCaustics: OpticalCausticsProps;
     opticalPointLights: OpticalPointLightsProps;
     reflectiveMaterial: ReflectiveMaterialProps;
-  }>({app: appShaderModule, opticalPointLights, reflectiveMaterial});
+  }>({app: appShaderModule, opticalCaustics, opticalPointLights, reflectiveMaterial});
   readonly metallicShaderInputs = new ShaderInputs<{
     app: AppUniforms;
+    opticalCaustics: OpticalCausticsProps;
     opticalPointLights: OpticalPointLightsProps;
     reflectiveMaterial: ReflectiveMaterialProps;
-  }>({app: appShaderModule, opticalPointLights, reflectiveMaterial});
+  }>({app: appShaderModule, opticalCaustics, opticalPointLights, reflectiveMaterial});
   readonly emissiveShaderInputs = new ShaderInputs<{
     app: AppUniforms;
     emissiveMaterial: EmissiveMaterialProps;
@@ -912,11 +1084,13 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly environmentTexture: Texture;
   readonly links: InstancedMesh<{
     app: AppUniforms;
+    opticalCaustics: OpticalCausticsProps;
     opticalPointLights: OpticalPointLightsProps;
     reflectiveMaterial: ReflectiveMaterialProps;
   }>;
   readonly hosts: InstancedMesh<{
     app: AppUniforms;
+    opticalCaustics: OpticalCausticsProps;
     opticalPointLights: OpticalPointLightsProps;
     reflectiveMaterial: ReflectiveMaterialProps;
   }>;
@@ -936,8 +1110,12 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly originalGlassColors: Color[];
   readonly congestedSwitchIndices = new Set<number>();
   readonly failedSwitchIndices = new Set<number>();
+  readonly recoveringSwitchIndices = new Set<number>();
   readonly conversationRoutes: ConversationRoute[];
   readonly networkLinks: NetworkLink[];
+  readonly linkColors: Float32Array;
+  readonly redLinkTrafficStrengths: Float32Array;
+  readonly greenLinkTrafficStrengths: Float32Array;
   readonly packets: InstancedMesh<{
     app: AppUniforms;
     emissiveMaterial: EmissiveMaterialProps;
@@ -947,6 +1125,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     emissiveMaterial: EmissiveMaterialProps;
   }>;
   readonly switchFlashes: InstancedMesh<{
+    app: AppUniforms;
+    emissiveMaterial: EmissiveMaterialProps;
+  }>;
+  readonly switchRipples: InstancedMesh<{
     app: AppUniforms;
     emissiveMaterial: EmissiveMaterialProps;
   }>;
@@ -962,23 +1144,39 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly switchFlashMatrices: Float32Array;
   readonly switchFlashColors: Float32Array;
   readonly switchFlashStrengths: Float32Array;
+  readonly switchRippleMatrices: Float32Array;
+  readonly switchRippleColors: Float32Array;
+  readonly switchRippleAges: Float32Array;
+  readonly causticLensLightColors = new Float32Array(SWITCH_POSITIONS.length * 3);
   readonly storyPacketMatrices = new Float32Array(MAX_STORY_PACKET_INSTANCES * 16);
   readonly storyPacketColors = new Float32Array(MAX_STORY_PACKET_INSTANCES * 4);
   readonly networkPacketEvents: NetworkPacketEvent[] = [];
   orbitControls: OrbitControls | null = null;
   nodePopup: NetworkNodePopup | null = null;
+  storyControls: NetworkStoryControls | null = null;
 
   private canvas: HTMLCanvasElement | null = null;
   private pendingPickRequest: NetworkNodePickRequest | null = null;
   private readonly detectingSwitchTimes = new Map<number, number>();
   private readonly nextCongestionTrimTimes = new Map<number, number>();
   private readonly nextSwitchProbeTimes = new Map<number, number>();
+  private readonly recoveryProbeCompletionTimes = new Map<number, number>();
   private animationTime = 0;
   private droppedPacketCount = 0;
   private trimmedPacketCount = 0;
   private pickingInProgress = false;
   private pointerDownPosition: [number, number] | null = null;
   private pointerSequence = 0;
+  private previousLinkTrafficTime: number | null = null;
+  private previousCausticTime: number | null = null;
+  private guidedStoryChapterIndex = 0;
+  private guidedStoryChapterStartedAt = 0;
+  private guidedStoryElapsedAtPause = 0;
+  private guidedStoryPlaying = false;
+  private guidedStoryStarted = false;
+  private guidedStoryCamera: NetworkStoryCamera | null = null;
+  private guidedStoryCameraTransitionEndsAt = 0;
+  private guidedStoryPreviousCameraTime: number | null = null;
 
   transparencyMode: TransparencyMode;
   speed = 0.85;
@@ -995,12 +1193,19 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   glassTransmissionStrength = 1.12;
   glassEnvironmentIntensity = 1.25;
   glassVolumeThickness = 1;
+  glassDynamicReflectionStrength = 0.38;
+  glassSecondaryBounceStrength = 0.55;
+  glassFaultDistortionStrength = 0.42;
   packetEmission = 5.2;
   packetTrailLength = 0.19;
   packetTrailIntensity = 0.55;
   switchFlashIntensity = 0.8;
+  switchRippleIntensity = 0.44;
   packetLightIntensity = 0.66;
   packetLightRadius = 1.05;
+  linkTrafficGlow = 0.58;
+  causticIntensity = 0.48;
+  causticFocus = 1.15;
   bloomIntensity = 1.7;
   bloomThreshold = 0.42;
   exposure = 0.96;
@@ -1057,11 +1262,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
     this.conversationRoutes = makeConversationRoutes();
     this.networkLinks = makeLinks(this.conversationRoutes);
+    this.linkColors = flattenColors(this.networkLinks.map(({color}) => color));
+    this.redLinkTrafficStrengths = new Float32Array(this.networkLinks.length);
+    this.greenLinkTrafficStrengths = new Float32Array(this.networkLinks.length);
     this.links = new InstancedMesh(device, this.reflectiveShaderInputs, {
       id: 'packet-spraying-links',
       geometry: new CylinderGeometry({radius: 1, height: 1, nradial: 16, nvertical: 1}),
       matrices: flattenMatrices(this.networkLinks.map(link => makeLinkMatrix(link, 0.09))),
-      colors: flattenColors(this.networkLinks.map(({color}) => color)),
+      colors: this.linkColors,
       transparent: true,
       reflective: true
     });
@@ -1177,6 +1385,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.switchFlashMatrices = new Float32Array(switchFlashCount * 16);
     this.switchFlashColors = new Float32Array(switchFlashCount * 4);
     this.switchFlashStrengths = new Float32Array(switchFlashCount);
+    this.switchRippleMatrices = new Float32Array(switchFlashCount * 16);
+    this.switchRippleColors = new Float32Array(switchFlashCount * 4);
+    this.switchRippleAges = new Float32Array(switchFlashCount);
     this.updatePacketVisuals(0);
     this.packets = new InstancedMesh(device, this.emissiveShaderInputs, {
       id: 'packet-spraying-packets',
@@ -1209,6 +1420,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       additive: true,
       emissive: true
     });
+    this.switchRipples = new InstancedMesh(device, this.emissiveShaderInputs, {
+      id: 'packet-spraying-switch-arrival-ripples',
+      geometry: new SphereGeometry({radius: 1, nlat: 12, nlong: 18}),
+      matrices: this.switchRippleMatrices,
+      colors: this.switchRippleColors,
+      additive: true,
+      emissive: true
+    });
     this.storyPackets = new InstancedMesh(device, this.emissiveShaderInputs, {
       id: 'packet-spraying-network-story-packets',
       geometry: new SphereGeometry({radius: 1, nlat: 8, nlong: 12}),
@@ -1237,12 +1456,19 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         glassTransmissionStrength: this.glassTransmissionStrength,
         glassEnvironmentIntensity: this.glassEnvironmentIntensity,
         glassVolumeThickness: this.glassVolumeThickness,
+        glassDynamicReflectionStrength: this.glassDynamicReflectionStrength,
+        glassSecondaryBounceStrength: this.glassSecondaryBounceStrength,
+        glassFaultDistortionStrength: this.glassFaultDistortionStrength,
         packetEmission: this.packetEmission,
         packetTrailLength: this.packetTrailLength,
         packetTrailIntensity: this.packetTrailIntensity,
         switchFlashIntensity: this.switchFlashIntensity,
+        switchRippleIntensity: this.switchRippleIntensity,
         packetLightIntensity: this.packetLightIntensity,
         packetLightRadius: this.packetLightRadius,
+        linkTrafficGlow: this.linkTrafficGlow,
+        causticIntensity: this.causticIntensity,
+        causticFocus: this.causticFocus,
         bloomIntensity: this.bloomIntensity,
         bloomThreshold: this.bloomThreshold,
         exposure: this.exposure
@@ -1279,19 +1505,32 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       canvas.addEventListener('pointerdown', this.handlePointerDown);
       canvas.addEventListener('pointerleave', this.handlePointerLeave);
       canvas.addEventListener('click', this.handleSwitchClick);
+      this.storyControls = new NetworkStoryControls(canvas, {
+        onNext: () => this.moveGuidedStoryChapter(1),
+        onPrevious: () => this.moveGuidedStoryChapter(-1),
+        onTogglePlayback: () => this.setGuidedStoryPlaying(!this.guidedStoryPlaying)
+      });
+      this.updateGuidedStoryControls();
       this.updateFailureAccessibility();
+
+      if (new URLSearchParams(window.location.search).get('story') === '1') {
+        this.setGuidedStoryPlaying(true);
+      }
     }
   }
 
   override onRender({device, width, height, aspect, time}: AnimationProps): void {
     this.resizeSceneFramebuffer(width, height);
     this.animationTime = (time / 1000) * this.speed;
+    this.updateGuidedStory(this.animationTime);
     this.updateSwitchStoryState(this.animationTime);
     this.updatePacketVisuals(this.animationTime);
+    this.updateLinkTraffic(this.animationTime);
     this.updateStoryPacketVisuals(this.animationTime);
     this.packets.updateMatrices(this.packetMatrices);
     this.packetTrails.updateInstances(this.packetTrailMatrices, this.packetTrailColors);
     this.switchFlashes.updateInstances(this.switchFlashMatrices, this.switchFlashColors);
+    this.switchRipples.updateInstances(this.switchRippleMatrices, this.switchRippleColors);
     this.storyPackets.updateInstances(this.storyPacketMatrices, this.storyPacketColors);
 
     this.orbitControls?.update(time);
@@ -1327,23 +1566,39 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       backfaceTexture: this.glassBackfaceTexture,
       environmentTexture: this.environmentTexture,
       environmentIntensity: this.glassEnvironmentIntensity,
-      thicknessStrength: this.glassVolumeThickness
+      thicknessStrength: this.glassVolumeThickness,
+      dynamicReflectionStrength: this.glassDynamicReflectionStrength,
+      secondaryBounceStrength: this.glassSecondaryBounceStrength,
+      faultDistortionStrength: this.glassFaultDistortionStrength,
+      time: this.animationTime
     };
+    const packetLights = this.makePacketLights();
     const pointLightProps: OpticalPointLightsProps = {
-      lights: this.makePacketLights(),
+      lights: packetLights,
       intensity: this.packetLightIntensity
     };
+    const causticLenses = this.makeCausticLenses(packetLights, this.animationTime);
+    const causticProps: OpticalCausticsProps = {
+      lenses: causticLenses,
+      intensity: this.causticIntensity,
+      focus: this.causticFocus
+    };
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingCausticLenses = String(causticLenses.length);
+    }
     this.emissiveShaderInputs.setProps({
       app: uniforms,
       emissiveMaterial: {intensity: this.packetEmission, rimStrength: 0.32}
     });
     this.reflectiveShaderInputs.setProps({
       app: uniforms,
+      opticalCaustics: causticProps,
       reflectiveMaterial: {},
       opticalPointLights: pointLightProps
     });
     this.metallicShaderInputs.setProps({
       app: uniforms,
+      opticalCaustics: causticProps,
       reflectiveMaterial: {
         roughness: 0.32,
         reflectionStrength: 0.26,
@@ -1364,6 +1619,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.packets.model.predraw(device.commandEncoder);
     this.packetTrails.model.predraw(device.commandEncoder);
     this.switchFlashes.model.predraw(device.commandEncoder);
+    this.switchRipples.model.predraw(device.commandEncoder);
     this.storyPackets.model.predraw(device.commandEncoder);
     this.links.model.predraw(device.commandEncoder);
     const sceneRenderPass = device.beginRenderPass({
@@ -1375,6 +1631,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.packets.model.draw(sceneRenderPass);
     this.packetTrails.model.draw(sceneRenderPass);
     this.switchFlashes.model.draw(sceneRenderPass);
+    this.switchRipples.model.draw(sceneRenderPass);
     this.storyPackets.model.draw(sceneRenderPass);
     this.links.model.draw(sceneRenderPass);
     sceneRenderPass.end();
@@ -1491,6 +1748,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.canvas?.removeEventListener('pointerleave', this.handlePointerLeave);
     this.canvas?.removeEventListener('click', this.handleSwitchClick);
     this.nodePopup?.destroy();
+    this.storyControls?.destroy();
     this.settingsPanel.finalize();
     this.panels.finalize();
     this.orbitControls?.destroy();
@@ -1509,6 +1767,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.packets.destroy();
     this.packetTrails.destroy();
     this.switchFlashes.destroy();
+    this.switchRipples.destroy();
     this.storyPackets.destroy();
     this.postprocessingRenderer.destroy();
     this.aBufferRenderer?.destroy();
@@ -1571,6 +1830,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         ) {
           const switchIndex = objectIndex - HOST_POSITIONS.length;
           if (switchIndex >= 0 && switchIndex < this.glassInstances.length) {
+            if (this.guidedStoryPlaying) {
+              this.setGuidedStoryPlaying(false);
+            }
             this.advanceSwitchState(switchIndex);
           }
         }
@@ -1644,6 +1906,167 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.nodePopup?.hide();
   };
 
+  private setGuidedStoryPlaying(isPlaying: boolean): void {
+    if (isPlaying === this.guidedStoryPlaying) {
+      return;
+    }
+
+    this.guidedStoryPlaying = isPlaying;
+    if (isPlaying) {
+      this.orbitControls?.setAutoRotate(false);
+      if (this.guidedStoryStarted) {
+        this.guidedStoryChapterStartedAt = this.animationTime - this.guidedStoryElapsedAtPause;
+      } else {
+        this.guidedStoryStarted = true;
+        this.enterGuidedStoryChapter(this.guidedStoryChapterIndex);
+      }
+    } else {
+      this.guidedStoryElapsedAtPause = this.animationTime - this.guidedStoryChapterStartedAt;
+      this.guidedStoryCameraTransitionEndsAt = this.animationTime;
+      this.orbitControls?.setAutoRotate(this.orbit > 0);
+    }
+
+    this.updateGuidedStoryControls();
+  }
+
+  private moveGuidedStoryChapter(direction: number): void {
+    this.guidedStoryStarted = true;
+    this.enterGuidedStoryChapter(this.guidedStoryChapterIndex + direction);
+  }
+
+  private enterGuidedStoryChapter(chapterIndex: number): void {
+    this.guidedStoryChapterIndex = getWrappedStoryChapterIndex(chapterIndex);
+    this.guidedStoryChapterStartedAt = this.animationTime;
+    this.guidedStoryElapsedAtPause = 0;
+    this.guidedStoryCamera = getNetworkStoryChapter(this.guidedStoryChapterIndex).camera;
+    this.guidedStoryCameraTransitionEndsAt = this.animationTime + 1.4;
+    this.guidedStoryPreviousCameraTime = null;
+
+    const switchIndex = GUIDED_STORY_SWITCH_INDEX;
+    const chapter = getNetworkStoryChapter(this.guidedStoryChapterIndex);
+
+    switch (chapter.networkState) {
+      case 'healthy':
+        this.resetGuidedStoryNetwork();
+        break;
+
+      case 'congested':
+        this.resetGuidedStoryNetwork();
+        this.advanceSwitchState(switchIndex);
+        break;
+
+      case 'failed':
+        if (this.recoveringSwitchIndices.has(switchIndex)) {
+          this.resetGuidedStoryNetwork();
+        }
+        if (!this.failedSwitchIndices.has(switchIndex)) {
+          if (!this.congestedSwitchIndices.has(switchIndex)) {
+            this.advanceSwitchState(switchIndex);
+          }
+          if (this.congestedSwitchIndices.has(switchIndex)) {
+            this.advanceSwitchState(switchIndex);
+          }
+        }
+        break;
+
+      case 'recovering':
+        if (this.recoveringSwitchIndices.has(switchIndex)) {
+          break;
+        }
+        if (this.detectingSwitchTimes.has(switchIndex)) {
+          this.completeSwitchFailure(switchIndex);
+        }
+        if (this.congestedSwitchIndices.has(switchIndex)) {
+          this.advanceSwitchState(switchIndex);
+          this.completeSwitchFailure(switchIndex);
+        }
+        if (!this.failedSwitchIndices.has(switchIndex)) {
+          this.completeSwitchFailure(switchIndex);
+        }
+        this.advanceSwitchState(switchIndex);
+        break;
+    }
+
+    this.updateGuidedStoryControls();
+  }
+
+  private resetGuidedStoryNetwork(): void {
+    const affectedSwitchIndices = new Set([
+      ...this.congestedSwitchIndices,
+      ...this.failedSwitchIndices,
+      ...this.recoveringSwitchIndices,
+      ...this.detectingSwitchTimes.keys()
+    ]);
+
+    for (const switchIndex of affectedSwitchIndices) {
+      this.glassInstances[switchIndex].color = [...this.originalGlassColors[switchIndex]] as Color;
+    }
+
+    this.congestedSwitchIndices.clear();
+    this.failedSwitchIndices.clear();
+    this.recoveringSwitchIndices.clear();
+    this.detectingSwitchTimes.clear();
+    this.nextCongestionTrimTimes.clear();
+    this.nextSwitchProbeTimes.clear();
+    this.recoveryProbeCompletionTimes.clear();
+    this.networkPacketEvents.splice(0, this.networkPacketEvents.length);
+    this.updateSwitchColors();
+    this.updateHealthyRoutes();
+    this.updateFailureAccessibility();
+  }
+
+  private updateGuidedStory(animationTime: number): void {
+    if (!this.guidedStoryStarted) {
+      return;
+    }
+
+    if (this.guidedStoryPlaying) {
+      const chapter = getNetworkStoryChapter(this.guidedStoryChapterIndex);
+      if (animationTime - this.guidedStoryChapterStartedAt >= chapter.duration) {
+        this.enterGuidedStoryChapter(this.guidedStoryChapterIndex + 1);
+      }
+    }
+
+    if (
+      !this.guidedStoryCamera ||
+      !this.orbitControls ||
+      (!this.guidedStoryPlaying && animationTime >= this.guidedStoryCameraTransitionEndsAt)
+    ) {
+      return;
+    }
+
+    const elapsedTime = Math.min(
+      Math.max(animationTime - (this.guidedStoryPreviousCameraTime ?? animationTime - 1 / 60), 0),
+      0.12
+    );
+    const smoothing = 1 - Math.exp(-elapsedTime * 3.8);
+    const controls = this.orbitControls;
+    const camera = this.guidedStoryCamera;
+    const yawDelta = Math.atan2(
+      Math.sin(camera.yaw - controls.yaw),
+      Math.cos(camera.yaw - controls.yaw)
+    );
+
+    controls.yaw += yawDelta * smoothing;
+    controls.pitch += (camera.pitch - controls.pitch) * smoothing;
+    controls.distance += (camera.distance - controls.distance) * smoothing;
+    controls.props.target = [
+      controls.props.target[0] + (camera.target[0] - controls.props.target[0]) * smoothing,
+      controls.props.target[1] + (camera.target[1] - controls.props.target[1]) * smoothing,
+      controls.props.target[2] + (camera.target[2] - controls.props.target[2]) * smoothing
+    ];
+    this.guidedStoryPreviousCameraTime = animationTime;
+  }
+
+  private updateGuidedStoryControls(): void {
+    const chapter = getNetworkStoryChapter(this.guidedStoryChapterIndex);
+    this.storyControls?.update(chapter, this.guidedStoryChapterIndex, this.guidedStoryPlaying);
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingStoryChapter = chapter.id;
+      this.canvas.dataset.packetSprayingStoryPlaying = String(this.guidedStoryPlaying);
+    }
+  }
+
   private getPickableNode(objectIndex: number): PickableNetworkNode | undefined {
     const node = this.pickableNodes[objectIndex];
     if (!node || objectIndex < HOST_POSITIONS.length) {
@@ -1657,8 +2080,19 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         role: `FAILED / ${node.role}`,
         description:
           'This switch dropped in-flight packets. MRC retired its paths, retransmitted the missing data, and now sends occasional recovery probes.',
-        detail: 'Click again to restore this switch and return its paths to service.',
+        detail: 'Click again to repair this switch and verify its path with a control probe.',
         status: 'offline'
+      };
+    }
+
+    if (this.recoveringSwitchIndices.has(switchIndex)) {
+      return {
+        ...node,
+        role: `RECOVERY PROBE / ${node.role}`,
+        description:
+          'This repaired switch remains out of service while a blue control packet verifies that its path is reachable.',
+        detail: 'Ordinary red and green traffic resumes only after the recovery probe arrives.',
+        status: 'probing'
       };
     }
 
@@ -1692,10 +2126,19 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   }
 
   private advanceSwitchState(switchIndex: number): void {
+    if (this.recoveringSwitchIndices.has(switchIndex)) {
+      return;
+    }
+
     if (this.failedSwitchIndices.has(switchIndex)) {
       this.failedSwitchIndices.delete(switchIndex);
       this.nextSwitchProbeTimes.delete(switchIndex);
       this.glassInstances[switchIndex].color = [...this.originalGlassColors[switchIndex]] as Color;
+
+      if (makeSwitchProbeEvent(this.conversationRoutes, switchIndex, this.animationTime)) {
+        this.recoveringSwitchIndices.add(switchIndex);
+        this.nextSwitchProbeTimes.set(switchIndex, this.animationTime);
+      }
     } else if (this.detectingSwitchTimes.has(switchIndex)) {
       this.completeSwitchFailure(switchIndex);
       return;
@@ -1721,6 +2164,15 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.failedSwitchIndices.add(switchIndex);
     this.nextSwitchProbeTimes.set(switchIndex, this.animationTime + SWITCH_PROBE_INTERVAL);
     this.glassInstances[switchIndex].color = [...FAILED_SWITCH_COLOR];
+    this.updateSwitchColors();
+    this.updateHealthyRoutes();
+    this.updateFailureAccessibility();
+  }
+
+  private completeSwitchRecovery(switchIndex: number): void {
+    this.recoveringSwitchIndices.delete(switchIndex);
+    this.recoveryProbeCompletionTimes.delete(switchIndex);
+    this.glassInstances[switchIndex].color = [...this.originalGlassColors[switchIndex]] as Color;
     this.updateSwitchColors();
     this.updateHealthyRoutes();
     this.updateFailureAccessibility();
@@ -1760,11 +2212,31 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
     for (const [switchIndex, nextProbeTime] of this.nextSwitchProbeTimes) {
       if (animationTime >= nextProbeTime) {
-        const probe = makeSwitchProbeEvent(this.conversationRoutes, switchIndex, nextProbeTime);
+        const unavailableSwitchIndices = new Set([
+          ...this.failedSwitchIndices,
+          ...this.recoveringSwitchIndices
+        ]);
+        const probe = makeSwitchProbeEvent(
+          this.conversationRoutes,
+          switchIndex,
+          nextProbeTime,
+          unavailableSwitchIndices
+        );
         if (probe) {
           this.networkPacketEvents.push(probe);
+          if (this.recoveringSwitchIndices.has(switchIndex)) {
+            this.recoveryProbeCompletionTimes.set(switchIndex, probe.startedAt + probe.duration);
+            this.nextSwitchProbeTimes.delete(switchIndex);
+            continue;
+          }
         }
         this.nextSwitchProbeTimes.set(switchIndex, nextProbeTime + SWITCH_PROBE_INTERVAL);
+      }
+    }
+
+    for (const [switchIndex, completionTime] of this.recoveryProbeCompletionTimes) {
+      if (animationTime >= completionTime) {
+        this.completeSwitchRecovery(switchIndex);
       }
     }
 
@@ -1789,7 +2261,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private updateHealthyRoutes(): void {
     const healthyRoutes = getHealthyConversationRoutes(
       this.conversationRoutes,
-      this.failedSwitchIndices
+      this.failedSwitchIndices,
+      this.recoveringSwitchIndices
     );
     reroutePackets(this.packetDefinitions, healthyRoutes);
     this.switchArrivalEvents = makeSwitchArrivals(this.packetDefinitions);
@@ -1815,6 +2288,62 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     );
   }
 
+  private updateLinkTraffic(animationTime: number): void {
+    const trafficByLink = makeLinkTraffic(this.packetDefinitions, animationTime);
+    const elapsedTime = Math.min(
+      Math.max(animationTime - (this.previousLinkTrafficTime ?? animationTime - 1 / 60), 0),
+      0.12
+    );
+    const attack = 1 - Math.exp(-elapsedTime * 12);
+    const decay = 1 - Math.exp(-elapsedTime * 4.5);
+    let illuminatedLinkCount = 0;
+
+    for (let linkIndex = 0; linkIndex < this.networkLinks.length; linkIndex++) {
+      const link = this.networkLinks[linkIndex];
+      const traffic = trafficByLink.get(makeLinkKey(link.start, link.end));
+      const targetRedStrength = Math.min((traffic?.red ?? 0) * 0.42, 1);
+      const targetGreenStrength = Math.min((traffic?.green ?? 0) * 0.42, 1);
+      const previousRedStrength = this.redLinkTrafficStrengths[linkIndex];
+      const previousGreenStrength = this.greenLinkTrafficStrengths[linkIndex];
+      const redStrength =
+        previousRedStrength +
+        (targetRedStrength - previousRedStrength) *
+          (targetRedStrength > previousRedStrength ? attack : decay);
+      const greenStrength =
+        previousGreenStrength +
+        (targetGreenStrength - previousGreenStrength) *
+          (targetGreenStrength > previousGreenStrength ? attack : decay);
+      this.redLinkTrafficStrengths[linkIndex] = redStrength;
+      this.greenLinkTrafficStrengths[linkIndex] = greenStrength;
+
+      const redGlow = redStrength * this.linkTrafficGlow;
+      const greenGlow = greenStrength * this.linkTrafficGlow;
+      const totalGlow = Math.min(redGlow + greenGlow, 1);
+      const colorOffset = linkIndex * 4;
+      this.linkColors[colorOffset] = Math.min(link.color[0] + redGlow * 0.3 + greenGlow * 0.055, 1);
+      this.linkColors[colorOffset + 1] = Math.min(
+        link.color[1] + redGlow * 0.04 + greenGlow * 0.27,
+        1
+      );
+      this.linkColors[colorOffset + 2] = Math.min(link.color[2] + totalGlow * 0.065, 1);
+      this.linkColors[colorOffset + 3] = Math.min(link.color[3] + totalGlow * 0.11, 0.34);
+
+      if (totalGlow > 0.025) {
+        illuminatedLinkCount++;
+      }
+    }
+
+    this.links.updateColors(this.linkColors);
+    this.previousLinkTrafficTime = animationTime;
+
+    if (
+      this.canvas &&
+      this.canvas.dataset.packetSprayingIlluminatedLinks !== String(illuminatedLinkCount)
+    ) {
+      this.canvas.dataset.packetSprayingIlluminatedLinks = String(illuminatedLinkCount);
+    }
+  }
+
   private updateFailureAccessibility(): void {
     if (!this.canvas) {
       return;
@@ -1822,19 +2351,25 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
     const congestedCount = this.congestedSwitchIndices.size;
     const failedCount = this.failedSwitchIndices.size;
+    const recoveringCount = this.recoveringSwitchIndices.size;
     const activePlaneCount = getActivePlaneCount(
-      getHealthyConversationRoutes(this.conversationRoutes, this.failedSwitchIndices)
+      getHealthyConversationRoutes(
+        this.conversationRoutes,
+        this.failedSwitchIndices,
+        this.recoveringSwitchIndices
+      )
     );
     this.canvas.dataset.packetSprayingCongestedSwitches = String(congestedCount);
     this.canvas.dataset.packetSprayingFailedSwitches = String(failedCount);
+    this.canvas.dataset.packetSprayingRecoveringSwitches = String(recoveringCount);
     this.canvas.dataset.packetSprayingActivePlanes = String(activePlaneCount);
     this.canvas.dataset.packetSprayingDroppedPackets = String(this.droppedPacketCount);
     this.canvas.dataset.packetSprayingTrimmedPackets = String(this.trimmedPacketCount);
     this.canvas.setAttribute(
       'aria-label',
-      failedCount === 0 && congestedCount === 0
+      failedCount === 0 && congestedCount === 0 && recoveringCount === 0
         ? 'Network packet spraying: all switches online'
-        : `Network packet spraying: ${congestedCount} congested, ${failedCount} failed, ${activePlaneCount} healthy network plane${activePlaneCount === 1 ? '' : 's'}`
+        : `Network packet spraying: ${congestedCount} congested, ${failedCount} failed, ${recoveringCount} recovering, ${activePlaneCount} healthy network plane${activePlaneCount === 1 ? '' : 's'}`
     );
   }
 
@@ -1995,6 +2530,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
   private updatePacketVisuals(animationTime: number): void {
     this.switchFlashStrengths.fill(0);
+    this.switchRippleAges.fill(Number.POSITIVE_INFINITY);
 
     for (let packetIndex = 0; packetIndex < this.packetDefinitions.length; packetIndex++) {
       const packet = this.packetDefinitions[packetIndex];
@@ -2036,21 +2572,31 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
     for (const arrival of this.switchArrivalEvents) {
       const arrivalAge = wrap(animationTime - arrival.arrivalTime, BURST_CYCLE_DURATION);
+      const flashIndex = arrival.switchIndex * CONVERSATIONS.length + arrival.conversationIndex;
+      if (arrivalAge < SWITCH_RIPPLE_DURATION) {
+        this.switchRippleAges[flashIndex] = Math.min(this.switchRippleAges[flashIndex], arrivalAge);
+      }
       if (arrivalAge >= SWITCH_FLASH_DURATION) {
         continue;
       }
 
       const attack = smoothstep(0, 0.018, arrivalAge);
       const decay = Math.exp(-arrivalAge * 15);
-      const flashIndex = arrival.switchIndex * CONVERSATIONS.length + arrival.conversationIndex;
       this.switchFlashStrengths[flashIndex] = Math.min(
         1,
         this.switchFlashStrengths[flashIndex] + attack * decay
       );
     }
 
+    let activeRippleCount = 0;
     for (let switchIndex = 0; switchIndex < this.glassInstances.length; switchIndex++) {
       const glassInstance = this.glassInstances[switchIndex];
+      const switchRadius =
+        switchIndex < LEAF_POSITIONS.length
+          ? LEAF_SWITCH_RADIUS
+          : switchIndex < LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length
+            ? AGGREGATION_SWITCH_RADIUS
+            : SPINE_SWITCH_RADIUS;
       for (
         let conversationIndex = 0;
         conversationIndex < CONVERSATIONS.length;
@@ -2075,7 +2621,41 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
           ],
           flashIndex * 4
         );
+
+        const rippleAge = this.switchRippleAges[flashIndex];
+        const rippleProgress = rippleAge / SWITCH_RIPPLE_DURATION;
+        const rippleStrength =
+          rippleProgress < 1
+            ? Math.sin(rippleProgress * Math.PI) *
+              (1 - rippleProgress * 0.35) *
+              this.switchRippleIntensity
+            : 0;
+        const rippleRadius = switchRadius * (0.2 + rippleProgress * 0.72);
+        const rippleMatrix =
+          rippleStrength > 0.004
+            ? makeObjectMatrix(glassInstance.position, [rippleRadius, rippleRadius, rippleRadius])
+            : makeObjectMatrix([0, -100, 0], [0.001, 0.001, 0.001]);
+        this.switchRippleMatrices.set(rippleMatrix, flashIndex * 16);
+        this.switchRippleColors.set(
+          [
+            flashColor[0] * rippleStrength * 0.14,
+            flashColor[1] * rippleStrength * 0.14,
+            flashColor[2] * rippleStrength * 0.14,
+            Math.min(rippleStrength * 0.28, 0.22)
+          ],
+          flashIndex * 4
+        );
+        if (rippleStrength > 0.004) {
+          activeRippleCount++;
+        }
       }
+    }
+
+    if (
+      this.canvas &&
+      this.canvas.dataset.packetSprayingSwitchRipples !== String(activeRippleCount)
+    ) {
+      this.canvas.dataset.packetSprayingSwitchRipples = String(activeRippleCount);
     }
   }
 
@@ -2160,6 +2740,70 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       ...switchFlashLights.slice(0, MAX_SWITCH_FLASH_LIGHTS),
       ...secondaryLights
     ].slice(0, 16);
+  }
+
+  private makeCausticLenses(
+    packetLights: readonly OpticalPointLight[],
+    animationTime: number
+  ): OpticalCausticLens[] {
+    const previousTime = this.previousCausticTime;
+    const timeDelta = previousTime === null ? 1 : Math.min(animationTime - previousTime, 0.15);
+    const attack = previousTime === null ? 1 : 1 - Math.exp(-Math.max(timeDelta, 0) * 9);
+    const decay = previousTime === null ? 1 : 1 - Math.exp(-Math.max(timeDelta, 0) * 4);
+    const lenses: OpticalCausticLens[] = [];
+    this.previousCausticTime = animationTime;
+
+    for (let switchIndex = 0; switchIndex < this.glassInstances.length; switchIndex++) {
+      const glassInstance = this.glassInstances[switchIndex];
+      const radius =
+        switchIndex < LEAF_POSITIONS.length
+          ? LEAF_SWITCH_RADIUS
+          : switchIndex < LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length
+            ? AGGREGATION_SWITCH_RADIUS
+            : SPINE_SWITCH_RADIUS;
+      const incomingColor: Vector3 = [0, 0, 0];
+
+      for (const packetLight of packetLights) {
+        const distance = getDistance(packetLight.position, glassInstance.position);
+        const influenceRadius = radius * 1.9;
+        if (distance >= influenceRadius) {
+          continue;
+        }
+
+        const contribution = (1 - distance / influenceRadius) ** 2 * (packetLight.intensity ?? 1);
+        incomingColor[0] += packetLight.color[0] * contribution;
+        incomingColor[1] += packetLight.color[1] * contribution;
+        incomingColor[2] += packetLight.color[2] * contribution;
+      }
+
+      const colorOffset = switchIndex * 3;
+      for (let colorIndex = 0; colorIndex < 3; colorIndex++) {
+        const previousColor = this.causticLensLightColors[colorOffset + colorIndex];
+        const targetColor = incomingColor[colorIndex];
+        const smoothing = targetColor > previousColor ? attack : decay;
+        this.causticLensLightColors[colorOffset + colorIndex] =
+          previousColor + (targetColor - previousColor) * smoothing;
+      }
+
+      const red = this.causticLensLightColors[colorOffset];
+      const green = this.causticLensLightColors[colorOffset + 1];
+      const blue = this.causticLensLightColors[colorOffset + 2];
+      const intensity = Math.max(red, green, blue);
+      if (intensity < 0.035) {
+        continue;
+      }
+
+      lenses.push({
+        position: glassInstance.position,
+        radius,
+        color: [red / intensity, green / intensity, blue / intensity],
+        intensity: Math.min(intensity * 0.68, 1.2)
+      });
+    }
+
+    return lenses
+      .sort((first, second) => (second.intensity ?? 0) - (first.intensity ?? 0))
+      .slice(0, MAX_OPTICAL_CAUSTIC_LENSES);
   }
 
   private makePanel(): Panel {
@@ -2292,6 +2936,30 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.glassVolumeThickness = glassVolumeThickness;
     }
 
+    const glassDynamicReflectionStrength = getChangedSetting(
+      changedSettings,
+      'glassDynamicReflectionStrength'
+    )?.nextValue;
+    if (typeof glassDynamicReflectionStrength === 'number') {
+      this.glassDynamicReflectionStrength = glassDynamicReflectionStrength;
+    }
+
+    const glassSecondaryBounceStrength = getChangedSetting(
+      changedSettings,
+      'glassSecondaryBounceStrength'
+    )?.nextValue;
+    if (typeof glassSecondaryBounceStrength === 'number') {
+      this.glassSecondaryBounceStrength = glassSecondaryBounceStrength;
+    }
+
+    const glassFaultDistortionStrength = getChangedSetting(
+      changedSettings,
+      'glassFaultDistortionStrength'
+    )?.nextValue;
+    if (typeof glassFaultDistortionStrength === 'number') {
+      this.glassFaultDistortionStrength = glassFaultDistortionStrength;
+    }
+
     const packetEmission = getChangedSetting(changedSettings, 'packetEmission')?.nextValue;
     if (typeof packetEmission === 'number') {
       this.packetEmission = packetEmission;
@@ -2318,6 +2986,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.switchFlashIntensity = switchFlashIntensity;
     }
 
+    const switchRippleIntensity = getChangedSetting(
+      changedSettings,
+      'switchRippleIntensity'
+    )?.nextValue;
+    if (typeof switchRippleIntensity === 'number') {
+      this.switchRippleIntensity = switchRippleIntensity;
+    }
+
     const packetLightIntensity = getChangedSetting(
       changedSettings,
       'packetLightIntensity'
@@ -2329,6 +3005,21 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     const packetLightRadius = getChangedSetting(changedSettings, 'packetLightRadius')?.nextValue;
     if (typeof packetLightRadius === 'number') {
       this.packetLightRadius = packetLightRadius;
+    }
+
+    const linkTrafficGlow = getChangedSetting(changedSettings, 'linkTrafficGlow')?.nextValue;
+    if (typeof linkTrafficGlow === 'number') {
+      this.linkTrafficGlow = linkTrafficGlow;
+    }
+
+    const causticIntensity = getChangedSetting(changedSettings, 'causticIntensity')?.nextValue;
+    if (typeof causticIntensity === 'number') {
+      this.causticIntensity = causticIntensity;
+    }
+
+    const causticFocus = getChangedSetting(changedSettings, 'causticFocus')?.nextValue;
+    if (typeof causticFocus === 'number') {
+      this.causticFocus = causticFocus;
     }
 
     const bloomIntensity = getChangedSetting(changedSettings, 'bloomIntensity')?.nextValue;
@@ -2353,10 +3044,11 @@ const PACKET_SPRAYING_ARTICLE_URL = 'https://openai.com/index/mrc-supercomputer-
 const PACKET_SPRAYING_OVERVIEW_HTML = `\
 <p><strong>Network Packet Spraying</strong></p>
 <p><strong>Two conversations, many routes.</strong> The two servers on the right send independent red and green transfers to two destination servers on the left.</p>
+<p>The guided network tour steps through packet spraying, congestion, switch failure, retransmission, and probe-confirmed recovery. Use Play, Back, and Next to follow or inspect each chapter.</p>
 <p>Packets enter their local Tier 0 switch as separate streams. Once the streams meet, the switch forwards alternating red and green packets across four representative independent network planes. The destination-side switches separate the traffic again and deliver each color to its intended server.</p>
-<p>Click any glass switch to move it through three states: healthy, orange and congested, red and failed, then healthy again.</p>
+<p>Click any glass switch to move it from healthy to orange and congested, then red and failed. Clicking a failed switch repairs it, but its path stays offline until a blue recovery probe confirms that the switch is reachable.</p>
 <p>An orange switch trims overloaded packet payloads while their smaller headers continue. A red switch briefly loses in-flight packets before MRC retires the failed plane, retransmits over healthy routes, and sends occasional recovery probes.</p>
-<p>Muted red and green cubes identify each conversation's source and destination; blue cubes are inactive servers. Glass spheres are switches, and faint tubes show the available fabric links. Emissive packets leave short directional trails, briefly illuminate arriving switches, and cast localized colored light onto nearby surfaces.</p>
+<p>Muted red and green cubes identify each conversation's source and destination; blue cubes are inactive servers. Glass spheres are switches, and fabric links softly brighten with red or green light only while packets are traveling through them. Packet arrivals send faint expanding ripples through each switch. Emissive packets leave short directional trails, reflect inside nearby glass, and project focused colored caustics onto adjacent reflective surfaces.</p>
 <p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Read OpenAI's supercomputer networking and MRC article</a></p>`;
 
 const PACKET_SPRAYING_BACKGROUND_HTML = `\
@@ -2365,9 +3057,9 @@ const PACKET_SPRAYING_BACKGROUND_HTML = `\
 <p><strong>Planes and packet spraying:</strong> a high-bandwidth network interface can be split across multiple independent physical planes. In the article's example, an 800 Gb/s interface becomes eight 100 Gb/s connections. This visualization shows four representative paths; each conversation sprays successive packets across all four instead of waiting behind one busy link.</p>
 <p><strong>Throughput:</strong> using many paths at once balances traffic, avoids persistent hot spots, and reduces worst-case transfer latency. That matters for synchronous AI training because an entire GPU group can wait for its slowest communication.</p>
 <p><strong>Congestion and packet trimming:</strong> if a switch cannot forward an entire packet, it can discard the payload while delivering a small header. The destination uses that header to request a retransmission without confusing congestion for a permanent network failure.</p>
-<p><strong>Resilience:</strong> if a link, plane, or switch fails, only packets already committed to that path are lost. The sender retires the affected route, retransmits through surviving planes, and occasionally probes the failed path for recovery. Losing one of eight interface links reduces peak physical bandwidth by one eighth instead of crashing the training job.</p>
+<p><strong>Resilience:</strong> if a link, plane, or switch fails, only packets already committed to that path are lost. The sender retires the affected route, retransmits through surviving planes, and occasionally probes the failed path for recovery. A repaired path does not carry ordinary traffic again until a control probe confirms it is reachable. Losing one of eight interface links reduces peak physical bandwidth by one eighth instead of crashing the training job.</p>
 <p><strong>Source routing:</strong> MRC uses IPv6 Segment Routing (SRv6) to encode a packet's chosen switch sequence. This allows static switch configuration, rapid rerouting, and a simpler control plane without waiting for dynamic routing convergence.</p>
-<p><strong>Rendering:</strong> reusable glass materials combine grazing-angle Fresnel reflection, GGX microfacet highlights, clearcoat, internal shell reflection, thin-film iridescence, and roughness-aware chromatic transmission. Emissive packet cores, directional trails, and switch flashes illuminate the glass through bounded point lights. Floating-point scene color preserves those highlights through exact A-buffer OIT, weighted-blended OIT, or depth-sorted alpha blending before multiscale bloom and filmic tone mapping.</p>
+<p><strong>Rendering:</strong> reusable glass materials combine grazing-angle Fresnel reflection, GGX microfacet highlights, clearcoat, two internal shell bounces, moving scene reflections, thin-film iridescence, and roughness-aware chromatic transmission. Emissive packet cores, directional trails, and switch flashes illuminate nearby glass through bounded point lights and focused raster caustics. Fault-tinted switches add subtle animated lens distortion. Floating-point scene color preserves those highlights through exact A-buffer OIT, weighted-blended OIT, or depth-sorted alpha blending before multiscale bloom and filmic tone mapping.</p>
 <p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Supercomputer networking to accelerate large scale AI training</a></p>`;
 
 function makeGlassInstances(): GlassInstance[] {
@@ -2721,6 +3413,15 @@ function makeSettingsSchema(
             step: 0.05
           },
           {
+            name: 'switchRippleIntensity',
+            label: 'Switch Arrival Ripple',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1.2,
+            step: 0.05
+          },
+          {
             name: 'packetLightIntensity',
             label: 'Local Light Intensity',
             type: 'number',
@@ -2732,6 +3433,33 @@ function makeSettingsSchema(
           {
             name: 'packetLightRadius',
             label: 'Local Light Radius',
+            type: 'number',
+            persist: 'none',
+            min: 0.2,
+            max: 2.5,
+            step: 0.05
+          },
+          {
+            name: 'linkTrafficGlow',
+            label: 'Link Traffic Glow',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1.4,
+            step: 0.05
+          },
+          {
+            name: 'causticIntensity',
+            label: 'Glass Caustic Intensity',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1.5,
+            step: 0.05
+          },
+          {
+            name: 'causticFocus',
+            label: 'Glass Caustic Focus',
             type: 'number',
             persist: 'none',
             min: 0.2,
@@ -2878,6 +3606,33 @@ function makeSettingsSchema(
             persist: 'none',
             min: 0.2,
             max: 2,
+            step: 0.05
+          },
+          {
+            name: 'glassDynamicReflectionStrength',
+            label: 'Moving Scene Reflections',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1.5,
+            step: 0.05
+          },
+          {
+            name: 'glassSecondaryBounceStrength',
+            label: 'Secondary Internal Bounce',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1.5,
+            step: 0.05
+          },
+          {
+            name: 'glassFaultDistortionStrength',
+            label: 'Fault Surface Distortion',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1.5,
             step: 0.05
           }
         ]

--- a/examples/showcase/packet-spraying/network.ts
+++ b/examples/showcase/packet-spraying/network.ts
@@ -49,6 +49,12 @@ export type NetworkLink = {
   startInset: number;
 };
 
+/** Number of red and green packets currently traveling through one physical link. */
+export type NetworkLinkTraffic = {
+  red: number;
+  green: number;
+};
+
 export type Conversation = {
   color: Color;
   destinationHostIndex: number;
@@ -70,7 +76,7 @@ export type PickableNetworkNode = {
   description: string;
   detail: string;
   role: string;
-  status?: 'congested' | 'detecting' | 'offline' | 'online';
+  status?: 'congested' | 'detecting' | 'offline' | 'online' | 'probing';
   title: string;
 };
 
@@ -342,11 +348,19 @@ export function makeSwitchPacketEvents({
 export function makeSwitchProbeEvent(
   conversationRoutes: readonly ConversationRoute[],
   switchIndex: number,
-  startedAt: number
+  startedAt: number,
+  unavailableSwitchIndices?: ReadonlySet<number>
 ): NetworkPacketEvent | null {
   const switchPosition = SWITCH_POSITIONS[switchIndex];
-  const conversationRoute = conversationRoutes.find(({route}) =>
-    route.points.some(position => position === switchPosition)
+  const conversationRoute = conversationRoutes.find(
+    ({route}) =>
+      route.points.some(position => position === switchPosition) &&
+      route.points.every(
+        position =>
+          position === switchPosition ||
+          !unavailableSwitchIndices ||
+          !isFailedSwitchPosition(position, unavailableSwitchIndices)
+      )
   );
   if (!conversationRoute) {
     return null;
@@ -365,10 +379,15 @@ export function makeSwitchProbeEvent(
 
 export function getHealthyConversationRoutes(
   conversationRoutes: readonly ConversationRoute[],
-  failedSwitchIndices: ReadonlySet<number>
+  failedSwitchIndices: ReadonlySet<number>,
+  recoveringSwitchIndices?: ReadonlySet<number>
 ): ConversationRoute[] {
   return conversationRoutes.filter(({route}) =>
-    route.points.every(position => !isFailedSwitchPosition(position, failedSwitchIndices))
+    route.points.every(
+      position =>
+        !isFailedSwitchPosition(position, failedSwitchIndices) &&
+        (!recoveringSwitchIndices || !isFailedSwitchPosition(position, recoveringSwitchIndices))
+    )
   );
 }
 
@@ -407,6 +426,47 @@ export function makeActiveLinkKeys(conversationRoutes: ConversationRoute[]): Set
   }
 
   return activeLinkKeys;
+}
+
+/** Classifies visible packets by their current route segment and traffic color. */
+export function makeLinkTraffic(
+  packets: readonly Packet[],
+  animationTime: number
+): Map<string, NetworkLinkTraffic> {
+  const trafficByLink = new Map<string, NetworkLinkTraffic>();
+
+  for (const packet of packets) {
+    if (!packet.enabled) {
+      continue;
+    }
+
+    const packetAge =
+      (((animationTime - packet.launchTime) % BURST_CYCLE_DURATION) + BURST_CYCLE_DURATION) %
+      BURST_CYCLE_DURATION;
+    const packetDistance = packetAge * PACKET_TRAVEL_SPEED;
+    if (packetDistance > packet.route.totalLength) {
+      continue;
+    }
+
+    let segmentIndex = 0;
+    while (
+      segmentIndex < packet.route.cumulativeLengths.length - 2 &&
+      packet.route.cumulativeLengths[segmentIndex + 1] < packetDistance
+    ) {
+      segmentIndex++;
+    }
+
+    const linkKey = makeLinkKey(
+      packet.route.points[segmentIndex],
+      packet.route.points[segmentIndex + 1]
+    );
+    const linkTraffic = trafficByLink.get(linkKey) || {red: 0, green: 0};
+    linkTraffic.red += packet.color[0];
+    linkTraffic.green += packet.color[1];
+    trafficByLink.set(linkKey, linkTraffic);
+  }
+
+  return trafficByLink;
 }
 
 export function makeLinks(conversationRoutes: ConversationRoute[]): NetworkLink[] {

--- a/examples/showcase/packet-spraying/story.ts
+++ b/examples/showcase/packet-spraying/story.ts
@@ -1,0 +1,83 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {AGGREGATION_POSITIONS, LEAF_POSITIONS, type Vector3} from './network';
+
+export type NetworkStoryState = 'healthy' | 'congested' | 'failed' | 'recovering';
+
+export type NetworkStoryCamera = {
+  distance: number;
+  pitch: number;
+  target: Vector3;
+  yaw: number;
+};
+
+export type NetworkStoryChapter = {
+  camera: NetworkStoryCamera;
+  description: string;
+  duration: number;
+  id: string;
+  networkState: NetworkStoryState;
+  title: string;
+};
+
+export const GUIDED_STORY_SWITCH_INDEX = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length + 1;
+
+export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
+  {
+    id: 'conversations',
+    title: 'Two conversations',
+    description: 'Red and green packets leave separate servers and meet at a shared access switch.',
+    duration: 7,
+    networkState: 'healthy',
+    camera: {target: [0, -0.85, 0], distance: 12.8, yaw: 0.52, pitch: 0.58}
+  },
+  {
+    id: 'packet-spraying',
+    title: 'Spraying across four planes',
+    description:
+      'Alternating packets spread across independent network paths and reunite near their destinations.',
+    duration: 8,
+    networkState: 'healthy',
+    camera: {target: [0, -0.2, 0], distance: 11.8, yaw: 0.78, pitch: 0.49}
+  },
+  {
+    id: 'congestion',
+    title: 'Congestion and packet trimming',
+    description:
+      'An overloaded switch trims packet payloads while small headers trigger retransmission.',
+    duration: 7,
+    networkState: 'congested',
+    camera: {target: [0, 0.65, 0.55], distance: 10.6, yaw: 0.42, pitch: 0.45}
+  },
+  {
+    id: 'failure',
+    title: 'Failure and instant rerouting',
+    description:
+      'A failed switch drops in-flight packets, then traffic moves onto the surviving planes.',
+    duration: 8,
+    networkState: 'failed',
+    camera: {target: [0, 0.7, 0.55], distance: 10.2, yaw: 0.24, pitch: 0.43}
+  },
+  {
+    id: 'recovery',
+    title: 'Probe, confirm, restore',
+    description:
+      'A blue probe verifies the repaired switch before its plane accepts ordinary traffic again.',
+    duration: 7,
+    networkState: 'recovering',
+    camera: {target: [0, 0.9, 0.65], distance: 9.8, yaw: 0.16, pitch: 0.46}
+  }
+];
+
+export function getWrappedStoryChapterIndex(chapterIndex: number): number {
+  return (
+    ((chapterIndex % NETWORK_STORY_CHAPTERS.length) + NETWORK_STORY_CHAPTERS.length) %
+    NETWORK_STORY_CHAPTERS.length
+  );
+}
+
+export function getNetworkStoryChapter(chapterIndex: number): NetworkStoryChapter {
+  return NETWORK_STORY_CHAPTERS[getWrappedStoryChapterIndex(chapterIndex)];
+}

--- a/modules/experimental/src/index.ts
+++ b/modules/experimental/src/index.ts
@@ -11,6 +11,17 @@ export {HTMLTexture} from './textures/html-texture';
 
 export {opticalLighting} from './materials/optical-lighting';
 export type {
+  OpticalCausticLens,
+  OpticalCausticLensUniform,
+  OpticalCausticsProps,
+  OpticalCausticsUniforms
+} from './materials/optical-caustics';
+export {
+  MAX_OPTICAL_CAUSTIC_LENSES,
+  opticalCaustics,
+  opticalCausticsPlugin
+} from './materials/optical-caustics';
+export type {
   OpticalPointLight,
   OpticalPointLightUniform,
   OpticalPointLightsProps,

--- a/modules/experimental/src/materials/glass-transmission.ts
+++ b/modules/experimental/src/materials/glass-transmission.ts
@@ -24,6 +24,14 @@ export type GlassTransmissionProps = {
   thicknessStrength?: number;
   /** Normalized-depth tolerance used to preserve foreground geometry. */
   depthBias?: number;
+  /** Strength of nearby opaque-scene reflections sampled from captured scene color. */
+  dynamicReflectionStrength?: number;
+  /** Strength of an additional environment bounce inside the glass shell. */
+  secondaryBounceStrength?: number;
+  /** Strength of animated lens distortion on warm-tinted fault surfaces. */
+  faultDistortionStrength?: number;
+  /** Animation clock used by optional fault-driven surface distortion. */
+  time?: number;
 };
 
 /** Uniform values consumed by {@link glassTransmission}. */
@@ -33,6 +41,10 @@ export type GlassTransmissionUniforms = {
   environmentIntensity: number;
   thicknessStrength: number;
   depthBias: number;
+  dynamicReflectionStrength: number;
+  secondaryBounceStrength: number;
+  faultDistortionStrength: number;
+  time: number;
 };
 
 /** Rasterized volume textures consumed by {@link glassTransmission}. */
@@ -51,6 +63,10 @@ struct glassTransmissionUniforms {
   environmentIntensity: f32,
   thicknessStrength: f32,
   depthBias: f32,
+  dynamicReflectionStrength: f32,
+  secondaryBounceStrength: f32,
+  faultDistortionStrength: f32,
+  time: f32,
 };
 
 @group(0) @binding(auto) var<uniform> glassTransmission: glassTransmissionUniforms;
@@ -163,8 +179,21 @@ fn glassTransmission_getColor(
     dot(combinedDeflection, cameraRight) / viewportAspect,
     -dot(combinedDeflection, cameraUp)
   );
+  let projectedNormal = vec2<f32>(
+    dot(frontNormal, cameraRight) / viewportAspect,
+    -dot(frontNormal, cameraUp)
+  );
+  let faultStrength = clamp(
+    (baseColor.r - max(baseColor.g, baseColor.b)) * 1.55 - 0.16,
+    0.0,
+    1.0
+  );
+  let faultRipple = sin(
+    dot(worldPosition.xz, vec2<f32>(11.0, 8.0)) +
+      glassTransmission.time * 5.5 + measuredThickness * 12.0
+  ) * faultStrength * glassTransmission.faultDistortionStrength;
   let proposedOffset = projectedDeflection * measuredThickness *
-    glassMaterial.refractionStrength * 0.18;
+    glassMaterial.refractionStrength * 0.18 + projectedNormal * faultRipple * 0.018;
   let proposedCoordinate = clamp(
     screenCoordinate + proposedOffset,
     vec2<f32>(0.001),
@@ -173,10 +202,6 @@ fn glassTransmission_getColor(
   let sampledDepth = glassTransmission_sampleDepth(proposedCoordinate);
   let foregroundOcclusion = sampledDepth + glassTransmission.depthBias < fragmentPosition.z;
   let safeOffset = select(proposedOffset, vec2<f32>(0.0), foregroundOcclusion);
-  let projectedNormal = vec2<f32>(
-    dot(frontNormal, cameraRight) / viewportAspect,
-    -dot(frontNormal, cameraUp)
-  );
   let dispersionOffset = projectedNormal * glassMaterial.dispersion *
     measuredThickness * 0.3;
   let transmittedColor = glassMaterial_sampleTransmission(
@@ -194,9 +219,32 @@ fn glassTransmission_getColor(
   let internalReflection = glassTransmission_sampleEnvironment(
     reflect(entryDirection, -backNormal)
   ) * select(0.18, 0.42, !hasExitRay);
+  let secondaryDirection = reflect(reflect(entryDirection, -backNormal), frontNormal);
+  let secondaryReflection = glassTransmission_sampleEnvironment(secondaryDirection) *
+    glassTransmission.secondaryBounceStrength * pow(1.0 - viewAlignment, 1.45) * 0.24;
+  let reflectionCoordinate = clamp(
+    screenCoordinate + projectedNormal * (0.025 + measuredThickness * 0.018),
+    vec2<f32>(0.001),
+    vec2<f32>(0.999)
+  );
+  let reflectedSceneColor = textureSampleLevel(
+    glassSceneColorTexture,
+    glassSceneColorTextureSampler,
+    reflectionCoordinate,
+    0.0
+  ).rgb;
+  let reflectedSceneLuminance = dot(reflectedSceneColor, vec3<f32>(0.2126, 0.7152, 0.0722));
+  let reflectedSceneResponse = smoothstep(0.045, 0.9, reflectedSceneLuminance);
+  let dynamicReflection = reflectedSceneColor * reflectedSceneResponse *
+    glassTransmission.dynamicReflectionStrength * (0.045 + fresnel * 0.5);
+  let faultFilament = baseColor.rgb * faultStrength *
+    glassTransmission.faultDistortionStrength *
+    pow(max(sin(dot(worldPosition, vec3<f32>(14.0, 10.0, 17.0)) +
+      glassTransmission.time * 7.0), 0.0), 10.0) * 0.12;
   let opticalColor = transmittedColor * absorption * glassMaterial.transmissionStrength +
     environmentReflection * (0.09 + fresnel * 0.65) +
-    internalReflection * pow(1.0 - viewAlignment, 2.0);
+    internalReflection * pow(1.0 - viewAlignment, 2.0) + secondaryReflection +
+    dynamicReflection + faultFilament;
   return vec4<f32>(mix(surfaceColor.rgb, opticalColor, 0.64), surfaceColor.a);
 }
 
@@ -231,6 +279,10 @@ layout(std140) uniform glassTransmissionUniforms {
   float environmentIntensity;
   float thicknessStrength;
   float depthBias;
+  float dynamicReflectionStrength;
+  float secondaryBounceStrength;
+  float faultDistortionStrength;
+  float time;
 } glassTransmission;
 
 uniform sampler2D glassSceneDepthTexture;
@@ -321,8 +373,21 @@ vec4 glassTransmission_getColor(
     dot(combinedDeflection, cameraRight) / viewportAspect,
     dot(combinedDeflection, cameraUp)
   );
+  vec2 projectedNormal = vec2(
+    dot(frontNormal, cameraRight) / viewportAspect,
+    dot(frontNormal, cameraUp)
+  );
+  float faultStrength = clamp(
+    (baseColor.r - max(baseColor.g, baseColor.b)) * 1.55 - 0.16,
+    0.0,
+    1.0
+  );
+  float faultRipple = sin(
+    dot(worldPosition.xz, vec2(11.0, 8.0)) +
+      glassTransmission.time * 5.5 + measuredThickness * 12.0
+  ) * faultStrength * glassTransmission.faultDistortionStrength;
   vec2 proposedOffset = projectedDeflection * measuredThickness *
-    glassMaterial.refractionStrength * 0.18;
+    glassMaterial.refractionStrength * 0.18 + projectedNormal * faultRipple * 0.018;
   vec2 proposedCoordinate = clamp(
     screenCoordinate + proposedOffset,
     vec2(0.001),
@@ -331,10 +396,6 @@ vec4 glassTransmission_getColor(
   float sampledDepth = glassTransmission_sampleDepth(proposedCoordinate);
   bool foregroundOcclusion = sampledDepth + glassTransmission.depthBias < fragmentPosition.z;
   vec2 safeOffset = foregroundOcclusion ? vec2(0.0) : proposedOffset;
-  vec2 projectedNormal = vec2(
-    dot(frontNormal, cameraRight) / viewportAspect,
-    dot(frontNormal, cameraUp)
-  );
   vec2 dispersionOffset = projectedNormal * glassMaterial.dispersion *
     measuredThickness * 0.3;
   vec3 transmittedColor = glassMaterial_sampleTransmission(
@@ -352,9 +413,27 @@ vec4 glassTransmission_getColor(
   vec3 internalReflection = glassTransmission_sampleEnvironment(
     reflect(entryDirection, -backNormal)
   ) * (hasExitRay ? 0.18 : 0.42);
+  vec3 secondaryDirection = reflect(reflect(entryDirection, -backNormal), frontNormal);
+  vec3 secondaryReflection = glassTransmission_sampleEnvironment(secondaryDirection) *
+    glassTransmission.secondaryBounceStrength * pow(1.0 - viewAlignment, 1.45) * 0.24;
+  vec2 reflectionCoordinate = clamp(
+    screenCoordinate + projectedNormal * (0.025 + measuredThickness * 0.018),
+    vec2(0.001),
+    vec2(0.999)
+  );
+  vec3 reflectedSceneColor = texture(glassSceneColorTexture, reflectionCoordinate).rgb;
+  float reflectedSceneLuminance = dot(reflectedSceneColor, vec3(0.2126, 0.7152, 0.0722));
+  float reflectedSceneResponse = smoothstep(0.045, 0.9, reflectedSceneLuminance);
+  vec3 dynamicReflection = reflectedSceneColor * reflectedSceneResponse *
+    glassTransmission.dynamicReflectionStrength * (0.045 + fresnel * 0.5);
+  vec3 faultFilament = baseColor.rgb * faultStrength *
+    glassTransmission.faultDistortionStrength *
+    pow(max(sin(dot(worldPosition, vec3(14.0, 10.0, 17.0)) +
+      glassTransmission.time * 7.0), 0.0), 10.0) * 0.12;
   vec3 opticalColor = transmittedColor * absorption * glassMaterial.transmissionStrength +
     environmentReflection * (0.09 + fresnel * 0.65) +
-    internalReflection * pow(1.0 - viewAlignment, 2.0);
+    internalReflection * pow(1.0 - viewAlignment, 2.0) + secondaryReflection +
+    dynamicReflection + faultFilament;
   return vec4(mix(surfaceColor.rgb, opticalColor, 0.64), surfaceColor.a);
 }
 
@@ -392,6 +471,13 @@ function getGlassTransmissionUniforms(
     environmentIntensity: props.environmentIntensity ?? previousUniforms?.environmentIntensity ?? 1,
     thicknessStrength: props.thicknessStrength ?? previousUniforms?.thicknessStrength ?? 1,
     depthBias: props.depthBias ?? previousUniforms?.depthBias ?? 0.00008,
+    dynamicReflectionStrength:
+      props.dynamicReflectionStrength ?? previousUniforms?.dynamicReflectionStrength ?? 0,
+    secondaryBounceStrength:
+      props.secondaryBounceStrength ?? previousUniforms?.secondaryBounceStrength ?? 0,
+    faultDistortionStrength:
+      props.faultDistortionStrength ?? previousUniforms?.faultDistortionStrength ?? 0,
+    time: props.time ?? previousUniforms?.time ?? 0,
     ...(props.sceneDepthTexture ? {glassSceneDepthTexture: props.sceneDepthTexture} : {}),
     ...(props.backfaceTexture ? {glassBackfaceTexture: props.backfaceTexture} : {}),
     ...(props.environmentTexture ? {glassEnvironmentTexture: props.environmentTexture} : {})
@@ -416,14 +502,22 @@ export const glassTransmission = {
     depthRange: 'vec2<f32>',
     environmentIntensity: 'f32',
     thicknessStrength: 'f32',
-    depthBias: 'f32'
+    depthBias: 'f32',
+    dynamicReflectionStrength: 'f32',
+    secondaryBounceStrength: 'f32',
+    faultDistortionStrength: 'f32',
+    time: 'f32'
   },
   defaultUniforms: {
     viewportSize: [1, 1],
     depthRange: [0.1, 100],
     environmentIntensity: 1,
     thicknessStrength: 1,
-    depthBias: 0.00008
+    depthBias: 0.00008,
+    dynamicReflectionStrength: 0,
+    secondaryBounceStrength: 0,
+    faultDistortionStrength: 0,
+    time: 0
   },
   getUniforms: getGlassTransmissionUniforms
 } as const satisfies ShaderModule<

--- a/modules/experimental/src/materials/optical-caustics.ts
+++ b/modules/experimental/src/materials/optical-caustics.ts
@@ -1,0 +1,234 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ShaderModule, ShaderPlugin} from '@luma.gl/shadertools';
+import {opticalLighting} from './optical-lighting';
+
+/** Maximum number of nearby focusing glass lenses in the portable uniform block. */
+export const MAX_OPTICAL_CAUSTIC_LENSES = 8;
+
+/** A colored glass lens that projects a compact rasterized caustic onto nearby surfaces. */
+export type OpticalCausticLens = {
+  /** World-space center of the focusing glass surface. */
+  position: [number, number, number];
+  /** Approximate world-space radius of the glass surface. */
+  radius?: number;
+  /** Linear RGB color of light entering the lens. */
+  color: [number, number, number];
+  /** Optional per-lens concentration multiplier. */
+  intensity?: number;
+};
+
+/** Runtime properties for a bounded collection of local focusing lenses. */
+export type OpticalCausticsProps = {
+  /** Active glass lenses; entries beyond the fixed capacity are ignored. */
+  lenses?: readonly OpticalCausticLens[];
+  /** Multiplier applied to the complete set of projected caustics. */
+  intensity?: number;
+  /** Concentration of the focused center and surrounding caustic ring. */
+  focus?: number;
+};
+
+/** One packed entry in the cross-backend caustic-lens uniform array. */
+export type OpticalCausticLensUniform = {
+  position: [number, number, number];
+  radius: number;
+  color: [number, number, number];
+  intensity: number;
+};
+
+/** Uniform values consumed by {@link opticalCaustics}. */
+export type OpticalCausticsUniforms = {
+  lensCount: number;
+  intensity: number;
+  focus: number;
+  lenses: readonly OpticalCausticLensUniform[];
+};
+
+const OPTICAL_CAUSTIC_LENS_UNIFORM_TYPE = {
+  position: 'vec3<f32>',
+  radius: 'f32',
+  color: 'vec3<f32>',
+  intensity: 'f32'
+} as const;
+
+const OPTICAL_CAUSTICS_WGSL = /* wgsl */ `\
+struct OpticalCausticLensUniform {
+  position: vec3<f32>,
+  radius: f32,
+  color: vec3<f32>,
+  intensity: f32,
+};
+
+struct opticalCausticsUniforms {
+  lensCount: i32,
+  intensity: f32,
+  focus: f32,
+  lenses: array<OpticalCausticLensUniform, ${MAX_OPTICAL_CAUSTIC_LENSES}>,
+};
+
+@group(0) @binding(auto) var<uniform> opticalCaustics: opticalCausticsUniforms;
+
+fn opticalCaustics_getColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  cameraPosition: vec3<f32>
+) -> vec3<f32> {
+  let viewDirection = normalize(cameraPosition - worldPosition);
+  let normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  var accumulatedColor = vec3<f32>(0.0);
+
+  for (var lensIndex = 0; lensIndex < ${MAX_OPTICAL_CAUSTIC_LENSES}; lensIndex++) {
+    if (lensIndex >= opticalCaustics.lensCount) {
+      break;
+    }
+
+    let lens = opticalCaustics.lenses[lensIndex];
+    let lensOffset = worldPosition - lens.position;
+    let distanceSquared = dot(lensOffset, lensOffset);
+    let radius = max(lens.radius, 0.0001);
+    let distance = sqrt(distanceSquared);
+    let normalizedDistance = clamp(distance / (radius * 4.2), 0.0, 1.0);
+    let attenuation = pow(1.0 - normalizedDistance, 2.0);
+    let projectedDistance = max(-lensOffset.y, 0.0);
+    let spread = radius * (0.82 + projectedDistance * 0.38);
+    let radialDistance = length(lensOffset.xz) / max(spread, 0.0001);
+    let concentration = max(opticalCaustics.focus, 0.0);
+    let focusedCore = exp(-radialDistance * radialDistance * (2.4 + concentration * 3.0));
+    let focusedRing = exp(-pow(radialDistance - 0.58, 2.0) *
+      (11.0 + concentration * 15.0));
+    let angularDetail = 0.78 + 0.22 * cos(
+      atan2(lensOffset.z, lensOffset.x) * 3.0 + distance * 7.0
+    );
+    let lensDirection = -lensOffset * inverseSqrt(max(distanceSquared, 0.00001));
+    let surfaceResponse = 0.18 +
+      max(dot(normalFacingCamera, lensDirection), 0.0) * 0.82;
+    let causticPattern = focusedCore * 0.58 + focusedRing * angularDetail * 0.42;
+    accumulatedColor += lens.color * lens.intensity * attenuation *
+      causticPattern * surfaceResponse;
+  }
+
+  return accumulatedColor * opticalCaustics.intensity;
+}
+`;
+
+const OPTICAL_CAUSTICS_GLSL = /* glsl */ `\
+struct OpticalCausticLensUniform {
+  vec3 position;
+  float radius;
+  vec3 color;
+  float intensity;
+};
+
+layout(std140) uniform opticalCausticsUniforms {
+  int lensCount;
+  float intensity;
+  float focus;
+  OpticalCausticLensUniform lenses[${MAX_OPTICAL_CAUSTIC_LENSES}];
+} opticalCaustics;
+
+vec3 opticalCaustics_getColor(
+  vec3 normal,
+  vec3 worldPosition,
+  vec3 cameraPosition
+) {
+  vec3 viewDirection = normalize(cameraPosition - worldPosition);
+  vec3 normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  vec3 accumulatedColor = vec3(0.0);
+
+  for (int lensIndex = 0; lensIndex < ${MAX_OPTICAL_CAUSTIC_LENSES}; lensIndex++) {
+    if (lensIndex >= opticalCaustics.lensCount) {
+      break;
+    }
+
+    OpticalCausticLensUniform lens = opticalCaustics.lenses[lensIndex];
+    vec3 lensOffset = worldPosition - lens.position;
+    float distanceSquared = dot(lensOffset, lensOffset);
+    float radius = max(lens.radius, 0.0001);
+    float distance = sqrt(distanceSquared);
+    float normalizedDistance = clamp(distance / (radius * 4.2), 0.0, 1.0);
+    float attenuation = pow(1.0 - normalizedDistance, 2.0);
+    float projectedDistance = max(-lensOffset.y, 0.0);
+    float spread = radius * (0.82 + projectedDistance * 0.38);
+    float radialDistance = length(lensOffset.xz) / max(spread, 0.0001);
+    float concentration = max(opticalCaustics.focus, 0.0);
+    float focusedCore = exp(-radialDistance * radialDistance * (2.4 + concentration * 3.0));
+    float focusedRing = exp(-pow(radialDistance - 0.58, 2.0) *
+      (11.0 + concentration * 15.0));
+    float angularDetail = 0.78 + 0.22 * cos(
+      atan(lensOffset.z, lensOffset.x) * 3.0 + distance * 7.0
+    );
+    vec3 lensDirection = -lensOffset * inversesqrt(max(distanceSquared, 0.00001));
+    float surfaceResponse = 0.18 +
+      max(dot(normalFacingCamera, lensDirection), 0.0) * 0.82;
+    float causticPattern = focusedCore * 0.58 + focusedRing * angularDetail * 0.42;
+    accumulatedColor += lens.color * lens.intensity * attenuation *
+      causticPattern * surfaceResponse;
+  }
+
+  return accumulatedColor * opticalCaustics.intensity;
+}
+`;
+
+function getOpticalCausticsUniforms(
+  props: Partial<OpticalCausticsProps> = {},
+  previousUniforms?: OpticalCausticsUniforms
+): OpticalCausticsUniforms {
+  const suppliedLenses = props.lenses;
+
+  return {
+    lensCount: suppliedLenses
+      ? Math.min(suppliedLenses.length, MAX_OPTICAL_CAUSTIC_LENSES)
+      : (previousUniforms?.lensCount ?? 0),
+    intensity: props.intensity ?? previousUniforms?.intensity ?? 1,
+    focus: props.focus ?? previousUniforms?.focus ?? 1,
+    lenses: suppliedLenses
+      ? makeOpticalCausticLensUniforms(suppliedLenses)
+      : (previousUniforms?.lenses ?? makeOpticalCausticLensUniforms([]))
+  };
+}
+
+function makeOpticalCausticLensUniforms(
+  lenses: readonly OpticalCausticLens[]
+): OpticalCausticLensUniform[] {
+  return Array.from({length: MAX_OPTICAL_CAUSTIC_LENSES}, (_, lensIndex) => {
+    const lens = lenses[lensIndex];
+
+    return lens
+      ? {
+          position: lens.position,
+          radius: lens.radius ?? 1,
+          color: lens.color,
+          intensity: lens.intensity ?? 1
+        }
+      : {
+          position: [0, 0, 0],
+          radius: 1,
+          color: [0, 0, 0],
+          intensity: 0
+        };
+  });
+}
+
+/** Portable raster approximation of focused light projected through nearby glass. */
+export const opticalCaustics = {
+  name: 'opticalCaustics',
+  source: OPTICAL_CAUSTICS_WGSL,
+  fs: OPTICAL_CAUSTICS_GLSL,
+  dependencies: [opticalLighting],
+  uniformTypes: {
+    lensCount: 'i32',
+    intensity: 'f32',
+    focus: 'f32',
+    lenses: [OPTICAL_CAUSTIC_LENS_UNIFORM_TYPE, MAX_OPTICAL_CAUSTIC_LENSES]
+  },
+  defaultUniforms: getOpticalCausticsUniforms(),
+  getUniforms: getOpticalCausticsUniforms
+} as const satisfies ShaderModule<OpticalCausticsProps, OpticalCausticsUniforms, {}>;
+
+/** Explicitly installs bounded focusing lenses for nearby reflective receiver surfaces. */
+export const opticalCausticsPlugin = {
+  name: 'opticalCaustics',
+  modules: [opticalCaustics as ShaderModule]
+} as const satisfies ShaderPlugin;

--- a/modules/experimental/test/materials/optical-materials.node.spec.ts
+++ b/modules/experimental/test/materials/optical-materials.node.spec.ts
@@ -12,7 +12,11 @@ import {
   glassMaterialPlugin,
   glassTransmission,
   glassTransmissionPlugin,
+  MAX_OPTICAL_CAUSTIC_LENSES,
   MAX_OPTICAL_POINT_LIGHTS,
+  type OpticalCausticLens,
+  opticalCaustics,
+  opticalCausticsPlugin,
   opticalLighting,
   type OpticalPointLight,
   opticalPointLights,
@@ -98,6 +102,11 @@ const ILLUMINATED_OPTICAL_MATERIAL_SHADER = OPTICAL_MATERIAL_SHADER.replace(
     inputs.worldPosition,
     cameraPosition
   );
+  let causticColor = opticalCaustics_getColor(
+    normal,
+    inputs.worldPosition,
+    cameraPosition
+  );
   let trailColor = emissiveMaterial_getTrailColor(
     normal,
     inputs.worldPosition,
@@ -107,7 +116,7 @@ const ILLUMINATED_OPTICAL_MATERIAL_SHADER = OPTICAL_MATERIAL_SHADER.replace(
     0.5
   );
   return mix(glassColor, reflectedColor, 0.25) + emittedColor * 0.2 + trailColor * 0.1 +
-    vec4<f32>(pointLightColor, 0.0);`
+    vec4<f32>(pointLightColor + causticColor, 0.0);`
   );
 
 test('optical material modules expose portable shared shader helpers', testCase => {
@@ -153,6 +162,16 @@ test('optical material modules expose portable shared shader helpers', testCase 
     [opticalPointLights],
     'point-light plugin installs local lighting explicitly'
   );
+  testCase.equal(
+    opticalCausticsPlugin.name,
+    'opticalCaustics',
+    'caustic-lens plugin has a stable name'
+  );
+  testCase.deepEqual(
+    opticalCausticsPlugin.modules,
+    [opticalCaustics],
+    'caustic-lens plugin installs focused lighting explicitly'
+  );
   testCase.deepEqual(
     glassMaterial.dependencies,
     [opticalLighting],
@@ -178,7 +197,13 @@ test('optical material modules expose portable shared shader helpers', testCase 
     [opticalLighting],
     'point-light shading reuses shared optical lighting'
   );
+  testCase.deepEqual(
+    opticalCaustics.dependencies,
+    [opticalLighting],
+    'caustic shading reuses shared optical lighting'
+  );
   testCase.equal(MAX_OPTICAL_POINT_LIGHTS, 16, 'point lights have a portable fixed capacity');
+  testCase.equal(MAX_OPTICAL_CAUSTIC_LENSES, 8, 'focusing lenses have a portable fixed capacity');
   testCase.match(opticalLighting.source, /fn opticalLighting_getFresnel/, 'WGSL helpers exist');
   testCase.match(opticalLighting.fs, /float opticalLighting_getFresnel/, 'GLSL helpers exist');
   testCase.match(
@@ -222,6 +247,16 @@ test('optical material modules expose portable shared shader helpers', testCase 
     opticalPointLights.fs,
     /vec3 opticalPointLights_getColor/,
     'GLSL point-light helper exists'
+  );
+  testCase.match(
+    opticalCaustics.source,
+    /fn opticalCaustics_getColor/,
+    'WGSL focused-light helper exists'
+  );
+  testCase.match(
+    opticalCaustics.fs,
+    /vec3 opticalCaustics_getColor/,
+    'GLSL focused-light helper exists'
   );
   testCase.end();
 });
@@ -286,7 +321,11 @@ test('optical materials retain defaults while applying partial updates', testCas
       depthRange: [0.1, 100],
       environmentIntensity: 1,
       thicknessStrength: 1,
-      depthBias: 0.00008
+      depthBias: 0.00008,
+      dynamicReflectionStrength: 0,
+      secondaryBounceStrength: 0,
+      faultDistortionStrength: 0,
+      time: 0
     },
     'rasterized transmission exposes stable optical defaults'
   );
@@ -309,6 +348,36 @@ test('optical materials retain defaults while applying partial updates', testCas
     0.00008,
     'foreground-depth tolerance is retained'
   );
+  testCase.equal(
+    updatedTransmissionUniforms.dynamicReflectionStrength,
+    0,
+    'dynamic reflections remain opt-in for existing consumers'
+  );
+  const animatedTransmissionUniforms = glassTransmission.getUniforms(
+    {
+      dynamicReflectionStrength: 0.45,
+      secondaryBounceStrength: 0.7,
+      faultDistortionStrength: 0.3,
+      time: 2.5
+    },
+    updatedTransmissionUniforms
+  );
+  testCase.equal(
+    animatedTransmissionUniforms.dynamicReflectionStrength,
+    0.45,
+    'captured-scene reflections are configurable'
+  );
+  testCase.equal(
+    animatedTransmissionUniforms.secondaryBounceStrength,
+    0.7,
+    'secondary internal reflections are configurable'
+  );
+  testCase.equal(
+    animatedTransmissionUniforms.faultDistortionStrength,
+    0.3,
+    'fault-driven lens distortion is configurable'
+  );
+  testCase.equal(animatedTransmissionUniforms.time, 2.5, 'fault animation accepts a scene clock');
 
   const initialReflectiveUniforms = reflectiveMaterial.getUniforms({});
   testCase.deepEqual(
@@ -469,6 +538,21 @@ test('rasterized glass transmission composes thickness, depth, and environment m
       /hasExitRay/,
       `${language} handles total internal reflection without ray marching`
     );
+    testCase.match(
+      shaderSource,
+      /reflectedSceneColor/,
+      `${language} reflects nearby captured-scene objects`
+    );
+    testCase.match(
+      shaderSource,
+      /secondaryDirection/,
+      `${language} approximates a second internal environment bounce`
+    );
+    testCase.match(
+      shaderSource,
+      /faultRipple/,
+      `${language} confines animated distortion to warm fault-colored glass`
+    );
   }
   testCase.end();
 });
@@ -528,8 +612,70 @@ test('optical point lights pack and retain a bounded portable uniform array', te
   testCase.end();
 });
 
+test('optical caustics pack and retain a bounded portable lens array', testCase => {
+  const initialUniforms = opticalCaustics.getUniforms({});
+  testCase.equal(initialUniforms.lensCount, 0, 'focusing lenses start disabled');
+  testCase.equal(initialUniforms.intensity, 1, 'caustics expose a stable global intensity');
+  testCase.equal(initialUniforms.focus, 1, 'caustics expose a stable focus multiplier');
+  testCase.equal(
+    initialUniforms.lenses.length,
+    MAX_OPTICAL_CAUSTIC_LENSES,
+    'default lenses occupy every fixed uniform slot'
+  );
+
+  const suppliedLenses = Array.from(
+    {length: MAX_OPTICAL_CAUSTIC_LENSES + 2},
+    (_, lensIndex): OpticalCausticLens => ({
+      position: [lensIndex, lensIndex + 1, lensIndex + 2],
+      color: [lensIndex % 2, 1, 0],
+      ...(lensIndex === 1 ? {intensity: 1.6, radius: 0.45} : {})
+    })
+  );
+  const packedUniforms = opticalCaustics.getUniforms({
+    lenses: suppliedLenses,
+    intensity: 0.6,
+    focus: 1.4
+  });
+
+  testCase.equal(
+    packedUniforms.lensCount,
+    MAX_OPTICAL_CAUSTIC_LENSES,
+    'additional lenses beyond the fixed capacity are ignored'
+  );
+  testCase.equal(packedUniforms.intensity, 0.6, 'global caustic intensity is configurable');
+  testCase.equal(packedUniforms.focus, 1.4, 'caustic focus is configurable');
+  testCase.deepEqual(
+    packedUniforms.lenses[0],
+    {position: [0, 1, 2], radius: 1, color: [0, 1, 0], intensity: 1},
+    'caustic-lens defaults are packed in portable field order'
+  );
+  testCase.deepEqual(
+    packedUniforms.lenses[1],
+    {position: [1, 2, 3], radius: 0.45, color: [1, 1, 0], intensity: 1.6},
+    'per-lens radius and intensity are preserved'
+  );
+
+  const updatedUniforms = opticalCaustics.getUniforms({focus: 0.8}, packedUniforms);
+  testCase.equal(updatedUniforms.focus, 0.8, 'focus updates independently');
+  testCase.equal(updatedUniforms.lensCount, 8, 'partial updates preserve active lenses');
+  testCase.equal(updatedUniforms.lenses, packedUniforms.lenses, 'packed lens arrays are reused');
+
+  const clearedUniforms = opticalCaustics.getUniforms({lenses: []}, updatedUniforms);
+  testCase.equal(clearedUniforms.lensCount, 0, 'an explicit empty lens list clears caustics');
+  testCase.ok(
+    clearedUniforms.lenses.every(lens => lens.intensity === 0),
+    'cleared lens slots are reset'
+  );
+  testCase.end();
+});
+
 test('optical materials expose matching WGSL and GLSL uniform layouts', testCase => {
-  for (const shaderModule of [emissiveMaterial, opticalPointLights, glassTransmission]) {
+  for (const shaderModule of [
+    emissiveMaterial,
+    opticalPointLights,
+    opticalCaustics,
+    glassTransmission
+  ]) {
     const wgslValidation = getShaderModuleUniformLayoutValidationResult(shaderModule, 'wgsl');
     const fragmentValidation = getShaderModuleUniformLayoutValidationResult(
       shaderModule,
@@ -572,7 +718,13 @@ test('rasterized glass transmission assembles portable optical and depth binding
   const assembledShader = assembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: transmissionShader,
-    modules: [glassTransmission, reflectiveMaterial, emissiveMaterial, opticalPointLights]
+    modules: [
+      glassTransmission,
+      reflectiveMaterial,
+      emissiveMaterial,
+      opticalPointLights,
+      opticalCaustics
+    ]
   });
   const reflectedShader = new WgslReflect(assembledShader.source);
   const textureNames = reflectedShader.textures.map(texture => texture.name);
@@ -665,6 +817,7 @@ test('illuminated optical materials compose once with emission and transparency'
       reflectiveMaterial,
       emissiveMaterial,
       opticalPointLights,
+      opticalCaustics,
       aBuffer,
       wboit
     ]
@@ -680,6 +833,11 @@ test('illuminated optical materials compose once with emission and transparency'
     assembledShader.source.match(/fn opticalPointLights_getColor\(/g)?.length,
     1,
     'point-light helper is emitted once'
+  );
+  testCase.equal(
+    assembledShader.source.match(/fn opticalCaustics_getColor\(/g)?.length,
+    1,
+    'focused-light helper is emitted once'
   );
   testCase.match(
     assembledShader.source,
@@ -713,6 +871,10 @@ test('illuminated optical materials compose once with emission and transparency'
   testCase.ok(
     reflectedShader.uniforms.some(resource => resource.name === 'emissiveMaterial'),
     'emissive material uniforms are reflected'
+  );
+  testCase.ok(
+    reflectedShader.uniforms.some(resource => resource.name === 'opticalCaustics'),
+    'caustic-lens uniforms are reflected'
   );
   testCase.end();
 });
@@ -750,10 +912,17 @@ void main(void) {
   );
   fragmentColor = mix(glassColor, reflectedColor, 0.25) +
     emissiveMaterial_getColor(normal, worldPosition, baseColor, cameraPosition) +
-    emissiveMaterial_getTrailColor(normal, worldPosition, baseColor, cameraPosition, 0.65, 0.5);
+    emissiveMaterial_getTrailColor(normal, worldPosition, baseColor, cameraPosition, 0.65, 0.5) +
+    vec4(opticalCaustics_getColor(normal, worldPosition, cameraPosition), 0.0);
 }
 `,
-    modules: [glassMaterial, reflectiveMaterial, emissiveMaterial, opticalPointLights]
+    modules: [
+      glassMaterial,
+      reflectiveMaterial,
+      emissiveMaterial,
+      opticalPointLights,
+      opticalCaustics
+    ]
   });
 
   testCase.match(
@@ -776,6 +945,11 @@ void main(void) {
     assembledShader.fs,
     /vec4 emissiveMaterial_getTrailColor/,
     'GLSL directional emission composes'
+  );
+  testCase.match(
+    assembledShader.fs,
+    /vec3 opticalCaustics_getColor/,
+    'GLSL focused lighting composes'
   );
   testCase.end();
 });

--- a/test/examples/packet-spraying-network.node.spec.ts
+++ b/test/examples/packet-spraying-network.node.spec.ts
@@ -18,12 +18,14 @@ import {
   isFailedSwitchPosition,
   makeConversationRoutes,
   makeLinks,
+  makeLinkTraffic,
   makePackets,
   makePickableNetworkNodes,
   makeSwitchPacketEvents,
   makeSwitchProbeEvent,
   makeSwitchGroups,
   makeSwitchArrivals,
+  makeLinkKey,
   reroutePackets
 } from '../../examples/showcase/packet-spraying/network';
 
@@ -99,6 +101,39 @@ test('packet-spraying switches form spine and two complete physical-plane groups
   testCase.end();
 });
 
+test('packet-spraying link traffic follows visible red and green packets', testCase => {
+  const packets = makePackets(makeConversationRoutes());
+  const firstRedPacket = packets.find(packet => packet.conversationIndex === 0)!;
+  const firstGreenPacket = packets.find(packet => packet.conversationIndex === 1)!;
+  const sharedLinkKey = makeLinkKey(firstRedPacket.route.points[1], firstRedPacket.route.points[2]);
+  const timeOnSharedLink =
+    firstRedPacket.launchTime +
+    (firstRedPacket.route.cumulativeLengths[1] + 0.5) / PACKET_TRAVEL_SPEED;
+  const traffic = makeLinkTraffic(packets, timeOnSharedLink);
+
+  testCase.deepEqual(
+    traffic.get(sharedLinkKey),
+    {red: 1, green: 1},
+    'shared switch links report interleaved red and green packets'
+  );
+
+  firstRedPacket.enabled = false;
+  testCase.deepEqual(
+    makeLinkTraffic(packets, timeOnSharedLink).get(sharedLinkKey),
+    {red: 0, green: 1},
+    'disabled or rerouted packets stop illuminating their former link'
+  );
+
+  firstGreenPacket.enabled = false;
+  testCase.equal(
+    makeLinkTraffic(packets, timeOnSharedLink).get(sharedLinkKey),
+    undefined,
+    'an empty link has no traffic illumination'
+  );
+
+  testCase.end();
+});
+
 test('packet-spraying traffic immediately avoids and restores failed planes', testCase => {
   const routes = makeConversationRoutes();
   const packets = makePackets(routes);
@@ -145,6 +180,41 @@ test('packet-spraying traffic immediately avoids and restores failed planes', te
     new Set(packets.map(packet => packet.route.points[3].join(','))).size,
     4,
     'packets resume using all four paths'
+  );
+  testCase.end();
+});
+
+test('packet-spraying keeps repaired planes offline until a recovery probe confirms them', testCase => {
+  const routes = makeConversationRoutes();
+  const packets = makePackets(routes);
+  const recoveringSpineIndex = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length;
+  const recoveringSwitches = new Set([recoveringSpineIndex]);
+  const recoveringRoutes = getHealthyConversationRoutes(routes, new Set(), recoveringSwitches);
+
+  testCase.equal(getActivePlaneCount(recoveringRoutes), 3, 'a repaired plane remains unavailable');
+  reroutePackets(packets, recoveringRoutes);
+  testCase.ok(
+    packets.every(packet => packet.route.points.every(position => position !== SPINE_POSITIONS[0])),
+    'ordinary traffic cannot enter a recovering switch'
+  );
+
+  const recoveryProbe = makeSwitchProbeEvent(routes, recoveringSpineIndex, 15, recoveringSwitches);
+  testCase.equal(recoveryProbe?.kind, 'probe', 'a blue control packet verifies the repaired path');
+  testCase.ok(
+    recoveryProbe?.route.points.includes(SPINE_POSITIONS[0]),
+    'the recovery probe reaches the repaired switch'
+  );
+
+  const blockedProbe = makeSwitchProbeEvent(routes, recoveringSpineIndex, 15, new Set([3]));
+  testCase.equal(blockedProbe, null, 'a probe cannot pass through a separate unavailable switch');
+
+  recoveringSwitches.clear();
+  const confirmedRoutes = getHealthyConversationRoutes(routes, new Set(), recoveringSwitches);
+  reroutePackets(packets, confirmedRoutes);
+  testCase.equal(getActivePlaneCount(confirmedRoutes), 4, 'probe confirmation restores the plane');
+  testCase.ok(
+    packets.some(packet => packet.route.points.includes(SPINE_POSITIONS[0])),
+    'ordinary traffic resumes after the repaired route is confirmed'
   );
   testCase.end();
 });

--- a/test/examples/packet-spraying-story.node.spec.ts
+++ b/test/examples/packet-spraying-story.node.spec.ts
@@ -1,0 +1,42 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {SWITCH_POSITIONS} from '../../examples/showcase/packet-spraying/network';
+import {
+  getNetworkStoryChapter,
+  getWrappedStoryChapterIndex,
+  GUIDED_STORY_SWITCH_INDEX,
+  NETWORK_STORY_CHAPTERS
+} from '../../examples/showcase/packet-spraying/story';
+
+test('packet-spraying guided tour tells the complete MRC recovery story', testCase => {
+  testCase.deepEqual(
+    NETWORK_STORY_CHAPTERS.map(chapter => chapter.id),
+    ['conversations', 'packet-spraying', 'congestion', 'failure', 'recovery'],
+    'chapters progress from independent conversations through confirmed recovery'
+  );
+  testCase.deepEqual(
+    NETWORK_STORY_CHAPTERS.map(chapter => chapter.networkState),
+    ['healthy', 'healthy', 'congested', 'failed', 'recovering'],
+    'each chapter requests the corresponding switch state'
+  );
+  testCase.ok(
+    NETWORK_STORY_CHAPTERS.every(chapter => chapter.duration >= 7),
+    'each chapter leaves enough time to observe the network behavior'
+  );
+  testCase.ok(
+    SWITCH_POSITIONS[GUIDED_STORY_SWITCH_INDEX],
+    'the scripted story targets a real physical spine switch'
+  );
+  testCase.end();
+});
+
+test('packet-spraying guided tour wraps forward and backward between chapters', testCase => {
+  testCase.equal(getWrappedStoryChapterIndex(-1), NETWORK_STORY_CHAPTERS.length - 1);
+  testCase.equal(getWrappedStoryChapterIndex(NETWORK_STORY_CHAPTERS.length), 0);
+  testCase.equal(getNetworkStoryChapter(-1).id, 'recovery');
+  testCase.equal(getNetworkStoryChapter(NETWORK_STORY_CHAPTERS.length).id, 'conversations');
+  testCase.end();
+});


### PR DESCRIPTION
## Goals

- Extend the merged HDR glass showcase with reusable rasterized optical effects that work on WebGPU and WebGL.
- Make Multipath Reliable Connection behavior easier to understand through a guided, interactive networking story.
- Preserve restrained visuals, alternating red/green traffic, and probe-confirmed switch recovery.

## Changes

### Reusable optical materials

- Add the exported `opticalCaustics` shader module and plugin with matching WGSL/GLSL implementations, typed configuration, and a portable fixed array of eight dynamic caustic lenses.
- Extend `glassTransmission` with opt-in captured-scene reflections, secondary internal environment bounces, animated fault distortion, and warm fault filaments while preserving zero-effect defaults for existing consumers.
- Expand optical-material composition and uniform-packing coverage for both shader languages.

### Network visualization and recovery

- Illuminate reflective links according to their actual red/green packet occupancy, with smoothed attack/decay instead of highlighting idle links.
- Project packet-driven caustics onto nearby reflective links and metallic servers.
- Add subtle expanding red/green switch-arrival ripples and configurable ripple intensity.
- Introduce a distinct recovering switch state: repaired switches remain excluded from ordinary routes until a visible blue probe reaches them.
- Retry probes when another unavailable switch blocks the path, and expose recovering-switch, active-plane, illuminated-link, ripple, and caustic state for accessibility and diagnostics.

### Guided storytelling

- Add a separate `story.ts` chapter model covering independent conversations, packet spraying, congestion and trimming, switch failure and rerouting, and probe-confirmed recovery.
- Add compact **Play / Back / Next** controls, optional `?story=1` autoplay, smooth chapter-specific camera framing, and scripted switch-state transitions.
- Pause the tour automatically when a user manually interacts with a switch.
- Update showcase explanations plus the glass-effects guide and API reference.

## Verification

- `env -u YARN_NO_PROXY corepack yarn build`: passed across all packages.
- `env -u YARN_NO_PROXY corepack yarn lint fix`: passed.
- `env -u YARN_NO_PROXY corepack yarn test-node`: **200 passed, 2 skipped**; the pre-commit hook reran the same suite successfully.
- `env -u YARN_NO_PROXY corepack yarn examples:typecheck`: passed for all **32 example workspaces**.
- `env -u YARN_NO_PROXY corepack yarn build` in `examples/showcase/packet-spraying`: standalone TypeScript and production Vite build passed.
- Focused story/network tests: **10 passed**.
- Previously verified exact A-buffer and weighted-blended transparency browser suites: **8 passed**.
- Full website production build and complete headless-browser suite were not rerun for this follow-up.
