### PR TITLE
feat(experimental): add external texture graph contracts

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1007,7 +1007,7 @@ schedule commitment.
 | 1 — Hardening and observability | GPU timestamps, performance baselines, adapter capability reporting, boundary and overflow validation, memory statistics, and device-loss and resource-lifetime coverage | Implemented | High | Medium |
 | 2 — Reusable visibility workflows | Renderer-independent time-range, bounds, LOD, and selection workflows that publish stable IDs, counts, and indirect commands | Implemented | High | Medium |
 | 3 — Algorithm and table scaling | Multi-chunk coverage, segmented and inclusive scans, weighted statistics, richer histograms, and batch-preserving algorithms | Implemented | High | Large |
-| 4 — Picking and texture coverage | Region picking, asynchronous staging rings, multisample resolves, and frame-scoped swapchain imports implemented; external-texture contracts remain | In progress | Medium | Large |
+| 4 — Picking and texture coverage | Region picking, asynchronous staging rings, multisample resolves, frame-scoped swapchain imports, and sampled-only external-image contracts | Implemented | Medium | Large |
 | 5 — Spatial acceleration | `GPUGridIndex` followed by `GPUBVH`, with explicit build, update, and query costs | Planned | High | Large |
 | 6 — GPUScene | A flat GPU draw database with stable identity, bounds, transforms, grouping, geometry references, and indirect command slots | Planned | High | Large |
 | 7 — API graduation | Stable package contracts, compatibility exports, and a dependency-safe move out of experimental packages | Planned | High | Large |
@@ -1019,7 +1019,7 @@ only when its entry dependency is present and its exit evidence can be produced;
 dependency order, not a schedule commitment. Tranches whose dependencies do not overlap may be
 developed independently.
 
-Tranches 4.1 through 4.3 are implemented; external-texture contracts in Tranche 4.4 are the next
+Phase 4 is implemented through Tranche 4.4. Spatial index construction in Tranche 5.1 is the next
 active boundary.
 
 | Tranche | Outcome | Entry dependency | Impact | Complexity/cost |
@@ -1029,7 +1029,7 @@ active boundary.
 | 4.1 — Region picking | Bounded rectangular picks with stable object and batch IDs, capacity, count, and overflow | Implemented | Medium | Medium |
 | 4.2 — Asynchronous readback ring | Reusable staging slots with backpressure, cancellation, and no mapped-buffer reuse hazards | Implemented | High | Medium |
 | 4.3 — Render-target graph contracts | Multisample resolve and swapchain imports with explicit subresource and frame ownership | Implemented | Medium | Large |
-| 4.4 — External-texture contracts | One-frame external-texture imports with validated access and device-loss behavior | Tranche 4.3 | Medium | Large |
+| 4.4 — External-texture contracts | One-frame external-texture imports with validated access and device-loss behavior | Implemented | Medium | Large |
 | 5.1 — `GPUGridIndex` build/update | Stable cell offsets and object-ID storage with measurable full-build and incremental-update costs | Tranche 3.2 and Phase 1 measurement | High | Large |
 | 5.2 — `GPUGridIndex` query | Bounds, radius, and point queries feeding visibility and region picking in 2D and 3D | Tranche 5.1, Phase 2, and Tranche 4.1 | High | Medium |
 | 5.3 — `GPUBVH` build/refit | Flat BVH storage with explicit rebuild and refit policies | Tranche 5.2 | High | Large |
@@ -1217,9 +1217,9 @@ application or renderer consumer.
 **Entry dependencies:** Phase 1 defines resource-lifetime and asynchronous readback behavior;
 Phase 2 defines stable visible identity.
 
-Region picking, reusable asynchronous staging-buffer rings, multisample resolves, and frame-scoped
-swapchain imports are implemented. External textures remain next so their access, ownership, and
-frame lifetime become equally explicit.
+Region picking, reusable asynchronous staging-buffer rings, multisample resolves, frame-scoped
+swapchain imports, and sampled-only external-image imports are implemented. Their access,
+ownership, and asynchronous or frame lifetime are explicit.
 Callback, highlighting, tooltip, and color-encoded fallback policies remain higher-level workflow
 or application concerns.
 
@@ -1258,13 +1258,23 @@ fail before submission.
 
 #### Tranche 4.4 — External-texture contracts
 
-Represent external textures as frame-scoped imports with access constraints that match WebGPU's
-external-image lifetime. Keep media scheduling, frame acquisition, and fallback conversion outside
-the graph.
+`importExternalTexture()` represents external images as a distinct sampled-only resource rather
+than pretending they are ordinary texture storage. Each encoding requires a fresh concrete
+binding and a strictly increasing frame ID coherent with every other frame resource. Render nodes
+resolve the current snapshot through `getExternalTexture()`; views, storage, copies, attachments,
+and graph ownership are deliberately unavailable. Media scheduling, frame acquisition, and
+fallback conversion stay outside the graph.
 
-**Exit evidence:** Validation prevents persistence into incompatible compiled encodings, tests
-cover replacement and device loss, and a consumer imports successive frames without graph-owned
-destruction or accidental cross-frame reuse.
+This boundary matters for video, camera, and browser-compositor sources. Their native WebGPU path
+can avoid a per-frame copy, but the resulting `texture_external` binding is opaque and short-lived.
+Making that lifetime explicit prevents an application from caching yesterday's browser binding or
+accidentally routing it through APIs that require reusable texture memory. The video-texture
+example demonstrates successive native bindings while retaining an explicit copied WebGL fallback.
+
+**Exit evidence:** Validation prevents persistence into incompatible compiled encodings; common
+device-loss checks cover encoding; replacement, cross-resource frame coherence, stale IDs, fresh
+binding identity, and borrowed destruction are tested; and the video-texture consumer imports
+successive native frames without graph-owned destruction or accidental cross-frame reuse.
 
 **Exit criteria:** Region results preserve stable object and batch identity; repeated picks do not
 serialize rendering on mapped buffers; and resolve, swapchain, and external resources participate

--- a/docs/api-reference/experimental/gpu-primitives/draw-command-buffer.md
+++ b/docs/api-reference/experimental/gpu-primitives/draw-command-buffer.md
@@ -15,6 +15,18 @@ indices. A compute pass can update those fields, and a later render pass can iss
 waiting for the CPU to inspect the result. `DrawCommandBuffer` supplies the exact WebGPU layouts,
 byte offsets, and ownership rules; it does not decide what is visible or record a render pass.
 
+### When to use it
+
+Use an indirect command when the GPU already knows how much work should be drawn. Common examples
+include a visibility workflow that writes the number of accepted instances, a particle simulation
+that creates or removes particles, and a tiled renderer that maintains one command per material or
+draw group. Keeping the count in GPU memory avoids a readback stall between compute and rendering.
+
+Use a normal `draw()` call when the CPU already has the authoritative count and it changes cheaply.
+`DrawCommandBuffer` is deliberately not a scene or batching system: applications still choose the
+geometry, pipelines, resource bindings, command grouping, and the compute operation that updates
+each record.
+
 ```ts
 const commands = new DrawCommandBuffer(device, {
   type: 'draw',

--- a/docs/api-reference/experimental/gpu-primitives/gpu-ancestor-projection.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-ancestor-projection.md
@@ -17,6 +17,18 @@ finds a visible source ID. The output remains source-aligned, so renderers can r
 endpoint without renumbering the original graph. A depth bound and invalid sentinel make cycles,
 missing parents, and malformed chains deterministic GPU data rather than CPU-side exceptions.
 
+### When to use it
+
+Ancestor projection is useful whenever filtering can hide structural intermediates but relationships
+should remain legible. A dependency viewer can reconnect an edge from a hidden operation to its
+visible service or process; an outline can attach annotations to the nearest expanded row; and a
+scene hierarchy can redirect a hidden object's relationship to its visible group. Because IDs stay
+source-aligned, picking and inspection can still recover the original endpoint.
+
+Use [`GPUGraphTraversal`](./gpu-graph-traversal) instead when the question is which nodes are
+reachable through arbitrary edges. Projection follows exactly one parent chain per row and finds a
+representative; it does not select a neighborhood or rewrite the graph.
+
 ```ts
 import {GPUAncestorProjection} from '@luma.gl/experimental';
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -10,7 +10,7 @@ import {GPUDataAnalysisExample} from '@site/src/examples';
 `GPUCommandGraph<Parameters>` declares fixed-capacity WebGPU buffer and texture resources plus
 ordered compute, render, and copy nodes. `compile()` returns a `CompiledGPUCommandGraph` that owns
 transient resources and node state but borrows every import. Render nodes can resolve multisampled
-attachments and consume explicitly numbered, frame-scoped swapchain textures.
+attachments and consume explicitly numbered, frame-scoped swapchain and external-image bindings.
 
 See [Choosing a GPU Data-Processing API](/docs/api-guide/gpu/gpu-data-processing) for guidance on
 when to use a command graph, portable GPGPU evaluators, or lower-level compute helpers.
@@ -31,6 +31,13 @@ texture can remain valid across many encodings, while a canvas texture belongs t
 frame and may be replaced at presentation. `importFrameTexture()` makes that boundary visible:
 every encoding supplies a fresh binding with a strictly increasing frame ID. This catches stale
 swapchain reuse without making the graph responsible for acquisition or presentation.
