### PR TITLE
feat(experimental): refine GPU grid candidates

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1019,9 +1019,9 @@ only when its entry dependency is present and its exit evidence can be produced;
 dependency order, not a schedule commitment. Tranches whose dependencies do not overlap may be
 developed independently.
 
-Phase 4 is implemented through Tranche 4.4. Compact `GPUGridIndex` construction and conservative
-query primitives are implemented; incremental maintenance and consumer cost comparisons remain
-separate active boundaries.
+Phase 4 is implemented through Tranche 4.4. Compact `GPUGridIndex` construction, conservative
+queries, and exact 2D/3D point refinement feeding visibility are implemented; incremental
+maintenance and measured cost comparisons remain separate active boundaries.
 
 | Tranche | Outcome | Entry dependency | Impact | Complexity/cost |
 | --- | --- | --- | :---: | :---: |
@@ -1034,7 +1034,8 @@ separate active boundaries.
 | 5.1a — `GPUGridIndex` build | Compact stable cell offsets and capacity-bounded object-ID storage for 2D and 3D points | Implemented | High | Medium |
 | 5.1b — `GPUGridIndex` incremental maintenance | Bounded relocation or reserved-cell updates with measured memory and update costs | Tranche 5.1a plus a changing-data consumer | High | Large |
 | 5.2a — `GPUGridIndex` query | Point, bounds, and radius cell candidates with bounded IDs, masks, count, and overflow | Implemented | High | Medium |
-| 5.2b — Query consumers and cost crossover | 2D and 3D visibility or picking consumers compared with an unindexed scan | Tranche 5.2a plus representative consumers | High | Medium |
+| 5.2b — Exact query consumers | 2D and 3D candidate refinement feeding the same visibility contract as an unindexed scan | Implemented | High | Medium |
+| 5.2c — Query cost crossover | Representative scan/grid comparisons with build amortization and selectivity guidance | Tranche 5.2b plus GPU timestamps | High | Medium |
 | 5.3 — `GPUBVH` build/refit | Flat BVH storage with explicit rebuild and refit policies | Tranche 5.2 | High | Large |
 | 5.4 — `GPUBVH` query and cost model | Visibility and picking queries with scan/grid/BVH comparison guidance | Tranche 5.3 | High | Medium |
 | 6.1 — Scene storage and updates | Flat stable-ID draw records, bounded update ranges, and explicit CPU/table adapters | Phase 2 and Tranche 5.2 | High | Large |
@@ -1318,8 +1319,8 @@ update costs separately from query cost.
 
 #### Tranche 5.2 — `GPUGridIndex` query
 
-**Status:** Conservative query primitives are implemented; cross-domain consumers and cost
-comparison remain planned.
+**Status:** Conservative queries and exact 2D/3D point-refinement consumers are implemented;
+representative cost comparison remains planned.
 
 Add bounds, radius, and point queries whose masks or compacted IDs compose directly with visibility
 and region-picking outputs. Query contracts preserve stable identity and do not require downloading
@@ -1332,8 +1333,16 @@ one cell; bounds and radius queries conservatively select intersecting cells. Ex
 deliberately a following application or visibility predicate, so the index does not embed one object
 shape or confuse cell overlap with an exact hit.
 
