### PR TITLE
feat(core): split canvas APIs from device entry

### DIFF
--- a/docs/api-reference/core/README.md
+++ b/docs/api-reference/core/README.md
@@ -35,7 +35,8 @@ const webgpuDevice = luma.createDevice({type: 'best-available', adapters: [webgp
 
 Libraries that need only one part of the portable API can avoid loading the full package root:
 
-- `@luma.gl/core/device` exports adapter, device, and canvas interfaces.
+- `@luma.gl/core/device` exports adapter and device interfaces without browser canvas code.
+- `@luma.gl/core/canvas` exports canvas and presentation interfaces.
 - `@luma.gl/core/resources` exports portable GPU resource classes.
 - `@luma.gl/core/uniforms` exports uniform layout, block, writer, and store utilities.
 - `@luma.gl/core/diagnostics` exports logging and statistics utilities.

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -31,6 +31,11 @@
       "import": "./dist/device.js",
       "require": "./dist/device.cjs"
     },
+    "./canvas": {
+      "types": "./dist/canvas.d.ts",
+      "import": "./dist/canvas.js",
+      "require": "./dist/canvas.cjs"
+    },
     "./resources": {
       "types": "./dist/resources.d.ts",
       "import": "./dist/resources.js",

--- a/modules/core/src/canvas.ts
+++ b/modules/core/src/canvas.ts
@@ -1,0 +1,10 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Narrow entry point for canvas and presentation interfaces. */
+
+export type {CanvasContextProps} from './adapter/canvas-context';
+export {CanvasContext} from './adapter/canvas-context';
+export type {PresentationContextProps} from './adapter/presentation-context';
+export {PresentationContext} from './adapter/presentation-context';

--- a/modules/core/src/device.ts
+++ b/modules/core/src/device.ts
@@ -18,6 +18,4 @@ export type {
 export {Device, DeviceFeatures, DeviceLimits, isHTMLInCanvasSupported} from './adapter/device';
 
 export type {CanvasContextProps} from './adapter/canvas-context';
-export {CanvasContext} from './adapter/canvas-context';
 export type {PresentationContextProps} from './adapter/presentation-context';
-export {PresentationContext} from './adapter/presentation-context';


### PR DESCRIPTION
## Goals

- Continue the narrow-entry and secondary bundle-size work tracked in #2852.
- Keep DOM canvas observation out of compute/headless consumers of the core device entry.

## Changes

- Remove runtime `CanvasContext` and `PresentationContext` exports from `@luma.gl/core/device`.
- Retain their prop types from the device entry for device creation typing.
- Add `@luma.gl/core/canvas` for the concrete canvas and presentation context classes.
- Document the separate device and canvas entry surfaces.

This PR is stacked on #2864 and targets `codex/narrow-entrypoints`.

## Bundle impact

Measured with esbuild, minified ESM, browser targets Chrome/Firefox 110 and Safari 15:

| Entry | Base min/gzip/Brotli | This PR min/gzip/Brotli | Reduction |
| --- | ---: | ---: | ---: |
| `@luma.gl/core/device` source entry | 48,015 / 13,937 / 12,511 | 38,101 / 11,419 / 10,298 | 9,914 / 2,518 / 2,213 |

The device entry metafile contains neither `canvas-surface.ts` nor `canvas-observer.ts`. The explicit canvas entry is 10,470 minified / 3,130 gzip / 2,792 Brotli bytes.

## Verification

- `yarn lint fix` — passed; no fixes required.
- `yarn build` — passed.
- ESM package export smoke test — passed; device exports the adapter/device runtime and canvas exports the two canvas classes.
- CommonJS package export smoke test — passed with the same surfaces.
- `yarn test` — node passed (332 tests, 2 skipped); headless passed 1,420 tests with 25 skipped and the same four unrelated WebGPU baseline failures:
  - `test/examples/volumetric-fire-forge.spec.ts`
  - `modules/arrow/test/arrow/dggs-gpu-polygons.spec.ts`
  - `modules/arrow-layers/test/layers/arrow-layers.spec.ts`
  - `modules/shadertools/test/modules/geospatial/dggs.spec.ts`
- `nvm use`, `yarn install`, `yarn website:build`, and `(cd website && yarn build)` were not rerun; dependencies were already installed and website behavior is unchanged.