### PR TITLE
fix(website): improve onboarding visibility and contain FP64 demo

### DIFF
--- a/examples/experimental/fp64/app.tsx
+++ b/examples/experimental/fp64/app.tsx
@@ -249,10 +249,13 @@ export default class App extends React.PureComponent<AppProps, AppState> {
     return (
       <div
         style={{
+          boxSizing: 'border-box',
           display: 'flex',
           flexDirection: 'column',
           gap: 20,
-          padding: 20
+          minWidth: 0,
+          padding: 20,
+          width: '100%'
         }}
       >
         {initializationError ? (
@@ -262,26 +265,28 @@ export default class App extends React.PureComponent<AppProps, AppState> {
         <div
           style={{
             display: 'grid',
-            gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-            gridTemplateRows: 'auto auto',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 320px), 1fr))',
             gap: 20,
-            alignItems: 'start'
+            alignItems: 'start',
+            minWidth: 0
           }}
         >
-          {visualizationSpecs.map(visualization => (
-            <ExamplePaneCopy
-              description={visualization.description}
-              key={`${visualization.kind}-copy`}
-              title={visualization.title}
-            />
-          ))}
-          {this.canvasRefs.map((canvasRef, index) => (
-            <ExamplePaneCanvas
-              canvasRef={canvasRef}
-              isReady={isReady}
-              key={`${visualizationSpecs[index].kind}-canvas`}
-              overlayLines={overlayLines}
-            />
+          {visualizationSpecs.map((visualization, index) => (
+            <div
+              data-fp64-visualization={visualization.kind}
+              key={visualization.kind}
+              style={{display: 'grid', gap: 12, minWidth: 0}}
+            >
+              <ExamplePaneCopy
+                description={visualization.description}
+                title={visualization.title}
+              />
+              <ExamplePaneCanvas
+                canvasRef={this.canvasRefs[index]}
+                isReady={isReady}
+                overlayLines={overlayLines}
+              />
+            </div>
           ))}
         </div>
         <FP64BenchmarkPanel
@@ -690,6 +695,8 @@ function ExamplePaneCanvas(props: {
         width={CANVAS_WIDTH}
         height={CANVAS_HEIGHT}
         style={{
+          boxSizing: 'border-box',
+          display: 'block',
           width: '100%',
           height: 'auto',
           aspectRatio: `${CANVAS_WIDTH} / ${CANVAS_HEIGHT}`,
@@ -702,7 +709,10 @@ function ExamplePaneCanvas(props: {
         style={{
           position: 'absolute',
           left: 12,
+          right: 12,
           bottom: 12,
+          boxSizing: 'border-box',
+          maxWidth: 'calc(100% - 24px)',
           padding: '8px 10px',
           background: 'rgba(0, 0, 0, 0.68)',
           color: '#fff',
@@ -710,6 +720,7 @@ function ExamplePaneCanvas(props: {
           fontSize: 12,
           lineHeight: 1.45,
           borderRadius: 8,
+          overflowWrap: 'anywhere',
           pointerEvents: 'none'
         }}
       >
@@ -769,7 +780,14 @@ function FP64BenchmarkPanel(props: {
           {isRunning ? 'Running benchmark…' : 'Run WebGPU benchmark'}
         </button>
       </div>
-      <p style={{margin: '12px 0 0', fontFamily: 'monospace', fontSize: 12}}>
+      <p
+        style={{
+          margin: '12px 0 0',
+          fontFamily: 'monospace',
+          fontSize: 12,
+          overflowWrap: 'anywhere'
+        }}
+      >
         {device
           ? `device = ${getBenchmarkDeviceLabel(device)} · automatic = ${automaticSelection}`
           : 'device = initializing'}

--- a/test/examples/fp64-responsive-layout.node.spec.ts
+++ b/test/examples/fp64-responsive-layout.node.spec.ts
@@ -1,0 +1,35 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import React from 'react';
+import {renderToStaticMarkup} from 'react-dom/server';
+import {describe, expect, test} from 'vitest';
+import FP64App from '../../examples/experimental/fp64/app';
+
+describe('FP64 example responsive layout', () => {
+  test('keeps each precision description paired with its canvas when the panes stack', () => {
+    const markup = renderToStaticMarkup(React.createElement(FP64App));
+    const singlePrecisionPane = markup.indexOf('data-fp64-visualization="fp32"');
+    const singlePrecisionCanvas = markup.indexOf('<canvas', singlePrecisionPane);
+    const doublePrecisionPane = markup.indexOf('data-fp64-visualization="fp64"');
+    const doublePrecisionCanvas = markup.indexOf('<canvas', doublePrecisionPane);
+
+    expect(markup).toContain(
+      'grid-template-columns:repeat(auto-fit, minmax(min(100%, 320px), 1fr))'
+    );
+    expect(singlePrecisionPane).toBeGreaterThanOrEqual(0);
+    expect(singlePrecisionCanvas).toBeGreaterThan(singlePrecisionPane);
+    expect(doublePrecisionPane).toBeGreaterThan(singlePrecisionCanvas);
+    expect(doublePrecisionCanvas).toBeGreaterThan(doublePrecisionPane);
+  });
+
+  test('contains bordered canvases, telemetry overlays, and benchmark metadata', () => {
+    const markup = renderToStaticMarkup(React.createElement(FP64App));
+
+    expect(markup).toContain('box-sizing:border-box;display:block;width:100%');
+    expect(markup).toContain('left:12px;right:12px;bottom:12px;box-sizing:border-box');
+    expect(markup).toContain('max-width:calc(100% - 24px)');
+    expect(markup.match(/overflow-wrap:anywhere/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/test/examples/homepage-navigation.node.spec.ts
+++ b/test/examples/homepage-navigation.node.spec.ts
@@ -1,0 +1,149 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {existsSync, readFileSync} from 'node:fs';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+type ExampleSidebarEntry =
+  | string
+  | {type: 'doc'; id: string; label?: string}
+  | {type: 'category'; label: string; items: ExampleSidebarEntry[]};
+
+const HOMEPAGE_SOURCE_PATH = path.join(process.cwd(), 'website/src/pages/index.jsx');
+const HOMEPAGE_STYLES_PATH = path.join(process.cwd(), 'website/src/pages/index.module.css');
+const EXAMPLE_CARD_SOURCE_PATH = path.join(
+  process.cwd(),
+  'website/src/components/example-card.tsx'
+);
+const EXAMPLE_CONTENT_DIRECTORY = path.join(process.cwd(), 'website/content/examples');
+const MINIMUM_PRIMARY_ACTION_CONTRAST = 7;
+
+describe('homepage navigation', () => {
+  test('routes both getting-started actions to the canonical, base-aware documentation page', () => {
+    const homepageSource = readFileSync(HOMEPAGE_SOURCE_PATH, 'utf8');
+
+    expect(homepageSource).toMatch(
+      /const\s+gettingStartedUrl\s*=\s*useBaseUrl\(\s*['"]\/docs\/getting-started['"]\s*\)/
+    );
+    expect(existsSync(path.join(process.cwd(), 'docs/getting-started.mdx'))).toBe(true);
+
+    const gettingStartedActions = Array.from(
+      homepageSource.matchAll(
+        /<(?:a|Link)\b(?=[^>]*\bclassName=\{styles\.(primaryAction|closingAction)\})(?=[^>]*\b(?:href|to)=\{gettingStartedUrl\})[^>]*>/g
+      ),
+      match => match[1]
+    );
+
+    expect(gettingStartedActions).toEqual(['primaryAction', 'closingAction']);
+  });
+
+  test('links every featured example card to a real catalog entry and documentation route', () => {
+    const homepageSource = readFileSync(HOMEPAGE_SOURCE_PATH, 'utf8');
+    const exampleCardSource = readFileSync(EXAMPLE_CARD_SOURCE_PATH, 'utf8');
+    const featuredExamples = homepageSource.match(
+      /const\s+FEATURED_EXAMPLES\s*=\s*\[([\s\S]*?)\n\];/
+    );
+
+    expect(featuredExamples).not.toBeNull();
+
+    const featuredExampleRoutes = Array.from(
+      featuredExamples![1].matchAll(/\broute:\s*['"]([^'"]+)['"]/g),
+      match => match[1]
+    );
+    const exampleIdentifiers = readLiveExampleIdentifiers();
+
+    expect(featuredExampleRoutes.length).toBeGreaterThan(0);
+    expect(homepageSource).toMatch(
+      /<ExampleCard\b[\s\S]*?\bhref=\{\s*`\$\{examplesUrl\}\/\$\{example\.route\}`\s*\}/
+    );
+    expect(exampleCardSource).toMatch(/<(?:a|Link)\b(?=[^>]*\b(?:href|to)=\{href\})[^>]*>/);
+
+    for (const featuredExampleRoute of featuredExampleRoutes) {
+      expect(
+        exampleIdentifiers.has(featuredExampleRoute),
+        `${featuredExampleRoute} must remain in the authoritative example catalog`
+      ).toBe(true);
+      expect(
+        existsSync(path.join(EXAMPLE_CONTENT_DIRECTORY, `${featuredExampleRoute}.mdx`)),
+        `${featuredExampleRoute} must resolve to an existing example documentation page`
+      ).toBe(true);
+    }
+  });
+
+  test('maintains WCAG AAA foreground contrast for normal and highlighted primary actions', () => {
+    const homepageStyles = readFileSync(HOMEPAGE_STYLES_PATH, 'utf8');
+    const normalActionRule = homepageStyles.match(/\.primaryAction\s*\{([^}]*)\}/);
+    const highlightedActionRule = homepageStyles.match(
+      /\.primaryAction:hover\s*,\s*\.primaryAction:focus-visible\s*\{([^}]*)\}/
+    );
+
+    expect(normalActionRule).not.toBeNull();
+    expect(highlightedActionRule).not.toBeNull();
+
+    const normalForeground = readHexColorDeclaration(normalActionRule![1], 'color');
+    const normalBackground = readHexColorDeclaration(normalActionRule![1], 'background');
+    const highlightedForeground = readHexColorDeclaration(highlightedActionRule![1], 'color');
+    const highlightedBackground = readHexColorDeclaration(highlightedActionRule![1], 'background');
+
+    expect(
+      getContrastRatio(normalForeground, normalBackground),
+      'The primary homepage action must meet WCAG AAA contrast while resting'
+    ).toBeGreaterThanOrEqual(MINIMUM_PRIMARY_ACTION_CONTRAST);
+    expect(
+      getContrastRatio(highlightedForeground, highlightedBackground),
+      'The primary homepage action must meet WCAG AAA contrast while hovered or focused'
+    ).toBeGreaterThanOrEqual(MINIMUM_PRIMARY_ACTION_CONTRAST);
+  });
+});
+
+function readLiveExampleIdentifiers(): Set<string> {
+  const tableOfContents = JSON.parse(
+    readFileSync(path.join(EXAMPLE_CONTENT_DIRECTORY, 'table-of-contents.json'), 'utf8')
+  ) as ExampleSidebarEntry[];
+  const exampleIdentifiers = new Set<string>();
+
+  const visitEntries = (entries: ExampleSidebarEntry[]): void => {
+    for (const entry of entries) {
+      if (typeof entry === 'string') {
+        exampleIdentifiers.add(entry);
+      } else if (entry.type === 'category') {
+        visitEntries(entry.items);
+      } else if (entry.id !== 'index') {
+        exampleIdentifiers.add(entry.id);
+      }
+    }
+  };
+
+  visitEntries(tableOfContents);
+  return exampleIdentifiers;
+}
+
+function readHexColorDeclaration(styleRule: string, property: 'background' | 'color'): string {
+  const declaration = styleRule.match(
+    new RegExp(`(?:^|;)\\s*${property}\\s*:\\s*(#[a-fA-F\\d]{6})\\s*(?:;|$)`)
+  );
+
+  expect(declaration, `The primary action must define an opaque ${property} color`).not.toBeNull();
+  return declaration![1];
+}
+
+function getContrastRatio(foreground: string, background: string): number {
+  const foregroundLuminance = getRelativeLuminance(foreground);
+  const backgroundLuminance = getRelativeLuminance(background);
+  const lighterLuminance = Math.max(foregroundLuminance, backgroundLuminance);
+  const darkerLuminance = Math.min(foregroundLuminance, backgroundLuminance);
+
+  return (lighterLuminance + 0.05) / (darkerLuminance + 0.05);
+}
+
+function getRelativeLuminance(color: string): number {
+  const channels = [1, 3, 5].map(offset => {
+    const channel = Number.parseInt(color.slice(offset, offset + 2), 16) / 255;
+
+    return channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+  });
+
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -144,7 +144,7 @@ if (typeof window !== 'undefined') {
 export default function IndexPage() {
   const {siteConfig} = useDocusaurusContext();
   const baseUrl = useBaseUrl('/');
-  const gettingStartedUrl = `${baseUrl}docs/developer-guide/installing`;
+  const gettingStartedUrl = useBaseUrl('/docs/getting-started');
   const examplesUrl = `${baseUrl}examples`;
 
   return (

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -139,15 +139,18 @@
 }
 
 .primaryAction {
-  background: #7dd3fc;
-  color: #082033;
+  border-color: #fff;
+  background: #f8fafc;
+  box-shadow: 0 8px 26px rgba(56, 189, 248, 0.22);
+  color: #071625;
+  font-weight: 750;
 }
 
 .primaryAction:hover,
 .primaryAction:focus-visible {
-  background: #a5f3fc;
-  box-shadow: 0 0 24px rgba(103, 232, 249, 0.27);
-  color: #082033;
+  background: #cffafe;
+  box-shadow: 0 0 28px rgba(103, 232, 249, 0.4);
+  color: #071625;
   text-decoration: none;
   transform: translateY(-2px);
 }


### PR DESCRIPTION
## Goals

Make the flagship homepage’s primary action unmistakable and direct newcomers to the real Getting Started guide, while keeping the FP64 comparison demo completely inside its available example viewport.

## Changes

- Route both **Get started** and **Start building** to the canonical, base-aware `/docs/getting-started` guide instead of the legacy developer-installation page.
- Increase the hero action’s visible emphasis and text contrast from **9.96:1 to 17.45:1**; its hover/focus state remains **16.30:1**, comfortably above WCAG AAA.
- Confirm that all eight featured example cards are real, working links; add a regression ensuring each destination remains in the authoritative catalog and resolves to a real documentation page.
- Replace FP64’s fixed two-column grid with responsive, auto-fitting precision panes while keeping each explanation paired with its corresponding FP32/FP64 canvas.
- Keep the demo root and bordered canvases within their containers using border-box sizing and shrinkable grid items.
- Constrain and wrap FP64 telemetry overlays and benchmark adapter metadata so long numeric values cannot escape the browser or containing card.
- Preserve existing GPU precision, iteration budgets, and rendering fidelity.

## Root cause

The reported dead links were reproduced against a stopped local server rather than a navigation bug; real browser clicks work correctly when the website is running. The onboarding CTA did target the wrong, legacy documentation page. FP64 independently had a genuine deterministic layout defect: a permanent two-column grid, full-width bordered canvases, and unbounded absolutely positioned telemetry.

## Verification

- Full production website build: `env -u YARN_NO_PROXY yarn website:build` — passed; standalone ANARI, Docusaurus, search, and **455 documentation pages** built successfully.
- `env -u YARN_NO_PROXY yarn lint fix` — passed.
- `env -u YARN_NO_PROXY yarn test-node` — **390 passed; 2 skipped**.
- Focused homepage + FP64 regressions — **5 passed**.
- Real-browser click verification:
  - **Get started** → `/docs/getting-started`, title **Getting Started | luma.gl**.
  - First featured card → `/examples/showcase/lightstorm-megacity`.
  - Primary action computed colors: `rgb(7, 22, 37)` on `rgb(248, 250, 252)`.
- Local rebuilt website available at `http://127.0.0.1:5191/`.

Part of Project Flagship; ANARI Playground styling remains unchanged.