### PR TITLE
perf(core): decouple luma from Device defaults

### DIFF
--- a/modules/core/src/adapter/device-defaults.ts
+++ b/modules/core/src/adapter/device-defaults.ts
@@ -1,0 +1,91 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {log} from '../utils/log';
+import type {DeviceProps} from './device';
+
+/** Shared defaults for device creation without importing the Device class. */
+export const DEVICE_DEFAULT_PROPS: Required<DeviceProps> = {
+  id: null!,
+  powerPreference: 'high-performance',
+  failIfMajorPerformanceCaveat: false,
+  featureLevel: undefined!,
+  createCanvasContext: undefined!,
+  // WebGL specific
+  webgl: {},
+
+  // Callbacks
+  // eslint-disable-next-line handle-callback-err
+  onError: (error: Error, context: unknown) => {},
+  onResize: (context, info) => {
+    const [width, height] = context.getDevicePixelSize();
+    log.log(1, `${context} resized => ${width}x${height}px`)();
+  },
+  onPositionChange: (context, info) => {
+    const [left, top] = context.getPosition();
+    log.log(1, `${context} repositioned => ${left},${top}`)();
+  },
+  onVisibilityChange: context => log.log(1, `${context} Visibility changed ${context.isVisible}`)(),
+  onDevicePixelRatioChange: (context, info) =>
+    log.log(1, `${context} DPR changed ${info.oldRatio} => ${context.devicePixelRatio}`)(),
+
+  // Debug flags
+  debug: getDefaultDebugValue(),
+  debugGPUTime: false,
+  debugShaders: log.get('debug-shaders') || undefined!,
+  debugFramebuffers: Boolean(log.get('debug-framebuffers')),
+  debugFactories: Boolean(log.get('debug-factories')),
+  debugWebGL: Boolean(log.get('debug-webgl')),
+  debugSpectorJS: undefined!, // Note: log setting is queried by the spector.js code
+  debugSpectorJSUrl: undefined!,
+
+  // Experimental
+  _reuseDevices: false,
+  _cacheShaders: true,
+  _destroyShaders: false,
+  _cachePipelines: true,
+  _sharePipelines: true,
+  _destroyPipelines: false,
+  // TODO - Change these after confirming things work as expected
+  _initializeFeatures: true,
+  _disabledFeatures: {
+    'compilation-status-async-webgl': true
+  },
+
+  // INTERNAL
+  _handle: undefined!
+};
+
+/**
+ * Internal helper for resolving the default `debug` prop.
+ * Precedence is: explicit log debug value first, then `NODE_ENV`, then `false`.
+ */
+export function _getDefaultDebugValue(logDebugValue: unknown, nodeEnv?: string): boolean {
+  if (logDebugValue !== undefined && logDebugValue !== null) {
+    return Boolean(logDebugValue);
+  }
+
+  if (nodeEnv !== undefined) {
+    return nodeEnv !== 'production';
+  }
+
+  return false;
+}
+
+function getDefaultDebugValue(): boolean {
+  return _getDefaultDebugValue(log.get('debug'), getNodeEnv());
+}
+
+function getNodeEnv(): string | undefined {
+  const processObject = (
+    globalThis as typeof globalThis & {
+      process?: {env?: Record<string, string | undefined>};
+    }
+  ).process;
+  if (!processObject?.env) {
+    return undefined;
+  }
+
+  return processObject.env['NODE_ENV'];
+}

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -39,6 +39,9 @@ import {textureFormatDecoder} from '../shadertypes/texture-types/texture-format-
 import type {ExternalImage} from '../shadertypes/image-types/image-types';
 import {isExternalImage, getExternalImageSize} from '../shadertypes/image-types/image-types';
 import {getTextureFormatTable} from '../shadertypes/texture-types/texture-format-table';
