### PR TITLE
perf(ci): shard browser coverage across three runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,9 +62,14 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
 
-  test:
+  browser_coverage:
+    name: Browser coverage (${{ matrix.shard }}/3)
     runs-on: ubuntu-22.04
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -126,7 +131,7 @@ jobs:
 
       - name: Run headless tests and generate coverage
         run: |
-          yarn test-coverage
+          yarn test-coverage --shard=${{ matrix.shard }}/3
 
       - name: Report disk usage after coverage
         if: always()
@@ -135,6 +140,7 @@ jobs:
           du -sh . coverage "${HOME}/.yarn" "${HOME}/.cache/ms-playwright" "${RUNNER_TEMP}" 2>/dev/null || true
 
       - name: Run node tests
+        if: ${{ matrix.shard == 1 }}
         run: |
           yarn test-node
 
@@ -174,6 +180,30 @@ jobs:
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: browser-${{ matrix.shard }}
+          parallel: true
+
+  test:
+    needs: browser_coverage
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Finalize parallel coverage in Coveralls
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
+
+      - name: Verify all browser coverage shards passed
+        if: always()
+        env:
+          SHARD_RESULT: ${{ needs.browser_coverage.result }}
+        run: |
+          if [ "$SHARD_RESULT" != "success" ]; then
+            echo "::error::Browser coverage shards finished with status: $SHARD_RESULT"
+            exit 1
+          fi
 
   examples:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,12 +176,13 @@ jobs:
           fs.writeFileSync(coveragePath, `${records.join('\n')}\n`);
           NODE
 
-      - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+      - name: Upload browser coverage artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: browser-${{ matrix.shard }}
-          parallel: true
+          name: browser-coverage-lcov-${{ matrix.shard }}
+          path: coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 1
 
   test:
     needs: browser_coverage
@@ -189,11 +190,32 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
-      - name: Finalize parallel coverage in Coveralls
+      - name: Checkout code for coverage reporting
+        if: ${{ needs.browser_coverage.result == 'success' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download browser coverage artifacts
+        if: ${{ needs.browser_coverage.result == 'success' }}
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          pattern: browser-coverage-lcov-*
+          path: coverage/shards
+
+      - name: Merge browser coverage reports
+        if: ${{ needs.browser_coverage.result == 'success' }}
+        run: |
+          cat \
+            coverage/shards/browser-coverage-lcov-1/lcov.info \
+            coverage/shards/browser-coverage-lcov-2/lcov.info \
+            coverage/shards/browser-coverage-lcov-3/lcov.info \
+            > coverage/lcov.info
+
+      - name: Upload combined coverage to Coveralls
+        if: ${{ needs.browser_coverage.result == 'success' }}
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true
+          file: coverage/lcov.info
 
       - name: Verify all browser coverage shards passed
         if: always()


### PR DESCRIPTION
## Goals

Reduce the browser-test critical path after #2891 without dropping test files, weakening Chromium/GPU stability safeguards, or producing misleading partial-coverage checks.

The previous CI optimization reduced example typechecking from approximately **152 seconds to 12 seconds**, but browser coverage still took **472 seconds (7m52s)** within a **586-second (9m46s)** test job. This PR reduced the observed workflow time to approximately **4m18s**.

## Changes

### Run browser coverage across three independent runners

- Replace the single browser-test job with a three-entry GitHub Actions matrix: `1/3`, `2/3`, and `3/3`.
- Pass Vitest's native `--shard=<index>/3` option through the existing `yarn test-coverage` command.
- Verified that the current **279 eligible browser spec files partition into 93 + 93 + 93**, with no overlap and no missing tests.
- Leave `.ocularrc.js` unchanged: every runner still uses SwiftShader in CI and preserves `fileParallelism: false`, avoiding known instability from running multiple Chromium/WebGL/WebGPU files concurrently on the same machine.
- Set matrix `fail-fast: false`, and run the Node test suite only on shard 1.

### Publish one complete Coveralls report

- Upload each shard's sanitized `coverage/lcov.info` as a short-lived GitHub Actions artifact instead of submitting three separate flagged Coveralls builds.
- After all three shards succeed, download their artifacts, concatenate the LCOV reports, and submit **one ordinary unflagged Coveralls report** from the final `test` job.
- Coveralls combines repeated source-file records and sums line/branch hit counts, so this preserves complete cross-shard coverage rather than averaging partial shard percentages.
- Preserve Istanbul's product-source include list and zero-hit records, preventing coverage denominators from silently shrinking.
- Remove the confusing failing `Coveralls - browser-1`, `browser-2`, and `browser-3` checks; the intended result is one aggregate `coverage/coveralls` status.
- Do not use `carryforward`, which could incorrectly substitute stale coverage for failed or missing shards.

### Preserve the canonical CI status check

- Retain a final job named `test` so integrations and existing status-check expectations continue to see the same aggregate result.
- Only download, merge, and upload coverage when every browser shard succeeded; explicitly fail `test` when any shard failed.
- Keep immutable installs, coverage sanitization, dependency/browser caching, unaffected bundle-size/examples/website jobs, and SHA-pinned GitHub Actions.

## Verification

- `env -u YARN_NO_PROXY corepack yarn lint fix` — formatting and lint checks passed across **1,456 files**.
- Mandatory repository pre-commit `test-fast` check — **87 node test files passed, 385 tests passed, and two tests were skipped**.
- Reproduced Vitest's installed SHA-1-based shard sequencer: **279 unique browser files, 93 per shard, zero duplicates**.
- Verified the root Yarn command forwards `--shard` to Vitest.
- Ran a real two-shard Vitest/Istanbul fixture with three source files; concatenated LCOV produced the same aggregate result as Istanbul's native merge: **4/5 lines covered (80%) and 2/2 branches covered (100%)**, while preserving the untouched zero-hit source.
- Parsed the workflow and verified three shards, disabled fail-fast, one Node-test invocation, exactly one unflagged Coveralls upload, failure propagation through `test`, and immutable action SHAs.
- Confirmed CI settings remain `softwareGpu: true`, `fileParallelism: false`, and Istanbul coverage provider.

## Risks and rollout

- Three runners increase aggregate runner usage and repeat a small amount of setup/uncovered-file processing in exchange for a substantially shorter critical path.
- A successful run requires all three coverage artifacts; failed or missing shards keep the aggregate `test` job red and do not publish incomplete coverage.
- Coverage artifacts expire after one day.