### PR TITLE
feat(shadertools): add precise raw fp64 deltas

### DIFF
--- a/docs/api-guide/shaders/gpu-floating-point-precision.md
+++ b/docs/api-guide/shaders/gpu-floating-point-precision.md
@@ -338,17 +338,36 @@ WGSL also provides these targeted helpers for `fp64u32` values:
 ```wgsl
 fn sub_fp64u32_to_f32_bits(aBits: vec2u, bBits: vec2u) -> u32
 fn sub_fp64u32_to_f32(aBits: vec2u, bBits: vec2u) -> f32
+fn sub_fp64u32_to_fp64_bits(aBits: vec2u, bBits: vec2u) -> vec2u
+fn sub_fp64u32_to_fp64(aBits: vec2u, bBits: vec2u) -> vec2f
 ```
 
 The words are in canonical order: `.x` contains the sign, exponent, and high
-fraction bits, and `.y` contains the low fraction bits. The helpers implement
-the exact-delta contract described above, including a single round-to-nearest,
-ties-to-even conversion to a binary32 encoding. The `_bits` helper returns that
-encoding as `u32`, including the module's defined handling of zeros,
-subnormals, infinities, and NaNs. WGSL's relaxed rules for those values mean
-that the direct `f32` helper has a portable exact-value guarantee only for
-normal finite results. These helpers are deliberately narrower than the
-general `fp64f32` arithmetic API.
+fraction bits, and `.y` contains the low fraction bits. The `to_f32` helpers
+implement the exact-delta contract described above, including a single
+round-to-nearest, ties-to-even conversion to a binary32 encoding. The
+`to_f32_bits` helper returns that encoding as `u32`, including the module's
+defined handling of zeros, subnormals, infinities, and NaNs. WGSL's relaxed
+rules for those values mean that the direct `f32` helper has a portable
+exact-value guarantee only for normal finite results. These helpers are
+deliberately narrower than the general `fp64f32` arithmetic API.
+
+The `to_fp64` variants implement the other rounding contract: they round the
+exact subtraction once to binary64 and then split that binary64 result into a
+normalized double-single pair. They preserve useful coordinate deltas that do
+not fit in one `f32`, but they do not extend the exponent range. The result has
+up to roughly 48 significand bits with an `f32` exponent range. Finite results
+above that range map to infinity and results below the `f32` subnormal range
+map to canonical zero. This makes the helpers a practical fit for terrestrial
+GIS coordinates and local metric deltas, not for arbitrary binary64-scale
+scientific values.
+
+`normalize_fp64`, `sign_fp64`, and `compare_fp64` use integer-controlled
+normalization regardless of the selected arithmetic mode. Normalization
+handles stored subnormal limb bits and canonicalizes signed zero. NaN remains
+unordered: `sign_fp64` and `compare_fp64` return `0` for NaN, so callers must
+use `is_nan_fp64` or `is_finite_fp64` before interpreting `0` as finite zero or
+equality.
 
 ## Validation Is Part Of The Technique
 

--- a/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
@@ -78,13 +78,29 @@ WGSL also exposes:
 ```wgsl
 fn sub_fp64u32_to_f32_bits(aBits: vec2u, bBits: vec2u) -> u32
 fn sub_fp64u32_to_f32(aBits: vec2u, bBits: vec2u) -> f32
+fn sub_fp64u32_to_fp64_bits(aBits: vec2u, bBits: vec2u) -> vec2u
+fn sub_fp64u32_to_fp64(aBits: vec2u, bBits: vec2u) -> vec2f
 ```
 
 These helpers subtract two `fp64u32` values, i.e. raw IEEE-754 binary64 values
-stored in `vec2u`, using integer arithmetic and round the exact result once to
-`f32`. They are intended for WebGPU paths that need `f32(a64 - b64)`, rather
-than `f32(a64) - f32(b64)`, without relying on emulated fp64 floating-point
-arithmetic.
+stored in `vec2u`, using integer arithmetic. The `to_f32` variants round the
+exact mathematical difference directly and once to `f32`. They are intended
+for WebGPU paths that need `f32(a64 - b64)`, rather than `f32(a64) - f32(b64)`,
+without relying on emulated fp64 floating-point arithmetic.
+
+The `to_fp64` variants first round the exact difference to binary64, matching a
+binary64 subtraction, and then split that value into normalized `f32` high and
+low limbs. This sequencing is intentional: direct exact-to-`f32` rounding and
+binary64-then-`f32` rounding can differ at double-rounding boundaries.
+
+The returned double-single value provides up to approximately 48 significand
+bits, but retains the `f32` exponent range. A finite binary64 result whose
+magnitude is above that range maps to an infinity high limb and zero low limb;
+a result below the `f32` subnormal range maps to canonical positive zero limbs.
+Callers that require a finite result must establish that the expected delta is
+representable in the `f32` exponent range. Terrestrial longitude/latitude,
+projected metre coordinates, and their local deltas are comfortably inside
+that range; this helper is not a general replacement for binary64 arithmetic.
 
 A full bitwise drop-in implementation of `fp64f32` arithmetic is intentionally
 not exposed. That approach is too expensive for iterative fragment shaders and
@@ -100,6 +116,22 @@ the `fp64f32` representation.
 
 If the source data comes from a JavaScript `Float64Array` reinterpreted as
 `Uint32Array`, convert from host word order before calling these helpers.
+
+WGSL additionally exposes normalized comparison helpers:
+
+```wgsl
+fn normalize_fp64(value: vec2f) -> vec2f
+fn is_nan_fp64(value: vec2f) -> bool
+fn is_finite_fp64(value: vec2f) -> bool
+fn sign_fp64(value: vec2f) -> i32
+fn compare_fp64(a: vec2f, b: vec2f) -> i32
+```
+
+`normalize_fp64` uses integer accumulation in both arithmetic modes, including
+for `f32` subnormal limbs, and canonicalizes every signed-zero pair to
+`vec2f(+0.0, +0.0)`. `sign_fp64` and `compare_fp64` return `0` for an unordered
+NaN input. Code where `0` must mean finite zero or equality must first call
+`is_nan_fp64` or `is_finite_fp64`; NaN is never implied to be equal.
 
 ## Remarks
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -9,6 +9,7 @@ Target Release Date: Q3, 2026
 **General**
 
 - **TypeScript 6.0** - luma.gl package builds, website tooling, and supported example typechecks now use TypeScript 6.0.
+- **Precise raw binary64 coordinate deltas** - The WGSL `fp64arithmetic` module can split a binary64-rounded subtraction into normalized double-single limbs, normalize and compare those limbs with integer-controlled behavior in either arithmetic mode, and explicitly classify non-finite values. The existing direct-to-`f32` helper retains its single-round exact-delta contract.
 
 **AI-Assisted Development**
 

