### PR TITLE
refactor(engine): share computation dispatch setup

### DIFF
--- a/modules/engine/src/compute/computation.ts
+++ b/modules/engine/src/compute/computation.ts
@@ -225,18 +225,7 @@ export class Computation {
   dispatch(computePass: ComputePass, x: number, y?: number, z?: number): void {
     try {
       this._logDrawCallStart();
-
-      // Check if the pipeline is invalidated
-      // TODO - this is likely the worst place to do this from performance perspective. Perhaps add a predraw()?
-      this.pipeline = this._updatePipeline();
-
-      // Set pipeline state, we may be sharing a pipeline so we need to set all state on every draw
-      // Any caching needs to be done inside the pipeline functions
-      this.pipeline.setBindings(this.bindings);
-      computePass.setPipeline(this.pipeline);
-      // @ts-expect-error
-      computePass.setBindings({});
-
+      this._setPipeline(computePass);
       computePass.dispatch(x, y, z);
     } finally {
       this._logDrawCallEnd();
@@ -247,17 +236,24 @@ export class Computation {
   dispatchIndirect(computePass: ComputePass, indirectBuffer: Buffer, indirectOffset = 0): void {
     try {
       this._logDrawCallStart();
-
-      this.pipeline = this._updatePipeline();
-      this.pipeline.setBindings(this.bindings);
-      computePass.setPipeline(this.pipeline);
-      // @ts-expect-error ComputePass implementations expose binding application internally.
-      computePass.setBindings({});
-
+      this._setPipeline(computePass);
       computePass.dispatchIndirect(indirectBuffer, indirectOffset);
     } finally {
       this._logDrawCallEnd();
     }
+  }
+
+  private _setPipeline(computePass: ComputePass): void {
+    // Check if the pipeline is invalidated
+    // TODO - this is likely the worst place to do this from performance perspective. Perhaps add a predraw()?
+    this.pipeline = this._updatePipeline();
+
+    // Set pipeline state, we may be sharing a pipeline so we need to set all state on every draw
+    // Any caching needs to be done inside the pipeline functions
+    this.pipeline.setBindings(this.bindings);
+    computePass.setPipeline(this.pipeline);
+    // @ts-expect-error ComputePass implementations expose binding application internally.
+    computePass.setBindings({});
   }
 
   // Update fixed fields (can trigger pipeline rebuild)

--- a/modules/engine/test/compute/computation.spec.ts
+++ b/modules/engine/test/compute/computation.spec.ts
@@ -93,7 +93,7 @@ test('Computation#dispatchIndirect', async t => {
       usage: Buffer.STORAGE | Buffer.COPY_SRC
     });
     const dispatchBuffer = webgpuDevice.createBuffer({
-      data: new Uint32Array([4, 1, 1]),
+      data: new Uint32Array([4, 1, 1, 1, 1, 1]),
       usage: Buffer.INDIRECT
     });
     computation.setBindings({data: workBuffer});
@@ -103,11 +103,43 @@ test('Computation#dispatchIndirect', async t => {
     computePass.end();
     webgpuDevice.submit();
 
-    const computedData = new Int32Array(await workBuffer.readAsync());
+    const computedBytes = await workBuffer.readAsync();
+    const computedData = new Int32Array(
+      computedBytes.buffer,
+      computedBytes.byteOffset,
+      computedBytes.byteLength / Int32Array.BYTES_PER_ELEMENT
+    );
     t.deepEqual(Array.from(computedData), [2, 4, 6, 8], 'GPU-written dimensions drive dispatch');
+
+    const offsetWorkBuffer = webgpuDevice.createBuffer({
+      data: new Int32Array([1, 2, 3, 4]),
+      usage: Buffer.STORAGE | Buffer.COPY_SRC
+    });
+    computation.setBindings({data: offsetWorkBuffer});
+    const offsetComputePass = webgpuDevice.beginComputePass({});
+    computation.dispatchIndirect(
+      offsetComputePass,
+      dispatchBuffer,
+      3 * Uint32Array.BYTES_PER_ELEMENT
+    );
+    offsetComputePass.end();
+    webgpuDevice.submit();
+
+    const offsetComputedBytes = await offsetWorkBuffer.readAsync();
+    const offsetComputedData = new Int32Array(
+      offsetComputedBytes.buffer,
+      offsetComputedBytes.byteOffset,
+      offsetComputedBytes.byteLength / Int32Array.BYTES_PER_ELEMENT
+    );
+    t.deepEqual(
+      Array.from(offsetComputedData),
+      [2, 2, 3, 4],
+      'nonzero byte offset selects the requested dispatch record'
+    );
 
     computation.destroy();
     workBuffer.destroy();
+    offsetWorkBuffer.destroy();
     dispatchBuffer.destroy();
   }
   t.end();


### PR DESCRIPTION
## Goals

- Keep direct and indirect compute dispatch on the same pipeline and binding setup path.
- Cover nonzero indirect-buffer byte offsets without weakening the existing GPU-written dispatch test.

## Changes

- Extracts `Computation._setPipeline()` and uses it for both `dispatch()` and `dispatchIndirect()`.
- Preserves pipeline refresh, binding application, logging, and error-finalization behavior.
- Retains the existing four-workgroup indirect assertion and adds a second dispatch record selected at byte offset 12.
- Fixes the test readback conversion so the returned byte offset and length are honored.

## Context

This is a small independent preparation PR for graph-native algorithms that use both direct and GPU-generated indirect dispatch. It does not add or change the public dispatch API.

## Verification

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn build`
- Focused headless WebGPU computation suite: 4/4 passed
- Commit hook `yarn test-fast`: Node suite 68 files passed, 2 skipped; 286 tests passed, 2 skipped

The full combined `yarn test`, examples typecheck, and website builds remain for merge preparation; this PR is opened as a draft.
