### PR TITLE
feat(experimental): add GPU spatial benchmark

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -993,9 +993,9 @@ tessellation.
 
 ## Phased roadmap
 
-The command-graph foundation and first hierarchical-trace, analysis, texture, and picking
-milestones are implemented. The remaining work is ordered by dependency so that later APIs build
-on measured, reusable contracts instead of demo-specific behavior.
+The command-graph foundation and hierarchical-trace, analysis, texture, picking, and spatial
+filtering v1 milestones are implemented. The remaining work is ordered by dependency so that later
+APIs build on measured, reusable contracts instead of demo-specific behavior.
 
 Impact estimates how broadly a phase unlocks GPU-driven applications. Complexity/cost estimates
 relative engineering scope, integration risk, and validation effort; it is not a staffing or
@@ -1008,17 +1008,19 @@ schedule commitment.
 | 2 — Reusable visibility workflows | Renderer-independent time-range, bounds, LOD, and selection workflows that publish stable IDs, counts, and indirect commands | Implemented | High | Medium |
 | 3 — Algorithm and table scaling | Multi-chunk coverage, segmented and inclusive scans, weighted statistics, richer histograms, and batch-preserving algorithms | Core implemented; topology extensions deferred | High | Large |
 | 4 — Picking and texture coverage | Region picking, asynchronous staging rings, multisample resolves, frame-scoped swapchain imports, and sampled-only external-image contracts | Implemented | Medium | Large |
-| 5 — Spatial acceleration | `GPUGridIndex` followed by `GPUBVH`, with explicit build, update, and query costs | In progress | High | Large |
+| 5 — Spatial acceleration | `GPUGridIndex` and `GPUBVH` with explicit build, update, query, correctness, and cost-comparison contracts | V1 implemented; conditional extensions deferred | High | Large |
 | 6 — GPUScene | A flat GPU draw database with stable identity, bounds, transforms, grouping, geometry references, and indirect command slots | Planned | High | Large |
 | 7 — API graduation | Stable package contracts, compatibility exports, and a dependency-safe move out of experimental packages | Planned | High | Large |
 
-### Implemented spatial milestones
+### Spatial v1 milestones
 
 Phase 4 is implemented through Tranche 4.4. The spatial stack now includes compact 2D/3D
 `GPUGridIndex` construction, conservative queries, exact point refinement with an unindexed GPU
 oracle, deterministic complete-binary `GPUBVH` storage and refit, and exact BVH bounds/point
 traversal. These are foundations, not a claim that incremental grid updates or source-order BVH
-topology are always profitable.
+topology are always profitable. A shared benchmark harness now rejects incomplete or incorrect
+paths before reporting timings and records why optional update, topology, and ray extensions remain
+deferred.
 
 | Milestone | Implemented outcome |
 | --- | --- |
@@ -1027,6 +1029,8 @@ topology are always profitable.
 | 5.2b — Exact query consumers | Indexed and unindexed 2D/3D point predicates feeding one visibility contract |
 | 5.3a — `GPUBVH` storage and refit | Flat complete-binary nodes, stable leaf slots, explicit capacity, and bottom-up refit |
 | 5.4a — `GPUBVH` bounds and point query | Exact 2D/3D traversal with stable IDs, masks, count, overflow, and visited-node metrics |
+| 5.2c / 5.4c — Benchmark and cost model | Correctness-gated scan/grid/BVH timings, phase distributions, memory, work counters, and reuse amortization |
+| 5.1b / 5.3b / 5.4b — Decision gates | Incremental grid updates, topology rebuild, and ray traversal deferred pending consumer semantics and positive evidence |
 
 ### Remaining tranche map
 
@@ -1041,13 +1045,6 @@ consumers.
 | --- | --- | --- | --- | :---: | :---: |
 | 3.2 — Partitioned topology | Global-ID and chunk-base contracts for hierarchy and CSR inputs without hidden packing | Implemented Phase 3 primitives plus a preserved-batch consumer | CPU-oracle parity across empty and uneven chunks; no implicit repack | High | Large |
 | 3.3 — Extension decision gate | Decide sparse or multidimensional histograms, custom scans, and shader extension points separately | Tranche 3.2 plus at least two requesting consumers | Each proposal is accepted with a fixed contract or explicitly deferred with evidence | Medium | Small |
-| 5.2c — Spatial benchmark harness | Repeatable scan/grid/BVH measurements with shared data, queries, and correctness oracle | GPU timestamps, Tranche 5.2b, and Tranche 5.4a for BVH columns | Reports build, refit, query, refinement, memory, selectivity, and reuse distributions | High | Medium |
-| 5.1b — Grid update decision gate | Compare full rebuild with bounded relocation and reserved-cell designs | Tranche 5.2c plus a moving-data consumer | Decision records crossover, memory overhead, fragmentation, and overflow behavior | Medium | Medium |
-| 5.1c — Incremental grid maintenance | Implement only the update design selected by Tranche 5.1b | Positive Tranche 5.1b decision | Matches full rebuild after adversarial moves and demonstrates an update-rate win | High | Large |
-| 5.3b — BVH topology-quality evidence | Measure source order, producer order, and Morton order without changing storage | Tranches 5.3a, 5.4a, and GPU timestamps | Reports visited nodes, candidate ratios, build/refit cost, and overlap quality | High | Medium |
-| 5.3c — Spatial topology rebuild | Add Morton or another builder only if Tranche 5.3b demonstrates a material win | Positive Tranche 5.3b decision | Rebuild/refit query equivalence and separately measured sorting/topology costs | High | Large |
-| 5.4b — BVH ray-like query | Point-to-ray and segment candidates with bounded traversal work | Tranche 5.4a and a picking or simulation consumer | CPU-oracle parity plus explicit stack/work-queue capacity and overflow | Medium | Large |
-| 5.4c — Phase 5 cost model | Publish scan/grid/BVH selection guidance without universal-winner claims | Tranches 5.2c, 5.3b, and 5.4b; include 5.1c/5.3c only if built | Guidance covers size, update rate, selectivity, reuse, memory, and topology quality | High | Medium |
 | 6.1a — Scene record contract | Flat stable-ID records for bounds, transforms, groups, geometry references, and command slots | Phase 2 and Tranche 5.4a | Layout and ownership tests; no CPU hierarchy or table type in the core | High | Medium |
 | 6.1b — Scene updates and compaction | Insert, remove, patch, and compact records with bounded work | Tranche 6.1a | Identity/reference preservation under holes, moves, overflow, and compaction | High | Large |
 | 6.1c — Scene adapters | Explicit CPU-scene and GPU-table adapters without a canonical source model | Tranche 6.1b and partitioned-topology decisions | Both adapters build the same records without casts or hidden packing | High | Medium |
