### PR TITLE
Cull trace dependencies from GPU candidate batches

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -8,7 +8,6 @@ import {AnimationLoopTemplate, Computation, Model} from '@luma.gl/engine';
 import {
   DispatchCommandBuffer,
   DrawCommandBuffer,
-  GPUAncestorProjection,
   GPUCommandGraph,
   GPUGraphTraversal,
   GPUHierarchyLayout,
@@ -133,7 +132,7 @@ type TraceGraphResources = {
   selectedSeedCount: Buffer;
   traversalDepth: Buffer;
   reachedSpans: Buffer;
-  visibleAncestors: Buffer;
+  dependencyResults: Buffer;
   visibilityGeneration: Buffer;
   baseVisibility: Buffer;
   spanVisibility: Buffer;
@@ -262,7 +261,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     const pick = this.pendingPick;
     const visibilityGeneration = (this.frameIndex % 0xfffffffe) + 1;
     resources.visibilityGeneration.write(Uint32Array.of(visibilityGeneration));
-    this.writeViewUniforms(width, height, pick, visibilityGeneration);
+    this.writeViewUniforms(width, height, pick, visibilityGeneration, resources.dependencyCount);
     const encoding = resources.compiled.encode(device.commandEncoder, {parameters: this.view});
     this.encodeTimeMilliseconds = encoding.stats.cpuEncodeTimeMilliseconds;
     this.frameIndex++;
@@ -381,7 +380,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
           {name: 'processStates', type: 'read-only-storage', group: 0, location: 3},
           {name: 'threadStates', type: 'read-only-storage', group: 0, location: 4},
           {name: 'threadOffsets', type: 'read-only-storage', group: 0, location: 5},
-          {name: 'visibleAncestors', type: 'read-only-storage', group: 0, location: 6},
+          {name: 'dependencyResults', type: 'read-only-storage', group: 0, location: 6},
           {name: 'viewUniforms', type: 'uniform', group: 0, location: 7}
         ]
       },
@@ -525,9 +524,9 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         spanMaskByteLength,
         Buffer.COPY_SRC
       ),
-      visibleAncestors: this.createStorageBuffer(
-        'gpu-trace-visible-ancestors',
-        spanMaskByteLength,
+      dependencyResults: this.createStorageBuffer(
+        'gpu-trace-dependency-results',
+        Math.max(dataset.dependencyCount * 3, 1) * UINT32_BYTE_LENGTH,
         Buffer.COPY_SRC
       ),
       visibilityGeneration: this.createDataBuffer(
@@ -639,7 +638,11 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       ),
       traversalDepth: importTraceBuffer(graph, 'traversal-depth', resources.traversalDepth),
       reachedSpans: importTraceBuffer(graph, 'reached-spans', resources.reachedSpans),
-      visibleAncestors: importTraceBuffer(graph, 'visible-ancestors', resources.visibleAncestors),
+      dependencyResults: importTraceBuffer(
+        graph,
+        'dependency-results',
+        resources.dependencyResults
+      ),
       visibilityGeneration: importTraceBuffer(
         graph,
         'visibility-generation',
@@ -918,31 +921,11 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       {buffer: handles.threadStates, usage: 'storage-read'},
       {buffer: handles.threadOffsets, usage: 'storage-read'},
       {buffer: handles.reachedSpans, usage: 'storage-read'},
-      {buffer: handles.visibleAncestors, usage: 'storage-read'},
+      {buffer: handles.dependencyResults, usage: 'storage-read'},
       {buffer: handles.densityBins, usage: 'storage-read'},
       {buffer: handles.uniforms, usage: 'uniform'},
       {buffer: handles.drawCommands, usage: 'indirect'}
     ];
-
-    new GPUAncestorProjection({
-      id: 'trace-visible-ancestor-projection',
-      parents: graph.createDataView(handles.parentSpans, {
-        format: 'uint32',
-        length: resources.spanCount
-      }),
-      visibility: graph.createDataView(handles.spanVisibility, {
-        format: 'uint32',
-        length: resources.spanCount
-      }),
-      visibilityValue: graph.createDataView(handles.visibilityGeneration, {
-        format: 'uint32',
-        length: 1
-      }),
-      output: graph.createDataView(handles.visibleAncestors, {
-        format: 'uint32',
-        length: resources.spanCount
-      })
-    }).addToGraph(graph);
 
     if (resources.dependencyCount > 0) {
       const candidateDependencyBatchFlags = graph.createTransientBuffer({
@@ -981,29 +964,24 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
           byteOffset: UINT32_BYTE_LENGTH
         })
       }).addToGraph(graph);
