### PR TITLE
feat(experimental): add GPU BVH refit storage

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1006,47 +1006,72 @@ schedule commitment.
 | 0 — Current foundation | Command graph, masks, hierarchy layout, graph traversal, ancestor projection, compaction, indirect drawing, picking, analysis primitives, and three working consumers | Implemented | High | Complete |
 | 1 — Hardening and observability | GPU timestamps, performance baselines, adapter capability reporting, boundary and overflow validation, memory statistics, and device-loss and resource-lifetime coverage | Implemented | High | Medium |
 | 2 — Reusable visibility workflows | Renderer-independent time-range, bounds, LOD, and selection workflows that publish stable IDs, counts, and indirect commands | Implemented | High | Medium |
-| 3 — Algorithm and table scaling | Multi-chunk coverage, segmented and inclusive scans, weighted statistics, richer histograms, and batch-preserving algorithms | Implemented | High | Large |
+| 3 — Algorithm and table scaling | Multi-chunk coverage, segmented and inclusive scans, weighted statistics, richer histograms, and batch-preserving algorithms | Core implemented; topology extensions deferred | High | Large |
 | 4 — Picking and texture coverage | Region picking, asynchronous staging rings, multisample resolves, frame-scoped swapchain imports, and sampled-only external-image contracts | Implemented | Medium | Large |
 | 5 — Spatial acceleration | `GPUGridIndex` followed by `GPUBVH`, with explicit build, update, and query costs | In progress | High | Large |
 | 6 — GPUScene | A flat GPU draw database with stable identity, bounds, transforms, grouping, geometry references, and indirect command slots | Planned | High | Large |
 | 7 — API graduation | Stable package contracts, compatibility exports, and a dependency-safe move out of experimental packages | Planned | High | Large |
 
+### Implemented spatial milestones
+
+Phase 4 is implemented through Tranche 4.4. The spatial stack now includes compact 2D/3D
+`GPUGridIndex` construction, conservative queries, exact point refinement with an unindexed GPU
+oracle, and deterministic complete-binary `GPUBVH` storage and refit. These are foundations, not a
+claim that incremental grid updates or source-order BVH topology are always profitable.
+
+| Milestone | Implemented outcome |
+| --- | --- |
+| 5.1a — `GPUGridIndex` build | Stable cell offsets and capacity-bounded IDs for packed 2D/3D points |
+| 5.2a — `GPUGridIndex` query | Point, bounds, and radius cell candidates with masks, counts, and overflow |
+| 5.2b — Exact query consumers | Indexed and unindexed 2D/3D point predicates feeding one visibility contract |
+| 5.3a — `GPUBVH` storage and refit | Flat complete-binary nodes, stable leaf slots, explicit capacity, and bottom-up refit |
+
 ### Remaining tranche map
 
-The remaining phases are intentionally divided into reviewable contracts. A tranche should land
-only when its entry dependency is present and its exit evidence can be produced; the numbering is
-dependency order, not a schedule commitment. Tranches whose dependencies do not overlap may be
-developed independently.
+The remaining work is divided into reviewable contracts. A tranche should land only when its entry
+dependency is present and its measurable exit evidence can be produced. Numbering groups related
+contracts; table order and the recommended sequence express dependency order, not staffing or
+schedule commitments. Conditional implementation tranches are entered only when the preceding
+decision gate shows that their added memory and complexity pay for themselves in representative
+consumers.
 
-Phase 4 is implemented through Tranche 4.4. Compact `GPUGridIndex` construction, conservative
-queries, exact 2D/3D point refinement, and the first flat `GPUBVH` storage/refit contract are
-implemented; optimized topology and measured cost comparisons remain active boundaries.
+| Tranche | Outcome | Entry dependency | Measurable exit | Impact | Cost |
+| --- | --- | --- | --- | :---: | :---: |
+| 3.2 — Partitioned topology | Global-ID and chunk-base contracts for hierarchy and CSR inputs without hidden packing | Implemented Phase 3 primitives plus a preserved-batch consumer | CPU-oracle parity across empty and uneven chunks; no implicit repack | High | Large |
+| 3.3 — Extension decision gate | Decide sparse or multidimensional histograms, custom scans, and shader extension points separately | Tranche 3.2 plus at least two requesting consumers | Each proposal is accepted with a fixed contract or explicitly deferred with evidence | Medium | Small |
+| 5.4a — BVH bounds and point query | Capacity-bounded candidates and masks using the grid refinement/overflow contract | Tranche 5.3a | 2D/3D CPU-oracle parity for empty, overlapping, invalid, and overflowed trees | High | Medium |
+| 5.2c — Spatial benchmark harness | Repeatable scan/grid/BVH measurements with shared data, queries, and correctness oracle | GPU timestamps, Tranche 5.2b, and Tranche 5.4a for BVH columns | Reports build, refit, query, refinement, memory, selectivity, and reuse distributions | High | Medium |
+| 5.1b — Grid update decision gate | Compare full rebuild with bounded relocation and reserved-cell designs | Tranche 5.2c plus a moving-data consumer | Decision records crossover, memory overhead, fragmentation, and overflow behavior | Medium | Medium |
+| 5.1c — Incremental grid maintenance | Implement only the update design selected by Tranche 5.1b | Positive Tranche 5.1b decision | Matches full rebuild after adversarial moves and demonstrates an update-rate win | High | Large |
+| 5.3b — BVH topology-quality evidence | Measure source order, producer order, and Morton order without changing storage | Tranches 5.3a, 5.4a, and GPU timestamps | Reports visited nodes, candidate ratios, build/refit cost, and overlap quality | High | Medium |
+| 5.3c — Spatial topology rebuild | Add Morton or another builder only if Tranche 5.3b demonstrates a material win | Positive Tranche 5.3b decision | Rebuild/refit query equivalence and separately measured sorting/topology costs | High | Large |
+| 5.4b — BVH ray-like query | Point-to-ray and segment candidates with bounded traversal work | Tranche 5.4a and a picking or simulation consumer | CPU-oracle parity plus explicit stack/work-queue capacity and overflow | Medium | Large |
+| 5.4c — Phase 5 cost model | Publish scan/grid/BVH selection guidance without universal-winner claims | Tranches 5.2c, 5.3b, and 5.4b; include 5.1c/5.3c only if built | Guidance covers size, update rate, selectivity, reuse, memory, and topology quality | High | Medium |
+| 6.1a — Scene record contract | Flat stable-ID records for bounds, transforms, groups, geometry references, and command slots | Phase 2 and Tranche 5.4a | Layout and ownership tests; no CPU hierarchy or table type in the core | High | Medium |
+| 6.1b — Scene updates and compaction | Insert, remove, patch, and compact records with bounded work | Tranche 6.1a | Identity/reference preservation under holes, moves, overflow, and compaction | High | Large |
+| 6.1c — Scene adapters | Explicit CPU-scene and GPU-table adapters without a canonical source model | Tranche 6.1b and partitioned-topology decisions | Both adapters build the same records without casts or hidden packing | High | Medium |
+| 6.2a — Draw-command generation | Visibility and spatial results write capacity-bounded indirect slots | Tranches 6.1b and 5.4a | Parameter-only graph encodings update counts and commands without CPU draw selection | High | Large |
+| 6.2b — Pipeline/resource grouping | Stable command groups under geometry or material changes within WebGPU binding limits | Tranche 6.2a | Empty groups, regrouping, ordering, and overflow pass deterministic tests | High | Large |
+| 6.3a — Conventional scene consumer | A CPU scene graph uses shared storage, visibility, picking, and draw generation | Tranche 6.2b and Phase 4 | No consumer-specific fields or CPU draw filtering | High | Medium |
+| 6.3b — Table-oriented scene consumer | A preserved-batch table application uses the same runtime contracts | Tranches 6.1c, 6.2b, and 3.2 | Shares public primitives with 6.3a without repacking or adapter casts | High | Medium |
+| 7.1 — Dependency audit and API freeze | Freeze names, ownership, failures, capacities, submission, and package graph | Phase 6 exits and two consumers per graduation candidate | Acyclic dependency report and owner for every public resource boundary | High | Medium |
+| 7.2 — Scheduling-core extraction | Move table-independent graph scheduling to `@luma.gl/engine` with compatibility exports | Tranche 7.1 | Engine builds without tables, gpgpu, or Arrow; existing imports still pass | High | Large |
+| 7.3 — Adapter and algorithm migration | Keep table adapters in `@luma.gl/tables`; move optional workflows to `@luma.gl/gpgpu` | Tranche 7.2 | Package tests enforce dependency direction and examples use final owners | High | Large |
+| 7.4 — Compatibility and graduation | Stable docs, migration guide, release notes, and experimental-removal criteria | Tranche 7.3 | API reports and links pass; one documented compatibility window exists | High | Medium |
 
