### PR TITLE
fix(shadertools): make fp64 reliable on Apple WebGPU

### DIFF
--- a/docs/api-guide/shaders/gpu-floating-point-precision.md
+++ b/docs/api-guide/shaders/gpu-floating-point-precision.md
@@ -1,8 +1,9 @@
-import {ShaderLevelDocsTabs} from '@site/src/components/docs/shader-level-docs-tabs';
+import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
+import {FP64Example} from '@site/src/examples';
 
 # GPU Floating-Point Precision Techniques
 
-<ShaderLevelDocsTabs active="gpu-floating-point-precision" />
+<ShaderModuleDocsTabs group="precision" active="precision-guide" />
 
 "fp64" is often used to mean "more precision than `f32`," but the available
 techniques do not all implement the same number system. A pair of `f32` values,
@@ -11,10 +12,23 @@ point have different precision, range, rounding, and portability guarantees.
 
 That distinction matters on WebGPU. Classic double-single arithmetic can be
 fast, but its correctness depends on individual `f32` rounding points that WGSL
-does not require a compiler to preserve. If a result must be reliable across
-WebGPU implementations, choose a representation and arithmetic contract that
-do not depend on those rounding points, or reduce the problem to a smaller
-exact operation.
+does not require a compiler to preserve. luma.gl therefore uses an
+integer-controlled double-single path automatically on Apple WebGPU adapters,
+while retaining the classic path where it is known to work.
+
+## Live Mandelbrot And Compute Benchmark
+
+The two Mandelbrot views follow the same deep zoom. The left view uses native
+`f32`; the right uses luma.gl's `fp64arithmetic` double-single representation.
+On WebGPU, use the benchmark below the canvases to compare native `f32`,
+automatic selection, the classic transforms, and the integer-controlled path
+on the active device.
+
+<FP64Example embedded embeddedHeight={900} />
+
+The benchmark is diagnostic rather than a CI performance test. It reports
+numerical error alongside runtime because the fastest implementation is not
+useful if the compiler has optimized away its residual terms.
 
 ## Start With The Required Contract
 
@@ -107,9 +121,9 @@ These exactness statements are conditional. The usual binary proofs assume
 round-to-nearest evaluation, no reassociation or unintended contraction,
 finite intermediates without overflow, and the required handling of tiny
 values. The `4097 * a` split is not safe for every finite `f32`: it can overflow
-even when `a` does not, so a complete implementation must scale large inputs.
-Subnormals or flush-to-zero behavior require similar care. Parentheses alone
-do not establish any of these conditions.
+even when `a` does not, so a complete implementation must handle large inputs.
+Subnormals or flush-to-zero behavior require similar care. Parentheses alone do
+not establish any of these conditions.
 
 Once `TwoSum`, `FastTwoSum`, and `TwoProd` are available, double-single add and
 multiply combine the high components, accumulate their residuals and the low
@@ -120,8 +134,8 @@ an `f32` approximation followed by one or more compensated corrections.
 
 An error-free transform is an algorithm over *rounding events*, not an
 algebraic identity. For example, the low term in `TwoSum` is algebraically zero
-over the real numbers. A compiler that reassociates the expression is therefore
-allowed to erase the information the algorithm was designed to recover.
+over the real numbers. A compiler that reassociates the expression can
+therefore erase the information the algorithm was designed to recover.
 
 The [WGSL floating-point evaluation
 rules](https://www.w3.org/TR/WGSL/#floating-point-evaluation) permit
@@ -142,16 +156,54 @@ As a result, these source-level techniques are not portable precision barriers:
 They may affect a particular compiler version, but they cannot turn an
 optimization-sensitive transform into a WebGPU guarantee. Native APIs or
 toolchains with a strict floating-point mode can make classic double-single a
-valid backend-specific fast path. WebGPU applications still need a portable
-fallback if correctness depends on it.
+valid backend-specific fast path. WebGPU applications still need a fallback
+when correctness depends on it.
+
+## luma.gl's Apple/Metal Path
+
+On Apple WebGPU adapters, `fp64arithmetic` replaces the rounding-sensitive
+transforms with integer-controlled operations. Each `f32` limb is decoded into
+sign, exponent, and significand fields. `TwoSum`, `TwoProd`, and the required
+renormalization use `u32` limbs with explicit round-to-nearest, ties-to-even
+packing back to `f32`. A 24-by-24-bit product needs only 48 exact bits, so this
+is considerably narrower than full software binary64.
+
+The public representation and function names remain `vec2f` double-single, so
+existing `fp64arithmetic` WGSL callers do not need a second API. The shader
+assembler selects this path automatically when the backend is WebGPU and the
+adapter is Apple. Applications can force it for testing on another adapter, or
+explicitly disable it on Apple:
+
+```ts
+const computation = new Computation(device, {
+  // ...
+  modules: [fp64arithmetic],
+  defines: {
+    LUMA_FP64_INTEGER_ARITHMETIC: true // false overrides the Apple default
+  }
+});
+```
+
+This path favors reliable rounding points over throughput. It still represents
+an expansion with essentially the `f32` exponent range, not binary64. While
+both limbs are normal it provides approximately 48 significand bits. For result
+magnitudes between roughly `2^-126` and `2^-102`, the low limb is subnormal, so
+available precision gradually tapers from about 48 bits toward 24 bits as the
+result approaches `f32` underflow.
+
+The portable contract covers finite, normalized double-single inputs and
+finite normal results within that representational range. It does not promise
+full binary64 special-value or subnormal semantics. Division and square root
+use native `f32` estimates followed by integer-controlled double-single
+corrections.
 
 ## The Main Alternatives
 
 | Approach | Typical cost | Portability | Best fit |
 | --- | --- | --- | --- |
 | Native hardware binary64 | Lowest when supported, sometimes low throughput | Not a portable WGSL feature | Native backends with a strict `f64` contract |
-| Classic double-single | Lower than integer emulation; operation-dependent | Depends on preserved rounding points | Controlled compilers and proven fast paths |
-| Integer-assisted double-single | Higher than classic double-single; implementation-dependent | Robust with specified `u32` operations | Portable expansion add/multiply when about 48 bits are enough |
+| Classic double-single | Lower than integer emulation; operation-dependent | Depends on preserved rounding points | Controlled compilers and verified fast paths |
+| Integer-assisted double-single | Higher than classic double-single; implementation-dependent | Robust with specified `u32` operations | Portable expansion arithmetic when about 48 bits are enough |
 | Exact binary64 delta to `f32` | Moderate, fixed integer cost | Robust as result bits; direct `f32` is exact for normal finite results | Large-coordinate origin subtraction |
 | Full software binary64 | High; division, square root, and transcendentals are especially costly | Robust if complete | Binary64 range, special values, or CPU-compatible stepwise semantics |
 | Fixed point | Very low for add; multiply and divide need wide intermediates | Robust | Bounded dynamic range and iterative kernels |
@@ -192,7 +244,7 @@ would require an unwanted copy.
 
 ### Integer-Assisted Double-Single
 
-A middle ground keeps the `high + low` representation while replacing only the
+A middle ground keeps the `high + low` representation while replacing the
 rounding-sensitive transforms with `u32` arithmetic. Decode each `f32` sign,
 exponent, and significand; align or multiply the integer significands; preserve
 guard, round, and sticky information; then emit a normalized high/low pair.
@@ -204,20 +256,17 @@ software binary64 and can provide deterministic building blocks for expansion
 addition and multiplication.
 
 Its scope should remain explicit. It still has essentially binary32 exponent
-range unless separate exponent state is added. Division, square root, NaNs,
-infinities, signed zero, and subnormal behavior require additional design. It
-also does not make arbitrary existing `vec2f` code safe: all
-rounding-sensitive transforms and renormalization steps in the supported
-operation must use the deterministic path. A low component that becomes an
-`f32` subnormal can still be flushed after packing, so a portable contract
-should exclude such terms or keep them encoded as integer bits.
+range unless separate exponent state is added. NaNs, infinities, signed zero,
+and subnormal behavior require additional design. It also does not make
+arbitrary existing `vec2f` code safe: every rounding-sensitive transform and
+renormalization step in a supported operation must use the deterministic path.
 
 ### Full Software Binary64
 
 A complete implementation stores sign, 11-bit exponent, and 52 fraction bits
 in integer words. Each operation aligns significands, computes with extra
-guard/round/sticky bits, normalizes, rounds, and handles zeros, subnormals,
-infinities, and NaNs.
+guard, round, and sticky bits, normalizes, rounds, and handles zeros,
+subnormals, infinities, and NaNs.
 
 This is the direct choice when binary64 range and behavior are requirements,
 not merely additional local precision. It is also the software route to
@@ -247,17 +296,17 @@ automatic exponent, NaN, or infinity behavior.
 ### Native Binary64
 
 Native `f64` is the obvious answer on a backend that supports it with the
-required evaluation controls. It is not currently a portable WGSL/WebGPU
-shader type, and hardware throughput varies widely. Even where native `f64`
-exists, bit-for-bit CPU agreement still requires matching operation order,
-rounding and contraction rules.
+required evaluation controls. It is not a portable WGSL/WebGPU shader type,
+and hardware throughput varies widely. Even where native `f64` exists,
+bit-for-bit CPU agreement still requires matching operation order, rounding,
+and contraction rules.
 
 ## Choosing By Workload
 
 | Workload | Preferred starting point | Reason |
 | --- | --- | --- |
 | World, geospatial, or astronomical coordinates | CPU origin rebasing or exact `fp64u32` delta | Preserves local detail, then returns to fast `f32` |
-| Deep iterative calculation over a bounded interval | Fixed point | Deterministic precision and predictable cost |
+| Deep iterative calculation over a bounded interval | Fixed point or integer-assisted double-single | Deterministic precision and a cost below full binary64 |
 | General arithmetic needing roughly 14 decimal digits | Integer-assisted double-single | More precision without implementing binary64's full range |
 | Binary64 storage or data interchange without arithmetic | Raw `fp64u32` words | Preserves every source bit without paying for software arithmetic |
 | Arithmetic requiring binary64 range and special values | Full software binary64 | The arithmetic semantics, not just the representation, are the requirement |
@@ -271,13 +320,18 @@ the only value that must reach the shader.
 
 ## luma.gl Precision Paths
 
-The [`fp64`](/docs/api-reference/shadertools/shader-modules/fp64) module and its
-low-level
+The [`fp64`](/docs/api-reference/shadertools/shader-modules/fp64) module exposes
+the full established `fp64f32` function library in GLSL only. It has no WGSL
+source, so its exponential, logarithmic, and trigonometric functions are not
+available to WebGPU shaders.
+
+Its lower-level
 [`fp64arithmetic`](/docs/api-reference/shadertools/shader-modules/fp64-arithmetic)
-dependency expose the established `fp64f32` expansion path. This path remains
-useful for GLSL and for backends on which its error-free transforms have been
-verified, but its classic floating-point implementation is not a portable
-strict-arithmetic guarantee under WGSL.
+dependency provides the add, subtract, multiply, divide, and square-root
+helpers in both GLSL and WGSL. Non-Apple WGSL uses the classic floating-point
+transforms by default. Apple WebGPU uses the integer-controlled implementation
+automatically, and callers can use `LUMA_FP64_INTEGER_ARITHMETIC` to test or
+override that choice.
 
 WGSL also provides these targeted helpers for `fp64u32` values:
 
@@ -293,11 +347,8 @@ ties-to-even conversion to a binary32 encoding. The `_bits` helper returns that
 encoding as `u32`, including the module's defined handling of zeros,
 subnormals, infinities, and NaNs. WGSL's relaxed rules for those values mean
 that the direct `f32` helper has a portable exact-value guarantee only for
-normal finite results. Neither helper provides general `fp64u32` addition or
-multiplication.
-
-luma.gl currently does not expose general integer-assisted double-single or
-full software binary64 arithmetic.
+normal finite results. These helpers are deliberately narrower than the
+general `fp64f32` arithmetic API.
 
 ## Validation Is Part Of The Technique
 

--- a/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
@@ -10,8 +10,10 @@ Use it directly when you only need the arithmetic primitives and want to avoid
 including the full `fp64` function library.
 
 See [GPU Floating-Point Precision Techniques](/docs/api-guide/shaders/gpu-floating-point-precision)
-for the numerical guarantees and tradeoffs of double-single, raw binary64,
-fixed-point, and integer-assisted approaches.
+for the numerical guarantees and tradeoffs of classic and integer-assisted
+double-single, native and software binary64, fixed point, and exact deltas. The
+[Mandelbrot and compute benchmark](/examples/experimental/fp64) runs these
+paths on the active GPU.
 
 ## Uniforms
 
@@ -31,6 +33,43 @@ import {fp64arithmetic} from '@luma.gl/shadertools';
 
 const modules = [fp64arithmetic];
 ```
+
+## Apple/Metal WGSL arithmetic
+
+On Apple WebGPU adapters, shadertools automatically selects an
+optimizer-independent implementation of the double-single arithmetic helpers.
+It decodes each `f32` limb into integer sign, exponent, and significand fields,
+performs the exact `twoSum` and `twoProd` transforms with integer operations,
+and rounds each result back to the existing `vec2f` representation. This avoids
+depending on floating-point expressions that Metal may reassociate or contract.
+
+The selection is a shader define, so it can also be forced on for another
+adapter or disabled on Apple:
+
+```ts
+const computation = new Computation(device, {
+  // ...
+  modules: [fp64arithmetic],
+  defines: {
+    LUMA_FP64_INTEGER_ARITHMETIC: true // false overrides the Apple default
+  }
+});
+```
+
+The integer path favors correctness over throughput. It preserves the public
+double-single API and provides approximately 48 significand bits while both
+limbs are normal, but it is not an IEEE-754 binary64 implementation: the
+exponent range remains that of `f32`. For result magnitudes between roughly
+`2^-126` and `2^-102`, the low limb is subnormal, so available precision
+gradually tapers from about 48 toward 24 bits as the result approaches `f32`
+underflow.
+
+The portable contract covers finite, normalized double-single inputs and
+finite normal results within that representational limit. Exact subnormal
+rounding and binary64 special-value semantics are not guaranteed. Division and
+square root normalize their inputs into a safe exponent range, use native `f32`
+seed operations, and apply integer-controlled double-single corrections before
+rescaling the result.
 
 ## WGSL fp64u32 Subtraction
 
@@ -64,7 +103,7 @@ If the source data comes from a JavaScript `Float64Array` reinterpreted as
 
 ## Remarks
 
-- `fp64` depends on `fp64arithmetic`, so applications that import `fp64` do not
-  usually need to add this module separately.
+- `fp64` depends on `fp64arithmetic`, so GLSL applications that import `fp64`
+  do not usually need to add this module separately.
 - The helper uniforms are part of the module's implementation and should not
   normally need to be overridden by applications.

--- a/docs/api-reference/shadertools/shader-modules/fp64.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64.md
@@ -20,28 +20,40 @@ Provides basic 64-bit math support in GPU shaders:
 | vec2 `cos_fp64`(vec2 a)         |             |
 | vec2 `tan_fp64`(vec2 a)         |             |
 
-The side-by-side Mandelbrot views show where fp32 loses detail as the animated zoom deepens:
+The full `fp64` function library is GLSL-only. It does not provide WGSL source,
+so WGSL shaders cannot call `exp_fp64`, `log_fp64`, or its trigonometric
+functions. For WebGPU, use the lower-level
+[`fp64arithmetic`](/docs/api-reference/shadertools/shader-modules/fp64-arithmetic)
+module, which supplies WGSL add, subtract, multiply, divide, and square-root
+helpers.
 
-<FP64Example embedded />
+The side-by-side Mandelbrot views show where fp32 loses detail as the animated zoom deepens. On
+WebGPU, the example uses `fp64arithmetic`, and the panel below the canvases can
+benchmark each arithmetic path on the active device:
+
+<FP64Example embedded embeddedHeight={900} />
 
 ## Precision
 
 WebGL and portable WGSL do not expose native 64-bit floating-point arithmetic.
-As an alternative, this module represents a value as the unevaluated sum of
-two 32-bit floating-point terms. This double-single representation can provide
-up to roughly 48 significant **bits**, or about 14 decimal digits, while
-remaining within the exponent range of `f32`. It is not IEEE 754 binary64,
-which has 53 significant bits and a much larger exponent range.
+The GLSL-only `fp64` library and its cross-language `fp64arithmetic` dependency
+instead represent a value as the unevaluated sum of two 32-bit floating-point
+terms. This double-single representation can provide up to roughly 48
+significant **bits**, or about 14 decimal digits, while remaining within the
+exponent range of `f32`. It is not IEEE 754 binary64, which has 53 significant
+bits and a much larger exponent range.
 
 The classic double-single algorithms depend on specific intermediate rounding
-points. Standard WGSL permits floating-point reassociation and fusion, so the
-precision of this path is backend-dependent on WebGPU. See
+points. This matters specifically to WGSL users of `fp64arithmetic`: WGSL
+permits floating-point reassociation and fusion, so Apple WebGPU adapters
+automatically select its integer-controlled implementation. The full `fp64`
+library remains GLSL-only. See
 [GPU Floating-Point Precision Techniques](/docs/api-guide/shaders/gpu-floating-point-precision)
-for a comparison with binary64, integer-assisted arithmetic, fixed point, and
-exact origin-relative subtraction.
+for a comparison with binary64, fixed point, exact origin-relative subtraction,
+and the available double-single paths.
 
 Historical WebGL testing on a 2015 MacBook Pro with an AMD Radeon R9 M370X
-measured these error bounds:
+measured these error bounds for the classic implementation:
 
 ```
 Addition and subtraction: < 1 ulp

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -123,7 +123,8 @@ Target Release Date: TBD
 
 - **[`colors`, `floatColors`, and `storageColors`](/docs/api-reference/shadertools/shader-modules/float-colors)** - Semantic color normalization now has a `colors` helper namespace, the legacy `floatColors` alias remains available, and WebGPU shaders can read packed RGBA storage rows through `storageColors`.
 - **[`dggs`](/docs/api-reference/shadertools/shader-modules/dggs)** - New WGSL helpers decode compact Uint64 DGGS cell keys for storage-buffer and boundary-extraction workflows.
-- **WGSL double-precision arithmetic** - The `fp64` shader module can subtract packed IEEE 754 double-precision values directly in WGSL and convert the result to `f32`.
+- **Apple/Metal-safe fp64 arithmetic** - WGSL double-single arithmetic automatically uses integer-controlled `twoSum`, `twoProd`, and renormalization on Apple WebGPU adapters, avoiding Metal compiler reassociation while retaining the existing `vec2f` API. The `LUMA_FP64_INTEGER_ARITHMETIC` shader define can force or disable the mode.
+- **WGSL double-precision arithmetic** - The `fp64arithmetic` shader module can subtract packed IEEE 754 double-precision values directly in WGSL and convert the result to `f32`.
 - **[`ShaderPlugin`](/docs/api-reference/shadertools/shader-plugin)** - Reusable shader assembly plugins group modules, defines, named injections, caller-owned vertex inputs, and generated cross-stage varyings.
 - **WGSL hooks and injections** - `ShaderAssembler` now applies registered hook functions and standard named injections such as `vs:#main-start` and `fs:#main-end` while assembling unified WGSL shaders.
 - **WGSL shader conditionals** - Shadertools preprocessing accepts simple boolean and numeric `#if` expressions, and assembled WGSL exposes `LUMA_SUPPORTS_VERTEX_STORAGE_BUFFERS` so inactive resource branches are removed before `@binding(auto)` assignment.

--- a/examples/experimental/fp64/app.tsx
+++ b/examples/experimental/fp64/app.tsx
@@ -16,6 +16,11 @@ import {
   ExampleSettingsPanelManager,
   getChangedSetting
 } from '../../example-panels';
+import {
+  runFP64ComputeBenchmark,
+  type FP64BenchmarkMode,
+  type FP64ComputeBenchmarkResult
+} from './fp64-compute-benchmark';
 
 type AppProps = {
   device?: Device | null;
@@ -23,8 +28,11 @@ type AppProps = {
 };
 
 type AppState = {
+  benchmarkError: string | null;
+  benchmarkResults: FP64ComputeBenchmarkResult[] | null;
   currentZoomLabel: string;
   initializationError: string | null;
+  isBenchmarkRunning: boolean;
   isReady: boolean;
   selectedPresetId: ZoomPresetId;
 };
@@ -114,8 +122,11 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     super(props);
 
     this.state = {
+      benchmarkError: null,
+      benchmarkResults: null,
       currentZoomLabel: formatZoomScale(INITIAL_PIXEL_SCALE),
       initializationError: null,
+      isBenchmarkRunning: false,
       isReady: false,
       selectedPresetId: DEFAULT_PRESET_ID
     };
@@ -166,8 +177,11 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     const initializationGeneration = ++this.initializationGeneration;
     this.destroyResources();
     this.setState({
+      benchmarkError: null,
+      benchmarkResults: null,
       currentZoomLabel: formatZoomScale(INITIAL_PIXEL_SCALE),
       initializationError: null,
+      isBenchmarkRunning: false,
       isReady: false
     });
 
@@ -219,7 +233,15 @@ export default class App extends React.PureComponent<AppProps, AppState> {
   }
 
   override render(): React.ReactNode {
-    const {currentZoomLabel, initializationError, isReady, selectedPresetId} = this.state;
+    const {
+      benchmarkError,
+      benchmarkResults,
+      currentZoomLabel,
+      initializationError,
+      isBenchmarkRunning,
+      isReady,
+      selectedPresetId
+    } = this.state;
     const selectedPreset = ZOOM_PRESETS[selectedPresetId];
     const overlayLines = getOverlayLines(selectedPreset, currentZoomLabel);
     const visualizationSpecs = getVisualizationSpecs();
@@ -230,7 +252,7 @@ export default class App extends React.PureComponent<AppProps, AppState> {
           display: 'flex',
           flexDirection: 'column',
           gap: 20,
-          padding: '72px 20px 20px'
+          padding: 20
         }}
       >
         {initializationError ? (
@@ -262,6 +284,13 @@ export default class App extends React.PureComponent<AppProps, AppState> {
             />
           ))}
         </div>
+        <FP64BenchmarkPanel
+          device={this.device}
+          error={benchmarkError}
+          isRunning={isBenchmarkRunning}
+          onRun={this.handleRunBenchmark}
+          results={benchmarkResults}
+        />
       </div>
     );
   }
