### PR TITLE
feat(showcase): finish Lightstorm HDR showcase

### DIFF
--- a/docs/api-guide/shaders/rendering-techniques.md
+++ b/docs/api-guide/shaders/rendering-techniques.md
@@ -304,8 +304,10 @@ renderer.renderToScreen({
     gtaoTemporal: {inverseProjectionMatrix},
     ssgiTrace: {projectionMatrix, inverseProjectionMatrix},
     ssgiTemporal: {inverseProjectionMatrix},
-    ssrTrace: {projectionMatrix, inverseProjectionMatrix},
-    ssrTemporal: {inverseProjectionMatrix}
+    ssrTrace: {projectionMatrix, inverseProjectionMatrix, frameIndex},
+    ssrTemporal: {inverseProjectionMatrix},
+    ssrSpatial: {inverseProjectionMatrix},
+    ssrComposite: {inverseProjectionMatrix}
   }
 });
 ```

--- a/examples/experimental/advanced-effects/app.ts
+++ b/examples/experimental/advanced-effects/app.ts
@@ -695,7 +695,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
                 : 36
         },
         ssrTemporal: {inverseProjectionMatrix},
-        ssrComposite: {debugMode: this.settings.debugView === 'Reflections' ? 1 : 0},
+        ssrSpatial: {inverseProjectionMatrix},
+        ssrComposite: {
+          inverseProjectionMatrix,
+          debugMode: this.settings.debugView === 'Reflections' ? 1 : 0
+        },
         volumetricFog: {
           density: this.settings.preset === 'Foggy Depth' ? 0.2 : 0.08,
           historyWeight: this.settings.shadowQuality === 'low' ? 0.08 : 0.18,

--- a/examples/experimental/deferred-rendering/app.ts
+++ b/examples/experimental/deferred-rendering/app.ts
@@ -880,7 +880,9 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           inverseProjectionMatrix,
           historyWeight: this.settings.reflectionHistoryWeight
         },
+        ssrSpatial: {inverseProjectionMatrix},
         ssrComposite: {
+          inverseProjectionMatrix,
           strength: this.settings.reflectionStrength,
           debugMode:
             this.settings.debugView === 'Reflections'

--- a/examples/showcase/lightstorm-megacity/app.ts
+++ b/examples/showcase/lightstorm-megacity/app.ts
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, Texture, type Device, type RenderBundle} from '@luma.gl/core';
-import {createBloomShaderPassPipeline, toneMapping} from '@luma.gl/effects';
+import {Buffer, type Device, type RenderBundle, type TextureFormatColor} from '@luma.gl/core';
+import {
+  createBloomShaderPassPipeline,
+  createSSRShaderPassPipeline,
+  toneMapping
+} from '@luma.gl/effects';
 import type {AnimationProps} from '@luma.gl/engine';
 import {
   AnimationLoopTemplate,
@@ -13,57 +17,69 @@ import {
   ShaderPassRenderer
 } from '@luma.gl/engine';
 import {
+  ClusteredLightGrid,
   decodeGPUIndexPickInfo,
   DrawCommandBuffer,
+  GBuffer,
   GPUCommandGraph,
   GPUIndexPickingTarget,
   GPUVisibilityWorkflow,
   INDEX_PICKING_READBACK_BYTE_LENGTH,
+  makeDeferredPointLightBufferData,
   type CompiledGPUCommandGraph
 } from '@luma.gl/experimental';
-import {Matrix4} from '@math.gl/core';
+import {Matrix4, type NumberArray3} from '@math.gl/core';
 import {ColumnPanel, type Panel} from '@deck.gl-community/panels';
 import {
   ExamplePanelManager,
   makeExamplePanelHostHtml,
   makeHtmlCustomPanel
 } from '../../example-panels';
+import {
+  getLightstormGuidedCameraSample,
+  LIGHTSTORM_CAMERA_FIELD_OF_VIEW,
+  makeLightstormGuidedCameraTour,
+  type LightstormCameraSample,
+  type LightstormGuidedCameraTour
+} from './lightstorm-camera';
 import {makeLightstormCity, type LightstormCityMetadata} from './lightstorm-data';
 import {
+  LIGHTSTORM_POINT_LIGHT_COUNT,
+  makeLightstormLightMarkerBufferData,
+  makeLightstormPointLights,
+  makeLightstormViewPointLights,
+  type LightstormPointLight
+} from './lightstorm-lighting';
+import {
+  LIGHTSTORM_LIGHTNING_SEGMENT_COUNT,
+  LIGHTSTORM_LIGHTNING_SEGMENT_WORD_COUNT,
+  getLightstormLightningSkyPulse,
+  makeLightstormLightningBolts,
+  makeLightstormLightningBufferData,
+  makeLightstormLightningSegments
+} from './lightstorm-lightning';
+import {LightstormThunderController} from './lightstorm-thunder';
+import {
+  createLightstormDeferredLightingShaderPassPipeline,
   getLightstormVisibilityShader,
+  LIGHTSTORM_LIGHTNING_SHADER,
+  LIGHTSTORM_LIGHT_MARKER_SHADER,
   LIGHTSTORM_PICKING_SHADER,
   LIGHTSTORM_RENDER_SHADER
 } from './lightstorm-shaders';
 
 export const title = 'Lightstorm Megacity';
 export const description =
-  'A million-record city filtered, culled, compacted, picked, and indirectly rendered on WebGPU.';
+  'A million-record city culled, compacted, clustered, lit, and indirectly rendered on WebGPU.';
 
 const CAPACITY_OPTIONS = [50_000, 250_000, 1_000_000] as const;
 const DEFAULT_CAPACITY = 250_000;
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
-const UNIFORM_BYTE_LENGTH = 176;
+const UNIFORM_BYTE_LENGTH = 240;
 const NEAR_PLANE = 0.1;
-const FIELD_OF_VIEW = Math.PI / 3.15;
 const TRIANGLES_PER_INSTANCE = 12;
 
 type LightstormDataLayer = 'all' | 'towers' | 'transit';
-
-type CameraPose = {
-  target: [number, number, number];
-  yaw: number;
-  pitch: number;
-  distance: number;
-  duration: number;
-};
-
-const GUIDED_CAMERA_POSES: readonly CameraPose[] = [
-  {target: [0, 24, 0], yaw: 0.64, pitch: 0.16, distance: 220, duration: 8},
-  {target: [92, 10, -54], yaw: 1.36, pitch: 0.06, distance: 82, duration: 6},
-  {target: [-86, 17, 96], yaw: 2.72, pitch: 0.12, distance: 96, duration: 7},
-  {target: [0, 31, 0], yaw: 4.05, pitch: 0.52, distance: 158, duration: 7},
-  {target: [0, 6, 0], yaw: 5.42, pitch: 1.02, distance: 410, duration: 8}
-];
 
 type LightstormGraphResources = {
   compiled: CompiledGPUCommandGraph<LightstormGraphParameters>;
@@ -73,8 +89,9 @@ type LightstormGraphResources = {
   pickingHeight: number;
   drawCommands: DrawCommandBuffer;
   instances: Buffer;
+  lightMarkers: Buffer;
   visibleIdentifiers: Buffer;
-  sceneColor: Texture;
+  sceneGBuffer: GBuffer;
   perspectiveRenderBundle: RenderBundle;
   overviewRenderBundle: RenderBundle;
 };
@@ -93,20 +110,36 @@ type LightstormPickingGraphParameters = {
   pixel: readonly [number, number];
 };
 
+type LightstormCameraState = {
+  viewMatrix: Matrix4;
+  projectionMatrix: Matrix4;
+  inverseProjectionMatrix: Matrix4;
+  viewProjectionMatrix: Matrix4;
+  farPlane: number;
+  lightningSkyPulse: number;
+};
+
 export default class LightstormMegacityAnimationLoopTemplate extends AnimationLoopTemplate {
   static info = makeExamplePanelHostHtml();
   static props = {createFramebuffer: true, debug: true};
 
   readonly device: Device;
   readonly model: Model;
+  readonly lightMarkerModel: Model;
+  readonly lightningModel: Model;
   readonly pickingModel: Model;
   readonly sceneColorFormat: LightstormSceneColorFormat;
+  readonly deferredLightingRenderer: ShaderPassRenderer;
   readonly postprocessingRenderer: ShaderPassRenderer;
+  readonly pointLightBuffer: Buffer;
+  readonly lightningBuffer: Buffer;
+  readonly clusteredLightGrid: ClusteredLightGrid;
   readonly uniformBuffer: Buffer;
   readonly overviewUniformBuffer: Buffer;
   readonly panels: ExamplePanelManager;
 
   private resources: LightstormGraphResources | null = null;
+  private readonly thunderAudio = new LightstormThunderController();
   private cityMetadata: LightstormCityMetadata = {
     gridSize: 1,
     fieldHalfExtent: 1,
@@ -120,9 +153,21 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
   private pitch = 0.28;
   private distance = 300;
   private guidedCamera = true;
-  private guidedCameraStartMilliseconds = 0;
+  private guidedCameraStartMilliseconds: number | null = null;
   private currentTimeMilliseconds = 0;
-  private currentCameraPose: CameraPose = GUIDED_CAMERA_POSES[0];
+  private guidedCameraTour!: LightstormGuidedCameraTour;
+  private currentCameraPose: LightstormCameraSample = {
+    eye: [0, 40, 120],
+    target: [0, 20, 0],
+    yaw: Math.PI,
+    pitch: 0.16,
+    distance: 121.66,
+    duration: 0,
+    shot: 'avenue establish'
+  };
+  private previousViewProjectionMatrix: Matrix4 | null = null;
+  private pointLights: readonly LightstormPointLight[] = [];
+  private activeClusteredLightCount = 0;
   private lightstormEnabled = true;
   private cullingEnabled = true;
   private comparisonView = false;
@@ -146,6 +191,8 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
   private statsElement: HTMLElement | null = null;
   private nodesElement: HTMLElement | null = null;
   private guidedCameraElement: HTMLInputElement | null = null;
+  private thunderStatusElement: HTMLElement | null = null;
+  private thunderActivationButton: HTMLButtonElement | null = null;
 
   constructor({
     device,
@@ -171,7 +218,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       id: 'lightstorm-megacity-model',
       source: LIGHTSTORM_RENDER_SHADER,
       geometry: new CubeGeometry({id: 'lightstorm-megacity-cube', indices: true}),
-      colorAttachmentFormats: [this.sceneColorFormat],
+      colorAttachmentFormats: getSceneGBufferColorFormats(this.sceneColorFormat),
       depthStencilAttachmentFormat: 'depth24plus',
       shaderLayout: {
         attributes: [
@@ -188,6 +235,60 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
         cullMode: 'back',
         depthCompare: 'less-equal',
         depthWriteEnabled: true
+      }
+    });
+    this.lightMarkerModel = new Model(device, {
+      id: 'lightstorm-megacity-light-marker-model',
+      source: LIGHTSTORM_LIGHT_MARKER_SHADER,
+      geometry: new CubeGeometry({id: 'lightstorm-megacity-light-marker-cube', indices: true}),
+      instanceCount: LIGHTSTORM_POINT_LIGHT_COUNT * 2,
+      colorAttachmentFormats: getSceneGBufferColorFormats(this.sceneColorFormat),
+      depthStencilAttachmentFormat: 'depth24plus',
+      shaderLayout: {
+        attributes: [
+          {name: 'positions', location: 0, type: 'vec3<f32>'},
+          {name: 'normals', location: 1, type: 'vec3<f32>'}
+        ],
+        bindings: [
+          {name: 'lightMarkers', type: 'read-only-storage', group: 0, location: 0},
+          {name: 'uniforms', type: 'uniform', group: 0, location: 1}
+        ]
+      },
+      parameters: {
+        cullMode: 'back',
+        depthCompare: 'less-equal',
+        depthWriteEnabled: true
+      }
+    });
+    this.lightningBuffer = device.createBuffer({
+      id: 'lightstorm-megacity-lightning-segments',
+      byteLength:
+        LIGHTSTORM_LIGHTNING_SEGMENT_COUNT *
+        LIGHTSTORM_LIGHTNING_SEGMENT_WORD_COUNT *
+        Float32Array.BYTES_PER_ELEMENT,
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    this.lightningModel = new Model(device, {
+      id: 'lightstorm-megacity-lightning-model',
+      source: LIGHTSTORM_LIGHTNING_SHADER,
+      geometry: new CubeGeometry({id: 'lightstorm-megacity-lightning-cube', indices: true}),
+      instanceCount: LIGHTSTORM_LIGHTNING_SEGMENT_COUNT,
+      colorAttachmentFormats: getSceneGBufferColorFormats(this.sceneColorFormat),
+      depthStencilAttachmentFormat: 'depth24plus',
+      shaderLayout: {
+        attributes: [
+          {name: 'positions', location: 0, type: 'vec3<f32>'},
+          {name: 'normals', location: 1, type: 'vec3<f32>'}
+        ],
+        bindings: [
+          {name: 'lightningSegments', type: 'read-only-storage', group: 0, location: 0},
+          {name: 'uniforms', type: 'uniform', group: 0, location: 1}
+        ]
+      },
+      parameters: {
+        cullMode: 'none',
+        depthCompare: 'less-equal',
+        depthWriteEnabled: false
       }
     });
     this.pickingModel = new Model(device, {
@@ -213,6 +314,24 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
         depthWriteEnabled: true
       }
     });
+    this.pointLightBuffer = device.createBuffer({
+      id: 'lightstorm-megacity-point-lights',
+      data: makeDeferredPointLightBufferData([], LIGHTSTORM_POINT_LIGHT_COUNT),
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    this.clusteredLightGrid = new ClusteredLightGrid(device, {
+      id: 'lightstorm-megacity-clustered-lights',
+      maxLightCount: LIGHTSTORM_POINT_LIGHT_COUNT
+    });
+    this.deferredLightingRenderer = new ShaderPassRenderer(device, {
+      shaderPasses: [
+        createLightstormDeferredLightingShaderPassPipeline(this.sceneColorFormat),
+        ...(this.sceneColorFormat === 'rgba16float'
+          ? [createSSRShaderPassPipeline({resolutionScale: 0.5})]
+          : [])
+      ],
+      colorFormat: this.sceneColorFormat
+    });
     this.postprocessingRenderer = new ShaderPassRenderer(device, {
       shaderPasses: [
         createBloomShaderPassPipeline({colorFormat: this.sceneColorFormat}),
@@ -235,6 +354,8 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       canvas.addEventListener('pointercancel', this.handlePointerUp);
       canvas.addEventListener('wheel', this.handleWheel, {passive: false});
     }
+    window.addEventListener('keydown', this.handleThunderActivation, {capture: true});
+    this.mountThunderActivationButton();
   }
 
   override onRender({
@@ -259,11 +380,93 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       }
     }
     const viewports = getViewports(width, height, this.comparisonView);
-    this.writeUniforms(viewports, time);
+    const cameraState = this.writeUniforms(viewports, time);
     const encodeStart = performance.now();
+    if (!this.comparisonView) {
+      const viewPointLights = makeLightstormViewPointLights(
+        this.pointLights,
+        cameraState.viewMatrix,
+        time / 1000,
+        this.lightstormEnabled
+      );
+      this.pointLightBuffer.write(
+        makeDeferredPointLightBufferData(viewPointLights, LIGHTSTORM_POINT_LIGHT_COUNT)
+      );
+      this.clusteredLightGrid.encode(device.commandEncoder, {
+        pointLights: this.pointLightBuffer,
+        pointLightCount: viewPointLights.length,
+        projectionMatrix: cameraState.projectionMatrix,
+        nearPlane: NEAR_PLANE,
+        farPlane: cameraState.farPlane
+      });
+      this.activeClusteredLightCount = viewPointLights.length;
+    } else {
+      this.activeClusteredLightCount = 0;
+    }
     resources.compiled.encode(device.commandEncoder, {parameters: viewports});
+    let postprocessingSource = resources.sceneGBuffer.colorTexture;
+    if (!this.comparisonView) {
+      const directionalLightDirectionView = normalizeVector3(
+        cameraState.viewMatrix.transformAsVector([0.36, 0.82, 0.44]) as NumberArray3
+      );
+      const litTexture = this.deferredLightingRenderer.encodeToTexture(device.commandEncoder, {
+        sourceTexture: resources.sceneGBuffer.colorTexture,
+        bindings: {
+          depthTexture: resources.sceneGBuffer.depthTexture,
+          normalTexture: resources.sceneGBuffer.normalRoughnessTexture,
+          velocityTexture: resources.sceneGBuffer.velocityTexture,
+          baseColorMetallicTexture:
+            resources.sceneGBuffer.getExtraColorTexture('baseColorMetallic'),
+          emissiveOcclusionTexture:
+            resources.sceneGBuffer.getExtraColorTexture('emissiveOcclusion'),
+          pointLights: this.pointLightBuffer,
+          ...this.clusteredLightGrid.getShaderPassBindings()
+        },
+        uniforms: {
+          clusteredDeferredLighting: {
+            inverseProjectionMatrix: cameraState.inverseProjectionMatrix,
+            ambientColor: getLightstormAmbientColor(cameraState.lightningSkyPulse),
+            directionalLightDirectionView,
+            directionalLightColor: [1, 0.84, 0.68],
+            directionalLightIntensity: 2.25,
+            ...this.clusteredLightGrid.getShaderPassUniforms(NEAR_PLANE, cameraState.farPlane)
+          },
+          lightstormDeferredComposite: {
+            inverseProjectionMatrix: cameraState.inverseProjectionMatrix,
+            fogColor: getLightstormFogColor(cameraState.lightningSkyPulse)
+          },
+          ssrTrace: {
+            projectionMatrix: cameraState.projectionMatrix,
+            inverseProjectionMatrix: cameraState.inverseProjectionMatrix,
+            intensity: 1.5,
+            maxDistance: 36,
+            thickness: 0.75,
+            sampleCount: 72,
+            maxRoughness: 0.6,
+            frameIndex: this.frameIndex
+          },
+          ssrTemporal: {
+            inverseProjectionMatrix: cameraState.inverseProjectionMatrix,
+            historyWeight: 0.82
+          },
+          ssrSpatial: {
+            inverseProjectionMatrix: cameraState.inverseProjectionMatrix,
+            maxRadius: 4.5,
+            depthSigma: 0.04
+          },
+          ssrComposite: {
+            inverseProjectionMatrix: cameraState.inverseProjectionMatrix,
+            strength: 0.8,
+            depthSigma: 0.04
+          }
+        }
+      });
+      if (litTexture) {
+        postprocessingSource = litTexture;
+      }
+    }
     this.postprocessingRenderer.encodeToScreen(device.commandEncoder, {
-      sourceTexture: resources.sceneColor,
+      sourceTexture: postprocessingSource,
       uniforms: {
         bloomExtract: {
           threshold: this.sceneColorFormat === 'rgba16float' ? 0.8 : 0.55
@@ -272,7 +475,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
         bloomComposite: {intensity: 0.55},
         toneMapping: {
           exposure: this.sceneColorFormat === 'rgba16float' ? 0.92 : 1,
-          maximumLuminance: device.preferredColorFormat === 'rgba16float' ? 2.4 : 1
+          maximumLuminance: device.preferredColorFormat === 'rgba16float' ? 1.8 : 1
         }
       }
     });
@@ -317,10 +520,19 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       this.canvas.removeEventListener('pointercancel', this.handlePointerUp);
       this.canvas.removeEventListener('wheel', this.handleWheel);
     }
+    window.removeEventListener('keydown', this.handleThunderActivation, {capture: true});
+    this.unmountThunderActivationButton();
     this.panels.finalize();
+    this.thunderAudio.destroy();
     this.destroyResources();
+    this.deferredLightingRenderer.destroy();
     this.postprocessingRenderer.destroy();
+    this.clusteredLightGrid.destroy();
+    this.pointLightBuffer.destroy();
     this.pickingModel.destroy();
+    this.lightningModel.destroy();
+    this.lightningBuffer.destroy();
+    this.lightMarkerModel.destroy();
     this.model.destroy();
     this.uniformBuffer.destroy();
     this.overviewUniformBuffer.destroy();
@@ -331,6 +543,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     this.destroyResources();
     this.capacity = capacity;
     const city = makeLightstormCity(capacity);
+    this.guidedCameraTour = makeLightstormGuidedCameraTour(city);
     this.cityMetadata = {
       gridSize: city.gridSize,
       fieldHalfExtent: city.fieldHalfExtent,
@@ -355,24 +568,40 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     const deviceSize = this.device.getDefaultCanvasContext().getDevicePixelSize();
     const pickingWidth = Math.max(1, deviceSize[0]);
     const pickingHeight = Math.max(1, deviceSize[1]);
-    const sceneColor = this.device.createTexture({
-      id: 'lightstorm-megacity-scene-color',
-      format: this.sceneColorFormat,
-      width: pickingWidth,
-      height: pickingHeight,
-      usage: Texture.SAMPLE | Texture.RENDER,
-      sampler: {
-        minFilter: 'linear',
-        magFilter: 'linear',
-        addressModeU: 'clamp-to-edge',
-        addressModeV: 'clamp-to-edge'
-      }
-    });
+    const lightningBolts = makeLightstormLightningBolts(
+      this.guidedCameraTour,
+      pickingWidth / pickingHeight
+    );
+    this.lightningBuffer.write(
+      makeLightstormLightningBufferData(makeLightstormLightningSegments(lightningBolts))
+    );
+    const sceneGBuffer = createSceneGBuffer(
+      this.device,
+      pickingWidth,
+      pickingHeight,
+      this.sceneColorFormat
+    );
+    this.deferredLightingRenderer.resize([pickingWidth, pickingHeight]);
+    this.deferredLightingRenderer.resetHistory();
     this.postprocessingRenderer.resize([pickingWidth, pickingHeight]);
+    this.pointLights = makeLightstormPointLights(
+      LIGHTSTORM_POINT_LIGHT_COUNT,
+      this.cityMetadata.gridSize
+    );
+    const lightMarkers = this.device.createBuffer({
+      id: 'lightstorm-megacity-light-markers',
+      data: makeLightstormLightMarkerBufferData(this.pointLights),
+      usage: Buffer.STORAGE
+    });
+    this.lightMarkerModel.setInstanceCount(this.pointLights.length * 2);
+    this.previousViewProjectionMatrix = null;
+    this.activeClusteredLightCount = 0;
     const perspectiveRenderBundle = this.createRenderBundle(
       'lightstorm-megacity-perspective-render-bundle',
       instances,
       visibleIdentifiers,
+      lightMarkers,
+      this.lightningBuffer,
       drawCommands,
       this.uniformBuffer
     );
@@ -380,6 +609,8 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       'lightstorm-megacity-overview-render-bundle',
       instances,
       visibleIdentifiers,
+      lightMarkers,
+      this.lightningBuffer,
       drawCommands,
       this.overviewUniformBuffer
     );
@@ -387,10 +618,12 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       capacity,
       instances,
       visibleIdentifiers,
+      lightMarkers,
+      this.lightningBuffer,
       drawCommands,
       perspectiveRenderBundle,
       overviewRenderBundle,
-      sceneColor
+      sceneGBuffer
     );
     const picking = this.createPickingGraph(
       pickingWidth,
@@ -407,8 +640,9 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       pickingHeight,
       drawCommands,
       instances,
+      lightMarkers,
       visibleIdentifiers,
-      sceneColor,
+      sceneGBuffer,
       perspectiveRenderBundle,
       overviewRenderBundle
     };
@@ -423,10 +657,12 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     capacity: number,
     instancesBuffer: Buffer,
     visibleIdentifiersBuffer: Buffer,
+    lightMarkersBuffer: Buffer,
+    lightningBuffer: Buffer,
     drawCommands: DrawCommandBuffer,
     perspectiveRenderBundle: RenderBundle,
     overviewRenderBundle: RenderBundle,
-    sceneColorTexture: Texture
+    sceneGBuffer: GBuffer
   ): CompiledGPUCommandGraph<LightstormGraphParameters> {
     const graph = new GPUCommandGraph<LightstormGraphParameters>(this.device, {
       id: 'lightstorm-megacity-command-graph'
@@ -442,6 +678,22 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
         usage: visibleIdentifiersBuffer.usage
       },
       visibleIdentifiersBuffer
+    );
+    const lightMarkers = graph.importBuffer(
+      {
+        id: 'light-markers',
+        byteLength: lightMarkersBuffer.byteLength,
+        usage: lightMarkersBuffer.usage
+      },
+      lightMarkersBuffer
+    );
+    const lightningSegments = graph.importBuffer(
+      {
+        id: 'lightning-segments',
+        byteLength: lightningBuffer.byteLength,
+        usage: lightningBuffer.usage
+      },
+      lightningBuffer
     );
     const uniforms = graph.importBuffer(
       {id: 'uniforms', byteLength: this.uniformBuffer.byteLength, usage: this.uniformBuffer.usage},
@@ -463,6 +715,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       },
       drawCommands.buffer
     );
+    const sceneColorTexture = sceneGBuffer.colorTexture;
     const sceneColor = graph.importTexture(
       {
         id: 'scene-color',
@@ -473,14 +726,66 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       },
       sceneColorTexture
     );
-    const sceneDepth = graph.createTransientTexture({
-      id: 'scene-depth',
-      format: 'depth24plus',
-      width: sceneColorTexture.width,
-      height: sceneColorTexture.height,
-      usage: Texture.RENDER
-    });
+    const sceneNormalTexture = sceneGBuffer.normalRoughnessTexture;
+    const sceneNormal = graph.importTexture(
+      {
+        id: 'scene-normal-roughness',
+        format: sceneNormalTexture.format,
+        width: sceneNormalTexture.width,
+        height: sceneNormalTexture.height,
+        usage: sceneNormalTexture.props.usage
+      },
+      sceneNormalTexture
+    );
+    const sceneVelocityTexture = sceneGBuffer.velocityTexture;
+    const sceneVelocity = graph.importTexture(
+      {
+        id: 'scene-velocity',
+        format: sceneVelocityTexture.format,
+        width: sceneVelocityTexture.width,
+        height: sceneVelocityTexture.height,
+        usage: sceneVelocityTexture.props.usage
+      },
+      sceneVelocityTexture
+    );
+    const baseColorMetallicTexture = sceneGBuffer.getExtraColorTexture('baseColorMetallic');
+    const baseColorMetallic = graph.importTexture(
+      {
+        id: 'scene-base-color-metallic',
+        format: baseColorMetallicTexture.format,
+        width: baseColorMetallicTexture.width,
+        height: baseColorMetallicTexture.height,
+        usage: baseColorMetallicTexture.props.usage
+      },
+      baseColorMetallicTexture
+    );
+    const emissiveOcclusionTexture = sceneGBuffer.getExtraColorTexture('emissiveOcclusion');
+    const emissiveOcclusion = graph.importTexture(
+      {
+        id: 'scene-emissive-occlusion',
+        format: emissiveOcclusionTexture.format,
+        width: emissiveOcclusionTexture.width,
+        height: emissiveOcclusionTexture.height,
+        usage: emissiveOcclusionTexture.props.usage
+      },
+      emissiveOcclusionTexture
+    );
+    const sceneDepthTexture = sceneGBuffer.depthTexture;
+    const sceneDepth = graph.importTexture(
+      {
+        id: 'scene-depth',
+        format: sceneDepthTexture.format,
+        width: sceneDepthTexture.width,
+        height: sceneDepthTexture.height,
+        usage: sceneDepthTexture.props.usage
+      },
+      sceneDepthTexture
+    );
     const sceneColorView = graph.createTextureView(sceneColor);
+    const sceneNormalView = graph.createTextureView(sceneNormal);
+    const sceneVelocityView = graph.createTextureView(sceneVelocity);
+    const baseColorMetallicView = graph.createTextureView(baseColorMetallic);
+    const emissiveOcclusionView = graph.createTextureView(emissiveOcclusion);
     const sceneDepthView = graph.createTextureView(sceneDepth);
     const flagsBuffer = graph.createTransientBuffer({
       id: 'visibility-flags',
@@ -541,12 +846,20 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     graph.addRenderPass({
       id: 'render-visible-city',
       attachments: {
-        colorAttachments: [sceneColorView],
+        colorAttachments: [
+          sceneColorView,
+          sceneNormalView,
+          sceneVelocityView,
+          baseColorMetallicView,
+          emissiveOcclusionView
+        ],
         depthStencilAttachment: sceneDepthView
       },
       resources: [
         {buffer: instances, usage: 'storage-read'},
         {buffer: visibleIdentifiers, usage: 'storage-read'},
+        {buffer: lightMarkers, usage: 'storage-read'},
+        {buffer: lightningSegments, usage: 'storage-read'},
         {buffer: uniforms, usage: 'uniform'},
         {buffer: overviewUniforms, usage: 'uniform'},
         {buffer: drawCommandBuffer, usage: 'indirect'}
@@ -554,7 +867,13 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       compile: () => ({
         getRenderPassProps: () => ({
           id: 'lightstorm-megacity-render-pass',
-          clearColor: [0.0015, 0.003, 0.012, 1],
+          clearColors: [
+            new Float32Array([0.0015, 0.003, 0.012, 1]),
+            new Float32Array([0.5, 0.5, 1, 1]),
+            new Float32Array([0, 0, 0, 0]),
+            new Float32Array([0, 0, 0, 0]),
+            new Uint32Array([0, 0, 0, 0])
+          ],
           clearDepth: 1,
           clearStencil: false
         }),
@@ -657,65 +976,88 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     identifier: string,
     instances: Buffer,
     visibleIdentifiers: Buffer,
+    lightMarkers: Buffer,
+    lightningSegments: Buffer,
     drawCommands: DrawCommandBuffer,
     uniforms: Buffer
   ): RenderBundle {
     const encoder = this.device.createRenderBundleEncoder({
       id: identifier,
-      colorAttachmentFormats: [this.sceneColorFormat],
+      colorAttachmentFormats: getSceneGBufferColorFormats(this.sceneColorFormat),
       depthStencilAttachmentFormat: 'depth24plus'
     });
     encoder.setPipeline(this.model.pipeline);
     encoder.setVertexArray(this.model.vertexArray);
     encoder.setBindings({instances, visibleIds: visibleIdentifiers, uniforms});
     drawCommands.draw(encoder, 0);
+    encoder.setPipeline(this.lightningModel.pipeline);
+    encoder.setVertexArray(this.lightningModel.vertexArray);
+    encoder.setBindings({lightningSegments, uniforms});
+    encoder.draw({
+      indexCount: this.getIndexCount(this.lightningModel),
+      instanceCount: this.lightningModel.instanceCount
+    });
+    encoder.setPipeline(this.lightMarkerModel.pipeline);
+    encoder.setVertexArray(this.lightMarkerModel.vertexArray);
+    encoder.setBindings({lightMarkers, uniforms});
+    encoder.draw({
+      indexCount: this.getIndexCount(this.lightMarkerModel),
+      instanceCount: this.lightMarkerModel.instanceCount
+    });
     return encoder.finish();
   }
 
-  private getIndexCount(): number {
-    const indexBuffer = this.model.vertexArray.indexBuffer;
+  private getIndexCount(model: Model = this.model): number {
+    const indexBuffer = model.vertexArray.indexBuffer;
     if (!indexBuffer) {
       throw new Error('Lightstorm Megacity requires indexed cube geometry');
     }
     return (
-      this.model.indexCount ?? indexBuffer.byteLength / (indexBuffer.indexType === 'uint32' ? 4 : 2)
+      model.indexCount ?? indexBuffer.byteLength / (indexBuffer.indexType === 'uint32' ? 4 : 2)
     );
   }
 
-  private writeUniforms(parameters: LightstormGraphParameters, timeMilliseconds: number): void {
+  private writeUniforms(
+    parameters: LightstormGraphParameters,
+    timeMilliseconds: number
+  ): LightstormCameraState {
+    this.guidedCameraStartMilliseconds ??= timeMilliseconds;
+    const guidedCameraTimeSeconds = (timeMilliseconds - this.guidedCameraStartMilliseconds) / 1000;
+    const lightningTimeSeconds = this.guidedCamera
+      ? guidedCameraTimeSeconds
+      : timeMilliseconds / 1000;
+    const lightningSkyPulse = getLightstormLightningSkyPulse(
+      lightningTimeSeconds,
+      this.lightstormEnabled
+    );
+    this.thunderAudio.update(lightningTimeSeconds, this.lightstormEnabled);
     const perspectiveAspect = getViewportAspect(parameters.perspectiveViewport);
     const cameraPose = this.guidedCamera
-      ? getGuidedCameraPose((timeMilliseconds - this.guidedCameraStartMilliseconds) / 1000)
-      : {
-          target: this.cameraTarget,
-          yaw: this.yaw,
-          pitch: this.pitch,
-          distance: this.distance,
-          duration: 0
-        };
+      ? getLightstormGuidedCameraSample(this.guidedCameraTour, guidedCameraTimeSeconds)
+      : makeOrbitCameraSample(this.cameraTarget, this.yaw, this.pitch, this.distance);
     this.currentCameraPose = cameraPose;
-    const cosinePitch = Math.cos(cameraPose.pitch);
-    const eye: [number, number, number] = [
-      cameraPose.target[0] + Math.sin(cameraPose.yaw) * cosinePitch * cameraPose.distance,
-      cameraPose.target[1] + Math.sin(cameraPose.pitch) * cameraPose.distance,
-      cameraPose.target[2] + Math.cos(cameraPose.yaw) * cosinePitch * cameraPose.distance
-    ];
+    const eye = cameraPose.eye;
     const viewMatrix = new Matrix4().lookAt({eye, center: cameraPose.target, up: [0, 1, 0]});
     const farPlane = Math.max(1800, this.cityMetadata.fieldHalfExtent * 3.2);
     const projectionMatrix = new Matrix4().perspective({
-      fovy: FIELD_OF_VIEW,
+      fovy: LIGHTSTORM_CAMERA_FIELD_OF_VIEW,
       aspect: perspectiveAspect,
       near: NEAR_PLANE,
       far: farPlane
     });
+    const viewProjectionMatrix = new Matrix4(projectionMatrix).multiplyRight(viewMatrix);
+    const previousViewProjectionMatrix = this.previousViewProjectionMatrix ?? viewProjectionMatrix;
     this.writeCameraUniforms(
       this.uniformBuffer,
       viewMatrix,
-      projectionMatrix,
+      viewProjectionMatrix,
+      previousViewProjectionMatrix,
       perspectiveAspect,
       farPlane,
       this.cullingEnabled,
-      timeMilliseconds
+      timeMilliseconds,
+      lightningTimeSeconds,
+      lightningSkyPulse
     );
 
     const overviewAspect = getViewportAspect(
@@ -740,33 +1082,50 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       near: NEAR_PLANE,
       far: overviewFarPlane
     });
+    const overviewViewProjectionMatrix = new Matrix4(overviewProjectionMatrix).multiplyRight(
+      overviewViewMatrix
+    );
     this.writeCameraUniforms(
       this.overviewUniformBuffer,
       overviewViewMatrix,
-      overviewProjectionMatrix,
+      overviewViewProjectionMatrix,
+      overviewViewProjectionMatrix,
       overviewAspect,
       overviewFarPlane,
       false,
-      timeMilliseconds
+      timeMilliseconds,
+      lightningTimeSeconds,
+      lightningSkyPulse
     );
+    this.previousViewProjectionMatrix = new Matrix4(viewProjectionMatrix);
+    return {
+      viewMatrix,
+      projectionMatrix,
+      inverseProjectionMatrix: new Matrix4(projectionMatrix).invert(),
+      viewProjectionMatrix,
+      farPlane,
+      lightningSkyPulse
+    };
   }
 
   private writeCameraUniforms(
     buffer: Buffer,
     viewMatrix: Matrix4,
-    projectionMatrix: Matrix4,
+    viewProjectionMatrix: Matrix4,
+    previousViewProjectionMatrix: Matrix4,
     aspect: number,
     farPlane: number,
     cullingEnabled: boolean,
-    timeMilliseconds: number
+    timeMilliseconds: number,
+    lightningTimeSeconds: number,
+    lightningSkyPulse: number
   ): void {
-    const viewProjectionMatrix = new Matrix4(projectionMatrix).multiplyRight(viewMatrix);
     const values = new Float32Array(UNIFORM_BYTE_LENGTH / Float32Array.BYTES_PER_ELEMENT);
     values.set(viewProjectionMatrix, 0);
     values.set(viewMatrix, 16);
     values.set(
       [
-        Math.tan(FIELD_OF_VIEW / 2),
+        Math.tan(LIGHTSTORM_CAMERA_FIELD_OF_VIEW / 2),
         aspect,
         NEAR_PLANE,
         farPlane,
@@ -776,11 +1135,12 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
         this.lightstormEnabled ? 1 : 0,
         timeMilliseconds / 1000,
         1,
-        0,
-        0
+        lightningTimeSeconds,
+        lightningSkyPulse
       ],
       32
     );
+    values.set(previousViewProjectionMatrix, 44);
     buffer.write(values);
   }
 
@@ -821,7 +1181,11 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
   private async readPickingResult(readbackBuffer: Buffer): Promise<void> {
     try {
       const bytes = await readbackBuffer.readAsync(0, 8);
-      this.pickedObjectIndex = decodeGPUIndexPickInfo(bytes).objectIndex;
+      const pickedObjectIndex = decodeGPUIndexPickInfo(bytes).objectIndex;
+      if (pickedObjectIndex !== this.pickedObjectIndex) {
+        this.deferredLightingRenderer.resetHistory();
+      }
+      this.pickedObjectIndex = pickedObjectIndex;
       this.updateInspector();
     } finally {
       readbackBuffer.destroy();
@@ -839,8 +1203,9 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     this.resources.overviewRenderBundle.destroy();
     this.resources.drawCommands.destroy();
     this.resources.instances.destroy();
+    this.resources.lightMarkers.destroy();
     this.resources.visibleIdentifiers.destroy();
-    this.resources.sceneColor.destroy();
+    this.resources.sceneGBuffer.destroy();
     this.resources = null;
   }
 
@@ -852,7 +1217,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
         makeHtmlCustomPanel({
           id: 'lightstorm-megacity-overview',
           title: '',
-          html: `<p style="margin:0;line-height:1.45"><strong>GPU resident · no per-frame instance upload.</strong> One command graph filters city layers, tests conservative tower bounds, stably compacts source IDs, writes an indexed indirect command, and replays a fixed render bundle into an HDR scene target. Multiscale bloom and ACES tone mapping finish the frame on the same command encoder.</p>`
+          html: `<p style="margin:0;line-height:1.45"><strong>GPU resident · no per-frame instance upload.</strong> One command graph filters city layers, tests conservative tower bounds, stably compacts source IDs, writes an indexed indirect command, and replays a five-target render bundle with 128 emissive source markers. Cinematic mode bins those point lights into a GPU cluster grid before deferred lighting, temporally stabilized screen-space reflections, bloom, and ACES finish the frame on the same command encoder.</p>`
         }),
         makeHtmlCustomPanel({
           id: 'lightstorm-megacity-controls',
@@ -890,6 +1255,8 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       </select></label>
       <label><input type="checkbox" data-culling checked> GPU frustum culling</label>
       <label><input type="checkbox" data-lightstorm checked> Animated lightstorm</label>
+      <label><input type="checkbox" data-thunder-audio checked> Procedural thunder audio</label>
+      <small data-thunder-status aria-live="polite"></small>
       <label><input type="checkbox" data-guided-camera checked> Guided camera</label>
       <label><input type="checkbox" data-comparison> Tactical visibility proof</label>
       <button type="button" data-restart-tour>Restart cinematic tour</button>
@@ -902,22 +1269,37 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     const layerSelect = root.querySelector('[data-layer-select]') as HTMLSelectElement;
     const culling = root.querySelector('[data-culling]') as HTMLInputElement;
     const lightstorm = root.querySelector('[data-lightstorm]') as HTMLInputElement;
+    const thunderAudio = root.querySelector('[data-thunder-audio]') as HTMLInputElement;
+    const thunderStatus = root.querySelector('[data-thunder-status]') as HTMLElement;
     const guidedCamera = root.querySelector('[data-guided-camera]') as HTMLInputElement;
     const comparison = root.querySelector('[data-comparison]') as HTMLInputElement;
     const restartTour = root.querySelector('[data-restart-tour]') as HTMLButtonElement;
     this.guidedCameraElement = guidedCamera;
+    this.thunderStatusElement = thunderStatus;
+    thunderAudio.checked = this.thunderAudio.enabled;
+    this.updateThunderStatus();
     const onCapacity = (): void => this.rebuild(Number(capacitySelect.value));
     const onLayer = (): void => {
       this.dataLayer = layerSelect.value as LightstormDataLayer;
       this.hasVisibilitySample = false;
       this.pickedObjectIndex = null;
+      this.deferredLightingRenderer.resetHistory();
     };
     const onCulling = (): void => {
       this.cullingEnabled = culling.checked;
       this.hasVisibilitySample = false;
+      this.deferredLightingRenderer.resetHistory();
     };
     const onLightstorm = (): void => {
       this.lightstormEnabled = lightstorm.checked;
+      this.deferredLightingRenderer.resetHistory();
+    };
+    const onThunderAudio = (): void => {
+      this.thunderAudio.setEnabled(thunderAudio.checked);
+      if (thunderAudio.checked) {
+        this.activateThunderAudio();
+      }
+      this.updateThunderStatus();
     };
     const onGuidedCamera = (): void => {
       if (guidedCamera.checked) {
@@ -928,6 +1310,8 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     };
     const onComparison = (): void => {
       this.comparisonView = comparison.checked;
+      this.previousViewProjectionMatrix = null;
+      this.deferredLightingRenderer.resetHistory();
       this.updateInspector();
     };
     const onRestartTour = (): void => this.restartGuidedCamera();
@@ -935,6 +1319,7 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     layerSelect.addEventListener('change', onLayer);
     culling.addEventListener('change', onCulling);
     lightstorm.addEventListener('change', onLightstorm);
+    thunderAudio.addEventListener('change', onThunderAudio);
     guidedCamera.addEventListener('change', onGuidedCamera);
     comparison.addEventListener('change', onComparison);
     restartTour.addEventListener('click', onRestartTour);
@@ -943,10 +1328,12 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       layerSelect.removeEventListener('change', onLayer);
       culling.removeEventListener('change', onCulling);
       lightstorm.removeEventListener('change', onLightstorm);
+      thunderAudio.removeEventListener('change', onThunderAudio);
       guidedCamera.removeEventListener('change', onGuidedCamera);
       comparison.removeEventListener('change', onComparison);
       restartTour.removeEventListener('click', onRestartTour);
       this.guidedCameraElement = null;
+      this.thunderStatusElement = null;
     };
   }
 
@@ -954,6 +1341,9 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     this.guidedCamera = true;
     this.guidedCameraStartMilliseconds = this.currentTimeMilliseconds;
     this.pickedObjectIndex = null;
+    this.previousViewProjectionMatrix = null;
+    this.thunderAudio.reset();
+    this.deferredLightingRenderer.resetHistory();
     if (this.guidedCameraElement) {
       this.guidedCameraElement.checked = true;
     }
@@ -967,6 +1357,9 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
       this.distance = this.currentCameraPose.distance;
     }
     this.guidedCamera = false;
+    this.previousViewProjectionMatrix = null;
+    this.thunderAudio.reset();
+    this.deferredLightingRenderer.resetHistory();
     if (this.guidedCameraElement) {
       this.guidedCameraElement.checked = false;
     }
@@ -992,18 +1385,27 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
         : 'sampling…';
       const culledLabel = this.hasVisibilitySample ? formatCount(culledCount) : 'sampling…';
       const submittedTriangles = this.hasVisibilitySample
-        ? formatCount(sampledVisibleCount * TRIANGLES_PER_INSTANCE * replayCount)
+        ? formatCount(
+            (sampledVisibleCount * TRIANGLES_PER_INSTANCE +
+              (this.lightMarkerModel.instanceCount + this.lightningModel.instanceCount) *
+                TRIANGLES_PER_INSTANCE) *
+              replayCount
+          )
         : 'sampling…';
       this.statsElement.innerHTML = `<div style="display:grid;grid-template-columns:1fr auto;gap:4px 12px;margin-top:8px">
