### PR TITLE
feat(experimental): add GPU region picking and readback ring

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -58,7 +58,8 @@ later render pass consume that count without a CPU synchronization point.
 The implementation consists of `GPUCommandGraph`, typed graph data views, `GPUScan`,
 `GPUCompaction`, `GPUMask`, `GPUVisibilityWorkflow`, `GPUHierarchyLayout`, `GPUGraphTraversal`,
 `GPUAncestorProjection`, `GPUSort`, `GPUBatchSort`, `GPUReduction`, `GPUHistogram`, `GPUGridBinning`,
-`GPUGridAggregation`, `GPUGroupAggregation`, and `DrawCommandBuffer`. The accompanying hierarchical trace viewer applies these primitives to
+`GPUGridAggregation`, `GPUGroupAggregation`, `GPUIndexPickingTarget`, `GPUReadbackRing`, and
+`DrawCommandBuffer`. The accompanying hierarchical trace viewer applies these primitives to
 process and thread collapse, source and topology filtering, dependency focusing, visible-parent
 projection, GPU picking, activity histograms, and indirect span and edge rendering over up to
 four million spans. The sort and data-analysis examples demonstrate independent composable

--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1006,7 +1006,7 @@ schedule commitment.
 | 1 — Hardening and observability | GPU timestamps, performance baselines, adapter capability reporting, boundary and overflow validation, memory statistics, and device-loss and resource-lifetime coverage | Implemented | High | Medium |
 | 2 — Reusable visibility workflows | Renderer-independent time-range, bounds, LOD, and selection workflows that publish stable IDs, counts, and indirect commands | Implemented | High | Medium |
 | 3 — Algorithm and table scaling | Multi-chunk coverage, segmented and inclusive scans, weighted statistics, richer histograms, and batch-preserving algorithms | Implemented | High | Large |
-| 4 — Picking and texture coverage | Region picking, asynchronous staging rings, multisample resolves, swapchain imports, and external-texture contracts | Planned | Medium | Large |
+| 4 — Picking and texture coverage | Region picking and asynchronous staging rings implemented; multisample resolves, swapchain imports, and external-texture contracts remain | In progress | Medium | Large |
 | 5 — Spatial acceleration | `GPUGridIndex` followed by `GPUBVH`, with explicit build, update, and query costs | Planned | High | Large |
 | 6 — GPUScene | A flat GPU draw database with stable identity, bounds, transforms, grouping, geometry references, and indirect command slots | Planned | High | Large |
 | 7 — API graduation | Stable package contracts, compatibility exports, and a dependency-safe move out of experimental packages | Planned | High | Large |
@@ -1018,14 +1018,15 @@ only when its entry dependency is present and its exit evidence can be produced;
 dependency order, not a schedule commitment. Tranches whose dependencies do not overlap may be
 developed independently.
 
-Tranches 3.2 and 3.3 are implemented; Phase 4 is the next active boundary.
+Tranches 4.1 and 4.2 are implemented; render-target contracts in Tranche 4.3 are the next active
+boundary.
 
 | Tranche | Outcome | Entry dependency | Impact | Complexity/cost |
 | --- | --- | --- | :---: | :---: |
 | 3.2 — Partitioned topology | Explicit global-ID and chunk-base contracts for hierarchy and CSR topology without hidden packing | Implemented Phase 3 data primitives | High | Large |
 | 3.3 — Extension decision gate | Evidence-backed decision on sparse histograms, multidimensional histograms, custom scans, and shader callbacks | Tranche 3.2 plus demonstrated consumers | Medium | Medium |
-| 4.1 — Region picking | Bounded rectangular picks with stable object and batch IDs, capacity, count, and overflow | Phase 2 stable identity | Medium | Medium |
-| 4.2 — Asynchronous readback ring | Reusable staging slots with backpressure, cancellation, and no mapped-buffer reuse hazards | Tranche 4.1 | High | Medium |
+| 4.1 — Region picking | Bounded rectangular picks with stable object and batch IDs, capacity, count, and overflow | Implemented | Medium | Medium |
+| 4.2 — Asynchronous readback ring | Reusable staging slots with backpressure, cancellation, and no mapped-buffer reuse hazards | Implemented | High | Medium |
 | 4.3 — Render-target graph contracts | Multisample resolve and swapchain imports with explicit subresource and frame ownership | Phase 1 lifetime contracts | Medium | Large |
 | 4.4 — External-texture contracts | One-frame external-texture imports with validated access and device-loss behavior | Tranche 4.3 | Medium | Large |
 | 5.1 — `GPUGridIndex` build/update | Stable cell offsets and object-ID storage with measurable full-build and incremental-update costs | Tranche 3.2 and Phase 1 measurement | High | Large |
@@ -1051,7 +1052,8 @@ inclusive, and segmented scans; stable compaction; chunk-preserving boolean mask
 traversal; nearest-visible parent projection; paired sort; scalar reduction; histogram counting;
 spatial grid binning; and GPU-written indirect commands.
 
-`GPUIndexPickingTarget` provides single-pixel integer object and batch picking. The hierarchical
+`GPUIndexPickingTarget` provides single-pixel and bounded-region integer object and batch picking;
+`GPUReadbackRing` overlaps reusable staging slots without mapped-buffer reuse. The hierarchical
 trace viewer adds GPU-scanned process/thread layout, source and topology filtering, dependency
 focus, click picking, collapsed activity, projected edges, and stable indirect span and edge groups.
 The frustum-culling and GPU data-analysis examples provide two additional consumers.
@@ -1214,17 +1216,18 @@ application or renderer consumer.
 **Entry dependencies:** Phase 1 defines resource-lifetime and asynchronous readback behavior;
 Phase 2 defines stable visible identity.
 
-Expand picking from one pixel to bounded regions and add reusable staging-buffer rings for
-asynchronous results. Add graph contracts for multisampled resolve targets, swapchain imports, and
-external textures so their subresources, hazards, ownership, and frame lifetimes are explicit.
+Region picking and reusable asynchronous staging-buffer rings are implemented. Next, add graph
+contracts for multisampled resolve targets, swapchain imports, and external textures so their
+subresources, hazards, ownership, and frame lifetimes are explicit.
 Callback, highlighting, tooltip, and color-encoded fallback policies remain higher-level workflow
 or application concerns.
 
 #### Tranche 4.1 — Region picking
 
-Add bounded rectangular picking that publishes object IDs, batch IDs, a result count, and an
-overflow flag into caller-sized GPU storage. Define ordering and duplicate handling explicitly;
-selection semantics such as nearest-only, toggling, or highlighting stay above the primitive.
+`GPUIndexPickingTarget.addRegionPass()` publishes object IDs, batch IDs, a total result count, and
+an overflow flag into caller-sized GPU storage. One covered pixel produces one pair, duplicates are
+preserved, and atomic append order is unspecified. Selection semantics such as nearest-only,
+toggling, deduplication, or highlighting stay above the primitive.
 
 **Exit evidence:** Tests cover empty regions, overlapping primitives, duplicate IDs, exact capacity,
 and overflow. An example uses stable IDs from `GPUVisibilityWorkflow` without a CPU-side identity
@@ -1232,9 +1235,9 @@ translation.
 
 #### Tranche 4.2 — Asynchronous readback ring
 
-Add a reusable staging-buffer ring whose tickets make availability, backpressure, cancellation,
-and device loss observable. The ring owns staging allocations but neither submits command buffers
-nor silently waits for a mapped slot.
+`GPUReadbackRing` provides reusable staging tickets with immediate and waiting acquisition paths,
+explicit cancellation, safe mapped-buffer reuse, destruction, and device-loss propagation. It owns
+staging allocations but neither submits command buffers nor silently waits for a mapped slot.
 
 **Exit evidence:** Repeated region picks can overlap rendering and readback without reusing a
 mapped buffer or serializing every frame. Tests cover ring exhaustion, out-of-order completion,
