### PR TITLE
Project Flagship: complete metadata for all 73 example demos

### DIFF
--- a/test/examples/example-catalog-metadata.node.spec.ts
+++ b/test/examples/example-catalog-metadata.node.spec.ts
@@ -1,0 +1,171 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+import {parse} from 'yaml';
+
+type ExampleSidebarEntry =
+  | string
+  | {type: 'doc'; id: string; label?: string}
+  | {type: 'category'; label: string; items: ExampleSidebarEntry[]};
+
+type ExampleCatalogMetadata = {
+  backends?: string[];
+  difficulty?: string;
+  display?: string;
+  maturity?: string;
+  topics?: string[];
+};
+
+type LiveExample = {
+  id: string;
+  categories: string[];
+  metadata?: ExampleCatalogMetadata;
+};
+
+const EXAMPLES_DIRECTORY = path.join(process.cwd(), 'website/content/examples');
+const WEBGPU_ONLY_EXAMPLES = new Set([
+  'api/render-bundles',
+  'arrow/arrow-columns',
+  'arrow/arrow-dggs-polygons',
+  'deck/gpu-culled-trace'
+]);
+const WEBGL_ONLY_EXAMPLES = new Set([
+  'integrations/external-context',
+  'integrations/react-strict-mode',
+  'tutorials/transform-feedback',
+  'tutorials/transform',
+  'experimental/webxr-kaleidoscope'
+]);
+const LIVE_EXAMPLES = readLiveExamples();
+
+describe('live example catalog metadata', () => {
+  test('provides complete, curated filters for every sidebar example', () => {
+    expect(LIVE_EXAMPLES.length).toBeGreaterThan(0);
+
+    for (const {id, metadata} of LIVE_EXAMPLES) {
+      expect(metadata, `${id} requires sidebar_custom_props`).toBeDefined();
+      expect(metadata?.backends, `${id} requires at least one supported backend`).not.toHaveLength(
+        0
+      );
+      expect(
+        metadata?.backends?.every(backend => backend === 'webgpu' || backend === 'webgl2'),
+        `${id} has an unsupported backend`
+      ).toBe(true);
+      expect(
+        ['tutorial', 'intermediate', 'advanced'].includes(metadata?.difficulty || ''),
+        `${id} has an invalid difficulty`
+      ).toBe(true);
+      expect(
+        ['stable', 'experimental'].includes(metadata?.maturity || ''),
+        `${id} has an invalid maturity`
+      ).toBe(true);
+      expect(metadata?.topics?.length, `${id} requires at least two topics`).toBeGreaterThanOrEqual(
+        2
+      );
+      expect(metadata?.topics?.length, `${id} allows at most five topics`).toBeLessThanOrEqual(5);
+      expect(new Set(metadata?.topics).size, `${id} has duplicate topics`).toBe(
+        metadata?.topics?.length
+      );
+    }
+  });
+
+  test('matches WebGPU-only and WebGL2-only examples to their website device wrappers', () => {
+    for (const {id, categories, metadata} of LIVE_EXAMPLES) {
+      const expectedBackends = WEBGL_ONLY_EXAMPLES.has(id)
+        ? ['webgl2']
+        : categories[0] === 'WebGPU' || WEBGPU_ONLY_EXAMPLES.has(id)
+          ? ['webgpu']
+          : ['webgpu', 'webgl2'];
+
+      expect(metadata?.backends, `${id} has inaccurate backend metadata`).toEqual(expectedBackends);
+    }
+  });
+
+  test('labels tutorials and prerelease GPU-data tracks consistently', () => {
+    for (const {id, categories, metadata} of LIVE_EXAMPLES) {
+      if (categories[0] === 'Tutorials') {
+        expect(metadata?.difficulty, `${id} must use the tutorial difficulty`).toBe('tutorial');
+      }
+
+      if (categories.some(category => category.includes('v10'))) {
+        expect(metadata?.difficulty, `${id} is an advanced GPU-data example`).toBe('advanced');
+        expect(metadata?.maturity, `${id} demonstrates prerelease v10 APIs`).toBe('experimental');
+      }
+    }
+  });
+
+  test('marks every high-dynamic-range website canvas as HDR capable', () => {
+    const websiteExamples = readFileSync(
+      path.join(process.cwd(), 'website/src/examples.tsx'),
+      'utf8'
+    );
+    const catalogById = new Map(LIVE_EXAMPLES.map(example => [example.id, example]));
+    const highDynamicRangeExampleIds: string[] = [];
+
+    for (const match of websiteExamples.matchAll(/<LumaExample\b([\s\S]*?)(?:\/>|>)/g)) {
+      const attributes = match[1];
+      if (!attributes.includes('canvasContextProfile="high-dynamic-range"')) {
+        continue;
+      }
+
+      const exampleId = attributes.match(/\bid="([^"]+)"/)?.[1];
+      const exampleDirectory = attributes.match(/\bdirectory="([^"]+)"/)?.[1];
+      expect(exampleId, 'HDR examples require a stable example ID').toBeDefined();
+      expect(exampleDirectory, 'HDR examples require a stable example directory').toBeDefined();
+      highDynamicRangeExampleIds.push(`${exampleDirectory}/${exampleId}`);
+    }
+
+    const highDynamicRangeCanvasCount = [
+      ...websiteExamples.matchAll(/canvasContextProfile="high-dynamic-range"/g)
+    ].length;
+    expect(highDynamicRangeExampleIds).toHaveLength(highDynamicRangeCanvasCount);
+    expect(highDynamicRangeExampleIds).toContain('showcase/billion-point-spatial-atlas');
+    for (const exampleId of highDynamicRangeExampleIds) {
+      expect(
+        catalogById.get(exampleId),
+        `${exampleId} is missing from the live sidebar`
+      ).toBeDefined();
+      expect(
+        catalogById.get(exampleId)?.metadata?.display,
+        `${exampleId} requires an HDR catalog tag`
+      ).toBe('hdr-capable');
+    }
+  });
+});
+
+function readLiveExamples(): LiveExample[] {
+  const tableOfContents = JSON.parse(
+    readFileSync(path.join(EXAMPLES_DIRECTORY, 'table-of-contents.json'), 'utf8')
+  ) as ExampleSidebarEntry[];
+  const liveExamples: LiveExample[] = [];
+
+  const visit = (entries: ExampleSidebarEntry[], categories: string[]): void => {
+    for (const entry of entries) {
+      if (typeof entry === 'string') {
+        liveExamples.push(readLiveExample(entry, categories));
+      } else if (entry.type === 'category') {
+        visit(entry.items, [...categories, entry.label]);
+      } else if (entry.id !== 'index') {
+        liveExamples.push(readLiveExample(entry.id, categories));
+      }
+    }
+  };
+
+  visit(tableOfContents, []);
+  return liveExamples;
+}
+
+function readLiveExample(id: string, categories: string[]): LiveExample {
+  const exampleSource = readFileSync(path.join(EXAMPLES_DIRECTORY, `${id}.mdx`), 'utf8');
+  const frontmatter = exampleSource.match(/^---\n([\s\S]*?)\n---/);
+  if (!frontmatter) {
+    throw new Error(`Example ${id} must declare YAML frontmatter`);
+  }
+
+  const metadata = parse(frontmatter[1]) as {sidebar_custom_props?: ExampleCatalogMetadata};
+  return {id, categories, metadata: metadata.sidebar_custom_props};
+}

