### PR TITLE
feat: add narrow package entry points

### DIFF
--- a/docs/api-reference/core/README.md
+++ b/docs/api-reference/core/README.md
@@ -15,7 +15,7 @@ be imported and provided during device creation.
 
 ```typescript
 import {luma} from '@luma.gl/core';
-import {webgpuAdapter} from '@luma.gl/webgpu';
+import {webgpuAdapter} from '@luma.gl/webgpu/adapter';
 
 const device = await luma.createDevice({type: 'webgpu', adapters: [webgpuAdapter], createCanvasContext: ...});
 ```
@@ -25,11 +25,22 @@ that can work in both WebGL and WebGPU environments.
 
 ```typescript
 import {luma} from '@luma.gl/core';
-import {webgpuAdapter} from '@luma.gl/webgpu';
-import {webglAdapter} '@luma.gl/webgl';
+import {webgpuAdapter} from '@luma.gl/webgpu/adapter';
+import {webgl2Adapter} from '@luma.gl/webgl/adapter';
 
-const webgpuDevice = luma.createDevice({type: 'best-available', adapters: [webgpuAdapter, webglAdapter], createCanvasContext: ...});
+const webgpuDevice = luma.createDevice({type: 'best-available', adapters: [webgpuAdapter, webgl2Adapter], createCanvasContext: ...});
 ```
+
+## Narrow entry points
+
+Libraries that need only one part of the portable API can avoid loading the full package root:
+
+- `@luma.gl/core/device` exports adapter, device, and canvas interfaces.
+- `@luma.gl/core/resources` exports portable GPU resource classes.
+- `@luma.gl/core/uniforms` exports uniform layout, block, writer, and store utilities.
+- `@luma.gl/core/diagnostics` exports logging and statistics utilities.
+
+The `luma` singleton remains available from `@luma.gl/core`.
 
 ## Creating GPU Resources
 

--- a/docs/api-reference/webgl/README.md
+++ b/docs/api-reference/webgl/README.md
@@ -8,12 +8,12 @@ import {WebGLDocsTabs} from '@site/src/components/docs/webgl-docs-tabs';
 
 This module contains the WebGL adapter for the "abstract" luma.gl API (`@luma.gl/core`).
 
