### PR TITLE
fix(optics): address glass transmission review feedback

### DIFF
--- a/docs/api-guide/shaders/glass-effects.md
+++ b/docs/api-guide/shaders/glass-effects.md
@@ -243,8 +243,8 @@ These materials are advanced raster approximations, not a complete physically ba
 system. In particular, the current implementation does not provide:
 
 - Full energy-conserving multiple-scattering or microfacet transmission.
-- Prefiltered environment probes, off-screen reflection recovery, or geometry-aware rough
-  transmission beyond the bounded screen-space footprint.
+- Authored HDR environment probes, importance-sampled GGX probe convolution, off-screen reflection
+  recovery, or geometry-aware rough transmission beyond the bounded screen-space footprint.
 - Physically traced multiple refraction events or caustics; the available focused-light module is
   an intentionally bounded raster approximation.
 - Off-screen background recovery or geometry-aware refracted-ray tracing.

--- a/modules/experimental/src/materials/glass-transmission.ts
+++ b/modules/experimental/src/materials/glass-transmission.ts
@@ -549,9 +549,17 @@ vec3 glassTransmission_sampleEnvironmentAtRoughness(
     ) * glassTransmission.environmentIntensity;
   }
   vec2 blurOffset = vec2(0.018, 0.011) * roughness;
-  vec3 centered = texture(glassEnvironmentTexture, environmentCoordinate).rgb;
-  vec3 forward = texture(glassEnvironmentTexture, environmentCoordinate + blurOffset).rgb;
-  vec3 backward = texture(glassEnvironmentTexture, environmentCoordinate - blurOffset).rgb;
+  vec3 centered = textureLod(glassEnvironmentTexture, environmentCoordinate, 0.0).rgb;
+  vec3 forward = textureLod(
+    glassEnvironmentTexture,
+    environmentCoordinate + blurOffset,
+    0.0
+  ).rgb;
+  vec3 backward = textureLod(
+    glassEnvironmentTexture,
+    environmentCoordinate - blurOffset,
+    0.0
+  ).rgb;
   vec3 baselineEnvironment = (centered + forward + backward) / 3.0;
   if (glassTransmission.roughTransmissionStrength <= 0.0) {
     return mix(
@@ -561,8 +569,16 @@ vec3 glassTransmission_sampleEnvironmentAtRoughness(
     ) * glassTransmission.environmentIntensity;
   }
   vec2 crossOffset = vec2(-blurOffset.y, blurOffset.x);
-  vec3 upper = texture(glassEnvironmentTexture, environmentCoordinate + crossOffset).rgb;
-  vec3 lower = texture(glassEnvironmentTexture, environmentCoordinate - crossOffset).rgb;
+  vec3 upper = textureLod(
+    glassEnvironmentTexture,
+    environmentCoordinate + crossOffset,
+    0.0
+  ).rgb;
+  vec3 lower = textureLod(
+    glassEnvironmentTexture,
+    environmentCoordinate - crossOffset,
+    0.0
+  ).rgb;
   vec3 filteredEnvironment = mix(
     baselineEnvironment,
     (centered + forward + backward + upper + lower) / 5.0,

--- a/modules/experimental/test/materials/optical-materials.node.spec.ts
+++ b/modules/experimental/test/materials/optical-materials.node.spec.ts
@@ -688,6 +688,14 @@ test('rasterized glass transmission composes thickness, depth, and environment m
       `${language} anchors translucent shells to nearby opaque geometry`
     );
   }
+  const glslEnvironmentSampleCalls = [
+    ...glassTransmission.fs.matchAll(/(texture(?:Lod)?)\(\s*glassEnvironmentTexture/g)
+  ];
+  testCase.ok(glslEnvironmentSampleCalls.length > 0, 'GLSL samples the environment texture');
+  testCase.ok(
+    glslEnvironmentSampleCalls.every(sampleCall => sampleCall[1] === 'textureLod'),
+    'GLSL uses explicit mip levels for prefiltered and legacy environment sampling'
+  );
   testCase.end();
 });
 


### PR DESCRIPTION
## Goals

- Address the two unresolved review comments posted after #2780 merged.
- Preserve WebGL/WebGPU fallback parity and keep the glass documentation internally consistent.

## Changes

- Force every GLSL legacy environment fallback sample to mip level zero with `textureLod`.
- Add regression coverage that rejects implicit GLSL environment sampling.
- Narrow the quality-boundary documentation to authored HDR probes and importance-sampled GGX convolution, which remain future work.

## Verification

- `nvm use`
- `yarn install` (completed with existing peer-dependency warnings)
- `yarn lint fix`
- `yarn build`
- `yarn test-node modules/experimental/test/materials/optical-materials.node.spec.ts`
- `yarn website:build`
- `(cd website && yarn build)`
- `yarn test`: node suite passed; headless suite passed 1,291 tests and failed one unrelated current-master WebGPU assertion in `modules/arrow-layers/test/layers/arrow-layers.spec.ts`, reproduced in isolation.