@@ -1458,6 +1461,7 @@ close enough to WebGPU that developers can reason about cost, ordering, and owne
 - [`GPUGridAggregation`](/docs/api-reference/experimental/gpu-primitives/gpu-grid-aggregation)
 - [`GPUGroupAggregation`](/docs/api-reference/experimental/gpu-primitives/gpu-group-aggregation)
 - [`GPUIndexPickingTarget`](/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target)
+- [`GPUReadbackRing`](/docs/api-reference/experimental/gpu-primitives/gpu-readback-ring)
 - [`DrawCommandBuffer`](/docs/api-reference/experimental/gpu-primitives/draw-command-buffer)
 - [GPU commands](/docs/api-guide/gpu/gpu-commands)
 - [GPU tables](/docs/api-guide/gpu/gpu-tables)

--- a/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target.md
@@ -6,9 +6,9 @@ import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-do
 
 ## Overview
 
-`GPUIndexPickingTarget` declares fixed-size WebGPU attachments for integer object picking and adds
-an explicit single-pixel texture-to-buffer copy. It does not render, submit, map buffers, manage
-highlight state, or own application UI.
+`GPUIndexPickingTarget` declares fixed-size WebGPU attachments for integer object picking. It can
+copy one pixel or reduce a rectangular region into capacity-bounded GPU storage. It does not
+render, submit, map buffers, choose selection semantics, manage highlight state, or own UI.
 
 ## Concepts
 
@@ -16,6 +16,11 @@ GPU picking renders stable object identity into an integer attachment alongside 
 depth. Copying one device pixel to a mapped staging buffer reveals the front-most object and batch
 at that coordinate. Keeping identity separate from display color avoids color-space ambiguity and
 lets the same source IDs flow through visibility, rendering, and interaction.
