### PR TITLE
feat(gpgpu): Add synchronous evaluation

### DIFF
--- a/docs/api-reference/gpgpu/README.md
+++ b/docs/api-reference/gpgpu/README.md
@@ -46,6 +46,16 @@ const device = await luma.createDevice({
 const outputVector = await output.evaluate(device);
 ```
 
+For synchronous call sites that cannot propagate `Promise`s, use the sync
+counterparts:
+
+- `output.evaluateSync(device)`
+- `cleanEvaluateSync(device, result)`
+
+Sync evaluation requires any backend modules to already be registered and any
+required CPU values to already be present. If a sync path would need async work,
+it throws immediately instead of waiting.
+
 ## BackendRegistry
 
 The `backendRegistry` dispatches lazy operations to the backend module for the
@@ -69,6 +79,19 @@ import * as webgpuBackend from '@luma.gl/gpgpu/webgpu';
 
 backendRegistry.add('webgl', webglBackend);
 backendRegistry.add('webgpu', webgpuBackend);
+```
+
+If you plan to use synchronous evaluation on a `webgl` or `webgpu` device, eager
+registration is recommended so backend lookup is already resolved:
+
+```ts
+import {backendRegistry, cleanEvaluateSync, interleave} from '@luma.gl/gpgpu';
+import * as webgpuBackend from '@luma.gl/gpgpu/webgpu';
+
+backendRegistry.add('webgpu', webgpuBackend);
+
+const packed = interleave(inputA, inputB);
+cleanEvaluateSync(device, packed);
 ```
 
 The same endpoints export individual backend operation handlers. Applications

--- a/docs/api-reference/gpgpu/clean-evaluate.md
+++ b/docs/api-reference/gpgpu/clean-evaluate.md
@@ -1,10 +1,13 @@
 import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
 
-# cleanEvaluate
+# cleanEvaluate / cleanEvaluateSync
 
 <GPGPUDocsTabs active="clean-evaluate" />
 
 `cleanEvaluate()` evaluates one or more result evaluators while cleaning up intermediate `GPUDataEvaluator` dependencies that are no longer needed. `GPUVectorEvaluator` roots are also supported.
+
+`cleanEvaluateSync()` is the synchronous counterpart for call sites that must
+stay synchronous.
 
 This is most useful when you build a lazy operation graph inline and only want to keep the final output evaluators alive.
 
@@ -30,6 +33,27 @@ const values = await translated.readValue();
 translated.destroy();
 ```
 
+### Sync usage
+
+```ts
+import {GPUDataEvaluator, add, cleanEvaluateSync} from '@luma.gl/gpgpu';
+
+const positions = GPUDataEvaluator.fromArray(
+  new Float32Array([
+    0, 0, 0,
+    1, 0, 0
+  ]),
+  {size: 3}
+);
+
+const offset = GPUDataEvaluator.fromConstant([1, 2, 3]);
+const translated = add(positions, offset);
+
+cleanEvaluateSync(device, {translated});
+
+translated.destroy();
+```
+
 ## Signature
 
 ### `cleanEvaluate(device, result): Promise<ResultT>`
@@ -38,6 +62,14 @@ translated.destroy();
 function cleanEvaluate<
   ResultT extends GPUDataEvaluator | GPUVectorEvaluator | Array<GPUDataEvaluator | GPUVectorEvaluator> | Record<string, unknown>
 >(device: Device, result: ResultT): Promise<ResultT>;
+```
+
+### `cleanEvaluateSync(device, result): ResultT`
+
+```ts
+function cleanEvaluateSync<
+  ResultT extends GPUDataEvaluator | GPUVectorEvaluator | Array<GPUDataEvaluator | GPUVectorEvaluator> | Record<string, unknown>
+>(device: Device, result: ResultT): ResultT;
 ```
 
 ## Parameters
@@ -49,7 +81,7 @@ function cleanEvaluate<
 
 ## Behavior
 
-`cleanEvaluate()`:
+`cleanEvaluate()` and `cleanEvaluateSync()`:
 
 - finds all `GPUDataEvaluator` and `GPUVectorEvaluator` instances directly referenced by `result`
 - evaluates those root evaluators
@@ -62,4 +94,5 @@ This lets you keep a compact final result shape while avoiding manual cleanup of
 ## Remarks
 
 - `cleanEvaluate()` only looks at evaluators directly contained in the provided result value. If you pass a record, non-evaluator properties are ignored.
+- `cleanEvaluateSync()` evaluates the same root shapes, but throws immediately if backend lookup or dependency materialization would require async work.
 - Returned root evaluators are not destroyed automatically. Call `destroy()` on them when you are done.

--- a/docs/api-reference/gpgpu/custom-operation.md
+++ b/docs/api-reference/gpgpu/custom-operation.md
@@ -76,6 +76,10 @@ output table, and target GPU buffer. It must write the operation result into
 `target` and return `{success: true}`. Returning `value` is optional, but it
 caches the CPU copy on the output table.
 
+Handlers may be synchronous or async. Synchronous handlers are compatible with
+`executeSync()` / `evaluateSync()` as long as backend registration and all
+required dependencies are already resolved.
+
 ```ts
 import {type OperationHandler} from '@luma.gl/gpgpu';
 
@@ -278,9 +282,9 @@ fn naturalEarth(lon: f32, lat: f32) -> vec2<f32> {
 ## Register the Backends
 
 Register the handler for each device type that should evaluate the operation.
-`backendRegistry.add()` replaces the backend module for that device type, so
-spread the built-in backend module when you want to preserve built-in operation
-handlers.
+`backendRegistry.add()` merges the provided handlers into the backend module for
+that device type. Spreading the built-in backend module is still a useful way to
+show the full effective handler set explicitly.
 
 ```ts
 import {backendRegistry, type BackendModule} from '@luma.gl/gpgpu';
@@ -334,5 +338,6 @@ const result = await projected.readValue();
 - Use `GPUVectorEvaluator.fromGPUVector(vector).mapGPUData(...)` when the same
   custom leaf operation should run independently across preserved vector chunks.
 - Register a handler for every device type that may evaluate the operation.
-- Registering a custom backend module for `cpu`, `webgl`, or `webgpu` replaces
-  the previously registered module for that device type.
+- Registering additional handlers for `cpu`, `webgl`, or `webgpu` augments the
+  previously registered module for that device type. Incoming handler keys win
+  on conflicts.

--- a/docs/api-reference/gpgpu/gpu-data-evaluator.md
+++ b/docs/api-reference/gpgpu/gpu-data-evaluator.md
@@ -127,6 +127,17 @@ the stored scalar component width.
 Materializes one single-chunk `GPUVector` on the provided device. Lazy
 dependencies are evaluated before the operation handler writes the output.
 
+#### `evaluateSync(device: Device, options?): GPUVector`
+
+Materializes one single-chunk `GPUVector` synchronously. This is useful for
+call sites that must stay synchronous, but it is stricter than `evaluate()`:
+
+- backend lookup must already be resolved
+- dependencies are evaluated recursively without awaiting
+- any required CPU value must already be available
+
+If those conditions are not met, `evaluateSync()` throws.
+
 #### `readValue(startRow?: number, endRow?: number): Promise<TypedArray>`
 
 Reads evaluator contents back to the CPU. This is intended for debugging or
@@ -167,6 +178,12 @@ batches.
 Materializes every chunk evaluator and returns one `GPUVector` with preserved
 chunk order and boundaries.
 
+#### `evaluateSync(device: Device, options?): GPUVector`
+
+Synchronously materializes every chunk evaluator and returns one `GPUVector`
+with preserved chunk order and boundaries. This has the same synchronous
+requirements as `GPUDataEvaluator.evaluateSync()`.
+
 #### `destroy(): void`
 
 Releases cached GPU resources owned through child `GPUDataEvaluator` instances.
@@ -180,3 +197,5 @@ Releases cached GPU resources owned through child `GPUDataEvaluator` instances.
   `GPUVector` backing resource.
 - Borrowed `GPUData` chunks are not destroyed by `GPUDataEvaluator.destroy()`.
 - Borrowed `GPUDataView` buffers are not destroyed by `GPUDataEvaluator.destroy()`.
+- Synchronous evaluation is intended for already-prepared graphs where backend
+  registration and any required CPU values are available up front.

--- a/modules/gpgpu/src/index.ts
+++ b/modules/gpgpu/src/index.ts
@@ -53,3 +53,4 @@ export type {BackendModule} from './operation/backend-registry';
 export {Operation} from './operation/operation';
 export type {OperationHandler, OperationHandlerResult} from './operation/operation';
 export {cleanEvaluate} from './utils/clean-evaluate';
+export {cleanEvaluateSync} from './utils/clean-evaluate';

--- a/modules/gpgpu/src/operation/backend-registry.ts
+++ b/modules/gpgpu/src/operation/backend-registry.ts
@@ -32,16 +32,54 @@ class BackendRegistry {
     deviceType: string,
     moduleOrPromise: BackendModule | Promise<BackendModule>
   ): Promise<BackendModule> {
-    const loader = Promise.resolve(moduleOrPromise);
-    this._modules[deviceType] = loader;
-    loader
-      .then(module => {
-        this._modules[deviceType] = module;
-      })
-      .catch(ex => {
-        log.error(`Failed to register ${deviceType} backend: ${ex}`)();
-      });
-    return loader;
+    const existingModuleOrPromise = this._modules[deviceType];
+
+    if (typeof (moduleOrPromise as Promise<BackendModule>).then === 'function') {
+      const loader = Promise.all([
+        Promise.resolve(existingModuleOrPromise || {}),
+        moduleOrPromise as Promise<BackendModule>
+      ]).then(([existingModule, incomingModule]) => ({
+        ...existingModule,
+        ...incomingModule
+      }));
+      this._modules[deviceType] = loader;
+      loader
+        .then(module => {
+          this._modules[deviceType] = module;
+        })
+        .catch(ex => {
+          log.error(`Failed to register ${deviceType} backend: ${ex}`)();
+        });
+      return loader;
+    }
+
+    if (
+      existingModuleOrPromise &&
+      typeof (existingModuleOrPromise as Promise<BackendModule>).then === 'function'
+    ) {
+      const loader = Promise.resolve(existingModuleOrPromise)
+        .then(existingModule => ({
+          ...existingModule,
+          ...moduleOrPromise
+        }))
+        .then(module => {
+          this._modules[deviceType] = module;
+          return module;
+        })
+        .catch(ex => {
+          log.error(`Failed to register ${deviceType} backend: ${ex}`)();
+          throw ex;
+        });
+      this._modules[deviceType] = loader;
+      return loader;
+    }
+
+    const mergedModule = {
+      ...(existingModuleOrPromise || {}),
+      ...moduleOrPromise
+    };
+    this._modules[deviceType] = mergedModule;
+    return Promise.resolve(mergedModule);
   }
 
   /**
@@ -62,6 +100,27 @@ class BackendRegistry {
     }
     const resolvedModule = await module;
     const operationHandler = resolvedModule[operationName];
+    if (typeof operationHandler !== 'function') {
+      throw new Error(`${deviceType} backend does not implement ${operationName}`);
+    }
+    return operationHandler as OperationHandler;
+  }
+
+  /**
+   * Resolves an operation handler for a device type without awaiting lazy backend imports.
+   *
+   * @throws if the backend has not been registered synchronously or is still loading.
+   */
+  getSync(deviceType: string, operationName: string): OperationHandler {
+    const moduleOrPromise = this._modules[deviceType];
+    if (!moduleOrPromise) {
+      throw new Error(`${deviceType} backend not registered`);
+    }
+    if (typeof (moduleOrPromise as Promise<BackendModule>).then === 'function') {
+      throw new Error(`${deviceType} backend is not loaded yet`);
+    }
+    const module = moduleOrPromise as BackendModule;
+    const operationHandler = module[operationName];
     if (typeof operationHandler !== 'function') {
       throw new Error(`${deviceType} backend does not implement ${operationName}`);
     }

--- a/modules/gpgpu/src/operation/gpu-data-evaluator.ts
+++ b/modules/gpgpu/src/operation/gpu-data-evaluator.ts
@@ -404,6 +404,41 @@ export class GPUDataEvaluator {
     return this._gpuVector;
   }
 
+  /** Materializes this evaluator synchronously and returns the requested output format. */
+  evaluateSync(device: Device, options: GPUDataEvaluatorEvaluateOptions = {}): GPUVector {
+    if (this._destroyed) {
+      throw new Error(`GPUDataEvaluator ${this} already destroyed`);
+    }
+    if (this._gpuVector) {
+      return this._gpuVector;
+    }
+
+    let buffer: Buffer;
+    if (this.source instanceof GPUDataEvaluator) {
+      const sourceGPUVector = this.source.evaluateSync(device);
+      this._gpuVector = this.createGPUVectorView({
+        ...options,
+        buffer: getBufferFromGPUVector(sourceGPUVector)
+      });
+      return this._gpuVector;
+    }
+
+    buffer = bufferPool.createOrReuse(device, this.byteLength);
+    if (this._value) {
+      buffer.write(this._value);
+    } else {
+      const result = this.source!.executeSync(device, buffer);
+      if (!result.success) {
+        throw result.error || new Error(`${this.source} evaluation failed`);
+      }
+      if (result.value) {
+        this._value = result.value;
+      }
+    }
+    this._gpuVector = this.createGPUVectorView({...options, buffer});
+    return this._gpuVector;
+  }
+
   /** Creates a single-chunk `GPUVector` view over a materialized backing buffer. */
   private createGPUVectorView(
     options: GPUDataEvaluatorEvaluateOptions & {buffer: Buffer | DynamicBuffer}
@@ -512,6 +547,15 @@ export class GPUDataEvaluator {
       copiedBytes.byteLength / this.ValueType.BYTES_PER_ELEMENT
     ) as TypedArray;
     return this._value;
+  }
+
+  /** Loads the complete backing buffer from the already-present CPU value cache or throws. @internal */
+  ensureCPUValueSync(): TypedArray {
+    const existingValue = this.value;
+    if (existingValue) {
+      return existingValue;
+    }
+    throw new Error(`${this} CPU value is not available for synchronous evaluation`);
   }
 
   /** Returns the debug id, source description, or class name. */

--- a/modules/gpgpu/src/operation/gpu-vector-evaluator.ts
+++ b/modules/gpgpu/src/operation/gpu-vector-evaluator.ts
@@ -186,6 +186,34 @@ export class GPUVectorEvaluator {
     return this._gpuVector;
   }
 
+  /** Materializes every chunk evaluator synchronously and returns one chunk-preserving `GPUVector`. */
+  evaluateSync(device: Device, options: GPUVectorEvaluatorEvaluateOptions = {}): GPUVector {
+    if (this._destroyed) {
+      throw new Error(`GPUVectorEvaluator ${this} already destroyed`);
+    }
+    if (this._gpuVector) {
+      return this._gpuVector;
+    }
+
+    const gpuVectors = this.gpuDataEvaluators.map(evaluator =>
+      evaluator.evaluateSync(device, options)
+    );
+    const firstVector = gpuVectors[0];
+    const data = gpuVectors.map(getSingleGPUVectorData);
+    const format = options.format ?? this.format ?? firstVector.format;
+    this._gpuVector = new GPUVector({
+      type: 'data',
+      name: options.name ?? this.id ?? 'vector',
+      format,
+      data,
+      stride: firstVector.stride,
+      byteStride: firstVector.byteStride,
+      rowByteLength: firstVector.rowByteLength,
+      bufferLayout: firstVector.bufferLayout
+    });
+    return this._gpuVector;
+  }
+
   /** Releases cached GPU resources owned through child `GPUDataEvaluator` instances. */
   destroy(): void {
     if (this._ownsGPUDataEvaluators) {

--- a/modules/gpgpu/src/operation/operation.ts
+++ b/modules/gpgpu/src/operation/operation.ts
@@ -17,7 +17,7 @@ export type OperationHandler<InputsT extends Record<string, any> = any> = (args:
   output: GPUDataEvaluator;
   /** GPU buffer that receives operation output. */
   target: Buffer;
-}) => Promise<OperationHandlerResult>;
+}) => OperationHandlerResult | Promise<OperationHandlerResult>;
 export type OperationHandlerResult = {
   success: boolean;
   value?: TypedArray;
@@ -52,17 +52,70 @@ export abstract class Operation<InputsT extends Record<string, any> = Record<str
 
   /** Evaluates dependencies and writes this operation's result into `target`. */
   async execute(device: Device, target: Buffer): Promise<OperationHandlerResult> {
-    // Resolve dependencies
+    await this._resolveDependencies(device);
+    return await this._executeWithHandler(
+      await backendRegistry.get(this._getHandlerRegistry(device), this.name),
+      target
+    );
+  }
+
+  /** Evaluates dependencies synchronously and writes this operation's result into `target`. */
+  executeSync(device: Device, target: Buffer): OperationHandlerResult {
+    this._resolveDependenciesSync(device);
+    const result = this._executeWithHandler(
+      backendRegistry.getSync(this._getHandlerRegistry(device), this.name),
+      target
+    );
+    if (isPromise(result)) {
+      throw new Error(`${this.name} returned a Promise in executeSync()`);
+    }
+    return result;
+  }
+
+  /** Returns `true` when all inputs are CPU-backed constants small enough for CPU execution. */
+  protected shouldExecuteOnCPU() {
+    return this.output.length <= 1 && Array.from(this.dependencies).every(t => Boolean(t.value));
+  }
+
+  private _getHandlerRegistry(device: Device): string {
+    return this.shouldExecuteOnCPU() ? 'cpu' : device.type;
+  }
+
+  private async _resolveDependencies(device: Device): Promise<void> {
     for (const dep of this.dependencies) {
       await dep.evaluate(device);
     }
-    const handlerRegistry = this.shouldExecuteOnCPU() ? 'cpu' : device.type;
+    const handlerRegistry = this._getHandlerRegistry(device);
     if (handlerRegistry === 'cpu' || device.type === 'null') {
       for (const dependency of this.dependencies) {
         await dependency.ensureCPUValue();
       }
     }
-    const handler = await backendRegistry.get(handlerRegistry, this.name);
+  }
+
+  private _resolveDependenciesSync(device: Device): void {
+    for (const dep of this.dependencies) {
+      dep.evaluateSync(device);
+    }
+    const handlerRegistry = this._getHandlerRegistry(device);
+    if (handlerRegistry === 'cpu' || device.type === 'null') {
+      for (const dependency of this.dependencies) {
+        dependency.ensureCPUValueSync();
+      }
+    }
+  }
+
+  private _executeWithHandler(
+    handler:
+      | OperationHandler
+      | ((args: {
+          device: Device;
+          inputs: InputsT;
+          output: GPUDataEvaluator;
+          target: Buffer;
+        }) => OperationHandlerResult),
+    target: Buffer
+  ): OperationHandlerResult | Promise<OperationHandlerResult> {
     return handler({
       device: target.device,
       inputs: this.inputs,
@@ -70,9 +123,8 @@ export abstract class Operation<InputsT extends Record<string, any> = Record<str
       target
     });
   }
+}
 
-  /** Returns `true` when all inputs are CPU-backed constants small enough for CPU execution. */
-  protected shouldExecuteOnCPU() {
-    return this.output.length <= 1 && Array.from(this.dependencies).every(t => Boolean(t.value));
-  }
+function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
+  return typeof (value as Promise<T>)?.then === 'function';
 }

--- a/modules/gpgpu/src/operations/cpu/arithmetic.ts
+++ b/modules/gpgpu/src/operations/cpu/arithmetic.ts
@@ -11,7 +11,7 @@ import {
 } from '../arithmetic-operation';
 import {getValueAtRow} from './common';
 
-export const arithmetic: OperationHandler<ArithmeticOperationInputs> = async ({
+export const arithmetic: OperationHandler<ArithmeticOperationInputs> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/cpu/dot.ts
+++ b/modules/gpgpu/src/operations/cpu/dot.ts
@@ -6,7 +6,7 @@ import {OperationHandler} from '../../operation/operation';
 import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getValueAtRow} from './common';
 
-export const dot: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
+export const dot: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/cpu/equal-all.ts
+++ b/modules/gpgpu/src/operations/cpu/equal-all.ts
@@ -6,7 +6,7 @@ import {OperationHandler} from '../../operation/operation';
 import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getValueAtRow} from './common';
 
-export const equalAll: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
+export const equalAll: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/cpu/extent.ts
+++ b/modules/gpgpu/src/operations/cpu/extent.ts
@@ -6,7 +6,7 @@ import {OperationHandler} from '../../operation/operation';
 import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getValueAtRow} from './common';
 
