### PR TITLE
Add live GPU scene and trace consumers

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1061,13 +1061,13 @@ consumers.
 | 8.3b — Partitioned-right decision | Decide paired partitions, key routing, or global addressing for multiple right indices | Implemented shared-right `GPUBatchHashJoin` plus a consumer with partitioned right ownership | One routing contract is accepted with empty/uneven batch evidence or explicitly deferred | High | Large |
 | 8.4 — Sparse graph analytics | Frontier/visited representations and graph algorithms selected by demonstrated consumers | Partitioned identity contracts from 3.2 and the 8.3b decision | Bounded CPU-oracle parity on disconnected, cyclic, and high-degree graphs | High | Large |
 | 8.5 — Field and solver composition | Reusable graph-native stencil, advection, and solver building blocks behind live simulations | Two existing simulation consumers agree on field and boundary contracts | Shared primitives replace consumer-local kernels without hidden submission | High | Large |
-| 3.2 — Partitioned topology | Global-ID and chunk-base contracts for hierarchy and CSR inputs without hidden packing | Implemented Phase 3 primitives plus a preserved-batch consumer | CPU-oracle parity across empty and uneven chunks; no implicit repack | High | Large |
-| 3.3 — Extension decision gate | Decide sparse or multidimensional histograms, custom scans, and shader extension points separately | Tranche 3.2 plus at least two requesting consumers | Each proposal is accepted with a fixed contract or explicitly deferred with evidence | Medium | Small |
-| 6.3a — Conventional scene consumer | A CPU scene graph uses shared storage, visibility, picking, and draw generation | Tranche 6.2b and Phase 4 | No consumer-specific fields or CPU draw filtering | High | Medium |
+| 3.2 — Partitioned topology | Implemented: global-ID and chunk-base contracts for hierarchy and CSR inputs without hidden packing | Implemented Phase 3 primitives plus a preserved-batch consumer | CPU-oracle parity across empty and uneven chunks; no implicit repack | High | Large |
+| 3.3 — Extension decision gate | Implemented: sparse/multidimensional histograms, custom scans, and shader predicates explicitly deferred pending consumer evidence | Tranche 3.2 plus at least two requesting consumers | Each proposal is accepted with a fixed contract or explicitly deferred with evidence | Medium | Small |
+| 6.3a — Conventional scene consumer | Implemented: an application-owned CPU scene graph uses shared flat storage, GPU visibility and picking, renderer resource groups, measured mutation, and indirect draw generation | Tranche 6.2b and Phase 4 | Stable application IDs, one compiled graph, explicit update costs, and no consumer-specific fields or CPU draw filtering | High | Medium |
 | 6.3b — Table-oriented scene consumer | A preserved-batch table application uses the same runtime contracts | Tranches 6.1c, 6.2b, and 3.2 | Shares public primitives with 6.3a without repacking or adapter casts | High | Medium |
 | T.1 — Canonical GPU trace scene | Stable spans, process/thread ownership, preserved source partitions, parents, dependency CSR, and generic scene projection | Implemented `GPUScene`, draw generation, and renderer-owned resource groups | Source identity, empty/uneven batches, bidirectional links, ownership, and scene draw/group integration pass GPU tests | High | Medium |
 | T.2 — Interactive GPU trace policies | Implemented: time windows, process/thread expansion, linked-span focus, ancestor retention, and stable indirect draws | Tranche T.1 plus hierarchy, mask, traversal, and visibility workflows | Policy-only updates reuse one graph with GPU-tested stable masks, row IDs, hierarchy offsets, ancestry, and indirect draws | High | Large |
-| T.3 — Scene-backed trace showcase | A live trace explorer combines canonical trace scenes, GPU interactions, picking, resource groups, and timing | Tranche T.2 plus existing picking and graph-inspection contracts | Representative traces pan, filter, collapse, focus, and pick without CPU draw selection | High | Large |
+| T.3 — Scene-backed trace showcase | Implemented: a bounded live trace explorer combines canonical trace scenes, GPU interactions, picking, resource groups, stable indirect drawing, and command-graph inspection | Tranche T.2 plus existing picking and graph-inspection contracts | Representative traces pan, filter, collapse, focus, and pick without CPU draw selection or graph recompilation | High | Large |
 | 7.1 — Dependency audit and API freeze | Freeze names, ownership, failures, capacities, submission, and package graph | Phase 6 exits and two consumers per graduation candidate | Acyclic dependency report and owner for every public resource boundary | High | Medium |
 | 7.2 — Scheduling-core extraction | Move table-independent graph scheduling directly to `@luma.gl/engine` | Tranche 7.1 | Engine builds without tables, gpgpu, or Arrow; all repository imports use the final owner | High | Large |
 | 7.3 — Adapter and algorithm migration | Keep table adapters in `@luma.gl/tables`; move optional workflows to `@luma.gl/gpgpu` | Tranche 7.2 | Package tests enforce dependency direction and examples use final owners | High | Large |
@@ -1075,12 +1075,14 @@ consumers.
 
 ### Recommended execution order
 
-1. Add a conventional scene consumer (6.3a) to prove shared visibility, picking, generated draws,
-   and renderer-owned resource groups without consumer-specific scene fields.
-2. Build on the implemented canonical trace-scene and interaction foundations (T.1–T.2) with a
-   live scene-backed trace showcase (T.3).
-3. Add partitioned topology (3.2) when a preserved-batch hierarchy or CSR consumer fixes the
-   cross-chunk identity contract.
+1. Add the preserved-batch table consumer (6.3b) beside the implemented conventional scene
+   consumer (6.3a) to prove the same shared visibility, picking, generated draws, and
+   renderer-owned resource groups without packing or consumer-specific scene fields.
+2. Preserve the implemented canonical trace-scene, reusable interaction, and live scene-backed
+   showcase contracts (T.1–T.3); add larger trace features only when a consumer establishes their
+   resource bounds and measurable benefit.
+3. Preserve the implemented partitioned hierarchy/CSR topology and explicit extension decision
+   gate (3.2–3.3); reopen extensions only when new consumers fix their memory and identity costs.
 4. Reopen incremental grid maintenance, spatial BVH rebuild, or ray traversal only when the
    documented decision gate gains a requesting consumer and positive evidence.
 5. Graduate packages only after both scene consumers prove the final APIs and dependency direction.
@@ -1517,8 +1519,15 @@ Prove that the storage contract serves both a conventional scene graph and a tab
 application. Both consumers use the same identity, visibility, picking, and indirect-draw path
 while retaining their own update and presentation policies.
 
-The conventional consumer lands as 6.3a; the preserved-batch table consumer follows as 6.3b. Phase
-6 does not exit until both use the same public runtime contracts without casts, hidden packing, or
+Tranche 6.3a is implemented by the live GPU Scene Graph Explorer. An application-owned hierarchy
+is flattened through `makeGPUSceneFromCPUScene`; GPU bounds visibility, stable-row compaction,
+source-indexed indirect draw generation, renderer-owned resource windows, visibility-aware
+picking, and explicit mutation costs share one compiled command graph. The hierarchy stays on the
+CPU, stable application IDs differ from physical scene slots, and group diagnostics never drive
+CPU draw selection.
+
+The preserved-batch table consumer follows as 6.3b. Phase 6 does not exit until that second
+independent consumer uses the same public runtime contracts without casts, hidden packing, or
 consumer-specific record fields.
 
 **Exit evidence:** Two independent consumers share the public scene primitives without adapter

--- a/docs/api-reference/experimental/gpu-primitives/gpu-scene-adapters.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-scene-adapters.md
@@ -1,4 +1,5 @@
 import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+import {GPUSceneGraphExample} from '@site/src/examples';
 
 # GPUScene adapters
 
@@ -21,6 +22,8 @@ graph naturally owns hierarchy, lifecycle, and incremental edits. A table natura
 streaming batches, and GPU-resident data. Both can feed the same visibility, picking, spatial, and
 draw-generation contracts once they agree on the flat record at the boundary.
 
+<GPUSceneGraphExample embedded />
+
 ## Concepts
 
 ### An adapter is a boundary, not a new source model
@@ -38,6 +41,12 @@ their own inherited state before returning a record.
 The output is an ordinary mutable `GPUScene`. Stable IDs, bounds, transforms, group references,
 geometry references, and command slots have exactly the same meaning as records supplied directly
 to the constructor.
+
+In the embedded explorer, three application-owned grouping branches contain ordinary renderable
+leaves. Grouping nodes deliberately return `null`; leaf records retain stable application IDs that
+differ from their physical slots. The resulting flat scene feeds the same visibility, picking,
+indirect-draw, and renderer-resource-group primitives as the trace explorer without importing its
+hierarchy or domain concepts into `GPUScene`.
 
 ### Zero-copy table adaptation requires a physical agreement
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-scene-draw-generation.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-scene-draw-generation.md
@@ -1,4 +1,5 @@
 import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+import {GPUSceneGraphExample} from '@site/src/examples';
 
 # GPUSceneDrawGeneration
 
@@ -16,6 +17,8 @@ culling, spatial queries, hierarchy expansion, and selection masks can remain GP
 of forcing a readback, rebuilding a CPU draw list, and uploading counts again. Geometry arguments
 remain stable; the workflow changes only `instanceCount` and `firstInstance`.
 
+<GPUSceneGraphExample embedded />
+
 ## Concepts
 
 ### Explicit slots separate selection from renderer policy
@@ -28,6 +31,11 @@ and starting offsets. Draw generation does not infer materials, pipelines, or re
 This division lets applications choose their own slot assignment and issue indirect calls in the
 order required by their renderer. It also keeps this primitive useful before pipeline/resource
 grouping is standardized.
+
+The live scene-graph example records every renderer-owned slot once in a reusable render bundle.
+Changing a group checkbox alters only the GPU visibility mask; moving or removing a selected
+object updates its ordinary scene record. The same compiled graph then republishes counts and
+source-indexed indirect commands without the application constructing a CPU-selected draw list.
 
 ### Fixed capacity is observable
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-scene-resource-groups.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-scene-resource-groups.md
@@ -1,4 +1,5 @@
 import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+import {GPUSceneGraphExample} from '@site/src/examples';
 
 # GPUSceneResourceGroups
 
@@ -21,6 +22,8 @@ geometry, CAD scenes with distinct pipeline states, and table-backed features gr
 textures or vertex buffers. Visibility changes update GPU counts without rebuilding CPU-selected
 draw lists.
 
+<GPUSceneGraphExample embedded />
+
 ## Concepts
 
 ### Groups describe binding topology, not a second scene graph
@@ -42,6 +45,11 @@ binding configurations.
 The class never owns a pipeline, material, bind group, scene hierarchy, or draw encoder. Those
 remain application concerns and may differ between a conventional renderer and a preserved-batch
 table application.
+
+The embedded conventional scene demonstrates three fixed renderer buckets: terrain, structures,
+and signals. Their command windows remain stable even when checkboxes hide an entire bucket or
+CPU-authored scene mutations remove an individual object. GPU-generated per-group counts are read
+back only for diagnostics; they never drive CPU draw selection.
 
 ### Generated commands are the source of truth
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-scene.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-scene.md
@@ -1,4 +1,5 @@
 import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+import {GPUSceneGraphExample} from '@site/src/examples';
 
 # GPUScene
 
@@ -15,6 +16,8 @@ The class is deliberately a storage contract, not a scene graph. A game-engine h
 a simulation, or a map tile system may all populate the records, but none becomes the canonical
 source model. This separation makes the expensive GPU path reusable while applications retain
 their own hierarchy, lifecycle, and presentation policy.
+
+<GPUSceneGraphExample embedded />
 
 ## Concepts
 
@@ -57,6 +60,12 @@ compaction uploads no record bytes.
 These operations use explicit WebGPU queue writes. They do not submit command buffers or read GPU
 data back. This is the CPU-authored update path for scene graphs and streaming producers; later
 GPU-authored draw selection consumes the same resident records without requiring CPU filtering.
+
+The embedded scene-graph explorer makes that boundary visible: an application-owned tree is
+flattened once, group checkboxes update GPU visibility policy, and clicking selects a stable
+application object ID rather than its temporary scene slot. Moving or removing the selection
+uses `mutate()` and displays the exact upload cost while the previously compiled draw and
+renderer-group workflows remain unchanged.
 
 ### One fixed record connects several workflows
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-trace-interaction.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-trace-interaction.md
@@ -1,4 +1,5 @@
 import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+import {GPUTraceSceneExample} from '@site/src/examples';
 
 # GPUTraceInteraction
 
@@ -23,6 +24,8 @@ Representative uses include service latency investigations, browser performance 
 capture timelines, build-system scheduling views, and scientific workflows with both hierarchical
 ownership and cross-process dependency edges.
 
