### PR TITLE
perf(core): extract lightweight buffer usage flags

### DIFF
--- a/docs/api-reference/core/resources/buffer.md
+++ b/docs/api-reference/core/resources/buffer.md
@@ -22,6 +22,18 @@ Usage expresses two things: The type of buffer and what operations can be perfor
 
 Note that the allowed combinations are very limited, especially in WebGPU.
 
+Import the lightweight `BufferUsage` object when only the flags are needed. The static `Buffer`
+aliases remain available and have the same values.
+
+```ts
+import {BufferUsage} from '@luma.gl/core';
+
+const buffer = device.createBuffer({
+  usage: BufferUsage.VERTEX | BufferUsage.COPY_DST,
+  byteLength: 1024
+});
+```
+
 | Usage Flag             | Value  | Description                                                         |
 | ---------------------- | ------ | ------------------------------------------------------------------- |
 | `Buffer.INDEX`         | 0x0010 | An index buffer (array of 8, 16 or 32 bit unsigned integers)        |

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -107,6 +107,7 @@ Target Release Date: TBD
 
 **@luma.gl/core**
 
+- **Lightweight buffer usage flags** - `BufferUsage` exposes the existing GPU buffer usage bits without retaining the `Buffer` resource hierarchy. The matching `Buffer` static aliases remain available.
 - **[WebGPU render bundles](/examples/api/render-bundles)** - Record reusable draw commands with `RenderBundleEncoder` and replay them from a `RenderPass`, reducing CPU command-recording time for repeated scenes.
 - **Render-pass draw commands** - `RenderPass` now owns pipeline, binding, vertex-array, direct-draw, indirect-draw, and render-bundle commands. The former `RenderPipeline` draw and binding APIs remain as deprecated compatibility paths.
 - **WebGPU feature levels** - `DeviceProps.featureLevel` can now request `'core'`, the portable WebGPU default; `'max'`, which requests every adapter feature and supported limit; `'compatibility'`; or `'best-available'`, which upgrades compatibility to core when available. The effective level is reported as `device.info.featureLevel`.

--- a/modules/core/src/adapter/device.ts
+++ b/modules/core/src/adapter/device.ts
@@ -13,8 +13,8 @@ import type {
 } from '../shadertypes/texture-types/texture-formats';
 import type {CanvasContext, CanvasContextProps} from './canvas-context';
 import type {PresentationContext, PresentationContextProps} from './presentation-context';
-import type {BufferProps} from './resources/buffer';
-import {Buffer} from './resources/buffer';
+import type {Buffer, BufferProps} from './resources/buffer';
+import {BufferUsage} from './resources/buffer-usage';
 import type {RenderPipeline, RenderPipelineProps} from './resources/render-pipeline';
 import type {SharedRenderPipeline} from './resources/shared-render-pipeline';
 import type {ComputePipeline, ComputePipelineProps} from './resources/compute-pipeline';
