### PR TITLE
perf(website): upgrade Docusaurus and optimize build stages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,9 +177,19 @@ jobs:
             .yarn/install-state.gz
           key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json') }}
 
-      - name: Install dependencies and build website
+      - name: Install website dependencies
+        run: yarn install --immutable
+
+      - name: Synchronize website example assets
+        run: node website/scripts/sync-example-assets.mjs
+
+      - name: Build Docusaurus website
         env:
           NODE_OPTIONS: --max-old-space-size=6144
-        run: |
-          yarn install --immutable
-          yarn website:build
+        run: yarn workspace website-docusaurus docusaurus build
+
+      - name: Normalize LLM documentation output
+        run: node website/scripts/normalize-llm-output.mjs
+
+      - name: Validate LLM documentation output
+        run: node website/scripts/check-llm-output.mjs

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -52,7 +52,10 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     needs: check_branch
-    
+
+    env:
+      WEBSITE_BASE_URL: ${{ needs.check_branch.outputs.website_base_url }}
+
     permissions:
       contents: write
 
@@ -82,15 +85,24 @@ jobs:
             .yarn/install-state.gz
           key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json') }}
 
-      - name: Install dependencies and build website
+      - name: Install website dependencies
+        run: yarn install --immutable
+
+      - name: Synchronize website example assets
+        run: node website/scripts/sync-example-assets.mjs
+
+      - name: Build Docusaurus website
         env:
           NODE_OPTIONS: --max-old-space-size=6144
-          WEBSITE_BASE_URL: ${{ needs.check_branch.outputs.website_base_url }}
-        run: |
-          yarn install --immutable
-          yarn website:build
+        run: yarn workspace website-docusaurus docusaurus build
 
-      - name: Deploy
+      - name: Normalize LLM documentation output
+        run: node website/scripts/normalize-llm-output.mjs
+
+      - name: Validate LLM documentation output
+        run: node website/scripts/check-llm-output.mjs
+
+      - name: Deploy website to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # 4.8.0
         with:
           token: ${{ secrets.WEBSITE_DEPLOY_TOKEN }}

--- a/docs/api-guide/engine/anari-rendering.md
+++ b/docs/api-guide/engine/anari-rendering.md
@@ -656,7 +656,7 @@ and emits standalone JSON glTF with embedded buffers/images or ASCII `.usda`. AN
 declarations, optional renderer presets, bloom, fog, and renderer-only HDR controls remain
 ANARI-specific and are not exported.
 
-:::caution Experimental playground format
+:::caution[Experimental playground format]
 The JSON format and its optional schema exports are experimental. They are not part of the ANARI C
 specification and can change with the private `@luma.gl/anari` workspace.
 :::

--- a/docs/api-guide/gpu/gpu-antialiasing.mdx
+++ b/docs/api-guide/gpu/gpu-antialiasing.mdx
@@ -90,8 +90,8 @@ Start by identifying which artifact is aliasing:
     <div className="docs-antialiasing-flow__arrow" aria-hidden="true">←</div>
   </div>
   <p className="docs-antialiasing-flow__caption">
-    Depth participates in scene visibility during rasterization, then often becomes a separate
-    sampled input for later effects.
+    {'Depth participates in scene visibility during rasterization, then often becomes a separate ' +
+      'sampled input for later effects.'}
   </p>
 </div>
 
