### PR TITLE
feat(core): make Probe logging optional

### DIFF
--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -46,6 +46,9 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 
 **@luma.gl/core**
 
+- Probe logging now requires `import '@luma.gl/core/diagnostics'`. The default `luma.log` facade
+  retains settings and log-level configuration but suppresses formatted log output.
+
 - WebGPU device creation now defaults to the portable `DeviceProps.featureLevel: 'core'`. Applications that relied on luma.gl requesting every adapter feature and supported limit should pass `featureLevel: 'max'`.
 - Render draw state is now owned by `RenderPass`. `RenderPipelineProps.bindings`, `RenderPipelineProps.bindGroups`, `RenderPipeline.setBindings()`, and `RenderPipeline.draw()` are deprecated compatibility APIs. Migrate low-level rendering code to `renderPass.setPipeline()`, `renderPass.setBindings()`, `renderPass.setVertexArray()`, and `renderPass.draw()`.
 - `CommandEncoder.finish()` no longer accepts command-buffer properties, and the `CommandBufferProps` type has been removed. Set `id` and `userData` on the command encoder; the finished command buffer inherits them.

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -8,6 +8,7 @@ Target Release Date: Q3, 2026
 
 **General**
 
+- **Optional Probe logging** - Rich Probe logging is available through `@luma.gl/core/diagnostics` and no longer increases normal application bundles.
 - **TypeScript 6.0** - luma.gl package builds, website tooling, and supported example typechecks now use TypeScript 6.0.
 - **Precise raw binary64 coordinate deltas** - The WGSL `fp64arithmetic` module can split a binary64-rounded subtraction into normalized double-single limbs, normalize and compare those limbs with integer-controlled behavior in either arithmetic mode, and explicitly classify non-finite values. The existing direct-to-`f32` helper retains its single-round exact-delta contract.
 

--- a/modules/core/package.json
+++ b/modules/core/package.json
@@ -38,7 +38,13 @@
     "dist.min.js",
     "README.md"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./src/diagnostics.ts",
+    "./src/diagnostics/probe-log.ts",
+    "./dist/diagnostics.js",
+    "./dist/diagnostics.cjs",
+    "./dist/diagnostics/probe-log.js"
+  ],
   "scripts": {
     "build-minified-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.min.js",
     "build-dev-bundle": "ocular-bundle ./bundle.ts --output=dist/dist.dev.js --env=dev",

--- a/modules/core/src/diagnostics.ts
+++ b/modules/core/src/diagnostics.ts
@@ -5,5 +5,6 @@
 /** Explicit entry point for logging, statistics, and resource diagnostics. */
 
 export {log} from './utils/log';
+export {probeLog} from './diagnostics/probe-log';
 export {StatsManager, lumaStats} from './utils/stats-manager';
 export {resourceStatsInstrumentation} from './diagnostics/resource-stats-instrumentation';

--- a/modules/core/src/diagnostics/probe-log.ts
+++ b/modules/core/src/diagnostics/probe-log.ts
@@ -1,0 +1,11 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Log} from '@probe.gl/log';
+import {registerLogImplementation} from '../utils/log';
+
+/** Full Probe logger installed by the optional diagnostics entry. */
+export const probeLog = new Log({id: 'luma.gl'});
+
+registerLogImplementation(probeLog);

--- a/modules/core/src/utils/log.ts
+++ b/modules/core/src/utils/log.ts
@@ -2,7 +2,95 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Log} from '@probe.gl/log';
+import type {Log} from '@probe.gl/log';
 
