### PR TITLE
feat(experimental): add GPU BVH queries

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1016,8 +1016,9 @@ schedule commitment.
 
 Phase 4 is implemented through Tranche 4.4. The spatial stack now includes compact 2D/3D
 `GPUGridIndex` construction, conservative queries, exact point refinement with an unindexed GPU
-oracle, and deterministic complete-binary `GPUBVH` storage and refit. These are foundations, not a
-claim that incremental grid updates or source-order BVH topology are always profitable.
+oracle, deterministic complete-binary `GPUBVH` storage and refit, and exact BVH bounds/point
+traversal. These are foundations, not a claim that incremental grid updates or source-order BVH
+topology are always profitable.
 
 | Milestone | Implemented outcome |
 | --- | --- |
@@ -1025,6 +1026,7 @@ claim that incremental grid updates or source-order BVH topology are always prof
 | 5.2a — `GPUGridIndex` query | Point, bounds, and radius cell candidates with masks, counts, and overflow |
 | 5.2b — Exact query consumers | Indexed and unindexed 2D/3D point predicates feeding one visibility contract |
 | 5.3a — `GPUBVH` storage and refit | Flat complete-binary nodes, stable leaf slots, explicit capacity, and bottom-up refit |
+| 5.4a — `GPUBVH` bounds and point query | Exact 2D/3D traversal with stable IDs, masks, count, overflow, and visited-node metrics |
 
 ### Remaining tranche map
 
@@ -1039,7 +1041,6 @@ consumers.
 | --- | --- | --- | --- | :---: | :---: |
 | 3.2 — Partitioned topology | Global-ID and chunk-base contracts for hierarchy and CSR inputs without hidden packing | Implemented Phase 3 primitives plus a preserved-batch consumer | CPU-oracle parity across empty and uneven chunks; no implicit repack | High | Large |
 | 3.3 — Extension decision gate | Decide sparse or multidimensional histograms, custom scans, and shader extension points separately | Tranche 3.2 plus at least two requesting consumers | Each proposal is accepted with a fixed contract or explicitly deferred with evidence | Medium | Small |
-| 5.4a — BVH bounds and point query | Capacity-bounded candidates and masks using the grid refinement/overflow contract | Tranche 5.3a | 2D/3D CPU-oracle parity for empty, overlapping, invalid, and overflowed trees | High | Medium |
 | 5.2c — Spatial benchmark harness | Repeatable scan/grid/BVH measurements with shared data, queries, and correctness oracle | GPU timestamps, Tranche 5.2b, and Tranche 5.4a for BVH columns | Reports build, refit, query, refinement, memory, selectivity, and reuse distributions | High | Medium |
 | 5.1b — Grid update decision gate | Compare full rebuild with bounded relocation and reserved-cell designs | Tranche 5.2c plus a moving-data consumer | Decision records crossover, memory overhead, fragmentation, and overflow behavior | Medium | Medium |
 | 5.1c — Incremental grid maintenance | Implement only the update design selected by Tranche 5.1b | Positive Tranche 5.1b decision | Matches full rebuild after adversarial moves and demonstrates an update-rate win | High | Large |
@@ -1061,17 +1062,15 @@ consumers.
 
 ### Recommended execution order
 
-1. Implement BVH bounds/point traversal (5.4a), because it unlocks correctness and topology-quality
-   measurements without committing to a spatial builder.
-2. Build the shared spatial benchmark harness (5.2c) and topology-quality evidence (5.3b). These can
+1. Build the shared spatial benchmark harness (5.2c) and topology-quality evidence (5.3b). These can
    progress together once BVH query output exists.
-3. Run the grid-update and BVH-rebuild decision gates (5.1b and 5.3b). Implement 5.1c or 5.3c only
+2. Run the grid-update and BVH-rebuild decision gates (5.1b and 5.3b). Implement 5.1c or 5.3c only
    where the measured consumer crossover is positive.
-4. Add ray-like BVH traversal (5.4b) when a picking or simulation consumer fixes the required query
+3. Add ray-like BVH traversal (5.4b) when a picking or simulation consumer fixes the required query
    semantics, then publish the Phase 5 cost model (5.4c).
-5. Start `GPUScene` storage (6.1a) after the bounds/point query contract is stable; draw generation
+4. Start `GPUScene` storage (6.1a) after the bounds/point query contract is stable; draw generation
    waits for update and grouping ownership to be explicit.
-6. Graduate packages only after both scene consumers prove the final APIs and dependency direction.
+5. Graduate packages only after both scene consumers prove the final APIs and dependency direction.
 
 ### Phase 0 — Current foundation
 
@@ -1401,15 +1400,20 @@ arbitrary order may create overlapping parents and poor traversal. Tranche 5.3b 
 nodes, overlap, candidate ratios, and build/refit cost for source, producer, and Morton order.
 Tranche 5.3c adds a spatial builder only after that comparison demonstrates a material benefit.
 
-**Remaining exit evidence:** CPU-oracle query tests cover degenerate and overlapping bounds;
-topology-quality metrics are reported separately from storage and refit cost; and any implemented
-spatial rebuild produces query results equivalent to refit.
+**Implemented query evidence:** `GPUBVHQuery` traverses complete-binary 2D/3D hierarchies for exact
+point containment and bounds intersection. CPU-oracle tests cover selective pruning, overlap,
+invalid queries, output overflow, mutable queries, and source-ID-addressed masks. `visitedCount`
+reports topology work independently from matches.
+
+**Remaining exit evidence:** Topology-quality metrics are reported separately from storage and
+refit cost; and any implemented spatial rebuild produces query results equivalent to refit.
 
 #### Tranche 5.4 — `GPUBVH` query and cost model
 
-Tranche 5.4a connects bounds and point traversal to the same bounded candidate, mask, count,
-overflow, and exact-refinement contracts used by grid queries. It intentionally precedes topology
-optimization: a query is required to measure whether a new topology improves useful work.
+Tranche 5.4a is implemented. `GPUBVHQuery` connects exact bounds and point traversal to the same
+bounded candidate, mask, count, and overflow contracts used by grid queries. It intentionally
+precedes topology optimization: `visitedCount` measures whether a new topology improves useful
+work.
 
 Tranche 5.4b adds ray-like or segment candidates only after a picking or simulation consumer fixes
 the semantics. Traversal stack or work-queue capacity must be explicit and overflow must never look
@@ -1582,6 +1586,7 @@ close enough to WebGPU that developers can reason about cost, ordering, and owne
 - [`GPUGridIndexQuery`](/docs/api-reference/experimental/gpu-primitives/gpu-grid-index-query)
 - [`GPUPointSpatialFilter`](/docs/api-reference/experimental/gpu-primitives/gpu-point-spatial-filter)
 - [`GPUBVH`](/docs/api-reference/experimental/gpu-primitives/gpu-bvh)
+- [`GPUBVHQuery`](/docs/api-reference/experimental/gpu-primitives/gpu-bvh-query)
 - [`GPUGroupAggregation`](/docs/api-reference/experimental/gpu-primitives/gpu-group-aggregation)
 - [`GPUIndexPickingTarget`](/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target)
 - [`GPUReadbackRing`](/docs/api-reference/experimental/gpu-primitives/gpu-readback-ring)

--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -993,9 +993,9 @@ tessellation.
 
 ## Phased roadmap
 
-The command-graph foundation and first hierarchical-trace, analysis, texture, and picking
-milestones are implemented. The remaining work is ordered by dependency so that later APIs build
-on measured, reusable contracts instead of demo-specific behavior.
+The command-graph foundation and hierarchical-trace, analysis, texture, picking, and spatial
+filtering v1 milestones are implemented. The remaining work is ordered by dependency so that later
+APIs build on measured, reusable contracts instead of demo-specific behavior.
 
 Impact estimates how broadly a phase unlocks GPU-driven applications. Complexity/cost estimates
 relative engineering scope, integration risk, and validation effort; it is not a staffing or
@@ -1008,17 +1008,19 @@ schedule commitment.
 | 2 — Reusable visibility workflows | Renderer-independent time-range, bounds, LOD, and selection workflows that publish stable IDs, counts, and indirect commands | Implemented | High | Medium |
 | 3 — Algorithm and table scaling | Multi-chunk coverage, segmented and inclusive scans, weighted statistics, richer histograms, and batch-preserving algorithms | Core implemented; topology extensions deferred | High | Large |
 | 4 — Picking and texture coverage | Region picking, asynchronous staging rings, multisample resolves, frame-scoped swapchain imports, and sampled-only external-image contracts | Implemented | Medium | Large |
-| 5 — Spatial acceleration | `GPUGridIndex` followed by `GPUBVH`, with explicit build, update, and query costs | In progress | High | Large |
+| 5 — Spatial acceleration | `GPUGridIndex` and `GPUBVH` with explicit build, update, query, correctness, and cost-comparison contracts | V1 implemented; conditional extensions deferred | High | Large |
 | 6 — GPUScene | A flat GPU draw database with stable identity, bounds, transforms, grouping, geometry references, and indirect command slots | Planned | High | Large |
 | 7 — API graduation | Stable package contracts, compatibility exports, and a dependency-safe move out of experimental packages | Planned | High | Large |
 
-### Implemented spatial milestones
+### Spatial v1 milestones
 
 Phase 4 is implemented through Tranche 4.4. The spatial stack now includes compact 2D/3D
 `GPUGridIndex` construction, conservative queries, exact point refinement with an unindexed GPU
 oracle, deterministic complete-binary `GPUBVH` storage and refit, and exact BVH bounds/point
 traversal. These are foundations, not a claim that incremental grid updates or source-order BVH
-topology are always profitable.
+topology are always profitable. A shared benchmark harness now rejects incomplete or incorrect
+paths before reporting timings and records why optional update, topology, and ray extensions remain
+deferred.
 
 | Milestone | Implemented outcome |
 | --- | --- |
@@ -1027,6 +1029,8 @@ topology are always profitable.
 | 5.2b — Exact query consumers | Indexed and unindexed 2D/3D point predicates feeding one visibility contract |
 | 5.3a — `GPUBVH` storage and refit | Flat complete-binary nodes, stable leaf slots, explicit capacity, and bottom-up refit |
 | 5.4a — `GPUBVH` bounds and point query | Exact 2D/3D traversal with stable IDs, masks, count, overflow, and visited-node metrics |
+| 5.2c / 5.4c — Benchmark and cost model | Correctness-gated scan/grid/BVH timings, phase distributions, memory, work counters, and reuse amortization |
+| 5.1b / 5.3b / 5.4b — Decision gates | Incremental grid updates, topology rebuild, and ray traversal deferred pending consumer semantics and positive evidence |
 
 ### Remaining tranche map
 
@@ -1041,13 +1045,6 @@ consumers.
 | --- | --- | --- | --- | :---: | :---: |
 | 3.2 — Partitioned topology | Global-ID and chunk-base contracts for hierarchy and CSR inputs without hidden packing | Implemented Phase 3 primitives plus a preserved-batch consumer | CPU-oracle parity across empty and uneven chunks; no implicit repack | High | Large |
 | 3.3 — Extension decision gate | Decide sparse or multidimensional histograms, custom scans, and shader extension points separately | Tranche 3.2 plus at least two requesting consumers | Each proposal is accepted with a fixed contract or explicitly deferred with evidence | Medium | Small |
-| 5.2c — Spatial benchmark harness | Repeatable scan/grid/BVH measurements with shared data, queries, and correctness oracle | GPU timestamps, Tranche 5.2b, and Tranche 5.4a for BVH columns | Reports build, refit, query, refinement, memory, selectivity, and reuse distributions | High | Medium |
-| 5.1b — Grid update decision gate | Compare full rebuild with bounded relocation and reserved-cell designs | Tranche 5.2c plus a moving-data consumer | Decision records crossover, memory overhead, fragmentation, and overflow behavior | Medium | Medium |
-| 5.1c — Incremental grid maintenance | Implement only the update design selected by Tranche 5.1b | Positive Tranche 5.1b decision | Matches full rebuild after adversarial moves and demonstrates an update-rate win | High | Large |
-| 5.3b — BVH topology-quality evidence | Measure source order, producer order, and Morton order without changing storage | Tranches 5.3a, 5.4a, and GPU timestamps | Reports visited nodes, candidate ratios, build/refit cost, and overlap quality | High | Medium |
-| 5.3c — Spatial topology rebuild | Add Morton or another builder only if Tranche 5.3b demonstrates a material win | Positive Tranche 5.3b decision | Rebuild/refit query equivalence and separately measured sorting/topology costs | High | Large |
-| 5.4b — BVH ray-like query | Point-to-ray and segment candidates with bounded traversal work | Tranche 5.4a and a picking or simulation consumer | CPU-oracle parity plus explicit stack/work-queue capacity and overflow | Medium | Large |
-| 5.4c — Phase 5 cost model | Publish scan/grid/BVH selection guidance without universal-winner claims | Tranches 5.2c, 5.3b, and 5.4b; include 5.1c/5.3c only if built | Guidance covers size, update rate, selectivity, reuse, memory, and topology quality | High | Medium |
 | 6.1a — Scene record contract | Flat stable-ID records for bounds, transforms, groups, geometry references, and command slots | Phase 2 and Tranche 5.4a | Layout and ownership tests; no CPU hierarchy or table type in the core | High | Medium |
 | 6.1b — Scene updates and compaction | Insert, remove, patch, and compact records with bounded work | Tranche 6.1a | Identity/reference preservation under holes, moves, overflow, and compaction | High | Large |
 | 6.1c — Scene adapters | Explicit CPU-scene and GPU-table adapters without a canonical source model | Tranche 6.1b and partitioned-topology decisions | Both adapters build the same records without casts or hidden packing | High | Medium |
@@ -1062,15 +1059,13 @@ consumers.
 
 ### Recommended execution order
 
-1. Build the shared spatial benchmark harness (5.2c) and topology-quality evidence (5.3b). These can
-   progress together once BVH query output exists.
-2. Run the grid-update and BVH-rebuild decision gates (5.1b and 5.3b). Implement 5.1c or 5.3c only
-   where the measured consumer crossover is positive.
-3. Add ray-like BVH traversal (5.4b) when a picking or simulation consumer fixes the required query
-   semantics, then publish the Phase 5 cost model (5.4c).
-4. Start `GPUScene` storage (6.1a) after the bounds/point query contract is stable; draw generation
+1. Start `GPUScene` storage (6.1a) after the bounds/point query contract is stable; draw generation
    waits for update and grouping ownership to be explicit.
