### PR TITLE
Clarify GPU trace filtering terminology

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -28,6 +28,10 @@ import {
   TRACE_COLLAPSED_STATE,
   TRACE_DURATION,
   TRACE_EXPANDED_STATE,
+  TRACE_FILTER_ERRORS_ONLY,
+  TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN,
+  TRACE_FILTER_HIDE_RUNTIME_SPANS,
+  TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS,
   TRACE_GROUPS,
   TRACE_INVALID_SPAN_INDEX,
   TRACE_LANE_COUNT,
@@ -137,7 +141,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   private enabledMask = 0b111;
   private statusMask = (1 << TRACE_STATUS_COUNT) - 1;
   private dependencyMask = 0b11;
-  private filterFlags = 0;
+  /** Enabled filtering policy; immutable source classifications remain in each span record. */
+  private activeFilterMask = 0;
   private minimumDuration = 0;
   private selectedSpanIndex = INVALID_SPAN_INDEX;
   private focusOnly = false;
@@ -780,7 +785,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     floats[3] = this.view.laneMax;
     unsigned[4] = this.enabledMask;
     unsigned[5] = this.statusMask;
-    unsigned[6] = this.filterFlags;
+    unsigned[6] = this.activeFilterMask;
     unsigned[7] = this.dependencyMask;
     floats[8] = this.minimumDuration;
     floats[9] = width;
@@ -1006,16 +1011,32 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
           label.textContent = `${this.minimumDuration.toFixed(2)} ms`;
         }
       } else if (target instanceof HTMLInputElement && target.matches('[data-hide-runtime]')) {
-        this.filterFlags = setBit(this.filterFlags, 0, target.checked);
+        this.activeFilterMask = setMaskFlag(
+          this.activeFilterMask,
+          TRACE_FILTER_HIDE_RUNTIME_SPANS,
+          target.checked
+        );
       } else if (target instanceof HTMLInputElement && target.matches('[data-errors-only]')) {
-        this.filterFlags = setBit(this.filterFlags, 1, target.checked);
+        this.activeFilterMask = setMaskFlag(
+          this.activeFilterMask,
+          TRACE_FILTER_ERRORS_ONLY,
+          target.checked
+        );
       } else if (target instanceof HTMLInputElement && target.matches('[data-hide-overlapping]')) {
-        this.filterFlags = setBit(this.filterFlags, 2, target.checked);
+        this.activeFilterMask = setMaskFlag(
+          this.activeFilterMask,
+          TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN,
+          target.checked
+        );
       } else if (
         target instanceof HTMLInputElement &&
         target.matches('[data-hide-similar-parents]')
       ) {
-        this.filterFlags = setBit(this.filterFlags, 3, target.checked);
+        this.activeFilterMask = setMaskFlag(
+          this.activeFilterMask,
+          TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS,
+          target.checked
+        );
       } else if (target instanceof HTMLInputElement && target.matches('[data-same-dependencies]')) {
         this.dependencyMask = setBit(this.dependencyMask, 0, target.checked);
       } else if (
@@ -1347,6 +1368,10 @@ function makeTraceBlendParameters() {
 
 function setBit(mask: number, bitIndex: number, enabled: boolean): number {
   return enabled ? mask | (1 << bitIndex) : mask & ~(1 << bitIndex);
+}
+
+function setMaskFlag(mask: number, flag: number, enabled: boolean): number {
+  return enabled ? mask | flag : mask & ~flag;
 }
 
 function clamp(value: number, minimum: number, maximum: number): number {

--- a/examples/experimental/gpu-trace-viewer/trace-data.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-data.ts
@@ -20,6 +20,11 @@ export const TRACE_RUNTIME_SPAN_FLAG = 1 << 8;
 export const TRACE_ERROR_SPAN_FLAG = 1 << 9;
 export const TRACE_OVERLAPPING_CHILD_FLAG = 1 << 10;
 export const TRACE_SIMILAR_DURATION_PARENT_FLAG = 1 << 11;
+/** Active filtering policy bits uploaded independently from immutable source span flags. */
+export const TRACE_FILTER_HIDE_RUNTIME_SPANS = 1 << 0;
+export const TRACE_FILTER_ERRORS_ONLY = 1 << 1;
+export const TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN = 1 << 2;
+export const TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS = 1 << 3;
 export const TRACE_MAXIMUM_OVERLAPPING_CHILD_DURATION = 1;
 export const TRACE_MAXIMUM_RELATIVE_PARENT_DURATION_DELTA = 0.25;
 export const TRACE_COLLAPSED_STATE = 0;

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -5,6 +5,10 @@
 import {
   TRACE_ACTIVITY_BIN_COUNT,
   TRACE_ERROR_SPAN_FLAG,
+  TRACE_FILTER_ERRORS_ONLY,
+  TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN,
+  TRACE_FILTER_HIDE_RUNTIME_SPANS,
+  TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS,
   TRACE_LANES_PER_THREAD,
   TRACE_OVERLAPPING_CHILD_FLAG,
   TRACE_RUNTIME_SPAN_FLAG,
@@ -23,6 +27,7 @@ struct TraceSpan {
   processIndex: u32,
   threadIndex: u32,
   sourceIndex: u32,
+  // Immutable classifications assigned when the source span is ingested.
   flags: u32,
 };
 
@@ -40,7 +45,8 @@ struct ViewUniforms {
   laneMax: f32,
   enabledMask: u32,
   statusMask: u32,
-  filterFlags: u32,
+  // Enabled filtering policy applied to the immutable source classifications.
+  activeFilterMask: u32,
   dependencyMask: u32,
   minimumDuration: f32,
   viewportWidth: f32,
@@ -310,13 +316,17 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let processVisible = processStates[span.processIndex] != 0u;
   let statusVisible = (viewUniforms.statusMask & (1u << (span.flags & 3u))) != 0u;
   let runtimeVisible =
-    (viewUniforms.filterFlags & 1u) == 0u || (span.flags & RUNTIME_SPAN_FLAG) == 0u;
+    (viewUniforms.activeFilterMask & ${TRACE_FILTER_HIDE_RUNTIME_SPANS}u) == 0u ||
+    (span.flags & RUNTIME_SPAN_FLAG) == 0u;
   let errorVisible =
-    (viewUniforms.filterFlags & 2u) == 0u || (span.flags & ERROR_SPAN_FLAG) != 0u;
+    (viewUniforms.activeFilterMask & ${TRACE_FILTER_ERRORS_ONLY}u) == 0u ||
+    (span.flags & ERROR_SPAN_FLAG) != 0u;
   let overlappingChildVisible =
-    (viewUniforms.filterFlags & 4u) == 0u || (span.flags & OVERLAPPING_CHILD_FLAG) == 0u;
+    (viewUniforms.activeFilterMask & ${TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN}u) == 0u ||
+    (span.flags & OVERLAPPING_CHILD_FLAG) == 0u;
   let similarParentVisible =
-    (viewUniforms.filterFlags & 8u) == 0u || (span.flags & SIMILAR_DURATION_PARENT_FLAG) == 0u;
+    (viewUniforms.activeFilterMask & ${TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS}u) == 0u ||
+    (span.flags & SIMILAR_DURATION_PARENT_FLAG) == 0u;
   let durationVisible = span.duration >= viewUniforms.minimumDuration;
   let visible = timeVisible && laneVisible && groupVisible && processVisible &&
     statusVisible && runtimeVisible && errorVisible && overlappingChildVisible &&

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -8,6 +8,8 @@ import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import GPUTraceViewerAnimationLoopTemplate from '../../examples/experimental/gpu-trace-viewer/app';
 import {
   TRACE_COLLAPSED_STATE,
+  TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN,
+  TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS,
   TRACE_PROCESS_COUNT,
   TRACE_THREAD_COUNT
 } from '../../examples/experimental/gpu-trace-viewer/trace-data';
@@ -50,7 +52,7 @@ describe('GPU hierarchical trace viewer', () => {
         selectedSpanIndex: number;
         focusDepth: number;
         focusOnly: boolean;
-        filterFlags: number;
+        activeFilterMask: number;
       };
       expect(state.resources.spanCount).toBe(4096);
       expect(state.resources.dependencyCount).toBeGreaterThan(0);
@@ -96,7 +98,9 @@ describe('GPU hierarchical trace viewer', () => {
       expect(hideOverlapping).not.toBeNull();
       hideOverlapping!.checked = true;
       hideOverlapping!.dispatchEvent(new Event('change', {bubbles: true}));
-      expect(state.filterFlags & 4).toBe(4);
+      expect(state.activeFilterMask & TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN).toBe(
+        TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN
+      );
 
       const hideSimilarParents = host.querySelector<HTMLInputElement>(
         '[data-hide-similar-parents]'
@@ -104,7 +108,9 @@ describe('GPU hierarchical trace viewer', () => {
       expect(hideSimilarParents).not.toBeNull();
       hideSimilarParents!.checked = true;
       hideSimilarParents!.dispatchEvent(new Event('change', {bubbles: true}));
-      expect(state.filterFlags & 8).toBe(8);
+      expect(state.activeFilterMask & TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS).toBe(
+        TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS
+      );
 
       const focusDepth = host.querySelector<HTMLInputElement>('[data-focus-depth]');
       expect(focusDepth).not.toBeNull();


### PR DESCRIPTION
## What changed

- Rename the trace viewer's global `filterFlags` control to `activeFilterMask`.
- Add shared named constants for the four active filtering policies.
- Use those constants in both TypeScript UI state and generated WGSL.
- Clarify that `span.flags` contains immutable source classifications while `activeFilterMask` controls enabled filtering policy.

## Why

The previous `filterFlags` name implied a source-aligned per-span column, even though it is a small global control mask. The new terminology makes the CPU-authored policy distinct from immutable span classifications and GPU-generated visibility masks, without changing uniform layout or filtering behavior.

## Validation

- `nvm use` — Node 22.22.1
- Targeted GPU trace viewer build — passed
- `yarn lint fix` — passed, no fixes required
- `yarn build` — passed
- Node tests — 251 passed, 2 skipped
- `yarn test-headless` — unable to start tests because Playwright Chromium aborted during launch with `SIGABRT`; a direct retry reproduced the same `kill EPERM` environment failure
