### PR TITLE
feat(optics): add prefiltered glass reflections and contact shadows

### DIFF
--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -17,6 +17,7 @@ GLSL shader modules, while transparency renderers remain responsible for composi
 | Backface thickness | Rasterizes sphere backfaces into a normal-and-depth texture and linearizes the front-to-back depth difference. | Glass centers and silhouettes acquire different optical path lengths. |
 | Two-surface transmission | Applies analytic entry and exit refraction while checking opaque scene depth. | Background bends convincingly without distorting geometry in front of the glass. |
 | Studio environment | Samples a generated equirectangular environment along the reflected viewing direction. | Polished surfaces receive camera-responsive studio reflections. |
+| Prefiltered environment | Selects initialized reflection-probe mip levels from surface roughness, including broader internal-bounce lobes. | Polished clearcoat remains sharp while rough and internal reflections become naturally softer. |
 | Chromatic dispersion | Offsets red, green, and blue scene-color samples. | Subtle colored separation around refracted features. |
 | Beer-Lambert absorption | Attenuates transmitted light with material color and thickness. | Longer optical paths produce darker, more tinted transmission. |
 | Spectral volume absorption | Applies independent red, green, and blue extinction over measured shell thickness. | Deep glass acquires wavelength-dependent tint without recoloring thin silhouettes. |
@@ -28,6 +29,7 @@ GLSL shader modules, while transparency renderers remain responsible for composi
 | Thin-film interference | Evaluates nanometer-scale coating thickness across representative red, green, and blue wavelengths. | Angle-dependent spectral bands follow grazing highlights without coloring the whole object. |
 | Localized point lights | Evaluates a bounded array of nearby colored light sources. | Moving emissive objects tint adjacent glass and reflective surfaces. |
 | Optical volume scattering | Couples nearby colored point lights into the measured glass interior. | Passing packets briefly illuminate the inside of a switch without washing out the network. |
+| Glass contact shadows | Compares captured opaque depth against measured front and back glass surfaces. | Adjacent links and server hardware subtly anchor to transparent switch shells. |
 | Dynamic scene reflections | Samples captured opaque scene color along a curved screen-space reflection offset. | Moving packets and active links appear as localized reflections on glass switches. |
 | Focused raster caustics | Projects bounded colored glass-lens contributions onto nearby reflective receivers. | Active switches concentrate moving red and green light onto adjacent links and servers. |
 | Fault-driven distortion | Modulates refraction and narrow internal filaments only on warm fault-tinted glass. | Congested and failed switches acquire subtle animated optical instability. |
