### PR TITLE
docs: connect discovery, live examples, tutorials, and developer guides

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -5,6 +5,10 @@ web. It provides one application-facing API with pluggable WebGPU and WebGL2 bac
 plus higher-level building blocks for models, animation, shader composition, and GPU
 data processing.
 
+Start with a live scene, follow the ideas behind a single rendered frame, and choose
+how much of the GPU you want to control. You can explore the examples and tutorials
+right here in your browser.
+
 <p className="badges">
   <a href="https://www.npmjs.com/package/@luma.gl/core">
     <img src="https://img.shields.io/npm/v/@luma.gl/core.svg?style=flat-square&label=npm" alt="npm package version" />
@@ -16,6 +20,8 @@ data processing.
     <img src="https://img.shields.io/badge/TypeScript-strict-3178C6.svg?style=flat-square" alt="TypeScript strict mode" />
   </a>
 </p>
+
+## Choose your starting point
 
 <div className="docs-api-card-grid">
   <a className="docs-api-card" href="/docs/getting-started">
@@ -44,8 +50,9 @@ data processing.
   </a>
 </div>
 
-Ready to build your own application? The [Installing guide](/docs/developer-guide/installing)
-walks through local project setup, device adapters, and your first rendered frame.
+When you are ready to turn an idea into your own application, the
+[Installing guide](/docs/developer-guide/installing) walks through your first project,
+device adapters, and your first rendered frame.
 
 ## Why luma.gl?
 
@@ -87,7 +94,8 @@ backends.
 Shadertools assembles WGSL and GLSL from reusable shader modules and application-defined
 hooks. It is used by luma.gl, deck.gl, and custom renderers.
 
-Read [A Tale of Three APIs](/docs/api-guide) for the detailed object model.
+Explore [how the three APIs fit together](/docs/api-guide) for the complete object
+model and guidance on choosing the right layer.
 
 ## Supported environments
 
@@ -95,8 +103,9 @@ luma.gl targets current evergreen browsers. WebGPU feature availability varies b
 browser and platform; WebGL2 provides the compatibility path for portable rendering.
 Compute shaders, storage textures, and some advanced features remain WebGPU-only.
 
-Node.js can be used when the host supplies a WebGPU or WebGL implementation, but browser
-image, canvas, and video APIs require environment-specific replacements.
+Server-side rendering and compute are also possible when the host supplies a compatible
+GPU implementation. Browser-specific image, canvas, and video APIs may require
+environment-specific replacements.
 
 ## Project and releases
 

--- a/docs/developer-guide/README.md
+++ b/docs/developer-guide/README.md
@@ -4,5 +4,44 @@ import {DeveloperDocsTabs} from '@site/src/components/docs/developer-docs-tabs';
 
 <DeveloperDocsTabs active="overview" />
 
-This developer guide focuses on the practicalities of developing with the luma.gl framework,
-such as installing, debugging, profiling, bundling etc.
+You have seen what luma.gl can do. This is where you turn those ideas into a working
+application, then make it easier to debug, faster to run, and lighter to ship.
+
+<div className="docs-api-card-grid">
+  <a className="docs-api-card" href="/docs/developer-guide/installing">
+    <span className="docs-api-card__kind">Start building</span>
+    <strong>Create your first project</strong>
+    <span>Set up a portable GPU application and render your first frame.</span>
+    <span className="docs-api-card__meta">WebGPU · WebGL2 · local setup</span>
+  </a>
+  <a className="docs-api-card" href="/docs/developer-guide/debugging">
+    <span className="docs-api-card__kind">Understand each frame</span>
+    <strong>Debug GPU applications</strong>
+    <span>Inspect shader errors, resource state, draw calls, and device diagnostics.</span>
+    <span className="docs-api-card__meta">Shaders · resources · logging</span>
+  </a>
+  <a className="docs-api-card" href="/docs/developer-guide/profiling">
+    <span className="docs-api-card__kind">Find your bottlenecks</span>
+    <strong>Measure and optimize</strong>
+    <span>Understand GPU timings, frame costs, memory use, and application performance.</span>
+    <span className="docs-api-card__meta">Timing · memory · performance</span>
+  </a>
+  <a className="docs-api-card" href="/docs/developer-guide/bundling">
+    <span className="docs-api-card__kind">Ship with confidence</span>
+    <strong>Keep your bundle lean</strong>
+    <span>Choose adapters deliberately and understand tree shaking, code splitting, and delivery size.</span>
+    <span className="docs-api-card__meta">Adapters · modules · bundling</span>
+  </a>
+</div>
+
+## Explore more workflows
+
+- [Testing](/docs/developer-guide/testing) covers reliable GPU-aware verification.
+- [Working with AI coding agents](/docs/developer-guide/working-with-ai) helps agents
+  navigate the documentation and choose the right API layer.
+- [Editing](/docs/developer-guide/editing) improves your shader development environment.
+- [Contributing](/docs/developer-guide/contributing) explains how to work on luma.gl
+  itself.
+
+Not ready to set up a project? [Explore live examples](/examples) or start with
+[Hello Triangle](/docs/tutorials/hello-triangle) directly in your browser.

--- a/docs/developer-guide/installing.md
+++ b/docs/developer-guide/installing.md
@@ -1,10 +1,16 @@
+import {DeveloperDocsTabs} from '@site/src/components/docs/developer-docs-tabs';
+
 # Installing
 
