### PR TITLE
feat(examples): add versioned taxi point source

### DIFF
--- a/examples/showcase/billion-point-spatial-atlas/scripts/preprocess-paul-taxi.mjs
+++ b/examples/showcase/billion-point-spatial-atlas/scripts/preprocess-paul-taxi.mjs
@@ -38,10 +38,10 @@ async function preprocess(sourcePath, targetDirectory, pointsPerShard) {
     const arrowPath = await maybeDecompress(sourcePath, temporaryDirectory ?? targetDirectory);
     process.stdout.write(`Reading Arrow IPC file ${arrowPath}\n`);
     const table = tableFromIPC(await readFile(arrowPath));
-    const [longitudeField, latitudeField] = findCoordinateFields(table.schema.fields);
-    const longitudeVector = table.getChild(longitudeField.name);
-    const latitudeVector = table.getChild(latitudeField.name);
-    if (!longitudeVector || !latitudeVector) {
+    const [xField, yField] = findCoordinateFields(table.schema.fields);
+    const xVector = table.getChild(xField.name);
+    const yVector = table.getChild(yField.name);
+    if (!xVector || !yVector) {
       throw new Error('Unable to read the selected coordinate columns');
     }
 
@@ -54,28 +54,31 @@ async function preprocess(sourcePath, targetDirectory, pointsPerShard) {
       const bounds = [Infinity, Infinity, -Infinity, -Infinity];
       for (let localIndex = 0; localIndex < pointCount; localIndex++) {
         const rowIndex = firstRow + localIndex;
-        const longitude = Number(longitudeVector.get(rowIndex));
-        const latitude = Number(latitudeVector.get(rowIndex));
-        positions[localIndex * 2] = longitude;
-        positions[localIndex * 2 + 1] = latitude;
-        if (Number.isFinite(longitude) && Number.isFinite(latitude)) {
-          bounds[0] = Math.min(bounds[0], longitude);
-          bounds[1] = Math.min(bounds[1], latitude);
-          bounds[2] = Math.max(bounds[2], longitude);
-          bounds[3] = Math.max(bounds[3], latitude);
+        const x = getCoordinateValue(xVector.get(rowIndex));
+        const y = getCoordinateValue(yVector.get(rowIndex));
+        positions[localIndex * 2] = x;
+        positions[localIndex * 2 + 1] = y;
+        const storedX = positions[localIndex * 2];
+        const storedY = positions[localIndex * 2 + 1];
+        if (Number.isFinite(storedX) && Number.isFinite(storedY)) {
+          bounds[0] = Math.min(bounds[0], storedX);
+          bounds[1] = Math.min(bounds[1], storedY);
+          bounds[2] = Math.max(bounds[2], storedX);
+          bounds[3] = Math.max(bounds[3], storedY);
         }
       }
       const file = `points-${String(shardIndex).padStart(4, '0')}.f32`;
-      await writeFile(join(targetDirectory, file), Buffer.from(positions.buffer));
+      await writeFile(join(targetDirectory, file), encodeLittleEndianFloat32(positions));
       shards.push({file, firstRow, pointCount, bounds: normalizeBounds(bounds)});
       process.stdout.write(`Wrote ${file} (${pointCount.toLocaleString()} rows)\n`);
     }
 
     const manifest = {
-      version: 1,
+      version: 2,
       source: DEFAULT_SOURCE_URL,
       sourceFile: basename(sourcePath),
-      coordinateColumns: [longitudeField.name, latitudeField.name],
+      coordinateColumns: [xField.name, yField.name],
+      coordinateSpace: {kind: 'source-xy', crs: null},
       format: 'float32x2-little-endian',
       pointCount: table.numRows,
       shardPointCount: pointsPerShard,
@@ -107,28 +110,40 @@ async function maybeDecompress(sourcePath, targetDirectory) {
 
 function findCoordinateFields(fields) {
   const byLowercaseName = new Map(fields.map(field => [field.name.toLowerCase(), field]));
-  const longitude = findFirst(byLowercaseName, ['longitude', 'lon', 'lng', 'pickup_longitude', 'x']);
-  const latitude = findFirst(byLowercaseName, ['latitude', 'lat', 'pickup_latitude', 'y']);
-  if (!longitude || !latitude || longitude === latitude) {
-    throw new Error(
-      `Could not identify longitude and latitude columns. Available columns: ${fields
-        .map(field => field.name)
-        .join(', ')}`
-    );
+  const coordinatePairs = [
+    ['x', 'y'],
+    ['longitude', 'latitude'],
+    ['lon', 'lat'],
+    ['lng', 'lat'],
+    ['pickup_longitude', 'pickup_latitude']
+  ];
+  for (const [xName, yName] of coordinatePairs) {
+    const x = byLowercaseName.get(xName);
+    const y = byLowercaseName.get(yName);
+    if (x && y) return [x, y];
   }
-  return [longitude, latitude];
-}
-
-function findFirst(fields, names) {
-  for (const name of names) {
-    const field = fields.get(name);
-    if (field) return field;
-  }
-  return undefined;
+  throw new Error(
+    `Could not identify a complete source X/Y coordinate pair. Available columns: ${fields
+      .map(field => field.name)
+      .join(', ')}`
+  );
 }
 
 function normalizeBounds(bounds) {
   return bounds.every(Number.isFinite) ? bounds : null;
+}
+
+function getCoordinateValue(value) {
+  return value === null || value === undefined ? Number.NaN : Number(value);
+}
+
+function encodeLittleEndianFloat32(values) {
+  const bytes = new Uint8Array(values.byteLength);
+  const dataView = new DataView(bytes.buffer);
+  for (let index = 0; index < values.length; index++) {
+    dataView.setFloat32(index * Float32Array.BYTES_PER_ELEMENT, values[index], true);
+  }
+  return bytes;
 }
 
 function parsePositiveInteger(value, name) {
@@ -163,7 +178,8 @@ function printUsage() {
 
 The original 859 MB object does not expose browser CORS. Download it once, then run this command
 to emit streamable packed float32 shards and manifest.json. The conversion needs enough memory to
-open the decompressed Arrow IPC file; it never runs in the browser.
+open the decompressed Arrow IPC file; it never runs in the browser. Coordinates remain in the
+source X/Y space, and the manifest leaves the coordinate reference system unspecified.
 
 Source:
   ${DEFAULT_SOURCE_URL}

--- a/examples/showcase/billion-point-spatial-atlas/taxi-source.ts
+++ b/examples/showcase/billion-point-spatial-atlas/taxi-source.ts
@@ -1,0 +1,644 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Selective read options shared by packed-shard and future columnar taxi sources. */
+export type TaxiPointSourceReadOptions = {
+  /** Zero-based row-group indexes. Omit to read every row group in manifest order. */
+  rowGroups?: readonly number[];
+  /** Logical source columns required by the consumer. Packed shards decode both coordinates. */
+  columns?: readonly string[];
+  /** Cancels metadata or row-group requests owned by this read. */
+  signal?: AbortSignal;
+};
+
+/** Identifies where a streamed batch appeared in the original source. */
+export type TaxiPointSourceBatchProvenance = {
+  rowGroupIndex: number;
+  originalRowOffset: number;
+};
+
+/** Cumulative point-source activity. */
+export type TaxiPointSourceTelemetry = {
+  downloadedByteCount: number;
+  requestCount: number;
+  networkTimeMilliseconds: number;
+  decodeTimeMilliseconds: number;
+  decodedRowCount: number;
+};
+
+/** HTTP validators retained for one fetched source object. */
+export type TaxiSourceObjectVersion = {
+  /** Strong ETag, when supplied by the server. */
+  etag?: string;
+  /** Last-Modified fallback, when supplied by the server. */
+  lastModified?: string;
+};
+
+/** Coordinate semantics declared by a taxi source manifest. */
+export type TaxiPointCoordinateSpace = {
+  /** Values are the original two-dimensional X/Y coordinates stored by the source. */
+  kind: 'source-xy';
+  /** Coordinate reference system identifier, or `null` when the source does not declare one. */
+  crs: string | null;
+};
+
+/** Public metadata for one independently addressable row group. */
+export type TaxiPointRowGroupMetadata = {
+  index: number;
+  rowCount: number;
+  originalRowOffset: number;
+  byteLength: number;
+  url: string;
+  bounds: readonly [number, number, number, number] | null;
+};
+
+/** Cached manifest metadata exposed by a {@link TaxiPointSource}. */
+export type TaxiPointSourceMetadata = {
+  manifestVersion: number;
+  rowCount: number;
+  rowGroups: readonly TaxiPointRowGroupMetadata[];
+  coordinateColumns: readonly [string, string];
+  coordinateSpace: TaxiPointCoordinateSpace;
+  /** Bounds across every row group, or `null` when any group has no finite bounds. */
+  bounds: readonly [number, number, number, number] | null;
+  /** Original dataset URL recorded by the offline preprocessor. */
+  source: string;
+  /** HTTP validators for the cached manifest object. */
+  objectVersion: TaxiSourceObjectVersion;
+};
+
+/** One fixed-width point batch in original source coordinate space. */
+export type TaxiPointBatch = {
+  /** Interleaved source X/Y values in original row order. */
+  positions: Float32Array;
+  rowCount: number;
+  provenance: TaxiPointSourceBatchProvenance;
+};
+
+/**
+ * Structural source contract shared by packed-shard and future columnar implementations.
+ *
+ * Sources retain metadata and object-version state across reads. Consumers own the returned batch
+ * arrays and decide how much decoded or GPU-resident data to retain.
+ */
+export interface TaxiPointSource {
+  getMetadata(signal?: AbortSignal): Promise<TaxiPointSourceMetadata>;
+  read(options?: TaxiPointSourceReadOptions): AsyncIterable<TaxiPointBatch>;
+  getTelemetry(): TaxiPointSourceTelemetry;
+  close(): void | Promise<void>;
+}
+
+export type PackedTaxiShardSourceOptions = {
+  fetch?: typeof globalThis.fetch;
+};
+
+type PackedTaxiManifest = {
+  version: 1 | 2;
+  source: string;
+  pointCount: number;
+  coordinateColumns: readonly [string, string];
+  coordinateSpace: TaxiPointCoordinateSpace;
+  shards: readonly PackedTaxiManifestShard[];
+};
+
+type PackedTaxiManifestShard = {
+  file: string;
+  firstRow: number;
+  pointCount: number;
+  bounds: readonly [number, number, number, number] | null;
+};
+
+type FetchResult = {
+  arrayBuffer: ArrayBuffer;
+  objectVersion: TaxiSourceObjectVersion;
+};
+
+const PACKED_TAXI_FORMAT = 'float32x2-little-endian';
+const BYTES_PER_TAXI_ROW = 2 * Float32Array.BYTES_PER_ELEMENT;
+const PLATFORM_IS_LITTLE_ENDIAN = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+
+/**
+ * Reads the independently addressable `.f32` row groups emitted by `preprocess-paul-taxi.mjs`.
+ *
+ * The manifest is fetched and decoded at most once. Shard buffers remain uncached so callers can
+ * bound resident memory themselves. Repeated reads of a shard carry its retained HTTP validator
+ * and fail if the server returns a different strong ETag, or a different Last-Modified value when
+ * no strong ETag is available.
+ */
+export class PackedTaxiShardSource implements TaxiPointSource {
+  private readonly manifestUrl: URL;
+  private readonly fetchImplementation: typeof globalThis.fetch;
+  private readonly closeController = new AbortController();
+  private readonly objectVersions = new Map<string, TaxiSourceObjectVersion>();
+  private readonly telemetry: TaxiPointSourceTelemetry = {
+    downloadedByteCount: 0,
+    requestCount: 0,
+    networkTimeMilliseconds: 0,
+    decodeTimeMilliseconds: 0,
+    decodedRowCount: 0
+  };
+
+  private metadataPromise?: Promise<TaxiPointSourceMetadata>;
+  private closed = false;
+
+  constructor(
+    manifestUrl: string | URL = './taxi-atlas/manifest.json',
+    options: PackedTaxiShardSourceOptions = {}
+  ) {
+    const documentBaseUrl =
+      typeof document === 'undefined' ? 'http://localhost/' : document.baseURI;
+    this.manifestUrl = new URL(manifestUrl, documentBaseUrl);
+    this.fetchImplementation = options.fetch ?? globalThis.fetch.bind(globalThis);
+  }
+
+  /** Returns validated manifest metadata, fetching and decoding it at most once. */
+  async getMetadata(signal?: AbortSignal): Promise<TaxiPointSourceMetadata> {
+    this.assertOpen();
+    signal?.throwIfAborted();
+    if (!this.metadataPromise) {
+      // The cached request belongs to the source, not whichever caller happens to start it.
+      const pendingMetadata = this.loadMetadata();
+      this.metadataPromise = pendingMetadata;
+      pendingMetadata.catch(() => {
+        if (this.metadataPromise === pendingMetadata) {
+          this.metadataPromise = undefined;
+        }
+      });
+    }
+    return await waitForPromise(this.metadataPromise, signal);
+  }
+
+  /** Streams selected packed row groups in the requested order. */
+  async *read(options: TaxiPointSourceReadOptions = {}): AsyncGenerator<TaxiPointBatch> {
+    this.assertOpen();
+    options.signal?.throwIfAborted();
+    const metadata = await this.getMetadata(options.signal);
+    validateRequestedColumns(options.columns, metadata.coordinateColumns);
+    const rowGroupIndexes = getRowGroupIndexes(options.rowGroups, metadata.rowGroups.length);
+
+    for (const rowGroupIndex of rowGroupIndexes) {
+      this.assertOpen();
+      options.signal?.throwIfAborted();
+      const rowGroup = metadata.rowGroups[rowGroupIndex];
+      // getRowGroupIndexes verifies every index against metadata.rowGroups.length.
+      if (!rowGroup) {
+        throw new Error(`Taxi point row group ${rowGroupIndex} is unavailable`);
+      }
+      const result = await this.fetchArrayBuffer(rowGroup.url, options.signal);
+      this.assertOpen();
+      options.signal?.throwIfAborted();
+      const decodeStartTime = getTimestamp();
+      if (result.arrayBuffer.byteLength !== rowGroup.byteLength) {
+        this.telemetry.decodeTimeMilliseconds += getTimestamp() - decodeStartTime;
+        throw new Error(
+          `Taxi point row group ${rowGroupIndex} has ${result.arrayBuffer.byteLength} bytes; expected ${rowGroup.byteLength}`
+        );
+      }
+      const positions = makeLittleEndianFloat32Array(result.arrayBuffer);
+      this.telemetry.decodeTimeMilliseconds += getTimestamp() - decodeStartTime;
+      this.telemetry.decodedRowCount += rowGroup.rowCount;
+      yield {
+        positions,
+        rowCount: rowGroup.rowCount,
+        provenance: {
+          rowGroupIndex,
+          originalRowOffset: rowGroup.originalRowOffset
+        }
+      };
+    }
+  }
+
+  /** Returns a detached snapshot so callers cannot mutate the source's counters. */
+  getTelemetry(): TaxiPointSourceTelemetry {
+    return {...this.telemetry};
+  }
+
+  /** Prevents new reads and aborts requests currently owned by this source. */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.closeController.abort(new Error('Packed taxi point source closed'));
+  }
+
+  private async loadMetadata(): Promise<TaxiPointSourceMetadata> {
+    const result = await this.fetchArrayBuffer(this.manifestUrl.href);
+    this.assertOpen();
+    const decodeStartTime = getTimestamp();
+    try {
+      const manifestText = new TextDecoder().decode(result.arrayBuffer);
+      const manifest = parsePackedTaxiManifest(JSON.parse(manifestText));
+      const manifestDirectory = new URL('.', this.manifestUrl);
+      const rowGroupUrls = new Set<string>();
+      const rowGroups = Object.freeze(
+        manifest.shards.map((shard, index): TaxiPointRowGroupMetadata => {
+          const rowGroupUrl = new URL(shard.file, manifestDirectory);
+          rowGroupUrl.hash = '';
+          if (rowGroupUrls.has(rowGroupUrl.href)) {
+            throw new Error(
+              `Taxi point manifest shard ${index} repeats resolved URL ${rowGroupUrl.href}`
+            );
+          }
+          rowGroupUrls.add(rowGroupUrl.href);
+          const bounds = shard.bounds
+            ? Object.freeze([
+                shard.bounds[0],
+                shard.bounds[1],
+                shard.bounds[2],
+                shard.bounds[3]
+              ] as const)
+            : null;
+          return Object.freeze({
+            index,
+            rowCount: shard.pointCount,
+            originalRowOffset: shard.firstRow,
+            byteLength: getTaxiRowGroupByteLength(shard.pointCount, index),
+            url: rowGroupUrl.href,
+            bounds
+          });
+        })
+      );
+      return Object.freeze({
+        manifestVersion: manifest.version,
+        rowCount: manifest.pointCount,
+        rowGroups,
+        coordinateColumns: Object.freeze([
+          manifest.coordinateColumns[0],
+          manifest.coordinateColumns[1]
+        ] as const),
+        coordinateSpace: Object.freeze({...manifest.coordinateSpace}),
+        bounds: getCombinedBounds(rowGroups),
+        source: manifest.source,
+        objectVersion: Object.freeze({...result.objectVersion})
+      });
+    } finally {
+      this.telemetry.decodeTimeMilliseconds += getTimestamp() - decodeStartTime;
+    }
+  }
+
+  private async fetchArrayBuffer(url: string, signal?: AbortSignal): Promise<FetchResult> {
+    const requestSignal = makeCombinedAbortSignal(signal, this.closeController.signal);
+    const knownVersion = this.objectVersions.get(url);
+    const headers: Record<string, string> = {};
+    if (knownVersion?.etag) {
+      headers['If-Match'] = knownVersion.etag;
+    } else if (knownVersion?.lastModified) {
+      headers['If-Unmodified-Since'] = knownVersion.lastModified;
+    }
+
+    this.telemetry.requestCount++;
+    const networkStartTime = getTimestamp();
+    try {
+      const response = await this.fetchImplementation(url, {
+        headers,
+        signal: requestSignal.signal
+      });
+      if (!response.ok) {
+        throw new Error(`Taxi point source request failed (${response.status}) for ${url}`);
+      }
+      const arrayBuffer = await response.arrayBuffer();
+      requestSignal.signal.throwIfAborted();
+      this.telemetry.downloadedByteCount += arrayBuffer.byteLength;
+      const objectVersion = getResponseObjectVersion(response);
+      this.validateObjectVersion(url, objectVersion);
+      return {arrayBuffer, objectVersion};
+    } finally {
+      this.telemetry.networkTimeMilliseconds += getTimestamp() - networkStartTime;
+      requestSignal.release();
+    }
+  }
+
+  private validateObjectVersion(url: string, receivedVersion: TaxiSourceObjectVersion): void {
+    const knownVersion = this.objectVersions.get(url);
+    if (!knownVersion) {
+      this.objectVersions.set(url, receivedVersion);
+      return;
+    }
+    if (knownVersion.etag && receivedVersion.etag !== knownVersion.etag) {
+      throw new Error(`Taxi point source ETag changed while reading ${url}`);
+    }
+    if (
+      !knownVersion.etag &&
+      knownVersion.lastModified &&
+      receivedVersion.lastModified !== knownVersion.lastModified
+    ) {
+      throw new Error(`Taxi point source Last-Modified changed while reading ${url}`);
+    }
+    this.objectVersions.set(url, {
+      etag: knownVersion.etag ?? receivedVersion.etag,
+      lastModified: knownVersion.lastModified ?? receivedVersion.lastModified
+    });
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new Error('Packed taxi point source is closed');
+    }
+  }
+}
+
+function parsePackedTaxiManifest(value: unknown): PackedTaxiManifest {
+  const manifest = getObject(value, 'Taxi point manifest');
+  const version = getManifestVersion(manifest.version);
+  if (manifest.format !== PACKED_TAXI_FORMAT) {
+    throw new Error(`Taxi point manifest format must be ${PACKED_TAXI_FORMAT}`);
+  }
+  const source = getNonEmptyString(manifest.source, 'Taxi point manifest source');
+  const pointCount = getNonNegativeSafeInteger(
+    manifest.pointCount,
+    'Taxi point manifest pointCount'
+  );
+  const shardPointCount = getPositiveSafeInteger(
+    manifest.shardPointCount,
+    'Taxi point manifest shardPointCount'
+  );
+  const coordinateColumns = parseCoordinateColumns(manifest.coordinateColumns);
+  const coordinateSpace = parseCoordinateSpace(manifest.coordinateSpace, version);
+  if (!Array.isArray(manifest.shards)) {
+    throw new Error('Taxi point manifest shards must be an array');
+  }
+
+  const shards: PackedTaxiManifestShard[] = [];
+  let expectedFirstRow = 0;
+  for (let index = 0; index < manifest.shards.length; index++) {
+    const shardValue = getObject(manifest.shards[index], `Taxi point manifest shard ${index}`);
+    const file = getNonEmptyString(shardValue.file, `Taxi point manifest shard ${index} file`);
+    if (!new URL(file, 'http://localhost/').pathname.toLowerCase().endsWith('.f32')) {
+      throw new Error(`Taxi point manifest shard ${index} must reference a .f32 file`);
+    }
+    const firstRow = getNonNegativeSafeInteger(
+      shardValue.firstRow,
+      `Taxi point manifest shard ${index} firstRow`
+    );
+    const shardRowCount = getPositiveSafeInteger(
+      shardValue.pointCount,
+      `Taxi point manifest shard ${index} pointCount`
+    );
+    if (firstRow !== expectedFirstRow) {
+      throw new Error(
+        `Taxi point manifest shard ${index} starts at row ${firstRow}; expected ${expectedFirstRow}`
+      );
+    }
+    if (shardRowCount > shardPointCount) {
+      throw new Error(`Taxi point manifest shard ${index} exceeds shardPointCount`);
+    }
+    getTaxiRowGroupByteLength(shardRowCount, index);
+    const bounds = parseBounds(shardValue.bounds, index);
+    shards.push({file, firstRow, pointCount: shardRowCount, bounds});
+    expectedFirstRow += shardRowCount;
+    if (!Number.isSafeInteger(expectedFirstRow)) {
+      throw new Error('Taxi point manifest row offsets exceed the safe integer range');
+    }
+  }
+  if (expectedFirstRow !== pointCount) {
+    throw new Error(
+      `Taxi point manifest row groups contain ${expectedFirstRow} rows; expected ${pointCount}`
+    );
+  }
+  if (pointCount > 0 && shards.length === 0) {
+    throw new Error('Taxi point manifest with rows must include at least one shard');
+  }
+
+  return {
+    version,
+    source,
+    pointCount,
+    coordinateColumns,
+    coordinateSpace,
+    shards
+  };
+}
+
+function getManifestVersion(value: unknown): 1 | 2 {
+  if (value !== 1 && value !== 2) {
+    throw new Error('Taxi point manifest version must be 1 or 2');
+  }
+  return value;
+}
+
+function parseCoordinateColumns(value: unknown): [string, string] {
+  if (!Array.isArray(value) || value.length !== 2) {
+    throw new Error('Taxi point manifest coordinateColumns must contain two source columns');
+  }
+  const firstColumn = getNonEmptyString(value[0], 'Taxi point first coordinate column');
+  const secondColumn = getNonEmptyString(value[1], 'Taxi point second coordinate column');
+  if (firstColumn === secondColumn) {
+    throw new Error('Taxi point manifest coordinate columns must be distinct');
+  }
+  return [firstColumn, secondColumn];
+}
+
+function parseCoordinateSpace(value: unknown, version: 1 | 2): TaxiPointCoordinateSpace {
+  if (value === undefined && version === 1) {
+    return {kind: 'source-xy', crs: null};
+  }
+  if (value === undefined) {
+    throw new Error('Taxi point manifest coordinateSpace is required in version 2');
+  }
+  const coordinateSpace = getObject(value, 'Taxi point manifest coordinateSpace');
+  if (coordinateSpace.kind !== 'source-xy') {
+    throw new Error('Taxi point manifest coordinateSpace kind must be source-xy');
+  }
+  const crs = coordinateSpace.crs;
+  if (crs === null) {
+    return {kind: 'source-xy', crs: null};
+  }
+  if (typeof crs !== 'string' || crs.length === 0) {
+    throw new Error('Taxi point manifest coordinateSpace crs must be a non-empty string or null');
+  }
+  return {kind: 'source-xy', crs};
+}
+
+function parseBounds(value: unknown, shardIndex: number): [number, number, number, number] | null {
+  if (value === null) return null;
+  if (!Array.isArray(value) || value.length !== 4 || !value.every(Number.isFinite)) {
+    throw new Error(
+      `Taxi point manifest shard ${shardIndex} bounds must be four finite numbers or null`
+    );
+  }
+  const bounds: [number, number, number, number] = [value[0], value[1], value[2], value[3]];
+  if (bounds[0] > bounds[2] || bounds[1] > bounds[3]) {
+    throw new Error(`Taxi point manifest shard ${shardIndex} bounds are inverted`);
+  }
+  return bounds;
+}
+
+function validateRequestedColumns(
+  requestedColumns: readonly string[] | undefined,
+  coordinateColumns: readonly [string, string]
+): void {
+  if (requestedColumns === undefined) return;
+  if (requestedColumns.length === 0) {
+    throw new Error('Taxi point source read columns must not be empty');
+  }
+  const seenColumns = new Set<string>();
+  for (const column of requestedColumns) {
+    if (!coordinateColumns.includes(column)) {
+      throw new Error(`Taxi point source does not provide requested column ${column}`);
+    }
+    if (seenColumns.has(column)) {
+      throw new Error(`Taxi point source read repeats column ${column}`);
+    }
+    seenColumns.add(column);
+  }
+}
+
+function getRowGroupIndexes(
+  requestedRowGroups: readonly number[] | undefined,
+  rowGroupCount: number
+): number[] {
+  if (requestedRowGroups === undefined) {
+    return Array.from({length: rowGroupCount}, (_, rowGroupIndex) => rowGroupIndex);
+  }
+  const rowGroupIndexes: number[] = [];
+  const seenRowGroups = new Set<number>();
+  for (const rowGroupIndex of requestedRowGroups) {
+    if (
+      !Number.isSafeInteger(rowGroupIndex) ||
+      rowGroupIndex < 0 ||
+      rowGroupIndex >= rowGroupCount
+    ) {
+      throw new Error(`Taxi point row group index ${rowGroupIndex} is out of range`);
+    }
+    if (seenRowGroups.has(rowGroupIndex)) {
+      throw new Error(`Taxi point source read repeats row group ${rowGroupIndex}`);
+    }
+    seenRowGroups.add(rowGroupIndex);
+    rowGroupIndexes.push(rowGroupIndex);
+  }
+  return rowGroupIndexes;
+}
+
+function getTaxiRowGroupByteLength(rowCount: number, rowGroupIndex: number): number {
+  const byteLength = rowCount * BYTES_PER_TAXI_ROW;
+  if (!Number.isSafeInteger(byteLength)) {
+    throw new Error(`Taxi point manifest shard ${rowGroupIndex} byte length is not a safe integer`);
+  }
+  return byteLength;
+}
+
+function getCombinedBounds(
+  rowGroups: readonly TaxiPointRowGroupMetadata[]
+): readonly [number, number, number, number] | null {
+  if (rowGroups.length === 0 || rowGroups.some(rowGroup => rowGroup.bounds === null)) {
+    return null;
+  }
+  const bounds: [number, number, number, number] = [Infinity, Infinity, -Infinity, -Infinity];
+  for (const rowGroup of rowGroups) {
+    const rowGroupBounds = rowGroup.bounds!;
+    bounds[0] = Math.min(bounds[0], rowGroupBounds[0]);
+    bounds[1] = Math.min(bounds[1], rowGroupBounds[1]);
+    bounds[2] = Math.max(bounds[2], rowGroupBounds[2]);
+    bounds[3] = Math.max(bounds[3], rowGroupBounds[3]);
+  }
+  return Object.freeze(bounds);
+}
+
+function makeLittleEndianFloat32Array(arrayBuffer: ArrayBuffer): Float32Array {
+  if (PLATFORM_IS_LITTLE_ENDIAN) {
+    return new Float32Array(arrayBuffer);
+  }
+  const values = new Float32Array(arrayBuffer.byteLength / Float32Array.BYTES_PER_ELEMENT);
+  const dataView = new DataView(arrayBuffer);
+  for (let index = 0; index < values.length; index++) {
+    values[index] = dataView.getFloat32(index * Float32Array.BYTES_PER_ELEMENT, true);
+  }
+  return values;
+}
+
+function getResponseObjectVersion(response: Response): TaxiSourceObjectVersion {
+  const etagHeader = response.headers.get('etag')?.trim();
+  const etag = etagHeader && !etagHeader.toLowerCase().startsWith('w/') ? etagHeader : undefined;
+  const lastModified = response.headers.get('last-modified')?.trim() || undefined;
+  return {etag, lastModified};
+}
+
+function makeCombinedAbortSignal(
+  callerSignal: AbortSignal | undefined,
+  closeSignal: AbortSignal
+): {signal: AbortSignal; release: () => void} {
+  if (!callerSignal) {
+    return {signal: closeSignal, release: () => {}};
+  }
+  const controller = new AbortController();
+  const forwardCallerAbort = () => controller.abort(callerSignal.reason);
+  const forwardCloseAbort = () => controller.abort(closeSignal.reason);
+  if (callerSignal.aborted) {
+    forwardCallerAbort();
+  } else if (closeSignal.aborted) {
+    forwardCloseAbort();
+  } else {
+    callerSignal.addEventListener('abort', forwardCallerAbort, {once: true});
+    closeSignal.addEventListener('abort', forwardCloseAbort, {once: true});
+  }
+  return {
+    signal: controller.signal,
+    release: () => {
+      callerSignal.removeEventListener('abort', forwardCallerAbort);
+      closeSignal.removeEventListener('abort', forwardCloseAbort);
+    }
+  };
+}
+
+function waitForPromise<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  signal.throwIfAborted();
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const removeAbortListener = () => signal.removeEventListener('abort', rejectOnAbort);
+    const rejectOnAbort = () => {
+      if (settled) return;
+      settled = true;
+      removeAbortListener();
+      reject(signal.reason);
+    };
+    signal.addEventListener('abort', rejectOnAbort, {once: true});
+    promise.then(
+      value => {
+        if (settled) return;
+        settled = true;
+        removeAbortListener();
+        resolve(value);
+      },
+      error => {
+        if (settled) return;
+        settled = true;
+        removeAbortListener();
+        reject(error);
+      }
+    );
+    if (signal.aborted) rejectOnAbort();
+  });
+}
+
+function getObject(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function getNonEmptyString(value: unknown, name: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function getNonNegativeSafeInteger(value: unknown, name: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function getPositiveSafeInteger(value: unknown, name: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function getTimestamp(): number {
+  return typeof performance === 'undefined' ? Date.now() : performance.now();
+}

--- a/test/examples/billion-point-spatial-atlas-taxi-preprocess.node.spec.ts
+++ b/test/examples/billion-point-spatial-atlas-taxi-preprocess.node.spec.ts
@@ -1,0 +1,102 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {execFile} from 'node:child_process';
+import {mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import * as arrow from 'apache-arrow';
+import {expect, test} from 'vitest';
+
+const PREPROCESSOR_PATH = fileURLToPath(
+  new URL(
+    '../../examples/showcase/billion-point-spatial-atlas/scripts/preprocess-paul-taxi.mjs',
+    import.meta.url
+  )
+);
+
+test('taxi preprocessing preserves invalid rows, stored bounds, and little-endian bytes', async () => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'luma-taxi-preprocess-test-'));
+  try {
+    const inputPath = join(temporaryDirectory, 'points.arrow');
+    const outputDirectory = join(temporaryDirectory, 'output');
+    const table = arrow.tableFromArrays({
+      x: arrow.vectorFromArray([0.1, null, -0.1], new arrow.Float64()),
+      y: arrow.vectorFromArray([0.2, 3, -0.2], new arrow.Float64())
+    });
+    await writeFile(inputPath, arrow.tableToIPC(table, 'file'));
+
+    await runPreprocessor(inputPath, outputDirectory);
+
+    const manifest: {
+      version: number;
+      coordinateColumns: string[];
+      coordinateSpace: {kind: string; crs: string | null};
+      shards: Array<{bounds: number[] | null}>;
+    } = JSON.parse(await readFile(join(outputDirectory, 'manifest.json'), 'utf8'));
+    expect(manifest).toMatchObject({
+      version: 2,
+      coordinateColumns: ['x', 'y'],
+      coordinateSpace: {kind: 'source-xy', crs: null}
+    });
+    expect(manifest.shards[0]?.bounds).toEqual([
+      Math.fround(-0.1),
+      Math.fround(-0.2),
+      Math.fround(0.1),
+      Math.fround(0.2)
+    ]);
+
+    const bytes = await readFile(join(outputDirectory, 'points-0000.f32'));
+    const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    expect(dataView.getFloat32(0, true)).toBe(Math.fround(0.1));
+    expect(dataView.getFloat32(4, true)).toBe(Math.fround(0.2));
+    expect(Number.isNaN(dataView.getFloat32(8, true))).toBe(true);
+    expect(dataView.getFloat32(12, true)).toBe(3);
+    expect(dataView.getFloat32(16, true)).toBe(Math.fround(-0.1));
+    expect(dataView.getFloat32(20, true)).toBe(Math.fround(-0.2));
+    expect(Array.from(bytes.subarray(0, 8))).toEqual([205, 204, 204, 61, 205, 204, 76, 62]);
+    expect(Array.from(bytes.subarray(12, 24))).toEqual([
+      0, 0, 64, 64, 205, 204, 204, 189, 205, 204, 76, 190
+    ]);
+  } finally {
+    await rm(temporaryDirectory, {recursive: true, force: true});
+  }
+}, 10_000);
+
+test('taxi preprocessing selects complete coordinate pairs without mixing aliases', async () => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'luma-taxi-coordinate-pair-test-'));
+  try {
+    const inputPath = join(temporaryDirectory, 'points.arrow');
+    const outputDirectory = join(temporaryDirectory, 'output');
+    const table = arrow.tableFromArrays({
+      x: arrow.vectorFromArray([999], new arrow.Float64()),
+      longitude: arrow.vectorFromArray([-73], new arrow.Float64()),
+      latitude: arrow.vectorFromArray([40], new arrow.Float64())
+    });
+    await writeFile(inputPath, arrow.tableToIPC(table, 'file'));
+
+    await runPreprocessor(inputPath, outputDirectory);
+
+    const manifest: {coordinateColumns: string[]} = JSON.parse(
+      await readFile(join(outputDirectory, 'manifest.json'), 'utf8')
+    );
+    expect(manifest.coordinateColumns).toEqual(['longitude', 'latitude']);
+    const bytes = await readFile(join(outputDirectory, 'points-0000.f32'));
+    const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    expect([dataView.getFloat32(0, true), dataView.getFloat32(4, true)]).toEqual([-73, 40]);
+  } finally {
+    await rm(temporaryDirectory, {recursive: true, force: true});
+  }
+});
+
+async function runPreprocessor(inputPath: string, outputDirectory: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    execFile(
+      process.execPath,
+      [PREPROCESSOR_PATH, '--input', inputPath, '--output', outputDirectory, '--shard-points', '3'],
+      error => (error ? reject(error) : resolve())
+    );
+  });
+}