+import {DEVICE_DEFAULT_PROPS} from './device-defaults';
+
+export {_getDefaultDebugValue} from './device-defaults';
 
 /**
  * Identifies the GPU vendor and driver.
@@ -487,57 +490,7 @@ export interface DeviceFactory {
  * WebGPU Device/WebGL context abstraction
  */
 export abstract class Device {
-  static defaultProps: Required<DeviceProps> = {
-    id: null!,
-    powerPreference: 'high-performance',
-    failIfMajorPerformanceCaveat: false,
-    featureLevel: undefined!,
-    createCanvasContext: undefined!,
-    // WebGL specific
-    webgl: {},
-
-    // Callbacks
-    // eslint-disable-next-line handle-callback-err
-    onError: (error: Error, context: unknown) => {},
-    onResize: (context: CanvasContext, info: {oldPixelSize: [number, number]}) => {
-      const [width, height] = context.getDevicePixelSize();
-      log.log(1, `${context} resized => ${width}x${height}px`)();
-    },
-    onPositionChange: (context: CanvasContext, info: {oldPosition: [number, number]}) => {
-      const [left, top] = context.getPosition();
-      log.log(1, `${context} repositioned => ${left},${top}`)();
-    },
-    onVisibilityChange: (context: CanvasContext) =>
-      log.log(1, `${context} Visibility changed ${context.isVisible}`)(),
-    onDevicePixelRatioChange: (context: CanvasContext, info: {oldRatio: number}) =>
-      log.log(1, `${context} DPR changed ${info.oldRatio} => ${context.devicePixelRatio}`)(),
-
-    // Debug flags
-    debug: getDefaultDebugValue(),
-    debugGPUTime: false,
-    debugShaders: log.get('debug-shaders') || undefined!,
-    debugFramebuffers: Boolean(log.get('debug-framebuffers')),
-    debugFactories: Boolean(log.get('debug-factories')),
-    debugWebGL: Boolean(log.get('debug-webgl')),
-    debugSpectorJS: undefined!, // Note: log setting is queried by the spector.js code
-    debugSpectorJSUrl: undefined!,
-
-    // Experimental
-    _reuseDevices: false,
-    _cacheShaders: true,
-    _destroyShaders: false,
-    _cachePipelines: true,
-    _sharePipelines: true,
-    _destroyPipelines: false,
-    // TODO - Change these after confirming things work as expected
-    _initializeFeatures: true,
-    _disabledFeatures: {
-      'compilation-status-async-webgl': true
-    },
-
-    // INTERNAL
-    _handle: undefined!
-  };
+  static defaultProps: Required<DeviceProps> = {...DEVICE_DEFAULT_PROPS};
 
   get [Symbol.toStringTag](): string {
     return 'Device';
@@ -1098,37 +1051,4 @@ or create a device with the 'debug: true' prop.`;
 
     return newProps;
   }
-}
-
-/**
- * Internal helper for resolving the default `debug` prop.
- * Precedence is: explicit log debug value first, then `NODE_ENV`, then `false`.
- */
-export function _getDefaultDebugValue(logDebugValue: unknown, nodeEnv?: string): boolean {
-  if (logDebugValue !== undefined && logDebugValue !== null) {
-    return Boolean(logDebugValue);
-  }
-
-  if (nodeEnv !== undefined) {
-    return nodeEnv !== 'production';
-  }
-
-  return false;
-}
-
-function getDefaultDebugValue(): boolean {
-  return _getDefaultDebugValue(log.get('debug'), getNodeEnv());
-}
-
-function getNodeEnv(): string | undefined {
-  const processObject = (
-    globalThis as typeof globalThis & {
-      process?: {env?: Record<string, string | undefined>};
-    }
-  ).process;
-  if (!processObject?.env) {
-    return undefined;
-  }
-
-  return processObject.env['NODE_ENV'];
 }

--- a/modules/core/src/adapter/luma.ts
+++ b/modules/core/src/adapter/luma.ts
@@ -3,8 +3,8 @@
 // Copyright (c) vis.gl contributors
 
 import type {Log} from '@probe.gl/log';
-import type {DeviceProps} from './device';
-import {Device} from './device';
+import type {Device, DeviceProps} from './device';
+import {DEVICE_DEFAULT_PROPS} from './device-defaults';
 import {Adapter} from './adapter';
 import {StatsManager, lumaStats} from '../utils/stats-manager';
 import {log} from '../utils/log';
@@ -45,7 +45,7 @@ export type AttachDeviceProps = {
  */
 export class Luma {
   static defaultProps: Required<CreateDeviceProps> = {
-    ...Device.defaultProps,
+    ...DEVICE_DEFAULT_PROPS,
     type: 'best-available',
     adapters: undefined!,
     waitForPageLoad: true


### PR DESCRIPTION
Addresses the shared device-defaults item in #2852.

## Goals

- Keep a named `luma` import from retaining the complete `Device` class.
- Preserve the existing `Luma.defaultProps` and `Device.defaultProps` behavior and compatibility surfaces.
- Keep the change focused and independently reviewable.

## Changes

- Extracts the common device defaults and debug-default resolver into a small internal `device-defaults` module.
- Initializes both `Luma.defaultProps` and `Device.defaultProps` from that shared definition.
- Changes `luma.ts` to use a type-only `Device` import.
- Re-exports the existing internal debug-default helper from `device.ts` so current tests and deep imports continue to work.

## Bundle impact

Measured with an esbuild production fixture that retains only the named `luma` export:

| Metric | Master | This PR | Reduction |
| --- | ---: | ---: | ---: |
| Minified | 39,867 B | 14,311 B | 25,556 B |
| gzip | 12,043 B | 5,166 B | 6,877 B |
| Brotli | 10,853 B | 4,639 B | 6,214 B |

This matches the opportunity identified in #2852. Fixtures that also retain a concrete backend already need the `Device` class, so their eventual-transfer size is intentionally unchanged by this slice.

## Verification

- `nvm use` — Node v22.22.1
- `yarn lint fix` — passed
- `yarn build` — passed
- `yarn test-headless modules/core/test/adapter/device.spec.ts` — 9 passed, 1 skipped
- `yarn test` node suite — 332 passed, 2 skipped
- `yarn test` headless suite — 1,420 passed, 25 skipped; 4 known unrelated WebGPU failures remain (volumetric fire, Arrow DGGS, Arrow Layers storage, and shadertools DGGS)
- `yarn install` — not rerun; existing workspace dependencies used
- `yarn website:build` — not run; no website changes
- `(cd website && yarn build)` — not run; no website package changes

## Risk

Low. The default object values and callback behavior are preserved; only their module ownership changes. Both public static defaults remain separate mutable objects, as before.