### PR TITLE
feat(website): make GPGPU demos discoverable, responsive, and projection-aware

### DIFF
--- a/docs/api-guide/shaders/gpu-floating-point-precision.md
+++ b/docs/api-guide/shaders/gpu-floating-point-precision.md
@@ -1,7 +1,10 @@
+import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
+import {DeferredFP64Example} from '@site/src/components/docs/deferred-fp64-example';
 import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
-import {FP64Example} from '@site/src/examples';
 
 # GPU Floating-Point Precision Techniques
+
+<GPGPUDocsTabs active="precision-guide" />
 
 <ShaderModuleDocsTabs group="precision" active="precision-guide" />
 
@@ -24,7 +27,7 @@ On WebGPU, use the benchmark below the canvases to compare native `f32`,
 automatic selection, the classic transforms, and the integer-controlled path
 on the active device.
 
-<FP64Example embedded embeddedHeight={900} />
+<DeferredFP64Example embeddedHeight={900} />
 
 The benchmark is diagnostic rather than a CI performance test. It reports
 numerical error alongside runtime because the fastest implementation is not

--- a/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
@@ -1,6 +1,6 @@
 import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
+import {DeferredFP64Example} from '@site/src/components/docs/deferred-fp64-example';
 import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
-import {FP64Example} from '@site/src/examples';
 
 # fp64arithmetic
 
@@ -28,7 +28,7 @@ double-single across add, multiply, divide, and square-root workloads. Each
 result reports its measured GPU timestamp or queue-completion timing alongside
 numerical error; the benchmark runs only when requested.
 
-<FP64Example embedded embeddedHeight={900} />
+<DeferredFP64Example embeddedHeight={900} />
 
 ## Uniforms
 

--- a/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md
@@ -1,7 +1,10 @@
+import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
 import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
 import {FP64Example} from '@site/src/examples';
 
 # fp64arithmetic
+
+<GPGPUDocsTabs active="fp64-arithmetic" />
 
 <ShaderModuleDocsTabs group="precision" active="fp64-arithmetic" />
 

--- a/docs/api-reference/shadertools/shader-modules/fp64.md
+++ b/docs/api-reference/shadertools/shader-modules/fp64.md
@@ -1,7 +1,10 @@
+import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';
+import {DeferredFP64Example} from '@site/src/components/docs/deferred-fp64-example';
 import {ShaderModuleDocsTabs} from '@site/src/components/docs/shader-module-docs-tabs';
-import {FP64Example} from '@site/src/examples';
 
 # fp64 (64-bit Floating Point)
+
+<GPGPUDocsTabs active="fp64" />
 
 <ShaderModuleDocsTabs group="precision" active="fp64" />
 
@@ -31,7 +34,7 @@ The side-by-side Mandelbrot views show where fp32 loses detail as the animated z
 WebGPU, the example uses `fp64arithmetic`, and the panel below the canvases can
 benchmark each arithmetic path on the active device:
 
-<FP64Example embedded embeddedHeight={900} />
+<DeferredFP64Example embeddedHeight={900} />
 
 ## Precision
 

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -80,7 +80,6 @@
           "api-guide/shaders/shader-assembly",
           "api-guide/shaders/writing-customizable-shaders",
           "api-guide/shaders/writing-portable-shaders",
-          "api-guide/shaders/gpu-floating-point-precision",
           "api-guide/shaders/shader-passes",
           "api-guide/shaders/rendering-techniques",
           "api-guide/shaders/transparency",
@@ -93,6 +92,7 @@
         "items": [
           "api-guide/gpu/README",
           "api-guide/gpu/gpu-data-processing",
+          "api-guide/shaders/gpu-floating-point-precision",
           "api-guide/gpu/gpu-tables",
           "api-guide/gpu/tabular-data-in-wgsl"
         ]

--- a/examples/deck/luspatial-taxi/app.ts
+++ b/examples/deck/luspatial-taxi/app.ts
@@ -57,6 +57,7 @@ export function createLuSpatialTaxiDeck(
     maxZoom: 20
   };
   let queryEffect: LuSpatialTaxiQueryEffect | null = null;
+  let latestSelectionCenter: readonly [number, number] = initialZone.center;
   let queryRadiusKilometres = 0.35;
 
   if (getComputedStyle(container).position === 'static') container.style.position = 'relative';