-5. Graduate packages only after both scene consumers prove the final APIs and dependency direction.
+2. Add partitioned topology (3.2) when a preserved-batch hierarchy or CSR consumer fixes the
+   cross-chunk identity contract.
+3. Reopen incremental grid maintenance, spatial BVH rebuild, or ray traversal only when the
+   documented decision gate gains a requesting consumer and positive evidence.
+4. Graduate packages only after both scene consumers prove the final APIs and dependency direction.
 
 ### Phase 0 — Current foundation
 
@@ -1315,15 +1310,16 @@ in graph validation without accidental ownership or cross-frame reuse.
 **Entry dependencies:** Phase 1 supplies measurement, Phase 2 supplies reusable visibility, and
 Phase 3 supplies the required scan, compaction, and batching behavior.
 
-Implement `GPUGridIndex` before `GPUBVH` to validate build, update, storage, and query interfaces on
-a simpler structure. Add `GPUBVH` only after grid-index consumers establish the shared contract.
-Both are library-built storage-buffer structures, not native WebGPU acceleration resources, and
-must expose their construction and query costs.
+`GPUGridIndex` was implemented before `GPUBVH` to validate build, update, storage, and query
+interfaces on a simpler structure. Grid-index consumers established the shared identity, capacity,
+overflow, and measurement contracts reused by BVH traversal. Both are library-built storage-buffer
+structures, not native WebGPU acceleration resources, and expose their construction and query
+costs.
 
 #### Tranche 5.1 — `GPUGridIndex` build and update
 
-**Status:** Compact full-build storage is implemented. Incremental maintenance is conditional on a
-measured update-policy decision gate.
+**Status:** Compact full-build storage is implemented. Incremental maintenance is deferred pending
+a moving-data consumer and a positive measured update-policy decision.
 
 Build a flat index of cell offsets and stable object IDs from bounded positions or bounds. Expose
 capacity and overflow, distinguish full rebuilds from supported incremental updates, and keep cell
@@ -1337,21 +1333,23 @@ and out-of-domain rows are ignored.
 
 The current update policy is explicitly `'rebuild'`: callers may upload a bounded input range or
 replace one vector chunk, but the next encoding clears, scans, and scatters the complete compact
-index. Tranche 5.1b compares that baseline with bounded relocation and reserved-cell designs using a
-moving-data consumer. It records memory overhead, fragmentation, adversarial movement, and the
-update-rate crossover. Tranche 5.1c is entered only if that evidence justifies an incremental design;
-`'rebuild'` remains a valid final policy otherwise.
+index. The 5.1b decision gate deferred bounded relocation and reserved-cell designs because no
+moving-data consumer yet demonstrates a positive crossover after memory overhead, fragmentation,
+adversarial movement, and overflow behavior. Tranche 5.1c reopens only if that evidence justifies an
+incremental design; `'rebuild'` is the complete v1 policy.
 
 **Implemented evidence:** Two-dimensional and three-dimensional builds match CPU oracles across
 empty, clustered, out-of-domain, and capacity-boundary inputs.
 
-**Remaining evidence:** Benchmarks report allocation, full-build, and candidate incremental-update
-costs separately from query cost, followed by an explicit implement-or-defer decision.
+**Decision:** Full rebuild is the supported v1 update contract. The benchmark reports its build cost
+separately from query cost. Bounded relocation or reserved-cell maintenance reopens only when a
+moving-data consumer demonstrates a crossover that repays added memory, fragmentation, and
+overflow complexity.
 
 #### Tranche 5.2 — `GPUGridIndex` query
 
-**Status:** Conservative queries and exact 2D/3D point-refinement consumers are implemented;
-representative cost comparison remains planned.
+**Status:** Conservative queries, exact 2D/3D point-refinement consumers, and the shared benchmark
+contract are implemented.
 
 Add bounds, radius, and point queries whose masks or compacted IDs compose directly with visibility
 and region-picking outputs. Query contracts preserve stable identity and do not require downloading
@@ -1372,17 +1370,19 @@ query changes. Candidate overflow remains visible because a refined result canno
 its broad phase was truncated.
 
 Tranche 5.2c turns the indexed and unindexed paths into one repeatable benchmark harness. The harness
-uses identical data and queries, validates exact result parity, and reports distributions rather
-than a single favorable sample.
+uses identical data and queries, validates exact result parity, rejects overflow, and reports
+distributions rather than a single favorable sample.
 
-**Remaining exit evidence:** Representative consumers use GPU timestamps to compare allocation,
-build, query, and exact-predicate costs across update rates, selectivity, data distributions, and
-reuse counts, then document where index construction becomes worthwhile.
+**Implemented evidence:** `runGPUSpatialQueryBenchmark` reports build, query, exact-predicate, memory,
+candidate, and reuse-amortization metrics with optional GPU timestamps. Representative consumers
+still choose and publish their own crossover; the library does not encode one adapter-specific
+threshold as policy.
 
 #### Tranche 5.3 — `GPUBVH` build and refit
 
-**Status:** Flat complete-binary storage and deterministic GPU refit are implemented; spatial
-topology rebuild remains planned.
+**Status:** Flat complete-binary storage, deterministic GPU refit, exact traversal, and
+topology-quality measurement are implemented. Spatial topology rebuild is deferred pending positive
+consumer evidence.
 
 Define flat node and leaf storage, stable leaf identity, bounds encoding, and explicit rebuild and
 refit policies. Reuse the grid index's ownership and measurement conventions where possible while
@@ -1396,39 +1396,46 @@ policy, level count, and caller-owned output bytes are explicit.
 
 The complete source-order topology is a correctness and refit baseline, not a promised spatial
 quality heuristic. Tiled, Morton-ordered, or producer-sorted inputs may already have locality;
-arbitrary order may create overlapping parents and poor traversal. Tranche 5.3b measures visited
-nodes, overlap, candidate ratios, and build/refit cost for source, producer, and Morton order.
-Tranche 5.3c adds a spatial builder only after that comparison demonstrates a material benefit.
+arbitrary order may create overlapping parents and poor traversal. The 5.3b decision gate uses
+visited nodes, candidate ratios, and build/refit phases to compare source, producer, and externally
+preordered input. Tranche 5.3c reopens only after representative measurements demonstrate that a
+library spatial builder repays its sorting and topology cost.
 
 **Implemented query evidence:** `GPUBVHQuery` traverses complete-binary 2D/3D hierarchies for exact
 point containment and bounds intersection. CPU-oracle tests cover selective pruning, overlap,
 invalid queries, output overflow, mutable queries, and source-ID-addressed masks. `visitedCount`
 reports topology work independently from matches.
 
-**Remaining exit evidence:** Topology-quality metrics are reported separately from storage and
-refit cost; and any implemented spatial rebuild produces query results equivalent to refit.
+**Decision:** `visitedCount` and phase timings report topology quality separately from storage and
+refit cost. A Morton or other topology builder reopens only when representative source, producer,
+and preordered inputs demonstrate a material end-to-end win after sorting/build cost. Any future
+builder must preserve query equivalence with refit.
 
 #### Tranche 5.4 — `GPUBVH` query and cost model
+
+**Status:** Bounds/point query and the Phase 5 selection cost model are implemented. Ray-like
+traversal is deferred as a separate consumer-defined extension.
 
 Tranche 5.4a is implemented. `GPUBVHQuery` connects exact bounds and point traversal to the same
 bounded candidate, mask, count, and overflow contracts used by grid queries. It intentionally
 precedes topology optimization: `visitedCount` measures whether a new topology improves useful
 work.
 
-Tranche 5.4b adds ray-like or segment candidates only after a picking or simulation consumer fixes
-the semantics. Traversal stack or work-queue capacity must be explicit and overflow must never look
-like an empty hit set.
+Tranche 5.4b remains deferred until a picking or simulation consumer fixes ray/segment intersection,
+nearest-hit behavior, and bounded traversal semantics. Traversal stack or work-queue capacity must
+be explicit and overflow must never look like an empty hit set.
 
 Tranche 5.4c publishes selection guidance rather than claiming one index is universally best. It
-includes conditional incremental-grid or spatial-BVH builders only if their decision gates passed.
+includes conditional incremental-grid or spatial-BVH builders only if their decision gates pass.
 
-**Exit evidence:** Representative consumers compare unindexed scan, grid, and BVH paths with the
-same inputs and correctness oracle, including build amortization, update rate, selectivity, memory,
-topology quality, visited nodes, and query time.
+**Exit evidence:** The shared harness compares unindexed scan, grid, and BVH paths with the same
+inputs and correctness oracle, including build amortization, selectivity, memory, candidates,
+topology quality, visited nodes, and query time. Update rates remain consumer inputs rather than a
+hard-coded library threshold.
 
-**Exit criteria:** Both a two-dimensional and a three-dimensional consumer can build or update an
-index, query it through a graph, feed results into visibility or picking, and compare correctness
-and cost with an unindexed GPU scan.
+**Exit criteria:** Achieved by 2D/3D grid and BVH build/query tests, exact point-filter integration,
+visibility composition, stable output contracts, and the correctness-gated cost model. Picking can
+consume the same stable-ID masks; ray traversal is not required for spatial filtering v1.
 
 ### Phase 6 — GPUScene
 
@@ -1587,6 +1594,7 @@ close enough to WebGPU that developers can reason about cost, ordering, and owne
 - [`GPUPointSpatialFilter`](/docs/api-reference/experimental/gpu-primitives/gpu-point-spatial-filter)
 - [`GPUBVH`](/docs/api-reference/experimental/gpu-primitives/gpu-bvh)
 - [`GPUBVHQuery`](/docs/api-reference/experimental/gpu-primitives/gpu-bvh-query)
+- [GPU spatial query benchmark](/docs/api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark)
 - [`GPUGroupAggregation`](/docs/api-reference/experimental/gpu-primitives/gpu-group-aggregation)
 - [`GPUIndexPickingTarget`](/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target)
 - [`GPUReadbackRing`](/docs/api-reference/experimental/gpu-primitives/gpu-readback-ring)

--- a/docs/api-reference/experimental/gpu-primitives/gpu-bvh-query.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-bvh-query.md
@@ -1,0 +1,98 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
+# GPUBVHQuery
+
+<GPUPrimitivesDocsTabs active="bvh-query" />
+
+## Overview
+
+`GPUBVHQuery` traverses a flat `GPUBVH` for exact point containment or axis-aligned bounds
+intersection. It keeps the query and results on the GPU, rejects disjoint subtrees, and publishes
+stable leaf IDs through the same capacity, count, overflow, and optional-mask contract used by the
+grid-index query path.
+
+This is useful for viewport and box selection, object-level visibility, simulation neighborhoods,
+and the broad phase of picking. It is especially valuable when object sizes vary or the domain is
+sparse: a uniform grid may then touch many empty cells or return many false positives. It is not a
+ray tracer, and it does not make a source-order hierarchy spatially good. The exposed
+`visitedCount` makes that distinction measurable.
+
+## Concepts
+
+### Level-ordered traversal
+
+The complete-binary topology gives every node a known depth. The query begins with the root active,
+then runs one compute pass per depth. An active internal node whose bounds match activates both
+children; a disjoint node activates neither. Matching leaves append their stable IDs atomically.
+
+This breadth-first design uses a bounded active-node mask instead of a hidden per-invocation stack.
+Its work and memory are therefore explicit and portable across WebGPU implementations. Output ID
+order is unspecified because parallel leaves append atomically; stable identity, not traversal
+order, is the contract.
+
+### Exact predicates
+
+A point query returns leaves whose closed bounds contain the point. A bounds query returns leaves
+whose closed bounds intersect the query bounds. Touching edges count as intersections. Non-finite
+points, non-finite query bounds, and reversed query bounds match nothing. Empty BVH leaves and
+invalid source bounds also match nothing.
+
+Unlike a grid query, these tests are exact for axis-aligned leaf bounds. An application querying
+circles, meshes, glyphs, or another shape should treat the result as a broad phase and apply its
+shape-specific predicate afterward.
+
+### Count, capacity, masks, and overflow
+
+`count` reports every match in the stored BVH even when `output` is too small. `overflow` is set when
+the BVH itself omitted source leaves or the query output capacity truncates matches. The optional
+source-ID-addressed `outputMask` contains only IDs actually stored in `output`, so it is deliberately
+incomplete when overflow is set. This prevents a truncated candidate set from looking complete.
+
+All output state is reset on every graph encoding. The caller can update the packed query buffer and
+encode the compiled graph again without rebuilding the hierarchy or recompiling the graph.
+
+### Topology quality is observable
+
+`visitedCount` reports how many node bounds were tested, including the root. A selective query on a
+well-grouped hierarchy should visit substantially fewer nodes than the full tree. A source-order
+hierarchy with heavily overlapping parents may visit nearly all nodes while still returning correct
+results.
+
+That metric supports an honest scan/grid/BVH comparison and a future topology-builder decision. A
+BVH should be selected because measured pruning and query reuse repay its build or refit cost, not
+because its asymptotic name sounds faster.
+
+### Choosing scan, grid, or BVH
+
+- Prefer an unindexed scan for small inputs, broad one-off queries, or data that changes before an
+  index can be reused.
+- Prefer a grid for similarly sized objects in a bounded domain when regular cell lookup and build
+  throughput dominate.
+- Prefer a BVH for sparse domains, widely varying object sizes, or queries that can reject coherent
+  groups of bounds.
+
+Always include build or refit time, query reuse, selectivity, memory, candidate refinement, and
+overflow in the comparison.
+
+## Usage
+
+```ts
+const query = new GPUBVHQuery({
+  bvh,
+  kind: 'bounds',
+  query: queryMinimaAndMaxima,
+  output: candidateIds,
+  count: candidateCount,
+  overflow: candidateOverflow,
+  outputMask: candidateMask,
+  visitedCount
+});
+
+query.addToGraph(graph);
+```
+
+The point query contains two or three packed `float32` values, matching the BVH dimension. The
+bounds query contains minima followed by maxima and therefore contains four or six values. All
+views must be packed and belong to the target command graph. The primitive does not allocate
+caller-visible output, submit commands, read results back, or apply application-specific geometry
+tests.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-bvh.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-bvh.md
@@ -104,5 +104,6 @@ bvh.addToGraph(graph);
 
 All views must be packed and belong to the target command graph. `nodeMinima`, `nodeMaxima`, and
 `nodeChildren` each contain `2 * leafCapacity - 1` rows; `leafIds` contains `leafCapacity` rows.
