### PR TITLE
feat(showcase): add cinematic network events and true HDR optics

### DIFF
--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -217,7 +217,9 @@ raise bloom extraction with them and finish with restrained filmic exposure. Mul
 existing red or green emission preserves its color without introducing pastel white halos.
 The packet-spraying showcase exposes a compact HDR-range slider next to its visual-style control;
 its default deliberately keeps display highlights below twice SDR white, while higher settings can
-reveal the full extended-range presentation.
+reveal the full extended-range presentation. HDR range and packet-core emission remain independent
+of visual style, so a minimal diagram can retain extended highlights without enabling refraction,
+bloom, or secondary glass lighting.
 
 Interactive path highlighting should remain optically subordinate to the material: emphasize the
 actual links and packet motion instead of filling switches with artificial light, changing their

--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -215,6 +215,9 @@ output does not clamp the extended highlight range. Increase emission, local ill
 reflective highlights gradually within available scene headroom;
 raise bloom extraction with them and finish with restrained filmic exposure. Multiplying a packet's
 existing red or green emission preserves its color without introducing pastel white halos.
+The packet-spraying showcase exposes a compact HDR-range slider next to its visual-style control;
+its default deliberately keeps display highlights below twice SDR white, while higher settings can
+reveal the full extended-range presentation.
 
 Interactive path highlighting should remain optically subordinate to the material: emphasize the
 actual links and packet motion instead of filling switches with artificial light, changing their

--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -205,6 +205,18 @@ Use `bloomShaderPassPipeline` after opaque and translucent composition, followed
 links or the entire glass silhouette. When floating-point scene color is unavailable, fall back to
 the preferred display format and reduce the extraction threshold.
 
+Floating-point scene rendering and HDR display presentation are distinct capabilities. An
+`rgba16float` intermediate attachment retains bright, saturated packet emission and narrow glass
+highlights even when the final canvas is standard dynamic range. Extended HDR presentation also
+requires a compatible WebGPU canvas, display, and extended tone-mapping configuration. Increase
+emission, local illumination, and reflective highlights gradually within available scene headroom;
+raise bloom extraction with them and finish with restrained filmic exposure. Multiplying a packet's
+existing red or green emission preserves its color without introducing pastel white halos.
+
+Interactive path highlighting should remain optically subordinate to the material: use a thin,
+low-opacity rim and bounded local illumination instead of filling the entire switch with bright
+color or increasing its transmission opacity.
+
 `glassMaterial_getIlluminatedColor(...)` and `reflectiveMaterial_getIlluminatedColor(...)` combine
 their existing optical response with `opticalPointLights`. Existing `getColor(...)` helpers remain
 appropriate when no dynamic local lights are needed.
@@ -243,7 +255,9 @@ an individual showcase.
   refraction, packet lighting, motion accents, spectral glass, caustics, and bloom while keeping
   advanced material settings independently adjustable.
 - A duration-weighted, directly navigable chapter timeline ties cinematic camera transitions to
-  congestion, packet loss, rerouting, and probe-confirmed path recovery.
+  congestion, packet loss, rerouting, and probe-confirmed path recovery. Colored event markers
+  choreograph path isolation, compact upstream packet queues, loss scattering, and the complete
+  outbound-probe / returning-confirmation handshake without enlarging the storytelling panel.
 - Exact A-buffer transparency, weighted-blended transparency, and depth-sorted alpha blending
   preserve the strongest supported compositing strategy on each backend.
 

--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -208,14 +208,17 @@ the preferred display format and reduce the extraction threshold.
 Floating-point scene rendering and HDR display presentation are distinct capabilities. An
 `rgba16float` intermediate attachment retains bright, saturated packet emission and narrow glass
 highlights even when the final canvas is standard dynamic range. Extended HDR presentation also
-requires a compatible WebGPU canvas, display, and extended tone-mapping configuration. Increase
-emission, local illumination, and reflective highlights gradually within available scene headroom;
+requires a compatible WebGPU canvas, display, and extended tone-mapping configuration. Configure
+the canvas with `colorFormat: 'rgba16float'`, `colorSpace: 'display-p3'`, and
+`toneMapping: 'extended'`, then set the filmic pass's `maximumLuminance` above one so its final
+output does not clamp the extended highlight range. Increase emission, local illumination, and
+reflective highlights gradually within available scene headroom;
 raise bloom extraction with them and finish with restrained filmic exposure. Multiplying a packet's
 existing red or green emission preserves its color without introducing pastel white halos.
 