+
+External images are even narrower than frame textures. A WebGPU `texture_external` is an opaque,
+short-lived sampling snapshot of a video or camera frame—not ordinary texture storage. It cannot
+be a render attachment, storage binding, copy endpoint, or source of graph-created views.
+`importExternalTexture()` therefore gives it a separate sampled-only handle and requires a newly
+acquired `ExternalTexture` on every numbered encoding. The application still owns playback,
+source acquisition, fallback conversion, and destruction.
 
 This example composes reduction, histogram, and grid-binning nodes in one reusable graph:
 
@@ -69,9 +76,10 @@ infers a stable node order, plans transient allocation reuse, creates physical t
 each node's `compile` callback once. The returned `CompiledGPUCommandGraph` can then be encoded
 repeatedly with different parameters and compatible imported-resource replacements.
 
-Imported buffers, textures, `GPUData`, and `GPUVector` chunks are borrowed. The compiled graph owns
-only node-created resources, physical transients, and cached texture views/framebuffers. Calling
-`destroy()` releases those owned resources and never destroys an import.
+Imported buffers, textures, external textures, `GPUData`, and `GPUVector` chunks are borrowed. The
+compiled graph owns only node-created resources, physical transients, and cached texture
+views/framebuffers. Calling `destroy()` releases those owned resources and never destroys an
+import.
 
 ## Buffer APIs
 
@@ -143,6 +151,44 @@ resolve resources. The application acquires the textures before encoding and pre
 submission. The graph validates exact descriptor compatibility and ownership, but never acquires,
 presents, treats an earlier frame binding as reusable, or destroys the imported texture.
 
+### `importExternalTexture(descriptor)`
+
+Declares a frame-scoped, sampled-only external image with fixed width and height. Each encoding
+supplies `externalTextures[id] = {texture, frameId}`. The frame ID must be non-negative, strictly
+increase for that handle, and match every `frameTextures` and `externalTextures` binding supplied
+to the same encoding. The concrete `ExternalTexture` wrapper must also be fresh; incrementing the
+frame ID cannot make an earlier opaque browser binding valid again.
+
+Only render nodes may declare `{externalTexture, usage: 'sampled'}`. Executables resolve the current
+snapshot with `getExternalTexture(handle)`. This intentionally rules out views, copies, storage,
+attachments, transient allocation, and implicit conversion. Use a normal `Texture` import when a
+workflow needs those operations.
+
+```ts
+const video = graph.importExternalTexture({id: 'video', width, height});
+
+graph.addRenderPass({
+  id: 'sample-video',
+  resources: [{externalTexture: video, usage: 'sampled'}],
+  compile: () => ({
+    encode: ({renderPass, getExternalTexture}) => {
+      model.setBindings({videoTexture: getExternalTexture(video)});
+      model.draw(renderPass);
+    }
+  })
+});
+
+const externalTexture = device.createExternalTexture({source: videoElement});
+compiled.encode(device.commandEncoder, {
+  parameters,
+  externalTextures: {video: {texture: externalTexture, frameId}}
+});
+```
+
+Acquire the concrete binding immediately before encoding. Media clocks and decoder queues stay
+outside the graph, and a WebGL or reusable-storage path should copy the source into a normal
+texture explicitly.
+
 ### `createTransientTexture(descriptor)`
 
 Declares graph-owned texture storage. Non-overlapping logical textures reuse one physical texture
@@ -193,9 +239,10 @@ Buffer nodes declare storage, uniform, copy, indirect, vertex, and index uses. T
 as read-write resources. `dependsOn` adds explicit ordering where resources do not express the
 dependency.
 
-Executable contexts expose `getBuffer()`, `getTexture()`, and `getTextureView()`. Concrete texture
-views and framebuffers are cached for repeated encodings and rebuilt when an imported texture is
-replaced. Non-default views over frame-scoped imports are refreshed for each frame ID.
+Executable contexts expose `getBuffer()`, `getTexture()`, `getTextureView()`, and
+`getExternalTexture()`. Concrete ordinary texture views and framebuffers are cached for repeated
+encodings and rebuilt when an imported texture is replaced. Non-default views over frame-scoped
+ordinary textures are refreshed for each frame ID; external textures never enter either cache.
 
 ## Hazards and scheduling
 
@@ -246,6 +293,10 @@ whole-graph and per-node CPU encoding statistics.
 
 `encode()` never submits, maps, reads, or grows resources.
 
+`options.frameTextures` and `options.externalTextures` form one coherent frame transaction. The
+graph validates every binding before advancing its remembered frame IDs, so a rejected replacement
+can be corrected and retried without partially consuming a frame.
+
 If the caller's encoder has a timestamp query set, compute and render passes record timestamp pairs
 without changing graph code. `encoding.canReadGPUTimings` reports whether any pairs were captured.
 After submitting the command buffer, `await encoding.readTimings()` explicitly reads per-node and
@@ -282,4 +333,4 @@ separate values and should not be collapsed into one score.
 ### `destroy()`
 
 Destroys compiled node resources, cached views/framebuffers, and physical transients. Imported
-buffers and textures remain caller-owned.
+buffers, textures, and external-image bindings remain caller-owned.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -26,6 +26,18 @@ Resource-use declarations are both contracts and dependency edges. A storage wri
 read creates a hazard the compiler orders automatically. Imports stay caller-owned, while graph
 transients and node-created pipelines belong to the compiled graph.
 
+### When to use a command graph
+
+A command graph fits repeated, multi-pass work whose capacities and resource shapes are known even
+when frame data changes. Visibility followed by compaction and indirect drawing, simulation followed
+by rendering, picking followed by a bounded copy, and analysis pipelines that share intermediate
+results all benefit from compiling hazards and transient lifetimes once and encoding many times.
+
+Use direct command encoding for a one-off pass or when the complete sequence is already simple and
+local. A graph does not own the frame loop, submission, presentation, application parameters, or
+unbounded allocation. Its value comes from making a reusable dataflow inspectable and validating
+the resource contracts between independently authored nodes.
+
 Render targets need a stricter lifetime distinction than ordinary data textures. An offscreen
 texture can remain valid across many encodings, while a canvas texture belongs to one acquired
 frame and may be replaced at presentation. `importFrameTexture()` makes that boundary visible:
@@ -38,6 +50,22 @@ be a render attachment, storage binding, copy endpoint, or source of graph-creat
 `importExternalTexture()` therefore gives it a separate sampled-only handle and requires a newly
 acquired `ExternalTexture` on every numbered encoding. The application still owns playback,
 source acquisition, fallback conversion, and destruction.
+
+### Choosing a texture lifetime
+
+The import kind communicates why a texture may be reused, replaced, or restricted:
+
+| Texture kind | Best fit | Example |
+| --- | --- | --- |
+| Imported texture | Persistent caller-owned storage | An atlas, uploaded image, history buffer, or offscreen target |
+| Frame texture | Newly acquired renderable storage for one numbered frame | A canvas swapchain color target or matching frame-local depth target |
+| External texture | Newly acquired sampled-only media snapshot | The current video, webcam, or decoded browser media frame |
+| Transient texture | Graph-owned scratch with a compile-time lifetime | An intermediate blur target or multisampled color attachment |
+
+Use a normal imported texture when later passes need copies, storage access, mip generation, or
+reuse across frames. External textures avoid an explicit media-to-texture copy but accept a narrow
+sampling-only lifetime. Frame textures model presentation resources, while transients let the graph
+reuse internal allocations whose logical lifetimes do not overlap.
 
 This example composes reduction, histogram, and grid-binning nodes in one reusable graph:
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-compaction.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-compaction.md
@@ -15,6 +15,17 @@ each selected row its destination index, a scatter copies selected values in sou
 count reports the valid output prefix. For input `[8, 3, 5, 2]` and flags `[1, 0, 1, 0]`, the valid
 output is `[8, 5]` with count `2`; capacity beyond that prefix is unspecified.
 
+### When to use it
+
+Use compaction when a later stage needs a dense work list rather than one flag per source row. It
+can turn a frustum mask into visible object IDs, a brush mask into selected record IDs, or a validity
+mask into jobs for a follow-up compute pass. Writing `count` into a `DrawCommandBuffer` also turns
+the same result directly into an indirect instance list.
+
+Keep the mask un-compacted when downstream shaders already visit every source row or need random
+source-aligned membership tests. Compaction adds scan and scatter work, and only the prefix selected
+by `count` is meaningful; it does not shrink the caller-owned output allocation.
+
 ```ts
 new GPUCompaction({
   id: 'visible-ids',

--- a/docs/api-reference/experimental/gpu-primitives/gpu-graph-traversal.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-graph-traversal.md
@@ -18,6 +18,18 @@ nodes, and expands one frontier per depth. Forward CSR follows outgoing edges; r
 incoming edges. The result is a source-aligned `0`/`1` reachability mask rather than a reordered
 list, so it composes directly with masks and compaction.
 
+### When to use it
+
+Traversal supports focus interactions over an existing graph: show the callers and callees of a
+selected operation, retain every dependency within three hops of an incident, reveal an object's
+incoming references, or propagate a selection through a network. `activeDepth` lets an interaction
+change the visible radius without rebuilding the compiled command graph.
+
+It is not a general shortest-path or ordering API. Use ancestor projection for one canonical parent
+chain, and use a purpose-built graph algorithm when results require distances, weights, or a
+deterministic visit order. The bounded breadth-first contract is designed to produce a membership
+mask for later filtering.
+
 ```ts
 import {GPUGraphTraversal} from '@luma.gl/experimental';
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-grid-aggregation.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-grid-aggregation.md
@@ -16,6 +16,18 @@ Every input row contains a position and one weight. The bounds and grid dimensio
 position to a cell, then `operation` chooses the statistic. Non-finite or out-of-bounds positions
 and non-finite weights are ignored. Exact maximum coordinates enter the final column or row.
 
