### PR TITLE
docs(fp64): explain GPU precision techniques and WGSL limits

### DIFF
--- a/docs/api-guide/shaders/README.md
+++ b/docs/api-guide/shaders/README.md
@@ -14,6 +14,7 @@ inputs, and run it through the engine APIs.
 | How does luma.gl combine application source with reusable shader code? | [Shader Assembly](/docs/api-guide/shaders/shader-assembly) | [`ShaderAssembler`](/docs/api-reference/shadertools/shader-assembler), [`ShaderModule`](/docs/api-reference/shadertools/shader-module), [`ShaderPlugin`](/docs/api-reference/shadertools/shader-plugin) |
 | How do I let optional features customize a base shader without copying it? | [Writing Customizable Shaders](/docs/api-guide/shaders/writing-customizable-shaders) | [`ShaderPlugin`](/docs/api-reference/shadertools/shader-plugin), [`ShaderAssembler`](/docs/api-reference/shadertools/shader-assembler) |
 | How do I keep one rendering feature available on WebGPU and WebGL 2? | [Writing Portable Shaders](/docs/api-guide/shaders/writing-portable-shaders) | [`Model`](/docs/api-reference/engine/model), [`WGSL Support`](/docs/api-reference/shadertools/wgsl-support) |
+| How do I preserve more than `f32` precision across WebGPU and WebGL 2? | [GPU Floating-Point Precision Techniques](/docs/api-guide/shaders/gpu-floating-point-precision) | [`fp64`](/docs/api-reference/shadertools/shader-modules/fp64), [`fp64arithmetic`](/docs/api-reference/shadertools/shader-modules/fp64-arithmetic) |
 | How do I run image effects or other fullscreen texture stages? | [Shader Passes](/docs/api-guide/shaders/shader-passes) | [`ShaderPass`](/docs/api-reference/shadertools/shader-pass), [`ShaderPassRenderer`](/docs/api-reference/engine/passes/shader-pass-renderer) |
 
 Related reference topics:

