### PR TITLE
feat(showcase): add adaptive fabric telemetry

### DIFF
--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -45,7 +45,9 @@ velocity-aligned mesh. A tapered cone behind each packet produces directional bl
 blurring stationary glass, links, or neighboring packet colors. Narrow packet-aligned optical wakes
 can remain inside reflective link geometry, while brief additive arrival flashes and expanding
 state-transition waves share the same emissive material. Bounded point lights carry these local
-color changes onto nearby glass without brightening the entire scene.
+color changes onto nearby glass without brightening the entire scene. Small, flattened emissive
+endpoint pulses can mark packet transmission and delivery while reflecting their true conversation
+color from adjacent metallic server surfaces.
 
 ## Attach a Glass Material
 

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -101,6 +101,7 @@ import {
   isFailedSwitchPosition,
   makeActiveLinkKeys,
   makeConversationRoutes,
+  makeEndpointSignals,
   makeHostColor,
   makeLinkColor,
   makeLinkKey,
@@ -108,6 +109,7 @@ import {
   makeLinkTraffic,
   makeLinks,
   makePackets,
+  makeNetworkPlaneTelemetry,
   makePickableNetworkNodes,
   makeSwitchPacketEvents,
   makeSwitchProbeConfirmationEvent,
@@ -119,6 +121,8 @@ import {
   type Color,
   type ConversationRoute,
   type NetworkLink,
+  type NetworkEndpointSignal,
+  type NetworkPlaneTelemetry,
   type NetworkPacketEvent,
   type NetworkScenario,
   type NetworkSwitchTransitionWave,
@@ -591,6 +595,7 @@ const SWITCH_FLASH_DURATION = 0.16;
 const SWITCH_RIPPLE_DURATION = 0.38;
 const MAX_SWITCH_FLASH_LIGHTS = 6;
 const MAX_SWITCH_TRANSITION_WAVES = 12;
+const MAX_ENDPOINT_SIGNALS = CONVERSATIONS.length * 2;
 const MAX_STORY_PACKET_INSTANCES = 160;
 const CONGESTED_SWITCH_COLOR: Color = [1, 0.42, 0.065, 0.56];
 const DETECTING_SWITCH_COLOR: Color = [1, 0.21, 0.035, 0.59];
@@ -900,8 +905,15 @@ class NetworkStoryControls {
   private readonly rootElement: HTMLDivElement;
   private readonly titleElement: HTMLDivElement;
   private readonly descriptionElement: HTMLParagraphElement;
+  private readonly fabricStatusElement: HTMLSpanElement;
+  private readonly planeIndicators: {
+    greenBar: HTMLDivElement;
+    redBar: HTMLDivElement;
+    status: HTMLSpanElement;
+  }[];
   private readonly chapterPositionElement: HTMLSpanElement;
   private readonly playbackButton: HTMLButtonElement;
+  private previousTelemetrySignature = '';
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -957,6 +969,71 @@ class NetworkStoryControls {
       color: '#bcc9dc'
     });
 
+    const telemetryElement = document.createElement('div');
+    Object.assign(telemetryElement.style, {
+      margin: '0 0 13px',
+      paddingTop: '9px',
+      borderTop: '1px solid rgba(137, 166, 211, 0.17)'
+    });
+
+    const telemetryHeading = document.createElement('div');
+    Object.assign(telemetryHeading.style, {
+      display: 'flex',
+      justifyContent: 'space-between',
+      marginBottom: '5px',
+      color: '#91a6c3',
+      fontSize: '10px'
+    });
+    const telemetryLabel = document.createElement('span');
+    telemetryLabel.textContent = 'FABRIC PLANES';
+    this.fabricStatusElement = document.createElement('span');
+    telemetryHeading.append(telemetryLabel, this.fabricStatusElement);
+    telemetryElement.appendChild(telemetryHeading);
+
+    this.planeIndicators = SPINE_POSITIONS.map((_, planeIndex) => {
+      const rowElement = document.createElement('div');
+      rowElement.dataset.networkPlane = String(planeIndex + 1);
+      Object.assign(rowElement.style, {
+        display: 'grid',
+        gridTemplateColumns: '42px minmax(0, 1fr) 56px',
+        alignItems: 'center',
+        gap: '7px',
+        height: '18px'
+      });
+
+      const labelElement = document.createElement('span');
+      labelElement.textContent = `Plane ${planeIndex + 1}`;
+      Object.assign(labelElement.style, {color: '#becce0', fontSize: '10px'});
+
+      const trackElement = document.createElement('div');
+      Object.assign(trackElement.style, {
+        display: 'flex',
+        height: '5px',
+        overflow: 'hidden',
+        borderRadius: '3px',
+        background: 'rgba(93, 113, 146, 0.3)'
+      });
+      const redBar = document.createElement('div');
+      const greenBar = document.createElement('div');
+      Object.assign(redBar.style, {
+        height: '100%',
+        background: '#ff504d',
+        transition: 'width 260ms ease'
+      });
+      Object.assign(greenBar.style, {
+        height: '100%',
+        background: '#34db87',
+        transition: 'width 260ms ease'
+      });
+      trackElement.append(redBar, greenBar);
+
+      const status = document.createElement('span');
+      Object.assign(status.style, {textAlign: 'right', fontSize: '9px'});
+      rowElement.append(labelElement, trackElement, status);
+      telemetryElement.appendChild(rowElement);
+      return {greenBar, redBar, status};
+    });
+
     const actionsElement = document.createElement('div');
     Object.assign(actionsElement.style, {
       display: 'flex',
@@ -987,6 +1064,7 @@ class NetworkStoryControls {
       headingElement,
       this.titleElement,
       this.descriptionElement,
+      telemetryElement,
       actionsElement
     );
     (canvas.parentElement || document.body).appendChild(this.rootElement);
@@ -1003,6 +1081,49 @@ class NetworkStoryControls {
     );
     this.rootElement.dataset.networkStoryChapter = chapter.id;
     this.rootElement.dataset.networkStoryPlaying = String(isPlaying);
+  }
+
+  updateTelemetry(planes: readonly NetworkPlaneTelemetry[]): void {
+    const signature = planes
+      .map(plane => `${plane.status}:${plane.redPacketCount}:${plane.greenPacketCount}`)
+      .join('|');
+    if (signature === this.previousTelemetrySignature) {
+      return;
+    }
+    this.previousTelemetrySignature = signature;
+
+    const availablePlaneCount = planes.filter(
+      plane => plane.status !== 'failed' && plane.status !== 'recovering'
+    ).length;
+    const maximumPlaneLoad = Math.max(
+      ...planes.map(plane => plane.redPacketCount + plane.greenPacketCount),
+      1
+    );
+    this.fabricStatusElement.textContent = `${availablePlaneCount} / ${planes.length} AVAILABLE`;
+
+    for (const plane of planes) {
+      const indicator = this.planeIndicators[plane.planeIndex];
+      indicator.redBar.style.width = `${(plane.redPacketCount / maximumPlaneLoad) * 100}%`;
+      indicator.greenBar.style.width = `${(plane.greenPacketCount / maximumPlaneLoad) * 100}%`;
+      indicator.status.textContent =
+        plane.status === 'healthy'
+          ? 'ONLINE'
+          : plane.status === 'congested'
+            ? 'PRESSURE'
+            : plane.status === 'recovering'
+              ? 'PROBING'
+              : 'OFFLINE';
+      indicator.status.style.color =
+        plane.status === 'healthy'
+          ? '#8ba6c7'
+          : plane.status === 'congested'
+            ? '#ffac59'
+            : plane.status === 'recovering'
+              ? '#72d4ff'
+              : '#ff7065';
+    }
+
+    this.rootElement.dataset.networkPlaneStates = planes.map(plane => plane.status).join(',');
   }
 
   destroy(): void {
@@ -1134,6 +1255,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     app: AppUniforms;
     emissiveMaterial: EmissiveMaterialProps;
   }>;
+  readonly endpointSignals: InstancedMesh<{
+    app: AppUniforms;
+    emissiveMaterial: EmissiveMaterialProps;
+  }>;
   readonly switchFlashes: InstancedMesh<{
     app: AppUniforms;
     emissiveMaterial: EmissiveMaterialProps;
@@ -1156,6 +1281,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly packetTrailColors: Float32Array;
   readonly linkPulseMatrices: Float32Array;
   readonly linkPulseColors: Float32Array;
+  readonly endpointSignalMatrices = new Float32Array(MAX_ENDPOINT_SIGNALS * 16);
+  readonly endpointSignalColors = new Float32Array(MAX_ENDPOINT_SIGNALS * 4);
   switchArrivalEvents: SwitchArrival[];
   readonly switchFlashMatrices: Float32Array;
   readonly switchFlashColors: Float32Array;
@@ -1170,6 +1297,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly storyPacketMatrices = new Float32Array(MAX_STORY_PACKET_INSTANCES * 16);
   readonly storyPacketColors = new Float32Array(MAX_STORY_PACKET_INSTANCES * 4);
   readonly networkPacketEvents: NetworkPacketEvent[] = [];
+  private endpointSignalDefinitions: NetworkEndpointSignal[] = [];
   orbitControls: OrbitControls | null = null;
   nodePopup: NetworkNodePopup | null = null;
   storyControls: NetworkStoryControls | null = null;
@@ -1198,6 +1326,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private guidedStoryPreviousCameraTime: number | null = null;
 
   transparencyMode: TransparencyMode;
+  adaptiveRouting = true;
   speed = 0.85;
   orbit = 0.08;
   glassIndexOfRefraction = 1.48;
@@ -1226,6 +1355,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   linkTrafficGlow = 0.58;
   linkPulseLength = 0.31;
   linkPulseIntensity = 0.48;
+  endpointSignalIntensity = 0.54;
   congestionPressureIntensity = 0.32;
   causticIntensity = 0.48;
   causticFocus = 1.15;
@@ -1451,6 +1581,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       additive: true,
       trail: true
     });
+    this.endpointSignals = new InstancedMesh(device, this.emissiveShaderInputs, {
+      id: 'packet-spraying-endpoint-activity',
+      geometry: new SphereGeometry({radius: 1, nlat: 10, nlong: 18}),
+      matrices: this.endpointSignalMatrices,
+      colors: this.endpointSignalColors,
+      additive: true,
+      emissive: true
+    });
     this.switchFlashes = new InstancedMesh(device, this.emissiveShaderInputs, {
       id: 'packet-spraying-switch-arrival-flashes',
       geometry: new SphereGeometry({radius: 1, nlat: 8, nlong: 12}),
@@ -1489,6 +1627,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       schema: makeSettingsSchema(supportsABuffer, supportsWeightedBlending),
       settings: {
         transparencyMode: this.transparencyMode,
+        adaptiveRouting: this.adaptiveRouting,
         speed: this.speed,
         orbit: this.orbit,
         glassIndexOfRefraction: this.glassIndexOfRefraction,
@@ -1517,6 +1656,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         linkTrafficGlow: this.linkTrafficGlow,
         linkPulseLength: this.linkPulseLength,
         linkPulseIntensity: this.linkPulseIntensity,
+        endpointSignalIntensity: this.endpointSignalIntensity,
         congestionPressureIntensity: this.congestionPressureIntensity,
         causticIntensity: this.causticIntensity,
         causticFocus: this.causticFocus,
@@ -1562,6 +1702,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         onTogglePlayback: () => this.setGuidedStoryPlaying(!this.guidedStoryPlaying)
       });
       this.updateGuidedStoryControls();
+      this.updateNetworkTelemetry();
       this.updateFailureAccessibility();
 
       if (new URLSearchParams(window.location.search).get('story') === '1') {
@@ -1577,6 +1718,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.updateSwitchStoryState(this.animationTime);
     this.updateSwitchPressure(this.animationTime);
     this.updatePacketVisuals(this.animationTime);
+    this.updateEndpointSignals(this.animationTime);
     this.updateLinkPulseVisuals(this.animationTime);
     this.updateLinkTraffic(this.animationTime);
     this.updateSwitchTransitionVisuals(this.animationTime);
@@ -1584,6 +1726,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.packets.updateMatrices(this.packetMatrices);
     this.packetTrails.updateInstances(this.packetTrailMatrices, this.packetTrailColors);
     this.linkPulses.updateInstances(this.linkPulseMatrices, this.linkPulseColors);
+    this.endpointSignals.updateInstances(this.endpointSignalMatrices, this.endpointSignalColors);
     this.switchFlashes.updateInstances(this.switchFlashMatrices, this.switchFlashColors);
     this.switchRipples.updateInstances(this.switchRippleMatrices, this.switchRippleColors);
     this.switchTransitionVisuals.updateInstances(
@@ -1682,6 +1825,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.packets.model.predraw(device.commandEncoder);
     this.packetTrails.model.predraw(device.commandEncoder);
     this.linkPulses.model.predraw(device.commandEncoder);
+    this.endpointSignals.model.predraw(device.commandEncoder);
     this.switchFlashes.model.predraw(device.commandEncoder);
     this.switchRipples.model.predraw(device.commandEncoder);
     this.switchTransitionVisuals.model.predraw(device.commandEncoder);
@@ -1696,6 +1840,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.packets.model.draw(sceneRenderPass);
     this.packetTrails.model.draw(sceneRenderPass);
     this.linkPulses.model.draw(sceneRenderPass);
+    this.endpointSignals.model.draw(sceneRenderPass);
     this.switchFlashes.model.draw(sceneRenderPass);
     this.switchRipples.model.draw(sceneRenderPass);
     this.switchTransitionVisuals.model.draw(sceneRenderPass);
@@ -1834,6 +1979,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.packets.destroy();
     this.packetTrails.destroy();
     this.linkPulses.destroy();
+    this.endpointSignals.destroy();
     this.switchFlashes.destroy();
     this.switchRipples.destroy();
     this.switchTransitionVisuals.destroy();
@@ -2369,7 +2515,11 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.failedSwitchIndices,
       this.recoveringSwitchIndices
     );
-    reroutePackets(this.packetDefinitions, healthyRoutes);
+    reroutePackets(
+      this.packetDefinitions,
+      healthyRoutes,
+      this.adaptiveRouting ? this.congestedSwitchIndices : undefined
+    );
     this.switchArrivalEvents = makeSwitchArrivals(this.packetDefinitions);
     const activeLinkKeys = makeActiveLinkKeys(healthyRoutes);
 
@@ -2391,6 +2541,74 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       flattenMatrices(this.networkLinks.map(link => makeLinkMatrix(link, 0.09))),
       flattenColors(this.networkLinks.map(link => link.color))
     );
+    this.updateNetworkTelemetry();
+  }
+
+  private updateNetworkTelemetry(): void {
+    const telemetry = makeNetworkPlaneTelemetry(
+      this.conversationRoutes,
+      this.packetDefinitions,
+      this.failedSwitchIndices,
+      this.recoveringSwitchIndices,
+      this.congestedSwitchIndices
+    );
+    this.storyControls?.updateTelemetry(telemetry);
+
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingPlaneStates = telemetry
+        .map(plane => plane.status)
+        .join(',');
+      this.canvas.dataset.packetSprayingPlaneAllocation = telemetry
+        .map(plane => `${plane.redPacketCount}:${plane.greenPacketCount}`)
+        .join(',');
+      this.canvas.dataset.packetSprayingAdaptiveRouting = String(this.adaptiveRouting);
+    }
+  }
+
+  private updateEndpointSignals(animationTime: number): void {
+    this.endpointSignalMatrices.fill(0);
+    this.endpointSignalColors.fill(0);
+    this.endpointSignalDefinitions =
+      this.endpointSignalIntensity > 0
+        ? makeEndpointSignals(this.packetDefinitions, animationTime)
+        : [];
+
+    for (const [signalIndex, signal] of this.endpointSignalDefinitions.entries()) {
+      if (signalIndex >= MAX_ENDPOINT_SIGNALS) {
+        break;
+      }
+
+      const hostPosition = HOST_POSITIONS[signal.hostIndex];
+      const destinationSignal = signal.kind === 'destination';
+      const radius =
+        (destinationSignal ? 0.22 : 0.17) + signal.strength * (destinationSignal ? 0.14 : 0.09);
+      const position: Vector3 = [
+        hostPosition[0],
+        hostPosition[1] + HOST_HALF_EXTENTS[1] + 0.035,
+        hostPosition[2]
+      ];
+      this.endpointSignalMatrices.set(
+        makeObjectMatrix(position, [radius, 0.038 + signal.strength * 0.014, radius]),
+        signalIndex * 16
+      );
+      const signalColor = makeBalancedEmissionColor(signal.color, 1);
+      const intensity = signal.strength * this.endpointSignalIntensity;
+      this.endpointSignalColors.set(
+        [
+          signalColor[0] * intensity * 0.37,
+          signalColor[1] * intensity * 0.37,
+          signalColor[2] * intensity * 0.37,
+          Math.min(intensity * 0.42, 0.32)
+        ],
+        signalIndex * 4
+      );
+    }
+
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingEndpointSignals = String(
+        this.endpointSignalDefinitions.length
+      );
+    }
   }
 
   private updateSwitchPressure(animationTime: number): void {
@@ -3000,8 +3218,20 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       });
     }
 
