### PR TITLE
feat(experimental): add spectral volume glass optics

### DIFF
--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -19,12 +19,15 @@ GLSL shader modules, while transparency renderers remain responsible for composi
 | Studio environment | Samples a generated equirectangular environment along the reflected viewing direction. | Polished surfaces receive camera-responsive studio reflections. |
 | Chromatic dispersion | Offsets red, green, and blue scene-color samples. | Subtle colored separation around refracted features. |
 | Beer-Lambert absorption | Attenuates transmitted light with material color and thickness. | Longer optical paths produce darker, more tinted transmission. |
+| Spectral volume absorption | Applies independent red, green, and blue extinction over measured shell thickness. | Deep glass acquires wavelength-dependent tint without recoloring thin silhouettes. |
+| Rough transmission | Filters refracted scene samples over a thickness- and roughness-dependent footprint. | Frosted glass softly blurs background packets while polished switches remain clear. |
 | GGX microfacets | Shared distribution and visibility helpers shade key and fill lights. | Roughness-dependent, camera-responsive polished highlights. |
 | Clearcoat | Adds a second narrow microfacet lobe above the base surface. | Crisp, bright reflections that make the outer shell readable. |
 | Internal reflection | Approximates a colored secondary environment bounce inside the shell. | A softer inner Fresnel band and greater visible depth. |
 | Multiple internal bounces | Reflects the refracted ray against both measured shell surfaces before sampling the studio environment again. | A second curved highlight suggests the depth of polished solid glass. |
-| Thin-film interference | Applies restrained wavelength-dependent color near grazing angles. | Subtle spectral variation without coloring the whole object. |
+| Thin-film interference | Evaluates nanometer-scale coating thickness across representative red, green, and blue wavelengths. | Angle-dependent spectral bands follow grazing highlights without coloring the whole object. |
 | Localized point lights | Evaluates a bounded array of nearby colored light sources. | Moving emissive objects tint adjacent glass and reflective surfaces. |
+| Optical volume scattering | Couples nearby colored point lights into the measured glass interior. | Passing packets briefly illuminate the inside of a switch without washing out the network. |
 | Dynamic scene reflections | Samples captured opaque scene color along a curved screen-space reflection offset. | Moving packets and active links appear as localized reflections on glass switches. |
 | Focused raster caustics | Projects bounded colored glass-lens contributions onto nearby reflective receivers. | Active switches concentrate moving red and green light onto adjacent links and servers. |
 | Fault-driven distortion | Modulates refraction and narrow internal filaments only on warm fault-tinted glass. | Congested and failed switches acquire subtle animated optical instability. |
