### PR TITLE
feat(showcase): finish cinematic network storytelling

### DIFF
--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -112,6 +112,7 @@ import {
   makeLinkTraffic,
   makeLinks,
   makePackets,
+  makeNetworkFabricTelemetry,
   makeNetworkPlaneTelemetry,
   makeNetworkPathFocus,
   makeNetworkSwitchPlaneTelemetry,
@@ -128,6 +129,7 @@ import {
   type ConversationRoute,
   type NetworkLink,
   type NetworkEndpointSignal,
+  type NetworkFabricTelemetry,
   type NetworkPlaneTelemetry,
   type NetworkPacketEvent,
   type NetworkPathFocus,
@@ -151,6 +153,7 @@ import {
   GUIDED_STORY_SWITCH_INDEX,
   makeNetworkDynamicRangeProfile,
   makeNetworkOpticsProfile,
+  makeNetworkStoryCamera,
   makeNetworkSwitchHighlightColor,
   MAX_NETWORK_HDR_HIGHLIGHT_BOOST,
   MAX_NETWORK_OPTICS_LEVEL,
@@ -1039,6 +1042,7 @@ class NetworkStoryControls {
   private readonly titleElement: HTMLDivElement;
   private readonly descriptionElement: HTMLParagraphElement;
   private readonly fabricStatusElement: HTMLSpanElement;
+  private readonly fabricMetricsElement: HTMLDivElement;
   private readonly planeIndicators: {
     greenBar: HTMLDivElement;
     redBar: HTMLDivElement;
@@ -1066,6 +1070,7 @@ class NetworkStoryControls {
   private readonly visualIntensityLabel: HTMLSpanElement;
   private readonly visualIntensityTitle: HTMLSpanElement;
   private currentBeatId = '';
+  private previousFabricMetricsSignature = '';
   private previousTelemetrySignature = '';
 
   constructor(
@@ -1366,6 +1371,19 @@ class NetworkStoryControls {
       return {greenBar, redBar, row: rowElement, status};
     });
 
+    this.fabricMetricsElement = document.createElement('div');
+    this.fabricMetricsElement.setAttribute('aria-live', 'polite');
+    Object.assign(this.fabricMetricsElement.style, {
+      display: 'flex',
+      justifyContent: 'space-between',
+      gap: '8px',
+      marginTop: '4px',
+      color: '#8fa5c3',
+      font: '8px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace',
+      whiteSpace: 'nowrap'
+    });
+    telemetryElement.appendChild(this.fabricMetricsElement);
+
     const visualIntensityElement = document.createElement('div');
     Object.assign(visualIntensityElement.style, {
       display: 'grid',
@@ -1611,6 +1629,42 @@ class NetworkStoryControls {
     }
 
     this.rootElement.dataset.networkPlaneStates = planes.map(plane => plane.status).join(',');
+  }
+
+  updateFabricTelemetry(telemetry: NetworkFabricTelemetry): void {
+    const signature = [
+      telemetry.state,
+      telemetry.capacityPercent,
+      telemetry.queuedPacketCount,
+      telemetry.trimmedPayloadCount,
+      telemetry.droppedPayloadCount,
+      telemetry.retransmissionCount,
+      telemetry.controlPacketCount
+    ].join(':');
+    if (signature === this.previousFabricMetricsSignature) {
+      return;
+    }
+    this.previousFabricMetricsSignature = signature;
+
+    const stateLabel = telemetry.state.toUpperCase();
+    const eventSummary = telemetry.controlPacketCount
+      ? `PROBE ${telemetry.controlPacketCount}`
+      : `Q ${telemetry.queuedPacketCount} · T ${telemetry.trimmedPayloadCount} · L ${telemetry.droppedPayloadCount} · R ${telemetry.retransmissionCount}`;
+    this.fabricMetricsElement.textContent = `${stateLabel} · CAP ${telemetry.capacityPercent}% · ${eventSummary}`;
+    this.fabricMetricsElement.style.color =
+      telemetry.state === 'balanced'
+        ? '#8fa5c3'
+        : telemetry.state === 'probing'
+          ? '#72dfff'
+          : telemetry.state === 'congested'
+            ? '#ffb764'
+            : '#ff8175';
+    this.fabricMetricsElement.setAttribute(
+      'aria-label',
+      `${stateLabel}. ${telemetry.activePathCount} of ${telemetry.totalPathCount} paths available, ${telemetry.capacityPercent} percent physical path capacity, ${telemetry.queuedPacketCount} queued payloads, ${telemetry.trimmedPayloadCount} trimmed payloads, ${telemetry.droppedPayloadCount} dropped payloads, ${telemetry.retransmissionCount} retransmissions, ${telemetry.controlPacketCount} control packets.`
+    );
+    this.rootElement.dataset.networkFabricState = telemetry.state;
+    this.rootElement.dataset.networkFabricCapacity = String(telemetry.capacityPercent);
   }
 
   setHighlightedPlane(planeIndex: number | null): void {
@@ -2981,6 +3035,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     const beat = getNetworkStoryBeat(this.guidedStoryChapterIndex, chapterElapsedTime);
     if (beat !== this.currentStoryBeat) {
       this.currentStoryBeat = beat;
+      this.guidedStoryCamera = makeNetworkStoryCamera(chapter, beat);
+      this.guidedStoryCameraTransitionEndsAt = animationTime + 1.25;
       this.storyControls?.updateBeat(chapter, beat);
       this.setStoryHighlight(beat?.planeIndex ?? null, beat?.pathIndex ?? null);
     }
@@ -3009,9 +3065,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     const controls = this.orbitControls;
     const camera = this.guidedStoryCamera;
     const cameraTarget: Vector3 = [...camera.target];
-    if (beat?.pathIndex !== undefined) {
+    if (!beat?.camera?.target && beat?.pathIndex !== undefined) {
       cameraTarget[2] += SPINE_POSITIONS[beat.pathIndex][2] * 0.2;
-    } else if (beat?.planeIndex !== undefined) {
+    } else if (!beat?.camera?.target && beat?.planeIndex !== undefined) {
       cameraTarget[2] += beat.planeIndex === 0 ? 0.32 : -0.32;
     }
     const yawDelta = Math.atan2(
@@ -4114,6 +4170,28 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         event.kind === 'probe-confirmation'
           ? makeBalancedEmissionColor(event.color, event.color[3])
           : event.color
+      );
+    }
+
+    const spinePathTelemetry = makeNetworkPlaneTelemetry(
+      this.conversationRoutes,
+      this.packetDefinitions,
+      this.failedSwitchIndices,
+      this.recoveringSwitchIndices,
+      this.congestedSwitchIndices
+    );
+    const fabricTelemetry = makeNetworkFabricTelemetry(
+      spinePathTelemetry,
+      this.queuedPacketDefinitions,
+      this.networkPacketEvents,
+      animationTime
+    );
+    this.storyControls?.updateFabricTelemetry(fabricTelemetry);
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingFabricState = fabricTelemetry.state;
+      this.canvas.dataset.packetSprayingCapacity = String(fabricTelemetry.capacityPercent);
+      this.canvas.dataset.packetSprayingRetransmissions = String(
+        fabricTelemetry.retransmissionCount
       );
     }
   }

--- a/examples/showcase/packet-spraying/network.ts
+++ b/examples/showcase/packet-spraying/network.ts
@@ -93,6 +93,21 @@ export type NetworkPlaneTelemetry = {
   status: NetworkPlaneStatus;
 };
 
+export type NetworkFabricState = 'balanced' | 'congested' | 'rerouting' | 'degraded' | 'probing';
+
+/** Compact, state-derived measurements for the guided network story. */
+export type NetworkFabricTelemetry = {
+  activePathCount: number;
+  capacityPercent: number;
+  controlPacketCount: number;
+  droppedPayloadCount: number;
+  queuedPacketCount: number;
+  retransmissionCount: number;
+  state: NetworkFabricState;
+  totalPathCount: number;
+  trimmedPayloadCount: number;
+};
+
 /** The physical switches, links, and endpoints traversed by one shared backbone path. */
 export type NetworkPathFocus = {
   hostIndices: Set<number>;
@@ -788,6 +803,51 @@ export function makeNetworkSwitchPlaneTelemetry(
       status: failed ? 'failed' : recovering ? 'recovering' : congested ? 'congested' : 'healthy'
     };
   });
+}
+
+/** Measures current path capacity and exceptional packet handling without estimating bandwidth. */
+export function makeNetworkFabricTelemetry(
+  spinePaths: readonly NetworkPlaneTelemetry[],
+  queuedPackets: readonly NetworkQueuedPacket[],
+  packetEvents: readonly NetworkPacketEvent[],
+  animationTime: number
+): NetworkFabricTelemetry {
+  const activeEvents = packetEvents.filter(
+    event => animationTime >= event.startedAt && animationTime <= event.startedAt + event.duration
+  );
+  const totalPathCount = spinePaths.length;
+  const activePathCount = spinePaths.filter(
+    path => path.status !== 'failed' && path.status !== 'recovering'
+  ).length;
+  const droppedPayloadCount = activeEvents.filter(event => event.kind === 'dropped-payload').length;
+  const trimmedPayloadCount = activeEvents.filter(event => event.kind === 'trimmed-payload').length;
+  const retransmissionCount = activeEvents.filter(event => event.kind === 'retransmission').length;
+  const controlPacketCount = activeEvents.filter(
+    event => event.kind === 'probe' || event.kind === 'probe-confirmation'
+  ).length;
+  const hasCongestion = spinePaths.some(path => path.status === 'congested');
+  const hasUnavailablePath = activePathCount < totalPathCount;
+  const state: NetworkFabricState = controlPacketCount
+    ? 'probing'
+    : droppedPayloadCount || retransmissionCount
+      ? 'rerouting'
+      : queuedPackets.length || trimmedPayloadCount || hasCongestion
+        ? 'congested'
+        : hasUnavailablePath
+          ? 'degraded'
+          : 'balanced';
+
+  return {
+    activePathCount,
+    capacityPercent: totalPathCount ? Math.round((activePathCount / totalPathCount) * 100) : 0,
+    controlPacketCount,
+    droppedPayloadCount,
+    queuedPacketCount: queuedPackets.length,
+    retransmissionCount,
+    state,
+    totalPathCount,
+    trimmedPayloadCount
+  };
 }
 
 /** Produces bounded source-launch and destination-delivery activity for active conversations. */

--- a/examples/showcase/packet-spraying/story.ts
+++ b/examples/showcase/packet-spraying/story.ts
@@ -14,6 +14,7 @@ import {
 export type NetworkStoryState = 'healthy' | 'congested' | 'failed' | 'recovering';
 
 export type NetworkStoryBeat = {
+  camera?: Partial<NetworkStoryCamera>;
   color: string;
   description: string;
   id: string;
@@ -99,6 +100,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Independent senders',
         description: 'Separate red and green servers launch their first packets.',
         color: '#a8c7ff',
+        camera: {target: [0, -1.7, 0.2], distance: 10.8, yaw: 0.56, pitch: 0.62},
         pathIndex: 0,
         position: 0.05
       },
@@ -107,6 +109,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Packets interleave',
         description: 'The source-side access plane interleaves one red packet with one green.',
         color: '#77adff',
+        camera: {target: [0, -0.7, 0.15], distance: 9.7, yaw: 0.43, pitch: 0.53},
         planeIndex: 0,
         position: 0.35
       },
@@ -115,6 +118,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Separate destinations',
         description: 'The destination plane separates both streams into their target servers.',
         color: '#77dfa4',
+        camera: {target: [0, -1.25, -0.2], distance: 10.7, yaw: 0.7, pitch: 0.57},
         planeIndex: 1,
         position: 0.71
       }
@@ -134,6 +138,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Backbone path one',
         description: 'The first spine carries alternating red and green packets.',
         color: '#83bcff',
+        camera: {target: [0, 0.15, 0], distance: 10.9, yaw: 0.76, pitch: 0.5},
         pathIndex: 0,
         position: 0.04
       },
@@ -142,6 +147,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Backbone path two',
         description: 'The next packets use an independent second spine.',
         color: '#83bcff',
+        camera: {target: [0, 0.35, 0], distance: 10.2, yaw: 0.58, pitch: 0.46},
         pathIndex: 1,
         position: 0.28
       },
@@ -150,6 +156,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Backbone path three',
         description: 'A third independent path adds throughput without congestion.',
         color: '#83bcff',
+        camera: {target: [0, 0.45, 0], distance: 9.9, yaw: 0.38, pitch: 0.44},
         pathIndex: 2,
         position: 0.52
       },