--- a/website/content/examples/api/animation.mdx
+++ b/website/content/examples/api/animation.mdx
@@ -1,6 +1,11 @@
 ---
 title: Animation
 description: Drive a portable render loop with frame timing, animated uniforms, and continuous model updates.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [api, animation, rendering]
 ---
 
 import {AnimationExample} from '@site/src/examples';

--- a/website/content/examples/api/blending.mdx
+++ b/website/content/examples/api/blending.mdx
@@ -1,6 +1,11 @@
 ---
 title: Blending
 description: Compare GPU blend equations and source/destination factors on overlapping transparent geometry.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [api, rendering, blending, transparency]
 ---
 
 import {BlendingExample} from '@site/src/examples';

--- a/website/content/examples/api/cubemap.mdx
+++ b/website/content/examples/api/cubemap.mdx
@@ -1,6 +1,11 @@
 ---
 title: Texture Cube
 description: Sample a cube texture across six faces to render direction-dependent environment imagery.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [api, textures, cubemaps, rendering]
 ---
 
 import {CubemapExample} from '@site/src/examples';

--- a/website/content/examples/api/multi-canvas.mdx
+++ b/website/content/examples/api/multi-canvas.mdx
@@ -1,6 +1,11 @@
 ---
 title: Multi Canvas
 description: Render two independently resized canvases through presentation contexts backed by one shared GPU device.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [api, rendering, integration]
 ---
 
 import {ExampleHeader, ExampleStage} from '@site/src/react-luma';

--- a/website/content/examples/api/render-bundles.mdx
+++ b/website/content/examples/api/render-bundles.mdx
@@ -3,6 +3,9 @@ title: Render Bundles
 description: Record repeated WebGPU draw commands once, then replay the bundle efficiently on every frame.
 sidebar_custom_props:
   backends: [webgpu]
