### PR TITLE
feat(experimental): add GPU render target contracts

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1007,7 +1007,7 @@ schedule commitment.
 | 1 — Hardening and observability | GPU timestamps, performance baselines, adapter capability reporting, boundary and overflow validation, memory statistics, and device-loss and resource-lifetime coverage | Implemented | High | Medium |
 | 2 — Reusable visibility workflows | Renderer-independent time-range, bounds, LOD, and selection workflows that publish stable IDs, counts, and indirect commands | Implemented | High | Medium |
 | 3 — Algorithm and table scaling | Multi-chunk coverage, segmented and inclusive scans, weighted statistics, richer histograms, and batch-preserving algorithms | Implemented | High | Large |
-| 4 — Picking and texture coverage | Region picking and asynchronous staging rings implemented; multisample resolves, swapchain imports, and external-texture contracts remain | In progress | Medium | Large |
+| 4 — Picking and texture coverage | Region picking, asynchronous staging rings, multisample resolves, and frame-scoped swapchain imports implemented; external-texture contracts remain | In progress | Medium | Large |
 | 5 — Spatial acceleration | `GPUGridIndex` followed by `GPUBVH`, with explicit build, update, and query costs | Planned | High | Large |
 | 6 — GPUScene | A flat GPU draw database with stable identity, bounds, transforms, grouping, geometry references, and indirect command slots | Planned | High | Large |
 | 7 — API graduation | Stable package contracts, compatibility exports, and a dependency-safe move out of experimental packages | Planned | High | Large |
@@ -1019,8 +1019,8 @@ only when its entry dependency is present and its exit evidence can be produced;
 dependency order, not a schedule commitment. Tranches whose dependencies do not overlap may be
 developed independently.
 
-Tranches 4.1 and 4.2 are implemented; render-target contracts in Tranche 4.3 are the next active
-boundary.
+Tranches 4.1 through 4.3 are implemented; external-texture contracts in Tranche 4.4 are the next
+active boundary.
 
 | Tranche | Outcome | Entry dependency | Impact | Complexity/cost |
 | --- | --- | --- | :---: | :---: |
@@ -1028,7 +1028,7 @@ boundary.
 | 3.3 — Extension decision gate | Evidence-backed decision on sparse histograms, multidimensional histograms, custom scans, and shader callbacks | Tranche 3.2 plus demonstrated consumers | Medium | Medium |
 | 4.1 — Region picking | Bounded rectangular picks with stable object and batch IDs, capacity, count, and overflow | Implemented | Medium | Medium |
 | 4.2 — Asynchronous readback ring | Reusable staging slots with backpressure, cancellation, and no mapped-buffer reuse hazards | Implemented | High | Medium |
-| 4.3 — Render-target graph contracts | Multisample resolve and swapchain imports with explicit subresource and frame ownership | Phase 1 lifetime contracts | Medium | Large |
+| 4.3 — Render-target graph contracts | Multisample resolve and swapchain imports with explicit subresource and frame ownership | Implemented | Medium | Large |
 | 4.4 — External-texture contracts | One-frame external-texture imports with validated access and device-loss behavior | Tranche 4.3 | Medium | Large |
 | 5.1 — `GPUGridIndex` build/update | Stable cell offsets and object-ID storage with measurable full-build and incremental-update costs | Tranche 3.2 and Phase 1 measurement | High | Large |
 | 5.2 — `GPUGridIndex` query | Bounds, radius, and point queries feeding visibility and region picking in 2D and 3D | Tranche 5.1, Phase 2, and Tranche 4.1 | High | Medium |
@@ -1217,9 +1217,9 @@ application or renderer consumer.
 **Entry dependencies:** Phase 1 defines resource-lifetime and asynchronous readback behavior;
 Phase 2 defines stable visible identity.
 
-Region picking and reusable asynchronous staging-buffer rings are implemented. Next, add graph
-contracts for multisampled resolve targets, swapchain imports, and external textures so their
-subresources, hazards, ownership, and frame lifetimes are explicit.
+Region picking, reusable asynchronous staging-buffer rings, multisample resolves, and frame-scoped
+swapchain imports are implemented. External textures remain next so their access, ownership, and
+frame lifetime become equally explicit.
 Callback, highlighting, tooltip, and color-encoded fallback policies remain higher-level workflow
 or application concerns.
 
@@ -1246,9 +1246,11 @@ cancellation, destruction, and device loss.
 
 #### Tranche 4.3 — Render-target graph contracts
 