@@ -158,6 +165,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Backbone path four',
         description: 'The fourth path completes the load-balanced packet spray.',
         color: '#83bcff',
+        camera: {target: [0, 0.35, 0], distance: 10.6, yaw: 0.2, pitch: 0.48},
         pathIndex: 3,
         position: 0.76
       }
@@ -177,6 +185,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Switch congestion',
         description: 'An amber spine becomes congested as incoming packets begin to queue.',
         color: '#ffbd68',
+        camera: {target: [0, 1.05, 0.55], distance: 8.9, yaw: 0.37, pitch: 0.4},
         pathIndex: 1,
         position: 0
       },
@@ -185,6 +194,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Packets queue',
         description: 'Alternating red and green packets briefly accumulate before the switch.',
         color: '#ffc26f',
+        camera: {target: [0, 0.72, 0.6], distance: 8.2, yaw: 0.31, pitch: 0.43},
         pathIndex: 1,
         position: 0.3
       },
@@ -193,6 +203,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Headers continue',
         description: 'The switch trims overloaded payloads while their compact headers continue.',
         color: '#ff9a54',
+        camera: {target: [0, 0.95, 0.58], distance: 7.8, yaw: 0.25, pitch: 0.39},
         pathIndex: 1,
         position: 0.53
       },
@@ -201,6 +212,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Healthy paths absorb load',
         description: 'Senders shift most packets toward healthy spines without retiring the path.',
         color: '#75dfa8',