+  difficulty: intermediate
+  maturity: stable
+  topics: [api, rendering, performance]
 ---
 
 import {RenderBundlesExample} from '@site/src/examples';

--- a/website/content/examples/api/texture-3d.mdx
+++ b/website/content/examples/api/texture-3d.mdx
@@ -1,6 +1,11 @@
 ---
 title: Texture 3D
 description: Upload and sample volumetric texture slices inside a continuously animated three-dimensional field.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [api, textures, volumes, rendering]
 ---
 
 import {Texture3DExample} from '@site/src/examples';

--- a/website/content/examples/api/texture-sampling.mdx
+++ b/website/content/examples/api/texture-sampling.mdx
@@ -1,6 +1,11 @@
 ---
 title: Texture Sampling
 description: Inspect how filter, mipmap, address, and anisotropy settings change texture sampling at oblique angles.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [api, textures, samplers, mipmaps]
 ---
 
 import {TextureSamplingExample} from '@site/src/examples';

--- a/website/content/examples/api/texture-tester.mdx
+++ b/website/content/examples/api/texture-tester.mdx
@@ -1,6 +1,11 @@
 ---
 title: Texture Tester
 description: Probe which compressed texture families the current browser and GPU can decode and render.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [api, textures, compression]
 ---
 
 import {ExampleHeader, ExampleStage} from '@site/src/react-luma';

--- a/website/content/examples/api/video-texture.mdx
+++ b/website/content/examples/api/video-texture.mdx
@@ -1,6 +1,11 @@
 ---
 title: 'Texture Video'
 description: Stream live video frames into a dynamic GPU texture and sample them while rendering.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [api, textures, video]
 ---
 
 import {VideoTextureExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-columns.mdx
+++ b/website/content/examples/arrow/arrow-columns.mdx
@@ -4,6 +4,9 @@ sidebar_label: DGGS + time
 description: Render GPU table columns that combine discrete global-grid cells with temporal values and filtering.
 sidebar_custom_props:
   backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, geospatial, time, compute]
 ---
 
 import {ArrowColumnRendererExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-dggs-polygons.mdx
+++ b/website/content/examples/arrow/arrow-dggs-polygons.mdx
@@ -4,6 +4,9 @@ sidebar_label: Global Grids
 description: Turn Arrow-encoded DGGS cells into GPU-rendered global grid polygons without repacking rows.
 sidebar_custom_props:
   backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, geospatial, polygons]
 ---
 
 import {ArrowDggsPolygonsExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-filtering.mdx
+++ b/website/content/examples/arrow/arrow-filtering.mdx
@@ -2,6 +2,11 @@
 title: 'Points - Filtering ShaderPlugin'
 sidebar_label: Points - Filtering ShaderPlugin
 description: Filter Arrow-backed point records in the shader with a reusable typed filtering plugin.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, filtering, shaders]
 ---
 
 import {ArrowFilteringExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-float64-precision.mdx
+++ b/website/content/examples/arrow/arrow-float64-precision.mdx
@@ -1,6 +1,11 @@
 ---
 title: 'Float64 Origin Rebasing'
 description: Preserve geospatial precision by rebasing Arrow float64 positions near a GPU-friendly local origin.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, precision, geospatial]
 ---
 
 import {ArrowFloat64PrecisionExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-geoarrow.mdx
+++ b/website/content/examples/arrow/arrow-geoarrow.mdx
@@ -2,6 +2,11 @@
 title: 'GeoArrow'
 sidebar_label: GeoArrow
 description: Upload GeoArrow geometry directly into GPU vectors and render its nested spatial coordinates.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, geoarrow, geospatial]
 ---
 
 import {ArrowGeoArrowExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-instancing.mdx
+++ b/website/content/examples/arrow/arrow-instancing.mdx
@@ -2,6 +2,11 @@
 title: 'Instancing'
 sidebar_label: Instancing
 description: Feed Arrow columns directly into per-instance attributes for dense, data-driven geometry.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, instancing, rendering]
 ---
 
 import {ArrowInstancingExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-lines.mdx
+++ b/website/content/examples/arrow/arrow-lines.mdx
@@ -2,6 +2,11 @@
 title: 'Lines'
 sidebar_label: Lines
 description: Render variable-length Arrow line paths from shared GPU vectors with per-row styling.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, rendering, lines]
 ---
 
 import {ArrowLinesExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-mesh-geometry.mdx
+++ b/website/content/examples/arrow/arrow-mesh-geometry.mdx
@@ -2,6 +2,11 @@
 title: 'Matrices'
 sidebar_label: Matrices
 description: Map Arrow fixed-size matrix values into GPU attributes that transform instanced mesh geometry.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, geometry, matrices]
 ---
 
 import {ArrowMeshGeometryExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-particles.mdx
+++ b/website/content/examples/arrow/arrow-particles.mdx
@@ -2,6 +2,11 @@
 title: 'Particles'
 sidebar_label: Particles
 description: Animate a GPU particle field whose initial positions and properties arrive as Arrow columns.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, particles, animation]
 ---
 
 import {ArrowParticlesExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-points.mdx
+++ b/website/content/examples/arrow/arrow-points.mdx
@@ -2,6 +2,11 @@
 title: 'Points'
 sidebar_label: Points
 description: Render Arrow point columns directly from GPU storage with data-driven size and color.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, rendering, points]
 ---
 
 import {ArrowPointRendererExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-polygons.mdx
+++ b/website/content/examples/arrow/arrow-polygons.mdx
@@ -2,6 +2,11 @@
 title: 'Polygons'
 sidebar_label: Polygons
 description: Triangulate and render nested Arrow polygon rings while preserving row-level attributes.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, rendering, polygons]
 ---
 
 import {ArrowPolygonRendererExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-temporal-starfield.mdx
+++ b/website/content/examples/arrow/arrow-temporal-starfield.mdx
@@ -2,6 +2,11 @@
 title: 'Durations'
 sidebar_label: Durations
 description: Animate a starfield from Arrow duration intervals and time-dependent visibility on the GPU.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, time, animation]
 ---
 
 import {ArrowTemporalStarfieldExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-text-2d.mdx
+++ b/website/content/examples/arrow/arrow-text-2d.mdx
@@ -2,6 +2,11 @@
 title: 'Text'
 sidebar_label: Text
 description: Draw labels from Arrow string and position columns with GPU-backed text styling.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, text, rendering]
 ---
 
 import {ArrowText2DExample} from '@site/src/examples';

