### PR TITLE
docs: expose experimental WebGPU APIs

### DIFF
--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -205,6 +205,7 @@
           "api-reference/experimental/mls-mpm-fluid-simulation",
           "api-reference/experimental/spectral-ocean-simulation",
           "api-reference/experimental/shadow-map-renderer",
+          "api-reference/experimental/spectral-caustics-renderer",
           "api-reference/experimental/glass-material",
           "api-reference/experimental/reflective-material",
           {
@@ -217,6 +218,7 @@
               "api-reference/experimental/gpu-primitives/gpu-compaction",
               "api-reference/experimental/gpu-primitives/gpu-mask",
               "api-reference/experimental/gpu-primitives/gpu-visibility-workflow",
+              "api-reference/experimental/gpu-primitives/gpu-virtual-geometry-selection",
               "api-reference/experimental/gpu-primitives/gpu-hierarchy-layout",
               "api-reference/experimental/gpu-primitives/gpu-graph-traversal",
               "api-reference/experimental/gpu-primitives/gpu-ancestor-projection",
@@ -305,6 +307,7 @@
           "api-reference/experimental/mls-mpm-fluid-simulation",
           "api-reference/experimental/spectral-ocean-simulation",
           "api-reference/experimental/shadow-map-renderer",
+          "api-reference/experimental/spectral-caustics-renderer",
           {
             "type": "category",
             "label": "GPU Primitives",
@@ -315,6 +318,7 @@
               "api-reference/experimental/gpu-primitives/gpu-compaction",
               "api-reference/experimental/gpu-primitives/gpu-mask",
               "api-reference/experimental/gpu-primitives/gpu-visibility-workflow",
+              "api-reference/experimental/gpu-primitives/gpu-virtual-geometry-selection",
               "api-reference/experimental/gpu-primitives/gpu-hierarchy-layout",
               "api-reference/experimental/gpu-primitives/gpu-graph-traversal",
               "api-reference/experimental/gpu-primitives/gpu-ancestor-projection",


### PR DESCRIPTION
## What changed

- Added `SpectralCausticsRenderer` to both mirrored `@luma.gl/experimental` API-reference sections, ordered after `ShadowMapRenderer`.
- Added `GPUVirtualGeometrySelection` to both mirrored GPU Primitives sections, ordered after `GPUVisibilityWorkflow`.

## Why

The merged API pages were linked from release notes and documentation tabs but were missing from the generated docs sidebar, making them difficult to discover.

## Impact

Documentation navigation only. No runtime APIs, examples, or example-sidebar entries change.

## Verification

- `nvm use`
- `yarn install --immutable`
- `yarn lint fix`
- pre-commit `test-fast`: 71 test files passed, 2 skipped; 295 tests passed, 2 skipped
- `yarn website:build`
- verified both generated HTML routes exist and contain the expected API/sidebar entries
- verified `docs/table-of-contents.json` parses and each target appears in both mirrored sections