@@ -163,7 +163,7 @@ For WebGPU concepts and sample-count constraints, see the
 [WebGPU multisampling guide](https://webgpufundamentals.org/webgpu/lessons/webgpu-multisampling.html)
 and the [WebGPU specification](https://gpuweb.github.io/gpuweb/).
 
-:::caution Proposed API, not implemented
+:::caution[Proposed API, not implemented]
 
 [RFC #2741](https://github.com/visgl/luma.gl/issues/2741) proposes a framebuffer-level
 request for color-only offscreen MSAA:

--- a/docs/api-reference/anari/README.md
+++ b/docs/api-reference/anari/README.md
@@ -8,7 +8,7 @@
 
 `@luma.gl/anari` provides a private, experimental, ANARI-inspired retained rendering API on top of luma.gl. Applications describe **what** to render as cameras, worlds, surfaces, materials, lights, and frames. The implementation decides **how** to compile that description into portable WebGPU or WebGL rendering.
 
-:::caution Experimental proof of concept
+:::caution[Experimental proof of concept]
 This package follows concepts from the ANARI object model, but it is not an ANARI C binding, does not implement the full ANARI specification, and does not claim Khronos conformance. Its TypeScript API and supported feature set can change.
 :::
 

--- a/docs/api-reference/anari/anari-schemas.md
+++ b/docs/api-reference/anari/anari-schemas.md
@@ -11,7 +11,7 @@ format and generates a JSON Schema suitable for Monaco, VS Code, and other schem
 It is separate from the ordinary `@luma.gl/anari` entry point, so applications that only render
 scenes do not load Zod.
 
-:::caution Experimental scene format
+:::caution[Experimental scene format]
 These schemas describe the private luma.gl ANARI playground format. They are not an official ANARI
 serialization standard, and their structure can change with the experimental package.
 :::

--- a/docs/api-reference/core/device.md
+++ b/docs/api-reference/core/device.md
@@ -314,7 +314,7 @@ createPresentationContext(props?: PresentationContextProps): PresentationContext
 
 Creates a new [`PresentationContext`](./presentation-context) for multi-canvas presentation.
 
-:::caution Experimental
+:::caution[Experimental]
 `createPresentationContext()` is experimental and may change in a future release.
 :::
 

--- a/docs/api-reference/core/presentation-context.md
+++ b/docs/api-reference/core/presentation-context.md
@@ -11,7 +11,7 @@ import {CoreDocsTabs} from '@site/src/components/docs/core-docs-tabs';
 
 `PresentationContext` is intended for multi-canvas presentation workflows that are portable across both WebGPU and WebGL.
 
-:::caution Experimental
+:::caution[Experimental]
 `PresentationContext` and `device.createPresentationContext()` are experimental APIs and may change in a future release.
 :::
 
@@ -105,7 +105,7 @@ Becomes `true` once the initial size is known.
 
 Creates a presentation context associated with the device.
 
-:::caution Experimental
+:::caution[Experimental]
 This method is experimental and may change in a future release.
 :::
 

--- a/docs/api-reference/shadertools/shader-modules/gpu-picking.md
+++ b/docs/api-reference/shadertools/shader-modules/gpu-picking.md
@@ -117,7 +117,7 @@ When inactive, renders normal colors, with the exception of selected object whic
 - `isActive` - When true, renders picking colors. Set when rendering to off-screen "picking" buffer. When false, renders normal colors, with the exception of selected object which is rendered with highlight 
 - `useByteColors` defaults to byte-compatible highlight color behavior in Phase 1.
 
-<!---
+{/*
 - `pickingActive`=`false` (_boolean_) - Renders the picking colors instead of the normal colors. Normally only used with an off-screen framebuffer during picking.
 - `pickingSelectedColor`=`null` (_array|null_) - The picking color of the selected (highlighted) object.
 - `pickingHighlightColor`= `[0, 255, 255, 255]` (_array_) - Color used to highlight the currently selected object.
@@ -131,7 +131,7 @@ opts can contain following keys:
 - `pickingActive`=`false` (_boolean_) - When true, renders the picking colors instead of the normal colors. Normally only used with an off-screen framebuffer during picking. Default value is `false`.
 
 Note that the selected item will be rendered using `pickingHighlightColor`, if blending is enabled for the draw, alpha channel can be used to control the blending result.
--->
+*/}
 
 ## Vertex Shader Functions
 

--- a/docs/api-reference/shadertools/shader-modules/picking.md
+++ b/docs/api-reference/shadertools/shader-modules/picking.md
@@ -103,7 +103,7 @@ When inactive, renders normal colors, with the exception of selected object whic
 - `isActive` - When true, renders picking colors. Set when rendering to off-screen "picking" buffer. When false, renders normal colors, with the exception of selected object which is rendered with highlight 
 - `useByteColors` defaults to byte-compatible highlight color behavior in Phase 1.
 
-<!---
+{/*
 - `pickingActive`=`false` (_boolean_) - Renders the picking colors instead of the normal colors. Normally only used with an off-screen framebuffer during picking.
 - `pickingSelectedColor`=`null` (_array|null_) - The picking color of the selected (highlighted) object.
 - `pickingHighlightColor`= `[0, 255, 255, 255]` (_array_) - Color used to highlight the currently selected object.
@@ -117,7 +117,7 @@ opts can contain following keys:
 - `pickingActive`=`false` (_boolean_) - When true, renders the picking colors instead of the normal colors. Normally only used with an off-screen framebuffer during picking. Default value is `false`.
 
 Note that the selected item will be rendered using `pickingHighlightColor`, if blending is enabled for the draw, alpha channel can be used to control the blending result.
--->
+*/}
 
 ## Vertex Shader Functions
 

--- a/docs/legacy/legacy-whats-new.md
+++ b/docs/legacy/legacy-whats-new.md
@@ -170,7 +170,7 @@ The `KeyFrames` class allows arbitrary data to be associated with time points. T
 
 Date: April 19, 2019
 
-<!--
+{/*
 <table style="border: 0;" align="center">
   <tbody>
     <tr>
@@ -185,12 +185,12 @@ Date: April 19, 2019
     </tr>
   </tbody>
 </table>
--->
+*/}
 #### glTF Support
 
-<!--
+{/*
 <img height="100" src="https://raw.github.com/visgl/deck.gl-data/master/images/gltf.png" />
--->
+*/}
 luma.gl can now load 3D models and scenegraphs in the popular [glTF™](https://www.khronos.org/gltf/) asset format (with the help of the loaders.gl [GLTFLoader](https://github.com/visgl/loaders.gl/blob/master/website/docs/api-reference/gltf-loaders/gltf-loader). All variants of glTF 2.0 are supported, including binary `.glb` files as well as JSON `.gltf` files with binary assets in base64 encoding or in separate files. The Draco Mesh compression extension is also supported.
 
 - **Physically-based Material Support**: Ensures that PBR models display as intended.
@@ -286,7 +286,7 @@ A new experimental class `AnimationLoopProxy` supports running an `AnimationLoop
 
 Date: September 12, 2018
 
-<!--
+{/*
 <table style="border: 0;" align="center">
   <tbody>
     <tr>
@@ -301,7 +301,7 @@ Date: September 12, 2018
     </tr>
   </tbody>
 </table>
--->
+*/}
 
 #### ShaderModulePass (Experimental)
 
@@ -315,7 +315,7 @@ Shader modules that expose "standard" filtering and sampling functions can be gi
 
 Date: Target August 31, 2018
 
-<!--
+{/*
 <table style="border: 0;" align="center">
   <tbody>
     <tr>
@@ -330,7 +330,7 @@ Date: Target August 31, 2018
     </tr>
   </tbody>
 </table>
--->
+*/}
 
 luma.gl 6.1 is a minor release that introduces a number of new experimental capabilities that are expected to be built out and become official over the next few releases.
 
@@ -358,7 +358,7 @@ luma.gl is now using the [ocular](https://github.com/uber-web/ocular) document g
 
 Date: July 18, 2018
 
-<!--
+{/*
 <table style="border: 0;" align="center">
   <tbody>
     <tr>
@@ -369,7 +369,7 @@ Date: July 18, 2018
     </tr>
   </tbody>
 </table>
--->
+*/}
 
 A major release that as always focuses on WebGL performance and code size optimizations, better support for shader/GLSL programming, improved documentation and API cleanup.
 
@@ -505,7 +505,7 @@ Improvements in particular to the `Buffer`, `TransformFeedback` and `Framebuffer
 
 Release date: July 27th, 2017
 
-<!--
+{/*
 <table style="border: 0;" align="center">
   <tbody>
     <tr>
@@ -516,7 +516,7 @@ Release date: July 27th, 2017
     </tr>
   </tbody>
 </table>
--->
+*/}
 
 A major release that brings full WebGL 2 support to luma.gl, as well as adding support for GL state management and a new shader module system.
 

--- a/package.json
+++ b/package.json
@@ -74,9 +74,10 @@
     "yaml": "^2.8.1"
   },
   "resolutions": {
-    "@docusaurus/plugin-client-redirects": "^3.9.2",
-    "@docusaurus/plugin-content-docs": "^3.9.2",
-    "@docusaurus/preset-classic": "^3.9.2",
+    "@cmfcmf/docusaurus-search-local": "^2.0.1",
+    "@docusaurus/plugin-client-redirects": "^3.10.2",
+    "@docusaurus/plugin-content-docs": "^3.10.2",
+    "@docusaurus/preset-classic": "^3.10.2",
     "cheerio": "1.0.0-rc.9",
     "typescript": "6.0.3",
     "tsconfig-paths": "^3.9.0",

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # Website
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 
 Run these commands from the repository root.
 

--- a/website/babel.config.js
+++ b/website/babel.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  presets: [require.resolve('@docusaurus/core/lib/babel/preset')],
-  plugins: ['styled-components']
-};

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -2,6 +2,10 @@ const {getDocusaurusConfig} = require('@vis.gl/docusaurus-website');
 const {OptionDefaults: typedocOptionDefaults} = require('typedoc');
 const path = require('path');
 
+const examplesDirectory = path.resolve(__dirname, '../examples');
+const modulesDirectory = path.resolve(__dirname, '../modules');
+const websiteExamplesPath = path.resolve(__dirname, 'src/examples.tsx');
+const websiteReactLumaDirectory = path.resolve(__dirname, 'src/react-luma');
 const websiteBaseUrl = process.env.WEBSITE_BASE_URL || '/';
 const websiteBasePathSegments = websiteBaseUrl.split('/').filter(Boolean);
 const websiteRoutePrefix =
@@ -69,13 +73,10 @@ const config = getDocusaurusConfig({
         createRedirects(existingPath) {
           // docs/examples/tutorials/*/api-reference <= /docs/tutorials
           if (existingPath.includes('/docs/examples/tutorials/')) {
-            return [
-              existingPath
-                .replace('/docs/examples/tutorials/', '/docs/tutorials/')
-            ];
+            return [existingPath.replace('/docs/examples/tutorials/', '/docs/tutorials/')];
           }
-    
-            // docs/modules/*/api-reference <= modules/*/docs/api-reference
+
+          // docs/modules/*/api-reference <= modules/*/docs/api-reference
           if (existingPath.includes('/docs/modules/')) {
             return [
               existingPath
@@ -93,6 +94,7 @@ const config = getDocusaurusConfig({
 
 const {
   onBrokenMarkdownLinks,
+  presets: basePresets = [],
   plugins: basePlugins = [],
   staticDirectories = [],
   ...baseConfig
@@ -102,8 +104,14 @@ module.exports = {
   ...baseConfig,
   baseUrl: websiteBaseUrl,
   staticDirectories: [...staticDirectories, '.generated/example-assets'],
+  presets: basePresets.map(preset => {
+    if (Array.isArray(preset) && preset[0] === 'classic') {
+      return [preset[0], {...preset[1], blog: false}];
+    }
+    return preset;
+  }),
   plugins: [
-    ...basePlugins.map((plugin) => {
+    ...basePlugins.map(plugin => {
       if (Array.isArray(plugin) && plugin[0] === '@cmfcmf/docusaurus-search-local') {
         return [
           plugin[0],
@@ -121,8 +129,7 @@ module.exports = {
       '@signalwire/docusaurus-plugin-llms-txt',
       {
         siteTitle: 'luma.gl',
-        siteDescription:
-          'WebGPU and WebGL2 framework documentation for visualization and compute.',
+        siteDescription: 'WebGPU and WebGL2 framework documentation for visualization and compute.',
         // Plugin 1.x builds its route tree from base-prefixed Docusaurus paths.
         // Preserve the configured three levels after the post-build base-path normalization.
         depth: Math.min(5, 3 + websiteBasePathSegments.length),
@@ -172,7 +179,7 @@ module.exports = {
     function arrowLayersSourceAlias() {
       return {
         name: 'arrow-layers-source-alias',
-        configureWebpack() {
+        configureWebpack(_configuration, isServer) {
           return {
             resolve: {
               alias: {
@@ -182,6 +189,34 @@ module.exports = {
                 )
               }
             },
+            ...(isServer
+              ? {}
+              : {
+                  optimization: {
+                    splitChunks: {
+                      cacheGroups: {
+                        // The default shared chunk requires use by half of all documentation routes.
+                        websiteExamples: {
+                          name: 'website-examples',
+                          chunks: 'async',
+                          minChunks: 2,
+                          priority: 45,
+                          reuseExistingChunk: true,
+                          test(module) {
+                            const resource = module.resource;
+                            return Boolean(
+                              resource &&
+                                (resource === websiteExamplesPath ||
+                                  resource.startsWith(`${examplesDirectory}${path.sep}`) ||
+                                  resource.startsWith(`${modulesDirectory}${path.sep}`) ||
+                                  resource.startsWith(`${websiteReactLumaDirectory}${path.sep}`))
+                            );
+                          }
+                        }
+                      }
+                    }
+                  }
+                }),
             watchOptions: {
               aggregateTimeout: 200,
               poll: 1000
@@ -192,7 +227,8 @@ module.exports = {
     }
   ],
   future: {
-    v4: true
+    v4: true,
+    faster: true
   },
   markdown: {
     ...(config.markdown || {}),

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -112,6 +112,19 @@ module.exports = {
   }),
   plugins: [
     ...basePlugins.map(plugin => {
+      if (
+        Array.isArray(plugin) &&
+        plugin[0] === '@docusaurus/plugin-content-docs' &&
+        plugin[1]?.id === 'examples'
+      ) {
+        return [
+          plugin[0],
+          {
+            ...plugin[1],
+            docItemComponent: path.resolve(__dirname, 'src/components/example-doc-item.tsx')
+          }
+        ];
+      }
       if (Array.isArray(plugin) && plugin[0] === '@cmfcmf/docusaurus-search-local') {
         return [
           plugin[0],

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
     "lint": "npx tsc --noEmit",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
-    "check": "yarn docusaurus-mdx-checker ../docs",
+    "check": "yarn docusaurus-mdx-checker --cwd ../docs",
     "clear": "docusaurus clear",
     "clean": "docusaurus clear",
     "serve": "docusaurus serve",
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "@algolia/autocomplete-js": "^1.19.2",
-    "@docusaurus/core": "^3.9.2",
+    "@docusaurus/core": "^3.10.2",
+    "@docusaurus/faster": "^3.10.2",
     "@probe.gl/stats": "^4.1.1",
     "@probe.gl/stats-widget": "^4.1.1",
     "@signalwire/docusaurus-plugin-llms-txt": "^1.2.2",
@@ -36,7 +37,7 @@
   },
   "devDependencies": {
     "@cmfcmf/docusaurus-search-local": "^2.0.0",
-    "@docusaurus/tsconfig": "^3.9.2",
+    "@docusaurus/tsconfig": "^3.10.2",
     "docusaurus-mdx-checker": "^3.0.0",
     "docusaurus-plugin-typedoc": "^1.4.2",
     "typedoc": "^0.28.19",

--- a/website/scripts/sync-example-assets.mjs
+++ b/website/scripts/sync-example-assets.mjs
@@ -36,43 +36,55 @@ const ASSET_EXTENSIONS = new Set([
 ]);
 
 const SKIPPED_DIRECTORY_NAMES = new Set(['dist', 'node_modules']);
-const EXAMPLE_SOURCE_FILE_NAMES = new Set([
-  'app.ts',
-  'app.tsx',
-  'index.html',
-  'package.json'
+const SKIPPED_EXAMPLE_DIRECTORIES = new Set([
+  // ANARI runs as a standalone Vite app and is not embedded in the website.
+  path.join('showcase', 'anari')
 ]);
+const EXAMPLE_SOURCE_FILE_NAMES = new Set(['app.ts', 'app.tsx', 'index.html', 'package.json']);
 
 function syncExampleAssets() {
-  rmSync(path.resolve(websiteDirectory, '.generated', 'example-assets'), {
-    force: true,
-    recursive: true
-  });
   mkdirSync(outputDirectory, {recursive: true});
 
   let copiedAssetCount = 0;
+  let unchangedAssetCount = 0;
+  let removedAssetCount = 0;
+  const assetPaths = new Set();
 
   const walkDirectory = currentDirectory => {
-    for (const entryName of readdirSync(currentDirectory)) {
-      if (SKIPPED_DIRECTORY_NAMES.has(entryName)) {
+    for (const entry of readdirSync(currentDirectory, {withFileTypes: true})) {
+      if (SKIPPED_DIRECTORY_NAMES.has(entry.name)) {
         continue;
       }
 
-      const entryPath = path.join(currentDirectory, entryName);
-      const entryStats = statSync(entryPath);
+      const entryPath = path.join(currentDirectory, entry.name);
 
-      if (entryStats.isDirectory()) {
-        walkDirectory(entryPath);
+      if (entry.isDirectory()) {
+        if (!SKIPPED_EXAMPLE_DIRECTORIES.has(path.relative(examplesDirectory, entryPath))) {
+          walkDirectory(entryPath);
+        }
         continue;
       }
 
-      const extension = path.extname(entryName).toLowerCase();
-      if (!ASSET_EXTENSIONS.has(extension) && !EXAMPLE_SOURCE_FILE_NAMES.has(entryName)) {
+      const extension = path.extname(entry.name).toLowerCase();
+      if (!ASSET_EXTENSIONS.has(extension) && !EXAMPLE_SOURCE_FILE_NAMES.has(entry.name)) {
         continue;
       }
 
       const relativePath = getWebsiteAssetPath(path.relative(examplesDirectory, entryPath));
       const destinationPath = path.join(outputDirectory, relativePath);
+      assetPaths.add(relativePath);
+
+      const sourceStats = statSync(entryPath);
+      const destinationStats = statSync(destinationPath, {throwIfNoEntry: false});
+      if (
+        destinationStats?.isFile() &&
+        sourceStats.size === destinationStats.size &&
+        sourceStats.mtimeMs <= destinationStats.mtimeMs
+      ) {
+        unchangedAssetCount++;
+        continue;
+      }
+
       mkdirSync(path.dirname(destinationPath), {recursive: true});
       cpSync(entryPath, destinationPath);
       copiedAssetCount++;
@@ -80,7 +92,26 @@ function syncExampleAssets() {
   };
 
   walkDirectory(examplesDirectory);
-  console.log(`Synced ${copiedAssetCount} example assets to ${outputDirectory}`);
+
+  const removeStaleAssets = currentDirectory => {
+    for (const entry of readdirSync(currentDirectory, {withFileTypes: true})) {
+      const entryPath = path.join(currentDirectory, entry.name);
+      if (entry.isDirectory()) {
+        removeStaleAssets(entryPath);
+        if (readdirSync(entryPath).length === 0) {
+          rmSync(entryPath, {recursive: true});
+        }
+      } else if (!assetPaths.has(path.relative(outputDirectory, entryPath))) {
+        rmSync(entryPath);
+        removedAssetCount++;
+      }
+    }
+  };
+
+  removeStaleAssets(outputDirectory);
+  console.log(
+    `Synced example assets: ${copiedAssetCount} copied, ${unchangedAssetCount} unchanged, ${removedAssetCount} removed.`
+  );
 }
 
 function getWebsiteAssetPath(relativePath) {

--- a/website/src/components/example-doc-item.module.css
+++ b/website/src/components/example-doc-item.module.css
@@ -1,0 +1,12 @@
+.demoContainer {
+  position: absolute;
+  overflow: hidden !important;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.demoContainer > h1 {
+  display: none;
+}

--- a/website/src/components/example-doc-item.tsx
+++ b/website/src/components/example-doc-item.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from './example-doc-item.module.css';
+
+type ExampleDocItemProps = {
+  content: React.ComponentType;
+  route: {
+    path: string;
+  };
+};
+
+export default function ExampleDocItem({content: Content, route}: ExampleDocItemProps) {
+  const indexPath = useBaseUrl('/examples');
+
+  if (route.path === indexPath) {
+    return (
+      <div key="index">
+        <Content />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.demoContainer} key="demo">
+      <Content />
+    </div>
+  );
+}

--- a/website/src/components/examples-index.module.css
+++ b/website/src/components/examples-index.module.css
@@ -1,0 +1,136 @@
+.mainExamples {
+  padding: 1rem 0 2rem;
+}
+
+.catalogControls {
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(14rem, 2fr) repeat(4, minmax(8rem, 1fr));
+  margin: 0 1rem 1.5rem;
+  padding: 1rem;
+}
+
+.catalogControls input,
+.catalogControls select {
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  color: var(--ifm-font-color-base);
+  font: inherit;
+  min-height: 2.65rem;
+  padding: 0.55rem 0.7rem;
+  width: 100%;
+}
+
+.resultsSummary {
+  color: var(--ifm-color-emphasis-700);
+  margin: 0 1rem 1rem;
+}
+
+.exampleSection {
+  margin: 0 1rem 2rem;
+}
+
+.exampleHeader {
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  margin: 0 0 1rem;
+  padding-bottom: 0.45rem;
+}
+
+.examplesGroup {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.exampleCard {
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 10px;
+  color: var(--ifm-font-color-base);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+  text-decoration: none;
+  transition:
+    border-color var(--ifm-transition-fast),
+    box-shadow var(--ifm-transition-fast),
+    transform var(--ifm-transition-fast);
+}
+
+.exampleCard:hover,
+.exampleCard:focus-visible {
+  border-color: var(--ifm-color-primary);
+  box-shadow: var(--ifm-global-shadow-md);
+  color: var(--ifm-font-color-base);
+  text-decoration: none;
+  transform: translateY(-2px);
+}
+
+.exampleCard img {
+  aspect-ratio: 16 / 9;
+  background: var(--ifm-color-emphasis-100);
+  object-fit: cover;
+  width: 100%;
+}
+
+.cardBody {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 0.9rem;
+}
+
+.cardBody h3 {
+  font-size: 1.08rem;
+  margin: 0;
+}
+
+.cardBody p {
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.9rem;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: auto;
+}
+
+.badge {
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 999px;
+  color: var(--ifm-color-emphasis-800);
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.18rem 0.45rem;
+}
+
+@media screen and (max-width: 996px) {
+  .catalogControls {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .catalogControls input {
+    grid-column: 1 / -1;
+  }
+}
+
+@media screen and (max-width: 520px) {
+  .catalogControls {
+    grid-template-columns: 1fr;
+  }
+
+  .catalogControls input {
+    grid-column: auto;
+  }
+}

--- a/website/src/components/examples-index.tsx
+++ b/website/src/components/examples-index.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useMemo, useState} from 'react';
 import {useDocsSidebar} from '@docusaurus/plugin-content-docs/client';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import styled from 'styled-components';
+import styles from './examples-index.module.css';
 
 type ExampleBackend = 'webgpu' | 'webgl2';
 type ExampleDifficulty = 'beginner' | 'intermediate' | 'advanced';
@@ -47,137 +47,6 @@ type ExamplesIndexProps = {
   getThumbnail: (item: SidebarDocItem) => string;
 };
 
-const MainExamples = styled.main`
-  padding: 1rem 0 2rem;
-`;
-
-const CatalogControls = styled.div`
-  background: var(--ifm-background-surface-color);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 12px;
-  display: grid;
-  gap: 0.75rem;
-  grid-template-columns: minmax(14rem, 2fr) repeat(4, minmax(8rem, 1fr));
-  margin: 0 1rem 1.5rem;
-  padding: 1rem;
-
-  input,
-  select {
-    background: var(--ifm-background-color);
-    border: 1px solid var(--ifm-color-emphasis-300);
-    border-radius: 8px;
-    color: var(--ifm-font-color-base);
-    font: inherit;
-    min-height: 2.65rem;
-    padding: 0.55rem 0.7rem;
-    width: 100%;
-  }
-
-  @media screen and (max-width: 996px) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-
-    input {
-      grid-column: 1 / -1;
-    }
-  }
-
-  @media screen and (max-width: 520px) {
-    grid-template-columns: 1fr;
-
-    input {
-      grid-column: auto;
-    }
-  }
-`;
-
-const ResultsSummary = styled.p`
-  color: var(--ifm-color-emphasis-700);
-  margin: 0 1rem 1rem;
-`;
-
-const ExampleSection = styled.section`
-  margin: 0 1rem 2rem;
-`;
-
-const ExampleHeader = styled.h2`
-  border-bottom: 1px solid var(--ifm-color-emphasis-200);
-  margin: 0 0 1rem;
-  padding-bottom: 0.45rem;
-`;
-
-const ExamplesGroup = styled.div`
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-`;
-
-const ExampleCard = styled.a`
-  background: var(--ifm-background-surface-color);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 10px;
-  color: var(--ifm-font-color-base);
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  overflow: hidden;
-  text-decoration: none;
-  transition: border-color var(--ifm-transition-fast), box-shadow var(--ifm-transition-fast),
-    transform var(--ifm-transition-fast);
-
-  &:hover,
-  &:focus-visible {
-    border-color: var(--ifm-color-primary);
-    box-shadow: var(--ifm-global-shadow-md);
-    color: var(--ifm-font-color-base);
-    text-decoration: none;
-    transform: translateY(-2px);
-  }
-
-  img {
-    aspect-ratio: 16 / 9;
-    background: var(--ifm-color-emphasis-100);
-    object-fit: cover;
-    width: 100%;
-  }
-`;
-
-const CardBody = styled.div`
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  gap: 0.55rem;
-  padding: 0.9rem;
-
-  h3 {
-    font-size: 1.08rem;
-    margin: 0;
-  }
-
-  p {
-    color: var(--ifm-color-emphasis-700);
-    font-size: 0.9rem;
-    line-height: 1.45;
-    margin: 0;
-  }
-`;
-
-const Badges = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-  margin-top: auto;
-`;
-
-const Badge = styled.span`
-  background: var(--ifm-color-emphasis-100);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 999px;
-  color: var(--ifm-color-emphasis-800);
-  font-size: 0.72rem;
-  font-weight: 600;
-  padding: 0.18rem 0.45rem;
-`;
-
 export function ExamplesIndex({getThumbnail}: ExamplesIndexProps) {
   const sidebar = useDocsSidebar() as SidebarRoot;
   const baseUrl = useBaseUrl('/');
@@ -214,7 +83,11 @@ export function ExamplesIndex({getThumbnail}: ExamplesIndexProps) {
     if (maturity !== 'all') parameters.set('maturity', maturity);
     if (topic !== 'all') parameters.set('topic', topic);
     const search = parameters.toString();
-    window.history.replaceState(null, '', `${window.location.pathname}${search ? `?${search}` : ''}`);
+    window.history.replaceState(
+      null,
+      '',
+      `${window.location.pathname}${search ? `?${search}` : ''}`
+    );
   }, [backend, difficulty, isInitialized, maturity, query, topic]);
 
   const normalizedQuery = query.trim().toLowerCase();
@@ -233,8 +106,8 @@ export function ExamplesIndex({getThumbnail}: ExamplesIndexProps) {
   const categories = groupByCategory(filteredCatalog);
 
   return (
-    <MainExamples>
-      <CatalogControls aria-label="Filter examples">
+    <main className={styles.mainExamples}>
+      <div className={styles.catalogControls} aria-label="Filter examples">
         <input
           type="search"
           value={query}
@@ -242,7 +115,12 @@ export function ExamplesIndex({getThumbnail}: ExamplesIndexProps) {
           placeholder="Search examples, APIs, and topics…"
           aria-label="Search examples"
         />
-        <FilterSelect label="Backend" value={backend} onChange={setBackend} options={['webgpu', 'webgl2']} />
+        <FilterSelect
+          label="Backend"
+          value={backend}
+          onChange={setBackend}
+          options={['webgpu', 'webgl2']}
+        />
         <FilterSelect
           label="Difficulty"
           value={difficulty}
@@ -256,39 +134,49 @@ export function ExamplesIndex({getThumbnail}: ExamplesIndexProps) {
           options={['stable', 'experimental']}
         />
         <FilterSelect label="Topic" value={topic} onChange={setTopic} options={topics} />
-      </CatalogControls>
-      <ResultsSummary aria-live="polite">
+      </div>
+      <p className={styles.resultsSummary} aria-live="polite">
         Showing {filteredCatalog.length} of {catalog.length} examples
-      </ResultsSummary>
+      </p>
       {categories.map(([category, items]) => (
-        <ExampleSection key={category}>
-          <ExampleHeader>{category}</ExampleHeader>
-          <ExamplesGroup>
+        <section className={styles.exampleSection} key={category}>
+          <h2 className={styles.exampleHeader}>{category}</h2>
+          <div className={styles.examplesGroup}>
             {items.map(item => {
               const thumbnail = getThumbnail(item);
               const imageUrl = `${baseUrl}${thumbnail.replace(/^\//, '')}`;
               return (
-                <ExampleCard key={item.href || item.docId || item.label} href={item.href}>
+                <a
+                  className={styles.exampleCard}
+                  key={item.href || item.docId || item.label}
+                  href={item.href}
+                >
                   <img src={imageUrl} alt="" />
-                  <CardBody>
+                  <div className={styles.cardBody}>
                     <h3>{item.label}</h3>
                     <p>{item.description}</p>
-                    <Badges>
-                      {item.backends.map(value => <Badge key={value}>{value}</Badge>)}
-                      <Badge>{item.difficulty}</Badge>
-                      {item.maturity === 'experimental' ? <Badge>experimental</Badge> : null}
-                    </Badges>
-                  </CardBody>
-                </ExampleCard>
+                    <div className={styles.badges}>
+                      {item.backends.map(value => (
+                        <span className={styles.badge} key={value}>
+                          {value}
+                        </span>
+                      ))}
+                      <span className={styles.badge}>{item.difficulty}</span>
+                      {item.maturity === 'experimental' ? (
+                        <span className={styles.badge}>experimental</span>
+                      ) : null}
+                    </div>
+                  </div>
+                </a>
               );
             })}
-          </ExamplesGroup>
-        </ExampleSection>
+          </div>
+        </section>
       ))}
       {filteredCatalog.length === 0 ? (
-        <ResultsSummary>No examples match the selected filters.</ResultsSummary>
+        <p className={styles.resultsSummary}>No examples match the selected filters.</p>
       ) : null}
-    </MainExamples>
+    </main>
   );
 }
 
@@ -306,7 +194,11 @@ function FilterSelect({
   return (
     <select aria-label={label} value={value} onChange={event => onChange(event.target.value)}>
       <option value="all">{getAllOptionsLabel(label)}</option>
-      {options.map(option => <option key={option} value={option}>{formatLabel(option)}</option>)}
+      {options.map(option => (
+        <option key={option} value={option}>
+          {formatLabel(option)}
+        </option>
+      ))}
     </select>
   );
 }
@@ -391,7 +283,11 @@ function groupByCategory(items: CatalogItem[]): Array<[string, CatalogItem[]]> {
 }
 
 function formatLabel(value: string): string {
-  return value === 'webgpu' ? 'WebGPU' : value === 'webgl2' ? 'WebGL2' : `${value[0].toUpperCase()}${value.slice(1)}`;
+  return value === 'webgpu'
+    ? 'WebGPU'
+    : value === 'webgl2'
+      ? 'WebGL2'
+      : `${value[0].toUpperCase()}${value.slice(1)}`;
 }
 
 function getAllOptionsLabel(label: string): string {

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -1,53 +1,47 @@
 import React from 'react';
 import Layout from '@theme/Layout';
-import {Home} from '@vis.gl/docusaurus-website/components';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {InstancingExample} from '../examples';
-import styled from 'styled-components';
+import styles from './index.module.css';
 
 if (typeof window !== 'undefined') {
   window.website = true;
 }
 
-const Bullet = styled.li`
-  background: url(img/icon-high-precision.svg) no-repeat left top;
-  list-style: none;
-  max-width: 540px;
-  margin-top: 8px;
-  padding: 0 0 12px 56px;
-  font: 16px;
-`;
+export default function IndexPage() {
+  const {siteConfig} = useDocusaurusContext();
 
-const ContentContainer = styled.div`
-  padding: 64px;
-
-  @media screen and (max-width: 768px) {
-    padding: 48px;
-  }
-`;
-
-const HeroExample = () => <InstancingExample panel={false} />
-
-export default class IndexPage extends React.Component {
-  render() {
-    return <Layout title="Home" description="luma.gl">
+  return (
+    <Layout title="Home" description="luma.gl">
       <main>
-        <Home HeroExample={HeroExample} getStartedLink="./docs/developer-guide/installing" theme="dark" />
-        <ContentContainer>
+        <section className={styles.banner}>
+          <div className={styles.heroExampleContainer}>
+            <InstancingExample panel={false} />
+          </div>
+          <div className={styles.bannerContainer}>
+            <h1 className={styles.projectName}>{siteConfig.title}</h1>
+            <p>{siteConfig.tagline}</p>
+            <a className={styles.getStartedLink} href="./docs/developer-guide/installing">
+              GET STARTED
+            </a>
+          </div>
+        </section>
+        <div className={styles.contentContainer}>
           <h2>High-performance toolkit for GPU-based data visualization.</h2>
           <ul>
-            <Bullet>
-            Focused on high-performance data processing, e.g. instanced rendering and GPU compute.
-            </Bullet>
-            <Bullet>
-            The core 3D rendering technology behind tools such as
-            deck.gl, kepler.gl, and avs.auto.
-            </Bullet>
-            <Bullet>
-            A clean TypeScript and WebGPU friendly GPU API that works across WebGPU and WebGL 2.
-            </Bullet>
+            <li className={styles.bullet}>
+              Focused on high-performance data processing, e.g. instanced rendering and GPU compute.
+            </li>
+            <li className={styles.bullet}>
+              The core 3D rendering technology behind tools such as deck.gl, kepler.gl, and
+              avs.auto.
+            </li>
+            <li className={styles.bullet}>
+              A clean TypeScript and WebGPU friendly GPU API that works across WebGPU and WebGL 2.
+            </li>
           </ul>
-        </ContentContainer>
+        </div>
       </main>
-    </Layout>;
-  }
+    </Layout>
+  );
 }

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -1,0 +1,97 @@
+.banner {
+  position: relative;
+  height: 30rem;
+  background: var(--ifm-color-gray-400);
+  color: var(--ifm-color-gray-200);
+  z-index: 0;
+}
+
+.heroExampleContainer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: -1;
+}
+
+.bannerContainer {
+  position: absolute;
+  bottom: 0;
+  max-width: 80rem;
+  width: 100%;
+  margin: 0;
+  padding: 2rem 2rem 2rem 4rem;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.projectName {
+  font-size: 5em;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 4px;
+  font-weight: 700;
+  margin: 0 0 16px;
+}
+
+.getStartedLink {
+  pointer-events: all;
+  font-size: 12px;
+  line-height: 44px;
+  letter-spacing: 2px;
+  font-weight: bold;
+  margin: 24px 0;
+  padding: 0 4rem;
+  display: inline-block;
+  text-decoration: none;
+  transition:
+    background-color 250ms ease-in,
+    color 250ms ease-in;
+  border: solid 2px var(--ifm-color-primary);
+  color: inherit;
+  border-image: linear-gradient(
+    to right,
+    var(--ifm-color-gray-700) 0%,
+    var(--ifm-color-gray-400) 100%
+  );
+  border-image-slice: 2;
+}
+
+.getStartedLink:visited {
+  color: inherit;
+}
+
+.getStartedLink:active,
+.getStartedLink:hover {
+  color: var(--ifm-color-white);
+}
+
+.getStartedLink:hover {
+  background-color: var(--ifm-color-primary);
+}
+
+.contentContainer {
+  padding: 64px;
+}
+
+.bullet {
+  background: url("/img/icon-high-precision.svg") no-repeat left top;
+  list-style: none;
+  max-width: 540px;
+  margin-top: 8px;
+  padding: 0 0 12px 56px;
+  font-size: 16px;
+}
+
+@media screen and (max-width: 768px) {
+  .contentContainer {
+    padding: 48px;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .banner {
+    height: 80vh;
+  }
+}

--- a/website/src/react-luma/components/components.module.css
+++ b/website/src/react-luma/components/components.module.css
@@ -1,0 +1,30 @@
+.button {
+  align-items: center;
+  background-color: var(--ifm-color-primary);
+  border-radius: 6px;
+  color: var(--ifm-color-white);
+  cursor: pointer;
+  display: inline-flex;
+  font-size: 14px;
+  font-family: var(--ifm-font-family-base);
+  font-weight: 600;
+  justify-content: center;
+  letter-spacing: 0.3px;
+  line-height: 14px;
+  outline: 0;
+  padding: 14px 32px;
+  text-align: center;
+  transition: background-color var(--ifm-transition-fast);
+  vertical-align: middle;
+}
+
+.button:hover,
+.button:focus,
+.button:active,
+.button:global(.active) {
+  background-color: var(--ifm-color-primary-dark);
+}
+
+.button svg {
+  margin-right: 8px;
+}

--- a/website/src/react-luma/components/components.tsx
+++ b/website/src/react-luma/components/components.tsx
@@ -1,34 +1,17 @@
-import styled from 'styled-components';
+import React, {type CSSProperties, type HTMLAttributes} from 'react';
+import clsx from 'clsx';
+import styles from './components.module.css';
 
-export const Button = styled.div.attrs({
-  className: 'button'
-})`
-  align-items: center;
-  background-color: ${props => props.theme.primaryBtnBgd};
-  border-radius: 6px;
-  color: ${props => props.theme.primaryBtnColor};
-  cursor: pointer;
-  display: inline-flex;
-  font-size: 14px;
-  font-family: ${props => props.theme.fontFamilySemiBold};
-  justify-content: center;
-  letter-spacing: 0.3px;
-  line-height: 14px;
-  outline: 0;
-  padding: 14px 32px;
-  text-align: center;
-  transition: ${props => props.theme.transition};
-  vertical-align: middle;
-  width: ${props => props.width || 'auto'};
+type ButtonProps = HTMLAttributes<HTMLDivElement> & {
+  width?: CSSProperties['width'];
+};
 
-  :hover,
-  :focus,
-  :active,
-  &.active {
-    background-color: ${props => props.theme.primaryBtnBgdHover};
-  }
-
-  svg {
-    margin-right: 8px;
-  }
-`;
+export function Button({className, style, width, ...properties}: ButtonProps) {
+  return (
+    <div
+      {...properties}
+      className={clsx('button', styles.button, className)}
+      style={{...style, width: width || style?.width || 'auto'}}
+    />
+  );
+}

--- a/website/src/react-luma/components/tabs.js
+++ b/website/src/react-luma/components/tabs.js
@@ -1,49 +1,6 @@
 import React, {Children, useState} from 'react';
-import styled from 'styled-components';
-
-const Header = styled.div`
-  display: inline-flex;
-  flex-direction: row;
-  align-items: stretch;
-  overflow: hidden;
-  min-height: 48px;
-  background-color: rgba(255, 255, 255, 0.96);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
-  border-radius: 12px;
-`;
-
-const HeaderItem = styled.div(
-  props => `
-  cursor: ${props.disabled ? 'not-allowed' : 'pointer'};
-  position: relative;
-  display: flex;
-  align-items: center;
-  padding: 4px 20px;
-  font-weight: bold;
-  font-size: 18px;
-  opacity: ${props.disabled ? 0.46 : 1};
-  border-bottom: 4px solid transparent;
-  transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
-  &:hover {
-    background-color: ${props.disabled ? 'transparent' : 'rgba(238, 239, 239, 0.9)'};
-  }
-  ${
-    props.isSelected
-      ? `
-    color: #276EF1;
-    border-bottom: 4px solid #276EF1;
-    background-color: rgba(39, 110, 241, 0.06);
-  `
-      : `
-    color: #111;
-  `
-  }
-`
-);
-
-const Body = styled.div`
-  margin-top: 0;
-`;
+import clsx from 'clsx';
+import styles from './tabs.module.css';
 
 export const Tabs = props => {
   const {children} = props;
@@ -57,17 +14,19 @@ export const Tabs = props => {
   }
   return (
     <>
-      <Header>
+      <div className={styles.header}>
         {tabs.map(tab => (
-          <HeaderItem
+          <div
+            className={clsx(styles.headerItem, {
+              [styles.disabled]: tab.props.disabled,
+              [styles.selected]: (tab.props.tag || tab.props.title) === selected
+            })}
             key={tab.props.tag || tab.props.title}
             data-luma-device-tab={tab.props.tag || tab.props.title}
             data-luma-device-tab-selected={
               (tab.props.tag || tab.props.title) === selected ? 'true' : undefined
             }
             aria-disabled={tab.props.disabled || undefined}
-            disabled={tab.props.disabled}
-            isSelected={(tab.props.tag || tab.props.title) === selected}
             onClick={() => {
               if (!tab.props.disabled) {
                 setSelected(tab.props.tag || tab.props.title);
@@ -113,10 +72,12 @@ export const Tabs = props => {
                 {tab.props.badge}
               </span>
             ) : null}
-          </HeaderItem>
+          </div>
         ))}
-      </Header>
-      <Body>{tabs.find(tab => (tab.props.tag || tab.props.title) === selected)}</Body>
+      </div>
+      <div className={styles.body}>
+        {tabs.find(tab => (tab.props.tag || tab.props.title) === selected)}
+      </div>
     </>
   );
 };

--- a/website/src/react-luma/components/tabs.module.css
+++ b/website/src/react-luma/components/tabs.module.css
@@ -1,0 +1,50 @@
+.header {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: stretch;
+  overflow: hidden;
+  min-height: 48px;
+  background-color: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
+  border-radius: 12px;
+}
+
+.headerItem {
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 4px 20px;
+  font-weight: bold;
+  font-size: 18px;
+  opacity: 1;
+  color: #111;
+  border-bottom: 4px solid transparent;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
+}
+
+.headerItem:hover {
+  background-color: rgba(238, 239, 239, 0.9);
+}
+
+.headerItem.selected {
+  color: #276ef1;
+  border-bottom-color: #276ef1;
+  background-color: rgba(39, 110, 241, 0.06);
+}
+
+.headerItem.disabled {
+  cursor: not-allowed;
+  opacity: 0.46;
+}
+
+.headerItem.disabled:hover {
+  background-color: transparent;
+}
+
+.body {
+  margin-top: 0;
+}

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -4,5 +4,6 @@
     "baseUrl": ".",
     "ignoreDeprecations": "6.0",
     "strict": false
-  }
+  },
+  "exclude": ["build", ".docusaurus", ".generated", "node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,18 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@11ty/gray-matter@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@11ty/gray-matter@npm:1.0.0"
+  dependencies:
+    js-yaml: "npm:^4.1.0"
+    kind-of: "npm:^6.0.3"
+    section-matter: "npm:^1.0.0"
+    strip-bom-string: "npm:^1.0.0"
+  checksum: 10c0/734361398905ff53ab5827d870bf83e010567f0b397ee853b67b749f76c2ae4be21eda4f2eb0e3909609cd22962adc377fbbf9ceb7e86cc5dd5cce48bd2bcfb9
+  languageName: node
+  linkType: hard
+
 "@algolia/abtesting@npm:1.15.2":
   version: 1.15.2
   resolution: "@algolia/abtesting@npm:1.15.2"
@@ -34,6 +46,16 @@ __metadata:
     "@algolia/autocomplete-plugin-algolia-insights": "npm:1.19.7"
     "@algolia/autocomplete-shared": "npm:1.19.7"
   checksum: 10c0/91bad604b26ceffb67d9f49e58ccdbaf065bc9e3fdf4cc00e888f9c112871d301ed06217cfd825c3f0c6334ebcfd355a607abfd10485509d30a8f69988058311
+  languageName: node
+  linkType: hard
+
+"@algolia/autocomplete-core@npm:^1.19.2":
+  version: 1.19.9
+  resolution: "@algolia/autocomplete-core@npm:1.19.9"
+  dependencies:
+    "@algolia/autocomplete-plugin-algolia-insights": "npm:1.19.9"
+    "@algolia/autocomplete-shared": "npm:1.19.9"
+  checksum: 10c0/392873e51a02bdf13c5aaf1324c4b1835e2ffbe94021a38afaefcb67cc7a83dd9def17cea93d89217e9740ce9f24125181f787582cb6c067061e8868b963fc85
   languageName: node
   linkType: hard
 
@@ -75,6 +97,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@algolia/autocomplete-plugin-algolia-insights@npm:1.19.9":
+  version: 1.19.9
+  resolution: "@algolia/autocomplete-plugin-algolia-insights@npm:1.19.9"
+  dependencies:
+    "@algolia/autocomplete-shared": "npm:1.19.9"
+  peerDependencies:
+    search-insights: ">= 1 < 3"
+  checksum: 10c0/d902e41f3ecf479afe86542feecd54905fa630336d16c8cab14c96a4ed7a515ea0656de2e4af55541a464361740cd8563067fcd98dbb8c02cc7040e8d9deffce
+  languageName: node
+  linkType: hard
+
 "@algolia/autocomplete-preset-algolia@npm:1.19.7":
   version: 1.19.7
   resolution: "@algolia/autocomplete-preset-algolia@npm:1.19.7"
@@ -104,6 +137,16 @@ __metadata:
     "@algolia/client-search": ">= 4.9.1 < 6"
     algoliasearch: ">= 4.9.1 < 6"
   checksum: 10c0/a4bc6d012ff49f0b10286ab50b42f0312bd3f90ed0cbf35b3471bb770bb927ae1cc8f9ac8e0f85a54efc098f143f3b8c9300b4f9dce1d85f7aa72a7ae8959d36
+  languageName: node
+  linkType: hard
+
+"@algolia/autocomplete-shared@npm:1.19.9":
+  version: 1.19.9
+  resolution: "@algolia/autocomplete-shared@npm:1.19.9"
+  peerDependencies:
+    "@algolia/client-search": ">= 4.9.1 < 6"
+    algoliasearch: ">= 4.9.1 < 6"
+  checksum: 10c0/a5398fbcae193f8b2a8a0b97d15fecf6205759703ff3af7ee6f049889597a4ab525ff411b97440c1f12d9155d05e080e3e9bfe59df0afad93b34db25332f647b
   languageName: node
   linkType: hard
 
@@ -1799,15 +1842,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime-corejs3@npm:^7.25.9":
-  version: 7.29.2
-  resolution: "@babel/runtime-corejs3@npm:7.29.2"
-  dependencies:
-    core-js-pure: "npm:^3.48.0"
-  checksum: 10c0/24a9de8b592cf67fbe62c36c002a0da8c0456079a0543646a40e2b1b0838e7712f5ff49e9551624395ccd67a409c63e7c638b23e3bebbfdf54e373b1c707ebff
-  languageName: node
-  linkType: hard
-
 "@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.25.9":
   version: 7.29.2
   resolution: "@babel/runtime@npm:7.29.2"
@@ -1999,30 +2033,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cmfcmf/docusaurus-search-local@npm:^1.0.0":
-  version: 1.2.0
-  resolution: "@cmfcmf/docusaurus-search-local@npm:1.2.0"
-  dependencies:
-    "@algolia/autocomplete-js": "npm:^1.8.2"
-    "@algolia/autocomplete-theme-classic": "npm:^1.8.2"
-    "@algolia/client-search": "npm:^4.12.0"
-    algoliasearch: "npm:^4.12.0"
-    cheerio: "npm:^1.0.0-rc.9"
-    clsx: "npm:^1.1.1"
-    lunr-languages: "npm:^1.4.0"
-    mark.js: "npm:^8.11.1"
-    tslib: "npm:^2.6.3"
-  peerDependencies:
-    "@docusaurus/core": ^2.0.0
-    nodejieba: ^2.5.0
-  peerDependenciesMeta:
-    nodejieba:
-      optional: true
-  checksum: 10c0/d188f7b31be67a5e0699d07b44c112f151dec7cc6c8fd79a3670903231f6a31b924f95620d98102c1db645c099bd03e626e3c4ed5d8123cf175ed7d0c3ca9d6e
-  languageName: node
-  linkType: hard
-
-"@cmfcmf/docusaurus-search-local@npm:^2.0.0":
+"@cmfcmf/docusaurus-search-local@npm:^2.0.1":
   version: 2.0.1
   resolution: "@cmfcmf/docusaurus-search-local@npm:2.0.1"
   dependencies:
@@ -2718,9 +2729,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docsearch/core@npm:4.6.0":
-  version: 4.6.0
-  resolution: "@docsearch/core@npm:4.6.0"
+"@docsearch/core@npm:4.6.3":
+  version: 4.6.3
+  resolution: "@docsearch/core@npm:4.6.3"
   peerDependencies:
     "@types/react": ">= 16.8.0 < 20.0.0"
     react: ">= 16.8.0 < 20.0.0"
@@ -2732,24 +2743,24 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/372092e6d38720db40aefe38226d20a3b37c75389de159bfa5e86258b97257022193dc0463876a0c5878e9f28f8b5672a2c55d1c091dbd07f01d726e54158c85
+  checksum: 10c0/3abf3c78f4f0df3a4129d553f77ffb0a23f6eca6bde350448f42ba51178bfbba3c2f6e42e83a07e73fa0cd3643ea9f4bad5fd7a5ebc910010fa12da6a8bf7f97
   languageName: node
   linkType: hard
 
-"@docsearch/css@npm:4.6.0":
-  version: 4.6.0
-  resolution: "@docsearch/css@npm:4.6.0"
-  checksum: 10c0/bba5290efbfd408d4acbe4f6a6d582be57daf682b4f8ea6acf326a24df2d4ac2e257b30e2eacf2ff34fd23b829531a97e69f1accf526506441ac8d390453efcf
+"@docsearch/css@npm:4.6.3":
+  version: 4.6.3
+  resolution: "@docsearch/css@npm:4.6.3"
+  checksum: 10c0/10c1282f102332915eaced15b16422d6aeb6b845311483e73d0f789fdc9c0913278adfa9f6ab29c856d769eafd1598d3271d6ef7059d74bec9d3f3c53a29f132
   languageName: node
   linkType: hard
 
-"@docsearch/react@npm:^3.9.0 || ^4.1.0":
-  version: 4.6.0
-  resolution: "@docsearch/react@npm:4.6.0"
+"@docsearch/react@npm:^3.9.0 || ^4.3.2":
+  version: 4.6.3
+  resolution: "@docsearch/react@npm:4.6.3"
   dependencies:
     "@algolia/autocomplete-core": "npm:1.19.2"
-    "@docsearch/core": "npm:4.6.0"
-    "@docsearch/css": "npm:4.6.0"
+    "@docsearch/core": "npm:4.6.3"
+    "@docsearch/css": "npm:4.6.3"
   peerDependencies:
     "@types/react": ">= 16.8.0 < 20.0.0"
     react: ">= 16.8.0 < 20.0.0"
@@ -2764,13 +2775,13 @@ __metadata:
       optional: true
     search-insights:
       optional: true
-  checksum: 10c0/ce5cf473779dbf045486b4d9a8095a83d07bbdb59420aa207f20f6a6387785d7fa6b7945b5cf8a025799fe59ae96c14755037a5ec8fc0b3dff3e0a615ee30337
+  checksum: 10c0/47e764c50fa99931aff47e93108a9f34cbeed0edcdbce3034e5475790e068ee9e5e24fdd6c650fb9c8c3bfb0f1fc4fdd95148a1abda9d854d9fb2ccbf628b09e
   languageName: node
   linkType: hard
 
-"@docusaurus/babel@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/babel@npm:3.9.2"
+"@docusaurus/babel@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/babel@npm:3.10.2"
   dependencies:
     "@babel/core": "npm:^7.25.9"
     "@babel/generator": "npm:^7.25.9"
@@ -2780,27 +2791,26 @@ __metadata:
     "@babel/preset-react": "npm:^7.25.9"
     "@babel/preset-typescript": "npm:^7.25.9"
     "@babel/runtime": "npm:^7.25.9"
-    "@babel/runtime-corejs3": "npm:^7.25.9"
     "@babel/traverse": "npm:^7.25.9"
-    "@docusaurus/logger": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
     babel-plugin-dynamic-import-node: "npm:^2.3.3"
     fs-extra: "npm:^11.1.1"
     tslib: "npm:^2.6.0"
-  checksum: 10c0/8147451a8ba79d35405ec8720c1cded7e84643867cb32877827799e5d36932cf56beaefd9fe4b25b9d855b38a9c08bc5397faddf73b63d7c52b05bf24ca99ee8
+  checksum: 10c0/5d6f5938bc3220e8f3664169e77ee0b1f11423a9adfc19409f8e7b3f4264afa8e8cd111f744fe54562278a8b276f6b4b6506f509cfdc3c31cc2ade36a6171dbd
   languageName: node
   linkType: hard
 
-"@docusaurus/bundler@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/bundler@npm:3.9.2"
+"@docusaurus/bundler@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/bundler@npm:3.10.2"
   dependencies:
     "@babel/core": "npm:^7.25.9"
-    "@docusaurus/babel": "npm:3.9.2"
-    "@docusaurus/cssnano-preset": "npm:3.9.2"
-    "@docusaurus/logger": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
+    "@docusaurus/babel": "npm:3.10.2"
+    "@docusaurus/cssnano-preset": "npm:3.10.2"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
     babel-loader: "npm:^9.2.1"
     clean-css: "npm:^5.3.3"
     copy-webpack-plugin: "npm:^11.0.0"
@@ -2818,27 +2828,27 @@ __metadata:
     tslib: "npm:^2.6.0"
     url-loader: "npm:^4.1.1"
     webpack: "npm:^5.95.0"
-    webpackbar: "npm:^6.0.1"
+    webpackbar: "npm:^7.0.0"
   peerDependencies:
     "@docusaurus/faster": "*"
   peerDependenciesMeta:
     "@docusaurus/faster":
       optional: true
-  checksum: 10c0/dcbb7d51eef3fcd57161cb356f63487dbc5a433eea02bc0dfb2a59439884543e76efa3c311ca01c582c2ca33caff19e887303bf72aad04ee374fd013fdcca31f
+  checksum: 10c0/141513e97d317ba2c2e2793dd4abae12b72132cf8e7c61e8f1d8d3521b6c6b162a5c5aa36ab02fbc41bad01bd8a50978133d58c9c420f1e10ec937a6d8b75109
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:3.9.2, @docusaurus/core@npm:^3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/core@npm:3.9.2"
+"@docusaurus/core@npm:3.10.2, @docusaurus/core@npm:^3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/core@npm:3.10.2"
   dependencies:
-    "@docusaurus/babel": "npm:3.9.2"
-    "@docusaurus/bundler": "npm:3.9.2"
-    "@docusaurus/logger": "npm:3.9.2"
-    "@docusaurus/mdx-loader": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-common": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@docusaurus/babel": "npm:3.10.2"
+    "@docusaurus/bundler": "npm:3.10.2"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/mdx-loader": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-common": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     boxen: "npm:^6.2.1"
     chalk: "npm:^4.1.2"
     chokidar: "npm:^3.5.3"
@@ -2846,11 +2856,11 @@ __metadata:
     combine-promises: "npm:^1.1.0"
     commander: "npm:^5.1.0"
     core-js: "npm:^3.31.1"
-    detect-port: "npm:^1.5.1"
+    detect-port: "npm:^2.1.0"
     escape-html: "npm:^1.0.3"
     eta: "npm:^2.2.0"
     eval: "npm:^0.1.8"
-    execa: "npm:5.1.1"
+    execa: "npm:^5.1.1"
     fs-extra: "npm:^11.1.1"
     html-tags: "npm:^3.3.1"
     html-webpack-plugin: "npm:^5.6.0"
@@ -2861,12 +2871,12 @@ __metadata:
     prompts: "npm:^2.4.2"
     react-helmet-async: "npm:@slorber/react-helmet-async@1.3.0"
     react-loadable: "npm:@docusaurus/react-loadable@6.0.0"
-    react-loadable-ssr-addon-v5-slorber: "npm:^1.0.1"
+    react-loadable-ssr-addon-v5-slorber: "npm:^1.0.3"
     react-router: "npm:^5.3.4"
     react-router-config: "npm:^5.1.1"
     react-router-dom: "npm:^5.3.4"
     semver: "npm:^7.5.4"
-    serve-handler: "npm:^6.1.6"
+    serve-handler: "npm:^6.1.7"
     tinypool: "npm:^1.0.2"
     tslib: "npm:^2.6.0"
     update-notifier: "npm:^6.0.2"
@@ -2875,44 +2885,68 @@ __metadata:
     webpack-dev-server: "npm:^5.2.2"
     webpack-merge: "npm:^6.0.1"
   peerDependencies:
+    "@docusaurus/faster": "*"
     "@mdx-js/react": ^3.0.0
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@docusaurus/faster":
+      optional: true
   bin:
     docusaurus: bin/docusaurus.mjs
-  checksum: 10c0/6058e2ca596ba0225f26f15baaf0c8fa5e91ddf794c3b942161702c44833baaf15be3acb71d42cf6e359a83e80be609485b6c1080802927591fe38bfc915aa11
+  checksum: 10c0/e788635b2b6705fb6ecb6ba22f09930eed0148f4e27ee5c435742e1228e27ab2aeb539bc623355e0edba2978bffde60ead1eff2464283f3a0d14eaeb108131e4
   languageName: node
   linkType: hard
 
-"@docusaurus/cssnano-preset@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/cssnano-preset@npm:3.9.2"
+"@docusaurus/cssnano-preset@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/cssnano-preset@npm:3.10.2"
   dependencies:
     cssnano-preset-advanced: "npm:^6.1.2"
     postcss: "npm:^8.5.4"
     postcss-sort-media-queries: "npm:^5.2.0"
     tslib: "npm:^2.6.0"
-  checksum: 10c0/98ca8939ba9c7c6d45cccdaa4028412cd84ea04c39b641d14e3870ee880d83cef8e04cdb485327b36e40550676ee1d614f1e89c9aa822b78e7d0c7dc0321f8db
+  checksum: 10c0/55d288fbe37abcac181323c59c03bb7c53f0f34531abe1bf35f537e4c926a6b97b8c597fd6044344b16fd5aa40f7a566032576857d0fa7c121651569631936ea
   languageName: node
   linkType: hard
 
-"@docusaurus/logger@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/logger@npm:3.9.2"
+"@docusaurus/faster@npm:^3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/faster@npm:3.10.2"
+  dependencies:
+    "@docusaurus/types": "npm:3.10.2"
+    "@rspack/core": "npm:^1.7.10"
+    "@swc/core": "npm:^1.15.40"
+    "@swc/html": "npm:^1.15.40"
+    browserslist: "npm:^4.24.2"
+    lightningcss: "npm:^1.27.0"
+    semver: "npm:^7.5.4"
+    swc-loader: "npm:^0.2.6"
+    tslib: "npm:^2.6.0"
+    webpack: "npm:^5.95.0"
+  peerDependencies:
+    "@docusaurus/types": "*"
+  checksum: 10c0/52a8942243839981d5896b7ff117d9ed09584d2a6ae5c2f525b1bc7907b58f3b15d654951ab777e6c33c1d04b6943bbf41589922786b76c9abe1632c265f0ef8
+  languageName: node
+  linkType: hard
+
+"@docusaurus/logger@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/logger@npm:3.10.2"
   dependencies:
     chalk: "npm:^4.1.2"
     tslib: "npm:^2.6.0"
-  checksum: 10c0/a21e0796873386a9be56f25906092a5d67c9bba5e52abf88e4c3c69d7c1e21467c04b3650c2ff2b9a803507aa4946c4173612791a87f04480d63ed87207b124a
+  checksum: 10c0/77f4751a9b7dba4b40f61c859f1696c0eb3b180551e73f4af624481e4f17613523ca6d2a9e2595dc9e5a9908a44c1d90f61455d970bbeee47b509cacea76dc7e
   languageName: node
   linkType: hard
 
-"@docusaurus/mdx-loader@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/mdx-loader@npm:3.9.2"
+"@docusaurus/mdx-loader@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/mdx-loader@npm:3.10.2"
   dependencies:
-    "@docusaurus/logger": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     "@mdx-js/mdx": "npm:^3.0.0"
     "@slorber/remark-comment": "npm:^1.0.0"
     escape-html: "npm:^1.0.3"
@@ -2937,15 +2971,15 @@ __metadata:
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/4f3afa817f16fd04dd338a35c04be59fdc0e799a93c6d56dc99b1f42f9a5156691737df62751e14466acbbd65c932e1f77d06a915c9c4ad8f2ad24b2f5479269
+  checksum: 10c0/eb37eebb858319d55d1493724a92dee6325d24f4badb334095d41260b0cb9601c4a9f64d4718616dc4c6829f5c062f91799452c1390c2b019f604ddc1c67a026
   languageName: node
   linkType: hard
 
-"@docusaurus/module-type-aliases@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/module-type-aliases@npm:3.9.2"
+"@docusaurus/module-type-aliases@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/module-type-aliases@npm:3.10.2"
   dependencies:
-    "@docusaurus/types": "npm:3.9.2"
+    "@docusaurus/types": "npm:3.10.2"
     "@types/history": "npm:^4.7.11"
     "@types/react": "npm:*"
     "@types/react-router-config": "npm:*"
@@ -2955,19 +2989,19 @@ __metadata:
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 10c0/60f163ff9004bb1fcbbad94b18200b6bca967da14576f78f5c533f8535aae0a3a723245cb28e1ca93f9d5881d3f1077e03ebf12bbad59d0e1c6916300d086642
+  checksum: 10c0/3a6a4cc350c48a4e4ba6826976f24e15fc833509533a958252f84b71f7b742d2d65813dde2bb0bc84f44b6918c891997b0fc4174d4b83edb0ef6aeed3330ca13
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-client-redirects@npm:^3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/plugin-client-redirects@npm:3.9.2"
+"@docusaurus/plugin-client-redirects@npm:^3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/plugin-client-redirects@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/logger": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-common": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-common": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     eta: "npm:^2.2.0"
     fs-extra: "npm:^11.1.1"
     lodash: "npm:^4.17.21"
@@ -2975,23 +3009,24 @@ __metadata:
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/5fe827fa5f3b3e4634034eb63ff73d8bd2e83852ada6ae989ad5b566aaef4937476c20403e1ef05f2090dad92c2e6b384e0981d393a783b49e8b45fa464d282b
+  checksum: 10c0/ab5ded6b97561047d35edf7fb6bee7e7bd795a38223873c89824e06597e762628d1ce3e72cf2c8c212c5579406a026bbacb3392d9c3b6dccbcace8239cd48801
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-blog@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/plugin-content-blog@npm:3.9.2"
+"@docusaurus/plugin-content-blog@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/plugin-content-blog@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/logger": "npm:3.9.2"
-    "@docusaurus/mdx-loader": "npm:3.9.2"
-    "@docusaurus/theme-common": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-common": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/mdx-loader": "npm:3.10.2"
+    "@docusaurus/theme-common": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-common": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     cheerio: "npm:1.0.0-rc.12"
+    combine-promises: "npm:^1.1.0"
     feed: "npm:^4.2.2"
     fs-extra: "npm:^11.1.1"
     lodash: "npm:^4.17.21"
@@ -3005,23 +3040,23 @@ __metadata:
     "@docusaurus/plugin-content-docs": "*"
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/98f82d76d248407a4c53f922f8953a7519a57d18c45f71e41bfb6380d7f801ba063068c9dec2a48b79f10fd4d4f4a909af4c70e4874223db19d9654d651982dd
+  checksum: 10c0/ef6b0aae35854fdc41e6e10b4e4fad837134e0431aee12324d94b3898db3048dba56316e172f878b97c575a1696242446e29554a6e900c7519eaa5c88b6d46ff
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-docs@npm:^3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/plugin-content-docs@npm:3.9.2"
+"@docusaurus/plugin-content-docs@npm:^3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/plugin-content-docs@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/logger": "npm:3.9.2"
-    "@docusaurus/mdx-loader": "npm:3.9.2"
-    "@docusaurus/module-type-aliases": "npm:3.9.2"
-    "@docusaurus/theme-common": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-common": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/mdx-loader": "npm:3.10.2"
+    "@docusaurus/module-type-aliases": "npm:3.10.2"
+    "@docusaurus/theme-common": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-common": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     "@types/react-router-config": "npm:^5.0.7"
     combine-promises: "npm:^1.1.0"
     fs-extra: "npm:^11.1.1"
@@ -3034,133 +3069,132 @@ __metadata:
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/f2df62f6e03a383a8e7f81b29bea81de9b69e918dfaa668cef15a6f787943d3c148bfd8ba120d89cd96a3bbb23cd3d29ce0658f8dee07380ad612db66e835fa4
+  checksum: 10c0/800674266633e204bfddddd7ce0a35cfbe308b0f05191e96be02d4968c2b0c92e677887dd4ddfc3cecbb0ae46e7e1248084c5a00a9db798274faa9531ed17f48
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-pages@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/plugin-content-pages@npm:3.9.2"
+"@docusaurus/plugin-content-pages@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/plugin-content-pages@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/mdx-loader": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/mdx-loader": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     fs-extra: "npm:^11.1.1"
     tslib: "npm:^2.6.0"
     webpack: "npm:^5.88.1"
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/294cbd3d127b9a777ab75c13be30e2a559b544bc96798ac6b6d479130f66b95dd6beaf1ca63991f78c279add23ffe16ea14454d3547d558196e747bdb85cb753
+  checksum: 10c0/68974ebe1446813f37cff5aa77163dfd82b46e62e724b829b7fc1461a33c5e54391699b3adf9ff9696f6d5bd1da50df8c66299ed3a6db3f7c2ca6356e77a6118
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-css-cascade-layers@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/plugin-css-cascade-layers@npm:3.9.2"
+"@docusaurus/plugin-css-cascade-layers@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/plugin-css-cascade-layers@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     tslib: "npm:^2.6.0"
-  checksum: 10c0/3a56f6f4eaa3c1ea014ba25b8d16e2a7ffb144ebf5726b5ec531b4df0a9f7bb33ced4de7ca31f9663a65358852d0635c584244c05f07e9d4c9172f80ba21a5ca
+  checksum: 10c0/2c7429b24edc1ef02aaa8e26734a429f117eb053e43b9b8a586be5285a897236560e7e0174277abedf6c364ccd10850dc728d851e48075eca3afbe1ac0ec77e3
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-debug@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/plugin-debug@npm:3.9.2"
+"@docusaurus/plugin-debug@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/plugin-debug@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
     fs-extra: "npm:^11.1.1"
     react-json-view-lite: "npm:^2.3.0"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/46819f1c22b31b3fbf30243dc5c0439b35a35f8cbbae835becf1e6992ff490ddbd91e4a7448b367ad76aaf20064ed739be07f0e664bb582b4dab39513996d7ba
+  checksum: 10c0/df6acce06f265a65a46986a2d47d60546a13b03b3204c472ff9e48b38cb140c939b6a8249e7aba64c387aa63ffdbd2122194e55f617dc34414303421dbb82554
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-analytics@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/plugin-google-analytics@npm:3.9.2"
+"@docusaurus/plugin-google-analytics@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/plugin-google-analytics@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/6fb787132170f731c1ab66c854fcab6d0c4f7919d60c336185942c8f80dc93b286e64e0bfb22f5f770e7d77fd02000fb5a54b35a357258a0cc6a59468778199e
+  checksum: 10c0/0b2f472203e16103ba8cebc3a32caddaecb783bca35162096ae6ad2d5fdcb724fcfce0b79682038394a664a0b38864e63e5e7a8d0d14024939891360e77ff49d
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-gtag@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/plugin-google-gtag@npm:3.9.2"
+"@docusaurus/plugin-google-gtag@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/plugin-google-gtag@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
-    "@types/gtag.js": "npm:^0.0.12"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/34d4b9c6787e3656dc1af42ecb31a41b766735c89f7a719db40c34a8695aa36825e070923a84639ae3dc42b64a41ee656bd4b2728621c1493952c4efa04b3927
+  checksum: 10c0/029b9b18e4c588daa0dd0cd79cb8b3682cc8c44a83b28f0179eb45c9717619e104d276df3f0ce7dadea01cdae4a61c8ef3fb993f59be5daa5365df3317ef2be8
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-tag-manager@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/plugin-google-tag-manager@npm:3.9.2"
+"@docusaurus/plugin-google-tag-manager@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/plugin-google-tag-manager@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/536cb63dc4a22a456e5b7f1d8b53acf0c45b16ba8fb7474c93d5ab7afec60682feccea65c39685dcbc568fccefd6629264e9b979e0f7069fb4c9dc816048659b
+  checksum: 10c0/1cf911e6b91dd76fe8283d1c16643d1c46435fc03a89b786968b2f93606ae1af58c3cd1208f548e980025c45b4ff5c9b307be71ab56c0102c4c2e8e91f052370
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-sitemap@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/plugin-sitemap@npm:3.9.2"
+"@docusaurus/plugin-sitemap@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/plugin-sitemap@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/logger": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-common": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-common": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     fs-extra: "npm:^11.1.1"
     sitemap: "npm:^7.1.1"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/a1bcbb8ab2531eaa810e74a7c5800942d89a11cfaf544d6d72941c7e37c29eaef609dcaff368ee92cf759e03be7c258c6e5e4cfc6046d77e727a63f84e63a045
+  checksum: 10c0/4d1c28458303ec439ef31ab9f7f23a18e7ee2d355c4331a739a42aae9cf19f5506415ea631d7569580008e0215274c15f4148b84d6cd0c5f8dd208f7f49e7349
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-svgr@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/plugin-svgr@npm:3.9.2"
+"@docusaurus/plugin-svgr@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/plugin-svgr@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     "@svgr/core": "npm:8.1.0"
     "@svgr/webpack": "npm:^8.1.0"
     tslib: "npm:^2.6.0"
@@ -3168,55 +3202,56 @@ __metadata:
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/d6a7a1aa0c05b759d6094969d31d05cb7840ee514a60812f8e841e13c2cf319a46d046c0903417e9072b8bc26a9fd0d63e7e5a75255ed7d6b08a9a0466f6cb1a
+  checksum: 10c0/2817f91f641336dab5d6874ee513e288d599a0be4e1a9c59698befcf41f91aeb73b3660198777c09f4470a6ba31c2d57e9fc1cfd482e0067372bb137932c6307
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:^3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/preset-classic@npm:3.9.2"
+"@docusaurus/preset-classic@npm:^3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/preset-classic@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/plugin-content-blog": "npm:3.9.2"
-    "@docusaurus/plugin-content-docs": "npm:3.9.2"
-    "@docusaurus/plugin-content-pages": "npm:3.9.2"
-    "@docusaurus/plugin-css-cascade-layers": "npm:3.9.2"
-    "@docusaurus/plugin-debug": "npm:3.9.2"
-    "@docusaurus/plugin-google-analytics": "npm:3.9.2"
-    "@docusaurus/plugin-google-gtag": "npm:3.9.2"
-    "@docusaurus/plugin-google-tag-manager": "npm:3.9.2"
-    "@docusaurus/plugin-sitemap": "npm:3.9.2"
-    "@docusaurus/plugin-svgr": "npm:3.9.2"
-    "@docusaurus/theme-classic": "npm:3.9.2"
-    "@docusaurus/theme-common": "npm:3.9.2"
-    "@docusaurus/theme-search-algolia": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/plugin-content-blog": "npm:3.10.2"
+    "@docusaurus/plugin-content-docs": "npm:3.10.2"
+    "@docusaurus/plugin-content-pages": "npm:3.10.2"
+    "@docusaurus/plugin-css-cascade-layers": "npm:3.10.2"
+    "@docusaurus/plugin-debug": "npm:3.10.2"
+    "@docusaurus/plugin-google-analytics": "npm:3.10.2"
+    "@docusaurus/plugin-google-gtag": "npm:3.10.2"
+    "@docusaurus/plugin-google-tag-manager": "npm:3.10.2"
+    "@docusaurus/plugin-sitemap": "npm:3.10.2"
+    "@docusaurus/plugin-svgr": "npm:3.10.2"
+    "@docusaurus/theme-classic": "npm:3.10.2"
+    "@docusaurus/theme-common": "npm:3.10.2"
+    "@docusaurus/theme-search-algolia": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/94e6f3948592209bd68b797591f21daee8543c6c9a4eac5ae498f5c6b8d1c7579b23173f8554a3430d0dff1cce90b953be0d5f2d53b6b4729116000f61e3dab2
+  checksum: 10c0/455b1dea7a9867a69e2634aef4286116c5aef6612e76277ebe82538ee14517ca9a6f2e0421196bd15f7cde6376160fd6284dfe83c03a3c0d1ee00bbc642d4d35
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-classic@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/theme-classic@npm:3.9.2"
+"@docusaurus/theme-classic@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/theme-classic@npm:3.10.2"
   dependencies:
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/logger": "npm:3.9.2"
-    "@docusaurus/mdx-loader": "npm:3.9.2"
-    "@docusaurus/module-type-aliases": "npm:3.9.2"
-    "@docusaurus/plugin-content-blog": "npm:3.9.2"
-    "@docusaurus/plugin-content-docs": "npm:3.9.2"
-    "@docusaurus/plugin-content-pages": "npm:3.9.2"
-    "@docusaurus/theme-common": "npm:3.9.2"
-    "@docusaurus/theme-translations": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-common": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/mdx-loader": "npm:3.10.2"
+    "@docusaurus/module-type-aliases": "npm:3.10.2"
+    "@docusaurus/plugin-content-blog": "npm:3.10.2"
+    "@docusaurus/plugin-content-docs": "npm:3.10.2"
+    "@docusaurus/plugin-content-pages": "npm:3.10.2"
+    "@docusaurus/theme-common": "npm:3.10.2"
+    "@docusaurus/theme-translations": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-common": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     "@mdx-js/react": "npm:^3.0.0"
     clsx: "npm:^2.0.0"
+    copy-text-to-clipboard: "npm:^3.2.0"
     infima: "npm:0.2.0-alpha.45"
     lodash: "npm:^4.17.21"
     nprogress: "npm:^0.2.0"
@@ -3230,18 +3265,18 @@ __metadata:
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/aa6442ac2e65539f083a0ed1e70030443bf61422d5cca24fc8b91c2c4192bcd4d8abdbf4b71536e2ae6afd413fd3f4be1379f2dc45e224173500577ebfa1c346
+  checksum: 10c0/c9a19f52ddf8323c22f4bd8765fbcf552cf1ac215949dd50df60e2131ff7f942365e8ac5b4f7fa8230e22b73df5400b97f0fa915fba8ad56445b9ff4eb3946cc
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-common@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/theme-common@npm:3.9.2"
+"@docusaurus/theme-common@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/theme-common@npm:3.10.2"
   dependencies:
-    "@docusaurus/mdx-loader": "npm:3.9.2"
-    "@docusaurus/module-type-aliases": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-common": "npm:3.9.2"
+    "@docusaurus/mdx-loader": "npm:3.10.2"
+    "@docusaurus/module-type-aliases": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-common": "npm:3.10.2"
     "@types/history": "npm:^4.7.11"
     "@types/react": "npm:*"
     "@types/react-router-config": "npm:*"
@@ -3254,22 +3289,23 @@ __metadata:
     "@docusaurus/plugin-content-docs": "*"
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/4ecb8570e1fee75a6048ddb43065252e7b5b058f075867b541219830fb01bdc4b41b8f5f0251d6e9e7ffbe3704fd23d16ef90f92a3e2511ecc7ff6d9a2d5bfd6
+  checksum: 10c0/2ec64449ff69beb3c506f3f7de837afe6a38fc904b1d38547415fb32cd3dcac7d868b14b59d6fc14e0eb3d47c2091bd05fecd294455b765a4bc9b2af9cdadf0a
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-search-algolia@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/theme-search-algolia@npm:3.9.2"
+"@docusaurus/theme-search-algolia@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/theme-search-algolia@npm:3.10.2"
   dependencies:
-    "@docsearch/react": "npm:^3.9.0 || ^4.1.0"
-    "@docusaurus/core": "npm:3.9.2"
-    "@docusaurus/logger": "npm:3.9.2"
-    "@docusaurus/plugin-content-docs": "npm:3.9.2"
-    "@docusaurus/theme-common": "npm:3.9.2"
-    "@docusaurus/theme-translations": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-validation": "npm:3.9.2"
+    "@algolia/autocomplete-core": "npm:^1.19.2"
+    "@docsearch/react": "npm:^3.9.0 || ^4.3.2"
+    "@docusaurus/core": "npm:3.10.2"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/plugin-content-docs": "npm:3.10.2"
+    "@docusaurus/theme-common": "npm:3.10.2"
+    "@docusaurus/theme-translations": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-validation": "npm:3.10.2"
     algoliasearch: "npm:^5.37.0"
     algoliasearch-helper: "npm:^3.26.0"
     clsx: "npm:^2.0.0"
@@ -3281,30 +3317,30 @@ __metadata:
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/676206059771d13c2268c4f8a20630288ac043aa1042090c259de434f8f833e1e95c0cf7de304880149ace3d084c901d3d01cfbfea63a48dc71aaa6726166621
+  checksum: 10c0/2097c7a0e80e251392b6e6c4a6d5d79eb88072dab002df6ce1dff0ec22e0660f0ba8c32e5a57605a51afe4461188ae998a49740cc97df5dcd803bb0853a536ad
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-translations@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/theme-translations@npm:3.9.2"
+"@docusaurus/theme-translations@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/theme-translations@npm:3.10.2"
   dependencies:
     fs-extra: "npm:^11.1.1"
     tslib: "npm:^2.6.0"
-  checksum: 10c0/543ee40933a8805357575c14d4fc8f8d504f6464796f5fa27ec13d8b0cec669617961edb206d5b74ba1d776d9486656fefdb1c777e2908cb1752ee6fbe28686c
+  checksum: 10c0/f063b75d700f70a4dc5203268962ceef84a5ba873109c5b9de0ffea7cc70ddd8fea74fa3676ffc27f736568d51219a3791486bee9f3ea6c4d925fa60e4300f54
   languageName: node
   linkType: hard
 
-"@docusaurus/tsconfig@npm:^3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/tsconfig@npm:3.9.2"
-  checksum: 10c0/d46241cb488d60f785710ee24980aad394423eaf5f76b64b0d47158fcbe19dd68a886898db83b1b65de18dfeb6c27d78adc8f8c4451d1ac29cc9da009ed15cd4
+"@docusaurus/tsconfig@npm:^3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/tsconfig@npm:3.10.2"
+  checksum: 10c0/f73d11ce6440d8ad3d8a87a87661e39d1d16451db0f16cd15a1856b331608b429e4b35ab1e8d1fae4c4e2b5bb4b8c238bac3900a8f024a68ba942c633c228361
   languageName: node
   linkType: hard
 
-"@docusaurus/types@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/types@npm:3.9.2"
+"@docusaurus/types@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/types@npm:3.10.2"
   dependencies:
     "@mdx-js/mdx": "npm:^3.0.0"
     "@types/history": "npm:^4.7.11"
@@ -3319,50 +3355,50 @@ __metadata:
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10c0/e50a9931e97944d39375a97a45ded13bc35baf3c9c14fe66d30944ebe1203df7748a7631291f937bef1a7a98db73c23505620cd8f03d109fbbdfa83725fb2857
+  checksum: 10c0/29672542109c69c7527a14767f0acbfac6635e650be6da75998f97cda7987deda30f402c04438879492a798975c9484265139f603631a2df0575a49f29a7345d
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-common@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/utils-common@npm:3.9.2"
+"@docusaurus/utils-common@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/utils-common@npm:3.10.2"
   dependencies:
-    "@docusaurus/types": "npm:3.9.2"
+    "@docusaurus/types": "npm:3.10.2"
     tslib: "npm:^2.6.0"
-  checksum: 10c0/0e34186ca66cf3c537935d998cfb2ce59beaad31ccb9b41c2288618f386d72dc4359e15e8cb012525211d1f1d753fc439d6c7e9701d6ac801e1121cfa3223d69
+  checksum: 10c0/65727f7acf200a2d026475e2f81a78fbe37b757c869f187122a69cfc40b4b1936699d83a2e701c2de856f9c68e7c8f307a3fb56a473bde9c883e865887b9e8c6
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/utils-validation@npm:3.9.2"
+"@docusaurus/utils-validation@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/utils-validation@npm:3.10.2"
   dependencies:
-    "@docusaurus/logger": "npm:3.9.2"
-    "@docusaurus/utils": "npm:3.9.2"
-    "@docusaurus/utils-common": "npm:3.9.2"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/utils": "npm:3.10.2"
+    "@docusaurus/utils-common": "npm:3.10.2"
     fs-extra: "npm:^11.2.0"
     joi: "npm:^17.9.2"
     js-yaml: "npm:^4.1.0"
     lodash: "npm:^4.17.21"
     tslib: "npm:^2.6.0"
-  checksum: 10c0/681b8c7fe0e2930affa388340f3db596a894affdb390e058277edd230181edca6f5593d37b48fb19c5077bbd5438549d944591f366b9f21ffff81feac1e1ae66
+  checksum: 10c0/67deae60e3338acae79928655d68db52bb1691ed467bf66ac9d1ed45a5b95d927af71f68c0d6120e908bea1d5e97562b3c3edbca93ebf07adc02012ec2da8277
   languageName: node
   linkType: hard
 
-"@docusaurus/utils@npm:3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/utils@npm:3.9.2"
+"@docusaurus/utils@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@docusaurus/utils@npm:3.10.2"
   dependencies:
-    "@docusaurus/logger": "npm:3.9.2"
-    "@docusaurus/types": "npm:3.9.2"
-    "@docusaurus/utils-common": "npm:3.9.2"
+    "@11ty/gray-matter": "npm:^1.0.0"
+    "@docusaurus/logger": "npm:3.10.2"
+    "@docusaurus/types": "npm:3.10.2"
+    "@docusaurus/utils-common": "npm:3.10.2"
     escape-string-regexp: "npm:^4.0.0"
-    execa: "npm:5.1.1"
+    execa: "npm:^5.1.1"
     file-loader: "npm:^6.2.0"
     fs-extra: "npm:^11.1.1"
     github-slugger: "npm:^1.5.0"
     globby: "npm:^11.1.0"
-    gray-matter: "npm:^4.0.3"
     jiti: "npm:^1.20.0"
     js-yaml: "npm:^4.1.0"
     lodash: "npm:^4.17.21"
@@ -3374,7 +3410,7 @@ __metadata:
     url-loader: "npm:^4.1.1"
     utility-types: "npm:^3.10.0"
     webpack: "npm:^5.88.1"
-  checksum: 10c0/9796b2e7bc93e47cb27ce81185264c6390b56cd9e68831f6013e4418af512a736f1baf9b97e5df8d646ef4da0650151512abf598f5d58793a3e6c0833c80e06a
+  checksum: 10c0/7d72ab04b8587a001d57efe71f40f8c0ae7e0087a51af791372455368726a8ea1c18473e0af5331aa30ea6a298d386a07417163597e2461a0213e14befb3609a
   languageName: node
   linkType: hard
 
@@ -3385,6 +3421,16 @@ __metadata:
     "@emnapi/wasi-threads": "npm:1.0.2"
     tslib: "npm:^2.4.0"
   checksum: 10c0/e30101d16d37ef3283538a35cad60e22095aff2403fb9226a35330b932eb6740b81364d525537a94eb4fb51355e48ae9b10d779c0dd1cdcd55d71461fe4b45c7
+  languageName: node
+  linkType: hard
+
+"@emnapi/core@npm:^1.5.0":
+  version: 1.11.3
+  resolution: "@emnapi/core@npm:1.11.3"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.3"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/4ca08d349a82d5d2887ccc9e12df630877b0412ddcd59b9faee61e3c3947ccead27a18257a18bfe17abdf2b0709857808ad75d423ac49edd50c32fb140a7ed6e
   languageName: node
   linkType: hard
 
@@ -3404,6 +3450,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/3b7ab72d21cb4e034f07df80165265f85f445ef3f581d1bc87b67e5239428baa00200b68a7d5e37a0425c3a78320b541b07f76c5530f6f6f95336a6294ebf30b
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:^1.5.0":
+  version: 1.11.3
+  resolution: "@emnapi/runtime@npm:1.11.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/a00f1020fefb9d4145c367f93a9fddb383a00da8ffd7871e20b19659890379b83aeecb9f84d7d0eda5456343f4a09eb05b0acb5153b0d3d889539dedb1ed87c3
   languageName: node
   linkType: hard
 
@@ -3431,6 +3486,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/1e3724b5814b06c14782fda87eee9b9aa68af01576c81ffeaefdf621ddb74386e419d5b3b1027b6a8172397729d95a92f814fc4b8d3c224376428faa07a6a01a
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@emnapi/wasi-threads@npm:1.2.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/5aed84bc5dbe867973b20406ca1ed95661a4892ecaef80378fdf2d37424b3f7b9c428df8a3e1d82b783a3345a530032bf049e699e1f113ea52203c3e9b4e6ce5
   languageName: node
   linkType: hard
 
@@ -5075,6 +5139,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@module-federation/error-codes@npm:0.22.0":
+  version: 0.22.0
+  resolution: "@module-federation/error-codes@npm:0.22.0"
+  checksum: 10c0/a9b25e8c930971e146e6352f482f915f1b54965ce54706984e834a87be714d30caebbd3946f9eb408e7821b2cc326b90787eeb2f8306edf1d322d9931543a139
+  languageName: node
+  linkType: hard
+
+"@module-federation/runtime-core@npm:0.22.0":
+  version: 0.22.0
+  resolution: "@module-federation/runtime-core@npm:0.22.0"
+  dependencies:
+    "@module-federation/error-codes": "npm:0.22.0"
+    "@module-federation/sdk": "npm:0.22.0"
+  checksum: 10c0/0406c26b119065dca23a8fb65872b8ab5794984d5d82984ed625c433658693050a8a800cde8c97cc1572b0bc154a7824fa9db5bb05106b7250643e799ba7091d
+  languageName: node
+  linkType: hard
+
+"@module-federation/runtime-tools@npm:0.22.0":
+  version: 0.22.0
+  resolution: "@module-federation/runtime-tools@npm:0.22.0"
+  dependencies:
+    "@module-federation/runtime": "npm:0.22.0"
+    "@module-federation/webpack-bundler-runtime": "npm:0.22.0"
+  checksum: 10c0/fbe76616fb176ce03550e3ce2bb43fa5d44c12d7d0939593f29dab5658accfb559b857df4180f7f681dc601aab928658cd9b49a78daad866089390b820854fbd
+  languageName: node
+  linkType: hard
+
+"@module-federation/runtime@npm:0.22.0":
+  version: 0.22.0
+  resolution: "@module-federation/runtime@npm:0.22.0"
+  dependencies:
+    "@module-federation/error-codes": "npm:0.22.0"
+    "@module-federation/runtime-core": "npm:0.22.0"
+    "@module-federation/sdk": "npm:0.22.0"
+  checksum: 10c0/f9cfaf7f8599a215195cb612a5d4532d4399cc8eb5a928ced60c4bdf0e7e2028849cdc384fa3f1506f9e7e0e112f74f6c30a5a76136dc56e155012d111ea075b
+  languageName: node
+  linkType: hard
+
+"@module-federation/sdk@npm:0.22.0":
+  version: 0.22.0
+  resolution: "@module-federation/sdk@npm:0.22.0"
+  checksum: 10c0/c09ba0147368151b67ba33b9174ef451a028e1709d2208aa811cacc1ae4efcae0f1987f02119f9b54754ee6430af3610e357c9b744147f112a25d8f7564f8041
+  languageName: node
+  linkType: hard
+
+"@module-federation/webpack-bundler-runtime@npm:0.22.0":
+  version: 0.22.0
+  resolution: "@module-federation/webpack-bundler-runtime@npm:0.22.0"
+  dependencies:
+    "@module-federation/runtime": "npm:0.22.0"
+    "@module-federation/sdk": "npm:0.22.0"
+  checksum: 10c0/4c1354b881ffc0c1521f1d676c9301db0b0d59186c386dde4dbb6d33f00fdb16bf118e85cfc38e2ffb36084fa87df8390d415a41c0c93b33bd0e5460a9a934f5
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:0.2.4":
   version: 0.2.4
   resolution: "@napi-rs/wasm-runtime@npm:0.2.4"
@@ -5083,6 +5202,17 @@ __metadata:
     "@emnapi/runtime": "npm:^1.1.0"
     "@tybys/wasm-util": "npm:^0.9.0"
   checksum: 10c0/1040de49b2ef509db207e2517465dbf7fb3474f20e8ec32897672a962ff4f59872385666dac61dc9dbeae3cae5dad265d8dc3865da756adeb07d1634c67b03a1
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:1.0.7":
+  version: 1.0.7
+  resolution: "@napi-rs/wasm-runtime@npm:1.0.7"
+  dependencies:
+    "@emnapi/core": "npm:^1.5.0"
+    "@emnapi/runtime": "npm:^1.5.0"
+    "@tybys/wasm-util": "npm:^0.10.1"
+  checksum: 10c0/2d8635498136abb49d6dbf7395b78c63422292240963bf055f307b77aeafbde57ae2c0ceaaef215601531b36d6eb92a2cdd6f5ba90ed2aa8127c27aff9c4ae55
   languageName: node
   linkType: hard
 
@@ -6115,6 +6245,140 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rspack/binding-darwin-arm64@npm:1.7.12":
+  version: 1.7.12
+  resolution: "@rspack/binding-darwin-arm64@npm:1.7.12"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-darwin-x64@npm:1.7.12":
+  version: 1.7.12
+  resolution: "@rspack/binding-darwin-x64@npm:1.7.12"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-linux-arm64-gnu@npm:1.7.12":
+  version: 1.7.12
+  resolution: "@rspack/binding-linux-arm64-gnu@npm:1.7.12"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-linux-arm64-musl@npm:1.7.12":
+  version: 1.7.12
+  resolution: "@rspack/binding-linux-arm64-musl@npm:1.7.12"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-linux-x64-gnu@npm:1.7.12":
+  version: 1.7.12
+  resolution: "@rspack/binding-linux-x64-gnu@npm:1.7.12"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-linux-x64-musl@npm:1.7.12":
+  version: 1.7.12
+  resolution: "@rspack/binding-linux-x64-musl@npm:1.7.12"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-wasm32-wasi@npm:1.7.12":
+  version: 1.7.12
+  resolution: "@rspack/binding-wasm32-wasi@npm:1.7.12"
+  dependencies:
+    "@napi-rs/wasm-runtime": "npm:1.0.7"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-win32-arm64-msvc@npm:1.7.12":
+  version: 1.7.12
+  resolution: "@rspack/binding-win32-arm64-msvc@npm:1.7.12"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-win32-ia32-msvc@npm:1.7.12":
+  version: 1.7.12
+  resolution: "@rspack/binding-win32-ia32-msvc@npm:1.7.12"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-win32-x64-msvc@npm:1.7.12":
+  version: 1.7.12
+  resolution: "@rspack/binding-win32-x64-msvc@npm:1.7.12"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rspack/binding@npm:1.7.12":
+  version: 1.7.12
+  resolution: "@rspack/binding@npm:1.7.12"
+  dependencies:
+    "@rspack/binding-darwin-arm64": "npm:1.7.12"
+    "@rspack/binding-darwin-x64": "npm:1.7.12"
+    "@rspack/binding-linux-arm64-gnu": "npm:1.7.12"
+    "@rspack/binding-linux-arm64-musl": "npm:1.7.12"
+    "@rspack/binding-linux-x64-gnu": "npm:1.7.12"
+    "@rspack/binding-linux-x64-musl": "npm:1.7.12"
+    "@rspack/binding-wasm32-wasi": "npm:1.7.12"
+    "@rspack/binding-win32-arm64-msvc": "npm:1.7.12"
+    "@rspack/binding-win32-ia32-msvc": "npm:1.7.12"
+    "@rspack/binding-win32-x64-msvc": "npm:1.7.12"
+  dependenciesMeta:
+    "@rspack/binding-darwin-arm64":
+      optional: true
+    "@rspack/binding-darwin-x64":
+      optional: true
+    "@rspack/binding-linux-arm64-gnu":
+      optional: true
+    "@rspack/binding-linux-arm64-musl":
+      optional: true
+    "@rspack/binding-linux-x64-gnu":
+      optional: true
+    "@rspack/binding-linux-x64-musl":
+      optional: true
+    "@rspack/binding-wasm32-wasi":
+      optional: true
+    "@rspack/binding-win32-arm64-msvc":
+      optional: true
+    "@rspack/binding-win32-ia32-msvc":
+      optional: true
+    "@rspack/binding-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/0bca963309c75418148ce67f9c102b11662844bc2412257da9e4fb56917bf279f37d5ebd8f6d641405bcde54d43384adc5693e22bc15c571f949a99a90aa6ec9
+  languageName: node
+  linkType: hard
+
+"@rspack/core@npm:^1.7.10":
+  version: 1.7.12
+  resolution: "@rspack/core@npm:1.7.12"
+  dependencies:
+    "@module-federation/runtime-tools": "npm:0.22.0"
+    "@rspack/binding": "npm:1.7.12"
+    "@rspack/lite-tapable": "npm:1.1.0"
+  peerDependencies:
+    "@swc/helpers": ">=0.5.1"
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: 10c0/575737cffae45720563a8f5bc933058a0c6c42dbae1a41b53f98c44281146eb5f917f118c866d53aa8e0f2b4533dae092c564f27412affb58ae3dbeb853266b4
+  languageName: node
+  linkType: hard
+
+"@rspack/lite-tapable@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@rspack/lite-tapable@npm:1.1.0"
+  checksum: 10c0/15059d1da73192b150339ceba3142a2d0073fa298dad9a497cc8c6037c597c3a982ed4c88dc50afa7b70d0757df1b47af7ae407cfe8acd31d333d524b84a7a4b
+  languageName: node
+  linkType: hard
+
 "@rtsao/scc@npm:^1.1.0":
   version: 1.1.0
   resolution: "@rtsao/scc@npm:1.1.0"
@@ -6472,12 +6736,294 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-darwin-arm64@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-darwin-arm64@npm:1.15.46"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-x64@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-darwin-x64@npm:1.15.46"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm-gnueabihf@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.15.46"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-gnu@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.15.46"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-musl@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-arm64-musl@npm:1.15.46"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-ppc64-gnu@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-ppc64-gnu@npm:1.15.46"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-s390x-gnu@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-s390x-gnu@npm:1.15.46"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-gnu@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-x64-gnu@npm:1.15.46"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-musl@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-linux-x64-musl@npm:1.15.46"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-arm64-msvc@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.15.46"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-ia32-msvc@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.15.46"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-x64-msvc@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/core-win32-x64-msvc@npm:1.15.46"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:^1.15.40":
+  version: 1.15.46
+  resolution: "@swc/core@npm:1.15.46"
+  dependencies:
+    "@swc/core-darwin-arm64": "npm:1.15.46"
+    "@swc/core-darwin-x64": "npm:1.15.46"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.15.46"
+    "@swc/core-linux-arm64-gnu": "npm:1.15.46"
+    "@swc/core-linux-arm64-musl": "npm:1.15.46"
+    "@swc/core-linux-ppc64-gnu": "npm:1.15.46"
+    "@swc/core-linux-s390x-gnu": "npm:1.15.46"
+    "@swc/core-linux-x64-gnu": "npm:1.15.46"
+    "@swc/core-linux-x64-musl": "npm:1.15.46"
+    "@swc/core-win32-arm64-msvc": "npm:1.15.46"
+    "@swc/core-win32-ia32-msvc": "npm:1.15.46"
+    "@swc/core-win32-x64-msvc": "npm:1.15.46"
+    "@swc/counter": "npm:^0.1.3"
+    "@swc/types": "npm:^0.1.27"
+  peerDependencies:
+    "@swc/helpers": ">=0.5.17"
+  dependenciesMeta:
+    "@swc/core-darwin-arm64":
+      optional: true
+    "@swc/core-darwin-x64":
+      optional: true
+    "@swc/core-linux-arm-gnueabihf":
+      optional: true
+    "@swc/core-linux-arm64-gnu":
+      optional: true
+    "@swc/core-linux-arm64-musl":
+      optional: true
+    "@swc/core-linux-ppc64-gnu":
+      optional: true
+    "@swc/core-linux-s390x-gnu":
+      optional: true
+    "@swc/core-linux-x64-gnu":
+      optional: true
+    "@swc/core-linux-x64-musl":
+      optional: true
+    "@swc/core-win32-arm64-msvc":
+      optional: true
+    "@swc/core-win32-ia32-msvc":
+      optional: true
+    "@swc/core-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: 10c0/70cab177b55c69ba6fea493267a4f31fd28c5a078893810d26ed3a84238dc8e23b875697b9f6494efc34c76b8280f6935345a3d89ed2b4848a9efcc17e1f802f
+  languageName: node
+  linkType: hard
+
+"@swc/counter@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@swc/counter@npm:0.1.3"
+  checksum: 10c0/8424f60f6bf8694cfd2a9bca45845bce29f26105cda8cf19cdb9fd3e78dc6338699e4db77a89ae449260bafa1cc6bec307e81e7fb96dbf7dcfce0eea55151356
+  languageName: node
+  linkType: hard
+
 "@swc/helpers@npm:^0.5.11":
   version: 0.5.17
   resolution: "@swc/helpers@npm:0.5.17"
   dependencies:
     tslib: "npm:^2.8.0"
   checksum: 10c0/fe1f33ebb968558c5a0c595e54f2e479e4609bff844f9ca9a2d1ffd8dd8504c26f862a11b031f48f75c95b0381c2966c3dd156e25942f90089badd24341e7dbb
+  languageName: node
+  linkType: hard
+
+"@swc/html-darwin-arm64@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/html-darwin-arm64@npm:1.15.46"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/html-darwin-x64@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/html-darwin-x64@npm:1.15.46"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/html-linux-arm-gnueabihf@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/html-linux-arm-gnueabihf@npm:1.15.46"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@swc/html-linux-arm64-gnu@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/html-linux-arm64-gnu@npm:1.15.46"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/html-linux-arm64-musl@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/html-linux-arm64-musl@npm:1.15.46"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/html-linux-ppc64-gnu@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/html-linux-ppc64-gnu@npm:1.15.46"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/html-linux-s390x-gnu@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/html-linux-s390x-gnu@npm:1.15.46"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/html-linux-x64-gnu@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/html-linux-x64-gnu@npm:1.15.46"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/html-linux-x64-musl@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/html-linux-x64-musl@npm:1.15.46"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/html-win32-arm64-msvc@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/html-win32-arm64-msvc@npm:1.15.46"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/html-win32-ia32-msvc@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/html-win32-ia32-msvc@npm:1.15.46"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@swc/html-win32-x64-msvc@npm:1.15.46":
+  version: 1.15.46
+  resolution: "@swc/html-win32-x64-msvc@npm:1.15.46"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/html@npm:^1.15.40":
+  version: 1.15.46
+  resolution: "@swc/html@npm:1.15.46"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+    "@swc/html-darwin-arm64": "npm:1.15.46"
+    "@swc/html-darwin-x64": "npm:1.15.46"
+    "@swc/html-linux-arm-gnueabihf": "npm:1.15.46"
+    "@swc/html-linux-arm64-gnu": "npm:1.15.46"
+    "@swc/html-linux-arm64-musl": "npm:1.15.46"
+    "@swc/html-linux-ppc64-gnu": "npm:1.15.46"
+    "@swc/html-linux-s390x-gnu": "npm:1.15.46"
+    "@swc/html-linux-x64-gnu": "npm:1.15.46"
+    "@swc/html-linux-x64-musl": "npm:1.15.46"
+    "@swc/html-win32-arm64-msvc": "npm:1.15.46"
+    "@swc/html-win32-ia32-msvc": "npm:1.15.46"
+    "@swc/html-win32-x64-msvc": "npm:1.15.46"
+  dependenciesMeta:
+    "@swc/html-darwin-arm64":
+      optional: true
+    "@swc/html-darwin-x64":
+      optional: true
+    "@swc/html-linux-arm-gnueabihf":
+      optional: true
+    "@swc/html-linux-arm64-gnu":
+      optional: true
+    "@swc/html-linux-arm64-musl":
+      optional: true
+    "@swc/html-linux-ppc64-gnu":
+      optional: true
+    "@swc/html-linux-s390x-gnu":
+      optional: true
+    "@swc/html-linux-x64-gnu":
+      optional: true
+    "@swc/html-linux-x64-musl":
+      optional: true
+    "@swc/html-win32-arm64-msvc":
+      optional: true
+    "@swc/html-win32-ia32-msvc":
+      optional: true
+    "@swc/html-win32-x64-msvc":
+      optional: true
+  checksum: 10c0/ce10a58dcd464036ae82bf6dfebcaa6ac06485c819c9c0359b899a885c92339622f32fd67bfb048ce2d1a9aad0b976f0d0685fcc9cd8a3a2a8735d1f12a23837
+  languageName: node
+  linkType: hard
+
+"@swc/types@npm:^0.1.27":
+  version: 0.1.27
+  resolution: "@swc/types@npm:0.1.27"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+  checksum: 10c0/25f1bfa0ac34e9ac60aa7de91778f70906cd77a7abb3eb68c5da8d38d5202286b293300d4bb2792b3bb8840a7f5d5c4627c4ec34d2fae6533bfb3e14a70fd8fb
   languageName: node
   linkType: hard
 
@@ -6762,13 +7308,6 @@ __metadata:
   version: 7946.0.14
   resolution: "@types/geojson@npm:7946.0.14"
   checksum: 10c0/54f3997708fa2970c03eeb31f7e4540a0eb6387b15e9f8a60513a1409c23cafec8d618525404573468b59c6fecbfd053724b3327f7fca416729c26271d799f55
-  languageName: node
-  linkType: hard
-
-"@types/gtag.js@npm:^0.0.12":
-  version: 0.0.12
-  resolution: "@types/gtag.js@npm:0.0.12"
-  checksum: 10c0/fee8f4c6e627301b89ab616c9e219bd53fa6ea1ffd1d0a8021e21363f0bdb2cf7eb1a5bcda0c6f1502186379bc7784ec29c932e21634f4e07f9e7a8c56887400
   languageName: node
   linkType: hard
 
@@ -7921,10 +8460,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"address@npm:^1.0.1":
-  version: 1.2.2
-  resolution: "address@npm:1.2.2"
-  checksum: 10c0/1c8056b77fb124456997b78ed682ecc19d2fd7ea8bd5850a2aa8c3e3134c913847c57bcae418622efd32ba858fa1e242a40a251ac31da0515664fc0ac03a047d
+"address@npm:^2.0.1":
+  version: 2.0.3
+  resolution: "address@npm:2.0.3"
+  checksum: 10c0/e95c8d989812a9b1cef5e167328a1dd6fd2c41b02005793b7b4631d32dbf7de30bd17685d2f17fbfb94b67f3c422f9a0399caee3c1fbfa18c8e20dc0c8c77d3b
   languageName: node
   linkType: hard
 
@@ -8096,7 +8635,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^4.2.1, ansi-escapes@npm:^4.3.2":
+"ansi-escapes@npm:^4.2.1":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
@@ -8171,6 +8710,13 @@ __metadata:
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
   checksum: 10c0/5d1ec38c123984bcedd996eac680d548f31828bd679a66db2bdf11844634dde55fec3efa9c6bb1d89056a5e79c1ac540c4c784d592ea1d25028a92227d2f2d5c
+  languageName: node
+  linkType: hard
+
+"ansis@npm:^3.2.0":
+  version: 3.17.0
+  resolution: "ansis@npm:3.17.0"
+  checksum: 10c0/d8fa94ca7bb91e7e5f8a7d323756aa075facce07c5d02ca883673e128b2873d16f93e0dec782f98f1eeb1f2b3b4b7b60dcf0ad98fb442e75054fe857988cc5cb
   languageName: node
   linkType: hard
 
@@ -8717,6 +9263,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"baseline-browser-mapping@npm:^2.10.44":
+  version: 2.11.4
+  resolution: "baseline-browser-mapping@npm:2.11.4"
+  bin:
+    baseline-browser-mapping: dist/cli.cjs
+  checksum: 10c0/670e2817531db0485ef3065de01f468f833f6b070a358940aaf1b4b507534ff972f748da89d04a262723245f5e2b585e406504f97cd91334e98cc2cad0e8e763
+  languageName: node
+  linkType: hard
+
 "baseline-browser-mapping@npm:^2.9.0":
   version: 2.10.9
   resolution: "baseline-browser-mapping@npm:2.10.9"
@@ -8925,6 +9480,21 @@ __metadata:
   bin:
     browserslist: cli.js
   checksum: 10c0/db7ebc1733cf471e0b490b4f47e3e2ea2947ce417192c9246644e92c667dd56a71406cc58f62ca7587caf828364892e9952904a02b7aead752bc65b62a37cfe9
+  languageName: node
+  linkType: hard
+
+"browserslist@npm:^4.24.2":
+  version: 4.28.7
+  resolution: "browserslist@npm:4.28.7"
+  dependencies:
+    baseline-browser-mapping: "npm:^2.10.44"
+    caniuse-lite: "npm:^1.0.30001806"
+    electron-to-chromium: "npm:^1.5.393"
+    node-releases: "npm:^2.0.51"
+    update-browserslist-db: "npm:^1.2.3"
+  bin:
+    browserslist: cli.js
+  checksum: 10c0/dc41922a9ff0d81e5492498bdab2d932e3a3222f4277814ba38ee64f4e51f26e5244a7cce0777b4cac3ceff6eb196f5cadbb2a832620973a7f9c39611f6bc78e
   languageName: node
   linkType: hard
 
@@ -9207,6 +9777,13 @@ __metadata:
   version: 1.0.30001715
   resolution: "caniuse-lite@npm:1.0.30001715"
   checksum: 10c0/0109a7da797ffbe1aa197baa5242b205011098eecec1087ef3d0c58ceea19be325ab6679b2751a78660adc3051a9f77e99d5789938fd1eb1235e6fdf6a1dbf8e
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001806":
+  version: 1.0.30001806
+  resolution: "caniuse-lite@npm:1.0.30001806"
+  checksum: 10c0/9442c8afff0968e9b2ce0104a7340c1ce4a5c09f469ccb9eef10d25712ea0afe542486e5318c697c70dd502f988cfc04eaa1c9438c92ac3bcf4d708a2a17bee1
   languageName: node
   linkType: hard
 
@@ -10010,6 +10587,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"copy-text-to-clipboard@npm:^3.2.0":
+  version: 3.2.2
+  resolution: "copy-text-to-clipboard@npm:3.2.2"
+  checksum: 10c0/451796734a380f7da7b0af27c4d94e449719d3a2f2170e99c7e46eeee54cf3c4b4fdeabc185f6d6e8cbdf932e350831d05e8387c4bae8dcedb7fb961c600ddd4
+  languageName: node
+  linkType: hard
+
 "copy-webpack-plugin@npm:^11.0.0":
   version: 11.0.0
   resolution: "copy-webpack-plugin@npm:11.0.0"
@@ -10032,13 +10616,6 @@ __metadata:
   dependencies:
     browserslist: "npm:^4.28.1"
   checksum: 10c0/546e64b7ce45f724825bc13c1347f35c0459a6e71c0dcccff3ec21fbff463f5b0b97fc1220e6d90302153863489301793276fe2bf96f46001ff555ead4140308
-  languageName: node
-  linkType: hard
-
-"core-js-pure@npm:^3.48.0":
-  version: 3.49.0
-  resolution: "core-js-pure@npm:3.49.0"
-  checksum: 10c0/b4580a57b917d0bf1029356b1a60abf0f9b99562b67bf39c01485d58891f23603459ed71bde1d7f75c0a9a346829d8c281b255c525fb119726341364c513e82e
   languageName: node
   linkType: hard
 
@@ -10815,16 +11392,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-port@npm:^1.5.1":
-  version: 1.6.1
-  resolution: "detect-port@npm:1.6.1"
+"detect-port@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "detect-port@npm:2.1.0"
   dependencies:
-    address: "npm:^1.0.1"
-    debug: "npm:4"
+    address: "npm:^2.0.1"
   bin:
-    detect: bin/detect-port.js
-    detect-port: bin/detect-port.js
-  checksum: 10c0/4ea9eb46a637cb21220dd0a62b6074792894fc77b2cacbc9de533d1908b2eedafa7bfd7547baaa2ac1e9c7ba7c289b34b17db896dca6da142f4fc6e2060eee17
+    detect: dist/commonjs/bin/detect-port.js
+    detect-port: dist/commonjs/bin/detect-port.js
+  checksum: 10c0/06236ff1197ffea038d4a1c0ab60200ece1ac234eb00a507f93e986483c06989b9efd424cc2bbb8e9556c3984ce906e8a663799797e415626eefb26f040bd5d8
   languageName: node
   linkType: hard
 
@@ -11140,6 +11716,13 @@ __metadata:
   version: 1.5.321
   resolution: "electron-to-chromium@npm:1.5.321"
   checksum: 10c0/1272703857b8ac9868a75d495c141b71bad36adcb0df53393196da3819012fa2596ba48fccac750bdcb746a523d2a33543b36e9dc0ae727a55e7a6f00b2b155a
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.5.393":
+  version: 1.5.396
+  resolution: "electron-to-chromium@npm:1.5.396"
+  checksum: 10c0/2ac1d007acae6466649c2ada1f147fa205d980fc01bc602da00823b64a88b4286138a71c7b145f67dfa9103f69fd884bf706395a72886358d8f231a7011a39e5
   languageName: node
   linkType: hard
 
@@ -12135,7 +12718,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:5.1.1":
+"execa@npm:^5.1.1":
   version: 5.1.1
   resolution: "execa@npm:5.1.1"
   dependencies:
@@ -12360,7 +12943,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"figures@npm:3.2.0, figures@npm:^3.0.0, figures@npm:^3.2.0":
+"figures@npm:3.2.0, figures@npm:^3.0.0":
   version: 3.2.0
   resolution: "figures@npm:3.2.0"
   dependencies:
@@ -13226,18 +13809,6 @@ __metadata:
   version: 1.4.0
   resolution: "graphemer@npm:1.4.0"
   checksum: 10c0/e951259d8cd2e0d196c72ec711add7115d42eb9a8146c8eeda5b8d3ac91e5dd816b9cd68920726d9fd4490368e7ed86e9c423f40db87e2d8dfafa00fa17c3a31
-  languageName: node
-  linkType: hard
-
-"gray-matter@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "gray-matter@npm:4.0.3"
-  dependencies:
-    js-yaml: "npm:^3.13.1"
-    kind-of: "npm:^6.0.2"
-    section-matter: "npm:^1.0.0"
-    strip-bom-string: "npm:^1.0.0"
-  checksum: 10c0/e38489906dad4f162ca01e0dcbdbed96d1a53740cef446b9bf76d80bec66fa799af07776a18077aee642346c5e1365ed95e4c91854a12bf40ba0d4fb43a625a6
   languageName: node
   linkType: hard
 
@@ -15606,9 +16177,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-android-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-android-arm64@npm:1.33.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "lightningcss-darwin-arm64@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-darwin-arm64@npm:1.32.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-arm64@npm:1.33.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -15620,9 +16205,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-darwin-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-x64@npm:1.33.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "lightningcss-freebsd-x64@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-freebsd-x64@npm:1.32.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-freebsd-x64@npm:1.33.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -15634,9 +16233,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-arm-gnueabihf@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.33.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "lightningcss-linux-arm64-gnu@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-linux-arm64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.33.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -15648,9 +16261,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-arm64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.33.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "lightningcss-linux-x64-gnu@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-linux-x64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.33.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -15662,9 +16289,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-x64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.33.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "lightningcss-win32-arm64-msvc@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-win32-arm64-msvc@npm:1.32.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-arm64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.33.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -15673,6 +16314,56 @@ __metadata:
   version: 1.32.0
   resolution: "lightningcss-win32-x64-msvc@npm:1.32.0"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.33.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:^1.27.0":
+  version: 1.33.0
+  resolution: "lightningcss@npm:1.33.0"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.33.0"
+    lightningcss-darwin-arm64: "npm:1.33.0"
+    lightningcss-darwin-x64: "npm:1.33.0"
+    lightningcss-freebsd-x64: "npm:1.33.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.33.0"
+    lightningcss-linux-arm64-gnu: "npm:1.33.0"
+    lightningcss-linux-arm64-musl: "npm:1.33.0"
+    lightningcss-linux-x64-gnu: "npm:1.33.0"
+    lightningcss-linux-x64-musl: "npm:1.33.0"
+    lightningcss-win32-arm64-msvc: "npm:1.33.0"
+    lightningcss-win32-x64-msvc: "npm:1.33.0"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10c0/ce1f8279fbae636dbf37fa6e7385d5f98ed881d72af3362f24afbd4685e19c1fcdfecf17e5dd77f2ebee3d0c23ade276230d85842d07292229a2cffba8ff20a3
   languageName: node
   linkType: hard
 
@@ -17439,15 +18130,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-table@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "markdown-table@npm:2.0.0"
-  dependencies:
-    repeat-string: "npm:^1.0.0"
-  checksum: 10c0/f257e0781ea50eb946919df84bdee4ba61f983971b277a369ca7276f89740fd0e2749b9b187163a42df4c48682b71962d4007215ce3523480028f06c11ddc2e6
-  languageName: node
-  linkType: hard
-
 "markdown-table@npm:^3.0.0":
   version: 3.0.4
   resolution: "markdown-table@npm:3.0.4"
@@ -19020,6 +19702,13 @@ __metadata:
   version: 2.0.36
   resolution: "node-releases@npm:2.0.36"
   checksum: 10c0/85d8d7f4b6248c8372831cbcc3829ce634cb2b01dbd85e55705cefc8a9eda4ce8121bd218b9629cf2579aef8a360541bad409f3925a35675c825b9471a49d7e9
+  languageName: node
+  linkType: hard
+
+"node-releases@npm:^2.0.51":
+  version: 2.0.51
+  resolution: "node-releases@npm:2.0.51"
+  checksum: 10c0/6cf3fe1f9eabe02ce6de67e9db77b73edc9f5625003791e1f8f239f8e2a851450a5aeb1eff2cc43cfb26312e19b26bfe07626bf428479e6a76f56553fc6148da
   languageName: node
   linkType: hard
 
@@ -21579,15 +22268,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-loadable-ssr-addon-v5-slorber@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "react-loadable-ssr-addon-v5-slorber@npm:1.0.1"
+"react-loadable-ssr-addon-v5-slorber@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "react-loadable-ssr-addon-v5-slorber@npm:1.0.3"
   dependencies:
     "@babel/runtime": "npm:^7.10.3"
   peerDependencies:
     react-loadable: "*"
     webpack: ">=4.41.1 || 5.x"
-  checksum: 10c0/7b0645f66adec56646f985ba8094c66a1c0a4627d96ad80eea32431d773ef1f79aa47d3247a8f21db3b064a0c6091653c5b5d3483b7046722eb64e55bffe635c
+  checksum: 10c0/6f7af924ad0187c41925dda948587452e30b6d5306465468795daa0382524406e6421dcf5be100a4d285dcb0acc916fcce511a35865eb53ab2d7306ecb525f32
   languageName: node
   linkType: hard
 
@@ -22170,7 +22859,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"repeat-string@npm:^1.0.0, repeat-string@npm:^1.5.2":
+"repeat-string@npm:^1.5.2":
   version: 1.6.1
   resolution: "repeat-string@npm:1.6.1"
   checksum: 10c0/87fa21bfdb2fbdedc44b9a5b118b7c1239bdd2c2c1e42742ef9119b7d412a5137a1d23f1a83dc6bb686f4f27429ac6f542e3d923090b44181bafa41e8ac0174d
@@ -22912,7 +23601,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-handler@npm:^6.1.6":
+"serve-handler@npm:^6.1.7":
   version: 6.1.7
   resolution: "serve-handler@npm:6.1.7"
   dependencies:
@@ -23914,6 +24603,18 @@ __metadata:
   bin:
     svgo: ./bin/svgo
   checksum: 10c0/06568c6b0430f96748c557f0b17dc7de79b19fa16d13d7523527ede0ec727fc6d8e6a10e13ff106dc4372d2e6063a1dca7c455c495efb1b83857480425f9b965
+  languageName: node
+  linkType: hard
+
+"swc-loader@npm:^0.2.6":
+  version: 0.2.7
+  resolution: "swc-loader@npm:0.2.7"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+  peerDependencies:
+    "@swc/core": ^1.2.147
+    webpack: ">=2"
+  checksum: 10c0/9c1b275adf9b83d7245e0e30a1dd41b0f6dbb0164267f772f855adc325a615c30a9d343e7362b585834350e2d9632ecd2239e03fa8f15a2d2e699a99e438d363
   languageName: node
   linkType: hard
 
@@ -25040,7 +25741,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.2.0":
+"update-browserslist-db@npm:^1.2.0, update-browserslist-db@npm:^1.2.3":
   version: 1.2.3
   resolution: "update-browserslist-db@npm:1.2.3"
   dependencies:
@@ -25682,21 +26383,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpackbar@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "webpackbar@npm:6.0.1"
+"webpackbar@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "webpackbar@npm:7.0.0"
   dependencies:
-    ansi-escapes: "npm:^4.3.2"
-    chalk: "npm:^4.1.2"
+    ansis: "npm:^3.2.0"
     consola: "npm:^3.2.3"
-    figures: "npm:^3.2.0"
-    markdown-table: "npm:^2.0.0"
     pretty-time: "npm:^1.1.0"
     std-env: "npm:^3.7.0"
-    wrap-ansi: "npm:^7.0.0"
   peerDependencies:
+    "@rspack/core": "*"
     webpack: 3 || 4 || 5
-  checksum: 10c0/8dfa2c55f8122f729c7efd515a2b50fb752c0d0cb27ec2ecdbc70d90a86d5f69f466c9c5d01004f71b500dafba957ecd4413fca196a98cf99a39b705f98cae97
+  peerDependenciesMeta:
+    "@rspack/core":
+      optional: true
+    webpack:
+      optional: true
+  checksum: 10c0/03ed85edca12af824319dfcd0fe5c3a90b9e3c86400a604a55589abe0a66a682033e7de027e89aae03652b6fb8ca7fd2831d86829179304ea3121f807808f7c6
   languageName: node
   linkType: hard
 
@@ -25706,8 +26409,9 @@ __metadata:
   dependencies:
     "@algolia/autocomplete-js": "npm:^1.19.2"
     "@cmfcmf/docusaurus-search-local": "npm:^2.0.0"
-    "@docusaurus/core": "npm:^3.9.2"
-    "@docusaurus/tsconfig": "npm:^3.9.2"
+    "@docusaurus/core": "npm:^3.10.2"
+    "@docusaurus/faster": "npm:^3.10.2"
+    "@docusaurus/tsconfig": "npm:^3.10.2"
     "@probe.gl/stats": "npm:^4.1.1"
     "@probe.gl/stats-widget": "npm:^4.1.1"
     "@signalwire/docusaurus-plugin-llms-txt": "npm:^1.2.2"


### PR DESCRIPTION
## Goals

- Upgrade the website to the latest stable Docusaurus release and prepare it for Docusaurus v4.
- Reduce website build time and output size.
- Make GitHub Actions website build/deployment timing visible per stage.

## Changes

- Upgrade Docusaurus packages to 3.10.2, add `@docusaurus/faster`, enable all five v4 future flags and all nine Faster options, and remove the obsolete Babel configuration.
- Extract shared example dependencies into one reusable client chunk, disable the unused blog, and deduplicate the outdated Docusaurus 2-only local-search dependency.
- Synchronize example assets incrementally, remove stale generated assets, and skip the standalone ANARI playground assets that are not embedded in the website.
- Migrate legacy MDX comments/admonitions to v4-compatible syntax, correct invalid generated paragraph markup, fix the MDX checker source directory, and exclude generated output from website TypeScript scanning.
- Split both GitHub Actions website jobs into separately timed dependency installation, asset synchronization, Docusaurus compilation, LLM-output normalization, LLM-output validation, and deployment stages; retain the existing 6 GB Node heap limit and deployment base URL.

## Measured impact

| Metric | Before | After |
| --- | ---: | ---: |
| Website build | ~81 seconds | ~20–35 seconds |
| JavaScript output | 315 MB | 13.5 MB |
| Complete website | 400 MB | 81 MB |
| Example assets | 42 MB | 11 MB |

## Verification

- `yarn install --immutable` in a clean worktree based on current `master`.
- `yarn lint fix`.
- Repository pre-commit `yarn test-fast`: lint passed; **332 Node tests passed, 2 skipped**.
- `yarn workspace website-docusaurus check`.
- Production and `/luma.gl/` staging website builds, including generated `llms.txt` and Markdown validation.
- Individual GitHub Actions build commands and workflow YAML/stage-order assertions.
- Incremental example-asset create, unchanged, update, and removal behavior.

## Notes

- Rspack currently emits nonfatal circular-chunk warnings.
- Existing website TypeScript errors outside this change remain; generated build directories are no longer included in that check.
- A previously published but unreferenced ~14 MB Mandelbrot GIF remains untouched to avoid breaking external URLs.