--- a/website/content/examples/arrow/arrow-time-columns.mdx
+++ b/website/content/examples/arrow/arrow-time-columns.mdx
@@ -2,6 +2,11 @@
 title: 'Time'
 sidebar_label: Time
 description: Visualize Arrow timestamp values and scrub time-aware records without converting their columns.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [arrow, data, time, visualization]
 ---
 
 import {ArrowTimeColumnsExample} from '@site/src/examples';

--- a/website/content/examples/deck/arrow-path-layer.mdx
+++ b/website/content/examples/deck/arrow-path-layer.mdx
@@ -2,6 +2,11 @@
 title: ArrowPathLayer
 sidebar_label: ArrowPathLayer
 description: Render Arrow-native path columns through deck.gl while keeping variable-length geometry GPU-ready.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [deck.gl, arrow, data, rendering, lines]
 ---
 
 import {DeckArrowPathLayerExample} from '@site/src/examples';

--- a/website/content/examples/deck/arrow-polygon-layer.mdx
+++ b/website/content/examples/deck/arrow-polygon-layer.mdx
@@ -2,6 +2,11 @@
 title: ArrowPolygonLayer
 sidebar_label: ArrowPolygonLayer
 description: Feed Arrow polygon rings and row attributes directly into a deck.gl polygon layer.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [deck.gl, arrow, data, rendering, polygons]
 ---
 
 import {DeckArrowPolygonLayerExample} from '@site/src/examples';

--- a/website/content/examples/deck/arrow-text-layer.mdx
+++ b/website/content/examples/deck/arrow-text-layer.mdx
@@ -2,6 +2,11 @@
 title: ArrowTextLayer
 sidebar_label: ArrowTextLayer
 description: Bind Arrow labels, positions, colors, and sizes directly to deck.gl text rendering.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [deck.gl, arrow, data, rendering, text]
 ---
 
 import {DeckArrowTextLayerExample} from '@site/src/examples';

--- a/website/content/examples/deck/gpu-culled-trace.mdx
+++ b/website/content/examples/deck/gpu-culled-trace.mdx
@@ -2,6 +2,11 @@
 title: GPU-Culled Trace with Arrow Text
 sidebar_label: GPU-Culled Trace
 description: Cull a hierarchical trace on the GPU and label the retained spans with Arrow-backed text.
+sidebar_custom_props:
+  backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [deck.gl, arrow, compute, culling, visualization]
 ---
 
 import {DeckGPUCulledTraceExample} from '@site/src/examples';