-        <span>Camera</span><strong>${this.guidedCamera ? 'guided tour' : 'free explore'}</strong>
+        <span>Camera</span><strong>${this.guidedCamera ? this.currentCameraPose.shot : 'free explore'}</strong>
         <span>Layer source</span><strong>${formatCount(eligibleCount)}</strong>
         <span>Visible / submitted</span><strong>${visibleLabel}</strong>
         <span>GPU rejected</span><strong>${culledLabel}</strong>
         <span>Nominal triangles</span><strong>${formatCount(eligibleCount * TRIANGLES_PER_INSTANCE)}</strong>
         <span>Submitted triangles</span><strong>${submittedTriangles}</strong>
         <span>Indirect draws</span><strong>${replayCount}</strong>
+        <span>Light marker draws</span><strong>${replayCount} · ${this.pointLights.length} emitters/replay</strong>
         <span>Bundle replays</span><strong>${replayCount}</strong>
-        <span>Post stack</span><strong>multiscale HDR bloom · ACES</strong>
+        <span>Lighting</span><strong>${this.comparisonView ? 'forward tactical split' : `clustered deferred · ${this.activeClusteredLightCount} lights`}</strong>
+        <span>G-buffer</span><strong>5 color targets · ${this.sceneColorFormat === 'rgba16float' ? 24 : 20} B/color sample · depth24plus</strong>
+        <span>Reflections</span><strong>${this.comparisonView ? 'disabled in tactical mode' : this.sceneColorFormat === 'rgba16float' ? 'half-resolution temporal SSR · 72 samples' : 'requires filterable rgba16float'}</strong>
+        <span>Post stack</span><strong>${this.sceneColorFormat === 'rgba16float' ? 'HDR floor composite · temporal SSR' : 'authored floor composite'} · multiscale bloom · ACES</strong>
         <span>Presentation</span><strong>${this.device.preferredColorFormat === 'rgba16float' ? 'Display P3 extended HDR' : 'filmic SDR'}</strong>
         <span>Frame rate</span><strong>${this.framesPerSecond.toFixed(1)} FPS</strong>
         <span>CPU frame</span><strong>${this.cpuFrameTimeMilliseconds.toFixed(2)} ms</strong>
@@ -1025,6 +1427,57 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     }
   }
 
+  private activateThunderAudio(restartTour = false): void {
+    void this.thunderAudio.activate().then(
+      () => {
+        if (this.thunderAudio.status === 'ready' && restartTour) {
+          this.restartGuidedCamera();
+        }
+        this.updateThunderStatus();
+      },
+      () => this.updateThunderStatus()
+    );
+  }
+
+  private updateThunderStatus(): void {
+    const thunderStatus = this.thunderAudio.status;
+    if (this.thunderActivationButton) {
+      this.thunderActivationButton.hidden = thunderStatus !== 'waiting';
+    }
+    if (!this.thunderStatusElement) {
+      return;
+    }
+    const statusLabels = {
+      waiting: 'Thunder: click or press a key to arm audio.',
+      ready: 'Thunder: armed · synchronized crack and low-frequency rumble.',
+      muted: 'Thunder: muted.',
+      unavailable: 'Thunder: Web Audio is unavailable in this browser.'
+    } as const;
+    this.thunderStatusElement.textContent = statusLabels[thunderStatus];
+  }
+
+  private mountThunderActivationButton(): void {
+    if (this.thunderActivationButton || typeof document === 'undefined') {
+      return;
+    }
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = 'Enable thunder + restart tour';
+    button.setAttribute('aria-label', 'Enable thunder audio and restart the cinematic tour');
+    button.style.cssText =
+      'position:fixed;left:50%;bottom:24px;z-index:2147483647;transform:translateX(-50%);padding:10px 16px;border:1px solid rgba(125,220,255,.72);border-radius:999px;background:rgba(4,10,24,.88);color:#eafaff;font:600 13px/1.2 system-ui,sans-serif;letter-spacing:.02em;box-shadow:0 0 24px rgba(55,180,255,.36);cursor:pointer;backdrop-filter:blur(8px)';
+    button.addEventListener('click', this.handleThunderActivationButton);
+    document.body.appendChild(button);
+    this.thunderActivationButton = button;
+    this.updateThunderStatus();
+  }
+
+  private unmountThunderActivationButton(): void {
+    this.thunderActivationButton?.removeEventListener('click', this.handleThunderActivationButton);
+    this.thunderActivationButton?.remove();
+    this.thunderActivationButton = null;
+  }
+
   private formatPickedRecord(): string {
     if (this.pickedObjectIndex === null) {
       return 'none';
@@ -1036,6 +1489,10 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
   }
 
   private readonly handlePointerDown = (event: PointerEvent): void => {
+    if (this.thunderAudio.status === 'waiting') {
+      this.activateThunderAudio(true);
+      return;
+    }
     this.switchToExplore();
     this.dragging = true;
     this.lastPointer = [event.clientX, event.clientY];
@@ -1043,6 +1500,16 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
     if (this.canvas) {
       this.canvas.style.cursor = 'grabbing';
     }
+  };
+
+  private readonly handleThunderActivation = (): void => {
+    if (this.thunderAudio.status === 'waiting') {
+      this.activateThunderAudio(true);
+    }
+  };
+
+  private readonly handleThunderActivationButton = (): void => {
+    this.activateThunderAudio(true);
   };
 
   private readonly handlePointerMove = (event: PointerEvent): void => {
@@ -1083,46 +1550,26 @@ export default class LightstormMegacityAnimationLoopTemplate extends AnimationLo
   };
 }
 
