### PR TITLE
feat(webgl): make WebGL1 compatibility optional

### DIFF
--- a/docs/api-reference/core/luma.md
+++ b/docs/api-reference/core/luma.md
@@ -173,6 +173,12 @@ so that device types do not have to be provided at `Device` create or attach tim
 
 ### `luma.enforceWebGL2()`
 
+Preload the optional WebGL1 compatibility entry before using this legacy facade:
+
+```ts
+import '@luma.gl/webgl/webgl1';
+```
+
 ```ts
 luma.enforceWebGL2(enforce: boolean = true, adapters: Adapter[]);
 ```
@@ -184,7 +190,9 @@ Since luma.gl only supports WebGL2 contexts (`WebGL2RenderingContext`), it is no
 This becomes a problem when using luma.gl with a WebGL library that always creates WebGL1 contexts (such as Mapbox GL JS v1).
 Calling `luma.enforceWebGL2()` before initializing the external library makes that library create a WebGL2 context, that luma.gl can then attach a Device to.
 
-Note that the `webgl2Adapter` must either be pre-registered or supplied to the `luma.enforceWebGL2()` call.
+Note that the `webgl2Adapter` must either be pre-registered or supplied to the
+`luma.enforceWebGL2()` call. Applications that do not need the `luma` facade can instead import and
+call `enforceWebGL2()` directly from `@luma.gl/webgl/webgl1`.
 
 :::caution
 Since WebGL2 is a essentially a superset of WebGL1, a library written for WebGL 1 will often still work with a WebGL 2 context. However there may be issues if the external library relies on WebGL1 extensions that are not available in WebGL2. To make a WebGL 2 context support WebGL1-only extensions, those extensions would also need to be emulated on top of the WebGL 2 API, and this is not currently done.

--- a/docs/developer-guide/debugging.md
+++ b/docs/developer-guide/debugging.md
@@ -129,7 +129,13 @@ luma.gl is pre-integrated with the Khronos group's WebGL developer tools (the [W
 
 The most flexible way to enable WebGL API tracing is by typing the following command into the browser developer tools console:
 
-Note that the developer tools module is loaded dynamically when a device is created with the debug flag set, so the developer tools can be activated in production code by opening the browser console and typing:
+Applications that want browser-console activation must include the optional debug registration entry:
+
+```ts
+import '@luma.gl/webgl/debug';
+```
+
+The developer tools script is then loaded dynamically when a device is created with the debug flag set, so the tools can be activated by opening the browser console and typing:
 
 ```ts
 luma.set('debug-webgl', true)
@@ -137,11 +143,13 @@ luma.set('debug-webgl', true)
 
 then reload your browser tab.
 
-While usually not recommended, it is also possible to activate the developer tools manually. Call [`luma.createDevice`](/docs/api-reference/core/luma#lumacreatedevice) with `debugWebGL: true` to create a WebGL context instrumented with the WebGL developer tools:
+While usually not recommended, it is also possible to activate the developer tools directly. Import the optional registration entry, then call [`luma.createDevice`](/docs/api-reference/core/luma#lumacreatedevice) with `debugWebGL: true`:
 
 ```ts
 import {luma} from '@luma.gl/core';
