### PR TITLE
perf(webgl): use forward-only GL constants

### DIFF
--- a/docs/api-reference/webgl/constants.md
+++ b/docs/api-reference/webgl/constants.md
@@ -12,7 +12,7 @@ import {WebGLDocsTabs} from '@site/src/components/docs/webgl-docs-tabs';
 In luma.gl versions earlier than v9.3, these exports were provided by `@luma.gl/constants`. Use `@luma.gl/webgl/constants` going forward.
 :::
 
-Use this entry point when you need the raw numeric WebGL enums that luma.gl still uses internally for WebGL interop.
+Use this entry point when you need the raw numeric WebGL constants that luma.gl still uses internally for WebGL interop.
 
 ```typescript
 import {GL} from '@luma.gl/webgl/constants';
@@ -21,8 +21,10 @@ import type {GLParameters, GLSamplerParameters} from '@luma.gl/webgl/constants';
 
 ## Exports
 
-- `GL`: numeric WebGL enum object covering WebGL 2 and supported extension constants.
-- WebGL enum-related TypeScript types such as `GLParameters`, `GLExtensions`, `GLTextureTarget`, `GLUniformType`, and related helper types.
+- `GL`: forward-only numeric WebGL constant object covering WebGL 2 and supported extension constants.
+- `GLConstant<Name>`: the numeric literal type for one named constant.
+- `GLValue`: a general numeric WebGL constant type.
+- WebGL-related TypeScript types such as `GLParameters`, `GLExtensions`, `GLTextureTarget`, `GLUniformType`, and related helper types.
 
 ## When To Use This
 
@@ -32,4 +34,4 @@ import type {GLParameters, GLSamplerParameters} from '@luma.gl/webgl/constants';
 
 ## Preferred API Style
 
-Most luma.gl application APIs use typed WebGPU-style strings rather than numeric WebGL enums. Prefer those higher-level string APIs unless you are specifically interfacing with raw WebGL.
+Most luma.gl application APIs use typed WebGPU-style strings rather than numeric WebGL constants. Prefer those higher-level string APIs unless you are specifically interfacing with raw WebGL.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -54,6 +54,10 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 - `Model.predraw(commandEncoder)` now requires an explicit command encoder. Call it with the encoder that will be submitted when ordered pre-draw uploads must be shared across multiple draws or viewports. Normal `Model.draw(renderPass)` calls continue to perform their own pre-draw work.
 - `makeGPUGeometry()` now interleaves CPU geometry attributes into a single vertex buffer by default. Callers that require separate attribute buffers should create those buffers and construct `GPUGeometry` explicitly with the corresponding `bufferLayout`.
 
+**@luma.gl/webgl**
+
+- `GL` is now a forward-only constant object instead of a numeric TypeScript enum. Named values such as `GL.TRIANGLES` are unchanged, but numeric reverse lookups such as `GL[GL.TRIANGLES]` are no longer available. Use `GLConstant<'TRIANGLES'>` for a named constant type and `GLValue` for a general numeric WebGL constant.
+
 **@luma.gl/arrow**
 
 - Arrow 2D text clip rectangles now require `FixedSizeList<Float32>[4]` columns, and GPU-backed

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -114,6 +114,10 @@ Target Release Date: TBD
 - **HTML-in-Canvas feature detection** - `device.features.has('html-in-canvas')` and `isHTMLInCanvasSupported()` report whether the active browser and backend expose the experimental DOM-to-texture rasterization path. The high-level `HTMLTexture` wrapper remains deferred with `@luma.gl/experimental` until v10.
 - **GPU data and buffer-layout utilities** - New exported helpers decode GPU data types, select native or emulated Float16 arrays, and resolve logical attributes over shared or composite buffer layouts.
 
+**@luma.gl/webgl**
+
+- **Forward-only WebGL constants** - `GL` keeps its named numeric constants without generating numeric reverse mappings, reducing bundles that retain the complete constant table. `GLConstant<Name>` and `GLValue` provide object-compatible constant types.
+
 **@luma.gl/engine**
 
 - **[`DynamicBuffer`](/docs/api-reference/engine/dynamic-buffer)** - New engine-level wrapper for resizable buffers. `Model` supports dynamic buffers for attributes, index buffers, and shader bindings, and `Material` supports dynamic buffer bindings with cache invalidation when the backing buffer changes.

--- a/modules/webgl/src/adapter/converters/device-parameters.ts
+++ b/modules/webgl/src/adapter/converters/device-parameters.ts
@@ -373,7 +373,7 @@ export function convertToCompareFunction(parameter: string, value: GLFunction): 
   });
 }
 
-function convertStencilOperation(parameter: string, value: StencilOperation): GL {
+function convertStencilOperation(parameter: string, value: StencilOperation): number {
   return map<StencilOperation, GLStencilOp>(parameter, value, {
     keep: GL.KEEP,
     zero: GL.ZERO,

--- a/modules/webgl/src/adapter/converters/sampler-parameters.ts
+++ b/modules/webgl/src/adapter/converters/sampler-parameters.ts
@@ -58,7 +58,7 @@ export function convertSamplerParametersToWebGL(props: SamplerProps): GLSamplerP
 /** Convert address more */
 function convertAddressMode(
   addressMode: 'clamp-to-edge' | 'repeat' | 'mirror-repeat'
-): GL.CLAMP_TO_EDGE | GL.REPEAT | GL.MIRRORED_REPEAT {
+): typeof GL.CLAMP_TO_EDGE | typeof GL.REPEAT | typeof GL.MIRRORED_REPEAT {
   switch (addressMode) {
     case 'clamp-to-edge':
       return GL.CLAMP_TO_EDGE;
@@ -69,7 +69,9 @@ function convertAddressMode(
   }
 }
 
-function convertMaxFilterMode(maxFilter: 'nearest' | 'linear'): GL.NEAREST | GL.LINEAR {
+function convertMaxFilterMode(
+  maxFilter: 'nearest' | 'linear'
+): typeof GL.NEAREST | typeof GL.LINEAR {
   switch (maxFilter) {
     case 'nearest':
       return GL.NEAREST;
@@ -86,12 +88,12 @@ function convertMinFilterMode(
   minFilter: 'nearest' | 'linear',
   mipmapFilter: 'none' | 'nearest' | 'linear' = 'none'
 ):
-  | GL.NEAREST
-  | GL.LINEAR
-  | GL.NEAREST_MIPMAP_NEAREST
-  | GL.LINEAR_MIPMAP_NEAREST
-  | GL.NEAREST_MIPMAP_LINEAR
-  | GL.LINEAR_MIPMAP_LINEAR {
+  | typeof GL.NEAREST
+  | typeof GL.LINEAR
+  | typeof GL.NEAREST_MIPMAP_NEAREST
+  | typeof GL.LINEAR_MIPMAP_NEAREST
+  | typeof GL.NEAREST_MIPMAP_LINEAR
+  | typeof GL.LINEAR_MIPMAP_LINEAR {
   if (!mipmapFilter) {
     return convertMaxFilterMode(minFilter);
   }

--- a/modules/webgl/src/adapter/converters/webgl-shadertypes.ts
+++ b/modules/webgl/src/adapter/converters/webgl-shadertypes.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {VariableShaderType, SignedDataType, VertexFormat, NormalizedDataType} from '@luma.gl/core';
-import {GL, GLUniformType, GLSamplerType, GLDataType} from '@luma.gl/webgl/constants';
+import {GL, GLSamplerType, GLDataType} from '@luma.gl/webgl/constants';
 
 export type TextureBindingInfo = {
   viewDimension: '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d';
@@ -17,21 +17,19 @@ export function convertDataTypeToGLDataType(normalizedType: NormalizedDataType):
 
 /** Convert a WebGL "compisite type (e.g. GL.VEC3) into the corresponding luma shader uniform type */
 export function convertGLUniformTypeToShaderVariableType(
-  glUniformType: GLUniformType
+  glUniformType: number
 ): VariableShaderType {
   return WEBGL_SHADER_TYPES[glUniformType];
 }
 
 /** Check if a WebGL "uniform:" is a texture binding */
-export function isGLSamplerType(type: GLUniformType | GLSamplerType): type is GLSamplerType {
+export function isGLSamplerType(type: number): type is GLSamplerType {
   // @ts-ignore TODO
   return Boolean(WEBGL_SAMPLER_TO_TEXTURE_BINDINGS[type]);
 }
 
 /* Get luma texture binding info (viewDimension and sampleType) from a WebGL "sampler" binding */
-export function getTextureBindingFromGLSamplerType(
-  glSamplerType: GLSamplerType
-): TextureBindingInfo {
+export function getTextureBindingFromGLSamplerType(glSamplerType: number): TextureBindingInfo {
   return WEBGL_SAMPLER_TO_TEXTURE_BINDINGS[glSamplerType];
 }
 
@@ -58,7 +56,7 @@ export function getVertexTypeFromGL(glType: GLDataType, normalized = false): Nor
 
 // Composite types table
 // @ts-ignore TODO - fix the type confusion here
-const WEBGL_SHADER_TYPES: Record<GLUniformType, VariableShaderType> = {
+const WEBGL_SHADER_TYPES: Record<number, VariableShaderType> = {
   [GL.FLOAT]: 'f32',
   [GL.FLOAT_VEC2]: 'vec2<f32>',
   [GL.FLOAT_VEC3]: 'vec3<f32>',
@@ -93,7 +91,7 @@ const WEBGL_SHADER_TYPES: Record<GLUniformType, VariableShaderType> = {
   [GL.FLOAT_MAT4]: 'mat4x4<f32>'
 };
 
-const WEBGL_SAMPLER_TO_TEXTURE_BINDINGS: Record<GLSamplerType, TextureBindingInfo> = {
+const WEBGL_SAMPLER_TO_TEXTURE_BINDINGS: Record<number, TextureBindingInfo> = {
   [GL.SAMPLER_2D]: {viewDimension: '2d', sampleType: 'float'},
   [GL.SAMPLER_CUBE]: {viewDimension: 'cube', sampleType: 'float'},
   [GL.SAMPLER_3D]: {viewDimension: '3d', sampleType: 'float'},

--- a/modules/webgl/src/adapter/converters/webgl-texture-table.ts
+++ b/modules/webgl/src/adapter/converters/webgl-texture-table.ts
@@ -118,7 +118,7 @@ function hasTextureFeature(
 
 /** Map a format to webgl and constants */
 type WebGLFormatInfo = {
-  gl?: GL;
+  gl?: number;
   /** compressed */
   x?: string;
   /** color-renderable capability gate. false means never color-renderable on WebGL. */
@@ -417,7 +417,7 @@ function isColorRenderableTextureFormat(
 
 /** Get parameters necessary to work with format in WebGL: internalFormat, dataFormat, type, compressed, */
 export function getTextureFormatWebGL(format: TextureFormat): {
-  internalFormat: GL;
+  internalFormat: number;
   format: GLTexelDataFormat;
   type: GLPixelType;
   compressed: boolean;
@@ -446,7 +446,7 @@ export function getTextureFormatWebGL(format: TextureFormat): {
 
 export function getDepthStencilAttachmentWebGL(
   format: TextureFormat
-): GL.DEPTH_ATTACHMENT | GL.STENCIL_ATTACHMENT | GL.DEPTH_STENCIL_ATTACHMENT {
+): typeof GL.DEPTH_ATTACHMENT | typeof GL.STENCIL_ATTACHMENT | typeof GL.DEPTH_STENCIL_ATTACHMENT {
   const formatInfo = textureFormatDecoder.getInfo(format);
   switch (formatInfo.attachment) {
     case 'depth':
@@ -472,7 +472,7 @@ export function getWebGLPixelDataFormat(
   channels: 'r' | 'rg' | 'rgb' | 'rgba' | 'bgra',
   integer: boolean,
   normalized: boolean,
-  format: GL
+  format: number
 ): GLTexelDataFormat {
   // WebGL1 formats use same internalFormat
   if (format === GL.RGBA || format === GL.RGB) {
@@ -492,7 +492,7 @@ export function getWebGLPixelDataFormat(
 /**
  * Map WebGPU style texture format strings to GL constants
  */
-function convertTextureFormatToGL(format: TextureFormat): GL {
+function convertTextureFormatToGL(format: TextureFormat): number {
   const formatInfo = WEBGL_TEXTURE_FORMATS[format];
   const webglFormat = formatInfo?.gl;
   if (webglFormat === undefined) {

--- a/modules/webgl/src/adapter/converters/webgl-vertex-formats.ts
+++ b/modules/webgl/src/adapter/converters/webgl-vertex-formats.ts
@@ -6,14 +6,14 @@ import {GL} from '@luma.gl/webgl/constants';
 import {VertexFormat, NormalizedDataType} from '@luma.gl/core';
 
 type GLDataType =
-  | GL.UNSIGNED_BYTE
-  | GL.BYTE
-  | GL.UNSIGNED_SHORT
-  | GL.SHORT
-  | GL.UNSIGNED_INT
-  | GL.INT
-  | GL.HALF_FLOAT
-  | GL.FLOAT;
+  | typeof GL.UNSIGNED_BYTE
+  | typeof GL.BYTE
+  | typeof GL.UNSIGNED_SHORT
+  | typeof GL.SHORT
+  | typeof GL.UNSIGNED_INT
+  | typeof GL.INT
+  | typeof GL.HALF_FLOAT
+  | typeof GL.FLOAT;
 
 /** Get vertex format from GL constants */
 export function getVertexFormatFromGL(type: GLDataType, components: 1 | 2 | 3 | 4): VertexFormat {
@@ -51,14 +51,14 @@ export function getVertexTypeFromGL(type: GLDataType, normalized = false): Norma
 export function getGLFromVertexType(
   dataType: NormalizedDataType
 ):
-  | GL.UNSIGNED_BYTE
-  | GL.BYTE
-  | GL.UNSIGNED_SHORT
-  | GL.SHORT
-  | GL.UNSIGNED_INT
-  | GL.INT
-  | GL.HALF_FLOAT
-  | GL.FLOAT {
+  | typeof GL.UNSIGNED_BYTE
+  | typeof GL.BYTE
+  | typeof GL.UNSIGNED_SHORT
+  | typeof GL.SHORT
+  | typeof GL.UNSIGNED_INT
+  | typeof GL.INT
+  | typeof GL.HALF_FLOAT
+  | typeof GL.FLOAT {
   // biome-ignore format: preserve layout
   switch (dataType) {
     case 'uint8': return GL.UNSIGNED_BYTE;

--- a/modules/webgl/src/adapter/device-helpers/webgl-device-limits.ts
+++ b/modules/webgl/src/adapter/device-helpers/webgl-device-limits.ts
@@ -46,14 +46,14 @@ export class WebGLDeviceLimits extends DeviceLimits {
   // PRIVATE
 
   protected gl: WebGL2RenderingContext;
-  protected limits: Partial<Record<GL, number>> = {};
+  protected limits: Partial<Record<number, number>> = {};
 
   constructor(gl: WebGL2RenderingContext) {
     super();
     this.gl = gl;
   }
 
-  protected getParameter(parameter: GL): number {
+  protected getParameter(parameter: number): number {
     if (this.limits[parameter] === undefined) {
       this.limits[parameter] = this.gl.getParameter(parameter);
     }

--- a/modules/webgl/src/adapter/helpers/format-utils.ts
+++ b/modules/webgl/src/adapter/helpers/format-utils.ts
@@ -5,7 +5,7 @@
 import {GL} from '@luma.gl/webgl/constants';
 
 // Returns number of components in a specific readPixels WebGL format
-export function glFormatToComponents(format: GL): 0 | 1 | 2 | 3 | 4 {
+export function glFormatToComponents(format: number): 0 | 1 | 2 | 3 | 4 {
   switch (format) {
     case GL.ALPHA:
     case GL.R32F:
@@ -33,7 +33,7 @@ export function glFormatToComponents(format: GL): 0 | 1 | 2 | 3 | 4 {
 }
 
 // Return byte count for given readPixels WebGL type
-export function glTypeToBytes(type: GL): 0 | 1 | 2 | 4 {
+export function glTypeToBytes(type: number): 0 | 1 | 2 | 4 {
   switch (type) {
     case GL.UNSIGNED_BYTE:
       return 1;

--- a/modules/webgl/src/adapter/helpers/get-shader-layout-from-glsl.ts
+++ b/modules/webgl/src/adapter/helpers/get-shader-layout-from-glsl.ts
@@ -216,7 +216,7 @@ function readUniformBlocks(
   gl: WebGL2RenderingContext,
   program: WebGLProgram
 ): UniformBlockBinding[] {
-  const getBlockParameter = (blockIndex: number, pname: GL): any =>
+  const getBlockParameter = (blockIndex: number, pname: number): any =>
     gl.getActiveUniformBlockParameter(program, blockIndex, pname);
 
   const uniformBlocks: UniformBlockBinding[] = [];

--- a/modules/webgl/src/adapter/helpers/webgl-texture-utils.ts
+++ b/modules/webgl/src/adapter/helpers/webgl-texture-utils.ts
@@ -35,7 +35,7 @@ export type WebGLSetTextureOptions = {
   depth: number;
   mipLevel?: number;
   glTarget: GLTextureTarget;
-  glInternalFormat: GL;
+  glInternalFormat: number;
   glFormat: GLTexelDataFormat;
   glType: GLPixelType;
   compressed?: boolean;
@@ -72,9 +72,9 @@ export type WebGLCopyTextureOptions = {
   z?: number;
 
   glTarget: GLTextureTarget;
-  glInternalFormat: GL;
-  glFormat: GL;
-  glType: GL;
+  glInternalFormat: number;
+  glFormat: number;
+  glType: number;
   compressed?: boolean;
   byteOffset?: number;
   byteLength?: number;
@@ -329,7 +329,7 @@ export function readPixelsToBuffer(
 // eslint-disable-next-line complexity, max-statements
 export function copyToTexture(
   sourceTexture: Framebuffer | Texture,
-  destinationTexture: Texture | GL,
+  destinationTexture: Texture | number,
   options?: {
     sourceX?: number;
     sourceY?: number;
@@ -375,7 +375,7 @@ export function copyToTexture(
   // const prevBuffer = gl.readBuffer(attachment);
   // assert(target);
   let texture: WEBGLTexture | null = null;
-  let textureTarget: GL;
+  let textureTarget: number;
   if (destinationTexture instanceof WEBGLTexture) {
     texture = destinationTexture;
     width = Number.isFinite(width) ? width : texture.width;
@@ -472,7 +472,7 @@ export function toFramebuffer(texture: Texture, props?: FramebufferProps): WEBGL
 function getPixelArray(
   pixelArray,
   glType: GLDataType | GLPixelType,
-  glFormat: GL,
+  glFormat: number,
   width: number,
   height: number,
   depth?: number

--- a/modules/webgl/src/adapter/helpers/webgl-topology-utils.ts
+++ b/modules/webgl/src/adapter/helpers/webgl-topology-utils.ts
@@ -74,13 +74,13 @@ export function getVertexCount(options: {
 export function getGLDrawMode(
   topology: PrimitiveTopology
 ):
-  | GL.POINTS
-  | GL.LINES
-  | GL.LINE_STRIP
-  | GL.LINE_LOOP
-  | GL.TRIANGLES
-  | GL.TRIANGLE_STRIP
-  | GL.TRIANGLE_FAN {
+  | typeof GL.POINTS
+  | typeof GL.LINES
+  | typeof GL.LINE_STRIP
+  | typeof GL.LINE_LOOP
+  | typeof GL.TRIANGLES
+  | typeof GL.TRIANGLE_STRIP
+  | typeof GL.TRIANGLE_FAN {
   // biome-ignore format: preserve layout
   switch (topology) {
     case 'point-list': return GL.POINTS;
@@ -93,7 +93,9 @@ export function getGLDrawMode(
 }
 
 /** Get the primitive type for transform feedback */
-export function getGLPrimitive(topology: PrimitiveTopology): GL.POINTS | GL.LINES | GL.TRIANGLES {
+export function getGLPrimitive(
+  topology: PrimitiveTopology
+): typeof GL.POINTS | typeof GL.LINES | typeof GL.TRIANGLES {
   // biome-ignore format: preserve layout
   switch (topology) {
     case 'point-list': return GL.POINTS;

--- a/modules/webgl/src/adapter/resources/webgl-buffer.ts
+++ b/modules/webgl/src/adapter/resources/webgl-buffer.ts
@@ -14,11 +14,14 @@ export class WEBGLBuffer extends Buffer {
   readonly handle: WebGLBuffer;
 
   /** Target in OpenGL defines the type of buffer */
-  readonly glTarget: GL.ARRAY_BUFFER | GL.ELEMENT_ARRAY_BUFFER | GL.UNIFORM_BUFFER;
+  readonly glTarget:
+    | typeof GL.ARRAY_BUFFER
+    | typeof GL.ELEMENT_ARRAY_BUFFER
+    | typeof GL.UNIFORM_BUFFER;
   /** Usage is a hint on how frequently the buffer will be updates */
-  readonly glUsage: GL.STATIC_DRAW | GL.DYNAMIC_DRAW;
+  readonly glUsage: typeof GL.STATIC_DRAW | typeof GL.DYNAMIC_DRAW;
   /** Index type is needed when issuing draw calls, so we pre-compute it */
-  readonly glIndexType: GL.UNSIGNED_SHORT | GL.UNSIGNED_INT = GL.UNSIGNED_SHORT;
+  readonly glIndexType: typeof GL.UNSIGNED_SHORT | typeof GL.UNSIGNED_INT = GL.UNSIGNED_SHORT;
 
   /** Number of bytes allocated on the GPU for this buffer */
   byteLength: number = 0;
@@ -214,7 +217,7 @@ export class WEBGLBuffer extends Buffer {
  */
 function getWebGLTarget(
   usage: number
-): GL.ARRAY_BUFFER | GL.ELEMENT_ARRAY_BUFFER | GL.UNIFORM_BUFFER {
+): typeof GL.ARRAY_BUFFER | typeof GL.ELEMENT_ARRAY_BUFFER | typeof GL.UNIFORM_BUFFER {
   if (usage & Buffer.INDEX) {
     return GL.ELEMENT_ARRAY_BUFFER;
   }
@@ -231,7 +234,7 @@ function getWebGLTarget(
 }
 
 /** @todo usage is not passed correctly */
-function getWebGLUsage(usage: number): GL.STATIC_DRAW | GL.DYNAMIC_DRAW {
+function getWebGLUsage(usage: number): typeof GL.STATIC_DRAW | typeof GL.DYNAMIC_DRAW {
   if (usage & Buffer.INDEX) {
     return GL.STATIC_DRAW;
   }

--- a/modules/webgl/src/adapter/resources/webgl-command-buffer.ts
+++ b/modules/webgl/src/adapter/resources/webgl-command-buffer.ts
@@ -310,7 +310,7 @@ function _copyTextureToTexture(device: WebGLDevice, options: CopyTextureToTextur
   // const prevBuffer = gl.readBuffer(attachment);
 
   let texture: WEBGLTexture;
-  let textureTarget: GL;
+  let textureTarget: number;
   if (destinationTexture instanceof WEBGLTexture) {
     texture = destinationTexture;
     width = Number.isFinite(width) ? width : texture.width;
@@ -411,8 +411,17 @@ export function getWebGLCubeFaceTarget(
   dimension: '1d' | '2d' | '2d-array' | 'cube' | 'cube-array' | '3d',
   level: number
 ): GLTextureTarget | GLTextureCubeMapTarget {
-  return dimension === 'cube' ? GL.TEXTURE_CUBE_MAP_POSITIVE_X + level : glTarget;
+  return dimension === 'cube' ? CUBE_MAP_FACES[level] : glTarget;
 }
+
+const CUBE_MAP_FACES = [
+  GL.TEXTURE_CUBE_MAP_POSITIVE_X,
+  GL.TEXTURE_CUBE_MAP_NEGATIVE_X,
+  GL.TEXTURE_CUBE_MAP_POSITIVE_Y,
+  GL.TEXTURE_CUBE_MAP_NEGATIVE_Y,
+  GL.TEXTURE_CUBE_MAP_POSITIVE_Z,
+  GL.TEXTURE_CUBE_MAP_NEGATIVE_Z
+] as const;
 
 /** Wrap a texture in a framebuffer so that we can use WebGL APIs that work on framebuffers */
 function getFramebuffer(source: Texture | Framebuffer): {
@@ -437,7 +446,7 @@ function getFramebuffer(source: Texture | Framebuffer): {
  * Returns number of components in a specific readPixels WebGL format
  * @todo use shadertypes utils instead?
  */
-export function glFormatToComponents(format: GL): 1 | 2 | 3 | 4 {
+export function glFormatToComponents(format: number): 1 | 2 | 3 | 4 {
   switch (format) {
     case GL.ALPHA:
     case GL.R32F:
@@ -462,7 +471,7 @@ export function glFormatToComponents(format: GL): 1 | 2 | 3 | 4 {
  * Return byte count for given readPixels WebGL type
  * @todo use shadertypes utils instead?
  */
-export function glTypeToBytes(type: GL): 1 | 2 | 4 {
+export function glTypeToBytes(type: number): 1 | 2 | 4 {
   switch (type) {
     case GL.UNSIGNED_BYTE:
       return 1;

--- a/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
+++ b/modules/webgl/src/adapter/resources/webgl-framebuffer.ts
@@ -81,7 +81,7 @@ export class WEBGLFramebuffer extends Framebuffer {
 
     /** Check the status */
     if (this.device.props.debug) {
-      const status = this.gl.checkFramebufferStatus(GL.FRAMEBUFFER) as GL;
+      const status = this.gl.checkFramebufferStatus(GL.FRAMEBUFFER) as number;
       if (status !== GL.FRAMEBUFFER_COMPLETE) {
         throw new Error(`Framebuffer ${_getFrameBufferStatus(status)}`);
       }
@@ -110,7 +110,7 @@ export class WEBGLFramebuffer extends Framebuffer {
    * @param layer = 0 - index into WEBGLTextureArray and Texture3D or face for `TextureCubeMap`
    * @param level = 0 - mipmapLevel
    */
-  protected _attachTextureView(attachment: GL, textureView: WEBGLTextureView): void {
+  protected _attachTextureView(attachment: number, textureView: WEBGLTextureView): void {
     const {gl} = this.device;
     const {texture} = textureView;
     const level = textureView.props.baseMipLevel;
@@ -156,7 +156,7 @@ export class WEBGLFramebuffer extends Framebuffer {
 // Helper functions
 
 // Map an index to a cube map face constant
-function mapIndexToCubeMapFace(layer: number | GL): GL {
+function mapIndexToCubeMapFace(layer: number): number {
   // TEXTURE_CUBE_MAP_POSITIVE_X is a big value (0x8515)
   // if smaller assume layer is index, otherwise assume it is already a cube map face constant
   return layer < (GL.TEXTURE_CUBE_MAP_POSITIVE_X as number)
@@ -166,7 +166,7 @@ function mapIndexToCubeMapFace(layer: number | GL): GL {
 
 // Helper METHODS
 // Get a string describing the framebuffer error if installed
-function _getFrameBufferStatus(status: GL) {
+function _getFrameBufferStatus(status: number) {
   switch (status) {
     case GL.FRAMEBUFFER_COMPLETE:
       return 'success';

--- a/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
+++ b/modules/webgl/src/adapter/resources/webgl-render-pipeline.ts
@@ -232,7 +232,7 @@ export class WEBGLRenderPipeline extends RenderPipeline {
           // Set buffer
           const {name} = binding;
           const location = gl.getUniformBlockIndex(this.handle, name);
-          if ((location as GL) === GL.INVALID_INDEX) {
+          if ((location as number) === GL.INVALID_INDEX) {
             throw new Error(`Invalid uniform block name ${name}`);
           }
           gl.uniformBlockBinding(this.handle, location, uniformBufferIndex);

--- a/modules/webgl/src/adapter/resources/webgl-sampler.ts
+++ b/modules/webgl/src/adapter/resources/webgl-sampler.ts
@@ -42,7 +42,7 @@ export class WEBGLSampler extends Sampler {
     for (const [pname, value] of Object.entries(parameters)) {
       // Apparently there are integer/float conversion issues requires two parameter setting functions in JavaScript.
       // For now, pick the float version for parameters specified as GLfloat.
-      const param = Number(pname) as GL.TEXTURE_MIN_LOD | GL.TEXTURE_MAX_LOD;
+      const param = Number(pname) as typeof GL.TEXTURE_MIN_LOD | typeof GL.TEXTURE_MAX_LOD;
       switch (param) {
         case GL.TEXTURE_MIN_LOD:
         case GL.TEXTURE_MAX_LOD:

--- a/modules/webgl/src/adapter/resources/webgl-texture.ts
+++ b/modules/webgl/src/adapter/resources/webgl-texture.ts
@@ -69,7 +69,7 @@ export class WEBGLTexture extends Texture {
   /** The WebGL data format - the type of each channel */
   glType: GLPixelType;
   /** The WebGL constant corresponding to the WebGPU style constant in format */
-  glInternalFormat: GL;
+  glInternalFormat: number;
   /** Whether the internal format is compressed */
   compressed: boolean;
 
@@ -597,7 +597,7 @@ export class WEBGLTexture extends Texture {
     };
 
     // Note: luma.gl overrides bindFramebuffer so that we can reliably restore the previous framebuffer.
-    const prevReadBuffer = this.gl.getParameter(GL.READ_BUFFER) as GL;
+    const prevReadBuffer = this.gl.getParameter(GL.READ_BUFFER) as number;
     const prevHandle = this.gl.bindFramebuffer(
       GL.FRAMEBUFFER,
       framebuffer.handle

--- a/modules/webgl/src/constants/index.ts
+++ b/modules/webgl/src/constants/index.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 export {GL} from './webgl-constants';
+export type {GLConstant, GLValue} from './webgl-constants';
 
 export type {
   GLTextureTarget,

--- a/modules/webgl/src/constants/webgl-constants.ts
+++ b/modules/webgl/src/constants/webgl-constants.ts
@@ -8,71 +8,70 @@
  * Standard WebGL, WebGL2 and extension constants (OpenGL constants)
  * @note (Most) of these constants are also defined on the WebGLRenderingContext interface.
  * @see https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/Constants
- * @privateRemarks Locally called `GLEnum` instead of `GL`, because `babel-plugin-inline-webl-constants`
- *  both depends on and processes this module, but shouldn't replace these declarations.
+ * @privateRemarks This is a forward-only object so importing constants does not generate the
+ * reverse numeric-to-name mappings emitted for TypeScript numeric enums.
  */
-// eslint-disable-next-line no-shadow
-enum GLEnum {
+const GL = {
   // Clearing buffers
   // Constants passed to clear() to clear buffer masks.
 
   /** Passed to clear to clear the current depth buffer. */
-  DEPTH_BUFFER_BIT = 0x00000100,
+  DEPTH_BUFFER_BIT: 0x00000100,
   /** Passed to clear to clear the current stencil buffer. */
-  STENCIL_BUFFER_BIT = 0x00000400,
+  STENCIL_BUFFER_BIT: 0x00000400,
   /** Passed to clear to clear the current color buffer. */
-  COLOR_BUFFER_BIT = 0x00004000,
+  COLOR_BUFFER_BIT: 0x00004000,
 
   // Rendering primitives
   // Constants passed to drawElements() or drawArrays() to specify what kind of primitive to render.
 
   /** Passed to drawElements or drawArrays to draw single points. */
-  POINTS = 0x0000,
+  POINTS: 0x0000,
   /** Passed to drawElements or drawArrays to draw lines. Each vertex connects to the one after it. */
-  LINES = 0x0001,
+  LINES: 0x0001,
   /** Passed to drawElements or drawArrays to draw lines. Each set of two vertices is treated as a separate line segment. */
-  LINE_LOOP = 0x0002,
+  LINE_LOOP: 0x0002,
   /** Passed to drawElements or drawArrays to draw a connected group of line segments from the first vertex to the last. */
-  LINE_STRIP = 0x0003,
+  LINE_STRIP: 0x0003,
   /** Passed to drawElements or drawArrays to draw triangles. Each set of three vertices creates a separate triangle. */
-  TRIANGLES = 0x0004,
+  TRIANGLES: 0x0004,
   /** Passed to drawElements or drawArrays to draw a connected group of triangles. */
-  TRIANGLE_STRIP = 0x0005,
+  TRIANGLE_STRIP: 0x0005,
   /** Passed to drawElements or drawArrays to draw a connected group of triangles. Each vertex connects to the previous and the first vertex in the fan. */
-  TRIANGLE_FAN = 0x0006,
+  TRIANGLE_FAN: 0x0006,
 
   // Blending modes
   // Constants passed to blendFunc() or blendFuncSeparate() to specify the blending mode (for both, RBG and alpha, or separately).
   /** Passed to blendFunc or blendFuncSeparate to turn off a component. */
-  ZERO = 0,
+  ZERO: 0,
   /** Passed to blendFunc or blendFuncSeparate to turn on a component. */
-  ONE = 1,
+  ONE: 1,
   /** Passed to blendFunc or blendFuncSeparate to multiply a component by the source elements color. */
-  SRC_COLOR = 0x0300,
+  SRC_COLOR: 0x0300,
   /** Passed to blendFunc or blendFuncSeparate to multiply a component by one minus the source elements color. */
-  ONE_MINUS_SRC_COLOR = 0x0301,
+  ONE_MINUS_SRC_COLOR: 0x0301,
   /** Passed to blendFunc or blendFuncSeparate to multiply a component by the source's alpha. */
-  SRC_ALPHA = 0x0302,
+  SRC_ALPHA: 0x0302,
   /** Passed to blendFunc or blendFuncSeparate to multiply a component by one minus the source's alpha. */
-  ONE_MINUS_SRC_ALPHA = 0x0303,
+  ONE_MINUS_SRC_ALPHA: 0x0303,
   /** Passed to blendFunc or blendFuncSeparate to multiply a component by the destination's alpha. */
-  DST_ALPHA = 0x0304,
+  DST_ALPHA: 0x0304,
   /** Passed to blendFunc or blendFuncSeparate to multiply a component by one minus the destination's alpha. */
-  ONE_MINUS_DST_ALPHA = 0x0305,
+  ONE_MINUS_DST_ALPHA: 0x0305,
   /** Passed to blendFunc or blendFuncSeparate to multiply a component by the destination's color. */
-  DST_COLOR = 0x0306,
+  DST_COLOR: 0x0306,
   /** Passed to blendFunc or blendFuncSeparate to multiply a component by one minus the destination's color. */
-  ONE_MINUS_DST_COLOR = 0x0307,
+  ONE_MINUS_DST_COLOR: 0x0307,
   /** Passed to blendFunc or blendFuncSeparate to multiply a component by the minimum of source's alpha or one minus the destination's alpha. */
-  SRC_ALPHA_SATURATE = 0x0308,
+  SRC_ALPHA_SATURATE: 0x0308,
   /** Passed to blendFunc or blendFuncSeparate to specify a constant color blend function. */
-  CONSTANT_COLOR = 0x8001,
+  CONSTANT_COLOR: 0x8001,
   /** Passed to blendFunc or blendFuncSeparate to specify one minus a constant color blend function. */
-  ONE_MINUS_CONSTANT_COLOR = 0x8002,
+  ONE_MINUS_CONSTANT_COLOR: 0x8002,
   /** Passed to blendFunc or blendFuncSeparate to specify a constant alpha blend function. */
-  CONSTANT_ALPHA = 0x8003,
+  CONSTANT_ALPHA: 0x8003,
   /** Passed to blendFunc or blendFuncSeparate to specify one minus a constant alpha blend function. */
-  ONE_MINUS_CONSTANT_ALPHA = 0x8004,
+  ONE_MINUS_CONSTANT_ALPHA: 0x8004,
 
   // Blending equations
   // Constants passed to blendEquation() or blendEquationSeparate() to control
@@ -81,413 +80,413 @@ enum GLEnum {
   /** Passed to blendEquation or blendEquationSeparate to set an addition blend function. */
   /** Passed to blendEquation or blendEquationSeparate to specify a subtraction blend function (source - destination). */
   /** Passed to blendEquation or blendEquationSeparate to specify a reverse subtraction blend function (destination - source). */
-  FUNC_ADD = 0x8006,
-  FUNC_SUBTRACT = 0x800a,
-  FUNC_REVERSE_SUBTRACT = 0x800b,
+  FUNC_ADD: 0x8006,
+  FUNC_SUBTRACT: 0x800a,
+  FUNC_REVERSE_SUBTRACT: 0x800b,
 
   // Getting GL parameter information
   // Constants passed to getParameter() to specify what information to return.
 
   /** Passed to getParameter to get the current RGB blend function. */
-  BLEND_EQUATION = 0x8009,
+  BLEND_EQUATION: 0x8009,
   /** Passed to getParameter to get the current RGB blend function. Same as BLEND_EQUATION */
-  BLEND_EQUATION_RGB = 0x8009,
+  BLEND_EQUATION_RGB: 0x8009,
   /** Passed to getParameter to get the current alpha blend function. Same as BLEND_EQUATION */
-  BLEND_EQUATION_ALPHA = 0x883d,
+  BLEND_EQUATION_ALPHA: 0x883d,
   /** Passed to getParameter to get the current destination RGB blend function. */
-  BLEND_DST_RGB = 0x80c8,
+  BLEND_DST_RGB: 0x80c8,
   /** Passed to getParameter to get the current destination RGB blend function. */
-  BLEND_SRC_RGB = 0x80c9,
+  BLEND_SRC_RGB: 0x80c9,
   /** Passed to getParameter to get the current destination alpha blend function. */
-  BLEND_DST_ALPHA = 0x80ca,
+  BLEND_DST_ALPHA: 0x80ca,
   /** Passed to getParameter to get the current source alpha blend function. */
-  BLEND_SRC_ALPHA = 0x80cb,
+  BLEND_SRC_ALPHA: 0x80cb,
 
   /** Passed to getParameter to return a the current blend color. */
-  BLEND_COLOR = 0x8005,
+  BLEND_COLOR: 0x8005,
   /** Passed to getParameter to get the array buffer binding. */
-  ARRAY_BUFFER_BINDING = 0x8894,
+  ARRAY_BUFFER_BINDING: 0x8894,
   /** Passed to getParameter to get the current element array buffer. */
-  ELEMENT_ARRAY_BUFFER_BINDING = 0x8895,
+  ELEMENT_ARRAY_BUFFER_BINDING: 0x8895,
   /** Passed to getParameter to get the current lineWidth (set by the lineWidth method). */
-  LINE_WIDTH = 0x0b21,
+  LINE_WIDTH: 0x0b21,
   /** Passed to getParameter to get the current size of a point drawn with gl.POINTS */
-  ALIASED_POINT_SIZE_RANGE = 0x846d,
+  ALIASED_POINT_SIZE_RANGE: 0x846d,
   /** Passed to getParameter to get the range of available widths for a line. Returns a length-2 array with the lo value at 0, and hight at 1. */
-  ALIASED_LINE_WIDTH_RANGE = 0x846e,
+  ALIASED_LINE_WIDTH_RANGE: 0x846e,
   /** Passed to getParameter to get the current value of cullFace. Should return FRONT, BACK, or FRONT_AND_BACK */
-  CULL_FACE_MODE = 0x0b45,
+  CULL_FACE_MODE: 0x0b45,
   /** Passed to getParameter to determine the current value of frontFace. Should return CW or CCW. */
-  FRONT_FACE = 0x0b46,
+  FRONT_FACE: 0x0b46,
   /** Passed to getParameter to return a length-2 array of floats giving the current depth range. */
-  DEPTH_RANGE = 0x0b70,
+  DEPTH_RANGE: 0x0b70,
   /** Passed to getParameter to determine if the depth write mask is enabled. */
 
-  DEPTH_WRITEMASK = 0x0b72,
+  DEPTH_WRITEMASK: 0x0b72,
   /** Passed to getParameter to determine the current depth clear value. */
-  DEPTH_CLEAR_VALUE = 0x0b73,
+  DEPTH_CLEAR_VALUE: 0x0b73,
   /** Passed to getParameter to get the current depth function. Returns NEVER, ALWAYS, LESS, EQUAL, LEQUAL, GREATER, GEQUAL, or NOTEQUAL. */
-  DEPTH_FUNC = 0x0b74,
+  DEPTH_FUNC: 0x0b74,
   /** Passed to getParameter to get the value the stencil will be cleared to. */
-  STENCIL_CLEAR_VALUE = 0x0b91,
+  STENCIL_CLEAR_VALUE: 0x0b91,
   /** Passed to getParameter to get the current stencil function. Returns NEVER, ALWAYS, LESS, EQUAL, LEQUAL, GREATER, GEQUAL, or NOTEQUAL. */
-  STENCIL_FUNC = 0x0b92,
+  STENCIL_FUNC: 0x0b92,
   /** Passed to getParameter to get the current stencil fail function. Should return KEEP, REPLACE, INCR, DECR, INVERT, INCR_WRAP, or DECR_WRAP. */
-  STENCIL_FAIL = 0x0b94,
+  STENCIL_FAIL: 0x0b94,
   /** Passed to getParameter to get the current stencil fail function should the depth buffer test fail. Should return KEEP, REPLACE, INCR, DECR, INVERT, INCR_WRAP, or DECR_WRAP. */
-  STENCIL_PASS_DEPTH_FAIL = 0x0b95,
+  STENCIL_PASS_DEPTH_FAIL: 0x0b95,
   /** Passed to getParameter to get the current stencil fail function should the depth buffer test pass. Should return KEEP, REPLACE, INCR, DECR, INVERT, INCR_WRAP, or DECR_WRAP. */
-  STENCIL_PASS_DEPTH_PASS = 0x0b96,
+  STENCIL_PASS_DEPTH_PASS: 0x0b96,
   /** Passed to getParameter to get the reference value used for stencil tests. */
-  STENCIL_REF = 0x0b97,
-  STENCIL_VALUE_MASK = 0x0b93,
-  STENCIL_WRITEMASK = 0x0b98,
-  STENCIL_BACK_FUNC = 0x8800,
-  STENCIL_BACK_FAIL = 0x8801,
-  STENCIL_BACK_PASS_DEPTH_FAIL = 0x8802,
-  STENCIL_BACK_PASS_DEPTH_PASS = 0x8803,
-  STENCIL_BACK_REF = 0x8ca3,
-  STENCIL_BACK_VALUE_MASK = 0x8ca4,
-  STENCIL_BACK_WRITEMASK = 0x8ca5,
+  STENCIL_REF: 0x0b97,
+  STENCIL_VALUE_MASK: 0x0b93,
+  STENCIL_WRITEMASK: 0x0b98,
+  STENCIL_BACK_FUNC: 0x8800,
+  STENCIL_BACK_FAIL: 0x8801,
+  STENCIL_BACK_PASS_DEPTH_FAIL: 0x8802,
+  STENCIL_BACK_PASS_DEPTH_PASS: 0x8803,
+  STENCIL_BACK_REF: 0x8ca3,
+  STENCIL_BACK_VALUE_MASK: 0x8ca4,
+  STENCIL_BACK_WRITEMASK: 0x8ca5,
 
   /** An Int32Array with four elements for the current viewport dimensions. */
-  VIEWPORT = 0x0ba2,
+  VIEWPORT: 0x0ba2,
   /** An Int32Array with four elements for the current scissor box dimensions. */
-  SCISSOR_BOX = 0x0c10,
-  COLOR_CLEAR_VALUE = 0x0c22,
-  COLOR_WRITEMASK = 0x0c23,
-  UNPACK_ALIGNMENT = 0x0cf5,
-  PACK_ALIGNMENT = 0x0d05,
-  MAX_TEXTURE_SIZE = 0x0d33,
-  MAX_VIEWPORT_DIMS = 0x0d3a,
-  SUBPIXEL_BITS = 0x0d50,
-  RED_BITS = 0x0d52,
-  GREEN_BITS = 0x0d53,
-  BLUE_BITS = 0x0d54,
-  ALPHA_BITS = 0x0d55,
-  DEPTH_BITS = 0x0d56,
-  STENCIL_BITS = 0x0d57,
-  POLYGON_OFFSET_UNITS = 0x2a00,
-  POLYGON_OFFSET_FACTOR = 0x8038,
-  TEXTURE_BINDING_2D = 0x8069,
-  SAMPLE_BUFFERS = 0x80a8,
-  SAMPLES = 0x80a9,
-  SAMPLE_COVERAGE_VALUE = 0x80aa,
-  SAMPLE_COVERAGE_INVERT = 0x80ab,
-  COMPRESSED_TEXTURE_FORMATS = 0x86a3,
-  VENDOR = 0x1f00,
-  RENDERER = 0x1f01,
-  VERSION = 0x1f02,
-  IMPLEMENTATION_COLOR_READ_TYPE = 0x8b9a,
-  IMPLEMENTATION_COLOR_READ_FORMAT = 0x8b9b,
-  BROWSER_DEFAULT_WEBGL = 0x9244,
+  SCISSOR_BOX: 0x0c10,
+  COLOR_CLEAR_VALUE: 0x0c22,
+  COLOR_WRITEMASK: 0x0c23,
+  UNPACK_ALIGNMENT: 0x0cf5,
+  PACK_ALIGNMENT: 0x0d05,
+  MAX_TEXTURE_SIZE: 0x0d33,
+  MAX_VIEWPORT_DIMS: 0x0d3a,
+  SUBPIXEL_BITS: 0x0d50,
+  RED_BITS: 0x0d52,
+  GREEN_BITS: 0x0d53,
+  BLUE_BITS: 0x0d54,
+  ALPHA_BITS: 0x0d55,
+  DEPTH_BITS: 0x0d56,
+  STENCIL_BITS: 0x0d57,
+  POLYGON_OFFSET_UNITS: 0x2a00,
+  POLYGON_OFFSET_FACTOR: 0x8038,
+  TEXTURE_BINDING_2D: 0x8069,
+  SAMPLE_BUFFERS: 0x80a8,
+  SAMPLES: 0x80a9,
+  SAMPLE_COVERAGE_VALUE: 0x80aa,
+  SAMPLE_COVERAGE_INVERT: 0x80ab,
+  COMPRESSED_TEXTURE_FORMATS: 0x86a3,
+  VENDOR: 0x1f00,
+  RENDERER: 0x1f01,
+  VERSION: 0x1f02,
+  IMPLEMENTATION_COLOR_READ_TYPE: 0x8b9a,
+  IMPLEMENTATION_COLOR_READ_FORMAT: 0x8b9b,
+  BROWSER_DEFAULT_WEBGL: 0x9244,
 
   // Buffers
   // Constants passed to bufferData(), bufferSubData(), bindBuffer(), or
   // getBufferParameter().
 
   /** Passed to bufferData as a hint about whether the contents of the buffer are likely to be used often and not change often. */
-  STATIC_DRAW = 0x88e4,
+  STATIC_DRAW: 0x88e4,
   /** Passed to bufferData as a hint about whether the contents of the buffer are likely to not be used often. */
-  STREAM_DRAW = 0x88e0,
+  STREAM_DRAW: 0x88e0,
   /** Passed to bufferData as a hint about whether the contents of the buffer are likely to be used often and change often. */
-  DYNAMIC_DRAW = 0x88e8,
+  DYNAMIC_DRAW: 0x88e8,
   /** Passed to bindBuffer or bufferData to specify the type of buffer being used. */
-  ARRAY_BUFFER = 0x8892,
+  ARRAY_BUFFER: 0x8892,
   /** Passed to bindBuffer or bufferData to specify the type of buffer being used. */
-  ELEMENT_ARRAY_BUFFER = 0x8893,
+  ELEMENT_ARRAY_BUFFER: 0x8893,
   /** Passed to getBufferParameter to get a buffer's size. */
-  BUFFER_SIZE = 0x8764,
+  BUFFER_SIZE: 0x8764,
   /** Passed to getBufferParameter to get the hint for the buffer passed in when it was created. */
-  BUFFER_USAGE = 0x8765,
+  BUFFER_USAGE: 0x8765,
 
   // Vertex attributes
   // Constants passed to getVertexAttrib().
 
   /** Passed to getVertexAttrib to read back the current vertex attribute. */
-  CURRENT_VERTEX_ATTRIB = 0x8626,
-  VERTEX_ATTRIB_ARRAY_ENABLED = 0x8622,
-  VERTEX_ATTRIB_ARRAY_SIZE = 0x8623,
-  VERTEX_ATTRIB_ARRAY_STRIDE = 0x8624,
-  VERTEX_ATTRIB_ARRAY_TYPE = 0x8625,
-  VERTEX_ATTRIB_ARRAY_NORMALIZED = 0x886a,
-  VERTEX_ATTRIB_ARRAY_POINTER = 0x8645,
-  VERTEX_ATTRIB_ARRAY_BUFFER_BINDING = 0x889f,
+  CURRENT_VERTEX_ATTRIB: 0x8626,
+  VERTEX_ATTRIB_ARRAY_ENABLED: 0x8622,
+  VERTEX_ATTRIB_ARRAY_SIZE: 0x8623,
+  VERTEX_ATTRIB_ARRAY_STRIDE: 0x8624,
+  VERTEX_ATTRIB_ARRAY_TYPE: 0x8625,
+  VERTEX_ATTRIB_ARRAY_NORMALIZED: 0x886a,
+  VERTEX_ATTRIB_ARRAY_POINTER: 0x8645,
+  VERTEX_ATTRIB_ARRAY_BUFFER_BINDING: 0x889f,
 
   // Culling
   // Constants passed to cullFace().
 
   /** Passed to enable/disable to turn on/off culling. Can also be used with getParameter to find the current culling method. */
-  CULL_FACE = 0x0b44,
+  CULL_FACE: 0x0b44,
   /** Passed to cullFace to specify that only front faces should be culled. */
-  FRONT = 0x0404,
+  FRONT: 0x0404,
   /** Passed to cullFace to specify that only back faces should be culled. */
-  BACK = 0x0405,
+  BACK: 0x0405,
   /** Passed to cullFace to specify that front and back faces should be culled. */
-  FRONT_AND_BACK = 0x0408,
+  FRONT_AND_BACK: 0x0408,
 
   // Enabling and disabling
   // Constants passed to enable() or disable().
 
   /** Passed to enable/disable to turn on/off blending. Can also be used with getParameter to find the current blending method. */
-  BLEND = 0x0be2,
+  BLEND: 0x0be2,
   /** Passed to enable/disable to turn on/off the depth test. Can also be used with getParameter to query the depth test. */
-  DEPTH_TEST = 0x0b71,
+  DEPTH_TEST: 0x0b71,
   /** Passed to enable/disable to turn on/off dithering. Can also be used with getParameter to find the current dithering method. */
-  DITHER = 0x0bd0,
+  DITHER: 0x0bd0,
   /** Passed to enable/disable to turn on/off the polygon offset. Useful for rendering hidden-line images, decals, and or solids with highlighted edges. Can also be used with getParameter to query the scissor test. */
-  POLYGON_OFFSET_FILL = 0x8037,
+  POLYGON_OFFSET_FILL: 0x8037,
   /** Passed to enable/disable to turn on/off the alpha to coverage. Used in multi-sampling alpha channels. */
-  SAMPLE_ALPHA_TO_COVERAGE = 0x809e,
+  SAMPLE_ALPHA_TO_COVERAGE: 0x809e,
   /** Passed to enable/disable to turn on/off the sample coverage. Used in multi-sampling. */
-  SAMPLE_COVERAGE = 0x80a0,
+  SAMPLE_COVERAGE: 0x80a0,
   /** Passed to enable/disable to turn on/off the scissor test. Can also be used with getParameter to query the scissor test. */
-  SCISSOR_TEST = 0x0c11,
+  SCISSOR_TEST: 0x0c11,
   /** Passed to enable/disable to turn on/off the stencil test. Can also be used with getParameter to query the stencil test. */
-  STENCIL_TEST = 0x0b90,
+  STENCIL_TEST: 0x0b90,
 
   // Errors
   // Constants returned from getError().
 
   /** Returned from getError(). */
-  NO_ERROR = 0,
+  NO_ERROR: 0,
   /** Returned from getError(). */
-  INVALID_ENUM = 0x0500,
+  INVALID_ENUM: 0x0500,
   /** Returned from getError(). */
-  INVALID_VALUE = 0x0501,
+  INVALID_VALUE: 0x0501,
   /** Returned from getError(). */
-  INVALID_OPERATION = 0x0502,
+  INVALID_OPERATION: 0x0502,
   /** Returned from getError(). */
-  OUT_OF_MEMORY = 0x0505,
+  OUT_OF_MEMORY: 0x0505,
   /** Returned from getError(). */
-  CONTEXT_LOST_WEBGL = 0x9242,
+  CONTEXT_LOST_WEBGL: 0x9242,
 
   // Front face directions
   // Constants passed to frontFace().
 
   /** Passed to frontFace to specify the front face of a polygon is drawn in the clockwise direction */
-  CW = 0x0900,
+  CW: 0x0900,
   /** Passed to frontFace to specify the front face of a polygon is drawn in the counter clockwise direction */
-  CCW = 0x0901,
+  CCW: 0x0901,
 
   // Hints
   // Constants passed to hint()
 
   /** There is no preference for this behavior. */
-  DONT_CARE = 0x1100,
+  DONT_CARE: 0x1100,
   /** The most efficient behavior should be used. */
-  FASTEST = 0x1101,
+  FASTEST: 0x1101,
   /** The most correct or the highest quality option should be used. */
-  NICEST = 0x1102,
+  NICEST: 0x1102,
   /** Hint for the quality of filtering when generating mipmap images with WebGLRenderingContext.generateMipmap(). */
-  GENERATE_MIPMAP_HINT = 0x8192,
+  GENERATE_MIPMAP_HINT: 0x8192,
 
   // Data types
 
-  BYTE = 0x1400,
-  UNSIGNED_BYTE = 0x1401,
-  SHORT = 0x1402,
-  UNSIGNED_SHORT = 0x1403,
-  INT = 0x1404,
-  UNSIGNED_INT = 0x1405,
-  FLOAT = 0x1406,
-  DOUBLE = 0x140a,
+  BYTE: 0x1400,
+  UNSIGNED_BYTE: 0x1401,
+  SHORT: 0x1402,
+  UNSIGNED_SHORT: 0x1403,
+  INT: 0x1404,
+  UNSIGNED_INT: 0x1405,
+  FLOAT: 0x1406,
+  DOUBLE: 0x140a,
 
   // Pixel formats
 
-  DEPTH_COMPONENT = 0x1902,
-  ALPHA = 0x1906,
-  RGB = 0x1907,
-  RGBA = 0x1908,
-  LUMINANCE = 0x1909,
-  LUMINANCE_ALPHA = 0x190a,
+  DEPTH_COMPONENT: 0x1902,
+  ALPHA: 0x1906,
+  RGB: 0x1907,
+  RGBA: 0x1908,
+  LUMINANCE: 0x1909,
+  LUMINANCE_ALPHA: 0x190a,
 
   // Pixel types
 
   // UNSIGNED_BYTE = 0x1401,
-  UNSIGNED_SHORT_4_4_4_4 = 0x8033,
-  UNSIGNED_SHORT_5_5_5_1 = 0x8034,
-  UNSIGNED_SHORT_5_6_5 = 0x8363,
+  UNSIGNED_SHORT_4_4_4_4: 0x8033,
+  UNSIGNED_SHORT_5_5_5_1: 0x8034,
+  UNSIGNED_SHORT_5_6_5: 0x8363,
 
   // Shaders
   // Constants passed to createShader() or getShaderParameter()
 
   /** Passed to createShader to define a fragment shader. */
-  FRAGMENT_SHADER = 0x8b30,
+  FRAGMENT_SHADER: 0x8b30,
   /** Passed to createShader to define a vertex shader */
-  VERTEX_SHADER = 0x8b31,
+  VERTEX_SHADER: 0x8b31,
   /** Passed to getShaderParameter to get the status of the compilation. Returns false if the shader was not compiled. You can then query getShaderInfoLog to find the exact error */
-  COMPILE_STATUS = 0x8b81,
+  COMPILE_STATUS: 0x8b81,
   /** Passed to getShaderParameter to determine if a shader was deleted via deleteShader. Returns true if it was, false otherwise. */
-  DELETE_STATUS = 0x8b80,
+  DELETE_STATUS: 0x8b80,
   /** Passed to getProgramParameter after calling linkProgram to determine if a program was linked correctly. Returns false if there were errors. Use getProgramInfoLog to find the exact error. */
-  LINK_STATUS = 0x8b82,
+  LINK_STATUS: 0x8b82,
   /** Passed to getProgramParameter after calling validateProgram to determine if it is valid. Returns false if errors were found. */
-  VALIDATE_STATUS = 0x8b83,
+  VALIDATE_STATUS: 0x8b83,
   /** Passed to getProgramParameter after calling attachShader to determine if the shader was attached correctly. Returns false if errors occurred. */
-  ATTACHED_SHADERS = 0x8b85,
+  ATTACHED_SHADERS: 0x8b85,
   /** Passed to getProgramParameter to get the number of attributes active in a program. */
-  ACTIVE_ATTRIBUTES = 0x8b89,
+  ACTIVE_ATTRIBUTES: 0x8b89,
   /** Passed to getProgramParameter to get the number of uniforms active in a program. */
-  ACTIVE_UNIFORMS = 0x8b86,
+  ACTIVE_UNIFORMS: 0x8b86,
   /** The maximum number of entries possible in the vertex attribute list. */
-  MAX_VERTEX_ATTRIBS = 0x8869,
-  MAX_VERTEX_UNIFORM_VECTORS = 0x8dfb,
-  MAX_VARYING_VECTORS = 0x8dfc,
-  MAX_COMBINED_TEXTURE_IMAGE_UNITS = 0x8b4d,
-  MAX_VERTEX_TEXTURE_IMAGE_UNITS = 0x8b4c,
+  MAX_VERTEX_ATTRIBS: 0x8869,
+  MAX_VERTEX_UNIFORM_VECTORS: 0x8dfb,
+  MAX_VARYING_VECTORS: 0x8dfc,
+  MAX_COMBINED_TEXTURE_IMAGE_UNITS: 0x8b4d,
+  MAX_VERTEX_TEXTURE_IMAGE_UNITS: 0x8b4c,
   /** Implementation dependent number of maximum texture units. At least 8. */
-  MAX_TEXTURE_IMAGE_UNITS = 0x8872,
-  MAX_FRAGMENT_UNIFORM_VECTORS = 0x8dfd,
-  SHADER_TYPE = 0x8b4f,
-  SHADING_LANGUAGE_VERSION = 0x8b8c,
-  CURRENT_PROGRAM = 0x8b8d,
+  MAX_TEXTURE_IMAGE_UNITS: 0x8872,
+  MAX_FRAGMENT_UNIFORM_VECTORS: 0x8dfd,
+  SHADER_TYPE: 0x8b4f,
+  SHADING_LANGUAGE_VERSION: 0x8b8c,
+  CURRENT_PROGRAM: 0x8b8d,
 
   // Depth or stencil tests
   // Constants passed to depthFunc() or stencilFunc().
 
   /** Passed to depthFunction or stencilFunction to specify depth or stencil tests will never pass, i.e., nothing will be drawn. */
-  NEVER = 0x0200,
+  NEVER: 0x0200,
   /** Passed to depthFunction or stencilFunction to specify depth or stencil tests will pass if the new depth value is less than the stored value. */
-  LESS = 0x0201,
+  LESS: 0x0201,
   /** Passed to depthFunction or stencilFunction to specify depth or stencil tests will pass if the new depth value is equals to the stored value. */
-  EQUAL = 0x0202,
+  EQUAL: 0x0202,
   /** Passed to depthFunction or stencilFunction to specify depth or stencil tests will pass if the new depth value is less than or equal to the stored value. */
-  LEQUAL = 0x0203,
+  LEQUAL: 0x0203,
   /** Passed to depthFunction or stencilFunction to specify depth or stencil tests will pass if the new depth value is greater than the stored value. */
-  GREATER = 0x0204,
+  GREATER: 0x0204,
   /** Passed to depthFunction or stencilFunction to specify depth or stencil tests will pass if the new depth value is not equal to the stored value. */
-  NOTEQUAL = 0x0205,
+  NOTEQUAL: 0x0205,
   /** Passed to depthFunction or stencilFunction to specify depth or stencil tests will pass if the new depth value is greater than or equal to the stored value. */
-  GEQUAL = 0x0206,
+  GEQUAL: 0x0206,
   /** Passed to depthFunction or stencilFunction to specify depth or stencil tests will always pass, i.e., pixels will be drawn in the order they are drawn. */
-  ALWAYS = 0x0207,
+  ALWAYS: 0x0207,
 
   // Stencil actions
   // Constants passed to stencilOp().
 
-  KEEP = 0x1e00,
-  REPLACE = 0x1e01,
-  INCR = 0x1e02,
-  DECR = 0x1e03,
-  INVERT = 0x150a,
-  INCR_WRAP = 0x8507,
-  DECR_WRAP = 0x8508,
+  KEEP: 0x1e00,
+  REPLACE: 0x1e01,
+  INCR: 0x1e02,
+  DECR: 0x1e03,
+  INVERT: 0x150a,
+  INCR_WRAP: 0x8507,
+  DECR_WRAP: 0x8508,
 
   // Textures
   // Constants passed to texParameteri(),
   // texParameterf(), bindTexture(), texImage2D(), and others.
 
-  NEAREST = 0x2600,
-  LINEAR = 0x2601,
-  NEAREST_MIPMAP_NEAREST = 0x2700,
-  LINEAR_MIPMAP_NEAREST = 0x2701,
-  NEAREST_MIPMAP_LINEAR = 0x2702,
-  LINEAR_MIPMAP_LINEAR = 0x2703,
+  NEAREST: 0x2600,
+  LINEAR: 0x2601,
+  NEAREST_MIPMAP_NEAREST: 0x2700,
+  LINEAR_MIPMAP_NEAREST: 0x2701,
+  NEAREST_MIPMAP_LINEAR: 0x2702,
+  LINEAR_MIPMAP_LINEAR: 0x2703,
   /** The texture magnification function is used when the pixel being textured maps to an area less than or equal to one texture element. It sets the texture magnification function to either GL_NEAREST or GL_LINEAR (see below). GL_NEAREST is generally faster than GL_LINEAR, but it can produce textured images with sharper edges because the transition between texture elements is not as smooth. Default: GL_LINEAR.  */
-  TEXTURE_MAG_FILTER = 0x2800,
+  TEXTURE_MAG_FILTER: 0x2800,
   /** The texture minifying function is used whenever the pixel being textured maps to an area greater than one texture element. There are six defined minifying functions. Two of them use the nearest one or nearest four texture elements to compute the texture value. The other four use mipmaps. Default: GL_NEAREST_MIPMAP_LINEAR */
-  TEXTURE_MIN_FILTER = 0x2801,
+  TEXTURE_MIN_FILTER: 0x2801,
   /** Sets the wrap parameter for texture coordinate  to either GL_CLAMP_TO_EDGE, GL_MIRRORED_REPEAT, or GL_REPEAT. G */
-  TEXTURE_WRAP_S = 0x2802,
+  TEXTURE_WRAP_S: 0x2802,
   /** Sets the wrap parameter for texture coordinate  to either GL_CLAMP_TO_EDGE, GL_MIRRORED_REPEAT, or GL_REPEAT. G */
-  TEXTURE_WRAP_T = 0x2803,
-  TEXTURE_2D = 0x0de1,
-  TEXTURE = 0x1702,
-  TEXTURE_CUBE_MAP = 0x8513,
-  TEXTURE_BINDING_CUBE_MAP = 0x8514,
-  TEXTURE_CUBE_MAP_POSITIVE_X = 0x8515,
-  TEXTURE_CUBE_MAP_NEGATIVE_X = 0x8516,
-  TEXTURE_CUBE_MAP_POSITIVE_Y = 0x8517,
-  TEXTURE_CUBE_MAP_NEGATIVE_Y = 0x8518,
-  TEXTURE_CUBE_MAP_POSITIVE_Z = 0x8519,
-  TEXTURE_CUBE_MAP_NEGATIVE_Z = 0x851a,
-  MAX_CUBE_MAP_TEXTURE_SIZE = 0x851c,
+  TEXTURE_WRAP_T: 0x2803,
+  TEXTURE_2D: 0x0de1,
+  TEXTURE: 0x1702,
+  TEXTURE_CUBE_MAP: 0x8513,
+  TEXTURE_BINDING_CUBE_MAP: 0x8514,
+  TEXTURE_CUBE_MAP_POSITIVE_X: 0x8515,
+  TEXTURE_CUBE_MAP_NEGATIVE_X: 0x8516,
+  TEXTURE_CUBE_MAP_POSITIVE_Y: 0x8517,
+  TEXTURE_CUBE_MAP_NEGATIVE_Y: 0x8518,
+  TEXTURE_CUBE_MAP_POSITIVE_Z: 0x8519,
+  TEXTURE_CUBE_MAP_NEGATIVE_Z: 0x851a,
+  MAX_CUBE_MAP_TEXTURE_SIZE: 0x851c,
   // TEXTURE0 - 31 0x84C0 - 0x84DF A texture unit.
-  TEXTURE0 = 0x84c0,
-  ACTIVE_TEXTURE = 0x84e0,
-  REPEAT = 0x2901,
-  CLAMP_TO_EDGE = 0x812f,
-  MIRRORED_REPEAT = 0x8370,
+  TEXTURE0: 0x84c0,
+  ACTIVE_TEXTURE: 0x84e0,
+  REPEAT: 0x2901,
+  CLAMP_TO_EDGE: 0x812f,
+  MIRRORED_REPEAT: 0x8370,
 
   // Emulation
-  TEXTURE_WIDTH = 0x1000,
-  TEXTURE_HEIGHT = 0x1001,
+  TEXTURE_WIDTH: 0x1000,
+  TEXTURE_HEIGHT: 0x1001,
 
   // Uniform types
 
-  FLOAT_VEC2 = 0x8b50,
-  FLOAT_VEC3 = 0x8b51,
-  FLOAT_VEC4 = 0x8b52,
-  INT_VEC2 = 0x8b53,
-  INT_VEC3 = 0x8b54,
-  INT_VEC4 = 0x8b55,
-  BOOL = 0x8b56,
-  BOOL_VEC2 = 0x8b57,
-  BOOL_VEC3 = 0x8b58,
-  BOOL_VEC4 = 0x8b59,
-  FLOAT_MAT2 = 0x8b5a,
-  FLOAT_MAT3 = 0x8b5b,
-  FLOAT_MAT4 = 0x8b5c,
-  SAMPLER_2D = 0x8b5e,
-  SAMPLER_CUBE = 0x8b60,
+  FLOAT_VEC2: 0x8b50,
+  FLOAT_VEC3: 0x8b51,
+  FLOAT_VEC4: 0x8b52,
+  INT_VEC2: 0x8b53,
+  INT_VEC3: 0x8b54,
+  INT_VEC4: 0x8b55,
+  BOOL: 0x8b56,
+  BOOL_VEC2: 0x8b57,
+  BOOL_VEC3: 0x8b58,
+  BOOL_VEC4: 0x8b59,
+  FLOAT_MAT2: 0x8b5a,
+  FLOAT_MAT3: 0x8b5b,
+  FLOAT_MAT4: 0x8b5c,
+  SAMPLER_2D: 0x8b5e,
+  SAMPLER_CUBE: 0x8b60,
 
   // Shader precision-specified types
 
-  LOW_FLOAT = 0x8df0,
-  MEDIUM_FLOAT = 0x8df1,
-  HIGH_FLOAT = 0x8df2,
-  LOW_INT = 0x8df3,
-  MEDIUM_INT = 0x8df4,
-  HIGH_INT = 0x8df5,
+  LOW_FLOAT: 0x8df0,
+  MEDIUM_FLOAT: 0x8df1,
+  HIGH_FLOAT: 0x8df2,
+  LOW_INT: 0x8df3,
+  MEDIUM_INT: 0x8df4,
+  HIGH_INT: 0x8df5,
 
   // Framebuffers and renderbuffers
 
-  FRAMEBUFFER = 0x8d40,
-  RENDERBUFFER = 0x8d41,
-  RGBA4 = 0x8056,
-  RGB5_A1 = 0x8057,
-  RGB565 = 0x8d62,
-  DEPTH_COMPONENT16 = 0x81a5,
-  STENCIL_INDEX = 0x1901,
-  STENCIL_INDEX8 = 0x8d48,
-  DEPTH_STENCIL = 0x84f9,
-  RENDERBUFFER_WIDTH = 0x8d42,
-  RENDERBUFFER_HEIGHT = 0x8d43,
-  RENDERBUFFER_INTERNAL_FORMAT = 0x8d44,
-  RENDERBUFFER_RED_SIZE = 0x8d50,
-  RENDERBUFFER_GREEN_SIZE = 0x8d51,
-  RENDERBUFFER_BLUE_SIZE = 0x8d52,
-  RENDERBUFFER_ALPHA_SIZE = 0x8d53,
-  RENDERBUFFER_DEPTH_SIZE = 0x8d54,
-  RENDERBUFFER_STENCIL_SIZE = 0x8d55,
-  FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE = 0x8cd0,
-  FRAMEBUFFER_ATTACHMENT_OBJECT_NAME = 0x8cd1,
-  FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL = 0x8cd2,
-  FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE = 0x8cd3,
-  COLOR_ATTACHMENT0 = 0x8ce0,
-  DEPTH_ATTACHMENT = 0x8d00,
-  STENCIL_ATTACHMENT = 0x8d20,
-  DEPTH_STENCIL_ATTACHMENT = 0x821a,
-  NONE = 0,
-  FRAMEBUFFER_COMPLETE = 0x8cd5,
-  FRAMEBUFFER_INCOMPLETE_ATTACHMENT = 0x8cd6,
-  FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT = 0x8cd7,
-  FRAMEBUFFER_INCOMPLETE_DIMENSIONS = 0x8cd9,
-  FRAMEBUFFER_UNSUPPORTED = 0x8cdd,
-  FRAMEBUFFER_BINDING = 0x8ca6,
-  RENDERBUFFER_BINDING = 0x8ca7,
-  READ_FRAMEBUFFER = 0x8ca8,
-  DRAW_FRAMEBUFFER = 0x8ca9,
-  MAX_RENDERBUFFER_SIZE = 0x84e8,
-  INVALID_FRAMEBUFFER_OPERATION = 0x0506,
+  FRAMEBUFFER: 0x8d40,
+  RENDERBUFFER: 0x8d41,
+  RGBA4: 0x8056,
+  RGB5_A1: 0x8057,
+  RGB565: 0x8d62,
+  DEPTH_COMPONENT16: 0x81a5,
+  STENCIL_INDEX: 0x1901,
+  STENCIL_INDEX8: 0x8d48,
+  DEPTH_STENCIL: 0x84f9,
+  RENDERBUFFER_WIDTH: 0x8d42,
+  RENDERBUFFER_HEIGHT: 0x8d43,
+  RENDERBUFFER_INTERNAL_FORMAT: 0x8d44,
+  RENDERBUFFER_RED_SIZE: 0x8d50,
+  RENDERBUFFER_GREEN_SIZE: 0x8d51,
+  RENDERBUFFER_BLUE_SIZE: 0x8d52,
+  RENDERBUFFER_ALPHA_SIZE: 0x8d53,
+  RENDERBUFFER_DEPTH_SIZE: 0x8d54,
+  RENDERBUFFER_STENCIL_SIZE: 0x8d55,
+  FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE: 0x8cd0,
+  FRAMEBUFFER_ATTACHMENT_OBJECT_NAME: 0x8cd1,
+  FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL: 0x8cd2,
+  FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE: 0x8cd3,
+  COLOR_ATTACHMENT0: 0x8ce0,
+  DEPTH_ATTACHMENT: 0x8d00,
+  STENCIL_ATTACHMENT: 0x8d20,
+  DEPTH_STENCIL_ATTACHMENT: 0x821a,
+  NONE: 0,
+  FRAMEBUFFER_COMPLETE: 0x8cd5,
+  FRAMEBUFFER_INCOMPLETE_ATTACHMENT: 0x8cd6,
+  FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT: 0x8cd7,
+  FRAMEBUFFER_INCOMPLETE_DIMENSIONS: 0x8cd9,
+  FRAMEBUFFER_UNSUPPORTED: 0x8cdd,
+  FRAMEBUFFER_BINDING: 0x8ca6,
+  RENDERBUFFER_BINDING: 0x8ca7,
+  READ_FRAMEBUFFER: 0x8ca8,
+  DRAW_FRAMEBUFFER: 0x8ca9,
+  MAX_RENDERBUFFER_SIZE: 0x84e8,
+  INVALID_FRAMEBUFFER_OPERATION: 0x0506,
 
   // Pixel storage modes
   // Constants passed to pixelStorei().
 
-  UNPACK_FLIP_Y_WEBGL = 0x9240,
-  UNPACK_PREMULTIPLY_ALPHA_WEBGL = 0x9241,
-  UNPACK_COLORSPACE_CONVERSION_WEBGL = 0x9243,
+  UNPACK_FLIP_Y_WEBGL: 0x9240,
+  UNPACK_PREMULTIPLY_ALPHA_WEBGL: 0x9241,
+  UNPACK_COLORSPACE_CONVERSION_WEBGL: 0x9243,
 
   // Additional constants defined WebGL 2
   // These constants are defined on the WebGL2RenderingContext interface.
@@ -497,555 +496,561 @@ enum GLEnum {
   // Constants passed to getParameter()
   // to specify what information to return.
 
-  READ_BUFFER = 0x0c02,
-  UNPACK_ROW_LENGTH = 0x0cf2,
-  UNPACK_SKIP_ROWS = 0x0cf3,
-  UNPACK_SKIP_PIXELS = 0x0cf4,
-  PACK_ROW_LENGTH = 0x0d02,
-  PACK_SKIP_ROWS = 0x0d03,
-  PACK_SKIP_PIXELS = 0x0d04,
-  TEXTURE_BINDING_3D = 0x806a,
-  UNPACK_SKIP_IMAGES = 0x806d,
-  UNPACK_IMAGE_HEIGHT = 0x806e,
-  MAX_3D_TEXTURE_SIZE = 0x8073,
-  MAX_ELEMENTS_VERTICES = 0x80e8,
-  MAX_ELEMENTS_INDICES = 0x80e9,
-  MAX_TEXTURE_LOD_BIAS = 0x84fd,
-  MAX_FRAGMENT_UNIFORM_COMPONENTS = 0x8b49,
-  MAX_VERTEX_UNIFORM_COMPONENTS = 0x8b4a,
-  MAX_ARRAY_TEXTURE_LAYERS = 0x88ff,
-  MIN_PROGRAM_TEXEL_OFFSET = 0x8904,
-  MAX_PROGRAM_TEXEL_OFFSET = 0x8905,
-  MAX_VARYING_COMPONENTS = 0x8b4b,
-  FRAGMENT_SHADER_DERIVATIVE_HINT = 0x8b8b,
-  RASTERIZER_DISCARD = 0x8c89,
-  VERTEX_ARRAY_BINDING = 0x85b5,
-  MAX_VERTEX_OUTPUT_COMPONENTS = 0x9122,
-  MAX_FRAGMENT_INPUT_COMPONENTS = 0x9125,
-  MAX_SERVER_WAIT_TIMEOUT = 0x9111,
-  MAX_ELEMENT_INDEX = 0x8d6b,
+  READ_BUFFER: 0x0c02,
+  UNPACK_ROW_LENGTH: 0x0cf2,
+  UNPACK_SKIP_ROWS: 0x0cf3,
+  UNPACK_SKIP_PIXELS: 0x0cf4,
+  PACK_ROW_LENGTH: 0x0d02,
+  PACK_SKIP_ROWS: 0x0d03,
+  PACK_SKIP_PIXELS: 0x0d04,
+  TEXTURE_BINDING_3D: 0x806a,
+  UNPACK_SKIP_IMAGES: 0x806d,
+  UNPACK_IMAGE_HEIGHT: 0x806e,
+  MAX_3D_TEXTURE_SIZE: 0x8073,
+  MAX_ELEMENTS_VERTICES: 0x80e8,
+  MAX_ELEMENTS_INDICES: 0x80e9,
+  MAX_TEXTURE_LOD_BIAS: 0x84fd,
+  MAX_FRAGMENT_UNIFORM_COMPONENTS: 0x8b49,
+  MAX_VERTEX_UNIFORM_COMPONENTS: 0x8b4a,
+  MAX_ARRAY_TEXTURE_LAYERS: 0x88ff,
+  MIN_PROGRAM_TEXEL_OFFSET: 0x8904,
+  MAX_PROGRAM_TEXEL_OFFSET: 0x8905,
+  MAX_VARYING_COMPONENTS: 0x8b4b,
+  FRAGMENT_SHADER_DERIVATIVE_HINT: 0x8b8b,
+  RASTERIZER_DISCARD: 0x8c89,
+  VERTEX_ARRAY_BINDING: 0x85b5,
+  MAX_VERTEX_OUTPUT_COMPONENTS: 0x9122,
+  MAX_FRAGMENT_INPUT_COMPONENTS: 0x9125,
+  MAX_SERVER_WAIT_TIMEOUT: 0x9111,
+  MAX_ELEMENT_INDEX: 0x8d6b,
 
   // Textures
   // Constants passed to texParameteri(),
   // texParameterf(), bindTexture(), texImage2D(), and others.
 
-  RED = 0x1903,
-  RGB8 = 0x8051,
-  RGBA8 = 0x8058,
-  RGB10_A2 = 0x8059,
-  TEXTURE_3D = 0x806f,
+  RED: 0x1903,
+  RGB8: 0x8051,
+  RGBA8: 0x8058,
+  RGB10_A2: 0x8059,
+  TEXTURE_3D: 0x806f,
   /** Sets the wrap parameter for texture coordinate  to either GL_CLAMP_TO_EDGE, GL_MIRRORED_REPEAT, or GL_REPEAT. G */
-  TEXTURE_WRAP_R = 0x8072,
-  TEXTURE_MIN_LOD = 0x813a,
-  TEXTURE_MAX_LOD = 0x813b,
-  TEXTURE_BASE_LEVEL = 0x813c,
-  TEXTURE_MAX_LEVEL = 0x813d,
-  TEXTURE_COMPARE_MODE = 0x884c,
-  TEXTURE_COMPARE_FUNC = 0x884d,
-  SRGB = 0x8c40,
-  SRGB8 = 0x8c41,
-  SRGB8_ALPHA8 = 0x8c43,
-  COMPARE_REF_TO_TEXTURE = 0x884e,
-  RGBA32F = 0x8814,
-  RGB32F = 0x8815,
-  RGBA16F = 0x881a,
-  RGB16F = 0x881b,
-  TEXTURE_2D_ARRAY = 0x8c1a,
-  TEXTURE_BINDING_2D_ARRAY = 0x8c1d,
-  R11F_G11F_B10F = 0x8c3a,
-  RGB9_E5 = 0x8c3d,
-  RGBA32UI = 0x8d70,
-  RGB32UI = 0x8d71,
-  RGBA16UI = 0x8d76,
-  RGB16UI = 0x8d77,
-  RGBA8UI = 0x8d7c,
-  RGB8UI = 0x8d7d,
-  RGBA32I = 0x8d82,
-  RGB32I = 0x8d83,
-  RGBA16I = 0x8d88,
-  RGB16I = 0x8d89,
-  RGBA8I = 0x8d8e,
-  RGB8I = 0x8d8f,
-  RED_INTEGER = 0x8d94,
-  RGB_INTEGER = 0x8d98,
-  RGBA_INTEGER = 0x8d99,
-  R8 = 0x8229,
-  RG8 = 0x822b,
-  R16F = 0x822d,
-  R32F = 0x822e,
-  RG16F = 0x822f,
-  RG32F = 0x8230,
-  R8I = 0x8231,
-  R8UI = 0x8232,
-  R16I = 0x8233,
-  R16UI = 0x8234,
-  R32I = 0x8235,
-  R32UI = 0x8236,
-  RG8I = 0x8237,
-  RG8UI = 0x8238,
-  RG16I = 0x8239,
-  RG16UI = 0x823a,
-  RG32I = 0x823b,
-  RG32UI = 0x823c,
-  R8_SNORM = 0x8f94,
-  RG8_SNORM = 0x8f95,
-  RGB8_SNORM = 0x8f96,
-  RGBA8_SNORM = 0x8f97,
-  RGB10_A2UI = 0x906f,
+  TEXTURE_WRAP_R: 0x8072,
+  TEXTURE_MIN_LOD: 0x813a,
+  TEXTURE_MAX_LOD: 0x813b,
+  TEXTURE_BASE_LEVEL: 0x813c,
+  TEXTURE_MAX_LEVEL: 0x813d,
+  TEXTURE_COMPARE_MODE: 0x884c,
+  TEXTURE_COMPARE_FUNC: 0x884d,
+  SRGB: 0x8c40,
+  SRGB8: 0x8c41,
+  SRGB8_ALPHA8: 0x8c43,
+  COMPARE_REF_TO_TEXTURE: 0x884e,
+  RGBA32F: 0x8814,
+  RGB32F: 0x8815,
+  RGBA16F: 0x881a,
+  RGB16F: 0x881b,
+  TEXTURE_2D_ARRAY: 0x8c1a,
+  TEXTURE_BINDING_2D_ARRAY: 0x8c1d,
+  R11F_G11F_B10F: 0x8c3a,
+  RGB9_E5: 0x8c3d,
+  RGBA32UI: 0x8d70,
+  RGB32UI: 0x8d71,
+  RGBA16UI: 0x8d76,
+  RGB16UI: 0x8d77,
+  RGBA8UI: 0x8d7c,
+  RGB8UI: 0x8d7d,
+  RGBA32I: 0x8d82,
+  RGB32I: 0x8d83,
+  RGBA16I: 0x8d88,
+  RGB16I: 0x8d89,
+  RGBA8I: 0x8d8e,
+  RGB8I: 0x8d8f,
+  RED_INTEGER: 0x8d94,
+  RGB_INTEGER: 0x8d98,
+  RGBA_INTEGER: 0x8d99,
+  R8: 0x8229,
+  RG8: 0x822b,
+  R16F: 0x822d,
+  R32F: 0x822e,
+  RG16F: 0x822f,
+  RG32F: 0x8230,
+  R8I: 0x8231,
+  R8UI: 0x8232,
+  R16I: 0x8233,
+  R16UI: 0x8234,
+  R32I: 0x8235,
+  R32UI: 0x8236,
+  RG8I: 0x8237,
+  RG8UI: 0x8238,
+  RG16I: 0x8239,
+  RG16UI: 0x823a,
+  RG32I: 0x823b,
+  RG32UI: 0x823c,
+  R8_SNORM: 0x8f94,
+  RG8_SNORM: 0x8f95,
+  RGB8_SNORM: 0x8f96,
+  RGBA8_SNORM: 0x8f97,
+  RGB10_A2UI: 0x906f,
 
   /* covered by extension
   COMPRESSED_R11_EAC  = 0x9270,
-  COMPRESSED_SIGNED_R11_EAC = 0x9271,
-  COMPRESSED_RG11_EAC = 0x9272,
+  COMPRESSED_SIGNED_R11_EAC  = 0x9271,
+  COMPRESSED_RG11_EAC  = 0x9272,
   COMPRESSED_SIGNED_RG11_EAC  = 0x9273,
   COMPRESSED_RGB8_ETC2  = 0x9274,
-  COMPRESSED_SRGB8_ETC2 = 0x9275,
+  COMPRESSED_SRGB8_ETC2  = 0x9275,
   COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2  = 0x9276,
   COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC  = 0x9277,
-  COMPRESSED_RGBA8_ETC2_EAC = 0x9278,
+  COMPRESSED_RGBA8_ETC2_EAC  = 0x9278,
   COMPRESSED_SRGB8_ALPHA8_ETC2_EAC  = 0x9279,
   */
-  TEXTURE_IMMUTABLE_FORMAT = 0x912f,
-  TEXTURE_IMMUTABLE_LEVELS = 0x82df,
+  TEXTURE_IMMUTABLE_FORMAT: 0x912f,
+  TEXTURE_IMMUTABLE_LEVELS: 0x82df,
 
   // Pixel types
 
-  UNSIGNED_INT_2_10_10_10_REV = 0x8368,
-  UNSIGNED_INT_10F_11F_11F_REV = 0x8c3b,
-  UNSIGNED_INT_5_9_9_9_REV = 0x8c3e,
-  FLOAT_32_UNSIGNED_INT_24_8_REV = 0x8dad,
-  UNSIGNED_INT_24_8 = 0x84fa,
-  HALF_FLOAT = 0x140b,
-  RG = 0x8227,
-  RG_INTEGER = 0x8228,
-  INT_2_10_10_10_REV = 0x8d9f,
+  UNSIGNED_INT_2_10_10_10_REV: 0x8368,
+  UNSIGNED_INT_10F_11F_11F_REV: 0x8c3b,
+  UNSIGNED_INT_5_9_9_9_REV: 0x8c3e,
+  FLOAT_32_UNSIGNED_INT_24_8_REV: 0x8dad,
+  UNSIGNED_INT_24_8: 0x84fa,
+  HALF_FLOAT: 0x140b,
+  RG: 0x8227,
+  RG_INTEGER: 0x8228,
+  INT_2_10_10_10_REV: 0x8d9f,
 
   // Queries
 
-  CURRENT_QUERY = 0x8865,
+  CURRENT_QUERY: 0x8865,
   /** Returns a GLuint containing the query result. */
-  QUERY_RESULT = 0x8866,
+  QUERY_RESULT: 0x8866,
   /** Whether query result is available. */
-  QUERY_RESULT_AVAILABLE = 0x8867,
+  QUERY_RESULT_AVAILABLE: 0x8867,
   /** Occlusion query (if drawing passed depth test)  */
-  ANY_SAMPLES_PASSED = 0x8c2f,
+  ANY_SAMPLES_PASSED: 0x8c2f,
   /** Occlusion query less accurate/faster version */
-  ANY_SAMPLES_PASSED_CONSERVATIVE = 0x8d6a,
+  ANY_SAMPLES_PASSED_CONSERVATIVE: 0x8d6a,
 
   // Draw buffers
 
-  MAX_DRAW_BUFFERS = 0x8824,
-  DRAW_BUFFER0 = 0x8825,
-  DRAW_BUFFER1 = 0x8826,
-  DRAW_BUFFER2 = 0x8827,
-  DRAW_BUFFER3 = 0x8828,
-  DRAW_BUFFER4 = 0x8829,
-  DRAW_BUFFER5 = 0x882a,
-  DRAW_BUFFER6 = 0x882b,
-  DRAW_BUFFER7 = 0x882c,
-  DRAW_BUFFER8 = 0x882d,
-  DRAW_BUFFER9 = 0x882e,
-  DRAW_BUFFER10 = 0x882f,
-  DRAW_BUFFER11 = 0x8830,
-  DRAW_BUFFER12 = 0x8831,
-  DRAW_BUFFER13 = 0x8832,
-  DRAW_BUFFER14 = 0x8833,
-  DRAW_BUFFER15 = 0x8834,
-  MAX_COLOR_ATTACHMENTS = 0x8cdf,
-  COLOR_ATTACHMENT1 = 0x8ce1,
-  COLOR_ATTACHMENT2 = 0x8ce2,
-  COLOR_ATTACHMENT3 = 0x8ce3,
-  COLOR_ATTACHMENT4 = 0x8ce4,
-  COLOR_ATTACHMENT5 = 0x8ce5,
-  COLOR_ATTACHMENT6 = 0x8ce6,
-  COLOR_ATTACHMENT7 = 0x8ce7,
-  COLOR_ATTACHMENT8 = 0x8ce8,
-  COLOR_ATTACHMENT9 = 0x8ce9,
-  COLOR_ATTACHMENT10 = 0x8cea,
-  COLOR_ATTACHMENT11 = 0x8ceb,
-  COLOR_ATTACHMENT12 = 0x8cec,
-  COLOR_ATTACHMENT13 = 0x8ced,
-  COLOR_ATTACHMENT14 = 0x8cee,
-  COLOR_ATTACHMENT15 = 0x8cef,
+  MAX_DRAW_BUFFERS: 0x8824,
+  DRAW_BUFFER0: 0x8825,
+  DRAW_BUFFER1: 0x8826,
+  DRAW_BUFFER2: 0x8827,
+  DRAW_BUFFER3: 0x8828,
+  DRAW_BUFFER4: 0x8829,
+  DRAW_BUFFER5: 0x882a,
+  DRAW_BUFFER6: 0x882b,
+  DRAW_BUFFER7: 0x882c,
+  DRAW_BUFFER8: 0x882d,
+  DRAW_BUFFER9: 0x882e,
+  DRAW_BUFFER10: 0x882f,
+  DRAW_BUFFER11: 0x8830,
+  DRAW_BUFFER12: 0x8831,
+  DRAW_BUFFER13: 0x8832,
+  DRAW_BUFFER14: 0x8833,
+  DRAW_BUFFER15: 0x8834,
+  MAX_COLOR_ATTACHMENTS: 0x8cdf,
+  COLOR_ATTACHMENT1: 0x8ce1,
+  COLOR_ATTACHMENT2: 0x8ce2,
+  COLOR_ATTACHMENT3: 0x8ce3,
+  COLOR_ATTACHMENT4: 0x8ce4,
+  COLOR_ATTACHMENT5: 0x8ce5,
+  COLOR_ATTACHMENT6: 0x8ce6,
+  COLOR_ATTACHMENT7: 0x8ce7,
+  COLOR_ATTACHMENT8: 0x8ce8,
+  COLOR_ATTACHMENT9: 0x8ce9,
+  COLOR_ATTACHMENT10: 0x8cea,
+  COLOR_ATTACHMENT11: 0x8ceb,
+  COLOR_ATTACHMENT12: 0x8cec,
+  COLOR_ATTACHMENT13: 0x8ced,
+  COLOR_ATTACHMENT14: 0x8cee,
+  COLOR_ATTACHMENT15: 0x8cef,
 
   // Samplers
 
-  SAMPLER_3D = 0x8b5f,
-  SAMPLER_2D_SHADOW = 0x8b62,
-  SAMPLER_2D_ARRAY = 0x8dc1,
-  SAMPLER_2D_ARRAY_SHADOW = 0x8dc4,
-  SAMPLER_CUBE_SHADOW = 0x8dc5,
-  INT_SAMPLER_2D = 0x8dca,
-  INT_SAMPLER_3D = 0x8dcb,
-  INT_SAMPLER_CUBE = 0x8dcc,
-  INT_SAMPLER_2D_ARRAY = 0x8dcf,
-  UNSIGNED_INT_SAMPLER_2D = 0x8dd2,
-  UNSIGNED_INT_SAMPLER_3D = 0x8dd3,
-  UNSIGNED_INT_SAMPLER_CUBE = 0x8dd4,
-  UNSIGNED_INT_SAMPLER_2D_ARRAY = 0x8dd7,
-  MAX_SAMPLES = 0x8d57,
-  SAMPLER_BINDING = 0x8919,
+  SAMPLER_3D: 0x8b5f,
+  SAMPLER_2D_SHADOW: 0x8b62,
+  SAMPLER_2D_ARRAY: 0x8dc1,
+  SAMPLER_2D_ARRAY_SHADOW: 0x8dc4,
+  SAMPLER_CUBE_SHADOW: 0x8dc5,
+  INT_SAMPLER_2D: 0x8dca,
+  INT_SAMPLER_3D: 0x8dcb,
+  INT_SAMPLER_CUBE: 0x8dcc,
+  INT_SAMPLER_2D_ARRAY: 0x8dcf,
+  UNSIGNED_INT_SAMPLER_2D: 0x8dd2,
+  UNSIGNED_INT_SAMPLER_3D: 0x8dd3,
+  UNSIGNED_INT_SAMPLER_CUBE: 0x8dd4,
+  UNSIGNED_INT_SAMPLER_2D_ARRAY: 0x8dd7,
+  MAX_SAMPLES: 0x8d57,
+  SAMPLER_BINDING: 0x8919,
 
   // Buffers
 
-  PIXEL_PACK_BUFFER = 0x88eb,
-  PIXEL_UNPACK_BUFFER = 0x88ec,
-  PIXEL_PACK_BUFFER_BINDING = 0x88ed,
-  PIXEL_UNPACK_BUFFER_BINDING = 0x88ef,
-  COPY_READ_BUFFER = 0x8f36,
-  COPY_WRITE_BUFFER = 0x8f37,
-  COPY_READ_BUFFER_BINDING = 0x8f36,
-  COPY_WRITE_BUFFER_BINDING = 0x8f37,
+  PIXEL_PACK_BUFFER: 0x88eb,
+  PIXEL_UNPACK_BUFFER: 0x88ec,
+  PIXEL_PACK_BUFFER_BINDING: 0x88ed,
+  PIXEL_UNPACK_BUFFER_BINDING: 0x88ef,
+  COPY_READ_BUFFER: 0x8f36,
+  COPY_WRITE_BUFFER: 0x8f37,
+  COPY_READ_BUFFER_BINDING: 0x8f36,
+  COPY_WRITE_BUFFER_BINDING: 0x8f37,
 
   // Data types
 
-  FLOAT_MAT2x3 = 0x8b65,
-  FLOAT_MAT2x4 = 0x8b66,
-  FLOAT_MAT3x2 = 0x8b67,
-  FLOAT_MAT3x4 = 0x8b68,
-  FLOAT_MAT4x2 = 0x8b69,
-  FLOAT_MAT4x3 = 0x8b6a,
-  UNSIGNED_INT_VEC2 = 0x8dc6,
-  UNSIGNED_INT_VEC3 = 0x8dc7,
-  UNSIGNED_INT_VEC4 = 0x8dc8,
-  UNSIGNED_NORMALIZED = 0x8c17,
-  SIGNED_NORMALIZED = 0x8f9c,
+  FLOAT_MAT2x3: 0x8b65,
+  FLOAT_MAT2x4: 0x8b66,
+  FLOAT_MAT3x2: 0x8b67,
+  FLOAT_MAT3x4: 0x8b68,
+  FLOAT_MAT4x2: 0x8b69,
+  FLOAT_MAT4x3: 0x8b6a,
+  UNSIGNED_INT_VEC2: 0x8dc6,
+  UNSIGNED_INT_VEC3: 0x8dc7,
+  UNSIGNED_INT_VEC4: 0x8dc8,
+  UNSIGNED_NORMALIZED: 0x8c17,
+  SIGNED_NORMALIZED: 0x8f9c,
 
   // Vertex attributes
 
-  VERTEX_ATTRIB_ARRAY_INTEGER = 0x88fd,
-  VERTEX_ATTRIB_ARRAY_DIVISOR = 0x88fe,
+  VERTEX_ATTRIB_ARRAY_INTEGER: 0x88fd,
+  VERTEX_ATTRIB_ARRAY_DIVISOR: 0x88fe,
 
   // Transform feedback
 
-  TRANSFORM_FEEDBACK_BUFFER_MODE = 0x8c7f,
-  MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS = 0x8c80,
-  TRANSFORM_FEEDBACK_VARYINGS = 0x8c83,
-  TRANSFORM_FEEDBACK_BUFFER_START = 0x8c84,
-  TRANSFORM_FEEDBACK_BUFFER_SIZE = 0x8c85,
-  TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN = 0x8c88,
-  MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS = 0x8c8a,
-  MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS = 0x8c8b,
-  INTERLEAVED_ATTRIBS = 0x8c8c,
-  SEPARATE_ATTRIBS = 0x8c8d,
-  TRANSFORM_FEEDBACK_BUFFER = 0x8c8e,
-  TRANSFORM_FEEDBACK_BUFFER_BINDING = 0x8c8f,
-  TRANSFORM_FEEDBACK = 0x8e22,
-  TRANSFORM_FEEDBACK_PAUSED = 0x8e23,
-  TRANSFORM_FEEDBACK_ACTIVE = 0x8e24,
-  TRANSFORM_FEEDBACK_BINDING = 0x8e25,
+  TRANSFORM_FEEDBACK_BUFFER_MODE: 0x8c7f,
+  MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS: 0x8c80,
+  TRANSFORM_FEEDBACK_VARYINGS: 0x8c83,
+  TRANSFORM_FEEDBACK_BUFFER_START: 0x8c84,
+  TRANSFORM_FEEDBACK_BUFFER_SIZE: 0x8c85,
+  TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN: 0x8c88,
+  MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS: 0x8c8a,
+  MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS: 0x8c8b,
+  INTERLEAVED_ATTRIBS: 0x8c8c,
+  SEPARATE_ATTRIBS: 0x8c8d,
+  TRANSFORM_FEEDBACK_BUFFER: 0x8c8e,
+  TRANSFORM_FEEDBACK_BUFFER_BINDING: 0x8c8f,
+  TRANSFORM_FEEDBACK: 0x8e22,
+  TRANSFORM_FEEDBACK_PAUSED: 0x8e23,
+  TRANSFORM_FEEDBACK_ACTIVE: 0x8e24,
+  TRANSFORM_FEEDBACK_BINDING: 0x8e25,
 
   // Framebuffers and renderbuffers
 
-  FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING = 0x8210,
-  FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE = 0x8211,
-  FRAMEBUFFER_ATTACHMENT_RED_SIZE = 0x8212,
-  FRAMEBUFFER_ATTACHMENT_GREEN_SIZE = 0x8213,
-  FRAMEBUFFER_ATTACHMENT_BLUE_SIZE = 0x8214,
-  FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE = 0x8215,
-  FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE = 0x8216,
-  FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE = 0x8217,
-  FRAMEBUFFER_DEFAULT = 0x8218,
+  FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING: 0x8210,
+  FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE: 0x8211,
+  FRAMEBUFFER_ATTACHMENT_RED_SIZE: 0x8212,
+  FRAMEBUFFER_ATTACHMENT_GREEN_SIZE: 0x8213,
+  FRAMEBUFFER_ATTACHMENT_BLUE_SIZE: 0x8214,
+  FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE: 0x8215,
+  FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE: 0x8216,
+  FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE: 0x8217,
+  FRAMEBUFFER_DEFAULT: 0x8218,
   // DEPTH_STENCIL_ATTACHMENT  = 0x821A,
   // DEPTH_STENCIL = 0x84F9,
-  DEPTH24_STENCIL8 = 0x88f0,
-  DRAW_FRAMEBUFFER_BINDING = 0x8ca6,
-  READ_FRAMEBUFFER_BINDING = 0x8caa,
-  RENDERBUFFER_SAMPLES = 0x8cab,
-  FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER = 0x8cd4,
-  FRAMEBUFFER_INCOMPLETE_MULTISAMPLE = 0x8d56,
+  DEPTH24_STENCIL8: 0x88f0,
+  DRAW_FRAMEBUFFER_BINDING: 0x8ca6,
+  READ_FRAMEBUFFER_BINDING: 0x8caa,
+  RENDERBUFFER_SAMPLES: 0x8cab,
+  FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER: 0x8cd4,
+  FRAMEBUFFER_INCOMPLETE_MULTISAMPLE: 0x8d56,
 
   // Uniforms
 
-  UNIFORM_BUFFER = 0x8a11,
-  UNIFORM_BUFFER_BINDING = 0x8a28,
-  UNIFORM_BUFFER_START = 0x8a29,
-  UNIFORM_BUFFER_SIZE = 0x8a2a,
-  MAX_VERTEX_UNIFORM_BLOCKS = 0x8a2b,
-  MAX_FRAGMENT_UNIFORM_BLOCKS = 0x8a2d,
-  MAX_COMBINED_UNIFORM_BLOCKS = 0x8a2e,
-  MAX_UNIFORM_BUFFER_BINDINGS = 0x8a2f,
-  MAX_UNIFORM_BLOCK_SIZE = 0x8a30,
-  MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS = 0x8a31,
-  MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS = 0x8a33,
-  UNIFORM_BUFFER_OFFSET_ALIGNMENT = 0x8a34,
-  ACTIVE_UNIFORM_BLOCKS = 0x8a36,
-  UNIFORM_TYPE = 0x8a37,
-  UNIFORM_SIZE = 0x8a38,
-  UNIFORM_BLOCK_INDEX = 0x8a3a,
-  UNIFORM_OFFSET = 0x8a3b,
-  UNIFORM_ARRAY_STRIDE = 0x8a3c,
-  UNIFORM_MATRIX_STRIDE = 0x8a3d,
-  UNIFORM_IS_ROW_MAJOR = 0x8a3e,
-  UNIFORM_BLOCK_BINDING = 0x8a3f,
-  UNIFORM_BLOCK_DATA_SIZE = 0x8a40,
-  UNIFORM_BLOCK_ACTIVE_UNIFORMS = 0x8a42,
-  UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES = 0x8a43,
-  UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER = 0x8a44,
-  UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER = 0x8a46,
+  UNIFORM_BUFFER: 0x8a11,
+  UNIFORM_BUFFER_BINDING: 0x8a28,
+  UNIFORM_BUFFER_START: 0x8a29,
+  UNIFORM_BUFFER_SIZE: 0x8a2a,
+  MAX_VERTEX_UNIFORM_BLOCKS: 0x8a2b,
+  MAX_FRAGMENT_UNIFORM_BLOCKS: 0x8a2d,
+  MAX_COMBINED_UNIFORM_BLOCKS: 0x8a2e,
+  MAX_UNIFORM_BUFFER_BINDINGS: 0x8a2f,
+  MAX_UNIFORM_BLOCK_SIZE: 0x8a30,
+  MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS: 0x8a31,
+  MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS: 0x8a33,
+  UNIFORM_BUFFER_OFFSET_ALIGNMENT: 0x8a34,
+  ACTIVE_UNIFORM_BLOCKS: 0x8a36,
+  UNIFORM_TYPE: 0x8a37,
+  UNIFORM_SIZE: 0x8a38,
+  UNIFORM_BLOCK_INDEX: 0x8a3a,
+  UNIFORM_OFFSET: 0x8a3b,
+  UNIFORM_ARRAY_STRIDE: 0x8a3c,
+  UNIFORM_MATRIX_STRIDE: 0x8a3d,
+  UNIFORM_IS_ROW_MAJOR: 0x8a3e,
+  UNIFORM_BLOCK_BINDING: 0x8a3f,
+  UNIFORM_BLOCK_DATA_SIZE: 0x8a40,
+  UNIFORM_BLOCK_ACTIVE_UNIFORMS: 0x8a42,
+  UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES: 0x8a43,
+  UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER: 0x8a44,
+  UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER: 0x8a46,
 
   // Sync objects
 
-  OBJECT_TYPE = 0x9112,
-  SYNC_CONDITION = 0x9113,
-  SYNC_STATUS = 0x9114,
-  SYNC_FLAGS = 0x9115,
-  SYNC_FENCE = 0x9116,
-  SYNC_GPU_COMMANDS_COMPLETE = 0x9117,
-  UNSIGNALED = 0x9118,
-  SIGNALED = 0x9119,
-  ALREADY_SIGNALED = 0x911a,
-  TIMEOUT_EXPIRED = 0x911b,
-  CONDITION_SATISFIED = 0x911c,
-  WAIT_FAILED = 0x911d,
-  SYNC_FLUSH_COMMANDS_BIT = 0x00000001,
+  OBJECT_TYPE: 0x9112,
+  SYNC_CONDITION: 0x9113,
+  SYNC_STATUS: 0x9114,
+  SYNC_FLAGS: 0x9115,
+  SYNC_FENCE: 0x9116,
+  SYNC_GPU_COMMANDS_COMPLETE: 0x9117,
+  UNSIGNALED: 0x9118,
+  SIGNALED: 0x9119,
+  ALREADY_SIGNALED: 0x911a,
+  TIMEOUT_EXPIRED: 0x911b,
+  CONDITION_SATISFIED: 0x911c,
+  WAIT_FAILED: 0x911d,
+  SYNC_FLUSH_COMMANDS_BIT: 0x00000001,
 
   // Miscellaneous constants
 
-  COLOR = 0x1800,
-  DEPTH = 0x1801,
-  STENCIL = 0x1802,
-  MIN = 0x8007,
-  MAX = 0x8008,
-  DEPTH_COMPONENT24 = 0x81a6,
-  STREAM_READ = 0x88e1,
-  STREAM_COPY = 0x88e2,
-  STATIC_READ = 0x88e5,
-  STATIC_COPY = 0x88e6,
-  DYNAMIC_READ = 0x88e9,
-  DYNAMIC_COPY = 0x88ea,
-  DEPTH_COMPONENT32F = 0x8cac,
-  DEPTH32F_STENCIL8 = 0x8cad,
-  INVALID_INDEX = 0xffffffff,
-  TIMEOUT_IGNORED = -1,
-  MAX_CLIENT_WAIT_TIMEOUT_WEBGL = 0x9247,
+  COLOR: 0x1800,
+  DEPTH: 0x1801,
+  STENCIL: 0x1802,
+  MIN: 0x8007,
+  MAX: 0x8008,
+  DEPTH_COMPONENT24: 0x81a6,
+  STREAM_READ: 0x88e1,
+  STREAM_COPY: 0x88e2,
+  STATIC_READ: 0x88e5,
+  STATIC_COPY: 0x88e6,
+  DYNAMIC_READ: 0x88e9,
+  DYNAMIC_COPY: 0x88ea,
+  DEPTH_COMPONENT32F: 0x8cac,
+  DEPTH32F_STENCIL8: 0x8cad,
+  INVALID_INDEX: 0xffffffff,
+  TIMEOUT_IGNORED: -1,
+  MAX_CLIENT_WAIT_TIMEOUT_WEBGL: 0x9247,
 
   // Constants defined in WebGL extensions
 
   // WEBGL_debug_renderer_info
 
   /** Passed to getParameter to get the vendor string of the graphics driver. */
-  UNMASKED_VENDOR_WEBGL = 0x9245,
+  UNMASKED_VENDOR_WEBGL: 0x9245,
   /** Passed to getParameter to get the renderer string of the graphics driver. */
-  UNMASKED_RENDERER_WEBGL = 0x9246,
+  UNMASKED_RENDERER_WEBGL: 0x9246,
 
   // EXT_texture_filter_anisotropic
 
   /** Returns the maximum available anisotropy. */
-  MAX_TEXTURE_MAX_ANISOTROPY_EXT = 0x84ff,
+  MAX_TEXTURE_MAX_ANISOTROPY_EXT: 0x84ff,
   /** Passed to texParameter to set the desired maximum anisotropy for a texture. */
-  TEXTURE_MAX_ANISOTROPY_EXT = 0x84fe,
+  TEXTURE_MAX_ANISOTROPY_EXT: 0x84fe,
 
   // EXT_texture_norm16 - https://khronos.org/registry/webgl/extensions/EXT_texture_norm16/
 
-  R16_EXT = 0x822a,
-  RG16_EXT = 0x822c,
-  RGB16_EXT = 0x8054,
-  RGBA16_EXT = 0x805b,
-  R16_SNORM_EXT = 0x8f98,
-  RG16_SNORM_EXT = 0x8f99,
-  RGB16_SNORM_EXT = 0x8f9a,
-  RGBA16_SNORM_EXT = 0x8f9b,
+  R16_EXT: 0x822a,
+  RG16_EXT: 0x822c,
+  RGB16_EXT: 0x8054,
+  RGBA16_EXT: 0x805b,
+  R16_SNORM_EXT: 0x8f98,
+  RG16_SNORM_EXT: 0x8f99,
+  RGB16_SNORM_EXT: 0x8f9a,
+  RGBA16_SNORM_EXT: 0x8f9b,
 
   // WEBGL_compressed_texture_s3tc (BC1, BC2, BC3)
 
   /** A DXT1-compressed image in an RGB image format. */
-  COMPRESSED_RGB_S3TC_DXT1_EXT = 0x83f0,
+  COMPRESSED_RGB_S3TC_DXT1_EXT: 0x83f0,
   /** A DXT1-compressed image in an RGB image format with a simple on/off alpha value. */
-  COMPRESSED_RGBA_S3TC_DXT1_EXT = 0x83f1,
+  COMPRESSED_RGBA_S3TC_DXT1_EXT: 0x83f1,
   /** A DXT3-compressed image in an RGBA image format. Compared to a 32-bit RGBA texture, it offers 4:1 compression. */
-  COMPRESSED_RGBA_S3TC_DXT3_EXT = 0x83f2,
+  COMPRESSED_RGBA_S3TC_DXT3_EXT: 0x83f2,
   /** A DXT5-compressed image in an RGBA image format. It also provides a 4:1 compression, but differs to the DXT3 compression in how the alpha compression is done. */
-  COMPRESSED_RGBA_S3TC_DXT5_EXT = 0x83f3,
+  COMPRESSED_RGBA_S3TC_DXT5_EXT: 0x83f3,
 
   // WEBGL_compressed_texture_s3tc_srgb (BC1, BC2, BC3 -  SRGB)
 
-  COMPRESSED_SRGB_S3TC_DXT1_EXT = 0x8c4c,
-  COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT = 0x8c4d,
-  COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT = 0x8c4e,
-  COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT = 0x8c4f,
+  COMPRESSED_SRGB_S3TC_DXT1_EXT: 0x8c4c,
+  COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT: 0x8c4d,
+  COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT: 0x8c4e,
+  COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT: 0x8c4f,
 
   // WEBGL_compressed_texture_rgtc (BC4, BC5)
 
-  COMPRESSED_RED_RGTC1_EXT = 0x8dbb,
-  COMPRESSED_SIGNED_RED_RGTC1_EXT = 0x8dbc,
-  COMPRESSED_RED_GREEN_RGTC2_EXT = 0x8dbd,
-  COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT = 0x8dbe,
+  COMPRESSED_RED_RGTC1_EXT: 0x8dbb,
+  COMPRESSED_SIGNED_RED_RGTC1_EXT: 0x8dbc,
+  COMPRESSED_RED_GREEN_RGTC2_EXT: 0x8dbd,
+  COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT: 0x8dbe,
 
   // WEBGL_compressed_texture_bptc (BC6, BC7)
 
-  COMPRESSED_RGBA_BPTC_UNORM_EXT = 0x8e8c,
-  COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT = 0x8e8d,
-  COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT = 0x8e8e,
-  COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT = 0x8e8f,
+  COMPRESSED_RGBA_BPTC_UNORM_EXT: 0x8e8c,
+  COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT: 0x8e8d,
+  COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT: 0x8e8e,
+  COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT: 0x8e8f,
 
   // WEBGL_compressed_texture_es3
 
   /** One-channel (red) unsigned format compression. */
-  COMPRESSED_R11_EAC = 0x9270,
+  COMPRESSED_R11_EAC: 0x9270,
   /** One-channel (red) signed format compression. */
-  COMPRESSED_SIGNED_R11_EAC = 0x9271,
+  COMPRESSED_SIGNED_R11_EAC: 0x9271,
   /** Two-channel (red and green) unsigned format compression. */
-  COMPRESSED_RG11_EAC = 0x9272,
+  COMPRESSED_RG11_EAC: 0x9272,
   /** Two-channel (red and green) signed format compression. */
-  COMPRESSED_SIGNED_RG11_EAC = 0x9273,
+  COMPRESSED_SIGNED_RG11_EAC: 0x9273,
   /** Compresses RGB8 data with no alpha channel. */
-  COMPRESSED_RGB8_ETC2 = 0x9274,
+  COMPRESSED_RGB8_ETC2: 0x9274,
   /** Compresses RGBA8 data. The RGB part is encoded the same as RGB_ETC2, but the alpha part is encoded separately. */
-  COMPRESSED_RGBA8_ETC2_EAC = 0x9275,
+  COMPRESSED_RGBA8_ETC2_EAC: 0x9275,
   /** Compresses sRGB8 data with no alpha channel. */
-  COMPRESSED_SRGB8_ETC2 = 0x9276,
+  COMPRESSED_SRGB8_ETC2: 0x9276,
   /** Compresses sRGBA8 data. The sRGB part is encoded the same as SRGB_ETC2, but the alpha part is encoded separately. */
-  COMPRESSED_SRGB8_ALPHA8_ETC2_EAC = 0x9277,
+  COMPRESSED_SRGB8_ALPHA8_ETC2_EAC: 0x9277,
   /** Similar to RGB8_ETC, but with ability to punch through the alpha channel, which means to make it completely opaque or transparent. */
-  COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9278,
+  COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2: 0x9278,
   /** Similar to SRGB8_ETC, but with ability to punch through the alpha channel, which means to make it completely opaque or transparent. */
-  COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9279,
+  COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2: 0x9279,
 
   // WEBGL_compressed_texture_pvrtc
 
   /** RGB compression in 4-bit mode. One block for each 4×4 pixels. */
-  COMPRESSED_RGB_PVRTC_4BPPV1_IMG = 0x8c00,
+  COMPRESSED_RGB_PVRTC_4BPPV1_IMG: 0x8c00,
   /** RGBA compression in 4-bit mode. One block for each 4×4 pixels. */
-  COMPRESSED_RGBA_PVRTC_4BPPV1_IMG = 0x8c02,
+  COMPRESSED_RGBA_PVRTC_4BPPV1_IMG: 0x8c02,
   /** RGB compression in 2-bit mode. One block for each 8×4 pixels. */
-  COMPRESSED_RGB_PVRTC_2BPPV1_IMG = 0x8c01,
+  COMPRESSED_RGB_PVRTC_2BPPV1_IMG: 0x8c01,
   /** RGBA compression in 2-bit mode. One block for each 8×4 pixels. */
-  COMPRESSED_RGBA_PVRTC_2BPPV1_IMG = 0x8c03,
+  COMPRESSED_RGBA_PVRTC_2BPPV1_IMG: 0x8c03,
 
   // WEBGL_compressed_texture_etc1
 
   /** Compresses 24-bit RGB data with no alpha channel. */
-  COMPRESSED_RGB_ETC1_WEBGL = 0x8d64,
+  COMPRESSED_RGB_ETC1_WEBGL: 0x8d64,
 
   // WEBGL_compressed_texture_atc
 
-  COMPRESSED_RGB_ATC_WEBGL = 0x8c92,
-  COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL = 0x8c92,
-  COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL = 0x87ee,
+  COMPRESSED_RGB_ATC_WEBGL: 0x8c92,
+  COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL: 0x8c92,
+  COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL: 0x87ee,
 
   // WEBGL_compressed_texture_astc
 
-  COMPRESSED_RGBA_ASTC_4x4_KHR = 0x93b0,
-  COMPRESSED_RGBA_ASTC_5x4_KHR = 0x93b1,
-  COMPRESSED_RGBA_ASTC_5x5_KHR = 0x93b2,
-  COMPRESSED_RGBA_ASTC_6x5_KHR = 0x93b3,
-  COMPRESSED_RGBA_ASTC_6x6_KHR = 0x93b4,
-  COMPRESSED_RGBA_ASTC_8x5_KHR = 0x93b5,
-  COMPRESSED_RGBA_ASTC_8x6_KHR = 0x93b6,
-  COMPRESSED_RGBA_ASTC_8x8_KHR = 0x93b7,
-  COMPRESSED_RGBA_ASTC_10x5_KHR = 0x93b8,
-  COMPRESSED_RGBA_ASTC_10x6_KHR = 0x93b9,
-  COMPRESSED_RGBA_ASTC_10x8_KHR = 0x93ba,
-  COMPRESSED_RGBA_ASTC_10x10_KHR = 0x93bb,
-  COMPRESSED_RGBA_ASTC_12x10_KHR = 0x93bc,
-  COMPRESSED_RGBA_ASTC_12x12_KHR = 0x93bd,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR = 0x93d0,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR = 0x93d1,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR = 0x93d2,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR = 0x93d3,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR = 0x93d4,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR = 0x93d5,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR = 0x93d6,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR = 0x93d7,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR = 0x93d8,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR = 0x93d9,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR = 0x93da,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR = 0x93db,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR = 0x93dc,
-  COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR = 0x93dd,
+  COMPRESSED_RGBA_ASTC_4x4_KHR: 0x93b0,
+  COMPRESSED_RGBA_ASTC_5x4_KHR: 0x93b1,
+  COMPRESSED_RGBA_ASTC_5x5_KHR: 0x93b2,
+  COMPRESSED_RGBA_ASTC_6x5_KHR: 0x93b3,
+  COMPRESSED_RGBA_ASTC_6x6_KHR: 0x93b4,
+  COMPRESSED_RGBA_ASTC_8x5_KHR: 0x93b5,
+  COMPRESSED_RGBA_ASTC_8x6_KHR: 0x93b6,
+  COMPRESSED_RGBA_ASTC_8x8_KHR: 0x93b7,
+  COMPRESSED_RGBA_ASTC_10x5_KHR: 0x93b8,
+  COMPRESSED_RGBA_ASTC_10x6_KHR: 0x93b9,
+  COMPRESSED_RGBA_ASTC_10x8_KHR: 0x93ba,
+  COMPRESSED_RGBA_ASTC_10x10_KHR: 0x93bb,
+  COMPRESSED_RGBA_ASTC_12x10_KHR: 0x93bc,
+  COMPRESSED_RGBA_ASTC_12x12_KHR: 0x93bd,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR: 0x93d0,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR: 0x93d1,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR: 0x93d2,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR: 0x93d3,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR: 0x93d4,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR: 0x93d5,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR: 0x93d6,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR: 0x93d7,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR: 0x93d8,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR: 0x93d9,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR: 0x93da,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR: 0x93db,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR: 0x93dc,
+  COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR: 0x93dd,
 
   // EXT_disjoint_timer_query
 
   /** The number of bits used to hold the query result for the given target. */
-  QUERY_COUNTER_BITS_EXT = 0x8864,
+  QUERY_COUNTER_BITS_EXT: 0x8864,
   /** The currently active query. */
-  CURRENT_QUERY_EXT = 0x8865,
+  CURRENT_QUERY_EXT: 0x8865,
   /** The query result. */
-  QUERY_RESULT_EXT = 0x8866,
+  QUERY_RESULT_EXT: 0x8866,
   /** A Boolean indicating whether or not a query result is available. */
-  QUERY_RESULT_AVAILABLE_EXT = 0x8867,
+  QUERY_RESULT_AVAILABLE_EXT: 0x8867,
   /** Elapsed time (in nanoseconds). */
-  TIME_ELAPSED_EXT = 0x88bf,
+  TIME_ELAPSED_EXT: 0x88bf,
   /** The current time. */
-  TIMESTAMP_EXT = 0x8e28,
+  TIMESTAMP_EXT: 0x8e28,
   /** A Boolean indicating whether or not the GPU performed any disjoint operation (lost context) */
-  GPU_DISJOINT_EXT = 0x8fbb,
+  GPU_DISJOINT_EXT: 0x8fbb,
 
   // KHR_parallel_shader_compile https://registry.khronos.org/webgl/extensions/KHR_parallel_shader_compile
 
   /** a non-blocking poll operation, so that compile/link status availability can be queried without potentially incurring stalls */
-  COMPLETION_STATUS_KHR = 0x91b1,
+  COMPLETION_STATUS_KHR: 0x91b1,
 
   // EXT_depth_clamp https://registry.khronos.org/webgl/extensions/EXT_depth_clamp/
 
   /** Disables depth clipping */
-  DEPTH_CLAMP_EXT = 0x864f,
+  DEPTH_CLAMP_EXT: 0x864f,
 
   // WEBGL_provoking_vertex https://registry.khronos.org/webgl/extensions/WEBGL_provoking_vertex/
 
   /** Values of first vertex in primitive are used for flat shading */
-  FIRST_VERTEX_CONVENTION_WEBGL = 0x8e4d,
+  FIRST_VERTEX_CONVENTION_WEBGL: 0x8e4d,
   /** Values of first vertex in primitive are used for flat shading */
-  LAST_VERTEX_CONVENTION_WEBGL = 0x8e4e, // default
+  LAST_VERTEX_CONVENTION_WEBGL: 0x8e4e, // default
   /** Controls which vertex in primitive is used for flat shading */
-  PROVOKING_VERTEX_WEBL = 0x8e4f,
+  PROVOKING_VERTEX_WEBL: 0x8e4f,
 
   // WEBGL_polygon_mode https://registry.khronos.org/webgl/extensions/WEBGL_polygon_mode/
 
-  POLYGON_MODE_WEBGL = 0x0b40,
-  POLYGON_OFFSET_LINE_WEBGL = 0x2a02,
-  LINE_WEBGL = 0x1b01,
-  FILL_WEBGL = 0x1b02,
+  POLYGON_MODE_WEBGL: 0x0b40,
+  POLYGON_OFFSET_LINE_WEBGL: 0x2a02,
+  LINE_WEBGL: 0x1b01,
+  FILL_WEBGL: 0x1b02,
 
   // WEBGL_clip_cull_distance https://registry.khronos.org/webgl/extensions/WEBGL_clip_cull_distance/
 
   /** Max clip distances */
-  MAX_CLIP_DISTANCES_WEBGL = 0x0d32,
+  MAX_CLIP_DISTANCES_WEBGL: 0x0d32,
   /** Max cull distances */
-  MAX_CULL_DISTANCES_WEBGL = 0x82f9,
+  MAX_CULL_DISTANCES_WEBGL: 0x82f9,
   /** Max clip and cull distances */
-  MAX_COMBINED_CLIP_AND_CULL_DISTANCES_WEBGL = 0x82fa,
+  MAX_COMBINED_CLIP_AND_CULL_DISTANCES_WEBGL: 0x82fa,
 
   /** Enable gl_ClipDistance[0] and gl_CullDistance[0] */
-  CLIP_DISTANCE0_WEBGL = 0x3000,
+  CLIP_DISTANCE0_WEBGL: 0x3000,
   /** Enable gl_ClipDistance[1] and gl_CullDistance[1] */
-  CLIP_DISTANCE1_WEBGL = 0x3001,
+  CLIP_DISTANCE1_WEBGL: 0x3001,
   /** Enable gl_ClipDistance[2] and gl_CullDistance[2] */
-  CLIP_DISTANCE2_WEBGL = 0x3002,
+  CLIP_DISTANCE2_WEBGL: 0x3002,
   /** Enable gl_ClipDistance[3] and gl_CullDistance[3] */
-  CLIP_DISTANCE3_WEBGL = 0x3003,
+  CLIP_DISTANCE3_WEBGL: 0x3003,
   /** Enable gl_ClipDistance[4] and gl_CullDistance[4] */
-  CLIP_DISTANCE4_WEBGL = 0x3004,
+  CLIP_DISTANCE4_WEBGL: 0x3004,
   /** Enable gl_ClipDistance[5] and gl_CullDistance[5] */
-  CLIP_DISTANCE5_WEBGL = 0x3005,
+  CLIP_DISTANCE5_WEBGL: 0x3005,
   /** Enable gl_ClipDistance[6] and gl_CullDistance[6] */
-  CLIP_DISTANCE6_WEBGL = 0x3006,
+  CLIP_DISTANCE6_WEBGL: 0x3006,
   /** Enable gl_ClipDistance[7] and gl_CullDistance[7] */
-  CLIP_DISTANCE7_WEBGL = 0x3007,
+  CLIP_DISTANCE7_WEBGL: 0x3007,
 
   /** EXT_polygon_offset_clamp https://registry.khronos.org/webgl/extensions/EXT_polygon_offset_clamp/ */
-  POLYGON_OFFSET_CLAMP_EXT = 0x8e1b,
+  POLYGON_OFFSET_CLAMP_EXT: 0x8e1b,
 
   /** EXT_clip_control https://registry.khronos.org/webgl/extensions/EXT_clip_control/ */
-  LOWER_LEFT_EXT = 0x8ca1,
-  UPPER_LEFT_EXT = 0x8ca2,
+  LOWER_LEFT_EXT: 0x8ca1,
+  UPPER_LEFT_EXT: 0x8ca2,
 
-  NEGATIVE_ONE_TO_ONE_EXT = 0x935e,
-  ZERO_TO_ONE_EXT = 0x935f,
+  NEGATIVE_ONE_TO_ONE_EXT: 0x935e,
+  ZERO_TO_ONE_EXT: 0x935f,
 
-  CLIP_ORIGIN_EXT = 0x935c,
-  CLIP_DEPTH_MODE_EXT = 0x935d,
+  CLIP_ORIGIN_EXT: 0x935c,
+  CLIP_DEPTH_MODE_EXT: 0x935d,
 
   /** WEBGL_blend_func_extended https://registry.khronos.org/webgl/extensions/WEBGL_blend_func_extended/ */
-  SRC1_COLOR_WEBGL = 0x88f9,
-  SRC1_ALPHA_WEBGL = 0x8589,
-  ONE_MINUS_SRC1_COLOR_WEBGL = 0x88fa,
-  ONE_MINUS_SRC1_ALPHA_WEBGL = 0x88fb,
-  MAX_DUAL_SOURCE_DRAW_BUFFERS_WEBGL = 0x88fc,
+  SRC1_COLOR_WEBGL: 0x88f9,
+  SRC1_ALPHA_WEBGL: 0x8589,
+  ONE_MINUS_SRC1_COLOR_WEBGL: 0x88fa,
+  ONE_MINUS_SRC1_ALPHA_WEBGL: 0x88fb,
+  MAX_DUAL_SOURCE_DRAW_BUFFERS_WEBGL: 0x88fc,
 
   /** EXT_texture_mirror_clamp_to_edge https://registry.khronos.org/webgl/extensions/EXT_texture_mirror_clamp_to_edge/ */
-  MIRROR_CLAMP_TO_EDGE_EXT = 0x8743
-}
+  MIRROR_CLAMP_TO_EDGE_EXT: 0x8743
+} as const;
 
-export {GLEnum as GL};
+/** Numeric value for a named WebGL constant. */
+export type GLConstant<Name extends keyof typeof GL> = (typeof GL)[Name];
+
+/** Numeric value of any WebGL constant. */
+export type GLValue = number;
+
+export {GL};

--- a/modules/webgl/src/constants/webgl-types.ts
+++ b/modules/webgl/src/constants/webgl-types.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 /* eslint-disable camelcase */
-import {GL} from './webgl-constants';
+import {GL, type GLConstant, type GLValue} from './webgl-constants';
 
 /** Type covering all typed arrays and classic arrays consisting of numbers */
 export type NumericArray = TypedArray | number[];
@@ -30,94 +30,94 @@ type Framebuffer = unknown;
 
 /** All possible texture targets */
 export type GLTextureTarget =
-  | GL.TEXTURE_2D
-  | GL.TEXTURE_CUBE_MAP
-  | GL.TEXTURE_2D_ARRAY
-  | GL.TEXTURE_3D;
+  | GLConstant<'TEXTURE_2D'>
+  | GLConstant<'TEXTURE_CUBE_MAP'>
+  | GLConstant<'TEXTURE_2D_ARRAY'>
+  | GLConstant<'TEXTURE_3D'>;
 
 /** All possible cube face targets for textImage2D */
 export type GLTextureCubeMapTarget =
-  | GL.TEXTURE_CUBE_MAP_POSITIVE_X
-  | GL.TEXTURE_CUBE_MAP_NEGATIVE_X
-  | GL.TEXTURE_CUBE_MAP_POSITIVE_Y
-  | GL.TEXTURE_CUBE_MAP_NEGATIVE_Y
-  | GL.TEXTURE_CUBE_MAP_POSITIVE_Z
-  | GL.TEXTURE_CUBE_MAP_NEGATIVE_Z;
+  | GLConstant<'TEXTURE_CUBE_MAP_POSITIVE_X'>
+  | GLConstant<'TEXTURE_CUBE_MAP_NEGATIVE_X'>
+  | GLConstant<'TEXTURE_CUBE_MAP_POSITIVE_Y'>
+  | GLConstant<'TEXTURE_CUBE_MAP_NEGATIVE_Y'>
+  | GLConstant<'TEXTURE_CUBE_MAP_POSITIVE_Z'>
+  | GLConstant<'TEXTURE_CUBE_MAP_NEGATIVE_Z'>;
 
 /** Texel data formats for gl.texSubImage() */
 export type GLTexelDataFormat =
-  | GL.ALPHA // Discards the red, green and blue components and reads the alpha component.
-  | GL.RGB // Discards the alpha components and reads the red, green and blue components.
-  | GL.RGBA // Red, green, blue and alpha components are read from the color buffer.
-  | GL.LUMINANCE // Each color component is a luminance component, alpha is 1.0.
-  | GL.LUMINANCE_ALPHA // Each component is a luminance/alpha component.
-  | GL.SRGB
+  | GLConstant<'ALPHA'> // Discards the red, green and blue components and reads the alpha component.
+  | GLConstant<'RGB'> // Discards the alpha components and reads the red, green and blue components.
+  | GLConstant<'RGBA'> // Red, green, blue and alpha components are read from the color buffer.
+  | GLConstant<'LUMINANCE'> // Each color component is a luminance component, alpha is 1.0.
+  | GLConstant<'LUMINANCE_ALPHA'> // Each component is a luminance/alpha component.
+  | GLConstant<'SRGB'>
   // | GL.SRGB_ALPHA_EXT
-  | GL.RED
-  | GL.RG
-  | GL.RED_INTEGER
-  | GL.RG_INTEGER
-  | GL.RGB_INTEGER
-  | GL.RGBA_INTEGER
-  | GL.DEPTH_COMPONENT
-  | GL.DEPTH_STENCIL;
+  | GLConstant<'RED'>
+  | GLConstant<'RG'>
+  | GLConstant<'RED_INTEGER'>
+  | GLConstant<'RG_INTEGER'>
+  | GLConstant<'RGB_INTEGER'>
+  | GLConstant<'RGBA_INTEGER'>
+  | GLConstant<'DEPTH_COMPONENT'>
+  | GLConstant<'DEPTH_STENCIL'>;
 
 /** Rendering primitives. Constants passed to drawElements() or drawArrays() to specify what kind of primitive to render. */
 export type GLPrimitiveTopology =
-  | GL.POINTS
-  | GL.LINES
-  | GL.LINE_STRIP
-  | GL.LINE_LOOP
-  | GL.TRIANGLES
-  | GL.TRIANGLE_STRIP
-  | GL.TRIANGLE_FAN;
+  | GLConstant<'POINTS'>
+  | GLConstant<'LINES'>
+  | GLConstant<'LINE_STRIP'>
+  | GLConstant<'LINE_LOOP'>
+  | GLConstant<'TRIANGLES'>
+  | GLConstant<'TRIANGLE_STRIP'>
+  | GLConstant<'TRIANGLE_FAN'>;
 
 /** Rendering primitives. Constants passed to transform feedback  . */
-export type GLPrimitive = GL.POINTS | GL.LINES | GL.TRIANGLES;
+export type GLPrimitive = GLConstant<'POINTS'> | GLConstant<'LINES'> | GLConstant<'TRIANGLES'>;
 
 /** Data Type */
 export type GLDataType =
-  | GL.FLOAT
-  | GL.UNSIGNED_SHORT
-  | GL.UNSIGNED_INT
-  | GL.UNSIGNED_BYTE
-  | GL.BYTE
-  | GL.SHORT
-  | GL.INT
-  | GL.HALF_FLOAT;
+  | GLConstant<'FLOAT'>
+  | GLConstant<'UNSIGNED_SHORT'>
+  | GLConstant<'UNSIGNED_INT'>
+  | GLConstant<'UNSIGNED_BYTE'>
+  | GLConstant<'BYTE'>
+  | GLConstant<'SHORT'>
+  | GLConstant<'INT'>
+  | GLConstant<'HALF_FLOAT'>;
 
 /** Pixel Data Type */
 export type GLPixelType =
   | GLDataType
-  | GL.UNSIGNED_SHORT_5_6_5
-  | GL.UNSIGNED_SHORT_4_4_4_4
-  | GL.UNSIGNED_SHORT_5_5_5_1
-  | GL.UNSIGNED_INT_2_10_10_10_REV
-  | GL.UNSIGNED_INT_10F_11F_11F_REV
-  | GL.UNSIGNED_INT_5_9_9_9_REV
-  | GL.UNSIGNED_INT_24_8
-  | GL.FLOAT_32_UNSIGNED_INT_24_8_REV;
+  | GLConstant<'UNSIGNED_SHORT_5_6_5'>
+  | GLConstant<'UNSIGNED_SHORT_4_4_4_4'>
+  | GLConstant<'UNSIGNED_SHORT_5_5_5_1'>
+  | GLConstant<'UNSIGNED_INT_2_10_10_10_REV'>
+  | GLConstant<'UNSIGNED_INT_10F_11F_11F_REV'>
+  | GLConstant<'UNSIGNED_INT_5_9_9_9_REV'>
+  | GLConstant<'UNSIGNED_INT_24_8'>
+  | GLConstant<'FLOAT_32_UNSIGNED_INT_24_8_REV'>;
 
 /**
  * Sampler uniform type
  * @note These are all the valid sampler types used with `gl.uniform1i((location, value)`
  */
 export type GLSamplerType =
-  | GL.SAMPLER_2D
-  | GL.SAMPLER_CUBE
-  | GL.SAMPLER_3D
-  | GL.SAMPLER_2D_SHADOW
-  | GL.SAMPLER_2D_ARRAY
-  | GL.SAMPLER_2D_ARRAY_SHADOW
-  | GL.SAMPLER_CUBE_SHADOW
-  | GL.INT_SAMPLER_2D
-  | GL.INT_SAMPLER_3D
-  | GL.INT_SAMPLER_CUBE
-  | GL.INT_SAMPLER_2D_ARRAY
-  | GL.UNSIGNED_INT_SAMPLER_2D
-  | GL.UNSIGNED_INT_SAMPLER_3D
-  | GL.UNSIGNED_INT_SAMPLER_CUBE
-  | GL.UNSIGNED_INT_SAMPLER_2D_ARRAY;
+  | GLConstant<'SAMPLER_2D'>
+  | GLConstant<'SAMPLER_CUBE'>
+  | GLConstant<'SAMPLER_3D'>
+  | GLConstant<'SAMPLER_2D_SHADOW'>
+  | GLConstant<'SAMPLER_2D_ARRAY'>
+  | GLConstant<'SAMPLER_2D_ARRAY_SHADOW'>
+  | GLConstant<'SAMPLER_CUBE_SHADOW'>
+  | GLConstant<'INT_SAMPLER_2D'>
+  | GLConstant<'INT_SAMPLER_3D'>
+  | GLConstant<'INT_SAMPLER_CUBE'>
+  | GLConstant<'INT_SAMPLER_2D_ARRAY'>
+  | GLConstant<'UNSIGNED_INT_SAMPLER_2D'>
+  | GLConstant<'UNSIGNED_INT_SAMPLER_3D'>
+  | GLConstant<'UNSIGNED_INT_SAMPLER_CUBE'>
+  | GLConstant<'UNSIGNED_INT_SAMPLER_2D_ARRAY'>;
 
 /**
  * Composite types table
@@ -125,107 +125,121 @@ export type GLSamplerType =
  * Different `gl.uniformXXX(location, value)` functions must be used depending on which composite type is being set.
  */
 export type GLUniformType =
-  | GL.FLOAT
-  | GL.FLOAT_VEC2
-  | GL.FLOAT_VEC3
-  | GL.FLOAT_VEC4
-  | GL.INT
-  | GL.INT_VEC2
-  | GL.INT_VEC3
-  | GL.INT_VEC4
-  | GL.UNSIGNED_INT
-  | GL.UNSIGNED_INT_VEC2
-  | GL.UNSIGNED_INT_VEC3
-  | GL.UNSIGNED_INT_VEC4
-  | GL.BOOL
-  | GL.BOOL_VEC2
-  | GL.BOOL_VEC3
-  | GL.BOOL_VEC4
-  | GL.FLOAT_MAT2
-  | GL.FLOAT_MAT2x3
-  | GL.FLOAT_MAT2x4
-  | GL.FLOAT_MAT3x2
-  | GL.FLOAT_MAT3
-  | GL.FLOAT_MAT3x4
-  | GL.FLOAT_MAT4x2
-  | GL.FLOAT_MAT4x3
-  | GL.FLOAT_MAT4;
+  | GLConstant<'FLOAT'>
+  | GLConstant<'FLOAT_VEC2'>
+  | GLConstant<'FLOAT_VEC3'>
+  | GLConstant<'FLOAT_VEC4'>
+  | GLConstant<'INT'>
+  | GLConstant<'INT_VEC2'>
+  | GLConstant<'INT_VEC3'>
+  | GLConstant<'INT_VEC4'>
+  | GLConstant<'UNSIGNED_INT'>
+  | GLConstant<'UNSIGNED_INT_VEC2'>
+  | GLConstant<'UNSIGNED_INT_VEC3'>
+  | GLConstant<'UNSIGNED_INT_VEC4'>
+  | GLConstant<'BOOL'>
+  | GLConstant<'BOOL_VEC2'>
+  | GLConstant<'BOOL_VEC3'>
+  | GLConstant<'BOOL_VEC4'>
+  | GLConstant<'FLOAT_MAT2'>
+  | GLConstant<'FLOAT_MAT2x3'>
+  | GLConstant<'FLOAT_MAT2x4'>
+  | GLConstant<'FLOAT_MAT3x2'>
+  | GLConstant<'FLOAT_MAT3'>
+  | GLConstant<'FLOAT_MAT3x4'>
+  | GLConstant<'FLOAT_MAT4x2'>
+  | GLConstant<'FLOAT_MAT4x3'>
+  | GLConstant<'FLOAT_MAT4'>;
 
 /**
  * Depth or stencil tests
  * Constants passed to WebGLRenderingContext.depthFunc() or WebGLRenderingContext.stencilFunc().
  */
 export type GLFunction =
-  | GL.NEVER
-  | GL.LESS
-  | GL.EQUAL
-  | GL.LEQUAL
-  | GL.GREATER
-  | GL.NOTEQUAL
-  | GL.GEQUAL
-  | GL.ALWAYS;
+  | GLConstant<'NEVER'>
+  | GLConstant<'LESS'>
+  | GLConstant<'EQUAL'>
+  | GLConstant<'LEQUAL'>
+  | GLConstant<'GREATER'>
+  | GLConstant<'NOTEQUAL'>
+  | GLConstant<'GEQUAL'>
+  | GLConstant<'ALWAYS'>;
 
 export type GLBlendEquation =
-  | GL.FUNC_ADD
-  | GL.FUNC_SUBTRACT
-  | GL.FUNC_REVERSE_SUBTRACT
-  | GL.MIN
-  | GL.MAX;
+  | GLConstant<'FUNC_ADD'>
+  | GLConstant<'FUNC_SUBTRACT'>
+  | GLConstant<'FUNC_REVERSE_SUBTRACT'>
+  | GLConstant<'MIN'>
+  | GLConstant<'MAX'>;
 
 export type GLBlendFunction =
-  | GL.ZERO
-  | GL.ONE
-  | GL.SRC_COLOR
-  | GL.ONE_MINUS_SRC_COLOR
-  | GL.DST_COLOR
-  | GL.ONE_MINUS_DST_COLOR
-  | GL.SRC_ALPHA
-  | GL.ONE_MINUS_SRC_ALPHA
-  | GL.DST_ALPHA
-  | GL.ONE_MINUS_DST_ALPHA
-  | GL.CONSTANT_COLOR
-  | GL.ONE_MINUS_CONSTANT_COLOR
-  | GL.CONSTANT_ALPHA
-  | GL.ONE_MINUS_CONSTANT_ALPHA
-  | GL.SRC_ALPHA_SATURATE;
+  | GLConstant<'ZERO'>
+  | GLConstant<'ONE'>
+  | GLConstant<'SRC_COLOR'>
+  | GLConstant<'ONE_MINUS_SRC_COLOR'>
+  | GLConstant<'DST_COLOR'>
+  | GLConstant<'ONE_MINUS_DST_COLOR'>
+  | GLConstant<'SRC_ALPHA'>
+  | GLConstant<'ONE_MINUS_SRC_ALPHA'>
+  | GLConstant<'DST_ALPHA'>
+  | GLConstant<'ONE_MINUS_DST_ALPHA'>
+  | GLConstant<'CONSTANT_COLOR'>
+  | GLConstant<'ONE_MINUS_CONSTANT_COLOR'>
+  | GLConstant<'CONSTANT_ALPHA'>
+  | GLConstant<'ONE_MINUS_CONSTANT_ALPHA'>
+  | GLConstant<'SRC_ALPHA_SATURATE'>;
 
 /**
  * Stencil actions
  * Constants passed to WebGLRenderingContext.stencilOp().
  */
 export type GLStencilOp =
-  | GL.KEEP
-  | GL.ZERO
-  | GL.REPLACE
-  | GL.INCR
-  | GL.INCR_WRAP
-  | GL.DECR
-  | GL.DECR_WRAP
-  | GL.INVERT;
+  | GLConstant<'KEEP'>
+  | GLConstant<'ZERO'>
+  | GLConstant<'REPLACE'>
+  | GLConstant<'INCR'>
+  | GLConstant<'INCR_WRAP'>
+  | GLConstant<'DECR'>
+  | GLConstant<'DECR_WRAP'>
+  | GLConstant<'INVERT'>;
 
-export type GLPolygonMode = GL.FILL_WEBGL | GL.LINE_WEBGL;
-export type GLCullFaceMode = GL.FRONT | GL.BACK | GL.FRONT_AND_BACK;
-export type GLProvokingVertex = GL.FIRST_VERTEX_CONVENTION_WEBGL | GL.LAST_VERTEX_CONVENTION_WEBGL;
+export type GLPolygonMode = GLConstant<'FILL_WEBGL'> | GLConstant<'LINE_WEBGL'>;
+export type GLCullFaceMode =
+  | GLConstant<'FRONT'>
+  | GLConstant<'BACK'>
+  | GLConstant<'FRONT_AND_BACK'>;
+export type GLProvokingVertex =
+  | GLConstant<'FIRST_VERTEX_CONVENTION_WEBGL'>
+  | GLConstant<'LAST_VERTEX_CONVENTION_WEBGL'>;
 
 /** Parameters for textures and samplers */
 export type GLSamplerParameters = {
   /** Sets the wrap parameter for texture coordinate  to either GL_CLAMP_TO_EDGE, GL_MIRRORED_REPEAT, or GL_REPEAT. */
-  [GL.TEXTURE_WRAP_S]?: GL.CLAMP_TO_EDGE | GL.REPEAT | GL.MIRRORED_REPEAT;
+  [GL.TEXTURE_WRAP_S]?:
+    | GLConstant<'CLAMP_TO_EDGE'>
+    | GLConstant<'REPEAT'>
+    | GLConstant<'MIRRORED_REPEAT'>;
   /** Sets the wrap parameter for texture coordinate  to either GL_CLAMP_TO_EDGE, GL_MIRRORED_REPEAT, or GL_REPEAT. */
-  [GL.TEXTURE_WRAP_T]?: GL.CLAMP_TO_EDGE | GL.REPEAT | GL.MIRRORED_REPEAT;
+  [GL.TEXTURE_WRAP_T]?:
+    | GLConstant<'CLAMP_TO_EDGE'>
+    | GLConstant<'REPEAT'>
+    | GLConstant<'MIRRORED_REPEAT'>;
   /** Sets the wrap parameter for texture coordinate  to either GL_CLAMP_TO_EDGE, GL_MIRRORED_REPEAT, or GL_REPEAT. */
-  [GL.TEXTURE_WRAP_R]?: GL.CLAMP_TO_EDGE | GL.REPEAT | GL.MIRRORED_REPEAT;
+  [GL.TEXTURE_WRAP_R]?:
+    | GLConstant<'CLAMP_TO_EDGE'>
+    | GLConstant<'REPEAT'>
+    | GLConstant<'MIRRORED_REPEAT'>;
 
   /** The texture magnification function is used when the pixel being textured maps to an area less than or equal to one texture element. It sets the texture magnification function to either GL_NEAREST or GL_LINEAR (see below). GL_NEAREST is generally faster than GL_LINEAR, but it can produce textured images with sharper edges because the transition between texture elements is not as smooth. Default: GL_LINEAR.  */
-  [GL.TEXTURE_MAG_FILTER]?: GL.NEAREST | GL.LINEAR;
+  [GL.TEXTURE_MAG_FILTER]?: GLConstant<'NEAREST'> | GLConstant<'LINEAR'>;
   /** The texture minifying function is used whenever the pixel being textured maps to an area greater than one texture element. There are six defined minifying functions. Two of them use the nearest one or nearest four texture elements to compute the texture value. The other four use mipmaps. Default: GL_NEAREST_MIPMAP_LINEAR */
   [GL.TEXTURE_MIN_FILTER]?:
-    | GL.NEAREST
-    | GL.LINEAR
-    | GL.NEAREST_MIPMAP_NEAREST
-    | GL.NEAREST_MIPMAP_LINEAR
-    | GL.LINEAR_MIPMAP_NEAREST
-    | GL.LINEAR_MIPMAP_LINEAR;
+    | GLConstant<'NEAREST'>
+    | GLConstant<'LINEAR'>
+    | GLConstant<'NEAREST_MIPMAP_NEAREST'>
+    | GLConstant<'NEAREST_MIPMAP_LINEAR'>
+    | GLConstant<'LINEAR_MIPMAP_NEAREST'>
+    | GLConstant<'LINEAR_MIPMAP_LINEAR'>;
   /* A GLfloat indicating the minimum level-of-detail mipmap. */
   [GL.TEXTURE_MIN_LOD]?: number;
   /* A GLfloat indicating the minimum level-of-detail mipmap. */
@@ -233,7 +247,7 @@ export type GLSamplerParameters = {
   /** Texture parameter TEXTURE_COMPARE_FUNC specifies the depth texture comparison function */
   [GL.TEXTURE_COMPARE_FUNC]?: number; // COMPARE_FUNC);
   /** Texture parameter TEXTURE_COMPARE_MODE specifies the depth texture comparison operands. */
-  [GL.TEXTURE_COMPARE_MODE]?: GL.COMPARE_REF_TO_TEXTURE;
+  [GL.TEXTURE_COMPARE_MODE]?: GLConstant<'COMPARE_REF_TO_TEXTURE'>;
   /** Max anisotropy level */
   [GL.TEXTURE_MAX_ANISOTROPY_EXT]?: number;
 };
@@ -253,14 +267,17 @@ export type GLValueParameters = {
   [GL.COLOR_CLEAR_VALUE]?: [number, number, number, number] | TypedArray;
   [GL.COLOR_WRITEMASK]?: [boolean, boolean, boolean, boolean] | boolean[];
   [GL.CULL_FACE]?: boolean;
-  [GL.CULL_FACE_MODE]?: GL.FRONT | GL.BACK | GL.FRONT_AND_BACK;
+  [GL.CULL_FACE_MODE]?: GLConstant<'FRONT'> | GLConstant<'BACK'> | GLConstant<'FRONT_AND_BACK'>;
   [GL.DEPTH_TEST]?: boolean;
   [GL.DEPTH_CLEAR_VALUE]?: number;
   [GL.DEPTH_FUNC]?: GLFunction;
   [GL.DEPTH_RANGE]?: [number, number] | TypedArray;
   [GL.DEPTH_WRITEMASK]?: boolean;
   [GL.DITHER]?: boolean;
-  [GL.FRAGMENT_SHADER_DERIVATIVE_HINT]?: GL.FASTEST | GL.NICEST | GL.DONT_CARE;
+  [GL.FRAGMENT_SHADER_DERIVATIVE_HINT]?:
+    | GLConstant<'FASTEST'>
+    | GLConstant<'NICEST'>
+    | GLConstant<'DONT_CARE'>;
   [GL.CURRENT_PROGRAM]?: WebGLProgram | null;
   [GL.FRAMEBUFFER_BINDING]?: WebGLFramebuffer | null;
   [GL.RENDERBUFFER_BINDING]?: WebGLRenderbuffer | null;
@@ -275,8 +292,11 @@ export type GLValueParameters = {
   [GL.TEXTURE_BINDING_2D_ARRAY]?: WebGLTexture | null;
   [GL.TEXTURE_BINDING_3D]?: WebGLTexture | null;
   [GL.TEXTURE_BINDING_CUBE_MAP]?: WebGLTexture | null;
-  [GL.FRONT_FACE]?: GL.CW | GL.CCW;
-  [GL.GENERATE_MIPMAP_HINT]?: GL.FASTEST | GL.NICEST | GL.DONT_CARE;
+  [GL.FRONT_FACE]?: GLConstant<'CW'> | GLConstant<'CCW'>;
+  [GL.GENERATE_MIPMAP_HINT]?:
+    | GLConstant<'FASTEST'>
+    | GLConstant<'NICEST'>
+    | GLConstant<'DONT_CARE'>;
   [GL.LINE_WIDTH]?: number;
   [GL.POLYGON_OFFSET_FILL]?: boolean;
   [GL.POLYGON_OFFSET_FACTOR]?: number;
@@ -316,7 +336,9 @@ export type GLValueParameters = {
   [GL.UNPACK_ALIGNMENT]?: 1 | 2 | 4 | 8;
   [GL.UNPACK_FLIP_Y_WEBGL]?: boolean;
   [GL.UNPACK_PREMULTIPLY_ALPHA_WEBGL]?: boolean;
-  [GL.UNPACK_COLORSPACE_CONVERSION_WEBGL]?: GL.NONE | GL.BROWSER_DEFAULT_WEBGL;
+  [GL.UNPACK_COLORSPACE_CONVERSION_WEBGL]?:
+    | GLConstant<'NONE'>
+    | GLConstant<'BROWSER_DEFAULT_WEBGL'>;
   [GL.UNPACK_ROW_LENGTH]?: number;
   [GL.UNPACK_IMAGE_HEIGHT]?: number;
   [GL.UNPACK_SKIP_PIXELS]?: number;
@@ -335,7 +357,9 @@ export type GLUnpackParameters = {
   [GL.UNPACK_ALIGNMENT]?: number;
   [GL.UNPACK_FLIP_Y_WEBGL]?: boolean;
   [GL.UNPACK_PREMULTIPLY_ALPHA_WEBGL]?: boolean;
-  [GL.UNPACK_COLORSPACE_CONVERSION_WEBGL]?: GL.NONE | GL.BROWSER_DEFAULT_WEBGL;
+  [GL.UNPACK_COLORSPACE_CONVERSION_WEBGL]?:
+    | GLConstant<'NONE'>
+    | GLConstant<'BROWSER_DEFAULT_WEBGL'>;
   [GL.UNPACK_ROW_LENGTH]?: number;
   [GL.UNPACK_IMAGE_HEIGHT]?: number;
   [GL.UNPACK_SKIP_PIXELS]?: number;
@@ -365,7 +389,7 @@ export type GLFunctionParameters = {
   colorMask?: [boolean, boolean, boolean, boolean] | boolean[];
 
   cull?: boolean;
-  cullFace?: GL.FRONT | GL.BACK | GL.FRONT_AND_BACK;
+  cullFace?: GLConstant<'FRONT'> | GLConstant<'BACK'> | GLConstant<'FRONT_AND_BACK'>;
 
   depthTest?: boolean;
   depthFunc?: GLFunction;
@@ -375,11 +399,11 @@ export type GLFunctionParameters = {
 
   dither?: boolean;
 
-  derivativeHint?: GL.FASTEST | GL.NICEST | GL.DONT_CARE;
+  derivativeHint?: GLConstant<'FASTEST'> | GLConstant<'NICEST'> | GLConstant<'DONT_CARE'>;
 
-  frontFace?: GL.CW | GL.CCW;
+  frontFace?: GLConstant<'CW'> | GLConstant<'CCW'>;
 
-  mipmapHint?: GL.FASTEST | GL.NICEST | GL.DONT_CARE;
+  mipmapHint?: GLConstant<'FASTEST'> | GLConstant<'NICEST'> | GLConstant<'DONT_CARE'>;
 
   lineWidth?: number;
 
@@ -608,14 +632,19 @@ type WEBGL_provoking_vertex = {
   // Constants in GL enum
   /** Set the provoking vertex */
   provokingVertexWEBGL(
-    provokeMode: GL.FIRST_VERTEX_CONVENTION_WEBGL | GL.LAST_VERTEX_CONVENTION_WEBGL
+    provokeMode:
+      | GLConstant<'FIRST_VERTEX_CONVENTION_WEBGL'>
+      | GLConstant<'LAST_VERTEX_CONVENTION_WEBGL'>
   ): void;
 };
 
 /** WEBGL_polygon_mode https://registry.khronos.org/webgl/extensions/WEBGL_polygon_mode/ */
 type WEBGL_polygon_mode = {
   /** Set polygon mode of face to fill or line */
-  polygonModeWEBGL(face: GL.FRONT | GL.BACK, mode: GL.LINE_WEBGL | GL.FILL_WEBGL): void;
+  polygonModeWEBGL(
+    face: GLConstant<'FRONT'> | GLConstant<'BACK'>,
+    mode: GLConstant<'LINE_WEBGL'> | GLConstant<'FILL_WEBGL'>
+  ): void;
 };
 
 /** WEBGL_clip_cull_distance https://registry.khronos.org/webgl/extensions/WEBGL_clip_cull_distance/ */
@@ -672,7 +701,7 @@ type EXT_clip_control = {
   CLIP_ORIGIN_EXT: 0x935c;
   CLIP_DEPTH_MODE_EXT: 0x935d;
 
-  clipControlEXT(origin: GL, depth: GL): void;
+  clipControlEXT(origin: GLValue, depth: GLValue): void;
 };
 
 /** WEBGL_blend_func_extended https://registry.khronos.org/webgl/extensions/WEBGL_blend_func_extended/ */
@@ -687,17 +716,23 @@ type WEBGL_blend_func_extended = {
 /** OES_draw_buffers_indexed https://registry.khronos.org/webgl/extensions/OES_draw_buffers_indexed/ */
 type OES_draw_buffers_indexed = {
   /** Enables blending for an individual draw buffer */
-  enableiOES(target: GL, index: number): void;
+  enableiOES(target: GLValue, index: number): void;
   /** Disables blending for an individual draw buffer */
-  disableiOES(target: GL, index: number): void;
+  disableiOES(target: GLValue, index: number): void;
   /** Modifies blend equation for an individual draw buffer */
-  blendEquationiOES(buf: number, mode: GL): void;
+  blendEquationiOES(buf: number, mode: GLValue): void;
   /** Modifies blend equation for an individual draw buffer */
-  blendEquationSeparateiOES(buf: number, modeRGB: GL, modeAlpha: GL): void;
+  blendEquationSeparateiOES(buf: number, modeRGB: GLValue, modeAlpha: GLValue): void;
   /** Modifies blend function for an individual draw buffer */
-  blendFunciOES(buf: number, src: GL, dst: GL): void;
+  blendFunciOES(buf: number, src: GLValue, dst: GLValue): void;
   /** Modifies blend function for an individual draw buffer */
-  blendFuncSeparateiOES(buf: number, srcRGB: GL, dstRGB: GL, srcAlpha: GL, dstAlpha: GL): void;
+  blendFuncSeparateiOES(
+    buf: number,
+    srcRGB: GLValue,
+    dstRGB: GLValue,
+    srcAlpha: GLValue,
+    dstAlpha: GLValue
+  ): void;
   /** Modifies color mask for an individual draw buffer */
   colorMaskiOES(buf: number, r: boolean, g: boolean, b: boolean, a: boolean): void;
 };
@@ -806,8 +841,8 @@ type WEBGL_shader_pixel_local_storage = {
   // framebufferPixelLocalClearValueuivWEBGL(plane: number,
   //                                                   Uint32List value,
   //                                                   optional unsigned long long srcOffset = 0): void;
-  beginPixelLocalStorageWEBGL(loadops: GL[]): void;
-  endPixelLocalStorageWEBGL(storeops: GL[]): void;
+  beginPixelLocalStorageWEBGL(loadops: GLValue[]): void;
+  endPixelLocalStorageWEBGL(storeops: GLValue[]): void;
   pixelLocalStorageBarrierWEBGL(): void;
-  getFramebufferPixelLocalStorageParameterWEBGL(plane: number, pname: GL): any;
+  getFramebufferPixelLocalStorageParameterWEBGL(plane: number, pname: GLValue): any;
 };

--- a/modules/webgl/src/context/debug/webgl-developer-tools.ts
+++ b/modules/webgl/src/context/debug/webgl-developer-tools.ts
@@ -88,9 +88,10 @@ function getDebugContext(
   );
 
   // Make sure we have all WebGL2 and extension constants (todo dynamic import to circumvent minification?)
-  for (const key in GLEnum) {
-    if (!(key in glDebug) && typeof GLEnum[key] === 'number') {
-      glDebug[key] = GLEnum[key];
+  const glDebugConstants = glDebug as unknown as Record<string, number>;
+  for (const [key, value] of Object.entries(GLEnum)) {
+    if (!(key in glDebug)) {
+      glDebugConstants[key] = value;
     }
   }
 

--- a/modules/webgl/src/context/parameters/webgl-parameter-tables.ts
+++ b/modules/webgl/src/context/parameters/webgl-parameter-tables.ts
@@ -94,19 +94,19 @@ export const GL_PARAMETER_DEFAULTS: GLParameters = {
 
 // SETTER TABLES - ENABLES SETTING ANY PARAMETER WITH A COMMON API
 
-const enable = (gl: WebGL2RenderingContext, value: unknown, key: GL) =>
+const enable = (gl: WebGL2RenderingContext, value: unknown, key: number) =>
   value ? gl.enable(key) : gl.disable(key);
-const hint = (gl: WebGL2RenderingContext, value: GL, key: GL) => gl.hint(key, value);
-const pixelStorei = (gl: WebGL2RenderingContext, value: number | boolean, key: GL) =>
+const hint = (gl: WebGL2RenderingContext, value: number, key: number) => gl.hint(key, value);
+const pixelStorei = (gl: WebGL2RenderingContext, value: number | boolean, key: number) =>
   gl.pixelStorei(key, value);
 
-const bindFramebuffer = (gl: WebGL2RenderingContext, value: unknown, key: GL) => {
+const bindFramebuffer = (gl: WebGL2RenderingContext, value: unknown, key: number) => {
   const target = key === GL.FRAMEBUFFER_BINDING ? GL.DRAW_FRAMEBUFFER : GL.READ_FRAMEBUFFER;
   return gl.bindFramebuffer(target, value as WebGLFramebuffer);
 };
 
-const bindBuffer = (gl: WebGL2RenderingContext, value: unknown, key: GL) => {
-  const bindingMap: Partial<Record<GL, GL>> = {
+const bindBuffer = (gl: WebGL2RenderingContext, value: unknown, key: number) => {
+  const bindingMap: Partial<Record<number, number>> = {
     [GL.ARRAY_BUFFER_BINDING]: GL.ARRAY_BUFFER,
     [GL.COPY_READ_BUFFER_BINDING]: GL.COPY_READ_BUFFER,
     [GL.COPY_WRITE_BUFFER_BINDING]: GL.COPY_WRITE_BUFFER,
@@ -402,19 +402,19 @@ type UpdateFunc = (params: Record<string, any>) => void;
 export const GL_HOOKED_SETTERS = {
   // GENERIC SETTERS
 
-  enable: (update: UpdateFunc, capability: GL) =>
+  enable: (update: UpdateFunc, capability: number) =>
     update({
       [capability]: true
     }),
-  disable: (update: UpdateFunc, capability: GL) =>
+  disable: (update: UpdateFunc, capability: number) =>
     update({
       [capability]: false
     }),
-  pixelStorei: (update: UpdateFunc, pname: GL, value) =>
+  pixelStorei: (update: UpdateFunc, pname: number, value) =>
     update({
       [pname]: value
     }),
-  hint: (update: UpdateFunc, pname: GL, value: GL) =>
+  hint: (update: UpdateFunc, pname: number, value: number) =>
     update({
       [pname]: value
     }),

--- a/modules/webgl/src/index.ts
+++ b/modules/webgl/src/index.ts
@@ -11,6 +11,7 @@
 // Types
 export type {WebGLDeviceLimits} from './adapter/device-helpers/webgl-device-limits';
 export {GL} from './constants/webgl-constants';
+export type {GLConstant, GLValue} from './constants/webgl-constants';
 export type {
   GLTextureTarget,
   GLTextureCubeMapTarget,

--- a/modules/webgl/src/webgl-constants.ts
+++ b/modules/webgl/src/webgl-constants.ts
@@ -3,3 +3,4 @@
 // Copyright (c) vis.gl contributors
 
 export {GL} from './constants/webgl-constants';
+export type {GLConstant, GLValue} from './constants/webgl-constants';

--- a/modules/webgl/test/constants/webgl-constants.node.spec.ts
+++ b/modules/webgl/test/constants/webgl-constants.node.spec.ts
@@ -1,0 +1,19 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {GL, type GLConstant, type GLValue} from '@luma.gl/webgl/constants';
+
+test('WebGL constants use a forward-only mapping', t => {
+  const triangles: GLConstant<'TRIANGLES'> = GL.TRIANGLES;
+  const webglConstant: GLValue = triangles;
+
+  t.is(webglConstant, 0x0004, 'named constants preserve their numeric values');
+  t.notOk(String(GL.TRIANGLES) in GL, 'numeric reverse mappings are not generated');
+  t.ok(
+    Object.values(GL).every(value => typeof value === 'number'),
+    'the mapping contains only forward numeric values'
+  );
+  t.end();
+});


### PR DESCRIPTION
Addresses the GL enum portion of #2852.

## Goals

- Remove TypeScript numeric-enum reverse mappings from the WebGL constants table.
- Preserve named constants and permissive WebGL numeric boundary types.
- Reduce the tracked WebGL/backend and adapter application bundles.

## Changes

- Replaces the `GL` numeric enum with a forward-only `as const` object.
- Adds `GLConstant<Name>` for named literal values and `GLValue` for general WebGL constants.
- Migrates enum-member type references to object-compatible literal types.
- Updates the debug-context constant installation loop for forward-only entries.
- Adds a regression test confirming numeric reverse mappings are absent.
- Documents the type/API migration as a v9.4 breaking change.

## Bundle impact

Measured with the source-level fixtures from #2853 against `master`:

| Fixture | Master gzip | This PR gzip | Reduction |
| --- | ---: | ---: | ---: |
| WebGL backend | 38,473 B | 37,509 B | 964 B |
| `luma + webgl2Adapter` | 59,907 B | 58,692 B | 1,215 B |

The tracked application also drops 4,310 minified bytes and 1,029 Brotli bytes. Combined with #2857, this projects the application fixture below the 50 KB gzip target.

The emitted `@luma.gl/webgl/constants` CommonJS entry drops from 46.9 KB to 38.7 KB.

## Verification

- `nvm use` — Node v22.22.1
- `yarn lint fix` — passed
- `yarn build` — passed
- `yarn test-node modules/webgl/test/constants/webgl-constants.node.spec.ts` — 1 passed
- `yarn test` node suite — 333 passed, 2 skipped
- `yarn test` headless suite — 1,420 passed, 25 skipped; 4 known unrelated WebGPU failures remain (volumetric fire, Arrow DGGS, Arrow Layers storage, and shadertools DGGS)
- `yarn install` — not rerun; existing workspace dependencies used
- `yarn website:build` — not run; no website runtime changes
- `(cd website && yarn build)` — not run; no website package changes

## Compatibility

Named runtime access such as `GL.TRIANGLES` is unchanged. Numeric reverse lookup such as `GL[GL.TRIANGLES]` is intentionally removed and documented in the upgrade guide.