-function getGuidedCameraPose(timeSeconds: number): CameraPose {
-  const totalDuration = GUIDED_CAMERA_POSES.reduce(
-    (duration, cameraPose) => duration + cameraPose.duration,
-    0
-  );
-  let localTime = ((timeSeconds % totalDuration) + totalDuration) % totalDuration;
-  for (let poseIndex = 0; poseIndex < GUIDED_CAMERA_POSES.length; poseIndex++) {
-    const startPose = GUIDED_CAMERA_POSES[poseIndex];
-    if (localTime <= startPose.duration) {
-      const endPose = GUIDED_CAMERA_POSES[(poseIndex + 1) % GUIDED_CAMERA_POSES.length];
-      const progress = smoothstep(localTime / startPose.duration);
-      const yawDelta = getShortestAngleDelta(startPose.yaw, endPose.yaw);
-      return {
-        target: [
-          mix(startPose.target[0], endPose.target[0], progress),
-          mix(startPose.target[1], endPose.target[1], progress),
-          mix(startPose.target[2], endPose.target[2], progress)
-        ],
-        yaw: startPose.yaw + yawDelta * progress,
-        pitch: mix(startPose.pitch, endPose.pitch, progress),
-        distance: mix(startPose.distance, endPose.distance, progress),
-        duration: startPose.duration
-      };
-    }
-    localTime -= startPose.duration;
-  }
-  return GUIDED_CAMERA_POSES[0];
-}
-
-function getShortestAngleDelta(start: number, end: number): number {
-  return ((((end - start + Math.PI) % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2)) - Math.PI;
-}
-
-function smoothstep(value: number): number {
-  const clampedValue = Math.max(0, Math.min(1, value));
-  return clampedValue * clampedValue * (3 - 2 * clampedValue);
-}
-
-function mix(start: number, end: number, amount: number): number {
-  return start + (end - start) * amount;
+function makeOrbitCameraSample(
+  target: [number, number, number],
+  yaw: number,
+  pitch: number,
+  distance: number
+): LightstormCameraSample {
+  const cosinePitch = Math.cos(pitch);
+  return {
+    eye: [
+      target[0] + Math.sin(yaw) * cosinePitch * distance,
+      target[1] + Math.sin(pitch) * distance,
+      target[2] + Math.cos(yaw) * cosinePitch * distance
+    ],
+    target,
+    yaw,
+    pitch,
+    distance,
+    duration: 0,
+    shot: 'free explore'
+  };
 }
 
 function getDataLayerMode(dataLayer: LightstormDataLayer): number {
@@ -1136,6 +1583,46 @@ function getSceneColorFormat(device: Device): LightstormSceneColorFormat {
   return floatingPointCapabilities.render && floatingPointCapabilities.filter
     ? 'rgba16float'
     : 'rgba8unorm';
+}
+
+function getLightstormAmbientColor(skyPulse: number): [number, number, number] {
+  return [0.028 + 0.05 * skyPulse, 0.038 + 0.075 * skyPulse, 0.075 + 0.15 * skyPulse];
+}
+
+function getLightstormFogColor(skyPulse: number): [number, number, number] {
+  return [0.008 + 0.1 * skyPulse, 0.018 + 0.16 * skyPulse, 0.055 + 0.34 * skyPulse];
+}
+
+function getSceneGBufferColorFormats(
+  sceneColorFormat: LightstormSceneColorFormat
+): TextureFormatColor[] {
+  return [sceneColorFormat, 'rgba8unorm', 'rg16float', 'rgba8unorm', 'rgba8uint'];
+}
+
+function createSceneGBuffer(
+  device: Device,
+  width: number,
+  height: number,
+  sceneColorFormat: LightstormSceneColorFormat
+): GBuffer {
+  return new GBuffer(device, {
+    id: 'lightstorm-megacity-scene',
+    width,
+    height,
+    colorFormat: sceneColorFormat,
+    normalRoughnessFormat: 'rgba8unorm',
+    velocityFormat: 'rg16float',
+    depthStencilFormat: 'depth24plus',
+    extraColorAttachments: [
+      {name: 'baseColorMetallic', format: 'rgba8unorm'},
+      {name: 'emissiveOcclusion', format: 'rgba8uint'}
+    ]
+  });
+}
+
+function normalizeVector3(vector: NumberArray3): [number, number, number] {
+  const length = Math.hypot(vector[0], vector[1], vector[2]);
+  return length > 0 ? [vector[0] / length, vector[1] / length, vector[2] / length] : [0, 1, 0];
 }
 
 function getEligibleCount(

--- a/examples/showcase/lightstorm-megacity/lightstorm-camera.ts
+++ b/examples/showcase/lightstorm-megacity/lightstorm-camera.ts
@@ -1,0 +1,259 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  LIGHTSTORM_GRID_SPACING,
+  LIGHTSTORM_INSTANCE_WORD_COUNT,
+  type LightstormCityData
+} from './lightstorm-data';
+
+export const LIGHTSTORM_CAMERA_FIELD_OF_VIEW = Math.PI / 3.15;
+
+type Vector3 = [number, number, number];
+
+export type LightstormCameraPose = {
+  eye: Vector3;
+  target: Vector3;
+  duration: number;
+  shot: string;
+};
+
+export type LightstormCameraSample = LightstormCameraPose & {
+  yaw: number;
+  pitch: number;
+  distance: number;
+};
+
+export type LightstormGuidedCameraTour = {
+  poses: readonly LightstormCameraPose[];
+  duration: number;
+  primaryAvenue: number;
+  secondaryAvenue: number;
+  maximumRoofHeight: number;
+  skyscraper: {
+    position: Vector3;
+    roofHeight: number;
+  };
+};
+
+/** Builds a capacity-aware tour whose low shots stay on deterministic avenue centerlines. */
+export function makeLightstormGuidedCameraTour(
+  city: LightstormCityData
+): LightstormGuidedCameraTour {
+  const [primaryAvenue, secondaryAvenue] = getCentralAvenues(city.gridSize);
+  const {maximumRoofHeight, skyscraper} = findRevealSkyscraper(city, secondaryAvenue);
+  const safeAltitude = maximumRoofHeight + 8;
+  const firstAvenueStart = secondaryAvenue - 68;
+  const verticalDirection = Math.sign(secondaryAvenue - primaryAvenue) || 1;
+  const towerDirection = Math.sign(skyscraper.position[0] - secondaryAvenue) || 1;
+  const towerApproachDistance = Math.min(
+    18,
+    Math.max(10, Math.abs(skyscraper.position[0] - secondaryAvenue) * 0.45)
+  );
+  const towerRevealEye = skyscraper.position[0] - towerDirection * towerApproachDistance;
+  const towerMidpoint = Math.max(18, skyscraper.roofHeight * 0.58);
+  const towerCrown = Math.max(towerMidpoint + 4, skyscraper.roofHeight * 0.92);
+  const avenueEyeHeight = 16;
+  const avenueTargetHeight = 12;
+  const skyscraperApproachEyeHeight = 12;
+
+  const poses: LightstormCameraPose[] = [
+    {
+      shot: 'avenue establish',
+      eye: [firstAvenueStart, safeAltitude + 10, primaryAvenue],
+      target: [secondaryAvenue, avenueTargetHeight, primaryAvenue],
+      duration: 3.2
+    },
+    {
+      shot: 'elevated avenue ingress',
+      eye: [firstAvenueStart, avenueEyeHeight, primaryAvenue],
+      target: [secondaryAvenue - 16, avenueTargetHeight, primaryAvenue],
+      duration: 3.4
+    },
+    {
+      shot: 'first intersection',
+      eye: [secondaryAvenue, avenueEyeHeight, primaryAvenue],
+      target: [secondaryAvenue + 44, avenueTargetHeight, primaryAvenue],
+      duration: 0.8
+    },
+    {
+      shot: 'avenue turn',
+      eye: [secondaryAvenue, avenueEyeHeight, primaryAvenue],
+      target: [secondaryAvenue, avenueTargetHeight, secondaryAvenue + verticalDirection * 28],
+      duration: 2.4
+    },
+    {
+      shot: 'second intersection',
+      eye: [secondaryAvenue, avenueEyeHeight, secondaryAvenue],
+      target: [secondaryAvenue, avenueTargetHeight, secondaryAvenue + verticalDirection * 36],
+      duration: 0.8
+    },
+    {
+      shot: 'skyscraper turn',
+      eye: [secondaryAvenue, avenueEyeHeight, secondaryAvenue],
+      target: [skyscraper.position[0], avenueTargetHeight, secondaryAvenue],
+      duration: 1.6
+    },
+    {
+      shot: 'skyscraper approach',
+      eye: [towerRevealEye, skyscraperApproachEyeHeight, secondaryAvenue],
+      target: [
+        skyscraper.position[0],
+        Math.max(16, skyscraper.roofHeight * 0.48),
+        skyscraper.position[2]
+      ],
+      duration: 1.8
+    },
+    {
+      shot: 'vertical reveal',
+      eye: [skyscraper.position[0], 10, secondaryAvenue],
+      target: [skyscraper.position[0], towerMidpoint, skyscraper.position[2]],
+      duration: 4
+    },
+    {
+      shot: 'crown reveal',
+      eye: [skyscraper.position[0], safeAltitude, secondaryAvenue],
+      target: [skyscraper.position[0], towerCrown, skyscraper.position[2]],
+      duration: 4
+    },
+    {
+      shot: 'roof clear',
+      eye: [
+        skyscraper.position[0] + towerDirection * 30,
+        safeAltitude + 13,
+        secondaryAvenue - verticalDirection * 34
+      ],
+      target: [skyscraper.position[0], towerMidpoint, skyscraper.position[2]],
+      duration: 5
+    },
+    {
+      shot: 'aerial return',
+      eye: [firstAvenueStart, safeAltitude + 17, primaryAvenue],
+      target: [secondaryAvenue, 12, primaryAvenue],
+      duration: 2
+    }
+  ];
+
+  return {
+    poses,
+    duration: poses.reduce((duration, pose) => duration + pose.duration, 0),
+    primaryAvenue,
+    secondaryAvenue,
+    maximumRoofHeight,
+    skyscraper
+  };
+}
+
+/** Samples the same explicit path used by the renderer, including deterministic loop wrapping. */
+export function getLightstormGuidedCameraSample(
+  tour: LightstormGuidedCameraTour,
+  timeSeconds: number
+): LightstormCameraSample {
+  let localTime = ((timeSeconds % tour.duration) + tour.duration) % tour.duration;
+  for (let poseIndex = 0; poseIndex < tour.poses.length; poseIndex++) {
+    const startPose = tour.poses[poseIndex]!;
+    if (localTime <= startPose.duration) {
+      const endPose = tour.poses[(poseIndex + 1) % tour.poses.length]!;
+      const progress = smoothstep(localTime / startPose.duration);
+      const eye = mixVector3(startPose.eye, endPose.eye, progress);
+      const target = mixVector3(startPose.target, endPose.target, progress);
+      return makeCameraSample(eye, target, startPose.duration, startPose.shot);
+    }
+    localTime -= startPose.duration;
+  }
+  const firstPose = tour.poses[0]!;
+  return makeCameraSample(firstPose.eye, firstPose.target, firstPose.duration, firstPose.shot);
+}
+
+function getCentralAvenues(gridSize: number): [number, number] {
+  const centeredGridCoordinate = (gridSize - 1) / 2;
+  const nearestRoadCycle = Math.round((centeredGridCoordinate - 0.5) / 12);
+  const primaryAvenue = getAvenueCenter(nearestRoadCycle, centeredGridCoordinate);
+  const oppositeRoadCycle = nearestRoadCycle + (primaryAvenue >= 0 ? -1 : 1);
+  const secondaryAvenue = getAvenueCenter(oppositeRoadCycle, centeredGridCoordinate);
+  return [primaryAvenue, secondaryAvenue];
+}
+
+function getAvenueCenter(roadCycle: number, centeredGridCoordinate: number): number {
+  return (roadCycle * 12 + 0.5 - centeredGridCoordinate) * LIGHTSTORM_GRID_SPACING;
+}
+
+function findRevealSkyscraper(
+  city: LightstormCityData,
+  avenueCenter: number
+): {maximumRoofHeight: number; skyscraper: LightstormGuidedCameraTour['skyscraper']} {
+  let maximumRoofHeight = 0;
+  let bestScore = -Infinity;
+  let skyscraper: LightstormGuidedCameraTour['skyscraper'] | null = null;
+  const centralExtent = Math.min(120, city.fieldHalfExtent * 0.45);
+  const instanceCount = city.instances.length / LIGHTSTORM_INSTANCE_WORD_COUNT;
+
+  for (let instanceIndex = 0; instanceIndex < instanceCount; instanceIndex++) {
+    const wordOffset = instanceIndex * LIGHTSTORM_INSTANCE_WORD_COUNT;
+    if (city.instances[wordOffset + 11] !== 0) {
+      continue;
+    }
+    const worldX = city.instances[wordOffset]!;
+    const centerY = city.instances[wordOffset + 1]!;
+    const worldZ = city.instances[wordOffset + 2]!;
+    const halfHeight = city.instances[wordOffset + 5]!;
+    const roofHeight = centerY + halfHeight;
+    maximumRoofHeight = Math.max(maximumRoofHeight, roofHeight);
+
+    const distanceFromAvenue = Math.abs(worldZ - avenueCenter);
+    const distanceFromCenter = Math.abs(worldX);
+    if (distanceFromAvenue > 6 || distanceFromCenter > centralExtent) {
+      continue;
+    }
+    const score = roofHeight - distanceFromCenter * 0.002;
+    if (score > bestScore) {
+      bestScore = score;
+      skyscraper = {position: [worldX, centerY, worldZ], roofHeight};
+    }
+  }
+
+  if (!skyscraper) {
+    // Every supported city contains central towers beside this avenue.
+    throw new Error('Lightstorm guided tour requires a skyscraper beside the central avenue');
+  }
+  return {maximumRoofHeight, skyscraper};
+}
+
+function makeCameraSample(
+  eye: Vector3,
+  target: Vector3,
+  duration: number,
+  shot: string
+): LightstormCameraSample {
+  const offsetX = eye[0] - target[0];
+  const offsetY = eye[1] - target[1];
+  const offsetZ = eye[2] - target[2];
+  const distance = Math.hypot(offsetX, offsetY, offsetZ);
+  return {
+    eye,
+    target,
+    yaw: Math.atan2(offsetX, offsetZ),
+    pitch: Math.asin(offsetY / distance),
+    distance,
+    duration,
+    shot
+  };
+}
+
+function mixVector3(start: Vector3, end: Vector3, amount: number): Vector3 {
+  return [
+    mix(start[0], end[0], amount),
+    mix(start[1], end[1], amount),
+    mix(start[2], end[2], amount)
+  ];
+}
+
+function smoothstep(value: number): number {
+  const clampedValue = Math.max(0, Math.min(1, value));
+  return clampedValue * clampedValue * (3 - 2 * clampedValue);
+}
+
+function mix(start: number, end: number, amount: number): number {
+  return start + (end - start) * amount;
+}

--- a/examples/showcase/lightstorm-megacity/lightstorm-lighting.ts
+++ b/examples/showcase/lightstorm-megacity/lightstorm-lighting.ts
@@ -1,0 +1,185 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {DeferredPointLight} from '@luma.gl/experimental';
+import type {Matrix4} from '@math.gl/core';
+import {LIGHTSTORM_GRID_SPACING} from './lightstorm-data';
+
+export const LIGHTSTORM_POINT_LIGHT_COUNT = 128;
+export const LIGHTSTORM_LIGHT_MARKER_WORD_COUNT = 12;
+
+const LIGHTSTORM_LIGHT_COLORS = [
+  [0.12, 0.78, 1],
+  [1, 0.46, 0.1],
+  [0.94, 0.18, 0.78]
+] as const;
+const LIGHT_COLUMN_COUNT = 16;
+const LIGHT_ALONG_STREET_CELL_STRIDE = 4;
+const LIGHT_CURB_OFFSET = LIGHTSTORM_GRID_SPACING * 0.375;
+const DEFAULT_CITY_GRID_SIZE = 500;
+
+/** One deterministic world-space light placed along the central street lattice. */
+export type LightstormPointLight = {
+  worldPosition: [number, number, number];
+  range: number;
+  color: [number, number, number];
+  intensity: number;
+  pulsePhase: number;
+  pulseFrequency: number;
+};
+
+/** Packs world-space point-light metadata for the visible emissive source markers. */
+export function makeLightstormLightMarkerBufferData(
+  lights: readonly LightstormPointLight[]
+): Float32Array {
+  const data = new Float32Array(lights.length * LIGHTSTORM_LIGHT_MARKER_WORD_COUNT);
+  for (let lightIndex = 0; lightIndex < lights.length; lightIndex++) {
+    const light = lights[lightIndex]!;
+    const wordOffset = lightIndex * LIGHTSTORM_LIGHT_MARKER_WORD_COUNT;
+    data.set(
+      [
+        light.worldPosition[0],
+        light.worldPosition[1],
+        light.worldPosition[2],
+        light.range,
+        light.color[0],
+        light.color[1],
+        light.color[2],
+        light.intensity,
+        light.pulsePhase,
+        light.pulseFrequency,
+        0,
+        0
+      ],
+      wordOffset
+    );
+  }
+  return data;
+}
+
+/** Creates a deterministic cyan, amber, and magenta street-light lattice. */
+export function makeLightstormPointLights(
+  count: number = LIGHTSTORM_POINT_LIGHT_COUNT,
+  cityGridSize: number = DEFAULT_CITY_GRID_SIZE
+): LightstormPointLight[] {
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error('Lightstorm point-light count must be a non-negative safe integer');
+  }
+  if (!Number.isSafeInteger(cityGridSize) || cityGridSize < 1) {
+    throw new Error('Lightstorm city grid size must be a positive safe integer');
+  }
+  if (count === 0) {
+    return [];
+  }
+
+  const columnCount = Math.min(LIGHT_COLUMN_COUNT, count);
+  const cityCenterGridIndex = (cityGridSize - 1) / 2;
+  const transitCorridors = getCentralTransitCorridors(cityGridSize);
+  const lights: LightstormPointLight[] = [];
+
+  for (let lightIndex = 0; lightIndex < count; lightIndex++) {
+    const corridor = Math.floor(lightIndex / columnCount);
+    const column = lightIndex % columnCount;
+    const lightsInCorridor = Math.min(columnCount, count - corridor * columnCount);
+    const proposedAlongStreetGridIndex = Math.max(
+      0,
+      Math.min(
+        cityGridSize - 1,
+        Math.round(
+          cityCenterGridIndex +
+            (column - (lightsInCorridor - 1) / 2) * LIGHT_ALONG_STREET_CELL_STRIDE
+        )
+      )
+    );
+    const alongStreetGridIndex = getNearestNonTransitGridIndex(
+      proposedAlongStreetGridIndex,
+      cityGridSize
+    );
+    const corridorGridIndex = transitCorridors[corridor % transitCorridors.length]!;
+    const alongStreetPosition =
+      (alongStreetGridIndex - cityCenterGridIndex) * LIGHTSTORM_GRID_SPACING;
+    const corridorPosition = (corridorGridIndex - cityCenterGridIndex) * LIGHTSTORM_GRID_SPACING;
+    const curbOffset = corridorGridIndex % 12 === 0 ? -LIGHT_CURB_OFFSET : LIGHT_CURB_OFFSET;
+    const followsEastWestStreet = corridor % 2 === 0;
+    const color = LIGHTSTORM_LIGHT_COLORS[lightIndex % LIGHTSTORM_LIGHT_COLORS.length]!;
+
+    lights.push({
+      worldPosition: [
+        followsEastWestStreet ? alongStreetPosition : corridorPosition + curbOffset,
+        3.5 + getDeterministicFraction(lightIndex, 0) * 2.5,
+        followsEastWestStreet ? corridorPosition + curbOffset : alongStreetPosition
+      ],
+      // Keep the brighter pools local so the pavement remains dark between fixtures.
+      range: 16 + getDeterministicFraction(lightIndex, 1) * 8,
+      color: [color[0], color[1], color[2]],
+      intensity: 14 + getDeterministicFraction(lightIndex, 2) * 10,
+      pulsePhase: getDeterministicFraction(lightIndex, 3) * Math.PI * 2,
+      pulseFrequency: 0.45 + getDeterministicFraction(lightIndex, 4) * 0.7
+    });
+  }
+
+  return lights;
+}
+
+/** Transforms world lights into view space and applies subtle deterministic intensity pulses. */
+export function makeLightstormViewPointLights(
+  lights: readonly LightstormPointLight[],
+  viewMatrix: Matrix4,
+  timeSeconds: number,
+  animate: boolean = true
+): DeferredPointLight[] {
+  const finiteTimeSeconds = Number.isFinite(timeSeconds) ? timeSeconds : 0;
+  return lights.map(light => {
+    const viewPosition = viewMatrix.transformAsPoint(light.worldPosition) as [
+      number,
+      number,
+      number
+    ];
+    const pulse = animate
+      ? 1 + Math.sin(light.pulsePhase + finiteTimeSeconds * light.pulseFrequency) * 0.07
+      : 1;
+    return {
+      position: [viewPosition[0], viewPosition[1], viewPosition[2]],
+      range: light.range,
+      color: [light.color[0], light.color[1], light.color[2]],
+      intensity: Math.max(0, light.intensity * pulse)
+    };
+  });
+}
+
+function getCentralTransitCorridors(cityGridSize: number): number[] {
+  const centerGridIndex = (cityGridSize - 1) / 2;
+  const corridors: number[] = [];
+  for (let gridIndex = 0; gridIndex < cityGridSize; gridIndex++) {
+    if (gridIndex % 12 <= 1) {
+      corridors.push(gridIndex);
+    }
+  }
+  corridors.sort(
+    (left, right) =>
+      Math.abs(left - centerGridIndex) - Math.abs(right - centerGridIndex) || left - right
+  );
+  return corridors.length > 0 ? corridors : [Math.round(centerGridIndex)];
+}
+
+function getNearestNonTransitGridIndex(gridIndex: number, cityGridSize: number): number {
+  for (let distance = 0; distance < 12; distance++) {
+    const lowerGridIndex = gridIndex - distance;
+    if (lowerGridIndex >= 0 && lowerGridIndex % 12 > 1) {
+      return lowerGridIndex;
+    }
+    const upperGridIndex = gridIndex + distance;
+    if (upperGridIndex < cityGridSize && upperGridIndex % 12 > 1) {
+      return upperGridIndex;
+    }
+  }
+  return gridIndex;
+}
+
+function getDeterministicFraction(lightIndex: number, sequenceIndex: number): number {
+  let value = Math.imul(lightIndex + 1, 0x45d9f3b) ^ Math.imul(sequenceIndex + 1, 0x27d4eb2d);
+  value = Math.imul(value ^ (value >>> 16), 0x45d9f3b);
+  value ^= value >>> 16;
+  return (value >>> 0) / 0xffffffff;
+}

--- a/examples/showcase/lightstorm-megacity/lightstorm-lightning.ts
+++ b/examples/showcase/lightstorm-megacity/lightstorm-lightning.ts
@@ -1,0 +1,418 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  getLightstormGuidedCameraSample,
+  LIGHTSTORM_CAMERA_FIELD_OF_VIEW,
+  type LightstormCameraSample,
+  type LightstormGuidedCameraTour
+} from './lightstorm-camera';
+
+export const LIGHTSTORM_LIGHTNING_SEGMENT_WORD_COUNT = 16;
+export const LIGHTSTORM_LIGHTNING_SEGMENT_CAPACITY = 96;
+export const LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS = 29;
+export const LIGHTSTORM_LIGHTNING_STRIKE_WIDTH_SECONDS = 0.085;
+export const LIGHTSTORM_LIGHTNING_RETURN_STROKE_DELAY_SECONDS = 0.26;
+export const LIGHTSTORM_LIGHTNING_RETURN_STROKE_WIDTH_SECONDS = 0.065;
+export const LIGHTSTORM_LIGHTNING_RETURN_STROKE_SCALE = 0.82;
+export const LIGHTSTORM_CANYON_STRIKE_SECONDS = 5.6;
+export const LIGHTSTORM_AVENUE_STRIKE_SECONDS = 8.6;
+export const LIGHTSTORM_REVEAL_STRIKE_SECONDS = 15.65;
+export const LIGHTSTORM_CANYON_SKY_PULSE_AMPLITUDE = 0.38;
+export const LIGHTSTORM_AVENUE_SKY_PULSE_AMPLITUDE = 0.3;
+export const LIGHTSTORM_REVEAL_SKY_PULSE_AMPLITUDE = 1;
+
+type Vector3 = [number, number, number];
+type LightstormLightningFramePoint = [normalizedX: number, normalizedY: number, depth: number];
+
+export type LightstormLightningBoltRole = 'canyon' | 'avenue' | 'reveal';
+
+export type LightstormLightningBoltDefinition = {
+  role: LightstormLightningBoltRole;
+  start: Vector3;
+  end: Vector3;
+  color: Vector3;
+  intensity: number;
+  phaseSeconds: number;
+  periodSeconds: number;
+  width: number;
+  segmentCount: number;
+  branchNodeIndices: readonly number[];
+  branchSegmentCount: number;
+  jitter: number;
+  sizeScale: number;
+  randomSeed: number;
+};
+
+export type LightstormLightningBoltSchedule = Omit<
+  LightstormLightningBoltDefinition,
+  'start' | 'end'
+>;
+
+export type LightstormLightningSegment = {
+  start: Vector3;
+  end: Vector3;
+  width: number;
+  seed: number;
+  color: Vector3;
+  intensity: number;
+  phaseSeconds: number;
+  periodSeconds: number;
+  branchLevel: number;
+  boltIndex: number;
+};
+
+/** Stable roles and phases shared by the visual and thunder timelines. */
+export const LIGHTSTORM_LIGHTNING_SCHEDULE: readonly LightstormLightningBoltSchedule[] = [
+  {
+    role: 'canyon',
+    color: [0.82, 0.91, 1],
+    intensity: 32,
+    phaseSeconds: LIGHTSTORM_CANYON_STRIKE_SECONDS,
+    periodSeconds: LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS,
+    width: 0.22,
+    segmentCount: 16,
+    branchNodeIndices: [4, 8, 12],
+    branchSegmentCount: 3,
+    jitter: 12,
+    sizeScale: 1,
+    randomSeed: 0x7d31a2f5
+  },
+  {
+    role: 'avenue',
+    color: [0.86, 0.93, 1],
+    intensity: 24,
+    phaseSeconds: LIGHTSTORM_AVENUE_STRIKE_SECONDS,
+    periodSeconds: LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS,
+    width: 0.24,
+    segmentCount: 15,
+    branchNodeIndices: [4, 9, 12],
+    branchSegmentCount: 3,
+    jitter: 14,
+    sizeScale: 1,
+    randomSeed: 0x41c6ce57
+  },
+  {
+    role: 'reveal',
+    color: [0.9, 0.96, 1],
+    intensity: 64,
+    phaseSeconds: LIGHTSTORM_REVEAL_STRIKE_SECONDS,
+    periodSeconds: LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS,
+    width: 0.44,
+    segmentCount: 24,
+    branchNodeIndices: [5, 10, 15, 20],
+    branchSegmentCount: 4,
+    jitter: 24,
+    sizeScale: 2,
+    randomSeed: 0xb5297a4d
+  }
+];
+
+const LIGHTSTORM_LIGHTNING_FRAMING: Record<
+  LightstormLightningBoltRole,
+  {start: LightstormLightningFramePoint; end: LightstormLightningFramePoint}
+> = {
+  canyon: {
+    start: [0.36, 0.88, 280],
+    end: [0.02, 0.18, 190]
+  },
+  avenue: {
+    start: [-0.4, 0.9, 280],
+    end: [-0.04, 0.22, 190]
+  },
+  reveal: {
+    start: [-0.78, 0.58, 380],
+    end: [0.78, 0.3, 380]
+  }
+};
+
+export const LIGHTSTORM_LIGHTNING_BOLT_COUNT = LIGHTSTORM_LIGHTNING_SCHEDULE.length;
+export const LIGHTSTORM_LIGHTNING_SEGMENT_COUNT = LIGHTSTORM_LIGHTNING_SCHEDULE.reduce(
+  (segmentCount, bolt) =>
+    segmentCount + bolt.segmentCount + bolt.branchNodeIndices.length * bolt.branchSegmentCount,
+  0
+);
+
+/** Places every authored bolt relative to its capacity-specific camera pose. */
+export function makeLightstormLightningBolts(
+  tour: LightstormGuidedCameraTour,
+  aspect: number
+): LightstormLightningBoltDefinition[] {
+  return LIGHTSTORM_LIGHTNING_SCHEDULE.map(bolt => {
+    const cameraSample = getLightstormGuidedCameraSample(tour, bolt.phaseSeconds);
+    const framing = LIGHTSTORM_LIGHTNING_FRAMING[bolt.role];
+    return {
+      ...bolt,
+      start: makeCameraFramedWorldPoint(cameraSample, framing.start, aspect),
+      end: makeCameraFramedWorldPoint(cameraSample, framing.end, aspect)
+    };
+  });
+}
+
+/** Returns bounded double flashes synchronized to each camera-framed lightning strike. */
+export function getLightstormLightningSkyPulse(
+  timeSeconds: number,
+  lightstormEnabled = true
+): number {
+  if (!lightstormEnabled || !Number.isFinite(timeSeconds)) {
+    return 0;
+  }
+  const pulseDefinitions = [
+    [LIGHTSTORM_CANYON_STRIKE_SECONDS, LIGHTSTORM_CANYON_SKY_PULSE_AMPLITUDE],
+    [LIGHTSTORM_AVENUE_STRIKE_SECONDS, LIGHTSTORM_AVENUE_SKY_PULSE_AMPLITUDE],
+    [LIGHTSTORM_REVEAL_STRIKE_SECONDS, LIGHTSTORM_REVEAL_SKY_PULSE_AMPLITUDE]
+  ] as const;
+  let skyPulse = 0;
+  for (const [phaseSeconds, amplitude] of pulseDefinitions) {
+    skyPulse = Math.max(
+      skyPulse,
+      amplitude * getLightstormLightningStrikeEnvelope(timeSeconds, phaseSeconds)
+    );
+  }
+  return Math.min(1, skyPulse);
+}
+
+function getLightstormLightningStrikeEnvelope(timeSeconds: number, phaseSeconds: number): number {
+  const cycleTime =
+    (((timeSeconds - phaseSeconds) % LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS) +
+      LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS) %
+    LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS;
+  const firstStrike = Math.exp(-Math.pow(cycleTime / LIGHTSTORM_LIGHTNING_STRIKE_WIDTH_SECONDS, 2));
+  const returnStroke =
+    Math.exp(
+      -Math.pow(
+        (cycleTime - LIGHTSTORM_LIGHTNING_RETURN_STROKE_DELAY_SECONDS) /
+          LIGHTSTORM_LIGHTNING_RETURN_STROKE_WIDTH_SECONDS,
+        2
+      )
+    ) * LIGHTSTORM_LIGHTNING_RETURN_STROKE_SCALE;
+  return Math.max(firstStrike, returnStroke);
+}
+
+/** Creates connected jagged trunks and first-order branches without mutable global state. */
+export function makeLightstormLightningSegments(
+  bolts: readonly LightstormLightningBoltDefinition[]
+): LightstormLightningSegment[] {
+  const segments: LightstormLightningSegment[] = [];
+
+  for (let boltIndex = 0; boltIndex < bolts.length; boltIndex++) {
+    const bolt = bolts[boltIndex]!;
+    const random = makeDeterministicRandom(bolt.randomSeed);
+    const trunkNodes = makeJaggedPath(bolt.start, bolt.end, bolt.segmentCount, bolt.jitter, random);
+
+    appendPathSegments(segments, trunkNodes, bolt, boltIndex, 0, random);
+
+    for (const branchNodeIndex of bolt.branchNodeIndices) {
+      const branchStart = trunkNodes[branchNodeIndex]!;
+      const previousNode = trunkNodes[Math.max(0, branchNodeIndex - 1)]!;
+      const nextNode = trunkNodes[Math.min(trunkNodes.length - 1, branchNodeIndex + 1)]!;
+      const trunkDirection = normalizeVector(subtractVectors(nextNode, previousNode));
+      const lateralDirection = getPerpendicularDirections(trunkDirection)[0];
+      const branchSign = random() < 0.5 ? -1 : 1;
+      const branchLength = (38 + random() * 28) * bolt.sizeScale;
+      const branchDirection = normalizeVector(
+        addVectors(
+          scaleVector(trunkDirection, 0.34),
+          scaleVector(lateralDirection, branchSign * 0.82),
+          [0, -0.24, 0]
+        )
+      );
+      const branchEnd = addVectors(branchStart, scaleVector(branchDirection, branchLength));
+      const branchNodes = makeJaggedPath(
+        branchStart,
+        branchEnd,
+        bolt.branchSegmentCount,
+        bolt.jitter * 0.32,
+        random
+      );
+      appendPathSegments(segments, branchNodes, bolt, boltIndex, 1, random);
+    }
+  }
+
+  if (segments.length > LIGHTSTORM_LIGHTNING_SEGMENT_CAPACITY) {
+    throw new Error('Lightstorm lightning segment capacity exceeded');
+  }
+  return segments;
+}
+
+/**
+ * Packs four shader-aligned vec4 values per segment:
+ * `[start.xyz, width]`, `[end.xyz, seed]`, `[color.rgb, intensity]`, and
+ * `[phaseSeconds, periodSeconds, branchLevel, boltIndex]`.
+ */
+export function makeLightstormLightningBufferData(
+  segments: readonly LightstormLightningSegment[]
+): Float32Array {
+  const data = new Float32Array(segments.length * LIGHTSTORM_LIGHTNING_SEGMENT_WORD_COUNT);
+  for (let segmentIndex = 0; segmentIndex < segments.length; segmentIndex++) {
+    const segment = segments[segmentIndex]!;
+    const wordOffset = segmentIndex * LIGHTSTORM_LIGHTNING_SEGMENT_WORD_COUNT;
+    data.set(
+      [
+        segment.start[0],
+        segment.start[1],
+        segment.start[2],
+        segment.width,
+        segment.end[0],
+        segment.end[1],
+        segment.end[2],
+        segment.seed,
+        segment.color[0],
+        segment.color[1],
+        segment.color[2],
+        segment.intensity,
+        segment.phaseSeconds,
+        segment.periodSeconds,
+        segment.branchLevel,
+        segment.boltIndex
+      ],
+      wordOffset
+    );
+  }
+  return data;
+}
+
+function appendPathSegments(
+  segments: LightstormLightningSegment[],
+  nodes: readonly Vector3[],
+  bolt: LightstormLightningBoltDefinition,
+  boltIndex: number,
+  branchLevel: number,
+  random: () => number
+): void {
+  const segmentCount = nodes.length - 1;
+  const branchScale = branchLevel === 0 ? 1 : 0.56;
+  for (let segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++) {
+    const pathProgress = segmentCount > 1 ? segmentIndex / (segmentCount - 1) : 0;
+    segments.push({
+      start: nodes[segmentIndex]!,
+      end: nodes[segmentIndex + 1]!,
+      width: bolt.width * branchScale * (1 - pathProgress * 0.38),
+      seed: random(),
+      color: [...bolt.color],
+      intensity: bolt.intensity * branchScale * (1 - pathProgress * 0.14),
+      phaseSeconds: bolt.phaseSeconds,
+      periodSeconds: bolt.periodSeconds,
+      branchLevel,
+      boltIndex
+    });
+  }
+}
+
+function makeCameraFramedWorldPoint(
+  cameraSample: LightstormCameraSample,
+  framePoint: LightstormLightningFramePoint,
+  aspect: number
+): Vector3 {
+  const cameraForward = normalizeVector(subtractVectors(cameraSample.target, cameraSample.eye));
+  let cameraRight = crossVectors(cameraForward, [0, 1, 0]);
+  if (vectorLength(cameraRight) < 0.00001) {
+    cameraRight = [1, 0, 0];
+  } else {
+    cameraRight = normalizeVector(cameraRight);
+  }
+  const cameraUp = normalizeVector(crossVectors(cameraRight, cameraForward));
+  const [normalizedX, normalizedY, depth] = framePoint;
+  const halfHeight = depth * Math.tan(LIGHTSTORM_CAMERA_FIELD_OF_VIEW / 2);
+  const halfWidth = halfHeight * aspect;
+  return addVectors(
+    cameraSample.eye,
+    scaleVector(cameraForward, depth),
+    scaleVector(cameraRight, normalizedX * halfWidth),
+    scaleVector(cameraUp, normalizedY * halfHeight)
+  );
+}
+
+function makeJaggedPath(
+  start: Vector3,
+  end: Vector3,
+  segmentCount: number,
+  jitter: number,
+  random: () => number
+): Vector3[] {
+  const direction = normalizeVector(subtractVectors(end, start));
+  const [firstPerpendicular, secondPerpendicular] = getPerpendicularDirections(direction);
+  const nodes: Vector3[] = [];
+
+  for (let nodeIndex = 0; nodeIndex <= segmentCount; nodeIndex++) {
+    const progress = nodeIndex / segmentCount;
+    const center = mixVectors(start, end, progress);
+    const jitterEnvelope = Math.sin(progress * Math.PI);
+    const firstOffset = (random() * 2 - 1) * jitter * jitterEnvelope;
+    const secondOffset = (random() * 2 - 1) * jitter * 0.45 * jitterEnvelope;
+    nodes.push(
+      addVectors(
+        center,
+        scaleVector(firstPerpendicular, firstOffset),
+        scaleVector(secondPerpendicular, secondOffset)
+      )
+    );
+  }
+
+  nodes[0] = [...start];
+  nodes[nodes.length - 1] = [...end];
+  return nodes;
+}
+
+function getPerpendicularDirections(direction: Vector3): [Vector3, Vector3] {
+  let firstPerpendicular = crossVectors(direction, [0, 1, 0]);
+  if (vectorLength(firstPerpendicular) < 0.00001) {
+    firstPerpendicular = crossVectors(direction, [1, 0, 0]);
+  }
+  firstPerpendicular = normalizeVector(firstPerpendicular);
+  return [firstPerpendicular, normalizeVector(crossVectors(direction, firstPerpendicular))];
+}
+
+function makeDeterministicRandom(randomSeed: number): () => number {
+  let randomState = randomSeed >>> 0;
+  return () => {
+    randomState ^= randomState << 13;
+    randomState ^= randomState >>> 17;
+    randomState ^= randomState << 5;
+    return (randomState >>> 0) / 0x100000000;
+  };
+}
+
+function mixVectors(start: Vector3, end: Vector3, progress: number): Vector3 {
+  return [
+    start[0] + (end[0] - start[0]) * progress,
+    start[1] + (end[1] - start[1]) * progress,
+    start[2] + (end[2] - start[2]) * progress
+  ];
+}
+
+function addVectors(...vectors: readonly Vector3[]): Vector3 {
+  const sum: Vector3 = [0, 0, 0];
+  for (const vector of vectors) {
+    sum[0] += vector[0];
+    sum[1] += vector[1];
+    sum[2] += vector[2];
+  }
+  return sum;
+}
+
+function subtractVectors(left: Vector3, right: Vector3): Vector3 {
+  return [left[0] - right[0], left[1] - right[1], left[2] - right[2]];
+}
+
+function scaleVector(vector: Vector3, scale: number): Vector3 {
+  return [vector[0] * scale, vector[1] * scale, vector[2] * scale];
+}
+
+function normalizeVector(vector: Vector3): Vector3 {
+  const length = vectorLength(vector);
+  return length > 0 ? scaleVector(vector, 1 / length) : [0, 1, 0];
+}
+
+function vectorLength(vector: Vector3): number {
+  return Math.hypot(vector[0], vector[1], vector[2]);
+}
+
+function crossVectors(left: Vector3, right: Vector3): Vector3 {
+  return [
+    left[1] * right[2] - left[2] * right[1],
+    left[2] * right[0] - left[0] * right[2],
+    left[0] * right[1] - left[1] * right[0]
+  ];
+}

--- a/examples/showcase/lightstorm-megacity/lightstorm-shaders.ts
+++ b/examples/showcase/lightstorm-megacity/lightstorm-shaders.ts
@@ -2,6 +2,139 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import type {Texture, TextureFormatColor} from '@luma.gl/core';
+import {clusteredDeferredLighting} from '@luma.gl/experimental';
+import type {ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
+import type {NumberArray16} from '@math.gl/core';
+import {
+  LIGHTSTORM_LIGHTNING_RETURN_STROKE_DELAY_SECONDS,
+  LIGHTSTORM_LIGHTNING_RETURN_STROKE_SCALE,
+  LIGHTSTORM_LIGHTNING_RETURN_STROKE_WIDTH_SECONDS,
+  LIGHTSTORM_LIGHTNING_STRIKE_WIDTH_SECONDS
+} from './lightstorm-lightning';
+
+type LightstormDeferredCompositeProps = {
+  forwardColorFloor?: number;
+  fogColor?: [number, number, number];
+  forwardColorTexture?: Texture;
+  depthTexture?: Texture;
+  inverseProjectionMatrix?: Readonly<NumberArray16>;
+};
+
+type LightstormDeferredCompositeUniforms = {
+  inverseProjectionMatrix: Readonly<NumberArray16>;
+  fogColor: [number, number, number];
+  forwardColorFloor: number;
+};
+
+type LightstormDeferredCompositeBindings = {
+  forwardColorTexture?: Texture;
+  depthTexture?: Texture;
+};
+
+const IDENTITY_MATRIX: NumberArray16 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+const lightstormDeferredComposite = {
+  name: 'lightstormDeferredComposite',
+  source: /* wgsl */ `
+struct LightstormDeferredCompositeUniforms {
+  inverseProjectionMatrix: mat4x4f,
+  fogColor: vec3f,
+  forwardColorFloor: f32,
+};
+
+@group(0) @binding(auto) var<uniform> lightstormDeferredComposite: LightstormDeferredCompositeUniforms;
+@group(0) @binding(auto) var forwardColorTexture: texture_2d<f32>;
+@group(0) @binding(auto) var forwardColorTextureSampler: sampler;
+@group(0) @binding(auto) var depthTexture: texture_depth_2d;
+@group(0) @binding(auto) var depthTextureSampler: sampler;
+
+fn lightstormDeferredComposite_reconstructViewDepth(texCoord: vec2f, depth: f32) -> f32 {
+  let clip = vec4f(texCoord.x * 2.0 - 1.0, 1.0 - texCoord.y * 2.0, depth, 1.0);
+  let viewPosition = lightstormDeferredComposite.inverseProjectionMatrix * clip;
+  return abs(viewPosition.z / max(abs(viewPosition.w), 0.00001));
+}
+
+fn lightstormDeferredComposite_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let deferredColor = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord, 0);
+  let forwardColor = textureSampleLevel(
+    forwardColorTexture,
+    forwardColorTextureSampler,
+    texCoord,
+    0
+  );
+  let depth = textureSampleLevel(depthTexture, depthTextureSampler, texCoord, 0);
+  let viewDepth = lightstormDeferredComposite_reconstructViewDepth(texCoord, depth);
+  let fogAmount = clamp(1.0 - exp(-viewDepth * 0.00165), 0.0, 0.96);
+  let foggedDeferredColor = mix(
+    deferredColor.rgb,
+    lightstormDeferredComposite.fogColor,
+    fogAmount
+  );
+  let authoredColorFloor = forwardColor.rgb * lightstormDeferredComposite.forwardColorFloor;
+  return vec4f(max(foggedDeferredColor, authoredColorFloor), forwardColor.a);
+}
+`,
+  bindingLayout: [
+    {name: 'forwardColorTexture', group: 0},
+    {name: 'depthTexture', group: 0}
+  ],
+  uniforms: {} as LightstormDeferredCompositeUniforms,
+  bindings: {} as LightstormDeferredCompositeBindings,
+  uniformTypes: {
+    inverseProjectionMatrix: 'mat4x4<f32>',
+    fogColor: 'vec3<f32>',
+    forwardColorFloor: 'f32'
+  },
+  defaultUniforms: {
+    inverseProjectionMatrix: IDENTITY_MATRIX,
+    fogColor: [0.008, 0.018, 0.055],
+    forwardColorFloor: 0.82
+  },
+  propTypes: {
+    inverseProjectionMatrix: {value: IDENTITY_MATRIX, private: true},
+    fogColor: {value: [0.008, 0.018, 0.055], private: true},
+    forwardColorFloor: {value: 0.82, min: 0, max: 1}
+  },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  LightstormDeferredCompositeProps,
+  LightstormDeferredCompositeUniforms,
+  LightstormDeferredCompositeBindings
+>;
+
+/** Preserves Lightstorm's authored HDR fog and emissive energy under clustered deferred light. */
+export function createLightstormDeferredLightingShaderPassPipeline(
+  colorFormat: TextureFormatColor
+): ShaderPassPipeline<'deferredLighting'> {
+  return {
+    name: 'lightstormDeferredLightingShaderPassPipeline',
+    renderTargets: {
+      deferredLighting: {format: colorFormat}
+    },
+    steps: [
+      {
+        shaderPass: clusteredDeferredLighting,
+        inputs: {sourceTexture: 'original'},
+        output: 'deferredLighting'
+      },
+      {
+        shaderPass: lightstormDeferredComposite,
+        inputs: {
+          sourceTexture: 'deferredLighting',
+          forwardColorTexture: 'original'
+        },
+        output: 'previous'
+      }
+    ]
+  };
+}
+
 export const LIGHTSTORM_RENDER_SHADER = /* wgsl */ `
 struct LightstormInstance {
   positionRadius: vec4<f32>,
@@ -15,6 +148,7 @@ struct LightstormUniforms {
   frustum: vec4<f32>,
   options: vec4<f32>,
   scene: vec4<f32>,
+  previousViewProjectionMatrix: mat4x4<f32>,
 };
 
 @group(0) @binding(0) var<storage, read> instances: array<LightstormInstance>;
@@ -35,6 +169,16 @@ struct VertexOutput {
   @location(4) seedAndKind: vec2<f32>,
   @location(5) viewDepth: f32,
   @location(6) @interpolate(flat) sourceIndex: u32,
+  @location(7) currentClip: vec4<f32>,
+  @location(8) previousClip: vec4<f32>,
+};
+
+struct FragmentOutput {
+  @location(0) color: vec4<f32>,
+  @location(1) normalRoughness: vec4<f32>,
+  @location(2) velocity: vec2<f32>,
+  @location(3) baseColorMetallic: vec4<f32>,
+  @location(4) emissiveOcclusion: vec4<u32>,
 };
 
 @vertex fn vertexMain(
@@ -46,8 +190,10 @@ struct VertexOutput {
   let localPosition = inputs.positions * instance.halfExtentsSeed.xyz;
   let worldPosition = localPosition + instance.positionRadius.xyz;
   let viewPosition = uniforms.viewMatrix * vec4<f32>(worldPosition, 1.0);
+  let currentClip = uniforms.viewProjectionMatrix * vec4<f32>(worldPosition, 1.0);
+  let previousClip = uniforms.previousViewProjectionMatrix * vec4<f32>(worldPosition, 1.0);
   var output: VertexOutput;
-  output.position = uniforms.viewProjectionMatrix * vec4<f32>(worldPosition, 1.0);
+  output.position = currentClip;
   output.normal = inputs.normals;
   output.worldPosition = worldPosition;
   output.localPosition = localPosition;
@@ -55,6 +201,8 @@ struct VertexOutput {
   output.seedAndKind = vec2<f32>(instance.halfExtentsSeed.w, instance.colorAndKind.w);
   output.viewDepth = -viewPosition.z;
   output.sourceIndex = sourceIndex;
+  output.currentClip = currentClip;
+  output.previousClip = previousClip;
   return output;
 }
 
@@ -62,7 +210,7 @@ fn hashWindow(value: vec2<f32>) -> f32 {
   return fract(sin(dot(value, vec2<f32>(127.1, 311.7))) * 43758.5453);
 }
 
-@fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+@fragment fn fragmentMain(input: VertexOutput) -> FragmentOutput {
   let normal = normalize(input.normal);
   let seed = input.seedAndKind.x;
   let isTransit = input.seedAndKind.y > 0.5;
@@ -71,20 +219,26 @@ fn hashWindow(value: vec2<f32>) -> f32 {
   let diffuse = max(dot(normal, lightDirection), 0.0);
   let rim = pow(1.0 - abs(normal.z), 3.0);
   var color = input.baseColor * (0.22 + diffuse * 0.72 + rim * 0.08);
+  var surfaceBaseColor = input.baseColor;
+  var emissive = vec3<f32>(0.0);
 
   let radialDistance = length(input.worldPosition.xz);
   let travelingWave = pow(
     0.5 + 0.5 * cos(radialDistance * 0.035 - time * 2.5 + seed * 6.28318),
     10.0
   );
-  let skyPulse = pow(max(sin(time * 0.73 - 0.9), 0.0), 24.0);
   let lightstormEnabled = uniforms.options.w > 0.5;
+  let skyPulse = select(0.0, clamp(uniforms.scene.w, 0.0, 1.0), lightstormEnabled);
 
   if (isTransit) {
     let laneCoordinate = min(abs(input.localPosition.x), abs(input.localPosition.z));
     let laneLine = 1.0 - smoothstep(0.025, 0.16, laneCoordinate);
-    let transitEnergy = 0.55 + laneLine * 1.8 + travelingWave * 4.5;
-    color = input.baseColor * select(1.2, transitEnergy, lightstormEnabled);
+    let pavementColor = vec3<f32>(0.008, 0.012, 0.02) + input.baseColor * 0.12;
+    let pavementLighting = 0.68 + diffuse * 0.22;
+    let laneEnergy = laneLine * select(0.32, 0.3 + travelingWave * 3.8, lightstormEnabled);
+    color = pavementColor * pavementLighting + input.baseColor * laneEnergy;
+    surfaceBaseColor = pavementColor;
+    emissive = input.baseColor * laneEnergy;
   } else if (abs(normal.y) < 0.5) {
     var facadePosition = vec2<f32>(input.worldPosition.x, input.worldPosition.y);
     if (abs(normal.x) > 0.5) {
@@ -103,21 +257,281 @@ fn hashWindow(value: vec2<f32>) -> f32 {
     let warmWindow = mix(vec3<f32>(0.28, 0.72, 1.35), vec3<f32>(1.35, 0.48, 0.2), seed);
     let windowEnergy = select(0.42, 0.55 + travelingWave * 5.2, lightstormEnabled);
     color += warmWindow * windowMask * windowEnergy;
+    emissive += warmWindow * windowMask * windowEnergy;
   } else {
     let roofBeacon = pow(max(0.0, 1.0 - length(input.localPosition.xz) * 0.65), 8.0);
-    color += vec3<f32>(0.3, 0.75, 1.5) * roofBeacon * (0.35 + travelingWave * 2.0);
+    let roofEnergy = select(0.35, 0.35 + travelingWave * 2.0, lightstormEnabled);
+    color += vec3<f32>(0.3, 0.75, 1.5) * roofBeacon * roofEnergy;
+    emissive += vec3<f32>(0.3, 0.75, 1.5) * roofBeacon * roofEnergy;
   }
 
   let highlighted =
     uniforms.options.y > 0.5 && input.sourceIndex == u32(uniforms.options.y - 1.0);
   color = select(color, vec3<f32>(3.5, 1.35, 0.12), highlighted);
+  emissive = select(emissive, vec3<f32>(3.5, 1.35, 0.12), highlighted);
 
   let fogAmount = 1.0 - exp(-max(input.viewDepth, 0.0) * 0.00165);
-  let fogColor = vec3<f32>(0.008, 0.018, 0.055) + vec3<f32>(0.2, 0.34, 0.72) * skyPulse;
+  let fogColor =
+    vec3<f32>(0.008, 0.018, 0.055) + vec3<f32>(0.1, 0.16, 0.34) * skyPulse;
   color = mix(color, fogColor, clamp(fogAmount, 0.0, 0.96));
-  color += vec3<f32>(0.12, 0.2, 0.48) * skyPulse * (1.0 - fogAmount * 0.5);
   color *= uniforms.scene.y;
-  return vec4<f32>(color, 1.0);
+
+  let viewNormal = normalize((uniforms.viewMatrix * vec4<f32>(normal, 0.0)).xyz);
+  let roughness = select(0.52, 0.24, isTransit);
+  let metallic = select(0.12, 0.58, isTransit);
+  let currentUv =
+    input.currentClip.xy / max(input.currentClip.w, 0.00001) * vec2<f32>(0.5, -0.5) + 0.5;
+  let previousUv =
+    input.previousClip.xy / max(input.previousClip.w, 0.00001) * vec2<f32>(0.5, -0.5) + 0.5;
+
+  var output: FragmentOutput;
+  output.color = vec4<f32>(color, 1.0);
+  output.normalRoughness = vec4<f32>(viewNormal * 0.5 + 0.5, roughness);
+  output.velocity = currentUv - previousUv;
+  output.baseColorMetallic = vec4<f32>(surfaceBaseColor, metallic);
+  output.emissiveOcclusion = vec4<u32>(
+    round(clamp(vec4<f32>(emissive, 1.0), vec4<f32>(0.0), vec4<f32>(1.0)) * 255.0)
+  );
+  return output;
+}`;
+
+/** Draws curb-mounted beacon masts and heads at the exact world-space clustered-light positions. */
+export const LIGHTSTORM_LIGHT_MARKER_SHADER = /* wgsl */ `
+struct LightstormLightMarker {
+  positionRange: vec4<f32>,
+  colorIntensity: vec4<f32>,
+  pulse: vec4<f32>,
+};
+
+struct LightstormUniforms {
+  viewProjectionMatrix: mat4x4<f32>,
+  viewMatrix: mat4x4<f32>,
+  frustum: vec4<f32>,
+  options: vec4<f32>,
+  scene: vec4<f32>,
+  previousViewProjectionMatrix: mat4x4<f32>,
+};
+
+@group(0) @binding(0) var<storage, read> lightMarkers: array<LightstormLightMarker>;
+@group(0) @binding(1) var<uniform> uniforms: LightstormUniforms;
+
+struct VertexInputs {
+  @location(0) positions: vec3<f32>,
+  @location(1) normals: vec3<f32>,
+};
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) viewNormal: vec3<f32>,
+  @location(1) viewDepth: f32,
+  @location(2) currentClip: vec4<f32>,
+  @location(3) previousClip: vec4<f32>,
+  @location(4) color: vec3<f32>,
+  @location(5) authoredEnergy: f32,
+  @location(6) pulse: vec2<f32>,
+};
+
+struct FragmentOutput {
+  @location(0) color: vec4<f32>,
+  @location(1) normalRoughness: vec4<f32>,
+  @location(2) velocity: vec2<f32>,
+  @location(3) baseColorMetallic: vec4<f32>,
+  @location(4) emissiveOcclusion: vec4<u32>,
+};
+
+@vertex fn vertexMain(
+  inputs: VertexInputs,
+  @builtin(instance_index) instanceIndex: u32
+) -> VertexOutput {
+  let marker = lightMarkers[instanceIndex / 2u];
+  let isBeaconHead = instanceIndex % 2u == 0u;
+  let transitSurfaceY = 0.01;
+  let markerViewDepth = max(
+    -(uniforms.viewMatrix * vec4<f32>(marker.positionRange.xyz, 1.0)).z,
+    0.0
+  );
+  let markerRadius = max(0.24 + marker.positionRange.w * 0.006, markerViewDepth * 0.0024);
+  let beaconHalfExtents = vec3<f32>(markerRadius, markerRadius * 1.25, markerRadius);
+  let postHalfExtents = vec3<f32>(0.075, (marker.positionRange.y - transitSurfaceY) * 0.5, 0.075);
+  let postCenter = vec3<f32>(
+    marker.positionRange.x,
+    transitSurfaceY + postHalfExtents.y,
+    marker.positionRange.z
+  );
+  let markerCenter = select(postCenter, marker.positionRange.xyz, isBeaconHead);
+  let halfExtents = select(postHalfExtents, beaconHalfExtents, isBeaconHead);
+  let worldPosition = markerCenter + inputs.positions * halfExtents;
+  let viewPosition = uniforms.viewMatrix * vec4<f32>(worldPosition, 1.0);
+  let currentClip = uniforms.viewProjectionMatrix * vec4<f32>(worldPosition, 1.0);
+  let previousClip = uniforms.previousViewProjectionMatrix * vec4<f32>(worldPosition, 1.0);
+
+  var output: VertexOutput;
+  output.position = currentClip;
+  output.viewNormal = normalize((uniforms.viewMatrix * vec4<f32>(inputs.normals, 0.0)).xyz);
+  output.viewDepth = -viewPosition.z;
+  output.currentClip = currentClip;
+  output.previousClip = previousClip;
+  let headColor = mix(marker.colorIntensity.rgb, vec3<f32>(1.0), 0.32);
+  output.color = select(marker.colorIntensity.rgb, headColor, isBeaconHead);
+  output.authoredEnergy = select(
+    0.32,
+    3.4 + marker.colorIntensity.w * 0.18,
+    isBeaconHead
+  );
+  output.pulse = marker.pulse.xy;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutput) -> FragmentOutput {
+  let lightstormEnabled = uniforms.options.w > 0.5;
+  let pulse = select(
+    1.0,
+    1.0 + sin(input.pulse.x + uniforms.scene.x * input.pulse.y) * 0.07,
+    lightstormEnabled
+  );
+  let energy = input.authoredEnergy * pulse;
+  let emissive = input.color * energy;
+  let fogAmount = 1.0 - exp(-max(input.viewDepth, 0.0) * 0.00165);
+  let fogColor = vec3<f32>(0.008, 0.018, 0.055);
+  let fogFactor = clamp(fogAmount * 0.65, 0.0, 0.88);
+  let color = mix(emissive, fogColor, fogFactor);
+  let currentUv =
+    input.currentClip.xy / max(input.currentClip.w, 0.00001) * vec2<f32>(0.5, -0.5) + 0.5;
+  let previousUv =
+    input.previousClip.xy / max(input.previousClip.w, 0.00001) * vec2<f32>(0.5, -0.5) + 0.5;
+
+  var output: FragmentOutput;
+  output.color = vec4<f32>(color, 1.0);
+  output.normalRoughness = vec4<f32>(input.viewNormal * 0.5 + 0.5, 0.18);
+  output.velocity = currentUv - previousUv;
+  output.baseColorMetallic = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+  output.emissiveOcclusion = vec4<u32>(
+    round(clamp(vec4<f32>(emissive, 1.0), vec4<f32>(0.0), vec4<f32>(1.0)) * 255.0)
+  );
+  return output;
+}`;
+
+/** Draws sparse world-space HDR lightning as connected cuboid segments. */
+export const LIGHTSTORM_LIGHTNING_SHADER = /* wgsl */ `
+struct LightstormLightningSegment {
+  startWidth: vec4<f32>,
+  endSeed: vec4<f32>,
+  colorIntensity: vec4<f32>,
+  timing: vec4<f32>,
+};
+
+struct LightstormUniforms {
+  viewProjectionMatrix: mat4x4<f32>,
+  viewMatrix: mat4x4<f32>,
+  frustum: vec4<f32>,
+  options: vec4<f32>,
+  scene: vec4<f32>,
+  previousViewProjectionMatrix: mat4x4<f32>,
+};
+
+@group(0) @binding(0) var<storage, read> lightningSegments: array<LightstormLightningSegment>;
+@group(0) @binding(1) var<uniform> uniforms: LightstormUniforms;
+
+struct VertexInputs {
+  @location(0) positions: vec3<f32>,
+  @location(1) normals: vec3<f32>,
+};
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) viewNormal: vec3<f32>,
+  @location(1) viewDepth: f32,
+  @location(2) currentClip: vec4<f32>,
+  @location(3) previousClip: vec4<f32>,
+  @location(4) color: vec3<f32>,
+  @location(5) intensity: f32,
+  @location(6) timing: vec4<f32>,
+  @location(7) seed: f32,
+};
+
+struct FragmentOutput {
+  @location(0) color: vec4<f32>,
+  @location(1) normalRoughness: vec4<f32>,
+  @location(2) velocity: vec2<f32>,
+  @location(3) baseColorMetallic: vec4<f32>,
+  @location(4) emissiveOcclusion: vec4<u32>,
+};
+
+@vertex fn vertexMain(
+  inputs: VertexInputs,
+  @builtin(instance_index) instanceIndex: u32
+) -> VertexOutput {
+  let segment = lightningSegments[instanceIndex];
+  let segmentVector = segment.endSeed.xyz - segment.startWidth.xyz;
+  let segmentLength = max(length(segmentVector), 0.0001);
+  let tangent = segmentVector / segmentLength;
+  var referenceAxis = vec3<f32>(0.0, 1.0, 0.0);
+  if (abs(dot(tangent, referenceAxis)) > 0.94) {
+    referenceAxis = vec3<f32>(1.0, 0.0, 0.0);
+  }
+  let across = normalize(cross(referenceAxis, tangent));
+  let forward = normalize(cross(tangent, across));
+  let center = (segment.startWidth.xyz + segment.endSeed.xyz) * 0.5;
+  let worldPosition =
+    center +
+    across * inputs.positions.x * segment.startWidth.w +
+    tangent * inputs.positions.y * segmentLength * 0.5 +
+    forward * inputs.positions.z * segment.startWidth.w;
+  let worldNormal = normalize(
+    across * inputs.normals.x + tangent * inputs.normals.y + forward * inputs.normals.z
+  );
+  let viewPosition = uniforms.viewMatrix * vec4<f32>(worldPosition, 1.0);
+  let currentClip = uniforms.viewProjectionMatrix * vec4<f32>(worldPosition, 1.0);
+  let previousClip = uniforms.previousViewProjectionMatrix * vec4<f32>(worldPosition, 1.0);
+
+  var output: VertexOutput;
+  output.position = currentClip;
+  output.viewNormal = normalize((uniforms.viewMatrix * vec4<f32>(worldNormal, 0.0)).xyz);
+  output.viewDepth = -viewPosition.z;
+  output.currentClip = currentClip;
+  output.previousClip = previousClip;
+  output.color = segment.colorIntensity.rgb;
+  output.intensity = segment.colorIntensity.w;
+  output.timing = segment.timing;
+  output.seed = segment.endSeed.w;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutput) -> FragmentOutput {
+  let cycleTime = fract(
+    (uniforms.scene.z - input.timing.x) / max(input.timing.y, 0.001)
+  ) * input.timing.y;
+  let firstStrike = exp(-pow(cycleTime / ${LIGHTSTORM_LIGHTNING_STRIKE_WIDTH_SECONDS}, 2.0));
+  let returnStroke = exp(-pow(
+    (cycleTime - ${LIGHTSTORM_LIGHTNING_RETURN_STROKE_DELAY_SECONDS}) /
+      ${LIGHTSTORM_LIGHTNING_RETURN_STROKE_WIDTH_SECONDS},
+    2.0
+  )) * ${LIGHTSTORM_LIGHTNING_RETURN_STROKE_SCALE};
+  let branchScale = select(1.0, 0.72, input.timing.z > 0.5);
+  let segmentFlicker = 0.88 + 0.12 * sin(uniforms.scene.z * 94.0 + input.seed * 53.0);
+  let strike = max(firstStrike, returnStroke) * branchScale * segmentFlicker;
+  if (uniforms.options.w < 0.5 || strike < 0.012) {
+    discard;
+  }
+
+  let emissive = input.color * input.intensity * strike;
+  let fogAmount = 1.0 - exp(-max(input.viewDepth, 0.0) * 0.00165);
+  let fogColor = vec3<f32>(0.008, 0.018, 0.055);
+  let color = mix(emissive, fogColor, clamp(fogAmount * 0.42, 0.0, 0.72));
+  let currentUv =
+    input.currentClip.xy / max(input.currentClip.w, 0.00001) * vec2<f32>(0.5, -0.5) + 0.5;
+  let previousUv =
+    input.previousClip.xy / max(input.previousClip.w, 0.00001) * vec2<f32>(0.5, -0.5) + 0.5;
+
+  var output: FragmentOutput;
+  output.color = vec4<f32>(color, 1.0);
+  output.normalRoughness = vec4<f32>(input.viewNormal * 0.5 + 0.5, 0.08);
+  output.velocity = currentUv - previousUv;
+  output.baseColorMetallic = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+  output.emissiveOcclusion = vec4<u32>(
+    round(clamp(vec4<f32>(emissive, 1.0), vec4<f32>(0.0), vec4<f32>(1.0)) * 255.0)
+  );
+  return output;
 }`;
 
 export const LIGHTSTORM_PICKING_SHADER = /* wgsl */ `

--- a/examples/showcase/lightstorm-megacity/lightstorm-thunder.ts
+++ b/examples/showcase/lightstorm-megacity/lightstorm-thunder.ts
@@ -1,0 +1,395 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  LIGHTSTORM_LIGHTNING_SCHEDULE,
+  type LightstormLightningBoltRole
+} from './lightstorm-lightning';
+
+const MINIMUM_GAIN = 0.0001;
+
+const THUNDER_STRENGTH_BY_ROLE: Record<LightstormLightningBoltRole, number> = {
+  canyon: 0.92,
+  avenue: 0.82,
+  reveal: 1.25
+};
+
+const THUNDER_PAN_BY_ROLE: Record<LightstormLightningBoltRole, number> = {
+  canyon: 0.42,
+  avenue: -0.36,
+  reveal: 0.08
+};
+
+export type LightstormThunderStatus = 'waiting' | 'ready' | 'muted' | 'unavailable';
+
+export type LightstormThunderStrike = {
+  boltIndex: number;
+  role: LightstormLightningBoltRole;
+  strikeTimeSeconds: number;
+  strength: number;
+};
+
+/**
+ * Finds primary lightning phases crossed since the previous frame. Return strokes are deliberately
+ * absent from this timeline so every visual bolt produces exactly one thunder event.
+ */
+export function getLightstormThunderStrikeCrossings(
+  previousTimeSeconds: number | null,
+  timeSeconds: number,
+  lightstormEnabled = true
+): LightstormThunderStrike[] {
+  if (
+    !lightstormEnabled ||
+    previousTimeSeconds === null ||
+    !Number.isFinite(previousTimeSeconds) ||
+    !Number.isFinite(timeSeconds) ||
+    timeSeconds <= previousTimeSeconds
+  ) {
+    return [];
+  }
+
+  const crossings: LightstormThunderStrike[] = [];
+  for (let boltIndex = 0; boltIndex < LIGHTSTORM_LIGHTNING_SCHEDULE.length; boltIndex++) {
+    const bolt = LIGHTSTORM_LIGHTNING_SCHEDULE[boltIndex]!;
+    const cycleIndex = Math.floor((timeSeconds - bolt.phaseSeconds) / bolt.periodSeconds);
+    const strikeTimeSeconds = bolt.phaseSeconds + cycleIndex * bolt.periodSeconds;
+    if (strikeTimeSeconds > previousTimeSeconds && strikeTimeSeconds <= timeSeconds) {
+      crossings.push({
+        boltIndex,
+        role: bolt.role,
+        strikeTimeSeconds,
+        strength: THUNDER_STRENGTH_BY_ROLE[bolt.role]
+      });
+    }
+  }
+  return crossings.sort((first, second) => first.strikeTimeSeconds - second.strikeTimeSeconds);
+}
+
+/** Gesture-activated procedural thunder with no fetched or decoded audio assets. */
+export class LightstormThunderController {
+  private audioContext: AudioContext | null = null;
+  private masterGain: GainNode | null = null;
+  private previousTimeSeconds: number | null = null;
+  private readonly activeSources = new Set<AudioScheduledSourceNode>();
+  private audioEnabled = true;
+  private destroyed = false;
+
+  get enabled(): boolean {
+    return this.audioEnabled;
+  }
+
+  get status(): LightstormThunderStatus {
+    if (!this.audioEnabled) {
+      return 'muted';
+    }
+    if (this.audioContext?.state === 'running') {
+      return 'ready';
+    }
+    return getAudioContextConstructor() ? 'waiting' : 'unavailable';
+  }
+
+  /** Must be called from a pointer or keyboard event to satisfy browser autoplay policies. */
+  async activate(): Promise<void> {
+    if (this.destroyed || !this.audioEnabled) {
+      return;
+    }
+    const AudioContextConstructor = getAudioContextConstructor();
+    if (!AudioContextConstructor) {
+      return;
+    }
+    if (!this.audioContext) {
+      this.audioContext = new AudioContextConstructor({latencyHint: 'interactive'});
+      this.masterGain = makeMasterGain(this.audioContext);
+    }
+    if (this.audioContext.state !== 'running' && this.audioContext.state !== 'closed') {
+      await this.audioContext.resume();
+    }
+    if (this.audioContext.state === 'running') {
+      // Start from the next live frame instead of consuming strikes while audio was locked.
+      this.previousTimeSeconds = null;
+    }
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.audioEnabled = enabled;
+    if (!enabled) {
+      this.stopActiveSources();
+    }
+  }
+
+  update(timeSeconds: number, lightstormEnabled = true): void {
+    if (this.audioContext?.state !== 'running' || !this.masterGain) {
+      this.previousTimeSeconds = null;
+      return;
+    }
+    const crossings = getLightstormThunderStrikeCrossings(
+      this.previousTimeSeconds,
+      timeSeconds,
+      lightstormEnabled && this.audioEnabled
+    );
+    this.previousTimeSeconds = Number.isFinite(timeSeconds) ? timeSeconds : null;
+
+    for (const crossing of crossings) {
+      this.playStrike(crossing);
+    }
+  }
+
+  /** Drops timeline state and silences any rumble left over from the previous camera run. */
+  reset(): void {
+    this.previousTimeSeconds = null;
+    this.stopActiveSources();
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.stopActiveSources();
+    const audioContext = this.audioContext;
+    this.audioContext = null;
+    this.masterGain = null;
+    if (audioContext && audioContext.state !== 'closed') {
+      void audioContext.close().catch(() => {});
+    }
+  }
+
+  private playStrike(strike: LightstormThunderStrike): void {
+    const audioContext = this.audioContext;
+    const masterGain = this.masterGain;
+    if (!audioContext || !masterGain) {
+      return;
+    }
+
+    const startTime = audioContext.currentTime + 0.012;
+    const stereoPan = THUNDER_PAN_BY_ROLE[strike.role];
+    const randomSeed = 0x9e3779b9 ^ ((strike.boltIndex + 1) * 0x85ebca6b);
+    this.playCrack(audioContext, masterGain, startTime, strike.strength, stereoPan, randomSeed);
+    this.playBody(audioContext, masterGain, startTime + 0.012, strike.strength, stereoPan * 0.65);
+    this.playRumble(
+      audioContext,
+      masterGain,
+      startTime + 0.055,
+      strike.strength,
+      stereoPan * 0.45,
+      randomSeed ^ 0xc2b2ae35,
+      strike.role === 'reveal'
+    );
+  }
+
+  private playCrack(
+    audioContext: AudioContext,
+    destination: AudioNode,
+    startTime: number,
+    strength: number,
+    stereoPan: number,
+    randomSeed: number
+  ): void {
+    const duration = 0.28;
+    const noise = audioContext.createBufferSource();
+    noise.buffer = makeNoiseBuffer(audioContext, duration, randomSeed);
+    const highPass = audioContext.createBiquadFilter();
+    highPass.type = 'highpass';
+    highPass.frequency.setValueAtTime(240, startTime);
+    highPass.Q.value = 0.72;
+    const crackGain = audioContext.createGain();
+    crackGain.gain.setValueAtTime(MINIMUM_GAIN, startTime);
+    crackGain.gain.linearRampToValueAtTime(0.58 * strength, startTime + 0.004);
+    crackGain.gain.exponentialRampToValueAtTime(MINIMUM_GAIN, startTime + duration);
+    const panner = audioContext.createStereoPanner();
+    panner.pan.value = stereoPan;
+
+    noise.connect(highPass).connect(crackGain).connect(panner).connect(destination);
+    this.startSource(noise, startTime, startTime + duration);
+  }
+
+  private playBody(
+    audioContext: AudioContext,
+    destination: AudioNode,
+    startTime: number,
+    strength: number,
+    stereoPan: number
+  ): void {
+    const duration = 0.95;
+    const oscillator = audioContext.createOscillator();
+    oscillator.type = 'triangle';
+    oscillator.frequency.setValueAtTime(118, startTime);
+    oscillator.frequency.exponentialRampToValueAtTime(44, startTime + duration);
+    const lowPass = audioContext.createBiquadFilter();
+    lowPass.type = 'lowpass';
+    lowPass.frequency.value = 260;
+    lowPass.Q.value = 0.82;
+    const bodyGain = audioContext.createGain();
+    bodyGain.gain.setValueAtTime(MINIMUM_GAIN, startTime);
+    bodyGain.gain.linearRampToValueAtTime(0.44 * strength, startTime + 0.018);
+    bodyGain.gain.exponentialRampToValueAtTime(0.18 * strength, startTime + 0.16);
+    bodyGain.gain.exponentialRampToValueAtTime(MINIMUM_GAIN, startTime + duration);
+    const panner = audioContext.createStereoPanner();
+    panner.pan.value = stereoPan;
+
+    oscillator.connect(lowPass).connect(bodyGain).connect(panner).connect(destination);
+    this.startSource(oscillator, startTime, startTime + duration);
+  }
+
+  private playRumble(
+    audioContext: AudioContext,
+    destination: AudioNode,
+    startTime: number,
+    strength: number,
+    stereoPan: number,
+    randomSeed: number,
+    isHeroStrike: boolean
+  ): void {
+    const nextRandomValue = makeDeterministicRandom(randomSeed);
+    const rollCount = isHeroStrike ? 5 : 3 + Math.floor(nextRandomValue() * 2);
+    let rollOffsetSeconds = 0;
+
+    for (let rollIndex = 0; rollIndex < rollCount; rollIndex++) {
+      const rollStartTime = startTime + rollOffsetSeconds;
+      const rollDuration =
+        (isHeroStrike ? 1.18 : 0.96) + nextRandomValue() * (isHeroStrike ? 0.82 : 0.68);
+      const rollStopTime = rollStartTime + rollDuration;
+      const attackDuration = 0.045 + nextRandomValue() * 0.105;
+      const crestDuration = 0.18 + nextRandomValue() * 0.24;
+      const peakGain = strength * (0.145 + nextRandomValue() * 0.065) * (1 - rollIndex * 0.055);
+
+      const noise = audioContext.createBufferSource();
+      const rollNoiseSeed = randomSeed ^ Math.imul(rollIndex + 1, 0x85ebca6b);
+      noise.buffer = makeNoiseBuffer(audioContext, rollDuration, rollNoiseSeed);
+      const noiseLowPass = audioContext.createBiquadFilter();
+      noiseLowPass.type = 'lowpass';
+      noiseLowPass.frequency.setValueAtTime(215 + nextRandomValue() * 105, rollStartTime);
+      noiseLowPass.frequency.exponentialRampToValueAtTime(
+        78 + nextRandomValue() * 34,
+        rollStopTime
+      );
+      noiseLowPass.Q.value = 0.72 + nextRandomValue() * 0.58;
+      const noiseGain = audioContext.createGain();
+      noiseGain.gain.value = 0.72;
+
+      const fundamentalFrequency = (isHeroStrike ? 48 : 54) + nextRandomValue() * 14;
+      const endingFundamentalFrequency = 32 + nextRandomValue() * 9;
+      const fundamentalOscillator = audioContext.createOscillator();
+      fundamentalOscillator.type = 'sine';
+      fundamentalOscillator.frequency.setValueAtTime(fundamentalFrequency, rollStartTime);
+      fundamentalOscillator.frequency.exponentialRampToValueAtTime(
+        endingFundamentalFrequency,
+        rollStopTime
+      );
+      const fundamentalGain = audioContext.createGain();
+      fundamentalGain.gain.value = isHeroStrike ? 0.42 : 0.36;
+
+      // This restrained octave-plus partial keeps the rumble audible on laptop speakers.
+      const harmonicOscillator = audioContext.createOscillator();
+      harmonicOscillator.type = 'triangle';
+      harmonicOscillator.frequency.setValueAtTime(
+        fundamentalFrequency * (2.05 + nextRandomValue() * 0.28),
+        rollStartTime
+      );
+      harmonicOscillator.frequency.exponentialRampToValueAtTime(
+        endingFundamentalFrequency * (2.1 + nextRandomValue() * 0.22),
+        rollStopTime
+      );
+      const harmonicGain = audioContext.createGain();
+      harmonicGain.gain.value = 0.105 + nextRandomValue() * 0.055;
+
+      const rollGain = audioContext.createGain();
+      rollGain.gain.setValueAtTime(MINIMUM_GAIN, rollStartTime);
+      rollGain.gain.linearRampToValueAtTime(peakGain, rollStartTime + attackDuration);
+      rollGain.gain.exponentialRampToValueAtTime(
+        peakGain * (0.42 + nextRandomValue() * 0.18),
+        rollStartTime + attackDuration + crestDuration
+      );
+      rollGain.gain.exponentialRampToValueAtTime(MINIMUM_GAIN, rollStopTime);
+      const panner = audioContext.createStereoPanner();
+      panner.pan.value = Math.max(-1, Math.min(1, stereoPan + (nextRandomValue() - 0.5) * 0.18));
+
+      noise.connect(noiseLowPass).connect(noiseGain).connect(rollGain);
+      fundamentalOscillator.connect(fundamentalGain).connect(rollGain);
+      harmonicOscillator.connect(harmonicGain).connect(rollGain);
+      rollGain.connect(panner).connect(destination);
+      this.startSource(noise, rollStartTime, rollStopTime);
+      this.startSource(fundamentalOscillator, rollStartTime, rollStopTime);
+      this.startSource(harmonicOscillator, rollStartTime, rollStopTime);
+
+      // Advance less than one roll's duration so neighboring rolls overlap naturally.
+      rollOffsetSeconds += 0.31 + nextRandomValue() * (isHeroStrike ? 0.34 : 0.29);
+    }
+  }
+
+  private startSource(source: AudioScheduledSourceNode, startTime: number, stopTime: number): void {
+    this.activeSources.add(source);
+    source.addEventListener(
+      'ended',
+      () => {
+        this.activeSources.delete(source);
+        source.disconnect();
+      },
+      {once: true}
+    );
+    source.start(startTime);
+    source.stop(stopTime);
+  }
+
+  private stopActiveSources(): void {
+    for (const source of this.activeSources) {
+      try {
+        source.stop();
+      } catch {
+        // A source can already be stopped while its final `ended` event is still queued.
+      }
+      source.disconnect();
+    }
+    this.activeSources.clear();
+  }
+}
+
+function makeMasterGain(audioContext: AudioContext): GainNode {
+  const masterGain = audioContext.createGain();
+  masterGain.gain.value = 0.8;
+  const compressor = audioContext.createDynamicsCompressor();
+  compressor.threshold.value = -12;
+  compressor.knee.value = 8;
+  compressor.ratio.value = 8;
+  compressor.attack.value = 0.002;
+  compressor.release.value = 0.32;
+  masterGain.connect(compressor).connect(audioContext.destination);
+  return masterGain;
+}
+
+function makeNoiseBuffer(
+  audioContext: AudioContext,
+  durationSeconds: number,
+  randomSeed: number
+): AudioBuffer {
+  const sampleCount = Math.ceil(audioContext.sampleRate * durationSeconds);
+  const buffer = audioContext.createBuffer(1, sampleCount, audioContext.sampleRate);
+  const samples = buffer.getChannelData(0);
+  let state = randomSeed >>> 0;
+  for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex++) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    samples[sampleIndex] = ((state >>> 0) / 0x80000000 - 1) * 0.82;
+  }
+  return buffer;
+}
+
+function makeDeterministicRandom(randomSeed: number): () => number {
+  let state = randomSeed >>> 0;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return (state >>> 0) / 0x100000000;
+  };
+}
+
+function getAudioContextConstructor(): typeof AudioContext | undefined {
+  if (typeof AudioContext !== 'undefined') {
+    return AudioContext;
+  }
+  return (
+    globalThis as typeof globalThis & {
+      webkitAudioContext?: typeof AudioContext;
+    }
+  ).webkitAudioContext;
+}

--- a/examples/showcase/lightstorm-megacity/vite.config.ts
+++ b/examples/showcase/lightstorm-megacity/vite.config.ts
@@ -2,6 +2,7 @@ import {defineConfig} from 'vite';
 
 const alias = {
   '@luma.gl/core': `${__dirname}/../../../modules/core/src`,
+  '@luma.gl/effects': `${__dirname}/../../../modules/effects/src`,
   '@luma.gl/engine': `${__dirname}/../../../modules/engine/src`,
   '@luma.gl/experimental': `${__dirname}/../../../modules/experimental/src`,
   '@luma.gl/shadertools': `${__dirname}/../../../modules/shadertools/src`,

--- a/modules/effects/src/passes/screen-space/screen-space-reflections.ts
+++ b/modules/effects/src/passes/screen-space/screen-space-reflections.ts
@@ -30,14 +30,17 @@ type SSRTemporalUniforms = {
 };
 
 type SSRSpatialUniforms = {
+  inverseProjectionMatrix: Readonly<NumberArray16>;
   direction: [number, number];
   maxRadius: number;
   depthSigma: number;
 };
 
 type SSRCompositeUniforms = {
+  inverseProjectionMatrix: Readonly<NumberArray16>;
   strength: number;
   debugMode: number;
+  depthSigma: number;
 };
 
 type SSRTraceBindings = {
@@ -103,8 +106,9 @@ fn ssrTrace_projectViewPosition(position: vec3f) -> vec2f {
   );
 }
 
-fn ssrTrace_hash(value: vec2f) -> f32 {
-  return fract(sin(dot(value, vec2f(12.9898, 78.233))) * 43758.5453);
+fn ssrTrace_hash(value: vec2f, frameIndex: f32) -> f32 {
+  let temporalPhase = fract(frameIndex * 0.61803398875) * SSR_TWO_PI;
+  return fract(sin(dot(value, vec2f(12.9898, 78.233)) + temporalPhase) * 43758.5453);
 }
 
 fn ssrTrace_sampleColor(
@@ -127,7 +131,7 @@ fn ssrTrace_sampleColor(
   let incidentDirection = normalize(viewPosition);
   let mirrorDirection = normalize(reflect(incidentDirection, normal));
   let pixelCoordinate = floor(sceneCoord * vec2f(textureDimensions(depthTexture)));
-  let noise = ssrTrace_hash(pixelCoordinate);
+  let noise = ssrTrace_hash(pixelCoordinate, ssrTrace.frameIndex);
   let noiseAngle = noise * SSR_TWO_PI;
   let referenceAxis = select(
     vec3f(0.0, 1.0, 0.0),
@@ -332,15 +336,27 @@ fn ssrTemporal_sampleColor(
     }
   }
 
-  let historyReflection = clamp(
-    textureSampleLevel(historyTexture, historyTextureSampler, clampedPreviousCoord, 0),
-    minimumReflection,
-    maximumReflection
+  let historyReflection = textureSampleLevel(
+    historyTexture,
+    historyTextureSampler,
+    clampedPreviousCoord,
+    0
   );
-  let validHistory = validCoordinate && validDepth && current.a > 0.001 &&
-    historyReflection.a > 0.001;
-  let historyWeight = select(0.0, ssrTemporal.historyWeight, validHistory);
-  return mix(current, historyReflection, historyWeight);
+  let validHistory = validCoordinate && validDepth && historyReflection.a > 0.001;
+  if (!validHistory) {
+    return current;
+  }
+
+  let hasCurrentSupport = maximumReflection.a > 0.001;
+  if (!hasCurrentSupport) {
+    return vec4f(
+      historyReflection.rgb,
+      historyReflection.a * ssrTemporal.historyWeight
+    );
+  }
+
+  let clampedHistory = clamp(historyReflection, minimumReflection, maximumReflection);
+  return mix(current, clampedHistory, ssrTemporal.historyWeight);
 }`,
   bindingLayout: [
     {name: 'historyTexture', group: 0},
@@ -393,6 +409,7 @@ export const ssrSpatial = {
   name: 'ssrSpatial',
   source: /* wgsl */ `\
 struct SSRSpatialUniforms {
+  inverseProjectionMatrix: mat4x4f,
   direction: vec2f,
   maxRadius: f32,
   depthSigma: f32,
@@ -403,6 +420,12 @@ struct SSRSpatialUniforms {
 @group(0) @binding(auto) var depthTextureSampler: sampler;
 @group(0) @binding(auto) var normalTexture: texture_2d<f32>;
 @group(0) @binding(auto) var normalTextureSampler: sampler;
+
+fn ssrSpatial_reconstructViewDepth(texCoord: vec2f, depth: f32) -> f32 {
+  let clip = vec4f(texCoord.x * 2.0 - 1.0, 1.0 - texCoord.y * 2.0, depth, 1.0);
+  let viewPosition = ssrSpatial.inverseProjectionMatrix * clip;
+  return abs(viewPosition.z / max(abs(viewPosition.w), 0.00001));
+}
 
 fn ssrSpatial_sampleColor(
   sourceTexture: texture_2d<f32>,
@@ -417,6 +440,7 @@ fn ssrSpatial_sampleColor(
   if (centerDepth >= 0.99999) {
     return vec4f(0.0);
   }
+  let centerViewDepth = ssrSpatial_reconstructViewDepth(texCoord, centerDepth);
   let hasCenterReflection = centerReflection.a > 0.001;
   if (!hasCenterReflection && roughness >= 0.28) {
     return centerReflection;
@@ -448,9 +472,11 @@ fn ssrSpatial_sampleColor(
       let sampleNormal = normalize(
         textureSampleLevel(normalTexture, normalTextureSampler, sampleCoord, 0).rgb * 2.0 - 1.0
       );
-      let depthDelta = abs(sampleDepth - centerDepth);
+      let sampleViewDepth = ssrSpatial_reconstructViewDepth(sampleCoord, sampleDepth);
+      let relativeDepthDelta = abs(sampleViewDepth - centerViewDepth) /
+        max(centerViewDepth, 0.0001);
       let depthWeight = exp(
-        -(depthDelta * depthDelta) /
+        -(relativeDepthDelta * relativeDepthDelta) /
           max(2.0 * ssrSpatial.depthSigma * ssrSpatial.depthSigma, 0.000001)
       );
       let normalWeight = pow(max(dot(centerNormal, sampleNormal), 0.0), 16.0);
@@ -483,14 +509,16 @@ fn ssrSpatial_sampleColor(
   uniforms: {} as SSRSpatialUniforms,
   bindings: {} as SSRSpatialBindings,
   uniformTypes: {
+    inverseProjectionMatrix: 'mat4x4<f32>',
     direction: 'vec2<f32>',
     maxRadius: 'f32',
     depthSigma: 'f32'
   },
   propTypes: {
+    inverseProjectionMatrix: {value: IDENTITY_MATRIX, private: true},
     direction: {value: [1, 0]},
     maxRadius: {value: 5, min: 0, max: 8},
-    depthSigma: {value: 0.012, min: 0.0001, softMax: 0.1}
+    depthSigma: {value: 0.035, min: 0.0001, softMax: 0.2}
   },
   passes: [{sampler: true}]
 } as const satisfies ShaderPass<
@@ -504,8 +532,10 @@ export const ssrComposite = {
   name: 'ssrComposite',
   source: /* wgsl */ `\
 struct SSRCompositeUniforms {
+  inverseProjectionMatrix: mat4x4f,
   strength: f32,
   debugMode: f32,
+  depthSigma: f32,
 };
 
 @group(0) @binding(auto) var<uniform> ssrComposite: SSRCompositeUniforms;
@@ -516,6 +546,12 @@ struct SSRCompositeUniforms {
 @group(0) @binding(auto) var normalTexture: texture_2d<f32>;
 @group(0) @binding(auto) var normalTextureSampler: sampler;
 
+fn ssrComposite_reconstructViewDepth(texCoord: vec2f, depth: f32) -> f32 {
+  let clip = vec4f(texCoord.x * 2.0 - 1.0, 1.0 - texCoord.y * 2.0, depth, 1.0);
+  let viewPosition = ssrComposite.inverseProjectionMatrix * clip;
+  return abs(viewPosition.z / max(abs(viewPosition.w), 0.00001));
+}
+
 fn ssrComposite_upsampleReflection(texCoord: vec2f) -> vec4f {
   let reflectionSize = vec2f(textureDimensions(reflectionTexture));
   let reflectionPosition = texCoord * reflectionSize - vec2f(0.5);
@@ -525,6 +561,7 @@ fn ssrComposite_upsampleReflection(texCoord: vec2f) -> vec4f {
   if (centerDepth >= 0.99999) {
     return textureSampleLevel(reflectionTexture, reflectionTextureSampler, texCoord, 0);
   }
+  let centerViewDepth = ssrComposite_reconstructViewDepth(texCoord, centerDepth);
   let centerNormal = normalize(
     textureSampleLevel(normalTexture, normalTextureSampler, texCoord, 0).rgb * 2.0 - 1.0
   );
@@ -553,7 +590,13 @@ fn ssrComposite_upsampleReflection(texCoord: vec2f) -> vec4f {
         reflectionFraction.y,
         sampleY == 1
       );
-      let depthWeight = exp(-abs(sampleDepth - centerDepth) * 140.0);
+      let sampleViewDepth = ssrComposite_reconstructViewDepth(sampleCoord, sampleDepth);
+      let relativeDepthDelta = abs(sampleViewDepth - centerViewDepth) /
+        max(centerViewDepth, 0.0001);
+      let depthWeight = exp(
+        -(relativeDepthDelta * relativeDepthDelta) /
+          max(2.0 * ssrComposite.depthSigma * ssrComposite.depthSigma, 0.000001)
+      );
       let normalWeight = pow(max(dot(centerNormal, sampleNormal), 0.0), 12.0);
       let weight = horizontalWeight * verticalWeight * depthWeight * normalWeight;
       reflection += textureLoad(reflectionTexture, reflectionPixel, 0) * weight;
@@ -591,10 +634,17 @@ fn ssrComposite_sampleColor(
   props: {} as Partial<SSRCompositeUniforms> & SSRCompositeBindings,
   uniforms: {} as SSRCompositeUniforms,
   bindings: {} as SSRCompositeBindings,
-  uniformTypes: {strength: 'f32', debugMode: 'f32'},
+  uniformTypes: {
+    inverseProjectionMatrix: 'mat4x4<f32>',
+    strength: 'f32',
+    debugMode: 'f32',
+    depthSigma: 'f32'
+  },
   propTypes: {
+    inverseProjectionMatrix: {value: IDENTITY_MATRIX, private: true},
     strength: {value: 1, min: 0, softMax: 2},
-    debugMode: {value: 0, min: 0, max: 2, private: true}
+    debugMode: {value: 0, min: 0, max: 2, private: true},
+    depthSigma: {value: 0.04, min: 0.0001, softMax: 0.2}
   },
   passes: [{sampler: true}]
 } as const satisfies ShaderPass<

--- a/modules/effects/test/passes/advanced-effects.spec.ts
+++ b/modules/effects/test/passes/advanced-effects.spec.ts
@@ -33,6 +33,9 @@ import {
   hdrLuminanceExtract,
   hdrLuminanceReduce,
   ssgiTemporal,
+  ssrComposite,
+  ssrSpatial,
+  ssrTrace,
   ssrTemporal
 } from '../../src';
 
@@ -388,6 +391,32 @@ test('advanced effects expose composable pipeline shapes', testCase => {
     ssrTemporal.uniformTypes.inverseProjectionMatrix,
     'mat4x4<f32>',
     'SSR temporal rejection reconstructs linear view-space depth'
+  );
+  testCase.ok(
+    ssrTrace.source.includes('ssrTrace_hash(pixelCoordinate, ssrTrace.frameIndex)'),
+    'SSR rotates its stochastic trace sample every frame'
+  );
+  testCase.equal(
+    ssrSpatial.uniformTypes.inverseProjectionMatrix,
+    'mat4x4<f32>',
+    'SSR denoising compares linear view-space depth'
+  );
+  testCase.ok(
+    ssrSpatial.source.includes('relativeDepthDelta'),
+    'SSR denoising rejects relative view-depth discontinuities'
+  );
+  testCase.equal(
+    ssrComposite.uniformTypes.inverseProjectionMatrix,
+    'mat4x4<f32>',
+    'SSR upsampling compares linear view-space depth'
+  );
+  testCase.ok(
+    ssrTemporal.source.includes('let hasCurrentSupport = maximumReflection.a > 0.001'),
+    'SSR temporal accumulation detects frame-local hit support'
+  );
+  testCase.ok(
+    ssrTemporal.source.includes('historyReflection.a * ssrTemporal.historyWeight'),
+    'SSR temporal accumulation decays valid history across stochastic misses'
   );
   testCase.end();
 });

--- a/test/examples/lightstorm-megacity.node.spec.ts
+++ b/test/examples/lightstorm-megacity.node.spec.ts
@@ -3,10 +3,55 @@
 // Copyright (c) vis.gl contributors
 
 import {describe, expect, test} from 'vitest';
+import {makeDeferredPointLightBufferData} from '@luma.gl/experimental';
+import {Matrix4} from '@math.gl/core';
 import {
+  LIGHTSTORM_GRID_SPACING,
   LIGHTSTORM_INSTANCE_WORD_COUNT,
+  type LightstormCityData,
   makeLightstormCity
 } from '../../examples/showcase/lightstorm-megacity/lightstorm-data';
+import {
+  getLightstormGuidedCameraSample,
+  LIGHTSTORM_CAMERA_FIELD_OF_VIEW,
+  type LightstormCameraSample,
+  type LightstormGuidedCameraTour,
+  makeLightstormGuidedCameraTour
+} from '../../examples/showcase/lightstorm-megacity/lightstorm-camera';
+import {
+  LIGHTSTORM_LIGHT_MARKER_WORD_COUNT,
+  LIGHTSTORM_POINT_LIGHT_COUNT,
+  makeLightstormLightMarkerBufferData,
+  makeLightstormPointLights,
+  makeLightstormViewPointLights
+} from '../../examples/showcase/lightstorm-megacity/lightstorm-lighting';
+import {
+  getLightstormLightningSkyPulse,
+  LIGHTSTORM_AVENUE_SKY_PULSE_AMPLITUDE,
+  LIGHTSTORM_AVENUE_STRIKE_SECONDS,
+  LIGHTSTORM_CANYON_SKY_PULSE_AMPLITUDE,
+  LIGHTSTORM_CANYON_STRIKE_SECONDS,
+  LIGHTSTORM_LIGHTNING_BOLT_COUNT,
+  LIGHTSTORM_LIGHTNING_RETURN_STROKE_DELAY_SECONDS,
+  LIGHTSTORM_LIGHTNING_RETURN_STROKE_SCALE,
+  LIGHTSTORM_LIGHTNING_SCHEDULE,
+  LIGHTSTORM_LIGHTNING_SEGMENT_CAPACITY,
+  LIGHTSTORM_LIGHTNING_SEGMENT_COUNT,
+  LIGHTSTORM_LIGHTNING_SEGMENT_WORD_COUNT,
+  LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS,
+  LIGHTSTORM_REVEAL_SKY_PULSE_AMPLITUDE,
+  LIGHTSTORM_REVEAL_STRIKE_SECONDS,
+  makeLightstormLightningBolts,
+  makeLightstormLightningBufferData,
+  makeLightstormLightningSegments
+} from '../../examples/showcase/lightstorm-megacity/lightstorm-lightning';
+import {getLightstormThunderStrikeCrossings} from '../../examples/showcase/lightstorm-megacity/lightstorm-thunder';
+
+const LIGHTSTORM_CAMERA_INSTANCE_COUNTS = [50_000, 250_000, 1_000_000] as const;
+const LIGHTSTORM_CAMERA_SAMPLES_PER_SECOND = 120;
+const LIGHTSTORM_CAMERA_ROOF_CLEARANCE = 8;
+const LIGHTSTORM_CAMERA_POSITION_EPSILON = 1e-5;
+const LIGHTSTORM_PROJECTION_TEST_ASPECT = 16 / 9;
 
 describe('Lightstorm Megacity data', () => {
   test('creates deterministic, conservatively bounded city records', () => {
@@ -33,3 +78,694 @@ describe('Lightstorm Megacity data', () => {
     }
   });
 });
+
+describe('Lightstorm Megacity lighting', () => {
+  test('creates a deterministic finite street-light lattice', () => {
+    const cityGridSize = 500;
+    const firstLights = makeLightstormPointLights(LIGHTSTORM_POINT_LIGHT_COUNT, cityGridSize);
+    const secondLights = makeLightstormPointLights(LIGHTSTORM_POINT_LIGHT_COUNT, cityGridSize);
+
+    expect(firstLights).toEqual(secondLights);
+    expect(firstLights).toHaveLength(LIGHTSTORM_POINT_LIGHT_COUNT);
+    expect(new Set(firstLights.map(light => light.color.join(','))).size).toBe(3);
+
+    for (let lightIndex = 0; lightIndex < firstLights.length; lightIndex++) {
+      const light = firstLights[lightIndex]!;
+      expect(light.worldPosition.every(Number.isFinite)).toBe(true);
+      expect(light.worldPosition[1]).toBeGreaterThan(0.01);
+      expect(light.range).toBeGreaterThanOrEqual(16);
+      expect(light.range).toBeLessThanOrEqual(24);
+      expect(light.color.every(value => Number.isFinite(value) && value >= 0)).toBe(true);
+      expect(light.intensity).toBeGreaterThan(0);
+      expect(light.intensity).toBeGreaterThanOrEqual(14);
+      expect(light.intensity).toBeLessThanOrEqual(24);
+      expect(Number.isFinite(light.pulsePhase)).toBe(true);
+      expect(light.pulsePhase).toBeGreaterThanOrEqual(0);
+      expect(light.pulseFrequency).toBeGreaterThan(0);
+      const gridX = light.worldPosition[0] / LIGHTSTORM_GRID_SPACING + (cityGridSize - 1) / 2;
+      const gridZ = light.worldPosition[2] / LIGHTSTORM_GRID_SPACING + (cityGridSize - 1) / 2;
+      const followsEastWestStreet = Math.floor(lightIndex / 16) % 2 === 0;
+      const alongStreetGridIndex = Math.round(followsEastWestStreet ? gridX : gridZ);
+      const curbGridCoordinate = followsEastWestStreet ? gridZ : gridX;
+      const curbGridIndex = Math.round(curbGridCoordinate);
+      expect(isTransitGridIndex(alongStreetGridIndex)).toBe(false);
+      expect(isTransitGridIndex(curbGridIndex)).toBe(true);
+      expect(Math.abs(curbGridCoordinate - curbGridIndex)).toBeCloseTo(0.375);
+      expect(
+        curbGridIndex % 12 === 0
+          ? curbGridCoordinate < curbGridIndex
+          : curbGridCoordinate > curbGridIndex
+      ).toBe(true);
+    }
+
+    const markerData = makeLightstormLightMarkerBufferData(firstLights);
+    expect(markerData).toHaveLength(
+      LIGHTSTORM_POINT_LIGHT_COUNT * LIGHTSTORM_LIGHT_MARKER_WORD_COUNT
+    );
+    for (let lightIndex = 0; lightIndex < firstLights.length; lightIndex++) {
+      const light = firstLights[lightIndex]!;
+      const wordOffset = lightIndex * LIGHTSTORM_LIGHT_MARKER_WORD_COUNT;
+      for (let componentIndex = 0; componentIndex < 3; componentIndex++) {
+        expect(markerData[wordOffset + componentIndex]).toBeCloseTo(
+          light.worldPosition[componentIndex]!
+        );
+        expect(markerData[wordOffset + 4 + componentIndex]).toBeCloseTo(
+          light.color[componentIndex]!
+        );
+      }
+    }
+  });
+
+  test('transforms and packs deterministic view-space point lights', () => {
+    const worldLights = makeLightstormPointLights();
+    const viewMatrix = new Matrix4().translate([4, -3, 2]);
+    const firstViewLights = makeLightstormViewPointLights(worldLights, viewMatrix, 2.75);
+    const secondViewLights = makeLightstormViewPointLights(worldLights, viewMatrix, 2.75);
+
+    expect(firstViewLights).toEqual(secondViewLights);
+    expect(firstViewLights).toHaveLength(LIGHTSTORM_POINT_LIGHT_COUNT);
+    expect(firstViewLights[0]?.position).toEqual(
+      Array.from(viewMatrix.transformAsPoint(worldLights[0]!.worldPosition))
+    );
+    const staticViewLightsAtStart = makeLightstormViewPointLights(
+      worldLights,
+      viewMatrix,
+      0,
+      false
+    );
+    const staticViewLightsLater = makeLightstormViewPointLights(
+      worldLights,
+      viewMatrix,
+      120,
+      false
+    );
+    expect(staticViewLightsAtStart).toEqual(staticViewLightsLater);
+    expect(staticViewLightsAtStart.map(light => light.intensity)).toEqual(
+      worldLights.map(light => light.intensity)
+    );
+    for (let lightIndex = 0; lightIndex < firstViewLights.length; lightIndex++) {
+      const light = firstViewLights[lightIndex]!;
+      const worldLight = worldLights[lightIndex]!;
+      expect(light.position.every(Number.isFinite)).toBe(true);
+      expect(Number.isFinite(light.range)).toBe(true);
+      expect(light.range).toBeGreaterThan(0);
+      expect(light.color.every(value => Number.isFinite(value) && value >= 0)).toBe(true);
+      expect(Number.isFinite(light.intensity)).toBe(true);
+      expect(light.intensity).toBeGreaterThanOrEqual(worldLight.intensity * 0.93);
+      expect(light.intensity).toBeLessThanOrEqual(worldLight.intensity * 1.07);
+    }
+
+    const packedLights = makeDeferredPointLightBufferData(
+      firstViewLights,
+      LIGHTSTORM_POINT_LIGHT_COUNT
+    );
+    expect(packedLights).toHaveLength(LIGHTSTORM_POINT_LIGHT_COUNT * 8);
+    expect(Array.from(packedLights).every(Number.isFinite)).toBe(true);
+  });
+});
+
+describe('Lightstorm Megacity guided camera', () => {
+  test.each(
+    LIGHTSTORM_CAMERA_INSTANCE_COUNTS
+  )('keeps the full 120 Hz loop finite and collision-free for %i instances', instanceCount => {
+    const city = makeLightstormCity(instanceCount);
+    const tour = makeLightstormGuidedCameraTour(city);
+
+    expect(tour.duration).toBe(29);
+    expect(getLightstormGuidedCameraSample(tour, tour.duration)).toEqual(
+      getLightstormGuidedCameraSample(tour, 0)
+    );
+    expect(getLightstormGuidedCameraSample(tour, -tour.duration)).toEqual(
+      getLightstormGuidedCameraSample(tour, 0)
+    );
+    expectCameraSamplesClose(
+      getLightstormGuidedCameraSample(tour, tour.duration * 1.37),
+      getLightstormGuidedCameraSample(tour, tour.duration * 0.37)
+    );
+
+    expectElevatedAvenueProperties(tour);
+    expectRevealSkyscraperProperties(city, tour);
+
+    const sampleCount = Math.round(tour.duration * LIGHTSTORM_CAMERA_SAMPLES_PER_SECOND);
+    const invalidSamples: string[] = [];
+    const intersectingSamples: string[] = [];
+    for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex++) {
+      const timeSeconds = sampleIndex / LIGHTSTORM_CAMERA_SAMPLES_PER_SECOND;
+      const sample = getLightstormGuidedCameraSample(tour, timeSeconds);
+      const numericValues = [
+        ...sample.eye,
+        ...sample.target,
+        sample.yaw,
+        sample.pitch,
+        sample.distance,
+        sample.duration
+      ];
+      const isFiniteSample = numericValues.every(Number.isFinite) && sample.distance > 0;
+      const isOnAvenue = isCameraOnGuidedAvenue(sample.eye, tour);
+      const isAboveRoofClearance =
+        sample.eye[1] >=
+        tour.maximumRoofHeight +
+          LIGHTSTORM_CAMERA_ROOF_CLEARANCE -
+          LIGHTSTORM_CAMERA_POSITION_EPSILON;
+      if (!isFiniteSample || (!isOnAvenue && !isAboveRoofClearance)) {
+        if (invalidSamples.length < 10) {
+          invalidSamples.push(`${timeSeconds.toFixed(4)}s (${sample.shot})`);
+        }
+      }
+
+      const towerIndex = findIntersectingTowerIndex(city, sample.eye);
+      if (towerIndex !== null && intersectingSamples.length < 10) {
+        intersectingSamples.push(
+          `${timeSeconds.toFixed(4)}s (${sample.shot}, tower ${towerIndex})`
+        );
+      }
+    }
+
+    expect(invalidSamples).toEqual([]);
+    expect(intersectingSamples).toEqual([]);
+  });
+});
+
+describe('Lightstorm Megacity lightning', () => {
+  test('aligns named bolt phases with sky-visible camera beats', () => {
+    const tour = makeLightstormGuidedCameraTour(makeLightstormCity(250_000));
+    const canyonBolt = LIGHTSTORM_LIGHTNING_SCHEDULE.find(bolt => bolt.role === 'canyon')!;
+    const avenueBolt = LIGHTSTORM_LIGHTNING_SCHEDULE.find(bolt => bolt.role === 'avenue')!;
+    const revealBolt = LIGHTSTORM_LIGHTNING_SCHEDULE.find(bolt => bolt.role === 'reveal')!;
+    const expectedBeats = [
+      {
+        bolt: canyonBolt,
+        phaseSeconds: LIGHTSTORM_CANYON_STRIKE_SECONDS,
+        shot: 'elevated avenue ingress'
+      },
+      {
+        bolt: avenueBolt,
+        phaseSeconds: LIGHTSTORM_AVENUE_STRIKE_SECONDS,
+        shot: 'avenue turn'
+      },
+      {
+        bolt: revealBolt,
+        phaseSeconds: LIGHTSTORM_REVEAL_STRIKE_SECONDS,
+        shot: 'vertical reveal'
+      }
+    ];
+
+    expect(LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS).toBe(tour.duration);
+    expect(LIGHTSTORM_LIGHTNING_SCHEDULE.map(bolt => bolt.role)).toEqual([
+      'canyon',
+      'avenue',
+      'reveal'
+    ]);
+    for (const {bolt, phaseSeconds, shot} of expectedBeats) {
+      expect(bolt.phaseSeconds).toBe(phaseSeconds);
+      expect(bolt.periodSeconds).toBe(tour.duration);
+      expect(getLightstormGuidedCameraSample(tour, bolt.phaseSeconds).shot).toBe(shot);
+    }
+  });
+
+  test.each(
+    LIGHTSTORM_CAMERA_INSTANCE_COUNTS
+  )('keeps every bolt camera-framed for %i instances', instanceCount => {
+    const tour = makeLightstormGuidedCameraTour(makeLightstormCity(instanceCount));
+    const bolts = makeLightstormLightningBolts(tour, LIGHTSTORM_PROJECTION_TEST_ASPECT);
+    const revealBolt = bolts.find(bolt => bolt.role === 'reveal')!;
+    const standardBolts = bolts.filter(bolt => bolt.role !== 'reveal');
+    const maximumStandardWidth = Math.max(...standardBolts.map(bolt => bolt.width));
+    const maximumStandardIntensity = Math.max(...standardBolts.map(bolt => bolt.intensity));
+    const projectedFrames = bolts.map(bolt => getProjectedLightningBoltFrame(bolt, tour));
+    const standardProjectedSpans = projectedFrames
+      .filter((_, boltIndex) => bolts[boltIndex]!.role !== 'reveal')
+      .map(frame => frame.horizontalSpan);
+    const revealProjectedSpan = projectedFrames[bolts.indexOf(revealBolt)]!.horizontalSpan;
+
+    expect(bolts).toHaveLength(LIGHTSTORM_LIGHTNING_BOLT_COUNT);
+    expect(bolts.map(bolt => bolt.role)).toEqual(['canyon', 'avenue', 'reveal']);
+    for (const frame of projectedFrames) {
+      for (const point of [frame.start, frame.end]) {
+        expect(point[0]).toBeGreaterThan(-0.95);
+        expect(point[0]).toBeLessThan(0.95);
+        expect(point[1]).toBeGreaterThan(0.1);
+        expect(point[1]).toBeLessThan(0.95);
+        expect(point[2]).toBeGreaterThan(-1);
+        expect(point[2]).toBeLessThan(1);
+      }
+      expect(frame.start[1]).toBeGreaterThan(frame.end[1]);
+    }
+
+    expect(standardBolts.map(bolt => bolt.sizeScale)).toEqual([1, 1]);
+    expect(standardProjectedSpans.every(Number.isFinite)).toBe(true);
+    expect(revealBolt.sizeScale).toBe(2);
+    expect(revealProjectedSpan).toBeGreaterThan(1.4);
+    expect(revealProjectedSpan).toBeLessThan(1.65);
+    expect(revealProjectedSpan).toBeGreaterThan(Math.max(...standardProjectedSpans) * 4);
+    expect(revealBolt.width).toBeGreaterThan(maximumStandardWidth * 1.75);
+    expect(revealBolt.intensity).toBeGreaterThan(maximumStandardIntensity * 1.7);
+
+    const segments = makeLightstormLightningSegments(bolts);
+    const bufferData = makeLightstormLightningBufferData(segments);
+    expect(segments).toHaveLength(LIGHTSTORM_LIGHTNING_SEGMENT_COUNT);
+    expect(bufferData).toHaveLength(
+      LIGHTSTORM_LIGHTNING_SEGMENT_COUNT * LIGHTSTORM_LIGHTNING_SEGMENT_WORD_COUNT
+    );
+    expect(Array.from(bufferData).every(Number.isFinite)).toBe(true);
+  });
+
+  test('produces role-scaled deterministic double pulses for every strike', () => {
+    const pulseDefinitions = [
+      {
+        phaseSeconds: LIGHTSTORM_CANYON_STRIKE_SECONDS,
+        amplitude: LIGHTSTORM_CANYON_SKY_PULSE_AMPLITUDE
+      },
+      {
+        phaseSeconds: LIGHTSTORM_AVENUE_STRIKE_SECONDS,
+        amplitude: LIGHTSTORM_AVENUE_SKY_PULSE_AMPLITUDE
+      },
+      {
+        phaseSeconds: LIGHTSTORM_REVEAL_STRIKE_SECONDS,
+        amplitude: LIGHTSTORM_REVEAL_SKY_PULSE_AMPLITUDE
+      }
+    ];
+
+    expect(LIGHTSTORM_REVEAL_SKY_PULSE_AMPLITUDE).toBeGreaterThan(
+      LIGHTSTORM_CANYON_SKY_PULSE_AMPLITUDE
+    );
+    expect(LIGHTSTORM_CANYON_SKY_PULSE_AMPLITUDE).toBeGreaterThan(
+      LIGHTSTORM_AVENUE_SKY_PULSE_AMPLITUDE
+    );
+    for (const {phaseSeconds, amplitude} of pulseDefinitions) {
+      const firstPulse = getLightstormLightningSkyPulse(phaseSeconds);
+      const returnPulse = getLightstormLightningSkyPulse(
+        phaseSeconds + LIGHTSTORM_LIGHTNING_RETURN_STROKE_DELAY_SECONDS
+      );
+      const pulseTrough = getLightstormLightningSkyPulse(
+        phaseSeconds + LIGHTSTORM_LIGHTNING_RETURN_STROKE_DELAY_SECONDS / 2
+      );
+      expect(firstPulse).toBeCloseTo(amplitude, 10);
+      expect(returnPulse).toBeCloseTo(amplitude * LIGHTSTORM_LIGHTNING_RETURN_STROKE_SCALE, 10);
+      expect(pulseTrough).toBeLessThan(amplitude * 0.15);
+      expect(
+        getLightstormLightningSkyPulse(phaseSeconds + LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS)
+      ).toBeCloseTo(firstPulse, 10);
+      expect(getLightstormLightningSkyPulse(phaseSeconds, false)).toBe(0);
+    }
+    expect(getLightstormLightningSkyPulse(Number.NaN)).toBe(0);
+
+    for (
+      let sampleIndex = 0;
+      sampleIndex < LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS * 240;
+      sampleIndex++
+    ) {
+      const pulse = getLightstormLightningSkyPulse(sampleIndex / 240);
+      expect(Number.isFinite(pulse)).toBe(true);
+      expect(pulse).toBeGreaterThanOrEqual(0);
+      expect(pulse).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test('creates deterministic, finite, connected bolt and branch segments', () => {
+    const tour = makeLightstormGuidedCameraTour(makeLightstormCity(250_000));
+    const bolts = makeLightstormLightningBolts(tour, LIGHTSTORM_PROJECTION_TEST_ASPECT);
+    const firstSegments = makeLightstormLightningSegments(bolts);
+    const secondSegments = makeLightstormLightningSegments(bolts);
+
+    expect(firstSegments).toEqual(secondSegments);
+    expect(firstSegments).toHaveLength(LIGHTSTORM_LIGHTNING_SEGMENT_COUNT);
+    expect(firstSegments.length).toBeLessThanOrEqual(LIGHTSTORM_LIGHTNING_SEGMENT_CAPACITY);
+    expect(bolts).toHaveLength(LIGHTSTORM_LIGHTNING_BOLT_COUNT);
+
+    let boltSegmentOffset = 0;
+    for (let boltIndex = 0; boltIndex < bolts.length; boltIndex++) {
+      const bolt = bolts[boltIndex]!;
+      const trunkSegments = firstSegments.slice(
+        boltSegmentOffset,
+        boltSegmentOffset + bolt.segmentCount
+      );
+      expect(trunkSegments[0]!.start).toEqual(bolt.start);
+      expect(trunkSegments.at(-1)!.end).toEqual(bolt.end);
+      expectConnectedSegments(trunkSegments);
+
+      for (let branchIndex = 0; branchIndex < bolt.branchNodeIndices.length; branchIndex++) {
+        const branchOffset =
+          boltSegmentOffset + bolt.segmentCount + branchIndex * bolt.branchSegmentCount;
+        const branchSegments = firstSegments.slice(
+          branchOffset,
+          branchOffset + bolt.branchSegmentCount
+        );
+        const branchNodeIndex = bolt.branchNodeIndices[branchIndex]!;
+        const branchStart =
+          branchNodeIndex === bolt.segmentCount
+            ? trunkSegments.at(-1)!.end
+            : trunkSegments[branchNodeIndex]!.start;
+        expect(branchSegments[0]!.start).toEqual(branchStart);
+        expectConnectedSegments(branchSegments);
+      }
+
+      const boltSegmentCount =
+        bolt.segmentCount + bolt.branchNodeIndices.length * bolt.branchSegmentCount;
+      const boltSegments = firstSegments.slice(
+        boltSegmentOffset,
+        boltSegmentOffset + boltSegmentCount
+      );
+      for (const segment of boltSegments) {
+        expect(
+          [
+            ...segment.start,
+            ...segment.end,
+            segment.width,
+            segment.seed,
+            ...segment.color,
+            segment.intensity,
+            segment.phaseSeconds,
+            segment.periodSeconds,
+            segment.branchLevel,
+            segment.boltIndex
+          ].every(Number.isFinite)
+        ).toBe(true);
+        expect(segment.boltIndex).toBe(boltIndex);
+        expect(segment.branchLevel === 0 || segment.branchLevel === 1).toBe(true);
+        expect(segment.width).toBeGreaterThan(0);
+        expect(segment.intensity).toBeGreaterThan(0);
+        expect(segment.periodSeconds).toBeGreaterThan(0);
+        expect(segment.seed).toBeGreaterThanOrEqual(0);
+        expect(segment.seed).toBeLessThan(1);
+      }
+      boltSegmentOffset += boltSegmentCount;
+    }
+    expect(boltSegmentOffset).toBe(firstSegments.length);
+  });
+
+  test('packs every lightning segment into the shader-aligned buffer layout', () => {
+    const tour = makeLightstormGuidedCameraTour(makeLightstormCity(250_000));
+    const bolts = makeLightstormLightningBolts(tour, LIGHTSTORM_PROJECTION_TEST_ASPECT);
+    const segments = makeLightstormLightningSegments(bolts);
+    const bufferData = makeLightstormLightningBufferData(segments);
+    const expectedData = new Float32Array(
+      segments.flatMap(segment => [
+        ...segment.start,
+        segment.width,
+        ...segment.end,
+        segment.seed,
+        ...segment.color,
+        segment.intensity,
+        segment.phaseSeconds,
+        segment.periodSeconds,
+        segment.branchLevel,
+        segment.boltIndex
+      ])
+    );
+
+    expect(bufferData).toHaveLength(segments.length * LIGHTSTORM_LIGHTNING_SEGMENT_WORD_COUNT);
+    expect(bufferData).toEqual(expectedData);
+    expect(Array.from(bufferData).every(Number.isFinite)).toBe(true);
+  });
+});
+
+describe('Lightstorm Megacity thunder schedule', () => {
+  test('emits one event for each primary strike without double-firing return strokes', () => {
+    for (const bolt of LIGHTSTORM_LIGHTNING_SCHEDULE) {
+      const primaryCrossings = getLightstormThunderStrikeCrossings(
+        bolt.phaseSeconds - 0.01,
+        bolt.phaseSeconds + 0.01
+      );
+      expect(primaryCrossings).toHaveLength(1);
+      expect(primaryCrossings[0]).toMatchObject({
+        boltIndex: LIGHTSTORM_LIGHTNING_SCHEDULE.indexOf(bolt),
+        role: bolt.role,
+        strikeTimeSeconds: bolt.phaseSeconds
+      });
+      expect(primaryCrossings[0]!.strength).toBeGreaterThan(0);
+
+      const returnStrokeTimeSeconds =
+        bolt.phaseSeconds + LIGHTSTORM_LIGHTNING_RETURN_STROKE_DELAY_SECONDS;
+      expect(
+        getLightstormThunderStrikeCrossings(
+          returnStrokeTimeSeconds - 0.01,
+          returnStrokeTimeSeconds + 0.01
+        )
+      ).toEqual([]);
+    }
+  });
+
+  test('schedules one event per role across loop wrap and timeline restart', () => {
+    const firstLoopCrossings = getLightstormThunderStrikeCrossings(
+      0,
+      LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS
+    );
+    const secondLoopCrossings = getLightstormThunderStrikeCrossings(
+      LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS,
+      LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS * 2
+    );
+    const expectedRoles = LIGHTSTORM_LIGHTNING_SCHEDULE.map(bolt => bolt.role);
+
+    expect(firstLoopCrossings.map(crossing => crossing.role)).toEqual(expectedRoles);
+    expect(firstLoopCrossings.map(crossing => crossing.strikeTimeSeconds)).toEqual(
+      LIGHTSTORM_LIGHTNING_SCHEDULE.map(bolt => bolt.phaseSeconds)
+    );
+    expect(secondLoopCrossings.map(crossing => crossing.role)).toEqual(expectedRoles);
+    expect(secondLoopCrossings.map(crossing => crossing.strikeTimeSeconds)).toEqual(
+      LIGHTSTORM_LIGHTNING_SCHEDULE.map(
+        bolt => bolt.phaseSeconds + LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS
+      )
+    );
+
+    const strengthByRole = Object.fromEntries(
+      firstLoopCrossings.map(crossing => [crossing.role, crossing.strength])
+    );
+    expect(strengthByRole.reveal!).toBeGreaterThan(strengthByRole.canyon!);
+    expect(strengthByRole.canyon!).toBeGreaterThan(strengthByRole.avenue!);
+
+    expect(
+      getLightstormThunderStrikeCrossings(LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS - 0.01, 0.01)
+    ).toEqual([]);
+    expect(getLightstormThunderStrikeCrossings(null, 0.01)).toEqual([]);
+    expect(
+      getLightstormThunderStrikeCrossings(0.01, LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS)
+    ).toEqual(firstLoopCrossings);
+    expect(
+      getLightstormThunderStrikeCrossings(0, LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS, false)
+    ).toEqual([]);
+    expect(
+      getLightstormThunderStrikeCrossings(Number.NaN, LIGHTSTORM_LIGHTNING_TOUR_DURATION_SECONDS)
+    ).toEqual([]);
+  });
+});
+
+function isTransitGridIndex(gridIndex: number): boolean {
+  const wrappedGridIndex = ((gridIndex % 12) + 12) % 12;
+  return wrappedGridIndex <= 1;
+}
+
+function expectCameraSamplesClose(
+  firstSample: LightstormCameraSample,
+  secondSample: LightstormCameraSample
+): void {
+  expect(firstSample.shot).toBe(secondSample.shot);
+  expect(firstSample.duration).toBe(secondSample.duration);
+  const firstValues = [
+    ...firstSample.eye,
+    ...firstSample.target,
+    firstSample.yaw,
+    firstSample.pitch,
+    firstSample.distance
+  ];
+  const secondValues = [
+    ...secondSample.eye,
+    ...secondSample.target,
+    secondSample.yaw,
+    secondSample.pitch,
+    secondSample.distance
+  ];
+  for (let valueIndex = 0; valueIndex < firstValues.length; valueIndex++) {
+    expect(firstValues[valueIndex]).toBeCloseTo(secondValues[valueIndex]!, 10);
+  }
+}
+
+function expectRevealSkyscraperProperties(
+  city: LightstormCityData,
+  tour: LightstormGuidedCameraTour
+): void {
+  const selectedTowerIndex = findTowerIndexAtPosition(city, tour.skyscraper.position);
+  expect(selectedTowerIndex).not.toBeNull();
+  const selectedTowerOffset = selectedTowerIndex! * LIGHTSTORM_INSTANCE_WORD_COUNT;
+  const selectedTowerRoofHeight =
+    city.instances[selectedTowerOffset + 1]! + city.instances[selectedTowerOffset + 5]!;
+  expect(city.instances[selectedTowerOffset + 11]).toBe(0);
+  expect(tour.skyscraper.roofHeight).toBeCloseTo(selectedTowerRoofHeight);
+  expect(tour.skyscraper.roofHeight).toBeLessThanOrEqual(tour.maximumRoofHeight);
+  expect(Math.abs(tour.skyscraper.position[2] - tour.secondaryAvenue)).toBeLessThanOrEqual(6);
+  expect(Math.abs(tour.skyscraper.position[0])).toBeLessThanOrEqual(
+    Math.min(120, city.fieldHalfExtent * 0.45)
+  );
+
+  const approachPose = tour.poses.find(pose => pose.shot === 'skyscraper approach')!;
+  const verticalRevealPose = tour.poses.find(pose => pose.shot === 'vertical reveal')!;
+  const crownRevealPose = tour.poses.find(pose => pose.shot === 'crown reveal')!;
+  for (const pose of [approachPose, verticalRevealPose, crownRevealPose]) {
+    expect(pose.target[0]).toBeCloseTo(tour.skyscraper.position[0]);
+    expect(pose.target[2]).toBeCloseTo(tour.skyscraper.position[2]);
+  }
+  expect(approachPose.target[1]).toBeLessThan(verticalRevealPose.target[1]);
+  expect(verticalRevealPose.target[1]).toBeLessThan(crownRevealPose.target[1]);
+  expect(crownRevealPose.target[1]).toBeGreaterThanOrEqual(tour.skyscraper.roofHeight * 0.9);
+  expect(crownRevealPose.target[1]).toBeLessThanOrEqual(tour.skyscraper.roofHeight);
+  expect(crownRevealPose.eye[1]).toBeCloseTo(
+    tour.maximumRoofHeight + LIGHTSTORM_CAMERA_ROOF_CLEARANCE
+  );
+}
+
+function expectElevatedAvenueProperties(tour: LightstormGuidedCameraTour): void {
+  const elevatedShotNames = [
+    'elevated avenue ingress',
+    'first intersection',
+    'avenue turn',
+    'second intersection',
+    'skyscraper turn'
+  ];
+  const elevatedPoses = elevatedShotNames.map(
+    shotName => tour.poses.find(pose => pose.shot === shotName)!
+  );
+  for (const pose of elevatedPoses) {
+    expect(pose.eye[1]).toBe(16);
+    expect(pose.target[1]).toBe(12);
+  }
+
+  const skyscraperApproachPose = tour.poses.find(pose => pose.shot === 'skyscraper approach')!;
+  const verticalRevealPose = tour.poses.find(pose => pose.shot === 'vertical reveal')!;
+  expect(skyscraperApproachPose.eye[1]).toBe(12);
+  expect(skyscraperApproachPose.eye[1]).toBeGreaterThan(verticalRevealPose.eye[1]);
+}
+
+function isCameraOnGuidedAvenue(
+  eye: readonly [number, number, number],
+  tour: LightstormGuidedCameraTour
+): boolean {
+  return [eye[0], eye[2]].some(
+    coordinate =>
+      Math.abs(coordinate - tour.primaryAvenue) <= LIGHTSTORM_CAMERA_POSITION_EPSILON ||
+      Math.abs(coordinate - tour.secondaryAvenue) <= LIGHTSTORM_CAMERA_POSITION_EPSILON
+  );
+}
+
+function findIntersectingTowerIndex(
+  city: LightstormCityData,
+  eye: readonly [number, number, number]
+): number | null {
+  const centeredGridCoordinate = (city.gridSize - 1) / 2;
+  const nearestGridX = Math.round(eye[0] / LIGHTSTORM_GRID_SPACING + centeredGridCoordinate);
+  const nearestGridZ = Math.round(eye[2] / LIGHTSTORM_GRID_SPACING + centeredGridCoordinate);
+
+  for (let gridZ = nearestGridZ - 2; gridZ <= nearestGridZ + 2; gridZ++) {
+    for (let gridX = nearestGridX - 2; gridX <= nearestGridX + 2; gridX++) {
+      const instanceIndex = gridZ * city.gridSize + gridX;
+      if (
+        gridX < 0 ||
+        gridX >= city.gridSize ||
+        gridZ < 0 ||
+        gridZ >= city.gridSize ||
+        instanceIndex < 0 ||
+        instanceIndex * LIGHTSTORM_INSTANCE_WORD_COUNT >= city.instances.length
+      ) {
+        continue;
+      }
+      const wordOffset = instanceIndex * LIGHTSTORM_INSTANCE_WORD_COUNT;
+      if (city.instances[wordOffset + 11] !== 0) {
+        continue;
+      }
+      const centerX = city.instances[wordOffset]!;
+      const centerY = city.instances[wordOffset + 1]!;
+      const centerZ = city.instances[wordOffset + 2]!;
+      const halfWidth = city.instances[wordOffset + 4]!;
+      const halfHeight = city.instances[wordOffset + 5]!;
+      const halfDepth = city.instances[wordOffset + 6]!;
+      if (
+        Math.abs(eye[0] - centerX) <= halfWidth &&
+        Math.abs(eye[1] - centerY) <= halfHeight &&
+        Math.abs(eye[2] - centerZ) <= halfDepth
+      ) {
+        return instanceIndex;
+      }
+    }
+  }
+  return null;
+}
+
+function findTowerIndexAtPosition(
+  city: LightstormCityData,
+  position: readonly [number, number, number]
+): number | null {
+  const centeredGridCoordinate = (city.gridSize - 1) / 2;
+  const nearestGridX = Math.round(position[0] / LIGHTSTORM_GRID_SPACING + centeredGridCoordinate);
+  const nearestGridZ = Math.round(position[2] / LIGHTSTORM_GRID_SPACING + centeredGridCoordinate);
+  for (let gridZ = nearestGridZ - 1; gridZ <= nearestGridZ + 1; gridZ++) {
+    for (let gridX = nearestGridX - 1; gridX <= nearestGridX + 1; gridX++) {
+      if (gridX < 0 || gridX >= city.gridSize || gridZ < 0 || gridZ >= city.gridSize) {
+        continue;
+      }
+      const instanceIndex = gridZ * city.gridSize + gridX;
+      const wordOffset = instanceIndex * LIGHTSTORM_INSTANCE_WORD_COUNT;
+      if (
+        instanceIndex < 0 ||
+        wordOffset >= city.instances.length ||
+        city.instances[wordOffset + 11] !== 0
+      ) {
+        continue;
+      }
+      const matchesPosition = [0, 1, 2].every(
+        componentIndex => city.instances[wordOffset + componentIndex] === position[componentIndex]
+      );
+      if (matchesPosition) {
+        return instanceIndex;
+      }
+    }
+  }
+  return null;
+}
+
+function expectConnectedSegments(
+  segments: readonly {
+    start: readonly [number, number, number];
+    end: readonly [number, number, number];
+  }[]
+): void {
+  for (let segmentIndex = 1; segmentIndex < segments.length; segmentIndex++) {
+    expect(segments[segmentIndex]!.start).toEqual(segments[segmentIndex - 1]!.end);
+  }
+}
+
+function getProjectedLightningBoltFrame(
+  bolt: {start: readonly number[]; end: readonly number[]; phaseSeconds: number},
+  tour: LightstormGuidedCameraTour
+): {
+  start: [number, number, number];
+  end: [number, number, number];
+  horizontalSpan: number;
+} {
+  const cameraSample = getLightstormGuidedCameraSample(tour, bolt.phaseSeconds);
+  const viewMatrix = new Matrix4().lookAt({
+    eye: cameraSample.eye,
+    center: cameraSample.target,
+    up: [0, 1, 0]
+  });
+  const projectionMatrix = new Matrix4().perspective({
+    fovy: LIGHTSTORM_CAMERA_FIELD_OF_VIEW,
+    aspect: LIGHTSTORM_PROJECTION_TEST_ASPECT,
+    near: 0.1,
+    far: 1800
+  });
+  const viewProjectionMatrix = new Matrix4(projectionMatrix).multiplyRight(viewMatrix);
+  const startClip = viewProjectionMatrix.transform([...bolt.start, 1]);
+  const endClip = viewProjectionMatrix.transform([...bolt.end, 1]);
+  expect(startClip[3]).toBeGreaterThan(0);
+  expect(endClip[3]).toBeGreaterThan(0);
+  const start: [number, number, number] = [
+    startClip[0]! / startClip[3]!,
+    startClip[1]! / startClip[3]!,
+    startClip[2]! / startClip[3]!
+  ];
+  const end: [number, number, number] = [
+    endClip[0]! / endClip[3]!,
+    endClip[1]! / endClip[3]!,
+    endClip[2]! / endClip[3]!
+  ];
+  return {start, end, horizontalSpan: Math.abs(start[0] - end[0])};
+}

--- a/test/examples/lightstorm-megacity.spec.ts
+++ b/test/examples/lightstorm-megacity.spec.ts
@@ -3,9 +3,18 @@
 // Copyright (c) vis.gl contributors
 
 import {describe, expect, test} from 'vitest';
+import {Buffer, type Texture} from '@luma.gl/core';
 import type {AnimationProps} from '@luma.gl/engine';
+import {CubeGeometry, Model, ShaderPassRenderer} from '@luma.gl/engine';
+import {ClusteredLightGrid, GBuffer, makeDeferredPointLightBufferData} from '@luma.gl/experimental';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {Matrix4, radians} from '@math.gl/core';
 import LightstormMegacityAnimationLoopTemplate from '../../examples/showcase/lightstorm-megacity/app';
+import {
+  createLightstormDeferredLightingShaderPassPipeline,
+  LIGHTSTORM_LIGHT_MARKER_SHADER,
+  LIGHTSTORM_RENDER_SHADER
+} from '../../examples/showcase/lightstorm-megacity/lightstorm-shaders';
 
 describe('Lightstorm Megacity', () => {
   test('compacts visible city records into an indirect draw', async () => {
@@ -29,6 +38,13 @@ describe('Lightstorm Megacity', () => {
         lightstormCapacity: 2048
       } as AnimationProps & {lightstormCapacity: number});
       const state = viewer as unknown as {
+        sceneColorFormat: string;
+        comparisonView: boolean;
+        activeClusteredLightCount: number;
+        clusteredLightGrid: ClusteredLightGrid;
+        deferredLightingRenderer: {
+          passRenderers: Array<{passDefinition: {name: string}}>;
+        };
         resources: {
           compiled: {
             stats: {
@@ -38,7 +54,7 @@ describe('Lightstorm Megacity', () => {
             };
           };
           drawCommands: {buffer: {readAsync: () => Promise<Uint8Array>}};
-          sceneColor: {format: string};
+          sceneGBuffer: GBuffer;
         };
       };
       const nodeOrder = state.resources.compiled.stats.nodeOrder;
@@ -47,9 +63,32 @@ describe('Lightstorm Megacity', () => {
         nodeOrder.some(identifier => identifier.startsWith('visible-city-records-compact'))
       ).toBe(true);
       expect(nodeOrder).toContain('render-visible-city');
-      expect(state.resources.compiled.stats.importedTextureCount).toBe(1);
-      expect(state.resources.compiled.stats.logicalTransientTextureCount).toBe(1);
-      expect(['rgba8unorm', 'rgba16float']).toContain(state.resources.sceneColor.format);
+      expect(state.resources.compiled.stats.importedTextureCount).toBe(6);
+      expect(state.resources.compiled.stats.logicalTransientTextureCount).toBe(0);
+      expect([
+        state.resources.sceneGBuffer.colorTexture.format,
+        state.resources.sceneGBuffer.normalRoughnessTexture.format,
+        state.resources.sceneGBuffer.velocityTexture.format,
+        state.resources.sceneGBuffer.getExtraColorTexture('baseColorMetallic').format,
+        state.resources.sceneGBuffer.getExtraColorTexture('emissiveOcclusion').format,
+        state.resources.sceneGBuffer.depthTexture.format
+      ]).toEqual([
+        state.sceneColorFormat,
+        'rgba8unorm',
+        'rg16float',
+        'rgba8unorm',
+        'rgba8uint',
+        'depth24plus'
+      ]);
+      expect(
+        state.deferredLightingRenderer.passRenderers.map(
+          passRenderer => passRenderer.passDefinition.name
+        )
+      ).toEqual(
+        state.sceneColorFormat === 'rgba16float'
+          ? ['lightstormDeferredLightingShaderPassPipeline', 'ssrShaderPassPipeline']
+          : ['lightstormDeferredLightingShaderPassPipeline']
+      );
 
       viewer.onRender({
         device,
@@ -64,6 +103,10 @@ describe('Lightstorm Megacity', () => {
       } as unknown as AnimationProps);
       device.submit();
 
+      expect(state.activeClusteredLightCount).toBe(128);
+      const clusterCounts = await readUint32Buffer(state.clusteredLightGrid.clusterLightCounts);
+      expect(clusterCounts.some(clusterCount => clusterCount > 0)).toBe(true);
+
       const bytes = await state.resources.drawCommands.buffer.readAsync();
       const command = new Uint32Array(
         bytes.buffer,
@@ -72,9 +115,313 @@ describe('Lightstorm Megacity', () => {
       );
       expect(command[1]).toBeGreaterThan(0);
       expect(command[1]).toBeLessThanOrEqual(2048);
+
+      state.comparisonView = true;
+      viewer.onRender({
+        device,
+        time: 1016,
+        width: 800,
+        height: 600,
+        animationLoop: {
+          frameRate: {getSampleHz: () => 60},
+          cpuTime: {getSampleAverageTime: () => 1},
+          gpuTime: {getSampleAverageTime: () => 1}
+        }
+      } as unknown as AnimationProps);
+      device.submit();
+      expect(state.activeClusteredLightCount).toBe(0);
     } finally {
       viewer?.onFinalize();
       host.remove();
     }
   }, 30_000);
+
+  test('draws the real five-target shader and clustered resolve on WebGPU', async () => {
+    const device = await getWebGPUTestDevice('core');
+    if (!device) {
+      return;
+    }
+
+    const width = 4;
+    const height = 4;
+    const nearPlane = 0.1;
+    const farPlane = 20;
+    const projectionMatrix = new Matrix4().perspective({
+      fovy: radians(60),
+      aspect: width / height,
+      near: nearPlane,
+      far: farPlane
+    });
+    const viewMatrix = new Matrix4();
+    const uniformData = new Float32Array(60);
+    uniformData.set(projectionMatrix, 0);
+    uniformData.set(viewMatrix, 16);
+    uniformData.set([Math.tan(radians(30)), 1, nearPlane, farPlane], 32);
+    uniformData.set([0, 0, 0, 1], 36);
+    uniformData.set([0, 1, 0, 0], 40);
+    uniformData.set(projectionMatrix, 44);
+
+    const resourcesToDestroy: Array<{destroy(): void}> = [];
+    try {
+      const sceneGBuffer = new GBuffer(device, {
+        id: 'lightstorm-five-target-test-scene',
+        width,
+        height,
+        colorFormat: 'rgba8unorm',
+        normalRoughnessFormat: 'rgba8unorm',
+        velocityFormat: 'rg16float',
+        depthStencilFormat: 'depth24plus',
+        extraColorAttachments: [
+          {name: 'baseColorMetallic', format: 'rgba8unorm'},
+          {name: 'emissiveOcclusion', format: 'rgba8uint'}
+        ]
+      });
+      resourcesToDestroy.push(sceneGBuffer);
+      const instances = device.createBuffer({
+        id: 'lightstorm-five-target-test-instances',
+        data: new Float32Array([0, 0.35, -2, 1, 0.5, 0.5, 0.5, 0.25, 0.1, 0.2, 0.35, 0]),
+        usage: Buffer.STORAGE
+      });
+      resourcesToDestroy.push(instances);
+      const visibleIdentifiers = device.createBuffer({
+        id: 'lightstorm-five-target-test-visible-identifiers',
+        data: new Uint32Array([0]),
+        usage: Buffer.STORAGE
+      });
+      resourcesToDestroy.push(visibleIdentifiers);
+      const uniforms = device.createBuffer({
+        id: 'lightstorm-five-target-test-uniforms',
+        data: uniformData,
+        usage: Buffer.UNIFORM
+      });
+      resourcesToDestroy.push(uniforms);
+      const lightMarkers = device.createBuffer({
+        id: 'lightstorm-five-target-test-light-markers',
+        // Keep the emissive marker behind the material cube so it exercises the five-target
+        // marker shader without depth-occluding the surface used to verify clustered lighting.
+        data: new Float32Array([0, 0.55, -3, 24, 1, 0.5, 0.25, 30, 0, 0.5, 0, 0]),
+        usage: Buffer.STORAGE
+      });
+      resourcesToDestroy.push(lightMarkers);
+      const pointLights = device.createBuffer({
+        id: 'lightstorm-five-target-test-point-lights',
+        data: makeDeferredPointLightBufferData(
+          [{position: [0, 0.55, -1], range: 24, color: [1, 0.5, 0.25], intensity: 30}],
+          1
+        ),
+        usage: Buffer.STORAGE | Buffer.COPY_DST
+      });
+      resourcesToDestroy.push(pointLights);
+      const darkPointLights = device.createBuffer({
+        id: 'lightstorm-five-target-test-dark-point-lights',
+        data: makeDeferredPointLightBufferData(
+          [{position: [0, 0.55, -1], range: 24, color: [1, 0.5, 0.25], intensity: 0}],
+          1
+        ),
+        usage: Buffer.STORAGE
+      });
+      resourcesToDestroy.push(darkPointLights);
+      const model = new Model(device, {
+        id: 'lightstorm-five-target-test-model',
+        source: LIGHTSTORM_RENDER_SHADER,
+        geometry: new CubeGeometry({id: 'lightstorm-five-target-test-cube', indices: true}),
+        colorAttachmentFormats: [
+          'rgba8unorm',
+          'rgba8unorm',
+          'rg16float',
+          'rgba8unorm',
+          'rgba8uint'
+        ],
+        depthStencilAttachmentFormat: 'depth24plus',
+        shaderLayout: {
+          attributes: [
+            {name: 'positions', location: 0, type: 'vec3<f32>'},
+            {name: 'normals', location: 1, type: 'vec3<f32>'}
+          ],
+          bindings: [
+            {name: 'instances', type: 'read-only-storage', group: 0, location: 0},
+            {name: 'visibleIds', type: 'read-only-storage', group: 0, location: 1},
+            {name: 'uniforms', type: 'uniform', group: 0, location: 2}
+          ]
+        },
+        parameters: {
+          cullMode: 'back',
+          depthCompare: 'less-equal',
+          depthWriteEnabled: true
+        }
+      });
+      resourcesToDestroy.push(model);
+      const lightMarkerModel = new Model(device, {
+        id: 'lightstorm-five-target-test-light-marker-model',
+        source: LIGHTSTORM_LIGHT_MARKER_SHADER,
+        geometry: new CubeGeometry({id: 'lightstorm-five-target-test-marker-cube', indices: true}),
+        instanceCount: 2,
+        colorAttachmentFormats: [
+          'rgba8unorm',
+          'rgba8unorm',
+          'rg16float',
+          'rgba8unorm',
+          'rgba8uint'
+        ],
+        depthStencilAttachmentFormat: 'depth24plus',
+        shaderLayout: {
+          attributes: [
+            {name: 'positions', location: 0, type: 'vec3<f32>'},
+            {name: 'normals', location: 1, type: 'vec3<f32>'}
+          ],
+          bindings: [
+            {name: 'lightMarkers', type: 'read-only-storage', group: 0, location: 0},
+            {name: 'uniforms', type: 'uniform', group: 0, location: 1}
+          ]
+        },
+        parameters: {
+          cullMode: 'back',
+          depthCompare: 'less-equal',
+          depthWriteEnabled: true
+        }
+      });
+      resourcesToDestroy.push(lightMarkerModel);
+      const clusteredLightGrid = new ClusteredLightGrid(device, {
+        id: 'lightstorm-five-target-test-clusters',
+        clusterDimensions: [2, 2, 2],
+        maxLightsPerCluster: 1,
+        maxLightCount: 1
+      });
+      resourcesToDestroy.push(clusteredLightGrid);
+      const deferredLightingRenderer = new ShaderPassRenderer(device, {
+        shaderPasses: [createLightstormDeferredLightingShaderPassPipeline('rgba8unorm')],
+        colorFormat: 'rgba8unorm'
+      });
+      resourcesToDestroy.push(deferredLightingRenderer);
+      deferredLightingRenderer.resize([width, height]);
+
+      clusteredLightGrid.encode(device.commandEncoder, {
+        pointLights,
+        pointLightCount: 1,
+        projectionMatrix,
+        nearPlane,
+        farPlane
+      });
+      model.setBindings({instances, visibleIds: visibleIdentifiers, uniforms});
+      model.predraw(device.commandEncoder);
+      lightMarkerModel.setBindings({lightMarkers, uniforms});
+      lightMarkerModel.predraw(device.commandEncoder);
+      const renderPass = device.commandEncoder.beginRenderPass({
+        id: 'lightstorm-five-target-test-render-pass',
+        framebuffer: sceneGBuffer.framebuffer,
+        clearColors: [
+          new Float32Array([0.0015, 0.003, 0.012, 1]),
+          new Float32Array([0.5, 0.5, 1, 1]),
+          new Float32Array([0, 0, 0, 0]),
+          new Float32Array([0, 0, 0, 0]),
+          new Uint32Array([0, 0, 0, 0])
+        ],
+        clearDepth: 1
+      });
+      const didDraw = model.draw(renderPass);
+      const didDrawLightMarkers = lightMarkerModel.draw(renderPass);
+      renderPass.end();
+      expect(didDraw).toBe(true);
+      expect(didDrawLightMarkers).toBe(true);
+
+      const makeResolveOptions = (lightBuffer: Buffer) => ({
+        sourceTexture: sceneGBuffer.colorTexture,
+        bindings: {
+          depthTexture: sceneGBuffer.depthTexture,
+          normalTexture: sceneGBuffer.normalRoughnessTexture,
+          baseColorMetallicTexture: sceneGBuffer.getExtraColorTexture('baseColorMetallic'),
+          emissiveOcclusionTexture: sceneGBuffer.getExtraColorTexture('emissiveOcclusion'),
+          pointLights: lightBuffer,
+          ...clusteredLightGrid.getShaderPassBindings()
+        },
+        uniforms: {
+          clusteredDeferredLighting: {
+            inverseProjectionMatrix: new Matrix4(projectionMatrix).invert(),
+            ambientColor: [0, 0, 0],
+            directionalLightDirectionView: [0.36, 0.82, 0.44],
+            directionalLightColor: [1, 0.84, 0.68],
+            directionalLightIntensity: 0,
+            ...clusteredLightGrid.getShaderPassUniforms(nearPlane, farPlane)
+          },
+          lightstormDeferredComposite: {
+            inverseProjectionMatrix: new Matrix4(projectionMatrix).invert(),
+            fogColor: [0, 0, 0],
+            forwardColorFloor: 0
+          }
+        }
+      });
+      const unlitTexture = deferredLightingRenderer.encodeToTexture(
+        device.commandEncoder,
+        makeResolveOptions(darkPointLights)
+      );
+      expect(unlitTexture).not.toBeNull();
+      device.submit();
+
+      const clusterCounts = await readUint32Buffer(clusteredLightGrid.clusterLightCounts);
+      expect(clusterCounts.some(clusterCount => clusterCount === 1)).toBe(true);
+      const unlitPixels = await readTexturePixels(unlitTexture!, width, height);
+
+      const litTexture = deferredLightingRenderer.encodeToTexture(
+        device.commandEncoder,
+        makeResolveOptions(pointLights)
+      );
+      expect(litTexture).not.toBeNull();
+      device.submit();
+      const litPixels = await readTexturePixels(litTexture!, width, height);
+      expect(sumRgb(litPixels)).toBeGreaterThan(sumRgb(unlitPixels));
+    } finally {
+      for (const resource of resourcesToDestroy.reverse()) {
+        resource.destroy();
+      }
+    }
+  }, 30_000);
 });
+
+async function readUint32Buffer(buffer: Buffer): Promise<Uint32Array> {
+  const bytes = await buffer.readAsync();
+  return new Uint32Array(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+  );
+}
+
+function sumRgb(pixels: Uint8Array): number {
+  let sum = 0;
+  for (let index = 0; index < pixels.length; index++) {
+    if (index % 4 !== 3) {
+      sum += pixels[index]!;
+    }
+  }
+  return sum;
+}
+
+async function readTexturePixels(
+  texture: Texture,
+  width: number,
+  height: number
+): Promise<Uint8Array> {
+  const layout = texture.computeMemoryLayout({width, height});
+  const buffer = texture.device.createBuffer({
+    byteLength: layout.byteLength,
+    usage: Buffer.COPY_DST | Buffer.MAP_READ
+  });
+  try {
+    texture.readBuffer({width, height}, buffer);
+    const paddedPixels = await buffer.readAsync(0, layout.byteLength);
+    const pixels = new Uint8Array(width * height * 4);
+    for (let row = 0; row < height; row++) {
+      pixels.set(
+        new Uint8Array(
+          paddedPixels.buffer,
+          paddedPixels.byteOffset + row * layout.bytesPerRow,
+          width * 4
+        ),
+        row * width * 4
+      );
+    }
+    return pixels;
+  } finally {
+    buffer.destroy();
+  }
+}

--- a/website/content/examples/showcase/lightstorm-megacity.mdx
+++ b/website/content/examples/showcase/lightstorm-megacity.mdx
@@ -1,8 +1,8 @@
 ---
 title: Lightstorm Megacity
-description: Filter, cull, compact, pick, and indirectly render up to one million city records on WebGPU.
+description: Cluster, light, cull, compact, pick, and indirectly render up to one million city records on WebGPU.
 sidebar_custom_props:
-  description: Filter, cull, compact, pick, and indirectly render up to one million city records on WebGPU.
+  description: Cluster, light, cull, compact, pick, and indirectly render up to one million city records on WebGPU.
   backends: [webgpu]
   difficulty: advanced
   maturity: experimental
@@ -17,14 +17,20 @@ Lightstorm Megacity combines a cinematic procedural city with an observable GPU-
 pipeline. Choose 50K, 250K, or one million deterministic source records. Every record stays in GPU
 storage while a command graph filters the selected data layer, tests conservative tower bounds
 against the perspective camera, stably compacts the surviving source IDs, writes the result count
-into an indexed indirect command, and replays a fixed render bundle into a graph-declared HDR
-scene target.
+into an indexed indirect command, and replays a fixed render bundle into a graph-declared,
+five-color G-buffer plus depth.
 
-The default guided tour is presentation mode. Disable it or drag to enter free exploration, then
-move the pointer over a tower or transit tile to pick its original source record. The optional
-**Tactical visibility proof** replays the same compacted perspective-visible subset from overhead;
-it does not perform a second visibility pass. Switch to **Transit energy grid** to see data-layer
-filtering feed the same compaction and indirect-rendering path.
+The default guided tour is presentation mode. Its 29-second, capacity-aware route follows connected
+avenue centerlines from a 16-meter eye height, turns through their intersections, and then rises
+beside a deterministically selected skyscraper before clearing the roof. Explicit eye and target
+interpolation keeps the avenue shots in the road corridor instead of bowing through a city block.
+Disable the tour or drag to enter free exploration, then move the pointer over a tower or transit
+tile to pick its original source record.
+The optional **Tactical visibility proof** replays the same compacted perspective-visible subset
+from overhead; it does not perform a second visibility pass. Tactical mode intentionally presents
+the shader's forward color instead of applying perspective-only depth reconstruction across the
+orthographic view. Switch to **Transit energy grid** to see data-layer filtering feed the same
+compaction and indirect-rendering path.
 
 The live inspector separates source, visible, rejected, nominal, and submitted work. The million
 record setting therefore means one million candidate records, not one million objects rendered in
@@ -32,14 +38,49 @@ every frame. It also reports CPU command-encoding time, total frame timing, tran
 and the command graph's node order. Picking is issued only after pointer movement in exploration
 mode so it does not silently tax the cinematic benchmark.
 
-The city renderer synthesizes facade windows, roof beacons, transit lanes, fog, and a traveling
-light wave in one forward WGSL pass. That pass preserves linear scene radiance in a filterable
-`rgba16float` target when supported. A reusable `ShaderPassRenderer` then records a half-, quarter-,
-and eighth-resolution bloom pyramid plus ACES filmic tone mapping onto the same caller-owned command
-encoder before the frame is submitted. On a compatible WebGPU display the final pass preserves
-restrained extended-luminance highlights through a Display P3 canvas; other displays receive filmic
-SDR. Render and picking transforms share the same non-uniform tower records, while compute culling
-uses their conservative bounding spheres.
+The city shader synthesizes facade windows, roof beacons, transit lanes, fog, and a traveling light
+wave while writing forward radiance, view normals and roughness, velocity, base color and metallic,
+and packed emissive and occlusion in one geometry pass. In cinematic mode, 128 deterministic city
+lights are transformed into view space, binned into a three-dimensional cluster grid on the GPU,
+and resolved with directional and Cook-Torrance point lighting. A final Lightstorm-specific
+composition keeps the authored HDR fog and emissive radiance as a floor under that physically based
+lighting, so deferred shading does not flatten the traveling wave or the city's atmospheric depth.
+Each source is placed along the outer edge of its two-cell road band and also drives a small
+emissive curb beacon: a dim mast reaches from grade to a white-hot HDR head at the exact
+clustered-light position. The avenue keeps its wet metallic response while concentrating animated
+neon in thin lane lines; the surrounding pavement stays dark enough for the beacon heads to retain
+the street-level lighting hierarchy. The 128 beacons use one static 6 KiB world-space buffer and one
+direct instanced draw inside the existing render bundle. The per-frame 4 KiB view-space light-state
+update remains separate from the million instance records, which stay GPU resident.
+
+Three deterministic lightning bolts add sparse HDR punctuation at camera-authored beats: one at the
+end of the elevated urban canyon, one over the avenue turn, and a screen-spanning hero strike during
+the open-sky skyscraper reveal. Their connected trunks and first-order branches are packed into one
+static 5.6 KiB buffer and drawn as 89 thin world-space cuboids in the existing render bundle. The
+hero bolt is roughly twice the authored scale and reaches the scene's HDR output ceiling. Per-bolt
+phase metadata drives brief double strokes and role-scaled sky pulses on the same 29-second clock;
+the hero sends the strongest pair through sky fog and ambient light while dark intervals discard the
+geometry. Optional procedural thunder synthesizes one high-frequency crack, an immediate bass body,
+and overlapping filtered low-frequency rolls for each primary stroke; the hero strike layers five
+rolls for a longer decay. It uses no audio asset or network request and arms after the first pointer
+or keyboard gesture to respect browser autoplay policy.
+
+When filterable `rgba16float` rendering is supported, the lit G-buffer also drives half-resolution,
+roughness-aware screen-space reflections. Reflection rays sample the HDR-lit scene, reject
+disocclusions with velocity and previous-depth history, and receive a separable depth/normal-aware
+denoise before composition. This makes the neon transit grid and beacon heads read back from
+smoother street and facade surfaces without redrawing the city. Tactical mode disables the
+perspective-only reflection contribution and resets temporal history when switching views or camera
+modes.
+
+The clustered resolve, temporal reflection stack, half-, quarter-, and eighth-resolution bloom
+pyramid, and ACES filmic tone mapping are all recorded onto the command graph's caller-owned encoder
+before one frame submission. The scene uses a filterable `rgba16float` target when supported. On a
+compatible WebGPU display the final pass preserves restrained extended-luminance highlights through
+a Display P3 canvas; other displays receive filmic SDR. The synchronized sky pulses affect distance
+fog and modest ambient light, while lightning remains localized geometry that reaches the HDR output
+ceiling. This avoids a periodic full-frame bloom washout. Render and picking transforms share
+the same non-uniform tower records, while compute culling uses their conservative bounding spheres.
 
 This first version deliberately demonstrates scalable instance processing rather than virtual
 geometry. It uses one cube mesh and does not claim meshlet LOD, occlusion culling, geometry


### PR DESCRIPTION
## Goals

- Finish Lightstorm Megacity as a flagship WebGPU/HDR showcase.
- Demonstrate clustered deferred lighting, stable screen-space reflections, cinematic exposure, HDR lightning, and synchronized procedural thunder at 50K–1M instances.
- Keep the cinematic camera, lightning, and street-light presentation robust across every supported capacity and canvas size.

## Changes

- Adds a capacity-aware avenue/skyscraper camera tour with collision and framing coverage.
- Adds 128 clustered HDR curb beacons, five-target G-buffer rendering, deferred light resolve, bloom, adaptive tone mapping, and stabilized half-resolution SSR.
- Adds camera-framed HDR lightning, double sky pulses, and gesture-activated rolling procedural thunder with deeper bass.
- Makes lightning geometry regenerate from the current tour and canvas aspect, while preserving an immutable strike/thunder schedule.
- Improves shared experimental SSR with frame-rotated roughness rays, temporal miss survival/decay, view-linear depth denoising, and edge-aware upsampling.
- Updates all in-repo SSR consumers and the canonical rendering-techniques documentation for the inverse-projection and frame-index contracts.
- Expands node and real WebGPU coverage, including 50K/250K/1M projection assertions and five-target clustered-light rendering.

## Verification

- `nvm use` — passed (Node 22.22.1).
- `yarn install` — passed with existing peer-dependency warnings.
- `yarn lint fix` — passed after the final rebase; no fixes required.
- `yarn build` — passed after rebasing onto current master/TypeScript 6.
- `yarn test` — node suite passed (268 passed, 2 skipped). The complete escalated browser run passed Lightstorm and 1,342 tests overall, with one unrelated existing failure in `modules/arrow-layers/test/layers/arrow-layers.spec.ts` (`polygonViewportUniforms not set`; drawable storage-backed polygon assertion). After the final no-overlap master rebase, sandboxed Chromium could not launch (SIGABRT) when the approval service timed out.
- Targeted Lightstorm node suite — 15/15 passed.
- Targeted Lightstorm WebGPU browser suite — 2/2 passed.
- Standalone `examples/showcase/lightstorm-megacity` production build — passed.
- `yarn website:build` — passed.
- `(cd website && yarn build)` — passed.
- `git diff --check` — passed.

## Risks

- The shared SSR spatial/composite passes now depend on a correct `inverseProjectionMatrix` for view-linear edge rejection. Defaults remain source-compatible, but external callers that omit it receive identity-based filtering; in-repo callers and docs are updated.
- Procedural thunder still requires a browser user gesture because of autoplay policy.
- Full HDR/SSR/clustered behavior requires WebGPU and float render-target support; existing format fallbacks remain in place.

## Follow-up

- Move to the next WebGPU supremacy demo: the temporal super-resolution/high-motion reconstruction lab, followed by the compute-fluid tranche.