### PR TITLE
perf(core): parse shader type metadata

### DIFF
--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -107,6 +107,7 @@ Target Release Date: TBD
 
 **@luma.gl/core**
 
+- **Compact shader type decoding** - Shader variable and attribute metadata is parsed and cached from WGSL-style type names instead of shipping exhaustive runtime lookup tables.
 - **[WebGPU render bundles](/examples/api/render-bundles)** - Record reusable draw commands with `RenderBundleEncoder` and replay them from a `RenderPass`, reducing CPU command-recording time for repeated scenes.
 - **Render-pass draw commands** - `RenderPass` now owns pipeline, binding, vertex-array, direct-draw, indirect-draw, and render-bundle commands. The former `RenderPipeline` draw and binding APIs remain as deprecated compatibility paths.
 - **WebGPU feature levels** - `DeviceProps.featureLevel` can now request `'core'`, the portable WebGPU default; `'max'`, which requests every adapter feature and supported limit; `'compatibility'`; or `'best-available'`, which upgrades compatibility to core when available. The effective level is reported as `device.info.featureLevel`.

--- a/modules/core/src/shadertypes/shader-types/shader-type-decoder.ts
+++ b/modules/core/src/shadertypes/shader-types/shader-type-decoder.ts
@@ -35,7 +35,7 @@ export function getVariableShaderTypeInfo(
   format: VariableShaderType | VariableShaderTypeAlias
 ): VariableShaderTypeInfo {
   const resolvedFormat = resolveVariableShaderTypeAlias(format);
-  const decoded = UNIFORM_FORMATS[resolvedFormat];
+  const decoded = parseVariableShaderType(resolvedFormat);
   if (!decoded) {
     throw new Error(`Unsupported variable shader type: ${format}`);
   }
@@ -47,15 +47,15 @@ export function getAttributeShaderTypeInfo(
   attributeType: AttributeShaderType | AttributeShaderTypeAlias
 ): AttributeShaderTypeInfo {
   const resolvedAttributeType = resolveAttributeShaderTypeAlias(attributeType);
-  const decoded = TYPE_INFO[resolvedAttributeType];
-  if (!decoded) {
+  const decoded = parseVariableShaderType(resolvedAttributeType);
+  if (!decoded || resolvedAttributeType.startsWith('mat') || decoded.components > 4) {
     throw new Error(`Unsupported attribute shader type: ${attributeType}`);
   }
-  const [primitiveType, components] = decoded;
+  const {type: primitiveType} = decoded;
+  const components = decoded.components as 1 | 2 | 3 | 4;
   const integer: boolean = primitiveType === 'i32' || primitiveType === 'u32';
   const signed: boolean = primitiveType !== 'u32';
-
-  const byteLength = PRIMITIVE_TYPE_SIZES[primitiveType] * components;
+  const byteLength = (primitiveType === 'f16' ? 2 : 4) * components;
   return {
     primitiveType,
     components,
@@ -108,178 +108,59 @@ export function makeShaderAttributeType(
 export function resolveAttributeShaderTypeAlias(
   alias: AttributeShaderTypeAlias | AttributeShaderType
 ): AttributeShaderType {
-  return WGSL_ATTRIBUTE_TYPE_ALIAS_MAP[alias as AttributeShaderTypeAlias] || alias;
+  return resolveShaderTypeAlias(alias, /^vec[2-4]([fiuh])$/) as AttributeShaderType;
 }
 
 export function resolveVariableShaderTypeAlias(
   alias: VariableShaderTypeAlias | VariableShaderType
 ): VariableShaderType {
-  return WGSL_VARIABLE_TYPE_ALIAS_MAP[alias as VariableShaderTypeAlias] || alias;
+  return resolveShaderTypeAlias(alias, /^(?:vec[2-4]|mat[2-4]x[2-4])([fiuh])$/);
 }
 
 /** Decoder for luma.gl shader types */
 export const shaderTypeDecoder = new ShaderTypeDecoder();
 
-// TABLES
+const VARIABLE_TYPE_INFO_CACHE = new Map<string, VariableShaderTypeInfo>();
+const ALIAS_PRIMITIVE_TYPES = {f: 'f32', h: 'f16', i: 'i32', u: 'u32'} as const;
 
-const PRIMITIVE_TYPE_SIZES: Record<PrimitiveDataType, 2 | 4> = {
-  f32: 4,
-  f16: 2,
-  i32: 4,
-  u32: 4
-  // 'bool-webgl': 4,
-};
+function parseVariableShaderType(format: string): VariableShaderTypeInfo | null {
+  const cached = VARIABLE_TYPE_INFO_CACHE.get(format);
+  if (cached) {
+    return cached;
+  }
 
-/** All valid shader attribute types. A table guarantees exhaustive list and fast execution */
-const TYPE_INFO: Record<AttributeShaderType, [PrimitiveDataType, components: 1 | 2 | 3 | 4]> = {
-  f32: ['f32', 1],
-  'vec2<f32>': ['f32', 2],
-  'vec3<f32>': ['f32', 3],
-  'vec4<f32>': ['f32', 4],
-  f16: ['f16', 1],
-  'vec2<f16>': ['f16', 2],
-  'vec3<f16>': ['f16', 3],
-  'vec4<f16>': ['f16', 4],
-  i32: ['i32', 1],
-  'vec2<i32>': ['i32', 2],
-  'vec3<i32>': ['i32', 3],
-  'vec4<i32>': ['i32', 4],
-  u32: ['u32', 1],
-  'vec2<u32>': ['u32', 2],
-  'vec3<u32>': ['u32', 3],
-  'vec4<u32>': ['u32', 4]
-};
+  let type: PrimitiveDataType;
+  let components: number;
+  const primitiveMatch = /^(f16|f32|i32|u32)$/.exec(format);
+  if (primitiveMatch) {
+    type = primitiveMatch[1] as PrimitiveDataType;
+    components = 1;
+  } else {
+    const compositeMatch = /^(?:vec([2-4])|mat([2-4])x([2-4]))<(f16|f32|i32|u32)>$/.exec(format);
+    if (!compositeMatch) {
+      return null;
+    }
+    type = compositeMatch[4] as PrimitiveDataType;
+    components = compositeMatch[1]
+      ? Number(compositeMatch[1])
+      : Number(compositeMatch[2]) * Number(compositeMatch[3]);
+  }
 
-/** @todo These tables are quite big, consider parsing type strings instead */
-const UNIFORM_FORMATS: Record<VariableShaderType, {type: PrimitiveDataType; components: number}> = {
-  f32: {type: 'f32', components: 1},
-  f16: {type: 'f16', components: 1},
-  i32: {type: 'i32', components: 1},
-  u32: {type: 'u32', components: 1},
-  // 'bool-webgl': {type: 'bool-webgl', components: 1},
-  'vec2<f32>': {type: 'f32', components: 2},
-  'vec3<f32>': {type: 'f32', components: 3},
-  'vec4<f32>': {type: 'f32', components: 4},
-  'vec2<f16>': {type: 'f16', components: 2},
-  'vec3<f16>': {type: 'f16', components: 3},
-  'vec4<f16>': {type: 'f16', components: 4},
-  'vec2<i32>': {type: 'i32', components: 2},
-  'vec3<i32>': {type: 'i32', components: 3},
-  'vec4<i32>': {type: 'i32', components: 4},
-  'vec2<u32>': {type: 'u32', components: 2},
-  'vec3<u32>': {type: 'u32', components: 3},
-  'vec4<u32>': {type: 'u32', components: 4},
+  const typeInfo = {type, components};
+  VARIABLE_TYPE_INFO_CACHE.set(format, typeInfo);
+  return typeInfo;
+}
 
-  'mat2x2<f32>': {type: 'f32', components: 4},
-  'mat2x3<f32>': {type: 'f32', components: 6},
-  'mat2x4<f32>': {type: 'f32', components: 8},
-  'mat3x2<f32>': {type: 'f32', components: 6},
-  'mat3x3<f32>': {type: 'f32', components: 9},
-  'mat3x4<f32>': {type: 'f32', components: 12},
-  'mat4x2<f32>': {type: 'f32', components: 8},
-  'mat4x3<f32>': {type: 'f32', components: 12},
-  'mat4x4<f32>': {type: 'f32', components: 16},
+function resolveShaderTypeAlias(alias: string, aliasPattern: RegExp): VariableShaderType {
+  const match = aliasPattern.exec(alias);
+  if (!match) {
+    return alias as VariableShaderType;
+  }
+  const primitiveType = getAliasPrimitiveType(match[1]);
+  return `${alias.slice(0, -1)}<${primitiveType}>` as VariableShaderType;
+}
 
-  'mat2x2<f16>': {type: 'f16', components: 4},
-  'mat2x3<f16>': {type: 'f16', components: 6},
-  'mat2x4<f16>': {type: 'f16', components: 8},
-  'mat3x2<f16>': {type: 'f16', components: 6},
-  'mat3x3<f16>': {type: 'f16', components: 9},
-  'mat3x4<f16>': {type: 'f16', components: 12},
-  'mat4x2<f16>': {type: 'f16', components: 8},
-  'mat4x3<f16>': {type: 'f16', components: 12},
-  'mat4x4<f16>': {type: 'f16', components: 16},
-
-  'mat2x2<i32>': {type: 'i32', components: 4},
-  'mat2x3<i32>': {type: 'i32', components: 6},
-  'mat2x4<i32>': {type: 'i32', components: 8},
-  'mat3x2<i32>': {type: 'i32', components: 6},
-  'mat3x3<i32>': {type: 'i32', components: 9},
-  'mat3x4<i32>': {type: 'i32', components: 12},
-  'mat4x2<i32>': {type: 'i32', components: 8},
-  'mat4x3<i32>': {type: 'i32', components: 12},
-  'mat4x4<i32>': {type: 'i32', components: 16},
-
-  'mat2x2<u32>': {type: 'u32', components: 4},
-  'mat2x3<u32>': {type: 'u32', components: 6},
-  'mat2x4<u32>': {type: 'u32', components: 8},
-  'mat3x2<u32>': {type: 'u32', components: 6},
-  'mat3x3<u32>': {type: 'u32', components: 9},
-  'mat3x4<u32>': {type: 'u32', components: 12},
-  'mat4x2<u32>': {type: 'u32', components: 8},
-  'mat4x3<u32>': {type: 'u32', components: 12},
-  'mat4x4<u32>': {type: 'u32', components: 16}
-};
-
-/**  Predeclared aliases @see https://www.w3.org/TR/WGSL/#vector-types */
-export const WGSL_ATTRIBUTE_TYPE_ALIAS_MAP: Record<AttributeShaderTypeAlias, AttributeShaderType> =
-  {
-    vec2i: 'vec2<i32>',
-    vec3i: 'vec3<i32>',
-    vec4i: 'vec4<i32>',
-    vec2u: 'vec2<u32>',
-    vec3u: 'vec3<u32>',
-    vec4u: 'vec4<u32>',
-    vec2f: 'vec2<f32>',
-    vec3f: 'vec3<f32>',
-    vec4f: 'vec4<f32>',
-    // Requires the f16 extension.
-    vec2h: 'vec2<f16>',
-    vec3h: 'vec3<f16>',
-    vec4h: 'vec4<f16>'
-  };
-
-/** @todo These tables are quite big, consider parsing alias strings instead */
-export const WGSL_VARIABLE_TYPE_ALIAS_MAP: Record<VariableShaderTypeAlias, VariableShaderType> = {
-  vec2i: 'vec2<i32>',
-  vec3i: 'vec3<i32>',
-  vec4i: 'vec4<i32>',
-  vec2u: 'vec2<u32>',
-  vec3u: 'vec3<u32>',
-  vec4u: 'vec4<u32>',
-  vec2f: 'vec2<f32>',
-  vec3f: 'vec3<f32>',
-  vec4f: 'vec4<f32>',
-  vec2h: 'vec2<f16>',
-  vec3h: 'vec3<f16>',
-  vec4h: 'vec4<f16>',
-  mat2x2f: 'mat2x2<f32>',
-  mat2x3f: 'mat2x3<f32>',
-  mat2x4f: 'mat2x4<f32>',
-  mat3x2f: 'mat3x2<f32>',
-  mat3x3f: 'mat3x3<f32>',
-  mat3x4f: 'mat3x4<f32>',
-  mat4x2f: 'mat4x2<f32>',
-  mat4x3f: 'mat4x3<f32>',
-  mat4x4f: 'mat4x4<f32>',
-
-  mat2x2i: 'mat2x2<i32>',
-  mat2x3i: 'mat2x3<i32>',
-  mat2x4i: 'mat2x4<i32>',
-  mat3x2i: 'mat3x2<i32>',
-  mat3x3i: 'mat3x3<i32>',
-  mat3x4i: 'mat3x4<i32>',
-  mat4x2i: 'mat4x2<i32>',
-  mat4x3i: 'mat4x3<i32>',
-  mat4x4i: 'mat4x4<i32>',
-
-  mat2x2u: 'mat2x2<u32>',
-  mat2x3u: 'mat2x3<u32>',
-  mat2x4u: 'mat2x4<u32>',
-  mat3x2u: 'mat3x2<u32>',
-  mat3x3u: 'mat3x3<u32>',
-  mat3x4u: 'mat3x4<u32>',
-  mat4x2u: 'mat4x2<u32>',
-  mat4x3u: 'mat4x3<u32>',
-  mat4x4u: 'mat4x4<u32>',
-
-  mat2x2h: 'mat2x2<f16>',
-  mat2x3h: 'mat2x3<f16>',
-  mat2x4h: 'mat2x4<f16>',
-  mat3x2h: 'mat3x2<f16>',
-  mat3x3h: 'mat3x3<f16>',
-  mat3x4h: 'mat3x4<f16>',
-  mat4x2h: 'mat4x2<f16>',
-  mat4x3h: 'mat4x3<f16>',
-  mat4x4h: 'mat4x4<f16>'
-};
+function getAliasPrimitiveType(suffix: string): PrimitiveDataType {
+  // Alias patterns only accept these four suffixes.
+  return ALIAS_PRIMITIVE_TYPES[suffix as keyof typeof ALIAS_PRIMITIVE_TYPES];
+}

--- a/modules/core/test/shadertypes/shader-type-decoder.spec.ts
+++ b/modules/core/test/shadertypes/shader-type-decoder.spec.ts
@@ -31,6 +31,16 @@ const TEST_CASES: {format: AttributeShaderType | string, result: AttributeShader
   // {format: 'bool-webgl', result: {primitiveType: 'bool-webgl', components: 1, byteLength: 1 * 4, integer: true, signed: false}}
 ];
 
+const PRIMITIVE_TYPES = ['f16', 'f32', 'i32', 'u32'] as const;
+const VECTOR_SIZES = [2, 3, 4] as const;
+const MATRIX_DIMENSIONS = [2, 3, 4] as const;
+const TYPE_ALIAS_SUFFIXES = {
+  h: 'f16',
+  f: 'f32',
+  i: 'i32',
+  u: 'u32'
+} as const;
+
 test('shadertypes#shaderTypeDecoder.getAttributeShaderTypeInfo', t => {
   for (const tc of TEST_CASES) {
     const decoded = shaderTypeDecoder.getAttributeShaderTypeInfo(tc.format);
@@ -38,6 +48,91 @@ test('shadertypes#shaderTypeDecoder.getAttributeShaderTypeInfo', t => {
       decoded,
       tc.result,
       `shaderTypeDecoder.getAttributeShaderTypeInfo('${tc.format}') => ${JSON.stringify(decoded.dataType)}`
+    );
+  }
+
+  for (const [suffix, primitiveType] of Object.entries(TYPE_ALIAS_SUFFIXES)) {
+    for (const components of VECTOR_SIZES) {
+      const alias = `vec${components}${suffix}` as any;
+      const expandedType = `vec${components}<${primitiveType}>` as AttributeShaderType;
+      t.equal(
+        shaderTypeDecoder.resolveAttributeShaderTypeAlias(alias),
+        expandedType,
+        `${alias} resolves to ${expandedType}`
+      );
+      t.deepEqual(
+        shaderTypeDecoder.getAttributeShaderTypeInfo(alias),
+        shaderTypeDecoder.getAttributeShaderTypeInfo(expandedType),
+        `${alias} has the same metadata as ${expandedType}`
+      );
+    }
+  }
+
+  t.throws(
+    () => shaderTypeDecoder.getAttributeShaderTypeInfo('mat2x2<f32>' as any),
+    /Unsupported attribute shader type/,
+    'matrix types are rejected as attributes'
+  );
+  t.end();
+});
+
+test('shadertypes#shaderTypeDecoder parses every variable shader type', t => {
+  for (const primitiveType of PRIMITIVE_TYPES) {
+    t.deepEqual(
+      shaderTypeDecoder.getVariableShaderTypeInfo(primitiveType),
+      {type: primitiveType, components: 1},
+      `${primitiveType} metadata matches`
+    );
+
+    for (const components of VECTOR_SIZES) {
+      const vectorType = `vec${components}<${primitiveType}>` as any;
+      t.deepEqual(
+        shaderTypeDecoder.getVariableShaderTypeInfo(vectorType),
+        {type: primitiveType, components},
+        `${vectorType} metadata matches`
+      );
+    }
+
+    for (const columns of MATRIX_DIMENSIONS) {
+      for (const rows of MATRIX_DIMENSIONS) {
+        const matrixType = `mat${columns}x${rows}<${primitiveType}>` as any;
+        t.deepEqual(
+          shaderTypeDecoder.getVariableShaderTypeInfo(matrixType),
+          {type: primitiveType, components: columns * rows},
+          `${matrixType} metadata matches`
+        );
+      }
+    }
+  }
+
+  for (const [suffix, primitiveType] of Object.entries(TYPE_ALIAS_SUFFIXES)) {
+    for (const components of VECTOR_SIZES) {
+      const alias = `vec${components}${suffix}` as any;
+      const expandedType = `vec${components}<${primitiveType}>`;
+      t.equal(
+        shaderTypeDecoder.resolveVariableShaderTypeAlias(alias),
+        expandedType,
+        `${alias} resolves to ${expandedType}`
+      );
+    }
+    for (const columns of MATRIX_DIMENSIONS) {
+      for (const rows of MATRIX_DIMENSIONS) {
+        const alias = `mat${columns}x${rows}${suffix}` as any;
+        const expandedType = `mat${columns}x${rows}<${primitiveType}>`;
+        t.equal(
+          shaderTypeDecoder.resolveVariableShaderTypeAlias(alias),
+          expandedType,
+          `${alias} resolves to ${expandedType}`
+        );
+      }
+    }
+  }
+
+  for (const invalidType of ['vec5<f32>', 'mat2x5<f32>', 'vec2<f64>', ' vec2<f32>']) {
+    t.throws(
+      () => shaderTypeDecoder.getVariableShaderTypeInfo(invalidType as any),
+      /Unsupported variable shader type/,
+      `${invalidType} is rejected`
     );
   }
   t.end();


### PR DESCRIPTION
Addresses the shader-type lookup-table item in #2852.

## Goals

- Replace exhaustive runtime shader-type and alias tables with compact parsing.
- Preserve all currently accepted primitive, vector, matrix, and WGSL alias forms.
- Reject malformed or attribute-incompatible formats explicitly.
- Keep repeated decoding inexpensive with a small cache.

## Changes

- Parses exact primitive, vector, and matrix type grammars into primitive type and component count.
- Resolves vector and matrix aliases from their compact suffix grammar.
- Caches the finite set of successfully parsed expanded formats.
- Derives attribute byte length and integer/signed flags from parsed metadata.
- Expands the regression corpus to cover every former table entry, every alias family, and invalid formats.
- Removes the now-unused runtime lookup maps.

## Bundle impact

Measured with esbuild production fixtures:

| Fixture | Metric | Master | This PR | Reduction |
| --- | --- | ---: | ---: | ---: |
| Full `@luma.gl/core` | Minified | 97,785 B | 94,751 B | 3,034 B |
| Full `@luma.gl/core` | gzip | 27,522 B | 27,022 B | 500 B |
| Full `@luma.gl/core` | Brotli | 24,222 B | 24,030 B | 192 B |
| `shaderTypeDecoder` | Minified | 4,324 B | 1,287 B | 3,037 B |
| `shaderTypeDecoder` | gzip | 1,019 B | 650 B | 369 B |
| `shaderTypeDecoder` | Brotli | 757 B | 581 B | 176 B |

## Verification

- `nvm use` — Node v22.22.1
- `yarn lint fix` — passed
- `yarn build` — passed
- `yarn test-headless modules/core/test/shadertypes/shader-type-decoder.spec.ts` — 2 test groups passed, covering 52 expanded variable formats, 48 aliases, all attribute formats, and invalid inputs
- `yarn test` node suite — 332 passed, 2 skipped
- `yarn test` headless suite — 1,421 passed, 25 skipped; 4 known unrelated WebGPU failures remain (volumetric fire, Arrow DGGS, Arrow Layers storage, and shadertools DGGS)
- `yarn install` — not rerun; existing workspace dependencies used
- `yarn website:build` — not run; documentation-only website changes
- `(cd website && yarn build)` — not run; no website package changes

## Compatibility

The root decoder API and accepted public type strings are unchanged. The removed lookup maps were internal deep-module exports with no repository consumers; the public resolver methods remain available on `shaderTypeDecoder`.