-The primitive does not allocate caller-visible storage, submit, read back, spatially sort, or query
-the hierarchy.
+The primitive does not allocate caller-visible storage, submit, read back, or spatially sort the
+hierarchy. Use [`GPUBVHQuery`](/docs/api-reference/experimental/gpu-primitives/gpu-bvh-query) for
+exact point containment and bounds-intersection traversal.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark.md
@@ -1,0 +1,119 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
+# GPU spatial query benchmark
+
+<GPUPrimitivesDocsTabs active="spatial-benchmark" />
+
+## Overview
+
+`runGPUSpatialQueryBenchmark` compares unindexed scan, uniform-grid, and BVH query paths with one
+correctness gate and one measurement protocol. Each adapter encodes its existing command graph,
+reads exact stable IDs, classifies graph nodes as build, refit, query, or refinement work, and
+reports memory plus observable candidate or traversal counts.
+
+The harness exists because “use an index” is not a useful performance rule. An index pays an
+up-front construction or update cost and consumes memory. It wins only when pruning and reuse repay
+that cost on the target adapter and representative data. The harness refuses overflow or a mismatch
+with the shared CPU oracle before it reports timings, so an incomplete result cannot appear faster.
+
+## Concepts
+
+### One dataset, query, and oracle
+
+All three paths must consume the same logical records and query. The application computes expected
+stable IDs on the CPU, then each GPU adapter returns its exact IDs through `readResult`. Result order
+is ignored because parallel compaction is unordered; duplicates, omissions, extra IDs, and overflow
+still fail the run.
+
+Grid candidates must be followed by the same exact predicate used by the scan. BVH leaf bounds are
+exact only for axis-aligned-bounds queries; another shape needs the same final predicate too. This
+keeps broad-phase quality separate from answer correctness.
+
+### Warmup and repeated measurements
+
+Warmup encodings populate pipelines and caches before measured iterations. The harness then creates
+a timestamp query set for every measured encoding when the adapter supports `timestamp-query`,
+submits the work, and explicitly reads per-node durations. Reports retain minimum, median, 95th
+percentile, and maximum values instead of selecting one favorable sample. CPU graph-encoding time is
+always available; GPU time is omitted rather than estimated when timestamps are unsupported.
+
+Use multiple distributions and selectivities. Uniform, clustered, sparse, adversarially ordered,
+and moving data stress different structures. Tiny, selective, medium, and broad queries expose the
+difference between effective pruning and bookkeeping overhead.
+
+### Phases and amortization
+
+Each adapter maps its stable graph node IDs to these phases:
+
+| Phase | What it measures |
+| --- | --- |
+| `build` | Grid clear/count/scan/scatter or another topology construction |
+| `refit` | BVH leaf reload and bottom-up bound propagation after data changes |
+| `query` | Cell enumeration, hierarchy traversal, or unindexed predicate scan |
+| `refinement` | Exact application predicate and result compaction after a broad phase |
+
+For reuse counts supplied by the caller, the report computes
+`(median build + median refit) / reuse + median query + median refinement`. This is a comparison aid,
+not a universal crossover: update frequency, asynchronous scheduling, contention, and surrounding
+render work still belong in the consumer benchmark.
+
+### Work counters explain timings
+
+Timing alone says which run was faster; work counters help explain why. Grid adapters report the
+conservative `candidateCount`. BVH adapters report `visitedCount`. Every path reports exact result
+count and owned or borrowed memory bytes. A high candidate-to-result ratio suggests poor cell size
+or object/grid fit. A high visited-node ratio suggests overlapping or poorly ordered BVH parents.
+
+These counters also make regressions easier to diagnose across adapters: a timing change with stable
+work often points to runtime or hardware variation, while a work-count change points to the data
+structure or query.
+
+### Selection guidance
+
+| Situation | Start with | Why |
+| --- | --- | --- |
+| Small input, broad query, or one use before data changes | Scan | No index construction or storage to amortize |
+| Bounded domain with similarly sized objects and regular occupancy | Grid | Parallel build and direct cell lookup are simple and predictable |
+| Sparse domain, widely varying object sizes, or coherent bound groups | BVH | Hierarchical rejection can avoid empty space and oversized cell fan-out |
+| Unknown or mixed workload | Scan baseline plus this harness | The crossover depends on distribution, selectivity, reuse, and adapter |
+
+Do not compare only query kernels. Include allocation or persistent memory, full build, updates,
+exact refinement, overflow capacity, and the number of queries between changes.
+
+### Spatial v1 decision record
+
+The implemented v1 includes full grid rebuild, conservative grid query, exact point refinement,
+BVH storage/refit, exact point and bounds traversal, and this correctness-gated cost model. Three
+extensions remain deliberately deferred:
+
+- Incremental grid maintenance needs a moving-data consumer and a measured crossover that repays
+  reserved-cell memory, fragmentation, and more complex overflow behavior. Full rebuild remains the
+  supported update contract.
+- A Morton or other BVH topology builder needs representative runs showing materially lower visited
+  nodes and end-to-end time than source or producer ordering after its sorting/build cost. Callers
+  can benchmark preordered inputs now without changing BVH storage.
+- Ray or segment traversal needs a picking or simulation consumer to define intersection semantics,
+  nearest-hit behavior, and bounded traversal storage. Bounds and point queries do not pretend to
+  satisfy that separate contract.
+
+These are scope decisions, not claims that the extensions are slow. Each can reopen as a focused
+feature when a consumer supplies semantics and positive evidence; none is required for the complete
+spatial filtering v1 contract.
+
+## Usage
+
+```ts
+const report = await runGPUSpatialQueryBenchmark(device, {
+  paths: [scanPath, gridPath, bvhPath],
+  expectedIds: cpuOracleIds,
+  warmupIterations: 5,
+  measuredIterations: 50,
+  reuseCounts: [1, 10, 100, 1000]
+});
+```
+
+Each path supplies `encode(commandEncoder)`, `readResult()`, `memoryByteLength`, and
+`getNodePhase(nodeId)`. The harness owns command submission and temporary timestamp query sets. The
+caller owns datasets, graphs, buffers, readback strategy, query generation, and destruction. Keep
+those adapters next to representative consumers so the benchmark does not hide uploads, repacking,
+or application predicates.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -227,6 +227,7 @@
               "api-reference/experimental/gpu-primitives/gpu-grid-index-query",
               "api-reference/experimental/gpu-primitives/gpu-point-spatial-filter",
               "api-reference/experimental/gpu-primitives/gpu-bvh",
+              "api-reference/experimental/gpu-primitives/gpu-bvh-query",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]
@@ -319,6 +320,7 @@
               "api-reference/experimental/gpu-primitives/gpu-grid-index-query",
               "api-reference/experimental/gpu-primitives/gpu-point-spatial-filter",
               "api-reference/experimental/gpu-primitives/gpu-bvh",
+              "api-reference/experimental/gpu-primitives/gpu-bvh-query",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -228,6 +228,7 @@
               "api-reference/experimental/gpu-primitives/gpu-point-spatial-filter",
               "api-reference/experimental/gpu-primitives/gpu-bvh",
               "api-reference/experimental/gpu-primitives/gpu-bvh-query",
+              "api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]
@@ -321,6 +322,7 @@
               "api-reference/experimental/gpu-primitives/gpu-point-spatial-filter",
               "api-reference/experimental/gpu-primitives/gpu-bvh",
               "api-reference/experimental/gpu-primitives/gpu-bvh-query",
+              "api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]

