### PR TITLE
Add independent GPU trace capacity controls

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -1187,6 +1187,9 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement)) {
         return;
       }
+      if (target instanceof HTMLSelectElement && event.type !== 'change') {
+        return;
+      }
       if (target.matches('[data-span-capacity]')) {
         this.rebuild(Number(target.value), this.dependencyCapacity);
       } else if (target.matches('[data-dependency-capacity]')) {

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -29,6 +29,7 @@ import {
 } from '../../example-panels';
 import {
   getTraceCapacityOptions,
+  getTraceDependencyCapacityOptions,
   makeTraceDataset,
   isTraceDensityMode,
   TRACE_COLLAPSED_STATE,
@@ -66,6 +67,7 @@ export const description =
   'GPU-resident hierarchical traces with live filtering, adaptive density LOD, dependency traversal, picking, and indirect rendering.';
 
 const DEFAULT_CAPACITY = 250_000;
+const DEFAULT_DEPENDENCY_CAPACITY = 250_000;
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 const TRACE_WORKGROUP_SIZE = 256;
 const VIEW_UNIFORM_BYTE_LENGTH = 64;
@@ -148,9 +150,11 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   readonly viewUniformBuffer: Buffer;
   readonly panels: ExamplePanelManager;
   readonly capacityOptions: number[];
+  readonly dependencyCapacityOptions: number[];
 
   private resources: TraceGraphResources | null = null;
-  private capacity = DEFAULT_CAPACITY;
+  private spanCapacity = DEFAULT_CAPACITY;
+  private dependencyCapacity = DEFAULT_DEPENDENCY_CAPACITY;
   private enabledMask = 0b111;
   private statusMask = (1 << TRACE_STATUS_COUNT) - 1;
   private dependencyMask = 0b11;
@@ -187,14 +191,19 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
 
   constructor({
     device,
-    traceCapacity = DEFAULT_CAPACITY
-  }: AnimationProps & {traceCapacity?: number}) {
+    traceCapacity = DEFAULT_CAPACITY,
+    dependencyCapacity = DEFAULT_DEPENDENCY_CAPACITY
+  }: AnimationProps & {traceCapacity?: number; dependencyCapacity?: number}) {
     super();
     if (device.type !== 'webgpu') {
       throw new Error('GPU Hierarchical Trace Viewer requires WebGPU');
     }
     this.device = device;
     this.capacityOptions = getTraceCapacityOptions(
+      device.limits.maxStorageBufferBindingSize,
+      device.limits.maxBufferSize
+    );
+    this.dependencyCapacityOptions = getTraceDependencyCapacityOptions(
       device.limits.maxStorageBufferBindingSize,
       device.limits.maxBufferSize
     );
@@ -207,7 +216,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     this.dependencyModel = this.createDependencyModel();
     this.densityModel = this.createDensityModel();
     this.panels = new ExamplePanelManager({panel: this.makePanel()});
-    this.rebuild(traceCapacity);
+    this.rebuild(traceCapacity, dependencyCapacity);
     this.panels.mount();
   }
 
@@ -365,12 +374,13 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     });
   }
 
