### PR TITLE
docs: add live FP64, projection, and spatial GPU benchmarks

### DIFF
--- a/docs/api-reference/experimental/README.md
+++ b/docs/api-reference/experimental/README.md
@@ -72,6 +72,18 @@ work to a `GPUCommandGraph`. It accepts either local f32 coordinates or raw bina
 words where supported and makes the f32-transcendental versus precise planar arithmetic boundary
 explicit.
 
+## High-precision GPU Coordinate Projection
+
+<p class="badges">
+  <img src="https://img.shields.io/badge/WebGPU-required-blueviolet.svg?style=flat-square" alt="WebGPU required" />
+</p>
+
+[`@luma.gl/experimental/luproj`](/docs/api-reference/experimental/luproj) compiles arbitrary CPU
+projection providers into adaptive, origin-relative WebGPU polynomial patches. It preserves raw
+binary64 coordinate precision without native WGSL `f64`, supports optional preassigned patch IDs,
+and includes a live browser benchmark comparing direct CPU, compiled CPU, and four real WebGPU
+execution paths.
+
 ## GPU Simulations
 
 <p class="badges">

--- a/docs/api-reference/experimental/geospatial.md
+++ b/docs/api-reference/experimental/geospatial.md
@@ -1,3 +1,5 @@
+import {SpatialBenchmark} from '@site/src/components/docs/spatial-benchmark';
+
 # WebGPU Geospatial Kernels
 
 The `@luma.gl/experimental/geospatial` entry point provides small, side-effect-free WebGPU
@@ -242,6 +244,14 @@ either the index or result capacity overflows. The four writable output views mu
 disjoint aligned storage-binding ranges and must not overlap positions, source IDs, query values,
 index storage, or polygon storage. This includes the one-row binding footprint of a zero-capacity
 `ids` view. Result order is unspecified; no CPU readback is required for rendering.
+
+### Run a live spatial-query benchmark
+
+Compare this real query kernel against an equivalent CPU bounds scan using your browser and GPU.
+The indexed path builds a reusable grid once, reports that construction cost separately, and checks
+all compacted IDs against the CPU result before displaying fence-synchronized timings.
+
+<SpatialBenchmark />
 
 ## Non-finite data
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark.md
@@ -1,8 +1,19 @@
 import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+import {SpatialBenchmark} from '@site/src/components/docs/spatial-benchmark';
 
 # GPU spatial query benchmark
 
 <GPUPrimitivesDocsTabs active="spatial-benchmark" />
+
+## Run on your device
+
+<SpatialBenchmark />
+
+This opt-in benchmark runs a deterministic CPU bounds scan, the actual
+`GPUPointSpatialQuery` scan, and the same query against a reusable `GPUGridIndex`. Every GPU result
+must match the complete CPU-selected ID set. Grid construction is reported separately because its
+cost must be amortized across repeated queries; the timed GPU paths include graph encoding,
+submission, and a completion fence, not merely CPU-side command submission.
 
 ## Overview
 

--- a/docs/api-reference/experimental/luproj.md
+++ b/docs/api-reference/experimental/luproj.md
@@ -1,0 +1,158 @@
+import {ExperimentalDocsTabs} from '@site/src/components/docs/experimental-docs-tabs';
+import {ProjectionBenchmark} from '@site/src/components/docs/projection-benchmark';
+
+# GPU Coordinate Projection (luProj)
+
+<ExperimentalDocsTabs active="luproj" />
+
+`@luma.gl/experimental/luproj` reprojects GPU-resident coordinates through WebGPU command graphs
+without requiring native GPU `f64` arithmetic. A JavaScript projection provider defines the
+coordinate-reference-system semantics; adaptive local polynomial patches provide the GPU execution
+strategy.
+
+That separation supports the wide range of coordinate systems handled by `@math.gl/proj4` without
+reimplementing every projection, datum, or coordinate-reference-system definition in WGSL.
+
+## Live CPU versus WebGPU benchmark
+
+This benchmark runs locally in your browser when you click the button. Every implementation receives
+the same deterministic WGS84 coordinate rows and converts them into Web Mercator. The direct
+Float64 CPU provider is the reference; the other paths compare compiled CPU evaluation with actual
+WebGPU execution over both `float32x2` and raw binary64 `uint32x4` source coordinates.
+
+<ProjectionBenchmark />
+
+The GPU measurements synchronize each submission before stopping the timer. They include submission
+and completion, but exclude source uploads, command-graph compilation, correctness readback, and
+validation. Where the device supports timestamp queries, the results also include compute-pass-only
+throughput. Every GPU path must agree with its source-format CPU oracle before results are shown.
+
+These measurements describe your browser, adapter, workload, and thermal state; they are not static
+published results or cross-machine performance guarantees.
+
+## Compile and execute a projection
+
+```ts
+import {GPUCommandGraph} from '@luma.gl/experimental';
+import {GPUProjection, compileProjectionPlan} from '@luma.gl/experimental/luproj';
+import {Proj4Projection} from '@math.gl/proj4';
+
+const projection = new Proj4Projection({
+  from: 'EPSG:32610',
+  to: 'EPSG:3857'
+});
+
+const plan = compileProjectionPlan({
+  projection,
+  bounds: [580_000, 4_085_000, 600_000, 4_105_000],
+  tolerance: 0.01,
+  degree: 3
+});
+
+const graph = new GPUCommandGraph(device);
+
+new GPUProjection({
+  positions: sourcePositions,
+  output: projectedPositions,
+  plan
+}).addToGraph(graph);
+
+const compiled = graph.compile();
+const encoder = device.createCommandEncoder({id: 'project-visible-points'});
+compiled.encode(encoder, {parameters: undefined});
+device.submit(encoder.finish());
+```
+
+Bounds are `[minimumX, minimumY, maximumX, maximumY]` in the source coordinate system. Tolerance is
+expressed in destination units: `0.01` requests one centimeter of sampled accuracy when the target
+coordinate system uses meters.
+
+`@math.gl/proj4` is optional and is not a dependency of `@luma.gl/experimental`. Any function or
+object with a `project(coordinates)` method can provide the projection. For WGS84-to-Web-Mercator
+applications, `createWebMercatorProjection()` provides a zero-dependency alternative:
+
+```ts
+import {
+  compileProjectionPlan,
+  createWebMercatorProjection
+} from '@luma.gl/experimental/luproj';
+
+const plan = compileProjectionPlan({
+  projection: createWebMercatorProjection(),
+  bounds: [-122.55, 37.7, -122.35, 37.85],
+  tolerance: 0.01
+});
+```
+
+## Preserve coordinate precision
+
+`GPUProjection` accepts two source storage formats:
+
+| Source format | Storage | Precision contract |
+| --- | --- | --- |
+| `float32x2` | Two GPU Float32 values | Fast native source coordinates |
+| `uint32x4` | Native low/high Uint32 words of two JavaScript Float64 values | Exact binary64 transport and subtraction before Float32 local evaluation |
+
+For binary64 coordinates, the shader subtracts each patch's source origin before converting the
+remaining local offset to Float32. This preserves small differences between large eastings or
+northings that would disappear if the original coordinates were converted directly to Float32.
+
+The output is `float32x2` relative to `plan.destinationOrigin`. Keep that origin in JavaScript
+Float64, combine it with a camera-relative origin, or preserve local coordinates through downstream
+GPU work. Adding a large global origin back into a Float32 output would discard the recovered
+precision.
+
+## Adaptive patches and explicit assignment
+
+`compileProjectionPlan()` samples the provider and subdivides regions until their local polynomial
+fits the requested tolerance. `degree` accepts `1`, `2`, or `3`; `maxDepth` bounds subdivision.
+
+By default, each GPU invocation scans the compiled patches to find its coordinate. Applications
+that already know the patch assignment can provide a source-aligned `uint32` `patchIds` view to
+avoid that per-row scan:
+
+```ts
+new GPUProjection({
+  positions: sourcePositions,
+  output: projectedPositions,
+  patchIds: sourcePatchIds,
+  plan
+}).addToGraph(graph);
+```
+
+The live benchmark compares both selection strategies for both source formats. This makes the
+cost of additional patches and the benefit of preassigned IDs directly observable on the active GPU.
+
+Source positions, optional patch IDs, and output positions must preserve identical row counts and
+chunk boundaries. Invalid coordinates, positions outside the exact plan bounds, and invalid patch
+IDs produce a deterministic local output of `[0, 0]`.
+
+## Reuse the benchmark programmatically
+
+Benchmark infrastructure is isolated behind an optional package entry point:
+
+```ts
+import {createWebMercatorProjection} from '@luma.gl/experimental/luproj';
+import {
+  runGPUProjectionBenchmark,
+  runProjectionBenchmark
+} from '@luma.gl/experimental/luproj/benchmarks';
+
+const options = {
+  projection: createWebMercatorProjection(),
+  bounds: [-123, 37, -122, 38] as const,
+  degree: 2 as const,
+  tolerance: 0.03,
+  coordinateCount: 16_384,
+  warmupIterations: 2,
+  measuredIterations: 5
+};
+
+const cpuReport = runProjectionBenchmark(options);
+const gpuReport = await runGPUProjectionBenchmark(device, options);
+```
+
+See [WebGPU Geospatial Kernels](/docs/api-reference/experimental/geospatial),
+[GPU spatial query benchmarks](/docs/api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark),
+and [GPU floating-point precision](/docs/api-guide/shaders/gpu-floating-point-precision) for related
+GPU execution and precision techniques.

