### PR TITLE
feat(docs): turn Getting Started into an inspiring GPU discovery experience

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -20,9 +20,9 @@ data processing.
 <div className="docs-api-card-grid">
   <a className="docs-api-card" href="/docs/getting-started">
     <span className="docs-api-card__kind">New to luma.gl</span>
-    <strong>Get a canvas running</strong>
-    <span>Create a Vite project, select WebGPU with WebGL2 fallback, and render your first frame.</span>
-    <span className="docs-api-card__meta">About ten minutes</span>
+    <strong>Discover what you can build</strong>
+    <span>Explore living worlds, physical simulations, visual effects, and GPU-powered data directly in your browser.</span>
+    <span className="docs-api-card__meta">No installation required</span>
   </a>
   <a className="docs-api-card" href="/docs/tutorials">
     <span className="docs-api-card__kind">Learn</span>
@@ -43,6 +43,9 @@ data processing.
     <span className="docs-api-card__meta">Organized by npm package</span>
   </a>
 </div>
+
+Ready to build your own application? The [Installing guide](/docs/developer-guide/installing)
+walks through local project setup, device adapters, and your first rendered frame.
 
 ## Why luma.gl?
 

--- a/docs/developer-guide/installing.md
+++ b/docs/developer-guide/installing.md
@@ -2,6 +2,131 @@
 
 **luma.gl** is published as a suite of npm modules. Each module responsible for a particular part of the rendering stack.
 
