### PR TITLE
Add GPU trace batch index foundation

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -27,6 +27,7 @@ import {
   makeHtmlCustomPanel
 } from '../../example-panels';
 import {
+  getTraceCapacityOptions,
   makeTraceDataset,
   isTraceDensityMode,
   TRACE_COLLAPSED_STATE,
@@ -62,7 +63,6 @@ export const title = 'GPU Hierarchical Trace Viewer';
 export const description =
   'GPU-resident hierarchical traces with live filtering, adaptive density LOD, dependency traversal, picking, and indirect rendering.';
 
-const CAPACITY_OPTIONS = [250_000, 1_000_000, 4_000_000] as const;
 const DEFAULT_CAPACITY = 250_000;
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 const TRACE_WORKGROUP_SIZE = 256;
@@ -98,6 +98,7 @@ type TraceGraphResources = {
   renderBundle: RenderBundle;
   groups: TraceGroupResources[];
   spans: Buffer;
+  spanBatchIndex: Buffer;
   dependencies: Buffer;
   parentSpans: Buffer;
   outgoingOffsets: Buffer;
@@ -121,6 +122,7 @@ type TraceGraphResources = {
   densityBins: Buffer;
   pickResult: Buffer;
   spanCount: number;
+  spanBatchCount: number;
   dependencyCount: number;
 };
 
@@ -141,6 +143,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   readonly densityModel: Model;
   readonly viewUniformBuffer: Buffer;
   readonly panels: ExamplePanelManager;
+  readonly capacityOptions: number[];
 
   private resources: TraceGraphResources | null = null;
   private capacity = DEFAULT_CAPACITY;
@@ -186,6 +189,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       throw new Error('GPU Hierarchical Trace Viewer requires WebGPU');
     }
     this.device = device;
+    this.capacityOptions = getTraceCapacityOptions(
+      device.limits.maxStorageBufferBindingSize,
+      device.limits.maxBufferSize
+    );
     this.viewUniformBuffer = device.createBuffer({
       id: 'gpu-trace-view-uniforms',
       byteLength: VIEW_UNIFORM_BYTE_LENGTH,
@@ -396,6 +403,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       readbackRing,
       groups,
       spans: this.createDataBuffer('gpu-trace-spans', dataset.spans),
+      spanBatchIndex: this.createDataBuffer('gpu-trace-span-batch-index', dataset.spanBatchIndex),
       dependencies: this.createDataBuffer('gpu-trace-dependencies', dataset.dependencies),
       parentSpans: this.createDataBuffer('gpu-trace-parent-spans', dataset.parentSpans),
       outgoingOffsets: this.createDataBuffer('gpu-trace-outgoing-offsets', outgoingOffsets),
@@ -453,6 +461,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         Buffer.COPY_SRC
       ),
       spanCount: dataset.spanCount,
+      spanBatchCount: dataset.spanBatches.length,
       dependencyCount: dataset.dependencyCount
     };
   }
