### PR TITLE
feat(experimental): add GPU grid index queries

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1255,9 +1255,9 @@ swapchain textures to carry one coherent, strictly increasing frame ID per encod
 validates hazards but never acquires, presents, or destroys a swapchain texture on the
 application's behalf.
 
-**Exit evidence:** Compute, render, copy, and resolve nodes reject conflicting subresource access;
-multisample and swapchain examples encode through the graph; stale-frame and ownership mistakes
-fail before submission.
+**Exit evidence:** Compute, render, copy, and resolve nodes order conflicting subresource access;
+multisample and swapchain examples encode through the graph; invalid same-pass access,
+stale-frame, and ownership mistakes fail before submission.
 
 #### Tranche 4.4 — External-texture contracts
 

--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1019,8 +1019,9 @@ only when its entry dependency is present and its exit evidence can be produced;
 dependency order, not a schedule commitment. Tranches whose dependencies do not overlap may be
 developed independently.
 
-Phase 4 is implemented through Tranche 4.4. Compact `GPUGridIndex` construction in Tranche 5.1a is
-implemented; incremental maintenance and query composition remain separate active boundaries.
+Phase 4 is implemented through Tranche 4.4. Compact `GPUGridIndex` construction and conservative
+query primitives are implemented; incremental maintenance and consumer cost comparisons remain
+separate active boundaries.
 
 | Tranche | Outcome | Entry dependency | Impact | Complexity/cost |
 | --- | --- | --- | :---: | :---: |
@@ -1032,7 +1033,8 @@ implemented; incremental maintenance and query composition remain separate activ
 | 4.4 — External-texture contracts | One-frame external-texture imports with validated access and device-loss behavior | Implemented | Medium | Large |
 | 5.1a — `GPUGridIndex` build | Compact stable cell offsets and capacity-bounded object-ID storage for 2D and 3D points | Implemented | High | Medium |
 | 5.1b — `GPUGridIndex` incremental maintenance | Bounded relocation or reserved-cell updates with measured memory and update costs | Tranche 5.1a plus a changing-data consumer | High | Large |
-| 5.2 — `GPUGridIndex` query | Bounds, radius, and point queries feeding visibility and region picking in 2D and 3D | Tranche 5.1a, Phase 2, and Tranche 4.1 | High | Medium |
+| 5.2a — `GPUGridIndex` query | Point, bounds, and radius cell candidates with bounded IDs, masks, count, and overflow | Implemented | High | Medium |
+| 5.2b — Query consumers and cost crossover | 2D and 3D visibility or picking consumers compared with an unindexed scan | Tranche 5.2a plus representative consumers | High | Medium |
 | 5.3 — `GPUBVH` build/refit | Flat BVH storage with explicit rebuild and refit policies | Tranche 5.2 | High | Large |
 | 5.4 — `GPUBVH` query and cost model | Visibility and picking queries with scan/grid/BVH comparison guidance | Tranche 5.3 | High | Medium |
 | 6.1 — Scene storage and updates | Flat stable-ID draw records, bounded update ranges, and explicit CPU/table adapters | Phase 2 and Tranche 5.2 | High | Large |
@@ -1316,9 +1318,19 @@ update costs separately from query cost.
 
 #### Tranche 5.2 — `GPUGridIndex` query
 
+**Status:** Conservative query primitives are implemented; cross-domain consumers and cost
+comparison remain planned.
+
 Add bounds, radius, and point queries whose masks or compacted IDs compose directly with visibility
 and region-picking outputs. Query contracts preserve stable identity and do not require downloading
 candidate lists before filtering or drawing.
+
+`GPUGridIndexQuery` consumes the flat grid storage and a mutable GPU-resident point, bounds, or
+radius query. It publishes capacity-bounded stable candidate IDs, the stored-prefix candidate count,
+propagated index or output overflow, and an optional source-ID-addressed mask. Point queries select
+one cell; bounds and radius queries conservatively select intersecting cells. Exact object tests are
+deliberately a following application or visibility predicate, so the index does not embed one object
+shape or confuse cell overlap with an exact hit.
 
 **Exit evidence:** A 2D and a 3D consumer feed query results into visibility or picking, validate
 against an unindexed GPU scan, and document where index construction becomes worthwhile.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-grid-index-query.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-grid-index-query.md
@@ -1,0 +1,109 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
+# GPUGridIndexQuery
+
+<GPUPrimitivesDocsTabs active="grid-index-query" />
+
+## Overview
+
+`GPUGridIndexQuery` selects stable object IDs from cells intersecting a GPU-resident point, bounds,
+or radius query. It publishes a capacity-bounded candidate list, the full stored-index candidate
+count, an overflow flag, and an optional source-ID-addressed mask. The result feeds visibility,
+compaction, picking policy, or an exact application predicate without CPU readback.
+
+The word **candidate** is essential. A uniform grid indexes cells, not exact object geometry. A
+point query returns every object in the containing cell; bounds and radius queries return every
+object in an intersecting cell. This deliberately permits false positives so the index remains
+independent of whether an ID represents a point, label, particle, span, polygon, or object with its
+own bounds.
+
+## Concepts
+
+### Narrow first, test exactly second
+
+Spatial acceleration is usually a two-stage operation:
+
+```text
+grid cell query → conservative candidate IDs → exact object predicate → visibility or picking
+```
+
+The grid stage should be cheap and reusable. An exact stage can then fetch application-owned data
+for only those candidates: point distance for a radius, object bounds for an intersection, or
+screen-space geometry for picking. Keeping those contracts separate prevents `GPUGridIndexQuery`
+from embedding one object representation or claiming that cell overlap is an exact hit.
+
+This matters most for large, selective queries. If a query covers most cells—or runs only once—an
+unindexed GPU scan may do less total work because it avoids index construction and candidate
+materialization.
+
+### Query kinds
+
+The packed `float32` query view is mutable between graph encodings:
+
+| Kind | Query layout | Cell rule | Typical use |
+| --- | --- | --- | --- |
+| `point` | 2D: `[x, y]`; 3D: `[x, y, z]` | The one cell containing the point | Nearby labels, cursor candidates, simulation lookup |
+| `bounds` | Minima followed by maxima | Every cell touching the query bounds | Rectangle selection, viewport candidates, box neighborhoods |
+| `radius` | Center followed by radius | Every cell whose bounds intersect the circle or sphere | Proximity, collision broad phase, local influence |
+
+Point coordinates use the same boundary rule as construction: a point on an internal boundary
+selects the upper cell, while the domain maximum selects the final cell. Invalid point, reversed
+bounds, non-finite values, and negative radii produce no candidates.
+
+### Lists, masks, and overflow
+
+The candidate `output` preserves stable IDs from `GPUGridIndex`, but atomic append order is
+unspecified. `count` reports how many candidates exist in the stored index prefix even if the
+output list is smaller. `overflow` becomes `1` when either the source index was truncated or the
+candidate output lacks capacity. Source-index overflow is propagated even when the stored prefix
+contains no match, because that apparently empty result may be incomplete.
+
+An optional `outputMask` is cleared on every encoding and sets row `objectId` to `1` when that ID
+fits the mask length. This form composes directly with `GPUMask` and `GPUVisibilityWorkflow` when
+IDs address source rows. Sparse or application-global IDs may exceed the mask; they remain present
+in the candidate list but do not write outside it.
+
+### When to use it
+
+Use candidate lists when the next pass should visit only spatially plausible IDs. Use the mask when
+the next workflow already operates source-aligned over every row. A list is usually better for a
+selective exact test; a mask is convenient for intersecting spatial membership with time, LOD,
+hierarchy, or selection decisions.
+
+Cell size remains the dominant tradeoff. Very small cells increase index offsets, clearing, and
+the number of cells touched by broad queries. Very large cells return many false positives. The
+right size depends on object density, query radius, update rate, and how many queries amortize one
+build; the API does not pretend one grid is universally optimal.
+
+## Usage
+
+```ts
+const index = new GPUGridIndex({
+  positions,
+  gridSize: [64, 64],
+  bounds: [-180, -90, 180, 90],
+  cellOffsets,
+  objectIds: indexedObjectIds,
+  count: indexCount,
+  overflow: indexOverflow
+});
+index.addToGraph(graph);
+
+new GPUGridIndexQuery({
+  index,
+  kind: 'radius',
+  query: centerAndRadius, // packed float32 [x, y, radius]
+  output: candidateIds,
+  count: candidateCount,
+  overflow: candidateOverflow,
+  outputMask: candidateMask
+}).addToGraph(graph);
+```
+
+For three dimensions, a radius query contains `[x, y, z, radius]`; bounds contain
+`[minX, minY, minZ, maxX, maxY, maxZ]`. Updating the query buffer and encoding the compiled graph
+again changes the candidates without rebuilding graph structure.
+
+The primitive neither builds the index nor applies exact object tests. It does not submit, grow
+capacity, sort or deduplicate IDs, or download results. Queries over an overflowed source index are
+explicitly marked incomplete.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -224,6 +224,7 @@
               "api-reference/experimental/gpu-primitives/gpu-grid-binning",
               "api-reference/experimental/gpu-primitives/gpu-grid-aggregation",
               "api-reference/experimental/gpu-primitives/gpu-grid-index",