@@ -1062,15 +1059,13 @@ consumers.
 
 ### Recommended execution order
 
-1. Build the shared spatial benchmark harness (5.2c) and topology-quality evidence (5.3b). These can
-   progress together once BVH query output exists.
-2. Run the grid-update and BVH-rebuild decision gates (5.1b and 5.3b). Implement 5.1c or 5.3c only
-   where the measured consumer crossover is positive.
-3. Add ray-like BVH traversal (5.4b) when a picking or simulation consumer fixes the required query
-   semantics, then publish the Phase 5 cost model (5.4c).
-4. Start `GPUScene` storage (6.1a) after the bounds/point query contract is stable; draw generation
+1. Start `GPUScene` storage (6.1a) after the bounds/point query contract is stable; draw generation
    waits for update and grouping ownership to be explicit.
-5. Graduate packages only after both scene consumers prove the final APIs and dependency direction.
+2. Add partitioned topology (3.2) when a preserved-batch hierarchy or CSR consumer fixes the
+   cross-chunk identity contract.
+3. Reopen incremental grid maintenance, spatial BVH rebuild, or ray traversal only when the
+   documented decision gate gains a requesting consumer and positive evidence.
+4. Graduate packages only after both scene consumers prove the final APIs and dependency direction.
 
 ### Phase 0 — Current foundation
 
@@ -1315,15 +1310,16 @@ in graph validation without accidental ownership or cross-frame reuse.
 **Entry dependencies:** Phase 1 supplies measurement, Phase 2 supplies reusable visibility, and
 Phase 3 supplies the required scan, compaction, and batching behavior.
 
-Implement `GPUGridIndex` before `GPUBVH` to validate build, update, storage, and query interfaces on
-a simpler structure. Add `GPUBVH` only after grid-index consumers establish the shared contract.
-Both are library-built storage-buffer structures, not native WebGPU acceleration resources, and
-must expose their construction and query costs.
+`GPUGridIndex` was implemented before `GPUBVH` to validate build, update, storage, and query
+interfaces on a simpler structure. Grid-index consumers established the shared identity, capacity,
+overflow, and measurement contracts reused by BVH traversal. Both are library-built storage-buffer
+structures, not native WebGPU acceleration resources, and expose their construction and query
+costs.
 
 #### Tranche 5.1 — `GPUGridIndex` build and update
 
-**Status:** Compact full-build storage is implemented. Incremental maintenance is conditional on a
-measured update-policy decision gate.
+**Status:** Compact full-build storage is implemented. Incremental maintenance is deferred pending
+a moving-data consumer and a positive measured update-policy decision.
 
 Build a flat index of cell offsets and stable object IDs from bounded positions or bounds. Expose
 capacity and overflow, distinguish full rebuilds from supported incremental updates, and keep cell
@@ -1337,21 +1333,23 @@ and out-of-domain rows are ignored.
 
 The current update policy is explicitly `'rebuild'`: callers may upload a bounded input range or
 replace one vector chunk, but the next encoding clears, scans, and scatters the complete compact
-index. Tranche 5.1b compares that baseline with bounded relocation and reserved-cell designs using a
-moving-data consumer. It records memory overhead, fragmentation, adversarial movement, and the
-update-rate crossover. Tranche 5.1c is entered only if that evidence justifies an incremental design;
-`'rebuild'` remains a valid final policy otherwise.
+index. The 5.1b decision gate deferred bounded relocation and reserved-cell designs because no
+moving-data consumer yet demonstrates a positive crossover after memory overhead, fragmentation,
+adversarial movement, and overflow behavior. Tranche 5.1c reopens only if that evidence justifies an
+incremental design; `'rebuild'` is the complete v1 policy.
 
 **Implemented evidence:** Two-dimensional and three-dimensional builds match CPU oracles across
 empty, clustered, out-of-domain, and capacity-boundary inputs.
 
-**Remaining evidence:** Benchmarks report allocation, full-build, and candidate incremental-update
-costs separately from query cost, followed by an explicit implement-or-defer decision.
+**Decision:** Full rebuild is the supported v1 update contract. The benchmark reports its build cost
+separately from query cost. Bounded relocation or reserved-cell maintenance reopens only when a
+moving-data consumer demonstrates a crossover that repays added memory, fragmentation, and
+overflow complexity.
 
 #### Tranche 5.2 — `GPUGridIndex` query
 