+        camera: {target: [0, 0.5, 0.15], distance: 10.4, yaw: 0.54, pitch: 0.47},
         pathIndex: 2,
         position: 0.75
       }
@@ -220,6 +232,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'In-flight packets are lost',
         description: 'The failing spine scatters the packets already committed to its path.',
         color: '#ff655e',
+        camera: {target: [0, 1.08, 0.58], distance: 8.2, yaw: 0.22, pitch: 0.4},
         pathIndex: 1,
         position: 0
       },
@@ -228,6 +241,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Failed path retires',
         description: 'MRC detects packet loss and immediately removes the failed spine.',
         color: '#ff7869',
+        camera: {target: [0, 0.92, 0.5], distance: 8.8, yaw: 0.13, pitch: 0.43},
         pathIndex: 1,
         position: 0.28
       },
@@ -236,6 +250,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Missing packets retransmit',
         description: 'Missing red and green payloads retransmit through an independent spine.',
         color: '#85dca7',
+        camera: {target: [0, 0.45, 0.05], distance: 9.8, yaw: 0.42, pitch: 0.46},
         pathIndex: 2,
         position: 0.51
       },
@@ -244,6 +259,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Training continues',
         description: 'The remaining healthy paths keep both conversations moving.',
         color: '#83c6ff',
