### PR TITLE
Project Flagship: shared cinematic example cards and gallery

### DIFF
--- a/examples/example-panels.ts
+++ b/examples/example-panels.ts
@@ -20,6 +20,7 @@ import {
 } from '@deck.gl-community/panels';
 import {Fragment, h, render} from 'preact';
 import {useEffect, useState} from 'preact/hooks';
+import {applyExampleTheme, EXAMPLE_THEME_TOKENS} from './example-theme';
 
 const EXAMPLE_PANEL_HOST_ID = 'example-panel-host';
 const EXAMPLE_PANEL_HOST_ATTRIBUTE = 'data-example-panel-host';
@@ -34,21 +35,21 @@ const EXAMPLE_PANEL_STYLE = `
   display: none !important;
 }
 [data-example-panel-host][${EXAMPLE_PANEL_APPEARANCE_ATTRIBUTE}='cinematic'] [data-panel-theme-mode] {
-  --button-background: rgba(15, 23, 42, 0.72) !important;
+  --button-background: var(--luma-example-surface-raised, rgba(15, 23, 42, 0.72)) !important;
   --button-icon-hover: rgb(240, 249, 255) !important;
-  --button-icon-idle: rgb(148, 163, 184) !important;
-  --button-stroke: rgba(148, 163, 184, 0.24) !important;
-  --button-text: rgb(226, 232, 240) !important;
+  --button-icon-idle: var(--luma-example-text-muted, rgb(148, 163, 184)) !important;
+  --button-stroke: var(--luma-example-border, rgba(148, 163, 184, 0.24)) !important;
+  --button-text: var(--luma-example-text, rgb(226, 232, 240)) !important;
   --menu-background: transparent !important;
   --menu-border-color: rgba(148, 163, 184, 0.2) !important;
   --menu-divider: rgba(148, 163, 184, 0.18) !important;
   --menu-item-hover: rgba(125, 211, 252, 0.12) !important;
-  --menu-text: rgb(226, 232, 240) !important;
+  --menu-text: var(--luma-example-text, rgb(226, 232, 240)) !important;
   --menu-weak-background: rgba(15, 23, 42, 0.48) !important;
-  --range-decoration-active-color: rgb(56, 189, 248) !important;
+  --range-decoration-active-color: var(--luma-example-accent, rgb(56, 189, 248)) !important;
   --range-thumb-color: rgb(125, 211, 252) !important;
   --range-track-color: rgba(71, 85, 105, 0.8) !important;
-  color: rgb(226, 232, 240);
+  color: var(--luma-example-text, rgb(226, 232, 240));
   color-scheme: dark;
 }
 [${EXAMPLE_SETTINGS_PANEL_ATTRIBUTE}] [data-setting-row-for] > label,
@@ -479,14 +480,15 @@ export function configurePanelHostElement(
   hostElement.style.minWidth = '0';
   hostElement.style.width = '100%';
   hostElement.setAttribute(EXAMPLE_PANEL_APPEARANCE_ATTRIBUTE, resolvedAppearance);
+  if (resolvedAppearance === 'cinematic' || resolvedAppearance === 'light') {
+    applyExampleTheme(hostElement, resolvedAppearance);
+  }
   hostElement.style.setProperty('--menu-backdrop-filter', 'unset');
   hostElement.style.setProperty(
     '--menu-background',
-    resolvedAppearance === 'cinematic'
-      ? 'rgb(8, 15, 27)'
-      : resolvedAppearance === 'light'
-        ? 'rgb(255, 255, 255)'
-        : 'transparent'
+    resolvedAppearance === 'cinematic' || resolvedAppearance === 'light'
+      ? EXAMPLE_THEME_TOKENS[resolvedAppearance].surface
+      : 'transparent'
   );
   hostElement.style.setProperty('--menu-border', 'none');
   hostElement.style.setProperty('--menu-shadow', 'none');

--- a/examples/example-theme.ts
+++ b/examples/example-theme.ts
@@ -1,0 +1,61 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export type ExampleThemeAppearance = 'cinematic' | 'light';
+
+export type ExampleThemeTokens = {
+  surface: string;
+  surfaceRaised: string;
+  border: string;
+  text: string;
+  textMuted: string;
+  accent: string;
+  radius: string;
+  shadow: string;
+  backdrop: string;
+};
+
+/** Framework-independent visual tokens shared by example cards, panels, and overlays. */
+export const EXAMPLE_THEME_TOKENS = {
+  cinematic: {
+    surface: 'rgb(8, 15, 27)',
+    surfaceRaised: 'rgba(15, 23, 42, 0.72)',
+    border: 'rgba(148, 163, 184, 0.24)',
+    text: 'rgb(226, 232, 240)',
+    textMuted: 'rgb(148, 163, 184)',
+    accent: 'rgb(56, 189, 248)',
+    radius: '14px',
+    shadow: '0 22px 58px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.07)',
+    backdrop: 'blur(18px) saturate(135%)'
+  },
+  light: {
+    surface: 'rgb(255, 255, 255)',
+    surfaceRaised: 'rgb(248, 250, 252)',
+    border: 'rgba(15, 23, 42, 0.1)',
+    text: 'rgb(17, 17, 17)',
+    textMuted: 'rgb(89, 101, 121)',
+    accent: 'rgb(20, 110, 245)',
+    radius: '14px',
+    shadow: '0 12px 32px rgba(0, 0, 0, 0.28)',
+    backdrop: 'none'
+  }
+} as const satisfies Record<ExampleThemeAppearance, ExampleThemeTokens>;
+
+/** Applies inheritable semantic custom properties without depending on a UI framework. */
+export function applyExampleTheme(
+  hostElement: HTMLElement,
+  appearance: ExampleThemeAppearance
+): void {
+  const theme = EXAMPLE_THEME_TOKENS[appearance];
+
+  hostElement.style.setProperty('--luma-example-surface', theme.surface);
+  hostElement.style.setProperty('--luma-example-surface-raised', theme.surfaceRaised);
+  hostElement.style.setProperty('--luma-example-border', theme.border);
+  hostElement.style.setProperty('--luma-example-text', theme.text);
+  hostElement.style.setProperty('--luma-example-text-muted', theme.textMuted);
+  hostElement.style.setProperty('--luma-example-accent', theme.accent);
+  hostElement.style.setProperty('--luma-example-radius', theme.radius);
+  hostElement.style.setProperty('--luma-example-shadow', theme.shadow);
+  hostElement.style.setProperty('--luma-example-backdrop', theme.backdrop);
+}

--- a/test/examples/example-panels.spec.ts
+++ b/test/examples/example-panels.spec.ts
@@ -10,6 +10,7 @@ import {
   makeHtmlCustomPanel,
   makeInlineSettingsSchema
 } from '../../examples/example-panels';
+import {applyExampleTheme, EXAMPLE_THEME_TOKENS} from '../../examples/example-theme';
 import {
   ArrowExamplePanelManager,
   makeArrowExamplePanelHostHtml
@@ -77,6 +78,75 @@ const MULTI_SELECT_SETTINGS_SCHEMA: SettingsSchema = {
 };
 
 describe('ExampleSettingsPanelManager', () => {
+  test('applies the shared cinematic semantic visual tokens', () => {
+    const hostElement = document.createElement('div');
+
+    applyExampleTheme(hostElement, 'cinematic');
+
+    expect(hostElement.style.getPropertyValue('--luma-example-surface')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.surface
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-surface-raised')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.surfaceRaised
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-border')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.border
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-text')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.text
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-text-muted')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.textMuted
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-accent')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.accent
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-radius')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.radius
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-shadow')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.shadow
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-backdrop')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.backdrop
+    );
+  });
+
+  test('replaces cinematic visual tokens with the light appearance', () => {
+    const hostElement = document.createElement('div');
+
+    applyExampleTheme(hostElement, 'cinematic');
+    applyExampleTheme(hostElement, 'light');
+
+    expect(hostElement.style.getPropertyValue('--luma-example-surface')).toBe(
+      EXAMPLE_THEME_TOKENS.light.surface
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-surface-raised')).toBe(
+      EXAMPLE_THEME_TOKENS.light.surfaceRaised
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-border')).toBe(
+      EXAMPLE_THEME_TOKENS.light.border
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-text')).toBe(
+      EXAMPLE_THEME_TOKENS.light.text
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-text-muted')).toBe(
+      EXAMPLE_THEME_TOKENS.light.textMuted
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-accent')).toBe(
+      EXAMPLE_THEME_TOKENS.light.accent
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-radius')).toBe(
+      EXAMPLE_THEME_TOKENS.light.radius
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-shadow')).toBe(
+      EXAMPLE_THEME_TOKENS.light.shadow
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-backdrop')).toBe(
+      EXAMPLE_THEME_TOKENS.light.backdrop
+    );
+  });
+
   test('configures the shared cinematic card appearance for panel content', () => {
     const hostElement = document.createElement('div');
 
@@ -86,6 +156,12 @@ describe('ExampleSettingsPanelManager', () => {
     expect(hostElement.dataset.examplePanelAppearance).toBe('cinematic');
     expect(hostElement.style.getPropertyValue('--menu-background')).toBe('rgb(8, 15, 27)');
     expect(hostElement.style.getPropertyValue('--menu-shadow')).toBe('none');
+    expect(hostElement.style.getPropertyValue('--luma-example-surface')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.surface
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-accent')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.accent
+    );
 
     const cardElement = document.createElement('section');
     const inheritedHostElement = document.createElement('div');
@@ -94,6 +170,41 @@ describe('ExampleSettingsPanelManager', () => {
     configurePanelHostElement(inheritedHostElement);
 
     expect(inheritedHostElement.dataset.examplePanelAppearance).toBe('cinematic');
+    expect(inheritedHostElement.style.getPropertyValue('--luma-example-surface')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.surface
+    );
+    expect(inheritedHostElement.style.getPropertyValue('--luma-example-backdrop')).toBe(
+      EXAMPLE_THEME_TOKENS.cinematic.backdrop
+    );
+  });
+
+  test('inherits the light appearance and preserves the panel framework background', () => {
+    const cardElement = document.createElement('section');
+    const hostElement = document.createElement('div');
+    cardElement.dataset.infoBoxAppearance = 'light';
+    cardElement.appendChild(hostElement);
+
+    configurePanelHostElement(hostElement);
+
+    expect(hostElement.dataset.examplePanelAppearance).toBe('light');
+    expect(hostElement.style.getPropertyValue('--luma-example-surface')).toBe(
+      EXAMPLE_THEME_TOKENS.light.surface
+    );
+    expect(hostElement.style.getPropertyValue('--luma-example-text')).toBe(
+      EXAMPLE_THEME_TOKENS.light.text
+    );
+    expect(hostElement.style.getPropertyValue('--menu-background')).toBe('rgb(255, 255, 255)');
+  });
+
+  test('leaves unthemed hosts available for inherited semantic visual tokens', () => {
+    const hostElement = document.createElement('div');
+
+    configurePanelHostElement(hostElement);
+
+    expect(hostElement.dataset.examplePanelAppearance).toBe('inherit');
+    expect(hostElement.style.getPropertyValue('--luma-example-surface')).toBe('');
+    expect(hostElement.style.getPropertyValue('--luma-example-accent')).toBe('');
+    expect(hostElement.style.getPropertyValue('--menu-background')).toBe('transparent');
   });
 
   test('registers descriptors and forwards structured changes', () => {

--- a/website/src/components/example-card.module.css
+++ b/website/src/components/example-card.module.css
@@ -1,0 +1,293 @@
+.card {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  height: 100%;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--luma-example-border, rgba(148, 163, 184, 0.2));
+  border-radius: var(--luma-example-radius, 16px);
+  background: var(--luma-example-surface, rgba(10, 17, 29, 0.96));
+  box-shadow: var(--luma-example-shadow, 0 18px 42px rgba(2, 6, 23, 0.2));
+  color: var(--luma-example-text, #f1f5f9);
+  text-decoration: none;
+  isolation: isolate;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease;
+}
+
+.card::after {
+  position: absolute;
+  z-index: 2;
+  border: 1px solid rgba(255, 255, 255, 0.045);
+  border-radius: inherit;
+  content: '';
+  inset: 0;
+  pointer-events: none;
+}
+
+.card:hover,
+.card:focus-visible {
+  border-color: var(--luma-example-card-accent, var(--luma-example-accent, #67e8f9));
+  box-shadow:
+    0 24px 56px rgba(2, 6, 23, 0.3),
+    0 0 0 1px color-mix(in srgb, var(--luma-example-card-accent, #67e8f9) 35%, transparent);
+  color: var(--luma-example-text, #f1f5f9);
+  text-decoration: none;
+  transform: translateY(-4px);
+}
+
+.card:focus-visible {
+  outline: 2px solid var(--luma-example-card-accent, var(--luma-example-accent, #67e8f9));
+  outline-offset: 4px;
+}
+
+.poster {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  background: var(--luma-example-surface-raised, #111c2c);
+}
+
+.poster::after {
+  position: absolute;
+  z-index: 1;
+  background:
+    linear-gradient(180deg, rgba(2, 6, 23, 0.48), transparent 38%),
+    linear-gradient(0deg, rgba(2, 6, 23, 0.3), transparent 42%);
+  content: '';
+  inset: 0;
+  pointer-events: none;
+}
+
+.posterImage {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition:
+    opacity 180ms ease,
+    transform 420ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.posterBackdrop {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  filter: blur(18px) saturate(0.8);
+  inset: 0;
+  object-fit: cover;
+  opacity: 0.68;
+  transform: scale(1.12);
+}
+
+.posterPreserved {
+  object-fit: contain;
+}
+
+.card:hover .posterImage,
+.card:focus-visible .posterImage {
+  transform: scale(1.035);
+}
+
+.posterFallback {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background:
+    radial-gradient(
+      ellipse at 70% 18%,
+      color-mix(in srgb, var(--luma-example-card-accent, #67e8f9) 24%, transparent),
+      transparent 48%
+    ),
+    radial-gradient(ellipse at 18% 88%, rgba(99, 102, 241, 0.21), transparent 52%),
+    linear-gradient(145deg, #111c2c, #070d18);
+  inset: 0;
+}
+
+.fallbackMark {
+  width: 76px;
+  color: var(--luma-example-card-accent, var(--luma-example-accent, #67e8f9));
+  filter: drop-shadow(0 0 16px currentColor);
+  opacity: 0.68;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.35;
+}
+
+.fallbackLabel {
+  position: absolute;
+  right: 18px;
+  bottom: 14px;
+  left: 18px;
+  overflow: hidden;
+  color: rgba(226, 232, 240, 0.8);
+  font-size: 0.69rem;
+  font-weight: 650;
+  letter-spacing: 0.09em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.capabilities {
+  position: absolute;
+  z-index: 2;
+  top: 12px;
+  right: 12px;
+  left: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.capability {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 999px;
+  background: rgba(6, 12, 23, 0.82);
+  backdrop-filter: blur(12px);
+  color: #e2e8f0;
+  font-size: 0.66rem;
+  font-weight: 750;
+  letter-spacing: 0.025em;
+  line-height: 1;
+  padding: 6px 8px;
+}
+
+.webgpu {
+  border-color: rgba(103, 232, 249, 0.3);
+  color: #a5f3fc;
+}
+
+.webgl {
+  border-color: rgba(134, 239, 172, 0.25);
+  color: #bbf7d0;
+}
+
+.hdr {
+  border-color: rgba(252, 211, 77, 0.34);
+  background: rgba(59, 36, 6, 0.76);
+  color: #fde68a;
+}
+
+.content {
+  position: relative;
+  display: flex;
+  min-height: 188px;
+  flex: 1 1 auto;
+  flex-direction: column;
+  padding: 17px 17px 16px;
+}
+
+.heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 7px;
+}
+
+.category {
+  overflow: hidden;
+  color: var(--luma-example-card-accent, var(--luma-example-accent, #67e8f9));
+  font-size: 0.65rem;
+  font-weight: 750;
+  letter-spacing: 0.085em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.actionIcon {
+  width: 17px;
+  height: 17px;
+  flex: 0 0 auto;
+  color: var(--luma-example-text-muted, #94a3b8);
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.6;
+  transition:
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.card:hover .actionIcon,
+.card:focus-visible .actionIcon {
+  color: var(--luma-example-card-accent, var(--luma-example-accent, #67e8f9));
+  transform: translate(2px, -2px);
+}
+
+.title {
+  margin: 0;
+  color: var(--luma-example-text, #f1f5f9);
+  font-size: 1.065rem;
+  font-weight: 720;
+  letter-spacing: -0.024em;
+  line-height: 1.3;
+}
+
+.description {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: 7px 0 15px;
+  color: var(--luma-example-text-muted, #94a3b8);
+  font-size: 0.805rem;
+  line-height: 1.55;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.metadata {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: auto;
+}
+
+.metadataBadge {
+  border: 1px solid var(--luma-example-border, rgba(148, 163, 184, 0.2));
+  border-radius: 999px;
+  background: var(--luma-example-surface-raised, rgba(30, 41, 59, 0.64));
+  color: var(--luma-example-text-muted, #a9b6c9);
+  font-size: 0.66rem;
+  font-weight: 590;
+  line-height: 1.15;
+  padding: 4px 7px;
+}
+
+.experimental {
+  border-color: rgba(196, 181, 253, 0.25);
+  color: #ddd6fe;
+}
+
+@media screen and (max-width: 540px) {
+  .content {
+    min-height: 168px;
+    padding: 15px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .posterImage,
+  .actionIcon {
+    transition: none;
+  }
+
+  .card:hover,
+  .card:focus-visible,
+  .card:hover .posterImage,
+  .card:focus-visible .posterImage,
+  .card:hover .actionIcon,
+  .card:focus-visible .actionIcon {
+    transform: none;
+  }
+}

--- a/website/src/components/example-card.tsx
+++ b/website/src/components/example-card.tsx
@@ -1,0 +1,164 @@
+import React, {useState, type CSSProperties} from 'react';
+import styles from './example-card.module.css';
+
+type ExampleCardBackend = 'webgpu' | 'webgl2';
+
+export type ExampleCardProps = {
+  backends: readonly ExampleCardBackend[];
+  category: string;
+  description: string;
+  difficulty: string;
+  highDynamicRange?: boolean;
+  href?: string;
+  imageUrl: string;
+  maturity?: string;
+  title: string;
+  topics?: readonly string[];
+};
+
+type CapabilityBadge = {
+  label: string;
+  tone: 'webgpu' | 'webgl' | 'hdr';
+};
+
+/** Shared cinematic poster card for website galleries and example collections. */
+export function ExampleCard({
+  backends,
+  category,
+  description,
+  difficulty,
+  highDynamicRange = false,
+  href,
+  imageUrl,
+  maturity,
+  title,
+  topics = []
+}: ExampleCardProps): React.JSX.Element {
+  const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null);
+  const [constrainedImageUrl, setConstrainedImageUrl] = useState<string | null>(null);
+  const hasImageError = failedImageUrl === imageUrl;
+  const hasConstrainedImage = constrainedImageUrl === imageUrl;
+  const capabilities = getCapabilityBadges(backends, highDynamicRange);
+  const accentColor = getCardAccent(category, topics);
+  const cardStyle = {'--luma-example-card-accent': accentColor} as CSSProperties;
+  const visibleTopics = [...new Set(topics)].slice(0, 2);
+
+  return (
+    <a className={styles.card} data-example-card="" href={href} style={cardStyle}>
+      <div className={styles.poster} data-image-state={hasImageError ? 'fallback' : 'ready'}>
+        <div className={styles.posterFallback} aria-hidden="true">
+          <svg className={styles.fallbackMark} viewBox="0 0 88 88" fill="none">
+            <path d="M44 7 76 25.5v37L44 81 12 62.5v-37L44 7Z" />
+            <path d="m12 25.5 32 18.5 32-18.5M44 44v37" />
+            <circle cx="44" cy="44" r="7" />
+          </svg>
+          <span className={styles.fallbackLabel}>{title}</span>
+        </div>
+        {!hasImageError ? (
+          <>
+            {hasConstrainedImage ? (
+              <img
+                className={styles.posterBackdrop}
+                src={imageUrl}
+                alt=""
+                aria-hidden="true"
+                loading="lazy"
+                decoding="async"
+              />
+            ) : null}
+            <img
+              className={`${styles.posterImage}${hasConstrainedImage ? ` ${styles.posterPreserved}` : ''}`}
+              src={imageUrl}
+              alt=""
+              width={1280}
+              height={720}
+              loading="lazy"
+              decoding="async"
+              onLoad={event => {
+                const {naturalHeight, naturalWidth} = event.currentTarget;
+                if (naturalHeight > 0 && naturalWidth / naturalHeight < 1.5) {
+                  setConstrainedImageUrl(imageUrl);
+                }
+              }}
+              onError={() => setFailedImageUrl(imageUrl)}
+            />
+          </>
+        ) : null}
+        <div className={styles.capabilities} aria-label="Example capabilities">
+          {capabilities.map(capability => (
+            <span
+              className={`${styles.capability} ${styles[capability.tone]}`}
+              key={capability.label}
+            >
+              {capability.label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.content}>
+        <div className={styles.heading}>
+          <span className={styles.category}>{category}</span>
+          <svg className={styles.actionIcon} viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <path d="M6 14 14 6M7 6h7v7" />
+          </svg>
+        </div>
+        <h3 className={styles.title}>{title}</h3>
+        <p className={styles.description}>{description}</p>
+
+        <div className={styles.metadata} aria-label="Example details">
+          <span className={styles.metadataBadge}>{formatCardLabel(difficulty)}</span>
+          {visibleTopics.map(topic => (
+            <span className={styles.metadataBadge} key={topic}>
+              {formatCardLabel(topic)}
+            </span>
+          ))}
+          {maturity === 'experimental' ? (
+            <span className={`${styles.metadataBadge} ${styles.experimental}`}>Experimental</span>
+          ) : null}
+        </div>
+      </div>
+    </a>
+  );
+}
+
+function getCapabilityBadges(
+  backends: readonly ExampleCardBackend[],
+  highDynamicRange: boolean
+): CapabilityBadge[] {
+  const badges: CapabilityBadge[] = backends.map(backend =>
+    backend === 'webgpu' ? {label: 'WebGPU', tone: 'webgpu'} : {label: 'WebGL2', tone: 'webgl'}
+  );
+
+  if (highDynamicRange) {
+    badges.push({label: 'HDR', tone: 'hdr'});
+  }
+
+  return badges;
+}
+
+function getCardAccent(category: string, topics: readonly string[]): string {
+  if (category === 'WebGPU') return '#67e8f9';
+  if (category === 'Tutorials') return '#6ee7b7';
+  if (category === 'Showcase') return '#c4b5fd';
+  if (category.includes('Arrow') || category.includes('Data')) return '#93c5fd';
+  if (topics.includes('effects')) return '#f9a8d4';
+  if (topics.includes('simulation')) return '#fbbf24';
+  return '#7dd3fc';
+}
+
+function formatCardLabel(value: string): string {
+  const labels: Record<string, string> = {
+    api: 'API',
+    gpgpu: 'GPGPU',
+    hdr: 'HDR'
+  };
+
+  return (
+    labels[value.toLowerCase()] ||
+    value
+      .split('-')
+      .map(segment => `${segment.charAt(0).toUpperCase()}${segment.slice(1)}`)
+      .join(' ')
+  );
+}

--- a/website/src/components/examples-index.module.css
+++ b/website/src/components/examples-index.module.css
@@ -1,136 +1,248 @@
 .mainExamples {
-  padding: 1rem 0 2rem;
+  width: 100%;
+  max-width: 1600px;
+  margin: 0 auto;
+  padding: 0.35rem 0 3rem;
 }
 
 .catalogControls {
-  background: var(--ifm-background-surface-color);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 12px;
   display: grid;
-  gap: 0.75rem;
-  grid-template-columns: minmax(14rem, 2fr) repeat(5, minmax(8rem, 1fr));
+  gap: 16px;
   margin: 0 1rem 1.5rem;
-  padding: 1rem;
+  padding: 21px;
+  overflow: hidden;
+  border: 1px solid var(--luma-example-border, rgba(148, 163, 184, 0.2));
+  border-radius: var(--luma-example-radius, 16px);
+  background:
+    radial-gradient(ellipse at 8% 0, rgba(56, 189, 248, 0.11), transparent 38%),
+    var(--luma-example-surface, rgba(10, 17, 29, 0.97));
+  box-shadow: var(--luma-example-shadow, 0 18px 42px rgba(2, 6, 23, 0.2));
+  color: var(--luma-example-text, #f1f5f9);
+}
+
+.controlsHeading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.controlsEyebrow {
+  margin: 0;
+  color: var(--luma-example-accent, #67e8f9);
+  font-size: 0.72rem;
+  font-weight: 760;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.controlsIntroduction {
+  margin: 5px 0 0;
+  color: var(--luma-example-text-muted, #a3b2c5);
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+.catalogCount {
+  flex: 0 0 auto;
+  border: 1px solid rgba(103, 232, 249, 0.25);
+  border-radius: 999px;
+  background: rgba(8, 47, 73, 0.56);
+  color: #bae6fd;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 6px 10px;
+}
+
+.searchField {
+  position: relative;
+}
+
+.searchIcon {
+  position: absolute;
+  top: 50%;
+  left: 13px;
+  width: 19px;
+  height: 19px;
+  color: var(--luma-example-text-muted, #94a3b8);
+  pointer-events: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 1.65;
+  transform: translateY(-50%);
 }
 
 .catalogControls input,
 .catalogControls select {
-  background: var(--ifm-background-color);
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 8px;
-  color: var(--ifm-font-color-base);
-  font: inherit;
-  min-height: 2.65rem;
-  padding: 0.55rem 0.7rem;
   width: 100%;
+  min-height: 42px;
+  border: 1px solid var(--luma-example-border, rgba(148, 163, 184, 0.22));
+  border-radius: 9px;
+  background: var(--luma-example-surface-raised, rgba(23, 35, 53, 0.8));
+  color: var(--luma-example-text, #e2e8f0);
+  font: inherit;
+  font-size: 0.78rem;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.catalogControls input {
+  min-height: 46px;
+  padding: 0 12px 0 42px;
+}
+
+.catalogControls input::placeholder {
+  color: var(--luma-example-text-muted, #94a3b8);
+}
+
+.catalogControls select {
+  padding: 0 9px;
+}
+
+.catalogControls input:focus-visible,
+.catalogControls select:focus-visible {
+  border-color: var(--luma-example-accent, #67e8f9);
+  box-shadow: 0 0 0 2px rgba(103, 232, 249, 0.15);
+  outline: none;
+}
+
+.filterGrid {
+  display: grid;
+  gap: 9px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.resultsBar {
+  display: flex;
+  min-height: 30px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0 1rem 1.65rem;
 }
 
 .resultsSummary {
+  margin: 0;
   color: var(--ifm-color-emphasis-700);
-  margin: 0 1rem 1rem;
+  font-size: 0.84rem;
+}
+
+.clearFilters {
+  border: 0;
+  background: transparent;
+  color: var(--ifm-color-primary-darkest, #17806d);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 680;
+  padding: 5px 0;
+}
+
+.clearFilters:hover,
+.clearFilters:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .exampleSection {
-  margin: 0 1rem 2rem;
+  margin: 0 1rem 2.8rem;
+}
+
+.sectionHeading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 15px;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  padding-bottom: 12px;
+}
+
+.sectionEyebrow {
+  margin: 0 0 4px;
+  color: var(--ifm-color-primary-darkest, #17806d);
+  font-size: 0.68rem;
+  font-weight: 740;
+  letter-spacing: 0.085em;
+  text-transform: uppercase;
 }
 
 .exampleHeader {
-  border-bottom: 1px solid var(--ifm-color-emphasis-200);
-  margin: 0 0 1rem;
-  padding-bottom: 0.45rem;
+  margin: 0;
+  font-size: clamp(1.35rem, 2vw, 1.75rem);
+  letter-spacing: -0.035em;
+  line-height: 1.1;
+}
+
+.sectionCount {
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.83rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
 }
 
 .examplesGroup {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 17px;
+  grid-template-columns: repeat(auto-fill, minmax(min(285px, 100%), 1fr));
 }
 
-.exampleCard {
-  background: var(--ifm-background-surface-color);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 10px;
-  color: var(--ifm-font-color-base);
+.emptyState {
   display: flex;
+  min-height: 180px;
+  align-items: center;
+  justify-content: center;
   flex-direction: column;
-  min-width: 0;
-  overflow: hidden;
-  text-decoration: none;
-  transition:
-    border-color var(--ifm-transition-fast),
-    box-shadow var(--ifm-transition-fast),
-    transform var(--ifm-transition-fast);
-}
-
-.exampleCard:hover,
-.exampleCard:focus-visible {
-  border-color: var(--ifm-color-primary);
-  box-shadow: var(--ifm-global-shadow-md);
-  color: var(--ifm-font-color-base);
-  text-decoration: none;
-  transform: translateY(-2px);
-}
-
-.exampleCard img {
-  aspect-ratio: 16 / 9;
-  background: var(--ifm-color-emphasis-100);
-  object-fit: cover;
-  width: 100%;
-}
-
-.cardBody {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  gap: 0.55rem;
-  padding: 0.9rem;
-}
-
-.cardBody h3 {
-  font-size: 1.08rem;
-  margin: 0;
-}
-
-.cardBody p {
+  gap: 6px;
+  margin: 0 1rem;
+  border: 1px dashed var(--ifm-color-emphasis-300);
+  border-radius: 14px;
   color: var(--ifm-color-emphasis-700);
-  font-size: 0.9rem;
-  line-height: 1.45;
+}
+
+.emptyState p {
   margin: 0;
 }
 
-.badges {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
-  margin-top: auto;
+@media screen and (max-width: 1080px) {
+  .filterGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
-.badge {
-  background: var(--ifm-color-emphasis-100);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 999px;
-  color: var(--ifm-color-emphasis-800);
-  font-size: 0.72rem;
-  font-weight: 600;
-  padding: 0.18rem 0.45rem;
-}
-
-@media screen and (max-width: 996px) {
+@media screen and (max-width: 640px) {
   .catalogControls {
+    padding: 16px;
+  }
+
+  .controlsHeading {
+    flex-direction: column;
+  }
+
+  .filterGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .catalogControls input {
-    grid-column: 1 / -1;
+  .examplesGroup {
+    gap: 14px;
   }
 }
 
-@media screen and (max-width: 520px) {
-  .catalogControls {
+@media screen and (max-width: 420px) {
+  .filterGrid {
     grid-template-columns: 1fr;
   }
 
-  .catalogControls input {
-    grid-column: auto;
+  .resultsBar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .catalogControls input,
+  .catalogControls select {
+    transition: none;
   }
 }

--- a/website/src/components/examples-index.tsx
+++ b/website/src/components/examples-index.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useMemo, useState} from 'react';
 import {useDocsSidebar, useDocsVersion} from '@docusaurus/plugin-content-docs/client';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import {ExampleCard} from './example-card';
 import styles from './examples-index.module.css';
 
 type ExampleBackend = 'webgpu' | 'webgl2';
@@ -105,7 +106,13 @@ export function ExamplesIndex({getThumbnail}: ExamplesIndexProps) {
 
   const normalizedQuery = query.trim().toLowerCase();
   const filteredCatalog = catalog.filter(item => {
-    const searchableText = [item.label, item.description, item.category, item.display, ...item.topics]
+    const searchableText = [
+      item.label,
+      item.description,
+      item.category,
+      item.display,
+      ...item.topics
+    ]
       .join(' ')
       .toLowerCase();
     return (
@@ -118,86 +125,127 @@ export function ExamplesIndex({getThumbnail}: ExamplesIndexProps) {
     );
   });
   const categories = groupByCategory(filteredCatalog);
+  const activeFilterCount =
+    [backend, difficulty, displayMode, maturity, topic].filter(value => value !== 'all').length +
+    Number(Boolean(query));
+
+  const clearFilters = () => {
+    setQuery('');
+    setBackend('all');
+    setDifficulty('all');
+    setDisplayMode('all');
+    setMaturity('all');
+    setTopic('all');
+  };
 
   return (
     <div className={styles.mainExamples}>
       <div className={styles.catalogControls} aria-label="Filter examples">
-        <input
-          type="search"
-          value={query}
-          onChange={event => setQuery(event.target.value)}
-          placeholder="Search examples, APIs, and topics…"
-          aria-label="Search examples"
-        />
-        <FilterSelect
-          label="Backend"
-          value={backend}
-          onChange={setBackend}
-          options={['webgpu', 'webgl2']}
-        />
-        <FilterSelect
-          label="Difficulty"
-          value={difficulty}
-          onChange={setDifficulty}
-          options={['tutorial', 'intermediate', 'advanced']}
-        />
-        <FilterSelect
-          label="Display"
-          value={displayMode}
-          onChange={setDisplayMode}
-          options={['hdr-capable', 'standard']}
-        />
-        <FilterSelect
-          label="Maturity"
-          value={maturity}
-          onChange={setMaturity}
-          options={['stable', 'experimental']}
-        />
-        <FilterSelect label="Topic" value={topic} onChange={setTopic} options={topics} />
+        <div className={styles.controlsHeading}>
+          <div>
+            <p className={styles.controlsEyebrow}>Realtime GPU experiments</p>
+            <p className={styles.controlsIntroduction}>
+              Explore rendering techniques, visual simulations, and interactive data.
+            </p>
+          </div>
+          <span className={styles.catalogCount}>{catalog.length} demos</span>
+        </div>
+
+        <div className={styles.searchField}>
+          <svg className={styles.searchIcon} viewBox="0 0 20 20" fill="none" aria-hidden="true">
+            <circle cx="8.5" cy="8.5" r="5.25" />
+            <path d="m12.5 12.5 4.25 4.25" />
+          </svg>
+          <input
+            type="search"
+            value={query}
+            onChange={event => setQuery(event.target.value)}
+            placeholder="Search examples, APIs, and techniques…"
+            aria-label="Search examples"
+          />
+        </div>
+
+        <div className={styles.filterGrid}>
+          <FilterSelect
+            label="Backend"
+            value={backend}
+            onChange={setBackend}
+            options={['webgpu', 'webgl2']}
+          />
+          <FilterSelect
+            label="Difficulty"
+            value={difficulty}
+            onChange={setDifficulty}
+            options={['tutorial', 'intermediate', 'advanced']}
+          />
+          <FilterSelect
+            label="Display"
+            value={displayMode}
+            onChange={setDisplayMode}
+            options={['hdr-capable', 'standard']}
+          />
+          <FilterSelect
+            label="Maturity"
+            value={maturity}
+            onChange={setMaturity}
+            options={['stable', 'experimental']}
+          />
+          <FilterSelect label="Topic" value={topic} onChange={setTopic} options={topics} />
+        </div>
       </div>
-      <p className={styles.resultsSummary} aria-live="polite">
-        Showing {filteredCatalog.length} of {catalog.length} examples
-      </p>
+
+      <div className={styles.resultsBar}>
+        <p className={styles.resultsSummary} aria-live="polite">
+          Showing {filteredCatalog.length} of {catalog.length} examples
+        </p>
+        {activeFilterCount > 0 ? (
+          <button className={styles.clearFilters} type="button" onClick={clearFilters}>
+            Clear {activeFilterCount === 1 ? 'filter' : `${activeFilterCount} filters`}
+          </button>
+        ) : null}
+      </div>
+
       {categories.map(([category, items]) => (
         <section className={styles.exampleSection} key={category}>
-          <h2 className={styles.exampleHeader}>{category}</h2>
+          <div className={styles.sectionHeading}>
+            <div>
+              <p className={styles.sectionEyebrow}>{getCategoryEyebrow(category)}</p>
+              <h2 className={styles.exampleHeader}>{category}</h2>
+            </div>
+            <span className={styles.sectionCount} aria-label={`${items.length} examples`}>
+              {String(items.length).padStart(2, '0')}
+            </span>
+          </div>
           <div className={styles.examplesGroup}>
             {items.map(item => {
               const thumbnail = getThumbnail(item);
               const imageUrl = `${baseUrl}${thumbnail.replace(/^\//, '')}`;
               return (
-                <a
-                  className={styles.exampleCard}
+                <ExampleCard
                   key={item.href || item.docId || item.label}
                   href={item.href}
-                >
-                  <img src={imageUrl} alt="" />
-                  <div className={styles.cardBody}>
-                    <h3>{item.label}</h3>
-                    <p>{item.description}</p>
-                    <div className={styles.badges}>
-                      {item.backends.map(value => (
-                        <span className={styles.badge} key={value}>
-                          {value}
-                        </span>
-                      ))}
-                      {item.display === 'hdr-capable' ? (
-                        <span className={styles.badge}>HDR</span>
-                      ) : null}
-                      <span className={styles.badge}>{item.difficulty}</span>
-                      {item.maturity === 'experimental' ? (
-                        <span className={styles.badge}>experimental</span>
-                      ) : null}
-                    </div>
-                  </div>
-                </a>
+                  imageUrl={imageUrl}
+                  title={item.label}
+                  description={item.description}
+                  category={item.category}
+                  backends={item.backends}
+                  highDynamicRange={item.display === 'hdr-capable'}
+                  difficulty={item.difficulty}
+                  maturity={item.maturity}
+                  topics={item.topics}
+                />
               );
             })}
           </div>
         </section>
       ))}
       {filteredCatalog.length === 0 ? (
-        <p className={styles.resultsSummary}>No examples match the selected filters.</p>
+        <div className={styles.emptyState}>
+          <p>No examples match the selected filters.</p>
+          <button className={styles.clearFilters} type="button" onClick={clearFilters}>
+            Clear all filters
+          </button>
+        </div>
       ) : null}
     </div>
   );