-/** Global log instance */
-export const log: Log = new Log({id: 'luma.gl'});
+type LogRegistry = {
+  implementation: Log | null;
+  settings: Record<string, unknown>;
+  level: number;
+};
+
+const LOG_REGISTRY_SYMBOL = Symbol.for('@luma.gl/core/log-registry');
+const NOOP_LOG = () => NOOP_LOG;
+
+const fallbackLog = {
+  id: 'luma.gl',
+  VERSION: '0.0.0',
+  userData: {},
+  get level(): number {
+    return getLogRegistry().level;
+  },
+  set level(level: number) {
+    getLogRegistry().level = level;
+  },
+  get priority(): number {
+    return getLogRegistry().level;
+  },
+  set priority(level: number) {
+    getLogRegistry().level = level;
+  },
+  isEnabled(): boolean {
+    return getLogRegistry().settings['enabled'] !== false;
+  },
+  getLevel(): number {
+    return getLogRegistry().level;
+  },
+  getTotal(): number {
+    return 0;
+  },
+  getDelta(): number {
+    return 0;
+  },
+  enable(enabled: boolean = true): Log {
+    getLogRegistry().settings['enabled'] = enabled;
+    return log;
+  },
+  setLevel(level: number): Log {
+    getLogRegistry().level = level;
+    return log;
+  },
+  get(setting: string): unknown {
+    return setting === 'level' ? getLogRegistry().level : getLogRegistry().settings[setting];
+  },
+  set(setting: string, value: unknown): void {
+    getLogRegistry().settings[setting] = value;
+  },
+  assert(condition: unknown, message?: string): asserts condition {
+    if (!condition) {
+      throw new Error(message || 'Assertion failed');
+    }
+  },
+  withGroup(_logLevel: number, _message: string, func: () => void): void {
+    func();
+  }
+};
+
+/** Global logging facade. Import `@luma.gl/core/diagnostics` to install Probe logging. */
+export const log = new Proxy(fallbackLog, {
+  get(target, property): unknown {
+    const implementation = getLogRegistry().implementation;
+    const source = implementation || target;
+    const value = Reflect.get(source, property, source);
+    return typeof value === 'function' ? value.bind(source) : (value ?? NOOP_LOG);
+  },
+  set(target, property, value): boolean {
+    const implementation = getLogRegistry().implementation;
+    return Reflect.set(implementation || target, property, value);
+  }
+}) as unknown as Log;
+
+/** Install a full logging implementation behind the stable facade. */
+export function registerLogImplementation(implementation: Log): void {
+  const registry = getLogRegistry();
+  implementation.level = registry.level;
+  for (const [setting, value] of Object.entries(registry.settings)) {
+    implementation.set(setting, value);
+  }
+  registry.implementation = implementation;
+}
+
+function getLogRegistry(): LogRegistry {
+  const globalRegistry = globalThis as unknown as Record<symbol, LogRegistry | undefined>;
+  globalRegistry[LOG_REGISTRY_SYMBOL] ||= {implementation: null, settings: {}, level: 0};
+  return globalRegistry[LOG_REGISTRY_SYMBOL];
+}


### PR DESCRIPTION
## Goals

- Continue the optional diagnostics work tracked in #2852.
- Remove rich Probe logging and its transitive environment helpers from normal core/application bundles.
- Preserve the `luma.log` configuration surface and make full logging explicitly opt-in.

## Changes

- Replace the eager Probe `Log` instance with a lightweight, globally registered facade.
- Preserve `level`, `priority`, `get/set`, `enable`, assertions, and execution semantics such as `withGroup`; default formatted log calls become no-ops.
- Replay settings and log level configured before diagnostics loading into the real Probe logger.
- Install and export the Probe logger from `@luma.gl/core/diagnostics`.
- Mark the diagnostics registration modules as side-effectful so bare ESM/CommonJS preload imports survive tree shaking.
- Document the v10 opt-in behavior.

This PR is stacked on #2866 and targets `codex/optional-core-diagnostics`.

## Bundle impact

Measured with esbuild, minified ESM, browser targets Chrome/Firefox 110 and Safari 15:

| Fixture | Base min/gzip/Brotli | This PR min/gzip/Brotli | Reduction |
| --- | ---: | ---: | ---: |
| Core root | 94,739 / 26,911 / 23,762 | 88,646 / 24,932 / 21,973 | 6,093 / 1,979 / 1,789 |
| Named `Device` | 34,814 / 10,681 / 9,643 | 28,109 / 8,488 / 7,662 | 6,705 / 2,193 / 1,981 |
| Core + WebGL adapter app | 208,824 / 59,313 / 49,449 | 202,572 / 57,328 / 47,678 | 6,252 / 1,985 / 1,771 |

The default core and representative app metafiles contain no `@probe.gl/log` inputs. The optional diagnostics entry grows from 13,786/4,461/4,015 to 14,779/4,783/4,313 bytes (+993/+322/+298) because it now carries the logger.

## Verification

- `yarn lint fix` — passed; no fixes required.
- `yarn build` — passed.
- ESM cross-entry smoke test — passed; preconfigured setting and level were replayed into `probeLog`.
- CommonJS cross-entry smoke test — passed with the same result.
- Bare diagnostics preload tree-shaking smoke test — passed; Probe Log modules remain in the bundle.
- `yarn test` — node passed (334 tests, 2 skipped); headless passed 1,420 tests with 25 skipped and the same four unrelated WebGPU baseline failures:
  - `test/examples/volumetric-fire-forge.spec.ts`
  - `modules/arrow/test/arrow/dggs-gpu-polygons.spec.ts`
  - `modules/arrow-layers/test/layers/arrow-layers.spec.ts`
  - `modules/shadertools/test/modules/geospatial/dggs.spec.ts`
- `nvm use`, `yarn install`, `yarn website:build`, and `(cd website && yarn build)` were not rerun; dependencies were already installed and website code is unchanged.

## Compatibility

This is a v10 behavior change. Applications that want formatted Probe output must preload:

```ts
import '@luma.gl/core/diagnostics';
```

The default facade continues to retain settings and log-level changes even when diagnostics are loaded later.