-| Tranche | Outcome | Entry dependency | Impact | Complexity/cost |
-| --- | --- | --- | :---: | :---: |
-| 3.2 — Partitioned topology | Explicit global-ID and chunk-base contracts for hierarchy and CSR topology without hidden packing | Implemented Phase 3 data primitives | High | Large |
-| 3.3 — Extension decision gate | Evidence-backed decision on sparse histograms, multidimensional histograms, custom scans, and shader callbacks | Tranche 3.2 plus demonstrated consumers | Medium | Medium |
-| 4.1 — Region picking | Bounded rectangular picks with stable object and batch IDs, capacity, count, and overflow | Implemented | Medium | Medium |
-| 4.2 — Asynchronous readback ring | Reusable staging slots with backpressure, cancellation, and no mapped-buffer reuse hazards | Implemented | High | Medium |
-| 4.3 — Render-target graph contracts | Multisample resolve and swapchain imports with explicit subresource and frame ownership | Implemented | Medium | Large |
-| 4.4 — External-texture contracts | One-frame external-texture imports with validated access and device-loss behavior | Implemented | Medium | Large |
-| 5.1a — `GPUGridIndex` build | Compact stable cell offsets and capacity-bounded object-ID storage for 2D and 3D points | Implemented | High | Medium |
-| 5.1b — `GPUGridIndex` incremental maintenance | Bounded relocation or reserved-cell updates with measured memory and update costs | Tranche 5.1a plus a changing-data consumer | High | Large |
-| 5.2a — `GPUGridIndex` query | Point, bounds, and radius cell candidates with bounded IDs, masks, count, and overflow | Implemented | High | Medium |
-| 5.2b — Exact query consumers | 2D and 3D candidate refinement feeding the same visibility contract as an unindexed scan | Implemented | High | Medium |
-| 5.2c — Query cost crossover | Representative scan/grid comparisons with build amortization and selectivity guidance | Tranche 5.2b plus GPU timestamps | High | Medium |
-| 5.3a — `GPUBVH` storage and refit | Complete-binary flat nodes, stable leaf slots, explicit capacity, and bottom-up refit | Implemented | High | Medium |
-| 5.3b — Spatial topology rebuild | Measured Morton or alternative topology construction without changing public storage | Tranche 5.3a plus representative query evidence | High | Large |
-| 5.4a — `GPUBVH` query | Bounds, point, and ray-like candidates feeding the established refinement contract | Tranche 5.3a | High | Medium |
-| 5.4b — Spatial cost model | Scan/grid/BVH comparison across rebuilds, refits, selectivity, update rate, and memory | Tranches 5.2c, 5.3b, and 5.4a | High | Medium |
-| 6.1 — Scene storage and updates | Flat stable-ID draw records, bounded update ranges, and explicit CPU/table adapters | Phase 2 and Tranche 5.2 | High | Large |
-| 6.2 — GPU draw generation | Visibility and spatial results writing grouped indirect-command slots without CPU draw selection | Tranche 6.1 | High | Large |
-| 6.3 — Cross-domain scene consumers | One scene-graph and one table-oriented consumer sharing storage, picking, and draw contracts | Tranche 6.2 plus Phases 4–5 | High | Large |
-| 7.1 — Dependency audit and API freeze | Final package graph, naming, ownership, failure, and extension-point decisions | Tranche 6.3 and two consumers per candidate API | High | Medium |
-| 7.2 — Scheduling-core extraction | Table-independent command graph moved to `@luma.gl/engine` with compatibility exports | Tranche 7.1 | High | Large |
-| 7.3 — Adapter and algorithm migration | Table adapters moved to `@luma.gl/tables`; optional algorithms and workflows moved to `@luma.gl/gpgpu` | Tranche 7.2 | High | Large |
-| 7.4 — Compatibility and graduation | Dependency audit, deprecation window, migration guide, and stable public documentation | Tranche 7.3 | High | Medium |
+### Recommended execution order
+
+1. Implement BVH bounds/point traversal (5.4a), because it unlocks correctness and topology-quality
+   measurements without committing to a spatial builder.
+2. Build the shared spatial benchmark harness (5.2c) and topology-quality evidence (5.3b). These can
+   progress together once BVH query output exists.
+3. Run the grid-update and BVH-rebuild decision gates (5.1b and 5.3b). Implement 5.1c or 5.3c only
+   where the measured consumer crossover is positive.
+4. Add ray-like BVH traversal (5.4b) when a picking or simulation consumer fixes the required query
+   semantics, then publish the Phase 5 cost model (5.4c).
+5. Start `GPUScene` storage (6.1a) after the bounds/point query contract is stable; draw generation
+   waits for update and grouping ownership to be explicit.
+6. Graduate packages only after both scene consumers prove the final APIs and dependency direction.
 
 ### Phase 0 — Current foundation
 
@@ -1298,7 +1323,8 @@ must expose their construction and query costs.
 
 #### Tranche 5.1 — `GPUGridIndex` build and update
 
-**Status:** Compact full-build storage is implemented; incremental maintenance remains planned.
+**Status:** Compact full-build storage is implemented. Incremental maintenance is conditional on a
+measured update-policy decision gate.
 
 Build a flat index of cell offsets and stable object IDs from bounded positions or bounds. Expose
 capacity and overflow, distinguish full rebuilds from supported incremental updates, and keep cell
@@ -1312,12 +1338,16 @@ and out-of-domain rows are ignored.
 
 The current update policy is explicitly `'rebuild'`: callers may upload a bounded input range or
 replace one vector chunk, but the next encoding clears, scans, and scatters the complete compact
-index. Tranche 5.1b will only add incremental maintenance after a changing-data consumer establishes
-whether bounded relocation or reserved per-cell capacity justifies its memory and complexity.
+index. Tranche 5.1b compares that baseline with bounded relocation and reserved-cell designs using a
+moving-data consumer. It records memory overhead, fragmentation, adversarial movement, and the
+update-rate crossover. Tranche 5.1c is entered only if that evidence justifies an incremental design;
+`'rebuild'` remains a valid final policy otherwise.
 
-**Exit evidence:** Two-dimensional and three-dimensional builds match CPU oracles across empty,
-clustered, out-of-domain, and capacity-boundary inputs. Benchmarks report allocation, build, and
-update costs separately from query cost.
+**Implemented evidence:** Two-dimensional and three-dimensional builds match CPU oracles across
+empty, clustered, out-of-domain, and capacity-boundary inputs.
+
+**Remaining evidence:** Benchmarks report allocation, full-build, and candidate incremental-update
+costs separately from query cost, followed by an explicit implement-or-defer decision.
 
 #### Tranche 5.2 — `GPUGridIndex` query
 