-**Exit evidence:** A 2D and a 3D consumer feed query results into visibility or picking, validate
-against an unindexed GPU scan, and document where index construction becomes worthwhile.
+`GPUPointSpatialFilter` supplies a fixed-contract exact predicate for packed points. It runs over
+either every source row or compact candidate row IDs and publishes the same source-aligned mask in
+both modes. Two- and three-dimensional tests feed the exact mask into `GPUVisibilityWorkflow`,
+intersect it with selection, and compare indexed results with an unindexed GPU scan after dynamic
+query changes. Candidate overflow remains visible because a refined result cannot be complete when
+its broad phase was truncated.
+
+**Remaining exit evidence:** Representative consumers use GPU timestamps to compare allocation,
+build, query, and exact-predicate costs against an unindexed scan across update rates, selectivity,
+and reuse counts, then document where index construction becomes worthwhile.
 
 #### Tranche 5.3 — `GPUBVH` build and refit
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-point-spatial-filter.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-point-spatial-filter.md
@@ -1,0 +1,107 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
+# GPUPointSpatialFilter
+
+<GPUPrimitivesDocsTabs active="point-spatial-filter" />
+
+## Overview
+
+`GPUPointSpatialFilter` evaluates exact bounds or radius predicates over packed 2D or 3D points.
+It can scan every source row or refine a compact candidate list from `GPUGridIndexQuery`. Both paths
+write the same source-row-aligned mask, so visibility, selection, compaction, picking, and indirect
+drawing do not need separate indexed and unindexed implementations.
+
+This primitive supplies the narrow phase that a grid deliberately does not. A grid knows which
+cells overlap a query; the filter knows whether each point is actually inside the bounds, circle,
+or sphere. Separating those jobs preserves exact results without teaching the index about every
+possible object representation.
+
+## Concepts
+
+### One predicate, two execution strategies
+
+```text
+unindexed: all source rows ────────────────→ exact point predicate → source mask
+indexed:   grid query → candidate row IDs → exact point predicate → source mask
+```
+
+The unindexed path is not merely a fallback. It is the correctness oracle and is often the faster
+choice for small data, broad queries, or data that changes so frequently that index construction
+cannot be amortized. The indexed path helps when queries are selective enough that testing a
+compact candidate set saves more work than building and querying the grid costs.
+
+Because both paths publish the same mask contract, an application can select a strategy from
+measurements without changing its renderer or interaction code.
+
+### What is exact
+
+| Kind | Query layout | Exact rule | Example use cases |
+| --- | --- | --- | --- |
+| `bounds` | 2D: `[minX, minY, maxX, maxY]`; 3D adds Z | Every coordinate is inside the inclusive bounds | Box selection, viewport points, simulation regions |
+| `radius` | Center followed by radius | Squared point distance is at most radius squared | Proximity, brush selection, influence neighborhoods |
+
+Non-finite positions or query values, reversed bounds, and negative radii do not match. The filter
+handles points, not object extents: a circle intersecting a polygon or a box touching a sphere needs
+an application-specific exact predicate over that geometry.
+
+### Candidate rows and stable identity
+
+Candidate IDs are interpreted as source-row addresses because the filter uses them to load packed
+positions and set the corresponding mask row. This is intentionally narrower than
+`GPUGridIndexQuery`, whose stable IDs may be arbitrary. Use this refinement path when the index was
+built with generated row IDs. Applications with global or sparse IDs can keep a separate row-to-ID
+vector for final visibility output, or provide a domain-specific refinement pass.
+
+The candidate `count` is clamped to candidate storage capacity before dispatch. Invalid row IDs are
+ignored rather than read. Candidate overflow is propagated, because an exact mask refined from a
+truncated broad phase is incomplete even if every stored candidate was tested successfully.
+
+### Choosing the crossover
+
+Do not infer the crossover from row count alone. Measure at least:
+
+- index build or rebuild time and how many queries reuse it;
+- cells touched and candidate count per query;
+- exact predicate time for all rows versus candidates;
+- grid storage, candidate storage, and source-mask memory;
+- update rate and the percentage of points that change cells.
+
+A useful first diagnostic is `candidateCount / positionCount`. A small ratio suggests that indexed
+refinement may help, but GPU dispatch overhead, cell density, and index amortization still determine
+the actual result. Performance guidance should report distributions across representative queries,
+not a universal threshold.
+
+## Usage
+
+```ts
+const candidateMask = graph.createDataView(candidateMaskBuffer, {
+  format: 'uint32',
+  length: positions.length
+});
+
+new GPUPointSpatialFilter({
+  positions,
+  kind: 'radius',
+  query: centerAndRadius,
+  candidates: {
+    ids: gridCandidates,
+    count: gridCandidateCount,
+    overflow: gridCandidateOverflow
+  },
+  outputMask: candidateMask,
+  overflow: exactResultOverflow
+}).addToGraph(graph);
+
+new GPUVisibilityWorkflow({
+  predicates: [
+    {kind: 'bounds', mask: candidateMask},
+    {kind: 'selection', mask: selectedRows}
+  ],
+  output: visibleIds,
+  count: visibleCount
+}).addToGraph(graph);
+```
+
+Omit `candidates` to dispatch the identical exact predicate over every source point. Query-buffer
+updates require no graph recompilation. The primitive clears its output mask and overflow word on
+every encoding; it does not submit, read back, compact, or allocate caller-visible results.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -225,6 +225,7 @@
               "api-reference/experimental/gpu-primitives/gpu-grid-aggregation",
               "api-reference/experimental/gpu-primitives/gpu-grid-index",
               "api-reference/experimental/gpu-primitives/gpu-grid-index-query",
+              "api-reference/experimental/gpu-primitives/gpu-point-spatial-filter",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]
@@ -315,6 +316,7 @@
               "api-reference/experimental/gpu-primitives/gpu-grid-aggregation",
               "api-reference/experimental/gpu-primitives/gpu-grid-index",
               "api-reference/experimental/gpu-primitives/gpu-grid-index-query",
+              "api-reference/experimental/gpu-primitives/gpu-point-spatial-filter",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]