--- a/website/content/examples/experimental/a-buffer.mdx
+++ b/website/content/examples/experimental/a-buffer.mdx
@@ -1,6 +1,11 @@
 ---
 title: Order-independent Transparency
 description: Compare exact per-pixel A-buffer transparency, weighted blended OIT, and ordinary alpha blending.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [rendering, transparency, blending, effects]
 ---
 
 import {OITExample} from '@site/src/examples';

--- a/website/content/examples/experimental/advanced-effects.mdx
+++ b/website/content/examples/experimental/advanced-effects.mdx
@@ -3,6 +3,9 @@ title: 'Effects: Visualization City'
 description: Inspect a procedural city through cascaded and local shadows, SSAO, SSR, fog, outlines, TAA, and motion blur.
 sidebar_custom_props:
   backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [rendering, effects, lighting, shadows, compute]
 ---
 
 import {AdvancedEffectsExample} from '@site/src/examples';

--- a/website/content/examples/experimental/antialiasing.mdx
+++ b/website/content/examples/experimental/antialiasing.mdx
@@ -1,6 +1,11 @@
 ---
 title: Antialiasing Techniques
 description: Compare single-sample rendering, FXAA, supersampling, and texture filtering in a split view.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [rendering, antialiasing, effects]
 ---
 
 import {AntialiasingExample} from '@site/src/examples';

--- a/website/content/examples/experimental/bloom.mdx
+++ b/website/content/examples/experimental/bloom.mdx
@@ -2,7 +2,11 @@
 title: 'Effects: Bloom'
 description: Extract bright HDR highlights, blur them across scales, and composite a tunable cinematic glow.
 sidebar_custom_props:
+  backends: [webgpu, webgl2]
   display: hdr-capable
+  difficulty: advanced
+  maturity: experimental
+  topics: [rendering, effects, bloom, hdr]
 ---
 
 import {BloomExample} from '@site/src/examples';

--- a/website/content/examples/experimental/deferred-rendering.mdx
+++ b/website/content/examples/experimental/deferred-rendering.mdx
@@ -4,6 +4,9 @@ description: Resolve hundreds of clustered lights through deferred PBR, GTAO, SS
 sidebar_custom_props:
   backends: [webgpu]
   display: hdr-capable
+  difficulty: advanced
+  maturity: experimental
+  topics: [rendering, lighting, effects, compute, hdr]
 ---
 
 import {DeferredRenderingExample} from '@site/src/examples';

--- a/website/content/examples/experimental/fp64.mdx
+++ b/website/content/examples/experimental/fp64.mdx
@@ -1,6 +1,11 @@
 ---
 title: FP64
 description: Compare float32 and emulated float64 shader arithmetic along the same deep Mandelbrot zoom.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [rendering, precision, shaders]
 ---
 
 import {ExampleHeader, ExampleStage} from '@site/src/react-luma';

--- a/website/content/examples/experimental/gpu-data-analysis.mdx
+++ b/website/content/examples/experimental/gpu-data-analysis.mdx
@@ -2,6 +2,11 @@
 title: Graph-native GPU data analysis
 sidebar_label: GPU data analysis
 description: Compose reductions, histograms, scans, grouped statistics, and spatial bins in one GPU command graph.
+sidebar_custom_props:
+  backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [compute, data, analytics, command-graphs]
 ---
 
 import {GPUDataAnalysisExample} from '@site/src/examples';

--- a/website/content/examples/experimental/gpu-frustum-culling.mdx
+++ b/website/content/examples/experimental/gpu-frustum-culling.mdx
@@ -2,6 +2,11 @@
 title: GPU Frustum Culling
 sidebar_label: GPU frustum culling
 description: Cull, stably compact, pick, and indirectly draw visible instances without a CPU visibility pass.
+sidebar_custom_props:
+  backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [compute, rendering, culling, command-graphs, indirect-rendering]
 ---
 
 import {GPUFrustumCullingExample} from '@site/src/examples';

--- a/website/content/examples/experimental/gpu-sort.mdx
+++ b/website/content/examples/experimental/gpu-sort.mdx
@@ -2,6 +2,11 @@
 title: Graph-native GPU sort
 sidebar_label: GPU sort
 description: Stably sort paired uint32 keys and values across global or independent batched GPU domains.
+sidebar_custom_props:
+  backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [compute, data, sorting, command-graphs]
 ---
 
 import {GPUSortExample} from '@site/src/examples';

--- a/website/content/examples/experimental/gpu-trace-viewer.mdx
+++ b/website/content/examples/experimental/gpu-trace-viewer.mdx
@@ -2,6 +2,11 @@
 title: GPU Hierarchical Trace Viewer
 sidebar_label: GPU hierarchical trace
 description: Filter, traverse, pick, density-LOD, and indirectly render hierarchical traces entirely on the GPU.