--- a/test/examples/billion-point-spatial-atlas-taxi-source.node.spec.ts
+++ b/test/examples/billion-point-spatial-atlas-taxi-source.node.spec.ts
@@ -1,0 +1,512 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {
+  PackedTaxiShardSource,
+  type TaxiPointSource
+} from '../../examples/showcase/billion-point-spatial-atlas/taxi-source';
+
+const MANIFEST_URL = 'https://example.test/taxi/manifest.json';
+const SOURCE_URL = 'https://example.test/original.arrow.gz';
+
+describe('PackedTaxiShardSource', () => {
+  test('caches versioned metadata and streams selected row groups with provenance', async () => {
+    const manifest = makeManifest();
+    const manifestBytes = new TextEncoder().encode(JSON.stringify(manifest));
+    const shardBytes = [
+      makePackedPositions([
+        [913_175.125, 120_121.875],
+        [913_200.5, 120_180.25]
+      ]),
+      makePackedPositions([[1_067_382.5, 272_844.28125]])
+    ];
+    const requests: RecordedRequest[] = [];
+    const fetchImplementation = makeFetch(
+      new Map([
+        [
+          MANIFEST_URL,
+          () =>
+            makeResponse(manifestBytes, {
+              etag: '"manifest-v2"',
+              lastModified: 'Mon, 03 Aug 2026 12:00:00 GMT'
+            })
+        ],
+        [
+          'https://example.test/taxi/points-0000.f32',
+          () => makeResponse(shardBytes[0], {etag: '"shard-0"'})
+        ],
+        [
+          'https://example.test/taxi/points-0001.f32',
+          () =>
+            makeResponse(shardBytes[1], {
+              lastModified: 'Mon, 03 Aug 2026 12:01:00 GMT'
+            })
+        ]
+      ]),
+      requests
+    );
+    const source: TaxiPointSource = new PackedTaxiShardSource(MANIFEST_URL, {
+      fetch: fetchImplementation
+    });
+
+    const firstMetadata = await source.getMetadata();
+    const secondMetadata = await source.getMetadata();
+    expect(secondMetadata).toBe(firstMetadata);
+    expect(firstMetadata).toEqual({
+      manifestVersion: 2,
+      rowCount: 3,
+      rowGroups: [
+        {
+          index: 0,
+          rowCount: 2,
+          originalRowOffset: 0,
+          byteLength: 16,
+          url: 'https://example.test/taxi/points-0000.f32',
+          bounds: [913_175.125, 120_121.875, 913_200.5, 120_180.25]
+        },
+        {
+          index: 1,
+          rowCount: 1,
+          originalRowOffset: 2,
+          byteLength: 8,
+          url: 'https://example.test/taxi/points-0001.f32',
+          bounds: [1_067_382.5, 272_844.28125, 1_067_382.5, 272_844.28125]
+        }
+      ],
+      coordinateColumns: ['x', 'y'],
+      coordinateSpace: {kind: 'source-xy', crs: null},
+      bounds: [913_175.125, 120_121.875, 1_067_382.5, 272_844.28125],
+      source: SOURCE_URL,
+      objectVersion: {
+        etag: '"manifest-v2"',
+        lastModified: 'Mon, 03 Aug 2026 12:00:00 GMT'
+      }
+    });
+    expect(Object.isFrozen(firstMetadata)).toBe(true);
+    expect(Object.isFrozen(firstMetadata.rowGroups)).toBe(true);
+    expect(Object.isFrozen(firstMetadata.coordinateSpace)).toBe(true);
+    expect(requests.map(request => request.url)).toEqual([MANIFEST_URL]);
+
+    const batches = [];
+    for await (const batch of source.read({
+      rowGroups: [1, 0],
+      columns: ['y', 'x']
+    })) {
+      batches.push(batch);
+    }
+    expect(batches).toHaveLength(2);
+    expect(batches[0]?.rowCount).toBe(1);
+    expect(batches[0]?.provenance).toEqual({rowGroupIndex: 1, originalRowOffset: 2});
+    expect(Array.from(batches[0]?.positions ?? [])).toEqual(
+      Array.from(new Float32Array([1_067_382.5, 272_844.28125]))
+    );
+    expect(batches[1]?.rowCount).toBe(2);
+    expect(batches[1]?.provenance).toEqual({rowGroupIndex: 0, originalRowOffset: 0});
+    expect(Array.from(batches[1]?.positions ?? [])).toEqual(
+      Array.from(new Float32Array([913_175.125, 120_121.875, 913_200.5, 120_180.25]))
+    );
+
+    const telemetry = source.getTelemetry();
+    expect(telemetry.requestCount).toBe(3);
+    expect(telemetry.downloadedByteCount).toBe(
+      manifestBytes.byteLength + shardBytes[0].byteLength + shardBytes[1].byteLength
+    );
+    expect(telemetry.decodedRowCount).toBe(3);
+    expect(telemetry.networkTimeMilliseconds).toBeGreaterThanOrEqual(0);
+    expect(telemetry.decodeTimeMilliseconds).toBeGreaterThanOrEqual(0);
+    telemetry.requestCount = -1;
+    expect(source.getTelemetry().requestCount).toBe(3);
+
+    await source.read({rowGroups: [0]}).next();
+    expect(requests.at(-1)).toMatchObject({
+      url: 'https://example.test/taxi/points-0000.f32',
+      headers: {'if-match': '"shard-0"'}
+    });
+    await source.read({rowGroups: [1]}).next();
+    expect(requests.at(-1)).toMatchObject({
+      url: 'https://example.test/taxi/points-0001.f32',
+      headers: {'if-unmodified-since': 'Mon, 03 Aug 2026 12:01:00 GMT'}
+    });
+    expect(source.getTelemetry()).toMatchObject({
+      requestCount: 5,
+      downloadedByteCount:
+        manifestBytes.byteLength + shardBytes[0].byteLength * 2 + shardBytes[1].byteLength * 2,
+      decodedRowCount: 6
+    });
+  });
+
+  test('treats legacy version 1 coordinates as source XY with an unspecified CRS', async () => {
+    const manifest = makeManifest({version: 1});
+    delete manifest.coordinateSpace;
+    const metadata = await makeSourceWithManifest(manifest).getMetadata();
+
+    expect(metadata.manifestVersion).toBe(1);
+    expect(metadata.coordinateSpace).toEqual({kind: 'source-xy', crs: null});
+  });
+
+  test('preserves an explicitly declared source coordinate reference system', async () => {
+    const manifest = makeManifest({
+      coordinateSpace: {kind: 'source-xy', crs: 'EPSG:2263'}
+    });
+    const metadata = await makeSourceWithManifest(manifest).getMetadata();
+
+    expect(metadata.coordinateSpace).toEqual({kind: 'source-xy', crs: 'EPSG:2263'});
+  });
+
+  test('rejects malformed manifests', async () => {
+    const unsupportedVersion = makeManifest({version: 3});
+    await expect(makeSourceWithManifest(unsupportedVersion).getMetadata()).rejects.toThrow(
+      'Taxi point manifest version must be 1 or 2'
+    );
+
+    const missingCoordinateSpace = makeManifest();
+    delete missingCoordinateSpace.coordinateSpace;
+    await expect(makeSourceWithManifest(missingCoordinateSpace).getMetadata()).rejects.toThrow(
+      'Taxi point manifest coordinateSpace is required in version 2'
+    );
+
+    const invalidCoordinateReferenceSystem = makeManifest({
+      coordinateSpace: {kind: 'source-xy', crs: ''}
+    });
+    await expect(
+      makeSourceWithManifest(invalidCoordinateReferenceSystem).getMetadata()
+    ).rejects.toThrow('Taxi point manifest coordinateSpace crs must be a non-empty string or null');
+
+    const discontinuousManifest = makeManifest();
+    discontinuousManifest.shards[1]!.firstRow = 3;
+    await expect(makeSourceWithManifest(discontinuousManifest).getMetadata()).rejects.toThrow(
+      'Taxi point manifest shard 1 starts at row 3; expected 2'
+    );
+
+    const duplicateCoordinateColumns = makeManifest({coordinateColumns: ['x', 'x']});
+    await expect(makeSourceWithManifest(duplicateCoordinateColumns).getMetadata()).rejects.toThrow(
+      'Taxi point manifest coordinate columns must be distinct'
+    );
+
+    const duplicateResolvedUrl = makeManifest();
+    duplicateResolvedUrl.shards[1]!.file = './points-0000.f32#duplicate';
+    await expect(makeSourceWithManifest(duplicateResolvedUrl).getMetadata()).rejects.toThrow(
+      'Taxi point manifest shard 1 repeats resolved URL https://example.test/taxi/points-0000.f32'
+    );
+
+    const invertedBounds = makeManifest();
+    invertedBounds.shards[0]!.bounds = [2, 0, 1, 3];
+    await expect(makeSourceWithManifest(invertedBounds).getMetadata()).rejects.toThrow(
+      'Taxi point manifest shard 0 bounds are inverted'
+    );
+
+    const incompleteRows = makeManifest({pointCount: 4});
+    await expect(makeSourceWithManifest(incompleteRows).getMetadata()).rejects.toThrow(
+      'Taxi point manifest row groups contain 3 rows; expected 4'
+    );
+  });
+
+  test('validates selected columns and row groups before requesting shard data', async () => {
+    const requests: RecordedRequest[] = [];
+    const source = makeSourceWithManifest(makeManifest(), requests);
+    await source.getMetadata();
+
+    await expect(source.read({columns: ['fare_amount']}).next()).rejects.toThrow(
+      'Taxi point source does not provide requested column fare_amount'
+    );
+    await expect(source.read({columns: []}).next()).rejects.toThrow(
+      'Taxi point source read columns must not be empty'
+    );
+    await expect(source.read({columns: ['x', 'x']}).next()).rejects.toThrow(
+      'Taxi point source read repeats column x'
+    );
+    await expect(source.read({rowGroups: [2]}).next()).rejects.toThrow(
+      'Taxi point row group index 2 is out of range'
+    );
+    await expect(source.read({rowGroups: [0, 0]}).next()).rejects.toThrow(
+      'Taxi point source read repeats row group 0'
+    );
+
+    const emptyRead = source.read({rowGroups: [], columns: ['x']});
+    expect(await emptyRead.next()).toEqual({done: true, value: undefined});
+    expect(requests.map(request => request.url)).toEqual([MANIFEST_URL]);
+  });
+
+  test('checks shard byte lengths without counting invalid rows as decoded', async () => {
+    const manifest = makeManifest({
+      pointCount: 1,
+      shardPointCount: 1,
+      shards: [
+        {
+          file: 'points-0000.f32',
+          firstRow: 0,
+          pointCount: 1,
+          bounds: [913_175.125, 120_121.875, 913_175.125, 120_121.875]
+        }
+      ]
+    });
+    const manifestText = JSON.stringify(manifest);
+    const shortSource = new PackedTaxiShardSource(MANIFEST_URL, {
+      fetch: makeFetch(
+        new Map([
+          [MANIFEST_URL, () => makeResponse(manifestText)],
+          ['https://example.test/taxi/points-0000.f32', () => makeResponse(new Uint8Array(4))]
+        ])
+      )
+    });
+
+    await expect(shortSource.read().next()).rejects.toThrow(
+      'Taxi point row group 0 has 4 bytes; expected 8'
+    );
+    expect(shortSource.getTelemetry()).toMatchObject({
+      requestCount: 2,
+      downloadedByteCount: new TextEncoder().encode(manifestText).byteLength + 4,
+      decodedRowCount: 0
+    });
+  });
+
+  test('rejects changed object validators and uses Last-Modified for weak ETags', async () => {
+    const manifest = makeManifest({
+      pointCount: 1,
+      shardPointCount: 1,
+      shards: [
+        {
+          file: 'points-0000.f32',
+          firstRow: 0,
+          pointCount: 1,
+          bounds: [913_175.125, 120_121.875, 913_175.125, 120_121.875]
+        }
+      ]
+    });
+    let shardVersion = '"shard-v1"';
+    let shardLastModified = 'Mon, 03 Aug 2026 12:02:00 GMT';
+    const requests: RecordedRequest[] = [];
+    const versionedSource = new PackedTaxiShardSource(MANIFEST_URL, {
+      fetch: makeFetch(
+        new Map([
+          [MANIFEST_URL, () => makeResponse(JSON.stringify(manifest))],
+          [
+            'https://example.test/taxi/points-0000.f32',
+            () =>
+              makeResponse(makePackedPositions([[913_175.125, 120_121.875]]), {
+                etag: shardVersion,
+                lastModified: shardLastModified
+              })
+          ]
+        ]),
+        requests
+      )
+    });
+    await versionedSource.read().next();
+    shardLastModified = 'Mon, 03 Aug 2026 12:03:00 GMT';
+    await versionedSource.read().next();
+    expect(requests.at(-1)?.headers).toEqual({'if-match': '"shard-v1"'});
+    shardVersion = '"shard-v2"';
+    await expect(versionedSource.read().next()).rejects.toThrow(
+      'Taxi point source ETag changed while reading https://example.test/taxi/points-0000.f32'
+    );
+    expect(requests.at(-1)?.headers).toEqual({'if-match': '"shard-v1"'});
+
+    const weakEtagRequests: RecordedRequest[] = [];
+    let weakEtagLastModified = 'Mon, 03 Aug 2026 12:02:00 GMT';
+    const weakEtagSource = new PackedTaxiShardSource(MANIFEST_URL, {
+      fetch: makeFetch(
+        new Map([
+          [MANIFEST_URL, () => makeResponse(JSON.stringify(manifest))],
+          [
+            'https://example.test/taxi/points-0000.f32',
+            () =>
+              makeResponse(makePackedPositions([[913_175.125, 120_121.875]]), {
+                etag: 'W/"weak-shard"',
+                lastModified: weakEtagLastModified
+              })
+          ]
+        ]),
+        weakEtagRequests
+      )
+    });
+    await weakEtagSource.read().next();
+    await weakEtagSource.read().next();
+    expect(weakEtagRequests.at(-1)?.headers).toEqual({
+      'if-unmodified-since': 'Mon, 03 Aug 2026 12:02:00 GMT'
+    });
+    weakEtagLastModified = 'Mon, 03 Aug 2026 12:03:00 GMT';
+    await expect(weakEtagSource.read().next()).rejects.toThrow(
+      'Taxi point source Last-Modified changed while reading https://example.test/taxi/points-0000.f32'
+    );
+  });
+
+  test('isolates cached metadata callers and closes idempotently', async () => {
+    const firstResponse = makeDeferred<Response>();
+    const firstRequestSignals: AbortSignal[] = [];
+    const firstSource = new PackedTaxiShardSource(MANIFEST_URL, {
+      fetch: async (_input, init) => {
+        const signal = init?.signal;
+        if (!signal) throw new Error('Expected source request signal');
+        firstRequestSignals.push(signal);
+        return await firstResponse.promise;
+      }
+    });
+    const firstAbortController = new AbortController();
+    const canceledFirstCaller = firstSource.getMetadata(firstAbortController.signal);
+    const survivingSecondCaller = firstSource.getMetadata();
+    firstAbortController.abort(new Error('first caller stopped'));
+    await expect(canceledFirstCaller).rejects.toThrow('first caller stopped');
+    expect(firstRequestSignals).toHaveLength(1);
+    expect(firstRequestSignals[0]?.aborted).toBe(false);
+    firstResponse.resolve(makeResponse(JSON.stringify(makeManifest())));
+    const firstMetadata = await survivingSecondCaller;
+    expect(await firstSource.getMetadata()).toBe(firstMetadata);
+
+    const secondResponse = makeDeferred<Response>();
+    const secondRequestSignals: AbortSignal[] = [];
+    const secondSource = new PackedTaxiShardSource(MANIFEST_URL, {
+      fetch: async (_input, init) => {
+        const signal = init?.signal;
+        if (!signal) throw new Error('Expected source request signal');
+        secondRequestSignals.push(signal);
+        return await secondResponse.promise;
+      }
+    });
+    const survivingFirstCaller = secondSource.getMetadata();
+    const secondAbortController = new AbortController();
+    const canceledSecondCaller = secondSource.getMetadata(secondAbortController.signal);
+    secondAbortController.abort(new Error('second caller stopped'));
+    await expect(canceledSecondCaller).rejects.toThrow('second caller stopped');
+    expect(secondRequestSignals).toHaveLength(1);
+    expect(secondRequestSignals[0]?.aborted).toBe(false);
+    secondResponse.resolve(makeResponse(JSON.stringify(makeManifest())));
+    await expect(survivingFirstCaller).resolves.toMatchObject({rowCount: 3});
+
+    const closedRequestSignals: AbortSignal[] = [];
+    const closeAwareFetch: typeof fetch = async (_input, init) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error('Expected source request signal');
+      closedRequestSignals.push(signal);
+      return await new Promise<Response>((_resolve, reject) => {
+        if (signal.aborted) {
+          reject(signal.reason);
+        } else {
+          signal.addEventListener('abort', () => reject(signal.reason), {once: true});
+        }
+      });
+    };
+
+    const closedSource = new PackedTaxiShardSource(MANIFEST_URL, {fetch: closeAwareFetch});
+    const closedMetadata = closedSource.getMetadata();
+    closedSource.close();
+    closedSource.close();
+    await expect(closedMetadata).rejects.toThrow('Packed taxi point source closed');
+    expect(closedRequestSignals[0]?.aborted).toBe(true);
+    await expect(closedSource.getMetadata()).rejects.toThrow('Packed taxi point source is closed');
+  });
+});
+
+type TestManifest = {
+  version: number;
+  source: string;
+  coordinateColumns: [string, string];
+  coordinateSpace?: {kind: string; crs: string | null};
+  format: string;
+  pointCount: number;
+  shardPointCount: number;
+  shards: {
+    file: string;
+    firstRow: number;
+    pointCount: number;
+    bounds: [number, number, number, number] | null;
+  }[];
+};
+
+type RecordedRequest = {
+  url: string;
+  headers: Record<string, string>;
+  signal?: AbortSignal | null;
+};
+
+function makeManifest(overrides: Partial<TestManifest> = {}): TestManifest {
+  return {
+    version: 2,
+    source: SOURCE_URL,
+    coordinateColumns: ['x', 'y'],
+    coordinateSpace: {kind: 'source-xy', crs: null},
+    format: 'float32x2-little-endian',
+    pointCount: 3,
+    shardPointCount: 2,
+    shards: [
+      {
+        file: 'points-0000.f32',
+        firstRow: 0,
+        pointCount: 2,
+        bounds: [913_175.125, 120_121.875, 913_200.5, 120_180.25]
+      },
+      {
+        file: 'points-0001.f32',
+        firstRow: 2,
+        pointCount: 1,
+        bounds: [1_067_382.5, 272_844.28125, 1_067_382.5, 272_844.28125]
+      }
+    ],
+    ...overrides
+  };
+}
+
+function makeSourceWithManifest(
+  manifest: TestManifest,
+  requests: RecordedRequest[] = []
+): PackedTaxiShardSource {
+  return new PackedTaxiShardSource(MANIFEST_URL, {
+    fetch: makeFetch(
+      new Map([[MANIFEST_URL, () => makeResponse(JSON.stringify(manifest))]]),
+      requests
+    )
+  });
+}
+
+function makePackedPositions(rows: readonly (readonly [number, number])[]): Uint8Array {
+  const bytes = new Uint8Array(rows.length * 2 * Float32Array.BYTES_PER_ELEMENT);
+  const dataView = new DataView(bytes.buffer);
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex]!;
+    dataView.setFloat32(rowIndex * 8, row[0], true);
+    dataView.setFloat32(rowIndex * 8 + 4, row[1], true);
+  }
+  return bytes;
+}
+
+function makeResponse(
+  body: string | Uint8Array,
+  version: {etag?: string; lastModified?: string} = {}
+): Response {
+  const headers = new Headers();
+  if (version.etag) headers.set('etag', version.etag);
+  if (version.lastModified) headers.set('last-modified', version.lastModified);
+  return new Response(body, {status: 200, headers});
+}
+
+function makeFetch(
+  responses: Map<string, () => Response>,
+  requests: RecordedRequest[] = []
+): typeof fetch {
+  return async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    const headers = Object.fromEntries(new Headers(init?.headers).entries());
+    requests.push({url, headers, signal: init?.signal});
+    const makeRequestedResponse = responses.get(url);
+    if (!makeRequestedResponse) {
+      return new Response('Not found', {status: 404});
+    }
+    return makeRequestedResponse();
+  };
+}
+
+function makeDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return {promise, resolve, reject};
+}