--- a/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl.ts
+++ b/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl.ts
@@ -4,7 +4,7 @@
 
 import {fp64arithmeticWGSLInteger} from './fp64-arithmetic-wgsl-integer';
 
-/** WGSL source for fp64 arithmetic helpers and raw binary64-to-Float32 subtraction. */
+/** WGSL source for fp64 arithmetic helpers and raw binary64 subtraction. */
 export const fp64arithmeticWGSL = /* wgsl */ `\
 struct Fp64ArithmeticUniforms {
   ONE: f32,
@@ -143,6 +143,20 @@ fn fp64_round_shift_right_to_u32(value: vec2u, shift: u32) -> u32 {
   return rounded;
 }
 
+fn fp64_round_shift_right(value: vec2u, shift: u32) -> vec2u {
+  if (shift == 0u) {
+    return value;
+  }
+
+  var rounded = fp64_u64_shift_right(value, shift);
+  let guard = fp64_u64_get_bit(value, shift - 1u);
+  let hasTrailingBits = fp64_u64_has_bits_below(value, shift - 1u);
+  if (guard && (hasTrailingBits || (rounded.y & 1u) == 1u)) {
+    rounded = fp64_u64_add(rounded, vec2u(0u, 1u));
+  }
+  return rounded;
+}
+
 fn fp64_make_f32_bits_from_u64(sign: u32, significand: vec2u, baseExponent: i32) -> u32 {
   if (fp64_u64_is_zero(significand)) {
     return sign << 31u;
@@ -217,6 +231,253 @@ fn fp64_finite_magnitude_compare(a: Fp64Bits, b: Fp64Bits) -> i32 {
   return fp64_u64_compare(a.significand, b.significand);
 }
 
+struct Fp64RawF32Bits {
+  sign: u32,
+  baseExponent: i32,
+  significand: u32,
+  isZero: bool,
+  isInf: bool,
+  isNan: bool,
+};
+
+// Decode an f32 as (-1)^sign * significand * 2^baseExponent. This shared
+// integer representation lets normalization remain independent of the
+// selected double-single arithmetic implementation.
+fn fp64_decode_raw_f32_bits(bits: u32) -> Fp64RawF32Bits {
+  let sign = bits >> 31u;
+  let exponentBits = (bits >> 23u) & 0xffu;
+  let fraction = bits & 0x7fffffu;
+
+  if (exponentBits == 0xffu) {
+    return Fp64RawF32Bits(sign, 0, 0u, false, fraction == 0u, fraction != 0u);
+  }
+  if (exponentBits == 0u) {
+    return Fp64RawF32Bits(sign, -149, fraction, fraction == 0u, false, false);
+  }
+  return Fp64RawF32Bits(
+    sign,
+    i32(exponentBits) - 150,
+    0x800000u | fraction,
+    false,
+    false,
+    false
+  );
+}
+
+fn fp64_raw_f32_magnitude_compare(aBits: u32, bBits: u32) -> i32 {
+  let aMagnitude = aBits & 0x7fffffffu;
+  let bMagnitude = bBits & 0x7fffffffu;
+  if (aMagnitude == bMagnitude) {
+    return 0;
+  }
+  return select(-1, 1, aMagnitude > bMagnitude);
+}
+
+fn fp64_make_raw_residual_f32_bits(
+  exactSign: u32,
+  exactMagnitude: vec2u,
+  exactBaseExponent: i32,
+  highBits: u32
+) -> u32 {
+  if (fp64_u64_is_zero(exactMagnitude)) {
+    return 0u;
+  }
+
+  let high = fp64_decode_raw_f32_bits(highBits);
+  if (high.isInf || high.isNan) {
+    return 0u;
+  }
+  if (high.isZero) {
+    return fp64_make_f32_bits_from_u64(exactSign, exactMagnitude, exactBaseExponent);
+  }
+
+  let commonBaseExponent = min(exactBaseExponent, high.baseExponent);
+  let exactShift = exactBaseExponent - commonBaseExponent;
+  let highShift = high.baseExponent - commonBaseExponent;
+  if (exactShift >= 64 || highShift >= 64) {
+    return 0u;
+  }
+
+  let exactAligned = fp64_u64_shift_left(exactMagnitude, u32(exactShift));
+  let highAligned = fp64_u64_shift_left(vec2u(0u, high.significand), u32(highShift));
+  let comparison = fp64_u64_compare(exactAligned, highAligned);
+  if (comparison == 0) {
+    return 0u;
+  }
+
+  var residualSign = exactSign;
+  var residualMagnitude: vec2u;
+  if (comparison > 0) {
+    residualMagnitude = fp64_u64_sub(exactAligned, highAligned);
+  } else {
+    residualSign = exactSign ^ 1u;
+    residualMagnitude = fp64_u64_sub(highAligned, exactAligned);
+  }
+  return fp64_make_f32_bits_from_u64(
+    residualSign,
+    residualMagnitude,
+    commonBaseExponent
+  );
+}
+
+fn fp64_split_raw_accumulator_bits(
+  sign: u32,
+  magnitude: vec2u,
+  baseExponent: i32
+) -> vec2u {
+  if (fp64_u64_is_zero(magnitude)) {
+    return vec2u(0u);
+  }
+  let highBits = fp64_make_f32_bits_from_u64(sign, magnitude, baseExponent);
+  let rawLowBits = fp64_make_raw_residual_f32_bits(sign, magnitude, baseExponent, highBits);
+  let lowBits = select(rawLowBits, 0u, (rawLowBits & 0x7fffffffu) == 0u);
+  if ((highBits & 0x7fffffffu) == 0u && (lowBits & 0x7fffffffu) == 0u) {
+    return vec2u(0u);
+  }
+  return vec2u(highBits, lowBits);
+}
+
+// Round an arithmetic accumulator to binary64 before splitting it. The
+// aligned add/subtract paths retain three guard bits plus a sticky bit, which
+// is sufficient for round-to-nearest-even at the binary64 boundary.
+fn fp64_split_binary64_accumulator_bits(
+  sign: u32,
+  magnitude: vec2u,
+  baseExponent: i32
+) -> vec2u {
+  if (fp64_u64_is_zero(magnitude)) {
+    return vec2u(0u);
+  }
+
+  let mostSignificantBit = 63u - fp64_u64_count_leading_zeros(magnitude);
+  let exponent = baseExponent + i32(mostSignificantBit);
+  if (exponent > 1023) {
+    return vec2u((sign << 31u) | 0x7f800000u, 0u);
+  }
+
+  var roundedMagnitude = magnitude;
+  var roundedBaseExponent = baseExponent;
+  if (exponent >= -1022) {
+    if (mostSignificantBit > 52u) {
+      let shift = mostSignificantBit - 52u;
+      roundedMagnitude = fp64_round_shift_right(magnitude, shift);
+      roundedBaseExponent = baseExponent + i32(shift);
+    }
+  } else {
+    let shift = -1074 - baseExponent;
+    if (shift > 0) {
+      roundedMagnitude = fp64_round_shift_right(magnitude, u32(shift));
+      roundedBaseExponent = -1074;
+    }
+  }
+
+  if (fp64_u64_is_zero(roundedMagnitude)) {
+    return vec2u(0u);
+  }
+  return fp64_split_raw_accumulator_bits(sign, roundedMagnitude, roundedBaseExponent);
+}
+
+fn fp64_add_raw_f32_bits(aBits: u32, bBits: u32) -> vec2u {
+  let a = fp64_decode_raw_f32_bits(aBits);
+  let b = fp64_decode_raw_f32_bits(bBits);
+
+  if (a.isNan || b.isNan) {
+    return vec2u(0x7fc00000u, 0u);
+  }
+  if (a.isInf || b.isInf) {
+    if (a.isInf && b.isInf && a.sign != b.sign) {
+      return vec2u(0x7fc00000u, 0u);
+    }
+    return select(vec2u(bBits, 0u), vec2u(aBits, 0u), a.isInf);
+  }
+  if (a.isZero && b.isZero) {
+    return vec2u(0u);
+  }
+  if (a.isZero) {
+    return vec2u(bBits, 0u);
+  }
+  if (b.isZero) {
+    return vec2u(aBits, 0u);
+  }
+
+  let exponentDifference = abs(a.baseExponent - b.baseExponent);
+  if (exponentDifference > 25) {
+    if (fp64_raw_f32_magnitude_compare(aBits, bBits) >= 0) {
+      return vec2u(aBits, bBits);
+    }
+    return vec2u(bBits, aBits);
+  }
+
+  let commonBaseExponent = min(a.baseExponent, b.baseExponent);
+  let aMagnitude = fp64_u64_shift_left(
+    vec2u(0u, a.significand),
+    u32(a.baseExponent - commonBaseExponent)
+  );
+  let bMagnitude = fp64_u64_shift_left(
+    vec2u(0u, b.significand),
+    u32(b.baseExponent - commonBaseExponent)
+  );
+
+  var resultSign = a.sign;
+  var resultMagnitude: vec2u;
+  if (a.sign == b.sign) {
+    resultMagnitude = fp64_u64_add(aMagnitude, bMagnitude);
+  } else {
+    let comparison = fp64_u64_compare(aMagnitude, bMagnitude);
+    if (comparison == 0) {
+      return vec2u(0u);
+    }
+    if (comparison > 0) {
+      resultMagnitude = fp64_u64_sub(aMagnitude, bMagnitude);
+    } else {
+      resultSign = b.sign;
+      resultMagnitude = fp64_u64_sub(bMagnitude, aMagnitude);
+    }
+  }
+
+  return fp64_split_raw_accumulator_bits(
+    resultSign,
+    resultMagnitude,
+    commonBaseExponent
+  );
+}
+
+fn fp64_add_aligned_magnitudes_to_fp64_bits(
+  sign: u32,
+  larger: Fp64Bits,
+  smaller: Fp64Bits
+) -> vec2u {
+  let largeSignificand = fp64_u64_shift_left(larger.significand, 3u);
+  let smallSignificand = fp64_u64_shift_right_sticky(
+    fp64_u64_shift_left(smaller.significand, 3u),
+    u32(larger.exponent - smaller.exponent)
+  );
+  let resultSignificand = fp64_u64_add(largeSignificand, smallSignificand);
+  return fp64_split_binary64_accumulator_bits(
+    sign,
+    resultSignificand,
+    larger.exponent - 55
+  );
+}
+
+fn fp64_sub_aligned_magnitudes_to_fp64_bits(
+  sign: u32,
+  larger: Fp64Bits,
+  smaller: Fp64Bits
+) -> vec2u {
+  let largeSignificand = fp64_u64_shift_left(larger.significand, 3u);
+  let smallSignificand = fp64_u64_shift_right_sticky(
+    fp64_u64_shift_left(smaller.significand, 3u),
+    u32(larger.exponent - smaller.exponent)
+  );
+  let resultSignificand = fp64_u64_sub(largeSignificand, smallSignificand);
+  return fp64_split_binary64_accumulator_bits(
+    sign,
+    resultSignificand,
+    larger.exponent - 55
+  );
+}
+
 fn fp64_add_aligned_magnitudes_to_f32_bits(sign: u32, larger: Fp64Bits, smaller: Fp64Bits) -> u32 {
   let largeSignificand = fp64_u64_shift_left(larger.significand, 3u);
   let smallSignificand = fp64_u64_shift_right_sticky(
@@ -283,6 +544,56 @@ fn sub_fp64u32_to_f32_bits(aBits: vec2u, bBits: vec2u) -> u32 {
 
 fn sub_fp64u32_to_f32(aBits: vec2u, bBits: vec2u) -> f32 {
   return bitcast<f32>(sub_fp64u32_to_f32_bits(aBits, bBits));
+}
+
+// Subtract two raw binary64 values, round once to binary64, then split the
+// result into normalized f32 limbs. Finite results must fit within the f32
+// exponent range; larger magnitudes map to infinity and smaller magnitudes
+// map to zero. The input words use canonical high/low word order.
+fn sub_fp64u32_to_fp64_bits(aBits: vec2u, bBits: vec2u) -> vec2u {
+  let a = fp64_decode_bits(aBits);
+  let b = fp64_decode_bits(bBits);
+  let bSubtractionSign = b.sign ^ 1u;
+
+  if (a.isNan || b.isNan) {
+    return vec2u(0x7fc00000u, 0u);
+  }
+  if (a.isInf && b.isInf) {
+    if (a.sign == bSubtractionSign) {
+      return vec2u((a.sign << 31u) | 0x7f800000u, 0u);
+    }
+    return vec2u(0x7fc00000u, 0u);
+  }
+  if (a.isInf) {
+    return vec2u((a.sign << 31u) | 0x7f800000u, 0u);
+  }
+  if (b.isInf) {
+    return vec2u((bSubtractionSign << 31u) | 0x7f800000u, 0u);
+  }
+  if (a.isZero && b.isZero) {
+    return vec2u(0u);
+  }
+
+  let magnitudeComparison = fp64_finite_magnitude_compare(a, b);
+  if (a.sign == bSubtractionSign) {
+    if (magnitudeComparison >= 0) {
+      return fp64_add_aligned_magnitudes_to_fp64_bits(a.sign, a, b);
+    }
+    return fp64_add_aligned_magnitudes_to_fp64_bits(a.sign, b, a);
+  }
+
+  if (magnitudeComparison == 0) {
+    return vec2u(0u);
+  }
+  if (magnitudeComparison > 0) {
+    return fp64_sub_aligned_magnitudes_to_fp64_bits(a.sign, a, b);
+  }
+  return fp64_sub_aligned_magnitudes_to_fp64_bits(bSubtractionSign, b, a);
+}
+
+fn sub_fp64u32_to_fp64(aBits: vec2u, bBits: vec2u) -> vec2f {
+  let resultBits = sub_fp64u32_to_fp64_bits(aBits, bBits);
+  return vec2f(bitcast<f32>(resultBits.x), bitcast<f32>(resultBits.y));
 }
 
 fn fp64_runtime_zero() -> f32 {
@@ -483,4 +794,91 @@ fn sqrt_fp64(a: vec2f) -> vec2f {
 #endif
 }
 #endif
+
+fn fp64_f32_bits_is_nan(bits: u32) -> bool {
+  return (bits & 0x7fffffffu) > 0x7f800000u;
+}
+
+fn fp64_f32_bits_is_inf(bits: u32) -> bool {
+  return (bits & 0x7fffffffu) == 0x7f800000u;
+}
+
+fn fp64_compare_f32_bits(aBits: u32, bBits: u32) -> i32 {
+  let aMagnitude = aBits & 0x7fffffffu;
+  let bMagnitude = bBits & 0x7fffffffu;
+  if (aMagnitude == 0u && bMagnitude == 0u) {
+    return 0;
+  }
+  let aSign = aBits >> 31u;
+  let bSign = bBits >> 31u;
+  if (aSign != bSign) {
+    return select(1, -1, aSign == 1u);
+  }
+  if (aMagnitude == bMagnitude) {
+    return 0;
+  }
+  let magnitudeComparison = select(-1, 1, aMagnitude > bMagnitude);
+  return select(magnitudeComparison, -magnitudeComparison, aSign == 1u);
+}
+
+// Normalize an arbitrary pair of finite f32 limbs with integer accumulation.
+// This is independent of LUMA_FP64_INTEGER_ARITHMETIC and canonicalizes every
+// representation of zero to vec2f(+0.0, +0.0).
+fn normalize_fp64(value: vec2f) -> vec2f {
+  let resultBits = fp64_add_raw_f32_bits(bitcast<u32>(value.x), bitcast<u32>(value.y));
+  return vec2f(bitcast<f32>(resultBits.x), bitcast<f32>(resultBits.y));
+}
+
+fn is_nan_fp64(value: vec2f) -> bool {
+  let normalized = normalize_fp64(value);
+  return fp64_f32_bits_is_nan(bitcast<u32>(normalized.x)) ||
+    fp64_f32_bits_is_nan(bitcast<u32>(normalized.y));
+}
+
+fn is_finite_fp64(value: vec2f) -> bool {
+  let normalized = normalize_fp64(value);
+  let highBits = bitcast<u32>(normalized.x);
+  let lowBits = bitcast<u32>(normalized.y);
+  return !fp64_f32_bits_is_nan(highBits) && !fp64_f32_bits_is_nan(lowBits) &&
+    !fp64_f32_bits_is_inf(highBits) && !fp64_f32_bits_is_inf(lowBits);
+}
+
+// Returns -1, 0, or 1. NaN is unordered and returns 0; call is_nan_fp64 or
+// is_finite_fp64 first when 0 must mean a finite zero.
+fn sign_fp64(value: vec2f) -> i32 {
+  let normalized = normalize_fp64(value);
+  let highBits = bitcast<u32>(normalized.x);
+  let lowBits = bitcast<u32>(normalized.y);
+  if (fp64_f32_bits_is_nan(highBits) || fp64_f32_bits_is_nan(lowBits)) {
+    return 0;
+  }
+  if ((highBits & 0x7fffffffu) != 0u) {
+    return select(1, -1, (highBits >> 31u) == 1u);
+  }
+  if ((lowBits & 0x7fffffffu) != 0u) {
+    return select(1, -1, (lowBits >> 31u) == 1u);
+  }
+  return 0;
+}
+
+// Compares double-single values and returns -1, 0, or 1. NaN is unordered
+// and returns 0; callers that require equality semantics must first check
+// is_nan_fp64 or is_finite_fp64.
+fn compare_fp64(a: vec2f, b: vec2f) -> i32 {
+  let normalizedA = normalize_fp64(a);
+  let normalizedB = normalize_fp64(b);
+  let aHighBits = bitcast<u32>(normalizedA.x);
+  let aLowBits = bitcast<u32>(normalizedA.y);
+  let bHighBits = bitcast<u32>(normalizedB.x);
+  let bLowBits = bitcast<u32>(normalizedB.y);
+  if (fp64_f32_bits_is_nan(aHighBits) || fp64_f32_bits_is_nan(aLowBits) ||
+      fp64_f32_bits_is_nan(bHighBits) || fp64_f32_bits_is_nan(bLowBits)) {
+    return 0;
+  }
+  let highComparison = fp64_compare_f32_bits(aHighBits, bHighBits);
+  if (highComparison != 0) {
+    return highComparison;
+  }
+  return fp64_compare_f32_bits(aLowBits, bLowBits);
+}
 `;