--- a/docs/api-guide/shaders/gpu-floating-point-precision.md
+++ b/docs/api-guide/shaders/gpu-floating-point-precision.md
@@ -1,0 +1,347 @@
+import {ShaderLevelDocsTabs} from '@site/src/components/docs/shader-level-docs-tabs';
+
+# GPU Floating-Point Precision Techniques
+
+<ShaderLevelDocsTabs active="gpu-floating-point-precision" />
+
+"fp64" is often used to mean "more precision than `f32`," but the available
+techniques do not all implement the same number system. A pair of `f32` values,
+raw IEEE 754 binary64 bits, fixed-point integers, and native 64-bit floating
+point have different precision, range, rounding, and portability guarantees.
+
+That distinction matters on WebGPU. Classic double-single arithmetic can be
+fast, but its correctness depends on individual `f32` rounding points that WGSL
+does not require a compiler to preserve. If a result must be reliable across
+WebGPU implementations, choose a representation and arithmetic contract that
+do not depend on those rounding points, or reduce the problem to a smaller
+exact operation.
+
+## Start With The Required Contract
+
+| Technique | Significant precision | Exponent or range | IEEE binary64 semantics? |
+| --- | --- | --- | --- |
+| Native `f32` | 24 binary digits, about 7 decimal digits | Binary32 | No |
+| Native binary64 | 53 binary digits, about 15–16 decimal digits | Binary64 | Only as guaranteed by the backend |
+| Double-single (`hi + lo`) | Up to about 48 binary digits, about 14 decimal digits in its normal operating range | Essentially binary32 | No |
+| Fixed point | Chosen explicitly | Chosen explicitly | No |
+| Software binary64 | 53 binary digits | Binary64 | Only to the extent implemented |
+
+A double-single value is an *expansion*: two non-overlapping `f32` values whose
+real sum is the represented value. It increases significand precision, not
+exponent range. It also does not automatically reproduce binary64 rounding,
+subnormal, infinity, or NaN behavior.
+
+Before choosing an implementation, answer three questions:
+
+1. Is the problem loss of *relative precision*, loss caused by subtracting two
+   large nearby values, or insufficient exponent range?
+2. Does every intermediate need more precision, or only one boundary operation
+   such as `position - origin`?
+3. Must the GPU agree bit-for-bit with a CPU binary64 operation sequence, or is
+   a numerically accurate result enough?
+
+The cheapest robust solution is usually the narrowest contract that solves the
+actual problem.
+
+## Storage Is Not Arithmetic
+
+Two 32-bit words can store every bit of a binary64 value without loss. That
+only defines a transport format. Addition, multiplication, comparisons,
+rounding, and special values still need implementations.
+
+Likewise, uploading `[high, low]` as two `f32` values does not by itself provide
+double-single arithmetic. Every operation must maintain a suitable expansion,
+and the error-free transforms used to do that need specific floating-point
+evaluation rules.
+
+This gives luma.gl two useful but distinct representations:
+
+- `fp64f32` is a `vec2f` expansion, normally interpreted as `high + low`.
+- `fp64u32` is the canonical high and low words of an IEEE 754 binary64 value.
+
+The first is convenient for expansion arithmetic. The second preserves the
+source value exactly and is suitable for integer-assisted operations.
+
+## How Classic Double-Single Arithmetic Works
+
+The building blocks are *error-free transforms*. They return a rounded result
+and a residual whose real sum equals the exact input operation.
+
+Let `fl(x)` mean that `x` is evaluated as a distinct binary32 operation and
+rounded to nearest. The general addition transform was discovered by Møller
+and later proved and presented by Knuth; it is therefore often called the
+Møller–Knuth `TwoSum` transform:
+
+```text
+s = fl(a + b)
+v = fl(s - a)
+e = fl(fl(a - fl(s - v)) + fl(b - v))
+```
+
+Under its assumptions, `s + e` is exactly equal to the real sum `a + b`.
+Dekker's shorter `FastTwoSum` uses:
+
+```text
+s = fl(a + b)
+e = fl(b - fl(s - a))
+```
+
+The shorter transform additionally requires the operands to be ordered, most
+commonly expressed as `abs(a) >= abs(b)` for binary arithmetic.
+
+For multiplication without a fused multiply-add, Dekker splits each operand
+into shorter components. For binary32, whose precision is 24 bits, a common
+split is:
+
+```text
+c = fl(4097 * a)              // 4097 = 2^12 + 1
+aHigh = fl(c - fl(c - a))
+aLow = fl(a - aHigh)
+```
+
+Products of the components can then recover the product residual. With a
+*genuinely fused* multiply-add, the residual has the much simpler form
+`fma(a, b, -fl(a * b))`.
+
+These exactness statements are conditional. The usual binary proofs assume
+round-to-nearest evaluation, no reassociation or unintended contraction,
+finite intermediates without overflow, and the required handling of tiny
+values. The `4097 * a` split is not safe for every finite `f32`: it can overflow
+even when `a` does not, so a complete implementation must scale large inputs.
+Subnormals or flush-to-zero behavior require similar care. Parentheses alone
+do not establish any of these conditions.
+
+Once `TwoSum`, `FastTwoSum`, and `TwoProd` are available, double-single add and
+multiply combine the high components, accumulate their residuals and the low
+components, then renormalize the result. Division and square root normally use
+an `f32` approximation followed by one or more compensated corrections.
+
+## Why This Is Fragile In WGSL And Metal
+
+An error-free transform is an algorithm over *rounding events*, not an
+algebraic identity. For example, the low term in `TwoSum` is algebraically zero
+over the real numbers. A compiler that reassociates the expression is therefore
+allowed to erase the information the algorithm was designed to recover.
+
+The [WGSL floating-point evaluation
+rules](https://www.w3.org/TR/WGSL/#floating-point-evaluation) permit
+reassociation and fusion, and do not specify a single rounding direction for
+all floating-point evaluation. WGSL's
+[`fma`](https://www.w3.org/TR/WGSL/#fma-builtin) also does not provide the
+portable, correctly rounded fused-operation contract that Dekker-style
+`TwoProd` would need.
+
+As a result, these source-level techniques are not portable precision barriers:
+
+- assigning an intermediate to `let` or `var`;
+- adding a runtime zero or multiplying by a runtime one;
+- moving an expression into a helper function;
+- adding parentheses or an identity `bitcast`;
+- spelling the product residual with WGSL `fma`.
+
+They may affect a particular compiler version, but they cannot turn an
+optimization-sensitive transform into a WebGPU guarantee. Native APIs or
+toolchains with a strict floating-point mode can make classic double-single a
+valid backend-specific fast path. WebGPU applications still need a portable
+fallback if correctness depends on it.
+
+## The Main Alternatives
+
+| Approach | Typical cost | Portability | Best fit |
+| --- | --- | --- | --- |
+| Native hardware binary64 | Lowest when supported, sometimes low throughput | Not a portable WGSL feature | Native backends with a strict `f64` contract |
+| Classic double-single | Lower than integer emulation; operation-dependent | Depends on preserved rounding points | Controlled compilers and proven fast paths |
+| Integer-assisted double-single | Higher than classic double-single; implementation-dependent | Robust with specified `u32` operations | Portable expansion add/multiply when about 48 bits are enough |
+| Exact binary64 delta to `f32` | Moderate, fixed integer cost | Robust as result bits; direct `f32` is exact for normal finite results | Large-coordinate origin subtraction |
+| Full software binary64 | High; division, square root, and transcendentals are especially costly | Robust if complete | Binary64 range, special values, or CPU-compatible stepwise semantics |
+| Fixed point | Very low for add; multiply and divide need wide intermediates | Robust | Bounded dynamic range and iterative kernels |
+| CPU preprocessing and origin rebasing | Usually lowest GPU cost | Robust | Rendering and analytics that only need local values on the GPU |
+
+### Origin Rebasing And An Exact Delta
+
+Large-coordinate rendering often does not need general fp64 arithmetic. It
+needs this operation:
+
+```text
+localPosition = round_f32(exact(worldPosition - worldOrigin))
+```
+
+Converting both inputs to `f32` first loses the low bits before cancellation.
+Subtracting their raw binary64 significands and exponents with integer
+operations, then rounding the exact difference once to `f32`, retains them.
+After that boundary operation, transforms, interpolation, and rasterization can
+remain ordinary `f32`.
+
+This is a targeted operation, not a binary64 arithmetic library. It is ideal
+when the output is known to fit in binary32 and later calculations only need
+binary32 precision. It does not help an iterative algorithm that must retain
+extra bits after every addition or multiplication.
+
+There is also a subtle semantic choice. Directly rounding the exact difference
+implements `round_f32(exact(a - b))`. A CPU expression that first performs an
+IEEE binary64 subtraction and then converts to `f32` implements
+`round_f32(round_binary64(a - b))`. Those results normally agree, but double
+rounding means they are not universally identical. If bit-for-bit agreement
+with a particular CPU operation sequence is part of the contract, implement
+that sequence rather than assuming the exact-delta contract is the same one.
+
+The subtraction can instead happen on the CPU when the origin changes
+infrequently. GPU integer subtraction is useful when both values arrive as
+columns of binary64 data, the origin changes frequently, or preprocessing
+would require an unwanted copy.
+
+### Integer-Assisted Double-Single
+
+A middle ground keeps the `high + low` representation while replacing only the
+rounding-sensitive transforms with `u32` arithmetic. Decode each `f32` sign,
+exponent, and significand; align or multiply the integer significands; preserve
+guard, round, and sticky information; then emit a normalized high/low pair.
+
+This is not a bit-at-a-time floating-point emulator. A binary32 significand is
+only 24 bits, so an exact product fits in 48 bits and can be represented by a
+small fixed set of `u32` limbs. It is substantially narrower than full
+software binary64 and can provide deterministic building blocks for expansion
+addition and multiplication.
+
+Its scope should remain explicit. It still has essentially binary32 exponent
+range unless separate exponent state is added. Division, square root, NaNs,
+infinities, signed zero, and subnormal behavior require additional design. It
+also does not make arbitrary existing `vec2f` code safe: all
+rounding-sensitive transforms and renormalization steps in the supported
+operation must use the deterministic path. A low component that becomes an
+`f32` subnormal can still be flushed after packing, so a portable contract
+should exclude such terms or keep them encoded as integer bits.
+
+### Full Software Binary64
+
+A complete implementation stores sign, 11-bit exponent, and 52 fraction bits
+in integer words. Each operation aligns significands, computes with extra
+guard/round/sticky bits, normalizes, rounds, and handles zeros, subnormals,
+infinities, and NaNs.
+
+This is the direct choice when binary64 range and behavior are requirements,
+not merely additional local precision. It is also the software route to
+step-by-step CPU agreement, provided the CPU contract is specified precisely:
+rounding mode, NaN policy, operation order, contraction, and transcendental
+functions all matter. Merely storing binary64 bits is insufficient, and an
+incomplete special-value or rounding implementation is not IEEE binary64.
+
+Software binary64 is expensive, but cost varies by workload. Addition and
+subtraction are much cheaper than division, square root, or correctly rounded
+transcendentals. A small application-specific subset can therefore be
+reasonable even when a general library is not.
+
+### Fixed Point
+
+Fixed point stores an integer `n` and interprets it as `n * 2^-k` (or another
+chosen scale). Addition and subtraction are exact until integer overflow.
+Multiplication needs a wide intermediate followed by an explicit rounding
+shift; division needs an explicitly scaled numerator.
+
+For a bounded domain, fixed point can deliver more useful fractional bits than
+double-single at much lower and more predictable cost. Deep-zoom fractals,
+geometric predicates over a known extent, counters, and reproducible
+accumulations are common fits. The tradeoff is manual range analysis and no
+automatic exponent, NaN, or infinity behavior.
+
+### Native Binary64
+
+Native `f64` is the obvious answer on a backend that supports it with the
+required evaluation controls. It is not currently a portable WGSL/WebGPU
+shader type, and hardware throughput varies widely. Even where native `f64`
+exists, bit-for-bit CPU agreement still requires matching operation order,
+rounding and contraction rules.
+
+## Choosing By Workload
+
+| Workload | Preferred starting point | Reason |
+| --- | --- | --- |
+| World, geospatial, or astronomical coordinates | CPU origin rebasing or exact `fp64u32` delta | Preserves local detail, then returns to fast `f32` |
+| Deep iterative calculation over a bounded interval | Fixed point | Deterministic precision and predictable cost |
+| General arithmetic needing roughly 14 decimal digits | Integer-assisted double-single | More precision without implementing binary64's full range |
+| Binary64 storage or data interchange without arithmetic | Raw `fp64u32` words | Preserves every source bit without paying for software arithmetic |
+| Arithmetic requiring binary64 range and special values | Full software binary64 | The arithmetic semantics, not just the representation, are the requirement |
+| Controlled native GPU backend | Native `f64`, or verified classic double-single | Can use backend guarantees unavailable to portable WGSL |
+| A few high-precision constants followed by ordinary math | CPU preprocessing | Avoids paying an emulation cost per invocation |
+
+Do not choose a representation from the label "fp64." Choose it from the
+failure mode. Origin rebasing cannot repair an iteration that loses bits on
+every step; software binary64 is unnecessary if one exact subtraction produces
+the only value that must reach the shader.
+
+## luma.gl Precision Paths
+
+The [`fp64`](/docs/api-reference/shadertools/shader-modules/fp64) module and its
+low-level
+[`fp64arithmetic`](/docs/api-reference/shadertools/shader-modules/fp64-arithmetic)
+dependency expose the established `fp64f32` expansion path. This path remains
+useful for GLSL and for backends on which its error-free transforms have been
+verified, but its classic floating-point implementation is not a portable
+strict-arithmetic guarantee under WGSL.
+
+WGSL also provides these targeted helpers for `fp64u32` values:
+
+```wgsl
+fn sub_fp64u32_to_f32_bits(aBits: vec2u, bBits: vec2u) -> u32
+fn sub_fp64u32_to_f32(aBits: vec2u, bBits: vec2u) -> f32
+```
+
+The words are in canonical order: `.x` contains the sign, exponent, and high
+fraction bits, and `.y` contains the low fraction bits. The helpers implement
+the exact-delta contract described above, including a single round-to-nearest,
+ties-to-even conversion to a binary32 encoding. The `_bits` helper returns that
+encoding as `u32`, including the module's defined handling of zeros,
+subnormals, infinities, and NaNs. WGSL's relaxed rules for those values mean
+that the direct `f32` helper has a portable exact-value guarantee only for
+normal finite results. Neither helper provides general `fp64u32` addition or
+multiplication.
+
+luma.gl currently does not expose general integer-assisted double-single or
+full software binary64 arithmetic.
+
+## Validation Is Part Of The Technique
+
+Precision code should be tested for its numerical contract, not merely for
+successful shader compilation.
+
+- Compare result bits with an independent, correctly rounded reference. For
+  exact-delta tests, do not use a host expression with a different intermediate
+  rounding contract as the only oracle.
+- Include cancellation, adjacent representable values, half-ULP ties, large
+  exponent gaps, signed zero, the normal/subnormal boundary, underflow,
+  overflow, infinities, and NaNs where the contract includes them.
+- Test precision and range separately. A double-single result can carry many
+  significant bits and still overflow at the binary32 limit.
+- Exercise compute, vertex, and fragment paths that matter to the application.
+  Optimizers and arithmetic lowering can differ by stage.
+- Run on real hardware from multiple vendors, especially the Metal path. A
+  software adapter or a compile-only test cannot demonstrate that residual
+  terms survive execution.
+- Inspect both the high component and a required nonzero low component. A final
+  value can look plausible even after the expansion silently collapses to
+  `f32`.
+- Benchmark the representative shader. Instruction counts alone do not capture
+  register pressure, occupancy, control flow, or driver lowering.
+
+For CPU agreement, first write down the CPU semantics being matched. JavaScript
+`Number` storage is binary64, but an oracle such as `Math.fround(a - b)` includes
+a binary64 arithmetic step before the binary32 conversion. An arbitrary-
+precision integer or rational reference is often clearer for exact-rounding
+tests.
+
+## Further Reading
+
+- [IEEE 754-2019](https://standards.ieee.org/ieee/754/6210/) defines binary
+  floating-point formats and arithmetic.
+- Ole Møller's [*Quasi double-precision in floating point
+  addition*](https://doi.org/10.1007/BF01975722) introduced the general
+  sum-and-roundoff method later associated with Knuth's `TwoSum` presentation.
+- T. J. Dekker's [*A Floating-Point Technique for Extending the Available
+  Precision*](https://eudml.org/doc/132105) develops splitting and expansion
+  arithmetic.
+- Jonathan Shewchuk's [*Adaptive Precision Floating-Point Arithmetic and Fast
+  Robust Geometric Predicates*](https://people.eecs.berkeley.edu/~jrs/papers/robustr.pdf)
+  is a practical treatment of expansions and exact predicates.
+- Berkeley [SoftFloat](https://www.jhauser.us/arithmetic/SoftFloat-3/doc/SoftFloat.html)
+  illustrates the scope of a complete software IEEE floating-point
+  implementation.

--- a/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
@@ -9,6 +9,10 @@ arithmetic used by [`fp64`](/docs/api-reference/shadertools/shader-modules/fp64)
 Use it directly when you only need the arithmetic primitives and want to avoid
 including the full `fp64` function library.
 
+See [GPU Floating-Point Precision Techniques](/docs/api-guide/shaders/gpu-floating-point-precision)
+for the numerical guarantees and tradeoffs of double-single, raw binary64,
+fixed-point, and integer-assisted approaches.
+
 ## Uniforms
 
 ```ts

--- a/docs/api-reference/shadertools/shader-modules/fp64.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64.md
@@ -26,17 +26,22 @@ The side-by-side Mandelbrot views show where fp32 loses detail as the animated z
 
 ## Precision
 
-WebGL does not expose native 64-bit floating point number support of
-modern desktop GPUs to developers. As an alternative, this module uses
-two 32-bit native floating point number to extend and preserve significant
-digits and uses algorithms similar to those used in many multiple precision
-math libraries to achieve precision close to what IEEE-754 double precision
-floating point numbers provide. Generally speaking, this mechanism provide
-46 significant digits in mantissa (48 overall) within the normal range of
-32-bit single precision float point numbers. This transfers to ~ `1x10^-15`
-relative error within ~ `1.2x10^-38` and `1.7x10^+38`.
+WebGL and portable WGSL do not expose native 64-bit floating-point arithmetic.
+As an alternative, this module represents a value as the unevaluated sum of
+two 32-bit floating-point terms. This double-single representation can provide
+up to roughly 48 significant **bits**, or about 14 decimal digits, while
+remaining within the exponent range of `f32`. It is not IEEE 754 binary64,
+which has 53 significant bits and a much larger exponent range.
 
-The error bound as tested on 2015 MacBook Pro with AMD Radeon R9 M370X GPU:
+The classic double-single algorithms depend on specific intermediate rounding
+points. Standard WGSL permits floating-point reassociation and fusion, so the
+precision of this path is backend-dependent on WebGPU. See
+[GPU Floating-Point Precision Techniques](/docs/api-guide/shaders/gpu-floating-point-precision)
+for a comparison with binary64, integer-assisted arithmetic, fixed point, and
+exact origin-relative subtraction.
+
+Historical WebGL testing on a 2015 MacBook Pro with an AMD Radeon R9 M370X
+measured these error bounds:
 
 ```
 Addition and subtraction: < 1 ulp
@@ -48,12 +53,12 @@ Logarithm: ~11.6 ulps (depends on the accuracy of native log() function)
 Trigonometry: ~5 ulps
 ```
 
-Note: `ulp` = [unit of least precision](https://en.wikipedia.org/wiki/Unit_in_the_last_place)
+Note: `ulp` = [unit in the last place](https://en.wikipedia.org/wiki/Unit_in_the_last_place)
 
 ## Performance Implications
 
-Since 64-bit floating point math is emulated using the multiple precision
-arithmetic, it costs significantly more GPU cycles than native 32-bit math
+Since extended-precision floating-point math is emulated using multiple
+operations, it costs significantly more GPU cycles than native 32-bit math
 (more than an order of magnitude, not to mention the non-IEEE compliant
 "fast-math" functions that most GPUs use to trade accuracy for speed).
 
@@ -65,10 +70,10 @@ For many applications, the amount of time spent in e.g.
 the vertex shading stage is only part of the time spent in the whole the
 rendering pipeline.
 
-There will be a memory impact too, in that all vertex attributes and uniform data
-that uses 64-bit maths require double storage space in JavaScirpt. Same as mentioned
-above, since a layer usually has some attributes that do not require 64-bit maths,the
-total memory impact normally be somewhat less than 2x.
+There is also a memory impact: vertex attributes and uniform data that use
+double-single values require two `f32` terms. Since a layer usually has other
+attributes that do not require extended precision, the total memory impact is
+normally less than 2x.
 
 ## References
 

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -80,6 +80,7 @@
           "api-guide/shaders/shader-assembly",
           "api-guide/shaders/writing-customizable-shaders",
           "api-guide/shaders/writing-portable-shaders",
+          "api-guide/shaders/gpu-floating-point-precision",
           "api-guide/shaders/shader-passes",
           "api-guide/shaders/rendering-techniques",
           "api-guide/shaders/transparency",

--- a/website/content/examples/experimental/fp64.mdx
+++ b/website/content/examples/experimental/fp64.mdx
@@ -13,8 +13,12 @@ import {FP64Example} from '@site/src/examples';
       `@luma.gl/shadertools`.
     </div>
     <div style={{marginBottom: 12}}>
-      Note that fp64 support in shaders relies on some unspecified behavior and is thus GPU dependent. 
-      In particular, Apple GPUs are hard to support.
+      The double-single arithmetic used here depends on intermediate rounding behavior that portable
+      WGSL does not guarantee, so results are GPU-dependent. See the{' '}
+      <a href="/docs/api-guide/shaders/gpu-floating-point-precision">
+        GPU floating-point precision guide
+      </a>{' '}
+      for robust alternatives, including fixed point and integer arithmetic.
     </div>
   </div>
 </ExampleHeader>

--- a/website/src/components/docs/shader-level-docs-tabs.tsx
+++ b/website/src/components/docs/shader-level-docs-tabs.tsx
@@ -16,6 +16,7 @@ export type ShaderLevelDocsTabId =
   | 'shader-assembly'
   | 'writing-portable-shaders'
   | 'writing-customizable-shaders'
+  | 'gpu-floating-point-precision'
   | 'shader-passes'
   | 'rendering-techniques'
   | 'transparency'
@@ -37,6 +38,11 @@ const SHADER_LEVEL_DOCS_TABS: ShaderLevelDocsTab[] = [
     id: 'writing-portable-shaders',
     label: 'Portable Shaders',
     href: '/docs/api-guide/shaders/writing-portable-shaders'
+  },
+  {
+    id: 'gpu-floating-point-precision',
+    label: 'GPU Precision',
+    href: '/docs/api-guide/shaders/gpu-floating-point-precision'
   },
   {id: 'shader-passes', label: 'Shader Passes', href: '/docs/api-guide/shaders/shader-passes'},
   {


### PR DESCRIPTION
## Summary

- Add a shader guide comparing native binary64, Dekker/Møller/Knuth double-single arithmetic, integer-assisted double-single, exact binary64-to-f32 deltas, fixed point, and full software binary64.
- Explain why classic error-free transforms are not portable under WGSL's floating-point evaluation contract.
- Distinguish `fp64f32` expansion arithmetic from raw `fp64u32` binary64 storage and document the existing exact-delta helpers.
- Add the guide to shader navigation and link it from the fp64 references and example.
- Correct the fp64 reference from “significant digits” to roughly 48 significant bits (about 14 decimal digits), while making the binary32 exponent-range limitation explicit.

## Why

The existing documentation used “fp64” for several different numerical contracts and did not clearly explain why optimizer-barrier workarounds can fail on WebGPU/Metal. WGSL permits reassociation and fusion and does not guarantee the intermediate rounding events required by classic double-single error-free transforms.

This PR documents the resulting design boundary and the robust alternatives. It does not change shader runtime behavior; implementation changes can follow independently with explicit numerical contracts and benchmarks.

## Impact

Users can select the least expensive technique that matches their actual requirement—for example, origin-relative subtraction for large-world rendering, fixed point for bounded iterative kernels, or software binary64 when binary64 semantics are truly required.

## Validation

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn website:build`
- Pre-commit `test-fast`: 62 test files passed, 2 skipped; 251 tests passed, 2 skipped