@@ -1079,7 +1079,7 @@ or create a device with the 'debug: true' prop.`;
     const newProps = {...props};
     // Deduce indexType
     const usage = props.usage || 0;
-    if (usage & Buffer.INDEX) {
+    if (usage & BufferUsage.INDEX) {
       if (!props.indexType) {
         if (props.data instanceof Uint32Array) {
           newProps.indexType = 'uint32';

--- a/modules/core/src/adapter/resources/buffer-usage.ts
+++ b/modules/core/src/adapter/resources/buffer-usage.ts
@@ -1,0 +1,17 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Lightweight buffer usage flags that can be imported without the Buffer class hierarchy. */
+export const BufferUsage = {
+  MAP_READ: 0x0001,
+  MAP_WRITE: 0x0002,
+  COPY_SRC: 0x0004,
+  COPY_DST: 0x0008,
+  INDEX: 0x0010,
+  VERTEX: 0x0020,
+  UNIFORM: 0x0040,
+  STORAGE: 0x0080,
+  INDIRECT: 0x0100,
+  QUERY_RESOLVE: 0x0200
+} as const;

--- a/modules/core/src/adapter/resources/buffer.ts
+++ b/modules/core/src/adapter/resources/buffer.ts
@@ -4,6 +4,7 @@
 
 import type {Device} from '../device';
 import {Resource, ResourceProps} from './resource';
+import {BufferUsage} from './buffer-usage';
 
 /** Callback for Buffer.mapAndReadAsync */
 export type BufferMapCallback<T> = (arrayBuffer: ArrayBuffer, lifetime: 'mapped' | 'copied') => T;
@@ -28,21 +29,21 @@ export type BufferProps = ResourceProps & {
 /** Abstract GPU buffer */
 export abstract class Buffer extends Resource<BufferProps> {
   /** Index buffer */
-  static INDEX = 0x0010;
+  static INDEX: number = BufferUsage.INDEX;
   /** Vertex buffer */
-  static VERTEX = 0x0020;
+  static VERTEX: number = BufferUsage.VERTEX;
   /** Uniform buffer */
-  static UNIFORM = 0x0040;
+  static UNIFORM: number = BufferUsage.UNIFORM;
   /** Storage buffer */
-  static STORAGE = 0x0080;
-  static INDIRECT = 0x0100;
-  static QUERY_RESOLVE = 0x0200;
+  static STORAGE: number = BufferUsage.STORAGE;
+  static INDIRECT: number = BufferUsage.INDIRECT;
+  static QUERY_RESOLVE: number = BufferUsage.QUERY_RESOLVE;
 
   // Usage Flags
-  static MAP_READ = 0x01;
-  static MAP_WRITE = 0x02;
-  static COPY_SRC = 0x0004;
-  static COPY_DST = 0x0008;
+  static MAP_READ: number = BufferUsage.MAP_READ;
+  static MAP_WRITE: number = BufferUsage.MAP_WRITE;
+  static COPY_SRC: number = BufferUsage.COPY_SRC;
+  static COPY_DST: number = BufferUsage.COPY_DST;
 
   override get [Symbol.toStringTag](): string {
     return 'Buffer';

--- a/modules/core/src/index.ts
+++ b/modules/core/src/index.ts
@@ -29,6 +29,7 @@ export {PresentationContext} from './adapter/presentation-context';
 export {Resource, type ResourceProps} from './adapter/resources/resource';
 
 export {Buffer, type BufferProps, type BufferMapCallback} from './adapter/resources/buffer';
+export {BufferUsage} from './adapter/resources/buffer-usage';
 
 export {Texture, type TextureProps} from './adapter/resources/texture';
 

--- a/modules/core/src/portable/uniform-store.ts
+++ b/modules/core/src/portable/uniform-store.ts
@@ -6,7 +6,8 @@ import type {CompositeShaderType} from '../shadertypes/shader-types/shader-types
 import type {CompositeUniformValue} from '../adapter/types/uniforms';
 import type {Device} from '../adapter/device';
 import type {CommandEncoder} from '../adapter/resources/command-encoder';
-import {Buffer} from '../adapter/resources/buffer';
+import type {Buffer} from '../adapter/resources/buffer';
+import {BufferUsage} from '../adapter/resources/buffer-usage';
 import {log} from '../utils/log';
 import {
   makeShaderBlockLayout,
@@ -159,7 +160,7 @@ export class UniformStore<
     }
     const byteLength = this.getUniformBufferByteLength(uniformBufferName);
     const uniformBuffer = this.device.createBuffer({
-      usage: Buffer.UNIFORM | Buffer.COPY_DST,
+      usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
       byteLength
     });
     // Note that this clears the needs redraw flag
@@ -173,7 +174,7 @@ export class UniformStore<
     if (!this.uniformBuffers.get(uniformBufferName)) {
       const byteLength = this.getUniformBufferByteLength(uniformBufferName);
       const uniformBuffer = this.device.createBuffer({
-        usage: Buffer.UNIFORM | Buffer.COPY_DST,
+        usage: BufferUsage.UNIFORM | BufferUsage.COPY_DST,
         byteLength
       });
       this.uniformBuffers.set(uniformBufferName, uniformBuffer);

--- a/modules/core/test/adapter/resources/buffer-usage.node.spec.ts
+++ b/modules/core/test/adapter/resources/buffer-usage.node.spec.ts
@@ -1,0 +1,13 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {Buffer, BufferUsage} from '@luma.gl/core';
+
+test('BufferUsage preserves Buffer static aliases', t => {
+  for (const name of Object.keys(BufferUsage) as (keyof typeof BufferUsage)[]) {
+    t.is(BufferUsage[name], Buffer[name], `${name} alias matches`);
+  }
+  t.end();
+});


### PR DESCRIPTION
Addresses the shared buffer-usage constants item in #2852.

## Goals

- Stop `Device` and `UniformStore` from retaining the `Buffer` resource hierarchy only to read usage bits.
- Offer applications a lightweight way to specify buffer usage.
- Preserve every existing `Buffer.*` static alias and its public type.

## Changes

- Adds the exported forward-only `BufferUsage` object.
- Initializes the existing mutable `Buffer` static aliases from the shared values while retaining their `number` declarations.
- Changes `Device` and `UniformStore` to import only the lightweight flags at runtime and `Buffer` as a type.
- Adds an alias-compatibility regression test and documents the lightweight API.

## Bundle impact

Measured with esbuild production fixtures retaining one named export:

| Fixture | Metric | Master | This PR | Reduction |
| --- | --- | ---: | ---: | ---: |
| `Device` | Minified | 37,604 B | 30,623 B | 6,981 B |
| `Device` | gzip | 11,194 B | 9,585 B | 1,609 B |
| `Device` | Brotli | 10,122 B | 8,658 B | 1,464 B |
| `UniformStore` | Minified | 26,429 B | 19,205 B | 7,224 B |
| `UniformStore` | gzip | 8,312 B | 6,301 B | 2,011 B |
| `UniformStore` | Brotli | 7,339 B | 5,513 B | 1,826 B |

A standalone `BufferUsage` import is 158 bytes minified / 163 bytes gzip / 142 bytes Brotli.

## Verification

- `nvm use` — Node v22.22.1
- `yarn lint fix` — passed
- `yarn build` — passed, including declaration generation confirming the existing `Buffer` aliases remain typed as `number`
- `yarn test-node modules/core/test/adapter/resources/buffer-usage.node.spec.ts` — 1 passed
- `yarn test-headless modules/core/test/portable/uniform-buffer-layout.spec.ts modules/core/test/adapter/resources/buffer.spec.ts` — 30 passed
- `yarn test` node suite — 333 passed, 2 skipped
- `yarn test` headless suite — 1,420 passed, 25 skipped; 4 known unrelated WebGPU failures remain (volumetric fire, Arrow DGGS, Arrow Layers storage, and shadertools DGGS)
- `yarn install` — not rerun; existing workspace dependencies used
- `yarn website:build` — not run; documentation-only website changes
- `(cd website && yarn build)` — not run; no website package changes

## Compatibility

`Buffer.INDEX`, `Buffer.UNIFORM`, and the other static fields remain available, mutable, and typed as `number`. Their initial runtime values are unchanged.