-  private rebuild(capacity: number): void {
+  private rebuild(spanCapacity: number, dependencyCapacity: number): void {
     const started = performance.now();
     this.destroyResources();
-    this.capacity = capacity;
+    this.spanCapacity = spanCapacity;
+    this.dependencyCapacity = dependencyCapacity;
     this.selectedSpanIndex = INVALID_SPAN_INDEX;
-    const dataset = makeTraceDataset(capacity);
+    const dataset = makeTraceDataset(spanCapacity, dependencyCapacity);
     const resources = this.createResources(dataset);
     resources.renderBundle = this.createRenderBundle(resources);
     resources.compiled = this.createGraph(resources, dataset);
@@ -1119,10 +1129,16 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         `<label><input type="checkbox" data-status="${index}" checked> ${name}</label>`
     ).join('');
     return `<div style="display:grid;gap:10px">
-      <label>Capacity <select data-capacity-select>${this.capacityOptions
+      <label>Spans <select data-span-capacity>${this.capacityOptions
         .map(
           value =>
-            `<option value="${value}"${value === this.capacity ? ' selected' : ''}>${formatCount(value)}</option>`
+            `<option value="${value}"${value === this.spanCapacity ? ' selected' : ''}>${formatCount(value)}</option>`
+        )
+        .join('')}</select></label>
+      <label>Dependencies <select data-dependency-capacity>${this.dependencyCapacityOptions
+        .map(
+          value =>
+            `<option value="${value}"${value === this.dependencyCapacity ? ' selected' : ''}>${formatCount(value)}</option>`
         )
         .join('')}</select></label>
       <fieldset style="display:grid;gap:4px"><legend>Span groups</legend>${groupControls}</fieldset>
@@ -1171,8 +1187,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement)) {
         return;
       }
-      if (target.matches('[data-capacity-select]')) {
-        this.rebuild(Number(target.value));
+      if (target.matches('[data-span-capacity]')) {
+        this.rebuild(Number(target.value), this.dependencyCapacity);
+      } else if (target.matches('[data-dependency-capacity]')) {
+        this.rebuild(this.spanCapacity, Number(target.value));
       } else if (target instanceof HTMLInputElement && target.dataset.group !== undefined) {
         const group = Number(target.dataset.group);
         this.enabledMask = setBit(this.enabledMask, group, target.checked);
@@ -1321,7 +1339,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       return;
     }
     if (this.capacityElement) {
-      this.capacityElement.innerHTML = `<strong>${formatCount(this.capacity)}</strong> spans · <strong>${formatCount(resources.spanBatchCount)}</strong> batches · <strong>${formatCount(resources.dependencyCount)}</strong> dependencies · graph compile #${this.compileCount} (${this.compileTimeMilliseconds.toFixed(1)} ms)`;
+      this.capacityElement.innerHTML = `<strong>${formatCount(this.spanCapacity)}</strong> spans · <strong>${formatCount(resources.spanBatchCount)}</strong> batches · <strong>${formatCount(resources.dependencyCount)}/${formatCount(this.dependencyCapacity)}</strong> dependencies · graph compile #${this.compileCount} (${this.compileTimeMilliseconds.toFixed(1)} ms)`;
     }
     if (this.selectionElement) {
       this.selectionElement.textContent =

--- a/examples/experimental/gpu-trace-viewer/trace-data.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-data.ts
@@ -50,6 +50,19 @@ export function getTraceCapacityOptions(
   return TRACE_DEMONSTRATION_CAPACITIES.filter(capacity => capacity <= maximumSpanCapacity);
 }
 
+/** Returns useful dependency limits that fit in one dependency storage-buffer binding. */
+export function getTraceDependencyCapacityOptions(
+  maxStorageBufferBindingSize: number,
+  maxBufferSize: number
+): number[] {
+  const dependencyRecordByteLength =
+    TRACE_DEPENDENCY_RECORD_WORD_LENGTH * Uint32Array.BYTES_PER_ELEMENT;
+  const maximumDependencyCapacity = Math.floor(
+    Math.min(maxStorageBufferBindingSize, maxBufferSize) / dependencyRecordByteLength
+  );
+  return TRACE_DEMONSTRATION_CAPACITIES.filter(capacity => capacity <= maximumDependencyCapacity);
+}
+
 /** Matches the GPU's adaptive exact-span versus density-rendering decision. */
 export function isTraceDensityMode(
   timeMin: number,
@@ -124,9 +137,19 @@ export type TraceDatasetData = {
  * Source identity is the canonical span row index. Groups borrow contiguous views of that same
  * source allocation rather than creating independently numbered records.
  */
-export function makeTraceDataset(totalSpanCount: number): TraceDatasetData {
+export function makeTraceDataset(
+  totalSpanCount: number,
+  maximumDependencyCount = 0xffffffff
+): TraceDatasetData {
   if (!Number.isSafeInteger(totalSpanCount) || totalSpanCount < 0 || totalSpanCount > 0xffffffff) {
     throw new RangeError('Trace span count must be a nonnegative uint32');
+  }
+  if (
+    !Number.isSafeInteger(maximumDependencyCount) ||
+    maximumDependencyCount < 0 ||
+    maximumDependencyCount > 0xffffffff
+  ) {
+    throw new RangeError('Trace dependency count must be a nonnegative uint32');
   }
 
   const spans = new Uint32Array(totalSpanCount * TRACE_SPAN_RECORD_WORD_LENGTH);
@@ -161,7 +184,7 @@ export function makeTraceDataset(totalSpanCount: number): TraceDatasetData {
     remainingSpanCount -= count;
   }
 
-  const topology = makeTraceDependencies(spans, totalSpanCount);
+  const topology = makeTraceDependencies(spans, totalSpanCount, maximumDependencyCount);
   const dependencyCount = topology.dependencies.length / TRACE_DEPENDENCY_RECORD_WORD_LENGTH;
   const {spanBatches, spanBatchIndex} = makeTraceSpanBatches(spans, groups);
   return {
@@ -293,9 +316,14 @@ function fillTraceGroup(params: {
 /** Generates sparse same-thread parent chains and cross-process dependency edges. */
 function makeTraceDependencies(
   spans: Uint32Array,
-  spanCount: number
+  spanCount: number,
+  requestedMaximumDependencyCount: number
 ): {dependencies: Uint32Array; parentSpans: Uint32Array} {
-  const maximumDependencyCount = Math.ceil(spanCount / 5) + Math.ceil(spanCount / 29) + 1;
+  const generatedMaximumDependencyCount = Math.ceil(spanCount / 5) + Math.ceil(spanCount / 29) + 1;
+  const maximumDependencyCount = Math.min(
+    requestedMaximumDependencyCount,
+    generatedMaximumDependencyCount
+  );
   const data = new Uint32Array(maximumDependencyCount * TRACE_DEPENDENCY_RECORD_WORD_LENGTH);
   const spanFloats = new Float32Array(spans.buffer, spans.byteOffset, spans.length);
   const previousSpanByThread = new Uint32Array(TRACE_THREAD_COUNT);
@@ -308,7 +336,11 @@ function makeTraceDependencies(
     const wordOffset = spanIndex * TRACE_SPAN_RECORD_WORD_LENGTH;
     const threadIndex = spans[wordOffset + 5];
     const previousSpan = previousSpanByThread[threadIndex];
-    if (spanIndex % 5 === 0 && previousSpan !== TRACE_INVALID_SPAN_INDEX) {
+    if (
+      dependencyCount < maximumDependencyCount &&
+      spanIndex % 5 === 0 &&
+      previousSpan !== TRACE_INVALID_SPAN_INDEX
+    ) {
       writeTraceDependency(
         data,
         dependencyCount++,
@@ -319,7 +351,7 @@ function makeTraceDependencies(
       parentSpans[spanIndex] = previousSpan;
       annotateTraceParentTopology(spans, spanFloats, previousSpan, spanIndex);
     }
-    if (spanIndex > 7 && spanIndex % 29 === 0) {
+    if (dependencyCount < maximumDependencyCount && spanIndex > 7 && spanIndex % 29 === 0) {
       const processIndex = spans[wordOffset + 4];
       let sourceIndex = spanIndex - 7;
       while (

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -6,6 +6,7 @@ import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {WgslReflect} from 'wgsl_reflect';
 import {
   getTraceCapacityOptions,
+  getTraceDependencyCapacityOptions,
   isTraceDensityMode,
   makeTraceDataset,
   makeTraceGroups,
@@ -39,6 +40,11 @@ test('GPU trace capacity options adapt to negotiated WebGPU buffer limits', t =>
     getTraceCapacityOptions(128 * 1024 * 1024, 256 * 1024 * 1024),
     [250_000, 1_000_000, 4_000_000],
     'portable limits retain the four-million-span ceiling'
+  );
+  t.deepEqual(
+    getTraceDependencyCapacityOptions(128 * 1024 * 1024, 256 * 1024 * 1024),
+    [250_000, 1_000_000, 4_000_000],
+    'dependency options use their smaller fixed-width record size'
   );
   t.deepEqual(
     getTraceCapacityOptions(256 * 1024 * 1024, 1024 * 1024 * 1024),
@@ -122,6 +128,14 @@ test('GPU trace data preserves deterministic canonical group and hierarchy ident
     [2, 2, 3],
     'the original trace-group helper remains compatible'
   );
+  t.end();
+});
+
+test('GPU trace dependency generation respects its independent capacity', t => {
+  const dataset = makeTraceDataset(10_000, 250);
+  t.equal(dataset.spanCount, 10_000, 'span capacity remains independent');
+  t.equal(dataset.dependencyCount, 250, 'dependency generation stops at its requested capacity');
+  t.equal(makeTraceDataset(10_000, 0).dependencyCount, 0, 'zero dependencies are supported');
   t.end();
 });
 
@@ -276,5 +290,10 @@ test('GPU trace data handles empty inputs and rejects invalid capacities', t => 
   t.deepEqual(Array.from(dataset.incoming.offsets), [0], 'empty reverse CSR has a sentinel');
   t.throws(() => makeTraceDataset(-1), /nonnegative uint32/, 'negative capacity is rejected');
   t.throws(() => makeTraceDataset(1.5), /nonnegative uint32/, 'fractional capacity is rejected');
+  t.throws(
+    () => makeTraceDataset(1, -1),
+    /dependency count must be a nonnegative uint32/,
+    'negative dependency capacity is rejected'
+  );
   t.end();
 });

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -56,12 +56,18 @@ describe('GPU hierarchical trace viewer', () => {
         focusDepth: number;
         focusOnly: boolean;
         activeFilterMask: number;
+        spanCapacity: number;
+        dependencyCapacity: number;
       };
       expect(state.resources.spanCount).toBe(4096);
       expect(state.resources.spanBatchCount).toBeGreaterThan(0);
       expect(state.resources.dependencyCount).toBeGreaterThan(0);
       expect(host.querySelectorAll('[data-process]')).toHaveLength(TRACE_PROCESS_COUNT);
       expect(host.querySelectorAll('[data-thread]')).toHaveLength(TRACE_THREAD_COUNT);
+      expect(host.querySelectorAll('[data-span-capacity]')).toHaveLength(1);
+      expect(host.querySelectorAll('[data-dependency-capacity]')).toHaveLength(1);
+      expect(state.spanCapacity).toBe(4096);
+      expect(state.dependencyCapacity).toBe(250_000);
 
       viewer.onRender({device, time: 6000, width: 2048, height: 1} as AnimationProps);
       device.submit();

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -58,6 +58,7 @@ describe('GPU hierarchical trace viewer', () => {
         activeFilterMask: number;
         spanCapacity: number;
         dependencyCapacity: number;
+        compileCount: number;
       };
       expect(state.resources.spanCount).toBe(4096);
       expect(state.resources.spanBatchCount).toBeGreaterThan(0);
@@ -68,6 +69,15 @@ describe('GPU hierarchical trace viewer', () => {
       expect(host.querySelectorAll('[data-dependency-capacity]')).toHaveLength(1);
       expect(state.spanCapacity).toBe(4096);
       expect(state.dependencyCapacity).toBe(250_000);
+      const dependencyCapacity = host.querySelector<HTMLSelectElement>(
+        '[data-dependency-capacity]'
+      );
+      expect(dependencyCapacity).not.toBeNull();
+      const initialCompileCount = state.compileCount;
+      dependencyCapacity!.dispatchEvent(new Event('input', {bubbles: true}));
+      expect(state.compileCount).toBe(initialCompileCount);
+      dependencyCapacity!.dispatchEvent(new Event('change', {bubbles: true}));
+      expect(state.compileCount).toBe(initialCompileCount + 1);
 
       viewer.onRender({device, time: 6000, width: 2048, height: 1} as AnimationProps);
       device.submit();


### PR DESCRIPTION
## Summary

- split trace generation into independent span and dependency capacity controls
- calculate limit-aware dropdown options from the respective 32-byte span and 16-byte dependency records
- enforce the selected dependency upper bound while generating deterministic topology
- report generated dependencies versus the requested limit in the inspector

## Stack

- stacked on #2819 (`codex/trace-density-lod`)
- GPU batch candidate selection was promoted into #2819 to make that PR self-contained after review

## Verification

- `yarn lint fix`
- `yarn build`
- `yarn test-node test/examples/gpu-trace-viewer.node.spec.ts` — 8 passed
- `yarn test-browser test/examples/gpu-trace-viewer.spec.ts` — 1 passed on hardware WebGPU
- commit hook `test-fast` — 259 passed, 2 skipped

## Notes

The 10M options are limit-aware. The inspector reports generated dependencies versus the selected upper bound because sparse topology may naturally produce fewer edges.
