### PR TITLE
Add adaptive density LOD to GPU trace viewer

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -27,6 +27,7 @@ import {
   makeHtmlCustomPanel
 } from '../../example-panels';
 import {
+  getTraceCapacityOptions,
   makeTraceDataset,
   isTraceDensityMode,
   TRACE_COLLAPSED_STATE,
@@ -62,7 +63,6 @@ export const title = 'GPU Hierarchical Trace Viewer';
 export const description =
   'GPU-resident hierarchical traces with live filtering, adaptive density LOD, dependency traversal, picking, and indirect rendering.';
 
-const CAPACITY_OPTIONS = [250_000, 1_000_000, 4_000_000] as const;
 const DEFAULT_CAPACITY = 250_000;
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 const TRACE_WORKGROUP_SIZE = 256;
@@ -98,6 +98,7 @@ type TraceGraphResources = {
   renderBundle: RenderBundle;
   groups: TraceGroupResources[];
   spans: Buffer;
+  spanBatchIndex: Buffer;
   dependencies: Buffer;
   parentSpans: Buffer;
   outgoingOffsets: Buffer;
@@ -121,6 +122,7 @@ type TraceGraphResources = {
   densityBins: Buffer;
   pickResult: Buffer;
   spanCount: number;
+  spanBatchCount: number;
   dependencyCount: number;
 };
 
@@ -141,6 +143,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   readonly densityModel: Model;
   readonly viewUniformBuffer: Buffer;
   readonly panels: ExamplePanelManager;
+  readonly capacityOptions: number[];
 
   private resources: TraceGraphResources | null = null;
   private capacity = DEFAULT_CAPACITY;
@@ -186,6 +189,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       throw new Error('GPU Hierarchical Trace Viewer requires WebGPU');
     }
     this.device = device;
+    this.capacityOptions = getTraceCapacityOptions(
+      device.limits.maxStorageBufferBindingSize,
+      device.limits.maxBufferSize
+    );
     this.viewUniformBuffer = device.createBuffer({
       id: 'gpu-trace-view-uniforms',
       byteLength: VIEW_UNIFORM_BYTE_LENGTH,
@@ -396,6 +403,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       readbackRing,
       groups,
       spans: this.createDataBuffer('gpu-trace-spans', dataset.spans),
+      spanBatchIndex: this.createDataBuffer('gpu-trace-span-batch-index', dataset.spanBatchIndex),
       dependencies: this.createDataBuffer('gpu-trace-dependencies', dataset.dependencies),
       parentSpans: this.createDataBuffer('gpu-trace-parent-spans', dataset.parentSpans),
       outgoingOffsets: this.createDataBuffer('gpu-trace-outgoing-offsets', outgoingOffsets),
@@ -453,6 +461,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         Buffer.COPY_SRC
       ),
       spanCount: dataset.spanCount,
+      spanBatchCount: dataset.spanBatches.length,
       dependencyCount: dataset.dependencyCount
     };
   }
