### PR TITLE
Highlight AI coding-agent support in v10 release notes

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -6,6 +6,12 @@ _This page contains news for recent luma.gl releases. For older releases (throug
 
 Target Release Date: Q3, 2026
 
+**AI-Assisted Development**
+
+- **Official `lumagl` Agent Skill** - luma.gl now ships an installable skill that teaches coding agents the framework architecture, WebGPU/WebGL portability boundaries, GPU debugging order, and contribution workflow.
+- **Agent-ready documentation** - [`llms.txt`](https://luma.gl/llms.txt) and page-level Markdown give agents fresh, linkable access to tutorials, API guides, API references, and developer guides instead of relying on stale training data.
+- **Evidence-driven agent workflows** - Browser-backed verification helps agents prove that generated GPU code actually renders instead of merely typechecking, while a checked-in evaluation corpus supports repeatable comparisons with and without the skill. See [Working with AI Coding Agents](/docs/developer-guide/working-with-ai).
+
 **New Modules**
 
 - **`@luma.gl/tables`** - Generic GPU table/runtime, planning, transform, and compute helpers.


### PR DESCRIPTION
## Summary

- Add a prominent **AI-Assisted Development** section to the v10 release notes.
- Highlight the official `lumagl` Agent Skill, agent-ready documentation, and evidence-driven verification and evaluation workflows in separate, scannable bullets.
- Link readers to the full **Working with AI Coding Agents** guide.

## Why

PR #2764 added first-class LLM and coding-agent support, but the v10 release notes did not advertise it. This makes the new capability visible and gives each part of the support story its own headline.

## Developer impact

Developers can quickly discover how to install the framework skill, give agents current luma.gl documentation, and require browser-backed evidence that generated GPU code renders correctly.

## Verification

- `yarn install` — passed with existing peer-dependency warnings.
- `yarn lint fix` — passed; no fixes required.
- Pre-commit node tests — 63 files passed, 2 skipped; 253 tests passed, 2 skipped.
- `git diff --check` — passed.
- `yarn website:build` — not completed locally: the server bundle compiled, but the client build was stopped after an extended stall, so CI remains the site-build verification.