+<GPUTraceSceneExample embedded />
+
 ## Concepts
 
 ### One compiled graph, many interaction states
@@ -45,6 +48,16 @@ The workflow composes existing independent primitives in a fixed order:
 
 The application owns graph compilation, encoding, submission, and any deliberate readback. None
 of the interaction stages uploads source spans again or chooses draw commands on the CPU.
+
+In the embedded example, scrolling updates only a three-value temporal window, checkboxes update
+process/thread and classification buffers, and clicking performs a GPU visibility-aware pick.
+Enabling linked-span focus changes policy and selection inputs without recompiling the graph.
+Per-group counts are sampled only as optional diagnostics; draw visibility is consumed directly
+from stable GPU-written indirect command slots.
+
+Scene-generated draw slots require the WebGPU `indirect-first-instance` feature. The live example
+therefore selects the maximum-feature WebGPU device explicitly instead of assuming that an
+otherwise functional core-only adapter supports source-indexed indirect rendering.
 
 ### Hierarchy collapse keeps representative lanes
 
@@ -156,5 +169,7 @@ selectedCountBuffer.write(Uint32Array.from([1]));
 ## Current scope
 
 This implements roadmap tranche T.2 for one canonical packed trace scene and a fixed regular
-process/thread/lane hierarchy. Arbitrary sparse ownership layouts, cross-partition scene storage,
-GPU picking integration, and a live scene-backed trace showcase remain explicit follow-up work.
+process/thread/lane hierarchy. The T.3 scene-backed explorer adds GPU visibility-aware picking,
+renderer-owned resource groups, indirect rendering, and graph inspection as application-owned
+composition. Arbitrary sparse ownership layouts and cross-partition scene storage remain separate
+consumer-defined follow-up contracts.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-trace-scene.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-trace-scene.md
@@ -1,4 +1,5 @@
 import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+import {GPUTraceSceneExample} from '@site/src/examples';
 
 # GPUTraceScene
 
@@ -21,6 +22,8 @@ resource groups without translating identities between those stages.
 Useful consumers include distributed execution timelines, browser performance recordings, GPU
 capture visualizers, task schedulers, service dependency traces, and scientific workflows whose
 operations have both temporal ownership and explicit cross-process links.
+
+<GPUTraceSceneExample embedded />
 
 ## Concepts
 