@@ -1342,9 +1372,13 @@ intersect it with selection, and compare indexed results with an unindexed GPU s
 query changes. Candidate overflow remains visible because a refined result cannot be complete when
 its broad phase was truncated.
 
+Tranche 5.2c turns the indexed and unindexed paths into one repeatable benchmark harness. The harness
+uses identical data and queries, validates exact result parity, and reports distributions rather
+than a single favorable sample.
+
 **Remaining exit evidence:** Representative consumers use GPU timestamps to compare allocation,
-build, query, and exact-predicate costs against an unindexed scan across update rates, selectivity,
-and reuse counts, then document where index construction becomes worthwhile.
+build, query, and exact-predicate costs across update rates, selectivity, data distributions, and
+reuse counts, then document where index construction becomes worthwhile.
 
 #### Tranche 5.3 — `GPUBVH` build and refit
 
@@ -1363,22 +1397,30 @@ policy, level count, and caller-owned output bytes are explicit.
 
 The complete source-order topology is a correctness and refit baseline, not a promised spatial
 quality heuristic. Tiled, Morton-ordered, or producer-sorted inputs may already have locality;
-arbitrary order may create overlapping parents and poor traversal. Spatial sorting and topology
-rebuild therefore remain a separate measured tranche rather than a hidden side effect of refit.
+arbitrary order may create overlapping parents and poor traversal. Tranche 5.3b measures visited
+nodes, overlap, candidate ratios, and build/refit cost for source, producer, and Morton order.
+Tranche 5.3c adds a spatial builder only after that comparison demonstrates a material benefit.
 
 **Remaining exit evidence:** CPU-oracle query tests cover degenerate and overlapping bounds;
-spatial rebuild and refit produce equivalent query results; topology quality, memory, construction,
-and refit costs are reported separately.
+topology-quality metrics are reported separately from storage and refit cost; and any implemented
+spatial rebuild produces query results equivalent to refit.
 
 #### Tranche 5.4 — `GPUBVH` query and cost model
 
-Connect BVH bounds, point, and ray-like selection queries to the same visibility and picking
-contracts used by grid queries. Publish guidance rather than claiming one index is universally
-best.
+Tranche 5.4a connects bounds and point traversal to the same bounded candidate, mask, count,
+overflow, and exact-refinement contracts used by grid queries. It intentionally precedes topology
+optimization: a query is required to measure whether a new topology improves useful work.
+
+Tranche 5.4b adds ray-like or segment candidates only after a picking or simulation consumer fixes
+the semantics. Traversal stack or work-queue capacity must be explicit and overflow must never look
+like an empty hit set.
+
+Tranche 5.4c publishes selection guidance rather than claiming one index is universally best. It
+includes conditional incremental-grid or spatial-BVH builders only if their decision gates passed.
 
 **Exit evidence:** Representative consumers compare unindexed scan, grid, and BVH paths with the
 same inputs and correctness oracle, including build amortization, update rate, selectivity, memory,
-and query time.
+topology quality, visited nodes, and query time.
 
 **Exit criteria:** Both a two-dimensional and a three-dimensional consumer can build or update an
 index, query it through a graph, feed results into visibility or picking, and compare correctness
@@ -1400,6 +1442,10 @@ Specify flat draw records, stable IDs, bounded update ranges, group membership, 
 and command-slot ownership. Provide explicit adapters for CPU scene graphs and GPU tables without
 making either representation canonical.
 
+Delivery is split into the table-independent record contract (6.1a), mutation and compaction
+semantics (6.1b), and explicit CPU-scene and GPU-table adapters (6.1c). This keeps adapter
+convenience from silently defining core storage or update ownership.
+
 **Exit evidence:** Insert, update, removal, and compaction tests preserve identity and references;
 partial updates have measurable upload bounds; no scene hierarchy or table type enters the core
 storage contract.
@@ -1410,6 +1456,10 @@ Translate visibility and spatial-query results into capacity-bounded indirect-co
 by compatible pipeline and resource bindings. WebGPU binding constraints remain explicit rather
 than being presented as a bindless renderer.
 
+Tranche 6.2a establishes command-slot generation and overflow. Tranche 6.2b adds stable pipeline and
+resource grouping, including regrouping after geometry or material changes. Separating them keeps
+basic GPU draw selection reviewable before taking on renderer grouping policy.
+
 **Exit evidence:** A compiled graph updates counts and commands after parameter-only changes with
 no CPU draw selection. Tests cover empty groups, stable ordering, capacity overflow, and geometry
 or material group changes.
@@ -1419,6 +1469,10 @@ or material group changes.
 Prove that the storage contract serves both a conventional scene graph and a table-oriented
 application. Both consumers use the same identity, visibility, picking, and indirect-draw path
 while retaining their own update and presentation policies.
+
+The conventional consumer lands as 6.3a; the preserved-batch table consumer follows as 6.3b. Phase
+6 does not exit until both use the same public runtime contracts without casts, hidden packing, or
+consumer-specific record fields.
 
 **Exit evidence:** Two independent consumers share the public scene primitives without adapter
 casts, hidden packing, or consumer-specific fields in `GPUScene`.
@@ -1524,6 +1578,10 @@ close enough to WebGPU that developers can reason about cost, ordering, and owne
 - [`GPUHistogram`](/docs/api-reference/experimental/gpu-primitives/gpu-histogram)
 - [`GPUGridBinning`](/docs/api-reference/experimental/gpu-primitives/gpu-grid-binning)
 - [`GPUGridAggregation`](/docs/api-reference/experimental/gpu-primitives/gpu-grid-aggregation)
+- [`GPUGridIndex`](/docs/api-reference/experimental/gpu-primitives/gpu-grid-index)
+- [`GPUGridIndexQuery`](/docs/api-reference/experimental/gpu-primitives/gpu-grid-index-query)
+- [`GPUPointSpatialFilter`](/docs/api-reference/experimental/gpu-primitives/gpu-point-spatial-filter)
+- [`GPUBVH`](/docs/api-reference/experimental/gpu-primitives/gpu-bvh)
 - [`GPUGroupAggregation`](/docs/api-reference/experimental/gpu-primitives/gpu-group-aggregation)
 - [`GPUIndexPickingTarget`](/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target)
 - [`GPUReadbackRing`](/docs/api-reference/experimental/gpu-primitives/gpu-readback-ring)

--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1020,8 +1020,8 @@ dependency order, not a schedule commitment. Tranches whose dependencies do not 
 developed independently.
 
 Phase 4 is implemented through Tranche 4.4. Compact `GPUGridIndex` construction, conservative
-queries, and exact 2D/3D point refinement feeding visibility are implemented; incremental
-maintenance and measured cost comparisons remain separate active boundaries.
+queries, exact 2D/3D point refinement, and the first flat `GPUBVH` storage/refit contract are
+implemented; optimized topology and measured cost comparisons remain active boundaries.
 
 | Tranche | Outcome | Entry dependency | Impact | Complexity/cost |
 | --- | --- | --- | :---: | :---: |
@@ -1036,8 +1036,10 @@ maintenance and measured cost comparisons remain separate active boundaries.
 | 5.2a — `GPUGridIndex` query | Point, bounds, and radius cell candidates with bounded IDs, masks, count, and overflow | Implemented | High | Medium |
 | 5.2b — Exact query consumers | 2D and 3D candidate refinement feeding the same visibility contract as an unindexed scan | Implemented | High | Medium |
 | 5.2c — Query cost crossover | Representative scan/grid comparisons with build amortization and selectivity guidance | Tranche 5.2b plus GPU timestamps | High | Medium |