@@ -923,6 +932,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     }
     for (const buffer of [
       resources.spans,
+      resources.spanBatchIndex,
       resources.dependencies,
       resources.parentSpans,
       resources.outgoingOffsets,
@@ -1005,10 +1015,12 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         `<label><input type="checkbox" data-status="${index}" checked> ${name}</label>`
     ).join('');
     return `<div style="display:grid;gap:10px">
-      <label>Capacity <select data-capacity-select>${CAPACITY_OPTIONS.map(
-        value =>
-          `<option value="${value}"${value === this.capacity ? ' selected' : ''}>${formatCount(value)}</option>`
-      ).join('')}</select></label>
+      <label>Capacity <select data-capacity-select>${this.capacityOptions
+        .map(
+          value =>
+            `<option value="${value}"${value === this.capacity ? ' selected' : ''}>${formatCount(value)}</option>`
+        )
+        .join('')}</select></label>
       <fieldset style="display:grid;gap:4px"><legend>Span groups</legend>${groupControls}</fieldset>
       <fieldset style="display:grid;gap:4px"><legend>Status</legend>${statusControls}</fieldset>
       <label>Minimum duration <input type="range" min="0" max="20" step="0.25" value="0" data-duration> <span data-duration-value>0.00 ms</span></label>
@@ -1024,7 +1036,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       </fieldset>
       <label>Source span <input type="number" min="0" value="0" data-source-span style="width:100px"></label>
       <div style="display:flex;gap:6px"><button type="button" data-select-span>Focus span</button><button type="button" data-clear-selection>Clear selection</button></div>
-      <label><input type="checkbox" data-auto-scroll checked> Auto-scroll</label>
+      <label><input type="checkbox" data-auto-scroll${this.autoScroll ? ' checked' : ''}> Auto-scroll</label>
       <button type="button" data-reset>Reset view</button>
       <small>Click a span to pick it on the GPU. Drag to pan; use the wheel to zoom.</small>
     </div>`;
@@ -1205,7 +1217,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       return;
     }
     if (this.capacityElement) {
-      this.capacityElement.innerHTML = `<strong>${formatCount(this.capacity)}</strong> spans · <strong>${formatCount(resources.dependencyCount)}</strong> dependencies · graph compile #${this.compileCount} (${this.compileTimeMilliseconds.toFixed(1)} ms)`;
+      this.capacityElement.innerHTML = `<strong>${formatCount(this.capacity)}</strong> spans · <strong>${formatCount(resources.spanBatchCount)}</strong> batches · <strong>${formatCount(resources.dependencyCount)}</strong> dependencies · graph compile #${this.compileCount} (${this.compileTimeMilliseconds.toFixed(1)} ms)`;
     }
     if (this.selectionElement) {
       this.selectionElement.textContent =
@@ -1226,6 +1238,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         <span>Dropped telemetry samples</span><strong>${formatCount(this.droppedTelemetrySampleCount)}</strong>
         <span>Deferred pick frames</span><strong>${formatCount(this.deferredPickFrameCount)}</strong>
         <span>Adapter</span><strong>${resources.compiled.capabilities.softwareAdapter ? 'software' : 'hardware'}</strong>
+        <span>Maximum storage binding</span><strong>${formatBytes(this.device.limits.maxStorageBufferBindingSize)}</strong>
+        <span>Maximum buffer</span><strong>${formatBytes(this.device.limits.maxBufferSize)}</strong>
         <span>Timestamp queries</span><strong>${resources.compiled.capabilities.timestampQueries ? 'available' : 'unavailable'}</strong>
         <span>Logical resources</span><strong>${formatBytes(stats.logicalResourceBytes)}</strong>
         <span>Owned transients</span><strong>${formatBytes(stats.physicalTransientResourceBytes)}</strong>

--- a/examples/experimental/gpu-trace-viewer/index.html
+++ b/examples/experimental/gpu-trace-viewer/index.html
@@ -3,14 +3,39 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>GPU Hierarchical Trace Viewer</title>
-  <style>body { margin: 0; background: #030712; }</style>
+  <style>
+    body { margin: 0; background: #030712; }
+    #example-panel-host {
+      position: fixed;
+      z-index: 1;
+      top: 12px;
+      right: 12px;
+      width: min(380px, calc(100vw - 24px)) !important;
+      max-height: calc(100vh - 24px);
+      overflow: auto;
+      box-sizing: border-box;
+      padding: 12px;
+      color: #e5e7eb;
+      background: rgb(3 7 18 / 88%);
+      border: 1px solid rgb(148 163 184 / 30%);
+      border-radius: 8px;
+      backdrop-filter: blur(8px);
+    }
+  </style>
 </head>
 <script type="module">
+  import {luma} from '@luma.gl/core';
   import {makeAnimationLoop} from '@luma.gl/engine';
   import {webgpuAdapter} from '@luma.gl/webgpu';
   import AnimationLoopTemplate from './app.ts';
 
-  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {adapters: [webgpuAdapter]});
+  const device = luma.createDevice({
+    id: 'gpu-trace-viewer',
+    adapters: [webgpuAdapter],
+    createCanvasContext: true,
+    featureLevel: 'max'
+  });
+  const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
   animationLoop.start();
 </script>
-<body></body>
+<body><div id="example-panel-host" data-example-panel-host></div></body>

--- a/examples/experimental/gpu-trace-viewer/trace-data.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-data.ts
@@ -11,7 +11,13 @@ export const TRACE_THREAD_COUNT = TRACE_PROCESS_COUNT * TRACE_THREADS_PER_PROCES
 export const TRACE_LANE_COUNT = TRACE_THREAD_COUNT * TRACE_LANES_PER_THREAD;
 export const TRACE_SPAN_RECORD_WORD_LENGTH = 8;
 export const TRACE_DEPENDENCY_RECORD_WORD_LENGTH = 4;
-export const TRACE_DENSITY_BIN_COUNT = 96;
+export const TRACE_SPAN_BATCH_RECORD_WORD_LENGTH = 8;
+export const TRACE_SPAN_BATCH_CAPACITY = 1_000_000;
+const TRACE_CAPACITY_INCREMENT = 250_000;
+const TRACE_DEMONSTRATION_CAPACITY_CEILING = 4_000_000;
+// Keep density scrolling visually continuous at common viewport widths while retaining a fixed,
+// allocation-stable aggregation target for the compiled GPU command graph.
+export const TRACE_DENSITY_BIN_COUNT = 512;
 /** Switch to density rendering when one horizontal pixel covers at least this much trace time. */
 export const TRACE_DENSITY_TIME_PER_PIXEL = 0.08;
 export const TRACE_STATUS_COUNT = 4;
@@ -32,6 +38,25 @@ export const TRACE_MAXIMUM_RELATIVE_PARENT_DURATION_DELTA = 0.25;
 export const TRACE_COLLAPSED_STATE = 0;
 export const TRACE_EXPANDED_STATE = 1;
 export const TRACE_INVALID_SPAN_INDEX = 0xffffffff;
+
+/** Returns useful demonstration sizes that fit in one span storage-buffer binding. */
+export function getTraceCapacityOptions(
+  maxStorageBufferBindingSize: number,
+  maxBufferSize: number
+): number[] {
+  const spanRecordByteLength = TRACE_SPAN_RECORD_WORD_LENGTH * Uint32Array.BYTES_PER_ELEMENT;
+  const maximumSpanCapacity = Math.floor(
+    Math.min(maxStorageBufferBindingSize, maxBufferSize) / spanRecordByteLength
+  );
+  const maximumDemonstrationCapacity =
+    Math.floor(
+      Math.min(maximumSpanCapacity, TRACE_DEMONSTRATION_CAPACITY_CEILING) / TRACE_CAPACITY_INCREMENT
+    ) * TRACE_CAPACITY_INCREMENT;
+  const capacities = [250_000, 1_000_000, 4_000_000, maximumDemonstrationCapacity].filter(
+    capacity => capacity > 0 && capacity <= maximumSpanCapacity
+  );
+  return [...new Set(capacities)];
+}
 
 /** Matches the GPU's adaptive exact-span versus density-rendering decision. */
 export function isTraceDensityMode(
@@ -54,6 +79,21 @@ export type TraceGroupData = {
   data: Uint32Array;
 };
 
+/** Stable source partition and coarse bounds used for GPU candidate-batch selection. */
+export type TraceSpanBatchData = {
+  batchIndex: number;
+  groupIndex: number;
+  name: TraceGroupName;
+  count: number;
+  firstSpanIndex: number;
+  timeMin: number;
+  timeMax: number;
+  laneMin: number;
+  laneMax: number;
+  /** Borrowed source-aligned view into the canonical span allocation. */
+  data: Uint32Array;
+};
+
 /** Compact forward or reverse compressed sparse dependency adjacency. */
 export type TraceAdjacencyData = {
   /** One stable offset per source node plus the final edge count. */
@@ -68,6 +108,10 @@ export type TraceDatasetData = {
   spans: Uint32Array;
   /** Original stable group ranges into the canonical span allocation. */
   groups: TraceGroupData[];
+  /** Group-aligned source partitions small enough for independent GPU processing. */
+  spanBatches: TraceSpanBatchData[];
+  /** Packed batch first/count, temporal bounds, lane bounds, group, and stable batch ID records. */
+  spanBatchIndex: Uint32Array;
   /** Packed 16-byte dependency source, destination, family, and keyword records. */
   dependencies: Uint32Array;
   /** One cross-process-prioritized canonical parent or invalid sentinel per span. */
@@ -127,9 +171,12 @@ export function makeTraceDataset(totalSpanCount: number): TraceDatasetData {
 
   const topology = makeTraceDependencies(spans, totalSpanCount);
   const dependencyCount = topology.dependencies.length / TRACE_DEPENDENCY_RECORD_WORD_LENGTH;
+  const {spanBatches, spanBatchIndex} = makeTraceSpanBatches(spans, groups);
   return {
     spans,
     groups,
+    spanBatches,
+    spanBatchIndex,
     dependencies: topology.dependencies,
     parentSpans: topology.parentSpans,
     outgoing: buildTraceAdjacency(totalSpanCount, topology.dependencies, 'outgoing'),
@@ -139,6 +186,70 @@ export function makeTraceDataset(totalSpanCount: number): TraceDatasetData {
     processCount: TRACE_PROCESS_COUNT,
     threadCount: TRACE_THREAD_COUNT
   };
+}
+
+/** Partitions canonical group ranges and builds coarse GPU-readable batch bounds. */
+export function makeTraceSpanBatches(
+  spans: Uint32Array,
+  groups: readonly TraceGroupData[],
+  batchCapacity = TRACE_SPAN_BATCH_CAPACITY
+): {spanBatches: TraceSpanBatchData[]; spanBatchIndex: Uint32Array} {
+  if (!Number.isSafeInteger(batchCapacity) || batchCapacity < 1) {
+    throw new RangeError('Trace span batch capacity must be a positive safe integer');
+  }
+  const spanFloats = new Float32Array(spans.buffer, spans.byteOffset, spans.length);
+  const spanBatches: TraceSpanBatchData[] = [];
+
+  for (const group of groups) {
+    for (let groupOffset = 0; groupOffset < group.count; groupOffset += batchCapacity) {
+      const count = Math.min(batchCapacity, group.count - groupOffset);
+      const firstSpanIndex = group.firstSpanIndex + groupOffset;
+      let timeMin = Number.POSITIVE_INFINITY;
+      let timeMax = Number.NEGATIVE_INFINITY;
+      let laneMin = TRACE_LANE_COUNT;
+      let laneMax = 0;
+      for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+        const wordOffset = (firstSpanIndex + rowIndex) * TRACE_SPAN_RECORD_WORD_LENGTH;
+        const start = spanFloats[wordOffset];
+        const end = start + spanFloats[wordOffset + 1];
+        const lane = spans[wordOffset + 2];
+        timeMin = Math.min(timeMin, start);
+        timeMax = Math.max(timeMax, end);
+        laneMin = Math.min(laneMin, lane);
+        laneMax = Math.max(laneMax, lane + 1);
+      }
+      spanBatches.push({
+        batchIndex: spanBatches.length,
+        groupIndex: group.groupIndex,
+        name: group.name,
+        count,
+        firstSpanIndex,
+        timeMin,
+        timeMax,
+        laneMin,
+        laneMax,
+        data: spans.subarray(
+          firstSpanIndex * TRACE_SPAN_RECORD_WORD_LENGTH,
+          (firstSpanIndex + count) * TRACE_SPAN_RECORD_WORD_LENGTH
+        )
+      });
+    }
+  }
+
+  const spanBatchIndex = new Uint32Array(spanBatches.length * TRACE_SPAN_BATCH_RECORD_WORD_LENGTH);
+  const spanBatchIndexFloats = new Float32Array(spanBatchIndex.buffer);
+  for (const batch of spanBatches) {
+    const wordOffset = batch.batchIndex * TRACE_SPAN_BATCH_RECORD_WORD_LENGTH;
+    spanBatchIndex[wordOffset] = batch.firstSpanIndex;
+    spanBatchIndex[wordOffset + 1] = batch.count;
+    spanBatchIndexFloats[wordOffset + 2] = batch.timeMin;
+    spanBatchIndexFloats[wordOffset + 3] = batch.timeMax;
+    spanBatchIndex[wordOffset + 4] = batch.laneMin;
+    spanBatchIndex[wordOffset + 5] = batch.laneMax;
+    spanBatchIndex[wordOffset + 6] = batch.groupIndex;
+    spanBatchIndex[wordOffset + 7] = batch.batchIndex;
+  }
+  return {spanBatches, spanBatchIndex};
 }
 
 /** Maintains the original example API while retaining canonical source references. */
@@ -168,7 +279,8 @@ function fillTraceGroup(params: {
     const laneIndex = Math.floor(random() * TRACE_LANE_COUNT);
     const threadIndex = Math.floor(laneIndex / TRACE_LANES_PER_THREAD);
     const processIndex = Math.floor(threadIndex / TRACE_THREADS_PER_PROCESS);
-    const cluster = Math.floor(random() * 20) * (TRACE_DURATION / 20);
+    const temporalFraction = groupRowIndex / Math.max(params.spanCount, 1);
+    const cluster = Math.floor(temporalFraction * 20) * (TRACE_DURATION / 20);
     const start = Math.min(TRACE_DURATION - 0.05, cluster + random() * 55);
     const durationScale = params.groupIndex === 0 ? 5 : params.groupIndex === 1 ? 14 : 28;
     const duration = Math.max(0.08, Math.pow(random(), 2.6) * durationScale);

--- a/modules/engine/src/compute/computation.ts
+++ b/modules/engine/src/compute/computation.ts
@@ -243,6 +243,23 @@ export class Computation {
     }
   }
 
+  /** Dispatches a GPU-written workgroup count from an indirect buffer. */
+  dispatchIndirect(computePass: ComputePass, indirectBuffer: Buffer, indirectOffset = 0): void {
+    try {
+      this._logDrawCallStart();
+
+      this.pipeline = this._updatePipeline();
+      this.pipeline.setBindings(this.bindings);
+      computePass.setPipeline(this.pipeline);
+      // @ts-expect-error ComputePass implementations expose binding application internally.
+      computePass.setBindings({});
+
+      computePass.dispatchIndirect(indirectBuffer, indirectOffset);
+    } finally {
+      this._logDrawCallEnd();
+    }
+  }
+
   // Update fixed fields (can trigger pipeline rebuild)
 
   // Update dynamic fields

--- a/modules/engine/test/compute/computation.spec.ts
+++ b/modules/engine/test/compute/computation.spec.ts
@@ -73,6 +73,46 @@ test('Computation#compute', async t => {
   t.end();
 });
 
+test('Computation#dispatchIndirect', async t => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (webgpuDevice) {
+    if (isSoftwareBackedDevice(webgpuDevice)) {
+      t.comment('Skipping WebGPU indirect compute test on a software-backed adapter');
+      t.end();
+      return;
+    }
+
+    const computation = new Computation(webgpuDevice, {
+      source,
+      shaderLayout: {
+        bindings: [{name: 'data', type: 'storage', group: 0, location: 0}]
+      }
+    });
+    const workBuffer = webgpuDevice.createBuffer({
+      data: new Int32Array([1, 2, 3, 4]),
+      usage: Buffer.STORAGE | Buffer.COPY_SRC
+    });
+    const dispatchBuffer = webgpuDevice.createBuffer({
+      data: new Uint32Array([4, 1, 1]),
+      usage: Buffer.INDIRECT
+    });
+    computation.setBindings({data: workBuffer});
+
+    const computePass = webgpuDevice.beginComputePass({});
+    computation.dispatchIndirect(computePass, dispatchBuffer);
+    computePass.end();
+    webgpuDevice.submit();
+
+    const computedData = new Int32Array(await workBuffer.readAsync());
+    t.deepEqual(Array.from(computedData), [2, 4, 6, 8], 'GPU-written dimensions drive dispatch');
+
+    computation.destroy();
+    workBuffer.destroy();
+    dispatchBuffer.destroy();
+  }
+  t.end();
+});
+
 test('Computation#plugins assemble WGSL contributions', async t => {
   const webgpuDevice = await getWebGPUTestDevice();
   if (webgpuDevice) {

--- a/modules/experimental/src/gpu-primitives/dispatch-command-buffer.ts
+++ b/modules/experimental/src/gpu-primitives/dispatch-command-buffer.ts
@@ -1,0 +1,154 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUData} from '@luma.gl/tables';
+
+const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
+const DISPATCH_RECORD_WORDS = 3;
+
+/** CPU description of one WebGPU `dispatchWorkgroupsIndirect` record. */
+export type DispatchCommand = {
+  /** Workgroup count in the X dimension. */
+  x: number;
+  /** Workgroup count in the Y dimension. Defaults to `1`. */
+  y?: number;
+  /** Workgroup count in the Z dimension. Defaults to `1`. */
+  z?: number;
+};
+
+/** Properties for one typed WebGPU indirect-dispatch buffer. */
+export type DispatchCommandBufferProps = {
+  /** Buffer identifier. */
+  id?: string;
+  /** Record capacity. Defaults to `commands.length`. */
+  capacity?: number;
+  /** Optional initial CPU records. Unspecified capacity slots are zero-filled. */
+  commands?: DispatchCommand[];
+  /** Optional compatible caller-supplied buffer. */
+  buffer?: Buffer;
+  /** Whether `destroy()` should destroy a supplied buffer. Defaults to `false`. */
+  ownsBuffer?: boolean;
+};
+
+/** Typed owner or borrower of GPU-writable WebGPU indirect-dispatch records. */
+export class DispatchCommandBuffer {
+  /** Byte size of one indirect dispatch record. */
+  static readonly recordByteLength = DISPATCH_RECORD_WORDS * UINT32_BYTE_LENGTH;
+
+  /** WebGPU device owning the backing buffer. */
+  readonly device: Device;
+  /** Buffer identifier. */
+  readonly id: string;
+  /** Maximum record count. */
+  readonly capacity: number;
+  /** Concrete storage/indirect buffer. */
+  readonly buffer: Buffer;
+  private ownsBuffer: boolean;
+  private destroyed = false;
+
+  /** Creates or adopts an indirect-dispatch buffer and optionally uploads initial records. */
+  constructor(device: Device, props: DispatchCommandBufferProps) {
+    if (device.type !== 'webgpu') {
+      throw new Error('DispatchCommandBuffer requires a WebGPU device');
+    }
+    const commands = props.commands ?? [];
+    const capacity = props.capacity ?? commands.length;
+    if (!Number.isSafeInteger(capacity) || capacity < 1) {
+      throw new Error('DispatchCommandBuffer capacity must be a positive safe integer');
+    }
+    if (commands.length > capacity) {
+      throw new Error('DispatchCommandBuffer commands exceed capacity');
+    }
+
+    this.device = device;
+    this.id = props.id ?? 'dispatch-command-buffer';
+    this.capacity = capacity;
+    const byteLength = capacity * DispatchCommandBuffer.recordByteLength;
+    const requiredUsage = Buffer.STORAGE | Buffer.INDIRECT | Buffer.COPY_DST | Buffer.COPY_SRC;
+
+    if (props.buffer) {
+      if (props.buffer.device !== device) {
+        throw new Error('DispatchCommandBuffer buffer must belong to the supplied device');
+      }
+      if (props.buffer.byteLength < byteLength) {
+        throw new Error('DispatchCommandBuffer buffer is smaller than capacity');
+      }
+      if ((props.buffer.usage & requiredUsage) !== requiredUsage) {
+        throw new Error(
+          'DispatchCommandBuffer buffer requires STORAGE, INDIRECT, COPY_DST, and COPY_SRC usage'
+        );
+      }
+      this.buffer = props.buffer;
+      this.ownsBuffer = props.ownsBuffer ?? false;
+      if (commands.length > 0) {
+        this.buffer.write(makeDispatchCommandData(capacity, commands));
+      }
+    } else {
+      this.buffer = device.createBuffer({
+        id: this.id,
+        data: makeDispatchCommandData(capacity, commands),
+        usage: requiredUsage
+      });
+      this.ownsBuffer = true;
+    }
+  }
+
+  /** Returns the byte offset of one indirect record after validating its index. */
+  getCommandByteOffset(commandIndex: number): number {
+    this.validateCommandIndex(commandIndex);
+    return commandIndex * DispatchCommandBuffer.recordByteLength;
+  }
+
+  /** Returns a borrowed table view over one complete three-word dispatch record. */
+  getCommandData(commandIndex: number): GPUData<'uint32'> {
+    return new GPUData({
+      buffer: this.buffer,
+      format: 'uint32',
+      length: DISPATCH_RECORD_WORDS,
+      byteOffset: this.getCommandByteOffset(commandIndex),
+      byteStride: UINT32_BYTE_LENGTH,
+      rowByteLength: UINT32_BYTE_LENGTH,
+      ownsBuffer: false
+    });
+  }
+
+  /** Releases the backing buffer only when this wrapper owns it. */
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    if (this.ownsBuffer) {
+      this.buffer.destroy();
+      this.ownsBuffer = false;
+    }
+    this.destroyed = true;
+  }
+
+  private validateCommandIndex(commandIndex: number): void {
+    if (!Number.isSafeInteger(commandIndex) || commandIndex < 0 || commandIndex >= this.capacity) {
+      throw new Error(`DispatchCommandBuffer command index ${commandIndex} is out of range`);
+    }
+  }
+}
+
+/** Encodes validated CPU command descriptions into little-endian WebGPU indirect records. */
+function makeDispatchCommandData(capacity: number, commands: DispatchCommand[]): Uint32Array {
+  const data = new Uint32Array(capacity * DISPATCH_RECORD_WORDS);
+  commands.forEach((command, commandIndex) => {
+    const wordOffset = commandIndex * DISPATCH_RECORD_WORDS;
+    data[wordOffset] = validateUint32(command.x, 'x');
+    data[wordOffset + 1] = validateUint32(command.y ?? 1, 'y');
+    data[wordOffset + 2] = validateUint32(command.z ?? 1, 'z');
+  });
+  return data;
+}
+
+/** Validates one unsigned indirect-record component. */
+function validateUint32(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 0xffffffff) {
+    throw new Error(`DispatchCommandBuffer ${name} must be a uint32 value`);
+  }
+  return value;
+}

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -135,3 +135,9 @@ export type {
   DrawCommandBufferProps,
   DrawIndexedCommand
 } from './draw-command-buffer';
+
+export {DispatchCommandBuffer} from './dispatch-command-buffer';
+export type {
+  DispatchCommand,
+  DispatchCommandBufferProps
+} from './dispatch-command-buffer';

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
@@ -5,7 +5,13 @@
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {Buffer, type Device, Texture} from '@luma.gl/core';
 import {DynamicBuffer, Model} from '@luma.gl/engine';
-import {DrawCommandBuffer, GPUCommandGraph, GPUCompaction, GPUScan} from '@luma.gl/experimental';
+import {
+  DispatchCommandBuffer,
+  DrawCommandBuffer,
+  GPUCommandGraph,
+  GPUCompaction,
+  GPUScan
+} from '@luma.gl/experimental';
 import {GPUData, GPUVector} from '@luma.gl/tables';
 import {getNullTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
 
@@ -952,6 +958,40 @@ test('DrawCommandBuffer replays an indirect draw through a render bundle', async
   model.destroy();
   framebuffer.destroy();
   colorTexture.destroy();
+  t.end();
+});
+
+test('DispatchCommandBuffer stores typed GPU-writable dispatch records', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  const dispatchCommands = new DispatchCommandBuffer(device, {
+    capacity: 3,
+    commands: [{x: 2}, {x: 3, y: 4, z: 5}]
+  });
+  const bytes = await dispatchCommands.buffer.readAsync();
+  const values = new Uint32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / 4);
+  t.deepEqual(
+    Array.from(values),
+    [2, 1, 1, 3, 4, 5, 0, 0, 0],
+    'records preserve WebGPU x/y/z layout and zero-fill capacity'
+  );
+  const secondCommand = dispatchCommands.getCommandData(1);
+  t.equal(secondCommand.length, 3, 'borrowed command data contains three uint32 rows');
+  t.equal(
+    secondCommand.byteOffset,
+    DispatchCommandBuffer.recordByteLength,
+    'borrowed command data points at the selected record'
+  );
+  t.throws(
+    () => dispatchCommands.getCommandByteOffset(3),
+    /out of range/,
+    'command index is bounded by capacity'
+  );
+  dispatchCommands.destroy();
   t.end();
 });
 

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -5,9 +5,11 @@
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {WgslReflect} from 'wgsl_reflect';
 import {
+  getTraceCapacityOptions,
   isTraceDensityMode,
   makeTraceDataset,
   makeTraceGroups,
+  makeTraceSpanBatches,
   TRACE_CROSS_PROCESS_DEPENDENCY,
   TRACE_DEPENDENCY_RECORD_WORD_LENGTH,
   TRACE_GROUPS,
@@ -17,6 +19,7 @@ import {
   TRACE_PROCESS_COUNT,
   TRACE_SAME_PROCESS_DEPENDENCY,
   TRACE_SPAN_RECORD_WORD_LENGTH,
+  TRACE_SPAN_BATCH_RECORD_WORD_LENGTH,
   TRACE_THREAD_COUNT,
   TRACE_THREADS_PER_PROCESS
 } from '../../examples/experimental/gpu-trace-viewer/trace-data';
@@ -29,6 +32,25 @@ import {
   TRACE_DEPENDENCY_RENDER_SHADER,
   TRACE_RENDER_SHADER
 } from '../../examples/experimental/gpu-trace-viewer/trace-shaders';
+
+test('GPU trace capacity options adapt to negotiated WebGPU buffer limits', t => {
+  t.deepEqual(
+    getTraceCapacityOptions(128 * 1024 * 1024, 256 * 1024 * 1024),
+    [250_000, 1_000_000, 4_000_000],
+    'portable limits retain the four-million-span ceiling'
+  );
+  t.deepEqual(
+    getTraceCapacityOptions(256 * 1024 * 1024, 1024 * 1024 * 1024),
+    [250_000, 1_000_000, 4_000_000],
+    'larger limits retain the interactive demonstration ceiling'
+  );
+  t.deepEqual(
+    getTraceCapacityOptions(1024 * 1024 * 1024, 1024 * 1024 * 1024),
+    [250_000, 1_000_000, 4_000_000],
+    'maximum adapters retain the interactive demonstration ceiling'
+  );
+  t.end();
+});
 
 test('GPU trace LOD switches at a stable trace-time-per-pixel threshold', t => {
   t.equal(isTraceDensityMode(0, 150, 2048), false, 'wide viewport keeps exact spans');
@@ -97,6 +119,71 @@ test('GPU trace data preserves deterministic canonical group and hierarchy ident
     makeTraceGroups(7).map(group => group.count),
     [2, 2, 3],
     'the original trace-group helper remains compatible'
+  );
+  t.end();
+});
+
+test('GPU trace span batches preserve global identity and publish coarse index bounds', t => {
+  const dataset = makeTraceDataset(11);
+  const {spanBatches, spanBatchIndex} = makeTraceSpanBatches(dataset.spans, dataset.groups, 2);
+  t.deepEqual(
+    spanBatches.map(batch => [batch.firstSpanIndex, batch.count, batch.groupIndex]),
+    [
+      [0, 2, 0],
+      [2, 1, 0],
+      [3, 2, 1],
+      [5, 1, 1],
+      [6, 2, 2],
+      [8, 2, 2],
+      [10, 1, 2]
+    ],
+    'batches remain group aligned and completely cover source rows'
+  );
+  t.equal(
+    spanBatchIndex.length,
+    spanBatches.length * TRACE_SPAN_BATCH_RECORD_WORD_LENGTH,
+    'publishes one fixed-width GPU index record per batch'
+  );
+  const spanFloats = new Float32Array(dataset.spans.buffer);
+  const indexFloats = new Float32Array(spanBatchIndex.buffer);
+  for (const batch of spanBatches) {
+    const indexOffset = batch.batchIndex * TRACE_SPAN_BATCH_RECORD_WORD_LENGTH;
+    t.equal(spanBatchIndex[indexOffset], batch.firstSpanIndex, 'index preserves global base');
+    t.equal(spanBatchIndex[indexOffset + 1], batch.count, 'index preserves batch length');
+    t.equal(spanBatchIndex[indexOffset + 6], batch.groupIndex, 'index preserves group identity');
+    t.equal(spanBatchIndex[indexOffset + 7], batch.batchIndex, 'index preserves batch identity');
+    t.ok(
+      Math.abs(indexFloats[indexOffset + 2] - batch.timeMin) < 0.001,
+      'index preserves minimum time'
+    );
+    t.ok(
+      Math.abs(indexFloats[indexOffset + 3] - batch.timeMax) < 0.001,
+      'index preserves maximum time'
+    );
+    for (let rowIndex = 0; rowIndex < batch.count; rowIndex++) {
+      const sourceIndex = batch.firstSpanIndex + rowIndex;
+      const wordOffset = sourceIndex * TRACE_SPAN_RECORD_WORD_LENGTH;
+      const start = spanFloats[wordOffset];
+      const end = start + spanFloats[wordOffset + 1];
+      const lane = dataset.spans[wordOffset + 2];
+      t.ok(start >= batch.timeMin && end <= batch.timeMax, 'batch encloses span time');
+      t.ok(lane >= batch.laneMin && lane < batch.laneMax, 'batch encloses span lane');
+    }
+  }
+  for (const group of dataset.groups) {
+    const groupBatches = spanBatches.filter(batch => batch.groupIndex === group.groupIndex);
+    for (let batchIndex = 1; batchIndex < groupBatches.length; batchIndex++) {
+      t.ok(
+        groupBatches[batchIndex].timeMin >= groupBatches[batchIndex - 1].timeMin,
+        'group batches retain increasing temporal locality'
+      );
+    }
+  }
+  t.equal(spanBatches[0].data.buffer, dataset.spans.buffer, 'batch borrows canonical storage');
+  t.throws(
+    () => makeTraceSpanBatches(dataset.spans, dataset.groups, 0),
+    /positive safe integer/,
+    'invalid batch capacity is rejected'
   );
   t.end();
 });
@@ -181,6 +268,8 @@ test('GPU trace data handles empty inputs and rejects invalid capacities', t => 
   t.equal(dataset.spans.length, 0, 'empty traces have no span rows');
   t.equal(dataset.dependencies.length, 0, 'empty traces have no dependency rows');
   t.equal(dataset.parentSpans.length, 0, 'empty traces have no canonical parent rows');
+  t.equal(dataset.spanBatches.length, 0, 'empty traces have no span batches');
+  t.equal(dataset.spanBatchIndex.length, 0, 'empty traces have no batch index records');
   t.deepEqual(Array.from(dataset.outgoing.offsets), [0], 'empty forward CSR has a sentinel');
   t.deepEqual(Array.from(dataset.incoming.offsets), [0], 'empty reverse CSR has a sentinel');
   t.throws(() => makeTraceDataset(-1), /nonnegative uint32/, 'negative capacity is rejected');

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -134,14 +134,9 @@ describe('GPU hierarchical trace viewer', () => {
         Uint32Array.BYTES_PER_ELEMENT
       );
       expect(new Uint32Array(reachedBytes.buffer, reachedBytes.byteOffset, 1)[0]).toBe(1);
-      const densityBytes = await state.resources.densityBins.readAsync();
-      const density = new Uint32Array(
-        densityBytes.buffer,
-        densityBytes.byteOffset,
-        densityBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
-      );
-      expect(density.some(value => value > 0)).toBe(true);
-
+      focusOnly!.checked = false;
+      focusOnly!.dispatchEvent(new Event('change', {bubbles: true}));
+      expect(state.focusOnly).toBe(false);
       viewer.onRender({device, time: 6000, width: 1, height: 1} as AnimationProps);
       device.submit();
       const densityFrame = await state.resources.drawCommands.buffer.readAsync();


### PR DESCRIPTION
## Summary

- add indirect compute dispatch support to `Computation` and a reusable `DispatchCommandBuffer`
- introduce stable, group-aligned trace span batches with global source identity
- upload a compact GPU batch index containing span ranges, time bounds, lane bounds, group IDs, and batch IDs
- make synthetic trace source ordering temporally clustered so batch bounds are selective
- request the maximum WebGPU feature level while keeping the interactive example capped at a proven 4M spans
- expose batch counts, negotiated buffer limits, and a usable standalone controls panel
- increase density-bin resolution to make automatic scrolling visually smoother

## Why

The trace viewer currently binds and scans one canonical span table. A 10M-span allocation can fit on high-limit adapters, but replaying the complete graph every frame overwhelms presentation. This tranche establishes the data and dispatch contracts needed to select candidate batches and drive later chunked or streamed execution without changing stable span IDs or dependency semantics.

This is stacked on #2819 so the batch/index work remains separate from adaptive density LOD.

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test-node test/examples/gpu-trace-viewer.node.spec.ts` — 7 passed
- `yarn test-browser test/examples/gpu-trace-viewer.spec.ts` — 1 passed on hardware WebGPU
- pre-commit `test-fast` — 258 passed, 2 skipped
- live standalone viewer — 4,000,000 spans, 6 batches, 937,917 dependencies

## Follow-up

- evaluate the GPU batch index against the current viewport
- compact candidate batch IDs and write indirect dispatch commands
- split or stream exact-span storage and reuse batch-local scratch
- re-enable the 10M target once per-frame work scales with candidate batches rather than total spans
