### PR TITLE
feat(experimental): add GPU scan variants

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -164,8 +164,8 @@ pipelines would confuse multi-pass algorithms with `GPUComputePipeline`.
 
 ### Algorithms
 
-Algorithms provide data semantics across one or more kernels. `GPUScan` promises an exclusive
-prefix sum. `GPUCompaction` promises stable selection. `GPUMask` promises canonical boolean
+Algorithms provide data semantics across one or more kernels. `GPUScan` promises exclusive or
+inclusive prefix sums, with optional segment starts. `GPUCompaction` promises stable selection. `GPUMask` promises canonical boolean
 composition over source-aligned masks. `GPUGraphTraversal` promises bounded, cycle-safe
 reachability over stable compressed sparse adjacency. `GPUAncestorProjection` promises bounded
 nearest-visible canonical parent resolution. `GPUHierarchyLayout` promises stable scan-based
@@ -366,16 +366,17 @@ resources whose contents are never simultaneously live.
 The trace viewer displays these values. They turn an otherwise invisible compiler behavior into a
 property developers can inspect and debate.
 
-## Exclusive scan
+## Prefix scan
 
 Prefix sum, commonly called scan, is the central primitive for converting per-record decisions into
 addresses. Given values `[1, 0, 1, 1]`, an exclusive sum produces `[0, 1, 1, 2]`. Each selected
 record can use its scanned value as a unique output offset.
 
-`GPUScan` implements a hierarchical exclusive sum over packed `uint32` data. Each workgroup scans
-256 values in workgroup memory using an up-sweep and down-sweep. The last aggregate from each block
-is written to a block-sum buffer. If there is more than one block, the algorithm recursively scans
-those sums. Offset passes then propagate scanned block totals back down the hierarchy.
+`GPUScan` implements hierarchical exclusive and inclusive sums over packed `uint32` data. Optional
+nonzero segment flags restart either prefix convention. Each workgroup scans 256 values in
+workgroup memory. The last aggregate from each block is written to a block-summary buffer. If there
+is more than one block, the algorithm recursively scans those summaries. Offset passes then
+propagate scanned block totals back down the hierarchy.
 
 The algorithm accepts arbitrary lengths. Partial final workgroups load zero for out-of-range lanes
 and avoid out-of-range output writes. Non-power-of-two input lengths therefore do not need caller