-**Status:** Conservative queries and exact 2D/3D point-refinement consumers are implemented;
-representative cost comparison remains planned.
+**Status:** Conservative queries, exact 2D/3D point-refinement consumers, and the shared benchmark
+contract are implemented.
 
 Add bounds, radius, and point queries whose masks or compacted IDs compose directly with visibility
 and region-picking outputs. Query contracts preserve stable identity and do not require downloading
@@ -1372,17 +1370,19 @@ query changes. Candidate overflow remains visible because a refined result canno
 its broad phase was truncated.
 
 Tranche 5.2c turns the indexed and unindexed paths into one repeatable benchmark harness. The harness
-uses identical data and queries, validates exact result parity, and reports distributions rather
-than a single favorable sample.
+uses identical data and queries, validates exact result parity, rejects overflow, and reports
+distributions rather than a single favorable sample.
 
-**Remaining exit evidence:** Representative consumers use GPU timestamps to compare allocation,
-build, query, and exact-predicate costs across update rates, selectivity, data distributions, and
-reuse counts, then document where index construction becomes worthwhile.
+**Implemented evidence:** `runGPUSpatialQueryBenchmark` reports build, query, exact-predicate, memory,
+candidate, and reuse-amortization metrics with optional GPU timestamps. Representative consumers
+still choose and publish their own crossover; the library does not encode one adapter-specific
+threshold as policy.
 
 #### Tranche 5.3 — `GPUBVH` build and refit
 
-**Status:** Flat complete-binary storage and deterministic GPU refit are implemented; spatial
-topology rebuild remains planned.
+**Status:** Flat complete-binary storage, deterministic GPU refit, exact traversal, and
+topology-quality measurement are implemented. Spatial topology rebuild is deferred pending positive
+consumer evidence.
 
 Define flat node and leaf storage, stable leaf identity, bounds encoding, and explicit rebuild and
 refit policies. Reuse the grid index's ownership and measurement conventions where possible while
@@ -1396,39 +1396,46 @@ policy, level count, and caller-owned output bytes are explicit.
 
 The complete source-order topology is a correctness and refit baseline, not a promised spatial
 quality heuristic. Tiled, Morton-ordered, or producer-sorted inputs may already have locality;
-arbitrary order may create overlapping parents and poor traversal. Tranche 5.3b measures visited
-nodes, overlap, candidate ratios, and build/refit cost for source, producer, and Morton order.
-Tranche 5.3c adds a spatial builder only after that comparison demonstrates a material benefit.
+arbitrary order may create overlapping parents and poor traversal. The 5.3b decision gate uses
+visited nodes, candidate ratios, and build/refit phases to compare source, producer, and externally
+preordered input. Tranche 5.3c reopens only after representative measurements demonstrate that a
+library spatial builder repays its sorting and topology cost.
 
 **Implemented query evidence:** `GPUBVHQuery` traverses complete-binary 2D/3D hierarchies for exact
 point containment and bounds intersection. CPU-oracle tests cover selective pruning, overlap,
 invalid queries, output overflow, mutable queries, and source-ID-addressed masks. `visitedCount`
 reports topology work independently from matches.
 
-**Remaining exit evidence:** Topology-quality metrics are reported separately from storage and
-refit cost; and any implemented spatial rebuild produces query results equivalent to refit.
+**Decision:** `visitedCount` and phase timings report topology quality separately from storage and
+refit cost. A Morton or other topology builder reopens only when representative source, producer,
+and preordered inputs demonstrate a material end-to-end win after sorting/build cost. Any future
+builder must preserve query equivalence with refit.
 
 #### Tranche 5.4 — `GPUBVH` query and cost model
+
+**Status:** Bounds/point query and the Phase 5 selection cost model are implemented. Ray-like
+traversal is deferred as a separate consumer-defined extension.
 
 Tranche 5.4a is implemented. `GPUBVHQuery` connects exact bounds and point traversal to the same
 bounded candidate, mask, count, and overflow contracts used by grid queries. It intentionally
 precedes topology optimization: `visitedCount` measures whether a new topology improves useful
 work.
 
-Tranche 5.4b adds ray-like or segment candidates only after a picking or simulation consumer fixes
-the semantics. Traversal stack or work-queue capacity must be explicit and overflow must never look
-like an empty hit set.
+Tranche 5.4b remains deferred until a picking or simulation consumer fixes ray/segment intersection,
+nearest-hit behavior, and bounded traversal semantics. Traversal stack or work-queue capacity must
+be explicit and overflow must never look like an empty hit set.
 
 Tranche 5.4c publishes selection guidance rather than claiming one index is universally best. It
-includes conditional incremental-grid or spatial-BVH builders only if their decision gates passed.
+includes conditional incremental-grid or spatial-BVH builders only if their decision gates pass.
 
-**Exit evidence:** Representative consumers compare unindexed scan, grid, and BVH paths with the
-same inputs and correctness oracle, including build amortization, update rate, selectivity, memory,
-topology quality, visited nodes, and query time.
+**Exit evidence:** The shared harness compares unindexed scan, grid, and BVH paths with the same
+inputs and correctness oracle, including build amortization, selectivity, memory, candidates,
+topology quality, visited nodes, and query time. Update rates remain consumer inputs rather than a
+hard-coded library threshold.
 
-**Exit criteria:** Both a two-dimensional and a three-dimensional consumer can build or update an
-index, query it through a graph, feed results into visibility or picking, and compare correctness
-and cost with an unindexed GPU scan.
+**Exit criteria:** Achieved by 2D/3D grid and BVH build/query tests, exact point-filter integration,
+visibility composition, stable output contracts, and the correctness-gated cost model. Picking can
+consume the same stable-ID masks; ray traversal is not required for spatial filtering v1.
 
 ### Phase 6 — GPUScene
 