-Model multisample resolves and swapchain texture imports with explicit mip, layer, aspect, access,
-and frame validity. The graph validates hazards but never acquires, presents, or destroys a
-swapchain texture on the application's behalf.
+Graph render attachments now model multisample resolve targets with explicit mip, layer, aspect,
+access, format, extent, and sample validation. `importFrameTexture()` requires caller-acquired
+swapchain textures to carry one coherent, strictly increasing frame ID per encoding. The graph
+validates hazards but never acquires, presents, or destroys a swapchain texture on the
+application's behalf.
 
 **Exit evidence:** Compute, render, copy, and resolve nodes reject conflicting subresource access;
 multisample and swapchain examples encode through the graph; stale-frame and ownership mistakes

--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -9,7 +9,8 @@ import {GPUDataAnalysisExample} from '@site/src/examples';
 
 `GPUCommandGraph<Parameters>` declares fixed-capacity WebGPU buffer and texture resources plus
 ordered compute, render, and copy nodes. `compile()` returns a `CompiledGPUCommandGraph` that owns
-transient resources and node state but borrows every import.
+transient resources and node state but borrows every import. Render nodes can resolve multisampled
+attachments and consume explicitly numbered, frame-scoped swapchain textures.
 
 See [Choosing a GPU Data-Processing API](/docs/api-guide/gpu/gpu-data-processing) for guidance on
 when to use a command graph, portable GPGPU evaluators, or lower-level compute helpers.
@@ -24,6 +25,12 @@ caller-owned command encoder; submission and readback remain explicit applicatio
 Resource-use declarations are both contracts and dependency edges. A storage write followed by a
 read creates a hazard the compiler orders automatically. Imports stay caller-owned, while graph
 transients and node-created pipelines belong to the compiled graph.
+
+Render targets need a stricter lifetime distinction than ordinary data textures. An offscreen
+texture can remain valid across many encodings, while a canvas texture belongs to one acquired
+frame and may be replaced at presentation. `importFrameTexture()` makes that boundary visible:
+every encoding supplies a fresh binding with a strictly increasing frame ID. This catches stale
+swapchain reuse without making the graph responsible for acquisition or presentation.
 
 This example composes reduction, histogram, and grid-binning nodes in one reusable graph:
 
@@ -125,6 +132,17 @@ than capacity-based: format, dimension, extent, mip count, and sample count must
 encoding, while concrete usage must contain every declared flag. Recompile canvas-sized graphs
 after a device-pixel resize.
 
+### `importFrameTexture(descriptor)`
+
+Declares a borrowed texture with no persistent default. Each encoding supplies
+`frameTextures[id] = {texture, frameId}`. All frame textures in one encoding must use the same
+non-negative frame ID, and that ID must increase on every later encoding of the compiled graph.
+
+This contract is intended for swapchain color attachments and any matching frame-local depth or
+resolve resources. The application acquires the textures before encoding and presents them after
+submission. The graph validates exact descriptor compatibility and ownership, but never acquires,
+presents, treats an earlier frame binding as reusable, or destroys the imported texture.
+
 ### `createTransientTexture(descriptor)`
 
 Declares graph-owned texture storage. Non-overlapping logical textures reuse one physical texture
@@ -136,6 +154,32 @@ their usage flags.
 Creates a `GraphTextureView` with normalized aspect, mip, and array-layer ranges. Texture hazards
 are inferred only between overlapping ranges. Handle-level uses conservatively cover the complete
 texture.
+
+## Render attachments and resolves
+
+`addRenderPass()` accepts graph-managed color and depth/stencil views. A multisampled color view
+can provide a corresponding single-sample entry in `resolveTargets`:
+
+```ts
+graph.addRenderPass({
+  id: 'render-msaa',
+  attachments: {
+    colorAttachments: [multisampledColor],
+    resolveTargets: [frameColor],
+    depthStencilAttachment: multisampledDepth
+  },
+  compile: () => renderExecutable
+});
+```
+
+Resolve arrays have one entry per color attachment; `null` skips a slot. Every non-null target
+must match its source format, extent, mip, layer, and aspect, use one sample, and resolve a source
+with more than one sample. Source, depth, and other render attachments retain matching sample
+counts. Resolve targets participate in ordinary graph hazards, so later sampling or copying is
+ordered after the render pass.
+
+Multisample resolve is currently a WebGPU contract. Render-pass callbacks cannot also supply their
+own framebuffer or resolve targets when graph attachments are present.
 
 ## Node APIs
 
@@ -151,7 +195,7 @@ dependency.
 
 Executable contexts expose `getBuffer()`, `getTexture()`, and `getTextureView()`. Concrete texture
 views and framebuffers are cached for repeated encodings and rebuilt when an imported texture is
-replaced.
+replaced. Non-default views over frame-scoped imports are refreshed for each frame ID.
 
 ## Hazards and scheduling
 