@@ -389,6 +390,11 @@ new GPUScan({
 }).addToGraph(graph);
 ```
 
+An inclusive segmented scan adds `mode: 'inclusive'` and a `segmentFlags` view. Segment flags use
+the same atomic or vector topology as the input. The first logical row begins a segment; every
+later nonzero flag starts another. A segment may cross vector chunk boundaries, so chunking remains
+storage metadata rather than changing data semantics.
+
 Scratch block sums and offsets are graph transients. They participate in lifetime analysis and are
 released with the compiled graph. `GPUScan` does not allocate during encoding.
 
@@ -396,10 +402,9 @@ For matching `GraphVectorView` input and output, scan treats all chunks as one l
 while keeping every caller-visible buffer and chunk boundary intact. It scans chunks locally,
 scans their totals, and explicitly propagates the resulting carries across chunk boundaries.
 
-The first implementation intentionally supports only exclusive `uint32` addition. Inclusive scan,
-signed or floating-point sums, segmented scans, minimum/maximum operators, and user-defined
-associative operators are plausible extensions. They need explicit numerical and determinism
-contracts before becoming public.
+All variants wrap modulo 2^32. Signed or floating-point sums, minimum/maximum operators, and
+user-defined associative operators remain deferred until they have explicit numerical and
+determinism contracts.
 
 ## Stable compaction
 
@@ -982,7 +987,7 @@ schedule commitment.
 | 0 — Current foundation | Command graph, masks, hierarchy layout, graph traversal, ancestor projection, compaction, indirect drawing, picking, analysis primitives, and three working consumers | Implemented | High | Complete |
 | 1 — Hardening and observability | GPU timestamps, performance baselines, adapter capability reporting, boundary and overflow validation, memory statistics, and device-loss and resource-lifetime coverage | Implemented | High | Medium |
 | 2 — Reusable visibility workflows | Renderer-independent time-range, bounds, LOD, and selection workflows that publish stable IDs, counts, and indirect commands | Implemented | High | Medium |
-| 3 — Algorithm and table scaling | Multi-chunk coverage, segmented and inclusive scans, weighted aggregation, richer histograms, and batch-preserving algorithms | Planned | High | Large |
+| 3 — Algorithm and table scaling | Multi-chunk coverage, segmented and inclusive scans, weighted aggregation, richer histograms, and batch-preserving algorithms | In progress | High | Large |
 | 4 — Picking and texture coverage | Region picking, asynchronous staging rings, multisample resolves, swapchain imports, and external-texture contracts | Planned | Medium | Large |
 | 5 — Spatial acceleration | `GPUGridIndex` followed by `GPUBVH`, with explicit build, update, and query costs | Planned | High | Large |
 | 6 — GPUScene | A flat GPU draw database with stable identity, bounds, transforms, grouping, geometry references, and indirect command slots | Planned | High | Large |
@@ -994,10 +999,10 @@ schedule commitment.
 
 The baseline includes fixed-capacity buffer and logical-texture scheduling across compute, render,
 and copy nodes; hazard inference; imported-resource overrides; graph-owned attachments; transient
-reuse; ownership validation; and allocation statistics. Implemented algorithms cover exclusive
-scan, stable compaction, chunk-preserving boolean masks, bounded CSR traversal, nearest-visible
-parent projection, paired sort, scalar reduction, histogram counting, spatial grid binning, and
-GPU-written indirect commands.
+reuse; ownership validation; and allocation statistics. Implemented algorithms cover exclusive,
+inclusive, and segmented scans; stable compaction; chunk-preserving boolean masks; bounded CSR
+traversal; nearest-visible parent projection; paired sort; scalar reduction; histogram counting;
+spatial grid binning; and GPU-written indirect commands.
 
 `GPUIndexPickingTarget` provides single-pixel integer object and batch picking. The hierarchical
 trace viewer adds GPU-scanned process/thread layout, source and topology filtering, dependency
@@ -1056,13 +1061,21 @@ flowing directly into indirect rendering.
 
 ### Phase 3 — Algorithm and table scaling
 
+**Status:** In progress. Inclusive and segmented `uint32` scans are implemented.
+
 **Entry dependencies:** Phase 2 provides real workflow demand for each added variant.
 
-Extend multi-chunk support to algorithms that still require one packed view. Add inclusive and
-segmented scans, weighted and floating-point grid aggregates, irregular-edge and categorical
-histograms, and batch-aware operations that preserve table structure. Custom associative scans,
-sparse histograms, and multidimensional histograms should be added only with a concrete consumer
-and an explicit numerical or memory contract.
+`GPUScan` now supports inclusive output and nonzero segment-start flags for both atomic data views
+and chunk-preserving vectors. Segments continue across chunk boundaries, hierarchical summaries
+preserve carry-in values when a later row starts a segment, and all arithmetic retains the
+documented modulo-2^32 behavior. The data-analysis example uses inclusive scan for a histogram CDF
+and a segmented inclusive scan for per-row spatial-grid prefixes.
+
+Remaining work extends multi-chunk support to algorithms that still require one packed view, then
+adds weighted and floating-point grid aggregates, irregular-edge and categorical histograms, and
+batch-aware operations that preserve table structure. Custom associative scans, sparse histograms,
+and multidimensional histograms should be added only with a concrete consumer and an explicit
+numerical or memory contract.
 
 **Exit criteria:** Each new variant has a deterministic CPU oracle, empty and boundary coverage,
 multi-chunk tests where applicable, explicit overflow and floating-point behavior, and at least one

--- a/docs/api-reference/experimental/gpu-primitives/gpu-scan.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-scan.md
@@ -4,7 +4,8 @@ import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-do
 
 <GPUPrimitivesDocsTabs active="scan" />
 
-`GPUScan` adds a hierarchical exclusive `uint32` prefix sum to a `GPUCommandGraph`.
+`GPUScan` adds a hierarchical `uint32` prefix sum to a `GPUCommandGraph`. Scans are exclusive by
+default and may be inclusive, segmented, or both.
 
 ```ts
 new GPUScan({
@@ -14,20 +15,43 @@ new GPUScan({
 }).addToGraph(graph);
 ```
 
+Set `mode: 'inclusive'` when each output should include its corresponding input value. Supply
+`segmentFlags` to reset the prefix at every nonzero flag:
+
+```ts
+new GPUScan({
+  id: 'cumulative-counts-by-group',
+  input: counts,
+  output: cumulativeCounts,
+  mode: 'inclusive',
+  segmentFlags: groupStarts
+}).addToGraph(graph);
+```
+
 `input` and `output` may both be packed, four-byte-aligned `GraphDataView<'uint32'>` values or both
 be `GraphVectorView<'uint32'>` values. A data-view output must contain at least as many rows as its
 input. Vector input and output must have identical ordered chunk lengths.
+
+`segmentFlags`, when supplied, must use the same view kind as `input` and must not share an
+underlying graph buffer with `output`. An atomic flags view must contain at least as many rows as
+the input; vector flags must have identical ordered chunk lengths. The first logical row begins a
+segment even if its flag is zero. Every later nonzero flag begins a new segment. Segments continue
+across vector chunk boundaries unless the first row in a later chunk is flagged.
 
 Scan treats chunked vectors as one logical sequence, while all caller-visible buffers and chunk
 boundaries remain intact. It scans each chunk locally, scans the ordered chunk totals, and adds the
 resulting carry to each original output chunk. Empty chunks retain their place in that sequence.
 
-For input `[1, 0, 1, 1]`, the output is `[0, 1, 1, 2]`.
+For input `[1, 0, 1, 1]`, exclusive output is `[0, 1, 1, 2]` and inclusive output is
+`[1, 1, 2, 3]`. With segment flags `[1, 0, 1, 0]`, those outputs become `[0, 1, 0, 1]` and
+`[1, 1, 1, 2]` respectively.
 
 The implementation scans 256 values per workgroup, recursively scans block sums, and propagates
-block offsets back to lower levels. Vector scans add transient chunk-total and carry buffers; they
-never concatenate or repack caller data. All scratch allocations participate in graph lifetime
-reuse. Arbitrary non-power-of-two lengths are supported. A zero-length scan adds no nodes.
+block offsets back to lower levels. Segmented scans propagate associative `(sum, segment)`
+summaries between workgroups and only apply a carry before the first local segment start. Vector
+scans add transient chunk-summary and carry buffers; they never concatenate or repack caller data.
+All scratch allocations participate in graph lifetime reuse. Arbitrary non-power-of-two lengths
+are supported. A zero-length scan adds no nodes.
 
-The experimental implementation supports only exclusive `uint32` addition. Inclusive, segmented,
-floating-point, and custom associative scans are future work.
+All arithmetic wraps modulo 2^32. Signed, floating-point, minimum/maximum, and custom associative
+scans remain future work.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-scan.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-scan.md
@@ -7,6 +7,28 @@ import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-do
 `GPUScan` adds a hierarchical `uint32` prefix sum to a `GPUCommandGraph`. Scans are exclusive by
 default and may be inclusive, segmented, or both.
 
+## Concepts
+
+A prefix sum turns a sequence into running totals. Whether the current value participates in its
+own total distinguishes the two modes:
+
+| Mode | Input `[3, 1, 4, 2]` produces | Typical uses |
+| --- | --- | --- |
+| Exclusive | `[0, 3, 4, 8]` | Output offsets, stream compaction, variable-size allocation |
+| Inclusive | `[3, 4, 8, 10]` | Cumulative distributions, running counts, cumulative sizes |
+
+A segmented scan restarts that running total within one input. For segment-start flags
+`[1, 0, 1, 0]`, the same input produces exclusive output `[0, 3, 0, 4]` or inclusive output
+`[3, 4, 4, 6]`. This is useful for grouped table rows, per-path geometry, per-level layout, and
+other adjacent records that need independent prefixes without separate dispatches.
+
+“Hierarchical” describes how the implementation scales, not another output mode. Each workgroup
+scans a block, higher levels scan the block summaries, and offset passes propagate those totals
+back down. Callers see one logical result even when the input spans many workgroups or vector
+chunks.
+
+## Usage
+
 ```ts
 new GPUScan({
   id: 'selection-offsets',

--- a/examples/experimental/gpu-data-analysis/src/app.ts
+++ b/examples/experimental/gpu-data-analysis/src/app.ts
@@ -9,6 +9,7 @@ import {
   GPUGridBinning,
   GPUHistogram,
   GPUReduction,
+  GPUScan,
   type CompiledGPUCommandGraph
 } from '@luma.gl/experimental';
 import type {GPUVector} from '@luma.gl/tables';
@@ -126,9 +127,26 @@ class GPUDataAnalysisExample {
       });
       const extentBuffer = makeOutputBuffer(this.device, 'extent', 2);
       const histogramBuffer = makeOutputBuffer(this.device, 'histogram', binCount);
-      const totalBuffer = makeOutputBuffer(this.device, 'histogram-total', 1);
+      const cumulativeHistogramBuffer = makeOutputBuffer(
+        this.device,
+        'cumulative-histogram',
+        binCount
+      );
       const gridBuffer = makeOutputBuffer(this.device, 'grid', gridWidth * gridWidth);
-      const outputs = [extentBuffer, histogramBuffer, totalBuffer, gridBuffer];
+      const gridSegmentFlagsBuffer = makeGridSegmentFlagsBuffer(this.device, gridWidth);
+      const cumulativeGridBuffer = makeOutputBuffer(
+        this.device,
+        'cumulative-grid-rows',
+        gridWidth * gridWidth
+      );
+      const outputs = [
+        extentBuffer,
+        histogramBuffer,
+        cumulativeHistogramBuffer,
+        gridBuffer,
+        gridSegmentFlagsBuffer,
+        cumulativeGridBuffer
+      ];
       const graph = new GPUCommandGraph(this.device, {id: 'gpu-data-analysis-example'});
       const valuesImport = graph.importGPUVector('values', gpuValues);
       const positionsImport = graph.importGPUVector('positions', gpuPositions);
@@ -144,8 +162,28 @@ class GPUDataAnalysisExample {
       }
       const extent = importOutput(graph, extentBuffer, 'extent', 'float32', 2);
       const histogram = importOutput(graph, histogramBuffer, 'histogram', 'uint32', binCount);
-      const total = importOutput(graph, totalBuffer, 'total', 'uint32', 1);
+      const cumulativeHistogram = importOutput(
+        graph,
+        cumulativeHistogramBuffer,
+        'cumulative-histogram',
+        'uint32',
+        binCount
+      );
       const grid = importOutput(graph, gridBuffer, 'grid', 'uint32', gridWidth * gridWidth);
+      const gridSegmentFlags = importOutput(
+        graph,
+        gridSegmentFlagsBuffer,
+        'grid-segment-flags',
+        'uint32',
+        gridWidth * gridWidth
+      );
+      const cumulativeGrid = importOutput(
+        graph,
+        cumulativeGridBuffer,
+        'cumulative-grid-rows',
+        'uint32',
+        gridWidth * gridWidth
+      );
       new GPUReduction({
         id: 'extent',
         input: valuesView,
@@ -158,11 +196,11 @@ class GPUDataAnalysisExample {
         output: histogram,
         domain: extent
       }).addToGraph(graph);
-      new GPUReduction({
-        id: 'histogram-total',
+      new GPUScan({
+        id: 'cumulative-histogram',
         input: histogram,
-        output: total,
-        operation: 'sum'
+        output: cumulativeHistogram,
+        mode: 'inclusive'
       }).addToGraph(graph);
       new GPUGridBinning({
         id: 'grid',
@@ -170,6 +208,13 @@ class GPUDataAnalysisExample {
         output: grid,
         gridSize: [gridWidth, gridWidth],
         bounds: [-1, -1, 1, 1]
+      }).addToGraph(graph);
+      new GPUScan({
+        id: 'cumulative-grid-rows',
+        input: grid,
+        output: cumulativeGrid,
+        mode: 'inclusive',
+        segmentFlags: gridSegmentFlags
       }).addToGraph(graph);
       const compileStart = performance.now();
       const compiled = graph.compile();
@@ -180,16 +225,42 @@ class GPUDataAnalysisExample {
       compiled.encode(commandEncoder, {parameters: undefined});
       compiled.encode(commandEncoder, {parameters: undefined});
       this.device.submit(commandEncoder.finish());
-      const [extentBytes, histogramBytes, totalBytes, gridBytes] = await Promise.all(
-        outputs.map(buffer => buffer.readAsync())
+      const [
+        extentBytes,
+        histogramBytes,
+        cumulativeHistogramBytes,
+        gridBytes,
+        cumulativeGridBytes
+      ] = await Promise.all(
+        [
+          extentBuffer,
+          histogramBuffer,
+          cumulativeHistogramBuffer,
+          gridBuffer,
+          cumulativeGridBuffer
+        ].map(buffer => buffer.readAsync())
       );
       const gpuExtent = Array.from(new Float32Array(extentBytes.buffer, extentBytes.byteOffset, 2));
       const gpuHistogram = Array.from(
         new Uint32Array(histogramBytes.buffer, histogramBytes.byteOffset, binCount)
       );
-      const gpuTotal = new Uint32Array(totalBytes.buffer, totalBytes.byteOffset, 1)[0];
+      const gpuCumulativeHistogram = Array.from(
+        new Uint32Array(
+          cumulativeHistogramBytes.buffer,
+          cumulativeHistogramBytes.byteOffset,
+          binCount
+        )
+      );
+      const gpuTotal = gpuCumulativeHistogram.at(-1) ?? 0;
       const gpuGrid = Array.from(
         new Uint32Array(gridBytes.buffer, gridBytes.byteOffset, gridWidth * gridWidth)
+      );
+      const gpuCumulativeGrid = Array.from(
+        new Uint32Array(
+          cumulativeGridBytes.buffer,
+          cumulativeGridBytes.byteOffset,
+          gridWidth * gridWidth
+        )
       );
       if (this.destroyed || version !== this.runVersion) {
         destroyResources(nextResources);
@@ -199,7 +270,11 @@ class GPUDataAnalysisExample {
       const valid =
         gpuExtent.every((value, index) => Math.abs(value - reference.extent[index]) < 1e-5) &&
         gpuHistogram.every((value, index) => value === reference.histogram[index]) &&
+        gpuCumulativeHistogram.every(
+          (value, index) => value === reference.cumulativeHistogram[index]
+        ) &&
         gpuGrid.every((value, index) => value === reference.grid[index]) &&
+        gpuCumulativeGrid.every((value, index) => value === reference.cumulativeGrid[index]) &&
         gpuTotal === length;
       this.releaseResources();
       this.resources = nextResources;
@@ -211,8 +286,8 @@ class GPUDataAnalysisExample {
         ? `${gpuTotal.toLocaleString()} rows verified after two encodings`
         : 'GPU/CPU mismatch';
       this.elements.validation.dataset.state = valid ? 'ok' : 'error';
-      renderHistogram(this.elements.histogram, gpuHistogram);
-      renderGrid(this.elements.heatmap, gpuGrid, gridWidth);
+      renderHistogram(this.elements.histogram, gpuHistogram, gpuCumulativeHistogram);
+      renderGrid(this.elements.heatmap, gpuGrid, gpuCumulativeGrid, gridWidth);
       this.setStatus(
         `Extent [${gpuExtent.map(value => value.toFixed(3)).join(', ')}] · ${binCount} bins · ${gridWidth}×${gridWidth} cells`
       );
@@ -258,7 +333,13 @@ function analyzeOnCPU(
   positions: Float32Array,
   binCount: number,
   gridWidth: number
-): {extent: [number, number]; histogram: number[]; grid: number[]} {
+): {
+  extent: [number, number];
+  histogram: number[];
+  cumulativeHistogram: number[];
+  grid: number[];
+  cumulativeGrid: number[];
+} {
   let minimum = Number.POSITIVE_INFINITY;
   let maximum = Number.NEGATIVE_INFINITY;
   for (const value of values) {
@@ -271,6 +352,8 @@ function analyzeOnCPU(
       value === maximum ? binCount - 1 : getFloat32Coordinate(value, minimum, maximum, binCount);
     histogram[bin]++;
   }
+  let histogramPrefix = 0;
+  const cumulativeHistogram = histogram.map(count => (histogramPrefix += count));
   const grid = Array.from({length: gridWidth * gridWidth}, () => 0);
   for (let index = 0; index < values.length; index++) {
     const x = positions[index * 2];
@@ -279,7 +362,13 @@ function analyzeOnCPU(
     const row = getFloat32Coordinate(y, -1, 1, gridWidth);
     grid[row * gridWidth + column]++;
   }
-  return {extent: [minimum, maximum], histogram, grid};
+  let gridPrefix = 0;
+  const cumulativeGrid = grid.map((count, index) => {
+    if (index % gridWidth === 0) gridPrefix = 0;
+    gridPrefix += count;
+    return gridPrefix;
+  });
+  return {extent: [minimum, maximum], histogram, cumulativeHistogram, grid, cumulativeGrid};
 }
 
 function getFloat32Coordinate(
@@ -303,6 +392,16 @@ function makeOutputBuffer(device: Device, id: string, length: number): Buffer {
   });
 }
 
+function makeGridSegmentFlagsBuffer(device: Device, gridWidth: number): Buffer {
+  return device.createBuffer({
+    id: 'grid-segment-flags',
+    data: Uint32Array.from({length: gridWidth * gridWidth}, (_, index) =>
+      Number(index % gridWidth === 0)
+    ),
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+}
+
 function importOutput<T extends 'float32' | 'uint32'>(
   graph: GPUCommandGraph,
   buffer: Buffer,
@@ -317,20 +416,29 @@ function importOutput<T extends 'float32' | 'uint32'>(
   return graph.createDataView(handle, {format, length});
 }
 
-function renderHistogram(element: HTMLElement, counts: number[]): void {
+function renderHistogram(element: HTMLElement, counts: number[], cumulativeCounts: number[]): void {
   const maximum = Math.max(...counts, 1);
   element.innerHTML = counts
     .map(
-      count => `<i style="height:${Math.max(2, (count / maximum) * 100)}%" title="${count}"></i>`
+      (count, index) =>
+        `<i style="height:${Math.max(2, (count / maximum) * 100)}%" title="${count} rows · ${cumulativeCounts[index]} cumulative"></i>`
     )
     .join('');
 }
 
-function renderGrid(element: HTMLElement, counts: number[], width: number): void {
+function renderGrid(
+  element: HTMLElement,
+  counts: number[],
+  cumulativeCounts: number[],
+  width: number
+): void {
   const maximum = Math.max(...counts, 1);
   element.style.gridTemplateColumns = `repeat(${width},1fr)`;
   element.innerHTML = counts
-    .map(count => `<i style="opacity:${0.08 + (count / maximum) * 0.92}" title="${count}"></i>`)
+    .map(
+      (count, index) =>
+        `<i style="opacity:${0.08 + (count / maximum) * 0.92}" title="${count} rows · ${cumulativeCounts[index]} row cumulative"></i>`
+    )
     .join('');
 }
 
@@ -375,6 +483,6 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-const EXAMPLE_HTML = `<main class="analysis-example"><header><p>EXPERIMENTAL · WEBGPU</p><h1>Command-graph data analysis</h1><span>Extent → histogram → count reduction, composed with spatial grid binning.</span></header><section class="controls"><label>Dataset<select data-dataset><option value="small">4K rows</option><option value="medium" selected>65K rows</option><option value="large">262K rows</option></select></label><label>Histogram bins<select data-bins><option>16</option><option selected>64</option><option>300</option></select></label><label>Grid<select data-grid><option>8</option><option selected>16</option><option>17</option></select></label><button data-run>Run graph</button></section><p class="status" data-status></p><section class="metrics"><article><span>Nodes</span><strong data-nodes>—</strong></article><article><span>Compile</span><strong data-compile-time>—</strong></article><article><span>Transient reuse</span><strong data-reuse>—</strong></article><article><span>Validation</span><strong data-validation>—</strong></article></section><section class="visuals"><article><h2>Histogram</h2><div class="histogram" data-histogram></div></article><article><h2>Grid heatmap</h2><div class="heatmap" data-heatmap></div></article></section></main>`;
+const EXAMPLE_HTML = `<main class="analysis-example"><header><p>EXPERIMENTAL · WEBGPU</p><h1>Command-graph data analysis</h1><span>Extent → histogram → inclusive CDF, composed with spatial bins and segmented row prefixes.</span></header><section class="controls"><label>Dataset<select data-dataset><option value="small">4K rows</option><option value="medium" selected>65K rows</option><option value="large">262K rows</option></select></label><label>Histogram bins<select data-bins><option>16</option><option selected>64</option><option>300</option></select></label><label>Grid<select data-grid><option>8</option><option selected>16</option><option>17</option></select></label><button data-run>Run graph</button></section><p class="status" data-status></p><section class="metrics"><article><span>Nodes</span><strong data-nodes>—</strong></article><article><span>Compile</span><strong data-compile-time>—</strong></article><article><span>Transient reuse</span><strong data-reuse>—</strong></article><article><span>Validation</span><strong data-validation>—</strong></article></section><section class="visuals"><article><h2>Histogram</h2><div class="histogram" data-histogram></div></article><article><h2>Grid heatmap</h2><div class="heatmap" data-heatmap></div></article></section></main>`;
 
 const STYLES = `.analysis-example{min-height:100%;box-sizing:border-box;padding:30px;color:#172033;background:radial-gradient(circle at 90% 0,#d9f4ea,transparent 35%),#f6f8fb;font-family:Inter,ui-sans-serif,system-ui}.analysis-example *{box-sizing:border-box}.analysis-example>header,.analysis-example>section,.analysis-example>.status{max-width:1120px;margin-left:auto;margin-right:auto}.analysis-example header p{margin:0;color:#08745b;font-size:12px;font-weight:800;letter-spacing:.13em}.analysis-example h1{margin:5px 0;font-size:clamp(30px,5vw,52px);letter-spacing:-.04em}.analysis-example header span{color:#5d687b}.controls{display:flex;flex-wrap:wrap;gap:12px;align-items:end;margin-top:24px;padding:16px;border:1px solid #ccd6df;border-radius:15px;background:#fff}.controls label{display:grid;gap:5px;color:#596579;font-size:12px;font-weight:700}.controls select,.controls button{height:40px;padding:0 12px;border:1px solid #aebdcc;border-radius:8px;background:#fff;color:#172033}.controls button{background:#08745b;color:#fff;border-color:#08745b;font-weight:700}.status{padding:10px 2px;color:#596579}.status[data-state=error],[data-validation][data-state=error]{color:#b42318}.metrics{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}.metrics article,.visuals article{padding:16px;border:1px solid #d5dde6;border-radius:14px;background:#fff;box-shadow:0 10px 30px #25324a0a}.metrics span{display:block;color:#667085;font-size:12px}.metrics strong{display:block;margin-top:7px;font-size:18px}.visuals{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px}.visuals h2{margin:0 0 12px;font-size:16px}.histogram{height:250px;display:flex;align-items:end;gap:2px;border-bottom:1px solid #b8c3cf}.histogram i{display:block;flex:1;min-width:1px;background:#2da98a;border-radius:2px 2px 0 0}.heatmap{height:250px;aspect-ratio:1;display:grid;gap:1px;margin:auto;background:#e8edf1}.heatmap i{display:block;background:#315cc5}@media(max-width:760px){.analysis-example{padding:18px}.metrics{grid-template-columns:1fr 1fr}.visuals{grid-template-columns:1fr}}`;

--- a/modules/experimental/src/gpu-primitives/gpu-scan.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-scan.ts
@@ -18,9 +18,6 @@ const SCAN_WORKGROUP_SIZE = 256;
 /** Packed uint32 graph data accepted by {@link GPUScan}. */
 export type GPUScanInput = GraphDataView<'uint32'> | GraphVectorView<'uint32'>;
 
-/** Whether each output row excludes or includes its corresponding input row. */
-export type GPUScanMode = 'exclusive' | 'inclusive';
-
 /** Properties for one graph-native prefix sum. */
 export type GPUScanProps = {
   /** Prefix for generated graph node and transient resource IDs. */
@@ -30,7 +27,7 @@ export type GPUScanProps = {
   /** Caller-owned destination with matching view kind and sufficient capacity or topology. */
   output: GPUScanInput;
   /** Prefix convention. Defaults to `exclusive`. */
-  mode?: GPUScanMode;
+  mode?: 'exclusive' | 'inclusive';
   /** Optional nonzero flags that start new segments. Row zero is always a segment start. */
   segmentFlags?: GPUScanInput;
 };
@@ -51,7 +48,7 @@ export class GPUScan {
   /** Caller-owned prefix destination with matching view kind. */
   readonly output: GPUScanInput;
   /** Whether output rows exclude or include their corresponding input rows. */
-  readonly mode: GPUScanMode;
+  readonly mode: 'exclusive' | 'inclusive';
   /** Optional nonzero flags that start new segments. */
   readonly segmentFlags?: GPUScanInput;
 
@@ -127,7 +124,7 @@ function addChunkedScan<Parameters>(
     id: string;
     input: GPUScanInput;
     output: GPUScanInput;
-    mode: GPUScanMode;
+    mode: 'exclusive' | 'inclusive';
     segmentFlags?: GPUScanInput;
   }
 ): void {
@@ -183,7 +180,7 @@ function addChunkedScan<Parameters>(
         )
       )
     : undefined;
-  nonEmptyChunks.forEach((chunk, partialIndex) => {
+  for (const [partialIndex, chunk] of nonEmptyChunks.entries()) {
     addScanLevels(graph, {
       id: `${props.id}-chunk-${chunk.chunkIndex}`,
       input: chunk.input,
@@ -196,7 +193,7 @@ function addChunkedScan<Parameters>(
         ? createPackedSubview(graph, chunkSegmentFlags, partialIndex)
         : undefined
     });
-  });
+  }
   addScanLevels(graph, {
     id: `${props.id}-chunk-carries`,
     input: chunkTotals,
@@ -205,7 +202,7 @@ function addChunkedScan<Parameters>(
     segmentFlags: chunkSegmentFlags,
     segmentSummaryInput: Boolean(chunkSegmentFlags)
   });
-  nonEmptyChunks.forEach((chunk, partialIndex) => {
+  for (const [partialIndex, chunk] of nonEmptyChunks.entries()) {
     addOffsetPass(graph, {
       id: `${props.id}-chunk-${chunk.chunkIndex}-add-carry`,
       output: chunk.output,
@@ -214,7 +211,7 @@ function addChunkedScan<Parameters>(
       offsetIndex: partialIndex,
       segmentPrefixes: chunkSegmentPrefixes?.[partialIndex]
     });
-  });
+  }
 }
 
 /** Adds every hierarchical level required to scan one non-empty packed data view. */
@@ -224,7 +221,7 @@ function addScanLevels<Parameters>(
     id: string;
     input: GraphDataView<'uint32'>;
     output: GraphDataView<'uint32'>;
-    mode: GPUScanMode;
+    mode: 'exclusive' | 'inclusive';
     segmentFlags?: GraphDataView<'uint32'>;
     outputSegmentPrefixes?: GraphDataView<'uint32'>;
     finalSum?: GraphDataView<'uint32'>;
@@ -272,7 +269,7 @@ function addScanLevels<Parameters>(
     const segmentPrefixes = levelSegmentFlags
       ? levelIndex === 0 && props.outputSegmentPrefixes
         ? props.outputSegmentPrefixes
-        : blockCount > 1
+        : blockCount > 1 || levelIndex > 0
           ? createTransientView(
               graph,
               `${props.id}-level-${levelIndex}-segment-prefixes`,
@@ -319,12 +316,14 @@ function addScanLevels<Parameters>(
 
   for (let index = levels.length - 2; index >= 0; index--) {
     const level = levels[index];
+    const parentLevel = levels[index + 1];
     addOffsetPass(graph, {
       id: `${props.id}-level-${index}-add-offsets`,
       output: level.output,
       offsets: level.blockOffsets!,
       length: level.length,
-      segmentPrefixes: level.segmentPrefixes
+      segmentPrefixes: level.segmentPrefixes,
+      offsetSegmentPrefixes: parentLevel.segmentPrefixes
     });
   }
 }
@@ -374,7 +373,7 @@ function addBlockScanPass<Parameters>(
     id: string;
     input: GraphDataView<'uint32'>;
     output: GraphDataView<'uint32'>;
-    mode: GPUScanMode;
+    mode: 'exclusive' | 'inclusive';
     segmentFlags?: GraphDataView<'uint32'>;
     /** Preserve carry into the current summary even when that summary contains a later start. */
     segmentSummaryInput?: boolean;
@@ -574,6 +573,7 @@ function addOffsetPass<Parameters>(
     length: number;
     offsetIndex?: number;
     segmentPrefixes?: GraphDataView<'uint32'>;
+    offsetSegmentPrefixes?: GraphDataView<'uint32'>;
   }
 ): void {
   const offsetIndex =
@@ -583,18 +583,27 @@ const ELEMENT_COUNT: u32 = ${props.length}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
 const OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.offsets)}u;
 ${props.segmentPrefixes ? `const SEGMENT_PREFIXES_OFFSET: u32 = ${getViewElementOffset(props.segmentPrefixes)}u;` : ''}
+${props.offsetSegmentPrefixes ? `const OFFSET_SEGMENT_PREFIXES_OFFSET: u32 = ${getViewElementOffset(props.offsetSegmentPrefixes)}u;` : ''}
 @group(0) @binding(0) var<storage, read_write> outputValues: array<u32>;
 @group(0) @binding(1) var<storage, read> offsets: array<u32>;
-${props.segmentPrefixes ? '@group(0) @binding(2) var<storage, read> segmentPrefixes: array<u32>;' : ''}
+${props.segmentPrefixes ? `@group(0) @binding(2) var<storage, ${props.offsetSegmentPrefixes ? 'read_write' : 'read'}> segmentPrefixes: array<u32>;` : ''}
+${props.offsetSegmentPrefixes ? '@group(0) @binding(3) var<storage, read> offsetSegmentPrefixes: array<u32>;' : ''}
 
 @compute @workgroup_size(${SCAN_WORKGROUP_SIZE}) fn main(
   @builtin(global_invocation_id) globalId: vec3<u32>
 ) {
   let index = globalId.x;
   if (index < ELEMENT_COUNT) {
-    ${props.segmentPrefixes ? 'if (segmentPrefixes[SEGMENT_PREFIXES_OFFSET + index] == 0u) {' : ''}
+    ${props.offsetSegmentPrefixes ? `let offsetSegmentPrefix = offsetSegmentPrefixes[OFFSET_SEGMENT_PREFIXES_OFFSET + ${offsetIndex}];` : ''}
+    ${
+      props.segmentPrefixes
+        ? `let segmentPrefix = segmentPrefixes[SEGMENT_PREFIXES_OFFSET + index];
+    if (segmentPrefix == 0u) {`
+        : ''
+    }
       outputValues[OUTPUT_OFFSET + index] = outputValues[OUTPUT_OFFSET + index] + offsets[OFFSETS_OFFSET + ${offsetIndex}];
     ${props.segmentPrefixes ? '}' : ''}
+    ${props.segmentPrefixes && props.offsetSegmentPrefixes ? 'segmentPrefixes[SEGMENT_PREFIXES_OFFSET + index] = segmentPrefix | offsetSegmentPrefix;' : ''}
   }
 }`;
   graph.addComputePass({
@@ -603,7 +612,15 @@ ${props.segmentPrefixes ? '@group(0) @binding(2) var<storage, read> segmentPrefi
       {buffer: props.output, usage: 'storage-read-write'},
       {buffer: props.offsets, usage: 'storage-read'},
       ...(props.segmentPrefixes
-        ? [{buffer: props.segmentPrefixes, usage: 'storage-read'} as const]
+        ? [
+            {
+              buffer: props.segmentPrefixes,
+              usage: props.offsetSegmentPrefixes ? 'storage-read-write' : 'storage-read'
+            } as const
+          ]
+        : []),
+      ...(props.offsetSegmentPrefixes
+        ? [{buffer: props.offsetSegmentPrefixes, usage: 'storage-read'} as const]
         : [])
     ],
     compile: ({device}) => {
@@ -616,6 +633,16 @@ ${props.segmentPrefixes ? '@group(0) @binding(2) var<storage, read> segmentPrefi
             {name: 'offsets', type: 'storage', group: 0, location: 1},
             ...(props.segmentPrefixes
               ? [{name: 'segmentPrefixes', type: 'storage' as const, group: 0, location: 2}]
+              : []),
+            ...(props.offsetSegmentPrefixes
+              ? [
+                  {
+                    name: 'offsetSegmentPrefixes',
+                    type: 'storage' as const,
+                    group: 0,
+                    location: 3
+                  }
+                ]
               : [])
           ]
         }
@@ -628,6 +655,12 @@ ${props.segmentPrefixes ? '@group(0) @binding(2) var<storage, read> segmentPrefi
           };
           if (props.segmentPrefixes) {
             bindings['segmentPrefixes'] = getViewBinding(props.segmentPrefixes, getBuffer);
+          }
+          if (props.offsetSegmentPrefixes) {
+            bindings['offsetSegmentPrefixes'] = getViewBinding(
+              props.offsetSegmentPrefixes,
+              getBuffer
+            );
           }
           computation.setBindings(bindings);
           computation.dispatch(computePass, Math.ceil(props.length / SCAN_WORKGROUP_SIZE));

--- a/modules/experimental/src/gpu-primitives/gpu-scan.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-scan.ts
@@ -18,7 +18,10 @@ const SCAN_WORKGROUP_SIZE = 256;
 /** Packed uint32 graph data accepted by {@link GPUScan}. */
 export type GPUScanInput = GraphDataView<'uint32'> | GraphVectorView<'uint32'>;
 
-/** Properties for one graph-native exclusive prefix sum. */
+/** Whether each output row excludes or includes its corresponding input row. */
+export type GPUScanMode = 'exclusive' | 'inclusive';
+
+/** Properties for one graph-native prefix sum. */
 export type GPUScanProps = {
   /** Prefix for generated graph node and transient resource IDs. */
   id?: string;
@@ -26,26 +29,34 @@ export type GPUScanProps = {
   input: GPUScanInput;
   /** Caller-owned destination with matching view kind and sufficient capacity or topology. */
   output: GPUScanInput;
+  /** Prefix convention. Defaults to `exclusive`. */
+  mode?: GPUScanMode;
+  /** Optional nonzero flags that start new segments. Row zero is always a segment start. */
+  segmentFlags?: GPUScanInput;
 };
 
 /**
- * Hierarchical exclusive prefix sum over packed `uint32` graph data.
+ * Hierarchical prefix sum over packed `uint32` graph data.
  *
- * Each 256-thread block writes local exclusive offsets and, when necessary, one block sum. Higher
- * levels scan those block sums before reverse-order offset passes add the parent offsets back into
- * every lower level. Vector inputs are one logical sequence whose carries cross chunk boundaries
- * without changing caller-visible topology. Arithmetic wraps modulo 2^32.
+ * Each 256-thread block writes local prefixes and, when necessary, one block summary. Higher
+ * levels scan those summaries before reverse-order offset passes add parent offsets back into every
+ * lower level. Optional nonzero flags restart the prefix without treating vector chunks as segment
+ * boundaries. Arithmetic wraps modulo 2^32.
  */
 export class GPUScan {
   /** Prefix for generated graph node and transient resource IDs. */
   readonly id: string;
   /** Packed unsigned source data or ordered source vector. */
   readonly input: GPUScanInput;
-  /** Caller-owned exclusive-prefix destination with matching view kind. */
+  /** Caller-owned prefix destination with matching view kind. */
   readonly output: GPUScanInput;
+  /** Whether output rows exclude or include their corresponding input rows. */
+  readonly mode: GPUScanMode;
+  /** Optional nonzero flags that start new segments. */
+  readonly segmentFlags?: GPUScanInput;
 
   /**
-   * Creates and validates an exclusive scan description.
+   * Creates and validates a scan description.
    *
    * @throws If either view is not packed `uint32` data or the output is shorter than the input.
    */
@@ -53,6 +64,8 @@ export class GPUScan {
     this.id = props.id ?? 'gpu-scan';
     this.input = props.input;
     this.output = props.output;
+    this.mode = props.mode ?? 'exclusive';
+    this.segmentFlags = props.segmentFlags;
     validateScanInput(this.input, `${this.id} input`);
     validateScanInput(this.output, `${this.id} output`);
     const inputIsVector = this.input instanceof GraphVectorView;
@@ -65,6 +78,24 @@ export class GPUScan {
     } else if (this.output.length < this.input.length) {
       throw new Error(`${this.id} output must contain at least input.length rows`);
     }
+    if (this.segmentFlags) {
+      validateScanInput(this.segmentFlags, `${this.id} segmentFlags`);
+      const flagsAreVector = this.segmentFlags instanceof GraphVectorView;
+      if (inputIsVector !== flagsAreVector) {
+        throw new Error(
+          `${this.id} input and segmentFlags must both be data views or vector views`
+        );
+      }
+      if (this.input instanceof GraphVectorView && this.segmentFlags instanceof GraphVectorView) {
+        validateMatchingVectorTopology(this.input, this.segmentFlags, `${this.id} segmentFlags`);
+      } else if (this.segmentFlags.length < this.input.length) {
+        throw new Error(`${this.id} segmentFlags must contain at least input.length rows`);
+      }
+      const outputBuffers = new Set(getScanChunks(this.output).map(chunk => chunk.buffer));
+      if (getScanChunks(this.segmentFlags).some(chunk => outputBuffers.has(chunk.buffer))) {
+        throw new Error(`${this.id} segmentFlags and output must use separate buffers`);
+      }
+    }
   }
 
   /**
@@ -76,70 +107,112 @@ export class GPUScan {
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
     validateScanOwnership(graph, this.input, this.id);
     validateScanOwnership(graph, this.output, this.id);
-    addChunkedScan(graph, this.id, this.input, this.output);
+    if (this.segmentFlags) {
+      validateScanOwnership(graph, this.segmentFlags, this.id);
+    }
+    addChunkedScan(graph, {
+      id: this.id,
+      input: this.input,
+      output: this.output,
+      mode: this.mode,
+      segmentFlags: this.segmentFlags
+    });
   }
 }
 
 /** Normalizes atomic and vector inputs and adds the required local scans and vector carries. */
 function addChunkedScan<Parameters>(
   graph: GPUCommandGraph<Parameters>,
-  id: string,
-  input: GPUScanInput,
-  output: GPUScanInput
+  props: {
+    id: string;
+    input: GPUScanInput;
+    output: GPUScanInput;
+    mode: GPUScanMode;
+    segmentFlags?: GPUScanInput;
+  }
 ): void {
-  const inputChunks = getScanChunks(input);
-  const outputChunks = getScanChunks(output);
+  const inputChunks = getScanChunks(props.input);
+  const outputChunks = getScanChunks(props.output);
+  const segmentFlagChunks = props.segmentFlags ? getScanChunks(props.segmentFlags) : undefined;
   const nonEmptyChunks = inputChunks
     .map((inputChunk, chunkIndex) => ({
       chunkIndex,
       input: inputChunk,
-      output: outputChunks[chunkIndex]
+      output: outputChunks[chunkIndex],
+      segmentFlags: segmentFlagChunks?.[chunkIndex]
     }))
     .filter(chunk => chunk.input.length > 0);
   if (nonEmptyChunks.length === 0) {
     return;
   }
-  const isVector = input instanceof GraphVectorView;
+  const isVector = props.input instanceof GraphVectorView;
   if (nonEmptyChunks.length === 1) {
     const chunk = nonEmptyChunks[0];
-    addScanLevels(
-      graph,
-      isVector ? `${id}-chunk-${chunk.chunkIndex}` : id,
-      chunk.input,
-      chunk.output
-    );
+    addScanLevels(graph, {
+      id: isVector ? `${props.id}-chunk-${chunk.chunkIndex}` : props.id,
+      input: chunk.input,
+      output: chunk.output,
+      mode: props.mode,
+      segmentFlags: chunk.segmentFlags
+    });
     return;
   }
 
   const chunkTotals = createTransientView(
     graph,
-    `${id}-chunk-totals`,
+    `${props.id}-chunk-totals`,
     'uint32',
     nonEmptyChunks.length
   );
   const chunkOffsets = createTransientView(
     graph,
-    `${id}-chunk-offsets`,
+    `${props.id}-chunk-offsets`,
     'uint32',
     nonEmptyChunks.length
   );
+  const chunkSegmentFlags = props.segmentFlags
+    ? createTransientView(graph, `${props.id}-chunk-segment-flags`, 'uint32', nonEmptyChunks.length)
+    : undefined;
+  const chunkSegmentPrefixes = props.segmentFlags
+    ? nonEmptyChunks.map(chunk =>
+        createTransientView(
+          graph,
+          `${props.id}-chunk-${chunk.chunkIndex}-segment-prefixes`,
+          'uint32',
+          chunk.input.length
+        )
+      )
+    : undefined;
   nonEmptyChunks.forEach((chunk, partialIndex) => {
-    addScanLevels(
-      graph,
-      `${id}-chunk-${chunk.chunkIndex}`,
-      chunk.input,
-      chunk.output,
-      createPackedSubview(graph, chunkTotals, partialIndex)
-    );
+    addScanLevels(graph, {
+      id: `${props.id}-chunk-${chunk.chunkIndex}`,
+      input: chunk.input,
+      output: chunk.output,
+      mode: props.mode,
+      segmentFlags: chunk.segmentFlags,
+      outputSegmentPrefixes: chunkSegmentPrefixes?.[partialIndex],
+      finalSum: createPackedSubview(graph, chunkTotals, partialIndex),
+      finalSegmentFlag: chunkSegmentFlags
+        ? createPackedSubview(graph, chunkSegmentFlags, partialIndex)
+        : undefined
+    });
   });
-  addScanLevels(graph, `${id}-chunk-carries`, chunkTotals, chunkOffsets);
+  addScanLevels(graph, {
+    id: `${props.id}-chunk-carries`,
+    input: chunkTotals,
+    output: chunkOffsets,
+    mode: 'exclusive',
+    segmentFlags: chunkSegmentFlags,
+    segmentSummaryInput: Boolean(chunkSegmentFlags)
+  });
   nonEmptyChunks.forEach((chunk, partialIndex) => {
     addOffsetPass(graph, {
-      id: `${id}-chunk-${chunk.chunkIndex}-add-carry`,
+      id: `${props.id}-chunk-${chunk.chunkIndex}-add-carry`,
       output: chunk.output,
       offsets: chunkOffsets,
       length: chunk.output.length,
-      offsetIndex: partialIndex
+      offsetIndex: partialIndex,
+      segmentPrefixes: chunkSegmentPrefixes?.[partialIndex]
     });
   });
 }
@@ -147,12 +220,20 @@ function addChunkedScan<Parameters>(
 /** Adds every hierarchical level required to scan one non-empty packed data view. */
 function addScanLevels<Parameters>(
   graph: GPUCommandGraph<Parameters>,
-  id: string,
-  input: GraphDataView<'uint32'>,
-  output: GraphDataView<'uint32'>,
-  finalSum?: GraphDataView<'uint32'>
+  props: {
+    id: string;
+    input: GraphDataView<'uint32'>;
+    output: GraphDataView<'uint32'>;
+    mode: GPUScanMode;
+    segmentFlags?: GraphDataView<'uint32'>;
+    outputSegmentPrefixes?: GraphDataView<'uint32'>;
+    finalSum?: GraphDataView<'uint32'>;
+    finalSegmentFlag?: GraphDataView<'uint32'>;
+    /** Summary flags report a start anywhere in one lower-level block, not at its first row. */
+    segmentSummaryInput?: boolean;
+  }
 ): void {
-  if (input.length === 0) {
+  if (props.input.length === 0) {
     return;
   }
 
@@ -160,47 +241,78 @@ function addScanLevels<Parameters>(
     output: GraphDataView<'uint32'>;
     length: number;
     blockOffsets?: GraphDataView<'uint32'>;
+    segmentPrefixes?: GraphDataView<'uint32'>;
   }> = [];
-  let levelInput = input;
-  let levelOutput = output;
-  let levelLength = input.length;
+  let levelInput = props.input;
+  let levelOutput = props.output;
+  let levelSegmentFlags = props.segmentFlags;
+  let levelLength = props.input.length;
   let levelIndex = 0;
 
   while (true) {
     const blockCount = Math.ceil(levelLength / SCAN_WORKGROUP_SIZE);
     let blockSums: GraphDataView<'uint32'> | undefined;
+    let blockSegmentFlags: GraphDataView<'uint32'> | undefined;
     if (blockCount > 1) {
       blockSums = createTransientView(
         graph,
-        `${id}-level-${levelIndex}-block-sums`,
+        `${props.id}-level-${levelIndex}-block-sums`,
         'uint32',
         blockCount
       );
+      if (levelSegmentFlags) {
+        blockSegmentFlags = createTransientView(
+          graph,
+          `${props.id}-level-${levelIndex}-block-segment-flags`,
+          'uint32',
+          blockCount
+        );
+      }
     }
+    const segmentPrefixes = levelSegmentFlags
+      ? levelIndex === 0 && props.outputSegmentPrefixes
+        ? props.outputSegmentPrefixes
+        : blockCount > 1
+          ? createTransientView(
+              graph,
+              `${props.id}-level-${levelIndex}-segment-prefixes`,
+              'uint32',
+              levelLength
+            )
+          : undefined
+      : undefined;
 
     addBlockScanPass(graph, {
-      id: `${id}-level-${levelIndex}-scan`,
+      id: `${props.id}-level-${levelIndex}-scan`,
       input: levelInput,
       output: levelOutput,
+      mode: levelIndex === 0 ? props.mode : 'exclusive',
+      segmentFlags: levelSegmentFlags,
+      segmentSummaryInput:
+        Boolean(levelSegmentFlags) && (levelIndex > 0 || props.segmentSummaryInput),
+      segmentPrefixes,
       blockSums,
-      finalSum: blockSums ? undefined : finalSum,
+      blockSegmentFlags,
+      finalSum: blockSums ? undefined : props.finalSum,
+      finalSegmentFlag: blockSums ? undefined : props.finalSegmentFlag,
       length: levelLength,
       blockCount
     });
-    levels.push({output: levelOutput, length: levelLength});
+    levels.push({output: levelOutput, length: levelLength, segmentPrefixes});
 
     if (!blockSums) {
       break;
     }
     const blockOffsets = createTransientView(
       graph,
-      `${id}-level-${levelIndex}-block-offsets`,
+      `${props.id}-level-${levelIndex}-block-offsets`,
       'uint32',
       blockCount
     );
     levels[levels.length - 1].blockOffsets = blockOffsets;
     levelInput = blockSums;
     levelOutput = blockOffsets;
+    levelSegmentFlags = blockSegmentFlags;
     levelLength = blockCount;
     levelIndex++;
   }
@@ -208,10 +320,11 @@ function addScanLevels<Parameters>(
   for (let index = levels.length - 2; index >= 0; index--) {
     const level = levels[index];
     addOffsetPass(graph, {
-      id: `${id}-level-${index}-add-offsets`,
+      id: `${props.id}-level-${index}-add-offsets`,
       output: level.output,
       offsets: level.blockOffsets!,
-      length: level.length
+      length: level.length,
+      segmentPrefixes: level.segmentPrefixes
     });
   }
 }
@@ -254,37 +367,94 @@ function validateScanOwnership<Parameters>(
   }
 }
 
-/** Adds one block-local exclusive scan level and optionally writes one sum per block. */
+/** Adds one block-local scan level and optionally writes one summary pair per block. */
 function addBlockScanPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   props: {
     id: string;
     input: GraphDataView<'uint32'>;
     output: GraphDataView<'uint32'>;
+    mode: GPUScanMode;
+    segmentFlags?: GraphDataView<'uint32'>;
+    /** Preserve carry into the current summary even when that summary contains a later start. */
+    segmentSummaryInput?: boolean;
+    segmentPrefixes?: GraphDataView<'uint32'>;
     blockSums?: GraphDataView<'uint32'>;
+    blockSegmentFlags?: GraphDataView<'uint32'>;
     finalSum?: GraphDataView<'uint32'>;
+    finalSegmentFlag?: GraphDataView<'uint32'>;
     length: number;
     blockCount: number;
   }
 ): void {
   const sumOutput = props.blockSums ?? props.finalSum;
+  const segmentFlagOutput = props.blockSegmentFlags ?? props.finalSegmentFlag;
   const sumBinding = sumOutput
     ? '@group(0) @binding(2) var<storage, read_write> sumValues: array<u32>;'
+    : '';
+  const segmentFlagsBinding = props.segmentFlags
+    ? '@group(0) @binding(3) var<storage, read> segmentFlags: array<u32>;'
+    : '';
+  const segmentPrefixesBinding = props.segmentPrefixes
+    ? '@group(0) @binding(4) var<storage, read_write> segmentPrefixes: array<u32>;'
+    : '';
+  const segmentFlagOutputBinding = segmentFlagOutput
+    ? '@group(0) @binding(5) var<storage, read_write> summarySegmentFlags: array<u32>;'
     : '';
   const sumWrite = props.blockSums
     ? 'sumValues[SUM_OFFSET + workgroupId.x] = scratch[255u];'
     : props.finalSum
       ? 'sumValues[SUM_OFFSET] = scratch[255u];'
       : '';
+  const segmentFlagWrite = props.blockSegmentFlags
+    ? 'summarySegmentFlags[SUMMARY_SEGMENT_FLAGS_OFFSET + workgroupId.x] = segmentScratch[255u];'
+    : props.finalSegmentFlag
+      ? 'summarySegmentFlags[SUMMARY_SEGMENT_FLAGS_OFFSET] = segmentScratch[255u];'
+      : '';
+  const inputSegmentFlag = props.segmentFlags ? 'segmentFlags[SEGMENT_FLAGS_OFFSET + index]' : '0u';
+  const scanUpdate = props.segmentFlags
+    ? `if (lane >= stride) {
+      scratch[lane] = select(addend + scratch[lane], scratch[lane], segmentScratch[lane] != 0u);
+      segmentScratch[lane] = addendSegment | segmentScratch[lane];
+    }`
+    : `if (lane >= stride) {
+      scratch[lane] = scratch[lane] + addend;
+    }`;
+  const outputValue = props.mode === 'inclusive' ? 'scratch[lane]' : 'scratch[lane] - inputValue';
+  const segmentedOutput =
+    props.segmentFlags && props.mode === 'exclusive'
+      ? `var scannedOutput = 0u;
+    if (lane > 0u) {
+      scannedOutput = scratch[lane - 1u];
+    }
+    ${props.segmentSummaryInput ? '' : 'if (inputSegmentFlag != 0u) { scannedOutput = 0u; }'}
+    outputValues[OUTPUT_OFFSET + index] = scannedOutput;`
+      : `outputValues[OUTPUT_OFFSET + index] = ${outputValue};`;
+  const segmentPrefixWrite = props.segmentPrefixes
+    ? props.segmentSummaryInput
+      ? `var segmentPrefix = 0u;
+    if (lane > 0u) {
+      segmentPrefix = segmentScratch[lane - 1u];
+    }
+    segmentPrefixes[SEGMENT_PREFIXES_OFFSET + index] = segmentPrefix;`
+      : 'segmentPrefixes[SEGMENT_PREFIXES_OFFSET + index] = segmentScratch[lane];'
+    : '';
   const source = /* wgsl */ `
 const ELEMENT_COUNT: u32 = ${props.length}u;
 const INPUT_OFFSET: u32 = ${getViewElementOffset(props.input)}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
 ${sumOutput ? `const SUM_OFFSET: u32 = ${getViewElementOffset(sumOutput)}u;` : ''}
+${props.segmentFlags ? `const SEGMENT_FLAGS_OFFSET: u32 = ${getViewElementOffset(props.segmentFlags)}u;` : ''}
+${props.segmentPrefixes ? `const SEGMENT_PREFIXES_OFFSET: u32 = ${getViewElementOffset(props.segmentPrefixes)}u;` : ''}
+${segmentFlagOutput ? `const SUMMARY_SEGMENT_FLAGS_OFFSET: u32 = ${getViewElementOffset(segmentFlagOutput)}u;` : ''}
 @group(0) @binding(0) var<storage, read> inputValues: array<u32>;
 @group(0) @binding(1) var<storage, read_write> outputValues: array<u32>;
 ${sumBinding}
+${segmentFlagsBinding}
+${segmentPrefixesBinding}
+${segmentFlagOutputBinding}
 var<workgroup> scratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;
+${props.segmentFlags ? `var<workgroup> segmentScratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;` : ''}
 
 @compute @workgroup_size(${SCAN_WORKGROUP_SIZE}) fn main(
   @builtin(global_invocation_id) globalId: vec3<u32>,
@@ -294,29 +464,34 @@ var<workgroup> scratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;
   let index = globalId.x;
   let lane = localId.x;
   var inputValue = 0u;
+  var inputSegmentFlag = 0u;
   if (index < ELEMENT_COUNT) {
     inputValue = inputValues[INPUT_OFFSET + index];
+    inputSegmentFlag = ${inputSegmentFlag};
   }
   scratch[lane] = inputValue;
+  ${props.segmentFlags ? 'segmentScratch[lane] = inputSegmentFlag;' : ''}
   workgroupBarrier();
 
   for (var stride = 1u; stride < ${SCAN_WORKGROUP_SIZE}u; stride = stride * 2u) {
     var addend = 0u;
+    ${props.segmentFlags ? 'var addendSegment = 0u;' : ''}
     if (lane >= stride) {
       addend = scratch[lane - stride];
+      ${props.segmentFlags ? 'addendSegment = segmentScratch[lane - stride];' : ''}
     }
     workgroupBarrier();
-    if (lane >= stride) {
-      scratch[lane] = scratch[lane] + addend;
-    }
+    ${scanUpdate}
     workgroupBarrier();
   }
 
   if (lane == ${SCAN_WORKGROUP_SIZE - 1}u) {
     ${sumWrite}
+    ${segmentFlagWrite}
   }
   if (index < ELEMENT_COUNT) {
-    outputValues[OUTPUT_OFFSET + index] = scratch[lane] - inputValue;
+    ${segmentedOutput}
+    ${segmentPrefixWrite}
   }
 }`;
 
@@ -325,7 +500,12 @@ var<workgroup> scratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;
     resources: [
       {buffer: props.input, usage: 'storage-read'},
       {buffer: props.output, usage: 'storage-write'},
-      ...(sumOutput ? [{buffer: sumOutput, usage: 'storage-write'} as const] : [])
+      ...(sumOutput ? [{buffer: sumOutput, usage: 'storage-write'} as const] : []),
+      ...(props.segmentFlags ? [{buffer: props.segmentFlags, usage: 'storage-read'} as const] : []),
+      ...(props.segmentPrefixes
+        ? [{buffer: props.segmentPrefixes, usage: 'storage-write'} as const]
+        : []),
+      ...(segmentFlagOutput ? [{buffer: segmentFlagOutput, usage: 'storage-write'} as const] : [])
     ],
     compile: ({device}) => {
       const computation = new Computation(device, {
@@ -337,6 +517,22 @@ var<workgroup> scratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;
             {name: 'outputValues', type: 'storage', group: 0, location: 1},
             ...(sumOutput
               ? [{name: 'sumValues', type: 'storage' as const, group: 0, location: 2}]
+              : []),
+            ...(props.segmentFlags
+              ? [{name: 'segmentFlags', type: 'storage' as const, group: 0, location: 3}]
+              : []),
+            ...(props.segmentPrefixes
+              ? [{name: 'segmentPrefixes', type: 'storage' as const, group: 0, location: 4}]
+              : []),
+            ...(segmentFlagOutput
+              ? [
+                  {
+                    name: 'summarySegmentFlags',
+                    type: 'storage' as const,
+                    group: 0,
+                    location: 5
+                  }
+                ]
               : [])
           ]
         }
@@ -349,6 +545,15 @@ var<workgroup> scratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;
           };
           if (sumOutput) {
             bindings['sumValues'] = getViewBinding(sumOutput, getBuffer);
+          }
+          if (props.segmentFlags) {
+            bindings['segmentFlags'] = getViewBinding(props.segmentFlags, getBuffer);
+          }
+          if (props.segmentPrefixes) {
+            bindings['segmentPrefixes'] = getViewBinding(props.segmentPrefixes, getBuffer);
+          }
+          if (segmentFlagOutput) {
+            bindings['summarySegmentFlags'] = getViewBinding(segmentFlagOutput, getBuffer);
           }
           computation.setBindings(bindings);
           computation.dispatch(computePass, props.blockCount);
@@ -368,6 +573,7 @@ function addOffsetPass<Parameters>(
     offsets: GraphDataView<'uint32'>;
     length: number;
     offsetIndex?: number;
+    segmentPrefixes?: GraphDataView<'uint32'>;
   }
 ): void {
   const offsetIndex =
@@ -376,22 +582,29 @@ function addOffsetPass<Parameters>(
 const ELEMENT_COUNT: u32 = ${props.length}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
 const OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.offsets)}u;
+${props.segmentPrefixes ? `const SEGMENT_PREFIXES_OFFSET: u32 = ${getViewElementOffset(props.segmentPrefixes)}u;` : ''}
 @group(0) @binding(0) var<storage, read_write> outputValues: array<u32>;
 @group(0) @binding(1) var<storage, read> offsets: array<u32>;
+${props.segmentPrefixes ? '@group(0) @binding(2) var<storage, read> segmentPrefixes: array<u32>;' : ''}
 
 @compute @workgroup_size(${SCAN_WORKGROUP_SIZE}) fn main(
   @builtin(global_invocation_id) globalId: vec3<u32>
 ) {
   let index = globalId.x;
   if (index < ELEMENT_COUNT) {
-    outputValues[OUTPUT_OFFSET + index] = outputValues[OUTPUT_OFFSET + index] + offsets[OFFSETS_OFFSET + ${offsetIndex}];
+    ${props.segmentPrefixes ? 'if (segmentPrefixes[SEGMENT_PREFIXES_OFFSET + index] == 0u) {' : ''}
+      outputValues[OUTPUT_OFFSET + index] = outputValues[OUTPUT_OFFSET + index] + offsets[OFFSETS_OFFSET + ${offsetIndex}];
+    ${props.segmentPrefixes ? '}' : ''}
   }
 }`;
   graph.addComputePass({
     id: props.id,
     resources: [
       {buffer: props.output, usage: 'storage-read-write'},
-      {buffer: props.offsets, usage: 'storage-read'}
+      {buffer: props.offsets, usage: 'storage-read'},
+      ...(props.segmentPrefixes
+        ? [{buffer: props.segmentPrefixes, usage: 'storage-read'} as const]
+        : [])
     ],
     compile: ({device}) => {
       const computation = new Computation(device, {
@@ -400,16 +613,23 @@ const OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.offsets)}u;
         shaderLayout: {
           bindings: [
             {name: 'outputValues', type: 'storage', group: 0, location: 0},
-            {name: 'offsets', type: 'storage', group: 0, location: 1}
+            {name: 'offsets', type: 'storage', group: 0, location: 1},
+            ...(props.segmentPrefixes
+              ? [{name: 'segmentPrefixes', type: 'storage' as const, group: 0, location: 2}]
+              : [])
           ]
         }
       });
       return {
         encode: ({computePass, getBuffer}) => {
-          computation.setBindings({
+          const bindings: Record<string, Binding> = {
             outputValues: getViewBinding(props.output, getBuffer),
             offsets: getViewBinding(props.offsets, getBuffer)
-          });
+          };
+          if (props.segmentPrefixes) {
+            bindings['segmentPrefixes'] = getViewBinding(props.segmentPrefixes, getBuffer);
+          }
+          computation.setBindings(bindings);
           computation.dispatch(computePass, Math.ceil(props.length / SCAN_WORKGROUP_SIZE));
         },
         destroy: () => computation.destroy()

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -46,7 +46,7 @@ export type {
 } from './gpu-command-graph';
 
 export {GPUScan} from './gpu-scan';
-export type {GPUScanInput, GPUScanProps} from './gpu-scan';
+export type {GPUScanInput, GPUScanMode, GPUScanProps} from './gpu-scan';
 export {GPUCompaction} from './gpu-compaction';
 export type {GPUCompactionInput, GPUCompactionProps} from './gpu-compaction';
 

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -46,7 +46,7 @@ export type {
 } from './gpu-command-graph';
 
 export {GPUScan} from './gpu-scan';
-export type {GPUScanInput, GPUScanMode, GPUScanProps} from './gpu-scan';
+export type {GPUScanInput, GPUScanProps} from './gpu-scan';
 export {GPUCompaction} from './gpu-compaction';
 export type {GPUCompactionInput, GPUCompactionProps} from './gpu-compaction';
 

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
@@ -718,6 +718,21 @@ test('GPUScan preserves segments and carries across GPUVector chunk boundaries',
     [[2, 5], [], [10, 7, 18], [31]],
     'inclusive segments preserve the same chunk topology'
   );
+
+  const longChunkValues = [Uint32Array.from([10]), Uint32Array.from({length: 512}, () => 1)];
+  const longChunkSegmentFlags = [new Uint32Array(1), new Uint32Array(512)];
+  longChunkSegmentFlags[1][100] = 1;
+  const longChunkResult = await runVectorScan(device, longChunkValues, {
+    segmentFlagChunks: longChunkSegmentFlags,
+    mode: 'exclusive'
+  });
+  t.equal(longChunkResult.chunks[1][99], 109, 'carry reaches rows before the segment start');
+  t.equal(longChunkResult.chunks[1][100], 0, 'the segment start discards the preceding carry');
+  t.equal(
+    longChunkResult.chunks[1][256],
+    156,
+    'the discarded carry stays removed in later workgroups'
+  );
   t.end();
 });
 

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
@@ -635,6 +635,92 @@ test('GPUScan propagates carries across GPUVector chunks without changing topolo
   t.end();
 });
 
+test('GPUScan computes inclusive and segmented uint32 prefixes across block boundaries', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const length = 65_537;
+  const values = Uint32Array.from({length}, (_, index) =>
+    index === 0 ? 0xffffffff : (index % 7) + 1
+  );
+  const segmentFlags = new Uint32Array(length);
+  for (const index of [0, 17, 255, 256, 257, 1025, 65_535, 65_536]) {
+    segmentFlags[index] = index % 2 === 0 ? 7 : 1;
+  }
+
+  for (const mode of ['exclusive', 'inclusive'] as const) {
+    const result = await runScan(device, values, {mode, segmentFlags});
+    t.deepEqual(
+      result,
+      getExpectedScan(values, mode, segmentFlags),
+      `${mode} segmented scan matches the CPU oracle`
+    );
+  }
+
+  const inclusive = await runScan(device, values, {mode: 'inclusive'});
+  t.deepEqual(
+    inclusive,
+    getExpectedScan(values, 'inclusive'),
+    'inclusive unsegmented scan matches the CPU oracle and wraps modulo 2^32'
+  );
+  t.deepEqual(
+    await runScan(device, new Uint32Array(0), {
+      mode: 'inclusive',
+      segmentFlags: new Uint32Array(0)
+    }),
+    [],
+    'empty segmented scans add no work'
+  );
+  t.end();
+});
+
+test('GPUScan preserves segments and carries across GPUVector chunk boundaries', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const valueChunks = [
+    Uint32Array.from([2, 3]),
+    new Uint32Array(0),
+    Uint32Array.from([5, 7, 11]),
+    Uint32Array.from([13])
+  ];
+  const segmentFlagChunks = [
+    Uint32Array.from([1, 0]),
+    new Uint32Array(0),
+    Uint32Array.from([0, 1, 0]),
+    Uint32Array.from([0])
+  ];
+
+  const exclusive = await runVectorScan(device, valueChunks, {
+    segmentFlagChunks,
+    mode: 'exclusive'
+  });
+  t.deepEqual(
+    exclusive.chunks,
+    [[0, 2], [], [5, 0, 7], [18]],
+    'exclusive segments continue across chunks and reset at flagged rows'
+  );
+
+  const inclusive = await runVectorScan(device, valueChunks, {
+    segmentFlagChunks,
+    mode: 'inclusive'
+  });
+  t.deepEqual(
+    inclusive.chunks,
+    [[2, 5], [], [10, 7, 18], [31]],
+    'inclusive segments preserve the same chunk topology'
+  );
+  t.end();
+});
+
 test('GPUCompaction preserves selected order and writes indirect instance count', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -882,14 +968,24 @@ async function readPixels(texture: Texture, width: number, height: number): Prom
 
 async function runVectorScan(
   device: Device,
-  chunks: Uint32Array[]
+  chunks: Uint32Array[],
+  options: {
+    mode?: 'exclusive' | 'inclusive';
+    segmentFlagChunks?: Uint32Array[];
+  } = {}
 ): Promise<{chunks: number[][]; nodeOrder: string[]}> {
   const inputFixture = createUint32VectorFixture(device, 'input', chunks);
   const outputFixture = createUint32VectorFixture(device, 'output', chunks, 0);
+  const segmentFlagsFixture = options.segmentFlagChunks
+    ? createUint32VectorFixture(device, 'segment-flags', options.segmentFlagChunks)
+    : null;
   const graph = new GPUCommandGraph(device, {id: 'vector-scan'});
   const input = graph.importGPUVector('input', inputFixture.vector);
   const output = graph.importGPUVector('output', outputFixture.vector);
-  new GPUScan({input, output}).addToGraph(graph);
+  const segmentFlags = segmentFlagsFixture
+    ? graph.importGPUVector('segment-flags', segmentFlagsFixture.vector)
+    : undefined;
+  new GPUScan({input, output, mode: options.mode, segmentFlags}).addToGraph(graph);
   const compiled = graph.compile();
   const commandEncoder = device.createCommandEncoder({id: 'vector-scan-encoder'});
   compiled.encode(commandEncoder, {parameters: undefined});
@@ -901,7 +997,84 @@ async function runVectorScan(
   compiled.destroy();
   destroyUint32VectorFixture(inputFixture);
   destroyUint32VectorFixture(outputFixture);
+  if (segmentFlagsFixture) destroyUint32VectorFixture(segmentFlagsFixture);
   return result;
+}
+
+async function runScan(
+  device: Device,
+  values: Uint32Array,
+  options: {
+    mode?: 'exclusive' | 'inclusive';
+    segmentFlags?: Uint32Array;
+  } = {}
+): Promise<number[]> {
+  const inputBuffer = device.createBuffer({
+    data: values.length > 0 ? values : new Uint32Array(1),
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  const outputBuffer = device.createBuffer({
+    byteLength: Math.max(values.length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  const segmentFlagsBuffer = options.segmentFlags
+    ? device.createBuffer({
+        data: options.segmentFlags.length > 0 ? options.segmentFlags : new Uint32Array(1),
+        usage: Buffer.STORAGE | Buffer.COPY_DST
+      })
+    : null;
+  const graph = new GPUCommandGraph(device, {id: 'scan-variant'});
+  const inputHandle = graph.importBuffer(
+    {id: 'input', byteLength: inputBuffer.byteLength, usage: inputBuffer.usage},
+    inputBuffer
+  );
+  const outputHandle = graph.importBuffer(
+    {id: 'output', byteLength: outputBuffer.byteLength, usage: outputBuffer.usage},
+    outputBuffer
+  );
+  const input = graph.createDataView(inputHandle, {format: 'uint32', length: values.length});
+  const output = graph.createDataView(outputHandle, {format: 'uint32', length: values.length});
+  const segmentFlagsHandle = segmentFlagsBuffer
+    ? graph.importBuffer(
+        {
+          id: 'segment-flags',
+          byteLength: segmentFlagsBuffer.byteLength,
+          usage: segmentFlagsBuffer.usage
+        },
+        segmentFlagsBuffer
+      )
+    : null;
+  const segmentFlags = segmentFlagsHandle
+    ? graph.createDataView(segmentFlagsHandle, {format: 'uint32', length: values.length})
+    : undefined;
+  new GPUScan({input, output, mode: options.mode, segmentFlags}).addToGraph(graph);
+  const compiled = graph.compile();
+  const commandEncoder = device.createCommandEncoder({id: 'scan-variant-encoder'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+  const outputBytes = await outputBuffer.readAsync();
+  const result = Array.from(
+    new Uint32Array(outputBytes.buffer, outputBytes.byteOffset, values.length)
+  );
+  compiled.destroy();
+  inputBuffer.destroy();
+  outputBuffer.destroy();
+  segmentFlagsBuffer?.destroy();
+  return result;
+}
+
+function getExpectedScan(
+  values: Uint32Array,
+  mode: 'exclusive' | 'inclusive',
+  segmentFlags?: Uint32Array
+): number[] {
+  let prefix = 0;
+  return Array.from(values, (value, index) => {
+    if (index === 0 || segmentFlags?.[index]) prefix = 0;
+    const exclusive = prefix;
+    prefix = (prefix + value) >>> 0;
+    return mode === 'inclusive' ? prefix : exclusive;
+  });
 }
 
 async function runVectorCompaction(


### PR DESCRIPTION
## Summary

Implements the first Phase 3 algorithm-scaling tranche from the GPU primitives roadmap.

This tranche was developed on #2786. That parent merged before publication, so this branch is
rebased onto its merge commit and contains only the follow-up scan work.

## Changes

- extend `GPUScan` with explicit exclusive/inclusive modes
- add optional nonzero segment-start flags for atomic data views and chunk-preserving vectors
- preserve segment continuation across vector chunk boundaries while retaining caller-owned topology
- propagate associative segment summaries through multi-level workgroup and chunk carries
- export the new `GPUScanMode` type and document modulo-2^32, topology, and aliasing contracts
- migrate the GPU data-analysis example to use an inclusive histogram CDF and segmented grid-row prefixes
- add deterministic CPU-oracle coverage for empty inputs, workgroup boundaries, a 65,537-row hierarchy, overflow, and cross-chunk segments
- mark Phase 3 as in progress and record the completed scan tranche

## Impact

Applications can now build cumulative counts and grouped offsets without CPU readback, data packing, or treating source batch boundaries as semantic segment boundaries. Existing callers retain exclusive scan behavior by default.

## Verification

- `nvm use` — passed
- `yarn install` — passed with existing peer-dependency warnings
- `yarn lint fix` — passed
- `yarn build` — passed
- `yarn test-headless modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts` — 16 tests passed
- `yarn workspace luma.gl-examples-experimental-gpu-data-analysis build` — passed
- `yarn website:build` — passed
- `(cd website && yarn build)` — passed
- `yarn test` — 1,308 passed and 25 skipped; one pre-existing macOS WebGPU Arrow polygon test failed because `polygonViewportUniforms` was not found in the shader layout

## Dependency

- Parent: #2786 (merged)
- Base: `master`
- Head: `codex/gpu-scan-variants`