+        camera: {target: [0, 0.15, 0], distance: 11.1, yaw: 0.66, pitch: 0.5},
         pathIndex: 3,
         position: 0.76
       }
@@ -263,6 +279,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Control probe',
         description: 'A blue control packet probes the repaired spine before traffic resumes.',
         color: '#69aaff',
+        camera: {target: [0, 0.95, 0.58], distance: 8.4, yaw: 0.13, pitch: 0.42},
         pathIndex: 1,
         position: 0
       },
@@ -271,6 +288,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Path confirmation',
         description: 'A cyan acknowledgment returns and confirms the entire route is healthy.',
         color: '#70eddf',
+        camera: {target: [0, 0.75, 0.48], distance: 8, yaw: 0.25, pitch: 0.44},
         pathIndex: 1,
         position: SWITCH_PROBE_DURATION / RECOVERY_CHAPTER_DURATION
       },
@@ -279,6 +297,7 @@ export const NETWORK_STORY_CHAPTERS: readonly NetworkStoryChapter[] = [
         title: 'Ordinary traffic resumes',
         description: 'Only after confirmation do alternating data packets return to the spine.',
         color: '#7de9a5',
+        camera: {target: [0, 0.3, 0], distance: 10.8, yaw: 0.56, pitch: 0.5},
         pathIndex: 1,
         position: (SWITCH_PROBE_DURATION + SWITCH_CONFIRMATION_DURATION) / RECOVERY_CHAPTER_DURATION
       }