+### When to use it
+
+Grid aggregation answers spatial questions where every point carries a measurement. Examples
+include mean temperature per map cell, total bytes transferred per screen tile, maximum particle
+speed in a simulation region, and minimum elevation in a terrain overview. The fixed grid produces
+a compact texture-like summary that can drive heatmaps, labels, or a later compute decision.
+
+Use [`GPUGridBinning`](./gpu-grid-binning) for population or occupancy alone. Use
+[`GPUGroupAggregation`](./gpu-group-aggregation) when rows already carry categorical IDs rather
+than continuous positions, and use a spatial index when the application needs the individual
+objects in a queried region instead of one statistic per cell.
+
 `'sum'` is the default. Sum and mean use an atomic compare/exchange addition, so ordinary
 `float32` rounding applies but cross-invocation accumulation order is not promised. Finite inputs
 may overflow a sum or mean to infinity, or produce NaN after opposite-sign overflow. Mean owns one

--- a/docs/api-reference/experimental/gpu-primitives/gpu-grid-binning.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-grid-binning.md
@@ -18,6 +18,18 @@ Counts answer density questions and can feed heatmaps, occupancy tests, or later
 [`GPUGridAggregation`](./gpu-grid-aggregation) when each point should contribute a floating-point
 weight instead of the constant count `1`.
 
+### When to use it
+
+Typical uses include point-density heatmaps, screen-tile occupancy, coarse particle density, and
+finding overloaded spatial cells before a more expensive pass. Because the output size depends on
+the grid rather than the input population, millions of points can become a small summary that is
+cheap to render or read back.
+
+Grid binning intentionally loses object identity. It is the wrong result for “which objects are in
+this cell?”, exact nearest-neighbor queries, or non-rectilinear regions; those require picking or a
+spatial index. Grid resolution is also an application tradeoff: finer grids preserve locality but
+increase clearing, contention, and result storage.
+
 ```ts
 new GPUGridBinning({
   positions,

--- a/docs/api-reference/experimental/gpu-primitives/gpu-group-aggregation.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-group-aggregation.md
@@ -19,6 +19,15 @@ ignored.
 
 ## Concepts
 
+Use grouped aggregation for stable categorical summaries: counts by status, mean latency by
+service, total bytes by protocol, or extrema by rendered material. The group rows remain stable
+while an optional GPU mask changes the participating population, which is especially useful for
+linked charts and legends that must track the same interactive selection as a renderer.
+
+It assumes dense integer category IDs and returns one aggregate per category. Use a histogram for
+numeric intervals, grid aggregation for spatial cells, or sorting when the application needs the
+contributing rows rather than a summary.
+
 ### Categories are identities, not numeric ranges
 
 A numeric histogram partitions an ordered domain into intervals. Category codes instead identify

--- a/docs/api-reference/experimental/gpu-primitives/gpu-hierarchy-layout.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-hierarchy-layout.md
@@ -18,6 +18,18 @@ with one summary height and zero out the remaining children. An exclusive scan t
 into stable row offsets. Updating expansion flags therefore changes layout entirely on the GPU
 without changing source identity.
 
+### When to use it
+
+This layout fits large, regularly grouped views whose expansion state changes more often than their
+source data: process/thread lanes, grouped timelines, layer panels, and batched diagnostic rows.
+The resulting heights and offsets can drive rendering and picking in the same frame without asking
+the CPU to rebuild a visible-row array after every expand or collapse interaction.
+
+The current contract assumes a fixed `childrenPerParent` and one parent level. Use a CPU layout or a
+more general hierarchy algorithm for arbitrary-depth trees, variable child ranges, text measurement,
+or constraints that depend on sibling content. The primitive computes scalar row placement; it does
+not choose styling or animation.
+
 ```ts
 import {GPUHierarchyLayout} from '@luma.gl/experimental';
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-histogram.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-histogram.md
@@ -18,6 +18,14 @@ or `'auto'`, which inserts an extent reduction. Irregular histograms accept expl
 GPU-resident edges. In both forms, the minimum is inclusive, the maximum is included in the final
 bin, and values outside the domain are ignored.
 
+Use histograms to inspect distribution shape without downloading every value: latency tails,
+duration profiles, sensor-value ranges, particle speeds, or selected-value summaries in a linked
+chart. Equal-width bins are convenient for exploratory views over compact domains; irregular edges
+are better when meaningful thresholds or several orders of magnitude must remain visible.
+
+A histogram discards source identity and order. Use group aggregation for named categories, sorting
+for ordered rows, or compaction when the application needs the selected IDs rather than counts.
+
 ### Why irregular edges matter
 
 Equal-width bins work well for compact numeric domains. They are less useful for heavy-tailed

--- a/docs/api-reference/experimental/gpu-primitives/gpu-mask.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-mask.md
@@ -16,6 +16,18 @@ output is canonicalized to `0` or `1`. Boolean composition keeps independent pro
 a viewport test, hierarchy state, and user selection can each own one mask, while downstream scan
 and compaction consume their combined decision without CPU readback.
 
+### When to use it
+
+Masks are the common currency between independent GPU decisions. A renderer can intersect time,
+viewport, hierarchy, and level-of-detail masks; a linked chart can union several selections; and an
+application can subtract muted or invalid rows. Producers remain reusable because none needs to
+know which other filters are active.
+
+Use a mask when downstream work benefits from source-aligned membership. Add
+[`GPUCompaction`](./gpu-compaction) or [`GPUVisibilityWorkflow`](./gpu-visibility-workflow) when the
+consumer instead needs a dense list and count. `GPUMask` only combines existing decisions—it does
+not evaluate geometric, temporal, or application-specific predicates itself.
+
 ```ts
 import {GPUMask} from '@luma.gl/experimental';
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-reduction.md
@@ -16,6 +16,17 @@ A reduction combines many scalar rows into one summary. `sum`, `min`, and `max` 
 higher levels reduce those partial results until one row remains. This fixed tree avoids CPU
 readback and makes the floating-point order repeatable for a fixed input topology.
 
+### When to use it
+
+Reductions answer whole-input questions that should remain on the GPU: compute an automatic chart
+domain, total selected bytes or work, find the largest simulated value, or verify a generated count.
+The one- or two-row result can feed uniforms, histogram domains, allocation decisions with fixed
+capacity, or a small asynchronous readback.
+
+Use grouped, grid, or histogram aggregation when the result must retain categories, spatial cells,
+or a distribution. A reduction deliberately discards row identity and intermediate structure; it
+does not report which row produced a minimum or maximum.
+
 ```ts
 new GPUReduction({input: values, output: extent, operation: 'extent'}).addToGraph(graph);
 ```

--- a/docs/api-reference/experimental/gpu-primitives/gpu-scan.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-scan.md
@@ -24,6 +24,12 @@ A segmented scan restarts that running total within one input. For segment-start
 `[3, 4, 4, 6]`. This is useful for grouped table rows, per-path geometry, per-level layout, and
 other adjacent records that need independent prefixes without separate dispatches.
 
+Choose a scan when each row needs the total contributed by preceding rows. Besides compaction,
+this supports vertex offsets for variable-size geometry, text or path expansion, cumulative
+distributions, grouped layout offsets, and allocation positions in fixed-capacity output. Use a
+reduction when only the final total matters; use compaction when the desired result is already a
+dense list rather than the offsets used to build one.
+
 “Hierarchical” describes how the implementation scales, not another output mode. Each workgroup
 scans a block, higher levels scan the block summaries, and offset passes propagate those totals
 back down. Callers see one logical result even when the input spans many workgroups or vector

--- a/docs/api-reference/experimental/gpu-primitives/gpu-visibility-workflow.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-visibility-workflow.md
@@ -19,6 +19,16 @@ source order, and the GPU-resident count defines the valid prefix of the output.
 that fixed contract without knowing whether rows were rejected by time, bounds, LOD, selection, or
 a combination of them.
 
+Use the workflow when several renderers or examples should share the same fixed visibility
+plumbing. Time-window filtering in a timeline, frustum culling in a 3D view, LOD selection for map
+tiles, and linked-selection filtering can all produce masks independently and receive the same
+stable IDs plus indirect count. This keeps renderer-specific shaders focused on producing predicates
+and consuming identities.
+
+Use `GPUMask` and `GPUCompaction` directly when an application needs different boolean semantics,
+custom outputs, or only one of those stages. The workflow intentionally does not accept arbitrary
+WGSL callbacks: fixed predicate-mask contracts remain easier to compose, validate, and reuse.
+
 ```ts
 import {GPUVisibilityWorkflow} from '@luma.gl/experimental';
 

