### PR TITLE
chore(webgl): emit Spector types as declarations

### DIFF
--- a/modules/webgl/src/context/debug/spector-types.ts
+++ b/modules/webgl/src/context/debug/spector-types.ts
@@ -12,7 +12,7 @@ interface IEvent<T> {
 type EventConstructor = {
   new <T>(): IEvent<T>;
 };
-enum LogLevel {
+declare enum LogLevel {
   noLog = 0,
   error = 1,
   warning = 2,
@@ -66,7 +66,7 @@ type CommandCapturedCallback = (command: ICommandCapture) => void;
 type CommandCapturedCallbacks = {
   [name: string]: CommandCapturedCallback[];
 };
-const enum CommandCaptureStatus {
+declare const enum CommandCaptureStatus {
   Unknown = 0,
   Unused = 10,
   Disabled = 20,
@@ -113,7 +113,7 @@ interface ICapture {
     };
   };
 }
-enum CaptureComparisonStatus {
+declare enum CaptureComparisonStatus {
   Equal = 0,
   Different = 1,
   OnlyInA = 2,
@@ -162,7 +162,7 @@ interface WebGlConstant {
   readonly description: string;
   readonly extensionName?: string;
 }
-export class WebGlConstants {
+export declare class WebGlConstants {
   static readonly DEPTH_BUFFER_BIT: WebGlConstant;
   static readonly STENCIL_BUFFER_BIT: WebGlConstant;
   static readonly COLOR_BUFFER_BIT: WebGlConstant;
@@ -1066,11 +1066,9 @@ interface IAvailableContext {
   readonly canvas: HTMLCanvasElement;
   readonly contextSpy: IContextSpy;
 }
-export abstract class Spector {
+export declare abstract class Spector {
   protected options;
-  static getFirstAvailable3dContext(canvas: HTMLCanvasElement): WebGLRenderingContexts {
-    return null as any;
-  }
+  static getFirstAvailable3dContext(canvas: HTMLCanvasElement): WebGLRenderingContexts;
   protected static tryGetContextFromHelperField: unknown;
   protected static tryGetContextFromCanvas: unknown;
   // @ts-ignore TODO
@@ -1094,7 +1092,7 @@ export abstract class Spector {
   protected retry;
   protected noFrameTimeout;
   protected marker;
-  constructor(options?: ISpectorOptions) {}
+  constructor(options?: ISpectorOptions);
   abstract displayUI(): void;
   abstract getResultUI(): IResultView;
   abstract getCaptureUI(): ICaptureMenu;


### PR DESCRIPTION
## Goals

- Continue the secondary package-size work tracked in #2852.
- Stop emitting runtime JavaScript for the vendored Spector type model.

## Changes

- Mark Spector's declaration-like enums as ambient declarations.
- Mark `WebGlConstants` and `Spector` as ambient classes.
- Remove the placeholder static method and constructor bodies that forced runtime output.
- Preserve the existing exported TypeScript type surface.

## Package impact

After `yarn build`:

| Generated artifact | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `dist/context/debug/spector-types.js` | 20,920 B | 179 B | 20,741 B |
| `dist/context/debug/spector-types.js.map` | 19,133 B | 162 B | 18,971 B |
| Combined JavaScript + map | 40,053 B | 341 B | 39,712 B |

The generated declaration remains 49,977 bytes. This change reduces published package contents rather than application bundles because current consumers import `Spector` as a type.

## Verification

- `yarn lint fix` — passed; no fixes required.
- `yarn build` — passed.
- `yarn test` — node passed (332 tests, 2 skipped); headless passed 1,420 tests with 25 skipped and the same four unrelated WebGPU baseline failures:
  - `test/examples/volumetric-fire-forge.spec.ts`
  - `modules/arrow/test/arrow/dggs-gpu-polygons.spec.ts`
  - `modules/arrow-layers/test/layers/arrow-layers.spec.ts`
  - `modules/shadertools/test/modules/geospatial/dggs.spec.ts`
- `nvm use`, `yarn install`, `yarn website:build`, and `(cd website && yarn build)` were not rerun; dependencies were already installed and website code is unchanged.