### PR TITLE
Address GPU roadmap review feedback

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/gpu-batch-hash-join.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-batch-hash-join.md
@@ -49,6 +49,10 @@ Each `outputLeftRows` chunk defines the pair capacity for the corresponding inpu
 aligned `outputRightRows` chunk must have the same capacity. A dense batch may overflow while a
 neighboring sparse batch leaves unused storage; spare capacity is not borrowed across the boundary.
 
+A nonempty input batch may deliberately have zero pair capacity. Lookup and scan still publish its
+exact required count, source-aligned diagnostics, and overflow, while pair-output buffers are never
+bound. This supports count-only planning and zero-length views at the end of an allocation.
+
 This is deliberate. Cross-batch spill would turn an ordered vector into a packed global output and
 make independent replacement, accounting, and partial consumption unsafe. Applications that want
 one shared capacity should use `GPUHashJoin` on a deliberately packed input instead.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-bvh-query.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-bvh-query.md
@@ -30,6 +30,10 @@ Its work and memory are therefore explicit and portable across WebGPU implementa
 order is unspecified because parallel leaves append atomically; stable identity, not traversal
 order, is the contract.
 
+Stable leaf IDs use the entire `uint32` range, including `0xffffffff`. Empty leaves are recognized
+by their invalid bounds rather than by reserving an application identity. Writable results must not
+overlap one another or any live query/BVH input.
+
 ### Exact predicates
 
 A point query returns leaves whose closed bounds contain the point. A bounds query returns leaves

