### PR TITLE
fix(showcase): restore glass focus and harden MRC recovery

### DIFF
--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -101,6 +101,7 @@ import {
   getPointAlongRoute,
   getRouteSegmentStartDistance,
   isFailedSwitchPosition,
+  isSwitchProbeRouteAvailable,
   makeActiveLinkKeys,
   makeConversationRoutes,
   makeEndpointSignals,
@@ -1643,6 +1644,10 @@ class NetworkStoryControls {
     );
   }
 
+  focusOpticsButton(): void {
+    this.opticsButton.focus();
+  }
+
   setVisualIntensity(level: number): void {
     const profile = makeNetworkOpticsProfile(level);
     this.visualIntensityInput.value = String(profile.level);
@@ -1868,6 +1873,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private readonly nextCongestionTrimTimes = new Map<number, number>();
   private readonly nextSwitchProbeTimes = new Map<number, number>();
   private readonly recoveryProbeCompletionTimes = new Map<number, number>();
+  private readonly recoveryProbeConfirmations = new Map<number, NetworkPacketEvent>();
   private animationTime = 0;
   private droppedPacketCount = 0;
   private trimmedPacketCount = 0;
@@ -2937,6 +2943,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.nextCongestionTrimTimes.clear();
     this.nextSwitchProbeTimes.clear();
     this.recoveryProbeCompletionTimes.clear();
+    this.recoveryProbeConfirmations.clear();
     this.networkPacketEvents.splice(0, this.networkPacketEvents.length);
     this.queuedPacketDefinitions = [];
     this.switchTransitionWaves.splice(0, this.switchTransitionWaves.length);
@@ -3161,8 +3168,12 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   }
 
   private setOpticsPanelVisible(isVisible: boolean): void {
+    const wasVisible = this.canvas?.dataset.packetSprayingOpticsExpanded === 'true';
     this.opticsPanel?.setVisible(isVisible);
     this.storyControls?.setOpticsExpanded(isVisible);
+    if (!isVisible && wasVisible) {
+      this.storyControls?.focusOpticsButton();
+    }
     if (this.canvas) {
       this.canvas.dataset.packetSprayingOpticsExpanded = String(isVisible);
     }
@@ -3236,11 +3247,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.failedSwitchIndices.delete(switchIndex);
       this.nextSwitchProbeTimes.delete(switchIndex);
       this.glassInstances[switchIndex].color = [...this.originalGlassColors[switchIndex]] as Color;
-
-      if (makeSwitchProbeEvent(this.conversationRoutes, switchIndex, this.animationTime)) {
-        this.recoveringSwitchIndices.add(switchIndex);
-        this.nextSwitchProbeTimes.set(switchIndex, this.animationTime);
-      }
+      this.recoveringSwitchIndices.add(switchIndex);
+      this.nextSwitchProbeTimes.set(switchIndex, this.animationTime);
     } else if (this.detectingSwitchTimes.has(switchIndex)) {
       this.completeSwitchFailure(switchIndex);
       return;
@@ -3277,6 +3285,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private completeSwitchRecovery(switchIndex: number): void {
     this.recoveringSwitchIndices.delete(switchIndex);
     this.recoveryProbeCompletionTimes.delete(switchIndex);
+    this.recoveryProbeConfirmations.delete(switchIndex);
     this.glassInstances[switchIndex].color = [...this.originalGlassColors[switchIndex]] as Color;
     this.switchTransitionWaves.push(
       makeSwitchTransitionWave(switchIndex, 'recovery', this.animationTime)
@@ -3322,7 +3331,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       if (animationTime >= nextProbeTime) {
         const unavailableSwitchIndices = new Set([
           ...this.failedSwitchIndices,
-          ...this.recoveringSwitchIndices
+          ...this.recoveringSwitchIndices,
+          ...this.detectingSwitchTimes.keys()
         ]);
         const probe = makeSwitchProbeEvent(
           this.conversationRoutes,
@@ -3339,6 +3349,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
               switchIndex,
               confirmation.startedAt + confirmation.duration
             );
+            this.recoveryProbeConfirmations.set(switchIndex, confirmation);
             this.nextSwitchProbeTimes.delete(switchIndex);
             continue;
           }
@@ -3349,7 +3360,19 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
     for (const [switchIndex, completionTime] of this.recoveryProbeCompletionTimes) {
       if (animationTime >= completionTime) {
-        this.completeSwitchRecovery(switchIndex);
+        const confirmation = this.recoveryProbeConfirmations.get(switchIndex);
+        const unavailableSwitchIndices = new Set([
+          ...this.failedSwitchIndices,
+          ...this.recoveringSwitchIndices,
+          ...this.detectingSwitchTimes.keys()
+        ]);
+        if (confirmation && isSwitchProbeRouteAvailable(confirmation, unavailableSwitchIndices)) {
+          this.completeSwitchRecovery(switchIndex);
+        } else {
+          this.recoveryProbeCompletionTimes.delete(switchIndex);
+          this.recoveryProbeConfirmations.delete(switchIndex);
+          this.nextSwitchProbeTimes.set(switchIndex, animationTime + SWITCH_PROBE_INTERVAL);
+        }
       }
     }
 
@@ -3390,17 +3413,20 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       const colors = flattenColors(
         group.instances.map((instance, instanceIndex) => {
           const switchIndex = group.switchIndices[instanceIndex];
-          const planeIndex = this.switchPlaneIndices.get(switchIndex);
-          const planeStrength =
-            planeIndex === undefined ? 0 : this.planeHighlightStrengths[planeIndex];
-          const pathStrength = this.getPathSwitchHighlightStrength(switchIndex);
-          return makeNetworkSwitchHighlightColor(instance.color, planeStrength, pathStrength);
+          return this.getHighlightedSwitchColor(instance.color, switchIndex);
         })
       );
       group.sorted.updateInstances(matrices, colors);
       group.aBuffer?.updateInstances(matrices, colors);
       group.weightedBlended?.updateInstances(matrices, colors);
     }
+  }
+
+  private getHighlightedSwitchColor(color: Color, switchIndex: number): Color {
+    const planeIndex = this.switchPlaneIndices.get(switchIndex);
+    const planeStrength = planeIndex === undefined ? 0 : this.planeHighlightStrengths[planeIndex];
+    const pathStrength = this.getPathSwitchHighlightStrength(switchIndex);
+    return makeNetworkSwitchHighlightColor(color, planeStrength, pathStrength);
   }
 
   private getPathSwitchHighlightStrength(switchIndex: number): number {
@@ -3962,7 +3988,11 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       );
     group.sorted.updateInstances(
       flattenMatrices(sortedInstances.map(({instance}) => instance.matrix)),
-      flattenColors(sortedInstances.map(({instance}) => instance.color))
+      flattenColors(
+        sortedInstances.map(({instance, switchIndex}) =>
+          this.getHighlightedSwitchColor(instance.color, switchIndex)
+        )
+      )
     );
   }
 

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -338,7 +338,16 @@ fn fragmentGlass(inputs: VertexOutputs) -> @location(0) vec4<f32> {
     inputs.position
   );
   let failureTint = smoothstep(0.44, 0.54, inputs.color.a);