-| 5.3 — `GPUBVH` build/refit | Flat BVH storage with explicit rebuild and refit policies | Tranche 5.2 | High | Large |
-| 5.4 — `GPUBVH` query and cost model | Visibility and picking queries with scan/grid/BVH comparison guidance | Tranche 5.3 | High | Medium |
+| 5.3a — `GPUBVH` storage and refit | Complete-binary flat nodes, stable leaf slots, explicit capacity, and bottom-up refit | Implemented | High | Medium |
+| 5.3b — Spatial topology rebuild | Measured Morton or alternative topology construction without changing public storage | Tranche 5.3a plus representative query evidence | High | Large |
+| 5.4a — `GPUBVH` query | Bounds, point, and ray-like candidates feeding the established refinement contract | Tranche 5.3a | High | Medium |
+| 5.4b — Spatial cost model | Scan/grid/BVH comparison across rebuilds, refits, selectivity, update rate, and memory | Tranches 5.2c, 5.3b, and 5.4a | High | Medium |
 | 6.1 — Scene storage and updates | Flat stable-ID draw records, bounded update ranges, and explicit CPU/table adapters | Phase 2 and Tranche 5.2 | High | Large |
 | 6.2 — GPU draw generation | Visibility and spatial results writing grouped indirect-command slots without CPU draw selection | Tranche 6.1 | High | Large |
 | 6.3 — Cross-domain scene consumers | One scene-graph and one table-oriented consumer sharing storage, picking, and draw contracts | Tranche 6.2 plus Phases 4–5 | High | Large |
@@ -1346,12 +1348,27 @@ and reuse counts, then document where index construction becomes worthwhile.
 
 #### Tranche 5.3 — `GPUBVH` build and refit
 
+**Status:** Flat complete-binary storage and deterministic GPU refit are implemented; spatial
+topology rebuild remains planned.
+
 Define flat node and leaf storage, stable leaf identity, bounds encoding, and explicit rebuild and
 refit policies. Reuse the grid index's ownership and measurement conventions where possible while
 allowing BVH-specific topology.
 
-**Exit evidence:** CPU-oracle tests cover degenerate, overlapping, and changing bounds; refit and
-rebuild produce equivalent query results; memory and construction costs are separately reported.
+`GPUBVH` reserves a power-of-two leaf capacity and publishes `2 * leafCapacity - 1` row-major node
+bounds and child pairs plus stable leaf IDs. Source order defines leaf slots. Each encoding reloads
+the bounded source prefix and reduces parent bounds in explicit bottom-up level passes, so changing
+bounds refits without graph recompilation or identity changes. Count, overflow, topology, update
+policy, level count, and caller-owned output bytes are explicit.
+
+The complete source-order topology is a correctness and refit baseline, not a promised spatial
+quality heuristic. Tiled, Morton-ordered, or producer-sorted inputs may already have locality;
+arbitrary order may create overlapping parents and poor traversal. Spatial sorting and topology
+rebuild therefore remain a separate measured tranche rather than a hidden side effect of refit.
+
+**Remaining exit evidence:** CPU-oracle query tests cover degenerate and overlapping bounds;
+spatial rebuild and refit produce equivalent query results; topology quality, memory, construction,
+and refit costs are reported separately.
 
 #### Tranche 5.4 — `GPUBVH` query and cost model
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-bvh.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-bvh.md
@@ -1,0 +1,108 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
+# GPUBVH
+
+<GPUPrimitivesDocsTabs active="bvh" />
+
+## Overview
+
+`GPUBVH` builds and refits a flat, complete-binary bounding-volume hierarchy over packed 2D or 3D
+axis-aligned bounds. Source order defines stable leaf slots, every node has caller-visible bounds
+and child indices, and each graph encoding reloads the bounded leaf prefix before reducing parent
+bounds bottom-up.
+
+This first BVH contract emphasizes storage, identity, update behavior, and measurable cost. It does
+not claim that source order is a high-quality spatial topology. Query and spatial-rebuild policies
+can be added against a concrete layout instead of coupling those decisions to hidden ownership or a
+CPU scene graph.
+
+## Concepts
+
+### Flat complete-binary storage
+
+For a power-of-two `leafCapacity`, the hierarchy contains `2 * leafCapacity - 1` nodes:
+
+```text
+node 0                         root
+nodes 1 … leafCapacity - 2     internal nodes
+nodes leafCapacity - 1 … end   leaf nodes
+```
+
+Internal node `i` stores children `2 * i + 1` and `2 * i + 2`. Leaves store
+`[0xffffffff, 0xffffffff]`. Minima and maxima use the source `float32x2` or `float32x3` format;
+stable IDs occupy a separate leaf array. The public `stats` object reports dimensions, node counts,
+levels, and caller-owned output bytes before any submission or readback.
+
+A complete tree deliberately trades unused leaf slots for simple traversal, deterministic memory,
+and logarithmic refit depth. Rounding a requested capacity up to a power of two uses less than twice
+the leaf storage, but sparse capacities can still waste meaningful memory.
+
+### Refit is not rebuild
+
+`updatePolicy` is `'refit'`. Every encoding:
+
+1. reloads current source bounds into the reserved leaf prefix;
+2. republishes stable leaf IDs and fixed child topology;
+3. reduces one internal level per compute pass until the root is current.
+
+Changing bounds therefore needs no graph recompilation and preserves leaf identity. Changing
+capacity, source ordering, or topology requires constructing a new BVH and recompiling the graph.
+That distinction matters: refit is predictable and cheap, but repeatedly moving objects far from
+their source-order neighbors can leave a poor hierarchy poor.
+
+### Why source-order topology exists
+
+A hierarchy is correct when every parent encloses its children; it is efficient only when traversal
+can reject large subtrees. Source order may already carry useful locality for tiled data, Morton-
+ordered tables, simulation blocks, or producer-sorted batches. For arbitrary order, parent bounds
+can overlap heavily and a query may visit nearly every leaf.
+
+The initial topology is therefore a useful baseline and refit target, not an assertion that sorting
+never matters. A later spatial-rebuild policy can compare Morton or other construction strategies
+against this deterministic baseline while preserving the same node and leaf storage contract.
+
+### Capacity, invalid bounds, and identity
+
+`count` reports the full source row count. `overflow` becomes `1` when it exceeds `leafCapacity`;
+only the stable prefix is stored. Unused leaves contain an invalid ID and empty bounds. Non-finite or
+reversed source bounds also produce empty leaf bounds, while retaining the row's stable ID slot so a
+later valid update does not silently change identity.
+
+Generated IDs equal source rows. Optional explicit IDs are copied without reordering. This makes
+the hierarchy suitable for table rows, scene records, simulation entities, or other flat databases
+without making any of those representations part of the BVH.
+
+### When to use it
+
+Use a BVH when object sizes vary substantially, the domain is sparse, or grid cells would produce
+too many false positives. Prefer a uniform grid when cell lookup and highly regular parallel build
+cost dominate. Prefer an unindexed scan for small inputs, broad one-off queries, or update rates
+that cannot amortize either structure.
+
+Measure storage, leaf loading, per-level refit, traversal, exact refinement, and rebuild cost
+separately. A lower asymptotic query bound does not compensate automatically for poor topology or a
+rebuild on every query.
+
+## Usage
+
+```ts
+const bvh = new GPUBVH({
+  minima: objectMinima,
+  maxima: objectMaxima,
+  sourceIds: stableObjectIds,
+  leafCapacity: 1 << 16,
+  nodeMinima,
+  nodeMaxima,
+  nodeChildren,
+  leafIds,
+  count: sourceCount,
+  overflow: capacityOverflow
+});
+
+bvh.addToGraph(graph);
+```
+
+All views must be packed and belong to the target command graph. `nodeMinima`, `nodeMaxima`, and
+`nodeChildren` each contain `2 * leafCapacity - 1` rows; `leafIds` contains `leafCapacity` rows.
+The primitive does not allocate caller-visible storage, submit, read back, spatially sort, or query
+the hierarchy.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -226,6 +226,7 @@
               "api-reference/experimental/gpu-primitives/gpu-grid-index",
               "api-reference/experimental/gpu-primitives/gpu-grid-index-query",
               "api-reference/experimental/gpu-primitives/gpu-point-spatial-filter",
