### PR TITLE
perf(webgl): move debugging to optional entry

### DIFF
--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -129,7 +129,13 @@ luma.gl is pre-integrated with the Khronos group's WebGL developer tools (the [W
 
 The most flexible way to enable WebGL API tracing is by typing the following command into the browser developer tools console:
 
-Note that the developer tools module is loaded dynamically when a device is created with the debug flag set, so the developer tools can be activated in production code by opening the browser console and typing:
+Applications that want browser-console activation must include the optional debug registration entry:
+
+```ts
+import '@luma.gl/webgl/debug';
+```
+
+The developer tools script is then loaded dynamically when a device is created with the debug flag set, so the tools can be activated by opening the browser console and typing:
 
 ```ts
 luma.set('debug-webgl', true)
@@ -137,11 +143,13 @@ luma.set('debug-webgl', true)
 
 then reload your browser tab.
 
-While usually not recommended, it is also possible to activate the developer tools manually. Call [`luma.createDevice`](/docs/api-reference/core/luma#lumacreatedevice) with `debugWebGL: true` to create a WebGL context instrumented with the WebGL developer tools:
+While usually not recommended, it is also possible to activate the developer tools directly. Import the optional registration entry, then call [`luma.createDevice`](/docs/api-reference/core/luma#lumacreatedevice) with `debugWebGL: true`:
 
 ```ts
 import {luma} from '@luma.gl/core';
