### PR TITLE
Enable HDR presentation for Bloom, Globe, and glTF

### DIFF
--- a/examples/experimental/bloom/app.ts
+++ b/examples/experimental/bloom/app.ts
@@ -9,9 +9,9 @@ import {
   loadImageBitmap,
   ShaderPassRenderer
 } from '@luma.gl/engine';
-import {Device} from '@luma.gl/core';
-import {bloom, bloomShaderPassPipeline} from '@luma.gl/effects';
-import type {ShaderPassPipeline} from '@luma.gl/shadertools';
+import {Device, type TextureFormatColor} from '@luma.gl/core';
+import {bloom, bloomShaderPassPipeline, toneMapping} from '@luma.gl/effects';
+import type {ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
 import {
   type Panel,
   type SettingsChangeDescriptor,
@@ -40,12 +40,21 @@ const BLOOM_BACKGROUND_HTML = `
 `;
 
 type BloomState = Record<'threshold' | 'intensity' | 'radius', number>;
-type ShaderPropType = NonNullable<typeof bloom.propTypes>[string];
+type ShaderPropType = {
+  value: number;
+  private?: boolean;
+  min?: number;
+  max?: number;
+  softMin?: number;
+  softMax?: number;
+};
+type ShaderPassLike = ShaderPass | ShaderPassPipeline;
 
 export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   static info = makeExamplePanelHostHtml();
 
   device: Device;
+  colorFormat: TextureFormatColor;
   imageTexture: DynamicTexture;
   bloomValues: BloomState = {...BLOOM_UNIFORMS};
   readonly settingsPanel: ExampleSettingsPanelManager;
@@ -56,6 +65,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     super();
 
     this.device = device;
+    this.colorFormat = getHighDynamicRangeColorFormat(device);
     this.imageTexture = this.createImageTexture('bloom-scene.png');
     this.settingsPanel = new ExampleSettingsPanelManager({
       id: 'bloom-settings',
@@ -65,7 +75,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     });
     this.panels = new ExamplePanelManager({panel: this.makePanel()});
     this.panels.mount();
-    this.setShaderPasses([this.getBloomPassPipeline()]);
+    this.setShaderPasses(this.getShaderPasses());
   }
 
   onFinalize(): void {
@@ -86,14 +96,31 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     });
   }
 