@@ -63,6 +66,14 @@ consume trace scenes without a trace-specific renderer or additional fields in `
 The projection is created explicitly during ingestion. Its memory cost is observable through
 `stats.sceneByteLength`; a trace viewer should therefore choose a bounded scene capacity instead
 of assuming that canonical 32-byte spans and projected 128-byte records cost the same.
+
+The embedded explorer intentionally demonstrates that boundary with a bounded canonical trace.
+Its render shader reads temporal bounds from ordinary scene records, while process/thread
+ownership and classification remain in the separate canonical span buffer. Stable per-span
+indirect slots are recorded into one reusable render bundle; renderer resource-group membership
+is classified on the GPU instead of rebuilding JavaScript draw lists as visibility changes.
+Because those generated slots preserve canonical source rows in `firstInstance`, the example
+explicitly requests a WebGPU device with the `indirect-first-instance` feature.
 
 ### Source batches remain visible, including empty batches
 
@@ -142,5 +153,6 @@ workflow.
 This tranche establishes canonical ingestion, stable trace-to-scene identity, preserved source
 partitions, bidirectional topology, explicit ownership, and compatibility with the existing
 indirect-rendering stack. Interactive process/thread expansion, linked-span selection, and stable
-draw publication are provided by `GPUTraceInteraction`; a live scene-backed trace showcase remains
-a separate follow-up tranche.
+draw publication are provided by `GPUTraceInteraction`. The embedded live trace explorer combines
+those contracts with GPU picking, resource groups, stable indirect rendering, and command-graph
+inspection without introducing trace-specific fields into `GPUScene`.

--- a/examples/experimental/gpu-scene-graph/app.ts
+++ b/examples/experimental/gpu-scene-graph/app.ts
@@ -1,0 +1,513 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device, type RenderBundle} from '@luma.gl/core';
+import {AnimationLoopTemplate, Computation, Model, type AnimationProps} from '@luma.gl/engine';
+import {
+  DrawCommandBuffer,
+  GPUCommandGraph,
+  GPUCommandGraphInspector,
+  GPUReadbackRing,
+  GPUSceneDrawGeneration,
+  GPUSceneResourceGroups,
+  GPUVisibilityWorkflow,
+  GPU_SCENE_INVALID_REFERENCE,
+  makeGPUSceneFromCPUScene,
+  type CompiledGPUCommandGraph,
+  type GPUReadbackTicket,
+  type GPUScene,
+  type GraphDataView
+} from '@luma.gl/experimental';
+import {
+  ExamplePanelManager,
+  makeExamplePanelHostHtml,
+  makeHtmlCustomPanel
+} from '../../example-panels';
+import {GPUCommandGraphInspectorPanel} from '../../gpu-command-graph-inspector-panel';
+import {
+  makeSceneGraphRoots,
+  SCENE_GRAPH_CAPACITY,
+  SCENE_GRAPH_GROUPS,
+  SCENE_GRAPH_OBJECTS_PER_GROUP
+} from './scene-graph-data';
+import {
+  getSceneGraphPickingShader,
+  getSceneGraphVisibilityShader,
+  SCENE_GRAPH_RENDER_SHADER
+} from './scene-graph-shaders';
+
+export const title = 'GPU Scene Graph Explorer';
+export const description =
+  'A conventional CPU scene hierarchy feeds generic GPU visibility, resource groups, picking, indirect drawing, and measurable mutation.';
+
+const STORAGE_USAGE = Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST;
+const VIEW_BYTE_LENGTH = 32;
+
+type OwnedUint32 = {buffer: Buffer; view: GraphDataView<'uint32'>};
+
+type SceneGraphResources = {
+  compiled: CompiledGPUCommandGraph<void>;
+  scene: GPUScene;
+  commands: DrawCommandBuffer;
+  bundle: RenderBundle;
+  ownedBuffers: Buffer[];
+  visibility: Buffer;
+  visibleCount: Buffer;
+  groupCounts: Buffer;
+  pickRequest: Buffer;
+  pickResult: Buffer;
+};
+
+/** Conventional CPU-hierarchy consumer of the same flat GPUScene contracts as trace applications. */
+export default class GPUSceneGraphAnimationLoopTemplate extends AnimationLoopTemplate {
+  static info = makeExamplePanelHostHtml();
+  static props = {createFramebuffer: true, debug: true};
+
+  readonly device: Device;
+  readonly graphInspector = new GPUCommandGraphInspector({maxSamples: 90});
+
+  private readonly model: Model;
+  private readonly viewUniforms: Buffer;
+  private readonly readbackRing: GPUReadbackRing;
+  private readonly panels: ExamplePanelManager;
+  private resources: SceneGraphResources;
+  private inspectorPanel: GPUCommandGraphInspectorPanel | null = null;
+  private controls: HTMLElement | null = null;
+  private canvas: HTMLCanvasElement | null = null;
+  private enabledGroups = (1 << SCENE_GRAPH_GROUPS.length) - 1;
+  private selectedObjectId = GPU_SCENE_INVALID_REFERENCE;
+  private pendingPick: readonly [number, number] | null = null;
+  private viewBounds: [number, number, number, number] = [-1.1, -1.1, 1.1, 1.1];
+  private frameIndex = 0;
+
+  constructor({device}: AnimationProps) {
+    super();
+    if (device.type !== 'webgpu' || !device.features.has('indirect-first-instance')) {
+      throw new Error('GPU Scene Graph Explorer requires indirect-first-instance');
+    }
+    this.device = device;
+    this.viewUniforms = device.createBuffer({
+      id: 'scene-graph-view',
+      byteLength: VIEW_BYTE_LENGTH,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    this.readbackRing = new GPUReadbackRing(device, {
+      id: 'scene-graph-readback',
+      byteLength: SCENE_GRAPH_GROUPS.length * Uint32Array.BYTES_PER_ELEMENT,
+      slotCount: 3
+    });
+    this.model = new Model(device, {
+      id: 'scene-graph-model',
+      source: SCENE_GRAPH_RENDER_SHADER,
+      topology: 'triangle-list',
+      vertexCount: 6,
+      colorAttachmentFormats: [device.preferredColorFormat],
+      depthStencilAttachmentFormat: 'depth24plus',
+      shaderLayout: {
+        attributes: [],
+        bindings: [
+          {name: 'records', type: 'read-only-storage', group: 0, location: 0},
+          {name: 'view', type: 'uniform', group: 0, location: 1}
+        ]
+      }
+    });
+    this.resources = this.createResources();
+    this.panels = new ExamplePanelManager({
+      panel: makeHtmlCustomPanel({
+        id: 'scene-graph-controls',
+        title: 'GPU Scene Graph Explorer',
+        html: makeControls(),
+        onRender: root => this.attachControls(root)
+      })
+    });
+    this.panels.mount();
+  }
+
+  override async onInitialize({canvas}: AnimationProps): Promise<void> {
+    if (canvas instanceof HTMLCanvasElement) {
+      this.canvas = canvas;
+      canvas.addEventListener('click', this.handleCanvasClick);
+      canvas.addEventListener('wheel', this.handleWheel, {passive: false});
+    }
+  }
+
+  override onRender({device}: AnimationProps): void {
+    this.writeView();
+    this.resources.pickResult.write(Uint32Array.of(GPU_SCENE_INVALID_REFERENCE));
+    const request = new ArrayBuffer(16);
+    if (this.pendingPick) {
+      new Float32Array(request).set(this.pendingPick);
+      new Uint32Array(request)[2] = 1;
+    }
+    this.resources.pickRequest.write(new Uint8Array(request));
+    const encoding = this.resources.compiled.encode(device.commandEncoder, {parameters: undefined});
+    this.graphInspector.recordEncoding(this.resources.compiled.id, encoding);
+    if (this.pendingPick) {
+      const ticket = this.readbackRing.tryAcquire();
+      if (ticket) {
+        this.pendingPick = null;
+        ticket.copyFrom(device.commandEncoder, this.resources.pickResult, {byteLength: 4});
+        queueMicrotask(() => void this.readSelection(ticket));
+      }
+    }
+    if (this.frameIndex++ % 30 === 0) {
+      const ticket = this.readbackRing.tryAcquire();
+      if (ticket) {
+        ticket.copyFrom(device.commandEncoder, this.resources.groupCounts);
+        queueMicrotask(() => void this.readGroupCounts(ticket));
+      }
+      this.inspectorPanel?.update(this.graphInspector.getSnapshot(), this.resources.compiled.id);
+    }
+  }
+
+  override onFinalize(): void {
+    this.canvas?.removeEventListener('click', this.handleCanvasClick);
+    this.canvas?.removeEventListener('wheel', this.handleWheel);
+    this.panels.finalize();
+    this.resources.compiled.destroy();
+    this.resources.bundle.destroy();
+    this.resources.commands.destroy();
+    this.resources.scene.destroy();
+    for (const buffer of this.resources.ownedBuffers) buffer.destroy();
+    this.readbackRing.destroy();
+    this.model.destroy();
+    this.viewUniforms.destroy();
+  }
+
+  private createResources(): SceneGraphResources {
+    const scene = makeGPUSceneFromCPUScene(this.device, {
+      id: 'scene-graph',
+      roots: makeSceneGraphRoots(),
+      getChildren: node => node.children,
+      getRecord: node => node.record ?? null,
+      capacity: SCENE_GRAPH_CAPACITY
+    });
+    const graph = new GPUCommandGraph<void>(this.device, {id: 'scene-graph-command-graph'});
+    const source = scene.importToGraph(graph);
+    const view = graph.importBuffer(
+      {id: 'view', byteLength: this.viewUniforms.byteLength, usage: this.viewUniforms.usage},
+      this.viewUniforms
+    );
+    const commands = new DrawCommandBuffer(this.device, {
+      id: 'scene-graph-draws',
+      type: 'draw',
+      commands: Array.from({length: SCENE_GRAPH_CAPACITY}, () => ({
+        vertexCount: 6,
+        instanceCount: 0
+      }))
+    });
+    const commandViews = commands.importToGraph(graph);
+    const ownedBuffers: Buffer[] = [];
+    const makeUint32 = (identifier: string, length: number): OwnedUint32 => {
+      const buffer = this.device.createBuffer({
+        id: `scene-graph-${identifier}`,
+        data: new Uint32Array(length),
+        usage: STORAGE_USAGE
+      });
+      ownedBuffers.push(buffer);
+      const handle = graph.importBuffer(
+        {id: identifier, byteLength: buffer.byteLength, usage: buffer.usage},
+        buffer
+      );
+      return {buffer, view: graph.createDataView(handle, {format: 'uint32', length})};
+    };
+    const visibility = makeUint32('visibility', SCENE_GRAPH_CAPACITY);
+    const visibleRows = makeUint32('visible-rows', SCENE_GRAPH_CAPACITY);
+    const visibleCount = makeUint32('visible-count', 1);
+    const requiredCount = makeUint32('required-count', 1);
+    const publishedCount = makeUint32('published-count', 1);
+    const drawOverflow = makeUint32('draw-overflow', 1);
+    const groupCounts = makeUint32('group-counts', SCENE_GRAPH_GROUPS.length);
+    const groupOverflows = makeUint32('group-overflows', SCENE_GRAPH_GROUPS.length);
+    const groupOverflow = makeUint32('group-overflow', 1);
+    const pickRequest = makeUint32('pick-request', 4);
+    const pickResult = makeUint32('pick-result', 1);
+
+    graph.addComputePass({
+      id: 'scene-graph-visibility',
+      resources: [
+        {buffer: source.records, usage: 'storage-read'},
+        {buffer: view, usage: 'uniform'},
+        {buffer: visibility.view, usage: 'storage-write'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: 'scene-graph-visibility',
+          source: getSceneGraphVisibilityShader(SCENE_GRAPH_CAPACITY),
+          shaderLayout: {
+            bindings: [
+              {name: 'records', type: 'storage', group: 0, location: 0},
+              {name: 'view', type: 'uniform', group: 0, location: 1},
+              {name: 'visibility', type: 'storage', group: 0, location: 2}
+            ]
+          }
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({
+              records: getBuffer(source.records),
+              view: getBuffer(view),
+              visibility: getBuffer(visibility.view)
+            });
+            computation.dispatch(computePass, Math.ceil(SCENE_GRAPH_CAPACITY / 256));
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+    new GPUVisibilityWorkflow({
+      id: 'scene-graph-visible-rows',
+      predicates: [{kind: 'bounds', mask: visibility.view}],
+      output: visibleRows.view,
+      count: visibleCount.view
+    }).addToGraph(graph);
+    new GPUSceneDrawGeneration({
+      id: 'scene-graph-draw-generation',
+      scene: source,
+      visibility: visibility.view,
+      commands: commandViews,
+      requiredCount: requiredCount.view,
+      publishedCount: publishedCount.view,
+      overflow: drawOverflow.view
+    }).addToGraph(graph);
+    new GPUSceneResourceGroups({
+      id: 'scene-graph-resource-groups',
+      scene: source,
+      commands: commandViews,
+      groups: SCENE_GRAPH_GROUPS.map((_, groupIndex) => ({
+        id: groupIndex,
+        firstCommand: groupIndex * SCENE_GRAPH_OBJECTS_PER_GROUP,
+        commandCount: SCENE_GRAPH_OBJECTS_PER_GROUP,
+        geometryId: 0
+      })),
+      counts: groupCounts.view,
+      overflows: groupOverflows.view,
+      overflow: groupOverflow.view
+    }).addToGraph(graph);
+    graph.addComputePass({
+      id: 'scene-graph-picking',
+      resources: [
+        {buffer: source.records, usage: 'storage-read'},
+        {buffer: visibility.view, usage: 'storage-read'},
+        {buffer: pickRequest.view, usage: 'storage-read'},
+        {buffer: pickResult.view, usage: 'storage-write'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: 'scene-graph-picking',
+          source: getSceneGraphPickingShader(SCENE_GRAPH_CAPACITY),
+          shaderLayout: {
+            bindings: [
+              {name: 'records', type: 'storage', group: 0, location: 0},
+              {name: 'visibility', type: 'storage', group: 0, location: 1},
+              {name: 'request', type: 'storage', group: 0, location: 2},
+              {name: 'result', type: 'storage', group: 0, location: 3}
+            ]
+          }
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({
+              records: getBuffer(source.records),
+              visibility: getBuffer(visibility.view),
+              request: getBuffer(pickRequest.view),
+              result: getBuffer(pickResult.view)
+            });
+            computation.dispatch(computePass, Math.ceil(SCENE_GRAPH_CAPACITY / 256));
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+
+    const encoder = this.device.createRenderBundleEncoder({
+      id: 'scene-graph-render-bundle',
+      colorAttachmentFormats: [this.device.preferredColorFormat],
+      depthStencilAttachmentFormat: 'depth24plus'
+    });
+    encoder.setPipeline(this.model.pipeline);
+    encoder.setVertexArray(this.model.vertexArray);
+    encoder.setBindings({records: scene.recordBuffer, view: this.viewUniforms});
+    for (let commandIndex = 0; commandIndex < commands.capacity; commandIndex++) {
+      commands.draw(encoder, commandIndex);
+    }
+    const bundle = encoder.finish();
+    graph.addRenderPass({
+      id: 'scene-graph-render',
+      resources: [
+        {buffer: source.records, usage: 'storage-read'},
+        {buffer: view, usage: 'uniform'},
+        {buffer: commandViews.buffer, usage: 'indirect'}
+      ],
+      compile: () => ({
+        getRenderPassProps: () => ({
+          id: 'scene-graph-render',
+          clearColor: [0.012, 0.018, 0.035, 1],
+          clearDepth: false,
+          clearStencil: false
+        }),
+        encode: ({renderPass}) => renderPass.executeBundles([bundle])
+      })
+    });
+    const compiled = graph.compile();
+    this.graphInspector.registerGraph(compiled);
+    return {
+      compiled,
+      scene,
+      commands,
+      bundle,
+      ownedBuffers,
+      visibility: visibility.buffer,
+      visibleCount: visibleCount.buffer,
+      groupCounts: groupCounts.buffer,
+      pickRequest: pickRequest.buffer,
+      pickResult: pickResult.buffer
+    };
+  }
+
+  private writeView(): void {
+    const data = new ArrayBuffer(VIEW_BYTE_LENGTH);
+    new Float32Array(data).set(this.viewBounds);
+    new Uint32Array(data).set([this.selectedObjectId, this.enabledGroups], 4);
+    this.viewUniforms.write(new Uint8Array(data));
+  }
+
+  private attachControls(root: HTMLElement): () => void {
+    this.controls = root;
+    const host = root.querySelector<HTMLElement>('[data-scene-graph-inspector]')!;
+    this.inspectorPanel = new GPUCommandGraphInspectorPanel(host, {
+      graphLabels: {[this.resources.compiled.id]: 'Hierarchy → scene → visibility → draw'}
+    });
+    this.inspectorPanel.update(this.graphInspector.getSnapshot(), this.resources.compiled.id);
+    root.addEventListener('change', this.handleControlChange);
+    root.addEventListener('click', this.handleControlClick);
+    return () => {
+      root.removeEventListener('change', this.handleControlChange);
+      root.removeEventListener('click', this.handleControlClick);
+      this.inspectorPanel?.destroy();
+      this.inspectorPanel = null;
+      this.controls = null;
+    };
+  }
+
+  private handleControlChange = (event: Event): void => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement) || target.dataset.group === undefined) return;
+    const groupBit = 1 << Number(target.dataset.group);
+    this.enabledGroups = target.checked
+      ? this.enabledGroups | groupBit
+      : this.enabledGroups & ~groupBit;
+  };
+
+  private handleControlClick = (event: Event): void => {
+    const target = event.target;
+    if (!(target instanceof HTMLButtonElement)) return;
+    if (target.dataset.move !== undefined) this.moveSelection();
+    if (target.dataset.remove !== undefined) this.removeSelection();
+  };
+
+  private handleCanvasClick = (event: MouseEvent): void => {
+    const bounds = this.canvas?.getBoundingClientRect();
+    if (!bounds?.width || !bounds.height) return;
+    const [minimumX, minimumY, maximumX, maximumY] = this.viewBounds;
+    this.pendingPick = [
+      minimumX + ((event.clientX - bounds.left) / bounds.width) * (maximumX - minimumX),
+      maximumY - ((event.clientY - bounds.top) / bounds.height) * (maximumY - minimumY)
+    ];
+  };
+
+  private handleWheel = (event: WheelEvent): void => {
+    event.preventDefault();
+    const scale = Math.max(0.45, Math.min(1.6, 1 + event.deltaY * 0.001));
+    this.viewBounds = [-1.1 * scale, -1.1 * scale, 1.1 * scale, 1.1 * scale];
+  };
+
+  private moveSelection(): void {
+    if (this.selectedObjectId === GPU_SCENE_INVALID_REFERENCE) return;
+    const slot = this.resources.scene.getRecordIndex(this.selectedObjectId);
+    if (slot === undefined) return;
+    const localIndex = slot % SCENE_GRAPH_OBJECTS_PER_GROUP;
+    const groupIndex = Math.floor(slot / SCENE_GRAPH_OBJECTS_PER_GROUP);
+    const centerX = -0.86 + (localIndex % 12) * 0.165;
+    const centerY = -0.85 + (groupIndex * 4 + Math.floor(localIndex / 12)) * 0.164;
+    const result = this.resources.scene.mutate({
+      update: [
+        {
+          id: this.selectedObjectId,
+          bounds: {
+            minimum: [centerX - 0.052, centerY - 0.052, 0],
+            maximum: [centerX + 0.052, centerY + 0.052, 1]
+          }
+        }
+      ]
+    });
+    this.setMutationSummary(`${result.uploadedByteLength} bytes · ${result.writeCount} writes`);
+  }
+
+  private removeSelection(): void {
+    if (this.selectedObjectId === GPU_SCENE_INVALID_REFERENCE) return;
+    const result = this.resources.scene.mutate({remove: [this.selectedObjectId]});
+    this.selectedObjectId = GPU_SCENE_INVALID_REFERENCE;
+    this.setMutationSummary(`${result.uploadedByteLength} bytes · ${result.activeCount} active`);
+    this.setSelectionSummary();
+  }
+
+  private async readSelection(ticket: GPUReadbackTicket): Promise<void> {
+    try {
+      const bytes = await ticket.read();
+      const slot = new Uint32Array(bytes.buffer, bytes.byteOffset, 1)[0];
+      this.selectedObjectId =
+        slot === GPU_SCENE_INVALID_REFERENCE ? GPU_SCENE_INVALID_REFERENCE : 10_000 + slot * 3;
+      this.setSelectionSummary();
+    } catch {
+      // Device loss releases the staging slot without applying stale selection.
+    }
+  }
+
+  private async readGroupCounts(ticket: GPUReadbackTicket): Promise<void> {
+    try {
+      const bytes = await ticket.read();
+      const counts = new Uint32Array(bytes.buffer, bytes.byteOffset, SCENE_GRAPH_GROUPS.length);
+      const summary = this.controls?.querySelector<HTMLElement>('[data-scene-graph-groups]');
+      if (summary) {
+        summary.textContent = SCENE_GRAPH_GROUPS.map(
+          (group, index) => `${group}: ${counts[index]}`
+        ).join(' · ');
+      }
+    } catch {
+      // Optional group diagnostics must not prevent scene rendering.
+    }
+  }
+
+  private setSelectionSummary(): void {
+    const element = this.controls?.querySelector<HTMLElement>('[data-scene-graph-selection]');
+    if (element) {
+      element.textContent =
+        this.selectedObjectId === GPU_SCENE_INVALID_REFERENCE
+          ? 'None'
+          : `Object ${this.selectedObjectId}`;
+    }
+  }
+
+  private setMutationSummary(value: string): void {
+    const element = this.controls?.querySelector<HTMLElement>('[data-scene-graph-mutation]');
+    if (element) element.textContent = value;
+  }
+}
+
+function makeControls(): string {
+  const groups = SCENE_GRAPH_GROUPS.map(
+    (group, index) =>
+      `<label><input type="checkbox" data-group="${index}" checked /> ${group}</label>`
+  ).join('');
+  return `<section data-scene-graph-panel style="display:grid;gap:10px;font-size:12px">
+    <p>Application-owned hierarchy becomes one flat GPU scene. Click an object and scroll to zoom.</p>
+    <div style="display:flex;gap:9px">${groups}</div>
+    <div>Selection: <span data-scene-graph-selection>None</span></div>
+    <div style="display:flex;gap:8px"><button data-move>Move selection</button><button data-remove>Remove selection</button></div>
+    <div>Last CPU mutation: <span data-scene-graph-mutation>None</span></div>
+    <div data-scene-graph-groups>Waiting for GPU group counts…</div>
+    <div data-scene-graph-inspector></div>
+  </section>`;
+}

--- a/examples/experimental/gpu-scene-graph/scene-graph-data.ts
+++ b/examples/experimental/gpu-scene-graph/scene-graph-data.ts
@@ -1,0 +1,45 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {GPUSceneRecord} from '@luma.gl/experimental';
+
+export const SCENE_GRAPH_GROUPS = ['terrain', 'structures', 'signals'] as const;
+export const SCENE_GRAPH_OBJECTS_PER_GROUP = 48;
+export const SCENE_GRAPH_CAPACITY = SCENE_GRAPH_GROUPS.length * SCENE_GRAPH_OBJECTS_PER_GROUP;
+
+/** The application hierarchy intentionally remains outside the flat GPUScene record contract. */
+export type SceneGraphNode = {
+  name: string;
+  children?: SceneGraphNode[];
+  record?: GPUSceneRecord;
+};
+
+/** Makes stable renderer-group branches whose leaf IDs differ from their physical scene slots. */
+export function makeSceneGraphRoots(): SceneGraphNode[] {
+  return SCENE_GRAPH_GROUPS.map((group, groupIndex) => ({
+    name: group,
+    children: Array.from({length: SCENE_GRAPH_OBJECTS_PER_GROUP}, (_, localIndex) => {
+      const sceneIndex = groupIndex * SCENE_GRAPH_OBJECTS_PER_GROUP + localIndex;
+      const column = localIndex % 12;
+      const row = groupIndex * 4 + Math.floor(localIndex / 12);
+      const centerX = -0.92 + column * 0.165;
+      const centerY = -0.91 + row * 0.164;
+      const halfWidth = 0.046 + ((sceneIndex * 7) % 5) * 0.005;
+      const halfHeight = 0.046 + ((sceneIndex * 11) % 4) * 0.006;
+      return {
+        name: `${group}-${localIndex}`,
+        record: {
+          id: 10_000 + sceneIndex * 3,
+          groupId: groupIndex,
+          geometryId: 0,
+          commandSlot: sceneIndex,
+          bounds: {
+            minimum: [centerX - halfWidth, centerY - halfHeight, 0],
+            maximum: [centerX + halfWidth, centerY + halfHeight, 1]
+          }
+        }
+      };
+    })
+  }));
+}

--- a/examples/experimental/gpu-scene-graph/scene-graph-shaders.ts
+++ b/examples/experimental/gpu-scene-graph/scene-graph-shaders.ts
@@ -1,0 +1,94 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+/** Draws generic scene bounds and stable application IDs without domain-specific scene fields. */
+export const SCENE_GRAPH_RENDER_SHADER = /* wgsl */ `
+struct SceneView {
+  bounds: vec4<f32>,
+  options: vec4<u32>,
+};
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec3<f32>,
+  @location(1) corner: vec2<f32>,
+};
+
+@group(0) @binding(0) var<storage, read> records: array<vec4<u32>>;
+@group(0) @binding(1) var<uniform> view: SceneView;
+
+@vertex fn vertexMain(
+  @builtin(vertex_index) vertexIndex: u32,
+  @builtin(instance_index) sceneIndex: u32
+) -> VertexOutput {
+  let corners = array<vec2<f32>, 6>(
+    vec2f(0.0, 0.0), vec2f(1.0, 0.0), vec2f(0.0, 1.0),
+    vec2f(0.0, 1.0), vec2f(1.0, 0.0), vec2f(1.0, 1.0)
+  );
+  let colors = array<vec3<f32>, 3>(
+    vec3f(0.20, 0.74, 0.96), vec3f(0.73, 0.45, 1.0), vec3f(1.0, 0.63, 0.26)
+  );
+  let base = sceneIndex * 8u;
+  let header = records[base];
+  let minimum = bitcast<vec4<f32>>(records[base + 2u]);
+  let maximum = bitcast<vec4<f32>>(records[base + 3u]);
+  let corner = corners[vertexIndex];
+  let position = mix(minimum.xy, maximum.xy, corner);
+  let span = max(view.bounds.zw - view.bounds.xy, vec2f(0.001));
+  var output: VertexOutput;
+  output.position = vec4f((position - view.bounds.xy) / span * 2.0 - 1.0, 0.0, 1.0);
+  output.color = select(colors[min(header.z, 2u)], vec3f(1.0, 0.95, 0.57), header.x == view.options.x);
+  output.corner = corner;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  let edge = min(min(input.corner.x, 1.0 - input.corner.x),
+                 min(input.corner.y, 1.0 - input.corner.y));
+  return vec4f(input.color * mix(0.58, 1.0, smoothstep(0.0, 0.16, edge)), 0.95);
+}`;
+
+/** Produces one source-aligned visibility flag from active bounds and renderer-owned groups. */
+export function getSceneGraphVisibilityShader(capacity: number): string {
+  return /* wgsl */ `
+struct SceneView { bounds: vec4<f32>, options: vec4<u32> };
+@group(0) @binding(0) var<storage, read> records: array<vec4<u32>>;
+@group(0) @binding(1) var<uniform> view: SceneView;
+@group(0) @binding(2) var<storage, read_write> visibility: array<u32>;
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) globalId: vec3u) {
+  let sceneIndex = globalId.x;
+  if (sceneIndex >= ${capacity}u) { return; }
+  let base = sceneIndex * 8u;
+  let header = records[base];
+  let minimum = bitcast<vec4<f32>>(records[base + 2u]);
+  let maximum = bitcast<vec4<f32>>(records[base + 3u]);
+  let intersects = all(maximum.xy >= view.bounds.xy) && all(minimum.xy <= view.bounds.zw);
+  let groupVisible = header.z < 32u && (view.options.y & (1u << header.z)) != 0u;
+  visibility[sceneIndex] = select(0u, 1u, (header.y & 1u) != 0u && intersects && groupVisible);
+}`;
+}
+
+/** Picks only currently visible scene rows and preserves deterministic stable source ordering. */
+export function getSceneGraphPickingShader(capacity: number): string {
+  return /* wgsl */ `
+struct PickRequest { point: vec2<f32>, active: u32, padding: u32 };
+@group(0) @binding(0) var<storage, read> records: array<vec4<u32>>;
+@group(0) @binding(1) var<storage, read> visibility: array<u32>;
+@group(0) @binding(2) var<storage, read> request: PickRequest;
+@group(0) @binding(3) var<storage, read_write> result: atomic<u32>;
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) globalId: vec3u) {
+  let sceneIndex = globalId.x;
+  if (sceneIndex >= ${capacity}u || request.active == 0u || visibility[sceneIndex] == 0u) {
+    return;
+  }
+  let base = sceneIndex * 8u;
+  let minimum = bitcast<vec4<f32>>(records[base + 2u]);
+  let maximum = bitcast<vec4<f32>>(records[base + 3u]);
+  if (all(request.point >= minimum.xy) && all(request.point <= maximum.xy)) {
+    atomicMin(&result, sceneIndex);
+  }
+}`;
+}

--- a/examples/experimental/gpu-trace-scene/app.ts
+++ b/examples/experimental/gpu-trace-scene/app.ts
@@ -1,0 +1,578 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device, type RenderBundle} from '@luma.gl/core';
+import {AnimationLoopTemplate, Computation, Model, type AnimationProps} from '@luma.gl/engine';
+import {
+  DrawCommandBuffer,
+  GPUCommandGraph,
+  GPUCommandGraphInspector,
+  GPUReadbackRing,
+  GPUSceneResourceGroups,
+  GPUTraceInteraction,
+  GPUTraceScene,
+  type CompiledGPUCommandGraph,
+  type GPUReadbackTicket,
+  type GraphDataView
+} from '@luma.gl/experimental';
+import {
+  ExamplePanelManager,
+  makeExamplePanelHostHtml,
+  makeHtmlCustomPanel
+} from '../../example-panels';
+import {GPUCommandGraphInspectorPanel} from '../../gpu-command-graph-inspector-panel';
+import {
+  makeTraceDataset,
+  TRACE_DURATION,
+  TRACE_ERROR_SPAN_FLAG,
+  TRACE_EXPANDED_STATE,
+  TRACE_GROUPS,
+  TRACE_INVALID_SPAN_INDEX,
+  TRACE_LANE_COUNT,
+  TRACE_LANES_PER_THREAD,
+  TRACE_PROCESS_COUNT,
+  TRACE_RUNTIME_SPAN_FLAG,
+  TRACE_THREAD_COUNT,
+  TRACE_THREADS_PER_PROCESS
+} from '../gpu-trace-viewer/trace-data';
+import {getTraceScenePickingShader, TRACE_SCENE_RENDER_SHADER} from './trace-scene-shaders';
+
+export const title = 'GPU Scene Trace Explorer';
+export const description =
+  'Canonical GPU trace scenes with reusable interaction policies, resource groups, stable indirect draws, and GPU picking.';
+
+const STORAGE_USAGE = Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST;
+const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
+const DEFAULT_SPAN_COUNT = 768;
+const MAXIMUM_FOCUS_DEPTH = 4;
+
+type OwnedView<Format extends 'uint32' | 'float32'> = {
+  buffer: Buffer;
+  view: GraphDataView<Format>;
+};
+
+type SceneTraceResources = {
+  compiled: CompiledGPUCommandGraph<void>;
+  trace: GPUTraceScene;
+  commands: DrawCommandBuffer;
+  renderBundle: RenderBundle;
+  buffers: Buffer[];
+  timeWindow: Buffer;
+  policy: Buffer;
+  processStates: Buffer;
+  threadStates: Buffer;
+  selectedSpans: Buffer;
+  selectedCount: Buffer;
+  focusDepth: Buffer;
+  visibleCount: Buffer;
+  groupCounts: Buffer;
+  pickRequest: Buffer;
+  pickResult: Buffer;
+};
+
+/** Bounded, independently registered consumer proving canonical trace and generic scene composition. */
+export default class GPUTraceSceneAnimationLoopTemplate extends AnimationLoopTemplate {
+  static info = makeExamplePanelHostHtml();
+  static props = {createFramebuffer: true, debug: true};
+
+  readonly device: Device;
+  readonly graphInspector = new GPUCommandGraphInspector({maxSamples: 90});
+
+  private readonly model: Model;
+  private readonly viewUniforms: Buffer;
+  private readonly readbackRing: GPUReadbackRing;
+  private readonly panels: ExamplePanelManager;
+  private readonly processExpansion = new Uint32Array(TRACE_PROCESS_COUNT).fill(
+    TRACE_EXPANDED_STATE
+  );
+  private readonly threadExpansion = new Uint32Array(TRACE_THREAD_COUNT).fill(TRACE_EXPANDED_STATE);
+  private resources: SceneTraceResources;
+  private inspectorPanel: GPUCommandGraphInspectorPanel | null = null;
+  private controls: HTMLElement | null = null;
+  private canvas: HTMLCanvasElement | null = null;
+  private timeMinimum = 0;
+  private timeMaximum = 240;
+  private minimumDuration = 0;
+  private focusEnabled = false;
+  private errorsOnly = false;
+  private hideRuntime = false;
+  private selectedSpan = TRACE_INVALID_SPAN_INDEX;
+  private pendingPick: {time: number; lane: number} | null = null;
+  private frameIndex = 0;
+
+  constructor({
+    device,
+    traceCapacity = DEFAULT_SPAN_COUNT
+  }: AnimationProps & {traceCapacity?: number}) {
+    super();
+    if (device.type !== 'webgpu') throw new Error('GPU Scene Trace Explorer requires WebGPU');
+    if (!device.features.has('indirect-first-instance')) {
+      throw new Error('GPU Scene Trace Explorer requires indirect-first-instance');
+    }
+    this.device = device;
+    this.viewUniforms = device.createBuffer({
+      id: 'scene-trace-view',
+      byteLength: 32,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    this.readbackRing = new GPUReadbackRing(device, {
+      id: 'scene-trace-readback',
+      byteLength: Math.max(TRACE_GROUPS.length * UINT32_BYTE_LENGTH, UINT32_BYTE_LENGTH),
+      slotCount: 3
+    });
+    this.model = new Model(device, {
+      id: 'scene-trace-spans',
+      source: TRACE_SCENE_RENDER_SHADER,
+      topology: 'triangle-list',
+      vertexCount: 6,
+      colorAttachmentFormats: [device.preferredColorFormat],
+      depthStencilAttachmentFormat: 'depth24plus',
+      shaderLayout: {
+        attributes: [],
+        bindings: [
+          {name: 'sceneRecords', type: 'read-only-storage', group: 0, location: 0},
+          {name: 'spans', type: 'read-only-storage', group: 0, location: 1},
+          {name: 'threadOffsets', type: 'read-only-storage', group: 0, location: 2},
+          {name: 'view', type: 'uniform', group: 0, location: 3}
+        ]
+      }
+    });
+    this.resources = this.createResources(traceCapacity);
+    this.panels = new ExamplePanelManager({
+      panel: makeHtmlCustomPanel({
+        id: 'scene-trace-controls',
+        title: 'GPU Scene Trace Explorer',
+        html: makeControlMarkup(),
+        onRender: root => this.attachControls(root)
+      })
+    });
+    this.panels.mount();
+  }
+
+  override async onInitialize({canvas}: AnimationProps): Promise<void> {
+    if (canvas instanceof HTMLCanvasElement) {
+      this.canvas = canvas;
+      canvas.addEventListener('click', this.handleClick);
+      canvas.addEventListener('wheel', this.handleWheel, {passive: false});
+    }
+  }
+
+  override onRender({device}: AnimationProps): void {
+    this.writeControls();
+    this.resources.pickResult.write(Uint32Array.of(TRACE_INVALID_SPAN_INDEX));
+    const pick = this.pendingPick;
+    const request = new ArrayBuffer(16);
+    const requestFloats = new Float32Array(request);
+    const requestWords = new Uint32Array(request);
+    if (pick) {
+      requestFloats[0] = pick.time;
+      requestFloats[1] = pick.lane;
+      requestWords[2] = 1;
+    }
+    this.resources.pickRequest.write(new Uint8Array(request));
+
+    const encoding = this.resources.compiled.encode(device.commandEncoder, {parameters: undefined});
+    this.graphInspector.recordEncoding(this.resources.compiled.id, encoding);
+    if (pick) {
+      const ticket = this.readbackRing.tryAcquire();
+      if (ticket) {
+        this.pendingPick = null;
+        ticket.copyFrom(device.commandEncoder, this.resources.pickResult, {byteLength: 4});
+        queueMicrotask(() => void this.readSelection(ticket));
+      }
+    }
+    if (this.frameIndex++ % 30 === 0) {
+      const ticket = this.readbackRing.tryAcquire();
+      if (ticket) {
+        ticket.copyFrom(device.commandEncoder, this.resources.groupCounts);
+        queueMicrotask(() => void this.readGroupCounts(ticket));
+      }
+      this.inspectorPanel?.update(this.graphInspector.getSnapshot(), this.resources.compiled.id);
+    }
+  }
+
+  override onFinalize(): void {
+    this.canvas?.removeEventListener('click', this.handleClick);
+    this.canvas?.removeEventListener('wheel', this.handleWheel);
+    this.panels.finalize();
+    this.resources.compiled.destroy();
+    this.resources.renderBundle.destroy();
+    this.resources.commands.destroy();
+    this.resources.trace.destroy();
+    for (const buffer of this.resources.buffers) buffer.destroy();
+    this.readbackRing.destroy();
+    this.model.destroy();
+    this.viewUniforms.destroy();
+  }
+
+  private createResources(capacity: number): SceneTraceResources {
+    const dataset = makeTraceDataset(capacity);
+    const trace = new GPUTraceScene(this.device, {
+      id: 'scene-trace',
+      spans: dataset.spans,
+      parents: dataset.parentSpans,
+      links: dataset.dependencies,
+      partitions: dataset.groups.map(group => ({
+        firstSpan: group.firstSpanIndex,
+        spanCount: group.count,
+        groupId: group.groupIndex
+      })),
+      processCount: dataset.processCount,
+      threadCount: dataset.threadCount,
+      geometryId: 0,
+      outgoing: dataset.outgoing,
+      incoming: dataset.incoming
+    });
+    const graph = new GPUCommandGraph<void>(this.device, {id: 'scene-trace-command-graph'});
+    const source = trace.importToGraph(graph);
+    const commands = new DrawCommandBuffer(this.device, {
+      id: 'scene-trace-draws',
+      type: 'draw',
+      commands: Array.from({length: capacity}, () => ({vertexCount: 6, instanceCount: 0}))
+    });
+    const commandViews = commands.importToGraph(graph);
+    const buffers: Buffer[] = [];
+    const makeUint32 = (identifier: string, values: Uint32Array): OwnedView<'uint32'> =>
+      makeOwnedView(this.device, graph, buffers, identifier, values, 'uint32');
+    const timeWindow = makeOwnedView(
+      this.device,
+      graph,
+      buffers,
+      'time-window',
+      Float32Array.of(this.timeMinimum, this.timeMaximum, 0),
+      'float32'
+    );
+    const policy = makeUint32('policy', new Uint32Array(3));
+    const processStates = makeUint32('process-states', this.processExpansion);
+    const threadStates = makeUint32('thread-states', this.threadExpansion);
+    const selectedSpans = makeUint32('selected-spans', new Uint32Array(1));
+    const selectedCount = makeUint32('selected-count', new Uint32Array(1));
+    const focusDepth = makeUint32('focus-depth', Uint32Array.of(2));
+    const threadHeights = makeUint32('thread-heights', new Uint32Array(TRACE_THREAD_COUNT));
+    const threadOffsets = makeUint32('thread-offsets', new Uint32Array(TRACE_THREAD_COUNT));
+    const reachedSpans = makeUint32('reached-spans', new Uint32Array(capacity));
+    const visibleMask = makeUint32('visible-mask', new Uint32Array(capacity));
+    const visibleSpans = makeUint32('visible-spans', new Uint32Array(capacity));
+    const visibleCount = makeUint32('visible-count', new Uint32Array(1));
+    const projectedAncestors = makeUint32('projected-ancestors', new Uint32Array(capacity));
+    const requiredCount = makeUint32('required-count', new Uint32Array(1));
+    const publishedCount = makeUint32('published-count', new Uint32Array(1));
+    const drawOverflow = makeUint32('draw-overflow', new Uint32Array(1));
+
+    new GPUTraceInteraction({
+      id: 'scene-trace-interaction',
+      trace: source,
+      timeWindow: timeWindow.view,
+      policy: policy.view,
+      processStates: processStates.view,
+      threadStates: threadStates.view,
+      selectedSpans: selectedSpans.view,
+      selectedCount: selectedCount.view,
+      focusDepth: focusDepth.view,
+      threadHeights: threadHeights.view,
+      threadOffsets: threadOffsets.view,
+      reachedSpans: reachedSpans.view,
+      visibleMask: visibleMask.view,
+      visibleSpans: visibleSpans.view,
+      visibleCount: visibleCount.view,
+      projectedAncestors: projectedAncestors.view,
+      draw: {
+        commands: commandViews,
+        requiredCount: requiredCount.view,
+        publishedCount: publishedCount.view,
+        overflow: drawOverflow.view
+      },
+      threadsPerProcess: TRACE_THREADS_PER_PROCESS,
+      lanesPerThread: TRACE_LANES_PER_THREAD,
+      maxFocusDepth: MAXIMUM_FOCUS_DEPTH
+    }).addToGraph(graph);
+
+    const groupCounts = makeUint32('group-counts', new Uint32Array(dataset.groups.length));
+    const groupOverflows = makeUint32('group-overflows', new Uint32Array(dataset.groups.length));
+    const groupOverflow = makeUint32('group-overflow', new Uint32Array(1));
+    new GPUSceneResourceGroups({
+      id: 'scene-trace-resource-groups',
+      scene: source.scene,
+      commands: commandViews,
+      groups: dataset.groups.map(group => ({
+        id: group.groupIndex,
+        firstCommand: group.firstSpanIndex,
+        commandCount: group.count,
+        geometryId: 0
+      })),
+      counts: groupCounts.view,
+      overflows: groupOverflows.view,
+      overflow: groupOverflow.view
+    }).addToGraph(graph);
+
+    const pickRequest = makeUint32('pick-request', new Uint32Array(4));
+    const pickResult = makeUint32('pick-result', Uint32Array.of(TRACE_INVALID_SPAN_INDEX));
+    graph.addComputePass({
+      id: 'scene-trace-picking',
+      resources: [
+        {buffer: source.spans, usage: 'storage-read'},
+        {buffer: threadOffsets.view, usage: 'storage-read'},
+        {buffer: visibleMask.view, usage: 'storage-read'},
+        {buffer: pickRequest.view, usage: 'storage-read'},
+        {buffer: pickResult.view, usage: 'storage-write'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: 'scene-trace-picking',
+          source: getTraceScenePickingShader(capacity),
+          shaderLayout: {
+            bindings: [
+              {name: 'spans', type: 'storage', group: 0, location: 0},
+              {name: 'threadOffsets', type: 'storage', group: 0, location: 1},
+              {name: 'visibleMask', type: 'storage', group: 0, location: 2},
+              {name: 'request', type: 'storage', group: 0, location: 3},
+              {name: 'result', type: 'storage', group: 0, location: 4}
+            ]
+          }
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({
+              spans: getBuffer(source.spans),
+              threadOffsets: getBuffer(threadOffsets.view),
+              visibleMask: getBuffer(visibleMask.view),
+              request: getBuffer(pickRequest.view),
+              result: getBuffer(pickResult.view)
+            });
+            computation.dispatch(computePass, Math.ceil(capacity / 256));
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+
+    const renderBundle = this.createRenderBundle(trace, commands, threadOffsets.buffer);
+    const viewHandle = graph.importBuffer(
+      {
+        id: 'view-uniforms',
+        byteLength: this.viewUniforms.byteLength,
+        usage: this.viewUniforms.usage
+      },
+      this.viewUniforms
+    );
+    graph.addRenderPass({
+      id: 'scene-trace-render',
+      resources: [
+        {buffer: source.scene.records, usage: 'storage-read'},
+        {buffer: source.spans, usage: 'storage-read'},
+        {buffer: threadOffsets.view, usage: 'storage-read'},
+        {buffer: viewHandle, usage: 'uniform'},
+        {buffer: commandViews.buffer, usage: 'indirect'}
+      ],
+      compile: () => ({
+        getRenderPassProps: () => ({
+          id: 'scene-trace-render',
+          clearColor: [0.012, 0.018, 0.035, 1],
+          clearDepth: false,
+          clearStencil: false
+        }),
+        encode: ({renderPass}) => renderPass.executeBundles([renderBundle])
+      })
+    });
+    const compiled = graph.compile();
+    this.graphInspector.registerGraph(compiled);
+    return {
+      compiled,
+      trace,
+      commands,
+      renderBundle,
+      buffers,
+      timeWindow: timeWindow.buffer,
+      policy: policy.buffer,
+      processStates: processStates.buffer,
+      threadStates: threadStates.buffer,
+      selectedSpans: selectedSpans.buffer,
+      selectedCount: selectedCount.buffer,
+      focusDepth: focusDepth.buffer,
+      visibleCount: visibleCount.buffer,
+      groupCounts: groupCounts.buffer,
+      pickRequest: pickRequest.buffer,
+      pickResult: pickResult.buffer
+    };
+  }
+
+  private createRenderBundle(
+    trace: GPUTraceScene,
+    commands: DrawCommandBuffer,
+    offsets: Buffer
+  ): RenderBundle {
+    const encoder = this.device.createRenderBundleEncoder({
+      id: 'scene-trace-render-bundle',
+      colorAttachmentFormats: [this.device.preferredColorFormat],
+      depthStencilAttachmentFormat: 'depth24plus'
+    });
+    encoder.setPipeline(this.model.pipeline);
+    encoder.setVertexArray(this.model.vertexArray);
+    encoder.setBindings({
+      sceneRecords: trace.scene.recordBuffer,
+      spans: trace.buffers.spans,
+      threadOffsets: offsets,
+      view: this.viewUniforms
+    });
+    for (let commandIndex = 0; commandIndex < commands.capacity; commandIndex++) {
+      commands.draw(encoder, commandIndex);
+    }
+    return encoder.finish();
+  }
+
+  private writeControls(): void {
+    this.resources.timeWindow.write(
+      Float32Array.of(this.timeMinimum, this.timeMaximum, this.minimumDuration)
+    );
+    this.resources.policy.write(
+      Uint32Array.of(
+        this.errorsOnly ? TRACE_ERROR_SPAN_FLAG : 0,
+        this.hideRuntime ? TRACE_RUNTIME_SPAN_FLAG : 0,
+        Number(this.focusEnabled)
+      )
+    );
+    const values = new ArrayBuffer(32);
+    new Float32Array(values).set([this.timeMinimum, this.timeMaximum, 0, TRACE_LANE_COUNT]);
+    new Uint32Array(values)[4] = this.selectedSpan;
+    this.viewUniforms.write(new Uint8Array(values));
+  }
+
+  private attachControls(root: HTMLElement): () => void {
+    this.controls = root;
+    const inspectorHost = root.querySelector<HTMLElement>('[data-scene-trace-inspector]')!;
+    this.inspectorPanel = new GPUCommandGraphInspectorPanel(inspectorHost, {
+      graphLabels: {[this.resources.compiled.id]: 'Scene interaction + picking + draw'}
+    });
+    this.inspectorPanel.update(this.graphInspector.getSnapshot(), this.resources.compiled.id);
+    root.addEventListener('change', this.handleControlChange);
+    root.addEventListener('input', this.handleControlChange);
+    return () => {
+      root.removeEventListener('change', this.handleControlChange);
+      root.removeEventListener('input', this.handleControlChange);
+      this.inspectorPanel?.destroy();
+      this.inspectorPanel = null;
+      this.controls = null;
+    };
+  }
+
+  private handleControlChange = (event: Event): void => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    if (target.dataset.process !== undefined) {
+      this.processExpansion[Number(target.dataset.process)] = Number(target.checked);
+      this.resources.processStates.write(this.processExpansion);
+    } else if (target.dataset.thread !== undefined) {
+      this.threadExpansion[Number(target.dataset.thread)] = Number(target.checked);
+      this.resources.threadStates.write(this.threadExpansion);
+    } else if (target.dataset.errorsOnly !== undefined) {
+      this.errorsOnly = target.checked;
+    } else if (target.dataset.hideRuntime !== undefined) {
+      this.hideRuntime = target.checked;
+    } else if (target.dataset.focus !== undefined) {
+      this.focusEnabled = target.checked;
+    } else if (target.dataset.depth !== undefined) {
+      this.resources.focusDepth.write(Uint32Array.of(Number(target.value)));
+    } else if (target.dataset.minimumDuration !== undefined) {
+      this.minimumDuration = Number(target.value);
+    }
+  };
+
+  private handleClick = (event: MouseEvent): void => {
+    const bounds = this.canvas?.getBoundingClientRect();
+    if (!bounds?.width || !bounds.height) return;
+    this.pendingPick = {
+      time:
+        this.timeMinimum +
+        ((event.clientX - bounds.left) / bounds.width) * (this.timeMaximum - this.timeMinimum),
+      lane: ((event.clientY - bounds.top) / bounds.height) * TRACE_LANE_COUNT
+    };
+  };
+
+  private handleWheel = (event: WheelEvent): void => {
+    event.preventDefault();
+    const range = this.timeMaximum - this.timeMinimum;
+    const delta = event.deltaY * range * 0.001;
+    this.timeMinimum = Math.max(0, Math.min(TRACE_DURATION - range, this.timeMinimum + delta));
+    this.timeMaximum = this.timeMinimum + range;
+  };
+
+  private async readSelection(ticket: GPUReadbackTicket): Promise<void> {
+    try {
+      const bytes = await ticket.read();
+      this.selectedSpan = new Uint32Array(bytes.buffer, bytes.byteOffset, 1)[0];
+      this.resources.selectedSpans.write(Uint32Array.of(this.selectedSpan));
+      this.resources.selectedCount.write(
+        Uint32Array.of(Number(this.selectedSpan !== TRACE_INVALID_SPAN_INDEX))
+      );
+      const selection = this.controls?.querySelector<HTMLElement>('[data-scene-trace-selection]');
+      if (selection)
+        selection.textContent =
+          this.selectedSpan === TRACE_INVALID_SPAN_INDEX ? 'None' : `Span ${this.selectedSpan}`;
+    } catch {
+      // Device loss releases the staging slot without applying an obsolete selection.
+    }
+  }
+
+  private async readGroupCounts(ticket: GPUReadbackTicket): Promise<void> {
+    try {
+      const bytes = await ticket.read();
+      const counts = new Uint32Array(bytes.buffer, bytes.byteOffset, TRACE_GROUPS.length);
+      const summary = this.controls?.querySelector<HTMLElement>('[data-scene-trace-groups]');
+      if (summary) {
+        summary.textContent = TRACE_GROUPS.map((group, index) => `${group}: ${counts[index]}`).join(
+          ' · '
+        );
+      }
+    } catch {
+      // Optional diagnostics must not disrupt rendering on cancellation or device loss.
+    }
+  }
+}
+
+function makeOwnedView<Format extends 'uint32' | 'float32'>(
+  device: Device,
+  graph: GPUCommandGraph<void>,
+  ownedBuffers: Buffer[],
+  identifier: string,
+  values: Format extends 'float32' ? Float32Array : Uint32Array,
+  format: Format
+): OwnedView<Format> {
+  const buffer = device.createBuffer({
+    id: `scene-trace-${identifier}`,
+    data: values,
+    usage: STORAGE_USAGE
+  });
+  ownedBuffers.push(buffer);
+  const handle = graph.importBuffer(
+    {id: identifier, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return {buffer, view: graph.createDataView(handle, {format, length: values.length})};
+}
+
+function makeControlMarkup(): string {
+  const processes = Array.from(
+    {length: TRACE_PROCESS_COUNT},
+    (_, index) =>
+      `<label><input type="checkbox" data-process="${index}" checked /> P${index}</label>`
+  ).join(' ');
+  const threads = Array.from(
+    {length: TRACE_THREADS_PER_PROCESS},
+    (_, index) =>
+      `<label><input type="checkbox" data-thread="${index}" checked /> T${index}</label>`
+  ).join(' ');
+  return `<section data-scene-trace-panel style="display:grid;gap:10px;font-size:12px">
+    <p>Scroll to pan. Click a span to select it, then enable dependency focus.</p>
+    <label><input type="checkbox" data-errors-only /> Errors only</label>
+    <label><input type="checkbox" data-hide-runtime /> Hide runtime spans</label>
+    <label><input type="checkbox" data-focus /> Focus linked spans</label>
+    <label>Dependency hops <input type="range" min="0" max="${MAXIMUM_FOCUS_DEPTH}" value="2" data-depth /></label>
+    <label>Minimum duration <input type="range" min="0" max="20" value="0" data-minimum-duration /></label>
+    <div><strong>Processes</strong><div style="display:flex;flex-wrap:wrap;gap:6px">${processes}</div></div>
+    <div><strong>Process 0 threads</strong><div style="display:flex;gap:8px">${threads}</div></div>
+    <div>Selection: <span data-scene-trace-selection>None</span></div>
+    <div data-scene-trace-groups>Waiting for GPU group counts…</div>
+    <div data-scene-trace-inspector></div>
+  </section>`;
+}

--- a/examples/experimental/gpu-trace-scene/trace-scene-shaders.ts
+++ b/examples/experimental/gpu-trace-scene/trace-scene-shaders.ts
@@ -1,0 +1,102 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {TRACE_ERROR_SPAN_FLAG, TRACE_LANES_PER_THREAD} from '../gpu-trace-viewer/trace-data';
+
+/** Draws directly from generic scene bounds while retaining canonical trace ownership metadata. */
+export const TRACE_SCENE_RENDER_SHADER = /* wgsl */ `
+struct TraceView {
+  limits: vec4<f32>,
+  selection: vec4<u32>,
+};
+
+struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec3<f32>,
+  @location(1) coordinates: vec2<f32>,
+};
+
+@group(0) @binding(0) var<storage, read> sceneRecords: array<vec4<u32>>;
+@group(0) @binding(1) var<storage, read> spans: array<vec4<u32>>;
+@group(0) @binding(2) var<storage, read> threadOffsets: array<u32>;
+@group(0) @binding(3) var<uniform> view: TraceView;
+
+@vertex fn vertexMain(
+  @builtin(vertex_index) vertexIndex: u32,
+  @builtin(instance_index) sourceIndex: u32
+) -> VertexOutput {
+  let corners = array<vec2<f32>, 6>(
+    vec2f(0.0, 0.0), vec2f(1.0, 0.0), vec2f(0.0, 1.0),
+    vec2f(0.0, 1.0), vec2f(1.0, 0.0), vec2f(1.0, 1.0)
+  );
+  let colors = array<vec3<f32>, 3>(
+    vec3f(0.22, 0.72, 1.0), vec3f(0.76, 0.43, 1.0), vec3f(1.0, 0.62, 0.21)
+  );
+  let corner = corners[vertexIndex];
+  let recordBase = sourceIndex * 8u;
+  let boundsMinimum = bitcast<vec4<f32>>(sceneRecords[recordBase + 2u]);
+  let boundsMaximum = bitcast<vec4<f32>>(sceneRecords[recordBase + 3u]);
+  let ownership = spans[sourceIndex * 2u + 1u];
+  let originalLane = u32(boundsMinimum.y);
+  let effectiveLane = f32(threadOffsets[ownership.y] + originalLane % ${TRACE_LANES_PER_THREAD}u);
+  let timestamp = mix(boundsMinimum.x, boundsMaximum.x, corner.x);
+  let lane = effectiveLane + 0.12 + corner.y * 0.76;
+  let timeRange = max(view.limits.y - view.limits.x, 0.001);
+  let laneRange = max(view.limits.w - view.limits.z, 1.0);
+  let groupId = sceneRecords[recordBase].z;
+  let selected = ownership.z == view.selection.x;
+  let hasError = (ownership.w & ${TRACE_ERROR_SPAN_FLAG}u) != 0u;
+
+  var output: VertexOutput;
+  output.position = vec4f(
+    (timestamp - view.limits.x) / timeRange * 2.0 - 1.0,
+    1.0 - (lane - view.limits.z) / laneRange * 2.0,
+    0.0,
+    1.0
+  );
+  output.color = select(colors[min(groupId, 2u)], vec3f(1.0, 0.31, 0.37), hasError);
+  output.color = select(output.color, vec3f(1.0, 0.96, 0.62), selected);
+  output.coordinates = corner;
+  return output;
+}
+
+@fragment fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  let edge = min(min(input.coordinates.x, 1.0 - input.coordinates.x),
+                 min(input.coordinates.y, 1.0 - input.coordinates.y));
+  let brightness = mix(0.68, 1.0, smoothstep(0.0, 0.12, edge));
+  return vec4f(input.color * brightness, 0.92);
+}`;
+
+/** Resolves a requested timeline coordinate against GPU-visible canonical source rows. */
+export function getTraceScenePickingShader(spanCount: number): string {
+  return /* wgsl */ `
+struct PickRequest {
+  time: f32,
+  lane: f32,
+  active: u32,
+  padding: u32,
+};
+
+@group(0) @binding(0) var<storage, read> spans: array<vec4<u32>>;
+@group(0) @binding(1) var<storage, read> threadOffsets: array<u32>;
+@group(0) @binding(2) var<storage, read> visibleMask: array<u32>;
+@group(0) @binding(3) var<storage, read> request: PickRequest;
+@group(0) @binding(4) var<storage, read_write> result: atomic<u32>;
+
+@compute @workgroup_size(256) fn main(@builtin(global_invocation_id) globalId: vec3u) {
+  let sourceIndex = globalId.x;
+  if (sourceIndex >= ${spanCount}u || request.active == 0u || visibleMask[sourceIndex] == 0u) {
+    return;
+  }
+  let timing = spans[sourceIndex * 2u];
+  let ownership = spans[sourceIndex * 2u + 1u];
+  let start = bitcast<f32>(timing.x);
+  let duration = bitcast<f32>(timing.y);
+  let lane = f32(threadOffsets[ownership.y] + timing.z % ${TRACE_LANES_PER_THREAD}u);
+  if (request.time >= start && request.time <= start + duration &&
+      request.lane >= lane && request.lane < lane + 1.0) {
+    atomicMin(&result, sourceIndex);
+  }
+}`;
+}

--- a/modules/experimental/test/gpu-primitives/gpu-scene-adapters.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-scene-adapters.spec.ts
@@ -3,11 +3,18 @@
 // Copyright (c) vis.gl contributors
 
 import test from '@luma.gl/devtools-extensions/tape-test-utils';
+import {Buffer, type Device} from '@luma.gl/core';
 import {
+  DrawCommandBuffer,
+  GPUCommandGraph,
   GPUScene,
+  GPUSceneDrawGeneration,
+  GPUSceneResourceGroups,
+  GPUVisibilityWorkflow,
   GPU_SCENE_RECORD_BYTE_LENGTH,
   makeGPUSceneFromCPUScene,
   makeGPUScenePartitionsFromGPUTable,
+  type GraphDataView,
   type GPUSceneRecord
 } from '@luma.gl/experimental';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
@@ -132,6 +139,114 @@ test('GPU scene adapters preserve CPU identity and table batch topology without 
   t.end();
 });
 
+test('CPU scene hierarchies reuse generic visibility, indirect draws, and renderer groups after mutation', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const bounds = {minimum: [0, 0, 0], maximum: [1, 1, 1]} as const;
+  const roots: CPUNode[] = [
+    {
+      children: [
+        {record: {id: 10, bounds, groupId: 0, geometryId: 7, commandSlot: 0}},
+        {record: {id: 20, bounds, groupId: 0, geometryId: 7, commandSlot: 1}}
+      ]
+    },
+    {
+      children: [
+        {record: {id: 30, bounds, groupId: 1, geometryId: 7, commandSlot: 2}},
+        {record: {id: 40, bounds, groupId: 1, geometryId: 7, commandSlot: 3}}
+      ]
+    }
+  ];
+  const scene = makeGPUSceneFromCPUScene(device, {
+    id: 'cpu-consumer-scene',
+    roots,
+    getChildren: node => node.children,
+    getRecord: node => node.record ?? null
+  });
+  const commands = new DrawCommandBuffer(device, {
+    type: 'draw',
+    commands: Array.from({length: 4}, () => ({vertexCount: 6, instanceCount: 0}))
+  });
+  const graph = new GPUCommandGraph(device, {id: 'cpu-consumer-command-graph'});
+  const source = scene.importToGraph(graph);
+  const commandViews = commands.importToGraph(graph);
+  const outputs: Buffer[] = [];
+  const makeOutput = (id: string, values: readonly number[]) =>
+    makeConsumerUint32(device, graph, outputs, id, values);
+  const visibility = makeOutput('visibility', [1, 0, 1, 1]);
+  const visibleRows = makeOutput('visible-rows', [0, 0, 0, 0]);
+  const visibleCount = makeOutput('visible-count', [0]);
+  const required = makeOutput('required', [0]);
+  const published = makeOutput('published', [0]);
+  const drawOverflow = makeOutput('draw-overflow', [0]);
+  const groupCounts = makeOutput('group-counts', [0, 0]);
+  const groupOverflows = makeOutput('group-overflows', [0, 0]);
+  const groupOverflow = makeOutput('group-overflow', [0]);
+
+  new GPUVisibilityWorkflow({
+    predicates: [{kind: 'bounds', mask: visibility.view}],
+    output: visibleRows.view,
+    count: visibleCount.view
+  }).addToGraph(graph);
+  new GPUSceneDrawGeneration({
+    scene: source,
+    visibility: visibility.view,
+    commands: commandViews,
+    requiredCount: required.view,
+    publishedCount: published.view,
+    overflow: drawOverflow.view
+  }).addToGraph(graph);
+  new GPUSceneResourceGroups({
+    scene: source,
+    commands: commandViews,
+    groups: [
+      {id: 0, firstCommand: 0, commandCount: 2, geometryId: 7},
+      {id: 1, firstCommand: 2, commandCount: 2, geometryId: 7}
+    ],
+    counts: groupCounts.view,
+    overflows: groupOverflows.view,
+    overflow: groupOverflow.view
+  }).addToGraph(graph);
+  const compiled = graph.compile();
+  let encoder = device.createCommandEncoder();
+  compiled.encode(encoder, {parameters: undefined});
+  device.submit(encoder.finish());
+
+  t.deepEqual(await readConsumerUint32(visibleRows.buffer, 3), [0, 2, 3]);
+  t.deepEqual(await readConsumerUint32(groupCounts.buffer, 2), [1, 2]);
+  t.deepEqual(await readConsumerUint32(published.buffer, 1), [3]);
+  t.equal(scene.getRecordIndex(40), 3, 'stable application identity differs from scene row');
+
+  const mutation = scene.mutate({remove: [30]});
+  visibility.buffer.write(Uint32Array.from([1, 1, 0, 1]));
+  encoder = device.createCommandEncoder();
+  compiled.encode(encoder, {parameters: undefined});
+  device.submit(encoder.finish());
+
+  t.equal(mutation.uploadedByteLength, 20, 'CPU hierarchy updates publish explicit bounded cost');
+  t.deepEqual(await readConsumerUint32(visibleRows.buffer, 3), [0, 1, 3]);
+  t.deepEqual(await readConsumerUint32(groupCounts.buffer, 2), [2, 1]);
+  t.deepEqual(await readConsumerUint32(groupOverflows.buffer, 2), [0, 0]);
+  t.deepEqual(await readConsumerUint32(groupOverflow.buffer, 1), [0]);
+  const commandWords = await readConsumerUint32(commands.buffer, 16);
+  t.deepEqual(
+    [commandWords[1], commandWords[5], commandWords[9], commandWords[13]],
+    [1, 1, 0, 1],
+    'one compiled graph updates stable renderer-owned command slots without CPU draw selection'
+  );
+
+  compiled.destroy();
+  commands.destroy();
+  scene.destroy();
+  for (const buffer of outputs) buffer.destroy();
+  t.end();
+});
+
 test('GPU scene adapters reject ambiguous CPU and table storage contracts', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -253,4 +368,29 @@ async function readSceneIds(scene: GPUScene): Promise<number[]> {
 async function readSceneRecordBytes(scene: GPUScene): Promise<Uint8Array> {
   const bytes = await scene.recordBuffer.readAsync();
   return bytes.slice(0, scene.recordCount * GPU_SCENE_RECORD_BYTE_LENGTH);
+}
+
+function makeConsumerUint32(
+  device: Device,
+  graph: GPUCommandGraph,
+  outputs: Buffer[],
+  id: string,
+  values: readonly number[]
+): {buffer: Buffer; view: GraphDataView<'uint32'>} {
+  const buffer = device.createBuffer({
+    id: `cpu-consumer-${id}`,
+    data: Uint32Array.from(values),
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  outputs.push(buffer);
+  const handle = graph.importBuffer(
+    {id, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return {buffer, view: graph.createDataView(handle, {format: 'uint32', length: values.length})};
+}
+
+async function readConsumerUint32(buffer: Buffer, length: number): Promise<number[]> {
+  const bytes = await buffer.readAsync();
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, length));
 }

--- a/test/examples/example-catalog-thumbnails.node.spec.ts
+++ b/test/examples/example-catalog-thumbnails.node.spec.ts
@@ -5,6 +5,7 @@
 import {existsSync, readFileSync, statSync} from 'node:fs';
 import path from 'node:path';
 import {describe, expect, test} from 'vitest';
+import {getExampleThumbnailPath} from '../../website/src/example-thumbnails';
 
 type ExampleSidebarEntry =
   | string
@@ -52,6 +53,12 @@ describe('live example catalog thumbnails', () => {
     );
     expect(resolveExampleThumbnailPath('experimental/anari-playground')).toBe(
       path.join(EXAMPLE_IMAGES_DIRECTORY, 'experimental/anari-playground.jpg')
+    );
+    expect(resolveExampleThumbnailPath('experimental/gpu-trace-scene')).toBe(
+      path.join(EXAMPLE_IMAGES_DIRECTORY, 'experimental/gpu-trace-viewer.jpg')
+    );
+    expect(resolveExampleThumbnailPath('experimental/gpu-scene-graph')).toBe(
+      path.join(EXAMPLE_IMAGES_DIRECTORY, 'experimental/gpu-frustum-culling.jpg')
     );
   });
 
@@ -108,12 +115,7 @@ function readLiveExampleIdentifiers(): string[] {
 }
 
 function resolveExampleThumbnailPath(exampleIdentifier: string): string {
-  const thumbnailName =
-    exampleIdentifier === 'v10/gpgpu'
-      ? 'gpu-tables/gpu-vector-storage-particles.jpg'
-      : `${exampleIdentifier}.jpg`;
-
-  return path.join(EXAMPLE_IMAGES_DIRECTORY, thumbnailName);
+  return path.join(EXAMPLE_IMAGES_DIRECTORY, getExampleThumbnailPath(exampleIdentifier));
 }
 
 function countDistinctJpegScanByteValues(imageBytes: Buffer): number {

--- a/test/examples/example-device-tabs.node.spec.ts
+++ b/test/examples/example-device-tabs.node.spec.ts
@@ -56,6 +56,7 @@ function renderBackendTabs(selectedItem: string = 'webgpu-core'): string {
     write: false,
     platform: 'node',
     format: 'cjs',
+    tsconfig: path.join(process.cwd(), 'tsconfig.json'),
     external: ['react', 'clsx']
   });
   const javascript = build.outputFiles.find(output => output.path.endsWith('.js'));

--- a/test/examples/gpu-scene-graph.node.spec.ts
+++ b/test/examples/gpu-scene-graph.node.spec.ts
@@ -1,0 +1,44 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {
+  makeSceneGraphRoots,
+  SCENE_GRAPH_CAPACITY,
+  SCENE_GRAPH_GROUPS,
+  SCENE_GRAPH_OBJECTS_PER_GROUP
+} from '../../examples/experimental/gpu-scene-graph/scene-graph-data';
+import {
+  getSceneGraphPickingShader,
+  getSceneGraphVisibilityShader,
+  SCENE_GRAPH_RENDER_SHADER
+} from '../../examples/experimental/gpu-scene-graph/scene-graph-shaders';
+
+describe('GPU scene graph application model', () => {
+  test('preserves application hierarchy, stable object identity, and renderer-owned group windows', () => {
+    const roots = makeSceneGraphRoots();
+    const leaves = roots.flatMap(root => root.children ?? []);
+
+    expect(roots.map(root => root.name)).toEqual(SCENE_GRAPH_GROUPS);
+    expect(leaves).toHaveLength(SCENE_GRAPH_CAPACITY);
+    expect(new Set(leaves.map(leaf => leaf.record!.id)).size).toBe(SCENE_GRAPH_CAPACITY);
+    for (const [sceneIndex, leaf] of leaves.entries()) {
+      expect(leaf.record!.id).toBe(10_000 + sceneIndex * 3);
+      expect(leaf.record!.commandSlot).toBe(sceneIndex);
+      expect(leaf.record!.groupId).toBe(Math.floor(sceneIndex / SCENE_GRAPH_OBJECTS_PER_GROUP));
+    }
+  });
+
+  test('consumes only generic scene headers, bounds, active flags, and stable source rows', () => {
+    const visibility = getSceneGraphVisibilityShader(144);
+    const picking = getSceneGraphPickingShader(144);
+
+    expect(SCENE_GRAPH_RENDER_SHADER).toContain('header.x == view.options.x');
+    expect(visibility).toContain('sceneIndex >= 144u');
+    expect(visibility).toContain('(header.y & 1u) != 0u');
+    expect(visibility).toContain('(view.options.y & (1u << header.z)) != 0u');
+    expect(picking).toContain('visibility[sceneIndex] == 0u');
+    expect(picking).toContain('atomicMin(&result, sceneIndex)');
+  });
+});

--- a/test/examples/gpu-scene-graph.spec.ts
+++ b/test/examples/gpu-scene-graph.spec.ts
@@ -1,0 +1,68 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import type {AnimationProps} from '@luma.gl/engine';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import GPUSceneGraphAnimationLoopTemplate from '../../examples/experimental/gpu-scene-graph/app';
+import {SCENE_GRAPH_CAPACITY} from '../../examples/experimental/gpu-scene-graph/scene-graph-data';
+
+describe('GPU conventional scene graph explorer', () => {
+  test('adapts a CPU hierarchy and preserves stable group controls and measured scene mutations', async () => {
+    const device = await getWebGPUTestDevice();
+    if (
+      !device ||
+      device.info.gpu === 'software' ||
+      device.info.gpuType === 'cpu' ||
+      device.info.fallback
+    ) {
+      return;
+    }
+
+    const host = document.createElement('div');
+    host.id = 'example-panel-host';
+    document.body.append(host);
+    let explorer: GPUSceneGraphAnimationLoopTemplate | null = null;
+    try {
+      explorer = new GPUSceneGraphAnimationLoopTemplate({device} as AnimationProps);
+      const state = explorer as unknown as {
+        resources: {
+          compiled: {stats: {nodeOrder: string[]}};
+          scene: {
+            activeCount: number;
+            getRecordIndex: (id: number) => number | undefined;
+          };
+          commands: {capacity: number};
+        };
+        enabledGroups: number;
+        selectedObjectId: number;
+      };
+      expect(state.resources.scene.activeCount).toBe(SCENE_GRAPH_CAPACITY);
+      expect(state.resources.scene.getRecordIndex(10_003)).toBe(1);
+      expect(state.resources.commands.capacity).toBe(SCENE_GRAPH_CAPACITY);
+      expect(state.resources.compiled.stats.nodeOrder).toContain('scene-graph-visibility');
+      expect(state.resources.compiled.stats.nodeOrder).toContain('scene-graph-picking');
+      expect(state.resources.compiled.stats.nodeOrder).toContain(
+        'scene-graph-resource-groups-classify'
+      );
+
+      const structures = host.querySelector<HTMLInputElement>('[data-group="1"]');
+      expect(structures).not.toBeNull();
+      structures!.checked = false;
+      structures!.dispatchEvent(new Event('change', {bubbles: true}));
+      expect(state.enabledGroups).toBe(0b101);
+
+      state.selectedObjectId = 10_003;
+      host.querySelector<HTMLButtonElement>('[data-move]')!.click();
+      expect(host.querySelector('[data-scene-graph-mutation]')?.textContent).toContain('bytes');
+      host.querySelector<HTMLButtonElement>('[data-remove]')!.click();
+      expect(state.resources.scene.activeCount).toBe(SCENE_GRAPH_CAPACITY - 1);
+      expect(state.resources.scene.getRecordIndex(10_003)).toBeUndefined();
+      expect(explorer.graphInspector.getSnapshot().graphs).toHaveLength(1);
+    } finally {
+      explorer?.onFinalize();
+      host.remove();
+    }
+  });
+});

--- a/test/examples/gpu-trace-scene.node.spec.ts
+++ b/test/examples/gpu-trace-scene.node.spec.ts
@@ -1,0 +1,31 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {
+  getTraceScenePickingShader,
+  TRACE_SCENE_RENDER_SHADER
+} from '../../examples/experimental/gpu-trace-scene/trace-scene-shaders';
+import {
+  TRACE_ERROR_SPAN_FLAG,
+  TRACE_LANES_PER_THREAD
+} from '../../examples/experimental/gpu-trace-viewer/trace-data';
+
+describe('GPU scene-backed trace shaders', () => {
+  test('renders generic scene bounds while keeping trace ownership in canonical source records', () => {
+    expect(TRACE_SCENE_RENDER_SHADER).toContain('sceneRecords[recordBase + 2u]');
+    expect(TRACE_SCENE_RENDER_SHADER).toContain('sceneRecords[recordBase + 3u]');
+    expect(TRACE_SCENE_RENDER_SHADER).toContain('spans[sourceIndex * 2u + 1u]');
+    expect(TRACE_SCENE_RENDER_SHADER).toContain(`${TRACE_ERROR_SPAN_FLAG}u`);
+  });
+
+  test('bounds GPU picking to visible canonical rows and scanned effective lanes', () => {
+    const source = getTraceScenePickingShader(384);
+
+    expect(source).toContain('sourceIndex >= 384u');
+    expect(source).toContain('visibleMask[sourceIndex] == 0u');
+    expect(source).toContain(`timing.z % ${TRACE_LANES_PER_THREAD}u`);
+    expect(source).toContain('atomicMin(&result, sourceIndex)');
+  });
+});

--- a/test/examples/gpu-trace-scene.spec.ts
+++ b/test/examples/gpu-trace-scene.spec.ts
@@ -1,0 +1,82 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import type {AnimationProps} from '@luma.gl/engine';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import GPUTraceSceneAnimationLoopTemplate from '../../examples/experimental/gpu-trace-scene/app';
+
+describe('GPU scene-backed trace explorer', () => {
+  test('composes one scene graph and updates hierarchy, classification, and focus controls', async () => {
+    const device = await getWebGPUTestDevice();
+    if (
+      !device ||
+      device.info.gpu === 'software' ||
+      device.info.gpuType === 'cpu' ||
+      device.info.fallback
+    ) {
+      return;
+    }
+
+    const host = document.createElement('div');
+    host.id = 'example-panel-host';
+    document.body.append(host);
+    let explorer: GPUTraceSceneAnimationLoopTemplate | null = null;
+    try {
+      explorer = new GPUTraceSceneAnimationLoopTemplate({
+        device,
+        traceCapacity: 96
+      } as AnimationProps & {
+        traceCapacity: number;
+      });
+      const state = explorer as unknown as {
+        resources: {
+          compiled: {stats: {nodeOrder: string[]}};
+          trace: {stats: {spanCount: number; partitionCount: number}};
+          commands: {capacity: number};
+        };
+        processExpansion: Uint32Array;
+        threadExpansion: Uint32Array;
+        errorsOnly: boolean;
+        focusEnabled: boolean;
+      };
+      expect(state.resources.trace.stats.spanCount).toBe(96);
+      expect(state.resources.trace.stats.partitionCount).toBe(3);
+      expect(state.resources.commands.capacity).toBe(96);
+      expect(state.resources.compiled.stats.nodeOrder).toContain('scene-trace-picking');
+      expect(state.resources.compiled.stats.nodeOrder).toContain('scene-trace-render');
+      expect(state.resources.compiled.stats.nodeOrder).toContain(
+        'scene-trace-resource-groups-classify'
+      );
+
+      const process = host.querySelector<HTMLInputElement>('[data-process="0"]');
+      expect(process).not.toBeNull();
+      process!.checked = false;
+      process!.dispatchEvent(new Event('change', {bubbles: true}));
+
+      const errors = host.querySelector<HTMLInputElement>('[data-errors-only]');
+      expect(errors).not.toBeNull();
+      errors!.checked = true;
+      errors!.dispatchEvent(new Event('change', {bubbles: true}));
+      expect(state.processExpansion[0]).toBe(0);
+      expect(state.errorsOnly).toBe(true);
+
+      const thread = host.querySelector<HTMLInputElement>('[data-thread="1"]');
+      expect(thread).not.toBeNull();
+      thread!.checked = false;
+      thread!.dispatchEvent(new Event('change', {bubbles: true}));
+      expect(state.threadExpansion[1]).toBe(0);
+
+      const focus = host.querySelector<HTMLInputElement>('[data-focus]');
+      expect(focus).not.toBeNull();
+      focus!.checked = true;
+      focus!.dispatchEvent(new Event('change', {bubbles: true}));
+      expect(state.focusEnabled).toBe(true);
+      expect(explorer.graphInspector.getSnapshot().graphs[0].encodingCount).toBe(0);
+    } finally {
+      explorer?.onFinalize();
+      host.remove();
+    }
+  });
+});

--- a/website/content/examples/experimental/gpu-scene-graph.mdx
+++ b/website/content/examples/experimental/gpu-scene-graph.mdx
@@ -1,0 +1,14 @@
+---
+title: GPU Scene Graph Explorer
+sidebar_label: GPU scene graph
+description: Adapt a CPU-owned hierarchy into generic GPU visibility, picking, resource groups, and indirect rendering.
+sidebar_custom_props:
+  backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [compute, rendering, visualization, command-graphs, picking]
+---
+
+import {GPUSceneGraphExample} from '@site/src/examples';
+
+<GPUSceneGraphExample />

--- a/website/content/examples/experimental/gpu-trace-scene.mdx
+++ b/website/content/examples/experimental/gpu-trace-scene.mdx
@@ -1,0 +1,14 @@
+---
+title: GPU Scene Trace Explorer
+sidebar_label: GPU scene trace
+description: Explore canonical trace scenes with reusable GPU interaction, resource groups, picking, and indirect drawing.
+sidebar_custom_props:
+  backends: [webgpu]
+  difficulty: advanced
+  maturity: experimental
+  topics: [compute, data, visualization, command-graphs, picking]
+---
+
+import {GPUTraceSceneExample} from '@site/src/examples';
+
+<GPUTraceSceneExample />

--- a/website/content/examples/index.mdx
+++ b/website/content/examples/index.mdx
@@ -5,6 +5,7 @@ hide_title: true
 ---
 
 import {ExamplesIndex} from '@site/src/components/examples-index';
+import {getExampleThumbnailPath} from '@site/src/example-thumbnails';
 
 <header className="luma-example-catalog-hero" aria-labelledby="luma-example-catalog-title">
   <p className="luma-example-catalog-eyebrow">The real-time GPU laboratory</p>
@@ -21,9 +22,6 @@ import {ExamplesIndex} from '@site/src/components/examples-index';
 <ExamplesIndex
   getThumbnail={item => {
     const exampleName = typeof item === 'string' ? item : item.docId || item.label.toLowerCase();
-    if (exampleName === 'v10/gpgpu') {
-      return '/images/examples/gpu-tables/gpu-vector-storage-particles.jpg'
-    }
-    return `/images/examples/${exampleName}.jpg`
+    return `/images/examples/${getExampleThumbnailPath(exampleName)}`
   }}
 />

--- a/website/content/examples/table-of-contents.json
+++ b/website/content/examples/table-of-contents.json
@@ -89,6 +89,8 @@
         "items": [
           "experimental/gpu-frustum-culling",
           "experimental/gpu-trace-viewer",
+          "experimental/gpu-trace-scene",
+          "experimental/gpu-scene-graph",
           "experimental/gpu-sort",
           "experimental/gpu-data-analysis"
         ]

--- a/website/src/example-thumbnails.ts
+++ b/website/src/example-thumbnails.ts
@@ -1,0 +1,13 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+const EXAMPLE_THUMBNAIL_ALIASES: Readonly<Record<string, string>> = {
+  'v10/gpgpu': 'gpu-tables/gpu-vector-storage-particles',
+  'experimental/gpu-trace-scene': 'experimental/gpu-trace-viewer',
+  'experimental/gpu-scene-graph': 'experimental/gpu-frustum-culling'
+};
+
+export function getExampleThumbnailPath(exampleIdentifier: string): string {
+  return `${EXAMPLE_THUMBNAIL_ALIASES[exampleIdentifier] ?? exampleIdentifier}.jpg`;
+}

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -32,6 +32,8 @@ import ArrowPolygonRendererApp from '../../examples/arrow/arrow-polygons/app';
 import BloomApp from '../../examples/experimental/bloom/app';
 import HTMLUIPrismApp from '../../examples/experimental/html-ui-prism/app';
 import GPUFrustumCullingApp from '../../examples/experimental/gpu-frustum-culling/app';
+import GPUSceneGraphApp from '../../examples/experimental/gpu-scene-graph/app';
+import GPUTraceSceneApp from '../../examples/experimental/gpu-trace-scene/app';
 import GPUTraceViewerApp from '../../examples/experimental/gpu-trace-viewer/app';
 import {
   initializeGPUSortExample,
@@ -1400,6 +1402,30 @@ export const GPUTraceViewerExample: React.FC = props => (
     directory="experimental"
     devices={['webgpu']}
     template={GPUTraceViewerApp}
+    config={exampleConfig}
+    {...props}
+  />
+);
+
+export const GPUTraceSceneExample: React.FC = props => (
+  <LumaExample
+    id="gpu-trace-scene"
+    title="GPU Scene Trace Explorer"
+    directory="experimental"
+    devices={['webgpu-max']}
+    template={GPUTraceSceneApp}
+    config={exampleConfig}
+    {...props}
+  />
+);
+
+export const GPUSceneGraphExample: React.FC = props => (
+  <LumaExample
+    id="gpu-scene-graph"
+    title="GPU Scene Graph Explorer"
+    directory="experimental"
+    devices={['webgpu-max']}
+    template={GPUSceneGraphApp}
     config={exampleConfig}
     {...props}
   />


### PR DESCRIPTION
## Goals

- Demonstrate that canonical GPU trace exploration and conventional CPU-owned scene hierarchies share the same renderer-independent GPU scene primitives.
- Complete roadmap tranches T.3 and 6.3a while keeping trace/domain concepts out of `GPUScene`.

## Changes

- Add a live GPU Scene Trace Explorer combining canonical trace ingestion, hierarchy/selection policies, GPU picking, renderer resource groups, stable indirect draw bundles, and command-graph inspection.
- Add a live GPU Scene Graph Explorer adapting an application-owned hierarchy into generic GPU visibility, picking, indirect draw generation, renderer-owned groups, and measurable scene mutations.
- Embed both live examples in the relevant Overview/Concepts documentation and correct stale roadmap/scope descriptions.
- Add GPU integration coverage for CPU-scene mutations plus focused live-example, shader, data-model, and catalog tests.
- Make the existing backend-tab Node test explicitly use the repository TypeScript configuration so protected pre-commit checks transform JSX consistently.

## Verification

- `nvm use`
- `yarn lint fix`
- `yarn lint`
- `yarn build`
- Full protected `yarn test-node`: 386 passed, 2 skipped.
- Focused Chromium/WebGPU coverage for GPU scene adapters, conventional scene consumer, trace scene consumer, and reusable trace interaction.
- Focused Node coverage for scene/trace shaders, hierarchy data, and website example catalog.

## Notes

- Scene-generated indirect draws explicitly require the WebGPU `indirect-first-instance` feature.
- Preserved-batch table consumption remains the next separate roadmap tranche (6.3b).
- The pre-existing local website dependency installation has stale/missing Docusaurus tooling; the full website build could not be completed in this checkout.