@@ -311,6 +340,36 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     const currentZoomLabel = formatZoomScale(pixelScale);
     if (currentZoomLabel !== this.state.currentZoomLabel) {
       this.setState({currentZoomLabel});
+    }
+  };
+
+  private handleRunBenchmark = async (): Promise<void> => {
+    const device = this.device;
+    const renderer = this.renderer;
+    if (!device || device.type !== 'webgpu' || this.state.isBenchmarkRunning) {
+      return;
+    }
+
+    const initializationGeneration = this.initializationGeneration;
+    renderer?.pause();
+    this.setState({benchmarkError: null, benchmarkResults: null, isBenchmarkRunning: true});
+
+    try {
+      const benchmarkResults = await runFP64ComputeBenchmark(device);
+      if (this.isReadyForInitialization(initializationGeneration)) {
+        this.setState({benchmarkResults});
+      }
+    } catch (error) {
+      if (this.isReadyForInitialization(initializationGeneration)) {
+        this.setState({
+          benchmarkError: error instanceof Error ? error.message : String(error)
+        });
+      }
+    } finally {
+      if (this.isReadyForInitialization(initializationGeneration) && this.renderer === renderer) {
+        renderer?.start();
+        this.setState({isBenchmarkRunning: false});
+      }
     }
   };
 }
@@ -392,15 +451,22 @@ class MultiCanvasRenderer {
   }
 
   start(): void {
+    if (this.animationFrame !== null) {
+      return;
+    }
     this.startTime = performance.now();
     this.animationFrame = requestAnimationFrame(this.animate);
   }
 