+sidebar_custom_props:
+  backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [compute, data, visualization, command-graphs, picking]
 ---
 
 import {GPUTraceViewerExample} from '@site/src/examples';

--- a/website/content/examples/experimental/html-ui-prism.mdx
+++ b/website/content/examples/experimental/html-ui-prism.mdx
@@ -1,6 +1,11 @@
 ---
 title: 'Texture HTML-in-Canvas'
 description: Copy live DOM panels into GPU textures and map them onto a rotating interactive prism.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [rendering, textures, html, ui]
 ---
 
 import {HTMLUIPrismExample} from '@site/src/examples';

--- a/website/content/examples/experimental/shadow-map.mdx
+++ b/website/content/examples/experimental/shadow-map.mdx
@@ -3,6 +3,9 @@ title: 'Effects: Shadow Map Quality'
 description: Compare fitted cascades, PCSS penumbrae, bias, resolution, and debug views across shadow-quality presets.
 sidebar_custom_props:
   backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [rendering, lighting, shadows, effects]
 ---
 
 import {ShadowMapExample} from '@site/src/examples';

--- a/website/content/examples/experimental/text-space-crawl.mdx
+++ b/website/content/examples/experimental/text-space-crawl.mdx
@@ -1,6 +1,11 @@
 ---
 title: Text Space Crawl
 description: Compare extruded, bitmap, SDF, and MSDF text as glyphs recede through perspective space.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [rendering, text, typography]
 ---
 
 import {TextSpaceCrawlExample} from '@site/src/examples';

--- a/website/content/examples/experimental/webxr-kaleidoscope.mdx
+++ b/website/content/examples/experimental/webxr-kaleidoscope.mdx
@@ -3,6 +3,9 @@ title: 'Texture WebXR'
 description: Enter an immersive WebXR kaleidoscope that reflects and repeats a live texture around the viewer.
 sidebar_custom_props:
   backends: [webgl2]
+  difficulty: advanced
+  maturity: experimental
+  topics: [rendering, textures, webxr]
 ---
 
 <p className="badges">

