### PR TITLE
Add ANARI deferred renderer

### DIFF
--- a/docs/api-guide/engine/anari-rendering.md
+++ b/docs/api-guide/engine/anari-rendering.md
@@ -187,6 +187,19 @@ requestAnimationFrame(render);
 
 The floor is attached directly to the world, so it uses the identity transform. The sphere is attached through a reusable group and transform instance.
 
+## Try the deferred renderer
+
+Use `newRenderer('deferred')` when you want the ANARI scene rendered through the experimental WebGPU G-buffer and deferred lighting path:
+
+```ts
+const renderer = anariDevice.newRenderer('deferred', {
+  ambientRadiance: 0.08,
+  background: [0.006, 0.008, 0.018, 1]
+});
+```
+
+The deferred renderer shares ANARI scene traversal, generated geometry, instance transforms, and PBR material textures with the default renderer, then resolves lighting through `@luma.gl/experimental` `GBuffer` and `deferredLighting`. This first path is intentionally limited to opaque material channels and direct lights; clustered lighting and screen-space effects remain separate follow-up work.
+
 ## Understand staging and commits
 
 Every retained object has **pending** and **committed** parameters. Initial constructor parameters are committed automatically, but later changes are invisible until committed:
@@ -419,6 +432,7 @@ const beauty = anariDevice.newRenderer('default', {
 
 const normals = anariDevice.newRenderer('debugNormals');
 const depth = anariDevice.newRenderer('debugDepth');
+const deferred = anariDevice.newRenderer('deferred');
 ```
 
 Switch renderers by committing the frame:
@@ -427,7 +441,7 @@ Switch renderers by committing the frame:
 frame.setParameter('renderer', normals).commitParameters();
 ```
 
-Debug renderers automatically skip bloom. Switch back to the `default` renderer to restore physically based shading and postprocessing.
+Debug renderers automatically skip bloom. Switch to `deferred` to use the WebGPU G-buffer path, or switch back to `default` to restore the portable forward renderer with bloom.
 
 ## Handle resizing
 
@@ -588,16 +602,17 @@ Each `frame.render()` performs the following work:
 1. Resolve the frame's committed world, camera, and renderer.
 2. Collect directly attached world surfaces and surfaces reached through world instances.
 3. Group placements by retained surface object identity.
-4. Reuse or rebuild one luma.gl `Model` per distinct surface.
-5. Upload four per-instance matrix-column vertex buffers.
-6. Translate ANARI materials into luma.gl material uniforms.
-7. Translate world and group lights into the shared luma.gl lighting shader module.
-8. Configure camera, exposure, fog, debug mode, and HDR uniforms.
-9. Issue one instanced draw per distinct surface.
-10. Optionally run bloom into an intermediate texture and composite the result to the canvas.
-11. Return surface, instance, draw-call, and triangle statistics.
+4. Select the forward or deferred renderer runtime from the committed renderer subtype.
+5. Reuse or rebuild one luma.gl `Model` per distinct surface.
+6. Upload four per-instance matrix-column vertex buffers.
+7. Translate ANARI materials into luma.gl material uniforms and texture bindings.
+8. Translate world and group lights into the renderer's lighting representation.
+9. Configure camera, exposure, fog, debug mode, and HDR uniforms.
+10. Issue one instanced draw per distinct surface.
+11. Optionally run renderer-owned composition such as bloom or deferred lighting.
+12. Return surface, instance, draw-call, and triangle statistics.
 
-WebGPU uses WGSL shaders; WebGL 2 uses equivalent GLSL shaders. Both consume the same retained object graph and the same public API.
+The forward runtime uses WGSL shaders on WebGPU and equivalent GLSL shaders on WebGL 2. The deferred runtime is WebGPU-only and resolves the same retained object graph through `GBuffer` plus `deferredLighting`.
 
 ### Cache invalidation
 
@@ -630,14 +645,16 @@ yarn workspace luma.gl-examples-showcase-anari start
 Open `/playground.html` on the reported development-server URL, or select **JSON LAB** in the
 Observatory. The playground provides a Monaco JSON editor with syntax highlighting,
 schema-aware completions, property documentation, red error indicators, animated example scenes,
-WebGPU/WebGL selection, automatic HDR presentation when available, orbit controls, validation
-feedback, and live instance, draw-call, and triangle statistics.
+WebGPU/WebGL selection, a renderer selector for frame presentation, automatic HDR presentation when
+available, orbit controls, validation feedback, and live instance, draw-call, and triangle
+statistics.
 
 Use **GLTF ↓** or **USD ↓** to download the currently valid retained scene. Export bakes procedural
 geometry, starfield distributions, and retained instances into a static snapshot; transfers mesh
 positions, normals, UVs, vertex colors, materials, texture images, camera, and supported lights;
 and emits standalone JSON glTF with embedded buffers/images or ASCII `.usda`. ANARI animation
-declarations, bloom, fog, and renderer-only HDR controls remain ANARI-specific and are not exported.
+declarations, optional renderer presets, bloom, fog, and renderer-only HDR controls remain
+ANARI-specific and are not exported.
 
 :::caution Experimental playground format
 The JSON format and its optional schema exports are experimental. They are not part of the ANARI C
@@ -682,7 +699,9 @@ paths back to precise Monaco error indicators.
 ### Describe a scene with JSON
 
 Use `@@type` to select ANARI object subtypes, registry keys to name shared resources, and `@@id`
-to name individual lights and instances:
+to name individual lights and instances. Renderer data is optional in the playground JSON: the
+ANARI world remains renderer-independent, while the active renderer subtype is selected by the
+playground UI and attached only when constructing the frame.
 
 ```json
 {
@@ -694,12 +713,6 @@ to name individual lights and instances:
     "target": [0, 1, 0],
     "fovy": 0.75,
     "orbit": {"speed": 0.08}
-  },
-  "renderer": {
-    "@@type": "default",
-    "background": [0.015, 0.02, 0.04, 1],
-    "exposure": 1.5,
-    "bloomIntensity": 0.5
   },
   "geometries": {
     "orb": {"@@type": "sphere", "radius": 0.8, "segments": 28},
@@ -767,7 +780,7 @@ for each orb.
 | `version` | JSON schema version; currently `1`. |
 | `name`, `description` | Human-readable preview title and optional scene description. |
 | `camera` | Camera `@@type`, normal ANARI camera parameters, optional `target`, and optional orbit speed. |
-| `renderer` | Renderer `@@type` and normal ANARI exposure, bloom, background, and fog parameters. |
+| `renderer` | Optional renderer preset parameters for exposure, bloom, background, and fog. The playground's renderer selector chooses the active renderer subtype independently of the scene. |
 | `geometries` | Named geometry declarations; triangle meshes accept number arrays or compact `torus`, `crystal`, and beveled `prism` generators. |
 | `materials` | Named `matte` or `physicallyBased` material declarations. |
 | `surfaces` | Named surface declarations referencing geometry and material identifiers. |
@@ -784,8 +797,8 @@ explicit named `group` when multiple surfaces or group-attached lights are requi
 
 Object subtypes match the private package: `triangle`, `sphere`, `cylinder`, `cone`, and `quad`
 geometry; `matte` and `physicallyBased` materials; `ambient`, `directional`, `point`, and `spot`
-lights; `perspective` and `orthographic` cameras; and `default`, `debugNormals`, and `debugDepth`
-renderers.
+lights; `perspective` and `orthographic` cameras; and optional renderer presets for `default`,
+`deferred`, `debugNormals`, and `debugDepth`.
 
 ### Generate compact triangle meshes and starfields
 
@@ -988,6 +1001,7 @@ The current package is a focused proof of concept, not a complete ANARI implemen
 - Automatically generated triangle normals assume non-indexed triangle-list positions.
 - Changing an opaque compiled material to transparent does not rebuild its blending pipeline.
 - Group-attached lights are not transformed by their owning instance.
+- The `deferred` renderer is WebGPU-only and does not yet include clustered lighting, screen-space effects, bloom, or temporal velocity history.
 - Visibility, picking, volumes, clipping planes, shadows, and asynchronous frame mapping are not implemented.
 - Experimental OpenUSD import does not support binary USDC crates or complete USD composition semantics.
 - Experimental glTF import supports common PBR textures and selected material extensions, but not skinning or animations.

--- a/docs/api-reference/anari/README.md
+++ b/docs/api-reference/anari/README.md
@@ -91,7 +91,7 @@ The package also exports parameter interfaces, subtype unions, object metadata, 
 | World | `default` |
 | Light | `ambient`, `directional`, `point`, `spot` |
 | Camera | `perspective`, `orthographic` |
-| Renderer | `default`, `debugNormals`, `debugDepth` |
+| Renderer | `default`, `deferred`, `debugNormals`, `debugDepth` |
 | Frame | `default` |
 
 Query the actual subtype list with `anariDevice.getObjectSubtypes(type)` instead of assuming future implementations expose the same set.
@@ -104,6 +104,7 @@ Query the actual subtype list with `anariDevice.getObjectSubtypes(type)` instead
 | Matte and physically based materials | Supported | Supported |
 | PBR image samplers and UV transforms | Supported | Supported |
 | Ambient, directional, point, and spot lighting | Supported | Supported |
+| Deferred renderer | Supported | WebGPU-only G-buffer plus direct deferred lighting. |
 | Debug normals and depth renderers | Supported | Supported |
 | Bloom and fog | Supported | Supported |
 | Extended-range, Display P3 presentation | Supported on compatible displays and browsers | Not supported; SDR fallback |
@@ -118,7 +119,8 @@ The private package includes a JSON scene playground at
 reported development-server URL. The playground translates deck.gl-inspired `@@type`
 declarations, named ANARI object references, shared retained surfaces, generated torus/crystal/prism
 meshes, starfield distributions, composable transform animations, lights following named
-instances, cameras, and renderer options into the API documented on these pages. The complete
+instances, cameras, and optional renderer presets into the API documented on these pages. The active
+renderer subtype is selected as frame state outside the renderer-independent scene. The complete
 Chromatic Atlas, Crystal Cathedral, and Celestial Engine showcase scenes are available as editable
 JSON presets.
 

--- a/docs/api-reference/anari/anari-api-mapping.md
+++ b/docs/api-reference/anari/anari-api-mapping.md
@@ -70,7 +70,7 @@ The native concept “select an ANARI device implementation” therefore maps to
 | `anariNewWorld(device)` | `anariDevice.newWorld({surface, instance, light})` | `new Scene()` | Supported for direct surfaces, instances, and lights. |
 | `anariNewLight(device, subtype)` | `anariDevice.newLight(subtype, parameters)` | THREE.js light subclasses | Supported for `directional`, `point`, and `spot`; JavaScript additionally provides an `ambient` convenience subtype. |
 | `anariNewCamera(device, subtype)` | `anariDevice.newCamera(subtype, parameters)` | `PerspectiveCamera` / `OrthographicCamera` | Supported for `perspective` and `orthographic`. |
-| `anariNewRenderer(device, subtype)` | `anariDevice.newRenderer(subtype, parameters)` | Renderer configuration / debug material | Supported for `default`, `debugNormals`, and `debugDepth`. |
+| `anariNewRenderer(device, subtype)` | `anariDevice.newRenderer(subtype, parameters)` | Renderer configuration / debug material | Supported for `default`, WebGPU-only `deferred`, `debugNormals`, and `debugDepth`. |
 | `anariNewFrame(device)` | `anariDevice.newFrame({world, camera, renderer, size})` | `renderer.render(scene, camera)` / render target | Supported for canvas presentation; arbitrary mapped output channels are not implemented. |
 | `anariNewSampler()` | `anariDevice.newSampler('image2D', {image, transform})` | `Texture`, sampler state, texture-backed material properties | Partial: retained 2D image samplers; no procedural or volume samplers. |
 | `anariNewSpatialField()` | No equivalent | 3D texture / volume field | Not implemented. |

--- a/docs/api-reference/anari/anari-device.md
+++ b/docs/api-reference/anari/anari-device.md
@@ -118,7 +118,7 @@ anariDevice.getObjectSubtypes('geometry');
 // ['triangle', 'sphere', 'cylinder', 'cone', 'quad']
 
 anariDevice.getObjectSubtypes('renderer');
-// ['default', 'debugNormals', 'debugDepth']
+// ['default', 'deferred', 'debugNormals', 'debugDepth']
 ```
 
 The `ANARIObjectType` union is:

--- a/docs/api-reference/anari/anari-rendering.md
+++ b/docs/api-reference/anari/anari-rendering.md
@@ -85,7 +85,7 @@ new ANARIRenderer(
 );
 
 newRenderer(
-  subtype?: 'default' | 'debugNormals' | 'debugDepth',
+  subtype?: 'default' | 'deferred' | 'debugNormals' | 'debugDepth',
   parameters?: ANARIRendererParameters
 ): ANARIRenderer;
 ```
@@ -134,6 +134,19 @@ const renderer = anariDevice.newRenderer('default', {
 ```
 
 Bloom renders into a temporary frame-sized texture before composing the result to the canvas. The intermediate texture uses the underlying device's preferred presentation format, preserving HDR values when the canvas uses `rgba16float`.
+
+### Deferred renderer
+
+```ts
+const renderer = anariDevice.newRenderer('deferred', {
+  ambientRadiance: 0.08,
+  background: [0.006, 0.008, 0.018, 1]
+});
+```
+
+`deferred` is a WebGPU-only alternate renderer that writes committed ANARI surfaces into a shared `GBuffer`, then resolves opaque PBR lighting with the experimental `deferredLighting` shader pass. It currently supports base color, normal, metallic-roughness, emissive, and occlusion maps, plus ambient, directional, point, and spot lights. Spot lights are mapped onto deferred point lights in this first implementation.
+
+The deferred path is intended as an architecture baseline for richer ANARI renderers. It does not yet include the full Deferred Illumination Lab chain such as clustered light bins, GTAO, SSGI, SSR, velocity history, or bloom.
 
 ### Debug normals
 
@@ -269,7 +282,7 @@ type ANARIGeometrySubtype = 'triangle' | 'sphere' | 'cylinder' | 'cone' | 'quad'
 type ANARIMaterialSubtype = 'matte' | 'physicallyBased';
 type ANARILightSubtype = 'ambient' | 'directional' | 'point' | 'spot';
 type ANARICameraSubtype = 'perspective' | 'orthographic';
-type ANARIRendererSubtype = 'default' | 'debugNormals' | 'debugDepth';
+type ANARIRendererSubtype = 'default' | 'deferred' | 'debugNormals' | 'debugDepth';
 ```
 
 All parameter interfaces, object classes, subtype aliases, object metadata, and frame statistics are exported from `@luma.gl/anari`.

--- a/docs/api-reference/anari/anari-schemas.md
+++ b/docs/api-reference/anari/anari-schemas.md
@@ -55,12 +55,12 @@ import {
 | `ANARIAnimationSchema` | `orbit`, `bob`, `spin`, `wobble`, `pulse`, and `follow` animations. |
 | `ANARILightSchema` | `ambient`, `directional`, `point`, and `spot` lights. |
 | `ANARICameraSchema` | `perspective` and `orthographic` cameras. |
-| `ANARIRendererSchema` | `default`, `debugNormals`, and `debugDepth` renderer configuration. |
+| `ANARIRendererSchema` | Optional renderer preset configuration for `default`, `deferred`, `debugNormals`, and `debugDepth`. |
 | `ANARISurfaceSchema` | Named geometry/material pairings. |
 | `ANARIGroupSchema` | Reusable retained surfaces and optional lights. |
 | `ANARIInstanceSchema` | Named transform placements and composable animations. |
 | `ANARIStarfieldSchema` | Deterministic retained background-star distributions. |
-| `ANARISceneSchema` | A complete scene and its cross-object semantic references. |
+| `ANARISceneSchema` | A renderer-independent scene and its cross-object semantic references, plus optional renderer presets. |
 | `ANARI_SCENE_JSON_SCHEMA` | Draft-07 JSON Schema generated from `ANARISceneSchema`. |
 | `ANARISceneDescription` | TypeScript scene type inferred from `ANARISceneSchema`. |
 

--- a/examples/showcase/anari/app.ts
+++ b/examples/showcase/anari/app.ts
@@ -74,6 +74,7 @@ export default class ANARIShowcase extends AnimationLoopTemplate {
   private bloomEnabled = true;
   private lastStatisticsUpdate = 0;
   private canvas: HTMLCanvasElement | null = null;
+  private readonly deferredRendererAvailable: boolean;
   private readonly importedScenes = new Map<string, number>();
   private importRequest = 0;
 
@@ -81,8 +82,13 @@ export default class ANARIShowcase extends AnimationLoopTemplate {
     super();
 
     this.anari = new ANARIDevice(device);
+    this.deferredRendererAvailable = device.type === 'webgpu';
     this.renderers = {
       default: this.anari.newRenderer('default', DEFAULT_RENDERER_PARAMETERS),
+      deferred: this.anari.newRenderer('deferred', {
+        ...DEFAULT_RENDERER_PARAMETERS,
+        bloomIntensity: 0
+      }),
       debugNormals: this.anari.newRenderer('debugNormals', {
         background: [0.027, 0.033, 0.06, 1]
       }),
@@ -207,13 +213,21 @@ export default class ANARIShowcase extends AnimationLoopTemplate {
     });
 
     for (const button of document.querySelectorAll<HTMLButtonElement>('[data-renderer]')) {
+      if (button.dataset['renderer'] === 'deferred' && !this.deferredRendererAvailable) {
+        button.disabled = true;
+        button.title = 'Deferred rendering requires WebGPU.';
+      }
       button.addEventListener('click', () => {
         const rendererName = button.dataset['renderer'];
         if (
           rendererName === 'default' ||
+          rendererName === 'deferred' ||
           rendererName === 'debugNormals' ||
           rendererName === 'debugDepth'
         ) {
+          if (rendererName === 'deferred' && !this.deferredRendererAvailable) {
+            return;
+          }
           this.frame.setParameter('renderer', this.renderers[rendererName]).commitParameters();
           for (const control of document.querySelectorAll('[data-renderer]')) {
             control.classList.toggle('active', control === button);
@@ -247,6 +261,13 @@ export default class ANARIShowcase extends AnimationLoopTemplate {
         bloomIntensity: this.bloomEnabled ? rendererParameters.bloomIntensity : 0
       })
       .commitParameters();
+    this.renderers.deferred
+      .setParameters({
+        ...DEFAULT_RENDERER_PARAMETERS,
+        ...rendererParameters,
+        bloomIntensity: 0
+      })
+      .commitParameters();
     this.frame.setParameter('world', scene.world).commitParameters();
     setElementText(
       'scene-number',
@@ -277,7 +298,9 @@ export default class ANARIShowcase extends AnimationLoopTemplate {
         return;
       }
 
-      const importedScene = createANARIJSONScene(this.anari, description);
+      const importedScene = createANARIJSONScene(this.anari, description, {
+        rendererSubtype: 'default'
+      });
       const world = importedScene.frame.getParameter('world');
       if (!world) {
         throw new Error('The imported 3D scene did not produce an ANARI world.');
@@ -289,6 +312,7 @@ export default class ANARIShowcase extends AnimationLoopTemplate {
         cameraPosition[0] - target[0],
         cameraPosition[2] - target[2]
       );
+      const rendererParameters = description.renderer || DEFAULT_RENDERER_PARAMETERS;
       const sceneIndex =
         this.scenes.push({
           label: description.name,
@@ -301,14 +325,14 @@ export default class ANARIShowcase extends AnimationLoopTemplate {
           elevation: Math.atan2(cameraPosition[1] - target[1], horizontalDistance),
           azimuth: Math.atan2(cameraPosition[0] - target[0], cameraPosition[2] - target[2]),
           rendererParameters: {
-            background: description.renderer.background,
-            ambientRadiance: description.renderer.ambientRadiance,
-            exposure: description.renderer.exposure,
-            bloomIntensity: description.renderer.bloomIntensity,
-            bloomThreshold: description.renderer.bloomThreshold,
-            bloomRadius: description.renderer.bloomRadius,
-            fogColor: description.renderer.fogColor,
-            fogDensity: description.renderer.fogDensity
+            background: rendererParameters.background,
+            ambientRadiance: rendererParameters.ambientRadiance,
+            exposure: rendererParameters.exposure,
+            bloomIntensity: rendererParameters.bloomIntensity,
+            bloomThreshold: rendererParameters.bloomThreshold,
+            bloomRadius: rendererParameters.bloomRadius,
+            fogColor: rendererParameters.fogColor,
+            fogDensity: rendererParameters.fogDensity
           }
         }) - 1;
       importedScene.frame.destroy();

--- a/examples/showcase/anari/index.html
+++ b/examples/showcase/anari/index.html
@@ -368,6 +368,7 @@
     </main>
     <aside class="controls" aria-label="Renderer controls">
       <button class="mode-button active" data-renderer="default">LIT</button>
+      <button class="mode-button" data-renderer="deferred">DEFERRED</button>
       <button class="mode-button" data-renderer="debugNormals">NORMALS</button>
       <button class="mode-button" data-renderer="debugDepth">DEPTH</button>
       <span class="separator" aria-hidden="true"></span>

--- a/examples/showcase/anari/package.json
+++ b/examples/showcase/anari/package.json
@@ -14,6 +14,7 @@
     "@luma.gl/core": "9.4.0-alpha.2",
     "@luma.gl/effects": "9.4.0-alpha.2",
     "@luma.gl/engine": "9.4.0-alpha.2",
+    "@luma.gl/experimental": "9.4.0-alpha.2",
     "@luma.gl/shadertools": "9.4.0-alpha.2",
     "@luma.gl/webgl": "9.4.0-alpha.2",
     "@luma.gl/webgpu": "9.4.0-alpha.2",

--- a/examples/showcase/anari/playground-presets.ts
+++ b/examples/showcase/anari/playground-presets.ts
@@ -1,5 +1,9 @@
 import type {ANARIVector3} from '@luma.gl/anari';
-import type {ANARIJSONScene, JSONInstanceDeclaration} from './playground-scene';
+import type {
+  ANARIJSONScene,
+  JSONInstanceDeclaration,
+  JSONRendererDeclaration
+} from './playground-scene';
 
 export type PlaygroundPreset = {
   label: string;
@@ -558,7 +562,7 @@ function addStarfield(scene: ANARIJSONScene, count: number, radius: number): voi
   ];
 }
 
-function makeRenderer(): ANARIJSONScene['renderer'] {
+function makeRenderer(): JSONRendererDeclaration {
   return {
     '@@type': 'default',
     background: [0.016, 0.019, 0.044, 1],

--- a/examples/showcase/anari/playground-scene.ts
+++ b/examples/showcase/anari/playground-scene.ts
@@ -142,7 +142,7 @@ export type ANARIJSONScene = {
   name: string;
   description?: string;
   camera: JSONCameraDeclaration;
-  renderer: JSONRendererDeclaration;
+  renderer?: JSONRendererDeclaration;
   geometries: Record<string, JSONGeometryDeclaration>;
   textures?: Record<string, JSONTextureDeclaration>;
   materials: Record<string, JSONMaterialDeclaration>;
@@ -179,9 +179,22 @@ const LIGHT_SUBTYPES: readonly ANARILightSubtype[] = ['ambient', 'directional', 
 const CAMERA_SUBTYPES: readonly ANARICameraSubtype[] = ['perspective', 'orthographic'];
 const RENDERER_SUBTYPES: readonly ANARIRendererSubtype[] = [
   'default',
+  'deferred',
   'debugNormals',
   'debugDepth'
 ];
+
+const DEFAULT_RENDERER_DECLARATION: JSONRendererDeclaration = {
+  '@@type': 'default',
+  background: [0.016, 0.019, 0.044, 1],
+  ambientRadiance: 0.1,
+  exposure: 1.5,
+  bloomIntensity: 0.82,
+  bloomThreshold: 0.64,
+  bloomRadius: 8,
+  fogColor: [0.018, 0.025, 0.065],
+  fogDensity: 0.00024
+};
 
 const MATERIAL_TEXTURE_NAMES: readonly JSONMaterialTextureName[] = [
   'baseColorTexture',
@@ -228,7 +241,8 @@ export async function preloadANARIJSONTextures(scene: ANARIJSONScene): Promise<v
 
 export function createANARIJSONScene(
   device: ANARIDevice,
-  scene: ANARIJSONScene
+  scene: ANARIJSONScene,
+  options: {rendererSubtype?: ANARIRendererSubtype} = {}
 ): ANARIJSONSceneHandle {
   if (scene.version !== 1) {
     throw new Error('Scene "version" must be 1.');
@@ -425,7 +439,9 @@ export function createANARIJSONScene(
     direction: cameraParameters.direction || subtractVectors(target, position)
   });
 
-  const {'@@type': rendererSubtype, ...rendererParameters} = scene.renderer;
+  const {'@@type': sceneRendererSubtype, ...rendererParameters} =
+    scene.renderer || DEFAULT_RENDERER_DECLARATION;
+  const rendererSubtype = options.rendererSubtype || sceneRendererSubtype;
   assertSubtype('renderer', rendererSubtype, RENDERER_SUBTYPES);
   const renderer = device.newRenderer(rendererSubtype, rendererParameters);
   const frame = device.newFrame({world, camera, renderer});

--- a/examples/showcase/anari/playground.html
+++ b/examples/showcase/anari/playground.html
@@ -221,6 +221,27 @@
         color: #bdaeff;
       }
 
+      .renderer-control {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        margin-left: 5px;
+        color: var(--muted);
+        font-size: 9px;
+        letter-spacing: 0.08em;
+      }
+
+      .renderer-selector {
+        max-width: 96px;
+        border: 1px solid rgba(191, 203, 247, 0.16);
+        border-radius: 5px;
+        background: rgba(7, 9, 17, 0.82);
+        color: #e5e9ff;
+        font: inherit;
+        font-size: 10px;
+        letter-spacing: 0;
+      }
+
       .apply-button {
         margin-left: 5px;
         padding: 8px 11px;
@@ -476,6 +497,15 @@
               <button id="copy-scene" class="tool-button">COPY</button>
               <button id="export-gltf" class="tool-button">GLTF ↓</button>
               <button id="export-usd" class="tool-button">USD ↓</button>
+              <label class="renderer-control">
+                <span>RENDERER</span>
+                <select id="renderer-selector" class="renderer-selector" aria-label="Renderer">
+                  <option value="default">Default</option>
+                  <option value="deferred">Deferred</option>
+                  <option value="debugNormals">Normals</option>
+                  <option value="debugDepth">Depth</option>
+                </select>
+              </label>
               <button id="apply-scene" class="apply-button">APPLY ↵</button>
             </div>
           </div>

--- a/examples/showcase/anari/playground.ts
+++ b/examples/showcase/anari/playground.ts
@@ -1,4 +1,4 @@
-import {ANARIDevice, type ANARIVector3} from '@luma.gl/anari';
+import {ANARIDevice, type ANARIRendererSubtype, type ANARIVector3} from '@luma.gl/anari';
 import {ANARISceneSchema} from '@luma.gl/anari/schemas';
 import {AnimationLoopTemplate, type AnimationProps} from '@luma.gl/engine';
 import {PLAYGROUND_PRESETS} from './playground-presets';
@@ -17,6 +17,7 @@ export default class ANARIPlayground extends AnimationLoopTemplate {
   readonly anari: ANARIDevice;
 
   private scene: ANARIJSONSceneHandle | null = null;
+  private readonly deferredRendererAvailable: boolean;
   private activePresetIndex = 0;
   private liveApplyEnabled = true;
   private pendingApply: number | null = null;
@@ -24,6 +25,7 @@ export default class ANARIPlayground extends AnimationLoopTemplate {
   private orbitAzimuth = 0;
   private orbitElevation = 0.2;
   private orbitDistance = 20;
+  private rendererSubtype: ANARIRendererSubtype = 'default';
   private lastStatisticsUpdate = 0;
   private readonly editor: ANARISceneEditor;
   private readonly canvas: HTMLCanvasElement;
@@ -33,6 +35,7 @@ export default class ANARIPlayground extends AnimationLoopTemplate {
     super();
 
     this.anari = new ANARIDevice(device);
+    this.deferredRendererAvailable = device.type === 'webgpu';
     this.editor = new ANARISceneEditor(
       getRequiredElement('scene-editor', HTMLTextAreaElement),
       getRequiredElement('scene-monaco-editor', HTMLDivElement)
@@ -169,6 +172,22 @@ export default class ANARIPlayground extends AnimationLoopTemplate {
         this.applyEditorScene();
       }
     });
+
+    const rendererSelector = getRequiredElement('renderer-selector', HTMLSelectElement);
+    const deferredOption = rendererSelector.querySelector<HTMLOptionElement>(
+      'option[value="deferred"]'
+    );
+    if (deferredOption && !this.deferredRendererAvailable) {
+      deferredOption.disabled = true;
+      deferredOption.title = 'Deferred rendering requires WebGPU.';
+    }
+    rendererSelector.addEventListener('change', event => {
+      const selector = event.currentTarget;
+      if (selector instanceof HTMLSelectElement) {
+        this.rendererSubtype = selector.value as ANARIRendererSubtype;
+        this.applyEditorScene();
+      }
+    });
   }
 
   private selectPreset(presetIndex: number): void {
@@ -219,7 +238,9 @@ export default class ANARIPlayground extends AnimationLoopTemplate {
       }
       this.editor.clearIssues();
       const sceneDescription: ANARIJSONScene = validatedScene.data;
-      const nextScene = createANARIJSONScene(this.anari, sceneDescription);
+      const nextScene = createANARIJSONScene(this.anari, sceneDescription, {
+        rendererSubtype: this.rendererSubtype
+      });
       const previousScene = this.scene;
       this.scene = nextScene;
       previousScene?.destroy();

--- a/examples/showcase/anari/usd-to-anari.ts
+++ b/examples/showcase/anari/usd-to-anari.ts
@@ -389,6 +389,7 @@ function configurePresentation(state: USDTranslationState): void {
   ];
   state.scene.camera.near = Math.max(0.01, extent * 0.001);
   state.scene.camera.far = Math.max(200, extent * 18);
+  state.scene.renderer ||= {'@@type': 'default'};
   state.scene.renderer.fogDensity = 0.003 / extent;
 
   const floorIdentifier = makeIdentifier('gallery', 'floor', state);

--- a/modules/anari/README.md
+++ b/modules/anari/README.md
@@ -94,7 +94,7 @@ changed object is committed.
 | Material | `matte`, `physicallyBased` |
 | Light | `ambient`, `directional`, `point`, `spot` |
 | Camera | `perspective`, `orthographic` |
-| Renderer | `default`, `debugNormals`, `debugDepth` |
+| Renderer | `default`, `deferred`, `debugNormals`, `debugDepth` |
 
 The scene hierarchy also supports arrays, surfaces, groups, transform instances, worlds, and
 frames. Reusing one surface across many instances normally produces one instanced draw.
@@ -143,7 +143,8 @@ fallback instead of automatically selecting WebGPU. HDR-capable displays automat
 Open `/playground.html` on the same development-server URL, or select **JSON LAB** from the
 showcase. The private, experimental playground provides a deck.gl-style JSON editor with
 `@@type` subtype declarations, named geometries and materials, retained surface references,
-transform instances, animated lights, renderer controls, and live HDR-capable rendering.
+transform instances, animated lights, renderer-independent scene data, frame renderer controls, and
+live HDR-capable rendering.
 
 Three presets represent the complete **Chromatic Atlas**, **Crystal Cathedral**, and
 **Celestial Engine** showcase scenes entirely in JSON, including procedural torus, crystal, and
@@ -154,8 +155,8 @@ last valid scene when JSON, parameter values, or retained object references are 
 
 The **GLTF ↓** and **USD ↓** actions export the currently valid scene as a static interchange
 snapshot. Procedural meshes, starfields, and retained instances are baked into glTF 2.0 or ASCII
-USD meshes with materials, textures, camera, and supported lights. ANARI animations and
-renderer-specific bloom, fog, and HDR presentation settings stay in the editable ANARI JSON.
+USD meshes with materials, textures, camera, and supported lights. ANARI animations and optional
+renderer preset parameters for bloom, fog, and HDR presentation stay in the editable ANARI JSON.
 
 The optional, experimental `@luma.gl/anari/schemas` entry point exports Zod schemas and the
 generated draft-07 JSON Schema without adding Zod to imports of the core ANARI rendering API:

--- a/modules/anari/package.json
+++ b/modules/anari/package.json
@@ -29,6 +29,7 @@
     "@luma.gl/core": "~9.4.0-alpha.2",
     "@luma.gl/effects": "~9.4.0-alpha.2",
     "@luma.gl/engine": "~9.4.0-alpha.2",
+    "@luma.gl/experimental": "~9.4.0-alpha.2",
     "@luma.gl/shadertools": "~9.4.0-alpha.2"
   },
   "dependencies": {

--- a/modules/anari/src/anari-deferred-rendering-runtime.ts
+++ b/modules/anari/src/anari-deferred-rendering-runtime.ts
@@ -1,0 +1,437 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device, type TextureFormatColor} from '@luma.gl/core';
+import {
+  GBuffer,
+  MAX_DEFERRED_POINT_LIGHTS,
+  createDeferredLightingShaderPassPipeline,
+  makeDeferredPointLightBufferData,
+  type DeferredPointLight
+} from '@luma.gl/experimental';
+import {Material, MaterialFactory, Model, ShaderInputs, ShaderPassRenderer} from '@luma.gl/engine';
+import {type Light} from '@luma.gl/shadertools';
+import {Matrix4, type NumberArray3} from '@math.gl/core';
+import {
+  type ANARIFallbackTextures,
+  type ANARIMaterialBindings,
+  type ANARITransformResources,
+  type SurfacePlacement,
+  collectLights,
+  collectSurfacePlacements,
+  createFallbackTexture,
+  getCameraUniforms,
+  getFrameSize,
+  getMaterialOpacity,
+  getMaterialTextureSignature,
+  groupPlacementsBySurface,
+  makeEngineGeometry,
+  makeMaterialBindings,
+  updateMaterial,
+  updateTransforms
+} from './anari-rendering-runtime';
+import type {ANARIRendererRuntime} from './anari-renderer-runtime';
+import {ANARI_DEFERRED_WGSL_SHADER} from './anari-deferred-shaders';
+import {
+  anariAppModule,
+  anariMaterialModule,
+  type ANARIAppUniforms,
+  type ANARIMaterialUniforms
+} from './anari-shaders';
+import type {ANARIFrame, ANARIGeometry, ANARISurface} from './anari-objects';
+import type {ANARIFrameStatistics} from './anari-types';
+
+type DeferredCompiledSurface = ANARITransformResources & {
+  surface: ANARISurface;
+  geometry: ANARIGeometry;
+  geometryVersion: number;
+  materialVersion: number;
+  placementCount: number;
+  model: Model;
+  material: Material<{anariMaterial: ANARIMaterialUniforms}, ANARIMaterialBindings>;
+  triangleCount: number;
+  textureSignature: string;
+};
+
+type DeferredFrameResources = {
+  compiledSurfaces: Map<string, DeferredCompiledSurface>;
+  gBuffer: GBuffer | null;
+};
+
+const DEFERRED_COLOR_ATTACHMENT_FORMATS = [
+  'rgba16float',
+  'rgba8unorm',
+  'rg16float',
+  'rgba8unorm',
+  'rgba16float'
+] satisfies (TextureFormatColor | null)[];
+
+const ZERO_POINT_LIGHTS = makeDeferredPointLightBufferData([], MAX_DEFERRED_POINT_LIGHTS);
+
+export class ANARIDeferredRenderingRuntime implements ANARIRendererRuntime {
+  private readonly device: Device;
+  private readonly materialFactory: MaterialFactory<
+    {anariMaterial: ANARIMaterialUniforms},
+    ANARIMaterialBindings
+  >;
+  private readonly fallbackTextures: ANARIFallbackTextures;
+  private readonly pointLightBuffer: Buffer;
+  private readonly frames = new Map<ANARIFrame, DeferredFrameResources>();
+  private readonly renderer: ShaderPassRenderer;
+
+  constructor(device: Device) {
+    if (device.type !== 'webgpu') {
+      throw new Error('ANARI deferred renderer requires a WebGPU device.');
+    }
+    this.device = device;
+    this.materialFactory = new MaterialFactory(device, {modules: [anariMaterialModule]});
+    this.fallbackTextures = {
+      white: createFallbackTexture(device, 'deferred-white', [255, 255, 255, 255]),
+      normal: createFallbackTexture(device, 'deferred-normal', [128, 128, 255, 255]),
+      black: createFallbackTexture(device, 'deferred-black', [0, 0, 0, 255])
+    };
+    this.pointLightBuffer = device.createBuffer({
+      id: 'anari-deferred-point-lights',
+      data: ZERO_POINT_LIGHTS,
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    this.renderer = new ShaderPassRenderer(device, {
+      shaderPasses: [createDeferredLightingShaderPassPipeline()],
+      colorFormat: 'rgba16float',
+      flipY: true
+    });
+  }
+
+  render(frame: ANARIFrame): ANARIFrameStatistics {
+    const world = frame.getParameter('world');
+    const camera = frame.getParameter('camera');
+    const renderer = frame.getParameter('renderer');
+    if (!world || !camera || !renderer) {
+      return {surfaceCount: 0, instanceCount: 0, drawCount: 0, triangleCount: 0};
+    }
+
+    const [width, height] = getFrameSize(frame, this.device);
+    const frameResources = this.getFrameResources(frame, width, height);
+    const placements = collectSurfacePlacements(world);
+    const placementsBySurface = groupPlacementsBySurface(placements);
+    const cameraUniforms = getCameraUniforms(camera, frame);
+    const appUniforms: ANARIAppUniforms = {
+      ...cameraUniforms,
+      exposure: renderer.getParameter('exposure') ?? 1.35,
+      fogColor: renderer.getParameter('fogColor') ?? [0.025, 0.035, 0.075],
+      fogDensity: renderer.getParameter('fogDensity') ?? 0,
+      renderMode: 0,
+      highDynamicRange: 1,
+      time: typeof performance !== 'undefined' ? performance.now() * 0.001 : 0
+    };
+
+    const liveSurfaceIdentifiers = new Set<string>();
+    let triangleCount = 0;
+    for (const [surface, surfacePlacements] of placementsBySurface) {
+      const compiledSurface = this.getCompiledSurface(frameResources, surface, surfacePlacements);
+      liveSurfaceIdentifiers.add(surface.id);
+      updateTransforms(compiledSurface, surfacePlacements);
+      updateMaterial(compiledSurface.material, surface.getParameter('material')!);
+      compiledSurface.model.shaderInputs.setProps({anariApp: appUniforms});
+      compiledSurface.model.predraw(this.device.commandEncoder);
+      triangleCount += compiledSurface.triangleCount * surfacePlacements.length;
+    }
+
+    for (const [surfaceIdentifier, compiledSurface] of frameResources.compiledSurfaces) {
+      if (!liveSurfaceIdentifiers.has(surfaceIdentifier)) {
+        destroyDeferredCompiledSurface(compiledSurface);
+        frameResources.compiledSurfaces.delete(surfaceIdentifier);
+      }
+    }
+
+    const background = renderer.getParameter('background') ?? [0.015, 0.018, 0.038, 1];
+    const renderPass = this.device.beginRenderPass({
+      id: `anari-${frame.id}-deferred-gbuffer`,
+      framebuffer: frameResources.gBuffer!.framebuffer,
+      clearColors: [
+        new Float32Array([background[0], background[1], background[2], background[3]]),
+        new Float32Array([0.5, 0.5, 1, 1]),
+        new Float32Array([0, 0, 0, 0]),
+        new Float32Array([0, 0, 0, 0]),
+        new Float32Array([0, 0, 0, 0])
+      ],
+      clearDepth: 1
+    });
+
+    let drawCount = 0;
+    for (const compiledSurface of frameResources.compiledSurfaces.values()) {
+      if (compiledSurface.model.draw(renderPass)) {
+        drawCount++;
+      }
+    }
+    renderPass.end();
+
+    const deferredLights = getDeferredLights(
+      collectLights(world, renderer.getParameter('ambientRadiance') ?? 0.12),
+      new Matrix4(cameraUniforms.viewMatrix)
+    );
+    this.pointLightBuffer.write(
+      makeDeferredPointLightBufferData(deferredLights.pointLights, MAX_DEFERRED_POINT_LIGHTS)
+    );
+    this.renderer.resize([width, height]);
+    this.renderer.renderToScreen({
+      sourceTexture: frameResources.gBuffer!.colorTexture,
+      bindings: {
+        depthTexture: frameResources.gBuffer!.depthTexture,
+        normalTexture: frameResources.gBuffer!.normalRoughnessTexture,
+        baseColorMetallicTexture: frameResources.gBuffer!.getExtraColorTexture('baseColorMetallic'),
+        emissiveOcclusionTexture: frameResources.gBuffer!.getExtraColorTexture('emissiveOcclusion'),
+        pointLights: this.pointLightBuffer
+      },
+      uniforms: {
+        deferredLighting: {
+          inverseProjectionMatrix: new Matrix4(cameraUniforms.projectionMatrix).invert(),
+          ambientColor: deferredLights.ambientColor,
+          exposure: appUniforms.exposure,
+          fogColor: appUniforms.fogColor,
+          fogDensity: appUniforms.fogDensity,
+          directionalLightDirectionView: deferredLights.directionalLightDirectionView,
+          directionalLightColor: deferredLights.directionalLightColor,
+          directionalLightIntensity: deferredLights.directionalLightIntensity,
+          pointLightCount: deferredLights.pointLights.length
+        }
+      }
+    });
+
+    return {
+      surfaceCount: placementsBySurface.size,
+      instanceCount: placements.length,
+      drawCount,
+      triangleCount
+    };
+  }
+
+  destroyFrame(frame: ANARIFrame): void {
+    const frameResources = this.frames.get(frame);
+    if (!frameResources) {
+      return;
+    }
+    for (const compiledSurface of frameResources.compiledSurfaces.values()) {
+      destroyDeferredCompiledSurface(compiledSurface);
+    }
+    frameResources.gBuffer?.destroy();
+    this.frames.delete(frame);
+  }
+
+  destroy(): void {
+    for (const frame of Array.from(this.frames.keys())) {
+      this.destroyFrame(frame);
+    }
+    this.renderer.destroy();
+    this.pointLightBuffer.destroy();
+    this.fallbackTextures.white.destroy();
+    this.fallbackTextures.normal.destroy();
+    this.fallbackTextures.black.destroy();
+  }
+
+  private getFrameResources(
+    frame: ANARIFrame,
+    width: number,
+    height: number
+  ): DeferredFrameResources {
+    let frameResources = this.frames.get(frame);
+    if (!frameResources) {
+      frameResources = {
+        compiledSurfaces: new Map(),
+        gBuffer: null
+      };
+      this.frames.set(frame, frameResources);
+    }
+
+    if (!frameResources.gBuffer) {
+      frameResources.gBuffer = new GBuffer(this.device, {
+        id: `anari-${frame.id}-deferred`,
+        width,
+        height,
+        colorFormat: 'rgba16float',
+        normalRoughnessFormat: 'rgba8unorm',
+        velocityFormat: 'rg16float',
+        depthStencilFormat: 'depth24plus',
+        extraColorAttachments: [
+          {name: 'baseColorMetallic', format: 'rgba8unorm'},
+          {name: 'emissiveOcclusion', format: 'rgba16float'}
+        ]
+      });
+    } else {
+      frameResources.gBuffer.resize({width, height});
+    }
+    return frameResources;
+  }
+
+  private getCompiledSurface(
+    frameResources: DeferredFrameResources,
+    surface: ANARISurface,
+    placements: SurfacePlacement[]
+  ): DeferredCompiledSurface {
+    const geometry = surface.getParameter('geometry')!;
+    const material = surface.getParameter('material')!;
+    let compiledSurface = frameResources.compiledSurfaces.get(surface.id);
+    if (
+      compiledSurface &&
+      (compiledSurface.geometry !== geometry ||
+        compiledSurface.geometryVersion !== geometry.version ||
+        compiledSurface.textureSignature !== getMaterialTextureSignature(material) ||
+        compiledSurface.placementCount !== placements.length)
+    ) {
+      destroyDeferredCompiledSurface(compiledSurface);
+      frameResources.compiledSurfaces.delete(surface.id);
+      compiledSurface = undefined;
+    }
+
+    if (!compiledSurface) {
+      const engineGeometry = makeEngineGeometry(geometry);
+      const transformBuffers: Buffer[] = [];
+      const transforms: Float32Array[] = [];
+      const attributes: Record<string, Buffer> = {};
+      const bufferLayout = [];
+      for (let columnIndex = 0; columnIndex < 4; columnIndex++) {
+        const transformData = new Float32Array(placements.length * 4);
+        const transformBuffer = this.device.createBuffer({
+          id: `${surface.id}-deferred-instance-column-${columnIndex}`,
+          data: transformData,
+          usage: Buffer.VERTEX | Buffer.COPY_DST
+        });
+        const attributeName = `instanceModelMatrixCol${columnIndex}`;
+        attributes[attributeName] = transformBuffer;
+        bufferLayout.push({
+          name: attributeName,
+          format: 'float32x4',
+          stepMode: 'instance'
+        } as const);
+        transformBuffers.push(transformBuffer);
+        transforms.push(transformData);
+      }
+
+      const engineMaterial = this.materialFactory.createMaterial({
+        id: `${material.id}-deferred-material`,
+        bindings: makeMaterialBindings(material, this.fallbackTextures)
+      });
+      updateMaterial(engineMaterial, material);
+
+      const model = new Model(this.device, {
+        id: `${surface.id}-deferred-model`,
+        source: ANARI_DEFERRED_WGSL_SHADER,
+        modules: [anariMaterialModule],
+        shaderInputs: new ShaderInputs({anariApp: anariAppModule}),
+        material: engineMaterial,
+        geometry: engineGeometry,
+        attributes,
+        bufferLayout,
+        instanceCount: placements.length,
+        colorAttachmentFormats: DEFERRED_COLOR_ATTACHMENT_FORMATS,
+        depthStencilAttachmentFormat: 'depth24plus',
+        parameters: {
+          cullMode: 'none',
+          depthWriteEnabled: true,
+          depthCompare: 'less-equal',
+          blend: getMaterialOpacity(material) < 1,
+          blendColorSrcFactor: 'src-alpha',
+          blendColorDstFactor: 'one-minus-src-alpha',
+          blendAlphaSrcFactor: 'one',
+          blendAlphaDstFactor: 'one-minus-src-alpha'
+        }
+      });
+
+      compiledSurface = {
+        surface,
+        geometry,
+        geometryVersion: geometry.version,
+        materialVersion: material.version,
+        placementCount: placements.length,
+        model,
+        material: engineMaterial,
+        transformBuffers,
+        transforms,
+        triangleCount: (engineGeometry.indices?.value.length ?? engineGeometry.vertexCount) / 3,
+        textureSignature: getMaterialTextureSignature(material)
+      };
+      frameResources.compiledSurfaces.set(surface.id, compiledSurface);
+    }
+    return compiledSurface;
+  }
+}
+
+function getDeferredLights(
+  lights: readonly Light[],
+  viewMatrix: Readonly<Matrix4>
+): {
+  ambientColor: NumberArray3;
+  directionalLightDirectionView: NumberArray3;
+  directionalLightColor: NumberArray3;
+  directionalLightIntensity: number;
+  pointLights: DeferredPointLight[];
+} {
+  const ambientColor: NumberArray3 = [0, 0, 0];
+  const directionalLightDirectionView: NumberArray3 = [0.3, 0.75, 0.55];
+  const directionalLightColor: NumberArray3 = [1, 0.95, 0.86];
+  let directionalLightIntensity = 0;
+  const pointLights: DeferredPointLight[] = [];
+
+  for (const light of lights) {
+    const color = normalizeColor(light.color || [1, 1, 1]);
+    const intensity = light.intensity ?? 1;
+    switch (light.type) {
+      case 'ambient':
+        ambientColor[0] += color[0] * intensity;
+        ambientColor[1] += color[1] * intensity;
+        ambientColor[2] += color[2] * intensity;
+        break;
+      case 'directional': {
+        const direction = normalizeVector(
+          viewMatrix.transformAsVector(light.direction) as NumberArray3
+        );
+        directionalLightDirectionView[0] = -direction[0];
+        directionalLightDirectionView[1] = -direction[1];
+        directionalLightDirectionView[2] = -direction[2];
+        directionalLightColor[0] = color[0];
+        directionalLightColor[1] = color[1];
+        directionalLightColor[2] = color[2];
+        directionalLightIntensity = intensity;
+        break;
+      }
+      case 'point':
+      case 'spot':
+        if (pointLights.length < MAX_DEFERRED_POINT_LIGHTS) {
+          pointLights.push({
+            position: viewMatrix.transformAsPoint(light.position) as [number, number, number],
+            range: Math.max(4, Math.sqrt(Math.max(intensity, 0)) * 3),
+            color,
+            intensity
+          });
+        }
+        break;
+    }
+  }
+
+  return {
+    ambientColor,
+    directionalLightDirectionView,
+    directionalLightColor,
+    directionalLightIntensity,
+    pointLights
+  };
+}
+
+function normalizeColor(color: Readonly<NumberArray3>): [number, number, number] {
+  const scale = color[0] > 1 || color[1] > 1 || color[2] > 1 ? 1 / 255 : 1;
+  return [color[0] * scale, color[1] * scale, color[2] * scale];
+}
+
+function normalizeVector(vector: Readonly<NumberArray3>): NumberArray3 {
+  const length = Math.hypot(vector[0], vector[1], vector[2]) || 1;
+  return [vector[0] / length, vector[1] / length, vector[2] / length];
+}
+
+function destroyDeferredCompiledSurface(compiledSurface: DeferredCompiledSurface): void {
+  compiledSurface.model.destroy();
+  compiledSurface.material.destroy();
+  for (const transformBuffer of compiledSurface.transformBuffers) {
+    transformBuffer.destroy();
+  }
+}

--- a/modules/anari/src/anari-deferred-shaders.ts
+++ b/modules/anari/src/anari-deferred-shaders.ts
@@ -1,0 +1,138 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export const ANARI_DEFERRED_WGSL_SHADER = /* wgsl */ `
+struct anariAppUniforms {
+  viewMatrix: mat4x4f,
+  projectionMatrix: mat4x4f,
+  cameraPosition: vec3f,
+  exposure: f32,
+  fogColor: vec3f,
+  fogDensity: f32,
+  renderMode: i32,
+  highDynamicRange: i32,
+  time: f32,
+};
+
+@group(0) @binding(auto) var<uniform> anariApp: anariAppUniforms;
+
+struct ANARIVertexInputs {
+  @location(0) positions: vec3f,
+  @location(1) normals: vec3f,
+  @location(2) colors: vec3f,
+  @location(3) texCoords: vec2f,
+  @location(4) instanceModelMatrixCol0: vec4f,
+  @location(5) instanceModelMatrixCol1: vec4f,
+  @location(6) instanceModelMatrixCol2: vec4f,
+  @location(7) instanceModelMatrixCol3: vec4f,
+};
+
+struct ANARIVertexOutputs {
+  @builtin(position) position: vec4f,
+  @location(0) worldPosition: vec3f,
+  @location(1) worldNormal: vec3f,
+  @location(2) color: vec3f,
+  @location(3) textureCoordinates: vec2f,
+};
+
+struct ANARIFragmentOutputs {
+  @location(0) color: vec4f,
+  @location(1) normalRoughness: vec4f,
+  @location(2) velocity: vec2f,
+  @location(3) baseColorMetallic: vec4f,
+  @location(4) emissiveOcclusion: vec4f,
+};
+
+fn getInverseTranspose3x3(matrix: mat3x3f) -> mat3x3f {
+  let firstCofactor = cross(matrix[1], matrix[2]);
+  let inverseDeterminant = 1.0 / dot(matrix[0], firstCofactor);
+  return mat3x3f(
+    firstCofactor,
+    cross(matrix[2], matrix[0]),
+    cross(matrix[0], matrix[1])
+  ) * inverseDeterminant;
+}
+
+@vertex
+fn vertexMain(inputs: ANARIVertexInputs) -> ANARIVertexOutputs {
+  let modelMatrix = mat4x4f(
+    inputs.instanceModelMatrixCol0,
+    inputs.instanceModelMatrixCol1,
+    inputs.instanceModelMatrixCol2,
+    inputs.instanceModelMatrixCol3
+  );
+  let worldPosition = modelMatrix * vec4f(inputs.positions, 1.0);
+  let normalMatrix = getInverseTranspose3x3(mat3x3f(
+    modelMatrix[0].xyz,
+    modelMatrix[1].xyz,
+    modelMatrix[2].xyz
+  ));
+
+  var outputs: ANARIVertexOutputs;
+  outputs.position = anariApp.projectionMatrix * anariApp.viewMatrix * worldPosition;
+  outputs.worldPosition = worldPosition.xyz;
+  outputs.worldNormal = normalize(normalMatrix * inputs.normals);
+  outputs.color = inputs.colors;
+  outputs.textureCoordinates = inputs.texCoords;
+  return outputs;
+}
+
+@fragment
+fn fragmentMain(inputs: ANARIVertexOutputs) -> ANARIFragmentOutputs {
+  let worldNormal = anariGetMappedNormal(
+    inputs.worldPosition,
+    normalize(inputs.worldNormal),
+    inputs.textureCoordinates
+  );
+  let viewNormal = normalize((anariApp.viewMatrix * vec4f(worldNormal, 0.0)).xyz);
+
+  var materialColor = anariMaterial.baseColor * inputs.color;
+  if (anariMaterial.baseColorTextureEnabled != 0) {
+    let coordinates = anariTransformUV(anariMaterial.baseColorUVTransform, inputs.textureCoordinates);
+    materialColor *= textureSample(anariBaseColorTexture, anariBaseColorTextureSampler, coordinates).rgb;
+  }
+
+  var metallic = anariMaterial.metallic;
+  var roughness = anariMaterial.roughness;
+  if (anariMaterial.metallicRoughnessTextureEnabled != 0) {
+    let coordinates = anariTransformUV(
+      anariMaterial.metallicRoughnessUVTransform,
+      inputs.textureCoordinates
+    );
+    let materialSample = textureSample(
+      anariMetallicRoughnessTexture,
+      anariMetallicRoughnessTextureSampler,
+      coordinates
+    );
+    roughness *= materialSample.g;
+    metallic *= materialSample.b;
+  }
+
+  var emissive = anariMaterial.emissiveColor;
+  if (anariMaterial.emissiveTextureEnabled != 0) {
+    let coordinates = anariTransformUV(anariMaterial.emissiveUVTransform, inputs.textureCoordinates);
+    emissive *= textureSample(anariEmissiveTexture, anariEmissiveTextureSampler, coordinates).rgb;
+  }
+
+  var occlusion = 1.0;
+  if (anariMaterial.occlusionTextureEnabled != 0) {
+    let coordinates = anariTransformUV(anariMaterial.occlusionUVTransform, inputs.textureCoordinates);
+    let sampledOcclusion = textureSample(anariOcclusionTexture, anariOcclusionTextureSampler, coordinates).r;
+    occlusion = mix(1.0, sampledOcclusion, anariMaterial.occlusionStrength);
+  }
+
+  let opacity = clamp(anariMaterial.opacity, 0.0, 1.0);
+  if (opacity < 0.01) {
+    discard;
+  }
+
+  var outputs: ANARIFragmentOutputs;
+  outputs.color = vec4f(materialColor * 0.015 + emissive, opacity);
+  outputs.normalRoughness = vec4f(viewNormal * 0.5 + 0.5, clamp(roughness, 0.045, 1.0));
+  outputs.velocity = vec2f(0.0);
+  outputs.baseColorMetallic = vec4f(materialColor, clamp(metallic, 0.0, 1.0));
+  outputs.emissiveOcclusion = vec4f(max(emissive, vec3f(0.0)), clamp(occlusion, 0.0, 1.0));
+  return outputs;
+}
+`;

--- a/modules/anari/src/anari-device.ts
+++ b/modules/anari/src/anari-device.ts
@@ -14,6 +14,8 @@ import {
   ANARIWorld
 } from './anari-objects';
 import {ANARIRenderingRuntime} from './anari-rendering-runtime';
+import {ANARIDeferredRenderingRuntime} from './anari-deferred-rendering-runtime';
+import type {ANARIRendererRuntime} from './anari-renderer-runtime';
 import type {
   ANARIArrayParameters,
   ANARICameraParameters,
@@ -47,7 +49,7 @@ const OBJECT_SUBTYPES: Record<ANARIObjectType, readonly string[]> = {
   instance: ['transform'],
   light: ['ambient', 'directional', 'point', 'spot'],
   material: ['matte', 'physicallyBased'],
-  renderer: ['default', 'debugNormals', 'debugDepth'],
+  renderer: ['default', 'deferred', 'debugNormals', 'debugDepth'],
   sampler: ['image2D'],
   surface: ['default'],
   world: ['default']
@@ -74,7 +76,7 @@ export class ANARIDevice {
   readonly device: Device;
   readonly extensions = SUPPORTED_EXTENSIONS;
 
-  private renderingRuntime: ANARIRenderingRuntime | null = null;
+  private readonly renderingRuntimes = new Map<'forward' | 'deferred', ANARIRendererRuntime>();
 
   constructor(device: Device) {
     this.device = device;
@@ -146,16 +148,29 @@ export class ANARIDevice {
   }
 
   renderFrame(frame: ANARIFrame): ANARIFrameStatistics {
-    this.renderingRuntime ||= new ANARIRenderingRuntime(this.device);
-    return this.renderingRuntime.render(frame);
+    const rendererSubtype = frame.getParameter('renderer')?.subtype;
+    const runtimeType = rendererSubtype === 'deferred' ? 'deferred' : 'forward';
+    let renderingRuntime = this.renderingRuntimes.get(runtimeType);
+    if (!renderingRuntime) {
+      renderingRuntime =
+        runtimeType === 'deferred'
+          ? new ANARIDeferredRenderingRuntime(this.device)
+          : new ANARIRenderingRuntime(this.device);
+      this.renderingRuntimes.set(runtimeType, renderingRuntime);
+    }
+    return renderingRuntime.render(frame);
   }
 
   destroyFrame(frame: ANARIFrame): void {
-    this.renderingRuntime?.destroyFrame(frame);
+    for (const renderingRuntime of this.renderingRuntimes.values()) {
+      renderingRuntime.destroyFrame(frame);
+    }
   }
 
   destroy(): void {
-    this.renderingRuntime?.destroy();
-    this.renderingRuntime = null;
+    for (const renderingRuntime of this.renderingRuntimes.values()) {
+      renderingRuntime.destroy();
+    }
+    this.renderingRuntimes.clear();
   }
 }

--- a/modules/anari/src/anari-renderer-runtime.ts
+++ b/modules/anari/src/anari-renderer-runtime.ts
@@ -1,0 +1,9 @@
+import type {ANARIFrame} from './anari-objects';
+import type {ANARIFrameStatistics} from './anari-types';
+
+/** Backend contract used by ANARI renderer subtypes. */
+export interface ANARIRendererRuntime {
+  render(frame: ANARIFrame): ANARIFrameStatistics;
+  destroyFrame(frame: ANARIFrame): void;
+  destroy(): void;
+}

--- a/modules/anari/src/anari-rendering-runtime.ts
+++ b/modules/anari/src/anari-rendering-runtime.ts
@@ -52,7 +52,7 @@ type CompiledSurface = {
   textureSignature: string;
 };
 
-type ANARIMaterialBindings = {
+export type ANARIMaterialBindings = {
   anariBaseColorTexture: Texture;
   anariNormalTexture: Texture;
   anariMetallicRoughnessTexture: Texture;
@@ -63,7 +63,7 @@ type ANARIMaterialBindings = {
   anariSheenColorTexture: Texture;
 };
 
-type SurfacePlacement = {
+export type SurfacePlacement = {
   surface: ANARISurface;
   transform: readonly number[];
 };
@@ -73,6 +73,17 @@ type FrameResources = {
   framebuffer: Framebuffer | null;
   colorTexture: Texture | null;
   bloomRenderer: ShaderPassRenderer | null;
+};
+
+export type ANARITransformResources = {
+  transformBuffers: Buffer[];
+  transforms: Float32Array[];
+};
+
+export type ANARIFallbackTextures = {
+  white: Texture;
+  normal: Texture;
+  black: Texture;
 };
 
 const IDENTITY_MATRIX = new Matrix4();
@@ -318,38 +329,11 @@ export class ANARIRenderingRuntime {
   }
 
   private getMaterialBindings(material: ANARIMaterial): ANARIMaterialBindings {
-    const parameters = material.getParameters();
-    return {
-      anariBaseColorTexture: getSamplerTexture(
-        parameters.baseColorTexture,
-        this.fallbackWhiteTexture
-      ),
-      anariNormalTexture: getSamplerTexture(parameters.normalTexture, this.fallbackNormalTexture),
-      anariMetallicRoughnessTexture: getSamplerTexture(
-        parameters.metallicRoughnessTexture,
-        this.fallbackWhiteTexture
-      ),
-      anariEmissiveTexture: getSamplerTexture(
-        parameters.emissiveTexture,
-        this.fallbackBlackTexture
-      ),
-      anariOcclusionTexture: getSamplerTexture(
-        parameters.occlusionTexture,
-        this.fallbackWhiteTexture
-      ),
-      anariClearcoatTexture: getSamplerTexture(
-        parameters.clearcoatTexture,
-        this.fallbackWhiteTexture
-      ),
-      anariTransmissionTexture: getSamplerTexture(
-        parameters.transmissionTexture,
-        this.fallbackWhiteTexture
-      ),
-      anariSheenColorTexture: getSamplerTexture(
-        parameters.sheenColorTexture,
-        this.fallbackWhiteTexture
-      )
-    };
+    return makeMaterialBindings(material, {
+      white: this.fallbackWhiteTexture,
+      normal: this.fallbackNormalTexture,
+      black: this.fallbackBlackTexture
+    });
   }
 
   private getFramebuffer(frame: ANARIFrame, frameResources: FrameResources): Framebuffer {
@@ -390,7 +374,7 @@ export class ANARIRenderingRuntime {
   }
 }
 
-function collectSurfacePlacements(world: ANARIWorld): SurfacePlacement[] {
+export function collectSurfacePlacements(world: ANARIWorld): SurfacePlacement[] {
   const placements: SurfacePlacement[] = [];
   const worldParameters = world.getParameters();
   const directSurfaces = resolveObjectArray(worldParameters.surface, worldParameters.surfaces);
@@ -431,7 +415,7 @@ function getGroupSurfaces(group: ANARIGroup): ANARISurface[] {
   return resolveObjectArray(parameters.surface, parameters.surfaces);
 }
 
-function groupPlacementsBySurface(
+export function groupPlacementsBySurface(
   placements: SurfacePlacement[]
 ): Map<ANARISurface, SurfacePlacement[]> {
   const groups = new Map<ANARISurface, SurfacePlacement[]>();
@@ -460,7 +444,7 @@ function resolveObjectArray<ObjectType extends ANARISurface | ANARIInstance | AN
   return Array.from(value);
 }
 
-function collectLights(world: ANARIWorld, ambientRadiance: number): Light[] {
+export function collectLights(world: ANARIWorld, ambientRadiance: number): Light[] {
   const lights: Light[] = [{type: 'ambient', color: [1, 1, 1], intensity: ambientRadiance}];
   const parameters = world.getParameters();
   const worldLights = resolveObjectArray(parameters.light, parameters.lights);
@@ -537,7 +521,7 @@ function addLight(light: ANARILight, lights: Light[]): void {
   }
 }
 
-function getCameraUniforms(
+export function getCameraUniforms(
   camera: ANARICamera,
   frame: ANARIFrame
 ): Pick<ANARIAppUniforms, 'viewMatrix' | 'projectionMatrix' | 'cameraPosition'> {
@@ -571,7 +555,7 @@ function getCameraUniforms(
   };
 }
 
-function getFrameSize(frame: ANARIFrame, device: Device): [number, number] {
+export function getFrameSize(frame: ANARIFrame, device: Device): [number, number] {
   const size = frame.getParameter('size');
   if (size) {
     return [size[0], size[1]];
@@ -579,7 +563,7 @@ function getFrameSize(frame: ANARIFrame, device: Device): [number, number] {
   return device.getDefaultCanvasContext().getDrawingBufferSize();
 }
 
-function makeEngineGeometry(geometry: ANARIGeometry): Geometry {
+export function makeEngineGeometry(geometry: ANARIGeometry): Geometry {
   const parameters = geometry.getParameters();
   const segments = parameters.segments ?? 32;
   let sourceGeometry: Geometry;
@@ -699,7 +683,10 @@ function makeVertexNormals(positions: Float32Array): Float32Array {
   return normals;
 }
 
-function updateTransforms(compiledSurface: CompiledSurface, placements: SurfacePlacement[]): void {
+export function updateTransforms(
+  compiledSurface: ANARITransformResources,
+  placements: SurfacePlacement[]
+): void {
   for (let placementIndex = 0; placementIndex < placements.length; placementIndex++) {
     const transform = placements[placementIndex].transform;
     for (let columnIndex = 0; columnIndex < 4; columnIndex++) {
@@ -714,7 +701,7 @@ function updateTransforms(compiledSurface: CompiledSurface, placements: SurfaceP
   }
 }
 
-function updateMaterial(
+export function updateMaterial(
   engineMaterial: Material<{anariMaterial: ANARIMaterialUniforms}, ANARIMaterialBindings>,
   material: ANARIMaterial
 ): void {
@@ -770,14 +757,37 @@ function getSamplerTransform(sampler: ANARISampler | undefined): Readonly<Number
   return sampler?.getParameter('transform') || IDENTITY_UV_TRANSFORM;
 }
 
-function getMaterialOpacity(material: ANARIMaterial): number {
+export function makeMaterialBindings(
+  material: ANARIMaterial,
+  fallbackTextures: ANARIFallbackTextures
+): ANARIMaterialBindings {
+  const parameters = material.getParameters();
+  return {
+    anariBaseColorTexture: getSamplerTexture(parameters.baseColorTexture, fallbackTextures.white),
+    anariNormalTexture: getSamplerTexture(parameters.normalTexture, fallbackTextures.normal),
+    anariMetallicRoughnessTexture: getSamplerTexture(
+      parameters.metallicRoughnessTexture,
+      fallbackTextures.white
+    ),
+    anariEmissiveTexture: getSamplerTexture(parameters.emissiveTexture, fallbackTextures.black),
+    anariOcclusionTexture: getSamplerTexture(parameters.occlusionTexture, fallbackTextures.white),
+    anariClearcoatTexture: getSamplerTexture(parameters.clearcoatTexture, fallbackTextures.white),
+    anariTransmissionTexture: getSamplerTexture(
+      parameters.transmissionTexture,
+      fallbackTextures.white
+    ),
+    anariSheenColorTexture: getSamplerTexture(parameters.sheenColorTexture, fallbackTextures.white)
+  };
+}
+
+export function getMaterialOpacity(material: ANARIMaterial): number {
   const parameters = material.getParameters();
   const color = parameters.baseColor || parameters.color;
   const explicitOpacity = parameters.opacity ?? (color && color.length > 3 ? (color[3] ?? 1) : 1);
   return Math.min(explicitOpacity, 1 - (parameters.transmission || 0) * 0.68);
 }
 
-function getMaterialTextureSignature(material: ANARIMaterial): string {
+export function getMaterialTextureSignature(material: ANARIMaterial): string {
   const parameters = material.getParameters();
   return [
     parameters.baseColorTexture,
@@ -793,7 +803,7 @@ function getMaterialTextureSignature(material: ANARIMaterial): string {
     .join(':');
 }
 
-function createFallbackTexture(
+export function createFallbackTexture(
   device: Device,
   identifier: string,
   color: readonly [number, number, number, number]

--- a/modules/anari/src/anari-types.ts
+++ b/modules/anari/src/anari-types.ts
@@ -33,7 +33,7 @@ export type ANARIMaterialSubtype = 'matte' | 'physicallyBased';
 export type ANARISamplerSubtype = 'image2D';
 export type ANARILightSubtype = 'ambient' | 'directional' | 'point' | 'spot';
 export type ANARICameraSubtype = 'perspective' | 'orthographic';
-export type ANARIRendererSubtype = 'default' | 'debugNormals' | 'debugDepth';
+export type ANARIRendererSubtype = 'default' | 'deferred' | 'debugNormals' | 'debugDepth';
 
 export type ANARIVector3 = readonly [number, number, number];
 export type ANARIVector4 = readonly [number, number, number, number];

--- a/modules/anari/src/index.ts
+++ b/modules/anari/src/index.ts
@@ -1,4 +1,5 @@
 export {ANARIDevice} from './anari-device';
+export type {ANARIRendererRuntime} from './anari-renderer-runtime';
 export {
   ANARIArray,
   ANARICamera,

--- a/modules/anari/src/schemas.ts
+++ b/modules/anari/src/schemas.ts
@@ -236,6 +236,7 @@ const rendererProperties = {
 export const ANARIRendererSchema = z
   .discriminatedUnion('@@type', [
     z.strictObject({'@@type': z.literal('default'), ...rendererProperties}),
+    z.strictObject({'@@type': z.literal('deferred'), ...rendererProperties}),
     z.strictObject({'@@type': z.literal('debugNormals'), ...rendererProperties}),
     z.strictObject({'@@type': z.literal('debugDepth'), ...rendererProperties})
   ])
@@ -289,7 +290,7 @@ export const ANARISceneSchema = z
     name: identifierSchema.describe('Human-readable scene title.'),
     description: z.string().optional(),
     camera: ANARICameraSchema,
-    renderer: ANARIRendererSchema,
+    renderer: ANARIRendererSchema.optional(),
     geometries: z.record(identifierSchema, ANARIGeometrySchema),
     textures: z.record(identifierSchema, ANARITextureSchema).optional(),
     materials: z.record(identifierSchema, ANARIMaterialSchema),

--- a/modules/anari/test/anari-device.node.spec.ts
+++ b/modules/anari/test/anari-device.node.spec.ts
@@ -29,7 +29,7 @@ test('ANARI device reports object subtypes and implemented extensions', testCont
 
   testContext.deepEqual(
     device.getObjectSubtypes('renderer'),
-    ['default', 'debugNormals', 'debugDepth'],
+    ['default', 'deferred', 'debugNormals', 'debugDepth'],
     'renderer implementations are discoverable'
   );
   testContext.ok(

--- a/modules/anari/test/anari-renderer.spec.ts
+++ b/modules/anari/test/anari-renderer.spec.ts
@@ -150,3 +150,61 @@ test('ANARI renderer samples PBR image maps on available GPU backends', async te
   }
   testContext.end();
 });
+
+test('ANARI deferred renderer resolves PBR surfaces on WebGPU', async testContext => {
+  for (const graphicsDevice of await getTestDevices()) {
+    if (graphicsDevice.type !== 'webgpu') {
+      continue;
+    }
+
+    const device = new ANARIDevice(graphicsDevice);
+    const geometry = device.newGeometry('sphere', {radius: 0.7, segments: 8});
+    const material = device.newMaterial('physicallyBased', {
+      baseColor: [0.9, 0.52, 0.18],
+      metallic: 0.8,
+      roughness: 0.22,
+      emissive: [0.3, 0.12, 0.04],
+      emissiveStrength: 2
+    });
+    const surface = device.newSurface({geometry, material});
+    const group = device.newGroup({surface: [surface]});
+    const world = device.newWorld({
+      instance: [
+        device.newInstance({
+          group,
+          transform: new Matrix4().translate([-0.7, 0, 0])
+        }),
+        device.newInstance({
+          group,
+          transform: new Matrix4().translate([0.7, 0, 0]).scale([0.75, 1.2, 0.75])
+        })
+      ],
+      light: [
+        device.newLight('directional', {
+          direction: [-0.4, -1, -0.3],
+          color: [1, 0.94, 0.82],
+          irradiance: 2.4
+        }),
+        device.newLight('point', {
+          position: [0.4, 1.2, 2],
+          color: [1, 0.45, 0.15],
+          intensity: 30
+        })
+      ]
+    });
+    const camera = device.newCamera('perspective', {position: [0, 0, 5]});
+    const renderer = device.newRenderer('deferred', {ambientRadiance: 0.08});
+    const frame = device.newFrame({world, camera, renderer, size: [32, 32]});
+
+    const statistics = frame.render();
+    graphicsDevice.submit();
+
+    testContext.equal(statistics.drawCount, 1, 'WebGPU deferred renderer draws one surface batch');
+    testContext.equal(statistics.instanceCount, 2, 'WebGPU deferred renderer keeps instances');
+    testContext.ok(statistics.triangleCount > 0, 'WebGPU deferred renderer counts geometry');
+
+    frame.destroy();
+    device.destroy();
+  }
+  testContext.end();
+});

--- a/modules/anari/tsconfig.json
+++ b/modules/anari/tsconfig.json
@@ -11,6 +11,7 @@
     {"path": "../core"},
     {"path": "../effects"},
     {"path": "../engine"},
+    {"path": "../experimental"},
     {"path": "../shadertools"}
   ]
 }

--- a/modules/experimental/src/rendering/deferred-lighting.ts
+++ b/modules/experimental/src/rendering/deferred-lighting.ts
@@ -23,6 +23,9 @@ export type DeferredPointLight = {
 type DeferredLightingUniforms = {
   inverseProjectionMatrix: Readonly<NumberArray16>;
   ambientColor: Readonly<NumberArray3>;
+  exposure: number;
+  fogColor: Readonly<NumberArray3>;
+  fogDensity: number;
   directionalLightDirectionView: Readonly<NumberArray3>;
   directionalLightColor: Readonly<NumberArray3>;
   directionalLightIntensity: number;
@@ -84,6 +87,9 @@ const DEFERRED_LIGHTING_MAX_POINT_LIGHTS: u32 = ${MAX_DEFERRED_POINT_LIGHTS}u;
 struct DeferredLightingUniforms {
   inverseProjectionMatrix: mat4x4f,
   ambientColor: vec3f,
+  exposure: f32,
+  fogColor: vec3f,
+  fogDensity: f32,
   directionalLightDirectionView: vec3f,
   directionalLightColor: vec3f,
   directionalLightIntensity: f32,
@@ -102,7 +108,7 @@ struct DeferredPointLight {
 @group(0) @binding(auto) var normalTextureSampler: sampler;
 @group(0) @binding(auto) var baseColorMetallicTexture: texture_2d<f32>;
 @group(0) @binding(auto) var baseColorMetallicTextureSampler: sampler;
-@group(0) @binding(auto) var emissiveOcclusionTexture: texture_2d<u32>;
+@group(0) @binding(auto) var emissiveOcclusionTexture: texture_2d<f32>;
 @group(0) @binding(auto) var<storage, read> pointLights: array<DeferredPointLight>;
 
 fn deferredLighting_reconstructViewPosition(uv: vec2f, depth: f32) -> vec3f {
@@ -194,9 +200,7 @@ fn deferredLighting_sampleColor(
   let emissiveOcclusionCoordinates = vec2i(
     clamp(sceneCoord * texSize, vec2f(0.0), texSize - vec2f(1.0))
   );
-  let emissiveOcclusion = vec4f(
-    textureLoad(emissiveOcclusionTexture, emissiveOcclusionCoordinates, 0)
-  ) / 255.0;
+  let emissiveOcclusion = textureLoad(emissiveOcclusionTexture, emissiveOcclusionCoordinates, 0);
   let emissive = max(emissiveOcclusion.rgb, vec3f(0.0));
   let occlusion = clamp(emissiveOcclusion.a, 0.0, 1.0);
   let viewPosition = deferredLighting_reconstructViewPosition(sceneCoord, depth);
@@ -240,6 +244,11 @@ fn deferredLighting_sampleColor(
     );
   }
 
+  let cameraDistance = length(viewPosition);
+  let fogAmount = 1.0 - exp(-cameraDistance * cameraDistance * deferredLighting.fogDensity);
+  color = mix(color, deferredLighting.fogColor, clamp(fogAmount, 0.0, 0.93));
+  color *= deferredLighting.exposure;
+
   return vec4f(color, 1.0);
 }`,
   bindingLayout: [
@@ -255,6 +264,9 @@ fn deferredLighting_sampleColor(
   uniformTypes: {
     inverseProjectionMatrix: 'mat4x4<f32>',
     ambientColor: 'vec3<f32>',
+    exposure: 'f32',
+    fogColor: 'vec3<f32>',
+    fogDensity: 'f32',
     directionalLightDirectionView: 'vec3<f32>',
     directionalLightColor: 'vec3<f32>',
     directionalLightIntensity: 'f32',
@@ -263,6 +275,9 @@ fn deferredLighting_sampleColor(
   propTypes: {
     inverseProjectionMatrix: {value: IDENTITY_MATRIX, private: true},
     ambientColor: {value: [0.04, 0.04, 0.05], private: true},
+    exposure: {value: 1, min: 0, softMax: 4},
+    fogColor: {value: [0.025, 0.035, 0.075], private: true},
+    fogDensity: {value: 0, min: 0, softMax: 0.01},
     directionalLightDirectionView: {value: [0.3, 0.75, 0.55], private: true},
     directionalLightColor: {value: [1, 0.95, 0.86], private: true},
     directionalLightIntensity: {value: 2.5, min: 0, softMax: 8},

--- a/modules/experimental/test/rendering/deferred-lighting.spec.ts
+++ b/modules/experimental/test/rendering/deferred-lighting.spec.ts
@@ -121,7 +121,7 @@ test('deferred lighting resolves G-buffer material attachments on WebGPU', async
   });
   const emissiveOcclusionTexture = device.createTexture({
     id: 'deferred-lighting-emissive-occlusion',
-    format: 'rgba8uint',
+    format: 'rgba16float',
     width,
     height,
     usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_DST
@@ -166,7 +166,7 @@ test('deferred lighting resolves G-buffer material attachments on WebGPU', async
         new Float32Array([0.01, 0.01, 0.01, 1]),
         new Float32Array([0.5, 0.5, 1, 0.4]),
         new Float32Array([0.72, 0.12, 0.08, 0.35]),
-        new Float32Array([5, 3, 0, 255])
+        new Float32Array([5, 3, 0, 1])
       ],
       clearDepth: 0.5
     });
@@ -185,6 +185,9 @@ test('deferred lighting resolves G-buffer material attachments on WebGPU', async
         deferredLighting: {
           inverseProjectionMatrix: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
           ambientColor: [0.04, 0.04, 0.05],
+          exposure: 1,
+          fogColor: [0.025, 0.035, 0.075],
+          fogDensity: 0,
           directionalLightDirectionView: [0.2, 0.7, -0.5],
           directionalLightColor: [1, 0.95, 0.9],
           directionalLightIntensity: 2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4633,6 +4633,7 @@ __metadata:
     "@luma.gl/core": ~9.4.0-alpha.2
     "@luma.gl/effects": ~9.4.0-alpha.2
     "@luma.gl/engine": ~9.4.0-alpha.2
+    "@luma.gl/experimental": ~9.4.0-alpha.2
     "@luma.gl/shadertools": ~9.4.0-alpha.2
   languageName: unknown
   linkType: soft
@@ -16611,6 +16612,7 @@ __metadata:
     "@luma.gl/core": "npm:9.4.0-alpha.2"
     "@luma.gl/effects": "npm:9.4.0-alpha.2"
     "@luma.gl/engine": "npm:9.4.0-alpha.2"
+    "@luma.gl/experimental": "npm:9.4.0-alpha.2"
     "@luma.gl/shadertools": "npm:9.4.0-alpha.2"
     "@luma.gl/webgl": "npm:9.4.0-alpha.2"
     "@luma.gl/webgpu": "npm:9.4.0-alpha.2"


### PR DESCRIPTION
## Goals

- Add a formal alternate renderer runtime path for the private ANARI module.
- Provide a first WebGPU-only deferred renderer using the experimental G-buffer and deferred lighting primitives.

## Changes

- Adds `deferred` as an ANARI renderer subtype and routes frames to forward or deferred runtimes.
- Adds a deferred ANARI runtime that writes surfaces into a five-target G-buffer and resolves direct PBR lighting.
- Reuses forward-runtime scene traversal, generated geometry, transform uploads, material uniforms, and texture bindings.
- Documents the deferred renderer and current limitations across the ANARI reference and guide.
- Adds WebGPU coverage for `newRenderer("deferred")`.

## Verification

- `env -u YARN_NO_PROXY yarn install --mode=skip-build`
- `env -u YARN_NO_PROXY yarn lint fix`
- `env -u YARN_NO_PROXY yarn build`
- `env -u YARN_NO_PROXY yarn test-headless modules/anari/test/anari-renderer.spec.ts`
- Commit hook: lint and `test-node` passed.

## Notes

- Full `yarn test-headless` still has an unrelated existing failure in `modules/arrow-layers/test/layers/arrow-layers.spec.ts` for `arrow-polygons-storage-test has drawable storage-backed instances`.
- The new deferred renderer is WebGPU-only and intentionally does not yet include clustered lights, GTAO, SSGI, SSR, bloom, or velocity history.