-Interactive path highlighting should remain optically subordinate to the material: use a thin,
-low-opacity rim and bounded local illumination instead of filling the entire switch with bright
-color or increasing its transmission opacity.
+Interactive path highlighting should remain optically subordinate to the material: emphasize the
+actual links and packet motion instead of filling switches with artificial light, changing their
+material color, or increasing transmission opacity.
 
 `glassMaterial_getIlluminatedColor(...)` and `reflectiveMaterial_getIlluminatedColor(...)` combine
 their existing optical response with `opticalPointLights`. Existing `getColor(...)` helpers remain

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -140,6 +140,7 @@ import {
   type Vector3
 } from './network';
 import {
+  DEFAULT_NETWORK_HDR_HIGHLIGHT_BOOST,
   DEFAULT_NETWORK_OPTICS_LEVEL,
   getNetworkStoryBeat,
   getNetworkStoryChapter,
@@ -148,6 +149,7 @@ import {
   GUIDED_STORY_SWITCH_INDEX,
   makeNetworkDynamicRangeProfile,
   makeNetworkOpticsProfile,
+  MAX_NETWORK_HDR_HIGHLIGHT_BOOST,
   MAX_NETWORK_OPTICS_LEVEL,
   NETWORK_STORY_CHAPTERS,
   type NetworkDynamicRangeOptions,
@@ -1037,6 +1039,9 @@ class NetworkStoryControls {
   private readonly chapterPositionElement: HTMLSpanElement;
   private readonly opticsButton: HTMLButtonElement;
   private readonly playbackButton: HTMLButtonElement;
+  private readonly hdrHighlightInput: HTMLInputElement;
+  private readonly hdrHighlightLabel: HTMLSpanElement;
+  private readonly hdrHighlightTitle: HTMLSpanElement;
   private readonly visualIntensityInput: HTMLInputElement;
   private readonly visualIntensityLabel: HTMLSpanElement;
   private readonly visualIntensityTitle: HTMLSpanElement;
@@ -1053,7 +1058,9 @@ class NetworkStoryControls {
       onHighlightPlane,
       onHighlightPath,
       onToggleOptics,
+      onHdrHighlightBoostChange,
       onVisualIntensityChange,
+      hdrHighlightBoost,
       visualIntensity
     }: {
       onNext: () => void;
@@ -1063,7 +1070,9 @@ class NetworkStoryControls {
       onHighlightPlane: (planeIndex: number | null) => void;
       onHighlightPath: (pathIndex: number | null) => void;
       onToggleOptics: () => void;
+      onHdrHighlightBoostChange: (highlightBoost: number) => void;
       onVisualIntensityChange: (level: number) => void;
+      hdrHighlightBoost: number;
       visualIntensity: number;
     }
   ) {
@@ -1339,10 +1348,14 @@ class NetworkStoryControls {
 
     const visualIntensityElement = document.createElement('div');
     Object.assign(visualIntensityElement.style, {
+      display: 'grid',
+      gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+      columnGap: '10px',
       margin: '0 0 7px',
       paddingTop: '6px',
       borderTop: '1px solid rgba(137, 166, 211, 0.17)'
     });
+    const visualIntensityControl = document.createElement('div');
     const visualIntensityHeading = document.createElement('div');
     Object.assign(visualIntensityHeading.style, {
       display: 'flex',
@@ -1373,8 +1386,45 @@ class NetworkStoryControls {
     this.visualIntensityInput.addEventListener('input', () => {
       onVisualIntensityChange(Number(this.visualIntensityInput.value));
     });
-    visualIntensityElement.append(visualIntensityHeading, this.visualIntensityInput);
+    visualIntensityControl.append(visualIntensityHeading, this.visualIntensityInput);
+
+    const hdrHighlightControl = document.createElement('div');
+    const hdrHighlightHeading = document.createElement('div');
+    Object.assign(hdrHighlightHeading.style, {
+      display: 'flex',
+      justifyContent: 'space-between',
+      marginBottom: '2px',
+      color: '#91a6c3',
+      fontSize: '9px'
+    });
+    this.hdrHighlightTitle = document.createElement('span');
+    this.hdrHighlightTitle.textContent = 'HDR';
+    this.hdrHighlightLabel = document.createElement('span');
+    hdrHighlightHeading.append(this.hdrHighlightTitle, this.hdrHighlightLabel);
+    this.hdrHighlightInput = document.createElement('input');
+    this.hdrHighlightInput.type = 'range';
+    this.hdrHighlightInput.min = '0';
+    this.hdrHighlightInput.max = '100';
+    this.hdrHighlightInput.step = '1';
+    this.hdrHighlightInput.dataset.networkHdrHighlight = '';
+    this.hdrHighlightInput.setAttribute('aria-label', 'HDR highlight intensity');
+    Object.assign(this.hdrHighlightInput.style, {
+      display: 'block',
+      width: '100%',
+      height: '14px',
+      margin: '0',
+      accentColor: '#ffbf80',
+      cursor: 'pointer'
+    });
+    this.hdrHighlightInput.addEventListener('input', () => {
+      onHdrHighlightBoostChange(
+        (Number(this.hdrHighlightInput.value) / 100) * MAX_NETWORK_HDR_HIGHLIGHT_BOOST
+      );
+    });
+    hdrHighlightControl.append(hdrHighlightHeading, this.hdrHighlightInput);
+    visualIntensityElement.append(visualIntensityControl, hdrHighlightControl);
     this.setVisualIntensity(visualIntensity);
+    this.setHdrHighlightBoost(hdrHighlightBoost);
 
     const actionsElement = document.createElement('div');
     Object.assign(actionsElement.style, {
@@ -1579,19 +1629,29 @@ class NetworkStoryControls {
     const profile = makeNetworkOpticsProfile(level);
     this.visualIntensityInput.value = String(profile.level);
     this.visualIntensityInput.setAttribute('aria-valuetext', profile.label);
-    this.visualIntensityLabel.textContent = `${profile.label.toUpperCase()} · ${profile.level.toFixed(
+    this.visualIntensityLabel.textContent = `${profile.label.toUpperCase()} ${profile.level.toFixed(
       profile.level % 1 === 0 ? 0 : 2
-    )} / ${MAX_NETWORK_OPTICS_LEVEL}`;
+    )}`;
     this.rootElement.dataset.networkVisualStyle = profile.label;
+  }
+
+  setHdrHighlightBoost(highlightBoost: number): void {
+    const percentage = Math.round((highlightBoost / MAX_NETWORK_HDR_HIGHLIGHT_BOOST) * 100);
+    this.hdrHighlightInput.value = String(percentage);
+    this.hdrHighlightInput.setAttribute('aria-valuetext', `${percentage}%`);
+    this.hdrHighlightLabel.textContent = `${percentage}%`;
+    this.rootElement.dataset.networkHdrHighlight = String(percentage);
   }
 
   setDynamicRange(profile: NetworkDynamicRangeProfile): void {
     this.visualIntensityTitle.textContent =
       profile.displayMode === 'extended-hdr'
-        ? 'VISUAL STYLE · HDR'
+        ? 'STYLE · HDR'
         : profile.sceneIsFloatingPoint
-          ? 'VISUAL STYLE · FP16'
-          : 'VISUAL STYLE';
+          ? 'STYLE · FP16'
+          : 'STYLE';
+    this.hdrHighlightTitle.textContent =
+      profile.displayMode === 'extended-hdr' ? 'HDR RANGE' : 'HIGHLIGHTS';
     this.rootElement.dataset.networkDynamicRange = profile.displayMode;
   }
 
@@ -1868,7 +1928,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   bloomIntensity = 1.7;
   bloomThreshold = 0.42;
   exposure = 0.96;
-  hdrHighlightBoost = 0.58;
+  hdrHighlightBoost = DEFAULT_NETWORK_HDR_HIGHLIGHT_BOOST;
 
   constructor({device, width, height}: AnimationProps) {
     super();
@@ -2243,7 +2303,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         onHighlightPath: pathIndex => this.setHighlightedPath(pathIndex),
         onToggleOptics: () =>
           this.setOpticsPanelVisible(this.canvas?.dataset.packetSprayingOpticsExpanded !== 'true'),
+        onHdrHighlightBoostChange: highlightBoost => this.setHdrHighlightBoost(highlightBoost),
         onVisualIntensityChange: level => this.setVisualIntensity(level),
+        hdrHighlightBoost: this.hdrHighlightBoost,
         visualIntensity: this.visualIntensity
       });
       this.storyControls.setDynamicRange(this.dynamicRangeProfile);
@@ -2962,6 +3024,23 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.canvas.dataset.packetSprayingVisualTarget = nextProfile.level.toFixed(2);
       this.canvas.dataset.packetSprayingVisualStyle = nextProfile.label;
     }
+  }
+
+  private setHdrHighlightBoost(highlightBoost: number, synchronizeSettings = true): void {
+    const nextHighlightBoost = Math.max(
+      0,
+      Math.min(highlightBoost, MAX_NETWORK_HDR_HIGHLIGHT_BOOST)
+    );
+    if (this.hdrHighlightBoost === nextHighlightBoost) {
+      return;
+    }
+
+    this.hdrHighlightBoost = nextHighlightBoost;
+    this.storyControls?.setHdrHighlightBoost(nextHighlightBoost);
+    if (synchronizeSettings) {
+      this.settingsPanel.setSettingValue('hdrHighlightBoost', nextHighlightBoost);
+    }
+    this.updateDynamicRangeProfile();
   }
 
   private updateVisualIntensity(animationTime: number): void {
@@ -4638,8 +4717,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
     const hdrHighlightBoost = getChangedSetting(changedSettings, 'hdrHighlightBoost')?.nextValue;
     if (typeof hdrHighlightBoost === 'number') {
-      this.hdrHighlightBoost = hdrHighlightBoost;
-      this.updateDynamicRangeProfile();
+      this.setHdrHighlightBoost(hdrHighlightBoost, false);
     }
   };
 }
@@ -5179,7 +5257,7 @@ function makeSettingsSchema(
             type: 'number',
             persist: 'none',
             min: 0,
-            max: 0.8,
+            max: MAX_NETWORK_HDR_HIGHLIGHT_BOOST,
             step: 0.05
           }
         ]

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -2451,7 +2451,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     }
     const packetEmission =
       this.packetEmission *
-      (0.24 + this.opticsProfile.illumination * 0.76) *
+      (0.72 + this.opticsProfile.illumination * 0.28) *
       this.dynamicRangeProfile.emissionScale;
     if (this.canvas) {
       this.canvas.dataset.packetSprayingPacketEmission = packetEmission.toFixed(2);

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -118,6 +118,7 @@ import {
   makeSwitchPacketEvents,
   makeSwitchProbeConfirmationEvent,
   makeSwitchProbeEvent,
+  makeSwitchQueuePackets,
   makeSwitchTransitionWave,
   makeSwitchGroups,
   makeSwitchArrivals,
@@ -129,6 +130,7 @@ import {
   type NetworkPlaneTelemetry,
   type NetworkPacketEvent,
   type NetworkPathFocus,
+  type NetworkQueuedPacket,
   type NetworkScenario,
   type NetworkSwitchTransitionWave,
   type NetworkSwitchGroupId,
@@ -139,14 +141,19 @@ import {
 } from './network';
 import {
   DEFAULT_NETWORK_OPTICS_LEVEL,
+  getNetworkStoryBeat,
   getNetworkStoryChapter,
   getNetworkStoryProgress,
   getWrappedStoryChapterIndex,
   GUIDED_STORY_SWITCH_INDEX,
+  makeNetworkDynamicRangeProfile,
   makeNetworkOpticsProfile,
   MAX_NETWORK_OPTICS_LEVEL,
   NETWORK_STORY_CHAPTERS,
+  type NetworkDynamicRangeOptions,
+  type NetworkDynamicRangeProfile,
   type NetworkOpticsProfile,
+  type NetworkStoryBeat,
   type NetworkStoryCamera,
   type NetworkStoryChapter
 } from './story';
@@ -1025,12 +1032,15 @@ class NetworkStoryControls {
   private readonly chapterSegments: {
     button: HTMLButtonElement;
     fill: HTMLDivElement;
+    markers: {beat: NetworkStoryBeat; element: HTMLSpanElement}[];
   }[];
   private readonly chapterPositionElement: HTMLSpanElement;
   private readonly opticsButton: HTMLButtonElement;
   private readonly playbackButton: HTMLButtonElement;
   private readonly visualIntensityInput: HTMLInputElement;
   private readonly visualIntensityLabel: HTMLSpanElement;
+  private readonly visualIntensityTitle: HTMLSpanElement;
+  private currentBeatId = '';
   private previousTelemetrySignature = '';
 
   constructor(
@@ -1129,6 +1139,7 @@ class NetworkStoryControls {
 
       const track = document.createElement('div');
       Object.assign(track.style, {
+        position: 'relative',
         height: '4px',
         overflow: 'hidden',
         borderRadius: '2px',
@@ -1143,10 +1154,29 @@ class NetworkStoryControls {
         transition: 'width 100ms linear, background 200ms ease'
       });
       track.appendChild(fill);
+      const markers = chapter.beats.map(beat => {
+        const marker = document.createElement('span');
+        marker.dataset.networkStoryMarker = beat.id;
+        marker.title = beat.title;
+        marker.setAttribute('aria-hidden', 'true');
+        Object.assign(marker.style, {
+          position: 'absolute',
+          top: '0',
+          left: `calc(${beat.position * 100}% - ${beat.position === 0 ? 0 : 1}px)`,
+          width: '3px',
+          height: '4px',
+          borderRadius: '2px',
+          background: beat.color,
+          opacity: '0.64',
+          transition: 'opacity 180ms ease, box-shadow 180ms ease'
+        });
+        track.appendChild(marker);
+        return {beat, element: marker};
+      });
       segmentButton.appendChild(track);
       segmentButton.addEventListener('click', () => onSelectChapter(chapterIndex));
       chapterTimeline.appendChild(segmentButton);
-      return {button: segmentButton, fill};
+      return {button: segmentButton, fill, markers};
     });
 
     const telemetryElement = document.createElement('div');
@@ -1321,10 +1351,10 @@ class NetworkStoryControls {
       color: '#91a6c3',
       fontSize: '9px'
     });
-    const visualIntensityTitle = document.createElement('span');
-    visualIntensityTitle.textContent = 'VISUAL STYLE';
+    this.visualIntensityTitle = document.createElement('span');
+    this.visualIntensityTitle.textContent = 'VISUAL STYLE';
     this.visualIntensityLabel = document.createElement('span');
-    visualIntensityHeading.append(visualIntensityTitle, this.visualIntensityLabel);
+    visualIntensityHeading.append(this.visualIntensityTitle, this.visualIntensityLabel);
     this.visualIntensityInput = document.createElement('input');
     this.visualIntensityInput.type = 'range';
     this.visualIntensityInput.min = '0';
@@ -1418,6 +1448,25 @@ class NetworkStoryControls {
       segment.fill.style.background = segmentIndex === chapterIndex ? '#a3c7ff' : '#638cc5';
     }
     this.rootElement.dataset.networkStoryProgress = progress.overallProgress.toFixed(3);
+  }
+
+  updateBeat(chapter: NetworkStoryChapter, beat: NetworkStoryBeat | null): void {
+    const nextBeatId = beat?.id ?? '';
+    if (this.currentBeatId === nextBeatId) {
+      return;
+    }
+
+    this.currentBeatId = nextBeatId;
+    this.descriptionElement.textContent = beat?.description ?? chapter.description;
+    this.rootElement.dataset.networkStoryBeat = nextBeatId;
+
+    for (const segment of this.chapterSegments) {
+      for (const marker of segment.markers) {
+        const isCurrentBeat = marker.beat === beat;
+        marker.element.style.opacity = isCurrentBeat ? '1' : '0.64';
+        marker.element.style.boxShadow = isCurrentBeat ? `0 0 6px ${marker.beat.color}` : 'none';
+      }
+    }
   }
 
   updateTelemetry(
@@ -1534,6 +1583,16 @@ class NetworkStoryControls {
       profile.level % 1 === 0 ? 0 : 2
     )} / ${MAX_NETWORK_OPTICS_LEVEL}`;
     this.rootElement.dataset.networkVisualStyle = profile.label;
+  }
+
+  setDynamicRange(profile: NetworkDynamicRangeProfile): void {
+    this.visualIntensityTitle.textContent =
+      profile.displayMode === 'extended-hdr'
+        ? 'VISUAL STYLE · HDR'
+        : profile.sceneIsFloatingPoint
+          ? 'VISUAL STYLE · FP16'
+          : 'VISUAL STYLE';
+    this.rootElement.dataset.networkDynamicRange = profile.displayMode;
   }
 
   destroy(): void {
@@ -1729,6 +1788,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     )
   );
   private endpointSignalDefinitions: NetworkEndpointSignal[] = [];
+  private queuedPacketDefinitions: NetworkQueuedPacket[] = [];
   orbitControls: OrbitControls | null = null;
   nodePopup: NetworkNodePopup | null = null;
   opticsPanel: NetworkOpticsPanel | null = null;
@@ -1756,14 +1816,24 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private guidedStoryCamera: NetworkStoryCamera | null = null;
   private guidedStoryCameraTransitionEndsAt = 0;
   private guidedStoryPreviousCameraTime: number | null = null;
+  private currentStoryBeat: NetworkStoryBeat | null = null;
   private highlightedPlaneIndex: number | null = null;
   private highlightedPathIndex: number | null = null;
+  private manualHighlightedPlaneIndex: number | null = null;
+  private manualHighlightedPathIndex: number | null = null;
+  private storyHighlightedPlaneIndex: number | null = null;
+  private storyHighlightedPathIndex: number | null = null;
   private previousPlaneHighlightTime: number | null = null;
   private previousVisualIntensityTime: number | null = null;
   private currentVisualIntensity = DEFAULT_NETWORK_OPTICS_LEVEL;
   private opticsProfile: NetworkOpticsProfile = makeNetworkOpticsProfile(
     DEFAULT_NETWORK_OPTICS_LEVEL
   );
+  private readonly dynamicRangeOptions: Omit<
+    NetworkDynamicRangeOptions,
+    'highlightBoost' | 'visualIntensity'
+  >;
+  private dynamicRangeProfile: NetworkDynamicRangeProfile;
 
   transparencyMode: TransparencyMode;
   visualIntensity = DEFAULT_NETWORK_OPTICS_LEVEL;
@@ -1771,24 +1841,24 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   speed = 0.85;
   orbit = 0.08;
   glassIndexOfRefraction = 1.48;
-  glassRoughness = 0.11;
+  glassRoughness = 0.045;
   glassDispersion = 0.026;
   glassThickness = 1.16;
   glassRefractionStrength = 1.32;
-  glassFresnelStrength = 1.28;
-  glassClearcoatStrength = 1.15;
+  glassFresnelStrength = 0.96;
+  glassClearcoatStrength = 0.68;
   glassIridescenceStrength = 0.16;
-  glassInternalReflectionStrength = 0.72;
-  glassTransmissionStrength = 1.12;
-  glassEnvironmentIntensity = 1.25;
+  glassInternalReflectionStrength = 0.36;
+  glassTransmissionStrength = 1.32;
+  glassEnvironmentIntensity = 0.68;
   glassVolumeThickness = 1;
-  glassRoughTransmissionStrength = 0.85;
-  glassSpectralAbsorptionStrength = 0.42;
+  glassRoughTransmissionStrength = 0.2;
+  glassSpectralAbsorptionStrength = 0.28;
   glassThinFilmThickness = 420;
   glassThinFilmStrength = 0.22;
-  glassVolumeScatteringStrength = 0.38;
-  glassDynamicReflectionStrength = 0.38;
-  glassSecondaryBounceStrength = 0.55;
+  glassVolumeScatteringStrength = 0.14;
+  glassDynamicReflectionStrength = 0.2;
+  glassSecondaryBounceStrength = 0.24;
   glassFaultDistortionStrength = 0.42;
   packetEmission = 5.2;
   packetTrailLength = 0.19;
@@ -1808,6 +1878,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   bloomIntensity = 1.7;
   bloomThreshold = 0.42;
   exposure = 0.96;
+  hdrHighlightBoost = 0.45;
 
   constructor({device, width, height}: AnimationProps) {
     super();
@@ -1818,6 +1889,19 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     }
 
     this.sceneColorFormat = getSceneColorFormat(device);
+    this.dynamicRangeOptions = {
+      deviceType: device.type,
+      displaySupportsHighDynamicRange:
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(dynamic-range: high)').matches,
+      presentationColorFormat: String(device.preferredColorFormat),
+      sceneColorFormat: this.sceneColorFormat
+    };
+    this.dynamicRangeProfile = makeNetworkDynamicRangeProfile({
+      ...this.dynamicRangeOptions,
+      highlightBoost: this.hdrHighlightBoost,
+      visualIntensity: this.currentVisualIntensity
+    });
     const supportsABuffer = getABufferSupport(device).supported;
     const supportsWeightedBlending = getWBOITSupport(device).supported;
     this.transparencyMode = supportsABuffer
@@ -2126,7 +2210,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         causticFocus: this.causticFocus,
         bloomIntensity: this.bloomIntensity,
         bloomThreshold: this.bloomThreshold,
-        exposure: this.exposure
+        exposure: this.exposure,
+        hdrHighlightBoost: this.hdrHighlightBoost
       },
       onSettingsChange: this.handleSettingsChange
     });
@@ -2142,6 +2227,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       canvas.dataset.packetSprayingGpuArchitecture = device.info.gpuArchitecture || '';
       canvas.dataset.packetSprayingAdapterVendor = device.info.vendor;
       canvas.dataset.packetSprayingFallback = String(Boolean(device.info.fallback));
+      canvas.dataset.packetSprayingDynamicRange = this.dynamicRangeProfile.displayMode;
+      canvas.dataset.packetSprayingSceneColorFormat = this.sceneColorFormat;
+      canvas.dataset.packetSprayingHighlightBoost =
+        this.dynamicRangeProfile.highlightBoost.toFixed(3);
       canvas.dataset.packetSprayingGlassGroups = this.glassGroups.map(group => group.id).join(',');
       this.nodePopup = new NetworkNodePopup(canvas);
       this.orbitControls = new OrbitControls(canvas, {
@@ -2173,6 +2262,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         onVisualIntensityChange: level => this.setVisualIntensity(level),
         visualIntensity: this.visualIntensity
       });
+      this.storyControls.setDynamicRange(this.dynamicRangeProfile);
       canvas.dataset.packetSprayingHighlightedPlane = '';
       canvas.dataset.packetSprayingHighlightedPath = '';
       canvas.dataset.packetSprayingPlaneHighlightStrength = '0.000';
@@ -2180,6 +2270,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       canvas.dataset.packetSprayingHighlightedSwitches = '0';
       canvas.dataset.packetSprayingHighlightedPathSwitches = '0';
       canvas.dataset.packetSprayingHighlightedPathLinks = '0';
+      canvas.dataset.packetSprayingQueuedPackets = '0';
+      canvas.dataset.packetSprayingStoryBeat = '';
       canvas.dataset.packetSprayingOpticsExpanded = 'false';
       canvas.dataset.packetSprayingVisualIntensity = this.visualIntensity.toFixed(2);
       canvas.dataset.packetSprayingVisualTarget = this.visualIntensity.toFixed(2);
@@ -2251,8 +2343,15 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       dispersion: this.glassDispersion * this.opticsProfile.spectral,
       thickness: this.glassThickness,
       refractionStrength: this.glassRefractionStrength * this.opticsProfile.refraction,
-      fresnelStrength: this.glassFresnelStrength * (0.2 + this.opticsProfile.surface * 0.8),
-      clearcoatStrength: this.glassClearcoatStrength * this.opticsProfile.surface,
+      reflectionStrength: 0.5,
+      fresnelStrength:
+        this.glassFresnelStrength *
+        (0.2 + this.opticsProfile.surface * 0.8) *
+        this.dynamicRangeProfile.specularScale,
+      clearcoatStrength:
+        this.glassClearcoatStrength *
+        this.opticsProfile.surface *
+        this.dynamicRangeProfile.specularScale,
       iridescenceStrength: this.glassIridescenceStrength * this.opticsProfile.spectral,
       internalReflectionStrength:
         this.glassInternalReflectionStrength *
@@ -2268,7 +2367,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       backfaceTexture: this.glassBackfaceTexture,
       environmentTexture: this.environmentTexture,
       environmentIntensity:
-        this.glassEnvironmentIntensity * (0.16 + this.opticsProfile.surface * 0.84),
+        this.glassEnvironmentIntensity *
+        (0.16 + this.opticsProfile.surface * 0.84) *
+        this.dynamicRangeProfile.specularScale,
       thicknessStrength: this.glassVolumeThickness * (0.45 + this.opticsProfile.refraction * 0.55),
       roughTransmissionStrength: this.glassRoughTransmissionStrength * this.opticsProfile.spectral,
       spectralAbsorptionStrength:
@@ -2289,7 +2390,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     const packetLights = this.makePacketLights();
     const pointLightProps: OpticalPointLightsProps = {
       lights: packetLights,
-      intensity: this.packetLightIntensity * this.opticsProfile.illumination
+      intensity:
+        this.packetLightIntensity *
+        this.opticsProfile.illumination *
+        this.dynamicRangeProfile.illuminationScale
     };
     const causticLenses =
       this.opticsProfile.caustics > 0.002
@@ -2306,13 +2410,16 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.emissiveShaderInputs.setProps({
       app: uniforms,
       emissiveMaterial: {
-        intensity: this.packetEmission * (0.24 + this.opticsProfile.illumination * 0.76),
+        intensity:
+          this.packetEmission *
+          (0.24 + this.opticsProfile.illumination * 0.76) *
+          this.dynamicRangeProfile.emissionScale,
         rimStrength: 0.12 + this.opticsProfile.surface * 0.2
       }
     });
     this.planeHighlightShaderInputs.setProps({
       app: uniforms,
-      emissiveMaterial: {intensity: 2.1, rimStrength: 3.6}
+      emissiveMaterial: {intensity: 0.16, rimStrength: 2.4}
     });
     this.reflectiveShaderInputs.setProps({
       app: uniforms,
@@ -2462,12 +2569,17 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         bloomExtract: {
           threshold:
             this.sceneColorFormat === 'rgba16float'
-              ? this.bloomThreshold
+              ? this.bloomThreshold * this.dynamicRangeProfile.bloomThresholdScale
               : Math.min(this.bloomThreshold, 0.38)
         },
         bloomBlur: {radius: 4},
-        bloomComposite: {intensity: this.bloomIntensity * this.opticsProfile.bloom},
-        toneMapping: {exposure: this.exposure}
+        bloomComposite: {
+          intensity:
+            this.bloomIntensity *
+            this.opticsProfile.bloom *
+            this.dynamicRangeProfile.bloomIntensityScale
+        },
+        toneMapping: {exposure: this.exposure * this.dynamicRangeProfile.exposureScale}
       }
     });
 
@@ -2697,6 +2809,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.guidedStoryCamera = getNetworkStoryChapter(this.guidedStoryChapterIndex).camera;
     this.guidedStoryCameraTransitionEndsAt = this.animationTime + 1.4;
     this.guidedStoryPreviousCameraTime = null;
+    this.currentStoryBeat = null;
 
     const switchIndex = GUIDED_STORY_SWITCH_INDEX;
     const chapter = getNetworkStoryChapter(this.guidedStoryChapterIndex);
@@ -2766,6 +2879,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.nextSwitchProbeTimes.clear();
     this.recoveryProbeCompletionTimes.clear();
     this.networkPacketEvents.splice(0, this.networkPacketEvents.length);
+    this.queuedPacketDefinitions = [];
     this.switchTransitionWaves.splice(0, this.switchTransitionWaves.length);
     this.updateSwitchColors();
     this.updateHealthyRoutes();
@@ -2787,12 +2901,20 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     const chapterElapsedTime = this.guidedStoryPlaying
       ? animationTime - this.guidedStoryChapterStartedAt
       : this.guidedStoryElapsedAtPause;
+    const chapter = getNetworkStoryChapter(this.guidedStoryChapterIndex);
+    const beat = getNetworkStoryBeat(this.guidedStoryChapterIndex, chapterElapsedTime);
+    if (beat !== this.currentStoryBeat) {
+      this.currentStoryBeat = beat;
+      this.storyControls?.updateBeat(chapter, beat);
+      this.setStoryHighlight(beat?.planeIndex ?? null, beat?.pathIndex ?? null);
+    }
     this.storyControls?.updateProgress(this.guidedStoryChapterIndex, chapterElapsedTime);
     if (this.canvas) {
       this.canvas.dataset.packetSprayingStoryProgress = getNetworkStoryProgress(
         this.guidedStoryChapterIndex,
         chapterElapsedTime
       ).overallProgress.toFixed(3);
+      this.canvas.dataset.packetSprayingStoryBeat = beat?.id ?? '';
     }
 
     if (
@@ -2810,6 +2932,12 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     const smoothing = 1 - Math.exp(-elapsedTime * 3.8);
     const controls = this.orbitControls;
     const camera = this.guidedStoryCamera;
+    const cameraTarget: Vector3 = [...camera.target];
+    if (beat?.pathIndex !== undefined) {
+      cameraTarget[2] += SPINE_POSITIONS[beat.pathIndex][2] * 0.2;
+    } else if (beat?.planeIndex !== undefined) {
+      cameraTarget[2] += beat.planeIndex === 0 ? 0.32 : -0.32;
+    }
     const yawDelta = Math.atan2(
       Math.sin(camera.yaw - controls.yaw),
       Math.cos(camera.yaw - controls.yaw)
@@ -2819,9 +2947,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     controls.pitch += (camera.pitch - controls.pitch) * smoothing;
     controls.distance += (camera.distance - controls.distance) * smoothing;
     controls.props.target = [
-      controls.props.target[0] + (camera.target[0] - controls.props.target[0]) * smoothing,
-      controls.props.target[1] + (camera.target[1] - controls.props.target[1]) * smoothing,
-      controls.props.target[2] + (camera.target[2] - controls.props.target[2]) * smoothing
+      controls.props.target[0] + (cameraTarget[0] - controls.props.target[0]) * smoothing,
+      controls.props.target[1] + (cameraTarget[1] - controls.props.target[1]) * smoothing,
+      controls.props.target[2] + (cameraTarget[2] - controls.props.target[2]) * smoothing
     ];
     this.guidedStoryPreviousCameraTime = animationTime;
   }
@@ -2829,6 +2957,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private updateGuidedStoryControls(): void {
     const chapter = getNetworkStoryChapter(this.guidedStoryChapterIndex);
     this.storyControls?.update(chapter, this.guidedStoryChapterIndex, this.guidedStoryPlaying);
+    this.storyControls?.updateBeat(chapter, this.currentStoryBeat);
     this.storyControls?.updateProgress(
       this.guidedStoryChapterIndex,
       this.guidedStoryElapsedAtPause
@@ -2874,6 +3003,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     }
 
     this.opticsProfile = makeNetworkOpticsProfile(this.currentVisualIntensity);
+    this.updateDynamicRangeProfile();
     if (this.canvas) {
       this.canvas.dataset.packetSprayingVisualIntensity = this.currentVisualIntensity.toFixed(2);
       this.canvas.dataset.packetSprayingVisualBloom = this.opticsProfile.bloom.toFixed(2);
@@ -2882,7 +3012,51 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     }
   }
 
+  private updateDynamicRangeProfile(): void {
+    this.dynamicRangeProfile = makeNetworkDynamicRangeProfile({
+      ...this.dynamicRangeOptions,
+      highlightBoost: this.hdrHighlightBoost,
+      visualIntensity: this.currentVisualIntensity
+    });
+    this.storyControls?.setDynamicRange(this.dynamicRangeProfile);
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingDynamicRange = this.dynamicRangeProfile.displayMode;
+      this.canvas.dataset.packetSprayingHighlightBoost =
+        this.dynamicRangeProfile.highlightBoost.toFixed(3);
+    }
+  }
+
   private setHighlightedPlane(planeIndex: number | null): void {
+    this.manualHighlightedPlaneIndex = planeIndex;
+    this.synchronizeStoryHighlights();
+  }
+
+  private setHighlightedPath(pathIndex: number | null): void {
+    this.manualHighlightedPathIndex = pathIndex;
+    this.synchronizeStoryHighlights();
+  }
+
+  private setStoryHighlight(planeIndex: number | null, pathIndex: number | null): void {
+    this.storyHighlightedPlaneIndex = planeIndex;
+    this.storyHighlightedPathIndex = pathIndex;
+    this.synchronizeStoryHighlights();
+  }
+
+  private synchronizeStoryHighlights(): void {
+    const hasManualHighlight =
+      this.manualHighlightedPlaneIndex !== null || this.manualHighlightedPathIndex !== null;
+    const planeIndex = hasManualHighlight
+      ? this.manualHighlightedPlaneIndex
+      : this.storyHighlightedPlaneIndex;
+    const pathIndex = hasManualHighlight
+      ? this.manualHighlightedPathIndex
+      : this.storyHighlightedPathIndex;
+
+    this.updateHighlightedPlane(planeIndex);
+    this.updateHighlightedPath(pathIndex);
+  }
+
+  private updateHighlightedPlane(planeIndex: number | null): void {
     if (this.highlightedPlaneIndex === planeIndex) {
       return;
     }
@@ -2895,7 +3069,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     }
   }
 
-  private setHighlightedPath(pathIndex: number | null): void {
+  private updateHighlightedPath(pathIndex: number | null): void {
     if (this.highlightedPathIndex === pathIndex) {
       return;
     }
@@ -3135,34 +3309,11 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private updateSwitchColors(): void {
     for (const group of this.glassGroups) {
       const matrices = flattenMatrices(group.instances.map(instance => instance.matrix));
-      const colors = flattenColors(
-        group.instances.map((instance, instanceIndex) =>
-          this.getHighlightedSwitchColor(instance.color, group.switchIndices[instanceIndex])
-        )
-      );
+      const colors = flattenColors(group.instances.map(instance => instance.color));
       group.sorted.updateInstances(matrices, colors);
       group.aBuffer?.updateInstances(matrices, colors);
       group.weightedBlended?.updateInstances(matrices, colors);
     }
-  }
-
-  private getHighlightedSwitchColor(color: Color, switchIndex: number): Color {
-    const planeIndex = this.switchPlaneIndices.get(switchIndex);
-    const planeStrength = planeIndex === undefined ? 0 : this.planeHighlightStrengths[planeIndex];
-    const pathStrength = this.getPathSwitchHighlightStrength(switchIndex);
-    const highlightStrength = Math.max(planeStrength, pathStrength);
-
-    if (highlightStrength < 0.001) {
-      return color;
-    }
-
-    const blueStrength = planeStrength * (1 - pathStrength);
-    return [
-      color[0] + (0.8 - color[0]) * blueStrength * 0.56 + pathStrength * 0.08,
-      color[1] + (0.92 - color[1]) * blueStrength * 0.56 + pathStrength * 0.24,
-      color[2] + (1.15 - color[2]) * blueStrength * 0.56 + pathStrength * 0.31,
-      Math.min(color[3] + highlightStrength * 0.065, 0.68)
-    ];
   }
 
   private getPathSwitchHighlightStrength(switchIndex: number): number {
@@ -3192,7 +3343,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     );
     this.previousPlaneHighlightTime = animationTime;
 
-    let requiresColorUpdate = false;
+    let requiresHighlightUpdate = false;
     for (let planeIndex = 0; planeIndex < this.planeHighlightStrengths.length; planeIndex++) {
       const targetStrength = this.highlightedPlaneIndex === planeIndex ? 1 : 0;
       const currentStrength = this.planeHighlightStrengths[planeIndex];
@@ -3208,7 +3359,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
       if (Math.abs(settledStrength - currentStrength) > 0.0001) {
         this.planeHighlightStrengths[planeIndex] = settledStrength;
-        requiresColorUpdate = true;
+        requiresHighlightUpdate = true;
       }
     }
 
@@ -3227,11 +3378,11 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
       if (Math.abs(settledStrength - currentStrength) > 0.0001) {
         this.pathHighlightStrengths[pathIndex] = settledStrength;
-        requiresColorUpdate = true;
+        requiresHighlightUpdate = true;
       }
     }
 
-    if (requiresColorUpdate) {
+    if (requiresHighlightUpdate) {
       this.planeHighlightMatrices.fill(0);
       this.planeHighlightColors.fill(0);
       let highlightedSwitchCount = 0;
@@ -3253,7 +3404,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
             : switchIndex < LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length
               ? AGGREGATION_SWITCH_RADIUS
               : SPINE_SWITCH_RADIUS;
-        const shellRadius = switchRadius * (1.025 + highlightStrength * 0.055);
+        const shellRadius = switchRadius * (1.004 + highlightStrength * 0.01);
         this.planeHighlightMatrices.set(
           makeObjectMatrix(this.glassInstances[switchIndex].position, [
             shellRadius,
@@ -3264,10 +3415,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         );
         this.planeHighlightColors.set(
           [
-            0.17 * planeStrength + 0.23 * pathStrength,
-            0.42 * planeStrength + 0.69 * pathStrength,
-            0.94 * planeStrength + 0.95 * pathStrength,
-            Math.min(0.19 * planeStrength + 0.24 * pathStrength, 0.32)
+            0.03 * planeStrength + 0.035 * pathStrength,
+            0.075 * planeStrength + 0.09 * pathStrength,
+            0.2 * planeStrength + 0.22 * pathStrength,
+            Math.min(0.007 * planeStrength + 0.009 * pathStrength, 0.013)
           ],
           switchIndex * 4
         );
@@ -3277,7 +3428,6 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         }
       }
 
-      this.updateSwitchColors();
       this.updateFocusedHostColors();
       if (this.canvas) {
         this.canvas.dataset.packetSprayingPlaneHighlightStrength = Math.max(
@@ -3750,11 +3900,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       );
     group.sorted.updateInstances(
       flattenMatrices(sortedInstances.map(({instance}) => instance.matrix)),
-      flattenColors(
-        sortedInstances.map(({instance, switchIndex}) =>
-          this.getHighlightedSwitchColor(instance.color, switchIndex)
-        )
-      )
+      flattenColors(sortedInstances.map(({instance}) => instance.color))
     );
   }
 
@@ -3775,6 +3921,20 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       instanceIndex++;
     };
 
+    this.queuedPacketDefinitions = [...this.congestedSwitchIndices].flatMap(switchIndex =>
+      makeSwitchQueuePackets(this.packetDefinitions, switchIndex, animationTime)
+    );
+    for (const queuedPacket of this.queuedPacketDefinitions) {
+      addParticle(
+        queuedPacket.position,
+        0.034 + queuedPacket.strength * 0.009,
+        makeBalancedEmissionColor(queuedPacket.color, queuedPacket.strength * 0.84)
+      );
+    }
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingQueuedPackets = String(this.queuedPacketDefinitions.length);
+    }
+
     for (const event of this.networkPacketEvents) {
       const age = animationTime - event.startedAt;
       if (age < 0 || age > event.duration) {
@@ -3789,10 +3949,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
       if (event.kind === 'dropped-payload' || event.kind === 'trimmed-payload') {
         const progress = age / event.duration;
-        const fragmentCount = event.kind === 'dropped-payload' ? 8 : 6;
-        const spread = (event.kind === 'dropped-payload' ? 1.15 : 0.78) * age;
+        const fragmentCount = event.kind === 'dropped-payload' ? 10 : 6;
+        const spread = (event.kind === 'dropped-payload' ? 1.42 : 0.78) * age;
         const fragmentRadius =
-          (event.kind === 'dropped-payload' ? 0.036 : 0.028) * (1 - progress * 0.8);
+          (event.kind === 'dropped-payload' ? 0.043 : 0.028) * (1 - progress * 0.78);
         const fragmentColor = makeBalancedEmissionColor(
           event.color,
           Math.max(0, (1 - progress) * 0.82)
@@ -3833,8 +3993,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         const distance = Math.min(event.route.totalLength, age * PACKET_TRAVEL_SPEED * 1.16);
         addParticle(
           getPointAlongRoute(event.route, distance / event.route.totalLength),
-          0.046,
-          makeBalancedEmissionColor(event.color, 0.92)
+          0.041,
+          makeBalancedEmissionColor(event.color, 0.98)
         );
         continue;
       }
@@ -3848,7 +4008,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
           : startDistance + (endDistance - startDistance) * progress;
       addParticle(
         getPointAlongRoute(event.route, distance / event.route.totalLength),
-        event.kind === 'probe-confirmation' ? 0.026 : 0.021,
+        event.kind === 'probe-confirmation' ? 0.035 : 0.029,
         event.kind === 'probe-confirmation'
           ? makeBalancedEmissionColor(event.color, event.color[3])
           : event.color
@@ -4102,25 +4262,16 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       intensity: signal.strength * this.endpointSignalIntensity * this.opticsProfile.motion * 0.65,
       radius: this.packetLightRadius * 0.65
     }));
-    const planeHighlightLights: OpticalPointLight[] = [];
-    for (let switchIndex = 0; switchIndex < this.glassInstances.length; switchIndex++) {
-      const planeIndex = this.switchPlaneIndices.get(switchIndex);
-      const highlightStrength =
-        planeIndex === undefined ? 0 : this.planeHighlightStrengths[planeIndex];
-      if (highlightStrength < 0.035) {
-        continue;
-      }
-
-      planeHighlightLights.push({
-        position: this.glassInstances[switchIndex].position,
-        color: [0.24, 0.48, 1],
-        intensity: highlightStrength * 1.05,
-        radius: this.packetLightRadius * 0.82
-      });
-    }
-
+    const queueLights: OpticalPointLight[] = this.queuedPacketDefinitions
+      .slice(0, 4)
+      .map(packet => ({
+        position: packet.position,
+        color: [packet.color[0], packet.color[1], packet.color[2]],
+        intensity: packet.strength * this.opticsProfile.motion * 0.74,
+        radius: this.packetLightRadius * 0.58
+      }));
     return [
-      ...planeHighlightLights,
+      ...queueLights,
       ...lights,
       ...endpointLights,
       ...transitionLights,
@@ -4514,6 +4665,12 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     if (typeof exposure === 'number') {
       this.exposure = exposure;
     }
+
+    const hdrHighlightBoost = getChangedSetting(changedSettings, 'hdrHighlightBoost')?.nextValue;
+    if (typeof hdrHighlightBoost === 'number') {
+      this.hdrHighlightBoost = hdrHighlightBoost;
+      this.updateDynamicRangeProfile();
+    }
   };
 }
 
@@ -4522,12 +4679,12 @@ const PACKET_SPRAYING_ARTICLE_URL = 'https://openai.com/index/mrc-supercomputer-
 const PACKET_SPRAYING_OVERVIEW_HTML = `\
 <p><strong>Network Packet Spraying</strong></p>
 <p><strong>Two conversations, many routes.</strong> The two servers on the right send independent red and green transfers to two destination servers on the left.</p>
-<p>The guided network tour steps through packet spraying, congestion, switch failure, retransmission, and probe-confirmed recovery. Follow the animated chapter timeline or select any chapter directly.</p>
+<p>The guided network tour steps through packet spraying, congestion, switch failure, retransmission, and probe-confirmed recovery. Colored timeline markers automatically choreograph each route, queue, loss, and control-packet event; select any chapter directly.</p>
 <p>The visual-style slider moves smoothly from a packet-first diagram through clear and cinematic glass to spectral lighting, focused caustics, and full optical fireworks. Individual material controls remain available in Settings.</p>
 <p>The visualization has two physical switch planes, each containing four Tier 0 access switches and four Tier 1 aggregation switches. Four larger spine switches connect those planes and provide four independent backbone paths for alternating red and green packets.</p>
 <p>The live fabric monitor shows red and green allocation across both physical planes and each of the four backbone paths. Hover or focus a plane to illuminate all eight switches across its two tiers, or inspect an individual path to trace both complete server-to-server routes through its five switches and eight links. Under pressure, adaptive routing moves most packets away from a congested path without retiring it; an offline or recovering path carries none until its control handshake succeeds.</p>
 <p>Click any glass switch to move it from healthy to orange and congested, then red and failed. Clicking a failed switch repairs it, but its path stays offline while a blue recovery probe travels to the switch and a cyan acknowledgment returns to its source.</p>
-<p>An orange switch trims overloaded packet payloads while their smaller headers continue. A red switch briefly loses in-flight packets before MRC retires the failed path, retransmits over healthy routes, and sends occasional recovery probes.</p>
+<p>An orange switch gathers a short alternating red/green packet queue and trims overloaded payloads while their smaller headers continue. A red switch visibly scatters in-flight packets before MRC retires the failed path, retransmits over healthy routes, and sends occasional recovery probes.</p>
 <p>Muted red and green cubes identify each conversation's source and destination; blue cubes are inactive servers. Each active server emits a restrained colored pulse when it launches or receives a packet. Glass spheres are switches, and fabric links softly brighten with red or green light only while packets are traveling through them. Directional light wakes remain inside each link, congested switches breathe amber, and failures or confirmed recoveries send restrained red or cyan waves through nearby glass. Emissive packets leave short trails, reflect inside nearby glass, and project focused colored caustics onto adjacent reflective surfaces.</p>
 <p><a href="${PACKET_SPRAYING_ARTICLE_URL}" target="_blank" rel="noopener noreferrer">Read OpenAI's supercomputer networking and MRC article</a></p>`;
 
@@ -4541,7 +4698,7 @@ const PACKET_SPRAYING_OPTICS_HTML = `\
 <h3>Light from moving packets</h3>
 <p>Red and green packets emit local light into nearby glass. Colored volume scattering, moving scene reflections, secondary internal bounces, and focused raster caustics transfer that energy onto switches, reflective tubes, and metallic servers.</p>
 <h3>Compositing and display</h3>
-<p>Hardware capability selects exact A-buffer transparency, weighted-blended order-independent transparency, or depth-sorted glass. An HDR framebuffer preserves bright details before selective multiscale bloom and filmic tone mapping.</p>
+<p>Hardware capability selects exact A-buffer transparency, weighted-blended order-independent transparency, or depth-sorted glass. A floating-point framebuffer preserves saturated packet cores and polished glass reflections before selective multiscale bloom and filmic tone mapping. Compatible extended-range WebGPU presentation can preserve additional display highlights when available; ordinary WebGL and SDR displays remain balanced and clearly labeled.</p>
 <p><strong>Everything is composable:</strong> reusable WGSL and GLSL shader modules expose bounded controls for optics, point lights, caustics, transparency, bloom, and exposure.</p>`;
 
 const PACKET_SPRAYING_BACKGROUND_HTML = `\
@@ -5044,6 +5201,15 @@ function makeSettingsSchema(
             persist: 'none',
             min: 0.25,
             max: 2.5,
+            step: 0.05
+          },
+          {
+            name: 'hdrHighlightBoost',
+            label: 'HDR Highlight Boost',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 0.8,
             step: 0.05
           }
         ]

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -149,6 +149,7 @@ import {
   GUIDED_STORY_SWITCH_INDEX,
   makeNetworkDynamicRangeProfile,
   makeNetworkOpticsProfile,
+  makeNetworkSwitchHighlightColor,
   MAX_NETWORK_HDR_HIGHLIGHT_BOOST,
   MAX_NETWORK_OPTICS_LEVEL,
   NETWORK_STORY_CHAPTERS,
@@ -3369,7 +3370,16 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private updateSwitchColors(): void {
     for (const group of this.glassGroups) {
       const matrices = flattenMatrices(group.instances.map(instance => instance.matrix));
-      const colors = flattenColors(group.instances.map(instance => instance.color));
+      const colors = flattenColors(
+        group.instances.map((instance, instanceIndex) => {
+          const switchIndex = group.switchIndices[instanceIndex];
+          const planeIndex = this.switchPlaneIndices.get(switchIndex);
+          const planeStrength =
+            planeIndex === undefined ? 0 : this.planeHighlightStrengths[planeIndex];
+          const pathStrength = this.getPathSwitchHighlightStrength(switchIndex);
+          return makeNetworkSwitchHighlightColor(instance.color, planeStrength, pathStrength);
+        })
+      );
       group.sorted.updateInstances(matrices, colors);
       group.aBuffer?.updateInstances(matrices, colors);
       group.weightedBlended?.updateInstances(matrices, colors);
@@ -3462,6 +3472,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         }
       }
 
+      this.updateSwitchColors();
       this.updateFocusedHostColors();
       if (this.canvas) {
         this.canvas.dataset.packetSprayingPlaneHighlightStrength = Math.max(

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -1642,10 +1642,6 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     app: AppUniforms;
     emissiveMaterial: EmissiveMaterialProps;
   }>({app: appShaderModule, emissiveMaterial});
-  readonly planeHighlightShaderInputs = new ShaderInputs<{
-    app: AppUniforms;
-    emissiveMaterial: EmissiveMaterialProps;
-  }>({app: appShaderModule, emissiveMaterial});
   readonly glassShaderInputs = new ShaderInputs<{
     app: AppUniforms;
     glassMaterial: GlassMaterialProps;
@@ -1745,10 +1741,6 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     app: AppUniforms;
     emissiveMaterial: EmissiveMaterialProps;
   }>;
-  readonly planeHighlightShells: InstancedMesh<{
-    app: AppUniforms;
-    emissiveMaterial: EmissiveMaterialProps;
-  }>;
   readonly storyPackets: InstancedMesh<{
     app: AppUniforms;
     emissiveMaterial: EmissiveMaterialProps;
@@ -1771,8 +1763,6 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   readonly switchTransitionMatrices = new Float32Array(MAX_SWITCH_TRANSITION_WAVES * 16);
   readonly switchTransitionColors = new Float32Array(MAX_SWITCH_TRANSITION_WAVES * 4);
   readonly switchTransitionWaves: NetworkSwitchTransitionWave[] = [];
-  readonly planeHighlightMatrices = new Float32Array(SWITCH_POSITIONS.length * 16);
-  readonly planeHighlightColors = new Float32Array(SWITCH_POSITIONS.length * 4);
   readonly causticLensLightColors = new Float32Array(SWITCH_POSITIONS.length * 3);
   readonly storyPacketMatrices = new Float32Array(MAX_STORY_PACKET_INSTANCES * 16);
   readonly storyPacketColors = new Float32Array(MAX_STORY_PACKET_INSTANCES * 4);
@@ -1845,20 +1835,20 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   glassDispersion = 0.026;
   glassThickness = 1.16;
   glassRefractionStrength = 1.32;
-  glassFresnelStrength = 0.96;
-  glassClearcoatStrength = 0.68;
+  glassFresnelStrength = 1.08;
+  glassClearcoatStrength = 0.84;
   glassIridescenceStrength = 0.16;
-  glassInternalReflectionStrength = 0.36;
+  glassInternalReflectionStrength = 0.46;
   glassTransmissionStrength = 1.32;
-  glassEnvironmentIntensity = 0.68;
+  glassEnvironmentIntensity = 0.86;
   glassVolumeThickness = 1;
   glassRoughTransmissionStrength = 0.2;
   glassSpectralAbsorptionStrength = 0.28;
   glassThinFilmThickness = 420;
   glassThinFilmStrength = 0.22;
-  glassVolumeScatteringStrength = 0.14;
-  glassDynamicReflectionStrength = 0.2;
-  glassSecondaryBounceStrength = 0.24;
+  glassVolumeScatteringStrength = 0.22;
+  glassDynamicReflectionStrength = 0.29;
+  glassSecondaryBounceStrength = 0.34;
   glassFaultDistortionStrength = 0.42;
   packetEmission = 5.2;
   packetTrailLength = 0.19;
@@ -1866,7 +1856,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   switchFlashIntensity = 0.8;
   switchRippleIntensity = 0.44;
   switchTransitionIntensity = 0.62;
-  packetLightIntensity = 0.66;
+  packetLightIntensity = 0.86;
   packetLightRadius = 1.05;
   linkTrafficGlow = 0.58;
   linkPulseLength = 0.31;
@@ -1878,7 +1868,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   bloomIntensity = 1.7;
   bloomThreshold = 0.42;
   exposure = 0.96;
-  hdrHighlightBoost = 0.45;
+  hdrHighlightBoost = 0.58;
 
   constructor({device, width, height}: AnimationProps) {
     super();
@@ -2147,14 +2137,6 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       additive: true,
       emissive: true
     });
-    this.planeHighlightShells = new InstancedMesh(device, this.planeHighlightShaderInputs, {
-      id: 'packet-spraying-plane-highlight-shells',
-      geometry: new SphereGeometry({radius: 1, nlat: 16, nlong: 24}),
-      matrices: this.planeHighlightMatrices,
-      colors: this.planeHighlightColors,
-      additive: true,
-      emissive: true
-    });
     this.storyPackets = new InstancedMesh(device, this.emissiveShaderInputs, {
       id: 'packet-spraying-network-story-packets',
       geometry: new SphereGeometry({radius: 1, nlat: 8, nlong: 12}),
@@ -2231,6 +2213,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       canvas.dataset.packetSprayingSceneColorFormat = this.sceneColorFormat;
       canvas.dataset.packetSprayingHighlightBoost =
         this.dynamicRangeProfile.highlightBoost.toFixed(3);
+      canvas.dataset.packetSprayingMaximumLuminance =
+        this.dynamicRangeProfile.maximumLuminance.toFixed(2);
       canvas.dataset.packetSprayingGlassGroups = this.glassGroups.map(group => group.id).join(',');
       this.nodePopup = new NetworkNodePopup(canvas);
       this.orbitControls = new OrbitControls(canvas, {
@@ -2313,10 +2297,6 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.switchTransitionMatrices,
       this.switchTransitionColors
     );
-    this.planeHighlightShells.updateInstances(
-      this.planeHighlightMatrices,
-      this.planeHighlightColors
-    );
     this.storyPackets.updateInstances(this.storyPacketMatrices, this.storyPacketColors);
 
     this.orbitControls?.update(time);
@@ -2343,7 +2323,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       dispersion: this.glassDispersion * this.opticsProfile.spectral,
       thickness: this.glassThickness,
       refractionStrength: this.glassRefractionStrength * this.opticsProfile.refraction,
-      reflectionStrength: 0.5,
+      reflectionStrength: 0.66,
       fresnelStrength:
         this.glassFresnelStrength *
         (0.2 + this.opticsProfile.surface * 0.8) *
@@ -2407,19 +2387,19 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     if (this.canvas) {
       this.canvas.dataset.packetSprayingCausticLenses = String(causticLenses.length);
     }
+    const packetEmission =
+      this.packetEmission *
+      (0.24 + this.opticsProfile.illumination * 0.76) *
+      this.dynamicRangeProfile.emissionScale;
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingPacketEmission = packetEmission.toFixed(2);
+    }
     this.emissiveShaderInputs.setProps({
       app: uniforms,
       emissiveMaterial: {
-        intensity:
-          this.packetEmission *
-          (0.24 + this.opticsProfile.illumination * 0.76) *
-          this.dynamicRangeProfile.emissionScale,
+        intensity: packetEmission,
         rimStrength: 0.12 + this.opticsProfile.surface * 0.2
       }
-    });
-    this.planeHighlightShaderInputs.setProps({
-      app: uniforms,
-      emissiveMaterial: {intensity: 0.16, rimStrength: 2.4}
     });
     this.reflectiveShaderInputs.setProps({
       app: uniforms,
@@ -2454,7 +2434,6 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.switchFlashes.model.predraw(device.commandEncoder);
     this.switchRipples.model.predraw(device.commandEncoder);
     this.switchTransitionVisuals.model.predraw(device.commandEncoder);
-    this.planeHighlightShells.model.predraw(device.commandEncoder);
     this.storyPackets.model.predraw(device.commandEncoder);
     this.links.model.predraw(device.commandEncoder);
     const sceneRenderPass = device.beginRenderPass({
@@ -2470,7 +2449,6 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.switchFlashes.model.draw(sceneRenderPass);
     this.switchRipples.model.draw(sceneRenderPass);
     this.switchTransitionVisuals.model.draw(sceneRenderPass);
-    this.planeHighlightShells.model.draw(sceneRenderPass);
     this.storyPackets.model.draw(sceneRenderPass);
     this.links.model.draw(sceneRenderPass);
     sceneRenderPass.end();
@@ -2579,7 +2557,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
             this.opticsProfile.bloom *
             this.dynamicRangeProfile.bloomIntensityScale
         },
-        toneMapping: {exposure: this.exposure * this.dynamicRangeProfile.exposureScale}
+        toneMapping: {
+          exposure: this.exposure * this.dynamicRangeProfile.exposureScale,
+          maximumLuminance: this.dynamicRangeProfile.maximumLuminance
+        }
       }
     });
 
@@ -2616,14 +2597,12 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.switchFlashes.destroy();
     this.switchRipples.destroy();
     this.switchTransitionVisuals.destroy();
-    this.planeHighlightShells.destroy();
     this.storyPackets.destroy();
     this.postprocessingRenderer.destroy();
     this.aBufferRenderer?.destroy();
     this.weightedBlendedRenderer?.destroy();
     this.backfaceShaderInputs.destroy();
     this.emissiveShaderInputs.destroy();
-    this.planeHighlightShaderInputs.destroy();
     this.reflectiveShaderInputs.destroy();
     this.metallicShaderInputs.destroy();
     this.pickingShaderInputs.destroy();
@@ -3023,6 +3002,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.canvas.dataset.packetSprayingDynamicRange = this.dynamicRangeProfile.displayMode;
       this.canvas.dataset.packetSprayingHighlightBoost =
         this.dynamicRangeProfile.highlightBoost.toFixed(3);
+      this.canvas.dataset.packetSprayingMaximumLuminance =
+        this.dynamicRangeProfile.maximumLuminance.toFixed(2);
     }
   }
 
@@ -3383,8 +3364,6 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     }
 
     if (requiresHighlightUpdate) {
-      this.planeHighlightMatrices.fill(0);
-      this.planeHighlightColors.fill(0);
       let highlightedSwitchCount = 0;
       let highlightedPathSwitchCount = 0;
 
@@ -3398,30 +3377,6 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
           continue;
         }
 
-        const switchRadius =
-          switchIndex < LEAF_POSITIONS.length
-            ? LEAF_SWITCH_RADIUS
-            : switchIndex < LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length
-              ? AGGREGATION_SWITCH_RADIUS
-              : SPINE_SWITCH_RADIUS;
-        const shellRadius = switchRadius * (1.004 + highlightStrength * 0.01);
-        this.planeHighlightMatrices.set(
-          makeObjectMatrix(this.glassInstances[switchIndex].position, [
-            shellRadius,
-            shellRadius,
-            shellRadius
-          ]),
-          switchIndex * 16
-        );
-        this.planeHighlightColors.set(
-          [
-            0.03 * planeStrength + 0.035 * pathStrength,
-            0.075 * planeStrength + 0.09 * pathStrength,
-            0.2 * planeStrength + 0.22 * pathStrength,
-            Math.min(0.007 * planeStrength + 0.009 * pathStrength, 0.013)
-          ],
-          switchIndex * 4
-        );
         highlightedSwitchCount++;
         if (pathStrength > 0.003) {
           highlightedPathSwitchCount++;
@@ -4161,7 +4116,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
     const candidatesByRoute = new Map<
       Packet['route'],
-      {color: Vector3; position: Vector3; switchDistance: number}[]
+      {color: Vector3; position: Vector3; switchDistance: number; switchSurfaceDistance: number}[]
     >();
 
     for (let packetIndex = 0; packetIndex < this.packetDefinitions.length; packetIndex++) {
@@ -4176,13 +4131,27 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       }
 
       const packet = this.packetDefinitions[packetIndex];
+      let nearestSwitchIndex = 0;
+      let nearestSwitchDistance = Number.POSITIVE_INFINITY;
+      for (let switchIndex = 0; switchIndex < SWITCH_POSITIONS.length; switchIndex++) {
+        const switchDistance = getDistanceSquared(position, SWITCH_POSITIONS[switchIndex]);
+        if (switchDistance < nearestSwitchDistance) {
+          nearestSwitchDistance = switchDistance;
+          nearestSwitchIndex = switchIndex;
+        }
+      }
+      const nearestSwitchRadius =
+        nearestSwitchIndex < LEAF_POSITIONS.length
+          ? LEAF_SWITCH_RADIUS
+          : nearestSwitchIndex < LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length
+            ? AGGREGATION_SWITCH_RADIUS
+            : SPINE_SWITCH_RADIUS;
       const candidates = candidatesByRoute.get(packet.route) || [];
       candidates.push({
         color: [packet.color[0], packet.color[1], packet.color[2]],
         position,
-        switchDistance: Math.min(
-          ...SWITCH_POSITIONS.map(switchPosition => getDistanceSquared(position, switchPosition))
-        )
+        switchDistance: nearestSwitchDistance,
+        switchSurfaceDistance: Math.max(Math.sqrt(nearestSwitchDistance) - nearestSwitchRadius, 0)
       });
       candidatesByRoute.set(packet.route, candidates);
     }
@@ -4192,11 +4161,12 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     for (const candidates of candidatesByRoute.values()) {
       candidates.sort((first, second) => first.switchDistance - second.switchDistance);
       for (const [candidateIndex, candidate] of candidates.slice(0, 2).entries()) {
+        const arrivalResponse = 1 - smoothstep(0.04, 0.3, candidate.switchSurfaceDistance);
         const light = {
           position: candidate.position,
           color: candidate.color,
-          intensity: 1,
-          radius: this.packetLightRadius
+          intensity: 0.22 + arrivalResponse * 0.78,
+          radius: this.packetLightRadius * (0.12 + arrivalResponse * 0.34)
         };
         if (candidateIndex === 0) {
           lights.push(light);

--- a/examples/showcase/packet-spraying/index.html
+++ b/examples/showcase/packet-spraying/index.html
@@ -2,6 +2,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <script type="module">
+    import {luma} from '@luma.gl/core';
     import {makeAnimationLoop} from '@luma.gl/engine';
     import {webgl2Adapter} from '@luma.gl/webgl';
     import {webgpuAdapter} from '@luma.gl/webgpu';
@@ -14,7 +15,18 @@
         : requestedDevice === 'webgpu'
           ? [webgpuAdapter]
           : [webgpuAdapter, webgl2Adapter];
-    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters});
+    const supportsHighDynamicRange =
+      requestedDevice !== 'webgl' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(dynamic-range: high)').matches;
+    const device = luma.createDevice({
+      id: 'packet-spraying',
+      adapters,
+      createCanvasContext: supportsHighDynamicRange
+        ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+        : true
+    });
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
     animationLoop.start();
   </script>
   <style>

--- a/examples/showcase/packet-spraying/network.ts
+++ b/examples/showcase/packet-spraying/network.ts
@@ -65,6 +65,15 @@ export type NetworkLinkPulse = {
   start: Vector3;
 };
 
+/** A short, animated packet queue immediately upstream of a congested switch. */
+export type NetworkQueuedPacket = {
+  color: Color;
+  conversationIndex: number;
+  position: Vector3;
+  strength: number;
+  switchIndex: number;
+};
+
 export type NetworkSwitchTransitionKind = 'failure' | 'recovery';
 
 export type NetworkSwitchTransitionWave = {
@@ -363,6 +372,63 @@ export function makeSwitchArrivals(packets: Packet[]): SwitchArrival[] {
   }
 
   return arrivals;
+}
+
+/** Places alternating packets inside the final incoming link without entering switch glass. */
+export function makeSwitchQueuePackets(
+  packets: readonly Packet[],
+  switchIndex: number,
+  animationTime: number,
+  maximumPackets = 6
+): NetworkQueuedPacket[] {
+  const switchPosition = SWITCH_POSITIONS[switchIndex];
+  if (!switchPosition || maximumPackets <= 0 || !Number.isFinite(animationTime)) {
+    return [];
+  }
+
+  const incomingPackets = CONVERSATIONS.map((_, conversationIndex) =>
+    packets.find(
+      packet =>
+        packet.enabled &&
+        packet.conversationIndex === conversationIndex &&
+        packet.route.points.includes(switchPosition)
+    )
+  ).filter((packet): packet is Packet => Boolean(packet));
+  if (incomingPackets.length === 0) {
+    return [];
+  }
+
+  const queuedPackets: NetworkQueuedPacket[] = [];
+  for (let queueIndex = 0; queueIndex < maximumPackets; queueIndex++) {
+    const packet = incomingPackets[queueIndex % incomingPackets.length];
+    const switchPointIndex = packet.route.points.indexOf(switchPosition);
+    if (switchPointIndex < 1) {
+      continue;
+    }
+
+    const previousPosition = packet.route.points[switchPointIndex - 1];
+    const switchSurface = getNetworkNodeSurfaceInset(switchPosition, previousPosition);
+    const queueSpacing = 0.115;
+    const oscillation = Math.sin(animationTime * 4.6 + queueIndex * 0.58) * 0.025;
+    const queueDistance = switchSurface + 0.065 + queueIndex * queueSpacing + oscillation;
+    const incomingSegmentLength =
+      packet.route.cumulativeLengths[switchPointIndex] -
+      packet.route.cumulativeLengths[switchPointIndex - 1];
+    if (queueDistance >= incomingSegmentLength - 0.06) {
+      break;
+    }
+
+    const distanceFromSource = packet.route.cumulativeLengths[switchPointIndex] - queueDistance;
+    queuedPackets.push({
+      color: packet.color,
+      conversationIndex: packet.conversationIndex,
+      position: getPointAlongRoute(packet.route, distanceFromSource / packet.route.totalLength),
+      strength: 0.65 + Math.sin(animationTime * 5 + queueIndex * 0.84) * 0.18,
+      switchIndex
+    });
+  }
+
+  return queuedPackets;
 }
 
 export function makeSwitchPacketEvents({

--- a/examples/showcase/packet-spraying/story.ts
+++ b/examples/showcase/packet-spraying/story.ts
@@ -58,6 +58,7 @@ export type NetworkDynamicRangeProfile = {
   exposureScale: number;
   highlightBoost: number;
   illuminationScale: number;
+  maximumLuminance: number;
   sceneIsFloatingPoint: boolean;
   specularScale: number;
 };
@@ -396,7 +397,8 @@ export function makeNetworkDynamicRangeProfile(
     emissionScale: 1 + highlightBoost * 0.6,
     exposureScale: 1 - highlightBoost * 0.06,
     highlightBoost,
-    illuminationScale: 1 + highlightBoost * 0.5,
+    illuminationScale: 1 + highlightBoost * (supportsExtendedPresentation ? 0.86 : 0.34),
+    maximumLuminance: supportsExtendedPresentation ? 1 + highlightBoost * 3.2 : 1,
     sceneIsFloatingPoint,
     specularScale: 1 + highlightBoost * 0.32
   };

--- a/examples/showcase/packet-spraying/story.ts
+++ b/examples/showcase/packet-spraying/story.ts
@@ -74,6 +74,8 @@ export type NetworkDynamicRangeOptions = {
 
 export const MAX_NETWORK_OPTICS_LEVEL = 11;
 export const DEFAULT_NETWORK_OPTICS_LEVEL = 7;
+export const MAX_NETWORK_HDR_HIGHLIGHT_BOOST = 0.8;
+export const DEFAULT_NETWORK_HDR_HIGHLIGHT_BOOST = 0.28;
 export const GUIDED_STORY_SWITCH_INDEX = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length + 1;
 
 export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
@@ -384,8 +386,8 @@ export function makeNetworkDynamicRangeProfile(
       : 'standard';
   const optics = makeNetworkOpticsProfile(options.visualIntensity);
   const requestedBoost = Number.isFinite(options.highlightBoost)
-    ? Math.max(0, Math.min(options.highlightBoost ?? 0, 0.8))
-    : 0.3;
+    ? Math.max(0, Math.min(options.highlightBoost ?? 0, MAX_NETWORK_HDR_HIGHLIGHT_BOOST))
+    : DEFAULT_NETWORK_HDR_HIGHLIGHT_BOOST;
   const availableHeadroom = supportsExtendedPresentation ? 1 : sceneIsFloatingPoint ? 0.7 : 0;
   const highlightBoost =
     requestedBoost * availableHeadroom * optics.surface * Math.min(optics.illumination, 1);

--- a/examples/showcase/packet-spraying/story.ts
+++ b/examples/showcase/packet-spraying/story.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {AGGREGATION_POSITIONS, LEAF_POSITIONS, type Vector3} from './network';
+import {AGGREGATION_POSITIONS, LEAF_POSITIONS, type Color, type Vector3} from './network';
 
 export type NetworkStoryState = 'healthy' | 'congested' | 'failed' | 'recovering';
 
@@ -367,6 +367,35 @@ export function makeNetworkOpticsProfile(level: number): NetworkOpticsProfile {
     spectral: stage(5, 10) * (1 + fireworks * 0.25),
     surface: stage(0, 3)
   };
+}
+
+/** Brightens selected glass without obscuring its refraction or fault-state color. */
+export function makeNetworkSwitchHighlightColor(
+  color: Color,
+  planeStrength: number,
+  pathStrength: number
+): Color {
+  if (color[3] >= 0.44) {
+    return color;
+  }
+
+  const boundedPlaneStrength = Math.max(0, Math.min(planeStrength, 1));
+  const boundedPathStrength = Math.max(0, Math.min(pathStrength, 1));
+  const highlightStrength = Math.min(boundedPlaneStrength * 0.42 + boundedPathStrength * 0.34, 0.6);
+  if (highlightStrength < 0.001) {
+    return color;
+  }
+
+  const targetColor: Color =
+    boundedPathStrength > boundedPlaneStrength
+      ? [0.42, 1.02, 1.2, color[3]]
+      : [0.6, 0.82, 1.15, color[3]];
+  return [
+    color[0] + (targetColor[0] - color[0]) * highlightStrength,
+    color[1] + (targetColor[1] - color[1]) * highlightStrength,
+    color[2] + (targetColor[2] - color[2]) * highlightStrength,
+    color[3]
+  ];
 }
 
 /** Keeps floating-point highlights restrained without misreporting SDR presentation as HDR. */

--- a/examples/showcase/packet-spraying/story.ts
+++ b/examples/showcase/packet-spraying/story.ts
@@ -6,6 +6,16 @@ import {AGGREGATION_POSITIONS, LEAF_POSITIONS, type Vector3} from './network';
 
 export type NetworkStoryState = 'healthy' | 'congested' | 'failed' | 'recovering';
 
+export type NetworkStoryBeat = {
+  color: string;
+  description: string;
+  id: string;
+  pathIndex?: number;
+  planeIndex?: number;
+  position: number;
+  title: string;
+};
+
 export type NetworkStoryCamera = {
   distance: number;
   pitch: number;
@@ -14,6 +24,7 @@ export type NetworkStoryCamera = {
 };
 
 export type NetworkStoryChapter = {
+  beats: readonly NetworkStoryBeat[];
   camera: NetworkStoryCamera;
   description: string;
   duration: number;
@@ -39,6 +50,27 @@ export type NetworkOpticsProfile = {
   surface: number;
 };
 
+export type NetworkDynamicRangeProfile = {
+  bloomIntensityScale: number;
+  bloomThresholdScale: number;
+  displayMode: 'extended-hdr' | 'floating-point' | 'standard';
+  emissionScale: number;
+  exposureScale: number;
+  highlightBoost: number;
+  illuminationScale: number;
+  sceneIsFloatingPoint: boolean;
+  specularScale: number;
+};
+
+export type NetworkDynamicRangeOptions = {
+  deviceType: string;
+  displaySupportsHighDynamicRange: boolean;
+  highlightBoost?: number;
+  presentationColorFormat: string;
+  sceneColorFormat: string;
+  visualIntensity: number;
+};
+
 export const MAX_NETWORK_OPTICS_LEVEL = 11;
 export const DEFAULT_NETWORK_OPTICS_LEVEL = 7;
 export const GUIDED_STORY_SWITCH_INDEX = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length + 1;
@@ -50,6 +82,32 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
     description: 'Red and green packets leave separate servers and meet at a shared access switch.',
     duration: 7,
     networkState: 'healthy',
+    beats: [
+      {
+        id: 'sources',
+        title: 'Independent senders',
+        description: 'Separate red and green servers launch their first packets.',
+        color: '#a8c7ff',
+        pathIndex: 0,
+        position: 0.05
+      },
+      {
+        id: 'interleave',
+        title: 'Packets interleave',
+        description: 'The source-side access plane interleaves one red packet with one green.',
+        color: '#77adff',
+        planeIndex: 0,
+        position: 0.35
+      },
+      {
+        id: 'destinations',
+        title: 'Separate destinations',
+        description: 'The destination plane separates both streams into their target servers.',
+        color: '#77dfa4',
+        planeIndex: 1,
+        position: 0.71
+      }
+    ],
     camera: {target: [0, -0.85, 0], distance: 12.8, yaw: 0.52, pitch: 0.58}
   },
   {
@@ -59,6 +117,40 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
       'Alternating packets cross two switch planes through four independent paths before reuniting.',
     duration: 8,
     networkState: 'healthy',
+    beats: [
+      {
+        id: 'path-1',
+        title: 'Backbone path one',
+        description: 'The first spine carries alternating red and green packets.',
+        color: '#83bcff',
+        pathIndex: 0,
+        position: 0.04
+      },
+      {
+        id: 'path-2',
+        title: 'Backbone path two',
+        description: 'The next packets use an independent second spine.',
+        color: '#83bcff',
+        pathIndex: 1,
+        position: 0.28
+      },
+      {
+        id: 'path-3',
+        title: 'Backbone path three',
+        description: 'A third independent path adds throughput without congestion.',
+        color: '#83bcff',
+        pathIndex: 2,
+        position: 0.52
+      },
+      {
+        id: 'path-4',
+        title: 'Backbone path four',
+        description: 'The fourth path completes the load-balanced packet spray.',
+        color: '#83bcff',
+        pathIndex: 3,
+        position: 0.76
+      }
+    ],
     camera: {target: [0, -0.2, 0], distance: 11.8, yaw: 0.78, pitch: 0.49}
   },
   {
@@ -68,6 +160,40 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
       'Packets shift toward healthy backbone paths while an overloaded switch trims payloads into headers.',
     duration: 7,
     networkState: 'congested',
+    beats: [
+      {
+        id: 'pressure',
+        title: 'Switch congestion',
+        description: 'An amber spine becomes congested as incoming packets begin to queue.',
+        color: '#ffbd68',
+        pathIndex: 1,
+        position: 0
+      },
+      {
+        id: 'queued',
+        title: 'Packets queue',
+        description: 'Alternating red and green packets briefly accumulate before the switch.',
+        color: '#ffc26f',
+        pathIndex: 1,
+        position: 0.3
+      },
+      {
+        id: 'trimmed',
+        title: 'Headers continue',
+        description: 'The switch trims overloaded payloads while their compact headers continue.',
+        color: '#ff9a54',
+        pathIndex: 1,
+        position: 0.53
+      },
+      {
+        id: 'rebalanced',
+        title: 'Healthy paths absorb load',
+        description: 'Senders shift most packets toward healthy spines without retiring the path.',
+        color: '#75dfa8',
+        pathIndex: 2,
+        position: 0.75
+      }
+    ],
     camera: {target: [0, 0.65, 0.55], distance: 10.6, yaw: 0.42, pitch: 0.45}
   },
   {
@@ -77,6 +203,40 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
       'A failed switch drops in-flight packets, then traffic moves onto the surviving backbone paths.',
     duration: 8,
     networkState: 'failed',
+    beats: [
+      {
+        id: 'packet-loss',
+        title: 'In-flight packets are lost',
+        description: 'The failing spine scatters the packets already committed to its path.',
+        color: '#ff655e',
+        pathIndex: 1,
+        position: 0
+      },
+      {
+        id: 'retired',
+        title: 'Failed path retires',
+        description: 'MRC detects packet loss and immediately removes the failed spine.',
+        color: '#ff7869',
+        pathIndex: 1,
+        position: 0.28
+      },
+      {
+        id: 'retransmitted',
+        title: 'Missing packets retransmit',
+        description: 'Missing red and green payloads retransmit through an independent spine.',
+        color: '#85dca7',
+        pathIndex: 2,
+        position: 0.51
+      },
+      {
+        id: 'surviving',
+        title: 'Training continues',
+        description: 'The remaining healthy paths keep both conversations moving.',
+        color: '#83c6ff',
+        pathIndex: 3,
+        position: 0.76
+      }
+    ],
     camera: {target: [0, 0.7, 0.55], distance: 10.2, yaw: 0.24, pitch: 0.43}
   },
   {
@@ -86,6 +246,32 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
       'A blue probe reaches the repaired switch, then a cyan acknowledgment restores its path.',
     duration: 7,
     networkState: 'recovering',
+    beats: [
+      {
+        id: 'probe',
+        title: 'Control probe',
+        description: 'A blue control packet probes the repaired spine before traffic resumes.',
+        color: '#69aaff',
+        pathIndex: 1,
+        position: 0
+      },
+      {
+        id: 'confirmation',
+        title: 'Path confirmation',
+        description: 'A cyan acknowledgment returns and confirms the entire route is healthy.',
+        color: '#70eddf',
+        pathIndex: 1,
+        position: 0.47
+      },
+      {
+        id: 'restored',
+        title: 'Ordinary traffic resumes',
+        description: 'Only after confirmation do alternating data packets return to the spine.',
+        color: '#7de9a5',
+        pathIndex: 1,
+        position: 0.77
+      }
+    ],
     camera: {target: [0, 0.9, 0.65], distance: 9.8, yaw: 0.16, pitch: 0.46}
   }
 ];
@@ -99,6 +285,27 @@ export function getWrappedStoryChapterIndex(chapterIndex: number): number {
 
 export function getNetworkStoryChapter(chapterIndex: number): NetworkStoryChapter {
   return NETWORK_STORY_CHAPTERS[getWrappedStoryChapterIndex(chapterIndex)];
+}
+
+/** Returns the most recent named event reached within the current story chapter. */
+export function getNetworkStoryBeat(
+  chapterIndex: number,
+  elapsedTime: number
+): NetworkStoryBeat | null {
+  const chapter = getNetworkStoryChapter(chapterIndex);
+  const progress = Number.isFinite(elapsedTime)
+    ? Math.max(0, Math.min(elapsedTime / chapter.duration, 1))
+    : 0;
+  let currentBeat: NetworkStoryBeat | null = null;
+
+  for (const beat of chapter.beats) {
+    if (beat.position > progress) {
+      break;
+    }
+    currentBeat = beat;
+  }
+
+  return currentBeat;
 }
 
 /** Returns bounded chapter and duration-weighted full-tour playback progress. */
@@ -156,5 +363,41 @@ export function makeNetworkOpticsProfile(level: number): NetworkOpticsProfile {
     refraction: stage(1.5, 6.25) * (1 + fireworks * 0.12),
     spectral: stage(5, 10) * (1 + fireworks * 0.25),
     surface: stage(0, 3)
+  };
+}
+
+/** Keeps floating-point highlights restrained without misreporting SDR presentation as HDR. */
+export function makeNetworkDynamicRangeProfile(
+  options: NetworkDynamicRangeOptions
+): NetworkDynamicRangeProfile {
+  const sceneIsFloatingPoint = options.sceneColorFormat === 'rgba16float';
+  const supportsExtendedPresentation =
+    sceneIsFloatingPoint &&
+    options.deviceType === 'webgpu' &&
+    options.displaySupportsHighDynamicRange &&
+    options.presentationColorFormat === 'rgba16float';
+  const displayMode = supportsExtendedPresentation
+    ? 'extended-hdr'
+    : sceneIsFloatingPoint
+      ? 'floating-point'
+      : 'standard';
+  const optics = makeNetworkOpticsProfile(options.visualIntensity);
+  const requestedBoost = Number.isFinite(options.highlightBoost)
+    ? Math.max(0, Math.min(options.highlightBoost ?? 0, 0.8))
+    : 0.3;
+  const availableHeadroom = supportsExtendedPresentation ? 1 : sceneIsFloatingPoint ? 0.7 : 0;
+  const highlightBoost =
+    requestedBoost * availableHeadroom * optics.surface * Math.min(optics.illumination, 1);
+
+  return {
+    bloomIntensityScale: 1 + highlightBoost * 0.28,
+    bloomThresholdScale: 1 + highlightBoost * 0.6,
+    displayMode,
+    emissionScale: 1 + highlightBoost * 0.6,
+    exposureScale: 1 - highlightBoost * 0.06,
+    highlightBoost,
+    illuminationScale: 1 + highlightBoost * 0.5,
+    sceneIsFloatingPoint,
+    specularScale: 1 + highlightBoost * 0.32
   };
 }

--- a/examples/showcase/packet-spraying/story.ts
+++ b/examples/showcase/packet-spraying/story.ts
@@ -384,13 +384,11 @@ export function makeNetworkDynamicRangeProfile(
     : sceneIsFloatingPoint
       ? 'floating-point'
       : 'standard';
-  const optics = makeNetworkOpticsProfile(options.visualIntensity);
   const requestedBoost = Number.isFinite(options.highlightBoost)
     ? Math.max(0, Math.min(options.highlightBoost ?? 0, MAX_NETWORK_HDR_HIGHLIGHT_BOOST))
     : DEFAULT_NETWORK_HDR_HIGHLIGHT_BOOST;
   const availableHeadroom = supportsExtendedPresentation ? 1 : sceneIsFloatingPoint ? 0.7 : 0;
-  const highlightBoost =
-    requestedBoost * availableHeadroom * optics.surface * Math.min(optics.illumination, 1);
+  const highlightBoost = requestedBoost * availableHeadroom;
 
   return {
     bloomIntensityScale: 1 + highlightBoost * 0.28,

--- a/modules/effects/src/passes/postprocessing/image-adjust-filters/tone-mapping.ts
+++ b/modules/effects/src/passes/postprocessing/image-adjust-filters/tone-mapping.ts
@@ -7,6 +7,7 @@ import type {ShaderPass} from '@luma.gl/shadertools';
 const source = /* wgsl */ `\
 struct toneMappingUniforms {
   exposure: f32,
+  maximumLuminance: f32,
 };
 
 @group(0) @binding(auto) var<uniform> toneMapping: toneMappingUniforms;
@@ -15,7 +16,15 @@ fn toneMapping_filterColor_ext(color: vec4f, texSize: vec2f, texCoords: vec2f) -
   let exposedColor = max(color.rgb * toneMapping.exposure, vec3f(0.0));
   let numerator = exposedColor * (2.51 * exposedColor + vec3f(0.03));
   let denominator = exposedColor * (2.43 * exposedColor + vec3f(0.59)) + vec3f(0.14);
-  let mappedColor = clamp(numerator / denominator, vec3f(0.0), vec3f(1.0));
+  let maximumLuminance = max(toneMapping.maximumLuminance, 1.0);
+  let sceneLuminance = max(exposedColor.r, max(exposedColor.g, exposedColor.b));
+  let highlightWeight = smoothstep(0.72, 1.7, sceneLuminance);
+  let extendedScale = mix(1.0, maximumLuminance, highlightWeight);
+  let mappedColor = clamp(
+    numerator / denominator * extendedScale,
+    vec3f(0.0),
+    vec3f(maximumLuminance)
+  );
   return vec4f(mappedColor, color.a);
 }
 `;
@@ -23,13 +32,22 @@ fn toneMapping_filterColor_ext(color: vec4f, texSize: vec2f, texCoords: vec2f) -
 const fs = /* glsl */ `\
 layout(std140) uniform toneMappingUniforms {
   float exposure;
+  float maximumLuminance;
 } toneMapping;
 
 vec4 toneMapping_filterColor_ext(vec4 color, vec2 texSize, vec2 texCoords) {
   vec3 exposedColor = max(color.rgb * toneMapping.exposure, vec3(0.0));
   vec3 numerator = exposedColor * (2.51 * exposedColor + vec3(0.03));
   vec3 denominator = exposedColor * (2.43 * exposedColor + vec3(0.59)) + vec3(0.14);
-  vec3 mappedColor = clamp(numerator / denominator, vec3(0.0), vec3(1.0));
+  float maximumLuminance = max(toneMapping.maximumLuminance, 1.0);
+  float sceneLuminance = max(exposedColor.r, max(exposedColor.g, exposedColor.b));
+  float highlightWeight = smoothstep(0.72, 1.7, sceneLuminance);
+  float extendedScale = mix(1.0, maximumLuminance, highlightWeight);
+  vec3 mappedColor = clamp(
+    numerator / denominator * extendedScale,
+    vec3(0.0),
+    vec3(maximumLuminance)
+  );
   return vec4(mappedColor, color.a);
 }
 `;
@@ -37,10 +55,13 @@ vec4 toneMapping_filterColor_ext(vec4 color, vec2 texSize, vec2 texCoords) {
 export type ToneMappingProps = {
   /** Linear exposure multiplier applied before the ACES filmic curve. */
   exposure?: number;
+  /** Maximum output luminance; values above one preserve highlights on HDR displays. */
+  maximumLuminance?: number;
 };
 
 export type ToneMappingUniforms = {
   exposure: number;
+  maximumLuminance: number;
 };
 
 /** Maps high-dynamic-range scene colors into display range with an ACES filmic curve. */
@@ -52,13 +73,16 @@ export const toneMapping = {
   props: {} as ToneMappingProps,
   uniforms: {} as ToneMappingUniforms,
   uniformTypes: {
-    exposure: 'f32'
+    exposure: 'f32',
+    maximumLuminance: 'f32'
   },
   defaultUniforms: {
-    exposure: 1
+    exposure: 1,
+    maximumLuminance: 1
   },
   propTypes: {
-    exposure: {format: 'f32', value: 1, min: 0, max: 10}
+    exposure: {format: 'f32', value: 1, min: 0, max: 10},
+    maximumLuminance: {format: 'f32', value: 1, min: 1, max: 4}
   },
 
   passes: [{filter: true}]

--- a/modules/effects/test/passes/image-adjust-filters/tone-mapping.spec.ts
+++ b/modules/effects/test/passes/image-adjust-filters/tone-mapping.spec.ts
@@ -51,10 +51,20 @@ fn fragmentMain() -> @location(0) vec4f {
 
 test('toneMapping#defaults', testCase => {
   const defaultUniforms = getShaderModuleUniforms(toneMapping, {}, {});
-  const overriddenUniforms = getShaderModuleUniforms(toneMapping, {exposure: 2.5}, {});
+  const overriddenUniforms = getShaderModuleUniforms(
+    toneMapping,
+    {exposure: 2.5, maximumLuminance: 1.6},
+    {}
+  );
 
   testCase.equal(defaultUniforms.exposure, 1, 'exposure defaults to one');
+  testCase.equal(defaultUniforms.maximumLuminance, 1, 'standard displays retain existing output');
   testCase.equal(overriddenUniforms.exposure, 2.5, 'exposure accepts caller configuration');
+  testCase.equal(
+    overriddenUniforms.maximumLuminance,
+    1.6,
+    'extended displays can preserve highlights above SDR white'
+  );
   testCase.deepEqual(toneMapping.passes, [{filter: true}], 'runs as one fullscreen filter pass');
   testCase.end();
 });
@@ -64,6 +74,10 @@ test('toneMapping#cross-backend shader sources', testCase => {
     testCase.ok(shaderSource.includes('2.51'), 'includes the ACES numerator coefficient');
     testCase.ok(shaderSource.includes('2.43'), 'includes the ACES denominator coefficient');
     testCase.ok(shaderSource.includes('toneMapping.exposure'), 'applies configurable exposure');
+    testCase.ok(
+      shaderSource.includes('toneMapping.maximumLuminance'),
+      'preserves optional extended-range highlight output'
+    );
     testCase.ok(shaderSource.includes('color.a'), 'preserves input alpha');
   }
   testCase.end();

--- a/test/examples/packet-spraying-network.node.spec.ts
+++ b/test/examples/packet-spraying-network.node.spec.ts
@@ -15,6 +15,7 @@ import {
   NETWORK_SWITCH_PLANE_COUNT,
   PACKET_TRAVEL_SPEED,
   SPINE_POSITIONS,
+  SPINE_SWITCH_RADIUS,
   SWITCH_CONFIRMATION_DURATION,
   SWITCH_POSITIONS,
   SWITCH_TRANSITION_WAVE_DURATION,
@@ -36,6 +37,7 @@ import {
   makeSwitchPacketEvents,
   makeSwitchProbeConfirmationEvent,
   makeSwitchProbeEvent,
+  makeSwitchQueuePackets,
   makeSwitchGroups,
   makeSwitchArrivals,
   makeSwitchTransitionWave,
@@ -410,6 +412,42 @@ test('packet-spraying adaptively shifts load away from congested physical planes
     packets.filter(packet => packet.route.points.includes(SPINE_POSITIONS[0])).length,
     12,
     'a shared access bottleneck cannot be bypassed by choosing a different plane'
+  );
+  testCase.end();
+});
+
+test('packet-spraying congestion forms bounded alternating queues before switch glass', testCase => {
+  const routes = makeConversationRoutes();
+  const packets = makePackets(routes);
+  const congestedSwitchIndex = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length + 1;
+  const queue = makeSwitchQueuePackets(packets, congestedSwitchIndex, 12, 6);
+
+  testCase.equal(queue.length, 6, 'the optical queue remains bounded to six visible packets');
+  testCase.deepEqual(
+    queue.map(packet => packet.conversationIndex),
+    [0, 1, 0, 1, 0, 1],
+    'the queue preserves alternating red and green packet order'
+  );
+  testCase.ok(
+    queue.every(
+      packet =>
+        getDistance(packet.position, SWITCH_POSITIONS[congestedSwitchIndex]) > SPINE_SWITCH_RADIUS
+    ),
+    'queued packets stay outside the glass switch boundary'
+  );
+  testCase.ok(
+    queue.every(packet => packet.strength > 0 && packet.strength < 1),
+    'queue pressure remains softly bounded'
+  );
+  testCase.deepEqual(
+    makeSwitchQueuePackets(packets, SWITCH_POSITIONS.length, 12),
+    [],
+    'unknown switches never create phantom queue packets'
+  );
+  testCase.deepEqual(
+    makeSwitchQueuePackets(packets, congestedSwitchIndex, Number.NaN),
+    [],
+    'invalid animation times never produce invalid packet positions'
   );
   testCase.end();
 });

--- a/test/examples/packet-spraying-story.node.spec.ts
+++ b/test/examples/packet-spraying-story.node.spec.ts
@@ -14,6 +14,7 @@ import {
   GUIDED_STORY_SWITCH_INDEX,
   makeNetworkDynamicRangeProfile,
   makeNetworkOpticsProfile,
+  MAX_NETWORK_HDR_HIGHLIGHT_BOOST,
   MAX_NETWORK_OPTICS_LEVEL,
   NETWORK_STORY_CHAPTERS
 } from '../../examples/showcase/packet-spraying/story';
@@ -181,6 +182,14 @@ test('packet-spraying floating-point highlights preserve honest display capabili
     sceneColorFormat: 'rgba16float',
     visualIntensity: DEFAULT_NETWORK_OPTICS_LEVEL
   });
+  const diagramExtendedProfile = makeNetworkDynamicRangeProfile({
+    deviceType: 'webgpu',
+    displaySupportsHighDynamicRange: true,
+    highlightBoost: 0.35,
+    presentationColorFormat: 'rgba16float',
+    sceneColorFormat: 'rgba16float',
+    visualIntensity: 0
+  });
 
   testCase.equal(standardProfile.displayMode, 'standard', '8-bit scenes remain standard range');
   testCase.equal(standardProfile.highlightBoost, 0, 'standard scenes do not claim false headroom');
@@ -219,6 +228,16 @@ test('packet-spraying floating-point highlights preserve honest display capabili
     defaultExtendedProfile.maximumLuminance < 2,
     'default HDR highlights remain below twice SDR white'
   );
+  testCase.equal(
+    diagramExtendedProfile.highlightBoost,
+    extendedProfile.highlightBoost,
+    'visual style does not change independently selected HDR brightness'
+  );
+  testCase.equal(
+    diagramExtendedProfile.maximumLuminance,
+    extendedProfile.maximumLuminance,
+    'diagram mode preserves extended display headroom'
+  );
   testCase.ok(
     extendedProfile.bloomThresholdScale > floatingPointProfile.bloomThresholdScale,
     'selective bloom remains above ordinary scene brightness'
@@ -236,8 +255,8 @@ test('packet-spraying floating-point highlights preserve honest display capabili
       sceneColorFormat: 'rgba16float',
       visualIntensity: 0
     }).highlightBoost,
-    0,
-    'diagram mode disables additional HDR accents'
+    MAX_NETWORK_HDR_HIGHLIGHT_BOOST,
+    'the HDR control remains bounded independently of visual style'
   );
   testCase.end();
 });

--- a/test/examples/packet-spraying-story.node.spec.ts
+++ b/test/examples/packet-spraying-story.node.spec.ts
@@ -14,6 +14,7 @@ import {
   GUIDED_STORY_SWITCH_INDEX,
   makeNetworkDynamicRangeProfile,
   makeNetworkOpticsProfile,
+  makeNetworkSwitchHighlightColor,
   MAX_NETWORK_HDR_HIGHLIGHT_BOOST,
   MAX_NETWORK_OPTICS_LEVEL,
   NETWORK_STORY_CHAPTERS
@@ -146,6 +147,35 @@ test('packet-spraying visual style introduces optical effects in readable cinema
     makeNetworkOpticsProfile(Number.NaN).level,
     DEFAULT_NETWORK_OPTICS_LEVEL,
     'invalid values return to the cinematic default'
+  );
+  testCase.end();
+});
+
+test('packet-spraying hover highlights glass without washing out transparency or switch faults', testCase => {
+  const clearSwitch: [number, number, number, number] = [0.28, 0.48, 0.82, 0.3];
+  const failedSwitch: [number, number, number, number] = [1, 0.065, 0.035, 0.59];
+  const planeHighlight = makeNetworkSwitchHighlightColor(clearSwitch, 1, 0);
+  const pathHighlight = makeNetworkSwitchHighlightColor(clearSwitch, 0, 1);
+
+  testCase.deepEqual(
+    makeNetworkSwitchHighlightColor(clearSwitch, 0, 0),
+    clearSwitch,
+    'unfocused switches retain their original glass color'
+  );
+  testCase.ok(
+    planeHighlight[1] > clearSwitch[1] && planeHighlight[2] > clearSwitch[2],
+    'hovered plane switches ease toward a visible cool glass highlight'
+  );
+  testCase.ok(
+    pathHighlight[1] > planeHighlight[1],
+    'focused backbone paths retain a distinct cyan glass accent'
+  );
+  testCase.equal(planeHighlight[3], clearSwitch[3], 'plane highlighting preserves glass opacity');
+  testCase.equal(pathHighlight[3], clearSwitch[3], 'path highlighting preserves glass opacity');
+  testCase.deepEqual(
+    makeNetworkSwitchHighlightColor(failedSwitch, 1, 1),
+    failedSwitch,
+    'failed or congested switch colors remain visually authoritative'
   );
   testCase.end();
 });

--- a/test/examples/packet-spraying-story.node.spec.ts
+++ b/test/examples/packet-spraying-story.node.spec.ts
@@ -5,6 +5,7 @@
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {SWITCH_POSITIONS} from '../../examples/showcase/packet-spraying/network';
 import {
+  DEFAULT_NETWORK_HDR_HIGHLIGHT_BOOST,
   DEFAULT_NETWORK_OPTICS_LEVEL,
   getNetworkStoryBeat,
   getNetworkStoryChapter,
@@ -173,6 +174,13 @@ test('packet-spraying floating-point highlights preserve honest display capabili
     sceneColorFormat: 'rgba16float',
     visualIntensity: DEFAULT_NETWORK_OPTICS_LEVEL
   });
+  const defaultExtendedProfile = makeNetworkDynamicRangeProfile({
+    deviceType: 'webgpu',
+    displaySupportsHighDynamicRange: true,
+    presentationColorFormat: 'rgba16float',
+    sceneColorFormat: 'rgba16float',
+    visualIntensity: DEFAULT_NETWORK_OPTICS_LEVEL
+  });
 
   testCase.equal(standardProfile.displayMode, 'standard', '8-bit scenes remain standard range');
   testCase.equal(standardProfile.highlightBoost, 0, 'standard scenes do not claim false headroom');
@@ -202,6 +210,14 @@ test('packet-spraying floating-point highlights preserve honest display capabili
   testCase.ok(
     extendedProfile.maximumLuminance > 2,
     'true HDR preserves packet and glass highlights well above SDR white'
+  );
+  testCase.ok(
+    Math.abs(defaultExtendedProfile.highlightBoost - DEFAULT_NETWORK_HDR_HIGHLIGHT_BOOST) < 0.01,
+    'the guided tour uses a restrained HDR highlight setting by default'
+  );
+  testCase.ok(
+    defaultExtendedProfile.maximumLuminance < 2,
+    'default HDR highlights remain below twice SDR white'
   );
   testCase.ok(
     extendedProfile.bloomThresholdScale > floatingPointProfile.bloomThresholdScale,

--- a/test/examples/packet-spraying-story.node.spec.ts
+++ b/test/examples/packet-spraying-story.node.spec.ts
@@ -181,6 +181,11 @@ test('packet-spraying floating-point highlights preserve honest display capabili
     'floating-point',
     'floating-point scene color is distinguished from display HDR'
   );
+  testCase.equal(
+    floatingPointProfile.maximumLuminance,
+    1,
+    'SDR presentation never emits unsupported extended-range values'
+  );
   testCase.ok(
     floatingPointProfile.highlightBoost > 0,
     'floating-point scenes retain bright detail'
@@ -195,8 +200,16 @@ test('packet-spraying floating-point highlights preserve honest display capabili
     'an extended display may use more of the available highlight headroom'
   );
   testCase.ok(
+    extendedProfile.maximumLuminance > 2,
+    'true HDR preserves packet and glass highlights well above SDR white'
+  );
+  testCase.ok(
     extendedProfile.bloomThresholdScale > floatingPointProfile.bloomThresholdScale,
     'selective bloom remains above ordinary scene brightness'
+  );
+  testCase.ok(
+    extendedProfile.illuminationScale > floatingPointProfile.illuminationScale,
+    'HDR displays can show stronger packet-driven glass lighting without washing out SDR'
   );
   testCase.equal(
     makeNetworkDynamicRangeProfile({

--- a/test/examples/packet-spraying-story.node.spec.ts
+++ b/test/examples/packet-spraying-story.node.spec.ts
@@ -6,10 +6,12 @@ import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {SWITCH_POSITIONS} from '../../examples/showcase/packet-spraying/network';
 import {
   DEFAULT_NETWORK_OPTICS_LEVEL,
+  getNetworkStoryBeat,
   getNetworkStoryChapter,
   getNetworkStoryProgress,
   getWrappedStoryChapterIndex,
   GUIDED_STORY_SWITCH_INDEX,
+  makeNetworkDynamicRangeProfile,
   makeNetworkOpticsProfile,
   MAX_NETWORK_OPTICS_LEVEL,
   NETWORK_STORY_CHAPTERS
@@ -70,6 +72,41 @@ test('packet-spraying chapter timeline tracks duration-weighted guided playback'
   testCase.end();
 });
 
+test('packet-spraying cinematic story beats explain load, failure, and confirmed recovery', testCase => {
+  testCase.ok(
+    NETWORK_STORY_CHAPTERS.every(chapter =>
+      chapter.beats.every(
+        (beat, beatIndex) =>
+          beat.position >= 0 &&
+          beat.position < 1 &&
+          (beatIndex === 0 || beat.position >= chapter.beats[beatIndex - 1].position)
+      )
+    ),
+    'chapter event markers remain ordered within their timeline segments'
+  );
+  testCase.deepEqual(
+    NETWORK_STORY_CHAPTERS[1].beats.map(beat => beat.pathIndex),
+    [0, 1, 2, 3],
+    'the spraying chapter visits all four independent spine paths'
+  );
+  testCase.equal(getNetworkStoryBeat(1, 0), null, 'the first path waits for its explicit beat');
+  testCase.equal(getNetworkStoryBeat(1, 2.5)?.id, 'path-2');
+  testCase.equal(getNetworkStoryBeat(1, 7.5)?.id, 'path-4');
+  testCase.equal(getNetworkStoryBeat(2, 0)?.id, 'pressure', 'congestion is visible immediately');
+  testCase.equal(getNetworkStoryBeat(3, 0)?.id, 'packet-loss', 'failure begins with packet loss');
+  testCase.equal(
+    getNetworkStoryBeat(4, 4)?.id,
+    'confirmation',
+    'recovery waits for its cyan confirmation beat'
+  );
+  testCase.equal(
+    getNetworkStoryBeat(4, Number.NaN)?.id,
+    'probe',
+    'invalid elapsed times safely remain at the initial recovery beat'
+  );
+  testCase.end();
+});
+
 test('packet-spraying visual style introduces optical effects in readable cinematic stages', testCase => {
   const diagram = makeNetworkOpticsProfile(0);
   const clearGlass = makeNetworkOpticsProfile(3);
@@ -107,6 +144,71 @@ test('packet-spraying visual style introduces optical effects in readable cinema
     makeNetworkOpticsProfile(Number.NaN).level,
     DEFAULT_NETWORK_OPTICS_LEVEL,
     'invalid values return to the cinematic default'
+  );
+  testCase.end();
+});
+
+test('packet-spraying floating-point highlights preserve honest display capabilities', testCase => {
+  const standardProfile = makeNetworkDynamicRangeProfile({
+    deviceType: 'webgl',
+    displaySupportsHighDynamicRange: true,
+    highlightBoost: 0.35,
+    presentationColorFormat: 'rgba8unorm',
+    sceneColorFormat: 'rgba8unorm',
+    visualIntensity: DEFAULT_NETWORK_OPTICS_LEVEL
+  });
+  const floatingPointProfile = makeNetworkDynamicRangeProfile({
+    deviceType: 'webgl',
+    displaySupportsHighDynamicRange: true,
+    highlightBoost: 0.35,
+    presentationColorFormat: 'rgba8unorm',
+    sceneColorFormat: 'rgba16float',
+    visualIntensity: DEFAULT_NETWORK_OPTICS_LEVEL
+  });
+  const extendedProfile = makeNetworkDynamicRangeProfile({
+    deviceType: 'webgpu',
+    displaySupportsHighDynamicRange: true,
+    highlightBoost: 0.35,
+    presentationColorFormat: 'rgba16float',
+    sceneColorFormat: 'rgba16float',
+    visualIntensity: DEFAULT_NETWORK_OPTICS_LEVEL
+  });
+
+  testCase.equal(standardProfile.displayMode, 'standard', '8-bit scenes remain standard range');
+  testCase.equal(standardProfile.highlightBoost, 0, 'standard scenes do not claim false headroom');
+  testCase.equal(
+    floatingPointProfile.displayMode,
+    'floating-point',
+    'floating-point scene color is distinguished from display HDR'
+  );
+  testCase.ok(
+    floatingPointProfile.highlightBoost > 0,
+    'floating-point scenes retain bright detail'
+  );
+  testCase.ok(
+    floatingPointProfile.emissionScale < 1.2,
+    'SDR presentation receives only restrained floating-point accents'
+  );
+  testCase.equal(extendedProfile.displayMode, 'extended-hdr', 'true HDR requires an FP16 canvas');
+  testCase.ok(
+    extendedProfile.highlightBoost > floatingPointProfile.highlightBoost,
+    'an extended display may use more of the available highlight headroom'
+  );
+  testCase.ok(
+    extendedProfile.bloomThresholdScale > floatingPointProfile.bloomThresholdScale,
+    'selective bloom remains above ordinary scene brightness'
+  );
+  testCase.equal(
+    makeNetworkDynamicRangeProfile({
+      deviceType: 'webgpu',
+      displaySupportsHighDynamicRange: true,
+      highlightBoost: 8,
+      presentationColorFormat: 'rgba16float',
+      sceneColorFormat: 'rgba16float',
+      visualIntensity: 0
+    }).highlightBoost,
+    0,
+    'diagram mode disables additional HDR accents'
   );
   testCase.end();
 });


### PR DESCRIPTION
## Goals
- Make packet spraying easier to understand through an explicit, guided sequence of congestion, loss, rerouting, and probe-based recovery.
- Preserve the clear glass optics while presenting genuine extended-range highlights on capable WebGPU displays.

## Changes
- Add cinematic event markers, alternating congestion queues, dropped-packet scattering, retransmission, and control-probe recovery beats.
- Configure HDR-capable WebGPU canvases for `rgba16float`, Display P3, and extended tone mapping while retaining WebGL/SDR fallbacks.
- Extend the reusable tone-mapping shader pass with optional `maximumLuminance` support; existing SDR consumers retain the previous default of 1.
- Keep packet emission substantially above SDR white and selectively preserve approximately 2.8x SDR-white display highlights.
- Light switches from nearby packet arrivals rather than artificial selection shells, with stronger localized illumination only on true HDR displays.
- Add dynamic-range diagnostics, focused shader/story tests, and glass-effects documentation.

## Verification
- `env -u YARN_NO_PROXY corepack yarn lint fix`
- `env -u YARN_NO_PROXY corepack yarn build`
- `env -u YARN_NO_PROXY corepack yarn test-node` - 214 passing tests; 2 skipped.
- `env -u YARN_NO_PROXY corepack yarn workspace luma.gl-examples-showcase-packet-spraying build`
- Browser-verified WebGPU extended HDR, `rgba16float`, 18 story markers, six congestion queue packets, switch failure, and probe-based recovery.
- Full `yarn test` currently reaches an unrelated existing Arrow-layer WebGPU browser failure: `polygonViewportUniforms` is not found in the shader layout.

Stacked on #2775.