-      const dependencyFlags = graph.createTransientBuffer({
-        id: 'trace-dependency-flags',
-        byteLength: resources.dependencyCount * UINT32_BYTE_LENGTH,
-        usage: Buffer.STORAGE
-      });
       addTraceIndirectComputePass(graph, {
         id: 'trace-candidate-dependency-visibility',
-        source: getCandidateDependencyVisibilityShader(),
+        source: getCandidateDependencyVisibilityShader(resources.spanCount),
         bindings: [
           storageRead('dependencies', handles.dependencies),
           storageRead('dependencyBatches', handles.dependencyBatchIndex),
           storageRead('candidateBatchIds', handles.candidateDependencyBatchIds),
           storageRead('spanVisibility', handles.spanVisibility),
           storageRead('processStates', handles.processStates),
-          storageRead('visibleAncestors', handles.visibleAncestors),
+          storageRead('parentSpans', handles.parentSpans),
           uniformBinding('viewUniforms', handles.uniforms),
-          storageWrite('dependencyFlags', dependencyFlags)
+          storageWrite('dependencyResults', handles.dependencyResults)
         ],
         dispatchBuffer: handles.candidateDependencyDispatchCommands
       });
       new GPUIndexedRangeCompaction({
         id: 'trace-visible-dependencies',
-        flags: graph.createDataView(dependencyFlags, {
+        flags: graph.createDataView(handles.dependencyResults, {
           format: 'uint32',
           length: resources.dependencyCount
         }),
@@ -1078,7 +1056,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       processStates: resources.processStates,
       threadStates: resources.threadStates,
       threadOffsets: resources.threadOffsets,
-      visibleAncestors: resources.visibleAncestors,
+      dependencyResults: resources.dependencyResults,
       viewUniforms: this.viewUniformBuffer
     });
     resources.drawCommands.draw(encoder, resources.groups.length);
@@ -1097,7 +1075,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     width: number,
     height: number,
     pick: PickPosition | null,
-    visibilityGeneration: number
+    visibilityGeneration: number,
+    dependencyEndpointOffset: number
   ): void {
     const data = new ArrayBuffer(VIEW_UNIFORM_BYTE_LENGTH);
     const floats = new Float32Array(data);
@@ -1119,6 +1098,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     floats[14] = pick?.time ?? -1;
     floats[15] = pick?.lane ?? -1;
     unsigned[16] = visibilityGeneration;
+    unsigned[17] = dependencyEndpointOffset;
     this.viewUniformBuffer.write(data);
   }
 
@@ -1247,7 +1227,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       resources.selectedSeedCount,
       resources.traversalDepth,
       resources.reachedSpans,
-      resources.visibleAncestors,
+      resources.dependencyResults,
       resources.visibilityGeneration,
       resources.baseVisibility,
       resources.spanVisibility,

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -33,6 +33,8 @@ import {
   makeTraceDataset,
   isTraceDensityMode,
   TRACE_COLLAPSED_STATE,
+  TRACE_DEPENDENCY_BATCH_CAPACITY,
+  TRACE_DEPENDENCY_BATCH_RECORD_WORD_LENGTH,
   TRACE_DENSITY_BIN_COUNT,
   TRACE_DURATION,
   TRACE_EXPANDED_STATE,
@@ -58,8 +60,9 @@ import {
   getCandidateFocusShader,
   getCandidatePickShader,
   getCandidateVisibilityShader,
+  getCandidateDependencyVisibilityShader,
   getDensityClearShader,
-  getDependencyVisibilityShader,
+  getDependencyBatchVisibilityShader,
   getPickClearShader,
   getTraceDrawCommandsShader,
   TRACE_DENSITY_RENDER_SHADER,
@@ -78,7 +81,7 @@ const TRACE_WORKGROUP_SIZE = 256;
 const TRACE_CANDIDATE_BATCH_WORKGROUP_COUNT = Math.ceil(
   TRACE_SPAN_BATCH_CAPACITY / TRACE_WORKGROUP_SIZE
 );
-const VIEW_UNIFORM_BYTE_LENGTH = 64;
+const VIEW_UNIFORM_BYTE_LENGTH = 80;
 const MAXIMUM_FOCUS_DEPTH = 4;
 const INVALID_SPAN_INDEX = TRACE_INVALID_SPAN_INDEX;
 const STATUS_NAMES = ['ok', 'waiting', 'active', 'error'] as const;
@@ -106,6 +109,7 @@ type TraceGraphResources = {
   compiled: CompiledGPUCommandGraph<TraceViewParameters>;
   drawCommands: DrawCommandBuffer;
   candidateDispatchCommands: DispatchCommandBuffer;
+  candidateDependencyDispatchCommands: DispatchCommandBuffer;
   readbackRing: GPUReadbackRing;
   renderBundle: RenderBundle;
   groups: TraceGroupResources[];
@@ -114,6 +118,8 @@ type TraceGraphResources = {
   candidateBatchIds: Buffer;
   visibleSpanIds: Buffer;
   dependencies: Buffer;
+  dependencyBatchIndex: Buffer;
+  candidateDependencyBatchIds: Buffer;
   parentSpans: Buffer;
   outgoingOffsets: Buffer;
   outgoingNeighbors: Buffer;
@@ -137,6 +143,7 @@ type TraceGraphResources = {
   pickResult: Buffer;
   spanCount: number;
   spanBatchCount: number;
+  dependencyBatchCount: number;
   dependencyCount: number;
 };
 
@@ -187,6 +194,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
   private sampledVisibleCounts = [0, 0, 0];
   private sampledDependencyCount = 0;
   private sampledCandidateBatchCount = 0;
+  private sampledCandidateDependencyBatchCount = 0;
   private droppedTelemetrySampleCount = 0;
   private deferredPickFrameCount = 0;
   private frameIndex = 0;
@@ -254,7 +262,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     const pick = this.pendingPick;
     const visibilityGeneration = (this.frameIndex % 0xfffffffe) + 1;
     resources.visibilityGeneration.write(Uint32Array.of(visibilityGeneration));
-    this.writeViewUniforms(width, height, pick);
+    this.writeViewUniforms(width, height, pick, visibilityGeneration);
     const encoding = resources.compiled.encode(device.commandEncoder, {parameters: this.view});
     this.encodeTimeMilliseconds = encoding.stats.cpuEncodeTimeMilliseconds;
     this.frameIndex++;
@@ -278,6 +286,22 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         readbackTicket.copyFrom(device.commandEncoder, resources.drawCommands.buffer);
         queueMicrotask(() => {
           void this.sampleVisibleCounts(resources, readbackTicket);
+        });
+      } else {
+        this.droppedTelemetrySampleCount++;
+      }
+      const dependencyCandidateReadbackTicket = resources.readbackRing.tryAcquire();
+      if (dependencyCandidateReadbackTicket) {
+        dependencyCandidateReadbackTicket.copyFrom(
+          device.commandEncoder,
+          resources.candidateDependencyDispatchCommands.buffer,
+          {sourceOffset: UINT32_BYTE_LENGTH, byteLength: UINT32_BYTE_LENGTH}
+        );
+        queueMicrotask(() => {
+          void this.sampleCandidateDependencyBatchCount(
+            resources,
+            dependencyCandidateReadbackTicket
+          );
         });
       } else {
         this.droppedTelemetrySampleCount++;
@@ -399,6 +423,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     this.compileTimeMilliseconds = performance.now() - started;
     this.sampledVisibleCounts = TRACE_GROUPS.map(() => 0);
     this.sampledDependencyCount = 0;
+    this.sampledCandidateBatchCount = 0;
+    this.sampledCandidateDependencyBatchCount = 0;
     this.updateInspector();
   }
 
@@ -428,6 +454,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       id: 'gpu-trace-candidate-dispatch-commands',
       commands: [{x: TRACE_CANDIDATE_BATCH_WORKGROUP_COUNT, y: 0, z: 1}]
     });
+    const candidateDependencyDispatchCommands = new DispatchCommandBuffer(this.device, {
+      id: 'gpu-trace-candidate-dependency-dispatch-commands',
+      commands: [{x: 1, y: 0, z: 1}]
+    });
     const readbackRing = new GPUReadbackRing(this.device, {
       id: 'gpu-trace-readback',
       byteLength: drawCommands.buffer.byteLength,
@@ -438,6 +468,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       renderBundle: undefined!,
       drawCommands,
       candidateDispatchCommands,
+      candidateDependencyDispatchCommands,
       readbackRing,
       groups,
       spans: this.createDataBuffer('gpu-trace-spans', dataset.spans),
@@ -453,6 +484,15 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         Buffer.COPY_SRC
       ),
       dependencies: this.createDataBuffer('gpu-trace-dependencies', dataset.dependencies),
+      dependencyBatchIndex: this.createDataBuffer(
+        'gpu-trace-dependency-batch-index',
+        dataset.dependencyBatchIndex
+      ),
+      candidateDependencyBatchIds: this.createStorageBuffer(
+        'gpu-trace-candidate-dependency-batch-ids',
+        dataset.dependencyBatches.length * UINT32_BYTE_LENGTH,
+        Buffer.COPY_SRC
+      ),
       parentSpans: this.createDataBuffer('gpu-trace-parent-spans', dataset.parentSpans),
       outgoingOffsets: this.createDataBuffer('gpu-trace-outgoing-offsets', outgoingOffsets),
       outgoingNeighbors: this.createDataBuffer(
@@ -498,7 +538,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       spanVisibility: this.createStorageBuffer('gpu-trace-span-visibility', spanMaskByteLength),
       visibleDependencyIds: this.createStorageBuffer(
         'gpu-trace-visible-dependencies',
-        dependencyMaskByteLength
+        dependencyMaskByteLength,
+        Buffer.COPY_SRC
       ),
       densityKeys: this.createStorageBuffer('gpu-trace-density-keys', spanMaskByteLength),
       densityBins: this.createStorageBuffer(
@@ -513,6 +554,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       ),
       spanCount: dataset.spanCount,
       spanBatchCount: dataset.spanBatches.length,
+      dependencyBatchCount: dataset.dependencyBatches.length,
       dependencyCount: dataset.dependencyCount
     };
   }
@@ -557,6 +599,21 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       ),
       visibleSpanIds: importTraceBuffer(graph, 'visible-span-ids', resources.visibleSpanIds),
       dependencies: importTraceBuffer(graph, 'dependencies', resources.dependencies),
+      dependencyBatchIndex: importTraceBuffer(
+        graph,
+        'dependency-batch-index',
+        resources.dependencyBatchIndex
+      ),
+      candidateDependencyBatchIds: importTraceBuffer(
+        graph,
+        'candidate-dependency-batch-ids',
+        resources.candidateDependencyBatchIds
+      ),
+      candidateDependencyDispatchCommands: importTraceBuffer(
+        graph,
+        'candidate-dependency-dispatch-commands',
+        resources.candidateDependencyDispatchCommands.buffer
+      ),
       parentSpans: importTraceBuffer(graph, 'parent-spans', resources.parentSpans),
       outgoingOffsets: importTraceBuffer(graph, 'outgoing-offsets', resources.outgoingOffsets),
       outgoingNeighbors: importTraceBuffer(
@@ -887,49 +944,92 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       })
     }).addToGraph(graph);
 