+You can explore the [live examples](/examples) without installing anything. When you are
+ready to build locally, this guide creates a small rendering project that tries WebGPU
+first and falls back to WebGL2.
+
+## Create Your First Project
+
+### Prerequisites
+
+- A current Node.js LTS release
+- A browser with WebGPU or WebGL2 support
+- Basic TypeScript knowledge
+
+### Choose a Package Manager
+
+Create a Vite project and install the luma.gl engine and both device adapters using your
+preferred package manager.
+
+**npm**
+
+```bash
+npm create vite@latest luma-demo -- --template vanilla-ts
+cd luma-demo
+npm install @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl
+```
+
+**yarn**
+
+```bash
+yarn create vite luma-demo --template vanilla-ts
+cd luma-demo
+yarn add @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl
+```
+
+**pnpm**
+
+```bash
+pnpm create vite luma-demo --template vanilla-ts
+cd luma-demo
+pnpm add @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl
+```
+
+### Render a Frame
+
+Replace `src/main.ts` with:
+
+```typescript
+import {AnimationLoopTemplate, type AnimationProps, makeAnimationLoop} from '@luma.gl/engine';
+import {webgpuAdapter} from '@luma.gl/webgpu';
+import {webgl2Adapter} from '@luma.gl/webgl';
+
+class App extends AnimationLoopTemplate {
+  override onRender({device}: AnimationProps): void {
+    const renderPass = device.beginRenderPass({
+      clearColor: [0.05, 0.08, 0.14, 1]
+    });
+    renderPass.end();
+  }
+}
+
+makeAnimationLoop(App, {
+  adapters: [webgpuAdapter, webgl2Adapter]
+}).start();
+```
+
+### Start the Development Server
+
+**npm**
+
+```bash
+npm run dev
+```
+
+**yarn**
+
+```bash
+yarn dev
+```
+
+**pnpm**
+
+```bash
+pnpm dev
+```
+
+You should see a dark canvas. luma.gl creates the best available device, begins a render
+pass each frame, and presents the result to the page.
+
+## How Backend Selection Works
+
+The application supplies both adapters in preference order. A WebGPU-capable browser
+uses `webgpuAdapter`; other supported browsers fall back to `webgl2Adapter`. Application
+code continues to use the same luma.gl `Device`, resource, and render-pass APIs.
+
+Use only `webgpuAdapter` when your application depends on compute shaders, storage
+textures, or another WebGPU-only feature. The documentation marks backend-specific
+features explicitly.
+
+## Troubleshooting
+
+### The Canvas Is Blank
+
+Check the browser console first. Confirm that `src/main.ts` is imported by `index.html`
+and that the canvas is not hidden by application CSS.
+
+### WebGPU Is Unavailable
+
+The example should fall back to WebGL2. To debug WebGPU specifically, consult the
+[WebGPU and WebGL comparison](/docs/api-guide/background/webgpu-vs-webgl) and inspect
+the selected device in your browser developer tools.
+
+### TypeScript Cannot Resolve a Package
+
+Install all three packages shown above. `@luma.gl/engine` provides `AnimationLoop` and
+`Model`; `@luma.gl/webgpu` and `@luma.gl/webgl` provide the concrete device adapters.
+
+## Next Step
+
+Continue with [Hello Triangle](/docs/tutorials/hello-triangle), where the empty render
+pass becomes a complete portable draw call. For lower-level resource management, start
+with [GPU resources and compute](/docs/api-guide/gpu).
+
+If your goal is a geospatial visualization rather than a GPU framework or custom
+renderer, start with [deck.gl](https://deck.gl) instead. deck.gl is built on luma.gl and
+provides higher-level layers, cameras, and interaction.
+
 ## A Minimal Install
 
 The most basic module is `@luma.gl/core` which provides an abstract API for writing application code

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -36,7 +36,7 @@ export function OnboardingPoster({image, alt, className, loading = 'lazy'}) {
         {'Your GPU is the canvas.'}
       </h1>
       <p className="luma-onboarding__subtitle">
-        {'Build living worlds, simulate light and motion, and move millions of data points—at the speed of the browser.'}
+        {'Build living worlds, simulate light and motion, and move millions of data points—at the speed of the GPU.'}
       </p>
       <div className="luma-onboarding__actions">
         <Link

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,154 +1,301 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
+---
+title: Getting Started
+description: Discover real-time rendering, physical simulation, GPU compute, and interactive visualization built with luma.gl.
+hide_title: true
+hide_table_of_contents: true
+---
 
-# Getting Started
+import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
-luma.gl is a TypeScript toolkit for applications that need direct, portable access to
-WebGPU and WebGL2. This guide creates a small rendering project that tries WebGPU first
-and falls back to WebGL2.
-
-## Prerequisites
-
-- A current Node.js LTS release
-- A browser with WebGPU or WebGL2 support
-- Basic TypeScript knowledge
-
-:::tip
-
-If your goal is a geospatial visualization rather than a GPU framework or custom
-renderer, start with [deck.gl](https://deck.gl) instead. deck.gl is built on luma.gl and
-provides higher-level layers, cameras, and interaction.
-
-:::
-
-## Create a project
-
-<Tabs groupId="package-manager">
-  <TabItem value="npm" label="npm" default>
-
-```bash
-npm create vite@latest luma-demo -- --template vanilla-ts
-cd luma-demo
-npm install @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl
-```
-
-  </TabItem>
-  <TabItem value="yarn" label="yarn">
-
-```bash
-yarn create vite luma-demo --template vanilla-ts
-cd luma-demo
-yarn add @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl
-```
-
-  </TabItem>
-  <TabItem value="pnpm" label="pnpm">
-
-```bash
-pnpm create vite luma-demo --template vanilla-ts
-cd luma-demo
-pnpm add @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl
-```
-
-  </TabItem>
-</Tabs>
-
-Replace `src/main.ts` with:
-
-```typescript
-import {AnimationLoopTemplate, type AnimationProps, makeAnimationLoop} from '@luma.gl/engine';
-import {webgpuAdapter} from '@luma.gl/webgpu';
-import {webgl2Adapter} from '@luma.gl/webgl';
-
-class App extends AnimationLoopTemplate {
-  override onRender({device}: AnimationProps): void {
-    const renderPass = device.beginRenderPass({
-      clearColor: [0.05, 0.08, 0.14, 1]
-    });
-    renderPass.end();
-  }
+export function OnboardingPoster({image, alt, className, loading = 'lazy'}) {
+  return (
+    <img
+      alt={alt}
+      className={className}
+      decoding="async"
+      height={720}
+      loading={loading}
+      src={useBaseUrl(`/images/examples/${image}`)}
+      width={1280}
+    />
+  );
 }
 
-makeAnimationLoop(App, {
-  adapters: [webgpuAdapter, webgl2Adapter]
-}).start();
-```
+<div className="luma-onboarding">
+  <header className="luma-onboarding__hero" aria-labelledby="luma-onboarding-title">
+    <OnboardingPoster
+      alt="Moonlight illuminating a cinematic, GPU-simulated ocean"
+      className="luma-onboarding__hero-image"
+      image="showcase/tempest-ocean.jpg"
+      loading="eager"
+    />
+    <div className="luma-onboarding__hero-content">
+      <p className="luma-onboarding__eyebrow">Start with what is possible</p>
+      <h1 className="luma-onboarding__title" id="luma-onboarding-title">
+        {'Your GPU is the canvas.'}
+      </h1>
+      <p className="luma-onboarding__subtitle">
+        {'Build living worlds, simulate light and motion, and move millions of data points—at the speed of the browser.'}
+      </p>
+      <div className="luma-onboarding__actions">
+        <Link
+          className="luma-onboarding__action luma-onboarding__action--primary"
+          to="/examples"
+        >
+          <span>Explore live examples</span> <span aria-hidden="true">↗</span>
+        </Link>
+        <Link
+          className="luma-onboarding__action luma-onboarding__action--secondary"
+          to="/docs/tutorials/hello-triangle"
+        >
+          <span>See your first triangle</span> <span aria-hidden="true">→</span>
+        </Link>
+      </div>
+      <p className="luma-onboarding__note">
+        <span className="luma-onboarding__status-dot" aria-hidden="true" />
+        <span>No installation. No account. Just your browser.</span>
+      </p>
+    </div>
+  </header>
 
-Start the development server:
+  <section className="luma-onboarding__section" aria-labelledby="luma-onboarding-examples">
+    <p className="luma-onboarding__section-label">01 · See it in motion</p>
+    <h2 className="luma-onboarding__section-title" id="luma-onboarding-examples">
+      {'This is what your browser can do.'}
+    </h2>
+    <p className="luma-onboarding__section-description">
+      {'These are interactive scenes, not videos. Open one, explore it, and look under the hood.'}
+    </p>
 
-<Tabs groupId="package-manager">
-  <TabItem value="npm" label="npm" default>
+    <div className="luma-onboarding__gallery">
+      <Link
+        className="luma-onboarding__showcase"
+        to="/examples/showcase/lightstorm-megacity"
+      >
+        <div className="luma-onboarding__showcase-media">
+          <OnboardingPoster
+            alt="A rain-soaked neon city illuminated by thousands of GPU-driven lights"
+            className="luma-onboarding__showcase-image"
+            image="showcase/lightstorm-megacity.jpg"
+          />
+        </div>
+        <div className="luma-onboarding__showcase-content">
+          <span className="luma-onboarding__showcase-kicker">Real-time lighting</span>
+          <h3 className="luma-onboarding__showcase-title">Lightstorm Megacity</h3>
+          <p className="luma-onboarding__showcase-description">
+            {'Fly between rain-soaked towers beneath lightning, reflections, and thousands of lights.'}
+          </p>
+          <div className="luma-onboarding__showcase-meta">
+            <span className="luma-onboarding__badge">WebGPU</span>
+            <span className="luma-onboarding__badge">HDR</span>
+          </div>
+        </div>
+      </Link>
 
-```bash
-npm run dev
-```
+      <Link className="luma-onboarding__showcase" to="/examples/showcase/tempest-ocean">
+        <div className="luma-onboarding__showcase-media">
+          <OnboardingPoster
+            alt="A moonlit storm ocean with physically simulated waves and luminous foam"
+            className="luma-onboarding__showcase-image"
+            image="showcase/tempest-ocean.jpg"
+          />
+        </div>
+        <div className="luma-onboarding__showcase-content">
+          <span className="luma-onboarding__showcase-kicker">Physical simulation</span>
+          <h3 className="luma-onboarding__showcase-title">Tempest Ocean</h3>
+          <p className="luma-onboarding__showcase-description">
+            {'Cross an endless spectral ocean shaped by wind, whitecaps, and moonlight.'}
+          </p>
+          <div className="luma-onboarding__showcase-meta">
+            <span className="luma-onboarding__badge">WebGPU</span>
+            <span className="luma-onboarding__badge">HDR</span>
+          </div>
+        </div>
+      </Link>
 
-  </TabItem>
-  <TabItem value="yarn" label="yarn">
+      <Link
+        className="luma-onboarding__showcase"
+        to="/examples/experimental/spectral-caustics"
+      >
+        <div className="luma-onboarding__showcase-media">
+          <OnboardingPoster
+            alt="Rainbow caustics refracting through a crystal inside an atmospheric cathedral"
+            className="luma-onboarding__showcase-image"
+            image="experimental/spectral-caustics.jpg"
+          />
+        </div>
+        <div className="luma-onboarding__showcase-content">
+          <span className="luma-onboarding__showcase-kicker">Light transport</span>
+          <h3 className="luma-onboarding__showcase-title">Prism Cathedral</h3>
+          <p className="luma-onboarding__showcase-description">
+            {'Follow spectral light through glass as rainbow caustics travel across stone.'}
+          </p>
+          <div className="luma-onboarding__showcase-meta">
+            <span className="luma-onboarding__badge">WebGPU</span>
+            <span className="luma-onboarding__badge">Caustics</span>
+          </div>
+        </div>
+      </Link>
 
-```bash
-yarn dev
-```
+      <Link className="luma-onboarding__showcase" to="/examples/experimental/fluid-foundry">
+        <div className="luma-onboarding__showcase-media">
+          <OnboardingPoster
+            alt="Liquid metal pouring and splashing inside an interactive industrial foundry"
+            className="luma-onboarding__showcase-image"
+            image="experimental/fluid-foundry.jpg"
+          />
+        </div>
+        <div className="luma-onboarding__showcase-content">
+          <span className="luma-onboarding__showcase-kicker">GPU compute</span>
+          <h3 className="luma-onboarding__showcase-title">Fluid Foundry</h3>
+          <p className="luma-onboarding__showcase-description">
+            {'Pour, splash, and reshape liquid metal without moving simulation data off the GPU.'}
+          </p>
+          <div className="luma-onboarding__showcase-meta">
+            <span className="luma-onboarding__badge">WebGPU</span>
+            <span className="luma-onboarding__badge">Simulation</span>
+          </div>
+        </div>
+      </Link>
 
-  </TabItem>
-  <TabItem value="pnpm" label="pnpm">
+      <Link
+        className="luma-onboarding__showcase"
+        to="/examples/experimental/virtual-geometry-canyon"
+      >
+        <div className="luma-onboarding__showcase-media">
+          <OnboardingPoster
+            alt="A vast desert canyon assembled from continuously streaming virtual geometry"
+            className="luma-onboarding__showcase-image"
+            image="experimental/virtual-geometry-canyon.jpg"
+          />
+        </div>
+        <div className="luma-onboarding__showcase-content">
+          <span className="luma-onboarding__showcase-kicker">Virtual geometry</span>
+          <h3 className="luma-onboarding__showcase-title">Virtual Geometry Canyon</h3>
+          <p className="luma-onboarding__showcase-description">
+            {'Travel across a massive procedural landscape that streams detail as you move.'}
+          </p>
+          <div className="luma-onboarding__showcase-meta">
+            <span className="luma-onboarding__badge">WebGPU</span>
+            <span className="luma-onboarding__badge">Geometry</span>
+          </div>
+        </div>
+      </Link>
 
-```bash
-pnpm dev
-```
+      <Link className="luma-onboarding__showcase" to="/examples/showcase/postprocessing">
+        <div className="luma-onboarding__showcase-media">
+          <OnboardingPoster
+            alt="Colorful animated geometry transformed by a stack of interactive image effects"
+            className="luma-onboarding__showcase-image"
+            image="showcase/postprocessing.jpg"
+          />
+        </div>
+        <div className="luma-onboarding__showcase-content">
+          <span className="luma-onboarding__showcase-kicker">Composable effects</span>
+          <h3 className="luma-onboarding__showcase-title">Image Processing</h3>
+          <p className="luma-onboarding__showcase-description">
+            {'Layer bloom, color grading, distortion, and film effects over a living scene.'}
+          </p>
+          <div className="luma-onboarding__showcase-meta">
+            <span className="luma-onboarding__badge">WebGPU</span>
+            <span className="luma-onboarding__badge">WebGL2</span>
+          </div>
+        </div>
+      </Link>
+    </div>
+  </section>
 
-  </TabItem>
-</Tabs>
+  <section className="luma-onboarding__section" aria-labelledby="luma-onboarding-capabilities">
+    <p className="luma-onboarding__section-label">02 · Built for ambitious ideas</p>
+    <h2 className="luma-onboarding__section-title" id="luma-onboarding-capabilities">
+      {'The whole GPU. Your way.'}
+    </h2>
+    <p className="luma-onboarding__section-description">
+      {'Start with a simple triangle or architect an entire rendering and compute pipeline.'}
+    </p>
 
-You should see a dark canvas. luma.gl creates the best available device, begins a render
-pass each frame, and presents the result to the page.
+    <div className="luma-onboarding__capabilities">
+      <article className="luma-onboarding__capability">
+        <span className="luma-onboarding__capability-index">01</span>
+        <h3 className="luma-onboarding__capability-title">Render without a ceiling.</h3>
+        <p className="luma-onboarding__capability-description">
+          {'Compose models, materials, HDR lighting, shader effects, and GPU-driven geometry at interactive frame rates.'}
+        </p>
+      </article>
+      <article className="luma-onboarding__capability">
+        <span className="luma-onboarding__capability-index">02</span>
+        <h3 className="luma-onboarding__capability-title">Keep the data moving.</h3>
+        <p className="luma-onboarding__capability-description">
+          {'Run fluid simulations, spatial queries, and million-point visualizations directly where the data lives: on the GPU.'}
+        </p>
+      </article>
+      <article className="luma-onboarding__capability">
+        <span className="luma-onboarding__capability-index">03</span>
+        <h3 className="luma-onboarding__capability-title">Write once. Choose your backend.</h3>
+        <p className="luma-onboarding__capability-description">
+          {'Build against one clear TypeScript API and run on WebGPU or WebGL2, with natural paths into deck.gl and Apache Arrow.'}
+        </p>
+      </article>
+    </div>
+  </section>
 
-## Choose a learning path
+  <section className="luma-onboarding__section" aria-labelledby="luma-onboarding-paths">
+    <p className="luma-onboarding__section-label">03 · Find your starting point</p>
+    <h2 className="luma-onboarding__section-title" id="luma-onboarding-paths">
+      {'Choose your own first adventure.'}
+    </h2>
 
-<div className="docs-api-card-grid">
-  <a className="docs-api-card" href="/docs/tutorials/hello-triangle">
-    <span className="docs-api-card__kind">Recommended</span>
-    <strong>Rendering with the Engine API</strong>
-    <span>Draw a triangle, add geometry and textures, then move on to instancing and reusable shaders.</span>
-    <span className="docs-api-card__meta">Start with Model and AnimationLoop</span>
-  </a>
-  <a className="docs-api-card" href="/docs/api-guide/gpu">
-    <span className="docs-api-card__kind">Lower level</span>
-    <strong>GPU resources and compute</strong>
-    <span>Work directly with devices, buffers, textures, bindings, command encoders, and compute passes.</span>
-    <span className="docs-api-card__meta">Start with the portable GPU API</span>
-  </a>
+    <div className="luma-onboarding__paths">
+      <Link className="luma-onboarding__path" to="/docs/tutorials/hello-triangle">
+        <span className="luma-onboarding__path-kicker">Start here</span>
+        <h3 className="luma-onboarding__path-title">Draw your first triangle.</h3>
+        <p className="luma-onboarding__path-description">
+          {'Watch a live, backend-switchable example, then follow its complete rendering pipeline.'}
+        </p>
+        <span className="luma-onboarding__path-meta">Interactive fundamentals →</span>
+      </Link>
+      <Link className="luma-onboarding__path" to="/docs/api-guide/engine">
+        <span className="luma-onboarding__path-kicker">Build worlds</span>
+        <h3 className="luma-onboarding__path-title">Meet the rendering engine.</h3>
+        <p className="luma-onboarding__path-description">
+          {'Explore models, animation loops, geometry, materials, and reusable shader modules.'}
+        </p>
+        <span className="luma-onboarding__path-meta">Engine API guide →</span>
+      </Link>
+      <Link className="luma-onboarding__path" to="/docs/api-guide/gpu/gpu-data-processing">
+        <span className="luma-onboarding__path-kicker">Move faster</span>
+        <h3 className="luma-onboarding__path-title">Think in GPU compute.</h3>
+        <p className="luma-onboarding__path-description">
+          {'Keep data resident for simulation, filtering, aggregation, and spatial processing.'}
+        </p>
+        <span className="luma-onboarding__path-meta">GPU data processing →</span>
+      </Link>
+      <Link className="luma-onboarding__path" to="/docs/api-guide/shaders/shader-passes">
+        <span className="luma-onboarding__path-kicker">Create effects</span>
+        <h3 className="luma-onboarding__path-title">Shape every pixel.</h3>
+        <p className="luma-onboarding__path-description">
+          {'Combine post-processing passes, custom shaders, and reusable effects into your look.'}
+        </p>
+        <span className="luma-onboarding__path-meta">Shader and effect passes →</span>
+      </Link>
+    </div>
+  </section>
+
+  <section className="luma-onboarding__closing" aria-labelledby="luma-onboarding-build">
+    <div>
+      <h2 className="luma-onboarding__closing-title" id="luma-onboarding-build">
+        {'Ready to make something move?'}
+      </h2>
+      <p className="luma-onboarding__closing-description">
+        {'Your first real project is only a few steps away.'}
+      </p>
+    </div>
+    <Link
+      className="luma-onboarding__action luma-onboarding__action--primary"
+      to="/docs/developer-guide/installing"
+    >
+      <span>Build your first project</span> <span aria-hidden="true">→</span>
+    </Link>
+  </section>
 </div>
-
-## How backend selection works
-
-The application supplies both adapters in preference order. A WebGPU-capable browser
-uses `webgpuAdapter`; other supported browsers fall back to `webgl2Adapter`. Application
-code continues to use the same luma.gl `Device`, resource, and render-pass APIs.
-
-Use only `webgpuAdapter` when your application depends on compute shaders, storage
-textures, or another WebGPU-only feature. The documentation marks backend-specific
-features explicitly.
-
-## Troubleshooting
-
-### The canvas is blank
-
-Check the browser console first. Confirm that `src/main.ts` is imported by `index.html`
-and that the canvas is not hidden by application CSS.
-
-### WebGPU is unavailable
-
-The example should fall back to WebGL2. To debug WebGPU specifically, consult the
-[WebGPU and WebGL comparison](/docs/api-guide/background/webgpu-vs-webgl) and inspect
-the selected device in your browser developer tools.
-
-### TypeScript cannot resolve a package
-
-Install all three packages shown above. `@luma.gl/engine` provides `AnimationLoop` and
-`Model`; `@luma.gl/webgpu` and `@luma.gl/webgl` provide the concrete device adapters.
-
-## Next step
-
-Continue with [Hello Triangle](/docs/tutorials/hello-triangle), where the empty render
-pass becomes a complete portable draw call.

--- a/docs/tutorials/README.mdx
+++ b/docs/tutorials/README.mdx
@@ -9,9 +9,11 @@ live example that can switch between WebGPU and WebGL2 when both backends suppor
 feature. The files shown on each page are loaded from the runnable examples in this
 repository, so the documentation and tested code stay in sync.
 
-Before starting, complete [Getting Started](/docs/getting-started). Familiarity with
-TypeScript and basic GPU concepts is helpful; the tutorials explain the luma.gl object
-model as it is introduced.
+Explore [Getting Started](/docs/getting-started) to see what you can build, or open any
+live lesson immediately. When you are ready to run the examples locally, follow the
+[Installing guide](/docs/developer-guide/installing). Familiarity with TypeScript and
+basic GPU concepts is helpful; the tutorials explain the luma.gl object model as it is
+introduced.
 
 ## Rendering foundations
 

--- a/docs/tutorials/hello-triangle.mdx
+++ b/docs/tutorials/hello-triangle.mdx
@@ -7,8 +7,10 @@ import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 <TutorialDocsTabs group="fundamentals" active="hello-triangle" />
 
-**Goal:** create one `Model` and issue a portable draw call. Complete
-[Getting Started](/docs/getting-started) before this lesson.
+**Goal:** create one `Model` and issue a portable draw call. Explore the live example
+below immediately, or follow the [Installing guide](/docs/developer-guide/installing) to
+run its source locally. New to luma.gl? [Getting Started](/docs/getting-started) shows
+what you can build next.
 
 <DeviceTabs />
 <HelloTriangleExample showHeader={false} showStats={false} />

--- a/test/examples/getting-started-onboarding.node.spec.ts
+++ b/test/examples/getting-started-onboarding.node.spec.ts
@@ -1,0 +1,138 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {existsSync, readFileSync, statSync} from 'node:fs';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+const ONBOARDING_SOURCE_PATH = path.join(process.cwd(), 'docs/getting-started.mdx');
+const INSTALLATION_SOURCE_PATH = path.join(process.cwd(), 'docs/developer-guide/installing.md');
+const EXAMPLE_IMAGES_DIRECTORY = path.join(process.cwd(), 'website/static/images/examples');
+const EXAMPLE_CONTENT_DIRECTORY = path.join(process.cwd(), 'website/content/examples');
+const EXTRACTION_CHECKER_PATH = path.join(process.cwd(), 'website/scripts/check-llm-output.mjs');
+
+describe('getting-started onboarding', () => {
+  test('introduces real, immediately explorable GPU experiences before technical setup', () => {
+    const onboardingSource = readFileSync(ONBOARDING_SOURCE_PATH, 'utf8');
+    const installationLinkOffset = onboardingSource.indexOf('/docs/developer-guide/installing');
+
+    expect(onboardingSource).toMatch(/<h1\b|^#\s+.+/m);
+    expect(onboardingSource).toMatch(/WebGPU/);
+    expect(onboardingSource).toMatch(/simulation|rendering|visual effects/i);
+    expect(onboardingSource).toMatch(/no installation\.\s*no account\.\s*just your browser/i);
+    expect(installationLinkOffset).toBeGreaterThan(0);
+    expect(onboardingSource).not.toMatch(/\bNode(?:\.js)?\b/i);
+    expect(onboardingSource).not.toMatch(/^#{2,}\s+Prerequisites\b/im);
+    expect(onboardingSource).not.toMatch(
+      /(?:^|\n)\s*(?:npm|yarn|pnpm)\s+(?:create|install|add|run|dev)\b/i
+    );
+
+    const onboardingPosters = Array.from(
+      onboardingSource.matchAll(
+        /<OnboardingPoster\b(?=[^>]*\bimage\s*=\s*["']([^"']+\.(?:jpe?g|png|webp))["'])[^>]*>/g
+      ),
+      match => ({image: match[1], offset: match.index ?? -1})
+    );
+    const linkedExampleRoutes = new Set(
+      Array.from(
+        onboardingSource.matchAll(
+          /<(?:Link|a)\b(?=[^>]*\b(?:to|href)\s*=\s*["'](\/examples\/[^"']+)["'])[^>]*>/g
+        ),
+        match => match[1]
+      )
+    );
+
+    expect(new Set(onboardingPosters.map(poster => poster.image)).size).toBeGreaterThanOrEqual(6);
+
+    for (const poster of onboardingPosters) {
+      const posterPath = path.join(EXAMPLE_IMAGES_DIRECTORY, poster.image);
+      const exampleIdentifier = poster.image.replace(/\.(?:jpe?g|png|webp)$/i, '');
+      const exampleRoute = `/examples/${exampleIdentifier}`;
+
+      expect(poster.offset, `${poster.image} must appear before local setup`).toBeLessThan(
+        installationLinkOffset
+      );
+      expect(existsSync(posterPath), `${poster.image} must be a real example screenshot`).toBe(
+        true
+      );
+      expect(statSync(posterPath).size, `${poster.image} must not be empty`).toBeGreaterThan(0);
+      expect(
+        linkedExampleRoutes.has(exampleRoute),
+        `${poster.image} must link to its interactive example`
+      ).toBe(true);
+      expect(
+        existsSync(path.join(EXAMPLE_CONTENT_DIRECTORY, `${exampleIdentifier}.mdx`)),
+        `${exampleRoute} must resolve to a live example page`
+      ).toBe(true);
+    }
+  });
+
+  test('preserves the complete runnable setup in the dedicated installation guide', () => {
+    const installationSource = readFileSync(INSTALLATION_SOURCE_PATH, 'utf8');
+
+    expect(installationSource).toMatch(/^# Installing$/m);
+    expect(installationSource).toMatch(/^## A Minimal Install$/m);
+    expect(installationSource).toMatch(/^## A Typical Install$/m);
+    expect(installationSource).toMatch(/\bNode\.js\b/);
+
+    for (const requiredSetup of [
+      'npm create vite@latest luma-demo -- --template vanilla-ts',
+      'yarn create vite luma-demo --template vanilla-ts',
+      'pnpm create vite luma-demo --template vanilla-ts',
+      'npm install @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl',
+      'yarn add @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl',
+      'pnpm add @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl',
+      'npm run dev',
+      'yarn dev',
+      'pnpm dev',
+      'class App extends AnimationLoopTemplate',
+      'adapters: [webgpuAdapter, webgl2Adapter]',
+      '## How Backend Selection Works',
+      '## Troubleshooting',
+      '### The Canvas Is Blank',
+      '### WebGPU Is Unavailable',
+      '### TypeScript Cannot Resolve a Package'
+    ]) {
+      expect(installationSource, `The installation guide must retain ${requiredSetup}`).toContain(
+        requiredSetup
+      );
+    }
+
+    expect(installationSource).not.toMatch(/<(?:Tabs|TabItem)\b/);
+  });
+
+  test('validates runnable LLM setup against Installing while keeping onboarding readable', () => {
+    const extractionCheckerSource = readFileSync(EXTRACTION_CHECKER_PATH, 'utf8');
+
+    expect(extractionCheckerSource).toContain(
+      "const installingPath = requireFile('docs/developer-guide/installing.md')"
+    );
+    expect(extractionCheckerSource).toContain(
+      "const installing = readFileSync(installingPath, 'utf8')"
+    );
+    expect(extractionCheckerSource).toContain('if (!installing.includes(expectedText))');
+    expect(extractionCheckerSource).not.toContain('if (!gettingStarted.includes(expectedText))');
+    expect(extractionCheckerSource).toContain('gettingStarted.trim().length');
+    expect(extractionCheckerSource).toContain('unprocessed MDX components');
+  });
+
+  test('keeps discovery and local installation as separate documentation journeys', () => {
+    const documentationOverview = readFileSync(path.join(process.cwd(), 'docs/README.mdx'), 'utf8');
+    const tutorialOverview = readFileSync(
+      path.join(process.cwd(), 'docs/tutorials/README.mdx'),
+      'utf8'
+    );
+    const helloTriangle = readFileSync(
+      path.join(process.cwd(), 'docs/tutorials/hello-triangle.mdx'),
+      'utf8'
+    );
+
+    expect(documentationOverview).toContain('Discover what you can build');
+    expect(documentationOverview).toContain('No installation required');
+    for (const documentationSource of [documentationOverview, tutorialOverview, helloTriangle]) {
+      expect(documentationSource).toContain('/docs/getting-started');
+      expect(documentationSource).toContain('/docs/developer-guide/installing');
+    }
+  });
+});

--- a/website/scripts/check-llm-output.mjs
+++ b/website/scripts/check-llm-output.mjs
@@ -123,6 +123,7 @@ const requiredIndexLinks = [
   'docs/tutorials/hello-triangle.md',
   'docs/api-guide.md',
   'docs/api-reference.md',
+  'docs/developer-guide/installing.md',
   'docs/developer-guide/working-with-ai.md'
 ].map((relativePath) => new URL(relativePath, websiteUrl).href);
 for (const link of requiredIndexLinks) {
@@ -132,6 +133,7 @@ for (const link of requiredIndexLinks) {
 }
 
 const gettingStartedPath = requireFile('docs/getting-started.md');
+const installingPath = requireFile('docs/developer-guide/installing.md');
 const workingWithAiPath = requireFile('docs/developer-guide/working-with-ai.md');
 requireFile('docs.md');
 requireFile('docs/api-guide.md');
@@ -151,13 +153,28 @@ if (markdownFiles.length < 100) {
 }
 
 const gettingStarted = readFileSync(gettingStartedPath, 'utf8');
-for (const expectedText of ['npm create vite', 'yarn create vite', 'pnpm create vite']) {
-  if (!gettingStarted.includes(expectedText)) {
-    fail(`rendered Getting Started Markdown is missing "${expectedText}"`);
-  }
+if (gettingStarted.trim().length < 80) {
+  fail('rendered Getting Started Markdown has empty editorial content');
 }
-if (gettingStarted.includes('<Tabs') || gettingStarted.includes('<TabItem')) {
+if (/<(?:Tabs|TabItem|OnboardingPoster|Link)\b/.test(gettingStarted)) {
   fail('rendered Getting Started Markdown contains unprocessed MDX components');
+}
+
+const installing = readFileSync(installingPath, 'utf8');
+for (const expectedText of [
+  'npm create vite',
+  'yarn create vite',
+  'pnpm create vite',
+  'makeAnimationLoop',
+  'webgpuAdapter',
+  'webgl2Adapter',
+  'npm run dev',
+  'yarn dev',
+  'pnpm dev'
+]) {
+  if (!installing.includes(expectedText)) {
+    fail(`rendered Installing Markdown is missing "${expectedText}"`);
+  }
 }
 
 const workingWithAi = readFileSync(workingWithAiPath, 'utf8');

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -1290,3 +1290,650 @@ body:has(.textures-example-page) .theme-layout-footer,
 body:has(.integration-example-page) .theme-layout-footer {
   display: none;
 }
+
+/* Getting Started is an invitation into the GPU laboratory, not an install screen. */
+.markdown .luma-onboarding {
+  --luma-onboarding-surface: #fff;
+  --luma-onboarding-surface-raised: #f4f7fb;
+  --luma-onboarding-text: #111d30;
+  --luma-onboarding-muted: #52647a;
+  --luma-onboarding-border: rgba(15, 23, 42, 0.12);
+  --luma-onboarding-accent: #0369a1;
+  --luma-onboarding-shadow: 0 20px 52px rgba(15, 23, 42, 0.09);
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  margin-bottom: 3rem;
+  color: var(--luma-onboarding-text);
+}
+
+html[data-theme="dark"] .markdown .luma-onboarding {
+  --luma-onboarding-surface: #111b2a;
+  --luma-onboarding-surface-raised: #172338;
+  --luma-onboarding-text: #eff6ff;
+  --luma-onboarding-muted: #b0bfd2;
+  --luma-onboarding-border: rgba(148, 163, 184, 0.2);
+  --luma-onboarding-accent: #7dd3fc;
+  --luma-onboarding-shadow: 0 20px 52px rgba(2, 6, 23, 0.28);
+}
+
+.markdown .luma-onboarding__hero {
+  position: relative;
+  display: flex;
+  min-height: 470px;
+  align-items: flex-end;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.19);
+  border-radius: 24px;
+  background: #07101d;
+  box-shadow: 0 26px 68px rgba(2, 6, 23, 0.22);
+  color: #f8fafc;
+  isolation: isolate;
+}
+
+.markdown .luma-onboarding__hero::before,
+.markdown .luma-onboarding__hero::after {
+  position: absolute;
+  z-index: 1;
+  content: "";
+  inset: 0;
+  pointer-events: none;
+}
+
+.markdown .luma-onboarding__hero::before {
+  background:
+    linear-gradient(90deg, rgba(3, 8, 17, 0.97) 0%, rgba(3, 8, 17, 0.76) 51%, transparent 100%),
+    linear-gradient(0deg, rgba(3, 8, 17, 0.93), transparent 67%);
+}
+
+.markdown .luma-onboarding__hero::after {
+  animation: lumaOnboardingGlow 11s ease-in-out infinite alternate;
+  background:
+    radial-gradient(ellipse at 9% 13%, rgba(56, 189, 248, 0.25), transparent 42%),
+    radial-gradient(ellipse at 86% 91%, rgba(129, 140, 248, 0.18), transparent 38%);
+}
+
+.markdown .luma-onboarding__hero-image {
+  position: absolute;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  animation: lumaOnboardingScene 22s ease-in-out infinite alternate;
+  inset: 0;
+  object-fit: cover;
+  object-position: 61% 48%;
+  opacity: 0.84;
+}
+
+.markdown .luma-onboarding__hero-content {
+  position: relative;
+  z-index: 2;
+  width: min(100%, 680px);
+  min-width: 0;
+  padding: clamp(36px, 6vw, 64px);
+}
+
+.markdown .luma-onboarding__eyebrow,
+.markdown .luma-onboarding__section-label,
+.markdown .luma-onboarding__showcase-kicker,
+.markdown .luma-onboarding__path-kicker {
+  margin: 0;
+  font-size: 0.71rem;
+  font-weight: 760;
+  letter-spacing: 0.12em;
+  line-height: 1.45;
+  text-transform: uppercase;
+}
+
+.markdown .luma-onboarding__eyebrow {
+  margin-bottom: 18px;
+  color: #a5f3fc;
+}
+
+.markdown .luma-onboarding__title {
+  max-width: 12ch;
+  margin: 0;
+  color: #f8fafc;
+  font-size: clamp(2.9rem, 6.7vw, 5.4rem);
+  font-weight: 790;
+  letter-spacing: -0.043em;
+  line-height: 0.98;
+}
+
+.markdown .luma-onboarding__subtitle {
+  max-width: 48ch;
+  margin: 18px 0 0;
+  color: #d2deec;
+  font-size: clamp(0.97rem, 1.5vw, 1.12rem);
+  line-height: 1.68;
+}
+
+.markdown .luma-onboarding__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 11px;
+  margin-top: 28px;
+}
+
+.markdown .luma-onboarding__action {
+  display: inline-flex;
+  max-width: 100%;
+  min-height: 46px;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 0.84rem;
+  font-weight: 720;
+  line-height: 1.2;
+  padding: 0 18px;
+  text-decoration: none;
+  transition:
+    background-color 170ms ease,
+    border-color 170ms ease,
+    box-shadow 170ms ease,
+    color 170ms ease,
+    transform 170ms ease;
+}
+
+.markdown .luma-onboarding__action--primary {
+  border-color: #fff;
+  background: #f8fafc;
+  box-shadow: 0 8px 26px rgba(56, 189, 248, 0.2);
+  color: #071625;
+}
+
+.markdown .luma-onboarding__action--primary:hover,
+.markdown .luma-onboarding__action--primary:focus-visible {
+  background: #cffafe;
+  box-shadow: 0 0 28px rgba(103, 232, 249, 0.36);
+  color: #071625;
+  text-decoration: none;
+  transform: translateY(-2px);
+}
+
+.markdown .luma-onboarding__action--secondary {
+  border-color: rgba(226, 232, 240, 0.36);
+  background: rgba(15, 23, 42, 0.64);
+  color: #f1f5f9;
+}
+
+.markdown .luma-onboarding__action--secondary:hover,
+.markdown .luma-onboarding__action--secondary:focus-visible {
+  border-color: rgba(125, 211, 252, 0.84);
+  background: rgba(15, 23, 42, 0.86);
+  color: #f8fafc;
+  text-decoration: none;
+  transform: translateY(-2px);
+}
+
+.markdown .luma-onboarding__note {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+  margin: 20px 0 0;
+  color: #b5c5d8;
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.markdown .luma-onboarding__status-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 8px;
+  border-radius: 50%;
+  animation: lumaOnboardingPulse 2.4s ease-in-out infinite;
+  background: #6ee7b7;
+  box-shadow: 0 0 13px rgba(110, 231, 183, 0.7);
+}
+
+.markdown .luma-onboarding__section {
+  margin-top: clamp(58px, 8vw, 88px);
+}
+
+.markdown .luma-onboarding__section-label,
+.markdown .luma-onboarding__showcase-kicker,
+.markdown .luma-onboarding__path-kicker {
+  color: var(--luma-onboarding-accent);
+}
+
+.markdown .luma-onboarding__section-title {
+  margin: 12px 0 0;
+  color: var(--luma-onboarding-text);
+  font-size: clamp(2rem, 4.4vw, 3.25rem);
+  font-weight: 760;
+  letter-spacing: -0.035em;
+  line-height: 1.08;
+}
+
+.markdown .luma-onboarding__section-description {
+  max-width: 64ch;
+  margin: 11px 0 0;
+  color: var(--luma-onboarding-muted);
+  font-size: 0.99rem;
+  line-height: 1.72;
+}
+
+.markdown .luma-onboarding__gallery {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 19px;
+  margin-top: 30px;
+}
+
+.markdown .luma-onboarding__showcase {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--luma-onboarding-border);
+  border-radius: 18px;
+  background: var(--luma-onboarding-surface);
+  box-shadow: var(--luma-onboarding-shadow);
+  color: var(--luma-onboarding-text);
+  text-decoration: none;
+  transition:
+    border-color 190ms ease,
+    box-shadow 190ms ease,
+    transform 190ms ease;
+}
+
+.markdown .luma-onboarding__showcase:hover,
+.markdown .luma-onboarding__showcase:focus-visible {
+  border-color: var(--luma-onboarding-accent);
+  box-shadow:
+    var(--luma-onboarding-shadow),
+    0 0 0 1px color-mix(in srgb, var(--luma-onboarding-accent) 34%, transparent);
+  color: var(--luma-onboarding-text);
+  text-decoration: none;
+  transform: translateY(-4px);
+}
+
+.markdown .luma-onboarding__showcase--featured {
+  grid-column: 1 / -1;
+}
+
+.markdown .luma-onboarding__showcase-media {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  background: #0b1422;
+}
+
+.markdown .luma-onboarding__showcase--featured .luma-onboarding__showcase-media {
+  max-height: 290px;
+  aspect-ratio: 21 / 9;
+}
+
+.markdown .luma-onboarding__showcase-media::after {
+  position: absolute;
+  background: linear-gradient(0deg, rgba(2, 6, 23, 0.37), transparent 45%);
+  content: "";
+  inset: 0;
+  pointer-events: none;
+}
+
+.markdown .luma-onboarding__showcase-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 520ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.markdown .luma-onboarding__showcase:hover .luma-onboarding__showcase-image,
+.markdown .luma-onboarding__showcase:focus-visible .luma-onboarding__showcase-image {
+  transform: scale(1.045);
+}
+
+.markdown .luma-onboarding__showcase-content {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  padding: 19px 19px 18px;
+}
+
+.markdown .luma-onboarding__showcase-title {
+  margin: 9px 0 0;
+  color: var(--luma-onboarding-text);
+  font-size: 1.17rem;
+  font-weight: 730;
+  letter-spacing: -0.028em;
+  line-height: 1.3;
+}
+
+.markdown .luma-onboarding__showcase--featured .luma-onboarding__showcase-title {
+  font-size: clamp(1.32rem, 2.5vw, 1.75rem);
+}
+
+.markdown .luma-onboarding__showcase-description {
+  margin: 8px 0 15px;
+  color: var(--luma-onboarding-muted);
+  font-size: 0.88rem;
+  line-height: 1.63;
+}
+
+.markdown .luma-onboarding__showcase-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: auto;
+}
+
+.markdown .luma-onboarding__badge {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--luma-onboarding-border);
+  border-radius: 999px;
+  background: var(--luma-onboarding-surface-raised);
+  color: var(--luma-onboarding-muted);
+  font-size: 0.68rem;
+  font-weight: 650;
+  line-height: 1;
+  padding: 6px 9px;
+}
+
+.markdown .luma-onboarding__capabilities {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 15px;
+  margin-top: 28px;
+}
+
+.markdown .luma-onboarding__capability {
+  min-width: 0;
+  border: 1px solid var(--luma-onboarding-border);
+  border-radius: 17px;
+  background:
+    radial-gradient(ellipse at 100% 0, rgba(56, 189, 248, 0.08), transparent 70%),
+    var(--luma-onboarding-surface);
+  padding: 23px 20px 22px;
+}
+
+.markdown .luma-onboarding__capability-index {
+  margin: 0;
+  color: var(--luma-onboarding-accent);
+  font-size: 0.75rem;
+  font-weight: 730;
+  letter-spacing: 0.1em;
+}
+
+.markdown .luma-onboarding__capability-title {
+  margin: 18px 0 0;
+  color: var(--luma-onboarding-text);
+  font-size: 1.12rem;
+  font-weight: 720;
+  letter-spacing: -0.023em;
+  line-height: 1.35;
+}
+
+.markdown .luma-onboarding__capability-description {
+  margin: 9px 0 0;
+  color: var(--luma-onboarding-muted);
+  font-size: 0.86rem;
+  line-height: 1.68;
+}
+
+.markdown .luma-onboarding__paths {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 15px;
+  margin-top: 28px;
+}
+
+.markdown .luma-onboarding__path {
+  display: flex;
+  min-width: 0;
+  min-height: 190px;
+  flex-direction: column;
+  border: 1px solid var(--luma-onboarding-border);
+  border-radius: 17px;
+  background: var(--luma-onboarding-surface);
+  color: var(--luma-onboarding-text);
+  padding: 22px 21px;
+  text-decoration: none;
+  transition:
+    border-color 170ms ease,
+    box-shadow 170ms ease,
+    transform 170ms ease;
+}
+
+.markdown .luma-onboarding__path:hover,
+.markdown .luma-onboarding__path:focus-visible {
+  border-color: var(--luma-onboarding-accent);
+  box-shadow: var(--luma-onboarding-shadow);
+  color: var(--luma-onboarding-text);
+  text-decoration: none;
+  transform: translateY(-3px);
+}
+
+.markdown .luma-onboarding__path-title {
+  margin: 12px 0 0;
+  color: var(--luma-onboarding-text);
+  font-size: 1.15rem;
+  font-weight: 730;
+  letter-spacing: -0.026em;
+  line-height: 1.35;
+}
+
+.markdown .luma-onboarding__path-description {
+  margin: 8px 0 16px;
+  color: var(--luma-onboarding-muted);
+  font-size: 0.87rem;
+  line-height: 1.65;
+}
+
+.markdown .luma-onboarding__path-meta {
+  margin-top: auto;
+  color: var(--luma-onboarding-accent);
+  font-size: 0.78rem;
+  font-weight: 670;
+}
+
+.markdown .luma-onboarding__closing {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 20px;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 21px;
+  margin-top: clamp(58px, 8vw, 86px);
+  background:
+    radial-gradient(ellipse at 92% 10%, rgba(56, 189, 248, 0.22), transparent 48%),
+    radial-gradient(ellipse at 3% 110%, rgba(129, 140, 248, 0.19), transparent 48%), #0b1421;
+  padding: clamp(31px, 5vw, 49px);
+}
+
+.markdown .luma-onboarding__closing > div {
+  min-width: 0;
+  flex: 1 1 16rem;
+}
+
+.markdown .luma-onboarding__closing-title {
+  max-width: 19ch;
+  margin: 0;
+  color: #f8fafc;
+  font-size: clamp(1.85rem, 4.1vw, 2.7rem);
+  font-weight: 750;
+  letter-spacing: -0.056em;
+  line-height: 1.12;
+}
+
+.markdown .luma-onboarding__closing-description {
+  max-width: 56ch;
+  margin: 12px 0 0;
+  color: #c2d0e0;
+  font-size: 0.94rem;
+  line-height: 1.7;
+}
+
+.markdown .luma-onboarding__action:focus-visible,
+.markdown .luma-onboarding__showcase:focus-visible,
+.markdown .luma-onboarding__path:focus-visible {
+  outline: 2px solid #7dd3fc;
+  outline-offset: 4px;
+}
+
+@keyframes lumaOnboardingGlow {
+  0% {
+    opacity: 0.54;
+    transform: translate3d(-2%, 0, 0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translate3d(2%, -2%, 0);
+  }
+}
+
+@keyframes lumaOnboardingScene {
+  0% {
+    transform: scale(1);
+  }
+
+  100% {
+    transform: scale(1.065);
+  }
+}
+
+@keyframes lumaOnboardingPulse {
+  0%,
+  100% {
+    opacity: 0.58;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}
+
+@media screen and (min-width: 1440px) {
+  .markdown .luma-onboarding__gallery {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .markdown .luma-onboarding__showcase--featured {
+    grid-column: span 2;
+  }
+
+  .markdown .luma-onboarding__showcase--featured .luma-onboarding__showcase-media {
+    max-height: none;
+    aspect-ratio: 21 / 11;
+  }
+}
+
+@media screen and (max-width: 996px) {
+  .markdown .luma-onboarding__capabilities {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .markdown .luma-onboarding__hero {
+    min-height: 445px;
+  }
+}
+
+@media screen and (max-width: 720px) {
+  .markdown .luma-onboarding__hero {
+    min-height: 440px;
+    border-radius: 18px;
+  }
+
+  .markdown .luma-onboarding__hero::before {
+    background:
+      linear-gradient(90deg, rgba(3, 8, 17, 0.88), rgba(3, 8, 17, 0.4) 86%),
+      linear-gradient(0deg, rgba(3, 8, 17, 0.97), rgba(3, 8, 17, 0.18) 80%);
+  }
+
+  .markdown .luma-onboarding__hero-content {
+    padding: 36px 26px;
+  }
+
+  .markdown .luma-onboarding__title {
+    font-size: clamp(2.7rem, 10vw, 4rem);
+  }
+
+  .markdown .luma-onboarding__gallery,
+  .markdown .luma-onboarding__capabilities,
+  .markdown .luma-onboarding__paths {
+    grid-template-columns: 1fr;
+  }
+
+  .markdown .luma-onboarding__showcase--featured {
+    grid-column: auto;
+  }
+
+  .markdown .luma-onboarding__showcase--featured .luma-onboarding__showcase-media {
+    max-height: none;
+    aspect-ratio: 16 / 9;
+  }
+
+  .markdown .luma-onboarding__path {
+    min-height: 0;
+  }
+
+  .markdown .luma-onboarding__closing {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .markdown .luma-onboarding__closing > div {
+    flex-basis: auto;
+  }
+}
+
+@media screen and (max-width: 420px) {
+  .markdown .luma-onboarding__hero {
+    min-height: 480px;
+  }
+
+  .markdown .luma-onboarding__hero-content {
+    padding: 32px 21px;
+  }
+
+  .markdown .luma-onboarding__actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .markdown .luma-onboarding__action {
+    justify-content: space-between;
+  }
+
+  .markdown .luma-onboarding__note {
+    align-items: flex-start;
+  }
+
+  .markdown .luma-onboarding__status-dot {
+    margin-top: 0.35em;
+  }
+
+  .markdown .luma-onboarding__closing {
+    padding: 30px 23px;
+  }
+
+  .markdown .luma-onboarding__closing .luma-onboarding__action {
+    align-self: stretch;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .markdown .luma-onboarding__hero::after,
+  .markdown .luma-onboarding__hero-image,
+  .markdown .luma-onboarding__status-dot {
+    animation: none;
+  }
+
+  .markdown .luma-onboarding__action,
+  .markdown .luma-onboarding__showcase,
+  .markdown .luma-onboarding__showcase-image,
+  .markdown .luma-onboarding__path {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Why

Getting Started is the first page a curious newcomer sees after choosing to explore luma.gl. It immediately required installing Node.js and creating a local project, before showing a single thing the GPU can do. The website should create delight and momentum first; detailed setup already has an appropriate home in the developer documentation.

## What changed

- Replace the prerequisites-first landing page with a cinematic, gently animated Tempest Ocean hero and the clear promise: **No installation. No account. Just your browser.**
- Feature six authentic, clickable screenshots linked directly to their interactive examples: Lightstorm Megacity, Tempest Ocean, Prism Cathedral, Fluid Foundry, Virtual Geometry Canyon, and Effects: Image Processing.
- Explain real-time rendering, GPU compute, large-scale data, and WebGPU/WebGL2 backend portability through three concise capability cards.
- Offer four immediate learning paths covering Hello Triangle, the rendering engine, GPU data processing, and shader/effect passes.
- Preserve the complete runnable npm/yarn/pnpm starter, adapter selection, fallback guidance, and troubleshooting in the existing dedicated Installing guide.
- Update documentation overview and tutorial links to distinguish zero-install discovery from optional local setup.
- Update the generated LLM documentation contract to verify the relocated complete starter while still validating the Getting Started editorial page.
- Add responsive light/dark styling, visible focus states, reduced-motion support, and base-path-safe Docusaurus links/images.
- Reuse existing example screenshots; add no datasets, embedded GPU-heavy scenes, or new media assets. The existing ANARI Playground experience is unchanged.

## Verification

- `env -u YARN_NO_PROXY yarn lint fix`
- `env -u YARN_NO_PROXY yarn test-node` — **410 passed, 2 skipped**
- `env -u YARN_NO_PROXY yarn website:build` — complete Docusaurus production build, standalone assets, search indexing, and **455 generated documentation pages validated**
- Focused onboarding regression coverage verifies all six genuine screenshot routes, the zero-install copy, complete relocated starter, tutorial cross-links, and generated LLM checks.
- Visually verified the production page in the actual browser at a 666px-wide viewport: six showcase cards, three capability cards, four learning paths, no horizontal overflow, and no Node.js/prerequisites copy.