### PR TITLE
feat(experimental): add partitioned GPU topology

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1005,7 +1005,7 @@ schedule commitment.
 | 0 — Current foundation | Command graph, masks, hierarchy layout, graph traversal, ancestor projection, compaction, indirect drawing, picking, analysis primitives, and three working consumers | Implemented | High | Complete |
 | 1 — Hardening and observability | GPU timestamps, performance baselines, adapter capability reporting, boundary and overflow validation, memory statistics, and device-loss and resource-lifetime coverage | Implemented | High | Medium |
 | 2 — Reusable visibility workflows | Renderer-independent time-range, bounds, LOD, and selection workflows that publish stable IDs, counts, and indirect commands | Implemented | High | Medium |
-| 3 — Algorithm and table scaling | Multi-chunk coverage, segmented and inclusive scans, weighted statistics, richer histograms, and batch-preserving algorithms | In progress | High | Large |
+| 3 — Algorithm and table scaling | Multi-chunk coverage, segmented and inclusive scans, weighted statistics, richer histograms, and batch-preserving algorithms | Implemented | High | Large |
 | 4 — Picking and texture coverage | Region picking, asynchronous staging rings, multisample resolves, swapchain imports, and external-texture contracts | Planned | Medium | Large |
 | 5 — Spatial acceleration | `GPUGridIndex` followed by `GPUBVH`, with explicit build, update, and query costs | Planned | High | Large |
 | 6 — GPUScene | A flat GPU draw database with stable identity, bounds, transforms, grouping, geometry references, and indirect command slots | Planned | High | Large |
@@ -1017,6 +1017,8 @@ The remaining phases are intentionally divided into reviewable contracts. A tran
 only when its entry dependency is present and its exit evidence can be produced; the numbering is
 dependency order, not a schedule commitment. Tranches whose dependencies do not overlap may be
 developed independently.
+
+Tranches 3.2 and 3.3 are implemented; Phase 4 is the next active boundary.
 
 | Tranche | Outcome | Entry dependency | Impact | Complexity/cost |
 | --- | --- | --- | :---: | :---: |
@@ -1106,9 +1108,9 @@ flowing directly into indirect rendering.
 
 ### Phase 3 — Algorithm and table scaling
 
-**Status:** In progress. Inclusive and segmented `uint32` scans, weighted floating-point grid and
-categorical statistics, irregular-edge histograms, filtered categorical counts, and
-batch-preserving paired sort are implemented.
+**Status:** Implemented. Inclusive and segmented `uint32` scans, weighted floating-point grid and
+categorical statistics, irregular-edge histograms, filtered categorical counts, batch-preserving
+paired sort, and partitioned hierarchy and CSR topology are implemented.
 
 **Entry dependencies:** Phase 2 provides real workflow demand for each added variant.
 
@@ -1149,16 +1151,24 @@ record batches, per-tile ordering, and incremental ingestion where partition bou
 of the storage and lifetime contract. The GPU sort example contrasts that behavior with one
 explicit packed global sort and validates mixed bitonic/radix batches against a CPU oracle.
 
-Remaining work extends meaningful multi-chunk support to topology algorithms that still require
-one packed view and adds more batch-aware operations only where consumers need partition-local
-semantics. Custom associative scans, sparse histograms, and multidimensional histograms should be
-added only with a concrete consumer and an explicit numerical or memory contract.
+More batch-aware operations remain consumer-driven rather than being required to complete this
+phase. Custom associative scans, sparse histograms, and multidimensional histograms should be added
+only with a concrete consumer and an explicit numerical or memory contract.
 
 #### Tranche 3.2 — Partitioned topology
+
+**Status:** Implemented.
 
 Define how chunk-local rows map to stable global IDs, including explicit base offsets and the
 ownership of cross-chunk hierarchy or CSR edges. Extend at least one hierarchy primitive and one
 CSR primitive to consume that contract without concatenating chunks behind the caller's back.
+
+`GPUHierarchyLayout` now derives stable cumulative bases independently for parent and child
+vectors, splits only the intersecting work when their boundaries differ, and scans offsets across
+the preserved child topology. `GPUGraphTraversal` accepts one local CSR allocation per output
+partition with global neighbor IDs and routes arbitrary cross-partition edges through explicit
+source-to-target passes. The trace viewer exercises both contracts using two logical partitions
+backed by its existing allocations.
 
 **Exit evidence:** CPU-oracle tests cover empty chunks, cross-chunk references, uneven boundaries,
 and incremental replacement of one batch. A hierarchy and graph consumer preserve their source
@@ -1166,11 +1176,24 @@ partitions while producing the same IDs and results as an explicitly packed inpu
 
 #### Tranche 3.3 — Extension decision gate
 
+**Status:** Implemented as an explicit deferral decision.
+
 Evaluate custom associative scans, sparse and multidimensional histograms, and shader predicate
 callbacks against demonstrated consumers after partitioned topology lands. Each candidate must
 state its numerical behavior, memory-growth bounds, composition model, and why existing fixed
 contracts are insufficient. Explicit deferral is a valid outcome; this tranche does not require
 inventing an extension API merely to complete a checklist.
+
+| Candidate | Decision | Evidence required to reopen |
+| --- | --- | --- |
+| Custom associative scans | Defer | Two consumers sharing an associative operation, identity value, overflow behavior, and shader value layout that the fixed `uint32` scan cannot express |
+| Sparse histograms | Defer | A high-cardinality consumer where dense output is demonstrably the dominant memory cost, plus bounded key storage and overflow semantics |
+| Multidimensional histograms | Defer | Two consumers requiring joint distributions that cannot compose `GPUGridBinning`, `GPUGridAggregation`, or dense group IDs without materializing an avoidable column |
+| Application WGSL predicate callbacks | Defer | Two visibility consumers sharing binding, validation, cache-key, diagnostic, and composition requirements beyond the fixed workflow masks |
+
+This decision keeps numerical behavior and shader interfaces inspectable. A future proposal should
+name the missing fixed-contract capability and its capacity bound rather than exposing an
+unconstrained callback as a shortcut.
 
 **Exit evidence:** Every candidate has two motivating consumers or remains documented as deferred,
 and any accepted API has a CPU oracle plus explicit capacity, overflow, and shader-compatibility

--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -104,8 +104,8 @@ its documented atomic graph resources; callers must select, adapt, or explicitly
 | `GPUScan` | Scalar `GraphDataView` or `GraphVectorView` | ✅ |
 | `GPUCompaction` | Scalar `GraphDataView`s or matching `GraphVectorView`s | ✅ |
 | `GPUMask` | Scalar masks or matching mask `GraphVectorView`s | ✅ |
-| `GPUHierarchyLayout` | Parent state, child state, heights, and offsets | ❌ |
-| `GPUGraphTraversal` | CSR adjacency and scalar graph data views | ❌ |
+| `GPUHierarchyLayout` | Parent state, child state, heights, and offsets | ✅ |
+| `GPUGraphTraversal` | Packed CSR or aligned local CSR partitions with global neighbor IDs | ✅ |
 | `GPUAncestorProjection` | Source-aligned parent, mask, and output views | ❌ |
 | `GPUSort` | Key and value `GraphDataView`s | ❌ |
 | `GPUReduction` | Scalar `GraphDataView` or `GraphVectorView` | ✅ |

--- a/docs/api-reference/experimental/gpu-primitives/gpu-graph-traversal.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-graph-traversal.md
@@ -36,7 +36,8 @@ new GPUGraphTraversal({
 }).addToGraph(graph);
 ```
 
-All inputs are packed `GraphDataView<'uint32'>` values:
+Inputs may use one packed `GraphDataView<'uint32'>` adjacency or partitioned
+`GraphVectorView<'uint32'>` adjacency:
 
 - `offsets` has `nodeCount + 1` entries; `neighbors` stores the forward CSR destinations.
 - `reverseOffsets` and `reverseNeighbors` provide reverse CSR for `'incoming'` or `'both'`.
@@ -46,10 +47,29 @@ All inputs are packed `GraphDataView<'uint32'>` values:
 - `maxDepth` defines the number of compiled frontier-expansion stages and must not exceed 1024.
 - Optional `activeDepth` changes the number of effective stages without recompiling the graph.
 
+### Partitioned CSR identity
+
+Partitioned traversal keeps one local CSR allocation per output partition. Each `offsets` chunk
+has `outputChunk.length + 1` entries beginning at zero, and the corresponding `neighbors` chunk
+contains that source partition's edges. Neighbor values remain stable global node IDs. Forward
+and reverse adjacency must each contain one offset and neighbor chunk per output chunk; seeds may
+use any chunk topology.
+
+Arbitrary edges can cross partitions. For each hop, traversal therefore emits explicit
+source-to-target partition passes: source offsets and frontiers use local indices, while global
+neighbor IDs select the target output and next-frontier chunk. Empty partitions remain present but
+add no dispatch. No adjacency, frontier, or output chunk is concatenated or repacked.
+
+The general cross-partition path has an O(partition²) dispatch envelope per hop. Coarse partitions
+are appropriate when boundaries represent streaming batches or independently replaced storage;
+each source partition's active adjacency is rescanned for every possible target partition.
+Applications with many fine partitions should pack explicitly or wait for a spatial/topological
+index that can route candidate targets without changing the global-ID contract.
+
 The seed nodes are included at depth zero. Out-of-range seed and neighbor IDs are ignored. Atomic
 node claims make cycles, duplicate dependencies, shared descendants, and overlapping frontiers
 safe.
 
-Frontier scratch is created as graph-owned transient buffers. The output buffer must not alias
+Frontier scratch is created as graph-owned transient buffers. Output buffers must not alias
 adjacency, seeds, or other traversal inputs. The operation neither submits commands nor reads
 results back; its output can be composed with `GPUMask` and passed directly to `GPUCompaction`.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-hierarchy-layout.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-hierarchy-layout.md
@@ -34,8 +34,8 @@ new GPUHierarchyLayout({
 }).addToGraph(graph);
 ```
 