-    const dependencyFlags = graph.createTransientBuffer({
-      id: 'trace-dependency-flags',
-      byteLength: Math.max(resources.dependencyCount, 1) * UINT32_BYTE_LENGTH,
-      usage: Buffer.STORAGE
-    });
     if (resources.dependencyCount > 0) {
+      const candidateDependencyBatchFlags = graph.createTransientBuffer({
+        id: 'trace-candidate-dependency-batch-flags',
+        byteLength: resources.dependencyBatchCount * UINT32_BYTE_LENGTH,
+        usage: Buffer.STORAGE
+      });
       addTraceComputePass(graph, {
-        id: 'trace-dependency-visibility',
-        source: getDependencyVisibilityShader(resources.dependencyCount),
+        id: 'trace-dependency-batch-visibility',
+        source: getDependencyBatchVisibilityShader(resources.dependencyBatchCount),
+        bindings: [
+          storageRead('dependencyBatches', handles.dependencyBatchIndex),
+          uniformBinding('viewUniforms', handles.uniforms),
+          storageWrite('candidateFlags', candidateDependencyBatchFlags)
+        ],
+        length: resources.dependencyBatchCount
+      });
+      new GPUVisibilityWorkflow({
+        id: 'trace-candidate-dependency-batches',
+        predicates: [
+          {
+            kind: ['time-range', 'selection'],
+            mask: graph.createDataView(candidateDependencyBatchFlags, {
+              format: 'uint32',
+              length: resources.dependencyBatchCount
+            })
+          }
+        ],
+        output: graph.createDataView(handles.candidateDependencyBatchIds, {
+          format: 'uint32',
+          length: resources.dependencyBatchCount
+        }),
+        count: graph.createDataView(handles.candidateDependencyDispatchCommands, {
+          format: 'uint32',
+          length: 1,
+          byteOffset: UINT32_BYTE_LENGTH
+        })
+      }).addToGraph(graph);
+      const dependencyFlags = graph.createTransientBuffer({
+        id: 'trace-dependency-flags',
+        byteLength: resources.dependencyCount * UINT32_BYTE_LENGTH,
+        usage: Buffer.STORAGE
+      });
+      addTraceIndirectComputePass(graph, {
+        id: 'trace-candidate-dependency-visibility',
+        source: getCandidateDependencyVisibilityShader(),
         bindings: [
           storageRead('dependencies', handles.dependencies),
-          storageRead('spans', handles.spans),
+          storageRead('dependencyBatches', handles.dependencyBatchIndex),
+          storageRead('candidateBatchIds', handles.candidateDependencyBatchIds),
           storageRead('spanVisibility', handles.spanVisibility),
           storageRead('processStates', handles.processStates),
           storageRead('visibleAncestors', handles.visibleAncestors),
-          storageRead('visibilityGeneration', handles.visibilityGeneration),
           uniformBinding('viewUniforms', handles.uniforms),
           storageWrite('dependencyFlags', dependencyFlags)
         ],
-        length: resources.dependencyCount
+        dispatchBuffer: handles.candidateDependencyDispatchCommands
       });
+      new GPUIndexedRangeCompaction({
+        id: 'trace-visible-dependencies',
+        flags: graph.createDataView(dependencyFlags, {
+          format: 'uint32',
+          length: resources.dependencyCount
+        }),
+        ranges: graph.createDataView(handles.dependencyBatchIndex, {
+          format: 'uint32',
+          length: resources.dependencyBatchCount * TRACE_DEPENDENCY_BATCH_RECORD_WORD_LENGTH
+        }),
+        rangeCount: resources.dependencyBatchCount,
+        rangeLayout: {wordStride: 6, firstIndexWordOffset: 0, countWordOffset: 1},
+        activeRangeIds: graph.createDataView(handles.candidateDependencyBatchIds, {
+          format: 'uint32',
+          length: resources.dependencyBatchCount
+        }),
+        activeRangeDispatch: handles.candidateDependencyDispatchCommands,
+        maximumRangeLength: TRACE_DEPENDENCY_BATCH_CAPACITY,
+        output: graph.createDataView(handles.visibleDependencyIds, {
+          format: 'uint32',
+          length: resources.dependencyCount
+        }),
+        count: graph.createDataView(handles.drawCommands, {
+          format: 'uint32',
+          length: 1,
+          byteOffset: resources.drawCommands.getInstanceCountByteOffset(resources.groups.length)
+        })
+      }).addToGraph(graph);
     }
