### PR TITLE
refine(examples): polish Volumetric Fire Forge

### DIFF
--- a/examples/experimental/volumetric-fire-forge/app.ts
+++ b/examples/experimental/volumetric-fire-forge/app.ts
@@ -36,6 +36,9 @@ export const description =
 const NEAR_PLANE = 0.1;
 const FAR_PLANE = 80;
 const CAMERA_TARGET: [number, number, number] = [0, 3.05, 0.4];
+const CAMERA_MINIMUM_YAW = Math.PI - 0.62;
+const CAMERA_MAXIMUM_YAW = Math.PI + 0.62;
+const CAMERA_AUTO_ORBIT_SPEED = 0.075;
 const INITIAL_WARMUP_STEP_COUNT = 24;
 
 type VolumetricFireQuality = 'Interactive' | 'High' | 'Cinematic';
@@ -109,6 +112,8 @@ export default class VolumetricFireForgeAnimationLoopTemplate extends AnimationL
   private accumulatorSeconds = 0;
   private simulationTimeSeconds = 0;
   private previousTimeMilliseconds: number | null = null;
+  private previousCameraTimeMilliseconds: number | null = null;
+  private cameraOrbitDirection = 1;
   private resetRequested = true;
   private singleStepRequested = false;
   private warmupStepsRemaining = INITIAL_WARMUP_STEP_COUNT;
@@ -166,8 +171,7 @@ export default class VolumetricFireForgeAnimationLoopTemplate extends AnimationL
         maxDistance: 34,
         minPitch: -0.04,
         maxPitch: 1.25,
-        autoRotate: this.settings.autoOrbitCamera,
-        autoRotateSpeed: 0.075
+        autoRotate: false
       });
     }
     document.getElementById('volumetric-fire-reset')?.addEventListener('click', this.handleReset);