-  let color = vec4<f32>(glassColor.rgb + inputs.color.rgb * failureTint * 0.46, glassColor.a);
+  let viewDirection = normalize(app.cameraPosition - inputs.worldPosition);
+  let viewAlignment = abs(dot(normalize(inputs.normal), viewDirection));
+  let focusRim = pow(1.0 - clamp(viewAlignment, 0.0, 1.0), 2.2);
+  let focusStrength = smoothstep(0.9, 1.05, inputs.color.b) * (1.0 - failureTint);
+  let focusColor = vec3<f32>(0.12, 0.38, 0.95) *
+    focusStrength * (0.08 + focusRim * 0.72);
+  let color = vec4<f32>(
+    glassColor.rgb + inputs.color.rgb * failureTint * 0.46 + focusColor,
+    glassColor.a
+  );
 #if A_BUFFER_ENABLED
   return aBuffer_captureStraightColor(color, inputs.position);
 #else
@@ -475,7 +484,15 @@ void main(void) {
     gl_FragCoord
   );
   float failureTint = smoothstep(0.44, 0.54, vColor.a);
-  vec4 color = vec4(glassColor.rgb + vColor.rgb * failureTint * 0.46, glassColor.a);
+  vec3 viewDirection = normalize(app.cameraPosition - vWorldPosition);
+  float viewAlignment = abs(dot(normalize(vNormal), viewDirection));
+  float focusRim = pow(1.0 - clamp(viewAlignment, 0.0, 1.0), 2.2);
+  float focusStrength = smoothstep(0.9, 1.05, vColor.b) * (1.0 - failureTint);
+  vec3 focusColor = vec3(0.12, 0.38, 0.95) * focusStrength * (0.08 + focusRim * 0.72);
+  vec4 color = vec4(
+    glassColor.rgb + vColor.rgb * failureTint * 0.46 + focusColor,
+    glassColor.a
+  );
 #if WBOIT_ENABLED
   fragColor = wboit_captureStraightColor(color, gl_FragCoord);
 #else