--- a/examples/api/video-texture/app.ts
+++ b/examples/api/video-texture/app.ts
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import type {NumberArray, VariableShaderType} from '@luma.gl/core';
-import {UniformStore} from '@luma.gl/core';
+import type {ExternalTexture, NumberArray, VariableShaderType} from '@luma.gl/core';
+import {Texture, UniformStore} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, CylinderGeometry, Model, VideoTexture} from '@luma.gl/engine';
+import {GPUCommandGraph, type CompiledGPUCommandGraph} from '@luma.gl/experimental';
 import {Matrix4} from '@math.gl/core';
 import {Input, ALL_FORMATS, BlobSource, VideoSampleSink} from 'mediabunny';
 
@@ -164,6 +165,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   videoSource: LiveVideoSource | null;
   readonly videoTexture: VideoTexture;
   readonly model: Model;
+  private _compiledGraph: CompiledGPUCommandGraph | null = null;
+  private _externalTextureWidth = 0;
+  private _externalTextureHeight = 0;
+  private _frameId = 0;
   private _isFinalized = false;
   private _videoFlipX = 0;
   private _mediabunnySource: MediabunnySource | null = null;
@@ -215,6 +220,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       AppAnimationLoopTemplate.current = null;
     }
     this.model.destroy();
+    this._compiledGraph?.destroy();
     this.videoTexture.destroy();
     this._teardownMediabunny();
     this.videoSource?.destroy();
@@ -243,12 +249,62 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       }
     });
 