### PR DESCRIPTION
## Goals

- Establish a reusable, format-neutral point-source seam for the Billion-Point Spatial Atlas.
- Make the existing offline taxi preprocessing output deterministic, versioned, and safe to stream in browser-sized row groups.
- Preserve source coordinate semantics until the atlas runtime explicitly projects them.

## Changes

- Adds a structural `TaxiPointSource` contract and `PackedTaxiShardSource` implementation with cached metadata, selective row-group reads, column validation, batch provenance, and detached telemetry snapshots.
- Retains strong ETag or Last-Modified validators across requests, gives strong ETags precedence, canonicalizes shard URLs, and rejects aliases that resolve to the same object.
- Keeps the shared metadata request source-owned so one caller's abort does not cancel other waiters; `close()` still cancels source-owned work.
- Introduces manifest version 2 with explicit source-XY coordinate metadata while retaining version 1 compatibility.
- Updates the offline Arrow preprocessor to select complete coordinate-column pairs, preserve null coordinates as NaN, calculate bounds from stored float32 values, and emit explicit little-endian bytes.
- Adds deterministic source and CLI fixture tests covering cancellation order, object-version changes, URL aliases, row provenance, nulls, float32 bounds, byte order, and mixed coordinate aliases.

## Validation

- `nvm use`
- `yarn lint fix`
- `yarn build`
- `yarn test` — 429 node tests and 1,520 browser/headless tests passed
- `yarn examples:typecheck`
- Focused taxi-source/preprocessor tests — 10 passed

Not rerun because this PR changes no dependencies or website integration:

- `yarn install`
- `yarn website:build`
- `(cd website && yarn build)`

## Risks and follow-up

- This PR adds the source boundary and offline format only; it does not yet switch the live atlas from deterministic generated data.
- The next stacked PR will stream these row groups into bounded GPU residency and the deck.gl map.
- A future Parquet-backed implementation can satisfy the same structural source contract once the loaders.gl source API exposes the required row-group controls and telemetry.