--- a/modules/experimental/src/gpu-primitives/gpu-point-spatial-filter.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-point-spatial-filter.ts
@@ -1,0 +1,352 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {type Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-command-graph';
+import {
+  getViewBinding,
+  getViewElementOffset,
+  validatePackedUint32View,
+  validatePackedView
+} from './graph-data-view-utils';
+
+const POINT_FILTER_WORKGROUP_SIZE = 256;
+
+/** Exact point predicate evaluated by {@link GPUPointSpatialFilter}. */
+export type GPUPointSpatialFilterKind = 'bounds' | 'radius';
+
+/** Optional compact candidate rows used instead of scanning every source point. */
+export type GPUPointSpatialFilterCandidates = {
+  /** Source-row IDs to test. */
+  ids: GraphDataView<'uint32'>;
+  /** Number of valid IDs, which may exceed `ids.length` when the producer overflowed. */
+  count: GraphDataView<'uint32'>;
+  /** Optional producer overflow flag propagated to the filter output. */
+  overflow?: GraphDataView<'uint32'>;
+};
+
+/** Properties for one exact point spatial predicate. */
+export type GPUPointSpatialFilterProps = {
+  /** Prefix for generated graph node IDs. */
+  id?: string;
+  /** Packed two- or three-dimensional source points. */
+  positions: GraphDataView<'float32x2'> | GraphDataView<'float32x3'>;
+  /** Exact predicate to evaluate. */
+  kind: GPUPointSpatialFilterKind;
+  /** Packed bounds or center/radius values, mutable between graph encodings. */
+  query: GraphDataView<'float32'>;
+  /** Source-row-aligned mask, cleared on every encoding. */
+  outputMask: GraphDataView<'uint32'>;
+  /** Receives candidate truncation or producer overflow. */
+  overflow: GraphDataView<'uint32'>;
+  /** When present, test only these source rows instead of scanning all positions. */
+  candidates?: GPUPointSpatialFilterCandidates;
+};
+
+/**
+ * Evaluates exact bounds or radius predicates over packed 2D or 3D points.
+ *
+ * Without candidates, every source point is scanned and the primitive provides an unindexed
+ * correctness and cost baseline. With candidates, only the compact source-row IDs produced by a
+ * spatial index are tested. Both modes publish the same source-aligned mask so downstream
+ * visibility, compaction, and indirect drawing remain independent of the acceleration strategy.
+ */
+export class GPUPointSpatialFilter {
+  readonly id: string;
+  readonly positions: GraphDataView<'float32x2'> | GraphDataView<'float32x3'>;
+  readonly kind: GPUPointSpatialFilterKind;
+  readonly query: GraphDataView<'float32'>;
+  readonly outputMask: GraphDataView<'uint32'>;
+  readonly overflow: GraphDataView<'uint32'>;
+  readonly candidates?: GPUPointSpatialFilterCandidates;
+  readonly dimension: 2 | 3;
+
+  constructor(props: GPUPointSpatialFilterProps) {
+    this.id = props.id ?? 'gpu-point-spatial-filter';
+    this.positions = props.positions;
+    this.kind = props.kind;
+    this.query = props.query;
+    this.outputMask = props.outputMask;
+    this.overflow = props.overflow;
+    this.candidates = props.candidates;
+    this.dimension = this.positions.format === 'float32x2' ? 2 : 3;
+
+    validatePackedView(this.positions, ['float32x2', 'float32x3'], `${this.id} positions`);
+    validatePackedView(this.query, ['float32'], `${this.id} query`);
+    validatePackedUint32View(this.outputMask, `${this.id} outputMask`);
+    validatePackedUint32View(this.overflow, `${this.id} overflow`);
+    if (this.outputMask.length !== this.positions.length) {
+      throw new Error(`${this.id} outputMask.length must equal positions.length`);
+    }
+    if (this.overflow.length < 1) {
+      throw new Error(`${this.id} overflow must contain one uint32 row`);
+    }
+    const expectedQueryLength = this.kind === 'bounds' ? this.dimension * 2 : this.dimension + 1;
+    if (this.query.length !== expectedQueryLength) {
+      throw new Error(`${this.id} ${this.kind} query must contain ${expectedQueryLength} floats`);
+    }
+    if (this.candidates) {
+      validatePackedUint32View(this.candidates.ids, `${this.id} candidate IDs`);
+      validatePackedUint32View(this.candidates.count, `${this.id} candidate count`);
+      if (this.candidates.count.length < 1) {
+        throw new Error(`${this.id} candidate count must contain one uint32 row`);
+      }
+      if (this.candidates.overflow) {
+        validatePackedUint32View(this.candidates.overflow, `${this.id} candidate overflow`);
+        if (this.candidates.overflow.length < 1) {
+          throw new Error(`${this.id} candidate overflow must contain one uint32 row`);
+        }
+      }
+    }
+  }
+
+  /** Adds mask initialization and exact point filtering without submission or readback. */
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    const views = [
+      this.positions,
+      this.query,
+      this.outputMask,
+      this.overflow,
+      ...(this.candidates
+        ? [
+            this.candidates.ids,
+            this.candidates.count,
+            ...(this.candidates.overflow ? [this.candidates.overflow] : [])
+          ]
+        : [])
+    ];
+    if (views.some(view => view.buffer.graph !== graph)) {
+      throw new Error(`${this.id} views must belong to the target graph`);
+    }
+    addInitializePass(graph, this);
+    const dispatchLength = this.candidates?.ids.length ?? this.positions.length;
+    if (dispatchLength > 0) addFilterPass(graph, this, dispatchLength);
+  }
+}
+
+function addInitializePass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  filter: GPUPointSpatialFilter
+): void {
+  const candidateBindings = filter.candidates
+    ? `@group(0) @binding(2) var<storage, read> candidateCount: array<u32>;
+${
+  filter.candidates.overflow
+    ? '@group(0) @binding(3) var<storage, read> sourceOverflow: array<u32>;'
+    : ''
+}`
+    : '';
+  const initialOverflow = filter.candidates
+    ? `select(0u, 1u, candidateCount[CANDIDATE_COUNT_OFFSET] > CANDIDATE_CAPACITY${
+        filter.candidates.overflow ? ' || sourceOverflow[SOURCE_OVERFLOW_OFFSET] != 0u' : ''
+      })`
+    : '0u';
+  const source = /* wgsl */ `
+const MASK_LENGTH: u32 = ${filter.outputMask.length}u;
+const MASK_OFFSET: u32 = ${getViewElementOffset(filter.outputMask)}u;
+const OVERFLOW_OFFSET: u32 = ${getViewElementOffset(filter.overflow)}u;
+${
+  filter.candidates
+    ? `const CANDIDATE_COUNT_OFFSET: u32 = ${getViewElementOffset(filter.candidates.count)}u;
+const CANDIDATE_CAPACITY: u32 = ${filter.candidates.ids.length}u;
+${
+  filter.candidates.overflow
+    ? `const SOURCE_OVERFLOW_OFFSET: u32 = ${getViewElementOffset(filter.candidates.overflow)}u;`
+    : ''
+}`
+    : ''
+}
+@group(0) @binding(0) var<storage, read_write> outputMask: array<u32>;
+@group(0) @binding(1) var<storage, read_write> outputOverflow: array<u32>;
+${candidateBindings}
+
+@compute @workgroup_size(${POINT_FILTER_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  if (globalId.x < MASK_LENGTH) { outputMask[MASK_OFFSET + globalId.x] = 0u; }
+  if (globalId.x == 0u) { outputOverflow[OVERFLOW_OFFSET] = ${initialOverflow}; }
+}`;
+  const resources: GraphBufferUse[] = [
+    {buffer: filter.outputMask, usage: 'storage-write'},
+    {buffer: filter.overflow, usage: 'storage-write'},
+    ...(filter.candidates
+      ? ([{buffer: filter.candidates.count, usage: 'storage-read'}] as GraphBufferUse[])
+      : []),
+    ...(filter.candidates?.overflow
+      ? ([{buffer: filter.candidates.overflow, usage: 'storage-read'}] as GraphBufferUse[])
+      : [])
+  ];
+  addComputationPass(graph, {
+    id: `${filter.id}-initialize`,
+    source,
+    resources,
+    bindings: {
+      outputMask: filter.outputMask,
+      outputOverflow: filter.overflow,
+      ...(filter.candidates ? {candidateCount: filter.candidates.count} : {}),
+      ...(filter.candidates?.overflow ? {sourceOverflow: filter.candidates.overflow} : {})
+    },
+    dispatchCount: Math.ceil(Math.max(filter.outputMask.length, 1) / POINT_FILTER_WORKGROUP_SIZE)
+  });
+}
+
+function addFilterPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  filter: GPUPointSpatialFilter,
+  dispatchLength: number
+): void {
+  const candidateBindings = filter.candidates
+    ? `@group(0) @binding(3) var<storage, read> candidateIds: array<u32>;
+@group(0) @binding(4) var<storage, read> candidateCount: array<u32>;`
+    : '';
+  const candidateConstants = filter.candidates
+    ? `const CANDIDATE_IDS_OFFSET: u32 = ${getViewElementOffset(filter.candidates.ids)}u;
+const CANDIDATE_COUNT_OFFSET: u32 = ${getViewElementOffset(filter.candidates.count)}u;
+const CANDIDATE_CAPACITY: u32 = ${filter.candidates.ids.length}u;`
+    : '';
+  const rowSelection = filter.candidates
+    ? `let storedCandidateCount = min(candidateCount[CANDIDATE_COUNT_OFFSET], CANDIDATE_CAPACITY);
+  if (invocationIndex >= storedCandidateCount) { return; }
+  let sourceRow = candidateIds[CANDIDATE_IDS_OFFSET + invocationIndex];`
+    : `if (invocationIndex >= POSITION_COUNT) { return; }
+  let sourceRow = invocationIndex;`;
+  const predicate = makePredicate(filter);
+  const source = /* wgsl */ `
+const POSITION_COUNT: u32 = ${filter.positions.length}u;
+const POSITIONS_OFFSET: u32 = ${getViewElementOffset(filter.positions)}u;
+const QUERY_OFFSET: u32 = ${getViewElementOffset(filter.query)}u;
+const MASK_OFFSET: u32 = ${getViewElementOffset(filter.outputMask)}u;
+${candidateConstants}
+@group(0) @binding(0) var<storage, read> positions: array<f32>;
+@group(0) @binding(1) var<storage, read> queryValues: array<f32>;
+@group(0) @binding(2) var<storage, read_write> outputMask: array<atomic<u32>>;
+${candidateBindings}
+
+fn finite(value: f32) -> bool {
+  return value == value && abs(value) <= 3.402823466e+38;
+}
+
+@compute @workgroup_size(${POINT_FILTER_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  let invocationIndex = globalId.x;
+  ${rowSelection}
+  if (sourceRow >= POSITION_COUNT) { return; }
+  ${predicate}
+  if (selected) { atomicStore(&outputMask[MASK_OFFSET + sourceRow], 1u); }
+}`;
+  const resources: GraphBufferUse[] = [
+    {buffer: filter.positions, usage: 'storage-read'},
+    {buffer: filter.query, usage: 'storage-read'},
+    {buffer: filter.outputMask, usage: 'storage-read-write'},
+    ...(filter.candidates
+      ? ([
+          {buffer: filter.candidates.ids, usage: 'storage-read'},
+          {buffer: filter.candidates.count, usage: 'storage-read'}
+        ] as GraphBufferUse[])
+      : [])
+  ];
+  addComputationPass(graph, {
+    id: filter.id,
+    source,
+    resources,
+    bindings: {
+      positions: filter.positions,
+      queryValues: filter.query,
+      outputMask: filter.outputMask,
+      ...(filter.candidates
+        ? {candidateIds: filter.candidates.ids, candidateCount: filter.candidates.count}
+        : {})
+    },
+    dispatchCount: Math.ceil(dispatchLength / POINT_FILTER_WORKGROUP_SIZE)
+  });
+}
+
+function makePredicate(filter: GPUPointSpatialFilter): string {
+  const axes = ['X', 'Y', ...(filter.dimension === 3 ? ['Z'] : [])];
+  const positionValues = axes
+    .map(
+      (axis, axisIndex) =>
+        `let position${axis} = positions[POSITIONS_OFFSET + sourceRow * ${filter.dimension}u + ${axisIndex}u];`
+    )
+    .join('\n  ');
+  const finitePosition = axes.map(axis => `finite(position${axis})`).join(' && ');
+  if (filter.kind === 'bounds') {
+    const queryValues = axes
+      .map(
+        (axis, axisIndex) =>
+          `let queryMin${axis} = queryValues[QUERY_OFFSET + ${axisIndex}u];
+  let queryMax${axis} = queryValues[QUERY_OFFSET + ${axisIndex + filter.dimension}u];`
+      )
+      .join('\n  ');
+    const validBounds = axes
+      .map(
+        axis =>
+          `finite(queryMin${axis}) && finite(queryMax${axis}) && queryMin${axis} <= queryMax${axis}`
+      )
+      .join(' && ');
+    const inside = axes
+      .map(axis => `position${axis} >= queryMin${axis} && position${axis} <= queryMax${axis}`)
+      .join(' && ');
+    return `${positionValues}
+  ${queryValues}
+  let selected = ${finitePosition} && ${validBounds} && ${inside};`;
+  }
+
+  const centerValues = axes
+    .map(
+      (axis, axisIndex) =>
+        `let query${axis} = queryValues[QUERY_OFFSET + ${axisIndex}u];
+  let distance${axis} = position${axis} - query${axis};`
+    )
+    .join('\n  ');
+  const finiteCenter = axes.map(axis => `finite(query${axis})`).join(' && ');
+  const squaredDistance = axes.map(axis => `distance${axis} * distance${axis}`).join(' + ');
+  return `${positionValues}
+  ${centerValues}
+  let radius = queryValues[QUERY_OFFSET + ${filter.dimension}u];
+  let selected = ${finitePosition} && ${finiteCenter} && finite(radius) && radius >= 0.0 && ${squaredDistance} <= radius * radius;`;
+}
+
+function addComputationPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    source: string;
+    resources: GraphBufferUse[];
+    bindings: Record<string, GraphDataView>;
+    dispatchCount: number;
+  }
+): void {
+  graph.addComputePass({
+    id: props.id,
+    resources: props.resources,
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: props.id,
+        source: props.source,
+        shaderLayout: {
+          bindings: Object.keys(props.bindings).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const [name, view] of Object.entries(props.bindings)) {
+            bindings[name] = getViewBinding(view, getBuffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatch(computePass, props.dispatchCount);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -117,6 +117,13 @@ export type {
   GPUGridIndexView
 } from './gpu-grid-index-query';
 
+export {GPUPointSpatialFilter} from './gpu-point-spatial-filter';
+export type {
+  GPUPointSpatialFilterCandidates,
+  GPUPointSpatialFilterKind,
+  GPUPointSpatialFilterProps
+} from './gpu-point-spatial-filter';
+
 export {GPUGridAggregation} from './gpu-grid-aggregation';
 export type {
   GPUGridAggregationOperation,

--- a/modules/experimental/test/gpu-primitives/gpu-point-spatial-filter.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-point-spatial-filter.spec.ts
@@ -1,0 +1,336 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {Buffer, type Device} from '@luma.gl/core';
+import {
+  GPUCommandGraph,
+  GPUGridIndex,
+  GPUGridIndexQuery,
+  GPUPointSpatialFilter,
+  GPUVisibilityWorkflow,
+  type CompiledGPUCommandGraph,
+  type GPUPointSpatialFilterKind,
+  type GraphDataView
+} from '@luma.gl/experimental';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+test('GPUPointSpatialFilter gives indexed and unindexed 2D visibility the same exact result', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const fixture = createFixture(device, {
+    positions: Float32Array.from([
+      0.1, 0.1, 0.7, 0.7, 1.1, 0.4, 1.6, 0.6, 0.4, 1.4, 1.4, 1.4, 1.9, 1.9
+    ]),
+    dimension: 2,
+    gridSize: [2, 2],
+    bounds: [0, 0, 2, 2],
+    kind: 'radius',
+    query: Float32Array.from([0.5, 0.5, 0.48])
+  });
+  encode(device, fixture.compiled);
+
+  t.deepEqual(await readVisible(fixture.indexed), [1], 'grid candidates are refined exactly');
+  t.deepEqual(
+    await readVisible(fixture.unindexed),
+    [1],
+    'the full scan provides the same exact visibility oracle'
+  );
+  t.deepEqual(
+    await readUint32(fixture.candidateCount, 1),
+    [2],
+    'the broad phase visits only points in intersecting cells'
+  );
+  t.deepEqual(await readUint32(fixture.indexed.overflow, 1), [0]);
+
+  fixture.query.write(Float32Array.from([1.5, 1.5, 0.6]));
+  encode(device, fixture.compiled);
+  t.deepEqual((await readVisible(fixture.indexed)).sort(sortNumbers), [5, 6]);
+  t.deepEqual(
+    (await readVisible(fixture.unindexed)).sort(sortNumbers),
+    [5, 6],
+    'query updates preserve indexed/unindexed equivalence without recompiling'
+  );
+
+  destroyFixture(fixture);
+  t.end();
+});
+
+test('GPUPointSpatialFilter composes 3D bounds candidates with selection visibility', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const fixture = createFixture(device, {
+    positions: Float32Array.from([
+      0.2, 0.2, 0.2, 0.8, 0.8, 0.8, 1.1, 0.4, 0.4, 1.7, 0.7, 0.7, 0.4, 0.4, 1.4, 1.4, 1.4, 1.4
+    ]),
+    dimension: 3,
+    gridSize: [2, 2, 2],
+    bounds: [0, 0, 0, 2, 2, 2],
+    kind: 'bounds',
+    query: Float32Array.from([0, 0, 0, 1.2, 0.6, 0.6]),
+    selection: Uint32Array.from([1, 1, 0, 1, 1, 1])
+  });
+  encode(device, fixture.compiled);
+
+  t.deepEqual(await readVisible(fixture.indexed), [0], 'selection intersects exact spatial mask');
+  t.deepEqual(await readVisible(fixture.unindexed), [0], '3D indexed and scan paths agree');
+  t.deepEqual(
+    await readUint32(fixture.indexed.mask, 6),
+    [1, 0, 0, 0, 0, 0],
+    'visibility publishes the composed canonical mask'
+  );
+
+  destroyFixture(fixture);
+  t.end();
+});
+
+type ResultBuffers = {
+  ids: Buffer;
+  count: Buffer;
+  mask: Buffer;
+  overflow: Buffer;
+};
+
+type Fixture = {
+  compiled: CompiledGPUCommandGraph<void>;
+  query: Buffer;
+  candidateCount: Buffer;
+  indexed: ResultBuffers;
+  unindexed: ResultBuffers;
+  buffers: Buffer[];
+};
+
+function createFixture(
+  device: Device,
+  props: {
+    positions: Float32Array;
+    dimension: 2 | 3;
+    gridSize: readonly [number, number] | readonly [number, number, number];
+    bounds:
+      | readonly [number, number, number, number]
+      | readonly [number, number, number, number, number, number];
+    kind: GPUPointSpatialFilterKind;
+    query: Float32Array;
+    selection?: Uint32Array;
+  }
+): Fixture {
+  const length = props.positions.length / props.dimension;
+  const cellCount = props.gridSize.reduce((product, size) => product * size, 1);
+  const positions = createInputBuffer(device, props.positions);
+  const query = createInputBuffer(device, props.query);
+  const selection = props.selection ? createInputBuffer(device, props.selection) : undefined;
+  const cellOffsets = createOutputBuffer(device, cellCount + 1);
+  const objectIds = createOutputBuffer(device, length);
+  const indexCount = createOutputBuffer(device, 1);
+  const indexOverflow = createOutputBuffer(device, 1);
+  const candidateIds = createOutputBuffer(device, length);
+  const candidateCount = createOutputBuffer(device, 1);
+  const candidateOverflow = createOutputBuffer(device, 1);
+  const indexed = createResultBuffers(device, length);
+  const unindexed = createResultBuffers(device, length);
+  const graph = new GPUCommandGraph(device, {id: 'point-spatial-filter-consumer'});
+
+  const positionsView = importView(
+    graph,
+    'positions',
+    positions,
+    props.dimension === 2 ? 'float32x2' : 'float32x3',
+    length
+  );
+  const queryView = importView(graph, 'query', query, 'float32', props.query.length);
+  const index = new GPUGridIndex({
+    positions: positionsView,
+    gridSize: props.gridSize,
+    bounds: props.bounds,
+    cellOffsets: importView(graph, 'cell-offsets', cellOffsets, 'uint32', cellCount + 1),
+    objectIds: importView(graph, 'object-ids', objectIds, 'uint32', length),
+    count: importView(graph, 'index-count', indexCount, 'uint32', 1),
+    overflow: importView(graph, 'index-overflow', indexOverflow, 'uint32', 1)
+  });
+  index.addToGraph(graph);
+
+  const candidateIdsView = importView(graph, 'candidate-ids', candidateIds, 'uint32', length);
+  const candidateCountView = importView(graph, 'candidate-count', candidateCount, 'uint32', 1);
+  const candidateOverflowView = importView(
+    graph,
+    'candidate-overflow',
+    candidateOverflow,
+    'uint32',
+    1
+  );
+  new GPUGridIndexQuery({
+    index,
+    kind: props.kind,
+    query: queryView,
+    output: candidateIdsView,
+    count: candidateCountView,
+    overflow: candidateOverflowView
+  }).addToGraph(graph);
+
+  addFilterAndVisibility(graph, {
+    id: 'indexed',
+    positions: positionsView,
+    kind: props.kind,
+    query: queryView,
+    result: indexed,
+    length,
+    selection,
+    candidates: {
+      ids: candidateIdsView,
+      count: candidateCountView,
+      overflow: candidateOverflowView
+    }
+  });
+  addFilterAndVisibility(graph, {
+    id: 'unindexed',
+    positions: positionsView,
+    kind: props.kind,
+    query: queryView,
+    result: unindexed,
+    length,
+    selection
+  });
+
+  const buffers = [
+    positions,
+    query,
+    ...(selection ? [selection] : []),
+    cellOffsets,
+    objectIds,
+    indexCount,
+    indexOverflow,
+    candidateIds,
+    candidateCount,
+    candidateOverflow,
+    ...Object.values(indexed),
+    ...Object.values(unindexed)
+  ];
+  return {compiled: graph.compile(), query, candidateCount, indexed, unindexed, buffers};
+}
+
+function addFilterAndVisibility(
+  graph: GPUCommandGraph,
+  props: {
+    id: string;
+    positions: GraphDataView<'float32x2'> | GraphDataView<'float32x3'>;
+    kind: GPUPointSpatialFilterKind;
+    query: GraphDataView<'float32'>;
+    result: ResultBuffers;
+    length: number;
+    selection?: Buffer;
+    candidates?: {
+      ids: GraphDataView<'uint32'>;
+      count: GraphDataView<'uint32'>;
+      overflow: GraphDataView<'uint32'>;
+    };
+  }
+): void {
+  const exactMaskBuffer = graph.createTransientBuffer({
+    id: `${props.id}-exact-mask`,
+    byteLength: Math.max(props.length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE
+  });
+  const exactMask = graph.createDataView(exactMaskBuffer, {format: 'uint32', length: props.length});
+  const outputMask = importView(
+    graph,
+    `${props.id}-output-mask`,
+    props.result.mask,
+    'uint32',
+    props.length
+  );
+  const overflow = importView(graph, `${props.id}-overflow`, props.result.overflow, 'uint32', 1);
+  new GPUPointSpatialFilter({
+    id: `${props.id}-point-filter`,
+    positions: props.positions,
+    kind: props.kind,
+    query: props.query,
+    outputMask: exactMask,
+    overflow,
+    candidates: props.candidates
+  }).addToGraph(graph);
+
+  const predicates = [{kind: 'bounds' as const, mask: exactMask}];
+  if (props.selection) {
+    predicates.push({
+      kind: 'selection',
+      mask: importView(graph, `${props.id}-selection`, props.selection, 'uint32', props.length)
+    });
+  }
+  new GPUVisibilityWorkflow({
+    id: `${props.id}-visibility`,
+    predicates,
+    output: importView(graph, `${props.id}-visible-ids`, props.result.ids, 'uint32', props.length),
+    count: importView(graph, `${props.id}-visible-count`, props.result.count, 'uint32', 1),
+    outputMask
+  }).addToGraph(graph);
+}
+
+function createResultBuffers(device: Device, length: number): ResultBuffers {
+  return {
+    ids: createOutputBuffer(device, length),
+    count: createOutputBuffer(device, 1),
+    mask: createOutputBuffer(device, length),
+    overflow: createOutputBuffer(device, 1)
+  };
+}
+
+function createInputBuffer(device: Device, values: Float32Array | Uint32Array): Buffer {
+  return device.createBuffer({data: values, usage: Buffer.STORAGE | Buffer.COPY_DST});
+}
+
+function createOutputBuffer(device: Device, length: number): Buffer {
+  return device.createBuffer({
+    byteLength: Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+}
+
+function importView<T extends 'float32x2' | 'float32x3' | 'float32' | 'uint32'>(
+  graph: GPUCommandGraph,
+  id: string,
+  buffer: Buffer,
+  format: T,
+  length: number
+): GraphDataView<T> {
+  const handle = graph.importBuffer(
+    {id, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return graph.createDataView(handle, {format, length});
+}
+
+async function readVisible(result: ResultBuffers): Promise<number[]> {
+  const count = (await readUint32(result.count, 1))[0];
+  return readUint32(result.ids, count);
+}
+
+async function readUint32(buffer: Buffer, length: number): Promise<number[]> {
+  const bytes = await buffer.readAsync();
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, length));
+}
+
+function encode(device: Device, compiled: CompiledGPUCommandGraph<void>): void {
+  const commandEncoder = device.createCommandEncoder({id: 'point-spatial-filter-test'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+}
+
+function destroyFixture(fixture: Fixture): void {
+  fixture.compiled.destroy();
+  for (const buffer of fixture.buffers) buffer.destroy();
+}
+
+function sortNumbers(left: number, right: number): number {
+  return left - right;
+}

--- a/website/src/components/docs/gpu-primitives-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-primitives-docs-tabs.tsx
@@ -18,6 +18,7 @@ export type GPUPrimitivesDocsTabId =
   | 'grid-aggregation'
   | 'grid-index'
   | 'grid-index-query'
+  | 'point-spatial-filter'
   | 'group-aggregation'
   | 'index-picking'
   | 'readback-ring'
@@ -103,6 +104,11 @@ const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
     id: 'grid-index-query',
     label: 'Grid Query',
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-grid-index-query'
+  },
+  {
+    id: 'point-spatial-filter',
+    label: 'Point Filter',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-point-spatial-filter'
   },
   {
     id: 'group-aggregation',


### PR DESCRIPTION
## Goals

Close the gap between conservative grid candidates and exact visibility while keeping indexed and unindexed execution behind the same source-mask contract.

## Changes

- add `GPUPointSpatialFilter` for exact 2D/3D bounds and radius predicates
- support a full source scan or compact candidate-row refinement with the same output mask
- propagate candidate capacity and producer overflow so incomplete broad phases remain visible
- compose exact masks with `GPUVisibilityWorkflow` and selection predicates
- compare indexed and unindexed GPU results in 2D and 3D, including dynamic query updates
- add an Overview/Concepts page covering broad versus narrow phases, row identity, use cases, and the scan/grid crossover inputs
- split measured crossover work from the now-implemented exact-consumer tranche

## Impact

Applications can add or remove grid acceleration without forking their visibility, compaction, picking, or indirect-draw path. The full-scan mode is also a correctness oracle and a legitimate strategy for small, broad, or frequently changing data.

## Verification

- `nvm use`
- `yarn lint fix`
- `yarn build`
- focused WebGPU point-filter suite: 2 tests passed
- commit hook/node suite: 254 passed, 2 skipped

## Stack

- Depends on #2813.
- The next slice adds flat `GPUBVH` storage/build contracts after this consumer establishes the shared refinement boundary.