@@ -312,6 +360,17 @@ function groupByCategory(items: CatalogItem[]): Array<[string, CatalogItem[]]> {
     groups.set(item.category, group);
   }
   return [...groups.entries()];
+}
+
+function getCategoryEyebrow(category: string): string {
+  if (category === 'WebGPU') return 'Next-generation graphics';
+  if (category === 'Showcase') return 'Featured experiences';
+  if (category === 'Tutorials') return 'Learn by building';
+  if (category === 'Experimental') return 'Emerging techniques';
+  if (category === 'Integrations') return 'Works with your stack';
+  if (category.includes('Arrow') || category.includes('Data')) return 'GPU-native data';
+  if (category.includes('Command Graph')) return 'Compute pipelines';
+  return 'Core capabilities';
 }
 
 function formatLabel(value: string): string {


### PR DESCRIPTION
## Goals

Launch Project Flagship with one recognizable cinematic presentation across the complete luma.gl example catalog, while preserving ANARI Playground's existing visual identity.

## Changes

- Add a reusable premium `ExampleCard` with cinematic 16:9 artwork, accessible WebGPU/WebGL2/HDR badges, difficulty and topic chips, category-specific accents, and resilient missing-art fallbacks.
- Preserve the full composition of existing square and portrait screenshots using an authentic blurred backdrop rather than cropping away the demo.
- Refresh the complete examples gallery with editorial category headings, clear result counts, improved search and filters, responsive layouts, keyboard focus, and reduced-motion support.
- Introduce framework-independent cinematic/light semantic tokens shared by gallery cards and the existing `@deck.gl-community/panels` example surfaces.
- Add focused regression coverage for semantic tokens, inherited panel appearances, and backwards-compatible light/cinematic behavior.
- Leave the ANARI Playground implementation and established visual styling untouched.

## Verification

- `env -u YARN_NO_PROXY yarn build` — **all workspace packages compiled**
- `env -u YARN_NO_PROXY yarn lint fix`
- `env -u YARN_NO_PROXY NODE_OPTIONS=--max-old-space-size=6144 yarn website:build` — **passed** (ANARI production bundle, complete client/server build, 4,525-document search index, and 452 validated raw docs)
- Repository pre-commit checks: **351 node tests passed; 2 skipped**
- Focused headless browser panel tests: **24 passed**
- Focused strict TypeScript, CSS parsing, and server-rendered card accessibility smoke checks passed.

## Project Flagship follow-ups

- #2884 completes accurate structured metadata for all 73 active examples.
- Additional pull requests will recover authentic missing posters, unify in-demo device/stats/source chrome, and refresh the flagship homepage.