### PR TITLE
fix(website): complete accessible example backend keyboard navigation

### DIFF
--- a/test/examples/example-device-tab-navigation.spec.ts
+++ b/test/examples/example-device-tab-navigation.spec.ts
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {afterEach, describe, expect, test} from 'vitest';
-import {getNextKeyboardTab} from '../../website/src/react-luma/components/tab-navigation';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {
+  getNextKeyboardTab,
+  handleKeyboardTabNavigation
+} from '../../website/src/react-luma/components/tab-navigation';
 
 let tabList: HTMLDivElement | null = null;
 
@@ -41,6 +44,83 @@ describe('example graphics backend keyboard navigation', () => {
     expect(getNextKeyboardTab(disabledTab, 'ArrowRight')).toBeNull();
     expect(getNextKeyboardTab(detachedButton, 'ArrowRight')).toBeNull();
   });
+
+  test.each([
+    ['Home', 'webgpu-core'],
+    ['End', 'webgl']
+  ])('prevents %s without reactivating the already targeted backend', (pressedKey, backend) => {
+    const onSelection = vi.fn();
+    const [firstTab, , lastTab] = renderInteractiveBackendTabs({
+      selectedBackend: backend,
+      onSelection
+    });
+    const currentTab = backend === 'webgpu-core' ? firstTab : lastTab;
+    currentTab.focus();
+    const focus = vi.spyOn(currentTab, 'focus');
+    const click = vi.spyOn(currentTab, 'click');
+
+    const keyboardEvent = pressNavigationKey(currentTab, pressedKey);
+
+    expect(keyboardEvent.defaultPrevented).toBe(true);
+    expect(focus).not.toHaveBeenCalled();
+    expect(click).not.toHaveBeenCalled();
+    expect(onSelection).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(currentTab);
+  });
+
+  test.each([
+    'ArrowLeft',
+    'ArrowRight',
+    'Home',
+    'End'
+  ])('prevents %s without reactivating the only available backend', pressedKey => {
+    const onSelection = vi.fn();
+    const [onlyEnabledTab, unavailableWebGPU, unavailableWebGL] = renderInteractiveBackendTabs({
+      enabledBackends: ['webgpu-core'],
+      onSelection
+    });
+    onlyEnabledTab.focus();
+    const focus = vi.spyOn(onlyEnabledTab, 'focus');
+    const click = vi.spyOn(onlyEnabledTab, 'click');
+
+    const keyboardEvent = pressNavigationKey(onlyEnabledTab, pressedKey);
+
+    expect(keyboardEvent.defaultPrevented).toBe(true);
+    expect(focus).not.toHaveBeenCalled();
+    expect(click).not.toHaveBeenCalled();
+    expect(onSelection).not.toHaveBeenCalled();
+    expect(onlyEnabledTab.tabIndex).toBe(0);
+    expect(unavailableWebGPU.tabIndex).toBe(-1);
+    expect(unavailableWebGL.tabIndex).toBe(-1);
+  });
+
+  test('moves focus and selection once while skipping disabled tabs and updating roving focus', () => {
+    const onSelection = vi.fn();
+    const [firstTab, disabledTab, lastTab] = renderInteractiveBackendTabs({onSelection});
+    firstTab.focus();
+
+    const keyboardEvent = pressNavigationKey(firstTab, 'ArrowRight');
+
+    expect(keyboardEvent.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(lastTab);
+    expect(onSelection).toHaveBeenCalledExactlyOnceWith('webgl');
+    expect(firstTab.tabIndex).toBe(-1);
+    expect(disabledTab.tabIndex).toBe(-1);
+    expect(lastTab.tabIndex).toBe(0);
+    expect(lastTab.getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('leaves native Tab handling untouched', () => {
+    const onSelection = vi.fn();
+    const [firstTab] = renderInteractiveBackendTabs({onSelection});
+    firstTab.focus();
+
+    const keyboardEvent = pressNavigationKey(firstTab, 'Tab');
+
+    expect(keyboardEvent.defaultPrevented).toBe(false);
+    expect(onSelection).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(firstTab);
+  });
 });
 
 function makeBackendTabs(): [HTMLButtonElement, HTMLButtonElement, HTMLButtonElement] {
@@ -59,4 +139,52 @@ function makeBackendTabs(): [HTMLButtonElement, HTMLButtonElement, HTMLButtonEle
   });
 
   return backends as [HTMLButtonElement, HTMLButtonElement, HTMLButtonElement];
+}
+
+function renderInteractiveBackendTabs({
+  selectedBackend = 'webgpu-core',
+  enabledBackends = ['webgpu-core', 'webgl'],
+  onSelection
+}: {
+  selectedBackend?: string;
+  enabledBackends?: string[];
+  onSelection?: (selectedBackend: string) => void;
+} = {}): [HTMLButtonElement, HTMLButtonElement, HTMLButtonElement] {
+  const backendTabs = makeBackendTabs();
+
+  for (const backendTab of backendTabs) {
+    const backend = backendTab.getAttribute('data-luma-device-tab') || '';
+    backendTab.disabled = !enabledBackends.includes(backend);
+    backendTab.tabIndex = backend === selectedBackend && !backendTab.disabled ? 0 : -1;
+    backendTab.setAttribute('aria-selected', String(backend === selectedBackend));
+    backendTab.addEventListener('keydown', keyboardEvent => {
+      handleKeyboardTabNavigation({
+        currentTarget: backendTab,
+        key: keyboardEvent.key,
+        preventDefault: () => keyboardEvent.preventDefault()
+      });
+    });
+    backendTab.addEventListener('click', () => {
+      onSelection?.(backend);
+      for (const otherBackendTab of backendTabs) {
+        const isSelected = otherBackendTab === backendTab;
+        otherBackendTab.tabIndex = isSelected ? 0 : -1;
+        otherBackendTab.setAttribute('aria-selected', String(isSelected));
+      }
+    });
+  }
+
+  return backendTabs;
+}
+
+function pressNavigationKey(currentTab: HTMLButtonElement, pressedKey: string): KeyboardEvent {
+  const keyboardEvent = new KeyboardEvent('keydown', {
+    key: pressedKey,
+    bubbles: true,
+    cancelable: true
+  });
+
+  currentTab.dispatchEvent(keyboardEvent);
+
+  return keyboardEvent;
 }

--- a/test/examples/example-device-tabs.node.spec.ts
+++ b/test/examples/example-device-tabs.node.spec.ts
@@ -30,9 +30,25 @@ describe('example graphics backend tab semantics', () => {
     expect(html).toContain('disabled=""');
     expect(html).toContain('N/A');
   });
+
+  test('keeps only the selected, enabled backend in the document tab order', () => {
+    const html = renderBackendTabs('webgpu-max');
+
+    expect(getBackendTabMarkup(html, 'webgpu-core')).toContain('tabindex="-1"');
+    expect(getBackendTabMarkup(html, 'webgpu-max')).toContain('tabindex="0"');
+    expect(getBackendTabMarkup(html, 'webgl')).toContain('tabindex="-1"');
+    expect(html.match(/tabindex="0"/g)).toHaveLength(1);
+  });
+
+  test('never puts a disabled selected backend in the document tab order', () => {
+    const html = renderBackendTabs('webgl');
+
+    expect(getBackendTabMarkup(html, 'webgl')).toContain('tabindex="-1"');
+    expect(html).not.toContain('tabindex="0"');
+  });
 });
 