-All input and output views are packed `GraphDataView<'uint32'>` values. A nonzero state is
-expanded; a zero state is collapsed.
+Inputs and outputs may be packed `GraphDataView<'uint32'>` values or ordered
+`GraphVectorView<'uint32'>` partitions. A nonzero state is expanded; a zero state is collapsed.
 
 - Expanded parents publish one height for each child.
 - Expanded children use `expandedChildHeight`.
@@ -45,8 +45,22 @@ expanded; a zero state is collapsed.
 - `GPUScan` converts the effective child heights into stable exclusive row offsets.
 
 `childStates.length` must equal `parentStates.length * childrenPerParent`. Both output lengths
-must equal the child count. Heights and offsets are caller-owned and cannot alias each other or
-their input buffers.
+must equal the child count. Vector heights and offsets preserve the exact child-state chunk
+topology; parent partitions may use different boundaries.
+
+### Partitioned hierarchy identity
+
+Partition boundaries are storage and update boundaries, not hierarchy boundaries. Cumulative row
+counts assign every parent and child one stable global ID. When a child chunk crosses a parent
+chunk boundary, `GPUHierarchyLayout` emits an explicit pass for each intersecting range and uses
+the global child ID to select its parent. It never concatenates or repacks either vector.
+
+This matters for streamed or incrementally replaced batches: an application can replace one
+parent or child allocation while preserving source identity and output partitions. Empty chunks
+retain their position. The exclusive scan carries layout offsets across child chunks, so the
+result is identical to laying out one explicitly packed sequence.
+
+Heights and offsets are caller-owned and cannot alias each other or their input buffers.
 
 Expansion states can be updated between graph encodings. The operation allocates only graph-owned
 scan scratch and does not submit, repack, or read back data.

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -16,6 +16,7 @@ import {
   type GraphBufferHandle,
   type GraphBufferUse
 } from '@luma.gl/experimental';