+    const endpointLights: OpticalPointLight[] = this.endpointSignalDefinitions.map(signal => ({
+      position: [
+        HOST_POSITIONS[signal.hostIndex][0],
+        HOST_POSITIONS[signal.hostIndex][1] + HOST_HALF_EXTENTS[1] + 0.045,
+        HOST_POSITIONS[signal.hostIndex][2]
+      ],
+      color: [signal.color[0], signal.color[1], signal.color[2]],
+      intensity: signal.strength * this.endpointSignalIntensity * 0.65,
+      radius: this.packetLightRadius * 0.65
+    }));
+
     return [
       ...lights,
+      ...endpointLights,
       ...transitionLights,
       ...switchFlashLights.slice(0, MAX_SWITCH_FLASH_LIGHTS),
       ...secondaryLights
@@ -3099,6 +3329,13 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     const transparencyMode = getChangedSetting(changedSettings, 'transparencyMode')?.nextValue;
     if (isTransparencyMode(transparencyMode)) {
       this.transparencyMode = transparencyMode;
+    }
+
+    const adaptiveRouting = getChangedSetting(changedSettings, 'adaptiveRouting')?.nextValue;
+    if (typeof adaptiveRouting === 'boolean') {
+      this.adaptiveRouting = adaptiveRouting;
+      this.updateHealthyRoutes();
+      this.updateFailureAccessibility();
     }
 
     const speed = getChangedSetting(changedSettings, 'speed')?.nextValue;
@@ -3296,6 +3533,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.linkPulseIntensity = linkPulseIntensity;
     }
 