-function renderBackendTabs(): string {
+function renderBackendTabs(selectedItem: string = 'webgpu-core'): string {
   const build = buildSync({
     entryPoints: [path.join(process.cwd(), 'website/src/react-luma/components/tabs.jsx')],
     outdir: path.join(process.cwd(), '.luma-device-tabs-memory'),
@@ -59,12 +75,18 @@ function renderBackendTabs(): string {
   return renderToStaticMarkup(
     React.createElement(
       Tabs,
-      {label: 'Graphics backend', selectedItem: 'webgpu-core'},
+      {label: 'Graphics backend', selectedItem},
       React.createElement(Tab, {
         key: 'webgpu-core',
         title: 'WebGPU',
         tag: 'webgpu-core',
         badge: 'CORE'
+      }),
+      React.createElement(Tab, {
+        key: 'webgpu-max',
+        title: 'WebGPU',
+        tag: 'webgpu-max',
+        badge: 'MAX'
       }),
       React.createElement(Tab, {
         key: 'webgl',
@@ -75,4 +97,12 @@ function renderBackendTabs(): string {
       })
     )
   );
+}
+
+function getBackendTabMarkup(html: string, backend: string): string {
+  const buttonMarkup = html.match(
+    new RegExp(`<button[^>]*data-luma-device-tab="${backend}"[^>]*>`)
+  );
+  expect(buttonMarkup).not.toBeNull();
+  return buttonMarkup?.[0] || '';
 }

--- a/website/src/react-luma/components/tab-navigation.ts
+++ b/website/src/react-luma/components/tab-navigation.ts
@@ -1,3 +1,23 @@
+/** Applies standard tab navigation without reactivating the currently selected backend. */
+export function handleKeyboardTabNavigation(event: {
+  currentTarget: HTMLButtonElement;
+  key: string;
+  preventDefault: () => void;
+}): void {
+  const nextTab = getNextKeyboardTab(event.currentTarget, event.key);
+  if (!nextTab) {
+    return;
+  }
+
+  event.preventDefault();
+  if (nextTab === event.currentTarget) {
+    return;
+  }
+
+  nextTab.focus();
+  nextTab.click();
+}
+
 /** Returns the enabled tab selected by standard horizontal-tab keyboard navigation. */
 export function getNextKeyboardTab(
   currentTab: HTMLButtonElement,

--- a/website/src/react-luma/components/tabs.jsx
+++ b/website/src/react-luma/components/tabs.jsx
@@ -1,6 +1,6 @@
 import React, {Children, useState} from 'react';
 import clsx from 'clsx';
-import {getNextKeyboardTab} from './tab-navigation';
+import {handleKeyboardTabNavigation} from './tab-navigation';
 import styles from './tabs.module.css';
 
 export const Tabs = props => {
@@ -13,16 +13,6 @@ export const Tabs = props => {
   if (!tabs.some(e => (e.props.tag || e.props.title) === selected)) {
     selected = selectedItem;
   }
-
-  const handleKeyboardNavigation = event => {
-    const nextTab = getNextKeyboardTab(event.currentTarget, event.key);
-    if (!nextTab) {
-      return;
-    }
-    nextTab.focus();
-    nextTab.click();
-    event.preventDefault();
-  };
 
   return (
     <>
@@ -45,12 +35,13 @@ export const Tabs = props => {
               aria-selected={isSelected}
               aria-disabled={tab.props.disabled || undefined}
               disabled={tab.props.disabled}
+              tabIndex={isSelected && !tab.props.disabled ? 0 : -1}
               onClick={() => {
                 if (!tab.props.disabled) {
                   setSelected(tabIdentifier);
                 }
               }}
-              onKeyDown={handleKeyboardNavigation}
+              onKeyDown={handleKeyboardTabNavigation}
             >
               <span className={styles.backendIndicator} aria-hidden="true" />
               <span className={styles.label}>{tab.props.label || tab.props.title}</span>


### PR DESCRIPTION
## Goals

Complete the Project Flagship backend-tab accessibility work and address both review findings posted after #2888 merged, without restarting an already-running visualization.

## Changes

- Extract the actual keyboard-navigation handler shared by the production React tab component and real-browser regression tests.
- When Home, End, or Arrow keys target the currently active backend—including a single available backend—prevent the browser’s default behavior without focusing, clicking, reselecting, or restarting the live example.
- Implement standard **roving `tabIndex`**: only the selected, enabled backend participates in sequential Tab navigation; disabled and inactive backends use `tabIndex={-1}`.
- Preserve ArrowLeft/ArrowRight/Home/End behavior, disabled-backend skipping, selection/focus synchronization, and native Tab navigation.
- Add focused Chromium regressions for selected Home/End, every navigation key with a single backend, disabled backends, one-time selection, and native Tab behavior.
- Add server-rendered markup regressions proving exactly one enabled selected tab is focusable and disabled selections never enter the tab order.

Addresses both post-merge review comments on #2888:
- https://github.com/visgl/luma.gl/pull/2888#discussion_r3708008093
- https://github.com/visgl/luma.gl/pull/2888#discussion_r3708008101

## Verification

- `env -u YARN_NO_PROXY yarn lint fix` — clean.
- Focused real Chromium keyboard-navigation suite — **12 passed**.
- Focused server-rendered backend semantics suite — **4 passed**.
- Full repository pre-commit/node suite — **367 passed; 2 skipped**.
- `git diff --check` — clean.

Part of Project Flagship; narrowly scoped follow-up to merged #2888.