### PR TITLE
fix(experimental): preserve extreme segment projections

### DIFF
--- a/modules/experimental/src/geospatial/geospatial-utils.ts
+++ b/modules/experimental/src/geospatial/geospatial-utils.ts
@@ -268,12 +268,13 @@ fn geospatial_hypot_fp64(x: vec2f, y: vec2f) -> vec2f {
   if (scaleValue == 0.0) {
     return vec2f(0.0, 0.0);
   }
-  let scaledX = geospatial_div_fp64_f32(normalizedX, scaleValue);
-  let scaledY = geospatial_div_fp64_f32(normalizedY, scaleValue);
+  let scaleExponent = frexp(scaleValue).exp;
+  let scaledX = fp64_scale_fp64_integer(normalizedX, -scaleExponent);
+  let scaledY = fp64_scale_fp64_integer(normalizedY, -scaleExponent);
   let scaledLength = sqrt_fp64(
     sum_fp64(mul_fp64(scaledX, scaledX), mul_fp64(scaledY, scaledY))
   );
-  return geospatial_mul_fp64_f32(scaledLength, scaleValue);
+  return fp64_scale_fp64_integer(scaledLength, scaleExponent);
 }
 `;
 

--- a/modules/experimental/src/geospatial/gpu-pairwise-point-linestring-nearest.ts
+++ b/modules/experimental/src/geospatial/gpu-pairwise-point-linestring-nearest.ts
@@ -407,8 +407,7 @@ function getFloat32NearestExpression(
       let directSegment = end - start;
       let directProjection = geospatial_project_onto_segment_f32(
         directSegment,
-        point - start,
-        point - end
+        point - start
       );
       let coordinateScale = max(
         1.0,
@@ -426,8 +425,7 @@ function getFloat32NearestExpression(
       let normalizedSegment = normalizedEnd - normalizedStart;
       let normalizedProjection = geospatial_project_onto_segment_f32(
         normalizedSegment,
-        normalizedPoint - normalizedStart,
-        normalizedPoint - normalizedEnd
+        normalizedPoint - normalizedStart
       );
       var projectedDelta = directProjection.projectedDelta;
       var candidatePoint = start;
@@ -594,13 +592,11 @@ fn geospatial_is_finite_vec2_f32(value: vec2f) -> bool {
 
 fn geospatial_project_onto_segment_f32(
   segment: vec2f,
-  pointFromStart: vec2f,
-  pointFromEnd: vec2f
+  pointFromStart: vec2f
 ) -> GeospatialSegmentProjectionF32 {
   if (
     !geospatial_is_finite_vec2_f32(segment) ||
-    !geospatial_is_finite_vec2_f32(pointFromStart) ||
-    !geospatial_is_finite_vec2_f32(pointFromEnd)
+    !geospatial_is_finite_vec2_f32(pointFromStart)
   ) {
     return GeospatialSegmentProjectionF32(vec2f(0.0), false);
   }
@@ -612,31 +608,21 @@ fn geospatial_project_onto_segment_f32(
   if (pointScale == 0.0) {
     return GeospatialSegmentProjectionF32(vec2f(0.0), true);
   }
-  let pointFromEndScale = max(abs(pointFromEnd.x), abs(pointFromEnd.y));
-  if (pointFromEndScale == 0.0) {
-    return GeospatialSegmentProjectionF32(segment, true);
-  }
   let segmentExponent = frexp(segmentScale).exp;
   let normalizedSegment = ldexp(segment, vec2i(-segmentExponent));
   var startProjection = dot(pointFromStart, normalizedSegment);
-  var endProjection = dot(pointFromEnd, normalizedSegment);
   let denominator = dot(normalizedSegment, normalizedSegment);
   var projectionExponent = 0;
-  if (
-    !geospatial_is_finite_f32(startProjection) ||
-    !geospatial_is_finite_f32(endProjection)
-  ) {
+  var endThreshold = ldexp(denominator, segmentExponent);
+  if (!geospatial_is_finite_f32(startProjection)) {
     let pointExponent = frexp(pointScale).exp;
-    let pointFromEndExponent = frexp(pointFromEndScale).exp;
     let normalizedPoint = ldexp(pointFromStart, vec2i(-pointExponent));
-    let normalizedPointFromEnd = ldexp(pointFromEnd, vec2i(-pointFromEndExponent));
     startProjection = dot(normalizedPoint, normalizedSegment);
-    endProjection = dot(normalizedPointFromEnd, normalizedSegment);
     projectionExponent = pointExponent;
+    endThreshold = ldexp(denominator, segmentExponent - pointExponent);
   }
   if (
     !geospatial_is_finite_f32(startProjection) ||
-    !geospatial_is_finite_f32(endProjection) ||
     !geospatial_is_finite_f32(denominator) ||
     denominator <= 0.0
   ) {
@@ -645,13 +631,14 @@ fn geospatial_project_onto_segment_f32(
   if (startProjection <= 0.0) {
     return GeospatialSegmentProjectionF32(vec2f(0.0), true);
   }
-  if (endProjection >= 0.0) {
+  if (geospatial_is_finite_f32(endThreshold) && startProjection >= endThreshold) {
     return GeospatialSegmentProjectionF32(segment, true);
   }
   // Construct the displacement before restoring scale. A true segment fraction can underflow
-  // even when its displacement remains representable.
+  // even when its displacement remains representable, while the scalar projection can overflow
+  // before multiplication by a normalized diagonal component brings it back into range.
   let projectedDelta = ldexp(
-    normalizedSegment * (startProjection / denominator),
+    (normalizedSegment * startProjection) / denominator,
     vec2i(projectionExponent)
   );
   return GeospatialSegmentProjectionF32(
@@ -696,12 +683,9 @@ fn geospatial_nearest_segment(
   let segmentY = sub_fp64u32_to_fp64(end.y, start.y);
   let pointX = sub_fp64u32_to_fp64(point.x, start.x);
   let pointY = sub_fp64u32_to_fp64(point.y, start.y);
-  let pointFromEndX = sub_fp64u32_to_fp64(point.x, end.x);
-  let pointFromEndY = sub_fp64u32_to_fp64(point.y, end.y);
   if (
     !is_finite_fp64(segmentX) || !is_finite_fp64(segmentY) ||
-    !is_finite_fp64(pointX) || !is_finite_fp64(pointY) ||
-    !is_finite_fp64(pointFromEndX) || !is_finite_fp64(pointFromEndY)
+    !is_finite_fp64(pointX) || !is_finite_fp64(pointY)
   ) {
     return geospatial_invalid_nearest_segment(pointX.x + pointY.x);
   }
@@ -712,7 +696,6 @@ fn geospatial_nearest_segment(
   let endY = geospatial_raw_scalar_to_fp64(end.y);
   let segmentScale = geospatial_max_abs_fp64(segmentX, segmentY);
   let pointScale = geospatial_max_abs_fp64(pointX, pointY);
-  let pointFromEndScale = geospatial_max_abs_fp64(pointFromEndX, pointFromEndY);
   if (segmentScale == 0.0) {
     let distance = geospatial_hypot_fp64(pointX, pointY);
     return GeospatialNearestSegment(
@@ -725,10 +708,6 @@ fn geospatial_nearest_segment(
   if (pointScale == 0.0) {
     return GeospatialNearestSegment(vec2f(0.0, 0.0), startX, startY, 1u);
   }
-  if (pointFromEndScale == 0.0) {
-    return GeospatialNearestSegment(vec2f(0.0, 0.0), endX, endY, 1u);
-  }
-
   let segmentExponent = frexp(segmentScale).exp;
   let normalizedSegmentX = fp64_scale_fp64_integer(segmentX, -segmentExponent);
   let normalizedSegmentY = fp64_scale_fp64_integer(segmentY, -segmentExponent);
@@ -736,46 +715,29 @@ fn geospatial_nearest_segment(
     mul_fp64(pointX, normalizedSegmentX),
     mul_fp64(pointY, normalizedSegmentY)
   );
-  let directEndProjection = sum_fp64(
-    mul_fp64(pointFromEndX, normalizedSegmentX),
-    mul_fp64(pointFromEndY, normalizedSegmentY)
-  );
   let denominator = sum_fp64(
     mul_fp64(normalizedSegmentX, normalizedSegmentX),
     mul_fp64(normalizedSegmentY, normalizedSegmentY)
   );
   var startProjection = directStartProjection;
-  var endProjection = directEndProjection;
   var projectionExponent = 0;
-  if (
-    !is_finite_fp64(startProjection) ||
-    !is_finite_fp64(endProjection)
-  ) {
+  var endThreshold = fp64_scale_fp64_integer(denominator, segmentExponent);
+  if (!is_finite_fp64(startProjection)) {
     let pointExponent = frexp(pointScale).exp;
-    let pointFromEndExponent = frexp(pointFromEndScale).exp;
     let normalizedPointX = fp64_scale_fp64_integer(pointX, -pointExponent);
     let normalizedPointY = fp64_scale_fp64_integer(pointY, -pointExponent);
-    let normalizedPointFromEndX = fp64_scale_fp64_integer(
-      pointFromEndX,
-      -pointFromEndExponent
-    );
-    let normalizedPointFromEndY = fp64_scale_fp64_integer(
-      pointFromEndY,
-      -pointFromEndExponent
-    );
     startProjection = sum_fp64(
       mul_fp64(normalizedPointX, normalizedSegmentX),
       mul_fp64(normalizedPointY, normalizedSegmentY)
     );
-    endProjection = sum_fp64(
-      mul_fp64(normalizedPointFromEndX, normalizedSegmentX),
-      mul_fp64(normalizedPointFromEndY, normalizedSegmentY)
-    );
     projectionExponent = pointExponent;
+    endThreshold = fp64_scale_fp64_integer(
+      denominator,
+      segmentExponent - pointExponent
+    );
   }
   if (
     !is_finite_fp64(startProjection) ||
-    !is_finite_fp64(endProjection) ||
     !is_finite_fp64(denominator) ||
     compare_fp64(denominator, vec2f(0.0, 0.0)) <= 0
   ) {
@@ -788,21 +750,23 @@ fn geospatial_nearest_segment(
   var nearestY = startY;
   if (compare_fp64(startProjection, vec2f(0.0, 0.0)) <= 0) {
     // Keep the segment start.
-  } else if (compare_fp64(endProjection, vec2f(0.0, 0.0)) >= 0) {
+  } else if (
+    is_finite_fp64(endThreshold) &&
+    compare_fp64(startProjection, endThreshold) >= 0
+  ) {
     projectionX = segmentX;
     projectionY = segmentY;
     nearestX = endX;
     nearestY = endY;
   } else {
-    // Keep the normalized projection separate from the segment's exponent so a tiny fraction
-    // cannot erase a representable projected displacement.
-    let normalizedProjection = div_fp64(startProjection, denominator);
+    // Multiply each normalized segment component before division. This avoids both a tiny true
+    // fraction and an overflowing scalar projection when each displacement remains representable.
     projectionX = fp64_scale_fp64_integer(
-      mul_fp64(normalizedSegmentX, normalizedProjection),
+      div_fp64(mul_fp64(normalizedSegmentX, startProjection), denominator),
       projectionExponent
     );
     projectionY = fp64_scale_fp64_integer(
-      mul_fp64(normalizedSegmentY, normalizedProjection),
+      div_fp64(mul_fp64(normalizedSegmentY, startProjection), denominator),
       projectionExponent
     );
     if (!is_finite_fp64(projectionX) || !is_finite_fp64(projectionY)) {

--- a/modules/experimental/src/geospatial/gpu-pairwise-point-linestring-nearest.ts
+++ b/modules/experimental/src/geospatial/gpu-pairwise-point-linestring-nearest.ts
@@ -404,6 +404,12 @@ function getFloat32NearestExpression(
         rowValid = false;
         continue;
       }
+      let directSegment = end - start;
+      let directProjection = geospatial_project_onto_segment_f32(
+        directSegment,
+        point - start,
+        point - end
+      );
       let coordinateScale = max(
         1.0,
         max(
@@ -418,25 +424,39 @@ function getFloat32NearestExpression(
       let normalizedStart = ldexp(start, vec2i(-coordinateExponent));
       let normalizedEnd = ldexp(end, vec2i(-coordinateExponent));
       let normalizedSegment = normalizedEnd - normalizedStart;
-      let denominator = dot(normalizedSegment, normalizedSegment);
-      var fraction = 0.0;
-      if (denominator > 0.0) {
-        fraction = clamp(
-          dot(normalizedPoint - normalizedStart, normalizedSegment) / denominator,
-          0.0,
-          1.0
+      let normalizedProjection = geospatial_project_onto_segment_f32(
+        normalizedSegment,
+        normalizedPoint - normalizedStart,
+        normalizedPoint - normalizedEnd
+      );
+      var projectedDelta = directProjection.projectedDelta;
+      var candidatePoint = start;
+      if (!directProjection.valid) {
+        projectedDelta = normalizedProjection.projectedDelta;
+        rowValid = normalizedProjection.valid;
+      }
+      if (!rowValid) {
+        continue;
+      }
+      if (directProjection.valid) {
+        candidatePoint = start + projectedDelta;
+      } else {
+        candidatePoint = ldexp(
+          normalizedStart + projectedDelta,
+          vec2i(coordinateExponent)
         );
       }
-      let normalizedCandidatePoint = normalizedStart + fraction * normalizedSegment;
-      let candidatePoint = ldexp(normalizedCandidatePoint, vec2i(coordinateExponent));
-      let normalizedDelta = normalizedPoint - normalizedCandidatePoint;
-      let deltaScale = max(abs(normalizedDelta.x), abs(normalizedDelta.y));
-      var normalizedDistance = 0.0;
-      if (deltaScale > 0.0) {
-        normalizedDistance = deltaScale * length(normalizedDelta / deltaScale);
+      let delta = point - candidatePoint;
+      let deltaIsFinite = geospatial_is_finite_vec2_f32(delta);
+      let deltaScale = max(abs(delta.x), abs(delta.y));
+      var candidateDistance = 0.0;
+      if (deltaIsFinite && deltaScale > 0.0) {
+        let deltaExponent = frexp(deltaScale).exp;
+        let normalizedDelta = ldexp(delta, vec2i(-deltaExponent));
+        candidateDistance = ldexp(length(normalizedDelta), deltaExponent);
       }
-      let candidateDistance = ldexp(normalizedDistance, coordinateExponent);
       if (
+        !deltaIsFinite ||
         !geospatial_is_finite_vec2_f32(candidatePoint) ||
         !geospatial_is_finite_f32(candidateDistance)
       ) {
@@ -559,12 +579,85 @@ function getPreciseNearestExpression(
 }
 
 const FLOAT32_FINITE_WGSL = /* wgsl */ `