-    new GPUVisibilityWorkflow({
-      id: 'trace-dependency-visibility',
-      predicates: [
-        {
-          kind: 'selection',
-          mask: graph.createDataView(dependencyFlags, {
-            format: 'uint32',
-            length: resources.dependencyCount
-          })
-        }
-      ],
-      output: graph.createDataView(handles.visibleDependencyIds, {
-        format: 'uint32',
-        length: resources.dependencyCount
-      }),
-      count: graph.createDataView(handles.drawCommands, {
-        format: 'uint32',
-        length: 1,
-        byteOffset: resources.drawCommands.getInstanceCountByteOffset(resources.groups.length)
-      })
-    }).addToGraph(graph);
     renderResources.push({buffer: handles.visibleDependencyIds, usage: 'storage-read'});
 
     graph.addRenderPass({
@@ -993,7 +1093,12 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     return encoder.finish();
   }
 
-  private writeViewUniforms(width: number, height: number, pick: PickPosition | null): void {
+  private writeViewUniforms(
+    width: number,
+    height: number,
+    pick: PickPosition | null,
+    visibilityGeneration: number
+  ): void {
     const data = new ArrayBuffer(VIEW_UNIFORM_BYTE_LENGTH);
     const floats = new Float32Array(data);
     const unsigned = new Uint32Array(data);
@@ -1013,6 +1118,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     floats[13] = 0.16;
     floats[14] = pick?.time ?? -1;
     floats[15] = pick?.lane ?? -1;
+    unsigned[16] = visibilityGeneration;
     this.viewUniformBuffer.write(data);
   }
 
@@ -1046,6 +1152,26 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         return;
       }
       this.sampledCandidateBatchCount = new Uint32Array(bytes.buffer, bytes.byteOffset, 1)[0];
+      this.updateInspector();
+    } catch {
+      // Device loss and cancellation release the ring slot without affecting rendering.
+    }
+  }
+
+  private async sampleCandidateDependencyBatchCount(
+    resources: TraceGraphResources,
+    readbackTicket: GPUReadbackTicket
+  ): Promise<void> {
+    try {
+      const bytes = await readbackTicket.read();
+      if (resources !== this.resources) {
+        return;
+      }
+      this.sampledCandidateDependencyBatchCount = new Uint32Array(
+        bytes.buffer,
+        bytes.byteOffset,
+        1
+      )[0];
       this.updateInspector();
     } catch {
       // Device loss and cancellation release the ring slot without affecting rendering.
@@ -1098,6 +1224,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     resources.renderBundle.destroy();
     resources.drawCommands.destroy();
     resources.candidateDispatchCommands.destroy();
+    resources.candidateDependencyDispatchCommands.destroy();
     resources.readbackRing.destroy();
     for (const buffer of [
       resources.spans,
@@ -1105,6 +1232,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       resources.candidateBatchIds,
       resources.visibleSpanIds,
       resources.dependencies,
+      resources.dependencyBatchIndex,
+      resources.candidateDependencyBatchIds,
       resources.parentSpans,
       resources.outgoingOffsets,
       resources.outgoingNeighbors,
@@ -1412,7 +1541,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       this.statsElement.innerHTML = `<div style="display:grid;grid-template-columns:1fr auto;gap:4px 12px;margin-top:8px">
         <span>Sampled exact spans</span><strong>${formatCount(visible)}</strong>
         <span>Sampled visible edges</span><strong>${formatCount(this.sampledDependencyCount)}</strong>
-        <span>Candidate batches</span><strong>${formatCount(this.sampledCandidateBatchCount)}/${formatCount(resources.spanBatchCount)}</strong>
+        <span>Candidate span batches</span><strong>${formatCount(this.sampledCandidateBatchCount)}/${formatCount(resources.spanBatchCount)}</strong>
+        <span>Candidate dependency batches</span><strong>${formatCount(this.sampledCandidateDependencyBatchCount)}/${formatCount(resources.dependencyBatchCount)}</strong>
         <span>Visible layout lanes</span><strong>${formatCount(this.getVisibleLaneCount())}</strong>
         <span>Collapsed processes</span><strong>${formatCount(this.processStates.filter(state => state === TRACE_COLLAPSED_STATE).length)}</strong>
         <span>CPU graph encode</span><strong>${this.encodeTimeMilliseconds.toFixed(2)} ms</strong>

--- a/examples/experimental/gpu-trace-viewer/trace-data.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-data.ts
@@ -12,8 +12,11 @@ export const TRACE_LANE_COUNT = TRACE_THREAD_COUNT * TRACE_LANES_PER_THREAD;
 export const TRACE_SPAN_RECORD_WORD_LENGTH = 8;
 export const TRACE_DEPENDENCY_RECORD_WORD_LENGTH = 4;
 export const TRACE_SPAN_BATCH_RECORD_WORD_LENGTH = 8;
+export const TRACE_DEPENDENCY_BATCH_RECORD_WORD_LENGTH = 6;
 // One span batch maps to one portable WebGPU workgroup for candidate-driven local compaction.
 export const TRACE_SPAN_BATCH_CAPACITY = 256;
+// One dependency batch maps to one portable WebGPU workgroup for candidate-driven compaction.
+export const TRACE_DEPENDENCY_BATCH_CAPACITY = 128;
 const TRACE_DEMONSTRATION_CAPACITIES = [250_000, 1_000_000, 4_000_000, 10_000_000];
 // Keep density scrolling visually continuous at common viewport widths while retaining a fixed,
 // allocation-stable aggregation target for the compiled GPU command graph.
@@ -24,6 +27,9 @@ export const TRACE_STATUS_COUNT = 4;
 export const TRACE_SAME_PROCESS_DEPENDENCY = 0;
 export const TRACE_CROSS_PROCESS_DEPENDENCY = 1;
 export const TRACE_PARENT_DEPENDENCY_FLAG = 1;
+export const TRACE_DEPENDENCY_PROCESS_MASK = 0xff;
+export const TRACE_DEPENDENCY_SOURCE_PROCESS_SHIFT = 8;
+export const TRACE_DEPENDENCY_DESTINATION_PROCESS_SHIFT = 16;
 export const TRACE_RUNTIME_SPAN_FLAG = 1 << 8;
 export const TRACE_ERROR_SPAN_FLAG = 1 << 9;
 export const TRACE_OVERLAPPING_CHILD_FLAG = 1 << 10;
@@ -100,6 +106,16 @@ export type TraceSpanBatchData = {
   data: Uint32Array;
 };
 
+/** Stable dependency range with a conservative endpoint and ancestor time envelope. */
+export type TraceDependencyBatchData = {
+  batchIndex: number;
+  count: number;
+  firstDependencyIndex: number;
+  timeMin: number;
+  timeMax: number;
+  familyMask: number;
+};
+
 /** Compact forward or reverse compressed sparse dependency adjacency. */
 export type TraceAdjacencyData = {
   /** One stable offset per source node plus the final edge count. */
@@ -118,8 +134,12 @@ export type TraceDatasetData = {
   spanBatches: TraceSpanBatchData[];
   /** Packed batch first/count, temporal bounds, lane bounds, group, and stable batch ID records. */
   spanBatchIndex: Uint32Array;
-  /** Packed 16-byte dependency source, destination, family, and keyword records. */
+  /** Packed 16-byte dependency source, destination, family, and endpoint metadata records. */
   dependencies: Uint32Array;
+  /** Stable dependency partitions small enough for one GPU workgroup. */
+  dependencyBatches: TraceDependencyBatchData[];
+  /** Packed dependency first/count, conservative time bounds, family mask, and batch ID. */
+  dependencyBatchIndex: Uint32Array;
   /** One cross-process-prioritized canonical parent or invalid sentinel per span. */
   parentSpans: Uint32Array;
   /** Forward source-to-destination CSR adjacency. */
@@ -188,12 +208,19 @@ export function makeTraceDataset(
   const topology = makeTraceDependencies(spans, totalSpanCount, maximumDependencyCount);
   const dependencyCount = topology.dependencies.length / TRACE_DEPENDENCY_RECORD_WORD_LENGTH;
   const {spanBatches, spanBatchIndex} = makeTraceSpanBatches(spans, groups);
+  const {dependencyBatches, dependencyBatchIndex} = makeTraceDependencyBatches(
+    spans,
+    topology.dependencies,
+    topology.parentSpans
+  );
   return {
     spans,
     groups,
     spanBatches,
     spanBatchIndex,
     dependencies: topology.dependencies,
+    dependencyBatches,
+    dependencyBatchIndex,
     parentSpans: topology.parentSpans,
     outgoing: buildTraceAdjacency(totalSpanCount, topology.dependencies, 'outgoing'),
     incoming: buildTraceAdjacency(totalSpanCount, topology.dependencies, 'incoming'),
@@ -202,6 +229,96 @@ export function makeTraceDataset(
     processCount: TRACE_PROCESS_COUNT,
     threadCount: TRACE_THREAD_COUNT
   };
+}
+
+/**
+ * Partitions canonical dependencies and publishes conservative time bounds for GPU selection.
+ *
+ * Each endpoint contributes its full ancestor envelope. This keeps selection conservative when a
+ * filtered endpoint is projected to a visible ancestor or a collapsed process uses the source row.
+ */
+export function makeTraceDependencyBatches(
+  spans: Uint32Array,
+  dependencies: Uint32Array,
+  parentSpans: Uint32Array,
+  batchCapacity = TRACE_DEPENDENCY_BATCH_CAPACITY
+): {
+  dependencyBatches: TraceDependencyBatchData[];
+  dependencyBatchIndex: Uint32Array;
+} {
+  if (!Number.isSafeInteger(batchCapacity) || batchCapacity < 1) {
+    throw new RangeError('Trace dependency batch capacity must be a positive safe integer');
+  }
+  const spanCount = spans.length / TRACE_SPAN_RECORD_WORD_LENGTH;
+  const dependencyCount = dependencies.length / TRACE_DEPENDENCY_RECORD_WORD_LENGTH;
+  const spanFloats = new Float32Array(spans.buffer, spans.byteOffset, spans.length);
+  const envelopeTimeMin = new Float32Array(spanCount);
+  const envelopeTimeMax = new Float32Array(spanCount);
+  for (let spanIndex = 0; spanIndex < spanCount; spanIndex++) {
+    const wordOffset = spanIndex * TRACE_SPAN_RECORD_WORD_LENGTH;
+    const start = spanFloats[wordOffset];
+    const end = start + spanFloats[wordOffset + 1];
+    const parentSpanIndex = parentSpans[spanIndex];
+    envelopeTimeMin[spanIndex] =
+      parentSpanIndex === TRACE_INVALID_SPAN_INDEX
+        ? start
+        : Math.min(start, envelopeTimeMin[parentSpanIndex]);
+    envelopeTimeMax[spanIndex] =
+      parentSpanIndex === TRACE_INVALID_SPAN_INDEX
+        ? end
+        : Math.max(end, envelopeTimeMax[parentSpanIndex]);
+  }
+
+  const dependencyBatches: TraceDependencyBatchData[] = [];
+  for (
+    let firstDependencyIndex = 0;
+    firstDependencyIndex < dependencyCount;
+    firstDependencyIndex += batchCapacity
+  ) {
+    const count = Math.min(batchCapacity, dependencyCount - firstDependencyIndex);
+    let timeMin = Number.POSITIVE_INFINITY;
+    let timeMax = Number.NEGATIVE_INFINITY;
+    let familyMask = 0;
+    for (let rowIndex = 0; rowIndex < count; rowIndex++) {
+      const wordOffset = (firstDependencyIndex + rowIndex) * TRACE_DEPENDENCY_RECORD_WORD_LENGTH;
+      const sourceSpanIndex = dependencies[wordOffset];
+      const destinationSpanIndex = dependencies[wordOffset + 1];
+      timeMin = Math.min(
+        timeMin,
+        envelopeTimeMin[sourceSpanIndex],
+        envelopeTimeMin[destinationSpanIndex]
+      );
+      timeMax = Math.max(
+        timeMax,
+        envelopeTimeMax[sourceSpanIndex],
+        envelopeTimeMax[destinationSpanIndex]
+      );
+      familyMask |= 1 << dependencies[wordOffset + 2];
+    }
+    dependencyBatches.push({
+      batchIndex: dependencyBatches.length,
+      count,
+      firstDependencyIndex,
+      timeMin,
+      timeMax,
+      familyMask
+    });
+  }
+
+  const dependencyBatchIndex = new Uint32Array(
+    dependencyBatches.length * TRACE_DEPENDENCY_BATCH_RECORD_WORD_LENGTH
+  );
+  const dependencyBatchIndexFloats = new Float32Array(dependencyBatchIndex.buffer);
+  for (const batch of dependencyBatches) {
+    const wordOffset = batch.batchIndex * TRACE_DEPENDENCY_BATCH_RECORD_WORD_LENGTH;
+    dependencyBatchIndex[wordOffset] = batch.firstDependencyIndex;
+    dependencyBatchIndex[wordOffset + 1] = batch.count;
+    dependencyBatchIndexFloats[wordOffset + 2] = batch.timeMin;
+    dependencyBatchIndexFloats[wordOffset + 3] = batch.timeMax;
+    dependencyBatchIndex[wordOffset + 4] = batch.familyMask;
+    dependencyBatchIndex[wordOffset + 5] = batch.batchIndex;
+  }
+  return {dependencyBatches, dependencyBatchIndex};
 }
 
 /** Partitions canonical group ranges and builds coarse GPU-readable batch bounds. */
@@ -344,6 +461,7 @@ function makeTraceDependencies(
     ) {
       writeTraceDependency(
         data,
+        spans,
         dependencyCount++,
         previousSpan,
         spanIndex,
@@ -364,6 +482,7 @@ function makeTraceDependencies(
       if (spans[sourceIndex * TRACE_SPAN_RECORD_WORD_LENGTH + 4] !== processIndex) {
         writeTraceDependency(
           data,
+          spans,
           dependencyCount++,
           sourceIndex,
           spanIndex,
@@ -412,6 +531,7 @@ function annotateTraceParentTopology(
 /** Writes one fixed-width dependency without allocating intermediate edge objects. */
 function writeTraceDependency(
   dependencies: Uint32Array,
+  spans: Uint32Array,
   dependencyIndex: number,
   sourceSpanIndex: number,
   destinationSpanIndex: number,
@@ -421,7 +541,12 @@ function writeTraceDependency(
   dependencies[wordOffset] = sourceSpanIndex;
   dependencies[wordOffset + 1] = destinationSpanIndex;
   dependencies[wordOffset + 2] = family;
-  dependencies[wordOffset + 3] = TRACE_PARENT_DEPENDENCY_FLAG;
+  const sourceProcessIndex = spans[sourceSpanIndex * TRACE_SPAN_RECORD_WORD_LENGTH + 4];
+  const destinationProcessIndex = spans[destinationSpanIndex * TRACE_SPAN_RECORD_WORD_LENGTH + 4];
+  dependencies[wordOffset + 3] =
+    TRACE_PARENT_DEPENDENCY_FLAG |
+    (sourceProcessIndex << TRACE_DEPENDENCY_SOURCE_PROCESS_SHIFT) |
+    (destinationProcessIndex << TRACE_DEPENDENCY_DESTINATION_PROCESS_SHIFT);
 }
 
 /** Builds stable compressed sparse rows without materializing per-node edge arrays. */

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -63,6 +63,7 @@ struct ViewUniforms {
   pickTime: f32,
   pickLane: f32,
   visibilityGeneration: u32,
+  dependencyEndpointOffset: u32,
 };
 
 const LANES_PER_THREAD: u32 = ${TRACE_LANES_PER_THREAD}u;
@@ -192,7 +193,7 @@ ${TRACE_SHADER_DECLARATIONS}
 @group(0) @binding(3) var<storage, read> processStates: array<u32>;
 @group(0) @binding(4) var<storage, read> threadStates: array<u32>;
 @group(0) @binding(5) var<storage, read> threadOffsets: array<u32>;
-@group(0) @binding(6) var<storage, read> visibleAncestors: array<u32>;
+@group(0) @binding(6) var<storage, read> dependencyResults: array<u32>;
 @group(0) @binding(7) var<uniform> viewUniforms: ViewUniforms;
 
 struct DependencyVertexOutput {
@@ -208,13 +209,8 @@ fn getEndpointLane(span: TraceSpan) -> u32 {
   return threadOffsets[span.threadIndex] + localLane;
 }
 
-fn getResolvedEndpoint(sourceIndex: u32) -> TraceSpan {
-  let sourceSpan = spans[sourceIndex];
-  if (processStates[sourceSpan.processIndex] == 0u) {
-    return sourceSpan;
-  }
-  let visibleAncestor = visibleAncestors[sourceIndex];
-  return spans[select(sourceIndex, visibleAncestor, visibleAncestor != 0xffffffffu)];
+fn getResolvedEndpoint(endpointResultIndex: u32) -> TraceSpan {
+  return spans[dependencyResults[viewUniforms.dependencyEndpointOffset + endpointResultIndex]];
 }
 
 @vertex fn vertexMain(
@@ -222,8 +218,9 @@ fn getResolvedEndpoint(sourceIndex: u32) -> TraceSpan {
   @builtin(instance_index) instanceIndex: u32
 ) -> DependencyVertexOutput {
   let dependency = dependencies[visibleDependencyIds[instanceIndex]];
-  let spanIndex = select(dependency.sourceIndex, dependency.destinationIndex, vertexIndex == 1u);
-  let span = getResolvedEndpoint(spanIndex);
+  let dependencyIndex = visibleDependencyIds[instanceIndex];
+  let endpointResultIndex = dependencyIndex * 2u + select(0u, 1u, vertexIndex == 1u);
+  let span = getResolvedEndpoint(endpointResultIndex);
   let timeRange = max(viewUniforms.timeMax - viewUniforms.timeMin, 0.0001);
   let laneRange = max(viewUniforms.laneMax - viewUniforms.laneMin, 1.0);
   let endpointTime = select(span.start + span.duration, span.start, vertexIndex == 1u);
@@ -609,7 +606,7 @@ fn main() {
 }
 
 /** Filters dependency rows inside GPU-selected candidate batches. */
-export function getCandidateDependencyVisibilityShader(): string {
+export function getCandidateDependencyVisibilityShader(spanCount: number): string {
   return /* wgsl */ `
 ${TRACE_SHADER_DECLARATIONS}
 struct DependencyBatch {
@@ -620,14 +617,31 @@ struct DependencyBatch {
   familyMask: u32,
   batchIndex: u32,
 };
+const SPAN_COUNT: u32 = ${spanCount}u;
+const MAXIMUM_ANCESTOR_DEPTH: u32 = 32u;
 @group(0) @binding(0) var<storage, read> dependencies: array<TraceDependency>;
 @group(0) @binding(1) var<storage, read> dependencyBatches: array<DependencyBatch>;
 @group(0) @binding(2) var<storage, read> candidateBatchIds: array<u32>;
 @group(0) @binding(3) var<storage, read> spanVisibility: array<u32>;
 @group(0) @binding(4) var<storage, read> processStates: array<u32>;
-@group(0) @binding(5) var<storage, read> visibleAncestors: array<u32>;
+@group(0) @binding(5) var<storage, read> parentSpans: array<u32>;
 @group(0) @binding(6) var<uniform> viewUniforms: ViewUniforms;
-@group(0) @binding(7) var<storage, read_write> dependencyFlags: array<u32>;
+@group(0) @binding(7) var<storage, read_write> dependencyResults: array<u32>;
+
+fn resolveVisibleAncestor(sourceIndex: u32) -> u32 {
+  var currentIndex = sourceIndex;
+  var depth = 0u;
+  loop {
+    if (currentIndex >= SPAN_COUNT || depth > MAXIMUM_ANCESTOR_DEPTH) {
+      return 0xffffffffu;
+    }
+    if (spanVisibility[currentIndex] == viewUniforms.visibilityGeneration) {
+      return currentIndex;
+    }
+    currentIndex = parentSpans[currentIndex];
+    depth++;
+  }
+}
 
 @compute @workgroup_size(${TRACE_DEPENDENCY_BATCH_CAPACITY})
 fn main(
@@ -640,8 +654,8 @@ fn main(
   }
   let index = batch.firstIndex + localId.x;
   let dependency = dependencies[index];
-  let projectedSource = visibleAncestors[dependency.sourceIndex];
-  let projectedDestination = visibleAncestors[dependency.destinationIndex];
+  let projectedSource = resolveVisibleAncestor(dependency.sourceIndex);
+  let projectedDestination = resolveVisibleAncestor(dependency.destinationIndex);
   let sourceProcessIndex =
     (dependency.flags >> ${TRACE_DEPENDENCY_SOURCE_PROCESS_SHIFT}u) &
     ${TRACE_DEPENDENCY_PROCESS_MASK}u;
@@ -664,10 +678,13 @@ fn main(
     destinationCollapsed
   );
   let distinctEndpoints = effectiveSource != effectiveDestination;
-  dependencyFlags[index] = select(
+  dependencyResults[index] = select(
     0u,
     1u,
     familyVisible && sourceVisible && destinationVisible && distinctEndpoints && !isDensityMode()
   );
+  let endpointResultOffset = viewUniforms.dependencyEndpointOffset + index * 2u;
+  dependencyResults[endpointResultOffset] = effectiveSource;
+  dependencyResults[endpointResultOffset + 1u] = effectiveDestination;
 }`;
 }

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -5,6 +5,10 @@
 import {
   TRACE_DENSITY_BIN_COUNT,
   TRACE_DENSITY_TIME_PER_PIXEL,
+  TRACE_DEPENDENCY_BATCH_CAPACITY,
+  TRACE_DEPENDENCY_DESTINATION_PROCESS_SHIFT,
+  TRACE_DEPENDENCY_PROCESS_MASK,
+  TRACE_DEPENDENCY_SOURCE_PROCESS_SHIFT,
   TRACE_ERROR_SPAN_FLAG,
   TRACE_FILTER_ERRORS_ONLY,
   TRACE_FILTER_HIDE_OVERLAPPING_CHILDREN,
@@ -58,6 +62,7 @@ struct ViewUniforms {
   activityScale: f32,
   pickTime: f32,
   pickLane: f32,
+  visibilityGeneration: u32,
 };
 
 const LANES_PER_THREAD: u32 = ${TRACE_LANES_PER_THREAD}u;
@@ -323,6 +328,41 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
 }`;
 }
 
+/** Conservatively selects dependency batches whose endpoint envelopes intersect the viewport. */
+export function getDependencyBatchVisibilityShader(batchCount: number): string {
+  return /* wgsl */ `
+${TRACE_SHADER_DECLARATIONS}
+struct DependencyBatch {
+  firstIndex: u32,
+  count: u32,
+  timeMin: f32,
+  timeMax: f32,
+  familyMask: u32,
+  batchIndex: u32,
+};
+const BATCH_COUNT: u32 = ${batchCount}u;
+@group(0) @binding(0) var<storage, read> dependencyBatches: array<DependencyBatch>;
+@group(0) @binding(1) var<uniform> viewUniforms: ViewUniforms;
+@group(0) @binding(2) var<storage, read_write> candidateFlags: array<u32>;
+
+@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let batchIndex = globalId.x;
+  if (batchIndex >= BATCH_COUNT) {
+    return;
+  }
+  let batch = dependencyBatches[batchIndex];
+  let timeVisible = batch.timeMin <= viewUniforms.timeMax &&
+    batch.timeMax >= viewUniforms.timeMin;
+  let familyVisible = (batch.familyMask & viewUniforms.dependencyMask) != 0u;
+  candidateFlags[batchIndex] = select(
+    0u,
+    1u,
+    timeVisible && familyVisible && !isDensityMode()
+  );
+}`;
+}
+
 /** Applies focus policy and publishes generation-tagged exact visibility for candidate spans. */
 export function getCandidateFocusShader(): string {
   return /* wgsl */ `
@@ -568,39 +608,54 @@ fn main() {
 }`;
 }
 
-/** Filters canonical dependency rows against visible or collapsed endpoint ownership. */
-export function getDependencyVisibilityShader(dependencyCount: number): string {
+/** Filters dependency rows inside GPU-selected candidate batches. */
+export function getCandidateDependencyVisibilityShader(): string {
   return /* wgsl */ `
 ${TRACE_SHADER_DECLARATIONS}
-const DEPENDENCY_COUNT: u32 = ${dependencyCount}u;
+struct DependencyBatch {
+  firstIndex: u32,
+  count: u32,
+  timeMin: f32,
+  timeMax: f32,
+  familyMask: u32,
+  batchIndex: u32,
+};
 @group(0) @binding(0) var<storage, read> dependencies: array<TraceDependency>;
-@group(0) @binding(1) var<storage, read> spans: array<TraceSpan>;
-@group(0) @binding(2) var<storage, read> spanVisibility: array<u32>;
-@group(0) @binding(3) var<storage, read> processStates: array<u32>;
-@group(0) @binding(4) var<storage, read> visibleAncestors: array<u32>;
-@group(0) @binding(5) var<storage, read> visibilityGeneration: array<u32>;
+@group(0) @binding(1) var<storage, read> dependencyBatches: array<DependencyBatch>;
+@group(0) @binding(2) var<storage, read> candidateBatchIds: array<u32>;
+@group(0) @binding(3) var<storage, read> spanVisibility: array<u32>;
+@group(0) @binding(4) var<storage, read> processStates: array<u32>;
+@group(0) @binding(5) var<storage, read> visibleAncestors: array<u32>;
 @group(0) @binding(6) var<uniform> viewUniforms: ViewUniforms;
 @group(0) @binding(7) var<storage, read_write> dependencyFlags: array<u32>;
 
-@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let index = globalId.x;
-  if (index >= DEPENDENCY_COUNT) {
+@compute @workgroup_size(${TRACE_DEPENDENCY_BATCH_CAPACITY})
+fn main(
+  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let batch = dependencyBatches[candidateBatchIds[workgroupId.y]];
+  if (localId.x >= batch.count) {
     return;
   }
+  let index = batch.firstIndex + localId.x;
   let dependency = dependencies[index];
-  let source = spans[dependency.sourceIndex];
-  let destination = spans[dependency.destinationIndex];
   let projectedSource = visibleAncestors[dependency.sourceIndex];
   let projectedDestination = visibleAncestors[dependency.destinationIndex];
-  let sourceCollapsed = processStates[source.processIndex] == 0u;
-  let destinationCollapsed = processStates[destination.processIndex] == 0u;
+  let sourceProcessIndex =
+    (dependency.flags >> ${TRACE_DEPENDENCY_SOURCE_PROCESS_SHIFT}u) &
+    ${TRACE_DEPENDENCY_PROCESS_MASK}u;
+  let destinationProcessIndex =
+    (dependency.flags >> ${TRACE_DEPENDENCY_DESTINATION_PROCESS_SHIFT}u) &
+    ${TRACE_DEPENDENCY_PROCESS_MASK}u;
+  let sourceCollapsed = processStates[sourceProcessIndex] == 0u;
+  let destinationCollapsed = processStates[destinationProcessIndex] == 0u;
   let familyVisible = (viewUniforms.dependencyMask & (1u << dependency.family)) != 0u;
   let sourceVisible =
-    spanVisibility[dependency.sourceIndex] == visibilityGeneration[0] || sourceCollapsed ||
+    spanVisibility[dependency.sourceIndex] == viewUniforms.visibilityGeneration || sourceCollapsed ||
     projectedSource != 0xffffffffu;
   let destinationVisible =
-    spanVisibility[dependency.destinationIndex] == visibilityGeneration[0] ||
+    spanVisibility[dependency.destinationIndex] == viewUniforms.visibilityGeneration ||
     destinationCollapsed || projectedDestination != 0xffffffffu;
   let effectiveSource = select(projectedSource, dependency.sourceIndex, sourceCollapsed);
   let effectiveDestination = select(

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -123,7 +123,7 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
       {firstBatchIndex: 2, batchCount: 1}
     ]),
     getDependencyBatchVisibilityShader(3),
-    getCandidateDependencyVisibilityShader()
+    getCandidateDependencyVisibilityShader(11)
   ];
   for (const shader of shaders) {
     t.ok(new WgslReflect(shader), 'shader parses');

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -9,10 +9,12 @@ import {
   getTraceCapacityOptions,
   getTraceDependencyCapacityOptions,
   isTraceDensityMode,
+  makeTraceDependencyBatches,
   makeTraceDataset,
   makeTraceGroups,
   makeTraceSpanBatches,
   TRACE_CROSS_PROCESS_DEPENDENCY,
+  TRACE_DEPENDENCY_BATCH_RECORD_WORD_LENGTH,
   TRACE_DEPENDENCY_RECORD_WORD_LENGTH,
   TRACE_GROUPS,
   TRACE_INVALID_SPAN_INDEX,
@@ -31,8 +33,9 @@ import {
   getCandidateFocusShader,
   getCandidatePickShader,
   getCandidateVisibilityShader,
+  getCandidateDependencyVisibilityShader,
   getDensityClearShader,
-  getDependencyVisibilityShader,
+  getDependencyBatchVisibilityShader,
   getPickClearShader,
   getTraceDrawCommandsShader,
   TRACE_DENSITY_RENDER_SHADER,
@@ -119,7 +122,8 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
       {firstBatchIndex: 0, batchCount: 2},
       {firstBatchIndex: 2, batchCount: 1}
     ]),
-    getDependencyVisibilityShader(11)
+    getDependencyBatchVisibilityShader(3),
+    getCandidateDependencyVisibilityShader()
   ];
   for (const shader of shaders) {
     t.ok(new WgslReflect(shader), 'shader parses');
@@ -180,6 +184,47 @@ test('GPU trace dependency generation respects its independent capacity', t => {
   t.equal(dataset.spanCount, 10_000, 'span capacity remains independent');
   t.equal(dataset.dependencyCount, 250, 'dependency generation stops at its requested capacity');
   t.equal(makeTraceDataset(10_000, 0).dependencyCount, 0, 'zero dependencies are supported');
+  t.end();
+});
+
+test('GPU trace dependency batches preserve identity and conservative ancestor bounds', t => {
+  const dataset = makeTraceDataset(2048);
+  const {dependencyBatches, dependencyBatchIndex} = makeTraceDependencyBatches(
+    dataset.spans,
+    dataset.dependencies,
+    dataset.parentSpans,
+    7
+  );
+  t.equal(
+    dependencyBatchIndex.length,
+    dependencyBatches.length * TRACE_DEPENDENCY_BATCH_RECORD_WORD_LENGTH,
+    'publishes one fixed-width GPU index record per dependency batch'
+  );
+  const indexFloats = new Float32Array(dependencyBatchIndex.buffer);
+  for (const batch of dependencyBatches) {
+    const indexOffset = batch.batchIndex * TRACE_DEPENDENCY_BATCH_RECORD_WORD_LENGTH;
+    t.equal(
+      dependencyBatchIndex[indexOffset],
+      batch.firstDependencyIndex,
+      'index preserves dependency base'
+    );
+    t.equal(dependencyBatchIndex[indexOffset + 1], batch.count, 'index preserves batch length');
+    t.equal(dependencyBatchIndex[indexOffset + 4], batch.familyMask, 'index preserves families');
+    t.equal(dependencyBatchIndex[indexOffset + 5], batch.batchIndex, 'index preserves identity');
+    t.ok(
+      Math.abs(indexFloats[indexOffset + 2] - batch.timeMin) < 0.001,
+      'index preserves minimum time'
+    );
+    t.ok(
+      Math.abs(indexFloats[indexOffset + 3] - batch.timeMax) < 0.001,
+      'index preserves maximum time'
+    );
+  }
+  t.throws(
+    () => makeTraceDependencyBatches(dataset.spans, dataset.dependencies, dataset.parentSpans, 0),
+    /positive safe integer/,
+    'invalid dependency batch capacity is rejected'
+  );
   t.end();
 });
 
@@ -290,7 +335,7 @@ test('GPU trace data publishes stable forward and reverse dependency adjacency',
     const source = dataset.dependencies[wordOffset];
     const destination = dataset.dependencies[wordOffset + 1];
     const family = dataset.dependencies[wordOffset + 2];
-    const flags = dataset.dependencies[wordOffset + 3];
+    const metadata = dataset.dependencies[wordOffset + 3];
     const outgoing = dataset.outgoing.neighbors.subarray(
       dataset.outgoing.offsets[source],
       dataset.outgoing.offsets[source + 1]
@@ -301,7 +346,7 @@ test('GPU trace data publishes stable forward and reverse dependency adjacency',
     );
     t.ok(outgoing.includes(destination), 'forward CSR contains the canonical destination');
     t.ok(incoming.includes(source), 'reverse CSR contains the canonical source');
-    t.equal(flags, TRACE_PARENT_DEPENDENCY_FLAG, 'parent classification remains numeric');
+    t.equal(metadata & 0xff, TRACE_PARENT_DEPENDENCY_FLAG, 'parent classification remains numeric');
     if (family === TRACE_SAME_PROCESS_DEPENDENCY) {
       sameProcessCount++;
       t.equal(
@@ -330,6 +375,12 @@ test('GPU trace data handles empty inputs and rejects invalid capacities', t => 
   t.equal(dataset.parentSpans.length, 0, 'empty traces have no canonical parent rows');
   t.equal(dataset.spanBatches.length, 0, 'empty traces have no span batches');
   t.equal(dataset.spanBatchIndex.length, 0, 'empty traces have no batch index records');
+  t.equal(dataset.dependencyBatches.length, 0, 'empty traces have no dependency batches');
+  t.equal(
+    dataset.dependencyBatchIndex.length,
+    0,
+    'empty traces have no dependency batch index records'
+  );
   t.deepEqual(Array.from(dataset.outgoing.offsets), [0], 'empty forward CSR has a sentinel');
   t.deepEqual(Array.from(dataset.incoming.offsets), [0], 'empty reverse CSR has a sentinel');
   t.throws(() => makeTraceDataset(-1), /nonnegative uint32/, 'negative capacity is rejected');

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -41,8 +41,12 @@ describe('GPU hierarchical trace viewer', () => {
       const state = viewer as unknown as {
         resources: {
           candidateDispatchCommands: {buffer: {readAsync: () => Promise<Uint8Array>}};
+          candidateDependencyDispatchCommands: {
+            buffer: {readAsync: () => Promise<Uint8Array>};
+          };
           drawCommands: {buffer: {readAsync: () => Promise<Uint8Array>}};
           visibleSpanIds: {readAsync: () => Promise<Uint8Array>};
+          visibleDependencyIds: {readAsync: () => Promise<Uint8Array>};
           densityBins: {readAsync: () => Promise<Uint8Array>};
           reachedSpans: {
             readAsync: (byteOffset?: number, byteLength?: number) => Promise<Uint8Array>;
@@ -50,6 +54,7 @@ describe('GPU hierarchical trace viewer', () => {
           dependencyCount: number;
           spanCount: number;
           spanBatchCount: number;
+          dependencyBatchCount: number;
         };
         processStates: Uint32Array;
         threadStates: Uint32Array;
@@ -64,6 +69,7 @@ describe('GPU hierarchical trace viewer', () => {
       expect(state.resources.spanCount).toBe(4096);
       expect(state.resources.spanBatchCount).toBeGreaterThan(0);
       expect(state.resources.dependencyCount).toBeGreaterThan(0);
+      expect(state.resources.dependencyBatchCount).toBeGreaterThan(0);
       expect(host.querySelectorAll('[data-process]')).toHaveLength(TRACE_PROCESS_COUNT);
       expect(host.querySelectorAll('[data-thread]')).toHaveLength(TRACE_THREAD_COUNT);
       expect(host.querySelectorAll('[data-span-capacity]')).toHaveLength(1);
@@ -104,6 +110,15 @@ describe('GPU hierarchical trace viewer', () => {
         );
         expect(groupIds).toEqual([...groupIds].sort((left, right) => left - right));
       }
+      const visibleDependencyBytes = await state.resources.visibleDependencyIds.readAsync();
+      const visibleDependencyIds = new Uint32Array(
+        visibleDependencyBytes.buffer,
+        visibleDependencyBytes.byteOffset,
+        firstCounts[13]
+      );
+      expect(Array.from(visibleDependencyIds)).toEqual(
+        Array.from(visibleDependencyIds).sort((left, right) => left - right)
+      );
       const candidateBytes = await state.resources.candidateDispatchCommands.buffer.readAsync();
       const candidateDispatch = new Uint32Array(
         candidateBytes.buffer,
@@ -114,6 +129,15 @@ describe('GPU hierarchical trace viewer', () => {
       const candidateCount = candidateDispatch[1];
       expect(candidateCount).toBeGreaterThan(0);
       expect(candidateCount).toBeLessThanOrEqual(state.resources.spanBatchCount);
+      const dependencyCandidateBytes =
+        await state.resources.candidateDependencyDispatchCommands.buffer.readAsync();
+      const dependencyCandidateCount = new Uint32Array(
+        dependencyCandidateBytes.buffer,
+        dependencyCandidateBytes.byteOffset,
+        3
+      )[1];
+      expect(dependencyCandidateCount).toBeGreaterThan(0);
+      expect(dependencyCandidateCount).toBeLessThan(state.resources.dependencyBatchCount);
 
       const firstGroup = host.querySelector<HTMLInputElement>('[data-group="0"]');
       expect(firstGroup).not.toBeNull();

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -47,6 +47,7 @@ describe('GPU hierarchical trace viewer', () => {
           drawCommands: {buffer: {readAsync: () => Promise<Uint8Array>}};
           visibleSpanIds: {readAsync: () => Promise<Uint8Array>};
           visibleDependencyIds: {readAsync: () => Promise<Uint8Array>};
+          dependencyResults: {readAsync: () => Promise<Uint8Array>};
           densityBins: {readAsync: () => Promise<Uint8Array>};
           reachedSpans: {
             readAsync: (byteOffset?: number, byteLength?: number) => Promise<Uint8Array>;
@@ -119,6 +120,20 @@ describe('GPU hierarchical trace viewer', () => {
       expect(Array.from(visibleDependencyIds)).toEqual(
         Array.from(visibleDependencyIds).sort((left, right) => left - right)
       );
+      const dependencyResultBytes = await state.resources.dependencyResults.readAsync();
+      const dependencyResults = new Uint32Array(
+        dependencyResultBytes.buffer,
+        dependencyResultBytes.byteOffset,
+        dependencyResultBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+      );
+      for (const dependencyIndex of visibleDependencyIds) {
+        const endpointOffset = state.resources.dependencyCount + dependencyIndex * 2;
+        const sourceSpanIndex = dependencyResults[endpointOffset];
+        const destinationSpanIndex = dependencyResults[endpointOffset + 1];
+        expect(sourceSpanIndex).toBeLessThan(state.resources.spanCount);
+        expect(destinationSpanIndex).toBeLessThan(state.resources.spanCount);
+        expect(sourceSpanIndex).not.toBe(destinationSpanIndex);
+      }
       const candidateBytes = await state.resources.candidateDispatchCommands.buffer.readAsync();
       const candidateDispatch = new Uint32Array(
         candidateBytes.buffer,


### PR DESCRIPTION
## Summary

- partition canonical dependencies into stable 128-edge batches with conservative endpoint and ancestor time envelopes
- select dependency batches on the GPU by viewport, dependency family, and density mode
- run exact dependency filtering and stable range compaction only across selected batches
- resolve visible ancestors only for candidate dependency endpoints
- remove the full-span ancestor projection dispatch and its span-sized output buffer
- expose candidate span and dependency batch ratios in the trace inspector

## Why

After the candidate-driven span compaction added in #2879, dependency filtering and full-domain ancestor projection were the remaining O(total trace size) frame costs. At multi-million-span scale they performed work for edges and spans that could not contribute to the current viewport.

This change makes dependency work proportional to compacted dependency batches and their endpoints while preserving stable dependency IDs, collapsed-process routing, focus projection, indirect draw counts, and portable WebGPU binding limits.

## Validation

- `yarn lint fix` — passed
- `yarn build` — passed after rebasing onto current master
- trace data/WGSL node suite — 10 passed after rebase
- focused Chromium/WebGPU trace-viewer suite — passed after rebase; verifies strict candidate-batch pruning, stable dependency IDs, and valid distinct resolved endpoints
- full Node gate — 342 passed, 2 skipped
- full browser gate remains noisy under shared GPU load; a clean run reached 1424 passed and 25 skipped with the two known unrelated failures in Volumetric Fire Forge and Arrow Layers. Other reruns produced unrelated GPU timeout failures; the isolated trace suite remained green.