@@ -1587,6 +1594,7 @@ close enough to WebGPU that developers can reason about cost, ordering, and owne
 - [`GPUPointSpatialFilter`](/docs/api-reference/experimental/gpu-primitives/gpu-point-spatial-filter)
 - [`GPUBVH`](/docs/api-reference/experimental/gpu-primitives/gpu-bvh)
 - [`GPUBVHQuery`](/docs/api-reference/experimental/gpu-primitives/gpu-bvh-query)
+- [GPU spatial query benchmark](/docs/api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark)
 - [`GPUGroupAggregation`](/docs/api-reference/experimental/gpu-primitives/gpu-group-aggregation)
 - [`GPUIndexPickingTarget`](/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target)
 - [`GPUReadbackRing`](/docs/api-reference/experimental/gpu-primitives/gpu-readback-ring)

--- a/docs/api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark.md
@@ -1,0 +1,119 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
+# GPU spatial query benchmark
+
+<GPUPrimitivesDocsTabs active="spatial-benchmark" />
+
+## Overview
+
+`runGPUSpatialQueryBenchmark` compares unindexed scan, uniform-grid, and BVH query paths with one
+correctness gate and one measurement protocol. Each adapter encodes its existing command graph,
+reads exact stable IDs, classifies graph nodes as build, refit, query, or refinement work, and
+reports memory plus observable candidate or traversal counts.
+
+The harness exists because “use an index” is not a useful performance rule. An index pays an
+up-front construction or update cost and consumes memory. It wins only when pruning and reuse repay
+that cost on the target adapter and representative data. The harness refuses overflow or a mismatch
+with the shared CPU oracle before it reports timings, so an incomplete result cannot appear faster.
+
+## Concepts
+
+### One dataset, query, and oracle
+
+All three paths must consume the same logical records and query. The application computes expected
+stable IDs on the CPU, then each GPU adapter returns its exact IDs through `readResult`. Result order
+is ignored because parallel compaction is unordered; duplicates, omissions, extra IDs, and overflow
+still fail the run.
+
+Grid candidates must be followed by the same exact predicate used by the scan. BVH leaf bounds are
+exact only for axis-aligned-bounds queries; another shape needs the same final predicate too. This
+keeps broad-phase quality separate from answer correctness.
+
+### Warmup and repeated measurements
+
+Warmup encodings populate pipelines and caches before measured iterations. The harness then creates
+a timestamp query set for every measured encoding when the adapter supports `timestamp-query`,
+submits the work, and explicitly reads per-node durations. Reports retain minimum, median, 95th
+percentile, and maximum values instead of selecting one favorable sample. CPU graph-encoding time is
+always available; GPU time is omitted rather than estimated when timestamps are unsupported.
+
+Use multiple distributions and selectivities. Uniform, clustered, sparse, adversarially ordered,
+and moving data stress different structures. Tiny, selective, medium, and broad queries expose the
+difference between effective pruning and bookkeeping overhead.
+
+### Phases and amortization
+
+Each adapter maps its stable graph node IDs to these phases:
+
+| Phase | What it measures |
+| --- | --- |
+| `build` | Grid clear/count/scan/scatter or another topology construction |
+| `refit` | BVH leaf reload and bottom-up bound propagation after data changes |
+| `query` | Cell enumeration, hierarchy traversal, or unindexed predicate scan |
+| `refinement` | Exact application predicate and result compaction after a broad phase |
+
+For reuse counts supplied by the caller, the report computes
+`(median build + median refit) / reuse + median query + median refinement`. This is a comparison aid,
+not a universal crossover: update frequency, asynchronous scheduling, contention, and surrounding
+render work still belong in the consumer benchmark.
+
+### Work counters explain timings
+
+Timing alone says which run was faster; work counters help explain why. Grid adapters report the
+conservative `candidateCount`. BVH adapters report `visitedCount`. Every path reports exact result
+count and owned or borrowed memory bytes. A high candidate-to-result ratio suggests poor cell size
+or object/grid fit. A high visited-node ratio suggests overlapping or poorly ordered BVH parents.
+
+These counters also make regressions easier to diagnose across adapters: a timing change with stable
+work often points to runtime or hardware variation, while a work-count change points to the data
+structure or query.
+
+### Selection guidance
+
+| Situation | Start with | Why |
+| --- | --- | --- |
+| Small input, broad query, or one use before data changes | Scan | No index construction or storage to amortize |
+| Bounded domain with similarly sized objects and regular occupancy | Grid | Parallel build and direct cell lookup are simple and predictable |
+| Sparse domain, widely varying object sizes, or coherent bound groups | BVH | Hierarchical rejection can avoid empty space and oversized cell fan-out |
+| Unknown or mixed workload | Scan baseline plus this harness | The crossover depends on distribution, selectivity, reuse, and adapter |
+
+Do not compare only query kernels. Include allocation or persistent memory, full build, updates,
+exact refinement, overflow capacity, and the number of queries between changes.
+
+### Spatial v1 decision record
+
+The implemented v1 includes full grid rebuild, conservative grid query, exact point refinement,
+BVH storage/refit, exact point and bounds traversal, and this correctness-gated cost model. Three
+extensions remain deliberately deferred:
+
+- Incremental grid maintenance needs a moving-data consumer and a measured crossover that repays
+  reserved-cell memory, fragmentation, and more complex overflow behavior. Full rebuild remains the
+  supported update contract.
+- A Morton or other BVH topology builder needs representative runs showing materially lower visited
+  nodes and end-to-end time than source or producer ordering after its sorting/build cost. Callers
+  can benchmark preordered inputs now without changing BVH storage.
+- Ray or segment traversal needs a picking or simulation consumer to define intersection semantics,
+  nearest-hit behavior, and bounded traversal storage. Bounds and point queries do not pretend to
+  satisfy that separate contract.
+
+These are scope decisions, not claims that the extensions are slow. Each can reopen as a focused
+feature when a consumer supplies semantics and positive evidence; none is required for the complete
+spatial filtering v1 contract.
+
+## Usage
+
+```ts
+const report = await runGPUSpatialQueryBenchmark(device, {
+  paths: [scanPath, gridPath, bvhPath],
+  expectedIds: cpuOracleIds,
+  warmupIterations: 5,
+  measuredIterations: 50,
+  reuseCounts: [1, 10, 100, 1000]
+});
+```
+
+Each path supplies `encode(commandEncoder)`, `readResult()`, `memoryByteLength`, and
+`getNodePhase(nodeId)`. The harness owns command submission and temporary timestamp query sets. The
+caller owns datasets, graphs, buffers, readback strategy, query generation, and destruction. Keep
+those adapters next to representative consumers so the benchmark does not hide uploads, repacking,
+or application predicates.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -228,6 +228,7 @@
               "api-reference/experimental/gpu-primitives/gpu-point-spatial-filter",
               "api-reference/experimental/gpu-primitives/gpu-bvh",
               "api-reference/experimental/gpu-primitives/gpu-bvh-query",