+              "api-reference/experimental/gpu-primitives/gpu-bvh",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]
@@ -317,6 +318,7 @@
               "api-reference/experimental/gpu-primitives/gpu-grid-index",
               "api-reference/experimental/gpu-primitives/gpu-grid-index-query",
               "api-reference/experimental/gpu-primitives/gpu-point-spatial-filter",
+              "api-reference/experimental/gpu-primitives/gpu-bvh",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]

--- a/modules/experimental/src/gpu-primitives/gpu-bvh.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-bvh.ts
@@ -1,0 +1,390 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {type Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {getGPUVectorFormatInfo} from '@luma.gl/tables';
+import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-command-graph';
+import {
+  getViewBinding,
+  getViewElementOffset,
+  validatePackedUint32View,
+  validatePackedView
+} from './graph-data-view-utils';
+
+const BVH_WORKGROUP_SIZE = 256;
+const INVALID_NODE = 0xffffffff;
+
+/** Packed two- or three-dimensional bounds consumed and published by {@link GPUBVH}. */
+export type GPUBVHBoundsView = GraphDataView<'float32x2'> | GraphDataView<'float32x3'>;
+
+/** Properties for one complete-binary GPU BVH. */
+export type GPUBVHProps = {
+  /** Prefix for generated graph node IDs. */
+  id?: string;
+  /** Packed source minima. */
+  minima: GPUBVHBoundsView;
+  /** Packed source maxima with the same format and length as `minima`. */
+  maxima: GPUBVHBoundsView;
+  /** Optional stable IDs aligned with source rows. Identity IDs are generated when omitted. */
+  sourceIds?: GraphDataView<'uint32'>;
+  /** Power-of-two number of reserved leaf slots. */
+  leafCapacity: number;
+  /** Caller-owned minima for all `2 * leafCapacity - 1` nodes. */
+  nodeMinima: GPUBVHBoundsView;
+  /** Caller-owned maxima for all `2 * leafCapacity - 1` nodes. */
+  nodeMaxima: GPUBVHBoundsView;
+  /** Caller-owned child pairs for every node; leaves contain `0xffffffff`. */
+  nodeChildren: GraphDataView<'uint32x2'>;
+  /** Caller-owned stable IDs for the reserved leaf slots. */
+  leafIds: GraphDataView<'uint32'>;
+  /** Caller-owned row receiving the full source row count. */
+  count: GraphDataView<'uint32'>;
+  /** Caller-owned row set when source rows exceed leaf capacity. */
+  overflow: GraphDataView<'uint32'>;
+};
+
+/** Allocation and topology facts exposed without GPU readback. */
+export type GPUBVHStorageStats = {
+  dimension: 2 | 3;
+  leafCapacity: number;
+  internalNodeCount: number;
+  nodeCount: number;
+  levelCount: number;
+  outputByteLength: number;
+};
+
+/**
+ * Builds and refits a flat complete-binary bounding-volume hierarchy on the GPU.
+ *
+ * Source order defines stable leaf slots. Every encoding reloads the bounded leaf prefix and
+ * reduces parent bounds bottom-up without changing topology or identity. This is a deterministic
+ * refit-oriented foundation; spatial sorting and topology rebuilds remain separate policies.
+ */
+export class GPUBVH {
+  readonly id: string;
+  readonly minima: GPUBVHBoundsView;
+  readonly maxima: GPUBVHBoundsView;
+  readonly sourceIds?: GraphDataView<'uint32'>;
+  readonly leafCapacity: number;
+  readonly nodeMinima: GPUBVHBoundsView;
+  readonly nodeMaxima: GPUBVHBoundsView;
+  readonly nodeChildren: GraphDataView<'uint32x2'>;
+  readonly leafIds: GraphDataView<'uint32'>;
+  readonly count: GraphDataView<'uint32'>;
+  readonly overflow: GraphDataView<'uint32'>;
+  readonly dimension: 2 | 3;
+  readonly nodeCount: number;
+  readonly internalNodeCount: number;
+  readonly levelCount: number;
+  readonly rootNode = 0;
+  readonly topology = 'complete-binary' as const;
+  readonly updatePolicy = 'refit' as const;
+  readonly stats: GPUBVHStorageStats;
+
+  constructor(props: GPUBVHProps) {
+    this.id = props.id ?? 'gpu-bvh';
+    this.minima = props.minima;
+    this.maxima = props.maxima;
+    this.sourceIds = props.sourceIds;
+    this.leafCapacity = props.leafCapacity;
+    this.nodeMinima = props.nodeMinima;
+    this.nodeMaxima = props.nodeMaxima;
+    this.nodeChildren = props.nodeChildren;
+    this.leafIds = props.leafIds;
+    this.count = props.count;
+    this.overflow = props.overflow;
+    this.dimension = this.minima.format === 'float32x2' ? 2 : 3;
+
+    if (this.minima.length > INVALID_NODE) {
+      throw new Error(`${this.id} source row count exceeds uint32 range`);
+    }
+    if (!Number.isSafeInteger(this.leafCapacity) || !isPowerOfTwo(this.leafCapacity)) {
+      throw new Error(`${this.id} leafCapacity must be a positive power of two`);
+    }
+    this.nodeCount = this.leafCapacity * 2 - 1;
+    this.internalNodeCount = this.leafCapacity - 1;
+    this.levelCount = Math.log2(this.leafCapacity) + 1;
+    if (!Number.isSafeInteger(this.nodeCount) || this.nodeCount > INVALID_NODE) {
+      throw new Error(`${this.id} node count exceeds uint32 range`);
+    }
+
+    validatePackedView(this.minima, ['float32x2', 'float32x3'], `${this.id} minima`);
+    validatePackedView(this.maxima, ['float32x2', 'float32x3'], `${this.id} maxima`);
+    validatePackedView(this.nodeMinima, ['float32x2', 'float32x3'], `${this.id} nodeMinima`);
+    validatePackedView(this.nodeMaxima, ['float32x2', 'float32x3'], `${this.id} nodeMaxima`);
+    validatePackedView(this.nodeChildren, ['uint32x2'], `${this.id} nodeChildren`);
+    validatePackedUint32View(this.leafIds, `${this.id} leafIds`);
+    validatePackedUint32View(this.count, `${this.id} count`);
+    validatePackedUint32View(this.overflow, `${this.id} overflow`);
+    if (this.sourceIds) validatePackedUint32View(this.sourceIds, `${this.id} sourceIds`);
+
+    if (this.minima.format !== this.maxima.format || this.minima.length !== this.maxima.length) {
+      throw new Error(`${this.id} minima and maxima must have matching formats and lengths`);
+    }
+    if (this.sourceIds && this.sourceIds.length !== this.minima.length) {
+      throw new Error(`${this.id} sourceIds.length must equal bounds length`);
+    }
+    if (
+      this.nodeMinima.format !== this.minima.format ||
+      this.nodeMaxima.format !== this.minima.format ||
+      this.nodeMinima.length !== this.nodeCount ||
+      this.nodeMaxima.length !== this.nodeCount
+    ) {
+      throw new Error(`${this.id} node bounds must match source format and node count`);
+    }
+    if (this.nodeChildren.length !== this.nodeCount) {
+      throw new Error(`${this.id} nodeChildren.length must equal node count`);
+    }
+    if (this.leafIds.length !== this.leafCapacity) {
+      throw new Error(`${this.id} leafIds.length must equal leafCapacity`);
+    }
+    if (this.count.length < 1 || this.overflow.length < 1) {
+      throw new Error(`${this.id} count and overflow must each contain one uint32 row`);
+    }
+
+    const boundsByteLength = getGPUVectorFormatInfo(this.minima.format).byteLength;
+    this.stats = {
+      dimension: this.dimension,
+      leafCapacity: this.leafCapacity,
+      internalNodeCount: this.internalNodeCount,
+      nodeCount: this.nodeCount,
+      levelCount: this.levelCount,
+      outputByteLength:
+        this.nodeCount * (boundsByteLength * 2 + Uint32Array.BYTES_PER_ELEMENT * 2) +
+        this.leafCapacity * Uint32Array.BYTES_PER_ELEMENT +
+        Uint32Array.BYTES_PER_ELEMENT * 2
+    };
+  }
+
+  /** Adds leaf loading, topology publication, and bottom-up refit passes to the graph. */
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    const views = [
+      this.minima,
+      this.maxima,
+      ...(this.sourceIds ? [this.sourceIds] : []),
+      this.nodeMinima,
+      this.nodeMaxima,
+      this.nodeChildren,
+      this.leafIds,
+      this.count,
+      this.overflow
+    ];
+    if (views.some(view => view.buffer.graph !== graph)) {
+      throw new Error(`${this.id} views must belong to the target graph`);
+    }
+
+    addLoadLeavesPass(graph, this);
+    for (let depth = this.levelCount - 2; depth >= 0; depth--) {
+      addRefitLevelPass(graph, this, depth);
+    }
+  }
+}
+
+function addLoadLeavesPass<Parameters>(graph: GPUCommandGraph<Parameters>, bvh: GPUBVH): void {
+  const sourceIdBinding = bvh.sourceIds
+    ? '@group(0) @binding(8) var<storage, read> sourceIds: array<u32>;'
+    : '';
+  const sourceId = bvh.sourceIds ? 'sourceIds[SOURCE_IDS_OFFSET + nodeIndex]' : 'nodeIndex';
+  const source = /* wgsl */ `
+const SOURCE_COUNT: u32 = ${bvh.minima.length}u;
+const STORED_COUNT: u32 = ${Math.min(bvh.minima.length, bvh.leafCapacity)}u;
+const LEAF_CAPACITY: u32 = ${bvh.leafCapacity}u;
+const INTERNAL_NODE_COUNT: u32 = ${bvh.internalNodeCount}u;
+const NODE_COUNT: u32 = ${bvh.nodeCount}u;
+const DIMENSION: u32 = ${bvh.dimension}u;
+const MINIMA_OFFSET: u32 = ${getViewElementOffset(bvh.minima)}u;
+const MAXIMA_OFFSET: u32 = ${getViewElementOffset(bvh.maxima)}u;
+const NODE_MINIMA_OFFSET: u32 = ${getViewElementOffset(bvh.nodeMinima)}u;
+const NODE_MAXIMA_OFFSET: u32 = ${getViewElementOffset(bvh.nodeMaxima)}u;
+const CHILDREN_OFFSET: u32 = ${getViewElementOffset(bvh.nodeChildren)}u;
+const LEAF_IDS_OFFSET: u32 = ${getViewElementOffset(bvh.leafIds)}u;
+const COUNT_OFFSET: u32 = ${getViewElementOffset(bvh.count)}u;
+const OVERFLOW_OFFSET: u32 = ${getViewElementOffset(bvh.overflow)}u;
+${bvh.sourceIds ? `const SOURCE_IDS_OFFSET: u32 = ${getViewElementOffset(bvh.sourceIds)}u;` : ''}
+@group(0) @binding(0) var<storage, read> sourceMinima: array<f32>;
+@group(0) @binding(1) var<storage, read> sourceMaxima: array<f32>;
+@group(0) @binding(2) var<storage, read_write> nodeMinima: array<f32>;
+@group(0) @binding(3) var<storage, read_write> nodeMaxima: array<f32>;
+@group(0) @binding(4) var<storage, read_write> nodeChildren: array<u32>;
+@group(0) @binding(5) var<storage, read_write> leafIds: array<u32>;
+@group(0) @binding(6) var<storage, read_write> outputCount: array<u32>;
+@group(0) @binding(7) var<storage, read_write> outputOverflow: array<u32>;
+${sourceIdBinding}
+
+fn finite(value: f32) -> bool {
+  return value == value && abs(value) <= 3.402823466e+38;
+}
+
+@compute @workgroup_size(${BVH_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  let nodeIndex = globalId.x;
+  if (nodeIndex >= NODE_COUNT) { return; }
+  let nodeComponent = nodeIndex * DIMENSION;
+  for (var axis = 0u; axis < DIMENSION; axis++) {
+    nodeMinima[NODE_MINIMA_OFFSET + nodeComponent + axis] = 3.402823466e+38;
+    nodeMaxima[NODE_MAXIMA_OFFSET + nodeComponent + axis] = -3.402823466e+38;
+  }
+  let childComponent = nodeIndex * 2u;
+  if (nodeIndex < INTERNAL_NODE_COUNT) {
+    nodeChildren[CHILDREN_OFFSET + childComponent] = nodeIndex * 2u + 1u;
+    nodeChildren[CHILDREN_OFFSET + childComponent + 1u] = nodeIndex * 2u + 2u;
+  } else {
+    nodeChildren[CHILDREN_OFFSET + childComponent] = ${INVALID_NODE}u;
+    nodeChildren[CHILDREN_OFFSET + childComponent + 1u] = ${INVALID_NODE}u;
+    let leafIndex = nodeIndex - INTERNAL_NODE_COUNT;
+    leafIds[LEAF_IDS_OFFSET + leafIndex] = ${INVALID_NODE}u;
+    if (leafIndex < STORED_COUNT) {
+      var valid = true;
+      let sourceComponent = leafIndex * DIMENSION;
+      for (var axis = 0u; axis < DIMENSION; axis++) {
+        let minimum = sourceMinima[MINIMA_OFFSET + sourceComponent + axis];
+        let maximum = sourceMaxima[MAXIMA_OFFSET + sourceComponent + axis];
+        valid = valid && finite(minimum) && finite(maximum) && minimum <= maximum;
+      }
+      leafIds[LEAF_IDS_OFFSET + leafIndex] = ${sourceId.replaceAll('nodeIndex', 'leafIndex')};
+      if (valid) {
+        for (var axis = 0u; axis < DIMENSION; axis++) {
+          nodeMinima[NODE_MINIMA_OFFSET + nodeComponent + axis] =
+            sourceMinima[MINIMA_OFFSET + sourceComponent + axis];
+          nodeMaxima[NODE_MAXIMA_OFFSET + nodeComponent + axis] =
+            sourceMaxima[MAXIMA_OFFSET + sourceComponent + axis];
+        }
+      }
+    }
+  }
+  if (nodeIndex == 0u) {
+    outputCount[COUNT_OFFSET] = SOURCE_COUNT;
+    outputOverflow[OVERFLOW_OFFSET] = select(0u, 1u, SOURCE_COUNT > LEAF_CAPACITY);
+  }
+}`;
+  const resources: GraphBufferUse[] = [
+    {buffer: bvh.minima, usage: 'storage-read'},
+    {buffer: bvh.maxima, usage: 'storage-read'},
+    {buffer: bvh.nodeMinima, usage: 'storage-write'},
+    {buffer: bvh.nodeMaxima, usage: 'storage-write'},
+    {buffer: bvh.nodeChildren, usage: 'storage-write'},
+    {buffer: bvh.leafIds, usage: 'storage-write'},
+    {buffer: bvh.count, usage: 'storage-write'},
+    {buffer: bvh.overflow, usage: 'storage-write'},
+    ...(bvh.sourceIds ? ([{buffer: bvh.sourceIds, usage: 'storage-read'}] as GraphBufferUse[]) : [])
+  ];
+  addComputationPass(graph, {
+    id: `${bvh.id}-load-leaves`,
+    source,
+    resources,
+    bindings: {
+      sourceMinima: bvh.minima,
+      sourceMaxima: bvh.maxima,
+      nodeMinima: bvh.nodeMinima,
+      nodeMaxima: bvh.nodeMaxima,
+      nodeChildren: bvh.nodeChildren,
+      leafIds: bvh.leafIds,
+      outputCount: bvh.count,
+      outputOverflow: bvh.overflow,
+      ...(bvh.sourceIds ? {sourceIds: bvh.sourceIds} : {})
+    },
+    dispatchCount: Math.ceil(bvh.nodeCount / BVH_WORKGROUP_SIZE)
+  });
+}
+
+function addRefitLevelPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  bvh: GPUBVH,
+  depth: number
+): void {
+  const firstNode = 2 ** depth - 1;
+  const levelNodeCount = 2 ** depth;
+  const source = /* wgsl */ `
+const FIRST_NODE: u32 = ${firstNode}u;
+const LEVEL_NODE_COUNT: u32 = ${levelNodeCount}u;
+const DIMENSION: u32 = ${bvh.dimension}u;
+const NODE_MINIMA_OFFSET: u32 = ${getViewElementOffset(bvh.nodeMinima)}u;
+const NODE_MAXIMA_OFFSET: u32 = ${getViewElementOffset(bvh.nodeMaxima)}u;
+const CHILDREN_OFFSET: u32 = ${getViewElementOffset(bvh.nodeChildren)}u;
+@group(0) @binding(0) var<storage, read_write> nodeMinima: array<f32>;
+@group(0) @binding(1) var<storage, read_write> nodeMaxima: array<f32>;
+@group(0) @binding(2) var<storage, read> nodeChildren: array<u32>;
+
+@compute @workgroup_size(${BVH_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  if (globalId.x >= LEVEL_NODE_COUNT) { return; }
+  let nodeIndex = FIRST_NODE + globalId.x;
+  let childComponent = nodeIndex * 2u;
+  let left = nodeChildren[CHILDREN_OFFSET + childComponent];
+  let right = nodeChildren[CHILDREN_OFFSET + childComponent + 1u];
+  for (var axis = 0u; axis < DIMENSION; axis++) {
+    nodeMinima[NODE_MINIMA_OFFSET + nodeIndex * DIMENSION + axis] = min(
+      nodeMinima[NODE_MINIMA_OFFSET + left * DIMENSION + axis],
+      nodeMinima[NODE_MINIMA_OFFSET + right * DIMENSION + axis]
+    );
+    nodeMaxima[NODE_MAXIMA_OFFSET + nodeIndex * DIMENSION + axis] = max(
+      nodeMaxima[NODE_MAXIMA_OFFSET + left * DIMENSION + axis],
+      nodeMaxima[NODE_MAXIMA_OFFSET + right * DIMENSION + axis]
+    );
+  }
+}`;
+  addComputationPass(graph, {
+    id: `${bvh.id}-refit-depth-${depth}`,
+    source,
+    resources: [
+      {buffer: bvh.nodeMinima, usage: 'storage-read-write'},
+      {buffer: bvh.nodeMaxima, usage: 'storage-read-write'},
+      {buffer: bvh.nodeChildren, usage: 'storage-read'}
+    ],
+    bindings: {
+      nodeMinima: bvh.nodeMinima,
+      nodeMaxima: bvh.nodeMaxima,
+      nodeChildren: bvh.nodeChildren
+    },
+    dispatchCount: Math.ceil(levelNodeCount / BVH_WORKGROUP_SIZE)
+  });
+}
+
+function addComputationPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    source: string;
+    resources: GraphBufferUse[];
+    bindings: Record<string, GraphDataView>;
+    dispatchCount: number;
+  }
+): void {
+  graph.addComputePass({
+    id: props.id,
+    resources: props.resources,
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: props.id,
+        source: props.source,
+        shaderLayout: {
+          bindings: Object.keys(props.bindings).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const [name, view] of Object.entries(props.bindings)) {
+            bindings[name] = getViewBinding(view, getBuffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatch(computePass, props.dispatchCount);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function isPowerOfTwo(value: number): boolean {
+  return value > 0 && Number.isInteger(Math.log2(value));
+}

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -124,6 +124,9 @@ export type {
   GPUPointSpatialFilterProps
 } from './gpu-point-spatial-filter';
 
+export {GPUBVH} from './gpu-bvh';
+export type {GPUBVHBoundsView, GPUBVHProps, GPUBVHStorageStats} from './gpu-bvh';
+
 export {GPUGridAggregation} from './gpu-grid-aggregation';
 export type {
   GPUGridAggregationOperation,

--- a/modules/experimental/test/gpu-primitives/gpu-bvh.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-bvh.spec.ts
@@ -1,0 +1,225 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {Buffer, type Device} from '@luma.gl/core';
+import {
+  GPUBVH,
+  GPUCommandGraph,
+  type CompiledGPUCommandGraph,
+  type GraphDataView
+} from '@luma.gl/experimental';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+test('GPUBVH builds deterministic 2D topology and bounds', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const fixture = createFixture(device, {
+    dimension: 2,
+    minima: Float32Array.from([0, 0, 3, 1, -2, 4]),
+    maxima: Float32Array.from([1, 2, 5, 3, -1, 6]),
+    leafCapacity: 4
+  });
+  encode(device, fixture.compiled);
+
+  t.deepEqual(
+    await readUint32(fixture.children, 14),
+    [
+      1, 2, 3, 4, 5, 6, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
+      0xffffffff, 0xffffffff
+    ]
+  );
+  t.deepEqual(await readUint32(fixture.leafIds, 4), [0, 1, 2, 0xffffffff]);
+  t.deepEqual(await readFloat32(fixture.nodeMinima, 2), [-2, 0], 'root contains every valid leaf');
+  t.deepEqual(await readFloat32(fixture.nodeMaxima, 2), [5, 6]);
+  t.deepEqual(await readUint32(fixture.count, 1), [3]);
+  t.deepEqual(await readUint32(fixture.overflow, 1), [0]);
+  t.equal(fixture.bvh.topology, 'complete-binary');
+  t.equal(fixture.bvh.updatePolicy, 'refit');
+  t.deepEqual(fixture.bvh.stats, {
+    dimension: 2,
+    leafCapacity: 4,
+    internalNodeCount: 3,
+    nodeCount: 7,
+    levelCount: 3,
+    outputByteLength: 192
+  });
+
+  destroyFixture(fixture);
+  t.end();
+});
+
+test('GPUBVH refits 3D bounds while preserving stable IDs and reports capacity overflow', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const fixture = createFixture(device, {
+    dimension: 3,
+    minima: Float32Array.from([0, 0, 0, 2, 2, 2, -1, 3, 1, 4, -2, 0, 100, 100, 100]),
+    maxima: Float32Array.from([1, 1, 1, 3, 4, 5, 0, 5, 2, 6, 0, 7, 101, 101, 101]),
+    sourceIds: Uint32Array.from([10, 20, 30, 40, 50]),
+    leafCapacity: 4
+  });
+  encode(device, fixture.compiled);
+
+  t.deepEqual(await readFloat32(fixture.nodeMinima, 3), [-1, -2, 0]);
+  t.deepEqual(await readFloat32(fixture.nodeMaxima, 3), [6, 5, 7]);
+  t.deepEqual(await readUint32(fixture.leafIds, 4), [10, 20, 30, 40]);
+  t.deepEqual(await readUint32(fixture.count, 1), [5], 'count reports required leaf capacity');
+  t.deepEqual(await readUint32(fixture.overflow, 1), [1], 'the fifth leaf is not written');
+
+  fixture.minima.write(Float32Array.from([8, 8, 8, 2, 2, 2, -1, 3, 1, 4, -2, 0, 100, 100, 100]));
+  fixture.maxima.write(Float32Array.from([9, 9, 9, 3, 4, 5, 0, 5, 2, 6, 0, 7, 101, 101, 101]));
+  encode(device, fixture.compiled);
+  t.deepEqual(await readFloat32(fixture.nodeMinima, 3), [-1, -2, 0]);
+  t.deepEqual(await readFloat32(fixture.nodeMaxima, 3), [9, 9, 9], 'root refits updated leaves');
+  t.deepEqual(await readUint32(fixture.leafIds, 4), [10, 20, 30, 40], 'identity is stable');
+  t.ok(
+    fixture.compiled.stats.nodeOrder.some(id => id === 'test-bvh-refit-depth-0'),
+    'the graph exposes explicit bottom-up refit levels'
+  );
+
+  destroyFixture(fixture);
+  t.end();
+});
+
+type Fixture = {
+  bvh: GPUBVH;
+  compiled: CompiledGPUCommandGraph<void>;
+  minima: Buffer;
+  maxima: Buffer;
+  nodeMinima: Buffer;
+  nodeMaxima: Buffer;
+  children: Buffer;
+  leafIds: Buffer;
+  count: Buffer;
+  overflow: Buffer;
+  buffers: Buffer[];
+};
+
+function createFixture(
+  device: Device,
+  props: {
+    dimension: 2 | 3;
+    minima: Float32Array;
+    maxima: Float32Array;
+    sourceIds?: Uint32Array;
+    leafCapacity: number;
+  }
+): Fixture {
+  const format = props.dimension === 2 ? 'float32x2' : 'float32x3';
+  const sourceLength = props.minima.length / props.dimension;
+  const nodeCount = props.leafCapacity * 2 - 1;
+  const minima = createInputBuffer(device, props.minima);
+  const maxima = createInputBuffer(device, props.maxima);
+  const sourceIds = props.sourceIds ? createInputBuffer(device, props.sourceIds) : undefined;
+  const nodeMinima = createFloatOutputBuffer(device, nodeCount * props.dimension);
+  const nodeMaxima = createFloatOutputBuffer(device, nodeCount * props.dimension);
+  const children = createUintOutputBuffer(device, nodeCount * 2);
+  const leafIds = createUintOutputBuffer(device, props.leafCapacity);
+  const count = createUintOutputBuffer(device, 1);
+  const overflow = createUintOutputBuffer(device, 1);
+  const graph = new GPUCommandGraph(device, {id: 'bvh-test'});
+  const bvh = new GPUBVH({
+    id: 'test-bvh',
+    minima: importView(graph, 'source-minima', minima, format, sourceLength),
+    maxima: importView(graph, 'source-maxima', maxima, format, sourceLength),
+    sourceIds: sourceIds
+      ? importView(graph, 'source-ids', sourceIds, 'uint32', sourceLength)
+      : undefined,
+    leafCapacity: props.leafCapacity,
+    nodeMinima: importView(graph, 'node-minima', nodeMinima, format, nodeCount),
+    nodeMaxima: importView(graph, 'node-maxima', nodeMaxima, format, nodeCount),
+    nodeChildren: importView(graph, 'node-children', children, 'uint32x2', nodeCount),
+    leafIds: importView(graph, 'leaf-ids', leafIds, 'uint32', props.leafCapacity),
+    count: importView(graph, 'count', count, 'uint32', 1),
+    overflow: importView(graph, 'overflow', overflow, 'uint32', 1)
+  });
+  bvh.addToGraph(graph);
+  return {
+    bvh,
+    compiled: graph.compile(),
+    minima,
+    maxima,
+    nodeMinima,
+    nodeMaxima,
+    children,
+    leafIds,
+    count,
+    overflow,
+    buffers: [
+      minima,
+      maxima,
+      ...(sourceIds ? [sourceIds] : []),
+      nodeMinima,
+      nodeMaxima,
+      children,
+      leafIds,
+      count,
+      overflow
+    ]
+  };
+}
+
+function createInputBuffer(device: Device, data: Float32Array | Uint32Array): Buffer {
+  return device.createBuffer({data, usage: Buffer.STORAGE | Buffer.COPY_DST});
+}
+
+function createFloatOutputBuffer(device: Device, length: number): Buffer {
+  return device.createBuffer({
+    byteLength: Math.max(length, 1) * Float32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+}
+
+function createUintOutputBuffer(device: Device, length: number): Buffer {
+  return device.createBuffer({
+    byteLength: Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+}
+
+function importView<T extends 'float32x2' | 'float32x3' | 'uint32x2' | 'uint32'>(
+  graph: GPUCommandGraph,
+  id: string,
+  buffer: Buffer,
+  format: T,
+  length: number
+): GraphDataView<T> {
+  const handle = graph.importBuffer(
+    {id, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return graph.createDataView(handle, {format, length});
+}
+
+async function readFloat32(buffer: Buffer, length: number): Promise<number[]> {
+  const bytes = await buffer.readAsync();
+  return Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, length));
+}
+
+async function readUint32(buffer: Buffer, length: number): Promise<number[]> {
+  const bytes = await buffer.readAsync();
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, length));
+}
+
+function encode(device: Device, compiled: CompiledGPUCommandGraph<void>): void {
+  const commandEncoder = device.createCommandEncoder({id: 'bvh-test'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+}
+
+function destroyFixture(fixture: Fixture): void {
+  fixture.compiled.destroy();
+  for (const buffer of fixture.buffers) buffer.destroy();
+}

--- a/website/src/components/docs/gpu-primitives-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-primitives-docs-tabs.tsx
@@ -19,6 +19,7 @@ export type GPUPrimitivesDocsTabId =
   | 'grid-index'
   | 'grid-index-query'
   | 'point-spatial-filter'
+  | 'bvh'
   | 'group-aggregation'
   | 'index-picking'
   | 'readback-ring'
@@ -109,6 +110,11 @@ const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
     id: 'point-spatial-filter',
     label: 'Point Filter',
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-point-spatial-filter'
+  },
+  {
+    id: 'bvh',
+    label: 'BVH',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-bvh'
   },
   {
     id: 'group-aggregation',


### PR DESCRIPTION
## Goals

Establish the flat GPU BVH storage, identity, capacity, and refit contract before adding traversal or spatial topology heuristics.

## Changes

- add `GPUBVH` for packed 2D and 3D axis-aligned bounds
- reserve a power-of-two leaf capacity and publish a complete-binary flat node layout
- expose node minima/maxima, child pairs, stable leaf IDs, full count, and overflow
- reload leaves and refit explicit tree levels bottom-up on every graph encoding
- preserve generated or explicit stable IDs across dynamic bound updates
- expose topology, update policy, node/level counts, and caller-owned output bytes
- test deterministic 2D topology, 3D refit, explicit IDs, and capacity overflow
- add an Overview/Concepts page covering flat storage, refit versus rebuild, source-order topology quality, memory, and grid/scan/BVH use cases
- split optimized spatial topology and BVH query/cost work into dependency-ordered roadmap slices

## Impact

The following query tranche can target a concrete renderer-independent BVH view. Applications can update bounds without recompiling while retaining explicit control over capacity and topology rebuild decisions.

Source-order topology is documented as a correctness/refit baseline, not a universal spatial-quality claim.

## Verification

- `nvm use`
- `yarn lint fix`
- `yarn build`
- focused WebGPU BVH suite: 2 tests passed
- `yarn website:build`
- `(cd website && yarn build)`
- commit hook/node suite: 254 passed, 2 skipped
- full `yarn test`: node suite passed; browser suite reached 1,356 passed and 25 skipped, with the inherited Arrow polygon storage assertion still failing in `modules/arrow-layers/test/layers/arrow-layers.spec.ts`

## Stack

- Depends on #2814.
- Next slices can add BVH traversal, then measure source-order versus spatially rebuilt topology.