-**luma.gl** is published as a suite of npm modules. Each module responsible for a particular part of the rendering stack.
+<DeveloperDocsTabs active="installing" />
 
-You can explore the [live examples](/examples) without installing anything. When you are
-ready to build locally, this guide creates a small rendering project that tries WebGPU
-first and falls back to WebGL2.
+When you are ready to turn an idea into your own application, this guide takes you from
+a new project to your first GPU-rendered frame. luma.gl is published as a family of npm
+packages, so you can choose the rendering tools and GPU backends your project needs.
+
+Still exploring? The [live examples](/examples) and
+[Hello Triangle tutorial](/docs/tutorials/hello-triangle) run directly in your browser;
+you do not need to install anything to try them.
 
 ## Create Your First Project
 
@@ -17,7 +23,8 @@ first and falls back to WebGL2.
 ### Choose a Package Manager
 
 Create a Vite project and install the luma.gl engine and both device adapters using your
-preferred package manager.
+preferred package manager. The finished application will try WebGPU first and fall back
+to WebGL2.
 
 **npm**
 
@@ -129,51 +136,51 @@ provides higher-level layers, cameras, and interaction.
 
 ## A Minimal Install
 
-The most basic module is `@luma.gl/core` which provides an abstract API for writing application code
-that works with both WebGPU and WebGL.
-
-However, the `@luma.gl/core` module cannot be used on its own: it relies on being backed up by another module
-that implements the API. luma.gl provides adapters (implementations of the abstract API)
-through the `@luma.gl/webgl` and `@luma.gl/webgpu` modules.
-
-The `@luma.gl/core` module is not usable on its own. A device adapter module must be imported.
+For lower-level applications, `@luma.gl/core` provides portable GPU devices, buffers,
+textures, and rendering resources. Pair it with at least one backend adapter:
+`@luma.gl/webgpu` for WebGPU or `@luma.gl/webgl` for WebGL2.
 
 ```bash
-yarn add @luma.gl/core
-yarn add @luma.gl/webgpu
+yarn add @luma.gl/core @luma.gl/webgpu
 ```
 
 ```typescript
 import {luma} from '@luma.gl/core';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 
-const device = await luma.createDevice({type: 'webgpu', adapters: [webgpuAdapter], createCanvasContext: ...});
+const device = await luma.createDevice({
+  type: 'webgpu',
+  adapters: [webgpuAdapter],
+  createCanvasContext: true
+});
 ```
 
-It is possible to register more than one device adapter to create an application
-that can work in both WebGL and WebGPU environments.
+To support both backends, install `@luma.gl/webgl` as well and supply the adapters in
+preference order:
 
 ```typescript
 import {luma} from '@luma.gl/core';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 import {webgl2Adapter} from '@luma.gl/webgl';
 
-const webgpuDevice = luma.createDevice({type: 'best-available', adapters: [webgl2Adapter, webgpuAdapter], createCanvasContext: ...});
+const device = await luma.createDevice({
+  type: 'best-available',
+  adapters: [webgpuAdapter, webgl2Adapter],
+  createCanvasContext: true
+});
 ```
 
 ## A Typical Install
 
-- `engine`: High-level constructs such as `Model`, `AnimationLoop` and `Geometry` that allow a developer to work without worrying about rendering pipeline details.
-- `webgl`: The WebGL backend adapter for `@luma.gl/core`. For lower-level rendering control in current luma.gl, look at `RenderPipeline` and related core resources rather than older `Program`-centric APIs.
-- `shadertools`: A system for modularizing and composing shader code.
-- `debug`: Tooling to aid in debugging.
-
+- `@luma.gl/core` provides portable devices, GPU resources, and rendering primitives.
+- `@luma.gl/engine` adds models, animation loops, geometry, and higher-level rendering
+  tools.
+- `@luma.gl/webgpu` and `@luma.gl/webgl` provide the WebGPU and WebGL2 backends.
+- `@luma.gl/shadertools` assembles reusable shader modules, hooks, and effects.
 
 ```bash
-yarn add @luma.gl/core
-yarn add @luma.gl/webgl
-yarn add @luma.gl/engine
-yarn add @luma.gl/shadertools
+yarn add @luma.gl/core @luma.gl/engine @luma.gl/webgpu @luma.gl/webgl @luma.gl/shadertools
 ```
 
