### PR TITLE
[9.3 backport] fix(core): skip buffer debug copies outside debug mode

### DIFF
--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -101,7 +101,7 @@ shader is involved when debugging shader parsing errors occur.
 
 ## Buffer data inspection
 
-`Buffer` objects contain a CPU side copy of the first few bytes of data in the `buffer.debugData` field. This field is refreshed whenever data is written or read from the CPU side, using `buffer.write()`, `buffer.readAsync()` etc and can be inspected in the debugger to inspect the contents of the buffer.
+On backends that support it, creating the device with `debug: true` enables a CPU side copy of the first few bytes of each `Buffer` in the `buffer.debugData` field. This field is refreshed whenever data is written or read from the CPU side, using `buffer.write()`, `buffer.readAsync()` etc and can be inspected in the debugger to inspect the contents of the buffer. When device debugging is disabled, `buffer.debugData` remains empty to avoid adding CPU allocations and copies to buffer updates.
 
 Note that this CPU side data copy can become invalid when buffers are updated on the GPU by compute shaders or transform feedback operations, in which case reading from the buffer would be necessary to refresh the CPU side data.
 

--- a/modules/core/src/adapter/resources/buffer.ts
+++ b/modules/core/src/adapter/resources/buffer.ts
@@ -130,6 +130,10 @@ export abstract class Buffer extends Resource<BufferProps> {
     _byteOffset: number,
     byteLength: number
   ): void {
+    if (!this.device.props.debug) {
+      return;
+    }
+
     let arrayBufferView: ArrayBufferView | null = null;
     let arrayBuffer: ArrayBufferLike | null;
     if (ArrayBuffer.isView(data)) {

--- a/modules/core/test/adapter/resources/buffer.spec.ts
+++ b/modules/core/test/adapter/resources/buffer.spec.ts
@@ -9,6 +9,7 @@ import {getTestDevices, getWebGPUTestDevice, getWebGLTestDevice} from '@luma.gl/
 
 import {TypedArray} from '@math.gl/types';
 import {Buffer, Device} from '@luma.gl/core';
+import {webgl2Adapter} from '@luma.gl/webgl';
 import {GL} from '@luma.gl/webgl/constants';
 
 const DEVICE_TYPES = ['webgpu', 'webgl', 'null'] as const;
@@ -677,6 +678,35 @@ test('Buffer#debugData', async t => {
     buffer.destroy();
   }
 
+  t.end();
+});
+
+test('WEBGLBuffer#debugData is disabled when device debugging is disabled', async t => {
+  const device = await webgl2Adapter.create({
+    createCanvasContext: {width: 1, height: 1},
+    debug: false
+  });
+  const buffer = device.createBuffer({
+    usage: Buffer.VERTEX | Buffer.COPY_SRC | Buffer.COPY_DST,
+    data: new Float32Array([1, 2, 3])
+  });
+  const emptyDebugData = buffer.debugData;
+
+  t.equal(buffer.debugData.byteLength, 0, 'Buffer.debugData is empty after construction');
+
+  buffer.write(new Float32Array([4, 5, 6]));
+  t.equal(buffer.debugData, emptyDebugData, 'Buffer.write() does not replace Buffer.debugData');
+
+  const data = await buffer.readAsync();
+  t.deepEqual(
+    new Float32Array(data.buffer),
+    new Float32Array([4, 5, 6]),
+    'Buffer contents are unaffected'
+  );
+  t.equal(buffer.debugData, emptyDebugData, 'Buffer.readAsync() does not replace Buffer.debugData');
+
+  buffer.destroy();
+  device.destroy();
   t.end();
 });
 


### PR DESCRIPTION
Backports #2838 to `9.3-release` (fixes #2785).

## Summary

- skip `Buffer._setDebugData()` allocations and copies when device debugging is disabled
- preserve existing debug-data behavior for `debug: true` devices
- add WebGL coverage for construction, writes, and reads with debugging disabled
- document that the CPU-side buffer mirror is debug-only

Cherry-picked landed commit `55360545c809f1d794ed29e5bec836322bf52f22` as `4a831a7da60ca6bc46f55a0b0f582bdac5d99214`.

## Validation

- `nvm use`
- `yarn install`
- `yarn lint fix` — no fixes needed
- `yarn build`
- `yarn test-node` — 21 files passed, 2 skipped; 43 tests passed, 2 skipped
- `yarn test-headless modules/core/test/adapter/resources/buffer.spec.ts` — 17 tests passed
- `git diff --check origin/9.3-release...HEAD`