-    const renderPass = device.beginRenderPass({
-      clearColor: [0.015, 0.02, 0.05, 1],
-      clearDepth: 1
+    if (device.type === 'webgpu') {
+      const externalTexture = this.videoTexture.resolveTextureBinding({
+        type: 'external-texture',
+        name: 'videoTexture',
+        group: 0,
+        location: 1
+      });
+      if (externalTexture && !(externalTexture instanceof Texture)) {
+        this._ensureExternalTextureGraph(externalTexture);
+        this._compiledGraph!.encode(device.commandEncoder, {
+          parameters: undefined,
+          externalTextures: {
+            video: {texture: externalTexture, frameId: this._frameId++}
+          }
+        });
+      }
+    } else {
+      const renderPass = device.beginRenderPass({
+        clearColor: [0.015, 0.02, 0.05, 1],
+        clearDepth: 1
+      });
+      this.model.draw(renderPass);
+      renderPass.end();
+    }
+  }
+
+  private _ensureExternalTextureGraph(externalTexture: ExternalTexture): void {
+    if (
+      this._compiledGraph &&
+      externalTexture.width === this._externalTextureWidth &&
+      externalTexture.height === this._externalTextureHeight
+    ) {
+      return;
+    }
+    this._compiledGraph?.destroy();
+    const graph = new GPUCommandGraph(this.model.device, {id: 'video-texture-frame'});
+    const externalTextureHandle = graph.importExternalTexture({
+      id: 'video',
+      width: externalTexture.width,
+      height: externalTexture.height
     });
-    this.model.draw(renderPass);
-    renderPass.end();
+    graph.addRenderPass({
+      id: 'render-video-frame',
+      resources: [{externalTexture: externalTextureHandle, usage: 'sampled'}],
+      compile: () => ({
+        getRenderPassProps: () => ({clearColor: [0.015, 0.02, 0.05, 1], clearDepth: 1}),
+        encode: ({renderPass, getExternalTexture}) => {
+          this.model.setBindings({videoTexture: getExternalTexture(externalTextureHandle)});
+          this.model.draw(renderPass);
+        }
+      })
+    });
+    this._compiledGraph = graph.compile();
+    this._externalTextureWidth = externalTexture.width;
+    this._externalTextureHeight = externalTexture.height;
+    this._frameId = 0;
   }
 
   async useCamera(): Promise<void> {

--- a/examples/api/video-texture/package.json
+++ b/examples/api/video-texture/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@luma.gl/core": "9.4.0-alpha.2",
     "@luma.gl/engine": "9.4.0-alpha.2",
+    "@luma.gl/experimental": "9.4.0-alpha.2",
     "@luma.gl/webgl": "9.4.0-alpha.2",
     "@luma.gl/webgpu": "9.4.0-alpha.2",
     "@math.gl/core": "^4.1.0",

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph-compiler.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph-compiler.ts
@@ -14,6 +14,7 @@ import type {
   GraphBufferUsage,
   GraphBufferUse,
   GraphDataView,
+  GraphExternalTextureHandle,
   GraphResourceUse,
   GraphTextureAspect,
   GraphTextureDimension,
@@ -84,6 +85,8 @@ export type GPUCommandGraphCompilation<Parameters> = {
   buffers: Map<string, GraphBufferHandle>;
   /** Snapshot of logical texture resources. */
   textures: Map<string, GraphTextureHandle>;
+  /** Snapshot of logical frame-scoped external-image resources. */
+  externalTextures: Map<string, GraphExternalTextureHandle>;
   /** Nodes and executables in stable topological order. */
   compiledNodes: CompiledNode<Parameters>[];
   /** Logical-to-physical transient buffer mapping. */
@@ -113,6 +116,7 @@ export function compileGPUCommandGraph<Parameters>(props: {
   id: string;
   buffers: Map<string, GraphBufferHandle>;
   textures: Map<string, GraphTextureHandle>;
+  externalTextures: Map<string, GraphExternalTextureHandle>;
   nodes: GPUCommandGraphNode<Parameters>[];
 }): GPUCommandGraphCompilation<Parameters> {
   const nodeOrder = getNodeOrder(props.nodes);
@@ -247,6 +251,7 @@ export function compileGPUCommandGraph<Parameters>(props: {
     id: props.id,
     buffers: new Map(props.buffers),
     textures: new Map(props.textures),
+    externalTextures: new Map(props.externalTextures),
     compiledNodes,
     transientBuffers,
     transientTextures,
@@ -271,6 +276,11 @@ export function getTextureHandle(
 /** Narrows a declared resource use to a buffer use. @internal */
 export function isGraphBufferUse(resource: GraphResourceUse): resource is GraphBufferUse {
   return 'buffer' in resource;
+}
+
+/** Narrows a declared resource use to an ordinary texture use. @internal */
+export function isGraphTextureUse(resource: GraphResourceUse): resource is GraphTextureUse {
+  return 'texture' in resource;
 }
 
 /** Returns whether an access observes existing buffer contents. */
@@ -367,7 +377,7 @@ function getNodeOrder<Parameters>(
           activeBufferReaders.set(handle, new Set());
           lastBufferWriter.set(handle, node.id);
         }
-      } else {
+      } else if (isGraphTextureUse(resource)) {
         const handle = getTextureHandle(resource.texture);
         const history = textureHistory.get(handle) ?? [];
         for (const previous of history) {
@@ -526,7 +536,7 @@ function getTextureTransientAllocationPlan<Parameters>(
   textures: Iterable<GraphTextureHandle>
 ): TextureTransientAllocation[] {
   const lifetimes = getResourceLifetimes(nodes, resource =>
-    isGraphBufferUse(resource) ? null : getTextureHandle(resource.texture)
+    isGraphTextureUse(resource) ? getTextureHandle(resource.texture) : null
   );
   const allocations: TextureTransientAllocation[] = [];
   const transientTextures = Array.from(textures)

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph-types.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph-types.ts
@@ -7,6 +7,7 @@ import type {
   CommandEncoder,
   ComputePass,
   Device,
+  ExternalTexture,
   RenderPass,
   RenderPassProps,
   Texture,
@@ -63,6 +64,24 @@ export type GraphImportedTexture = Texture | DynamicTexture;
 export type GraphFrameTextureBinding = {
   /** Caller-acquired texture valid for this encoding only. */
   texture: GraphImportedTexture;
+  /** Strictly increasing application frame identifier for this compiled graph. */
+  frameId: number;
+};
+
+/** Descriptor for one frame-scoped external-image binding. */
+export type GraphExternalTextureDescriptor = {
+  /** Graph-wide resource identifier. */
+  id: string;
+  /** Expected source width in pixels. */
+  width: number;
+  /** Expected source height in pixels. */
+  height: number;
+};
+
+/** One explicitly numbered external-image binding valid for a single encoding. */
+export type GraphExternalTextureBinding = {
+  /** Fresh caller-acquired external texture for this encoding. */
+  texture: ExternalTexture;
   /** Strictly increasing application frame identifier for this compiled graph. */
   frameId: number;
 };
@@ -302,6 +321,31 @@ export class GraphTextureHandle<Format extends TextureFormat = TextureFormat> {
   }
 }
 
+/**
+ * Opaque frame-scoped external-image binding tracked by a `GPUCommandGraph`.
+ *
+ * External textures are sampled-only browser snapshots. They cannot be viewed, copied, stored,
+ * attached, allocated, or destroyed by the graph.
+ */
+export class GraphExternalTextureHandle {
+  /** Graph-wide resource identifier. */
+  readonly id: string;
+  /** Expected source width in pixels. */
+  readonly width: number;
+  /** Expected source height in pixels. */
+  readonly height: number;
+  /** @internal */
+  readonly graph: GPUCommandGraphOwner;
+
+  /** @internal */
+  constructor(graph: GPUCommandGraphOwner, descriptor: GraphExternalTextureDescriptor) {
+    this.graph = graph;
+    this.id = descriptor.id;
+    this.width = descriptor.width;
+    this.height = descriptor.height;
+  }
+}
+
 /** Subresource range selected by `GPUCommandGraph.createTextureView`. */
 export type GraphTextureViewProps = {
   /** View dimension. Defaults to the dimension implied by the texture. */
@@ -378,8 +422,16 @@ export type GraphTextureUse = {
   usage: GraphTextureUsage;
 };
 
+/** One sampled-only external-image use declared by a graph node. */
+export type GraphExternalTextureUse = {
+  /** Frame-scoped external texture sampled by the node. */
+  externalTexture: GraphExternalTextureHandle;
+  /** External textures expose sampled access only. */
+  usage: 'sampled';
+};
+
 /** One resource use declared by a graph node. */
-export type GraphResourceUse = GraphBufferUse | GraphTextureUse;
+export type GraphResourceUse = GraphBufferUse | GraphTextureUse | GraphExternalTextureUse;
 
 /** Graph-owned texture attachments resolved into a framebuffer for a render node. */
 export type GraphRenderPassAttachments = {
@@ -409,6 +461,8 @@ export type GPUCommandGraphEncodeContext<Parameters> = {
   getTexture: (texture: GraphTextureHandle | GraphTextureView) => Texture;
   /** Resolves and caches the concrete texture view for a logical texture or view. */
   getTextureView: (texture: GraphTextureHandle | GraphTextureView) => TextureView;
+  /** Resolves a frame-scoped external-image handle to its concrete sampled binding. */
+  getExternalTexture: (texture: GraphExternalTextureHandle) => ExternalTexture;
 };
 
 /** Compiled compute-pass callback. */
@@ -597,4 +651,6 @@ export type GPUCommandGraphEncodeOptions<Parameters> = {
   textures?: Record<string, GraphImportedTexture>;
   /** Per-encoding frame-scoped texture bindings keyed by graph resource ID. */
   frameTextures?: Record<string, GraphFrameTextureBinding>;
+  /** Per-encoding frame-scoped external-image bindings keyed by graph resource ID. */
+  externalTextures?: Record<string, GraphExternalTextureBinding>;
 };

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
@@ -730,7 +730,7 @@ export class CompiledGPUCommandGraph<Parameters = void> {
   private readonly cachedFramebuffers: CachedFramebuffer[] = [];
   private readonly lastFrameIds = new Map<GraphTextureHandle, number>();
   private readonly lastExternalTextureFrameIds = new Map<GraphExternalTextureHandle, number>();
-  private readonly lastExternalTextures = new Map<GraphExternalTextureHandle, ExternalTexture>();
+  private readonly consumedExternalTextures = new WeakSet<ExternalTexture>();
   private destroyed = false;
 
   /** @internal */
@@ -784,8 +784,8 @@ export class CompiledGPUCommandGraph<Parameters = void> {
     for (const [handle, nextFrameId] of externalTextureResult.frameIds) {
       this.lastExternalTextureFrameIds.set(handle, nextFrameId);
     }
-    for (const [handle, texture] of externalTextureResult.textures) {
-      this.lastExternalTextures.set(handle, texture);
+    for (const texture of externalTextureResult.textures.values()) {
+      this.consumedExternalTextures.add(texture);
     }
     const importedTextures = importedTextureResult.textures;
     const getBuffer = (bufferOrView: GraphBufferHandle | GraphDataView): Buffer => {
@@ -1068,7 +1068,7 @@ export class CompiledGPUCommandGraph<Parameters = void> {
           `GPUCommandGraph external texture "${id}" frameId ${binding.frameId} is stale; expected greater than ${lastFrameId}`
         );
       }
-      if (this.lastExternalTextures.get(handle) === binding.texture) {
+      if (this.consumedExternalTextures.has(binding.texture)) {
         throw new Error(
           `GPUCommandGraph external texture "${id}" requires a fresh binding for each frame`
         );

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
@@ -7,6 +7,7 @@ import type {
   CommandEncoder,
   ComputePass,
   Device,
+  ExternalTexture,
   Framebuffer,
   QuerySet,
   RenderPass,
@@ -27,6 +28,7 @@ import {
   getBufferHandle,
   getTextureHandle,
   isGraphBufferUse,
+  isGraphTextureUse,
   type BufferTransientAllocation,
   type CompiledNode,
   type GPUCommandGraphCompilation,
@@ -35,6 +37,7 @@ import {
 import {
   GraphBufferHandle,
   GraphDataView,
+  GraphExternalTextureHandle,
   GraphTextureHandle,
   GraphTextureView,
   GraphVectorView
@@ -56,6 +59,8 @@ import type {
   GPUCommandGraphTimingReport,
   GraphBufferDescriptor,
   GraphBufferUsage,
+  GraphExternalTextureBinding,
+  GraphExternalTextureDescriptor,
   GraphFrameTextureBinding,
   GraphImportedBuffer,
   GraphImportedTexture,
@@ -70,6 +75,7 @@ import type {
 export {
   GraphBufferHandle,
   GraphDataView,
+  GraphExternalTextureHandle,
   GraphTextureHandle,
   GraphTextureView,
   GraphVectorView
@@ -95,6 +101,9 @@ export type {
   GraphBufferDescriptor,
   GraphBufferUsage,
   GraphBufferUse,
+  GraphExternalTextureBinding,
+  GraphExternalTextureDescriptor,
+  GraphExternalTextureUse,
   GraphFrameTextureBinding,
   GraphImportedBuffer,
   GraphImportedTexture,
@@ -209,6 +218,7 @@ export class GPUCommandGraph<Parameters = void> {
 
   private readonly buffers = new Map<string, GraphBufferHandle>();
   private readonly textures = new Map<string, GraphTextureHandle>();
+  private readonly externalTextures = new Map<string, GraphExternalTextureHandle>();
   private readonly tableBufferHandles = new Map<Buffer, GraphBufferHandle>();
   private readonly nodes: GPUCommandGraphNode<Parameters>[] = [];
   private readonly nodeIds = new Set<string>();
@@ -377,6 +387,18 @@ export class GPUCommandGraph<Parameters = void> {
   }
 
   /**
+   * Declares a sampled external image that must be replaced for every numbered encoding frame.
+   *
+   * Media scheduling and acquisition remain caller-owned. The graph borrows each fresh binding
+   * for one encoding and never destroys it.
+   */
+  importExternalTexture(descriptor: GraphExternalTextureDescriptor): GraphExternalTextureHandle {
+    this.assertMutable();
+    validateGraphExternalTextureDescriptor(descriptor, this.device);
+    return this.addExternalTexture(new GraphExternalTextureHandle(this, descriptor));
+  }
+
+  /**
    * Declares one graph-owned fixed-size transient texture.
    *
    * Descriptor-compatible textures with disjoint compiled lifetimes may share an allocation.
@@ -475,6 +497,7 @@ export class GPUCommandGraph<Parameters = void> {
         id: this.id,
         buffers: this.buffers,
         textures: this.textures,
+        externalTextures: this.externalTextures,
         nodes: this.nodes
       })
     );
@@ -493,11 +516,19 @@ export class GPUCommandGraph<Parameters = void> {
         const buffer = getBufferHandle(resource.buffer);
         this.assertBuffer(buffer);
         validateBufferUseAgainstDescriptor(buffer, resource.usage);
-      } else {
+      } else if (isGraphTextureUse(resource)) {
         const texture = getTextureHandle(resource.texture);
         this.assertTexture(texture);
         validateTextureUseAgainstDescriptor(texture, resource.usage);
         validateTextureViewForUsage(resource.texture, resource.usage);
+      } else {
+        this.assertExternalTexture(resource.externalTexture);
+        if (resource.usage !== 'sampled') {
+          throw new Error('GPUCommandGraph external textures support sampled access only');
+        }
+        if (node.type !== 'render') {
+          throw new Error('GPUCommandGraph external textures can be sampled only by render nodes');
+        }
       }
     }
     this.nodeIds.add(node.id);
@@ -505,7 +536,11 @@ export class GPUCommandGraph<Parameters = void> {
   }
 
   private addBuffer(buffer: GraphBufferHandle): GraphBufferHandle {
-    if (this.buffers.has(buffer.id) || this.textures.has(buffer.id)) {
+    if (
+      this.buffers.has(buffer.id) ||
+      this.textures.has(buffer.id) ||
+      this.externalTextures.has(buffer.id)
+    ) {
       throw new Error(`GPUCommandGraph resource id "${buffer.id}" is already in use`);
     }
     this.buffers.set(buffer.id, buffer);
@@ -515,10 +550,26 @@ export class GPUCommandGraph<Parameters = void> {
   private addTexture<Format extends TextureFormat>(
     texture: GraphTextureHandle<Format>
   ): GraphTextureHandle<Format> {
-    if (this.buffers.has(texture.id) || this.textures.has(texture.id)) {
+    if (
+      this.buffers.has(texture.id) ||
+      this.textures.has(texture.id) ||
+      this.externalTextures.has(texture.id)
+    ) {
       throw new Error(`GPUCommandGraph resource id "${texture.id}" is already in use`);
     }
     this.textures.set(texture.id, texture);
+    return texture;
+  }
+
+  private addExternalTexture(texture: GraphExternalTextureHandle): GraphExternalTextureHandle {
+    if (
+      this.buffers.has(texture.id) ||
+      this.textures.has(texture.id) ||
+      this.externalTextures.has(texture.id)
+    ) {
+      throw new Error(`GPUCommandGraph resource id "${texture.id}" is already in use`);
+    }
+    this.externalTextures.set(texture.id, texture);
     return texture;
   }
 
@@ -556,6 +607,12 @@ export class GPUCommandGraph<Parameters = void> {
   private assertTexture(texture: GraphTextureHandle): void {
     if (texture.graph !== this || this.textures.get(texture.id) !== texture) {
       throw new Error(`Graph texture "${texture.id}" does not belong to ${this.id}`);
+    }
+  }
+
+  private assertExternalTexture(texture: GraphExternalTextureHandle): void {
+    if (texture.graph !== this || this.externalTextures.get(texture.id) !== texture) {
+      throw new Error(`Graph external texture "${texture.id}" does not belong to ${this.id}`);
     }
   }
 
@@ -663,6 +720,7 @@ export class CompiledGPUCommandGraph<Parameters = void> {
 
   private readonly buffers: Map<string, GraphBufferHandle>;
   private readonly textures: Map<string, GraphTextureHandle>;
+  private readonly externalTextures: Map<string, GraphExternalTextureHandle>;
   private readonly compiledNodes: CompiledNode<Parameters>[];
   private readonly transientBuffers: Map<GraphBufferHandle, Buffer>;
   private readonly transientTextures: Map<GraphTextureHandle, Texture>;
@@ -671,6 +729,8 @@ export class CompiledGPUCommandGraph<Parameters = void> {
   private readonly cachedTextureViews: CachedTextureView[] = [];
   private readonly cachedFramebuffers: CachedFramebuffer[] = [];
   private readonly lastFrameIds = new Map<GraphTextureHandle, number>();
+  private readonly lastExternalTextureFrameIds = new Map<GraphExternalTextureHandle, number>();
+  private readonly lastExternalTextures = new Map<GraphExternalTextureHandle, ExternalTexture>();
   private destroyed = false;
 
   /** @internal */
@@ -679,6 +739,7 @@ export class CompiledGPUCommandGraph<Parameters = void> {
     this.id = props.id;
     this.buffers = props.buffers;
     this.textures = props.textures;
+    this.externalTextures = props.externalTextures;
     this.compiledNodes = props.compiledNodes;
     this.transientBuffers = props.transientBuffers;
     this.transientTextures = props.transientTextures;
@@ -711,10 +772,22 @@ export class CompiledGPUCommandGraph<Parameters = void> {
 
     const encodingStartTime = getTimestampMilliseconds();
     const importedBuffers = this.resolveImportedBuffers(options.buffers ?? {});
-    const importedTextures = this.resolveImportedTextures(
+    validateEncodingFrameId(options.frameTextures ?? {}, options.externalTextures ?? {});
+    const importedTextureResult = this.resolveImportedTextures(
       options.textures ?? {},
       options.frameTextures ?? {}
     );
+    const externalTextureResult = this.resolveExternalTextures(options.externalTextures ?? {});
+    for (const [handle, nextFrameId] of importedTextureResult.frameIds) {
+      this.lastFrameIds.set(handle, nextFrameId);
+    }
+    for (const [handle, nextFrameId] of externalTextureResult.frameIds) {
+      this.lastExternalTextureFrameIds.set(handle, nextFrameId);
+    }
+    for (const [handle, texture] of externalTextureResult.textures) {
+      this.lastExternalTextures.set(handle, texture);
+    }
+    const importedTextures = importedTextureResult.textures;
     const getBuffer = (bufferOrView: GraphBufferHandle | GraphDataView): Buffer => {
       const handle = getBufferHandle(bufferOrView);
       const buffer = handle.transient
@@ -783,13 +856,21 @@ export class CompiledGPUCommandGraph<Parameters = void> {
       });
       return view;
     };
+    const getExternalTexture = (handle: GraphExternalTextureHandle): ExternalTexture => {
+      const texture = externalTextureResult.textures.get(handle);
+      if (!texture) {
+        throw new Error(`GPUCommandGraph external texture "${handle.id}" is not bound`);
+      }
+      return texture;
+    };
 
     const baseContext: GPUCommandGraphEncodeContext<Parameters> = {
       commandEncoder,
       parameters: options.parameters,
       getBuffer,
       getTexture,
-      getTextureView
+      getTextureView,
+      getExternalTexture
     };
 
     const encodedNodes: EncodedGPUCommandGraphNode[] = [];
@@ -922,10 +1003,12 @@ export class CompiledGPUCommandGraph<Parameters = void> {
   private resolveImportedTextures(
     overrides: Record<string, GraphImportedTexture>,
     frameBindings: Record<string, GraphFrameTextureBinding>
-  ): Map<GraphTextureHandle, Texture> {
+  ): {
+    textures: Map<GraphTextureHandle, Texture>;
+    frameIds: Map<GraphTextureHandle, number>;
+  } {
     const resolved = new Map<GraphTextureHandle, Texture>();
     const nextFrameIds = new Map<GraphTextureHandle, number>();
-    let encodingFrameId: number | undefined;
     for (const [id, handle] of this.textures) {
       if (handle.transient) {
         continue;
@@ -935,13 +1018,6 @@ export class CompiledGPUCommandGraph<Parameters = void> {
         if (!binding) {
           throw new Error(`GPUCommandGraph frame texture "${id}" is required`);
         }
-        if (!Number.isSafeInteger(binding.frameId) || binding.frameId < 0) {
-          throw new Error(`GPUCommandGraph frame texture "${id}" requires a valid frameId`);
-        }
-        if (encodingFrameId !== undefined && binding.frameId !== encodingFrameId) {
-          throw new Error('GPUCommandGraph frame textures must share one frameId per encoding');
-        }
-        encodingFrameId = binding.frameId;
         const lastFrameId = this.lastFrameIds.get(handle);
         if (lastFrameId !== undefined && binding.frameId <= lastFrameId) {
           throw new Error(
@@ -972,10 +1048,41 @@ export class CompiledGPUCommandGraph<Parameters = void> {
         throw new Error(`GPUCommandGraph has no frame texture named "${id}"`);
       }
     }
-    for (const [handle, frameId] of nextFrameIds) {
-      this.lastFrameIds.set(handle, frameId);
+    return {textures: resolved, frameIds: nextFrameIds};
+  }
+
+  private resolveExternalTextures(bindings: Record<string, GraphExternalTextureBinding>): {
+    textures: Map<GraphExternalTextureHandle, ExternalTexture>;
+    frameIds: Map<GraphExternalTextureHandle, number>;
+  } {
+    const textures = new Map<GraphExternalTextureHandle, ExternalTexture>();
+    const frameIds = new Map<GraphExternalTextureHandle, number>();
+    for (const [id, handle] of this.externalTextures) {
+      const binding = bindings[id];
+      if (!binding) {
+        throw new Error(`GPUCommandGraph external texture "${id}" is required`);
+      }
+      const lastFrameId = this.lastExternalTextureFrameIds.get(handle);
+      if (lastFrameId !== undefined && binding.frameId <= lastFrameId) {
+        throw new Error(
+          `GPUCommandGraph external texture "${id}" frameId ${binding.frameId} is stale; expected greater than ${lastFrameId}`
+        );
+      }
+      if (this.lastExternalTextures.get(handle) === binding.texture) {
+        throw new Error(
+          `GPUCommandGraph external texture "${id}" requires a fresh binding for each frame`
+        );
+      }
+      validateImportedExternalTexture(binding.texture, handle, this.device);
+      textures.set(handle, binding.texture);
+      frameIds.set(handle, binding.frameId);
     }
-    return resolved;
+    for (const id of Object.keys(bindings)) {
+      if (!this.externalTextures.has(id)) {
+        throw new Error(`GPUCommandGraph has no external texture named "${id}"`);
+      }
+    }
+    return {textures, frameIds};
   }
 
   private getFramebuffer(
@@ -1032,6 +1139,26 @@ function getCoreTexture(texture: GraphImportedTexture): Texture {
   return texture;
 }
 
+/** Ensures all ephemeral image imports belong to one explicit application frame. */
+function validateEncodingFrameId(
+  frameTextures: Record<string, GraphFrameTextureBinding>,
+  externalTextures: Record<string, GraphExternalTextureBinding>
+): void {
+  let encodingFrameId: number | undefined;
+  for (const [id, binding] of [
+    ...Object.entries(frameTextures),
+    ...Object.entries(externalTextures)
+  ]) {
+    if (!Number.isSafeInteger(binding.frameId) || binding.frameId < 0) {
+      throw new Error(`GPUCommandGraph frame resource "${id}" requires a valid frameId`);
+    }
+    if (encodingFrameId !== undefined && binding.frameId !== encodingFrameId) {
+      throw new Error('GPUCommandGraph frame resources must share one frameId per encoding');
+    }
+    encodingFrameId = binding.frameId;
+  }
+}
+
 /** Returns a portable timestamp pair recorded by one render or compute pass. */
 function getPassTimestamp(
   pass: ComputePass | RenderPass
@@ -1086,6 +1213,34 @@ function validateGraphBufferDescriptor(descriptor: GraphBufferDescriptor, device
   }
   if (!Number.isSafeInteger(descriptor.usage) || descriptor.usage <= 0) {
     throw new Error(`GPUCommandGraph buffer "${descriptor.id}" requires buffer usage flags`);
+  }
+}
+
+/** Validates the stable metadata used to check successive external-image snapshots. */
+function validateGraphExternalTextureDescriptor(
+  descriptor: GraphExternalTextureDescriptor,
+  device: Device
+): void {
+  if (!descriptor.id) {
+    throw new Error('GPUCommandGraph external texture id is required');
+  }
+  for (const [name, value] of Object.entries({
+    width: descriptor.width,
+    height: descriptor.height
+  })) {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new Error(
+        `GPUCommandGraph external texture "${descriptor.id}" ${name} must be a positive safe integer`
+      );
+    }
+  }
+  if (
+    descriptor.width > device.limits.maxTextureDimension2D ||
+    descriptor.height > device.limits.maxTextureDimension2D
+  ) {
+    throw new Error(
+      `GPUCommandGraph external texture "${descriptor.id}" exceeds device dimension limits`
+    );
   }
 }
 
@@ -1287,6 +1442,27 @@ function validateImportedTexture(
   }
   if ((texture.props.usage & descriptor.usage) !== descriptor.usage) {
     throw new Error(`GPUCommandGraph texture "${descriptor.id}" has incompatible usage flags`);
+  }
+}
+
+/** Validates one opaque, sampled-only external-image snapshot. */
+function validateImportedExternalTexture(
+  texture: ExternalTexture,
+  descriptor: GraphExternalTextureHandle,
+  device: Device
+): void {
+  if (texture.device !== device) {
+    throw new Error(
+      `GPUCommandGraph external texture "${descriptor.id}" belongs to another device`
+    );
+  }
+  if (texture.destroyed) {
+    throw new Error(`GPUCommandGraph external texture "${descriptor.id}" has been destroyed`);
+  }
+  if (texture.width !== descriptor.width || texture.height !== descriptor.height) {
+    throw new Error(
+      `GPUCommandGraph external texture "${descriptor.id}" has incompatible dimensions (${texture.width}x${texture.height} !== ${descriptor.width}x${descriptor.height})`
+    );
   }
 }
 

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -8,6 +8,7 @@ export {
   GPUCommandGraphEncoding,
   GraphBufferHandle,
   GraphDataView,
+  GraphExternalTextureHandle,
   GraphTextureHandle,
   GraphTextureView,
   GraphVectorView
@@ -33,6 +34,9 @@ export type {
   GraphBufferDescriptor,
   GraphBufferUsage,
   GraphBufferUse,
+  GraphExternalTextureBinding,
+  GraphExternalTextureDescriptor,
+  GraphExternalTextureUse,
   GraphFrameTextureBinding,
   GraphImportedBuffer,
   GraphImportedTexture,

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
@@ -3,7 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {Buffer, Texture, type Device} from '@luma.gl/core';
+import {
+  Buffer,
+  ExternalTexture,
+  Sampler,
+  Texture,
+  type Device,
+  type SamplerProps
+} from '@luma.gl/core';
 import {Computation, Model} from '@luma.gl/engine';
 import {
   decodeGPUIndexPickInfo,
@@ -14,6 +21,24 @@ import {
   INDEX_PICKING_READBACK_BYTE_LENGTH
 } from '@luma.gl/experimental';
 import {getNullTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+/** Metadata-only external texture used to test graph contracts without importing browser video. */
+class TestExternalTexture extends ExternalTexture {
+  readonly device: Device;
+  readonly handle = null;
+  sampler: Sampler;
+
+  constructor(device: Device, sampler: Sampler, id: string, width: number, height: number) {
+    super(device, {id, width, height});
+    this.device = device;
+    this.sampler = sampler;
+  }
+
+  setSampler(sampler: Sampler | SamplerProps): this {
+    this.sampler = sampler instanceof Sampler ? sampler : this.device.createSampler(sampler);
+    return this;
+  }
+}
 
 test('GPUCommandGraph validates texture descriptors, views, and imports', async t => {
   const device = await getWebGPUTestDevice();
@@ -349,21 +374,13 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
     t.end();
     return;
   }
-  const makeExternalTexture = (id: string) =>
-    device.createExternalTexture({
-      id,
-      handle: {} as GPUExternalTexture,
-      width: 4,
-      height: 4
-    });
+  const externalTextureSampler = device.createSampler({id: 'external-texture-test-sampler'});
+  const makeExternalTexture = (id: string, width = 4, height = 4) => {
+    return new TestExternalTexture(device, externalTextureSampler, id, width, height);
+  };
   const firstExternalTexture = makeExternalTexture('external-frame-0');
   const secondExternalTexture = makeExternalTexture('external-frame-1');
-  const wrongSizeExternalTexture = device.createExternalTexture({
-    id: 'external-wrong-size',
-    handle: {} as GPUExternalTexture,
-    width: 8,
-    height: 4
-  });
+  const wrongSizeExternalTexture = makeExternalTexture('external-wrong-size', 8, 4);
   const frameTexture = device.createTexture({
     id: 'external-frame-color',
     format: 'rgba8unorm',
@@ -378,13 +395,14 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
     'external texture descriptors require positive fixed dimensions'
   );
   const externalTexture = graph.importExternalTexture({id: 'video', width: 4, height: 4});
-  graph.importFrameTexture({
+  const frameTextureHandle = graph.importFrameTexture({
     id: 'color',
     format: 'rgba8unorm',
     width: 4,
     height: 4,
     usage: Texture.RENDER
   });
+  const frameTextureView = graph.createTextureView(frameTextureHandle);
   const resolvedExternalTextures: unknown[] = [];
   t.throws(
     () =>
@@ -398,6 +416,7 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
   );
   graph.addRenderPass({
     id: 'sample-video',
+    attachments: {colorAttachments: [frameTextureView]},
     resources: [{externalTexture, usage: 'sampled'}],
     compile: () => ({
       encode: ({getExternalTexture}) =>
@@ -405,18 +424,21 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
     })
   });
   const compiled = graph.compile();
+  const missingFrameEncoder = device.createCommandEncoder({id: 'missing-external-frame'});
   t.throws(
     () =>
-      compiled.encode(device.createCommandEncoder({id: 'missing-external-frame'}), {
+      compiled.encode(missingFrameEncoder, {
         parameters: undefined,
         frameTextures: {color: {texture: frameTexture, frameId: 0}}
       }),
     /external texture "video" is required/,
     'external texture imports have no persistent default'
   );
+  missingFrameEncoder.destroy();
+  const wrongSizeEncoder = device.createCommandEncoder({id: 'wrong-size-external-frame'});
   t.throws(
     () =>
-      compiled.encode(device.createCommandEncoder({id: 'wrong-size-external-frame'}), {
+      compiled.encode(wrongSizeEncoder, {
         parameters: undefined,
         frameTextures: {color: {texture: frameTexture, frameId: 0}},
         externalTextures: {video: {texture: wrongSizeExternalTexture, frameId: 0}}
@@ -424,15 +446,19 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
     /incompatible dimensions/,
     'external frame dimensions must match the compiled contract'
   );
-  compiled.encode(device.createCommandEncoder({id: 'external-frame-0'}), {
+  wrongSizeEncoder.destroy();
+  const firstFrameEncoder = device.createCommandEncoder({id: 'external-frame-0'});
+  compiled.encode(firstFrameEncoder, {
     parameters: undefined,
     frameTextures: {color: {texture: frameTexture, frameId: 0}},
     externalTextures: {video: {texture: firstExternalTexture, frameId: 0}}
   });
+  firstFrameEncoder.destroy();
   t.equal(resolvedExternalTextures[0], firstExternalTexture, 'first frame resolves its snapshot');
+  const reusedFrameEncoder = device.createCommandEncoder({id: 'reused-external-frame'});
   t.throws(
     () =>
-      compiled.encode(device.createCommandEncoder({id: 'reused-external-frame'}), {
+      compiled.encode(reusedFrameEncoder, {
         parameters: undefined,
         frameTextures: {color: {texture: frameTexture, frameId: 1}},
         externalTextures: {video: {texture: firstExternalTexture, frameId: 1}}
@@ -440,9 +466,11 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
     /requires a fresh binding/,
     'the same opaque external binding cannot cross frame boundaries'
   );
+  reusedFrameEncoder.destroy();
+  const mixedFrameEncoder = device.createCommandEncoder({id: 'mixed-external-frame'});
   t.throws(
     () =>
-      compiled.encode(device.createCommandEncoder({id: 'mixed-external-frame'}), {
+      compiled.encode(mixedFrameEncoder, {
         parameters: undefined,
         frameTextures: {color: {texture: frameTexture, frameId: 1}},
         externalTextures: {video: {texture: secondExternalTexture, frameId: 2}}
@@ -450,11 +478,14 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
     /must share one frameId/,
     'ordinary and external frame imports share one coherent frame ID'
   );
-  compiled.encode(device.createCommandEncoder({id: 'external-frame-1'}), {
+  mixedFrameEncoder.destroy();
+  const secondFrameEncoder = device.createCommandEncoder({id: 'external-frame-1'});
+  compiled.encode(secondFrameEncoder, {
     parameters: undefined,
     frameTextures: {color: {texture: frameTexture, frameId: 1}},
     externalTextures: {video: {texture: secondExternalTexture, frameId: 1}}
   });
+  secondFrameEncoder.destroy();
   t.equal(
     resolvedExternalTextures[1],
     secondExternalTexture,
@@ -467,6 +498,7 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
   secondExternalTexture.destroy();
   wrongSizeExternalTexture.destroy();
   frameTexture.destroy();
+  externalTextureSampler.destroy();
   t.end();
 });
 

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
@@ -491,6 +491,20 @@ test('GPUCommandGraph enforces sampled-only external texture frames', async t =>
     secondExternalTexture,
     'the next frame resolves a fresh binding'
   );
+  const nonconsecutiveReuseEncoder = device.createCommandEncoder({
+    id: 'nonconsecutive-reused-external-frame'
+  });
+  t.throws(
+    () =>
+      compiled.encode(nonconsecutiveReuseEncoder, {
+        parameters: undefined,
+        frameTextures: {color: {texture: frameTexture, frameId: 2}},
+        externalTextures: {video: {texture: firstExternalTexture, frameId: 2}}
+      }),
+    /requires a fresh binding/,
+    'an expired binding cannot be reused after an intervening frame'
+  );
+  nonconsecutiveReuseEncoder.destroy();
   compiled.destroy();
   t.notOk(firstExternalTexture.destroyed, 'compiled graph leaves external bindings caller-owned');
   t.notOk(secondExternalTexture.destroyed, 'replacement external binding remains caller-owned');

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
@@ -342,6 +342,134 @@ test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
   t.end();
 });
 
+test('GPUCommandGraph enforces sampled-only external texture frames', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const makeExternalTexture = (id: string) =>
+    device.createExternalTexture({
+      id,
+      handle: {} as GPUExternalTexture,
+      width: 4,
+      height: 4
+    });
+  const firstExternalTexture = makeExternalTexture('external-frame-0');
+  const secondExternalTexture = makeExternalTexture('external-frame-1');
+  const wrongSizeExternalTexture = device.createExternalTexture({
+    id: 'external-wrong-size',
+    handle: {} as GPUExternalTexture,
+    width: 8,
+    height: 4
+  });
+  const frameTexture = device.createTexture({
+    id: 'external-frame-color',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER
+  });
+  const graph = new GPUCommandGraph(device, {id: 'external-texture'});
+  t.throws(
+    () => graph.importExternalTexture({id: 'invalid-video', width: 0, height: 4}),
+    /positive safe integer/,
+    'external texture descriptors require positive fixed dimensions'
+  );
+  const externalTexture = graph.importExternalTexture({id: 'video', width: 4, height: 4});
+  graph.importFrameTexture({
+    id: 'color',
+    format: 'rgba8unorm',
+    width: 4,
+    height: 4,
+    usage: Texture.RENDER
+  });
+  const resolvedExternalTextures: unknown[] = [];
+  t.throws(
+    () =>
+      graph.addComputePass({
+        id: 'invalid-external-compute',
+        resources: [{externalTexture, usage: 'sampled'}],
+        compile: () => ({encode: () => {}})
+      }),
+    /only by render nodes/,
+    'external texture bindings cannot leak into incompatible pass types'
+  );
+  graph.addRenderPass({
+    id: 'sample-video',
+    resources: [{externalTexture, usage: 'sampled'}],
+    compile: () => ({
+      encode: ({getExternalTexture}) =>
+        void resolvedExternalTextures.push(getExternalTexture(externalTexture))
+    })
+  });
+  const compiled = graph.compile();
+  t.throws(
+    () =>
+      compiled.encode(device.createCommandEncoder({id: 'missing-external-frame'}), {
+        parameters: undefined,
+        frameTextures: {color: {texture: frameTexture, frameId: 0}}
+      }),
+    /external texture "video" is required/,
+    'external texture imports have no persistent default'
+  );
+  t.throws(
+    () =>
+      compiled.encode(device.createCommandEncoder({id: 'wrong-size-external-frame'}), {
+        parameters: undefined,
+        frameTextures: {color: {texture: frameTexture, frameId: 0}},
+        externalTextures: {video: {texture: wrongSizeExternalTexture, frameId: 0}}
+      }),
+    /incompatible dimensions/,
+    'external frame dimensions must match the compiled contract'
+  );
+  compiled.encode(device.createCommandEncoder({id: 'external-frame-0'}), {
+    parameters: undefined,
+    frameTextures: {color: {texture: frameTexture, frameId: 0}},
+    externalTextures: {video: {texture: firstExternalTexture, frameId: 0}}
+  });
+  t.equal(resolvedExternalTextures[0], firstExternalTexture, 'first frame resolves its snapshot');
+  t.throws(
+    () =>
+      compiled.encode(device.createCommandEncoder({id: 'reused-external-frame'}), {
+        parameters: undefined,
+        frameTextures: {color: {texture: frameTexture, frameId: 1}},
+        externalTextures: {video: {texture: firstExternalTexture, frameId: 1}}
+      }),
+    /requires a fresh binding/,
+    'the same opaque external binding cannot cross frame boundaries'
+  );
+  t.throws(
+    () =>
+      compiled.encode(device.createCommandEncoder({id: 'mixed-external-frame'}), {
+        parameters: undefined,
+        frameTextures: {color: {texture: frameTexture, frameId: 1}},
+        externalTextures: {video: {texture: secondExternalTexture, frameId: 2}}
+      }),
+    /must share one frameId/,
+    'ordinary and external frame imports share one coherent frame ID'
+  );
+  compiled.encode(device.createCommandEncoder({id: 'external-frame-1'}), {
+    parameters: undefined,
+    frameTextures: {color: {texture: frameTexture, frameId: 1}},
+    externalTextures: {video: {texture: secondExternalTexture, frameId: 1}}
+  });
+  t.equal(
+    resolvedExternalTextures[1],
+    secondExternalTexture,
+    'the next frame resolves a fresh binding'
+  );
+  compiled.destroy();
+  t.notOk(firstExternalTexture.destroyed, 'compiled graph leaves external bindings caller-owned');
+  t.notOk(secondExternalTexture.destroyed, 'replacement external binding remains caller-owned');
+  firstExternalTexture.destroy();
+  secondExternalTexture.destroy();
+  wrongSizeExternalTexture.destroy();
+  frameTexture.destroy();
+  t.end();
+});
+
 test('GPUCommandGraph tracks texture subresources and reuses compatible transients', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16007,6 +16007,7 @@ __metadata:
   dependencies:
     "@luma.gl/core": "npm:9.4.0-alpha.2"
     "@luma.gl/engine": "npm:9.4.0-alpha.2"
+    "@luma.gl/experimental": "npm:9.4.0-alpha.2"
     "@luma.gl/webgl": "npm:9.4.0-alpha.2"
     "@luma.gl/webgpu": "npm:9.4.0-alpha.2"
     "@math.gl/core": "npm:^4.1.0"


### PR DESCRIPTION
## Overview

Completes roadmap Tranche 4.4 by adding explicit, frame-scoped external-image bindings to `GPUCommandGraph`.

## Changes

- adds a distinct `GraphExternalTextureHandle` and `importExternalTexture()` API
- restricts external textures to sampled render-node access, excluding views, storage, copies, attachments, and graph allocation
- requires coherent, strictly increasing frame IDs and a fresh concrete binding for every frame
- validates device ownership, dimensions, destruction, missing bindings, and cross-frame reuse before encoding state advances
- routes the WebGPU video-texture example through the graph while preserving the copied WebGL fallback
- expands the command-graph Overview/Concepts documentation and marks Phase 4 complete

## Ownership and lifecycle

Media scheduling, frame acquisition, fallback conversion, submission, and destruction remain application-owned. The graph borrows external bindings for one encoding and never destroys them.

## Verification

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn build`
- focused WebGPU command-graph texture suite: 9/9 passing
- video-texture Vite production build
- `yarn test`: 253/253 node tests passing; 1338/1340 headless tests passing, with the known unrelated Arrow storage-layer failure and one transient model pipeline timing failure that passed 19/19 on focused rerun
- `yarn website:build`
- `(cd website && yarn build)`

## Stack

Stacked on #2809. The full active stack has been rebased onto the latest `master`.