@@ -181,8 +185,7 @@ export default class VolumetricFireForgeAnimationLoopTemplate extends AnimationL
 
   onRender({device, width, height, aspect, time}: AnimationProps): void {
     this.renderer.resize(width, height);
-    this.orbitControls?.setAutoRotate(this.settings.autoOrbitCamera);
-    this.orbitControls?.update(time);
+    this.updateCamera(time);
     const cameraPosition: NumberArray3 = this.orbitControls?.getEyePosition() || [6.2, 5.5, -13.5];
     const viewMatrix = new Matrix4().lookAt({
       eye: cameraPosition,
@@ -240,6 +243,39 @@ export default class VolumetricFireForgeAnimationLoopTemplate extends AnimationL
 
   requestSingleStep(): void {
     this.singleStepRequested = true;
+  }
+
+  private updateCamera(timeMilliseconds: number): void {
+    if (!this.orbitControls) {
+      return;
+    }
+
+    const deltaSeconds =
+      this.previousCameraTimeMilliseconds === null
+        ? 0
+        : Math.min(
+            Math.max((timeMilliseconds - this.previousCameraTimeMilliseconds) / 1000, 0),
+            0.1
+          );
+    this.previousCameraTimeMilliseconds = timeMilliseconds;
+    this.orbitControls.update(timeMilliseconds);
+
+    if (this.orbitControls.yaw <= CAMERA_MINIMUM_YAW) {
+      this.orbitControls.yaw = CAMERA_MINIMUM_YAW;
+      this.cameraOrbitDirection = 1;
+    } else if (this.orbitControls.yaw >= CAMERA_MAXIMUM_YAW) {
+      this.orbitControls.yaw = CAMERA_MAXIMUM_YAW;
+      this.cameraOrbitDirection = -1;
+    } else if (this.settings.autoOrbitCamera) {
+      this.orbitControls.yaw += this.cameraOrbitDirection * CAMERA_AUTO_ORBIT_SPEED * deltaSeconds;
+      if (this.orbitControls.yaw >= CAMERA_MAXIMUM_YAW) {
+        this.orbitControls.yaw = CAMERA_MAXIMUM_YAW;
+        this.cameraOrbitDirection = -1;
+      } else if (this.orbitControls.yaw <= CAMERA_MINIMUM_YAW) {
+        this.orbitControls.yaw = CAMERA_MINIMUM_YAW;
+        this.cameraOrbitDirection = 1;
+      }
+    }
   }
 
   private encodeSimulationSteps(device: Device, timeMilliseconds: number): void {
@@ -370,12 +406,15 @@ export default class VolumetricFireForgeAnimationLoopTemplate extends AnimationL
     if (previousSettings.preset !== this.settings.preset) {
       this.requestReset();
     }
-    this.orbitControls?.setAutoRotate(this.settings.autoOrbitCamera);
   };
 
   private readonly handleReset = (): void => this.requestReset();
   private readonly handleSingleStep = (): void => this.requestSingleStep();
-  private readonly handleResetCamera = (): void => this.orbitControls?.reset();
+  private readonly handleResetCamera = (): void => {
+    this.orbitControls?.reset();
+    this.previousCameraTimeMilliseconds = null;
+    this.cameraOrbitDirection = 1;
+  };
 
   private updateTelemetry(): void {
     const telemetryElement = document.getElementById('volumetric-fire-telemetry');

--- a/examples/experimental/volumetric-fire-forge/volumetric-fire-forge-renderer.ts
+++ b/examples/experimental/volumetric-fire-forge/volumetric-fire-forge-renderer.ts
@@ -117,7 +117,7 @@ export class VolumetricFireForgeRenderer {
           {name: 'instancePositions', format: 'float32x3'},
           {name: 'instanceHalfSizes', format: 'float32x3'},
           {name: 'instanceBaseColors', format: 'float32x3'},
-          {name: 'instanceMaterials', format: 'float32x3'},
+          {name: 'instanceMaterials', format: 'float32x4'},
           {name: 'instanceEmissiveColors', format: 'float32x3'}
         ],
         attributes: {
@@ -362,7 +362,8 @@ function makeForgeInstanceData(): {
       VOLUMETRIC_FIRE_FORGE_BOXES.flatMap(box => [
         box.roughness,
         box.metallic,
-        box.emissiveTopOnly ? 1 : 0
+        box.emissiveTopOnly ? 1 : 0,
+        box.surfaceTreatment === 'refractory-masonry' ? 1 : 0
       ])
     ),
     emissiveColors: new Float32Array(VOLUMETRIC_FIRE_FORGE_BOXES.flatMap(box => box.emissiveColor))

--- a/examples/experimental/volumetric-fire-forge/volumetric-fire-forge-scene.ts
+++ b/examples/experimental/volumetric-fire-forge/volumetric-fire-forge-scene.ts
@@ -22,6 +22,7 @@ export type VolumetricFireForgeBox = {
   color: readonly [number, number, number];
   emissiveColor: readonly [number, number, number];
   emissiveTopOnly?: boolean;
+  surfaceTreatment?: 'refractory-masonry';
   metallic: number;
   roughness: number;
 };
@@ -44,28 +45,31 @@ export const VOLUMETRIC_FIRE_FORGE_BOXES: readonly VolumetricFireForgeBox[] = [
     id: 'rear-refractory-wall',
     center: [0, 1.65, 4.55],
     halfSize: [5.8, 1.65, 0.25],
-    color: [0.052, 0.05, 0.048],
-    emissiveColor: [0.003, 0.0012, 0.0005],
-    metallic: 0.08,
-    roughness: 0.9
+    color: [0.082, 0.05, 0.034],
+    emissiveColor: [0.004, 0.0015, 0.00045],
+    surfaceTreatment: 'refractory-masonry',
+    metallic: 0.03,
+    roughness: 0.92
   },
   {
     id: 'left-forge-cheek',
     center: [-5.55, 1.6, 1.3],
     halfSize: [0.25, 1.6, 3.25],
-    color: [0.046, 0.05, 0.056],
-    emissiveColor: [0.0015, 0.0008, 0.0005],
-    metallic: 0.72,
-    roughness: 0.48
+    color: [0.071, 0.044, 0.032],
+    emissiveColor: [0.0025, 0.001, 0.0004],
+    surfaceTreatment: 'refractory-masonry',
+    metallic: 0.04,
+    roughness: 0.9
   },
   {
     id: 'right-forge-cheek',
     center: [5.55, 1.6, 1.3],
     halfSize: [0.25, 1.6, 3.25],
-    color: [0.046, 0.05, 0.056],
-    emissiveColor: [0.0015, 0.0008, 0.0005],
-    metallic: 0.72,
-    roughness: 0.48
+    color: [0.071, 0.044, 0.032],
+    emissiveColor: [0.0025, 0.001, 0.0004],
+    surfaceTreatment: 'refractory-masonry',
+    metallic: 0.04,
+    roughness: 0.9
   },
   {
     id: 'front-left-lip',

--- a/examples/experimental/volumetric-fire-forge/volumetric-fire-forge-shaders.ts
+++ b/examples/experimental/volumetric-fire-forge/volumetric-fire-forge-shaders.ts
@@ -40,7 +40,7 @@ struct VertexInputs {
   @location(2) instancePositions: vec3f,
   @location(3) instanceHalfSizes: vec3f,
   @location(4) instanceBaseColors: vec3f,
-  @location(5) instanceMaterials: vec3f,
+  @location(5) instanceMaterials: vec4f,
   @location(6) instanceEmissiveColors: vec3f,
 };
 
@@ -49,7 +49,7 @@ struct FragmentInputs {
   @location(0) worldPosition: vec3f,
   @location(1) worldNormal: vec3f,
   @location(2) baseColor: vec3f,
-  @location(3) material: vec3f,
+  @location(3) material: vec4f,
   @location(4) emissiveColor: vec3f,
 };
 
@@ -66,6 +66,76 @@ fn vertexMain(inputs: VertexInputs) -> FragmentInputs {
   outputs.material = inputs.instanceMaterials;
   outputs.emissiveColor = inputs.instanceEmissiveColors;
   return outputs;
+}
+
+fn forgeScene_getMasonryCoordinates(worldPosition: vec3f, normal: vec3f) -> vec2f {
+  let absoluteNormal = abs(normal);
+  var masonryCoordinates = worldPosition.xy;
+  if (absoluteNormal.x > max(absoluteNormal.y, absoluteNormal.z)) {
+    masonryCoordinates = vec2f(worldPosition.z, worldPosition.y);
+  } else if (absoluteNormal.y > absoluteNormal.z) {
+    masonryCoordinates = vec2f(worldPosition.x, worldPosition.z);
+  }
+  return masonryCoordinates;
+}
+
+fn forgeScene_hash21(value: vec2f) -> f32 {
+  return fract(sin(dot(value, vec2f(127.1, 311.7))) * 43758.5453);
+}
+
+fn forgeScene_getMasonrySurface(
+  worldPosition: vec3f,
+  normal: vec3f,
+  baseColor: vec3f
+) -> vec4f {
+  let masonryCoordinates = forgeScene_getMasonryCoordinates(worldPosition, normal);
+  let brickSize = vec2f(1.22, 0.52);
+  let courseIndex = floor(masonryCoordinates.y / brickSize.y);
+  let courseOffset = fract(courseIndex * 0.5);
+  let brickGrid = vec2f(
+    masonryCoordinates.x / brickSize.x + courseOffset,
+    masonryCoordinates.y / brickSize.y
+  );
+  let brickIndex = floor(brickGrid);
+  let brickCoordinates = fract(brickGrid);
+  let verticalJointDistance = min(brickCoordinates.x, 1.0 - brickCoordinates.x) * brickSize.x;
+  let horizontalJointDistance = min(brickCoordinates.y, 1.0 - brickCoordinates.y) * brickSize.y;
+  let mortarDistance = min(verticalJointDistance, horizontalJointDistance);
+  let mortarHalfWidth = 0.035;
+  let mortarFilterWidth = max(fwidth(mortarDistance), 0.0015);
+  let brickMask = smoothstep(
+    mortarHalfWidth - mortarFilterWidth,
+    mortarHalfWidth + mortarFilterWidth,
+    mortarDistance
+  );
+
+  let brickVariation = forgeScene_hash21(brickIndex);
+  let mineralVariation = forgeScene_hash21(brickIndex * 1.73 + vec2f(19.1, 7.7));
+  let sootVariation = forgeScene_hash21(
+    floor(masonryCoordinates * vec2f(0.72, 1.45)) + vec2f(43.0, 17.0)
+  );
+  let upperSoot = smoothstep(1.45, 3.35, worldPosition.y);
+  let soot = clamp(0.025 + upperSoot * (0.12 + sootVariation * 0.12), 0.0, 0.28);
+  let heatCoordinates = (worldPosition.xz - vec2f(0.0, 0.25)) * vec2f(0.16, 0.22);
+  let heatWash = exp(-dot(heatCoordinates, heatCoordinates)) *
+    (1.0 - smoothstep(1.1, 3.5, worldPosition.y));
+
+  let refractoryColor = mix(
+    baseColor * vec3f(1.08, 0.98, 0.9),
+    vec3f(0.135, 0.053, 0.023),
+    0.42
+  );
+  var brickColor = mix(refractoryColor, vec3f(0.18, 0.06, 0.015), heatWash * 0.28);
+  brickColor *= mix(0.8, 1.13, brickVariation) * mix(0.96, 1.04, mineralVariation);
+  brickColor = mix(brickColor, vec3f(0.012, 0.014, 0.016), soot);
+  let bevel = smoothstep(mortarHalfWidth, mortarHalfWidth + 0.065, mortarDistance);
+  brickColor *= mix(0.86, 1.0, bevel);
+
+  let mortarBase = vec3f(0.044, 0.04, 0.035) * mix(0.9, 1.08, mineralVariation);
+  let mortarColor = mix(mortarBase, vec3f(0.012, 0.014, 0.016), soot * 0.72);
+  let surfaceColor = mix(mortarColor, brickColor, brickMask);
+  let surfaceRoughness = mix(0.99, mix(0.84, 0.93, mineralVariation), brickMask);
+  return vec4f(surfaceColor, surfaceRoughness);
 }
 
 fn forgeScene_fresnelSchlick(cosine: f32, baseReflectance: vec3f) -> vec3f {
@@ -114,9 +184,16 @@ fn forgeScene_getBurnerLight(
 fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4f {
   let normal = normalize(inputs.worldNormal);
   let viewDirection = normalize(forgeScene.cameraPosition - inputs.worldPosition);
-  let roughness = clamp(inputs.material.x, 0.06, 1.0);
-  let metallic = clamp(inputs.material.y, 0.0, 1.0);
-  let baseReflectance = mix(vec3f(0.035), inputs.baseColor, metallic);
+  let masonrySurface = forgeScene_getMasonrySurface(
+    inputs.worldPosition,
+    normal,
+    inputs.baseColor
+  );
+  let masonryMask = clamp(inputs.material.w, 0.0, 1.0);
+  let surfaceColor = mix(inputs.baseColor, masonrySurface.rgb, masonryMask);
+  let roughness = mix(clamp(inputs.material.x, 0.06, 1.0), masonrySurface.a, masonryMask);
+  let metallic = mix(clamp(inputs.material.y, 0.0, 1.0), 0.025, masonryMask);
+  let baseReflectance = mix(vec3f(0.035), surfaceColor, metallic);
 
   let frontLeftFire = forgeScene.emitterPosition + vec3f(-1.7, 0.0, -1.15);
   let frontRightFire = forgeScene.emitterPosition + vec3f(1.7, 0.0, -1.15);
@@ -124,30 +201,30 @@ fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4f {
   let rearRightFire = forgeScene.emitterPosition + vec3f(1.3, 0.0, 0.85);
   let fireLighting =
     forgeScene_getBurnerLight(
-      inputs.worldPosition, normal, viewDirection, inputs.baseColor, baseReflectance,
+      inputs.worldPosition, normal, viewDirection, surfaceColor, baseReflectance,
       roughness, metallic, frontLeftFire, 0.0
     ) +
     forgeScene_getBurnerLight(
-      inputs.worldPosition, normal, viewDirection, inputs.baseColor, baseReflectance,
+      inputs.worldPosition, normal, viewDirection, surfaceColor, baseReflectance,
       roughness, metallic, frontRightFire, 1.7
     ) +
     forgeScene_getBurnerLight(
-      inputs.worldPosition, normal, viewDirection, inputs.baseColor, baseReflectance,
+      inputs.worldPosition, normal, viewDirection, surfaceColor, baseReflectance,
       roughness, metallic, rearLeftFire, 3.1
     ) +
     forgeScene_getBurnerLight(
-      inputs.worldPosition, normal, viewDirection, inputs.baseColor, baseReflectance,
+      inputs.worldPosition, normal, viewDirection, surfaceColor, baseReflectance,
       roughness, metallic, rearRightFire, 4.6
     );
 
   let fillDirection = normalize(vec3f(-0.38, 0.82, 0.42));
   let fillDiffuse = max(dot(normal, fillDirection), 0.0);
   let fillColor = vec3f(0.18, 0.26, 0.4) * (0.32 + fillDiffuse * 0.6);
-  let ambient = inputs.baseColor * (0.12 + max(normal.y, 0.0) * 0.05);
+  let ambient = surfaceColor * (0.12 + max(normal.y, 0.0) * 0.05);
   let emissiveTopMask = mix(1.0, smoothstep(0.45, 0.82, normal.y), inputs.material.z);
   let emissive = inputs.emissiveColor * emissiveTopMask *
     (0.9 + 0.1 * sin(forgeScene.time * 5.3 + inputs.worldPosition.x * 2.1));
-  let color = ambient + inputs.baseColor * fillColor + fireLighting + emissive;
+  let color = ambient + surfaceColor * fillColor + fireLighting + emissive;
   return vec4f(max(color, vec3f(0.0)), 1.0);
 }
 `;

--- a/test/examples/volumetric-fire-forge.node.spec.ts
+++ b/test/examples/volumetric-fire-forge.node.spec.ts
@@ -45,6 +45,20 @@ describe('Volumetric Fire Forge scene data', () => {
     const highDynamicRangeBurners = VOLUMETRIC_FIRE_FORGE_BOXES.filter(box => box.emissiveTopOnly);
     expect(highDynamicRangeBurners).toHaveLength(4);
     expect(highDynamicRangeBurners.every(box => Math.max(...box.emissiveColor) > 1)).toBe(true);
+
+    const masonryBoxes = VOLUMETRIC_FIRE_FORGE_BOXES.filter(
+      box => box.surfaceTreatment === 'refractory-masonry'
+    );
+    expect(masonryBoxes.map(box => box.id)).toEqual([
+      'rear-refractory-wall',
+      'left-forge-cheek',
+      'right-forge-cheek'
+    ]);
+    expect(
+      VOLUMETRIC_FIRE_FORGE_BOXES.filter(
+        box => box.id === 'hearth-floor' || box.id.includes('burner')
+      ).every(box => box.surfaceTreatment === undefined)
+    ).toBe(true);
   });
 
   test('voxelizes forge boxes deterministically in x-major texture order', () => {

--- a/test/examples/volumetric-fire-forge.spec.ts
+++ b/test/examples/volumetric-fire-forge.spec.ts
@@ -24,6 +24,8 @@ describe('Volumetric Fire Forge', () => {
     const host = document.createElement('div');
     host.id = 'example-panel-host';
     document.body.append(host);
+    const canvas = document.createElement('canvas');
+    host.append(canvas);
     let viewer: VolumetricFireForgeAnimationLoopTemplate | null = null;
     const simulationDimensions = [16, 24, 16] as const;
     try {
@@ -38,6 +40,12 @@ describe('Volumetric Fire Forge', () => {
         pressureIterations: number;
       });
       viewer.settings.sampleCount = 16;
+      await viewer.onInitialize({
+        ...makeAnimationProps(device, 1000),
+        canvas
+      } as AnimationProps);
+      expect(viewer.orbitControls).not.toBeNull();
+      viewer.orbitControls!.yaw = 0;
       const initialSceneColorTexture = viewer.renderer.sceneColorTexture;
       const initialSceneDepthTexture = viewer.renderer.sceneDepthTexture;
 
@@ -67,6 +75,8 @@ describe('Volumetric Fire Forge', () => {
 
       viewer.onRender(makeAnimationProps(device, 1000));
       device.submit();
+      expect(viewer.orbitControls!.yaw).toBeGreaterThan(Math.PI / 2);
+      expect(viewer.orbitControls!.yaw).toBeLessThan((Math.PI * 3) / 2);
       expect(viewer.stepsThisFrame).toBeGreaterThan(0);
       expect(viewer.renderer.framebufferSize).toEqual([96, 72]);
       expect(viewer.renderer.sceneColorTexture).not.toBe(initialSceneColorTexture);


### PR DESCRIPTION
## Goals

Polish the Volumetric Fire Forge showcase after hands-on visual review while keeping the renderer composable and the cinematic camera inside the forge.

## Changes

- constrain the automatic and interactive camera to a front-facing path that cannot rotate behind the walls
- add procedural refractory brick detail and stronger fire-driven wall illumination
- preserve the HDR fire contrast while improving the forge's material readability
- extend focused node and WebGPU coverage for the camera bounds and rendered result

## Verification

- `yarn lint fix`
- `yarn examples:typecheck` — 34 examples
- focused node tests — 4/4
- focused Chromium WebGPU test — 1/1
- commit hook node suite — 272 passed, 2 skipped

## Stack

Follow-up to the merged renderer showcase PR #2823. This remains based on the open volumetric-fire foundation branch in #2821.