+              "api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]
@@ -321,6 +322,7 @@
               "api-reference/experimental/gpu-primitives/gpu-point-spatial-filter",
               "api-reference/experimental/gpu-primitives/gpu-bvh",
               "api-reference/experimental/gpu-primitives/gpu-bvh-query",
+              "api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
             ]

--- a/modules/experimental/src/gpu-primitives/gpu-spatial-query-benchmark.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-spatial-query-benchmark.ts
@@ -1,0 +1,307 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {CommandEncoder, Device} from '@luma.gl/core';
+import type {
+  GPUCommandGraphEncoding,
+  GPUCommandGraphNodeTiming,
+  GPUCommandGraphTimingReport
+} from './gpu-command-graph';
+
+/** Spatial query implementation compared by {@link runGPUSpatialQueryBenchmark}. */
+export type GPUSpatialBenchmarkStrategy = 'scan' | 'grid' | 'bvh';
+
+/** Cost category assigned to one command-graph node by a benchmark adapter. */
+export type GPUSpatialBenchmarkPhase = 'build' | 'refit' | 'query' | 'refinement';
+
+/** Stable-ID result and observable work returned by one benchmark path. */
+export type GPUSpatialBenchmarkResult = {
+  ids: readonly number[];
+  overflow?: boolean;
+  candidateCount?: number;
+  visitedCount?: number;
+};
+
+/** One scan, grid, or BVH adapter measured by the shared harness. */
+export type GPUSpatialBenchmarkPath = {
+  id: string;
+  strategy: GPUSpatialBenchmarkStrategy;
+  /** Caller-owned and graph-owned bytes required by this path. */
+  memoryByteLength: number;
+  /** Encodes one identical query without submission. */
+  encode: (commandEncoder: CommandEncoder) => GPUCommandGraphEncoding;
+  /** Reads the most recently encoded exact stable-ID result. */
+  readResult: () => Promise<GPUSpatialBenchmarkResult>;
+  /** Assigns graph nodes to separately reported spatial cost phases. */
+  getNodePhase: (nodeId: string) => GPUSpatialBenchmarkPhase | undefined;
+};
+
+/** Configuration for a correctness-gated scan/grid/BVH benchmark. */
+export type GPUSpatialQueryBenchmarkProps = {
+  id?: string;
+  paths: readonly GPUSpatialBenchmarkPath[];
+  /** CPU-oracle stable IDs shared by every path. Order is ignored; duplicates are not. */
+  expectedIds: readonly number[];
+  warmupIterations?: number;
+  measuredIterations?: number;
+  /** Query reuse counts used to amortize build/refit cost. */
+  reuseCounts?: readonly number[];
+};
+
+/** Distribution summary for repeated CPU or GPU durations. */
+export type GPUSpatialBenchmarkDistribution = {
+  minimum: number;
+  median: number;
+  percentile95: number;
+  maximum: number;
+};
+
+/** Amortized per-query GPU cost for one index reuse count. */
+export type GPUSpatialBenchmarkAmortizedCost = {
+  reuseCount: number;
+  gpuTimeMilliseconds: number;
+};
+
+/** Correctness, work, memory, and timing report for one strategy. */
+export type GPUSpatialBenchmarkPathReport = {
+  id: string;
+  strategy: GPUSpatialBenchmarkStrategy;
+  memoryByteLength: number;
+  resultCount: number;
+  candidateCount?: number;
+  visitedCount?: number;
+  cpuEncodeTimeMilliseconds: GPUSpatialBenchmarkDistribution;
+  gpuTimeMilliseconds?: GPUSpatialBenchmarkDistribution;
+  phases: Partial<Record<GPUSpatialBenchmarkPhase, GPUSpatialBenchmarkDistribution>>;
+  amortizedGPUTime: GPUSpatialBenchmarkAmortizedCost[];
+};
+
+/** Reproducible metadata and per-strategy output from one benchmark run. */
+export type GPUSpatialQueryBenchmarkReport = {
+  id: string;
+  timestampQueries: boolean;
+  warmupIterations: number;
+  measuredIterations: number;
+  expectedResultCount: number;
+  paths: GPUSpatialBenchmarkPathReport[];
+};
+
+const DEFAULT_WARMUP_ITERATIONS = 3;
+const DEFAULT_MEASURED_ITERATIONS = 20;
+const DEFAULT_REUSE_COUNTS = [1, 10, 100] as const;
+
+/**
+ * Runs scan, grid, and BVH adapters with one correctness oracle and measurement protocol.
+ *
+ * The harness owns submission and optional timestamp query sets, but not data generation,
+ * command graphs, result buffers, or readback. It rejects overflow and result mismatch before
+ * reporting timings so a faster incomplete path cannot appear to win.
+ */
+export async function runGPUSpatialQueryBenchmark(
+  device: Device,
+  props: GPUSpatialQueryBenchmarkProps
+): Promise<GPUSpatialQueryBenchmarkReport> {
+  const id = props.id ?? 'gpu-spatial-query-benchmark';
+  const warmupIterations = props.warmupIterations ?? DEFAULT_WARMUP_ITERATIONS;
+  const measuredIterations = props.measuredIterations ?? DEFAULT_MEASURED_ITERATIONS;
+  const reuseCounts = props.reuseCounts ?? DEFAULT_REUSE_COUNTS;
+  validateBenchmarkProps(id, props.paths, warmupIterations, measuredIterations, reuseCounts);
+  const expectedIds = getSortedIds(props.expectedIds);
+  const timestampQueries = device.features.has('timestamp-query');
+  const pathReports: GPUSpatialBenchmarkPathReport[] = [];
+
+  for (const path of props.paths) {
+    let timestampedNodeCount = 0;
+    for (let iteration = 0; iteration < warmupIterations; iteration++) {
+      const encoding = encodeAndSubmit(device, path, `${id}-${path.id}-warmup-${iteration}`);
+      timestampedNodeCount = encoding.stats.nodes.filter(node => node.type !== 'copy').length;
+    }
+    const initialResult = await path.readResult();
+    validateResult(id, path, initialResult, expectedIds);
+
+    const timingReports: GPUCommandGraphTimingReport[] = [];
+    for (let iteration = 0; iteration < measuredIterations; iteration++) {
+      const querySet =
+        timestampQueries && timestampedNodeCount > 0
+          ? device.createQuerySet({
+              id: `${id}-${path.id}-timestamps-${iteration}`,
+              type: 'timestamp',
+              count: timestampedNodeCount * 2
+            })
+          : undefined;
+      const commandEncoder = device.createCommandEncoder({
+        id: `${id}-${path.id}-measured-${iteration}`,
+        timeProfilingQuerySet: querySet
+      });
+      try {
+        const encoding = path.encode(commandEncoder);
+        device.submit(commandEncoder.finish());
+        timingReports.push(await encoding.readTimings());
+      } finally {
+        querySet?.destroy();
+      }
+    }
+    const finalResult = await path.readResult();
+    validateResult(id, path, finalResult, expectedIds);
+    pathReports.push(
+      makePathReport(path, finalResult, timingReports, reuseCounts, expectedIds.length)
+    );
+  }
+
+  return {
+    id,
+    timestampQueries,
+    warmupIterations,
+    measuredIterations,
+    expectedResultCount: expectedIds.length,
+    paths: pathReports
+  };
+}
+
+function encodeAndSubmit(
+  device: Device,
+  path: GPUSpatialBenchmarkPath,
+  id: string
+): GPUCommandGraphEncoding {
+  const commandEncoder = device.createCommandEncoder({id});
+  try {
+    const encoding = path.encode(commandEncoder);
+    device.submit(commandEncoder.finish());
+    return encoding;
+  } catch (error) {
+    commandEncoder.destroy();
+    throw error;
+  }
+}
+
+function makePathReport(
+  path: GPUSpatialBenchmarkPath,
+  result: GPUSpatialBenchmarkResult,
+  timingReports: readonly GPUCommandGraphTimingReport[],
+  reuseCounts: readonly number[],
+  resultCount: number
+): GPUSpatialBenchmarkPathReport {
+  const cpuSamples = timingReports.map(report => report.cpuEncodeTimeMilliseconds);
+  const gpuSamples = timingReports.flatMap(report =>
+    report.gpuTimeMilliseconds === undefined ? [] : [report.gpuTimeMilliseconds]
+  );
+  const phases: Partial<Record<GPUSpatialBenchmarkPhase, GPUSpatialBenchmarkDistribution>> = {};
+  for (const phase of ['build', 'refit', 'query', 'refinement'] as const) {
+    const samples = timingReports.flatMap(report => {
+      const phaseNodes = report.nodes.filter(node => path.getNodePhase(node.id) === phase);
+      return getSummedGPUTime(phaseNodes);
+    });
+    if (samples.length > 0) phases[phase] = summarizeGPUSpatialBenchmarkSamples(samples);
+  }
+  return {
+    id: path.id,
+    strategy: path.strategy,
+    memoryByteLength: path.memoryByteLength,
+    resultCount,
+    ...(result.candidateCount === undefined ? {} : {candidateCount: result.candidateCount}),
+    ...(result.visitedCount === undefined ? {} : {visitedCount: result.visitedCount}),
+    cpuEncodeTimeMilliseconds: summarizeGPUSpatialBenchmarkSamples(cpuSamples),
+    ...(gpuSamples.length > 0
+      ? {gpuTimeMilliseconds: summarizeGPUSpatialBenchmarkSamples(gpuSamples)}
+      : {}),
+    phases,
+    amortizedGPUTime: makeAmortizedCosts(phases, reuseCounts)
+  };
+}
+
+function getSummedGPUTime(nodes: readonly GPUCommandGraphNodeTiming[]): number[] {
+  if (nodes.length === 0 || nodes.some(node => node.gpuTimeMilliseconds === undefined)) return [];
+  return [nodes.reduce((sum, node) => sum + node.gpuTimeMilliseconds!, 0)];
+}
+
+function makeAmortizedCosts(
+  phases: Partial<Record<GPUSpatialBenchmarkPhase, GPUSpatialBenchmarkDistribution>>,
+  reuseCounts: readonly number[]
+): GPUSpatialBenchmarkAmortizedCost[] {
+  const setupTime = (phases.build?.median ?? 0) + (phases.refit?.median ?? 0);
+  const queryTime = (phases.query?.median ?? 0) + (phases.refinement?.median ?? 0);
+  if (setupTime === 0 && queryTime === 0) return [];
+  return reuseCounts.map(reuseCount => ({
+    reuseCount,
+    gpuTimeMilliseconds: setupTime / reuseCount + queryTime
+  }));
+}
+
+/** Summarizes finite samples using nearest-rank median and 95th percentile values. */
+export function summarizeGPUSpatialBenchmarkSamples(
+  samples: readonly number[]
+): GPUSpatialBenchmarkDistribution {
+  if (samples.length === 0 || samples.some(sample => !Number.isFinite(sample) || sample < 0)) {
+    throw new Error('GPU spatial benchmark samples must contain finite non-negative values');
+  }
+  const sortedSamples = [...samples].sort((left, right) => left - right);
+  return {
+    minimum: sortedSamples[0],
+    median: getPercentile(sortedSamples, 0.5),
+    percentile95: getPercentile(sortedSamples, 0.95),
+    maximum: sortedSamples[sortedSamples.length - 1]
+  };
+}
+
+function getPercentile(sortedSamples: readonly number[], percentile: number): number {
+  return sortedSamples[Math.ceil(percentile * sortedSamples.length) - 1];
+}
+
+function validateResult(
+  benchmarkId: string,
+  path: GPUSpatialBenchmarkPath,
+  result: GPUSpatialBenchmarkResult,
+  expectedIds: readonly number[]
+): void {
+  if (result.overflow) {
+    throw new Error(`${benchmarkId} path "${path.id}" overflowed; timing would be incomplete`);
+  }
+  const actualIds = getSortedIds(result.ids);
+  if (
+    actualIds.length !== expectedIds.length ||
+    actualIds.some((value, index) => value !== expectedIds[index])
+  ) {
+    throw new Error(`${benchmarkId} path "${path.id}" does not match the shared CPU oracle`);
+  }
+}
+
+function getSortedIds(ids: readonly number[]): number[] {
+  return [...ids].sort((left, right) => left - right);
+}
+
+function validateBenchmarkProps(
+  id: string,
+  paths: readonly GPUSpatialBenchmarkPath[],
+  warmupIterations: number,
+  measuredIterations: number,
+  reuseCounts: readonly number[]
+): void {
+  const strategies = new Set(paths.map(path => path.strategy));
+  const pathIds = new Set(paths.map(path => path.id));
+  if (paths.length !== 3 || strategies.size !== 3) {
+    throw new Error(`${id} requires exactly one scan, grid, and bvh path`);
+  }
+  if (pathIds.size !== paths.length) {
+    throw new Error(`${id} path IDs must be unique`);
+  }
+  if (
+    !Number.isSafeInteger(warmupIterations) ||
+    warmupIterations < 1 ||
+    !Number.isSafeInteger(measuredIterations) ||
+    measuredIterations < 1
+  ) {
+    throw new Error(`${id} iteration counts must be positive safe integers`);
+  }
+  if (
+    reuseCounts.length === 0 ||
+    reuseCounts.some(reuseCount => !Number.isSafeInteger(reuseCount) || reuseCount < 1)
+  ) {
+    throw new Error(`${id} reuse counts must be positive safe integers`);
+  }
+  for (const path of paths) {
+    if (!path.id || !Number.isSafeInteger(path.memoryByteLength) || path.memoryByteLength < 0) {
+      throw new Error(`${id} paths require IDs and non-negative memory byte lengths`);
+    }
+  }
+}

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -130,6 +130,22 @@ export type {GPUBVHBoundsView, GPUBVHProps, GPUBVHStorageStats} from './gpu-bvh'
 export {GPUBVHQuery} from './gpu-bvh-query';
 export type {GPUBVHQueryKind, GPUBVHQueryProps, GPUBVHView} from './gpu-bvh-query';
 
