### PR TITLE
Add candidate-driven trace range compaction

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -10,9 +10,9 @@ import {
   DrawCommandBuffer,
   GPUAncestorProjection,
   GPUCommandGraph,
-  GPUGroupAggregation,
   GPUGraphTraversal,
   GPUHierarchyLayout,
+  GPUIndexedRangeCompaction,
   GPUReadbackRing,
   GPUVisibilityWorkflow,
   GraphVectorView,
@@ -45,6 +45,7 @@ import {
   TRACE_LANE_COUNT,
   TRACE_LANES_PER_THREAD,
   TRACE_PROCESS_COUNT,
+  TRACE_SPAN_BATCH_CAPACITY,
   TRACE_STATUS_COUNT,
   TRACE_THREAD_COUNT,
   TRACE_THREADS_PER_PROCESS,
@@ -53,10 +54,14 @@ import {
 } from './trace-data';
 import {
   getBatchVisibilityShader,
+  getCandidateDensityShader,
+  getCandidateFocusShader,
+  getCandidatePickShader,
+  getCandidateVisibilityShader,
+  getDensityClearShader,
   getDependencyVisibilityShader,
-  getFocusMaskShader,
   getPickClearShader,
-  getVisibilityShader,
+  getTraceDrawCommandsShader,
   TRACE_DENSITY_RENDER_SHADER,
   TRACE_DEPENDENCY_RENDER_SHADER,
   TRACE_RENDER_SHADER
@@ -70,6 +75,9 @@ const DEFAULT_CAPACITY = 250_000;
 const DEFAULT_DEPENDENCY_CAPACITY = 250_000;
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 const TRACE_WORKGROUP_SIZE = 256;
+const TRACE_CANDIDATE_BATCH_WORKGROUP_COUNT = Math.ceil(
+  TRACE_SPAN_BATCH_CAPACITY / TRACE_WORKGROUP_SIZE
+);
 const VIEW_UNIFORM_BYTE_LENGTH = 64;
 const MAXIMUM_FOCUS_DEPTH = 4;
 const INVALID_SPAN_INDEX = TRACE_INVALID_SPAN_INDEX;
@@ -86,7 +94,6 @@ type TraceGroupResources = {
   name: TraceGroupName;
   count: number;
   firstSpanIndex: number;
-  visibleIds: Buffer;
 };
 
 type PickPosition = {
@@ -105,6 +112,7 @@ type TraceGraphResources = {
   spans: Buffer;
   spanBatchIndex: Buffer;
   candidateBatchIds: Buffer;
+  visibleSpanIds: Buffer;
   dependencies: Buffer;
   parentSpans: Buffer;
   outgoingOffsets: Buffer;
@@ -120,7 +128,7 @@ type TraceGraphResources = {
   traversalDepth: Buffer;
   reachedSpans: Buffer;
   visibleAncestors: Buffer;
-  focusMask: Buffer;
+  visibilityGeneration: Buffer;
   baseVisibility: Buffer;
   spanVisibility: Buffer;
   visibleDependencyIds: Buffer;
@@ -244,6 +252,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       this.view.timeMax = this.view.timeMin + windowSize;
     }
     const pick = this.pendingPick;
+    const visibilityGeneration = (this.frameIndex % 0xfffffffe) + 1;
+    resources.visibilityGeneration.write(Uint32Array.of(visibilityGeneration));
     this.writeViewUniforms(width, height, pick);
     const encoding = resources.compiled.encode(device.commandEncoder, {parameters: this.view});
     this.encodeTimeMilliseconds = encoding.stats.cpuEncodeTimeMilliseconds;
@@ -277,7 +287,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         candidateReadbackTicket.copyFrom(
           device.commandEncoder,
           resources.candidateDispatchCommands.buffer,
-          {byteLength: UINT32_BYTE_LENGTH}
+          {sourceOffset: UINT32_BYTE_LENGTH, byteLength: UINT32_BYTE_LENGTH}
         );
         queueMicrotask(() => {
           void this.sampleCandidateBatchCount(resources, candidateReadbackTicket);
@@ -397,12 +407,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     const groups = dataset.groups.map(group => ({
       name: group.name,
       count: group.count,
-      firstSpanIndex: group.firstSpanIndex,
-      visibleIds: this.device.createBuffer({
-        id: `gpu-trace-${group.name}-visible-ids`,
-        byteLength: Math.max(group.count, 1) * UINT32_BYTE_LENGTH,
-        usage: Buffer.STORAGE | Buffer.COPY_SRC
-      })
+      firstSpanIndex: group.firstSpanIndex
     }));
     const spanMaskByteLength = Math.max(dataset.spanCount, 1) * UINT32_BYTE_LENGTH;
     const dependencyMaskByteLength = Math.max(dataset.dependencyCount, 1) * UINT32_BYTE_LENGTH;
@@ -421,7 +426,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     });
     const candidateDispatchCommands = new DispatchCommandBuffer(this.device, {
       id: 'gpu-trace-candidate-dispatch-commands',
-      commands: [{x: 0, y: 1, z: 1}]
+      commands: [{x: TRACE_CANDIDATE_BATCH_WORKGROUP_COUNT, y: 0, z: 1}]
     });
     const readbackRing = new GPUReadbackRing(this.device, {
       id: 'gpu-trace-readback',
@@ -440,6 +445,11 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       candidateBatchIds: this.createStorageBuffer(
         'gpu-trace-candidate-batch-ids',
         dataset.spanBatches.length * UINT32_BYTE_LENGTH,
+        Buffer.COPY_SRC
+      ),
+      visibleSpanIds: this.createStorageBuffer(
+        'gpu-trace-visible-span-ids',
+        spanMaskByteLength,
         Buffer.COPY_SRC
       ),
       dependencies: this.createDataBuffer('gpu-trace-dependencies', dataset.dependencies),
@@ -480,7 +490,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         spanMaskByteLength,
         Buffer.COPY_SRC
       ),
-      focusMask: this.createStorageBuffer('gpu-trace-focus-mask', spanMaskByteLength),
+      visibilityGeneration: this.createDataBuffer(
+        'gpu-trace-visibility-generation',
+        Uint32Array.of(1)
+      ),
       baseVisibility: this.createStorageBuffer('gpu-trace-base-visibility', spanMaskByteLength),
       spanVisibility: this.createStorageBuffer('gpu-trace-span-visibility', spanMaskByteLength),
       visibleDependencyIds: this.createStorageBuffer(
@@ -542,6 +555,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         'candidate-dispatch-commands',
         resources.candidateDispatchCommands.buffer
       ),
+      visibleSpanIds: importTraceBuffer(graph, 'visible-span-ids', resources.visibleSpanIds),
       dependencies: importTraceBuffer(graph, 'dependencies', resources.dependencies),
       parentSpans: importTraceBuffer(graph, 'parent-spans', resources.parentSpans),
       outgoingOffsets: importTraceBuffer(graph, 'outgoing-offsets', resources.outgoingOffsets),
@@ -569,7 +583,11 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       traversalDepth: importTraceBuffer(graph, 'traversal-depth', resources.traversalDepth),
       reachedSpans: importTraceBuffer(graph, 'reached-spans', resources.reachedSpans),
       visibleAncestors: importTraceBuffer(graph, 'visible-ancestors', resources.visibleAncestors),
-      focusMask: importTraceBuffer(graph, 'focus-mask', resources.focusMask),
+      visibilityGeneration: importTraceBuffer(
+        graph,
+        'visibility-generation',
+        resources.visibilityGeneration
+      ),
       baseVisibility: importTraceBuffer(graph, 'base-visibility', resources.baseVisibility),
       spanVisibility: importTraceBuffer(graph, 'span-visibility', resources.spanVisibility),
       visibleDependencyIds: importTraceBuffer(
@@ -629,7 +647,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       }),
       count: graph.createDataView(handles.candidateDispatchCommands, {
         format: 'uint32',
-        length: 1
+        length: 1,
+        byteOffset: UINT32_BYTE_LENGTH
       })
     }).addToGraph(graph);
 
@@ -714,25 +733,129 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     }).addToGraph(graph);
 
     addTraceComputePass(graph, {
-      id: 'trace-focus-mask',
-      source: getFocusMaskShader(resources.spanCount),
-      bindings: [
-        storageRead('reachedSpans', handles.reachedSpans),
-        storageRead('activeSeedCount', handles.selectedSeedCount),
-        storageWrite('focusMask', handles.focusMask),
-        uniformBinding('viewUniforms', handles.uniforms)
-      ],
-      length: resources.spanCount
-    });
-    addTraceComputePass(graph, {
       id: 'trace-clear-pick',
       source: getPickClearShader(),
       bindings: [storageWrite('pickResult', handles.pickResult)],
       length: 1,
       workgroupSize: 1
     });
+    addTraceIndirectComputePass(graph, {
+      id: 'trace-candidate-span-visibility',
+      source: getCandidateVisibilityShader(),
+      bindings: [
+        storageRead('spans', handles.spans),
+        storageRead('spanBatches', handles.spanBatchIndex),
+        storageRead('candidateBatchIds', handles.candidateBatchIds),
+        uniformBinding('viewUniforms', handles.uniforms),
+        storageRead('processStates', handles.processStates),
+        storageRead('threadOffsets', handles.threadOffsets),
+        storageRead('threadStates', handles.threadStates),
+        storageWrite('visibilityFlags', handles.baseVisibility),
+        storageWrite('densityKeys', handles.densityKeys)
+      ],
+      dispatchBuffer: handles.candidateDispatchCommands
+    });
+    addTraceIndirectComputePass(graph, {
+      id: 'trace-candidate-focus',
+      source: getCandidateFocusShader(),
+      bindings: [
+        storageRead('spanBatches', handles.spanBatchIndex),
+        storageRead('candidateBatchIds', handles.candidateBatchIds),
+        storageRead('baseVisibility', handles.baseVisibility),
+        storageRead('reachedSpans', handles.reachedSpans),
+        storageRead('activeSeedCount', handles.selectedSeedCount),
+        storageRead('visibilityGeneration', handles.visibilityGeneration),
+        storageWrite('spanVisibility', handles.spanVisibility),
+        uniformBinding('viewUniforms', handles.uniforms)
+      ],
+      dispatchBuffer: handles.candidateDispatchCommands
+    });
+    addTraceComputePass(graph, {
+      id: 'trace-clear-density',
+      source: getDensityClearShader(),
+      bindings: [storageWrite('densityBins', handles.densityBins)],
+      length: TRACE_LANE_COUNT * TRACE_DENSITY_BIN_COUNT
+    });
+    addTraceIndirectComputePass(graph, {
+      id: 'trace-candidate-density',
+      source: getCandidateDensityShader(),
+      bindings: [
+        storageRead('spanBatches', handles.spanBatchIndex),
+        storageRead('candidateBatchIds', handles.candidateBatchIds),
+        storageRead('densityKeys', handles.densityKeys),
+        storageRead('reachedSpans', handles.reachedSpans),
+        storageRead('activeSeedCount', handles.selectedSeedCount),
+        storageWrite('densityBins', handles.densityBins),
+        uniformBinding('viewUniforms', handles.uniforms)
+      ],
+      dispatchBuffer: handles.candidateDispatchCommands
+    });
+    addTraceIndirectComputePass(graph, {
+      id: 'trace-candidate-pick',
+      source: getCandidatePickShader(),
+      bindings: [
+        storageRead('spans', handles.spans),
+        storageRead('spanBatches', handles.spanBatchIndex),
+        storageRead('candidateBatchIds', handles.candidateBatchIds),
+        uniformBinding('viewUniforms', handles.uniforms),
+        storageRead('processStates', handles.processStates),
+        storageRead('threadOffsets', handles.threadOffsets),
+        storageRead('threadStates', handles.threadStates),
+        storageWrite('pickResult', handles.pickResult)
+      ],
+      dispatchBuffer: handles.candidateDispatchCommands
+    });
+    const visibleSpanCountBuffer = graph.createTransientBuffer({
+      id: 'trace-visible-span-count',
+      byteLength: UINT32_BYTE_LENGTH,
+      usage: Buffer.STORAGE
+    });
+    const rangeCompaction = new GPUIndexedRangeCompaction({
+      id: 'trace-visible-spans',
+      flags: graph.createDataView(handles.spanVisibility, {
+        format: 'uint32',
+        length: resources.spanCount
+      }),
+      ranges: graph.createDataView(handles.spanBatchIndex, {
+        format: 'uint32',
+        length: resources.spanBatchCount * 8
+      }),
+      rangeCount: resources.spanBatchCount,
+      rangeLayout: {wordStride: 8, firstIndexWordOffset: 0, countWordOffset: 1},
+      activeRangeIds: graph.createDataView(handles.candidateBatchIds, {
+        format: 'uint32',
+        length: resources.spanBatchCount
+      }),
+      activeRangeDispatch: handles.candidateDispatchCommands,
+      maximumRangeLength: TRACE_SPAN_BATCH_CAPACITY,
+      output: graph.createDataView(handles.visibleSpanIds, {
+        format: 'uint32',
+        length: resources.spanCount
+      }),
+      count: graph.createDataView(visibleSpanCountBuffer, {format: 'uint32', length: 1})
+    }).addToGraph(graph);
+    const groupBatchRanges = resources.groups.map((_, groupIndex) => {
+      const firstBatchIndex = dataset.spanBatches.findIndex(
+        batch => batch.groupIndex === groupIndex
+      );
+      const batchCount = dataset.spanBatches.filter(
+        batch => batch.groupIndex === groupIndex
+      ).length;
+      return {firstBatchIndex, batchCount};
+    });
+    addTraceComputePass(graph, {
+      id: 'trace-publish-span-draw-commands',
+      source: getTraceDrawCommandsShader(groupBatchRanges),
+      bindings: [
+        storageRead('rangeCounts', rangeCompaction.rangeCounts.buffer),
+        storageRead('rangeOffsets', rangeCompaction.rangeOffsets.buffer),
+        storageWrite('drawCommands', handles.drawCommands)
+      ],
+      length: resources.groups.length
+    });
     const renderResources: GraphBufferUse[] = [
       {buffer: handles.spans, usage: 'storage-read'},
+      {buffer: handles.visibleSpanIds, usage: 'storage-read'},
       {buffer: handles.dependencies, usage: 'storage-read'},
       {buffer: handles.processStates, usage: 'storage-read'},
       {buffer: handles.threadStates, usage: 'storage-read'},
@@ -744,75 +867,6 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       {buffer: handles.drawCommands, usage: 'indirect'}
     ];
 
-    for (const [groupIndex, group] of resources.groups.entries()) {
-      const visibleIds = importTraceBuffer(graph, `${group.name}-visible-ids`, group.visibleIds);
-      renderResources.push({buffer: visibleIds, usage: 'storage-read'});
-      if (group.count > 0) {
-        addTraceComputePass(graph, {
-          id: `${group.name}-base-visibility`,
-          source: getVisibilityShader(group.count, groupIndex, group.firstSpanIndex),
-          bindings: [
-            storageRead('spans', handles.spans),
-            uniformBinding('viewUniforms', handles.uniforms),
-            storageRead('processStates', handles.processStates),
-            storageRead('threadOffsets', handles.threadOffsets),
-            storageRead('threadStates', handles.threadStates),
-            storageWrite('visibilityFlags', handles.baseVisibility),
-            storageWrite('pickResult', handles.pickResult),
-            storageWrite('densityKeys', handles.densityKeys)
-          ],
-          length: group.count
-        });
-      }
-      const byteOffset = group.firstSpanIndex * UINT32_BYTE_LENGTH;
-      const baseMask = graph.createDataView(handles.baseVisibility, {
-        format: 'uint32',
-        length: group.count,
-        byteOffset
-      });
-      const focusMask = graph.createDataView(handles.focusMask, {
-        format: 'uint32',
-        length: group.count,
-        byteOffset
-      });
-      const finalMask = graph.createDataView(handles.spanVisibility, {
-        format: 'uint32',
-        length: group.count,
-        byteOffset
-      });
-      new GPUVisibilityWorkflow({
-        id: `${group.name}-visibility`,
-        predicates: [
-          {kind: ['time-range', 'bounds', 'lod'], mask: baseMask},
-          {kind: 'selection', mask: focusMask}
-        ],
-        outputMask: finalMask,
-        output: graph.createDataView(visibleIds, {format: 'uint32', length: group.count}),
-        count: graph.createDataView(handles.drawCommands, {
-          format: 'uint32',
-          length: 1,
-          byteOffset: resources.drawCommands.getInstanceCountByteOffset(groupIndex)
-        }),
-        firstSourceIndex: group.firstSpanIndex
-      }).addToGraph(graph);
-    }
-
-    new GPUGroupAggregation({
-      id: 'trace-density',
-      keys: graph.createDataView(handles.densityKeys, {
-        format: 'uint32',
-        length: resources.spanCount
-      }),
-      mask: graph.createDataView(handles.focusMask, {
-        format: 'uint32',
-        length: resources.spanCount
-      }),
-      output: graph.createDataView(handles.densityBins, {
-        format: 'uint32',
-        length: TRACE_LANE_COUNT * TRACE_DENSITY_BIN_COUNT
-      })
-    }).addToGraph(graph);
-
     new GPUAncestorProjection({
       id: 'trace-visible-ancestor-projection',
       parents: graph.createDataView(handles.parentSpans, {
@@ -822,6 +876,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       visibility: graph.createDataView(handles.spanVisibility, {
         format: 'uint32',
         length: resources.spanCount
+      }),
+      visibilityValue: graph.createDataView(handles.visibilityGeneration, {
+        format: 'uint32',
+        length: 1
       }),
       output: graph.createDataView(handles.visibleAncestors, {
         format: 'uint32',
@@ -844,6 +902,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
           storageRead('spanVisibility', handles.spanVisibility),
           storageRead('processStates', handles.processStates),
           storageRead('visibleAncestors', handles.visibleAncestors),
+          storageRead('visibilityGeneration', handles.visibilityGeneration),
           uniformBinding('viewUniforms', handles.uniforms),
           storageWrite('dependencyFlags', dependencyFlags)
         ],
@@ -898,10 +957,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     });
     encoder.setPipeline(this.model.pipeline);
     encoder.setVertexArray(this.model.vertexArray);
-    for (const [groupIndex, group] of resources.groups.entries()) {
+    for (const [groupIndex] of resources.groups.entries()) {
       encoder.setBindings({
         spans: resources.spans,
-        visibleIds: group.visibleIds,
+        visibleIds: resources.visibleSpanIds,
         threadOffsets: resources.threadOffsets,
         threadStates: resources.threadStates,
         reachedSpans: resources.reachedSpans,
@@ -1040,13 +1099,11 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     resources.drawCommands.destroy();
     resources.candidateDispatchCommands.destroy();
     resources.readbackRing.destroy();
-    for (const group of resources.groups) {
-      group.visibleIds.destroy();
-    }
     for (const buffer of [
       resources.spans,
       resources.spanBatchIndex,
       resources.candidateBatchIds,
+      resources.visibleSpanIds,
       resources.dependencies,
       resources.parentSpans,
       resources.outgoingOffsets,
@@ -1062,7 +1119,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       resources.traversalDepth,
       resources.reachedSpans,
       resources.visibleAncestors,
-      resources.focusMask,
+      resources.visibilityGeneration,
       resources.baseVisibility,
       resources.spanVisibility,
       resources.visibleDependencyIds,
@@ -1622,6 +1679,49 @@ function addTraceComputePass<Parameters>(
             computePass,
             Math.ceil(props.length / (props.workgroupSize ?? TRACE_WORKGROUP_SIZE))
           );
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+/** Adds a candidate-driven kernel whose workgroup counts are published by an earlier GPU pass. */
+function addTraceIndirectComputePass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    source: string;
+    bindings: readonly TraceComputePassBinding[];
+    dispatchBuffer: GraphBufferHandle;
+  }
+): void {
+  graph.addComputePass({
+    id: props.id,
+    resources: [
+      ...props.bindings.map(binding => ({buffer: binding.buffer, usage: binding.usage})),
+      {buffer: props.dispatchBuffer, usage: 'indirect' as const}
+    ],
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: props.id,
+        source: props.source,
+        shaderLayout: {
+          bindings: props.bindings.map((binding, location) =>
+            binding.type === 'uniform'
+              ? {name: binding.name, type: 'uniform' as const, group: 0, location}
+              : {name: binding.name, type: 'storage' as const, group: 0, location}
+          )
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const binding of props.bindings) {
+            bindings[binding.name] = getBuffer(binding.buffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatchIndirect(computePass, getBuffer(props.dispatchBuffer));
         },
         destroy: () => computation.destroy()
       };

--- a/examples/experimental/gpu-trace-viewer/trace-data.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-data.ts
@@ -12,7 +12,8 @@ export const TRACE_LANE_COUNT = TRACE_THREAD_COUNT * TRACE_LANES_PER_THREAD;
 export const TRACE_SPAN_RECORD_WORD_LENGTH = 8;
 export const TRACE_DEPENDENCY_RECORD_WORD_LENGTH = 4;
 export const TRACE_SPAN_BATCH_RECORD_WORD_LENGTH = 8;
-export const TRACE_SPAN_BATCH_CAPACITY = 1_000_000;
+// One span batch maps to one portable WebGPU workgroup for candidate-driven local compaction.
+export const TRACE_SPAN_BATCH_CAPACITY = 256;
 const TRACE_DEMONSTRATION_CAPACITIES = [250_000, 1_000_000, 4_000_000, 10_000_000];
 // Keep density scrolling visually continuous at common viewport widths while retaining a fixed,
 // allocation-stable aggregation target for the compiled GPU command graph.

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -10,6 +10,7 @@ import {
   TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN,
   TRACE_FILTER_HIDE_RUNTIME_SPANS,
   TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS,
+  TRACE_LANE_COUNT,
   TRACE_LANES_PER_THREAD,
   TRACE_OVERLAPPING_CHILD_FLAG,
   TRACE_RUNTIME_SPAN_FLAG,
@@ -87,6 +88,35 @@ fn getCorner(vertexIndex: u32) -> vec2<f32> {
     vec2<f32>(1.0, 1.0)
   );
   return corners[vertexIndex];
+}`;
+
+const TRACE_VISIBILITY_FILTER_DECLARATIONS = /* wgsl */ `
+const RUNTIME_SPAN_FLAG: u32 = ${TRACE_RUNTIME_SPAN_FLAG}u;
+const ERROR_SPAN_FLAG: u32 = ${TRACE_ERROR_SPAN_FLAG}u;
+const OVERLAPPING_CHILD_FLAG: u32 = ${TRACE_OVERLAPPING_CHILD_FLAG}u;
+const SIMILAR_DURATION_PARENT_FLAG: u32 = ${TRACE_SIMILAR_DURATION_PARENT_FLAG}u;
+
+fn isSpanSourceVisible(span: TraceSpan, lane: f32) -> bool {
+  let end = span.start + span.duration;
+  let timeVisible = end >= viewUniforms.timeMin && span.start <= viewUniforms.timeMax;
+  let laneVisible = lane >= viewUniforms.laneMin && lane < viewUniforms.laneMax;
+  let groupVisible = (viewUniforms.enabledMask & (1u << span.group)) != 0u;
+  let statusVisible = (viewUniforms.statusMask & (1u << (span.flags & 3u))) != 0u;
+  let runtimeVisible =
+    (viewUniforms.activeFilterMask & ${TRACE_FILTER_HIDE_RUNTIME_SPANS}u) == 0u ||
+    (span.flags & RUNTIME_SPAN_FLAG) == 0u;
+  let errorVisible =
+    (viewUniforms.activeFilterMask & ${TRACE_FILTER_ERRORS_ONLY}u) == 0u ||
+    (span.flags & ERROR_SPAN_FLAG) != 0u;
+  let overlappingChildVisible =
+    (viewUniforms.activeFilterMask & ${TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN}u) == 0u ||
+    (span.flags & OVERLAPPING_CHILD_FLAG) == 0u;
+  let similarParentVisible =
+    (viewUniforms.activeFilterMask & ${TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS}u) == 0u ||
+    (span.flags & SIMILAR_DURATION_PARENT_FLAG) == 0u;
+  let durationVisible = span.duration >= viewUniforms.minimumDuration;
+  return timeVisible && laneVisible && groupVisible && statusVisible && runtimeVisible &&
+    errorVisible && overlappingChildVisible && similarParentVisible && durationVisible;
 }`;
 
 /** Indirect span renderer reading GPU-generated stable source IDs and thread layout. */
@@ -260,27 +290,6 @@ struct DensityVertexOutput {
   return input.color;
 }`;
 
-/** Turns a selected dependency-reachability mask into an optional all-span focus predicate. */
-export function getFocusMaskShader(spanCount: number): string {
-  return /* wgsl */ `
-${TRACE_SHADER_DECLARATIONS}
-const SPAN_COUNT: u32 = ${spanCount}u;
-@group(0) @binding(0) var<storage, read> reachedSpans: array<u32>;
-@group(0) @binding(1) var<storage, read> activeSeedCount: array<u32>;
-@group(0) @binding(2) var<storage, read_write> focusMask: array<u32>;
-@group(0) @binding(3) var<uniform> viewUniforms: ViewUniforms;
-
-@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let index = globalId.x;
-  if (index >= SPAN_COUNT) {
-    return;
-  }
-  let focusEnabled = viewUniforms.focusMode != 0u && activeSeedCount[0] != 0u;
-  focusMask[index] = select(1u, select(0u, 1u, reachedSpans[index] != 0u), focusEnabled);
-}`;
-}
-
 /** Coarsely rejects immutable span batches that cannot contribute to the active view. */
 export function getBatchVisibilityShader(batchCount: number): string {
   return /* wgsl */ `
@@ -314,64 +323,174 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
 }`;
 }
 
-/** Tests view, process, thread, status, duration, and source filters for one stable draw group. */
-export function getVisibilityShader(
-  spanCount: number,
-  groupIndex: number,
-  firstSpanIndex = 0
-): string {
+/** Applies focus policy and publishes generation-tagged exact visibility for candidate spans. */
+export function getCandidateFocusShader(): string {
   return /* wgsl */ `
 ${TRACE_SHADER_DECLARATIONS}
-const SPAN_COUNT: u32 = ${spanCount}u;
-const FIRST_SPAN_INDEX: u32 = ${firstSpanIndex}u;
-const GROUP_BIT: u32 = ${1 << groupIndex}u;
-const RUNTIME_SPAN_FLAG: u32 = ${TRACE_RUNTIME_SPAN_FLAG}u;
-const ERROR_SPAN_FLAG: u32 = ${TRACE_ERROR_SPAN_FLAG}u;
-const OVERLAPPING_CHILD_FLAG: u32 = ${TRACE_OVERLAPPING_CHILD_FLAG}u;
-const SIMILAR_DURATION_PARENT_FLAG: u32 = ${TRACE_SIMILAR_DURATION_PARENT_FLAG}u;
-@group(0) @binding(0) var<storage, read> spans: array<TraceSpan>;
-@group(0) @binding(1) var<uniform> viewUniforms: ViewUniforms;
-@group(0) @binding(2) var<storage, read> processStates: array<u32>;
-@group(0) @binding(3) var<storage, read> threadOffsets: array<u32>;
-@group(0) @binding(4) var<storage, read> threadStates: array<u32>;
-@group(0) @binding(5) var<storage, read_write> visibilityFlags: array<u32>;
-@group(0) @binding(6) var<storage, read_write> pickResult: array<atomic<u32>>;
-@group(0) @binding(7) var<storage, read_write> densityKeys: array<u32>;
+struct TraceSpanBatch {
+  firstSpanIndex: u32,
+  spanCount: u32,
+  timeMin: f32,
+  timeMax: f32,
+  laneMin: u32,
+  laneMax: u32,
+  groupIndex: u32,
+  batchIndex: u32,
+};
+@group(0) @binding(0) var<storage, read> spanBatches: array<TraceSpanBatch>;
+@group(0) @binding(1) var<storage, read> candidateBatchIds: array<u32>;
+@group(0) @binding(2) var<storage, read> baseVisibility: array<u32>;
+@group(0) @binding(3) var<storage, read> reachedSpans: array<u32>;
+@group(0) @binding(4) var<storage, read> activeSeedCount: array<u32>;
+@group(0) @binding(5) var<storage, read> visibilityGeneration: array<u32>;
+@group(0) @binding(6) var<storage, read_write> spanVisibility: array<u32>;
+@group(0) @binding(7) var<uniform> viewUniforms: ViewUniforms;
 
 @compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let groupRowIndex = globalId.x;
-  if (groupRowIndex >= SPAN_COUNT) {
+fn main(
+  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let batch = spanBatches[candidateBatchIds[workgroupId.y]];
+  if (localId.x >= batch.spanCount) {
     return;
   }
-  let sourceIndex = FIRST_SPAN_INDEX + groupRowIndex;
+  let sourceIndex = batch.firstSpanIndex + localId.x;
+  let focusEnabled = viewUniforms.focusMode != 0u && activeSeedCount[0] != 0u;
+  let focusVisible = !focusEnabled || reachedSpans[sourceIndex] != 0u;
+  let visible = baseVisibility[sourceIndex] != 0u && focusVisible;
+  spanVisibility[sourceIndex] = select(0u, visibilityGeneration[0], visible);
+}`;
+}
+
+/** Clears the fixed-size density target without touching source-aligned span storage. */
+export function getDensityClearShader(): string {
+  return /* wgsl */ `
+const DENSITY_BIN_COUNT: u32 = ${TRACE_LANE_COUNT * TRACE_DENSITY_BIN_COUNT}u;
+@group(0) @binding(0) var<storage, read_write> densityBins: array<u32>;
+@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  if (globalId.x < DENSITY_BIN_COUNT) {
+    densityBins[globalId.x] = 0u;
+  }
+}`;
+}
+
+/** Aggregates focused candidate density directly, avoiding a full-domain key scan. */
+export function getCandidateDensityShader(): string {
+  return /* wgsl */ `
+${TRACE_SHADER_DECLARATIONS}
+struct TraceSpanBatch {
+  firstSpanIndex: u32,
+  spanCount: u32,
+  timeMin: f32,
+  timeMax: f32,
+  laneMin: u32,
+  laneMax: u32,
+  groupIndex: u32,
+  batchIndex: u32,
+};
+@group(0) @binding(0) var<storage, read> spanBatches: array<TraceSpanBatch>;
+@group(0) @binding(1) var<storage, read> candidateBatchIds: array<u32>;
+@group(0) @binding(2) var<storage, read> densityKeys: array<u32>;
+@group(0) @binding(3) var<storage, read> reachedSpans: array<u32>;
+@group(0) @binding(4) var<storage, read> activeSeedCount: array<u32>;
+@group(0) @binding(5) var<storage, read_write> densityBins: array<atomic<u32>>;
+@group(0) @binding(6) var<uniform> viewUniforms: ViewUniforms;
+
+@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let batch = spanBatches[candidateBatchIds[workgroupId.y]];
+  if (localId.x >= batch.spanCount) {
+    return;
+  }
+  let sourceIndex = batch.firstSpanIndex + localId.x;
+  let focusEnabled = viewUniforms.focusMode != 0u && activeSeedCount[0] != 0u;
+  let focusVisible = !focusEnabled || reachedSpans[sourceIndex] != 0u;
+  let densityKey = densityKeys[sourceIndex];
+  if (focusVisible && densityKey != 0xffffffffu) {
+    atomicAdd(&densityBins[densityKey], 1u);
+  }
+}`;
+}
+
+/** Publishes stable global visible-ID slices into the per-group indirect draw commands. */
+export function getTraceDrawCommandsShader(
+  groupBatchRanges: readonly {firstBatchIndex: number; batchCount: number}[]
+): string {
+  const firstBatchIndices = groupBatchRanges.map(range => `${range.firstBatchIndex}u`).join(', ');
+  const lastBatchIndices = groupBatchRanges
+    .map(range => `${range.firstBatchIndex + range.batchCount - 1}u`)
+    .join(', ');
+  return /* wgsl */ `
+const GROUP_COUNT: u32 = ${groupBatchRanges.length}u;
+const FIRST_BATCH_INDICES = array<u32, ${groupBatchRanges.length}>(${firstBatchIndices});
+const LAST_BATCH_INDICES = array<u32, ${groupBatchRanges.length}>(${lastBatchIndices});
+@group(0) @binding(0) var<storage, read> rangeCounts: array<u32>;
+@group(0) @binding(1) var<storage, read> rangeOffsets: array<u32>;
+@group(0) @binding(2) var<storage, read_write> drawCommands: array<u32>;
+@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let groupIndex = globalId.x;
+  if (groupIndex >= GROUP_COUNT) {
+    return;
+  }
+  let firstBatchIndex = FIRST_BATCH_INDICES[groupIndex];
+  let lastBatchIndex = LAST_BATCH_INDICES[groupIndex];
+  let firstInstance = rangeOffsets[firstBatchIndex];
+  let endInstance = rangeOffsets[lastBatchIndex] + rangeCounts[lastBatchIndex];
+  let commandOffset = groupIndex * 4u;
+  drawCommands[commandOffset + 1u] = endInstance - firstInstance;
+  drawCommands[commandOffset + 3u] = firstInstance;
+}`;
+}
+
+/** Tests exact span predicates only inside the compacted list of candidate batches. */
+export function getCandidateVisibilityShader(): string {
+  return /* wgsl */ `
+${TRACE_SHADER_DECLARATIONS}
+struct TraceSpanBatch {
+  firstSpanIndex: u32,
+  spanCount: u32,
+  timeMin: f32,
+  timeMax: f32,
+  laneMin: u32,
+  laneMax: u32,
+  groupIndex: u32,
+  batchIndex: u32,
+};
+${TRACE_VISIBILITY_FILTER_DECLARATIONS}
+@group(0) @binding(0) var<storage, read> spans: array<TraceSpan>;
+@group(0) @binding(1) var<storage, read> spanBatches: array<TraceSpanBatch>;
+@group(0) @binding(2) var<storage, read> candidateBatchIds: array<u32>;
+@group(0) @binding(3) var<uniform> viewUniforms: ViewUniforms;
+@group(0) @binding(4) var<storage, read> processStates: array<u32>;
+@group(0) @binding(5) var<storage, read> threadOffsets: array<u32>;
+@group(0) @binding(6) var<storage, read> threadStates: array<u32>;
+@group(0) @binding(7) var<storage, read_write> visibilityFlags: array<u32>;
+@group(0) @binding(8) var<storage, read_write> densityKeys: array<u32>;
+
+@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
+fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let batch = spanBatches[candidateBatchIds[workgroupId.y]];
+  let batchRowIndex = globalId.x;
+  if (batchRowIndex >= batch.spanCount) {
+    return;
+  }
+  let sourceIndex = batch.firstSpanIndex + batchRowIndex;
   let span = spans[sourceIndex];
-  let end = span.start + span.duration;
   let processExpanded = processStates[span.processIndex] != 0u;
   let localLane = select(0u, span.lane % LANES_PER_THREAD, threadStates[span.threadIndex] != 0u);
   let expandedLane = threadOffsets[span.threadIndex] + localLane;
   let collapsedLane = threadOffsets[span.processIndex * THREADS_PER_PROCESS];
   let lane = f32(select(collapsedLane, expandedLane, processExpanded));
-  let timeVisible = end >= viewUniforms.timeMin && span.start <= viewUniforms.timeMax;
-  let laneVisible = lane >= viewUniforms.laneMin && lane < viewUniforms.laneMax;
-  let groupVisible = (viewUniforms.enabledMask & GROUP_BIT) != 0u;
-  let statusVisible = (viewUniforms.statusMask & (1u << (span.flags & 3u))) != 0u;
-  let runtimeVisible =
-    (viewUniforms.activeFilterMask & ${TRACE_FILTER_HIDE_RUNTIME_SPANS}u) == 0u ||
-    (span.flags & RUNTIME_SPAN_FLAG) == 0u;
-  let errorVisible =
-    (viewUniforms.activeFilterMask & ${TRACE_FILTER_ERRORS_ONLY}u) == 0u ||
-    (span.flags & ERROR_SPAN_FLAG) != 0u;
-  let overlappingChildVisible =
-    (viewUniforms.activeFilterMask & ${TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN}u) == 0u ||
-    (span.flags & OVERLAPPING_CHILD_FLAG) == 0u;
-  let similarParentVisible =
-    (viewUniforms.activeFilterMask & ${TRACE_FILTER_HIDE_SIMILAR_DURATION_PARENTS}u) == 0u ||
-    (span.flags & SIMILAR_DURATION_PARENT_FLAG) == 0u;
-  let durationVisible = span.duration >= viewUniforms.minimumDuration;
-  let sourceVisible = timeVisible && laneVisible && groupVisible &&
-    statusVisible && runtimeVisible && errorVisible && overlappingChildVisible &&
-    similarParentVisible && durationVisible;
+  let sourceVisible = isSpanSourceVisible(span, lane);
   let densityMode = isDensityMode();
   let exactVisible = sourceVisible && processExpanded && !densityMode;
   visibilityFlags[sourceIndex] = select(0u, 1u, exactVisible);
@@ -381,11 +500,58 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let densityKey = u32(lane) * ${TRACE_DENSITY_BIN_COUNT}u + bin;
   let densityVisible = sourceVisible && (densityMode || !processExpanded);
   densityKeys[sourceIndex] = select(0xffffffffu, densityKey, densityVisible);
-  let pickRequested = viewUniforms.pickLane >= 0.0;
-  let timePicked = viewUniforms.pickTime >= span.start &&
-    viewUniforms.pickTime <= span.start + span.duration;
+}`;
+}
+
+/** Resolves explicit picking inside the same compacted candidate batches as classification. */
+export function getCandidatePickShader(): string {
+  return /* wgsl */ `
+${TRACE_SHADER_DECLARATIONS}
+struct TraceSpanBatch {
+  firstSpanIndex: u32,
+  spanCount: u32,
+  timeMin: f32,
+  timeMax: f32,
+  laneMin: u32,
+  laneMax: u32,
+  groupIndex: u32,
+  batchIndex: u32,
+};
+${TRACE_VISIBILITY_FILTER_DECLARATIONS}
+@group(0) @binding(0) var<storage, read> spans: array<TraceSpan>;
+@group(0) @binding(1) var<storage, read> spanBatches: array<TraceSpanBatch>;
+@group(0) @binding(2) var<storage, read> candidateBatchIds: array<u32>;
+@group(0) @binding(3) var<uniform> viewUniforms: ViewUniforms;
+@group(0) @binding(4) var<storage, read> processStates: array<u32>;
+@group(0) @binding(5) var<storage, read> threadOffsets: array<u32>;
+@group(0) @binding(6) var<storage, read> threadStates: array<u32>;
+@group(0) @binding(7) var<storage, read_write> pickResult: array<atomic<u32>>;
+
+@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
+fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  if (viewUniforms.pickLane < 0.0) {
+    return;
+  }
+  let batch = spanBatches[candidateBatchIds[workgroupId.y]];
+  let batchRowIndex = globalId.x;
+  if (batchRowIndex >= batch.spanCount) {
+    return;
+  }
+  let sourceIndex = batch.firstSpanIndex + batchRowIndex;
+  let span = spans[sourceIndex];
+  let processExpanded = processStates[span.processIndex] != 0u;
+  let localLane = select(0u, span.lane % LANES_PER_THREAD, threadStates[span.threadIndex] != 0u);
+  let expandedLane = threadOffsets[span.threadIndex] + localLane;
+  let collapsedLane = threadOffsets[span.processIndex * THREADS_PER_PROCESS];
+  let lane = f32(select(collapsedLane, expandedLane, processExpanded));
+  let end = span.start + span.duration;
+  let sourceVisible = isSpanSourceVisible(span, lane);
+  let timePicked = viewUniforms.pickTime >= span.start && viewUniforms.pickTime <= end;
   let lanePicked = viewUniforms.pickLane >= lane && viewUniforms.pickLane < lane + 1.0;
-  if (sourceVisible && pickRequested && timePicked && lanePicked) {
+  if (sourceVisible && timePicked && lanePicked) {
     atomicMin(&pickResult[0], sourceIndex);
   }
 }`;
@@ -412,8 +578,9 @@ const DEPENDENCY_COUNT: u32 = ${dependencyCount}u;
 @group(0) @binding(2) var<storage, read> spanVisibility: array<u32>;
 @group(0) @binding(3) var<storage, read> processStates: array<u32>;
 @group(0) @binding(4) var<storage, read> visibleAncestors: array<u32>;
-@group(0) @binding(5) var<uniform> viewUniforms: ViewUniforms;
-@group(0) @binding(6) var<storage, read_write> dependencyFlags: array<u32>;
+@group(0) @binding(5) var<storage, read> visibilityGeneration: array<u32>;
+@group(0) @binding(6) var<uniform> viewUniforms: ViewUniforms;
+@group(0) @binding(7) var<storage, read_write> dependencyFlags: array<u32>;
 
 @compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
 fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
@@ -430,10 +597,10 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   let destinationCollapsed = processStates[destination.processIndex] == 0u;
   let familyVisible = (viewUniforms.dependencyMask & (1u << dependency.family)) != 0u;
   let sourceVisible =
-    spanVisibility[dependency.sourceIndex] != 0u || sourceCollapsed ||
+    spanVisibility[dependency.sourceIndex] == visibilityGeneration[0] || sourceCollapsed ||
     projectedSource != 0xffffffffu;
   let destinationVisible =
-    spanVisibility[dependency.destinationIndex] != 0u ||
+    spanVisibility[dependency.destinationIndex] == visibilityGeneration[0] ||
     destinationCollapsed || projectedDestination != 0xffffffffu;
   let effectiveSource = select(projectedSource, dependency.sourceIndex, sourceCollapsed);
   let effectiveDestination = select(

--- a/modules/experimental/src/gpu-primitives/gpu-ancestor-projection.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-ancestor-projection.ts
@@ -23,6 +23,8 @@ export type GPUAncestorProjectionProps = {
   parents: GraphDataView<'uint32'>;
   /** Current source-aligned, zero/nonzero visibility mask. */
   visibility: GraphDataView<'uint32'>;
+  /** Optional one-row value that marks currently visible entries instead of any nonzero value. */
+  visibilityValue?: GraphDataView<'uint32'>;
   /** Caller-owned nearest-visible source index per node. */
   output: GraphDataView<'uint32'>;
   /** Maximum number of hidden canonical parent edges to follow. Defaults to 32. */
@@ -45,6 +47,8 @@ export class GPUAncestorProjection {
   readonly parents: GraphDataView<'uint32'>;
   /** Current source-aligned visibility mask. */
   readonly visibility: GraphDataView<'uint32'>;
+  /** Optional exact visibility value, useful for generation-tagged sparse masks. */
+  readonly visibilityValue?: GraphDataView<'uint32'>;
   /** Caller-owned resolved source IDs. */
   readonly output: GraphDataView<'uint32'>;
   /** Maximum number of ancestry edges visited per source row. */
@@ -56,6 +60,7 @@ export class GPUAncestorProjection {
     this.id = props.id ?? 'gpu-ancestor-projection';
     this.parents = props.parents;
     this.visibility = props.visibility;
+    this.visibilityValue = props.visibilityValue;
     this.output = props.output;
     this.maxDepth = props.maxDepth ?? 32;
     this.invalidValue = props.invalidValue ?? DEFAULT_INVALID_ANCESTOR;
@@ -71,6 +76,12 @@ export class GPUAncestorProjection {
       this.visibility.length !== this.output.length
     ) {
       throw new Error(`${this.id} parents, visibility, and output must have matching lengths`);
+    }
+    if (this.visibilityValue) {
+      validatePackedUint32View(this.visibilityValue, `${this.id} visibilityValue`);
+      if (this.visibilityValue.length < 1) {
+        throw new Error(`${this.id} visibilityValue must contain one uint32 row`);
+      }
     }
     if (!Number.isSafeInteger(this.maxDepth) || this.maxDepth < 0) {
       throw new Error(`${this.id} maxDepth must be a nonnegative safe integer`);
@@ -98,7 +109,8 @@ export class GPUAncestorProjection {
     if (
       this.parents.buffer.graph !== graph ||
       this.visibility.buffer.graph !== graph ||
-      this.output.buffer.graph !== graph
+      this.output.buffer.graph !== graph ||
+      (this.visibilityValue && this.visibilityValue.buffer.graph !== graph)
     ) {
       throw new Error(`${this.id} views must belong to the target graph`);
     }
@@ -112,10 +124,16 @@ const MAX_DEPTH: u32 = ${this.maxDepth}u;
 const INVALID_ANCESTOR: u32 = ${this.invalidValue}u;
 const PARENTS_OFFSET: u32 = ${getViewElementOffset(this.parents)}u;
 const VISIBILITY_OFFSET: u32 = ${getViewElementOffset(this.visibility)}u;
+${this.visibilityValue ? `const VISIBILITY_VALUE_OFFSET: u32 = ${getViewElementOffset(this.visibilityValue)}u;` : ''}
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(this.output)}u;
 @group(0) @binding(0) var<storage, read> parents: array<u32>;
 @group(0) @binding(1) var<storage, read> visibility: array<u32>;
 @group(0) @binding(2) var<storage, read_write> projectedAncestors: array<u32>;
+${this.visibilityValue ? '@group(0) @binding(3) var<storage, read> visibilityValue: array<u32>;' : ''}
+
+fn isVisible(index: u32) -> bool {
+  ${this.visibilityValue ? 'return visibility[VISIBILITY_OFFSET + index] == visibilityValue[VISIBILITY_VALUE_OFFSET];' : 'return visibility[VISIBILITY_OFFSET + index] != 0u;'}
+}
 
 @compute @workgroup_size(${ANCESTOR_PROJECTION_WORKGROUP_SIZE})
 fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
@@ -123,7 +141,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   if (sourceIndex >= NODE_COUNT) {
     return;
   }
-  if (visibility[VISIBILITY_OFFSET + sourceIndex] != 0u) {
+  if (isVisible(sourceIndex)) {
     projectedAncestors[OUTPUT_OFFSET + sourceIndex] = sourceIndex;
     return;
   }
@@ -134,7 +152,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
       projectedAncestors[OUTPUT_OFFSET + sourceIndex] = INVALID_ANCESTOR;
       return;
     }
-    if (visibility[VISIBILITY_OFFSET + parentIndex] != 0u) {
+    if (isVisible(parentIndex)) {
       projectedAncestors[OUTPUT_OFFSET + sourceIndex] = parentIndex;
       return;
     }
@@ -145,14 +163,18 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
     const views = {
       parents: this.parents,
       visibility: this.visibility,
-      projectedAncestors: this.output
+      projectedAncestors: this.output,
+      ...(this.visibilityValue ? {visibilityValue: this.visibilityValue} : {})
     };
     graph.addComputePass({
       id: this.id,
       resources: [
         {buffer: this.parents, usage: 'storage-read'},
         {buffer: this.visibility, usage: 'storage-read'},
-        {buffer: this.output, usage: 'storage-write'}
+        {buffer: this.output, usage: 'storage-write'},
+        ...(this.visibilityValue
+          ? [{buffer: this.visibilityValue, usage: 'storage-read'} as const]
+          : [])
       ],
       compile: ({device}) => {
         const computation = new Computation(device, {

--- a/modules/experimental/src/gpu-primitives/gpu-indexed-range-compaction.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-indexed-range-compaction.ts
@@ -1,0 +1,494 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {type Binding, type Buffer, type Device} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {GPUCommandGraph, type GraphBufferHandle, type GraphDataView} from './gpu-command-graph';
+import {GPUScan} from './gpu-scan';
+import {
+  createTransientView,
+  getViewBinding,
+  getViewElementOffset,
+  validatePackedUint32View
+} from './graph-data-view-utils';
+
+const RANGE_COMPACTION_WORKGROUP_SIZE = 256;
+
+/** Packed record layout describing source ranges consumed by indexed range compaction. */
+export type GPUIndexedRangeLayout = {
+  /** Number of uint32 words in one range record. */
+  wordStride: number;
+  /** Word containing the first source index. */
+  firstIndexWordOffset: number;
+  /** Word containing the source row count. */
+  countWordOffset: number;
+};
+
+/** Properties for candidate-driven stable source-index compaction. */
+export type GPUIndexedRangeCompactionProps = {
+  /** Prefix for generated resources and graph nodes. */
+  id?: string;
+  /** Source-aligned zero/nonzero selection flags. */
+  flags: GraphDataView<'uint32'>;
+  /** Packed source-range records. */
+  ranges: GraphDataView<'uint32'>;
+  /** Number of range records. */
+  rangeCount: number;
+  /** Packed range-record layout. */
+  rangeLayout: GPUIndexedRangeLayout;
+  /** Stable compacted IDs of active range records. */
+  activeRangeIds: GraphDataView<'uint32'>;
+  /** Indirect dispatch whose X dimension is one and Y dimension is the active range count. */
+  activeRangeDispatch: GraphBufferHandle;
+  /** Maximum number of source rows in one range. Must not exceed 256. */
+  maximumRangeLength: number;
+  /** Destination for stable compacted source indices. */
+  output: GraphDataView<'uint32'>;
+  /** Destination whose first row receives the total selected count. */
+  count: GraphDataView<'uint32'>;
+};
+
+/** Graph-owned intermediate views exposed to downstream range-aware consumers. */
+export type GPUIndexedRangeCompactionResult = {
+  /** Source-aligned offsets within each active range. Only selected active rows are defined. */
+  localOffsets: GraphDataView<'uint32'>;
+  /** Selected row count for every range; inactive ranges contain zero. */
+  rangeCounts: GraphDataView<'uint32'>;
+  /** Exclusive selected-row offset for every range in canonical range order. */
+  rangeOffsets: GraphDataView<'uint32'>;
+};
+
+/**
+ * Stably compacts source indices from a GPU-generated list of active, non-overlapping ranges.
+ *
+ * One workgroup scans each active range locally. A small canonical-range scan then supplies stable
+ * global offsets before a second indirect pass scatters selected source IDs. Runtime work scales
+ * with active ranges plus the range index rather than the full source domain.
+ */
+export class GPUIndexedRangeCompaction {
+  readonly id: string;
+  readonly flags: GraphDataView<'uint32'>;
+  readonly ranges: GraphDataView<'uint32'>;
+  readonly rangeCount: number;
+  readonly rangeLayout: GPUIndexedRangeLayout;
+  readonly activeRangeIds: GraphDataView<'uint32'>;
+  readonly activeRangeDispatch: GraphBufferHandle;
+  readonly maximumRangeLength: number;
+  readonly output: GraphDataView<'uint32'>;
+  readonly count: GraphDataView<'uint32'>;
+
+  constructor(props: GPUIndexedRangeCompactionProps) {
+    this.id = props.id ?? 'gpu-indexed-range-compaction';
+    this.flags = props.flags;
+    this.ranges = props.ranges;
+    this.rangeCount = props.rangeCount;
+    this.rangeLayout = props.rangeLayout;
+    this.activeRangeIds = props.activeRangeIds;
+    this.activeRangeDispatch = props.activeRangeDispatch;
+    this.maximumRangeLength = props.maximumRangeLength;
+    this.output = props.output;
+    this.count = props.count;
+
+    for (const [name, view] of [
+      ['flags', this.flags],
+      ['ranges', this.ranges],
+      ['activeRangeIds', this.activeRangeIds],
+      ['output', this.output],
+      ['count', this.count]
+    ] as const) {
+      validatePackedUint32View(view, `${this.id} ${name}`);
+    }
+    if (!Number.isSafeInteger(this.rangeCount) || this.rangeCount < 1) {
+      throw new Error(`${this.id} rangeCount must be a positive safe integer`);
+    }
+    if (
+      !Number.isSafeInteger(this.maximumRangeLength) ||
+      this.maximumRangeLength < 1 ||
+      this.maximumRangeLength > RANGE_COMPACTION_WORKGROUP_SIZE
+    ) {
+      throw new Error(`${this.id} maximumRangeLength must be between 1 and 256`);
+    }
+    validateRangeLayout(this.id, this.rangeLayout);
+    if (this.ranges.length < this.rangeCount * this.rangeLayout.wordStride) {
+      throw new Error(`${this.id} ranges does not contain rangeCount records`);
+    }
+    if (this.activeRangeIds.length < this.rangeCount) {
+      throw new Error(`${this.id} activeRangeIds must have rangeCount capacity`);
+    }
+    if (this.output.length < this.flags.length) {
+      throw new Error(`${this.id} output must contain at least flags.length rows`);
+    }
+    if (this.count.length < 1) {
+      throw new Error(`${this.id} count must contain one uint32 row`);
+    }
+  }
+
+  /** Adds range clearing, local scans, canonical range scan, scatter, and count publication. */
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): GPUIndexedRangeCompactionResult {
+    for (const view of [this.flags, this.ranges, this.activeRangeIds, this.output, this.count]) {
+      if (view.buffer.graph !== graph) {
+        throw new Error(`${this.id} views must belong to the target graph`);
+      }
+    }
+    if (this.activeRangeDispatch.graph !== graph) {
+      throw new Error(`${this.id} activeRangeDispatch must belong to the target graph`);
+    }
+
+    const localOffsets = createTransientView(
+      graph,
+      `${this.id}-local-offsets`,
+      'uint32',
+      this.flags.length
+    );
+    const rangeCounts = createTransientView(
+      graph,
+      `${this.id}-range-counts`,
+      'uint32',
+      this.rangeCount
+    );
+    const rangeOffsets = createTransientView(
+      graph,
+      `${this.id}-range-offsets`,
+      'uint32',
+      this.rangeCount
+    );
+
+    addClearRangeCountsPass(graph, this.id, rangeCounts);
+    addLocalScanPass(graph, this, localOffsets, rangeCounts);
+    new GPUScan({
+      id: `${this.id}-range-scan`,
+      input: rangeCounts,
+      output: rangeOffsets
+    }).addToGraph(graph);
+    addScatterPass(graph, this, localOffsets, rangeOffsets);
+    addCountPass(graph, this.id, rangeCounts, rangeOffsets, this.count);
+    return {localOffsets, rangeCounts, rangeOffsets};
+  }
+}
+
+function validateRangeLayout(id: string, layout: GPUIndexedRangeLayout): void {
+  if (!Number.isSafeInteger(layout.wordStride) || layout.wordStride < 2) {
+    throw new Error(`${id} rangeLayout.wordStride must be at least two`);
+  }
+  for (const [name, offset] of [
+    ['firstIndexWordOffset', layout.firstIndexWordOffset],
+    ['countWordOffset', layout.countWordOffset]
+  ] as const) {
+    if (!Number.isSafeInteger(offset) || offset < 0 || offset >= layout.wordStride) {
+      throw new Error(`${id} rangeLayout.${name} must address one record word`);
+    }
+  }
+}
+
+function addClearRangeCountsPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  rangeCounts: GraphDataView<'uint32'>
+): void {
+  const passId = `${id}-clear-range-counts`;
+  const source = /* wgsl */ `
+const RANGE_COUNT: u32 = ${rangeCounts.length}u;
+const RANGE_COUNTS_OFFSET: u32 = ${getViewElementOffset(rangeCounts)}u;
+@group(0) @binding(0) var<storage, read_write> rangeCounts: array<u32>;
+@compute @workgroup_size(${RANGE_COMPACTION_WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  if (globalId.x < RANGE_COUNT) {
+    rangeCounts[RANGE_COUNTS_OFFSET + globalId.x] = 0u;
+  }
+}`;
+  addDirectPass(graph, {
+    id: passId,
+    source,
+    views: {rangeCounts},
+    resources: [{buffer: rangeCounts, usage: 'storage-write'}],
+    dispatchCount: Math.ceil(rangeCounts.length / RANGE_COMPACTION_WORKGROUP_SIZE)
+  });
+}
+
+function addLocalScanPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  compaction: GPUIndexedRangeCompaction,
+  localOffsets: GraphDataView<'uint32'>,
+  rangeCounts: GraphDataView<'uint32'>
+): void {
+  const {rangeLayout} = compaction;
+  const passId = `${compaction.id}-local-scan`;
+  const source = /* wgsl */ `
+const RANGE_COUNT: u32 = ${compaction.rangeCount}u;
+const RANGE_WORD_STRIDE: u32 = ${rangeLayout.wordStride}u;
+const RANGE_FIRST_WORD: u32 = ${rangeLayout.firstIndexWordOffset}u;
+const RANGE_COUNT_WORD: u32 = ${rangeLayout.countWordOffset}u;
+const FLAGS_OFFSET: u32 = ${getViewElementOffset(compaction.flags)}u;
+const RANGES_OFFSET: u32 = ${getViewElementOffset(compaction.ranges)}u;
+const ACTIVE_RANGE_IDS_OFFSET: u32 = ${getViewElementOffset(compaction.activeRangeIds)}u;
+const LOCAL_OFFSETS_OFFSET: u32 = ${getViewElementOffset(localOffsets)}u;
+const RANGE_COUNTS_OFFSET: u32 = ${getViewElementOffset(rangeCounts)}u;
+@group(0) @binding(0) var<storage, read> flags: array<u32>;
+@group(0) @binding(1) var<storage, read> ranges: array<u32>;
+@group(0) @binding(2) var<storage, read> activeRangeIds: array<u32>;
+@group(0) @binding(3) var<storage, read_write> localOffsets: array<u32>;
+@group(0) @binding(4) var<storage, read_write> rangeCounts: array<u32>;
+var<workgroup> prefixes: array<u32, ${RANGE_COMPACTION_WORKGROUP_SIZE}>;
+
+@compute @workgroup_size(${RANGE_COMPACTION_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let rangeId = activeRangeIds[ACTIVE_RANGE_IDS_OFFSET + workgroupId.y];
+  if (rangeId >= RANGE_COUNT) {
+    return;
+  }
+  let recordOffset = RANGES_OFFSET + rangeId * RANGE_WORD_STRIDE;
+  let firstIndex = ranges[recordOffset + RANGE_FIRST_WORD];
+  let elementCount = ranges[recordOffset + RANGE_COUNT_WORD];
+  let localIndex = localId.x;
+  var selected = 0u;
+  if (localIndex < elementCount && flags[FLAGS_OFFSET + firstIndex + localIndex] != 0u) {
+    selected = 1u;
+  }
+  prefixes[localIndex] = selected;
+  workgroupBarrier();
+
+  var step = 1u;
+  loop {
+    if (step >= ${RANGE_COMPACTION_WORKGROUP_SIZE}u) {
+      break;
+    }
+    var addend = 0u;
+    if (localIndex >= step) {
+      addend = prefixes[localIndex - step];
+    }
+    workgroupBarrier();
+    prefixes[localIndex] += addend;
+    workgroupBarrier();
+    step *= 2u;
+  }
+
+  if (localIndex < elementCount) {
+    localOffsets[LOCAL_OFFSETS_OFFSET + firstIndex + localIndex] =
+      prefixes[localIndex] - selected;
+  }
+  if (localIndex == 0u) {
+    var selectedCount = 0u;
+    if (elementCount != 0u) {
+      selectedCount = prefixes[elementCount - 1u];
+    }
+    rangeCounts[RANGE_COUNTS_OFFSET + rangeId] = selectedCount;
+  }
+}`;
+  addIndirectPass(graph, {
+    id: passId,
+    source,
+    views: {
+      flags: compaction.flags,
+      ranges: compaction.ranges,
+      activeRangeIds: compaction.activeRangeIds,
+      localOffsets,
+      rangeCounts
+    },
+    resources: [
+      {buffer: compaction.flags, usage: 'storage-read'},
+      {buffer: compaction.ranges, usage: 'storage-read'},
+      {buffer: compaction.activeRangeIds, usage: 'storage-read'},
+      {buffer: localOffsets, usage: 'storage-write'},
+      {buffer: rangeCounts, usage: 'storage-write'}
+    ],
+    dispatchBuffer: compaction.activeRangeDispatch
+  });
+}
+
+function addScatterPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  compaction: GPUIndexedRangeCompaction,
+  localOffsets: GraphDataView<'uint32'>,
+  rangeOffsets: GraphDataView<'uint32'>
+): void {
+  const {rangeLayout} = compaction;
+  const passId = `${compaction.id}-scatter`;
+  const source = /* wgsl */ `
+const RANGE_COUNT: u32 = ${compaction.rangeCount}u;
+const RANGE_WORD_STRIDE: u32 = ${rangeLayout.wordStride}u;
+const RANGE_FIRST_WORD: u32 = ${rangeLayout.firstIndexWordOffset}u;
+const RANGE_COUNT_WORD: u32 = ${rangeLayout.countWordOffset}u;
+const FLAGS_OFFSET: u32 = ${getViewElementOffset(compaction.flags)}u;
+const RANGES_OFFSET: u32 = ${getViewElementOffset(compaction.ranges)}u;
+const ACTIVE_RANGE_IDS_OFFSET: u32 = ${getViewElementOffset(compaction.activeRangeIds)}u;
+const LOCAL_OFFSETS_OFFSET: u32 = ${getViewElementOffset(localOffsets)}u;
+const RANGE_OFFSETS_OFFSET: u32 = ${getViewElementOffset(rangeOffsets)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(compaction.output)}u;
+@group(0) @binding(0) var<storage, read> flags: array<u32>;
+@group(0) @binding(1) var<storage, read> ranges: array<u32>;
+@group(0) @binding(2) var<storage, read> activeRangeIds: array<u32>;
+@group(0) @binding(3) var<storage, read> localOffsets: array<u32>;
+@group(0) @binding(4) var<storage, read> rangeOffsets: array<u32>;
+@group(0) @binding(5) var<storage, read_write> outputIds: array<u32>;
+
+@compute @workgroup_size(${RANGE_COMPACTION_WORKGROUP_SIZE})
+fn main(
+  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let rangeId = activeRangeIds[ACTIVE_RANGE_IDS_OFFSET + workgroupId.y];
+  if (rangeId >= RANGE_COUNT) {
+    return;
+  }
+  let recordOffset = RANGES_OFFSET + rangeId * RANGE_WORD_STRIDE;
+  let firstIndex = ranges[recordOffset + RANGE_FIRST_WORD];
+  let elementCount = ranges[recordOffset + RANGE_COUNT_WORD];
+  let localIndex = localId.x;
+  if (localIndex >= elementCount) {
+    return;
+  }
+  let sourceIndex = firstIndex + localIndex;
+  if (flags[FLAGS_OFFSET + sourceIndex] != 0u) {
+    let outputIndex = rangeOffsets[RANGE_OFFSETS_OFFSET + rangeId] +
+      localOffsets[LOCAL_OFFSETS_OFFSET + sourceIndex];
+    outputIds[OUTPUT_OFFSET + outputIndex] = sourceIndex;
+  }
+}`;
+  addIndirectPass(graph, {
+    id: passId,
+    source,
+    views: {
+      flags: compaction.flags,
+      ranges: compaction.ranges,
+      activeRangeIds: compaction.activeRangeIds,
+      localOffsets,
+      rangeOffsets,
+      outputIds: compaction.output
+    },
+    resources: [
+      {buffer: compaction.flags, usage: 'storage-read'},
+      {buffer: compaction.ranges, usage: 'storage-read'},
+      {buffer: compaction.activeRangeIds, usage: 'storage-read'},
+      {buffer: localOffsets, usage: 'storage-read'},
+      {buffer: rangeOffsets, usage: 'storage-read'},
+      {buffer: compaction.output, usage: 'storage-write'}
+    ],
+    dispatchBuffer: compaction.activeRangeDispatch
+  });
+}
+
+function addCountPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  rangeCounts: GraphDataView<'uint32'>,
+  rangeOffsets: GraphDataView<'uint32'>,
+  count: GraphDataView<'uint32'>
+): void {
+  const passId = `${id}-publish-count`;
+  const source = /* wgsl */ `
+const LAST_RANGE_INDEX: u32 = ${rangeCounts.length - 1}u;
+const RANGE_COUNTS_OFFSET: u32 = ${getViewElementOffset(rangeCounts)}u;
+const RANGE_OFFSETS_OFFSET: u32 = ${getViewElementOffset(rangeOffsets)}u;
+const COUNT_OFFSET: u32 = ${getViewElementOffset(count)}u;
+@group(0) @binding(0) var<storage, read> rangeCounts: array<u32>;
+@group(0) @binding(1) var<storage, read> rangeOffsets: array<u32>;
+@group(0) @binding(2) var<storage, read_write> outputCount: array<u32>;
+@compute @workgroup_size(1)
+fn main() {
+  outputCount[COUNT_OFFSET] = rangeOffsets[RANGE_OFFSETS_OFFSET + LAST_RANGE_INDEX] +
+    rangeCounts[RANGE_COUNTS_OFFSET + LAST_RANGE_INDEX];
+}`;
+  addDirectPass(graph, {
+    id: passId,
+    source,
+    views: {rangeCounts, rangeOffsets, outputCount: count},
+    resources: [
+      {buffer: rangeCounts, usage: 'storage-read'},
+      {buffer: rangeOffsets, usage: 'storage-read'},
+      {buffer: count, usage: 'storage-write'}
+    ],
+    dispatchCount: 1
+  });
+}
+
+type RangePassResource = {
+  buffer: GraphDataView;
+  usage: 'storage-read' | 'storage-write';
+};
+
+function addDirectPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    source: string;
+    views: Record<string, GraphDataView>;
+    resources: RangePassResource[];
+    dispatchCount: number;
+  }
+): void {
+  graph.addComputePass({
+    id: props.id,
+    resources: props.resources,
+    compile: ({device}) => {
+      const computation = makeComputation(device, props.id, props.source, props.views);
+      return {
+        encode: ({computePass, getBuffer}) => {
+          computation.setBindings(resolveBindings(props.views, getBuffer));
+          computation.dispatch(computePass, props.dispatchCount);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function addIndirectPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    source: string;
+    views: Record<string, GraphDataView>;
+    resources: RangePassResource[];
+    dispatchBuffer: GraphBufferHandle;
+  }
+): void {
+  graph.addComputePass({
+    id: props.id,
+    resources: [...props.resources, {buffer: props.dispatchBuffer, usage: 'indirect' as const}],
+    compile: ({device}) => {
+      const computation = makeComputation(device, props.id, props.source, props.views);
+      return {
+        encode: ({computePass, getBuffer}) => {
+          computation.setBindings(resolveBindings(props.views, getBuffer));
+          computation.dispatchIndirect(computePass, getBuffer(props.dispatchBuffer));
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function makeComputation(
+  device: Device,
+  id: string,
+  source: string,
+  views: Record<string, GraphDataView>
+): Computation {
+  return new Computation(device, {
+    id,
+    source,
+    shaderLayout: {
+      bindings: Object.keys(views).map((name, location) => ({
+        name,
+        type: 'storage' as const,
+        group: 0,
+        location
+      }))
+    }
+  });
+}
+
+function resolveBindings(
+  views: Record<string, GraphDataView>,
+  getBuffer: (handle: GraphBufferHandle | GraphDataView) => Buffer
+): Record<string, Binding> {
+  const bindings: Record<string, Binding> = {};
+  for (const [name, view] of Object.entries(views)) {
+    bindings[name] = getViewBinding(view, getBuffer);
+  }
+  return bindings;
+}

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -69,6 +69,12 @@ export {GPUScan} from './gpu-scan';
 export type {GPUScanInput, GPUScanProps} from './gpu-scan';
 export {GPUCompaction} from './gpu-compaction';
 export type {GPUCompactionInput, GPUCompactionProps} from './gpu-compaction';
+export {GPUIndexedRangeCompaction} from './gpu-indexed-range-compaction';
+export type {
+  GPUIndexedRangeCompactionProps,
+  GPUIndexedRangeCompactionResult,
+  GPUIndexedRangeLayout
+} from './gpu-indexed-range-compaction';
 export {GPUTextSelection} from './gpu-text-selection';
 export type {GPUTextSelectionProps} from './gpu-text-selection';
 

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -27,10 +27,14 @@ import {
 } from '../../examples/experimental/gpu-trace-viewer/trace-data';
 import {
   getBatchVisibilityShader,
+  getCandidateDensityShader,
+  getCandidateFocusShader,
+  getCandidatePickShader,
+  getCandidateVisibilityShader,
+  getDensityClearShader,
   getDependencyVisibilityShader,
-  getFocusMaskShader,
   getPickClearShader,
-  getVisibilityShader,
+  getTraceDrawCommandsShader,
   TRACE_DENSITY_RENDER_SHADER,
   TRACE_DEPENDENCY_RENDER_SHADER,
   TRACE_RENDER_SHADER
@@ -104,10 +108,17 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     TRACE_RENDER_SHADER,
     TRACE_DEPENDENCY_RENDER_SHADER,
     TRACE_DENSITY_RENDER_SHADER,
-    getFocusMaskShader(17),
     getBatchVisibilityShader(3),
     getPickClearShader(),
-    getVisibilityShader(17, 1, 5),
+    getCandidateVisibilityShader(),
+    getCandidateFocusShader(),
+    getDensityClearShader(),
+    getCandidateDensityShader(),
+    getCandidatePickShader(),
+    getTraceDrawCommandsShader([
+      {firstBatchIndex: 0, batchCount: 2},
+      {firstBatchIndex: 2, batchCount: 1}
+    ]),
     getDependencyVisibilityShader(11)
   ];
   for (const shader of shaders) {

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -42,6 +42,7 @@ describe('GPU hierarchical trace viewer', () => {
         resources: {
           candidateDispatchCommands: {buffer: {readAsync: () => Promise<Uint8Array>}};
           drawCommands: {buffer: {readAsync: () => Promise<Uint8Array>}};
+          visibleSpanIds: {readAsync: () => Promise<Uint8Array>};
           densityBins: {readAsync: () => Promise<Uint8Array>};
           reachedSpans: {
             readAsync: (byteOffset?: number, byteLength?: number) => Promise<Uint8Array>;
@@ -89,12 +90,28 @@ describe('GPU hierarchical trace viewer', () => {
       );
       expect(firstCounts[1] + firstCounts[5] + firstCounts[9]).toBeGreaterThan(0);
       expect(firstCounts[13]).toBeGreaterThan(0);
+      const visibleSpanBytes = await state.resources.visibleSpanIds.readAsync();
+      const visibleSpanIds = new Uint32Array(
+        visibleSpanBytes.buffer,
+        visibleSpanBytes.byteOffset,
+        visibleSpanBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+      );
+      for (let groupIndex = 0; groupIndex < 3; groupIndex++) {
+        const instanceCount = firstCounts[groupIndex * 4 + 1];
+        const firstInstance = firstCounts[groupIndex * 4 + 3];
+        const groupIds = Array.from(
+          visibleSpanIds.subarray(firstInstance, firstInstance + instanceCount)
+        );
+        expect(groupIds).toEqual([...groupIds].sort((left, right) => left - right));
+      }
       const candidateBytes = await state.resources.candidateDispatchCommands.buffer.readAsync();
-      const candidateCount = new Uint32Array(
+      const candidateDispatch = new Uint32Array(
         candidateBytes.buffer,
         candidateBytes.byteOffset,
-        1
-      )[0];
+        3
+      );
+      expect(candidateDispatch[0]).toBeGreaterThan(0);
+      const candidateCount = candidateDispatch[1];
       expect(candidateCount).toBeGreaterThan(0);
       expect(candidateCount).toBeLessThanOrEqual(state.resources.spanBatchCount);
 
@@ -107,7 +124,7 @@ describe('GPU hierarchical trace viewer', () => {
       const filteredCandidateBytes =
         await state.resources.candidateDispatchCommands.buffer.readAsync();
       expect(
-        new Uint32Array(filteredCandidateBytes.buffer, filteredCandidateBytes.byteOffset, 1)[0]
+        new Uint32Array(filteredCandidateBytes.buffer, filteredCandidateBytes.byteOffset, 3)[1]
       ).toBeLessThan(candidateCount);
       firstGroup!.checked = true;
       firstGroup!.dispatchEvent(new Event('change', {bubbles: true}));


### PR DESCRIPTION
## Summary

- add reusable `GPUIndexedRangeCompaction` for stable compaction from GPU-selected ranges
- drive trace classification, focus, density, picking, and span-ID scatter from candidate batches
- publish one stable visible-ID stream with GPU-generated per-group indirect draw slices
- support generation-tagged visibility in `GPUAncestorProjection`

## Why

The trace viewer's first candidate-index tranche avoided expensive classification outside visible batches, but still cleared and compacted the entire span domain every frame. At 10M spans, that O(total spans) housekeeping dominated scrolling. This moves steady-state span work to candidate ranges plus a small range-index scan.

## Implementation

- use 256-row span batches mapped to one portable WebGPU workgroup
- locally scan each active batch, scan compact batch counts, then stably scatter source IDs
- use generation-tagged visibility to avoid full-span clearing
- aggregate density directly from candidate batches
- populate indirect draw `instanceCount` and `firstInstance` for group slices
- stay within the portable eight-storage-buffer shader limit

## Validation

- `yarn lint fix` — passed
- `yarn build` — passed
- trace WGSL/node suite — 9 passed
- isolated WebGPU trace-viewer test — passed; validates candidate pruning and stable group-ordered visible IDs
- `yarn test` — Node: 341 passed, 2 skipped; browser: 1423 passed, 25 skipped, with three unrelated failures in the volumetric-fire and Arrow-layers suites

## Follow-up

Candidate-driven dependency filtering remains the next tranche; dependencies are now the dominant full-domain pass at 10M spans.