@@ -125,6 +128,11 @@ shaderInputs.setProps({
     environmentTexture,
     environmentIntensity: 1.25,
     thicknessStrength: 1,
+    roughTransmissionStrength: 0.85,
+    spectralAbsorptionStrength: 0.42,
+    thinFilmThickness: 420,
+    thinFilmStrength: 0.22,
+    volumeScatteringStrength: 0.38,
     dynamicReflectionStrength: 0.38,
     secondaryBounceStrength: 0.55,
     faultDistortionStrength: 0.42,
@@ -138,7 +146,12 @@ Call `glassTransmission_getColor(...)`, or install `opticalPointLightsPlugin` an
 adding depth-derived thickness, analytic entry/exit refraction, foreground-depth rejection,
 total-internal-reflection handling, sampled equirectangular environment reflections, optional
 screen-space scene reflections, secondary internal bounces, and fault-tinted optical distortion.
-The additional controls default to zero so existing transmission consumers retain their appearance.
+Optional spectral-volume controls add bounded multisample rough transmission, wavelength-dependent
+Beer-Lambert absorption, nanometer-scale thin-film interference, and colored in-volume scattering
+from nearby point lights. These additional controls default to zero so existing transmission
+consumers retain their appearance. Rough transmission requires four additional chromatic scene
+samples and two additional environment samples; it remains a bounded raster approximation rather
+than geometry-aware ray tracing.
 
 ## Add Focused Raster Caustics
 
@@ -202,7 +215,8 @@ These materials are advanced raster approximations, not a complete physically ba
 system. In particular, the current implementation does not provide:
 
 - Full energy-conserving multiple-scattering or microfacet transmission.
-- Filtered environment probes and geometry-aware rough transmission.
+- Prefiltered environment probes, off-screen reflection recovery, or geometry-aware rough
+  transmission beyond the bounded screen-space footprint.
 - Physically traced multiple refraction events or caustics; the available focused-light module is
   an intentionally bounded raster approximation.
 - Off-screen background recovery or geometry-aware refracted-ray tracing.
@@ -210,6 +224,38 @@ system. In particular, the current implementation does not provide:
 Those capabilities require additional depth, normal, backface, environment, or ray-tracing data
 and should be introduced as explicitly composable modules or render passes rather than hidden in
 an individual showcase.
+
+## Optical Roadmap
+
+### Available Now: Portable Raster Optics
+
+- Camera-responsive Fresnel, GGX microfacet highlights, clearcoat, chromatic dispersion, and
+  analytic entry/exit refraction work across WebGL and WebGPU.
+- Backface-derived thickness, foreground rejection, wavelength-dependent volume absorption,
+  thickness-aware rough transmission, and nanometer-scale thin-film interference give glass
+  measurable optical depth without per-pixel ray tracing.
+- Bounded colored point lights, in-volume scattering, screen-space scene reflections, secondary
+  environment bounces, and focused raster caustics connect moving emitters to nearby glass.
+- Exact A-buffer transparency, weighted-blended transparency, and depth-sorted alpha blending
+  preserve the strongest supported compositing strategy on each backend.
+
+### Next: Richer Raster Light Transport
+
+- Add temporally accumulated rough transmission and history rejection to reduce multisample cost
+  while preserving animated packet detail.
+- Introduce filtered environment probes and roughness-selected reflection levels with explicit
+  capability-aware fallbacks.
+- Improve geometry-aware screen-space reflections and thickness-guided indirect packet lighting
+  without reading from active render attachments.
+- Add adaptive local scattering and neighborhood-aware translucent contact shadows while keeping
+  light counts bounded and diagrams legible.
+
+### Future: Opt-In Physically Traced Effects
+
+- Investigate energy-conserving microfacet transmission, multiple internal scattering events, and
+  ray-traced refraction only behind explicit backend and performance capability checks.
+- Treat physically traced caustics, off-screen background recovery, and hardware-ray-tracing
+  integration as separately composable render passes rather than hidden showcase requirements.
 
 For a complete application, see
 [Effects: Glass - Network Packet Spraying](/examples/showcase/packet-spraying), which combines glass switches,

--- a/docs/api-reference/experimental/glass-material.md
+++ b/docs/api-reference/experimental/glass-material.md
@@ -75,6 +75,11 @@ existing `glassMaterial_getColor(...)` consumers.
 | `environmentTexture` | `Texture` | Required for rendering. | Equirectangular studio or HDR environment. |
 | `environmentIntensity` | `number` | `1` | Environment reflection multiplier. |
 | `thicknessStrength` | `number` | `1` | Measured optical-path multiplier. |
+| `roughTransmissionStrength` | `number` | `0` | Thickness-aware rough transmission and filtered environment reflection strength. |
+| `spectralAbsorptionStrength` | `number` | `0` | Wavelength-dependent Beer-Lambert extinction inside the measured glass volume. |
+| `thinFilmThickness` | `number` | `0` | Surface coating thickness in nanometers; zero disables coating interference. |
+| `thinFilmStrength` | `number` | `0` | Intensity of angle-dependent red, green, and blue coating interference. |
+| `volumeScatteringStrength` | `number` | `0` | Strength of restrained in-volume scattering and nearby point-light coupling. |
 | `depthBias` | `number` | `0.00008` | Foreground depth-comparison tolerance. |
 | `dynamicReflectionStrength` | `number` | `0` | Captured-scene reflection strength for nearby moving objects. |
 | `secondaryBounceStrength` | `number` | `0` | Additional reflected environment bounce inside the glass shell. |
@@ -84,6 +89,12 @@ existing `glassMaterial_getColor(...)` consumers.
 Use `glassTransmission_getColor(...)`, or add `opticalPointLightsPlugin` and use
 `glassTransmission_getIlluminatedColor(...)` for localized illumination. Both are available in
 matching WGSL and GLSL forms.
+
+The optional volume controls preserve existing output when left at their zero defaults. Rough
+transmission adds bounded scene-color and environment samples; spectral absorption uses the
+backface-measured optical path; thin-film interference evaluates representative red, green, and
+blue wavelengths from the coating thickness; and volume scattering couples nearby optical point
+lights into the glass interior. No mode requires per-pixel ray tracing.
 
 `opticalCausticsPlugin` separately adds a bounded array of focused glass lenses for nearby
 reflective receiver surfaces. Call `opticalCaustics_getColor(normal, worldPosition,

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -1341,6 +1341,11 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   glassTransmissionStrength = 1.12;
   glassEnvironmentIntensity = 1.25;
   glassVolumeThickness = 1;
+  glassRoughTransmissionStrength = 0.85;
+  glassSpectralAbsorptionStrength = 0.42;
+  glassThinFilmThickness = 420;
+  glassThinFilmStrength = 0.22;
+  glassVolumeScatteringStrength = 0.38;
   glassDynamicReflectionStrength = 0.38;
   glassSecondaryBounceStrength = 0.55;
   glassFaultDistortionStrength = 0.42;
@@ -1642,6 +1647,11 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         glassTransmissionStrength: this.glassTransmissionStrength,
         glassEnvironmentIntensity: this.glassEnvironmentIntensity,
         glassVolumeThickness: this.glassVolumeThickness,
+        glassRoughTransmissionStrength: this.glassRoughTransmissionStrength,
+        glassSpectralAbsorptionStrength: this.glassSpectralAbsorptionStrength,
+        glassThinFilmThickness: this.glassThinFilmThickness,
+        glassThinFilmStrength: this.glassThinFilmStrength,
+        glassVolumeScatteringStrength: this.glassVolumeScatteringStrength,
         glassDynamicReflectionStrength: this.glassDynamicReflectionStrength,
         glassSecondaryBounceStrength: this.glassSecondaryBounceStrength,
         glassFaultDistortionStrength: this.glassFaultDistortionStrength,
@@ -1773,6 +1783,11 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       environmentTexture: this.environmentTexture,
       environmentIntensity: this.glassEnvironmentIntensity,
       thicknessStrength: this.glassVolumeThickness,
+      roughTransmissionStrength: this.glassRoughTransmissionStrength,
+      spectralAbsorptionStrength: this.glassSpectralAbsorptionStrength,
+      thinFilmThickness: this.glassThinFilmThickness,
+      thinFilmStrength: this.glassThinFilmStrength,
+      volumeScatteringStrength: this.glassVolumeScatteringStrength,
       dynamicReflectionStrength: this.glassDynamicReflectionStrength,
       secondaryBounceStrength: this.glassSecondaryBounceStrength,
       faultDistortionStrength: this.glassFaultDistortionStrength,
@@ -3439,6 +3454,46 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.glassVolumeThickness = glassVolumeThickness;
     }
 
+    const glassRoughTransmissionStrength = getChangedSetting(
+      changedSettings,
+      'glassRoughTransmissionStrength'
+    )?.nextValue;
+    if (typeof glassRoughTransmissionStrength === 'number') {
+      this.glassRoughTransmissionStrength = glassRoughTransmissionStrength;
+    }
+
+    const glassSpectralAbsorptionStrength = getChangedSetting(
+      changedSettings,
+      'glassSpectralAbsorptionStrength'
+    )?.nextValue;
+    if (typeof glassSpectralAbsorptionStrength === 'number') {
+      this.glassSpectralAbsorptionStrength = glassSpectralAbsorptionStrength;
+    }
+
+    const glassThinFilmThickness = getChangedSetting(
+      changedSettings,
+      'glassThinFilmThickness'
+    )?.nextValue;
+    if (typeof glassThinFilmThickness === 'number') {
+      this.glassThinFilmThickness = glassThinFilmThickness;
+    }
+
+    const glassThinFilmStrength = getChangedSetting(
+      changedSettings,
+      'glassThinFilmStrength'
+    )?.nextValue;
+    if (typeof glassThinFilmStrength === 'number') {
+      this.glassThinFilmStrength = glassThinFilmStrength;
+    }
+
+    const glassVolumeScatteringStrength = getChangedSetting(
+      changedSettings,
+      'glassVolumeScatteringStrength'
+    )?.nextValue;
+    if (typeof glassVolumeScatteringStrength === 'number') {
+      this.glassVolumeScatteringStrength = glassVolumeScatteringStrength;
+    }
+
     const glassDynamicReflectionStrength = getChangedSetting(
       changedSettings,
       'glassDynamicReflectionStrength'
@@ -3597,7 +3652,7 @@ const PACKET_SPRAYING_BACKGROUND_HTML = `\
 <p><strong>Congestion and packet trimming:</strong> if a switch cannot forward an entire packet, it can discard the payload while delivering a small header. The destination uses that header to request a retransmission without confusing congestion for a permanent network failure.</p>
 <p><strong>Resilience:</strong> if a link, plane, or switch fails, only packets already committed to that path are lost. The sender retires the affected route, retransmits through surviving planes, and occasionally probes the failed path for recovery. A repaired path does not carry ordinary traffic again until an outbound control probe reaches the switch and its acknowledgment successfully returns. Losing one of eight interface links reduces peak physical bandwidth by one eighth instead of crashing the training job.</p>
 <p><strong>Source routing:</strong> MRC uses IPv6 Segment Routing (SRv6) to encode a packet's chosen switch sequence. This allows static switch configuration, rapid rerouting, and a simpler control plane without waiting for dynamic routing convergence.</p>
-<p><strong>Rendering:</strong> reusable glass materials combine grazing-angle Fresnel reflection, GGX microfacet highlights, clearcoat, two internal shell bounces, moving scene reflections, thin-film iridescence, and roughness-aware chromatic transmission. Emissive packet cores, directional trails, and switch flashes illuminate nearby glass through bounded point lights and focused raster caustics. Fault-tinted switches add subtle animated lens distortion. Floating-point scene color preserves those highlights through exact A-buffer OIT, weighted-blended OIT, or depth-sorted alpha blending before multiscale bloom and filmic tone mapping.</p>
+<p><strong>Rendering:</strong> reusable glass materials combine grazing-angle Fresnel reflection, GGX microfacet highlights, clearcoat, two internal shell bounces, moving scene reflections, wavelength-dependent volume absorption, thickness-aware frosted transmission, and angular thin-film interference. Emissive packet cores, directional trails, and switch flashes illuminate nearby glass through bounded point lights, colored in-volume scattering, and focused raster caustics. Fault-tinted switches add subtle animated lens distortion. Floating-point scene color preserves those highlights through exact A-buffer OIT, weighted-blended OIT, or depth-sorted alpha blending before multiscale bloom and filmic tone mapping.</p>
 <p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Supercomputer networking to accelerate large scale AI training</a></p>`;
 
 function makeGlassInstances(): GlassInstance[] {
@@ -4195,6 +4250,51 @@ function makeSettingsSchema(
             persist: 'none',
             min: 0.2,
             max: 2,
+            step: 0.05
+          },
+          {
+            name: 'glassRoughTransmissionStrength',
+            label: 'Frosted Transmission',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2,
+            step: 0.05
+          },
+          {
+            name: 'glassSpectralAbsorptionStrength',
+            label: 'Spectral Absorption',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2,
+            step: 0.05
+          },
+          {
+            name: 'glassThinFilmThickness',
+            label: 'Film Thickness (nm)',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 900,
+            step: 10
+          },
+          {
+            name: 'glassThinFilmStrength',
+            label: 'Thin-Film Interference',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1,
+            step: 0.02
+          },
+          {
+            name: 'glassVolumeScatteringStrength',
+            label: 'Volume Light Scattering',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1.5,
             step: 0.05
           },
           {

--- a/modules/experimental/src/materials/glass-transmission.ts
+++ b/modules/experimental/src/materials/glass-transmission.ts
@@ -22,6 +22,16 @@ export type GlassTransmissionProps = {
   environmentIntensity?: number;
   /** Multiplier applied to the measured front-to-back optical path. */
   thicknessStrength?: number;
+  /** Strength of thickness-aware multisample transmission blur. */
+  roughTransmissionStrength?: number;
+  /** Strength of wavelength-dependent absorption through the measured glass volume. */
+  spectralAbsorptionStrength?: number;
+  /** Thickness in nanometers of an optional thin-film surface coating. */
+  thinFilmThickness?: number;
+  /** Strength of angular spectral interference from the thin-film coating. */
+  thinFilmStrength?: number;
+  /** Strength of colored in-volume scattering around nearby optical point lights. */
+  volumeScatteringStrength?: number;
   /** Normalized-depth tolerance used to preserve foreground geometry. */
   depthBias?: number;
   /** Strength of nearby opaque-scene reflections sampled from captured scene color. */
@@ -40,6 +50,11 @@ export type GlassTransmissionUniforms = {
   depthRange: [number, number];
   environmentIntensity: number;
   thicknessStrength: number;
+  roughTransmissionStrength: number;
+  spectralAbsorptionStrength: number;
+  thinFilmThickness: number;
+  thinFilmStrength: number;
+  volumeScatteringStrength: number;
   depthBias: number;
   dynamicReflectionStrength: number;
   secondaryBounceStrength: number;
@@ -62,6 +77,11 @@ struct glassTransmissionUniforms {
   depthRange: vec2<f32>,
   environmentIntensity: f32,
   thicknessStrength: f32,
+  roughTransmissionStrength: f32,
+  spectralAbsorptionStrength: f32,
+  thinFilmThickness: f32,
+  thinFilmStrength: f32,
+  volumeScatteringStrength: f32,
   depthBias: f32,
   dynamicReflectionStrength: f32,
   secondaryBounceStrength: f32,
@@ -117,11 +137,109 @@ fn glassTransmission_sampleEnvironment(reflectionDirection: vec3<f32>) -> vec3<f
     environmentCoordinate - blurOffset,
     0.0
   ).rgb;
+  let baselineEnvironment = (centered + forward + backward) / 3.0;
+  if (glassTransmission.roughTransmissionStrength <= 0.0) {
+    return mix(
+      centered,
+      baselineEnvironment,
+      smoothstep(0.08, 0.7, glassMaterial.roughness)
+    ) * glassTransmission.environmentIntensity;
+  }
+  let crossOffset = vec2<f32>(-blurOffset.y, blurOffset.x);
+  let upper = textureSampleLevel(
+    glassEnvironmentTexture,
+    glassEnvironmentTextureSampler,
+    environmentCoordinate + crossOffset,
+    0.0
+  ).rgb;
+  let lower = textureSampleLevel(
+    glassEnvironmentTexture,
+    glassEnvironmentTextureSampler,
+    environmentCoordinate - crossOffset,
+    0.0
+  ).rgb;
+  let filteredEnvironment = mix(
+    baselineEnvironment,
+    (centered + forward + backward + upper + lower) / 5.0,
+    clamp(glassTransmission.roughTransmissionStrength, 0.0, 1.0)
+  );
   return mix(
     centered,
-    (centered + forward + backward) / 3.0,
+    filteredEnvironment,
     smoothstep(0.08, 0.7, glassMaterial.roughness)
   ) * glassTransmission.environmentIntensity;
+}
+
+fn glassTransmission_sampleRoughTransmission(
+  screenCoordinate: vec2<f32>,
+  refractionOffset: vec2<f32>,
+  dispersionOffset: vec2<f32>,
+  measuredThickness: f32
+) -> vec3<f32> {
+  let centered = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    refractionOffset,
+    dispersionOffset
+  );
+  let roughness = glassMaterial.roughness * glassTransmission.roughTransmissionStrength;
+  if (roughness <= 0.0001) {
+    return centered;
+  }
+  let pixelSize = vec2<f32>(1.0) / max(glassTransmission.viewportSize, vec2<f32>(1.0));
+  let blurOffset = pixelSize * roughness * (2.0 + measuredThickness * 11.0);
+  let horizontalOffset = vec2<f32>(blurOffset.x, 0.0);
+  let verticalOffset = vec2<f32>(0.0, blurOffset.y);
+  let positiveHorizontal = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    refractionOffset + horizontalOffset,
+    dispersionOffset
+  );
+  let negativeHorizontal = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    refractionOffset - horizontalOffset,
+    dispersionOffset
+  );
+  let positiveVertical = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    refractionOffset + verticalOffset,
+    dispersionOffset
+  );
+  let negativeVertical = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    refractionOffset - verticalOffset,
+    dispersionOffset
+  );
+  let filteredTransmission = (
+    centered * 2.0 + positiveHorizontal + negativeHorizontal + positiveVertical + negativeVertical
+  ) / 6.0;
+  return mix(centered, filteredTransmission, smoothstep(0.02, 0.42, roughness));
+}
+
+fn glassTransmission_getSpectralAbsorption(
+  baseColor: vec3<f32>,
+  measuredThickness: f32
+) -> vec3<f32> {
+  let baselineExtinction = vec3<f32>(0.1, 0.065, 0.032) + (1.0 - baseColor) * 0.22;
+  let spectralExtinction = (
+    vec3<f32>(0.11, 0.045, 0.022) * 0.35 +
+    (1.0 - baseColor) * vec3<f32>(0.46, 0.26, 0.15)
+  ) * glassTransmission.spectralAbsorptionStrength;
+  return exp(-(baselineExtinction + spectralExtinction) * measuredThickness);
+}
+
+fn glassTransmission_getThinFilm(viewAlignment: f32) -> vec3<f32> {
+  let refractiveIndex = max(glassMaterial.indexOfRefraction, 1.001);
+  let filmAlignment = sqrt(max(
+    1.0 - (1.0 - viewAlignment * viewAlignment) / (refractiveIndex * refractiveIndex),
+    0.02
+  ));
+  let wavelengths = vec3<f32>(650.0, 530.0, 460.0);
+  let phase = 12.56637061 * glassTransmission.thinFilmThickness *
+    refractiveIndex * filmAlignment / wavelengths;
+  let spectralInterference = 0.5 + 0.5 * cos(phase);
+  let filmPresence = select(0.0, 1.0, glassTransmission.thinFilmThickness > 0.0);
+  return spectralInterference * pow(1.0 - viewAlignment, 1.45) *
+    glassTransmission.thinFilmStrength * filmPresence * 0.18;
 }
 
 fn glassTransmission_getColor(
@@ -204,14 +322,13 @@ fn glassTransmission_getColor(
   let safeOffset = select(proposedOffset, vec2<f32>(0.0), foregroundOcclusion);
   let dispersionOffset = projectedNormal * glassMaterial.dispersion *
     measuredThickness * 0.3;
-  let transmittedColor = glassMaterial_sampleTransmission(
+  let transmittedColor = glassTransmission_sampleRoughTransmission(
     screenCoordinate,
     safeOffset,
-    dispersionOffset
+    dispersionOffset,
+    measuredThickness
   );
-  let absorption = exp(-(
-    vec3<f32>(0.1, 0.065, 0.032) + (1.0 - baseColor.rgb) * 0.22
-  ) * measuredThickness);
+  let absorption = glassTransmission_getSpectralAbsorption(baseColor.rgb, measuredThickness);
   let reflectionDirection = reflect(-viewDirection, frontNormal);
   let environmentReflection = glassTransmission_sampleEnvironment(reflectionDirection);
   let viewAlignment = clamp(dot(frontNormal, viewDirection), 0.0, 1.0);
@@ -222,6 +339,9 @@ fn glassTransmission_getColor(
   let secondaryDirection = reflect(reflect(entryDirection, -backNormal), frontNormal);
   let secondaryReflection = glassTransmission_sampleEnvironment(secondaryDirection) *
     glassTransmission.secondaryBounceStrength * pow(1.0 - viewAlignment, 1.45) * 0.24;
+  let thinFilmReflection = glassTransmission_getThinFilm(viewAlignment);
+  let volumeScattering = baseColor.rgb * (1.0 - exp(-measuredThickness * 1.3)) *
+    glassTransmission.volumeScatteringStrength * (0.045 + (1.0 - viewAlignment) * 0.09);
   let reflectionCoordinate = clamp(
     screenCoordinate + projectedNormal * (0.025 + measuredThickness * 0.018),
     vec2<f32>(0.001),
@@ -244,7 +364,7 @@ fn glassTransmission_getColor(
   let opticalColor = transmittedColor * absorption * glassMaterial.transmissionStrength +
     environmentReflection * (0.09 + fresnel * 0.65) +
     internalReflection * pow(1.0 - viewAlignment, 2.0) + secondaryReflection +
-    dynamicReflection + faultFilament;
+    thinFilmReflection + volumeScattering + dynamicReflection + faultFilament;
   return vec4<f32>(mix(surfaceColor.rgb, opticalColor, 0.64), surfaceColor.a);
 }
 
@@ -264,8 +384,11 @@ fn glassTransmission_getIlluminatedColor(
     fragmentPosition
   );
   let pointLightColor = opticalPointLights_getColor(normal, worldPosition, cameraPosition);
+  let volumeLightScattering = pointLightColor *
+    glassTransmission.volumeScatteringStrength * 0.24;
   return vec4<f32>(
-    transmittedColor.rgb + pointLightColor * glassMaterial.reflectionStrength,
+    transmittedColor.rgb + pointLightColor * glassMaterial.reflectionStrength +
+      volumeLightScattering,
     transmittedColor.a
   );
 }
@@ -278,6 +401,11 @@ layout(std140) uniform glassTransmissionUniforms {
   vec2 depthRange;
   float environmentIntensity;
   float thicknessStrength;
+  float roughTransmissionStrength;
+  float spectralAbsorptionStrength;
+  float thinFilmThickness;
+  float thinFilmStrength;
+  float volumeScatteringStrength;
   float depthBias;
   float dynamicReflectionStrength;
   float secondaryBounceStrength;
@@ -313,11 +441,96 @@ vec3 glassTransmission_sampleEnvironment(vec3 reflectionDirection) {
   vec3 centered = texture(glassEnvironmentTexture, environmentCoordinate).rgb;
   vec3 forward = texture(glassEnvironmentTexture, environmentCoordinate + blurOffset).rgb;
   vec3 backward = texture(glassEnvironmentTexture, environmentCoordinate - blurOffset).rgb;
+  vec3 baselineEnvironment = (centered + forward + backward) / 3.0;
+  if (glassTransmission.roughTransmissionStrength <= 0.0) {
+    return mix(
+      centered,
+      baselineEnvironment,
+      smoothstep(0.08, 0.7, glassMaterial.roughness)
+    ) * glassTransmission.environmentIntensity;
+  }
+  vec2 crossOffset = vec2(-blurOffset.y, blurOffset.x);
+  vec3 upper = texture(glassEnvironmentTexture, environmentCoordinate + crossOffset).rgb;
+  vec3 lower = texture(glassEnvironmentTexture, environmentCoordinate - crossOffset).rgb;
+  vec3 filteredEnvironment = mix(
+    baselineEnvironment,
+    (centered + forward + backward + upper + lower) / 5.0,
+    clamp(glassTransmission.roughTransmissionStrength, 0.0, 1.0)
+  );
   return mix(
     centered,
-    (centered + forward + backward) / 3.0,
+    filteredEnvironment,
     smoothstep(0.08, 0.7, glassMaterial.roughness)
   ) * glassTransmission.environmentIntensity;
+}
+
+vec3 glassTransmission_sampleRoughTransmission(
+  vec2 screenCoordinate,
+  vec2 refractionOffset,
+  vec2 dispersionOffset,
+  float measuredThickness
+) {
+  vec3 centered = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    refractionOffset,
+    dispersionOffset
+  );
+  float roughness = glassMaterial.roughness * glassTransmission.roughTransmissionStrength;
+  if (roughness <= 0.0001) {
+    return centered;
+  }
+  vec2 pixelSize = vec2(1.0) / max(glassTransmission.viewportSize, vec2(1.0));
+  vec2 blurOffset = pixelSize * roughness * (2.0 + measuredThickness * 11.0);
+  vec2 horizontalOffset = vec2(blurOffset.x, 0.0);
+  vec2 verticalOffset = vec2(0.0, blurOffset.y);
+  vec3 positiveHorizontal = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    refractionOffset + horizontalOffset,
+    dispersionOffset
+  );
+  vec3 negativeHorizontal = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    refractionOffset - horizontalOffset,
+    dispersionOffset
+  );
+  vec3 positiveVertical = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    refractionOffset + verticalOffset,
+    dispersionOffset
+  );
+  vec3 negativeVertical = glassMaterial_sampleTransmission(
+    screenCoordinate,
+    refractionOffset - verticalOffset,
+    dispersionOffset
+  );
+  vec3 filteredTransmission = (
+    centered * 2.0 + positiveHorizontal + negativeHorizontal + positiveVertical + negativeVertical
+  ) / 6.0;
+  return mix(centered, filteredTransmission, smoothstep(0.02, 0.42, roughness));
+}
+
+vec3 glassTransmission_getSpectralAbsorption(vec3 baseColor, float measuredThickness) {
+  vec3 baselineExtinction = vec3(0.1, 0.065, 0.032) + (1.0 - baseColor) * 0.22;
+  vec3 spectralExtinction = (
+    vec3(0.11, 0.045, 0.022) * 0.35 +
+    (1.0 - baseColor) * vec3(0.46, 0.26, 0.15)
+  ) * glassTransmission.spectralAbsorptionStrength;
+  return exp(-(baselineExtinction + spectralExtinction) * measuredThickness);
+}
+
+vec3 glassTransmission_getThinFilm(float viewAlignment) {
+  float refractiveIndex = max(glassMaterial.indexOfRefraction, 1.001);
+  float filmAlignment = sqrt(max(
+    1.0 - (1.0 - viewAlignment * viewAlignment) / (refractiveIndex * refractiveIndex),
+    0.02
+  ));
+  vec3 wavelengths = vec3(650.0, 530.0, 460.0);
+  vec3 phase = 12.56637061 * glassTransmission.thinFilmThickness *
+    refractiveIndex * filmAlignment / wavelengths;
+  vec3 spectralInterference = 0.5 + 0.5 * cos(phase);
+  float filmPresence = glassTransmission.thinFilmThickness > 0.0 ? 1.0 : 0.0;
+  return spectralInterference * pow(1.0 - viewAlignment, 1.45) *
+    glassTransmission.thinFilmStrength * filmPresence * 0.18;
 }
 
 vec4 glassTransmission_getColor(
@@ -398,14 +611,13 @@ vec4 glassTransmission_getColor(
   vec2 safeOffset = foregroundOcclusion ? vec2(0.0) : proposedOffset;
   vec2 dispersionOffset = projectedNormal * glassMaterial.dispersion *
     measuredThickness * 0.3;
-  vec3 transmittedColor = glassMaterial_sampleTransmission(
+  vec3 transmittedColor = glassTransmission_sampleRoughTransmission(
     screenCoordinate,
     safeOffset,
-    dispersionOffset
+    dispersionOffset,
+    measuredThickness
   );
-  vec3 absorption = exp(-(
-    vec3(0.1, 0.065, 0.032) + (1.0 - baseColor.rgb) * 0.22
-  ) * measuredThickness);
+  vec3 absorption = glassTransmission_getSpectralAbsorption(baseColor.rgb, measuredThickness);
   vec3 reflectionDirection = reflect(-viewDirection, frontNormal);
   vec3 environmentReflection = glassTransmission_sampleEnvironment(reflectionDirection);
   float viewAlignment = clamp(dot(frontNormal, viewDirection), 0.0, 1.0);
@@ -416,6 +628,9 @@ vec4 glassTransmission_getColor(
   vec3 secondaryDirection = reflect(reflect(entryDirection, -backNormal), frontNormal);
   vec3 secondaryReflection = glassTransmission_sampleEnvironment(secondaryDirection) *
     glassTransmission.secondaryBounceStrength * pow(1.0 - viewAlignment, 1.45) * 0.24;
+  vec3 thinFilmReflection = glassTransmission_getThinFilm(viewAlignment);
+  vec3 volumeScattering = baseColor.rgb * (1.0 - exp(-measuredThickness * 1.3)) *
+    glassTransmission.volumeScatteringStrength * (0.045 + (1.0 - viewAlignment) * 0.09);
   vec2 reflectionCoordinate = clamp(
     screenCoordinate + projectedNormal * (0.025 + measuredThickness * 0.018),
     vec2(0.001),
@@ -433,7 +648,7 @@ vec4 glassTransmission_getColor(
   vec3 opticalColor = transmittedColor * absorption * glassMaterial.transmissionStrength +
     environmentReflection * (0.09 + fresnel * 0.65) +
     internalReflection * pow(1.0 - viewAlignment, 2.0) + secondaryReflection +
-    dynamicReflection + faultFilament;
+    thinFilmReflection + volumeScattering + dynamicReflection + faultFilament;
   return vec4(mix(surfaceColor.rgb, opticalColor, 0.64), surfaceColor.a);
 }
 
@@ -453,8 +668,11 @@ vec4 glassTransmission_getIlluminatedColor(
     fragmentPosition
   );
   vec3 pointLightColor = opticalPointLights_getColor(normal, worldPosition, cameraPosition);
+  vec3 volumeLightScattering = pointLightColor *
+    glassTransmission.volumeScatteringStrength * 0.24;
   return vec4(
-    transmittedColor.rgb + pointLightColor * glassMaterial.reflectionStrength,
+    transmittedColor.rgb + pointLightColor * glassMaterial.reflectionStrength +
+      volumeLightScattering,
     transmittedColor.a
   );
 }
@@ -470,6 +688,14 @@ function getGlassTransmissionUniforms(
     depthRange: props.depthRange ?? previousUniforms?.depthRange ?? [0.1, 100],
     environmentIntensity: props.environmentIntensity ?? previousUniforms?.environmentIntensity ?? 1,
     thicknessStrength: props.thicknessStrength ?? previousUniforms?.thicknessStrength ?? 1,
+    roughTransmissionStrength:
+      props.roughTransmissionStrength ?? previousUniforms?.roughTransmissionStrength ?? 0,
+    spectralAbsorptionStrength:
+      props.spectralAbsorptionStrength ?? previousUniforms?.spectralAbsorptionStrength ?? 0,
+    thinFilmThickness: props.thinFilmThickness ?? previousUniforms?.thinFilmThickness ?? 0,
+    thinFilmStrength: props.thinFilmStrength ?? previousUniforms?.thinFilmStrength ?? 0,
+    volumeScatteringStrength:
+      props.volumeScatteringStrength ?? previousUniforms?.volumeScatteringStrength ?? 0,
     depthBias: props.depthBias ?? previousUniforms?.depthBias ?? 0.00008,
     dynamicReflectionStrength:
       props.dynamicReflectionStrength ?? previousUniforms?.dynamicReflectionStrength ?? 0,
@@ -502,6 +728,11 @@ export const glassTransmission = {
     depthRange: 'vec2<f32>',
     environmentIntensity: 'f32',
     thicknessStrength: 'f32',
+    roughTransmissionStrength: 'f32',
+    spectralAbsorptionStrength: 'f32',
+    thinFilmThickness: 'f32',
+    thinFilmStrength: 'f32',
+    volumeScatteringStrength: 'f32',
     depthBias: 'f32',
     dynamicReflectionStrength: 'f32',
     secondaryBounceStrength: 'f32',
@@ -513,6 +744,11 @@ export const glassTransmission = {
     depthRange: [0.1, 100],
     environmentIntensity: 1,
     thicknessStrength: 1,
+    roughTransmissionStrength: 0,
+    spectralAbsorptionStrength: 0,
+    thinFilmThickness: 0,
+    thinFilmStrength: 0,
+    volumeScatteringStrength: 0,
     depthBias: 0.00008,
     dynamicReflectionStrength: 0,
     secondaryBounceStrength: 0,

--- a/modules/experimental/test/materials/optical-materials.node.spec.ts
+++ b/modules/experimental/test/materials/optical-materials.node.spec.ts
@@ -321,6 +321,11 @@ test('optical materials retain defaults while applying partial updates', testCas
       depthRange: [0.1, 100],
       environmentIntensity: 1,
       thicknessStrength: 1,
+      roughTransmissionStrength: 0,
+      spectralAbsorptionStrength: 0,
+      thinFilmThickness: 0,
+      thinFilmStrength: 0,
+      volumeScatteringStrength: 0,
       depthBias: 0.00008,
       dynamicReflectionStrength: 0,
       secondaryBounceStrength: 0,
@@ -358,6 +363,11 @@ test('optical materials retain defaults while applying partial updates', testCas
       dynamicReflectionStrength: 0.45,
       secondaryBounceStrength: 0.7,
       faultDistortionStrength: 0.3,
+      roughTransmissionStrength: 0.85,
+      spectralAbsorptionStrength: 0.42,
+      thinFilmThickness: 420,
+      thinFilmStrength: 0.22,
+      volumeScatteringStrength: 0.38,
       time: 2.5
     },
     updatedTransmissionUniforms
@@ -377,7 +387,56 @@ test('optical materials retain defaults while applying partial updates', testCas
     0.3,
     'fault-driven lens distortion is configurable'
   );
+  testCase.equal(
+    animatedTransmissionUniforms.roughTransmissionStrength,
+    0.85,
+    'thickness-aware rough transmission is configurable'
+  );
+  testCase.equal(
+    animatedTransmissionUniforms.spectralAbsorptionStrength,
+    0.42,
+    'wavelength-dependent volume absorption is configurable'
+  );
+  testCase.equal(
+    animatedTransmissionUniforms.thinFilmThickness,
+    420,
+    'thin-film coating thickness is configured in nanometers'
+  );
+  testCase.equal(
+    animatedTransmissionUniforms.thinFilmStrength,
+    0.22,
+    'angular thin-film interference is configurable'
+  );
+  testCase.equal(
+    animatedTransmissionUniforms.volumeScatteringStrength,
+    0.38,
+    'localized optical volume scattering is configurable'
+  );
   testCase.equal(animatedTransmissionUniforms.time, 2.5, 'fault animation accepts a scene clock');
+  const retainedOpticalUniforms = glassTransmission.getUniforms(
+    {environmentIntensity: 1.8},
+    animatedTransmissionUniforms
+  );
+  testCase.equal(
+    retainedOpticalUniforms.roughTransmissionStrength,
+    0.85,
+    'partial updates preserve rough transmission'
+  );
+  testCase.equal(
+    retainedOpticalUniforms.spectralAbsorptionStrength,
+    0.42,
+    'partial updates preserve spectral volume absorption'
+  );
+  testCase.equal(
+    retainedOpticalUniforms.thinFilmThickness,
+    420,
+    'partial updates preserve the coating thickness'
+  );
+  testCase.equal(
+    retainedOpticalUniforms.volumeScatteringStrength,
+    0.38,
+    'partial updates preserve optical volume scattering'
+  );
 
   const initialReflectiveUniforms = reflectiveMaterial.getUniforms({});
   testCase.deepEqual(
@@ -552,6 +611,36 @@ test('rasterized glass transmission composes thickness, depth, and environment m
       shaderSource,
       /faultRipple/,
       `${language} confines animated distortion to warm fault-colored glass`
+    );
+    testCase.match(
+      shaderSource,
+      /glassTransmission_sampleRoughTransmission/,
+      `${language} filters transmission using optical thickness and surface roughness`
+    );
+    testCase.match(
+      shaderSource,
+      /glassTransmission_getSpectralAbsorption/,
+      `${language} applies wavelength-dependent volume absorption`
+    );
+    testCase.match(
+      shaderSource,
+      /glassTransmission_getThinFilm/,
+      `${language} computes angular thin-film interference`
+    );
+    testCase.match(
+      shaderSource,
+      /650\.0, 530\.0, 460\.0/,
+      `${language} evaluates representative red, green, and blue wavelengths`
+    );
+    testCase.match(
+      shaderSource,
+      /volumeLightScattering/,
+      `${language} scatters nearby colored lights inside the glass volume`
+    );
+    testCase.match(
+      shaderSource,
+      /filteredEnvironment/,
+      `${language} filters environment reflections for rough optical surfaces`
     );
   }
   testCase.end();


### PR DESCRIPTION
## Goals

- Advance the composable glass-effects roadmap without introducing ray tracing or breaking existing optical material consumers.
- Make the network packet-spraying showcase visibly richer on both hardware WebGPU and WebGL.

## Changes

- Document a staged optical roadmap covering existing portable raster optics, the next raster-lighting techniques, and explicitly deferred physically traced effects.
- Extend `glassTransmission` with five opt-in, backward-compatible material controls: thickness-aware rough transmission, wavelength-dependent Beer-Lambert absorption, nanometer-scale thin-film coating thickness and interference, and localized volume scattering.
- Implement matching WGSL and GLSL helpers with bounded texture taps, filtered environment reflections, measured optical thickness, representative red/green/blue wavelengths, and packet-driven interior lighting.
- Preserve existing appearance and sampling costs when the new optional controls remain disabled.
- Enable restrained spectral-volume defaults and interactive controls in **Effects: Glass - Network Packet Spraying**.
- Expand shader-composition, default-uniform, partial-update, and cross-language optical coverage.

## Verification

- `yarn lint fix`: passed, including the normal pre-commit lint checks.
- `yarn build`: passed after final source changes.
- `yarn test-node`: passed, **206 tests**; the pre-commit hook independently reran the complete Node suite successfully.
- `yarn test-node modules/experimental/test/materials/optical-materials.node.spec.ts`: passed, **12 focused optical tests**.
- `yarn workspace luma.gl-examples-showcase-packet-spraying build`: passed.
- `yarn workspace website-docusaurus check`: passed; **all 480 MDX files compile**.
- Live browser verification: hardware Apple Metal WebGPU and WebGL both render the updated scene with no shader or application console errors.
- `yarn test`: attempted; the full browser phase reproduces unrelated existing Arrow polygon binding failures and widespread GPU-contention timeouts outside this change.
- `yarn website:build`: attempted; the server bundle compiled, but the exceptionally resource-intensive client build was stopped after saturating the workstation.
- `yarn workspace website-docusaurus lint`: exposes existing unrelated TypeScript errors in other examples and website components; the changed packet-spraying example builds cleanly on its own.
- `nvm use` and `yarn install`: not rerun; the existing Node 22 workspace and installed dependencies were reused.
- `(cd website && yarn build)`: not run separately because it invokes the same Docusaurus production build as `yarn website:build`.

## Risks and Follow-up

- Rough transmission performs four additional chromatic scene samples and two additional environment taps only when explicitly enabled.
- Future roadmap items remain separately scoped: temporal rough transmission, filtered reflection probes, improved screen-space reflections, and optional physically traced effects.