-Importing `webgl2Adapter` from `@luma.gl/webgl` enables WebGL devices to
+Importing `webgl2Adapter` from `@luma.gl/webgl/adapter` enables WebGL devices to
 be created using `luma.createDevice(props)`. See [`CreateDeviceProps`](/docs/api-reference/core/luma#createdeviceprops) for WebGL property options.
 
 ```typescript
 import {luma} from '@luma.gl/core';
-import {webgl2Adapter} from '@luma.gl/webgl';
+import {webgl2Adapter} from '@luma.gl/webgl/adapter';
 
 const device = await luma.createDevice({
   adapters: [webgl2Adapter],
@@ -35,7 +35,7 @@ To use a luma.gl WebGL `Device` with raw WebGL calls, the application can access
 the underlying WebGL handles (`WebGL2RenderingContext`, `WebGLBuffer`, ...) using the `.handle` properties:
 
 ```typescript
-import type {WebGLDevice} from '@luma.gl/webgl';
+import type {WebGLDevice} from '@luma.gl/webgl/classes';
 
 const webglDevice = device as WebGLDevice;
 const gpuDevice: WebGL2RenderingContext = webglDevice.handle;

--- a/docs/api-reference/webgpu/README.md
+++ b/docs/api-reference/webgpu/README.md
@@ -4,12 +4,12 @@
 
 This module contains the WebGPU adapter for the "abstract" luma.gl API (`@luma.gl/core`).
 
-The `webgpuAdapter` imported from `@luma.gl/webgpu` enables WebGPU devices to
+The `webgpuAdapter` imported from `@luma.gl/webgpu/adapter` enables WebGPU devices to
 be created using `luma.createDevice(props)`: See [`CreateDeviceProps`](/docs/api-reference/core/luma#createdeviceprops) for WebGPU prop options.
 
 ```typescript
 import {luma} from '@luma.gl/core';
-import {webgpuAdapter} from '@luma.gl/webgpu';
+import {webgpuAdapter} from '@luma.gl/webgpu/adapter';
 
 const device = await luma.createDevice({adapters: [webgpuAdapter], createCanvasContext: {width: 800, height: 600}});
 
@@ -77,7 +77,7 @@ If you are only interested in using WebGPU for compute and not for rendering (or
 
 ```typescript
 import {luma} from '@luma.gl/core';
-import {webgpuAdapter} from '@luma.gl/webgpu';
+import {webgpuAdapter} from '@luma.gl/webgpu/adapter';
 
 const device = await luma.createDevice({adapters: [webgpuAdapter]});
 
@@ -91,7 +91,7 @@ To use a luma.gl WebGPU `Device` with raw WebGPU calls, the application can acce
 the underlying WebGPU handles (`GPUDevice`, `GPUBuffer`, ...) using the `.handle` properties:
 
 ```typescript
-import type {WebGPUDevice} from '@luma.gl/webgpu`;
+import type {WebGPUDevice} from '@luma.gl/webgpu/classes';
 
 const webgpuDevice = device as WebGPUDevice;
 const gpuDevice: GPUDevice = webgpuDevice.handle;

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -9,6 +9,7 @@ Target Release Date: Q3, 2026
 **General**
 
 - **TypeScript 6.0** - luma.gl package builds, website tooling, and supported example typechecks now use TypeScript 6.0.
+- **Narrow package entry points** - Applications and libraries can import core device, resource, uniform, and diagnostics APIs from explicit `@luma.gl/core` subpaths. WebGL and WebGPU adapters and concrete classes likewise have explicit adapter-oriented subpaths, allowing package prebundlers to defer backend implementation code until it is requested.
 - **Precise raw binary64 coordinate deltas** - The WGSL `fp64arithmetic` module can split a binary64-rounded subtraction into normalized double-single limbs, normalize and compare those limbs with integer-controlled behavior in either arithmetic mode, and explicitly classify non-finite values. The existing direct-to-`f32` helper retains its single-round exact-delta contract.
 
 **AI-Assisted Development**

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -25,6 +25,26 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./device": {
+      "types": "./dist/device.d.ts",
+      "import": "./dist/device.js",
+      "require": "./dist/device.cjs"
+    },
+    "./resources": {
+      "types": "./dist/resources.d.ts",
+      "import": "./dist/resources.js",
+      "require": "./dist/resources.cjs"
+    },
+    "./uniforms": {
+      "types": "./dist/uniforms.d.ts",
+      "import": "./dist/uniforms.js",
+      "require": "./dist/uniforms.cjs"
+    },
+    "./diagnostics": {
+      "types": "./dist/diagnostics.d.ts",
+      "import": "./dist/diagnostics.js",
+      "require": "./dist/diagnostics.cjs"
     }
   },
   "files": [

--- a/modules/core/src/device.ts
+++ b/modules/core/src/device.ts
@@ -1,0 +1,23 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Narrow entry point for adapter and device interfaces. */
+
+export {Adapter} from './adapter/adapter';
+
+export type {
+  DeviceProps,
+  DeviceInfo,
+  DeviceFeature,
+  BrowserDeviceFeature,
+  DeviceTextureFormatCapabilities,
+  WebGPUFeatureLevel,
+  WebGPUDeviceFeatureLevel
+} from './adapter/device';
+export {Device, DeviceFeatures, DeviceLimits, isHTMLInCanvasSupported} from './adapter/device';
+
+export type {CanvasContextProps} from './adapter/canvas-context';
+export {CanvasContext} from './adapter/canvas-context';
+export type {PresentationContextProps} from './adapter/presentation-context';
+export {PresentationContext} from './adapter/presentation-context';

--- a/modules/core/src/diagnostics.ts
+++ b/modules/core/src/diagnostics.ts
@@ -1,0 +1,8 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Narrow entry point for logging and statistics diagnostics. */
+
+export {log} from './utils/log';
+export {StatsManager, lumaStats} from './utils/stats-manager';

--- a/modules/core/src/resources.ts
+++ b/modules/core/src/resources.ts
@@ -1,0 +1,60 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Narrow entry point for portable GPU resource classes. */
+
+export {Resource, type ResourceProps} from './adapter/resources/resource';
+export {Buffer, type BufferProps, type BufferMapCallback} from './adapter/resources/buffer';
+export {Texture, type TextureProps} from './adapter/resources/texture';
+export {TextureView, type TextureViewProps} from './adapter/resources/texture-view';
+export {ExternalTexture, type ExternalTextureProps} from './adapter/resources/external-texture';
+export {Shader, type ShaderProps} from './adapter/resources/shader';
+export {Sampler, type SamplerProps, type SamplerParameters} from './adapter/resources/sampler';
+export {Framebuffer, type FramebufferProps} from './adapter/resources/framebuffer';
+export {RenderPipeline, type RenderPipelineProps} from './adapter/resources/render-pipeline';
+export {
+  SharedRenderPipeline,
+  type SharedRenderPipelineProps
+} from './adapter/resources/shared-render-pipeline';
+export {PipelineFactory, type PipelineFactoryProps} from './factories/pipeline-factory';
+export {ShaderFactory} from './factories/shader-factory';
+export {_getDefaultBindGroupFactory} from './factories/bind-group-factory';
+export {
+  RenderPass,
+  type RenderPassProps,
+  type RenderPassDrawOptions,
+  type RenderPassBindingOptions
+} from './adapter/resources/render-pass';
+export {
+  RenderBundle,
+  RenderBundleEncoder,
+  type RenderBundleEncoderProps
+} from './adapter/resources/render-bundle';
+export {ComputePipeline, type ComputePipelineProps} from './adapter/resources/compute-pipeline';
+export {ComputePass, type ComputePassProps} from './adapter/resources/compute-pass';
+export {CommandEncoder, type CommandEncoderProps} from './adapter/resources/command-encoder';
+export {CommandBuffer} from './adapter/resources/command-buffer';
+export {VertexArray, type VertexArrayProps} from './adapter/resources/vertex-array';
+export {
+  TransformFeedback,
+  type TransformFeedbackProps,
+  type BufferRange
+} from './adapter/resources/transform-feedback';
+export {QuerySet, type QuerySetProps} from './adapter/resources/query-set';
+export {Fence, type FenceProps} from './adapter/resources/fence';
+export {PipelineLayout, type PipelineLayoutProps} from './adapter/resources/pipeline-layout';
+
+export type {
+  CopyBufferToBufferOptions,
+  CopyBufferToTextureOptions,
+  CopyTextureToBufferOptions,
+  CopyTextureToTextureOptions
+} from './adapter/resources/command-encoder';
+export type {
+  CopyElementImageOptions,
+  CopyExternalImageOptions,
+  CopyImageDataOptions,
+  TextureReadOptions,
+  TextureWriteOptions
+} from './adapter/resources/texture';

--- a/modules/core/src/uniforms.ts
+++ b/modules/core/src/uniforms.ts
@@ -1,0 +1,21 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Narrow entry point for portable uniform buffer utilities. */
+
+export {
+  makeShaderBlockLayout,
+  type ShaderBlockLayout,
+  type ShaderBlockLayoutEntry,
+  type ShaderBlockLayoutOptions
+} from './shadertypes/shader-types/shader-block-layout';
+export {ShaderBlockWriter} from './portable/shader-block-writer';
+export {UniformBlock} from './portable/uniform-block';
+export {UniformStore} from './portable/uniform-store';
+export type {
+  UniformValue,
+  CompositeUniformValue,
+  CompositeUniformValueArray,
+  CompositeUniformValueStruct
+} from './adapter/types/uniforms';

--- a/modules/webgl/package.json
+++ b/modules/webgl/package.json
@@ -26,6 +26,21 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./adapter": {
+      "types": "./dist/adapter.d.ts",
+      "import": "./dist/adapter.js",
+      "require": "./dist/adapter.cjs"
+    },
+    "./classes": {
+      "types": "./dist/classes.d.ts",
+      "import": "./dist/classes.js",
+      "require": "./dist/classes.cjs"
+    },
+    "./legacy": {
+      "types": "./dist/legacy.d.ts",
+      "import": "./dist/legacy.js",
+      "require": "./dist/legacy.cjs"
+    },
     "./constants": {
       "types": "./dist/constants/index.d.ts",
       "import": "./dist/constants/index.js",

--- a/modules/webgl/src/adapter.ts
+++ b/modules/webgl/src/adapter.ts
@@ -1,0 +1,9 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Narrow entry point for the lazily loaded WebGL adapter. */
+
+export type {WebGLAdapter} from './adapter/webgl-adapter';
+export {webgl2Adapter} from './adapter/webgl-adapter';
+export type {WebGLDeviceLimits} from './adapter/device-helpers/webgl-device-limits';

--- a/modules/webgl/src/classes.ts
+++ b/modules/webgl/src/classes.ts
@@ -1,0 +1,19 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Explicit entry point for concrete WebGL classes. */
+
+export {WebGLDevice} from './adapter/webgl-device';
+export {WebGLCanvasContext} from './adapter/webgl-canvas-context';
+export {WEBGLBuffer} from './adapter/resources/webgl-buffer';
+export {WEBGLTexture} from './adapter/resources/webgl-texture';
+export {WEBGLShader} from './adapter/resources/webgl-shader';
+export {WEBGLSampler} from './adapter/resources/webgl-sampler';
+export {WEBGLFramebuffer} from './adapter/resources/webgl-framebuffer';
+export {WEBGLFence} from './adapter/resources/webgl-fence';
+export {WEBGLRenderPipeline} from './adapter/resources/webgl-render-pipeline';
+export {WEBGLCommandEncoder} from './adapter/resources/webgl-command-encoder';
+export {WEBGLRenderPass} from './adapter/resources/webgl-render-pass';
+export {WEBGLVertexArray} from './adapter/resources/webgl-vertex-array';
+export {WEBGLTransformFeedback} from './adapter/resources/webgl-transform-feedback';

--- a/modules/webgl/src/legacy.ts
+++ b/modules/webgl/src/legacy.ts
@@ -1,0 +1,12 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Explicit entry point for deprecated WebGL parameter helpers. */
+
+export {
+  resetGLParameters,
+  setGLParameters,
+  getGLParameters
+} from './context/parameters/unified-parameter-api';
+export {withGLParameters} from './context/state-tracker/with-parameters';

--- a/modules/webgpu/package.json
+++ b/modules/webgpu/package.json
@@ -22,6 +22,16 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./adapter": {
+      "types": "./dist/adapter.d.ts",
+      "import": "./dist/adapter.js",
+      "require": "./dist/adapter.cjs"
+    },
+    "./classes": {
+      "types": "./dist/classes.d.ts",
+      "import": "./dist/classes.js",
+      "require": "./dist/classes.cjs"
     }
   },
   "files": [

--- a/modules/webgpu/src/adapter.ts
+++ b/modules/webgpu/src/adapter.ts
@@ -1,0 +1,8 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Narrow entry point for the lazily loaded WebGPU adapter. */
+
+export type {WebGPUAdapter} from './adapter/webgpu-adapter';
+export {webgpuAdapter} from './adapter/webgpu-adapter';

--- a/modules/webgpu/src/classes.ts
+++ b/modules/webgpu/src/classes.ts
@@ -1,0 +1,16 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Explicit entry point for concrete WebGPU classes. */
+
+export {WebGPUDevice} from './adapter/webgpu-device';
+export {WebGPUBuffer} from './adapter/resources/webgpu-buffer';
+export {WebGPUTexture} from './adapter/resources/webgpu-texture';
+export {WebGPUSampler} from './adapter/resources/webgpu-sampler';
+export {WebGPUShader} from './adapter/resources/webgpu-shader';
+export {
+  WebGPURenderBundle,
+  WebGPURenderBundleEncoder
+} from './adapter/resources/webgpu-render-bundle';
+export {WebGPUFence} from './adapter/resources/webgpu-fence';


### PR DESCRIPTION
Addresses the narrow-entrypoint portion of #2852.

## Goals

- Let applications and libraries depend on one luma.gl capability without routing through a complete package root.
- Preserve the existing root entry points for compatibility.
- Give package prebundlers an adapter-only path that can defer concrete backend implementations until device creation.

## Changes

- Adds `@luma.gl/core/device`, `/resources`, `/uniforms`, and `/diagnostics`.
- Adds `@luma.gl/webgl/adapter`, `/classes`, and `/legacy`.
- Adds `@luma.gl/webgpu/adapter` and `/classes`.
- Emits TypeScript declarations, ESM, and CommonJS for every subpath through the existing package build.
- Updates the core, WebGL, and WebGPU API guides to recommend adapter-only imports while retaining documented root compatibility.

## Initial-load impact

Measurements use esbuild code splitting, production minification, gzip-9, and Brotli-11. Core is bundled normally; backend measurements keep `@luma.gl/core` external.

| Entry | Minified | gzip | Brotli |
| --- | ---: | ---: | ---: |
| `@luma.gl/core` root | 97,785 B | 27,522 B | 24,222 B |
| `@luma.gl/core/device` | 48,015 B | 13,937 B | 12,511 B |
| `@luma.gl/core/resources` | 53,731 B | 15,274 B | 13,716 B |
| `@luma.gl/core/uniforms` | 26,489 B | 8,326 B | 7,360 B |
| `@luma.gl/core/diagnostics` | 10,719 B | 3,742 B | 3,368 B |
| `@luma.gl/webgpu` root, initial chunks | 272,926 B | 56,217 B | 47,368 B |
| `@luma.gl/webgpu/adapter`, initial chunk | 3,083 B | 1,264 B | 1,109 B |
| `@luma.gl/webgl` root, initial chunks | 134,576 B | 38,015 B | 32,412 B |
| `@luma.gl/webgl/adapter`, initial chunks | 40,197 B | 10,943 B | 8,673 B |

The WebGPU adapter subpath defers 54,953 B gzip until device creation. The WebGL adapter subpath defers 27,072 B gzip on current master; the adapter becomes smaller when the separate debug-loading PR lands. This is initial-load deferral, not an eventual backend transfer reduction.

## Verification

- `nvm use` — Node 22.22.1
- `yarn lint fix`
- `yarn build` — emitted all declaration, ESM, and CommonJS subpaths
- ESM dynamic-import smoke check — all nine subpaths loaded with expected exports
- CommonJS require smoke check — all nine subpaths loaded with expected exports
- `yarn test` — Node: 332 passed, 2 skipped; headless: 1,420 passed, 25 skipped, with the same four known unrelated failures in volumetric-fire-forge, Arrow storage-backed models, Arrow DGGS polygons, and shadertools DGGS
- Commit hook — lint and Node suite passed
- `yarn install` — not rerun; existing workspace dependencies were used
- `yarn website:build` — not run; documentation-only website changes
- `(cd website && yarn build)` — not run; no website package implementation changed

## Compatibility

All existing root exports remain unchanged. The new subpaths expose the same public classes and utilities in capability-focused groups; WebGL legacy helpers remain available from the root and now also have an explicit compatibility subpath.