### PR TITLE
feat(shadertools): scan WGSL interfaces during assembly

### DIFF
--- a/modules/shadertools/src/index.ts
+++ b/modules/shadertools/src/index.ts
@@ -10,6 +10,10 @@
  */
 export type {PlatformInfo} from './lib/shader-assembly/platform-info';
 export type {ShaderBindingDebugRow} from './lib/shader-assembly/wgsl-binding-debug';
+export {
+  scanWGSLInterface,
+  type ScanWGSLInterfaceOptions
+} from './lib/shader-assembly/wgsl-interface-scan';
 
 // ShaderModules
 

--- a/modules/shadertools/src/lib/shader-assembler.ts
+++ b/modules/shadertools/src/lib/shader-assembler.ts
@@ -15,6 +15,8 @@ import {
   type ShaderBindingDebugRow
 } from './shader-assembly/wgsl-binding-debug';
 import {preprocess} from './preprocessor/preprocessor';
+import {scanWGSLInterface} from './shader-assembly/wgsl-interface-scan';
+import type {ShaderLayout} from '@luma.gl/core';
 
 /**
  * A stateful version of `assembleShaders` that can be used to assemble shaders.
@@ -86,6 +88,7 @@ export class ShaderAssembler {
     modules: ShaderModule[];
     bindingAssignments: {moduleName: string; name: string; group: number; location: number}[];
     bindingTable: ShaderBindingDebugRow[];
+    shaderLayout: ShaderLayout | null;
   } {
     const modules = this._getModuleList(props.modules); // Combine with default modules
     const hookFunctions = this._hookFunctions; // TODO - combine with default hook functions
@@ -117,7 +120,10 @@ export class ShaderAssembler {
       getUniforms,
       modules,
       bindingAssignments,
-      bindingTable: getShaderBindingDebugRowsFromWGSL(preprocessedSource, bindingAssignments)
+      bindingTable: getShaderBindingDebugRowsFromWGSL(preprocessedSource, bindingAssignments),
+      shaderLayout: scanWGSLInterface(preprocessedSource, {
+        vertexEntryPoint: props.vertexEntryPoint
+      })
     };
   }
 

--- a/modules/shadertools/src/lib/shader-assembly/assemble-shaders.ts
+++ b/modules/shadertools/src/lib/shader-assembly/assemble-shaders.ts
@@ -18,8 +18,9 @@ import {ShaderHook, normalizeShaderHooks, getShaderHooks} from './shader-hooks';
 import {assert} from '../utils/assert';
 import {getShaderInfo} from '../glsl-utils/get-shader-info';
 import {getShaderBindingDebugRowsFromWGSL, type ShaderBindingDebugRow} from './wgsl-binding-debug';
+import {scanWGSLInterface} from './wgsl-interface-scan';
 import {preprocess} from '../preprocessor/preprocessor';
-import type {AttributeShaderType} from '@luma.gl/core';
+import type {AttributeShaderType, ShaderLayout} from '@luma.gl/core';
 import type {ResolvedShaderPluginVarying} from '../shader-plugin';
 import {
   assembleShaderPluginVertexInputsWGSL,
@@ -150,6 +151,7 @@ export function assembleWGSLShader(
   getUniforms: GetUniformsFunc;
   bindingAssignments: {moduleName: string; name: string; group: number; location: number}[];
   bindingTable: ShaderBindingDebugRow[];
+  shaderLayout: ShaderLayout | null;
 } {
   const modules = getShaderModuleDependencies(options.modules || []);
   const {source, bindingAssignments} = assembleShaderWGSL(options.platformInfo, {
@@ -163,7 +165,8 @@ export function assembleWGSLShader(
     source,
     getUniforms: assembleGetUniforms(modules),
     bindingAssignments,
-    bindingTable: getShaderBindingDebugRowsFromWGSL(source, bindingAssignments)
+    bindingTable: getShaderBindingDebugRowsFromWGSL(source, bindingAssignments),
+    shaderLayout: scanWGSLInterface(source, {vertexEntryPoint: options.vertexEntryPoint})
   };
 }
 

--- a/modules/shadertools/src/lib/shader-assembly/wgsl-interface-scan.ts
+++ b/modules/shadertools/src/lib/shader-assembly/wgsl-interface-scan.ts
@@ -1,0 +1,664 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  AttributeDeclaration,
+  AttributeShaderType,
+  BindingDeclaration,
+  SamplerBindingLayout,
+  ShaderLayout,
+  StorageTextureBindingLayout,
+  TextureBindingLayout,
+  TextureFormat
+} from '@luma.gl/core';
+
+import {maskWGSLComments} from './wgsl-binding-scan';
+
+export type ScanWGSLInterfaceOptions = {
+  /** Selected render-pipeline vertex entry point. Required when WGSL declares multiple vertices. */
+  vertexEntryPoint?: string;
+};
+
+type WGSLToken = {
+  value: string;
+  index: number;
+};
+
+type WGSLFunction = {
+  name: string;
+  vertex: boolean;
+  parameters: WGSLToken[];
+};
+
+/**
+ * Scans the pipeline interface needed to create a WebGPU shader layout without a full WGSL parser.
+ * Returns `null` when an interface is ambiguous or uses unsupported syntax, signaling that the
+ * caller must provide an explicit layout.
+ */
+export function scanWGSLInterface(
+  source: string,
+  options: ScanWGSLInterfaceOptions = {}
+): ShaderLayout | null {
+  const tokens = tokenizeWGSL(source);
+  const braceDepths = getBraceDepths(tokens);
+  if (!braceDepths) {
+    return null;
+  }
+
+  const aliases = scanWGSLAliases(tokens, braceDepths);
+  const structures = scanWGSLStructures(tokens, braceDepths);
+  if (!aliases || !structures) {
+    return null;
+  }
+
+  const bindings = scanWGSLBindings(tokens, braceDepths, aliases);
+  const attributes = scanWGSLVertexAttributes(
+    tokens,
+    braceDepths,
+    aliases,
+    structures,
+    options.vertexEntryPoint
+  );
+  return bindings && attributes ? {attributes, bindings} : null;
+}
+
+function tokenizeWGSL(source: string): WGSLToken[] {
+  const maskedSource = maskWGSLComments(source);
+  const tokenPattern = /[A-Za-z_][A-Za-z0-9_]*|(?:0[xX][0-9A-Fa-f]+|\d+)|[@(){}<>\[\]:,;=]/g;
+  const tokens: WGSLToken[] = [];
+  let match = tokenPattern.exec(maskedSource);
+  while (match) {
+    tokens.push({value: match[0], index: match.index});
+    match = tokenPattern.exec(maskedSource);
+  }
+  return tokens;
+}
+
+function getBraceDepths(tokens: WGSLToken[]): number[] | null {
+  const depths: number[] = [];
+  let depth = 0;
+  for (const token of tokens) {
+    if (token.value === '}' && depth === 0) {
+      return null;
+    }
+    depths.push(depth);
+    if (token.value === '{') {
+      depth++;
+    } else if (token.value === '}') {
+      depth--;
+    }
+  }
+  return depth === 0 ? depths : null;
+}
+
+function scanWGSLAliases(tokens: WGSLToken[], braceDepths: number[]): Map<string, string> | null {
+  const aliases = new Map<string, string>();
+  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+    if (braceDepths[tokenIndex] !== 0 || tokens[tokenIndex].value !== 'alias') {
+      continue;
+    }
+    const name = tokens[tokenIndex + 1]?.value;
+    if (!isWGSLIdentifier(name) || tokens[tokenIndex + 2]?.value !== '=' || aliases.has(name)) {
+      return null;
+    }
+    const semicolonIndex = findTopLevelToken(tokens, braceDepths, tokenIndex + 3, ';');
+    if (semicolonIndex < 0 || semicolonIndex === tokenIndex + 3) {
+      return null;
+    }
+    aliases.set(name, formatWGSLTokens(tokens.slice(tokenIndex + 3, semicolonIndex)));
+    tokenIndex = semicolonIndex;
+  }
+  return aliases;
+}
+
+function scanWGSLStructures(
+  tokens: WGSLToken[],
+  braceDepths: number[]
+): Map<string, WGSLToken[]> | null {
+  const structures = new Map<string, WGSLToken[]>();
+  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+    if (braceDepths[tokenIndex] !== 0 || tokens[tokenIndex].value !== 'struct') {
+      continue;
+    }
+    const name = tokens[tokenIndex + 1]?.value;
+    const openBraceIndex = tokenIndex + 2;
+    if (!isWGSLIdentifier(name) || structures.has(name) || tokens[openBraceIndex]?.value !== '{') {
+      return null;
+    }
+    const closeBraceIndex = findMatchingToken(tokens, openBraceIndex, '{', '}');
+    if (closeBraceIndex < 0) {
+      return null;
+    }
+    structures.set(name, tokens.slice(openBraceIndex + 1, closeBraceIndex));
+    tokenIndex = closeBraceIndex;
+  }
+  return structures;
+}
+
+function scanWGSLBindings(
+  tokens: WGSLToken[],
+  braceDepths: number[],
+  aliases: Map<string, string>
+): BindingDeclaration[] | null {
+  const bindings: BindingDeclaration[] = [];
+  const bindingLocations = new Set<string>();
+  const bindingNames = new Set<string>();
+
+  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+    if (braceDepths[tokenIndex] !== 0 || tokens[tokenIndex].value !== 'var') {
+      continue;
+    }
+
+    const statementStart = findTopLevelStatementStart(tokens, braceDepths, tokenIndex);
+    const attributes = tokens.slice(statementStart, tokenIndex);
+    const group = getNumericWGSLAttribute(attributes, 'group');
+    const location = getNumericWGSLAttribute(attributes, 'binding');
+    if (group === null || location === null || (group === undefined) !== (location === undefined)) {
+      return null;
+    }
+    if (group === undefined || location === undefined) {
+      continue;
+    }
+
+    let cursor = tokenIndex + 1;
+    let addressSpace: string[] = [];
+    if (tokens[cursor]?.value === '<') {
+      const closeAngleIndex = findMatchingToken(tokens, cursor, '<', '>');
+      if (closeAngleIndex < 0) {
+        return null;
+      }
+      const addressParts = splitTopLevelTokens(tokens.slice(cursor + 1, closeAngleIndex), ',');
+      if (!addressParts) {
+        return null;
+      }
+      addressSpace = addressParts.map(formatWGSLTokens);
+      cursor = closeAngleIndex + 1;
+    }
+
+    const name = tokens[cursor]?.value;
+    if (!isWGSLIdentifier(name) || tokens[cursor + 1]?.value !== ':') {
+      return null;
+    }
+    const semicolonIndex = findTopLevelToken(tokens, braceDepths, cursor + 2, ';');
+    if (semicolonIndex < 0 || semicolonIndex === cursor + 2) {
+      return null;
+    }
+    const resourceType = resolveWGSLTypeAliases(
+      formatWGSLTokens(tokens.slice(cursor + 2, semicolonIndex)),
+      aliases
+    );
+    if (!resourceType) {
+      return null;
+    }
+
+    const binding = getWGSLBindingDeclaration({
+      name,
+      group,
+      location,
+      addressSpace,
+      resourceType
+    });
+    const bindingKey = `${group}:${location}`;
+    if (!binding || bindingLocations.has(bindingKey) || bindingNames.has(name)) {
+      return null;
+    }
+    bindings.push(binding);
+    bindingLocations.add(bindingKey);
+    bindingNames.add(name);
+    tokenIndex = semicolonIndex;
+  }
+
+  normalizeWGSLSamplerBindings(bindings);
+  return bindings.sort(
+    (left, right) =>
+      left.group - right.group ||
+      left.location - right.location ||
+      left.name.localeCompare(right.name)
+  );
+}
+
+function getWGSLBindingDeclaration(options: {
+  name: string;
+  group: number;
+  location: number;
+  addressSpace: string[];
+  resourceType: string;
+}): BindingDeclaration | null {
+  const {name, group, location, addressSpace, resourceType} = options;
+  const base = {name, group, location};
+
+  if (addressSpace[0] === 'uniform' && addressSpace.length === 1) {
+    return {...base, type: 'uniform'};
+  }
+  if (addressSpace[0] === 'storage' && addressSpace.length <= 2) {
+    const access = addressSpace[1] || 'read';
+    if (access === 'read') {
+      return {...base, type: 'read-only-storage'};
+    }
+    return access === 'read_write' ? {...base, type: 'storage'} : null;
+  }
+  if (addressSpace.length > 0) {
+    return null;
+  }
+
+  if (resourceType === 'sampler' || resourceType === 'sampler_comparison') {
+    return {
+      ...base,
+      type: 'sampler',
+      ...(resourceType === 'sampler_comparison' ? {samplerType: 'comparison' as const} : {})
+    };
+  }
+  if (resourceType === 'texture_external') {
+    return {...base, type: 'external-texture'};
+  }
+
+  return (
+    getWGSLStorageTextureBinding(base, resourceType) || getWGSLTextureBinding(base, resourceType)
+  );
+}
+
+function getWGSLStorageTextureBinding(
+  base: {name: string; group: number; location: number},
+  resourceType: string
+): StorageTextureBindingLayout | null {
+  const match =
+    /^texture_storage_(1d|2d|2d_array|3d)<([A-Za-z0-9_]+),(read|write|read_write)>$/.exec(
+      resourceType
+    );
+  if (!match) {
+    return null;
+  }
+  const access = {
+    read: 'read-only',
+    write: 'write-only',
+    read_write: 'read-write'
+  }[match[3]] as StorageTextureBindingLayout['access'];
+  return {
+    ...base,
+    type: 'storage',
+    format: match[2] as TextureFormat,
+    access,
+    viewDimension: getWGSLTextureViewDimension(match[1])
+  };
+}
+
+function getWGSLTextureBinding(
+  base: {name: string; group: number; location: number},
+  resourceType: string
+): TextureBindingLayout | null {
+  const sampledTexture =
+    /^texture_(multisampled_)?(1d|2d|2d_array|cube|cube_array|3d)<(f32|i32|u32)>$/.exec(
+      resourceType
+    );
+  if (sampledTexture) {
+    if (sampledTexture[1] && sampledTexture[2] !== '2d') {
+      return null;
+    }
+    const sampleType = {f32: 'float', i32: 'sint', u32: 'uint'}[sampledTexture[3]] as
+      | 'float'
+      | 'sint'
+      | 'uint';
+    return {
+      ...base,
+      type: 'texture',
+      viewDimension: getWGSLTextureViewDimension(sampledTexture[2]),
+      sampleType,
+      multisampled: Boolean(sampledTexture[1])
+    };
+  }
+
+  const depthTexture = /^texture_depth_(multisampled_)?(2d|2d_array|cube|cube_array)$/.exec(
+    resourceType
+  );
+  if (!depthTexture || (depthTexture[1] && depthTexture[2] !== '2d')) {
+    return null;
+  }
+  return {
+    ...base,
+    type: 'texture',
+    viewDimension: getWGSLTextureViewDimension(depthTexture[2]),
+    sampleType: 'depth',
+    multisampled: Boolean(depthTexture[1])
+  };
+}
+
+function normalizeWGSLSamplerBindings(bindings: BindingDeclaration[]): void {
+  for (const binding of bindings) {
+    if (binding.type !== 'sampler' || binding.samplerType || !binding.name.endsWith('Sampler')) {
+      continue;
+    }
+    const textureName = binding.name.slice(0, -'Sampler'.length);
+    const pairedTexture = bindings.find(
+      candidate =>
+        candidate.type === 'texture' &&
+        candidate.name === textureName &&
+        candidate.group === binding.group
+    ) as TextureBindingLayout | undefined;
+    if (pairedTexture?.sampleType === 'depth') {
+      (binding as SamplerBindingLayout).samplerType = 'non-filtering';
+    }
+  }
+}
+
+function scanWGSLVertexAttributes(
+  tokens: WGSLToken[],
+  braceDepths: number[],
+  aliases: Map<string, string>,
+  structures: Map<string, WGSLToken[]>,
+  vertexEntryPoint: string | undefined
+): AttributeDeclaration[] | null {
+  const functions = scanWGSLFunctions(tokens, braceDepths);
+  if (!functions) {
+    return null;
+  }
+  const vertexFunctions = functions.filter(shaderFunction => shaderFunction.vertex);
+  const selectedFunction = vertexEntryPoint
+    ? vertexFunctions.find(shaderFunction => shaderFunction.name === vertexEntryPoint)
+    : vertexFunctions.length === 1
+      ? vertexFunctions[0]
+      : undefined;
+
+  if (!selectedFunction) {
+    return vertexFunctions.length === 0 && !vertexEntryPoint ? [] : null;
+  }
+
+  const parameterDeclarations = splitTopLevelTokens(selectedFunction.parameters, ',');
+  if (!parameterDeclarations) {
+    return null;
+  }
+  const attributes: AttributeDeclaration[] = [];
+  const attributeLocations = new Set<number>();
+  const attributeNames = new Set<string>();
+  const visitedStructures = new Set<string>();
+  for (const declaration of parameterDeclarations) {
+    if (
+      declaration.length > 0 &&
+      !scanWGSLVertexInputDeclaration({
+        declaration,
+        aliases,
+        structures,
+        attributes,
+        attributeLocations,
+        attributeNames,
+        visitedStructures
+      })
+    ) {
+      return null;
+    }
+  }
+  return attributes.sort(
+    (left, right) => left.location - right.location || left.name.localeCompare(right.name)
+  );
+}
+
+function scanWGSLFunctions(tokens: WGSLToken[], braceDepths: number[]): WGSLFunction[] | null {
+  const functions: WGSLFunction[] = [];
+  const functionNames = new Set<string>();
+  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+    if (braceDepths[tokenIndex] !== 0 || tokens[tokenIndex].value !== 'fn') {
+      continue;
+    }
+    const name = tokens[tokenIndex + 1]?.value;
+    const openParenthesisIndex = tokenIndex + 2;
+    if (
+      !isWGSLIdentifier(name) ||
+      functionNames.has(name) ||
+      tokens[openParenthesisIndex]?.value !== '('
+    ) {
+      return null;
+    }
+    const closeParenthesisIndex = findMatchingToken(tokens, openParenthesisIndex, '(', ')');
+    if (closeParenthesisIndex < 0) {
+      return null;
+    }
+    const statementStart = findTopLevelStatementStart(tokens, braceDepths, tokenIndex);
+    functions.push({
+      name,
+      vertex: hasWGSLAttribute(tokens.slice(statementStart, tokenIndex), 'vertex'),
+      parameters: tokens.slice(openParenthesisIndex + 1, closeParenthesisIndex)
+    });
+    functionNames.add(name);
+    tokenIndex = closeParenthesisIndex;
+  }
+  return functions;
+}
+
+function scanWGSLVertexInputDeclaration(options: {
+  declaration: WGSLToken[];
+  aliases: Map<string, string>;
+  structures: Map<string, WGSLToken[]>;
+  attributes: AttributeDeclaration[];
+  attributeLocations: Set<number>;
+  attributeNames: Set<string>;
+  visitedStructures: Set<string>;
+}): boolean {
+  const {
+    declaration,
+    aliases,
+    structures,
+    attributes,
+    attributeLocations,
+    attributeNames,
+    visitedStructures
+  } = options;
+  const colonIndex = findTopLevelTokenInSlice(declaration, ':');
+  if (colonIndex < 1 || colonIndex === declaration.length - 1) {
+    return false;
+  }
+  const name = findLastWGSLIdentifier(declaration.slice(0, colonIndex));
+  const location = getNumericWGSLAttribute(declaration.slice(0, colonIndex), 'location');
+  const builtin = hasWGSLAttribute(declaration.slice(0, colonIndex), 'builtin');
+  const resolvedType = resolveWGSLTypeAliases(
+    formatWGSLTokens(declaration.slice(colonIndex + 1)),
+    aliases
+  );
+  if (!name || location === null || !resolvedType || (location !== undefined && builtin)) {
+    return false;
+  }
+
+  if (location !== undefined) {
+    const attributeType = getWGSLAttributeShaderType(resolvedType);
+    if (!attributeType || attributeLocations.has(location) || attributeNames.has(name)) {
+      return false;
+    }
+    attributes.push({name, location, type: attributeType});
+    attributeLocations.add(location);
+    attributeNames.add(name);
+    return true;
+  }
+  if (builtin) {
+    return true;
+  }
+
+  const structureMembers = structures.get(resolvedType);
+  if (!structureMembers || visitedStructures.has(resolvedType)) {
+    return false;
+  }
+  const memberDeclarations = splitTopLevelTokens(structureMembers, ',');
+  if (!memberDeclarations) {
+    return false;
+  }
+  visitedStructures.add(resolvedType);
+  for (const memberDeclaration of memberDeclarations) {
+    if (
+      memberDeclaration.length > 0 &&
+      !scanWGSLVertexInputDeclaration({...options, declaration: memberDeclaration})
+    ) {
+      return false;
+    }
+  }
+  visitedStructures.delete(resolvedType);
+  return true;
+}
+
+function resolveWGSLTypeAliases(
+  type: string,
+  aliases: Map<string, string>,
+  resolvingAliases: Set<string> = new Set()
+): string | null {
+  const tokens = tokenizeWGSL(type);
+  let resolvedType = '';
+  for (const token of tokens) {
+    const alias = aliases.get(token.value);
+    if (!alias) {
+      resolvedType += normalizeWGSLBuiltinTypeAlias(token.value);
+      continue;
+    }
+    if (resolvingAliases.has(token.value)) {
+      return null;
+    }
+    const nextResolvingAliases = new Set(resolvingAliases);
+    nextResolvingAliases.add(token.value);
+    const resolvedAlias = resolveWGSLTypeAliases(alias, aliases, nextResolvingAliases);
+    if (!resolvedAlias) {
+      return null;
+    }
+    resolvedType += resolvedAlias;
+  }
+  return resolvedType;
+}
+
+function normalizeWGSLBuiltinTypeAlias(type: string): string {
+  const aliasMatch = /^(vec[234]|mat[234]x[234])([fiuh])$/.exec(type);
+  if (!aliasMatch) {
+    return type;
+  }
+  const primitiveType = {f: 'f32', i: 'i32', u: 'u32', h: 'f16'}[aliasMatch[2]];
+  return `${aliasMatch[1]}<${primitiveType}>`;
+}
+
+function getWGSLAttributeShaderType(type: string): AttributeShaderType | null {
+  return /^(?:i32|u32|f32|f16|vec[234]<(?:i32|u32|f32|f16)>)$/.test(type)
+    ? (type as AttributeShaderType)
+    : null;
+}
+
+function getNumericWGSLAttribute(tokens: WGSLToken[], name: string): number | null | undefined {
+  let value: number | undefined;
+  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+    if (tokens[tokenIndex].value !== '@' || tokens[tokenIndex + 1]?.value !== name) {
+      continue;
+    }
+    if (
+      value !== undefined ||
+      tokens[tokenIndex + 2]?.value !== '(' ||
+      !/^\d+$/.test(tokens[tokenIndex + 3]?.value || '') ||
+      tokens[tokenIndex + 4]?.value !== ')'
+    ) {
+      return null;
+    }
+    value = Number(tokens[tokenIndex + 3].value);
+  }
+  return value;
+}
+
+function hasWGSLAttribute(tokens: WGSLToken[], name: string): boolean {
+  return tokens.some(
+    (token, tokenIndex) => token.value === '@' && tokens[tokenIndex + 1]?.value === name
+  );
+}
+
+function getWGSLTextureViewDimension(dimension: string): TextureBindingLayout['viewDimension'] {
+  return dimension.replace('_', '-') as TextureBindingLayout['viewDimension'];
+}
+
+function findMatchingToken(
+  tokens: WGSLToken[],
+  openTokenIndex: number,
+  openValue: string,
+  closeValue: string
+): number {
+  let depth = 0;
+  for (let tokenIndex = openTokenIndex; tokenIndex < tokens.length; tokenIndex++) {
+    if (tokens[tokenIndex].value === openValue) {
+      depth++;
+    } else if (tokens[tokenIndex].value === closeValue && --depth === 0) {
+      return tokenIndex;
+    }
+  }
+  return -1;
+}
+
+function splitTopLevelTokens(tokens: WGSLToken[], delimiter: string): WGSLToken[][] | null {
+  const parts: WGSLToken[][] = [];
+  let partStart = 0;
+  const delimiterDepths: Record<string, number> = {'(': 0, '<': 0, '[': 0, '{': 0};
+  const openingValues = Object.keys(delimiterDepths);
+  const closingToOpening: Record<string, string> = {')': '(', '>': '<', ']': '[', '}': '{'};
+
+  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+    const value = tokens[tokenIndex].value;
+    if (value === delimiter && openingValues.every(opening => delimiterDepths[opening] === 0)) {
+      parts.push(tokens.slice(partStart, tokenIndex));
+      partStart = tokenIndex + 1;
+      continue;
+    }
+    if (value in delimiterDepths) {
+      delimiterDepths[value]++;
+    } else if (value in closingToOpening) {
+      const opening = closingToOpening[value];
+      delimiterDepths[opening]--;
+      if (delimiterDepths[opening] < 0) {
+        return null;
+      }
+    }
+  }
+  if (!openingValues.every(opening => delimiterDepths[opening] === 0)) {
+    return null;
+  }
+  parts.push(tokens.slice(partStart));
+  return parts;
+}
+
+function findTopLevelTokenInSlice(tokens: WGSLToken[], value: string): number {
+  const parts = splitTopLevelTokens(tokens, value);
+  return parts && parts.length === 2 ? parts[0].length : -1;
+}
+
+function findTopLevelToken(
+  tokens: WGSLToken[],
+  braceDepths: number[],
+  startIndex: number,
+  value: string
+): number {
+  for (let tokenIndex = startIndex; tokenIndex < tokens.length; tokenIndex++) {
+    if (braceDepths[tokenIndex] === 0 && tokens[tokenIndex].value === value) {
+      return tokenIndex;
+    }
+  }
+  return -1;
+}
+
+function findTopLevelStatementStart(
+  tokens: WGSLToken[],
+  braceDepths: number[],
+  beforeIndex: number
+): number {
+  for (let tokenIndex = beforeIndex - 1; tokenIndex >= 0; tokenIndex--) {
+    if (
+      (tokens[tokenIndex].value === ';' && braceDepths[tokenIndex] === 0) ||
+      (tokens[tokenIndex].value === '}' && braceDepths[tokenIndex] === 1)
+    ) {
+      return tokenIndex + 1;
+    }
+  }
+  return 0;
+}
+
+function findLastWGSLIdentifier(tokens: WGSLToken[]): string | null {
+  for (let tokenIndex = tokens.length - 1; tokenIndex >= 0; tokenIndex--) {
+    if (isWGSLIdentifier(tokens[tokenIndex].value)) {
+      return tokens[tokenIndex].value;
+    }
+  }
+  return null;
+}
+
+function formatWGSLTokens(tokens: WGSLToken[]): string {
+  return tokens.map(token => token.value).join('');
+}
+
+function isWGSLIdentifier(value: string | undefined): value is string {
+  return Boolean(value && /^[A-Za-z_][A-Za-z0-9_]*$/.test(value));
+}

