### PR TITLE
fix(showcase): tune packet glass reflections

### DIFF
--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -640,6 +640,11 @@ const MAX_SWITCH_FLASH_LIGHTS = 6;
 const MAX_SWITCH_TRANSITION_WAVES = 12;
 const MAX_ENDPOINT_SIGNALS = CONVERSATIONS.length * 2;
 const MAX_STORY_PACKET_INSTANCES = 160;
+const REFLECTION_LAB_SWITCH_INDEX = 0;
+const REFLECTION_LAB_SPHERE_POSITION: Vector3 = [0, 0, 0];
+const REFLECTION_LAB_SPHERE_RADIUS = 1;
+const REFLECTION_LAB_PACKET_RADIUS = 0.085;
+const REFLECTION_LAB_PACKET_COLOR: Color = [1, 0.04, 0.025, 0.9];
 const NETWORK_PLANE_HIGHLIGHT_ATTACK = 2.9;
 const NETWORK_PLANE_HIGHLIGHT_DECAY = 2.25;
 const CONGESTED_SWITCH_COLOR: Color = [1, 0.42, 0.065, 0.56];
@@ -1967,6 +1972,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     'highlightBoost' | 'visualIntensity'
   >;
   private dynamicRangeProfile: NetworkDynamicRangeProfile;
+  private readonly reflectionLab: boolean;
 
   transparencyMode: TransparencyMode;
   visualIntensity = DEFAULT_NETWORK_OPTICS_LEVEL;