--- a/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
@@ -1,4 +1,5 @@
 import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
+import {FP64Example} from '@site/src/examples';
 
 # fp64arithmetic
 
@@ -14,6 +15,17 @@ for the numerical guarantees and tradeoffs of classic and integer-assisted
 double-single, native and software binary64, fixed point, and exact deltas. The
 [Mandelbrot and compute benchmark](/examples/experimental/fp64) runs these
 paths on the active GPU.
+
+## Live WebGPU benchmark
+
+The Mandelbrot views below compare native `f32` and double-single precision on
+your current device. Select **Run WebGPU benchmark** to measure native `f32`,
+automatic selection, classic double-single, and integer-controlled
+double-single across add, multiply, divide, and square-root workloads. Each
+result reports its measured GPU timestamp or queue-completion timing alongside
+numerical error; the benchmark runs only when requested.
+
+<FP64Example embedded embeddedHeight={900} />
 
 ## Uniforms
 

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -200,6 +200,7 @@
         "items": [
           "api-reference/experimental/README",
           "api-reference/experimental/geospatial",
+          "api-reference/experimental/luproj",
           "api-reference/experimental/g-buffer",
           "api-reference/experimental/deferred-lighting",
           "api-reference/experimental/clustered-lighting",
@@ -312,6 +313,7 @@
         "items": [
           "api-reference/experimental/README",
           "api-reference/experimental/geospatial",
+          "api-reference/experimental/luproj",
           "api-reference/experimental/g-buffer",
           "api-reference/experimental/deferred-lighting",
           "api-reference/experimental/clustered-lighting",

--- a/test/examples/fp64-live-benchmark-docs.node.spec.ts
+++ b/test/examples/fp64-live-benchmark-docs.node.spec.ts
@@ -1,0 +1,37 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+import {describe, expect, test} from 'vitest';
+
+const PRECISION_DOCUMENTATION_PAGES = [
+  '../../docs/api-guide/shaders/gpu-floating-point-precision.md',
+  '../../docs/api-reference/shadertools/shader-modules/fp64.md',
+  '../../docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md'
+] as const;
+
+describe('FP64 live benchmark documentation', () => {
+  test.each(
+    PRECISION_DOCUMENTATION_PAGES
+  )('embeds the interactive, device-backed benchmark in %s', documentationPath => {
+    const documentationContent = readFileSync(new URL(documentationPath, import.meta.url), 'utf8');
+
+    expect(documentationContent).toContain("import {FP64Example} from '@site/src/examples';");
+    expect(documentationContent).toContain('<FP64Example embedded embeddedHeight={900} />');
+  });
+
+  test('explains that fp64 arithmetic benchmarks run only when requested', () => {
+    const documentationContent = readFileSync(
+      new URL(
+        '../../docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md',
+        import.meta.url
+      ),
+      'utf8'
+    );
+
+    expect(documentationContent).toContain('## Live WebGPU benchmark');
+    expect(documentationContent).toContain('**Run WebGPU benchmark**');
+    expect(documentationContent).toContain('the benchmark runs only when requested');
+  });
+});

--- a/test/examples/live-benchmark-panel.node.spec.ts
+++ b/test/examples/live-benchmark-panel.node.spec.ts
@@ -1,0 +1,77 @@
+import {readFileSync} from 'node:fs';
+import {createRequire} from 'node:module';
+
+import React from 'react';
+import {renderToString} from 'react-dom/server';
+import typescript from 'typescript';
+import {describe, expect, test, vi} from 'vitest';
+
+const benchmarkPanelSource = readFileSync(
+  new URL('../../website/src/components/docs/live-benchmark-panel.tsx', import.meta.url),
+  'utf8'
+);
+const transpiledBenchmarkPanel = typescript.transpileModule(benchmarkPanelSource, {
+  compilerOptions: {
+    esModuleInterop: true,
+    jsx: typescript.JsxEmit.ReactJSX,
+    module: typescript.ModuleKind.CommonJS,
+    target: typescript.ScriptTarget.ES2022
+  }
+});
+type BenchmarkPanelComponent = React.ComponentType<{
+  title: string;
+  description: string;
+  onRun: () => Promise<React.ReactNode>;
+  unsupportedReason?: string;
+}>;
+const benchmarkPanelModule: {exports: Record<string, BenchmarkPanelComponent>} = {exports: {}};
+const loadBenchmarkPanel = new Function(
+  'require',
+  'module',
+  'exports',
+  transpiledBenchmarkPanel.outputText
+);
+loadBenchmarkPanel(
+  createRequire(import.meta.url),
+  benchmarkPanelModule,
+  benchmarkPanelModule.exports
+);
+const LiveBenchmarkPanel = benchmarkPanelModule.exports.LiveBenchmarkPanel;
+
+describe('live documentation benchmark panel', () => {
+  test('server-renders without running or requesting benchmark work', () => {
+    const runBenchmark = vi.fn(async () => React.createElement('p', null, 'Measured results'));
+
+    const markup = renderToString(
+      React.createElement(LiveBenchmarkPanel, {
+        title: 'Live projection benchmark',
+        description: 'Measures actual CPU and WebGPU execution.',
+        onRun: runBenchmark
+      })
+    );
+
+    expect(runBenchmark).not.toHaveBeenCalled();
+    expect(markup).toContain('Live projection benchmark');
+    expect(markup).toContain('Measures actual CPU and WebGPU execution.');
+    expect(markup).toContain('Run live WebGPU benchmark');
+    expect(markup).not.toContain('Measured results');
+  });
+
+  test('explains unavailable capabilities without claiming benchmark results', () => {
+    const runBenchmark = vi.fn(async () => React.createElement('p', null, 'Invalid results'));
+
+    const markup = renderToString(
+      React.createElement(LiveBenchmarkPanel, {
+        title: 'Live spatial benchmark',
+        description: 'Runs on WebGPU adapters.',
+        onRun: runBenchmark,
+        unsupportedReason: 'WebGPU is unavailable in this browser.'
+      })
+    );
+
+    expect(runBenchmark).not.toHaveBeenCalled();
+    expect(markup).toContain('WebGPU is unavailable in this browser.');
+    expect(markup).toContain('disabled=""');
+    expect(markup).not.toContain('Invalid results');
+  });
+});

--- a/test/examples/luproj-live-benchmark-docs.node.spec.ts
+++ b/test/examples/luproj-live-benchmark-docs.node.spec.ts
@@ -1,0 +1,231 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+import {createRequire} from 'node:module';
+
+import React from 'react';
+import {renderToString} from 'react-dom/server';
+import typescript from 'typescript';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
+
+type MockBenchmarkPanelProps = {
+  title: string;
+  description: string;
+  runLabel: string;
+  onRun: () => Promise<React.ReactNode>;
+};
+
+const projectionBenchmarkSource = readFileSync(
+  new URL('../../website/src/components/docs/projection-benchmark.tsx', import.meta.url),
+  'utf8'
+);
+const transpiledProjectionBenchmark = typescript.transpileModule(projectionBenchmarkSource, {
+  compilerOptions: {
+    esModuleInterop: true,
+    jsx: typescript.JsxEmit.ReactJSX,
+    module: typescript.ModuleKind.CommonJS,
+    target: typescript.ScriptTarget.ES2022
+  }
+});
+
+const projectionProvider = {project: (coordinate: number[]) => coordinate};
+const createWebMercatorProjection = vi.fn(() => projectionProvider);
+const runGPUProjectionBenchmark = vi.fn();
+const createDevice = vi.fn();
+let selectedDevice: Record<string, unknown> | undefined;
+let benchmarkPanelProps: MockBenchmarkPanelProps | undefined;
+
+const nativeRequire = createRequire(import.meta.url);
+function requireProjectionBenchmarkDependency(moduleName: string): unknown {
+  if (moduleName === '@luma.gl/experimental/luproj') {
+    return {createWebMercatorProjection};
+  }
+  if (moduleName === '@luma.gl/experimental/luproj/benchmarks') {
+    return {runGPUProjectionBenchmark};
+  }
+  if (moduleName === '../../react-luma/store/device-store') {
+    return {
+      createDevice,
+      useStore: (selector: (state: {presentationDevice?: unknown}) => unknown) =>
+        selector({presentationDevice: selectedDevice})
+    };
+  }
+  if (moduleName === './live-benchmark-panel') {
+    return {
+      LiveBenchmarkPanel: (props: MockBenchmarkPanelProps) => {
+        benchmarkPanelProps = props;
+        return React.createElement(
+          'section',
+          null,
+          React.createElement('h3', null, props.title),
+          React.createElement('p', null, props.description),
+          React.createElement('button', null, props.runLabel)
+        );
+      }
+    };
+  }
+
+  return nativeRequire(moduleName);
+}
+
+const projectionBenchmarkModule: {exports: Record<string, React.ComponentType>} = {exports: {}};
+const loadProjectionBenchmark = new Function(
+  'require',
+  'module',
+  'exports',
+  transpiledProjectionBenchmark.outputText
+);
+loadProjectionBenchmark(
+  requireProjectionBenchmarkDependency,
+  projectionBenchmarkModule,
+  projectionBenchmarkModule.exports
+);
+const ProjectionBenchmark = projectionBenchmarkModule.exports.ProjectionBenchmark;
+
+beforeEach(() => {
+  createWebMercatorProjection.mockClear();
+  runGPUProjectionBenchmark.mockReset();
+  createDevice.mockReset();
+  selectedDevice = undefined;
+  benchmarkPanelProps = undefined;
+});
+
+describe('GPU projection live benchmark documentation', () => {
+  test('publishes an embedded browser benchmark in both experimental documentation sidebars', () => {
+    const documentationContent = readFileSync(
+      new URL('../../docs/api-reference/experimental/luproj.md', import.meta.url),
+      'utf8'
+    );
+    const sidebarContent = readFileSync(
+      new URL('../../docs/table-of-contents.json', import.meta.url),
+      'utf8'
+    );
+    const experimentalNavigation = readFileSync(
+      new URL('../../website/src/components/docs/experimental-docs-tabs.tsx', import.meta.url),
+      'utf8'
+    );
+
+    expect(documentationContent).toContain(
+      "import {ProjectionBenchmark} from '@site/src/components/docs/projection-benchmark';"
+    );
+    expect(documentationContent).toContain('<ProjectionBenchmark />');
+    expect(documentationContent).toContain("'@luma.gl/experimental/luproj/benchmarks'");
+    expect(sidebarContent.match(/"api-reference\/experimental\/luproj"/g)).toHaveLength(2);
+    expect(experimentalNavigation).toContain("href: '/docs/api-reference/experimental/luproj'");
+  });
+
+  test('server-renders dataset controls without creating a device or running benchmark work', () => {
+    const markup = renderToString(React.createElement(ProjectionBenchmark));
+
+    expect(markup).toContain('Live CPU versus WebGPU projection');
+    expect(markup).toContain('Run projection benchmark');
+    expect(markup).toContain('16,384');
+    expect(markup).toContain('262,144');
+    expect(createDevice).not.toHaveBeenCalled();
+    expect(createWebMercatorProjection).not.toHaveBeenCalled();
+    expect(runGPUProjectionBenchmark).not.toHaveBeenCalled();
+  });
+
+  test('compares direct CPU evaluation against all four real WebGPU execution paths', async () => {
+    selectedDevice = {
+      type: 'webgpu',
+      info: {renderer: 'Reader GPU', vendor: 'Reader vendor', gpu: 'unknown'}
+    };
+    runGPUProjectionBenchmark.mockResolvedValue(makeProjectionBenchmarkReport());
+
+    renderToString(React.createElement(ProjectionBenchmark));
+    const benchmarkResult = await benchmarkPanelProps!.onRun();
+    const markup = renderToString(React.createElement(React.Fragment, null, benchmarkResult));
+
+    expect(createDevice).not.toHaveBeenCalled();
+    expect(runGPUProjectionBenchmark).toHaveBeenCalledWith(
+      selectedDevice,
+      expect.objectContaining({
+        projection: projectionProvider,
+        coordinateCount: 16_384,
+        warmupIterations: 1,
+        measuredIterations: 3
+      })
+    );
+    expect(markup).toContain('CPU provider');
+    expect(markup).toContain('CPU compiled plan');
+    expect(markup.match(/>WebGPU</g)).toHaveLength(4);
+    expect(markup).toContain('Float32');
+    expect(markup).toContain('Raw Float64');
+    expect(markup).toContain('Patch scan');
+    expect(markup).toContain('Explicit IDs');
+    expect(markup).toContain('Reader GPU');
+    expect(markup).toContain('completion fence');
+  });
+
+  test('lazily requests a cached WebGPU device when none is currently selected', async () => {
+    const requestedDevice = {
+      type: 'webgpu',
+      info: {renderer: 'Requested GPU', vendor: 'Reader vendor', gpu: 'unknown'}
+    };
+    createDevice.mockResolvedValue(requestedDevice);
+    runGPUProjectionBenchmark.mockResolvedValue(makeProjectionBenchmarkReport());
+
+    renderToString(React.createElement(ProjectionBenchmark));
+    expect(createDevice).not.toHaveBeenCalled();
+
+    await benchmarkPanelProps!.onRun();
+
+    expect(createDevice).toHaveBeenCalledOnce();
+    expect(createDevice).toHaveBeenCalledWith('webgpu-core');
+    expect(runGPUProjectionBenchmark).toHaveBeenCalledWith(
+      requestedDevice,
+      expect.objectContaining({coordinateCount: 16_384})
+    );
+  });
+});
+
+function makeProjectionBenchmarkReport() {
+  const duration = {minimum: 0.4, median: 0.5, percentile95: 0.6, maximum: 0.6};
+  const providerThroughput = 20_000_000;
+
+  return {
+    cpu: {
+      coordinateCount: 16_384,
+      patchCount: 4,
+      warmupIterations: 1,
+      measuredIterations: 3,
+      maxError: 0.012,
+      compilationTimeMilliseconds: duration,
+      paths: [
+        {
+          strategy: 'provider',
+          durationMilliseconds: duration,
+          coordinatesPerSecond: providerThroughput
+        },
+        {
+          strategy: 'plan-scan',
+          durationMilliseconds: duration,
+          coordinatesPerSecond: 30_000_000
+        },
+        {
+          strategy: 'plan-patch-ids',
+          durationMilliseconds: duration,
+          coordinatesPerSecond: 40_000_000
+        }
+      ]
+    },
+    timestampQueries: false,
+    paths: [
+      {inputFormat: 'float32x2', patchStrategy: 'scan'},
+      {inputFormat: 'float32x2', patchStrategy: 'patch-ids'},
+      {inputFormat: 'uint32x4', patchStrategy: 'scan'},
+      {inputFormat: 'uint32x4', patchStrategy: 'patch-ids'}
+    ].map(path => ({
+      ...path,
+      memoryByteLength: 262_144,
+      maxError: 0.012,
+      cpuEncodeTimeMilliseconds: duration,
+      synchronizedTimeMilliseconds: duration,
+      synchronizedCoordinatesPerSecond: 100_000_000,
+      synchronizedSpeedupOverCPUProvider: 100_000_000 / providerThroughput
+    }))
+  };
+}

--- a/test/examples/spatial-live-benchmark-docs.node.spec.ts
+++ b/test/examples/spatial-live-benchmark-docs.node.spec.ts
@@ -1,0 +1,64 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+import {describe, expect, test} from 'vitest';
+
+const componentSource = readFileSync(
+  new URL('../../website/src/components/docs/spatial-benchmark.tsx', import.meta.url),
+  'utf8'
+);
+const geospatialDocumentation = readFileSync(
+  new URL('../../docs/api-reference/experimental/geospatial.md', import.meta.url),
+  'utf8'
+);
+const benchmarkDocumentation = readFileSync(
+  new URL(
+    '../../docs/api-reference/experimental/gpu-primitives/gpu-spatial-query-benchmark.md',
+    import.meta.url
+  ),
+  'utf8'
+);
+
+describe('live spatial benchmark documentation', () => {
+  test('embeds the same interactive benchmark in both spatial documentation pages', () => {
+    for (const documentation of [geospatialDocumentation, benchmarkDocumentation]) {
+      expect(documentation).toContain(
+        "import {SpatialBenchmark} from '@site/src/components/docs/spatial-benchmark';"
+      );
+      expect(documentation).toContain('<SpatialBenchmark />');
+    }
+  });
+
+  test('compares a genuine CPU predicate against unindexed and indexed WebGPU queries', () => {
+    expect(componentSource).toContain('runCPUSpatialQuery(positions, bounds, output)');
+    expect(componentSource).toContain('new GPUPointSpatialQuery({');
+    expect(componentSource).toContain('new GPUGridIndex({');
+    expect(componentSource).toContain(
+      'await verifySpatialOutput(output, expectedIds, props.label)'
+    );
+    expect(componentSource).toContain('CPU point scan');
+    expect(componentSource).toContain('WebGPU point scan');
+    expect(componentSource).toContain('WebGPU reusable grid');
+  });
+
+  test('waits for completed GPU execution and reports grid construction separately', () => {
+    expect(componentSource).toContain('device.submit(commandEncoder.finish())');
+    expect(componentSource).toContain('const fence = device.createFence()');
+    expect(componentSource).toContain('await fence.signaled');
+    expect(componentSource).toContain('indexBuildMilliseconds');
+    expect(componentSource).toMatch(/Query timings exclude this\s+build/);
+    expect(geospatialDocumentation).toContain('construction cost separately');
+    expect(benchmarkDocumentation).toContain('Grid construction is reported separately');
+  });
+
+  test('keeps browser work opt-in and provides explicit device and dataset controls', () => {
+    expect(componentSource).toContain('<LiveBenchmarkPanel');
+    expect(componentSource).toContain('onRun={async () => {');
+    expect(componentSource).toContain('Run live CPU and WebGPU spatial benchmark');
+    expect(componentSource).toContain("await createDevice('webgpu-core')");
+    expect(componentSource).toContain('POINT_COUNTS.map(count =>');
+    expect(benchmarkDocumentation).toContain('opt-in benchmark');
+  });
+});

--- a/website/src/components/docs/experimental-docs-tabs.tsx
+++ b/website/src/components/docs/experimental-docs-tabs.tsx
@@ -6,6 +6,7 @@ type ExperimentalDocsTab = {id: ExperimentalDocsTabId; label: string; href: stri
 /** Experimental documentation tab identifiers. */
 export type ExperimentalDocsTabId =
   | 'overview'
+  | 'luproj'
   | 'g-buffer'
   | 'deferred-lighting'
   | 'clustered-lighting'
@@ -20,6 +21,7 @@ export type ExperimentalDocsTabId =
 
 const EXPERIMENTAL_DOCS_TABS: ExperimentalDocsTab[] = [
   {id: 'overview', label: 'Overview', href: '/docs/api-reference/experimental'},
+  {id: 'luproj', label: 'GPU Projection', href: '/docs/api-reference/experimental/luproj'},
   {id: 'g-buffer', label: 'GBuffer', href: '/docs/api-reference/experimental/g-buffer'},
   {
     id: 'deferred-lighting',

--- a/website/src/components/docs/live-benchmark-panel.tsx
+++ b/website/src/components/docs/live-benchmark-panel.tsx
@@ -1,0 +1,110 @@
+import React, {type CSSProperties, type ReactNode, useEffect, useRef, useState} from 'react';
+
+/** Shared, user-triggered presentation for benchmarks executed on the visitor's actual device. */
+export type LiveBenchmarkPanelProps = {
+  /** Accessible panel heading describing the benchmarked operation. */
+  title: string;
+  /** Short explanation of the workload and what its measurements include. */
+  description: string;
+  /** Optional action text; defaults to a WebGPU-oriented benchmark label. */
+  runLabel?: string;
+  /** Executes real benchmark work and returns the results to render. */
+  onRun: () => Promise<ReactNode>;
+  /** Explicit capability message that disables the benchmark without claiming synthetic results. */
+  unsupportedReason?: string;
+};
+
+const PANEL_STYLE: CSSProperties = {
+  border: '1px solid var(--ifm-color-emphasis-300)',
+  borderRadius: 12,
+  margin: '1.25rem 0 2rem',
+  padding: '1.25rem',
+  background: 'var(--ifm-background-surface-color)'
+};
+
+/**
+ * Keeps documentation benchmarks opt-in, accessible, SSR-safe, and visibly device-specific.
+ *
+ * Work never starts during render or page hydration. A generation counter prevents a promise
+ * finishing after navigation from updating a component that has already unmounted.
+ */
+export function LiveBenchmarkPanel({
+  title,
+  description,
+  runLabel = 'Run live WebGPU benchmark',
+  onRun,
+  unsupportedReason
+}: LiveBenchmarkPanelProps): ReactNode {
+  const [isRunning, setIsRunning] = useState(false);
+  const [results, setResults] = useState<ReactNode>(null);
+  const [error, setError] = useState<string | null>(null);
+  const runGeneration = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      runGeneration.current++;
+    };
+  }, []);
+
+  const handleRun = async (): Promise<void> => {
+    if (isRunning || unsupportedReason) {
+      return;
+    }
+
+    const currentGeneration = ++runGeneration.current;
+    setIsRunning(true);
+    setError(null);
+    setResults(null);
+
+    try {
+      const benchmarkResults = await onRun();
+      if (runGeneration.current === currentGeneration) {
+        setResults(benchmarkResults);
+      }
+    } catch (benchmarkError) {
+      if (runGeneration.current === currentGeneration) {
+        setError(benchmarkError instanceof Error ? benchmarkError.message : String(benchmarkError));
+      }
+    } finally {
+      if (runGeneration.current === currentGeneration) {
+        setIsRunning(false);
+      }
+    }
+  };
+
+  return (
+    <section aria-label={title} data-live-benchmark="true" style={PANEL_STYLE}>
+      <h3 style={{marginTop: 0}}>{title}</h3>
+      <p>{description}</p>
+
+      <button
+        className="button button--primary"
+        disabled={isRunning || Boolean(unsupportedReason)}
+        onClick={() => {
+          void handleRun();
+        }}
+        type="button"
+      >
+        {isRunning ? 'Running on your device…' : runLabel}
+      </button>
+
+      {unsupportedReason ? (
+        <p aria-live="polite" style={{marginBottom: 0}}>
+          {unsupportedReason}
+        </p>
+      ) : null}
+
+      {error ? (
+        <p role="alert" style={{color: 'var(--ifm-color-danger)', marginBottom: 0}}>
+          {error}
+        </p>
+      ) : null}
+
+      {results ? (
+        <div aria-live="polite" style={{marginTop: '1rem', overflowX: 'auto'}}>
+          {results}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/website/src/components/docs/projection-benchmark.tsx
+++ b/website/src/components/docs/projection-benchmark.tsx
@@ -1,0 +1,208 @@
+import React, {useEffect, useState, type ReactNode} from 'react';
+
+import {createWebMercatorProjection} from '@luma.gl/experimental/luproj';
+import {
+  runGPUProjectionBenchmark,
+  type GPUProjectionBenchmarkPathReport,
+  type GPUProjectionBenchmarkReport,
+  type ProjectionBenchmarkPathReport
+} from '@luma.gl/experimental/luproj/benchmarks';
+
+import {createDevice, useStore} from '../../react-luma/store/device-store';
+import {LiveBenchmarkPanel} from './live-benchmark-panel';
+
+const PROJECTION_BENCHMARK_ROW_COUNTS = [4_096, 16_384, 65_536, 262_144] as const;
+
+/** Runs the documented projection benchmark against the reader's actual browser and GPU. */
+export function ProjectionBenchmark(): ReactNode {
+  const selectedDevice = useStore(store => store.presentationDevice || store.device);
+  const [coordinateCount, setCoordinateCount] = useState<number>(16_384);
+  const [webGPUUnavailable, setWebGPUUnavailable] = useState(false);
+
+  useEffect(() => {
+    setWebGPUUnavailable(typeof navigator === 'undefined' || !('gpu' in navigator));
+  }, []);
+
+  return (
+    <div>
+      <label
+        htmlFor="projection-benchmark-coordinate-count"
+        style={{alignItems: 'center', display: 'flex', gap: 10, marginBottom: 12}}
+      >
+        Coordinates per run
+        <select
+          id="projection-benchmark-coordinate-count"
+          onChange={event => setCoordinateCount(Number(event.target.value))}
+          value={coordinateCount}
+        >
+          {PROJECTION_BENCHMARK_ROW_COUNTS.map(rowCount => (
+            <option key={rowCount} value={rowCount}>
+              {rowCount.toLocaleString()}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <LiveBenchmarkPanel
+        title="Live CPU versus WebGPU projection"
+        description="Project the same deterministic WGS84 coordinates into Web Mercator using direct CPU calls, compiled CPU patches, and four real WebGPU execution paths."
+        runLabel="Run projection benchmark"
+        unsupportedReason={
+          webGPUUnavailable
+            ? 'WebGPU is unavailable in this browser. Use a WebGPU-capable browser and a secure origin.'
+            : undefined
+        }
+        onRun={async () => {
+          const device =
+            selectedDevice?.type === 'webgpu' ? selectedDevice : await createDevice('webgpu-core');
+          const report = await runGPUProjectionBenchmark(device, {
+            projection: createWebMercatorProjection(),
+            bounds: [-123, 37, -122, 38],
+            degree: 2,
+            tolerance: 0.03,
+            maxDepth: 5,
+            coordinateCount,
+            warmupIterations: 1,
+            measuredIterations: 3
+          });
+
+          return (
+            <ProjectionBenchmarkResults
+              report={report}
+              deviceLabel={device.info.renderer || device.info.vendor || device.info.gpu}
+            />
+          );
+        }}
+      />
+    </div>
+  );
+}
+
+function ProjectionBenchmarkResults({
+  report,
+  deviceLabel
+}: {
+  report: GPUProjectionBenchmarkReport;
+  deviceLabel: string;
+}): ReactNode {
+  const providerThroughput = report.cpu.paths[0].coordinatesPerSecond;
+
+  return (
+    <div>
+      <p style={{margin: '14px 0 10px'}}>
+        <strong>{report.cpu.coordinateCount.toLocaleString()}</strong> coordinates ·{' '}
+        <strong>{report.cpu.patchCount}</strong> adaptive patches ·{' '}
+        <strong>{report.cpu.measuredIterations}</strong> measured iterations · {deviceLabel}
+      </p>
+
+      <div style={{overflowX: 'auto'}}>
+        <table style={{fontSize: 13, minWidth: 760, width: '100%'}}>
+          <thead>
+            <tr>
+              <th>Execution</th>
+              <th>Source precision</th>
+              <th>Patch lookup</th>
+              <th>Median</th>
+              <th>Throughput</th>
+              <th>Versus CPU</th>
+              <th>Maximum error</th>
+            </tr>
+          </thead>
+          <tbody>
+            {report.cpu.paths.map(path => (
+              <ProjectionCPUBenchmarkRow
+                key={path.strategy}
+                path={path}
+                providerThroughput={providerThroughput}
+                maxError={report.cpu.maxError}
+              />
+            ))}
+            {report.paths.map(path => (
+              <ProjectionGPUBenchmarkRow
+                key={`${path.inputFormat}-${path.patchStrategy}`}
+                path={path}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p style={{fontSize: 12, margin: '10px 0 0'}}>
+        GPU times include command submission and a completion fence. Uploads, graph compilation,
+        correctness readback, and output validation are excluded. Every GPU row is checked against
+        the same CPU oracle before timings are reported.
+      </p>
+
+      {report.timestampQueries ? (
+        <p style={{fontSize: 12, margin: '8px 0 0'}}>
+          Timestamp-query compute-only rates:{' '}
+          {report.paths
+            .filter(path => path.gpuCoordinatesPerSecond !== undefined)
+            .map(
+              path =>
+                `${formatProjectionInputFormat(path.inputFormat)} / ${formatProjectionPatchStrategy(path.patchStrategy)}: ${formatProjectionThroughput(path.gpuCoordinatesPerSecond!)}`
+            )
+            .join(' · ')}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function ProjectionCPUBenchmarkRow({
+  path,
+  providerThroughput,
+  maxError
+}: {
+  path: ProjectionBenchmarkPathReport;
+  providerThroughput: number;
+  maxError: number;
+}): ReactNode {
+  return (
+    <tr>
+      <td>{path.strategy === 'provider' ? 'CPU provider' : 'CPU compiled plan'}</td>
+      <td>Float64</td>
+      <td>
+        {path.strategy === 'provider'
+          ? 'Not applicable'
+          : formatProjectionPatchStrategy(path.strategy === 'plan-scan' ? 'scan' : 'patch-ids')}
+      </td>
+      <td>{path.durationMilliseconds.median.toFixed(3)} ms</td>
+      <td>{formatProjectionThroughput(path.coordinatesPerSecond)}</td>
+      <td>{(path.coordinatesPerSecond / providerThroughput).toFixed(2)}×</td>
+      <td>{path.strategy === 'provider' ? 'Reference' : formatProjectionError(maxError)}</td>
+    </tr>
+  );
+}
+
+function ProjectionGPUBenchmarkRow({path}: {path: GPUProjectionBenchmarkPathReport}): ReactNode {
+  return (
+    <tr>
+      <td>WebGPU</td>
+      <td>{formatProjectionInputFormat(path.inputFormat)}</td>
+      <td>{formatProjectionPatchStrategy(path.patchStrategy)}</td>
+      <td>{path.synchronizedTimeMilliseconds.median.toFixed(3)} ms</td>
+      <td>{formatProjectionThroughput(path.synchronizedCoordinatesPerSecond)}</td>
+      <td>{path.synchronizedSpeedupOverCPUProvider.toFixed(2)}×</td>
+      <td>{formatProjectionError(path.maxError)}</td>
+    </tr>
+  );
+}
+
+function formatProjectionInputFormat(inputFormat: GPUProjectionBenchmarkPathReport['inputFormat']) {
+  return inputFormat === 'float32x2' ? 'Float32' : 'Raw Float64';
+}
+
+function formatProjectionPatchStrategy(
+  patchStrategy: GPUProjectionBenchmarkPathReport['patchStrategy']
+) {
+  return patchStrategy === 'scan' ? 'Patch scan' : 'Explicit IDs';
+}
+
+function formatProjectionThroughput(coordinatesPerSecond: number): string {
+  return `${(coordinatesPerSecond / 1_000_000).toFixed(2)}M rows/s`;
+}
+
+function formatProjectionError(errorInMeters: number): string {
+  return `${(errorInMeters * 100).toFixed(2)} cm`;
+}

--- a/website/src/components/docs/spatial-benchmark.tsx
+++ b/website/src/components/docs/spatial-benchmark.tsx
@@ -1,0 +1,511 @@
+import React, {type ReactNode, useEffect, useId, useState} from 'react';
+import {Buffer, type Device} from '@luma.gl/core';
+import {
+  type CompiledGPUCommandGraph,
+  GPUCommandGraph,
+  type GraphDataView
+} from '@luma.gl/experimental';
+import {
+  GPUGridIndex,
+  type GPUGridIndexView,
+  GPUPointSpatialQuery
+} from '@luma.gl/experimental/geospatial';
+import {createDevice, useStore} from '../../react-luma/store/device-store';
+import {LiveBenchmarkPanel} from './live-benchmark-panel';
+
+const POINT_COUNTS = [16_384, 65_536, 262_144] as const;
+const DEFAULT_POINT_COUNT = 65_536;
+const GRID_DIMENSION = 32;
+const WARMUP_ITERATIONS = 2;
+const MEASURED_ITERATIONS = 7;
+const INDEX_BOUNDS = [0, 0, 1, 1] as const;
+const QUERY_BOUNDS = new Float32Array([0.35, 0.37, 0.66, 0.63]);
+
+type SpatialBenchmarkOutput = {
+  ids: Buffer;
+  count: Buffer;
+  overflow: Buffer;
+};
+
+type SpatialBenchmarkIndex = {
+  cellOffsets: Buffer;
+  rowIndices: Buffer;
+  count: Buffer;
+  overflow: Buffer;
+};
+
+type SpatialBenchmarkResult = {
+  label: string;
+  medianMilliseconds: number;
+  pointCount: number;
+  resultCount: number;
+};
+
+/** Compares real luSpatial scan and indexed queries against one equivalent CPU predicate. */
+export function SpatialBenchmark(): ReactNode {
+  const selectedDevice = useStore(store => store.presentationDevice);
+  const [pointCount, setPointCount] = useState(DEFAULT_POINT_COUNT);
+  const [unsupportedReason, setUnsupportedReason] = useState<string>();
+  const pointCountId = useId();
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('gpu' in navigator)) {
+      setUnsupportedReason('WebGPU is unavailable in this browser or secure context.');
+    }
+  }, []);
+
+  return (
+    <div>
+      <label htmlFor={pointCountId}>
+        Dataset size{' '}
+        <select
+          id={pointCountId}
+          onChange={event => setPointCount(Number(event.target.value))}
+          value={pointCount}
+        >
+          {POINT_COUNTS.map(count => (
+            <option key={count} value={count}>
+              {count.toLocaleString()} points
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <LiveBenchmarkPanel
+        title="Live luSpatial: CPU vs. WebGPU"
+        description="Run the same bounds predicate and compact matching point IDs on your CPU, an unindexed WebGPU graph, and a reusable WebGPU grid index. GPU timings include command encoding, submission, and completed execution."
+        onRun={async () => {
+          const device =
+            selectedDevice?.type === 'webgpu' ? selectedDevice : await createDevice('webgpu-core');
+          return await runSpatialBenchmark(device, pointCount);
+        }}
+        runLabel="Run live CPU and WebGPU spatial benchmark"
+        unsupportedReason={unsupportedReason}
+      />
+    </div>
+  );
+}
+
+async function runSpatialBenchmark(device: Device, pointCount: number): Promise<ReactNode> {
+  const positions = makeSpatialPositions(pointCount);
+  const cpuOutput = new Uint32Array(pointCount);
+  const cpuResult = measureCPUQuery(positions, QUERY_BOUNDS, cpuOutput);
+  const expectedIds = cpuOutput.slice(0, cpuResult.resultCount);
+  const ownedBuffers: Buffer[] = [];
+  const compiledGraphs: CompiledGPUCommandGraph[] = [];
+
+  try {
+    const positionBuffer = createSpatialInputBuffer(device, ownedBuffers, positions);
+    const queryBuffer = createSpatialInputBuffer(device, ownedBuffers, QUERY_BOUNDS);
+    const scanOutput = createSpatialOutput(device, ownedBuffers, pointCount);
+    const indexedOutput = createSpatialOutput(device, ownedBuffers, pointCount);
+    const index = createSpatialIndex(device, ownedBuffers, pointCount);
+
+    const indexBuild = compileIndexBuild(device, positionBuffer, index, pointCount);
+    compiledGraphs.push(indexBuild);
+    const scanQuery = compileSpatialQuery(
+      device,
+      positionBuffer,
+      queryBuffer,
+      scanOutput,
+      pointCount
+    );
+    compiledGraphs.push(scanQuery);
+    const indexedQuery = compileSpatialQuery(
+      device,
+      positionBuffer,
+      queryBuffer,
+      indexedOutput,
+      pointCount,
+      index
+    );
+    compiledGraphs.push(indexedQuery);
+
+    await executeSpatialGraph(device, indexBuild, 'docs-spatial-index-warmup');
+    const indexBuildMilliseconds = await executeSpatialGraph(
+      device,
+      indexBuild,
+      'docs-spatial-index-build'
+    );
+    const indexedPointCount = await readSpatialScalar(index.count);
+    const indexOverflow = await readSpatialScalar(index.overflow);
+    if (indexedPointCount !== pointCount || indexOverflow !== 0) {
+      throw new Error('The WebGPU grid index did not include the complete benchmark dataset.');
+    }
+
+    const scanResult = await measureGPUQuery(device, scanQuery, scanOutput, expectedIds, {
+      label: 'WebGPU point scan',
+      pointCount
+    });
+    const indexedResult = await measureGPUQuery(device, indexedQuery, indexedOutput, expectedIds, {
+      label: 'WebGPU reusable grid',
+      pointCount
+    });
+    const indexByteLength =
+      index.cellOffsets.byteLength +
+      index.rowIndices.byteLength +
+      index.count.byteLength +
+      index.overflow.byteLength;
+
+    return (
+      <SpatialBenchmarkResults
+        indexBuildMilliseconds={indexBuildMilliseconds}
+        indexByteLength={indexByteLength}
+        results={[cpuResult, scanResult, indexedResult]}
+      />
+    );
+  } finally {
+    for (const graph of compiledGraphs) graph.destroy();
+    for (const buffer of ownedBuffers) buffer.destroy();
+  }
+}
+
+function SpatialBenchmarkResults({
+  results,
+  indexBuildMilliseconds,
+  indexByteLength
+}: {
+  results: SpatialBenchmarkResult[];
+  indexBuildMilliseconds: number;
+  indexByteLength: number;
+}): ReactNode {
+  const cpuMilliseconds = results[0].medianMilliseconds;
+
+  return (
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th>Implementation</th>
+            <th>Median</th>
+            <th>Points / second</th>
+            <th>CPU comparison</th>
+            <th>Matching IDs</th>
+          </tr>
+        </thead>
+        <tbody>
+          {results.map(result => (
+            <tr key={result.label}>
+              <td>{result.label}</td>
+              <td>{result.medianMilliseconds.toFixed(3)} ms</td>
+              <td>
+                {Math.round(
+                  (result.pointCount * 1000) / Math.max(result.medianMilliseconds, Number.EPSILON)
+                ).toLocaleString()}
+              </td>
+              <td>
+                {(cpuMilliseconds / Math.max(result.medianMilliseconds, Number.EPSILON)).toFixed(2)}
+                ×
+              </td>
+              <td>{result.resultCount.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p>
+        One-time {GRID_DIMENSION} × {GRID_DIMENSION} grid build:{' '}
+        <strong>{indexBuildMilliseconds.toFixed(3)} ms</strong>; persistent index storage:{' '}
+        <strong>{(indexByteLength / 1024).toFixed(1)} KiB</strong>. Query timings exclude this
+        build, initial upload, graph compilation, and verification readback. Every GPU result was
+        checked against all CPU-selected IDs.
+      </p>
+      <p>
+        Medians use {WARMUP_ITERATIONS} warmup and {MEASURED_ITERATIONS} measured iterations.
+        Results depend on your browser, adapter, current load, and query selectivity.
+      </p>
+    </>
+  );
+}
+
+function makeSpatialPositions(pointCount: number): Float32Array {
+  const positions = new Float32Array(pointCount * 2);
+  let randomState = 0x4c554d41;
+  for (let index = 0; index < positions.length; index++) {
+    randomState = (Math.imul(randomState, 1_664_525) + 1_013_904_223) >>> 0;
+    positions[index] = randomState / 0x1_0000_0000;
+  }
+  return positions;
+}
+
+function measureCPUQuery(
+  positions: Float32Array,
+  bounds: Float32Array,
+  output: Uint32Array
+): SpatialBenchmarkResult {
+  for (let iteration = 0; iteration < WARMUP_ITERATIONS; iteration++) {
+    runCPUSpatialQuery(positions, bounds, output);
+  }
+
+  const durations: number[] = [];
+  let resultCount = 0;
+  for (let iteration = 0; iteration < MEASURED_ITERATIONS; iteration++) {
+    const startTime = performance.now();
+    resultCount = runCPUSpatialQuery(positions, bounds, output);
+    durations.push(performance.now() - startTime);
+  }
+
+  return {
+    label: 'CPU point scan',
+    medianMilliseconds: getMedianDuration(durations),
+    pointCount: positions.length / 2,
+    resultCount
+  };
+}
+
+function runCPUSpatialQuery(
+  positions: Float32Array,
+  bounds: Float32Array,
+  output: Uint32Array
+): number {
+  const [minimumX, minimumY, maximumX, maximumY] = bounds;
+  let resultCount = 0;
+  for (let rowIndex = 0; rowIndex < output.length; rowIndex++) {
+    const positionX = positions[rowIndex * 2];
+    const positionY = positions[rowIndex * 2 + 1];
+    if (
+      positionX >= minimumX &&
+      positionX <= maximumX &&
+      positionY >= minimumY &&
+      positionY <= maximumY
+    ) {
+      output[resultCount++] = rowIndex;
+    }
+  }
+  return resultCount;
+}
+
+async function measureGPUQuery(
+  device: Device,
+  graph: CompiledGPUCommandGraph,
+  output: SpatialBenchmarkOutput,
+  expectedIds: Uint32Array,
+  props: {label: string; pointCount: number}
+): Promise<SpatialBenchmarkResult> {
+  await executeSpatialGraph(device, graph, `${props.label}-validation`);
+  await verifySpatialOutput(output, expectedIds, props.label);
+
+  for (let iteration = 0; iteration < WARMUP_ITERATIONS; iteration++) {
+    await executeSpatialGraph(device, graph, `${props.label}-warmup-${iteration}`);
+  }
+
+  const durations: number[] = [];
+  for (let iteration = 0; iteration < MEASURED_ITERATIONS; iteration++) {
+    durations.push(
+      await executeSpatialGraph(device, graph, `${props.label}-measurement-${iteration}`)
+    );
+  }
+  await verifySpatialOutput(output, expectedIds, props.label);
+
+  return {
+    label: props.label,
+    medianMilliseconds: getMedianDuration(durations),
+    pointCount: props.pointCount,
+    resultCount: expectedIds.length
+  };
+}
+
+async function executeSpatialGraph(
+  device: Device,
+  graph: CompiledGPUCommandGraph,
+  identifier: string
+): Promise<number> {
+  const commandEncoder = device.createCommandEncoder({id: identifier});
+  const startTime = performance.now();
+  let submitted = false;
+
+  try {
+    graph.encode(commandEncoder, {parameters: undefined});
+    device.submit(commandEncoder.finish());
+    submitted = true;
+    const fence = device.createFence();
+    try {
+      await fence.signaled;
+    } finally {
+      fence.destroy();
+    }
+    return performance.now() - startTime;
+  } catch (error) {
+    if (!submitted) commandEncoder.destroy();
+    throw error;
+  }
+}
+
+async function verifySpatialOutput(
+  output: SpatialBenchmarkOutput,
+  expectedIds: Uint32Array,
+  label: string
+): Promise<void> {
+  const resultCount = await readSpatialScalar(output.count);
+  const overflow = await readSpatialScalar(output.overflow);
+  if (overflow !== 0 || resultCount !== expectedIds.length) {
+    throw new Error(`${label} returned an incomplete result or an incorrect result count.`);
+  }
+
+  const resultBytes = await output.ids.readAsync(0, resultCount * Uint32Array.BYTES_PER_ELEMENT);
+  const actualIds = new Uint32Array(resultBytes.buffer, resultBytes.byteOffset, resultCount).sort();
+  if (actualIds.some((identifier, index) => identifier !== expectedIds[index])) {
+    throw new Error(`${label} returned IDs that do not match the CPU predicate.`);
+  }
+}
+
+async function readSpatialScalar(buffer: Buffer): Promise<number> {
+  const bytes = await buffer.readAsync(0, Uint32Array.BYTES_PER_ELEMENT);
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(0, true);
+}
+
+function compileIndexBuild(
+  device: Device,
+  positions: Buffer,
+  index: SpatialBenchmarkIndex,
+  pointCount: number
+): CompiledGPUCommandGraph {
+  const graph = new GPUCommandGraph(device, {id: 'docs-spatial-grid-build'});
+  const positionView = importSpatialView(graph, 'positions', positions, 'float32x2', pointCount);
+  const cellOffsets = importSpatialView(
+    graph,
+    'cell-offsets',
+    index.cellOffsets,
+    'uint32',
+    GRID_DIMENSION * GRID_DIMENSION + 1
+  );
+  const rowIndices = importSpatialView(
+    graph,
+    'row-indices',
+    index.rowIndices,
+    'uint32',
+    pointCount
+  );
+  const count = importSpatialView(graph, 'index-count', index.count, 'uint32', 1);
+  const overflow = importSpatialView(graph, 'index-overflow', index.overflow, 'uint32', 1);
+
+  new GPUGridIndex({
+    id: 'docs-spatial-grid',
+    positions: positionView,
+    gridSize: [GRID_DIMENSION, GRID_DIMENSION],
+    bounds: INDEX_BOUNDS,
+    cellOffsets,
+    objectIds: rowIndices,
+    count,
+    overflow
+  }).addToGraph(graph);
+
+  return graph.compile();
+}
+
+function compileSpatialQuery(
+  device: Device,
+  positions: Buffer,
+  query: Buffer,
+  output: SpatialBenchmarkOutput,
+  pointCount: number,
+  index?: SpatialBenchmarkIndex
+): CompiledGPUCommandGraph {
+  const graph = new GPUCommandGraph(device, {
+    id: index ? 'docs-spatial-indexed-query' : 'docs-spatial-scan-query'
+  });
+  const positionView = importSpatialView(graph, 'positions', positions, 'float32x2', pointCount);
+  const queryView = importSpatialView(graph, 'query', query, 'float32', QUERY_BOUNDS.length);
+  const resultViews = {
+    ids: importSpatialView(graph, 'result-ids', output.ids, 'uint32', pointCount),
+    count: importSpatialView(graph, 'result-count', output.count, 'uint32', 1),
+    overflow: importSpatialView(graph, 'result-overflow', output.overflow, 'uint32', 1)
+  };
+  const indexView: GPUGridIndexView | undefined = index
+    ? {
+        gridSize: [GRID_DIMENSION, GRID_DIMENSION],
+        bounds: INDEX_BOUNDS,
+        cellOffsets: importSpatialView(
+          graph,
+          'cell-offsets',
+          index.cellOffsets,
+          'uint32',
+          GRID_DIMENSION * GRID_DIMENSION + 1
+        ),
+        rowIndices: importSpatialView(graph, 'row-indices', index.rowIndices, 'uint32', pointCount),
+        count: importSpatialView(graph, 'index-count', index.count, 'uint32', 1),
+        overflow: importSpatialView(graph, 'index-overflow', index.overflow, 'uint32', 1)
+      }
+    : undefined;
+
+  new GPUPointSpatialQuery({
+    id: index ? 'docs-spatial-indexed' : 'docs-spatial-scan',
+    positions: positionView,
+    kind: 'bounds',
+    query: queryView,
+    output: resultViews,
+    ...(indexView ? {index: indexView} : {})
+  }).addToGraph(graph);
+
+  return graph.compile();
+}
+
+function importSpatialView<Format extends 'float32' | 'float32x2' | 'uint32'>(
+  graph: GPUCommandGraph,
+  identifier: string,
+  buffer: Buffer,
+  format: Format,
+  length: number
+): GraphDataView<Format> {
+  const handle = graph.importBuffer(
+    {id: identifier, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return graph.createDataView(handle, {format, length});
+}
+
+function createSpatialInputBuffer(
+  device: Device,
+  ownedBuffers: Buffer[],
+  data: Float32Array
+): Buffer {
+  const buffer = device.createBuffer({data, usage: Buffer.STORAGE | Buffer.COPY_DST});
+  ownedBuffers.push(buffer);
+  return buffer;
+}
+
+function createSpatialOutput(
+  device: Device,
+  ownedBuffers: Buffer[],
+  pointCount: number
+): SpatialBenchmarkOutput {
+  return {
+    ids: createSpatialStorageBuffer(device, ownedBuffers, pointCount),
+    count: createSpatialStorageBuffer(device, ownedBuffers, 1),
+    overflow: createSpatialStorageBuffer(device, ownedBuffers, 1)
+  };
+}
+
+function createSpatialIndex(
+  device: Device,
+  ownedBuffers: Buffer[],
+  pointCount: number
+): SpatialBenchmarkIndex {
+  return {
+    cellOffsets: createSpatialStorageBuffer(
+      device,
+      ownedBuffers,
+      GRID_DIMENSION * GRID_DIMENSION + 1
+    ),
+    rowIndices: createSpatialStorageBuffer(device, ownedBuffers, pointCount),
+    count: createSpatialStorageBuffer(device, ownedBuffers, 1),
+    overflow: createSpatialStorageBuffer(device, ownedBuffers, 1)
+  };
+}
+
+function createSpatialStorageBuffer(
+  device: Device,
+  ownedBuffers: Buffer[],
+  rowCount: number
+): Buffer {
+  const buffer = device.createBuffer({
+    byteLength: rowCount * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  ownedBuffers.push(buffer);
+  return buffer;
+}
+
+function getMedianDuration(durations: number[]): number {
+  const sortedDurations = [...durations].sort((left, right) => left - right);
+  return sortedDurations[Math.floor(sortedDurations.length / 2)];
+}


### PR DESCRIPTION
## Goals

- Let documentation readers measure FP64 arithmetic, high-precision coordinate reprojection, and luSpatial queries on their own browser and WebGPU device.
- Compare equivalent CPU and GPU workloads with transparent timing semantics, validated results, and explicit user initiation instead of static or synthetic performance claims.

## Changes

- Add an accessible, SSR-safe, reusable live-benchmark panel with explicit run, progress, error, unsupported-WebGPU, and unmount/navigation states.
- Add public `@luma.gl/experimental/luproj` documentation and navigation, including provider integration, adaptive patches, binary64 coordinate transport, optional patch IDs, and the separate benchmark entry point.
- Embed a selectable-size luProj benchmark comparing direct CPU projection, two compiled CPU paths, and four real WebGPU float32/raw-binary64 plus scan/explicit-patch paths. Report synchronized throughput, CPU-relative speedups, projection error, and optional GPU timestamps.
- Add opt-in luSpatial benchmarks to both the geospatial reference and spatial-query benchmark pages. Compare a CPU bounds scan with the actual GPU scan and reusable grid-index paths, validate every matching ID, and report grid construction time/storage separately.
- Embed the existing 16-case FP64 compute benchmark directly in the `fp64arithmetic` reference, covering native Float32 and automatic/classic/integer-controlled double-single arithmetic.
- Add focused node coverage for server rendering, opt-in execution, unsupported-device presentation, existing-device reuse, projection documentation/navigation, FP64 documentation embeds, and spatial documentation/kernel integration.

## Verification

- `nvm use` (Node 22.22.1)
- `YARN_CACHE_FOLDER=/Users/ib/opensource/luma.gl/.yarn/cache yarn install --immutable`
- `yarn lint fix`
- `yarn build`
- `yarn test` — 433 node tests and 1,520 real headless-browser/WebGPU tests passed.
- `yarn lint`
- `yarn examples:typecheck`
- `yarn bundle-size`
- `yarn website:build`
- `(cd website && yarn build)`
- Focused node documentation/server-rendering regression tests: 14 cases across FP64, shared UI,
  projection, and spatial pages.
- Built-production-site Playwright: actually ran luProj on 4,096 coordinates and verified three CPU plus four WebGPU result rows, including both raw binary64 paths.
- Built-production-site Playwright: actually ran luSpatial on 16,384 points and verified the CPU scan, GPU scan, and reusable GPU grid all produced the same 1,304 IDs, with index build reported separately.
- Built-production-site Playwright: actually ran the `fp64arithmetic` benchmark and verified all 16 operation/precision-mode results.
- Built-production-site Playwright: verified the geospatial page stays idle until clicked and all three projection/spatial pages disable their benchmark with an explanatory message when WebGPU is unavailable.

## Risks and rollout

- Benchmarks run only after an explicit click and reuse the site's existing WebGPU device; unsupported browsers see a disabled control and an explanation.
- GPU timings wait for completed work, while separately labeled timestamp throughput excludes CPU/queue overhead. Projection excludes one-time uploads/compilation; spatial reports index-build cost separately.
- FP64 embedding reuses the existing production demo; no new dependencies or changes to published runtime package entry points are introduced.