-const device = luma.createDevice({type: 'webgl', {debugWebGL: true});
+import '@luma.gl/webgl/debug';
+
+const device = await luma.createDevice({type: 'webgl', debugWebGL: true});
 ```
 
 > Warning: WebGL debug contexts impose a significant performance penalty (luma waits for the GPU after each WebGL call to check error codes) and should not be activated in production code.
@@ -159,7 +167,7 @@ luma.log.set('debug-spectorjs', true);
 And then restarting the application (e.g. via Command-R on MacOS),
 
 
-You can also enable spector when creating a device  by adding the `debugSpectorJS: true` option.
+You can also enable Spector when creating a device by importing `@luma.gl/webgl/debug` and adding the `debugSpectorJS: true` option.
 
 To display Spector.js stats when loaded.
 
@@ -168,5 +176,5 @@ luma.spector.displayUI()
 ```
 
 :::info
-Spector.js is dynamically loaded into your application, so there is no bundle size penalty.
+Spector.js itself is loaded from a CDN. The optional `@luma.gl/webgl/debug` registration entry keeps the integration code out of normal WebGL application bundles.
 :::

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -54,6 +54,10 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 - `Model.predraw(commandEncoder)` now requires an explicit command encoder. Call it with the encoder that will be submitted when ordered pre-draw uploads must be shared across multiple draws or viewports. Normal `Model.draw(renderPass)` calls continue to perform their own pre-draw work.
 - `makeGPUGeometry()` now interleaves CPU geometry attributes into a single vertex buffer by default. Callers that require separate attribute buffers should create those buffers and construct `GPUGeometry` explicitly with the corresponding `bufferLayout`.
 
+**@luma.gl/webgl**
+
+- WebGLDeveloperTools and Spector integration now require `import '@luma.gl/webgl/debug'` before enabling `debugWebGL` or `debugSpectorJS`. This keeps debug-only code and the full GL enum out of normal adapter application bundles.
+
 **@luma.gl/arrow**
 
 - Arrow 2D text clip rectangles now require `FixedSizeList<Float32>[4]` columns, and GPU-backed

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -57,6 +57,8 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 **@luma.gl/webgl**
 
 - WebGLDeveloperTools and Spector integration now require `import '@luma.gl/webgl/debug'` before enabling `debugWebGL` or `debugSpectorJS`. This keeps debug-only code and the full GL enum out of normal adapter application bundles.
+- Legacy WebGL1 context enforcement now requires `import '@luma.gl/webgl/webgl1'` before calling
+  `luma.enforceWebGL2()`. Applications can also call the subpath's `enforceWebGL2()` export directly.
 
 **@luma.gl/arrow**
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -114,6 +114,10 @@ Target Release Date: TBD
 - **HTML-in-Canvas feature detection** - `device.features.has('html-in-canvas')` and `isHTMLInCanvasSupported()` report whether the active browser and backend expose the experimental DOM-to-texture rasterization path. The high-level `HTMLTexture` wrapper remains deferred with `@luma.gl/experimental` until v10.
 - **GPU data and buffer-layout utilities** - New exported helpers decode GPU data types, select native or emulated Float16 arrays, and resolve logical attributes over shared or composite buffer layouts.
 
+**@luma.gl/webgl**
+
+- **Optional WebGL debugging** - WebGLDeveloperTools and Spector integration are registered through `@luma.gl/webgl/debug`, keeping debug-only code out of normal adapter application bundles.
+
 **@luma.gl/engine**
 
 - **[`DynamicBuffer`](/docs/api-reference/engine/dynamic-buffer)** - New engine-level wrapper for resizable buffers. `Model` supports dynamic buffers for attributes, index buffers, and shader bindings, and `Material` supports dynamic buffer bindings with cache invalidation when the backing buffer changes.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -9,6 +9,7 @@ Target Release Date: Q3, 2026
 **General**
 
 - **TypeScript 6.0** - luma.gl package builds, website tooling, and supported example typechecks now use TypeScript 6.0.
+- **Optional WebGL1 compatibility** - Legacy WebGL1 context enforcement and extension emulation are available through `@luma.gl/webgl/webgl1` and no longer increase the normal WebGL2 adapter bundle.
 - **Precise raw binary64 coordinate deltas** - The WGSL `fp64arithmetic` module can split a binary64-rounded subtraction into normalized double-single limbs, normalize and compare those limbs with integer-controlled behavior in either arithmetic mode, and explicitly classify non-finite values. The existing direct-to-`f32` helper retains its single-round exact-delta contract.
 
 **AI-Assisted Development**

--- a/modules/core/test/adapter/luma.spec.ts
+++ b/modules/core/test/adapter/luma.spec.ts
@@ -61,6 +61,8 @@ interface TestHTMLCanvasElement {
 }
 
 test('luma#enforceWebGL2', async t => {
+  await import('@luma.gl/webgl/webgl1');
+
   const prototype = HTMLCanvasElement.prototype as unknown as TestHTMLCanvasElement;
 
   // Setup mock getContext

--- a/modules/webgl/package.json
+++ b/modules/webgl/package.json
@@ -31,6 +31,11 @@
       "import": "./dist/debug.js",
       "require": "./dist/debug.cjs"
     },
+    "./webgl1": {
+      "types": "./dist/webgl1.d.ts",
+      "import": "./dist/webgl1.js",
+      "require": "./dist/webgl1.cjs"
+    },
     "./constants": {
       "types": "./dist/constants/index.d.ts",
       "import": "./dist/constants/index.js",
@@ -53,7 +58,20 @@
     "dist.min.js",
     "README.md"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/debug.ts",
+    "./src/webgl1.ts",
+    "./src/context/debug/spector.ts",
+    "./src/context/debug/webgl-developer-tools.ts",
+    "./src/context/polyfills/polyfill-webgl1-extensions.ts",
+    "./dist/debug.js",
+    "./dist/debug.cjs",
+    "./dist/context/debug/spector.js",
+    "./dist/context/debug/webgl-developer-tools.js",
+    "./dist/context/polyfills/polyfill-webgl1-extensions.js",
+    "./dist/webgl1.js",
+    "./dist/webgl1.cjs"
+  ],
   "scripts": {
     "build-minified-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.min.js",
     "build-dev-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.dev.js --env=dev",

--- a/modules/webgl/package.json
+++ b/modules/webgl/package.json
@@ -26,6 +26,11 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
+    "./debug": {
+      "types": "./dist/debug.d.ts",
+      "import": "./dist/debug.js",
+      "require": "./dist/debug.cjs"
+    },
     "./constants": {
       "types": "./dist/constants/index.d.ts",
       "import": "./dist/constants/index.js",

--- a/modules/webgl/src/adapter/resources/webgl-vertex-array.ts
+++ b/modules/webgl/src/adapter/resources/webgl-vertex-array.ts
@@ -6,7 +6,6 @@ import type {TypedArray, NumericArray} from '@math.gl/types';
 import type {AttributeInfo, Device, Buffer, VertexArrayProps} from '@luma.gl/core';
 import {VertexArray, getAttributeInfosFromLayouts, getScratchArray} from '@luma.gl/core';
 import {GL} from '@luma.gl/webgl/constants';
-import {getBrowser} from '@probe.gl/env';
 
 import {WebGLDevice} from '../webgl-device';
 import {WEBGLBuffer} from '../resources/webgl-buffer';
@@ -35,7 +34,7 @@ export class WEBGLVertexArray extends VertexArray {
    * @returns `true` when constant attribute 0 is supported on the current browser.
    */
   static isConstantAttributeZeroSupported(device: Device): boolean {
-    return getBrowser() === 'Chrome';
+    return isChromiumBrowser();
   }
 
   /**
@@ -287,6 +286,12 @@ function normalizeConstantArrayValue(arrayValue: NumericArray) {
     return new Float32Array(arrayValue);
   }
   return arrayValue;
+}
+
+function isChromiumBrowser(): boolean {
+  const chrome = (globalThis as typeof globalThis & {chrome?: unknown}).chrome;
+  const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+  return Boolean(chrome) && !userAgent.includes('Electron');
 }
 
 /**

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -4,7 +4,7 @@
 
 import type {WebGLDevice} from './webgl-device';
 import {Adapter, Device, DeviceProps, log} from '@luma.gl/core';
-import {enforceWebGL2} from '../context/polyfills/polyfill-webgl1-extensions';
+import {enforceRegisteredWebGL2} from '../context/polyfills/webgl1-compatibility-hooks';
 import {
   loadRegisteredSpectorJS,
   loadRegisteredWebGLDeveloperTools
@@ -18,7 +18,7 @@ export class WebGLAdapter extends Adapter {
 
   /** Force any created WebGL contexts to be WebGL2 contexts, polyfilled with WebGL1 extensions */
   enforceWebGL2(enable: boolean): void {
-    enforceWebGL2(enable);
+    enforceRegisteredWebGL2(enable);
   }
 
   /** Check if WebGL 2 is available */

--- a/modules/webgl/src/adapter/webgl-adapter.ts
+++ b/modules/webgl/src/adapter/webgl-adapter.ts
@@ -5,20 +5,16 @@
 import type {WebGLDevice} from './webgl-device';
 import {Adapter, Device, DeviceProps, log} from '@luma.gl/core';
 import {enforceWebGL2} from '../context/polyfills/polyfill-webgl1-extensions';
-import {loadSpectorJS, DEFAULT_SPECTOR_PROPS} from '../context/debug/spector';
-import {loadWebGLDeveloperTools} from '../context/debug/webgl-developer-tools';
+import {
+  loadRegisteredSpectorJS,
+  loadRegisteredWebGLDeveloperTools
+} from '../context/debug/debug-hooks';
 
 const LOG_LEVEL = 1;
 
 export class WebGLAdapter extends Adapter {
   /** type of device's created by this adapter */
   readonly type: Device['type'] = 'webgl';
-
-  constructor() {
-    super();
-    // Add spector default props to device default props, so that runtime settings are observed
-    Device.defaultProps = {...Device.defaultProps, ...DEFAULT_SPECTOR_PROPS};
-  }
 
   /** Force any created WebGL contexts to be WebGL2 contexts, polyfilled with WebGL1 extensions */
   enforceWebGL2(enable: boolean): void {
@@ -63,6 +59,9 @@ export class WebGLAdapter extends Adapter {
       throw new Error('Invalid WebGL2RenderingContext');
     }
 
+    props = resolveWebGLDebugProps(props);
+    await loadWebGLDebugTools(props);
+
     const createCanvasContext = props.createCanvasContext === true ? {} : props.createCanvasContext;
 
     // We create a new device using the provided WebGL context and its canvas
@@ -76,26 +75,8 @@ export class WebGLAdapter extends Adapter {
 
   async create(props: DeviceProps = {}): Promise<WebGLDevice> {
     const {WebGLDevice} = await import('./webgl-device');
-
-    const promises: Promise<unknown>[] = [];
-
-    // Load webgl and spector debug scripts from CDN if requested
-    if (props.debugWebGL || props.debug) {
-      promises.push(loadWebGLDeveloperTools());
-    }
-
-    if (props.debugSpectorJS) {
-      promises.push(loadSpectorJS(props));
-    }
-
-    // Wait for all the loads to settle before creating the context.
-    // The Device.create() functions are async, so in contrast to the constructor, we can `await` here.
-    const results = await Promise.allSettled(promises);
-    for (const result of results) {
-      if (result.status === 'rejected') {
-        log.error(`Failed to initialize debug libraries ${result.reason}`)();
-      }
-    }
+    props = resolveWebGLDebugProps(props);
+    await loadWebGLDebugTools(props);
 
     try {
       const device = new WebGLDevice(props);
@@ -128,3 +109,29 @@ function isWebGL(gl: any): gl is WebGL2RenderingContext {
 }
 
 export const webgl2Adapter = new WebGLAdapter();
+
+function resolveWebGLDebugProps(props: DeviceProps): DeviceProps {
+  return {
+    ...props,
+    debug: props.debug ?? Device.defaultProps.debug,
+    debugWebGL: props.debugWebGL ?? Device.defaultProps.debugWebGL,
+    debugSpectorJS: props.debugSpectorJS ?? Boolean(log.get('debug-spectorjs'))
+  };
+}
+
+async function loadWebGLDebugTools(props: DeviceProps): Promise<void> {
+  const promises: Promise<void>[] = [];
+  if (props.debugWebGL || props.debug) {
+    promises.push(loadRegisteredWebGLDeveloperTools());
+  }
+  if (props.debugSpectorJS) {
+    promises.push(loadRegisteredSpectorJS(props));
+  }
+
+  const results = await Promise.allSettled(promises);
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      log.error(`Failed to initialize debug libraries ${result.reason}`)();
+    }
+  }
+}

--- a/modules/webgl/src/adapter/webgl-device.ts
+++ b/modules/webgl/src/adapter/webgl-device.ts
@@ -46,8 +46,10 @@ import {WebGLDeviceLimits} from './device-helpers/webgl-device-limits';
 import {WebGLCanvasContext} from './webgl-canvas-context';
 import {WebGLPresentationContext} from './webgl-presentation-context';
 import type {Spector} from '../context/debug/spector-types';
-import {initializeSpectorJS} from '../context/debug/spector';
-import {makeDebugContext} from '../context/debug/webgl-developer-tools';
+import {
+  initializeRegisteredSpectorJS,
+  makeRegisteredDebugContext
+} from '../context/debug/debug-hooks';
 import {getTextureFormatCapabilitiesWebGL} from './converters/webgl-texture-table';
 import {uid} from '../utils/uid';
 
@@ -229,7 +231,7 @@ export class WebGLDevice extends Device {
     // Add spector debug instrumentation to context
     // We need to trust spector integration to decide if spector should be initialized
     // We also run spector instrumentation first, otherwise spector can clobber luma instrumentation.
-    this.spectorJS = initializeSpectorJS({...this.props, gl: this.handle});
+    this.spectorJS = initializeRegisteredSpectorJS({...this.props, gl: this.handle});
 
     // Instrument context
     const contextData = getWebGLContextData(this.handle);
@@ -257,7 +259,10 @@ export class WebGLDevice extends Device {
     // props.debug - instrument the WebGL context with Khronos debug tools
     // props.debugWebGL - activate WebGL context tracing, force log level to at least 1
     if (props.debug || props.debugWebGL) {
-      this.gl = makeDebugContext(this.gl, {debugWebGL: true, traceWebGL: props.debugWebGL});
+      this.gl = makeRegisteredDebugContext(this.gl, {
+        debugWebGL: true,
+        traceWebGL: props.debugWebGL
+      });
       log.warn('WebGL debug mode activated. Performance reduced.')();
     }
     if (props.debugWebGL) {

--- a/modules/webgl/src/context/debug/debug-hooks.ts
+++ b/modules/webgl/src/context/debug/debug-hooks.ts
@@ -25,19 +25,24 @@ type SpectorHooks = {
   initialize(props: SpectorProps): Spector | null;
 };
 
-let webglDeveloperToolsHooks: WebGLDeveloperToolsHooks | null = null;
-let spectorHooks: SpectorHooks | null = null;
-let debugImportWarningShown = false;
+type WebGLDebugHooksRegistry = {
+  webglDeveloperToolsHooks: WebGLDeveloperToolsHooks | null;
+  spectorHooks: SpectorHooks | null;
+  debugImportWarningShown: boolean;
+};
+
+const WEBGL_DEBUG_HOOKS_SYMBOL = Symbol.for('@luma.gl/webgl/debug-hooks');
 
 export function registerWebGLDeveloperTools(hooks: WebGLDeveloperToolsHooks): void {
-  webglDeveloperToolsHooks = hooks;
+  getWebGLDebugHooksRegistry().webglDeveloperToolsHooks = hooks;
 }
 
 export function registerSpectorJS(hooks: SpectorHooks): void {
-  spectorHooks = hooks;
+  getWebGLDebugHooksRegistry().spectorHooks = hooks;
 }
 
 export async function loadRegisteredWebGLDeveloperTools(): Promise<void> {
+  const {webglDeveloperToolsHooks} = getWebGLDebugHooksRegistry();
   if (!webglDeveloperToolsHooks) {
     warnDebugImportRequired();
     return;
@@ -49,6 +54,7 @@ export function makeRegisteredDebugContext(
   gl: WebGL2RenderingContext,
   props: DebugContextProps
 ): WebGL2RenderingContext {
+  const {webglDeveloperToolsHooks} = getWebGLDebugHooksRegistry();
   if (!webglDeveloperToolsHooks) {
     warnDebugImportRequired();
     return gl;
@@ -57,6 +63,7 @@ export function makeRegisteredDebugContext(
 }
 
 export async function loadRegisteredSpectorJS(props: SpectorProps): Promise<void> {
+  const {spectorHooks} = getWebGLDebugHooksRegistry();
   if (!spectorHooks) {
     warnDebugImportRequired();
     return;
@@ -65,12 +72,27 @@ export async function loadRegisteredSpectorJS(props: SpectorProps): Promise<void
 }
 
 export function initializeRegisteredSpectorJS(props: SpectorProps): Spector | null {
+  const {spectorHooks} = getWebGLDebugHooksRegistry();
   return spectorHooks?.initialize(props) || null;
 }
 
 function warnDebugImportRequired(): void {
-  if (!debugImportWarningShown) {
-    debugImportWarningShown = true;
+  const registry = getWebGLDebugHooksRegistry();
+  if (!registry.debugImportWarningShown) {
+    registry.debugImportWarningShown = true;
     log.warn('Import @luma.gl/webgl/debug before enabling WebGL debugging.')();
   }
+}
+
+function getWebGLDebugHooksRegistry(): WebGLDebugHooksRegistry {
+  const globalRegistry = globalThis as unknown as Record<
+    symbol,
+    WebGLDebugHooksRegistry | undefined
+  >;
+  globalRegistry[WEBGL_DEBUG_HOOKS_SYMBOL] ||= {
+    webglDeveloperToolsHooks: null,
+    spectorHooks: null,
+    debugImportWarningShown: false
+  };
+  return globalRegistry[WEBGL_DEBUG_HOOKS_SYMBOL];
 }

--- a/modules/webgl/src/context/debug/debug-hooks.ts
+++ b/modules/webgl/src/context/debug/debug-hooks.ts
@@ -1,0 +1,76 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {DeviceProps} from '@luma.gl/core';
+import {log} from '@luma.gl/core';
+import type {Spector} from './spector-types';
+
+type DebugContextProps = {
+  debugWebGL?: boolean;
+  traceWebGL?: boolean;
+};
+
+type SpectorProps = Pick<DeviceProps, 'debugSpectorJS' | 'debugSpectorJSUrl'> & {
+  gl?: WebGL2RenderingContext;
+};
+
+type WebGLDeveloperToolsHooks = {
+  load(): Promise<void>;
+  makeDebugContext(gl: WebGL2RenderingContext, props?: DebugContextProps): WebGL2RenderingContext;
+};
+
+type SpectorHooks = {
+  load(props: SpectorProps): Promise<void>;
+  initialize(props: SpectorProps): Spector | null;
+};
+
+let webglDeveloperToolsHooks: WebGLDeveloperToolsHooks | null = null;
+let spectorHooks: SpectorHooks | null = null;
+let debugImportWarningShown = false;
+
+export function registerWebGLDeveloperTools(hooks: WebGLDeveloperToolsHooks): void {
+  webglDeveloperToolsHooks = hooks;
+}
+
+export function registerSpectorJS(hooks: SpectorHooks): void {
+  spectorHooks = hooks;
+}
+
+export async function loadRegisteredWebGLDeveloperTools(): Promise<void> {
+  if (!webglDeveloperToolsHooks) {
+    warnDebugImportRequired();
+    return;
+  }
+  await webglDeveloperToolsHooks.load();
+}
+
+export function makeRegisteredDebugContext(
+  gl: WebGL2RenderingContext,
+  props: DebugContextProps
+): WebGL2RenderingContext {
+  if (!webglDeveloperToolsHooks) {
+    warnDebugImportRequired();
+    return gl;
+  }
+  return webglDeveloperToolsHooks.makeDebugContext(gl, props);
+}
+
+export async function loadRegisteredSpectorJS(props: SpectorProps): Promise<void> {
+  if (!spectorHooks) {
+    warnDebugImportRequired();
+    return;
+  }
+  await spectorHooks.load(props);
+}
+
+export function initializeRegisteredSpectorJS(props: SpectorProps): Spector | null {
+  return spectorHooks?.initialize(props) || null;
+}
+
+function warnDebugImportRequired(): void {
+  if (!debugImportWarningShown) {
+    debugImportWarningShown = true;
+    log.warn('Import @luma.gl/webgl/debug before enabling WebGL debugging.')();
+  }
+}

--- a/modules/webgl/src/context/debug/spector.ts
+++ b/modules/webgl/src/context/debug/spector.ts
@@ -7,6 +7,7 @@ import {loadScript} from '../../utils/load-script';
 import {getWebGLContextData} from '../helpers/webgl-context-data';
 
 import type {Spector} from './spector-types';
+import {registerSpectorJS} from './debug-hooks';
 
 /** Spector debug initialization options */
 type SpectorProps = {
@@ -106,3 +107,5 @@ export function initializeSpectorJS(props: SpectorProps): Spector | null {
 
   return spector;
 }
+
+registerSpectorJS({load: loadSpectorJS, initialize: initializeSpectorJS});

--- a/modules/webgl/src/context/debug/webgl-developer-tools.ts
+++ b/modules/webgl/src/context/debug/webgl-developer-tools.ts
@@ -4,9 +4,10 @@
 
 import {log} from '@luma.gl/core';
 // Rename constant to prevent inlining. We need the full set of constants for generating debug strings.
-import {GL as GLEnum} from '@luma.gl/webgl/constants';
+import {GL as GLEnum} from '../../constants/webgl-constants';
 import {isBrowser} from '@probe.gl/env';
 import {loadScript} from '../../utils/load-script';
+import {registerWebGLDeveloperTools} from './debug-hooks';
 
 const WEBGL_DEBUG_CDN_URL = 'https://unpkg.com/webgl-debug@2.0.1/index.js';
 
@@ -170,3 +171,5 @@ function onValidateGLFunc(
     }
   }
 }
+
+registerWebGLDeveloperTools({load: loadWebGLDeveloperTools, makeDebugContext});

--- a/modules/webgl/src/context/polyfills/polyfill-webgl1-extensions.ts
+++ b/modules/webgl/src/context/polyfills/polyfill-webgl1-extensions.ts
@@ -8,6 +8,7 @@
 /* eslint-disable camelcase */
 
 import {GL} from '@luma.gl/webgl/constants';
+import {registerWebGL1Compatibility} from './webgl1-compatibility-hooks';
 
 // webgl1 extensions natively supported by webgl2
 const WEBGL1_STATIC_EXTENSIONS = {
@@ -106,6 +107,8 @@ export function enforceWebGL2(enforce: boolean = true): void {
     return this.originalGetContext(contextId, options);
   };
 }
+
+registerWebGL1Compatibility({enforceWebGL2});
 
 /** Install WebGL1-only extensions on WebGL2 contexts */
 export function polyfillWebGL1Extensions(gl: WebGL2RenderingContext): void {

--- a/modules/webgl/src/context/polyfills/webgl1-compatibility-hooks.ts
+++ b/modules/webgl/src/context/polyfills/webgl1-compatibility-hooks.ts
@@ -1,0 +1,26 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+type WebGL1CompatibilityHooks = {
+  enforceWebGL2(enable?: boolean): void;
+};
+
+const WEBGL1_COMPATIBILITY_HOOKS_SYMBOL = Symbol.for('@luma.gl/webgl/webgl1-compatibility-hooks');
+
+export function registerWebGL1Compatibility(hooks: WebGL1CompatibilityHooks): void {
+  getGlobalHooksRegistry()[WEBGL1_COMPATIBILITY_HOOKS_SYMBOL] = hooks;
+}
+
+export function enforceRegisteredWebGL2(enable: boolean): void {
+  const webgl1CompatibilityHooks = getGlobalHooksRegistry()[WEBGL1_COMPATIBILITY_HOOKS_SYMBOL];
+  if (!webgl1CompatibilityHooks) {
+    // Preload @luma.gl/webgl/webgl1 before using the legacy luma.enforceWebGL2() facade.
+    throw new Error('WebGL1 compatibility not registered');
+  }
+  webgl1CompatibilityHooks.enforceWebGL2(enable);
+}
+
+function getGlobalHooksRegistry(): Record<symbol, WebGL1CompatibilityHooks | undefined> {
+  return globalThis as unknown as Record<symbol, WebGL1CompatibilityHooks | undefined>;
+}

--- a/modules/webgl/src/debug.ts
+++ b/modules/webgl/src/debug.ts
@@ -1,0 +1,9 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {
+  loadWebGLDeveloperTools,
+  makeDebugContext
+} from './context/debug/webgl-developer-tools';
+export {loadSpectorJS, initializeSpectorJS} from './context/debug/spector';

--- a/modules/webgl/src/webgl1.ts
+++ b/modules/webgl/src/webgl1.ts
@@ -1,0 +1,10 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Explicit entry point for legacy WebGL1 compatibility. */
+
+export {
+  enforceWebGL2,
+  polyfillWebGL1Extensions
+} from './context/polyfills/polyfill-webgl1-extensions';

--- a/modules/webgl/test/adapter/webgl1-compatibility.node.spec.ts
+++ b/modules/webgl/test/adapter/webgl1-compatibility.node.spec.ts
@@ -1,0 +1,23 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {WebGLAdapter} from '../../src/adapter/webgl-adapter';
+import {registerWebGL1Compatibility} from '../../src/context/polyfills/webgl1-compatibility-hooks';
+
+test('WebGLAdapter delegates WebGL1 enforcement to an optional compatibility hook', t => {
+  const events: boolean[] = [];
+  registerWebGL1Compatibility({
+    enforceWebGL2(enable) {
+      events.push(Boolean(enable));
+    }
+  });
+
+  const adapter = new WebGLAdapter();
+  adapter.enforceWebGL2(true);
+  adapter.enforceWebGL2(false);
+
+  t.deepEqual(events, [true, false], 'adapter delegates both enable and disable operations');
+  t.end();
+});

--- a/modules/webgl/test/context/debug-bundle.node.spec.ts
+++ b/modules/webgl/test/context/debug-bundle.node.spec.ts
@@ -1,0 +1,47 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {resolve} from 'node:path';
+import esbuild from 'esbuild';
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+
+test('WebGL debug tools stay outside the normal adapter bundle', async t => {
+  const sourceAliases = {
+    name: 'webgl-source-alias',
+    setup(build: esbuild.PluginBuild): void {
+      build.onResolve({filter: /^@luma\.gl\/webgl$/}, () => ({
+        path: resolve('modules/webgl/src/index.ts')
+      }));
+    }
+  };
+  const buildResult = await esbuild.build({
+    stdin: {
+      contents: "export {webgl2Adapter} from '@luma.gl/webgl';",
+      resolveDir: process.cwd()
+    },
+    bundle: true,
+    external: ['@luma.gl/core'],
+    format: 'esm',
+    logLevel: 'silent',
+    metafile: true,
+    plugins: [sourceAliases],
+    treeShaking: true,
+    write: false
+  });
+  const bundledInputs = Object.keys(buildResult.metafile.inputs);
+
+  t.notOk(
+    bundledInputs.some(path => path.endsWith('/webgl-developer-tools.ts')),
+    'adapter bundle excludes WebGLDeveloperTools'
+  );
+  t.notOk(
+    bundledInputs.some(path => path.endsWith('/spector.ts')),
+    'adapter bundle excludes Spector integration'
+  );
+  t.ok(
+    bundledInputs.some(path => path.endsWith('/debug-hooks.ts')),
+    'adapter bundle retains only lightweight registration hooks'
+  );
+  t.end();
+});

--- a/modules/webgpu/package.json
+++ b/modules/webgpu/package.json
@@ -40,7 +40,6 @@
     "@luma.gl/core": "~9.4.0-alpha.1"
   },
   "dependencies": {
-    "@probe.gl/env": "^4.1.1",
     "@webgpu/types": "^0.1.69",
     "wgsl_reflect": "^1.2.3"
   },

--- a/modules/webgpu/src/adapter/resources/webgpu-vertex-array.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-vertex-array.ts
@@ -4,7 +4,6 @@
 
 import type {Device, Buffer, VertexArrayProps, RenderPass} from '@luma.gl/core';
 import {VertexArray, log} from '@luma.gl/core';
-import {getBrowser} from '@probe.gl/env';
 
 import {WebGPUDevice} from '../webgpu-device';
 import {WebGPUBuffer} from '../resources/webgpu-buffer';
@@ -141,6 +140,12 @@ export class WebGPUVertexArray extends VertexArray {
    * Attribute 0 can not be disable on most desktop OpenGL based browsers
    */
   static isConstantAttributeZeroSupported(device: Device): boolean {
-    return getBrowser() === 'Chrome';
+    return isChromiumBrowser();
   }
+}
+
+function isChromiumBrowser(): boolean {
+  const chrome = (globalThis as typeof globalThis & {chrome?: unknown}).chrome;
+  const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+  return Boolean(chrome) && !userAgent.includes('Electron');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4829,7 +4829,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@luma.gl/webgpu@workspace:modules/webgpu"
   dependencies:
-    "@probe.gl/env": "npm:^4.1.1"
     "@webgpu/types": "npm:^0.1.69"
     wgsl_reflect: "npm:^1.2.3"
   peerDependencies:


### PR DESCRIPTION
## Goals

- Continue the bundle-size work tracked in #2852 by removing legacy WebGL1 compatibility code from normal WebGL2 application bundles.
- Preserve `luma.enforceWebGL2()` through an explicit optional preload.

## Changes

- Add the `@luma.gl/webgl/webgl1` entry, exporting `enforceWebGL2()` and `polyfillWebGL1Extensions()`.
- Replace the default adapter's implementation import with a small registered hook.
- Use a global symbol registry so optional ESM and CommonJS entries register correctly even when bundled separately.
- Mark the debug and WebGL1 registration entries as side-effectful so bare preload imports survive tree shaking.
- Apply the same cross-bundle registry fix to the optional debug hooks introduced by the stacked base PR.
- Document the v10 compatibility change and update browser/node coverage.

This PR is stacked on #2857 and targets `codex/webgl-debug-entrypoint`.

## Bundle impact

Measured with esbuild, minified ESM, browser targets Chrome/Firefox 110 and Safari 15:

| Bundle | Base min/gzip/Brotli | This PR min/gzip/Brotli | Reduction |
| --- | ---: | ---: | ---: |
| WebGL backend, core external | 134,030 / 37,403 / 32,144 | 132,718 / 36,986 / 31,750 | 1,312 / 417 / 394 |
| Core + WebGL adapter app | 176,553 / 50,836 / 43,262 | 175,232 / 50,367 / 42,817 | 1,321 / 469 / 445 |

The optional `webgl1` entry is 2,012 minified / 936 gzip / 827 Brotli bytes with core and constants external.

## Verification

- `yarn lint fix` — passed; no fixes required.
- `yarn build` — passed.
- `yarn test-node modules/webgl/test/adapter/webgl1-compatibility.node.spec.ts` — passed (1 test).
- `yarn test-headless modules/core/test/adapter/luma.spec.ts` — passed (7 tests).
- `yarn test` — node passed (334 tests, 2 skipped); headless passed 1,420 tests with 25 skipped and the same four unrelated WebGPU baseline failures:
  - `test/examples/volumetric-fire-forge.spec.ts`
  - `modules/arrow/test/arrow/dggs-gpu-polygons.spec.ts`
  - `modules/arrow-layers/test/layers/arrow-layers.spec.ts`
  - `modules/shadertools/test/modules/geospatial/dggs.spec.ts`
- ESM and CommonJS cross-entry registration smoke checks — passed.
- Bare debug and WebGL1 preload tree-shaking smoke checks — passed.
- `nvm use`, `yarn install`, `yarn website:build`, and `(cd website && yarn build)` were not rerun; dependencies were already installed and website code is unchanged.

## Compatibility

This is a v10 behavior change. Applications using the legacy facade must preload:

```ts
import '@luma.gl/webgl/webgl1';
```

before calling `luma.enforceWebGL2()`. Applications may instead import and call `enforceWebGL2()` directly from the new subpath.