-Refer to the [Module Catalog](/docs/api-reference) for more information about which luma.gl modules to install.
+Explore the [module catalog](/docs/api-reference) to choose the packages that match
+your application.

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -62,10 +62,10 @@ export function OnboardingPoster({image, alt, className, loading = 'lazy'}) {
   <section className="luma-onboarding__section" aria-labelledby="luma-onboarding-examples">
     <p className="luma-onboarding__section-label">01 · See it in motion</p>
     <h2 className="luma-onboarding__section-title" id="luma-onboarding-examples">
-      {'This is what your browser can do.'}
+      {'See what your GPU makes possible.'}
     </h2>
     <p className="luma-onboarding__section-description">
-      {'These are interactive scenes, not videos. Open one, explore it, and look under the hood.'}
+      {'Every card opens a live, interactive scene. Advanced scenes require WebGPU; Effects: Image Processing also runs on WebGL2.'}
     </p>
 
     <div className="luma-onboarding__gallery">
@@ -193,7 +193,7 @@ export function OnboardingPoster({image, alt, className, loading = 'lazy'}) {
         </div>
         <div className="luma-onboarding__showcase-content">
           <span className="luma-onboarding__showcase-kicker">Composable effects</span>
-          <h3 className="luma-onboarding__showcase-title">Image Processing</h3>
+          <h3 className="luma-onboarding__showcase-title">Effects: Image Processing</h3>
           <p className="luma-onboarding__showcase-description">
             {'Layer bloom, color grading, distortion, and film effects over a living scene.'}
           </p>
@@ -212,7 +212,7 @@ export function OnboardingPoster({image, alt, className, loading = 'lazy'}) {
       {'The whole GPU. Your way.'}
     </h2>
     <p className="luma-onboarding__section-description">
-      {'Start with a simple triangle or architect an entire rendering and compute pipeline.'}
+      {'Behind every scene are composable building blocks for rendering, GPU-resident data, and programmable effects.'}
     </p>
 
     <div className="luma-onboarding__capabilities">
@@ -225,16 +225,16 @@ export function OnboardingPoster({image, alt, className, loading = 'lazy'}) {
       </article>
       <article className="luma-onboarding__capability">
         <span className="luma-onboarding__capability-index">02</span>
-        <h3 className="luma-onboarding__capability-title">Keep the data moving.</h3>
+        <h3 className="luma-onboarding__capability-title">Keep your data on the GPU.</h3>
         <p className="luma-onboarding__capability-description">
-          {'Run fluid simulations, spatial queries, and million-point visualizations directly where the data lives: on the GPU.'}
+          {'Simulate, filter, and visualize millions of records without shuttling data back to the CPU between steps.'}
         </p>
       </article>
       <article className="luma-onboarding__capability">
         <span className="luma-onboarding__capability-index">03</span>
-        <h3 className="luma-onboarding__capability-title">Write once. Choose your backend.</h3>
+        <h3 className="luma-onboarding__capability-title">One API. Two ways to render.</h3>
         <p className="luma-onboarding__capability-description">
-          {'Build against one clear TypeScript API and run on WebGPU or WebGL2, with natural paths into deck.gl and Apache Arrow.'}
+          {'Share portable rendering across WebGPU and WebGL2, connect with deck.gl and Apache Arrow, and use WebGPU for compute shaders.'}
         </p>
       </article>
     </div>
@@ -245,13 +245,16 @@ export function OnboardingPoster({image, alt, className, loading = 'lazy'}) {
     <h2 className="luma-onboarding__section-title" id="luma-onboarding-paths">
       {'Choose your own first adventure.'}
     </h2>
+    <p className="luma-onboarding__section-description">
+      {'Begin with an interactive lesson, or go straight to the part of the GPU stack you want to explore.'}
+    </p>
 
     <div className="luma-onboarding__paths">
       <Link className="luma-onboarding__path" to="/docs/tutorials/hello-triangle">
         <span className="luma-onboarding__path-kicker">Start here</span>
         <h3 className="luma-onboarding__path-title">Draw your first triangle.</h3>
         <p className="luma-onboarding__path-description">
-          {'Watch a live, backend-switchable example, then follow its complete rendering pipeline.'}
+          {'Start with a live, backend-switchable scene, then follow its rendering pipeline one step at a time.'}
         </p>
         <span className="luma-onboarding__path-meta">Interactive fundamentals →</span>
       </Link>
@@ -267,15 +270,15 @@ export function OnboardingPoster({image, alt, className, loading = 'lazy'}) {
         <span className="luma-onboarding__path-kicker">Move faster</span>
         <h3 className="luma-onboarding__path-title">Think in GPU compute.</h3>
         <p className="luma-onboarding__path-description">
-          {'Keep data resident for simulation, filtering, aggregation, and spatial processing.'}
+          {'Compare portable data operations with WebGPU-native compute for simulation, filtering, and spatial processing.'}
         </p>
-        <span className="luma-onboarding__path-meta">GPU data processing →</span>
+        <span className="luma-onboarding__path-meta">Choose a GPU data workflow →</span>
       </Link>
       <Link className="luma-onboarding__path" to="/docs/api-guide/shaders/shader-passes">
         <span className="luma-onboarding__path-kicker">Create effects</span>
         <h3 className="luma-onboarding__path-title">Shape every pixel.</h3>
         <p className="luma-onboarding__path-description">
-          {'Combine post-processing passes, custom shaders, and reusable effects into your look.'}
+          {'Experiment with live image effects, then compose post-processing passes and reusable shader modules.'}
         </p>
         <span className="luma-onboarding__path-meta">Shader and effect passes →</span>
       </Link>
@@ -288,7 +291,7 @@ export function OnboardingPoster({image, alt, className, loading = 'lazy'}) {
         {'Ready to make something move?'}
       </h2>
       <p className="luma-onboarding__closing-description">
-        {'Your first real project is only a few steps away.'}
+        {'When you are ready to create your own app, the developer guide takes you from local project setup to your first rendered frame.'}
       </p>
     </div>
     <Link

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -436,8 +436,8 @@
     "label": "Developer Guide",
     "items": [
       "developer-guide/README",
-      "developer-guide/working-with-ai",
       "developer-guide/installing",
+      "developer-guide/working-with-ai",
       "developer-guide/editing",
       "developer-guide/debugging",
       "developer-guide/testing",

--- a/docs/tutorials/README.mdx
+++ b/docs/tutorials/README.mdx
@@ -4,43 +4,45 @@ import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 <TutorialDocsTabs group="fundamentals" active="setup" />
 
-This course builds a portable renderer one concept at a time. Every lesson includes a
-live example that can switch between WebGPU and WebGL2 when both backends support the
-feature. The files shown on each page are loaded from the runnable examples in this
-repository, so the documentation and tested code stay in sync.
+A living scene begins with a single draw call. Start with a triangle, add depth and
+light, then discover how the same rendering ideas scale into richer GPU-powered worlds.
+Every lesson includes a working example you can explore directly in your browser.
 
-Explore [Getting Started](/docs/getting-started) to see what you can build, or open any
-live lesson immediately. When you are ready to run the examples locally, follow the
-[Installing guide](/docs/developer-guide/installing). Familiarity with TypeScript and
-basic GPU concepts is helpful; the tutorials explain the luma.gl object model as it is
-introduced.
+**Start with [Hello Triangle](/docs/tutorials/hello-triangle). No installation required.**
+
+When a feature supports both backends, its live example can switch between WebGPU and
+WebGL2. The source shown on each page comes directly from the runnable example, so you
+can move from what you see to how it works without leaving the lesson.
+
+Curious where these fundamentals can take you? [Getting Started](/docs/getting-started)
+shows complete scenes, simulations, visual effects, and GPU data workflows.
 
 ## Rendering foundations
 
 <div className="docs-api-card-grid">
   <a className="docs-api-card" href="/docs/tutorials/hello-triangle">
-    <span className="docs-api-card__kind">1 · Beginner</span>
+    <span className="docs-api-card__kind">1 · Your first draw</span>
     <strong>Hello Triangle</strong>
     <span>Create a Model, supply portable shaders, and issue a draw inside a render pass.</span>
     <span className="docs-api-card__meta">Model · shaders · render passes</span>
   </a>
   <a className="docs-api-card" href="/docs/tutorials/hello-cube">
-    <span className="docs-api-card__kind">2 · Beginner</span>
+    <span className="docs-api-card__kind">2 · Add a dimension</span>
     <strong>Hello Cube</strong>
     <span>Add geometry, textures, depth testing, and uniforms that update every frame.</span>
     <span className="docs-api-card__meta">Geometry · textures · uniforms</span>
   </a>
-  <a className="docs-api-card" href="/docs/tutorials/hello-instancing">
-    <span className="docs-api-card__kind">3 · Intermediate</span>
-    <strong>Hello Instancing</strong>
-    <span>Draw many copies of one geometry using per-instance attributes.</span>
-    <span className="docs-api-card__meta">Buffers · layouts · instancing</span>
-  </a>
   <a className="docs-api-card" href="/docs/tutorials/lighting">
-    <span className="docs-api-card__kind">4 · Intermediate</span>
+    <span className="docs-api-card__kind">3 · Shape with light</span>
     <strong>Lighting</strong>
     <span>Compose reusable shader functionality and supply material inputs.</span>
     <span className="docs-api-card__meta">Shader modules · materials</span>
+  </a>
+  <a className="docs-api-card" href="/docs/tutorials/hello-instancing">
+    <span className="docs-api-card__kind">4 · Scale the scene</span>
+    <strong>Hello Instancing</strong>
+    <span>Draw many copies of one geometry using per-instance attributes.</span>
+    <span className="docs-api-card__meta">Buffers · layouts · instancing</span>
   </a>
 </div>
 
@@ -63,4 +65,6 @@ introduced.
 - Full source links point to the same files rendered in the documentation.
 
 After the course, use [What's Next?](/docs/tutorials/whats-next) to choose a deeper API
-guide or a larger example.
+guide or a larger example. Ready to work with the code on your own machine? The
+[Installing guide](/docs/developer-guide/installing) takes you from an empty project
+to your first rendered frame.

--- a/docs/tutorials/hello-triangle.mdx
+++ b/docs/tutorials/hello-triangle.mdx
@@ -7,16 +7,18 @@ import {TutorialDocsTabs} from '@site/src/components/docs/tutorial-docs-tabs';
 
 <TutorialDocsTabs group="fundamentals" active="hello-triangle" />
 
-**Goal:** create one `Model` and issue a portable draw call. Explore the live example
-below immediately, or follow the [Installing guide](/docs/developer-guide/installing) to
-run its source locally. New to luma.gl? [Getting Started](/docs/getting-started) shows
-what you can build next.
+Every rendered world starts somewhere. This live example turns one `Model` into a
+portable GPU draw call and runs directly in your browser.
+
+**What you will learn:** how shaders, a model, and a render pass work together to draw
+your first shape.
 
 <DeviceTabs />
 <HelloTriangleExample showHeader={false} showStats={false} />
 
-The example should display a red triangle. Switch backends above the canvas to verify
-that the same application code runs with WebGPU and WebGL2.
+The canvas displays a red triangle. When both backends are available, switch between
+WebGPU and WebGL2 above the example to see the same application logic run through
+either GPU API.
 
 ## The mental model
 
@@ -51,3 +53,7 @@ WebGL2 backend consumes GLSL, while the model and render loop are shared.
 You created a model, provided backend-appropriate shaders, and drew it through the same
 render-pass API. Next, [Hello Cube](/docs/tutorials/hello-cube) adds geometry, textures,
 depth testing, and uniforms.
+
+Want to run the example yourself? The [Installing guide](/docs/developer-guide/installing)
+sets up a local project. For a glimpse of where these building blocks can lead, explore
+the complete scenes and simulations in [Getting Started](/docs/getting-started).

--- a/test/examples/getting-started-onboarding.node.spec.ts
+++ b/test/examples/getting-started-onboarding.node.spec.ts
@@ -11,6 +11,19 @@ const INSTALLATION_SOURCE_PATH = path.join(process.cwd(), 'docs/developer-guide/
 const EXAMPLE_IMAGES_DIRECTORY = path.join(process.cwd(), 'website/static/images/examples');
 const EXAMPLE_CONTENT_DIRECTORY = path.join(process.cwd(), 'website/content/examples');
 const EXTRACTION_CHECKER_PATH = path.join(process.cwd(), 'website/scripts/check-llm-output.mjs');
+const WEBSITE_STYLES_PATH = path.join(process.cwd(), 'website/src/custom.css');
+const DEVELOPER_DOCS_TABS_SOURCE_PATH = path.join(
+  process.cwd(),
+  'website/src/components/docs/developer-docs-tabs.tsx'
+);
+const TUTORIAL_DOCS_TABS_SOURCE_PATH = path.join(
+  process.cwd(),
+  'website/src/components/docs/tutorial-docs-tabs.tsx'
+);
+const DOCUMENTATION_TABLE_OF_CONTENTS_PATH = path.join(
+  process.cwd(),
+  'docs/table-of-contents.json'
+);
 
 describe('getting-started onboarding', () => {
   test('introduces real, immediately explorable GPU experiences before technical setup', () => {
@@ -70,8 +83,13 @@ describe('getting-started onboarding', () => {
 
   test('preserves the complete runnable setup in the dedicated installation guide', () => {
     const installationSource = readFileSync(INSTALLATION_SOURCE_PATH, 'utf8');
+    const developerTabsSource = readFileSync(DEVELOPER_DOCS_TABS_SOURCE_PATH, 'utf8');
 
     expect(installationSource).toMatch(/^# Installing$/m);
+    expect(installationSource).toContain('<DeveloperDocsTabs active="installing" />');
+    expect(developerTabsSource).toMatch(
+      /id:\s*'installing',\s*label:\s*'Installing',\s*href:\s*'\/docs\/developer-guide\/installing'/
+    );
     expect(installationSource).toMatch(/^## A Minimal Install$/m);
     expect(installationSource).toMatch(/^## A Typical Install$/m);
     expect(installationSource).toMatch(/\bNode\.js\b/);
@@ -102,6 +120,61 @@ describe('getting-started onboarding', () => {
     expect(installationSource).not.toMatch(/<(?:Tabs|TabItem)\b/);
   });
 
+  test('connects live discovery to accurate backend choices, learning paths, and optional setup', () => {
+    const onboardingSource = readFileSync(ONBOARDING_SOURCE_PATH, 'utf8');
+    const discoveryOffset = onboardingSource.indexOf('01 · See it in motion');
+    const capabilityOffset = onboardingSource.indexOf('02 · Built for ambitious ideas');
+    const learningPathOffset = onboardingSource.indexOf('03 · Find your starting point');
+    const projectSetupOffset = onboardingSource.indexOf('/docs/developer-guide/installing');
+
+    expect(discoveryOffset).toBeGreaterThan(0);
+    expect(capabilityOffset).toBeGreaterThan(discoveryOffset);
+    expect(learningPathOffset).toBeGreaterThan(capabilityOffset);
+    expect(projectSetupOffset).toBeGreaterThan(learningPathOffset);
+
+    expect(onboardingSource).toContain('Advanced scenes require WebGPU');
+    expect(onboardingSource).toContain('Effects: Image Processing also runs on WebGL2');
+    expect(onboardingSource).toContain('Share portable rendering across WebGPU and WebGL2');
+    expect(onboardingSource).toContain('use WebGPU for compute shaders');
+
+    for (const learningPath of [
+      '/docs/tutorials/hello-triangle',
+      '/docs/api-guide/engine',
+      '/docs/api-guide/gpu/gpu-data-processing',
+      '/docs/api-guide/shaders/shader-passes'
+    ]) {
+      expect(onboardingSource, `${learningPath} must remain an available learning path`).toContain(
+        learningPath
+      );
+    }
+
+    expect(onboardingSource).toContain('the developer guide takes you from local project setup');
+    expect(onboardingSource).toContain('Build your first project');
+  });
+
+  test('keeps tutorial and developer navigation consistent with the onboarding journey', () => {
+    const tutorialTabsSource = readFileSync(TUTORIAL_DOCS_TABS_SOURCE_PATH, 'utf8');
+    const websiteStyles = readFileSync(WEBSITE_STYLES_PATH, 'utf8');
+    const tableOfContents = JSON.parse(
+      readFileSync(DOCUMENTATION_TABLE_OF_CONTENTS_PATH, 'utf8')
+    ) as Array<string | {label?: string; items?: string[]}>;
+    const developerGuide = tableOfContents.find(
+      (item): item is {label: string; items: string[]} =>
+        typeof item !== 'string' && item.label === 'Developer Guide' && Array.isArray(item.items)
+    );
+
+    expect(tutorialTabsSource).toMatch(
+      /id:\s*'setup',\s*label:\s*'Overview',\s*href:\s*'\/docs\/tutorials'/
+    );
+    expect(tutorialTabsSource).not.toMatch(/label:\s*'Setup'/);
+    expect(websiteStyles).toContain('.container:has(.luma-example-page):not(:has(> .row))');
+    expect(developerGuide?.items.slice(0, 3)).toEqual([
+      'developer-guide/README',
+      'developer-guide/installing',
+      'developer-guide/working-with-ai'
+    ]);
+  });
+
   test('validates runnable LLM setup against Installing while keeping onboarding readable', () => {
     const extractionCheckerSource = readFileSync(EXTRACTION_CHECKER_PATH, 'utf8');
 
@@ -112,6 +185,7 @@ describe('getting-started onboarding', () => {
       "const installing = readFileSync(installingPath, 'utf8')"
     );
     expect(extractionCheckerSource).toContain('if (!installing.includes(expectedText))');
+    expect(extractionCheckerSource).toContain("if (installing.includes('<DeveloperDocsTabs'))");
     expect(extractionCheckerSource).not.toContain('if (!gettingStarted.includes(expectedText))');
     expect(extractionCheckerSource).toContain('gettingStarted.trim().length');
     expect(extractionCheckerSource).toContain('unprocessed MDX components');

--- a/test/examples/homepage-navigation.node.spec.ts
+++ b/test/examples/homepage-navigation.node.spec.ts
@@ -17,6 +17,11 @@ const EXAMPLE_CARD_SOURCE_PATH = path.join(
   process.cwd(),
   'website/src/components/example-card.tsx'
 );
+const EXAMPLES_INDEX_SOURCE_PATH = path.join(
+  process.cwd(),
+  'website/src/components/examples-index.tsx'
+);
+const COMMUNITY_SHOWCASE_SOURCE_PATH = path.join(process.cwd(), 'website/src/pages/showcase.tsx');
 const EXAMPLE_CONTENT_DIRECTORY = path.join(process.cwd(), 'website/content/examples');
 const MINIMUM_PRIMARY_ACTION_CONTRAST = 7;
 
@@ -37,6 +42,44 @@ describe('homepage navigation', () => {
     );
 
     expect(gettingStartedActions).toEqual(['primaryAction', 'closingAction']);
+  });
+
+  test('introduces getting started as a zero-install guided discovery experience', () => {
+    const homepageSource = readFileSync(HOMEPAGE_SOURCE_PATH, 'utf8');
+
+    expect(homepageSource).toContain('Start with a guided tour. No installation required.');
+    expect(homepageSource).toContain('Explore live examples');
+    expect(homepageSource).toContain('Choose your starting point');
+  });
+
+  test('connects the example gallery to the guided tour and first tutorial with base-aware links', () => {
+    const examplesIndexSource = readFileSync(EXAMPLES_INDEX_SOURCE_PATH, 'utf8');
+
+    expect(examplesIndexSource).toMatch(
+      /const\s+gettingStartedUrl\s*=\s*useBaseUrl\(\s*['"]\/docs\/getting-started['"]\s*\)/
+    );
+    expect(examplesIndexSource).toMatch(
+      /const\s+firstTriangleUrl\s*=\s*useBaseUrl\(\s*['"]\/docs\/tutorials\/hello-triangle['"]\s*\)/
+    );
+    expect(examplesIndexSource).toContain('New here? Take the guided tour');
+    expect(examplesIndexSource).toContain('Draw your first triangle');
+    expect(examplesIndexSource).toMatch(/<a\b[^>]*\bhref=\{gettingStartedUrl\}[^>]*>/);
+    expect(examplesIndexSource).toMatch(/<a\b[^>]*\bhref=\{firstTriangleUrl\}[^>]*>/);
+  });
+
+  test('continues from the community showcase into first-party discovery and live examples', () => {
+    const communityShowcaseSource = readFileSync(COMMUNITY_SHOWCASE_SOURCE_PATH, 'utf8');
+
+    expect(communityShowcaseSource).toMatch(
+      /const\s+gettingStartedUrl\s*=\s*useBaseUrl\(\s*['"]\/docs\/getting-started['"]\s*\)/
+    );
+    expect(communityShowcaseSource).toMatch(
+      /const\s+examplesUrl\s*=\s*useBaseUrl\(\s*['"]\/examples['"]\s*\)/
+    );
+    expect(communityShowcaseSource).toContain('Find your starting point');
+    expect(communityShowcaseSource).toContain('Explore live examples');
+    expect(communityShowcaseSource).toMatch(/<a\b[^>]*\bhref=\{gettingStartedUrl\}[^>]*>/);
+    expect(communityShowcaseSource).toMatch(/<a\b[^>]*\bhref=\{examplesUrl\}[^>]*>/);
   });
 
   test('links every featured example card to a real catalog entry and documentation route', () => {

--- a/website/scripts/check-llm-output.mjs
+++ b/website/scripts/check-llm-output.mjs
@@ -176,6 +176,9 @@ for (const expectedText of [
     fail(`rendered Installing Markdown is missing "${expectedText}"`);
   }
 }
+if (installing.includes('<DeveloperDocsTabs')) {
+  fail('rendered Installing Markdown contains an unprocessed tab component');
+}
 
 const workingWithAi = readFileSync(workingWithAiPath, 'utf8');
 if (!workingWithAi.includes('Start from local truth')) {

--- a/website/src/components/docs/developer-docs-tabs.tsx
+++ b/website/src/components/docs/developer-docs-tabs.tsx
@@ -10,6 +10,7 @@ type DeveloperDocsTab = {
 /** Developer documentation tab identifiers. */
 export type DeveloperDocsTabId =
   | 'overview'
+  | 'installing'
   | 'ai'
   | 'contributing'
   | 'editing'
@@ -20,6 +21,7 @@ export type DeveloperDocsTabId =
 
 const DEVELOPER_DOCS_TABS: DeveloperDocsTab[] = [
   {id: 'overview', label: 'Overview', href: '/docs/developer-guide'},
+  {id: 'installing', label: 'Installing', href: '/docs/developer-guide/installing'},
   {
     id: 'ai',
     label: 'AI Agents',

--- a/website/src/components/docs/tutorial-docs-tabs.tsx
+++ b/website/src/components/docs/tutorial-docs-tabs.tsx
@@ -25,7 +25,7 @@ export type TutorialDocsTabGroupId = 'fundamentals' | 'shaders' | 'transforms';
 
 const TUTORIAL_DOCS_TABS: Record<TutorialDocsTabGroupId, TutorialDocsTab[]> = {
   fundamentals: [
-    {id: 'setup', label: 'Setup', href: '/docs/tutorials'},
+    {id: 'setup', label: 'Overview', href: '/docs/tutorials'},
     {id: 'hello-triangle', label: 'Triangle', href: '/docs/tutorials/hello-triangle'},
     {id: 'hello-cube', label: 'Cube', href: '/docs/tutorials/hello-cube'},
     {id: 'hello-instancing', label: 'Instancing', href: '/docs/tutorials/hello-instancing'}

--- a/website/src/components/examples-index.module.css
+++ b/website/src/components/examples-index.module.css
@@ -54,6 +54,36 @@
   padding: 6px 10px;
 }
 
+.discoveryPaths {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px 18px;
+  margin-top: -2px;
+}
+
+.discoveryPath {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border-radius: 4px;
+  color: #bae6fd;
+  font-size: 0.77rem;
+  font-weight: 670;
+  text-decoration: none;
+}
+
+.discoveryPath:hover,
+.discoveryPath:focus-visible {
+  color: #e0f2fe;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.discoveryPath:focus-visible {
+  outline: 2px solid var(--luma-example-accent, #67e8f9);
+  outline-offset: 3px;
+}
+
 .searchField {
   position: relative;
 }

--- a/website/src/components/examples-index.tsx
+++ b/website/src/components/examples-index.tsx
@@ -58,6 +58,8 @@ export function ExamplesIndex({getThumbnail}: ExamplesIndexProps) {
   const sidebar = useDocsSidebar() as SidebarRoot;
   const {docs} = useDocsVersion();
   const baseUrl = useBaseUrl('/');
+  const gettingStartedUrl = useBaseUrl('/docs/getting-started');
+  const firstTriangleUrl = useBaseUrl('/docs/tutorials/hello-triangle');
   const catalog = useMemo(() => buildCatalog(sidebar, docs), [docs, sidebar]);
   const topics = useMemo(
     () => [...new Set(catalog.flatMap(item => item.topics))].sort(),
@@ -143,12 +145,21 @@ export function ExamplesIndex({getThumbnail}: ExamplesIndexProps) {
       <div className={styles.catalogControls} aria-label="Filter examples">
         <div className={styles.controlsHeading}>
           <div>
-            <p className={styles.controlsEyebrow}>Realtime GPU experiments</p>
+            <p className={styles.controlsEyebrow}>Live GPU experiences</p>
             <p className={styles.controlsIntroduction}>
-              Explore rendering techniques, visual simulations, and interactive data.
+              Open a live scene, explore the technique, and see what you can build.
             </p>
           </div>
           <span className={styles.catalogCount}>{catalog.length} demos</span>
+        </div>
+
+        <div className={styles.discoveryPaths} aria-label="Suggested starting points">
+          <a className={styles.discoveryPath} href={gettingStartedUrl}>
+            New here? Take the guided tour <span aria-hidden="true">→</span>
+          </a>
+          <a className={styles.discoveryPath} href={firstTriangleUrl}>
+            Draw your first triangle <span aria-hidden="true">→</span>
+          </a>
         </div>
 
         <div className={styles.searchField}>

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -1178,7 +1178,7 @@ html[data-theme="dark"] .docusaurus-highlight-code-line {
   padding-right: 0;
 }
 
-.container:has(.luma-example-page) {
+.container:has(.luma-example-page):not(:has(> .row)) {
   max-width: none;
   width: 100%;
   padding: 0;

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -164,8 +164,8 @@ export default function IndexPage() {
             </h1>
             <p className={styles.heroTagline}>{siteConfig.tagline}</p>
             <p className={styles.heroDescription}>
-              Create ambitious real-time rendering, simulation, and data visualization—directly on
-              the GPU.
+              Build living worlds, responsive simulations, and rich data visualizations—at the
+              speed of the GPU.
             </p>
 
             <div className={styles.heroActions}>
@@ -173,9 +173,12 @@ export default function IndexPage() {
                 Get started <span aria-hidden="true">→</span>
               </a>
               <a className={styles.secondaryAction} href={examplesUrl}>
-                Explore examples <span aria-hidden="true">↗</span>
+                Explore live examples <span aria-hidden="true">↗</span>
               </a>
             </div>
+            <p className={styles.heroActionNote}>
+              Start with a guided tour. No installation required.
+            </p>
 
             <ul className={styles.heroCapabilities} aria-label="Toolkit capabilities">
               {HERO_CAPABILITIES.map(capability => (
@@ -201,7 +204,8 @@ export default function IndexPage() {
                 </h2>
               </div>
               <p className={styles.sectionDescription}>
-                Real-time worlds, physical simulations, and visual effects—running in your browser.
+                Real-time worlds, physical simulations, and visual effects—live in your browser,
+                with nothing to install.
               </p>
             </div>
 
@@ -261,9 +265,9 @@ export default function IndexPage() {
             </div>
 
             <div className={styles.closingStatement}>
-              <p>Ready to build something that moves?</p>
+              <p>Found your inspiration? Find the right place to begin.</p>
               <a className={styles.closingAction} href={gettingStartedUrl}>
-                Start building <span aria-hidden="true">→</span>
+                Choose your starting point <span aria-hidden="true">→</span>
               </a>
             </div>
           </div>

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -114,6 +114,13 @@
   pointer-events: auto;
 }
 
+.heroActionNote {
+  margin: 13px 0 0;
+  color: rgba(203, 213, 225, 0.8);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
 .primaryAction,
 .secondaryAction,
 .galleryAction,

--- a/website/src/pages/showcase.module.css
+++ b/website/src/pages/showcase.module.css
@@ -69,6 +69,14 @@
   max-width: 680px;
 }
 
+.heroActions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 24px;
+  margin-top: 28px;
+}
+
 .gallery {
   border-top: 1px solid var(--showcase-border);
   padding-top: 28px;

--- a/website/src/pages/showcase.tsx
+++ b/website/src/pages/showcase.tsx
@@ -10,6 +10,8 @@ const LUMA_GL_REPOSITORY_URL = 'https://github.com/visgl/luma.gl';
 
 export default function ShowcasePage(): React.JSX.Element {
   const climateGlobeImageUrl = useBaseUrl('/images/showcase-climate-globe.png');
+  const gettingStartedUrl = useBaseUrl('/docs/getting-started');
+  const examplesUrl = useBaseUrl('/examples');
 
   return (
     <Layout
@@ -22,8 +24,17 @@ export default function ShowcasePage(): React.JSX.Element {
             <p className={styles.eyebrow}>Community showcase</p>
             <h1>Made with luma.gl</h1>
             <p className={styles.introduction}>
-              A collection of ambitious, beautiful, and unexpected projects powered by luma.gl.
+              Ambitious, beautiful, and unexpected projects from people turning GPU-level control
+              into something worth sharing.
             </p>
+            <div className={styles.heroActions}>
+              <a className={styles.primaryAction} href={gettingStartedUrl}>
+                Find your starting point <span aria-hidden="true">→</span>
+              </a>
+              <a className={styles.secondaryAction} href={examplesUrl}>
+                Explore live examples
+              </a>
+            </div>
           </div>
         </header>
 


### PR DESCRIPTION
## Why

The new Getting Started page now opens with a cinematic, zero-install discovery experience, but the surrounding website still interrupted the journey: the homepage described discovery as setup, the example catalog and community showcase had no return path, tutorials labeled their overview “Setup,” and the Developer Guide omitted Installing from its navigation and immediately sent readers to AI tooling.

## What changed

- Align homepage language with the new GPU-first, zero-install introduction and make calls to action accurately describe the guided discovery page.
- Add base-path-safe links from the example gallery back to Getting Started and forward to the first interactive triangle lesson.
- Connect the community showcase to first-party discovery and runnable examples.
- Refine onboarding section copy, use the full **Effects: Image Processing** title, and honestly distinguish WebGPU-only advanced compute scenes from portable WebGPU/WebGL2 rendering.
- Rewrite the Fundamentals introduction and Hello Triangle opening so the live canvas comes before optional installation.
- Rename the tutorial overview tab from **Setup** to **Overview**.
- Replace the one-sentence Developer Guide landing page with four clear paths for creating a project, debugging, profiling, and bundling.
- Add **Installing** to the shared developer navigation, render those tabs in the installation guide, and reorder sidebar pagination to **Overview → Installing → Working with AI**.
- Repair and clarify the runnable WebGPU-first minimal installation snippets.
- Fix horizontal overflow affecting all embedded tutorial examples while preserving full-bleed standalone examples.
- Extend onboarding, homepage navigation, sidebar ordering, backend honesty, base-path safety, tutorial layout, and generated Markdown extraction regressions.

## Verification

- `env -u YARN_NO_PROXY yarn lint fix`
- `env -u YARN_NO_PROXY yarn test-node` — **415 passed, 2 skipped**
- `env -u YARN_NO_PROXY yarn test-node test/examples/getting-started-onboarding.node.spec.ts test/examples/homepage-navigation.node.spec.ts` — **12 focused tests passed**
- `env -u YARN_NO_PROXY yarn website:build` — complete production build and **455 generated documentation pages validated**
- Verified the live production journey across homepage, Getting Started, examples, Fundamentals, Hello Triangle, Developer Guide, Installing, and community showcase.
- Confirmed embedded triangle/cube documentation no longer overflows at 1280px while standalone examples retain their intended edge-to-edge canvas.