--- a/website/content/examples/integrations/external-context.mdx
+++ b/website/content/examples/integrations/external-context.mdx
@@ -3,6 +3,9 @@ title: External WebGL Context
 description: Attach luma.gl to MapLibre's WebGL2 context and render a world-anchored overlay in its frame loop.
 sidebar_custom_props:
   backends: [webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [integration, rendering, geospatial, maplibre]
 ---
 
 import {ExampleHeader, ExampleStage} from '@site/src/react-luma';

--- a/website/content/examples/integrations/react-strict-mode.mdx
+++ b/website/content/examples/integrations/react-strict-mode.mdx
@@ -3,6 +3,9 @@ title: React Strict Mode
 description: Mount and remount a luma.gl canvas safely under React Strict Mode's development lifecycle checks.
 sidebar_custom_props:
   backends: [webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [integration, react, rendering]
 ---
 
 import {ReactStrictModeExample} from '@site/src/examples';

--- a/website/content/examples/showcase/billion-point-spatial-atlas.mdx
+++ b/website/content/examples/showcase/billion-point-spatial-atlas.mdx
@@ -4,6 +4,7 @@ description: Query and indirectly render massive NYC point corpora with graph-na
 sidebar_custom_props:
   description: Query and indirectly render massive NYC point corpora with graph-native WebGPU geospatial algorithms.
   backends: [webgpu]
+  display: hdr-capable
   difficulty: advanced
   maturity: experimental
   topics: [compute, rendering, data, geospatial]

--- a/website/content/examples/showcase/dof.mdx
+++ b/website/content/examples/showcase/dof.mdx
@@ -1,6 +1,11 @@
 ---
 title: 'Effects: Depth of Field'
 description: Focus a layered 3D scene with a reusable depth-aware bokeh and depth-of-field pipeline.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [effects, image-processing, rendering]
 ---
 
 import {DOFExample} from '@site/src/examples';

--- a/website/content/examples/showcase/globe.mdx
+++ b/website/content/examples/showcase/globe.mdx
@@ -2,7 +2,11 @@
 title: Globe
 description: Orbit a richly shaded Earth with animated water, specular oceans, ice, atmosphere, and an HDR Tycho starfield.
 sidebar_custom_props:
+  backends: [webgpu, webgl2]
   display: hdr-capable
+  difficulty: intermediate
+  maturity: stable
+  topics: [rendering, geospatial, lighting, hdr]
 ---
 
 import {GlobeExample} from '@site/src/examples';

--- a/website/content/examples/showcase/gltf.mdx
+++ b/website/content/examples/showcase/gltf.mdx
@@ -2,7 +2,11 @@
 title: glTF
 description: Browse production glTF assets with PBR lighting, animation, camera controls, and extension-focused scenes.
 sidebar_custom_props:
+  backends: [webgpu, webgl2]
   display: hdr-capable
+  difficulty: intermediate
+  maturity: stable
+  topics: [rendering, gltf, materials, animation, hdr]
 ---
 
 import {GLTFExample} from '@site/src/examples';

--- a/website/content/examples/showcase/instancing.mdx
+++ b/website/content/examples/showcase/instancing.mdx
@@ -2,7 +2,11 @@
 title: Instancing
 description: Animate a dense field of geometry with per-instance transforms and colors issued in a compact draw.
 sidebar_custom_props:
+  backends: [webgpu, webgl2]
   display: hdr-capable
+  difficulty: intermediate
+  maturity: stable
+  topics: [rendering, instancing, animation, hdr]
 ---
 
 import {InstancingExample} from '@site/src/examples';

--- a/website/content/examples/showcase/packet-spraying.mdx
+++ b/website/content/examples/showcase/packet-spraying.mdx
@@ -2,7 +2,11 @@
 title: 'Effects: Glass'
 description: Follow emissive multipath packets through glass switches with reflections, transparency, bloom, and HDR tone mapping.
 sidebar_custom_props:
+  backends: [webgpu, webgl2]
   display: hdr-capable
+  difficulty: intermediate
+  maturity: stable
+  topics: [rendering, effects, transparency, hdr]
 ---
 
 import {PacketSprayingExample} from '@site/src/examples';

--- a/website/content/examples/showcase/persistence.mdx
+++ b/website/content/examples/showcase/persistence.mdx
@@ -1,6 +1,11 @@
 ---
 title: 'Effects: Persistence'
 description: Accumulate animated electron trails across framebuffer history with a tunable persistence effect.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: intermediate
+  maturity: stable
+  topics: [effects, animation, rendering]
 ---
 
 import {PersistenceExample} from '@site/src/examples';

--- a/website/content/examples/showcase/postprocessing.mdx
+++ b/website/content/examples/showcase/postprocessing.mdx
@@ -2,6 +2,7 @@
 title: 'Effects: Image Processing'
 description: Compose, reorder, and live-tune a complete image-effect library against an animated procedural scene.
 sidebar_custom_props:
+  backends: [webgpu, webgl2]
   difficulty: intermediate
   maturity: stable
   topics: [effects, image-processing, shaders]

--- a/website/content/examples/tutorials/hello-gltf.mdx
+++ b/website/content/examples/tutorials/hello-gltf.mdx
@@ -1,6 +1,11 @@
 ---
 title: Hello glTF
 description: Load a glTF asset and render its meshes, materials, textures, and scene transforms.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: tutorial
+  maturity: stable
+  topics: [fundamentals, gltf, rendering]
 ---
 
 import {HelloGLTFExample} from '@site/src/examples';

--- a/website/content/examples/tutorials/hello-instancing.mdx
+++ b/website/content/examples/tutorials/hello-instancing.mdx
@@ -3,7 +3,7 @@ title: Hello Instancing
 description: Draw multiple objects efficiently with per-instance attributes.
 sidebar_custom_props:
   backends: [webgpu, webgl2]
-  difficulty: intermediate
+  difficulty: tutorial
   maturity: stable
   topics: [fundamentals, rendering]
 ---

--- a/website/content/examples/tutorials/instanced-cubes.mdx
+++ b/website/content/examples/tutorials/instanced-cubes.mdx
@@ -1,6 +1,11 @@
 ---
 title: Instanced Cubes
 description: Animate many cubes with per-instance offsets and colors while sharing one geometry and draw call.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: tutorial
+  maturity: stable
+  topics: [fundamentals, instancing, rendering]
 ---
 
 import {InstancedCubesExample} from '@site/src/examples';

--- a/website/content/examples/tutorials/lighting.mdx
+++ b/website/content/examples/tutorials/lighting.mdx
@@ -1,6 +1,11 @@
 ---
 title: Hello Lighting
 description: Add normals, material response, and ambient and directional lights to a rotating mesh.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: tutorial
+  maturity: stable
+  topics: [fundamentals, lighting, rendering]
 ---
 
 import {LightingExample} from '@site/src/examples';

--- a/website/content/examples/tutorials/shader-hooks.mdx
+++ b/website/content/examples/tutorials/shader-hooks.mdx
@@ -1,6 +1,11 @@
 ---
 title: Shader Hooks
 description: Inject custom shader logic at declared hook points without replacing the surrounding shader pipeline.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: tutorial
+  maturity: stable
+  topics: [fundamentals, shaders, extensions, rendering]
 ---
 
 import {ShaderHooksExample} from '@site/src/examples';

--- a/website/content/examples/tutorials/shader-modules.mdx
+++ b/website/content/examples/tutorials/shader-modules.mdx
@@ -1,6 +1,11 @@
 ---
 title: Shader Modules
 description: Compose reusable shader modules, uniforms, and helper functions into a portable model.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: tutorial
+  maturity: stable
+  topics: [fundamentals, shaders, modules, rendering]
 ---
 
 import {ShaderModulesExample} from '@site/src/examples';

--- a/website/content/examples/tutorials/shader-plugins.mdx
+++ b/website/content/examples/tutorials/shader-plugins.mdx
@@ -1,6 +1,11 @@
 ---
 title: Shader Plugins
 description: Extend model shaders with typed plugins that contribute code, bindings, and runtime properties.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: tutorial
+  maturity: stable
+  topics: [fundamentals, shaders, plugins, rendering]
 ---
 
 import {ShaderPluginsExample} from '@site/src/examples';

--- a/website/content/examples/tutorials/transform-feedback.mdx
+++ b/website/content/examples/tutorials/transform-feedback.mdx
@@ -3,6 +3,9 @@ title: Transform Feedback
 description: Update particle-like vertex data entirely on WebGL2 with transform feedback and buffer swapping.
 sidebar_custom_props:
   backends: [webgl2]
+  difficulty: tutorial
+  maturity: stable
+  topics: [fundamentals, compute, webgl, particles]
 ---
 
 import {TransformFeedbackExample} from '@site/src/examples';

--- a/website/content/examples/tutorials/transform.mdx
+++ b/website/content/examples/tutorials/transform.mdx
@@ -1,6 +1,11 @@
 ---
 title: Transform
 description: Run a GPU data transform and capture its computed output for reuse in later rendering work.
+sidebar_custom_props:
+  backends: [webgl2]
+  difficulty: tutorial
+  maturity: stable
+  topics: [fundamentals, compute, webgl]
 ---
 
 import {TransformExample} from '@site/src/examples';

--- a/website/content/examples/tutorials/two-cubes.mdx
+++ b/website/content/examples/tutorials/two-cubes.mdx
@@ -1,6 +1,11 @@
 ---
 title: Two Cubes
 description: Draw two independently transformed cubes from shared geometry, shaders, and texture resources.
+sidebar_custom_props:
+  backends: [webgpu, webgl2]
+  difficulty: tutorial
+  maturity: stable
+  topics: [fundamentals, rendering, animation]
 ---
 
 import {TwoCubesExample} from '@site/src/examples';

--- a/website/content/examples/v10/gpgpu.mdx
+++ b/website/content/examples/v10/gpgpu.mdx
@@ -2,6 +2,11 @@
 title: GPGPU
 sidebar_label: GPGPU
 description: Filter, sort, aggregate, and visualize typed GPU-resident table columns without CPU readback.
+sidebar_custom_props:
+  backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [compute, data, gpgpu, sorting, analytics]
 ---
 
 import {GPGPUExample} from '@site/src/examples';


### PR DESCRIPTION
## Goals

Make every luma.gl demo discoverable and honestly described in Project Flagship's example gallery without altering any example implementation or ANARI Playground's established appearance.

## Changes

- Complete structured sidebar metadata for **all 73 active examples**: explicit supported backends, difficulty, maturity, and carefully curated technology topics.
- Correct actual runtime support: **21 WebGPU-only**, **5 WebGL2-only**, and **47 dual-backend** demos.
- Mark all **12 tutorials** as `tutorial`, including the previously misclassified Hello Instancing example.
- Identify prerelease GPU-data, command-graph, Apache Arrow, and deck.gl v10 tracks accurately.
- Mark **13 genuinely HDR-capable demos**, including the previously missing Billion-Point Spatial Atlas tag.
- Preserve every existing title, sidebar label, description, demo body, and ANARI Playground file unchanged.
- Add four catalog regression tests that enforce complete filters, real backend restrictions, tutorial/prerelease classifications, and every HDR canvas wrapper.

## Verification

- `env -u YARN_NO_PROXY yarn install --immutable`
- `env -u YARN_NO_PROXY yarn lint fix`
- `env -u YARN_NO_PROXY yarn test-node test/examples/example-catalog-metadata.node.spec.ts` — **4 passed**
- Full repository pre-commit/node suite — **355 passed; 2 skipped**
- Rebased onto latest `master`; independent of the reusable-card PR.

Part of Project Flagship; pairs with #2883.