### PR TITLE
fix(luproj): enforce exact outer plan bounds

### DIFF
--- a/modules/experimental/src/luproj/README.md
+++ b/modules/experimental/src/luproj/README.md
@@ -134,7 +134,9 @@ returns an absolute destination coordinate rather than a GPU-local offset.
 Non-finite input coordinates, rows outside the compiled source bounds, invalid
 patch IDs, and patch IDs that do not cover their assigned row produce a
 deterministic GPU output of `[0, 0]`. A valid row can also project to the local
-origin, so validate inputs separately when that distinction matters.
+origin, so validate inputs separately when that distinction matters. Patch
+lookup tolerates float32 normalization at shared seams and inclusive endpoints,
+but that tolerance never expands the plan's exterior source bounds.
 
 Graph vector inputs preserve their ordered source chunks, including empty
 chunks. Source positions, optional patch IDs, and output positions must share
@@ -142,15 +144,15 @@ the same row and chunk topology; `luproj` never concatenates or implicitly
 repacks application-owned vectors.
 
 `GPUProjection.updatePlan(nextPlan)` updates an equally sized packed plan
-without recompiling the surrounding command graph. Call
+without recompiling the surrounding command graph. Plans produced by
+`packProjectionPlan()` keep the exact outer bounds in the same storage as the
+patch records, so per-encoding plan-buffer replacements cannot separate domain
+validation from the polynomial data they accompany. Packed buffers created
+before the bounds trailer was added are not accepted; repack the plan with the
+current `packProjectionPlan()` result. Call
 `GPUProjection.destroy()` when the contributor is no longer needed; only its
-privately allocated plan and exact-boundary storage are destroyed, never
+privately allocated plan storage is destroyed, never
 caller-owned source, destination, or explicitly supplied `planBuffer` storage.
-
-The complete source domain is checked exactly before patch lookup. Interior
-patch seams retain a small Float32 normalization tolerance, but rows outside
-the active binary64 plan bounds always receive the documented `[0, 0]`
-sentinel.
 
 ## Benchmark CPU and GPU projection paths
 

--- a/modules/experimental/src/luproj/gpu-projection-benchmark.ts
+++ b/modules/experimental/src/luproj/gpu-projection-benchmark.ts
@@ -20,7 +20,11 @@ import {
   type ProjectionBenchmarkOptions,
   type ProjectionBenchmarkReport
 } from './projection-benchmark';
-import {findProjectionPatch, PROJECTION_PATCH_WORD_LENGTH} from './projection-plan';
+import {
+  findProjectionPatch,
+  PROJECTION_PATCH_WORD_LENGTH,
+  PROJECTION_PLAN_BOUNDS_WORD_LENGTH
+} from './projection-plan';
 
 /** Physical coordinate representation evaluated by the GPU benchmark. */
 export type GPUProjectionBenchmarkInputFormat = 'float32x2' | 'uint32x4';
