### PR TITLE
feat: add cinematic Lightstorm postprocessing

### DIFF
--- a/docs/api-reference/engine/passes/shader-pass-renderer.md
+++ b/docs/api-reference/engine/passes/shader-pass-renderer.md
@@ -239,11 +239,45 @@ renderToTexture(options: {
 }): Texture | null
 ```
 
+### `encodeToScreen(commandEncoder, options): boolean`
+
+Records the pass chain and final presentation into a caller-owned command encoder.
+
+```ts
+encodeToScreen(
+  commandEncoder: CommandEncoder,
+  options: ShaderPassRendererRenderOptions
+): boolean
+```
+
+This method only records commands. The caller remains responsible for finishing and submitting the
+encoder. The encoder must belong to the renderer's device, and no render or compute pass may be
+active when this method is called. Returns `false` when the source texture is not ready yet.
+
+### `encodeToTexture(commandEncoder, options): Texture | null`
+
+Records the pass chain into a caller-owned command encoder and returns the renderer-owned output
+texture.
+
+```ts
+encodeToTexture(
+  commandEncoder: CommandEncoder,
+  options: ShaderPassRendererRenderOptions
+): Texture | null
+```
+
+This method does not finish or submit the encoder. The encoder must belong to the renderer's device,
+and no render or compute pass may be active. The returned texture is valid after the recorded command
+buffer has been submitted.
+
 ## Remarks
 
 - `sourceTexture` may be a `DynamicTexture` or a ready `Texture`.
 - `uniforms` may supply per-draw shader module uniforms keyed by shader pass name.
 - `bindings` may supply per-draw texture bindings or texture binding sources keyed by shader binding name.
+- `renderToScreen()` and `renderToTexture()` are convenience wrappers that record onto
+  `device.commandEncoder`; use the `encodeTo*()` variants when composing with a command graph or
+  another caller-owned encoder.
 - Two internal framebuffers are used for ping-pong rendering through the shared `previous` sequence.
 - Named render targets are declared only on `ShaderPassPipeline`, not on `ShaderPass`.
 - Target names `original` and `previous` are reserved and may not be used as pipeline target names.

--- a/examples/showcase/lightstorm-megacity/app.ts
+++ b/examples/showcase/lightstorm-megacity/app.ts
@@ -2,9 +2,16 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, type Device, type RenderBundle} from '@luma.gl/core';
+import {Buffer, Texture, type Device, type RenderBundle} from '@luma.gl/core';
+import {createBloomShaderPassPipeline, toneMapping} from '@luma.gl/effects';
 import type {AnimationProps} from '@luma.gl/engine';
-import {AnimationLoopTemplate, Computation, CubeGeometry, Model} from '@luma.gl/engine';
+import {
+  AnimationLoopTemplate,
+  Computation,
+  CubeGeometry,
+  Model,
+  ShaderPassRenderer
+} from '@luma.gl/engine';
 import {
   decodeGPUIndexPickInfo,
   DrawCommandBuffer,
@@ -67,9 +74,12 @@ type LightstormGraphResources = {
   drawCommands: DrawCommandBuffer;
   instances: Buffer;
   visibleIdentifiers: Buffer;
+  sceneColor: Texture;
   perspectiveRenderBundle: RenderBundle;
   overviewRenderBundle: RenderBundle;
 };
+
+type LightstormSceneColorFormat = 'rgba8unorm' | 'rgba16float';
 
 type Viewport = [number, number, number, number];
 
@@ -90,6 +100,8 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
   readonly device: Device;
   readonly model: Model;
   readonly pickingModel: Model;
+  readonly sceneColorFormat: LightstormSceneColorFormat;
+  readonly postprocessingRenderer: ShaderPassRenderer;
   readonly uniformBuffer: Buffer;
   readonly overviewUniformBuffer: Buffer;
   readonly panels: ExamplePanelManager;
@@ -144,6 +156,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       throw new Error('Lightstorm Megacity requires WebGPU');
     }
     this.device = device;
+    this.sceneColorFormat = getSceneColorFormat(device);
     this.uniformBuffer = device.createBuffer({
       id: 'lightstorm-megacity-uniforms',
       byteLength: UNIFORM_BYTE_LENGTH,
@@ -158,7 +171,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       id: 'lightstorm-megacity-model',
       source: LIGHTSTORM_RENDER_SHADER,
       geometry: new CubeGeometry({id: 'lightstorm-megacity-cube', indices: true}),
-      colorAttachmentFormats: [device.preferredColorFormat],
+      colorAttachmentFormats: [this.sceneColorFormat],
       depthStencilAttachmentFormat: 'depth24plus',
       shaderLayout: {
         attributes: [
@@ -199,6 +212,13 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
         depthCompare: 'less-equal',
         depthWriteEnabled: true
       }
+    });
+    this.postprocessingRenderer = new ShaderPassRenderer(device, {
+      shaderPasses: [
+        createBloomShaderPassPipeline({colorFormat: this.sceneColorFormat}),
+        toneMapping
+      ],
+      colorFormat: this.sceneColorFormat
     });
     this.panels = new ExamplePanelManager({panel: this.makePanel()});
     this.rebuild(lightstormCapacity);
@@ -242,6 +262,20 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     this.writeUniforms(viewports, time);
     const encodeStart = performance.now();
     resources.compiled.encode(device.commandEncoder, {parameters: viewports});
+    this.postprocessingRenderer.encodeToScreen(device.commandEncoder, {
+      sourceTexture: resources.sceneColor,
+      uniforms: {
+        bloomExtract: {
+          threshold: this.sceneColorFormat === 'rgba16float' ? 0.8 : 0.55
+        },
+        bloomBlur: {radius: 6},
+        bloomComposite: {intensity: 0.55},
+        toneMapping: {
+          exposure: this.sceneColorFormat === 'rgba16float' ? 0.92 : 1,
+          maximumLuminance: device.preferredColorFormat === 'rgba16float' ? 2.4 : 1
+        }
+      }
+    });
     if (
       !this.guidedCamera &&
       this.pointerDirty &&
@@ -285,6 +319,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     }
     this.panels.finalize();
     this.destroyResources();
+    this.postprocessingRenderer.destroy();
     this.pickingModel.destroy();
     this.model.destroy();
     this.uniformBuffer.destroy();
@@ -317,6 +352,23 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       type: 'draw-indexed',
       commands: [{indexCount: this.getIndexCount(), instanceCount: 0}]
     });
+    const deviceSize = this.device.getDefaultCanvasContext().getDevicePixelSize();
+    const pickingWidth = Math.max(1, deviceSize[0]);
+    const pickingHeight = Math.max(1, deviceSize[1]);
+    const sceneColor = this.device.createTexture({
+      id: 'lightstorm-megacity-scene-color',
+      format: this.sceneColorFormat,
+      width: pickingWidth,
+      height: pickingHeight,
+      usage: Texture.SAMPLE | Texture.RENDER,
+      sampler: {
+        minFilter: 'linear',
+        magFilter: 'linear',
+        addressModeU: 'clamp-to-edge',
+        addressModeV: 'clamp-to-edge'
+      }
+    });
+    this.postprocessingRenderer.resize([pickingWidth, pickingHeight]);
     const perspectiveRenderBundle = this.createRenderBundle(
       'lightstorm-megacity-perspective-render-bundle',
       instances,
@@ -337,11 +389,9 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       visibleIdentifiers,
       drawCommands,
       perspectiveRenderBundle,
-      overviewRenderBundle
+      overviewRenderBundle,
+      sceneColor
     );
-    const deviceSize = this.device.getDefaultCanvasContext().getDevicePixelSize();
-    const pickingWidth = Math.max(1, deviceSize[0]);
-    const pickingHeight = Math.max(1, deviceSize[1]);
     const picking = this.createPickingGraph(
       pickingWidth,
       pickingHeight,
@@ -358,6 +408,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       drawCommands,
       instances,
       visibleIdentifiers,
+      sceneColor,
       perspectiveRenderBundle,
       overviewRenderBundle
     };
@@ -374,7 +425,8 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     visibleIdentifiersBuffer: Buffer,
     drawCommands: DrawCommandBuffer,
     perspectiveRenderBundle: RenderBundle,
-    overviewRenderBundle: RenderBundle
+    overviewRenderBundle: RenderBundle,
+    sceneColorTexture: Texture
   ): CompiledGPUCommandGraph<LightstormGraphParameters> {
     const graph = new GPUCommandGraph<LightstormGraphParameters>(this.device, {
       id: 'lightstorm-megacity-command-graph'
@@ -411,6 +463,25 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       },
       drawCommands.buffer
     );
+    const sceneColor = graph.importTexture(
+      {
+        id: 'scene-color',
+        format: sceneColorTexture.format,
+        width: sceneColorTexture.width,
+        height: sceneColorTexture.height,
+        usage: sceneColorTexture.props.usage
+      },
+      sceneColorTexture
+    );
+    const sceneDepth = graph.createTransientTexture({
+      id: 'scene-depth',
+      format: 'depth24plus',
+      width: sceneColorTexture.width,
+      height: sceneColorTexture.height,
+      usage: Texture.RENDER
+    });
+    const sceneColorView = graph.createTextureView(sceneColor);
+    const sceneDepthView = graph.createTextureView(sceneDepth);
     const flagsBuffer = graph.createTransientBuffer({
       id: 'visibility-flags',
       byteLength: capacity * UINT32_BYTE_LENGTH,
@@ -469,6 +540,10 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
 
     graph.addRenderPass({
       id: 'render-visible-city',
+      attachments: {
+        colorAttachments: [sceneColorView],
+        depthStencilAttachment: sceneDepthView
+      },
       resources: [
         {buffer: instances, usage: 'storage-read'},
         {buffer: visibleIdentifiers, usage: 'storage-read'},
@@ -587,7 +662,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
   ): RenderBundle {
     const encoder = this.device.createRenderBundleEncoder({
       id: identifier,
-      colorAttachmentFormats: [this.device.preferredColorFormat],
+      colorAttachmentFormats: [this.sceneColorFormat],
       depthStencilAttachmentFormat: 'depth24plus'
     });
     encoder.setPipeline(this.model.pipeline);
@@ -700,8 +775,8 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
         getDataLayerMode(this.dataLayer),
         this.lightstormEnabled ? 1 : 0,
         timeMilliseconds / 1000,
-        this.device.preferredColorFormat === 'rgba16float' ? 1 : 1.35,
-        this.device.preferredColorFormat === 'rgba16float' ? 1 : 0,
+        1,
+        0,
         0
       ],
       32
@@ -765,6 +840,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     this.resources.drawCommands.destroy();
     this.resources.instances.destroy();
     this.resources.visibleIdentifiers.destroy();
+    this.resources.sceneColor.destroy();
     this.resources = null;
   }
 
@@ -776,7 +852,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
         makeHtmlCustomPanel({
           id: 'lightstorm-megacity-overview',
           title: '',
-          html: `<p style="margin:0;line-height:1.45"><strong>GPU resident · no per-frame instance upload.</strong> One command graph filters city layers, tests conservative tower bounds, stably compacts source IDs, writes an indexed indirect command, and replays a fixed render bundle. Extended HDR presentation is used when available.</p>`
+          html: `<p style="margin:0;line-height:1.45"><strong>GPU resident · no per-frame instance upload.</strong> One command graph filters city layers, tests conservative tower bounds, stably compacts source IDs, writes an indexed indirect command, and replays a fixed render bundle into an HDR scene target. Multiscale bloom and ACES tone mapping finish the frame on the same command encoder.</p>`
         }),
         makeHtmlCustomPanel({
           id: 'lightstorm-megacity-controls',
@@ -927,12 +1003,13 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
         <span>Submitted triangles</span><strong>${submittedTriangles}</strong>
         <span>Indirect draws</span><strong>${replayCount}</strong>
         <span>Bundle replays</span><strong>${replayCount}</strong>
-        <span>Presentation</span><strong>${this.device.preferredColorFormat === 'rgba16float' ? 'Display P3 extended HDR' : 'tone-mapped SDR'}</strong>
+        <span>Post stack</span><strong>multiscale HDR bloom · ACES</strong>
+        <span>Presentation</span><strong>${this.device.preferredColorFormat === 'rgba16float' ? 'Display P3 extended HDR' : 'filmic SDR'}</strong>
         <span>Frame rate</span><strong>${this.framesPerSecond.toFixed(1)} FPS</strong>
         <span>CPU frame</span><strong>${this.cpuFrameTimeMilliseconds.toFixed(2)} ms</strong>
         <span>GPU frame</span><strong>${formatGpuTime(this.device, this.gpuFrameTimeMilliseconds)}</strong>
         <span>Picked record</span><strong>${this.formatPickedRecord()}</strong>
-        <span>CPU graph encode</span><strong>${this.encodeTimeMilliseconds.toFixed(2)} ms</strong>
+        <span>CPU command encode</span><strong>${this.encodeTimeMilliseconds.toFixed(2)} ms</strong>
         <span>Logical scratch</span><strong>${formatBytes(stats.logicalTransientBytes)}</strong>
         <span>Physical scratch</span><strong>${formatBytes(stats.physicalTransientBytes)}</strong>
         <span>Transient reuse</span><strong>${stats.reusePercentage.toFixed(0)}%</strong>
@@ -1052,6 +1129,13 @@ function getDataLayerMode(dataLayer: LightstormDataLayer): number {
   if (dataLayer === 'towers') return 1;
   if (dataLayer === 'transit') return 2;
   return 0;
+}
+
+function getSceneColorFormat(device: Device): LightstormSceneColorFormat {
+  const floatingPointCapabilities = device.getTextureFormatCapabilities('rgba16float');
+  return floatingPointCapabilities.render && floatingPointCapabilities.filter
+    ? 'rgba16float'
+    : 'rgba8unorm';
 }
 
 function getEligibleCount(

--- a/examples/showcase/lightstorm-megacity/lightstorm-shaders.ts
+++ b/examples/showcase/lightstorm-megacity/lightstorm-shaders.ts
@@ -117,10 +117,6 @@ fn hashWindow(value: vec2<f32>) -> f32 {
   color = mix(color, fogColor, clamp(fogAmount, 0.0, 0.96));
   color += vec3<f32>(0.12, 0.2, 0.48) * skyPulse * (1.0 - fogAmount * 0.5);
   color *= uniforms.scene.y;
-
-  if (uniforms.scene.z < 0.5) {
-    color = color / (color + vec3<f32>(1.0));
-  }
   return vec4<f32>(color, 1.0);
 }`;
 

