### PR TITLE
Project Flagship: launch a cinematic WebGPU showcase homepage

### DIFF
--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -1,8 +1,141 @@
 import React from 'react';
 import Layout from '@theme/Layout';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {ExampleCard} from '../components/example-card';
 import {InstancingExample} from '../examples';
 import styles from './index.module.css';
+
+const HERO_CAPABILITIES = ['WebGPU', 'WebGL2', 'GPU compute', 'HDR rendering'];
+
+const FEATURED_EXAMPLES = [
+  {
+    title: 'Lightstorm Megacity',
+    route: 'showcase/lightstorm-megacity',
+    image: 'showcase/lightstorm-megacity.jpg',
+    description:
+      'Fly through a GPU-driven city beneath synchronized lightning, luminous streets, and screen-space reflections.',
+    category: 'WebGPU',
+    backends: ['webgpu'],
+    highDynamicRange: true,
+    difficulty: 'advanced',
+    maturity: 'experimental',
+    topics: ['lighting', 'compute']
+  },
+  {
+    title: 'Tempest Ocean',
+    route: 'showcase/tempest-ocean',
+    image: 'showcase/tempest-ocean.jpg',
+    description:
+      'Cross a spectral stormfront with GPU-displaced waves, wind-driven whitecaps, and high-dynamic-range moonlight.',
+    category: 'WebGPU',
+    backends: ['webgpu'],
+    highDynamicRange: true,
+    difficulty: 'advanced',
+    maturity: 'experimental',
+    topics: ['simulation', 'compute']
+  },
+  {
+    title: 'Volumetric Fire Forge',
+    route: 'experimental/volumetric-fire-forge',
+    image: 'experimental/volumetric-fire-forge.jpg',
+    description:
+      'Simulate reactive fire around solid obstacles, then compose emissive flames and drifting smoke into a 3D forge.',
+    category: 'WebGPU',
+    backends: ['webgpu'],
+    highDynamicRange: true,
+    difficulty: 'advanced',
+    maturity: 'experimental',
+    topics: ['volumetrics', 'simulation']
+  },
+  {
+    title: 'Prism Cathedral',
+    route: 'experimental/spectral-caustics',
+    image: 'experimental/spectral-caustics.jpg',
+    description:
+      'Follow light through a faceted refractor as spectral caustics scatter across an atmospheric stone interior.',
+    category: 'WebGPU',
+    backends: ['webgpu'],
+    highDynamicRange: true,
+    difficulty: 'advanced',
+    maturity: 'experimental',
+    topics: ['caustics', 'lighting']
+  },
+  {
+    title: 'Fluid Foundry',
+    route: 'experimental/fluid-foundry',
+    image: 'experimental/fluid-foundry.jpg',
+    description:
+      'Shape a GPU-resident liquid-metal simulation inside an industrial vessel with responsive splashes and HDR highlights.',
+    category: 'WebGPU',
+    backends: ['webgpu'],
+    highDynamicRange: true,
+    difficulty: 'advanced',
+    maturity: 'experimental',
+    topics: ['simulation', 'compute']
+  },
+  {
+    title: 'Virtual Geometry Canyon',
+    route: 'experimental/virtual-geometry-canyon',
+    image: 'experimental/virtual-geometry-canyon.jpg',
+    description:
+      'Travel through a procedural canyon as GPU-selected geometry streams new detail into a massive virtual landscape.',
+    category: 'WebGPU',
+    backends: ['webgpu'],
+    difficulty: 'advanced',
+    maturity: 'experimental',
+    topics: ['geometry', 'performance']
+  },
+  {
+    title: 'Illumination Lab',
+    route: 'experimental/deferred-rendering',
+    image: 'experimental/deferred-rendering.jpg',
+    description:
+      'Inspect clustered lighting, ambient occlusion, glossy reflections, volumetrics, and adaptive HDR exposure.',
+    category: 'WebGPU',
+    backends: ['webgpu'],
+    highDynamicRange: true,
+    difficulty: 'advanced',
+    maturity: 'experimental',
+    topics: ['lighting', 'effects']
+  },
+  {
+    title: 'Effects: Image Processing',
+    route: 'showcase/postprocessing',
+    image: 'showcase/postprocessing.jpg',
+    description:
+      'Build, reorder, and tune a complete image-effect stack against a continuously animated procedural scene.',
+    category: 'API',
+    backends: ['webgpu', 'webgl2'],
+    difficulty: 'intermediate',
+    maturity: 'stable',
+    topics: ['effects', 'image-processing']
+  }
+];
+
+const CAPABILITY_STORIES = [
+  {
+    index: '01',
+    title: 'Rendering that scales',
+    description:
+      'Move from a first triangle to physically based materials, HDR lighting, composable effects, and GPU-driven scenes.',
+    technologies: ['Shader modules', 'PBR + HDR', 'Indirect draws']
+  },
+  {
+    index: '02',
+    title: 'Compute without detours',
+    description:
+      'Keep data on the GPU for simulation, filtering, aggregation, spatial queries, and command-graph execution.',
+    technologies: ['Compute pipelines', 'GPU tables', 'Zero readback']
+  },
+  {
+    index: '03',
+    title: 'Open by design',
+    description:
+      'Build with a TypeScript-first API across WebGPU and WebGL2, with natural paths into deck.gl, Arrow, and glTF.',
+    technologies: ['WebGPU + WebGL2', 'Apache Arrow', 'deck.gl + glTF']
+  }
+];
 
 if (typeof window !== 'undefined') {
   window.website = true;
@@ -10,37 +143,131 @@ if (typeof window !== 'undefined') {
 
 export default function IndexPage() {
   const {siteConfig} = useDocusaurusContext();
+  const baseUrl = useBaseUrl('/');
+  const gettingStartedUrl = `${baseUrl}docs/developer-guide/installing`;
+  const examplesUrl = `${baseUrl}examples`;
 
   return (
-    <Layout title="Home" description="luma.gl">
-      <main>
-        <section className={styles.banner}>
+    <Layout
+      title="Home"
+      description="The open-source WebGPU and WebGL2 toolkit for ambitious rendering, GPU compute, and data visualization."
+    >
+      <main className={styles.page}>
+        <section className={styles.banner} aria-labelledby="homepage-title">
           <div className={styles.heroExampleContainer}>
             <InstancingExample panel={false} />
           </div>
           <div className={styles.bannerContainer}>
-            <h1 className={styles.projectName}>{siteConfig.title}</h1>
-            <p>{siteConfig.tagline}</p>
-            <a className={styles.getStartedLink} href="./docs/developer-guide/installing">
-              GET STARTED
+            <p className={styles.heroEyebrow}>The open-source GPU toolkit</p>
+            <h1 className={styles.projectName} id="homepage-title">
+              {siteConfig.title}
+            </h1>
+            <p className={styles.heroTagline}>{siteConfig.tagline}</p>
+            <p className={styles.heroDescription}>
+              Create ambitious real-time rendering, simulation, and data visualization—directly on
+              the GPU.
+            </p>
+
+            <div className={styles.heroActions}>
+              <a className={styles.primaryAction} href={gettingStartedUrl}>
+                Get started <span aria-hidden="true">→</span>
+              </a>
+              <a className={styles.secondaryAction} href={examplesUrl}>
+                Explore examples <span aria-hidden="true">↗</span>
+              </a>
+            </div>
+
+            <ul className={styles.heroCapabilities} aria-label="Toolkit capabilities">
+              {HERO_CAPABILITIES.map(capability => (
+                <li className={styles.heroCapability} key={capability}>
+                  {capability}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <p className={styles.liveSceneLabel}>
+            <span className={styles.liveSceneIndicator} aria-hidden="true" />
+            Live GPU-rendered scene
+          </p>
+        </section>
+
+        <section className={styles.flagshipSection} aria-labelledby="flagship-examples-heading">
+          <div className={styles.sectionContainer}>
+            <div className={styles.sectionHeading}>
+              <div>
+                <p className={styles.sectionEyebrow}>Built with luma.gl</p>
+                <h2 className={styles.sectionTitle} id="flagship-examples-heading">
+                  See what the GPU can do.
+                </h2>
+              </div>
+              <p className={styles.sectionDescription}>
+                Real-time worlds, physical simulations, and visual effects—running in your browser.
+              </p>
+            </div>
+
+            <div className={styles.flagshipGrid}>
+              {FEATURED_EXAMPLES.map(example => (
+                <ExampleCard
+                  key={example.route}
+                  href={`${examplesUrl}/${example.route}`}
+                  imageUrl={`${baseUrl}images/examples/${example.image}`}
+                  title={example.title}
+                  description={example.description}
+                  category={example.category}
+                  backends={example.backends}
+                  highDynamicRange={example.highDynamicRange}
+                  difficulty={example.difficulty}
+                  maturity={example.maturity}
+                  topics={example.topics}
+                />
+              ))}
+            </div>
+
+            <a className={styles.galleryAction} href={examplesUrl}>
+              Explore every example <span aria-hidden="true">→</span>
             </a>
           </div>
         </section>
-        <div className={styles.contentContainer}>
-          <h2>High-performance toolkit for GPU-based data visualization.</h2>
-          <ul>
-            <li className={styles.bullet}>
-              Focused on high-performance data processing, e.g. instanced rendering and GPU compute.
-            </li>
-            <li className={styles.bullet}>
-              The core 3D rendering technology behind tools such as deck.gl, kepler.gl, and
-              avs.auto.
-            </li>
-            <li className={styles.bullet}>
-              A clean TypeScript and WebGPU friendly GPU API that works across WebGPU and WebGL 2.
-            </li>
-          </ul>
-        </div>
+
+        <section className={styles.capabilitySection} aria-labelledby="capabilities-heading">
+          <div className={styles.sectionContainer}>
+            <div className={styles.capabilityHeading}>
+              <p className={styles.capabilityEyebrow}>Built for the whole pipeline</p>
+              <h2 className={styles.capabilityTitle} id="capabilities-heading">
+                Low-level control.
+                <br />
+                High-level ambition.
+              </h2>
+              <p className={styles.capabilityIntroduction}>
+                One toolkit for the shader, the simulation, and everything you build around them.
+              </p>
+            </div>
+
+            <div className={styles.capabilityGrid}>
+              {CAPABILITY_STORIES.map(capability => (
+                <article className={styles.capabilityCard} key={capability.index}>
+                  <p className={styles.capabilityIndex}>{capability.index}</p>
+                  <h3 className={styles.capabilityCardTitle}>{capability.title}</h3>
+                  <p className={styles.capabilityCardDescription}>{capability.description}</p>
+                  <ul className={styles.technologyList} aria-label="Related technologies">
+                    {capability.technologies.map(technology => (
+                      <li className={styles.technology} key={technology}>
+                        {technology}
+                      </li>
+                    ))}
+                  </ul>
+                </article>
+              ))}
+            </div>
+
+            <div className={styles.closingStatement}>
+              <p>Ready to build something that moves?</p>
+              <a className={styles.closingAction} href={gettingStartedUrl}>
+                Start building <span aria-hidden="true">→</span>
+              </a>
+            </div>
+          </div>
+        </section>
       </main>
     </Layout>
   );

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -1,97 +1,574 @@
+.page {
+  --homepage-background: #f5f7fa;
+  --homepage-surface: #fff;
+  --homepage-ink: #0d1828;
+  --homepage-muted: #637086;
+  --homepage-border: rgba(15, 23, 42, 0.12);
+  --homepage-accent: #0284c7;
+  background: var(--homepage-background);
+  color: var(--homepage-ink);
+}
+
+:global(html[data-theme="dark"]) .page {
+  --homepage-background: #0c1320;
+  --homepage-surface: #121c2b;
+  --homepage-ink: #eff6ff;
+  --homepage-muted: #a5b4ca;
+  --homepage-border: rgba(148, 163, 184, 0.18);
+  --homepage-accent: #67e8f9;
+}
+
 .banner {
   position: relative;
-  height: 30rem;
-  background: var(--ifm-color-gray-400);
-  color: var(--ifm-color-gray-200);
-  z-index: 0;
+  display: flex;
+  min-height: clamp(620px, 78svh, 820px);
+  align-items: flex-end;
+  overflow: hidden;
+  background: #050b15;
+  color: #f8fafc;
+  isolation: isolate;
+}
+
+.banner::before,
+.banner::after {
+  position: absolute;
+  z-index: 1;
+  content: "";
+  inset: 0;
+  pointer-events: none;
+}
+
+.banner::before {
+  background:
+    linear-gradient(90deg, rgba(3, 8, 17, 0.94) 0%, rgba(3, 8, 17, 0.8) 36%, transparent 78%),
+    linear-gradient(0deg, rgba(3, 8, 17, 0.94), transparent 66%);
+}
+
+.banner::after {
+  background:
+    radial-gradient(ellipse at 20% 0%, rgba(56, 189, 248, 0.12), transparent 42%),
+    linear-gradient(0deg, rgba(2, 6, 23, 0.35), transparent 18%);
 }
 
 .heroExampleContainer {
   position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: -1;
+  z-index: 0;
+  inset: 0;
 }
 
 .bannerContainer {
-  position: absolute;
-  bottom: 0;
-  max-width: 80rem;
-  width: 100%;
-  margin: 0;
-  padding: 2rem 2rem 2rem 4rem;
+  position: relative;
+  z-index: 2;
+  width: min(100%, 1440px);
+  margin: 0 auto;
+  padding: clamp(120px, 17vh, 170px) clamp(28px, 7vw, 100px) clamp(82px, 10vh, 112px);
   pointer-events: none;
-  z-index: 0;
+}
+
+.heroEyebrow,
+.sectionEyebrow,
+.capabilityEyebrow {
+  margin: 0 0 20px;
+  font-size: 0.76rem;
+  font-weight: 720;
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+.heroEyebrow {
+  color: #a5f3fc;
 }
 
 .projectName {
-  font-size: 5em;
-  line-height: 1;
-  text-transform: uppercase;
-  letter-spacing: 4px;
-  font-weight: 700;
-  margin: 0 0 16px;
+  margin: 0;
+  color: #f8fafc;
+  font-size: clamp(5.1rem, 12.8vw, 10.5rem);
+  font-weight: 790;
+  letter-spacing: -0.085em;
+  line-height: 0.84;
 }
 
-.getStartedLink {
-  pointer-events: all;
-  font-size: 12px;
-  line-height: 44px;
-  letter-spacing: 2px;
-  font-weight: bold;
-  margin: 24px 0;
-  padding: 0 4rem;
-  display: inline-block;
+.heroTagline {
+  max-width: 660px;
+  margin: 26px 0 0;
+  color: #f1f5f9;
+  font-size: clamp(1.12rem, 2vw, 1.58rem);
+  font-weight: 570;
+  letter-spacing: -0.022em;
+  line-height: 1.4;
+}
+
+.heroDescription {
+  max-width: 570px;
+  margin: 13px 0 0;
+  color: rgba(203, 213, 225, 0.91);
+  font-size: clamp(0.93rem, 1.35vw, 1.06rem);
+  line-height: 1.65;
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 31px;
+  pointer-events: auto;
+}
+
+.primaryAction,
+.secondaryAction,
+.galleryAction,
+.closingAction {
+  display: inline-flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 0.86rem;
+  font-weight: 680;
+  letter-spacing: 0.008em;
+  padding: 0 19px;
   text-decoration: none;
   transition:
-    background-color 250ms ease-in,
-    color 250ms ease-in;
-  border: solid 2px var(--ifm-color-primary);
-  color: inherit;
-  border-image: linear-gradient(
-    to right,
-    var(--ifm-color-gray-700) 0%,
-    var(--ifm-color-gray-400) 100%
-  );
-  border-image-slice: 2;
+    background-color 170ms ease,
+    border-color 170ms ease,
+    box-shadow 170ms ease,
+    color 170ms ease,
+    transform 170ms ease;
 }
 
-.getStartedLink:visited {
-  color: inherit;
+.primaryAction {
+  background: #7dd3fc;
+  color: #082033;
 }
 
-.getStartedLink:active,
-.getStartedLink:hover {
-  color: var(--ifm-color-white);
+.primaryAction:hover,
+.primaryAction:focus-visible {
+  background: #a5f3fc;
+  box-shadow: 0 0 24px rgba(103, 232, 249, 0.27);
+  color: #082033;
+  text-decoration: none;
+  transform: translateY(-2px);
 }
 
-.getStartedLink:hover {
-  background-color: var(--ifm-color-primary);
+.secondaryAction {
+  border-color: rgba(226, 232, 240, 0.34);
+  background: rgba(15, 23, 42, 0.56);
+  backdrop-filter: blur(12px);
+  color: #f1f5f9;
 }
 
-.contentContainer {
-  padding: 64px;
+.secondaryAction:hover,
+.secondaryAction:focus-visible {
+  border-color: rgba(125, 211, 252, 0.82);
+  background: rgba(15, 23, 42, 0.82);
+  color: #f8fafc;
+  text-decoration: none;
+  transform: translateY(-2px);
 }
 
-.bullet {
-  background: url("/img/icon-high-precision.svg") no-repeat left top;
+.primaryAction:focus-visible,
+.secondaryAction:focus-visible,
+.galleryAction:focus-visible,
+.closingAction:focus-visible {
+  outline: 2px solid #7dd3fc;
+  outline-offset: 4px;
+}
+
+.heroCapabilities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 30px 0 0;
+  padding: 0;
   list-style: none;
-  max-width: 540px;
-  margin-top: 8px;
-  padding: 0 0 12px 56px;
-  font-size: 16px;
 }
 
-@media screen and (max-width: 768px) {
-  .contentContainer {
-    padding: 48px;
+.heroCapability {
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  border-radius: 999px;
+  background: rgba(8, 15, 27, 0.56);
+  color: #dbeafe;
+  font-size: 0.69rem;
+  font-weight: 630;
+  letter-spacing: 0.015em;
+  line-height: 1.1;
+  padding: 7px 10px;
+}
+
+.liveSceneLabel {
+  position: absolute;
+  z-index: 2;
+  right: clamp(22px, 5vw, 64px);
+  bottom: 31px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0;
+  color: rgba(226, 232, 240, 0.77);
+  font-size: 0.72rem;
+  letter-spacing: 0.025em;
+  pointer-events: none;
+}
+
+.liveSceneIndicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  animation: livePulse 2.2s ease-in-out infinite;
+  background: #6ee7b7;
+  box-shadow: 0 0 12px rgba(110, 231, 183, 0.72);
+}
+
+.flagshipSection {
+  --luma-example-surface: rgba(11, 19, 32, 0.92);
+  --luma-example-surface-raised: rgba(22, 34, 52, 0.88);
+  --luma-example-border: rgba(148, 163, 184, 0.18);
+  --luma-example-text: #f1f5f9;
+  --luma-example-text-muted: #a3b2c5;
+  --luma-example-accent: #67e8f9;
+  --luma-example-radius: 16px;
+  --luma-example-shadow: 0 18px 44px rgba(2, 6, 23, 0.26);
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(ellipse at 76% 4%, rgba(56, 189, 248, 0.105), transparent 43%),
+    radial-gradient(ellipse at 3% 73%, rgba(129, 140, 248, 0.095), transparent 42%), #070e19;
+  color: #f1f5f9;
+}
+
+.sectionContainer {
+  width: min(100%, 1480px);
+  margin: 0 auto;
+  padding: 106px clamp(24px, 6.2vw, 96px) 100px;
+}
+
+.sectionHeading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  margin-bottom: 44px;
+}
+
+.sectionEyebrow {
+  color: #7dd3fc;
+}
+
+.sectionTitle,
+.capabilityTitle {
+  margin: 0;
+  font-size: clamp(2.2rem, 4.7vw, 4.05rem);
+  font-weight: 730;
+  letter-spacing: -0.06em;
+  line-height: 1.04;
+}
+
+.sectionTitle {
+  color: #f8fafc;
+}
+
+.sectionDescription {
+  max-width: 390px;
+  margin: 0 0 3px;
+  color: #a8b6c9;
+  font-size: 0.91rem;
+  line-height: 1.65;
+}
+
+.flagshipGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  align-items: stretch;
+  gap: 18px;
+}
+
+.galleryAction {
+  margin-top: 40px;
+  border-color: rgba(125, 211, 252, 0.48);
+  background: rgba(8, 47, 73, 0.26);
+  color: #bae6fd;
+}
+
+.galleryAction:hover,
+.galleryAction:focus-visible {
+  border-color: #7dd3fc;
+  background: rgba(8, 47, 73, 0.5);
+  color: #e0f2fe;
+  text-decoration: none;
+  transform: translateX(3px);
+}
+
+.capabilitySection {
+  background:
+    radial-gradient(ellipse at 0% 0%, rgba(56, 189, 248, 0.08), transparent 39%),
+    var(--homepage-background);
+}
+
+.capabilityHeading {
+  max-width: 800px;
+  margin-bottom: 51px;
+}
+
+.capabilityEyebrow {
+  color: var(--homepage-accent);
+}
+
+.capabilityTitle {
+  color: var(--homepage-ink);
+}
+
+.capabilityIntroduction {
+  max-width: 570px;
+  margin: 20px 0 0;
+  color: var(--homepage-muted);
+  font-size: clamp(1rem, 1.7vw, 1.16rem);
+  line-height: 1.65;
+}
+
+.capabilityGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 17px;
+}
+
+.capabilityCard {
+  display: flex;
+  min-height: 285px;
+  flex-direction: column;
+  border: 1px solid var(--homepage-border);
+  border-radius: 18px;
+  background: var(--homepage-surface);
+  padding: 25px 24px 22px;
+}
+
+.capabilityIndex {
+  margin: 0 0 24px;
+  color: var(--homepage-accent);
+  font-size: 0.76rem;
+  font-weight: 750;
+  letter-spacing: 0.09em;
+}
+
+.capabilityCardTitle {
+  margin: 0;
+  color: var(--homepage-ink);
+  font-size: 1.14rem;
+  font-weight: 710;
+  letter-spacing: -0.025em;
+}
+
+.capabilityCardDescription {
+  margin: 11px 0 20px;
+  color: var(--homepage-muted);
+  font-size: 0.89rem;
+  line-height: 1.66;
+}
+
+.technologyList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin: auto 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.technology {
+  border: 1px solid var(--homepage-border);
+  border-radius: 999px;
+  color: var(--homepage-muted);
+  font-size: 0.68rem;
+  line-height: 1.1;
+  padding: 6px 8px;
+}
+
+.closingStatement {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-top: 62px;
+  border-top: 1px solid var(--homepage-border);
+  padding-top: 26px;
+}
+
+.closingStatement > p {
+  margin: 0;
+  color: var(--homepage-ink);
+  font-size: clamp(1rem, 1.7vw, 1.18rem);
+  font-weight: 590;
+}
+
+.closingAction {
+  border-color: var(--homepage-border);
+  background: var(--homepage-surface);
+  color: var(--homepage-ink);
+}
+
+.closingAction:hover,
+.closingAction:focus-visible {
+  border-color: var(--homepage-accent);
+  color: var(--homepage-accent);
+  text-decoration: none;
+  transform: translateX(3px);
+}
+
+@keyframes livePulse {
+  0%,
+  100% {
+    opacity: 0.58;
+  }
+
+  50% {
+    opacity: 1;
   }
 }
 
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 1180px) {
+  .flagshipGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media screen and (max-width: 860px) {
   .banner {
-    height: 80vh;
+    min-height: 680px;
+  }
+
+  .bannerContainer {
+    padding-right: 34px;
+    padding-left: 34px;
+  }
+
+  .liveSceneLabel {
+    right: 34px;
+  }
+
+  .sectionContainer {
+    padding: 84px 34px;
+  }
+
+  .sectionHeading {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .sectionDescription {
+    max-width: 540px;
+  }
+
+  .flagshipGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .capabilityGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .capabilityCard {
+    min-height: 0;
+  }
+}
+
+@media screen and (max-width: 540px) {
+  .banner {
+    min-height: 720px;
+  }
+
+  .banner::before {
+    background:
+      linear-gradient(90deg, rgba(3, 8, 17, 0.8), transparent 96%),
+      linear-gradient(0deg, rgba(3, 8, 17, 0.96), rgba(3, 8, 17, 0.38) 75%);
+  }
+
+  .bannerContainer {
+    padding: 138px 23px 90px;
+  }
+
+  .heroEyebrow,
+  .sectionEyebrow,
+  .capabilityEyebrow {
+    font-size: 0.68rem;
+  }
+
+  .projectName {
+    font-size: clamp(4.3rem, 18vw, 6.2rem);
+  }
+
+  .heroActions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .primaryAction,
+  .secondaryAction {
+    justify-content: space-between;
+  }
+
+  .heroCapabilities {
+    gap: 6px;
+  }
+
+  .heroCapability {
+    font-size: 0.64rem;
+  }
+
+  .liveSceneLabel {
+    right: 23px;
+    bottom: 28px;
+    font-size: 0.68rem;
+  }
+
+  .sectionContainer {
+    padding: 73px 22px;
+  }
+
+  .sectionHeading {
+    margin-bottom: 30px;
+  }
+
+  .flagshipGrid {
+    grid-template-columns: 1fr;
+    gap: 15px;
+  }
+
+  .capabilityHeading {
+    margin-bottom: 34px;
+  }
+
+  .capabilityCard {
+    padding: 23px 20px;
+  }
+
+  .closingStatement {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .liveSceneIndicator {
+    animation: none;
+  }
+
+  .primaryAction,
+  .secondaryAction,
+  .galleryAction,
+  .closingAction {
+    transition: none;
+  }
+
+  .primaryAction:hover,
+  .primaryAction:focus-visible,
+  .secondaryAction:hover,
+  .secondaryAction:focus-visible,
+  .galleryAction:hover,
+  .galleryAction:focus-visible,
+  .closingAction:hover,
+  .closingAction:focus-visible {
+    transform: none;
   }
 }


### PR DESCRIPTION
## Goals

Give luma.gl a homepage worthy of the full Project Flagship demo suite while preserving the existing live Instancing hero and ANARI Playground's distinct style.

## Changes

- Replace the old three-bullet landing page with a premium editorial GPU-toolkit homepage while retaining the actual live `<InstancingExample panel={false} />` hero.
- Add readable cinematic hero treatment, honest WebGPU/WebGL2/compute/HDR capability chips, accessible Getting Started and Explore Examples calls to action, and a live-rendered-scene indicator.
- Feature **eight real interactive demonstrations** using the reusable #2883 `ExampleCard`: Lightstorm, Tempest Ocean, Fire Forge, Prism Cathedral, Fluid Foundry, Virtual Geometry Canyon, Illumination Lab, and Image Processing.
- Preserve accurate backend and HDR classifications for every featured demo and reuse only existing authentic screenshot assets.
- Introduce concise rendering, GPU-compute/data, and open-interoperability storytelling with responsive layouts, dark/light theme support, keyboard focus, and reduced-motion handling.
- Use base-URL-aware routes and images for staged Docusaurus deployments; leave ANARI application code and visual styling unchanged.

## Verification

- `env -u YARN_NO_PROXY yarn install --immutable`
- `env -u YARN_NO_PROXY yarn lint fix`
- `env -u YARN_NO_PROXY NODE_OPTIONS=--max-old-space-size=6144 yarn website:build` — **passed**, including standalone ANARI, complete server/client bundles, 4,525-document search index, and llms output verification.
- Production `website/build/index.html`: all **eight real cards and routes** server-rendered successfully.
- All eight image assets/routes, six HDR flags, seven WebGPU-only flags, one dual-backend card, JSX/CSS parsing, responsive behavior, and reduced-motion rules verified.
- Full pre-commit/node suite: **351 passed; 2 skipped**.

Rebased onto latest master after the Project Flagship foundation #2883 and metadata #2884 both landed.