-  setShaderPasses(shaderPasses: ShaderPassPipeline[]): void {
+  setShaderPasses(shaderPasses: ShaderPassLike[]): void {
     this.shaderPassRenderer?.destroy();
-    this.shaderPassRenderer = new ShaderPassRenderer(this.device, {shaderPasses});
+    this.shaderPassRenderer = new ShaderPassRenderer(this.device, {
+      shaderPasses,
+      colorFormat: this.colorFormat
+    });
+  }
+
+  getShaderPasses(): ShaderPassLike[] {
+    const shaderPasses: ShaderPassLike[] = [this.getBloomPassPipeline()];
+    if (this.colorFormat === 'rgba16float' && this.device.preferredColorFormat !== 'rgba16float') {
+      shaderPasses.push(toneMapping);
+    }
+    return shaderPasses;
   }
 
   getBloomPassPipeline(): ShaderPassPipeline {
     return {
       ...bloomShaderPassPipeline,
+      renderTargets: Object.fromEntries(
+        Object.entries(bloomShaderPassPipeline.renderTargets).map(([targetName, renderTarget]) => [
+          targetName,
+          {...renderTarget, format: this.colorFormat}
+        ])
+      ),
       steps: bloomShaderPassPipeline.steps.map(step => {
         switch (step.shaderPass.name) {
           case 'bloomExtract':
@@ -117,7 +144,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         makeHtmlCustomPanel({
           id: 'bloom-description',
           title: 'Overview',
-          html: '<p>Experimental bloom pipeline demo using extracted highlights, multi-stage blur targets, and final recomposition.</p>'
+          html: this.makeOverviewHtml()
         }),
         this.settingsPanel.makePanel(),
         makeHtmlCustomPanel({
@@ -139,8 +166,27 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         this.bloomValues[propName] = nextValue;
       }
     }
-    this.setShaderPasses([this.getBloomPassPipeline()]);
+    this.setShaderPasses(this.getShaderPasses());
   };
+
+  private makeOverviewHtml(): string {
+    const processingDescription =
+      this.colorFormat === 'rgba16float'
+        ? 'Bloom processing uses floating-point render targets, preserving highlights above SDR white.'
+        : 'This device does not support filterable floating-point render targets, so bloom uses its preferred color format.';
+    const presentationDescription =
+      this.device.preferredColorFormat === 'rgba16float'
+        ? 'The HDR canvas presents extended highlights directly.'
+        : this.colorFormat === 'rgba16float'
+          ? 'ACES tone mapping compresses the HDR result for SDR presentation.'
+          : 'The bloom result uses standard dynamic-range presentation.';
+    return `<p>${processingDescription}</p><p>${presentationDescription}</p>`;
+  }
+}
+
+function getHighDynamicRangeColorFormat(device: Device): TextureFormatColor {
+  const capabilities = device.getTextureFormatCapabilities('rgba16float');
+  return capabilities.render && capabilities.filter ? 'rgba16float' : device.preferredColorFormat;
 }
 
 export function makeBloomSettingsSchema(): SettingsSchema {
@@ -151,7 +197,7 @@ export function makeBloomSettingsSchema(): SettingsSchema {
         id: 'bloom',
         name: 'Bloom',
         initiallyCollapsed: false,
-        settings: Object.entries(bloom.propTypes || {})
+        settings: Object.entries<ShaderPropType>(bloom.propTypes || {})
           .filter(([, propType]) => !propType.private && typeof propType.value === 'number')
           .map(([propName, propType]) => {
             const value = propType.value as number;

--- a/examples/experimental/bloom/app.ts
+++ b/examples/experimental/bloom/app.ts
@@ -27,9 +27,9 @@ import {
 } from '../../example-panels';
 
 const BLOOM_UNIFORMS = {
-  threshold: 0.55,
-  intensity: 1.8,
-  radius: 8
+  threshold: 0.1,
+  intensity: 5,
+  radius: 24
 } as const;
 
 const BLOOM_BACKGROUND_HTML = `
@@ -208,7 +208,7 @@ export function makeBloomSettingsSchema(): SettingsSchema {
               type: 'number' as const,
               persist: 'none' as const,
               min: bounds.min,
-              max: bounds.max,
+              max: getBloomControlMaximum(propName, bounds.max),
               step: bounds.step
             };
           })
@@ -237,6 +237,17 @@ function getControlBounds(
       : Math.max(Number(((max - min) / 200).toFixed(4)), 0.001);
 
   return {min, max, step};
+}
+
+function getBloomControlMaximum(propName: string, defaultMaximum: number): number {
+  switch (propName) {
+    case 'radius':
+      return 24;
+    case 'intensity':
+      return 8;
+    default:
+      return defaultMaximum;
+  }
 }
 
 function formatControlLabel(propName: string): string {

--- a/examples/experimental/bloom/index.html
+++ b/examples/experimental/bloom/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
     body {
       background: black;
@@ -8,10 +9,31 @@
   </style>
 </head>
 <script type="module">
+  import {luma} from '@luma.gl/core';
   import {webgl2Adapter} from '@luma.gl/webgl';
+  import {webgpuAdapter} from '@luma.gl/webgpu';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import AnimationLoopTemplate from './app.ts';
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgl2Adapter]});
+
+  const requestedDevice = new URLSearchParams(window.location.search).get('device');
+  const adapters =
+    requestedDevice === 'webgl'
+      ? [webgl2Adapter]
+      : requestedDevice === 'webgpu'
+        ? [webgpuAdapter]
+        : [webgpuAdapter, webgl2Adapter];
+  const supportsHighDynamicRange =
+    requestedDevice !== 'webgl' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(dynamic-range: high)').matches;
+  const device = luma.createDevice({
+    id: 'bloom',
+    adapters,
+    createCanvasContext: supportsHighDynamicRange
+      ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+      : true
+  });
+  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
   animationLoop.start();
 </script>
 <body></body>

--- a/examples/experimental/bloom/index.html
+++ b/examples/experimental/bloom/index.html
@@ -4,7 +4,23 @@
   <style>
     body {
       background: black;
+      color-scheme: dark;
       margin: 0;
+    }
+
+    #example-panel-container {
+      position: fixed;
+      top: 16px;
+      right: 16px;
+      z-index: 1;
+      width: min(360px, calc(100vw - 32px));
+      max-height: calc(100vh - 32px);
+      overflow: auto;
+      border: 1px solid rgb(255 255 255 / 15%);
+      border-radius: 8px;
+      background: rgb(3 7 18 / 82%);
+      color: white;
+      backdrop-filter: blur(12px);
     }
   </style>
 </head>
@@ -36,4 +52,8 @@
   const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
   animationLoop.start();
 </script>
-<body></body>
+<body>
+  <aside id="example-panel-container">
+    <div id="example-panel-host" data-example-panel-host></div>
+  </aside>
+</body>

--- a/examples/showcase/globe/app.ts
+++ b/examples/showcase/globe/app.ts
@@ -58,6 +58,7 @@ struct SkyboxSceneUniforms {
   modelMatrix: mat4x4<f32>,
   viewMatrix: mat4x4<f32>,
   projectionMatrix: mat4x4<f32>,
+  hdrStarsEnabled: i32,
 };
 
 @group(0) @binding(auto) var<uniform> skyboxScene : SkyboxSceneUniforms;
@@ -88,13 +89,17 @@ fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
 @fragment
 fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
   let skyColor = textureSample(cubeTexture, cubeTextureSampler, normalize(inputs.direction)).rgb;
-  return vec4<f32>(skyColor * 1.35, 1.0);
+  let starPeak = max(max(skyColor.r, skyColor.g), skyColor.b);
+  let hdrStarGain = 1.0 + smoothstep(0.1, 0.45, starPeak) * 5.0;
+  let starGain = select(1.0, hdrStarGain, skyboxScene.hdrStarsEnabled != 0);
+  return vec4<f32>(skyColor * starGain, 1.0);
 }
 `;
 
 const SKYBOX_SHADER_GLSL = /* glsl */ `\
 #version 300 es
 precision highp float;
+precision highp int;
 
 in vec3 positions;
 
@@ -104,6 +109,7 @@ uniform skyboxSceneUniforms {
   mat4 modelMatrix;
   mat4 viewMatrix;
   mat4 projectionMatrix;
+  int hdrStarsEnabled;
 } skyboxScene;
 
 void main(void) {
@@ -119,16 +125,26 @@ void main(void) {
 const SKYBOX_FRAGMENT_GLSL = /* glsl */ `\
 #version 300 es
 precision highp float;
+precision highp int;
 
 in vec3 vDirection;
 
 uniform samplerCube cubeTexture;
+uniform skyboxSceneUniforms {
+  mat4 modelMatrix;
+  mat4 viewMatrix;
+  mat4 projectionMatrix;
+  int hdrStarsEnabled;
+} skyboxScene;
 
 out vec4 fragColor;
 
 void main(void) {
   vec3 skyColor = texture(cubeTexture, normalize(vDirection)).rgb;
-  fragColor = vec4(skyColor * 1.35, 1.0);
+  float starPeak = max(max(skyColor.r, skyColor.g), skyColor.b);
+  float hdrStarGain = 1.0 + smoothstep(0.1, 0.45, starPeak) * 5.0;
+  float starGain = skyboxScene.hdrStarsEnabled != 0 ? hdrStarGain : 1.0;
+  fragColor = vec4(skyColor * starGain, 1.0);
 }
 `;
 
@@ -139,6 +155,7 @@ struct GlobeSceneUniforms {
   normalMatrix: mat4x4<f32>,
   cameraPosition: vec3<f32>,
   showLandTexture: i32,
+  oceanReflectionStrength: f32,
 };
 
 @group(0) @binding(auto) var<uniform> globeScene : GlobeSceneUniforms;
@@ -234,6 +251,7 @@ struct GlobeSceneUniforms {
   normalMatrix: mat4x4<f32>,
   cameraPosition: vec3<f32>,
   showLandTexture: i32,
+  oceanReflectionStrength: f32,
 };
 
 @group(0) @binding(auto) var<uniform> globeScene : GlobeSceneUniforms;
@@ -286,6 +304,10 @@ fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
     normalizedNormal,
     surfaceUV
   );
+  let waterLuminance = dot(waterColor.rgb, vec3<f32>(0.2126, 0.7152, 0.0722));
+  let waterReflectionGain =
+    1.0 + smoothstep(0.6, 0.95, waterLuminance) * globeScene.oceanReflectionStrength;
+  let oceanColor = waterColor.rgb * waterReflectionGain;
   var sunVisibility = 1.0;
   let viewDirection = normalize(globeScene.cameraPosition - inputs.fragPosition);
   let iceRim = pow(1.0 - max(dot(viewDirection, normalizedNormal), 0.0), 5.0);
@@ -310,7 +332,7 @@ fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
 
   let iceColor = vec3<f32>(0.95, 0.98, 1.0) + vec3<f32>(0.85, 0.92, 1.0) * iceRim * 0.28 + iceHighlight;
   let finalColor =
-    (waterColor.rgb * openWaterMask + iceColor * polarIceMask) *
+    (oceanColor * openWaterMask + iceColor * polarIceMask) *
     mix(0.18, 1.0, sunVisibility);
   let finalAlpha = waterColor.a * openWaterMask + 0.96 * polarIceMask;
   return vec4<f32>(finalColor, finalAlpha);
@@ -337,6 +359,7 @@ uniform globeSceneUniforms {
   mat4 normalMatrix;
   vec3 cameraPosition;
   int showLandTexture;
+  float oceanReflectionStrength;
 } globeScene;
 
 void main(void) {
@@ -368,6 +391,7 @@ uniform globeSceneUniforms {
   mat4 normalMatrix;
   vec3 cameraPosition;
   int showLandTexture;
+  float oceanReflectionStrength;
 } globeScene;
 
 out vec4 fragColor;
@@ -434,6 +458,7 @@ uniform globeSceneUniforms {
   mat4 normalMatrix;
   vec3 cameraPosition;
   int showLandTexture;
+  float oceanReflectionStrength;
 } globeScene;
 
 out vec4 fragColor;
@@ -453,6 +478,10 @@ void main(void) {
     normalizedNormal,
     surfaceUV
   );
+  float waterLuminance = dot(waterColor.rgb, vec3(0.2126, 0.7152, 0.0722));
+  float waterReflectionGain =
+    1.0 + smoothstep(0.6, 0.95, waterLuminance) * globeScene.oceanReflectionStrength;
+  vec3 oceanColor = waterColor.rgb * waterReflectionGain;
   float sunVisibility = 1.0;
   vec3 viewDirection = normalize(globeScene.cameraPosition - vPosition);
   float iceRim = pow(1.0 - max(dot(viewDirection, normalizedNormal), 0.0), 5.0);
@@ -480,7 +509,7 @@ void main(void) {
     vec3(0.85, 0.92, 1.0) * iceRim * 0.28 +
     iceHighlight;
   vec3 finalColor =
-    waterColor.rgb * openWaterMask +
+    oceanColor * openWaterMask +
     iceColor * polarIceMask;
   finalColor *= mix(0.18, 1.0, sunVisibility);
   float finalAlpha = waterColor.a * openWaterMask + 0.96 * polarIceMask;
@@ -495,7 +524,8 @@ const globeScene: ShaderModule<GlobeSceneUniforms, GlobeSceneUniforms> = {
     modelMatrix: 'mat4x4<f32>',
     normalMatrix: 'mat4x4<f32>',
     cameraPosition: 'vec3<f32>',
-    showLandTexture: 'i32'
+    showLandTexture: 'i32',
+    oceanReflectionStrength: 'f32'
   }
 };
 
@@ -504,7 +534,8 @@ const skyboxScene: ShaderModule<SkyboxSceneUniforms, SkyboxSceneUniforms> = {
   uniformTypes: {
     modelMatrix: 'mat4x4<f32>',
     viewMatrix: 'mat4x4<f32>',
-    projectionMatrix: 'mat4x4<f32>'
+    projectionMatrix: 'mat4x4<f32>',
+    hdrStarsEnabled: 'i32'
   }
 };
 
@@ -514,22 +545,26 @@ type GlobeSceneUniforms = {
   normalMatrix: Matrix4;
   cameraPosition: [number, number, number];
   showLandTexture: number;
+  oceanReflectionStrength: number;
 };
 
 type SkyboxSceneUniforms = {
   modelMatrix: Matrix4;
   viewMatrix: Matrix4;
   projectionMatrix: Matrix4;
+  hdrStarsEnabled: number;
 };
 
 type GlobeControls = {
   starBackgroundEnabled: boolean;
+  hdrStarsEnabled: boolean;
   waterEnabled: boolean;
   landTextureEnabled: boolean;
   waveSpeed: number;
   normalStrength: number;
   fresnelPower: number;
   specularIntensity: number;
+  oceanReflectionStrength: number;
   lightAzimuth: number;
   lightElevation: number;
 };
@@ -550,12 +585,14 @@ type SkyboxShaderInputs = {
 
 const DEFAULT_CONTROLS: GlobeControls = {
   starBackgroundEnabled: true,
+  hdrStarsEnabled: true,
   waterEnabled: true,
   landTextureEnabled: true,
   waveSpeed: 1.25,
   normalStrength: 0.52,
   fresnelPower: 6.2,
   specularIntensity: 2.45,
+  oceanReflectionStrength: 0.65,
   lightAzimuth: -38,
   lightElevation: 34
 };
@@ -846,7 +883,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         skyboxScene: {
           modelMatrix: new Matrix4().scale([40, 40, 40]),
           viewMatrix: skyboxViewMatrix,
-          projectionMatrix
+          projectionMatrix,
+          hdrStarsEnabled: this.controls.hdrStarsEnabled ? 1 : 0
         }
       });
       this.backgroundModel.draw(renderPass);
@@ -865,7 +903,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         modelMatrix: globeRotation,
         normalMatrix,
         cameraPosition,
-        showLandTexture: this.controls.landTextureEnabled ? 1 : 0
+        showLandTexture: this.controls.landTextureEnabled ? 1 : 0,
+        oceanReflectionStrength: this.controls.oceanReflectionStrength
       },
       lighting: lightingProps
     });
@@ -876,7 +915,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         modelMatrix: globeRotation,
         normalMatrix,
         cameraPosition,
-        showLandTexture: this.controls.landTextureEnabled ? 1 : 0
+        showLandTexture: this.controls.landTextureEnabled ? 1 : 0,
+        oceanReflectionStrength: this.controls.oceanReflectionStrength
       },
       lighting: lightingProps
     });
@@ -985,6 +1025,12 @@ function makeGlobeSettingsSchema(): SettingsSchema {
             type: 'boolean',
             persist: 'none'
           },
+          {
+            name: 'hdrStarsEnabled',
+            label: 'HDR Stars',
+            type: 'boolean',
+            persist: 'none'
+          },
           {name: 'waterEnabled', label: 'Water Overlay', type: 'boolean', persist: 'none'},
           {name: 'landTextureEnabled', label: 'Land Texture', type: 'boolean', persist: 'none'}
         ]
@@ -1023,11 +1069,20 @@ function makeGlobeSettingsSchema(): SettingsSchema {
           },
           {
             name: 'specularIntensity',
-            label: 'Specular Intensity',
+            label: 'Base Specular',
             type: 'number',
             persist: 'none',
             min: 0,
             max: 5,
+            step: 0.05
+          },
+          {
+            name: 'oceanReflectionStrength',
+            label: 'HDR Reflection Boost',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2,
             step: 0.05
           }
         ]

--- a/examples/showcase/globe/app.ts
+++ b/examples/showcase/globe/app.ts
@@ -223,7 +223,7 @@ fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
 
   litColor += vec3<f32>(0.9, 0.96, 1.0) * iceMask * (iceRim * 0.55) + iceHighlight * iceMask;
   litColor *= mix(0.22, 1.0, sunVisibility);
-  return vec4<f32>(min(litColor, vec3<f32>(1.0, 1.0, 1.0)), 1.0);
+  return vec4<f32>(litColor, 1.0);
 }
 `;
 
@@ -310,7 +310,7 @@ fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4<f32> {
 
   let iceColor = vec3<f32>(0.95, 0.98, 1.0) + vec3<f32>(0.85, 0.92, 1.0) * iceRim * 0.28 + iceHighlight;
   let finalColor =
-    (waterColor.rgb * openWaterMask + min(iceColor, vec3<f32>(1.0, 1.0, 1.0)) * polarIceMask) *
+    (waterColor.rgb * openWaterMask + iceColor * polarIceMask) *
     mix(0.18, 1.0, sunVisibility);
   let finalAlpha = waterColor.a * openWaterMask + 0.96 * polarIceMask;
   return vec4<f32>(finalColor, finalAlpha);
@@ -412,7 +412,7 @@ void main(void) {
 
   litColor += vec3(0.9, 0.96, 1.0) * iceMask * (iceRim * 0.55) + iceHighlight * iceMask;
   litColor *= mix(0.22, 1.0, sunVisibility);
-  fragColor = vec4(min(litColor, vec3(1.0)), 1.0);
+  fragColor = vec4(litColor, 1.0);
 }
 `;
 
@@ -481,7 +481,7 @@ void main(void) {
     iceHighlight;
   vec3 finalColor =
     waterColor.rgb * openWaterMask +
-    min(iceColor, vec3(1.0)) * polarIceMask;
+    iceColor * polarIceMask;
   finalColor *= mix(0.18, 1.0, sunVisibility);
   float finalAlpha = waterColor.a * openWaterMask + 0.96 * polarIceMask;
   fragColor = vec4(finalColor, finalAlpha);

--- a/examples/showcase/globe/app.ts
+++ b/examples/showcase/globe/app.ts
@@ -591,8 +591,8 @@ const DEFAULT_CONTROLS: GlobeControls = {
   waveSpeed: 1.25,
   normalStrength: 0.52,
   fresnelPower: 6.2,
-  specularIntensity: 2.45,
-  oceanReflectionStrength: 0.65,
+  specularIntensity: 1.8,
+  oceanReflectionStrength: 0.2,
   lightAzimuth: -38,
   lightElevation: 34
 };
@@ -713,7 +713,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     });
 
     const globeGeometry = new SphereGeometry({radius: 1, nlat: 48, nlong: 72});
-    const oceanGeometry = new SphereGeometry({radius: 1.012, nlat: 48, nlong: 72});
+    const oceanGeometry = new SphereGeometry({radius: 1.002, nlat: 48, nlong: 72});
     const landMaterialFactory = new MaterialFactory<
       {phongMaterial: typeof phongMaterial.props},
       {}

--- a/examples/showcase/globe/index.html
+++ b/examples/showcase/globe/index.html
@@ -1,14 +1,31 @@
 <!doctype html>
 <head>
   <script type="module">
+    import {luma} from '@luma.gl/core';
     import {makeAnimationLoop} from '@luma.gl/engine';
     import {webgpuAdapter} from '@luma.gl/webgpu';
     import {webgl2Adapter} from '@luma.gl/webgl';
     import AnimationLoopTemplate from './app.ts';
 
-    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {
-      adapters: [webgpuAdapter, webgl2Adapter]
+    const requestedDevice = new URLSearchParams(window.location.search).get('device');
+    const adapters =
+      requestedDevice === 'webgl'
+        ? [webgl2Adapter]
+        : requestedDevice === 'webgpu'
+          ? [webgpuAdapter]
+          : [webgpuAdapter, webgl2Adapter];
+    const supportsHighDynamicRange =
+      requestedDevice !== 'webgl' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(dynamic-range: high)').matches;
+    const device = luma.createDevice({
+      id: 'globe',
+      adapters,
+      createCanvasContext: supportsHighDynamicRange
+        ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+        : true
     });
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
     animationLoop.start();
   </script>
   <style>

--- a/examples/showcase/gltf/index.html
+++ b/examples/showcase/gltf/index.html
@@ -1,12 +1,31 @@
 <!doctype html>
 <head>
   <script type="module">
+    import {luma} from '@luma.gl/core';
     import {makeAnimationLoop} from '@luma.gl/engine';
     import {webgpuAdapter} from '@luma.gl/webgpu';
     import {webgl2Adapter} from '@luma.gl/webgl';
     import AnimationLoopTemplate from './app.ts';
 
-    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter, webgl2Adapter]});
+    const requestedDevice = new URLSearchParams(window.location.search).get('device');
+    const adapters =
+      requestedDevice === 'webgl'
+        ? [webgl2Adapter]
+        : requestedDevice === 'webgpu'
+          ? [webgpuAdapter]
+          : [webgpuAdapter, webgl2Adapter];
+    const supportsHighDynamicRange =
+      requestedDevice !== 'webgl' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(dynamic-range: high)').matches;
+    const device = luma.createDevice({
+      id: 'gltf',
+      adapters,
+      createCanvasContext: supportsHighDynamicRange
+        ? {colorFormat: 'rgba16float', colorSpace: 'display-p3', toneMapping: 'extended'}
+        : true
+    });
+    const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
     animationLoop.start();
   </script>
   <style>

--- a/modules/core/test/adapter/device.spec.ts
+++ b/modules/core/test/adapter/device.spec.ts
@@ -48,6 +48,20 @@ test('Device#isTextureFormatCompressed', async t => {
   t.end();
 });
 
+test('WebGPUDevice reports baseline rgba16float capabilities', async t => {
+  const device = await getWebGPUTestDevice('core');
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const capabilities = device.getTextureFormatCapabilities('rgba16float');
+  t.equal(capabilities.render, true, 'rgba16float is renderable');
+  t.equal(capabilities.filter, true, 'rgba16float is filterable');
+  t.end();
+});
+
 test('Device#getSupportedCompressedTextureFormats', async t => {
   for (const device of await getTestDevices()) {
     const formats = device.getSupportedCompressedTextureFormats();

--- a/modules/webgpu/src/adapter/webgpu-canvas-context.ts
+++ b/modules/webgpu/src/adapter/webgpu-canvas-context.ts
@@ -20,6 +20,9 @@ import {getCpuHotspotProfiler, getTimestamp} from './helpers/cpu-hotspot-profile
 export class WebGPUCanvasContext extends CanvasContext {
   readonly device: WebGPUDevice;
   readonly handle: GPUCanvasContext;
+  colorFormat?: 'rgba8unorm' | 'bgra8unorm' | 'rgba16float';
+  colorSpace?: 'srgb' | 'display-p3';
+  toneMapping?: 'standard' | 'extended';
 
   private colorAttachment: WebGPUTexture | null = null;
   private depthStencilAttachment: WebGPUTexture | null = null;
@@ -72,16 +75,42 @@ export class WebGPUCanvasContext extends CanvasContext {
       this.depthStencilAttachment = null;
     }
 
-    // Reconfigure the canvas size.
-    this.handle.configure({
+    const requestedConfiguration: GPUCanvasConfiguration = {
       device: this.device.handle,
-      format: this.device.preferredColorFormat,
+      format: this.colorFormat || this.device.preferredColorFormat,
       // Can be used to define e.g. -srgb views
       // viewFormats: [...]
-      colorSpace: this.props.colorSpace,
+      colorSpace: this.colorSpace || this.props.colorSpace,
       alphaMode: this.props.alphaMode,
-      toneMapping: {mode: this.props.toneMapping}
-    });
+      toneMapping: {mode: this.toneMapping || this.props.toneMapping}
+    };
+
+    // Reconfigure the canvas size.
+    this.handle.configure(requestedConfiguration);
+
+    let configuredConfiguration = requestedConfiguration;
+    let acceptedConfiguration = this.handle.getConfiguration();
+    if (
+      requestedConfiguration.toneMapping?.mode === 'extended' &&
+      !isHighDynamicRangeCanvasConfiguration(acceptedConfiguration)
+    ) {
+      const standardConfiguration: GPUCanvasConfiguration = {
+        device: this.device.handle,
+        format: navigator.gpu.getPreferredCanvasFormat(),
+        colorSpace: 'srgb',
+        alphaMode: this.props.alphaMode,
+        toneMapping: {mode: 'standard'}
+      };
+      this.handle.configure(standardConfiguration);
+      configuredConfiguration = standardConfiguration;
+      acceptedConfiguration = this.handle.getConfiguration();
+    }
+
+    this.colorFormat = (acceptedConfiguration?.format ||
+      configuredConfiguration.format) as typeof this.colorFormat;
+    this.colorSpace = acceptedConfiguration?.colorSpace || configuredConfiguration.colorSpace;
+    this.toneMapping =
+      acceptedConfiguration?.toneMapping?.mode || configuredConfiguration.toneMapping?.mode;
 
     this._createDepthStencilAttachment(this.device.preferredDepthFormat);
   }
@@ -194,4 +223,10 @@ export class WebGPUCanvasContext extends CanvasContext {
     }
     return this.depthStencilAttachment!;
   }
+}
+
+export function isHighDynamicRangeCanvasConfiguration(
+  configuration: GPUCanvasConfigurationOut | null
+): boolean {
+  return configuration?.format === 'rgba16float' && configuration.toneMapping?.mode === 'extended';
 }

--- a/modules/webgpu/src/adapter/webgpu-device.ts
+++ b/modules/webgpu/src/adapter/webgpu-device.ts
@@ -141,6 +141,7 @@ export class WebGPUDevice extends Device {
     // Note: WebGPU devices can be created without a canvas, for compute shader purposes
     if (canvasContextProps) {
       this.canvasContext = new WebGPUCanvasContext(this, this.adapter, canvasContextProps);
+      this.preferredColorFormat = this.canvasContext.colorFormat || this.preferredColorFormat;
     }
 
     this.commandEncoder = this.createCommandEncoder({});
@@ -556,6 +557,7 @@ export class WebGPUDevice extends Device {
       'compilation-status-async-webgl',
       'float32-renderable-webgl',
       'float16-renderable-webgl',
+      'float16-filterable-webgl',
       'norm16-renderable-webgl',
       'texture-filterable-anisotropic-webgl',
       'shader-noperspective-interpolation-webgl'

--- a/modules/webgpu/test/webgpu/adapter/webgpu-adapter.spec.ts
+++ b/modules/webgpu/test/webgpu/adapter/webgpu-adapter.spec.ts
@@ -10,6 +10,7 @@ import {
   getWebGPUFeatureLevel,
   getWebGPURequestAdapterOptions
 } from '../../../src/adapter/webgpu-adapter';
+import {isHighDynamicRangeCanvasConfiguration} from '../../../src/adapter/webgpu-canvas-context';
 
 test('WebGPUAdapter imports from the ESM package entry without circular init errors', async t => {
   t.plan(2);
@@ -133,5 +134,33 @@ test('WebGPUAdapter feature helpers keep requested profiles separate', t => {
     'best available reports compatibility when core is unavailable'
   );
 
+  t.end();
+});
+
+test('isHighDynamicRangeCanvasConfiguration verifies accepted HDR presentation', t => {
+  const standardConfiguration = {
+    format: 'rgba16float',
+    toneMapping: {mode: 'standard'}
+  } as GPUCanvasConfigurationOut;
+  const highDynamicRangeConfiguration = {
+    format: 'rgba16float',
+    toneMapping: {mode: 'extended'}
+  } as GPUCanvasConfigurationOut;
+
+  t.equal(
+    isHighDynamicRangeCanvasConfiguration(standardConfiguration),
+    false,
+    'floating-point presentation without extended tone mapping is not HDR'
+  );
+  t.equal(
+    isHighDynamicRangeCanvasConfiguration(highDynamicRangeConfiguration),
+    true,
+    'floating-point presentation with extended tone mapping is HDR'
+  );
+  t.equal(
+    isHighDynamicRangeCanvasConfiguration(null),
+    false,
+    'an unavailable configuration cannot verify HDR support'
+  );
   t.end();
 });

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -549,6 +549,7 @@ export const GLTFExample: React.FC<WebsiteExampleProps> = props => (
     directory="showcase"
     template={GLTFApp}
     config={exampleConfig}
+    canvasContextProfile="high-dynamic-range"
     {...props}
   />
 );
@@ -933,6 +934,7 @@ export const GlobeExample: React.FC = props => (
     directory="showcase"
     template={GlobeApp}
     config={exampleConfig}
+    canvasContextProfile="high-dynamic-range"
     {...props}
   />
 );

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -1016,6 +1016,7 @@ export const BloomExample: React.FC<WebsiteExampleProps> = props => (
     directory="experimental"
     template={BloomApp}
     config={exampleConfig}
+    canvasContextProfile="high-dynamic-range"
     {...props}
   />
 );

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -17,6 +17,7 @@ import {
   createPresentationDevice,
   getCanvasContainer,
   getPreferredAvailableDeviceType,
+  type CanvasContextProfile,
   type DeviceType,
   useStore
 } from '../store/device-store';
@@ -66,6 +67,7 @@ export type LumaExampleProps = React.PropsWithChildren<
   showHeader?: boolean;
   showStats?: boolean;
   devices?: DeviceTabSelection[];
+  canvasContextProfile?: CanvasContextProfile;
   templateInfoPlacement?: 'header' | 'page';
   headerControls?: React.ReactNode;
   }
@@ -214,9 +216,13 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
       }
 
       if (!requestedDeviceTypes || requestedDeviceTypes.includes(deviceType)) {
+        const exampleDevice =
+          props.canvasContextProfile && props.canvasContextProfile !== 'default'
+            ? await createDevice(deviceType, props.canvasContextProfile)
+            : device;
         if (!isCancelled) {
           setEffectiveDeviceType(deviceType);
-          setEffectiveDevice(device);
+          setEffectiveDevice(exampleDevice);
         }
         return;
       }
@@ -230,7 +236,7 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
         return;
       }
 
-      const fallbackDevice = await createDevice(fallbackDeviceType);
+      const fallbackDevice = await createDevice(fallbackDeviceType, props.canvasContextProfile);
       await createPresentationDevice(fallbackDeviceType);
       if (!isCancelled) {
         setEffectiveDeviceType(fallbackDeviceType);
@@ -243,7 +249,7 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
     return () => {
       isCancelled = true;
     };
-  }, [deviceType, device, requestedDeviceTypesKey]);
+  }, [deviceType, device, props.canvasContextProfile, requestedDeviceTypesKey]);
 
   useEffect(() => {
     if (!canvasContainerRef.current || !effectiveDeviceType || !effectiveDevice) {

--- a/website/src/react-luma/store/device-store.tsx
+++ b/website/src/react-luma/store/device-store.tsx
@@ -14,6 +14,8 @@ const DEFAULT_DEVICE_TYPE: DeviceType = 'webgpu-core';
 const FALLBACK_DEVICE_TYPE_ORDER: DeviceType[] = ['webgpu-core', 'webgpu-compatibility', 'webgl'];
 
 export type DeviceType = 'webgl' | 'webgpu-core' | 'webgpu-max' | 'webgpu-compatibility';
+export type CanvasContextProfile = 'default' | 'high-dynamic-range';
+type DeviceCacheKey = `${DeviceType}:${CanvasContextProfile}`;
 
 const WEBGPU_FEATURE_LEVELS = {
   'webgpu-core': 'core',
@@ -30,7 +32,7 @@ export type Store = {
   setDeviceType: (type: any) => Promise<void>;
 };
 
-let cachedDevice: Partial<Record<DeviceType, Promise<Device>>> = {};
+let cachedDevice: Partial<Record<DeviceCacheKey, Promise<Device>>> = {};
 let cachedPresentationDevice: Partial<Record<DeviceType, Promise<Device>>> = {};
 let cachedDeviceAvailability: Partial<Record<DeviceType, Promise<boolean>>> = {};
 let deviceRequestGeneration = 0;
@@ -45,26 +47,46 @@ export function getCanvasContainer() {
   return cachedContainer;
 }
 
-export async function createDevice(type: DeviceType): Promise<Device> {
-  cachedDevice[type] ||= (async () => {
+export async function createDevice(
+  type: DeviceType,
+  canvasContextProfile: CanvasContextProfile = 'default'
+): Promise<Device> {
+  const resolvedCanvasContextProfile = resolveCanvasContextProfile(type, canvasContextProfile);
+  const cacheKey: DeviceCacheKey = `${type}:${resolvedCanvasContextProfile}`;
+  cachedDevice[cacheKey] ||= (async () => {
     const device = await luma.createDevice({
       adapters: [webgl2Adapter, webgpuAdapter],
       ...getDeviceRequestProps(type),
       debugGPUTime: true,
       createCanvasContext: {
         container: getCanvasContainer(),
-        alphaMode: 'opaque'
+        alphaMode: 'opaque',
+        ...(resolvedCanvasContextProfile === 'high-dynamic-range'
+          ? {
+              colorFormat: 'rgba16float' as const,
+              colorSpace: 'display-p3' as const,
+              toneMapping: 'extended' as const
+            }
+          : {})
       }
     });
 
     validateCreatedDeviceType(type, device);
     return device;
   })().catch(error => {
-    delete cachedDevice[type];
+    delete cachedDevice[cacheKey];
     throw error;
   });
 
-  return await cachedDevice[type]!;
+  try {
+    return await cachedDevice[cacheKey]!;
+  } catch (error) {
+    if (resolvedCanvasContextProfile === 'high-dynamic-range') {
+      logError(`Failed to create ${type} HDR canvas; falling back to standard presentation`, error);
+      return await createDevice(type);
+    }
+    throw error;
+  }
 }
 
 export async function createPresentationDevice(type: DeviceType): Promise<Device> {
@@ -233,6 +255,21 @@ function getDeviceRequestProps(type: DeviceType): {
 
 function isWebGPUDeviceType(type: DeviceType): boolean {
   return type.startsWith('webgpu-');
+}
+
+function resolveCanvasContextProfile(
+  type: DeviceType,
+  canvasContextProfile: CanvasContextProfile
+): CanvasContextProfile {
+  const supportsHighDynamicRange =
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(dynamic-range: high)').matches;
+  return canvasContextProfile === 'high-dynamic-range' &&
+    isWebGPUDeviceType(type) &&
+    supportsHighDynamicRange
+    ? 'high-dynamic-range'
+    : 'default';
 }
 
 function validateCreatedDeviceType(type: DeviceType, device: Device): void {


### PR DESCRIPTION
## What changed

- Add a reusable per-example `high-dynamic-range` canvas profile to the website device cache with graceful SDR and WebGL fallback.
- Report baseline filterability for half-float WebGPU textures so Bloom retains HDR intermediates on ordinary SDR canvases.
- Verify extended HDR presentation through `GPUCanvasContext.getConfiguration()` and transparently reconfigure unsupported canvases for SDR presentation.
- Run Bloom in filterable `rgba16float` targets, present extended highlights on HDR WebGPU canvases, and tone map for SDR presentation.
- Strengthen Bloom defaults and expose its controls in the standalone example.
- Enable HDR canvases for the standalone and website Globe and glTF/PBR showcases.
- Preserve Globe star, ice, land, and restrained ocean highlights above SDR white, with website controls for HDR stars and ocean reflection.

## Why

Bloom, environment-lit PBR materials, emissive surfaces, stars, and specular sunlight naturally produce values above SDR white. These examples previously presented through standard canvases, while Globe additionally discarded extended surface highlights in its shaders.

## Validation

- `yarn lint fix`
- `yarn build`
- Bloom, Globe, and glTF production Vite bundles
- Live browser verification of Bloom, Globe, and glTF
- Node tests: 209 passed, 2 skipped
- Headless browser tests: 1,288 passed, 25 skipped; one unrelated Arrow polygon storage test failed
- `yarn website:build`: client and server bundles compiled previously; static-page emission stopped with `ENOSPC`