-const device = luma.createDevice({type: 'webgl', {debugWebGL: true});
+import '@luma.gl/webgl/debug';
+
+const device = await luma.createDevice({type: 'webgl', debugWebGL: true});
 ```
 
 > Warning: WebGL debug contexts impose a significant performance penalty (luma waits for the GPU after each WebGL call to check error codes) and should not be activated in production code.
@@ -159,7 +167,7 @@ luma.log.set('debug-spectorjs', true);
 And then restarting the application (e.g. via Command-R on MacOS),
 
 
-You can also enable spector when creating a device  by adding the `debugSpectorJS: true` option.
+You can also enable Spector when creating a device by importing `@luma.gl/webgl/debug` and adding the `debugSpectorJS: true` option.
 
 To display Spector.js stats when loaded.
 
@@ -168,5 +176,5 @@ luma.spector.displayUI()
 ```
 
 :::info
-Spector.js is dynamically loaded into your application, so there is no bundle size penalty.
+Spector.js itself is loaded from a CDN. The optional `@luma.gl/webgl/debug` registration entry keeps the integration code out of normal WebGL application bundles.
 :::

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -54,6 +54,10 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 - `Model.predraw(commandEncoder)` now requires an explicit command encoder. Call it with the encoder that will be submitted when ordered pre-draw uploads must be shared across multiple draws or viewports. Normal `Model.draw(renderPass)` calls continue to perform their own pre-draw work.
 - `makeGPUGeometry()` now interleaves CPU geometry attributes into a single vertex buffer by default. Callers that require separate attribute buffers should create those buffers and construct `GPUGeometry` explicitly with the corresponding `bufferLayout`.
 
+**@luma.gl/webgl**
+
+- WebGLDeveloperTools and Spector integration now require `import '@luma.gl/webgl/debug'` before enabling `debugWebGL` or `debugSpectorJS`. This keeps debug-only code and the full GL enum out of normal adapter application bundles.
+
 **@luma.gl/arrow**
 
 - Arrow 2D text clip rectangles now require `FixedSizeList<Float32>[4]` columns, and GPU-backed

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -114,6 +114,10 @@ Target Release Date: TBD
 - **HTML-in-Canvas feature detection** - `device.features.has('html-in-canvas')` and `isHTMLInCanvasSupported()` report whether the active browser and backend expose the experimental DOM-to-texture rasterization path. The high-level `HTMLTexture` wrapper remains deferred with `@luma.gl/experimental` until v10.
 - **GPU data and buffer-layout utilities** - New exported helpers decode GPU data types, select native or emulated Float16 arrays, and resolve logical attributes over shared or composite buffer layouts.
 
+**@luma.gl/webgl**
+
+- **Optional WebGL debugging** - WebGLDeveloperTools and Spector integration are registered through `@luma.gl/webgl/debug`, keeping debug-only code out of normal adapter application bundles.
+
 **@luma.gl/engine**
 
 - **[`DynamicBuffer`](/docs/api-reference/engine/dynamic-buffer)** - New engine-level wrapper for resizable buffers. `Model` supports dynamic buffers for attributes, index buffers, and shader bindings, and `Material` supports dynamic buffer bindings with cache invalidation when the backing buffer changes.

--- a/modules/webgl/package.json
+++ b/modules/webgl/package.json
@@ -26,6 +26,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./debug": {
+      "types": "./dist/debug.d.ts",
+      "import": "./dist/debug.js",
+      "require": "./dist/debug.cjs"
+    },
     "./constants": {
       "types": "./dist/constants/index.d.ts",
       "import": "./dist/constants/index.js",

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -5,20 +5,16 @@
 import type {WebGLDevice} from './webgl-device';
 import {Adapter, Device, DeviceProps, log} from '@luma.gl/core';
 import {enforceWebGL2} from '../context/polyfills/polyfill-webgl1-extensions';
-import {loadSpectorJS, DEFAULT_SPECTOR_PROPS} from '../context/debug/spector';
-import {loadWebGLDeveloperTools} from '../context/debug/webgl-developer-tools';
+import {
+  loadRegisteredSpectorJS,
+  loadRegisteredWebGLDeveloperTools
+} from '../context/debug/debug-hooks';
 
 const LOG_LEVEL = 1;
 
 export class WebGLAdapter extends Adapter {
   /** type of device's created by this adapter */
   readonly type: Device['type'] = 'webgl';
-
-  constructor() {
-    super();
-    // Add spector default props to device default props, so that runtime settings are observed
-    Device.defaultProps = {...Device.defaultProps, ...DEFAULT_SPECTOR_PROPS};
-  }
 
   /** Force any created WebGL contexts to be WebGL2 contexts, polyfilled with WebGL1 extensions */
   enforceWebGL2(enable: boolean): void {
@@ -63,6 +59,9 @@ export class WebGLAdapter extends Adapter {
       throw new Error('Invalid WebGL2RenderingContext');
     }
 
+    props = resolveWebGLDebugProps(props);
+    await loadWebGLDebugTools(props);
+
     const createCanvasContext = props.createCanvasContext === true ? {} : props.createCanvasContext;
 
     // We create a new device using the provided WebGL context and its canvas
@@ -76,26 +75,8 @@ export class WebGLAdapter extends Adapter {
 
   async create(props: DeviceProps = {}): Promise<WebGLDevice> {
     const {WebGLDevice} = await import('./webgl-device');
-
-    const promises: Promise<unknown>[] = [];
-
-    // Load webgl and spector debug scripts from CDN if requested
-    if (props.debugWebGL || props.debug) {
-      promises.push(loadWebGLDeveloperTools());
-    }
-
-    if (props.debugSpectorJS) {
-      promises.push(loadSpectorJS(props));
-    }
-
-    // Wait for all the loads to settle before creating the context.
-    // The Device.create() functions are async, so in contrast to the constructor, we can `await` here.
-    const results = await Promise.allSettled(promises);
-    for (const result of results) {
-      if (result.status === 'rejected') {
-        log.error(`Failed to initialize debug libraries ${result.reason}`)();
-      }
-    }
+    props = resolveWebGLDebugProps(props);
+    await loadWebGLDebugTools(props);
 
     try {
       const device = new WebGLDevice(props);
@@ -128,3 +109,29 @@ function isWebGL(gl: any): gl is WebGL2RenderingContext {
 }
 
 export const webgl2Adapter = new WebGLAdapter();
+
+function resolveWebGLDebugProps(props: DeviceProps): DeviceProps {
+  return {
+    ...props,
+    debug: props.debug ?? Device.defaultProps.debug,
+    debugWebGL: props.debugWebGL ?? Device.defaultProps.debugWebGL,
+    debugSpectorJS: props.debugSpectorJS ?? Boolean(log.get('debug-spectorjs'))
+  };
+}
+
+async function loadWebGLDebugTools(props: DeviceProps): Promise<void> {
+  const promises: Promise<void>[] = [];
+  if (props.debugWebGL || props.debug) {
+    promises.push(loadRegisteredWebGLDeveloperTools());
+  }
+  if (props.debugSpectorJS) {
+    promises.push(loadRegisteredSpectorJS(props));
+  }
+
+  const results = await Promise.allSettled(promises);
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      log.error(`Failed to initialize debug libraries ${result.reason}`)();
+    }
+  }
+}

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -46,8 +46,10 @@ import {WebGLDeviceLimits} from './device-helpers/webgl-device-limits';
 import {WebGLCanvasContext} from './webgl-canvas-context';
 import {WebGLPresentationContext} from './webgl-presentation-context';
 import type {Spector} from '../context/debug/spector-types';
-import {initializeSpectorJS} from '../context/debug/spector';
-import {makeDebugContext} from '../context/debug/webgl-developer-tools';
+import {
+  initializeRegisteredSpectorJS,
+  makeRegisteredDebugContext
+} from '../context/debug/debug-hooks';
 import {getTextureFormatCapabilitiesWebGL} from './converters/webgl-texture-table';
 import {uid} from '../utils/uid';
 
@@ -229,7 +231,7 @@ export class WebGLDevice extends Device {
     // Add spector debug instrumentation to context
     // We need to trust spector integration to decide if spector should be initialized
     // We also run spector instrumentation first, otherwise spector can clobber luma instrumentation.
-    this.spectorJS = initializeSpectorJS({...this.props, gl: this.handle});
+    this.spectorJS = initializeRegisteredSpectorJS({...this.props, gl: this.handle});
 
     // Instrument context
     const contextData = getWebGLContextData(this.handle);
@@ -257,7 +259,10 @@ export class WebGLDevice extends Device {
     // props.debug - instrument the WebGL context with Khronos debug tools
     // props.debugWebGL - activate WebGL context tracing, force log level to at least 1
     if (props.debug || props.debugWebGL) {
-      this.gl = makeDebugContext(this.gl, {debugWebGL: true, traceWebGL: props.debugWebGL});
+      this.gl = makeRegisteredDebugContext(this.gl, {
+        debugWebGL: true,
+        traceWebGL: props.debugWebGL
+      });
       log.warn('WebGL debug mode activated. Performance reduced.')();
     }
     if (props.debugWebGL) {

--- a/modules/webgl/src/context/debug/debug-hooks.ts
+++ b/modules/webgl/src/context/debug/debug-hooks.ts
@@ -1,0 +1,76 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {DeviceProps} from '@luma.gl/core';
+import {log} from '@luma.gl/core';
+import type {Spector} from './spector-types';
+
+type DebugContextProps = {
+  debugWebGL?: boolean;
+  traceWebGL?: boolean;
+};
+
+type SpectorProps = Pick<DeviceProps, 'debugSpectorJS' | 'debugSpectorJSUrl'> & {
+  gl?: WebGL2RenderingContext;
+};
+
+type WebGLDeveloperToolsHooks = {
+  load(): Promise<void>;
+  makeDebugContext(gl: WebGL2RenderingContext, props?: DebugContextProps): WebGL2RenderingContext;
+};
+
+type SpectorHooks = {
+  load(props: SpectorProps): Promise<void>;
+  initialize(props: SpectorProps): Spector | null;
+};
+
+let webglDeveloperToolsHooks: WebGLDeveloperToolsHooks | null = null;
+let spectorHooks: SpectorHooks | null = null;
+let debugImportWarningShown = false;
+
+export function registerWebGLDeveloperTools(hooks: WebGLDeveloperToolsHooks): void {
+  webglDeveloperToolsHooks = hooks;
+}
+
+export function registerSpectorJS(hooks: SpectorHooks): void {
+  spectorHooks = hooks;
+}
+
+export async function loadRegisteredWebGLDeveloperTools(): Promise<void> {
+  if (!webglDeveloperToolsHooks) {
+    warnDebugImportRequired();
+    return;
+  }
+  await webglDeveloperToolsHooks.load();
+}
+
+export function makeRegisteredDebugContext(
+  gl: WebGL2RenderingContext,
+  props: DebugContextProps
+): WebGL2RenderingContext {
+  if (!webglDeveloperToolsHooks) {
+    warnDebugImportRequired();
+    return gl;
+  }
+  return webglDeveloperToolsHooks.makeDebugContext(gl, props);
+}
+
+export async function loadRegisteredSpectorJS(props: SpectorProps): Promise<void> {
+  if (!spectorHooks) {
+    warnDebugImportRequired();
+    return;
+  }
+  await spectorHooks.load(props);
+}
+
+export function initializeRegisteredSpectorJS(props: SpectorProps): Spector | null {
+  return spectorHooks?.initialize(props) || null;
+}
+
+function warnDebugImportRequired(): void {
+  if (!debugImportWarningShown) {
+    debugImportWarningShown = true;
+    log.warn('Import @luma.gl/webgl/debug before enabling WebGL debugging.')();
+  }
+}

--- a/modules/webgl/src/context/debug/spector.ts
+++ b/modules/webgl/src/context/debug/spector.ts
@@ -7,6 +7,7 @@ import {loadScript} from '../../utils/load-script';
 import {getWebGLContextData} from '../helpers/webgl-context-data';
 
 import type {Spector} from './spector-types';
+import {registerSpectorJS} from './debug-hooks';
 
 /** Spector debug initialization options */
 type SpectorProps = {
@@ -106,3 +107,5 @@ export function initializeSpectorJS(props: SpectorProps): Spector | null {
 
   return spector;
 }
+
+registerSpectorJS({load: loadSpectorJS, initialize: initializeSpectorJS});

--- a/modules/webgl/src/context/debug/webgl-developer-tools.ts
+++ b/modules/webgl/src/context/debug/webgl-developer-tools.ts
@@ -4,9 +4,10 @@
 
 import {log} from '@luma.gl/core';
 // Rename constant to prevent inlining. We need the full set of constants for generating debug strings.
-import {GL as GLEnum} from '@luma.gl/webgl/constants';
+import {GL as GLEnum} from '../../constants/webgl-constants';
 import {isBrowser} from '@probe.gl/env';
 import {loadScript} from '../../utils/load-script';
+import {registerWebGLDeveloperTools} from './debug-hooks';
 
 const WEBGL_DEBUG_CDN_URL = 'https://unpkg.com/webgl-debug@2.0.1/index.js';
 
@@ -170,3 +171,5 @@ function onValidateGLFunc(
     }
   }
 }
+
+registerWebGLDeveloperTools({load: loadWebGLDeveloperTools, makeDebugContext});

--- a/modules/webgl/src/debug.ts
+++ b/modules/webgl/src/debug.ts
@@ -1,0 +1,9 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {
+  loadWebGLDeveloperTools,
+  makeDebugContext
+} from './context/debug/webgl-developer-tools';
+export {loadSpectorJS, initializeSpectorJS} from './context/debug/spector';

--- a/modules/webgl/test/context/debug-bundle.node.spec.ts
+++ b/modules/webgl/test/context/debug-bundle.node.spec.ts
@@ -1,0 +1,47 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {resolve} from 'node:path';
+import esbuild from 'esbuild';
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+
+test('WebGL debug tools stay outside the normal adapter bundle', async t => {
+  const sourceAliases = {
+    name: 'webgl-source-alias',
+    setup(build: esbuild.PluginBuild): void {
+      build.onResolve({filter: /^@luma\.gl\/webgl$/}, () => ({
+        path: resolve('modules/webgl/src/index.ts')
+      }));
+    }
+  };
+  const buildResult = await esbuild.build({
+    stdin: {
+      contents: "export {webgl2Adapter} from '@luma.gl/webgl';",
+      resolveDir: process.cwd()
+    },
+    bundle: true,
+    external: ['@luma.gl/core'],
+    format: 'esm',
+    logLevel: 'silent',
+    metafile: true,
+    plugins: [sourceAliases],
+    treeShaking: true,
+    write: false
+  });
+  const bundledInputs = Object.keys(buildResult.metafile.inputs);
+
+  t.notOk(
+    bundledInputs.some(path => path.endsWith('/webgl-developer-tools.ts')),
+    'adapter bundle excludes WebGLDeveloperTools'
+  );
+  t.notOk(
+    bundledInputs.some(path => path.endsWith('/spector.ts')),
+    'adapter bundle excludes Spector integration'
+  );
+  t.ok(
+    bundledInputs.some(path => path.endsWith('/debug-hooks.ts')),
+    'adapter bundle retains only lightweight registration hooks'
+  );
+  t.end();
+});


### PR DESCRIPTION
Addresses the WebGL debug/Spector portion of #2852.

## Goals

- Keep WebGLDeveloperTools, Spector integration, and debug-only GL enum use out of normal WebGL application bundles.
- Preserve opt-in debugging through an explicit, documented registration entry.
- Add a regression test for the production bundle graph.

## Changes

- Adds `@luma.gl/webgl/debug` as an optional package entrypoint.
- Replaces eager debug imports in `WebGLAdapter` and `WebGLDevice` with lightweight registration hooks.
- Normalizes debug defaults before loading registered tools for both `create()` and `attach()`.
- Documents the required side-effect import and the v9.4 compatibility change.
- Adds an esbuild metafile test proving the normal adapter bundle excludes the WebGLDeveloperTools and Spector source modules.

## Bundle impact

Measured with esbuild production fixtures against `master`:

| Fixture | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| WebGL backend, min | 136,677 B | 134,030 B | 2,647 B |
| WebGL backend, gzip | 38,473 B | 37,403 B | 1,070 B |
| WebGL backend, Brotli | 32,959 B | 32,144 B | 815 B |
| Realistic WebGL app, min | 211,914 B | 176,545 B | 35,369 B |
| Realistic WebGL app, gzip | 59,907 B | 50,827 B | 9,080 B |
| Realistic WebGL app, Brotli | 49,886 B | 43,249 B | 6,637 B |

The realistic app is now 827 bytes above the issue's exact 50,000-byte gzip target. The remaining full WebGL constant retention is intentionally left for the next focused PR.

## Verification

- `nvm use` — Node 22.14.0
- `yarn install` — existing workspace install is current; no dependency changes
- `yarn lint fix` — passed
- `yarn build` — passed
- `yarn test-node modules/webgl/test/context/debug-bundle.node.spec.ts` — passed
- ESM and CommonJS imports of `@luma.gl/webgl/debug` — passed
- `yarn test` — Node: 333 passed, 2 skipped. Headless: 1420 passed, 25 skipped; the same four unrelated WebGPU failures reproduced from `master` (Volumetric Fire Forge, two DGGS/A5 tests, and Arrow storage-backed layers).
- `yarn website:build` — not run; documentation-only website changes
- `(cd website && yarn build)` — not run; no website package changes

## Compatibility

Applications enabling `debugWebGL`, `debugSpectorJS`, or console-driven WebGL debugging must first import `@luma.gl/webgl/debug`. Normal applications do not pay for those integrations.