--- a/examples/showcase/lightstorm-megacity/package.json
+++ b/examples/showcase/lightstorm-megacity/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e",
     "@luma.gl/core": "9.4.0-alpha.2",
+    "@luma.gl/effects": "9.4.0-alpha.2",
     "@luma.gl/engine": "9.4.0-alpha.2",
     "@luma.gl/experimental": "9.4.0-alpha.2",
     "@luma.gl/shadertools": "9.4.0-alpha.2",

--- a/modules/engine/src/passes/shader-pass-renderer.ts
+++ b/modules/engine/src/passes/shader-pass-renderer.ts
@@ -146,7 +146,19 @@ export class ShaderPassRenderer {
   }
 
   renderToScreen(options: ShaderPassRendererRenderOptions): boolean {
-    const outputTexture = this.renderToTexture(options);
+    return this.encodeToScreen(this.device.commandEncoder, options);
+  }
+
+  /**
+   * Records the shader-pass chain and presentation into a caller-owned command encoder.
+   * The encoder must belong to this renderer's device and have no active pass. This method does
+   * not finish or submit the encoder.
+   */
+  encodeToScreen(
+    commandEncoder: CommandEncoder,
+    options: ShaderPassRendererRenderOptions
+  ): boolean {
+    const outputTexture = this.encodeToTexture(commandEncoder, options);
     if (!outputTexture) {
       return false;
     }
@@ -157,8 +169,8 @@ export class ShaderPassRenderer {
     // Prepare fullscreen presentation bindings before opening the render pass so WebGPU
     // uploads stay on the parent command encoder rather than the active render pass encoder.
     this.textureModel.setProps({backgroundTexture: outputTexture});
-    this.textureModel.predraw(this.device.commandEncoder);
-    const renderPass = this.device.beginRenderPass({
+    this.textureModel.predraw(commandEncoder);
+    const renderPass = commandEncoder.beginRenderPass({
       id: 'shader-pass-renderer-to-screen',
       framebuffer,
       clearDepth: false
@@ -172,6 +184,21 @@ export class ShaderPassRenderer {
    * @returns null if the the sourceTexture has not yet been loaded
    */
   renderToTexture(options: ShaderPassRendererRenderOptions): Texture | null {
+    return this.encodeToTexture(this.device.commandEncoder, options);
+  }
+
+  /**
+   * Records the shader-pass chain into a caller-owned command encoder.
+   * The encoder must belong to this renderer's device and have no active pass. This method does
+   * not finish or submit the encoder.
+   */
+  encodeToTexture(
+    commandEncoder: CommandEncoder,
+    options: ShaderPassRendererRenderOptions
+  ): Texture | null {
+    if (commandEncoder.device !== this.device) {
+      throw new Error('ShaderPassRenderer command encoder must belong to the renderer device');
+    }
     const {sourceTexture} = options;
     if (sourceTexture instanceof DynamicTexture && !sourceTexture.isReady) {
       return null;
@@ -192,10 +219,10 @@ export class ShaderPassRenderer {
     this.textureModel.setProps({backgroundTexture: originalTexture});
     // The seed draw updates fullscreen bind groups, so it must be prepared before the
     // render pass begins to avoid command-encoder locking errors on WebGPU.
-    this.textureModel.predraw(this.device.commandEncoder);
+    this.textureModel.predraw(commandEncoder);
 
     const sourceFramebuffer = getSeedFramebuffer(this.swapFramebuffers, originalTexture);
-    const seedRenderPass = this.device.beginRenderPass({
+    const seedRenderPass = commandEncoder.beginRenderPass({
       id: 'shader-pass-renderer-seed-source',
       framebuffer: sourceFramebuffer,
       clearColor: [0, 0, 0, 1],
@@ -209,7 +236,7 @@ export class ShaderPassRenderer {
     let frameSucceeded = false;
     try {
       for (const passRenderer of this.passRenderers) {
-        passRenderer.initializeHistoryTargets(originalTexture, this.textureModel);
+        passRenderer.initializeHistoryTargets(originalTexture, this.textureModel, commandEncoder);
         for (const execution of passRenderer.subPassExecutions) {
           const outputName = execution.output || 'previous';
           const outputFramebuffer: Framebuffer =
@@ -235,7 +262,7 @@ export class ShaderPassRenderer {
           );
 
           execution.subPassRenderer.prepare({
-            commandEncoder: this.device.commandEncoder,
+            commandEncoder,
             bindings: resolvedBindings,
             textureScale: calculateTextureScale(
               (resolvedBindings['sourceTexture'] as Texture) || previousTexture,
@@ -243,7 +270,7 @@ export class ShaderPassRenderer {
             ),
             uniforms: resolvedUniforms
           });
-          const renderPass = this.device.beginRenderPass({
+          const renderPass = commandEncoder.beginRenderPass({
             id: 'shader-pass-renderer-run-pass',
             framebuffer: outputFramebuffer,
             clearColor: [0, 0, 0, 1],
@@ -324,7 +351,11 @@ class PassRenderer {
     }
   }
 
-  initializeHistoryTargets(originalTexture: Texture, textureModel: BackgroundTextureModel): void {
+  initializeHistoryTargets(
+    originalTexture: Texture,
+    textureModel: BackgroundTextureModel,
+    commandEncoder: CommandEncoder
+  ): void {
     for (const renderTarget of Object.values(this.renderTargets)) {
       if (renderTarget.spec.lifetime !== 'history' || renderTarget.historyInitialized) {
         continue;
@@ -335,8 +366,8 @@ class PassRenderer {
       };
       if (initialize === 'original') {
         textureModel.setProps({backgroundTexture: originalTexture});
-        textureModel.predraw(this.device.commandEncoder);
-        const renderPass = this.device.beginRenderPass({
+        textureModel.predraw(commandEncoder);
+        const renderPass = commandEncoder.beginRenderPass({
           id: `${renderTarget.name}-initialize-history`,
           framebuffer: historyFramebuffer,
           clearColor: [0, 0, 0, 0],
@@ -345,7 +376,7 @@ class PassRenderer {
         textureModel.draw(renderPass);
         renderPass.end();
       } else {
-        const renderPass = this.device.beginRenderPass({
+        const renderPass = commandEncoder.beginRenderPass({
           id: `${renderTarget.name}-clear-history`,
           framebuffer: historyFramebuffer,
           clearColor: initialize.clearColor,

--- a/modules/engine/test/passes/shader-pass-renderer.spec.ts
+++ b/modules/engine/test/passes/shader-pass-renderer.spec.ts
@@ -778,6 +778,113 @@ test('ShaderPassRenderer calls BackgroundTextureModel.predraw before drawing', a
   t.end();
 });
 
+test('ShaderPassRenderer encodes into a caller-owned command encoder', async t => {
+  const devices = await getTestDevices();
+  const device = devices.find(candidate => candidate.type !== 'webgpu');
+  t.ok(device, 'has a test device');
+
+  if (!device) {
+    t.end();
+    return;
+  }
+
+  const sourceTexture = new DynamicTexture(device, {
+    id: 'explicit-encoder-source-texture',
+    usage: Texture.RENDER | Texture.COPY_SRC | Texture.COPY_DST,
+    dimension: '2d',
+    data: {data: new Uint8Array([255, 0, 0, 255]), width: 1, height: 1, format: 'rgba8unorm'}
+  });
+  await sourceTexture.ready;
+
+  const renderer = new ShaderPassRenderer(device, {
+    shaderPasses: [copyPass],
+    shaderInputs: new ShaderInputs({copy: copyPass})
+  });
+  const foreignDevice = devices.find(candidate => candidate !== device);
+  if (foreignDevice) {
+    const foreignCommandEncoder = foreignDevice.createCommandEncoder({
+      id: 'shader-pass-foreign-encoder'
+    });
+    t.throws(
+      () => renderer.encodeToTexture(foreignCommandEncoder, {sourceTexture}),
+      /must belong to the renderer device/,
+      'rejects a command encoder from another device'
+    );
+    foreignCommandEncoder.destroy();
+  }
+  const commandEncoder = device.createCommandEncoder({id: 'shader-pass-explicit-encoder'});
+  let renderPassCount = 0;
+  const originalBeginRenderPass = commandEncoder.beginRenderPass.bind(commandEncoder);
+  commandEncoder.beginRenderPass = props => {
+    renderPassCount++;
+    return originalBeginRenderPass(props);
+  };
+  const observedEncoders: CommandEncoder[] = [];
+  const originalPredraw = renderer.textureModel.predraw.bind(renderer.textureModel);
+  renderer.textureModel.predraw = observedCommandEncoder => {
+    observedEncoders.push(observedCommandEncoder);
+    originalPredraw(observedCommandEncoder);
+  };
+
+  const rendered = renderer.encodeToScreen(commandEncoder, {sourceTexture});
+
+  t.ok(rendered, 'encodes the pass chain and presentation');
+  t.equal(
+    renderPassCount,
+    3,
+    'opens seed, shader, and presentation passes on the supplied encoder'
+  );
+  t.equal(
+    observedEncoders.filter(observedCommandEncoder => observedCommandEncoder === commandEncoder)
+      .length,
+    2,
+    'prepares source seeding and presentation on the supplied encoder'
+  );
+
+  commandEncoder.destroy();
+  renderer.destroy();
+  sourceTexture.destroy();
+  t.end();
+});
+
+test('ShaderPassRenderer submits caller-owned WebGPU command encoders', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const sourceTexture = new DynamicTexture(device, {
+    id: 'webgpu-explicit-encoder-source-texture',
+    usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_SRC | Texture.COPY_DST,
+    dimension: '2d',
+    data: {data: new Uint8Array([255, 0, 0, 255]), width: 1, height: 1, format: 'rgba8unorm'}
+  });
+  await sourceTexture.ready;
+
+  const renderer = new ShaderPassRenderer(device, {
+    shaderPasses: [invertPass],
+    shaderInputs: new ShaderInputs({invert: invertPass}),
+    colorFormat: 'rgba8unorm'
+  });
+  const commandEncoder = device.createCommandEncoder({id: 'shader-pass-webgpu-explicit-encoder'});
+  const outputTexture = renderer.encodeToTexture(commandEncoder, {sourceTexture});
+  const commandBuffer = commandEncoder.finish();
+  device.submit(commandBuffer);
+
+  t.ok(outputTexture, 'encodes an output texture');
+  t.deepEqual(
+    Array.from(await readPixels(outputTexture!)),
+    [0, 255, 255, 255],
+    'submitted custom encoder produces the expected pixels'
+  );
+
+  renderer.destroy();
+  sourceTexture.destroy();
+  t.end();
+});
+
 test('ShaderPassRenderer prepares each subpass before drawing', async t => {
   const devices = await getTestDevices();
   for (const device of devices) {

--- a/test/examples/lightstorm-megacity.spec.ts
+++ b/test/examples/lightstorm-megacity.spec.ts
@@ -30,8 +30,15 @@ describe('Lightstorm Megacity', () => {
       } as AnimationProps & {lightstormCapacity: number});
       const state = viewer as unknown as {
         resources: {
-          compiled: {stats: {nodeOrder: string[]}};
+          compiled: {
+            stats: {
+              nodeOrder: string[];
+              importedTextureCount: number;
+              logicalTransientTextureCount: number;
+            };
+          };
           drawCommands: {buffer: {readAsync: () => Promise<Uint8Array>}};
+          sceneColor: {format: string};
         };
       };
       const nodeOrder = state.resources.compiled.stats.nodeOrder;
@@ -39,6 +46,10 @@ describe('Lightstorm Megacity', () => {
       expect(
         nodeOrder.some(identifier => identifier.startsWith('visible-city-records-compact'))
       ).toBe(true);
+      expect(nodeOrder).toContain('render-visible-city');
+      expect(state.resources.compiled.stats.importedTextureCount).toBe(1);
+      expect(state.resources.compiled.stats.logicalTransientTextureCount).toBe(1);
+      expect(['rgba8unorm', 'rgba16float']).toContain(state.resources.sceneColor.format);
 
       viewer.onRender({
         device,

--- a/website/content/examples/showcase/lightstorm-megacity.mdx
+++ b/website/content/examples/showcase/lightstorm-megacity.mdx
@@ -17,7 +17,8 @@ Lightstorm Megacity combines a cinematic procedural city with an observable GPU-
 pipeline. Choose 50K, 250K, or one million deterministic source records. Every record stays in GPU
 storage while a command graph filters the selected data layer, tests conservative tower bounds
 against the perspective camera, stably compacts the surviving source IDs, writes the result count
-into an indexed indirect command, and replays a fixed render bundle.
+into an indexed indirect command, and replays a fixed render bundle into a graph-declared HDR
+scene target.
 
 The default guided tour is presentation mode. Disable it or drag to enter free exploration, then
 move the pointer over a tower or transit tile to pick its original source record. The optional
@@ -27,15 +28,18 @@ filtering feed the same compaction and indirect-rendering path.
 
 The live inspector separates source, visible, rejected, nominal, and submitted work. The million
 record setting therefore means one million candidate records, not one million objects rendered in
-every frame. It also reports CPU graph-encoding time, total frame timing, transient-buffer reuse,
+every frame. It also reports CPU command-encoding time, total frame timing, transient-buffer reuse,
 and the command graph's node order. Picking is issued only after pointer movement in exploration
 mode so it does not silently tax the cinematic benchmark.
 
 The city renderer synthesizes facade windows, roof beacons, transit lanes, fog, and a traveling
-light wave in one forward WGSL pass. On a compatible WebGPU display it presents restrained
-extended-luminance highlights through a `rgba16float`, Display P3 canvas; otherwise the shader uses
-an SDR tone-mapping path. Render and picking transforms share the same non-uniform tower records,
-while compute culling uses their conservative bounding spheres.
+light wave in one forward WGSL pass. That pass preserves linear scene radiance in a filterable
+`rgba16float` target when supported. A reusable `ShaderPassRenderer` then records a half-, quarter-,
+and eighth-resolution bloom pyramid plus ACES filmic tone mapping onto the same caller-owned command
+encoder before the frame is submitted. On a compatible WebGPU display the final pass preserves
+restrained extended-luminance highlights through a Display P3 canvas; other displays receive filmic
+SDR. Render and picking transforms share the same non-uniform tower records, while compute culling
+uses their conservative bounding spheres.
 
 This first version deliberately demonstrates scalable instance processing rather than virtual
 geometry. It uses one cube mesh and does not claim meshlet LOD, occlusion culling, geometry

--- a/yarn.lock
+++ b/yarn.lock
@@ -16882,6 +16882,7 @@ __metadata:
   dependencies:
     "@deck.gl-community/panels": "https://github.com/visgl/deck.gl-community.git#workspace=@deck.gl-community/panels&commit=ede78777382aaf1c821a9c427cdb48eb4e77e20e"
     "@luma.gl/core": "npm:9.4.0-alpha.2"
+    "@luma.gl/effects": "npm:9.4.0-alpha.2"
     "@luma.gl/engine": "npm:9.4.0-alpha.2"
     "@luma.gl/experimental": "npm:9.4.0-alpha.2"
     "@luma.gl/shadertools": "npm:9.4.0-alpha.2"


### PR DESCRIPTION
## Summary

- add caller-owned command-encoder APIs to `ShaderPassRenderer` while preserving the existing convenience wrappers
- render Lightstorm Megacity into a graph-declared HDR scene target
- record multiscale bloom and ACES tone mapping onto the same WebGPU command encoder before submission
- document the composition contract and cover it with foreign-device validation, command-routing assertions, and WebGPU pixel readback

## Why

Lightstorm should demonstrate both cinematic rendering and explicit WebGPU composition. Keeping the post stack on the caller-owned encoder preserves a single frame submission without hiding the multi-pass work inside the command graph's copy abstraction.

## Validation

- `nvm use` — Node v22.22.1
- `yarn install`
- `yarn lint fix`
- `yarn build`
- `CI=1 yarn test` — 254 Node tests passed, 2 skipped; 1,337 headless tests passed, 25 skipped
- `yarn examples:typecheck`
- `yarn workspace luma.gl-examples-showcase-lightstorm-megacity build`
- `yarn website:build`
- `(cd website && yarn build)`
- manual browser visual QA of the Lightstorm example

## Notes

A non-CI hardware run still reproduces an unrelated Arrow storage-polygon assertion; its isolated CI/SwiftShader run passes.