### PR TITLE
feat(showcase): add cinematic backbone path inspection

### DIFF
--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -237,10 +237,13 @@ an individual showcase.
 - Bounded colored point lights, in-volume scattering, screen-space scene reflections, secondary
   environment bounces, and focused raster caustics connect moving emitters to nearby glass.
 - Linked switch-plane telemetry gradually emphasizes all eight switches across both tiers of each
-  physical plane, distinguishes four independent spine paths, and links to a GPU-optics panel.
+  physical plane, while four independently inspectable backbone paths reveal both conversations'
+  complete server-to-server routes with smoothly isolated switches, links, and packet wakes.
 - A single guided-story visual-style control progressively introduces surface highlights,
   refraction, packet lighting, motion accents, spectral glass, caustics, and bloom while keeping
   advanced material settings independently adjustable.
+- A duration-weighted, directly navigable chapter timeline ties cinematic camera transitions to
+  congestion, packet loss, rerouting, and probe-confirmed path recovery.
 - Exact A-buffer transparency, weighted-blended transparency, and depth-sorted alpha blending
   preserve the strongest supported compositing strategy on each backend.
 

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -112,6 +112,7 @@ import {
   makeLinks,
   makePackets,
   makeNetworkPlaneTelemetry,
+  makeNetworkPathFocus,
   makeNetworkSwitchPlaneTelemetry,
   makePickableNetworkNodes,
   makeSwitchPacketEvents,
@@ -127,6 +128,7 @@ import {
   type NetworkEndpointSignal,
   type NetworkPlaneTelemetry,
   type NetworkPacketEvent,
+  type NetworkPathFocus,
   type NetworkScenario,
   type NetworkSwitchTransitionWave,
   type NetworkSwitchGroupId,
@@ -138,6 +140,7 @@ import {
 import {
   DEFAULT_NETWORK_OPTICS_LEVEL,
   getNetworkStoryChapter,
+  getNetworkStoryProgress,
   getWrappedStoryChapterIndex,
   GUIDED_STORY_SWITCH_INDEX,
   makeNetworkOpticsProfile,
@@ -1013,6 +1016,16 @@ class NetworkStoryControls {
     row: HTMLButtonElement;
     status: HTMLSpanElement;
   }[];
+  private readonly pathIndicators: {
+    greenBar: HTMLDivElement;
+    redBar: HTMLDivElement;
+    row: HTMLButtonElement;
+    status: HTMLSpanElement;
+  }[];
+  private readonly chapterSegments: {
+    button: HTMLButtonElement;
+    fill: HTMLDivElement;
+  }[];
   private readonly chapterPositionElement: HTMLSpanElement;
   private readonly opticsButton: HTMLButtonElement;
   private readonly playbackButton: HTMLButtonElement;
@@ -1025,16 +1038,20 @@ class NetworkStoryControls {
     {
       onNext,
       onPrevious,
+      onSelectChapter,
       onTogglePlayback,
       onHighlightPlane,
+      onHighlightPath,
       onToggleOptics,
       onVisualIntensityChange,
       visualIntensity
     }: {
       onNext: () => void;
       onPrevious: () => void;
+      onSelectChapter: (chapterIndex: number) => void;
       onTogglePlayback: () => void;
       onHighlightPlane: (planeIndex: number | null) => void;
+      onHighlightPath: (pathIndex: number | null) => void;
       onToggleOptics: () => void;
       onVisualIntensityChange: (level: number) => void;
       visualIntensity: number;
@@ -1080,6 +1097,56 @@ class NetworkStoryControls {
     Object.assign(this.descriptionElement.style, {
       margin: '6px 0 12px',
       color: '#bcc9dc'
+    });
+
+    const chapterTimeline = document.createElement('div');
+    chapterTimeline.setAttribute('role', 'group');
+    chapterTimeline.setAttribute('aria-label', 'Guided network story chapters');
+    Object.assign(chapterTimeline.style, {
+      display: 'flex',
+      gap: '4px',
+      height: '12px',
+      margin: '0 0 11px'
+    });
+    this.chapterSegments = NETWORK_STORY_CHAPTERS.map((chapter, chapterIndex) => {
+      const segmentButton = document.createElement('button');
+      segmentButton.type = 'button';
+      segmentButton.title = chapter.title;
+      segmentButton.dataset.networkStorySegment = chapter.id;
+      segmentButton.setAttribute(
+        'aria-label',
+        `Go to chapter ${chapterIndex + 1}: ${chapter.title}`
+      );
+      Object.assign(segmentButton.style, {
+        position: 'relative',
+        flex: String(chapter.duration),
+        height: '12px',
+        padding: '4px 0',
+        border: '0',
+        background: 'transparent',
+        cursor: 'pointer'
+      });
+
+      const track = document.createElement('div');
+      Object.assign(track.style, {
+        height: '4px',
+        overflow: 'hidden',
+        borderRadius: '2px',
+        background: 'rgba(113, 136, 171, 0.3)'
+      });
+      const fill = document.createElement('div');
+      Object.assign(fill.style, {
+        width: '0%',
+        height: '100%',
+        borderRadius: '2px',
+        background: '#86b6ff',
+        transition: 'width 100ms linear, background 200ms ease'
+      });
+      track.appendChild(fill);
+      segmentButton.appendChild(track);
+      segmentButton.addEventListener('click', () => onSelectChapter(chapterIndex));
+      chapterTimeline.appendChild(segmentButton);
+      return {button: segmentButton, fill};
     });
 
     const telemetryElement = document.createElement('div');
@@ -1165,6 +1232,73 @@ class NetworkStoryControls {
       return {greenBar, redBar, row: rowElement, status};
     });
 
+    const pathHeading = document.createElement('div');
+    pathHeading.textContent = 'BACKBONE PATHS';
+    Object.assign(pathHeading.style, {
+      margin: '9px 0 4px',
+      color: '#91a6c3',
+      fontSize: '10px'
+    });
+    telemetryElement.appendChild(pathHeading);
+
+    this.pathIndicators = SPINE_POSITIONS.map((_, pathIndex) => {
+      const rowElement = document.createElement('button');
+      rowElement.type = 'button';
+      rowElement.dataset.networkPath = String(pathIndex + 1);
+      rowElement.setAttribute('aria-label', `Inspect complete backbone path ${pathIndex + 1}`);
+      rowElement.setAttribute('aria-pressed', 'false');
+      Object.assign(rowElement.style, {
+        display: 'grid',
+        gridTemplateColumns: '42px minmax(0, 1fr) 56px',
+        alignItems: 'center',
+        gap: '7px',
+        width: 'calc(100% + 8px)',
+        height: '19px',
+        padding: '0 4px',
+        margin: '0 -4px',
+        border: '1px solid transparent',
+        borderRadius: '4px',
+        background: 'transparent',
+        cursor: 'pointer',
+        transition: 'background 220ms ease, border-color 220ms ease'
+      });
+      rowElement.addEventListener('pointerenter', () => onHighlightPath(pathIndex));
+      rowElement.addEventListener('pointermove', () => onHighlightPath(pathIndex));
+      rowElement.addEventListener('pointerleave', () => onHighlightPath(null));
+      rowElement.addEventListener('focus', () => onHighlightPath(pathIndex));
+      rowElement.addEventListener('blur', () => onHighlightPath(null));
+
+      const label = document.createElement('span');
+      label.textContent = `Path ${pathIndex + 1}`;
+      Object.assign(label.style, {color: '#becce0', fontSize: '10px'});
+      const track = document.createElement('div');
+      Object.assign(track.style, {
+        display: 'flex',
+        height: '4px',
+        overflow: 'hidden',
+        borderRadius: '2px',
+        background: 'rgba(93, 113, 146, 0.3)'
+      });
+      const redBar = document.createElement('div');
+      const greenBar = document.createElement('div');
+      Object.assign(redBar.style, {
+        height: '100%',
+        background: '#ff504d',
+        transition: 'width 260ms ease'
+      });
+      Object.assign(greenBar.style, {
+        height: '100%',
+        background: '#34db87',
+        transition: 'width 260ms ease'
+      });
+      track.append(redBar, greenBar);
+      const status = document.createElement('span');
+      Object.assign(status.style, {textAlign: 'right', fontSize: '9px'});
+      rowElement.append(label, track, status);
+      telemetryElement.appendChild(rowElement);
+      return {greenBar, redBar, row: rowElement, status};
+    });
+
     const visualIntensityElement = document.createElement('div');
     Object.assign(visualIntensityElement.style, {
       margin: '0 0 13px',
@@ -1239,6 +1373,7 @@ class NetworkStoryControls {
       headingElement,
       this.titleElement,
       this.descriptionElement,
+      chapterTimeline,
       telemetryElement,
       visualIntensityElement,
       actionsElement
@@ -1257,6 +1392,24 @@ class NetworkStoryControls {
     );
     this.rootElement.dataset.networkStoryChapter = chapter.id;
     this.rootElement.dataset.networkStoryPlaying = String(isPlaying);
+    for (const [segmentIndex, segment] of this.chapterSegments.entries()) {
+      segment.button.setAttribute('aria-current', segmentIndex === chapterIndex ? 'step' : 'false');
+    }
+  }
+
+  updateProgress(chapterIndex: number, elapsedTime: number): void {
+    const progress = getNetworkStoryProgress(chapterIndex, elapsedTime);
+    for (const [segmentIndex, segment] of this.chapterSegments.entries()) {
+      const fill =
+        segmentIndex < chapterIndex
+          ? 1
+          : segmentIndex === chapterIndex
+            ? Math.max(progress.chapterProgress, 0.08)
+            : 0;
+      segment.fill.style.width = `${fill * 100}%`;
+      segment.fill.style.background = segmentIndex === chapterIndex ? '#a3c7ff' : '#638cc5';
+    }
+    this.rootElement.dataset.networkStoryProgress = progress.overallProgress.toFixed(3);
   }
 
   updateTelemetry(
@@ -1278,6 +1431,10 @@ class NetworkStoryControls {
     ).length;
     const maximumPlaneLoad = Math.max(
       ...planes.map(plane => plane.redPacketCount + plane.greenPacketCount),
+      1
+    );
+    const maximumPathLoad = Math.max(
+      ...spinePaths.map(path => path.redPacketCount + path.greenPacketCount),
       1
     );
     this.fabricStatusElement.textContent = `${availablePlaneCount} / ${planes.length} · ${availablePathCount} / ${spinePaths.length} PATHS`;
@@ -1304,6 +1461,28 @@ class NetworkStoryControls {
               : '#ff7065';
     }
 
+    for (const path of spinePaths) {
+      const indicator = this.pathIndicators[path.planeIndex];
+      indicator.redBar.style.width = `${(path.redPacketCount / maximumPathLoad) * 100}%`;
+      indicator.greenBar.style.width = `${(path.greenPacketCount / maximumPathLoad) * 100}%`;
+      indicator.status.textContent =
+        path.status === 'healthy'
+          ? 'ONLINE'
+          : path.status === 'congested'
+            ? 'PRESSURE'
+            : path.status === 'recovering'
+              ? 'PROBING'
+              : 'OFFLINE';
+      indicator.status.style.color =
+        path.status === 'healthy'
+          ? '#8ba6c7'
+          : path.status === 'congested'
+            ? '#ffac59'
+            : path.status === 'recovering'
+              ? '#72d4ff'
+              : '#ff7065';
+    }
+
     this.rootElement.dataset.networkPlaneStates = planes.map(plane => plane.status).join(',');
   }
 
@@ -1315,6 +1494,18 @@ class NetworkStoryControls {
       const highlighted = indicatorIndex === planeIndex;
       indicator.row.style.background = highlighted ? 'rgba(97, 145, 216, 0.13)' : 'transparent';
       indicator.row.style.borderColor = highlighted ? 'rgba(137, 184, 255, 0.34)' : 'transparent';
+      indicator.row.setAttribute('aria-pressed', String(highlighted));
+    }
+  }
+
+  setHighlightedPath(pathIndex: number | null): void {
+    this.rootElement.dataset.networkHighlightedPath =
+      pathIndex === null ? '' : String(pathIndex + 1);
+
+    for (const [indicatorIndex, indicator] of this.pathIndicators.entries()) {
+      const highlighted = indicatorIndex === pathIndex;
+      indicator.row.style.background = highlighted ? 'rgba(86, 171, 199, 0.15)' : 'transparent';
+      indicator.row.style.borderColor = highlighted ? 'rgba(112, 211, 230, 0.36)' : 'transparent';
       indicator.row.setAttribute('aria-pressed', String(highlighted));
     }
   }
@@ -1454,6 +1645,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly failedSwitchIndices = new Set<number>();
   readonly recoveringSwitchIndices = new Set<number>();
   readonly conversationRoutes: ConversationRoute[];
+  readonly pathFocuses: NetworkPathFocus[];
   readonly networkLinks: NetworkLink[];
   readonly linkColors: Float32Array;
   readonly redLinkTrafficStrengths: Float32Array;
@@ -1519,6 +1711,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly storyPacketColors = new Float32Array(MAX_STORY_PACKET_INSTANCES * 4);
   readonly networkPacketEvents: NetworkPacketEvent[] = [];
   readonly planeHighlightStrengths = new Float32Array(NETWORK_SWITCH_PLANE_COUNT);
+  readonly pathHighlightStrengths = new Float32Array(SPINE_POSITIONS.length);
   private readonly switchPlaneIndices = new Map<number, number>(
     Array.from({length: NETWORK_SWITCH_PLANE_COUNT}, (_, planeIndex) => planeIndex).flatMap(
       planeIndex =>
@@ -1556,6 +1749,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private guidedStoryCameraTransitionEndsAt = 0;
   private guidedStoryPreviousCameraTime: number | null = null;
   private highlightedPlaneIndex: number | null = null;
+  private highlightedPathIndex: number | null = null;
   private previousPlaneHighlightTime: number | null = null;
   private previousVisualIntensityTime: number | null = null;
   private currentVisualIntensity = DEFAULT_NETWORK_OPTICS_LEVEL;
@@ -1658,6 +1852,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     });
 
     this.conversationRoutes = makeConversationRoutes();
+    this.pathFocuses = SPINE_POSITIONS.map((_, pathIndex) =>
+      makeNetworkPathFocus(this.conversationRoutes, pathIndex)
+    ).filter((focus): focus is NetworkPathFocus => focus !== null);
     this.networkLinks = makeLinks(this.conversationRoutes);
     this.linkColors = flattenColors(this.networkLinks.map(({color}) => color));
     this.redLinkTrafficStrengths = new Float32Array(this.networkLinks.length);
@@ -1959,16 +2156,22 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.storyControls = new NetworkStoryControls(canvas, {
         onNext: () => this.moveGuidedStoryChapter(1),
         onPrevious: () => this.moveGuidedStoryChapter(-1),
+        onSelectChapter: chapterIndex => this.selectGuidedStoryChapter(chapterIndex),
         onTogglePlayback: () => this.setGuidedStoryPlaying(!this.guidedStoryPlaying),
         onHighlightPlane: planeIndex => this.setHighlightedPlane(planeIndex),
+        onHighlightPath: pathIndex => this.setHighlightedPath(pathIndex),
         onToggleOptics: () =>
           this.setOpticsPanelVisible(this.canvas?.dataset.packetSprayingOpticsExpanded !== 'true'),
         onVisualIntensityChange: level => this.setVisualIntensity(level),
         visualIntensity: this.visualIntensity
       });
       canvas.dataset.packetSprayingHighlightedPlane = '';
+      canvas.dataset.packetSprayingHighlightedPath = '';
       canvas.dataset.packetSprayingPlaneHighlightStrength = '0.000';
+      canvas.dataset.packetSprayingPathHighlightStrength = '0.000';
       canvas.dataset.packetSprayingHighlightedSwitches = '0';
+      canvas.dataset.packetSprayingHighlightedPathSwitches = '0';
+      canvas.dataset.packetSprayingHighlightedPathLinks = '0';
       canvas.dataset.packetSprayingOpticsExpanded = 'false';
       canvas.dataset.packetSprayingVisualIntensity = this.visualIntensity.toFixed(2);
       canvas.dataset.packetSprayingVisualTarget = this.visualIntensity.toFixed(2);
@@ -2368,6 +2571,18 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
           objectIndex === null || objectIndex === undefined
             ? undefined
             : this.getPickableNode(objectIndex);
+        if (pickRequest.action === 'hover') {
+          const spineIndex =
+            objectIndex === null || objectIndex === undefined
+              ? -1
+              : objectIndex -
+                HOST_POSITIONS.length -
+                LEAF_POSITIONS.length -
+                AGGREGATION_POSITIONS.length;
+          this.setHighlightedPath(
+            spineIndex >= 0 && spineIndex < SPINE_POSITIONS.length ? spineIndex : null
+          );
+        }
         if (node) {
           this.nodePopup?.show(node, pickRequest.clientPosition);
           if (this.canvas) {
@@ -2431,6 +2646,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.pendingPickRequest = null;
     this.pickingManager.clearPickState();
     this.nodePopup?.hide();
+    this.setHighlightedPath(null);
   };
 
   private setGuidedStoryPlaying(isPlaying: boolean): void {
@@ -2459,6 +2675,11 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private moveGuidedStoryChapter(direction: number): void {
     this.guidedStoryStarted = true;
     this.enterGuidedStoryChapter(this.guidedStoryChapterIndex + direction);
+  }
+
+  private selectGuidedStoryChapter(chapterIndex: number): void {
+    this.guidedStoryStarted = true;
+    this.enterGuidedStoryChapter(chapterIndex);
   }
 
   private enterGuidedStoryChapter(chapterIndex: number): void {
@@ -2555,6 +2776,17 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       }
     }
 
+    const chapterElapsedTime = this.guidedStoryPlaying
+      ? animationTime - this.guidedStoryChapterStartedAt
+      : this.guidedStoryElapsedAtPause;
+    this.storyControls?.updateProgress(this.guidedStoryChapterIndex, chapterElapsedTime);
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingStoryProgress = getNetworkStoryProgress(
+        this.guidedStoryChapterIndex,
+        chapterElapsedTime
+      ).overallProgress.toFixed(3);
+    }
+
     if (
       !this.guidedStoryCamera ||
       !this.orbitControls ||
@@ -2589,6 +2821,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private updateGuidedStoryControls(): void {
     const chapter = getNetworkStoryChapter(this.guidedStoryChapterIndex);
     this.storyControls?.update(chapter, this.guidedStoryChapterIndex, this.guidedStoryPlaying);
+    this.storyControls?.updateProgress(
+      this.guidedStoryChapterIndex,
+      this.guidedStoryElapsedAtPause
+    );
     if (this.canvas) {
       this.canvas.dataset.packetSprayingStoryChapter = chapter.id;
       this.canvas.dataset.packetSprayingStoryPlaying = String(this.guidedStoryPlaying);
@@ -2648,6 +2884,19 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     if (this.canvas) {
       this.canvas.dataset.packetSprayingHighlightedPlane =
         planeIndex === null ? '' : String(planeIndex + 1);
+    }
+  }
+
+  private setHighlightedPath(pathIndex: number | null): void {
+    if (this.highlightedPathIndex === pathIndex) {
+      return;
+    }
+
+    this.highlightedPathIndex = pathIndex;
+    this.storyControls?.setHighlightedPath(pathIndex);
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingHighlightedPath =
+        pathIndex === null ? '' : String(pathIndex + 1);
     }
   }
 
@@ -2891,19 +3140,41 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
   private getHighlightedSwitchColor(color: Color, switchIndex: number): Color {
     const planeIndex = this.switchPlaneIndices.get(switchIndex);
-    const highlightStrength =
-      planeIndex === undefined ? 0 : this.planeHighlightStrengths[planeIndex];
+    const planeStrength = planeIndex === undefined ? 0 : this.planeHighlightStrengths[planeIndex];
+    const pathStrength = this.getPathSwitchHighlightStrength(switchIndex);
+    const highlightStrength = Math.max(planeStrength, pathStrength);
 
     if (highlightStrength < 0.001) {
       return color;
     }
 
+    const blueStrength = planeStrength * (1 - pathStrength);
     return [
-      color[0] + (0.8 - color[0]) * highlightStrength * 0.56,
-      color[1] + (0.92 - color[1]) * highlightStrength * 0.56,
-      color[2] + (1.15 - color[2]) * highlightStrength * 0.56,
-      Math.min(color[3] + highlightStrength * 0.055, 0.68)
+      color[0] + (0.8 - color[0]) * blueStrength * 0.56 + pathStrength * 0.08,
+      color[1] + (0.92 - color[1]) * blueStrength * 0.56 + pathStrength * 0.24,
+      color[2] + (1.15 - color[2]) * blueStrength * 0.56 + pathStrength * 0.31,
+      Math.min(color[3] + highlightStrength * 0.065, 0.68)
     ];
+  }
+
+  private getPathSwitchHighlightStrength(switchIndex: number): number {
+    let maximumStrength = 0;
+    for (const [pathIndex, focus] of this.pathFocuses.entries()) {
+      if (focus.switchIndices.has(switchIndex)) {
+        maximumStrength = Math.max(maximumStrength, this.pathHighlightStrengths[pathIndex]);
+      }
+    }
+    return maximumStrength;
+  }
+
+  private getPathLinkHighlightStrength(linkKey: string): number {
+    let maximumStrength = 0;
+    for (const [pathIndex, focus] of this.pathFocuses.entries()) {
+      if (focus.linkKeys.has(linkKey)) {
+        maximumStrength = Math.max(maximumStrength, this.pathHighlightStrengths[pathIndex]);
+      }
+    }
+    return maximumStrength;
   }
 
   private updatePlaneHighlight(animationTime: number): void {
@@ -2933,15 +3204,37 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       }
     }
 
+    for (let pathIndex = 0; pathIndex < this.pathHighlightStrengths.length; pathIndex++) {
+      const targetStrength = this.highlightedPathIndex === pathIndex ? 1 : 0;
+      const currentStrength = this.pathHighlightStrengths[pathIndex];
+      const responseRate =
+        targetStrength > currentStrength
+          ? NETWORK_PLANE_HIGHLIGHT_ATTACK
+          : NETWORK_PLANE_HIGHLIGHT_DECAY;
+      const nextStrength =
+        currentStrength +
+        (targetStrength - currentStrength) * (1 - Math.exp(-elapsedTime * responseRate));
+      const settledStrength =
+        Math.abs(nextStrength - targetStrength) < 0.001 ? targetStrength : nextStrength;
+
+      if (Math.abs(settledStrength - currentStrength) > 0.0001) {
+        this.pathHighlightStrengths[pathIndex] = settledStrength;
+        requiresColorUpdate = true;
+      }
+    }
+
     if (requiresColorUpdate) {
       this.planeHighlightMatrices.fill(0);
       this.planeHighlightColors.fill(0);
       let highlightedSwitchCount = 0;
+      let highlightedPathSwitchCount = 0;
 
       for (let switchIndex = 0; switchIndex < this.glassInstances.length; switchIndex++) {
         const planeIndex = this.switchPlaneIndices.get(switchIndex);
-        const highlightStrength =
+        const planeStrength =
           planeIndex === undefined ? 0 : this.planeHighlightStrengths[planeIndex];
+        const pathStrength = this.getPathSwitchHighlightStrength(switchIndex);
+        const highlightStrength = Math.max(planeStrength, pathStrength);
         if (highlightStrength < 0.003) {
           continue;
         }
@@ -2963,24 +3256,55 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         );
         this.planeHighlightColors.set(
           [
-            0.17 * highlightStrength,
-            0.42 * highlightStrength,
-            0.94 * highlightStrength,
-            0.19 * highlightStrength
+            0.17 * planeStrength + 0.23 * pathStrength,
+            0.42 * planeStrength + 0.69 * pathStrength,
+            0.94 * planeStrength + 0.95 * pathStrength,
+            Math.min(0.19 * planeStrength + 0.24 * pathStrength, 0.32)
           ],
           switchIndex * 4
         );
         highlightedSwitchCount++;
+        if (pathStrength > 0.003) {
+          highlightedPathSwitchCount++;
+        }
       }
 
       this.updateSwitchColors();
+      this.updateFocusedHostColors();
       if (this.canvas) {
         this.canvas.dataset.packetSprayingPlaneHighlightStrength = Math.max(
           ...this.planeHighlightStrengths
         ).toFixed(3);
         this.canvas.dataset.packetSprayingHighlightedSwitches = String(highlightedSwitchCount);
+        this.canvas.dataset.packetSprayingPathHighlightStrength = Math.max(
+          ...this.pathHighlightStrengths
+        ).toFixed(3);
+        this.canvas.dataset.packetSprayingHighlightedPathSwitches = String(
+          highlightedPathSwitchCount
+        );
       }
     }
+  }
+
+  private updateFocusedHostColors(): void {
+    const maximumPathStrength = Math.max(...this.pathHighlightStrengths);
+    const hostColors = HOST_POSITIONS.map((_, hostIndex) => {
+      const color = makeHostColor(hostIndex);
+      let focusStrength = 0;
+      for (const [pathIndex, focus] of this.pathFocuses.entries()) {
+        if (focus.hostIndices.has(hostIndex)) {
+          focusStrength = Math.max(focusStrength, this.pathHighlightStrengths[pathIndex]);
+        }
+      }
+      const backgroundStrength = 1 - (maximumPathStrength - focusStrength) * 0.36;
+      return [
+        color[0] * backgroundStrength + focusStrength * 0.045,
+        color[1] * backgroundStrength + focusStrength * 0.07,
+        color[2] * backgroundStrength + focusStrength * 0.075,
+        color[3]
+      ] as Color;
+    });
+    this.hosts.updateColors(flattenColors(hostColors));
   }
 
   private updateHealthyRoutes(): void {
@@ -3129,19 +3453,22 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     }
 
     const pulses = makeLinkPulses(this.packetDefinitions, animationTime, this.linkPulseLength);
+    const maximumPathStrength = Math.max(...this.pathHighlightStrengths);
     for (let pulseIndex = 0; pulseIndex < pulses.length; pulseIndex++) {
       const pulse = pulses[pulseIndex];
       const pulseColor = makeBalancedEmissionColor(pulse.color, 1);
+      const pathStrength = this.getPathLinkHighlightStrength(pulse.linkKey);
+      const focusIntensity = 1 - (maximumPathStrength - pathStrength) * 0.6 + pathStrength * 0.3;
       this.linkPulseMatrices.set(
         makeSegmentMatrix(pulse.start, pulse.end, LINK_PULSE_RADIUS),
         pulseIndex * 16
       );
       this.linkPulseColors.set(
         [
-          pulseColor[0] * linkPulseIntensity * 0.34,
-          pulseColor[1] * linkPulseIntensity * 0.34,
-          pulseColor[2] * linkPulseIntensity * 0.34,
-          Math.min(linkPulseIntensity * 0.42, 0.42)
+          pulseColor[0] * linkPulseIntensity * focusIntensity * 0.34,
+          pulseColor[1] * linkPulseIntensity * focusIntensity * 0.34,
+          pulseColor[2] * linkPulseIntensity * focusIntensity * 0.34,
+          Math.min(linkPulseIntensity * focusIntensity * 0.42, 0.46)
         ],
         pulseIndex * 4
       );
@@ -3205,11 +3532,17 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     );
     const attack = 1 - Math.exp(-elapsedTime * 12);
     const decay = 1 - Math.exp(-elapsedTime * 4.5);
+    const maximumPathStrength = Math.max(...this.pathHighlightStrengths);
     let illuminatedLinkCount = 0;
+    let highlightedPathLinkCount = 0;
 
     for (let linkIndex = 0; linkIndex < this.networkLinks.length; linkIndex++) {
       const link = this.networkLinks[linkIndex];
-      const traffic = trafficByLink.get(makeLinkKey(link.start, link.end));
+      const linkKey = makeLinkKey(link.start, link.end);
+      const traffic = trafficByLink.get(linkKey);
+      const pathStrength = this.getPathLinkHighlightStrength(linkKey);
+      const backgroundStrength = 1 - (maximumPathStrength - pathStrength) * 0.55;
+      const routeGlow = pathStrength * (0.075 + this.opticsProfile.surface * 0.085);
       const targetRedStrength = Math.min((traffic?.red ?? 0) * 0.42, 1);
       const targetGreenStrength = Math.min((traffic?.green ?? 0) * 0.42, 1);
       const previousRedStrength = this.redLinkTrafficStrengths[linkIndex];
@@ -3264,28 +3597,41 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       const totalGlow = Math.min(redGlow + greenGlow + signalGlow * 0.48, 1);
       const colorOffset = linkIndex * 4;
       this.linkColors[colorOffset] = Math.min(
-        link.color[0] + redGlow * 0.3 + greenGlow * 0.055 + failureGlow * 0.2 + pressureGlow * 0.16,
+        (link.color[0] +
+          redGlow * 0.3 +
+          greenGlow * 0.055 +
+          failureGlow * 0.2 +
+          pressureGlow * 0.16) *
+          backgroundStrength +
+          routeGlow * 0.24,
         1
       );
       this.linkColors[colorOffset + 1] = Math.min(
-        link.color[1] +
+        (link.color[1] +
           redGlow * 0.04 +
           greenGlow * 0.27 +
           recoveryGlow * 0.14 +
-          pressureGlow * 0.085,
+          pressureGlow * 0.085) *
+          backgroundStrength +
+          routeGlow * 0.7,
         1
       );
       this.linkColors[colorOffset + 2] = Math.min(
-        link.color[2] + totalGlow * 0.065 + recoveryGlow * 0.17,
+        (link.color[2] + totalGlow * 0.065 + recoveryGlow * 0.17) * backgroundStrength +
+          routeGlow * 0.9,
         1
       );
       this.linkColors[colorOffset + 3] = Math.min(
-        link.color[3] + totalGlow * 0.11 + signalGlow * 0.055,
-        0.38
+        (link.color[3] + totalGlow * 0.11 + signalGlow * 0.055) * backgroundStrength +
+          routeGlow * 0.16,
+        0.42
       );
 
       if (totalGlow > 0.025) {
         illuminatedLinkCount++;
+      }
+      if (pathStrength > 0.003) {
+        highlightedPathLinkCount++;
       }
     }
 
@@ -3297,6 +3643,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.canvas.dataset.packetSprayingIlluminatedLinks !== String(illuminatedLinkCount)
     ) {
       this.canvas.dataset.packetSprayingIlluminatedLinks = String(illuminatedLinkCount);
+    }
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingHighlightedPathLinks = String(highlightedPathLinkCount);
     }
   }
 
@@ -4165,10 +4514,10 @@ const PACKET_SPRAYING_ARTICLE_URL = 'https://openai.com/index/mrc-supercomputer-
 const PACKET_SPRAYING_OVERVIEW_HTML = `\
 <p><strong>Network Packet Spraying</strong></p>
 <p><strong>Two conversations, many routes.</strong> The two servers on the right send independent red and green transfers to two destination servers on the left.</p>
-<p>The guided network tour steps through packet spraying, congestion, switch failure, retransmission, and probe-confirmed recovery. Use Play, Back, and Next to follow or inspect each chapter.</p>
+<p>The guided network tour steps through packet spraying, congestion, switch failure, retransmission, and probe-confirmed recovery. Follow the animated chapter timeline or select any chapter directly.</p>
 <p>The visual-style slider moves smoothly from a packet-first diagram through clear and cinematic glass to spectral lighting, focused caustics, and full optical fireworks. Individual material controls remain available in Settings.</p>
 <p>The visualization has two physical switch planes, each containing four Tier 0 access switches and four Tier 1 aggregation switches. Four larger spine switches connect those planes and provide four independent backbone paths for alternating red and green packets.</p>
-<p>The live switch-plane monitor shows red and green allocation across both physical planes and separately reports available backbone paths. Hover or focus a plane to illuminate all eight switches across its two tiers. Under pressure, adaptive routing moves most packets away from a congested path without retiring it; an offline or recovering path carries none until its control handshake succeeds.</p>
+<p>The live fabric monitor shows red and green allocation across both physical planes and each of the four backbone paths. Hover or focus a plane to illuminate all eight switches across its two tiers, or inspect an individual path to trace both complete server-to-server routes through its five switches and eight links. Under pressure, adaptive routing moves most packets away from a congested path without retiring it; an offline or recovering path carries none until its control handshake succeeds.</p>
 <p>Click any glass switch to move it from healthy to orange and congested, then red and failed. Clicking a failed switch repairs it, but its path stays offline while a blue recovery probe travels to the switch and a cyan acknowledgment returns to its source.</p>
 <p>An orange switch trims overloaded packet payloads while their smaller headers continue. A red switch briefly loses in-flight packets before MRC retires the failed path, retransmits over healthy routes, and sends occasional recovery probes.</p>
 <p>Muted red and green cubes identify each conversation's source and destination; blue cubes are inactive servers. Each active server emits a restrained colored pulse when it launches or receives a packet. Glass spheres are switches, and fabric links softly brighten with red or green light only while packets are traveling through them. Directional light wakes remain inside each link, congested switches breathe amber, and failures or confirmed recoveries send restrained red or cyan waves through nearby glass. Emissive packets leave short trails, reflect inside nearby glass, and project focused colored caustics onto adjacent reflective surfaces.</p>

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -1063,39 +1063,39 @@ class NetworkStoryControls {
     this.rootElement.setAttribute('aria-label', 'Network packet spraying guided tour');
     Object.assign(this.rootElement.style, {
       position: 'fixed',
-      left: '18px',
-      bottom: '18px',
+      left: '12px',
+      bottom: '12px',
       zIndex: '15',
-      width: 'min(360px, calc(100vw - 36px))',
-      padding: '14px 16px',
+      width: 'min(320px, calc(100vw - 24px))',
+      padding: '9px 11px',
       boxSizing: 'border-box',
       border: '1px solid rgba(126, 157, 205, 0.26)',
       borderRadius: '8px',
       background: 'rgba(8, 12, 20, 0.86)',
       backdropFilter: 'blur(12px)',
       color: '#eff4fd',
-      font: '13px/1.45 system-ui, sans-serif'
+      font: '11px/1.35 system-ui, sans-serif'
     });
 
     const headingElement = document.createElement('div');
     headingElement.textContent = 'GUIDED NETWORK TOUR';
     Object.assign(headingElement.style, {
       color: '#88a9d6',
-      fontSize: '10px',
+      fontSize: '9px',
       fontWeight: '650'
     });
 
     this.titleElement = document.createElement('div');
     this.titleElement.setAttribute('aria-live', 'polite');
     Object.assign(this.titleElement.style, {
-      marginTop: '5px',
-      fontSize: '15px',
+      marginTop: '3px',
+      fontSize: '13px',
       fontWeight: '650'
     });
 
     this.descriptionElement = document.createElement('p');
     Object.assign(this.descriptionElement.style, {
-      margin: '6px 0 12px',
+      margin: '3px 0 6px',
       color: '#bcc9dc'
     });
 
@@ -1105,8 +1105,8 @@ class NetworkStoryControls {
     Object.assign(chapterTimeline.style, {
       display: 'flex',
       gap: '4px',
-      height: '12px',
-      margin: '0 0 11px'
+      height: '10px',
+      margin: '0 0 5px'
     });
     this.chapterSegments = NETWORK_STORY_CHAPTERS.map((chapter, chapterIndex) => {
       const segmentButton = document.createElement('button');
@@ -1120,8 +1120,8 @@ class NetworkStoryControls {
       Object.assign(segmentButton.style, {
         position: 'relative',
         flex: String(chapter.duration),
-        height: '12px',
-        padding: '4px 0',
+        height: '10px',
+        padding: '3px 0',
         border: '0',
         background: 'transparent',
         cursor: 'pointer'
@@ -1151,8 +1151,8 @@ class NetworkStoryControls {
 
     const telemetryElement = document.createElement('div');
     Object.assign(telemetryElement.style, {
-      margin: '0 0 13px',
-      paddingTop: '9px',
+      margin: '0 0 7px',
+      paddingTop: '6px',
       borderTop: '1px solid rgba(137, 166, 211, 0.17)'
     });
 
@@ -1160,9 +1160,9 @@ class NetworkStoryControls {
     Object.assign(telemetryHeading.style, {
       display: 'flex',
       justifyContent: 'space-between',
-      marginBottom: '5px',
+      marginBottom: '2px',
       color: '#91a6c3',
-      fontSize: '10px'
+      fontSize: '9px'
     });
     const telemetryLabel = document.createElement('span');
     telemetryLabel.textContent = 'SWITCH PLANES';
@@ -1178,11 +1178,11 @@ class NetworkStoryControls {
       rowElement.setAttribute('aria-pressed', 'false');
       Object.assign(rowElement.style, {
         display: 'grid',
-        gridTemplateColumns: '42px minmax(0, 1fr) 56px',
+        gridTemplateColumns: '39px minmax(0, 1fr) 45px',
         alignItems: 'center',
-        gap: '7px',
+        gap: '5px',
         width: 'calc(100% + 8px)',
-        height: '21px',
+        height: '17px',
         padding: '0 4px',
         margin: '0 -4px',
         border: '1px solid transparent',
@@ -1201,7 +1201,7 @@ class NetworkStoryControls {
 
       const labelElement = document.createElement('span');
       labelElement.textContent = `Plane ${planeIndex + 1}`;
-      Object.assign(labelElement.style, {color: '#becce0', fontSize: '10px'});
+      Object.assign(labelElement.style, {color: '#becce0', fontSize: '9px'});
 
       const trackElement = document.createElement('div');
       Object.assign(trackElement.style, {
@@ -1226,7 +1226,7 @@ class NetworkStoryControls {
       trackElement.append(redBar, greenBar);
 
       const status = document.createElement('span');
-      Object.assign(status.style, {textAlign: 'right', fontSize: '9px'});
+      Object.assign(status.style, {textAlign: 'right', fontSize: '8px'});
       rowElement.append(labelElement, trackElement, status);
       telemetryElement.appendChild(rowElement);
       return {greenBar, redBar, row: rowElement, status};
@@ -1235,11 +1235,19 @@ class NetworkStoryControls {
     const pathHeading = document.createElement('div');
     pathHeading.textContent = 'BACKBONE PATHS';
     Object.assign(pathHeading.style, {
-      margin: '9px 0 4px',
+      margin: '5px 0 2px',
       color: '#91a6c3',
-      fontSize: '10px'
+      fontSize: '9px'
     });
     telemetryElement.appendChild(pathHeading);
+
+    const pathGrid = document.createElement('div');
+    Object.assign(pathGrid.style, {
+      display: 'grid',
+      gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+      columnGap: '7px'
+    });
+    telemetryElement.appendChild(pathGrid);
 
     this.pathIndicators = SPINE_POSITIONS.map((_, pathIndex) => {
       const rowElement = document.createElement('button');
@@ -1249,13 +1257,13 @@ class NetworkStoryControls {
       rowElement.setAttribute('aria-pressed', 'false');
       Object.assign(rowElement.style, {
         display: 'grid',
-        gridTemplateColumns: '42px minmax(0, 1fr) 56px',
+        gridTemplateColumns: '34px minmax(0, 1fr) 39px',
         alignItems: 'center',
-        gap: '7px',
-        width: 'calc(100% + 8px)',
-        height: '19px',
-        padding: '0 4px',
-        margin: '0 -4px',
+        gap: '4px',
+        width: '100%',
+        height: '17px',
+        padding: '0 2px',
+        margin: '0',
         border: '1px solid transparent',
         borderRadius: '4px',
         background: 'transparent',
@@ -1270,7 +1278,7 @@ class NetworkStoryControls {
 
       const label = document.createElement('span');
       label.textContent = `Path ${pathIndex + 1}`;
-      Object.assign(label.style, {color: '#becce0', fontSize: '10px'});
+      Object.assign(label.style, {color: '#becce0', fontSize: '9px'});
       const track = document.createElement('div');
       Object.assign(track.style, {
         display: 'flex',
@@ -1293,25 +1301,25 @@ class NetworkStoryControls {
       });
       track.append(redBar, greenBar);
       const status = document.createElement('span');
-      Object.assign(status.style, {textAlign: 'right', fontSize: '9px'});
+      Object.assign(status.style, {textAlign: 'right', fontSize: '8px'});
       rowElement.append(label, track, status);
-      telemetryElement.appendChild(rowElement);
+      pathGrid.appendChild(rowElement);
       return {greenBar, redBar, row: rowElement, status};
     });
 
     const visualIntensityElement = document.createElement('div');
     Object.assign(visualIntensityElement.style, {
-      margin: '0 0 13px',
-      paddingTop: '9px',
+      margin: '0 0 7px',
+      paddingTop: '6px',
       borderTop: '1px solid rgba(137, 166, 211, 0.17)'
     });
     const visualIntensityHeading = document.createElement('div');
     Object.assign(visualIntensityHeading.style, {
       display: 'flex',
       justifyContent: 'space-between',
-      marginBottom: '5px',
+      marginBottom: '2px',
       color: '#91a6c3',
-      fontSize: '10px'
+      fontSize: '9px'
     });
     const visualIntensityTitle = document.createElement('span');
     visualIntensityTitle.textContent = 'VISUAL STYLE';
@@ -1327,7 +1335,7 @@ class NetworkStoryControls {
     Object.assign(this.visualIntensityInput.style, {
       display: 'block',
       width: '100%',
-      height: '16px',
+      height: '14px',
       margin: '0',
       accentColor: '#84acff',
       cursor: 'pointer'
@@ -1342,7 +1350,7 @@ class NetworkStoryControls {
     Object.assign(actionsElement.style, {
       display: 'flex',
       alignItems: 'center',
-      gap: '7px'
+      gap: '5px'
     });
 
     const previousButton = this.makeButton('Back', 'Previous story chapter', onPrevious);
@@ -1359,7 +1367,7 @@ class NetworkStoryControls {
     Object.assign(this.chapterPositionElement.style, {
       marginLeft: 'auto',
       color: '#90a2bd',
-      fontSize: '12px'
+      fontSize: '11px'
     });
 
     actionsElement.append(
@@ -1542,13 +1550,13 @@ class NetworkStoryControls {
     button.textContent = label;
     button.setAttribute('aria-label', accessibleLabel);
     Object.assign(button.style, {
-      padding: '5px 10px',
+      padding: '4px 8px',
       border: '1px solid rgba(140, 169, 211, 0.3)',
       borderRadius: '5px',
       background: 'rgba(30, 41, 58, 0.75)',
       color: '#edf3fc',
       cursor: 'pointer',
-      font: '12px system-ui, sans-serif'
+      font: '11px system-ui, sans-serif'
     });
     button.addEventListener('click', onClick);
     return button;

--- a/examples/showcase/packet-spraying/network.ts
+++ b/examples/showcase/packet-spraying/network.ts
@@ -84,6 +84,14 @@ export type NetworkPlaneTelemetry = {
   status: NetworkPlaneStatus;
 };
 
+/** The physical switches, links, and endpoints traversed by one shared backbone path. */
+export type NetworkPathFocus = {
+  hostIndices: Set<number>;
+  linkKeys: Set<string>;
+  pathIndex: number;
+  switchIndices: Set<number>;
+};
+
 export type NetworkEndpointSignalKind = 'source' | 'destination';
 
 export type NetworkEndpointSignal = {
@@ -257,6 +265,47 @@ export function makeConversationRoutes(): ConversationRoute[] {
   }
 
   return conversationRoutes;
+}
+
+/** Collects both conversations' complete source-to-destination routes through one spine. */
+export function makeNetworkPathFocus(
+  conversationRoutes: readonly ConversationRoute[],
+  pathIndex: number
+): NetworkPathFocus | null {
+  if (!Number.isInteger(pathIndex) || pathIndex < 0 || pathIndex >= SPINE_POSITIONS.length) {
+    return null;
+  }
+
+  const spinePosition = SPINE_POSITIONS[pathIndex];
+  const focusedRoutes = conversationRoutes.filter(({route}) =>
+    route.points.includes(spinePosition)
+  );
+  if (focusedRoutes.length === 0) {
+    return null;
+  }
+
+  const hostIndices = new Set<number>();
+  const linkKeys = new Set<string>();
+  const switchIndices = new Set<number>();
+
+  for (const {conversationIndex, route} of focusedRoutes) {
+    const conversation = CONVERSATIONS[conversationIndex];
+    hostIndices.add(conversation.sourceHostIndex);
+    hostIndices.add(conversation.destinationHostIndex);
+
+    for (let pointIndex = 0; pointIndex < route.points.length; pointIndex++) {
+      const point = route.points[pointIndex];
+      const switchIndex = SWITCH_INDICES_BY_POSITION.get(point.join(','));
+      if (switchIndex !== undefined) {
+        switchIndices.add(switchIndex);
+      }
+      if (pointIndex > 0) {
+        linkKeys.add(makeLinkKey(route.points[pointIndex - 1], point));
+      }
+    }
+  }
+
+  return {hostIndices, linkKeys, pathIndex, switchIndices};
 }
 
 export function makePackets(conversationRoutes: ConversationRoute[]): Packet[] {

--- a/examples/showcase/packet-spraying/story.ts
+++ b/examples/showcase/packet-spraying/story.ts
@@ -22,6 +22,11 @@ export type NetworkStoryChapter = {
   title: string;
 };
 
+export type NetworkStoryProgress = {
+  chapterProgress: number;
+  overallProgress: number;
+};
+
 export type NetworkOpticsProfile = {
   bloom: number;
   caustics: number;
@@ -94,6 +99,31 @@ export function getWrappedStoryChapterIndex(chapterIndex: number): number {
 
 export function getNetworkStoryChapter(chapterIndex: number): NetworkStoryChapter {
   return NETWORK_STORY_CHAPTERS[getWrappedStoryChapterIndex(chapterIndex)];
+}
+
+/** Returns bounded chapter and duration-weighted full-tour playback progress. */
+export function getNetworkStoryProgress(
+  chapterIndex: number,
+  elapsedTime: number
+): NetworkStoryProgress {
+  const wrappedIndex = getWrappedStoryChapterIndex(chapterIndex);
+  const chapter = NETWORK_STORY_CHAPTERS[wrappedIndex];
+  const boundedElapsedTime = Number.isFinite(elapsedTime)
+    ? Math.max(0, Math.min(elapsedTime, chapter.duration))
+    : 0;
+  const elapsedPreviousChapters = NETWORK_STORY_CHAPTERS.slice(0, wrappedIndex).reduce(
+    (totalDuration, previousChapter) => totalDuration + previousChapter.duration,
+    0
+  );
+  const totalDuration = NETWORK_STORY_CHAPTERS.reduce(
+    (duration, storyChapter) => duration + storyChapter.duration,
+    0
+  );
+
+  return {
+    chapterProgress: boundedElapsedTime / chapter.duration,
+    overallProgress: (elapsedPreviousChapters + boundedElapsedTime) / totalDuration
+  };
 }
 
 /** Brings optical techniques online progressively while keeping low settings packet-first. */

--- a/test/examples/packet-spraying-network.node.spec.ts
+++ b/test/examples/packet-spraying-network.node.spec.ts
@@ -30,6 +30,7 @@ import {
   makeLinkTraffic,
   makePackets,
   makeNetworkPlaneTelemetry,
+  makeNetworkPathFocus,
   makeNetworkSwitchPlaneTelemetry,
   makePickableNetworkNodes,
   makeSwitchPacketEvents,
@@ -112,6 +113,36 @@ test('packet-spraying switches form spine and two complete physical-plane groups
     groups[2].switchIndices.every(switchIndex => SWITCH_POSITIONS[switchIndex][2] < 0),
     'the second physical plane keeps its negative-depth switch row together'
   );
+  testCase.end();
+});
+
+test('packet-spraying path inspection follows both complete conversations through one spine', testCase => {
+  const routes = makeConversationRoutes();
+
+  for (let pathIndex = 0; pathIndex < SPINE_POSITIONS.length; pathIndex++) {
+    const focus = makeNetworkPathFocus(routes, pathIndex)!;
+
+    testCase.equal(focus.pathIndex, pathIndex, 'the focus identifies its physical backbone path');
+    testCase.equal(
+      focus.hostIndices.size,
+      4,
+      'both source and destination server pairs participate'
+    );
+    testCase.equal(focus.switchIndices.size, 5, 'the focused path crosses five physical switches');
+    testCase.equal(focus.linkKeys.size, 8, 'shared links combine with both endpoint branches');
+    testCase.ok(
+      focus.switchIndices.has(LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length + pathIndex),
+      'the selected spine belongs to its focused route'
+    );
+  }
+
+  testCase.equal(makeNetworkPathFocus(routes, -1), null, 'negative path indices are rejected');
+  testCase.equal(
+    makeNetworkPathFocus(routes, SPINE_POSITIONS.length),
+    null,
+    'out-of-range path indices are rejected'
+  );
+  testCase.equal(makeNetworkPathFocus([], 0), null, 'missing routes cannot produce a focus');
   testCase.end();
 });
 

--- a/test/examples/packet-spraying-story.node.spec.ts
+++ b/test/examples/packet-spraying-story.node.spec.ts
@@ -7,6 +7,7 @@ import {SWITCH_POSITIONS} from '../../examples/showcase/packet-spraying/network'
 import {
   DEFAULT_NETWORK_OPTICS_LEVEL,
   getNetworkStoryChapter,
+  getNetworkStoryProgress,
   getWrappedStoryChapterIndex,
   GUIDED_STORY_SWITCH_INDEX,
   makeNetworkOpticsProfile,
@@ -41,6 +42,31 @@ test('packet-spraying guided tour wraps forward and backward between chapters', 
   testCase.equal(getWrappedStoryChapterIndex(NETWORK_STORY_CHAPTERS.length), 0);
   testCase.equal(getNetworkStoryChapter(-1).id, 'recovery');
   testCase.equal(getNetworkStoryChapter(NETWORK_STORY_CHAPTERS.length).id, 'conversations');
+  testCase.end();
+});
+
+test('packet-spraying chapter timeline tracks duration-weighted guided playback', testCase => {
+  const firstChapter = getNetworkStoryProgress(0, 3.5);
+  const secondChapter = getNetworkStoryProgress(1, 4);
+  const finalChapter = getNetworkStoryProgress(NETWORK_STORY_CHAPTERS.length - 1, 7);
+
+  testCase.equal(firstChapter.chapterProgress, 0.5, 'individual chapter progress is normalized');
+  testCase.equal(secondChapter.chapterProgress, 0.5, 'different chapter lengths remain normalized');
+  testCase.ok(
+    secondChapter.overallProgress > firstChapter.overallProgress,
+    'the complete tour advances monotonically'
+  );
+  testCase.equal(finalChapter.overallProgress, 1, 'finishing the final chapter completes the tour');
+  testCase.equal(
+    getNetworkStoryProgress(0, -4).chapterProgress,
+    0,
+    'negative playback times clamp to zero'
+  );
+  testCase.equal(
+    getNetworkStoryProgress(0, Number.NaN).chapterProgress,
+    0,
+    'invalid playback times cannot poison timeline state'
+  );
   testCase.end();
 });
 


### PR DESCRIPTION
## Goals
- Make the four independent backbone paths as inspectable as the two physical switch planes.
- Improve guided-story navigation without sacrificing the packet-first visual hierarchy.

## Changes
- Add a pure path-focus model identifying both conversations' four endpoints, five shared switches, and eight physical links for each spine path.
- Add four live, accessible backbone-path telemetry strips showing red/green packet allocation, congestion, failures, and probe-confirmed recovery.
- Smoothly isolate a hovered path across glass switch shells, reflective links, directional packet wakes, and active servers; hovering a physical spine also selects its complete route.
- Add a directly navigable, duration-weighted five-chapter story timeline with progressive playback indicators and synchronized cinematic camera transitions.
- Extend focused topology/story tests and update the GPU glass-effects roadmap and showcase documentation.

## Stack
- Base: #2773 (`codex/network-visual-style-dial`).

## Verification
- `env -u YARN_NO_PROXY corepack yarn lint fix`
- `env -u YARN_NO_PROXY corepack yarn build`
- `env -u YARN_NO_PROXY corepack yarn test-node` (211 passed, 2 skipped)
- `env -u YARN_NO_PROXY corepack yarn workspace luma.gl-examples-showcase-packet-spraying build`
- Repository commit hook reran Biome checks and all 211 Node tests.
- Browser-verified live WebGL rendering, four accessible path rows, five chapter controls, route highlighting of exactly five switches/eight links, and targeted failure telemetry.

## Notes
- The in-app browser's WebGPU adapter did not initialize during this run; production builds include both WebGPU and WebGL bundles, and the live WebGL hardware path was verified.