--- a/examples/showcase/packet-spraying/network.ts
+++ b/examples/showcase/packet-spraying/network.ts
@@ -167,6 +167,7 @@ export const FAILURE_DETECTION_DELAY = 0.52;
 export const PACKET_TRAVEL_SPEED = 3.4;
 export const ENDPOINT_SIGNAL_DURATION = 0.34;
 export const SWITCH_CONFIRMATION_DURATION = 0.46;
+export const SWITCH_PROBE_DURATION = 0.66;
 export const SWITCH_PROBE_INTERVAL = 2.2;
 export const SWITCH_TRANSITION_WAVE_DURATION = 0.78;
 
@@ -550,7 +551,7 @@ export function makeSwitchProbeEvent(
   return {
     color: [0.35, 0.7, 1, 0.76],
     conversationIndex: conversationRoute?.conversationIndex ?? 0,
-    duration: 0.66,
+    duration: SWITCH_PROBE_DURATION,
     kind: 'probe',
     route,
     startedAt,
@@ -615,6 +616,27 @@ export function makeSwitchProbeConfirmationEvent(probe: NetworkPacketEvent): Net
     kind: 'probe-confirmation',
     startedAt: probe.startedAt + probe.duration
   };
+}
+
+/** Checks whether a control packet can still traverse its complete physical switch route. */
+export function isSwitchProbeRouteAvailable(
+  probe: NetworkPacketEvent,
+  unavailableSwitchIndices: ReadonlySet<number>
+): boolean {
+  const targetSwitchPosition = SWITCH_POSITIONS[probe.switchIndex];
+  const targetPositionIndex = targetSwitchPosition
+    ? probe.route.points.indexOf(targetSwitchPosition)
+    : -1;
+  return (
+    targetPositionIndex >= 0 &&
+    probe.route.points
+      .slice(0, targetPositionIndex + 1)
+      .every(
+        position =>
+          position === targetSwitchPosition ||
+          !isFailedSwitchPosition(position, unavailableSwitchIndices)
+      )
+  );
 }
 
 /** Creates a restrained state-transition wave centered on a physical switch. */
