### PR TITLE
feat: enable HDR rendering in Illumination Lab

### DIFF
--- a/docs/api-guide/gpu/gpu-rendering.md
+++ b/docs/api-guide/gpu/gpu-rendering.md
@@ -84,6 +84,69 @@ While there are ways to obtain multiple `CanvasContext` instances on WebGPU, the
 
 For portable multi-canvas rendering, see the [Multiple Canvases](/docs/developer-guide/multiple-canvases) developer guide.
 
+### High-dynamic-range presentation
+
+Rendering into an `rgba16float` offscreen texture does not automatically produce an HDR image on
+the display. The final WebGPU canvas must also use a floating-point presentation format and
+explicitly enable extended tone mapping. Otherwise, the browser clamps displayed colors to the
+standard `[0, 1]` range even when internal lighting and postprocessing retain brighter values.
+
+Detect whether the current display advertises high dynamic range, then configure the default
+canvas when creating the device:
+
+```ts
+import {luma} from '@luma.gl/core';
+import {webgpuAdapter} from '@luma.gl/webgpu';
+
+const supportsHighDynamicRange =
+  typeof window !== 'undefined' && window.matchMedia('(dynamic-range: high)').matches;
+
+const device = await luma.createDevice({
+  adapters: [webgpuAdapter],
+  createCanvasContext: supportsHighDynamicRange
+    ? {
+        colorFormat: 'rgba16float',
+        colorSpace: 'display-p3',
+        toneMapping: 'extended'
+      }
+    : true
+});
+
+const renderingHighDynamicRange = device.preferredColorFormat === 'rgba16float';
+```
+
+The three canvas settings have separate responsibilities:
+
+- `colorFormat: 'rgba16float'` preserves fractional precision and color components above `1.0`.
+- `toneMapping: 'extended'` asks WebGPU to display values above SDR white instead of clipping
+  them to the `[0, 1]` presentation range.
+- `colorSpace: 'display-p3'` selects a wider display gamut; wide color and HDR luminance are
+  related but independent capabilities.
+
+Applications must preserve that range throughout their rendering pipeline:
+
+1. Keep scene lighting, emissive materials, and intermediate postprocessing in floating-point
+   textures such as `rgba16float`.
+2. Match fullscreen render pipelines and presentation targets to `device.preferredColorFormat`.
+3. Avoid unconditional `clamp(color, 0.0, 1.0)` in the final shader when HDR presentation is
+   active. Apply an SDR-safe curve to ordinary colors while preserving brighter specular and
+   emissive highlights.
+4. Retain the normal 8-bit canvas and SDR tone mapping when the display, browser, or backend
+   cannot present HDR.
+
+`window.matchMedia('(dynamic-range: high)')` identifies display capability, not browser WebGPU
+canvas support. On browsers exposing `GPUCanvasContext.getConfiguration()`, inspect
+`configuration.toneMapping?.mode === 'extended'` to verify that extended presentation was
+accepted. Monitor availability can also change when a window moves between displays.
+
+HDR presentation is WebGPU-specific. WebGL applications can still use floating-point intermediate
+render targets where supported, but their ordinary presentation canvas remains SDR. Floating-point
+presentation and intermediate textures also consume more GPU memory than 8-bit formats.
+
+The [Deferred Rendering: Illumination Lab](/examples/experimental/deferred-rendering) example
+demonstrates clustered lighting, floating-point postprocessing, configurable highlight intensity,
+and automatic HDR/SDR presentation selection.
+
 ### Creating a RenderPipeline
 
 ```typescript

--- a/docs/api-reference/core/canvas-context.md
+++ b/docs/api-reference/core/canvas-context.md
@@ -73,6 +73,35 @@ const canvasContext = device.getDefaultCanvasContext()
 
 The same `createCanvasContext` options are also used when attaching to an externally created WebGL context through `luma.attachDevice()` or `webgl2Adapter.attach()`, including compatibility options such as `pixelSizeSource`.
 
+### HDR presentation
+
+On an HDR-capable display, configure a WebGPU canvas with a floating-point presentation format,
+wide color gamut, and extended tone mapping:
+
+```ts
+const supportsHighDynamicRange = window.matchMedia('(dynamic-range: high)').matches;
+
+const device = await luma.createDevice({
+  adapters: [webgpuAdapter],
+  createCanvasContext: supportsHighDynamicRange
+    ? {
+        colorFormat: 'rgba16float',
+        colorSpace: 'display-p3',
+        toneMapping: 'extended'
+      }
+    : true
+});
+```
+
+`device.preferredColorFormat` becomes `'rgba16float'` for the HDR device. Render pipelines,
+offscreen passes, and the final fragment shader must preserve values above `1.0`; an SDR tone
+mapping curve that clamps every channel defeats HDR presentation even with an HDR canvas.
+
+On non-HDR displays, use the normal 8-bit presentation format and standard tone mapping. WebGL
+can use floating-point intermediate textures when supported, but HDR canvas presentation is
+currently a WebGPU feature. See [High-dynamic-range presentation](/docs/api-guide/gpu/gpu-rendering#high-dynamic-range-presentation)
+for the complete rendering pipeline and fallback guidance.
+
 Use a device's default canvas context to render into the associated canvas
 
 ```typescript
