### PR TITLE
refactor(shadertools): split shader assemblers by language

### DIFF
--- a/docs/api-guide/shaders/writing-customizable-shaders.md
+++ b/docs/api-guide/shaders/writing-customizable-shaders.md
@@ -33,7 +33,7 @@ A hook has three parts:
 ```typescript
 import {ShaderAssembler} from '@luma.gl/shadertools';
 
-const shaderAssembler = ShaderAssembler.getDefaultShaderAssembler();
+const shaderAssembler = ShaderAssembler.getDefaultShaderAssembler('glsl');
 shaderAssembler.addShaderHook('vs:OFFSET_POSITION(inout vec4 position)');
 ```
 

--- a/docs/api-reference/shadertools/shader-assembler.md
+++ b/docs/api-reference/shadertools/shader-assembler.md
@@ -29,7 +29,7 @@ import {
   WGSLShaderAssembler
 } from '@luma.gl/shadertools';
 
-const glslShaderAssembler = ShaderAssembler.getDefaultShaderAssembler();
+const glslShaderAssembler = ShaderAssembler.getDefaultShaderAssembler('glsl');
 glslShaderAssembler.addShaderHook('vs:OFFSET_POSITION(inout vec4 position)');
 
 const assembledShaders = glslShaderAssembler.assembleGLSLShaderPair({
@@ -74,15 +74,14 @@ Common assembly props:
 
 ## Static Methods
 
-### `getDefaultShaderAssembler(): GLSLShaderAssembler`
-
 ### `getDefaultShaderAssembler('glsl'): GLSLShaderAssembler`
 
 ### `getDefaultShaderAssembler('wgsl'): WGSLShaderAssembler`
 
-Returns the shared assembler for the requested shader language. Omitting the
-argument preserves the existing GLSL default. The WGSL default is a separate
-instance, so registering WGSL hooks cannot overwrite or remove GLSL hooks.
+Returns the shared assembler for the explicitly requested shader language. The
+language argument is required. GLSL and WGSL use separate instances, so
+registering hooks for one language cannot overwrite or remove hooks for the
+other.
 
 ## Methods
 

--- a/docs/api-reference/shadertools/shader-assembler.md
+++ b/docs/api-reference/shadertools/shader-assembler.md
@@ -4,10 +4,15 @@ import {ShadertoolsDocsTabs} from '@site/src/components/docs/shadertools-docs-ta
 
 <ShadertoolsDocsTabs active="shader-assembler" />
 
-`ShaderAssembler` combines application shader source with shadertools modules,
-hook functions, and injections before luma.gl creates shader resources. Use
-`assembleGLSLShaderPair()` for WebGL/GLSL and `assembleWGSLShader()` for unified
-WGSL used by WebGPU.
+`ShaderAssembler` is the abstract base for stateful shader assembly. Its concrete
+subclasses combine application shader source with shadertools modules, hook
+functions, and injections before luma.gl creates shader resources:
+
+- `GLSLShaderAssembler` assembles GLSL vertex and fragment shaders for WebGL.
+- `WGSLShaderAssembler` assembles unified WGSL shaders for WebGPU.
+
+Each shader language has its own default assembler, keeping language-specific
+hooks, default modules, and other assembly state isolated.
 
 For the assembly model, see
 [Shader Assembly](/docs/api-guide/shaders/shader-assembly). For extension design,
@@ -18,17 +23,31 @@ For WGSL binding relocation and conditionals, see
 ## Usage
 
 ```typescript
-import {ShaderAssembler} from '@luma.gl/shadertools';
+import {
+  GLSLShaderAssembler,
+  ShaderAssembler,
+  WGSLShaderAssembler
+} from '@luma.gl/shadertools';
 
-const shaderAssembler = ShaderAssembler.getDefaultShaderAssembler();
-shaderAssembler.addShaderHook('vs:OFFSET_POSITION(inout vec4 position)');
+const glslShaderAssembler = ShaderAssembler.getDefaultShaderAssembler();
+glslShaderAssembler.addShaderHook('vs:OFFSET_POSITION(inout vec4 position)');
 
-const assembledShaders = shaderAssembler.assembleGLSLShaderPair({
-  platformInfo,
+const assembledShaders = glslShaderAssembler.assembleGLSLShaderPair({
+  platformInfo: glslPlatformInfo,
   vs: vertexShaderSource,
   fs: fragmentShaderSource,
   modules: [offsetLeftModule]
 });
+
+const wgslShaderAssembler = ShaderAssembler.getDefaultShaderAssembler('wgsl');
+const assembledWGSLShader = wgslShaderAssembler.assembleWGSLShader({
+  platformInfo: wgslPlatformInfo,
+  source: wgslShaderSource,
+  modules: [offsetLeftModule]
+});
+
+const isolatedGLSLShaderAssembler = new GLSLShaderAssembler();
+const isolatedWGSLShaderAssembler = new WGSLShaderAssembler();
 ```
 
 ## Types
@@ -55,9 +74,15 @@ Common assembly props:
 
 ## Static Methods
 
-### `getDefaultShaderAssembler(): ShaderAssembler`
+### `getDefaultShaderAssembler(): GLSLShaderAssembler`
 
-Returns the shared assembler used by default by engine classes.
+### `getDefaultShaderAssembler('glsl'): GLSLShaderAssembler`
+
+### `getDefaultShaderAssembler('wgsl'): WGSLShaderAssembler`
+
+Returns the shared assembler for the requested shader language. Omitting the
+argument preserves the existing GLSL default. The WGSL default is a separate
+instance, so registering WGSL hooks cannot overwrite or remove GLSL hooks.
 
 ## Methods
 
@@ -77,12 +102,12 @@ hook signatures use GLSL syntax, for example
 `vs:OFFSET_POSITION(inout vec4 position)`. WGSL hook signatures use WGSL syntax,
 for example `vs:OFFSET_POSITION(position: ptr<function, vec4<f32>>)`.
 
-### `assembleGLSLShaderPair(props: AssembleShaderProps)`
+### `GLSLShaderAssembler.assembleGLSLShaderPair(props: AssembleShaderProps)`
 
 Assembles a GLSL vertex/fragment pair and returns `{vs, fs, getUniforms,
 modules}`.
 
-### `assembleWGSLShader(props: AssembleShaderProps)`
+### `WGSLShaderAssembler.assembleWGSLShader(props: AssembleShaderProps)`
 
 Assembles one unified WGSL source string and returns `{source, getUniforms,
 modules, bindingAssignments, bindingTable}`. Module WGSL source is prepended to
@@ -98,7 +123,7 @@ function, and lets modules or plugin contributions add ordered source by using
 the same stage-prefixed key without the function signature.
 
 ```typescript
-shaderAssembler.addShaderHook('vs:OFFSET_POSITION(inout vec4 position)');
+glslShaderAssembler.addShaderHook('vs:OFFSET_POSITION(inout vec4 position)');
 
 const offsetLeftModule = {
   name: 'offsetLeft',
@@ -119,7 +144,7 @@ If no module injects into a hook, the generated hook function is a no-op. WGSL
 uses the same flow with WGSL hook signatures and pointer arguments:
 
 ```typescript
-shaderAssembler.addShaderHook('vs:OFFSET_POSITION(position: ptr<function, vec4<f32>>)');
+wgslShaderAssembler.addShaderHook('vs:OFFSET_POSITION(position: ptr<function, vec4<f32>>)');
 ```
 
 ```wgsl

--- a/docs/tutorials/shader-hooks.mdx
+++ b/docs/tutorials/shader-hooks.mdx
@@ -93,7 +93,7 @@ class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       throw new Error('This demo is only implemented for WebGL2');
     }
 
-    const shaderAssembler = ShaderAssembler.getDefaultShaderAssembler();
+    const shaderAssembler = ShaderAssembler.getDefaultShaderAssembler('glsl');
     shaderAssembler.addShaderHook('vs:OFFSET_POSITION(inout vec4 position)');
 
     this.positionBuffer = device.createBuffer(new Float32Array([-0.3, -0.5, 0.3, -0.5, 0.0, 0.5]));

--- a/docs/tutorials/shader-plugins.mdx
+++ b/docs/tutorials/shader-plugins.mdx
@@ -139,7 +139,9 @@ CLIP_COLOR(&color);
 The hook signatures are registered for the active shader language:
 
 ```ts
-const shaderAssembler = new ShaderAssembler();
+import {GLSLShaderAssembler} from '@luma.gl/shadertools';
+
+const shaderAssembler = new GLSLShaderAssembler();
 
 shaderAssembler.addShaderHook(
   'vs:CLIP_POSITION(inout vec4 position, vec2 instanceCoordinates, vec2 geometryCoordinates)'
@@ -147,7 +149,8 @@ shaderAssembler.addShaderHook(
 shaderAssembler.addShaderHook('fs:CLIP_COLOR(inout vec4 color)');
 ```
 
-The WGSL signatures use pointers for the mutable position and color. WGSL
+For WGSL, create a `WGSLShaderAssembler` instead. Its hook signatures use
+pointers for the mutable position and color. WGSL
 varying synthesis requires the selected vertex entry point to return a named
 stage-I/O struct and the fragment entry point to consume one named stage-I/O
 struct. The structs may be the same or separate. The assembler assigns unused

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -12,6 +12,18 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 
 ## Upgrading to v10.0
 
+**@luma.gl/shadertools**
+
+- `ShaderAssembler` is now abstract and can no longer be constructed directly. Replace
+  `new ShaderAssembler()` with `new GLSLShaderAssembler()` for GLSL or
+  `new WGSLShaderAssembler()` for WGSL. The default
+  `ShaderAssembler.getDefaultShaderAssembler()` remains the GLSL assembler; use
+  `ShaderAssembler.getDefaultShaderAssembler('wgsl')` for the separate WGSL assembler.
+- `assembleGLSLShaderPair()` is available only on `GLSLShaderAssembler`, and
+  `assembleWGSLShader()` is available only on `WGSLShaderAssembler`. Narrow existing
+  `ShaderAssembler` references with `instanceof GLSLShaderAssembler` or
+  `instanceof WGSLShaderAssembler` before assembling shader source.
+
 **@luma.gl/experimental**
 
 - `ABufferRenderer.render()` and `WBOITRenderer.render()` now accept an already-rendered opaque

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -16,9 +16,10 @@ luma.gl largely follows [SEMVER](https://semver.org) conventions. Breaking chang
 
 - `ShaderAssembler` is now abstract and can no longer be constructed directly. Replace
   `new ShaderAssembler()` with `new GLSLShaderAssembler()` for GLSL or
-  `new WGSLShaderAssembler()` for WGSL. The default
-  `ShaderAssembler.getDefaultShaderAssembler()` remains the GLSL assembler; use
-  `ShaderAssembler.getDefaultShaderAssembler('wgsl')` for the separate WGSL assembler.
+  `new WGSLShaderAssembler()` for WGSL.
+- `ShaderAssembler.getDefaultShaderAssembler()` now requires an explicit shader language.
+  Replace calls without an argument with `ShaderAssembler.getDefaultShaderAssembler('glsl')`
+  or `ShaderAssembler.getDefaultShaderAssembler('wgsl')`.
 - `assembleGLSLShaderPair()` is available only on `GLSLShaderAssembler`, and
   `assembleWGSLShader()` is available only on `WGSLShaderAssembler`. Narrow existing
   `ShaderAssembler` references with `instanceof GLSLShaderAssembler` or

--- a/examples/arrow/arrow-filtering/arrow-filtering-renderer.ts
+++ b/examples/arrow/arrow-filtering/arrow-filtering-renderer.ts
@@ -5,7 +5,7 @@
 import {makeGPUTableFromArrowTable} from '@luma.gl/arrow';
 import type {Device, RenderPass, ShaderLayout} from '@luma.gl/core';
 import type {FilterShaderPluginProps, ShaderModule} from '@luma.gl/shadertools';
-import {filterShaderPlugin, ShaderAssembler} from '@luma.gl/shadertools';
+import {filterShaderPlugin, GLSLShaderAssembler, WGSLShaderAssembler} from '@luma.gl/shadertools';
 import {GPUTableModel, type GPUTable} from '@luma.gl/tables';
 import type {ArrowFilteringTable} from './arrow-filtering-data';
 
@@ -140,7 +140,10 @@ export class ArrowFilteringRenderer {
   readonly gpuTable: GPUTable;
 
   constructor(device: Device, arrowTable: ArrowFilteringTable) {
-    const shaderAssembler = new ShaderAssembler();
+    const shaderAssembler =
+      device.info.shadingLanguage === 'wgsl'
+        ? new WGSLShaderAssembler()
+        : new GLSLShaderAssembler();
     shaderAssembler.addShaderHook(
       device.info.shadingLanguage === 'wgsl'
         ? 'vs:FILTER_POSITION(position: ptr<function, vec4<f32>>)'

--- a/examples/tutorials/shader-hooks/app.ts
+++ b/examples/tutorials/shader-hooks/app.ts
@@ -70,7 +70,7 @@ Modifying shader behavior with shader hooks
       throw new Error('This demo is only implemented for WebGL2');
     }
 
-    const shaderAssembler = ShaderAssembler.getDefaultShaderAssembler();
+    const shaderAssembler = ShaderAssembler.getDefaultShaderAssembler('glsl');
     shaderAssembler.addShaderHook('vs:OFFSET_POSITION(inout vec4 position)');
     this.uniformStore = new UniformStore(device, {
       app: {

--- a/examples/tutorials/shader-plugins/app.ts
+++ b/examples/tutorials/shader-plugins/app.ts
@@ -5,7 +5,7 @@
 import {Buffer} from '@luma.gl/core';
 import {AnimationLoopTemplate, AnimationProps, Model} from '@luma.gl/engine';
 import type {ClipShaderPluginProps, ShaderPlugin} from '@luma.gl/shadertools';
-import {clipShaderPlugin, ShaderAssembler} from '@luma.gl/shadertools';
+import {clipShaderPlugin, GLSLShaderAssembler, WGSLShaderAssembler} from '@luma.gl/shadertools';
 import type {SettingsChangeDescriptor, SettingsSchema} from '@deck.gl-community/panels';
 import {
   ExamplePanelManager,
@@ -176,7 +176,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.fillPatternSizeBuffer = device.createBuffer(triangleAttributes.fillPatternSizes);
     this.fillPatternUvBuffer = device.createBuffer(triangleAttributes.fillPatternUvs);
 
-    const shaderAssembler = new ShaderAssembler();
+    const shaderAssembler =
+      device.info.shadingLanguage === 'wgsl'
+        ? new WGSLShaderAssembler()
+        : new GLSLShaderAssembler();
     if (device.info.shadingLanguage === 'wgsl') {
       shaderAssembler.addShaderHook(
         'vs:CLIP_POSITION(position: ptr<function, vec4<f32>>, instanceCoordinates: vec2<f32>, geometryCoordinates: vec2<f32>)'

--- a/modules/arrow-layers/test/layers/arrow-layers.spec.ts
+++ b/modules/arrow-layers/test/layers/arrow-layers.spec.ts
@@ -8,10 +8,11 @@ import {makeGPUVectorFromArrow} from '@luma.gl/arrow';
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import type {Device} from '@luma.gl/core';
 import type {Model} from '@luma.gl/engine';
+import {ShaderAssembler} from '@luma.gl/shadertools';
 import {buildBitmapFontAtlas} from '@luma.gl/text';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import {Table, vectorFromArray, type RecordBatch} from 'apache-arrow';
-import {afterAll} from 'vitest';
+import {afterAll, vi} from 'vitest';
 import {
   makeArrowLineRecordBatches,
   makeArrowLineSourceData
@@ -26,8 +27,10 @@ const TEXT_FONT_ATLAS = buildBitmapFontAtlas({
   characterSet: ' ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/-'
 });
 let sharedStorageDeck: {deck: Deck; parent: HTMLDivElement} | null = null;
+let restoreLegacyDeckShaderAssembler: (() => void) | null = null;
 
 afterAll(() => {
+  restoreLegacyDeckShaderAssembler?.();
   finalizeSharedStorageDeck();
 });
 
@@ -588,7 +591,31 @@ function createTestDeck(device?: Device): {deck: Deck; parent: HTMLDivElement} {
     ...(device ? {device} : {}),
     views: new OrthographicView({id: 'main'}),
     initialViewState: {target: [0, 0], zoom: 0},
-    layers: []
+    layers: [],
+    onDeviceInitialized: initializedDevice => {
+      restoreLegacyDeckShaderAssembler?.();
+
+      const getDefaultShaderAssembler = ShaderAssembler.getDefaultShaderAssembler;
+      const shaderAssemblerSpy = vi.spyOn(ShaderAssembler, 'getDefaultShaderAssembler');
+      restoreLegacyDeckShaderAssembler = () => {
+        shaderAssemblerSpy.mockRestore();
+        restoreLegacyDeckShaderAssembler = null;
+      };
+
+      shaderAssemblerSpy.mockImplementation(shaderLanguage => {
+        if (shaderLanguage !== undefined) {
+          return getDefaultShaderAssembler.call(ShaderAssembler, shaderLanguage);
+        }
+
+        // deck.gl 9.3.4 requests its assembler without the now-required language.
+        // Restore strict behavior before forwarding this single legacy call.
+        restoreLegacyDeckShaderAssembler?.();
+        return getDefaultShaderAssembler.call(
+          ShaderAssembler,
+          initializedDevice.info.shadingLanguage
+        );
+      });
+    }
   });
   return {deck, parent};
 }

--- a/modules/arrow/src/arrow/renderers/text/renderers/arrow-text-renderer.ts
+++ b/modules/arrow/src/arrow/renderers/text/renderers/arrow-text-renderer.ts
@@ -13,7 +13,7 @@ import {
   makeGPUTableFromArrowTable
 } from '../../../gpu/arrow-gpu-table-adapters';
 import {type ModelProps} from '@luma.gl/engine';
-import {ShaderAssembler} from '@luma.gl/shadertools';
+import {GLSLShaderAssembler, WGSLShaderAssembler} from '@luma.gl/shadertools';
 import {GPURenderable, GPUVector, GPUTable, getRequiredGPUVector} from '@luma.gl/tables';
 import {GPUTextResources, TextRenderer, type FontAtlas, type GPUTextData} from '@luma.gl/text';
 import {
@@ -803,7 +803,11 @@ export class ArrowTextRenderer extends GPURenderable<
     const angle = props.angle ?? DEFAULT_TEXT_ANGLE;
     const size = props.size ?? DEFAULT_TEXT_SIZE;
     setArrowTextFontAtlasShaderProps(this.shaderInputs, props.fontAtlas);
-    const shaderAssembler = props.modelProps?.shaderAssembler ?? new ShaderAssembler();
+    const shaderAssembler =
+      props.modelProps?.shaderAssembler ??
+      (this.device.info.shadingLanguage === 'wgsl'
+        ? new WGSLShaderAssembler()
+        : new GLSLShaderAssembler());
     const usesCustomShaderSource =
       this.device.info.shadingLanguage === 'wgsl'
         ? Boolean(props.modelProps?.source)

--- a/modules/arrow/src/arrow/renderers/text/renderers/arrow-text-shaders.ts
+++ b/modules/arrow/src/arrow/renderers/text/renderers/arrow-text-shaders.ts
@@ -34,10 +34,10 @@ const configuredAttributeVertexHooks = new WeakMap<ShaderAssembler, Set<string>>
  * that ordinary text shaders compile while allowing hosts such as Space Crawl to replace
  * projection and texture orientation without forking the text shader.
  */
-export function configureArrowTextShaderAssembler(
-  shaderAssembler: ShaderAssembler,
+export function configureArrowTextShaderAssembler<ShaderAssemblerType extends ShaderAssembler>(
+  shaderAssembler: ShaderAssemblerType,
   shaderLanguage: 'glsl' | 'wgsl'
-): ShaderAssembler {
+): ShaderAssemblerType {
   let configuredLanguages = configuredAttributeVertexHooks.get(shaderAssembler);
   if (!configuredLanguages) {
     configuredLanguages = new Set();

--- a/modules/arrow/test/arrow/arrow-text-shaders.node.spec.ts
+++ b/modules/arrow/test/arrow/arrow-text-shaders.node.spec.ts
@@ -4,7 +4,7 @@
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {getArrowTextRenderModules} from '@luma.gl/arrow';
-import {ShaderAssembler, type PlatformInfo} from '@luma.gl/shadertools';
+import {WGSLShaderAssembler, type PlatformInfo} from '@luma.gl/shadertools';
 import {NullDevice} from '@luma.gl/test-utils';
 import {
   configureArrowTextShaderAssembler,
@@ -23,7 +23,7 @@ const WEBGPU_PLATFORM_INFO: PlatformInfo = {
 };
 
 test('Arrow text storage WGSL shaders resolve application auto bindings', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const modules = getArrowTextRenderModules(new NullDevice({}));
 
   for (const [label, source] of [
@@ -51,7 +51,7 @@ test('Arrow text storage WGSL shaders resolve application auto bindings', t => {
 });
 
 test('Arrow attribute text WGSL exposes a vertex transform hook before returning', t => {
-  const shaderAssembler = configureArrowTextShaderAssembler(new ShaderAssembler(), 'wgsl');
+  const shaderAssembler = configureArrowTextShaderAssembler(new WGSLShaderAssembler(), 'wgsl');
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: WEBGPU_PLATFORM_INFO,
     source: WGSL_SHADER,

--- a/modules/effects/test/passes/image-adjust-filters/tone-mapping.spec.ts
+++ b/modules/effects/test/passes/image-adjust-filters/tone-mapping.spec.ts
@@ -4,7 +4,12 @@
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {toneMapping} from '@luma.gl/effects';
-import {getShaderModuleUniforms, ShaderAssembler, type PlatformInfo} from '@luma.gl/shadertools';
+import {
+  getShaderModuleUniforms,
+  GLSLShaderAssembler,
+  WGSLShaderAssembler,
+  type PlatformInfo
+} from '@luma.gl/shadertools';
 import {WgslReflect} from 'wgsl_reflect';
 
 const WEBGL_PLATFORM_INFO: PlatformInfo = {
@@ -84,7 +89,7 @@ test('toneMapping#cross-backend shader sources', testCase => {
 });
 
 test('toneMapping#WGSL assembly', testCase => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: WEBGPU_PLATFORM_INFO,
     source: FRAGMENT_SHADER_WGSL,
@@ -100,7 +105,7 @@ test('toneMapping#WGSL assembly', testCase => {
 });
 
 test('toneMapping#GLSL assembly', testCase => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new GLSLShaderAssembler();
   const assembledShaders = shaderAssembler.assembleGLSLShaderPair({
     platformInfo: WEBGL_PLATFORM_INFO,
     vs: VERTEX_SHADER_GLSL,

--- a/modules/effects/test/passes/postprocessing-wgsl.spec.ts
+++ b/modules/effects/test/passes/postprocessing-wgsl.spec.ts
@@ -39,7 +39,7 @@ import {
   vignette,
   zoomBlur
 } from '../../src/index';
-import {ShaderAssembler} from '../../../shadertools/src/lib/shader-assembler';
+import {WGSLShaderAssembler} from '../../../shadertools/src/lib/shader-assembler';
 import {getFragmentShaderForRenderPass} from '../../../engine/src/passes/get-fragment-shader';
 import {textureTransform} from '../../../engine/src/passes/texture-transform-module';
 
@@ -170,7 +170,7 @@ async function getCompilationInfoWithTimeout(shader: {
 }
 
 test('postprocessing WGSL#assemble/compile', async testCase => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const webgpuDevice = await getOptionalWebGPUDevice();
 
   if (!webgpuDevice) {

--- a/modules/engine/src/compute/computation.ts
+++ b/modules/engine/src/compute/computation.ts
@@ -15,6 +15,7 @@ import {
   PipelineFactory,
   ShaderFactory,
   UniformStore,
+  assert,
   log,
   dataTypeDecoder
 } from '@luma.gl/core';
@@ -24,7 +25,8 @@ import {
   type PlatformInfo,
   mergeShaderPluginModules,
   resolveShaderPlugins,
-  ShaderAssembler
+  ShaderAssembler,
+  WGSLShaderAssembler
 } from '@luma.gl/shadertools';
 import {type TypedArray, isNumericArray} from '@math.gl/types';
 import {ShaderInputs} from '../shader-inputs';
@@ -62,7 +64,7 @@ export type ComputationProps = Omit<ComputePipelineProps, 'shader'> & {
   pipelineFactory?: PipelineFactory;
   /** Factory used to create a {@link Shader}. Defaults to {@link Device} default factory. */
   shaderFactory?: ShaderFactory;
-  /** Shader assembler. Defaults to the ShaderAssembler.getShaderAssembler() */
+  /** WGSL shader assembler. Defaults to the shared WGSL shader assembler. */
   shaderAssembler?: ShaderAssembler;
 };
 
@@ -91,7 +93,7 @@ export class Computation {
 
     pipelineFactory: undefined!,
     shaderFactory: undefined!,
-    shaderAssembler: ShaderAssembler.getDefaultShaderAssembler(),
+    shaderAssembler: ShaderAssembler.getDefaultShaderAssembler('wgsl'),
 
     debugShaders: undefined!
   };
@@ -173,7 +175,10 @@ export class Computation {
       props.pipelineFactory || PipelineFactory.getDefaultPipelineFactory(this.device);
     this.shaderFactory = props.shaderFactory || ShaderFactory.getDefaultShaderFactory(this.device);
 
-    const {source, getUniforms} = this.props.shaderAssembler.assembleWGSLShader({
+    const shaderAssembler = this.props.shaderAssembler;
+    // Compute shaders require an assembler with WGSL-specific hooks and binding state.
+    assert(shaderAssembler instanceof WGSLShaderAssembler);
+    const {source, getUniforms} = shaderAssembler.assembleWGSLShader({
       platformInfo,
       ...this.props,
       modules,

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -210,7 +210,7 @@ export class Model {
     pipelineFactory: undefined!,
     shaderFactory: undefined!,
     transformFeedback: undefined!,
-    shaderAssembler: ShaderAssembler.getDefaultShaderAssembler(),
+    shaderAssembler: ShaderAssembler.getDefaultShaderAssembler('glsl'),
 
     debugShaders: undefined!,
     disableWarnings: undefined!

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -32,6 +32,7 @@ import {
   PipelineFactory,
   ShaderFactory,
   UniformStore,
+  assert,
   log,
   dataTypeDecoder,
   getAttributeInfosFromLayouts,
@@ -47,7 +48,9 @@ import type {
 import {
   mergeShaderPluginModules,
   resolveShaderPlugins,
-  ShaderAssembler
+  ShaderAssembler,
+  GLSLShaderAssembler,
+  WGSLShaderAssembler
 } from '@luma.gl/shadertools';
 
 import type {Geometry} from '../geometry/geometry';
@@ -156,7 +159,7 @@ export type ModelProps = Omit<RenderPipelineProps, 'vs' | 'fs' | 'bindings'> & {
   pipelineFactory?: PipelineFactory;
   /** Factory used to create a {@link Shader}. Defaults to {@link Device} default factory. */
   shaderFactory?: ShaderFactory;
-  /** Shader assembler. Defaults to the ShaderAssembler.getShaderAssembler() */
+  /** Shader assembler. Defaults to the shared assembler for the device's shader language. */
   shaderAssembler?: ShaderAssembler;
 };
 
@@ -316,7 +319,16 @@ export class Model {
   }
 
   constructor(device: Device, props: ModelProps) {
-    this.props = {...Model.defaultProps, ...props};
+    const defaultShaderAssembler = Model.defaultProps.shaderAssembler;
+    this.props = {
+      ...Model.defaultProps,
+      ...props,
+      shaderAssembler:
+        props.shaderAssembler ??
+        (defaultShaderAssembler.shaderLanguage === device.info.shadingLanguage
+          ? defaultShaderAssembler
+          : ShaderAssembler.getDefaultShaderAssembler(device.info.shadingLanguage))
+    };
     props = this.props;
     this.id = props.id || uid('model');
     this.device = device;
@@ -358,7 +370,10 @@ export class Model {
     // TODO - this is wrong, compile a single shader
     if (isWebGPU && this.props.source) {
       // WGSL
-      const {source, getUniforms, bindingTable} = this.props.shaderAssembler.assembleWGSLShader({
+      const shaderAssembler = this.props.shaderAssembler;
+      // WGSL sources require an assembler with WGSL-specific hooks and binding state.
+      assert(shaderAssembler instanceof WGSLShaderAssembler);
+      const {source, getUniforms, bindingTable} = shaderAssembler.assembleWGSLShader({
         platformInfo,
         ...this.props,
         modules,
@@ -388,7 +403,10 @@ export class Model {
         mergeShaderModuleBindingsIntoLayout(shaderLayout || null, modules) || null;
     } else {
       // GLSL
-      const {vs, fs, getUniforms} = this.props.shaderAssembler.assembleGLSLShaderPair({
+      const shaderAssembler = this.props.shaderAssembler;
+      // GLSL shader pairs require an assembler with GLSL-specific hooks.
+      assert(shaderAssembler instanceof GLSLShaderAssembler);
+      const {vs, fs, getUniforms} = shaderAssembler.assembleGLSLShaderPair({
         platformInfo,
         ...this.props,
         modules,

--- a/modules/engine/src/model/model.ts
+++ b/modules/engine/src/model/model.ts
@@ -43,14 +43,14 @@ import type {
   ShaderBindingDebugRow,
   ShaderModule,
   ShaderPlugin,
-  PlatformInfo
+  PlatformInfo,
+  GLSLShaderAssembler,
+  WGSLShaderAssembler
 } from '@luma.gl/shadertools';
 import {
   mergeShaderPluginModules,
   resolveShaderPlugins,
-  ShaderAssembler,
-  GLSLShaderAssembler,
-  WGSLShaderAssembler
+  ShaderAssembler
 } from '@luma.gl/shadertools';
 
 import type {Geometry} from '../geometry/geometry';
@@ -325,7 +325,7 @@ export class Model {
       ...props,
       shaderAssembler:
         props.shaderAssembler ??
-        (defaultShaderAssembler.shaderLanguage === device.info.shadingLanguage
+        (isShaderAssemblerForLanguage(defaultShaderAssembler, device.info.shadingLanguage)
           ? defaultShaderAssembler
           : ShaderAssembler.getDefaultShaderAssembler(device.info.shadingLanguage))
     };
@@ -372,7 +372,7 @@ export class Model {
       // WGSL
       const shaderAssembler = this.props.shaderAssembler;
       // WGSL sources require an assembler with WGSL-specific hooks and binding state.
-      assert(shaderAssembler instanceof WGSLShaderAssembler);
+      assert(isShaderAssemblerForLanguage(shaderAssembler, 'wgsl'));
       const {source, getUniforms, bindingTable} = shaderAssembler.assembleWGSLShader({
         platformInfo,
         ...this.props,
@@ -405,7 +405,7 @@ export class Model {
       // GLSL
       const shaderAssembler = this.props.shaderAssembler;
       // GLSL shader pairs require an assembler with GLSL-specific hooks.
-      assert(shaderAssembler instanceof GLSLShaderAssembler);
+      assert(isShaderAssemblerForLanguage(shaderAssembler, 'glsl'));
       const {vs, fs, getUniforms} = shaderAssembler.assembleGLSLShaderPair({
         platformInfo,
         ...this.props,
@@ -1315,6 +1315,36 @@ export class Model {
 }
 
 // HELPERS
+
+function isShaderAssemblerForLanguage(
+  shaderAssembler: ShaderAssembler,
+  shaderLanguage: 'glsl'
+): shaderAssembler is GLSLShaderAssembler;
+function isShaderAssemblerForLanguage(
+  shaderAssembler: ShaderAssembler,
+  shaderLanguage: 'wgsl'
+): shaderAssembler is WGSLShaderAssembler;
+function isShaderAssemblerForLanguage(
+  shaderAssembler: ShaderAssembler,
+  shaderLanguage: 'glsl' | 'wgsl'
+): shaderAssembler is GLSLShaderAssembler | WGSLShaderAssembler;
+function isShaderAssemblerForLanguage(
+  shaderAssembler: ShaderAssembler,
+  shaderLanguage: 'glsl' | 'wgsl'
+): boolean {
+  if (
+    shaderAssembler.shaderLanguage !== undefined &&
+    shaderAssembler.shaderLanguage !== shaderLanguage
+  ) {
+    return false;
+  }
+
+  return shaderLanguage === 'glsl'
+    ? 'assembleGLSLShaderPair' in shaderAssembler &&
+        typeof shaderAssembler.assembleGLSLShaderPair === 'function'
+    : 'assembleWGSLShader' in shaderAssembler &&
+        typeof shaderAssembler.assembleWGSLShader === 'function';
+}
 
 function normalizeShaderPluginAttributeNames(
   shaderLayout: ShaderLayout | null | undefined,

--- a/modules/engine/test/lib/model.node.spec.ts
+++ b/modules/engine/test/lib/model.node.spec.ts
@@ -1,0 +1,316 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import type {Device} from '@luma.gl/core';
+import {Model} from '@luma.gl/engine';
+import {GLSLShaderAssembler, WGSLShaderAssembler, type ShaderAssembler} from '@luma.gl/shadertools';
+import {NullDevice} from '@luma.gl/test-utils';
+
+const WGSL_SOURCE = /* wgsl */ `\
+@vertex
+fn vertexMain() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+
+@fragment
+fn fragmentMain() -> @location(0) vec4<f32> {
+  return vec4<f32>(1.0);
+}
+`;
+
+const GLSL_VERTEX_SOURCE = /* glsl */ `\
+#version 300 es
+void main() {
+  gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+}
+`;
+
+const GLSL_FRAGMENT_SOURCE = /* glsl */ `\
+#version 300 es
+precision highp float;
+out vec4 fragmentColor;
+void main() {
+  fragmentColor = vec4(1.0);
+}
+`;
+
+class TrackingWGSLShaderAssembler extends WGSLShaderAssembler {
+  assemblyCount = 0;
+
+  override assembleWGSLShader(
+    props: Parameters<WGSLShaderAssembler['assembleWGSLShader']>[0]
+  ): ReturnType<WGSLShaderAssembler['assembleWGSLShader']> {
+    this.assemblyCount++;
+    return super.assembleWGSLShader(props);
+  }
+}
+
+test('Model preserves explicitly supplied custom WGSL shader assemblers', testCase => {
+  const device = makeWebGPUDevice();
+  const shaderAssembler = new TrackingWGSLShaderAssembler();
+  shaderAssembler.addDefaultModule({
+    name: 'customWGSLModule',
+    source: 'const CUSTOM_WGSL_MODULE_MARKER: f32 = 1.0;'
+  });
+  shaderAssembler.addShaderHook('vs:CUSTOM_WGSL_MODEL_HOOK(position: ptr<function, vec4<f32>>)');
+
+  const model = new Model(device, {
+    id: 'custom-wgsl-shader-assembler',
+    source: WGSL_SOURCE,
+    shaderAssembler,
+    vertexCount: 1
+  });
+
+  try {
+    testCase.equal(shaderAssembler.assemblyCount, 1, 'the supplied custom assembler is used');
+    testCase.ok(
+      model.source.includes('CUSTOM_WGSL_MODULE_MARKER'),
+      'custom assembler default modules are preserved'
+    );
+    testCase.ok(
+      model.source.includes('fn CUSTOM_WGSL_MODEL_HOOK('),
+      'custom assembler hooks are preserved'
+    );
+  } finally {
+    model.destroy();
+    device.destroy();
+  }
+
+  testCase.end();
+});
+
+test('Model preserves legacy Deck assemblers for both shader languages', testCase => {
+  const glslShaderAssembler = new GLSLShaderAssembler();
+  const wgslShaderAssembler = new WGSLShaderAssembler();
+  glslShaderAssembler.addDefaultModule({
+    name: 'legacyGLSLModule',
+    vs: 'const float LEGACY_GLSL_MODULE_MARKER = 1.0;'
+  });
+  glslShaderAssembler.addShaderHook('vs:LEGACY_DECK_HOOK(inout vec4 position)');
+  wgslShaderAssembler.addDefaultModule({
+    name: 'legacyWGSLModule',
+    source: 'const LEGACY_WGSL_MODULE_MARKER: f32 = 1.0;'
+  });
+  wgslShaderAssembler.addShaderHook('vs:LEGACY_DECK_HOOK(position: ptr<function, vec4<f32>>)');
+
+  // deck.gl 9.3.4 forwards an assembler with both methods but no shaderLanguage.
+  const legacyShaderAssembler = {
+    addDefaultModule: wgslShaderAssembler.addDefaultModule.bind(wgslShaderAssembler),
+    removeDefaultModule: wgslShaderAssembler.removeDefaultModule.bind(wgslShaderAssembler),
+    addShaderHook: wgslShaderAssembler.addShaderHook.bind(wgslShaderAssembler),
+    assembleGLSLShaderPair: glslShaderAssembler.assembleGLSLShaderPair.bind(glslShaderAssembler),
+    assembleWGSLShader: wgslShaderAssembler.assembleWGSLShader.bind(wgslShaderAssembler)
+  };
+  testCase.notOk(
+    'shaderLanguage' in legacyShaderAssembler,
+    'the pinned Deck compatibility assembler has no language metadata'
+  );
+
+  const webgpuDevice = makeWebGPUDevice();
+  const wgslModel = new Model(webgpuDevice, {
+    id: 'legacy-wgsl-shader-assembler',
+    source: WGSL_SOURCE,
+    shaderAssembler: legacyShaderAssembler as unknown as ShaderAssembler,
+    vertexCount: 1
+  });
+
+  try {
+    testCase.ok(
+      wgslModel.source.includes('LEGACY_WGSL_MODULE_MARKER'),
+      'legacy WGSL assembler modules are preserved'
+    );
+    testCase.ok(
+      wgslModel.source.includes('fn LEGACY_DECK_HOOK('),
+      'legacy WGSL assembler hooks are preserved'
+    );
+  } finally {
+    wgslModel.destroy();
+    webgpuDevice.destroy();
+  }
+
+  const glslDevice = new NullDevice({});
+  const glslModel = new Model(glslDevice, {
+    id: 'legacy-glsl-shader-assembler',
+    vs: GLSL_VERTEX_SOURCE,
+    fs: GLSL_FRAGMENT_SOURCE,
+    shaderAssembler: legacyShaderAssembler as unknown as ShaderAssembler,
+    vertexCount: 1
+  });
+
+  try {
+    testCase.ok(
+      glslModel.vs.includes('LEGACY_GLSL_MODULE_MARKER'),
+      'legacy GLSL assembler modules are preserved'
+    );
+    testCase.ok(
+      glslModel.vs.includes('void LEGACY_DECK_HOOK('),
+      'legacy GLSL assembler hooks are preserved'
+    );
+  } finally {
+    glslModel.destroy();
+    glslDevice.destroy();
+  }
+
+  testCase.end();
+});
+
+test('Model preserves a legacy default shader assembler override for WebGPU', testCase => {
+  const device = makeWebGPUDevice();
+  const originalDefaultShaderAssembler = Model.defaultProps.shaderAssembler;
+  const glslShaderAssembler = new GLSLShaderAssembler();
+  const wgslShaderAssembler = new TrackingWGSLShaderAssembler();
+  wgslShaderAssembler.addDefaultModule({
+    name: 'legacyDefaultWGSLModule',
+    source: 'const LEGACY_DEFAULT_WGSL_MODULE_MARKER: f32 = 1.0;'
+  });
+  wgslShaderAssembler.addShaderHook(
+    'vs:LEGACY_DEFAULT_WGSL_HOOK(position: ptr<function, vec4<f32>>)'
+  );
+
+  const legacyDefaultShaderAssembler = {
+    addDefaultModule: wgslShaderAssembler.addDefaultModule.bind(wgslShaderAssembler),
+    removeDefaultModule: wgslShaderAssembler.removeDefaultModule.bind(wgslShaderAssembler),
+    addShaderHook: wgslShaderAssembler.addShaderHook.bind(wgslShaderAssembler),
+    assembleGLSLShaderPair: glslShaderAssembler.assembleGLSLShaderPair.bind(glslShaderAssembler),
+    assembleWGSLShader: wgslShaderAssembler.assembleWGSLShader.bind(wgslShaderAssembler)
+  };
+  let model: Model | null = null;
+
+  try {
+    Model.defaultProps.shaderAssembler = legacyDefaultShaderAssembler as unknown as ShaderAssembler;
+    model = new Model(device, {
+      id: 'legacy-default-wgsl-shader-assembler',
+      source: WGSL_SOURCE,
+      vertexCount: 1
+    });
+
+    testCase.equal(
+      wgslShaderAssembler.assemblyCount,
+      1,
+      'the configured legacy default is retained for WebGPU'
+    );
+    testCase.ok(
+      model.source.includes('LEGACY_DEFAULT_WGSL_MODULE_MARKER'),
+      'legacy default assembler modules are preserved'
+    );
+    testCase.ok(
+      model.source.includes('fn LEGACY_DEFAULT_WGSL_HOOK('),
+      'legacy default assembler hooks are preserved'
+    );
+  } finally {
+    Model.defaultProps.shaderAssembler = originalDefaultShaderAssembler;
+    try {
+      model?.destroy();
+    } finally {
+      device.destroy();
+    }
+  }
+
+  testCase.end();
+});
+
+test('Model accepts compatible WGSL assemblers from another module instance', testCase => {
+  const device = makeWebGPUDevice();
+  const sourceShaderAssembler = new WGSLShaderAssembler();
+  sourceShaderAssembler.addDefaultModule({
+    name: 'duplicateWGSLModule',
+    source: 'const DUPLICATE_WGSL_MODULE_MARKER: f32 = 1.0;'
+  });
+  sourceShaderAssembler.addShaderHook(
+    'vs:DUPLICATE_WGSL_MODEL_HOOK(position: ptr<function, vec4<f32>>)'
+  );
+
+  const duplicateShaderAssembler = {
+    shaderLanguage: 'wgsl' as const,
+    addDefaultModule: sourceShaderAssembler.addDefaultModule.bind(sourceShaderAssembler),
+    removeDefaultModule: sourceShaderAssembler.removeDefaultModule.bind(sourceShaderAssembler),
+    addShaderHook: sourceShaderAssembler.addShaderHook.bind(sourceShaderAssembler),
+    assembleWGSLShader: sourceShaderAssembler.assembleWGSLShader.bind(sourceShaderAssembler)
+  };
+  testCase.notOk(
+    duplicateShaderAssembler instanceof WGSLShaderAssembler,
+    'the duplicate-copy assembler has a different constructor identity'
+  );
+
+  const model = new Model(device, {
+    id: 'duplicate-wgsl-shader-assembler',
+    source: WGSL_SOURCE,
+    shaderAssembler: duplicateShaderAssembler as unknown as ShaderAssembler,
+    vertexCount: 1
+  });
+
+  try {
+    testCase.ok(
+      model.source.includes('DUPLICATE_WGSL_MODULE_MARKER'),
+      'duplicate-copy assembler default modules are preserved'
+    );
+    testCase.ok(
+      model.source.includes('fn DUPLICATE_WGSL_MODEL_HOOK('),
+      'duplicate-copy assembler hooks are preserved'
+    );
+  } finally {
+    model.destroy();
+    device.destroy();
+  }
+
+  testCase.end();
+});
+
+test('Model rejects an explicitly supplied assembler for the wrong shader language', testCase => {
+  const webgpuDevice = makeWebGPUDevice();
+
+  try {
+    testCase.throws(
+      () =>
+        new Model(webgpuDevice, {
+          id: 'wrong-wgsl-shader-assembler',
+          source: WGSL_SOURCE,
+          shaderAssembler: new GLSLShaderAssembler(),
+          vertexCount: 1
+        }),
+      'WebGPU rejects an explicitly supplied GLSL assembler'
+    );
+  } finally {
+    webgpuDevice.destroy();
+  }
+
+  const glslDevice = new NullDevice({});
+
+  try {
+    testCase.throws(
+      () =>
+        new Model(glslDevice, {
+          id: 'wrong-glsl-shader-assembler',
+          vs: GLSL_VERTEX_SOURCE,
+          fs: GLSL_FRAGMENT_SOURCE,
+          shaderAssembler: new WGSLShaderAssembler(),
+          vertexCount: 1
+        }),
+      'GLSL rejects an explicitly supplied WGSL assembler'
+    );
+  } finally {
+    glslDevice.destroy();
+  }
+
+  testCase.end();
+});
+
+function makeWebGPUDevice(): Device {
+  const nullDevice = new NullDevice({});
+  const webgpuDevice = Object.create(nullDevice) as Device;
+
+  Object.defineProperties(webgpuDevice, {
+    type: {value: 'webgpu'},
+    info: {
+      value: {
+        ...nullDevice.info,
+        type: 'webgpu',
+        shadingLanguage: 'wgsl'
+      }
+    }
+  });
+
+  return webgpuDevice;
+}

--- a/modules/experimental/test/materials/optical-materials.node.spec.ts
+++ b/modules/experimental/test/materials/optical-materials.node.spec.ts
@@ -25,7 +25,11 @@ import {
   reflectiveMaterialPlugin,
   wboit
 } from '@luma.gl/experimental';
-import {getShaderModuleUniformLayoutValidationResult, ShaderAssembler} from '@luma.gl/shadertools';
+import {
+  getShaderModuleUniformLayoutValidationResult,
+  GLSLShaderAssembler,
+  WGSLShaderAssembler
+} from '@luma.gl/shadertools';
 import {WgslReflect} from 'wgsl_reflect';
 
 const PLATFORM_INFO = {
@@ -872,7 +876,7 @@ test('optical materials expose matching WGSL and GLSL uniform layouts', testCase
 });
 
 test('rasterized glass transmission assembles portable optical and depth bindings', testCase => {
-  const assembler = new ShaderAssembler();
+  const assembler = new WGSLShaderAssembler();
   const transmissionShader = ILLUMINATED_OPTICAL_MATERIAL_SHADER.replace(
     'glassMaterial_getIlluminatedColor(',
     'glassTransmission_getIlluminatedColor('
@@ -914,7 +918,7 @@ test('rasterized glass transmission assembles portable optical and depth binding
 });
 
 test('existing optical materials compose without the optional point-light module', testCase => {
-  const assembler = new ShaderAssembler();
+  const assembler = new WGSLShaderAssembler();
   const assembledShader = assembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: OPTICAL_MATERIAL_SHADER,
@@ -970,7 +974,7 @@ test('existing optical materials compose without the optional point-light module
 });
 
 test('illuminated optical materials compose once with emission and transparency', testCase => {
-  const assembler = new ShaderAssembler();
+  const assembler = new WGSLShaderAssembler();
   const assembledShader = assembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: ILLUMINATED_OPTICAL_MATERIAL_SHADER,
@@ -1042,7 +1046,7 @@ test('illuminated optical materials compose once with emission and transparency'
 });
 
 test('illuminated optical helpers assemble for GLSL', testCase => {
-  const assembler = new ShaderAssembler();
+  const assembler = new GLSLShaderAssembler();
   const assembledShader = assembler.assembleGLSLShaderPair({
     platformInfo: GLSL_PLATFORM_INFO,
     vs: `#version 300 es

--- a/modules/experimental/test/rendering/spectral-caustics.node.spec.ts
+++ b/modules/experimental/test/rendering/spectral-caustics.node.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {ShaderAssembler} from '@luma.gl/shadertools';
+import {WGSLShaderAssembler} from '@luma.gl/shadertools';
 import {WgslReflect} from 'wgsl_reflect';
 import {
   convertD65XYZToLinearSRGB,
@@ -84,7 +84,7 @@ test('spectral caustics clamp only negative final RGB and preserve HDR', testCas
 });
 
 test('spectral caustics assemble as a planar XYZ receiver module', testCase => {
-  const assembledShader = new ShaderAssembler().assembleWGSLShader({
+  const assembledShader = new WGSLShaderAssembler().assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: RECEIVER_SHADER,
     modules: [spectralCaustics]

--- a/modules/experimental/test/shadows/shadow-wgsl.spec.ts
+++ b/modules/experimental/test/shadows/shadow-wgsl.spec.ts
@@ -8,7 +8,7 @@ import {Model, ShaderInputs} from '@luma.gl/engine';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import {Matrix4, radians} from '@math.gl/core';
 import {WgslReflect} from 'wgsl_reflect';
-import {ShaderAssembler} from '../../../shadertools/src/lib/shader-assembler';
+import {WGSLShaderAssembler} from '../../../shadertools/src/lib/shader-assembler';
 import {getFragmentShaderForRenderPass} from '../../../engine/src/passes/get-fragment-shader';
 import {textureTransform} from '../../../engine/src/passes/texture-transform-module';
 import {
@@ -69,7 +69,7 @@ struct VertexOutput {
 }`;
 
 test('shadow WGSL assembles and reflects group-2 depth resources', async t => {
-  const assembler = new ShaderAssembler();
+  const assembler = new WGSLShaderAssembler();
   const assembled = assembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: SHADOW_RECEIVER_SHADER,
@@ -94,7 +94,7 @@ test('shadow WGSL assembles and reflects group-2 depth resources', async t => {
 });
 
 test('contact shadow passes assemble and compile', async t => {
-  const assembler = new ShaderAssembler();
+  const assembler = new WGSLShaderAssembler();
   for (const shaderPass of [
     contactShadowTrace,
     contactShadowBilateralBlur,

--- a/modules/gpgpu/src/operations/webgl/common/row-transform.ts
+++ b/modules/gpgpu/src/operations/webgl/common/row-transform.ts
@@ -4,7 +4,7 @@
 
 import {SignedDataType, Buffer, BufferLayout} from '@luma.gl/core';
 import {BufferTransform} from '@luma.gl/engine';
-import {ShaderAssembler, type ShaderModule} from '@luma.gl/shadertools';
+import {GLSLShaderAssembler, type ShaderModule} from '@luma.gl/shadertools';
 import {GPUDataEvaluator} from '../../../operation/gpu-data-evaluator';
 import {bufferPool} from '../../../utils/buffer-pool';
 import {
@@ -16,7 +16,7 @@ import {
 
 const GPGPU_OPERATION_STATS = 'GPGPU Operation Counts';
 const TRANSFORM_RUNS = 'Transform Runs';
-const GPGPU_SHADER_ASSEMBLER = new ShaderAssembler();
+const GPGPU_SHADER_ASSEMBLER = new GLSLShaderAssembler();
 
 export function runRowTransform({
   module,

--- a/modules/gpgpu/src/operations/webgpu/common/row-transform.ts
+++ b/modules/gpgpu/src/operations/webgpu/common/row-transform.ts
@@ -4,7 +4,7 @@
 
 import {Buffer, SignedDataType} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {ShaderAssembler, type ShaderModule} from '@luma.gl/shadertools';
+import {WGSLShaderAssembler, type ShaderModule} from '@luma.gl/shadertools';
 import {GPUDataEvaluator} from '../../../operation/gpu-data-evaluator';
 import {getWebGPUDispatchLayout, getWebGPUDispatchRowIndex} from './dispatch';
 import {getLiteralValue, getWGSLType, getZeroValue} from './helper';
@@ -12,7 +12,7 @@ import {getLiteralValue, getWGSLType, getZeroValue} from './helper';
 const WORKGROUP_SIZE = 64;
 const GPGPU_OPERATION_STATS = 'GPGPU Operation Counts';
 const COMPUTATION_RUNS = 'Computation Runs';
-const GPGPU_SHADER_ASSEMBLER = new ShaderAssembler();
+const GPGPU_SHADER_ASSEMBLER = new WGSLShaderAssembler();
 
 export function runRowComputation({
   module,

--- a/modules/gpgpu/test/operations/interleave.spec.ts
+++ b/modules/gpgpu/test/operations/interleave.spec.ts
@@ -6,7 +6,7 @@ import {test, expect, describe, beforeEach} from 'vitest';
 import type {Device} from '@luma.gl/core';
 import {Computation, Model} from '@luma.gl/engine';
 import {cleanEvaluate, interleave, GPUDataEvaluator, Operation} from '@luma.gl/gpgpu';
-import {ShaderAssembler} from '@luma.gl/shadertools';
+import {GLSLShaderAssembler, WGSLShaderAssembler} from '@luma.gl/shadertools';
 import {
   getRunStats,
   getTestDevice,
@@ -42,8 +42,13 @@ for (const deviceType of ['webgl', 'webgpu'] as const) {
 
     const defaultProps = deviceType === 'webgpu' ? Computation.defaultProps : Model.defaultProps;
     const defaultShaderAssembler = defaultProps.shaderAssembler;
-    const contaminatedShaderAssembler = new ShaderAssembler();
-    contaminatedShaderAssembler.addShaderHook('vs:INVALID_GLSL_HOOK(inout invalid_type value)');
+    const contaminatedShaderAssembler =
+      deviceType === 'webgpu' ? new WGSLShaderAssembler() : new GLSLShaderAssembler();
+    contaminatedShaderAssembler.addShaderHook(
+      deviceType === 'webgpu'
+        ? 'vs:INVALID_WGSL_HOOK(value: ptr<function, invalid_type>)'
+        : 'vs:INVALID_GLSL_HOOK(inout invalid_type value)'
+    );
     defaultProps.shaderAssembler = contaminatedShaderAssembler;
 
     const result = interleave(

--- a/modules/shadertools/src/index.ts
+++ b/modules/shadertools/src/index.ts
@@ -65,7 +65,7 @@ export {resolveModules as _resolveModules} from './lib/shader-module/shader-modu
 export {getDependencyGraph as _getDependencyGraph} from './lib/shader-module/shader-module-dependencies';
 
 // ShaderAssembler
-export {ShaderAssembler} from './lib/shader-assembler';
+export {ShaderAssembler, GLSLShaderAssembler, WGSLShaderAssembler} from './lib/shader-assembler';
 export type {ShaderHook} from './lib/shader-assembly/shader-hooks';
 export type {ShaderInjection} from './lib/shader-assembly/shader-injections';
 

--- a/modules/shadertools/src/lib/shader-assembler.ts
+++ b/modules/shadertools/src/lib/shader-assembler.ts
@@ -22,23 +22,40 @@ import type {ShaderLayout} from '@luma.gl/core';
  * A stateful version of `assembleShaders` that can be used to assemble shaders.
  * Supports setting of default modules and hooks.
  */
-export class ShaderAssembler {
-  /** Default ShaderAssembler instance */
-  static defaultShaderAssembler: ShaderAssembler;
+export abstract class ShaderAssembler {
+  /** Default GLSL assembler, retained for compatibility with existing applications. */
+  static defaultShaderAssembler: GLSLShaderAssembler;
+  /** Default WGSL assembler, isolated from GLSL modules and hooks. */
+  private static defaultWGSLShaderAssembler: WGSLShaderAssembler;
+  /** Shader language accepted by this assembler. */
+  abstract readonly shaderLanguage: 'glsl' | 'wgsl';
   /** Hook functions */
-  private readonly _hookFunctions: any[] = [];
+  protected readonly _hookFunctions: any[] = [];
   /** Shader modules */
-  private _defaultModules: ShaderModule[] = [];
-  /** Stable per-run WGSL auto-binding assignments keyed by group/module/binding. */
-  private readonly _wgslBindingRegistry = new Map<string, number>();
+  protected _defaultModules: ShaderModule[] = [];
 
   /**
    * A default shader assembler instance - the natural place to register default modules and hooks
-   * @returns Shared default shader assembler.
+   * @param shaderLanguage Shader language whose shared assembler should be returned.
+   * @returns Shared default shader assembler for the requested language.
    */
-  static getDefaultShaderAssembler(): ShaderAssembler {
+  static getDefaultShaderAssembler(): GLSLShaderAssembler;
+  static getDefaultShaderAssembler(shaderLanguage: 'glsl'): GLSLShaderAssembler;
+  static getDefaultShaderAssembler(shaderLanguage: 'wgsl'): WGSLShaderAssembler;
+  static getDefaultShaderAssembler(
+    shaderLanguage: 'glsl' | 'wgsl'
+  ): GLSLShaderAssembler | WGSLShaderAssembler;
+  static getDefaultShaderAssembler(
+    shaderLanguage: 'glsl' | 'wgsl' = 'glsl'
+  ): GLSLShaderAssembler | WGSLShaderAssembler {
+    if (shaderLanguage === 'wgsl') {
+      ShaderAssembler.defaultWGSLShaderAssembler =
+        ShaderAssembler.defaultWGSLShaderAssembler || new WGSLShaderAssembler();
+      return ShaderAssembler.defaultWGSLShaderAssembler;
+    }
+
     ShaderAssembler.defaultShaderAssembler =
-      ShaderAssembler.defaultShaderAssembler || new ShaderAssembler();
+      ShaderAssembler.defaultShaderAssembler || new GLSLShaderAssembler();
     return ShaderAssembler.defaultShaderAssembler;
   }
 
@@ -78,7 +95,75 @@ export class ShaderAssembler {
   }
 
   /**
-   * Assemble a WGSL unified shader
+   * Dedupe and combine with default modules
+   */
+  _getModuleList(appModules: ShaderModule[] = []): ShaderModule[] {
+    const modules = new Array<ShaderModule>(this._defaultModules.length + appModules.length);
+    const seen: Record<string, boolean> = {};
+    let count = 0;
+
+    for (let i = 0, len = this._defaultModules.length; i < len; ++i) {
+      const module = this._defaultModules[i];
+      const name = module.name;
+      modules[count++] = module;
+      seen[name] = true;
+    }
+
+    for (let i = 0, len = appModules.length; i < len; ++i) {
+      const module = appModules[i];
+      const name = module.name;
+      if (!seen[name]) {
+        modules[count++] = module;
+        seen[name] = true;
+      }
+    }
+
+    modules.length = count;
+
+    initializeShaderModules(modules);
+    return modules;
+  }
+}
+
+/** Stateful assembler for GLSL vertex and fragment shaders. */
+export class GLSLShaderAssembler extends ShaderAssembler {
+  readonly shaderLanguage: 'glsl' = 'glsl';
+
+  /**
+   * Assemble a pair of shaders into a single shader program.
+   * @param props GLSL vertex and fragment source, platform information, shader modules, defines, and injections.
+   * @returns Assembled GLSL source, resolved modules, and combined uniform getter.
+   */
+  assembleGLSLShaderPair(props: AssembleShaderProps): {
+    vs: string;
+    fs: string;
+    getUniforms: GetUniformsFunc;
+    modules: ShaderModule[];
+  } {
+    const modules = this._getModuleList(props.modules); // Combine with default modules
+    const hookFunctions = this._hookFunctions; // TODO - combine with default hook functions
+    const assembled = assembleGLSLShaderPair({
+      ...props,
+      // @ts-expect-error
+      vs: props.vs,
+      // @ts-expect-error
+      fs: props.fs,
+      modules,
+      hookFunctions
+    });
+
+    return {...assembled, modules};
+  }
+}
+
+/** Stateful assembler for unified WGSL shaders. */
+export class WGSLShaderAssembler extends ShaderAssembler {
+  readonly shaderLanguage: 'wgsl' = 'wgsl';
+  /** Stable per-run WGSL auto-binding assignments keyed by group/module/binding. */
+  private readonly _wgslBindingRegistry = new Map<string, number>();
+
+  /**
+   * Assemble a WGSL unified shader.
    * @param props WGSL source, platform information, shader modules, defines, and injections.
    * @returns Assembled WGSL source, resolved modules, uniforms, and binding debug metadata.
    */
@@ -125,62 +210,6 @@ export class ShaderAssembler {
         vertexEntryPoint: props.vertexEntryPoint
       })
     };
-  }
-
-  /**
-   * Assemble a pair of shaders into a single shader program
-   * @param props GLSL vertex and fragment source, platform information, shader modules, defines, and injections.
-   * @returns Assembled GLSL source, resolved modules, and combined uniform getter.
-   */
-  assembleGLSLShaderPair(props: AssembleShaderProps): {
-    vs: string;
-    fs: string;
-    getUniforms: GetUniformsFunc;
-    modules: ShaderModule[];
-  } {
-    const modules = this._getModuleList(props.modules); // Combine with default modules
-    const hookFunctions = this._hookFunctions; // TODO - combine with default hook functions
-    const assembled = assembleGLSLShaderPair({
-      ...props,
-      // @ts-expect-error
-      vs: props.vs,
-      // @ts-expect-error
-      fs: props.fs,
-      modules,
-      hookFunctions
-    });
-
-    return {...assembled, modules};
-  }
-
-  /**
-   * Dedupe and combine with default modules
-   */
-  _getModuleList(appModules: ShaderModule[] = []): ShaderModule[] {
-    const modules = new Array<ShaderModule>(this._defaultModules.length + appModules.length);
-    const seen: Record<string, boolean> = {};
-    let count = 0;
-
-    for (let i = 0, len = this._defaultModules.length; i < len; ++i) {
-      const module = this._defaultModules[i];
-      const name = module.name;
-      modules[count++] = module;
-      seen[name] = true;
-    }
-
-    for (let i = 0, len = appModules.length; i < len; ++i) {
-      const module = appModules[i];
-      const name = module.name;
-      if (!seen[name]) {
-        modules[count++] = module;
-        seen[name] = true;
-      }
-    }
-
-    modules.length = count;
-
-    initializeShaderModules(modules);
-    return modules;
   }
 }
 

--- a/modules/shadertools/src/lib/shader-assembler.ts
+++ b/modules/shadertools/src/lib/shader-assembler.ts
@@ -16,6 +16,7 @@ import {
 } from './shader-assembly/wgsl-binding-debug';
 import {preprocess} from './preprocessor/preprocessor';
 import {scanWGSLInterface} from './shader-assembly/wgsl-interface-scan';
+import {assert} from './utils/assert';
 import type {ShaderLayout} from '@luma.gl/core';
 
 /**
@@ -23,10 +24,11 @@ import type {ShaderLayout} from '@luma.gl/core';
  * Supports setting of default modules and hooks.
  */
 export abstract class ShaderAssembler {
-  /** Default GLSL assembler, retained for compatibility with existing applications. */
-  static defaultShaderAssembler: GLSLShaderAssembler;
-  /** Default WGSL assembler, isolated from GLSL modules and hooks. */
-  private static defaultWGSLShaderAssembler: WGSLShaderAssembler;
+  /** Shared assemblers, with independent module and hook state for each shader language. */
+  private static readonly defaultShaderAssemblers: {
+    glsl?: GLSLShaderAssembler;
+    wgsl?: WGSLShaderAssembler;
+  } = {};
   /** Shader language accepted by this assembler. */
   abstract readonly shaderLanguage: 'glsl' | 'wgsl';
   /** Hook functions */
@@ -39,24 +41,26 @@ export abstract class ShaderAssembler {
    * @param shaderLanguage Shader language whose shared assembler should be returned.
    * @returns Shared default shader assembler for the requested language.
    */
-  static getDefaultShaderAssembler(): GLSLShaderAssembler;
   static getDefaultShaderAssembler(shaderLanguage: 'glsl'): GLSLShaderAssembler;
   static getDefaultShaderAssembler(shaderLanguage: 'wgsl'): WGSLShaderAssembler;
   static getDefaultShaderAssembler(
     shaderLanguage: 'glsl' | 'wgsl'
   ): GLSLShaderAssembler | WGSLShaderAssembler;
   static getDefaultShaderAssembler(
-    shaderLanguage: 'glsl' | 'wgsl' = 'glsl'
+    shaderLanguage: 'glsl' | 'wgsl'
   ): GLSLShaderAssembler | WGSLShaderAssembler {
+    // Shader language must be explicit to avoid mixing GLSL and WGSL hooks.
+    assert(shaderLanguage === 'glsl' || shaderLanguage === 'wgsl');
+
     if (shaderLanguage === 'wgsl') {
-      ShaderAssembler.defaultWGSLShaderAssembler =
-        ShaderAssembler.defaultWGSLShaderAssembler || new WGSLShaderAssembler();
-      return ShaderAssembler.defaultWGSLShaderAssembler;
+      ShaderAssembler.defaultShaderAssemblers.wgsl =
+        ShaderAssembler.defaultShaderAssemblers.wgsl || new WGSLShaderAssembler();
+      return ShaderAssembler.defaultShaderAssemblers.wgsl;
     }
 
-    ShaderAssembler.defaultShaderAssembler =
-      ShaderAssembler.defaultShaderAssembler || new GLSLShaderAssembler();
-    return ShaderAssembler.defaultShaderAssembler;
+    ShaderAssembler.defaultShaderAssemblers.glsl =
+      ShaderAssembler.defaultShaderAssemblers.glsl || new GLSLShaderAssembler();
+    return ShaderAssembler.defaultShaderAssemblers.glsl;
   }
 
   /**
@@ -177,7 +181,7 @@ export class WGSLShaderAssembler extends ShaderAssembler {
   } {
     const modules = this._getModuleList(props.modules); // Combine with default modules
     const hookFunctions = this._hookFunctions; // TODO - combine with default hook functions
-    const defines = getShaderPreprocessorDefines(props, modules);
+    const defines = WGSLShaderAssembler.getShaderPreprocessorDefines(props, modules);
     const preprocessedApplicationSource =
       props.platformInfo.shaderLanguage === 'wgsl' && props.source
         ? preprocess(props.source, {defines})
@@ -211,33 +215,33 @@ export class WGSLShaderAssembler extends ShaderAssembler {
       })
     };
   }
-}
 
-function getShaderPreprocessorDefines(
-  props: AssembleShaderProps,
-  modules: ShaderModule[]
-): Record<string, boolean | number> {
-  return {
-    ...getPlatformPreprocessorDefines(props.platformInfo),
-    ...modules.reduce<Record<string, boolean | number>>((accumulator, module) => {
-      Object.assign(accumulator, module.defines);
-      return accumulator;
-    }, {}),
-    ...props.defines
-  };
-}
+  private static getShaderPreprocessorDefines(
+    props: AssembleShaderProps,
+    modules: ShaderModule[]
+  ): Record<string, boolean | number> {
+    return {
+      ...WGSLShaderAssembler.getPlatformPreprocessorDefines(props.platformInfo),
+      ...modules.reduce<Record<string, boolean | number>>((accumulator, module) => {
+        Object.assign(accumulator, module.defines);
+        return accumulator;
+      }, {}),
+      ...props.defines
+    };
+  }
 
-function getPlatformPreprocessorDefines(
-  platformInfo: AssembleShaderProps['platformInfo']
-): Record<string, boolean> {
-  const limits = platformInfo.limits || {};
-  return {
-    LUMA_SUPPORTS_VERTEX_STORAGE_BUFFERS:
-      platformInfo.type === 'webgpu' && (limits['maxStorageBuffersInVertexStage'] || 0) > 0,
-    // Metal may reassociate the floating-point transforms used by classic
-    // double-single arithmetic. The integer path makes each rounding point
-    // explicit while preserving the public vec2<f32> representation.
-    LUMA_FP64_INTEGER_ARITHMETIC:
-      platformInfo.type === 'webgpu' && platformInfo.gpu.toLowerCase() === 'apple'
-  };
+  private static getPlatformPreprocessorDefines(
+    platformInfo: AssembleShaderProps['platformInfo']
+  ): Record<string, boolean> {
+    const limits = platformInfo.limits || {};
+    return {
+      LUMA_SUPPORTS_VERTEX_STORAGE_BUFFERS:
+        platformInfo.type === 'webgpu' && (limits['maxStorageBuffersInVertexStage'] || 0) > 0,
+      // Metal may reassociate the floating-point transforms used by classic
+      // double-single arithmetic. The integer path makes each rounding point
+      // explicit while preserving the public vec2<f32> representation.
+      LUMA_FP64_INTEGER_ARITHMETIC:
+        platformInfo.type === 'webgpu' && platformInfo.gpu.toLowerCase() === 'apple'
+    };
+  }
 }

--- a/modules/shadertools/test/lib/shader-assembler.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembler.spec.ts
@@ -255,47 +255,111 @@ test('ShaderAssembler#defaultModules', t => {
 });
 
 test('ShaderAssembler#getDefaultShaderAssembler isolates shader language state', t => {
-  const glslShaderAssembler = ShaderAssembler.getDefaultShaderAssembler();
+  const glslShaderAssembler = ShaderAssembler.getDefaultShaderAssembler('glsl');
   const wgslShaderAssembler = ShaderAssembler.getDefaultShaderAssembler('wgsl');
 
-  t.ok(glslShaderAssembler instanceof GLSLShaderAssembler, 'GLSL remains the default assembler');
-  t.ok(wgslShaderAssembler instanceof WGSLShaderAssembler, 'WGSL gets its own default assembler');
+  t.ok(glslShaderAssembler instanceof GLSLShaderAssembler, 'GLSL selects the GLSL assembler');
+  t.ok(wgslShaderAssembler instanceof WGSLShaderAssembler, 'WGSL selects the WGSL assembler');
+  t.equal(glslShaderAssembler.shaderLanguage, 'glsl', 'the GLSL default identifies its language');
+  t.equal(wgslShaderAssembler.shaderLanguage, 'wgsl', 'the WGSL default identifies its language');
   t.equal(
     ShaderAssembler.getDefaultShaderAssembler('glsl'),
     glslShaderAssembler,
-    'explicit GLSL requests reuse the default assembler'
+    'explicit GLSL requests reuse the GLSL assembler'
   );
   t.equal(
     ShaderAssembler.getDefaultShaderAssembler('wgsl'),
     wgslShaderAssembler,
-    'WGSL requests reuse the WGSL default assembler'
+    'explicit WGSL requests reuse the WGSL assembler'
   );
   t.notEqual(glslShaderAssembler, wgslShaderAssembler, 'shader languages never share an assembler');
-
-  const isolatedWGSLShaderAssembler = new WGSLShaderAssembler();
-  const initialGLSLSource = glslShaderAssembler.assembleGLSLShaderPair({platformInfo, vs, fs}).vs;
-  isolatedWGSLShaderAssembler.addShaderHook(
-    'vs:LUMAGL_isolatedDefaultHook(value: ptr<function, vec4<f32>>)'
+  t.equal(
+    typeof glslShaderAssembler.assembleGLSLShaderPair,
+    'function',
+    'GLSL assemblers expose GLSL assembly'
+  );
+  t.notOk(
+    'assembleWGSLShader' in glslShaderAssembler,
+    'GLSL assemblers do not expose WGSL assembly'
+  );
+  t.equal(
+    typeof wgslShaderAssembler.assembleWGSLShader,
+    'function',
+    'WGSL assemblers expose WGSL assembly'
+  );
+  t.notOk(
+    'assembleGLSLShaderPair' in wgslShaderAssembler,
+    'WGSL assemblers do not expose GLSL assembly'
+  );
+  t.throws(
+    () => Reflect.apply(ShaderAssembler.getDefaultShaderAssembler, ShaderAssembler, []),
+    'a shader language must be supplied explicitly'
+  );
+  t.throws(
+    () => Reflect.apply(ShaderAssembler.getDefaultShaderAssembler, ShaderAssembler, ['spirv']),
+    'unsupported shader languages are rejected'
   );
 
-  const assembledWGSLSource = isolatedWGSLShaderAssembler.assembleWGSLShader({
-    platformInfo: wgslPlatformInfo,
-    source: wgslSource
-  }).source;
-  const retainedGLSLSource = glslShaderAssembler.assembleGLSLShaderPair({
+  const isolatedGLSLShaderAssembler = new GLSLShaderAssembler();
+  const isolatedWGSLShaderAssembler = new WGSLShaderAssembler();
+  const initialGLSLDefaultSource = glslShaderAssembler.assembleGLSLShaderPair({
     platformInfo,
     vs,
     fs
   }).vs;
+  const initialWGSLDefaultSource = wgslShaderAssembler.assembleWGSLShader({
+    platformInfo: wgslPlatformInfo,
+    source: wgslSource
+  }).source;
+  isolatedGLSLShaderAssembler.addShaderHook('vs:LUMAGL_isolatedHook(inout vec4 value)');
+  isolatedWGSLShaderAssembler.addShaderHook(
+    'vs:LUMAGL_isolatedHook(value: ptr<function, vec4<f32>>)'
+  );
+
+  const assembledGLSLSource = isolatedGLSLShaderAssembler.assembleGLSLShaderPair({
+    platformInfo,
+    vs,
+    fs
+  }).vs;
+  const assembledWGSLSource = isolatedWGSLShaderAssembler.assembleWGSLShader({
+    platformInfo: wgslPlatformInfo,
+    source: wgslSource
+  }).source;
+  const retainedGLSLDefaultSource = glslShaderAssembler.assembleGLSLShaderPair({
+    platformInfo,
+    vs,
+    fs
+  }).vs;
+  const retainedWGSLDefaultSource = wgslShaderAssembler.assembleWGSLShader({
+    platformInfo: wgslPlatformInfo,
+    source: wgslSource
+  }).source;
 
   t.ok(
-    assembledWGSLSource.includes('fn LUMAGL_isolatedDefaultHook('),
-    'WGSL hooks are installed on the WGSL assembler without mutating its shared default'
+    assembledGLSLSource.includes('void LUMAGL_isolatedHook(inout vec4 value)'),
+    'GLSL assemblers retain their own GLSL hook signatures'
   );
-  t.equal(retainedGLSLSource, initialGLSLSource, 'WGSL hooks never mutate the GLSL default');
+  t.ok(
+    assembledWGSLSource.includes('fn LUMAGL_isolatedHook(value: ptr<function, vec4<f32>>)'),
+    'WGSL assemblers retain their own WGSL hook signatures'
+  );
+  t.equal(
+    retainedGLSLDefaultSource,
+    initialGLSLDefaultSource,
+    'isolated hooks never mutate the GLSL default'
+  );
+  t.equal(
+    retainedWGSLDefaultSource,
+    initialWGSLDefaultSource,
+    'isolated hooks never mutate the WGSL default'
+  );
   t.notOk(
-    retainedGLSLSource.includes('LUMAGL_isolatedDefaultHook'),
-    'WGSL hooks are absent from GLSL source'
+    retainedGLSLDefaultSource.includes('LUMAGL_isolatedHook'),
+    'isolated hooks are absent from shared GLSL source'
+  );
+  t.notOk(
+    retainedWGSLDefaultSource.includes('LUMAGL_isolatedHook'),
+    'isolated hooks are absent from shared WGSL source'
   );
 
   t.end();

--- a/modules/shadertools/test/lib/shader-assembler.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembler.spec.ts
@@ -3,7 +3,14 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {ShaderAssembler, PlatformInfo, picking, dirlight} from '@luma.gl/shadertools';
+import {
+  GLSLShaderAssembler,
+  ShaderAssembler,
+  WGSLShaderAssembler,
+  type PlatformInfo,
+  picking,
+  dirlight
+} from '@luma.gl/shadertools';
 
 const platformInfo: PlatformInfo = {
   type: 'webgl',
@@ -27,6 +34,21 @@ precision highp float;
 out vec4 fragmentColor;
 void main(void) {
   fragmentColor = vec4(1.0, 1.0, 1.0, 1.0);
+}
+`;
+
+const wgslPlatformInfo: PlatformInfo = {
+  type: 'webgpu',
+  gpu: 'test-gpu',
+  shaderLanguage: 'wgsl',
+  shaderLanguageVersion: 300,
+  features: new Set()
+};
+
+const wgslSource = /* wgsl */ `\
+@vertex
+fn vertexMain() -> @builtin(position) vec4<f32> {
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
 }
 `;
 
@@ -61,7 +83,7 @@ const FS_300 = /* glsl *`\
 */
 
 test('ShaderAssembler#hooks', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new GLSLShaderAssembler();
 
   const preHookShaders = shaderAssembler.assembleGLSLShaderPair({platformInfo, vs, fs});
 
@@ -180,7 +202,7 @@ test('ShaderAssembler#hooks', t => {
 });
 
 test('ShaderAssembler#defaultModules', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new GLSLShaderAssembler();
 
   const program = shaderAssembler.assembleGLSLShaderPair({platformInfo, vs, fs});
 
@@ -228,6 +250,53 @@ test('ShaderAssembler#defaultModules', t => {
   // TODO - this deep equal thing doesn't make sense due to getUniforms
   t.notDeepEqual(defaultModuleProgram, uncachedProgram, 'Program is not cached');
   t.deepEqual(preDefaultModuleSource, defaultModuleSource, 'Default modules create correct source');
+
+  t.end();
+});
+
+test('ShaderAssembler#getDefaultShaderAssembler isolates shader language state', t => {
+  const glslShaderAssembler = ShaderAssembler.getDefaultShaderAssembler();
+  const wgslShaderAssembler = ShaderAssembler.getDefaultShaderAssembler('wgsl');
+
+  t.ok(glslShaderAssembler instanceof GLSLShaderAssembler, 'GLSL remains the default assembler');
+  t.ok(wgslShaderAssembler instanceof WGSLShaderAssembler, 'WGSL gets its own default assembler');
+  t.equal(
+    ShaderAssembler.getDefaultShaderAssembler('glsl'),
+    glslShaderAssembler,
+    'explicit GLSL requests reuse the default assembler'
+  );
+  t.equal(
+    ShaderAssembler.getDefaultShaderAssembler('wgsl'),
+    wgslShaderAssembler,
+    'WGSL requests reuse the WGSL default assembler'
+  );
+  t.notEqual(glslShaderAssembler, wgslShaderAssembler, 'shader languages never share an assembler');
+
+  const isolatedWGSLShaderAssembler = new WGSLShaderAssembler();
+  const initialGLSLSource = glslShaderAssembler.assembleGLSLShaderPair({platformInfo, vs, fs}).vs;
+  isolatedWGSLShaderAssembler.addShaderHook(
+    'vs:LUMAGL_isolatedDefaultHook(value: ptr<function, vec4<f32>>)'
+  );
+
+  const assembledWGSLSource = isolatedWGSLShaderAssembler.assembleWGSLShader({
+    platformInfo: wgslPlatformInfo,
+    source: wgslSource
+  }).source;
+  const retainedGLSLSource = glslShaderAssembler.assembleGLSLShaderPair({
+    platformInfo,
+    vs,
+    fs
+  }).vs;
+
+  t.ok(
+    assembledWGSLSource.includes('fn LUMAGL_isolatedDefaultHook('),
+    'WGSL hooks are installed on the WGSL assembler without mutating its shared default'
+  );
+  t.equal(retainedGLSLSource, initialGLSLSource, 'WGSL hooks never mutate the GLSL default');
+  t.notOk(
+    retainedGLSLSource.includes('LUMAGL_isolatedDefaultHook'),
+    'WGSL hooks are absent from GLSL source'
+  );
 
   t.end();
 });

--- a/modules/shadertools/test/lib/shader-assembly/assemble-shaders.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembly/assemble-shaders.spec.ts
@@ -11,7 +11,7 @@ import {
   fp64,
   pbrMaterial,
   PlatformInfo,
-  ShaderAssembler
+  WGSLShaderAssembler
 } from '@luma.gl/shadertools';
 import type {WebGLDevice} from '@luma.gl/webgl';
 import {isBrowser} from '@probe.gl/env';
@@ -748,8 +748,8 @@ test('assembleGLSLShaderPair#shaderhooks', async t => {
   t.end();
 });
 
-test('ShaderAssembler#assembleWGSLShader supports hooks and named injections', t => {
-  const shaderAssembler = new ShaderAssembler();
+test('WGSLShaderAssembler#assembleWGSLShader supports hooks and named injections', t => {
+  const shaderAssembler = new WGSLShaderAssembler();
   shaderAssembler.addShaderHook('vs:OFFSET_POSITION(position: ptr<function, vec4<f32>>)');
   shaderAssembler.addShaderHook('fs:FILTER_COLOR(color: ptr<function, vec4<f32>>)');
 

--- a/modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {ShaderAssembler, type PlatformInfo, type ShaderModule} from '@luma.gl/shadertools';
+import {WGSLShaderAssembler, type PlatformInfo, type ShaderModule} from '@luma.gl/shadertools';
 import {getShaderLayoutFromWGSL} from '@luma.gl/webgpu';
 import {skin} from '../../../src/modules/engine/skin/skin';
 import {ibl} from '../../../src/modules/lighting/ibl/ibl';
@@ -38,7 +38,7 @@ fn vertexMain(@builtin(vertex_index) vertexIndex: u32) -> @builtin(position) vec
 `;
 
 test('assembleWGSLShader#selects optimizer-independent fp64 arithmetic', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
 
   const appleSource = shaderAssembler.assembleWGSLShader({
     platformInfo: {...PLATFORM_INFO, gpu: 'apple'},
@@ -448,7 +448,7 @@ var<uniform> unsupportedModuleBinding: UnsupportedAutoBindingUniforms;
 };
 
 test('assembleWGSLShader#relocates stock group 0 auto bindings', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_WGSL,
@@ -539,7 +539,7 @@ test('assembleWGSLShader#relocates stock group 0 auto bindings', t => {
 });
 
 test('assembleWGSLShader#allocates multiple auto bindings in one module', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_WGSL,
@@ -570,7 +570,7 @@ test('assembleWGSLShader#allocates multiple auto bindings in one module', t => {
 });
 
 test('assembleWGSLShader#relocates application group 0 auto bindings from 0', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_GROUP_0_AUTO_WGSL,
@@ -591,7 +591,7 @@ test('assembleWGSLShader#relocates application group 0 auto bindings from 0', t 
 });
 
 test('assembleWGSLShader#relocates multiline application group 0 auto bindings', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_MULTILINE_GROUP_0_AUTO_WGSL,
@@ -612,7 +612,7 @@ test('assembleWGSLShader#relocates multiline application group 0 auto bindings',
 });
 
 test('assembleWGSLShader#allocates multiple application auto bindings in declaration order', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_MULTIPLE_AUTO_WGSL,
@@ -632,7 +632,7 @@ test('assembleWGSLShader#allocates multiple application auto bindings in declara
 });
 
 test('assembleWGSLShader#application auto bindings skip occupied slots', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_EXPLICIT_AND_AUTO_WGSL,
@@ -652,7 +652,7 @@ test('assembleWGSLShader#application auto bindings skip occupied slots', t => {
 });
 
 test('assembleWGSLShader#multiline explicit application bindings reserve occupied slots', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_MULTILINE_EXPLICIT_AND_AUTO_WGSL,
@@ -672,7 +672,7 @@ test('assembleWGSLShader#multiline explicit application bindings reserve occupie
 });
 
 test('assembleWGSLShader#supports binding-first module auto declarations', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_WGSL,
@@ -693,7 +693,7 @@ test('assembleWGSLShader#supports binding-first module auto declarations', t => 
 });
 
 test('assembleWGSLShader#multiline module bindings are discovered for reservation and relocation', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_WGSL,
@@ -718,7 +718,7 @@ test('assembleWGSLShader#multiline module bindings are discovered for reservatio
 });
 
 test('assembleWGSLShader#ignores line-comment binding annotations before private state', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_WGSL,
@@ -739,7 +739,7 @@ test('assembleWGSLShader#ignores line-comment binding annotations before private
 });
 
 test('assembleWGSLShader#ignores commented binding annotations above real bindings', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_WGSL,
@@ -760,7 +760,7 @@ test('assembleWGSLShader#ignores commented binding annotations above real bindin
 });
 
 test('assembleWGSLShader#ignores block-comment binding annotations before private state', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_WGSL,
@@ -781,7 +781,7 @@ test('assembleWGSLShader#ignores block-comment binding annotations before privat
 });
 
 test('assembleWGSLShader#binding table excludes commented declarations', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_WGSL,
@@ -802,7 +802,7 @@ test('assembleWGSLShader#binding table excludes commented declarations', t => {
 });
 
 test('assembleWGSLShader#relocates stock group 2 auto bindings in deterministic order', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_WGSL,
@@ -887,7 +887,7 @@ test('assembleWGSLShader#relocates stock group 2 auto bindings in deterministic 
 });
 
 test('assembleWGSLShader#allocates group 0 auto bindings in dependency order', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledSource = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_WGSL,
@@ -907,7 +907,7 @@ test('assembleWGSLShader#allocates group 0 auto bindings in dependency order', t
 });
 
 test('assembleWGSLShader#application group 0 auto bindings reserve low slots before modules', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_GROUP_0_AUTO_WITH_MODULE_WGSL,
@@ -934,7 +934,7 @@ test('assembleWGSLShader#application group 0 auto bindings reserve low slots bef
 });
 
 test('assembleWGSLShader#preprocesses platform limit conditionals before auto binding relocation', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: {
       ...PLATFORM_INFO,
@@ -953,7 +953,7 @@ test('assembleWGSLShader#preprocesses platform limit conditionals before auto bi
     'inactive vertex storage binding is not assigned a binding slot'
   );
 
-  const storageShader = new ShaderAssembler().assembleWGSLShader({
+  const storageShader = new WGSLShaderAssembler().assembleWGSLShader({
     platformInfo: {
       ...PLATFORM_INFO,
       limits: {maxStorageBuffersInVertexStage: 1}
@@ -974,7 +974,7 @@ test('assembleWGSLShader#preprocesses platform limit conditionals before auto bi
 });
 
 test('assembleWGSLShader#preprocesses module conditionals before auto binding relocation', t => {
-  const textureShader = new ShaderAssembler().assembleWGSLShader({
+  const textureShader = new WGSLShaderAssembler().assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_GROUP_0_AUTO_WGSL,
     modules: [CONDITIONAL_DEPTH_MODULE],
@@ -994,7 +994,7 @@ test('assembleWGSLShader#preprocesses module conditionals before auto binding re
     'only the active texture binding is assigned'
   );
 
-  const depthShader = new ShaderAssembler().assembleWGSLShader({
+  const depthShader = new WGSLShaderAssembler().assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_GROUP_0_AUTO_WGSL,
     modules: [CONDITIONAL_DEPTH_MODULE],
@@ -1018,7 +1018,7 @@ test('assembleWGSLShader#preprocesses module conditionals before auto binding re
 });
 
 test('assembleWGSLShader#application auto bindings allocate before modules in non-zero groups', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const assembledShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source: APP_GROUP_2_AUTO_WITH_MODULE_WGSL,
@@ -1045,7 +1045,7 @@ test('assembleWGSLShader#application auto bindings allocate before modules in no
 });
 
 test('assembleWGSLShader#keeps module auto allocations stable within one assembler', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
 
   const firstShader = shaderAssembler.assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
@@ -1078,7 +1078,7 @@ test('assembleWGSLShader#keeps module auto allocations stable within one assembl
 });
 
 test('assembleWGSLShader#rejects application group 0 bindings above reserved range', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
 
   t.throws(
     () =>
@@ -1106,7 +1106,7 @@ fn vertexMain() -> @builtin(position) vec4<f32> {
 });
 
 test('assembleWGSLShader#rejects explicit module group 0 bindings below reserved range', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
 
   t.throws(
     () =>
@@ -1123,7 +1123,7 @@ test('assembleWGSLShader#rejects explicit module group 0 bindings below reserved
 });
 
 test('assembleWGSLShader#rejects duplicate explicit module bindings', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
 
   t.throws(
     () =>
@@ -1140,7 +1140,7 @@ test('assembleWGSLShader#rejects duplicate explicit module bindings', t => {
 });
 
 test('assembleWGSLShader#rejects unsupported application auto binding declaration forms', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
 
   t.throws(
     () =>
@@ -1157,7 +1157,7 @@ test('assembleWGSLShader#rejects unsupported application auto binding declaratio
 });
 
 test('assembleWGSLShader#rejects unresolved auto bindings with module and binding names', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
 
   t.throws(
     () =>

--- a/modules/shadertools/test/lib/shader-assembly/wgsl-interface-scan.node.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembly/wgsl-interface-scan.node.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
-import {scanWGSLInterface, ShaderAssembler, type PlatformInfo} from '@luma.gl/shadertools';
+import {scanWGSLInterface, WGSLShaderAssembler, type PlatformInfo} from '@luma.gl/shadertools';
 
 const PLATFORM_INFO: PlatformInfo = {
   type: 'webgpu',
@@ -218,7 +218,7 @@ struct BrokenInput {
   t.end();
 });
 
-test('ShaderAssembler#assembleWGSLShader returns the scanned interface', t => {
+test('WGSLShaderAssembler#assembleWGSLShader returns the scanned interface', t => {
   const source = /* wgsl */ `\
 struct FrameUniforms {
   scale: f32,
@@ -231,7 +231,7 @@ fn selectedVertex(@location(1) position: vec3f) -> @builtin(position) vec4f {
   return vec4f(position * frame.scale, 1.0);
 }
 `;
-  const assembledShader = new ShaderAssembler().assembleWGSLShader({
+  const assembledShader = new WGSLShaderAssembler().assembleWGSLShader({
     platformInfo: PLATFORM_INFO,
     source,
     vertexEntryPoint: 'selectedVertex'

--- a/modules/shadertools/test/lib/shader-plugin.spec.ts
+++ b/modules/shadertools/test/lib/shader-plugin.spec.ts
@@ -6,7 +6,8 @@ import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {
   mergeShaderPluginModules,
   resolveShaderPlugins,
-  ShaderAssembler,
+  GLSLShaderAssembler,
+  WGSLShaderAssembler,
   type PlatformInfo,
   type ShaderModule
 } from '@luma.gl/shadertools';
@@ -243,7 +244,7 @@ test('ShaderPlugin#explicit modules win duplicate names', t => {
 });
 
 test('ShaderPlugin#WGSL main injections land in stage bodies', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const resolved = resolveShaderPlugins(
     [
       {
@@ -281,7 +282,7 @@ test('ShaderPlugin#WGSL main injections land in stage bodies', t => {
 });
 
 test('ShaderPlugin#WGSL fragment declarations enter unified shader source', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const resolved = resolveShaderPlugins(
     [
       {
@@ -316,7 +317,7 @@ test('ShaderPlugin#WGSL fragment declarations enter unified shader source', t =>
 });
 
 test('ShaderPlugin#GLSL vertex inputs are declared and conflicts are rejected', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new GLSLShaderAssembler();
   const shaders = shaderAssembler.assembleGLSLShaderPair({
     platformInfo: GLSL_PLATFORM_INFO,
     vs: /* glsl */ `#version 300 es
@@ -351,7 +352,7 @@ void main() { fragmentColor = vec4(1.0); }`,
 });
 
 test('ShaderPlugin#WGSL vertex inputs support direct and struct entry-point inputs', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   shaderAssembler.addShaderHook('vs:FILTER_POSITION(position: ptr<function, vec4<f32>>)');
 
   const assembled = shaderAssembler.assembleWGSLShader({
@@ -421,7 +422,7 @@ fn fragmentMain() -> @location(0) vec4<f32> {
 });
 
 test('ShaderPlugin#WGSL vertex inputs support an entry point without parameters', t => {
-  const assembled = new ShaderAssembler().assembleWGSLShader({
+  const assembled = new WGSLShaderAssembler().assembleWGSLShader({
     platformInfo: WGSL_PLATFORM_INFO,
     source: WGSL_SOURCE,
     pluginVertexInputs: {filterValues: 'f32'}
@@ -439,7 +440,7 @@ test('ShaderPlugin#WGSL vertex inputs support an entry point without parameters'
 });
 
 test('ShaderPlugin#GLSL varyings generate matched stage interfaces', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new GLSLShaderAssembler();
   shaderAssembler.addShaderHook('vs:SET_PLUGIN_VARYINGS()');
   shaderAssembler.addShaderHook('fs:USE_PLUGIN_VARYINGS(inout vec4 color)');
   const shaders = shaderAssembler.assembleGLSLShaderPair({
@@ -500,7 +501,7 @@ void main() { fragmentColor = pluginColor; }`,
 });
 
 test('ShaderPlugin#WGSL varyings extend named stage structs', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   shaderAssembler.addShaderHook('vs:SET_PLUGIN_VARYINGS()');
   shaderAssembler.addShaderHook('fs:USE_PLUGIN_VARYINGS(color: ptr<function, vec4<f32>>)');
   const source = /* wgsl */ `
@@ -601,7 +602,7 @@ fn selectedFragmentMain(inputs: FragmentInput, @builtin(front_facing) frontFacin
 });
 
 test('ShaderPlugin#WGSL varyings reject unsupported interfaces', t => {
-  const assembler = new ShaderAssembler();
+  const assembler = new WGSLShaderAssembler();
   t.throws(
     () =>
       assembler.assembleWGSLShader({

--- a/modules/shadertools/test/modules/color/float-colors.spec.ts
+++ b/modules/shadertools/test/modules/color/float-colors.spec.ts
@@ -13,7 +13,7 @@ import {
   getShaderModuleUniforms,
   normalizeByteColor3,
   normalizeByteColor4,
-  ShaderAssembler,
+  WGSLShaderAssembler,
   STORAGE_COLOR_DEFAULT_BYTE_STRIDES,
   STORAGE_COLOR_FORMAT,
   storageColors,
@@ -185,7 +185,7 @@ void main(void) {
 });
 
 test('storageColors#assembledWGSLContract', t => {
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   const baseColorsShader = shaderAssembler.assembleWGSLShader({
     platformInfo: WGSL_PLATFORM_INFO,
     source: WGSL_COMPUTE_APP,

--- a/modules/shadertools/test/modules/engine/clip.spec.ts
+++ b/modules/shadertools/test/modules/engine/clip.spec.ts
@@ -6,7 +6,7 @@ import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import type {Test} from '@luma.gl/devtools-extensions/tape-test-utils';
 import {Buffer, Device, Texture} from '@luma.gl/core';
 import {Model} from '@luma.gl/engine';
-import {clipShaderPlugin, ShaderAssembler} from '@luma.gl/shadertools';
+import {clipShaderPlugin, GLSLShaderAssembler, WGSLShaderAssembler} from '@luma.gl/shadertools';
 import {getWebGLTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
 
 const WIDTH = 4;
@@ -14,7 +14,7 @@ const HEIGHT = 4;
 
 test('clipShaderPlugin#WebGL2 clips instances and geometry without rebuilding', async t => {
   const device = await getWebGLTestDevice();
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new GLSLShaderAssembler();
   shaderAssembler.addShaderHook(
     'vs:CLIP_POSITION(inout vec4 position, vec2 instanceCoordinates, vec2 geometryCoordinates)'
   );
@@ -60,7 +60,7 @@ test('clipShaderPlugin#WebGPU clips instances and geometry without rebuilding', 
     return;
   }
 
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   shaderAssembler.addShaderHook(
     'vs:CLIP_POSITION(position: ptr<function, vec4<f32>>, instanceCoordinates: vec2<f32>, geometryCoordinates: vec2<f32>)'
   );

--- a/modules/shadertools/test/modules/engine/filter.spec.ts
+++ b/modules/shadertools/test/modules/engine/filter.spec.ts
@@ -5,12 +5,12 @@
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
 import {Buffer} from '@luma.gl/core';
 import {Model} from '@luma.gl/engine';
-import {filterShaderPlugin, ShaderAssembler} from '@luma.gl/shadertools';
+import {filterShaderPlugin, GLSLShaderAssembler, WGSLShaderAssembler} from '@luma.gl/shadertools';
 import {getWebGLTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
 
 test('filterShaderPlugin#WebGL2 model binds, updates, and draws', async t => {
   const device = await getWebGLTestDevice();
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new GLSLShaderAssembler();
   shaderAssembler.addShaderHook('vs:FILTER_POSITION(inout vec4 position)');
   const filterValues = device.createBuffer({
     data: new Float32Array([0.5]),
@@ -56,7 +56,7 @@ test('filterShaderPlugin#WebGPU model binds, updates, and draws', async t => {
     return;
   }
 
-  const shaderAssembler = new ShaderAssembler();
+  const shaderAssembler = new WGSLShaderAssembler();
   shaderAssembler.addShaderHook('vs:FILTER_POSITION(position: ptr<function, vec4<f32>>)');
   const filterValues = device.createBuffer({
     data: new Float32Array([0.5]),


### PR DESCRIPTION
## Goals
- Offer a language-specific luma.gl alternative to visgl/deck.gl#10524 for the cross-backend shader-assembler mutation exposed by visgl/deck.gl#10521.
- Keep GLSL and WGSL hooks, default modules, and binding state isolated without creating an assembler for every Deck.

## Changes
- Make `ShaderAssembler` abstract and export concrete `GLSLShaderAssembler` and `WGSLShaderAssembler` subclasses.
- Require `ShaderAssembler.getDefaultShaderAssembler('glsl' | 'wgsl')`; missing and unsupported languages fail instead of silently selecting GLSL.
- Keep reusable language-specific singleton state private, and move WGSL preprocessing, platform defines, interface scanning, and binding state into `WGSLShaderAssembler`.
- Select explicit languages in `Model`, `Computation`, Arrow/GPGPU helpers, examples, tutorials, and documentation.
- Accept backend-compatible legacy Deck assemblers and duplicate-package instances in `Model` while preserving configured hooks/default modules and rejecting wrong-language assemblers.
- Cover explicit custom assemblers, legacy Deck contexts/defaults, duplicate-package instances, and mismatched backends with five deterministic GPU-free Model regressions.
- Migrate 58 constructor calls in tests and verify subclass-only assembly methods, strict factory arguments, and noncontaminating GLSL/WGSL hooks.
- Bridge the currently installed deck.gl 9.3.4 legacy call only inside its integration test; the adapter restores the strict factory immediately and forwards the actual device language.

## Verification
- `env -u YARN_NO_PROXY yarn lint fix`
- `env -u YARN_NO_PROXY yarn build`
- `env -u YARN_NO_PROXY CI=1 yarn test` — **1,773 tests passed**: 346 Node tests and 1,427 headless Chromium tests; 27 skipped.
- `env -u YARN_NO_PROXY yarn exec vitest run --config vitest.config.ts --project node modules/engine/test/lib/model.node.spec.ts` — all 5 assembler-compatibility regressions passed.
- `env -u YARN_NO_PROXY CI=1 yarn exec vitest run --config vitest.config.ts --project headless modules/arrow-layers/test/layers/arrow-layers.spec.ts` — all 3 deck.gl integration tests passed.

## Compatibility and follow-up
- **Breaking:** replace `new ShaderAssembler()` with the appropriate concrete subclass; narrow base-typed references before calling backend-specific assembly methods.
- **Breaking:** all calls to `ShaderAssembler.getDefaultShaderAssembler` must pass `'glsl'` or `'wgsl'`, including downstream deck.gl; no zero-argument compatibility overload remains.