+              "api-reference/experimental/gpu-primitives/gpu-grid-index-query",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]
@@ -313,6 +314,7 @@
               "api-reference/experimental/gpu-primitives/gpu-grid-binning",
               "api-reference/experimental/gpu-primitives/gpu-grid-aggregation",
               "api-reference/experimental/gpu-primitives/gpu-grid-index",
+              "api-reference/experimental/gpu-primitives/gpu-grid-index-query",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -13,12 +13,12 @@ import {
   GPUHierarchyLayout,
   GPUReadbackRing,
   GPUVisibilityWorkflow,
+  GraphVectorView,
   type CompiledGPUCommandGraph,
   type GraphBufferHandle,
   type GraphBufferUse,
   type GPUReadbackTicket
 } from '@luma.gl/experimental';
-import {GPUData, GPUVector} from '@luma.gl/tables';
 import {ColumnPanel, type Panel} from '@deck.gl-community/panels';
 import {
   ExamplePanelManager,
@@ -538,21 +538,33 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
 
     new GPUHierarchyLayout({
       id: 'trace-process-thread-layout',
-      parentStates: graph.importGPUVector(
+      parentStates: makeUint32GraphVector(
+        graph,
         'process-state-partitions',
-        makeUint32Vector('process states', resources.processStates, processChunkLengths)
+        'process states',
+        handles.processStates,
+        processChunkLengths
       ),
-      childStates: graph.importGPUVector(
+      childStates: makeUint32GraphVector(
+        graph,
         'thread-state-partitions',
-        makeUint32Vector('thread states', resources.threadStates, threadChunkLengths)
+        'thread states',
+        handles.threadStates,
+        threadChunkLengths
       ),
-      heights: graph.importGPUVector(
+      heights: makeUint32GraphVector(
+        graph,
         'thread-height-partitions',
-        makeUint32Vector('thread heights', resources.threadHeights, threadChunkLengths)
+        'thread heights',
+        handles.threadHeights,
+        threadChunkLengths
       ),
-      offsets: graph.importGPUVector(
+      offsets: makeUint32GraphVector(
+        graph,
         'thread-offset-partitions',
-        makeUint32Vector('thread offsets', resources.threadOffsets, threadChunkLengths)
+        'thread offsets',
+        handles.threadOffsets,
+        threadChunkLengths
       ),
       childrenPerParent: TRACE_THREADS_PER_PROCESS,
       expandedChildHeight: TRACE_LANES_PER_THREAD,
@@ -562,44 +574,43 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
 
     new GPUGraphTraversal({
       id: 'trace-selected-dependencies',
-      offsets: graph.importGPUVector(
+      offsets: makeUint32GraphVector(
+        graph,
         'outgoing-offset-partitions',
-        makeUint32Vector(
-          'outgoing offsets',
-          resources.outgoingOffsets,
-          topologyChunkLengths.map(length => length + 1)
-        )
+        'outgoing offsets',
+        handles.outgoingOffsets,
+        topologyChunkLengths.map(length => length + 1)
       ),
-      neighbors: graph.importGPUVector(
+      neighbors: makeUint32GraphVector(
+        graph,
         'outgoing-neighbor-partitions',
-        makeUint32Vector(
-          'outgoing neighbors',
-          resources.outgoingNeighbors,
-          outgoingNeighborChunkLengths
-        )
+        'outgoing neighbors',
+        handles.outgoingNeighbors,
+        outgoingNeighborChunkLengths
       ),
-      reverseOffsets: graph.importGPUVector(
+      reverseOffsets: makeUint32GraphVector(
+        graph,
         'incoming-offset-partitions',
-        makeUint32Vector(
-          'incoming offsets',
-          resources.incomingOffsets,
-          topologyChunkLengths.map(length => length + 1)
-        )
+        'incoming offsets',
+        handles.incomingOffsets,
+        topologyChunkLengths.map(length => length + 1)
       ),
-      reverseNeighbors: graph.importGPUVector(
+      reverseNeighbors: makeUint32GraphVector(
+        graph,
         'incoming-neighbor-partitions',
-        makeUint32Vector(
-          'incoming neighbors',
-          resources.incomingNeighbors,
-          incomingNeighborChunkLengths
-        )
+        'incoming neighbors',
+        handles.incomingNeighbors,
+        incomingNeighborChunkLengths
       ),
       seeds: graph.createDataView(handles.selectedSeeds, {format: 'uint32', length: 1}),
       seedCount: graph.createDataView(handles.selectedSeedCount, {format: 'uint32', length: 1}),
       activeDepth: graph.createDataView(handles.traversalDepth, {format: 'uint32', length: 1}),
-      output: graph.importGPUVector(
+      output: makeUint32GraphVector(
+        graph,
         'reached-span-partitions',
-        makeUint32Vector('reached spans', resources.reachedSpans, topologyChunkLengths)
+        'reached spans',
+        handles.reachedSpans,
+        topologyChunkLengths
       ),
       direction: 'both',
       maxDepth: MAXIMUM_FOCUS_DEPTH
@@ -1388,24 +1399,35 @@ function makePartitionedOffsets(
 }
 
 /** Adapts consecutive subranges of one caller-owned allocation as a chunk-preserving vector. */
-function makeUint32Vector(
+function makeUint32GraphVector<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
   name: string,
-  buffer: Buffer,
+  buffer: GraphBufferHandle,
   chunkLengths: readonly number[]
-): GPUVector<'uint32'> {
+): GraphVectorView<'uint32'> {
   let byteOffset = 0;
   const data = chunkLengths.map(length => {
-    const chunk = new GPUData({
-      buffer,
+    const chunk = graph.createDataView(buffer, {
       format: 'uint32',
       length,
-      byteOffset,
-      ownsBuffer: false
+      byteOffset
     });
     byteOffset += length * UINT32_BYTE_LENGTH;
     return chunk;
   });
-  return new GPUVector({type: 'data', name, format: 'uint32', data, ownsData: false});
+  const length = chunkLengths.reduce((sum, chunkLength) => sum + chunkLength, 0);
+  return new GraphVectorView({
+    id,
+    name,
+    format: 'uint32',
+    length,
+    valueLength: length,
+    stride: 1,
+    byteStride: UINT32_BYTE_LENGTH,
+    rowByteLength: UINT32_BYTE_LENGTH,
+    data
+  });
 }
 
 /** Preserves caller-owned imports and the original GPU command-graph ownership contract. */

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -88,7 +88,7 @@ type TraceGroupResources = {
 type PickPosition = {
   time: number;
   lane: number;
-  requestId: number;
+  requestIdentifier: number;
 };
 
 type TraceGraphResources = {
@@ -160,7 +160,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   private pointerMoved = false;
   private lastPointer: [number, number] = [0, 0];
   private pendingPick: PickPosition | null = null;
-  private latestPickRequestId = 0;
+  private latestPickRequestIdentifier = 0;
   private encodeTimeMilliseconds = 0;
   private compileCount = 0;
   private compileTimeMilliseconds = 0;
@@ -232,7 +232,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
           byteLength: UINT32_BYTE_LENGTH
         });
         queueMicrotask(() => {
-          void this.samplePickedSpan(resources, readbackTicket, pick.requestId);
+          void this.samplePickedSpan(resources, readbackTicket, pick.requestIdentifier);
         });
       } else {
         this.deferredPickFrameCount++;
@@ -876,11 +876,11 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   private async samplePickedSpan(
     resources: TraceGraphResources,
     readbackTicket: GPUReadbackTicket,
-    requestId: number
+    requestIdentifier: number
   ): Promise<void> {
     try {
       const bytes = await readbackTicket.read();
-      if (resources !== this.resources || requestId !== this.latestPickRequestId) {
+      if (resources !== this.resources || requestIdentifier !== this.latestPickRequestIdentifier) {
         return;
       }
       const pickedSpanIndex = new Uint32Array(bytes.buffer, bytes.byteOffset, 1)[0];
@@ -1304,11 +1304,11 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       const rectangle = this.canvas.getBoundingClientRect();
       const horizontalFraction = clamp((event.clientX - rectangle.left) / rectangle.width, 0, 1);
       const verticalFraction = clamp((event.clientY - rectangle.top) / rectangle.height, 0, 1);
-      this.latestPickRequestId++;
+      this.latestPickRequestIdentifier++;
       this.pendingPick = {
         time: this.view.timeMin + horizontalFraction * (this.view.timeMax - this.view.timeMin),
         lane: this.view.laneMin + verticalFraction * (this.view.laneMax - this.view.laneMin),
-        requestId: this.latestPickRequestId
+        requestIdentifier: this.latestPickRequestIdentifier
       };
     }
     this.finishPointerInteraction(event);

--- a/modules/experimental/src/gpu-primitives/gpu-batch-sort.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-batch-sort.ts
@@ -86,6 +86,8 @@ export class GPUBatchSort {
       this.outputValues,
       `${this.id} keys and output values`
     );
+    validateDisjointOutputChunks(this.outputKeys, `${this.id} output keys`);
+    validateDisjointOutputChunks(this.outputValues, `${this.id} output values`);
     validateSeparateVectorBuffers(this);
 
     this.chunkSorts = this.keys.data.map(
@@ -112,6 +114,24 @@ export class GPUBatchSort {
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
     for (const sort of this.chunkSorts) {
       sort.addToGraph(graph);
+    }
+  }
+}
+
+/** Rejects overlapping writable chunks while allowing disjoint slices of one logical buffer. */
+function validateDisjointOutputChunks(vector: GraphVectorView<'uint32'>, name: string): void {
+  for (let firstIndex = 0; firstIndex < vector.data.length; firstIndex++) {
+    const first = vector.data[firstIndex];
+    if (first.length === 0) continue;
+    const firstEnd = first.byteOffset + (first.length - 1) * first.byteStride + first.rowByteLength;
+    for (let secondIndex = firstIndex + 1; secondIndex < vector.data.length; secondIndex++) {
+      const second = vector.data[secondIndex];
+      if (first.buffer !== second.buffer || second.length === 0) continue;
+      const secondEnd =
+        second.byteOffset + (second.length - 1) * second.byteStride + second.rowByteLength;
+      if (first.byteOffset < secondEnd && second.byteOffset < firstEnd) {
+        throw new Error(`${name} chunks must not overlap`);
+      }
     }
   }
 }

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
@@ -822,6 +822,7 @@ export class CompiledGPUCommandGraph<Parameters = void> {
             entry.texture === texture &&
             entry.frameId !== frameId
           ) {
+            this.destroyFramebuffersUsingView(entry.view);
             entry.view.destroy();
             this.cachedTextureViews.splice(index, 1);
           }
@@ -1120,6 +1121,19 @@ export class CompiledGPUCommandGraph<Parameters = void> {
       framebuffer
     });
     return framebuffer;
+  }
+
+  private destroyFramebuffersUsingView(view: TextureView): void {
+    for (let index = this.cachedFramebuffers.length - 1; index >= 0; index--) {
+      const cached = this.cachedFramebuffers[index];
+      if (
+        cached.depthStencilAttachment === view ||
+        cached.colorAttachments.some(attachment => attachment === view)
+      ) {
+        cached.framebuffer.destroy();
+        this.cachedFramebuffers.splice(index, 1);
+      }
+    }
   }
 }
 

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
@@ -817,11 +817,7 @@ export class CompiledGPUCommandGraph<Parameters = void> {
         const frameId = this.lastFrameIds.get(textureOrView.texture);
         for (let index = this.cachedTextureViews.length - 1; index >= 0; index--) {
           const entry = this.cachedTextureViews[index];
-          if (
-            entry.logicalView === textureOrView &&
-            entry.texture === texture &&
-            entry.frameId !== frameId
-          ) {
+          if (entry.logicalView === textureOrView && entry.frameId !== frameId) {
             this.destroyFramebuffersUsingView(entry.view);
             entry.view.destroy();
             this.cachedTextureViews.splice(index, 1);

--- a/modules/experimental/src/gpu-primitives/gpu-grid-index-query.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-grid-index-query.ts
@@ -1,0 +1,501 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {type Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-command-graph';
+import type {GPUGridIndexBounds, GPUGridIndexSize} from './gpu-grid-index';
+import {
+  getViewBinding,
+  getViewElementOffset,
+  validatePackedUint32View,
+  validatePackedView
+} from './graph-data-view-utils';
+
+const GRID_QUERY_WORKGROUP_SIZE = 256;
+
+/** Storage and domain contract consumed by {@link GPUGridIndexQuery}. */
+export type GPUGridIndexView = {
+  gridSize: GPUGridIndexSize;
+  bounds: GPUGridIndexBounds;
+  cellOffsets: GraphDataView<'uint32'>;
+  objectIds: GraphDataView<'uint32'>;
+  count: GraphDataView<'uint32'>;
+  overflow: GraphDataView<'uint32'>;
+};
+
+/** Coarse spatial query evaluated against grid cells. */
+export type GPUGridIndexQueryKind = 'point' | 'bounds' | 'radius';
+
+/** Properties for one grid-index candidate query. */
+export type GPUGridIndexQueryProps = {
+  /** Prefix for generated graph node IDs. */
+  id?: string;
+  /** Grid storage and domain, commonly a `GPUGridIndex` instance. */
+  index: GPUGridIndexView;
+  /** Cell-selection rule. */
+  kind: GPUGridIndexQueryKind;
+  /** Packed query scalars: point, minima/maxima, or center/radius. */
+  query: GraphDataView<'float32'>;
+  /** Caller-owned capacity-bounded candidate IDs. */
+  output: GraphDataView<'uint32'>;
+  /** Caller-owned row receiving the stored-index candidate count. */
+  count: GraphDataView<'uint32'>;
+  /** Caller-owned row receiving index or candidate-output overflow. */
+  overflow: GraphDataView<'uint32'>;
+  /** Optional source-ID-addressed candidate mask, cleared on every encoding. */
+  outputMask?: GraphDataView<'uint32'>;
+};
+
+/**
+ * Queries a flat grid index for IDs in cells intersecting a point, bounds, or radius.
+ *
+ * Results are conservative cell candidates. Bounds and radius queries may include objects outside
+ * the exact geometry, and point queries return every object in the containing cell. Output order is
+ * unspecified because candidates append atomically.
+ */
+export class GPUGridIndexQuery {
+  readonly id: string;
+  readonly index: GPUGridIndexView;
+  readonly kind: GPUGridIndexQueryKind;
+  readonly query: GraphDataView<'float32'>;
+  readonly output: GraphDataView<'uint32'>;
+  readonly count: GraphDataView<'uint32'>;
+  readonly overflow: GraphDataView<'uint32'>;
+  readonly outputMask?: GraphDataView<'uint32'>;
+  readonly dimension: 2 | 3;
+
+  constructor(props: GPUGridIndexQueryProps) {
+    this.id = props.id ?? 'gpu-grid-index-query';
+    this.index = props.index;
+    this.kind = props.kind;
+    this.query = props.query;
+    this.output = props.output;
+    this.count = props.count;
+    this.overflow = props.overflow;
+    this.outputMask = props.outputMask;
+    this.dimension = this.index.gridSize.length === 2 ? 2 : 3;
+
+    validateIndexView(this.id, this.index, this.dimension);
+    validatePackedView(this.query, ['float32'], `${this.id} query`);
+    validatePackedUint32View(this.output, `${this.id} output`);
+    validatePackedUint32View(this.count, `${this.id} count`);
+    validatePackedUint32View(this.overflow, `${this.id} overflow`);
+    if (this.outputMask) validatePackedUint32View(this.outputMask, `${this.id} outputMask`);
+    if (this.count.length < 1 || this.overflow.length < 1) {
+      throw new Error(`${this.id} count and overflow must each contain one uint32 row`);
+    }
+    const expectedQueryLength =
+      this.kind === 'point'
+        ? this.dimension
+        : this.kind === 'bounds'
+          ? this.dimension * 2
+          : this.dimension + 1;
+    if (this.query.length !== expectedQueryLength) {
+      throw new Error(`${this.id} ${this.kind} query must contain ${expectedQueryLength} floats`);
+    }
+  }
+
+  /** Adds output initialization and candidate collection without submitting or reading back work. */
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    const views = [
+      this.index.cellOffsets,
+      this.index.objectIds,
+      this.index.count,
+      this.index.overflow,
+      this.query,
+      this.output,
+      this.count,
+      this.overflow,
+      ...(this.outputMask ? [this.outputMask] : [])
+    ];
+    if (views.some(view => view.buffer.graph !== graph)) {
+      throw new Error(`${this.id} views must belong to the target graph`);
+    }
+
+    addInitializePass(graph, this);
+    if (this.index.objectIds.length > 0) addQueryPass(graph, this);
+  }
+}
+
+function addInitializePass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  query: GPUGridIndexQuery
+): void {
+  const maskBinding = query.outputMask
+    ? '@group(0) @binding(3) var<storage, read_write> outputMask: array<u32>;'
+    : '';
+  const maskClear = query.outputMask
+    ? `if (index < MASK_LENGTH) { outputMask[MASK_OFFSET + index] = 0u; }`
+    : '';
+  const source = /* wgsl */ `
+const INDEX_OVERFLOW_OFFSET: u32 = ${getViewElementOffset(query.index.overflow)}u;
+const COUNT_OFFSET: u32 = ${getViewElementOffset(query.count)}u;
+const OVERFLOW_OFFSET: u32 = ${getViewElementOffset(query.overflow)}u;
+${
+  query.outputMask
+    ? `const MASK_OFFSET: u32 = ${getViewElementOffset(query.outputMask)}u;
+const MASK_LENGTH: u32 = ${query.outputMask.length}u;`
+    : ''
+}
+@group(0) @binding(0) var<storage, read> indexOverflow: array<u32>;
+@group(0) @binding(1) var<storage, read_write> outputCount: array<u32>;
+@group(0) @binding(2) var<storage, read_write> outputOverflow: array<u32>;
+${maskBinding}
+@compute @workgroup_size(${GRID_QUERY_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  let index = globalId.x;
+  if (index == 0u) {
+    outputCount[COUNT_OFFSET] = 0u;
+    outputOverflow[OVERFLOW_OFFSET] = min(indexOverflow[INDEX_OVERFLOW_OFFSET], 1u);
+  }
+  ${maskClear}
+}`;
+  const resources: GraphBufferUse[] = [
+    {buffer: query.index.overflow, usage: 'storage-read'},
+    {buffer: query.count, usage: 'storage-write'},
+    {buffer: query.overflow, usage: 'storage-write'},
+    ...(query.outputMask
+      ? ([{buffer: query.outputMask, usage: 'storage-write'}] as GraphBufferUse[])
+      : [])
+  ];
+  addComputationPass(graph, {
+    id: `${query.id}-initialize`,
+    source,
+    resources,
+    bindings: {
+      indexOverflow: query.index.overflow,
+      outputCount: query.count,
+      outputOverflow: query.overflow,
+      ...(query.outputMask ? {outputMask: query.outputMask} : {})
+    },
+    dispatchCount: Math.ceil(Math.max(query.outputMask?.length ?? 0, 1) / GRID_QUERY_WORKGROUP_SIZE)
+  });
+}
+
+function addQueryPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  query: GPUGridIndexQuery
+): void {
+  const dimension = query.dimension;
+  const width = query.index.gridSize[0];
+  const height = query.index.gridSize[1];
+  const depth = dimension === 3 ? query.index.gridSize[2] : 1;
+  const cellCount = query.index.gridSize.reduce((product, size) => product * size, 1);
+  const maskBinding = query.outputMask
+    ? '@group(0) @binding(7) var<storage, read_write> outputMask: array<atomic<u32>>;'
+    : '';
+  const maskWrite = query.outputMask
+    ? `if (objectId < MASK_LENGTH) {
+      atomicStore(&outputMask[MASK_OFFSET + objectId], 1u);
+    }`
+    : '';
+  const source = /* wgsl */ `
+const CELL_COUNT: u32 = ${cellCount}u;
+const WIDTH: u32 = ${width}u;
+const HEIGHT: u32 = ${height}u;
+const DEPTH: u32 = ${depth}u;
+const INDEX_CAPACITY: u32 = ${query.index.objectIds.length}u;
+const OUTPUT_CAPACITY: u32 = ${query.output.length}u;
+const CELL_OFFSETS_OFFSET: u32 = ${getViewElementOffset(query.index.cellOffsets)}u;
+const OBJECT_IDS_OFFSET: u32 = ${getViewElementOffset(query.index.objectIds)}u;
+const INDEX_COUNT_OFFSET: u32 = ${getViewElementOffset(query.index.count)}u;
+const QUERY_OFFSET: u32 = ${getViewElementOffset(query.query)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(query.output)}u;
+const COUNT_OFFSET: u32 = ${getViewElementOffset(query.count)}u;
+const OVERFLOW_OFFSET: u32 = ${getViewElementOffset(query.overflow)}u;
+${
+  query.outputMask
+    ? `const MASK_OFFSET: u32 = ${getViewElementOffset(query.outputMask)}u;
+const MASK_LENGTH: u32 = ${query.outputMask.length}u;`
+    : ''
+}
+@group(0) @binding(0) var<storage, read> cellOffsets: array<u32>;
+@group(0) @binding(1) var<storage, read> objectIds: array<u32>;
+@group(0) @binding(2) var<storage, read> indexCount: array<u32>;
+@group(0) @binding(3) var<storage, read> queryValues: array<f32>;
+@group(0) @binding(4) var<storage, read_write> outputIds: array<u32>;
+@group(0) @binding(5) var<storage, read_write> outputCount: array<atomic<u32>>;
+@group(0) @binding(6) var<storage, read_write> outputOverflow: array<atomic<u32>>;
+${maskBinding}
+
+fn finite(value: f32) -> bool {
+  return value == value && abs(value) <= 3.402823466e+38;
+}
+
+fn getCoordinate(value: f32, minimum: f32, maximum: f32, size: u32) -> u32 {
+  if (!finite(value)) { return 0u; }
+  if (maximum == minimum || value == minimum) { return 0u; }
+  if (value == maximum) { return size - 1u; }
+  return min(u32((value - minimum) / (maximum - minimum) * f32(size)), size - 1u);
+}
+
+fn findCellIndex(objectIndex: u32) -> u32 {
+  var low = 0u;
+  var high = CELL_COUNT;
+  loop {
+    if (low >= high) { break; }
+    let middle = low + (high - low) / 2u;
+    if (cellOffsets[CELL_OFFSETS_OFFSET + middle + 1u] <= objectIndex) {
+      low = middle + 1u;
+    } else {
+      high = middle;
+    }
+  }
+  return min(low, CELL_COUNT - 1u);
+}
+
+fn cellMinimum(coordinate: u32, size: u32, minimum: f32, maximum: f32) -> f32 {
+  return minimum + (maximum - minimum) * f32(coordinate) / f32(size);
+}
+
+fn cellMaximum(coordinate: u32, size: u32, minimum: f32, maximum: f32) -> f32 {
+  if (coordinate + 1u == size) { return maximum; }
+  return minimum + (maximum - minimum) * f32(coordinate + 1u) / f32(size);
+}
+
+@compute @workgroup_size(${GRID_QUERY_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  let objectIndex = globalId.x;
+  let storedCount = min(indexCount[INDEX_COUNT_OFFSET], INDEX_CAPACITY);
+  if (objectIndex >= storedCount) { return; }
+  let cellIndex = findCellIndex(objectIndex);
+  let column = cellIndex % WIDTH;
+  let row = (cellIndex / WIDTH) % HEIGHT;
+  let layer = cellIndex / (WIDTH * HEIGHT);
+  ${makeCellSelection(query)}
+  if (selected) {
+    let objectId = objectIds[OBJECT_IDS_OFFSET + objectIndex];
+    let outputIndex = atomicAdd(&outputCount[COUNT_OFFSET], 1u);
+    if (outputIndex < OUTPUT_CAPACITY) {
+      outputIds[OUTPUT_OFFSET + outputIndex] = objectId;
+    } else {
+      atomicStore(&outputOverflow[OVERFLOW_OFFSET], 1u);
+    }
+    ${maskWrite}
+  }
+}`;
+  const resources: GraphBufferUse[] = [
+    {buffer: query.index.cellOffsets, usage: 'storage-read'},
+    {buffer: query.index.objectIds, usage: 'storage-read'},
+    {buffer: query.index.count, usage: 'storage-read'},
+    {buffer: query.query, usage: 'storage-read'},
+    {buffer: query.output, usage: 'storage-write'},
+    {buffer: query.count, usage: 'storage-read-write'},
+    {buffer: query.overflow, usage: 'storage-read-write'},
+    ...(query.outputMask
+      ? ([{buffer: query.outputMask, usage: 'storage-read-write'}] as GraphBufferUse[])
+      : [])
+  ];
+  addComputationPass(graph, {
+    id: query.id,
+    source,
+    resources,
+    bindings: {
+      cellOffsets: query.index.cellOffsets,
+      objectIds: query.index.objectIds,
+      indexCount: query.index.count,
+      queryValues: query.query,
+      outputIds: query.output,
+      outputCount: query.count,
+      outputOverflow: query.overflow,
+      ...(query.outputMask ? {outputMask: query.outputMask} : {})
+    },
+    dispatchCount: Math.ceil(query.index.objectIds.length / GRID_QUERY_WORKGROUP_SIZE)
+  });
+}
+
+function makeCellSelection(query: GPUGridIndexQuery): string {
+  const dimension = query.dimension;
+  const bounds = query.index.bounds;
+  const maximaOffset = dimension;
+  const axes = [
+    {
+      name: 'x',
+      coordinate: 'column',
+      size: 'WIDTH',
+      minimum: bounds[0],
+      maximum: bounds[maximaOffset]
+    },
+    {
+      name: 'y',
+      coordinate: 'row',
+      size: 'HEIGHT',
+      minimum: bounds[1],
+      maximum: bounds[maximaOffset + 1]
+    },
+    ...(dimension === 3
+      ? [
+          {
+            name: 'z',
+            coordinate: 'layer',
+            size: 'DEPTH',
+            minimum: bounds[2]!,
+            maximum: bounds[5]!
+          }
+        ]
+      : [])
+  ];
+  const cellDeclarations = axes
+    .map(
+      axis => `let cellMin${axis.name.toUpperCase()} = cellMinimum(${axis.coordinate}, ${axis.size}, ${getFloatLiteral(axis.minimum)}, ${getFloatLiteral(axis.maximum)});
+  let cellMax${axis.name.toUpperCase()} = cellMaximum(${axis.coordinate}, ${axis.size}, ${getFloatLiteral(axis.minimum)}, ${getFloatLiteral(axis.maximum)});`
+    )
+    .join('\n  ');
+
+  if (query.kind === 'point') {
+    const values = axes
+      .map(
+        (axis, axisIndex) =>
+          `let query${axis.name.toUpperCase()} = queryValues[QUERY_OFFSET + ${axisIndex}u];`
+      )
+      .join('\n  ');
+    const valid = axes
+      .map(
+        axis =>
+          `finite(query${axis.name.toUpperCase()}) && query${axis.name.toUpperCase()} >= ${getFloatLiteral(axis.minimum)} && query${axis.name.toUpperCase()} <= ${getFloatLiteral(axis.maximum)}`
+      )
+      .join(' && ');
+    const queryCoordinates = axes
+      .map(
+        axis =>
+          `let query${axis.name.toUpperCase()}Coordinate = getCoordinate(query${axis.name.toUpperCase()}, ${getFloatLiteral(axis.minimum)}, ${getFloatLiteral(axis.maximum)}, ${axis.size});`
+      )
+      .join('\n  ');
+    const queryCell =
+      dimension === 2
+        ? 'queryYCoordinate * WIDTH + queryXCoordinate'
+        : '(queryZCoordinate * HEIGHT + queryYCoordinate) * WIDTH + queryXCoordinate';
+    return `${values}
+  ${queryCoordinates}
+  let selected = ${valid} && cellIndex == ${queryCell};`;
+  }
+
+  if (query.kind === 'bounds') {
+    const values = axes
+      .map(
+        (axis, axisIndex) =>
+          `let queryMin${axis.name.toUpperCase()} = queryValues[QUERY_OFFSET + ${axisIndex}u];
+  let queryMax${axis.name.toUpperCase()} = queryValues[QUERY_OFFSET + ${axisIndex + dimension}u];`
+      )
+      .join('\n  ');
+    const valid = axes
+      .map(
+        axis =>
+          `finite(queryMin${axis.name.toUpperCase()}) && finite(queryMax${axis.name.toUpperCase()}) && queryMin${axis.name.toUpperCase()} <= queryMax${axis.name.toUpperCase()}`
+      )
+      .join(' && ');
+    const selected = axes
+      .map(
+        axis =>
+          `cellMax${axis.name.toUpperCase()} >= queryMin${axis.name.toUpperCase()} && cellMin${axis.name.toUpperCase()} <= queryMax${axis.name.toUpperCase()}`
+      )
+      .join(' && ');
+    return `${cellDeclarations}
+  ${values}
+  let selected = ${valid} && ${selected};`;
+  }
+
+  const values = axes
+    .map(
+      (axis, axisIndex) =>
+        `let query${axis.name.toUpperCase()} = queryValues[QUERY_OFFSET + ${axisIndex}u];`
+    )
+    .join('\n  ');
+  const validCenter = axes.map(axis => `finite(query${axis.name.toUpperCase()})`).join(' && ');
+  const distances = axes
+    .map(
+      axis =>
+        `let closest${axis.name.toUpperCase()} = clamp(query${axis.name.toUpperCase()}, cellMin${axis.name.toUpperCase()}, cellMax${axis.name.toUpperCase()});
+  let distance${axis.name.toUpperCase()} = query${axis.name.toUpperCase()} - closest${axis.name.toUpperCase()};`
+    )
+    .join('\n  ');
+  const squaredDistance = axes
+    .map(axis => `distance${axis.name.toUpperCase()} * distance${axis.name.toUpperCase()}`)
+    .join(' + ');
+  return `${cellDeclarations}
+  ${values}
+  let radius = queryValues[QUERY_OFFSET + ${dimension}u];
+  ${distances}
+  let selected = ${validCenter} && finite(radius) && radius >= 0.0 && ${squaredDistance} <= radius * radius;`;
+}
+
+function validateIndexView(id: string, index: GPUGridIndexView, dimension: 2 | 3): void {
+  if (index.bounds.length !== dimension * 2) {
+    throw new Error(`${id} index gridSize and bounds must have matching dimensions`);
+  }
+  if (index.gridSize.some(size => !Number.isSafeInteger(size) || size <= 0)) {
+    throw new Error(`${id} index gridSize must contain positive integers`);
+  }
+  if (
+    !index.bounds.every(Number.isFinite) ||
+    Array.from({length: dimension}, (_, axis) => axis).some(
+      axis => index.bounds[axis]! > index.bounds[axis + dimension]!
+    )
+  ) {
+    throw new Error(`${id} index bounds must contain finite ordered minima and maxima`);
+  }
+  const cellCount = index.gridSize.reduce((product, size) => product * size, 1);
+  for (const [name, view] of [
+    ['cellOffsets', index.cellOffsets],
+    ['objectIds', index.objectIds],
+    ['count', index.count],
+    ['overflow', index.overflow]
+  ] as const) {
+    validatePackedUint32View(view, `${id} index ${name}`);
+  }
+  if (index.cellOffsets.length !== cellCount + 1) {
+    throw new Error(`${id} index cellOffsets.length must equal cellCount + 1`);
+  }
+  if (index.count.length < 1 || index.overflow.length < 1) {
+    throw new Error(`${id} index count and overflow must each contain one uint32 row`);
+  }
+}
+
+function addComputationPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    source: string;
+    resources: GraphBufferUse[];
+    bindings: Record<string, GraphDataView>;
+    dispatchCount: number;
+  }
+): void {
+  graph.addComputePass({
+    id: props.id,
+    resources: props.resources,
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: props.id,
+        source: props.source,
+        shaderLayout: {
+          bindings: Object.keys(props.bindings).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const [name, view] of Object.entries(props.bindings)) {
+            bindings[name] = getViewBinding(view, getBuffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatch(computePass, props.dispatchCount);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function getFloatLiteral(value: number): string {
+  return Number.isInteger(value) ? `${value}.0` : `${value}`;
+}

--- a/modules/experimental/src/gpu-primitives/gpu-grid-index.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-grid-index.ts
@@ -608,5 +608,6 @@ function getSourceIdChunks(sourceIds?: GPUGridIndexSourceIds): readonly GraphDat
 }
 
 function getFloatLiteral(value: number): string {
-  return Number.isInteger(value) ? `${value}.0` : `${value}`;
+  const literal = `${Math.fround(value)}`;
+  return literal.includes('.') || literal.includes('e') ? literal : `${literal}.0`;
 }

--- a/modules/experimental/src/gpu-primitives/gpu-grid-index.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-grid-index.ts
@@ -148,6 +148,7 @@ export class GPUGridIndex {
       throw new Error(`${this.id} sourceIds and firstSourceIndex are mutually exclusive`);
     }
     validateSourceIds(this.id, this.positions, this.sourceIds);
+    validateDisjointGridInputs(this.id, this.positions, this.sourceIds, this.objectIds);
   }
 
   /** Adds a complete index rebuild to the target graph without submitting or reading back work. */
@@ -468,6 +469,15 @@ ${bindings}
 fn getCoordinate(value: f32, minimum: f32, maximum: f32, size: u32) -> u32 {
   if (maximum == minimum || value == minimum) { return 0u; }
   if (value == maximum) { return size - 1u; }
+  if (minimum < 0.0 && maximum > 0.0) {
+    let scaledValue = value * 0.5;
+    let scaledMinimum = minimum * 0.5;
+    let scaledMaximum = maximum * 0.5;
+    return min(
+      u32((scaledValue - scaledMinimum) / (scaledMaximum - scaledMinimum) * f32(size)),
+      size - 1u
+    );
+  }
   return min(u32((value - minimum) / (maximum - minimum) * f32(size)), size - 1u);
 }
 
@@ -556,6 +566,34 @@ function validateSourceIds(
   } else if (positions.length !== sourceIds.length) {
     throw new Error(`${id} sourceIds.length must equal positions.length`);
   }
+}
+
+function validateDisjointGridInputs(
+  id: string,
+  positions: GPUGridIndexPositions,
+  sourceIds: GPUGridIndexSourceIds | undefined,
+  objectIds: GraphDataView<'uint32'>
+): void {
+  for (const positionChunk of getPositionChunks(positions)) {
+    if (doViewsOverlap(positionChunk, objectIds)) {
+      throw new Error(`${id} positions and objectIds must not overlap`);
+    }
+  }
+  for (const sourceIdChunk of getSourceIdChunks(sourceIds)) {
+    if (doViewsOverlap(sourceIdChunk, objectIds)) {
+      throw new Error(`${id} sourceIds and objectIds must not overlap`);
+    }
+  }
+}
+
+function doViewsOverlap(first: GraphDataView, second: GraphDataView): boolean {
+  if (first.buffer !== second.buffer || first.length === 0 || second.length === 0) {
+    return false;
+  }
+  const firstEnd = first.byteOffset + (first.length - 1) * first.byteStride + first.rowByteLength;
+  const secondEnd =
+    second.byteOffset + (second.length - 1) * second.byteStride + second.rowByteLength;
+  return first.byteOffset < secondEnd && second.byteOffset < firstEnd;
 }
 
 function getPositionChunks(

--- a/modules/experimental/src/gpu-primitives/gpu-histogram.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-histogram.ts
@@ -606,11 +606,15 @@ function validateHistogramEdges<T extends GPUScalarFormat>(
   }
   const minimum = format === 'uint32' ? 0 : -0x80000000;
   const maximum = format === 'uint32' ? 0xffffffff : 0x7fffffff;
+  const representableEdges = format === 'float32' ? edges.map(Math.fround) : edges;
   const invalidValue =
     format === 'float32'
-      ? edges.some(value => !Number.isFinite(value) || Math.abs(value) > 3.402823466e38)
+      ? representableEdges.some(value => !Number.isFinite(value))
       : edges.some(value => !Number.isInteger(value) || value < minimum || value > maximum);
-  if (invalidValue || edges.some((value, index) => index > 0 && value <= edges[index - 1])) {
+  if (
+    invalidValue ||
+    representableEdges.some((value, index) => index > 0 && value <= representableEdges[index - 1])
+  ) {
     throw new Error(`${id} literal edges must be finite, representable, and strictly increasing`);
   }
 }
@@ -656,5 +660,6 @@ function getShaderType(format: GPUScalarFormat): 'u32' | 'i32' | 'f32' {
 function getLiteral(value: number, format: GPUScalarFormat): string {
   if (format === 'uint32') return `${value}u`;
   if (format === 'sint32') return `${value}`;
-  return Number.isInteger(value) ? `${value}.0` : `${value}`;
+  const literal = `${Math.fround(value)}`;
+  return literal.includes('.') || literal.includes('e') ? literal : `${literal}.0`;
 }

--- a/modules/experimental/src/gpu-primitives/gpu-visibility-workflow.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-visibility-workflow.ts
@@ -139,10 +139,7 @@ export class GPUVisibilityWorkflow {
     }
 
     const finalMask =
-      this.outputMask ??
-      (this.predicates.length === 1
-        ? template
-        : createTransientVisibilityInput(graph, `${this.id}-mask`, template));
+      this.outputMask ?? createTransientVisibilityInput(graph, `${this.id}-mask`, template);
     if (finalMask !== template || this.predicates.length > 1) {
       new GPUMask({
         id: `${this.id}-compose`,

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -110,6 +110,13 @@ export type {
   GPUGridIndexSourceIds
 } from './gpu-grid-index';
 
+export {GPUGridIndexQuery} from './gpu-grid-index-query';
+export type {
+  GPUGridIndexQueryKind,
+  GPUGridIndexQueryProps,
+  GPUGridIndexView
+} from './gpu-grid-index-query';
+
 export {GPUGridAggregation} from './gpu-grid-aggregation';
 export type {
   GPUGridAggregationOperation,

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-textures.spec.ts
@@ -271,6 +271,7 @@ test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
     format: 'rgba8unorm',
     width: 4,
     height: 4,
+    depth: 2,
     usage: Texture.RENDER
   });
   const secondTexture = device.createTexture({
@@ -278,6 +279,7 @@ test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
     format: 'rgba8unorm',
     width: 4,
     height: 4,
+    depth: 2,
     usage: Texture.RENDER
   });
   const auxiliaryTexture = device.createTexture({
@@ -293,6 +295,7 @@ test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
     format: 'rgba8unorm',
     width: 4,
     height: 4,
+    depth: 2,
     usage: Texture.RENDER
   });
   graph.importFrameTexture({
@@ -304,10 +307,21 @@ test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
   });
   graph.addRenderPass({
     id: 'render-frame',
-    attachments: {colorAttachments: [graph.createTextureView(frameColor)]},
+    attachments: {
+      colorAttachments: [
+        graph.createTextureView(frameColor, {
+          dimension: '2d',
+          baseArrayLayer: 1,
+          arrayLayerCount: 1
+        })
+      ]
+    },
     compile: () => ({encode: () => {}})
   });
   const compiled = graph.compile();
+  const resourceStats = device.statsManager.getStats('Resource Counts');
+  const baselineFramebufferCount = resourceStats.get('Framebuffers Active').count;
+  const baselineTextureViewCount = resourceStats.get('TextureViews Active').count;
   t.throws(
     () =>
       compiled.encode(device.createCommandEncoder({id: 'missing-frame'}), {
@@ -325,6 +339,16 @@ test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
     }
   });
   device.submit(firstEncoder.finish());
+  t.equal(
+    resourceStats.get('Framebuffers Active').count,
+    baselineFramebufferCount + 1,
+    'the first frame owns one cached framebuffer'
+  );
+  t.equal(
+    resourceStats.get('TextureViews Active').count,
+    baselineTextureViewCount + 1,
+    'the first frame owns one non-default attachment view'
+  );
   t.throws(
     () =>
       compiled.encode(device.createCommandEncoder({id: 'stale-frame'}), {
@@ -358,7 +382,22 @@ test('GPUCommandGraph enforces frame-scoped texture bindings', async t => {
     }
   });
   device.submit(secondEncoder.finish());
+  t.equal(
+    resourceStats.get('Framebuffers Active').count,
+    baselineFramebufferCount + 1,
+    'refreshing a frame view retires its stale framebuffer'
+  );
+  t.equal(
+    resourceStats.get('TextureViews Active').count,
+    baselineTextureViewCount + 1,
+    'refreshing a frame view retires its stale texture view'
+  );
   compiled.destroy();
+  t.equal(
+    resourceStats.get('Framebuffers Active').count,
+    baselineFramebufferCount,
+    'destroy releases the final cached framebuffer'
+  );
   t.notOk(firstTexture.destroyed, 'first frame texture remains caller-owned');
   t.notOk(secondTexture.destroyed, 'replacement frame texture remains caller-owned');
   firstTexture.destroy();

--- a/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-data-analysis.spec.ts
@@ -241,6 +241,16 @@ test('GPUHistogram supports irregular literal and GPU-resident edges', async t =
   t.deepEqual(
     await runIrregularHistogram(
       device,
+      Float32Array.from([0, 1e21, 2e21]),
+      'float32',
+      [0, 1e21, 2e21]
+    ),
+    [1, 2],
+    'exponential float edges generate valid WGSL literals'
+  );
+  t.deepEqual(
+    await runIrregularHistogram(
+      device,
       Uint32Array.from([0, 1, 9, 10, 99, 100]),
       'uint32',
       [0, 10, 100]
@@ -853,6 +863,17 @@ test('GPU data analysis primitives validate layouts and ownership', async t => {
     () => new GPUHistogram({input, output: two, edges: [0, 1, 1]}),
     /strictly increasing/,
     'literal histogram edges must be strictly increasing'
+  );
+  const floatInput = graph.createDataView(inputHandle, {format: 'float32', length: 4});
+  t.throws(
+    () =>
+      new GPUHistogram({
+        input: floatInput,
+        output: two,
+        edges: [16_777_216, 16_777_217, 16_777_218]
+      }),
+    /strictly increasing/,
+    'literal histogram edges must remain ordered after float32 conversion'
   );
   t.throws(
     () =>

--- a/modules/experimental/test/gpu-primitives/gpu-grid-index-query.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-grid-index-query.spec.ts
@@ -1,0 +1,309 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {Buffer, type Device} from '@luma.gl/core';
+import {
+  GPUCommandGraph,
+  GPUGridIndex,
+  GPUGridIndexQuery,
+  type GPUGridIndexBounds,
+  type GPUGridIndexQueryKind,
+  type GPUGridIndexSize
+} from '@luma.gl/experimental';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+const POSITIONS_2D = Float32Array.from([
+  0.25, 0.25, 0.75, 0.75, 1.25, 0.25, 0.25, 1.25, 1.25, 1.25, 1.75, 1.75
+]);
+
+test('GPUGridIndexQuery selects point cells and refreshes IDs and masks', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const fixture = createQueryFixture(device, {
+    positions: POSITIONS_2D,
+    format: 'float32x2',
+    gridSize: [2, 2],
+    bounds: [0, 0, 2, 2],
+    kind: 'point',
+    query: Float32Array.from([0.5, 0.5]),
+    outputCapacity: 6,
+    maskLength: 6
+  });
+  encode(device, fixture.compiled);
+  t.deepEqual((await readQueryResult(fixture)).ids.sort(sortNumbers), [0, 1]);
+  t.deepEqual(await readUint32(fixture.outputMask!, 6), [1, 1, 0, 0, 0, 0]);
+
+  fixture.query.write(Float32Array.from([1, 0.5]));
+  encode(device, fixture.compiled);
+  t.deepEqual(
+    await readQueryResult(fixture),
+    {ids: [2], count: 1, overflow: 0},
+    'an internal boundary selects the same upper cell used by index construction'
+  );
+  t.deepEqual(
+    await readUint32(fixture.outputMask!, 6),
+    [0, 0, 1, 0, 0, 0],
+    'each encoding clears the previous source-aligned mask'
+  );
+  destroyFixture(fixture);
+  t.end();
+});
+
+test('GPUGridIndexQuery returns conservative bounds and radius candidates', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const boundsFixture = createQueryFixture(device, {
+    positions: POSITIONS_2D,
+    format: 'float32x2',
+    gridSize: [2, 2],
+    bounds: [0, 0, 2, 2],
+    kind: 'bounds',
+    query: Float32Array.from([0, 0, 0.5, 0.5]),
+    outputCapacity: 6
+  });
+  encode(device, boundsFixture.compiled);
+  t.deepEqual(
+    (await readQueryResult(boundsFixture)).ids.sort(sortNumbers),
+    [0, 1],
+    'bounds return the containing-cell candidates, including a documented false positive'
+  );
+  destroyFixture(boundsFixture);
+
+  const radiusFixture = createQueryFixture(device, {
+    positions: POSITIONS_2D,
+    format: 'float32x2',
+    gridSize: [2, 2],
+    bounds: [0, 0, 2, 2],
+    kind: 'radius',
+    query: Float32Array.from([0.5, 0.5, 0.6]),
+    outputCapacity: 6
+  });
+  encode(device, radiusFixture.compiled);
+  t.deepEqual(
+    (await readQueryResult(radiusFixture)).ids.sort(sortNumbers),
+    [0, 1, 2, 3],
+    'radius rejects a diagonally distant cell while preserving intersecting candidates'
+  );
+  destroyFixture(radiusFixture);
+  t.end();
+});
+
+test('GPUGridIndexQuery reports query and source-index overflow independently', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const outputOverflow = createQueryFixture(device, {
+    positions: POSITIONS_2D,
+    format: 'float32x2',
+    gridSize: [2, 2],
+    bounds: [0, 0, 2, 2],
+    kind: 'bounds',
+    query: Float32Array.from([0, 0, 2, 2]),
+    outputCapacity: 2
+  });
+  encode(device, outputOverflow.compiled);
+  const outputResult = await readQueryResult(outputOverflow);
+  t.equal(outputResult.count, 6, 'candidate count reports required output capacity');
+  t.equal(outputResult.ids.length, 2, 'candidate storage remains bounded');
+  t.equal(outputResult.overflow, 1, 'candidate truncation sets overflow');
+  destroyFixture(outputOverflow);
+
+  const indexOverflow = createQueryFixture(device, {
+    positions: POSITIONS_2D,
+    format: 'float32x2',
+    gridSize: [2, 2],
+    bounds: [0, 0, 2, 2],
+    kind: 'point',
+    query: Float32Array.from([1.5, 1.5]),
+    indexCapacity: 4,
+    outputCapacity: 6
+  });
+  encode(device, indexOverflow.compiled);
+  t.deepEqual(
+    await readQueryResult(indexOverflow),
+    {ids: [], count: 0, overflow: 1},
+    'an overflowed source index marks even an otherwise empty stored-prefix result incomplete'
+  );
+  destroyFixture(indexOverflow);
+  t.end();
+});
+
+test('GPUGridIndexQuery selects 3D point cells', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const fixture = createQueryFixture(device, {
+    positions: Float32Array.from([0.25, 0.25, 0.25, 1.25, 0.25, 0.25, 0.25, 0.25, 1.25]),
+    format: 'float32x3',
+    gridSize: [2, 1, 2],
+    bounds: [0, 0, 0, 2, 1, 2],
+    kind: 'point',
+    query: Float32Array.from([0.5, 0.5, 1.5]),
+    outputCapacity: 3
+  });
+  encode(device, fixture.compiled);
+  t.deepEqual(await readQueryResult(fixture), {ids: [2], count: 1, overflow: 0});
+  destroyFixture(fixture);
+  t.end();
+});
+
+type QueryFixture = {
+  compiled: ReturnType<GPUCommandGraph['compile']>;
+  query: Buffer;
+  output: Buffer;
+  outputCount: Buffer;
+  outputOverflow: Buffer;
+  outputMask?: Buffer;
+  outputCapacity: number;
+  buffers: Buffer[];
+};
+
+function createQueryFixture(
+  device: Device,
+  props: {
+    positions: Float32Array;
+    format: 'float32x2' | 'float32x3';
+    gridSize: GPUGridIndexSize;
+    bounds: GPUGridIndexBounds;
+    kind: GPUGridIndexQueryKind;
+    query: Float32Array;
+    indexCapacity?: number;
+    outputCapacity: number;
+    maskLength?: number;
+  }
+): QueryFixture {
+  const rowLength = props.format === 'float32x2' ? 2 : 3;
+  const positionCount = props.positions.length / rowLength;
+  const cellCount = props.gridSize.reduce((product, size) => product * size, 1);
+  const indexCapacity = props.indexCapacity ?? positionCount;
+  const positions = createInputBuffer(device, props.positions);
+  const query = createInputBuffer(device, props.query);
+  const cellOffsets = createOutputBuffer(device, cellCount + 1);
+  const objectIds = createOutputBuffer(device, indexCapacity);
+  const indexCount = createOutputBuffer(device, 1);
+  const indexOverflow = createOutputBuffer(device, 1);
+  const output = createOutputBuffer(device, props.outputCapacity);
+  const outputCount = createOutputBuffer(device, 1);
+  const outputOverflow = createOutputBuffer(device, 1);
+  const outputMask =
+    props.maskLength === undefined ? undefined : createOutputBuffer(device, props.maskLength);
+  const graph = new GPUCommandGraph(device);
+  const index = new GPUGridIndex({
+    positions: importView(graph, 'positions', positions, props.format, positionCount) as never,
+    gridSize: props.gridSize,
+    bounds: props.bounds,
+    cellOffsets: importView(graph, 'cell-offsets', cellOffsets, 'uint32', cellCount + 1),
+    objectIds: importView(graph, 'object-ids', objectIds, 'uint32', indexCapacity),
+    count: importView(graph, 'index-count', indexCount, 'uint32', 1),
+    overflow: importView(graph, 'index-overflow', indexOverflow, 'uint32', 1)
+  });
+  index.addToGraph(graph);
+  new GPUGridIndexQuery({
+    index,
+    kind: props.kind,
+    query: importView(graph, 'query', query, 'float32', props.query.length),
+    output: importView(graph, 'output', output, 'uint32', props.outputCapacity),
+    count: importView(graph, 'output-count', outputCount, 'uint32', 1),
+    overflow: importView(graph, 'output-overflow', outputOverflow, 'uint32', 1),
+    outputMask: outputMask
+      ? importView(graph, 'output-mask', outputMask, 'uint32', props.maskLength!)
+      : undefined
+  }).addToGraph(graph);
+  return {
+    compiled: graph.compile(),
+    query,
+    output,
+    outputCount,
+    outputOverflow,
+    outputMask,
+    outputCapacity: props.outputCapacity,
+    buffers: [
+      positions,
+      query,
+      cellOffsets,
+      objectIds,
+      indexCount,
+      indexOverflow,
+      output,
+      outputCount,
+      outputOverflow,
+      ...(outputMask ? [outputMask] : [])
+    ]
+  };
+}
+
+async function readQueryResult(
+  fixture: QueryFixture
+): Promise<{ids: number[]; count: number; overflow: number}> {
+  const count = (await readUint32(fixture.outputCount, 1))[0];
+  return {
+    ids: await readUint32(fixture.output, Math.min(count, fixture.outputCapacity)),
+    count,
+    overflow: (await readUint32(fixture.outputOverflow, 1))[0]
+  };
+}
+
+function destroyFixture(fixture: QueryFixture): void {
+  fixture.compiled.destroy();
+  for (const buffer of fixture.buffers) buffer.destroy();
+}
+
+function encode(device: Device, compiled: ReturnType<GPUCommandGraph['compile']>): void {
+  const commandEncoder = device.createCommandEncoder({id: 'grid-index-query-test'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+}
+
+function createInputBuffer(device: Device, values: Float32Array): Buffer {
+  return device.createBuffer({data: values, usage: Buffer.STORAGE | Buffer.COPY_DST});
+}
+
+function createOutputBuffer(device: Device, length: number): Buffer {
+  return device.createBuffer({
+    byteLength: Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+}
+
+function importView<T extends 'float32x2' | 'float32x3' | 'float32' | 'uint32'>(
+  graph: GPUCommandGraph,
+  id: string,
+  buffer: Buffer,
+  format: T,
+  length: number
+) {
+  const handle = graph.importBuffer(
+    {id, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return graph.createDataView(handle, {format, length});
+}
+
+async function readUint32(buffer: Buffer, length: number): Promise<number[]> {
+  const bytes = await buffer.readAsync();
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, length));
+}
+
+function sortNumbers(left: number, right: number): number {
+  return left - right;
+}

--- a/modules/experimental/test/gpu-primitives/gpu-grid-index.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-grid-index.spec.ts
@@ -107,7 +107,11 @@ test('GPUGridIndex rejects overlapping scatter inputs and output', async t => {
     'float32x2',
     2
   );
-  const sourceIds = graph.createDataView(sharedHandle, {format: 'uint32', length: 2});
+  const sourceIds = graph.createDataView(sharedHandle, {
+    format: 'uint32',
+    length: 2,
+    byteOffset: 4
+  });
   t.throws(
     () =>
       new GPUGridIndex({

--- a/modules/experimental/test/gpu-primitives/gpu-grid-index.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-grid-index.spec.ts
@@ -39,6 +39,95 @@ test('GPUGridIndex builds bounded 2D cells with stable logical IDs', async t => 
   t.end();
 });
 
+test('GPUGridIndex normalizes bounds whose full span exceeds float32', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const result = await runGridIndex(
+    device,
+    Float32Array.from([0, 0]),
+    'float32x2',
+    [3, 1],
+    [-3e38, 0, 3e38, 1],
+    1
+  );
+  t.deepEqual(result.cellOffsets, [0, 0, 1, 1], 'zero maps to the middle of extreme bounds');
+  t.deepEqual(result.objectIds, [0], 'the accepted point keeps its logical ID');
+  t.end();
+});
+
+test('GPUGridIndex rejects overlapping scatter inputs and output', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const graph = new GPUCommandGraph(device);
+  const sharedBuffer = device.createBuffer({
+    byteLength: 32,
+    usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+  });
+  const sharedHandle = graph.importBuffer(
+    {id: 'shared-grid-data', byteLength: sharedBuffer.byteLength, usage: sharedBuffer.usage},
+    sharedBuffer
+  );
+  const positions = graph.createDataView(sharedHandle, {format: 'float32x2', length: 2});
+  const overlappingObjectIds = graph.createDataView(sharedHandle, {
+    format: 'uint32',
+    length: 2,
+    byteOffset: 8
+  });
+  const outputs = createIndexOutputs(device, 1, 2);
+  const importedOutputs = importIndexOutputs(graph, outputs, 1, 2);
+
+  t.throws(
+    () =>
+      new GPUGridIndex({
+        positions,
+        gridSize: [1, 1],
+        bounds: [0, 0, 1, 1],
+        ...importedOutputs,
+        objectIds: overlappingObjectIds
+      }),
+    /positions and objectIds must not overlap/,
+    'position reads cannot alias object ID writes'
+  );
+
+  const separatePositionsBuffer = createInputBuffer(device, Float32Array.from([0, 0, 1, 1]));
+  const separatePositions = importView(
+    graph,
+    'separate-positions',
+    separatePositionsBuffer,
+    'float32x2',
+    2
+  );
+  const sourceIds = graph.createDataView(sharedHandle, {format: 'uint32', length: 2});
+  t.throws(
+    () =>
+      new GPUGridIndex({
+        positions: separatePositions,
+        sourceIds,
+        gridSize: [1, 1],
+        bounds: [0, 0, 1, 1],
+        ...importedOutputs,
+        objectIds: overlappingObjectIds
+      }),
+    /sourceIds and objectIds must not overlap/,
+    'source ID reads cannot alias object ID writes'
+  );
+
+  sharedBuffer.destroy();
+  separatePositionsBuffer.destroy();
+  for (const buffer of Object.values(outputs)) buffer.destroy();
+  t.end();
+});
+
 test('GPUGridIndex reports capacity overflow without corrupting offsets', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {

--- a/modules/experimental/test/gpu-primitives/gpu-sort.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-sort.spec.ts
@@ -174,6 +174,54 @@ test('GPUBatchSort resolves algorithms per chunk and validates vector topology',
     /separate buffers/,
     'outputs cannot alias any input chunk'
   );
+  const sharedOutputBuffer = graph.createTransientBuffer({
+    id: 'shared-output-keys',
+    byteLength: 16,
+    usage: Buffer.STORAGE
+  });
+  const makeSharedOutputKeys = (secondByteOffset: number) =>
+    new GraphVectorView({
+      id: `shared-output-keys-${secondByteOffset}`,
+      name: 'shared output keys',
+      format: 'uint32',
+      length: 4,
+      valueLength: 4,
+      stride: 1,
+      byteStride: 4,
+      rowByteLength: 4,
+      data: [
+        graph.createDataView(sharedOutputBuffer, {format: 'uint32', length: 2}),
+        graph.createDataView(sharedOutputBuffer, {
+          format: 'uint32',
+          length: 2,
+          byteOffset: secondByteOffset
+        })
+      ]
+    });
+  const twoChunkKeys = makeGraphVector(graph, 'two-chunk-keys', [2, 2]);
+  const twoChunkValues = makeGraphVector(graph, 'two-chunk-values', [2, 2]);
+  const twoChunkOutputValues = makeGraphVector(graph, 'two-chunk-output-values', [2, 2]);
+  t.throws(
+    () =>
+      new GPUBatchSort({
+        keys: twoChunkKeys,
+        values: twoChunkValues,
+        outputKeys: makeSharedOutputKeys(4),
+        outputValues: twoChunkOutputValues
+      }),
+    /output keys chunks must not overlap/,
+    'writable chunks cannot overlap within one output vector'
+  );
+  t.doesNotThrow(
+    () =>
+      new GPUBatchSort({
+        keys: twoChunkKeys,
+        values: twoChunkValues,
+        outputKeys: makeSharedOutputKeys(8),
+        outputValues: twoChunkOutputValues
+      }),
+    'disjoint output chunks may share one logical buffer'
+  );
   t.throws(
     () =>
       new GPUBatchSort({

--- a/modules/experimental/test/gpu-primitives/gpu-visibility-workflow.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-visibility-workflow.spec.ts
@@ -147,9 +147,9 @@ test('GPUVisibilityWorkflow preserves chunk topology while generating global IDs
   }
 
   const maskFixture = createVectorFixture(device, 'mask', [
-    Uint32Array.from([1, 0, 1]),
+    Uint32Array.from([2, 0, 3]),
     new Uint32Array(0),
-    Uint32Array.from([1, 1])
+    Uint32Array.from([4, 1])
   ]);
   const outputFixture = createVectorFixture(
     device,
@@ -182,6 +182,11 @@ test('GPUVisibilityWorkflow preserves chunk topology while generating global IDs
     'identity generation and compaction preserve global order across chunks'
   );
   t.deepEqual(await readUint32(countBuffer, 1), [4], 'one count spans the complete vector');
+  t.deepEqual(
+    compiled.stats.nodeOrder.filter(id => id.includes('compose')),
+    ['gpu-visibility-compose-chunk-0', 'gpu-visibility-compose-chunk-2'],
+    'one noncanonical predicate is normalized before compaction'
+  );
   t.deepEqual(
     compiled.stats.nodeOrder.filter(id => id.includes('identity')),
     ['gpu-visibility-identity-chunk-0', 'gpu-visibility-identity-chunk-2'],

--- a/website/src/components/docs/gpu-primitives-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-primitives-docs-tabs.tsx
@@ -17,6 +17,7 @@ export type GPUPrimitivesDocsTabId =
   | 'grid-binning'
   | 'grid-aggregation'
   | 'grid-index'
+  | 'grid-index-query'
   | 'group-aggregation'
   | 'index-picking'
   | 'readback-ring'
@@ -97,6 +98,11 @@ const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
     id: 'grid-index',
     label: 'Grid Index',
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-grid-index'
+  },
+  {
+    id: 'grid-index-query',
+    label: 'Grid Query',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-grid-index-query'
   },
   {
     id: 'group-aggregation',


### PR DESCRIPTION
## Goals

Add the query half of the experimental GPU grid index as a focused tranche stacked on #2812.

## Changes

- add `GPUGridIndexQuery` for point, bounds, and radius cell queries in 2D and 3D
- keep queries GPU-resident and graph-composable, with mutable packed query buffers
- publish capacity-bounded stable candidate IDs, full candidate counts, propagated overflow, and an optional source-ID-addressed mask
- define the result as a conservative broad phase so application-specific exact predicates remain separate
- cover dynamic queries, boundary behavior, masks, source/output overflow, conservative candidates, and 3D selection
- add an Overview/Concepts page explaining use cases, broad-phase versus exact filtering, list/mask choices, cell-size tradeoffs, and when an unindexed scan is cheaper
- split roadmap tranche 5.2 into the implemented primitive and the remaining consumer/cost-crossover evidence

## Verification

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn build`
- focused WebGPU suites: 8 tests passed
- `yarn website:build`
- `(cd website && yarn build)`
- commit hook/node suite: 254 passed, 2 skipped
- full `yarn test`: node suite passed; browser suite reached 1,352 passed and 25 skipped, with one unrelated existing Arrow polygon storage assertion failing in `modules/arrow-layers/test/layers/arrow-layers.spec.ts`. The isolated Arrow test reproduces the same failure; this PR changes only experimental grid-query and documentation files.

## Stack

- Depends on #2812 (`GPUGridIndex` construction).
- A following tranche can add representative visibility/picking consumers and measure the scan/grid crossover.