@@ -2018,7 +2024,9 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   constructor({device, width, height}: AnimationProps) {
     super();
 
-    const requestedOrbit = new URLSearchParams(window.location.search).get('orbit');
+    const searchParams = new URLSearchParams(window.location.search);
+    this.reflectionLab = searchParams.get('lab') === 'reflection';
+    const requestedOrbit = searchParams.get('orbit');
     if (requestedOrbit !== null && Number.isFinite(Number(requestedOrbit))) {
       this.orbit = Math.max(0, Math.min(Number(requestedOrbit), 0.5));
     }
@@ -2089,8 +2097,12 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.links = new InstancedMesh(device, this.reflectiveShaderInputs, {
       id: 'packet-spraying-links',
       geometry: new CylinderGeometry({radius: 1, height: 1, nradial: 16, nvertical: 1}),
-      matrices: flattenMatrices(this.networkLinks.map(link => makeLinkMatrix(link, 0.09))),
-      colors: this.linkColors,
+      matrices: this.reflectionLab
+        ? makeHiddenMatrices(this.networkLinks.length)
+        : flattenMatrices(this.networkLinks.map(link => makeLinkMatrix(link, 0.09))),
+      colors: this.reflectionLab
+        ? makeTransparentColors(this.networkLinks.length)
+        : this.linkColors,
       transparent: true,
       reflective: true
     });
@@ -2098,14 +2110,20 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.hosts = new InstancedMesh(device, this.metallicShaderInputs, {
       id: 'packet-spraying-hosts',
       geometry: new CubeGeometry({indices: true}),
-      matrices: flattenMatrices(
-        HOST_POSITIONS.map(position => makeObjectMatrix(position, HOST_HALF_EXTENTS))
-      ),
-      colors: flattenColors(HOST_POSITIONS.map((_, hostIndex) => makeHostColor(hostIndex))),
+      matrices: this.reflectionLab
+        ? makeReflectionLabHostMatrices()
+        : flattenMatrices(
+            HOST_POSITIONS.map(position => makeObjectMatrix(position, HOST_HALF_EXTENTS))
+          ),
+      colors: this.reflectionLab
+        ? makeReflectionLabHostColors()
+        : flattenColors(HOST_POSITIONS.map((_, hostIndex) => makeHostColor(hostIndex))),
       reflective: true
     });
 
-    this.glassInstances = makeGlassInstances();
+    this.glassInstances = this.reflectionLab
+      ? makeReflectionLabGlassInstances()
+      : makeGlassInstances();
     this.originalGlassColors = this.glassInstances.map(instance => [...instance.color] as Color);
     this.pickableNodes = makePickableNetworkNodes();
     this.pickingManager = new PickingManager(device, {
@@ -2217,9 +2235,16 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       id: 'packet-spraying-packets',
       geometry: new SphereGeometry({radius: 1, nlat: 8, nlong: 12}),
       matrices: this.packetMatrices,
-      colors: flattenColors(
-        this.packetDefinitions.map(packet => makeBalancedEmissionColor(packet.color, packet.alpha))
-      ),
+      colors: this.reflectionLab
+        ? makeReflectionLabPacketColors(
+            this.packetDefinitions.length,
+            REFLECTION_LAB_PACKET_COLOR[3]
+          )
+        : flattenColors(
+            this.packetDefinitions.map(packet =>
+              makeBalancedEmissionColor(packet.color, packet.alpha)
+            )
+          ),
       emissive: true
     });
     this.packetTrails = new InstancedMesh(device, this.emissiveShaderInputs, {
@@ -2357,6 +2382,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       canvas.dataset.packetSprayingAdapterVendor = device.info.vendor;
       canvas.dataset.packetSprayingFallback = String(Boolean(device.info.fallback));
       canvas.dataset.packetSprayingDynamicRange = this.dynamicRangeProfile.displayMode;
+      canvas.dataset.packetSprayingLab = this.reflectionLab ? 'reflection' : '';
       canvas.dataset.packetSprayingSceneColorFormat = this.sceneColorFormat;
       canvas.dataset.packetSprayingEnvironmentMipLevels = String(this.environmentTexture.mipLevels);
       canvas.dataset.packetSprayingHighlightBoost =
@@ -2366,11 +2392,11 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       canvas.dataset.packetSprayingGlassGroups = this.glassGroups.map(group => group.id).join(',');
       this.nodePopup = new NetworkNodePopup(canvas);
       this.orbitControls = new OrbitControls(canvas, {
-        target: [0, -0.9, 0],
-        distance: 12.7,
-        yaw: 0.52,
-        pitch: 0.59,
-        minDistance: 6,
+        target: this.reflectionLab ? [0, -0.1, 0] : [0, -0.9, 0],
+        distance: this.reflectionLab ? 4.2 : 12.7,
+        yaw: this.reflectionLab ? 0.58 : 0.52,
+        pitch: this.reflectionLab ? 0.5 : 0.59,
+        minDistance: this.reflectionLab ? 2.4 : 6,
         maxDistance: 25,
         minPitch: 0.12,
         maxPitch: 1.3,
@@ -3723,6 +3749,14 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private updateEndpointSignals(animationTime: number): void {
     this.endpointSignalMatrices.fill(0);
     this.endpointSignalColors.fill(0);
+    if (this.reflectionLab) {
+      this.endpointSignalDefinitions = [];
+      if (this.canvas) {
+        this.canvas.dataset.packetSprayingEndpointSignals = '0';
+      }
+      return;
+    }
+
     const endpointSignalIntensity = this.endpointSignalIntensity * this.opticsProfile.motion;
     this.endpointSignalDefinitions =
       endpointSignalIntensity > 0.005
@@ -3791,6 +3825,13 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private updateLinkPulseVisuals(animationTime: number): void {
     this.linkPulseMatrices.fill(0);
     this.linkPulseColors.fill(0);
+    if (this.reflectionLab) {
+      if (this.canvas) {
+        this.canvas.dataset.packetSprayingLinkPulses = '0';
+      }
+      return;
+    }
+
     const linkPulseIntensity = this.linkPulseIntensity * this.opticsProfile.motion;
     if (linkPulseIntensity <= 0.005 || this.linkPulseLength <= 0) {
       if (this.canvas) {
@@ -3829,6 +3870,13 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private updateSwitchTransitionVisuals(animationTime: number): void {
     this.switchTransitionMatrices.fill(0);
     this.switchTransitionColors.fill(0);
+    if (this.reflectionLab) {
+      if (this.canvas) {
+        this.canvas.dataset.packetSprayingTransitionWaves = '0';
+      }
+      return;
+    }
+
     let activeWaveCount = 0;
 
     for (const wave of this.switchTransitionWaves.slice(0, MAX_SWITCH_TRANSITION_WAVES)) {
@@ -3872,6 +3920,18 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   }
 
   private updateLinkTraffic(animationTime: number): void {
+    if (this.reflectionLab) {
+      this.redLinkTrafficStrengths.fill(0);
+      this.greenLinkTrafficStrengths.fill(0);
+      this.links.updateColors(makeTransparentColors(this.networkLinks.length));
+      this.previousLinkTrafficTime = animationTime;
+      if (this.canvas) {
+        this.canvas.dataset.packetSprayingIlluminatedLinks = '0';
+        this.canvas.dataset.packetSprayingHighlightedPathLinks = '0';
+      }
+      return;
+    }
+
     const trafficByLink = makeLinkTraffic(this.packetDefinitions, animationTime);
     const elapsedTime = Math.min(
       Math.max(animationTime - (this.previousLinkTrafficTime ?? animationTime - 1 / 60), 0),
@@ -4231,9 +4291,56 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     }
   }
 
+  private updateReflectionLabPacketVisuals(animationTime: number): void {
+    fillHiddenMatrices(this.packetMatrices);
+    fillHiddenMatrices(this.packetTrailMatrices);
+    this.packetTrailColors.fill(0);
+    fillHiddenMatrices(this.switchFlashMatrices);
+    this.switchFlashColors.fill(0);
+    fillHiddenMatrices(this.switchRippleMatrices);
+    this.switchRippleColors.fill(0);
+    this.switchRippleAges.fill(Number.POSITIVE_INFINITY);
+    this.switchFlashStrengths.fill(0);
+
+    const packetPosition = getReflectionLabPacketPosition(animationTime);
+    this.packetMatrices.set(
+      makeObjectMatrix(packetPosition, [
+        REFLECTION_LAB_PACKET_RADIUS,
+        REFLECTION_LAB_PACKET_RADIUS,
+        REFLECTION_LAB_PACKET_RADIUS
+      ]),
+      0
+    );
+
+    const previousPacketPosition = getReflectionLabPacketPosition(animationTime - 0.18);
+    const trailColor = makeBalancedEmissionColor(REFLECTION_LAB_PACKET_COLOR, 0.36);
+    this.packetTrailMatrices.set(
+      makeSegmentMatrix(previousPacketPosition, packetPosition, PACKET_TRAIL_RADIUS * 0.72),
+      0
+    );
+    this.packetTrailColors.set(
+      [
+        trailColor[0] * this.packetTrailIntensity * 0.75,
+        trailColor[1] * this.packetTrailIntensity * 0.75,
+        trailColor[2] * this.packetTrailIntensity * 0.75,
+        trailColor[3]
+      ],
+      0
+    );
+
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingSwitchRipples = '0';
+    }
+  }
+
   private updatePacketVisuals(animationTime: number): void {
     this.switchFlashStrengths.fill(0);
     this.switchRippleAges.fill(Number.POSITIVE_INFINITY);
+    if (this.reflectionLab) {
+      this.updateReflectionLabPacketVisuals(animationTime);
+      return;
+    }
+
     const packetTrailIntensity = this.packetTrailIntensity * this.opticsProfile.motion;
     const switchFlashIntensity = this.switchFlashIntensity * this.opticsProfile.motion;
     const switchRippleIntensity = this.switchRippleIntensity * this.opticsProfile.motion;
@@ -4366,6 +4473,22 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   }
 
   private makePacketLights(): OpticalPointLight[] {
+    if (this.reflectionLab) {
+      const packetPosition = getReflectionLabPacketPosition(this.animationTime);
+      return [
+        {
+          position: packetPosition,
+          color: [
+            REFLECTION_LAB_PACKET_COLOR[0],
+            REFLECTION_LAB_PACKET_COLOR[1],
+            REFLECTION_LAB_PACKET_COLOR[2]
+          ],
+          intensity: 1,
+          radius: this.packetLightRadius * 0.92
+        }
+      ];
+    }
+
     if (
       this.packetLightIntensity <= 0 ||
       this.packetLightRadius <= 0 ||
@@ -4977,6 +5100,62 @@ function makeGlassInstances(): GlassInstance[] {
   ];
 }
 
+function makeReflectionLabGlassInstances(): GlassInstance[] {
+  return makeGlassInstances().map((instance, switchIndex) =>
+    switchIndex === REFLECTION_LAB_SWITCH_INDEX
+      ? {
+          position: REFLECTION_LAB_SPHERE_POSITION,
+          matrix: makeObjectMatrix(REFLECTION_LAB_SPHERE_POSITION, [
+            REFLECTION_LAB_SPHERE_RADIUS,
+            REFLECTION_LAB_SPHERE_RADIUS,
+            REFLECTION_LAB_SPHERE_RADIUS
+          ]),
+          color: [0.28, 0.5, 0.92, 0.34]
+        }
+      : {
+          position: instance.position,
+          matrix: makeHiddenMatrix(),
+          color: [0, 0, 0, 0]
+        }
+  );
+}
+
+function makeReflectionLabHostMatrices(): Float32Array {
+  return flattenMatrices(
+    HOST_POSITIONS.map((_, hostIndex) =>
+      hostIndex === 0 ? makeObjectMatrix([0, -1.55, 0.2], [0.45, 0.18, 0.34]) : makeHiddenMatrix()
+    )
+  );
+}
+
+function makeReflectionLabHostColors(): Float32Array {
+  return flattenColors(
+    HOST_POSITIONS.map((_, hostIndex) =>
+      hostIndex === 0 ? ([0.08, 0.18, 0.34, 1] as Color) : ([0, 0, 0, 0] as Color)
+    )
+  );
+}
+
+function makeReflectionLabPacketColors(packetCount: number, alpha: number): Float32Array {
+  return flattenColors(
+    Array.from({length: packetCount}, (_, packetIndex) =>
+      packetIndex === 0
+        ? makeBalancedEmissionColor(REFLECTION_LAB_PACKET_COLOR, alpha)
+        : ([0, 0, 0, 0] as Color)
+    )
+  );
+}
+
+function getReflectionLabPacketPosition(animationTime: number): Vector3 {
+  const progress = wrap(animationTime * 0.18, 1);
+  const easedProgress = progress * progress * (3 - 2 * progress);
+  return [
+    -1.08 + easedProgress * 2.16,
+    -1.04 + easedProgress * 1.92,
+    1.04 + Math.sin(progress * Math.PI * 2) * 0.045
+  ];
+}
+
 function makeBalancedEmissionColor(color: Color, alpha: number): Color {
   const luminance = color[0] * 0.2126 + color[1] * 0.7152 + color[2] * 0.0722;
   const brightnessScale = 0.45 / Math.max(luminance, 0.2);
@@ -5099,6 +5278,25 @@ function makeStudioEnvironmentTexture(device: Device): Texture {
 
 function makeObjectMatrix(position: Vector3, scale: Vector3): Matrix4 {
   return new Matrix4().translate(position).scale(scale);
+}
+
+function makeHiddenMatrix(): Matrix4 {
+  return makeObjectMatrix([0, -100, 0], [0.001, 0.001, 0.001]);
+}
+
+function makeHiddenMatrices(instanceCount: number): Float32Array {
+  return flattenMatrices(Array.from({length: instanceCount}, () => makeHiddenMatrix()));
+}
+
+function fillHiddenMatrices(matrices: Float32Array): void {
+  const hiddenMatrix = makeHiddenMatrix();
+  for (let matrixOffset = 0; matrixOffset < matrices.length; matrixOffset += 16) {
+    matrices.set(hiddenMatrix, matrixOffset);
+  }
+}
+
+function makeTransparentColors(instanceCount: number): Float32Array {
+  return new Float32Array(instanceCount * 4);
 }
 
 function makeLinkMatrix(link: NetworkLink, radius: number): Matrix4 {

--- a/examples/showcase/packet-spraying/app.ts
+++ b/examples/showcase/packet-spraying/app.ts
@@ -1930,6 +1930,10 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   private readonly recoveryProbeCompletionTimes = new Map<number, number>();
   private readonly recoveryProbeConfirmations = new Map<number, NetworkPacketEvent>();
   private animationTime = 0;
+  private rawAnimationTime = 0;
+  private animationTimeOffset = 0;
+  private animationPausedAt: number | null = null;
+  private rawAnimationPausedAt: number | null = null;
   private droppedPacketCount = 0;
   private trimmedPacketCount = 0;
   private pickingInProgress = false;
@@ -2409,6 +2413,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
       canvas.dataset.packetSprayingVisualBloom = this.opticsProfile.bloom.toFixed(2);
       canvas.dataset.packetSprayingVisualCaustics = this.opticsProfile.caustics.toFixed(2);
       canvas.dataset.packetSprayingVisualRefraction = this.opticsProfile.refraction.toFixed(2);
+      canvas.dataset.packetSprayingAnimationPaused = 'false';
+      canvas.dataset.packetSprayingAnimationTime = this.animationTime.toFixed(3);
       this.updateGuidedStoryControls();
       this.updateNetworkTelemetry();
       this.updateFailureAccessibility();
@@ -2422,7 +2428,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
   override onRender({device, width, height, aspect, time}: AnimationProps): void {
     this.resizeSceneFramebuffer(width, height);
     this.updateVisualIntensity(time / 1000);
-    this.animationTime = (time / 1000) * this.speed;
+    this.updateAnimationClock((time / 1000) * this.speed);
     this.updateGuidedStory(this.animationTime);
     this.updateSwitchStoryState(this.animationTime);
     this.updateSwitchPressure(this.animationTime);
@@ -2898,6 +2904,33 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     this.setHighlightedPath(null);
   };
 
+  private updateAnimationClock(rawAnimationTime: number): void {
+    this.rawAnimationTime = rawAnimationTime;
+    this.animationTime = this.animationPausedAt ?? rawAnimationTime - this.animationTimeOffset;
+
+    if (this.canvas) {
+      this.canvas.dataset.packetSprayingAnimationPaused = String(this.animationPausedAt !== null);
+      this.canvas.dataset.packetSprayingAnimationTime = this.animationTime.toFixed(3);
+    }
+  }
+
+  private setAnimationClockPaused(isPaused: boolean): void {
+    if (isPaused) {
+      if (this.animationPausedAt === null) {
+        this.animationPausedAt = this.animationTime;
+        this.rawAnimationPausedAt = this.rawAnimationTime;
+      }
+      return;
+    }
+
+    if (this.animationPausedAt !== null && this.rawAnimationPausedAt !== null) {
+      this.animationTimeOffset += this.rawAnimationTime - this.rawAnimationPausedAt;
+      this.animationTime = this.rawAnimationTime - this.animationTimeOffset;
+    }
+    this.animationPausedAt = null;
+    this.rawAnimationPausedAt = null;
+  }
+
   private setGuidedStoryPlaying(isPlaying: boolean): void {
     if (isPlaying === this.guidedStoryPlaying) {
       return;
@@ -2905,6 +2938,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
 
     this.guidedStoryPlaying = isPlaying;
     if (isPlaying) {
+      this.setAnimationClockPaused(false);
       this.orbitControls?.setAutoRotate(false);
       if (this.guidedStoryStarted) {
         this.guidedStoryChapterStartedAt = this.animationTime - this.guidedStoryElapsedAtPause;
@@ -2915,6 +2949,7 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
     } else {
       this.guidedStoryElapsedAtPause = this.animationTime - this.guidedStoryChapterStartedAt;
       this.guidedStoryCameraTransitionEndsAt = this.animationTime;
+      this.setAnimationClockPaused(true);
       this.orbitControls?.setAutoRotate(this.orbit > 0);
     }
 
@@ -4390,8 +4425,8 @@ export default class PacketSprayingAnimationLoopTemplate extends AnimationLoopTe
         const light = {
           position: candidate.position,
           color: candidate.color,
-          intensity: 0.22 + arrivalResponse * 0.78,
-          radius: this.packetLightRadius * (0.12 + arrivalResponse * 0.34)
+          intensity: 0.28 + arrivalResponse * 0.72,
+          radius: this.packetLightRadius * (0.32 + arrivalResponse * 0.38)
         };
         if (candidateIndex === 0) {
           lights.push(light);

--- a/modules/experimental/src/materials/glass-material.ts
+++ b/modules/experimental/src/materials/glass-material.ts
@@ -257,7 +257,12 @@ fn glassMaterial_getIlluminatedColor(
     cameraPosition,
     fragmentPosition
   );
-  let pointLightColor = opticalPointLights_getColor(normal, worldPosition, cameraPosition);
+  let pointLightColor = opticalPointLights_getSpecularColor(
+    normal,
+    worldPosition,
+    cameraPosition,
+    glassMaterial.roughness
+  );
   return vec4<f32>(
     glassColor.rgb + pointLightColor * glassMaterial.reflectionStrength,
     glassColor.a
@@ -437,6 +442,12 @@ vec4 glassMaterial_getColor(
 
 #ifdef LUMA_OPTICAL_POINT_LIGHTS
 vec3 opticalPointLights_getColor(vec3 normal, vec3 worldPosition, vec3 cameraPosition);
+vec3 opticalPointLights_getSpecularColor(
+  vec3 normal,
+  vec3 worldPosition,
+  vec3 cameraPosition,
+  float roughness
+);
 
 vec4 glassMaterial_getIlluminatedColor(
   vec3 normal,
@@ -452,7 +463,12 @@ vec4 glassMaterial_getIlluminatedColor(
     cameraPosition,
     fragmentPosition
   );
-  vec3 pointLightColor = opticalPointLights_getColor(normal, worldPosition, cameraPosition);
+  vec3 pointLightColor = opticalPointLights_getSpecularColor(
+    normal,
+    worldPosition,
+    cameraPosition,
+    glassMaterial.roughness
+  );
   return vec4(
     glassColor.rgb + pointLightColor * glassMaterial.reflectionStrength,
     glassColor.a

--- a/modules/experimental/src/materials/glass-transmission.ts
+++ b/modules/experimental/src/materials/glass-transmission.ts
@@ -416,7 +416,10 @@ fn glassTransmission_getColor(
   let volumeScattering = baseColor.rgb * (1.0 - exp(-measuredThickness * 1.3)) *
     glassTransmission.volumeScatteringStrength * (0.045 + (1.0 - viewAlignment) * 0.09);
   let reflectionCoordinate = clamp(
-    screenCoordinate + projectedNormal * (0.025 + measuredThickness * 0.018),
+    screenCoordinate + vec2<f32>(
+      dot(reflectionDirection, cameraRight) / viewportAspect,
+      -dot(reflectionDirection, cameraUp)
+    ) * (0.025 + measuredThickness * 0.018),
     vec2<f32>(0.001),
     vec2<f32>(0.999)
   );
@@ -427,9 +430,10 @@ fn glassTransmission_getColor(
     0.0
   ).rgb;
   let reflectedSceneLuminance = dot(reflectedSceneColor, vec3<f32>(0.2126, 0.7152, 0.0722));
-  let reflectedSceneResponse = smoothstep(0.045, 0.9, reflectedSceneLuminance);
+  let reflectedSceneResponse = smoothstep(0.42, 1.4, reflectedSceneLuminance);
+  let grazingReflection = pow(1.0 - viewAlignment, 1.7);
   let dynamicReflection = reflectedSceneColor * reflectedSceneResponse *
-    glassTransmission.dynamicReflectionStrength * (0.045 + fresnel * 0.5);
+    glassTransmission.dynamicReflectionStrength * grazingReflection * (0.12 + fresnel * 0.34);
   let faultFilament = baseColor.rgb * faultStrength *
     glassTransmission.faultDistortionStrength *
     pow(max(sin(dot(worldPosition, vec3<f32>(14.0, 10.0, 17.0)) +
@@ -464,10 +468,16 @@ fn glassTransmission_getIlluminatedColor(
     fragmentPosition
   );
   let pointLightColor = opticalPointLights_getColor(normal, worldPosition, cameraPosition);
+  let pointLightReflection = opticalPointLights_getSpecularColor(
+    normal,
+    worldPosition,
+    cameraPosition,
+    glassMaterial.roughness
+  );
   let volumeLightScattering = pointLightColor *
-    glassTransmission.volumeScatteringStrength * 0.24;
+    glassTransmission.volumeScatteringStrength * 0.11;
   return vec4<f32>(
-    transmittedColor.rgb + pointLightColor * glassMaterial.reflectionStrength +
+    transmittedColor.rgb + pointLightReflection * glassMaterial.reflectionStrength +
       volumeLightScattering,
     transmittedColor.a
   );
@@ -790,15 +800,19 @@ vec4 glassTransmission_getColor(
   vec3 volumeScattering = baseColor.rgb * (1.0 - exp(-measuredThickness * 1.3)) *
     glassTransmission.volumeScatteringStrength * (0.045 + (1.0 - viewAlignment) * 0.09);
   vec2 reflectionCoordinate = clamp(
-    screenCoordinate + projectedNormal * (0.025 + measuredThickness * 0.018),
+    screenCoordinate + vec2(
+      dot(reflectionDirection, cameraRight) / viewportAspect,
+      dot(reflectionDirection, cameraUp)
+    ) * (0.025 + measuredThickness * 0.018),
     vec2(0.001),
     vec2(0.999)
   );
   vec3 reflectedSceneColor = texture(glassSceneColorTexture, reflectionCoordinate).rgb;
   float reflectedSceneLuminance = dot(reflectedSceneColor, vec3(0.2126, 0.7152, 0.0722));
-  float reflectedSceneResponse = smoothstep(0.045, 0.9, reflectedSceneLuminance);
+  float reflectedSceneResponse = smoothstep(0.42, 1.4, reflectedSceneLuminance);
+  float grazingReflection = pow(1.0 - viewAlignment, 1.7);
   vec3 dynamicReflection = reflectedSceneColor * reflectedSceneResponse *
-    glassTransmission.dynamicReflectionStrength * (0.045 + fresnel * 0.5);
+    glassTransmission.dynamicReflectionStrength * grazingReflection * (0.12 + fresnel * 0.34);
   vec3 faultFilament = baseColor.rgb * faultStrength *
     glassTransmission.faultDistortionStrength *
     pow(max(sin(dot(worldPosition, vec3(14.0, 10.0, 17.0)) +
@@ -833,10 +847,16 @@ vec4 glassTransmission_getIlluminatedColor(
     fragmentPosition
   );
   vec3 pointLightColor = opticalPointLights_getColor(normal, worldPosition, cameraPosition);
+  vec3 pointLightReflection = opticalPointLights_getSpecularColor(
+    normal,
+    worldPosition,
+    cameraPosition,
+    glassMaterial.roughness
+  );
   vec3 volumeLightScattering = pointLightColor *
-    glassTransmission.volumeScatteringStrength * 0.24;
+    glassTransmission.volumeScatteringStrength * 0.11;
   return vec4(
-    transmittedColor.rgb + pointLightColor * glassMaterial.reflectionStrength +
+    transmittedColor.rgb + pointLightReflection * glassMaterial.reflectionStrength +
       volumeLightScattering,
     transmittedColor.a
   );

--- a/modules/experimental/src/materials/optical-point-lights.ts
+++ b/modules/experimental/src/materials/optical-point-lights.ts
@@ -96,6 +96,46 @@ fn opticalPointLights_getColor(
 
   return accumulatedColor * opticalPointLights.intensity;
 }
+
+fn opticalPointLights_getSpecularColor(
+  normal: vec3<f32>,
+  worldPosition: vec3<f32>,
+  cameraPosition: vec3<f32>,
+  roughness: f32
+) -> vec3<f32> {
+  let viewDirection = normalize(cameraPosition - worldPosition);
+  let normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  let shininess = mix(118.0, 34.0, clamp(roughness, 0.0, 1.0));
+  let fresnel = opticalLighting_getFresnel(
+    clamp(dot(normalFacingCamera, viewDirection), 0.0, 1.0),
+    0.04,
+    5.0
+  );
+  var accumulatedColor = vec3<f32>(0.0);
+
+  for (var lightIndex = 0; lightIndex < ${MAX_OPTICAL_POINT_LIGHTS}; lightIndex++) {
+    if (lightIndex >= opticalPointLights.lightCount) {
+      break;
+    }
+
+    let light = opticalPointLights.lights[lightIndex];
+    let lightOffset = light.position - worldPosition;
+    let distanceSquared = dot(lightOffset, lightOffset);
+    let radius = max(light.radius, 0.0001);
+    let normalizedDistance = clamp(sqrt(distanceSquared) / radius, 0.0, 1.0);
+    let attenuation = pow(1.0 - normalizedDistance * normalizedDistance, 2.0);
+    let lightDirection = lightOffset * inverseSqrt(max(distanceSquared, 0.00001));
+    let reflectionDirection = reflect(-viewDirection, normalFacingCamera);
+    let reflectionAlignment = max(dot(reflectionDirection, lightDirection), 0.0);
+    let specular = pow(reflectionAlignment, shininess);
+    let softSpecular = pow(reflectionAlignment, max(shininess * 0.34, 10.0)) * 0.045;
+    accumulatedColor += light.color * light.intensity * attenuation *
+      (specular * 1.45 + softSpecular) *
+      (0.35 + fresnel * 1.65);
+  }
+
+  return accumulatedColor * opticalPointLights.intensity;
+}
 `;
 
 const OPTICAL_POINT_LIGHTS_GLSL = /* glsl */ `\
@@ -138,6 +178,46 @@ vec3 opticalPointLights_getColor(
     float specular = pow(max(dot(normalFacingCamera, halfVector), 0.0), 28.0);
     float surfaceResponse = 0.08 + diffuse * 0.52 + specular * 0.4;
     accumulatedColor += light.color * light.intensity * attenuation * surfaceResponse;
+  }
+
+  return accumulatedColor * opticalPointLights.intensity;
+}
+
+vec3 opticalPointLights_getSpecularColor(
+  vec3 normal,
+  vec3 worldPosition,
+  vec3 cameraPosition,
+  float roughness
+) {
+  vec3 viewDirection = normalize(cameraPosition - worldPosition);
+  vec3 normalFacingCamera = opticalLighting_faceNormal(normalize(normal), viewDirection);
+  float shininess = mix(118.0, 34.0, clamp(roughness, 0.0, 1.0));
+  float fresnel = opticalLighting_getFresnel(
+    clamp(dot(normalFacingCamera, viewDirection), 0.0, 1.0),
+    0.04,
+    5.0
+  );
+  vec3 accumulatedColor = vec3(0.0);
+
+  for (int lightIndex = 0; lightIndex < ${MAX_OPTICAL_POINT_LIGHTS}; lightIndex++) {
+    if (lightIndex >= opticalPointLights.lightCount) {
+      break;
+    }
+
+    OpticalPointLightUniform light = opticalPointLights.lights[lightIndex];
+    vec3 lightOffset = light.position - worldPosition;
+    float distanceSquared = dot(lightOffset, lightOffset);
+    float radius = max(light.radius, 0.0001);
+    float normalizedDistance = clamp(sqrt(distanceSquared) / radius, 0.0, 1.0);
+    float attenuation = pow(1.0 - normalizedDistance * normalizedDistance, 2.0);
+    vec3 lightDirection = lightOffset * inversesqrt(max(distanceSquared, 0.00001));
+    vec3 reflectionDirection = reflect(-viewDirection, normalFacingCamera);
+    float reflectionAlignment = max(dot(reflectionDirection, lightDirection), 0.0);
+    float specular = pow(reflectionAlignment, shininess);
+    float softSpecular = pow(reflectionAlignment, max(shininess * 0.34, 10.0)) * 0.045;
+    accumulatedColor += light.color * light.intensity * attenuation *
+      (specular * 1.45 + softSpecular) *
+      (0.35 + fresnel * 1.65);
   }
 
   return accumulatedColor * opticalPointLights.intensity;

--- a/modules/experimental/test/materials/optical-materials.node.spec.ts
+++ b/modules/experimental/test/materials/optical-materials.node.spec.ts
@@ -634,6 +634,11 @@ test('rasterized glass transmission composes thickness, depth, and environment m
     );
     testCase.match(
       shaderSource,
+      /dot\(reflectionDirection,\s*cameraRight\)/,
+      `${language} projects dynamic scene reflections along the reflected view ray`
+    );
+    testCase.match(
+      shaderSource,
       /secondaryDirection/,
       `${language} approximates a second internal environment bounce`
     );
@@ -666,6 +671,11 @@ test('rasterized glass transmission composes thickness, depth, and environment m
       shaderSource,
       /volumeLightScattering/,
       `${language} scatters nearby colored lights inside the glass volume`
+    );
+    testCase.match(
+      shaderSource,
+      /opticalPointLights_getSpecularColor/,
+      `${language} keeps local packet glints as front-surface reflections`
     );
     testCase.match(
       shaderSource,
@@ -750,6 +760,16 @@ test('optical point lights pack and retain a bounded portable uniform array', te
   testCase.ok(
     clearedUniforms.lights.every(light => light.intensity === 0),
     'cleared light slots are reset'
+  );
+  testCase.match(
+    opticalPointLights.source,
+    /softSpecular/,
+    'WGSL retains a broader packet reflection lobe on curved glass'
+  );
+  testCase.match(
+    opticalPointLights.fs,
+    /softSpecular/,
+    'GLSL retains a broader packet reflection lobe on curved glass'
   );
   testCase.end();
 });


### PR DESCRIPTION
## Goals

Improve the Effects: Glass / Network Packet Spraying example so packet reflections read as surface glints instead of broad inverted blobs on the glass spheres, while preserving the HDR packet-lighting work.

## Changes

- Adds a specular-only optical point-light helper for glass and reflective packet highlights.
- Uses packet point lights as surface reflections on glass, with reduced volume scattering to avoid washing out switches.
- Constrains captured-scene dynamic reflections to bright, grazing-angle samples so packet images do not appear on the wrong hemisphere of the spheres.
- Adds a URL-gated reflection lab at `?lab=reflection` with one glass sphere and one packet for isolated shader debugging.
- Fixes guided-story pause/resume so the animation clock actually freezes while paused.
- Adds shader composition coverage for the new optical point-light and illuminated glass paths.

## Validation

- Pre-commit hook ran lint and node tests: 63 passed, 2 skipped.
- Ran focused material test: `yarn test-node modules/experimental/test/materials/optical-materials.node.spec.ts`.
- Built the packet-spraying example: `yarn build` in `examples/showcase/packet-spraying`.

## Notes

Unrelated local gpu-trace-viewer, lightstorm-megacity, website, and yarn.lock edits were left unstaged and are not included in this PR.