--- a/examples/experimental/gpu-frustum-culling/app.ts
+++ b/examples/experimental/gpu-frustum-culling/app.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, type Device, type RenderBundle} from '@luma.gl/core';
+import {Buffer, Texture, type Device, type RenderBundle} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Computation, CubeGeometry, Model} from '@luma.gl/engine';
 import {
@@ -47,6 +47,8 @@ type CullingGraphResources = {
   compiled: CompiledGPUCommandGraph<CullingGraphParameters>;
   pickingCompiled: CompiledGPUCommandGraph<PickingGraphParameters>;
   pickingReadbackId: string;
+  frameColorId: string;
+  frameDepthId: string;
   pickingWidth: number;
   pickingHeight: number;
   drawCommands: DrawCommandBuffer;
@@ -218,7 +220,22 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
     const viewports = getViewports(width, height, this.comparisonView);
     this.writeUniforms(viewports);
     const encodeStart = performance.now();
-    resources.compiled.encode(device.commandEncoder, {parameters: viewports});
+    const frame = device
+      .getDefaultCanvasContext()
+      .getCurrentFramebuffer({depthStencilFormat: 'depth24plus'});
+    resources.compiled.encode(device.commandEncoder, {
+      parameters: viewports,
+      frameTextures: {
+        [resources.frameColorId]: {
+          texture: frame.colorAttachments[0].texture,
+          frameId: this.frameIndex
+        },
+        [resources.frameDepthId]: {
+          texture: frame.depthStencilAttachment!.texture,
+          frameId: this.frameIndex
+        }
+      }
+    });
     if (_mousePosition && this.frameIndex % 4 === 0) {
       const readbackTicket = this.pickingReadbackRing.tryAcquire();
       if (readbackTicket) {
@@ -294,17 +311,19 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
       drawCommands,
       this.overviewUniformBuffer
     );
-    const compiled = this.createGraph(
+    const deviceSize = this.device.getDefaultCanvasContext().getDevicePixelSize();
+    const pickingWidth = Math.max(1, deviceSize[0]);
+    const pickingHeight = Math.max(1, deviceSize[1]);
+    const renderGraph = this.createGraph(
       capacity,
+      pickingWidth,
+      pickingHeight,
       instances,
       visibleIds,
       drawCommands,
       perspectiveRenderBundle,
       overviewRenderBundle
     );
-    const deviceSize = this.device.getDefaultCanvasContext().getDevicePixelSize();
-    const pickingWidth = Math.max(1, deviceSize[0]);
-    const pickingHeight = Math.max(1, deviceSize[1]);
     const picking = this.createPickingGraph(
       pickingWidth,
       pickingHeight,
@@ -313,7 +332,9 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
       drawCommands
     );
     this.resources = {
-      compiled,
+      compiled: renderGraph.compiled,
+      frameColorId: renderGraph.frameColorId,
+      frameDepthId: renderGraph.frameDepthId,
       pickingCompiled: picking.compiled,
       pickingReadbackId: picking.readbackId,
       pickingWidth,
@@ -332,12 +353,18 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
 
   private createGraph(
     capacity: number,
+    width: number,
+    height: number,
     instancesBuffer: Buffer,
     visibleIdsBuffer: Buffer,
     drawCommands: DrawCommandBuffer,
     perspectiveRenderBundle: RenderBundle,
     overviewRenderBundle: RenderBundle
-  ): CompiledGPUCommandGraph<CullingGraphParameters> {
+  ): {
+    compiled: CompiledGPUCommandGraph<CullingGraphParameters>;
+    frameColorId: string;
+    frameDepthId: string;
+  } {
     const graph = new GPUCommandGraph<CullingGraphParameters>(this.device, {
       id: 'gpu-frustum-culling-command-graph'
     });
@@ -369,6 +396,20 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
       },
       drawCommands.buffer
     );
+    const frameColor = graph.importFrameTexture({
+      id: 'frame-color',
+      format: this.device.preferredColorFormat,
+      width,
+      height,
+      usage: Texture.RENDER
+    });
+    const frameDepth = graph.importFrameTexture({
+      id: 'frame-depth',
+      format: 'depth24plus',
+      width,
+      height,
+      usage: Texture.RENDER
+    });
     const flagsBuffer = graph.createTransientBuffer({
       id: 'visibility-flags',
       byteLength: capacity * UINT32_BYTE_LENGTH,
@@ -427,6 +468,10 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
 
     graph.addRenderPass({
       id: 'render-visible-instances',
+      attachments: {
+        colorAttachments: [graph.createTextureView(frameColor)],
+        depthStencilAttachment: graph.createTextureView(frameDepth)
+      },
       resources: [
         {buffer: instances, usage: 'storage-read'},
         {buffer: visibleIds, usage: 'storage-read'},
@@ -452,7 +497,11 @@ export default class GPUFrustumCullingAnimationLoopTemplate extends AnimationLoo
       })
     });
 
-    return graph.compile();
+    return {
+      compiled: graph.compile(),
+      frameColorId: frameColor.id,
+      frameDepthId: frameDepth.id
+    };
   }
 
   private createPickingGraph(

--- a/modules/core/src/adapter/resources/render-pass.ts
+++ b/modules/core/src/adapter/resources/render-pass.ts
@@ -15,6 +15,7 @@ import type {RenderBundle} from './render-bundle';
 import type {RenderPipeline} from './render-pipeline';
 import type {TransformFeedback} from './transform-feedback';
 import type {VertexArray} from './vertex-array';
+import type {TextureView} from './texture-view';
 
 /** Draw arguments consumed by the active state on a {@link RenderPass}. */
 export type RenderPassDrawOptions = {
@@ -56,6 +57,8 @@ export type RenderPassBindingOptions = {
 export type RenderPassProps = ResourceProps & {
   /** Framebuffer specifies which textures to render into. Default gets framebuffer from canvas context. */
   framebuffer?: Framebuffer | null;
+  /** Optional single-sample targets receiving resolved multisampled color attachments. WebGPU only. */
+  resolveTargets?: (TextureView | null)[];
   /** Control viewport, scissor rect, blend constant and stencil ref */
   parameters?: RenderPassParameters;
 
@@ -174,6 +177,7 @@ export abstract class RenderPass extends Resource<RenderPassProps> {
   static override defaultProps: Required<RenderPassProps> = {
     ...Resource.defaultProps,
     framebuffer: null,
+    resolveTargets: undefined!,
     parameters: undefined!,
     clearColor: RenderPass.defaultClearColor,
     clearColors: undefined!,

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph-types.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph-types.ts
@@ -59,6 +59,14 @@ export type GraphImportedBuffer = Buffer | DynamicBuffer;
 /** Caller-owned texture accepted as a fixed or per-encoding graph import. */
 export type GraphImportedTexture = Texture | DynamicTexture;
 
+/** One explicitly numbered frame-scoped texture binding. */
+export type GraphFrameTextureBinding = {
+  /** Caller-acquired texture valid for this encoding only. */
+  texture: GraphImportedTexture;
+  /** Strictly increasing application frame identifier for this compiled graph. */
+  frameId: number;
+};
+
 /** Descriptor for one imported or transient graph buffer. */
 export type GraphBufferDescriptor = {
   /** Graph-wide resource identifier. */
@@ -263,6 +271,8 @@ export class GraphTextureHandle<Format extends TextureFormat = TextureFormat> {
   readonly samples: number;
   /** Whether the graph owns and may alias the physical allocation. */
   readonly transient: boolean;
+  /** Whether every encoding requires a fresh, explicitly numbered frame binding. */
+  readonly frameScoped: boolean;
   /** @internal */
   readonly graph: GPUCommandGraphOwner;
   /** @internal */
@@ -273,7 +283,8 @@ export class GraphTextureHandle<Format extends TextureFormat = TextureFormat> {
     graph: GPUCommandGraphOwner,
     descriptor: NormalizedGraphTextureDescriptor<Format>,
     transient: boolean,
-    defaultTexture?: GraphImportedTexture
+    defaultTexture?: GraphImportedTexture,
+    frameScoped = false
   ) {
     this.graph = graph;
     this.id = descriptor.id;
@@ -286,6 +297,7 @@ export class GraphTextureHandle<Format extends TextureFormat = TextureFormat> {
     this.mipLevels = descriptor.mipLevels;
     this.samples = descriptor.samples;
     this.transient = transient;
+    this.frameScoped = frameScoped;
     this.defaultTexture = defaultTexture;
   }
 }
@@ -373,6 +385,8 @@ export type GraphResourceUse = GraphBufferUse | GraphTextureUse;
 export type GraphRenderPassAttachments = {
   /** Color attachment views in render-target order. */
   colorAttachments: GraphTextureView[];
+  /** Optional single-sample resolve target corresponding to each color attachment. */
+  resolveTargets?: (GraphTextureView | null)[];
   /** Optional depth/stencil attachment view. */
   depthStencilAttachment?: GraphTextureView;
 };
@@ -581,4 +595,6 @@ export type GPUCommandGraphEncodeOptions<Parameters> = {
   buffers?: Record<string, GraphImportedBuffer>;
   /** Per-encoding imported-texture replacements keyed by graph resource ID. */
   textures?: Record<string, GraphImportedTexture>;
+  /** Per-encoding frame-scoped texture bindings keyed by graph resource ID. */
+  frameTextures?: Record<string, GraphFrameTextureBinding>;
 };

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
@@ -56,6 +56,7 @@ import type {
   GPUCommandGraphTimingReport,
   GraphBufferDescriptor,
   GraphBufferUsage,
+  GraphFrameTextureBinding,
   GraphImportedBuffer,
   GraphImportedTexture,
   GraphRenderPassAttachments,
@@ -94,6 +95,7 @@ export type {
   GraphBufferDescriptor,
   GraphBufferUsage,
   GraphBufferUse,
+  GraphFrameTextureBinding,
   GraphImportedBuffer,
   GraphImportedTexture,
   GraphRenderPassAttachments,
@@ -110,6 +112,7 @@ type CachedTextureView = {
   logicalView: GraphTextureView;
   texture: Texture;
   view: TextureView;
+  frameId?: number;
 };
 
 type CachedFramebuffer = {
@@ -358,6 +361,22 @@ export class GPUCommandGraph<Parameters = void> {
   }
 
   /**
+   * Declares a caller-acquired texture that is valid for exactly one numbered encoding frame.
+   *
+   * Frame textures have no default and must be supplied through `encode({frameTextures})` with a
+   * strictly increasing frame ID. The graph borrows but never acquires, presents, or destroys them.
+   */
+  importFrameTexture<Format extends TextureFormat>(
+    descriptor: GraphTextureDescriptor<Format>
+  ): GraphTextureHandle<Format> {
+    this.assertMutable();
+    const normalizedDescriptor = normalizeGraphTextureDescriptor(descriptor, this.device);
+    return this.addTexture(
+      new GraphTextureHandle(this, normalizedDescriptor, false, undefined, true)
+    );
+  }
+
+  /**
    * Declares one graph-owned fixed-size transient texture.
    *
    * Descriptor-compatible textures with disjoint compiled lifetimes may share an allocation.
@@ -410,6 +429,9 @@ export class GPUCommandGraph<Parameters = void> {
             texture,
             usage: 'render-attachment' as const
           })),
+          ...(node.attachments.resolveTargets ?? [])
+            .filter((texture): texture is GraphTextureView => texture !== null)
+            .map(texture => ({texture, usage: 'render-attachment' as const})),
           ...(node.attachments.depthStencilAttachment
             ? [
                 {
@@ -575,6 +597,51 @@ export class GPUCommandGraph<Parameters = void> {
         );
       }
     }
+    this.validateResolveTargets(id, attachments);
+  }
+
+  private validateResolveTargets(id: string, attachments: GraphRenderPassAttachments): void {
+    const resolveTargets = attachments.resolveTargets;
+    if (!resolveTargets) {
+      return;
+    }
+    if (this.device.type !== 'webgpu') {
+      throw new Error(`GPUCommandGraph render node "${id}" resolve targets require WebGPU`);
+    }
+    if (resolveTargets.length !== attachments.colorAttachments.length) {
+      throw new Error(
+        `GPUCommandGraph render node "${id}" requires one resolve entry per color attachment`
+      );
+    }
+    for (let index = 0; index < resolveTargets.length; index++) {
+      const target = resolveTargets[index];
+      if (!target) {
+        continue;
+      }
+      const source = attachments.colorAttachments[index];
+      this.assertTexture(target.texture);
+      if (
+        source.texture.samples <= 1 ||
+        target.texture.samples !== 1 ||
+        source.format !== target.format ||
+        source.width !== target.width ||
+        source.height !== target.height
+      ) {
+        throw new Error(
+          `GPUCommandGraph render node "${id}" resolve target ${index} must match a multisampled source and be single-sampled`
+        );
+      }
+      if (
+        target.dimension !== '2d' ||
+        target.aspect !== 'all' ||
+        target.mipLevelCount !== 1 ||
+        target.arrayLayerCount !== 1
+      ) {
+        throw new Error(
+          `GPUCommandGraph render node "${id}" resolve targets must be single-mip, single-layer 2d color views`
+        );
+      }
+    }
   }
 }
 
@@ -603,6 +670,7 @@ export class CompiledGPUCommandGraph<Parameters = void> {
   private readonly textureTransientAllocations: TextureTransientAllocation[];
   private readonly cachedTextureViews: CachedTextureView[] = [];
   private readonly cachedFramebuffers: CachedFramebuffer[] = [];
+  private readonly lastFrameIds = new Map<GraphTextureHandle, number>();
   private destroyed = false;
 
   /** @internal */
@@ -643,7 +711,10 @@ export class CompiledGPUCommandGraph<Parameters = void> {
 
     const encodingStartTime = getTimestampMilliseconds();
     const importedBuffers = this.resolveImportedBuffers(options.buffers ?? {});
-    const importedTextures = this.resolveImportedTextures(options.textures ?? {});
+    const importedTextures = this.resolveImportedTextures(
+      options.textures ?? {},
+      options.frameTextures ?? {}
+    );
     const getBuffer = (bufferOrView: GraphBufferHandle | GraphDataView): Buffer => {
       const handle = getBufferHandle(bufferOrView);
       const buffer = handle.transient
@@ -669,8 +740,26 @@ export class CompiledGPUCommandGraph<Parameters = void> {
       if (textureOrView instanceof GraphTextureHandle || isDefaultGraphTextureView(textureOrView)) {
         return texture.view;
       }
+      if (textureOrView.texture.frameScoped) {
+        const frameId = this.lastFrameIds.get(textureOrView.texture);
+        for (let index = this.cachedTextureViews.length - 1; index >= 0; index--) {
+          const entry = this.cachedTextureViews[index];
+          if (
+            entry.logicalView === textureOrView &&
+            entry.texture === texture &&
+            entry.frameId !== frameId
+          ) {
+            entry.view.destroy();
+            this.cachedTextureViews.splice(index, 1);
+          }
+        }
+      }
       const cached = this.cachedTextureViews.find(
-        entry => entry.logicalView === textureOrView && entry.texture === texture
+        entry =>
+          entry.logicalView === textureOrView &&
+          entry.texture === texture &&
+          (!textureOrView.texture.frameScoped ||
+            entry.frameId === this.lastFrameIds.get(textureOrView.texture))
       );
       if (cached) {
         return cached.view;
@@ -684,7 +773,14 @@ export class CompiledGPUCommandGraph<Parameters = void> {
         baseArrayLayer: textureOrView.baseArrayLayer,
         arrayLayerCount: textureOrView.arrayLayerCount
       });
-      this.cachedTextureViews.push({logicalView: textureOrView, texture, view});
+      this.cachedTextureViews.push({
+        logicalView: textureOrView,
+        texture,
+        view,
+        ...(textureOrView.texture.frameScoped
+          ? {frameId: this.lastFrameIds.get(textureOrView.texture)}
+          : {})
+      });
       return view;
     };
 
@@ -726,12 +822,21 @@ export class CompiledGPUCommandGraph<Parameters = void> {
               `GPUCommandGraph render node "${node.id}" cannot supply framebuffer with graph attachments`
             );
           }
+          if (node.attachments?.resolveTargets && renderPassProps.resolveTargets !== undefined) {
+            throw new Error(
+              `GPUCommandGraph render node "${node.id}" cannot supply resolveTargets with graph attachments`
+            );
+          }
           const framebuffer = node.attachments
             ? this.getFramebuffer(node.id, node.attachments, getTextureView)
             : undefined;
+          const resolveTargets = node.attachments?.resolveTargets?.map(target =>
+            target ? getTextureView(target) : null
+          );
           const renderPass = commandEncoder.beginRenderPass({
             ...renderPassProps,
-            ...(framebuffer ? {framebuffer} : {})
+            ...(framebuffer ? {framebuffer} : {}),
+            ...(resolveTargets ? {resolveTargets} : {})
           });
           timestamp = getPassTimestamp(renderPass);
           renderPass.pushDebugGroup(node.id);
@@ -815,11 +920,37 @@ export class CompiledGPUCommandGraph<Parameters = void> {
   }
 
   private resolveImportedTextures(
-    overrides: Record<string, GraphImportedTexture>
+    overrides: Record<string, GraphImportedTexture>,
+    frameBindings: Record<string, GraphFrameTextureBinding>
   ): Map<GraphTextureHandle, Texture> {
     const resolved = new Map<GraphTextureHandle, Texture>();
+    const nextFrameIds = new Map<GraphTextureHandle, number>();
+    let encodingFrameId: number | undefined;
     for (const [id, handle] of this.textures) {
       if (handle.transient) {
+        continue;
+      }
+      if (handle.frameScoped) {
+        const binding = frameBindings[id];
+        if (!binding) {
+          throw new Error(`GPUCommandGraph frame texture "${id}" is required`);
+        }
+        if (!Number.isSafeInteger(binding.frameId) || binding.frameId < 0) {
+          throw new Error(`GPUCommandGraph frame texture "${id}" requires a valid frameId`);
+        }
+        if (encodingFrameId !== undefined && binding.frameId !== encodingFrameId) {
+          throw new Error('GPUCommandGraph frame textures must share one frameId per encoding');
+        }
+        encodingFrameId = binding.frameId;
+        const lastFrameId = this.lastFrameIds.get(handle);
+        if (lastFrameId !== undefined && binding.frameId <= lastFrameId) {
+          throw new Error(
+            `GPUCommandGraph frame texture "${id}" frameId ${binding.frameId} is stale; expected greater than ${lastFrameId}`
+          );
+        }
+        validateImportedTexture(binding.texture, handle, this.device);
+        resolved.set(handle, getCoreTexture(binding.texture));
+        nextFrameIds.set(handle, binding.frameId);
         continue;
       }
       const importedTexture = overrides[id] ?? handle.defaultTexture;
@@ -831,9 +962,18 @@ export class CompiledGPUCommandGraph<Parameters = void> {
     }
     for (const id of Object.keys(overrides)) {
       const handle = this.textures.get(id);
-      if (!handle || handle.transient) {
+      if (!handle || handle.transient || handle.frameScoped) {
         throw new Error(`GPUCommandGraph has no imported texture named "${id}"`);
       }
+    }
+    for (const id of Object.keys(frameBindings)) {
+      const handle = this.textures.get(id);
+      if (!handle?.frameScoped) {
+        throw new Error(`GPUCommandGraph has no frame texture named "${id}"`);
+      }
+    }
+    for (const [handle, frameId] of nextFrameIds) {
+      this.lastFrameIds.set(handle, frameId);
     }
     return resolved;
   }

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -33,6 +33,7 @@ export type {
   GraphBufferDescriptor,
   GraphBufferUsage,
   GraphBufferUse,
+  GraphFrameTextureBinding,
   GraphImportedBuffer,
   GraphImportedTexture,
   GraphRenderPassAttachments,

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
@@ -146,6 +146,202 @@ test('GPUCommandGraph validates texture descriptors, views, and imports', async 
   t.end();
 });
 
+test('GPUCommandGraph resolves multisampled color attachments', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const resolvedTexture = device.createTexture({
+    id: 'resolved-color',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER | Texture.COPY_SRC
+  });
+  const graph = new GPUCommandGraph(device, {id: 'multisample-resolve'});
+  const multisampled = graph.createTransientTexture({
+    id: 'multisampled-color',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    samples: 4,
+    usage: Texture.RENDER
+  });
+  const resolved = graph.importTexture(
+    {
+      id: 'resolved-color',
+      format: 'rgba8unorm',
+      width: 4,
+      height: 4,
+      usage: Texture.RENDER | Texture.COPY_SRC
+    },
+    resolvedTexture
+  );
+  graph.addRenderPass({
+    id: 'resolve-red',
+    attachments: {
+      colorAttachments: [graph.createTextureView(multisampled)],
+      resolveTargets: [graph.createTextureView(resolved)]
+    },
+    compile: () => ({
+      getRenderPassProps: () => ({clearColor: [1, 0, 0, 1]}),
+      encode: () => {}
+    })
+  });
+  const compiled = graph.compile();
+  const commandEncoder = device.createCommandEncoder({id: 'multisample-resolve'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+  const pixels = await readPixels(resolvedTexture, 4, 4);
+  t.ok(
+    pixels[0] > 240 && pixels[1] < 10 && pixels[2] < 10,
+    'multisampled clear resolves into the declared single-sample target'
+  );
+  compiled.destroy();
+  t.notOk(resolvedTexture.destroyed, 'resolve target remains caller-owned');
+  resolvedTexture.destroy();
+
+  const invalidGraph = new GPUCommandGraph(device, {id: 'invalid-resolve'});
+  const singleSample = invalidGraph.createTransientTexture({
+    id: 'single-source',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER
+  });
+  const invalidTarget = invalidGraph.createTransientTexture({
+    id: 'single-target',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER
+  });
+  t.throws(
+    () =>
+      invalidGraph.addRenderPass({
+        id: 'invalid-resolve-pass',
+        attachments: {
+          colorAttachments: [invalidGraph.createTextureView(singleSample)],
+          resolveTargets: [invalidGraph.createTextureView(invalidTarget)]
+        },
+        compile: () => ({encode: () => {}})
+      }),
+    /match a multisampled source and be single-sampled/,
+    'single-sample sources cannot declare resolve targets'
+  );
+  t.end();
+});
+
+test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const firstTexture = device.createTexture({
+    id: 'frame-color-0',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER
+  });
+  const secondTexture = device.createTexture({
+    id: 'frame-color-1',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER
+  });
+  const auxiliaryTexture = device.createTexture({
+    id: 'frame-auxiliary',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER
+  });
+  const graph = new GPUCommandGraph(device, {id: 'frame-texture'});
+  const frameColor = graph.importFrameTexture({
+    id: 'frame-color',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER
+  });
+  graph.importFrameTexture({
+    id: 'frame-auxiliary',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER
+  });
+  graph.addRenderPass({
+    id: 'render-frame',
+    attachments: {colorAttachments: [graph.createTextureView(frameColor)]},
+    compile: () => ({encode: () => {}})
+  });
+  const compiled = graph.compile();
+  t.throws(
+    () =>
+      compiled.encode(device.createCommandEncoder({id: 'missing-frame'}), {
+        parameters: undefined
+      }),
+    /frame texture "frame-color" is required/,
+    'frame-scoped imports have no persistent default'
+  );
+  const firstEncoder = device.createCommandEncoder({id: 'frame-0'});
+  compiled.encode(firstEncoder, {
+    parameters: undefined,
+    frameTextures: {
+      ['frame-color']: {texture: firstTexture, frameId: 0},
+      ['frame-auxiliary']: {texture: auxiliaryTexture, frameId: 0}
+    }
+  });
+  device.submit(firstEncoder.finish());
+  t.throws(
+    () =>
+      compiled.encode(device.createCommandEncoder({id: 'stale-frame'}), {
+        parameters: undefined,
+        frameTextures: {
+          ['frame-color']: {texture: firstTexture, frameId: 0},
+          ['frame-auxiliary']: {texture: auxiliaryTexture, frameId: 0}
+        }
+      }),
+    /frameId 0 is stale/,
+    'a consumed frame ID cannot be reused'
+  );
+  t.throws(
+    () =>
+      compiled.encode(device.createCommandEncoder({id: 'mixed-frame'}), {
+        parameters: undefined,
+        frameTextures: {
+          ['frame-color']: {texture: secondTexture, frameId: 1},
+          ['frame-auxiliary']: {texture: auxiliaryTexture, frameId: 2}
+        }
+      }),
+    /must share one frameId/,
+    'all frame-scoped imports in one encoding share a coherent frame ID'
+  );
+  const secondEncoder = device.createCommandEncoder({id: 'frame-1'});
+  compiled.encode(secondEncoder, {
+    parameters: undefined,
+    frameTextures: {
+      ['frame-color']: {texture: secondTexture, frameId: 1},
+      ['frame-auxiliary']: {texture: auxiliaryTexture, frameId: 1}
+    }
+  });
+  device.submit(secondEncoder.finish());
+  compiled.destroy();
+  t.notOk(firstTexture.destroyed, 'first frame texture remains caller-owned');
+  t.notOk(secondTexture.destroyed, 'replacement frame texture remains caller-owned');
+  firstTexture.destroy();
+  secondTexture.destroy();
+  auxiliaryTexture.destroy();
+  t.end();
+});
+
 test('GPUCommandGraph tracks texture subresources and reuses compatible transients', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {

--- a/modules/webgpu/src/adapter/resources/webgpu-render-pass.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-render-pass.ts
@@ -20,6 +20,7 @@ import {WebGPUBuffer} from './webgpu-buffer';
 import {WebGPURenderPipeline} from './webgpu-render-pipeline';
 import {WebGPUQuerySet} from './webgpu-query-set';
 import {WebGPUFramebuffer} from './webgpu-framebuffer';
+import {WebGPUTextureView} from './webgpu-texture-view';
 import {WebGPURenderBundle} from './webgpu-render-bundle';
 import {getCpuHotspotProfiler, getTimestamp} from '../helpers/cpu-hotspot-profiler';
 
@@ -295,6 +296,9 @@ export class WebGPURenderPass extends RenderPass {
           this.props.clearColors?.[index] || this.props.clearColor || RenderPass.defaultClearColor
         ),
         storeOp: this.props.discard ? 'discard' : 'store',
+        resolveTarget: this.props.resolveTargets?.[index]
+          ? (this.props.resolveTargets[index] as WebGPUTextureView).handle
+          : undefined,
         // ...colorAttachment,
         view: colorAttachment.handle
       })


### PR DESCRIPTION
## Goals

- Implement roadmap Tranche 4.3 with explicit multisample resolve and swapchain lifetime contracts.
- Keep canvas acquisition, presentation, submission, and ownership in the application while allowing render targets to participate in command-graph validation and hazards.

## Changes

- Add graph-managed multisample resolve targets with format, extent, sample-count, mip, layer, aspect, usage, and WebGPU validation.
- Extend WebGPU render passes with explicit single-sample resolve views.
- Add `GPUCommandGraph.importFrameTexture()` and `frameTextures` encode bindings. Frame-local imports have no persistent default, require one coherent non-negative frame ID per encoding, and reject stale or repeated IDs.
- Refresh non-default logical views across frame IDs while continuing to borrow every imported texture.
- Migrate the GPU frustum-culling consumer to explicitly acquire and bind its current canvas color and depth textures each frame.
- Expand the command-graph Overview/Concepts documentation and mark Tranche 4.3 implemented in the roadmap.
- Add real WebGPU resolve coverage plus missing-frame, mixed-frame, stale-frame, replacement, and ownership tests.

## Verification

- `nvm use` — passed (`v22.22.1`)
- `yarn lint fix` — passed
- `yarn build` — passed
- `yarn test-headless gpu-command-graph-textures` — passed (8/8)
- `yarn test` — node tests passed (253 passed, 2 skipped); headless tests reached 1,338 passed and 25 skipped, with the pre-existing unrelated `arrow-polygons-storage-test has drawable storage-backed instances` assertion failing in `modules/arrow-layers/test/layers/arrow-layers.spec.ts`
- `yarn website:build` — passed
- `(cd website && yarn build)` — passed

## Review audit

- PRs #2804, #2806, and #2808 currently have no conversation comments, reviews, or unresolved inline threads, so no review replies were required.

## Stack

- Stacked on #2808.
- Tranche 4.4, frame-scoped external-texture contracts, is the next Phase 4 boundary.
