### PR TITLE
fix(luproj): enforce exact bounds and benchmark CPU versus GPU

### DIFF
--- a/modules/experimental/package.json
+++ b/modules/experimental/package.json
@@ -41,6 +41,11 @@
       "import": "./dist/luproj/index.js",
       "require": "./dist/luproj/index.cjs",
       "types": "./dist/luproj/index.d.ts"
+    },
+    "./luproj/benchmarks": {
+      "import": "./dist/luproj/benchmarks.js",
+      "require": "./dist/luproj/benchmarks.cjs",
+      "types": "./dist/luproj/benchmarks.d.ts"
     }
   },
   "files": [

--- a/modules/experimental/src/luproj/README.md
+++ b/modules/experimental/src/luproj/README.md
@@ -144,8 +144,64 @@ repacks application-owned vectors.
 `GPUProjection.updatePlan(nextPlan)` updates an equally sized packed plan
 without recompiling the surrounding command graph. Call
 `GPUProjection.destroy()` when the contributor is no longer needed; only its
-privately allocated plan storage is destroyed, never caller-owned source,
-destination, or explicitly supplied `planBuffer` storage.
+privately allocated plan and exact-boundary storage are destroyed, never
+caller-owned source, destination, or explicitly supplied `planBuffer` storage.
+
+The complete source domain is checked exactly before patch lookup. Interior
+patch seams retain a small Float32 normalization tolerance, but rows outside
+the active binary64 plan bounds always receive the documented `[0, 0]`
+sentinel.
+
+## Benchmark CPU and GPU projection paths
+
+The optional benchmark helpers compare the same deterministic source rows and
+report nearest-rank timing distributions in milliseconds plus coordinates per
+second:
+
+```ts
+import {createWebMercatorProjection} from '@luma.gl/experimental/luproj';
+import {
+  runGPUProjectionBenchmark,
+  runProjectionBenchmark
+} from '@luma.gl/experimental/luproj/benchmarks';
+
+const options = {
+  projection: createWebMercatorProjection(),
+  bounds: [-123, 37, -122, 38] as const,
+  degree: 2 as const,
+  tolerance: 0.03,
+  coordinateCount: 16_384,
+  warmupIterations: 2,
+  measuredIterations: 5
+};
+
+const cpuReport = runProjectionBenchmark(options);
+const gpuReport = await runGPUProjectionBenchmark(device, options);
+```
+
+The isolated `/benchmarks` entry point keeps benchmark infrastructure out of the
+normal `luproj` bundle. The CPU report measures plan compilation, direct provider
+calls, automatic patch scans, and preassigned patch IDs. The GPU report includes those same CPU
+baselines plus `float32x2` and raw binary64 `uint32x4` inputs, each with both
+patch-selection strategies. Each measured GPU dispatch waits for a device
+fence; its synchronized throughput includes submission and completion but
+excludes graph setup, position uploads, result validation, and readback. Devices
+supporting `timestamp-query` also report compute-pass-only timing and throughput.
+
+Every GPU path reports `synchronizedSpeedupOverCPUProvider`, comparing its
+end-to-end synchronized throughput with direct CPU projection. Timestamp-enabled
+paths also report `gpuSpeedupOverCPUProvider` for compute-pass-only throughput.
+Float32 paths are validated against their actual rounded source positions;
+raw binary64 paths and the shared CPU baseline retain their original coordinates.
+
+The reproducible browser benchmark can also be run from the repository root;
+the environment variable selects a representative dataset while ordinary CI
+uses a small smoke-test dataset:
+
+```sh
+VITE_LUPROJ_BENCHMARK_ROWS=16384 yarn test-headless \
+  modules/experimental/test/luproj/projection-benchmark.spec.ts --reporter=verbose
+```
 
 ## Accuracy boundaries
 

--- a/modules/experimental/src/luproj/benchmarks.ts
+++ b/modules/experimental/src/luproj/benchmarks.ts
@@ -1,0 +1,20 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {runProjectionBenchmark} from './projection-benchmark';
+export type {
+  ProjectionBenchmarkDistribution,
+  ProjectionBenchmarkOptions,
+  ProjectionBenchmarkPathReport,
+  ProjectionBenchmarkReport,
+  ProjectionBenchmarkStrategy
+} from './projection-benchmark';
+
+export {runGPUProjectionBenchmark} from './gpu-projection-benchmark';
+export type {
+  GPUProjectionBenchmarkInputFormat,
+  GPUProjectionBenchmarkPatchStrategy,
+  GPUProjectionBenchmarkPathReport,
+  GPUProjectionBenchmarkReport
+} from './gpu-projection-benchmark';

--- a/modules/experimental/src/luproj/gpu-projection-benchmark.ts
+++ b/modules/experimental/src/luproj/gpu-projection-benchmark.ts
@@ -1,0 +1,397 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device, type QuerySet} from '@luma.gl/core';
+
+import {
+  GPUCommandGraph,
+  type CompiledGPUCommandGraph,
+  type GPUCommandGraphTimingReport
+} from '../gpu-primitives/gpu-command-graph';
+import {GPUProjection} from './gpu-projection';
+import {
+  getProjectionBenchmarkThroughput,
+  getProjectionBenchmarkTime,
+  prepareProjectionBenchmark,
+  summarizeProjectionBenchmarkSamples,
+  type ProjectionBenchmarkContext,
+  type ProjectionBenchmarkDistribution,
+  type ProjectionBenchmarkOptions,
+  type ProjectionBenchmarkReport
+} from './projection-benchmark';
+import {findProjectionPatch, PROJECTION_PATCH_WORD_LENGTH} from './projection-plan';
+
+/** Physical coordinate representation evaluated by the GPU benchmark. */
+export type GPUProjectionBenchmarkInputFormat = 'float32x2' | 'uint32x4';
+
+/** Whether source rows discover their patch or consume source-aligned patch IDs. */
+export type GPUProjectionBenchmarkPatchStrategy = 'scan' | 'patch-ids';
+
+/** Correctness-gated memory, throughput, and timing results for one WebGPU execution path. */
+export type GPUProjectionBenchmarkPathReport = {
+  inputFormat: GPUProjectionBenchmarkInputFormat;
+  patchStrategy: GPUProjectionBenchmarkPatchStrategy;
+  memoryByteLength: number;
+  maxError: number;
+  cpuEncodeTimeMilliseconds: ProjectionBenchmarkDistribution;
+  /** Queue submission through fence completion, excluding uploads, validation, and readback. */
+  synchronizedTimeMilliseconds: ProjectionBenchmarkDistribution;
+  synchronizedCoordinatesPerSecond: number;
+  /** End-to-end synchronized throughput divided by direct CPU-provider throughput. */
+  synchronizedSpeedupOverCPUProvider: number;
+  /** Compute-pass duration and throughput when the device exposes timestamp-query. */
+  gpuTimeMilliseconds?: ProjectionBenchmarkDistribution;
+  gpuCoordinatesPerSecond?: number;
+  /** Compute-pass-only throughput divided by direct CPU-provider throughput. */
+  gpuSpeedupOverCPUProvider?: number;
+};
+
+/** Shared CPU baselines plus all float32/binary64 and scan/explicit-patch WebGPU paths. */
+export type GPUProjectionBenchmarkReport = {
+  cpu: ProjectionBenchmarkReport;
+  timestampQueries: boolean;
+  paths: GPUProjectionBenchmarkPathReport[];
+};
+
+type ProjectionBenchmarkGPUPath = {
+  inputFormat: GPUProjectionBenchmarkInputFormat;
+  patchStrategy: GPUProjectionBenchmarkPatchStrategy;
+};
+
+type ProjectionBenchmarkGPUExecution = {
+  timing: GPUCommandGraphTimingReport;
+  synchronizedTimeMilliseconds: number;
+};
+
+const BENCHMARK_GPU_PATHS: readonly ProjectionBenchmarkGPUPath[] = [
+  {inputFormat: 'float32x2', patchStrategy: 'scan'},
+  {inputFormat: 'float32x2', patchStrategy: 'patch-ids'},
+  {inputFormat: 'uint32x4', patchStrategy: 'scan'},
+  {inputFormat: 'uint32x4', patchStrategy: 'patch-ids'}
+];
+
+/**
+ * Compares CPU baselines with four real WebGPU coordinate-reprojection implementations.
+ *
+ * Position upload, graph compilation, correctness readback, and timestamp-query readback stay
+ * outside measured intervals. Every measured GPU submission waits for a portable device fence,
+ * preventing asynchronous command-queue submission from being mistaken for GPU throughput.
+ * Float32 paths are validated against their actual rounded source positions, while raw binary64
+ * paths retain the original JavaScript coordinates.
+ */
+export async function runGPUProjectionBenchmark(
+  device: Device,
+  options: ProjectionBenchmarkOptions
+): Promise<GPUProjectionBenchmarkReport> {
+  const context = prepareProjectionBenchmark(options);
+  const paths: GPUProjectionBenchmarkPathReport[] = [];
+
+  for (const path of BENCHMARK_GPU_PATHS) {
+    paths.push(await measureGPUProjectionBenchmarkPath(device, options, context, path));
+  }
+
+  return {
+    cpu: context.report,
+    timestampQueries: device.features.has('timestamp-query'),
+    paths
+  };
+}
+
+async function measureGPUProjectionBenchmarkPath(
+  device: Device,
+  options: ProjectionBenchmarkOptions,
+  context: ProjectionBenchmarkContext,
+  path: ProjectionBenchmarkGPUPath
+): Promise<GPUProjectionBenchmarkPathReport> {
+  const identifier = `projection-benchmark-${path.inputFormat}-${path.patchStrategy}`;
+  const coordinates = createGPUProjectionBenchmarkCoordinates(context, path.inputFormat);
+  const patchIds =
+    path.inputFormat === 'uint32x4'
+      ? context.patchIds
+      : Uint32Array.from(coordinates, coordinate => findProjectionPatch(context.plan, coordinate));
+  const sourceData = createGPUProjectionBenchmarkSource(coordinates, path.inputFormat);
+  const sourceBuffer = device.createBuffer({
+    id: `${identifier}-positions`,
+    data: sourceData,
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  let outputBuffer: Buffer | undefined;
+  let patchIdBuffer: Buffer | undefined;
+  let contributor: GPUProjection | undefined;
+  let compiled: CompiledGPUCommandGraph<void> | undefined;
+
+  try {
+    outputBuffer = device.createBuffer({
+      id: `${identifier}-output`,
+      byteLength: coordinates.length * 2 * Float32Array.BYTES_PER_ELEMENT,
+      usage: Buffer.STORAGE | Buffer.COPY_SRC
+    });
+    const graph = new GPUCommandGraph(device, {id: identifier});
+    const sourceHandle = graph.importBuffer(
+      {
+        id: `${identifier}-positions`,
+        byteLength: sourceBuffer.byteLength,
+        usage: sourceBuffer.usage
+      },
+      sourceBuffer
+    );
+    const outputHandle = graph.importBuffer(
+      {id: `${identifier}-output`, byteLength: outputBuffer.byteLength, usage: outputBuffer.usage},
+      outputBuffer
+    );
+    const positionView =
+      path.inputFormat === 'float32x2'
+        ? graph.createDataView(sourceHandle, {format: 'float32x2', length: coordinates.length})
+        : graph.createDataView(sourceHandle, {format: 'uint32x4', length: coordinates.length});
+    const outputView = graph.createDataView(outputHandle, {
+      format: 'float32x2',
+      length: coordinates.length
+    });
+
+    if (path.patchStrategy === 'patch-ids') {
+      patchIdBuffer = device.createBuffer({
+        id: `${identifier}-patch-ids`,
+        data: patchIds,
+        usage: Buffer.STORAGE | Buffer.COPY_DST
+      });
+    }
+    const patchIdView = patchIdBuffer
+      ? graph.createDataView(
+          graph.importBuffer(
+            {
+              id: `${identifier}-patch-ids`,
+              byteLength: patchIdBuffer.byteLength,
+              usage: patchIdBuffer.usage
+            },
+            patchIdBuffer
+          ),
+          {format: 'uint32', length: coordinates.length}
+        )
+      : undefined;
+
+    contributor = new GPUProjection({
+      id: identifier,
+      positions: positionView,
+      output: outputView,
+      plan: context.plan,
+      ...(patchIdView ? {patchIds: patchIdView} : {})
+    });
+    contributor.addToGraph(graph);
+    compiled = graph.compile();
+
+    // A complete correctness pass precedes warmups so invalid implementations never report speed.
+    await executeGPUProjectionBenchmark(device, compiled, `${identifier}-validation`);
+    let maxError = await validateGPUProjectionBenchmarkOutput(
+      outputBuffer,
+      options,
+      context,
+      coordinates
+    );
+    for (let iteration = 0; iteration < context.report.warmupIterations; iteration++) {
+      await executeGPUProjectionBenchmark(device, compiled, `${identifier}-warmup-${iteration}`);
+    }
+
+    const executions: ProjectionBenchmarkGPUExecution[] = [];
+    for (let iteration = 0; iteration < context.report.measuredIterations; iteration++) {
+      const querySet = device.features.has('timestamp-query')
+        ? device.createQuerySet({
+            id: `${identifier}-timestamps-${iteration}`,
+            type: 'timestamp',
+            count: 2
+          })
+        : undefined;
+      try {
+        executions.push(
+          await executeGPUProjectionBenchmark(
+            device,
+            compiled,
+            `${identifier}-measured-${iteration}`,
+            querySet
+          )
+        );
+      } finally {
+        querySet?.destroy();
+      }
+    }
+    maxError = Math.max(
+      maxError,
+      await validateGPUProjectionBenchmarkOutput(outputBuffer, options, context, coordinates)
+    );
+
+    const synchronizedTimeMilliseconds = summarizeProjectionBenchmarkSamples(
+      executions.map(execution => execution.synchronizedTimeMilliseconds)
+    );
+    const gpuSamples = executions.flatMap(execution =>
+      execution.timing.gpuTimeMilliseconds === undefined
+        ? []
+        : [execution.timing.gpuTimeMilliseconds]
+    );
+    const gpuTimeMilliseconds =
+      gpuSamples.length > 0 ? summarizeProjectionBenchmarkSamples(gpuSamples) : undefined;
+    const providerCoordinatesPerSecond = context.report.paths[0].coordinatesPerSecond;
+    const synchronizedCoordinatesPerSecond = getProjectionBenchmarkThroughput(
+      coordinates.length,
+      synchronizedTimeMilliseconds.median
+    );
+    const gpuCoordinatesPerSecond = gpuTimeMilliseconds
+      ? getProjectionBenchmarkThroughput(coordinates.length, gpuTimeMilliseconds.median)
+      : undefined;
+
+    return {
+      inputFormat: path.inputFormat,
+      patchStrategy: path.patchStrategy,
+      memoryByteLength:
+        sourceBuffer.byteLength +
+        outputBuffer.byteLength +
+        (patchIdBuffer?.byteLength ?? 0) +
+        context.plan.patches.length * PROJECTION_PATCH_WORD_LENGTH * Uint32Array.BYTES_PER_ELEMENT +
+        4 * Float64Array.BYTES_PER_ELEMENT,
+      maxError,
+      cpuEncodeTimeMilliseconds: summarizeProjectionBenchmarkSamples(
+        executions.map(execution => execution.timing.cpuEncodeTimeMilliseconds)
+      ),
+      synchronizedTimeMilliseconds,
+      synchronizedCoordinatesPerSecond,
+      synchronizedSpeedupOverCPUProvider:
+        synchronizedCoordinatesPerSecond / providerCoordinatesPerSecond,
+      ...(gpuTimeMilliseconds && gpuCoordinatesPerSecond !== undefined
+        ? {
+            gpuTimeMilliseconds,
+            gpuCoordinatesPerSecond,
+            gpuSpeedupOverCPUProvider: gpuCoordinatesPerSecond / providerCoordinatesPerSecond
+          }
+        : {})
+    };
+  } finally {
+    compiled?.destroy();
+    contributor?.destroy();
+    patchIdBuffer?.destroy();
+    outputBuffer?.destroy();
+    sourceBuffer.destroy();
+  }
+}
+
+async function executeGPUProjectionBenchmark(
+  device: Device,
+  compiled: CompiledGPUCommandGraph<void>,
+  identifier: string,
+  querySet?: QuerySet
+): Promise<ProjectionBenchmarkGPUExecution> {
+  const commandEncoder = device.createCommandEncoder({
+    id: identifier,
+    ...(querySet ? {timeProfilingQuerySet: querySet} : {})
+  });
+  let submitted = false;
+
+  try {
+    const encoding = compiled.encode(commandEncoder, {parameters: undefined});
+    const startTime = getProjectionBenchmarkTime();
+    device.submit(commandEncoder.finish());
+    submitted = true;
+    const fence = device.createFence();
+    try {
+      await fence.signaled;
+    } finally {
+      fence.destroy();
+    }
+    const synchronizedTimeMilliseconds = getProjectionBenchmarkTime() - startTime;
+    const timing = await encoding.readTimings();
+    return {timing, synchronizedTimeMilliseconds};
+  } catch (error) {
+    if (!submitted) commandEncoder.destroy();
+    throw error;
+  }
+}
+
+function createGPUProjectionBenchmarkCoordinates(
+  context: ProjectionBenchmarkContext,
+  inputFormat: GPUProjectionBenchmarkInputFormat
+): [number, number][] {
+  if (inputFormat === 'uint32x4') return context.coordinates;
+  const [minimumX, minimumY, maximumX, maximumY] = context.plan.bounds;
+  return context.coordinates.map(coordinates => [
+    getBoundedFloat32BenchmarkCoordinate(coordinates[0], minimumX, maximumX),
+    getBoundedFloat32BenchmarkCoordinate(coordinates[1], minimumY, maximumY)
+  ]);
+}
+
+function getBoundedFloat32BenchmarkCoordinate(
+  value: number,
+  minimum: number,
+  maximum: number
+): number {
+  let rounded = Math.fround(value);
+  if (rounded < minimum) rounded = stepFloat32BenchmarkCoordinate(rounded, 1);
+  if (rounded > maximum) rounded = stepFloat32BenchmarkCoordinate(rounded, -1);
+  if (!Number.isFinite(rounded) || rounded < minimum || rounded > maximum) {
+    throw new Error('projection benchmark bounds contain no representable float32 coordinates');
+  }
+  return rounded;
+}
+
+function stepFloat32BenchmarkCoordinate(value: number, direction: 1 | -1): number {
+  if (value === 0) return direction * 2 ** -149;
+  const values = new Float32Array([value]);
+  const words = new Uint32Array(values.buffer);
+  words[0] += value > 0 === direction > 0 ? 1 : -1;
+  return values[0];
+}
+
+function createGPUProjectionBenchmarkSource(
+  coordinates: readonly [number, number][],
+  inputFormat: GPUProjectionBenchmarkInputFormat
+): Float32Array | Uint32Array {
+  if (inputFormat === 'float32x2') {
+    const values = new Float32Array(coordinates.length * 2);
+    for (let coordinateIndex = 0; coordinateIndex < coordinates.length; coordinateIndex++) {
+      values[coordinateIndex * 2] = coordinates[coordinateIndex][0];
+      values[coordinateIndex * 2 + 1] = coordinates[coordinateIndex][1];
+    }
+    return values;
+  }
+
+  const values = new Float64Array(coordinates.length * 2);
+  for (let coordinateIndex = 0; coordinateIndex < coordinates.length; coordinateIndex++) {
+    values[coordinateIndex * 2] = coordinates[coordinateIndex][0];
+    values[coordinateIndex * 2 + 1] = coordinates[coordinateIndex][1];
+  }
+  return new Uint32Array(values.buffer);
+}
+
+async function validateGPUProjectionBenchmarkOutput(
+  outputBuffer: Buffer,
+  options: ProjectionBenchmarkOptions,
+  context: ProjectionBenchmarkContext,
+  coordinates: readonly [number, number][]
+): Promise<number> {
+  const outputBytes = await outputBuffer.readAsync();
+  const outputValues = new Float32Array(
+    outputBytes.buffer,
+    outputBytes.byteOffset,
+    coordinates.length * 2
+  );
+  const provider =
+    typeof options.projection === 'function'
+      ? options.projection
+      : options.projection.project.bind(options.projection);
+  let maxError = 0;
+
+  for (let coordinateIndex = 0; coordinateIndex < coordinates.length; coordinateIndex++) {
+    const projected = provider([...coordinates[coordinateIndex]]);
+    const expectedX = projected[0] - context.plan.destinationOrigin[0];
+    const expectedY = projected[1] - context.plan.destinationOrigin[1];
+    const error = Math.hypot(
+      outputValues[coordinateIndex * 2] - expectedX,
+      outputValues[coordinateIndex * 2 + 1] - expectedY
+    );
+    const roundingAllowance =
+      Math.max(Math.abs(expectedX), Math.abs(expectedY), 1) * 2 ** -21 + 1e-7;
+    if (!Number.isFinite(error) || error > context.plan.tolerance + roundingAllowance) {
+      throw new Error('GPU projection benchmark output does not match its shared CPU oracle');
+    }
+    maxError = Math.max(maxError, error);
+  }
+
+  return maxError;
+}

--- a/modules/experimental/src/luproj/gpu-projection.ts
+++ b/modules/experimental/src/luproj/gpu-projection.ts
@@ -76,6 +76,7 @@ export class GPUProjection implements GPUCommandGraphContributor {
 
   private projectionPlan: ProjectionPlan;
   private ownedPlanBuffer?: Buffer;
+  private ownedBoundsBuffer?: Buffer;
   private hasRegisteredGraph = false;
   private destroyed = false;
 
@@ -143,6 +144,7 @@ export class GPUProjection implements GPUCommandGraphContributor {
       }
       externalBuffer.write(packedPlan, this.planBuffer.byteOffset);
     }
+    this.ownedBoundsBuffer?.write(packProjectionBounds(plan));
     this.projectionPlan = plan;
   }
 
@@ -165,6 +167,7 @@ export class GPUProjection implements GPUCommandGraphContributor {
     }
 
     const planView = this.planBuffer ?? this.createOwnedPlanView(graph);
+    const boundsView = this.createOwnedBoundsView(graph);
     const inputChunks = getRowChunks(this.positions);
     const outputChunks = getRowChunks(this.output);
     const patchIdChunks = this.patchIds ? getRowChunks(this.patchIds) : undefined;
@@ -179,18 +182,21 @@ export class GPUProjection implements GPUCommandGraphContributor {
         input,
         output: outputChunks[chunkIndex],
         patchIds: patchIdChunks?.[chunkIndex],
-        plan: planView
+        plan: planView,
+        bounds: boundsView
       });
     }
 
     this.hasRegisteredGraph = true;
   }
 