@@ -245,8 +249,9 @@ async function measureGPUProjectionBenchmarkPath(
         sourceBuffer.byteLength +
         outputBuffer.byteLength +
         (patchIdBuffer?.byteLength ?? 0) +
-        context.plan.patches.length * PROJECTION_PATCH_WORD_LENGTH * Uint32Array.BYTES_PER_ELEMENT +
-        4 * Float64Array.BYTES_PER_ELEMENT,
+        (context.plan.patches.length * PROJECTION_PATCH_WORD_LENGTH +
+          PROJECTION_PLAN_BOUNDS_WORD_LENGTH) *
+          Uint32Array.BYTES_PER_ELEMENT,
       maxError,
       cpuEncodeTimeMilliseconds: summarizeProjectionBenchmarkSamples(
         executions.map(execution => execution.timing.cpuEncodeTimeMilliseconds)

--- a/modules/experimental/src/luproj/gpu-projection.ts
+++ b/modules/experimental/src/luproj/gpu-projection.ts
@@ -28,7 +28,11 @@ import {
   validateRowView
 } from '../geospatial/geospatial-utils';
 import type {GPUFloat32Positions, GPUGeospatialPositions} from '../geospatial/types';
-import {packProjectionPlan, PROJECTION_PATCH_WORD_LENGTH} from './projection-plan';
+import {
+  packProjectionPlan,
+  PROJECTION_PATCH_WORD_LENGTH,
+  PROJECTION_PLAN_BOUNDS_WORD_LENGTH
+} from './projection-plan';
 import type {ProjectionPlan} from './types';
 
 /** Optional per-row plan-patch IDs, preserving the source vector's ordered chunk topology. */
@@ -46,7 +50,7 @@ export type GPUProjectionProps = {
   plan: ProjectionPlan;
   /** Optional explicit patch index per position; omission performs source-domain lookup. */
   patchIds?: GPUProjectionPatchIds;
-  /** Optional initialized packed patch storage created with {@link packProjectionPlan}. */
+  /** Optional initialized packed projection-plan storage created with {@link packProjectionPlan}. */
   planBuffer?: GraphDataView<'uint32'>;
 };
 
@@ -76,7 +80,6 @@ export class GPUProjection implements GPUCommandGraphContributor {
 
   private projectionPlan: ProjectionPlan;
   private ownedPlanBuffer?: Buffer;
-  private ownedBoundsBuffer?: Buffer;
   private hasRegisteredGraph = false;
   private destroyed = false;
 
@@ -105,7 +108,11 @@ export class GPUProjection implements GPUCommandGraphContributor {
 
     if (this.planBuffer) {
       validatePackedView(this.planBuffer, ['uint32'], `${this.id} plan buffer`);
-      if (this.planBuffer.length < props.plan.patches.length * PROJECTION_PATCH_WORD_LENGTH) {
+      if (
+        this.planBuffer.length <
+        props.plan.patches.length * PROJECTION_PATCH_WORD_LENGTH +
+          PROJECTION_PLAN_BOUNDS_WORD_LENGTH
+      ) {
         throw new Error(`${this.id} plan buffer is smaller than its packed projection plan`);
       }
       inputs.push(['plan buffer', this.planBuffer]);
@@ -144,7 +151,6 @@ export class GPUProjection implements GPUCommandGraphContributor {
       }
       externalBuffer.write(packedPlan, this.planBuffer.byteOffset);
     }
-    this.ownedBoundsBuffer?.write(packProjectionBounds(plan));
     this.projectionPlan = plan;
   }
 
@@ -167,7 +173,6 @@ export class GPUProjection implements GPUCommandGraphContributor {
     }
 
     const planView = this.planBuffer ?? this.createOwnedPlanView(graph);
-    const boundsView = this.createOwnedBoundsView(graph);
     const inputChunks = getRowChunks(this.positions);
     const outputChunks = getRowChunks(this.output);
     const patchIdChunks = this.patchIds ? getRowChunks(this.patchIds) : undefined;
@@ -182,21 +187,18 @@ export class GPUProjection implements GPUCommandGraphContributor {
         input,
         output: outputChunks[chunkIndex],
         patchIds: patchIdChunks?.[chunkIndex],
-        plan: planView,
-        bounds: boundsView
+        plan: planView
       });
     }
 
     this.hasRegisteredGraph = true;
   }
 
-  /** Releases privately allocated plan and bounds storage; caller-owned resources remain intact. */
+  /** Releases privately allocated plan storage; caller-owned input, output, and plan remain intact. */
   destroy(): void {
     if (!this.destroyed) {
       this.ownedPlanBuffer?.destroy();
       this.ownedPlanBuffer = undefined;
-      this.ownedBoundsBuffer?.destroy();
-      this.ownedBoundsBuffer = undefined;
       this.destroyed = true;
     }
   }
@@ -219,24 +221,6 @@ export class GPUProjection implements GPUCommandGraphContributor {
     return graph.createDataView(handle, {format: 'uint32', length: words.length});
   }
 
-  private createOwnedBoundsView<Parameters>(
-    graph: GPUCommandGraph<Parameters>
-  ): GraphDataView<'uint32'> {
-    const words = packProjectionBounds(this.projectionPlan);
-    const id = `${this.id}-projection-bounds`;
-    const buffer = graph.device.createBuffer({
-      id,
-      data: words,
-      usage: Buffer.STORAGE | Buffer.COPY_DST
-    });
-    this.ownedBoundsBuffer = buffer;
-    const handle = graph.importBuffer(
-      {id, byteLength: words.byteLength, usage: buffer.usage},
-      buffer
-    );
-    return graph.createDataView(handle, {format: 'uint32', length: words.length});
-  }
-
   private addProjectionPass<Parameters>(
     graph: GPUCommandGraph<Parameters>,
     options: {
@@ -245,10 +229,9 @@ export class GPUProjection implements GPUCommandGraphContributor {
       output: GraphDataView<'float32x2'>;
       patchIds?: GraphDataView<'uint32'>;
       plan: GraphDataView<'uint32'>;
-      bounds: GraphDataView<'uint32'>;
     }
   ): void {
-    const {chunkIndex, input, output, patchIds, plan, bounds} = options;
+    const {chunkIndex, input, output, patchIds, plan} = options;
     const inputSource = getPositionReadSource('positions', input);
     const dispatchLayout = getGeospatialDispatchLayout(
       input.length,
@@ -257,13 +240,11 @@ export class GPUProjection implements GPUCommandGraphContributor {
     const resources: GraphBufferUse[] = [
       {buffer: input, usage: 'storage-read'},
       {buffer: plan, usage: 'storage-read'},
-      {buffer: bounds, usage: 'storage-read'},
       {buffer: output, usage: 'storage-write'}
     ];
     const bindings: Record<string, GraphDataView> = {
       positions: input,
       projectionPlans: plan,
-      projectionBounds: bounds,
       outputPositions: output
     };
     if (patchIds) {
@@ -298,19 +279,6 @@ export class GPUProjection implements GPUCommandGraphContributor {
       throw new Error(`${this.id} projection contributor has been destroyed`);
     }
   }
-}
-
-function packProjectionBounds(plan: ProjectionPlan): Uint32Array {
-  const words = new Uint32Array(8);
-  const dataView = new DataView(words.buffer);
-  for (let coordinateIndex = 0; coordinateIndex < plan.bounds.length; coordinateIndex++) {
-    dataView.setFloat64(
-      coordinateIndex * Float64Array.BYTES_PER_ELEMENT,
-      plan.bounds[coordinateIndex],
-      true
-    );
-  }
-  return words;
 }
 
 function validateProjectionPlan(plan: ProjectionPlan, id: string): void {
@@ -392,35 +360,46 @@ function getProjectionShaderSource(options: {
   const finitePosition = precise
     ? 'rawPointIsFinite(position)'
     : `all((bitcast<vec2u>(position) & vec2u(0x7f800000u)) != vec2u(0x7f800000u))`;
-  const rawBoundsCoordinates = precise
-    ? `let coordinateX = position.x;
-  let coordinateY = position.y;`
-    : `let coordinateX = projectionFloat32ToRaw(position.x);
-  let coordinateY = projectionFloat32ToRaw(position.y);`;
-  const float32Conversion = precise
-    ? ''
-    : `fn projectionFloat32ToRaw(value: f32) -> vec2u {
-  let bits = bitcast<u32>(value);
-  let sign = bits & 0x80000000u;
-  let exponent = (bits >> 23u) & 0xffu;
-  let fraction = bits & 0x007fffffu;
+  const planContains = precise
+    ? `let minimumX = projectionPlanRawBound(0u);
+  let minimumY = projectionPlanRawBound(1u);
+  let maximumX = projectionPlanRawBound(2u);
+  let maximumY = projectionPlanRawBound(3u);
+  return compareFiniteBinary64(position.x, minimumX) >= 0 &&
+    compareFiniteBinary64(position.y, minimumY) >= 0 &&
+    compareFiniteBinary64(position.x, maximumX) <= 0 &&
+    compareFiniteBinary64(position.y, maximumY) <= 0;`
+    : `let minimum = vec2f(
+    bitcast<f32>(projectionPlans[PLAN_BOUNDS_OFFSET + 8u]),
+    bitcast<f32>(projectionPlans[PLAN_BOUNDS_OFFSET + 9u])
+  );
+  let maximum = vec2f(
+    bitcast<f32>(projectionPlans[PLAN_BOUNDS_OFFSET + 10u]),
+    bitcast<f32>(projectionPlans[PLAN_BOUNDS_OFFSET + 11u])
+  );
+  return all(position >= minimum) && all(position <= maximum);`;
+  const precisePlanBoundsFunctions = precise
+    ? `fn projectionPlanRawBound(boundIndex: u32) -> vec2u {
+  let wordOffset = PLAN_BOUNDS_OFFSET + boundIndex * 2u;
+  return vec2u(
+    projectionPlans[wordOffset + 1u],
+    projectionPlans[wordOffset]
+  );
+}
 
-  if (exponent == 0u) {
-    if (fraction == 0u) {
-      return vec2u(sign, 0u);
-    }
-    let leading = 31u - countLeadingZeros(fraction);
-    let normalizedFraction = (fraction << (23u - leading)) & 0x007fffffu;
-    let binary64Exponent = leading + 874u;
-    return vec2u(
-      sign | (binary64Exponent << 20u) | (normalizedFraction >> 3u),
-      normalizedFraction << 29u
-    );
+fn compareFiniteBinary64(firstBits: vec2u, secondBits: vec2u) -> i32 {
+  let first = fp64_decode_bits(firstBits);
+  let second = fp64_decode_bits(secondBits);
+  if (first.isZero && second.isZero) {
+    return 0;
   }
-
-  let binary64Exponent = exponent + 896u;
-  return vec2u(sign | (binary64Exponent << 20u) | (fraction >> 3u), fraction << 29u);
-}`;
+  if (first.sign != second.sign) {
+    return select(1, -1, first.sign == 1u);
+  }
+  let magnitudeComparison = fp64_finite_magnitude_compare(first, second);
+  return select(magnitudeComparison, -magnitudeComparison, first.sign == 1u);
+}`
+    : '';
   const patchIdDeclaration =
     patchIdOffset === undefined
       ? ''
@@ -437,56 +416,23 @@ const ELEMENT_COUNT: u32 = ${elementCount}u;
 const PATCH_COUNT: u32 = ${patchCount}u;
 const PATCH_WORD_LENGTH: u32 = ${PROJECTION_PATCH_WORD_LENGTH}u;
 const PLAN_OFFSET: u32 = ${planOffset}u;
+const PLAN_BOUNDS_OFFSET: u32 = PLAN_OFFSET + PATCH_COUNT * PATCH_WORD_LENGTH;
 const OUTPUT_OFFSET: u32 = ${outputOffset}u;
 const INVALID_PATCH: u32 = 0xffffffffu;
 
 ${inputDeclaration}
 @group(0) @binding(auto) var<storage, read> projectionPlans: array<u32>;
-@group(0) @binding(auto) var<storage, read> projectionBounds: array<u32>;
 @group(0) @binding(auto) var<storage, read_write> outputPositions: array<vec2f>;
 ${patchIdDeclaration}
 
-${float32Conversion}
-
-fn projectionRawLess(first: vec2u, second: vec2u) -> bool {
-  let firstMagnitude = first.x & 0x7fffffffu;
-  let secondMagnitude = second.x & 0x7fffffffu;
-  if ((firstMagnitude | first.y | secondMagnitude | second.y) == 0u) {
-    return false;
-  }
-
-  let firstNegative = (first.x & 0x80000000u) != 0u;
-  let secondNegative = (second.x & 0x80000000u) != 0u;
-  if (firstNegative != secondNegative) {
-    return firstNegative;
-  }
-  // Boolean-valued select expressions crash Chromium's Metal compiler; branch explicitly.
-  if (first.x != second.x) {
-    if (firstNegative) {
-      return first.x > second.x;
-    }
-    return first.x < second.x;
-  }
-  if (firstNegative) {
-    return first.y > second.y;
-  }
-  return first.y < second.y;
-}
-
-fn projectionBoundsContains(position: ${positionType}) -> bool {
-  ${rawBoundsCoordinates}
-  let minimumX = vec2u(projectionBounds[1u], projectionBounds[0u]);
-  let minimumY = vec2u(projectionBounds[3u], projectionBounds[2u]);
-  let maximumX = vec2u(projectionBounds[5u], projectionBounds[4u]);
-  let maximumY = vec2u(projectionBounds[7u], projectionBounds[6u]);
-  return !projectionRawLess(coordinateX, minimumX) &&
-    !projectionRawLess(maximumX, coordinateX) &&
-    !projectionRawLess(coordinateY, minimumY) &&
-    !projectionRawLess(maximumY, coordinateY);
-}
-
 fn projectionPlanWord(patchIndex: u32, wordIndex: u32) -> u32 {
   return projectionPlans[PLAN_OFFSET + patchIndex * PATCH_WORD_LENGTH + wordIndex];
+}
+
+${precisePlanBoundsFunctions}
+
+fn projectionPlanContains(position: ${positionType}) -> bool {
+  ${planContains}
 }
 
 fn projectionSourceOffset(position: ${positionType}, patchIndex: u32) -> vec2f {
@@ -561,7 +507,11 @@ fn main(
   ${invocationIndexSource}
   if (index >= ELEMENT_COUNT) { return; }
   let position = ${readPosition};
-  if (!(${finitePosition}) || !projectionBoundsContains(position)) {
+  if (!(${finitePosition})) {
+    outputPositions[OUTPUT_OFFSET + index] = vec2f(0.0);
+    return;
+  }
+  if (!projectionPlanContains(position)) {
     outputPositions[OUTPUT_OFFSET + index] = vec2f(0.0);
     return;
   }

--- a/modules/experimental/src/luproj/index.ts
+++ b/modules/experimental/src/luproj/index.ts
@@ -17,6 +17,7 @@ export {
   evaluateProjectionPlan,
   findProjectionPatch,
   packProjectionPlan,
+  PROJECTION_PLAN_BOUNDS_WORD_LENGTH,
   PROJECTION_PATCH_WORD_LENGTH
 } from './projection-plan';
 

--- a/modules/experimental/src/luproj/projection-plan.ts
+++ b/modules/experimental/src/luproj/projection-plan.ts
@@ -15,6 +15,9 @@ import type {
 /** Number of uint32 words occupied by one stable packed GPU projection-patch record. */
 export const PROJECTION_PATCH_WORD_LENGTH = 40;
 
+/** Number of uint32 words occupied by the source-bounds trailer in a packed projection plan. */
+export const PROJECTION_PLAN_BOUNDS_WORD_LENGTH = 12;
+
 const MAXIMUM_COEFFICIENT_COUNT = 10;
 const DEFAULT_TOLERANCE = 0.01;
 const DEFAULT_MAXIMUM_DEPTH = 8;
@@ -135,14 +138,16 @@ export function evaluateProjectionPlan(
 }
 
 /**
- * Packs the stable, little-endian GPU patch ABI without a header or hidden metadata.
+ * Packs the stable, little-endian GPU patch ABI followed by the plan's source-bounds trailer.
  *
  * Each record contains source and destination binary64 origin words, source normalization,
  * the patch's destination offset from the plan origin, degree, and two padded coefficient sets.
+ * The trailer contains four exact binary64 bounds plus four inward-rounded float32 bounds.
  * Updating an imported GPU plan buffer with the result does not require recompiling its graph.
  */
 export function packProjectionPlan(plan: ProjectionPlan): Uint32Array {
-  const words = new Uint32Array(plan.patches.length * PROJECTION_PATCH_WORD_LENGTH);
+  const patchWordLength = plan.patches.length * PROJECTION_PATCH_WORD_LENGTH;
+  const words = new Uint32Array(patchWordLength + PROJECTION_PLAN_BOUNDS_WORD_LENGTH);
   const dataView = new DataView(words.buffer);
 
   for (const patch of plan.patches) {
@@ -216,7 +221,52 @@ export function packProjectionPlan(plan: ProjectionPlan): Uint32Array {
     }
   }
 
+  for (let boundIndex = 0; boundIndex < plan.bounds.length; boundIndex++) {
+    dataView.setFloat64(
+      (patchWordLength + boundIndex * 2) * Uint32Array.BYTES_PER_ELEMENT,
+      plan.bounds[boundIndex],
+      true
+    );
+  }
+  const float32Bounds = [
+    getFloat32Ceiling(plan.bounds[0]),
+    getFloat32Ceiling(plan.bounds[1]),
+    getFloat32Floor(plan.bounds[2]),
+    getFloat32Floor(plan.bounds[3])
+  ];
+  for (let boundIndex = 0; boundIndex < float32Bounds.length; boundIndex++) {
+    dataView.setFloat32(
+      (patchWordLength + 8 + boundIndex) * Uint32Array.BYTES_PER_ELEMENT,
+      float32Bounds[boundIndex],
+      true
+    );
+  }
+
   return words;
+}
+
+function getFloat32Ceiling(value: number): number {
+  const rounded = Math.fround(value);
+  return rounded >= value ? rounded : getAdjacentFloat32(rounded, 1);
+}
+
+function getFloat32Floor(value: number): number {
+  const rounded = Math.fround(value);
+  return rounded <= value ? rounded : getAdjacentFloat32(rounded, -1);
+}
+
+function getAdjacentFloat32(value: number, direction: -1 | 1): number {
+  const values = new Float32Array(1);
+  const words = new Uint32Array(values.buffer);
+  values[0] = value;
+  if (value === 0) {
+    words[0] = direction === 1 ? 1 : 0x80000001;
+  } else if (value > 0 === (direction === 1)) {
+    words[0]++;
+  } else {
+    words[0]--;
+  }
+  return values[0];
 }
 
 function validateCompilerOptions(options: {

--- a/modules/experimental/test/luproj/luproj.spec.ts
+++ b/modules/experimental/test/luproj/luproj.spec.ts
@@ -10,12 +10,43 @@ import {
   evaluateProjectionPlan,
   findProjectionPatch,
   GPUProjection,
-  packProjectionPlan
+  packProjectionPlan,
+  PROJECTION_PLAN_BOUNDS_WORD_LENGTH,
+  PROJECTION_PATCH_WORD_LENGTH
 } from '@luma.gl/experimental/luproj';
 import type {GPUVectorFormat} from '@luma.gl/tables';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 
 type Coordinates = readonly [number, number];
+
+test('packProjectionPlan rounds subnormal float32 bounds inward', tapeTest => {
+  const plan = compileProjectionPlan({
+    projection: (coordinates: number[]): number[] => [...coordinates],
+    bounds: [0, 0, 1, 1],
+    degree: 1,
+    tolerance: 1e-5
+  });
+  const minimumPositive = Number.MIN_VALUE;
+  const subnormalPlan = {
+    ...plan,
+    bounds: [minimumPositive, -minimumPositive * 2, minimumPositive * 2, -minimumPositive] as const
+  };
+  const packedPlan = packProjectionPlan(subnormalPlan);
+  const boundsWordOffset =
+    plan.patches.length * PROJECTION_PATCH_WORD_LENGTH + PROJECTION_PLAN_BOUNDS_WORD_LENGTH - 4;
+
+  tapeTest.equal(
+    packedPlan[boundsWordOffset],
+    1,
+    'a positive minimum rounds up to the least positive float32'
+  );
+  tapeTest.equal(
+    packedPlan[boundsWordOffset + 3],
+    0x80000001,
+    'a negative maximum rounds down to the least negative float32'
+  );
+  tapeTest.end();
+});
 
 test('GPUProjection writes origin-relative f32 positions and honors nonzero view offsets', async tapeTest => {
   const device = await getWebGPUTestDevice();
@@ -781,6 +812,50 @@ test('GPUProjection rejects source and output handles sharing physical storage',
   tapeTest.end();
 });
 
+test('GPUProjection rejects legacy packed plans without the bounds trailer', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const plan = compileProjectionPlan({
+    projection: (coordinates: number[]): number[] => [...coordinates],
+    bounds: [0, 0, 1, 1],
+    degree: 1,
+    tolerance: 1e-5
+  });
+  const positionBuffer = createBuffer(device, Float32Array.from([0.5, 0.5]));
+  const outputBuffer = createOutputBuffer(device, 2);
+  const legacyPlanWordLength = plan.patches.length * PROJECTION_PATCH_WORD_LENGTH;
+  const legacyPlanBuffer = device.createBuffer({
+    byteLength: legacyPlanWordLength * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE
+  });
+  const graph = new GPUCommandGraph(device, {id: 'luproj-legacy-packed-plan'});
+  const positions = importView(graph, 'positions', positionBuffer, 'float32x2', 1);
+  const output = importView(graph, 'output', outputBuffer, 'float32x2', 1);
+  const planBuffer = importView(
+    graph,
+    'legacy-plan',
+    legacyPlanBuffer,
+    'uint32',
+    legacyPlanWordLength
+  );
+
+  tapeTest.throws(
+    () => new GPUProjection({positions, output, plan, planBuffer}),
+    /plan buffer is smaller than its packed projection plan/,
+    'legacy patch-only storage must be repacked with the source-bounds trailer'
+  );
+
+  positionBuffer.destroy();
+  outputBuffer.destroy();
+  legacyPlanBuffer.destroy();
+  tapeTest.end();
+});
+
 test('GPUProjection rejects caller-owned plan and output handles sharing physical storage', async tapeTest => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -1080,8 +1155,146 @@ test('GPUProjection updates exact global bounds without rebuilding its graph', a
 
   compiled.destroy();
   contributor.destroy();
-  tapeTest.equal(planBuffer.destroyed, false, 'caller-owned plan survives private bounds cleanup');
+  tapeTest.equal(planBuffer.destroyed, false, 'caller-owned plan survives contributor destruction');
   planBuffer.destroy();
+  inputBuffer.destroy();
+  outputBuffer.destroy();
+  tapeTest.end();
+});
+
+test('GPUProjection retains tolerant raw-binary64 assignment at internal patch seams', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const minimum = 4_189_890.0279418225;
+  const maximum = 4_189_891.498858749;
+  const midpoint = minimum + (maximum - minimum) / 2;
+  const plan = compileProjectionPlan({
+    projection: (coordinates: number[]): number[] => {
+      const horizontal = coordinates[0] - midpoint;
+      const vertical = coordinates[1] - midpoint;
+      return [horizontal + horizontal * horizontal * 0.1, vertical + vertical * vertical * 0.1];
+    },
+    bounds: [minimum, minimum, maximum, maximum],
+    degree: 1,
+    tolerance: 0.01,
+    maxDepth: 1
+  });
+  const point: Coordinates = [midpoint, minimum + (midpoint - minimum) / 2];
+  const patchId = findProjectionPatch(plan, point);
+  const inputBuffer = createBuffer(device, encodeFloat64Points([point]));
+  const patchIdBuffer = createBuffer(device, Uint32Array.from([patchId]));
+  const outputBuffer = createOutputBuffer(device, 2);
+  const graph = new GPUCommandGraph(device, {id: 'luproj-internal-seam'});
+  const contributor = new GPUProjection({
+    positions: importView(graph, 'raw-position', inputBuffer, 'uint32x4', 1),
+    output: importView(graph, 'projected', outputBuffer, 'float32x2', 1),
+    patchIds: importView(graph, 'patch-id', patchIdBuffer, 'uint32', 1),
+    plan
+  });
+
+  tapeTest.equal(plan.patches.length, 4, 'the curved plan subdivides into four patches');
+  tapeTest.equal(patchId, 0, 'the inclusive CPU lookup selects the lower-left seam patch');
+  contributor.addToGraph(graph);
+  const compiled = graph.compile();
+  const encoder = device.createCommandEncoder({id: 'luproj-internal-seam-encoding'});
+  compiled.encode(encoder, {parameters: undefined});
+  device.submit(encoder.finish());
+
+  const actual = await readFloat32(outputBuffer, 2);
+  assertProjectedPoints(tapeTest, plan, [point], actual);
+  tapeTest.notEqual(actual[1], 0, 'the accepted seam row is distinct from the zero sentinel');
+
+  compiled.destroy();
+  contributor.destroy();
+  inputBuffer.destroy();
+  patchIdBuffer.destroy();
+  outputBuffer.destroy();
+  tapeTest.end();
+});
+
+test('GPUProjection keeps strict bounds coupled to per-encoding plan overrides', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const initialPlan = compileProjectionPlan({
+    projection: (coordinates: number[]): number[] => [
+      1_000 + coordinates[0] * 2,
+      2_000 + coordinates[1] * 3
+    ],
+    bounds: [0, 0, 1, 1],
+    degree: 1,
+    tolerance: 1e-5
+  });
+  const shiftedPlan = compileProjectionPlan({
+    projection: (coordinates: number[]): number[] => [
+      5_000 + (coordinates[0] - 100) * 4,
+      6_000 - (coordinates[1] - 200) * 2
+    ],
+    bounds: [100, 200, 101, 201],
+    degree: 1,
+    tolerance: 1e-5
+  });
+  const initialPackedPlan = packProjectionPlan(initialPlan);
+  const shiftedPackedPlan = packProjectionPlan(shiftedPlan);
+  const initialPlanBuffer = device.createBuffer({data: initialPackedPlan, usage: Buffer.STORAGE});
+  const shiftedPlanBuffer = device.createBuffer({data: shiftedPackedPlan, usage: Buffer.STORAGE});
+  const points: Coordinates[] = [
+    [0.25, 0.75],
+    [100.25, 200.75]
+  ];
+  const inputBuffer = createBuffer(device, Float32Array.from(points.flat()));
+  const outputBuffer = createOutputBuffer(device, points.length * 2);
+  const graph = new GPUCommandGraph(device, {id: 'luproj-overrideable-plan'});
+  const planHandle = graph.importBuffer({
+    id: 'dynamic-plan',
+    byteLength: initialPackedPlan.byteLength,
+    usage: Buffer.STORAGE
+  });
+  const contributor = new GPUProjection({
+    positions: importView(graph, 'positions', inputBuffer, 'float32x2', points.length),
+    output: importView(graph, 'output', outputBuffer, 'float32x2', points.length),
+    plan: initialPlan,
+    planBuffer: graph.createDataView(planHandle, {
+      format: 'uint32',
+      length: initialPackedPlan.length
+    })
+  });
+
+  contributor.addToGraph(graph);
+  const compiled = graph.compile();
+  const initialEncoder = device.createCommandEncoder({id: 'luproj-initial-override-encoding'});
+  compiled.encode(initialEncoder, {
+    parameters: undefined,
+    buffers: {'dynamic-plan': initialPlanBuffer}
+  });
+  device.submit(initialEncoder.finish());
+  const initialOutput = await readFloat32(outputBuffer, points.length * 2);
+  assertProjectedPoints(tapeTest, initialPlan, [points[0]], initialOutput.slice(0, 2));
+  tapeTest.deepEqual(initialOutput.slice(2), [0, 0], 'initial override rejects shifted rows');
+
+  const shiftedEncoder = device.createCommandEncoder({id: 'luproj-shifted-override-encoding'});
+  compiled.encode(shiftedEncoder, {
+    parameters: undefined,
+    buffers: {'dynamic-plan': shiftedPlanBuffer}
+  });
+  device.submit(shiftedEncoder.finish());
+  const shiftedOutput = await readFloat32(outputBuffer, points.length * 2);
+  tapeTest.deepEqual(shiftedOutput.slice(0, 2), [0, 0], 'shifted override rejects initial rows');
+  assertProjectedPoints(tapeTest, shiftedPlan, [points[1]], shiftedOutput.slice(2));
+
+  compiled.destroy();
+  contributor.destroy();
+  initialPlanBuffer.destroy();
+  shiftedPlanBuffer.destroy();
   inputBuffer.destroy();
   outputBuffer.destroy();
   tapeTest.end();

--- a/modules/experimental/test/luproj/projection-plan.node.spec.ts
+++ b/modules/experimental/test/luproj/projection-plan.node.spec.ts
@@ -12,6 +12,7 @@ import {
   evaluateProjectionPlan,
   findProjectionPatch,
   packProjectionPlan,
+  PROJECTION_PLAN_BOUNDS_WORD_LENGTH,
   PROJECTION_PATCH_WORD_LENGTH,
   WEB_MERCATOR_EARTH_RADIUS,
   WEB_MERCATOR_MAX_LATITUDE
@@ -25,6 +26,7 @@ const LUPROJ_RUNTIME_EXPORTS = [
   'evaluateProjectionPlan',
   'findProjectionPatch',
   'packProjectionPlan',
+  'PROJECTION_PLAN_BOUNDS_WORD_LENGTH',
   'PROJECTION_PATCH_WORD_LENGTH',
   'WEB_MERCATOR_EARTH_RADIUS',
   'WEB_MERCATOR_MAX_LATITUDE'
@@ -349,7 +351,7 @@ describe('CPU projection plan compilation', () => {
     ).toThrow(/tolerance/);
   });
 
-  test('packs canonical binary64 origins and stable 40-word GPU patch records', () => {
+  test('packs canonical binary64 origins, stable patch records, and exact plan bounds', () => {
     const sourceOrigin = [20_000_000.125, 30_000_000.375] as const;
     const projection = (coordinates: number[]): number[] => [
       coordinates[0] * 0.5 - 13_000_000,
@@ -365,10 +367,12 @@ describe('CPU projection plan compilation', () => {
     const packedAgain = packProjectionPlan(plan);
     const bytes = new DataView(packed.buffer, packed.byteOffset, packed.byteLength);
     const patch = plan.patches[0];
+    const boundsWordOffset = plan.patches.length * PROJECTION_PATCH_WORD_LENGTH;
 
     expect(PROJECTION_PATCH_WORD_LENGTH).toBe(40);
+    expect(PROJECTION_PLAN_BOUNDS_WORD_LENGTH).toBe(12);
     expect(packed).toBeInstanceOf(Uint32Array);
-    expect(packed.length).toBe(plan.patches.length * PROJECTION_PATCH_WORD_LENGTH);
+    expect(packed.length).toBe(boundsWordOffset + PROJECTION_PLAN_BOUNDS_WORD_LENGTH);
     expect(packedAgain).toEqual(packed);
     expect(bytes.getFloat64(0, true)).toBe(patch.sourceOrigin[0]);
     expect(bytes.getFloat64(8, true)).toBe(patch.sourceOrigin[1]);
@@ -391,6 +395,19 @@ describe('CPU projection plan compilation', () => {
     expect(bytes.getFloat32(14 * 4, true)).toBe(Math.fround(patch.sourceOrigin[1]));
     expect(bytes.getFloat64(16 * 4, true)).toBe(patch.destinationOrigin[0]);
     expect(bytes.getFloat64(18 * 4, true)).toBe(patch.destinationOrigin[1]);
+    for (let boundIndex = 0; boundIndex < plan.bounds.length; boundIndex++) {
+      expect(bytes.getFloat64((boundsWordOffset + boundIndex * 2) * 4, true)).toBe(
+        plan.bounds[boundIndex]
+      );
+    }
+    const float32MinimumX = bytes.getFloat32((boundsWordOffset + 8) * 4, true);
+    const float32MinimumY = bytes.getFloat32((boundsWordOffset + 9) * 4, true);
+    const float32MaximumX = bytes.getFloat32((boundsWordOffset + 10) * 4, true);
+    const float32MaximumY = bytes.getFloat32((boundsWordOffset + 11) * 4, true);
+    expect(float32MinimumX).toBeGreaterThanOrEqual(plan.bounds[0]);
+    expect(float32MinimumY).toBeGreaterThanOrEqual(plan.bounds[1]);
+    expect(float32MaximumX).toBeLessThanOrEqual(plan.bounds[2]);
+    expect(float32MaximumY).toBeLessThanOrEqual(plan.bounds[3]);
   });
 });
 


### PR DESCRIPTION
## Root cause

The two-ULP normalized tolerance used to preserve inclusive endpoints and internal patch seams also expanded the exterior domain. On a billion-unit source extent, rows roughly 119 source units outside the compiled plan could be assigned to a boundary patch and extrapolated.

## Changes

- Add a strict outer-plan gate before tolerant patch lookup for both float32 and raw browser-binary64 inputs.
- Store exact binary64 bounds and inward-rounded float32 bounds in a 12-word trailer attached to every packed plan.
- Keep the existing stable 40-word per-patch record ABI and internal seam tolerance.
- Keep bounds coupled to default buffers, `updatePlan()`, and per-encoding imported-buffer replacements.
- Document the exterior-bound guarantee.

## Verification

- `nvm use`
- `yarn install`
- `yarn lint fix`
- `yarn build`
- `yarn test` — 406 Node tests and 1,517 browser tests passed
- Focused luProj Node suite — 13 passed
- Focused luProj WebGPU suite — 14 passed

Regression coverage includes large-domain exterior bands, one-binary64-ULP exterior inputs, explicit patch IDs, internal seams, same-count domain updates, and no-default per-encoding plan-buffer overrides.

Follow-up to #2897.