@@ -317,6 +336,18 @@ export function getNetworkStoryBeat(
   }
 
   return currentBeat;
+}
+
+/** Resolves an authored beat-level shot while inheriting unspecified chapter framing. */
+export function makeNetworkStoryCamera(
+  chapter: NetworkStoryChapter,
+  beat: NetworkStoryBeat | null
+): NetworkStoryCamera {
+  return {
+    ...chapter.camera,
+    ...beat?.camera,
+    target: beat?.camera?.target ? [...beat.camera.target] : [...chapter.camera.target]
+  };
 }
 
 /** Returns bounded chapter and duration-weighted full-tour playback progress. */

--- a/test/examples/packet-spraying-network.node.spec.ts
+++ b/test/examples/packet-spraying-network.node.spec.ts
@@ -32,6 +32,7 @@ import {
   makeLinkPulses,
   makeLinkTraffic,
   makePackets,
+  makeNetworkFabricTelemetry,
   makeNetworkPlaneTelemetry,
   makeNetworkPathFocus,
   makeNetworkSwitchPlaneTelemetry,
@@ -532,6 +533,57 @@ test('packet-spraying telemetry reports per-plane load, failure, and recovery', 
     recoveringTelemetry.slice(1).every(plane => plane.status === 'healthy'),
     'unaffected planes continue operating normally'
   );
+  testCase.end();
+});
+
+test('packet-spraying fabric telemetry measures capacity and exceptional packet handling', testCase => {
+  const routes = makeConversationRoutes();
+  const packets = makePackets(routes);
+  const spineSwitchIndex = LEAF_POSITIONS.length + AGGREGATION_POSITIONS.length + 1;
+  const congestedSwitches = new Set([spineSwitchIndex]);
+  reroutePackets(packets, routes, congestedSwitches);
+  const congestedPaths = makeNetworkPlaneTelemetry(
+    routes,
+    packets,
+    new Set(),
+    new Set(),
+    congestedSwitches
+  );
+  const queue = makeSwitchQueuePackets(packets, spineSwitchIndex, 12, 6);
+  const congestedMetrics = makeNetworkFabricTelemetry(congestedPaths, queue, [], 12);
+
+  testCase.equal(congestedMetrics.state, 'congested');
+  testCase.equal(congestedMetrics.capacityPercent, 100, 'congestion preserves physical capacity');
+  testCase.equal(congestedMetrics.queuedPacketCount, 6, 'the visible queue is measured directly');
+
+  const failedSwitches = new Set([spineSwitchIndex]);
+  const failureEvents = makeSwitchPacketEvents({
+    packets,
+    conversationRoutes: routes,
+    scenario: 'failure',
+    startedAt: 20,
+    switchIndex: spineSwitchIndex
+  });
+  reroutePackets(packets, getHealthyConversationRoutes(routes, failedSwitches));
+  const failedPaths = makeNetworkPlaneTelemetry(
+    routes,
+    packets,
+    failedSwitches,
+    new Set(),
+    new Set()
+  );
+  const reroutingMetrics = makeNetworkFabricTelemetry(failedPaths, [], failureEvents, 20.8);
+
+  testCase.equal(reroutingMetrics.state, 'rerouting');
+  testCase.equal(reroutingMetrics.activePathCount, 3, 'one failed spine retires one path');
+  testCase.equal(reroutingMetrics.capacityPercent, 75, 'capacity reflects three surviving paths');
+  testCase.ok(reroutingMetrics.droppedPayloadCount > 0, 'in-flight loss is measured');
+  testCase.ok(reroutingMetrics.retransmissionCount > 0, 'replacement traffic is measured');
+
+  const probe = makeSwitchProbeEvent(routes, spineSwitchIndex, 30)!;
+  const probingMetrics = makeNetworkFabricTelemetry(failedPaths, [], [probe], 30.2);
+  testCase.equal(probingMetrics.state, 'probing', 'control traffic takes telemetry precedence');
+  testCase.equal(probingMetrics.controlPacketCount, 1);
   testCase.end();
 });
 