@@ -742,11 +764,7 @@ export function makeNetworkSwitchPlaneTelemetry(
       })
     );
     const failed = planeRoutes.every(({route}) =>
-      route.points.some(
-        position =>
-          isFailedSwitchPosition(position, failedSwitchIndices) ||
-          isFailedSwitchPosition(position, recoveringSwitchIndices)
-      )
+      route.points.some(position => isFailedSwitchPosition(position, failedSwitchIndices))
     );
     const recovering = [...switchIndices].some(switchIndex =>
       recoveringSwitchIndices.has(switchIndex)

--- a/examples/showcase/packet-spraying/story.ts
+++ b/examples/showcase/packet-spraying/story.ts
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {AGGREGATION_POSITIONS, LEAF_POSITIONS, type Color, type Vector3} from './network';
+import {
+  AGGREGATION_POSITIONS,
+  LEAF_POSITIONS,
+  SWITCH_CONFIRMATION_DURATION,
+  SWITCH_PROBE_DURATION,
+  type Color,
+  type Vector3
+} from './network';
 
 export type NetworkStoryState = 'healthy' | 'congested' | 'failed' | 'recovering';
 
@@ -77,6 +84,7 @@ export const DEFAULT_NETWORK_OPTICS_LEVEL = 7;
 export const MAX_NETWORK_HDR_HIGHLIGHT_BOOST = 0.8;
 export const DEFAULT_NETWORK_HDR_HIGHLIGHT_BOOST = 0.28;
 export const GUIDED_STORY_SWITCH_INDEX = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length + 1;
+const RECOVERY_CHAPTER_DURATION = 7;
 
 export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
   {
@@ -247,7 +255,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
     title: 'Probe, confirm, restore',
     description:
       'A blue probe reaches the repaired switch, then a cyan acknowledgment restores its path.',
-    duration: 7,
+    duration: RECOVERY_CHAPTER_DURATION,
     networkState: 'recovering',
     beats: [
       {
@@ -264,7 +272,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         description: 'A cyan acknowledgment returns and confirms the entire route is healthy.',
         color: '#70eddf',
         pathIndex: 1,
-        position: 0.47
+        position: SWITCH_PROBE_DURATION / RECOVERY_CHAPTER_DURATION
       },
       {
         id: 'restored',
@@ -272,7 +280,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         description: 'Only after confirmation do alternating data packets return to the spine.',
         color: '#7de9a5',
         pathIndex: 1,
-        position: 0.77
+        position: (SWITCH_PROBE_DURATION + SWITCH_CONFIRMATION_DURATION) / RECOVERY_CHAPTER_DURATION
       }
     ],
     camera: {target: [0, 0.9, 0.65], distance: 9.8, yaw: 0.16, pitch: 0.46}

--- a/test/examples/packet-spraying-network.node.spec.ts
+++ b/test/examples/packet-spraying-network.node.spec.ts
@@ -17,6 +17,7 @@ import {
   SPINE_POSITIONS,
   SPINE_SWITCH_RADIUS,
   SWITCH_CONFIRMATION_DURATION,
+  SWITCH_PROBE_DURATION,
   SWITCH_POSITIONS,
   SWITCH_TRANSITION_WAVE_DURATION,
   getActivePlaneCount,
@@ -24,6 +25,7 @@ import {
   getHealthyConversationRoutes,
   getNetworkPlaneSwitchIndices,
   isFailedSwitchPosition,
+  isSwitchProbeRouteAvailable,
   makeConversationRoutes,
   makeEndpointSignals,
   makeLinks,
@@ -212,6 +214,27 @@ test('packet-spraying physical-plane telemetry preserves four independent backbo
     3,
     'three of the four independent backbone paths remain available'
   );
+  testCase.end();
+});
+
+test('packet-spraying physical-plane telemetry preserves recovery while data routes are blocked', testCase => {
+  const routes = makeConversationRoutes();
+  const packets = makePackets(routes);
+  const recoveringAccessSwitchIndex = 3;
+  const recoveringSwitches = new Set([recoveringAccessSwitchIndex]);
+
+  reroutePackets(packets, getHealthyConversationRoutes(routes, new Set(), recoveringSwitches));
+  const telemetry = makeNetworkSwitchPlaneTelemetry(
+    routes,
+    packets,
+    new Set(),
+    recoveringSwitches,
+    new Set()
+  );
+
+  testCase.equal(telemetry[0].status, 'recovering', 'the blocked physical plane remains probing');
+  testCase.equal(telemetry[0].redPacketCount, 0, 'recovery prevents ordinary red traffic');
+  testCase.equal(telemetry[0].greenPacketCount, 0, 'recovery prevents ordinary green traffic');
   testCase.end();
 });
 
@@ -610,6 +633,9 @@ test('packet-spraying physically probes unused switches and confirms the return 
   const routes = makeConversationRoutes();
   const unusedLeafIndex = 0;
   const probe = makeSwitchProbeEvent(routes, unusedLeafIndex, 9, new Set([unusedLeafIndex]));
+  const physicalLinkKeys = new Set(
+    makeLinks(routes).map(link => makeLinkKey(link.start, link.end))
+  );
 
   testCase.ok(
     routes.every(({route}) => !route.points.includes(LEAF_POSITIONS[unusedLeafIndex])),
@@ -621,11 +647,24 @@ test('packet-spraying physically probes unused switches and confirms the return 
     'a physical control packet can still reach the unused access switch'
   );
   testCase.ok(
-    SWITCH_POSITIONS.every((_, switchIndex) => makeSwitchProbeEvent(routes, switchIndex, 9)),
-    'every physical switch has a recovery-probe path'
+    SWITCH_POSITIONS.every((switchPosition, switchIndex) => {
+      const physicalProbe = makeSwitchProbeEvent(routes, switchIndex, 9);
+      return (
+        Boolean(physicalProbe?.route.points.includes(switchPosition)) &&
+        physicalProbe!.route.points.every(
+          (position, positionIndex) =>
+            positionIndex === 0 ||
+            physicalLinkKeys.has(
+              makeLinkKey(physicalProbe!.route.points[positionIndex - 1], position)
+            )
+        )
+      );
+    }),
+    'every physical switch has a control path composed entirely of real fabric links'
   );
 
   const confirmation = makeSwitchProbeConfirmationEvent(probe!);
+  testCase.equal(probe?.duration, SWITCH_PROBE_DURATION, 'probe timing uses the shared duration');
   testCase.equal(confirmation.kind, 'probe-confirmation', 'the response is a confirmation packet');
   testCase.equal(
     confirmation.startedAt,
@@ -645,6 +684,43 @@ test('packet-spraying physically probes unused switches and confirms the return 
   testCase.ok(
     confirmation.color[1] > confirmation.color[0] && confirmation.color[2] > confirmation.color[0],
     'the returning acknowledgment has a distinct cyan color'
+  );
+  testCase.end();
+});
+
+test('packet-spraying recovery acknowledgments reject newly unavailable return paths', testCase => {
+  const routes = makeConversationRoutes();
+  const recoveringSpineIndex = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length;
+  const recoveringSwitches = new Set([recoveringSpineIndex]);
+  const probe = makeSwitchProbeEvent(routes, recoveringSpineIndex, 15, recoveringSwitches)!;
+  const confirmation = makeSwitchProbeConfirmationEvent(probe);
+  const targetPositionIndex = probe.route.points.indexOf(SWITCH_POSITIONS[recoveringSpineIndex]);
+  const intermediateSwitchPosition = probe.route.points.find(
+    position =>
+      position !== SWITCH_POSITIONS[recoveringSpineIndex] &&
+      isFailedSwitchPosition(position, new Set([3]))
+  );
+  const downstreamSwitchIndex = probe.route.points
+    .slice(targetPositionIndex + 1)
+    .map(position => SWITCH_POSITIONS.indexOf(position))
+    .find(switchIndex => switchIndex >= 0);
+
+  testCase.ok(
+    isSwitchProbeRouteAvailable(confirmation, recoveringSwitches),
+    'the target switch itself remains available to control traffic while recovering'
+  );
+  testCase.ok(intermediateSwitchPosition, 'the confirmation traverses another physical switch');
+  testCase.notOk(
+    isSwitchProbeRouteAvailable(confirmation, new Set([...recoveringSwitches, 3])),
+    'a newly failed intermediate switch invalidates the return acknowledgment'
+  );
+  testCase.ok(
+    downstreamSwitchIndex !== undefined &&
+      isSwitchProbeRouteAvailable(
+        confirmation,
+        new Set([...recoveringSwitches, downstreamSwitchIndex])
+      ),
+    'an unrelated downstream switch cannot invalidate the acknowledgment return path'
   );
   testCase.end();
 });

--- a/test/examples/packet-spraying-story.node.spec.ts
+++ b/test/examples/packet-spraying-story.node.spec.ts
@@ -167,6 +167,10 @@ test('packet-spraying hover highlights glass without washing out transparency or
     'hovered plane switches ease toward a visible cool glass highlight'
   );
   testCase.ok(
+    planeHighlight[2] > 0.9 && pathHighlight[2] > 0.9,
+    'focused switch colors activate the dedicated Fresnel rim in both shader backends'
+  );
+  testCase.ok(
     pathHighlight[1] > planeHighlight[1],
     'focused backbone paths retain a distinct cyan glass accent'
   );

--- a/test/examples/packet-spraying-story.node.spec.ts
+++ b/test/examples/packet-spraying-story.node.spec.ts
@@ -3,7 +3,11 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {SWITCH_POSITIONS} from '../../examples/showcase/packet-spraying/network';
+import {
+  SWITCH_CONFIRMATION_DURATION,
+  SWITCH_POSITIONS,
+  SWITCH_PROBE_DURATION
+} from '../../examples/showcase/packet-spraying/network';
 import {
   DEFAULT_NETWORK_HDR_HIGHLIGHT_BOOST,
   DEFAULT_NETWORK_OPTICS_LEVEL,
@@ -98,9 +102,19 @@ test('packet-spraying cinematic story beats explain load, failure, and confirmed
   testCase.equal(getNetworkStoryBeat(2, 0)?.id, 'pressure', 'congestion is visible immediately');
   testCase.equal(getNetworkStoryBeat(3, 0)?.id, 'packet-loss', 'failure begins with packet loss');
   testCase.equal(
-    getNetworkStoryBeat(4, 4)?.id,
+    getNetworkStoryBeat(4, SWITCH_PROBE_DURATION - 0.01)?.id,
+    'probe',
+    'the outbound probe remains active until it reaches the repaired switch'
+  );
+  testCase.equal(
+    getNetworkStoryBeat(4, SWITCH_PROBE_DURATION)?.id,
     'confirmation',
-    'recovery waits for its cyan confirmation beat'
+    'the cyan confirmation begins exactly when the outbound probe arrives'
+  );
+  testCase.equal(
+    getNetworkStoryBeat(4, SWITCH_PROBE_DURATION + SWITCH_CONFIRMATION_DURATION)?.id,
+    'restored',
+    'ordinary traffic resumes exactly when the recovery acknowledgment completes'
   );
   testCase.equal(
     getNetworkStoryBeat(4, Number.NaN)?.id,


### PR DESCRIPTION
## Goals
- Restore clearly visible, gradual glass-switch highlighting in the packet-spraying showcase on both WebGPU and WebGL transparency paths.
- Address still-actionable review feedback left on recently merged networking/optics PRs without duplicating fixes already present on master.

## Changes
- Add balanced Fresnel rim accents to highlighted glass switches in matching WGSL and GLSL shaders.
- Preserve highlighted switch colors when sorted-alpha transparency reorders glass instances.
- Keep every repaired switch in recovery until a physically valid blue probe and cyan return acknowledgment complete.
- Revalidate the actually traversed acknowledgment path before restoring ordinary traffic and retry when another switch fails mid-handshake.
- Report fully blocked physical planes as recovering rather than failed when their blocking switch is being probed.
- Synchronize recovery story beats with shared probe/confirmation durations.
- Restore keyboard focus to the Optics button after closing its information panel, including Escape.
- Extend regression coverage for all 20 physical probe routes, real network links, interrupted acknowledgments, unrelated downstream faults, physical-plane recovery telemetry, and recovery timing.

## Review Feedback Audit
- Addressed unresolved comments from #2777, #2772, #2767, and #2766.
- Confirmed older reflective-material direction/opaque-alpha comments and animated camera-target feedback are already fixed on master; no duplicate changes included.

## Verification
- `env -u YARN_NO_PROXY corepack yarn lint fix` — passed.
- `env -u YARN_NO_PROXY corepack yarn build` — passed after final changes.
- `env -u YARN_NO_PROXY corepack yarn test-node` — 217 passed, 2 skipped.
- `env -u YARN_NO_PROXY corepack yarn workspace luma.gl-examples-showcase-packet-spraying build` — passed.
- Browser-verified WebGPU and WebGL plane hover highlights, probe/confirmation/restoration beat timing, and both Close/Escape focus restoration.
- `env -u YARN_NO_PROXY corepack yarn test` — Node suite passed; browser suite has 1 existing unrelated failure in `modules/arrow-layers/test/layers/arrow-layers.spec.ts` (`Arrow polygon and text layers render storage-backed WebGPU models`), with 1,290 other browser tests passing and 25 skipped.