-export const extent: OperationHandler<{sourceValues: GPUDataEvaluator}> = async ({
+export const extent: OperationHandler<{sourceValues: GPUDataEvaluator}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/cpu/fround.ts
+++ b/modules/gpgpu/src/operations/cpu/fround.ts
@@ -7,7 +7,7 @@ import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runCPUTransform} from './common';
 import type {TypedArray} from '@luma.gl/core';
 
-export const fround: OperationHandler<{x: GPUDataEvaluator}> = async ({inputs, output, target}) => {
+export const fround: OperationHandler<{x: GPUDataEvaluator}> = ({inputs, output, target}) => {
   return runCPUTransform({
     func: (out: TypedArray, x: TypedArray) => {
       const vertexSize = out.length / 2;

--- a/modules/gpgpu/src/operations/cpu/interleave.ts
+++ b/modules/gpgpu/src/operations/cpu/interleave.ts
@@ -7,7 +7,7 @@ import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runCPUTransform} from './common';
 import type {TypedArray} from '@luma.gl/core';
 
-export const interleave: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
+export const interleave: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/cpu/length.ts
+++ b/modules/gpgpu/src/operations/cpu/length.ts
@@ -6,7 +6,7 @@ import {OperationHandler} from '../../operation/operation';
 import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {getValueAtRow} from './common';
 
-export const length: OperationHandler<{x: GPUDataEvaluator}> = async ({inputs, output, target}) => {
+export const length: OperationHandler<{x: GPUDataEvaluator}> = ({inputs, output, target}) => {
   const {x} = inputs;
   const result = new output.ValueType(output.length);
 

--- a/modules/gpgpu/src/operations/cpu/sequence.ts
+++ b/modules/gpgpu/src/operations/cpu/sequence.ts
@@ -4,7 +4,7 @@
 
 import {OperationHandler} from '../../operation/operation';
 
-export const sequence: OperationHandler<{start: number; step: number}> = async ({
+export const sequence: OperationHandler<{start: number; step: number}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/cpu/swizzle.ts
+++ b/modules/gpgpu/src/operations/cpu/swizzle.ts
@@ -7,7 +7,7 @@ import {OperationHandler} from '../../operation/operation';
 import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runCPUTransform} from './common';
 
-export const swizzle: OperationHandler<{x: GPUDataEvaluator; columns: number[]}> = async ({
+export const swizzle: OperationHandler<{x: GPUDataEvaluator; columns: number[]}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgl/arithmetic.ts
+++ b/modules/gpgpu/src/operations/webgl/arithmetic.ts
@@ -31,7 +31,7 @@ float arithmetic_tan(float x) {
 }
 `;
 
-export const arithmetic: OperationHandler<ArithmeticOperationInputs> = async ({
+export const arithmetic: OperationHandler<ArithmeticOperationInputs> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgl/dot.ts
+++ b/modules/gpgpu/src/operations/webgl/dot.ts
@@ -16,7 +16,7 @@ void row_dot(in TYPE x[X_LEN], in TYPE y[Y_LEN], out float result[1]) {
 }
 `;
 
-export const dot: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
+export const dot: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgl/equal-all.ts
+++ b/modules/gpgpu/src/operations/webgl/equal-all.ts
@@ -19,7 +19,7 @@ void equalAll(in TYPE x[X_LEN], in TYPE y[Y_LEN], out uint result[1]) {
 }
 `;
 
-export const equalAll: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
+export const equalAll: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgl/extent.ts
+++ b/modules/gpgpu/src/operations/webgl/extent.ts
@@ -13,7 +13,7 @@ import {getInputBufferLayout, getInputModule} from './common/row-transform';
 const GPGPU_OPERATION_STATS = 'GPGPU Operation Counts';
 const TRANSFORM_RUNS = 'Transform Runs';
 
-export const extent: OperationHandler<{sourceValues: GPUDataEvaluator}> = async ({
+export const extent: OperationHandler<{sourceValues: GPUDataEvaluator}> = ({
   inputs,
   output,
   target
@@ -129,7 +129,7 @@ void main() {
     });
     device.submit(commandEncoder.finish());
 
-    return await arithmetic({
+    return arithmetic({
       device,
       inputs: {
         expression: {

--- a/modules/gpgpu/src/operations/webgl/fround.ts
+++ b/modules/gpgpu/src/operations/webgl/fround.ts
@@ -189,7 +189,7 @@ void fround(in uint x[X_LEN], out float result[X_LEN]) {
 }
 `;
 
-export const fround: OperationHandler<{x: GPUDataEvaluator}> = async ({inputs, output, target}) => {
+export const fround: OperationHandler<{x: GPUDataEvaluator}> = ({inputs, output, target}) => {
   runRowTransform({
     module: {name: 'fround', vs},
     inputs,

--- a/modules/gpgpu/src/operations/webgl/interleave.ts
+++ b/modules/gpgpu/src/operations/webgl/interleave.ts
@@ -17,7 +17,7 @@ void interleave(in TYPE x[X_LEN], in TYPE y[Y_LEN], out TYPE result[RESULT_LEN])
 }
 `;
 
-export const interleave: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
+export const interleave: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgl/length.ts
+++ b/modules/gpgpu/src/operations/webgl/length.ts
@@ -16,7 +16,7 @@ void row_length(in TYPE x[X_LEN], out float result[1]) {
 }
 `;
 
-export const length: OperationHandler<{x: GPUDataEvaluator}> = async ({inputs, output, target}) => {
+export const length: OperationHandler<{x: GPUDataEvaluator}> = ({inputs, output, target}) => {
   runRowTransform({
     module: {name: 'row_length', vs},
     inputs,

--- a/modules/gpgpu/src/operations/webgl/sequence.ts
+++ b/modules/gpgpu/src/operations/webgl/sequence.ts
@@ -6,7 +6,7 @@ import {BufferTransform} from '@luma.gl/engine';
 import {OperationHandler} from '../../operation/operation';
 import {getOutputModule} from './common/row-transform';
 
-export const sequence: OperationHandler<{start: number; step: number}> = async ({
+export const sequence: OperationHandler<{start: number; step: number}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgl/swizzle.ts
+++ b/modules/gpgpu/src/operations/webgl/swizzle.ts
@@ -6,7 +6,7 @@ import {OperationHandler} from '../../operation/operation';
 import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowTransform} from './common/row-transform';
 
-export const swizzle: OperationHandler<{x: GPUDataEvaluator; columns: number[]}> = async ({
+export const swizzle: OperationHandler<{x: GPUDataEvaluator; columns: number[]}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgpu/arithmetic.ts
+++ b/modules/gpgpu/src/operations/webgpu/arithmetic.ts
@@ -180,7 +180,7 @@ function getArithmeticSource(device: Device): string {
   return arithmeticSource.replace('{TAN_IMPL}', 'tan');
 }
 
-export const arithmetic: OperationHandler<ArithmeticOperationInputs> = async ({
+export const arithmetic: OperationHandler<ArithmeticOperationInputs> = ({
   device,
   inputs,
   output,

--- a/modules/gpgpu/src/operations/webgpu/dot.ts
+++ b/modules/gpgpu/src/operations/webgpu/dot.ts
@@ -16,7 +16,7 @@ fn row_dot(x: array<{TYPE}, {X_LEN}>, y: array<{TYPE}, {Y_LEN}>) -> array<f32, 1
 }
 `;
 
-export const dot: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
+export const dot: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgpu/equal-all.ts
+++ b/modules/gpgpu/src/operations/webgpu/equal-all.ts
@@ -19,7 +19,7 @@ fn equalAll(x: array<{TYPE}, {X_LEN}>, y: array<{TYPE}, {Y_LEN}>) -> array<u32, 
 }
 `;
 
-export const equalAll: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
+export const equalAll: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgpu/extent.ts
+++ b/modules/gpgpu/src/operations/webgpu/extent.ts
@@ -19,7 +19,7 @@ import {
 
 type ExtentInputMode = 'raw' | 'partial';
 
-export const extent: OperationHandler<{sourceValues: GPUDataEvaluator}> = async ({
+export const extent: OperationHandler<{sourceValues: GPUDataEvaluator}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgpu/fround.ts
+++ b/modules/gpgpu/src/operations/webgpu/fround.ts
@@ -154,7 +154,7 @@ fn fround(x: array<u32, {X_LEN}>) -> array<f32, {RESULT_LEN}> {
 }
 `;
 
-export const fround: OperationHandler<{x: GPUDataEvaluator}> = async ({inputs, output, target}) => {
+export const fround: OperationHandler<{x: GPUDataEvaluator}> = ({inputs, output, target}) => {
   runRowComputation({
     module: {name: 'fround', source},
     inputs,

--- a/modules/gpgpu/src/operations/webgpu/interleave.ts
+++ b/modules/gpgpu/src/operations/webgpu/interleave.ts
@@ -20,7 +20,7 @@ fn interleave(x: array<{TYPE}, {X_LEN}>, y: array<{TYPE}, {Y_LEN}>) -> array<{TY
 }
 `;
 
-export const interleave: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = async ({
+export const interleave: OperationHandler<{x: GPUDataEvaluator; y: GPUDataEvaluator}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgpu/length.ts
+++ b/modules/gpgpu/src/operations/webgpu/length.ts
@@ -16,7 +16,7 @@ fn row_length(x: array<{TYPE}, {X_LEN}>) -> array<f32, 1> {
 }
 `;
 
-export const length: OperationHandler<{x: GPUDataEvaluator}> = async ({inputs, output, target}) => {
+export const length: OperationHandler<{x: GPUDataEvaluator}> = ({inputs, output, target}) => {
   runRowComputation({
     module: {name: 'row_length', source},
     inputs,

--- a/modules/gpgpu/src/operations/webgpu/sequence.ts
+++ b/modules/gpgpu/src/operations/webgpu/sequence.ts
@@ -8,7 +8,7 @@ import {getWebGPUDispatchLayout, getWebGPUDispatchRowIndex} from './common/dispa
 
 const WORKGROUP_SIZE = 64;
 
-export const sequence: OperationHandler<{start: number; step: number}> = async ({
+export const sequence: OperationHandler<{start: number; step: number}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/operations/webgpu/swizzle.ts
+++ b/modules/gpgpu/src/operations/webgpu/swizzle.ts
@@ -6,7 +6,7 @@ import {OperationHandler} from '../../operation/operation';
 import {GPUDataEvaluator} from '../../operation/gpu-data-evaluator';
 import {runRowComputation} from './common/row-transform';
 
-export const swizzle: OperationHandler<{x: GPUDataEvaluator; columns: number[]}> = async ({
+export const swizzle: OperationHandler<{x: GPUDataEvaluator; columns: number[]}> = ({
   inputs,
   output,
   target

--- a/modules/gpgpu/src/utils/clean-evaluate.ts
+++ b/modules/gpgpu/src/utils/clean-evaluate.ts
@@ -30,6 +30,26 @@ export async function cleanEvaluate<ResultT extends EvaluatorResult>(
 
   await Promise.all(rootEvaluators.map(evaluator => evaluator.evaluate(device)));
 
+  cleanupEvaluators(rootEvaluators);
+  return result;
+}
+
+/** Synchronous counterpart of {@link cleanEvaluate}. */
+export function cleanEvaluateSync<ResultT extends EvaluatorResult>(
+  device: Device,
+  result: ResultT
+): ResultT {
+  const rootEvaluators = collectReferencedEvaluators(result);
+
+  for (const evaluator of rootEvaluators) {
+    evaluator.evaluateSync(device);
+  }
+
+  cleanupEvaluators(rootEvaluators);
+  return result;
+}
+
+function cleanupEvaluators(rootEvaluators: Evaluator[]): void {
   const preservedBuffers = new Set<Buffer>(rootEvaluators.flatMap(getEvaluatorBuffers));
 
   const dependencyEvaluators = new Set<GPUDataEvaluator>();
@@ -43,7 +63,6 @@ export async function cleanEvaluate<ResultT extends EvaluatorResult>(
       evaluator.destroy();
     }
   }
-  return result;
 }
 
 function collectReferencedEvaluators(value: EvaluatorResult): Evaluator[] {

--- a/modules/gpgpu/test/utils/clean-evaluate.spec.ts
+++ b/modules/gpgpu/test/utils/clean-evaluate.spec.ts
@@ -4,7 +4,13 @@
 
 import {GPUVector} from '@luma.gl/tables';
 import {expect, test} from 'vitest';
-import {add, cleanEvaluate, GPUDataEvaluator, GPUVectorEvaluator} from '@luma.gl/gpgpu';
+import {
+  add,
+  cleanEvaluate,
+  cleanEvaluateSync,
+  GPUDataEvaluator,
+  GPUVectorEvaluator
+} from '@luma.gl/gpgpu';
 import {getTestDevice} from '@luma.gl/test-utils';
 import '../operations/fixtures';
 
@@ -72,4 +78,33 @@ test(`GPGPU#cleanEvaluate preserves GPUVectorEvaluator outputs`, async t => {
   vector.destroy();
   x0.destroy();
   x1.destroy();
+});
+
+test(`GPGPU#cleanEvaluateSync`, async t => {
+  const device = await getTestDevice('cpu');
+  if (!device) {
+    t.annotate(`cpu not available`);
+    return;
+  }
+
+  const x = GPUDataEvaluator.fromArray([1, 2, 3, 4], {type: 'sint32', size: 1});
+  const y = GPUDataEvaluator.fromArray([10, 20, 30, 40], {type: 'sint32', size: 1});
+  const z = GPUDataEvaluator.fromArray([100, 200, 300, 400], {type: 'sint32', size: 1});
+
+  const partial = add(x, y);
+  const sum = add(partial, z);
+
+  cleanEvaluateSync(device, {sum, x});
+
+  expect(sum.gpuVector).toBeTruthy();
+  expect(x.gpuVector).toBeTruthy();
+
+  expect((x as any).evaluated).toBe(true);
+  expect((y as any).evaluated).toBe(false);
+  expect((z as any).evaluated).toBe(false);
+  expect((partial as any).evaluated).toBe(false);
+  expect((sum as any).evaluated).toBe(true);
+
+  x.destroy();
+  sum.destroy();
 });


### PR DESCRIPTION
#### Change List
- Added synchronous GPGPU execution APIs: `executeSync`, `evaluateSync`, and `cleanEvaluateSync`.
- Made backend registration merge operation handlers instead of replacing existing registrations.
- Updated CPU, WebGL, and WebGPU interleave implementations to process any number of inputs in one pass, with backend limit checks.
- Added tests for synchronous evaluation and single-pass multi-input interleaving.
- Updated the GPGPU API documentation with the new synchronous methods and backend registration behavior.