+struct GeospatialSegmentProjectionF32 {
+  projectedDelta: vec2f,
+  valid: bool
+}
+
 fn geospatial_is_finite_f32(value: f32) -> bool {
   return (bitcast<u32>(value) & 0x7f800000u) != 0x7f800000u;
 }
 
 fn geospatial_is_finite_vec2_f32(value: vec2f) -> bool {
   return geospatial_is_finite_f32(value.x) && geospatial_is_finite_f32(value.y);
+}
+
+fn geospatial_project_onto_segment_f32(
+  segment: vec2f,
+  pointFromStart: vec2f,
+  pointFromEnd: vec2f
+) -> GeospatialSegmentProjectionF32 {
+  if (
+    !geospatial_is_finite_vec2_f32(segment) ||
+    !geospatial_is_finite_vec2_f32(pointFromStart) ||
+    !geospatial_is_finite_vec2_f32(pointFromEnd)
+  ) {
+    return GeospatialSegmentProjectionF32(vec2f(0.0), false);
+  }
+  let segmentScale = max(abs(segment.x), abs(segment.y));
+  if (segmentScale == 0.0) {
+    return GeospatialSegmentProjectionF32(vec2f(0.0), true);
+  }
+  let pointScale = max(abs(pointFromStart.x), abs(pointFromStart.y));
+  if (pointScale == 0.0) {
+    return GeospatialSegmentProjectionF32(vec2f(0.0), true);
+  }
+  let pointFromEndScale = max(abs(pointFromEnd.x), abs(pointFromEnd.y));
+  if (pointFromEndScale == 0.0) {
+    return GeospatialSegmentProjectionF32(segment, true);
+  }
+  let segmentExponent = frexp(segmentScale).exp;
+  let normalizedSegment = ldexp(segment, vec2i(-segmentExponent));
+  var startProjection = dot(pointFromStart, normalizedSegment);
+  var endProjection = dot(pointFromEnd, normalizedSegment);
+  let denominator = dot(normalizedSegment, normalizedSegment);
+  var projectionExponent = 0;
+  if (
+    !geospatial_is_finite_f32(startProjection) ||
+    !geospatial_is_finite_f32(endProjection)
+  ) {
+    let pointExponent = frexp(pointScale).exp;
+    let pointFromEndExponent = frexp(pointFromEndScale).exp;
+    let normalizedPoint = ldexp(pointFromStart, vec2i(-pointExponent));
+    let normalizedPointFromEnd = ldexp(pointFromEnd, vec2i(-pointFromEndExponent));
+    startProjection = dot(normalizedPoint, normalizedSegment);
+    endProjection = dot(normalizedPointFromEnd, normalizedSegment);
+    projectionExponent = pointExponent;
+  }
+  if (
+    !geospatial_is_finite_f32(startProjection) ||
+    !geospatial_is_finite_f32(endProjection) ||
+    !geospatial_is_finite_f32(denominator) ||
+    denominator <= 0.0
+  ) {
+    return GeospatialSegmentProjectionF32(vec2f(0.0), false);
+  }
+  if (startProjection <= 0.0) {
+    return GeospatialSegmentProjectionF32(vec2f(0.0), true);
+  }
+  if (endProjection >= 0.0) {
+    return GeospatialSegmentProjectionF32(segment, true);
+  }
+  // Construct the displacement before restoring scale. A true segment fraction can underflow
+  // even when its displacement remains representable.
+  let projectedDelta = ldexp(
+    normalizedSegment * (startProjection / denominator),
+    vec2i(projectionExponent)
+  );
+  return GeospatialSegmentProjectionF32(
+    projectedDelta,
+    geospatial_is_finite_vec2_f32(projectedDelta)
+  );
 }
 
 `;
@@ -603,9 +696,12 @@ fn geospatial_nearest_segment(
   let segmentY = sub_fp64u32_to_fp64(end.y, start.y);
   let pointX = sub_fp64u32_to_fp64(point.x, start.x);
   let pointY = sub_fp64u32_to_fp64(point.y, start.y);
+  let pointFromEndX = sub_fp64u32_to_fp64(point.x, end.x);
+  let pointFromEndY = sub_fp64u32_to_fp64(point.y, end.y);
   if (
     !is_finite_fp64(segmentX) || !is_finite_fp64(segmentY) ||
-    !is_finite_fp64(pointX) || !is_finite_fp64(pointY)
+    !is_finite_fp64(pointX) || !is_finite_fp64(pointY) ||
+    !is_finite_fp64(pointFromEndX) || !is_finite_fp64(pointFromEndY)
   ) {
     return geospatial_invalid_nearest_segment(pointX.x + pointY.x);
   }
@@ -616,6 +712,7 @@ fn geospatial_nearest_segment(
   let endY = geospatial_raw_scalar_to_fp64(end.y);
   let segmentScale = geospatial_max_abs_fp64(segmentX, segmentY);
   let pointScale = geospatial_max_abs_fp64(pointX, pointY);
+  let pointFromEndScale = geospatial_max_abs_fp64(pointFromEndX, pointFromEndY);
   if (segmentScale == 0.0) {
     let distance = geospatial_hypot_fp64(pointX, pointY);
     return GeospatialNearestSegment(
@@ -625,38 +722,94 @@ fn geospatial_nearest_segment(
       select(0u, 1u, is_finite_fp64(distance))
     );
   }
+  if (pointScale == 0.0) {
+    return GeospatialNearestSegment(vec2f(0.0, 0.0), startX, startY, 1u);
+  }
+  if (pointFromEndScale == 0.0) {
+    return GeospatialNearestSegment(vec2f(0.0, 0.0), endX, endY, 1u);
+  }
 
-  let commonScale = max(segmentScale, pointScale);
-  let normalizedSegmentX = geospatial_div_fp64_f32(segmentX, commonScale);
-  let normalizedSegmentY = geospatial_div_fp64_f32(segmentY, commonScale);
-  let normalizedPointX = geospatial_div_fp64_f32(pointX, commonScale);
-  let normalizedPointY = geospatial_div_fp64_f32(pointY, commonScale);
-  let numerator = sum_fp64(
-    mul_fp64(normalizedPointX, normalizedSegmentX),
-    mul_fp64(normalizedPointY, normalizedSegmentY)
+  let segmentExponent = frexp(segmentScale).exp;
+  let normalizedSegmentX = fp64_scale_fp64_integer(segmentX, -segmentExponent);
+  let normalizedSegmentY = fp64_scale_fp64_integer(segmentY, -segmentExponent);
+  let directStartProjection = sum_fp64(
+    mul_fp64(pointX, normalizedSegmentX),
+    mul_fp64(pointY, normalizedSegmentY)
+  );
+  let directEndProjection = sum_fp64(
+    mul_fp64(pointFromEndX, normalizedSegmentX),
+    mul_fp64(pointFromEndY, normalizedSegmentY)
   );
   let denominator = sum_fp64(
     mul_fp64(normalizedSegmentX, normalizedSegmentX),
     mul_fp64(normalizedSegmentY, normalizedSegmentY)
   );
+  var startProjection = directStartProjection;
+  var endProjection = directEndProjection;
+  var projectionExponent = 0;
+  if (
+    !is_finite_fp64(startProjection) ||
+    !is_finite_fp64(endProjection)
+  ) {
+    let pointExponent = frexp(pointScale).exp;
+    let pointFromEndExponent = frexp(pointFromEndScale).exp;
+    let normalizedPointX = fp64_scale_fp64_integer(pointX, -pointExponent);
+    let normalizedPointY = fp64_scale_fp64_integer(pointY, -pointExponent);
+    let normalizedPointFromEndX = fp64_scale_fp64_integer(
+      pointFromEndX,
+      -pointFromEndExponent
+    );
+    let normalizedPointFromEndY = fp64_scale_fp64_integer(
+      pointFromEndY,
+      -pointFromEndExponent
+    );
+    startProjection = sum_fp64(
+      mul_fp64(normalizedPointX, normalizedSegmentX),
+      mul_fp64(normalizedPointY, normalizedSegmentY)
+    );
+    endProjection = sum_fp64(
+      mul_fp64(normalizedPointFromEndX, normalizedSegmentX),
+      mul_fp64(normalizedPointFromEndY, normalizedSegmentY)
+    );
+    projectionExponent = pointExponent;
+  }
+  if (
+    !is_finite_fp64(startProjection) ||
+    !is_finite_fp64(endProjection) ||
+    !is_finite_fp64(denominator) ||
+    compare_fp64(denominator, vec2f(0.0, 0.0)) <= 0
+  ) {
+    return geospatial_invalid_nearest_segment(startProjection.x + denominator.x);
+  }
 
   var projectionX = vec2f(0.0, 0.0);
   var projectionY = vec2f(0.0, 0.0);
   var nearestX = startX;
   var nearestY = startY;
-  if (compare_fp64(numerator, vec2f(0.0, 0.0)) > 0) {
-    if (compare_fp64(numerator, denominator) >= 0) {
-      projectionX = segmentX;
-      projectionY = segmentY;
-      nearestX = endX;
-      nearestY = endY;
-    } else {
-      let fraction = div_fp64(numerator, denominator);
-      projectionX = mul_fp64(segmentX, fraction);
-      projectionY = mul_fp64(segmentY, fraction);
-      nearestX = sum_fp64(startX, projectionX);
-      nearestY = sum_fp64(startY, projectionY);
+  if (compare_fp64(startProjection, vec2f(0.0, 0.0)) <= 0) {
+    // Keep the segment start.
+  } else if (compare_fp64(endProjection, vec2f(0.0, 0.0)) >= 0) {
+    projectionX = segmentX;
+    projectionY = segmentY;
+    nearestX = endX;
+    nearestY = endY;
+  } else {
+    // Keep the normalized projection separate from the segment's exponent so a tiny fraction
+    // cannot erase a representable projected displacement.
+    let normalizedProjection = div_fp64(startProjection, denominator);
+    projectionX = fp64_scale_fp64_integer(
+      mul_fp64(normalizedSegmentX, normalizedProjection),
+      projectionExponent
+    );
+    projectionY = fp64_scale_fp64_integer(
+      mul_fp64(normalizedSegmentY, normalizedProjection),
+      projectionExponent
+    );
+    if (!is_finite_fp64(projectionX) || !is_finite_fp64(projectionY)) {
+      return geospatial_invalid_nearest_segment(projectionX.x + projectionY.x);
     }
+    nearestX = sum_fp64(startX, projectionX);
+    nearestY = sum_fp64(startY, projectionY);
   }
   let distance = geospatial_hypot_fp64(
     sub_fp64(pointX, projectionX),

--- a/modules/experimental/test/geospatial/gpu-pairwise-point-linestring-nearest.spec.ts
+++ b/modules/experimental/test/geospatial/gpu-pairwise-point-linestring-nearest.spec.ts
@@ -375,49 +375,61 @@ test('GPUPairwisePointLinestringNearest keeps extreme finite f32 rows finite', a
     return;
   }
 
-  const pointValues = Float32Array.from([3e38, 1e38, -3e38, -1e38]);
-  const linestringValues = Float32Array.from([2e38, 0, 3e38, 0, -2e38, 0, -3e38, 0]);
-  const geometryOffsetValues = Uint32Array.from([0, 1, 2]);
-  const linestringOffsetValues = Uint32Array.from([0, 2, 4]);
+  const pointValues = Float32Array.from([3e38, 1e38, -3e38, -1e38, 0.5, 1e30, 1e38, 1e38, 1, 1]);
+  const linestringValues = Float32Array.from([
+    2e38, 0, 3e38, 0, -2e38, 0, -3e38, 0, 0, 0, 1, 0, 0, 0, 3e38, 3e38, 0, 0, 3e38, 0
+  ]);
+  const geometryOffsetValues = Uint32Array.from([0, 1, 2, 3, 4, 5]);
+  const linestringOffsetValues = Uint32Array.from([0, 2, 4, 6, 8, 10]);
   const pointBuffer = createInputBuffer(device, pointValues);
   const linestringBuffer = createInputBuffer(device, linestringValues);
   const geometryOffsetsBuffer = createInputBuffer(device, geometryOffsetValues);
   const linestringOffsetsBuffer = createInputBuffer(device, linestringOffsetValues);
-  const distanceBuffer = createOutputBuffer(device, 2, 4);
-  const nearestPointBuffer = createOutputBuffer(device, 2, 8);
+  const distanceBuffer = createOutputBuffer(device, 5, 4);
+  const nearestPointBuffer = createOutputBuffer(device, 5, 8);
   const graph = new GPUCommandGraph(device, {id: 'pairwise-linestring-nearest-extreme'});
 
   new GPUPairwisePointLinestringNearest({
-    points: importView(graph, 'points', pointBuffer, 'float32x2', 2),
+    points: importView(graph, 'points', pointBuffer, 'float32x2', 5),
     linestringPositions: importView(
       graph,
       'linestring-positions',
       linestringBuffer,
       'float32x2',
-      4
+      10
     ),
-    geometryOffsets: importView(graph, 'geometry-offsets', geometryOffsetsBuffer, 'uint32', 3),
+    geometryOffsets: importView(graph, 'geometry-offsets', geometryOffsetsBuffer, 'uint32', 6),
     linestringOffsets: importView(
       graph,
       'linestring-offsets',
       linestringOffsetsBuffer,
       'uint32',
-      3
+      6
     ),
-    output: importView(graph, 'distances', distanceBuffer, 'float32', 2),
-    nearestPoints: importView(graph, 'nearest-points', nearestPointBuffer, 'float32x2', 2)
+    output: importView(graph, 'distances', distanceBuffer, 'float32', 5),
+    nearestPoints: importView(graph, 'nearest-points', nearestPointBuffer, 'float32x2', 5)
   }).addToGraph(graph);
   const compiled = graph.compile();
   encode(device, compiled);
 
-  for (const [index, distance] of (await readFloat32(distanceBuffer, 2)).entries()) {
+  const distances = await readFloat32(distanceBuffer, 5);
+  for (const [index, distance] of distances.slice(0, 2).entries()) {
     assertRelativeClose(tapeTest, distance, 1e38, 2e-6, `extreme distance ${index}`);
   }
-  const nearestPoints = await readFloat32(nearestPointBuffer, 4);
+  assertRelativeClose(tapeTest, distances[2], 1e30, 2e-6, 'far perpendicular distance');
+  tapeTest.ok(distances[3] <= 2e32, 'long-diagonal projection remains near the point');
+  tapeTest.equal(distances[4], 1, 'tiny fraction retains its perpendicular distance');
+  const nearestPoints = await readFloat32(nearestPointBuffer, 10);
   assertRelativeClose(tapeTest, nearestPoints[0], 3e38, 2e-6, 'extreme positive nearest x');
   tapeTest.equal(nearestPoints[1], 0, 'extreme positive nearest y');
   assertRelativeClose(tapeTest, nearestPoints[2], -3e38, 2e-6, 'extreme negative nearest x');
   tapeTest.equal(nearestPoints[3], 0, 'extreme negative nearest y');
+  tapeTest.equal(nearestPoints[4], 0.5, 'far point retains the short-segment projection');
+  tapeTest.equal(nearestPoints[5], 0, 'far point projects onto the short segment');
+  assertRelativeClose(tapeTest, nearestPoints[6], 1e38, 2e-6, 'long-diagonal nearest x');
+  assertRelativeClose(tapeTest, nearestPoints[7], 1e38, 2e-6, 'long-diagonal nearest y');
+  tapeTest.equal(nearestPoints[8], 1, 'tiny fraction retains its projected displacement');
+  tapeTest.equal(nearestPoints[9], 0, 'tiny fraction projects onto the huge segment');
 
   compiled.destroy();
   for (const buffer of [
@@ -552,7 +564,9 @@ test('GPUPairwisePointLinestringNearest preserves raw-binary64 projection deltas
   const points: Point[] = [
     [x + 1e-7, y + 3e-7],
     [x + 2e-7, y + 3e-7],
-    [x, y]
+    [x, y],
+    [0.5, 1e30],
+    [1e-30, 1]
   ];
   const linestringPositions: Point[] = [
     [x, y + 1e-6],
@@ -562,10 +576,14 @@ test('GPUPairwisePointLinestringNearest preserves raw-binary64 projection deltas
     [x, y],
     [x, y],
     [Number.NaN, y],
-    [x, y]
+    [x, y],
+    [0, 0],
+    [1, 0],
+    [0, 0],
+    [3e38, 0]
   ];
-  const geometryOffsetValues = Uint32Array.from([0, 2, 3, 4]);
-  const linestringOffsetValues = Uint32Array.from([0, 2, 4, 6, 8]);
+  const geometryOffsetValues = Uint32Array.from([0, 2, 3, 4, 5, 6]);
+  const linestringOffsetValues = Uint32Array.from([0, 2, 4, 6, 8, 10, 12]);
   const pointBuffer = createInputBuffer(device, encodeFloat64Points(points));
   const linestringBuffer = createInputBuffer(device, encodeFloat64Points(linestringPositions));
   const geometryOffsetsBuffer = createInputBuffer(device, geometryOffsetValues);
@@ -629,7 +647,9 @@ test('GPUPairwisePointLinestringNearest preserves raw-binary64 projection deltas
   const expectedDistances = [
     Math.abs(points[0][1] - y),
     Math.hypot(points[1][0] - x, points[1][1] - y),
-    Number.NaN
+    Number.NaN,
+    1e30,
+    1
   ];
   for (let index = 0; index < expectedDistances.length; index++) {
     const distance = distanceLimbs[index * 2] + distanceLimbs[index * 2 + 1];
@@ -650,7 +670,9 @@ test('GPUPairwisePointLinestringNearest preserves raw-binary64 projection deltas
   const expectedNearest: Point[] = [
     [points[0][0], y],
     [x, y],
-    [Number.NaN, Number.NaN]
+    [Number.NaN, Number.NaN],
+    [0.5, 0],
+    [1e-30, 0]
   ];
   for (let index = 0; index < expectedNearest.length; index++) {
     const nearestX = nearestLimbs[index * 4] + nearestLimbs[index * 4 + 1];
@@ -662,8 +684,21 @@ test('GPUPairwisePointLinestringNearest preserves raw-binary64 projection deltas
       assertClose(tapeTest, nearestY, expectedNearest[index][1], 2e-7, `raw nearest y ${index}`);
     }
   }
-  tapeTest.deepEqual(await readUint32(linestringIndexBuffer, points.length), [1, 0, NO_INDEX]);
-  tapeTest.deepEqual(await readUint32(segmentIndexBuffer, points.length), [0, 0, NO_INDEX]);
+  assertClose(
+    tapeTest,
+    nearestLimbs[16] + nearestLimbs[17],
+    1e-30,
+    2e-36,
+    'raw tiny fraction retains its projected displacement'
+  );
+  tapeTest.deepEqual(await readUint32(linestringIndexBuffer, points.length), [
+    1,
+    0,
+    NO_INDEX,
+    0,
+    0
+  ]);
+  tapeTest.deepEqual(await readUint32(segmentIndexBuffer, points.length), [0, 0, NO_INDEX, 0, 0]);
 
   compiled.destroy();
   for (const buffer of [

--- a/modules/experimental/test/geospatial/gpu-pairwise-point-linestring-nearest.spec.ts
+++ b/modules/experimental/test/geospatial/gpu-pairwise-point-linestring-nearest.spec.ts
@@ -375,51 +375,55 @@ test('GPUPairwisePointLinestringNearest keeps extreme finite f32 rows finite', a
     return;
   }
 
-  const pointValues = Float32Array.from([3e38, 1e38, -3e38, -1e38, 0.5, 1e30, 1e38, 1e38, 1, 1]);
-  const linestringValues = Float32Array.from([
-    2e38, 0, 3e38, 0, -2e38, 0, -3e38, 0, 0, 0, 1, 0, 0, 0, 3e38, 3e38, 0, 0, 3e38, 0
+  const pointValues = Float32Array.from([
+    3e38, 1e38, -3e38, -1e38, 0.5, 1e30, 1e38, 1e38, 1, 1, 3e38, 0
   ]);
-  const geometryOffsetValues = Uint32Array.from([0, 1, 2, 3, 4, 5]);
-  const linestringOffsetValues = Uint32Array.from([0, 2, 4, 6, 8, 10]);
+  const linestringValues = Float32Array.from([
+    2e38, 0, 3e38, 0, -2e38, 0, -3e38, 0, 0, 0, 1, 0, 0, 0, 3e38, 3e38, 0, 0, 3e38, 0, 0, 0, -3e38,
+    0
+  ]);
+  const geometryOffsetValues = Uint32Array.from([0, 1, 2, 3, 4, 5, 6]);
+  const linestringOffsetValues = Uint32Array.from([0, 2, 4, 6, 8, 10, 12]);
   const pointBuffer = createInputBuffer(device, pointValues);
   const linestringBuffer = createInputBuffer(device, linestringValues);
   const geometryOffsetsBuffer = createInputBuffer(device, geometryOffsetValues);
   const linestringOffsetsBuffer = createInputBuffer(device, linestringOffsetValues);
-  const distanceBuffer = createOutputBuffer(device, 5, 4);
-  const nearestPointBuffer = createOutputBuffer(device, 5, 8);
+  const distanceBuffer = createOutputBuffer(device, 6, 4);
+  const nearestPointBuffer = createOutputBuffer(device, 6, 8);
   const graph = new GPUCommandGraph(device, {id: 'pairwise-linestring-nearest-extreme'});
 
   new GPUPairwisePointLinestringNearest({
-    points: importView(graph, 'points', pointBuffer, 'float32x2', 5),
+    points: importView(graph, 'points', pointBuffer, 'float32x2', 6),
     linestringPositions: importView(
       graph,
       'linestring-positions',
       linestringBuffer,
       'float32x2',
-      10
+      12
     ),
-    geometryOffsets: importView(graph, 'geometry-offsets', geometryOffsetsBuffer, 'uint32', 6),
+    geometryOffsets: importView(graph, 'geometry-offsets', geometryOffsetsBuffer, 'uint32', 7),
     linestringOffsets: importView(
       graph,
       'linestring-offsets',
       linestringOffsetsBuffer,
       'uint32',
-      6
+      7
     ),
-    output: importView(graph, 'distances', distanceBuffer, 'float32', 5),
-    nearestPoints: importView(graph, 'nearest-points', nearestPointBuffer, 'float32x2', 5)
+    output: importView(graph, 'distances', distanceBuffer, 'float32', 6),
+    nearestPoints: importView(graph, 'nearest-points', nearestPointBuffer, 'float32x2', 6)
   }).addToGraph(graph);
   const compiled = graph.compile();
   encode(device, compiled);
 
-  const distances = await readFloat32(distanceBuffer, 5);
+  const distances = await readFloat32(distanceBuffer, 6);
   for (const [index, distance] of distances.slice(0, 2).entries()) {
     assertRelativeClose(tapeTest, distance, 1e38, 2e-6, `extreme distance ${index}`);
   }
   assertRelativeClose(tapeTest, distances[2], 1e30, 2e-6, 'far perpendicular distance');
   tapeTest.ok(distances[3] <= 2e32, 'long-diagonal projection remains near the point');
   tapeTest.equal(distances[4], 1, 'tiny fraction retains its perpendicular distance');
-  const nearestPoints = await readFloat32(nearestPointBuffer, 10);
+  assertRelativeClose(tapeTest, distances[5], 3e38, 2e-6, 'overflowed end delta distance');
+  const nearestPoints = await readFloat32(nearestPointBuffer, 12);
   assertRelativeClose(tapeTest, nearestPoints[0], 3e38, 2e-6, 'extreme positive nearest x');
   tapeTest.equal(nearestPoints[1], 0, 'extreme positive nearest y');
   assertRelativeClose(tapeTest, nearestPoints[2], -3e38, 2e-6, 'extreme negative nearest x');
@@ -430,6 +434,8 @@ test('GPUPairwisePointLinestringNearest keeps extreme finite f32 rows finite', a
   assertRelativeClose(tapeTest, nearestPoints[7], 1e38, 2e-6, 'long-diagonal nearest y');
   tapeTest.equal(nearestPoints[8], 1, 'tiny fraction retains its projected displacement');
   tapeTest.equal(nearestPoints[9], 0, 'tiny fraction projects onto the huge segment');
+  tapeTest.equal(nearestPoints[10], 0, 'overflowed end delta selects the segment start x');
+  tapeTest.equal(nearestPoints[11], 0, 'overflowed end delta selects the segment start y');
 
   compiled.destroy();
   for (const buffer of [
@@ -561,12 +567,16 @@ test('GPUPairwisePointLinestringNearest preserves raw-binary64 projection deltas
 
   const x = 12_345_678.125;
   const y = -7_654_321.5;
+  const extremeDiagonalCoordinate = 2 ** 127;
+  const nearEndCoordinate = (1 - 2 ** -30) * extremeDiagonalCoordinate;
   const points: Point[] = [
     [x + 1e-7, y + 3e-7],
     [x + 2e-7, y + 3e-7],
     [x, y],
     [0.5, 1e30],
-    [1e-30, 1]
+    [1e-30, 1],
+    [3e38, 0],
+    [nearEndCoordinate, nearEndCoordinate]
   ];
   const linestringPositions: Point[] = [
     [x, y + 1e-6],
@@ -580,10 +590,14 @@ test('GPUPairwisePointLinestringNearest preserves raw-binary64 projection deltas
     [0, 0],
     [1, 0],
     [0, 0],
-    [3e38, 0]
+    [3e38, 0],
+    [0, 0],
+    [-3e38, 0],
+    [0, 0],
+    [extremeDiagonalCoordinate, extremeDiagonalCoordinate]
   ];
-  const geometryOffsetValues = Uint32Array.from([0, 2, 3, 4, 5, 6]);
-  const linestringOffsetValues = Uint32Array.from([0, 2, 4, 6, 8, 10, 12]);
+  const geometryOffsetValues = Uint32Array.from([0, 2, 3, 4, 5, 6, 7, 8]);
+  const linestringOffsetValues = Uint32Array.from([0, 2, 4, 6, 8, 10, 12, 14, 16]);
   const pointBuffer = createInputBuffer(device, encodeFloat64Points(points));
   const linestringBuffer = createInputBuffer(device, encodeFloat64Points(linestringPositions));
   const geometryOffsetsBuffer = createInputBuffer(device, geometryOffsetValues);
@@ -649,12 +663,22 @@ test('GPUPairwisePointLinestringNearest preserves raw-binary64 projection deltas
     Math.hypot(points[1][0] - x, points[1][1] - y),
     Number.NaN,
     1e30,
-    1
+    1,
+    3e38,
+    0
   ];
   for (let index = 0; index < expectedDistances.length; index++) {
     const distance = distanceLimbs[index * 2] + distanceLimbs[index * 2 + 1];
     if (Number.isNaN(expectedDistances[index])) {
       tapeTest.ok(Number.isNaN(distance), `raw distance ${index} is invalid`);
+    } else if (index === expectedDistances.length - 1) {
+      assertClose(
+        tapeTest,
+        distance,
+        0,
+        extremeDiagonalCoordinate * 1e-12,
+        'raw near-end diagonal distance'
+      );
     } else {
       assertRelativeClose(
         tapeTest,
@@ -672,13 +696,30 @@ test('GPUPairwisePointLinestringNearest preserves raw-binary64 projection deltas
     [x, y],
     [Number.NaN, Number.NaN],
     [0.5, 0],
-    [1e-30, 0]
+    [1e-30, 0],
+    [0, 0],
+    [nearEndCoordinate, nearEndCoordinate]
   ];
   for (let index = 0; index < expectedNearest.length; index++) {
     const nearestX = nearestLimbs[index * 4] + nearestLimbs[index * 4 + 1];
     const nearestY = nearestLimbs[index * 4 + 2] + nearestLimbs[index * 4 + 3];
     if (Number.isNaN(expectedNearest[index][0])) {
       tapeTest.ok(Number.isNaN(nearestX) && Number.isNaN(nearestY));
+    } else if (index === expectedNearest.length - 1) {
+      assertClose(
+        tapeTest,
+        nearestX,
+        expectedNearest[index][0],
+        Math.abs(expectedNearest[index][0]) * 1e-12,
+        `raw nearest x ${index}`
+      );
+      assertClose(
+        tapeTest,
+        nearestY,
+        expectedNearest[index][1],
+        Math.abs(expectedNearest[index][1]) * 1e-12,
+        `raw nearest y ${index}`
+      );
     } else {
       assertClose(tapeTest, nearestX, expectedNearest[index][0], 2e-7, `raw nearest x ${index}`);
       assertClose(tapeTest, nearestY, expectedNearest[index][1], 2e-7, `raw nearest y ${index}`);
@@ -696,9 +737,19 @@ test('GPUPairwisePointLinestringNearest preserves raw-binary64 projection deltas
     0,
     NO_INDEX,
     0,
+    0,
+    0,
     0
   ]);
-  tapeTest.deepEqual(await readUint32(segmentIndexBuffer, points.length), [0, 0, NO_INDEX, 0, 0]);
+  tapeTest.deepEqual(await readUint32(segmentIndexBuffer, points.length), [
+    0,
+    0,
+    NO_INDEX,
+    0,
+    0,
+    0,
+    0
+  ]);
 
   compiled.destroy();
   for (const buffer of [
@@ -797,7 +848,10 @@ function assertClose(
   tolerance: number,
   message: string
 ): void {
-  tapeTest.ok(Math.abs(actual - expected) <= tolerance, message);
+  tapeTest.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `${message}: expected ${expected} ± ${tolerance}, received ${actual}`
+  );
 }
 
 function isSoftwareBackedDevice(device: Device): boolean {


### PR DESCRIPTION
## Goals

- Follow up on the nearest-linestring numerical reviews from #2882 and this PR.
- Preserve valid nearest points and distances across extreme point/segment scale ratios.

## Changes

- Construct projected displacements in power-of-two-normalized segment space instead of materializing potentially subnormal true fractions.
- Multiply normalized segment components before projection division so a large diagonal scalar cannot overflow before yielding representable coordinates.
- Classify the end from a scaled segment threshold, avoiding overflowed point-to-end deltas.
- Exponent-scale the shared precise hypotenuse helper at the top of the f32 range.
- Cover far-point/short-segment, long-diagonal, tiny-fraction, overflowed-end-delta, and near-end diagonal regressions in f32 and raw-binary64 paths.

## Verification

- nvm use
- yarn install
- yarn lint fix
- yarn build
- complete geospatial headless Chromium/WebGPU suite: 27 passed
- pre-commit Node suite: 382 passed, 2 skipped
- full local yarn test before refreshing the rebased dependency link: Node passed; headless completed 1,439 tests with five unrelated existing async/timing failures in engine, Arrow, reduction, and Volumetric Fire Forge tests
- GitHub CI is rerunning for the latest review-response commit