--- a/docs/api-reference/experimental/gpu-primitives/gpu-fft2d.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-fft2d.md
@@ -103,7 +103,9 @@ type GPUFFT2DEncodeOptions = {
 
 Both buffers must belong to the transform's device, declare `Buffer.STORAGE`, and contain at least
 `stats.complexBufferByteLength` bytes. They must be separate allocations; the source is never
-modified. `encode()` returns `outputBuffer` for convenient downstream binding.
+modified. Separate wrapper objects around the same underlying `GPUBuffer` are also rejected,
+because the physical allocation would still alias across parallel butterfly invocations.
+`encode()` returns `outputBuffer` for convenient downstream binding.
 
 The normalization convention is:
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-hash-index.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-hash-index.md
@@ -64,6 +64,10 @@ therefore produces the same key-to-value mapping even when workgroups execute in
 order. When no value input is supplied, the retained value is `firstValue + sourceRow`, making the
 primitive directly useful as a key-to-row index.
 
+An empty explicit values view is also valid, including a zero-length view positioned at the end of
+its backing buffer. Empty rebuilds clear the table and statistics without binding unavailable input
+rows.
+
 ### Statistics expose the cost model
 
 Build statistics contain:

--- a/docs/api-reference/experimental/gpu-primitives/gpu-scene-adapters.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-scene-adapters.md
@@ -86,6 +86,11 @@ producer is responsible for writing valid scene records, including `GPU_SCENE_AC
 active rows. GPU-authored validation can be composed explicitly when untrusted producers require
 it.
 
+The producer must also provide one exact `activeCounts` entry per preserved batch. This metadata
+distinguishes the physical high-water mark from live records when a batch contains inactive holes;
+empty batches have an active count of zero. The adapter never guesses activity by reading or
+scanning the borrowed GPU records.
+
 Because the adapter has no CPU copy of IDs or holes, table scenes expose `mutable === false`.
 CPU-authored `mutate()` and `compact()` reject; GPU workflows may still read their typed graph
 views. Replacing a table batch means creating a new adaptation for that allocation rather than
@@ -125,6 +130,7 @@ const scene = makeGPUSceneFromCPUScene(device, {
 
 ```ts
 const adapted = makeGPUScenePartitionsFromGPUTable(device, table, {
+  activeCounts: producerActiveCounts,
   columns: {
     objectId: 'featureId',
     geometryId: 'meshId'

--- a/docs/api-reference/experimental/gpu-primitives/gpu-scene.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-scene.md
@@ -32,6 +32,10 @@ removal, `count` is the physical high-water mark and may include holes; `activeC
 number of live records. Consumers therefore combine the prefix with `flags` until compaction makes
 the two counts equal again.
 
+Pre-populated borrowed records may declare an explicit `activeCount` below their physical
+`recordCount`. Newly allocated empty storage cannot claim a positive record count, and bounds or
+transform values must remain finite after conversion to the stored `float32` representation.
+
 ### Mutation is transactional and measurable
 
 `mutate()` accepts removals, patches, insertions, and optional compaction as one transaction. The

--- a/docs/api-reference/experimental/gpu-primitives/gpu-virtual-geometry-selection.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-virtual-geometry-selection.md
@@ -63,7 +63,8 @@ contains every root, so forests do not need a synthetic root.
 Each node has four source-aligned rows:
 
 - `sphereBounds`: packed `float32x4` world-space center XYZ and nonnegative radius.
-- `geometricErrors`: packed `float32` object-space error.
+- `geometricErrors`: packed `float32` world-space error, transformed with the same scale as the
+  world-space bounding sphere.
 - `children`: packed `uint32x2` first-child index and child count.
 - `clusterIds`: packed `uint32` render identity.
 
@@ -72,9 +73,10 @@ breadth level. CPU-visible lengths and level offsets are validated when the sele
 GPU child ranges are checked conservatively during traversal; an invalid range retains its coarse
 parent instead of creating a geometry hole.
 
-The active state is node-aligned. Multiple roots and convergent activation write the same boolean
-node bit, so a node can appear at most once. A refined parent is never selected in the same
-frontier as its children.
+The active state is node-aligned. Multiple roots and convergent activation write the same node
+state, so a node can appear at most once. If one parent remains coarse while another requests the
+same children, the coarse parent blocks those children. A selected parent and its children
+therefore never appear together even when child ranges converge.
 
 ## View and error metric
 
@@ -99,6 +101,10 @@ The projected error is:
 geometricError * projectionScalePixels /
 max(distance(camera, sphere.center) - sphere.radius, 1e-6)
 ```
+
+`geometricError`, the sphere, and the camera must use the same world-space units. If source
+geometry is scaled during placement, multiply its object-space error by the appropriate world
+scale before uploading the error column.
 
 A node refines when that value exceeds `maximumScreenSpaceError`, expressed in pixels. A camera
 inside or within `1e-6` world units of a sphere refines conservatively when valid children exist.

--- a/modules/experimental/src/gpu-primitives/gpu-bvh-query.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-bvh-query.ts
@@ -8,6 +8,7 @@ import {GPUCommandGraph, type GraphBufferUse, type GraphDataView} from './gpu-co
 import type {GPUBVHBoundsView} from './gpu-bvh';
 import {
   createTransientView,
+  doGraphDataViewsOverlap,
   getViewBinding,
   getViewElementOffset,
   validatePackedUint32View,
@@ -110,6 +111,7 @@ export class GPUBVHQuery {
     if (this.query.length !== expectedQueryLength) {
       throw new Error(`${this.id} ${this.kind} query must contain ${expectedQueryLength} floats`);
     }
+    validateDisjointViews(this);
   }
 
   /** Adds initialization and level-ordered traversal without submission or readback. */
@@ -289,13 +291,11 @@ fn finite(value: f32) -> bool {
   if (selected) {
     let leafIndex = nodeIndex - INTERNAL_NODE_COUNT;
     let objectId = leafIds[LEAF_IDS_OFFSET + leafIndex];
-    if (objectId != ${INVALID_NODE}u) {
-      let outputIndex = atomicAdd(&outputCount[COUNT_OFFSET], 1u);
-      if (outputIndex < OUTPUT_CAPACITY) {
-        outputIds[OUTPUT_OFFSET + outputIndex] = objectId;
-      } else {
-        atomicStore(&outputOverflow[OVERFLOW_OFFSET], 1u);
-      }
+    let outputIndex = atomicAdd(&outputCount[COUNT_OFFSET], 1u);
+    if (outputIndex < OUTPUT_CAPACITY) {
+      outputIds[OUTPUT_OFFSET + outputIndex] = objectId;
+    } else {
+      atomicStore(&outputOverflow[OVERFLOW_OFFSET], 1u);
     }
   }
 }`;
@@ -394,6 +394,33 @@ fn finite(value: f32) -> bool {
     },
     dispatchCount: Math.ceil(levelNodeCount / BVH_QUERY_WORKGROUP_SIZE)
   });
+}
+
+function validateDisjointViews(query: GPUBVHQuery): void {
+  const inputs = [
+    query.bvh.nodeMinima,
+    query.bvh.nodeMaxima,
+    query.bvh.nodeChildren,
+    query.bvh.leafIds,
+    query.bvh.overflow,
+    query.query
+  ];
+  const outputs = [
+    query.output,
+    query.count,
+    query.overflow,
+    ...(query.outputMask ? [query.outputMask] : []),
+    ...(query.visitedCount ? [query.visitedCount] : [])
+  ];
+  for (let outputIndex = 0; outputIndex < outputs.length; outputIndex++) {
+    const output = outputs[outputIndex]!;
+    if (inputs.some(input => doGraphDataViewsOverlap(input, output))) {
+      throw new Error(`${query.id} output views must not overlap query or BVH inputs`);
+    }
+    if (outputs.slice(outputIndex + 1).some(other => doGraphDataViewsOverlap(output, other))) {
+      throw new Error(`${query.id} output views must not overlap one another`);
+    }
+  }
 }
 
 function addOutputMaskPass<Parameters>(

--- a/modules/experimental/src/gpu-primitives/gpu-fft2d.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-fft2d.ts
@@ -144,7 +144,10 @@ export class GPUFFT2D {
     }
     validateGPUFFT2DBuffer(this.device, options.inputBuffer, this.stats, 'input');
     validateGPUFFT2DBuffer(this.device, options.outputBuffer, this.stats, 'output');
-    if (options.inputBuffer === options.outputBuffer) {
+    if (
+      options.inputBuffer === options.outputBuffer ||
+      options.inputBuffer.handle === options.outputBuffer.handle
+    ) {
       throw new Error('GPUFFT2D input and output buffers must be separate.');
     }
 

--- a/modules/experimental/src/gpu-primitives/gpu-hash-index.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-hash-index.ts
@@ -427,11 +427,12 @@ function addBuildFinalizePass<Parameters>(
     index.tableKeys.length,
     graph.device.limits.maxComputeWorkgroupsPerDimension
   );
-  const valueBinding = index.values
+  const hasExplicitValues = Boolean(index.values && index.keys.length > 0);
+  const valueBinding = hasExplicitValues
     ? '@group(0) @binding(3) var<storage, read> inputValues: array<u32>;'
     : '';
-  const valueExpression = index.values
-    ? `inputValues[${getViewElementOffset(index.values)}u + sourceRow]`
+  const valueExpression = hasExplicitValues
+    ? `inputValues[${getViewElementOffset(index.values!)}u + sourceRow]`
     : `${index.firstValue}u + sourceRow`;
   const source = /* wgsl */ `
 const CAPACITY: u32 = ${index.tableKeys.length}u;
@@ -461,13 +462,15 @@ ${valueBinding}
       {buffer: index.tableKeys, usage: 'storage-read'},
       {buffer: sourceRows, usage: 'storage-read'},
       {buffer: index.tableValues, usage: 'storage-write'},
-      ...(index.values ? ([{buffer: index.values, usage: 'storage-read'}] as GraphBufferUse[]) : [])
+      ...(hasExplicitValues
+        ? ([{buffer: index.values!, usage: 'storage-read'}] as GraphBufferUse[])
+        : [])
     ],
     bindings: {
       tableKeys: index.tableKeys,
       sourceRows,
       tableValues: index.tableValues,
-      ...(index.values ? {inputValues: index.values} : {})
+      ...(hasExplicitValues ? {inputValues: index.values!} : {})
     },
     dispatchSize: layout
   });

--- a/modules/experimental/src/gpu-primitives/gpu-hash-join.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-hash-join.ts
@@ -270,6 +270,10 @@ function addJoinScatterPass<Parameters>(
   found: GraphDataView<'uint32'>,
   offsets: GraphDataView<'uint32'>
 ): void {
+  if (join.outputLeftRows.length === 0) {
+    addJoinCountOnlyPass(graph, join, found, offsets);
+    return;
+  }
   const layout = getDispatchLayout(
     join.keys.length,
     graph.device.limits.maxComputeWorkgroupsPerDimension
@@ -348,6 +352,43 @@ ${leftRowsBinding}
       overflow: join.overflow
     },
     dispatchSize: layout
+  });
+}
+
+function addJoinCountOnlyPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  join: GPUHashJoin,
+  found: GraphDataView<'uint32'>,
+  offsets: GraphDataView<'uint32'>
+): void {
+  const source = /* wgsl */ `
+const LAST_INDEX: u32 = ${join.keys.length - 1}u;
+const FOUND_OFFSET: u32 = ${getViewElementOffset(found)}u;
+const OFFSETS_OFFSET: u32 = ${getViewElementOffset(offsets)}u;
+const COUNT_OFFSET: u32 = ${getViewElementOffset(join.count)}u;
+const OVERFLOW_OFFSET: u32 = ${getViewElementOffset(join.overflow)}u;
+@group(0) @binding(0) var<storage, read> found: array<u32>;
+@group(0) @binding(1) var<storage, read> offsets: array<u32>;
+@group(0) @binding(2) var<storage, read_write> count: array<u32>;
+@group(0) @binding(3) var<storage, read_write> overflow: array<u32>;
+
+@compute @workgroup_size(1) fn main() {
+  let requiredCount = offsets[OFFSETS_OFFSET + LAST_INDEX] +
+    min(found[FOUND_OFFSET + LAST_INDEX], 1u);
+  count[COUNT_OFFSET] = requiredCount;
+  overflow[OVERFLOW_OFFSET] = min(requiredCount, 1u);
+}`;
+  addComputationPass(graph, {
+    id: `${join.id}-count-only`,
+    source,
+    resources: [
+      {buffer: found, usage: 'storage-read'},
+      {buffer: offsets, usage: 'storage-read'},
+      {buffer: join.count, usage: 'storage-write'},
+      {buffer: join.overflow, usage: 'storage-write'}
+    ],
+    bindings: {found, offsets, count: join.count, overflow: join.overflow},
+    dispatchSize: {x: 1, y: 1, z: 1}
   });
 }
 