--- a/modules/shadertools/test/lib/shader-assembly/wgsl-interface-scan.node.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembly/wgsl-interface-scan.node.spec.ts
@@ -1,0 +1,249 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {scanWGSLInterface, ShaderAssembler, type PlatformInfo} from '@luma.gl/shadertools';
+
+const PLATFORM_INFO: PlatformInfo = {
+  type: 'webgpu',
+  gpu: 'test-gpu',
+  shaderLanguage: 'wgsl',
+  shaderLanguageVersion: 300,
+  features: new Set()
+};
+
+test('scanWGSLInterface#scans selected entry point and resource bindings', t => {
+  const source = /* wgsl */ `\
+alias Scalar = f32;
+alias Position = vec3<Scalar>;
+
+struct FrameUniforms {
+  scale: f32,
+};
+
+@binding(2) @group(1) var<uniform> frame: FrameUniforms;
+@group(0) @binding(0) var<storage, read> inputData: array<array<Position, 2>, 4>;
+@binding(1) @group(0) var<storage, read_write> outputData: array<Position>;
+@group(0) @binding(2) var depthTexture: texture_depth_2d;
+@binding(3) @group(0) var depthTextureSampler: sampler;
+@group(0) @binding(4) var shadowSampler: sampler_comparison;
+@group(0) @binding(5) var outputTexture: texture_storage_2d<rgba8unorm, write>;
+@group(0) @binding(6) var videoFrame: texture_external;
+
+@vertex
+fn firstVertex(@location(7) unused: vec4f) -> @builtin(position) vec4f {
+  return unused;
+}
+
+@vertex
+fn selectedVertex(
+  @interpolate(flat) @location(2) featureId: u32,
+  @location(0) position: Position,
+  @builtin(instance_index) instanceIndex: u32
+) -> @builtin(position) vec4f {
+  return vec4f(position * frame.scale, 1.0);
+}
+`;
+
+  t.deepEqual(
+    scanWGSLInterface(source, {vertexEntryPoint: 'selectedVertex'}),
+    {
+      attributes: [
+        {name: 'position', location: 0, type: 'vec3<f32>'},
+        {name: 'featureId', location: 2, type: 'u32'}
+      ],
+      bindings: [
+        {name: 'inputData', group: 0, location: 0, type: 'read-only-storage'},
+        {name: 'outputData', group: 0, location: 1, type: 'storage'},
+        {
+          name: 'depthTexture',
+          group: 0,
+          location: 2,
+          type: 'texture',
+          viewDimension: '2d',
+          sampleType: 'depth',
+          multisampled: false
+        },
+        {
+          name: 'depthTextureSampler',
+          group: 0,
+          location: 3,
+          type: 'sampler',
+          samplerType: 'non-filtering'
+        },
+        {
+          name: 'shadowSampler',
+          group: 0,
+          location: 4,
+          type: 'sampler',
+          samplerType: 'comparison'
+        },
+        {
+          name: 'outputTexture',
+          group: 0,
+          location: 5,
+          type: 'storage',
+          format: 'rgba8unorm',
+          access: 'write-only',
+          viewDimension: '2d'
+        },
+        {name: 'videoFrame', group: 0, location: 6, type: 'external-texture'},
+        {name: 'frame', group: 1, location: 2, type: 'uniform'}
+      ]
+    },
+    'selected entry point, aliases, nested generic storage, and bindings are scanned'
+  );
+  t.end();
+});
+
+test('scanWGSLInterface#scans aliased struct vertex inputs and ignores comments', t => {
+  const source = /* wgsl */ `\
+alias Scalar = f32;
+alias Coordinates = vec2<Scalar>;
+alias VertexInputAlias = VertexInput;
+
+struct VertexInput {
+  @builtin(vertex_index) vertexIndex: u32,
+  @interpolate(flat) @location(3) category: u32,
+  @location(1) coordinates: Coordinates,
+  // @location(9) hidden: vec4f,
+};
+
+/* @group(0) @binding(8) var<uniform> hiddenBinding: Hidden; */
+@group(0) @binding(0) var<storage, read> positions: array<array<vec4f, 2>, 4>;
+
+@vertex
+fn vertexMain(input: VertexInputAlias) -> @builtin(position) vec4f {
+  return vec4f(input.coordinates, 0.0, 1.0);
+}
+`;
+
+  t.deepEqual(
+    scanWGSLInterface(source),
+    {
+      attributes: [
+        {name: 'coordinates', location: 1, type: 'vec2<f32>'},
+        {name: 'category', location: 3, type: 'u32'}
+      ],
+      bindings: [{name: 'positions', group: 0, location: 0, type: 'read-only-storage'}]
+    },
+    'struct members are scanned and commented declarations are ignored'
+  );
+  t.end();
+});
+
+test('scanWGSLInterface#requires an entry point selection for multiple vertices', t => {
+  const source = /* wgsl */ `\
+@vertex
+fn first(@location(0) firstPosition: vec2f) -> @builtin(position) vec4f {
+  return vec4f(firstPosition, 0.0, 1.0);
+}
+
+@vertex
+fn second(@location(1) secondPosition: vec3f) -> @builtin(position) vec4f {
+  return vec4f(secondPosition, 1.0);
+}
+`;
+
+  t.equal(scanWGSLInterface(source), null, 'multiple vertex entry points are ambiguous');
+  t.deepEqual(
+    scanWGSLInterface(source, {vertexEntryPoint: 'second'}),
+    {
+      attributes: [{name: 'secondPosition', location: 1, type: 'vec3<f32>'}],
+      bindings: []
+    },
+    'the selected vertex entry point controls the scanned attributes'
+  );
+  t.equal(
+    scanWGSLInterface(source, {vertexEntryPoint: 'missing'}),
+    null,
+    'an unknown selected entry point requires an explicit layout'
+  );
+  t.end();
+});
+
+test('scanWGSLInterface#scans compute bindings without vertex attributes', t => {
+  const source = /* wgsl */ `\
+@group(0) @binding(0) var<storage, read_write> values: array<u32>;
+
+@compute @workgroup_size(1)
+fn computeMain() {
+  values[0] = 1;
+}
+`;
+
+  t.deepEqual(
+    scanWGSLInterface(source),
+    {
+      attributes: [],
+      bindings: [{name: 'values', group: 0, location: 0, type: 'storage'}]
+    },
+    'compute-only shaders still produce binding layouts'
+  );
+  t.end();
+});
+
+test('scanWGSLInterface#falls back for unsupported or malformed interfaces', t => {
+  t.equal(
+    scanWGSLInterface(`\
+@group(0) @binding(0) var textures: binding_array<texture_2d<f32>>;
+@compute @workgroup_size(1) fn computeMain() {}
+`),
+    null,
+    'unsupported binding arrays require an explicit layout'
+  );
+  t.equal(
+    scanWGSLInterface(`\
+alias PositionA = PositionB;
+alias PositionB = PositionA;
+@vertex fn vertexMain(@location(0) position: PositionA) -> @builtin(position) vec4f {
+  return vec4f(0.0);
+}
+`),
+    null,
+    'recursive type aliases require an explicit layout'
+  );
+  t.equal(
+    scanWGSLInterface(`\
+struct BrokenInput {
+  @location(0) position: vec3f,
+@vertex fn vertexMain(input: BrokenInput) -> @builtin(position) vec4f {
+  return vec4f(input.position, 1.0);
+}
+`),
+    null,
+    'unbalanced delimiters require an explicit layout'
+  );
+  t.end();
+});
+
+test('ShaderAssembler#assembleWGSLShader returns the scanned interface', t => {
+  const source = /* wgsl */ `\
+struct FrameUniforms {
+  scale: f32,
+};
+
+@group(0) @binding(0) var<uniform> frame: FrameUniforms;
+
+@vertex
+fn selectedVertex(@location(1) position: vec3f) -> @builtin(position) vec4f {
+  return vec4f(position * frame.scale, 1.0);
+}
+`;
+  const assembledShader = new ShaderAssembler().assembleWGSLShader({
+    platformInfo: PLATFORM_INFO,
+    source,
+    vertexEntryPoint: 'selectedVertex'
+  });
+
+  t.deepEqual(
+    assembledShader.shaderLayout,
+    {
+      attributes: [{name: 'position', location: 1, type: 'vec3<f32>'}],
+      bindings: [{name: 'frame', group: 0, location: 0, type: 'uniform'}]
+    },
+    'assembly returns a layout for its final preprocessed WGSL source'
+  );
+  t.end();
+});