-  /** Releases privately allocated plan storage; caller-owned input, output, and plan remain intact. */
+  /** Releases privately allocated plan and bounds storage; caller-owned resources remain intact. */
   destroy(): void {
     if (!this.destroyed) {
       this.ownedPlanBuffer?.destroy();
       this.ownedPlanBuffer = undefined;
+      this.ownedBoundsBuffer?.destroy();
+      this.ownedBoundsBuffer = undefined;
       this.destroyed = true;
     }
   }
@@ -213,6 +219,24 @@ export class GPUProjection implements GPUCommandGraphContributor {
     return graph.createDataView(handle, {format: 'uint32', length: words.length});
   }
 
+  private createOwnedBoundsView<Parameters>(
+    graph: GPUCommandGraph<Parameters>
+  ): GraphDataView<'uint32'> {
+    const words = packProjectionBounds(this.projectionPlan);
+    const id = `${this.id}-projection-bounds`;
+    const buffer = graph.device.createBuffer({
+      id,
+      data: words,
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    this.ownedBoundsBuffer = buffer;
+    const handle = graph.importBuffer(
+      {id, byteLength: words.byteLength, usage: buffer.usage},
+      buffer
+    );
+    return graph.createDataView(handle, {format: 'uint32', length: words.length});
+  }
+
   private addProjectionPass<Parameters>(
     graph: GPUCommandGraph<Parameters>,
     options: {
@@ -221,9 +245,10 @@ export class GPUProjection implements GPUCommandGraphContributor {
       output: GraphDataView<'float32x2'>;
       patchIds?: GraphDataView<'uint32'>;
       plan: GraphDataView<'uint32'>;
+      bounds: GraphDataView<'uint32'>;
     }
   ): void {
-    const {chunkIndex, input, output, patchIds, plan} = options;
+    const {chunkIndex, input, output, patchIds, plan, bounds} = options;
     const inputSource = getPositionReadSource('positions', input);
     const dispatchLayout = getGeospatialDispatchLayout(
       input.length,
@@ -232,11 +257,13 @@ export class GPUProjection implements GPUCommandGraphContributor {
     const resources: GraphBufferUse[] = [
       {buffer: input, usage: 'storage-read'},
       {buffer: plan, usage: 'storage-read'},
+      {buffer: bounds, usage: 'storage-read'},
       {buffer: output, usage: 'storage-write'}
     ];
     const bindings: Record<string, GraphDataView> = {
       positions: input,
       projectionPlans: plan,
+      projectionBounds: bounds,
       outputPositions: output
     };
     if (patchIds) {
@@ -273,9 +300,31 @@ export class GPUProjection implements GPUCommandGraphContributor {
   }
 }
 
+function packProjectionBounds(plan: ProjectionPlan): Uint32Array {
+  const words = new Uint32Array(8);
+  const dataView = new DataView(words.buffer);
+  for (let coordinateIndex = 0; coordinateIndex < plan.bounds.length; coordinateIndex++) {
+    dataView.setFloat64(
+      coordinateIndex * Float64Array.BYTES_PER_ELEMENT,
+      plan.bounds[coordinateIndex],
+      true
+    );
+  }
+  return words;
+}
+
 function validateProjectionPlan(plan: ProjectionPlan, id: string): void {
   if (!plan || !Array.isArray(plan.patches) || plan.patches.length === 0) {
     throw new Error(`${id} projection plan must contain at least one patch`);
+  }
+  if (
+    !Array.isArray(plan.bounds) ||
+    plan.bounds.length !== 4 ||
+    !plan.bounds.every(Number.isFinite) ||
+    plan.bounds[0] >= plan.bounds[2] ||
+    plan.bounds[1] >= plan.bounds[3]
+  ) {
+    throw new Error(`${id} projection plan must contain finite, increasing source bounds`);
   }
   if (
     plan.patches.some(
@@ -343,6 +392,35 @@ function getProjectionShaderSource(options: {
   const finitePosition = precise
     ? 'rawPointIsFinite(position)'
     : `all((bitcast<vec2u>(position) & vec2u(0x7f800000u)) != vec2u(0x7f800000u))`;
+  const rawBoundsCoordinates = precise
+    ? `let coordinateX = position.x;
+  let coordinateY = position.y;`
+    : `let coordinateX = projectionFloat32ToRaw(position.x);
+  let coordinateY = projectionFloat32ToRaw(position.y);`;
+  const float32Conversion = precise
+    ? ''
+    : `fn projectionFloat32ToRaw(value: f32) -> vec2u {
+  let bits = bitcast<u32>(value);
+  let sign = bits & 0x80000000u;
+  let exponent = (bits >> 23u) & 0xffu;
+  let fraction = bits & 0x007fffffu;
+
+  if (exponent == 0u) {
+    if (fraction == 0u) {
+      return vec2u(sign, 0u);
+    }
+    let leading = 31u - countLeadingZeros(fraction);
+    let normalizedFraction = (fraction << (23u - leading)) & 0x007fffffu;
+    let binary64Exponent = leading + 874u;
+    return vec2u(
+      sign | (binary64Exponent << 20u) | (normalizedFraction >> 3u),
+      normalizedFraction << 29u
+    );
+  }
+
+  let binary64Exponent = exponent + 896u;
+  return vec2u(sign | (binary64Exponent << 20u) | (fraction >> 3u), fraction << 29u);
+}`;
   const patchIdDeclaration =
     patchIdOffset === undefined
       ? ''
@@ -364,8 +442,48 @@ const INVALID_PATCH: u32 = 0xffffffffu;
 
 ${inputDeclaration}
 @group(0) @binding(auto) var<storage, read> projectionPlans: array<u32>;
+@group(0) @binding(auto) var<storage, read> projectionBounds: array<u32>;
 @group(0) @binding(auto) var<storage, read_write> outputPositions: array<vec2f>;
 ${patchIdDeclaration}
+
+${float32Conversion}
+
+fn projectionRawLess(first: vec2u, second: vec2u) -> bool {
+  let firstMagnitude = first.x & 0x7fffffffu;
+  let secondMagnitude = second.x & 0x7fffffffu;
+  if ((firstMagnitude | first.y | secondMagnitude | second.y) == 0u) {
+    return false;
+  }
+
+  let firstNegative = (first.x & 0x80000000u) != 0u;
+  let secondNegative = (second.x & 0x80000000u) != 0u;
+  if (firstNegative != secondNegative) {
+    return firstNegative;
+  }
+  // Boolean-valued select expressions crash Chromium's Metal compiler; branch explicitly.
+  if (first.x != second.x) {
+    if (firstNegative) {
+      return first.x > second.x;
+    }
+    return first.x < second.x;
+  }
+  if (firstNegative) {
+    return first.y > second.y;
+  }
+  return first.y < second.y;
+}
+
+fn projectionBoundsContains(position: ${positionType}) -> bool {
+  ${rawBoundsCoordinates}
+  let minimumX = vec2u(projectionBounds[1u], projectionBounds[0u]);
+  let minimumY = vec2u(projectionBounds[3u], projectionBounds[2u]);
+  let maximumX = vec2u(projectionBounds[5u], projectionBounds[4u]);
+  let maximumY = vec2u(projectionBounds[7u], projectionBounds[6u]);
+  return !projectionRawLess(coordinateX, minimumX) &&
+    !projectionRawLess(maximumX, coordinateX) &&
+    !projectionRawLess(coordinateY, minimumY) &&
+    !projectionRawLess(maximumY, coordinateY);
+}
 
 fn projectionPlanWord(patchIndex: u32, wordIndex: u32) -> u32 {
   return projectionPlans[PLAN_OFFSET + patchIndex * PATCH_WORD_LENGTH + wordIndex];
@@ -443,7 +561,7 @@ fn main(
   ${invocationIndexSource}
   if (index >= ELEMENT_COUNT) { return; }
   let position = ${readPosition};
-  if (!(${finitePosition})) {
+  if (!(${finitePosition}) || !projectionBoundsContains(position)) {
     outputPositions[OUTPUT_OFFSET + index] = vec2f(0.0);
     return;
   }

--- a/modules/experimental/src/luproj/projection-benchmark.ts
+++ b/modules/experimental/src/luproj/projection-benchmark.ts
@@ -1,0 +1,242 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  compileProjectionPlan,
+  evaluateProjectionPlan,
+  findProjectionPatch
+} from './projection-plan';
+import type {CompileProjectionPlanOptions, ProjectionCoordinates, ProjectionPlan} from './types';
+
+/** Repeated-duration distribution in milliseconds, using nearest-rank percentiles. */
+export type ProjectionBenchmarkDistribution = {
+  minimum: number;
+  median: number;
+  percentile95: number;
+  maximum: number;
+};
+
+/** CPU implementation evaluated against the same deterministic source coordinates. */
+export type ProjectionBenchmarkStrategy = 'provider' | 'plan-scan' | 'plan-patch-ids';
+
+/** Timing, throughput, and observable output from one CPU implementation. */
+export type ProjectionBenchmarkPathReport = {
+  strategy: ProjectionBenchmarkStrategy;
+  durationMilliseconds: ProjectionBenchmarkDistribution;
+  coordinatesPerSecond: number;
+  checksum: number;
+};
+
+/** Projection compiler options and controls shared by CPU and WebGPU benchmarks. */
+export type ProjectionBenchmarkOptions = CompileProjectionPlanOptions & {
+  /** Number of deterministic source rows evaluated by every implementation. Defaults to 16,384. */
+  coordinateCount?: number;
+  /** Untimed iterations before each measured implementation. Defaults to two. */
+  warmupIterations?: number;
+  /** Timed iterations used for nearest-rank distributions. Defaults to five. */
+  measuredIterations?: number;
+};
+
+/** Reproducible compilation and CPU-evaluation benchmark results. */
+export type ProjectionBenchmarkReport = {
+  coordinateCount: number;
+  patchCount: number;
+  warmupIterations: number;
+  measuredIterations: number;
+  maxError: number;
+  compilationTimeMilliseconds: ProjectionBenchmarkDistribution;
+  paths: ProjectionBenchmarkPathReport[];
+};
+
+/** @internal Shared deterministic source data consumed by the WebGPU companion benchmark. */
+export type ProjectionBenchmarkContext = {
+  plan: ProjectionPlan;
+  coordinates: [number, number][];
+  patchIds: Uint32Array;
+  report: ProjectionBenchmarkReport;
+};
+
+const DEFAULT_COORDINATE_COUNT = 16_384;
+const DEFAULT_WARMUP_ITERATIONS = 2;
+const DEFAULT_MEASURED_ITERATIONS = 5;
+const GOLDEN_RATIO_FRACTION = 0.6180339887498949;
+
+/**
+ * Benchmarks provider calls, adaptive-plan compilation, patch scans, and explicit patch lookup.
+ *
+ * Every evaluation path receives the same deterministic in-bounds coordinates. Source generation
+ * and patch-ID assignment occur outside the measured evaluation loops, and returned checksums keep
+ * calculated values observable without making output allocation part of the comparison.
+ */
+export function runProjectionBenchmark(
+  options: ProjectionBenchmarkOptions
+): ProjectionBenchmarkReport {
+  return prepareProjectionBenchmark(options).report;
+}
+
+/** @internal Builds one CPU report and retains its exact source rows and compiled plan. */
+export function prepareProjectionBenchmark(
+  options: ProjectionBenchmarkOptions
+): ProjectionBenchmarkContext {
+  const coordinateCount = options.coordinateCount ?? DEFAULT_COORDINATE_COUNT;
+  const warmupIterations = options.warmupIterations ?? DEFAULT_WARMUP_ITERATIONS;
+  const measuredIterations = options.measuredIterations ?? DEFAULT_MEASURED_ITERATIONS;
+
+  if (!Number.isSafeInteger(coordinateCount) || coordinateCount < 1) {
+    throw new Error('projection benchmark coordinateCount must be a positive safe integer');
+  }
+  if (!Number.isSafeInteger(warmupIterations) || warmupIterations < 0) {
+    throw new Error('projection benchmark warmupIterations must be a non-negative safe integer');
+  }
+  if (!Number.isSafeInteger(measuredIterations) || measuredIterations < 1) {
+    throw new Error('projection benchmark measuredIterations must be a positive safe integer');
+  }
+
+  let plan: ProjectionPlan | undefined;
+  for (let iteration = 0; iteration < warmupIterations; iteration++) {
+    plan = compileProjectionPlan(options);
+  }
+  const compilationSamples: number[] = [];
+  for (let iteration = 0; iteration < measuredIterations; iteration++) {
+    const startTime = getProjectionBenchmarkTime();
+    plan = compileProjectionPlan(options);
+    compilationSamples.push(getProjectionBenchmarkTime() - startTime);
+  }
+
+  // At least one measured iteration is required, so a compiled plan always exists here.
+  const compiledPlan = plan!;
+  const coordinates = createProjectionBenchmarkCoordinates(compiledPlan, coordinateCount);
+  const patchIds = Uint32Array.from(coordinates, coordinate =>
+    findProjectionPatch(compiledPlan, coordinate)
+  );
+  const provider =
+    typeof options.projection === 'function'
+      ? options.projection
+      : options.projection.project.bind(options.projection);
+  const paths: ProjectionBenchmarkPathReport[] = [
+    measureProjectionBenchmarkPath(
+      'provider',
+      coordinates,
+      warmupIterations,
+      measuredIterations,
+      coordinate => provider([coordinate[0], coordinate[1]])
+    ),
+    measureProjectionBenchmarkPath(
+      'plan-scan',
+      coordinates,
+      warmupIterations,
+      measuredIterations,
+      coordinate => evaluateProjectionPlan(compiledPlan, coordinate)
+    ),
+    measureProjectionBenchmarkPath(
+      'plan-patch-ids',
+      coordinates,
+      warmupIterations,
+      measuredIterations,
+      (coordinate, coordinateIndex) =>
+        evaluateProjectionPlan(compiledPlan, coordinate, patchIds[coordinateIndex])
+    )
+  ];
+
+  return {
+    plan: compiledPlan,
+    coordinates,
+    patchIds,
+    report: {
+      coordinateCount,
+      patchCount: compiledPlan.patches.length,
+      warmupIterations,
+      measuredIterations,
+      maxError: compiledPlan.maxError,
+      compilationTimeMilliseconds: summarizeProjectionBenchmarkSamples(compilationSamples),
+      paths
+    }
+  };
+}
+
+/** @internal Returns a monotonic timer when available, with a portable Date fallback. */
+export function getProjectionBenchmarkTime(): number {
+  return globalThis.performance?.now() ?? Date.now();
+}
+
+/** @internal Summarizes validated millisecond samples without interpolating observed timings. */
+export function summarizeProjectionBenchmarkSamples(
+  samples: readonly number[]
+): ProjectionBenchmarkDistribution {
+  if (samples.length === 0 || samples.some(sample => !Number.isFinite(sample) || sample < 0)) {
+    throw new Error('projection benchmark samples must contain finite non-negative durations');
+  }
+  const sortedSamples = [...samples].sort((left, right) => left - right);
+  return {
+    minimum: sortedSamples[0],
+    median: sortedSamples[Math.ceil(sortedSamples.length * 0.5) - 1],
+    percentile95: sortedSamples[Math.ceil(sortedSamples.length * 0.95) - 1],
+    maximum: sortedSamples[sortedSamples.length - 1]
+  };
+}
+
+function createProjectionBenchmarkCoordinates(
+  plan: ProjectionPlan,
+  coordinateCount: number
+): [number, number][] {
+  const [minimumX, minimumY, maximumX, maximumY] = plan.bounds;
+  return Array.from({length: coordinateCount}, (_, coordinateIndex) => {
+    const horizontalFraction = (coordinateIndex + 0.5) / coordinateCount;
+    const verticalFraction = ((coordinateIndex + 1) * GOLDEN_RATIO_FRACTION) % 1;
+    return [
+      minimumX + (maximumX - minimumX) * horizontalFraction,
+      minimumY + (maximumY - minimumY) * verticalFraction
+    ];
+  });
+}
+
+function measureProjectionBenchmarkPath(
+  strategy: ProjectionBenchmarkStrategy,
+  coordinates: [number, number][],
+  warmupIterations: number,
+  measuredIterations: number,
+  project: (coordinate: ProjectionCoordinates, coordinateIndex: number) => readonly number[]
+): ProjectionBenchmarkPathReport {
+  for (let iteration = 0; iteration < warmupIterations; iteration++) {
+    evaluateProjectionBenchmarkCoordinates(coordinates, project);
+  }
+
+  const samples: number[] = [];
+  let checksum = 0;
+  for (let iteration = 0; iteration < measuredIterations; iteration++) {
+    const startTime = getProjectionBenchmarkTime();
+    checksum = evaluateProjectionBenchmarkCoordinates(coordinates, project);
+    samples.push(getProjectionBenchmarkTime() - startTime);
+  }
+  const durationMilliseconds = summarizeProjectionBenchmarkSamples(samples);
+  return {
+    strategy,
+    durationMilliseconds,
+    coordinatesPerSecond: getProjectionBenchmarkThroughput(
+      coordinates.length,
+      durationMilliseconds.median
+    ),
+    checksum
+  };
+}
+
+function evaluateProjectionBenchmarkCoordinates(
+  coordinates: [number, number][],
+  project: (coordinate: ProjectionCoordinates, coordinateIndex: number) => readonly number[]
+): number {
+  let checksum = 0;
+  for (let coordinateIndex = 0; coordinateIndex < coordinates.length; coordinateIndex++) {
+    const projected = project(coordinates[coordinateIndex], coordinateIndex);
+    checksum += projected[0] + projected[1];
+  }
+  return checksum;
+}
+
+/** @internal Converts milliseconds to rows per second without serializing infinite rates. */
+export function getProjectionBenchmarkThroughput(
+  coordinateCount: number,
+  durationMilliseconds: number
+): number {
+  return (coordinateCount * 1000) / Math.max(durationMilliseconds, Number.EPSILON);
+}

--- a/modules/experimental/test/index.ts
+++ b/modules/experimental/test/index.ts
@@ -35,3 +35,4 @@ import './simulation/spectral-ocean-simulation.spec';
 import './geospatial/geospatial-projection-distance.spec';
 import './luxfilter';
 import './luproj/luproj.spec';
+import './luproj/projection-benchmark.spec';

--- a/modules/experimental/test/luproj/luproj.spec.ts
+++ b/modules/experimental/test/luproj/luproj.spec.ts
@@ -338,6 +338,196 @@ test('GPUProjection accepts inclusive binary64 patch endpoints after Float32 nor
   tapeTest.end();
 });
 
+test('GPUProjection rejects outer-domain positions without removing patch seam tolerance', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const minimum = -500_000_000;
+  const maximum = 500_000_000;
+  const plan = compileProjectionPlan({
+    projection: (coordinates: number[]): number[] => [
+      coordinates[0] / 1_000_000_000,
+      coordinates[1] / 1_000_000_000
+    ],
+    bounds: [minimum, minimum, maximum, maximum],
+    degree: 1,
+    tolerance: 1e-6
+  });
+  const points: Coordinates[] = [
+    [minimum, 250_000_000],
+    [maximum, -250_000_000],
+    [250_000_000, minimum],
+    [-250_000_000, maximum],
+    [minimum - 100, 250_000_000],
+    [maximum + 100, -250_000_000],
+    [250_000_000, minimum - 100],
+    [-250_000_000, maximum + 100],
+    [Number.NaN, 250_000_000],
+    [250_000_000, Number.POSITIVE_INFINITY]
+  ];
+  const graph = new GPUCommandGraph(device, {id: 'luproj-exact-outer-bounds'});
+  const rawInputBuffer = createBuffer(device, encodeFloat64Points(points));
+  const float32InputBuffer = createBuffer(device, Float32Array.from(points.flat()));
+  const patchIdBuffer = createBuffer(device, new Uint32Array(points.length));
+  const rawPositions = importView(
+    graph,
+    'raw-positions',
+    rawInputBuffer,
+    'uint32x4',
+    points.length
+  );
+  const float32Positions = importView(
+    graph,
+    'float32-positions',
+    float32InputBuffer,
+    'float32x2',
+    points.length
+  );
+  const patchIds = importView(graph, 'patch-ids', patchIdBuffer, 'uint32', points.length);
+  const cases: Array<{
+    name: string;
+    positions: typeof rawPositions | typeof float32Positions;
+    explicitPatchIds: boolean;
+    outputBuffer: Buffer;
+  }> = [
+    {
+      name: 'raw-automatic',
+      positions: rawPositions,
+      explicitPatchIds: false,
+      outputBuffer: createOutputBuffer(device, points.length * 2)
+    },
+    {
+      name: 'raw-explicit',
+      positions: rawPositions,
+      explicitPatchIds: true,
+      outputBuffer: createOutputBuffer(device, points.length * 2)
+    },
+    {
+      name: 'float32-automatic',
+      positions: float32Positions,
+      explicitPatchIds: false,
+      outputBuffer: createOutputBuffer(device, points.length * 2)
+    },
+    {
+      name: 'float32-explicit',
+      positions: float32Positions,
+      explicitPatchIds: true,
+      outputBuffer: createOutputBuffer(device, points.length * 2)
+    }
+  ];
+  const contributors = cases.map(({name, positions, explicitPatchIds, outputBuffer}) => {
+    const contributor = new GPUProjection({
+      id: name,
+      positions,
+      output: importView(graph, `${name}-output`, outputBuffer, 'float32x2', points.length),
+      patchIds: explicitPatchIds ? patchIds : undefined,
+      plan
+    });
+    contributor.addToGraph(graph);
+    return contributor;
+  });
+
+  const compiled = graph.compile();
+  const encoder = device.createCommandEncoder({id: 'luproj-exact-outer-boundary-encoding'});
+  compiled.encode(encoder, {parameters: undefined});
+  device.submit(encoder.finish());
+
+  for (const {name, outputBuffer} of cases) {
+    const actual = await readFloat32(outputBuffer, points.length * 2);
+    for (let pointIndex = 0; pointIndex < 4; pointIndex++) {
+      const expected = evaluateProjectionPlan(plan, points[pointIndex]);
+      assertClose(
+        tapeTest,
+        actual[pointIndex * 2],
+        expected[0] - plan.destinationOrigin[0],
+        1e-6,
+        `${name} accepts inclusive x endpoint ${pointIndex}`
+      );
+      assertClose(
+        tapeTest,
+        actual[pointIndex * 2 + 1],
+        expected[1] - plan.destinationOrigin[1],
+        1e-6,
+        `${name} accepts inclusive y endpoint ${pointIndex}`
+      );
+    }
+    tapeTest.deepEqual(
+      actual.slice(8),
+      new Array((points.length - 4) * 2).fill(0),
+      `${name} rejects coordinates beyond exact exterior bounds and non-finite inputs`
+    );
+  }
+
+  compiled.destroy();
+  for (const contributor of contributors) {
+    contributor.destroy();
+  }
+  for (const buffer of [
+    rawInputBuffer,
+    float32InputBuffer,
+    patchIdBuffer,
+    ...cases.map(({outputBuffer}) => outputBuffer)
+  ]) {
+    buffer.destroy();
+  }
+  tapeTest.end();
+});
+
+test('GPUProjection compares Float32 positions against exact fractional binary64 bounds', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const plan = compileProjectionPlan({
+    projection: (coordinates: number[]): number[] => [...coordinates],
+    bounds: [0, 0.1, 1, 1.1],
+    degree: 1,
+    tolerance: 1e-6
+  });
+  const points: Coordinates[] = [
+    [-0, Math.fround(0.1)],
+    [1, Math.fround(1.1 - 1e-7)],
+    [-0, Math.fround(0.1 - 1e-8)],
+    [0, Math.fround(1.1)]
+  ];
+  const inputBuffer = createBuffer(device, Float32Array.from(points.flat()));
+  const outputBuffer = createOutputBuffer(device, points.length * 2);
+  const graph = new GPUCommandGraph(device, {id: 'luproj-float32-fractional-bounds'});
+  const contributor = new GPUProjection({
+    positions: importView(graph, 'positions', inputBuffer, 'float32x2', points.length),
+    output: importView(graph, 'output', outputBuffer, 'float32x2', points.length),
+    plan
+  });
+
+  contributor.addToGraph(graph);
+  const compiled = graph.compile();
+  const encoder = device.createCommandEncoder({id: 'luproj-float32-fractional-boundary-encoding'});
+  compiled.encode(encoder, {parameters: undefined});
+  device.submit(encoder.finish());
+
+  const actual = await readFloat32(outputBuffer, points.length * 2);
+  assertProjectedPoints(tapeTest, plan, points.slice(0, 2), actual.slice(0, 4));
+  tapeTest.notEqual(actual[0], 0, 'negative zero equals the positive-zero lower boundary');
+  tapeTest.deepEqual(
+    actual.slice(4),
+    [0, 0, 0, 0],
+    'Float32 values immediately outside unrounded binary64 bounds produce zero rows'
+  );
+
+  compiled.destroy();
+  contributor.destroy();
+  inputBuffer.destroy();
+  outputBuffer.destroy();
+  tapeTest.end();
+});
+
 test('GPUProjection automatically selects different adaptive patches for mixed rows', async tapeTest => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -652,16 +842,19 @@ test('GPUProjection rejects updates to caller-owned plans without COPY_DST usage
   });
   const packedPlan = packProjectionPlan(initialPlan);
   const readOnlyPlanBuffer = device.createBuffer({data: packedPlan, usage: Buffer.STORAGE});
-  const positionBuffer = createBuffer(device, Float32Array.from([0.5, 0.5]));
+  const positionBuffer = createBuffer(device, Float32Array.from([0.75, 0.5]));
   const outputBuffer = createOutputBuffer(device, 2);
   const graph = new GPUCommandGraph(device, {id: 'luproj-read-only-plan-update'});
+  const positions = importView(graph, 'positions', positionBuffer, 'float32x2', 1);
+  const output = importView(graph, 'output', outputBuffer, 'float32x2', 1);
   const contributor = new GPUProjection({
-    positions: importView(graph, 'positions', positionBuffer, 'float32x2', 1),
-    output: importView(graph, 'output', outputBuffer, 'float32x2', 1),
+    positions,
+    output,
     plan: initialPlan,
     planBuffer: importView(graph, 'read-only-plan', readOnlyPlanBuffer, 'uint32', packedPlan.length)
   });
 
+  contributor.addToGraph(graph);
   tapeTest.throws(
     () => contributor.updatePlan(updatedPlan),
     /COPY_DST/,
@@ -669,6 +862,45 @@ test('GPUProjection rejects updates to caller-owned plans without COPY_DST usage
   );
   tapeTest.equal(contributor.plan, initialPlan, 'a rejected update preserves the current CPU plan');
 
+  const invalidBounds = [
+    [0, 0, Number.POSITIVE_INFINITY, 1],
+    [1, 0, 0, 1],
+    [0, 1, 1, 0]
+  ] as const;
+  for (const bounds of invalidBounds) {
+    const invalidPlan = {...updatedPlan, bounds};
+    tapeTest.throws(
+      () => contributor.updatePlan(invalidPlan),
+      /finite, increasing source bounds/,
+      'plan updates reject non-finite or unordered source bounds'
+    );
+    tapeTest.throws(
+      () => new GPUProjection({positions, output, plan: invalidPlan}),
+      /finite, increasing source bounds/,
+      'construction rejects non-finite or unordered source bounds'
+    );
+  }
+  const compiled = graph.compile();
+  const encoder = device.createCommandEncoder({id: 'luproj-rejected-plan-update-encoding'});
+  compiled.encode(encoder, {parameters: undefined});
+  device.submit(encoder.finish());
+  const actual = await readFloat32(outputBuffer, 2);
+  assertClose(
+    tapeTest,
+    actual[0],
+    0.25,
+    1e-6,
+    'rejected updates preserve the packed projection plan and exact x bounds'
+  );
+  assertClose(
+    tapeTest,
+    actual[1],
+    0,
+    1e-6,
+    'rejected updates preserve the packed projection plan and exact y bounds'
+  );
+
+  compiled.destroy();
   contributor.destroy();
   readOnlyPlanBuffer.destroy();
   positionBuffer.destroy();
@@ -770,6 +1002,85 @@ test('GPUProjection updates caller-owned packed plans without rebuilding its gra
   tapeTest.equal(outputBuffer.destroyed, false, 'caller-owned destination remains allocated');
   tapeTest.throws(() => contributor.updatePlan(initialPlan), /destroyed/);
 
+  planBuffer.destroy();
+  inputBuffer.destroy();
+  outputBuffer.destroy();
+  tapeTest.end();
+});
+
+test('GPUProjection updates exact global bounds without rebuilding its graph', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const projection = (coordinates: number[]): number[] => [...coordinates];
+  const initialPlan = compileProjectionPlan({
+    projection,
+    bounds: [-2, -2, -0, -0],
+    degree: 1,
+    tolerance: 1e-5
+  });
+  const updatedPlan = compileProjectionPlan({
+    projection,
+    bounds: [0, 0, 2, 2],
+    degree: 1,
+    tolerance: 1e-5
+  });
+  const points: Coordinates[] = [
+    [-1.5, -0.5],
+    [-0, 0],
+    [0, -0],
+    [1.5, 0.5]
+  ];
+  const packedPlan = packProjectionPlan(initialPlan);
+  const planBuffer = device.createBuffer({
+    data: packedPlan,
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  const inputBuffer = createBuffer(device, encodeFloat64Points(points));
+  const outputBuffer = createOutputBuffer(device, points.length * 2);
+  const graph = new GPUCommandGraph(device, {id: 'luproj-shifted-global-bounds'});
+  const contributor = new GPUProjection({
+    id: 'mutable-global-bounds',
+    positions: importView(graph, 'positions', inputBuffer, 'uint32x4', points.length),
+    output: importView(graph, 'output', outputBuffer, 'float32x2', points.length),
+    plan: initialPlan,
+    planBuffer: importView(graph, 'caller-owned-plan', planBuffer, 'uint32', packedPlan.length)
+  });
+
+  contributor.addToGraph(graph);
+  const compiled = graph.compile();
+  const nodeOrder = [...compiled.stats.nodeOrder];
+  const initialEncoder = device.createCommandEncoder({id: 'luproj-initial-global-bounds'});
+  compiled.encode(initialEncoder, {parameters: undefined});
+  device.submit(initialEncoder.finish());
+  tapeTest.deepEqual(
+    await readFloat32(outputBuffer, points.length * 2),
+    [-0.5, 0.5, 1, 1, 1, 1, 0, 0],
+    'initial bounds accept both signed zeros and reject coordinates outside their upper edges'
+  );
+
+  contributor.updatePlan(updatedPlan);
+  const updatedEncoder = device.createCommandEncoder({id: 'luproj-updated-global-bounds'});
+  compiled.encode(updatedEncoder, {parameters: undefined});
+  device.submit(updatedEncoder.finish());
+  tapeTest.deepEqual(
+    await readFloat32(outputBuffer, points.length * 2),
+    [0, 0, -1, -1, -1, -1, 0.5, -0.5],
+    'shifted bounds reject old coordinates while still accepting both signed zeros'
+  );
+  tapeTest.deepEqual(
+    compiled.stats.nodeOrder,
+    nodeOrder,
+    'shifted bounds reuse the compiled graph'
+  );
+
+  compiled.destroy();
+  contributor.destroy();
+  tapeTest.equal(planBuffer.destroyed, false, 'caller-owned plan survives private bounds cleanup');
   planBuffer.destroy();
   inputBuffer.destroy();
   outputBuffer.destroy();

--- a/modules/experimental/test/luproj/projection-benchmark.node.spec.ts
+++ b/modules/experimental/test/luproj/projection-benchmark.node.spec.ts
@@ -1,0 +1,122 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+
+import * as experimentalModule from '@luma.gl/experimental';
+import * as projectionModule from '@luma.gl/experimental/luproj';
+import * as benchmarkModule from '@luma.gl/experimental/luproj/benchmarks';
+import {
+  runProjectionBenchmark,
+  type ProjectionBenchmarkOptions
+} from '@luma.gl/experimental/luproj/benchmarks';
+import {describe, expect, test} from 'vitest';
+
+const BENCHMARK_OPTIONS: ProjectionBenchmarkOptions = {
+  projection: (coordinates: number[]): number[] => [
+    1_000 + coordinates[0] + coordinates[0] * coordinates[0] * 0.2,
+    2_000 + coordinates[1] + coordinates[1] * coordinates[1] * 0.15
+  ],
+  bounds: [0, 0, 2, 2],
+  degree: 1,
+  tolerance: 0.06,
+  maxDepth: 5,
+  coordinateCount: 64,
+  warmupIterations: 0,
+  measuredIterations: 2
+};
+
+describe('CPU projection benchmarks', () => {
+  test('compares provider and both adaptive-patch strategies on deterministic coordinates', () => {
+    const report = runProjectionBenchmark(BENCHMARK_OPTIONS);
+
+    expect(report.coordinateCount).toBe(64);
+    expect(report.patchCount).toBeGreaterThan(1);
+    expect(report.warmupIterations).toBe(0);
+    expect(report.measuredIterations).toBe(2);
+    expect(report.maxError).toBeLessThanOrEqual(BENCHMARK_OPTIONS.tolerance!);
+    expect(report.compilationTimeMilliseconds.minimum).toBeGreaterThanOrEqual(0);
+    expect(report.compilationTimeMilliseconds.maximum).toBeGreaterThanOrEqual(
+      report.compilationTimeMilliseconds.median
+    );
+    expect(report.paths.map(path => path.strategy)).toEqual([
+      'provider',
+      'plan-scan',
+      'plan-patch-ids'
+    ]);
+
+    for (const path of report.paths) {
+      expect(path.durationMilliseconds.minimum).toBeGreaterThanOrEqual(0);
+      expect(path.durationMilliseconds.percentile95).toBeGreaterThanOrEqual(
+        path.durationMilliseconds.median
+      );
+      expect(path.coordinatesPerSecond).toBeGreaterThan(0);
+      expect(Number.isFinite(path.checksum)).toBe(true);
+    }
+    expect(report.paths[1].checksum).toBe(report.paths[2].checksum);
+    expect(Math.abs(report.paths[0].checksum - report.paths[1].checksum)).toBeLessThan(
+      report.coordinateCount * BENCHMARK_OPTIONS.tolerance! * 2
+    );
+
+    const repeated = runProjectionBenchmark(BENCHMARK_OPTIONS);
+    expect(repeated.paths.map(path => path.checksum)).toEqual(
+      report.paths.map(path => path.checksum)
+    );
+  });
+
+  test('preserves object-provider receivers and supplies mutable source-coordinate arrays', () => {
+    const provider = {
+      offset: 20,
+      project(coordinates: number[]): number[] {
+        const projected = [coordinates[0] + this.offset, coordinates[1] - this.offset];
+        coordinates[0] = Number.NaN;
+        return projected;
+      }
+    };
+    const report = runProjectionBenchmark({
+      projection: provider,
+      bounds: [0, 0, 2, 2],
+      degree: 1,
+      tolerance: 1e-5,
+      coordinateCount: 8,
+      warmupIterations: 0,
+      measuredIterations: 1
+    });
+
+    expect(report.paths[1].checksum).toBeCloseTo(report.paths[0].checksum, 5);
+    expect(report.paths[2].checksum).toBeCloseTo(report.paths[0].checksum, 5);
+  });
+
+  test('rejects invalid benchmark dimensions without exporting helpers from the root module', () => {
+    expect(() => runProjectionBenchmark({...BENCHMARK_OPTIONS, coordinateCount: 0})).toThrow(
+      /coordinateCount/
+    );
+    expect(() => runProjectionBenchmark({...BENCHMARK_OPTIONS, coordinateCount: 1.5})).toThrow(
+      /coordinateCount/
+    );
+    expect(() => runProjectionBenchmark({...BENCHMARK_OPTIONS, warmupIterations: -1})).toThrow(
+      /warmupIterations/
+    );
+    expect(() => runProjectionBenchmark({...BENCHMARK_OPTIONS, measuredIterations: 0})).toThrow(
+      /measuredIterations/
+    );
+  });
+
+  test('isolates benchmark helpers behind their optional nested package entry point', () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
+    ) as {exports?: Record<string, Record<string, string>>};
+
+    expect(packageJson.exports?.['./luproj/benchmarks']).toEqual({
+      import: './dist/luproj/benchmarks.js',
+      require: './dist/luproj/benchmarks.cjs',
+      types: './dist/luproj/benchmarks.d.ts'
+    });
+    for (const exportName of ['runProjectionBenchmark', 'runGPUProjectionBenchmark'] as const) {
+      expect(benchmarkModule[exportName]).toBeTypeOf('function');
+      expect(exportName in experimentalModule).toBe(false);
+      expect(exportName in projectionModule).toBe(false);
+    }
+  });
+});

--- a/modules/experimental/test/luproj/projection-benchmark.spec.ts
+++ b/modules/experimental/test/luproj/projection-benchmark.spec.ts
@@ -1,0 +1,78 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {createWebMercatorProjection} from '@luma.gl/experimental/luproj';
+import {runGPUProjectionBenchmark} from '@luma.gl/experimental/luproj/benchmarks';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+test('runGPUProjectionBenchmark compares CPU baselines and synchronized WebGPU paths', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const configuredRows = import.meta.env.VITE_LUPROJ_BENCHMARK_ROWS;
+  const coordinateCount = configuredRows ? Number(configuredRows) : 64;
+  const benchmarkReport = await runGPUProjectionBenchmark(device, {
+    projection: createWebMercatorProjection(),
+    bounds: [-123, 37, -122, 38],
+    degree: 2,
+    tolerance: 0.03,
+    maxDepth: 5,
+    coordinateCount,
+    warmupIterations: configuredRows ? 2 : 0,
+    measuredIterations: configuredRows ? 5 : 1
+  });
+
+  tapeTest.equal(benchmarkReport.cpu.coordinateCount, coordinateCount);
+  tapeTest.ok(benchmarkReport.cpu.patchCount > 1, 'benchmark rows span multiple adaptive patches');
+  tapeTest.deepEqual(
+    benchmarkReport.cpu.paths.map(path => path.strategy),
+    ['provider', 'plan-scan', 'plan-patch-ids'],
+    'provider and both CPU patch strategies share one deterministic dataset'
+  );
+  tapeTest.deepEqual(
+    benchmarkReport.paths.map(path => `${path.inputFormat}:${path.patchStrategy}`),
+    ['float32x2:scan', 'float32x2:patch-ids', 'uint32x4:scan', 'uint32x4:patch-ids'],
+    'both source representations are compared with scan and explicit patch IDs'
+  );
+
+  for (const path of benchmarkReport.paths) {
+    tapeTest.ok(
+      path.synchronizedCoordinatesPerSecond > 0,
+      `${path.inputFormat} reports throughput`
+    );
+    tapeTest.ok(path.synchronizedTimeMilliseconds.minimum >= 0, 'GPU submission is synchronized');
+    tapeTest.ok(path.cpuEncodeTimeMilliseconds.minimum >= 0, 'CPU encoding is measured separately');
+    tapeTest.ok(path.maxError <= 0.0301, 'the entire output matches its source-format CPU oracle');
+    tapeTest.equal(
+      path.synchronizedSpeedupOverCPUProvider,
+      path.synchronizedCoordinatesPerSecond / benchmarkReport.cpu.paths[0].coordinatesPerSecond,
+      'end-to-end GPU throughput is compared directly against the CPU provider'
+    );
+    if (path.gpuCoordinatesPerSecond !== undefined) {
+      tapeTest.equal(
+        path.gpuSpeedupOverCPUProvider,
+        path.gpuCoordinatesPerSecond / benchmarkReport.cpu.paths[0].coordinatesPerSecond,
+        'timestamped compute throughput is compared directly against the CPU provider'
+      );
+    }
+  }
+  tapeTest.ok(
+    benchmarkReport.paths[1].memoryByteLength > benchmarkReport.paths[0].memoryByteLength,
+    'explicit patch-ID storage is reflected in reported memory consumption'
+  );
+  tapeTest.ok(
+    benchmarkReport.paths[2].memoryByteLength > benchmarkReport.paths[0].memoryByteLength,
+    'raw binary64 inputs report their wider physical storage'
+  );
+
+  if (configuredRows) {
+    tapeTest.comment('LUPROJ_BENCHMARK_REPORT', JSON.stringify(benchmarkReport));
+  }
+  tapeTest.end();
+});


### PR DESCRIPTION
## Goals

- Correct the outer-boundary regression identified in the post-merge review of [#2897](https://github.com/visgl/luma.gl/pull/2897#discussion_r3708153181): no out-of-domain coordinate may be admitted by the tolerance intended for interior patch seams.
- Add repeatable, correctness-checked CPU and actual-WebGPU projection benchmarks so applications can compare provider evaluation, projection-plan compilation, precision formats, and explicit versus automatic patch assignment.
- Preserve the existing packed projection-plan ABI, optional package isolation, caller-owned resource semantics, and mutable `GPUProjection.updatePlan()` behavior.

## Changes

- Validate plan-wide source bounds exactly on the GPU before performing tolerance-aware patch selection. Compare raw binary64 coordinates directly and convert native Float32 coordinates to exact binary64 bit pairs without requiring WGSL `f64`.
- Store exact global bounds in a private, mutable 32-byte GPU buffer, allowing equally sized plans with different bounds to update without recompiling command graphs or changing the existing 40-word patch ABI.
- Keep inclusive plan boundaries, signed-zero equivalence, fractional Float32 boundaries, and interior-patch seam tolerance while rejecting exterior rows for both Float32 and raw-binary64 inputs; use explicit comparator branches to avoid Chromium/Metal's renderer crash on boolean-valued WGSL `select`.
- Add `runProjectionBenchmark()` for adaptive plan compilation, direct CPU projection-provider execution, and compiled-plan CPU evaluation with automatic versus explicit patch selection.
- Add `runGPUProjectionBenchmark()` for actual-WebGPU comparisons against those same CPU baselines across Float32 and raw-binary64 coordinates with automatic patch scanning and explicit patch IDs, including correctness validation, warmups, repeated timing distributions, queue-fence synchronization, optional GPU timestamps, memory usage, throughput, and explicit GPU-versus-CPU speedups.
- Publish both benchmark runners through the separately optional `@luma.gl/experimental/luproj/benchmarks` ESM/CommonJS/types entry point, keeping the production projection entry free of bundled GPU-command-graph benchmark machinery.
- Document the benchmark APIs, interpretation, ownership, and precision/patch-selection tradeoffs.
- Add focused node and real-WebGPU regressions covering large-domain exterior rows, exact boundaries, mutable bounds, benchmark reports, resource ownership, and correctness oracles.

## Representative hardware benchmark

Actual Chromium/WebGPU hardware run: **16,384 WGS84 → Web Mercator coordinates, 16 adaptive patches, five measured iterations**. GPU-only numbers use device timestamp queries; synchronized numbers also include queue submission and fence completion.

| Input format | Patch assignment | GPU compute throughput | Submission + fence throughput |
| --- | --- | ---: | ---: |
| Float32 | Automatic patch scan | ~480 million rows/s | ~32.8 million rows/s |
| Float32 | Explicit patch IDs | ~840 million rows/s | ~54.6 million rows/s |
| Raw binary64 | Automatic patch scan | ~118 million rows/s | ~41.0 million rows/s |
| Raw binary64 | Explicit patch IDs | ~562 million rows/s | ~41.0 million rows/s |

On the same deterministic dataset, the direct CPU Web Mercator provider processed ~41.0 million rows/s, CPU plan scanning ~12.6 million rows/s, and explicit-ID CPU evaluation ~18.2 million rows/s. The explicit-ID Float32 GPU path is therefore ~1.3× faster than the CPU provider when submission/fencing is included, or ~20.5× faster for timestamped GPU compute alone; the raw-binary64 path is ~1.0× and ~13.7× faster, respectively. Median adaptive-plan compilation took ~2.0 ms; measured GPU error stayed below ~0.013 m for a 0.03 m tolerance. These are representative local measurements, not universal performance guarantees.

Increasing the same workload to **262,144 coordinates** amortizes GPU submission costs: the direct CPU provider processed ~35.9 million rows/s, while explicit-ID Float32 GPU projection reached ~374 million rows/s (**~10.4× end-to-end CPU speedup**) and raw-binary64 GPU projection reached ~524 million rows/s (**~14.6× end-to-end CPU speedup**), including queue submission and completion.

Cross-repository CPU validation with the real `@math.gl/proj4` adapter from [math.gl #102](https://github.com/visgl/math.gl/pull/102) also compared EPSG:32610 → EPSG:3857 over 65,536 coordinates and nine measured iterations: direct proj4 evaluation reached ~3.9–4.1 million rows/s, while compiled-plan evaluation reached ~14.1–15.0 million rows/s (**~3.5–3.8× faster** across three independent runs), with ≤0.13 mm sampled projection error.

## Verification

Required repository setup and merge gates:

- [x] `nvm use` — Node.js 22.22.1 selected.
- [x] `yarn install` — immutable install completed successfully against the existing lockfile.
- [x] `yarn lint fix` — final formatting and lint checks passed.
- [x] `yarn build` — every workspace, isolated benchmark ESM/CommonJS entry, and generated declaration built after final code and formatting changes.
- [x] `yarn test` — passed with production `CI=1` settings: 410 node tests across 91 files and 1,518 Chromium/WebGPU tests across 282 files.
- [x] `yarn website:build` — production documentation/website build passed and validated 455 raw documentation pages.
- [x] `(cd website && yarn build)` — independent website-package production build passed.

Additional focused and compatibility checks:

- [x] Focused CPU benchmark suite — four node tests passed.
- [x] Focused actual-hardware WebGPU projection suite — 14 tests passed, including exact outer bounds across both formats and patch strategies.
- [x] Focused actual-hardware GPU benchmark smoke test — all four GPU paths passed.
- [x] Representative hardware benchmark measurements across all four GPU paths — 16,384-row and 262,144-row runs passed with CPU speedups and actual timestamp-query measurements.
- [x] Cross-repository CPU benchmark with the real `@math.gl/proj4` adapter — three 65,536-row UTM-to-Web-Mercator runs passed.
- [x] `yarn lint` — repository lint passed.
- [x] `yarn examples:typecheck` — all 44 example workspaces passed.
- [x] `yarn bundle-size` — every existing production bundle budget passed.
- [x] Optional ESM/CommonJS/declaration package boundaries — benchmark helpers load only from `@luma.gl/experimental/luproj/benchmarks`, not from the main projection or experimental entry; primary projection CommonJS bundle remains ~49 KB.

## Risks and follow-up

- Each projection contributor allocates one additional private 32-byte storage buffer; the resulting four or five storage bindings remain below WebGPU's guaranteed minimum of eight per shader stage.
- Interior seam tolerance remains intentionally permissive only after exact plan-wide exterior rejection.
- GPU timestamp measurements are reported only on devices exposing timestamp queries; synchronized wall-clock throughput remains available everywhere.
- Benchmark results depend on adapter, driver, row count, patch topology, precision format, and projection provider; compare runs only under equivalent conditions.