--- a/modules/experimental/src/gpu-primitives/gpu-scene-adapters.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-scene-adapters.ts
@@ -54,6 +54,8 @@ export type GPUSceneTableAdapterProps = {
   id?: string;
   /** Optional table-column renaming. Unspecified roles use their canonical names. */
   columns?: Partial<GPUSceneTableColumnNames>;
+  /** Exact producer-known active counts, including one zero for every empty batch. */
+  activeCounts?: readonly number[];
 };
 
 /** One preserved table batch and its optional nonempty zero-copy scene. */
@@ -196,6 +198,18 @@ export function makeGPUScenePartitionsFromGPUTable(
     }
     return recordBuffer;
   });
+  if (
+    !props.activeCounts ||
+    props.activeCounts.length !== table.batches.length ||
+    props.activeCounts.some(
+      (activeCount, batchIndex) =>
+        !Number.isSafeInteger(activeCount) ||
+        activeCount < 0 ||
+        activeCount > table.batches[batchIndex]!.numRows
+    )
+  ) {
+    throw new Error('GPU scene table adapter requires one exact active count per batch');
+  }
 
   const partitions: GPUSceneTablePartition[] = [];
   let firstRecord = 0;
@@ -206,6 +220,7 @@ export function makeGPUScenePartitionsFromGPUTable(
     for (let batchIndex = 0; batchIndex < table.batches.length; batchIndex++) {
       const batch = table.batches[batchIndex]!;
       const recordCount = batch.numRows;
+      const activeCount = props.activeCounts[batchIndex]!;
       const recordBuffer = recordBuffers[batchIndex];
       if (!recordBuffer) {
         partitions.push(Object.freeze({batchIndex, firstRecord, recordCount, scene: null}));
@@ -214,7 +229,7 @@ export function makeGPUScenePartitionsFromGPUTable(
 
       const stateBuffer = device.createBuffer({
         id: `${props.id ?? 'gpu-scene-table'}-batch-${batchIndex}-state`,
-        data: new Uint32Array([recordCount, recordCount, 0, 0]),
+        data: new Uint32Array([recordCount, activeCount, 0, 0]),
         usage: REQUIRED_BUFFER_USAGE
       });
       let scene: GPUScene;
@@ -223,6 +238,7 @@ export function makeGPUScenePartitionsFromGPUTable(
           id: `${props.id ?? 'gpu-scene-table'}-batch-${batchIndex}`,
           capacity: recordCount,
           recordCount,
+          activeCount,
           buffers: {records: recordBuffer, state: stateBuffer},
           ownsBuffers: {records: false, state: true}
         });

--- a/modules/experimental/src/gpu-primitives/gpu-scene.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-scene.ts
@@ -125,6 +125,8 @@ export type GPUSceneProps = {
   records?: readonly GPUSceneRecord[];
   /** Logical active-prefix length for pre-populated borrowed storage. */
   recordCount?: number;
+  /** Exact number of active rows in pre-populated borrowed storage. Defaults to recordCount. */
+  activeCount?: number;
   /** Optional compatible caller-owned record and state buffers. */
   buffers?: GPUSceneBuffers;
   /** Whether `destroy()` owns supplied buffers. Each adopted buffer may be selected independently. */
@@ -194,6 +196,7 @@ export class GPUScene {
     }
     const records = props.records ?? [];
     const recordCount = props.recordCount ?? records.length;
+    const activeCount = props.activeCount ?? recordCount;
     const capacity = props.capacity ?? records.length;
     if (!Number.isSafeInteger(capacity) || capacity < 1) {
       throw new Error('GPUScene capacity must be a positive safe integer');
@@ -202,12 +205,21 @@ export class GPUScene {
       !Number.isSafeInteger(recordCount) ||
       recordCount < 0 ||
       recordCount > capacity ||
-      records.length > capacity
+      records.length > capacity ||
+      !Number.isSafeInteger(activeCount) ||
+      activeCount < 0 ||
+      activeCount > recordCount
     ) {
       throw new Error('GPUScene record count must fit capacity');
     }
     if (records.length > 0 && recordCount !== records.length) {
       throw new Error('GPUScene recordCount must equal records.length when records are supplied');
+    }
+    if (records.length > 0 && activeCount !== records.length) {
+      throw new Error('GPUScene activeCount must equal records.length when records are supplied');
+    }
+    if (recordCount > 0 && records.length === 0 && !props.buffers) {
+      throw new Error('GPUScene positive recordCount requires records or pre-populated buffers');
     }
     if (props.buffers && records.length === 0 && props.recordCount === undefined) {
       throw new Error('GPUScene borrowed storage requires recordCount or initial records');
@@ -218,7 +230,7 @@ export class GPUScene {
     this.id = props.id ?? 'gpu-scene';
     this.capacity = capacity;
     this.highWaterMark = recordCount;
-    this.activeRecordCount = recordCount;
+    this.activeRecordCount = activeCount;
     this.mutable = records.length === recordCount;
     this.recordsBySlot = new Array(capacity);
     records.forEach((record, recordIndex) => {
@@ -352,7 +364,13 @@ export class GPUScene {
     }
 
     const overflowCount = insert.length - insertedCount;
-    const moves = mutation.compact ? this.compactRecords(this.highWaterMark, writes) : [];
+    const moves = mutation.compact
+      ? this.compactRecords(
+          this.highWaterMark,
+          writes,
+          updatedIds.length > 0 || insertedIds.length > 0
+        )
+      : [];
     if (!mutation.compact) this.trimHighWaterMark();
     writes.push({
       target: 'state',
@@ -469,7 +487,8 @@ export class GPUScene {
 
   private compactRecords(
     previousHighWaterMark: number,
-    writes: GPUSceneBufferWrite[]
+    writes: GPUSceneBufferWrite[],
+    recordsChanged: boolean
   ): GPUSceneMove[] {
     const compacted = this.recordsBySlot.filter(
       (record): record is GPUSceneRecord => record !== undefined
@@ -486,7 +505,7 @@ export class GPUScene {
       this.slotsById.set(record.id, slot);
     });
     this.highWaterMark = compacted.length;
-    if (moves.length > 0 || previousHighWaterMark > compacted.length) {
+    if (moves.length > 0 || previousHighWaterMark > compacted.length || recordsChanged) {
       const upload = new Uint8Array(previousHighWaterMark * GPU_SCENE_RECORD_BYTE_LENGTH);
       upload.set(makeRecordData(compacted));
       writes.push({target: 'records', data: upload, byteOffset: 0});
@@ -554,13 +573,18 @@ function validateRecords(records: readonly GPUSceneRecord[]): void {
     for (let axis = 0; axis < 3; axis++) {
       const minimum = record.bounds.minimum[axis];
       const maximum = record.bounds.maximum[axis];
-      if (!Number.isFinite(minimum) || !Number.isFinite(maximum) || minimum > maximum) {
+      if (
+        !Number.isFinite(Math.fround(minimum)) ||
+        !Number.isFinite(Math.fround(maximum)) ||
+        minimum > maximum
+      ) {
         throw new Error('GPUScene bounds must contain finite ordered minima and maxima');
       }
     }
     if (
       record.transform &&
-      (record.transform.length !== 16 || !record.transform.every(Number.isFinite))
+      (record.transform.length !== 16 ||
+        !record.transform.every(value => Number.isFinite(Math.fround(value))))
     ) {
       throw new Error('GPUScene transform must contain 16 finite values');
     }

--- a/modules/experimental/src/gpu-primitives/gpu-virtual-geometry-selection.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-virtual-geometry-selection.ts
@@ -25,7 +25,7 @@ export const GPU_VIRTUAL_GEOMETRY_FRUSTUM_PLANE_COUNT = 6;
 export type GPUVirtualGeometryHierarchy = {
   /** World-space bounding sphere per hierarchy node as center XYZ and nonnegative radius. */
   sphereBounds: GraphDataView<'float32x4'>;
-  /** Object-space geometric error per hierarchy node. */
+  /** World-space geometric error per hierarchy node, scaled with its world-space bounds. */
   geometricErrors: GraphDataView<'float32'>;
   /** First-child index and child count per node. A zero child count identifies a leaf. */
   children: GraphDataView<'uint32x2'>;
@@ -123,7 +123,8 @@ export function makeGPUVirtualGeometrySelectionPlan(
  *
  * Traversal writes a source-aligned mask. {@link GPUVisibilityWorkflow} then performs stable scan
  * compaction of cluster IDs, so multiple roots and convergent child activation cannot duplicate a
- * node and output order is deterministic. The final pass copies only retained IDs and resets the
+ * node. A coarse shared parent suppresses its shared children, preserving frontier exclusivity.
+ * The final pass copies only retained IDs and resets the
  * borrowed count, optional `totalCount`, and `overflow` rows on every graph encoding.
  */
 export class GPUVirtualGeometrySelection {
@@ -444,7 +445,7 @@ fn sphereVisible(center: vec3f, radius: f32) -> bool {
 ) {
   if (globalId.x >= LEVEL_NODE_COUNT) { return; }
   let nodeIndex = FIRST_NODE + globalId.x;
-  if (atomicLoad(&activeNodes[ACTIVE_OFFSET + nodeIndex]) == 0u) { return; }
+  if (atomicLoad(&activeNodes[ACTIVE_OFFSET + nodeIndex]) != 1u) { return; }
 
   let boundsOffset = BOUNDS_OFFSET + nodeIndex * 4u;
   let center = vec3f(
@@ -489,9 +490,15 @@ fn sphereVisible(center: vec3f, radius: f32) -> bool {
   if (validChildRange && refineForView) {
     let childEnd = firstChild + childCount;
     for (var childIndex = firstChild; childIndex < childEnd; childIndex++) {
-      atomicStore(&activeNodes[ACTIVE_OFFSET + childIndex], 1u);
+      atomicMax(&activeNodes[ACTIVE_OFFSET + childIndex], 1u);
     }
     return;
+  }
+  if (validChildRange) {
+    let childEnd = firstChild + childCount;
+    for (var childIndex = firstChild; childIndex < childEnd; childIndex++) {
+      atomicMax(&activeNodes[ACTIVE_OFFSET + childIndex], 2u);
+    }
   }
   selectedMask[SELECTED_OFFSET + nodeIndex] = 1u;
 }`;

--- a/modules/experimental/test/gpu-primitives/gpu-batch-hash-join.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-batch-hash-join.spec.ts
@@ -88,6 +88,27 @@ test('GPUBatchHashJoin preserves explicit IDs and propagates source overflow per
   t.end();
 });
 
+test('GPUBatchHashJoin reports matches for nonempty zero-capacity batches', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const result = await runBatchJoin(device, {
+    keyChunks: [Uint32Array.from([70, 20]), Uint32Array.from([1])],
+    outputCapacities: [0, 0]
+  });
+
+  t.deepEqual(result.leftRows, [[], []], 'zero-capacity output chunks retain their topology');
+  t.deepEqual(result.rightRows, [[], []]);
+  t.deepEqual(result.counts, [2, 0], 'required counts remain exact without output bindings');
+  t.deepEqual(result.overflows, [1, 0], 'only a nonempty required result overflows');
+  t.deepEqual(result.found, [[1, 1], [0]], 'source-aligned lookup masks remain available');
+  t.end();
+});
+
 test('GPUBatchHashJoin validates partition and output topology', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -277,9 +298,16 @@ function makeOutputVector(
   capacities: number[]
 ) {
   const buffers = capacities.map(capacity => createOutputBuffer(device, capacity));
-  const data = capacities.map((capacity, index) =>
-    importView(graph, `${id}-${index}`, buffers[index], capacity)
-  );
+  const data = capacities.map((capacity, index) => {
+    const view = importView(graph, `${id}-${index}`, buffers[index], capacity);
+    return capacity === 0
+      ? graph.createDataView(view.buffer, {
+          format: 'uint32',
+          length: 0,
+          byteOffset: buffers[index].byteLength
+        })
+      : view;
+  });
   return {vector: makeGraphVector(id, data), buffers};
 }
 

--- a/modules/experimental/test/gpu-primitives/gpu-bvh-query.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-bvh-query.spec.ts
@@ -93,8 +93,64 @@ test('GPUBVHQuery traverses 3D points and reports bounded-output overflow', asyn
   t.end();
 });
 
+test('GPUBVHQuery preserves maximum stable IDs and rejects overlapping views', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const fixture = createFixture(device, {
+    dimension: 2,
+    minima: Float32Array.from([0, 0]),
+    maxima: Float32Array.from([1, 1]),
+    sourceIds: Uint32Array.of(0xffffffff),
+    query: Float32Array.from([0.5, 0.5]),
+    kind: 'point',
+    leafCapacity: 2,
+    outputCapacity: 2,
+    maskLength: 2
+  });
+  encode(device, fixture.compiled);
+  t.deepEqual(await readSortedOutput(fixture), [0xffffffff], 'the full uint32 ID range survives');
+  t.deepEqual(await readUint32(fixture.count, 1), [1], 'invalid empty leaves remain excluded');
+
+  const query = fixture.workflow;
+  t.throws(
+    () =>
+      new GPUBVHQuery({
+        bvh: query.bvh,
+        kind: query.kind,
+        query: query.query,
+        output: query.bvh.leafIds,
+        count: query.count,
+        overflow: query.overflow
+      }),
+    /must not overlap query or BVH inputs/,
+    'stable leaf IDs cannot alias writable output'
+  );
+  t.throws(
+    () =>
+      new GPUBVHQuery({
+        bvh: query.bvh,
+        kind: query.kind,
+        query: query.query,
+        output: query.output,
+        count: query.count,
+        overflow: query.count
+      }),
+    /must not overlap one another/,
+    'count and overflow require independent writable storage'
+  );
+
+  destroyFixture(fixture);
+  t.end();
+});
+
 type Fixture = {
   compiled: CompiledGPUCommandGraph<void>;
+  workflow: GPUBVHQuery;
   query: Buffer;
   output: Buffer;
   count: Buffer;
@@ -110,6 +166,7 @@ function createFixture(
     dimension: 2 | 3;
     minima: Float32Array;
     maxima: Float32Array;
+    sourceIds?: Uint32Array;
     query: Float32Array;
     kind: 'point' | 'bounds';
     leafCapacity: number;
@@ -122,6 +179,7 @@ function createFixture(
   const nodeCount = props.leafCapacity * 2 - 1;
   const minima = createInputBuffer(device, props.minima);
   const maxima = createInputBuffer(device, props.maxima);
+  const sourceIds = props.sourceIds ? createInputBuffer(device, props.sourceIds) : undefined;
   const query = createInputBuffer(device, props.query);
   const nodeMinima = createFloatOutputBuffer(device, nodeCount * props.dimension);
   const nodeMaxima = createFloatOutputBuffer(device, nodeCount * props.dimension);
@@ -139,6 +197,9 @@ function createFixture(
     id: 'test-bvh',
     minima: importView(graph, 'source-minima', minima, format, sourceLength),
     maxima: importView(graph, 'source-maxima', maxima, format, sourceLength),
+    ...(sourceIds
+      ? {sourceIds: importView(graph, 'source-ids', sourceIds, 'uint32', sourceLength)}
+      : {}),
     leafCapacity: props.leafCapacity,
     nodeMinima: importView(graph, 'node-minima', nodeMinima, format, nodeCount),
     nodeMaxima: importView(graph, 'node-maxima', nodeMaxima, format, nodeCount),
@@ -162,6 +223,7 @@ function createFixture(
   bvhQuery.addToGraph(graph);
   return {
     compiled: graph.compile(),
+    workflow: bvhQuery,
     query,
     output,
     count,
@@ -171,6 +233,7 @@ function createFixture(
     buffers: [
       minima,
       maxima,
+      ...(sourceIds ? [sourceIds] : []),
       query,
       nodeMinima,
       nodeMaxima,

--- a/modules/experimental/test/gpu-primitives/gpu-fft2d.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-fft2d.spec.ts
@@ -81,6 +81,11 @@ test('GPUFFT2D rejects aliased and incompatible caller buffers', async t => {
     usage: Buffer.STORAGE
   });
   const shortBuffer = device.createBuffer({byteLength: 8, usage: Buffer.STORAGE});
+  const aliasBuffer = device.createBuffer({
+    handle: validBuffer.handle,
+    byteLength: validBuffer.byteLength,
+    usage: Buffer.STORAGE
+  });
   const copyOnlyBuffer = device.createBuffer({
     byteLength: transform.stats.complexBufferByteLength,
     usage: Buffer.COPY_DST
@@ -95,6 +100,15 @@ test('GPUFFT2D rejects aliased and incompatible caller buffers', async t => {
         }),
       /must be separate/,
       'in-place aliasing is rejected'
+    );
+    t.throws(
+      () =>
+        transform.encode(device.commandEncoder, {
+          inputBuffer: validBuffer,
+          outputBuffer: aliasBuffer
+        }),
+      /must be separate/,
+      'distinct Buffer wrappers cannot alias the same GPU allocation'
     );
     t.throws(
       () =>
@@ -126,6 +140,7 @@ test('GPUFFT2D rejects aliased and incompatible caller buffers', async t => {
     );
   } finally {
     transform.destroy();
+    aliasBuffer.destroy();
     validBuffer.destroy();
     shortBuffer.destroy();
     copyOnlyBuffer.destroy();

--- a/modules/experimental/test/gpu-primitives/gpu-hash-index.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-hash-index.spec.ts
@@ -148,6 +148,60 @@ test('GPUHashIndex validates capacity, probe bounds, and aliasing', async t => {
   t.end();
 });
 
+test('GPUHashIndex accepts empty explicit-value views at the end of their buffers', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const graph = new GPUCommandGraph(device);
+  const keysBuffer = createBuffer(device, Uint32Array.of(7), Buffer.STORAGE | Buffer.COPY_DST);
+  const valuesBuffer = createBuffer(device, Uint32Array.of(70), Buffer.STORAGE | Buffer.COPY_DST);
+  const tableKeysBuffer = createOutputBuffer(device, 4);
+  const tableValuesBuffer = createOutputBuffer(device, 4);
+  const statisticsBuffer = createOutputBuffer(device, 6);
+  const keyHandle = graph.importBuffer(
+    {id: 'empty-keys', byteLength: keysBuffer.byteLength, usage: keysBuffer.usage},
+    keysBuffer
+  );
+  const valueHandle = graph.importBuffer(
+    {id: 'empty-values', byteLength: valuesBuffer.byteLength, usage: valuesBuffer.usage},
+    valuesBuffer
+  );
+  new GPUHashIndex({
+    keys: graph.createDataView(keyHandle, {format: 'uint32', length: 0, byteOffset: 4}),
+    values: graph.createDataView(valueHandle, {format: 'uint32', length: 0, byteOffset: 4}),
+    tableKeys: importView(graph, 'empty-table-keys', tableKeysBuffer, 4),
+    tableValues: importView(graph, 'empty-table-values', tableValuesBuffer, 4),
+    statistics: importView(graph, 'empty-statistics', statisticsBuffer, 6)
+  }).addToGraph(graph);
+  const compiled = graph.compile();
+  const commandEncoder = device.createCommandEncoder();
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+
+  const tableBytes = await tableKeysBuffer.readAsync();
+  t.deepEqual(
+    Array.from(new Uint32Array(tableBytes.buffer, tableBytes.byteOffset, 4)),
+    Array.from({length: 4}, () => GPU_HASH_INDEX_EMPTY_KEY),
+    'an empty rebuild clears every table slot without binding empty source values'
+  );
+
+  compiled.destroy();
+  for (const buffer of [
+    keysBuffer,
+    valuesBuffer,
+    tableKeysBuffer,
+    tableValuesBuffer,
+    statisticsBuffer
+  ]) {
+    buffer.destroy();
+  }
+  t.end();
+});
+
 async function runHashIndex(
   device: Device,
   inputKeys: Uint32Array,

--- a/modules/experimental/test/gpu-primitives/gpu-scene-adapters.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-scene-adapters.spec.ts
@@ -75,7 +75,10 @@ test('GPU scene adapters preserve CPU identity and table batch topology without 
       makeSceneBatch(secondSource, 1)
     ]
   });
-  const adapted = makeGPUScenePartitionsFromGPUTable(device, table, {id: 'table-scene'});
+  const adapted = makeGPUScenePartitionsFromGPUTable(device, table, {
+    id: 'table-scene',
+    activeCounts: [1, 0, 1]
+  });
 
   t.deepEqual(
     adapted.partitions.map(partition => ({
@@ -114,6 +117,7 @@ test('GPU scene adapters preserve CPU identity and table batch topology without 
     [20],
     'later table partitions preserve their source records'
   );
+  t.equal(adapted.partitions[0]!.scene!.activeCount, 1, 'producer-known active counts are exact');
 
   const firstStateBuffer = adapted.partitions[0]!.scene!.stateBuffer;
   adapted.destroy();
@@ -165,7 +169,55 @@ test('GPU scene adapters reject ambiguous CPU and table storage contracts', asyn
     'one physical column cannot fill multiple scene roles'
   );
 
+  const validTable = new GPUTable({batches: [makeSceneBatch(source, 1)]});
+  t.throws(
+    () => makeGPUScenePartitionsFromGPUTable(device, validTable),
+    /exact active count per batch/,
+    'opaque table records require producer-known active-count metadata'
+  );
+  t.throws(
+    () => makeGPUScenePartitionsFromGPUTable(device, validTable, {activeCounts: [2]}),
+    /exact active count per batch/,
+    'active counts cannot exceed their physical batch size'
+  );
+
+  validTable.destroy();
   invalidTable.destroy();
+  source.destroy();
+  t.end();
+});
+
+test('GPU scene table adapters preserve exact active counts for batches with holes', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const bounds = {minimum: [0, 0, 0], maximum: [1, 1, 1]} as const;
+  const source = new GPUScene(device, {
+    records: [
+      {id: 1, bounds},
+      {id: 2, bounds}
+    ]
+  });
+  source.mutate({remove: [1]});
+  const table = new GPUTable({batches: [makeSceneBatch(source, 2)]});
+  const adapted = makeGPUScenePartitionsFromGPUTable(device, table, {activeCounts: [1]});
+  const scene = adapted.partitions[0]!.scene!;
+
+  t.equal(scene.recordCount, 2, 'the physical prefix retains its inactive hole');
+  t.equal(scene.activeCount, 1, 'only the producer-known live row contributes to activeCount');
+  const stateBytes = await scene.stateBuffer.readAsync();
+  t.deepEqual(
+    Array.from(new Uint32Array(stateBytes.buffer, stateBytes.byteOffset, 4)),
+    [2, 1, 0, 0],
+    'GPU state distinguishes physical prefix length from exact live count'
+  );
+
+  adapted.destroy();
+  table.destroy();
   source.destroy();
   t.end();
 });

--- a/modules/experimental/test/gpu-primitives/gpu-scene.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-scene.spec.ts
@@ -145,6 +145,27 @@ test('GPUScene validates identity, layout, and borrowed ownership', async t => {
     'transforms have a fixed layout'
   );
   t.throws(
+    () => new GPUScene(device, {capacity: 1, recordCount: 1}),
+    /requires records or pre-populated buffers/,
+    'an active prefix cannot be declared over newly allocated empty storage'
+  );
+  t.throws(
+    () =>
+      new GPUScene(device, {
+        records: [{id: 1, bounds: {minimum: [0, 0, 0], maximum: [1e100, 1, 1]}}]
+      }),
+    /finite ordered minima/,
+    'finite JavaScript bounds that overflow float32 are rejected'
+  );
+  t.throws(
+    () =>
+      new GPUScene(device, {
+        records: [{id: 1, bounds, transform: Array.from({length: 16}, () => 1e100)}]
+      }),
+    /16 finite values/,
+    'finite JavaScript transforms that overflow float32 are rejected'
+  );
+  t.throws(
     () =>
       new GPUScene(device, {
         capacity: 3,
@@ -221,6 +242,20 @@ test('GPUScene mutates holes, reports overflow, and compacts in stable slot orde
     stateBufferByteLength: 16,
     outputByteLength: 528
   });
+
+  const denseUpdate = scene.mutate({update: [{id: 30, geometryId: 17}], compact: true});
+  t.equal(denseUpdate.writeCount, 2, 'dense compacting updates upload their changed records');
+  t.equal(denseUpdate.uploadedByteLength, 272);
+  const updatedBytes = await scene.recordBuffer.readAsync();
+  t.equal(
+    new DataView(updatedBytes.buffer, updatedBytes.byteOffset).getUint32(12, true),
+    17,
+    'the GPU record reflects the dense compacting update'
+  );
+
+  const denseInsertion = scene.mutate({insert: [{id: 60, bounds}], compact: true});
+  t.equal(denseInsertion.writeCount, 2, 'dense compacting insertions upload their new tail');
+  t.deepEqual(await readSceneIds(scene, 3), [30, 50, 60]);
 
   scene.destroy();
   t.end();

--- a/modules/experimental/test/gpu-primitives/gpu-virtual-geometry-selection.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-virtual-geometry-selection.spec.ts
@@ -118,9 +118,17 @@ test('GPUVirtualGeometrySelection culls roots and deduplicates convergent activa
   );
   testCase.deepEqual(await readUint32(fixture.overflow, 1), [0]);
 
+  fixture.maximumScreenSpaceError.write(Float32Array.of(50));
+  encode(device, fixture.compiled);
+  testCase.deepEqual(
+    await readSelectedIds(fixture),
+    [101],
+    'a coarse shared parent suppresses children requested by another refining parent'
+  );
+
   testCase.equal(
     await destroyFixture(fixture),
-    2,
+    1,
     'destroying selector-owned storage does not destroy the draw command'
   );
   testCase.end();


### PR DESCRIPTION
## Goals

Close every unresolved actionable review thread across the already-merged GPU primitive roadmap while preserving explicit GPU ownership, capacity, and visibility contracts.

## Changes

- Fix dense `GPUScene` compacting updates/insertions, reject fabricated active prefixes and nonrepresentable float32 inputs, and require exact producer-provided active counts for zero-copy table partitions.
- Preserve the full uint32 stable-ID range in BVH queries and reject overlapping query/index/result storage.
- Reject FFT wrappers that alias the same physical GPU allocation.
- Preserve parent/child frontier exclusivity under convergent virtual-geometry child ranges and document the required world-space geometric-error units.
- Support empty hash-index value views at the end of their backing buffers and count-only zero-capacity hash-join output partitions.
- Add direct browser-backed regressions and update the relevant Overview/Concepts documentation for every corrected contract.

## Review threads addressed

Addresses unresolved feedback from merged PRs #2816, #2831, #2834, #2839, #2841, #2844, #2847, and #2851.

## Verification

- `yarn lint fix` — passed.
- `yarn build` — passed across every workspace package.
- Focused headless WebGPU coverage across BVH, FFT, scene, adapters, virtual geometry, hash indexing, hash joins, batch joins, and scene draw generation: **9 files, 28 tests passed**.
- Normal pre-commit Node suite: **78 files, 338 tests passed**.

Stacked on #2876.