@@ -139,8 +168,10 @@ canvasContext.getDevicePixelResolution()
 | `canvas?`              | `HTMLCanvasElement` \| `OffscreenCanvas` \| `string` | A new canvas will be created if not supplied.                                                                                          |
 | `container?`           | `HTMLElement`                                        | Parent DOM element for new canvas. Defaults to first child of `document.body`                                                          |
 | `visible?`             | `boolean`                                            | Visibility (only used if new canvas is created).                                                                                       |
-| `alphaMode?: string`   | `'opaque'`                                           | `'opaque' \| 'premultiplied'`. See [alphaMode](https://developer.mozilla.org/en-US/docs/Web/API/GPUCanvasContext/configure#alphamode). |
-| `colorSpace?: 'string` | `'srgb'`                                             | `'srgb' \| 'display-p3'`. See [colorSpace](https://developer.mozilla.org/en-US/docs/Web/API/GPUCanvasContext/configure#colorspace).    |
+| `alphaMode?`           | `'opaque' \| 'premultiplied'`                        | WebGPU presentation alpha mode.                                                                                                        |
+| `colorSpace?`          | `'srgb' \| 'display-p3'`                             | Presentation color space. Use `'display-p3'` for wide-gamut HDR output.                                                               |
+| `colorFormat?`         | `'rgba8unorm' \| 'bgra8unorm' \| 'rgba16float'`      | Optional WebGPU presentation texture format. Use `'rgba16float'` to retain HDR values.                                                |
+| `toneMapping?`         | `'standard' \| 'extended'`                           | WebGPU presentation tone mapping. `'extended'` preserves colors brighter than SDR white.                                              |
 
 ### `useDevicePixels: boolean`
 

--- a/docs/api-reference/core/presentation-context.md
+++ b/docs/api-reference/core/presentation-context.md
@@ -80,7 +80,9 @@ Because of this design, WebGL presentation contexts are sequential and require t
 | `container?`           | `HTMLElement` \| `string`                            | Parent DOM element for a newly created destination canvas       |
 | `visible?`             | `boolean`                                            | Visibility for a newly created destination canvas               |
 | `alphaMode?`           | `'opaque' \| 'premultiplied'`                        | Canvas alpha mode metadata                                      |
-| `colorSpace?`          | `'srgb'`                                             | Canvas color space metadata                                     |
+| `colorSpace?`          | `'srgb' \| 'display-p3'`                             | Presentation color space                                        |
+| `colorFormat?`         | `'rgba8unorm' \| 'bgra8unorm' \| 'rgba16float'`      | Requested WebGPU presentation texture format                    |
+| `toneMapping?`         | `'standard' \| 'extended'`                           | Whether WebGPU presentation preserves HDR luminance             |
 | `trackPosition?`       | `boolean`                                            | Whether to track destination canvas position                    |
 
 ## Fields

--- a/examples/experimental/deferred-rendering/app.ts
+++ b/examples/experimental/deferred-rendering/app.ts
@@ -75,6 +75,7 @@ type DeferredRenderingSettings = {
   animate: boolean;
   autoOrbitCamera: boolean;
   exposure: number;
+  highlightBoost: number;
   sunIntensity: number;
   ambientOcclusionRadius: number;
   ambientOcclusionIntensity: number;
@@ -98,6 +99,7 @@ const DEFAULT_SETTINGS: DeferredRenderingSettings = {
   animate: true,
   autoOrbitCamera: true,
   exposure: 1.15,
+  highlightBoost: 1.4,
   sunIntensity: 2.8,
   ambientOcclusionRadius: 2.2,
   ambientOcclusionIntensity: 3.2,
@@ -121,6 +123,7 @@ const DEFERRED_RENDERING_BACKGROUND_HTML = `
 <p><b>Why GTAO belongs after lighting:</b> a half-resolution horizon search reuses the same depth and view normals to estimate ambient visibility around contacts. G-buffer velocity reprojects the previous AO result, depth rejects disocclusions, and a depth-aware blur removes remaining half-resolution noise before the AO is composed into lit color.</p>
 <p><b>Where colored bounce comes from:</b> cosine-weighted hemisphere rays gather already-lit radiance from nearby visible surfaces. Cyan, magenta, and amber emitter panels transfer their color onto neighboring walls, floors, and matte materials; velocity, linear-depth rejection, and bilateral filtering stabilize the diffuse bounce.</p>
 <p><b>Where the reflections come from:</b> stochastic screen-space rays bounce from the same view normals into already-lit scene color. Rough surfaces widen the reflection cone; velocity and depth history stabilize animated highlights, while depth/normal-aware denoising preserves sharp mirrors and produces soft glossy lobes.</p>
+<p><b>Why HDR changes the image:</b> floating-point G-buffer and lighting passes retain radiance above SDR white. On compatible displays, a Display P3, <code>rgba16float</code>, extended-tone-mapping canvas preserves those concentrated specular highlights and emissive panels instead of clipping them.</p>
 <p><b>Work changes shape:</b> the expensive path becomes roughly geometry + visible pixels × lights in the local cluster, instead of objects × every light. The same G-buffer also feeds GTAO, diffuse global illumination, SSR, fog, outline, temporal, and motion effects without redrawing material geometry.</p>
 <p><b>Correctness at the limit:</b> candidate bits are compacted in stable light-index order. If a cluster exceeds its retained list, that pixel falls back to the active light prefix rather than showing tile-shaped truncation; <b>Cluster Occupancy</b>, <b>Indirect Lighting</b>, <b>Bounce Confidence</b>, <b>Reflections</b>, and <b>Reflection Confidence</b> reveal where work or uncertain screen-space hits accumulate.</p>
 `;
@@ -215,6 +218,8 @@ type DeferredDisplayUniforms = {
   inverseProjectionMatrix: Matrix4;
   debugMode: number;
   exposure: number;
+  highDynamicRange: number;
+  highlightBoost: number;
   clusterCountX: number;
   clusterCountY: number;
   clusterCountZ: number;
@@ -238,6 +243,8 @@ struct DeferredDisplayUniforms {
   inverseProjectionMatrix: mat4x4f,
   debugMode: f32,
   exposure: f32,
+  highDynamicRange: f32,
+  highlightBoost: f32,
   clusterCountX: u32,
   clusterCountY: u32,
   clusterCountZ: u32,
@@ -259,7 +266,16 @@ fn deferredDisplay_toneMap(color: vec3f) -> vec3f {
   let exposed = max(color * deferredDisplay.exposure, vec3f(0.0));
   let mapped = (exposed * (2.51 * exposed + 0.03)) /
     (exposed * (2.43 * exposed + 0.59) + 0.14);
-  return pow(clamp(mapped, vec3f(0.0), vec3f(1.0)), vec3f(1.0 / 2.2));
+  let standardColor = clamp(mapped, vec3f(0.0), vec3f(1.0));
+  let peakIntensity = max(max(exposed.r, exposed.g), exposed.b);
+  let highlightWeight = smoothstep(0.32, 1.35, peakIntensity);
+  let extendedHighlights = exposed * highlightWeight * deferredDisplay.highlightBoost * 0.68;
+  let displayColor = select(
+    standardColor,
+    standardColor + extendedHighlights,
+    deferredDisplay.highDynamicRange > 0.5
+  );
+  return pow(displayColor, vec3f(1.0 / 2.2));
 }
 
 fn deferredDisplay_reconstructViewPosition(uv: vec2f, depth: f32) -> vec3f {
@@ -372,6 +388,8 @@ fn deferredDisplay_sampleColor(
     inverseProjectionMatrix: 'mat4x4<f32>',
     debugMode: 'f32',
     exposure: 'f32',
+    highDynamicRange: 'f32',
+    highlightBoost: 'f32',
     clusterCountX: 'u32',
     clusterCountY: 'u32',
     clusterCountZ: 'u32',
@@ -383,6 +401,8 @@ fn deferredDisplay_sampleColor(
     inverseProjectionMatrix: {value: new Matrix4(), private: true},
     debugMode: {value: 0, private: true},
     exposure: {value: DEFAULT_SETTINGS.exposure, min: 0.1, softMax: 3},
+    highDynamicRange: {value: 0, private: true},
+    highlightBoost: {value: DEFAULT_SETTINGS.highlightBoost, min: 0, softMax: 3},
     clusterCountX: {value: 16, private: true},
     clusterCountY: {value: 9, private: true},
     clusterCountZ: {value: 24, private: true},
@@ -559,6 +579,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   }
 
   override async onInitialize({canvas}: AnimationProps): Promise<void> {
+    document
+      .getElementById('hdr-highlight-boost')
+      ?.addEventListener('input', this.handleHighlightBoostChange);
     if (canvas instanceof HTMLCanvasElement) {
       this.orbitControls = new OrbitControls(canvas, {
         target: [0, 0.9, 0],
@@ -576,6 +599,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   }
 
   onRender({device, width, height, aspect, tick}: AnimationProps): void {
+    this.synchronizeHighlightBoost();
+
     if (this.framebufferSize[0] !== width || this.framebufferSize[1] !== height) {
       this.framebufferSize = [width, height];
       this.sceneGBuffer.resize({width, height});
@@ -614,7 +639,14 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       Math.round(this.settings.pointLightCount),
       MAX_EXAMPLE_POINT_LIGHTS
     );
-    const lightState = makeAnimatedPointLights(time, activeLightCount, viewMatrix);
+    const highlightBoost =
+      device.preferredColorFormat === 'rgba16float' ? this.settings.highlightBoost : 0;
+    const lightState = makeAnimatedPointLights(
+      time,
+      activeLightCount,
+      viewMatrix,
+      1 + highlightBoost * 1.45
+    );
     this.pointLightBuffer.write(
       makeDeferredPointLightBufferData(lightState.viewLights, MAX_CLUSTERED_POINT_LIGHTS)
     );
@@ -742,6 +774,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           inverseProjectionMatrix,
           debugMode: getDebugMode(this.settings.debugView),
           exposure: this.settings.exposure,
+          highDynamicRange: device.preferredColorFormat === 'rgba16float' ? 1 : 0,
+          highlightBoost: this.settings.highlightBoost,
           ...clusterUniforms
         }
       }
@@ -752,6 +786,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   }
 
   onFinalize(): void {
+    document
+      .getElementById('hdr-highlight-boost')
+      ?.removeEventListener('input', this.handleHighlightBoostChange);
     this.settingsPanel.finalize();
     this.panels.finalize();
     this.orbitControls?.destroy();
@@ -769,7 +806,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   private makePanel(): Panel {
     return makeExampleTabbedPanel({
       id: 'deferred-rendering-tabs',
-      title: 'Deferred Illumination Lab',
+      title: `Deferred Illumination Lab${this.device.preferredColorFormat === 'rgba16float' ? ' · HDR' : ''}`,
       panels: [
         makeHtmlCustomPanel({
           id: 'deferred-rendering-description',
@@ -791,8 +828,39 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     _changedSettings?: SettingsChangeDescriptor[]
   ): void => {
     this.settings = {...this.settings, ...(nextSettings as DeferredRenderingSettings)};
+    const highlightBoostInput = document.getElementById('hdr-highlight-boost');
+    if (highlightBoostInput instanceof HTMLInputElement) {
+      highlightBoostInput.value = String(this.settings.highlightBoost);
+    }
+    this.updateHighlightBoostLabel();
     this.orbitControls?.setAutoRotate(this.settings.autoOrbitCamera);
   };
+
+  private readonly handleHighlightBoostChange = (event: Event): void => {
+    const input = event.currentTarget;
+    if (input instanceof HTMLInputElement) {
+      this.settings = {...this.settings, highlightBoost: input.valueAsNumber};
+      this.updateHighlightBoostLabel();
+    }
+  };
+
+  private synchronizeHighlightBoost(): void {
+    const highlightBoostInput = document.getElementById('hdr-highlight-boost');
+    if (
+      highlightBoostInput instanceof HTMLInputElement &&
+      highlightBoostInput.valueAsNumber !== this.settings.highlightBoost
+    ) {
+      this.settings = {...this.settings, highlightBoost: highlightBoostInput.valueAsNumber};
+      this.updateHighlightBoostLabel();
+    }
+  }
+
+  private updateHighlightBoostLabel(): void {
+    const highlightValue = document.getElementById('hdr-highlight-value');
+    if (highlightValue) {
+      highlightValue.textContent = `${this.settings.highlightBoost.toFixed(2)}×`;
+    }
+  }
 }
 
 function createRenderer(device: Device): ShaderPassRenderer {
@@ -978,7 +1046,8 @@ function makeLightMarkerData(): SurfaceInstanceData {
 function makeAnimatedPointLights(
   time: number,
   lightCount: number,
-  viewMatrix: Matrix4
+  viewMatrix: Matrix4,
+  lightIntensityMultiplier = 1
 ): {viewLights: DeferredPointLight[]; markerPositions: Float32Array} {
   const viewLights: DeferredPointLight[] = [];
   const markerPositions = new Float32Array(MAX_EXAMPLE_POINT_LIGHTS * 3);
@@ -1007,7 +1076,7 @@ function makeAnimatedPointLights(
       position: viewMatrix.transformAsPoint(worldPosition) as [number, number, number],
       range: 3.6 + (ring % 3) * 0.55,
       color: [color[0], color[1], color[2]],
-      intensity: 7.5 + (ring % 3) * 1.2
+      intensity: (7.5 + (ring % 3) * 1.2) * lightIntensityMultiplier
     });
   }
   return {viewLights, markerPositions};
@@ -1099,6 +1168,15 @@ function makeSettingsSchema(): SettingsSchema {
             persist: 'none',
             min: 0.2,
             max: 2.5,
+            step: 0.05
+          },
+          {
+            name: 'highlightBoost',
+            label: 'HDR Highlight Boost',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 4,
             step: 0.05
           }
         ]

--- a/examples/experimental/deferred-rendering/index.html
+++ b/examples/experimental/deferred-rendering/index.html
@@ -1,7 +1,28 @@
 <!doctype html>
 <head>
+  <meta charset="utf-8" />
+  <title>Deferred Illumination Lab</title>
   <style>
     body { margin: 0; background: #01030b; color-scheme: dark; }
+    .display-status {
+      position: fixed;
+      top: 20px;
+      left: 20px;
+      z-index: 1;
+      padding: 13px 16px;
+      color: #e7ecff;
+      background: rgba(5, 8, 20, 0.76);
+      border: 1px solid rgba(175, 195, 255, 0.18);
+      border-radius: 10px;
+      font: 12px/1.5 system-ui, sans-serif;
+      letter-spacing: 0.04em;
+      backdrop-filter: blur(12px);
+    }
+    .display-status strong { display: block; font-size: 14px; }
+    .display-status label { display: block; margin-top: 9px; color: #aeb8dc; }
+    .display-status input { display: block; width: 170px; margin-top: 5px; }
+    #dynamic-range-status { color: #ffd493; }
+    #hdr-highlight-value { color: #ffd493; }
   </style>
 </head>
 <script type="module">
@@ -10,12 +31,27 @@
   import {webgpuAdapter} from '@luma.gl/webgpu';
   import AnimationLoopTemplate from './app.ts';
 
+  const supportsHighDynamicRange = window.matchMedia('(dynamic-range: high)').matches;
+  const displayMode = supportsHighDynamicRange ? 'WEBGPU · HDR · DISPLAY P3' : 'WEBGPU · SDR';
+  document.title = `Deferred Illumination Lab · ${supportsHighDynamicRange ? 'HDR' : 'SDR'}`;
+  document.getElementById('dynamic-range-status').textContent = displayMode;
   const device = luma.createDevice({
     id: 'deferred-rendering',
     adapters: [webgpuAdapter],
-    createCanvasContext: true,
+    createCanvasContext: supportsHighDynamicRange
+      ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+      : true,
     featureLevel: 'max'
   });
   makeAnimationLoop(AnimationLoopTemplate, {device}).start();
 </script>
-<body></body>
+<body>
+  <aside class="display-status">
+    <strong>ILLUMINATION LAB</strong>
+    <span id="dynamic-range-status"></span>
+    <label for="hdr-highlight-boost">
+      HDR HIGHLIGHT BOOST <span id="hdr-highlight-value">1.40×</span>
+    </label>
+    <input id="hdr-highlight-boost" type="range" min="0" max="6" step="0.05" value="1.4" />
+  </aside>
+</body>

--- a/modules/core/src/adapter/canvas-surface.ts
+++ b/modules/core/src/adapter/canvas-surface.ts
@@ -43,7 +43,11 @@ export type CanvasContextProps = {
   /** @see https://developer.mozilla.org/en-US/docs/Web/API/GPUCanvasContext/configure#alphamode */
   alphaMode?: 'opaque' | 'premultiplied';
   /** @see https://developer.mozilla.org/en-US/docs/Web/API/GPUCanvasContext/configure#colorspace */
-  colorSpace?: 'srgb'; // GPUPredefinedColorSpace
+  colorSpace?: 'srgb' | 'display-p3';
+  /** Optional WebGPU presentation texture format. Use rgba16float for HDR presentation. */
+  colorFormat?: 'rgba8unorm' | 'bgra8unorm' | 'rgba16float';
+  /** Whether WebGPU presentation preserves colors brighter than SDR white. */
+  toneMapping?: 'standard' | 'extended';
   /** Whether to track position changes. Calls this.device.onPositionChange */
   trackPosition?: boolean;
 };
@@ -86,6 +90,8 @@ export abstract class CanvasSurface {
     visible: true,
     alphaMode: 'opaque',
     colorSpace: 'srgb',
+    colorFormat: undefined!,
+    toneMapping: 'standard',
     trackPosition: false
   };
 

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -586,8 +586,8 @@ export abstract class Device {
 
   // Texture helpers
 
-  /** Optimal TextureFormat for displaying 8-bit depth, standard dynamic range content on this system. */
-  abstract preferredColorFormat: 'rgba8unorm' | 'bgra8unorm';
+  /** Optimal presentation format, including rgba16float for high-dynamic-range canvases. */
+  abstract preferredColorFormat: 'rgba8unorm' | 'bgra8unorm' | 'rgba16float';
   /** Default depth format used on this system */
   abstract preferredDepthFormat: 'depth16' | 'depth24plus' | 'depth32float';
 

--- a/modules/core/test/adapter/canvas-context.spec.ts
+++ b/modules/core/test/adapter/canvas-context.spec.ts
@@ -64,6 +64,24 @@ class TestPresentationContext extends PresentationContext {
   }
 }
 
+test('CanvasContext preserves HDR presentation options', testContext => {
+  const canvasContext = new TestCanvasContext(
+    {
+      colorFormat: 'rgba16float',
+      colorSpace: 'display-p3',
+      toneMapping: 'extended'
+    },
+    false
+  );
+
+  testContext.equal(canvasContext.props.colorFormat, 'rgba16float', 'preserves floating format');
+  testContext.equal(canvasContext.props.colorSpace, 'display-p3', 'preserves wide color gamut');
+  testContext.equal(canvasContext.props.toneMapping, 'extended', 'preserves extended luminance');
+
+  canvasContext.destroy();
+  testContext.end();
+});
+
 function createCanvasContextSpyDevice() {
   const calls = {onResize: 0, onVisibilityChange: 0};
   return {

--- a/modules/webgpu/src/adapter/webgpu-canvas-context.ts
+++ b/modules/webgpu/src/adapter/webgpu-canvas-context.ts
@@ -79,7 +79,8 @@ export class WebGPUCanvasContext extends CanvasContext {
       // Can be used to define e.g. -srgb views
       // viewFormats: [...]
       colorSpace: this.props.colorSpace,
-      alphaMode: this.props.alphaMode
+      alphaMode: this.props.alphaMode,
+      toneMapping: {mode: this.props.toneMapping}
     });
 
     this._createDepthStencilAttachment(this.device.preferredDepthFormat);

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -80,9 +80,7 @@ export class WebGPUDevice extends Device {
   /** type of this device */
   readonly type = 'webgpu';
 
-  readonly preferredColorFormat = navigator.gpu.getPreferredCanvasFormat() as
-    | 'rgba8unorm'
-    | 'bgra8unorm';
+  readonly preferredColorFormat: 'rgba8unorm' | 'bgra8unorm' | 'rgba16float';
   readonly preferredDepthFormat = 'depth24plus';
 
   readonly features: DeviceFeatures;
@@ -112,6 +110,10 @@ export class WebGPUDevice extends Device {
     adapterInfo: GPUAdapterInfo
   ) {
     super({...props, id: props.id || 'webgpu-device'});
+    const canvasContextProps = Device._getCanvasContextProps(props);
+    this.preferredColorFormat =
+      canvasContextProps?.colorFormat ??
+      (navigator.gpu.getPreferredCanvasFormat() as 'rgba8unorm' | 'bgra8unorm');
     this.handle = device;
     this.adapter = adapter;
     this.adapterInfo = adapterInfo;
@@ -137,7 +139,6 @@ export class WebGPUDevice extends Device {
     });
 
     // Note: WebGPU devices can be created without a canvas, for compute shader purposes
-    const canvasContextProps = Device._getCanvasContextProps(props);
     if (canvasContextProps) {
       this.canvasContext = new WebGPUCanvasContext(this, this.adapter, canvasContextProps);
     }

--- a/modules/webgpu/src/adapter/webgpu-presentation-context.ts
+++ b/modules/webgpu/src/adapter/webgpu-presentation-context.ts
@@ -74,7 +74,8 @@ export class WebGPUPresentationContext extends PresentationContext {
       device: this.device.handle,
       format: this.device.preferredColorFormat,
       colorSpace: this.props.colorSpace,
-      alphaMode: this.props.alphaMode
+      alphaMode: this.props.alphaMode,
+      toneMapping: {mode: this.props.toneMapping}
     });
 
     this._createDepthStencilAttachment(this.device.preferredDepthFormat);


### PR DESCRIPTION
## Summary

Enable genuine HDR presentation in the Illumination Lab and expose the WebGPU canvas configuration needed for applications to opt in.

- Extend canvas presentation options with `rgba16float`, Display P3, and extended tone mapping.
- Configure WebGPU canvas and presentation contexts to preserve luminance above SDR white.
- Detect HDR-capable displays and retain an SDR fallback in the deferred-rendering example.
- Add an interactive HDR highlight boost that increases real point-light intensity, specular reflections, and over-white presentation.
- Document HDR enablement, display capability detection, fallback behavior, and presentation APIs.
- Add focused coverage for HDR canvas configuration.

## Validation

- `env -u YARN_NO_PROXY corepack yarn build`
- `env -u YARN_NO_PROXY CI=1 corepack yarn test`
  - Node: 54 test files passed, 208 tests passed.
  - Browser/headless: 238 test files passed, 1,287 tests passed.
- `env -u YARN_NO_PROXY corepack yarn lint fix`
- `env -u YARN_NO_PROXY corepack yarn workspace luma.gl-examples-experimental-deferred-rendering build`
- `env -u YARN_NO_PROXY corepack yarn website:build`
- Verified the live example reports `WEBGPU · HDR · DISPLAY P3` and the HDR boost slider updates scene lighting.