### PR TITLE
fix(website): clean up example transitions

### DIFF
--- a/modules/effects/src/passes/postprocessing/image-adjust-filters/persistence.ts
+++ b/modules/effects/src/passes/postprocessing/image-adjust-filters/persistence.ts
@@ -48,5 +48,6 @@ export const persistenceEffect = {
   name: 'persistence',
   source,
   fs,
+  bindingLayout: [{name: 'persistenceTexture', group: 0}],
   passes: [{filter: true}]
 } as const satisfies ShaderPass;

--- a/modules/effects/test/index.ts
+++ b/modules/effects/test/index.ts
@@ -15,6 +15,7 @@ import './passes/image-adjust-filters/brightnesscontrast.spec';
 import './passes/image-adjust-filters/denoise.spec';
 import './passes/image-adjust-filters/huesaturation.spec';
 import './passes/image-adjust-filters/noise.spec';
+import './passes/image-adjust-filters/persistence.spec';
 import './passes/image-adjust-filters/sepia.spec';
 import './passes/image-adjust-filters/vibrance.spec';
 import './passes/image-adjust-filters/vignette.spec';

--- a/modules/effects/test/passes/image-adjust-filters/persistence.spec.ts
+++ b/modules/effects/test/passes/image-adjust-filters/persistence.spec.ts
@@ -1,0 +1,15 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {persistenceEffect} from '@luma.gl/effects';
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+
+test('persistenceEffect#bindings', t => {
+  t.deepEqual(
+    persistenceEffect.bindingLayout,
+    [{name: 'persistenceTexture', group: 0}],
+    'declares the frame-history texture binding'
+  );
+  t.end();
+});

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -256,6 +256,7 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
       return;
     }
 
+    const canvasContainer = canvasContainerRef.current;
     let isCancelled = false;
     let animationLoop: AnimationLoop | null = null;
     const defaultCanvasContext = effectiveDevice.getDefaultCanvasContext();
@@ -275,7 +276,7 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
       deviceCanvas.style.display = EXAMPLE_CANVAS_STYLE.display;
       deviceCanvas.style.width = EXAMPLE_CANVAS_STYLE.width;
       deviceCanvas.style.height = EXAMPLE_CANVAS_STYLE.height;
-      canvasContainerRef.current?.replaceChildren(deviceCanvas);
+      canvasContainer.replaceChildren(deviceCanvas);
       setActiveCpuHotspotProfilerDevice(effectiveDevice);
 
       animationLoop = makeAnimationLoop(props.template as unknown as typeof AnimationLoopTemplate, {
@@ -307,6 +308,9 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
 
     return () => {
       isCancelled = true;
+      // Route transitions must stop displaying the outgoing example immediately, even when its
+      // asynchronous initialization is still ahead of cleanup in the serialized task queue.
+      canvasContainer.replaceChildren();
 
       currentLumaExampleTask = currentLumaExampleTask
         .then(() => {
@@ -319,7 +323,6 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
           }
 
           clearActiveCpuHotspotProfilerDevice(effectiveDevice);
-          canvasContainerRef.current?.replaceChildren();
           getCanvasContainer().appendChild(deviceCanvas);
         })
         .catch(error => {


### PR DESCRIPTION
## Goals
- Stop outgoing luma examples from leaving their canvas and custom controls visible during Docusaurus route transitions.
- Fix the WebGPU Persistence example console errors caused by the persistence shader pass dropping its frame-history texture binding.

## Changes
- Clear the captured example canvas container synchronously during React effect cleanup, while leaving GPU teardown serialized.
- Declare persistenceTexture in persistenceEffect.bindingLayout so per-frame history texture bindings survive ShaderPassRenderer filtering.
- Add a focused effects test covering the Persistence pass binding contract.

## Verification
- yarn lint fix
- yarn build
- yarn test-node
- Browser dev-server check: loaded Effects: Persistence with device=webgpu; the previous luma.gl WebGPU bind-group errors were gone.
- Browser route-transition check: navigated from Effects: Glass to Effects: Persistence; the guided packet-spraying panel disappeared immediately and only one visible canvas remained.

## Notes
- yarn test-headless could not run locally because Chromium for Testing aborted during launch with SIGABRT / kill EPERM before any tests executed.
- Local yarn website:build was started but did not complete in a useful time window; the dev server compiled successfully and GitHub CI should provide the authoritative production website build.