--- a/test/examples/packet-spraying-story.node.spec.ts
+++ b/test/examples/packet-spraying-story.node.spec.ts
@@ -18,6 +18,7 @@ import {
   GUIDED_STORY_SWITCH_INDEX,
   makeNetworkDynamicRangeProfile,
   makeNetworkOpticsProfile,
+  makeNetworkStoryCamera,
   makeNetworkSwitchHighlightColor,
   MAX_NETWORK_HDR_HIGHLIGHT_BOOST,
   MAX_NETWORK_OPTICS_LEVEL,
@@ -81,6 +82,10 @@ test('packet-spraying chapter timeline tracks duration-weighted guided playback'
 
 test('packet-spraying cinematic story beats explain load, failure, and confirmed recovery', testCase => {
   testCase.ok(
+    NETWORK_STORY_CHAPTERS.every(chapter => chapter.beats.every(beat => beat.camera)),
+    'every named network event has an authored camera shot'
+  );
+  testCase.ok(
     NETWORK_STORY_CHAPTERS.every(chapter =>
       chapter.beats.every(
         (beat, beatIndex) =>
@@ -120,6 +125,27 @@ test('packet-spraying cinematic story beats explain load, failure, and confirmed
     getNetworkStoryBeat(4, Number.NaN)?.id,
     'probe',
     'invalid elapsed times safely remain at the initial recovery beat'
+  );
+  testCase.end();
+});
+
+test('packet-spraying beat cameras inherit chapter framing without sharing target arrays', testCase => {
+  const chapter = NETWORK_STORY_CHAPTERS[2];
+  const beat = chapter.beats[1];
+  const chapterCamera = makeNetworkStoryCamera(chapter, null);
+  const beatCamera = makeNetworkStoryCamera(chapter, beat);
+
+  testCase.deepEqual(chapterCamera, chapter.camera, 'a chapter starts from its establishing shot');
+  testCase.equal(
+    beatCamera.distance,
+    beat.camera?.distance,
+    'a beat can tighten the camera distance'
+  );
+  testCase.deepEqual(beatCamera.target, beat.camera?.target, 'a beat can focus a network event');
+  testCase.notEqual(
+    beatCamera.target,
+    beat.camera?.target,
+    'resolved camera targets are safe to animate in place'
   );
   testCase.end();
 });


### PR DESCRIPTION
## Goals

- Finish the packet-spraying showcase with authored cinematic framing for each network event.
- Make congestion, trimming, loss, rerouting, and recovery measurable without expanding the story panel substantially.

## Changes

- Add beat-level camera shots for conversations, path spraying, congestion, failure, retransmission, probing, and restoration.
- Smoothly retarget OrbitControls as each narrated beat begins.
- Add reusable fabric telemetry for physical path capacity, queued payloads, trims, losses, retransmissions, and control probes.
- Add a single compact live telemetry line to the guided-tour panel and expose state through canvas data attributes.
- Add focused story and network regression coverage.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test-node test/examples/packet-spraying-story.node.spec.ts test/examples/packet-spraying-network.node.spec.ts`
- `yarn workspace luma.gl-examples-showcase-packet-spraying build`
- `yarn website:build`
- `(cd website && yarn build)`
- WebGPU visual verification at `?device=webgpu&orbit=0`
- WebGL visual verification at `?device=webgl&orbit=0`
- `yarn test`: node tests and 1,292 headless tests passed; the known local `arrow-layers` storage-backed WebGPU assertion failed again and is unrelated to this five-file example/test change.