@@ -127,12 +129,15 @@ shaderInputs.setProps({
     backfaceTexture,
     environmentTexture,
     environmentIntensity: 1.25,
+    environmentMipLevels: environmentTexture.mipLevels,
+    environmentPrefilterStrength: 1,
     thicknessStrength: 1,
     roughTransmissionStrength: 0.85,
     spectralAbsorptionStrength: 0.42,
     thinFilmThickness: 420,
     thinFilmStrength: 0.22,
     volumeScatteringStrength: 0.38,
+    contactShadowStrength: 0.35,
     dynamicReflectionStrength: 0.38,
     secondaryBounceStrength: 0.55,
     faultDistortionStrength: 0.42,
@@ -148,10 +153,13 @@ total-internal-reflection handling, sampled equirectangular environment reflecti
 screen-space scene reflections, secondary internal bounces, and fault-tinted optical distortion.
 Optional spectral-volume controls add bounded multisample rough transmission, wavelength-dependent
 Beer-Lambert absorption, nanometer-scale thin-film interference, and colored in-volume scattering
-from nearby point lights. These additional controls default to zero so existing transmission
-consumers retain their appearance. Rough transmission requires four additional chromatic scene
-samples and two additional environment samples; it remains a bounded raster approximation rather
-than geometry-aware ray tracing.
+from nearby point lights. A fully initialized environment mip pyramid enables roughness-selected
+reflection probes and broader internal reflection lobes without repeated per-fragment neighborhood
+filtering. Optional contact shadows compare the existing opaque depth attachment against the
+measured front and back glass surfaces; they affect transmitted scene light without clouding
+unoccupied glass. These additional controls default to zero so existing transmission consumers
+retain their appearance. All modes remain bounded raster approximations rather than geometry-aware
+ray tracing.
 
 ## Add Focused Raster Caustics
 
@@ -254,6 +262,8 @@ an individual showcase.
 - Backface-derived thickness, foreground rejection, wavelength-dependent volume absorption,
   thickness-aware rough transmission, and nanometer-scale thin-film interference give glass
   measurable optical depth without per-pixel ray tracing.
+- Initialized prefiltered studio-probe mip chains support roughness-selected environment reflections
+  and broadened internal bounces; opaque-depth contact shadows anchor hardware to transparent shells.
 - Bounded colored point lights, in-volume scattering, screen-space scene reflections, secondary
   environment bounces, and focused raster caustics connect moving emitters to nearby glass.
 - Linked switch-plane telemetry gradually emphasizes all eight switches across both tiers of each
@@ -273,8 +283,8 @@ an individual showcase.
 
 - Add temporally accumulated rough transmission and history rejection to reduce multisample cost
   while preserving animated packet detail.
-- Introduce filtered environment probes and roughness-selected reflection levels with explicit
-  capability-aware fallbacks.
+- Extend prefiltered environment probes with authored HDR assets, importance-sampled convolution,
+  and explicit capability-aware fallback levels.
 - Improve geometry-aware screen-space reflections and thickness-guided indirect packet lighting
   without reading from active render attachments.
 - Add adaptive local scattering and neighborhood-aware translucent contact shadows while keeping

--- a/docs/api-reference/experimental/glass-material.md
+++ b/docs/api-reference/experimental/glass-material.md
@@ -74,12 +74,15 @@ existing `glassMaterial_getColor(...)` consumers.
 | `backfaceTexture` | `Texture` | Required for rendering. | Encoded world-space backface normals and depth. |
 | `environmentTexture` | `Texture` | Required for rendering. | Equirectangular studio or HDR environment. |
 | `environmentIntensity` | `number` | `1` | Environment reflection multiplier. |
+| `environmentMipLevels` | `number` | `1` | Number of initialized environment-probe mip levels available for roughness-selected reflection. |
+| `environmentPrefilterStrength` | `number` | `0` | Opt-in roughness-to-mip multiplier; zero preserves legacy bounded environment filtering. |
 | `thicknessStrength` | `number` | `1` | Measured optical-path multiplier. |
 | `roughTransmissionStrength` | `number` | `0` | Thickness-aware rough transmission and filtered environment reflection strength. |
 | `spectralAbsorptionStrength` | `number` | `0` | Wavelength-dependent Beer-Lambert extinction inside the measured glass volume. |
 | `thinFilmThickness` | `number` | `0` | Surface coating thickness in nanometers; zero disables coating interference. |
 | `thinFilmStrength` | `number` | `0` | Intensity of angle-dependent red, green, and blue coating interference. |
 | `volumeScatteringStrength` | `number` | `0` | Strength of restrained in-volume scattering and nearby point-light coupling. |
+| `contactShadowStrength` | `number` | `0` | Depth-aware optical contact shadows around adjacent opaque network hardware. |
 | `depthBias` | `number` | `0.00008` | Foreground depth-comparison tolerance. |
 | `dynamicReflectionStrength` | `number` | `0` | Captured-scene reflection strength for nearby moving objects. |
 | `secondaryBounceStrength` | `number` | `0` | Additional reflected environment bounce inside the glass shell. |
@@ -91,10 +94,12 @@ Use `glassTransmission_getColor(...)`, or add `opticalPointLightsPlugin` and use
 matching WGSL and GLSL forms.
 
 The optional volume controls preserve existing output when left at their zero defaults. Rough
-transmission adds bounded scene-color and environment samples; spectral absorption uses the
-backface-measured optical path; thin-film interference evaluates representative red, green, and
-blue wavelengths from the coating thickness; and volume scattering couples nearby optical point
-lights into the glass interior. No mode requires per-pixel ray tracing.
+transmission adds bounded scene-color and environment samples; a prefiltered environment texture
+can replace repeated neighborhood sampling with explicit roughness-selected mip levels; spectral
+absorption uses the backface-measured optical path; thin-film interference evaluates representative
+red, green, and blue wavelengths from the coating thickness; volume scattering couples nearby
+optical point lights into the glass interior; and optional contact shadows use the opaque depth
+already captured for foreground rejection. No mode requires per-pixel ray tracing.
 
 `opticalCausticsPlugin` separately adds a bounded array of focused glass lenses for nearby
 reflective receiver surfaces. Call `opticalCaustics_getColor(normal, worldPosition,

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -140,6 +140,7 @@ import {
   type SwitchArrival,
   type Vector3
 } from './network';
+import {makeStudioEnvironmentMipLevels} from './optics';
 import {
   DEFAULT_NETWORK_HDR_HIGHLIGHT_BOOST,
   DEFAULT_NETWORK_OPTICS_LEVEL,
@@ -1925,6 +1926,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   glassInternalReflectionStrength = 0.46;
   glassTransmissionStrength = 1.32;
   glassEnvironmentIntensity = 0.86;
+  glassEnvironmentPrefilterStrength = 1;
+  glassContactShadowStrength = 0.36;
   glassVolumeThickness = 1;
   glassRoughTransmissionStrength = 0.2;
   glassSpectralAbsorptionStrength = 0.28;
@@ -2250,6 +2253,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         glassInternalReflectionStrength: this.glassInternalReflectionStrength,
         glassTransmissionStrength: this.glassTransmissionStrength,
         glassEnvironmentIntensity: this.glassEnvironmentIntensity,
+        glassEnvironmentPrefilterStrength: this.glassEnvironmentPrefilterStrength,
+        glassContactShadowStrength: this.glassContactShadowStrength,
         glassVolumeThickness: this.glassVolumeThickness,
         glassRoughTransmissionStrength: this.glassRoughTransmissionStrength,
         glassSpectralAbsorptionStrength: this.glassSpectralAbsorptionStrength,
@@ -2295,6 +2300,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       canvas.dataset.packetSprayingFallback = String(Boolean(device.info.fallback));
       canvas.dataset.packetSprayingDynamicRange = this.dynamicRangeProfile.displayMode;
       canvas.dataset.packetSprayingSceneColorFormat = this.sceneColorFormat;
+      canvas.dataset.packetSprayingEnvironmentMipLevels = String(this.environmentTexture.mipLevels);
       canvas.dataset.packetSprayingHighlightBoost =
         this.dynamicRangeProfile.highlightBoost.toFixed(3);
       canvas.dataset.packetSprayingMaximumLuminance =
@@ -2436,6 +2442,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         this.glassEnvironmentIntensity *
         (0.16 + this.opticsProfile.surface * 0.84) *
         this.dynamicRangeProfile.specularScale,
+      environmentMipLevels: this.environmentTexture.mipLevels,
+      environmentPrefilterStrength:
+        this.glassEnvironmentPrefilterStrength * this.opticsProfile.surface,
+      contactShadowStrength: this.glassContactShadowStrength * this.opticsProfile.refraction,
       thicknessStrength: this.glassVolumeThickness * (0.45 + this.opticsProfile.refraction * 0.55),
       roughTransmissionStrength: this.glassRoughTransmissionStrength * this.opticsProfile.spectral,
       spectralAbsorptionStrength:
@@ -4590,6 +4600,22 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       this.glassEnvironmentIntensity = glassEnvironmentIntensity;
     }
 
+    const glassEnvironmentPrefilterStrength = getChangedSetting(
+      changedSettings,
+      'glassEnvironmentPrefilterStrength'
+    )?.nextValue;
+    if (typeof glassEnvironmentPrefilterStrength === 'number') {
+      this.glassEnvironmentPrefilterStrength = glassEnvironmentPrefilterStrength;
+    }
+
+    const glassContactShadowStrength = getChangedSetting(
+      changedSettings,
+      'glassContactShadowStrength'
+    )?.nextValue;
+    if (typeof glassContactShadowStrength === 'number') {
+      this.glassContactShadowStrength = glassContactShadowStrength;
+    }
+
     const glassVolumeThickness = getChangedSetting(
       changedSettings,
       'glassVolumeThickness'
@@ -4798,9 +4824,9 @@ const PACKET_SPRAYING_OPTICS_HTML = `\
 <p>Every switch is a transparent GPU-rendered glass volume; the image is generated live on hardware WebGPU or WebGL without per-pixel ray tracing.</p>
 <p>The guided tour's 0–11 visual-style control introduces these techniques in stages, preserving clear packet movement at the low end and progressively revealing the complete optical pipeline.</p>
 <h3>Glass surfaces</h3>
-<p>Grazing-angle Fresnel reflection, GGX microfacets, a polished clearcoat, angular thin-film interference, and camera-responsive studio lighting define each curved outer surface.</p>
+<p>Grazing-angle Fresnel reflection, GGX microfacets, a polished clearcoat, angular thin-film interference, and roughness-selected prefiltered studio reflections define each curved outer surface.</p>
 <h3>Inside the glass</h3>
-<p>A dedicated backface pass measures optical thickness. Entry and exit refraction bend captured scene color, chromatic dispersion separates wavelengths, spectral Beer-Lambert absorption tints longer paths, and controlled multisampling creates frosted transmission.</p>
+<p>A dedicated backface pass measures optical thickness. Entry and exit refraction bend captured scene color, chromatic dispersion separates wavelengths, spectral Beer-Lambert absorption tints longer paths, controlled multisampling creates frosted transmission, and opaque-depth contact shadows anchor nearby hardware to each glass shell.</p>
 <h3>Light from moving packets</h3>
 <p>Red and green packets emit local light into nearby glass. Colored volume scattering, moving scene reflections, secondary internal bounces, and focused raster caustics transfer that energy onto switches, reflective tubes, and metallic servers.</p>
 <h3>Compositing and display</h3>
@@ -4933,68 +4959,28 @@ function makeBackfaceTexture(
 }
 
 function makeStudioEnvironmentTexture(device: Device): Texture {
-  const width = 256;
-  const height = 128;
-  const pixels = new Uint8Array(width * height * 4);
-  const studioLights = [
-    {direction: [-0.58, 0.64, 0.5], color: [1, 0.92, 0.78], width: 0.11},
-    {direction: [0.72, 0.24, -0.58], color: [0.35, 0.62, 1], width: 0.16},
-    {direction: [0.05, 0.94, 0.33], color: [0.78, 0.88, 1], width: 0.085},
-    {direction: [-0.8, -0.12, -0.58], color: [0.42, 0.35, 0.8], width: 0.2}
-  ];
-
-  for (let row = 0; row < height; row++) {
-    const elevation = (row / (height - 1)) * Math.PI;
-    for (let column = 0; column < width; column++) {
-      const azimuth = (column / (width - 1) - 0.5) * Math.PI * 2;
-      const direction: Vector3 = [
-        Math.cos(azimuth) * Math.sin(elevation),
-        Math.cos(elevation),
-        Math.sin(azimuth) * Math.sin(elevation)
-      ];
-      const horizon = Math.pow(1 - Math.abs(direction[1]), 8);
-      const sky = Math.max(direction[1], 0);
-      const color: Vector3 = [
-        0.035 + sky * 0.065 + horizon * 0.09,
-        0.045 + sky * 0.085 + horizon * 0.12,
-        0.075 + sky * 0.16 + horizon * 0.19
-      ];
-
-      for (const light of studioLights) {
-        const alignment = Math.max(
-          direction[0] * light.direction[0] +
-            direction[1] * light.direction[1] +
-            direction[2] * light.direction[2],
-          0
-        );
-        const intensity = Math.pow(alignment, 1 / light.width ** 2);
-        color[0] += light.color[0] * intensity * 0.78;
-        color[1] += light.color[1] * intensity * 0.78;
-        color[2] += light.color[2] * intensity * 0.78;
-      }
-
-      const pixelOffset = (row * width + column) * 4;
-      pixels[pixelOffset] = Math.round(Math.min(color[0], 1) * 255);
-      pixels[pixelOffset + 1] = Math.round(Math.min(color[1], 1) * 255);
-      pixels[pixelOffset + 2] = Math.round(Math.min(color[2], 1) * 255);
-      pixels[pixelOffset + 3] = 255;
-    }
-  }
-
+  const mipLevels = makeStudioEnvironmentMipLevels();
+  const baseLevel = mipLevels[0];
   const environmentTexture = device.createTexture({
     id: 'packet-spraying-studio-environment',
-    width,
-    height,
+    width: baseLevel.width,
+    height: baseLevel.height,
+    mipLevels: mipLevels.length,
     format: 'rgba8unorm',
     usage: Texture.SAMPLE | Texture.COPY_DST,
     sampler: {
       minFilter: 'linear',
       magFilter: 'linear',
+      mipmapFilter: 'linear',
+      lodMaxClamp: mipLevels.length - 1,
       addressModeU: 'repeat',
       addressModeV: 'clamp-to-edge'
     }
   });
-  environmentTexture.writeData(pixels);
+
+  for (const [mipLevel, {height, pixels, width}] of mipLevels.entries()) {
+    environmentTexture.writeData(pixels, {height, mipLevel, width});
+  }
   return environmentTexture;
 }
 
@@ -5422,6 +5408,24 @@ function makeSettingsSchema(
             persist: 'none',
             min: 0,
             max: 3,
+            step: 0.05
+          },
+          {
+            name: 'glassEnvironmentPrefilterStrength',
+            label: 'Prefiltered Reflections',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 2,
+            step: 0.05
+          },
+          {
+            name: 'glassContactShadowStrength',
+            label: 'Glass Contact Shadows',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1,
             step: 0.05
           },
           {

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -342,10 +342,10 @@ fn fragmentGlass(inputs: VertexOutputs) -> @location(0) vec4<f32> {
   let failureTint = smoothstep(0.44, 0.54, inputs.color.a);
   let viewDirection = normalize(app.cameraPosition - inputs.worldPosition);
   let viewAlignment = abs(dot(normalize(inputs.normal), viewDirection));
-  let focusRim = pow(1.0 - clamp(viewAlignment, 0.0, 1.0), 2.2);
+  let focusRim = pow(1.0 - clamp(viewAlignment, 0.0, 1.0), 1.8);
   let focusStrength = smoothstep(0.9, 1.05, inputs.color.b) * (1.0 - failureTint);
-  let focusColor = vec3<f32>(0.12, 0.38, 0.95) *
-    focusStrength * (0.08 + focusRim * 0.72);
+  let focusColor = vec3<f32>(0.16, 0.48, 1.05) *
+    focusStrength * (0.08 + focusRim * 0.95);
   let color = vec4<f32>(
     glassColor.rgb + inputs.color.rgb * failureTint * 0.46 + focusColor,
     glassColor.a
@@ -488,9 +488,9 @@ void main(void) {
   float failureTint = smoothstep(0.44, 0.54, vColor.a);
   vec3 viewDirection = normalize(app.cameraPosition - vWorldPosition);
   float viewAlignment = abs(dot(normalize(vNormal), viewDirection));
-  float focusRim = pow(1.0 - clamp(viewAlignment, 0.0, 1.0), 2.2);
+  float focusRim = pow(1.0 - clamp(viewAlignment, 0.0, 1.0), 1.8);
   float focusStrength = smoothstep(0.9, 1.05, vColor.b) * (1.0 - failureTint);
-  vec3 focusColor = vec3(0.12, 0.38, 0.95) * focusStrength * (0.08 + focusRim * 0.72);
+  vec3 focusColor = vec3(0.16, 0.48, 1.05) * focusStrength * (0.08 + focusRim * 0.95);
   vec4 color = vec4(
     glassColor.rgb + vColor.rgb * failureTint * 0.46 + focusColor,
     glassColor.a

--- a/examples/showcase/packet-spraying/optics.ts
+++ b/examples/showcase/packet-spraying/optics.ts
@@ -1,0 +1,95 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Vector3} from './network';
+
+export type StudioEnvironmentMipLevel = {
+  height: number;
+  pixels: Uint8Array;
+  width: number;
+};
+
+const STUDIO_LIGHTS = [
+  {direction: [-0.58, 0.64, 0.5], color: [1, 0.92, 0.78], width: 0.11},
+  {direction: [0.72, 0.24, -0.58], color: [0.35, 0.62, 1], width: 0.16},
+  {direction: [0.05, 0.94, 0.33], color: [0.78, 0.88, 1], width: 0.085},
+  {direction: [-0.8, -0.12, -0.58], color: [0.42, 0.35, 0.8], width: 0.2}
+];
+
+/** Builds a deterministic equirectangular studio probe and its complete roughness mip pyramid. */
+export function makeStudioEnvironmentMipLevels(
+  width = 256,
+  height = 128
+): StudioEnvironmentMipLevel[] {
+  const pixels = new Uint8Array(width * height * 4);
+
+  for (let row = 0; row < height; row++) {
+    const elevation = (row / Math.max(height - 1, 1)) * Math.PI;
+    for (let column = 0; column < width; column++) {
+      const azimuth = (column / Math.max(width - 1, 1) - 0.5) * Math.PI * 2;
+      const direction: Vector3 = [
+        Math.cos(azimuth) * Math.sin(elevation),
+        Math.cos(elevation),
+        Math.sin(azimuth) * Math.sin(elevation)
+      ];
+      const horizon = Math.pow(1 - Math.abs(direction[1]), 8);
+      const sky = Math.max(direction[1], 0);
+      const color: Vector3 = [
+        0.035 + sky * 0.065 + horizon * 0.09,
+        0.045 + sky * 0.085 + horizon * 0.12,
+        0.075 + sky * 0.16 + horizon * 0.19
+      ];
+
+      for (const light of STUDIO_LIGHTS) {
+        const alignment = Math.max(
+          direction[0] * light.direction[0] +
+            direction[1] * light.direction[1] +
+            direction[2] * light.direction[2],
+          0
+        );
+        const intensity = Math.pow(alignment, 1 / light.width ** 2);
+        color[0] += light.color[0] * intensity * 0.78;
+        color[1] += light.color[1] * intensity * 0.78;
+        color[2] += light.color[2] * intensity * 0.78;
+      }
+
+      const pixelOffset = (row * width + column) * 4;
+      pixels[pixelOffset] = Math.round(Math.min(color[0], 1) * 255);
+      pixels[pixelOffset + 1] = Math.round(Math.min(color[1], 1) * 255);
+      pixels[pixelOffset + 2] = Math.round(Math.min(color[2], 1) * 255);
+      pixels[pixelOffset + 3] = 255;
+    }
+  }
+
+  const levels: StudioEnvironmentMipLevel[] = [{height, pixels, width}];
+  while (width > 1 || height > 1) {
+    const previousLevel = levels[levels.length - 1];
+    width = Math.max(1, Math.floor(width / 2));
+    height = Math.max(1, Math.floor(height / 2));
+    const levelPixels = new Uint8Array(width * height * 4);
+
+    for (let row = 0; row < height; row++) {
+      for (let column = 0; column < width; column++) {
+        for (let channel = 0; channel < 4; channel++) {
+          let accumulatedValue = 0;
+          for (let rowOffset = 0; rowOffset < 2; rowOffset++) {
+            const sourceRow = Math.min(row * 2 + rowOffset, previousLevel.height - 1);
+            for (let columnOffset = 0; columnOffset < 2; columnOffset++) {
+              const sourceColumn = (column * 2 + columnOffset) % previousLevel.width;
+              accumulatedValue +=
+                previousLevel.pixels[
+                  (sourceRow * previousLevel.width + sourceColumn) * 4 + channel
+                ];
+            }
+          }
+          levelPixels[(row * width + column) * 4 + channel] = Math.round(accumulatedValue / 4);
+        }
+      }
+    }
+
+    levels.push({height, pixels: levelPixels, width});
+  }
+
+  return levels;
+}

--- a/examples/showcase/packet-spraying/story.ts
+++ b/examples/showcase/packet-spraying/story.ts
@@ -396,8 +396,8 @@ export function makeNetworkSwitchHighlightColor(
 
   const targetColor: Color =
     boundedPathStrength > boundedPlaneStrength
-      ? [0.42, 1.02, 1.2, color[3]]
-      : [0.6, 0.82, 1.15, color[3]];
+      ? [0.42, 1.02, 1.55, color[3]]
+      : [0.6, 0.82, 1.46, color[3]];
   return [
     color[0] + (targetColor[0] - color[0]) * highlightStrength,
     color[1] + (targetColor[1] - color[1]) * highlightStrength,

--- a/modules/experimental/src/materials/glass-transmission.ts
+++ b/modules/experimental/src/materials/glass-transmission.ts
@@ -20,6 +20,10 @@ export type GlassTransmissionProps = {
   environmentTexture?: Texture;
   /** Multiplier applied to sampled environment reflections. */
   environmentIntensity?: number;
+  /** Number of initialized levels in the optional prefiltered environment texture. */
+  environmentMipLevels?: number;
+  /** Strength of roughness-selected environment mip sampling; zero preserves legacy filtering. */
+  environmentPrefilterStrength?: number;
   /** Multiplier applied to the measured front-to-back optical path. */
   thicknessStrength?: number;
   /** Strength of thickness-aware multisample transmission blur. */
@@ -32,6 +36,8 @@ export type GlassTransmissionProps = {
   thinFilmStrength?: number;
   /** Strength of colored in-volume scattering around nearby optical point lights. */
   volumeScatteringStrength?: number;
+  /** Strength of depth-aware localized darkening where opaque geometry touches the glass. */
+  contactShadowStrength?: number;
   /** Normalized-depth tolerance used to preserve foreground geometry. */
   depthBias?: number;
   /** Strength of nearby opaque-scene reflections sampled from captured scene color. */
@@ -49,12 +55,15 @@ export type GlassTransmissionUniforms = {
   viewportSize: [number, number];
   depthRange: [number, number];
   environmentIntensity: number;
+  environmentMipLevels: number;
+  environmentPrefilterStrength: number;
   thicknessStrength: number;
   roughTransmissionStrength: number;
   spectralAbsorptionStrength: number;
   thinFilmThickness: number;
   thinFilmStrength: number;
   volumeScatteringStrength: number;
+  contactShadowStrength: number;
   depthBias: number;
   dynamicReflectionStrength: number;
   secondaryBounceStrength: number;
@@ -76,12 +85,15 @@ struct glassTransmissionUniforms {
   viewportSize: vec2<f32>,
   depthRange: vec2<f32>,
   environmentIntensity: f32,
+  environmentMipLevels: f32,
+  environmentPrefilterStrength: f32,
   thicknessStrength: f32,
   roughTransmissionStrength: f32,
   spectralAbsorptionStrength: f32,
   thinFilmThickness: f32,
   thinFilmStrength: f32,
   volumeScatteringStrength: f32,
+  contactShadowStrength: f32,
   depthBias: f32,
   dynamicReflectionStrength: f32,
   secondaryBounceStrength: f32,
@@ -112,13 +124,43 @@ fn glassTransmission_sampleDepth(screenCoordinate: vec2<f32>) -> f32 {
   return textureLoad(glassSceneDepthTexture, pixelCoordinate, 0);
 }
 
-fn glassTransmission_sampleEnvironment(reflectionDirection: vec3<f32>) -> vec3<f32> {
+fn glassTransmission_sampleEnvironmentAtRoughness(
+  reflectionDirection: vec3<f32>,
+  surfaceRoughness: f32
+) -> vec3<f32> {
   let normalizedDirection = normalize(reflectionDirection);
   let environmentCoordinate = vec2<f32>(
     atan2(normalizedDirection.z, normalizedDirection.x) * 0.15915494 + 0.5,
     acos(clamp(normalizedDirection.y, -1.0, 1.0)) * 0.31830989
   );
-  let blurOffset = vec2<f32>(0.018, 0.011) * glassMaterial.roughness;
+  let roughness = clamp(surfaceRoughness, 0.0, 1.0);
+  let maximumMipLevel = max(glassTransmission.environmentMipLevels - 1.0, 0.0);
+  if (glassTransmission.environmentPrefilterStrength > 0.0 && maximumMipLevel > 0.0) {
+    let reflectionLevel = clamp(
+      roughness * roughness * maximumMipLevel * glassTransmission.environmentPrefilterStrength,
+      0.0,
+      maximumMipLevel
+    );
+    let clearcoatLevel = max(reflectionLevel - 0.6, 0.0);
+    let filteredEnvironment = textureSampleLevel(
+      glassEnvironmentTexture,
+      glassEnvironmentTextureSampler,
+      environmentCoordinate,
+      reflectionLevel
+    ).rgb;
+    let clearcoatEnvironment = textureSampleLevel(
+      glassEnvironmentTexture,
+      glassEnvironmentTextureSampler,
+      environmentCoordinate,
+      clearcoatLevel
+    ).rgb;
+    return mix(
+      clearcoatEnvironment,
+      filteredEnvironment,
+      smoothstep(0.045, 0.58, roughness)
+    ) * glassTransmission.environmentIntensity;
+  }
+  let blurOffset = vec2<f32>(0.018, 0.011) * roughness;
   let centered = textureSampleLevel(
     glassEnvironmentTexture,
     glassEnvironmentTextureSampler,
@@ -142,7 +184,7 @@ fn glassTransmission_sampleEnvironment(reflectionDirection: vec3<f32>) -> vec3<f
     return mix(
       centered,
       baselineEnvironment,
-      smoothstep(0.08, 0.7, glassMaterial.roughness)
+      smoothstep(0.08, 0.7, roughness)
     ) * glassTransmission.environmentIntensity;
   }
   let crossOffset = vec2<f32>(-blurOffset.y, blurOffset.x);
@@ -166,8 +208,35 @@ fn glassTransmission_sampleEnvironment(reflectionDirection: vec3<f32>) -> vec3<f
   return mix(
     centered,
     filteredEnvironment,
-    smoothstep(0.08, 0.7, glassMaterial.roughness)
+    smoothstep(0.08, 0.7, roughness)
   ) * glassTransmission.environmentIntensity;
+}
+
+fn glassTransmission_sampleEnvironment(reflectionDirection: vec3<f32>) -> vec3<f32> {
+  return glassTransmission_sampleEnvironmentAtRoughness(
+    reflectionDirection,
+    glassMaterial.roughness
+  );
+}
+
+fn glassTransmission_getContactShadow(
+  screenCoordinate: vec2<f32>,
+  frontDepth: f32,
+  backDepth: f32,
+  hasBackface: bool
+) -> f32 {
+  if (glassTransmission.contactShadowStrength <= 0.0 || !hasBackface) {
+    return 1.0;
+  }
+  let opaqueDepth = glassTransmission_sampleDepth(screenCoordinate);
+  if (opaqueDepth >= 0.99999) {
+    return 1.0;
+  }
+  let receiverDepth = glassTransmission_linearizeDepth(opaqueDepth);
+  let receiverIsBehindFront = smoothstep(frontDepth - 0.035, frontDepth + 0.045, receiverDepth);
+  let receiverGap = max(receiverDepth - backDepth, 0.0);
+  let contact = receiverIsBehindFront * (1.0 - smoothstep(0.035, 0.44, receiverGap));
+  return 1.0 - contact * clamp(glassTransmission.contactShadowStrength, 0.0, 1.0) * 0.36;
 }
 
 fn glassTransmission_sampleRoughTransmission(
@@ -333,11 +402,15 @@ fn glassTransmission_getColor(
   let environmentReflection = glassTransmission_sampleEnvironment(reflectionDirection);
   let viewAlignment = clamp(dot(frontNormal, viewDirection), 0.0, 1.0);
   let fresnel = opticalLighting_getFresnel(viewAlignment, 0.04, 5.0);
-  let internalReflection = glassTransmission_sampleEnvironment(
-    reflect(entryDirection, -backNormal)
+  let internalReflection = glassTransmission_sampleEnvironmentAtRoughness(
+    reflect(entryDirection, -backNormal),
+    glassMaterial.roughness + glassTransmission.environmentPrefilterStrength * 0.13
   ) * select(0.18, 0.42, !hasExitRay);
   let secondaryDirection = reflect(reflect(entryDirection, -backNormal), frontNormal);
-  let secondaryReflection = glassTransmission_sampleEnvironment(secondaryDirection) *
+  let secondaryReflection = glassTransmission_sampleEnvironmentAtRoughness(
+    secondaryDirection,
+    glassMaterial.roughness + glassTransmission.environmentPrefilterStrength * 0.25
+  ) *
     glassTransmission.secondaryBounceStrength * pow(1.0 - viewAlignment, 1.45) * 0.24;
   let thinFilmReflection = glassTransmission_getThinFilm(viewAlignment);
   let volumeScattering = baseColor.rgb * (1.0 - exp(-measuredThickness * 1.3)) *
@@ -361,7 +434,14 @@ fn glassTransmission_getColor(
     glassTransmission.faultDistortionStrength *
     pow(max(sin(dot(worldPosition, vec3<f32>(14.0, 10.0, 17.0)) +
       glassTransmission.time * 7.0), 0.0), 10.0) * 0.12;
-  let opticalColor = transmittedColor * absorption * glassMaterial.transmissionStrength +
+  let contactShadow = glassTransmission_getContactShadow(
+    screenCoordinate,
+    frontDepth,
+    backDepth,
+    hasBackface
+  );
+  let opticalColor = transmittedColor * absorption * glassMaterial.transmissionStrength *
+      contactShadow +
     environmentReflection * (0.09 + fresnel * 0.65) +
     internalReflection * pow(1.0 - viewAlignment, 2.0) + secondaryReflection +
     thinFilmReflection + volumeScattering + dynamicReflection + faultFilament;
@@ -400,12 +480,15 @@ layout(std140) uniform glassTransmissionUniforms {
   vec2 viewportSize;
   vec2 depthRange;
   float environmentIntensity;
+  float environmentMipLevels;
+  float environmentPrefilterStrength;
   float thicknessStrength;
   float roughTransmissionStrength;
   float spectralAbsorptionStrength;
   float thinFilmThickness;
   float thinFilmStrength;
   float volumeScatteringStrength;
+  float contactShadowStrength;
   float depthBias;
   float dynamicReflectionStrength;
   float secondaryBounceStrength;
@@ -431,13 +514,41 @@ float glassTransmission_sampleDepth(vec2 screenCoordinate) {
   ).r;
 }
 
-vec3 glassTransmission_sampleEnvironment(vec3 reflectionDirection) {
+vec3 glassTransmission_sampleEnvironmentAtRoughness(
+  vec3 reflectionDirection,
+  float surfaceRoughness
+) {
   vec3 normalizedDirection = normalize(reflectionDirection);
   vec2 environmentCoordinate = vec2(
     atan(normalizedDirection.z, normalizedDirection.x) * 0.15915494 + 0.5,
     acos(clamp(normalizedDirection.y, -1.0, 1.0)) * 0.31830989
   );
-  vec2 blurOffset = vec2(0.018, 0.011) * glassMaterial.roughness;
+  float roughness = clamp(surfaceRoughness, 0.0, 1.0);
+  float maximumMipLevel = max(glassTransmission.environmentMipLevels - 1.0, 0.0);
+  if (glassTransmission.environmentPrefilterStrength > 0.0 && maximumMipLevel > 0.0) {
+    float reflectionLevel = clamp(
+      roughness * roughness * maximumMipLevel * glassTransmission.environmentPrefilterStrength,
+      0.0,
+      maximumMipLevel
+    );
+    float clearcoatLevel = max(reflectionLevel - 0.6, 0.0);
+    vec3 filteredEnvironment = textureLod(
+      glassEnvironmentTexture,
+      environmentCoordinate,
+      reflectionLevel
+    ).rgb;
+    vec3 clearcoatEnvironment = textureLod(
+      glassEnvironmentTexture,
+      environmentCoordinate,
+      clearcoatLevel
+    ).rgb;
+    return mix(
+      clearcoatEnvironment,
+      filteredEnvironment,
+      smoothstep(0.045, 0.58, roughness)
+    ) * glassTransmission.environmentIntensity;
+  }
+  vec2 blurOffset = vec2(0.018, 0.011) * roughness;
   vec3 centered = texture(glassEnvironmentTexture, environmentCoordinate).rgb;
   vec3 forward = texture(glassEnvironmentTexture, environmentCoordinate + blurOffset).rgb;
   vec3 backward = texture(glassEnvironmentTexture, environmentCoordinate - blurOffset).rgb;
@@ -446,7 +557,7 @@ vec3 glassTransmission_sampleEnvironment(vec3 reflectionDirection) {
     return mix(
       centered,
       baselineEnvironment,
-      smoothstep(0.08, 0.7, glassMaterial.roughness)
+      smoothstep(0.08, 0.7, roughness)
     ) * glassTransmission.environmentIntensity;
   }
   vec2 crossOffset = vec2(-blurOffset.y, blurOffset.x);
@@ -460,8 +571,35 @@ vec3 glassTransmission_sampleEnvironment(vec3 reflectionDirection) {
   return mix(
     centered,
     filteredEnvironment,
-    smoothstep(0.08, 0.7, glassMaterial.roughness)
+    smoothstep(0.08, 0.7, roughness)
   ) * glassTransmission.environmentIntensity;
+}
+
+vec3 glassTransmission_sampleEnvironment(vec3 reflectionDirection) {
+  return glassTransmission_sampleEnvironmentAtRoughness(
+    reflectionDirection,
+    glassMaterial.roughness
+  );
+}
+
+float glassTransmission_getContactShadow(
+  vec2 screenCoordinate,
+  float frontDepth,
+  float backDepth,
+  bool hasBackface
+) {
+  if (glassTransmission.contactShadowStrength <= 0.0 || !hasBackface) {
+    return 1.0;
+  }
+  float opaqueDepth = glassTransmission_sampleDepth(screenCoordinate);
+  if (opaqueDepth >= 0.99999) {
+    return 1.0;
+  }
+  float receiverDepth = glassTransmission_linearizeDepth(opaqueDepth);
+  float receiverIsBehindFront = smoothstep(frontDepth - 0.035, frontDepth + 0.045, receiverDepth);
+  float receiverGap = max(receiverDepth - backDepth, 0.0);
+  float contact = receiverIsBehindFront * (1.0 - smoothstep(0.035, 0.44, receiverGap));
+  return 1.0 - contact * clamp(glassTransmission.contactShadowStrength, 0.0, 1.0) * 0.36;
 }
 
 vec3 glassTransmission_sampleRoughTransmission(
@@ -622,11 +760,15 @@ vec4 glassTransmission_getColor(
   vec3 environmentReflection = glassTransmission_sampleEnvironment(reflectionDirection);
   float viewAlignment = clamp(dot(frontNormal, viewDirection), 0.0, 1.0);
   float fresnel = opticalLighting_getFresnel(viewAlignment, 0.04, 5.0);
-  vec3 internalReflection = glassTransmission_sampleEnvironment(
-    reflect(entryDirection, -backNormal)
+  vec3 internalReflection = glassTransmission_sampleEnvironmentAtRoughness(
+    reflect(entryDirection, -backNormal),
+    glassMaterial.roughness + glassTransmission.environmentPrefilterStrength * 0.13
   ) * (hasExitRay ? 0.18 : 0.42);
   vec3 secondaryDirection = reflect(reflect(entryDirection, -backNormal), frontNormal);
-  vec3 secondaryReflection = glassTransmission_sampleEnvironment(secondaryDirection) *
+  vec3 secondaryReflection = glassTransmission_sampleEnvironmentAtRoughness(
+    secondaryDirection,
+    glassMaterial.roughness + glassTransmission.environmentPrefilterStrength * 0.25
+  ) *
     glassTransmission.secondaryBounceStrength * pow(1.0 - viewAlignment, 1.45) * 0.24;
   vec3 thinFilmReflection = glassTransmission_getThinFilm(viewAlignment);
   vec3 volumeScattering = baseColor.rgb * (1.0 - exp(-measuredThickness * 1.3)) *
@@ -645,7 +787,14 @@ vec4 glassTransmission_getColor(
     glassTransmission.faultDistortionStrength *
     pow(max(sin(dot(worldPosition, vec3(14.0, 10.0, 17.0)) +
       glassTransmission.time * 7.0), 0.0), 10.0) * 0.12;
-  vec3 opticalColor = transmittedColor * absorption * glassMaterial.transmissionStrength +
+  float contactShadow = glassTransmission_getContactShadow(
+    screenCoordinate,
+    frontDepth,
+    backDepth,
+    hasBackface
+  );
+  vec3 opticalColor = transmittedColor * absorption * glassMaterial.transmissionStrength *
+      contactShadow +
     environmentReflection * (0.09 + fresnel * 0.65) +
     internalReflection * pow(1.0 - viewAlignment, 2.0) + secondaryReflection +
     thinFilmReflection + volumeScattering + dynamicReflection + faultFilament;
@@ -687,6 +836,9 @@ function getGlassTransmissionUniforms(
     viewportSize: props.viewportSize ?? previousUniforms?.viewportSize ?? [1, 1],
     depthRange: props.depthRange ?? previousUniforms?.depthRange ?? [0.1, 100],
     environmentIntensity: props.environmentIntensity ?? previousUniforms?.environmentIntensity ?? 1,
+    environmentMipLevels: props.environmentMipLevels ?? previousUniforms?.environmentMipLevels ?? 1,
+    environmentPrefilterStrength:
+      props.environmentPrefilterStrength ?? previousUniforms?.environmentPrefilterStrength ?? 0,
     thicknessStrength: props.thicknessStrength ?? previousUniforms?.thicknessStrength ?? 1,
     roughTransmissionStrength:
       props.roughTransmissionStrength ?? previousUniforms?.roughTransmissionStrength ?? 0,
@@ -696,6 +848,8 @@ function getGlassTransmissionUniforms(
     thinFilmStrength: props.thinFilmStrength ?? previousUniforms?.thinFilmStrength ?? 0,
     volumeScatteringStrength:
       props.volumeScatteringStrength ?? previousUniforms?.volumeScatteringStrength ?? 0,
+    contactShadowStrength:
+      props.contactShadowStrength ?? previousUniforms?.contactShadowStrength ?? 0,
     depthBias: props.depthBias ?? previousUniforms?.depthBias ?? 0.00008,
     dynamicReflectionStrength:
       props.dynamicReflectionStrength ?? previousUniforms?.dynamicReflectionStrength ?? 0,
@@ -727,12 +881,15 @@ export const glassTransmission = {
     viewportSize: 'vec2<f32>',
     depthRange: 'vec2<f32>',
     environmentIntensity: 'f32',
+    environmentMipLevels: 'f32',
+    environmentPrefilterStrength: 'f32',
     thicknessStrength: 'f32',
     roughTransmissionStrength: 'f32',
     spectralAbsorptionStrength: 'f32',
     thinFilmThickness: 'f32',
     thinFilmStrength: 'f32',
     volumeScatteringStrength: 'f32',
+    contactShadowStrength: 'f32',
     depthBias: 'f32',
     dynamicReflectionStrength: 'f32',
     secondaryBounceStrength: 'f32',
@@ -743,12 +900,15 @@ export const glassTransmission = {
     viewportSize: [1, 1],
     depthRange: [0.1, 100],
     environmentIntensity: 1,
+    environmentMipLevels: 1,
+    environmentPrefilterStrength: 0,
     thicknessStrength: 1,
     roughTransmissionStrength: 0,
     spectralAbsorptionStrength: 0,
     thinFilmThickness: 0,
     thinFilmStrength: 0,
     volumeScatteringStrength: 0,
+    contactShadowStrength: 0,
     depthBias: 0.00008,
     dynamicReflectionStrength: 0,
     secondaryBounceStrength: 0,

--- a/modules/experimental/test/materials/optical-materials.node.spec.ts
+++ b/modules/experimental/test/materials/optical-materials.node.spec.ts
@@ -320,12 +320,15 @@ test('optical materials retain defaults while applying partial updates', testCas
       viewportSize: [1, 1],
       depthRange: [0.1, 100],
       environmentIntensity: 1,
+      environmentMipLevels: 1,
+      environmentPrefilterStrength: 0,
       thicknessStrength: 1,
       roughTransmissionStrength: 0,
       spectralAbsorptionStrength: 0,
       thinFilmThickness: 0,
       thinFilmStrength: 0,
       volumeScatteringStrength: 0,
+      contactShadowStrength: 0,
       depthBias: 0.00008,
       dynamicReflectionStrength: 0,
       secondaryBounceStrength: 0,
@@ -335,13 +338,30 @@ test('optical materials retain defaults while applying partial updates', testCas
     'rasterized transmission exposes stable optical defaults'
   );
   const updatedTransmissionUniforms = glassTransmission.getUniforms(
-    {environmentIntensity: 1.6, thicknessStrength: 1.25},
+    {
+      environmentIntensity: 1.6,
+      environmentMipLevels: 9,
+      environmentPrefilterStrength: 0.85,
+      contactShadowStrength: 0.4,
+      thicknessStrength: 1.25
+    },
     initialTransmissionUniforms
   );
   testCase.equal(
     updatedTransmissionUniforms.environmentIntensity,
     1.6,
     'environment reflections remain adjustable'
+  );
+  testCase.equal(updatedTransmissionUniforms.environmentMipLevels, 9, 'probe mip capacity updates');
+  testCase.equal(
+    updatedTransmissionUniforms.environmentPrefilterStrength,
+    0.85,
+    'roughness-selected environment filtering is configurable'
+  );
+  testCase.equal(
+    updatedTransmissionUniforms.contactShadowStrength,
+    0.4,
+    'opaque-depth contact shadows are configurable'
   );
   testCase.equal(
     updatedTransmissionUniforms.thicknessStrength,
@@ -436,6 +456,16 @@ test('optical materials retain defaults while applying partial updates', testCas
     retainedOpticalUniforms.volumeScatteringStrength,
     0.38,
     'partial updates preserve optical volume scattering'
+  );
+  testCase.equal(
+    retainedOpticalUniforms.environmentMipLevels,
+    9,
+    'partial updates preserve the prefiltered environment pyramid'
+  );
+  testCase.equal(
+    retainedOpticalUniforms.contactShadowStrength,
+    0.4,
+    'partial updates preserve contact-shadow strength'
   );
 
   const initialReflectiveUniforms = reflectiveMaterial.getUniforms({});
@@ -641,6 +671,21 @@ test('rasterized glass transmission composes thickness, depth, and environment m
       shaderSource,
       /filteredEnvironment/,
       `${language} filters environment reflections for rough optical surfaces`
+    );
+    testCase.match(
+      shaderSource,
+      /glassTransmission_sampleEnvironmentAtRoughness/,
+      `${language} samples explicit roughness-dependent reflection lobes`
+    );
+    testCase.match(
+      shaderSource,
+      /reflectionLevel/,
+      `${language} selects initialized studio-environment mip levels`
+    );
+    testCase.match(
+      shaderSource,
+      /glassTransmission_getContactShadow/,
+      `${language} anchors translucent shells to nearby opaque geometry`
     );
   }
   testCase.end();

--- a/test/examples/packet-spraying-optics.node.spec.ts
+++ b/test/examples/packet-spraying-optics.node.spec.ts
@@ -1,0 +1,81 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {makeStudioEnvironmentMipLevels} from '../../examples/showcase/packet-spraying/optics';
+
+test('packet-spraying builds a complete portable studio-environment reflection pyramid', testCase => {
+  const levels = makeStudioEnvironmentMipLevels();
+
+  testCase.deepEqual(
+    levels.map(level => [level.width, level.height]),
+    [
+      [256, 128],
+      [128, 64],
+      [64, 32],
+      [32, 16],
+      [16, 8],
+      [8, 4],
+      [4, 2],
+      [2, 1],
+      [1, 1]
+    ],
+    'all environment levels are initialized down to a single rough-reflection texel'
+  );
+  testCase.ok(
+    levels.every(level => level.pixels.length === level.width * level.height * 4),
+    'each mip level has a tightly packed portable RGBA upload'
+  );
+  testCase.ok(
+    levels.every(level =>
+      level.pixels.every((channel, index) => index % 4 !== 3 || channel === 255)
+    ),
+    'studio environment coverage stays opaque across the complete pyramid'
+  );
+  testCase.ok(
+    levels[0].pixels.some((channel, index) => index % 4 !== 3 && channel > 150),
+    'the base level preserves directional studio highlights'
+  );
+
+  const finalLevel = levels[levels.length - 1];
+  testCase.ok(
+    finalLevel.pixels[2] > finalLevel.pixels[0],
+    'fully rough reflection retains the cool studio lighting balance'
+  );
+  testCase.end();
+});
+
+test('packet-spraying studio downsampling preserves averaged reflected light', testCase => {
+  const levels = makeStudioEnvironmentMipLevels(8, 4);
+
+  for (let levelIndex = 1; levelIndex < levels.length; levelIndex++) {
+    const previousLevel = levels[levelIndex - 1];
+    const currentLevel = levels[levelIndex];
+    for (let row = 0; row < currentLevel.height; row++) {
+      for (let column = 0; column < currentLevel.width; column++) {
+        for (let channel = 0; channel < 4; channel++) {
+          let sourceTotal = 0;
+          for (let rowOffset = 0; rowOffset < 2; rowOffset++) {
+            const sourceRow = Math.min(row * 2 + rowOffset, previousLevel.height - 1);
+            for (let columnOffset = 0; columnOffset < 2; columnOffset++) {
+              const sourceColumn = (column * 2 + columnOffset) % previousLevel.width;
+              sourceTotal +=
+                previousLevel.pixels[
+                  (sourceRow * previousLevel.width + sourceColumn) * 4 + channel
+                ];
+            }
+          }
+
+          testCase.equal(
+            currentLevel.pixels[(row * currentLevel.width + column) * 4 + channel],
+            Math.round(sourceTotal / 4),
+            `level ${levelIndex} texel ${column},${row} channel ${channel} conserves studio light`
+          );
+        }
+      }
+    }
+  }
+
+  testCase.end();
+});

--- a/test/examples/packet-spraying-story.node.spec.ts
+++ b/test/examples/packet-spraying-story.node.spec.ts
@@ -181,8 +181,12 @@ test('packet-spraying hover highlights glass without washing out transparency or
     'hovered plane switches ease toward a visible cool glass highlight'
   );
   testCase.ok(
-    planeHighlight[2] > 0.9 && pathHighlight[2] > 0.9,
-    'focused switch colors activate the dedicated Fresnel rim in both shader backends'
+    planeHighlight[2] >= 1.05 && pathHighlight[2] >= 1.05,
+    'fully focused switches cross the actual Fresnel-rim activation threshold'
+  );
+  testCase.ok(
+    makeNetworkSwitchHighlightColor(clearSwitch, 0.5, 0)[2] < planeHighlight[2],
+    'partial plane focus fades in before reaching the complete Fresnel rim'
   );
   testCase.ok(
     pathHighlight[1] > planeHighlight[1],


### PR DESCRIPTION
## Goals
- Advance the packet-spraying glass optics roadmap with reusable roughness-aware environment reflections and depth-aware optical contact.
- Preserve existing `glassTransmission` output unless the new controls are explicitly enabled.

## Changes
- Add optional `environmentMipLevels`, `environmentPrefilterStrength`, and `contactShadowStrength` controls to `glassTransmission`.
- Implement matching WGSL/GLSL roughness-selected environment mip sampling with separately softened internal reflection lobes.
- Add opaque-depth contact shadows that attenuate only transmitted light near actual adjacent geometry.
- Extract deterministic studio-environment generation into a dedicated showcase optics helper and explicitly upload its complete nine-level mip pyramid on WebGPU and WebGL.
- Expose independent prefiltered-reflection and glass-contact settings in the packet-spraying showcase.
- Update optical documentation, roadmap, module uniform/assembly tests, and deterministic environment-pyramid coverage.

## Verification
- `env -u YARN_NO_PROXY corepack yarn lint fix`
- `env -u YARN_NO_PROXY corepack yarn build`
- `env -u YARN_NO_PROXY corepack yarn test-node` — 219 passed, 2 skipped.
- `env -u YARN_NO_PROXY corepack yarn test-headless modules/experimental/test/oit/a-buffer-renderer.spec.ts modules/experimental/test/oit/wboit-renderer.spec.ts` — 2 files and 8 tests passed.
- `env -u YARN_NO_PROXY corepack yarn workspace luma.gl-examples-showcase-packet-spraying build`
- Live browser verification on both `?device=webgpu&orbit=0` and `?device=webgl&orbit=0`, confirming nine initialized reflection mips and no rendering errors.
- A broad `yarn test` run reached unrelated headless GPU/browser resource contention; the focused transparency browser suites, all Node tests, and live WebGPU/WebGL examples pass.