--- a/modules/experimental/src/gpu-primitives/gpu-bvh-query.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-bvh-query.ts
@@ -1,0 +1,525 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {type Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-command-graph';
+import type {GPUBVHBoundsView} from './gpu-bvh';
+import {
+  createTransientView,
+  getViewBinding,
+  getViewElementOffset,
+  validatePackedUint32View,
+  validatePackedView
+} from './graph-data-view-utils';
+
+const BVH_QUERY_WORKGROUP_SIZE = 256;
+const INVALID_NODE = 0xffffffff;
+
+/** Flat complete-binary hierarchy consumed by {@link GPUBVHQuery}. */
+export type GPUBVHView = {
+  leafCapacity: number;
+  nodeMinima: GPUBVHBoundsView;
+  nodeMaxima: GPUBVHBoundsView;
+  nodeChildren: GraphDataView<'uint32x2'>;
+  leafIds: GraphDataView<'uint32'>;
+  overflow: GraphDataView<'uint32'>;
+};
+
+/** Bounds predicate evaluated during BVH traversal. */
+export type GPUBVHQueryKind = 'point' | 'bounds';
+
+/** Properties for one complete-binary BVH traversal. */
+export type GPUBVHQueryProps = {
+  /** Prefix for generated graph resources and node IDs. */
+  id?: string;
+  /** Flat hierarchy, commonly a `GPUBVH` instance. */
+  bvh: GPUBVHView;
+  /** Node intersection rule. */
+  kind: GPUBVHQueryKind;
+  /** Packed point or minima/maxima query, mutable between graph encodings. */
+  query: GraphDataView<'float32'>;
+  /** Caller-owned capacity-bounded stable leaf IDs. */
+  output: GraphDataView<'uint32'>;
+  /** Caller-owned row receiving the full stored-tree match count. */
+  count: GraphDataView<'uint32'>;
+  /** Caller-owned row receiving source-tree or output-capacity overflow. */
+  overflow: GraphDataView<'uint32'>;
+  /** Optional source-ID-addressed result mask, cleared on every encoding. */
+  outputMask?: GraphDataView<'uint32'>;
+  /** Optional row receiving the number of active nodes whose bounds were tested. */
+  visitedCount?: GraphDataView<'uint32'>;
+};
+
+/**
+ * Traverses a complete-binary GPU BVH for point containment or bounds intersection.
+ *
+ * One compute pass processes each tree depth. Only active nodes test their bounds and activate
+ * children, while matched leaves append stable IDs atomically. Output order is unspecified;
+ * `visitedCount` exposes traversal work for topology-quality and cost comparisons.
+ */
+export class GPUBVHQuery {
+  readonly id: string;
+  readonly bvh: GPUBVHView;
+  readonly kind: GPUBVHQueryKind;
+  readonly query: GraphDataView<'float32'>;
+  readonly output: GraphDataView<'uint32'>;
+  readonly count: GraphDataView<'uint32'>;
+  readonly overflow: GraphDataView<'uint32'>;
+  readonly outputMask?: GraphDataView<'uint32'>;
+  readonly visitedCount?: GraphDataView<'uint32'>;
+  readonly dimension: 2 | 3;
+  readonly nodeCount: number;
+  readonly internalNodeCount: number;
+  readonly levelCount: number;
+
+  constructor(props: GPUBVHQueryProps) {
+    this.id = props.id ?? 'gpu-bvh-query';
+    this.bvh = props.bvh;
+    this.kind = props.kind;
+    this.query = props.query;
+    this.output = props.output;
+    this.count = props.count;
+    this.overflow = props.overflow;
+    this.outputMask = props.outputMask;
+    this.visitedCount = props.visitedCount;
+    this.dimension = this.bvh.nodeMinima.format === 'float32x2' ? 2 : 3;
+
+    if (!Number.isSafeInteger(this.bvh.leafCapacity) || !isPowerOfTwo(this.bvh.leafCapacity)) {
+      throw new Error(`${this.id} bvh leafCapacity must be a positive power of two`);
+    }
+    this.nodeCount = this.bvh.leafCapacity * 2 - 1;
+    this.internalNodeCount = this.bvh.leafCapacity - 1;
+    this.levelCount = Math.log2(this.bvh.leafCapacity) + 1;
+    validateIndexView(this);
+    validatePackedView(this.query, ['float32'], `${this.id} query`);
+    validatePackedUint32View(this.output, `${this.id} output`);
+    validatePackedUint32View(this.count, `${this.id} count`);
+    validatePackedUint32View(this.overflow, `${this.id} overflow`);
+    if (this.outputMask) validatePackedUint32View(this.outputMask, `${this.id} outputMask`);
+    if (this.visitedCount) validatePackedUint32View(this.visitedCount, `${this.id} visitedCount`);
+    if (
+      this.count.length < 1 ||
+      this.overflow.length < 1 ||
+      (this.visitedCount && this.visitedCount.length < 1)
+    ) {
+      throw new Error(`${this.id} count, overflow, and visitedCount must contain one uint32 row`);
+    }
+    const expectedQueryLength = this.kind === 'point' ? this.dimension : this.dimension * 2;
+    if (this.query.length !== expectedQueryLength) {
+      throw new Error(`${this.id} ${this.kind} query must contain ${expectedQueryLength} floats`);
+    }
+  }
+
+  /** Adds initialization and level-ordered traversal without submission or readback. */
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    const views = [
+      this.bvh.nodeMinima,
+      this.bvh.nodeMaxima,
+      this.bvh.nodeChildren,
+      this.bvh.leafIds,
+      this.bvh.overflow,
+      this.query,
+      this.output,
+      this.count,
+      this.overflow,
+      ...(this.outputMask ? [this.outputMask] : []),
+      ...(this.visitedCount ? [this.visitedCount] : [])
+    ];
+    if (views.some(view => view.buffer.graph !== graph)) {
+      throw new Error(`${this.id} views must belong to the target graph`);
+    }
+    const activeNodes = createTransientView(
+      graph,
+      `${this.id}-active-nodes`,
+      'uint32',
+      this.nodeCount
+    );
+    addInitializePass(graph, this, activeNodes);
+    for (let depth = 0; depth < this.levelCount; depth++) {
+      addTraversalLevelPass(graph, this, activeNodes, depth);
+    }
+    if (this.outputMask && this.output.length > 0) addOutputMaskPass(graph, this);
+  }
+}
+
+function validateIndexView(query: GPUBVHQuery): void {
+  validatePackedView(query.bvh.nodeMinima, ['float32x2', 'float32x3'], `${query.id} nodeMinima`);
+  validatePackedView(query.bvh.nodeMaxima, ['float32x2', 'float32x3'], `${query.id} nodeMaxima`);
+  validatePackedView(query.bvh.nodeChildren, ['uint32x2'], `${query.id} nodeChildren`);
+  validatePackedUint32View(query.bvh.leafIds, `${query.id} leafIds`);
+  validatePackedUint32View(query.bvh.overflow, `${query.id} bvh overflow`);
+  if (
+    query.bvh.nodeMinima.format !== query.bvh.nodeMaxima.format ||
+    query.bvh.nodeMinima.length !== query.nodeCount ||
+    query.bvh.nodeMaxima.length !== query.nodeCount ||
+    query.bvh.nodeChildren.length !== query.nodeCount ||
+    query.bvh.leafIds.length !== query.bvh.leafCapacity
+  ) {
+    throw new Error(`${query.id} bvh views must match its complete-binary topology`);
+  }
+  if (query.bvh.overflow.length < 1) {
+    throw new Error(`${query.id} bvh overflow must contain one uint32 row`);
+  }
+}
+
+function addInitializePass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  query: GPUBVHQuery,
+  activeNodes: GraphDataView<'uint32'>
+): void {
+  const maskBinding = query.outputMask
+    ? '@group(0) @binding(4) var<storage, read_write> outputMask: array<u32>;'
+    : '';
+  const visitedBinding = query.visitedCount
+    ? `@group(0) @binding(${query.outputMask ? 5 : 4}) var<storage, read_write> visitedCount: array<u32>;`
+    : '';
+  const source = /* wgsl */ `
+const NODE_COUNT: u32 = ${query.nodeCount}u;
+const ACTIVE_OFFSET: u32 = ${getViewElementOffset(activeNodes)}u;
+const BVH_OVERFLOW_OFFSET: u32 = ${getViewElementOffset(query.bvh.overflow)}u;
+const COUNT_OFFSET: u32 = ${getViewElementOffset(query.count)}u;
+const OVERFLOW_OFFSET: u32 = ${getViewElementOffset(query.overflow)}u;
+${
+  query.outputMask
+    ? `const MASK_OFFSET: u32 = ${getViewElementOffset(query.outputMask)}u;
+const MASK_LENGTH: u32 = ${query.outputMask.length}u;`
+    : ''
+}
+${
+  query.visitedCount
+    ? `const VISITED_OFFSET: u32 = ${getViewElementOffset(query.visitedCount)}u;`
+    : ''
+}
+@group(0) @binding(0) var<storage, read_write> activeNodes: array<u32>;
+@group(0) @binding(1) var<storage, read> bvhOverflow: array<u32>;
+@group(0) @binding(2) var<storage, read_write> outputCount: array<u32>;
+@group(0) @binding(3) var<storage, read_write> outputOverflow: array<u32>;
+${maskBinding}
+${visitedBinding}
+
+@compute @workgroup_size(${BVH_QUERY_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  let index = globalId.x;
+  if (index < NODE_COUNT) { activeNodes[ACTIVE_OFFSET + index] = select(0u, 1u, index == 0u); }
+  ${query.outputMask ? 'if (index < MASK_LENGTH) { outputMask[MASK_OFFSET + index] = 0u; }' : ''}
+  if (index == 0u) {
+    outputCount[COUNT_OFFSET] = 0u;
+    outputOverflow[OVERFLOW_OFFSET] = min(bvhOverflow[BVH_OVERFLOW_OFFSET], 1u);
+    ${query.visitedCount ? 'visitedCount[VISITED_OFFSET] = 1u;' : ''}
+  }
+}`;
+  const resources: GraphBufferUse[] = [
+    {buffer: activeNodes, usage: 'storage-write'},
+    {buffer: query.bvh.overflow, usage: 'storage-read'},
+    {buffer: query.count, usage: 'storage-write'},
+    {buffer: query.overflow, usage: 'storage-write'},
+    ...(query.outputMask
+      ? ([{buffer: query.outputMask, usage: 'storage-write'}] as GraphBufferUse[])
+      : []),
+    ...(query.visitedCount
+      ? ([{buffer: query.visitedCount, usage: 'storage-write'}] as GraphBufferUse[])
+      : [])
+  ];
+  addComputationPass(graph, {
+    id: `${query.id}-initialize`,
+    source,
+    resources,
+    bindings: {
+      activeNodes,
+      bvhOverflow: query.bvh.overflow,
+      outputCount: query.count,
+      outputOverflow: query.overflow,
+      ...(query.outputMask ? {outputMask: query.outputMask} : {}),
+      ...(query.visitedCount ? {visitedCount: query.visitedCount} : {})
+    },
+    dispatchCount: Math.ceil(
+      Math.max(query.nodeCount, query.outputMask?.length ?? 0, 1) / BVH_QUERY_WORKGROUP_SIZE
+    )
+  });
+}
+
+function addTraversalLevelPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  query: GPUBVHQuery,
+  activeNodes: GraphDataView<'uint32'>,
+  depth: number
+): void {
+  const firstNode = 2 ** depth - 1;
+  const levelNodeCount = 2 ** depth;
+  const leafLevel = depth === query.levelCount - 1;
+  const predicate = makeNodePredicate(query);
+  if (leafLevel) {
+    const source = /* wgsl */ `
+const FIRST_NODE: u32 = ${firstNode}u;
+const LEVEL_NODE_COUNT: u32 = ${levelNodeCount}u;
+const INTERNAL_NODE_COUNT: u32 = ${query.internalNodeCount}u;
+const DIMENSION: u32 = ${query.dimension}u;
+const OUTPUT_CAPACITY: u32 = ${query.output.length}u;
+const ACTIVE_OFFSET: u32 = ${getViewElementOffset(activeNodes)}u;
+const NODE_MINIMA_OFFSET: u32 = ${getViewElementOffset(query.bvh.nodeMinima)}u;
+const NODE_MAXIMA_OFFSET: u32 = ${getViewElementOffset(query.bvh.nodeMaxima)}u;
+const LEAF_IDS_OFFSET: u32 = ${getViewElementOffset(query.bvh.leafIds)}u;
+const QUERY_OFFSET: u32 = ${getViewElementOffset(query.query)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(query.output)}u;
+const COUNT_OFFSET: u32 = ${getViewElementOffset(query.count)}u;
+const OVERFLOW_OFFSET: u32 = ${getViewElementOffset(query.overflow)}u;
+@group(0) @binding(0) var<storage, read_write> activeNodes: array<atomic<u32>>;
+@group(0) @binding(1) var<storage, read> nodeMinima: array<f32>;
+@group(0) @binding(2) var<storage, read> nodeMaxima: array<f32>;
+@group(0) @binding(3) var<storage, read> leafIds: array<u32>;
+@group(0) @binding(4) var<storage, read> queryValues: array<f32>;
+@group(0) @binding(5) var<storage, read_write> outputIds: array<u32>;
+@group(0) @binding(6) var<storage, read_write> outputCount: array<atomic<u32>>;
+@group(0) @binding(7) var<storage, read_write> outputOverflow: array<atomic<u32>>;
+
+fn finite(value: f32) -> bool {
+  return value == value && abs(value) <= 3.402823466e+38;
+}
+
+@compute @workgroup_size(${BVH_QUERY_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  if (globalId.x >= LEVEL_NODE_COUNT) { return; }
+  let nodeIndex = FIRST_NODE + globalId.x;
+  if (atomicLoad(&activeNodes[ACTIVE_OFFSET + nodeIndex]) == 0u) { return; }
+  ${predicate}
+  if (selected) {
+    let leafIndex = nodeIndex - INTERNAL_NODE_COUNT;
+    let objectId = leafIds[LEAF_IDS_OFFSET + leafIndex];
+    if (objectId != ${INVALID_NODE}u) {
+      let outputIndex = atomicAdd(&outputCount[COUNT_OFFSET], 1u);
+      if (outputIndex < OUTPUT_CAPACITY) {
+        outputIds[OUTPUT_OFFSET + outputIndex] = objectId;
+      } else {
+        atomicStore(&outputOverflow[OVERFLOW_OFFSET], 1u);
+      }
+    }
+  }
+}`;
+    addComputationPass(graph, {
+      id: `${query.id}-depth-${depth}`,
+      source,
+      resources: [
+        {buffer: activeNodes, usage: 'storage-read-write'},
+        {buffer: query.bvh.nodeMinima, usage: 'storage-read'},
+        {buffer: query.bvh.nodeMaxima, usage: 'storage-read'},
+        {buffer: query.bvh.leafIds, usage: 'storage-read'},
+        {buffer: query.query, usage: 'storage-read'},
+        {buffer: query.output, usage: 'storage-write'},
+        {buffer: query.count, usage: 'storage-read-write'},
+        {buffer: query.overflow, usage: 'storage-read-write'}
+      ],
+      bindings: {
+        activeNodes,
+        nodeMinima: query.bvh.nodeMinima,
+        nodeMaxima: query.bvh.nodeMaxima,
+        leafIds: query.bvh.leafIds,
+        queryValues: query.query,
+        outputIds: query.output,
+        outputCount: query.count,
+        outputOverflow: query.overflow
+      },
+      dispatchCount: Math.ceil(levelNodeCount / BVH_QUERY_WORKGROUP_SIZE)
+    });
+    return;
+  }
+
+  const visitedBinding = query.visitedCount
+    ? '@group(0) @binding(5) var<storage, read_write> visitedCount: array<atomic<u32>>;'
+    : '';
+  const source = /* wgsl */ `
+const FIRST_NODE: u32 = ${firstNode}u;
+const LEVEL_NODE_COUNT: u32 = ${levelNodeCount}u;
+const DIMENSION: u32 = ${query.dimension}u;
+const ACTIVE_OFFSET: u32 = ${getViewElementOffset(activeNodes)}u;
+const NODE_MINIMA_OFFSET: u32 = ${getViewElementOffset(query.bvh.nodeMinima)}u;
+const NODE_MAXIMA_OFFSET: u32 = ${getViewElementOffset(query.bvh.nodeMaxima)}u;
+const CHILDREN_OFFSET: u32 = ${getViewElementOffset(query.bvh.nodeChildren)}u;
+const QUERY_OFFSET: u32 = ${getViewElementOffset(query.query)}u;
+${
+  query.visitedCount
+    ? `const VISITED_OFFSET: u32 = ${getViewElementOffset(query.visitedCount)}u;`
+    : ''
+}
+@group(0) @binding(0) var<storage, read_write> activeNodes: array<atomic<u32>>;
+@group(0) @binding(1) var<storage, read> nodeMinima: array<f32>;
+@group(0) @binding(2) var<storage, read> nodeMaxima: array<f32>;
+@group(0) @binding(3) var<storage, read> nodeChildren: array<u32>;
+@group(0) @binding(4) var<storage, read> queryValues: array<f32>;
+${visitedBinding}
+
+fn finite(value: f32) -> bool {
+  return value == value && abs(value) <= 3.402823466e+38;
+}
+
+@compute @workgroup_size(${BVH_QUERY_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  if (globalId.x >= LEVEL_NODE_COUNT) { return; }
+  let nodeIndex = FIRST_NODE + globalId.x;
+  if (atomicLoad(&activeNodes[ACTIVE_OFFSET + nodeIndex]) == 0u) { return; }
+  ${predicate}
+  if (selected) {
+    let childComponent = nodeIndex * 2u;
+    let left = nodeChildren[CHILDREN_OFFSET + childComponent];
+    let right = nodeChildren[CHILDREN_OFFSET + childComponent + 1u];
+    if (left != ${INVALID_NODE}u) { atomicStore(&activeNodes[ACTIVE_OFFSET + left], 1u); }
+    if (right != ${INVALID_NODE}u) { atomicStore(&activeNodes[ACTIVE_OFFSET + right], 1u); }
+    ${query.visitedCount ? 'atomicAdd(&visitedCount[VISITED_OFFSET], 2u);' : ''}
+  }
+}`;
+  addComputationPass(graph, {
+    id: `${query.id}-depth-${depth}`,
+    source,
+    resources: [
+      {buffer: activeNodes, usage: 'storage-read-write'},
+      {buffer: query.bvh.nodeMinima, usage: 'storage-read'},
+      {buffer: query.bvh.nodeMaxima, usage: 'storage-read'},
+      {buffer: query.bvh.nodeChildren, usage: 'storage-read'},
+      {buffer: query.query, usage: 'storage-read'},
+      ...(query.visitedCount
+        ? ([{buffer: query.visitedCount, usage: 'storage-read-write'}] as GraphBufferUse[])
+        : [])
+    ],
+    bindings: {
+      activeNodes,
+      nodeMinima: query.bvh.nodeMinima,
+      nodeMaxima: query.bvh.nodeMaxima,
+      nodeChildren: query.bvh.nodeChildren,
+      queryValues: query.query,
+      ...(query.visitedCount ? {visitedCount: query.visitedCount} : {})
+    },
+    dispatchCount: Math.ceil(levelNodeCount / BVH_QUERY_WORKGROUP_SIZE)
+  });
+}
+
+function addOutputMaskPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  query: GPUBVHQuery
+): void {
+  const source = /* wgsl */ `
+const OUTPUT_CAPACITY: u32 = ${query.output.length}u;
+const MASK_LENGTH: u32 = ${query.outputMask!.length}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(query.output)}u;
+const COUNT_OFFSET: u32 = ${getViewElementOffset(query.count)}u;
+const MASK_OFFSET: u32 = ${getViewElementOffset(query.outputMask!)}u;
+@group(0) @binding(0) var<storage, read> outputIds: array<u32>;
+@group(0) @binding(1) var<storage, read> outputCount: array<u32>;
+@group(0) @binding(2) var<storage, read_write> outputMask: array<atomic<u32>>;
+
+@compute @workgroup_size(${BVH_QUERY_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  let index = globalId.x;
+  let storedCount = min(outputCount[COUNT_OFFSET], OUTPUT_CAPACITY);
+  if (index >= storedCount) { return; }
+  let objectId = outputIds[OUTPUT_OFFSET + index];
+  if (objectId < MASK_LENGTH) { atomicStore(&outputMask[MASK_OFFSET + objectId], 1u); }
+}`;
+  addComputationPass(graph, {
+    id: `${query.id}-output-mask`,
+    source,
+    resources: [
+      {buffer: query.output, usage: 'storage-read'},
+      {buffer: query.count, usage: 'storage-read'},
+      {buffer: query.outputMask!, usage: 'storage-read-write'}
+    ],
+    bindings: {outputIds: query.output, outputCount: query.count, outputMask: query.outputMask!},
+    dispatchCount: Math.ceil(query.output.length / BVH_QUERY_WORKGROUP_SIZE)
+  });
+}
+
+function makeNodePredicate(query: GPUBVHQuery): string {
+  const axes = ['X', 'Y', ...(query.dimension === 3 ? ['Z'] : [])];
+  const nodeValues = axes
+    .map(
+      (axis, axisIndex) =>
+        `let nodeMin${axis} = nodeMinima[NODE_MINIMA_OFFSET + nodeIndex * DIMENSION + ${axisIndex}u];
+  let nodeMax${axis} = nodeMaxima[NODE_MAXIMA_OFFSET + nodeIndex * DIMENSION + ${axisIndex}u];`
+    )
+    .join('\n  ');
+  const validNode = axes
+    .map(
+      axis => `finite(nodeMin${axis}) && finite(nodeMax${axis}) && nodeMin${axis} <= nodeMax${axis}`
+    )
+    .join(' && ');
+  if (query.kind === 'point') {
+    const queryValues = axes
+      .map((axis, axisIndex) => `let query${axis} = queryValues[QUERY_OFFSET + ${axisIndex}u];`)
+      .join('\n  ');
+    const validQuery = axes.map(axis => `finite(query${axis})`).join(' && ');
+    const contains = axes
+      .map(axis => `query${axis} >= nodeMin${axis} && query${axis} <= nodeMax${axis}`)
+      .join(' && ');
+    return `${nodeValues}
+  ${queryValues}
+  let selected = ${validNode} && ${validQuery} && ${contains};`;
+  }
+  const queryValues = axes
+    .map(
+      (axis, axisIndex) =>
+        `let queryMin${axis} = queryValues[QUERY_OFFSET + ${axisIndex}u];
+  let queryMax${axis} = queryValues[QUERY_OFFSET + ${axisIndex + query.dimension}u];`
+    )
+    .join('\n  ');
+  const validQuery = axes
+    .map(
+      axis =>
+        `finite(queryMin${axis}) && finite(queryMax${axis}) && queryMin${axis} <= queryMax${axis}`
+    )
+    .join(' && ');
+  const intersects = axes
+    .map(axis => `nodeMax${axis} >= queryMin${axis} && nodeMin${axis} <= queryMax${axis}`)
+    .join(' && ');
+  return `${nodeValues}
+  ${queryValues}
+  let selected = ${validNode} && ${validQuery} && ${intersects};`;
+}
+
+function addComputationPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    source: string;
+    resources: GraphBufferUse[];
+    bindings: Record<string, GraphDataView>;
+    dispatchCount: number;
+  }
+): void {
+  graph.addComputePass({
+    id: props.id,
+    resources: props.resources,
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: props.id,
+        source: props.source,
+        shaderLayout: {
+          bindings: Object.keys(props.bindings).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const [name, view] of Object.entries(props.bindings)) {
+            bindings[name] = getViewBinding(view, getBuffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatch(computePass, props.dispatchCount);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function isPowerOfTwo(value: number): boolean {
+  return value > 0 && Number.isInteger(Math.log2(value));
+}

--- a/modules/experimental/src/gpu-primitives/gpu-bvh.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-bvh.ts
@@ -16,6 +16,8 @@ import {
 const BVH_WORKGROUP_SIZE = 256;
 const INVALID_NODE = 0xffffffff;
 
+type GPUBVHDispatchLayout = {x: number; y: number; z: number};
+
 /** Packed two- or three-dimensional bounds consumed and published by {@link GPUBVH}. */
 export type GPUBVHBoundsView = GraphDataView<'float32x2'> | GraphDataView<'float32x3'>;
 
@@ -175,14 +177,22 @@ export class GPUBVH {
       throw new Error(`${this.id} views must belong to the target graph`);
     }
 
-    addLoadLeavesPass(graph, this);
+    addLoadLeavesPass(
+      graph,
+      this,
+      getGPUBVHDispatchLayout(this.nodeCount, graph.device.limits.maxComputeWorkgroupsPerDimension)
+    );
     for (let depth = this.levelCount - 2; depth >= 0; depth--) {
       addRefitLevelPass(graph, this, depth);
     }
   }
 }
 
-function addLoadLeavesPass<Parameters>(graph: GPUCommandGraph<Parameters>, bvh: GPUBVH): void {
+function addLoadLeavesPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  bvh: GPUBVH,
+  dispatchLayout: GPUBVHDispatchLayout
+): void {
   const sourceIdBinding = bvh.sourceIds
     ? '@group(0) @binding(8) var<storage, read> sourceIds: array<u32>;'
     : '';
@@ -218,9 +228,11 @@ fn finite(value: f32) -> bool {
 }
 
 @compute @workgroup_size(${BVH_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) globalId: vec3<u32>
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>
 ) {
-  let nodeIndex = globalId.x;
+  let workgroupIndex = (workgroupId.z * ${dispatchLayout.y}u + workgroupId.y) * ${dispatchLayout.x}u + workgroupId.x;
+  let nodeIndex = workgroupIndex * ${BVH_WORKGROUP_SIZE}u + localId.x;
   if (nodeIndex >= NODE_COUNT) { return; }
   let nodeComponent = nodeIndex * DIMENSION;
   for (var axis = 0u; axis < DIMENSION; axis++) {
@@ -286,7 +298,7 @@ fn finite(value: f32) -> bool {
       outputOverflow: bvh.overflow,
       ...(bvh.sourceIds ? {sourceIds: bvh.sourceIds} : {})
     },
-    dispatchCount: Math.ceil(bvh.nodeCount / BVH_WORKGROUP_SIZE)
+    dispatchSize: dispatchLayout
   });
 }
 
@@ -351,7 +363,8 @@ function addComputationPass<Parameters>(
     source: string;
     resources: GraphBufferUse[];
     bindings: Record<string, GraphDataView>;
-    dispatchCount: number;
+    dispatchCount?: number;
+    dispatchSize?: GPUBVHDispatchLayout;
   }
 ): void {
   graph.addComputePass({
@@ -377,12 +390,39 @@ function addComputationPass<Parameters>(
             bindings[name] = getViewBinding(view, getBuffer);
           }
           computation.setBindings(bindings);
-          computation.dispatch(computePass, props.dispatchCount);
+          if (props.dispatchSize) {
+            computation.dispatch(
+              computePass,
+              props.dispatchSize.x,
+              props.dispatchSize.y,
+              props.dispatchSize.z
+            );
+          } else {
+            computation.dispatch(computePass, props.dispatchCount!);
+          }
         },
         destroy: () => computation.destroy()
       };
     }
   });
+}
+
+/** Plans a bounded 3D dispatch for BVH node initialization. @internal */
+export function getGPUBVHDispatchLayout(
+  nodeCount: number,
+  maxComputeWorkgroupsPerDimension: number
+): GPUBVHDispatchLayout {
+  const maximum = Math.floor(maxComputeWorkgroupsPerDimension);
+  const workgroupCount = Math.max(1, Math.ceil(nodeCount / BVH_WORKGROUP_SIZE));
+  const x = Math.min(workgroupCount, maximum);
+  const y = Math.min(Math.ceil(workgroupCount / x), maximum);
+  const z = Math.ceil(workgroupCount / x / y);
+  if (z > maximum) {
+    throw new Error(
+      `GPUBVH requires ${workgroupCount} workgroups, exceeding the 3D dispatch limit of ${maximum} per dimension`
+    );
+  }
+  return {x, y, z};
 }
 
 function isPowerOfTwo(value: number): boolean {

--- a/modules/experimental/src/gpu-primitives/gpu-grid-index-query.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-grid-index-query.ts
@@ -7,6 +7,7 @@ import {Computation} from '@luma.gl/engine';
 import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-command-graph';
 import type {GPUGridIndexBounds, GPUGridIndexSize} from './gpu-grid-index';
 import {
+  doGraphDataViewsOverlap,
   getViewBinding,
   getViewElementOffset,
   validatePackedUint32View,
@@ -95,6 +96,12 @@ export class GPUGridIndexQuery {
     if (this.query.length !== expectedQueryLength) {
       throw new Error(`${this.id} ${this.kind} query must contain ${expectedQueryLength} floats`);
     }
+    validateDisjointQueryViews(this.id, this.index, this.query, [
+      this.output,
+      this.count,
+      this.overflow,
+      ...(this.outputMask ? [this.outputMask] : [])
+    ]);
   }
 
   /** Adds output initialization and candidate collection without submitting or reading back work. */
@@ -229,6 +236,16 @@ fn getCoordinate(value: f32, minimum: f32, maximum: f32, size: u32) -> u32 {
   if (!finite(value)) { return 0u; }
   if (maximum == minimum || value == minimum) { return 0u; }
   if (value == maximum) { return size - 1u; }
+  if (minimum < 0.0 && maximum > 0.0) {
+    let scale = max(abs(minimum), abs(maximum));
+    let scaledValue = value / scale;
+    let scaledMinimum = minimum / scale;
+    let scaledMaximum = maximum / scale;
+    return min(
+      u32((scaledValue - scaledMinimum) / (scaledMaximum - scaledMinimum) * f32(size)),
+      size - 1u
+    );
+  }
   return min(u32((value - minimum) / (maximum - minimum) * f32(size)), size - 1u);
 }
 
@@ -248,12 +265,14 @@ fn findCellIndex(objectIndex: u32) -> u32 {
 }
 
 fn cellMinimum(coordinate: u32, size: u32, minimum: f32, maximum: f32) -> f32 {
-  return minimum + (maximum - minimum) * f32(coordinate) / f32(size);
+  let ratio = f32(coordinate) / f32(size);
+  return minimum * (1.0 - ratio) + maximum * ratio;
 }
 
 fn cellMaximum(coordinate: u32, size: u32, minimum: f32, maximum: f32) -> f32 {
   if (coordinate + 1u == size) { return maximum; }
-  return minimum + (maximum - minimum) * f32(coordinate + 1u) / f32(size);
+  let ratio = f32(coordinate + 1u) / f32(size);
+  return minimum * (1.0 - ratio) + maximum * ratio;
 }
 
 @compute @workgroup_size(${GRID_QUERY_WORKGROUP_SIZE}) fn main(
@@ -406,21 +425,66 @@ function makeCellSelection(query: GPUGridIndexQuery): string {
     )
     .join('\n  ');
   const validCenter = axes.map(axis => `finite(query${axis.name.toUpperCase()})`).join(' && ');
-  const distances = axes
+  const closestPoints = axes
     .map(
       axis =>
-        `let closest${axis.name.toUpperCase()} = clamp(query${axis.name.toUpperCase()}, cellMin${axis.name.toUpperCase()}, cellMax${axis.name.toUpperCase()});
-  let distance${axis.name.toUpperCase()} = query${axis.name.toUpperCase()} - closest${axis.name.toUpperCase()};`
+        `let closest${axis.name.toUpperCase()} = clamp(query${axis.name.toUpperCase()}, cellMin${axis.name.toUpperCase()}, cellMax${axis.name.toUpperCase()});`
     )
     .join('\n  ');
+  const scale = makeNestedMaximum([
+    'radius',
+    ...axes.flatMap(axis => [
+      `abs(query${axis.name.toUpperCase()})`,
+      `abs(closest${axis.name.toUpperCase()})`
+    ])
+  ]);
   const squaredDistance = axes
-    .map(axis => `distance${axis.name.toUpperCase()} * distance${axis.name.toUpperCase()}`)
+    .map(
+      axis =>
+        `(query${axis.name.toUpperCase()} / scale - closest${axis.name.toUpperCase()} / scale) * (query${axis.name.toUpperCase()} / scale - closest${axis.name.toUpperCase()} / scale)`
+    )
     .join(' + ');
   return `${cellDeclarations}
   ${values}
   let radius = queryValues[QUERY_OFFSET + ${dimension}u];
-  ${distances}
-  let selected = ${validCenter} && finite(radius) && radius >= 0.0 && ${squaredDistance} <= radius * radius;`;
+  ${closestPoints}
+  let scale = ${scale};
+  let selected = ${validCenter} && finite(radius) && radius >= 0.0 && (scale == 0.0 || ${squaredDistance} <= (radius / scale) * (radius / scale));`;
+}
+
+function makeNestedMaximum(values: string[]): string {
+  return values.slice(1).reduce((maximum, value) => `max(${maximum}, ${value})`, values[0]);
+}
+
+function validateDisjointQueryViews(
+  id: string,
+  index: GPUGridIndexView,
+  query: GraphDataView<'float32'>,
+  outputs: GraphDataView<'uint32'>[]
+): void {
+  const inputs: [string, GraphDataView][] = [
+    ['index cellOffsets', index.cellOffsets],
+    ['index objectIds', index.objectIds],
+    ['index count', index.count],
+    ['index overflow', index.overflow],
+    ['query', query]
+  ];
+  const outputNames = ['output', 'count', 'overflow', 'outputMask'];
+  for (let outputIndex = 0; outputIndex < outputs.length; outputIndex++) {
+    const output = outputs[outputIndex];
+    for (const [inputName, input] of inputs) {
+      if (doGraphDataViewsOverlap(output, input)) {
+        throw new Error(`${id} ${outputNames[outputIndex]} and ${inputName} must not overlap`);
+      }
+    }
+    for (let previousIndex = 0; previousIndex < outputIndex; previousIndex++) {
+      if (doGraphDataViewsOverlap(output, outputs[previousIndex])) {
+        throw new Error(
+          `${id} ${outputNames[outputIndex]} and ${outputNames[previousIndex]} must not overlap`
+        );
+      }
+    }
+  }
 }
 
 function validateIndexView(id: string, index: GPUGridIndexView, dimension: 2 | 3): void {
@@ -497,5 +561,6 @@ function addComputationPass<Parameters>(
 }
 
 function getFloatLiteral(value: number): string {
-  return Number.isInteger(value) ? `${value}.0` : `${value}`;
+  const literal = `${Math.fround(value)}`;
+  return literal.includes('.') || literal.includes('e') ? literal : `${literal}.0`;
 }

--- a/modules/experimental/src/gpu-primitives/gpu-grid-index.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-grid-index.ts
@@ -13,6 +13,7 @@ import {
 import {GPUScan} from './gpu-scan';
 import {
   createTransientView,
+  doGraphDataViewsOverlap,
   getViewBinding,
   getViewElementOffset,
   validateMatchingVectorTopology,
@@ -470,9 +471,10 @@ fn getCoordinate(value: f32, minimum: f32, maximum: f32, size: u32) -> u32 {
   if (maximum == minimum || value == minimum) { return 0u; }
   if (value == maximum) { return size - 1u; }
   if (minimum < 0.0 && maximum > 0.0) {
-    let scaledValue = value * 0.5;
-    let scaledMinimum = minimum * 0.5;
-    let scaledMaximum = maximum * 0.5;
+    let scale = max(abs(minimum), abs(maximum));
+    let scaledValue = value / scale;
+    let scaledMinimum = minimum / scale;
+    let scaledMaximum = maximum / scale;
     return min(
       u32((scaledValue - scaledMinimum) / (scaledMaximum - scaledMinimum) * f32(size)),
       size - 1u
@@ -575,25 +577,15 @@ function validateDisjointGridInputs(
   objectIds: GraphDataView<'uint32'>
 ): void {
   for (const positionChunk of getPositionChunks(positions)) {
-    if (doViewsOverlap(positionChunk, objectIds)) {
+    if (doGraphDataViewsOverlap(positionChunk, objectIds)) {
       throw new Error(`${id} positions and objectIds must not overlap`);
     }
   }
   for (const sourceIdChunk of getSourceIdChunks(sourceIds)) {
-    if (doViewsOverlap(sourceIdChunk, objectIds)) {
+    if (doGraphDataViewsOverlap(sourceIdChunk, objectIds)) {
       throw new Error(`${id} sourceIds and objectIds must not overlap`);
     }
   }
-}
-
-function doViewsOverlap(first: GraphDataView, second: GraphDataView): boolean {
-  if (first.buffer !== second.buffer || first.length === 0 || second.length === 0) {
-    return false;
-  }
-  const firstEnd = first.byteOffset + (first.length - 1) * first.byteStride + first.rowByteLength;
-  const secondEnd =
-    second.byteOffset + (second.length - 1) * second.byteStride + second.rowByteLength;
-  return first.byteOffset < secondEnd && second.byteOffset < firstEnd;
 }
 
 function getPositionChunks(

--- a/modules/experimental/src/gpu-primitives/gpu-point-spatial-filter.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-point-spatial-filter.ts
@@ -296,18 +296,28 @@ function makePredicate(filter: GPUPointSpatialFilter): string {
   }
 
   const centerValues = axes
-    .map(
-      (axis, axisIndex) =>
-        `let query${axis} = queryValues[QUERY_OFFSET + ${axisIndex}u];
-  let distance${axis} = position${axis} - query${axis};`
-    )
+    .map((axis, axisIndex) => `let query${axis} = queryValues[QUERY_OFFSET + ${axisIndex}u];`)
     .join('\n  ');
   const finiteCenter = axes.map(axis => `finite(query${axis})`).join(' && ');
-  const squaredDistance = axes.map(axis => `distance${axis} * distance${axis}`).join(' + ');
+  const scale = makeNestedMaximum([
+    'radius',
+    ...axes.flatMap(axis => [`abs(position${axis})`, `abs(query${axis})`])
+  ]);
+  const squaredDistance = axes
+    .map(
+      axis =>
+        `(position${axis} / scale - query${axis} / scale) * (position${axis} / scale - query${axis} / scale)`
+    )
+    .join(' + ');
   return `${positionValues}
   ${centerValues}
   let radius = queryValues[QUERY_OFFSET + ${filter.dimension}u];
-  let selected = ${finitePosition} && ${finiteCenter} && finite(radius) && radius >= 0.0 && ${squaredDistance} <= radius * radius;`;
+  let scale = ${scale};
+  let selected = ${finitePosition} && ${finiteCenter} && finite(radius) && radius >= 0.0 && (scale == 0.0 || ${squaredDistance} <= (radius / scale) * (radius / scale));`;
+}
+
+function makeNestedMaximum(values: string[]): string {
+  return values.slice(1).reduce((maximum, value) => `max(${maximum}, ${value})`, values[0]);
 }
 
 function addComputationPass<Parameters>(

--- a/modules/experimental/src/gpu-primitives/gpu-spatial-query-benchmark.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-spatial-query-benchmark.ts
@@ -138,6 +138,9 @@ export async function runGPUSpatialQueryBenchmark(
         const encoding = path.encode(commandEncoder);
         device.submit(commandEncoder.finish());
         timingReports.push(await encoding.readTimings());
+      } catch (error) {
+        commandEncoder.destroy();
+        throw error;
       } finally {
         querySet?.destroy();
       }

--- a/modules/experimental/src/gpu-primitives/gpu-spatial-query-benchmark.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-spatial-query-benchmark.ts
@@ -1,0 +1,307 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CommandEncoder, Device} from '@luma.gl/core';
+import type {
+  GPUCommandGraphEncoding,
+  GPUCommandGraphNodeTiming,
+  GPUCommandGraphTimingReport
+} from './gpu-command-graph';
+
+/** Spatial query implementation compared by {@link runGPUSpatialQueryBenchmark}. */
+export type GPUSpatialBenchmarkStrategy = 'scan' | 'grid' | 'bvh';
+
+/** Cost category assigned to one command-graph node by a benchmark adapter. */
+export type GPUSpatialBenchmarkPhase = 'build' | 'refit' | 'query' | 'refinement';
+
+/** Stable-ID result and observable work returned by one benchmark path. */
+export type GPUSpatialBenchmarkResult = {
+  ids: readonly number[];
+  overflow?: boolean;
+  candidateCount?: number;
+  visitedCount?: number;
+};
+
+/** One scan, grid, or BVH adapter measured by the shared harness. */
+export type GPUSpatialBenchmarkPath = {
+  id: string;
+  strategy: GPUSpatialBenchmarkStrategy;
+  /** Caller-owned and graph-owned bytes required by this path. */
+  memoryByteLength: number;
+  /** Encodes one identical query without submission. */
+  encode: (commandEncoder: CommandEncoder) => GPUCommandGraphEncoding;
+  /** Reads the most recently encoded exact stable-ID result. */
+  readResult: () => Promise<GPUSpatialBenchmarkResult>;
+  /** Assigns graph nodes to separately reported spatial cost phases. */
+  getNodePhase: (nodeId: string) => GPUSpatialBenchmarkPhase | undefined;
+};
+
+/** Configuration for a correctness-gated scan/grid/BVH benchmark. */
+export type GPUSpatialQueryBenchmarkProps = {
+  id?: string;
+  paths: readonly GPUSpatialBenchmarkPath[];
+  /** CPU-oracle stable IDs shared by every path. Order is ignored; duplicates are not. */
+  expectedIds: readonly number[];
+  warmupIterations?: number;
+  measuredIterations?: number;
+  /** Query reuse counts used to amortize build/refit cost. */
+  reuseCounts?: readonly number[];
+};
+
+/** Distribution summary for repeated CPU or GPU durations. */
+export type GPUSpatialBenchmarkDistribution = {
+  minimum: number;
+  median: number;
+  percentile95: number;
+  maximum: number;
+};
+
+/** Amortized per-query GPU cost for one index reuse count. */
+export type GPUSpatialBenchmarkAmortizedCost = {
+  reuseCount: number;
+  gpuTimeMilliseconds: number;
+};
+
+/** Correctness, work, memory, and timing report for one strategy. */
+export type GPUSpatialBenchmarkPathReport = {
+  id: string;
+  strategy: GPUSpatialBenchmarkStrategy;
+  memoryByteLength: number;
+  resultCount: number;
+  candidateCount?: number;
+  visitedCount?: number;
+  cpuEncodeTimeMilliseconds: GPUSpatialBenchmarkDistribution;
+  gpuTimeMilliseconds?: GPUSpatialBenchmarkDistribution;
+  phases: Partial<Record<GPUSpatialBenchmarkPhase, GPUSpatialBenchmarkDistribution>>;
+  amortizedGPUTime: GPUSpatialBenchmarkAmortizedCost[];
+};
+
+/** Reproducible metadata and per-strategy output from one benchmark run. */
+export type GPUSpatialQueryBenchmarkReport = {
+  id: string;
+  timestampQueries: boolean;
+  warmupIterations: number;
+  measuredIterations: number;
+  expectedResultCount: number;
+  paths: GPUSpatialBenchmarkPathReport[];
+};
+
+const DEFAULT_WARMUP_ITERATIONS = 3;
+const DEFAULT_MEASURED_ITERATIONS = 20;
+const DEFAULT_REUSE_COUNTS = [1, 10, 100] as const;
+
+/**
+ * Runs scan, grid, and BVH adapters with one correctness oracle and measurement protocol.
+ *
+ * The harness owns submission and optional timestamp query sets, but not data generation,
+ * command graphs, result buffers, or readback. It rejects overflow and result mismatch before
+ * reporting timings so a faster incomplete path cannot appear to win.
+ */
+export async function runGPUSpatialQueryBenchmark(
+  device: Device,
+  props: GPUSpatialQueryBenchmarkProps
+): Promise<GPUSpatialQueryBenchmarkReport> {
+  const id = props.id ?? 'gpu-spatial-query-benchmark';
+  const warmupIterations = props.warmupIterations ?? DEFAULT_WARMUP_ITERATIONS;
+  const measuredIterations = props.measuredIterations ?? DEFAULT_MEASURED_ITERATIONS;
+  const reuseCounts = props.reuseCounts ?? DEFAULT_REUSE_COUNTS;
+  validateBenchmarkProps(id, props.paths, warmupIterations, measuredIterations, reuseCounts);
+  const expectedIds = getSortedIds(props.expectedIds);
+  const timestampQueries = device.features.has('timestamp-query');
+  const pathReports: GPUSpatialBenchmarkPathReport[] = [];
+
+  for (const path of props.paths) {
+    let timestampedNodeCount = 0;
+    for (let iteration = 0; iteration < warmupIterations; iteration++) {
+      const encoding = encodeAndSubmit(device, path, `${id}-${path.id}-warmup-${iteration}`);
+      timestampedNodeCount = encoding.stats.nodes.filter(node => node.type !== 'copy').length;
+    }
+    const initialResult = await path.readResult();
+    validateResult(id, path, initialResult, expectedIds);
+
+    const timingReports: GPUCommandGraphTimingReport[] = [];
+    for (let iteration = 0; iteration < measuredIterations; iteration++) {
+      const querySet =
+        timestampQueries && timestampedNodeCount > 0
+          ? device.createQuerySet({
+              id: `${id}-${path.id}-timestamps-${iteration}`,
+              type: 'timestamp',
+              count: timestampedNodeCount * 2
+            })
+          : undefined;
+      const commandEncoder = device.createCommandEncoder({
+        id: `${id}-${path.id}-measured-${iteration}`,
+        timeProfilingQuerySet: querySet
+      });
+      try {
+        const encoding = path.encode(commandEncoder);
+        device.submit(commandEncoder.finish());
+        timingReports.push(await encoding.readTimings());
+      } finally {
+        querySet?.destroy();
+      }
+    }
+    const finalResult = await path.readResult();
+    validateResult(id, path, finalResult, expectedIds);
+    pathReports.push(
+      makePathReport(path, finalResult, timingReports, reuseCounts, expectedIds.length)
+    );
+  }
+
+  return {
+    id,
+    timestampQueries,
+    warmupIterations,
+    measuredIterations,
+    expectedResultCount: expectedIds.length,
+    paths: pathReports
+  };
+}
+
+function encodeAndSubmit(
+  device: Device,
+  path: GPUSpatialBenchmarkPath,
+  id: string
+): GPUCommandGraphEncoding {
+  const commandEncoder = device.createCommandEncoder({id});
+  try {
+    const encoding = path.encode(commandEncoder);
+    device.submit(commandEncoder.finish());
+    return encoding;
+  } catch (error) {
+    commandEncoder.destroy();
+    throw error;
+  }
+}
+
+function makePathReport(
+  path: GPUSpatialBenchmarkPath,
+  result: GPUSpatialBenchmarkResult,
+  timingReports: readonly GPUCommandGraphTimingReport[],
+  reuseCounts: readonly number[],
+  resultCount: number
+): GPUSpatialBenchmarkPathReport {
+  const cpuSamples = timingReports.map(report => report.cpuEncodeTimeMilliseconds);
+  const gpuSamples = timingReports.flatMap(report =>
+    report.gpuTimeMilliseconds === undefined ? [] : [report.gpuTimeMilliseconds]
+  );
+  const phases: Partial<Record<GPUSpatialBenchmarkPhase, GPUSpatialBenchmarkDistribution>> = {};
+  for (const phase of ['build', 'refit', 'query', 'refinement'] as const) {
+    const samples = timingReports.flatMap(report => {
+      const phaseNodes = report.nodes.filter(node => path.getNodePhase(node.id) === phase);
+      return getSummedGPUTime(phaseNodes);
+    });
+    if (samples.length > 0) phases[phase] = summarizeGPUSpatialBenchmarkSamples(samples);
+  }
+  return {
+    id: path.id,
+    strategy: path.strategy,
+    memoryByteLength: path.memoryByteLength,
+    resultCount,
+    ...(result.candidateCount === undefined ? {} : {candidateCount: result.candidateCount}),
+    ...(result.visitedCount === undefined ? {} : {visitedCount: result.visitedCount}),
+    cpuEncodeTimeMilliseconds: summarizeGPUSpatialBenchmarkSamples(cpuSamples),
+    ...(gpuSamples.length > 0
+      ? {gpuTimeMilliseconds: summarizeGPUSpatialBenchmarkSamples(gpuSamples)}
+      : {}),
+    phases,
+    amortizedGPUTime: makeAmortizedCosts(phases, reuseCounts)
+  };
+}
+
+function getSummedGPUTime(nodes: readonly GPUCommandGraphNodeTiming[]): number[] {
+  if (nodes.length === 0 || nodes.some(node => node.gpuTimeMilliseconds === undefined)) return [];
+  return [nodes.reduce((sum, node) => sum + node.gpuTimeMilliseconds!, 0)];
+}
+
+function makeAmortizedCosts(
+  phases: Partial<Record<GPUSpatialBenchmarkPhase, GPUSpatialBenchmarkDistribution>>,
+  reuseCounts: readonly number[]
+): GPUSpatialBenchmarkAmortizedCost[] {
+  const setupTime = (phases.build?.median ?? 0) + (phases.refit?.median ?? 0);
+  const queryTime = (phases.query?.median ?? 0) + (phases.refinement?.median ?? 0);
+  if (setupTime === 0 && queryTime === 0) return [];
+  return reuseCounts.map(reuseCount => ({
+    reuseCount,
+    gpuTimeMilliseconds: setupTime / reuseCount + queryTime
+  }));
+}
+
+/** Summarizes finite samples using nearest-rank median and 95th percentile values. */
+export function summarizeGPUSpatialBenchmarkSamples(
+  samples: readonly number[]
+): GPUSpatialBenchmarkDistribution {
+  if (samples.length === 0 || samples.some(sample => !Number.isFinite(sample) || sample < 0)) {
+    throw new Error('GPU spatial benchmark samples must contain finite non-negative values');
+  }
+  const sortedSamples = [...samples].sort((left, right) => left - right);
+  return {
+    minimum: sortedSamples[0],
+    median: getPercentile(sortedSamples, 0.5),
+    percentile95: getPercentile(sortedSamples, 0.95),
+    maximum: sortedSamples[sortedSamples.length - 1]
+  };
+}
+
+function getPercentile(sortedSamples: readonly number[], percentile: number): number {
+  return sortedSamples[Math.ceil(percentile * sortedSamples.length) - 1];
+}
+
+function validateResult(
+  benchmarkId: string,
+  path: GPUSpatialBenchmarkPath,
+  result: GPUSpatialBenchmarkResult,
+  expectedIds: readonly number[]
+): void {
+  if (result.overflow) {
+    throw new Error(`${benchmarkId} path "${path.id}" overflowed; timing would be incomplete`);
+  }
+  const actualIds = getSortedIds(result.ids);
+  if (
+    actualIds.length !== expectedIds.length ||
+    actualIds.some((value, index) => value !== expectedIds[index])
+  ) {
+    throw new Error(`${benchmarkId} path "${path.id}" does not match the shared CPU oracle`);
+  }
+}
+
+function getSortedIds(ids: readonly number[]): number[] {
+  return [...ids].sort((left, right) => left - right);
+}
+
+function validateBenchmarkProps(
+  id: string,
+  paths: readonly GPUSpatialBenchmarkPath[],
+  warmupIterations: number,
+  measuredIterations: number,
+  reuseCounts: readonly number[]
+): void {
+  const strategies = new Set(paths.map(path => path.strategy));
+  const pathIds = new Set(paths.map(path => path.id));
+  if (paths.length !== 3 || strategies.size !== 3) {
+    throw new Error(`${id} requires exactly one scan, grid, and bvh path`);
+  }
+  if (pathIds.size !== paths.length) {
+    throw new Error(`${id} path IDs must be unique`);
+  }
+  if (
+    !Number.isSafeInteger(warmupIterations) ||
+    warmupIterations < 1 ||
+    !Number.isSafeInteger(measuredIterations) ||
+    measuredIterations < 1
+  ) {
+    throw new Error(`${id} iteration counts must be positive safe integers`);
+  }
+  if (
+    reuseCounts.length === 0 ||
+    reuseCounts.some(reuseCount => !Number.isSafeInteger(reuseCount) || reuseCount < 1)
+  ) {
+    throw new Error(`${id} reuse counts must be positive safe integers`);
+  }
+  for (const path of paths) {
+    if (!path.id || !Number.isSafeInteger(path.memoryByteLength) || path.memoryByteLength < 0) {
+      throw new Error(`${id} paths require IDs and non-negative memory byte lengths`);
+    }
+  }
+}

--- a/modules/experimental/src/gpu-primitives/graph-data-view-utils.ts
+++ b/modules/experimental/src/gpu-primitives/graph-data-view-utils.ts
@@ -72,6 +72,17 @@ export function getViewElementOffset(view: GraphDataView): number {
   return (view.byteOffset % STORAGE_BINDING_ALIGNMENT) / UINT32_BYTE_LENGTH;
 }
 
+/** Returns whether two logical views touch any of the same bytes. @internal */
+export function doGraphDataViewsOverlap(first: GraphDataView, second: GraphDataView): boolean {
+  if (first.buffer !== second.buffer || first.length === 0 || second.length === 0) {
+    return false;
+  }
+  const firstEnd = first.byteOffset + (first.length - 1) * first.byteStride + first.rowByteLength;
+  const secondEnd =
+    second.byteOffset + (second.length - 1) * second.byteStride + second.rowByteLength;
+  return first.byteOffset < secondEnd && second.byteOffset < firstEnd;
+}
+
 /** Creates a packed graph-owned transient buffer and a typed view spanning it. @internal */
 export function createTransientView<T extends GPUVectorFormat, Parameters>(
   graph: GPUCommandGraph<Parameters>,

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -127,6 +127,9 @@ export type {
 export {GPUBVH} from './gpu-bvh';
 export type {GPUBVHBoundsView, GPUBVHProps, GPUBVHStorageStats} from './gpu-bvh';
 
+export {GPUBVHQuery} from './gpu-bvh-query';
+export type {GPUBVHQueryKind, GPUBVHQueryProps, GPUBVHView} from './gpu-bvh-query';
+
 export {GPUGridAggregation} from './gpu-grid-aggregation';
 export type {
   GPUGridAggregationOperation,

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -130,6 +130,22 @@ export type {GPUBVHBoundsView, GPUBVHProps, GPUBVHStorageStats} from './gpu-bvh'
 export {GPUBVHQuery} from './gpu-bvh-query';
 export type {GPUBVHQueryKind, GPUBVHQueryProps, GPUBVHView} from './gpu-bvh-query';
 
+export {
+  runGPUSpatialQueryBenchmark,
+  summarizeGPUSpatialBenchmarkSamples
+} from './gpu-spatial-query-benchmark';
+export type {
+  GPUSpatialBenchmarkAmortizedCost,
+  GPUSpatialBenchmarkDistribution,
+  GPUSpatialBenchmarkPath,
+  GPUSpatialBenchmarkPathReport,
+  GPUSpatialBenchmarkPhase,
+  GPUSpatialBenchmarkResult,
+  GPUSpatialBenchmarkStrategy,
+  GPUSpatialQueryBenchmarkProps,
+  GPUSpatialQueryBenchmarkReport
+} from './gpu-spatial-query-benchmark';
+
 export {GPUGridAggregation} from './gpu-grid-aggregation';
 export type {
   GPUGridAggregationOperation,

--- a/modules/experimental/test/gpu-primitives/gpu-bvh-query.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-bvh-query.spec.ts
@@ -1,0 +1,241 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {Buffer, type Device} from '@luma.gl/core';
+import {
+  GPUBVH,
+  GPUBVHQuery,
+  GPUCommandGraph,
+  type CompiledGPUCommandGraph,
+  type GraphDataView
+} from '@luma.gl/experimental';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+test('GPUBVHQuery traverses 2D bounds and clears reusable result masks', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const fixture = createFixture(device, {
+    dimension: 2,
+    minima: Float32Array.from([0, 0, 2, 0, 10, 10, 12, 10]),
+    maxima: Float32Array.from([1, 1, 3, 1, 11, 11, 13, 11]),
+    query: Float32Array.from([-0.5, -0.5, 3.5, 1.5]),
+    kind: 'bounds',
+    leafCapacity: 4,
+    outputCapacity: 4,
+    maskLength: 4
+  });
+  encode(device, fixture.compiled);
+
+  t.deepEqual(await readSortedOutput(fixture), [0, 1], 'bounds query matches the CPU oracle');
+  t.deepEqual(await readUint32(fixture.outputMask, 4), [1, 1, 0, 0]);
+  t.deepEqual(await readUint32(fixture.overflow, 1), [0]);
+  t.deepEqual(await readUint32(fixture.visitedCount, 1), [5], 'the disjoint subtree is pruned');
+
+  fixture.query.write(Float32Array.from([11.5, 9.5, 13.5, 11.5]));
+  encode(device, fixture.compiled);
+  t.deepEqual(await readSortedOutput(fixture), [3], 'the same graph accepts a new query');
+  t.deepEqual(await readUint32(fixture.outputMask, 4), [0, 0, 0, 1], 'old mask bits clear');
+
+  destroyFixture(fixture);
+  t.end();
+});
+
+test('GPUBVHQuery traverses 3D points and reports bounded-output overflow', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const fixture = createFixture(device, {
+    dimension: 3,
+    minima: Float32Array.from([0, 0, 0, 1, 1, 1, -2, -2, -2, 10, 10, 10, 100, 100, 100]),
+    maxima: Float32Array.from([2, 2, 2, 3, 3, 3, -1, -1, -1, 11, 11, 11, 101, 101, 101]),
+    query: Float32Array.from([1.5, 1.5, 1.5]),
+    kind: 'point',
+    leafCapacity: 4,
+    outputCapacity: 1,
+    maskLength: 4
+  });
+  encode(device, fixture.compiled);
+
+  t.deepEqual(await readUint32(fixture.count, 1), [2], 'count is the complete CPU-oracle result');
+  t.deepEqual(
+    await readUint32(fixture.overflow, 1),
+    [1],
+    'source or output truncation is explicit'
+  );
+  const storedOutput = await readUint32(fixture.output, 1);
+  t.ok(storedOutput[0] === 0 || storedOutput[0] === 1, 'one matching stable ID is stored');
+  const outputMask = await readUint32(fixture.outputMask, 4);
+  t.equal(
+    outputMask.reduce((sum, value) => sum + value, 0),
+    1,
+    'mask describes stored output'
+  );
+  t.equal(outputMask[storedOutput[0]], 1);
+
+  fixture.query.write(Float32Array.from([Number.NaN, 0, 0]));
+  encode(device, fixture.compiled);
+  t.deepEqual(await readUint32(fixture.count, 1), [0], 'non-finite queries match nothing');
+  t.deepEqual(await readUint32(fixture.overflow, 1), [1], 'source BVH overflow is propagated');
+  t.deepEqual(await readUint32(fixture.outputMask, 4), [0, 0, 0, 0]);
+
+  destroyFixture(fixture);
+  t.end();
+});
+
+type Fixture = {
+  compiled: CompiledGPUCommandGraph<void>;
+  query: Buffer;
+  output: Buffer;
+  count: Buffer;
+  overflow: Buffer;
+  outputMask: Buffer;
+  visitedCount: Buffer;
+  buffers: Buffer[];
+};
+
+function createFixture(
+  device: Device,
+  props: {
+    dimension: 2 | 3;
+    minima: Float32Array;
+    maxima: Float32Array;
+    query: Float32Array;
+    kind: 'point' | 'bounds';
+    leafCapacity: number;
+    outputCapacity: number;
+    maskLength: number;
+  }
+): Fixture {
+  const format = props.dimension === 2 ? 'float32x2' : 'float32x3';
+  const sourceLength = props.minima.length / props.dimension;
+  const nodeCount = props.leafCapacity * 2 - 1;
+  const minima = createInputBuffer(device, props.minima);
+  const maxima = createInputBuffer(device, props.maxima);
+  const query = createInputBuffer(device, props.query);
+  const nodeMinima = createFloatOutputBuffer(device, nodeCount * props.dimension);
+  const nodeMaxima = createFloatOutputBuffer(device, nodeCount * props.dimension);
+  const children = createUintOutputBuffer(device, nodeCount * 2);
+  const leafIds = createUintOutputBuffer(device, props.leafCapacity);
+  const bvhCount = createUintOutputBuffer(device, 1);
+  const bvhOverflow = createUintOutputBuffer(device, 1);
+  const output = createUintOutputBuffer(device, props.outputCapacity);
+  const count = createUintOutputBuffer(device, 1);
+  const overflow = createUintOutputBuffer(device, 1);
+  const outputMask = createUintOutputBuffer(device, props.maskLength);
+  const visitedCount = createUintOutputBuffer(device, 1);
+  const graph = new GPUCommandGraph(device, {id: 'bvh-query-test'});
+  const bvh = new GPUBVH({
+    id: 'test-bvh',
+    minima: importView(graph, 'source-minima', minima, format, sourceLength),
+    maxima: importView(graph, 'source-maxima', maxima, format, sourceLength),
+    leafCapacity: props.leafCapacity,
+    nodeMinima: importView(graph, 'node-minima', nodeMinima, format, nodeCount),
+    nodeMaxima: importView(graph, 'node-maxima', nodeMaxima, format, nodeCount),
+    nodeChildren: importView(graph, 'node-children', children, 'uint32x2', nodeCount),
+    leafIds: importView(graph, 'leaf-ids', leafIds, 'uint32', props.leafCapacity),
+    count: importView(graph, 'bvh-count', bvhCount, 'uint32', 1),
+    overflow: importView(graph, 'bvh-overflow', bvhOverflow, 'uint32', 1)
+  });
+  bvh.addToGraph(graph);
+  const bvhQuery = new GPUBVHQuery({
+    id: 'test-bvh-query',
+    bvh,
+    kind: props.kind,
+    query: importView(graph, 'query', query, 'float32', props.query.length),
+    output: importView(graph, 'output', output, 'uint32', props.outputCapacity),
+    count: importView(graph, 'query-count', count, 'uint32', 1),
+    overflow: importView(graph, 'query-overflow', overflow, 'uint32', 1),
+    outputMask: importView(graph, 'output-mask', outputMask, 'uint32', props.maskLength),
+    visitedCount: importView(graph, 'visited-count', visitedCount, 'uint32', 1)
+  });
+  bvhQuery.addToGraph(graph);
+  return {
+    compiled: graph.compile(),
+    query,
+    output,
+    count,
+    overflow,
+    outputMask,
+    visitedCount,
+    buffers: [
+      minima,
+      maxima,
+      query,
+      nodeMinima,
+      nodeMaxima,
+      children,
+      leafIds,
+      bvhCount,
+      bvhOverflow,
+      output,
+      count,
+      overflow,
+      outputMask,
+      visitedCount
+    ]
+  };
+}
+
+function createInputBuffer(device: Device, data: Float32Array | Uint32Array): Buffer {
+  return device.createBuffer({data, usage: Buffer.STORAGE | Buffer.COPY_DST});
+}
+
+function createFloatOutputBuffer(device: Device, length: number): Buffer {
+  return device.createBuffer({
+    byteLength: Math.max(length, 1) * Float32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+}
+
+function createUintOutputBuffer(device: Device, length: number): Buffer {
+  return device.createBuffer({
+    byteLength: Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+}
+
+function importView<T extends 'float32' | 'float32x2' | 'float32x3' | 'uint32x2' | 'uint32'>(
+  graph: GPUCommandGraph,
+  id: string,
+  buffer: Buffer,
+  format: T,
+  length: number
+): GraphDataView<T> {
+  const handle = graph.importBuffer(
+    {id, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return graph.createDataView(handle, {format, length});
+}
+
+async function readSortedOutput(fixture: Fixture): Promise<number[]> {
+  const [count] = await readUint32(fixture.count, 1);
+  return (await readUint32(fixture.output, count)).sort((left, right) => left - right);
+}
+
+async function readUint32(buffer: Buffer, length: number): Promise<number[]> {
+  const bytes = await buffer.readAsync();
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, length));
+}
+
+function encode(device: Device, compiled: CompiledGPUCommandGraph<void>): void {
+  const commandEncoder = device.createCommandEncoder({id: 'bvh-query-test'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+}
+
+function destroyFixture(fixture: Fixture): void {
+  fixture.compiled.destroy();
+  for (const buffer of fixture.buffers) buffer.destroy();
+}

--- a/modules/experimental/test/gpu-primitives/gpu-bvh.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-bvh.spec.ts
@@ -11,6 +11,16 @@ import {
   type GraphDataView
 } from '@luma.gl/experimental';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {getGPUBVHDispatchLayout} from '../../src/gpu-primitives/gpu-bvh';
+
+test('GPUBVH plans multidimensional leaf-loading dispatches', t => {
+  t.deepEqual(
+    getGPUBVHDispatchLayout(2 ** 24 - 1, 65535),
+    {x: 65535, y: 2, z: 1},
+    'the largest standard-binding 2D tree does not exceed the per-dimension limit'
+  );
+  t.end();
+});
 
 test('GPUBVH builds deterministic 2D topology and bounds', async t => {
   const device = await getWebGPUTestDevice();

--- a/modules/experimental/test/gpu-primitives/gpu-grid-index-query.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-grid-index-query.spec.ts
@@ -167,6 +167,108 @@ test('GPUGridIndexQuery selects 3D point cells', async t => {
   t.end();
 });
 
+test('GPUGridIndexQuery handles extreme domains and exponential WGSL literals', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const pointFixture = createQueryFixture(device, {
+    positions: Float32Array.from([0, 0.5]),
+    format: 'float32x2',
+    gridSize: [2, 1],
+    bounds: [-3e38, 0, 3e38, 1],
+    kind: 'point',
+    query: Float32Array.from([0, 0.5]),
+    outputCapacity: 1
+  });
+  encode(device, pointFixture.compiled);
+  t.deepEqual(
+    await readQueryResult(pointFixture),
+    {ids: [0], count: 1, overflow: 0},
+    'cross-zero normalization agrees with index construction'
+  );
+  destroyFixture(pointFixture);
+
+  const radiusFixture = createQueryFixture(device, {
+    positions: Float32Array.from([-2e38, 0.5, 2e38, 0.5]),
+    format: 'float32x2',
+    gridSize: [2, 1],
+    bounds: [-3e38, 0, 3e38, 1],
+    kind: 'radius',
+    query: Float32Array.from([0, 0.5, 1e20]),
+    outputCapacity: 2
+  });
+  encode(device, radiusFixture.compiled);
+  t.deepEqual(
+    (await readQueryResult(radiusFixture)).ids.sort(sortNumbers),
+    [0, 1],
+    'overflow-safe cell boundaries preserve both cells touching the query radius'
+  );
+  destroyFixture(radiusFixture);
+  t.end();
+});
+
+test('GPUGridIndexQuery rejects overlapping inputs and writable results', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const buffer = device.createBuffer({byteLength: 256, usage: Buffer.STORAGE});
+  const graph = new GPUCommandGraph(device);
+  const handle = graph.importBuffer(
+    {id: 'shared', byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  const view = <T extends 'float32' | 'uint32'>(format: T, length: number, byteOffset: number) =>
+    graph.createDataView(handle, {format, length, byteOffset});
+  const index = {
+    gridSize: [1, 1] as const,
+    bounds: [0, 0, 1, 1] as const,
+    cellOffsets: view('uint32', 2, 0),
+    objectIds: view('uint32', 2, 16),
+    count: view('uint32', 1, 32),
+    overflow: view('uint32', 1, 36)
+  };
+  const query = view('float32', 2, 40);
+  const overflow = view('uint32', 1, 60);
+
+  t.throws(
+    () =>
+      new GPUGridIndexQuery({
+        index,
+        kind: 'point',
+        query,
+        output: view('uint32', 2, 20),
+        count: view('uint32', 1, 56),
+        overflow
+      }),
+    /output and index objectIds must not overlap/,
+    'query writes cannot alias live index reads'
+  );
+  t.throws(
+    () =>
+      new GPUGridIndexQuery({
+        index,
+        kind: 'point',
+        query,
+        output: view('uint32', 2, 64),
+        count: view('uint32', 1, 68),
+        overflow
+      }),
+    /count and output must not overlap/,
+    'writable result views cannot race each other'
+  );
+
+  buffer.destroy();
+  t.end();
+});
+
 type QueryFixture = {
   compiled: ReturnType<GPUCommandGraph['compile']>;
   query: Buffer;

--- a/modules/experimental/test/gpu-primitives/gpu-point-spatial-filter.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-point-spatial-filter.spec.ts
@@ -95,6 +95,39 @@ test('GPUPointSpatialFilter composes 3D bounds candidates with selection visibil
   t.end();
 });
 
+test('GPUPointSpatialFilter compares large radii without squared-distance overflow', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const fixture = createFixture(device, {
+    positions: Float32Array.from([3e20, 0]),
+    dimension: 2,
+    gridSize: [1, 1],
+    bounds: [0, -1, 4e20, 1],
+    kind: 'radius',
+    query: Float32Array.from([0, 0, 2e20])
+  });
+  encode(device, fixture.compiled);
+
+  t.deepEqual(
+    await readVisible(fixture.indexed),
+    [],
+    'indexed refinement rejects the distant point'
+  );
+  t.deepEqual(
+    await readVisible(fixture.unindexed),
+    [],
+    'the exact full scan rejects inf-squared false positives'
+  );
+
+  destroyFixture(fixture);
+  t.end();
+});
+
 type ResultBuffers = {
   ids: Buffer;
   count: Buffer;

--- a/modules/experimental/test/gpu-primitives/gpu-spatial-query-benchmark.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-spatial-query-benchmark.spec.ts
@@ -85,6 +85,39 @@ test('runGPUSpatialQueryBenchmark applies one oracle to scan, grid, and BVH path
   }
   t.match(String(mismatchError), /shared CPU oracle/, 'incorrect paths cannot report timings');
 
+  const resourceCounts = device.statsManager.getStats('Resource Counts');
+  const activeCommandEncodersBeforeFailure = resourceCounts.get('CommandEncoders Active').count;
+  let encodeCount = 0;
+  let encodingError: unknown;
+  try {
+    await runGPUSpatialQueryBenchmark(device, {
+      paths: [
+        {
+          ...paths[0],
+          id: 'failing-path',
+          encode: commandEncoder => {
+            encodeCount++;
+            if (encodeCount === 2) {
+              throw new Error('intentional measured encoding failure');
+            }
+            return paths[0].encode(commandEncoder);
+          }
+        }
+      ],
+      expectedIds: [2, 9],
+      warmupIterations: 1,
+      measuredIterations: 1
+    });
+  } catch (error) {
+    encodingError = error;
+  }
+  t.match(String(encodingError), /intentional measured encoding failure/);
+  t.equal(
+    resourceCounts.get('CommandEncoders Active').count,
+    activeCommandEncodersBeforeFailure,
+    'a failed measured encoding releases its command encoder'
+  );
+
   for (const compiled of compiledGraphs) compiled.destroy();
   t.end();
 });

--- a/modules/experimental/test/gpu-primitives/gpu-spatial-query-benchmark.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-spatial-query-benchmark.spec.ts
@@ -102,7 +102,9 @@ test('runGPUSpatialQueryBenchmark applies one oracle to scan, grid, and BVH path
             }
             return paths[0].encode(commandEncoder);
           }
-        }
+        },
+        paths[1],
+        paths[2]
       ],
       expectedIds: [2, 9],
       warmupIterations: 1,

--- a/modules/experimental/test/gpu-primitives/gpu-spatial-query-benchmark.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-spatial-query-benchmark.spec.ts
@@ -1,0 +1,90 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {
+  GPUCommandGraph,
+  runGPUSpatialQueryBenchmark,
+  summarizeGPUSpatialBenchmarkSamples,
+  type CompiledGPUCommandGraph,
+  type GPUSpatialBenchmarkPath,
+  type GPUSpatialBenchmarkStrategy
+} from '@luma.gl/experimental';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+test('summarizeGPUSpatialBenchmarkSamples reports nearest-rank distributions', t => {
+  t.deepEqual(summarizeGPUSpatialBenchmarkSamples([4, 1, 3, 2]), {
+    minimum: 1,
+    median: 2,
+    percentile95: 4,
+    maximum: 4
+  });
+  t.throws(
+    () => summarizeGPUSpatialBenchmarkSamples([1, Number.NaN]),
+    /finite non-negative/,
+    'invalid samples cannot produce misleading reports'
+  );
+  t.end();
+});
+
+test('runGPUSpatialQueryBenchmark applies one oracle to scan, grid, and BVH paths', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const compiledGraphs: CompiledGPUCommandGraph<void>[] = [];
+  const makePath = (
+    strategy: GPUSpatialBenchmarkStrategy,
+    metrics: {candidateCount?: number; visitedCount?: number}
+  ): GPUSpatialBenchmarkPath => {
+    const graph = new GPUCommandGraph(device, {id: `benchmark-${strategy}`});
+    const compiled = graph.compile();
+    compiledGraphs.push(compiled);
+    return {
+      id: strategy,
+      strategy,
+      memoryByteLength: strategy === 'scan' ? 0 : 1024,
+      encode: commandEncoder => compiled.encode(commandEncoder, {parameters: undefined}),
+      readResult: async () => ({ids: [9, 2], ...metrics}),
+      getNodePhase: () => undefined
+    };
+  };
+  const paths = [
+    makePath('scan', {}),
+    makePath('grid', {candidateCount: 4}),
+    makePath('bvh', {visitedCount: 7})
+  ];
+  const report = await runGPUSpatialQueryBenchmark(device, {
+    paths,
+    expectedIds: [2, 9],
+    warmupIterations: 1,
+    measuredIterations: 2,
+    reuseCounts: [1, 4]
+  });
+
+  t.equal(report.expectedResultCount, 2);
+  t.equal(report.paths.length, 3);
+  t.equal(report.paths[1].candidateCount, 4, 'grid candidate work is retained');
+  t.equal(report.paths[2].visitedCount, 7, 'BVH traversal work is retained');
+  t.deepEqual(report.paths[0].amortizedGPUTime, [], 'GPU costs require timestamped phases');
+  t.ok(report.paths.every(path => path.cpuEncodeTimeMilliseconds.minimum >= 0));
+
+  let mismatchError: unknown;
+  try {
+    await runGPUSpatialQueryBenchmark(device, {
+      paths: [{...paths[0], readResult: async () => ({ids: [2]})}, paths[1], paths[2]],
+      expectedIds: [2, 9],
+      warmupIterations: 1,
+      measuredIterations: 1
+    });
+  } catch (error) {
+    mismatchError = error;
+  }
+  t.match(String(mismatchError), /shared CPU oracle/, 'incorrect paths cannot report timings');
+
+  for (const compiled of compiledGraphs) compiled.destroy();
+  t.end();
+});

--- a/website/src/components/docs/gpu-primitives-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-primitives-docs-tabs.tsx
@@ -117,6 +117,11 @@ const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-bvh'
   },
   {
+    id: 'bvh-query',
+    label: 'BVH Query',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-bvh-query'
+  },
+  {
     id: 'group-aggregation',
     label: 'Group Aggregation',
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-group-aggregation'

--- a/website/src/components/docs/gpu-primitives-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-primitives-docs-tabs.tsx
@@ -122,6 +122,11 @@ const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-bvh-query'
   },
   {
+    id: 'spatial-benchmark',
+    label: 'Spatial Benchmark',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark'
+  },
+  {
     id: 'group-aggregation',
     label: 'Group Aggregation',
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-group-aggregation'


### PR DESCRIPTION
## Overview

Adds exact point-containment and axis-aligned bounds-intersection traversal for the experimental flat GPU BVH.

## Concepts and use cases

- Traverses the complete-binary hierarchy one level at a time and prunes disjoint subtrees without a hidden traversal stack.
- Publishes stable IDs through capacity-bounded output, full match count, overflow, and optional source-ID mask contracts.
- Reports visited-node count so source ordering and future topology builders can be compared by useful traversal work.
- Supports viewport and box selection, object-level visibility, simulation neighborhoods, and picking broad phases while documenting when scan or grid paths are preferable.

## Changes

- Add `GPUBVHQuery` with mutable packed 2D/3D point and bounds queries.
- Add exact CPU-oracle tests for pruning, overlap, mutable queries, invalid input, masks, and overflow propagation.
- Add an Overview/Concepts documentation page, navigation, and roadmap status update.

## Verification

- `nvm use`
- `yarn lint fix`
- `yarn build`
- `yarn test-headless modules/experimental/test/gpu-primitives/gpu-bvh-query.spec.ts`
- Full `yarn test`: node suite passes and the command-graph texture CI regression passes; the run retains an unrelated `modules/arrow-layers/test/layers/arrow-layers.spec.ts` failure in files untouched by this stack.
- `(cd website && yarn build)`

## Stack

Base: #2815