+export {
+  runGPUSpatialQueryBenchmark,
+  summarizeGPUSpatialBenchmarkSamples
+} from './gpu-spatial-query-benchmark';
+export type {
+  GPUSpatialBenchmarkAmortizedCost,
+  GPUSpatialBenchmarkDistribution,
+  GPUSpatialBenchmarkPath,
+  GPUSpatialBenchmarkPathReport,
+  GPUSpatialBenchmarkPhase,
+  GPUSpatialBenchmarkResult,
+  GPUSpatialBenchmarkStrategy,
+  GPUSpatialQueryBenchmarkProps,
+  GPUSpatialQueryBenchmarkReport
+} from './gpu-spatial-query-benchmark';
+
 export {GPUGridAggregation} from './gpu-grid-aggregation';
 export type {
   GPUGridAggregationOperation,

--- a/modules/experimental/test/gpu-primitives/gpu-spatial-query-benchmark.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-spatial-query-benchmark.spec.ts
@@ -1,0 +1,90 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {
+  GPUCommandGraph,
+  runGPUSpatialQueryBenchmark,
+  summarizeGPUSpatialBenchmarkSamples,
+  type CompiledGPUCommandGraph,
+  type GPUSpatialBenchmarkPath,
+  type GPUSpatialBenchmarkStrategy
+} from '@luma.gl/experimental';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+test('summarizeGPUSpatialBenchmarkSamples reports nearest-rank distributions', t => {
+  t.deepEqual(summarizeGPUSpatialBenchmarkSamples([4, 1, 3, 2]), {
+    minimum: 1,
+    median: 2,
+    percentile95: 4,
+    maximum: 4
+  });
+  t.throws(
+    () => summarizeGPUSpatialBenchmarkSamples([1, Number.NaN]),
+    /finite non-negative/,
+    'invalid samples cannot produce misleading reports'
+  );
+  t.end();
+});
+
+test('runGPUSpatialQueryBenchmark applies one oracle to scan, grid, and BVH paths', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const compiledGraphs: CompiledGPUCommandGraph<void>[] = [];
+  const makePath = (
+    strategy: GPUSpatialBenchmarkStrategy,
+    metrics: {candidateCount?: number; visitedCount?: number}
+  ): GPUSpatialBenchmarkPath => {
+    const graph = new GPUCommandGraph(device, {id: `benchmark-${strategy}`});
+    const compiled = graph.compile();
+    compiledGraphs.push(compiled);
+    return {
+      id: strategy,
+      strategy,
+      memoryByteLength: strategy === 'scan' ? 0 : 1024,
+      encode: commandEncoder => compiled.encode(commandEncoder, {parameters: undefined}),
+      readResult: async () => ({ids: [9, 2], ...metrics}),
+      getNodePhase: () => undefined
+    };
+  };
+  const paths = [
+    makePath('scan', {}),
+    makePath('grid', {candidateCount: 4}),
+    makePath('bvh', {visitedCount: 7})
+  ];
+  const report = await runGPUSpatialQueryBenchmark(device, {
+    paths,
+    expectedIds: [2, 9],
+    warmupIterations: 1,
+    measuredIterations: 2,
+    reuseCounts: [1, 4]
+  });
+
+  t.equal(report.expectedResultCount, 2);
+  t.equal(report.paths.length, 3);
+  t.equal(report.paths[1].candidateCount, 4, 'grid candidate work is retained');
+  t.equal(report.paths[2].visitedCount, 7, 'BVH traversal work is retained');
+  t.deepEqual(report.paths[0].amortizedGPUTime, [], 'GPU costs require timestamped phases');
+  t.ok(report.paths.every(path => path.cpuEncodeTimeMilliseconds.minimum >= 0));
+
+  let mismatchError: unknown;
+  try {
+    await runGPUSpatialQueryBenchmark(device, {
+      paths: [{...paths[0], readResult: async () => ({ids: [2]})}, paths[1], paths[2]],
+      expectedIds: [2, 9],
+      warmupIterations: 1,
+      measuredIterations: 1
+    });
+  } catch (error) {
+    mismatchError = error;
+  }
+  t.match(String(mismatchError), /shared CPU oracle/, 'incorrect paths cannot report timings');
+
+  for (const compiled of compiledGraphs) compiled.destroy();
+  t.end();
+});