+    const endpointSignalIntensity = getChangedSetting(
+      changedSettings,
+      'endpointSignalIntensity'
+    )?.nextValue;
+    if (typeof endpointSignalIntensity === 'number') {
+      this.endpointSignalIntensity = endpointSignalIntensity;
+    }
+
     const congestionPressureIntensity = getChangedSetting(
       changedSettings,
       'congestionPressureIntensity'
@@ -3338,16 +3583,17 @@ const PACKET_SPRAYING_OVERVIEW_HTML = `\
 <p><strong>Two conversations, many routes.</strong> The two servers on the right send independent red and green transfers to two destination servers on the left.</p>
 <p>The guided network tour steps through packet spraying, congestion, switch failure, retransmission, and probe-confirmed recovery. Use Play, Back, and Next to follow or inspect each chapter.</p>
 <p>Packets enter their local Tier 0 switch as separate streams. Once the streams meet, the switch forwards alternating red and green packets across four representative independent network planes. The destination-side switches separate the traffic again and deliver each color to its intended server.</p>
+<p>The live plane monitor shows red and green allocation on every path. Under pressure, adaptive routing moves most packets away from a congested plane without retiring it; an offline or recovering plane carries none until its control handshake succeeds.</p>
 <p>Click any glass switch to move it from healthy to orange and congested, then red and failed. Clicking a failed switch repairs it, but its path stays offline while a blue recovery probe travels to the switch and a cyan acknowledgment returns to its source.</p>
 <p>An orange switch trims overloaded packet payloads while their smaller headers continue. A red switch briefly loses in-flight packets before MRC retires the failed plane, retransmits over healthy routes, and sends occasional recovery probes.</p>
-<p>Muted red and green cubes identify each conversation's source and destination; blue cubes are inactive servers. Glass spheres are switches, and fabric links softly brighten with red or green light only while packets are traveling through them. Directional light wakes remain inside each link, congested switches breathe amber, and failures or confirmed recoveries send restrained red or cyan waves through nearby glass. Emissive packets leave short trails, reflect inside nearby glass, and project focused colored caustics onto adjacent reflective surfaces.</p>
+<p>Muted red and green cubes identify each conversation's source and destination; blue cubes are inactive servers. Each active server emits a restrained colored pulse when it launches or receives a packet. Glass spheres are switches, and fabric links softly brighten with red or green light only while packets are traveling through them. Directional light wakes remain inside each link, congested switches breathe amber, and failures or confirmed recoveries send restrained red or cyan waves through nearby glass. Emissive packets leave short trails, reflect inside nearby glass, and project focused colored caustics onto adjacent reflective surfaces.</p>
 <p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Read OpenAI's supercomputer networking and MRC article</a></p>`;
 
 const PACKET_SPRAYING_BACKGROUND_HTML = `\
 <p><strong>Multipath Reliable Connection (MRC)</strong> extends RDMA over Converged Ethernet so a single transfer is no longer pinned to one network path.</p>
 <p><strong>How the two conversations mix:</strong> the red source talks to one destination, and the green source talks to another. Their packets can share the same switch-to-switch link, interleaving one red packet with one green packet before being separated near their destinations.</p>
 <p><strong>Planes and packet spraying:</strong> a high-bandwidth network interface can be split across multiple independent physical planes. In the article's example, an 800 Gb/s interface becomes eight 100 Gb/s connections. This visualization shows four representative paths; each conversation sprays successive packets across all four instead of waiting behind one busy link.</p>
-<p><strong>Throughput:</strong> using many paths at once balances traffic, avoids persistent hot spots, and reduces worst-case transfer latency. That matters for synchronous AI training because an entire GPU group can wait for its slowest communication.</p>
+<p><strong>Throughput:</strong> using many paths at once balances traffic, avoids persistent hot spots, and reduces worst-case transfer latency. When a path becomes congested, MRC reduces its share and spreads subsequent packets across healthier planes while still testing the pressured route. That matters for synchronous AI training because an entire GPU group can wait for its slowest communication.</p>
 <p><strong>Congestion and packet trimming:</strong> if a switch cannot forward an entire packet, it can discard the payload while delivering a small header. The destination uses that header to request a retransmission without confusing congestion for a permanent network failure.</p>
 <p><strong>Resilience:</strong> if a link, plane, or switch fails, only packets already committed to that path are lost. The sender retires the affected route, retransmits through surviving planes, and occasionally probes the failed path for recovery. A repaired path does not carry ordinary traffic again until an outbound control probe reaches the switch and its acknowledgment successfully returns. Losing one of eight interface links reduces peak physical bandwidth by one eighth instead of crashing the training job.</p>
 <p><strong>Source routing:</strong> MRC uses IPv6 Segment Routing (SRv6) to encode a packet's chosen switch sequence. This allows static switch configuration, rapid rerouting, and a simpler control plane without waiting for dynamic routing convergence.</p>
@@ -3660,6 +3906,12 @@ function makeSettingsSchema(
             min: 0,
             max: 0.5,
             step: 0.01
+          },
+          {
+            name: 'adaptiveRouting',
+            label: 'Adaptive Routing',
+            type: 'boolean',
+            persist: 'none'
           }
         ]
       },
@@ -3761,6 +4013,15 @@ function makeSettingsSchema(
           {
             name: 'linkPulseIntensity',
             label: 'Link Pulse Intensity',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1.4,
+            step: 0.05
+          },
+          {
+            name: 'endpointSignalIntensity',
+            label: 'Server Activity Glow',
             type: 'number',
             persist: 'none',
             min: 0,

--- a/examples/showcase/packet-spraying/network.ts
+++ b/examples/showcase/packet-spraying/network.ts
@@ -75,6 +75,25 @@ export type NetworkSwitchTransitionWave = {
   switchIndex: number;
 };
 
+export type NetworkPlaneStatus = 'healthy' | 'congested' | 'failed' | 'recovering';
+
+export type NetworkPlaneTelemetry = {
+  greenPacketCount: number;
+  planeIndex: number;
+  redPacketCount: number;
+  status: NetworkPlaneStatus;
+};
+
+export type NetworkEndpointSignalKind = 'source' | 'destination';
+
+export type NetworkEndpointSignal = {
+  color: Color;
+  conversationIndex: number;
+  hostIndex: number;
+  kind: NetworkEndpointSignalKind;
+  strength: number;
+};
+
 export type Conversation = {
   color: Color;
   destinationHostIndex: number;
@@ -129,6 +148,7 @@ export const BURST_CYCLE_DURATION = 11;
 export const CONGESTION_TRIM_INTERVAL = 1.35;
 export const FAILURE_DETECTION_DELAY = 0.52;
 export const PACKET_TRAVEL_SPEED = 3.4;
+export const ENDPOINT_SIGNAL_DURATION = 0.34;
 export const SWITCH_CONFIRMATION_DURATION = 0.46;
 export const SWITCH_PROBE_INTERVAL = 2.2;
 export const SWITCH_TRANSITION_WAVE_DURATION = 0.78;
@@ -494,17 +514,138 @@ export function getHealthyConversationRoutes(
   );
 }
 
-export function reroutePackets(packets: Packet[], healthyRoutes: ConversationRoute[]): void {
-  for (const packet of packets) {
+export function reroutePackets(
+  packets: Packet[],
+  healthyRoutes: readonly ConversationRoute[],
+  congestedSwitchIndices?: ReadonlySet<number>
+): void {
+  const scheduledRoutesByConversation = new Map<number, ConversationRoute[]>();
+
+  for (let conversationIndex = 0; conversationIndex < CONVERSATIONS.length; conversationIndex++) {
     const conversationRoutes = healthyRoutes.filter(
-      route => route.conversationIndex === packet.conversationIndex
+      route => route.conversationIndex === conversationIndex
     );
+    const uncongestedRoutes = congestedSwitchIndices
+      ? conversationRoutes.filter(({route}) =>
+          route.points.every(position => !isFailedSwitchPosition(position, congestedSwitchIndices))
+        )
+      : conversationRoutes;
+
+    if (uncongestedRoutes.length === 0 || uncongestedRoutes.length === conversationRoutes.length) {
+      scheduledRoutesByConversation.set(conversationIndex, conversationRoutes);
+      continue;
+    }
+
+    const congestedRoutes = conversationRoutes.filter(route => !uncongestedRoutes.includes(route));
+    scheduledRoutesByConversation.set(conversationIndex, [
+      ...uncongestedRoutes,
+      ...congestedRoutes,
+      ...uncongestedRoutes,
+      ...uncongestedRoutes
+    ]);
+  }
+
+  for (const packet of packets) {
+    const conversationRoutes = scheduledRoutesByConversation.get(packet.conversationIndex) || [];
     packet.enabled = conversationRoutes.length > 0;
     if (packet.enabled) {
       packet.route =
         conversationRoutes[packet.preferredRouteIndex % conversationRoutes.length].route;
     }
   }
+}
+
+/** Summarizes the health and red/green packet allocation of each independent spine plane. */
+export function makeNetworkPlaneTelemetry(
+  conversationRoutes: readonly ConversationRoute[],
+  packets: readonly Packet[],
+  failedSwitchIndices: ReadonlySet<number>,
+  recoveringSwitchIndices: ReadonlySet<number>,
+  congestedSwitchIndices: ReadonlySet<number>
+): NetworkPlaneTelemetry[] {
+  return SPINE_POSITIONS.map((spinePosition, planeIndex) => {
+    const planeRoutes = conversationRoutes.filter(({route}) =>
+      route.points.includes(spinePosition)
+    );
+    const failed = planeRoutes.every(({route}) =>
+      route.points.some(position => isFailedSwitchPosition(position, failedSwitchIndices))
+    );
+    const recovering = planeRoutes.every(({route}) =>
+      route.points.some(
+        position =>
+          isFailedSwitchPosition(position, failedSwitchIndices) ||
+          isFailedSwitchPosition(position, recoveringSwitchIndices)
+      )
+    );
+    const congested = planeRoutes.some(({route}) =>
+      route.points.some(position => isFailedSwitchPosition(position, congestedSwitchIndices))
+    );
+    const planePackets = packets.filter(
+      packet => packet.enabled && packet.route.points.includes(spinePosition)
+    );
+
+    return {
+      planeIndex,
+      redPacketCount: planePackets.filter(packet => packet.conversationIndex === 0).length,
+      greenPacketCount: planePackets.filter(packet => packet.conversationIndex === 1).length,
+      status: failed ? 'failed' : recovering ? 'recovering' : congested ? 'congested' : 'healthy'
+    };
+  });
+}
+
+/** Produces bounded source-launch and destination-delivery activity for active conversations. */
+export function makeEndpointSignals(
+  packets: readonly Packet[],
+  animationTime: number,
+  duration = ENDPOINT_SIGNAL_DURATION
+): NetworkEndpointSignal[] {
+  if (duration <= 0) {
+    return [];
+  }
+
+  const signalsByHost = new Map<number, NetworkEndpointSignal>();
+
+  for (const packet of packets) {
+    if (!packet.enabled) {
+      continue;
+    }
+
+    const conversation = CONVERSATIONS[packet.conversationIndex];
+    const endpointEvents: [number, NetworkEndpointSignalKind, number][] = [
+      [conversation.sourceHostIndex, 'source', packet.launchTime],
+      [
+        conversation.destinationHostIndex,
+        'destination',
+        packet.launchTime + packet.route.totalLength / PACKET_TRAVEL_SPEED
+      ]
+    ];
+
+    for (const [hostIndex, kind, eventTime] of endpointEvents) {
+      const age =
+        (((animationTime - eventTime) % BURST_CYCLE_DURATION) + BURST_CYCLE_DURATION) %
+        BURST_CYCLE_DURATION;
+      if (age > duration) {
+        continue;
+      }
+
+      const progress = age / duration;
+      const strength = Math.sin(progress * Math.PI) * (1 - progress * 0.28);
+      const currentSignal = signalsByHost.get(hostIndex);
+      if (currentSignal) {
+        currentSignal.strength = Math.min(currentSignal.strength + strength * 0.55, 1);
+      } else {
+        signalsByHost.set(hostIndex, {
+          color: packet.color,
+          conversationIndex: packet.conversationIndex,
+          hostIndex,
+          kind,
+          strength
+        });
+      }
+    }
+  }
+
+  return [...signalsByHost.values()];
 }
 
 export function isFailedSwitchPosition(

--- a/examples/showcase/packet-spraying/story.ts
+++ b/examples/showcase/packet-spraying/story.ts
@@ -46,7 +46,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
     id: 'congestion',
     title: 'Congestion and packet trimming',
     description:
-      'An overloaded switch trims packet payloads while small headers trigger retransmission.',
+      'Packets shift toward healthy planes while an overloaded switch trims payloads into headers.',
     duration: 7,
     networkState: 'congested',
     camera: {target: [0, 0.65, 0.55], distance: 10.6, yaw: 0.42, pitch: 0.45}

--- a/test/examples/packet-spraying-network.node.spec.ts
+++ b/test/examples/packet-spraying-network.node.spec.ts
@@ -8,6 +8,7 @@ import {
   AGGREGATION_SWITCH_RADIUS,
   FAILURE_DETECTION_DELAY,
   CONVERSATIONS,
+  ENDPOINT_SIGNAL_DURATION,
   HOST_POSITIONS,
   LEAF_SWITCH_RADIUS,
   LEAF_POSITIONS,
@@ -21,10 +22,12 @@ import {
   getHealthyConversationRoutes,
   isFailedSwitchPosition,
   makeConversationRoutes,
+  makeEndpointSignals,
   makeLinks,
   makeLinkPulses,
   makeLinkTraffic,
   makePackets,
+  makeNetworkPlaneTelemetry,
   makePickableNetworkNodes,
   makeSwitchPacketEvents,
   makeSwitchProbeConfirmationEvent,
@@ -259,6 +262,156 @@ test('packet-spraying traffic immediately avoids and restores failed planes', te
     4,
     'packets resume using all four paths'
   );
+  testCase.end();
+});
+
+test('packet-spraying adaptively shifts load away from congested physical planes', testCase => {
+  const routes = makeConversationRoutes();
+  const packets = makePackets(routes);
+  const congestedSpineIndex = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length;
+  const congestedSwitches = new Set([congestedSpineIndex]);
+
+  reroutePackets(packets, routes, congestedSwitches);
+
+  for (let conversationIndex = 0; conversationIndex < CONVERSATIONS.length; conversationIndex++) {
+    const conversationPackets = packets.filter(
+      packet => packet.conversationIndex === conversationIndex
+    );
+    const congestedPackets = conversationPackets.filter(packet =>
+      packet.route.points.includes(SPINE_POSITIONS[0])
+    );
+    const healthyPackets = conversationPackets.filter(
+      packet => !packet.route.points.includes(SPINE_POSITIONS[0])
+    );
+
+    testCase.ok(congestedPackets.length > 0, 'a congested plane still receives low-rate traffic');
+    testCase.ok(
+      congestedPackets.length < 4,
+      'the congested plane carries fewer packets than equal round-robin spraying'
+    );
+    testCase.equal(
+      healthyPackets.length + congestedPackets.length,
+      conversationPackets.length,
+      'congestion-aware routing preserves every packet in the transfer'
+    );
+  }
+
+  reroutePackets(packets, routes);
+  testCase.equal(
+    packets.filter(packet => packet.route.points.includes(SPINE_POSITIONS[0])).length,
+    12,
+    'disabling adaptive pressure restores equal traffic across every plane'
+  );
+
+  reroutePackets(packets, routes, new Set([3]));
+  testCase.equal(
+    packets.filter(packet => packet.route.points.includes(SPINE_POSITIONS[0])).length,
+    12,
+    'a shared access bottleneck cannot be bypassed by choosing a different plane'
+  );
+  testCase.end();
+});
+
+test('packet-spraying telemetry reports per-plane load, failure, and recovery', testCase => {
+  const routes = makeConversationRoutes();
+  const packets = makePackets(routes);
+  const planeSwitchIndex = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length;
+  const congestedSwitches = new Set([planeSwitchIndex]);
+
+  reroutePackets(packets, routes, congestedSwitches);
+  const congestedTelemetry = makeNetworkPlaneTelemetry(
+    routes,
+    packets,
+    new Set(),
+    new Set(),
+    congestedSwitches
+  );
+
+  testCase.equal(congestedTelemetry.length, 4, 'telemetry includes all four physical planes');
+  testCase.equal(congestedTelemetry[0].status, 'congested');
+  testCase.ok(
+    congestedTelemetry[0].redPacketCount < congestedTelemetry[1].redPacketCount,
+    'telemetry exposes reduced red allocation on the congested plane'
+  );
+  testCase.ok(
+    congestedTelemetry[0].greenPacketCount < congestedTelemetry[1].greenPacketCount,
+    'telemetry exposes reduced green allocation on the congested plane'
+  );
+
+  const failedSwitches = new Set([planeSwitchIndex]);
+  reroutePackets(packets, getHealthyConversationRoutes(routes, failedSwitches));
+  const failedTelemetry = makeNetworkPlaneTelemetry(
+    routes,
+    packets,
+    failedSwitches,
+    new Set(),
+    new Set()
+  );
+  testCase.equal(failedTelemetry[0].status, 'failed', 'a retired plane is visibly marked offline');
+  testCase.equal(failedTelemetry[0].redPacketCount, 0, 'retired planes carry no red packets');
+  testCase.equal(failedTelemetry[0].greenPacketCount, 0, 'retired planes carry no green packets');
+
+  const recoveringSwitches = new Set([planeSwitchIndex]);
+  reroutePackets(packets, getHealthyConversationRoutes(routes, new Set(), recoveringSwitches));
+  const recoveringTelemetry = makeNetworkPlaneTelemetry(
+    routes,
+    packets,
+    new Set(),
+    recoveringSwitches,
+    new Set()
+  );
+  testCase.equal(
+    recoveringTelemetry[0].status,
+    'recovering',
+    'a repaired plane remains in recovery until its acknowledgment returns'
+  );
+  testCase.ok(
+    recoveringTelemetry.slice(1).every(plane => plane.status === 'healthy'),
+    'unaffected planes continue operating normally'
+  );
+  testCase.end();
+});
+
+test('packet-spraying endpoint signals follow packet launch and delivery', testCase => {
+  const packets = makePackets(makeConversationRoutes());
+  const redPacket = packets.find(packet => packet.conversationIndex === 0)!;
+  const launchTime = redPacket.launchTime + ENDPOINT_SIGNAL_DURATION * 0.4;
+  const sourceSignals = makeEndpointSignals(packets, launchTime);
+  const redSourceSignal = sourceSignals.find(
+    signal => signal.conversationIndex === 0 && signal.kind === 'source'
+  );
+
+  testCase.equal(
+    redSourceSignal?.hostIndex,
+    CONVERSATIONS[0].sourceHostIndex,
+    'red launch activity remains attached to the source server'
+  );
+  testCase.ok(
+    (redSourceSignal?.strength ?? 0) > 0 && (redSourceSignal?.strength ?? 0) <= 1,
+    'launch signals remain smoothly bounded'
+  );
+
+  const deliveryTime =
+    redPacket.launchTime +
+    redPacket.route.totalLength / PACKET_TRAVEL_SPEED +
+    ENDPOINT_SIGNAL_DURATION * 0.4;
+  const redDeliverySignal = makeEndpointSignals(packets, deliveryTime).find(
+    signal => signal.conversationIndex === 0 && signal.kind === 'destination'
+  );
+  testCase.equal(
+    redDeliverySignal?.hostIndex,
+    CONVERSATIONS[0].destinationHostIndex,
+    'delivery signals arrive at the intended destination server'
+  );
+
+  for (const packet of packets.filter(packet => packet.conversationIndex === 0)) {
+    packet.enabled = false;
+  }
+  testCase.ok(
+    makeEndpointSignals(packets, launchTime).every(signal => signal.conversationIndex !== 0),
+    'disabled traffic cannot illuminate its source or destination'
+  );
+  testCase.deepEqual(makeEndpointSignals(packets, launchTime, 0), [], 'zero duration disables');
   testCase.end();
 });
 


### PR DESCRIPTION
## Summary

- Adapt packet spraying under congestion: retain a small traffic share on pressured planes while shifting most packets to healthy alternatives, without disabling the plane.
- Integrate four live per-plane telemetry rows into the guided network tour, showing red/green allocation and online, pressured, offline, or probing state.
- Render restrained source-launch and destination-delivery signals on active servers, with bounded local colored illumination and adjustable intensity.
- Add an adaptive-routing toggle, machine-readable canvas telemetry, updated guided-story explanations, and focused regression coverage for weighted routing, plane state transitions, and endpoint activity.
- Follow up on merged #2767.

## Verification

- `env -u YARN_NO_PROXY corepack yarn lint fix`
- `env -u YARN_NO_PROXY corepack yarn build`
- `env -u YARN_NO_PROXY corepack yarn examples:typecheck` (all 32 examples)
- `env -u YARN_NO_PROXY corepack yarn website:build`
- `env -u YARN_NO_PROXY corepack yarn build` from `examples/showcase/packet-spraying`
- `env -u YARN_NO_PROXY corepack yarn test-node`: 206 passed, 2 skipped.
- Focused packet-spraying network/story tests: 16 passed.
- `env -u YARN_NO_PROXY corepack yarn test`: Node phase passes; headless Chromium runs 1,284 passing tests but reproduces two existing unrelated Arrow/WebGPU failures in untouched files:
  - `modules/arrow/test/arrow/arrow-point-constant-render.spec.ts` intermittently reports a pending WebGPU pipeline.
  - `modules/arrow-layers/test/layers/arrow-layers.spec.ts` reports an existing storage-backed polygon rendering failure.
- `git diff --check`