### PR DESCRIPTION
For #2852.

## Goals

- Establish a small, dependency-free WGSL interface scanner that can replace runtime `wgsl_reflect` use in later focused PRs.
- Return interface metadata from shader assembly without changing pipeline behavior yet.
- Fall back safely when source is malformed, ambiguous, or outside the scanner's supported WGSL subset.

## Changes

- Add exported `scanWGSLInterface(source, {vertexEntryPoint})`.
- Scan bind groups, buffers, sampled/depth/storage/external textures, samplers, and vertex attributes.
- Handle comments, reordered attributes, aliases, nested generics, struct inputs, built-in inputs, and multiple vertex entry points.
- Return `null` for unsupported binding arrays, cyclic aliases, malformed delimiters, duplicate interface locations/names, and ambiguous entry points.
- Include `shaderLayout` in both WGSL assembly APIs, derived from the final preprocessed source.
- Add focused Node coverage for successful scans, safe fallback, and assembler integration.

## Verification

- `nvm use` — Node 22.22.1
- `yarn install --immutable` — passed (existing peer dependency warnings)
- `yarn lint fix` — passed
- `yarn build` — passed after final formatting
- `yarn test-node modules/shadertools/test/lib/shader-assembly/wgsl-interface-scan.node.spec.ts` — 6 passed
- `yarn test-node` — 338 passed, 2 skipped
- `yarn test` — Node portion passed; headless portion reached 1,420 passed and 25 skipped, with four unrelated WebGPU failures (DGGS shader decoding, Arrow DGGS paths, Arrow-layer storage rendering, and the volumetric-fire timing assertion)
- `yarn website:build` — not run; no website changes
- `(cd website && yarn build)` — not run; no website package changes

## Risk and rollout

This PR only computes and returns metadata. Engine and adapter code does not consume it yet, so shader pipeline behavior remains unchanged. Unsupported syntax produces `null`; the follow-up integration will preserve explicit-layout and reflection fallback paths before removing `wgsl_reflect`.