@@ -934,6 +943,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     }
     for (const buffer of [
       resources.spans,
+      resources.spanBatchIndex,
       resources.dependencies,
       resources.parentSpans,
       resources.outgoingOffsets,
@@ -1016,10 +1026,12 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         `<label><input type="checkbox" data-status="${index}" checked> ${name}</label>`
     ).join('');
     return `<div style="display:grid;gap:10px">
-      <label>Capacity <select data-capacity-select>${CAPACITY_OPTIONS.map(
-        value =>
-          `<option value="${value}"${value === this.capacity ? ' selected' : ''}>${formatCount(value)}</option>`
-      ).join('')}</select></label>
+      <label>Capacity <select data-capacity-select>${this.capacityOptions
+        .map(
+          value =>
+            `<option value="${value}"${value === this.capacity ? ' selected' : ''}>${formatCount(value)}</option>`
+        )
+        .join('')}</select></label>
       <fieldset style="display:grid;gap:4px"><legend>Span groups</legend>${groupControls}</fieldset>
       <fieldset style="display:grid;gap:4px"><legend>Status</legend>${statusControls}</fieldset>
       <label>Minimum duration <input type="range" min="0" max="20" step="0.25" value="0" data-duration> <span data-duration-value>0.00 ms</span></label>
@@ -1035,7 +1047,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       </fieldset>
       <label>Source span <input type="number" min="0" value="0" data-source-span style="width:100px"></label>
       <div style="display:flex;gap:6px"><button type="button" data-select-span>Focus span</button><button type="button" data-clear-selection>Clear selection</button></div>
-      <label><input type="checkbox" data-auto-scroll checked> Auto-scroll</label>
+      <label><input type="checkbox" data-auto-scroll${this.autoScroll ? ' checked' : ''}> Auto-scroll</label>
       <button type="button" data-reset>Reset view</button>
       <small>Click a span to pick it on the GPU. Drag to pan; use the wheel to zoom.</small>
     </div>`;
@@ -1216,7 +1228,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       return;
     }
     if (this.capacityElement) {
-      this.capacityElement.innerHTML = `<strong>${formatCount(this.capacity)}</strong> spans · <strong>${formatCount(resources.dependencyCount)}</strong> dependencies · graph compile #${this.compileCount} (${this.compileTimeMilliseconds.toFixed(1)} ms)`;
+      this.capacityElement.innerHTML = `<strong>${formatCount(this.capacity)}</strong> spans · <strong>${formatCount(resources.spanBatchCount)}</strong> batches · <strong>${formatCount(resources.dependencyCount)}</strong> dependencies · graph compile #${this.compileCount} (${this.compileTimeMilliseconds.toFixed(1)} ms)`;
     }
     if (this.selectionElement) {
       this.selectionElement.textContent =
@@ -1237,6 +1249,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         <span>Dropped telemetry samples</span><strong>${formatCount(this.droppedTelemetrySampleCount)}</strong>
         <span>Deferred pick frames</span><strong>${formatCount(this.deferredPickFrameCount)}</strong>
         <span>Adapter</span><strong>${resources.compiled.capabilities.softwareAdapter ? 'software' : 'hardware'}</strong>
+        <span>Maximum storage binding</span><strong>${formatBytes(this.device.limits.maxStorageBufferBindingSize)}</strong>
+        <span>Maximum buffer</span><strong>${formatBytes(this.device.limits.maxBufferSize)}</strong>
         <span>Timestamp queries</span><strong>${resources.compiled.capabilities.timestampQueries ? 'available' : 'unavailable'}</strong>
         <span>Logical resources</span><strong>${formatBytes(stats.logicalResourceBytes)}</strong>
         <span>Owned transients</span><strong>${formatBytes(stats.physicalTransientResourceBytes)}</strong>

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -6,6 +6,7 @@ import {Buffer, type Binding, type Device, type RenderBundle} from '@luma.gl/cor
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Computation, Model} from '@luma.gl/engine';
 import {
+  DispatchCommandBuffer,
   DrawCommandBuffer,
   GPUAncestorProjection,
   GPUCommandGraph,
@@ -50,6 +51,7 @@ import {
   type TraceGroupName
 } from './trace-data';
 import {
+  getBatchVisibilityShader,
   getDependencyVisibilityShader,
   getFocusMaskShader,
   getPickClearShader,
@@ -94,11 +96,13 @@ type PickPosition = {
 type TraceGraphResources = {
   compiled: CompiledGPUCommandGraph<TraceViewParameters>;
   drawCommands: DrawCommandBuffer;
+  candidateDispatchCommands: DispatchCommandBuffer;
   readbackRing: GPUReadbackRing;
   renderBundle: RenderBundle;
   groups: TraceGroupResources[];
   spans: Buffer;
   spanBatchIndex: Buffer;
+  candidateBatchIds: Buffer;
   dependencies: Buffer;
   parentSpans: Buffer;
   outgoingOffsets: Buffer;
@@ -170,6 +174,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   private compileTimeMilliseconds = 0;
   private sampledVisibleCounts = [0, 0, 0];
   private sampledDependencyCount = 0;
+  private sampledCandidateBatchCount = 0;
   private droppedTelemetrySampleCount = 0;
   private deferredPickFrameCount = 0;
   private frameIndex = 0;
@@ -254,6 +259,19 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         readbackTicket.copyFrom(device.commandEncoder, resources.drawCommands.buffer);
         queueMicrotask(() => {
           void this.sampleVisibleCounts(resources, readbackTicket);
+        });
+      } else {
+        this.droppedTelemetrySampleCount++;
+      }
+      const candidateReadbackTicket = resources.readbackRing.tryAcquire();
+      if (candidateReadbackTicket) {
+        candidateReadbackTicket.copyFrom(
+          device.commandEncoder,
+          resources.candidateDispatchCommands.buffer,
+          {byteLength: UINT32_BYTE_LENGTH}
+        );
+        queueMicrotask(() => {
+          void this.sampleCandidateBatchCount(resources, candidateReadbackTicket);
         });
       } else {
         this.droppedTelemetrySampleCount++;
@@ -391,19 +409,29 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         {vertexCount: 6, instanceCount: densityBinCount}
       ]
     });
+    const candidateDispatchCommands = new DispatchCommandBuffer(this.device, {
+      id: 'gpu-trace-candidate-dispatch-commands',
+      commands: [{x: 0, y: 1, z: 1}]
+    });
     const readbackRing = new GPUReadbackRing(this.device, {
       id: 'gpu-trace-readback',
       byteLength: drawCommands.buffer.byteLength,
-      slotCount: 3
+      slotCount: 4
     });
     return {
       compiled: undefined!,
       renderBundle: undefined!,
       drawCommands,
+      candidateDispatchCommands,
       readbackRing,
       groups,
       spans: this.createDataBuffer('gpu-trace-spans', dataset.spans),
       spanBatchIndex: this.createDataBuffer('gpu-trace-span-batch-index', dataset.spanBatchIndex),
+      candidateBatchIds: this.createStorageBuffer(
+        'gpu-trace-candidate-batch-ids',
+        dataset.spanBatches.length * UINT32_BYTE_LENGTH,
+        Buffer.COPY_SRC
+      ),
       dependencies: this.createDataBuffer('gpu-trace-dependencies', dataset.dependencies),
       parentSpans: this.createDataBuffer('gpu-trace-parent-spans', dataset.parentSpans),
       outgoingOffsets: this.createDataBuffer('gpu-trace-outgoing-offsets', outgoingOffsets),
@@ -493,6 +521,17 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     const handles = {
       uniforms: importTraceBuffer(graph, 'view-uniforms', this.viewUniformBuffer),
       spans: importTraceBuffer(graph, 'spans', resources.spans),
+      spanBatchIndex: importTraceBuffer(graph, 'span-batch-index', resources.spanBatchIndex),
+      candidateBatchIds: importTraceBuffer(
+        graph,
+        'candidate-batch-ids',
+        resources.candidateBatchIds
+      ),
+      candidateDispatchCommands: importTraceBuffer(
+        graph,
+        'candidate-dispatch-commands',
+        resources.candidateDispatchCommands.buffer
+      ),
       dependencies: importTraceBuffer(graph, 'dependencies', resources.dependencies),
       parentSpans: importTraceBuffer(graph, 'parent-spans', resources.parentSpans),
       outgoingOffsets: importTraceBuffer(graph, 'outgoing-offsets', resources.outgoingOffsets),
@@ -547,6 +586,42 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       dataset.incoming.offsets,
       topologyChunkLengths
     );
+
+    const candidateBatchFlags = graph.createTransientBuffer({
+      id: 'trace-candidate-batch-flags',
+      byteLength: Math.max(resources.spanBatchCount, 1) * UINT32_BYTE_LENGTH,
+      usage: Buffer.STORAGE
+    });
+    addTraceComputePass(graph, {
+      id: 'trace-batch-visibility',
+      source: getBatchVisibilityShader(resources.spanBatchCount),
+      bindings: [
+        storageRead('spanBatches', handles.spanBatchIndex),
+        uniformBinding('viewUniforms', handles.uniforms),
+        storageWrite('candidateFlags', candidateBatchFlags)
+      ],
+      length: resources.spanBatchCount
+    });
+    new GPUVisibilityWorkflow({
+      id: 'trace-candidate-batches',
+      predicates: [
+        {
+          kind: ['time-range', 'bounds'],
+          mask: graph.createDataView(candidateBatchFlags, {
+            format: 'uint32',
+            length: resources.spanBatchCount
+          })
+        }
+      ],
+      output: graph.createDataView(handles.candidateBatchIds, {
+        format: 'uint32',
+        length: resources.spanBatchCount
+      }),
+      count: graph.createDataView(handles.candidateDispatchCommands, {
+        format: 'uint32',
+        length: 1
+      })
+    }).addToGraph(graph);
 
     new GPUHierarchyLayout({
       id: 'trace-process-thread-layout',
@@ -892,6 +967,22 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     }
   }
 
+  private async sampleCandidateBatchCount(
+    resources: TraceGraphResources,
+    readbackTicket: GPUReadbackTicket
+  ): Promise<void> {
+    try {
+      const bytes = await readbackTicket.read();
+      if (resources !== this.resources) {
+        return;
+      }
+      this.sampledCandidateBatchCount = new Uint32Array(bytes.buffer, bytes.byteOffset, 1)[0];
+      this.updateInspector();
+    } catch {
+      // Device loss and cancellation release the ring slot without affecting rendering.
+    }
+  }
+
   /** Reads a single explicitly requested GPU-picked source row after the frame is submitted. */
   private async samplePickedSpan(
     resources: TraceGraphResources,
@@ -937,6 +1028,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     resources.compiled.destroy();
     resources.renderBundle.destroy();
     resources.drawCommands.destroy();
+    resources.candidateDispatchCommands.destroy();
     resources.readbackRing.destroy();
     for (const group of resources.groups) {
       group.visibleIds.destroy();
@@ -944,6 +1036,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     for (const buffer of [
       resources.spans,
       resources.spanBatchIndex,
+      resources.candidateBatchIds,
       resources.dependencies,
       resources.parentSpans,
       resources.outgoingOffsets,
@@ -1241,6 +1334,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       this.statsElement.innerHTML = `<div style="display:grid;grid-template-columns:1fr auto;gap:4px 12px;margin-top:8px">
         <span>Sampled exact spans</span><strong>${formatCount(visible)}</strong>
         <span>Sampled visible edges</span><strong>${formatCount(this.sampledDependencyCount)}</strong>
+        <span>Candidate batches</span><strong>${formatCount(this.sampledCandidateBatchCount)}/${formatCount(resources.spanBatchCount)}</strong>
         <span>Visible layout lanes</span><strong>${formatCount(this.getVisibleLaneCount())}</strong>
         <span>Collapsed processes</span><strong>${formatCount(this.processStates.filter(state => state === TRACE_COLLAPSED_STATE).length)}</strong>
         <span>CPU graph encode</span><strong>${this.encodeTimeMilliseconds.toFixed(2)} ms</strong>

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -9,6 +9,7 @@ import {
   DrawCommandBuffer,
   GPUAncestorProjection,
   GPUCommandGraph,
+  GPUGroupAggregation,
   GPUGraphTraversal,
   GPUHierarchyLayout,
   GPUReadbackRing,
@@ -27,8 +28,9 @@ import {
 } from '../../example-panels';
 import {
   makeTraceDataset,
-  TRACE_ACTIVITY_BIN_COUNT,
+  isTraceDensityMode,
   TRACE_COLLAPSED_STATE,
+  TRACE_DENSITY_BIN_COUNT,
   TRACE_DURATION,
   TRACE_EXPANDED_STATE,
   TRACE_FILTER_ERRORS_ONLY,
@@ -47,20 +49,18 @@ import {
   type TraceGroupName
 } from './trace-data';
 import {
-  getActivityAccumulationShader,
-  getActivityClearShader,
   getDependencyVisibilityShader,
   getFocusMaskShader,
   getPickClearShader,
   getVisibilityShader,
-  TRACE_ACTIVITY_RENDER_SHADER,
+  TRACE_DENSITY_RENDER_SHADER,
   TRACE_DEPENDENCY_RENDER_SHADER,
   TRACE_RENDER_SHADER
 } from './trace-shaders';
 
 export const title = 'GPU Hierarchical Trace Viewer';
 export const description =
-  'GPU-resident hierarchical traces with live filtering, process and thread collapse, dependency traversal, picking, and indirect rendering.';
+  'GPU-resident hierarchical traces with live filtering, adaptive density LOD, dependency traversal, picking, and indirect rendering.';
 
 const CAPACITY_OPTIONS = [250_000, 1_000_000, 4_000_000] as const;
 const DEFAULT_CAPACITY = 250_000;
@@ -117,7 +117,8 @@ type TraceGraphResources = {
   baseVisibility: Buffer;
   spanVisibility: Buffer;
   visibleDependencyIds: Buffer;
-  activityBins: Buffer;
+  densityKeys: Buffer;
+  densityBins: Buffer;
   pickResult: Buffer;
   spanCount: number;
   dependencyCount: number;
@@ -137,7 +138,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   readonly device: Device;
   readonly model: Model;
   readonly dependencyModel: Model;
-  readonly activityModel: Model;
+  readonly densityModel: Model;
   readonly viewUniformBuffer: Buffer;
   readonly panels: ExamplePanelManager;
 
@@ -169,6 +170,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   private droppedTelemetrySampleCount = 0;
   private deferredPickFrameCount = 0;
   private frameIndex = 0;
+  private viewportWidth = 1;
   private canvas: HTMLCanvasElement | null = null;
   private statsElement: HTMLElement | null = null;
   private nodesElement: HTMLElement | null = null;
@@ -191,7 +193,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     });
     this.model = this.createSpanModel();
     this.dependencyModel = this.createDependencyModel();
-    this.activityModel = this.createActivityModel();
+    this.densityModel = this.createDensityModel();
     this.panels = new ExamplePanelManager({panel: this.makePanel()});
     this.rebuild(traceCapacity);
     this.panels.mount();
@@ -214,6 +216,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     if (!resources) {
       return;
     }
+    this.viewportWidth = width;
     if (this.autoScroll) {
       const windowSize = this.view.timeMax - this.view.timeMin;
       this.view.timeMin = (time * 0.025) % Math.max(TRACE_DURATION - windowSize, 1);
@@ -266,7 +269,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     this.destroyResources();
     this.model.destroy();
     this.dependencyModel.destroy();
-    this.activityModel.destroy();
+    this.densityModel.destroy();
     this.viewUniformBuffer.destroy();
   }
 
@@ -318,10 +321,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     });
   }
 
-  private createActivityModel(): Model {
+  private createDensityModel(): Model {
     return new Model(this.device, {
-      id: 'gpu-trace-collapsed-activity-model',
-      source: TRACE_ACTIVITY_RENDER_SHADER,
+      id: 'gpu-trace-density-model',
+      source: TRACE_DENSITY_RENDER_SHADER,
       topology: 'triangle-list',
       vertexCount: 6,
       colorAttachmentFormats: [this.device.preferredColorFormat],
@@ -329,10 +332,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       shaderLayout: {
         attributes: [],
         bindings: [
-          {name: 'activityBins', type: 'read-only-storage', group: 0, location: 0},
-          {name: 'processStates', type: 'read-only-storage', group: 0, location: 1},
-          {name: 'threadOffsets', type: 'read-only-storage', group: 0, location: 2},
-          {name: 'viewUniforms', type: 'uniform', group: 0, location: 3}
+          {name: 'densityBins', type: 'read-only-storage', group: 0, location: 0},
+          {name: 'viewUniforms', type: 'uniform', group: 0, location: 1}
         ]
       },
       parameters: makeTraceBlendParameters()
@@ -370,7 +371,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     }));
     const spanMaskByteLength = Math.max(dataset.spanCount, 1) * UINT32_BYTE_LENGTH;
     const dependencyMaskByteLength = Math.max(dataset.dependencyCount, 1) * UINT32_BYTE_LENGTH;
-    const activityBinCount = TRACE_PROCESS_COUNT * TRACE_ACTIVITY_BIN_COUNT;
+    const densityBinCount = TRACE_LANE_COUNT * TRACE_DENSITY_BIN_COUNT;
     const topologyChunkLengths = getTopologyChunkLengths(dataset.spanCount);
     const outgoingOffsets = makePartitionedOffsets(dataset.outgoing.offsets, topologyChunkLengths);
     const incomingOffsets = makePartitionedOffsets(dataset.incoming.offsets, topologyChunkLengths);
@@ -380,7 +381,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       commands: [
         ...groups.map(() => ({vertexCount: 6, instanceCount: 0})),
         {vertexCount: 2, instanceCount: 0},
-        {vertexCount: 6, instanceCount: activityBinCount}
+        {vertexCount: 6, instanceCount: densityBinCount}
       ]
     });
     const readbackRing = new GPUReadbackRing(this.device, {
@@ -440,9 +441,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         'gpu-trace-visible-dependencies',
         dependencyMaskByteLength
       ),
-      activityBins: this.createStorageBuffer(
-        'gpu-trace-activity-bins',
-        activityBinCount * UINT32_BYTE_LENGTH,
+      densityKeys: this.createStorageBuffer('gpu-trace-density-keys', spanMaskByteLength),
+      densityBins: this.createStorageBuffer(
+        'gpu-trace-density-bins',
+        densityBinCount * UINT32_BYTE_LENGTH,
         Buffer.COPY_SRC
       ),
       pickResult: this.createStorageBuffer(
@@ -471,7 +473,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     });
   }
 
-  /** Compiles the complete immutable hierarchy, focus, visibility, edge, and activity graph. */
+  /** Compiles the complete immutable hierarchy, focus, visibility, density, and edge graph. */
   private createGraph(
     resources: TraceGraphResources,
     dataset: TraceDatasetData
@@ -517,7 +519,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         'visible-dependency-ids',
         resources.visibleDependencyIds
       ),
-      activityBins: importTraceBuffer(graph, 'activity-bins', resources.activityBins),
+      densityKeys: importTraceBuffer(graph, 'density-keys', resources.densityKeys),
+      densityBins: importTraceBuffer(graph, 'density-bins', resources.densityBins),
       pickResult: importTraceBuffer(graph, 'pick-result', resources.pickResult),
       drawCommands: importTraceBuffer(graph, 'draw-commands', resources.drawCommands.buffer)
     };
@@ -634,24 +637,6 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       length: 1,
       workgroupSize: 1
     });
-    addTraceComputePass(graph, {
-      id: 'trace-clear-activity',
-      source: getActivityClearShader(TRACE_PROCESS_COUNT * TRACE_ACTIVITY_BIN_COUNT),
-      bindings: [storageWrite('activityBins', handles.activityBins)],
-      length: TRACE_PROCESS_COUNT * TRACE_ACTIVITY_BIN_COUNT
-    });
-    addTraceComputePass(graph, {
-      id: 'trace-accumulate-activity',
-      source: getActivityAccumulationShader(resources.spanCount),
-      bindings: [
-        storageRead('spans', handles.spans),
-        storageRead('processStates', handles.processStates),
-        uniformBinding('viewUniforms', handles.uniforms),
-        storageWrite('activityBins', handles.activityBins)
-      ],
-      length: resources.spanCount
-    });
-
     const renderResources: GraphBufferUse[] = [
       {buffer: handles.spans, usage: 'storage-read'},
       {buffer: handles.dependencies, usage: 'storage-read'},
@@ -660,7 +645,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       {buffer: handles.threadOffsets, usage: 'storage-read'},
       {buffer: handles.reachedSpans, usage: 'storage-read'},
       {buffer: handles.visibleAncestors, usage: 'storage-read'},
-      {buffer: handles.activityBins, usage: 'storage-read'},
+      {buffer: handles.densityBins, usage: 'storage-read'},
       {buffer: handles.uniforms, usage: 'uniform'},
       {buffer: handles.drawCommands, usage: 'indirect'}
     ];
@@ -679,7 +664,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
             storageRead('threadOffsets', handles.threadOffsets),
             storageRead('threadStates', handles.threadStates),
             storageWrite('visibilityFlags', handles.baseVisibility),
-            storageWrite('pickResult', handles.pickResult)
+            storageWrite('pickResult', handles.pickResult),
+            storageWrite('densityKeys', handles.densityKeys)
           ],
           length: group.count
         });
@@ -716,6 +702,22 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         firstSourceIndex: group.firstSpanIndex
       }).addToGraph(graph);
     }
+
+    new GPUGroupAggregation({
+      id: 'trace-density',
+      keys: graph.createDataView(handles.densityKeys, {
+        format: 'uint32',
+        length: resources.spanCount
+      }),
+      mask: graph.createDataView(handles.focusMask, {
+        format: 'uint32',
+        length: resources.spanCount
+      }),
+      output: graph.createDataView(handles.densityBins, {
+        format: 'uint32',
+        length: TRACE_LANE_COUNT * TRACE_DENSITY_BIN_COUNT
+      })
+    }).addToGraph(graph);
 
     new GPUAncestorProjection({
       id: 'trace-visible-ancestor-projection',
@@ -793,7 +795,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     return graph.compile();
   }
 
-  /** Records the fixed span, dependency, and collapsed-activity indirect draw topology. */
+  /** Records the fixed exact-span, dependency, and adaptive-density draw topology. */
   private createRenderBundle(resources: TraceGraphResources): RenderBundle {
     const encoder = this.device.createRenderBundleEncoder({
       id: 'gpu-hierarchical-trace-render-bundle',
@@ -828,12 +830,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     });
     resources.drawCommands.draw(encoder, resources.groups.length);
 
-    encoder.setPipeline(this.activityModel.pipeline);
-    encoder.setVertexArray(this.activityModel.vertexArray);
+    encoder.setPipeline(this.densityModel.pipeline);
+    encoder.setVertexArray(this.densityModel.vertexArray);
     encoder.setBindings({
-      activityBins: resources.activityBins,
-      processStates: resources.processStates,
-      threadOffsets: resources.threadOffsets,
+      densityBins: resources.densityBins,
       viewUniforms: this.viewUniformBuffer
     });
     resources.drawCommands.draw(encoder, resources.groups.length + 1);
@@ -953,7 +953,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       resources.baseVisibility,
       resources.spanVisibility,
       resources.visibleDependencyIds,
-      resources.activityBins,
+      resources.densityKeys,
+      resources.densityBins,
       resources.pickResult
     ]) {
       buffer.destroy();
@@ -969,7 +970,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         makeHtmlCustomPanel({
           id: 'gpu-trace-overview',
           title: '',
-          html: '<p style="margin:0;line-height:1.5">A fixed WebGPU command graph owns hierarchical layout, composed filters, dependency traversal, picking, collapsed activity, and indirect span and edge rendering.</p>'
+          html: '<p style="margin:0;line-height:1.5">A fixed WebGPU command graph owns hierarchical layout, composed filters, dependency traversal, picking, adaptive exact-or-density rendering, and indirect draws.</p>'
         }),
         makeHtmlCustomPanel({
           id: 'gpu-trace-controls',
@@ -1226,11 +1227,12 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     if (this.statsElement) {
       const visible = this.sampledVisibleCounts.reduce((sum, count) => sum + count, 0);
       this.statsElement.innerHTML = `<div style="display:grid;grid-template-columns:1fr auto;gap:4px 12px;margin-top:8px">
-        <span>Sampled visible spans</span><strong>${formatCount(visible)}</strong>
+        <span>Sampled exact spans</span><strong>${formatCount(visible)}</strong>
         <span>Sampled visible edges</span><strong>${formatCount(this.sampledDependencyCount)}</strong>
         <span>Visible layout lanes</span><strong>${formatCount(this.getVisibleLaneCount())}</strong>
         <span>Collapsed processes</span><strong>${formatCount(this.processStates.filter(state => state === TRACE_COLLAPSED_STATE).length)}</strong>
         <span>CPU graph encode</span><strong>${this.encodeTimeMilliseconds.toFixed(2)} ms</strong>
+        <span>Trace LOD</span><strong>${isTraceDensityMode(this.view.timeMin, this.view.timeMax, this.viewportWidth) ? 'density bins' : 'exact spans'}</strong>
         <span>Readback slots</span><strong>${resources.readbackRing.availableSlotCount}/${resources.readbackRing.slotCount}</strong>
         <span>Dropped telemetry samples</span><strong>${formatCount(this.droppedTelemetrySampleCount)}</strong>
         <span>Deferred pick frames</span><strong>${formatCount(this.deferredPickFrameCount)}</strong>

--- a/examples/experimental/gpu-trace-viewer/index.html
+++ b/examples/experimental/gpu-trace-viewer/index.html
@@ -3,14 +3,39 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>GPU Hierarchical Trace Viewer</title>
-  <style>body { margin: 0; background: #030712; }</style>
+  <style>
+    body { margin: 0; background: #030712; }
+    #example-panel-host {
+      position: fixed;
+      z-index: 1;
+      top: 12px;
+      right: 12px;
+      width: min(380px, calc(100vw - 24px)) !important;
+      max-height: calc(100vh - 24px);
+      overflow: auto;
+      box-sizing: border-box;
+      padding: 12px;
+      color: #e5e7eb;
+      background: rgb(3 7 18 / 88%);
+      border: 1px solid rgb(148 163 184 / 30%);
+      border-radius: 8px;
+      backdrop-filter: blur(8px);
+    }
+  </style>
 </head>
 <script type="module">
+  import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';
   import AnimationLoopTemplate from './app.ts';
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter]});
+  const device = luma.createDevice({
+    id: 'gpu-trace-viewer',
+    adapters: [webgpuAdapter],
+    createCanvasContext: true,
+    featureLevel: 'max'
+  });
+  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
   animationLoop.start();
 </script>
-<body></body>
+<body><div id="example-panel-host" data-example-panel-host></div></body>

--- a/examples/experimental/gpu-trace-viewer/trace-data.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-data.ts
@@ -13,8 +13,7 @@ export const TRACE_SPAN_RECORD_WORD_LENGTH = 8;
 export const TRACE_DEPENDENCY_RECORD_WORD_LENGTH = 4;
 export const TRACE_SPAN_BATCH_RECORD_WORD_LENGTH = 8;
 export const TRACE_SPAN_BATCH_CAPACITY = 1_000_000;
-const TRACE_CAPACITY_INCREMENT = 250_000;
-const TRACE_DEMONSTRATION_CAPACITY_CEILING = 4_000_000;
+const TRACE_DEMONSTRATION_CAPACITIES = [250_000, 1_000_000, 4_000_000, 10_000_000];
 // Keep density scrolling visually continuous at common viewport widths while retaining a fixed,
 // allocation-stable aggregation target for the compiled GPU command graph.
 export const TRACE_DENSITY_BIN_COUNT = 512;
@@ -48,14 +47,7 @@ export function getTraceCapacityOptions(
   const maximumSpanCapacity = Math.floor(
     Math.min(maxStorageBufferBindingSize, maxBufferSize) / spanRecordByteLength
   );
-  const maximumDemonstrationCapacity =
-    Math.floor(
-      Math.min(maximumSpanCapacity, TRACE_DEMONSTRATION_CAPACITY_CEILING) / TRACE_CAPACITY_INCREMENT
-    ) * TRACE_CAPACITY_INCREMENT;
-  const capacities = [250_000, 1_000_000, 4_000_000, maximumDemonstrationCapacity].filter(
-    capacity => capacity > 0 && capacity <= maximumSpanCapacity
-  );
-  return [...new Set(capacities)];
+  return TRACE_DEMONSTRATION_CAPACITIES.filter(capacity => capacity <= maximumSpanCapacity);
 }
 
 /** Matches the GPU's adaptive exact-span versus density-rendering decision. */

--- a/examples/experimental/gpu-trace-viewer/trace-data.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-data.ts
@@ -11,7 +11,13 @@ export const TRACE_THREAD_COUNT = TRACE_PROCESS_COUNT * TRACE_THREADS_PER_PROCES
 export const TRACE_LANE_COUNT = TRACE_THREAD_COUNT * TRACE_LANES_PER_THREAD;
 export const TRACE_SPAN_RECORD_WORD_LENGTH = 8;
 export const TRACE_DEPENDENCY_RECORD_WORD_LENGTH = 4;
-export const TRACE_DENSITY_BIN_COUNT = 96;
+export const TRACE_SPAN_BATCH_RECORD_WORD_LENGTH = 8;
+export const TRACE_SPAN_BATCH_CAPACITY = 1_000_000;
+const TRACE_CAPACITY_INCREMENT = 250_000;
+const TRACE_DEMONSTRATION_CAPACITY_CEILING = 4_000_000;
+// Keep density scrolling visually continuous at common viewport widths while retaining a fixed,
+// allocation-stable aggregation target for the compiled GPU command graph.
+export const TRACE_DENSITY_BIN_COUNT = 512;
 /** Switch to density rendering when one horizontal pixel covers at least this much trace time. */
 export const TRACE_DENSITY_TIME_PER_PIXEL = 0.08;
 export const TRACE_STATUS_COUNT = 4;
@@ -32,6 +38,25 @@ export const TRACE_MAXIMUM_RELATIVE_PARENT_DURATION_DELTA = 0.25;
 export const TRACE_COLLAPSED_STATE = 0;
 export const TRACE_EXPANDED_STATE = 1;
 export const TRACE_INVALID_SPAN_INDEX = 0xffffffff;
+
+/** Returns useful demonstration sizes that fit in one span storage-buffer binding. */
+export function getTraceCapacityOptions(
+  maxStorageBufferBindingSize: number,
+  maxBufferSize: number
+): number[] {
+  const spanRecordByteLength = TRACE_SPAN_RECORD_WORD_LENGTH * Uint32Array.BYTES_PER_ELEMENT;
+  const maximumSpanCapacity = Math.floor(
+    Math.min(maxStorageBufferBindingSize, maxBufferSize) / spanRecordByteLength
+  );
+  const maximumDemonstrationCapacity =
+    Math.floor(
+      Math.min(maximumSpanCapacity, TRACE_DEMONSTRATION_CAPACITY_CEILING) / TRACE_CAPACITY_INCREMENT
+    ) * TRACE_CAPACITY_INCREMENT;
+  const capacities = [250_000, 1_000_000, 4_000_000, maximumDemonstrationCapacity].filter(
+    capacity => capacity > 0 && capacity <= maximumSpanCapacity
+  );
+  return [...new Set(capacities)];
+}
 
 /** Matches the GPU's adaptive exact-span versus density-rendering decision. */
 export function isTraceDensityMode(
@@ -54,6 +79,21 @@ export type TraceGroupData = {
   data: Uint32Array;
 };
 
+/** Stable source partition and coarse bounds used for GPU candidate-batch selection. */
+export type TraceSpanBatchData = {
+  batchIndex: number;
+  groupIndex: number;
+  name: TraceGroupName;
+  count: number;
+  firstSpanIndex: number;
+  timeMin: number;
+  timeMax: number;
+  laneMin: number;
+  laneMax: number;
+  /** Borrowed source-aligned view into the canonical span allocation. */
+  data: Uint32Array;
+};
+
 /** Compact forward or reverse compressed sparse dependency adjacency. */
 export type TraceAdjacencyData = {
   /** One stable offset per source node plus the final edge count. */
@@ -68,6 +108,10 @@ export type TraceDatasetData = {
   spans: Uint32Array;
   /** Original stable group ranges into the canonical span allocation. */
   groups: TraceGroupData[];
+  /** Group-aligned source partitions small enough for independent GPU processing. */
+  spanBatches: TraceSpanBatchData[];
+  /** Packed batch first/count, temporal bounds, lane bounds, group, and stable batch ID records. */
+  spanBatchIndex: Uint32Array;
   /** Packed 16-byte dependency source, destination, family, and keyword records. */
   dependencies: Uint32Array;
   /** One cross-process-prioritized canonical parent or invalid sentinel per span. */
@@ -127,9 +171,12 @@ export function makeTraceDataset(totalSpanCount: number): TraceDatasetData {
 
   const topology = makeTraceDependencies(spans, totalSpanCount);
   const dependencyCount = topology.dependencies.length / TRACE_DEPENDENCY_RECORD_WORD_LENGTH;
+  const {spanBatches, spanBatchIndex} = makeTraceSpanBatches(spans, groups);
   return {
     spans,
     groups,
+    spanBatches,
+    spanBatchIndex,
     dependencies: topology.dependencies,
     parentSpans: topology.parentSpans,
     outgoing: buildTraceAdjacency(totalSpanCount, topology.dependencies, 'outgoing'),
@@ -139,6 +186,70 @@ export function makeTraceDataset(totalSpanCount: number): TraceDatasetData {
     processCount: TRACE_PROCESS_COUNT,
     threadCount: TRACE_THREAD_COUNT
   };
+}
+
+/** Partitions canonical group ranges and builds coarse GPU-readable batch bounds. */
+export function makeTraceSpanBatches(
+  spans: Uint32Array,
+  groups: readonly TraceGroupData[],
+  batchCapacity = TRACE_SPAN_BATCH_CAPACITY
+): {spanBatches: TraceSpanBatchData[]; spanBatchIndex: Uint32Array} {
+  if (!Number.isSafeInteger(batchCapacity) || batchCapacity < 1) {
+    throw new RangeError('Trace span batch capacity must be a positive safe integer');
+  }
+  const spanFloats = new Float32Array(spans.buffer, spans.byteOffset, spans.length);
+  const spanBatches: TraceSpanBatchData[] = [];
+
+  for (const group of groups) {
+    for (let groupOffset = 0; groupOffset < group.count; groupOffset += batchCapacity) {
+      const count = Math.min(batchCapacity, group.count - groupOffset);
+      const firstSpanIndex = group.firstSpanIndex + groupOffset;
+      let timeMin = Number.POSITIVE_INFINITY;
+      let timeMax = Number.NEGATIVE_INFINITY;
+      let laneMin = TRACE_LANE_COUNT;
+      let laneMax = 0;
+      for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+        const wordOffset = (firstSpanIndex + rowIndex) * TRACE_SPAN_RECORD_WORD_LENGTH;
+        const start = spanFloats[wordOffset];
+        const end = start + spanFloats[wordOffset + 1];
+        const lane = spans[wordOffset + 2];
+        timeMin = Math.min(timeMin, start);
+        timeMax = Math.max(timeMax, end);
+        laneMin = Math.min(laneMin, lane);
+        laneMax = Math.max(laneMax, lane + 1);
+      }
+      spanBatches.push({
+        batchIndex: spanBatches.length,
+        groupIndex: group.groupIndex,
+        name: group.name,
+        count,
+        firstSpanIndex,
+        timeMin,
+        timeMax,
+        laneMin,
+        laneMax,
+        data: spans.subarray(
+          firstSpanIndex * TRACE_SPAN_RECORD_WORD_LENGTH,
+          (firstSpanIndex + count) * TRACE_SPAN_RECORD_WORD_LENGTH
+        )
+      });
+    }
+  }
+
+  const spanBatchIndex = new Uint32Array(spanBatches.length * TRACE_SPAN_BATCH_RECORD_WORD_LENGTH);
+  const spanBatchIndexFloats = new Float32Array(spanBatchIndex.buffer);
+  for (const batch of spanBatches) {
+    const wordOffset = batch.batchIndex * TRACE_SPAN_BATCH_RECORD_WORD_LENGTH;
+    spanBatchIndex[wordOffset] = batch.firstSpanIndex;
+    spanBatchIndex[wordOffset + 1] = batch.count;
+    spanBatchIndexFloats[wordOffset + 2] = batch.timeMin;
+    spanBatchIndexFloats[wordOffset + 3] = batch.timeMax;
+    spanBatchIndex[wordOffset + 4] = batch.laneMin;
+    spanBatchIndex[wordOffset + 5] = batch.laneMax;
+    spanBatchIndex[wordOffset + 6] = batch.groupIndex;
+    spanBatchIndex[wordOffset + 7] = batch.batchIndex;
+  }
+  return {spanBatches, spanBatchIndex};
 }
 
 /** Maintains the original example API while retaining canonical source references. */
@@ -168,7 +279,8 @@ function fillTraceGroup(params: {
     const laneIndex = Math.floor(random() * TRACE_LANE_COUNT);
     const threadIndex = Math.floor(laneIndex / TRACE_LANES_PER_THREAD);
     const processIndex = Math.floor(threadIndex / TRACE_THREADS_PER_PROCESS);
-    const cluster = Math.floor(random() * 20) * (TRACE_DURATION / 20);
+    const temporalFraction = groupRowIndex / Math.max(params.spanCount, 1);
+    const cluster = Math.floor(temporalFraction * 20) * (TRACE_DURATION / 20);
     const start = Math.min(TRACE_DURATION - 0.05, cluster + random() * 55);
     const durationScale = params.groupIndex === 0 ? 5 : params.groupIndex === 1 ? 14 : 28;
     const duration = Math.max(0.08, Math.pow(random(), 2.6) * durationScale);

--- a/examples/experimental/gpu-trace-viewer/trace-data.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-data.ts
@@ -11,7 +11,9 @@ export const TRACE_THREAD_COUNT = TRACE_PROCESS_COUNT * TRACE_THREADS_PER_PROCES
 export const TRACE_LANE_COUNT = TRACE_THREAD_COUNT * TRACE_LANES_PER_THREAD;
 export const TRACE_SPAN_RECORD_WORD_LENGTH = 8;
 export const TRACE_DEPENDENCY_RECORD_WORD_LENGTH = 4;
-export const TRACE_ACTIVITY_BIN_COUNT = 96;
+export const TRACE_DENSITY_BIN_COUNT = 96;
+/** Switch to density rendering when one horizontal pixel covers at least this much trace time. */
+export const TRACE_DENSITY_TIME_PER_PIXEL = 0.08;
 export const TRACE_STATUS_COUNT = 4;
 export const TRACE_SAME_PROCESS_DEPENDENCY = 0;
 export const TRACE_CROSS_PROCESS_DEPENDENCY = 1;
@@ -30,6 +32,15 @@ export const TRACE_MAXIMUM_RELATIVE_PARENT_DURATION_DELTA = 0.25;
 export const TRACE_COLLAPSED_STATE = 0;
 export const TRACE_EXPANDED_STATE = 1;
 export const TRACE_INVALID_SPAN_INDEX = 0xffffffff;
+
+/** Matches the GPU's adaptive exact-span versus density-rendering decision. */
+export function isTraceDensityMode(
+  timeMin: number,
+  timeMax: number,
+  viewportWidth: number
+): boolean {
+  return (timeMax - timeMin) / Math.max(viewportWidth, 1) >= TRACE_DENSITY_TIME_PER_PIXEL;
+}
 
 export type TraceGroupName = (typeof TRACE_GROUPS)[number];
 

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -314,12 +314,14 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let sourceIndex = FIRST_SPAN_INDEX + groupRowIndex;
   let span = spans[sourceIndex];
   let end = span.start + span.duration;
+  let processExpanded = processStates[span.processIndex] != 0u;
   let localLane = select(0u, span.lane % LANES_PER_THREAD, threadStates[span.threadIndex] != 0u);
-  let lane = f32(threadOffsets[span.threadIndex] + localLane);
+  let expandedLane = threadOffsets[span.threadIndex] + localLane;
+  let collapsedLane = threadOffsets[span.processIndex * THREADS_PER_PROCESS];
+  let lane = f32(select(collapsedLane, expandedLane, processExpanded));
   let timeVisible = end >= viewUniforms.timeMin && span.start <= viewUniforms.timeMax;
   let laneVisible = lane >= viewUniforms.laneMin && lane < viewUniforms.laneMax;
   let groupVisible = (viewUniforms.enabledMask & GROUP_BIT) != 0u;
-  let processExpanded = processStates[span.processIndex] != 0u;
   let statusVisible = (viewUniforms.statusMask & (1u << (span.flags & 3u))) != 0u;
   let runtimeVisible =
     (viewUniforms.activeFilterMask & ${TRACE_FILTER_HIDE_RUNTIME_SPANS}u) == 0u ||

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -3,7 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 import {
-  TRACE_ACTIVITY_BIN_COUNT,
+  TRACE_DENSITY_BIN_COUNT,
+  TRACE_DENSITY_TIME_PER_PIXEL,
   TRACE_ERROR_SPAN_FLAG,
   TRACE_FILTER_ERRORS_ONLY,
   TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN,
@@ -60,6 +61,12 @@ struct ViewUniforms {
 
 const LANES_PER_THREAD: u32 = ${TRACE_LANES_PER_THREAD}u;
 const THREADS_PER_PROCESS: u32 = ${TRACE_THREADS_PER_PROCESS}u;
+const DENSITY_TIME_PER_PIXEL: f32 = ${TRACE_DENSITY_TIME_PER_PIXEL};
+
+fn isDensityMode() -> bool {
+  let timeRange = max(viewUniforms.timeMax - viewUniforms.timeMin, 0.0001);
+  return timeRange / max(viewUniforms.viewportWidth, 1.0) >= DENSITY_TIME_PER_PIXEL;
+}
 
 fn getGroupColor(group: u32) -> vec3<f32> {
   let colors = array<vec3<f32>, 3>(
@@ -206,17 +213,15 @@ fn getResolvedEndpoint(sourceIndex: u32) -> TraceSpan {
   return input.color;
 }`;
 
-/** Renders one compact histogram strip for each currently collapsed process. */
-export const TRACE_ACTIVITY_RENDER_SHADER = /* wgsl */ `
+/** Renders GPU-aggregated density bins for the current visible lane layout. */
+export const TRACE_DENSITY_RENDER_SHADER = /* wgsl */ `
 ${TRACE_SHADER_DECLARATIONS}
 
-const ACTIVITY_BIN_COUNT: u32 = ${TRACE_ACTIVITY_BIN_COUNT}u;
-@group(0) @binding(0) var<storage, read> activityBins: array<u32>;
-@group(0) @binding(1) var<storage, read> processStates: array<u32>;
-@group(0) @binding(2) var<storage, read> threadOffsets: array<u32>;
-@group(0) @binding(3) var<uniform> viewUniforms: ViewUniforms;
+const DENSITY_BIN_COUNT: u32 = ${TRACE_DENSITY_BIN_COUNT}u;
+@group(0) @binding(0) var<storage, read> densityBins: array<u32>;
+@group(0) @binding(1) var<uniform> viewUniforms: ViewUniforms;
 
-struct ActivityVertexOutput {
+struct DensityVertexOutput {
   @builtin(position) position: vec4<f32>,
   @location(0) color: vec4<f32>,
 };
@@ -224,22 +229,22 @@ struct ActivityVertexOutput {
 @vertex fn vertexMain(
   @builtin(vertex_index) vertexIndex: u32,
   @builtin(instance_index) instanceIndex: u32
-) -> ActivityVertexOutput {
-  let processIndex = instanceIndex / ACTIVITY_BIN_COUNT;
-  let binIndex = instanceIndex % ACTIVITY_BIN_COUNT;
-  let count = activityBins[instanceIndex];
+) -> DensityVertexOutput {
+  let lane = instanceIndex / DENSITY_BIN_COUNT;
+  let binIndex = instanceIndex % DENSITY_BIN_COUNT;
+  let count = densityBins[instanceIndex];
   let corner = getCorner(vertexIndex);
   let laneRange = max(viewUniforms.laneMax - viewUniforms.laneMin, 1.0);
-  let lane = f32(threadOffsets[processIndex * THREADS_PER_PROCESS]);
   let laneHeight = 2.0 / laneRange;
-  let startX = (f32(binIndex) / f32(ACTIVITY_BIN_COUNT)) * 2.0 - 1.0;
-  let endX = (f32(binIndex + 1u) / f32(ACTIVITY_BIN_COUNT)) * 2.0 - 1.0;
+  let startX = (f32(binIndex) / f32(DENSITY_BIN_COUNT)) * 2.0 - 1.0;
+  let endX = (f32(binIndex + 1u) / f32(DENSITY_BIN_COUNT)) * 2.0 - 1.0;
   let intensity = clamp(log2(f32(count) + 1.0) * viewUniforms.activityScale, 0.12, 1.0);
-  let visible = processStates[processIndex] == 0u && count > 0u;
-  var output: ActivityVertexOutput;
+  let visible = count > 0u && f32(lane) >= viewUniforms.laneMin &&
+    f32(lane) < viewUniforms.laneMax;
+  var output: DensityVertexOutput;
   output.position = vec4<f32>(
     mix(startX, endX, corner.x),
-    1.0 - ((lane - viewUniforms.laneMin) / laneRange) * 2.0 -
+    1.0 - ((f32(lane) - viewUniforms.laneMin) / laneRange) * 2.0 -
       corner.y * laneHeight * 0.78 * intensity,
     0.0,
     1.0
@@ -251,7 +256,7 @@ struct ActivityVertexOutput {
   return output;
 }
 
-@fragment fn fragmentMain(input: ActivityVertexOutput) -> @location(0) vec4<f32> {
+@fragment fn fragmentMain(input: DensityVertexOutput) -> @location(0) vec4<f32> {
   return input.color;
 }`;
 
@@ -298,6 +303,7 @@ const SIMILAR_DURATION_PARENT_FLAG: u32 = ${TRACE_SIMILAR_DURATION_PARENT_FLAG}u
 @group(0) @binding(4) var<storage, read> threadStates: array<u32>;
 @group(0) @binding(5) var<storage, read_write> visibilityFlags: array<u32>;
 @group(0) @binding(6) var<storage, read_write> pickResult: array<atomic<u32>>;
+@group(0) @binding(7) var<storage, read_write> densityKeys: array<u32>;
 
 @compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
 fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
@@ -313,7 +319,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let timeVisible = end >= viewUniforms.timeMin && span.start <= viewUniforms.timeMax;
   let laneVisible = lane >= viewUniforms.laneMin && lane < viewUniforms.laneMax;
   let groupVisible = (viewUniforms.enabledMask & GROUP_BIT) != 0u;
-  let processVisible = processStates[span.processIndex] != 0u;
+  let processExpanded = processStates[span.processIndex] != 0u;
   let statusVisible = (viewUniforms.statusMask & (1u << (span.flags & 3u))) != 0u;
   let runtimeVisible =
     (viewUniforms.activeFilterMask & ${TRACE_FILTER_HIDE_RUNTIME_SPANS}u) == 0u ||
@@ -328,15 +334,23 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
     (viewUniforms.activeFilterMask & ${TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS}u) == 0u ||
     (span.flags & SIMILAR_DURATION_PARENT_FLAG) == 0u;
   let durationVisible = span.duration >= viewUniforms.minimumDuration;
-  let visible = timeVisible && laneVisible && groupVisible && processVisible &&
+  let sourceVisible = timeVisible && laneVisible && groupVisible &&
     statusVisible && runtimeVisible && errorVisible && overlappingChildVisible &&
     similarParentVisible && durationVisible;
-  visibilityFlags[sourceIndex] = select(0u, 1u, visible);
+  let densityMode = isDensityMode();
+  let exactVisible = sourceVisible && processExpanded && !densityMode;
+  visibilityFlags[sourceIndex] = select(0u, 1u, exactVisible);
+  let timeRange = max(viewUniforms.timeMax - viewUniforms.timeMin, 0.0001);
+  let fraction = clamp((span.start - viewUniforms.timeMin) / timeRange, 0.0, 0.999999);
+  let bin = min(u32(fraction * f32(${TRACE_DENSITY_BIN_COUNT}u)), ${TRACE_DENSITY_BIN_COUNT - 1}u);
+  let densityKey = u32(lane) * ${TRACE_DENSITY_BIN_COUNT}u + bin;
+  let densityVisible = sourceVisible && (densityMode || !processExpanded);
+  densityKeys[sourceIndex] = select(0xffffffffu, densityKey, densityVisible);
   let pickRequested = viewUniforms.pickLane >= 0.0;
   let timePicked = viewUniforms.pickTime >= span.start &&
     viewUniforms.pickTime <= span.start + span.duration;
   let lanePicked = viewUniforms.pickLane >= lane && viewUniforms.pickLane < lane + 1.0;
-  if (visible && pickRequested && timePicked && lanePicked) {
+  if (sourceVisible && pickRequested && timePicked && lanePicked) {
     atomicMin(&pickResult[0], sourceIndex);
   }
 }`;
@@ -396,53 +410,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   dependencyFlags[index] = select(
     0u,
     1u,
-    familyVisible && sourceVisible && destinationVisible && distinctEndpoints
+    familyVisible && sourceVisible && destinationVisible && distinctEndpoints && !isDensityMode()
   );
-}`;
-}
-
-/** Clears every collapsed-process histogram bin on the GPU before accumulation. */
-export function getActivityClearShader(binCount: number): string {
-  return /* wgsl */ `
-const BIN_COUNT: u32 = ${binCount}u;
-@group(0) @binding(0) var<storage, read_write> activityBins: array<atomic<u32>>;
-
-@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  if (globalId.x < BIN_COUNT) {
-    atomicStore(&activityBins[globalId.x], 0u);
-  }
-}`;
-}
-
-/** Bins visible-time source spans into GPU-resident collapsed-process activity histograms. */
-export function getActivityAccumulationShader(spanCount: number): string {
-  return /* wgsl */ `
-${TRACE_SHADER_DECLARATIONS}
-const SPAN_COUNT: u32 = ${spanCount}u;
-const ACTIVITY_BIN_COUNT: u32 = ${TRACE_ACTIVITY_BIN_COUNT}u;
-@group(0) @binding(0) var<storage, read> spans: array<TraceSpan>;
-@group(0) @binding(1) var<storage, read> processStates: array<u32>;
-@group(0) @binding(2) var<uniform> viewUniforms: ViewUniforms;
-@group(0) @binding(3) var<storage, read_write> activityBins: array<atomic<u32>>;
-
-@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let index = globalId.x;
-  if (index >= SPAN_COUNT) {
-    return;
-  }
-  let span = spans[index];
-  if (processStates[span.processIndex] != 0u) {
-    return;
-  }
-  let end = span.start + span.duration;
-  if (end < viewUniforms.timeMin || span.start > viewUniforms.timeMax) {
-    return;
-  }
-  let timeRange = max(viewUniforms.timeMax - viewUniforms.timeMin, 0.0001);
-  let fraction = clamp((span.start - viewUniforms.timeMin) / timeRange, 0.0, 0.999999);
-  let bin = min(u32(fraction * f32(ACTIVITY_BIN_COUNT)), ACTIVITY_BIN_COUNT - 1u);
-  atomicAdd(&activityBins[span.processIndex * ACTIVITY_BIN_COUNT + bin], 1u);
 }`;
 }

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -281,6 +281,39 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
 }`;
 }
 
+/** Coarsely rejects immutable span batches that cannot contribute to the active view. */
+export function getBatchVisibilityShader(batchCount: number): string {
+  return /* wgsl */ `
+${TRACE_SHADER_DECLARATIONS}
+struct TraceSpanBatch {
+  firstSpanIndex: u32,
+  spanCount: u32,
+  timeMin: f32,
+  timeMax: f32,
+  laneMin: u32,
+  laneMax: u32,
+  groupIndex: u32,
+  batchIndex: u32,
+};
+const BATCH_COUNT: u32 = ${batchCount}u;
+@group(0) @binding(0) var<storage, read> spanBatches: array<TraceSpanBatch>;
+@group(0) @binding(1) var<uniform> viewUniforms: ViewUniforms;
+@group(0) @binding(2) var<storage, read_write> candidateFlags: array<u32>;
+
+@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let batchIndex = globalId.x;
+  if (batchIndex >= BATCH_COUNT) {
+    return;
+  }
+  let batch = spanBatches[batchIndex];
+  let timeVisible = batch.timeMax >= viewUniforms.timeMin &&
+    batch.timeMin <= viewUniforms.timeMax;
+  let groupVisible = (viewUniforms.enabledMask & (1u << batch.groupIndex)) != 0u;
+  candidateFlags[batchIndex] = select(0u, 1u, timeVisible && groupVisible);
+}`;
+}
+
 /** Tests view, process, thread, status, duration, and source filters for one stable draw group. */
 export function getVisibilityShader(
   spanCount: number,

--- a/modules/engine/src/compute/computation.ts
+++ b/modules/engine/src/compute/computation.ts
@@ -243,6 +243,23 @@ export class Computation {
     }
   }
 
+  /** Dispatches a GPU-written workgroup count from an indirect buffer. */
+  dispatchIndirect(computePass: ComputePass, indirectBuffer: Buffer, indirectOffset = 0): void {
+    try {
+      this._logDrawCallStart();
+
+      this.pipeline = this._updatePipeline();
+      this.pipeline.setBindings(this.bindings);
+      computePass.setPipeline(this.pipeline);
+      // @ts-expect-error ComputePass implementations expose binding application internally.
+      computePass.setBindings({});
+
+      computePass.dispatchIndirect(indirectBuffer, indirectOffset);
+    } finally {
+      this._logDrawCallEnd();
+    }
+  }
+
   // Update fixed fields (can trigger pipeline rebuild)
 
   // Update dynamic fields

--- a/modules/engine/test/compute/computation.spec.ts
+++ b/modules/engine/test/compute/computation.spec.ts
@@ -73,6 +73,46 @@ test('Computation#compute', async t => {
   t.end();
 });
 
+test('Computation#dispatchIndirect', async t => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (webgpuDevice) {
+    if (isSoftwareBackedDevice(webgpuDevice)) {
+      t.comment('Skipping WebGPU indirect compute test on a software-backed adapter');
+      t.end();
+      return;
+    }
+
+    const computation = new Computation(webgpuDevice, {
+      source,
+      shaderLayout: {
+        bindings: [{name: 'data', type: 'storage', group: 0, location: 0}]
+      }
+    });
+    const workBuffer = webgpuDevice.createBuffer({
+      data: new Int32Array([1, 2, 3, 4]),
+      usage: Buffer.STORAGE | Buffer.COPY_SRC
+    });
+    const dispatchBuffer = webgpuDevice.createBuffer({
+      data: new Uint32Array([4, 1, 1]),
+      usage: Buffer.INDIRECT
+    });
+    computation.setBindings({data: workBuffer});
+
+    const computePass = webgpuDevice.beginComputePass({});
+    computation.dispatchIndirect(computePass, dispatchBuffer);
+    computePass.end();
+    webgpuDevice.submit();
+
+    const computedData = new Int32Array(await workBuffer.readAsync());
+    t.deepEqual(Array.from(computedData), [2, 4, 6, 8], 'GPU-written dimensions drive dispatch');
+
+    computation.destroy();
+    workBuffer.destroy();
+    dispatchBuffer.destroy();
+  }
+  t.end();
+});
+
 test('Computation#plugins assemble WGSL contributions', async t => {
   const webgpuDevice = await getWebGPUTestDevice();
   if (webgpuDevice) {

--- a/modules/experimental/src/gpu-primitives/dispatch-command-buffer.ts
+++ b/modules/experimental/src/gpu-primitives/dispatch-command-buffer.ts
@@ -1,0 +1,154 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUData} from '@luma.gl/tables';
+
+const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
+const DISPATCH_RECORD_WORDS = 3;
+
+/** CPU description of one WebGPU `dispatchWorkgroupsIndirect` record. */
+export type DispatchCommand = {
+  /** Workgroup count in the X dimension. */
+  x: number;
+  /** Workgroup count in the Y dimension. Defaults to `1`. */
+  y?: number;
+  /** Workgroup count in the Z dimension. Defaults to `1`. */
+  z?: number;
+};
+
+/** Properties for one typed WebGPU indirect-dispatch buffer. */
+export type DispatchCommandBufferProps = {
+  /** Buffer identifier. */
+  id?: string;
+  /** Record capacity. Defaults to `commands.length`. */
+  capacity?: number;
+  /** Optional initial CPU records. Unspecified capacity slots are zero-filled. */
+  commands?: DispatchCommand[];
+  /** Optional compatible caller-supplied buffer. */
+  buffer?: Buffer;
+  /** Whether `destroy()` should destroy a supplied buffer. Defaults to `false`. */
+  ownsBuffer?: boolean;
+};
+
+/** Typed owner or borrower of GPU-writable WebGPU indirect-dispatch records. */
+export class DispatchCommandBuffer {
+  /** Byte size of one indirect dispatch record. */
+  static readonly recordByteLength = DISPATCH_RECORD_WORDS * UINT32_BYTE_LENGTH;
+
+  /** WebGPU device owning the backing buffer. */
+  readonly device: Device;
+  /** Buffer identifier. */
+  readonly id: string;
+  /** Maximum record count. */
+  readonly capacity: number;
+  /** Concrete storage/indirect buffer. */
+  readonly buffer: Buffer;
+  private ownsBuffer: boolean;
+  private destroyed = false;
+
+  /** Creates or adopts an indirect-dispatch buffer and optionally uploads initial records. */
+  constructor(device: Device, props: DispatchCommandBufferProps) {
+    if (device.type !== 'webgpu') {
+      throw new Error('DispatchCommandBuffer requires a WebGPU device');
+    }
+    const commands = props.commands ?? [];
+    const capacity = props.capacity ?? commands.length;
+    if (!Number.isSafeInteger(capacity) || capacity < 1) {
+      throw new Error('DispatchCommandBuffer capacity must be a positive safe integer');
+    }
+    if (commands.length > capacity) {
+      throw new Error('DispatchCommandBuffer commands exceed capacity');
+    }
+
+    this.device = device;
+    this.id = props.id ?? 'dispatch-command-buffer';
+    this.capacity = capacity;
+    const byteLength = capacity * DispatchCommandBuffer.recordByteLength;
+    const requiredUsage = Buffer.STORAGE | Buffer.INDIRECT | Buffer.COPY_DST | Buffer.COPY_SRC;
+
+    if (props.buffer) {
+      if (props.buffer.device !== device) {
+        throw new Error('DispatchCommandBuffer buffer must belong to the supplied device');
+      }
+      if (props.buffer.byteLength < byteLength) {
+        throw new Error('DispatchCommandBuffer buffer is smaller than capacity');
+      }
+      if ((props.buffer.usage & requiredUsage) !== requiredUsage) {
+        throw new Error(
+          'DispatchCommandBuffer buffer requires STORAGE, INDIRECT, COPY_DST, and COPY_SRC usage'
+        );
+      }
+      this.buffer = props.buffer;
+      this.ownsBuffer = props.ownsBuffer ?? false;
+      if (commands.length > 0) {
+        this.buffer.write(makeDispatchCommandData(capacity, commands));
+      }
+    } else {
+      this.buffer = device.createBuffer({
+        id: this.id,
+        data: makeDispatchCommandData(capacity, commands),
+        usage: requiredUsage
+      });
+      this.ownsBuffer = true;
+    }
+  }
+
+  /** Returns the byte offset of one indirect record after validating its index. */
+  getCommandByteOffset(commandIndex: number): number {
+    this.validateCommandIndex(commandIndex);
+    return commandIndex * DispatchCommandBuffer.recordByteLength;
+  }
+
+  /** Returns a borrowed table view over one complete three-word dispatch record. */
+  getCommandData(commandIndex: number): GPUData<'uint32'> {
+    return new GPUData({
+      buffer: this.buffer,
+      format: 'uint32',
+      length: DISPATCH_RECORD_WORDS,
+      byteOffset: this.getCommandByteOffset(commandIndex),
+      byteStride: UINT32_BYTE_LENGTH,
+      rowByteLength: UINT32_BYTE_LENGTH,
+      ownsBuffer: false
+    });
+  }
+
+  /** Releases the backing buffer only when this wrapper owns it. */
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    if (this.ownsBuffer) {
+      this.buffer.destroy();
+      this.ownsBuffer = false;
+    }
+    this.destroyed = true;
+  }
+
+  private validateCommandIndex(commandIndex: number): void {
+    if (!Number.isSafeInteger(commandIndex) || commandIndex < 0 || commandIndex >= this.capacity) {
+      throw new Error(`DispatchCommandBuffer command index ${commandIndex} is out of range`);
+    }
+  }
+}
+
+/** Encodes validated CPU command descriptions into little-endian WebGPU indirect records. */
+function makeDispatchCommandData(capacity: number, commands: DispatchCommand[]): Uint32Array {
+  const data = new Uint32Array(capacity * DISPATCH_RECORD_WORDS);
+  commands.forEach((command, commandIndex) => {
+    const wordOffset = commandIndex * DISPATCH_RECORD_WORDS;
+    data[wordOffset] = validateUint32(command.x, 'x');
+    data[wordOffset + 1] = validateUint32(command.y ?? 1, 'y');
+    data[wordOffset + 2] = validateUint32(command.z ?? 1, 'z');
+  });
+  return data;
+}
+
+/** Validates one unsigned indirect-record component. */
+function validateUint32(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
+    throw new Error(`DispatchCommandBuffer ${name} must be a uint32 value`);
+  }
+  return value;
+}

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -166,3 +166,9 @@ export type {
   DrawCommandBufferProps,
   DrawIndexedCommand
 } from './draw-command-buffer';
+
+export {DispatchCommandBuffer} from './dispatch-command-buffer';
+export type {
+  DispatchCommand,
+  DispatchCommandBufferProps
+} from './dispatch-command-buffer';

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
@@ -5,7 +5,13 @@
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {Buffer, type Device, Texture} from '@luma.gl/core';
 import {DynamicBuffer, Model} from '@luma.gl/engine';
-import {DrawCommandBuffer, GPUCommandGraph, GPUCompaction, GPUScan} from '@luma.gl/experimental';
+import {
+  DispatchCommandBuffer,
+  DrawCommandBuffer,
+  GPUCommandGraph,
+  GPUCompaction,
+  GPUScan
+} from '@luma.gl/experimental';
 import {GPUData, GPUVector} from '@luma.gl/tables';
 import {getNullTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
 
@@ -952,6 +958,40 @@ test('DrawCommandBuffer replays an indirect draw through a render bundle', async
   model.destroy();
   framebuffer.destroy();
   colorTexture.destroy();
+  t.end();
+});
+
+test('DispatchCommandBuffer stores typed GPU-writable dispatch records', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const dispatchCommands = new DispatchCommandBuffer(device, {
+    capacity: 3,
+    commands: [{x: 2}, {x: 3, y: 4, z: 5}]
+  });
+  const bytes = await dispatchCommands.buffer.readAsync();
+  const values = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
+  t.deepEqual(
+    Array.from(values),
+    [2, 1, 1, 3, 4, 5, 0, 0, 0],
+    'records preserve WebGPU x/y/z layout and zero-fill capacity'
+  );
+  const secondCommand = dispatchCommands.getCommandData(1);
+  t.equal(secondCommand.length, 3, 'borrowed command data contains three uint32 rows');
+  t.equal(
+    secondCommand.byteOffset,
+    DispatchCommandBuffer.recordByteLength,
+    'borrowed command data points at the selected record'
+  );
+  t.throws(
+    () => dispatchCommands.getCommandByteOffset(3),
+    /out of range/,
+    'command index is bounded by capacity'
+  );
+  dispatchCommands.destroy();
   t.end();
 });
 

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -24,6 +24,7 @@ import {
   TRACE_THREADS_PER_PROCESS
 } from '../../examples/experimental/gpu-trace-viewer/trace-data';
 import {
+  getBatchVisibilityShader,
   getDependencyVisibilityShader,
   getFocusMaskShader,
   getPickClearShader,
@@ -42,12 +43,12 @@ test('GPU trace capacity options adapt to negotiated WebGPU buffer limits', t =>
   t.deepEqual(
     getTraceCapacityOptions(256 * 1024 * 1024, 1024 * 1024 * 1024),
     [250_000, 1_000_000, 4_000_000],
-    'larger limits retain the interactive demonstration ceiling'
+    'a 256 MiB storage binding remains below the ten-million-span requirement'
   );
   t.deepEqual(
     getTraceCapacityOptions(1024 * 1024 * 1024, 1024 * 1024 * 1024),
-    [250_000, 1_000_000, 4_000_000],
-    'maximum adapters retain the interactive demonstration ceiling'
+    [250_000, 1_000_000, 4_000_000, 10_000_000],
+    'maximum adapters expose the ten-million-span demonstration'
   );
   t.end();
 });
@@ -65,6 +66,7 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     TRACE_DEPENDENCY_RENDER_SHADER,
     TRACE_DENSITY_RENDER_SHADER,
     getFocusMaskShader(17),
+    getBatchVisibilityShader(3),
     getPickClearShader(),
     getVisibilityShader(17, 1, 5),
     getDependencyVisibilityShader(11)

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -3,7 +3,9 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {WgslReflect} from 'wgsl_reflect';
 import {
+  isTraceDensityMode,
   makeTraceDataset,
   makeTraceGroups,
   TRACE_CROSS_PROCESS_DEPENDENCY,
@@ -18,6 +20,38 @@ import {
   TRACE_THREAD_COUNT,
   TRACE_THREADS_PER_PROCESS
 } from '../../examples/experimental/gpu-trace-viewer/trace-data';
+import {
+  getDependencyVisibilityShader,
+  getFocusMaskShader,
+  getPickClearShader,
+  getVisibilityShader,
+  TRACE_DENSITY_RENDER_SHADER,
+  TRACE_DEPENDENCY_RENDER_SHADER,
+  TRACE_RENDER_SHADER
+} from '../../examples/experimental/gpu-trace-viewer/trace-shaders';
+
+test('GPU trace LOD switches at a stable trace-time-per-pixel threshold', t => {
+  t.equal(isTraceDensityMode(0, 150, 2048), false, 'wide viewport keeps exact spans');
+  t.equal(isTraceDensityMode(0, 150, 1), true, 'zoomed-out viewport uses density bins');
+  t.equal(isTraceDensityMode(10, 10.01, 0), false, 'zero-width viewport remains bounded');
+  t.end();
+});
+
+test('GPU trace adaptive LOD shaders parse as WGSL', t => {
+  const shaders = [
+    TRACE_RENDER_SHADER,
+    TRACE_DEPENDENCY_RENDER_SHADER,
+    TRACE_DENSITY_RENDER_SHADER,
+    getFocusMaskShader(17),
+    getPickClearShader(),
+    getVisibilityShader(17, 1, 5),
+    getDependencyVisibilityShader(11)
+  ];
+  for (const shader of shaders) {
+    t.ok(new WgslReflect(shader), 'shader parses');
+  }
+  t.end();
+});
 
 test('GPU trace data preserves deterministic canonical group and hierarchy identities', t => {
   const dataset = makeTraceDataset(257);

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -5,9 +5,11 @@
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {WgslReflect} from 'wgsl_reflect';
 import {
+  getTraceCapacityOptions,
   isTraceDensityMode,
   makeTraceDataset,
   makeTraceGroups,
+  makeTraceSpanBatches,
   TRACE_CROSS_PROCESS_DEPENDENCY,
   TRACE_DEPENDENCY_RECORD_WORD_LENGTH,
   TRACE_GROUPS,
@@ -17,6 +19,7 @@ import {
   TRACE_PROCESS_COUNT,
   TRACE_SAME_PROCESS_DEPENDENCY,
   TRACE_SPAN_RECORD_WORD_LENGTH,
+  TRACE_SPAN_BATCH_RECORD_WORD_LENGTH,
   TRACE_THREAD_COUNT,
   TRACE_THREADS_PER_PROCESS
 } from '../../examples/experimental/gpu-trace-viewer/trace-data';
@@ -29,6 +32,25 @@ import {
   TRACE_DEPENDENCY_RENDER_SHADER,
   TRACE_RENDER_SHADER
 } from '../../examples/experimental/gpu-trace-viewer/trace-shaders';
+
+test('GPU trace capacity options adapt to negotiated WebGPU buffer limits', t => {
+  t.deepEqual(
+    getTraceCapacityOptions(128 * 1024 * 1024, 256 * 1024 * 1024),
+    [250_000, 1_000_000, 4_000_000],
+    'portable limits retain the four-million-span ceiling'
+  );
+  t.deepEqual(
+    getTraceCapacityOptions(256 * 1024 * 1024, 1024 * 1024 * 1024),
+    [250_000, 1_000_000, 4_000_000],
+    'larger limits retain the interactive demonstration ceiling'
+  );
+  t.deepEqual(
+    getTraceCapacityOptions(1024 * 1024 * 1024, 1024 * 1024 * 1024),
+    [250_000, 1_000_000, 4_000_000],
+    'maximum adapters retain the interactive demonstration ceiling'
+  );
+  t.end();
+});
 
 test('GPU trace LOD switches at a stable trace-time-per-pixel threshold', t => {
   t.equal(isTraceDensityMode(0, 150, 2048), false, 'wide viewport keeps exact spans');
@@ -97,6 +119,71 @@ test('GPU trace data preserves deterministic canonical group and hierarchy ident
     makeTraceGroups(7).map(group => group.count),
     [2, 2, 3],
     'the original trace-group helper remains compatible'
+  );
+  t.end();
+});
+
+test('GPU trace span batches preserve global identity and publish coarse index bounds', t => {
+  const dataset = makeTraceDataset(11);
+  const {spanBatches, spanBatchIndex} = makeTraceSpanBatches(dataset.spans, dataset.groups, 2);
+  t.deepEqual(
+    spanBatches.map(batch => [batch.firstSpanIndex, batch.count, batch.groupIndex]),
+    [
+      [0, 2, 0],
+      [2, 1, 0],
+      [3, 2, 1],
+      [5, 1, 1],
+      [6, 2, 2],
+      [8, 2, 2],
+      [10, 1, 2]
+    ],
+    'batches remain group aligned and completely cover source rows'
+  );
+  t.equal(
+    spanBatchIndex.length,
+    spanBatches.length * TRACE_SPAN_BATCH_RECORD_WORD_LENGTH,
+    'publishes one fixed-width GPU index record per batch'
+  );
+  const spanFloats = new Float32Array(dataset.spans.buffer);
+  const indexFloats = new Float32Array(spanBatchIndex.buffer);
+  for (const batch of spanBatches) {
+    const indexOffset = batch.batchIndex * TRACE_SPAN_BATCH_RECORD_WORD_LENGTH;
+    t.equal(spanBatchIndex[indexOffset], batch.firstSpanIndex, 'index preserves global base');
+    t.equal(spanBatchIndex[indexOffset + 1], batch.count, 'index preserves batch length');
+    t.equal(spanBatchIndex[indexOffset + 6], batch.groupIndex, 'index preserves group identity');
+    t.equal(spanBatchIndex[indexOffset + 7], batch.batchIndex, 'index preserves batch identity');
+    t.ok(
+      Math.abs(indexFloats[indexOffset + 2] - batch.timeMin) < 0.001,
+      'index preserves minimum time'
+    );
+    t.ok(
+      Math.abs(indexFloats[indexOffset + 3] - batch.timeMax) < 0.001,
+      'index preserves maximum time'
+    );
+    for (let rowIndex = 0; rowIndex < batch.count; rowIndex++) {
+      const sourceIndex = batch.firstSpanIndex + rowIndex;
+      const wordOffset = sourceIndex * TRACE_SPAN_RECORD_WORD_LENGTH;
+      const start = spanFloats[wordOffset];
+      const end = start + spanFloats[wordOffset + 1];
+      const lane = dataset.spans[wordOffset + 2];
+      t.ok(start >= batch.timeMin && end <= batch.timeMax, 'batch encloses span time');
+      t.ok(lane >= batch.laneMin && lane < batch.laneMax, 'batch encloses span lane');
+    }
+  }
+  for (const group of dataset.groups) {
+    const groupBatches = spanBatches.filter(batch => batch.groupIndex === group.groupIndex);
+    for (let batchIndex = 1; batchIndex < groupBatches.length; batchIndex++) {
+      t.ok(
+        groupBatches[batchIndex].timeMin >= groupBatches[batchIndex - 1].timeMin,
+        'group batches retain increasing temporal locality'
+      );
+    }
+  }
+  t.equal(spanBatches[0].data.buffer, dataset.spans.buffer, 'batch borrows canonical storage');
+  t.throws(
+    () => makeTraceSpanBatches(dataset.spans, dataset.groups, 0),
+    /positive safe integer/,
+    'invalid batch capacity is rejected'
   );
   t.end();
 });
@@ -181,6 +268,8 @@ test('GPU trace data handles empty inputs and rejects invalid capacities', t => 
   t.equal(dataset.spans.length, 0, 'empty traces have no span rows');
   t.equal(dataset.dependencies.length, 0, 'empty traces have no dependency rows');
   t.equal(dataset.parentSpans.length, 0, 'empty traces have no canonical parent rows');
+  t.equal(dataset.spanBatches.length, 0, 'empty traces have no span batches');
+  t.equal(dataset.spanBatchIndex.length, 0, 'empty traces have no batch index records');
   t.deepEqual(Array.from(dataset.outgoing.offsets), [0], 'empty forward CSR has a sentinel');
   t.deepEqual(Array.from(dataset.incoming.offsets), [0], 'empty reverse CSR has a sentinel');
   t.throws(() => makeTraceDataset(-1), /nonnegative uint32/, 'negative capacity is rejected');

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -40,7 +40,7 @@ describe('GPU hierarchical trace viewer', () => {
       const state = viewer as unknown as {
         resources: {
           drawCommands: {buffer: {readAsync: () => Promise<Uint8Array>}};
-          activityBins: {readAsync: () => Promise<Uint8Array>};
+          densityBins: {readAsync: () => Promise<Uint8Array>};
           reachedSpans: {
             readAsync: (byteOffset?: number, byteLength?: number) => Promise<Uint8Array>;
           };
@@ -59,7 +59,7 @@ describe('GPU hierarchical trace viewer', () => {
       expect(host.querySelectorAll('[data-process]')).toHaveLength(TRACE_PROCESS_COUNT);
       expect(host.querySelectorAll('[data-thread]')).toHaveLength(TRACE_THREAD_COUNT);
 
-      viewer.onRender({device, time: 6000, width: 1, height: 1} as AnimationProps);
+      viewer.onRender({device, time: 6000, width: 2048, height: 1} as AnimationProps);
       device.submit();
       const firstFrame = await state.resources.drawCommands.buffer.readAsync();
       const firstCounts = new Uint32Array(
@@ -118,7 +118,7 @@ describe('GPU hierarchical trace viewer', () => {
       focusDepth!.dispatchEvent(new Event('input', {bubbles: true}));
       expect(state.focusDepth).toBe(3);
 
-      viewer.onRender({device, time: 6000, width: 1, height: 1} as AnimationProps);
+      viewer.onRender({device, time: 6000, width: 2048, height: 1} as AnimationProps);
       device.submit();
       const focusedFrame = await state.resources.drawCommands.buffer.readAsync();
       const focusedCounts = new Uint32Array(
@@ -134,13 +134,31 @@ describe('GPU hierarchical trace viewer', () => {
         Uint32Array.BYTES_PER_ELEMENT
       );
       expect(new Uint32Array(reachedBytes.buffer, reachedBytes.byteOffset, 1)[0]).toBe(1);
-      const activityBytes = await state.resources.activityBins.readAsync();
-      const activity = new Uint32Array(
-        activityBytes.buffer,
-        activityBytes.byteOffset,
-        activityBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+      const densityBytes = await state.resources.densityBins.readAsync();
+      const density = new Uint32Array(
+        densityBytes.buffer,
+        densityBytes.byteOffset,
+        densityBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
       );
-      expect(activity.some(value => value > 0)).toBe(true);
+      expect(density.some(value => value > 0)).toBe(true);
+
+      viewer.onRender({device, time: 6000, width: 1, height: 1} as AnimationProps);
+      device.submit();
+      const densityFrame = await state.resources.drawCommands.buffer.readAsync();
+      const densityCounts = new Uint32Array(
+        densityFrame.buffer,
+        densityFrame.byteOffset,
+        densityFrame.byteLength / Uint32Array.BYTES_PER_ELEMENT
+      );
+      expect(densityCounts[1] + densityCounts[5] + densityCounts[9]).toBe(0);
+      expect(densityCounts[13]).toBe(0);
+      const adaptiveDensityBytes = await state.resources.densityBins.readAsync();
+      const adaptiveDensity = new Uint32Array(
+        adaptiveDensityBytes.buffer,
+        adaptiveDensityBytes.byteOffset,
+        adaptiveDensityBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+      );
+      expect(adaptiveDensity.some(value => value > 0)).toBe(true);
 
       host.querySelector<HTMLButtonElement>('[data-clear-selection]')!.click();
       expect(state.selectedSpanIndex).toBe(0xffffffff);

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -8,6 +8,7 @@ import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import GPUTraceViewerAnimationLoopTemplate from '../../examples/experimental/gpu-trace-viewer/app';
 import {
   TRACE_COLLAPSED_STATE,
+  TRACE_DENSITY_BIN_COUNT,
   TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN,
   TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS,
   TRACE_PROCESS_COUNT,
@@ -154,6 +155,7 @@ describe('GPU hierarchical trace viewer', () => {
         adaptiveDensityBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
       );
       expect(adaptiveDensity.some(value => value > 0)).toBe(true);
+      expect(adaptiveDensity.slice(0, TRACE_DENSITY_BIN_COUNT).some(value => value > 0)).toBe(true);
 
       host.querySelector<HTMLButtonElement>('[data-clear-selection]')!.click();
       expect(state.selectedSpanIndex).toBe(0xffffffff);

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -134,14 +134,9 @@ describe('GPU hierarchical trace viewer', () => {
         Uint32Array.BYTES_PER_ELEMENT
       );
       expect(new Uint32Array(reachedBytes.buffer, reachedBytes.byteOffset, 1)[0]).toBe(1);
-      const densityBytes = await state.resources.densityBins.readAsync();
-      const density = new Uint32Array(
-        densityBytes.buffer,
-        densityBytes.byteOffset,
-        densityBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
-      );
-      expect(density.some(value => value > 0)).toBe(true);
-
+      focusOnly!.checked = false;
+      focusOnly!.dispatchEvent(new Event('change', {bubbles: true}));
+      expect(state.focusOnly).toBe(false);
       viewer.onRender({device, time: 6000, width: 1, height: 1} as AnimationProps);
       device.submit();
       const densityFrame = await state.resources.drawCommands.buffer.readAsync();

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -40,6 +40,7 @@ describe('GPU hierarchical trace viewer', () => {
       } as AnimationProps & {traceCapacity: number});
       const state = viewer as unknown as {
         resources: {
+          candidateDispatchCommands: {buffer: {readAsync: () => Promise<Uint8Array>}};
           drawCommands: {buffer: {readAsync: () => Promise<Uint8Array>}};
           densityBins: {readAsync: () => Promise<Uint8Array>};
           reachedSpans: {
@@ -47,6 +48,7 @@ describe('GPU hierarchical trace viewer', () => {
           };
           dependencyCount: number;
           spanCount: number;
+          spanBatchCount: number;
         };
         processStates: Uint32Array;
         threadStates: Uint32Array;
@@ -56,6 +58,7 @@ describe('GPU hierarchical trace viewer', () => {
         activeFilterMask: number;
       };
       expect(state.resources.spanCount).toBe(4096);
+      expect(state.resources.spanBatchCount).toBeGreaterThan(0);
       expect(state.resources.dependencyCount).toBeGreaterThan(0);
       expect(host.querySelectorAll('[data-process]')).toHaveLength(TRACE_PROCESS_COUNT);
       expect(host.querySelectorAll('[data-thread]')).toHaveLength(TRACE_THREAD_COUNT);
@@ -70,6 +73,28 @@ describe('GPU hierarchical trace viewer', () => {
       );
       expect(firstCounts[1] + firstCounts[5] + firstCounts[9]).toBeGreaterThan(0);
       expect(firstCounts[13]).toBeGreaterThan(0);
+      const candidateBytes = await state.resources.candidateDispatchCommands.buffer.readAsync();
+      const candidateCount = new Uint32Array(
+        candidateBytes.buffer,
+        candidateBytes.byteOffset,
+        1
+      )[0];
+      expect(candidateCount).toBeGreaterThan(0);
+      expect(candidateCount).toBeLessThanOrEqual(state.resources.spanBatchCount);
+
+      const firstGroup = host.querySelector<HTMLInputElement>('[data-group="0"]');
+      expect(firstGroup).not.toBeNull();
+      firstGroup!.checked = false;
+      firstGroup!.dispatchEvent(new Event('change', {bubbles: true}));
+      viewer.onRender({device, time: 6000, width: 2048, height: 1} as AnimationProps);
+      device.submit();
+      const filteredCandidateBytes =
+        await state.resources.candidateDispatchCommands.buffer.readAsync();
+      expect(
+        new Uint32Array(filteredCandidateBytes.buffer, filteredCandidateBytes.byteOffset, 1)[0]
+      ).toBeLessThan(candidateCount);
+      firstGroup!.checked = true;
+      firstGroup!.dispatchEvent(new Event('change', {bubbles: true}));
 
       const firstProcess = host.querySelector<HTMLInputElement>('[data-process="0"]');
       expect(firstProcess).not.toBeNull();


### PR DESCRIPTION
## Summary

- switch automatically between exact compacted spans and per-lane density bins based on trace time per viewport pixel
- generate density keys during visibility evaluation and aggregate focused, filtered rows with `GPUGroupAggregation`
- suppress exact spans and dependency edges in density mode without rebuilding the command graph
- retain density rendering for collapsed processes while exact mode is active
- report the active trace LOD in the live inspector
- replace the bespoke histogram clear and accumulation shaders with the reusable graph primitive

This follows merged PR #2817, which introduced the readback ring used by the trace viewer.

## Verification

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn workspace luma.gl-examples-experimental-gpu-trace-viewer build`
- `yarn test-node test/examples/gpu-trace-viewer.node.spec.ts` — 5 passed
- full Node portion of `yarn test` and the commit hook — 256 passed, 2 skipped
- all trace WGSL variants parsed with `wgsl_reflect`

The browser portion of `yarn test` could not start in the local environment: Playwright Chromium aborted during launch with `SIGABRT` and `kill EPERM`, before any browser tests executed.