--- a/modules/shadertools/test/modules/math/fp64-arithmetic-compute.spec.ts
+++ b/modules/shadertools/test/modules/math/fp64-arithmetic-compute.spec.ts
@@ -269,6 +269,12 @@ const FP64U32_SUBTRACT_CASES: Fp64u32SubtractCase[] = [
   {label: 'subnormal tie to even', inputA: 3 * 2 ** -150, inputB: 0},
   {label: 'largest f32 subnormal', inputA: 2 ** -126, inputB: 2 ** -149},
   {label: 'normal subnormal boundary tie', inputA: 2 ** -126, inputB: 2 ** -150},
+  {
+    label: 'single-round exact delta avoids binary64 double rounding',
+    inputA: 1 + 2 ** -24,
+    inputB: -(2 ** -77),
+    expectedBits: 0x3f800001
+  },
   {label: 'tiny negative underflow', inputA: 0, inputB: Number.MIN_VALUE},
   {label: 'finite positive overflow', inputA: Number.MAX_VALUE, inputB: -Number.MAX_VALUE},
   {label: 'finite negative overflow', inputA: -Number.MAX_VALUE, inputB: Number.MAX_VALUE},
@@ -323,7 +329,7 @@ test('fp64 WGSL#sub_fp64u32_to_f32', async tapeTest => {
     encodedInputB[index * 2 + 1] = inputB[1];
     expectedBits[index] =
       fp64u32SubtractCase.expectedBits ??
-      getFloat32Bits(Math.fround(fp64u32SubtractCase.inputA - fp64u32SubtractCase.inputB));
+      getExpectedExactDifferenceF32Bits(fp64u32SubtractCase.inputA, fp64u32SubtractCase.inputB);
   }
 
   const inputABuffer = webgpuDevice.createBuffer({
@@ -389,6 +395,383 @@ test('fp64 WGSL#sub_fp64u32_to_f32', async tapeTest => {
     inputABuffer.destroy();
     inputBBuffer.destroy();
     resultBuffer.destroy();
+  }
+
+  tapeTest.end();
+});
+
+test('fp64 WGSL#sub_fp64u32_to_fp64 preserves binary64 coordinate deltas', async tapeTest => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    tapeTest.comment('WebGPU unavailable, skipping fp64u32 double-single subtraction diagnostics');
+    tapeTest.end();
+    return;
+  }
+
+  const coordinateCases = [
+    {inputA: 20_000_000.123456, inputB: 20_000_000, label: 'projected coordinate offset'},
+    {inputA: -73.985656000001, inputB: -73.985656, label: 'longitude cancellation'},
+    {inputA: 1 + 2 ** -40, inputB: 1, label: 'sub-f32 unit delta'},
+    {inputA: -8_000_000, inputB: -7_999_999.999999, label: 'negative projected delta'},
+    {inputA: 20_000_000 + 2 ** -28, inputB: 20_000_000, label: 'one ULP GIS delta'},
+    {inputA: -20_000_000 - 2 ** -28, inputB: -20_000_000, label: 'negative GIS delta'},
+    {inputA: 2 ** 53, inputB: 2 ** 53 - 1, label: 'adjacent maximum-precision integers'},
+    {inputA: 1 + 2 ** -24, inputB: -(2 ** -77), label: 'binary64 double-round boundary'},
+    {inputA: 1, inputB: 2 ** -100, label: 'wide exponent gap rounds before splitting'},
+    {inputA: 1, inputB: 2 ** -40, label: 'sparse representable low limb'},
+    {inputA: 1.5, inputB: -2.25, label: 'opposite-sign addition path'},
+    {inputA: 3.4028234663852886e38, inputB: 0, label: 'maximum f32 magnitude'},
+    {inputA: 2 ** -149, inputB: 0, label: 'minimum f32 subnormal'},
+    {inputA: 3 * 2 ** -150, inputB: 0, label: 'subnormal residual zero canonicalization'},
+    {inputA: Number.MIN_VALUE, inputB: 0, label: 'below f32 exponent range'},
+    {inputA: Number.MAX_VALUE, inputB: 0, label: 'above f32 exponent range'},
+    {inputA: Number.MAX_VALUE, inputB: -Number.MAX_VALUE, label: 'binary64 overflow'},
+    {inputA: Infinity, inputB: -Infinity, label: 'positive infinity'},
+    {inputA: -Infinity, inputB: Infinity, label: 'negative infinity'},
+    {inputA: Infinity, inputB: Infinity, label: 'invalid infinity subtraction'},
+    {inputA: NaN, inputB: 1, label: 'nan propagation'},
+    {inputA: -0, inputB: 0, label: 'zero canonicalization'},
+    ...makeRawBinary64SubtractCases(96)
+  ];
+  const encodedInputA = new Uint32Array(coordinateCases.length * 2);
+  const encodedInputB = new Uint32Array(coordinateCases.length * 2);
+  const expectedBits = new Uint32Array(coordinateCases.length * 2);
+
+  for (let index = 0; index < coordinateCases.length; index++) {
+    const coordinateCase = coordinateCases[index];
+    encodedInputA.set(getFloat64Words(coordinateCase.inputA), index * 2);
+    encodedInputB.set(getFloat64Words(coordinateCase.inputB), index * 2);
+    expectedBits.set(
+      getExpectedBinary64DifferenceFp64Bits(coordinateCase.inputA, coordinateCase.inputB),
+      index * 2
+    );
+  }
+
+  const inputABuffer = webgpuDevice.createBuffer({
+    data: encodedInputA,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  const inputBBuffer = webgpuDevice.createBuffer({
+    data: encodedInputB,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  const resultBuffer = webgpuDevice.createBuffer({
+    byteLength: coordinateCases.length * 16,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  const computation = new Computation(webgpuDevice, {
+    source: buildWGSLFp64u32DoubleSingleSubtractSource(),
+    modules: [fp64arithmetic],
+    defines: {LUMA_FP64_INTEGER_ARITHMETIC: true},
+    shaderLayout: {
+      bindings: [
+        {name: 'inputAData', type: 'storage', group: 0, location: 1},
+        {name: 'inputBData', type: 'storage', group: 0, location: 2},
+        {name: 'resultData', type: 'storage', group: 0, location: 3}
+      ]
+    }
+  });
+
+  try {
+    computation.setBindings({
+      inputAData: inputABuffer,
+      inputBData: inputBBuffer,
+      resultData: resultBuffer
+    });
+    const computePass = webgpuDevice.beginComputePass({});
+    computation.dispatch(computePass, coordinateCases.length);
+    computePass.end();
+    webgpuDevice.submit();
+
+    const resultBytes = await resultBuffer.readAsync();
+    const resultBits = new Uint32Array(
+      resultBytes.buffer,
+      resultBytes.byteOffset,
+      resultBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+    );
+    const signedResults = new Int32Array(
+      resultBytes.buffer,
+      resultBytes.byteOffset,
+      resultBytes.byteLength / Int32Array.BYTES_PER_ELEMENT
+    );
+    for (let index = 0; index < coordinateCases.length; index++) {
+      tapeTest.equal(
+        resultBits[index * 4],
+        expectedBits[index * 2],
+        `${coordinateCases[index].label} high limb is exact`
+      );
+      tapeTest.equal(
+        resultBits[index * 4 + 1],
+        expectedBits[index * 2 + 1],
+        `${coordinateCases[index].label} low limb is exact`
+      );
+      const expectedValue =
+        bitcastUint32ToFloat32(expectedBits[index * 2]) +
+        bitcastUint32ToFloat32(expectedBits[index * 2 + 1]);
+      const expectedSign = Number.isNaN(expectedValue)
+        ? 0
+        : expectedValue > 0
+          ? 1
+          : expectedValue < 0
+            ? -1
+            : 0;
+      tapeTest.equal(
+        signedResults[index * 4 + 2],
+        expectedSign,
+        `${coordinateCases[index].label} has normalized sign`
+      );
+      tapeTest.equal(
+        signedResults[index * 4 + 3],
+        expectedSign,
+        `${coordinateCases[index].label} compares against zero`
+      );
+    }
+  } finally {
+    computation.destroy();
+    inputABuffer.destroy();
+    inputBBuffer.destroy();
+    resultBuffer.destroy();
+  }
+
+  tapeTest.end();
+});
+
+test('fp64 WGSL#normalize, classify, sign, and compare double-single values', async tapeTest => {
+  const webgpuDevice = await getWebGPUTestDevice();
+  if (!webgpuDevice) {
+    tapeTest.comment('WebGPU unavailable, skipping fp64 comparison diagnostics');
+    tapeTest.end();
+    return;
+  }
+
+  const nextFloatBelowOne = bitcastUint32ToFloat32(0x3f7fffff);
+  const minimumSubnormal = bitcastUint32ToFloat32(0x00000001);
+  const largestSubnormal = bitcastUint32ToFloat32(0x007fffff);
+  const minimumNormal = bitcastUint32ToFloat32(0x00800000);
+  const comparisonCases = [
+    {
+      inputA: [1, -2],
+      inputB: [-0.5, 0],
+      normalizedBits: [0xbf800000, 0],
+      sign: -1,
+      comparison: -1,
+      finite: 1,
+      nan: 0,
+      label: 'overlapping limbs'
+    },
+    {
+      inputA: [1, -(2 ** -24)],
+      inputB: [nextFloatBelowOne, 0],
+      normalizedBits: [0x3f7fffff, 0],
+      sign: 1,
+      comparison: 0,
+      finite: 1,
+      nan: 0,
+      label: 'equivalent decompositions'
+    },
+    {
+      inputA: [minimumSubnormal, 0],
+      inputB: [0, 0],
+      normalizedBits: [0x00000001, 0],
+      sign: 1,
+      comparison: 1,
+      finite: 1,
+      nan: 0,
+      label: 'minimum subnormal bits'
+    },
+    {
+      inputA: [largestSubnormal, minimumSubnormal],
+      inputB: [minimumNormal, 0],
+      normalizedBits: [0x00800000, 0],
+      sign: 1,
+      comparison: 0,
+      finite: 1,
+      nan: 0,
+      label: 'subnormal to normal carry'
+    },
+    {
+      inputA: [minimumNormal, -minimumSubnormal],
+      inputB: [largestSubnormal, 0],
+      normalizedBits: [0x007fffff, 0],
+      sign: 1,
+      comparison: 0,
+      finite: 1,
+      nan: 0,
+      label: 'normal to subnormal borrow'
+    },
+    ...[
+      [0, 0],
+      [0, -0],
+      [-0, 0],
+      [-0, -0]
+    ].map((inputA, index) => ({
+      inputA,
+      inputB: [0, 0],
+      normalizedBits: [0, 0],
+      sign: 0,
+      comparison: 0,
+      finite: 1,
+      nan: 0,
+      label: `signed zero pair ${index}`
+    })),
+    {
+      inputA: [1, 2 ** -30],
+      inputB: [1, 2 ** -31],
+      normalizedBits: [0x3f800000, getFloat32Bits(2 ** -30)],
+      sign: 1,
+      comparison: 1,
+      finite: 1,
+      nan: 0,
+      label: 'positive low-limb ordering'
+    },
+    {
+      inputA: [-1, -(2 ** -30)],
+      inputB: [-1, -(2 ** -31)],
+      normalizedBits: [0xbf800000, getFloat32Bits(-(2 ** -30))],
+      sign: -1,
+      comparison: -1,
+      finite: 1,
+      nan: 0,
+      label: 'negative low-limb ordering'
+    },
+    {
+      inputA: [NaN, 0],
+      inputB: [0, 0],
+      normalizedBits: [0x7fc00000, 0],
+      sign: 0,
+      comparison: 0,
+      finite: 0,
+      nan: 1,
+      label: 'unordered high nan'
+    },
+    {
+      inputA: [1, NaN],
+      inputB: [0, 0],
+      normalizedBits: [0x7fc00000, 0],
+      sign: 0,
+      comparison: 0,
+      finite: 0,
+      nan: 1,
+      label: 'unordered low nan'
+    },
+    {
+      inputA: [Infinity, -Infinity],
+      inputB: [0, 0],
+      normalizedBits: [0x7fc00000, 0],
+      sign: 0,
+      comparison: 0,
+      finite: 0,
+      nan: 1,
+      label: 'opposite infinities normalize to nan'
+    },
+    {
+      inputA: [Infinity, 0],
+      inputB: [3.4028234663852886e38, 0],
+      normalizedBits: [0x7f800000, 0],
+      sign: 1,
+      comparison: 1,
+      finite: 0,
+      nan: 0,
+      label: 'positive infinity'
+    }
+  ];
+  const encodedInputs = new Uint32Array(comparisonCases.length * 4);
+  for (let index = 0; index < comparisonCases.length; index++) {
+    const comparisonCase = comparisonCases[index];
+    encodedInputs.set(
+      [
+        getFloat32Bits(comparisonCase.inputA[0]),
+        getFloat32Bits(comparisonCase.inputA[1]),
+        getFloat32Bits(comparisonCase.inputB[0]),
+        getFloat32Bits(comparisonCase.inputB[1])
+      ],
+      index * 4
+    );
+  }
+
+  const inputBuffer = webgpuDevice.createBuffer({
+    data: encodedInputs,
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  try {
+    for (const arithmeticMode of [
+      {label: 'default arithmetic', defines: {}},
+      {label: 'integer arithmetic', defines: {LUMA_FP64_INTEGER_ARITHMETIC: true}}
+    ]) {
+      const resultBuffer = webgpuDevice.createBuffer({
+        byteLength: comparisonCases.length * 32,
+        usage: Buffer.STORAGE | Buffer.COPY_SRC
+      });
+      const computation = new Computation(webgpuDevice, {
+        source: buildWGSLFp64ComparisonSource(),
+        modules: [fp64arithmetic],
+        defines: arithmeticMode.defines,
+        shaderLayout: {
+          bindings: [
+            {name: 'inputData', type: 'storage', group: 0, location: 1},
+            {name: 'resultData', type: 'storage', group: 0, location: 2}
+          ]
+        }
+      });
+      try {
+        computation.setBindings({inputData: inputBuffer, resultData: resultBuffer});
+        const computePass = webgpuDevice.beginComputePass({});
+        computation.dispatch(computePass, comparisonCases.length);
+        computePass.end();
+        webgpuDevice.submit();
+
+        const resultBytes = await resultBuffer.readAsync();
+        const resultBits = new Uint32Array(
+          resultBytes.buffer,
+          resultBytes.byteOffset,
+          resultBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+        );
+        const signedResults = new Int32Array(
+          resultBytes.buffer,
+          resultBytes.byteOffset,
+          resultBytes.byteLength / Int32Array.BYTES_PER_ELEMENT
+        );
+        for (let index = 0; index < comparisonCases.length; index++) {
+          const comparisonCase = comparisonCases[index];
+          const resultOffset = index * 8;
+          tapeTest.equal(
+            resultBits[resultOffset],
+            comparisonCase.normalizedBits[0],
+            `${arithmeticMode.label} ${comparisonCase.label} normalized high limb`
+          );
+          tapeTest.equal(
+            resultBits[resultOffset + 1],
+            comparisonCase.normalizedBits[1],
+            `${arithmeticMode.label} ${comparisonCase.label} normalized low limb`
+          );
+          tapeTest.equal(
+            signedResults[resultOffset + 2],
+            comparisonCase.sign,
+            `${arithmeticMode.label} ${comparisonCase.label} sign`
+          );
+          tapeTest.equal(
+            signedResults[resultOffset + 3],
+            comparisonCase.comparison,
+            `${arithmeticMode.label} ${comparisonCase.label} comparison`
+          );
+          tapeTest.equal(
+            resultBits[resultOffset + 4],
+            comparisonCase.finite,
+            `${arithmeticMode.label} ${comparisonCase.label} finite classification`
+          );
+          tapeTest.equal(
+            resultBits[resultOffset + 5],
+            comparisonCase.nan,
+            `${arithmeticMode.label} ${comparisonCase.label} nan classification`
+          );
+        }
+      } finally {
+        computation.destroy();
+        resultBuffer.destroy();
+      }
+    }
+  } finally {
+    inputBuffer.destroy();
   }
 
   tapeTest.end();
@@ -867,6 +1250,54 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
 `;
 }
 
+function buildWGSLFp64u32DoubleSingleSubtractSource(): string {
+  return `\
+@group(0) @binding(1) var<storage, read> inputAData: array<vec2u>;
+@group(0) @binding(2) var<storage, read> inputBData: array<vec2u>;
+@group(0) @binding(3) var<storage, read_write> resultData: array<vec4u>;
+
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+  let index = id.x;
+  let difference = sub_fp64u32_to_fp64(inputAData[index], inputBData[index]);
+  resultData[index] = vec4u(
+    bitcast<u32>(difference.x),
+    bitcast<u32>(difference.y),
+    bitcast<u32>(sign_fp64(difference)),
+    bitcast<u32>(compare_fp64(difference, vec2f(0.0)))
+  );
+}
+`;
+}
+
+function buildWGSLFp64ComparisonSource(): string {
+  return `\
+@group(0) @binding(1) var<storage, read> inputData: array<vec4u>;
+@group(0) @binding(2) var<storage, read_write> resultData: array<vec4u>;
+
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+  let index = id.x;
+  let input = inputData[index];
+  let valueA = vec2f(bitcast<f32>(input.x), bitcast<f32>(input.y));
+  let valueB = vec2f(bitcast<f32>(input.z), bitcast<f32>(input.w));
+  let normalized = normalize_fp64(valueA);
+  resultData[index * 2u] = vec4u(
+    bitcast<u32>(normalized.x),
+    bitcast<u32>(normalized.y),
+    bitcast<u32>(sign_fp64(valueA)),
+    bitcast<u32>(compare_fp64(valueA, valueB))
+  );
+  resultData[index * 2u + 1u] = vec4u(
+    select(0u, 1u, is_finite_fp64(valueA)),
+    select(0u, 1u, is_nan_fp64(valueA)),
+    0u,
+    0u
+  );
+}
+`;
+}
+
 function getFloat64Words(value: number): [number, number] {
   const dataView = new DataView(new ArrayBuffer(8));
   dataView.setFloat64(0, value, false);
@@ -877,6 +1308,195 @@ function getFloat32Bits(value: number): number {
   const dataView = new DataView(new ArrayBuffer(4));
   dataView.setFloat32(0, value, false);
   return dataView.getUint32(0, false);
+}
+
+function bitcastUint32ToFloat32(value: number): number {
+  const dataView = new DataView(new ArrayBuffer(4));
+  dataView.setUint32(0, value, false);
+  return dataView.getFloat32(0, false);
+}
+
+type ExactBinary = {
+  coefficient: bigint;
+  exponent: number;
+};
+
+function getExpectedExactDifferenceF32Bits(inputA: number, inputB: number): number {
+  const specialDifference = inputA - inputB;
+  if (Number.isNaN(specialDifference)) {
+    return 0x7fc00000;
+  }
+  if (!Number.isFinite(specialDifference)) {
+    return getFloat32Bits(specialDifference);
+  }
+
+  const difference = subtractExactBinary(decodeFiniteFloat64(inputA), decodeFiniteFloat64(inputB));
+  if (difference.coefficient === 0n) {
+    return Object.is(inputA, -0) && Object.is(inputB, 0) ? 0x80000000 : 0;
+  }
+  return Number(roundExactBinaryToFormat(difference, 23, 8, 127));
+}
+
+function getExpectedBinary64DifferenceFp64Bits(inputA: number, inputB: number): [number, number] {
+  const specialDifference = inputA - inputB;
+  if (Number.isNaN(specialDifference)) {
+    return [0x7fc00000, 0];
+  }
+  if (!Number.isFinite(specialDifference)) {
+    return [getFloat32Bits(specialDifference), 0];
+  }
+
+  const exactDifference = subtractExactBinary(
+    decodeFiniteFloat64(inputA),
+    decodeFiniteFloat64(inputB)
+  );
+  if (exactDifference.coefficient === 0n) {
+    return [0, 0];
+  }
+
+  const roundedBinary64Bits = roundExactBinaryToFormat(exactDifference, 52, 11, 1023);
+  const roundedDifference = decodeFiniteBinary64Bits(roundedBinary64Bits);
+  const highBits = Number(roundExactBinaryToFormat(roundedDifference, 23, 8, 127));
+  const highMagnitude = highBits & 0x7fffffff;
+  if (highMagnitude === 0 || highMagnitude >= 0x7f800000) {
+    return [highMagnitude === 0 ? 0 : highBits, 0];
+  }
+
+  const residual = subtractExactBinary(roundedDifference, decodeFiniteFloat32Bits(highBits));
+  const lowBits = Number(roundExactBinaryToFormat(residual, 23, 8, 127));
+  return [highBits, lowBits & 0x7fffffff ? lowBits : 0];
+}
+
+function decodeFiniteFloat64(value: number): ExactBinary {
+  const [highWord, lowWord] = getFloat64Words(value);
+  return decodeFiniteBinary64Bits((BigInt(highWord) << 32n) | BigInt(lowWord));
+}
+
+function decodeFiniteBinary64Bits(bits: bigint): ExactBinary {
+  const sign = bits >> 63n;
+  const exponentBits = Number((bits >> 52n) & 0x7ffn);
+  const fraction = bits & 0xfffffffffffffn;
+  const coefficient = exponentBits === 0 ? fraction : (1n << 52n) | fraction;
+  return {
+    coefficient: sign === 0n ? coefficient : -coefficient,
+    exponent: exponentBits === 0 ? -1074 : exponentBits - 1075
+  };
+}
+
+function decodeFiniteFloat32Bits(bits: number): ExactBinary {
+  const sign = bits >>> 31;
+  const exponentBits = (bits >>> 23) & 0xff;
+  const fraction = bits & 0x7fffff;
+  const coefficient = BigInt(exponentBits === 0 ? fraction : 0x800000 | fraction);
+  return {
+    coefficient: sign === 0 ? coefficient : -coefficient,
+    exponent: exponentBits === 0 ? -149 : exponentBits - 150
+  };
+}
+
+function subtractExactBinary(inputA: ExactBinary, inputB: ExactBinary): ExactBinary {
+  const exponent = Math.min(inputA.exponent, inputB.exponent);
+  return {
+    coefficient:
+      (inputA.coefficient << BigInt(inputA.exponent - exponent)) -
+      (inputB.coefficient << BigInt(inputB.exponent - exponent)),
+    exponent
+  };
+}
+
+function roundExactBinaryToFormat(
+  value: ExactBinary,
+  fractionBits: number,
+  exponentBits: number,
+  exponentBias: number
+): bigint {
+  const sign = value.coefficient < 0n ? 1n : 0n;
+  const magnitude = value.coefficient < 0n ? -value.coefficient : value.coefficient;
+  const signShift = BigInt(fractionBits + exponentBits);
+  if (magnitude === 0n) {
+    return sign << signShift;
+  }
+
+  const mostSignificantBit = magnitude.toString(2).length - 1;
+  let exponent = value.exponent + mostSignificantBit;
+  const maximumExponent = exponentBias;
+  const minimumNormalExponent = 1 - exponentBias;
+  const infinityExponent = (1n << BigInt(exponentBits)) - 1n;
+  if (exponent > maximumExponent) {
+    return (sign << signShift) | (infinityExponent << BigInt(fractionBits));
+  }
+
+  if (exponent >= minimumNormalExponent) {
+    let significand = roundBigIntRightToEven(magnitude, mostSignificantBit - fractionBits);
+    if (significand >= 1n << BigInt(fractionBits + 1)) {
+      significand >>= 1n;
+      exponent++;
+      if (exponent > maximumExponent) {
+        return (sign << signShift) | (infinityExponent << BigInt(fractionBits));
+      }
+    }
+    const encodedExponent = BigInt(exponent + exponentBias);
+    const fractionMask = (1n << BigInt(fractionBits)) - 1n;
+    return (
+      (sign << signShift) | (encodedExponent << BigInt(fractionBits)) | (significand & fractionMask)
+    );
+  }
+
+  const minimumSubnormalExponent = minimumNormalExponent - fractionBits;
+  const mantissa = roundBigIntRightToEven(magnitude, minimumSubnormalExponent - value.exponent);
+  if (mantissa >= 1n << BigInt(fractionBits)) {
+    return (sign << signShift) | (1n << BigInt(fractionBits));
+  }
+  return (sign << signShift) | mantissa;
+}
+
+function roundBigIntRightToEven(value: bigint, shift: number): bigint {
+  if (shift <= 0) {
+    return value << BigInt(-shift);
+  }
+  const bigintShift = BigInt(shift);
+  const truncated = value >> bigintShift;
+  const remainder = value - (truncated << bigintShift);
+  const halfway = 1n << BigInt(shift - 1);
+  return remainder > halfway || (remainder === halfway && (truncated & 1n) === 1n)
+    ? truncated + 1n
+    : truncated;
+}
+
+function makeRawBinary64SubtractCases(
+  count: number
+): {inputA: number; inputB: number; label: string}[] {
+  const cases: {inputA: number; inputB: number; label: string}[] = [];
+  let state = 0x91e10da5;
+  const next = (): number => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state;
+  };
+
+  for (let index = 0; index < count; index++) {
+    const exponentA = 880 + (next() % 287);
+    const highWordA = ((next() & 1) << 31) | (exponentA << 20) | (next() & 0xfffff);
+    const lowWordA = next();
+    const exponentB = index % 3 === 0 ? exponentA : 880 + (next() % 287);
+    const highWordB =
+      (index % 3 === 0 ? highWordA & 0x80000000 : (next() & 1) << 31) |
+      (exponentB << 20) |
+      (next() & 0xfffff);
+    const lowWordB = next();
+    cases.push({
+      inputA: getFloat64FromWords(highWordA >>> 0, lowWordA),
+      inputB: getFloat64FromWords(highWordB >>> 0, lowWordB),
+      label: `deterministic full-mantissa raw case ${index}`
+    });
+  }
+  return cases;
+}
+
+function getFloat64FromWords(highWord: number, lowWord: number): number {
+  const dataView = new DataView(new ArrayBuffer(8));
+  dataView.setUint32(0, highWord, false);
+  dataView.setUint32(4, lowWord, false);
+  return dataView.getFloat64(0, false);
 }
 
 function getExpectedTwoSumBits(inputA: number, inputB: number): [number, number] {


### PR DESCRIPTION
## Goals

- Prepare the WGSL fp64 module for precise geospatial kernels that start from raw browser `Float64Array` words.
- Preserve the established exact-delta-to-`f32` behavior while adding a separate binary64-rounded double-single path.
- Make normalization and finite predicate work deterministic across arithmetic modes, including stored subnormal limbs.

## Changes

- Adds `sub_fp64u32_to_fp64_bits` and `sub_fp64u32_to_fp64` for raw binary64 subtraction followed by a normalized high/low `f32` split.
- Keeps `sub_fp64u32_to_f32[_bits]` on its original direct exact-to-binary32 path, avoiding a double-rounding compatibility regression.
- Adds integer-controlled `normalize_fp64`, `sign_fp64`, `compare_fp64`, `is_nan_fp64`, and `is_finite_fp64` helpers in both WGSL arithmetic modes.
- Canonicalizes all zero double-single results and residual limbs to `+0`.
- Documents the numerical boundary explicitly: about 48 significand bits with the `f32` exponent range, suitable for terrestrial coordinates and local metric deltas but not arbitrary binary64-scale values or fp64 trigonometry.
- Documents NaN as unordered; callers use the classification helpers before treating comparison result `0` as equality.

## Numerical coverage

- Uses BigInt-based exact binary oracles instead of JavaScript subtraction for raw-word expectations.
- Covers the exact-to-`f32` double-rounding counterexample (`1 + 2^-24` minus `-2^-77`).
- Covers full binary64 mantissas, cancellation, guard/round/sticky cases, f32 normal/subnormal boundaries, overflow/underflow policy, signed zero, infinities, NaNs, equivalent decompositions, and positive/negative low-limb ordering.
- Runs normalization checks in both default and forced `LUMA_FP64_INTEGER_ARITHMETIC` modes.

## Verification

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn examples:typecheck` — all 33 workspaces passed
- Focused WebGPU/headless fp64 suite — 16/16 passed
- `yarn website:build`
- `(cd website && yarn build)`
- Full Node phase of `yarn test` — 66 files / 275 tests passed, 2 files / 2 tests skipped

The full headless sweep completed with 248 files / 1,361 tests passing and 25 skipped, plus two pre-existing failures outside this five-file change: an Arrow polygon/text storage-binding expectation and the experimental `GPUGridIndex` extreme-bound midpoint fixture. The focused fp64 WebGPU suite is clean.

## Limits

- This is double-single arithmetic, not IEEE binary64 shader execution.
- The new subtraction path does not extend the f32 exponent range.
- Transcendentals remain f32 operations; this PR prepares coordinate arithmetic and predicates, not exact topology or fp64 trigonometry.