@@ -91,6 +92,7 @@ export function createLuSpatialTaxiDeck(
       deck?.redraw('luSpatial radius changed');
     },
     onZoneChange: zone => {
+      latestSelectionCenter = zone.center;
       viewState = {
         ...viewState,
         longitude: zone.center[0],
@@ -136,6 +138,7 @@ export function createLuSpatialTaxiDeck(
       const coordinate = info.coordinate;
       if (!coordinate || coordinate.length < 2) return;
       const center = [coordinate[0], coordinate[1]] as const;
+      latestSelectionCenter = center;
       queryEffect?.setSelection(center, queryRadiusKilometres);
       controls.setCoordinate(center, 'Custom map query');
       controls.setCustomZone();
@@ -173,7 +176,7 @@ export function createLuSpatialTaxiDeck(
           queryEffect = new LuSpatialTaxiQueryEffect(device, generatedTaxiData, {
             onStats: stats => controls.updateStats(stats)
           });
-          queryEffect.setSelection(initialZone.center, queryRadiusKilometres);
+          queryEffect.setSelection(latestSelectionCenter, queryRadiusKilometres);
           loadedDeck.setProps({
             effects: [queryEffect],
             layers: [

--- a/examples/deck/luspatial-taxi/app.ts
+++ b/examples/deck/luspatial-taxi/app.ts
@@ -17,9 +17,11 @@ import {LuSpatialPointLayer} from './luspatial-point-layer';
 import {LuSpatialTaxiQueryEffect, type LuSpatialTaxiQueryStats} from './luspatial-query-effect';
 import {
   TAXI_CORPUS_POINT_COUNT,
+  TAXI_POINT_COUNT,
   getTaxiPoint,
-  makeLuSpatialTaxiData,
+  makeLuSpatialTaxiDataAsync,
   makeTaxiZonePresets,
+  type LuSpatialTaxiData,
   type TaxiZonePreset
 } from './taxi-data';
 
@@ -41,7 +43,8 @@ export function createLuSpatialTaxiDeck(
 ) {
   const ownsContainer = !parent;
   const container = parent ?? createStandaloneContainer();
-  const taxiData = makeLuSpatialTaxiData();
+  const generationController = new AbortController();
+  let taxiData: LuSpatialTaxiData | null = null;
   const zonePresets = makeTaxiZonePresets();
   const initialZone = zonePresets.find(zone => zone.id === INITIAL_ZONE_ID) ?? zonePresets[0];
   let viewState: TaxiViewState = {
@@ -57,6 +60,7 @@ export function createLuSpatialTaxiDeck(
   let queryRadiusKilometres = 0.35;
 
   if (getComputedStyle(container).position === 'static') container.style.position = 'relative';
+  const loadingIndicator = createLoadingIndicator(container);
   const basemapContainer = document.createElement('div');
   Object.assign(basemapContainer.style, {
     position: 'absolute',
@@ -101,6 +105,16 @@ export function createLuSpatialTaxiDeck(
     }
   });
   controls.setCoordinate(initialZone.center, initialZone.name);
+  const handleBasemapError = () => {
+    controls.setBasemapStatus('Basemap tiles unavailable · GPU queries remain interactive');
+    loadingIndicator.setBasemapStatus('Basemap unavailable. GPU data continues loading.');
+  };
+  const handleBasemapLoad = () => {
+    controls.setBasemapStatus('');
+    loadingIndicator.setBasemapStatus('Basemap ready.');
+  };
+  map.on('error', handleBasemapError);
+  map.on('load', handleBasemapLoad);
 
   deck = new ArrowDeck({
     parent: container,
@@ -117,7 +131,7 @@ export function createLuSpatialTaxiDeck(
     style: {background: 'transparent'},
     layers: [],
     effects: [],
-    getTooltip: info => getTooltip(taxiData, info),
+    getTooltip: info => (taxiData ? getTooltip(taxiData, info) : null),
     onClick: (info: PickingInfo) => {
       const coordinate = info.coordinate;
       if (!coordinate || coordinate.length < 2) return;
@@ -143,48 +157,74 @@ export function createLuSpatialTaxiDeck(
           background: 'transparent'
         });
       }
-      queryEffect = new LuSpatialTaxiQueryEffect(device, taxiData, {
-        onStats: stats => controls.updateStats(stats)
-      });
-      queryEffect.setSelection(initialZone.center, queryRadiusKilometres);
-      loadedDeck.setProps({
-        effects: [queryEffect],
-        layers: [
-          new LuSpatialPointLayer({
-            id: 'luspatial-taxi-context',
-            data: [],
-            pickable: true,
-            autoHighlight: true,
-            highlightColor: [255, 140, 32, 230],
-            longitudeLatitudes: queryEffect.longitudeLatitudes,
-            visibleIds: queryEffect.viewportIds,
-            drawCommands: queryEffect.drawCommands,
-            commandIndex: 0,
-            color: [94, 172, 198, 105],
-            radiusPixels: 0.9,
-            opacity: 0.46
-          }),
-          new LuSpatialPointLayer({
-            id: 'luspatial-taxi-selection',
-            data: [],
-            pickable: true,
-            autoHighlight: true,
-            highlightColor: [255, 140, 32, 245],
-            longitudeLatitudes: queryEffect.longitudeLatitudes,
-            visibleIds: queryEffect.selectedIds,
-            drawCommands: queryEffect.drawCommands,
-            commandIndex: 1,
-            color: [52, 220, 244, 205],
-            radiusPixels: 1.25,
-            opacity: 0.72
-          })
-        ]
-      });
-      loadedDeck.redraw('luSpatial initialized');
+      void (async () => {
+        try {
+          const generatedTaxiData = await makeLuSpatialTaxiDataAsync(TAXI_POINT_COUNT, {
+            signal: generationController.signal,
+            onProgress: (processedPointCount, totalPointCount) => {
+              controls.setLoadingProgress(processedPointCount, totalPointCount);
+              loadingIndicator.setProgress(processedPointCount, totalPointCount);
+            }
+          });
+          generationController.signal.throwIfAborted();
+          taxiData = generatedTaxiData;
+          loadingIndicator.setStatus('Compiling luProj projection and GPU spatial index…');
+
+          queryEffect = new LuSpatialTaxiQueryEffect(device, generatedTaxiData, {
+            onStats: stats => controls.updateStats(stats)
+          });
+          queryEffect.setSelection(initialZone.center, queryRadiusKilometres);
+          loadedDeck.setProps({
+            effects: [queryEffect],
+            layers: [
+              new LuSpatialPointLayer({
+                id: 'luspatial-taxi-context',
+                data: [],
+                pickable: true,
+                autoHighlight: true,
+                highlightColor: [255, 140, 32, 230],
+                longitudeLatitudes: queryEffect.longitudeLatitudes,
+                visibleIds: queryEffect.viewportIds,
+                drawCommands: queryEffect.drawCommands,
+                commandIndex: 0,
+                color: [94, 172, 198, 105],
+                radiusPixels: 0.9,
+                opacity: 0.46
+              }),
+              new LuSpatialPointLayer({
+                id: 'luspatial-taxi-selection',
+                data: [],
+                pickable: true,
+                autoHighlight: true,
+                highlightColor: [255, 140, 32, 245],
+                longitudeLatitudes: queryEffect.longitudeLatitudes,
+                visibleIds: queryEffect.selectedIds,
+                drawCommands: queryEffect.drawCommands,
+                commandIndex: 1,
+                color: [52, 220, 244, 205],
+                radiusPixels: 1.25,
+                opacity: 0.72
+              })
+            ]
+          });
+          loadingIndicator.destroy();
+          loadedDeck.redraw('luProj and luSpatial initialized');
+        } catch (error) {
+          if (!generationController.signal.aborted) {
+            loadingIndicator.setStatus(
+              `GPU initialization failed: ${error instanceof Error ? error.message : String(error)}`
+            );
+          }
+        }
+      })();
     },
     onFinalize: () => {
+      generationController.abort();
       resizeObserver.disconnect();
+      loadingIndicator.destroy();
       controls.destroy();
+      map.off('error', handleBasemapError);
+      map.off('load', handleBasemapLoad);
       map.remove();
       if (ownsContainer) container.remove();
     }
@@ -211,10 +251,7 @@ function synchronizeBasemap(map: maplibregl.Map, viewState: TaxiViewState): void
   });
 }
 
-function getTooltip(
-  data: ReturnType<typeof makeLuSpatialTaxiData>,
-  info: PickingInfo
-): {html: string} | null {
+function getTooltip(data: LuSpatialTaxiData, info: PickingInfo): {html: string} | null {
   const point = getTaxiPoint(data, info.index);
   if (!point) return null;
   return {
@@ -234,10 +271,69 @@ type ControlPanelCallbacks = {
 
 type TaxiControlPanel = {
   destroy: () => void;
+  setBasemapStatus: (status: string) => void;
   setCoordinate: (coordinate: readonly [number, number], label: string) => void;
   setCustomZone: () => void;
+  setLoadingProgress: (processedPointCount: number, totalPointCount: number) => void;
   updateStats: (stats: LuSpatialTaxiQueryStats) => void;
 };
+
+type TaxiLoadingIndicator = {
+  destroy: () => void;
+  setBasemapStatus: (status: string) => void;
+  setProgress: (processedPointCount: number, totalPointCount: number) => void;
+  setStatus: (status: string) => void;
+};
+
+function createLoadingIndicator(container: HTMLElement): TaxiLoadingIndicator {
+  const root = document.createElement('section');
+  root.setAttribute('role', 'status');
+  root.setAttribute('aria-live', 'polite');
+  root.setAttribute('aria-label', 'Loading GPU taxi data');
+  Object.assign(root.style, {
+    position: 'absolute',
+    inset: '0',
+    zIndex: '8',
+    display: 'grid',
+    placeItems: 'center',
+    padding: '24px',
+    pointerEvents: 'none',
+    background: 'radial-gradient(ellipse at center, rgba(3, 12, 19, .82), rgba(2, 6, 9, .48))'
+  });
+  root.innerHTML = `<div style="width:min(340px,100%);padding:20px 22px;border:1px solid rgba(84,221,243,.25);border-radius:12px;background:rgba(4,11,17,.94);box-shadow:0 18px 54px rgba(0,0,0,.36);color:#e6f6ff;font:12px/1.55 Inter,system-ui,sans-serif">
+    <div style="color:#63eaff;font:700 10px ui-monospace,monospace;letter-spacing:.12em">LUPROJ + LUSPATIAL</div>
+    <div data-taxi-loading-status style="margin-top:9px;font-size:14px;font-weight:650">Preparing WebGPU taxi explorer…</div>
+    <div data-taxi-loading-progress role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" style="height:5px;margin-top:13px;overflow:hidden;border-radius:999px;background:rgba(108,154,177,.22)">
+      <div data-taxi-loading-bar style="width:0%;height:100%;border-radius:inherit;background:linear-gradient(90deg,#2fc9dd,#6aeeff);transition:width 120ms linear"></div>
+    </div>
+    <div data-taxi-loading-count style="margin-top:8px;color:#adc4d2;font:10px ui-monospace,monospace">Waiting for the GPU…</div>
+    <div data-taxi-basemap-status style="margin-top:8px;color:#8296a5;font-size:10px">Basemap tiles stream separately and never block GPU data.</div>
+  </div>`;
+  container.appendChild(root);
+
+  const statusElement = root.querySelector<HTMLElement>('[data-taxi-loading-status]')!;
+  const progressElement = root.querySelector<HTMLElement>('[data-taxi-loading-progress]')!;
+  const progressBar = root.querySelector<HTMLElement>('[data-taxi-loading-bar]')!;
+  const countElement = root.querySelector<HTMLElement>('[data-taxi-loading-count]')!;
+  const basemapStatusElement = root.querySelector<HTMLElement>('[data-taxi-basemap-status]')!;
+
+  return {
+    destroy: () => root.remove(),
+    setBasemapStatus: status => {
+      basemapStatusElement.textContent = status;
+    },
+    setProgress: (processedPointCount, totalPointCount) => {
+      const percentage = Math.round((processedPointCount / Math.max(1, totalPointCount)) * 100);
+      statusElement.textContent = 'Generating taxi rows without blocking the page…';
+      progressElement.setAttribute('aria-valuenow', String(percentage));
+      progressBar.style.width = `${percentage}%`;
+      countElement.textContent = `${formatCount(processedPointCount)} / ${formatCount(totalPointCount)} points prepared`;
+    },
+    setStatus: status => {
+      statusElement.textContent = status;
+    }
+  };
+}
 
 function createControlPanel(
   container: HTMLElement,
@@ -314,7 +410,7 @@ function createControlPanel(
   </style>
   <div data-luspatial-card>
     <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:10px;padding-bottom:10px;border-bottom:1px solid rgba(125,180,206,.16)">
-      <div><div style="font:700 16px/1.1 ui-sans-serif,system-ui">luSpatial</div><div style="margin-top:3px;color:#7890a4">NYC taxi query explorer</div></div>
+      <div><div style="font:700 16px/1.1 ui-sans-serif,system-ui">luProj + luSpatial</div><div style="margin-top:3px;color:#7890a4">NYC taxi query explorer</div></div>
       <div style="padding:4px 6px;border:1px solid rgba(54,223,255,.28);border-radius:5px;color:#4be4ff;font:700 9px ui-monospace,monospace">DECK.GL · WEBGPU</div>
     </div>
     <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:10px">
@@ -323,6 +419,7 @@ function createControlPanel(
       <div><div data-luspatial-label>IN VIEW</div><div data-luspatial-value data-visible>—</div></div>
       <div><div data-luspatial-label>SELECTED</div><div data-luspatial-value data-selected style="color:#49e3ff">—</div></div>
     </div>
+    <div data-basemap-warning hidden style="margin-top:9px;color:#e9ba7d;font:9px/1.45 ui-monospace,monospace"></div>
     <div style="margin-top:12px"><div data-luspatial-label>TAXI ZONE PRESET</div>
       <div data-zone-picker>
         <button data-zone-trigger type="button" aria-haspopup="listbox" aria-expanded="false" aria-controls="luspatial-zone-list" aria-label="Taxi zone preset: Manhattan, Midtown Center"><span data-zone-trigger-label>MANHATTAN · MIDTOWN CENTER</span></button>
@@ -357,13 +454,14 @@ function createControlPanel(
   const radiusValue = root.querySelector<HTMLElement>('[data-radius-value]')!;
   const coordinateElement = root.querySelector<HTMLElement>('[data-coordinate]')!;
   const residentElement = root.querySelector<HTMLElement>('[data-resident]')!;
+  const basemapWarningElement = root.querySelector<HTMLElement>('[data-basemap-warning]')!;
   const visibleElement = root.querySelector<HTMLElement>('[data-visible]')!;
   const selectedElement = root.querySelector<HTMLElement>('[data-selected]')!;
   const queryTimeElement = root.querySelector<HTMLElement>('[data-query-time]')!;
   const graphInspectorElement = root.querySelector<HTMLElement>('[data-graph-inspector]')!;
   const graphInspectorPanel = new GPUCommandGraphInspectorPanel(graphInspectorElement, {
     graphLabels: {
-      'luspatial-taxi-build-graph': 'Projection + grid build',
+      'luspatial-taxi-build-graph': 'luProj projection + grid build',
       'luspatial-taxi-query-graph': 'Viewport + radius queries'
     }
   });
@@ -468,6 +566,10 @@ function createControlPanel(
       graphInspectorPanel.destroy();
       root.remove();
     },
+    setBasemapStatus: status => {
+      basemapWarningElement.hidden = !status;
+      basemapWarningElement.textContent = status;
+    },
     setCoordinate: (coordinate, label) => {
       coordinateElement.textContent = `${label} · ${coordinate[0].toFixed(5)}, ${coordinate[1].toFixed(5)}`;
     },
@@ -476,6 +578,10 @@ function createControlPanel(
       zoneTriggerLabel.textContent = 'CUSTOM MAP QUERY';
       zoneTrigger.setAttribute('aria-label', 'Taxi zone preset: custom map query');
       closeZonePicker();
+    },
+    setLoadingProgress: (processedPointCount, totalPointCount) => {
+      const percentage = Math.round((processedPointCount / Math.max(1, totalPointCount)) * 100);
+      residentElement.textContent = `${percentage}% loading`;
     },
     updateStats: stats => {
       residentElement.textContent = formatCount(stats.residentPointCount);

--- a/examples/deck/luspatial-taxi/luspatial-query-effect.ts
+++ b/examples/deck/luspatial-taxi/luspatial-query-effect.ts
@@ -11,17 +11,9 @@ import {
   type GPUCommandGraphInspectorSnapshot,
   type CompiledGPUCommandGraph
 } from '@luma.gl/experimental';
-import {
-  GPUGridIndex,
-  GPUPointSpatialQuery,
-  GPUSinusoidalProjection
-} from '@luma.gl/experimental/geospatial';
-import {
-  TAXI_GRID_SIZE,
-  TAXI_PROJECTION_ORIGIN,
-  projectTaxiLongitudeLatitude,
-  type LuSpatialTaxiData
-} from './taxi-data';
+import {GPUGridIndex, GPUPointSpatialQuery} from '@luma.gl/experimental/geospatial';
+import {compileProjectionPlan, GPUProjection} from '@luma.gl/experimental/luproj';
+import {TAXI_GRID_SIZE, projectTaxiLongitudeLatitude, type LuSpatialTaxiData} from './taxi-data';
 
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 
@@ -74,6 +66,7 @@ export class LuSpatialTaxiQueryEffect implements Effect {
   private readonly buildGraph: CompiledGPUCommandGraph<void>;
   private readonly queryGraph: CompiledGPUCommandGraph<void>;
   private readonly onStats?: (stats: LuSpatialTaxiQueryStats) => void;
+  private projection: GPUProjection | null = null;
   private selectionCenter: readonly [number, number] = [-73.9855, 40.758];
   private selectionRadiusKilometres = 0.35;
   private visiblePointCount = 0;
@@ -167,7 +160,9 @@ export class LuSpatialTaxiQueryEffect implements Effect {
     this.buildEncodingMilliseconds = encoding.stats.cpuEncodeTimeMilliseconds;
     device.submit(commandEncoder.finish());
     if (encoding.canReadGPUTimings) {
-      setTimeout(() => void this.inspector.recordGPUTimings(this.buildGraph.id, encoding), 0);
+      setTimeout(() => {
+        if (!this.destroyed) void this.inspector.recordGPUTimings(this.buildGraph.id, encoding);
+      }, 0);
     }
     this.publishStats();
   }
@@ -195,6 +190,7 @@ export class LuSpatialTaxiQueryEffect implements Effect {
   }
 
   preRender(options: Parameters<Effect['preRender']>[0]): void {
+    if (this.destroyed) return;
     const viewport = options.viewports[0];
     if (!viewport || viewport.width <= 0 || viewport.height <= 0) return;
 
@@ -213,6 +209,8 @@ export class LuSpatialTaxiQueryEffect implements Effect {
     const viewportBoundsChanged =
       !this.lastViewportBounds ||
       viewportBounds.some((value, index) => value !== this.lastViewportBounds?.[index]);
+    if (!viewportBoundsChanged && !this.queryInputsChanged) return;
+
     this.lastViewportBounds = viewportBounds;
     const projectedSelection = projectTaxiLongitudeLatitude(this.selectionCenter);
     this.viewportQuery.write(viewportBounds);
@@ -228,14 +226,14 @@ export class LuSpatialTaxiQueryEffect implements Effect {
     this.inspector.recordEncoding(this.queryGraph.id, encoding);
     this.queryEncodingMilliseconds = encoding.stats.cpuEncodeTimeMilliseconds;
     this.frameIndex++;
-    if (viewportBoundsChanged || this.queryInputsChanged) {
-      this.queryInputsChanged = false;
-      this.scheduleCountSample(80);
-    }
+    this.queryInputsChanged = false;
+    this.scheduleCountSample(80);
     if (this.frameIndex === 1 || this.frameIndex % 30 === 0) {
       this.scheduleCountSample(0);
       if (encoding.canReadGPUTimings) {
-        setTimeout(() => void this.inspector.recordGPUTimings(this.queryGraph.id, encoding), 0);
+        setTimeout(() => {
+          if (!this.destroyed) void this.inspector.recordGPUTimings(this.queryGraph.id, encoding);
+        }, 0);
       }
     }
     if (this.frameIndex === 1 || this.frameIndex % 15 === 0) this.publishStats();
@@ -247,6 +245,8 @@ export class LuSpatialTaxiQueryEffect implements Effect {
     if (this.countSampleTimer !== null) clearTimeout(this.countSampleTimer);
     this.buildGraph.destroy();
     this.queryGraph.destroy();
+    this.projection?.destroy();
+    this.projection = null;
     this.drawCommands.destroy();
     this.longitudeLatitudes.destroy();
     this.projectedPositions.destroy();
@@ -291,12 +291,24 @@ export class LuSpatialTaxiQueryEffect implements Effect {
     const count = graph.createDataView(countBuffer, {format: 'uint32', length: 1});
     const overflow = graph.createDataView(overflowBuffer, {format: 'uint32', length: 1});
 
-    new GPUSinusoidalProjection({
-      id: 'luspatial-taxi-project',
+    const projectionPlan = compileProjectionPlan({
+      projection: coordinates => {
+        const projected = projectTaxiLongitudeLatitude([coordinates[0], coordinates[1]]);
+        return [projected[0], projected[1]];
+      },
+      bounds: this.data.sourceBounds,
+      degree: 2,
+      tolerance: 0.0005,
+      maxDepth: 4
+    });
+    const projection = new GPUProjection({
+      id: 'luspatial-taxi-luproj-project',
       positions: source,
       output: projected,
-      origin: TAXI_PROJECTION_ORIGIN
-    }).addToGraph(graph);
+      plan: projectionPlan
+    });
+    projection.addToGraph(graph);
+    this.projection = projection;
     new GPUGridIndex({
       id: 'luspatial-taxi-grid',
       positions: projected,

--- a/examples/deck/luspatial-taxi/taxi-data.ts
+++ b/examples/deck/luspatial-taxi/taxi-data.ts
@@ -13,6 +13,8 @@ export const TAXI_CORPUS_POINT_COUNT = PAUL_TAYLOR_POINT_COUNT;
 export const TAXI_PROJECTION_ORIGIN = [-73.97, 40.75] as const;
 export const TAXI_GRID_SIZE = [256, 256] as const;
 
+const TAXI_GENERATION_CHUNK_SIZE = 20_000;
+const TAXI_SOURCE_BOUNDS_PADDING = 0.002;
 const LOCAL_LONGITUDE_SCALE = 8;
 const LOCAL_LATITUDE_SCALE = 9;
 const KILOMETRES_PER_DEGREE = 40_000 / 360;
@@ -21,7 +23,14 @@ const DEGREES_TO_RADIANS = Math.PI / 180;
 export type LuSpatialTaxiData = {
   pointCount: number;
   longitudeLatitudes: Float32Array;
+  sourceBounds: readonly [number, number, number, number];
   projectedBounds: readonly [number, number, number, number];
+};
+
+export type LuSpatialTaxiDataGenerationOptions = {
+  chunkSize?: number;
+  onProgress?: (processedPointCount: number, totalPointCount: number) => void;
+  signal?: AbortSignal;
 };
 
 export type TaxiZonePreset = {
@@ -34,21 +43,99 @@ export type TaxiZonePreset = {
 
 /** Builds a longitude/latitude resident window from the atlas' deterministic public fixture. */
 export function makeLuSpatialTaxiData(pointCount = TAXI_POINT_COUNT): LuSpatialTaxiData {
-  const localPositions = makeSyntheticTaxiPositions(pointCount);
   const longitudeLatitudes = new Float32Array(pointCount * 2);
-  const projectedBounds = [Infinity, Infinity, -Infinity, -Infinity];
+  const sourceBounds = [Infinity, Infinity, -Infinity, -Infinity];
 
-  for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
-    const localOffset = pointIndex * 3;
-    const longitudeLatitudeOffset = pointIndex * 2;
+  for (let firstPointIndex = 0; firstPointIndex < pointCount; ) {
+    const chunkPointCount = Math.min(TAXI_GENERATION_CHUNK_SIZE, pointCount - firstPointIndex);
+    appendTaxiPositionChunk(longitudeLatitudes, sourceBounds, firstPointIndex, chunkPointCount);
+    firstPointIndex += chunkPointCount;
+  }
+
+  return makeTaxiDataFromBounds(pointCount, longitudeLatitudes, sourceBounds);
+}
+
+/** Generates deterministic taxi rows progressively without monopolizing the browser main thread. */
+export async function makeLuSpatialTaxiDataAsync(
+  pointCount = TAXI_POINT_COUNT,
+  options: LuSpatialTaxiDataGenerationOptions = {}
+): Promise<LuSpatialTaxiData> {
+  const {onProgress, signal} = options;
+  const chunkSize = Math.max(1, Math.floor(options.chunkSize ?? TAXI_GENERATION_CHUNK_SIZE));
+  const longitudeLatitudes = new Float32Array(pointCount * 2);
+  const sourceBounds = [Infinity, Infinity, -Infinity, -Infinity];
+
+  signal?.throwIfAborted();
+  onProgress?.(0, pointCount);
+
+  for (let firstPointIndex = 0; firstPointIndex < pointCount; ) {
+    await yieldTaxiGeneration(signal);
+    signal?.throwIfAborted();
+
+    const chunkPointCount = Math.min(chunkSize, pointCount - firstPointIndex);
+    appendTaxiPositionChunk(longitudeLatitudes, sourceBounds, firstPointIndex, chunkPointCount);
+    firstPointIndex += chunkPointCount;
+    onProgress?.(firstPointIndex, pointCount);
+  }
+
+  signal?.throwIfAborted();
+  return makeTaxiDataFromBounds(pointCount, longitudeLatitudes, sourceBounds);
+}
+
+function appendTaxiPositionChunk(
+  longitudeLatitudes: Float32Array,
+  sourceBounds: number[],
+  firstPointIndex: number,
+  pointCount: number
+): void {
+  const localPositions = makeSyntheticTaxiPositions(pointCount, firstPointIndex);
+
+  for (let localPointIndex = 0; localPointIndex < pointCount; localPointIndex++) {
+    const localOffset = localPointIndex * 3;
+    const longitudeLatitudeOffset = (firstPointIndex + localPointIndex) * 2;
     const longitude =
       localPositions[localOffset] / LOCAL_LONGITUDE_SCALE + TAXI_PROJECTION_ORIGIN[0];
     const latitude =
       localPositions[localOffset + 1] / LOCAL_LATITUDE_SCALE + TAXI_PROJECTION_ORIGIN[1];
     longitudeLatitudes[longitudeLatitudeOffset] = longitude;
     longitudeLatitudes[longitudeLatitudeOffset + 1] = latitude;
+    sourceBounds[0] = Math.min(sourceBounds[0], longitude);
+    sourceBounds[1] = Math.min(sourceBounds[1], latitude);
+    sourceBounds[2] = Math.max(sourceBounds[2], longitude);
+    sourceBounds[3] = Math.max(sourceBounds[3], latitude);
+  }
+}
 
-    const [projectedX, projectedY] = projectTaxiLongitudeLatitude([longitude, latitude]);
+function makeTaxiDataFromBounds(
+  pointCount: number,
+  longitudeLatitudes: Float32Array,
+  sourceBounds: number[]
+): LuSpatialTaxiData {
+  const longitudeExtent =
+    Math.max(
+      TAXI_PROJECTION_ORIGIN[0] - sourceBounds[0],
+      sourceBounds[2] - TAXI_PROJECTION_ORIGIN[0]
+    ) + TAXI_SOURCE_BOUNDS_PADDING;
+  const latitudeExtent =
+    Math.max(
+      TAXI_PROJECTION_ORIGIN[1] - sourceBounds[1],
+      sourceBounds[3] - TAXI_PROJECTION_ORIGIN[1]
+    ) + TAXI_SOURCE_BOUNDS_PADDING;
+  const projectionSourceBounds = [
+    TAXI_PROJECTION_ORIGIN[0] - longitudeExtent,
+    TAXI_PROJECTION_ORIGIN[1] - latitudeExtent,
+    TAXI_PROJECTION_ORIGIN[0] + longitudeExtent,
+    TAXI_PROJECTION_ORIGIN[1] + latitudeExtent
+  ] as const;
+  const projectedCorners = [
+    projectTaxiLongitudeLatitude([sourceBounds[0], sourceBounds[1]]),
+    projectTaxiLongitudeLatitude([sourceBounds[0], sourceBounds[3]]),
+    projectTaxiLongitudeLatitude([sourceBounds[2], sourceBounds[1]]),
+    projectTaxiLongitudeLatitude([sourceBounds[2], sourceBounds[3]])
+  ];
+  const projectedBounds = [Infinity, Infinity, -Infinity, -Infinity];
+
+  for (const [projectedX, projectedY] of projectedCorners) {
     projectedBounds[0] = Math.min(projectedBounds[0], projectedX);
     projectedBounds[1] = Math.min(projectedBounds[1], projectedY);
     projectedBounds[2] = Math.max(projectedBounds[2], projectedX);
@@ -59,6 +146,7 @@ export function makeLuSpatialTaxiData(pointCount = TAXI_POINT_COUNT): LuSpatialT
   return {
     pointCount,
     longitudeLatitudes,
+    sourceBounds: projectionSourceBounds,
     projectedBounds: [
       projectedBounds[0] - padding,
       projectedBounds[1] - padding,
@@ -68,7 +156,22 @@ export function makeLuSpatialTaxiData(pointCount = TAXI_POINT_COUNT): LuSpatialT
   };
 }
 
-/** Mirrors GPUSinusoidalProjection for tiny mutable query inputs. */
+function yieldTaxiGeneration(signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener('abort', abortGeneration);
+      resolve();
+    }, 0);
+    const abortGeneration = () => {
+      clearTimeout(timeout);
+      reject(signal?.reason ?? new DOMException('Taxi generation was cancelled', 'AbortError'));
+    };
+
+    signal?.addEventListener('abort', abortGeneration, {once: true});
+  });
+}
+
+/** CPU projection provider and tiny query-input companion for the adaptive luProj GPU plan. */
 export function projectTaxiLongitudeLatitude(
   longitudeLatitude: readonly [number, number]
 ): readonly [number, number] {

--- a/examples/experimental/gpu-data-analysis/src/app.ts
+++ b/examples/experimental/gpu-data-analysis/src/app.ts
@@ -89,11 +89,15 @@ class GPUDataAnalysisExample {
   async initialize(): Promise<void> {
     this.setStatus('Requesting a WebGPU device...');
     try {
-      this.device = await luma.createDevice({
+      const device = await luma.createDevice({
         type: 'webgpu',
-        adapters: [webgpuAdapter],
-        createCanvasContext: true
+        adapters: [webgpuAdapter]
       });
+      if (this.destroyed) {
+        device.destroy();
+        return;
+      }
+      this.device = device;
       await this.run();
     } catch (error) {
       this.setStatus(getErrorMessage(error), true);

--- a/examples/experimental/gpu-sort/src/app.ts
+++ b/examples/experimental/gpu-sort/src/app.ts
@@ -85,17 +85,7 @@ class GPUSortExample {
     try {
       const device = await luma.createDevice({
         type: 'webgpu',
-        adapters: [webgpuAdapter],
-        createCanvasContext:
-          typeof OffscreenCanvas === 'undefined'
-            ? true
-            : {
-                canvas: new OffscreenCanvas(1, 1),
-                width: 1,
-                height: 1,
-                autoResize: false,
-                useDevicePixels: false
-              }
+        adapters: [webgpuAdapter]
       });
       if (this.destroyed) {
         device.destroy();

--- a/examples/showcase/billion-point-spatial-atlas/app.ts
+++ b/examples/showcase/billion-point-spatial-atlas/app.ts
@@ -63,6 +63,7 @@ const TAXI_DOMAIN = [-1.25, -1.25, 1.25, 1.25] as const;
 const LIDAR_DOMAIN = [-1.25, -1.25, -0.25, 1.25, 1.25, 2.5] as const;
 const TAXI_GRID_SIZE = [128, 128] as const;
 const LIDAR_GRID_SIZE = [64, 64, 16] as const;
+const ATLAS_GENERATION_CHUNK_SIZE = 20_000;
 const VISUAL_SMOKE_POINT_COUNT = 100_000;
 const MINIMUM_VIEW_SCALE = 0.35;
 const MAXIMUM_VIEW_SCALE = 32;
@@ -76,6 +77,7 @@ const ATLAS_GRAPH_LABELS: Readonly<Record<string, string>> = {
   'spatial-atlas-radius-scan-graph': 'Radius · full scan',
   'spatial-atlas-polygon-index-graph': 'Polygon · grid index',
   'spatial-atlas-polygon-scan-graph': 'Polygon · full scan',
+  'spatial-atlas-display-graph': 'Cached-result rendering',
   'spatial-atlas-picking-graph': 'Point picking'
 };
 
@@ -310,6 +312,7 @@ type AtlasResources = {
   sceneColor: Texture;
   renderBundle: RenderBundle;
   buildGraph: CompiledGPUCommandGraph<void>;
+  renderGraph: CompiledGPUCommandGraph<AtlasGraphParameters>;
   queryGraphs: Map<QueryGraphKey, CompiledGPUCommandGraph<AtlasGraphParameters>>;
   pickingGraph: CompiledGPUCommandGraph<PickingGraphParameters>;
   pickingReadbackIdentifier: string;
@@ -381,6 +384,10 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   private lastLidarRefreshCenter: [number, number] | null = null;
   private lastLidarRefreshTime = 0;
   private lidarPublishTimer: ReturnType<typeof setTimeout> | null = null;
+  private dataGenerationAbortController: AbortController | null = null;
+  private loadingOverlay: HTMLDivElement | null = null;
+  private lastQuerySignature: string | null = null;
+  private finalized = false;
   private lastLidarPublishTime = 0;
   private readonly benchmarkSampleMilliseconds = getBenchmarkSampleMilliseconds();
   private benchmarkSampleStartTime: number | null = null;
@@ -408,7 +415,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     if (initialZone) {
       this.queryCenter = getBoundsCenter(initialZone.bounds);
     }
-    this.currentPositions = makeSyntheticTaxiPositions(this.capacity);
+    this.currentPositions = new Float32Array(0);
     this.uniformBuffer = device.createBuffer({
       id: 'spatial-atlas-uniforms',
       byteLength: UNIFORM_BYTE_LENGTH,
@@ -430,8 +437,8 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
       slotCount: 2
     });
     this.panels = new ExamplePanelManager({panel: this.makePanel()});
-    this.rebuildResources(this.currentPositions);
     this.panels.mount();
+    this.setStatus(`Preparing ${formatCount(this.capacity)} GPU-resident points…`);
   }
 
   override async onInitialize({canvas}: AnimationProps): Promise<void> {
@@ -455,6 +462,8 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
       this.mountNavigationOverlay(canvas);
       this.updateInteractionPresentation();
     }
+
+    await this.loadSyntheticDataset(this.mode, this.capacity);
   }
 
   override onRender({
@@ -471,15 +480,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     if (this.benchmarkFinishing) return;
     const deviceSize = device.getDefaultCanvasContext().getDevicePixelSize();
     if (resources.width !== deviceSize[0] || resources.height !== deviceSize[1]) {
-      const lidarSnapshot = this.mode === 'lidar' ? this.lidarTileCache?.getSnapshot() : undefined;
-      this.rebuildResources(
-        lidarSnapshot?.positions ?? this.currentPositions,
-        lidarSnapshot ? this.lidarTileCache?.positionsBuffer : undefined,
-        lidarSnapshot?.attributes,
-        lidarSnapshot ? this.lidarTileCache?.attributesBuffer : undefined
-      );
-      resources = this.resources;
-      if (!resources) return;
+      this.resizeResources(resources, Math.max(1, deviceSize[0]), Math.max(1, deviceSize[1]));
     }
 
     if (this.mode === 'lidar' && this.cinematicFlyThrough && !this.pointerAction) {
@@ -489,11 +490,23 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
       this.queryCenter = [Math.sin(time * 0.00009) * 0.38, Math.cos(time * 0.00007) * 0.24];
     }
     this.maybeRefreshLidarTiles();
-    this.writeQuery(resources);
     this.writeUniforms(width, height, time);
     this.updateQueryFootprint();
-    const graph = resources.queryGraphs.get(`${this.queryKind}-${this.queryExecution}`);
-    if (!graph) return;
+    const querySignature = [
+      this.queryKind,
+      this.queryExecution,
+      this.selectedZoneId,
+      this.queryCenter[0],
+      this.queryCenter[1],
+      this.queryRadius
+    ].join(':');
+    const queryChanged =
+      this.benchmarkSampleMilliseconds !== null || querySignature !== this.lastQuerySignature;
+    if (queryChanged) {
+      this.writeQuery(resources);
+      this.lastQuerySignature = querySignature;
+    }
+    const graph = queryChanged ? this.getQueryGraph(resources) : resources.renderGraph;
     const encoding = graph.encode(device.commandEncoder, {
       parameters: {viewport: [0, 0, width, height]}
     });
@@ -545,6 +558,10 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   }
 
   override onFinalize(): void {
+    this.finalized = true;
+    this.dataGenerationAbortController?.abort();
+    this.loadingOverlay?.remove();
+    this.loadingOverlay = null;
     this.lidarLoadAbortController?.abort();
     if (this.lidarPublishTimer) clearTimeout(this.lidarPublishTimer);
     if (this.canvas) {
@@ -569,6 +586,106 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     this.model.destroy();
     this.contextModel.destroy();
     this.uniformBuffer.destroy();
+  }
+
+  /** Builds large deterministic fixtures between browser tasks so navigation stays responsive. */
+  private async loadSyntheticDataset(mode: AtlasMode, pointCount: number): Promise<void> {
+    this.dataGenerationAbortController?.abort();
+    const generationController = new AbortController();
+    this.dataGenerationAbortController = generationController;
+    this.mountLoadingOverlay(mode, pointCount);
+    this.setStatus(
+      `Preparing ${formatCount(pointCount)} GPU-resident points without blocking navigation…`
+    );
+
+    try {
+      const positions = new Float32Array(pointCount * 3);
+
+      for (let firstPointIndex = 0; firstPointIndex < pointCount; ) {
+        await yieldAtlasGeneration(generationController.signal);
+        generationController.signal.throwIfAborted();
+
+        const chunkPointCount = Math.min(ATLAS_GENERATION_CHUNK_SIZE, pointCount - firstPointIndex);
+        const chunk =
+          mode === 'taxi'
+            ? makeSyntheticTaxiPositions(chunkPointCount, firstPointIndex)
+            : makeSyntheticLidarPositions(chunkPointCount, firstPointIndex);
+        positions.set(chunk, firstPointIndex * 3);
+        firstPointIndex += chunkPointCount;
+        this.updateLoadingOverlay(firstPointIndex, pointCount);
+      }
+
+      generationController.signal.throwIfAborted();
+      if (this.finalized || this.mode !== mode || this.capacity !== pointCount) return;
+
+      this.currentPositions = positions;
+      this.decodedPointCount = mode === 'taxi' ? pointCount : 0;
+      this.setStatus('Building the resident GPU spatial index…');
+      this.updateLoadingOverlay(pointCount, pointCount, 'Building the GPU spatial index…');
+      await yieldAtlasGeneration(generationController.signal);
+      generationController.signal.throwIfAborted();
+      if (this.finalized || this.mode !== mode || this.capacity !== pointCount) return;
+
+      this.rebuildResources(positions);
+      this.setStatus('');
+      this.updateInteractionPresentation();
+    } catch (error) {
+      if (!generationController.signal.aborted && !this.finalized) {
+        this.setStatus(
+          `GPU data initialization failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    } finally {
+      if (this.dataGenerationAbortController === generationController) {
+        this.dataGenerationAbortController = null;
+        this.loadingOverlay?.remove();
+        this.loadingOverlay = null;
+      }
+    }
+  }
+
+  private mountLoadingOverlay(mode: AtlasMode, pointCount: number): void {
+    this.loadingOverlay?.remove();
+    const container = this.canvasContainer;
+    if (!container) return;
+
+    const overlay = document.createElement('div');
+    overlay.setAttribute('role', 'status');
+    overlay.setAttribute('aria-live', 'polite');
+    overlay.dataset.atlasLoading = '';
+    overlay.style.cssText =
+      'position:absolute;inset:0;z-index:2;display:grid;place-items:center;padding:24px;pointer-events:none;background:radial-gradient(ellipse at center,rgba(6,12,22,.91),rgba(4,8,14,.46));';
+    overlay.innerHTML = `<div style="width:min(340px,100%);padding:20px 22px;border:1px solid rgba(126,157,205,.3);border-radius:12px;background:rgba(8,12,20,.94);box-shadow:0 16px 48px rgba(0,0,0,.35);color:#edf3fc;font:12px/1.5 system-ui,sans-serif">
+      <div style="color:#87bfff;font:700 10px ui-monospace,monospace;letter-spacing:.1em">GPU SPATIAL ATLAS</div>
+      <div data-atlas-loading-message style="margin-top:8px;font-size:14px;font-weight:650">Preparing ${mode === 'taxi' ? 'NYC taxi' : 'NYC LiDAR'} points…</div>
+      <div data-atlas-loading-progress role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" style="height:5px;margin-top:13px;overflow:hidden;border-radius:999px;background:rgba(119,145,176,.24)">
+        <div data-atlas-loading-bar style="width:0%;height:100%;border-radius:inherit;background:linear-gradient(90deg,#68a4f4,#76d7ff);transition:width 120ms linear"></div>
+      </div>
+      <div data-atlas-loading-count style="margin-top:8px;color:#aec1d8;font:10px ui-monospace,monospace">0 / ${formatCount(pointCount)} points</div>
+      <div style="margin-top:8px;color:#8293ab;font-size:10px">Generated locally in responsive, cancellable batches.</div>
+    </div>`;
+    container.appendChild(overlay);
+    this.loadingOverlay = overlay;
+  }
+
+  private updateLoadingOverlay(
+    processedPointCount: number,
+    totalPointCount: number,
+    message?: string
+  ): void {
+    const overlay = this.loadingOverlay;
+    if (!overlay) return;
+    const progress = Math.round((processedPointCount / Math.max(1, totalPointCount)) * 100);
+    const progressElement = overlay.querySelector<HTMLElement>('[data-atlas-loading-progress]');
+    const progressBar = overlay.querySelector<HTMLElement>('[data-atlas-loading-bar]');
+    const countElement = overlay.querySelector<HTMLElement>('[data-atlas-loading-count]');
+    const messageElement = overlay.querySelector<HTMLElement>('[data-atlas-loading-message]');
+    progressElement?.setAttribute('aria-valuenow', String(progress));
+    if (progressBar) progressBar.style.width = `${progress}%`;
+    if (countElement) {
+      countElement.textContent = `${formatCount(processedPointCount)} / ${formatCount(totalPointCount)} points`;
+    }
+    if (message && messageElement) messageElement.textContent = message;
   }
 
   private createModel(kind: 'context' | 'selection' | 'picking'): Model {
@@ -620,6 +737,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     this.hoverGeneration++;
     this.pointerDirty = false;
     this.frameIndex = 0;
+    this.lastQuerySignature = null;
     this.currentPositions = renderPositions;
     const pointCount = Math.floor(renderPositions.length / 3);
     const dimension: 2 | 3 = this.mode === 'taxi' ? 2 : 3;
@@ -704,19 +822,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     const deviceSize = this.device.getDefaultCanvasContext().getDevicePixelSize();
     const width = Math.max(1, deviceSize[0]);
     const height = Math.max(1, deviceSize[1]);
-    const sceneColor = this.device.createTexture({
-      id: 'spatial-atlas-scene-color',
-      format: this.sceneColorFormat,
-      width,
-      height,
-      usage: Texture.SAMPLE | Texture.RENDER,
-      sampler: {
-        minFilter: 'linear',
-        magFilter: 'linear',
-        addressModeU: 'clamp-to-edge',
-        addressModeV: 'clamp-to-edge'
-      }
-    });
+    const sceneColor = this.createSceneColorTexture(width, height);
     this.postprocessingRenderer.resize([width, height]);
     const renderBundle = this.createRenderBundle(
       renderPositionsBuffer,
@@ -751,15 +857,18 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
       renderBundle
     };
     const buildGraph = this.createBuildGraph(shared);
+    const renderGraph = this.createRenderGraph(shared);
     const queryGraphs = this.createQueryGraphs(shared);
     const picking = this.createPickingGraph(shared, width, height);
     this.graphInspector.registerGraph(buildGraph);
+    this.graphInspector.registerGraph(renderGraph);
     for (const queryGraph of queryGraphs.values()) this.graphInspector.registerGraph(queryGraph);
     this.graphInspector.registerGraph(picking.graph);
     const newResources: AtlasResources = {
       ...shared,
       mode: this.mode,
       buildGraph,
+      renderGraph,
       queryGraphs,
       pickingGraph: picking.graph,
       pickingReadbackIdentifier: picking.readbackIdentifier,
@@ -782,6 +891,51 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     this.pickedObjectIndex = null;
     this.hideHoverTooltip();
     this.updateInspector();
+  }
+
+  private createSceneColorTexture(width: number, height: number): Texture {
+    return this.device.createTexture({
+      id: 'spatial-atlas-scene-color',
+      format: this.sceneColorFormat,
+      width,
+      height,
+      usage: Texture.SAMPLE | Texture.RENDER,
+      sampler: {
+        minFilter: 'linear',
+        magFilter: 'linear',
+        addressModeU: 'clamp-to-edge',
+        addressModeV: 'clamp-to-edge'
+      }
+    });
+  }
+
+  /** Replaces framebuffer-sized graphs while preserving all resident points and their GPU index. */
+  private resizeResources(resources: AtlasResources, width: number, height: number): void {
+    this.hoverGeneration++;
+    this.pointerDirty = false;
+    resources.renderGraph.destroy();
+    for (const graph of resources.queryGraphs.values()) graph.destroy();
+    resources.pickingGraph.destroy();
+    resources.sceneColor.destroy();
+
+    resources.width = width;
+    resources.height = height;
+    resources.sceneColor = this.createSceneColorTexture(width, height);
+    this.postprocessingRenderer.resize([width, height]);
+    resources.renderGraph = this.createRenderGraph(resources);
+    resources.queryGraphs = this.createQueryGraphs(resources);
+    const picking = this.createPickingGraph(resources, width, height);
+    resources.pickingGraph = picking.graph;
+    resources.pickingReadbackIdentifier = picking.readbackIdentifier;
+
+    this.graphInspector.clear();
+    this.graphInspector.registerGraph(resources.buildGraph);
+    this.graphInspector.registerGraph(resources.renderGraph);
+    for (const queryGraph of resources.queryGraphs.values()) {
+      this.graphInspector.registerGraph(queryGraph);
+    }
+    this.graphInspector.registerGraph(resources.pickingGraph);
+    this.lastQuerySignature = null;
   }
 
   private createBuildGraph(
@@ -863,14 +1017,100 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     >
   ): Map<QueryGraphKey, CompiledGPUCommandGraph<AtlasGraphParameters>> {
     const graphs = new Map<QueryGraphKey, CompiledGPUCommandGraph<AtlasGraphParameters>>();
-    const kinds: GPUPointSpatialQueryKind[] =
-      resources.dimension === 2 ? ['bounds', 'radius', 'polygon'] : ['bounds', 'radius'];
-    for (const kind of kinds) {
-      for (const execution of ['index', 'scan'] as const) {
-        graphs.set(`${kind}-${execution}`, this.createQueryGraph(resources, kind, execution));
-      }
-    }
+    const queryKind =
+      resources.dimension === 3 && this.queryKind === 'polygon' ? 'bounds' : this.queryKind;
+    graphs.set(
+      `${queryKind}-${this.queryExecution}`,
+      this.createQueryGraph(resources, queryKind, this.queryExecution)
+    );
     return graphs;
+  }
+
+  /** Alternate query pipelines are compiled only when a visitor actually selects them. */
+  private getQueryGraph(resources: AtlasResources): CompiledGPUCommandGraph<AtlasGraphParameters> {
+    const graphKey = `${this.queryKind}-${this.queryExecution}` as const;
+    let graph = resources.queryGraphs.get(graphKey);
+    if (!graph) {
+      graph = this.createQueryGraph(resources, this.queryKind, this.queryExecution);
+      resources.queryGraphs.set(graphKey, graph);
+      this.graphInspector.registerGraph(graph);
+    }
+    return graph;
+  }
+
+  /** Redraws persistent query results without dispatching a million-row spatial query again. */
+  private createRenderGraph(
+    resources: Pick<
+      AtlasResources,
+      | 'renderPositions'
+      | 'pointAttributes'
+      | 'visibleIds'
+      | 'drawCommands'
+      | 'sceneColor'
+      | 'renderBundle'
+    >
+  ): CompiledGPUCommandGraph<AtlasGraphParameters> {
+    const graph = new GPUCommandGraph<AtlasGraphParameters>(this.device, {
+      id: 'spatial-atlas-display-graph'
+    });
+    const renderPositions = importBuffer(
+      graph,
+      'display-render-positions',
+      resources.renderPositions
+    );
+    const pointAttributes = importBuffer(
+      graph,
+      'display-point-attributes',
+      resources.pointAttributes
+    );
+    const visibleIds = importBuffer(graph, 'display-visible-ids', resources.visibleIds);
+    const drawCommand = importBuffer(graph, 'display-draw-command', resources.drawCommands.buffer);
+    const uniforms = importBuffer(graph, 'display-uniforms', this.uniformBuffer);
+    const sceneColor = graph.importTexture(
+      {
+        id: 'display-scene-color',
+        format: resources.sceneColor.format,
+        width: resources.sceneColor.width,
+        height: resources.sceneColor.height,
+        usage: resources.sceneColor.props.usage
+      },
+      resources.sceneColor
+    );
+    const sceneDepth = graph.createTransientTexture({
+      id: 'display-scene-depth',
+      format: 'depth24plus',
+      width: resources.sceneColor.width,
+      height: resources.sceneColor.height,
+      usage: Texture.RENDER
+    });
+
+    graph.addRenderPass({
+      id: 'spatial-atlas-render-cached-results',
+      attachments: {
+        colorAttachments: [graph.createTextureView(sceneColor)],
+        depthStencilAttachment: graph.createTextureView(sceneDepth)
+      },
+      resources: [
+        {buffer: renderPositions, usage: 'storage-read'},
+        {buffer: pointAttributes, usage: 'storage-read'},
+        {buffer: visibleIds, usage: 'storage-read'},
+        {buffer: uniforms, usage: 'uniform'},
+        {buffer: drawCommand, usage: 'indirect'}
+      ],
+      compile: () => ({
+        getRenderPassProps: () => ({
+          id: 'spatial-atlas-cached-render-pass',
+          clearColor: [0.001, 0.002, 0.012, 1],
+          clearDepth: 1,
+          clearStencil: false
+        }),
+        encode: ({parameters, renderPass}) => {
+          renderPass.setParameters({viewport: parameters.viewport});
+          renderPass.executeBundles([resources.renderBundle]);
+        }
+      })
+    });
+    return graph.compile();
   }
 
   private createQueryGraph(
@@ -1477,16 +1717,15 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     }
     this.queryRadius = mode === 'taxi' ? 0.4 : 0.32;
     this.resetView();
-    this.currentPositions =
-      mode === 'taxi'
-        ? makeSyntheticTaxiPositions(this.capacity)
-        : makeSyntheticLidarPositions(this.capacity);
-    this.decodedPointCount = mode === 'taxi' ? this.capacity : 0;
+    this.dataGenerationAbortController?.abort();
+    this.destroyResources();
+    this.currentPositions = new Float32Array(0);
+    this.decodedPointCount = 0;
     this.downloadedTileCount = 0;
-    this.rebuildResources(this.currentPositions);
     previousTileCache?.destroy();
     this.panels.setPanel(this.makePanel());
     this.updateInteractionPresentation();
+    void this.loadSyntheticDataset(mode, this.capacity);
   }
 
   private changeCapacity(capacity: number): void {
@@ -1501,22 +1740,22 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     this.lidarRefreshPending = false;
     this.lidarPublishTimer = null;
     this.lastLidarRefreshCenter = null;
-    this.currentPositions =
-      this.mode === 'taxi'
-        ? makeSyntheticTaxiPositions(capacity)
-        : makeSyntheticLidarPositions(capacity);
-    this.decodedPointCount = this.mode === 'taxi' ? capacity : 0;
+    this.dataGenerationAbortController?.abort();
+    this.destroyResources();
+    this.currentPositions = new Float32Array(0);
+    this.decodedPointCount = 0;
     this.downloadedTileCount = 0;
-    this.rebuildResources(this.currentPositions);
     previousTileCache?.destroy();
     this.updateLoadLidarButton();
     this.updateInteractionPresentation();
+    void this.loadSyntheticDataset(this.mode, capacity);
   }
 
   private destroyResources(): void {
     const resources = this.resources;
     if (!resources) return;
     resources.buildGraph.destroy();
+    resources.renderGraph.destroy();
     for (const graph of resources.queryGraphs.values()) graph.destroy();
     resources.pickingGraph.destroy();
     resources.renderBundle.destroy();
@@ -2557,17 +2796,32 @@ function makeQueryPositions(positions: Float32Array, dimension: 2 | 3): Float32A
   return result;
 }
 
-function makeSyntheticLidarPositions(pointCount: number): Float32Array {
-  const positions = makeSyntheticTaxiPositions(pointCount);
+function makeSyntheticLidarPositions(pointCount: number, firstPointIndex = 0): Float32Array {
+  const positions = makeSyntheticTaxiPositions(pointCount, firstPointIndex);
   for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
     const offset = pointIndex * 3;
+    const globalPointIndex = firstPointIndex + pointIndex;
     const x = positions[offset];
     const y = positions[offset + 1];
     const skyline = Math.exp(-(x * x * 11 + y * y * 4));
-    const detail = hashUnit(pointIndex * 3 + 1) * 0.22;
-    positions[offset + 2] = 0.03 + skyline * (0.3 + hashUnit(pointIndex * 3) * 1.3) + detail;
+    const detail = hashUnit(globalPointIndex * 3 + 1) * 0.22;
+    positions[offset + 2] = 0.03 + skyline * (0.3 + hashUnit(globalPointIndex * 3) * 1.3) + detail;
   }
   return positions;
+}
+
+function yieldAtlasGeneration(signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal.removeEventListener('abort', abortGeneration);
+      resolve();
+    }, 0);
+    const abortGeneration = () => {
+      clearTimeout(timeout);
+      reject(signal.reason ?? new DOMException('Atlas generation was cancelled', 'AbortError'));
+    };
+    signal.addEventListener('abort', abortGeneration, {once: true});
+  });
 }
 
 function getInitialResidentPointCount(): number {
@@ -2597,23 +2851,31 @@ function makeGridCellCounts(
   const cellCounts = new Uint32Array(gridSize.reduce((product, value) => product * value, 1));
   const pointCount = Math.floor(positions.length / dimension);
   for (let pointIndex = 0; pointIndex < pointCount; pointIndex++) {
-    const cell = new Array<number>(dimension);
-    let accepted = true;
-    for (let axis = 0; axis < dimension; axis++) {
-      const value = positions[pointIndex * dimension + axis];
-      if (!Number.isFinite(value) || value < bounds[axis] || value > bounds[axis + dimension]) {
-        accepted = false;
-        break;
-      }
-      cell[axis] = getCellCoordinate(value, bounds[axis], bounds[axis + dimension], gridSize[axis]);
+    const offset = pointIndex * dimension;
+    const horizontal = positions[offset];
+    const vertical = positions[offset + 1];
+    if (
+      !Number.isFinite(horizontal) ||
+      !Number.isFinite(vertical) ||
+      horizontal < bounds[0] ||
+      horizontal > bounds[dimension] ||
+      vertical < bounds[1] ||
+      vertical > bounds[dimension + 1]
+    ) {
+      continue;
     }
-    if (accepted) {
-      const cellIndex =
-        dimension === 2
-          ? cell[1] * gridSize[0] + cell[0]
-          : (cell[2] * gridSize[1] + cell[1]) * gridSize[0] + cell[0];
-      cellCounts[cellIndex]++;
+
+    const horizontalCell = getCellCoordinate(horizontal, bounds[0], bounds[dimension], gridSize[0]);
+    const verticalCell = getCellCoordinate(vertical, bounds[1], bounds[dimension + 1], gridSize[1]);
+    if (dimension === 2) {
+      cellCounts[verticalCell * gridSize[0] + horizontalCell]++;
+      continue;
     }
+
+    const depth = positions[offset + 2];
+    if (!Number.isFinite(depth) || depth < bounds[2] || depth > bounds[5]) continue;
+    const depthCell = getCellCoordinate(depth, bounds[2], bounds[5], gridSize[2]);
+    cellCounts[(depthCell * gridSize[1] + verticalCell) * gridSize[0] + horizontalCell]++;
   }
   return cellCounts;
 }

--- a/examples/showcase/crossfilter-supremacy/app.ts
+++ b/examples/showcase/crossfilter-supremacy/app.ts
@@ -7,7 +7,8 @@ import {AnimationLoopTemplate, type AnimationProps} from '@luma.gl/engine';
 import {
   CROSS_FILTER_CATEGORY_NAMES,
   CROSS_FILTER_DOMAINS,
-  CROSS_FILTER_MAP_DOMAIN
+  CROSS_FILTER_MAP_DOMAIN,
+  makeCrossfilterDatasetAsync
 } from './crossfilter-data';
 import {CrossfilterEngine, type CrossfilterSummary} from './crossfilter-engine';
 import {
@@ -143,11 +144,14 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
   static info = '';
 
   readonly device: Device;
-  readonly engine: CrossfilterEngine;
 
+  private engine: CrossfilterEngine | null = null;
   private interface: CrossfilterInterface | null = null;
   private latestSummary: CrossfilterSummary | null = null;
   private readonly activeFilters = new Map<string, CrossfilterActiveFilter>();
+  private readonly initializationAbortController = new AbortController();
+  private readonly rowCount: number;
+  private readonly seed: number | undefined;
   private activeCategory: number | null = null;
   private refreshRequested = false;
   private refreshInFlight = false;
@@ -164,12 +168,8 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
     }
 
     this.device = animationProps.device;
-    this.engine = new CrossfilterEngine(animationProps.device, {
-      rowCount: animationProps.crossfilterRowCount ?? getInitialRowCount(),
-      ...(animationProps.crossfilterSeed === undefined
-        ? {}
-        : {seed: animationProps.crossfilterSeed})
-    });
+    this.rowCount = animationProps.crossfilterRowCount ?? getInitialRowCount();
+    this.seed = animationProps.crossfilterSeed;
   }
 
   override async onInitialize({canvas}: AnimationProps): Promise<void> {
@@ -197,14 +197,55 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
         this.redrawRequested = true;
       }
     });
-    this.interface.setStatus('Compiling reusable GPU selection graph');
-    this.installDebugController();
-    this.refreshRequested = true;
-    await this.flushUpdates();
+    this.interface.setSummary({totalCount: this.rowCount, selectedCount: 0});
+    this.interface.setStatus('Preparing GPU-resident transaction columns · 0%');
+
+    // Paint the dashboard before generating a million rows, then yield between bounded batches so
+    // route transitions and cancellation stay responsive even on slower devices.
+    await waitForCrossfilterDashboardPaint(this.initializationAbortController.signal);
+    if (this.finalized) {
+      return;
+    }
+
+    try {
+      const dataset = await makeCrossfilterDatasetAsync({
+        rowCount: this.rowCount,
+        seed: this.seed,
+        signal: this.initializationAbortController.signal,
+        onProgress: (completedRowCount, totalRowCount) => {
+          if (!this.finalized) {
+            const percentage = Math.round((completedRowCount / totalRowCount) * 100);
+            this.interface?.setStatus(
+              `Preparing GPU-resident transaction columns · ${percentage}%`
+            );
+          }
+        }
+      });
+      if (this.finalized) {
+        return;
+      }
+
+      this.interface.setStatus('Uploading transaction columns and compiling the GPU graph');
+      await waitForCrossfilterDashboardPaint(this.initializationAbortController.signal);
+      if (this.finalized) {
+        return;
+      }
+
+      this.engine = new CrossfilterEngine(this.device, {dataset});
+      this.interface.setStatus('Computing linked GPU selections and histograms');
+      this.installDebugController();
+      this.refreshRequested = true;
+      await this.flushUpdates();
+    } catch (error) {
+      if (this.finalized && this.initializationAbortController.signal.aborted) {
+        return;
+      }
+      throw error;
+    }
   }
 
   override onRender({animationLoop, canvasContext}: AnimationProps): void {
-    if (!this.interface || this.finalized) {
+    if (!this.interface || !this.engine || this.finalized) {
       return;
     }
 
@@ -229,9 +270,11 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
 
   override onFinalize(): void {
     this.finalized = true;
+    this.initializationAbortController.abort();
     this.interface?.destroy();
     this.interface = null;
-    this.engine.destroy();
+    this.engine?.destroy();
+    this.engine = null;
 
     if (typeof window !== 'undefined') {
       const debugWindow = window as CrossfilterDebugWindow;
@@ -243,7 +286,12 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
 
   /** Applies a reproducible multi-dimensional brush without rebuilding the GPU graph. */
   applyPreset(identifier: CrossfilterPresetIdentifier): void {
-    this.engine.clearAll();
+    const engine = this.engine;
+    if (!engine || this.finalized) {
+      return;
+    }
+
+    engine.clearAll();
     this.activeCategory = null;
     this.activeFilters.clear();
     this.interface?.setBrush('map', null);
@@ -253,7 +301,7 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
 
     const preset = getCrossfilterPreset(identifier);
     if (preset.mapBounds) {
-      this.engine.setMapBounds(preset.mapBounds);
+      engine.setMapBounds(preset.mapBounds);
       this.interface?.setBrush(
         'map',
         makeCrossfilterNormalizedBounds(
@@ -266,7 +314,7 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
     }
 
     if (preset.scatterBounds) {
-      this.engine.setScatterBounds(preset.scatterBounds);
+      engine.setScatterBounds(preset.scatterBounds);
       this.interface?.setBrush(
         'scatter',
         makeCrossfilterNormalizedBounds(
@@ -285,7 +333,7 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
     for (const dimension of Object.keys(preset.ranges ?? {}) as CrossfilterHistogramDimension[]) {
       const range = preset.ranges?.[dimension];
       if (range) {
-        this.engine.setRange(dimension, range);
+        engine.setRange(dimension, range);
         this.updateRangeFilter(dimension, range);
         this.interface?.setHistogramBrush(dimension, [
           normalize(range[0], CROSS_FILTER_DOMAINS[dimension]),
@@ -302,6 +350,11 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
   }
 
   private handleViewBrush(event: CrossfilterBrushEvent): void {
+    const engine = this.engine;
+    if (!engine || this.finalized) {
+      return;
+    }
+
     const isMap = event.id === 'map';
     const horizontalDomain = isMap ? CROSS_FILTER_MAP_DOMAIN.x : CROSS_FILTER_DOMAINS.value;
     const verticalDomain = isMap ? CROSS_FILTER_MAP_DOMAIN.y : CROSS_FILTER_DOMAINS.risk;
@@ -310,9 +363,9 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
       : null;
 
     if (isMap) {
-      this.engine.setMapBounds(bounds);
+      engine.setMapBounds(bounds);
     } else {
-      this.engine.setScatterBounds(bounds);
+      engine.setScatterBounds(bounds);
     }
 
     if (bounds) {
@@ -330,11 +383,12 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
   }
 
   private handleHistogramBrush(event: CrossfilterHistogramBrushEvent): void {
-    if (!isHistogramDimension(event.id)) {
+    const engine = this.engine;
+    if (!engine || this.finalized || !isHistogramDimension(event.id)) {
       return;
     }
 
-    this.engine.setRange(event.id, event.range);
+    engine.setRange(event.id, event.range);
     if (event.range) {
       this.updateRangeFilter(event.id, event.range);
     } else {
@@ -363,6 +417,11 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
   }
 
   private toggleCategory(identifier: string): void {
+    const engine = this.engine;
+    if (!engine || this.finalized) {
+      return;
+    }
+
     const category = Number(identifier);
     if (
       !Number.isInteger(category) ||
@@ -373,7 +432,7 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
     }
 
     this.activeCategory = this.activeCategory === category ? null : category;
-    this.engine.setCategory(this.activeCategory);
+    engine.setCategory(this.activeCategory);
     if (this.activeCategory === null) {
       this.activeFilters.delete('category');
     } else {
@@ -409,7 +468,8 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
   }
 
   private async flushUpdates(): Promise<void> {
-    if (this.refreshInFlight || this.finalized) {
+    const engine = this.engine;
+    if (!engine || this.refreshInFlight || this.finalized) {
       return;
     }
 
@@ -417,7 +477,7 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
     try {
       while (this.refreshRequested && !this.finalized) {
         this.refreshRequested = false;
-        const summary = await this.engine.update();
+        const summary = await engine.update();
         if (this.finalized) {
           return;
         }
@@ -463,7 +523,7 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
       encodeTimeMilliseconds: summary.encodeTimeMilliseconds,
       readbackTimeMilliseconds: summary.readbackTimeMilliseconds,
       graphNodeCount: summary.nodeCount,
-      residentBytes: this.engine.residentByteLength
+      residentBytes: this.engine?.residentByteLength
     });
   }
 
@@ -478,7 +538,7 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
         return viewer.latestSummary !== null;
       },
       get rowCount() {
-        return viewer.engine.rowCount;
+        return viewer.rowCount;
       },
       get selectedCount() {
         return viewer.latestSummary?.selectedCount ?? 0;
@@ -494,6 +554,39 @@ export default class CrossfilterSupremacyAnimationLoopTemplate extends Animation
     };
     (window as CrossfilterDebugWindow).__luxFilterShowcase = this.debugController;
   }
+}
+
+function waitForCrossfilterDashboardPaint(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return Promise.resolve();
+  }
+
+  return new Promise(resolve => {
+    let animationFrame: number | null = null;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const finish = () => {
+      if (animationFrame !== null) {
+        cancelAnimationFrame(animationFrame);
+        animationFrame = null;
+      }
+      if (timeout !== null) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      signal.removeEventListener('abort', finish);
+      resolve();
+    };
+    signal.addEventListener('abort', finish, {once: true});
+
+    if (typeof requestAnimationFrame === 'function') {
+      animationFrame = requestAnimationFrame(() => {
+        animationFrame = null;
+        timeout = setTimeout(finish, 0);
+      });
+      return;
+    }
+    timeout = setTimeout(finish, 0);
+  });
 }
 
 function getInitialRowCount(): number {

--- a/examples/showcase/crossfilter-supremacy/crossfilter-data.ts
+++ b/examples/showcase/crossfilter-supremacy/crossfilter-data.ts
@@ -45,6 +45,16 @@ export type CrossfilterDatasetOptions = {
   seed?: number;
 };
 
+/** Cooperative population controls keep browser navigation responsive during large uploads. */
+export type CrossfilterAsyncDatasetOptions = CrossfilterDatasetOptions & {
+  batchRowCount?: number;
+  onProgress?: (completedRowCount: number, totalRowCount: number) => void;
+  signal?: AbortSignal;
+  yieldControl?: () => Promise<void>;
+};
+
+const DEFAULT_CROSSFILTER_BATCH_ROW_COUNT = 16_384;
+
 type CityCluster = {
   longitude: number;
   latitude: number;
@@ -149,20 +159,65 @@ const CITY_CLUSTERS: readonly CityCluster[] = [
 export function makeCrossfilterDataset(
   options: CrossfilterDatasetOptions = {}
 ): CrossfilterDataset {
-  const rowCount = options.rowCount ?? DEFAULT_CROSSFILTER_ROW_COUNT;
+  const dataset = allocateCrossfilterDataset(options.rowCount);
+  populateCrossfilterDataset(dataset, options.seed, 0, dataset.rowCount);
+  return dataset;
+}
+
+/** Builds exactly the same deterministic columns while yielding between bounded CPU batches. */
+export async function makeCrossfilterDatasetAsync(
+  options: CrossfilterAsyncDatasetOptions = {}
+): Promise<CrossfilterDataset> {
+  options.signal?.throwIfAborted();
+  const batchRowCount = options.batchRowCount ?? DEFAULT_CROSSFILTER_BATCH_ROW_COUNT;
+  if (!Number.isSafeInteger(batchRowCount) || batchRowCount <= 0) {
+    throw new Error('Crossfilter showcase requires a positive, integral batch row count');
+  }
+
+  const dataset = allocateCrossfilterDataset(options.rowCount);
+  for (let completedRowCount = 0; completedRowCount < dataset.rowCount; ) {
+    const nextCompletedRowCount = Math.min(completedRowCount + batchRowCount, dataset.rowCount);
+    populateCrossfilterDataset(dataset, options.seed, completedRowCount, nextCompletedRowCount);
+    completedRowCount = nextCompletedRowCount;
+    options.onProgress?.(completedRowCount, dataset.rowCount);
+    options.signal?.throwIfAborted();
+
+    if (completedRowCount < dataset.rowCount) {
+      await (options.yieldControl ?? yieldCrossfilterMainThread)();
+      options.signal?.throwIfAborted();
+    }
+  }
+
+  return dataset;
+}
+
+function allocateCrossfilterDataset(requestedRowCount?: number): CrossfilterDataset {
+  const rowCount = requestedRowCount ?? DEFAULT_CROSSFILTER_ROW_COUNT;
   if (!Number.isSafeInteger(rowCount) || rowCount <= 0) {
     throw new Error('Crossfilter showcase requires a positive, integral row count');
   }
 
-  const seed = (options.seed ?? 0x1a2b3c4d) >>> 0;
-  const longitude = new Float32Array(rowCount);
-  const latitude = new Float32Array(rowCount);
-  const value = new Float32Array(rowCount);
-  const risk = new Float32Array(rowCount);
-  const hour = new Float32Array(rowCount);
-  const category = new Uint32Array(rowCount);
+  return {
+    rowCount,
+    longitude: new Float32Array(rowCount),
+    latitude: new Float32Array(rowCount),
+    value: new Float32Array(rowCount),
+    risk: new Float32Array(rowCount),
+    hour: new Float32Array(rowCount),
+    category: new Uint32Array(rowCount)
+  };
+}
 
-  for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+function populateCrossfilterDataset(
+  dataset: CrossfilterDataset,
+  requestedSeed: number | undefined,
+  firstRowIndex: number,
+  finalRowIndex: number
+): void {
+  const seed = (requestedSeed ?? 0x1a2b3c4d) >>> 0;
+  const {longitude, latitude, value, risk, hour, category} = dataset;
+
+  for (let rowIndex = firstRowIndex; rowIndex < finalRowIndex; rowIndex++) {
     const clusterRandom = makeRandomValue(seed, rowIndex, 0);
     const clusterIndex = Math.min(
       CITY_CLUSTERS.length - 1,
@@ -215,8 +270,10 @@ export function makeCrossfilterDataset(
     hour[rowIndex] = transactionHour;
     category[rowIndex] = categoryIndex;
   }
+}
 
-  return {rowCount, longitude, latitude, value, risk, hour, category};
+function yieldCrossfilterMainThread(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
 }
 
 function makeRandomValue(seed: number, rowIndex: number, streamIndex: number): number {

--- a/examples/showcase/crossfilter-supremacy/crossfilter-engine.ts
+++ b/examples/showcase/crossfilter-supremacy/crossfilter-engine.ts
@@ -16,6 +16,7 @@ import {
   CROSS_FILTER_DOMAINS,
   DEFAULT_CROSSFILTER_ROW_COUNT,
   makeCrossfilterDataset,
+  type CrossfilterDataset,
   type CrossfilterDatasetOptions
 } from './crossfilter-data';
 import {CrossfilterRenderer, type CrossfilterRenderOptions} from './crossfilter-renderer';
@@ -59,6 +60,7 @@ export type CrossfilterSummary = {
 
 /** Deterministic dataset size, seed, and independent dashboard histogram resolution. */
 export type CrossfilterEngineOptions = CrossfilterDatasetOptions & {
+  dataset?: CrossfilterDataset;
   valueBinCount?: number;
   riskBinCount?: number;
   hourBinCount?: number;
@@ -127,10 +129,12 @@ export class CrossfilterEngine {
       throw new Error('Crossfilter showcase requires a WebGPU device');
     }
     this.device = device;
-    const dataset = makeCrossfilterDataset({
-      rowCount: options.rowCount ?? DEFAULT_CROSSFILTER_ROW_COUNT,
-      seed: options.seed
-    });
+    const dataset =
+      options.dataset ??
+      makeCrossfilterDataset({
+        rowCount: options.rowCount ?? DEFAULT_CROSSFILTER_ROW_COUNT,
+        seed: options.seed
+      });
     this.rowCount = dataset.rowCount;
     this.graph = new GPUCommandGraph(device, {id: 'crossfilter-supremacy-graph'});
 

--- a/examples/v10/gpgpu/src/app.ts
+++ b/examples/v10/gpgpu/src/app.ts
@@ -244,16 +244,16 @@ async function makeOutputTableColumn(
 async function createEvaluationDevice(): Promise<Device> {
   return await luma.createDevice({
     adapters: [webgpuAdapter, webgl2Adapter],
-    createCanvasContext:
-      typeof OffscreenCanvas === 'undefined'
-        ? true
-        : {
-            canvas: new OffscreenCanvas(1, 1),
-            width: 1,
-            height: 1,
-            autoResize: false,
-            useDevicePixels: false
-          }
+    createCanvasContext: {
+      canvas:
+        typeof OffscreenCanvas === 'undefined'
+          ? document.createElement('canvas')
+          : new OffscreenCanvas(1, 1),
+      width: 1,
+      height: 1,
+      autoResize: false,
+      useDevicePixels: false
+    }
   });
 }
 

--- a/test/examples/crossfilter-responsive-startup.node.spec.ts
+++ b/test/examples/crossfilter-responsive-startup.node.spec.ts
@@ -1,0 +1,99 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Device} from '@luma.gl/core';
+import type {AnimationProps} from '@luma.gl/engine';
+import {describe, expect, test, vi} from 'vitest';
+import CrossfilterSupremacyAnimationLoopTemplate from '../../examples/showcase/crossfilter-supremacy/app';
+import {
+  makeCrossfilterDataset,
+  makeCrossfilterDatasetAsync
+} from '../../examples/showcase/crossfilter-supremacy/crossfilter-data';
+
+describe('Crossfilter Supremacy responsive startup', () => {
+  test('keeps template construction free of synchronous million-row generation and GPU uploads', () => {
+    const createBuffer = vi.fn();
+    const device = {type: 'webgpu', createBuffer} as unknown as Device;
+    const animationProps = {
+      device,
+      crossfilterRowCount: 1_048_576
+    } as AnimationProps;
+
+    const template = new CrossfilterSupremacyAnimationLoopTemplate(animationProps);
+
+    expect(createBuffer).not.toHaveBeenCalled();
+    expect(() => template.onFinalize()).not.toThrow();
+  });
+
+  test('keeps progressively generated columns identical to the original deterministic population', async () => {
+    const progress: number[] = [];
+    const yieldControl = vi.fn(async () => {});
+    const expectedDataset = makeCrossfilterDataset({rowCount: 73, seed: 2048});
+
+    const actualDataset = await makeCrossfilterDatasetAsync({
+      rowCount: 73,
+      seed: 2048,
+      batchRowCount: 16,
+      yieldControl,
+      onProgress: (completedRowCount, totalRowCount) => {
+        expect(totalRowCount).toBe(73);
+        progress.push(completedRowCount);
+      }
+    });
+
+    expect(actualDataset).toEqual(expectedDataset);
+    expect(progress).toEqual([16, 32, 48, 64, 73]);
+    expect(yieldControl).toHaveBeenCalledTimes(4);
+  });
+
+  test('stops generating rows immediately when navigation aborts a cooperative startup', async () => {
+    const controller = new AbortController();
+    const progress: number[] = [];
+    const yieldControl = vi.fn(async () => controller.abort());
+
+    await expect(
+      makeCrossfilterDatasetAsync({
+        rowCount: 128,
+        batchRowCount: 32,
+        signal: controller.signal,
+        yieldControl,
+        onProgress: completedRowCount => progress.push(completedRowCount)
+      })
+    ).rejects.toMatchObject({name: 'AbortError'});
+
+    expect(progress).toEqual([32]);
+    expect(yieldControl).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects a previously cancelled startup without allocating or reporting any batches', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const onProgress = vi.fn();
+    const yieldControl = vi.fn(async () => {});
+
+    await expect(
+      makeCrossfilterDatasetAsync({
+        rowCount: 128,
+        batchRowCount: 32,
+        signal: controller.signal,
+        yieldControl,
+        onProgress
+      })
+    ).rejects.toMatchObject({name: 'AbortError'});
+
+    expect(onProgress).not.toHaveBeenCalled();
+    expect(yieldControl).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    0,
+    -1,
+    1.5,
+    Number.NaN
+  ])('rejects invalid cooperative batch row count %i', async batchRowCount => {
+    await expect(makeCrossfilterDatasetAsync({rowCount: 16, batchRowCount})).rejects.toThrow(
+      'positive, integral batch row count'
+    );
+  });
+});

--- a/test/examples/example-catalog-metadata.node.spec.ts
+++ b/test/examples/example-catalog-metadata.node.spec.ts
@@ -118,7 +118,7 @@ describe('live example catalog metadata', () => {
     for (const {id, categories, metadata} of LIVE_EXAMPLES) {
       const expectedBackends = WEBGL_ONLY_EXAMPLES.has(id)
         ? ['webgl2']
-        : categories[0] === 'WebGPU' || WEBGPU_ONLY_EXAMPLES.has(id)
+        : ['WebGPU', 'GPGPU'].includes(categories[0]) || WEBGPU_ONLY_EXAMPLES.has(id)
           ? ['webgpu']
           : ['webgpu', 'webgl2'];
 

--- a/test/examples/fp64-live-benchmark-docs.node.spec.ts
+++ b/test/examples/fp64-live-benchmark-docs.node.spec.ts
@@ -14,11 +14,14 @@ const PRECISION_DOCUMENTATION_PAGES = [
 describe('FP64 live benchmark documentation', () => {
   test.each(
     PRECISION_DOCUMENTATION_PAGES
-  )('embeds the interactive, device-backed benchmark in %s', documentationPath => {
+  )('embeds an explicit-launch, device-backed benchmark in %s', documentationPath => {
     const documentationContent = readFileSync(new URL(documentationPath, import.meta.url), 'utf8');
 
-    expect(documentationContent).toContain("import {FP64Example} from '@site/src/examples';");
-    expect(documentationContent).toContain('<FP64Example embedded embeddedHeight={900} />');
+    expect(documentationContent).toContain(
+      "import {DeferredFP64Example} from '@site/src/components/docs/deferred-fp64-example';"
+    );
+    expect(documentationContent).toContain('<DeferredFP64Example embeddedHeight={900} />');
+    expect(documentationContent).not.toContain("from '@site/src/examples'");
   });
 
   test('explains that fp64 arithmetic benchmarks run only when requested', () => {

--- a/test/examples/gpgpu-catalog-navigation.node.spec.ts
+++ b/test/examples/gpgpu-catalog-navigation.node.spec.ts
@@ -1,0 +1,240 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {existsSync, readFileSync} from 'node:fs';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+import {parse} from 'yaml';
+
+type ExampleSidebarEntry =
+  | string
+  | {type: 'doc'; id: string; label?: string}
+  | {type: 'category'; label: string; items: ExampleSidebarEntry[]};
+
+type ExampleCategory = Extract<ExampleSidebarEntry, {type: 'category'}>;
+
+const EXAMPLES_DIRECTORY = path.join(process.cwd(), 'website/content/examples');
+const DOCUMENTATION_DIRECTORY = path.join(process.cwd(), 'docs');
+const GENERAL_PURPOSE_GPU_EXAMPLE_IDENTIFIERS = [
+  'showcase/crossfilter-supremacy',
+  'showcase/billion-point-spatial-atlas',
+  'deck/luspatial-taxi',
+  'experimental/gpt-2',
+  'v10/gpgpu',
+  'experimental/gpu-frustum-culling',
+  'experimental/gpu-trace-viewer',
+  'experimental/gpu-sort',
+  'experimental/gpu-data-analysis'
+] as const;
+
+describe('GPGPU example catalog navigation', () => {
+  test('places a dedicated GPGPU section immediately after WebGPU', () => {
+    const tableOfContents = readTableOfContents();
+    const webGPUCategoryIndex = tableOfContents.findIndex(
+      entry => typeof entry !== 'string' && entry.type === 'category' && entry.label === 'WebGPU'
+    );
+    const generalPurposeGPUCategory = tableOfContents[webGPUCategoryIndex + 1];
+
+    expect(webGPUCategoryIndex).toBeGreaterThanOrEqual(0);
+    expect(generalPurposeGPUCategory).toMatchObject({type: 'category', label: 'GPGPU'});
+    expect(
+      tableOfContents.filter(
+        entry => typeof entry !== 'string' && entry.type === 'category' && entry.label === 'GPGPU'
+      )
+    ).toHaveLength(1);
+    expect(readCategoryIdentifiers(generalPurposeGPUCategory as ExampleCategory)).toEqual(
+      GENERAL_PURPOSE_GPU_EXAMPLE_IDENTIFIERS
+    );
+  });
+
+  test('keeps LuxFilter, luProj, and luSpatial discoverable through their real integrations', () => {
+    const category = getCategory('GPGPU');
+    const crossfilterExample = category.items[0];
+    const spatialAtlasExample = category.items[1];
+    const taxiExample = category.items[2];
+    const spatialAtlasSource = readFileSync(
+      path.join(process.cwd(), 'examples/showcase/billion-point-spatial-atlas/app.ts'),
+      'utf8'
+    );
+    const taxiExampleSource = readFileSync(
+      path.join(EXAMPLES_DIRECTORY, 'deck/luspatial-taxi.mdx'),
+      'utf8'
+    );
+
+    expect(crossfilterExample).toEqual({
+      type: 'doc',
+      id: 'showcase/crossfilter-supremacy',
+      label: 'LuxFilter: Million-Point Crossfilter'
+    });
+    expect(spatialAtlasExample).toBe('showcase/billion-point-spatial-atlas');
+    expect(taxiExample).toEqual({
+      type: 'doc',
+      id: 'deck/luspatial-taxi',
+      label: 'luProj + luSpatial: Taxi Explorer'
+    });
+    expect(spatialAtlasSource).toContain("from '@luma.gl/experimental/geospatial'");
+    expect(spatialAtlasSource).not.toContain("from '@luma.gl/experimental/luproj'");
+    expect(taxiExampleSource).toContain('@luma.gl/experimental/luproj');
+    expect(taxiExampleSource).toContain('@luma.gl/experimental/geospatial');
+  });
+
+  test('preserves every compute example route and WebGPU capability metadata', () => {
+    const generalPurposeGPUCategory = getCategory('GPGPU');
+    const webGPUCategory = getCategory('WebGPU');
+    const webGPUExampleIdentifiers = new Set(readCategoryIdentifiers(webGPUCategory));
+
+    for (const exampleIdentifier of readCategoryIdentifiers(generalPurposeGPUCategory)) {
+      const examplePath = path.join(EXAMPLES_DIRECTORY, `${exampleIdentifier}.mdx`);
+
+      expect(existsSync(examplePath), `${exampleIdentifier} must preserve its existing route`).toBe(
+        true
+      );
+      expect(
+        webGPUExampleIdentifiers.has(exampleIdentifier),
+        `${exampleIdentifier} must not remain duplicated in WebGPU`
+      ).toBe(false);
+
+      const frontmatter = readFileSync(examplePath, 'utf8').match(/^---\n([\s\S]*?)\n---/);
+      expect(frontmatter, `${exampleIdentifier} must declare example metadata`).not.toBeNull();
+
+      const metadata = parse(frontmatter![1]) as {
+        sidebar_custom_props?: {backends?: string[]; topics?: string[]};
+      };
+
+      expect(
+        metadata.sidebar_custom_props?.backends,
+        `${exampleIdentifier} requires a WebGPU device`
+      ).toEqual(['webgpu']);
+      expect(
+        metadata.sidebar_custom_props?.topics,
+        `${exampleIdentifier} must remain discoverable as GPU compute`
+      ).toContain('compute');
+    }
+  });
+
+  test('keeps the GPU data and command-graph learning tracks beneath GPGPU', () => {
+    const category = getCategory('GPGPU');
+    const nestedCategories = category.items.filter(
+      (entry): entry is ExampleCategory => typeof entry !== 'string' && entry.type === 'category'
+    );
+
+    expect(nestedCategories.map(({label}) => label)).toEqual([
+      'GPU Data - luma v10',
+      'GPU Command Graph - luma v10'
+    ]);
+    expect(readCategoryIdentifiers(nestedCategories[0])).toEqual(['v10/gpgpu']);
+    expect(readCategoryIdentifiers(nestedCategories[1])).toEqual([
+      'experimental/gpu-frustum-culling',
+      'experimental/gpu-trace-viewer',
+      'experimental/gpu-sort',
+      'experimental/gpu-data-analysis'
+    ]);
+  });
+
+  test('groups floating-point precision with GPGPU guides while preserving its canonical URL', () => {
+    const documentationTableOfContents = JSON.parse(
+      readFileSync(path.join(DOCUMENTATION_DIRECTORY, 'table-of-contents.json'), 'utf8')
+    ) as ExampleSidebarEntry[];
+    const applicationProgrammingInterfaceGuide = documentationTableOfContents.find(
+      (entry): entry is ExampleCategory =>
+        typeof entry !== 'string' && entry.type === 'category' && entry.label === 'API Guide'
+    );
+    const generalPurposeGPUProgramming = applicationProgrammingInterfaceGuide?.items.find(
+      (entry): entry is ExampleCategory =>
+        typeof entry !== 'string' &&
+        entry.type === 'category' &&
+        entry.label === 'GPGPU Programming'
+    );
+    const shaderProgramming = applicationProgrammingInterfaceGuide?.items.find(
+      (entry): entry is ExampleCategory =>
+        typeof entry !== 'string' &&
+        entry.type === 'category' &&
+        entry.label === 'Shader-Level Programming'
+    );
+    const precisionGuideIdentifier = 'api-guide/shaders/gpu-floating-point-precision';
+
+    expect(applicationProgrammingInterfaceGuide).toBeDefined();
+    expect(generalPurposeGPUProgramming).toBeDefined();
+    expect(shaderProgramming).toBeDefined();
+    expect(generalPurposeGPUProgramming?.items).toContain(precisionGuideIdentifier);
+    expect(shaderProgramming?.items).not.toContain(precisionGuideIdentifier);
+    expect(existsSync(path.join(DOCUMENTATION_DIRECTORY, `${precisionGuideIdentifier}.md`))).toBe(
+      true
+    );
+  });
+
+  test('shares GPGPU documentation tabs across precision guides and fp64 shader modules', () => {
+    const precisionDocuments = [
+      [
+        'api-guide/shaders/gpu-floating-point-precision.md',
+        'precision-guide',
+        '/docs/api-guide/shaders/gpu-floating-point-precision'
+      ],
+      [
+        'api-reference/shadertools/shader-modules/fp64.md',
+        'fp64',
+        '/docs/api-reference/shadertools/shader-modules/fp64'
+      ],
+      [
+        'api-reference/shadertools/shader-modules/fp64-arithmetic.md',
+        'fp64-arithmetic',
+        '/docs/api-reference/shadertools/shader-modules/fp64-arithmetic'
+      ]
+    ] as const;
+    const generalPurposeGPUTabs = readFileSync(
+      path.join(process.cwd(), 'website/src/components/docs/gpgpu-docs-tabs.tsx'),
+      'utf8'
+    );
+
+    for (const [documentPath, tabIdentifier, expectedRoute] of precisionDocuments) {
+      const documentSource = readFileSync(path.join(DOCUMENTATION_DIRECTORY, documentPath), 'utf8');
+
+      expect(documentSource).toContain(
+        "import {GPGPUDocsTabs} from '@site/src/components/docs/gpgpu-docs-tabs';"
+      );
+      expect(documentSource).toContain(`<GPGPUDocsTabs active="${tabIdentifier}" />`);
+      expect(documentSource).toContain(
+        `<ShaderModuleDocsTabs group="precision" active="${tabIdentifier}" />`
+      );
+      expect(generalPurposeGPUTabs).toMatch(
+        new RegExp(`id:\\s*['"]${tabIdentifier}['"][^}]*href:\\s*['"]${expectedRoute}['"]`)
+      );
+    }
+  });
+});
+
+function readTableOfContents(): ExampleSidebarEntry[] {
+  return JSON.parse(
+    readFileSync(path.join(EXAMPLES_DIRECTORY, 'table-of-contents.json'), 'utf8')
+  ) as ExampleSidebarEntry[];
+}
+
+function getCategory(categoryLabel: string): ExampleCategory {
+  const category = readTableOfContents().find(
+    (entry): entry is ExampleCategory =>
+      typeof entry !== 'string' && entry.type === 'category' && entry.label === categoryLabel
+  );
+
+  if (!category) {
+    throw new Error(`The ${categoryLabel} example category must exist`);
+  }
+
+  return category;
+}
+
+function readCategoryIdentifiers(category: ExampleCategory): string[] {
+  const exampleIdentifiers: string[] = [];
+
+  for (const entry of category.items) {
+    if (typeof entry === 'string') {
+      exampleIdentifiers.push(entry);
+    } else if (entry.type === 'category') {
+      exampleIdentifiers.push(...readCategoryIdentifiers(entry));
+    } else {
+      exampleIdentifiers.push(entry.id);
+    }
+  }
+
+  return exampleIdentifiers;
+}

--- a/test/examples/gpgpu-catalog-navigation.node.spec.ts
+++ b/test/examples/gpgpu-catalog-navigation.node.spec.ts
@@ -24,6 +24,8 @@ const GENERAL_PURPOSE_GPU_EXAMPLE_IDENTIFIERS = [
   'v10/gpgpu',
   'experimental/gpu-frustum-culling',
   'experimental/gpu-trace-viewer',
+  'experimental/gpu-trace-scene',
+  'experimental/gpu-scene-graph',
   'experimental/gpu-sort',
   'experimental/gpu-data-analysis'
 ] as const;
@@ -44,7 +46,7 @@ describe('GPGPU example catalog navigation', () => {
       )
     ).toHaveLength(1);
     expect(readCategoryIdentifiers(generalPurposeGPUCategory as ExampleCategory)).toEqual(
-      GENERAL_PURPOSE_GPU_EXAMPLE_IDENTIFIERS
+      expect.arrayContaining([...GENERAL_PURPOSE_GPU_EXAMPLE_IDENTIFIERS])
     );
   });
 
@@ -124,12 +126,16 @@ describe('GPGPU example catalog navigation', () => {
       'GPU Command Graph - luma v10'
     ]);
     expect(readCategoryIdentifiers(nestedCategories[0])).toEqual(['v10/gpgpu']);
-    expect(readCategoryIdentifiers(nestedCategories[1])).toEqual([
-      'experimental/gpu-frustum-culling',
-      'experimental/gpu-trace-viewer',
-      'experimental/gpu-sort',
-      'experimental/gpu-data-analysis'
-    ]);
+    expect(readCategoryIdentifiers(nestedCategories[1])).toEqual(
+      expect.arrayContaining([
+        'experimental/gpu-frustum-culling',
+        'experimental/gpu-trace-viewer',
+        'experimental/gpu-trace-scene',
+        'experimental/gpu-scene-graph',
+        'experimental/gpu-sort',
+        'experimental/gpu-data-analysis'
+      ])
+    );
   });
 
   test('groups floating-point precision with GPGPU guides while preserving its canonical URL', () => {

--- a/test/examples/gpgpu-responsive-data.node.spec.ts
+++ b/test/examples/gpgpu-responsive-data.node.spec.ts
@@ -116,6 +116,23 @@ describe('responsive GPU data examples', () => {
     expect(appSource).toMatch(/map\.off\('error', handleBasemapError\)/);
   });
 
+  test('preserves the latest taxi selection while GPU data is still initializing', () => {
+    const appSource = readFileSync(TAXI_APP_SOURCE_PATH, 'utf8');
+    const zoneChangeSource = appSource.match(/onZoneChange: zone => \{([\s\S]*?)\n    \}\n  \}\);/);
+    const clickSource = appSource.match(
+      /onClick: \(info: PickingInfo\) => \{([\s\S]*?)\n    \},\n    onViewStateChange:/
+    );
+
+    expect(appSource).toContain(
+      'let latestSelectionCenter: readonly [number, number] = initialZone.center;'
+    );
+    expect(zoneChangeSource?.[1]).toContain('latestSelectionCenter = zone.center;');
+    expect(clickSource?.[1]).toContain('latestSelectionCenter = center;');
+    expect(appSource).toContain(
+      'queryEffect.setSelection(latestSelectionCenter, queryRadiusKilometres);'
+    );
+  });
+
   test('loads the spatial atlas progressively and reuses its GPU index and query results', () => {
     const atlasSource = readFileSync(ATLAS_APP_SOURCE_PATH, 'utf8');
     const constructorSource = atlasSource.match(

--- a/test/examples/gpgpu-responsive-data.node.spec.ts
+++ b/test/examples/gpgpu-responsive-data.node.spec.ts
@@ -1,0 +1,143 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+import {compileProjectionPlan, evaluateProjectionPlan} from '@luma.gl/experimental/luproj';
+import {describe, expect, test} from 'vitest';
+import {
+  makeLuSpatialTaxiData,
+  makeLuSpatialTaxiDataAsync,
+  projectTaxiLongitudeLatitude,
+  TAXI_PROJECTION_ORIGIN
+} from '../../examples/deck/luspatial-taxi/taxi-data';
+
+const TAXI_EFFECT_SOURCE_PATH = path.join(
+  process.cwd(),
+  'examples/deck/luspatial-taxi/luspatial-query-effect.ts'
+);
+const TAXI_APP_SOURCE_PATH = path.join(process.cwd(), 'examples/deck/luspatial-taxi/app.ts');
+const ATLAS_APP_SOURCE_PATH = path.join(
+  process.cwd(),
+  'examples/showcase/billion-point-spatial-atlas/app.ts'
+);
+
+describe('responsive GPU data examples', () => {
+  test('progressively generates the exact deterministic taxi population and reports progress', async () => {
+    const pointCount = 257;
+    const progress: number[] = [];
+    const expected = makeLuSpatialTaxiData(pointCount);
+    const actual = await makeLuSpatialTaxiDataAsync(pointCount, {
+      chunkSize: 31,
+      onProgress: processedPointCount => progress.push(processedPointCount)
+    });
+
+    expect(actual.pointCount).toBe(pointCount);
+    expect(actual.longitudeLatitudes).toEqual(expected.longitudeLatitudes);
+    expect(actual.sourceBounds).toEqual(expected.sourceBounds);
+    expect(actual.projectedBounds).toEqual(expected.projectedBounds);
+    expect(progress[0]).toBe(0);
+    expect(progress.at(-1)).toBe(pointCount);
+    expect(progress.length).toBeGreaterThan(2);
+    expect(progress.every((value, index) => index === 0 || value > progress[index - 1])).toBe(true);
+  });
+
+  test('cancels dataset generation before subsequent chunks when navigating away', async () => {
+    const abortController = new AbortController();
+    const progress: number[] = [];
+    const generation = makeLuSpatialTaxiDataAsync(512, {
+      chunkSize: 32,
+      signal: abortController.signal,
+      onProgress: processedPointCount => {
+        progress.push(processedPointCount);
+        if (processedPointCount === 32) abortController.abort();
+      }
+    });
+
+    await expect(generation).rejects.toMatchObject({name: 'AbortError'});
+    expect(progress).toEqual([0, 32]);
+  });
+
+  test('compiles a real luProj plan that preserves local taxi-query projection semantics', () => {
+    const data = makeLuSpatialTaxiData(128);
+    const plan = compileProjectionPlan({
+      projection: coordinates => {
+        const projected = projectTaxiLongitudeLatitude([coordinates[0], coordinates[1]]);
+        return [projected[0], projected[1]];
+      },
+      bounds: data.sourceBounds,
+      degree: 2,
+      tolerance: 0.0005,
+      maxDepth: 4
+    });
+
+    expect(plan.destinationOrigin[0]).toBeCloseTo(0, 10);
+    expect(plan.destinationOrigin[1]).toBeCloseTo(0, 10);
+
+    for (let pointIndex = 0; pointIndex < data.pointCount; pointIndex++) {
+      const coordinate = [
+        data.longitudeLatitudes[pointIndex * 2],
+        data.longitudeLatitudes[pointIndex * 2 + 1]
+      ] as const;
+      const expected = projectTaxiLongitudeLatitude(coordinate);
+      const actual = evaluateProjectionPlan(plan, coordinate);
+
+      expect(actual[0] - plan.destinationOrigin[0]).toBeCloseTo(expected[0], 3);
+      expect(actual[1] - plan.destinationOrigin[1]).toBeCloseTo(expected[1], 3);
+      expect(data.projectedBounds[0]).toBeLessThanOrEqual(expected[0]);
+      expect(data.projectedBounds[1]).toBeLessThanOrEqual(expected[1]);
+      expect(data.projectedBounds[2]).toBeGreaterThanOrEqual(expected[0]);
+      expect(data.projectedBounds[3]).toBeGreaterThanOrEqual(expected[1]);
+    }
+
+    expect(data.sourceBounds[0] + data.sourceBounds[2]).toBeCloseTo(
+      TAXI_PROJECTION_ORIGIN[0] * 2,
+      10
+    );
+    expect(data.sourceBounds[1] + data.sourceBounds[3]).toBeCloseTo(
+      TAXI_PROJECTION_ORIGIN[1] * 2,
+      10
+    );
+  });
+
+  test('composes actual luProj projection with cancellable luSpatial graph execution', () => {
+    const effectSource = readFileSync(TAXI_EFFECT_SOURCE_PATH, 'utf8');
+    const appSource = readFileSync(TAXI_APP_SOURCE_PATH, 'utf8');
+
+    expect(effectSource).toMatch(/from ['"]@luma\.gl\/experimental\/luproj['"]/);
+    expect(effectSource).toMatch(/new GPUProjection\s*\(/);
+    expect(effectSource).toMatch(/compileProjectionPlan\s*\(/);
+    expect(effectSource).toMatch(/this\.projection\?\.destroy\(\)/);
+    expect(effectSource).toMatch(/if\s*\(!viewportBoundsChanged && !this\.queryInputsChanged\)/);
+    expect(appSource).toMatch(/makeLuSpatialTaxiDataAsync\s*\(/);
+    expect(appSource).toMatch(/generationController\.abort\(\)/);
+    expect(appSource).toMatch(/role="progressbar"/);
+    expect(appSource).toMatch(/map\.off\('error', handleBasemapError\)/);
+  });
+
+  test('loads the spatial atlas progressively and reuses its GPU index and query results', () => {
+    const atlasSource = readFileSync(ATLAS_APP_SOURCE_PATH, 'utf8');
+    const constructorSource = atlasSource.match(
+      /constructor\(\{device\}: AnimationProps\)\s*\{([\s\S]*?)\n  \}\n\n  override async onInitialize/
+    );
+    const gridCountSource = atlasSource.match(
+      /function makeGridCellCounts\s*\([\s\S]*?\n\}\n\nfunction countCandidates/
+    );
+
+    expect(constructorSource).not.toBeNull();
+    expect(constructorSource![1]).toMatch(/this\.currentPositions\s*=\s*new Float32Array\(0\)/);
+    expect(constructorSource![1]).not.toMatch(/makeSyntheticTaxiPositions\s*\(/);
+    expect(atlasSource).toMatch(/await this\.loadSyntheticDataset\(this\.mode, this\.capacity\)/);
+    expect(atlasSource).toMatch(/await yieldAtlasGeneration\(generationController\.signal\)/);
+    expect(atlasSource).toMatch(/this\.dataGenerationAbortController\?\.abort\(\)/);
+    expect(atlasSource).toMatch(/this\.resizeResources\(resources,/);
+    expect(atlasSource).toMatch(
+      /queryChanged \? this\.getQueryGraph\(resources\) : resources\.renderGraph/
+    );
+    expect(atlasSource).toMatch(/if\s*\(!graph\)\s*\{\s*graph = this\.createQueryGraph/);
+    expect(gridCountSource).not.toBeNull();
+    expect(gridCountSource![0]).not.toMatch(/new Array<number>\(dimension\)/);
+    expect(atlasSource).toMatch(/resources\.renderGraph\.destroy\(\)/);
+  });
+});

--- a/test/examples/gpgpu-responsive-website.node.spec.ts
+++ b/test/examples/gpgpu-responsive-website.node.spec.ts
@@ -92,21 +92,24 @@ describe('responsive GPGPU website examples', () => {
     expect(homepageSceneSource).toContain("from '../../../examples/showcase/instancing/app'");
   });
 
-  test('stops initializing GPU applications before waiting for serialized route cleanup', () => {
+  test('serializes template finalization after asynchronous initialization', () => {
     const lifecycleSource = readFileSync(LUMA_EXAMPLE_PATH, 'utf8');
-    const cancellationCommentOffset = lifecycleSource.indexOf('// Stop immediately');
-    const immediateStopOffset = lifecycleSource.indexOf(
-      'animationLoop?.stop()',
-      cancellationCommentOffset
-    );
+    const cleanupOffset = lifecycleSource.lastIndexOf('return () => {\n      isCancelled = true;');
     const queuedCleanupOffset = lifecycleSource.indexOf(
       'currentLumaExampleTask = currentLumaExampleTask',
-      immediateStopOffset
+      cleanupOffset
     );
+    const serializedDestroyOffset = lifecycleSource.indexOf(
+      'animationLoop.destroy()',
+      queuedCleanupOffset
+    );
+    const immediateCleanupSource = lifecycleSource.slice(cleanupOffset, queuedCleanupOffset);
 
-    expect(cancellationCommentOffset).toBeGreaterThan(0);
-    expect(immediateStopOffset).toBeGreaterThan(cancellationCommentOffset);
-    expect(queuedCleanupOffset).toBeGreaterThan(immediateStopOffset);
+    expect(cleanupOffset).toBeGreaterThan(0);
+    expect(queuedCleanupOffset).toBeGreaterThan(cleanupOffset);
+    expect(serializedDestroyOffset).toBeGreaterThan(queuedCleanupOffset);
+    expect(immediateCleanupSource).not.toContain('animationLoop?.stop()');
+    expect(immediateCleanupSource).toContain('canvasContainer.replaceChildren()');
   });
 
   test('keeps DOM-only compute examples from inserting presentation canvases into the page', () => {

--- a/test/examples/gpgpu-responsive-website.node.spec.ts
+++ b/test/examples/gpgpu-responsive-website.node.spec.ts
@@ -1,0 +1,114 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+const WEBSITE_EXAMPLES_PATH = path.join(process.cwd(), 'website/src/examples.tsx');
+const LUMA_EXAMPLE_PATH = path.join(
+  process.cwd(),
+  'website/src/react-luma/components/luma-example.tsx'
+);
+const EXAMPLE_CATALOG_PATH = path.join(process.cwd(), 'website/src/components/examples-index.tsx');
+const EXAMPLE_CARD_PATH = path.join(process.cwd(), 'website/src/components/example-card.tsx');
+const HOMEPAGE_SOURCE_PATH = path.join(process.cwd(), 'website/src/pages/index.jsx');
+const HOMEPAGE_GPU_SCENE_PATH = path.join(
+  process.cwd(),
+  'website/src/components/homepage-gpu-scene.tsx'
+);
+const DEFERRED_FP64_EXAMPLE_PATH = path.join(
+  process.cwd(),
+  'website/src/components/docs/deferred-fp64-example.tsx'
+);
+
+describe('responsive GPGPU website examples', () => {
+  test('loads heavyweight compute and precision applications only when their route requests them', () => {
+    const examplesSource = readFileSync(WEBSITE_EXAMPLES_PATH, 'utf8');
+
+    for (const modulePath of [
+      '../../examples/showcase/billion-point-spatial-atlas/app',
+      '../../examples/showcase/crossfilter-supremacy/app',
+      '../../examples/deck/luspatial-taxi/app',
+      '../../examples/experimental/fp64/app'
+    ]) {
+      expect(examplesSource, `${modulePath} must be loaded asynchronously`).toContain(
+        `import('${modulePath}')`
+      );
+    }
+
+    expect(examplesSource).not.toMatch(
+      /^import\s+(?:BillionPointSpatialAtlasApp|CrossfilterSupremacyApp|FP64App)\s+from/m
+    );
+    expect(examplesSource).not.toMatch(/^import\s+\{createLuSpatialTaxiDeck\}\s+from/m);
+    expect(examplesSource).toContain("role={errorMessage ? 'alert' : 'status'}");
+    expect(examplesSource).toContain('Preparing GPU experience');
+    expect(examplesSource).toContain('window.clearTimeout(loadingTimeout)');
+  });
+
+  test('keeps embedded precision benchmarks idle until the reader explicitly launches them', () => {
+    const examplesSource = readFileSync(WEBSITE_EXAMPLES_PATH, 'utf8');
+    const deferredExampleSource = readFileSync(DEFERRED_FP64_EXAMPLE_PATH, 'utf8');
+
+    expect(examplesSource).toContain('useState(!props.embedded || autoStart)');
+    expect(examplesSource).toContain(
+      'useDeferredExampleModule(loadFP64Example, isBenchmarkRequested)'
+    );
+    expect(examplesSource).toContain('if (!isBenchmarkRequested)');
+    expect(examplesSource).toContain('Launch precision benchmark');
+    expect(deferredExampleSource).toContain("await import('../../examples')");
+    expect(deferredExampleSource).toContain('if (isRequested)');
+
+    for (const precisionPage of [
+      'docs/api-guide/shaders/gpu-floating-point-precision.md',
+      'docs/api-reference/shadertools/shader-modules/fp64.md'
+    ]) {
+      const precisionPageSource = readFileSync(path.join(process.cwd(), precisionPage), 'utf8');
+      expect(precisionPageSource).toContain('<DeferredFP64Example embeddedHeight={900} />');
+      expect(precisionPageSource).not.toMatch(/from ['"]@site\/src\/examples['"]/);
+    }
+  });
+
+  test('renders the homepage before asynchronously starting its isolated GPU hero', () => {
+    const homepageSource = readFileSync(HOMEPAGE_SOURCE_PATH, 'utf8');
+    const homepageSceneSource = readFileSync(HOMEPAGE_GPU_SCENE_PATH, 'utf8');
+
+    expect(homepageSource).toContain(
+      "React.lazy(() => import('../components/homepage-gpu-scene'))"
+    );
+    expect(homepageSource).toContain('window.clearTimeout(sceneStartupTimeout)');
+    expect(homepageSource).toContain('radial-gradient');
+    expect(homepageSource).not.toContain('/images/examples/showcase/instancing.jpg');
+    expect(homepageSource).not.toMatch(/from ['"]\.\.\/examples['"]/);
+    expect(homepageSceneSource).not.toMatch(/from ['"]\.\.\/examples['"]/);
+    expect(homepageSceneSource).toContain("from '../../../examples/showcase/instancing/app'");
+  });
+
+  test('stops initializing GPU applications before waiting for serialized route cleanup', () => {
+    const lifecycleSource = readFileSync(LUMA_EXAMPLE_PATH, 'utf8');
+    const cancellationCommentOffset = lifecycleSource.indexOf('// Stop immediately');
+    const immediateStopOffset = lifecycleSource.indexOf(
+      'animationLoop?.stop()',
+      cancellationCommentOffset
+    );
+    const queuedCleanupOffset = lifecycleSource.indexOf(
+      'currentLumaExampleTask = currentLumaExampleTask',
+      immediateStopOffset
+    );
+
+    expect(cancellationCommentOffset).toBeGreaterThan(0);
+    expect(immediateStopOffset).toBeGreaterThan(cancellationCommentOffset);
+    expect(queuedCleanupOffset).toBeGreaterThan(immediateStopOffset);
+  });
+
+  test('gives the dedicated GPGPU collection accurate backend, difficulty, and visual metadata', () => {
+    const catalogSource = readFileSync(EXAMPLE_CATALOG_PATH, 'utf8');
+    const cardSource = readFileSync(EXAMPLE_CARD_PATH, 'utf8');
+
+    expect(catalogSource.match(/category === 'GPGPU'/g)?.length).toBeGreaterThanOrEqual(5);
+    expect(catalogSource).toContain("if (category === 'GPGPU') return 'compute'");
+    expect(catalogSource).toContain('Compute, projections, and GPU-native data');
+    expect(cardSource).toContain("if (category === 'GPGPU') return '#a78bfa'");
+  });
+});

--- a/test/examples/gpgpu-responsive-website.node.spec.ts
+++ b/test/examples/gpgpu-responsive-website.node.spec.ts
@@ -68,7 +68,8 @@ describe('responsive GPGPU website examples', () => {
 
     for (const precisionPage of [
       'docs/api-guide/shaders/gpu-floating-point-precision.md',
-      'docs/api-reference/shadertools/shader-modules/fp64.md'
+      'docs/api-reference/shadertools/shader-modules/fp64.md',
+      'docs/api-reference/shadertools/shader-modules/fp64-arithmetic.md'
     ]) {
       const precisionPageSource = readFileSync(path.join(process.cwd(), precisionPage), 'utf8');
       expect(precisionPageSource).toContain('<DeferredFP64Example embeddedHeight={900} />');

--- a/test/examples/gpgpu-responsive-website.node.spec.ts
+++ b/test/examples/gpgpu-responsive-website.node.spec.ts
@@ -22,6 +22,12 @@ const DEFERRED_FP64_EXAMPLE_PATH = path.join(
   process.cwd(),
   'website/src/components/docs/deferred-fp64-example.tsx'
 );
+const GPU_DATA_ANALYSIS_PATH = path.join(
+  process.cwd(),
+  'examples/experimental/gpu-data-analysis/src/app.ts'
+);
+const GPU_SORT_PATH = path.join(process.cwd(), 'examples/experimental/gpu-sort/src/app.ts');
+const LEGACY_GPGPU_SHOWCASE_PATH = path.join(process.cwd(), 'examples/v10/gpgpu/src/app.ts');
 
 describe('responsive GPGPU website examples', () => {
   test('loads heavyweight compute and precision applications only when their route requests them', () => {
@@ -100,6 +106,22 @@ describe('responsive GPGPU website examples', () => {
     expect(cancellationCommentOffset).toBeGreaterThan(0);
     expect(immediateStopOffset).toBeGreaterThan(cancellationCommentOffset);
     expect(queuedCleanupOffset).toBeGreaterThan(immediateStopOffset);
+  });
+
+  test('keeps DOM-only compute examples from inserting presentation canvases into the page', () => {
+    for (const examplePath of [GPU_DATA_ANALYSIS_PATH, GPU_SORT_PATH]) {
+      const exampleSource = readFileSync(examplePath, 'utf8');
+
+      expect(exampleSource).toContain('const device = await luma.createDevice({');
+      expect(exampleSource).not.toContain('createCanvasContext');
+      expect(exampleSource).not.toContain('new OffscreenCanvas');
+      expect(exampleSource).toContain('if (this.destroyed) {\n        device.destroy();');
+    }
+
+    const legacyShowcaseSource = readFileSync(LEGACY_GPGPU_SHOWCASE_PATH, 'utf8');
+    expect(legacyShowcaseSource).toContain("document.createElement('canvas')");
+    expect(legacyShowcaseSource).toContain('new OffscreenCanvas(1, 1)');
+    expect(legacyShowcaseSource).not.toMatch(/typeof OffscreenCanvas === 'undefined'\s*\? true/);
   });
 
   test('gives the dedicated GPGPU collection accurate backend, difficulty, and visual metadata', () => {

--- a/website/content/examples/deck/luspatial-taxi.mdx
+++ b/website/content/examples/deck/luspatial-taxi.mdx
@@ -1,21 +1,22 @@
 ---
 title: luSpatial Taxi Explorer
-description: A deck.gl WebGPU map that queries one million resident taxi points on the GPU and renders the result indirectly.
+description: Project and query one million GPU-resident taxi points with luProj and luSpatial, then render the result indirectly with deck.gl.
 sidebar_custom_props:
-  description: Query a million resident taxi points through luSpatial and render the result over a basemap with deck.gl.
+  description: Project, index, and query a million resident taxi points with luProj, luSpatial, and deck.gl.
   backends: [webgpu]
   difficulty: advanced
   maturity: experimental
-  topics: [compute, rendering, data, geospatial, deck.gl]
+  topics: [compute, projection, geospatial, gpgpu, deck.gl]
 ---
 
 import {DeckLuSpatialTaxiExample} from '@site/src/examples';
 
 <DeckLuSpatialTaxiExample />
 
-This focused integration keeps spatial compute and map rendering in their natural layers. The
-deck.gl `MapView` owns pan, zoom, picking, and the camera; MapLibre supplies a synchronized dark
-basemap; and `@luma.gl/experimental/geospatial` projects, indexes, and queries the resident points.
+This focused integration keeps projection, spatial compute, and map rendering in their natural
+layers. The deck.gl `MapView` owns pan, zoom, picking, and the camera; MapLibre supplies a
+synchronized dark basemap; `@luma.gl/experimental/luproj` projects the source coordinates; and
+`@luma.gl/experimental/geospatial` indexes and queries the resident points.
 
 The uniform grid stores position-row indices, keeping candidate addressing distinct from optional
 application IDs. Both the viewport and radius queries use the default row-index output and write it

--- a/website/content/examples/experimental/gpt-2.mdx
+++ b/website/content/examples/experimental/gpt-2.mdx
@@ -5,7 +5,7 @@ sidebar_custom_props:
   backends: [webgpu]
   difficulty: advanced
   maturity: experimental
-  topics: [compute, data]
+  topics: [compute, data, gpgpu, inference]
 ---
 
 import {GPT2Example} from '@site/src/examples';

--- a/website/content/examples/experimental/gpu-data-analysis.mdx
+++ b/website/content/examples/experimental/gpu-data-analysis.mdx
@@ -6,7 +6,7 @@ sidebar_custom_props:
   backends: [webgpu]
   difficulty: advanced
   maturity: experimental
-  topics: [compute, data, analytics, command-graphs]
+  topics: [compute, data, gpgpu, analytics, command-graphs]
 ---
 
 import {GPUDataAnalysisExample} from '@site/src/examples';

--- a/website/content/examples/experimental/gpu-sort.mdx
+++ b/website/content/examples/experimental/gpu-sort.mdx
@@ -6,7 +6,7 @@ sidebar_custom_props:
   backends: [webgpu]
   difficulty: advanced
   maturity: experimental
-  topics: [compute, data, sorting, command-graphs]
+  topics: [compute, data, gpgpu, sorting, command-graphs]
 ---
 
 import {GPUSortExample} from '@site/src/examples';

--- a/website/content/examples/showcase/billion-point-spatial-atlas.mdx
+++ b/website/content/examples/showcase/billion-point-spatial-atlas.mdx
@@ -7,7 +7,7 @@ sidebar_custom_props:
   display: hdr-capable
   difficulty: advanced
   maturity: experimental
-  topics: [compute, rendering, data, geospatial]
+  topics: [compute, data, geospatial, gpgpu, rendering]
 ---
 
 import {BillionPointSpatialAtlasExample} from '@site/src/examples';

--- a/website/content/examples/showcase/crossfilter-supremacy.mdx
+++ b/website/content/examples/showcase/crossfilter-supremacy.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Crossfilter Supremacy: Million-Point Command Center'
-description: Brush one million GPU-resident points across linked maps, scatterplots, histograms, and categorical distributions without reading source rows back to the CPU.
+description: Brush one million GPU-resident points with LuxFilter across linked maps, scatterplots, histograms, and categorical distributions without CPU readback.
 sidebar_custom_props:
   backends: [webgpu]
   difficulty: advanced
   maturity: experimental
-  topics: [compute, rendering, data]
+  topics: [compute, data, crossfilter, gpgpu, rendering]
 ---
 
 import {CrossfilterSupremacyExample} from '@site/src/examples';

--- a/website/content/examples/table-of-contents.json
+++ b/website/content/examples/table-of-contents.json
@@ -33,13 +33,6 @@
     "type": "category",
     "label": "WebGPU",
     "items": [
-      "showcase/crossfilter-supremacy",
-      "showcase/billion-point-spatial-atlas",
-      {
-        "type": "doc",
-        "id": "deck/luspatial-taxi",
-        "label": "luSpatial Taxi Explorer"
-      },
       "showcase/lightstorm-megacity",
       "experimental/volumetric-fire-forge",
       {
@@ -76,6 +69,23 @@
         "type": "doc",
         "id": "experimental/shadow-map",
         "label": "Effects: Shadow Map Quality"
+      }
+    ]
+  },
+  {
+    "type": "category",
+    "label": "GPGPU",
+    "items": [
+      {
+        "type": "doc",
+        "id": "showcase/crossfilter-supremacy",
+        "label": "LuxFilter: Million-Point Crossfilter"
+      },
+      "showcase/billion-point-spatial-atlas",
+      {
+        "type": "doc",
+        "id": "deck/luspatial-taxi",
+        "label": "luProj + luSpatial: Taxi Explorer"
       },
       "experimental/gpt-2",
       {

--- a/website/src/components/docs/deferred-fp64-example.tsx
+++ b/website/src/components/docs/deferred-fp64-example.tsx
@@ -1,0 +1,78 @@
+import React, {Suspense, useState} from 'react';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+const LazyFP64Example = React.lazy(async () => {
+  const {FP64Example} = await import('../../examples');
+  return {default: FP64Example};
+});
+
+/** Keeps the heavyweight precision scene and example registry out of ordinary documentation loads. */
+export function DeferredFP64Example({embeddedHeight = 900}: {embeddedHeight?: number}) {
+  const [isRequested, setIsRequested] = useState(false);
+  const previewImageUrl = useBaseUrl('/images/examples/experimental/fp64.jpg');
+
+  if (isRequested) {
+    return (
+      <Suspense
+        fallback={
+          <div aria-live="polite" role="status" style={{padding: 32}}>
+            Loading the interactive GPU precision benchmark…
+          </div>
+        }
+      >
+        <LazyFP64Example autoStart embedded embeddedHeight={embeddedHeight} />
+      </Suspense>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Interactive GPU precision benchmark"
+      style={{
+        minHeight: 280,
+        display: 'grid',
+        alignContent: 'center',
+        justifyItems: 'start',
+        gap: 12,
+        padding: 28,
+        margin: '1.5rem 0',
+        border: '1px solid rgba(148, 163, 184, 0.24)',
+        borderRadius: 12,
+        background: `linear-gradient(90deg, rgba(4, 10, 20, 0.97), rgba(4, 10, 20, 0.68)), url("${previewImageUrl}") center / cover`,
+        color: '#f8fafc'
+      }}
+    >
+      <span
+        style={{
+          color: '#a5b4fc',
+          fontSize: 11,
+          fontWeight: 750,
+          letterSpacing: '0.12em',
+          textTransform: 'uppercase'
+        }}
+      >
+        Optional interactive GPU benchmark
+      </span>
+      <strong style={{fontSize: 22, lineHeight: 1.2}}>Explore floating-point precision.</strong>
+      <span style={{maxWidth: 460, color: '#cbd5e1', fontSize: 14, lineHeight: 1.6}}>
+        Compare Mandelbrot rendering and compute precision when you are ready to use your GPU.
+      </span>
+      <button
+        onClick={() => setIsRequested(true)}
+        style={{
+          border: 0,
+          borderRadius: 999,
+          background: '#e2e8f0',
+          color: '#0f172a',
+          cursor: 'pointer',
+          fontSize: 13,
+          fontWeight: 700,
+          padding: '10px 16px'
+        }}
+        type="button"
+      >
+        Launch precision benchmark →
+      </button>
+    </section>
+  );
+}

--- a/website/src/components/docs/gpgpu-docs-tabs.tsx
+++ b/website/src/components/docs/gpgpu-docs-tabs.tsx
@@ -16,7 +16,10 @@ export type GPGPUDocsTabId =
   | 'gpu-data-evaluator'
   | 'operations'
   | 'custom-operation'
-  | 'clean-evaluate';
+  | 'clean-evaluate'
+  | 'precision-guide'
+  | 'fp64'
+  | 'fp64-arithmetic';
 
 const GPGPU_DOCS_TABS: GPGPUDocsTab[] = [
   {id: 'overview', label: 'Overview', href: '/docs/api-reference/gpgpu'},
@@ -27,7 +30,22 @@ const GPGPU_DOCS_TABS: GPGPUDocsTab[] = [
     label: 'Custom Operations',
     href: '/docs/api-reference/gpgpu/custom-operation'
   },
-  {id: 'clean-evaluate', label: 'cleanEvaluate', href: '/docs/api-reference/gpgpu/clean-evaluate'}
+  {id: 'clean-evaluate', label: 'cleanEvaluate', href: '/docs/api-reference/gpgpu/clean-evaluate'},
+  {
+    id: 'precision-guide',
+    label: 'Precision',
+    href: '/docs/api-guide/shaders/gpu-floating-point-precision'
+  },
+  {
+    id: 'fp64',
+    label: 'fp64',
+    href: '/docs/api-reference/shadertools/shader-modules/fp64'
+  },
+  {
+    id: 'fp64-arithmetic',
+    label: 'fp64 arithmetic',
+    href: '/docs/api-reference/shadertools/shader-modules/fp64-arithmetic'
+  }
 ];
 
 /**

--- a/website/src/components/example-card.tsx
+++ b/website/src/components/example-card.tsx
@@ -139,6 +139,7 @@ function getCapabilityBadges(
 
 function getCardAccent(category: string, topics: readonly string[]): string {
   if (category === 'WebGPU') return '#67e8f9';
+  if (category === 'GPGPU') return '#a78bfa';
   if (category === 'Tutorials') return '#6ee7b7';
   if (category === 'Showcase') return '#c4b5fd';
   if (category.includes('Arrow') || category.includes('Data')) return '#93c5fd';

--- a/website/src/components/examples-index.tsx
+++ b/website/src/components/examples-index.tsx
@@ -327,6 +327,7 @@ function normalizeItem(
 
 function getDefaultBackends(category: string): ExampleBackend[] {
   return category === 'WebGPU' ||
+    category === 'GPGPU' ||
     category.includes('GPU Data') ||
     category.includes('GPU Command Graph')
     ? ['webgpu']
@@ -338,6 +339,7 @@ function getDefaultDifficulty(category: string): ExampleDifficulty {
   if (
     category === 'Experimental' ||
     category === 'WebGPU' ||
+    category === 'GPGPU' ||
     category.includes('Arrow') ||
     category.includes('GPU Command Graph')
   ) {
@@ -349,6 +351,7 @@ function getDefaultDifficulty(category: string): ExampleDifficulty {
 function getDefaultMaturity(category: string): ExampleMaturity {
   return category === 'Experimental' ||
     category === 'WebGPU' ||
+    category === 'GPGPU' ||
     category.includes('GPU Command Graph')
     ? 'experimental'
     : 'stable';
@@ -357,6 +360,7 @@ function getDefaultMaturity(category: string): ExampleMaturity {
 function getDefaultTopic(category: string): string {
   if (category === 'Tutorials') return 'fundamentals';
   if (category === 'Integrations') return 'integration';
+  if (category === 'GPGPU') return 'compute';
   if (category.includes('GPU Command Graph')) return 'compute';
   if (category.includes('GPU Data') || category.includes('Arrow')) return 'data';
   if (category === 'API') return 'api';
@@ -375,6 +379,7 @@ function groupByCategory(items: CatalogItem[]): Array<[string, CatalogItem[]]> {
 
 function getCategoryEyebrow(category: string): string {
   if (category === 'WebGPU') return 'Next-generation graphics';
+  if (category === 'GPGPU') return 'Compute, projections, and GPU-native data';
   if (category === 'Showcase') return 'Featured experiences';
   if (category === 'Tutorials') return 'Learn by building';
   if (category === 'Experimental') return 'Emerging techniques';

--- a/website/src/components/homepage-gpu-scene.tsx
+++ b/website/src/components/homepage-gpu-scene.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import InstancingApp from '../../../examples/showcase/instancing/app';
+import {LumaExample} from '../react-luma';
+
+/** Loads the homepage scene independently of the complete interactive-example registry. */
+export default function HomepageGPUScene(): React.JSX.Element {
+  return (
+    <LumaExample
+      id="instancing"
+      directory="showcase"
+      template={InstancingApp}
+      config={{}}
+      canvasContextProfile="high-dynamic-range"
+      panel={false}
+    />
+  );
+}

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -43,7 +43,6 @@ import {
   initializeGPUDataAnalysisExample,
   type GPUDataAnalysisExampleHandle
 } from '../../examples/experimental/gpu-data-analysis/src/app';
-import FP64App from '../../examples/experimental/fp64/app';
 import GPT2App from '../../examples/experimental/gpt-2/app';
 import VideoTextureApp from '../../examples/api/video-texture/app';
 import WebXRKaleidoscopeApp from '../../examples/experimental/webxr-kaleidoscope/app';
@@ -81,8 +80,6 @@ import ArrowTemporalStarfieldApp from '../../examples/arrow/arrow-temporal-starf
 import ArrowTimeColumnsApp from '../../examples/arrow/arrow-time-columns/app';
 import ArrowText2DApp from '../../examples/arrow/arrow-text-2d/app';
 import InstancingApp from '../../examples/showcase/instancing/app';
-import BillionPointSpatialAtlasApp from '../../examples/showcase/billion-point-spatial-atlas/app';
-import CrossfilterSupremacyApp from '../../examples/showcase/crossfilter-supremacy/app';
 import LightstormMegacityApp from '../../examples/showcase/lightstorm-megacity/app';
 import TempestOceanApp from '../../examples/showcase/tempest-ocean/app';
 import RenderBundlesApp from '../../examples/api/render-bundles/app';
@@ -111,18 +108,125 @@ import {createArrowPathLayerDeck} from '../../examples/deck/arrow-path-layer/app
 import {createArrowPolygonLayerDeck} from '../../examples/deck/arrow-polygon-layer/app';
 import {createArrowTextLayerDeck} from '../../examples/deck/arrow-text-layer/app';
 import {createGPUCulledTraceDeck} from '../../examples/deck/gpu-culled-trace/app';
-import {createLuSpatialTaxiDeck} from '../../examples/deck/luspatial-taxi/app';
 
 const exampleConfig = {};
 
+const loadBillionPointSpatialAtlasExample = () =>
+  import('../../examples/showcase/billion-point-spatial-atlas/app');
+const loadCrossfilterSupremacyExample = () =>
+  import('../../examples/showcase/crossfilter-supremacy/app');
+const loadLuSpatialTaxiExample = () => import('../../examples/deck/luspatial-taxi/app');
+const loadFP64Example = () => import('../../examples/experimental/fp64/app');
+
 type WebsiteExampleProps = React.PropsWithChildren<
   ExampleDisplayProps & {
+    autoStart?: boolean;
     panel?: boolean;
     showHeader?: boolean;
     showStats?: boolean;
     templateInfoPlacement?: 'header' | 'page';
   }
 >;
+
+type DeferredExampleModuleState<Module> = {
+  module: Module | null;
+  errorMessage: string | null;
+};
+
+function useDeferredExampleModule<Module>(
+  loadModule: () => Promise<Module>,
+  enabled = true
+): DeferredExampleModuleState<Module> {
+  const [moduleState, setModuleState] = useState<DeferredExampleModuleState<Module>>({
+    module: null,
+    errorMessage: null
+  });
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    let isCancelled = false;
+    const loadingTimeout = window.setTimeout(() => {
+      void loadModule()
+        .then(module => {
+          if (!isCancelled) {
+            setModuleState({module, errorMessage: null});
+          }
+        })
+        .catch(error => {
+          if (!isCancelled) {
+            setModuleState({module: null, errorMessage: getErrorMessage(error)});
+          }
+        });
+    }, 0);
+
+    return () => {
+      isCancelled = true;
+      window.clearTimeout(loadingTimeout);
+    };
+  }, [enabled, loadModule]);
+
+  return moduleState;
+}
+
+function DeferredGPUExampleStatus({
+  title,
+  description,
+  errorMessage,
+  embedded,
+  embeddedHeight,
+  style
+}: {
+  title: string;
+  description: string;
+  errorMessage?: string | null;
+} & WebsiteExampleProps): React.JSX.Element {
+  return (
+    <ExamplePage
+      embedded={embedded}
+      embeddedHeight={embeddedHeight}
+      style={{
+        background:
+          'radial-gradient(ellipse at 22% 16%, rgba(56, 189, 248, 0.16), transparent 42%), #07101d',
+        ...style
+      }}
+    >
+      <div
+        aria-live="polite"
+        role={errorMessage ? 'alert' : 'status'}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'grid',
+          alignContent: 'center',
+          justifyContent: 'center',
+          gap: 12,
+          padding: 32,
+          color: '#f1f5f9',
+          textAlign: 'center'
+        }}
+      >
+        <span
+          style={{
+            color: '#7dd3fc',
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase'
+          }}
+        >
+          {errorMessage ? 'Unable to load GPU experience' : 'Preparing GPU experience'}
+        </span>
+        <strong style={{fontSize: 22, lineHeight: 1.2}}>{title}</strong>
+        <span style={{maxWidth: 420, color: '#b6c5d7', fontSize: 14, lineHeight: 1.6}}>
+          {errorMessage || description}
+        </span>
+      </div>
+    </ExamplePage>
+  );
+}
 
 type DeckExampleHandle = {
   finalize: () => void;
@@ -330,21 +434,37 @@ export const DeckGPUCulledTraceExample: React.FC<DeckArrowLayerExampleProps> = (
 
 export const DeckLuSpatialTaxiExample: React.FC<DeckArrowLayerExampleProps> = ({
   embedded = false
-}) => (
-  <ReactExample
-    component={DeckArrowLayerCanvas}
-    componentProps={{
-      createDeck: createLuSpatialTaxiDeck,
-      panel: {
-        id: 'luspatial-taxi',
-        title: 'luSpatial Taxi Explorer',
-        devices: ['webgpu']
-      }
-    }}
-    showStats={false}
-    style={embedded ? DECK_ARROW_LAYER_EMBEDDED_STYLE : undefined}
-  />
-);
+}) => {
+  const {module, errorMessage} = useDeferredExampleModule(loadLuSpatialTaxiExample);
+
+  if (!module) {
+    return (
+      <DeferredGPUExampleStatus
+        title="luProj + luSpatial Taxi Explorer"
+        description="Loading the projection, spatial-query, and interactive map tools."
+        errorMessage={errorMessage}
+        embedded={embedded}
+        style={embedded ? DECK_ARROW_LAYER_EMBEDDED_STYLE : undefined}
+      />
+    );
+  }
+
+  return (
+    <ReactExample
+      component={DeckArrowLayerCanvas}
+      componentProps={{
+        createDeck: module.createLuSpatialTaxiDeck,
+        panel: {
+          id: 'luspatial-taxi',
+          title: 'luProj + luSpatial Taxi Explorer',
+          devices: ['webgpu']
+        }
+      }}
+      showStats={false}
+      style={embedded ? DECK_ARROW_LAYER_EMBEDDED_STYLE : undefined}
+    />
+  );
+};
 
 type DeckArrowLayerExampleId = 'path' | 'polygon' | 'text';
 
@@ -646,32 +766,62 @@ export const LightstormMegacityExample: React.FC<WebsiteExampleProps> = props =>
   />
 );
 
-export const BillionPointSpatialAtlasExample: React.FC<WebsiteExampleProps> = props => (
-  <LumaExample
-    id="billion-point-spatial-atlas"
-    title="Billion-Point Spatial Atlas"
-    subtitle="Indexed geospatial queries and indirect rendering at data scale"
-    directory="showcase"
-    devices={['webgpu']}
-    template={BillionPointSpatialAtlasApp}
-    config={exampleConfig}
-    canvasContextProfile="high-dynamic-range"
-    {...props}
-  />
-);
+export const BillionPointSpatialAtlasExample: React.FC<WebsiteExampleProps> = props => {
+  const {module, errorMessage} = useDeferredExampleModule(loadBillionPointSpatialAtlasExample);
 
-export const CrossfilterSupremacyExample: React.FC<WebsiteExampleProps> = props => (
-  <LumaExample
-    id="crossfilter-supremacy"
-    title="Crossfilter Supremacy"
-    subtitle="One million points · one GPU-resident linked dashboard"
-    directory="showcase"
-    devices={['webgpu']}
-    template={CrossfilterSupremacyApp}
-    config={exampleConfig}
-    {...props}
-  />
-);
+  if (!module) {
+    return (
+      <DeferredGPUExampleStatus
+        {...props}
+        title="Billion-Point Spatial Atlas"
+        description="Loading the GPU-native spatial index and interactive atlas."
+        errorMessage={errorMessage}
+      />
+    );
+  }
+
+  return (
+    <LumaExample
+      id="billion-point-spatial-atlas"
+      title="Billion-Point Spatial Atlas"
+      subtitle="Indexed geospatial queries and indirect rendering at data scale"
+      directory="showcase"
+      devices={['webgpu']}
+      template={module.default}
+      config={exampleConfig}
+      canvasContextProfile="high-dynamic-range"
+      {...props}
+    />
+  );
+};
+
+export const CrossfilterSupremacyExample: React.FC<WebsiteExampleProps> = props => {
+  const {module, errorMessage} = useDeferredExampleModule(loadCrossfilterSupremacyExample);
+
+  if (!module) {
+    return (
+      <DeferredGPUExampleStatus
+        {...props}
+        title="LuxFilter: Crossfilter Supremacy"
+        description="Loading the million-row linked dashboard and GPU filtering pipeline."
+        errorMessage={errorMessage}
+      />
+    );
+  }
+
+  return (
+    <LumaExample
+      id="crossfilter-supremacy"
+      title="Crossfilter Supremacy"
+      subtitle="One million points · one GPU-resident linked dashboard"
+      directory="showcase"
+      devices={['webgpu']}
+      template={module.default}
+      config={exampleConfig}
+      {...props}
+    />
+  );
+};
 
 export const TempestOceanExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample
@@ -1534,19 +1684,100 @@ export const MultiCanvasExample: React.FC<WebsiteExampleProps> = props => {
   );
 };
 
-export const FP64Example: React.FC<WebsiteExampleProps> = ({embeddedHeight, ...props}) => {
+export const FP64Example: React.FC<WebsiteExampleProps> = ({
+  autoStart = false,
+  embeddedHeight,
+  ...props
+}) => {
+  const [isBenchmarkRequested, setIsBenchmarkRequested] = useState(!props.embedded || autoStart);
+  const {module, errorMessage} = useDeferredExampleModule(loadFP64Example, isBenchmarkRequested);
   const deviceType = useStore(store => store.deviceType);
   const presentationDevice = useStore(store => store.presentationDevice);
   const presentationDeviceError = useStore(store => store.presentationDeviceError);
+  const previewImageUrl = useBaseUrl('/images/examples/experimental/fp64.jpg');
+
+  if (!isBenchmarkRequested) {
+    return (
+      <ExamplePage
+        embedded
+        embeddedHeight={300}
+        style={{
+          border: '1px solid rgba(148, 163, 184, 0.24)',
+          borderRadius: 12,
+          background: `linear-gradient(90deg, rgba(4, 10, 20, 0.97), rgba(4, 10, 20, 0.68)), url("${previewImageUrl}") center / cover`,
+          margin: '1.5rem 0'
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'grid',
+            alignContent: 'center',
+            justifyItems: 'start',
+            gap: 12,
+            padding: 28,
+            color: '#f8fafc'
+          }}
+        >
+          <span
+            style={{
+              color: '#a5b4fc',
+              fontSize: 11,
+              fontWeight: 750,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase'
+            }}
+          >
+            Optional interactive GPU benchmark
+          </span>
+          <strong style={{fontSize: 22, lineHeight: 1.2}}>
+            Explore floating-point precision.
+          </strong>
+          <span style={{maxWidth: 460, color: '#cbd5e1', fontSize: 14, lineHeight: 1.6}}>
+            Compare Mandelbrot rendering and compute precision when you are ready to use your GPU.
+          </span>
+          <button
+            onClick={() => setIsBenchmarkRequested(true)}
+            style={{
+              border: 0,
+              borderRadius: 999,
+              background: '#e2e8f0',
+              color: '#0f172a',
+              cursor: 'pointer',
+              fontSize: 13,
+              fontWeight: 700,
+              padding: '10px 16px'
+            }}
+            type="button"
+          >
+            Launch precision benchmark →
+          </button>
+        </div>
+      </ExamplePage>
+    );
+  }
 
   if (presentationDeviceError) {
     return <div>{presentationDeviceError}</div>;
   }
 
+  if (errorMessage || !module) {
+    return (
+      <DeferredGPUExampleStatus
+        {...props}
+        title="64-bit GPU Precision"
+        description="Loading the interactive Mandelbrot and floating-point compute benchmark."
+        errorMessage={errorMessage}
+        embeddedHeight={embeddedHeight ?? (props.embedded ? 720 : undefined)}
+      />
+    );
+  }
+
   return deviceType && presentationDevice ? (
     <ReactExample
       {...props}
-      component={FP64App}
+      component={module.default}
       componentProps={{presentationDevice}}
       embeddedHeight={embeddedHeight ?? (props.embedded ? 720 : undefined)}
       showStats={false}

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -3,9 +3,9 @@ import Layout from '@theme/Layout';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import {ExampleCard} from '../components/example-card';
-import {InstancingExample} from '../examples';
 import styles from './index.module.css';
 
+const HomepageGPUScene = React.lazy(() => import('../components/homepage-gpu-scene'));
 const HERO_CAPABILITIES = ['WebGPU', 'WebGL2', 'GPU compute', 'HDR rendering'];
 
 const FEATURED_EXAMPLES = [
@@ -141,6 +141,31 @@ if (typeof window !== 'undefined') {
   window.website = true;
 }
 
+function DeferredHomepageGPUScene() {
+  const [isSceneRequested, setIsSceneRequested] = React.useState(false);
+
+  React.useEffect(() => {
+    const sceneStartupTimeout = window.setTimeout(() => setIsSceneRequested(true), 120);
+    return () => window.clearTimeout(sceneStartupTimeout);
+  }, []);
+
+  return (
+    <div
+      className={styles.heroExampleContainer}
+      style={{
+        background:
+          'radial-gradient(ellipse at 72% 34%, rgba(56, 189, 248, 0.18), transparent 44%), #050b15'
+      }}
+    >
+      {isSceneRequested ? (
+        <React.Suspense fallback={null}>
+          <HomepageGPUScene />
+        </React.Suspense>
+      ) : null}
+    </div>
+  );
+}
+
 export default function IndexPage() {
   const {siteConfig} = useDocusaurusContext();
   const baseUrl = useBaseUrl('/');
@@ -154,9 +179,7 @@ export default function IndexPage() {
     >
       <main className={styles.page}>
         <section className={styles.banner} aria-labelledby="homepage-title">
-          <div className={styles.heroExampleContainer}>
-            <InstancingExample panel={false} />
-          </div>
+          <DeferredHomepageGPUScene />
           <div className={styles.bannerContainer}>
             <p className={styles.heroEyebrow}>The open-source GPU toolkit</p>
             <h1 className={styles.projectName} id="homepage-title">

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -421,6 +421,9 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
 
     return () => {
       isCancelled = true;
+      // Stop immediately so asynchronously initializing templates can abort their pending work
+      // before the serialized cleanup queue waits for animationLoop.start() to settle.
+      animationLoop?.stop();
       captureController?.finalize();
       removeBrowserCaptureFunction();
       // Route transitions must stop displaying the outgoing example immediately, even when its

--- a/website/src/react-luma/components/luma-example.tsx
+++ b/website/src/react-luma/components/luma-example.tsx
@@ -19,7 +19,6 @@ import {
   HDRCanvasCaptureController,
   type HDRScreenshotCapture
 } from '../utils/hdr-screenshot-capture';
-
 // import {VRDisplay} from '@luma.gl/experimental';
 import {
   createDevice,
@@ -421,9 +420,6 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
 
     return () => {
       isCancelled = true;
-      // Stop immediately so asynchronously initializing templates can abort their pending work
-      // before the serialized cleanup queue waits for animationLoop.start() to settle.
-      animationLoop?.stop();
       captureController?.finalize();
       removeBrowserCaptureFunction();
       // Route transitions must stop displaying the outgoing example immediately, even when its
@@ -433,6 +429,8 @@ export const LumaExample: FC<LumaExampleProps> = (props: LumaExampleProps) => {
       currentLumaExampleTask = currentLumaExampleTask
         .then(() => {
           if (animationLoop) {
+            // destroy() synchronously finalizes the template, so it must remain serialized after
+            // animationLoop.start() and its asynchronous onInitialize() have settled.
             if (!effectiveDevice.isLost) {
               effectiveDevice.submit();
             }


### PR DESCRIPTION
## Goals

Make luma.gl's GPU-compute examples easy to discover, keep the website responsive while million-row workloads initialize, use the real luProj pipeline for projection, and connect floating-point precision documentation to the broader GPGPU story.

## Changes

### Discoverability and documentation

- Add a dedicated **GPGPU** examples section immediately after **WebGPU**, preserving every existing example URL.
- Group LuxFilter, the Billion-Point Spatial Atlas, **luProj + luSpatial: Taxi Explorer**, GPT-2, GPU Data, and GPU Command Graph under the new section.
- Update gallery metadata, cards, descriptions, badges, topics, and compute-focused styling.
- Move the GPU floating-point precision guide into the GPGPU Programming documentation section without changing its URL.
- Add shared GPGPU documentation tabs for **Precision**, **fp64**, and **fp64 arithmetic** while retaining shader-module navigation.

### Genuine projection and responsive million-row workloads

- Replace the taxi explorer's stand-in projection with the actual `GPUProjection` and `compileProjectionPlan` APIs from `@luma.gl/experimental/luproj`, composed with the existing luSpatial index and query pipeline.
- Preserve the complete 1,000,000-row spatial fixtures and 1,048,576-row LuxFilter dataset while generating them cooperatively in cancellable 20,000-row and 16,384-row chunks.
- Show visible, accessible loading and progress states before expensive CPU/GPU initialization.
- Cancel pending data generation, readbacks, timers, and GPU work when navigating away.
- Cache unchanged spatial query results instead of redispatching identical million-row queries every frame.
- Preserve the spatial atlas GPU index across canvas resize, compile query graphs only when selected, and remove per-point temporary allocations.
- Treat slow or unavailable external taxi basemap requests as nonfatal.

### Faster navigation and lighter documentation

- Dynamically import LuxFilter, the spatial atlas, the taxi explorer, and fp64 examples rather than eagerly bundling them into every route.
- Stop animation loops immediately during route cleanup instead of waiting for initialization and serialized destruction.
- Defer the homepage GPU hero until after primary content and navigation have painted.
- Replace automatically launched fp64 documentation benchmarks with an explicit **Launch precision benchmark** preview, keeping heavy example code and GPU work out of ordinary documentation visits.

## Verification

- `env -u YARN_NO_PROXY yarn build` — passed.
- `env -u YARN_NO_PROXY yarn examples:typecheck` — passed across 45 example workspaces.
- `env -u YARN_NO_PROXY yarn test-node` — **447 passed**, 2 skipped across 99 files.
- `env -u YARN_NO_PROXY yarn lint fix` — passed with no changes.
- `env -u YARN_NO_PROXY yarn website:build` — passed, including generated documentation validation.
- Live production-browser verification confirmed GPGPU section order, real luProj labels, responsive loading states, immediate route teardown, no horizontal overflow, shared precision/fp64 tabs, and zero canvases on unopened benchmark documentation pages.