-  destroy(): void {
+  pause(): void {
     if (this.animationFrame !== null) {
       cancelAnimationFrame(this.animationFrame);
       this.animationFrame = null;
     }
+  }
+
+  destroy(): void {
+    this.pause();
 
     for (const visualization of this.visualizations) {
       visualization.model?.destroy();
@@ -653,6 +719,165 @@ function ExamplePaneCanvas(props: {
       </div>
     </div>
   );
+}
+
+function FP64BenchmarkPanel(props: {
+  device: Device | null;
+  error: string | null;
+  isRunning: boolean;
+  onRun: () => Promise<void>;
+  results: FP64ComputeBenchmarkResult[] | null;
+}): React.ReactNode {
+  const {device, error, isRunning, onRun, results} = props;
+  const isWebGPU = device?.type === 'webgpu';
+  const automaticSelection =
+    isWebGPU && device.info.gpu === 'apple' ? 'Metal-safe integer' : 'classic';
+
+  return (
+    <section
+      style={{
+        border: '1px solid #d7d2df',
+        borderRadius: 10,
+        padding: 16,
+        minWidth: 0
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'start',
+          justifyContent: 'space-between',
+          gap: 16,
+          flexWrap: 'wrap'
+        }}
+      >
+        <div style={{maxWidth: 760}}>
+          <h3 style={{margin: '0 0 6px'}}>FP64 compute benchmark</h3>
+          <p style={{margin: 0, lineHeight: 1.45}}>
+            Runs dependent add, multiply, divide, and square-root recurrences across 8,192 GPU
+            lanes. Results compare native float32, automatic selection, classic double-single, and
+            the Metal-safe integer double-single path. The Mandelbrot animation pauses while the
+            benchmark runs.
+          </p>
+        </div>
+        <button
+          disabled={!isWebGPU || isRunning}
+          onClick={() => void onRun()}
+          style={{padding: '8px 14px', whiteSpace: 'nowrap'}}
+          type="button"
+        >
+          {isRunning ? 'Running benchmark…' : 'Run WebGPU benchmark'}
+        </button>
+      </div>
+      <p style={{margin: '12px 0 0', fontFamily: 'monospace', fontSize: 12}}>
+        {device
+          ? `device = ${getBenchmarkDeviceLabel(device)} · automatic = ${automaticSelection}`
+          : 'device = initializing'}
+      </p>
+      {!isWebGPU ? (
+        <p style={{margin: '10px 0 0'}}>This benchmark is available on WebGPU devices only.</p>
+      ) : null}
+      {error ? <p style={{color: '#b00020', margin: '10px 0 0'}}>{error}</p> : null}
+      {results ? <FP64BenchmarkResultsTable results={results} /> : null}
+    </section>
+  );
+}
+
+function FP64BenchmarkResultsTable(props: {
+  results: FP64ComputeBenchmarkResult[];
+}): React.ReactNode {
+  return (
+    <div style={{overflowX: 'auto', marginTop: 16}}>
+      <table style={{borderCollapse: 'collapse', fontSize: 13, width: '100%'}}>
+        <thead>
+          <tr>
+            {[
+              'Operation',
+              'Arithmetic path',
+              'Runtime',
+              'Throughput',
+              'Max relative error',
+              'Timer'
+            ].map(heading => (
+              <th
+                key={heading}
+                style={{borderBottom: '1px solid #a9a2b5', padding: '7px 9px', textAlign: 'left'}}
+              >
+                {heading}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {props.results.map(result => (
+            <tr key={`${result.operation}-${result.mode}`}>
+              <td style={BENCHMARK_CELL_STYLE}>{result.operation}</td>
+              <td style={BENCHMARK_CELL_STYLE}>{formatBenchmarkMode(result.mode)}</td>
+              {result.error !== undefined ? (
+                <td colSpan={4} style={{...BENCHMARK_CELL_STYLE, color: '#b00020'}}>
+                  {result.error}
+                </td>
+              ) : (
+                <>
+                  <td style={BENCHMARK_CELL_STYLE}>
+                    {formatBenchmarkRuntime(result.runtimeMilliseconds)}
+                  </td>
+                  <td style={BENCHMARK_CELL_STYLE}>
+                    {result.throughputMillionIterationsPerSecond.toFixed(2)} M iter/s
+                  </td>
+                  <td style={BENCHMARK_CELL_STYLE}>
+                    {formatBenchmarkError(result.maximumRelativeError)}
+                  </td>
+                  <td style={BENCHMARK_CELL_STYLE}>{result.timing}</td>
+                </>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p style={{fontSize: 12, lineHeight: 1.4, margin: '10px 0 0'}}>
+        Timed work uses three dispatches of 8,192 lanes × 32 dependent iterations. Accuracy is
+        checked once after timing against JavaScript number arithmetic; no performance threshold is
+        enforced.
+      </p>
+    </div>
+  );
+}
+
+const BENCHMARK_CELL_STYLE: React.CSSProperties = {
+  borderBottom: '1px solid #e4e0e8',
+  padding: '7px 9px',
+  textAlign: 'left',
+  whiteSpace: 'nowrap'
+};
+
+function getBenchmarkDeviceLabel(device: Device): string {
+  const adapter = device.info.renderer || device.info.vendor || device.info.gpu;
+  const backend = device.info.gpuBackend || device.type;
+  return `${adapter} (${backend})`;
+}
+
+function formatBenchmarkMode(mode: FP64BenchmarkMode): string {
+  switch (mode) {
+    case 'automatic':
+      return 'FP64 automatic';
+    case 'classic':
+      return 'FP64 classic';
+    case 'integer':
+      return 'FP64 integer';
+    case 'float32':
+      return 'native float32';
+  }
+}
+
+function formatBenchmarkRuntime(runtimeMilliseconds: number): string {
+  return runtimeMilliseconds < 1
+    ? `${runtimeMilliseconds.toFixed(3)} ms`
+    : `${runtimeMilliseconds.toFixed(2)} ms`;
+}
+
+function formatBenchmarkError(relativeError: number): string {
+  return relativeError === 0 ? '0' : relativeError.toExponential(2);
 }
 
 const mandelbrot32: ShaderModule<Mandelbrot32Uniforms> = {

--- a/examples/experimental/fp64/fp64-compute-benchmark.ts
+++ b/examples/experimental/fp64/fp64-compute-benchmark.ts
@@ -1,0 +1,381 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type ComputeShaderLayout, type Device, type QuerySet} from '@luma.gl/core';
+import {Computation, ShaderInputs} from '@luma.gl/engine';
+import {fp64arithmetic, type ShaderModule} from '@luma.gl/shadertools';
+
+export type FP64BenchmarkMode = 'automatic' | 'classic' | 'integer' | 'float32';
+export type FP64BenchmarkOperation = 'add' | 'multiply' | 'divide' | 'square root';
+
+type FP64ComputeBenchmarkResultBase = {
+  mode: FP64BenchmarkMode;
+  operation: FP64BenchmarkOperation;
+  timing: 'GPU timestamp' | 'queue completion';
+};
+
+export type FP64ComputeBenchmarkResult = FP64ComputeBenchmarkResultBase &
+  (
+    | {
+        error?: undefined;
+        maximumRelativeError: number;
+        runtimeMilliseconds: number;
+        throughputMillionIterationsPerSecond: number;
+      }
+    | {
+        error: string;
+      }
+  );
+
+const LANE_COUNT = 8192;
+const WORKGROUP_SIZE = 64;
+const WORK_ITERATIONS = 32;
+const TIMED_DISPATCH_COUNT = 3;
+const WORKGROUP_COUNT = LANE_COUNT / WORKGROUP_SIZE;
+// Shader modules reserve group-0 bindings 100 and above. fp64arithmetic is the
+// only module in these pipelines, so its uniform block receives the first slot.
+const FP64_ARITHMETIC_UNIFORM_BINDING = 100;
+// ComputationProps currently erases shader-module generics. Widen the type
+// without cloning the module so future metadata remains attached.
+const FP64_BENCHMARK_MODULE: ShaderModule<any, any, any> = fp64arithmetic;
+
+const BENCHMARK_MODES: FP64BenchmarkMode[] = ['automatic', 'classic', 'integer', 'float32'];
+const BENCHMARK_OPERATIONS: FP64BenchmarkOperation[] = ['add', 'multiply', 'divide', 'square root'];
+
+type BenchmarkInputs = {
+  data: Float32Array;
+  expectedValues: Float64Array;
+};
+
+/** Runs a compact, interactive benchmark. It intentionally has no pass/fail performance limits. */
+export async function runFP64ComputeBenchmark(
+  device: Device
+): Promise<FP64ComputeBenchmarkResult[]> {
+  if (device.type !== 'webgpu') {
+    throw new Error('The FP64 compute benchmark requires WebGPU.');
+  }
+
+  await waitForGPU(device);
+
+  const results: FP64ComputeBenchmarkResult[] = [];
+  for (const operation of BENCHMARK_OPERATIONS) {
+    const inputs = makeBenchmarkInputs(operation);
+    for (const mode of BENCHMARK_MODES) {
+      try {
+        results.push(await runBenchmarkCase(device, mode, operation, inputs));
+      } catch (error) {
+        results.push({
+          error: error instanceof Error ? error.message : String(error),
+          mode,
+          operation,
+          timing: 'queue completion'
+        });
+      }
+    }
+  }
+  return results;
+}
+
+async function runBenchmarkCase(
+  device: Device,
+  mode: FP64BenchmarkMode,
+  operation: FP64BenchmarkOperation,
+  inputs: BenchmarkInputs
+): Promise<FP64ComputeBenchmarkResult> {
+  const inputBuffer = device.createBuffer({
+    id: `fp64-benchmark-${mode}-${operation}-input`,
+    data: inputs.data,
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  const outputBuffer = device.createBuffer({
+    id: `fp64-benchmark-${mode}-${operation}-output`,
+    byteLength: LANE_COUNT * 2 * Float32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  let computation: Computation | null = null;
+  let timestampQuerySet: QuerySet | null = null;
+
+  try {
+    computation = makeComputation(device, mode, operation);
+    timestampQuerySet = makeTimestampQuerySet(device, mode, operation);
+    computation.setBindings({inputValues: inputBuffer, outputValues: outputBuffer});
+    computation.updateShaderInputs();
+
+    const warmupPass = device.beginComputePass({});
+    computation.dispatch(warmupPass, WORKGROUP_COUNT);
+    warmupPass.end();
+    device.submit();
+    await waitForGPU(device);
+
+    const timedPass = device.beginComputePass(
+      timestampQuerySet
+        ? {
+            timestampQuerySet,
+            beginTimestampIndex: 0,
+            endTimestampIndex: 1
+          }
+        : {}
+    );
+    for (let dispatchIndex = 0; dispatchIndex < TIMED_DISPATCH_COUNT; dispatchIndex++) {
+      computation.dispatch(timedPass, WORKGROUP_COUNT);
+    }
+    timedPass.end();
+
+    const submitTime = performance.now();
+    device.submit();
+    await waitForGPU(device);
+    const completionMilliseconds = performance.now() - submitTime;
+    const gpuMilliseconds = await tryReadTimestampDuration(timestampQuerySet);
+    const runtimeMilliseconds = gpuMilliseconds ?? completionMilliseconds;
+
+    // Reading results is deliberately outside the timed region.
+    const outputBytes = await outputBuffer.readAsync();
+    const outputValues = new Float32Array(
+      outputBytes.buffer,
+      outputBytes.byteOffset,
+      outputBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+    );
+    const maximumRelativeError = getMaximumRelativeError(outputValues, inputs.expectedValues, mode);
+    const iterationCount = LANE_COUNT * WORK_ITERATIONS * TIMED_DISPATCH_COUNT;
+
+    return {
+      maximumRelativeError,
+      mode,
+      operation,
+      runtimeMilliseconds,
+      throughputMillionIterationsPerSecond: iterationCount / runtimeMilliseconds / 1000,
+      timing: gpuMilliseconds === undefined ? 'queue completion' : 'GPU timestamp'
+    };
+  } finally {
+    timestampQuerySet?.destroy();
+    computation?.destroy();
+    outputBuffer.destroy();
+    inputBuffer.destroy();
+  }
+}
+
+function makeComputation(
+  device: Device,
+  mode: FP64BenchmarkMode,
+  operation: FP64BenchmarkOperation
+): Computation {
+  const useFloat32 = mode === 'float32';
+  const defines: Record<string, boolean | number> = {};
+  if (mode === 'classic') {
+    defines['LUMA_FP64_INTEGER_ARITHMETIC'] = false;
+  } else if (mode === 'integer') {
+    defines['LUMA_FP64_INTEGER_ARITHMETIC'] = true;
+  }
+  const usesClassicSplit =
+    operation !== 'add' &&
+    (mode === 'classic' || (mode === 'automatic' && device.info.gpu !== 'apple'));
+  const storageBindings: ComputeShaderLayout['bindings'] = [
+    {name: 'inputValues', type: 'read-only-storage', group: 0, location: 1},
+    {name: 'outputValues', type: 'storage', group: 0, location: 2}
+  ];
+  const shaderLayout: ComputeShaderLayout = {
+    bindings: usesClassicSplit
+      ? [
+          {
+            name: 'fp64arithmeticUniforms',
+            type: 'uniform',
+            group: 0,
+            location: FP64_ARITHMETIC_UNIFORM_BINDING
+          },
+          ...storageBindings
+        ]
+      : storageBindings
+  };
+
+  return new Computation(device, {
+    id: `fp64-benchmark-${mode}-${operation}`,
+    source: makeBenchmarkShader(operation, useFloat32),
+    modules: useFloat32 ? [] : [FP64_BENCHMARK_MODULE],
+    defines,
+    shaderLayout,
+    // Do not create a managed module-uniform binding when the selected path
+    // cannot reach classic split(). The declaration is absent from the
+    // caller-owned layout in those cases and an extra logical binding would
+    // produce a misleading validation warning.
+    shaderInputs: new ShaderInputs(usesClassicSplit ? {fp64arithmetic} : {})
+  });
+}
+
+function makeBenchmarkShader(operation: FP64BenchmarkOperation, useFloat32: boolean): string {
+  const operationExpression = getOperationExpression(operation, useFloat32);
+  const valueType = useFloat32 ? 'f32' : 'vec2<f32>';
+  const initialValue = useFloat32 ? 'benchmarkInput.value.x' : 'benchmarkInput.value';
+  const operand = useFloat32 ? 'benchmarkInput.operand.x' : 'benchmarkInput.operand';
+  const outputValue = useFloat32 ? 'vec2<f32>(value, 0.0)' : 'value';
+
+  return /* wgsl */ `\
+struct BenchmarkInput {
+  value: vec2<f32>,
+  operand: vec2<f32>,
+};
+
+@group(0) @binding(1) var<storage, read> inputValues: array<BenchmarkInput>;
+@group(0) @binding(2) var<storage, read_write> outputValues: array<vec2<f32>>;
+
+@compute @workgroup_size(${WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) globalInvocationId: vec3<u32>) {
+  let index = globalInvocationId.x;
+  let benchmarkInput = inputValues[index];
+  var value: ${valueType} = ${initialValue};
+  let operand: ${valueType} = ${operand};
+  for (
+    var iteration = 0u;
+    iteration < ${WORK_ITERATIONS}u;
+    iteration = iteration + 1u
+  ) {
+    value = ${operationExpression};
+  }
+  outputValues[index] = ${outputValue};
+}
+`;
+}
+
+function getOperationExpression(operation: FP64BenchmarkOperation, useFloat32: boolean): string {
+  if (useFloat32) {
+    switch (operation) {
+      case 'add':
+        return 'value + operand';
+      case 'multiply':
+        return 'value * operand';
+      case 'divide':
+        return 'value / operand';
+      case 'square root':
+        return 'sqrt(value + operand)';
+    }
+  }
+
+  switch (operation) {
+    case 'add':
+      return 'sum_fp64(value, operand)';
+    case 'multiply':
+      return 'mul_fp64(value, operand)';
+    case 'divide':
+      return 'div_fp64(value, operand)';
+    case 'square root':
+      return 'sqrt_fp64(sum_fp64(value, operand))';
+  }
+}
+
+function makeBenchmarkInputs(operation: FP64BenchmarkOperation): BenchmarkInputs {
+  const data = new Float32Array(LANE_COUNT * 4);
+  const expectedValues = new Float64Array(LANE_COUNT);
+
+  for (let laneIndex = 0; laneIndex < LANE_COUNT; laneIndex++) {
+    const fraction = laneIndex / (LANE_COUNT - 1);
+    const [initialValue, operand] = getInputValues(operation, laneIndex, fraction);
+    const [valueHigh, valueLow] = split64(initialValue);
+    const [operandHigh, operandLow] = split64(operand);
+    const dataOffset = laneIndex * 4;
+    data[dataOffset] = valueHigh;
+    data[dataOffset + 1] = valueLow;
+    data[dataOffset + 2] = operandHigh;
+    data[dataOffset + 3] = operandLow;
+
+    let expectedValue = initialValue;
+    for (let iteration = 0; iteration < WORK_ITERATIONS; iteration++) {
+      expectedValue = applyReferenceOperation(operation, expectedValue, operand);
+    }
+    expectedValues[laneIndex] = expectedValue;
+  }
+
+  return {data, expectedValues};
+}
+
+function getInputValues(
+  operation: FP64BenchmarkOperation,
+  laneIndex: number,
+  fraction: number
+): [number, number] {
+  const lowPart = ((laneIndex % 13) - 6) * 2 ** -31;
+  switch (operation) {
+    case 'add':
+      return [0.75 + fraction * 0.5 + lowPart, 2 ** -27 * (1 + (laneIndex % 7) / 16)];
+    case 'multiply':
+      return [0.75 + fraction * 0.5 + lowPart, 1 + 2 ** -20 + (laneIndex % 5) * 2 ** -24];
+    case 'divide':
+      return [0.75 + fraction * 0.5 + lowPart, 1 + 2 ** -20 + (laneIndex % 5) * 2 ** -24];
+    case 'square root':
+      return [1 + fraction * 3 + lowPart, 0.125 + (laneIndex % 11) * 2 ** -18];
+  }
+}
+
+function applyReferenceOperation(
+  operation: FP64BenchmarkOperation,
+  value: number,
+  operand: number
+): number {
+  switch (operation) {
+    case 'add':
+      return value + operand;
+    case 'multiply':
+      return value * operand;
+    case 'divide':
+      return value / operand;
+    case 'square root':
+      return Math.sqrt(value + operand);
+  }
+}
+
+function split64(value: number): [number, number] {
+  const highPart = Math.fround(value);
+  return [highPart, value - highPart];
+}
+
+function makeTimestampQuerySet(
+  device: Device,
+  mode: FP64BenchmarkMode,
+  operation: FP64BenchmarkOperation
+): QuerySet | null {
+  if (!device.features.has('timestamp-query')) {
+    return null;
+  }
+  try {
+    return device.createQuerySet({
+      id: `fp64-benchmark-${mode}-${operation}-timestamps`,
+      type: 'timestamp',
+      count: 2
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function tryReadTimestampDuration(querySet: QuerySet | null): Promise<number | undefined> {
+  if (!querySet) {
+    return undefined;
+  }
+  try {
+    const duration = await querySet.readTimestampDuration(0, 1);
+    return Number.isFinite(duration) && duration > 0 ? duration : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getMaximumRelativeError(
+  outputValues: Float32Array,
+  expectedValues: Float64Array,
+  mode: FP64BenchmarkMode
+): number {
+  let maximumRelativeError = 0;
+  for (let laneIndex = 0; laneIndex < LANE_COUNT; laneIndex++) {
+    const outputOffset = laneIndex * 2;
+    const actualValue =
+      outputValues[outputOffset] + (mode === 'float32' ? 0 : outputValues[outputOffset + 1]);
+    const expectedValue = expectedValues[laneIndex];
+    const relativeError = Math.abs(actualValue - expectedValue) / Math.abs(expectedValue);
+    maximumRelativeError = Math.max(maximumRelativeError, relativeError);
+  }
+  return maximumRelativeError;
+}
+
+async function waitForGPU(device: Device): Promise<void> {
+  const webgpuQueue = (device.handle as {queue: {onSubmittedWorkDone: () => Promise<void>}}).queue;
+  await webgpuQueue.onSubmittedWorkDone();
+}

--- a/modules/shadertools/src/lib/shader-assembler.ts
+++ b/modules/shadertools/src/lib/shader-assembler.ts
@@ -198,6 +198,11 @@ function getPlatformPreprocessorDefines(
   const limits = platformInfo.limits || {};
   return {
     LUMA_SUPPORTS_VERTEX_STORAGE_BUFFERS:
-      platformInfo.type === 'webgpu' && (limits['maxStorageBuffersInVertexStage'] || 0) > 0
+      platformInfo.type === 'webgpu' && (limits['maxStorageBuffersInVertexStage'] || 0) > 0,
+    // Metal may reassociate the floating-point transforms used by classic
+    // double-single arithmetic. The integer path makes each rounding point
+    // explicit while preserving the public vec2<f32> representation.
+    LUMA_FP64_INTEGER_ARITHMETIC:
+      platformInfo.type === 'webgpu' && platformInfo.gpu.toLowerCase() === 'apple'
   };
 }

--- a/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl-integer.ts
+++ b/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl-integer.ts
@@ -1,0 +1,454 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/**
+ * Optimizer-independent double-single arithmetic for WGSL implementations that
+ * cannot preserve the rounding points required by the classic floating-point
+ * error-free transforms.
+ *
+ * This source is interpolated into fp64-arithmetic-wgsl.ts after the shared
+ * integer helpers. It intentionally keeps the public vec2<f32> API unchanged.
+ */
+export const fp64arithmeticWGSLInteger = /* wgsl */ `\
+struct Fp64F32Bits {
+  sign: u32,
+  baseExponent: i32,
+  significand: u32,
+  isZero: bool,
+  isInf: bool,
+  isNan: bool,
+};
+
+// Decode an f32 as (-1)^sign * significand * 2^baseExponent.
+fn fp64_decode_f32_bits(bits: u32) -> Fp64F32Bits {
+  let sign = bits >> 31u;
+  let exponentBits = (bits >> 23u) & 0xffu;
+  let fraction = bits & 0x7fffffu;
+
+  if (exponentBits == 0xffu) {
+    return Fp64F32Bits(sign, 0, 0u, false, fraction == 0u, fraction != 0u);
+  }
+  if (exponentBits == 0u) {
+    return Fp64F32Bits(sign, -149, fraction, fraction == 0u, false, false);
+  }
+  return Fp64F32Bits(sign, i32(exponentBits) - 150, 0x800000u | fraction, false, false, false);
+}
+
+fn fp64_f32_magnitude_compare(aBits: u32, bBits: u32) -> i32 {
+  let aMagnitude = aBits & 0x7fffffffu;
+  let bMagnitude = bBits & 0x7fffffffu;
+  if (aMagnitude == bMagnitude) {
+    return 0;
+  }
+  return select(-1, 1, aMagnitude > bMagnitude);
+}
+
+fn fp64_make_residual_f32_bits(
+  exactSign: u32,
+  exactMagnitude: vec2u,
+  exactBaseExponent: i32,
+  highBits: u32
+) -> u32 {
+  if (fp64_u64_is_zero(exactMagnitude)) {
+    return 0u;
+  }
+
+  let high = fp64_decode_f32_bits(highBits);
+  if (high.isInf || high.isNan) {
+    return exactSign << 31u;
+  }
+  if (high.isZero) {
+    return fp64_make_f32_bits_from_u64(exactSign, exactMagnitude, exactBaseExponent);
+  }
+
+  let commonBaseExponent = min(exactBaseExponent, high.baseExponent);
+  let exactShift = exactBaseExponent - commonBaseExponent;
+  let highShift = high.baseExponent - commonBaseExponent;
+
+  // A normal two-sum/two-product residual never needs a shift this large.
+  // This guard gives deterministic underflow behavior outside that contract.
+  if (exactShift >= 64 || highShift >= 64) {
+    return exactSign << 31u;
+  }
+
+  let exactAligned = fp64_u64_shift_left(exactMagnitude, u32(exactShift));
+  let highAligned = fp64_u64_shift_left(vec2u(0u, high.significand), u32(highShift));
+  let comparison = fp64_u64_compare(exactAligned, highAligned);
+  if (comparison == 0) {
+    return 0u;
+  }
+
+  var residualSign = exactSign;
+  var residualMagnitude: vec2u;
+  if (comparison > 0) {
+    residualMagnitude = fp64_u64_sub(exactAligned, highAligned);
+  } else {
+    residualSign = exactSign ^ 1u;
+    residualMagnitude = fp64_u64_sub(highAligned, exactAligned);
+  }
+  return fp64_make_f32_bits_from_u64(
+    residualSign,
+    residualMagnitude,
+    commonBaseExponent
+  );
+}
+
+fn fp64_split_accumulator_bits(
+  sign: u32,
+  magnitude: vec2u,
+  baseExponent: i32
+) -> vec2u {
+  let highBits = fp64_make_f32_bits_from_u64(sign, magnitude, baseExponent);
+  let lowBits = fp64_make_residual_f32_bits(sign, magnitude, baseExponent, highBits);
+  return vec2u(highBits, lowBits);
+}
+
+fn fp64_two_sum_integer_bits(aBits: u32, bBits: u32) -> vec2u {
+  let a = fp64_decode_f32_bits(aBits);
+  let b = fp64_decode_f32_bits(bBits);
+
+  if (a.isNan || b.isNan) {
+    return vec2u(0x7fc00000u, 0u);
+  }
+  if (a.isInf || b.isInf) {
+    if (a.isInf && b.isInf && a.sign != b.sign) {
+      return vec2u(0x7fc00000u, 0u);
+    }
+    return select(vec2u(bBits, 0u), vec2u(aBits, 0u), a.isInf);
+  }
+  if (a.isZero && b.isZero) {
+    return vec2u((a.sign & b.sign) << 31u, 0u);
+  }
+  if (a.isZero) {
+    return vec2u(bBits, 0u);
+  }
+  if (b.isZero) {
+    return vec2u(aBits, 0u);
+  }
+
+  let exponentDifference = select(
+    b.baseExponent - a.baseExponent,
+    a.baseExponent - b.baseExponent,
+    a.baseExponent >= b.baseExponent
+  );
+
+  // Beyond half an ulp, rounding cannot change the larger operand. Returning
+  // the smaller operand intact also avoids an unbounded integer alignment.
+  // At a power-of-two boundary the spacing below the larger operand is half
+  // the spacing above it, so an opposite-sign gap-25 operand can still change
+  // the rounded high limb. Gap 26 is the first universally safe early-out.
+  if (exponentDifference > 25) {
+    if (fp64_f32_magnitude_compare(aBits, bBits) >= 0) {
+      return vec2u(aBits, bBits);
+    }
+    return vec2u(bBits, aBits);
+  }
+
+  let commonBaseExponent = min(a.baseExponent, b.baseExponent);
+  let aMagnitude = fp64_u64_shift_left(
+    vec2u(0u, a.significand),
+    u32(a.baseExponent - commonBaseExponent)
+  );
+  let bMagnitude = fp64_u64_shift_left(
+    vec2u(0u, b.significand),
+    u32(b.baseExponent - commonBaseExponent)
+  );
+
+  var resultSign = a.sign;
+  var resultMagnitude: vec2u;
+  if (a.sign == b.sign) {
+    resultMagnitude = fp64_u64_add(aMagnitude, bMagnitude);
+  } else {
+    let comparison = fp64_u64_compare(aMagnitude, bMagnitude);
+    if (comparison == 0) {
+      return vec2u(0u, 0u);
+    }
+    if (comparison > 0) {
+      resultMagnitude = fp64_u64_sub(aMagnitude, bMagnitude);
+    } else {
+      resultSign = b.sign;
+      resultMagnitude = fp64_u64_sub(bMagnitude, aMagnitude);
+    }
+  }
+
+  return fp64_split_accumulator_bits(resultSign, resultMagnitude, commonBaseExponent);
+}
+
+fn fp64_two_sum_integer(a: f32, b: f32) -> vec2f {
+  let resultBits = fp64_two_sum_integer_bits(bitcast<u32>(a), bitcast<u32>(b));
+  return vec2f(bitcast<f32>(resultBits.x), bitcast<f32>(resultBits.y));
+}
+
+fn fp64_multiply_significands(a: u32, b: u32) -> vec2u {
+  let aLow = a & 0xffffu;
+  let aHigh = a >> 16u;
+  let bLow = b & 0xffffu;
+  let bHigh = b >> 16u;
+  let lowProduct = aLow * bLow;
+  let crossProduct = aLow * bHigh + aHigh * bLow;
+  let highProduct = aHigh * bHigh;
+
+  var result = vec2u(0u, lowProduct);
+  result = fp64_u64_add(
+    result,
+    fp64_u64_shift_left(vec2u(0u, crossProduct), 16u)
+  );
+  result = fp64_u64_add(result, vec2u(highProduct, 0u));
+  return result;
+}
+
+fn fp64_two_prod_integer_bits(aBits: u32, bBits: u32) -> vec2u {
+  let a = fp64_decode_f32_bits(aBits);
+  let b = fp64_decode_f32_bits(bBits);
+  let resultSign = a.sign ^ b.sign;
+
+  if (a.isNan || b.isNan || ((a.isZero || b.isZero) && (a.isInf || b.isInf))) {
+    return vec2u(0x7fc00000u, 0u);
+  }
+  if (a.isInf || b.isInf) {
+    return vec2u((resultSign << 31u) | 0x7f800000u, resultSign << 31u);
+  }
+  if (a.isZero || b.isZero) {
+    return vec2u(resultSign << 31u, resultSign << 31u);
+  }
+
+  let magnitude = fp64_multiply_significands(a.significand, b.significand);
+  return fp64_split_accumulator_bits(
+    resultSign,
+    magnitude,
+    a.baseExponent + b.baseExponent
+  );
+}
+
+fn fp64_two_prod_integer(a: f32, b: f32) -> vec2f {
+  let resultBits = fp64_two_prod_integer_bits(bitcast<u32>(a), bitcast<u32>(b));
+  return vec2f(bitcast<f32>(resultBits.x), bitcast<f32>(resultBits.y));
+}
+
+fn fp64_round_add_integer(a: f32, b: f32) -> f32 {
+  return fp64_two_sum_integer(a, b).x;
+}
+
+fn fp64_round_mul_integer(a: f32, b: f32) -> f32 {
+  return fp64_two_prod_integer(a, b).x;
+}
+
+fn fp64_f32_finite_exponent(value: Fp64F32Bits) -> i32 {
+  let mostSignificantBit = 31u - countLeadingZeros(value.significand);
+  return value.baseExponent + i32(mostSignificantBit);
+}
+
+fn fp64_scale_f32_integer(value: f32, exponent: i32) -> f32 {
+  let decoded = fp64_decode_f32_bits(bitcast<u32>(value));
+  if (decoded.isZero || decoded.isInf || decoded.isNan) {
+    return value;
+  }
+  let resultBits = fp64_make_f32_bits_from_u64(
+    decoded.sign,
+    vec2u(0u, decoded.significand),
+    decoded.baseExponent + exponent
+  );
+  return bitcast<f32>(resultBits);
+}
+
+// Divide normalized significands so the hardware operation cannot overflow,
+// underflow, or flush a subnormal result. Reapply the exponent with integer
+// packing, which also produces subnormal correction limbs without relying on
+// floating-point arithmetic to preserve them.
+fn fp64_divide_f32_integer(aValue: f32, bValue: f32) -> f32 {
+  let a = fp64_decode_f32_bits(bitcast<u32>(aValue));
+  let b = fp64_decode_f32_bits(bitcast<u32>(bValue));
+  if (a.isZero || b.isZero || a.isInf || b.isInf || a.isNan || b.isNan) {
+    return aValue / bValue;
+  }
+
+  let aMostSignificantBit = 31u - countLeadingZeros(a.significand);
+  let bMostSignificantBit = 31u - countLeadingZeros(b.significand);
+  let normalizedABits = fp64_make_f32_bits_from_u64(
+    a.sign,
+    vec2u(0u, a.significand),
+    -i32(aMostSignificantBit)
+  );
+  let normalizedBBits = fp64_make_f32_bits_from_u64(
+    b.sign,
+    vec2u(0u, b.significand),
+    -i32(bMostSignificantBit)
+  );
+  let normalizedQuotient = bitcast<f32>(normalizedABits) / bitcast<f32>(normalizedBBits);
+  let quotient = fp64_decode_f32_bits(bitcast<u32>(normalizedQuotient));
+  let exponentShift =
+    a.baseExponent + i32(aMostSignificantBit) -
+    b.baseExponent - i32(bMostSignificantBit);
+  let quotientBits = fp64_make_f32_bits_from_u64(
+    quotient.sign,
+    vec2u(0u, quotient.significand),
+    quotient.baseExponent + exponentShift
+  );
+  return bitcast<f32>(quotientBits);
+}
+
+fn split(a: f32) -> vec2f {
+  let aBits = bitcast<u32>(a);
+  let decoded = fp64_decode_f32_bits(aBits);
+  if (decoded.isZero || decoded.isInf || decoded.isNan) {
+    return vec2f(a, 0.0);
+  }
+
+  var roundedHigh = decoded.significand >> 12u;
+  let remainder = decoded.significand & 0xfffu;
+  if (remainder > 0x800u || (remainder == 0x800u && (roundedHigh & 1u) == 1u)) {
+    roundedHigh = roundedHigh + 1u;
+  }
+  var highMagnitude = vec2u(0u, roundedHigh << 12u);
+  var highBits = fp64_make_f32_bits_from_u64(
+    decoded.sign,
+    highMagnitude,
+    decoded.baseExponent
+  );
+  // Rounding the high limb of a maximum-exponent value can overflow even
+  // though the original value is finite. Truncate only in that boundary case
+  // so split remains an exact finite decomposition.
+  if (fp64_decode_f32_bits(highBits).isInf) {
+    roundedHigh = decoded.significand >> 12u;
+    highMagnitude = vec2u(0u, roundedHigh << 12u);
+    highBits = fp64_make_f32_bits_from_u64(
+      decoded.sign,
+      highMagnitude,
+      decoded.baseExponent
+    );
+  }
+  let lowBits = fp64_make_residual_f32_bits(
+    decoded.sign,
+    vec2u(0u, decoded.significand),
+    decoded.baseExponent,
+    highBits
+  );
+  return vec2f(bitcast<f32>(highBits), bitcast<f32>(lowBits));
+}
+
+fn split2(a: vec2f) -> vec2f {
+  var result = split(a.x);
+  result.y = fp64_round_add_integer(result.y, a.y);
+  return result;
+}
+
+fn quickTwoSum(a: f32, b: f32) -> vec2f {
+  return fp64_two_sum_integer(a, b);
+}
+
+fn twoSum(a: f32, b: f32) -> vec2f {
+  return fp64_two_sum_integer(a, b);
+}
+
+fn twoSub(a: f32, b: f32) -> vec2f {
+  let bBits = bitcast<u32>(b) ^ 0x80000000u;
+  let resultBits = fp64_two_sum_integer_bits(bitcast<u32>(a), bBits);
+  return vec2f(bitcast<f32>(resultBits.x), bitcast<f32>(resultBits.y));
+}
+
+fn twoSqr(a: f32) -> vec2f {
+  return fp64_two_prod_integer(a, a);
+}
+
+fn twoProd(a: f32, b: f32) -> vec2f {
+  return fp64_two_prod_integer(a, b);
+}
+
+fn sum_fp64(a: vec2f, b: vec2f) -> vec2f {
+  var sum = fp64_two_sum_integer(a.x, b.x);
+  let lowSum = fp64_two_sum_integer(a.y, b.y);
+  sum.y = fp64_round_add_integer(sum.y, lowSum.x);
+  sum = fp64_two_sum_integer(sum.x, sum.y);
+  sum.y = fp64_round_add_integer(sum.y, lowSum.y);
+  return fp64_two_sum_integer(sum.x, sum.y);
+}
+
+fn sub_fp64(a: vec2f, b: vec2f) -> vec2f {
+  let negatedB = vec2f(
+    bitcast<f32>(bitcast<u32>(b.x) ^ 0x80000000u),
+    bitcast<f32>(bitcast<u32>(b.y) ^ 0x80000000u)
+  );
+  return sum_fp64(a, negatedB);
+}
+
+fn mul_fp64(a: vec2f, b: vec2f) -> vec2f {
+  var product = fp64_two_prod_integer(a.x, b.x);
+  let crossProduct1 = fp64_round_mul_integer(a.x, b.y);
+  product.y = fp64_round_add_integer(product.y, crossProduct1);
+  product = fp64_two_sum_integer(product.x, product.y);
+  let crossProduct2 = fp64_round_mul_integer(a.y, b.x);
+  product.y = fp64_round_add_integer(product.y, crossProduct2);
+  return fp64_two_sum_integer(product.x, product.y);
+}
+
+fn fp64_scale_fp64_integer(value: vec2f, exponent: i32) -> vec2f {
+  let high = fp64_scale_f32_integer(value.x, exponent);
+  let low = fp64_scale_f32_integer(value.y, exponent);
+  return sum_fp64(vec2f(high, 0.0), vec2f(low, 0.0));
+}
+
+fn fp64_div_fp64_normalized(a: vec2f, b: vec2f) -> vec2f {
+  let quotientHigh = fp64_divide_f32_integer(a.x, b.x);
+  var quotient = vec2f(quotientHigh, 0.0);
+
+  let remainder = sub_fp64(a, mul_fp64(b, quotient));
+  let quotientLow = fp64_divide_f32_integer(remainder.x, b.x);
+  quotient = sum_fp64(quotient, vec2f(quotientLow, 0.0));
+
+  let secondRemainder = sub_fp64(a, mul_fp64(b, quotient));
+  let correction = fp64_divide_f32_integer(secondRemainder.x, b.x);
+  return sum_fp64(quotient, vec2f(correction, 0.0));
+}
+
+fn div_fp64(a: vec2f, b: vec2f) -> vec2f {
+  let decodedA = fp64_decode_f32_bits(bitcast<u32>(a.x));
+  let decodedB = fp64_decode_f32_bits(bitcast<u32>(b.x));
+  if (
+    decodedA.isZero || decodedB.isZero ||
+    decodedA.isInf || decodedB.isInf ||
+    decodedA.isNan || decodedB.isNan
+  ) {
+    return fp64_div_fp64_normalized(a, b);
+  }
+
+  let exponentA = fp64_f32_finite_exponent(decodedA);
+  let exponentB = fp64_f32_finite_exponent(decodedB);
+  // Correct the quotient near unity so b * q and the remainder stay clear of
+  // both f32 underflow and overflow. The exponent difference is applied once.
+  let normalizedA = fp64_scale_fp64_integer(a, -exponentA);
+  let normalizedB = fp64_scale_fp64_integer(b, -exponentB);
+  let normalizedQuotient = fp64_div_fp64_normalized(normalizedA, normalizedB);
+  return fp64_scale_fp64_integer(normalizedQuotient, exponentA - exponentB);
+}
+
+fn fp64_sqrt_fp64_normalized(a: vec2f) -> vec2f {
+  let estimate = sqrt(a.x);
+  let difference = sub_fp64(a, fp64_two_prod_integer(estimate, estimate)).x;
+  let denominator = fp64_round_add_integer(estimate, estimate);
+  let correction = fp64_divide_f32_integer(difference, denominator);
+  return sum_fp64(vec2f(estimate, 0.0), vec2f(correction, 0.0));
+}
+
+fn sqrt_fp64(a: vec2f) -> vec2f {
+  let decoded = fp64_decode_f32_bits(bitcast<u32>(a.x));
+  let decodedLow = fp64_decode_f32_bits(bitcast<u32>(a.y));
+  if (decoded.isZero && decodedLow.isZero) {
+    return vec2f(0.0, 0.0);
+  }
+  if (decoded.sign == 1u) {
+    let nanValue = fp64_nan(a.x);
+    return vec2f(nanValue, nanValue);
+  }
+
+  if (decoded.isInf || decoded.isNan) {
+    return fp64_sqrt_fp64_normalized(a);
+  }
+  let exponent = fp64_f32_finite_exponent(decoded);
+  // An even scale lets the final square-root rescale use an integer exponent.
+  let evenExponent = exponent - (exponent & 1);
+  let normalizedA = fp64_scale_fp64_integer(a, -evenExponent);
+  let normalizedRoot = fp64_sqrt_fp64_normalized(normalizedA);
+  return fp64_scale_fp64_integer(normalizedRoot, evenExponent / 2);
+}
+`;

--- a/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl.ts
+++ b/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import {fp64arithmeticWGSLInteger} from './fp64-arithmetic-wgsl-integer';
+
 /** WGSL source for fp64 arithmetic helpers and raw binary64-to-Float32 subtraction. */
 export const fp64arithmeticWGSL = /* wgsl */ `\
 struct Fp64ArithmeticUniforms {
@@ -295,6 +297,9 @@ fn prevent_fp64_optimization(value: f32) -> f32 {
 #endif
 }
 
+#ifdef LUMA_FP64_INTEGER_ARITHMETIC
+${fp64arithmeticWGSLInteger}
+#else
 fn split(a: f32) -> vec2f {
   let splitValue = prevent_fp64_optimization(fp64arithmetic.SPLIT + fp64_runtime_zero());
   let t = prevent_fp64_optimization(a * splitValue);
@@ -477,4 +482,5 @@ fn sqrt_fp64(a: vec2f) -> vec2f {
   return sum_fp64(vec2f(yn, 0.0), prod);
 #endif
 }
+#endif
 `;

--- a/modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.ts
@@ -10,6 +10,7 @@ import {ibl} from '../../../src/modules/lighting/ibl/ibl';
 import {lighting} from '../../../src/modules/lighting/lights/lighting';
 import {dirlight} from '../../../src/modules/lighting/no-material/dirlight';
 import {pbrProjection} from '../../../src/modules/lighting/pbr-material/pbr-projection';
+import {fp64arithmetic} from '../../../src/modules/math/fp64/fp64';
 
 const PLATFORM_INFO: PlatformInfo = {
   type: 'webgpu',
@@ -18,6 +19,9 @@ const PLATFORM_INFO: PlatformInfo = {
   shaderLanguageVersion: 300,
   features: new Set()
 };
+
+const FP64_INTEGER_MARKER = 'fn fp64_two_sum_integer_bits';
+const FP64_CLASSIC_MARKER = 'let splitValue = prevent_fp64_optimization';
 
 const APP_WGSL = /* wgsl */ `\
 struct AppFrameUniforms {
@@ -32,6 +36,54 @@ fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> @builtin(position) vec
   return vec4<f32>(x, 0.0, 0.0, 1.0);
 }
 `;
+
+test('assembleWGSLShader#selects optimizer-independent fp64 arithmetic', t => {
+  const shaderAssembler = new ShaderAssembler();
+
+  const appleSource = shaderAssembler.assembleWGSLShader({
+    platformInfo: {...PLATFORM_INFO, gpu: 'apple'},
+    source: APP_WGSL,
+    modules: [fp64arithmetic]
+  }).source;
+  t.ok(appleSource.includes(FP64_INTEGER_MARKER), 'Apple WebGPU selects integer arithmetic');
+  t.notOk(appleSource.includes(FP64_CLASSIC_MARKER), 'Apple WebGPU omits classic arithmetic');
+
+  const defaultSource = shaderAssembler.assembleWGSLShader({
+    platformInfo: PLATFORM_INFO,
+    source: APP_WGSL,
+    modules: [fp64arithmetic]
+  }).source;
+  t.ok(
+    defaultSource.includes(FP64_CLASSIC_MARKER),
+    'other WebGPU adapters retain classic arithmetic'
+  );
+  t.notOk(
+    defaultSource.includes(FP64_INTEGER_MARKER),
+    'integer arithmetic is not enabled globally'
+  );
+
+  const forcedSource = shaderAssembler.assembleWGSLShader({
+    platformInfo: PLATFORM_INFO,
+    source: APP_WGSL,
+    modules: [fp64arithmetic],
+    defines: {LUMA_FP64_INTEGER_ARITHMETIC: true}
+  }).source;
+  t.ok(forcedSource.includes(FP64_INTEGER_MARKER), 'callers can force integer arithmetic');
+
+  const disabledSource = shaderAssembler.assembleWGSLShader({
+    platformInfo: {...PLATFORM_INFO, gpu: 'apple'},
+    source: APP_WGSL,
+    modules: [fp64arithmetic],
+    defines: {LUMA_FP64_INTEGER_ARITHMETIC: false}
+  }).source;
+  t.ok(disabledSource.includes(FP64_CLASSIC_MARKER), 'callers can disable the Apple default');
+  t.notOk(
+    disabledSource.includes(FP64_INTEGER_MARKER),
+    'false override removes integer arithmetic'
+  );
+
+  t.end();
+});
 
 const APP_GROUP_0_AUTO_WGSL = /* wgsl */ `\
 struct AppAutoUniforms {

--- a/modules/shadertools/test/modules/math/fp64-arithmetic-compute.spec.ts
+++ b/modules/shadertools/test/modules/math/fp64-arithmetic-compute.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {Buffer} from '@luma.gl/core';
+import {Buffer, type Device} from '@luma.gl/core';
 import {Computation, ShaderInputs} from '@luma.gl/engine';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import {equals, config} from '@math.gl/core';
@@ -497,6 +497,11 @@ test('fp64 WGSL#integer division and square root preserve subnormal limbs', asyn
     tapeTest.end();
     return;
   }
+  if (isSoftwareBackedDevice(webgpuDevice)) {
+    tapeTest.comment('Skipping slow fp64 integer division and square root on software WebGPU');
+    tapeTest.end();
+    return;
+  }
 
   const expectedBits = new Uint32Array([0x00000001, 0x80000001, 0x00000000, 0x00000001]);
   const resultBuffer = webgpuDevice.createBuffer({
@@ -547,6 +552,11 @@ for (const arithmeticOperation of ARITHMETIC_OPERATIONS) {
     const webgpuDevice = await getWebGPUTestDevice();
     if (!webgpuDevice) {
       tapeTest.comment('WebGPU unavailable, skipping fp64 WGSL arithmetic tests');
+      tapeTest.end();
+      return;
+    }
+    if (isSoftwareBackedDevice(webgpuDevice)) {
+      tapeTest.comment('Skipping slow fp64 integer arithmetic on software WebGPU');
       tapeTest.end();
       return;
     }
@@ -659,6 +669,11 @@ for (const helperOperation of HELPER_OPERATIONS) {
     const webgpuDevice = await getWebGPUTestDevice();
     if (!webgpuDevice) {
       tapeTest.comment('WebGPU unavailable, skipping fp64 WGSL helper tests');
+      tapeTest.end();
+      return;
+    }
+    if (isSoftwareBackedDevice(webgpuDevice)) {
+      tapeTest.comment('Skipping slow fp64 integer helpers on software WebGPU');
       tapeTest.end();
       return;
     }
@@ -934,6 +949,14 @@ function makeWideExponentPrimitiveCases(count: number): IntegerPrimitiveCase[] {
 
 function getFp64IntegerTestDefines(gpu: string): Record<string, boolean> {
   // On Apple this deliberately exercises automatic platform selection. Other
-  // adapters force the path so that headless CI also compiles and executes it.
+  // hardware adapters force the path to keep cross-backend coverage. Software
+  // adapters only run the compact integer primitive test above because their
+  // shader compiler is prohibitively slow for the high-level function matrix.
   return gpu.toLowerCase() === 'apple' ? {} : {LUMA_FP64_INTEGER_ARITHMETIC: true};
+}
+
+function isSoftwareBackedDevice(device: Device): boolean {
+  return (
+    device.info.gpu === 'software' || device.info.gpuType === 'cpu' || Boolean(device.info.fallback)
+  );
 }

--- a/modules/shadertools/test/modules/math/fp64-arithmetic-compute.spec.ts
+++ b/modules/shadertools/test/modules/math/fp64-arithmetic-compute.spec.ts
@@ -11,15 +11,14 @@ import {fp64arithmetic, fp64ify} from '@luma.gl/shadertools';
 
 config.EPSILON = 1e-11;
 
-const ENABLE_WGSL_FP64_COMPUTE_DIAGNOSTICS = false;
-
-type ArithmeticOperationName = 'sum_fp64' | 'sub_fp64' | 'mul_fp64' | 'div_fp64';
-type HelperOperationName = 'split' | 'quickTwoSum' | 'twoSum' | 'twoSub' | 'twoProd';
+type ArithmeticOperationName = 'sum_fp64' | 'sub_fp64' | 'mul_fp64' | 'div_fp64' | 'sqrt_fp64';
+type HelperOperationName = 'split' | 'quickTwoSum' | 'twoSum' | 'twoSub' | 'twoSqr' | 'twoProd';
 
 type ArithmeticCase = {
   inputA: number;
   inputB: number;
   label: string;
+  operations?: ArithmeticOperationName[];
 };
 
 type HelperCase = {
@@ -48,18 +47,97 @@ type Fp64u32SubtractCase = {
   expectedBits?: number;
 };
 
+type IntegerPrimitiveCase = {
+  label: string;
+  inputA: number;
+  inputB: number;
+};
+
 const ARITHMETIC_CASES: ArithmeticCase[] = [
   {label: 'decimal pair', inputA: 0.1, inputB: 0.1},
   {label: 'mixed magnitude pair', inputA: 3.0e-19, inputB: 3.3e13},
   {label: 'large over medium', inputA: 1.4e9, inputB: 6.3e5},
-  {label: 'fraction over tiny', inputA: 0.3, inputB: 3.2e-16}
+  {label: 'fraction over tiny', inputA: 0.3, inputB: 3.2e-16},
+  {
+    label: 'low-limb cancellation',
+    inputA: 1 + 2 ** -30,
+    inputB: -1,
+    operations: ['sum_fp64']
+  },
+  {
+    label: 'signed arithmetic',
+    inputA: -2.75,
+    inputB: 0.125,
+    operations: ['sum_fp64', 'sub_fp64', 'mul_fp64', 'div_fp64']
+  },
+  {
+    label: 'maximum divided by itself',
+    inputA: 3.4028234663852886e38,
+    inputB: 3.4028234663852886e38,
+    operations: ['div_fp64']
+  },
+  {
+    label: 'maximum divided by finite scalar',
+    inputA: 3.4028234663852886e38,
+    inputB: 25,
+    operations: ['div_fp64']
+  },
+  {
+    label: 'negative maximum divided by maximum',
+    inputA: -3.4028234663852886e38,
+    inputB: 3.4028234663852886e38,
+    operations: ['div_fp64']
+  },
+  {
+    label: 'minimum normal divided by itself',
+    inputA: 2 ** -126,
+    inputB: 2 ** -126,
+    operations: ['div_fp64']
+  },
+  {
+    label: 'minimum normal operands with one-third quotient',
+    inputA: 2 ** -126,
+    inputB: 3 * 2 ** -126,
+    operations: ['div_fp64']
+  },
+  {
+    label: 'subnormal operands with normal quotient',
+    inputA: 2 ** -149,
+    inputB: 3 * 2 ** -149,
+    operations: ['div_fp64']
+  },
+  {
+    label: 'maximum square root',
+    inputA: 3.4028234663852886e38,
+    inputB: 1,
+    operations: ['sqrt_fp64']
+  },
+  {
+    label: 'minimum normal square root',
+    inputA: 2 ** -126,
+    inputB: 1,
+    operations: ['sqrt_fp64']
+  },
+  {
+    label: 'small normal square root with residual',
+    inputA: 3 * 2 ** -126,
+    inputB: 1,
+    operations: ['sqrt_fp64']
+  },
+  {
+    label: 'minimum subnormal square root',
+    inputA: 2 ** -149,
+    inputB: 1,
+    operations: ['sqrt_fp64']
+  }
 ];
 
 const ARITHMETIC_OPERATIONS: ArithmeticOperation[] = [
   {name: 'sum_fp64', operation: (inputA, inputB) => inputA + inputB},
   {name: 'sub_fp64', operation: (inputA, inputB) => inputA - inputB},
   {name: 'mul_fp64', operation: (inputA, inputB) => inputA * inputB},
-  {name: 'div_fp64', operation: (inputA, inputB) => inputA / inputB}
+  {name: 'div_fp64', operation: (inputA, inputB) => inputA / inputB},
+  {name: 'sqrt_fp64', operation: inputA => Math.sqrt(inputA)}
 ];
 
 const HELPER_OPERATIONS: HelperOperation[] = [
@@ -75,7 +153,13 @@ const HELPER_OPERATIONS: HelperOperation[] = [
         inputB: 0,
         expectNonZeroLowPart: true
       },
-      {label: 'tiny split', inputA: 3.2e-16, inputB: 0, expectNonZeroLowPart: true}
+      {label: 'tiny split', inputA: 3.2e-16, inputB: 0, expectNonZeroLowPart: true},
+      {
+        label: 'maximum finite split',
+        inputA: 3.4028234663852886e38,
+        inputB: 0,
+        expectNonZeroLowPart: true
+      }
     ]
   },
   {
@@ -123,7 +207,7 @@ const HELPER_OPERATIONS: HelperOperation[] = [
     expression: 'twoSub(inputA.x, inputB.x)',
     operation: (inputA, inputB) => inputA - inputB,
     cases: [
-      {label: 'decimal difference', inputA: 0.3, inputB: 0.2, expectNonZeroLowPart: true},
+      {label: 'decimal difference', inputA: 0.3, inputB: 0.2},
       {
         label: 'large minus tiny',
         inputA: 3.3e13,
@@ -136,6 +220,21 @@ const HELPER_OPERATIONS: HelperOperation[] = [
         inputB: 1.0e-8,
         expectNonZeroLowPart: true
       }
+    ]
+  },
+  {
+    name: 'twoSqr',
+    expression: 'twoSqr(inputA.x)',
+    operation: inputA => inputA * inputA,
+    cases: [
+      {label: 'decimal square', inputA: 0.1, inputB: 0, expectNonZeroLowPart: true},
+      {
+        label: 'seahorse square',
+        inputA: -0.743643887037151,
+        inputB: 0,
+        expectNonZeroLowPart: true
+      },
+      {label: 'near-one square', inputA: 1 + 2 ** -23, inputB: 0, expectNonZeroLowPart: true}
     ]
   },
   {
@@ -184,6 +283,22 @@ const FP64U32_SUBTRACT_CASES: Fp64u32SubtractCase[] = [
     expectedBits: 0x7fc00000
   },
   {label: 'nan propagation', inputA: NaN, inputB: 1, expectedBits: 0x7fc00000}
+];
+
+const INTEGER_PRIMITIVE_CASES: IntegerPrimitiveCase[] = [
+  {label: 'half ulp tie', inputA: 1, inputB: 2 ** -24},
+  {label: 'exponent gap 24', inputA: 2 ** 20, inputB: 2 ** -4},
+  {label: 'exponent gap 25', inputA: 2 ** 20, inputB: 2 ** -5},
+  {label: 'exponent gap 26', inputA: 2 ** 20, inputB: 2 ** -6},
+  {label: 'power boundary borrow', inputA: 1, inputB: -(3 * 2 ** -26)},
+  {label: 'negative power boundary borrow', inputA: -1, inputB: 3 * 2 ** -26},
+  {label: 'cancellation', inputA: 1, inputB: -(1 - 2 ** -23)},
+  {label: 'wide exponent gap', inputA: 2 ** 100, inputB: 2 ** -100},
+  {label: 'decimal pair', inputA: 0.1, inputB: 0.1},
+  {label: 'product carry', inputA: 1 + 2 ** -23, inputB: 1 + 2 ** -23},
+  {label: 'negative product', inputA: -0.743643887037151, inputB: 1.0e-8},
+  ...makeIntegerPrimitiveCases(64),
+  ...makeWideExponentPrimitiveCases(64)
 ];
 
 test('fp64 WGSL#sub_fp64u32_to_f32', async tapeTest => {
@@ -279,32 +394,174 @@ test('fp64 WGSL#sub_fp64u32_to_f32', async tapeTest => {
   tapeTest.end();
 });
 
+test('fp64 WGSL#integer twoSum and twoProd preserve exact residual bits', async tapeTest => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    tapeTest.comment('WebGPU unavailable, skipping fp64 WGSL integer primitive tests');
+    tapeTest.end();
+    return;
+  }
+
+  const encodedInputs = new Uint32Array(INTEGER_PRIMITIVE_CASES.length * 2);
+  const expectedResults = new Uint32Array(INTEGER_PRIMITIVE_CASES.length * 4);
+  for (let index = 0; index < INTEGER_PRIMITIVE_CASES.length; index++) {
+    const primitiveCase = INTEGER_PRIMITIVE_CASES[index];
+    const inputA = Math.fround(primitiveCase.inputA);
+    const inputB = Math.fround(primitiveCase.inputB);
+    encodedInputs[index * 2] = getFloat32Bits(inputA);
+    encodedInputs[index * 2 + 1] = getFloat32Bits(inputB);
+
+    const [sumHighBits, sumLowBits] = getExpectedTwoSumBits(inputA, inputB);
+    const exactProduct = inputA * inputB;
+    const productHigh = Math.fround(exactProduct);
+    const productLow = Math.fround(exactProduct - productHigh);
+    expectedResults.set(
+      [sumHighBits, sumLowBits, getFloat32Bits(productHigh), getFloat32Bits(productLow)],
+      index * 4
+    );
+  }
+
+  const inputBuffer = webgpuDevice.createBuffer({
+    data: encodedInputs,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  const resultBuffer = webgpuDevice.createBuffer({
+    byteLength: expectedResults.byteLength,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  const computation = new Computation(webgpuDevice, {
+    source: buildWGSLIntegerPrimitiveSource(),
+    modules: [fp64arithmetic],
+    defines: getFp64IntegerTestDefines(webgpuDevice.info.gpu),
+    shaderLayout: {
+      bindings: [
+        {name: 'inputData', type: 'storage', group: 0, location: 1},
+        {name: 'resultData', type: 'storage', group: 0, location: 2}
+      ]
+    }
+  });
+
+  try {
+    const compilationMessages = await (
+      computation.shader as typeof computation.shader & {
+        getCompilationInfo: () => Promise<readonly {message: string; type: string}[]>;
+      }
+    ).getCompilationInfo();
+    for (const message of compilationMessages.filter(message => message.type === 'error')) {
+      tapeTest.comment(`WGSL compilation error: ${message.message}`);
+    }
+    tapeTest.equal(
+      compilationMessages.filter(message => message.type === 'error').length,
+      0,
+      'integer fp64 WGSL compiles without errors'
+    );
+
+    computation.setBindings({inputData: inputBuffer, resultData: resultBuffer});
+    computation.updateShaderInputs();
+
+    const computePass = webgpuDevice.beginComputePass({});
+    computation.dispatch(computePass, INTEGER_PRIMITIVE_CASES.length);
+    computePass.end();
+    webgpuDevice.submit();
+
+    const resultBytes = await resultBuffer.readAsync();
+    const resultBits = new Uint32Array(
+      resultBytes.buffer,
+      resultBytes.byteOffset,
+      resultBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+    );
+    for (let index = 0; index < INTEGER_PRIMITIVE_CASES.length; index++) {
+      const label = INTEGER_PRIMITIVE_CASES[index].label;
+      for (let component = 0; component < 4; component++) {
+        const resultIndex = index * 4 + component;
+        tapeTest.equal(
+          resultBits[resultIndex],
+          expectedResults[resultIndex],
+          `${label} ${['sum high', 'sum low', 'product high', 'product low'][component]} bits`
+        );
+      }
+    }
+  } finally {
+    computation.destroy();
+    inputBuffer.destroy();
+    resultBuffer.destroy();
+  }
+
+  tapeTest.end();
+});
+
+test('fp64 WGSL#integer division and square root preserve subnormal limbs', async tapeTest => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    tapeTest.comment('WebGPU unavailable, skipping fp64 WGSL subnormal limb tests');
+    tapeTest.end();
+    return;
+  }
+
+  const expectedBits = new Uint32Array([0x00000001, 0x80000001, 0x00000000, 0x00000001]);
+  const resultBuffer = webgpuDevice.createBuffer({
+    byteLength: expectedBits.byteLength,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  const computation = new Computation(webgpuDevice, {
+    source: buildWGSLIntegerSubnormalSource(),
+    modules: [fp64arithmetic],
+    defines: getFp64IntegerTestDefines(webgpuDevice.info.gpu),
+    shaderLayout: {
+      bindings: [{name: 'resultData', type: 'storage', group: 0, location: 1}]
+    }
+  });
+
+  try {
+    computation.setBindings({resultData: resultBuffer});
+    const computePass = webgpuDevice.beginComputePass({});
+    computation.dispatch(computePass, 1);
+    computePass.end();
+    webgpuDevice.submit();
+
+    const resultBytes = await resultBuffer.readAsync();
+    const resultBits = new Uint32Array(
+      resultBytes.buffer,
+      resultBytes.byteOffset,
+      resultBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+    );
+    const labels = [
+      'minimum subnormal quotient',
+      'negative minimum subnormal quotient',
+      'half-minimum tie to even',
+      'square-root subnormal correction'
+    ];
+    for (let index = 0; index < expectedBits.length; index++) {
+      tapeTest.equal(resultBits[index], expectedBits[index], `${labels[index]} bits`);
+    }
+  } finally {
+    computation.destroy();
+    resultBuffer.destroy();
+  }
+
+  tapeTest.end();
+});
+
 for (const arithmeticOperation of ARITHMETIC_OPERATIONS) {
   test(`fp64 WGSL#${arithmeticOperation.name}`, async tapeTest => {
-    if (!ENABLE_WGSL_FP64_COMPUTE_DIAGNOSTICS) {
-      tapeTest.comment('Temporarily disabling fp64 WGSL compute diagnostics');
-      tapeTest.end();
-      return;
-    }
     const webgpuDevice = await getWebGPUTestDevice();
     if (!webgpuDevice) {
-      tapeTest.comment('WebGPU unavailable, skipping fp64 WGSL diagnostics');
-      tapeTest.end();
-      return;
-    }
-    if (isAppleMetalDevice(webgpuDevice)) {
-      tapeTest.comment('Skipping fp64 WGSL diagnostics on Apple Metal');
+      tapeTest.comment('WebGPU unavailable, skipping fp64 WGSL arithmetic tests');
       tapeTest.end();
       return;
     }
 
-    const encodedInputA = new Float32Array(ARITHMETIC_CASES.length * 2);
-    const encodedInputB = new Float32Array(ARITHMETIC_CASES.length * 2);
+    const arithmeticCases = ARITHMETIC_CASES.filter(
+      arithmeticCase =>
+        !arithmeticCase.operations || arithmeticCase.operations.includes(arithmeticOperation.name)
+    );
+    const encodedInputA = new Float32Array(arithmeticCases.length * 2);
+    const encodedInputB = new Float32Array(arithmeticCases.length * 2);
 
-    for (let index = 0; index < ARITHMETIC_CASES.length; index++) {
+    for (let index = 0; index < arithmeticCases.length; index++) {
       const float64Index = index * 2;
-      fp64ify(ARITHMETIC_CASES[index].inputA, encodedInputA, float64Index);
-      fp64ify(ARITHMETIC_CASES[index].inputB, encodedInputB, float64Index);
+      fp64ify(arithmeticCases[index].inputA, encodedInputA, float64Index);
+      fp64ify(arithmeticCases[index].inputB, encodedInputB, float64Index);
     }
 
     const inputABuffer = webgpuDevice.createBuffer({
@@ -324,10 +581,10 @@ for (const arithmeticOperation of ARITHMETIC_OPERATIONS) {
     const computation = new Computation(webgpuDevice, {
       source: buildWGSLArithmeticSource(arithmeticOperation.name),
       modules: [fp64arithmetic],
+      defines: getFp64IntegerTestDefines(webgpuDevice.info.gpu),
       shaderInputs,
       shaderLayout: {
         bindings: [
-          {name: 'fp64arithmeticUniforms', type: 'uniform', group: 0, location: 0},
           {name: 'inputAData', type: 'storage', group: 0, location: 1},
           {name: 'inputBData', type: 'storage', group: 0, location: 2},
           {name: 'resultData', type: 'storage', group: 0, location: 3}
@@ -344,13 +601,18 @@ for (const arithmeticOperation of ARITHMETIC_OPERATIONS) {
       computation.updateShaderInputs();
 
       const computePass = webgpuDevice.beginComputePass({});
-      computation.dispatch(computePass, ARITHMETIC_CASES.length);
+      computation.dispatch(computePass, arithmeticCases.length);
       computePass.end();
       webgpuDevice.submit();
 
-      const resultData = new Float32Array(await resultBuffer.readAsync());
-      for (let index = 0; index < ARITHMETIC_CASES.length; index++) {
-        const arithmeticCase = ARITHMETIC_CASES[index];
+      const resultBytes = await resultBuffer.readAsync();
+      const resultData = new Float32Array(
+        resultBytes.buffer,
+        resultBytes.byteOffset,
+        resultBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+      );
+      for (let index = 0; index < arithmeticCases.length; index++) {
+        const arithmeticCase = arithmeticCases[index];
         const expectedValue = arithmeticOperation.operation(
           arithmeticCase.inputA,
           arithmeticCase.inputB
@@ -359,13 +621,20 @@ for (const arithmeticOperation of ARITHMETIC_OPERATIONS) {
         const resultLow = resultData[index * 2 + 1];
         const result64 = resultHigh + resultLow;
         const absoluteError = Math.abs(expectedValue - result64);
-        const relativeError = expectedValue === 0 ? absoluteError : absoluteError / expectedValue;
+        const relativeError =
+          expectedValue === 0 ? absoluteError : absoluteError / Math.abs(expectedValue);
+        const withinTolerance = expectedValue === 0 ? absoluteError === 0 : relativeError <= 1e-11;
 
         tapeTest.ok(
-          equals(expectedValue, result64),
-          `${arithmeticOperation.name} ${arithmeticCase.label} within tolerance`
+          Number.isFinite(resultHigh) && Number.isFinite(resultLow),
+          `${arithmeticOperation.name} ${arithmeticCase.label} has finite limbs`
         );
-        if (!equals(expectedValue, result64)) {
+        tapeTest.ok(
+          withinTolerance,
+          `${arithmeticOperation.name} ${arithmeticCase.label} within tolerance ` +
+            `(expected=${expectedValue}, result=${result64}, relativeError=${relativeError})`
+        );
+        if (!withinTolerance) {
           tapeTest.comment(
             `  ${arithmeticOperation.name} ${arithmeticCase.label} expected=${expectedValue} result=${result64}`
           );
@@ -387,19 +656,9 @@ for (const arithmeticOperation of ARITHMETIC_OPERATIONS) {
 
 for (const helperOperation of HELPER_OPERATIONS) {
   test(`fp64 WGSL helper#${helperOperation.name}`, async tapeTest => {
-    if (!ENABLE_WGSL_FP64_COMPUTE_DIAGNOSTICS) {
-      tapeTest.comment('Temporarily disabling fp64 WGSL helper diagnostics');
-      tapeTest.end();
-      return;
-    }
     const webgpuDevice = await getWebGPUTestDevice();
     if (!webgpuDevice) {
-      tapeTest.comment('WebGPU unavailable, skipping fp64 WGSL helper diagnostics');
-      tapeTest.end();
-      return;
-    }
-    if (isAppleMetalDevice(webgpuDevice)) {
-      tapeTest.comment('Skipping fp64 WGSL helper diagnostics on Apple Metal');
+      tapeTest.comment('WebGPU unavailable, skipping fp64 WGSL helper tests');
       tapeTest.end();
       return;
     }
@@ -429,10 +688,10 @@ for (const helperOperation of HELPER_OPERATIONS) {
     const computation = new Computation(webgpuDevice, {
       source: buildWGSLHelperSource(helperOperation.expression),
       modules: [fp64arithmetic],
+      defines: getFp64IntegerTestDefines(webgpuDevice.info.gpu),
       shaderInputs,
       shaderLayout: {
         bindings: [
-          {name: 'fp64arithmeticUniforms', type: 'uniform', group: 0, location: 0},
           {name: 'inputAData', type: 'storage', group: 0, location: 1},
           {name: 'inputBData', type: 'storage', group: 0, location: 2},
           {name: 'resultData', type: 'storage', group: 0, location: 3}
@@ -453,10 +712,18 @@ for (const helperOperation of HELPER_OPERATIONS) {
       computePass.end();
       webgpuDevice.submit();
 
-      const resultData = new Float32Array(await resultBuffer.readAsync());
+      const resultBytes = await resultBuffer.readAsync();
+      const resultData = new Float32Array(
+        resultBytes.buffer,
+        resultBytes.byteOffset,
+        resultBytes.byteLength / Float32Array.BYTES_PER_ELEMENT
+      );
       for (let index = 0; index < helperOperation.cases.length; index++) {
         const helperCase = helperOperation.cases[index];
-        const expectedValue = helperOperation.operation(helperCase.inputA, helperCase.inputB);
+        const expectedValue = helperOperation.operation(
+          Math.fround(helperCase.inputA),
+          Math.fround(helperCase.inputB)
+        );
         const resultHigh = resultData[index * 2];
         const resultLow = resultData[index * 2 + 1];
         const result64 = resultHigh + resultLow;
@@ -501,6 +768,8 @@ for (const helperOperation of HELPER_OPERATIONS) {
 }
 
 function buildWGSLArithmeticSource(operationName: ArithmeticOperationName): string {
+  const expression =
+    operationName === 'sqrt_fp64' ? `${operationName}(inputA)` : `${operationName}(inputA, inputB)`;
   return `\
 @group(0) @binding(1) var<storage, read> inputAData: array<vec2f>;
 @group(0) @binding(2) var<storage, read> inputBData: array<vec2f>;
@@ -511,7 +780,7 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
   let index = id.x;
   let inputA = inputAData[index];
   let inputB = inputBData[index];
-  resultData[index] = ${operationName}(inputA, inputB);
+  resultData[index] = ${expression};
 }
 `;
 }
@@ -528,6 +797,43 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
   let inputA = inputAData[index];
   let inputB = inputBData[index];
   resultData[index] = ${expression};
+}
+`;
+}
+
+function buildWGSLIntegerPrimitiveSource(): string {
+  return `\
+@group(0) @binding(1) var<storage, read> inputData: array<vec2u>;
+@group(0) @binding(2) var<storage, read_write> resultData: array<vec4u>;
+
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+  let index = id.x;
+  let inputs = inputData[index];
+  let sum = fp64_two_sum_integer_bits(inputs.x, inputs.y);
+  let product = fp64_two_prod_integer_bits(inputs.x, inputs.y);
+  resultData[index] = vec4u(sum.x, sum.y, product.x, product.y);
+}
+`;
+}
+
+function buildWGSLIntegerSubnormalSource(): string {
+  return `\
+@group(0) @binding(1) var<storage, read_write> resultData: array<vec4u>;
+
+@compute @workgroup_size(1)
+fn main() {
+  let minimumNormal = bitcast<f32>(0x00800000u);
+  let negativeMinimumNormal = bitcast<f32>(0x80800000u);
+  let divisor23 = bitcast<f32>(0x4b000000u);
+  let divisor24 = bitcast<f32>(0x4b800000u);
+  let squareRoot = sqrt_fp64(vec2f(1.0, bitcast<f32>(0x00000002u)));
+  resultData[0] = vec4u(
+    bitcast<u32>(fp64_divide_f32_integer(minimumNormal, divisor23)),
+    bitcast<u32>(fp64_divide_f32_integer(negativeMinimumNormal, divisor23)),
+    bitcast<u32>(fp64_divide_f32_integer(minimumNormal, divisor24)),
+    bitcast<u32>(squareRoot.y)
+  );
 }
 `;
 }
@@ -556,4 +862,78 @@ function getFloat32Bits(value: number): number {
   const dataView = new DataView(new ArrayBuffer(4));
   dataView.setFloat32(0, value, false);
   return dataView.getUint32(0, false);
+}
+
+function getExpectedTwoSumBits(inputA: number, inputB: number): [number, number] {
+  const inputABits = getFloat32Bits(inputA);
+  const inputBBits = getFloat32Bits(inputB);
+  const exponentA = ((inputABits >>> 23) & 0xff) - 150;
+  const exponentB = ((inputBBits >>> 23) & 0xff) - 150;
+  if (Math.abs(exponentA - exponentB) > 25) {
+    return (inputABits & 0x7fffffff) >= (inputBBits & 0x7fffffff)
+      ? [inputABits, inputBBits]
+      : [inputBBits, inputABits];
+  }
+
+  const exactSum = inputA + inputB;
+  const sumHigh = Math.fround(exactSum);
+  return [getFloat32Bits(sumHigh), getFloat32Bits(Math.fround(exactSum - sumHigh))];
+}
+
+function makeIntegerPrimitiveCases(count: number): IntegerPrimitiveCase[] {
+  const cases: IntegerPrimitiveCase[] = [];
+  let state = 0x6d2b79f5;
+  const next = (): number => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state;
+  };
+
+  for (let index = 0; index < count; index++) {
+    const exponentA = (next() % 61) - 30;
+    const exponentB = exponentA + (next() % 49) - 24;
+    const significandA = 1 + (next() & 0x7fffff) / 0x800000;
+    const significandB = 1 + (next() & 0x7fffff) / 0x800000;
+    const signA = (next() & 1) === 0 ? 1 : -1;
+    const signB = (next() & 1) === 0 ? 1 : -1;
+    cases.push({
+      label: `fixed random pair ${index}`,
+      inputA: Math.fround(signA * significandA * 2 ** exponentA),
+      inputB: Math.fround(signB * significandB * 2 ** exponentB)
+    });
+  }
+  return cases;
+}
+
+function makeWideExponentPrimitiveCases(count: number): IntegerPrimitiveCase[] {
+  const cases: IntegerPrimitiveCase[] = [];
+  let state = 0x9e3779b9;
+  const next = (): number => {
+    state = (Math.imul(state, 1103515245) + 12345) >>> 0;
+    return state;
+  };
+
+  while (cases.length < count) {
+    const exponentA = (next() % 201) - 100;
+    const productExponent = (next() % 61) - 30;
+    const exponentB = productExponent - exponentA;
+    if (exponentB < -120 || exponentB > 120) {
+      continue;
+    }
+    const significandA = 1 + (next() & 0x7fffff) / 0x800000;
+    const significandB = 1 + (next() & 0x7fffff) / 0x800000;
+    const signA = (next() & 1) === 0 ? 1 : -1;
+    const signB = (next() & 1) === 0 ? 1 : -1;
+    cases.push({
+      label: `wide exponent pair ${cases.length}`,
+      inputA: Math.fround(signA * significandA * 2 ** exponentA),
+      inputB: Math.fround(signB * significandB * 2 ** exponentB)
+    });
+  }
+  return cases;
+}
+
+function getFp64IntegerTestDefines(gpu: string): Record<string, boolean> {
+  // On Apple this deliberately exercises automatic platform selection. Other
+  // adapters force the path so that headless CI also compiles and executes it.
+  return gpu.toLowerCase() === 'apple' ? {} : {LUMA_FP64_INTEGER_ARITHMETIC: true};
 }

--- a/website/content/examples/experimental/fp64.mdx
+++ b/website/content/examples/experimental/fp64.mdx
@@ -4,8 +4,18 @@ title: FP64
 
 import {ExampleHeader} from '@site/src/react-luma';
 import {FP64Example} from '@site/src/examples';
+import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
 
-<ExampleHeader id="fp64" directory="experimental" devices={['webgl2', 'webgpu']}>
+<div className="markdown">
+  <ShaderModuleDocsTabs group="precision" active="fp64-example" />
+</div>
+
+<ExampleHeader
+  id="fp64"
+  directory="experimental"
+  devices={['webgl2', 'webgpu']}
+  style={{position: 'relative', padding: '0 0 12px'}}
+>
   <div>
     <div style={{marginBottom: 12}}>
       Two fragment shaders following the same Mandelbrot zoom path. The left canvas uses float32
@@ -13,12 +23,15 @@ import {FP64Example} from '@site/src/examples';
       `@luma.gl/shadertools`.
     </div>
     <div style={{marginBottom: 12}}>
-      The double-single arithmetic used here depends on intermediate rounding behavior that portable
-      WGSL does not guarantee, so results are GPU-dependent. See the{' '}
-      <a href="/docs/api-guide/shaders/gpu-floating-point-precision">
-        GPU floating-point precision guide
-      </a>{' '}
-      for robust alternatives, including fixed point and integer arithmetic.
+      On Apple WebGPU/Metal, `fp64arithmetic` automatically selects an integer-controlled
+      double-single implementation. Other GPUs use the classic floating-point error transforms by
+      default.
+    </div>
+    <div style={{marginBottom: 12}}>
+      The opt-in WebGPU benchmark below the canvases compares automatic selection, both explicit
+      double-single paths, and native float32 for add, multiply, divide, and square-root compute
+      workloads. It reports timing and numerical error together; the results are diagnostic and do
+      not impose performance thresholds.
     </div>
   </div>
 </ExampleHeader>

--- a/website/src/components/docs/shader-module-docs-tabs.tsx
+++ b/website/src/components/docs/shader-module-docs-tabs.tsx
@@ -10,8 +10,10 @@ type ShaderModuleDocsTab = {
 /** Built-in shader module documentation tab identifiers. */
 export type ShaderModuleDocsTabId =
   | 'fp32'
+  | 'precision-guide'
   | 'fp64'
   | 'fp64-arithmetic'
+  | 'fp64-example'
   | 'lighting'
   | 'dirlight'
   | 'lambert-material'
@@ -24,12 +26,22 @@ export type ShaderModuleDocsTabGroupId = 'precision' | 'lighting';
 
 const SHADER_MODULE_DOCS_TABS: Record<ShaderModuleDocsTabGroupId, ShaderModuleDocsTab[]> = {
   precision: [
+    {
+      id: 'precision-guide',
+      label: 'Precision Guide',
+      href: '/docs/api-guide/shaders/gpu-floating-point-precision'
+    },
     {id: 'fp32', label: 'fp32', href: '/docs/api-reference/shadertools/shader-modules/fp32'},
     {id: 'fp64', label: 'fp64', href: '/docs/api-reference/shadertools/shader-modules/fp64'},
     {
       id: 'fp64-arithmetic',
       label: 'fp64arithmetic',
       href: '/docs/api-reference/shadertools/shader-modules/fp64-arithmetic'
+    },
+    {
+      id: 'fp64-example',
+      label: 'Mandelbrot & Benchmarks',
+      href: '/examples/experimental/fp64'
     }
   ],
   lighting: [
@@ -66,8 +78,13 @@ export function ShaderModuleDocsTabs({
   group: ShaderModuleDocsTabGroupId;
   active: ShaderModuleDocsTabId;
 }): ReactNode {
+  const ariaLabel =
+    group === 'precision'
+      ? 'GPU floating-point precision documentation sections'
+      : 'Built-in shader module documentation sections';
+
   return (
-    <nav className="docs-page-tabs" aria-label="Built-in shader module documentation sections">
+    <nav className="docs-page-tabs" aria-label={ariaLabel}>
       {SHADER_MODULE_DOCS_TABS[group].map(tab => (
         <Link
           key={tab.id}


### PR DESCRIPTION
## Summary

- Add an optimizer-independent integer-controlled WGSL implementation of double-single arithmetic, selected automatically on Apple WebGPU/Metal while preserving the existing `vec2<f32>` API.
- Add assembly and real WebGPU compute coverage for automatic selection, explicit overrides, arithmetic primitives, boundary values, division, and square root.
- Turn the Mandelbrot example into an fp32/fp64 showcase with an opt-in WebGPU compute benchmark covering automatic, classic, integer-controlled, and native-f32 modes.
- Add shared precision-documentation tabs and embed the showcase in the guide and reference pages.
- Follow up on #2795 by documenting that the full `fp64` function library is GLSL-only; WebGPU/WGSL support belongs to the lower-level `fp64arithmetic` module.

## Why

Classic Dekker/Knuth error transforms depend on intermediate `f32` rounding points. WGSL permits reassociation and contraction, and Metal can optimize those residual-producing expressions away. The Apple path instead decodes each limb into integer sign, exponent, and significand fields, performs exact sum/product transforms and rounding with integer operations, then packs the result back into the public double-single representation.

## Apple Metal benchmark

The interactive benchmark ran 8,192 lanes, 32 dependent operations per lane, and three timed dispatches. All 16 operation/mode rows completed on Apple WebGPU/Metal. Representative maximum relative errors:

| Operation | Automatic | Integer-controlled | Classic | Native f32 |
| --- | ---: | ---: | ---: | ---: |
| Add | 4.87e-15 | 4.87e-15 | 1.14e-7 | 1.14e-7 |
| Multiply | 1.27e-13 | 1.27e-13 | 3.69e-6 | 2.01e-6 |
| Divide | 1.15e-13 | 1.15e-13 | 3.76e-6 | 2.02e-6 |
| Square root | 1.02e-14 | 1.02e-14 | 8.83e-8 | 1.29e-7 |

Timing is reported by the example using GPU timestamps when available, otherwise queue completion; no performance threshold is imposed.

## Validation

- `nvm use` — Node 22.22.1
- `yarn install` — passed (existing peer warnings only)
- `yarn lint fix` — passed on the final sources and again in the commit hook
- `yarn build` — passed
- Commit-hook node suite — 253 passed, 2 skipped
- Focused Apple WebGPU browser suite — 40 passed across shader assembly and fp64 arithmetic compute tests
- Live Apple WebGPU/Metal check — both Mandelbrot canvases rendered and all 16 benchmark rows completed
- `yarn website:build` — passed
- `(cd website && yarn build)` — passed on the exact final sources, including static generation and validation of 429 raw documentation pages
- `yarn test` — node passed. An earlier code-complete headless run reached 1,323 passed / 25 skipped with only the known Arrow polygon/text failure reproduced on `master`; the final shared-machine rerun was stopped after broad unrelated GPU/browser timeouts made it non-diagnostic.

## Limits

This remains double-single arithmetic rather than IEEE-754 binary64. It retains the `f32` exponent range and provides approximately 48 significand bits while both limbs are normal; precision tapers as the low limb becomes subnormal. The documented portable contract covers finite normalized double-single inputs and finite normal results.
