### PR TITLE
perf(ci): speed up example typechecks and dependency caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,8 @@ jobs:
             ~/.yarn/berry/cache
             .yarn/install-state.gz
           key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn4-
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -78,24 +80,42 @@ jobs:
           corepack prepare yarn@4.13.0 --activate
           yarn -v
 
-      - name: Cache Yarn Berry artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Restore Yarn Berry artifacts
+        id: yarn-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.yarn/berry/cache
             .yarn/install-state.gz
           key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn4-
 
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Save Yarn Berry artifacts before reclaiming disk space
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.yarn/berry/cache
+            .yarn/install-state.gz
+          key: ${{ steps.yarn-cache.outputs.cache-primary-key }}
+
+      - name: Resolve installed Playwright version
+        id: playwright-version
+        run: yarn workspace @luma.gl/devtools-extensions node -p "'version=' + require('playwright/package.json').version" >> "$GITHUB_OUTPUT"
+
       - name: Cache Playwright Chromium
+        id: playwright-cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-ms-playwright-${{ hashFiles('yarn.lock', 'dev-modules/devtools-extensions/package.json') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-ms-playwright-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: yarn playwright:install
 
       - name: Reclaim install cache and report disk usage
@@ -180,6 +200,8 @@ jobs:
             ~/.yarn/berry/cache
             .yarn/install-state.gz
           key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn4-
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -221,6 +243,8 @@ jobs:
             ~/.yarn/berry/cache
             .yarn/install-state.gz
           key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn4-
 
       - name: Install website dependencies
         run: yarn install --immutable

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,12 +1,1 @@
 nodeLinker: node-modules
-
-supportedArchitectures:
-  cpu:
-    - arm64
-    - x64
-    - darwin-x64
-  os:
-    - current
-    - darwin
-    - linux
-    - win32

--- a/scripts/examples-typecheck.mjs
+++ b/scripts/examples-typecheck.mjs
@@ -135,10 +135,20 @@ function getExampleWorkspaces() {
   return workspaces;
 }
 
-function createTempTypecheckConfig(workspacePath) {
+function createTempTypecheckConfig(workspaces) {
   const tempDirectory = mkdtempSync(join(tmpdir(), 'luma-examples-typecheck-'));
   const ambientTypesPath = join(tempDirectory, 'ambient.d.ts');
   const tsconfigPath = join(tempDirectory, 'tsconfig.json');
+  const includedFiles = workspaces.flatMap(({workspacePath}) => [
+    `${workspacePath}/**/*.ts`,
+    `${workspacePath}/**/*.tsx`,
+    `${workspacePath}/**/*.d.ts`
+  ]);
+  const excludedFiles = workspaces.flatMap(({workspacePath}) => [
+    `${workspacePath}/node_modules`,
+    `${workspacePath}/dist`,
+    `${workspacePath}/vite.config.ts`
+  ]);
 
   writeFileSync(ambientTypesPath, AMBIENT_MODULE_DECLARATIONS);
   writeFileSync(
@@ -147,17 +157,8 @@ function createTempTypecheckConfig(workspacePath) {
       {
         extends: join(repoRoot, 'tsconfig.json'),
         compilerOptions: SHARED_COMPILER_OPTIONS,
-        include: [
-          `${workspacePath}/**/*.ts`,
-          `${workspacePath}/**/*.tsx`,
-          `${workspacePath}/**/*.d.ts`,
-          ambientTypesPath
-        ],
-        exclude: [
-          `${workspacePath}/node_modules`,
-          `${workspacePath}/dist`,
-          `${workspacePath}/vite.config.ts`
-        ]
+        include: [...includedFiles, ambientTypesPath],
+        exclude: excludedFiles
       },
       null,
       2
@@ -167,35 +168,38 @@ function createTempTypecheckConfig(workspacePath) {
   return {tempDirectory, tsconfigPath};
 }
 
-function typecheckWorkspace({name, workspaceId, workspacePath}) {
-  const {tempDirectory, tsconfigPath} = NATIVE_TYPESCRIPT_CONFIG_WORKSPACES.has(workspaceId)
-    ? {tempDirectory: null, tsconfigPath: join(workspacePath, 'tsconfig.json')}
-    : createTempTypecheckConfig(workspacePath);
+function runTypecheck(tsconfigPath, description) {
+  console.log(`Typechecking ${description}`);
+  const result = spawnSync(tscPath, ['-p', tsconfigPath, '--noEmit'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: 'pipe'
+  });
+
+  if (result.status !== 0) {
+    process.stderr.write(result.stdout || '');
+    process.stderr.write(result.stderr || '');
+    return false;
+  }
+
+  return true;
+}
+
+function typecheckWorkspaces(workspaces) {
+  if (workspaces.length === 0) {
+    return true;
+  }
+
+  const {tempDirectory, tsconfigPath} = createTempTypecheckConfig(workspaces);
 
   try {
-    console.log(`Typechecking ${name}`);
-    const result = spawnSync(tscPath, ['-p', tsconfigPath, '--noEmit'], {
-      cwd: repoRoot,
-      encoding: 'utf8',
-      stdio: 'pipe'
-    });
-
-    if (result.status !== 0) {
-      process.stderr.write(result.stdout || '');
-      process.stderr.write(result.stderr || '');
-      return false;
-    }
-
-    return true;
+    return runTypecheck(tsconfigPath, `${workspaces.length} example workspaces together`);
   } finally {
-    if (tempDirectory) {
-      rmSync(tempDirectory, {recursive: true, force: true});
-    }
+    rmSync(tempDirectory, {recursive: true, force: true});
   }
 }
 
 const workspaces = getExampleWorkspaces();
-let allPassed = true;
 
 console.log(
   `Typechecking ${workspaces.length} example workspace${workspaces.length === 1 ? '' : 's'}: ${workspaces
@@ -203,8 +207,16 @@ console.log(
     .join(', ')}`
 );
 
-for (const workspace of workspaces) {
-  allPassed = typecheckWorkspace(workspace) && allPassed;
+const sharedConfigurationWorkspaces = workspaces.filter(
+  ({workspaceId}) => !NATIVE_TYPESCRIPT_CONFIG_WORKSPACES.has(workspaceId)
+);
+const nativeConfigurationWorkspaces = workspaces.filter(({workspaceId}) =>
+  NATIVE_TYPESCRIPT_CONFIG_WORKSPACES.has(workspaceId)
+);
+let allPassed = typecheckWorkspaces(sharedConfigurationWorkspaces);
+
+for (const {name, workspacePath} of nativeConfigurationWorkspaces) {
+  allPassed = runTypecheck(join(workspacePath, 'tsconfig.json'), name) && allPassed;
 }
 
 if (!allPassed) {


### PR DESCRIPTION
## Goals

Reduce avoidable GitHub Actions runtime and dependency download volume without changing test coverage, weakening Chromium/GPU stability protections, or including unrelated changes from the existing working tree.

## Changes

### Batch example TypeScript checks

- Replace one TypeScript process per example with a single shared compiler program for the 43 examples that use the common generated configuration.
- Keep `showcase/anari` on its existing native TypeScript configuration, reducing the current 44-example suite from 44 compiler invocations to two while preserving its separate settings.
- Preserve the supported-workspace allowlist, compiler options, source globs, exclusions, shared ambient asset declarations, diagnostics, and temporary-directory cleanup.
- Full local verification checked all 44 examples successfully; the aggregated run completed in 46.67 seconds on the isolated worktree. Recent CI runs spent approximately 134–153 seconds typechecking a smaller set of examples sequentially.

### Install native dependencies only for the current platform

- Remove the broad `supportedArchitectures` override and retain the existing `node-modules` linker.
- Yarn now resolves installation targets as `os: [current]`, `cpu: [current]`, and `libc: [current]` instead of fetching macOS, Linux, Windows, ARM64, and x64 native packages together.
- A controlled comparison reduced platform-specific package downloads from approximately 879 MiB to 197 MiB.
- Verify that the existing lockfile retains every platform variant and remains byte-for-byte unchanged after offline resolution.

### Make CI dependency and browser caches effective

- Add Yarn cache restore-prefix fallbacks to all four CI jobs: bundle size, tests, examples, and website.
- Split the main test job into explicit cache restore and cache save actions, saving the fully populated cache before the existing disk-space cleanup removes Yarn archives.
- Resolve the installed Playwright version and key the Chromium cache by operating system, CPU architecture, and Playwright version instead of invalidating it for every unrelated lockfile change.
- Skip Chromium installation only on an exact matching browser-cache hit.
- Preserve the four existing jobs, immutable installs, coverage generation, disk cleanup, and SHA-pinned GitHub Actions.

## Verification

- `nvm use` — Node 22.22.1.
- `env -u YARN_NO_PROXY corepack yarn build` — passed for all workspace packages.
- `env -u YARN_NO_PROXY corepack yarn examples:typecheck` — all 44 examples passed; 43 batched plus the separate ANARI configuration.
- `env -u YARN_NO_PROXY corepack yarn lint fix` — 1,438 files formatted/checked; no fixes required.
- Mandatory repository pre-commit `test-fast` check — 82 node test files passed, 355 tests passed, and two tests were skipped; local worker count and timeout were adjusted for host contention.
- Parsed the workflow YAML and verified all four cache restore fallbacks, save-before-cleanup ordering, architecture-aware Chromium cache key, and SHA-pinned actions.
- Ran offline Yarn resolution in a temporary manifest-only checkout; `yarn.lock` SHA-256 remained `8a36a2cf0c3e56f8a056637f956a61f0a4fe1c9f2c73a4da5441ffb323b28079` before and after.

## Risks and rollout

- The first run using the new Chromium cache key intentionally populates a fresh, version-specific browser cache.
- A single `node_modules` installation is no longer pre-populated for other operating systems or CPU architectures; those environments continue to resolve normally from the unchanged cross-platform lockfile.
- Browser test parallelism and coverage configuration are intentionally unchanged.