+import {GPUData, GPUVector} from '@luma.gl/tables';
 import {ColumnPanel, type Panel} from '@deck.gl-community/panels';
 import {
   ExamplePanelManager,
@@ -350,6 +351,9 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     const spanMaskByteLength = Math.max(dataset.spanCount, 1) * UINT32_BYTE_LENGTH;
     const dependencyMaskByteLength = Math.max(dataset.dependencyCount, 1) * UINT32_BYTE_LENGTH;
     const activityBinCount = TRACE_PROCESS_COUNT * TRACE_ACTIVITY_BIN_COUNT;
+    const topologyChunkLengths = getTopologyChunkLengths(dataset.spanCount);
+    const outgoingOffsets = makePartitionedOffsets(dataset.outgoing.offsets, topologyChunkLengths);
+    const incomingOffsets = makePartitionedOffsets(dataset.incoming.offsets, topologyChunkLengths);
     const drawCommands = new DrawCommandBuffer(this.device, {
       id: 'gpu-trace-draw-commands',
       type: 'draw',
@@ -367,18 +371,12 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       spans: this.createDataBuffer('gpu-trace-spans', dataset.spans),
       dependencies: this.createDataBuffer('gpu-trace-dependencies', dataset.dependencies),
       parentSpans: this.createDataBuffer('gpu-trace-parent-spans', dataset.parentSpans),
-      outgoingOffsets: this.createDataBuffer(
-        'gpu-trace-outgoing-offsets',
-        dataset.outgoing.offsets
-      ),
+      outgoingOffsets: this.createDataBuffer('gpu-trace-outgoing-offsets', outgoingOffsets),
       outgoingNeighbors: this.createDataBuffer(
         'gpu-trace-outgoing-neighbors',
         dataset.outgoing.neighbors
       ),
-      incomingOffsets: this.createDataBuffer(
-        'gpu-trace-incoming-offsets',
-        dataset.incoming.offsets
-      ),
+      incomingOffsets: this.createDataBuffer('gpu-trace-incoming-offsets', incomingOffsets),
       incomingNeighbors: this.createDataBuffer(
         'gpu-trace-incoming-neighbors',
         dataset.incoming.neighbors
@@ -497,25 +495,39 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       pickResult: importTraceBuffer(graph, 'pick-result', resources.pickResult),
       drawCommands: importTraceBuffer(graph, 'draw-commands', resources.drawCommands.buffer)
     };
+    const processChunkLengths = [1, TRACE_PROCESS_COUNT - 1];
+    const threadChunkLengths = [
+      TRACE_THREADS_PER_PROCESS + 1,
+      TRACE_THREAD_COUNT - TRACE_THREADS_PER_PROCESS - 1
+    ];
+    const topologyChunkLengths = getTopologyChunkLengths(resources.spanCount);
+    const outgoingNeighborChunkLengths = getNeighborChunkLengths(
+      dataset.outgoing.offsets,
+      topologyChunkLengths
+    );
+    const incomingNeighborChunkLengths = getNeighborChunkLengths(
+      dataset.incoming.offsets,
+      topologyChunkLengths
+    );
 
     new GPUHierarchyLayout({
       id: 'trace-process-thread-layout',
-      parentStates: graph.createDataView(handles.processStates, {
-        format: 'uint32',
-        length: TRACE_PROCESS_COUNT
-      }),
-      childStates: graph.createDataView(handles.threadStates, {
-        format: 'uint32',
-        length: TRACE_THREAD_COUNT
-      }),
-      heights: graph.createDataView(handles.threadHeights, {
-        format: 'uint32',
-        length: TRACE_THREAD_COUNT
-      }),
-      offsets: graph.createDataView(handles.threadOffsets, {
-        format: 'uint32',
-        length: TRACE_THREAD_COUNT
-      }),
+      parentStates: graph.importGPUVector(
+        'process-state-partitions',
+        makeUint32Vector('process states', resources.processStates, processChunkLengths)
+      ),
+      childStates: graph.importGPUVector(
+        'thread-state-partitions',
+        makeUint32Vector('thread states', resources.threadStates, threadChunkLengths)
+      ),
+      heights: graph.importGPUVector(
+        'thread-height-partitions',
+        makeUint32Vector('thread heights', resources.threadHeights, threadChunkLengths)
+      ),
+      offsets: graph.importGPUVector(
+        'thread-offset-partitions',
+        makeUint32Vector('thread offsets', resources.threadOffsets, threadChunkLengths)
+      ),
       childrenPerParent: TRACE_THREADS_PER_PROCESS,
       expandedChildHeight: TRACE_LANES_PER_THREAD,
       collapsedChildHeight: 1,
@@ -524,29 +536,45 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
 
     new GPUGraphTraversal({
       id: 'trace-selected-dependencies',
-      offsets: graph.createDataView(handles.outgoingOffsets, {
-        format: 'uint32',
-        length: dataset.outgoing.offsets.length
-      }),
-      neighbors: graph.createDataView(handles.outgoingNeighbors, {
-        format: 'uint32',
-        length: dataset.outgoing.neighbors.length
-      }),
-      reverseOffsets: graph.createDataView(handles.incomingOffsets, {
-        format: 'uint32',
-        length: dataset.incoming.offsets.length
-      }),
-      reverseNeighbors: graph.createDataView(handles.incomingNeighbors, {
-        format: 'uint32',
-        length: dataset.incoming.neighbors.length
-      }),
+      offsets: graph.importGPUVector(
+        'outgoing-offset-partitions',
+        makeUint32Vector(
+          'outgoing offsets',
+          resources.outgoingOffsets,
+          topologyChunkLengths.map(length => length + 1)
+        )
+      ),
+      neighbors: graph.importGPUVector(
+        'outgoing-neighbor-partitions',
+        makeUint32Vector(
+          'outgoing neighbors',
+          resources.outgoingNeighbors,
+          outgoingNeighborChunkLengths
+        )
+      ),
+      reverseOffsets: graph.importGPUVector(
+        'incoming-offset-partitions',
+        makeUint32Vector(
+          'incoming offsets',
+          resources.incomingOffsets,
+          topologyChunkLengths.map(length => length + 1)
+        )
+      ),
+      reverseNeighbors: graph.importGPUVector(
+        'incoming-neighbor-partitions',
+        makeUint32Vector(
+          'incoming neighbors',
+          resources.incomingNeighbors,
+          incomingNeighborChunkLengths
+        )
+      ),
       seeds: graph.createDataView(handles.selectedSeeds, {format: 'uint32', length: 1}),
       seedCount: graph.createDataView(handles.selectedSeedCount, {format: 'uint32', length: 1}),
       activeDepth: graph.createDataView(handles.traversalDepth, {format: 'uint32', length: 1}),
-      output: graph.createDataView(handles.reachedSpans, {
-        format: 'uint32',
-        length: resources.spanCount
-      }),
+      output: graph.importGPUVector(
+        'reached-span-partitions',
+        makeUint32Vector('reached spans', resources.reachedSpans, topologyChunkLengths)
+      ),
       direction: 'both',
       maxDepth: MAXIMUM_FOCUS_DEPTH
     }).addToGraph(graph);
@@ -1284,6 +1312,66 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     this.view.timeMin = anchor - nextRange * fraction;
     this.view.timeMax = this.view.timeMin + nextRange;
   };
+}
+
+/** Splits source-aligned topology into two stable global-ID partitions. */
+function getTopologyChunkLengths(length: number): number[] {
+  if (length < 2) {
+    return [length];
+  }
+  const firstLength = Math.floor(length / 2);
+  return [firstLength, length - firstLength];
+}
+
+/** Returns the edge allocation length owned by each consecutive node partition. */
+function getNeighborChunkLengths(
+  offsets: Uint32Array,
+  nodeChunkLengths: readonly number[]
+): number[] {
+  let nodeBase = 0;
+  return nodeChunkLengths.map(nodeCount => {
+    const neighborCount = offsets[nodeBase + nodeCount] - offsets[nodeBase];
+    nodeBase += nodeCount;
+    return neighborCount;
+  });
+}
+
+/** Rewrites global CSR offsets as consecutive partition-local offset arrays. */
+function makePartitionedOffsets(
+  offsets: Uint32Array,
+  nodeChunkLengths: readonly number[]
+): Uint32Array {
+  const partitionedOffsets: number[] = [];
+  let nodeBase = 0;
+  for (const nodeCount of nodeChunkLengths) {
+    const neighborBase = offsets[nodeBase];
+    for (let localNodeIndex = 0; localNodeIndex <= nodeCount; localNodeIndex++) {
+      partitionedOffsets.push(offsets[nodeBase + localNodeIndex] - neighborBase);
+    }
+    nodeBase += nodeCount;
+  }
+  return Uint32Array.from(partitionedOffsets);
+}
+
+/** Adapts consecutive subranges of one caller-owned allocation as a chunk-preserving vector. */
+function makeUint32Vector(
+  name: string,
+  buffer: Buffer,
+  chunkLengths: readonly number[]
+): GPUVector<'uint32'> {
+  let byteOffset = 0;
+  const data = chunkLengths.map(length => {
+    const chunk = new GPUData({
+      buffer,
+      format: 'uint32',
+      length,
+      byteOffset,
+      ownsBuffer: false
+    });
+    byteOffset += length * UINT32_BYTE_LENGTH;
+    return chunk;
+  });
+  return new GPUVector({type: 'data', name, format: 'uint32', data, ownsData: false});
 }
 
 /** Preserves caller-owned imports and the original GPU command-graph ownership contract. */

--- a/modules/experimental/src/gpu-primitives/gpu-graph-traversal.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-graph-traversal.ts
@@ -4,9 +4,15 @@
 
 import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-command-graph';
+import {
+  GPUCommandGraph,
+  GraphVectorView,
+  type GraphBufferUse,
+  type GraphDataView
+} from './gpu-command-graph';
 import {
   createTransientView,
+  createTransientVectorView,
   getViewBinding,
   getViewElementOffset,
   validatePackedUint32View
@@ -18,24 +24,27 @@ const MAXIMUM_GRAPH_TRAVERSAL_DEPTH = 1024;
 /** Direction in which a compressed sparse graph is traversed. */
 export type GPUGraphTraversalDirection = 'outgoing' | 'incoming' | 'both';
 
+/** Packed traversal data stored in one allocation or ordered partitions. */
+export type GPUGraphTraversalData = GraphDataView<'uint32'> | GraphVectorView<'uint32'>;
+
 /** Properties for bounded, GPU-resident breadth-first graph traversal. */
 export type GPUGraphTraversalProps = {
   /** Prefix for graph nodes and graph-owned frontier buffers. */
   id?: string;
-  /** Forward CSR offsets; contains one more entry than the number of nodes. */
-  offsets: GraphDataView<'uint32'>;
-  /** Forward CSR destinations using stable node indices. */
-  neighbors: GraphDataView<'uint32'>;
-  /** Reverse CSR offsets used for incoming or bidirectional traversal. */
-  reverseOffsets?: GraphDataView<'uint32'>;
-  /** Reverse CSR destinations used for incoming or bidirectional traversal. */
-  reverseNeighbors?: GraphDataView<'uint32'>;
+  /** Forward CSR offsets; packed globally or one local nodeCount + 1 chunk per partition. */
+  offsets: GPUGraphTraversalData;
+  /** Forward CSR destinations using stable global node indices. */
+  neighbors: GPUGraphTraversalData;
+  /** Reverse CSR offsets, using the same partition contract as forward offsets. */
+  reverseOffsets?: GPUGraphTraversalData;
+  /** Reverse CSR destinations using stable global node indices. */
+  reverseNeighbors?: GPUGraphTraversalData;
   /** Caller-owned stable starting node indices. */
-  seeds: GraphDataView<'uint32'>;
+  seeds: GPUGraphTraversalData;
   /** Optional GPU-resident number of active seed rows. */
   seedCount?: GraphDataView<'uint32'>;
   /** Caller-owned, node-aligned zero/one reachability mask. */
-  output: GraphDataView<'uint32'>;
+  output: GPUGraphTraversalData;
   /** Maximum number of compiled graph hops. Defaults to one. */
   maxDepth?: number;
   /** Optional dynamic hop count, clamped by the compiled maximum. */
@@ -63,19 +72,19 @@ export class GPUGraphTraversal {
   /** Prefix for graph nodes and frontier storage. */
   readonly id: string;
   /** Forward CSR offsets. */
-  readonly offsets: GraphDataView<'uint32'>;
+  readonly offsets: GPUGraphTraversalData;
   /** Forward CSR destinations. */
-  readonly neighbors: GraphDataView<'uint32'>;
+  readonly neighbors: GPUGraphTraversalData;
   /** Optional reverse CSR offsets. */
-  readonly reverseOffsets?: GraphDataView<'uint32'>;
+  readonly reverseOffsets?: GPUGraphTraversalData;
   /** Optional reverse CSR destinations. */
-  readonly reverseNeighbors?: GraphDataView<'uint32'>;
+  readonly reverseNeighbors?: GPUGraphTraversalData;
   /** Stable starting node indices. */
-  readonly seeds: GraphDataView<'uint32'>;
+  readonly seeds: GPUGraphTraversalData;
   /** Optional active seed count. */
   readonly seedCount?: GraphDataView<'uint32'>;
   /** Caller-owned reachability mask. */
-  readonly output: GraphDataView<'uint32'>;
+  readonly output: GPUGraphTraversalData;
   /** Number of compiled breadth-first expansion stages. */
   readonly maxDepth: number;
   /** Optional dynamically selected number of active expansion stages. */
@@ -96,9 +105,9 @@ export class GPUGraphTraversal {
     this.activeDepth = props.activeDepth;
     this.direction = props.direction ?? 'outgoing';
 
-    const namedViews = this.getNamedViews();
-    for (const [name, view] of namedViews) {
-      validatePackedUint32View(view, `${this.id} ${name}`);
+    const namedData = this.getNamedData();
+    for (const [name, data] of namedData) {
+      validateTraversalData(data, `${this.id} ${name}`);
     }
     if (!Number.isSafeInteger(this.maxDepth) || this.maxDepth < 0) {
       throw new Error(`${this.id} maxDepth must be a nonnegative safe integer`);
@@ -106,9 +115,7 @@ export class GPUGraphTraversal {
     if (this.maxDepth > MAXIMUM_GRAPH_TRAVERSAL_DEPTH) {
       throw new Error(`${this.id} maxDepth must be at most ${MAXIMUM_GRAPH_TRAVERSAL_DEPTH}`);
     }
-    if (this.offsets.length !== this.output.length + 1) {
-      throw new Error(`${this.id} offsets must contain one more row than the output`);
-    }
+    validateAdjacencyTopology(this.id, this.offsets, this.neighbors, this.output, 'forward');
     if (this.seedCount && this.seedCount.length !== 1) {
       throw new Error(`${this.id} seedCount must contain exactly one row`);
     }
@@ -121,11 +128,21 @@ export class GPUGraphTraversal {
     if (this.direction !== 'outgoing' && !this.reverseOffsets) {
       throw new Error(`${this.id} ${this.direction} traversal requires reverse adjacency`);
     }
-    if (this.reverseOffsets && this.reverseOffsets.length !== this.output.length + 1) {
-      throw new Error(`${this.id} reverse offsets must contain one more row than the output`);
+    if (this.reverseOffsets && this.reverseNeighbors) {
+      validateAdjacencyTopology(
+        this.id,
+        this.reverseOffsets,
+        this.reverseNeighbors,
+        this.output,
+        'reverse'
+      );
     }
+    const outputBuffers = new Set(getTraversalChunks(this.output).map(view => view.buffer));
     if (
-      namedViews.some(([name, view]) => name !== 'output' && view.buffer === this.output.buffer)
+      namedData.some(
+        ([name, data]) =>
+          name !== 'output' && getTraversalChunks(data).some(view => outputBuffers.has(view.buffer))
+      )
     ) {
       throw new Error(`${this.id} output must use a separate buffer from traversal inputs`);
     }
@@ -138,36 +155,61 @@ export class GPUGraphTraversal {
    * edges from rediscovering a previously reached node.
    */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
-    for (const [, view] of this.getNamedViews()) {
-      if (view.buffer.graph !== graph) {
-        throw new Error(`${this.id} views must belong to the target graph`);
+    for (const [, data] of this.getNamedData()) {
+      for (const view of getTraversalChunks(data)) {
+        if (view.buffer.graph !== graph) {
+          throw new Error(`${this.id} views must belong to the target graph`);
+        }
       }
     }
     if (this.output.length === 0) {
       return;
     }
 
+    if (this.output instanceof GraphVectorView) {
+      this.addPartitionedToGraph(graph);
+      return;
+    }
+    this.addPackedToGraph(graph);
+  }
+
+  /** Adds the original one-allocation traversal path. */
+  private addPackedToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    const output = this.output as GraphDataView<'uint32'>;
+    const offsets = this.offsets as GraphDataView<'uint32'>;
+    const neighbors = this.neighbors as GraphDataView<'uint32'>;
+    const reverseOffsets = this.reverseOffsets as GraphDataView<'uint32'> | undefined;
+    const reverseNeighbors = this.reverseNeighbors as GraphDataView<'uint32'> | undefined;
     let currentFrontier = createTransientView(
       graph,
       `${this.id}-frontier-current`,
       'uint32',
-      this.output.length
+      output.length
     );
     let nextFrontier = createTransientView(
       graph,
       `${this.id}-frontier-next`,
       'uint32',
-      this.output.length
+      output.length
     );
-    addInitializationPass(graph, this.id, this.output, currentFrontier);
+    addInitializationPass(graph, this.id, output, currentFrontier);
     if (this.seeds.length > 0) {
-      addSeedPass(graph, {
-        id: `${this.id}-seed`,
-        seeds: this.seeds,
-        seedCount: this.seedCount,
-        frontier: currentFrontier,
-        output: this.output
-      });
+      for (const seedChunk of getTraversalChunkRanges(this.seeds)) {
+        if (seedChunk.view.length > 0) {
+          addSeedPass(graph, {
+            id:
+              this.seeds instanceof GraphVectorView
+                ? `${this.id}-seed-${seedChunk.index}`
+                : `${this.id}-seed`,
+            seeds: seedChunk.view,
+            seedBase: seedChunk.base,
+            seedCount: this.seedCount,
+            targetBase: 0,
+            frontier: currentFrontier,
+            output
+          });
+        }
+      }
     }
 
     for (let depth = 0; depth < this.maxDepth; depth++) {
@@ -175,11 +217,12 @@ export class GPUGraphTraversal {
       if (this.direction !== 'incoming') {
         addExpansionPass(graph, {
           id: `${this.id}-depth-${depth}-outgoing`,
-          offsets: this.offsets,
-          neighbors: this.neighbors,
+          offsets,
+          neighbors,
           frontier: currentFrontier,
           nextFrontier,
-          output: this.output,
+          output,
+          targetBase: 0,
           activeDepth: this.activeDepth,
           depth
         });
@@ -187,11 +230,91 @@ export class GPUGraphTraversal {
       if (this.direction !== 'outgoing') {
         addExpansionPass(graph, {
           id: `${this.id}-depth-${depth}-incoming`,
-          offsets: this.reverseOffsets!,
-          neighbors: this.reverseNeighbors!,
+          offsets: reverseOffsets!,
+          neighbors: reverseNeighbors!,
           frontier: currentFrontier,
           nextFrontier,
-          output: this.output,
+          output,
+          targetBase: 0,
+          activeDepth: this.activeDepth,
+          depth
+        });
+      }
+      [currentFrontier, nextFrontier] = [nextFrontier, currentFrontier];
+    }
+  }
+
+  /** Adds partition-preserving traversal over local CSR rows and global stable neighbor IDs. */
+  private addPartitionedToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    const output = this.output as GraphVectorView<'uint32'>;
+    const offsets = this.offsets as GraphVectorView<'uint32'>;
+    const neighbors = this.neighbors as GraphVectorView<'uint32'>;
+    const reverseOffsets = this.reverseOffsets as GraphVectorView<'uint32'> | undefined;
+    const reverseNeighbors = this.reverseNeighbors as GraphVectorView<'uint32'> | undefined;
+    let currentFrontier = createTransientVectorView(graph, `${this.id}-frontier-current`, output);
+    let nextFrontier = createTransientVectorView(graph, `${this.id}-frontier-next`, output);
+    const outputRanges = getTraversalChunkRanges(output);
+    const seedRanges = getTraversalChunkRanges(this.seeds);
+
+    for (const outputRange of outputRanges) {
+      if (outputRange.view.length > 0) {
+        addInitializationPass(
+          graph,
+          `${this.id}-partition-${outputRange.index}`,
+          outputRange.view,
+          currentFrontier.data[outputRange.index]
+        );
+      }
+    }
+    for (const seedRange of seedRanges) {
+      if (seedRange.view.length === 0) {
+        continue;
+      }
+      for (const targetRange of outputRanges) {
+        if (targetRange.view.length > 0) {
+          addSeedPass(graph, {
+            id: `${this.id}-seed-${seedRange.index}-target-${targetRange.index}`,
+            seeds: seedRange.view,
+            seedBase: seedRange.base,
+            seedCount: this.seedCount,
+            targetBase: targetRange.base,
+            frontier: currentFrontier.data[targetRange.index],
+            output: targetRange.view
+          });
+        }
+      }
+    }
+
+    for (let depth = 0; depth < this.maxDepth; depth++) {
+      for (const targetRange of outputRanges) {
+        if (targetRange.view.length > 0) {
+          addClearFrontierPass(
+            graph,
+            `${this.id}-depth-${depth}-clear-${targetRange.index}`,
+            nextFrontier.data[targetRange.index]
+          );
+        }
+      }
+      if (this.direction !== 'incoming') {
+        addPartitionedExpansionPasses(graph, {
+          id: `${this.id}-depth-${depth}-outgoing`,
+          offsets,
+          neighbors,
+          currentFrontier,
+          nextFrontier,
+          output,
+          activeDepth: this.activeDepth,
+          depth
+        });
+      }
+      if (this.direction !== 'outgoing') {
+        addPartitionedExpansionPasses(graph, {
+          id: `${this.id}-depth-${depth}-incoming`,
+          offsets: reverseOffsets!,
+          neighbors: reverseNeighbors!,
+          currentFrontier,
+          nextFrontier,
+          output,
           activeDepth: this.activeDepth,
           depth
         });
@@ -201,26 +324,26 @@ export class GPUGraphTraversal {
   }
 
   /** Returns caller-owned graph views in stable validation order. */
-  private getNamedViews(): Array<[string, GraphDataView<'uint32'>]> {
-    const views: Array<[string, GraphDataView<'uint32'>]> = [
+  private getNamedData(): Array<[string, GPUGraphTraversalData]> {
+    const data: Array<[string, GPUGraphTraversalData]> = [
       ['offsets', this.offsets],
       ['neighbors', this.neighbors]
     ];
     if (this.reverseOffsets) {
-      views.push(['reverseOffsets', this.reverseOffsets]);
+      data.push(['reverseOffsets', this.reverseOffsets]);
     }
     if (this.reverseNeighbors) {
-      views.push(['reverseNeighbors', this.reverseNeighbors]);
+      data.push(['reverseNeighbors', this.reverseNeighbors]);
     }
-    views.push(['seeds', this.seeds]);
+    data.push(['seeds', this.seeds]);
     if (this.seedCount) {
-      views.push(['seedCount', this.seedCount]);
+      data.push(['seedCount', this.seedCount]);
     }
     if (this.activeDepth) {
-      views.push(['activeDepth', this.activeDepth]);
+      data.push(['activeDepth', this.activeDepth]);
     }
-    views.push(['output', this.output]);
-    return views;
+    data.push(['output', this.output]);
+    return data;
   }
 }
 
@@ -264,7 +387,9 @@ function addSeedPass<Parameters>(
   props: {
     id: string;
     seeds: GraphDataView<'uint32'>;
+    seedBase: number;
     seedCount?: GraphDataView<'uint32'>;
+    targetBase: number;
     frontier: GraphDataView<'uint32'>;
     output: GraphDataView<'uint32'>;
   }
@@ -274,11 +399,13 @@ function addSeedPass<Parameters>(
 @group(0) @binding(3) var<storage, read> activeSeedCount: array<u32>;`
     : '';
   const effectiveCount = props.seedCount
-    ? 'min(activeSeedCount[SEED_COUNT_OFFSET], SEED_CAPACITY)'
-    : 'SEED_CAPACITY';
+    ? 'activeSeedCount[SEED_COUNT_OFFSET]'
+    : `${props.seedBase + props.seeds.length}u`;
   const source = /* wgsl */ `
-const NODE_COUNT: u32 = ${props.output.length}u;
 const SEED_CAPACITY: u32 = ${props.seeds.length}u;
+const SEED_BASE: u32 = ${props.seedBase}u;
+const TARGET_BASE: u32 = ${props.targetBase}u;
+const TARGET_COUNT: u32 = ${props.output.length}u;
 const SEEDS_OFFSET: u32 = ${getViewElementOffset(props.seeds)}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
 const FRONTIER_OFFSET: u32 = ${getViewElementOffset(props.frontier)}u;
@@ -290,13 +417,14 @@ ${countDeclaration}
 @compute @workgroup_size(${GRAPH_TRAVERSAL_WORKGROUP_SIZE})
 fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let seedIndex = globalId.x;
-  if (seedIndex >= ${effectiveCount}) {
+  if (seedIndex >= SEED_CAPACITY || SEED_BASE + seedIndex >= ${effectiveCount}) {
     return;
   }
   let nodeIndex = seeds[SEEDS_OFFSET + seedIndex];
-  if (nodeIndex < NODE_COUNT) {
-    atomicStore(&reached[OUTPUT_OFFSET + nodeIndex], 1u);
-    atomicStore(&frontier[FRONTIER_OFFSET + nodeIndex], 1u);
+  if (nodeIndex >= TARGET_BASE && nodeIndex - TARGET_BASE < TARGET_COUNT) {
+    let targetIndex = nodeIndex - TARGET_BASE;
+    atomicStore(&reached[OUTPUT_OFFSET + targetIndex], 1u);
+    atomicStore(&frontier[FRONTIER_OFFSET + targetIndex], 1u);
   }
 }`;
   const bindings: Record<string, GraphDataView<'uint32'>> = {
@@ -358,6 +486,7 @@ function addExpansionPass<Parameters>(
     frontier: GraphDataView<'uint32'>;
     nextFrontier: GraphDataView<'uint32'>;
     output: GraphDataView<'uint32'>;
+    targetBase: number;
     activeDepth?: GraphDataView<'uint32'>;
     depth: number;
   }
@@ -372,7 +501,9 @@ function addExpansionPass<Parameters>(
   }`
     : '';
   const source = /* wgsl */ `
-const NODE_COUNT: u32 = ${props.output.length}u;
+const SOURCE_COUNT: u32 = ${props.frontier.length}u;
+const TARGET_COUNT: u32 = ${props.output.length}u;
+const TARGET_BASE: u32 = ${props.targetBase}u;
 const NEIGHBOR_COUNT: u32 = ${props.neighbors.length}u;
 const OFFSETS_OFFSET: u32 = ${getViewElementOffset(props.offsets)}u;
 const NEIGHBORS_OFFSET: u32 = ${getViewElementOffset(props.neighbors)}u;
@@ -389,7 +520,7 @@ ${activeDepthDeclaration}
 @compute @workgroup_size(${GRAPH_TRAVERSAL_WORKGROUP_SIZE})
 fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let nodeIndex = globalId.x;
-  if (nodeIndex >= NODE_COUNT || frontier[FRONTIER_OFFSET + nodeIndex] == 0u) {
+  if (nodeIndex >= SOURCE_COUNT || frontier[FRONTIER_OFFSET + nodeIndex] == 0u) {
     return;
   }
   ${activeDepthGuard}
@@ -397,9 +528,11 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let lastNeighbor = min(offsets[OFFSETS_OFFSET + nodeIndex + 1u], NEIGHBOR_COUNT);
   for (var neighborIndex = firstNeighbor; neighborIndex < lastNeighbor; neighborIndex++) {
     let neighbor = neighbors[NEIGHBORS_OFFSET + neighborIndex];
-    if (neighbor < NODE_COUNT &&
-      atomicExchange(&reached[OUTPUT_OFFSET + neighbor], 1u) == 0u) {
-      atomicStore(&nextFrontier[NEXT_FRONTIER_OFFSET + neighbor], 1u);
+    if (neighbor >= TARGET_BASE && neighbor - TARGET_BASE < TARGET_COUNT) {
+      let targetIndex = neighbor - TARGET_BASE;
+      if (atomicExchange(&reached[OUTPUT_OFFSET + targetIndex], 1u) == 0u) {
+        atomicStore(&nextFrontier[NEXT_FRONTIER_OFFSET + targetIndex], 1u);
+      }
     }
   }
 }`;
@@ -426,8 +559,113 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
     source,
     resources,
     bindings,
-    dispatchCount: Math.ceil(props.output.length / GRAPH_TRAVERSAL_WORKGROUP_SIZE)
+    dispatchCount: Math.ceil(props.frontier.length / GRAPH_TRAVERSAL_WORKGROUP_SIZE)
   });
+}
+
+/** Adds every source-to-target partition pair required for arbitrary cross-partition edges. */
+function addPartitionedExpansionPasses<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    offsets: GraphVectorView<'uint32'>;
+    neighbors: GraphVectorView<'uint32'>;
+    currentFrontier: GraphVectorView<'uint32'>;
+    nextFrontier: GraphVectorView<'uint32'>;
+    output: GraphVectorView<'uint32'>;
+    activeDepth?: GraphDataView<'uint32'>;
+    depth: number;
+  }
+): void {
+  const sourceRanges = getTraversalChunkRanges(props.output);
+  for (const sourceRange of sourceRanges) {
+    if (sourceRange.view.length === 0) {
+      continue;
+    }
+    for (const targetRange of sourceRanges) {
+      if (targetRange.view.length === 0) {
+        continue;
+      }
+      addExpansionPass(graph, {
+        id: `${props.id}-source-${sourceRange.index}-target-${targetRange.index}`,
+        offsets: props.offsets.data[sourceRange.index],
+        neighbors: props.neighbors.data[sourceRange.index],
+        frontier: props.currentFrontier.data[sourceRange.index],
+        nextFrontier: props.nextFrontier.data[targetRange.index],
+        output: targetRange.view,
+        targetBase: targetRange.base,
+        activeDepth: props.activeDepth,
+        depth: props.depth
+      });
+    }
+  }
+}
+
+/** Validates atomic adjacency or one local CSR allocation per output partition. */
+function validateAdjacencyTopology(
+  id: string,
+  offsets: GPUGraphTraversalData,
+  neighbors: GPUGraphTraversalData,
+  output: GPUGraphTraversalData,
+  direction: 'forward' | 'reverse'
+): void {
+  const partitioned = output instanceof GraphVectorView;
+  if (
+    offsets instanceof GraphVectorView !== partitioned ||
+    neighbors instanceof GraphVectorView !== partitioned
+  ) {
+    throw new Error(`${id} ${direction} adjacency must use the same partition kind as output`);
+  }
+  if (!partitioned) {
+    if (offsets.length !== output.length + 1) {
+      const prefix = direction === 'reverse' ? 'reverse ' : '';
+      throw new Error(`${id} ${prefix}offsets must contain one more row than the output`);
+    }
+    return;
+  }
+  const offsetVector = offsets as GraphVectorView<'uint32'>;
+  const neighborVector = neighbors as GraphVectorView<'uint32'>;
+  const outputVector = output as GraphVectorView<'uint32'>;
+  if (
+    offsetVector.data.length !== outputVector.data.length ||
+    neighborVector.data.length !== outputVector.data.length
+  ) {
+    throw new Error(`${id} ${direction} adjacency must contain one CSR chunk per output chunk`);
+  }
+  for (const [chunkIndex, outputChunk] of outputVector.data.entries()) {
+    if (offsetVector.data[chunkIndex].length !== outputChunk.length + 1) {
+      throw new Error(
+        `${id} ${direction} offsets chunk ${chunkIndex} must contain one more row than its output chunk`
+      );
+    }
+  }
+}
+
+/** Normalizes traversal data into ordered physical chunks. */
+function getTraversalChunks(data: GPUGraphTraversalData): readonly GraphDataView<'uint32'>[] {
+  return data instanceof GraphVectorView ? data.data : [data];
+}
+
+/** Adds stable global row bases to ordered traversal chunks. */
+function getTraversalChunkRanges(data: GPUGraphTraversalData): Array<{
+  index: number;
+  base: number;
+  view: GraphDataView<'uint32'>;
+}> {
+  let base = 0;
+  return getTraversalChunks(data).map((view, index) => {
+    const range = {index, base, view};
+    base += view.length;
+    return range;
+  });
+}
+
+/** Validates every traversal partition as packed unsigned scalar data. */
+function validateTraversalData(data: GPUGraphTraversalData, name: string): void {
+  for (const [chunkIndex, view] of getTraversalChunks(data).entries()) {
+    const chunkName = data instanceof GraphVectorView ? `${name} chunk ${chunkIndex}` : name;
+    validatePackedUint32View(view, chunkName);
+  }
 }
 
 /** Wraps generated WGSL in one graph-owned, lazily bound computation. */

--- a/modules/experimental/src/gpu-primitives/gpu-hierarchy-layout.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-hierarchy-layout.ts
@@ -4,28 +4,32 @@
 
 import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {GPUCommandGraph, GraphVectorView, type GraphDataView} from './gpu-command-graph';
 import {GPUScan} from './gpu-scan';
 import {
   getViewBinding,
   getViewElementOffset,
+  validateMatchingVectorTopology,
   validatePackedUint32View
 } from './graph-data-view-utils';
 
 const HIERARCHY_LAYOUT_WORKGROUP_SIZE = 256;
+
+/** Packed hierarchy data stored in one allocation or ordered partitions. */
+export type GPUHierarchyLayoutData = GraphDataView<'uint32'> | GraphVectorView<'uint32'>;
 
 /** Properties for scan-based GPU layout of fixed-width parent/child groups. */
 export type GPUHierarchyLayoutProps = {
   /** Prefix for generated hierarchy and prefix-scan nodes. */
   id?: string;
   /** One zero/nonzero expansion state per parent. */
-  parentStates: GraphDataView<'uint32'>;
+  parentStates: GPUHierarchyLayoutData;
   /** One zero/nonzero expansion state per child. */
-  childStates: GraphDataView<'uint32'>;
+  childStates: GPUHierarchyLayoutData;
   /** Caller-owned effective heights for each child. */
-  heights: GraphDataView<'uint32'>;
+  heights: GPUHierarchyLayoutData;
   /** Caller-owned exclusive layout offsets for each child. */
-  offsets: GraphDataView<'uint32'>;
+  offsets: GPUHierarchyLayoutData;
   /** Number of consecutive children belonging to each parent. */
   childrenPerParent: number;
   /** Height contributed by an expanded child. Defaults to one. */
@@ -47,13 +51,13 @@ export class GPUHierarchyLayout {
   /** Prefix for generated command-graph nodes. */
   readonly id: string;
   /** Source-aligned parent expansion states. */
-  readonly parentStates: GraphDataView<'uint32'>;
+  readonly parentStates: GPUHierarchyLayoutData;
   /** Source-aligned child expansion states. */
-  readonly childStates: GraphDataView<'uint32'>;
+  readonly childStates: GPUHierarchyLayoutData;
   /** Caller-owned effective child heights. */
-  readonly heights: GraphDataView<'uint32'>;
+  readonly heights: GPUHierarchyLayoutData;
   /** Caller-owned exclusive child offsets. */
-  readonly offsets: GraphDataView<'uint32'>;
+  readonly offsets: GPUHierarchyLayoutData;
   /** Number of consecutive children represented by one parent. */
   readonly childrenPerParent: number;
   /** Effective expanded child height. */
@@ -74,13 +78,13 @@ export class GPUHierarchyLayout {
     this.collapsedChildHeight = props.collapsedChildHeight ?? 1;
     this.collapsedParentHeight = props.collapsedParentHeight ?? 1;
 
-    for (const [name, view] of [
+    for (const [name, data] of [
       ['parentStates', this.parentStates],
       ['childStates', this.childStates],
       ['heights', this.heights],
       ['offsets', this.offsets]
     ] as const) {
-      validatePackedUint32View(view, `${this.id} ${name}`);
+      validateHierarchyData(data, `${this.id} ${name}`);
     }
     if (!Number.isSafeInteger(this.childrenPerParent) || this.childrenPerParent <= 0) {
       throw new Error(`${this.id} childrenPerParent must be a positive safe integer`);
@@ -94,6 +98,8 @@ export class GPUHierarchyLayout {
     ) {
       throw new Error(`${this.id} heights and offsets must match the child count`);
     }
+    validateChildOutputTopology(this.childStates, this.heights, `${this.id} heights`);
+    validateChildOutputTopology(this.childStates, this.offsets, `${this.id} offsets`);
     for (const [name, value] of [
       ['expandedChildHeight', this.expandedChildHeight],
       ['collapsedChildHeight', this.collapsedChildHeight],
@@ -103,12 +109,16 @@ export class GPUHierarchyLayout {
         throw new Error(`${this.id} ${name} must be a uint32`);
       }
     }
+    const heightBuffers = getHierarchyBuffers(this.heights);
+    const offsetBuffers = getHierarchyBuffers(this.offsets);
+    const inputBuffers = new Set([
+      ...getHierarchyBuffers(this.parentStates),
+      ...getHierarchyBuffers(this.childStates)
+    ]);
     if (
-      this.heights.buffer === this.offsets.buffer ||
-      this.heights.buffer === this.parentStates.buffer ||
-      this.heights.buffer === this.childStates.buffer ||
-      this.offsets.buffer === this.parentStates.buffer ||
-      this.offsets.buffer === this.childStates.buffer
+      heightBuffers.some(buffer => offsetBuffers.includes(buffer)) ||
+      heightBuffers.some(buffer => inputBuffers.has(buffer)) ||
+      offsetBuffers.some(buffer => inputBuffers.has(buffer))
     ) {
       throw new Error(
         `${this.id} layout outputs must use separate buffers from inputs and each other`
@@ -118,15 +128,40 @@ export class GPUHierarchyLayout {
 
   /** Adds one hierarchy-height kernel and the graph-native exclusive prefix scan. */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
-    for (const view of [this.parentStates, this.childStates, this.heights, this.offsets]) {
-      if (view.buffer.graph !== graph) {
-        throw new Error(`${this.id} views must belong to the target graph`);
+    for (const data of [this.parentStates, this.childStates, this.heights, this.offsets]) {
+      for (const view of getHierarchyChunks(data)) {
+        if (view.buffer.graph !== graph) {
+          throw new Error(`${this.id} views must belong to the target graph`);
+        }
       }
     }
     if (this.childStates.length === 0) {
       return;
     }
-    this.addHeightPass(graph);
+    const parentChunks = getHierarchyChunkRanges(this.parentStates);
+    const childChunks = getHierarchyChunkRanges(this.childStates);
+    const heightChunks = getHierarchyChunks(this.heights);
+    for (const childChunk of childChunks) {
+      for (const parentChunk of parentChunks) {
+        const firstChild = Math.max(childChunk.base, parentChunk.base * this.childrenPerParent);
+        const lastChild = Math.min(
+          childChunk.base + childChunk.view.length,
+          (parentChunk.base + parentChunk.view.length) * this.childrenPerParent
+        );
+        if (firstChild < lastChild) {
+          this.addHeightPass(graph, {
+            id: `${this.id}-heights-child-${childChunk.index}-parent-${parentChunk.index}`,
+            parentStates: parentChunk.view,
+            parentBase: parentChunk.base,
+            childStates: childChunk.view,
+            childHeights: heightChunks[childChunk.index],
+            childBase: childChunk.base,
+            firstChild,
+            childCount: lastChild - firstChild
+          });
+        }
+      }
+    }
     new GPUScan({
       id: `${this.id}-offsets`,
       input: this.heights,
@@ -135,32 +170,48 @@ export class GPUHierarchyLayout {
   }
 
   /** Publishes one effective child height for the current parent and child expansion state. */
-  private addHeightPass<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+  private addHeightPass<Parameters>(
+    graph: GPUCommandGraph<Parameters>,
+    props: {
+      id: string;
+      parentStates: GraphDataView<'uint32'>;
+      parentBase: number;
+      childStates: GraphDataView<'uint32'>;
+      childHeights: GraphDataView<'uint32'>;
+      childBase: number;
+      firstChild: number;
+      childCount: number;
+    }
+  ): void {
     const source = /* wgsl */ `
-const CHILD_COUNT: u32 = ${this.childStates.length}u;
+const CHILD_COUNT: u32 = ${props.childCount}u;
 const CHILDREN_PER_PARENT: u32 = ${this.childrenPerParent}u;
 const EXPANDED_CHILD_HEIGHT: u32 = ${this.expandedChildHeight}u;
 const COLLAPSED_CHILD_HEIGHT: u32 = ${this.collapsedChildHeight}u;
 const COLLAPSED_PARENT_HEIGHT: u32 = ${this.collapsedParentHeight}u;
-const PARENT_OFFSET: u32 = ${getViewElementOffset(this.parentStates)}u;
-const CHILD_OFFSET: u32 = ${getViewElementOffset(this.childStates)}u;
-const HEIGHT_OFFSET: u32 = ${getViewElementOffset(this.heights)}u;
+const PARENT_BASE: u32 = ${props.parentBase}u;
+const CHILD_BASE: u32 = ${props.childBase}u;
+const FIRST_CHILD: u32 = ${props.firstChild}u;
+const PARENT_OFFSET: u32 = ${getViewElementOffset(props.parentStates)}u;
+const CHILD_OFFSET: u32 = ${getViewElementOffset(props.childStates)}u;
+const HEIGHT_OFFSET: u32 = ${getViewElementOffset(props.childHeights)}u;
 @group(0) @binding(0) var<storage, read> parentStates: array<u32>;
 @group(0) @binding(1) var<storage, read> childStates: array<u32>;
 @group(0) @binding(2) var<storage, read_write> childHeights: array<u32>;
 
 @compute @workgroup_size(${HIERARCHY_LAYOUT_WORKGROUP_SIZE})
 fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let childIndex = globalId.x;
-  if (childIndex >= CHILD_COUNT) {
+  if (globalId.x >= CHILD_COUNT) {
     return;
   }
-  let parentIndex = childIndex / CHILDREN_PER_PARENT;
+  let globalChildIndex = FIRST_CHILD + globalId.x;
+  let childIndex = globalChildIndex - CHILD_BASE;
+  let parentIndex = globalChildIndex / CHILDREN_PER_PARENT - PARENT_BASE;
   if (parentStates[PARENT_OFFSET + parentIndex] == 0u) {
     childHeights[HEIGHT_OFFSET + childIndex] = select(
       0u,
       COLLAPSED_PARENT_HEIGHT,
-      childIndex % CHILDREN_PER_PARENT == 0u
+      globalChildIndex % CHILDREN_PER_PARENT == 0u
     );
     return;
   }
@@ -171,20 +222,20 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   );
 }`;
     const views = {
-      parentStates: this.parentStates,
-      childStates: this.childStates,
-      childHeights: this.heights
+      parentStates: props.parentStates,
+      childStates: props.childStates,
+      childHeights: props.childHeights
     };
     graph.addComputePass({
-      id: `${this.id}-heights`,
+      id: props.id,
       resources: [
-        {buffer: this.parentStates, usage: 'storage-read'},
-        {buffer: this.childStates, usage: 'storage-read'},
-        {buffer: this.heights, usage: 'storage-write'}
+        {buffer: props.parentStates, usage: 'storage-read'},
+        {buffer: props.childStates, usage: 'storage-read'},
+        {buffer: props.childHeights, usage: 'storage-write'}
       ],
       compile: ({device}) => {
         const computation = new Computation(device, {
-          id: `${this.id}-heights`,
+          id: props.id,
           source,
           shaderLayout: {
             bindings: Object.keys(views).map((name, location) => ({
@@ -204,7 +255,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
             computation.setBindings(resolvedBindings);
             computation.dispatch(
               computePass,
-              Math.ceil(this.childStates.length / HIERARCHY_LAYOUT_WORKGROUP_SIZE)
+              Math.ceil(props.childCount / HIERARCHY_LAYOUT_WORKGROUP_SIZE)
             );
           },
           destroy: () => computation.destroy()
@@ -212,4 +263,50 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
       }
     });
   }
+}
+
+/** Normalizes hierarchy data into ordered physical chunks. */
+function getHierarchyChunks(data: GPUHierarchyLayoutData): readonly GraphDataView<'uint32'>[] {
+  return data instanceof GraphVectorView ? data.data : [data];
+}
+
+/** Adds stable cumulative row bases without modifying caller-owned chunk metadata. */
+function getHierarchyChunkRanges(data: GPUHierarchyLayoutData): Array<{
+  index: number;
+  base: number;
+  view: GraphDataView<'uint32'>;
+}> {
+  let base = 0;
+  return getHierarchyChunks(data).map((view, index) => {
+    const range = {index, base, view};
+    base += view.length;
+    return range;
+  });
+}
+
+/** Validates every hierarchy partition as packed unsigned scalar data. */
+function validateHierarchyData(data: GPUHierarchyLayoutData, name: string): void {
+  for (const [chunkIndex, view] of getHierarchyChunks(data).entries()) {
+    const chunkName = data instanceof GraphVectorView ? `${name} chunk ${chunkIndex}` : name;
+    validatePackedUint32View(view, chunkName);
+  }
+}
+
+/** Requires child-aligned outputs to preserve the source partition topology. */
+function validateChildOutputTopology(
+  childStates: GPUHierarchyLayoutData,
+  output: GPUHierarchyLayoutData,
+  name: string
+): void {
+  if (childStates instanceof GraphVectorView !== output instanceof GraphVectorView) {
+    throw new Error(`${name} must use the same data-view or vector-view kind as childStates`);
+  }
+  if (childStates instanceof GraphVectorView && output instanceof GraphVectorView) {
+    validateMatchingVectorTopology(childStates, output, name);
+  }
+}
+
+/** Returns the logical buffers referenced by one hierarchy input or output. */
+function getHierarchyBuffers(data: GPUHierarchyLayoutData) {
+  return getHierarchyChunks(data).map(view => view.buffer);
 }

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -61,10 +61,14 @@ export {GPUMask} from './gpu-mask';
 export type {GPUMaskInput, GPUMaskOperation, GPUMaskProps} from './gpu-mask';
 
 export {GPUHierarchyLayout} from './gpu-hierarchy-layout';
-export type {GPUHierarchyLayoutProps} from './gpu-hierarchy-layout';
+export type {GPUHierarchyLayoutData, GPUHierarchyLayoutProps} from './gpu-hierarchy-layout';
 
 export {GPUGraphTraversal} from './gpu-graph-traversal';
-export type {GPUGraphTraversalDirection, GPUGraphTraversalProps} from './gpu-graph-traversal';
+export type {
+  GPUGraphTraversalData,
+  GPUGraphTraversalDirection,
+  GPUGraphTraversalProps
+} from './gpu-graph-traversal';
 
 export {GPUAncestorProjection} from './gpu-ancestor-projection';
 export type {GPUAncestorProjectionProps} from './gpu-ancestor-projection';

--- a/modules/experimental/test/gpu-primitives/gpu-trace-manipulation.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-trace-manipulation.spec.ts
@@ -121,6 +121,37 @@ test('GPUHierarchyLayout scans live parent and child expansion states', async t 
   t.end();
 });
 
+test('GPUHierarchyLayout preserves uneven parent and child partitions', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const result = await runPartitionedHierarchyLayout(device);
+  t.deepEqual(
+    result.heights,
+    [[4, 1, 1], [], [0, 1, 4]],
+    'global parent IDs remain correct when one child chunk crosses parent chunk boundaries'
+  );
+  t.deepEqual(
+    result.offsets,
+    [[0, 4, 5], [], [6, 6, 7]],
+    'the vector-wide scan preserves empty and uneven output chunks'
+  );
+  t.ok(
+    result.nodeOrder.includes('partitioned-hierarchy-heights-child-0-parent-2'),
+    'the crossing child chunk is split against the relevant parent partition'
+  );
+  t.deepEqual(
+    result.updatedOffsets,
+    [[0, 4, 5], [], [6, 6, 10]],
+    'replacing one child batch updates the vector-wide layout without recompiling the graph'
+  );
+  t.end();
+});
+
 test('GPUGraphTraversal expands outgoing, incoming, and bidirectional frontiers', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -189,6 +220,28 @@ test('GPUGraphTraversal reads dynamic seed counts and traversal depth', async t 
     }),
     [0, 0, 0, 0, 0, 0],
     'zero active seeds clear every previously selected node'
+  );
+  t.end();
+});
+
+test('GPUGraphTraversal follows global IDs across local CSR partitions', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const result = await runPartitionedTraversal(device);
+  t.deepEqual(
+    result.output,
+    [[1, 1], [], [1, 1], [1, 0]],
+    'cross-partition edges match the packed traversal while preserving output topology'
+  );
+  t.ok(
+    result.nodeOrder.includes('partitioned-traversal-depth-0-outgoing-source-0-target-2') &&
+      result.nodeOrder.includes('partitioned-traversal-depth-1-outgoing-source-2-target-3'),
+    'source-to-target partition pairs make cross-partition routing explicit'
   );
   t.end();
 });
@@ -423,6 +476,51 @@ async function runHierarchyLayout(
   return {heights, offsets};
 }
 
+async function runPartitionedHierarchyLayout(device: Device): Promise<{
+  heights: number[][];
+  offsets: number[][];
+  updatedOffsets: number[][];
+  nodeOrder: string[];
+}> {
+  const parentChunks = [Uint32Array.from([1]), new Uint32Array(0), Uint32Array.from([0, 1])];
+  const childChunks = [
+    Uint32Array.from([1, 0, 1]),
+    new Uint32Array(0),
+    Uint32Array.from([1, 0, 1])
+  ];
+  const parents = createVectorFixture(device, 'parents', parentChunks, false);
+  const children = createVectorFixture(device, 'children', childChunks, false);
+  const heights = createVectorFixture(device, 'heights', childChunks, true);
+  const offsets = createVectorFixture(device, 'offsets', childChunks, true);
+  const graph = new GPUCommandGraph(device, {id: 'partitioned-hierarchy-test'});
+  new GPUHierarchyLayout({
+    id: 'partitioned-hierarchy',
+    parentStates: graph.importGPUVector('parents', parents.vector),
+    childStates: graph.importGPUVector('children', children.vector),
+    heights: graph.importGPUVector('heights', heights.vector),
+    offsets: graph.importGPUVector('offsets', offsets.vector),
+    childrenPerParent: 2,
+    expandedChildHeight: 4
+  }).addToGraph(graph);
+  const compiled = graph.compile();
+  submitGraph(device, compiled, 'partitioned-hierarchy-test');
+  const firstHeights = await readVectorFixture(heights);
+  const firstOffsets = await readVectorFixture(offsets);
+  children.buffers[2].write(Uint32Array.from([1, 1, 1]));
+  submitGraph(device, compiled, 'partitioned-hierarchy-update-test');
+  const result = {
+    heights: firstHeights,
+    offsets: firstOffsets,
+    updatedOffsets: await readVectorFixture(offsets),
+    nodeOrder: compiled.stats.nodeOrder
+  };
+  compiled.destroy();
+  for (const fixture of [parents, children, heights, offsets]) {
+    destroyVectorFixture(fixture);
+  }
+  return result;
+}
+
 async function runAncestorProjection(
   device: Device,
   parents: Uint32Array,
@@ -542,6 +640,52 @@ async function runTraversal(
   return result;
 }
 
+async function runPartitionedTraversal(device: Device): Promise<{
+  output: number[][];
+  nodeOrder: string[];
+}> {
+  const outputChunks = [
+    new Uint32Array(2),
+    new Uint32Array(0),
+    new Uint32Array(2),
+    new Uint32Array(2)
+  ];
+  const offsetChunks = [
+    Uint32Array.from([0, 2, 4]),
+    Uint32Array.from([0]),
+    Uint32Array.from([0, 2, 3]),
+    Uint32Array.from([0, 0, 0])
+  ];
+  const neighborChunks = [
+    Uint32Array.from([1, 2, 2, 3]),
+    new Uint32Array(0),
+    Uint32Array.from([0, 3, 4]),
+    new Uint32Array(0)
+  ];
+  const seedChunks = [Uint32Array.from([0]), new Uint32Array(0), new Uint32Array(0)];
+  const offsets = createVectorFixture(device, 'offsets', offsetChunks, false);
+  const neighbors = createVectorFixture(device, 'neighbors', neighborChunks, false);
+  const seeds = createVectorFixture(device, 'seeds', seedChunks, false);
+  const output = createVectorFixture(device, 'output', outputChunks, true);
+  const graph = new GPUCommandGraph(device, {id: 'partitioned-traversal-test'});
+  new GPUGraphTraversal({
+    id: 'partitioned-traversal',
+    offsets: graph.importGPUVector('offsets', offsets.vector),
+    neighbors: graph.importGPUVector('neighbors', neighbors.vector),
+    seeds: graph.importGPUVector('seeds', seeds.vector),
+    output: graph.importGPUVector('output', output.vector),
+    maxDepth: 3
+  }).addToGraph(graph);
+  const compiled = graph.compile();
+  submitGraph(device, compiled, 'partitioned-traversal-test');
+  const result = {output: await readVectorFixture(output), nodeOrder: compiled.stats.nodeOrder};
+  compiled.destroy();
+  for (const fixture of [offsets, neighbors, seeds, output]) {
+    destroyVectorFixture(fixture);
+  }
+  return result;
+}
+
 type Uint32VectorFixture = {
   vector: GPUVector<'uint32'>;
   buffers: Buffer[];
@@ -581,6 +725,12 @@ function destroyVectorFixture(fixture: Uint32VectorFixture): void {
   for (const buffer of fixture.buffers) {
     buffer.destroy();
   }
+}
+
+async function readVectorFixture(fixture: Uint32VectorFixture): Promise<number[][]> {
+  return Promise.all(
+    fixture.buffers.map((buffer, index) => readUint32(buffer, fixture.vector.data[index].length))
+  );
 }
 
 function createUint32Buffer(device: Device, values: Uint32Array, readable: boolean): Buffer {


### PR DESCRIPTION
## Goals

- Complete roadmap tranche 3.2 with explicit global identity across partitioned hierarchy and CSR inputs.
- Complete tranche 3.3 by recording evidence thresholds for speculative extension APIs.
- Preserve source batch boundaries without hidden packing or a second application storage model.

## Changes

- Extends `GPUHierarchyLayout` to accept independently partitioned parent and child vectors, split intersecting ranges explicitly, and scan caller-owned child output partitions globally.
- Extends `GPUGraphTraversal` to accept one local CSR allocation per output partition while retaining global neighbor IDs and arbitrary cross-partition edges.
- Preserves partition topology in graph-owned frontiers, supports chunked seeds, and documents the O(partition²) dispatch envelope.
- Migrates the hierarchical trace example to two logical hierarchy and CSR partitions backed by its existing allocations.
- Adds WebGPU coverage for empty and uneven chunks, boundary-crossing parent lookup, cross-partition graph edges, and replacing one child batch without recompilation.
- Adds Overview/Concepts documentation for both partition contracts and records explicit deferral criteria for custom scans, sparse and multidimensional histograms, and WGSL callbacks.

## Stack

- Base: #2804 (`codex/expand-gpu-roadmap`)
- This PR implements roadmap tranches 3.2 and 3.3 described by that documentation PR.

## Verification

- `nvm use` — passed (Node 22.22.1)
- `yarn install` — not run; existing lockfile installation was used and dependencies were unchanged
- `yarn lint fix` — passed
- `yarn build` — passed
- `yarn test-node` — passed (253 tests, 2 skipped)
- `yarn test-headless gpu-trace-manipulation` — passed (9 tests)
- `yarn test` — Node suite passed; headless suite passed 1,335 tests with 25 skipped and one unrelated existing failure in `arrow-layers.spec.ts` (`arrow-polygons-storage-test has drawable storage-backed instances`)
- `yarn website:build` — passed
- `(cd website && yarn build)` — passed
- Rendered hierarchy and traversal Concepts pages checked at desktop and 390px widths; new roadmap table remains in its horizontal scroll wrapper
- `git diff --check` and internal-terminology scan — passed

## Risks and follow-up

- General cross-partition CSR traversal rescans each active source partition for every target partition. The contract is intended for coarse storage/update boundaries; the docs make this cost explicit.
- Fine-grained target routing belongs in a later topological or spatial index and can build on the same global-ID contract.