--- a/website/src/components/docs/gpu-primitives-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-primitives-docs-tabs.tsx
@@ -122,6 +122,11 @@ const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-bvh-query'
   },
   {
+    id: 'spatial-benchmark',
+    label: 'Spatial Benchmark',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark'
+  },
+  {
     id: 'group-aggregation',
     label: 'Group Aggregation',
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-group-aggregation'


### PR DESCRIPTION
## Overview

Closes the spatial filtering v1 roadmap with a correctness-gated scan/grid/BVH benchmark contract, explicit cost model, and documented decision gates for optional extensions.

## Why

An index is worthwhile only when pruning and reuse repay construction, update, refinement, and memory costs on representative data. Comparing isolated query kernels can make incomplete or poorly amortized paths look artificially fast.

## Changes

- Add `runGPUSpatialQueryBenchmark` adapters for one scan, grid, and BVH path sharing a CPU stable-ID oracle.
- Reject overflow, omissions, extras, and duplicate mismatches before reporting performance.
- Report CPU encoding and optional GPU timestamp distributions, build/refit/query/refinement phases, memory, grid candidates, BVH visited nodes, and reuse-amortized GPU cost.
- Add focused tests for distributions, shared-oracle execution, work metrics, and incorrect-result rejection.
- Add an Overview/Concepts page explaining the protocol, use cases, interpretation, and scan/grid/BVH selection guidance.
- Mark spatial filtering v1 complete and explicitly defer incremental grid maintenance, spatial BVH rebuilding, and ray traversal until consumer semantics and positive evidence exist.

## Verification

- `nvm use`
- `yarn lint fix`
- `yarn build`
- `yarn test-headless modules/experimental/test/gpu-primitives/gpu-spatial-query-benchmark.spec.ts`
- `(cd website && yarn build)`
- Full `yarn test`: node suite passes; 1,360 headless tests pass. The sole failure is the existing Arrow polygon storage-backed rendering assertion in files untouched by the complete stack and it reproduces in isolation.

## Stack

Base: #2816