+
+A single pixel answers “what is under the pointer?” A region answers “which rendered fragments are
+inside this brush or lasso bound?” on the GPU, without transferring the full picking attachment.
+This matters when a selection covers thousands of pixels but the application needs only stable
+identities and an honest indication that its chosen result capacity was too small.
 
 ```ts
 const target = new GPUIndexPickingTarget(graph, {
@@ -53,5 +58,38 @@ concurrent requests without writing a mapped staging buffer.
 Coordinates are integer WebGPU device pixels with a top-left origin. The helper validates them
 against its compiled extent. Recreate and recompile the target after a canvas resize.
 
-The helper intentionally handles one pixel. Region reduction, color fallback, automatic staging
-rings, submission, callbacks, highlighting, and tooltips remain application policy.
+Color fallback, submission, callbacks, highlighting, tooltips, and region selection semantics
+remain application policy. Staging reuse is available separately through `GPUReadbackRing`.
+
+### Region results
+
+`addRegionPass()` reads a GPU-resident `[x, y, width, height]` rectangle and writes a packed result:
+
+| Word | Meaning |
+| --- | --- |
+| 0 | Total non-background pixel count |
+| 1 | Overflow flag (`0` or `1`) |
+| 2… | Signed object/batch index pairs |
+
+```ts
+target.addRegionPass({
+  after: 'render-picking',
+  region,
+  result
+});
+```
+
+The pair capacity is `floor((result.length - 2) / 2)`. Counting continues after capacity is
+reached, so `decodeGPUIndexPickRegion()` reports both the total count and whether the stored prefix
+was truncated. Rectangle coordinates are clipped to the target extent; zero width or height
+produces an empty result.
+
+One covered pixel produces one pair. Duplicates are deliberately preserved because pixel
+frequency can represent coverage, while deduplication would impose a particular selection policy
+and extra storage cost. Atomic append order is unspecified. Callers that need unique IDs, nearest
+objects, coverage ranking, toggle behavior, or deterministic ordering should compose those rules
+above this primitive.
+
+Use [`GPUReadbackRing`](/docs/api-reference/experimental/gpu-primitives/gpu-readback-ring) to move
+the small packed result to the CPU without allocating or remapping the same staging buffer every
+frame.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target.md
@@ -22,6 +22,20 @@ inside this brush or lasso bound?” on the GPU, without transferring the full p
 This matters when a selection covers thousands of pixels but the application needs only stable
 identities and an honest indication that its chosen result capacity was too small.
 
+### Choosing a picking path
+
+Use single-pixel picking for hover, click, tooltip, and context-menu interactions where only the
+front-most fragment at one device coordinate matters. Use region picking for rectangle selection,
+the bounding box of a lasso, coverage sampling, or other interactions where transferring the full
+attachment would dominate the useful result. A `GPUReadbackRing` keeps either small result from
+serializing later frames.
+
+The region result preserves one entry per covered pixel, not one entry per object. That is useful
+for coverage ranking and lets applications choose their own deduplication policy, but its required
+capacity grows with selected screen area. Use a spatial index or application-specific selection
+kernel when selection semantics are based on world-space bounds, occluded objects, nearest distance,
+or unique object identity rather than rendered fragments.
+
 ```ts
 const target = new GPUIndexPickingTarget(graph, {
   id: 'objects',
@@ -79,7 +93,9 @@ target.addRegionPass({
 });
 ```
 
-The pair capacity is `floor((result.length - 2) / 2)`. Counting continues after capacity is
+The pair capacity is `floor((result.length - 2) / 2)`. A valid object may use batch index `-1` to
+represent no batch; `decodeGPUIndexPickRegion()` maps that sentinel to `null`, matching single-pixel
+picking. Counting continues after capacity is
 reached, so `decodeGPUIndexPickRegion()` reports both the total count and whether the stored prefix
 was truncated. Rectangle coordinates are clipped to the target extent; zero width or height
 produces an empty result.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-readback-ring.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-readback-ring.md
@@ -1,0 +1,75 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
+# GPUReadbackRing
+
+<GPUPrimitivesDocsTabs active="readback-ring" />
+
+## Overview
+
+`GPUReadbackRing` reuses a fixed number of `COPY_DST | MAP_READ` staging buffers for asynchronous
+GPU results. Each `GPUReadbackTicket` owns one slot from reservation through mapping, preventing an
+in-flight or mapped buffer from being overwritten by a later frame.
+
+Readback is useful but easy to accidentally serialize: allocating every frame adds churn, while
+reusing one buffer forces the renderer to wait for mapping before encoding the next result. A small
+ring lets rendering continue while older picks, counters, timestamps, or analysis summaries cross
+the GPU/CPU boundary.
+
+## Concepts
+
+The ring separates three responsibilities:
+
+1. The ring owns staging allocations and slot availability.
+2. A ticket records or represents one copy and owns that slot until mapping settles.
+3. The application owns command submission and decides whether pressure means drop or wait.
+
+```ts
+const ring = new GPUReadbackRing(device, {
+  byteLength: resultBuffer.byteLength,
+  slotCount: 3
+});
+
+const ticket = ring.tryAcquire();
+if (ticket) {
+  ticket.copyFrom(commandEncoder, resultBuffer);
+  device.submit(commandEncoder.finish());
+  const bytes = await ticket.read();
+}
+```
+
+`tryAcquire()` returns `null` when all slots are busy, making frame-dropping backpressure explicit.
+`acquire()` instead returns a promise for the next completed slot; call it before constructing work
+whose encoder must remain current. Neither method submits commands or silently blocks encoding.
+
+### Command graphs and texture copies
+
+A graph can import `ticket.buffer` as a per-encoding buffer override. After the graph records its
+copy, call `markEncoded()` so the ticket can enforce its lifecycle:
+
+```ts
+const ticket = ring.tryAcquire();
+if (ticket) {
+  compiled.encode(commandEncoder, {
+    parameters,
+    buffers: {[readbackHandle.id]: ticket.buffer}
+  });
+  ticket.markEncoded({byteLength: 8});
+  device.submit(commandEncoder.finish());
+  const pick = decodeGPUIndexPickInfo(await ticket.read());
+}
+```
+
+### Backpressure, cancellation, and loss
+
+An unused reservation can be cancelled immediately. Once a copy is encoded, its destination cannot
+be reused safely until GPU work and mapping finish. Start `read()` before cancelling an encoded
+ticket; cancellation then discards the value while the internal completion path releases the slot.
+
+Mapping failures, including device loss, release active tickets before propagating the error.
+Destroying the ring rejects queued waiters and destroys idle buffers immediately; active buffers
+are destroyed when their ticket settles. This keeps resource lifetime observable without allowing
+use-after-map or use-after-destroy shortcuts.
+
+`availableSlotCount` exposes current immediate capacity. It is intentionally a scheduling signal,
+not a completion callback: applications still decide how frequently to request results and whether
+stale interaction data should be discarded.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-readback-ring.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-readback-ring.md
@@ -23,6 +23,15 @@ The ring separates three responsibilities:
 2. A ticket records or represents one copy and owns that slot until mapping settles.
 3. The application owns command submission and decides whether pressure means drop or wait.
 
+Use a ring for small answers that the CPU genuinely needs: hover picks, selection summaries,
+timestamps, validation counters, exported analysis values, or occasional screenshots copied through
+a bounded staging path. Interactive results often prefer `tryAcquire()` and dropping stale work;
+exports and diagnostics commonly prefer `acquire()` and waiting for capacity.
+
+Do not read back data merely to feed the next GPU pass—keep that dependency in a command graph
+instead. A ring hides neither transfer latency nor bandwidth: it makes several in-flight transfers
+safe and makes overload policy explicit.
+
 ```ts
 const ring = new GPUReadbackRing(device, {
   byteLength: resultBuffer.byteLength,

--- a/examples/experimental/gpu-frustum-culling/app.ts
+++ b/examples/experimental/gpu-frustum-culling/app.ts
@@ -10,9 +10,11 @@ import {
   DrawCommandBuffer,
   GPUCommandGraph,
   GPUIndexPickingTarget,
+  GPUReadbackRing,
   GPUVisibilityWorkflow,
   INDEX_PICKING_READBACK_BYTE_LENGTH,
-  type CompiledGPUCommandGraph
+  type CompiledGPUCommandGraph,
+  type GPUReadbackTicket
 } from '@luma.gl/experimental';
 import {Matrix4} from '@math.gl/core';
 import {ColumnPanel, type Panel} from '@deck.gl-community/panels';
@@ -75,6 +77,7 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
   readonly pickingModel: Model;
   readonly uniformBuffer: Buffer;
   readonly overviewUniformBuffer: Buffer;
+  readonly pickingReadbackRing: GPUReadbackRing;
   readonly panels: ExamplePanelManager;
 
   private resources: CullingGraphResources | null = null;
@@ -90,7 +93,6 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
   private sampledVisibleCount = 0;
   private countReadPending = false;
   private pickedObjectIndex: number | null = null;
-  private pickReadPendingCount = 0;
   private frameIndex = 0;
   private encodeTimeMilliseconds = 0;
   private compileTimeMilliseconds = 0;
@@ -121,6 +123,11 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
       id: 'gpu-frustum-culling-overview-uniforms',
       byteLength: UNIFORM_BYTE_LENGTH,
       usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    this.pickingReadbackRing = new GPUReadbackRing(device, {
+      id: 'gpu-frustum-culling-pick-readback',
+      byteLength: INDEX_PICKING_READBACK_BYTE_LENGTH,
+      slotCount: 2
     });
     this.model = new Model(device, {
       id: 'gpu-frustum-culling-model',
@@ -212,19 +219,17 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
     this.writeUniforms(viewports);
     const encodeStart = performance.now();
     resources.compiled.encode(device.commandEncoder, {parameters: viewports});
-    if (_mousePosition && this.frameIndex % 4 === 0 && this.pickReadPendingCount < 2) {
-      const pixel = this.getPickingPixel(_mousePosition as [number, number], resources);
-      const readbackBuffer = device.createBuffer({
-        id: `gpu-frustum-culling-pick-${this.frameIndex}`,
-        byteLength: INDEX_PICKING_READBACK_BYTE_LENGTH,
-        usage: Buffer.COPY_DST | Buffer.MAP_READ
-      });
-      resources.pickingCompiled.encode(device.commandEncoder, {
-        parameters: {perspectiveViewport: viewports.perspectiveViewport, pixel},
-        buffers: {[resources.pickingReadbackId]: readbackBuffer}
-      });
-      this.pickReadPendingCount++;
-      queueMicrotask(() => void this.readPickingResult(readbackBuffer));
+    if (_mousePosition && this.frameIndex % 4 === 0) {
+      const readbackTicket = this.pickingReadbackRing.tryAcquire();
+      if (readbackTicket) {
+        const pixel = this.getPickingPixel(_mousePosition as [number, number], resources);
+        resources.pickingCompiled.encode(device.commandEncoder, {
+          parameters: {perspectiveViewport: viewports.perspectiveViewport, pixel},
+          buffers: {[resources.pickingReadbackId]: readbackTicket.buffer}
+        });
+        readbackTicket.markEncoded({byteLength: 8});
+        queueMicrotask(() => void this.readPickingResult(readbackTicket));
+      }
     }
     this.encodeTimeMilliseconds = performance.now() - encodeStart;
     this.framesPerSecond = animationLoop.frameRate.getSampleHz();
@@ -249,6 +254,7 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
     }
     this.panels.finalize();
     this.destroyResources();
+    this.pickingReadbackRing.destroy();
     this.pickingModel.destroy();
     this.model.destroy();
     this.uniformBuffer.destroy();
@@ -668,14 +674,13 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
     ];
   }
 
-  private async readPickingResult(readbackBuffer: Buffer): Promise<void> {
+  private async readPickingResult(readbackTicket: GPUReadbackTicket): Promise<void> {
     try {
-      const bytes = await readbackBuffer.readAsync(0, 8);
+      const bytes = await readbackTicket.read();
       this.pickedObjectIndex = decodeGPUIndexPickInfo(bytes).objectIndex;
       this.updateInspector();
-    } finally {
-      readbackBuffer.destroy();
-      this.pickReadPendingCount--;
+    } catch {
+      // Device loss and cancellation release the ring slot without updating interaction state.
     }
   }
 

--- a/modules/experimental/src/gpu-primitives/gpu-index-picking-target.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-index-picking-target.ts
@@ -283,7 +283,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let pixel = origin + globalId.xy;
   if (any(pixel >= TARGET_SIZE)) { return; }
   let pick = textureLoad(indices, vec2<i32>(pixel), 0).xy;
-  if (pick.x == ${INDEX_PICKING_INVALID_INDEX} || pick.y == ${INDEX_PICKING_INVALID_INDEX}) { return; }
+  if (pick.x == ${INDEX_PICKING_INVALID_INDEX}) { return; }
   let outputIndex = atomicAdd(&result[RESULT_OFFSET], 1u);
   if (outputIndex < RESULT_CAPACITY) {
     let pairOffset = RESULT_OFFSET + 2u + outputIndex * 2u;
@@ -374,9 +374,10 @@ export function decodeGPUIndexPickRegion(
   const picks: PickInfo[] = [];
   for (let index = 0; index < storedCount; index++) {
     const pairByteOffset = (2 + index * 2) * Uint32Array.BYTES_PER_ELEMENT;
+    const batchIndex = view.getInt32(pairByteOffset + Int32Array.BYTES_PER_ELEMENT, true);
     picks.push({
       objectIndex: view.getInt32(pairByteOffset, true),
-      batchIndex: view.getInt32(pairByteOffset + Int32Array.BYTES_PER_ELEMENT, true)
+      batchIndex: batchIndex === INDEX_PICKING_INVALID_INDEX ? null : batchIndex
     });
   }
   return {picks, count, overflow};

--- a/modules/experimental/src/gpu-primitives/gpu-index-picking-target.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-index-picking-target.ts
@@ -2,15 +2,21 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, Texture} from '@luma.gl/core';
-import type {RenderPassProps} from '@luma.gl/core';
+import {Buffer, Texture, type Binding, type RenderPassProps} from '@luma.gl/core';
 import type {PickInfo} from '@luma.gl/engine';
+import {Computation} from '@luma.gl/engine';
 import {
   GPUCommandGraph,
   type GraphBufferHandle,
+  type GraphDataView,
   type GraphRenderPassAttachments,
   type GraphTextureView
 } from './gpu-command-graph';
+import {
+  getViewBinding,
+  getViewElementOffset,
+  validatePackedUint32View
+} from './graph-data-view-utils';
 
 /** WebGPU-aligned byte capacity required by the single-pixel picking readback buffer. */
 export const INDEX_PICKING_READBACK_BYTE_LENGTH = 256;
@@ -38,6 +44,31 @@ export type GPUIndexPickingReadbackProps<Parameters> = {
   getPixel: (parameters: Parameters) => readonly [number, number];
 };
 
+/** Properties for one capacity-bounded rectangular picking reduction. */
+export type GPUIndexPickingRegionProps = {
+  /** Compute node ID. Defaults to the target ID plus `-region`. */
+  id?: string;
+  /** Render node that must complete before the index texture is inspected. */
+  after: string;
+  /** Packed `[x, y, width, height]` device-pixel rectangle, updated on the GPU or CPU. */
+  region: GraphDataView<'uint32'>;
+  /**
+   * Packed result words: total count, overflow flag, then object/batch index pairs.
+   * The pair capacity is `floor((result.length - 2) / 2)`.
+   */
+  result: GraphDataView<'uint32'>;
+};
+
+/** Decoded capacity-bounded result from {@link GPUIndexPickingTarget.addRegionPass}. */
+export type GPUIndexPickingRegionResult = {
+  /** Stored picks. Duplicate covered pixels are intentionally preserved. */
+  picks: PickInfo[];
+  /** Total number of non-background pixels, including values beyond result capacity. */
+  count: number;
+  /** Whether `count` exceeded the number of stored pairs. */
+  overflow: boolean;
+};
+
 /**
  * Fixed-size graph texture target for WebGPU integer object picking.
  *
@@ -61,14 +92,14 @@ export class GPUIndexPickingTarget<Parameters = void> {
   readonly attachments: GraphRenderPassAttachments;
   /** Clear values matching the color, index, and depth attachments. */
   readonly renderPassProps: Pick<RenderPassProps, 'clearColors' | 'clearDepth'>;
-  /** Borrowed logical handle for the caller-owned readback buffer. */
-  readonly readback: GraphBufferHandle;
-
   private readonly graph: GPUCommandGraph<Parameters>;
+  private readbackHandle: GraphBufferHandle | null = null;
   private readbackPassAdded = false;
+  private regionPassAdded = false;
 
   /**
-   * Declares fixed-size transient attachments and one imported readback buffer in `graph`.
+   * Declares fixed-size transient attachments. A supplied readback buffer is imported immediately;
+   * otherwise the logical readback import is created only by `addReadbackPass()`.
    *
    * @throws If width or height is not a positive safe integer.
    */
@@ -91,7 +122,7 @@ export class GPUIndexPickingTarget<Parameters = void> {
       format: 'rg32sint',
       width: this.width,
       height: this.height,
-      usage: Texture.RENDER | Texture.COPY_SRC
+      usage: Texture.RENDER | Texture.COPY_SRC | Texture.SAMPLE
     });
     const depthStencilTexture = graph.createTransientTexture({
       id: `${this.id}-depth`,
@@ -115,14 +146,17 @@ export class GPUIndexPickingTarget<Parameters = void> {
       ],
       clearDepth: 1
     };
-    this.readback = graph.importBuffer(
-      {
-        id: `${this.id}-readback`,
-        byteLength: INDEX_PICKING_READBACK_BYTE_LENGTH,
-        usage: Buffer.COPY_DST | Buffer.MAP_READ
-      },
-      props.readbackBuffer
-    );
+    if (props.readbackBuffer) {
+      this.readbackHandle = this.createReadbackHandle(props.readbackBuffer);
+    }
+  }
+
+  /** Borrowed logical handle for the caller-owned single-pixel readback buffer. */
+  get readback(): GraphBufferHandle {
+    if (!this.readbackHandle) {
+      throw new Error('GPU index picking readback pass has not been added');
+    }
+    return this.readbackHandle;
   }
 
   /**
@@ -136,12 +170,14 @@ export class GPUIndexPickingTarget<Parameters = void> {
       throw new Error(`${this.id} readback pass has already been added`);
     }
     this.readbackPassAdded = true;
+    this.readbackHandle ??= this.createReadbackHandle();
+    const readback = this.readbackHandle;
     this.graph.addCopyPass({
       id: props.id ?? `${this.id}-readback`,
       dependsOn: [props.after],
       resources: [
         {texture: this.indexAttachment, usage: 'copy-source'},
-        {buffer: this.readback, usage: 'copy-destination'}
+        {buffer: readback, usage: 'copy-destination'}
       ],
       compile: () => ({
         encode: ({commandEncoder, parameters, getBuffer, getTexture}) => {
@@ -154,7 +190,7 @@ export class GPUIndexPickingTarget<Parameters = void> {
             width: 1,
             height: 1,
             depthOrArrayLayers: 1,
-            destinationBuffer: getBuffer(this.readback),
+            destinationBuffer: getBuffer(readback),
             byteOffset: 0,
             bytesPerRow: INDEX_PICKING_READBACK_BYTE_LENGTH,
             rowsPerImage: 1
@@ -162,6 +198,138 @@ export class GPUIndexPickingTarget<Parameters = void> {
         }
       })
     });
+  }
+
+  /**
+   * Adds one rectangular GPU reduction after the picking render node.
+   *
+   * Every non-background pixel appends its stable object/batch pair. Duplicate pixels are
+   * preserved and atomic append order is unspecified. The total count continues past capacity and
+   * sets the overflow word, allowing callers to resize or deliberately accept truncation.
+   */
+  addRegionPass(props: GPUIndexPickingRegionProps): void {
+    if (this.regionPassAdded) {
+      throw new Error(`${this.id} region pass has already been added`);
+    }
+    validatePackedUint32View(props.region, 'GPU index picking region');
+    validatePackedUint32View(props.result, 'GPU index picking region result');
+    if (props.region.length < 4) {
+      throw new Error('GPU index picking region requires four uint32 values');
+    }
+    if (props.result.length < 4) {
+      throw new Error('GPU index picking region result requires a header and at least one pair');
+    }
+    if (props.region.buffer === props.result.buffer) {
+      throw new Error('GPU index picking region and result require separate buffers');
+    }
+    this.regionPassAdded = true;
+    const id = props.id ?? `${this.id}-region`;
+    const clearId = `${id}-clear`;
+    const resultOffset = getViewElementOffset(props.result);
+    const regionOffset = getViewElementOffset(props.region);
+    const capacity = Math.floor((props.result.length - 2) / 2);
+
+    this.graph.addComputePass({
+      id: clearId,
+      resources: [{buffer: props.result, usage: 'storage-write'}],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: clearId,
+          source: `const RESULT_OFFSET: u32 = ${resultOffset}u;
+@group(0) @binding(0) var<storage, read_write> result: array<atomic<u32>>;
+@compute @workgroup_size(1) fn main() {
+  atomicStore(&result[RESULT_OFFSET], 0u);
+  atomicStore(&result[RESULT_OFFSET + 1u], 0u);
+}`,
+          shaderLayout: {
+            bindings: [{name: 'result', type: 'storage', group: 0, location: 0}]
+          }
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({result: getViewBinding(props.result, getBuffer)});
+            computation.dispatch(computePass, 1);
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+
+    this.graph.addComputePass({
+      id,
+      dependsOn: [props.after, clearId],
+      resources: [
+        {texture: this.indexAttachment, usage: 'sampled'},
+        {buffer: props.region, usage: 'storage-read'},
+        {buffer: props.result, usage: 'storage-read-write'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id,
+          source: `const REGION_OFFSET: u32 = ${regionOffset}u;
+const RESULT_OFFSET: u32 = ${resultOffset}u;
+const RESULT_CAPACITY: u32 = ${capacity}u;
+const TARGET_SIZE: vec2<u32> = vec2<u32>(${this.width}u, ${this.height}u);
+@group(0) @binding(0) var indices: texture_2d<i32>;
+@group(0) @binding(1) var<storage, read> region: array<u32>;
+@group(0) @binding(2) var<storage, read_write> result: array<atomic<u32>>;
+
+@compute @workgroup_size(8, 8)
+fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let extent = vec2<u32>(region[REGION_OFFSET + 2u], region[REGION_OFFSET + 3u]);
+  if (any(globalId.xy >= extent)) { return; }
+  let origin = vec2<u32>(region[REGION_OFFSET], region[REGION_OFFSET + 1u]);
+  if (any(origin >= TARGET_SIZE)) { return; }
+  let pixel = origin + globalId.xy;
+  if (any(pixel >= TARGET_SIZE)) { return; }
+  let pick = textureLoad(indices, vec2<i32>(pixel), 0).xy;
+  if (pick.x == ${INDEX_PICKING_INVALID_INDEX} || pick.y == ${INDEX_PICKING_INVALID_INDEX}) { return; }
+  let outputIndex = atomicAdd(&result[RESULT_OFFSET], 1u);
+  if (outputIndex < RESULT_CAPACITY) {
+    let pairOffset = RESULT_OFFSET + 2u + outputIndex * 2u;
+    atomicStore(&result[pairOffset], bitcast<u32>(pick.x));
+    atomicStore(&result[pairOffset + 1u], bitcast<u32>(pick.y));
+  } else {
+    atomicStore(&result[RESULT_OFFSET + 1u], 1u);
+  }
+}`,
+          shaderLayout: {
+            bindings: [
+              {name: 'indices', type: 'texture', group: 0, location: 0, sampleType: 'sint'},
+              {name: 'region', type: 'storage', group: 0, location: 1},
+              {name: 'result', type: 'storage', group: 0, location: 2}
+            ]
+          }
+        });
+        return {
+          encode: ({computePass, getBuffer, getTextureView}) => {
+            const bindings: Record<string, Binding> = {
+              indices: getTextureView(this.indexAttachment),
+              region: getViewBinding(props.region, getBuffer),
+              result: getViewBinding(props.result, getBuffer)
+            };
+            computation.setBindings(bindings);
+            computation.dispatch(
+              computePass,
+              Math.ceil(this.width / 8),
+              Math.ceil(this.height / 8)
+            );
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+
+  private createReadbackHandle(readbackBuffer?: Buffer): GraphBufferHandle {
+    return this.graph.importBuffer(
+      {
+        id: `${this.id}-readback`,
+        byteLength: INDEX_PICKING_READBACK_BYTE_LENGTH,
+        usage: Buffer.COPY_DST | Buffer.MAP_READ
+      },
+      readbackBuffer
+    );
   }
 }
 
@@ -184,6 +352,34 @@ export function decodeGPUIndexPickInfo(data: ArrayBuffer | ArrayBufferView): Pic
     objectIndex: objectIndex === INDEX_PICKING_INVALID_INDEX ? null : objectIndex,
     batchIndex: batchIndex === INDEX_PICKING_INVALID_INDEX ? null : batchIndex
   };
+}
+
+/** Decodes a packed region result while preserving its GPU-produced pair order. */
+export function decodeGPUIndexPickRegion(
+  data: ArrayBuffer | ArrayBufferView
+): GPUIndexPickingRegionResult {
+  const byteOffset = ArrayBuffer.isView(data) ? data.byteOffset : 0;
+  const byteLength = ArrayBuffer.isView(data) ? data.byteLength : data.byteLength;
+  const buffer = ArrayBuffer.isView(data) ? data.buffer : data;
+  if (byteLength < Uint32Array.BYTES_PER_ELEMENT * 4) {
+    throw new Error('GPU index picking region result requires at least sixteen bytes');
+  }
+  const view = new DataView(buffer, byteOffset, byteLength);
+  const count = view.getUint32(0, true);
+  const overflow = view.getUint32(Uint32Array.BYTES_PER_ELEMENT, true) !== 0;
+  const storedCount = Math.min(
+    count,
+    Math.floor((byteLength / Uint32Array.BYTES_PER_ELEMENT - 2) / 2)
+  );
+  const picks: PickInfo[] = [];
+  for (let index = 0; index < storedCount; index++) {
+    const pairByteOffset = (2 + index * 2) * Uint32Array.BYTES_PER_ELEMENT;
+    picks.push({
+      objectIndex: view.getInt32(pairByteOffset, true),
+      batchIndex: view.getInt32(pairByteOffset + Int32Array.BYTES_PER_ELEMENT, true)
+    });
+  }
+  return {picks, count, overflow};
 }
 
 /** Validates the fixed attachment extent. */

--- a/modules/experimental/src/gpu-primitives/gpu-readback-ring.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-readback-ring.ts
@@ -1,0 +1,261 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type CommandEncoder, type Device} from '@luma.gl/core';
+
+/** Construction properties for {@link GPUReadbackRing}. */
+export type GPUReadbackRingProps = {
+  /** Prefix for the staging-buffer IDs. */
+  id?: string;
+  /** Capacity of every staging buffer, in bytes. Must be a positive multiple of four. */
+  byteLength: number;
+  /** Number of independently reusable staging buffers. Defaults to three. */
+  slotCount?: number;
+};
+
+type GPUReadbackTicketState = 'reserved' | 'encoded' | 'reading' | 'released';
+
+/**
+ * One exclusive reservation in a {@link GPUReadbackRing}.
+ *
+ * A ticket may record one copy, or expose its buffer to another encoder and call `markEncoded()`.
+ * The application submits the encoder before calling `read()`. A slot is returned to the ring only
+ * after mapping finishes, so a mapped or in-flight staging buffer is never reused.
+ */
+export class GPUReadbackTicket {
+  /** Caller-visible staging buffer for graph imports and texture-to-buffer copies. */
+  readonly buffer: Buffer;
+
+  private readonly ring: GPUReadbackRing;
+  private state: GPUReadbackTicketState = 'reserved';
+  private copiedByteOffset = 0;
+  private copiedByteLength: number;
+  private cancelled = false;
+
+  /** @internal */
+  constructor(ring: GPUReadbackRing, buffer: Buffer) {
+    this.ring = ring;
+    this.buffer = buffer;
+    this.copiedByteLength = buffer.byteLength;
+  }
+
+  /** Records a buffer copy into this ticket without submitting the command encoder. */
+  copyFrom(
+    commandEncoder: CommandEncoder,
+    sourceBuffer: Buffer,
+    options: {sourceOffset?: number; destinationOffset?: number; byteLength?: number} = {}
+  ): void {
+    this.assertReserved();
+    const sourceOffset = options.sourceOffset ?? 0;
+    const destinationOffset = options.destinationOffset ?? 0;
+    const byteLength = options.byteLength ?? sourceBuffer.byteLength - sourceOffset;
+    validateCopyRange(sourceBuffer, this.buffer, sourceOffset, destinationOffset, byteLength);
+    commandEncoder.copyBufferToBuffer({
+      sourceBuffer,
+      sourceOffset,
+      destinationBuffer: this.buffer,
+      destinationOffset,
+      size: byteLength
+    });
+    this.copiedByteOffset = destinationOffset;
+    this.copiedByteLength = byteLength;
+    this.state = 'encoded';
+  }
+
+  /**
+   * Marks a copy encoded by another abstraction, such as a command graph texture-copy node.
+   */
+  markEncoded(options: {byteOffset?: number; byteLength?: number} = {}): void {
+    this.assertReserved();
+    const byteOffset = options.byteOffset ?? 0;
+    const byteLength = options.byteLength ?? this.buffer.byteLength - byteOffset;
+    validateAlignedRange(this.buffer.byteLength, byteOffset, byteLength, 'readback');
+    this.copiedByteOffset = byteOffset;
+    this.copiedByteLength = byteLength;
+    this.state = 'encoded';
+  }
+
+  /**
+   * Maps and copies the encoded bytes after the application submits its command encoder.
+   *
+   * Mapping errors, including device loss, release the slot before they are rethrown.
+   */
+  async read(): Promise<Uint8Array> {
+    if (this.state !== 'encoded') {
+      throw new Error('GPU readback ticket must be encoded before reading');
+    }
+    this.state = 'reading';
+    try {
+      const data = await this.buffer.readAsync(this.copiedByteOffset, this.copiedByteLength);
+      if (this.cancelled) {
+        throw new Error('GPU readback ticket was cancelled');
+      }
+      return data;
+    } finally {
+      this.release();
+    }
+  }
+
+  /**
+   * Cancels an unused reservation, or discards a read already in progress.
+   *
+   * An encoded ticket cannot be released safely until its submitted copy finishes; start `read()`
+   * first, then cancel it when its value is no longer needed.
+   */
+  cancel(): void {
+    if (this.state === 'reserved') {
+      this.cancelled = true;
+      this.release();
+      return;
+    }
+    if (this.state === 'reading') {
+      this.cancelled = true;
+      return;
+    }
+    if (this.state === 'encoded') {
+      throw new Error('Start reading an encoded GPU readback ticket before cancelling it');
+    }
+  }
+
+  private assertReserved(): void {
+    if (this.state !== 'reserved') {
+      throw new Error('GPU readback ticket has already been used');
+    }
+  }
+
+  private release(): void {
+    if (this.state !== 'released') {
+      this.state = 'released';
+      this.ring.release(this.buffer);
+    }
+  }
+}
+
+/**
+ * Fixed-capacity ring of reusable asynchronous GPU-to-CPU staging buffers.
+ *
+ * `tryAcquire()` makes drop-on-pressure policy explicit. `acquire()` instead waits for the next
+ * completed slot. Neither path submits commands or hides queue synchronization.
+ */
+export class GPUReadbackRing {
+  /** Capacity of every staging buffer, in bytes. */
+  readonly byteLength: number;
+  /** Total number of staging slots. */
+  readonly slotCount: number;
+
+  private readonly buffers: Buffer[];
+  private readonly availableBuffers: Buffer[];
+  private readonly waiters: Array<{
+    resolve: (ticket: GPUReadbackTicket) => void;
+    reject: (error: Error) => void;
+  }> = [];
+  private destroyed = false;
+
+  constructor(device: Device, props: GPUReadbackRingProps) {
+    const slotCount = props.slotCount ?? 3;
+    validateAlignedRange(Number.MAX_SAFE_INTEGER, 0, props.byteLength, 'ring');
+    if (!Number.isSafeInteger(slotCount) || slotCount <= 0) {
+      throw new Error('GPUReadbackRing slotCount must be a positive integer');
+    }
+    this.byteLength = props.byteLength;
+    this.slotCount = slotCount;
+    const id = props.id ?? 'gpu-readback-ring';
+    this.buffers = Array.from({length: slotCount}, (_, slotIndex) =>
+      device.createBuffer({
+        id: `${id}-slot-${slotIndex}`,
+        byteLength: props.byteLength,
+        usage: Buffer.COPY_DST | Buffer.MAP_READ
+      })
+    );
+    this.availableBuffers = [...this.buffers];
+    void device.lost.then(() => this.destroy());
+  }
+
+  /** Number of slots that can be reserved immediately. */
+  get availableSlotCount(): number {
+    return this.availableBuffers.length;
+  }
+
+  /** Reserves a slot immediately, or returns `null` when the ring is under backpressure. */
+  tryAcquire(): GPUReadbackTicket | null {
+    if (this.destroyed) {
+      return null;
+    }
+    const buffer = this.availableBuffers.shift();
+    return buffer ? new GPUReadbackTicket(this, buffer) : null;
+  }
+
+  /** Waits for and reserves the next available slot. */
+  acquire(): Promise<GPUReadbackTicket> {
+    const ticket = this.tryAcquire();
+    if (ticket) {
+      return Promise.resolve(ticket);
+    }
+    if (this.destroyed) {
+      return Promise.reject(new Error('GPUReadbackRing has been destroyed'));
+    }
+    return new Promise((resolve, reject) => this.waiters.push({resolve, reject}));
+  }
+
+  /** Rejects pending waiters and destroys idle slots; active slots are destroyed on release. */
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.reject(new Error('GPUReadbackRing has been destroyed'));
+    }
+    for (const buffer of this.availableBuffers.splice(0)) {
+      buffer.destroy();
+    }
+  }
+
+  /** @internal */
+  release(buffer: Buffer): void {
+    if (this.destroyed) {
+      buffer.destroy();
+      return;
+    }
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter.resolve(new GPUReadbackTicket(this, buffer));
+    } else {
+      this.availableBuffers.push(buffer);
+    }
+  }
+}
+
+function validateCopyRange(
+  sourceBuffer: Buffer,
+  destinationBuffer: Buffer,
+  sourceOffset: number,
+  destinationOffset: number,
+  byteLength: number
+): void {
+  if (sourceBuffer.device !== destinationBuffer.device) {
+    throw new Error('GPU readback source and staging buffers must belong to the same device');
+  }
+  validateAlignedRange(sourceBuffer.byteLength, sourceOffset, byteLength, 'source');
+  validateAlignedRange(destinationBuffer.byteLength, destinationOffset, byteLength, 'destination');
+}
+
+function validateAlignedRange(
+  capacity: number,
+  byteOffset: number,
+  byteLength: number,
+  name: string
+): void {
+  if (
+    !Number.isSafeInteger(byteOffset) ||
+    !Number.isSafeInteger(byteLength) ||
+    byteOffset < 0 ||
+    byteLength <= 0 ||
+    byteOffset % 4 !== 0 ||
+    byteLength % 4 !== 0 ||
+    byteOffset + byteLength > capacity
+  ) {
+    throw new Error(`${name} byte range must be positive, four-byte aligned, and in bounds`);
+  }
+}

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -115,13 +115,19 @@ export type {
 
 export {
   decodeGPUIndexPickInfo,
+  decodeGPUIndexPickRegion,
   GPUIndexPickingTarget,
   INDEX_PICKING_READBACK_BYTE_LENGTH
 } from './gpu-index-picking-target';
 export type {
+  GPUIndexPickingRegionProps,
+  GPUIndexPickingRegionResult,
   GPUIndexPickingReadbackProps,
   GPUIndexPickingTargetProps
 } from './gpu-index-picking-target';
+
+export {GPUReadbackRing, GPUReadbackTicket} from './gpu-readback-ring';
+export type {GPUReadbackRingProps} from './gpu-readback-ring';
 
 export {DrawCommandBuffer} from './draw-command-buffer';
 export type {

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
@@ -7,8 +7,10 @@ import {Buffer, Texture, type Device} from '@luma.gl/core';
 import {Computation, Model} from '@luma.gl/engine';
 import {
   decodeGPUIndexPickInfo,
+  decodeGPUIndexPickRegion,
   GPUCommandGraph,
   GPUIndexPickingTarget,
+  GPUReadbackRing,
   INDEX_PICKING_READBACK_BYTE_LENGTH
 } from '@luma.gl/experimental';
 import {getNullTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
@@ -465,6 +467,188 @@ test('GPUIndexPickingTarget renders stable integer IDs and copies dynamic pixels
   defaultReadback.destroy();
   replacementReadback.destroy();
   backgroundReadback.destroy();
+  t.end();
+});
+
+test('GPUIndexPickingTarget reduces regions through a reusable readback ring', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const capacity = 6;
+  const resultByteLength = (2 + capacity * 2) * Uint32Array.BYTES_PER_ELEMENT;
+  const regionBuffer = device.createBuffer({
+    id: 'picking-region',
+    data: new Uint32Array([0, 0, 4, 4]),
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  const resultBuffer = device.createBuffer({
+    id: 'picking-region-result',
+    byteLength: resultByteLength,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  const graph = new GPUCommandGraph(device, {id: 'index-region-picking'});
+  const regionHandle = graph.importBuffer(
+    {id: 'region', byteLength: regionBuffer.byteLength, usage: Buffer.STORAGE},
+    regionBuffer
+  );
+  const resultHandle = graph.importBuffer(
+    {
+      id: 'region-result',
+      byteLength: resultBuffer.byteLength,
+      usage: Buffer.STORAGE | Buffer.COPY_SRC
+    },
+    resultBuffer
+  );
+  const target = new GPUIndexPickingTarget(graph, {id: 'pick-region', width: 4, height: 4});
+  graph.addRenderPass({
+    id: 'pick-region-render',
+    attachments: target.attachments,
+    compile: ({device: compileDevice}) => {
+      const model = new Model(compileDevice, {
+        id: 'index-region-picking-model',
+        source: `struct FragmentOutputs {
+  @location(0) color: vec4<f32>,
+  @location(1) indices: vec2<i32>,
+};
+@vertex fn vertexMain(@builtin(vertex_index) index: u32) -> @builtin(position) vec4<f32> {
+  let positions = array<vec2<f32>, 3>(vec2(-1.0, -1.0), vec2(3.0, -1.0), vec2(-1.0, 3.0));
+  return vec4(positions[index], 0.0, 1.0);
+}
+@fragment fn fragmentMain(@builtin(position) position: vec4<f32>) -> FragmentOutputs {
+  if (position.y >= 3.0) { discard; }
+  var output: FragmentOutputs;
+  output.color = vec4(0.0);
+  output.indices = vec2<i32>(select(7, 9, position.x >= 2.0), 3);
+  return output;
+}`,
+        vertexCount: 3,
+        colorAttachmentFormats: ['rgba8unorm', 'rg32sint'],
+        depthStencilAttachmentFormat: 'depth24plus'
+      });
+      return {
+        getRenderPassProps: () => target.renderPassProps,
+        encode: ({renderPass}) => model.draw(renderPass),
+        destroy: () => model.destroy()
+      };
+    }
+  });
+  target.addRegionPass({
+    after: 'pick-region-render',
+    region: graph.createDataView(regionHandle, {format: 'uint32', length: 4}),
+    result: graph.createDataView(resultHandle, {
+      format: 'uint32',
+      length: resultByteLength / Uint32Array.BYTES_PER_ELEMENT
+    })
+  });
+  const compiled = graph.compile();
+  const ring = new GPUReadbackRing(device, {
+    id: 'picking-region-readback',
+    byteLength: resultByteLength,
+    slotCount: 2
+  });
+
+  const firstTicket = ring.tryAcquire();
+  const reservedTicket = ring.tryAcquire();
+  t.ok(firstTicket && reservedTicket, 'all configured staging slots can be reserved');
+  t.equal(ring.tryAcquire(), null, 'tryAcquire exposes drop-on-pressure policy');
+  const waitingTicketPromise = ring.acquire();
+  reservedTicket?.cancel();
+  const waitingTicket = await waitingTicketPromise;
+  t.ok(waitingTicket, 'acquire waits for the next released slot');
+  waitingTicket.cancel();
+
+  const firstEncoder = device.createCommandEncoder({id: 'pick-region-first'});
+  compiled.encode(firstEncoder, {parameters: undefined});
+  firstTicket?.copyFrom(firstEncoder, resultBuffer);
+  device.submit(firstEncoder.finish());
+  const firstResult = decodeGPUIndexPickRegion(await firstTicket!.read());
+  t.equal(firstResult.count, 12, 'count includes every non-background covered pixel');
+  t.equal(firstResult.picks.length, capacity, 'stored pairs stop at caller capacity');
+  t.ok(firstResult.overflow, 'overflow reports truncated results');
+  t.ok(
+    firstResult.picks.every(
+      pick => (pick.objectIndex === 7 || pick.objectIndex === 9) && pick.batchIndex === 3
+    ),
+    'stable object and batch IDs survive unordered atomic collection'
+  );
+
+  regionBuffer.write(new Uint32Array([0, 0, 2, 3]));
+  const exactTicket = ring.tryAcquire();
+  const exactEncoder = device.createCommandEncoder({id: 'pick-region-exact-capacity'});
+  compiled.encode(exactEncoder, {parameters: undefined});
+  exactTicket?.copyFrom(exactEncoder, resultBuffer);
+  device.submit(exactEncoder.finish());
+  const exactResult = decodeGPUIndexPickRegion(await exactTicket!.read());
+  t.equal(exactResult.count, capacity, 'exact-capacity selection reports the complete count');
+  t.equal(exactResult.picks.length, capacity, 'exact-capacity selection stores every pair');
+  t.notOk(exactResult.overflow, 'exact capacity does not report overflow');
+
+  regionBuffer.write(new Uint32Array([0, 0, 0, 3]));
+  const emptyTicket = ring.tryAcquire();
+  const emptyEncoder = device.createCommandEncoder({id: 'pick-region-empty'});
+  compiled.encode(emptyEncoder, {parameters: undefined});
+  emptyTicket?.copyFrom(emptyEncoder, resultBuffer);
+  device.submit(emptyEncoder.finish());
+  t.deepEqual(
+    decodeGPUIndexPickRegion(await emptyTicket!.read()),
+    {picks: [], count: 0, overflow: false},
+    'empty rectangles clear prior results'
+  );
+
+  regionBuffer.write(new Uint32Array([0, 0, 1, 1]));
+  const secondTicket = ring.tryAcquire();
+  t.ok(secondTicket, 'mapped slot is reusable after read completion');
+  const secondEncoder = device.createCommandEncoder({id: 'pick-region-second'});
+  compiled.encode(secondEncoder, {parameters: undefined});
+  secondTicket?.copyFrom(secondEncoder, resultBuffer);
+  device.submit(secondEncoder.finish());
+  t.deepEqual(
+    decodeGPUIndexPickRegion(await secondTicket!.read()),
+    {picks: [{objectIndex: 7, batchIndex: 3}], count: 1, overflow: false},
+    'GPU-resident rectangle updates produce exact results without rebuilding the graph'
+  );
+
+  const heldTicket = ring.tryAcquire();
+  const cancelledTicket = ring.tryAcquire();
+  const overlapEncoder = device.createCommandEncoder({id: 'pick-region-overlapping-readbacks'});
+  heldTicket?.copyFrom(overlapEncoder, resultBuffer);
+  cancelledTicket?.copyFrom(overlapEncoder, resultBuffer);
+  device.submit(overlapEncoder.finish());
+  const cancelledRead = cancelledTicket!.read().then(
+    () => '',
+    error => String(error)
+  );
+  cancelledTicket?.cancel();
+  t.match(
+    await cancelledRead,
+    /cancelled/,
+    'in-progress cancellation drains and discards its slot'
+  );
+  t.equal(
+    ring.availableSlotCount,
+    1,
+    'a later ticket can complete while an earlier encoded ticket remains reserved'
+  );
+  await heldTicket?.read();
+  t.equal(ring.availableSlotCount, 2, 'out-of-order completion eventually releases every slot');
+
+  const pendingTicket = ring.tryAcquire();
+  const secondPendingTicket = ring.tryAcquire();
+  const rejectedWaiter = ring.acquire();
+  const rejectionMessage = rejectedWaiter.then(
+    () => '',
+    error => String(error)
+  );
+  ring.destroy();
+  t.match(await rejectionMessage, /destroyed/, 'destroy rejects pending backpressure waiters');
+  pendingTicket?.cancel();
+  secondPendingTicket?.cancel();
+  compiled.destroy();
+  regionBuffer.destroy();
+  resultBuffer.destroy();
   t.end();
 });
 

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
@@ -418,7 +418,10 @@ test('GPUIndexPickingTarget renders stable integer IDs and copies dynamic pixels
   if (position.y >= 3.0) { discard; }
   var output: FragmentOutputs;
   output.color = vec4(0.0);
-  output.indices = vec2<i32>(select(7, 9, position.x >= 2.0), 3);
+  output.indices = vec2<i32>(
+    select(7, 9, position.x >= 2.0),
+    select(-1, 3, position.x >= 2.0)
+  );
   return output;
 }`,
         vertexCount: 3,
@@ -437,8 +440,8 @@ test('GPUIndexPickingTarget renders stable integer IDs and copies dynamic pixels
   await encodePick(device, compiled, [0, 0]);
   t.deepEqual(
     decodeGPUIndexPickInfo(await defaultReadback.readAsync(0, 8)),
-    {objectIndex: 7, batchIndex: 3},
-    'left pixel returns first stable ID'
+    {objectIndex: 7, batchIndex: null},
+    'left pixel preserves a stable object without a batch ID'
   );
   const replacementReadback = makePickingReadbackBuffer(device, 'picking-readback-replacement');
   await encodePick(device, compiled, [3, 0], replacementReadback, target.readback.id);
@@ -521,7 +524,10 @@ test('GPUIndexPickingTarget reduces regions through a reusable readback ring', a
   if (position.y >= 3.0) { discard; }
   var output: FragmentOutputs;
   output.color = vec4(0.0);
-  output.indices = vec2<i32>(select(7, 9, position.x >= 2.0), 3);
+  output.indices = vec2<i32>(
+    select(7, 9, position.x >= 2.0),
+    select(-1, 3, position.x >= 2.0)
+  );
   return output;
 }`,
         vertexCount: 3,
@@ -570,9 +576,11 @@ test('GPUIndexPickingTarget reduces regions through a reusable readback ring', a
   t.ok(firstResult.overflow, 'overflow reports truncated results');
   t.ok(
     firstResult.picks.every(
-      pick => (pick.objectIndex === 7 || pick.objectIndex === 9) && pick.batchIndex === 3
+      pick =>
+        (pick.objectIndex === 7 && pick.batchIndex === null) ||
+        (pick.objectIndex === 9 && pick.batchIndex === 3)
     ),
-    'stable object and batch IDs survive unordered atomic collection'
+    'stable object IDs survive collection with optional batch IDs'
   );
 
   regionBuffer.write(new Uint32Array([0, 0, 2, 3]));
@@ -607,7 +615,7 @@ test('GPUIndexPickingTarget reduces regions through a reusable readback ring', a
   device.submit(secondEncoder.finish());
   t.deepEqual(
     decodeGPUIndexPickRegion(await secondTicket!.read()),
-    {picks: [{objectIndex: 7, batchIndex: 3}], count: 1, overflow: false},
+    {picks: [{objectIndex: 7, batchIndex: null}], count: 1, overflow: false},
     'GPU-resident rectangle updates produce exact results without rebuilding the graph'
   );
 

--- a/website/src/components/docs/gpu-primitives-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-primitives-docs-tabs.tsx
@@ -18,6 +18,7 @@ export type GPUPrimitivesDocsTabId =
   | 'grid-aggregation'
   | 'group-aggregation'
   | 'index-picking'
+  | 'readback-ring'
   | 'draw-command-buffer';
 
 const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
@@ -100,6 +101,11 @@ const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
     id: 'index-picking',
     label: 'Picking',
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target'
+  },
+  {
+    id: 'readback-ring',
+    label: 'Readback Ring',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-readback-ring'
   },
   {
     id: 'draw-command-buffer',


### PR DESCRIPTION
## Goals

- Implement roadmap Tranches 4.1 and 4.2 without imposing renderer or selection policy.
- Keep stable object and batch identity on the GPU while making capacity, overflow, backpressure, cancellation, and resource lifetime explicit.

## Changes

- Add capacity-bounded rectangular reduction to `GPUIndexPickingTarget`, with GPU-resident region input and packed count/overflow/object/batch output.
- Add `decodeGPUIndexPickRegion()` and document preserved duplicates plus unspecified atomic output order.
- Add `GPUReadbackRing` and lifecycle-enforced tickets for reusable asynchronous staging buffers. The ring supports immediate or waiting acquisition, cancellation, graph-imported copies, safe reuse, destruction, and device-loss propagation without submitting commands.
- Migrate the GPU frustum-culling picker from per-request buffer allocation to a two-slot drop-on-pressure ring.
- Add Overview/Concepts documentation, a dedicated readback-ring reference page, navigation, and roadmap status updates.
- Add WebGPU coverage for empty, exact-capacity, overflow, duplicate-ID, dynamic-region, exhaustion, cancellation, out-of-order completion, and destruction behavior.

## Verification

- `nvm use` — passed (`v22.22.1`)
- `yarn lint fix` — passed
- `yarn build` — passed
- `yarn test-headless gpu-command-graph-textures` — passed (6/6)
- `yarn test` — node tests passed (253 passed, 2 skipped); headless tests reached 1,336 passed and 25 skipped, with the pre-existing unrelated `arrow-polygons-storage-test has drawable storage-backed instances` assertion failing in `modules/arrow-layers/test/layers/arrow-layers.spec.ts`
- `yarn website:build` — passed
- `(cd website && yarn build)` — passed

## Stack

- Stacked on #2806.
- The next roadmap boundary is Tranche 4.3: render-target graph contracts for multisample resolves and swapchain imports.
