### PR TITLE
fix(gpgpu): remove circular reference

### DIFF
--- a/modules/gpgpu/src/operations/arithmetic-expression.ts
+++ b/modules/gpgpu/src/operations/arithmetic-expression.ts
@@ -1,0 +1,40 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {GPUDataEvaluator} from '../operation/gpu-data-evaluator';
+import type {Expression, ExpressionOperations} from '../utils/expression';
+
+export type ArithmeticOp =
+  | 'add'
+  | 'subtract'
+  | 'multiply'
+  | 'divide'
+  | 'pow'
+  | 'sqrt'
+  | 'abs'
+  | 'sin'
+  | 'cos'
+  | 'tan'
+  | 'exp'
+  | 'log';
+
+export type ArithmeticOperationInputs = {
+  expression: Expression<ArithmeticOp>;
+  namedInputs: Record<string, GPUDataEvaluator>;
+};
+
+export const ARITHMETIC_OPERATIONS: ExpressionOperations<ArithmeticOp> = {
+  add: {arity: 2, symbol: 'arithmetic_add'},
+  subtract: {arity: 2, symbol: 'arithmetic_subtract'},
+  multiply: {arity: 2, symbol: 'arithmetic_multiply'},
+  divide: {arity: 2, symbol: 'arithmetic_divide'},
+  pow: {arity: 2, symbol: 'pow'},
+  sqrt: {arity: 1, symbol: 'sqrt'},
+  abs: {arity: 1, symbol: 'abs'},
+  sin: {arity: 1, symbol: 'sin'},
+  cos: {arity: 1, symbol: 'cos'},
+  tan: {arity: 1, symbol: 'arithmetic_tan'},
+  exp: {arity: 1, symbol: 'exp'},
+  log: {arity: 1, symbol: 'log'}
+};

--- a/modules/gpgpu/src/operations/arithmetic-operation.ts
+++ b/modules/gpgpu/src/operations/arithmetic-operation.ts
@@ -9,50 +9,19 @@ import {
   type GPUDataEvaluatorInput
 } from '../operation/gpu-data-evaluator';
 import {Operation} from '../operation/operation';
-import {
-  compileExpression,
-  type ExpressionLiteral,
-  Expression,
-  ExpressionOperations
-} from '../utils/expression';
+import {compileExpression, type ExpressionLiteral, Expression} from '../utils/expression';
 import {deduceOutputProps} from '../utils/output-props';
+import {
+  ARITHMETIC_OPERATIONS,
+  type ArithmeticOp,
+  type ArithmeticOperationInputs
+} from './arithmetic-expression';
 
-export type ArithmeticOp =
-  | 'add'
-  | 'subtract'
-  | 'multiply'
-  | 'divide'
-  | 'pow'
-  | 'sqrt'
-  | 'abs'
-  | 'sin'
-  | 'cos'
-  | 'tan'
-  | 'exp'
-  | 'log';
-
-export type ArithmeticOperationInputs = {
-  expression: Expression<ArithmeticOp>;
-  namedInputs: Record<string, GPUDataEvaluator>;
-};
+export {ARITHMETIC_OPERATIONS} from './arithmetic-expression';
+export type {ArithmeticOp, ArithmeticOperationInputs} from './arithmetic-expression';
 
 export type ArithmeticArgument = GPUDataEvaluatorInput | number | number[];
 type NormalizedArithmeticArgument = GPUDataEvaluator | number | number[];
-
-export const ARITHMETIC_OPERATIONS: ExpressionOperations<ArithmeticOp> = {
-  add: {arity: 2, symbol: 'arithmetic_add'},
-  subtract: {arity: 2, symbol: 'arithmetic_subtract'},
-  multiply: {arity: 2, symbol: 'arithmetic_multiply'},
-  divide: {arity: 2, symbol: 'arithmetic_divide'},
-  pow: {arity: 2, symbol: 'pow'},
-  sqrt: {arity: 1, symbol: 'sqrt'},
-  abs: {arity: 1, symbol: 'abs'},
-  sin: {arity: 1, symbol: 'sin'},
-  cos: {arity: 1, symbol: 'cos'},
-  tan: {arity: 1, symbol: 'arithmetic_tan'},
-  exp: {arity: 1, symbol: 'exp'},
-  log: {arity: 1, symbol: 'log'}
-};
 
 const FLOAT_OUTPUT_OPS = new Set<ArithmeticOp>(['pow', 'sqrt', 'sin', 'cos', 'tan', 'exp', 'log']);
 

--- a/modules/gpgpu/src/operations/cpu/arithmetic.ts
+++ b/modules/gpgpu/src/operations/cpu/arithmetic.ts
@@ -5,10 +5,10 @@
 import {OperationHandler} from '../../operation/operation';
 import {Expression} from '../../utils/expression';
 import {
-  ArithmeticOperationInputs,
-  ArithmeticOp,
-  ARITHMETIC_OPERATIONS
-} from '../arithmetic-operation';
+  ARITHMETIC_OPERATIONS,
+  type ArithmeticOperationInputs,
+  type ArithmeticOp
+} from '../arithmetic-expression';
 import {getValueAtRow} from './common';
 
 export const arithmetic: OperationHandler<ArithmeticOperationInputs> = ({

--- a/modules/gpgpu/src/operations/webgl/arithmetic.ts
+++ b/modules/gpgpu/src/operations/webgl/arithmetic.ts
@@ -5,7 +5,7 @@
 import {fp32} from '@luma.gl/shadertools';
 import {OperationHandler} from '../../operation/operation';
 import {compileExpression} from '../../utils/expression';
-import {ARITHMETIC_OPERATIONS, ArithmeticOperationInputs} from '../arithmetic-operation';
+import {ARITHMETIC_OPERATIONS, type ArithmeticOperationInputs} from '../arithmetic-expression';
 import {runRowTransform} from './common/row-transform';
 import {formatLiteralValue, getAttributeType, getZeroLiteral} from './common/helper';
 

--- a/modules/gpgpu/src/operations/webgpu/arithmetic.ts
+++ b/modules/gpgpu/src/operations/webgpu/arithmetic.ts
@@ -5,7 +5,7 @@
 import type {Device} from '@luma.gl/core';
 import {OperationHandler} from '../../operation/operation';
 import {compileExpression} from '../../utils/expression';
-import {ARITHMETIC_OPERATIONS, ArithmeticOperationInputs} from '../arithmetic-operation';
+import {ARITHMETIC_OPERATIONS, type ArithmeticOperationInputs} from '../arithmetic-expression';
 import {runRowComputation} from './common/row-transform';
 import {formatLiteralValue, getWGSLType, getZeroValue} from './common/helper';
 


### PR DESCRIPTION
`Operation → backendRegistry → cpuBackend → ArithmeticOperation → Operation`

Breaks webpack when building deck.gl website.

#### Change list

- Separate shared constants for backends from ArithmeticOperation