### PR TITLE
perf: trim backend browser detection

### DIFF
--- a/modules/webgl/src/adapter/resources/webgl-vertex-array.ts
+++ b/modules/webgl/src/adapter/resources/webgl-vertex-array.ts
@@ -6,7 +6,6 @@ import type {TypedArray, NumericArray} from '@math.gl/types';
 import type {AttributeInfo, Device, Buffer, VertexArrayProps} from '@luma.gl/core';
 import {VertexArray, getAttributeInfosFromLayouts, getScratchArray} from '@luma.gl/core';
 import {GL} from '@luma.gl/webgl/constants';
-import {getBrowser} from '@probe.gl/env';
 
 import {WebGLDevice} from '../webgl-device';
 import {WEBGLBuffer} from '../resources/webgl-buffer';
@@ -35,7 +34,7 @@ export class WEBGLVertexArray extends VertexArray {
    * @returns `true` when constant attribute 0 is supported on the current browser.
    */
   static isConstantAttributeZeroSupported(device: Device): boolean {
-    return getBrowser() === 'Chrome';
+    return isChromiumBrowser();
   }
 
   /**
@@ -287,6 +286,12 @@ function normalizeConstantArrayValue(arrayValue: NumericArray) {
     return new Float32Array(arrayValue);
   }
   return arrayValue;
+}
+
+function isChromiumBrowser(): boolean {
+  const chrome = (globalThis as typeof globalThis & {chrome?: unknown}).chrome;
+  const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+  return Boolean(chrome) && !userAgent.includes('Electron');
 }
 
 /**

--- a/modules/webgpu/package.json
+++ b/modules/webgpu/package.json
@@ -40,7 +40,6 @@
     "@luma.gl/core": "~9.4.0-alpha.1"
   },
   "dependencies": {
-    "@probe.gl/env": "^4.1.1",
     "@webgpu/types": "^0.1.69",
     "wgsl_reflect": "^1.2.3"
   },

--- a/modules/webgpu/src/adapter/resources/webgpu-vertex-array.ts
+++ b/modules/webgpu/src/adapter/resources/webgpu-vertex-array.ts
@@ -4,7 +4,6 @@
 
 import type {Device, Buffer, VertexArrayProps, RenderPass} from '@luma.gl/core';
 import {VertexArray, log} from '@luma.gl/core';
-import {getBrowser} from '@probe.gl/env';
 
 import {WebGPUDevice} from '../webgpu-device';
 import {WebGPUBuffer} from '../resources/webgpu-buffer';
@@ -141,6 +140,12 @@ export class WebGPUVertexArray extends VertexArray {
    * Attribute 0 can not be disable on most desktop OpenGL based browsers
    */
   static isConstantAttributeZeroSupported(device: Device): boolean {
-    return getBrowser() === 'Chrome';
+    return isChromiumBrowser();
   }
+}
+
+function isChromiumBrowser(): boolean {
+  const chrome = (globalThis as typeof globalThis & {chrome?: unknown}).chrome;
+  const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+  return Boolean(chrome) && !userAgent.includes('Electron');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4829,7 +4829,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@luma.gl/webgpu@workspace:modules/webgpu"
   dependencies:
-    "@probe.gl/env": "npm:^4.1.1"
     "@webgpu/types": "npm:^0.1.69"
     wgsl_reflect: "npm:^1.2.3"
   peerDependencies:


### PR DESCRIPTION
## Goals

- Continue the backend bundle-size work tracked in #2852.
- Avoid loading the general `@probe.gl/env` browser classifier just to identify Chromium constant-attribute behavior.

## Changes

- Replace `getBrowser() === 'Chrome'` in the WebGL and WebGPU vertex-array implementations with a small local Chromium check.
- Preserve the relevant behavior: Chromium/Chromium Edge are accepted, Electron is excluded, and Node/Safari/Firefox are rejected.
- Remove WebGPU's now-unused direct `@probe.gl/env` dependency and lockfile edge.

This PR is stacked on #2868 and targets `codex/optional-webgl1-compatibility`.

## Bundle impact

Exact before/after comparison used esbuild with virtual base sources, minified ESM, browser targets Chrome/Firefox 110 and Safari 15:

| Bundle | Base min/gzip/Brotli | This PR min/gzip/Brotli | Reduction |
| --- | ---: | ---: | ---: |
| WebGL backend, core external | 132,718 / 36,986 / 31,750 | 132,057 / 36,707 / 31,474 | 661 / 279 / 276 |
| WebGPU backend, core external | 274,383 / 56,890 / 47,879 | 273,722 / 56,605 / 47,597 | 661 / 285 / 282 |

Neither backend metafile includes `@probe.gl/env` after this change. The representative core+WebGL app saves only 24 minified / 25 gzip / 11 Brotli bytes because core logging independently includes env; this PR is intentionally framed as backend cleanup.

## Verification

- `yarn install` — passed with the repository's existing peer-dependency warnings.
- `yarn lint fix` — passed; no fixes required on the final scope.
- `yarn build` — passed.
- `yarn test` — node passed (334 tests, 2 skipped); headless passed 1,420 tests with 25 skipped and the same four unrelated WebGPU baseline failures:
  - `test/examples/volumetric-fire-forge.spec.ts`
  - `modules/arrow/test/arrow/dggs-gpu-polygons.spec.ts`
  - `modules/arrow-layers/test/layers/arrow-layers.spec.ts`
  - `modules/shadertools/test/modules/geospatial/dggs.spec.ts`
- `nvm use`, `yarn website:build`, and `(cd website && yarn build)` were not run; website code is unchanged.