### PR TITLE
feat(examples): stream packed taxi data into deck.gl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,21 +124,8 @@ jobs:
           df -h .
           du -sh . "${HOME}/.yarn" "${HOME}/.cache/ms-playwright" "${RUNNER_TEMP}" 2>/dev/null || true
 
-      - name: Run headless tests and generate coverage
-        run: |
-          yarn test-coverage --shard=${{ matrix.shard }}/3
-
-      - name: Report disk usage after coverage
-        if: always()
-        run: |
-          df -h .
-          du -sh . coverage "${HOME}/.yarn" "${HOME}/.cache/ms-playwright" "${RUNNER_TEMP}" 2>/dev/null || true
-
-      - name: Run node tests
-        if: ${{ matrix.shard == 1 }}
-        run: |
-          yarn test-node
-
+      # Run the standalone WebGPU smoke before the coverage suite so its SwiftShader device starts
+      # from a clean runner state instead of inheriting resource pressure from prior browser tests.
       - name: Install Spatial Atlas Playwright Chromium
         if: ${{ matrix.shard == 1 }}
         run: yarn workspace luma.gl-examples-showcase-billion-point-spatial-atlas exec playwright install chromium
@@ -157,6 +144,21 @@ jobs:
           path: ${{ runner.temp }}/billion-point-spatial-atlas*.png
           if-no-files-found: warn
           retention-days: 7
+
+      - name: Run headless tests and generate coverage
+        run: |
+          yarn test-coverage --shard=${{ matrix.shard }}/3
+
+      - name: Report disk usage after coverage
+        if: always()
+        run: |
+          df -h .
+          du -sh . coverage "${HOME}/.yarn" "${HOME}/.cache/ms-playwright" "${RUNNER_TEMP}" 2>/dev/null || true
+
+      - name: Run node tests
+        if: ${{ matrix.shard == 1 }}
+        run: |
+          yarn test-node
 
       - name: Sanitize lcov for Coveralls
         run: |

--- a/examples/deck/luspatial-taxi/app.ts
+++ b/examples/deck/luspatial-taxi/app.ts
@@ -11,6 +11,11 @@ import {
 import maplibregl from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import {GPUCommandGraphInspectorPanel} from '../../gpu-command-graph-inspector-panel';
+import {loadTaxiPointResidentWindow} from '../../showcase/billion-point-spatial-atlas/taxi-resident-window';
+import {
+  PackedTaxiShardSource,
+  type TaxiPointSource
+} from '../../showcase/billion-point-spatial-atlas/taxi-source';
 import {ArrowDeck} from '../arrow-deck';
 import {getDeckExampleProps, type DeckExampleDeviceOptions} from '../deck-example-device';
 import {LuSpatialPointLayer} from './luspatial-point-layer';
@@ -18,8 +23,10 @@ import {LuSpatialTaxiQueryEffect, type LuSpatialTaxiQueryStats} from './luspatia
 import {
   TAXI_CORPUS_POINT_COUNT,
   TAXI_POINT_COUNT,
+  assertLongitudeLatitudeTaxiMetadata,
   getTaxiPoint,
   makeLuSpatialTaxiDataAsync,
+  makeLuSpatialTaxiDataFromResidentWindow,
   makeTaxiZonePresets,
   type LuSpatialTaxiData,
   type TaxiZonePreset
@@ -27,6 +34,7 @@ import {
 
 const BASEMAP_STYLE = 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json';
 const INITIAL_ZONE_ID = 161;
+const MAX_RESIDENT_POINT_CAPACITY = 10_000_000;
 
 type TaxiViewState = MapViewState & {
   longitude: number;
@@ -36,15 +44,45 @@ type TaxiViewState = MapViewState & {
   bearing: number;
 };
 
+export type LuSpatialTaxiDeckOptions = DeckExampleDeviceOptions & {
+  /** Caller-supplied source whose ownership transfers to the returned Deck instance. */
+  taxiPointSource?: TaxiPointSource;
+  /** Packed manifest URL used when `taxiPointSource` is not supplied. */
+  taxiManifestUrl?: string | URL;
+  /** Maximum source rows retained for one GPU-resident window. */
+  residentPointCapacity?: number;
+};
+
 /** Creates the WebGPU-only luSpatial taxi explorer with a synchronized MapLibre basemap. */
 export function createLuSpatialTaxiDeck(
   parent?: HTMLDivElement,
-  options: DeckExampleDeviceOptions = {}
+  options: LuSpatialTaxiDeckOptions = {}
 ) {
+  const {
+    taxiPointSource: suppliedTaxiPointSource,
+    taxiManifestUrl: suppliedTaxiManifestUrl,
+    residentPointCapacity = TAXI_POINT_COUNT,
+    ...deviceOptions
+  } = options;
+  if (
+    !Number.isSafeInteger(residentPointCapacity) ||
+    residentPointCapacity <= 0 ||
+    residentPointCapacity > MAX_RESIDENT_POINT_CAPACITY
+  ) {
+    throw new Error(
+      `luSpatial taxi residentPointCapacity must be between 1 and ${MAX_RESIDENT_POINT_CAPACITY}`
+    );
+  }
   const ownsContainer = !parent;
   const container = parent ?? createStandaloneContainer();
   const generationController = new AbortController();
   let taxiData: LuSpatialTaxiData | null = null;
+  const configuredManifestUrl = suppliedTaxiManifestUrl ?? getConfiguredTaxiManifestUrl();
+  const taxiPointSource =
+    suppliedTaxiPointSource ??
+    (configuredManifestUrl ? new PackedTaxiShardSource(configuredManifestUrl) : null);
+  const sourceLoadController = taxiPointSource ? new AbortController() : null;
+  let finalized = false;
   const zonePresets = makeTaxiZonePresets();
   const initialZone = zonePresets.find(zone => zone.id === INITIAL_ZONE_ID) ?? zonePresets[0];
   let viewState: TaxiViewState = {
@@ -58,7 +96,10 @@ export function createLuSpatialTaxiDeck(
   };
   let queryEffect: LuSpatialTaxiQueryEffect | null = null;
   let latestSelectionCenter: readonly [number, number] = initialZone.center;
+  let stagingQueryEffect: LuSpatialTaxiQueryEffect | null = null;
+  let activeLayers: LuSpatialPointLayer[] = [];
   let queryRadiusKilometres = 0.35;
+  let taxiDataRevision = 0;
 
   if (getComputedStyle(container).position === 'static') container.style.position = 'relative';
   const loadingIndicator = createLoadingIndicator(container);
@@ -89,6 +130,7 @@ export function createLuSpatialTaxiDeck(
     onRadiusChange: radiusKilometres => {
       queryRadiusKilometres = radiusKilometres;
       queryEffect?.setSelectionRadius(radiusKilometres);
+      stagingQueryEffect?.setSelectionRadius(radiusKilometres);
       deck?.redraw('luSpatial radius changed');
     },
     onZoneChange: zone => {
@@ -100,6 +142,7 @@ export function createLuSpatialTaxiDeck(
         zoom: zone.zoom
       };
       queryEffect?.setSelection(zone.center, queryRadiusKilometres);
+      stagingQueryEffect?.setSelection(zone.center, queryRadiusKilometres);
       controls.setCoordinate(zone.center, zone.name);
       deck?.setProps({viewState});
       synchronizeBasemap(map, viewState);
@@ -120,7 +163,7 @@ export function createLuSpatialTaxiDeck(
 
   deck = new ArrowDeck({
     parent: container,
-    ...getDeckExampleProps({...options, deviceType: 'webgpu'}),
+    ...getDeckExampleProps({...deviceOptions, deviceType: 'webgpu'}),
     views: new MapView({id: 'map', repeat: false}),
     viewState,
     controller: {
@@ -140,6 +183,7 @@ export function createLuSpatialTaxiDeck(
       const center = [coordinate[0], coordinate[1]] as const;
       latestSelectionCenter = center;
       queryEffect?.setSelection(center, queryRadiusKilometres);
+      stagingQueryEffect?.setSelection(center, queryRadiusKilometres);
       controls.setCoordinate(center, 'Custom map query');
       controls.setCustomZone();
       deck.redraw('luSpatial query moved');
@@ -160,69 +204,181 @@ export function createLuSpatialTaxiDeck(
           background: 'transparent'
         });
       }
-      void (async () => {
+      const activateTaxiData = (
+        nextTaxiData: LuSpatialTaxiData,
+        redrawReason: string
+      ): Promise<void> => {
+        const previousQueryEffect = queryEffect;
+        const previousLayers = activeLayers;
+        const nextTaxiDataRevision = taxiDataRevision + 1;
+        let nextQueryEffect: LuSpatialTaxiQueryEffect;
         try {
-          const generatedTaxiData = await makeLuSpatialTaxiDataAsync(TAXI_POINT_COUNT, {
-            signal: generationController.signal,
-            onProgress: (processedPointCount, totalPointCount) => {
-              controls.setLoadingProgress(processedPointCount, totalPointCount);
-              loadingIndicator.setProgress(processedPointCount, totalPointCount);
-            }
-          });
-          generationController.signal.throwIfAborted();
-          taxiData = generatedTaxiData;
-          loadingIndicator.setStatus('Compiling luProj projection and GPU spatial index…');
-
-          queryEffect = new LuSpatialTaxiQueryEffect(device, generatedTaxiData, {
+          nextQueryEffect = new LuSpatialTaxiQueryEffect(device, nextTaxiData, {
+            id: `luspatial-taxi-query-effect-${nextTaxiDataRevision}`,
             onStats: stats => controls.updateStats(stats)
           });
-          queryEffect.setSelection(latestSelectionCenter, queryRadiusKilometres);
-          loadedDeck.setProps({
-            effects: [queryEffect],
-            layers: [
-              new LuSpatialPointLayer({
-                id: 'luspatial-taxi-context',
-                data: [],
-                pickable: true,
-                autoHighlight: true,
-                highlightColor: [255, 140, 32, 230],
-                longitudeLatitudes: queryEffect.longitudeLatitudes,
-                visibleIds: queryEffect.viewportIds,
-                drawCommands: queryEffect.drawCommands,
-                commandIndex: 0,
-                color: [94, 172, 198, 105],
-                radiusPixels: 0.9,
-                opacity: 0.46
-              }),
-              new LuSpatialPointLayer({
-                id: 'luspatial-taxi-selection',
-                data: [],
-                pickable: true,
-                autoHighlight: true,
-                highlightColor: [255, 140, 32, 245],
-                longitudeLatitudes: queryEffect.longitudeLatitudes,
-                visibleIds: queryEffect.selectedIds,
-                drawCommands: queryEffect.drawCommands,
-                commandIndex: 1,
-                color: [52, 220, 244, 205],
-                radiusPixels: 1.25,
-                opacity: 0.72
-              })
-            ]
-          });
-          loadingIndicator.destroy();
-          loadedDeck.redraw('luProj and luSpatial initialized');
         } catch (error) {
-          if (!generationController.signal.aborted) {
+          return Promise.reject(error);
+        }
+        nextQueryEffect.setSelection(latestSelectionCenter, queryRadiusKilometres);
+        stagingQueryEffect = nextQueryEffect;
+
+        return new Promise<void>((resolve, reject) => {
+          let settled = false;
+          const readyLayerIndexes = new Set<number>();
+          let stagedLayers: LuSpatialPointLayer[] = [];
+
+          const rejectActivation = (error: Error): void => {
+            if (settled) return;
+            settled = true;
+            queueMicrotask(() => {
+              if (stagingQueryEffect === nextQueryEffect) stagingQueryEffect = null;
+              if (!finalized) {
+                try {
+                  loadedDeck.setProps({
+                    effects: previousQueryEffect ? [previousQueryEffect] : [],
+                    layers: previousLayers
+                  });
+                  loadedDeck.redraw('luSpatial taxi source activation rolled back');
+                } catch {
+                  // Deck is already tearing down; the effect cleanup below remains idempotent.
+                }
+              }
+              nextQueryEffect.destroy();
+              reject(error);
+            });
+          };
+
+          const commitActivation = (): void => {
+            if (settled) return;
+            if (finalized) {
+              rejectActivation(new Error('luSpatial taxi explorer finalized during activation'));
+              return;
+            }
+            try {
+              loadedDeck.setProps({
+                effects: previousQueryEffect
+                  ? [previousQueryEffect, nextQueryEffect]
+                  : [nextQueryEffect],
+                layers: stagedLayers
+              });
+            } catch (error) {
+              rejectActivation(error instanceof Error ? error : new Error(String(error)));
+              return;
+            }
+            settled = true;
+            for (const layer of stagedLayers) layer.reveal();
+            taxiData = nextTaxiData;
+            taxiDataRevision = nextTaxiDataRevision;
+            queryEffect = nextQueryEffect;
+            stagingQueryEffect = null;
+            activeLayers = stagedLayers;
+            controls.updateSourceStatus({
+              corpusPointCount: nextTaxiData.corpusPointCount,
+              message:
+                nextTaxiData.sourceKind === 'packed'
+                  ? `${nextTaxiData.sourceLabel} · ${formatByteCount(nextTaxiData.sourceTelemetry?.downloadedByteCount ?? 0)} downloaded`
+                  : 'Deterministic generated fixture · no network request'
+            });
+            loadedDeck.redraw(redrawReason);
+            retirePreviousQueryEffect(
+              loadedDeck,
+              previousQueryEffect,
+              nextQueryEffect,
+              () => finalized || queryEffect !== nextQueryEffect
+            );
+            resolve();
+          };
+
+          stagedLayers = makeTaxiLayers(nextQueryEffect, nextTaxiDataRevision, {
+            staged: true,
+            onLayerReady: layerIndex => {
+              readyLayerIndexes.add(layerIndex);
+              if (readyLayerIndexes.size === stagedLayers.length) {
+                queueMicrotask(commitActivation);
+              }
+            },
+            onLayerError: rejectActivation
+          });
+
+          try {
+            loadedDeck.setProps({
+              effects: previousQueryEffect
+                ? [previousQueryEffect, nextQueryEffect]
+                : [nextQueryEffect],
+              layers: [...previousLayers, ...stagedLayers]
+            });
+            loadedDeck.redraw('luSpatial taxi source activation staged');
+          } catch (error) {
+            rejectActivation(error instanceof Error ? error : new Error(String(error)));
+          }
+        });
+      };
+
+      void (async () => {
+        let generatedTaxiData: LuSpatialTaxiData;
+        try {
+          generatedTaxiData = await makeLuSpatialTaxiDataAsync(
+            Math.min(residentPointCapacity, TAXI_POINT_COUNT),
+            {
+              signal: generationController.signal,
+              onProgress: (processedPointCount, totalPointCount) => {
+                controls.setLoadingProgress(processedPointCount, totalPointCount);
+                loadingIndicator.setProgress(processedPointCount, totalPointCount);
+              }
+            }
+          );
+          generationController.signal.throwIfAborted();
+          loadingIndicator.setStatus('Compiling luProj projection and GPU spatial index…');
+          await activateTaxiData(generatedTaxiData, 'luProj and luSpatial initialized');
+          loadingIndicator.destroy();
+        } catch (error) {
+          if (!generationController.signal.aborted && !finalized) {
             loadingIndicator.setStatus(
               `GPU initialization failed: ${error instanceof Error ? error.message : String(error)}`
             );
+          }
+          return;
+        }
+        if (taxiPointSource && sourceLoadController) {
+          controls.updateSourceStatus({message: 'Reading packed taxi manifest…'});
+          try {
+            const metadata = await taxiPointSource.getMetadata(sourceLoadController.signal);
+            assertLongitudeLatitudeTaxiMetadata(metadata);
+            controls.updateSourceStatus({
+              corpusPointCount: metadata.rowCount,
+              message: `Streaming ${formatCount(Math.min(residentPointCapacity, metadata.rowCount))} source rows…`
+            });
+            const residentWindow = await loadTaxiPointResidentWindow(taxiPointSource, {
+              capacity: residentPointCapacity,
+              signal: sourceLoadController.signal,
+              onProgress: progress => {
+                if (finalized) return;
+                controls.updateSourceStatus({
+                  corpusPointCount: progress.sourceRowCount,
+                  message: `Streaming ${formatCount(progress.residentRowCount)} / ${formatCount(progress.targetRowCount)} · ${formatByteCount(progress.telemetry.downloadedByteCount)}`
+                });
+              }
+            });
+            const packedTaxiData = makeLuSpatialTaxiDataFromResidentWindow(residentWindow);
+            sourceLoadController.signal.throwIfAborted();
+            if (finalized) return;
+            await activateTaxiData(packedTaxiData, 'luSpatial packed taxi source activated');
+          } catch (error) {
+            if (sourceLoadController.signal.aborted || finalized) return;
+            controls.updateSourceStatus({
+              corpusPointCount: taxiData?.corpusPointCount ?? generatedTaxiData.corpusPointCount,
+              message: `Packed source unavailable; using synthetic fixture · ${error instanceof Error ? error.message : String(error)}`
+            });
           }
         }
       })();
     },
     onFinalize: () => {
+      finalized = true;
       generationController.abort();
+      sourceLoadController?.abort(new Error('luSpatial taxi explorer finalized'));
+      void closeTaxiPointSource(taxiPointSource);
       resizeObserver.disconnect();
       loadingIndicator.destroy();
       controls.destroy();
@@ -259,10 +415,10 @@ function getTooltip(data: LuSpatialTaxiData, info: PickingInfo): {html: string} 
   if (!point) return null;
   return {
     html: `<div style="font:12px/1.5 ui-monospace,monospace;min-width:190px">
-      <div style="color:#64e9ff;font-weight:700">TRIP ROW ${info.index.toLocaleString()}</div>
+      <div style="color:#64e9ff;font-weight:700">TRIP ROW ${point.sourceRowIndex.toLocaleString()}</div>
       <div>longitude&nbsp; ${point.longitude.toFixed(6)}</div>
       <div>latitude&nbsp;&nbsp; ${point.latitude.toFixed(6)}</div>
-      <div style="margin-top:4px;color:#91a4b7">Synthetic public-sample expansion</div>
+      <div style="margin-top:4px;color:#91a4b7">${data.sourceLabel}</div>
     </div>`
   };
 }
@@ -278,6 +434,7 @@ type TaxiControlPanel = {
   setCoordinate: (coordinate: readonly [number, number], label: string) => void;
   setCustomZone: () => void;
   setLoadingProgress: (processedPointCount: number, totalPointCount: number) => void;
+  updateSourceStatus: (status: {corpusPointCount?: number; message: string}) => void;
   updateStats: (stats: LuSpatialTaxiQueryStats) => void;
 };
 
@@ -417,7 +574,7 @@ function createControlPanel(
       <div style="padding:4px 6px;border:1px solid rgba(54,223,255,.28);border-radius:5px;color:#4be4ff;font:700 9px ui-monospace,monospace">DECK.GL · WEBGPU</div>
     </div>
     <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:10px">
-      <div><div data-luspatial-label>CORPUS</div><div data-luspatial-value>${formatCount(TAXI_CORPUS_POINT_COUNT)}</div></div>
+      <div><div data-luspatial-label>CORPUS</div><div data-luspatial-value data-corpus>${formatCount(TAXI_CORPUS_POINT_COUNT)}</div></div>
       <div><div data-luspatial-label>GPU RESIDENT</div><div data-luspatial-value data-resident>—</div></div>
       <div><div data-luspatial-label>IN VIEW</div><div data-luspatial-value data-visible>—</div></div>
       <div><div data-luspatial-label>SELECTED</div><div data-luspatial-value data-selected style="color:#49e3ff">—</div></div>
@@ -437,6 +594,7 @@ function createControlPanel(
     <div style="margin-top:9px;padding:8px;border-radius:6px;background:rgba(32,210,242,.07);border:1px solid rgba(42,218,249,.13)">
       <div data-luspatial-label>QUERY CENTER</div><div data-coordinate style="margin-top:3px;color:#cdebf4;font:10px/1.4 ui-monospace,monospace">—</div>
     </div>
+    <div data-source-status style="margin-top:7px;color:#6f8598;font:9px/1.35 ui-monospace,monospace">DETERMINISTIC GENERATED FIXTURE · NO NETWORK REQUEST</div>
     <div style="display:flex;justify-content:space-between;gap:10px;margin-top:9px;color:#6f8598;font:9px/1.35 ui-monospace,monospace">
       <span>CLICK TO MOVE QUERY<br/>DRAG / SCROLL TO NAVIGATE</span>
       <span style="text-align:right"><span data-query-time>—</span> CPU ENCODE<br/>GPU COUNT → INDIRECT DRAW</span>
@@ -456,6 +614,8 @@ function createControlPanel(
   const radiusInput = root.querySelector<HTMLInputElement>('[data-radius]')!;
   const radiusValue = root.querySelector<HTMLElement>('[data-radius-value]')!;
   const coordinateElement = root.querySelector<HTMLElement>('[data-coordinate]')!;
+  const corpusElement = root.querySelector<HTMLElement>('[data-corpus]')!;
+  const sourceStatusElement = root.querySelector<HTMLElement>('[data-source-status]')!;
   const residentElement = root.querySelector<HTMLElement>('[data-resident]')!;
   const basemapWarningElement = root.querySelector<HTMLElement>('[data-basemap-warning]')!;
   const visibleElement = root.querySelector<HTMLElement>('[data-visible]')!;
@@ -586,6 +746,12 @@ function createControlPanel(
       const percentage = Math.round((processedPointCount / Math.max(1, totalPointCount)) * 100);
       residentElement.textContent = `${percentage}% loading`;
     },
+    updateSourceStatus: status => {
+      if (status.corpusPointCount !== undefined) {
+        corpusElement.textContent = formatCount(status.corpusPointCount);
+      }
+      sourceStatusElement.textContent = status.message;
+    },
     updateStats: stats => {
       residentElement.textContent = formatCount(stats.residentPointCount);
       visibleElement.textContent = formatCount(stats.visiblePointCount);
@@ -601,4 +767,94 @@ function formatCount(value: number): string {
     notation: 'compact',
     maximumFractionDigits: 1
   }).format(value);
+}
+
+function formatByteCount(value: number): string {
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KiB`;
+  return `${(value / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+function getConfiguredTaxiManifestUrl(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return new URLSearchParams(window.location.search).get('taxi-manifest')?.trim() || undefined;
+}
+
+async function closeTaxiPointSource(source: TaxiPointSource | null): Promise<void> {
+  try {
+    await source?.close();
+  } catch {
+    // Finalization is best effort; an asynchronous source cleanup failure must not be unhandled.
+  }
+}
+
+function retirePreviousQueryEffect(
+  deck: ArrowDeck<MapView>,
+  previousQueryEffect: LuSpatialTaxiQueryEffect | null,
+  nextQueryEffect: LuSpatialTaxiQueryEffect,
+  shouldSkip: () => boolean
+): void {
+  if (!previousQueryEffect) return;
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      if (shouldSkip()) return;
+      deck.setProps({effects: [nextQueryEffect]});
+      deck.redraw('luSpatial previous taxi source retired');
+    });
+  });
+}
+
+type TaxiLayerStagingOptions = {
+  staged?: boolean;
+  onLayerReady?: (layerIndex: number) => void;
+  onLayerError?: (error: Error) => void;
+};
+
+function makeTaxiLayers(
+  queryEffect: LuSpatialTaxiQueryEffect,
+  taxiDataRevision: number,
+  options: TaxiLayerStagingOptions = {}
+): LuSpatialPointLayer[] {
+  return [
+    new LuSpatialPointLayer({
+      id: `luspatial-taxi-context-${taxiDataRevision}`,
+      data: [],
+      pickable: true,
+      autoHighlight: true,
+      highlightColor: [255, 140, 32, 230],
+      longitudeLatitudes: queryEffect.longitudeLatitudes,
+      visibleIds: queryEffect.viewportIds,
+      drawCommands: queryEffect.drawCommands,
+      commandIndex: 0,
+      color: [94, 172, 198, 105],
+      radiusPixels: 0.9,
+      opacity: 0.46,
+      staged: options.staged,
+      onResourcesReady: () => options.onLayerReady?.(0),
+      onError: error => {
+        options.onLayerError?.(error);
+        return Boolean(options.onLayerError);
+      }
+    }),
+    new LuSpatialPointLayer({
+      id: `luspatial-taxi-selection-${taxiDataRevision}`,
+      data: [],
+      pickable: true,
+      autoHighlight: true,
+      highlightColor: [255, 140, 32, 245],
+      longitudeLatitudes: queryEffect.longitudeLatitudes,
+      visibleIds: queryEffect.selectedIds,
+      drawCommands: queryEffect.drawCommands,
+      commandIndex: 1,
+      color: [52, 220, 244, 205],
+      radiusPixels: 1.25,
+      opacity: 0.72,
+      staged: options.staged,
+      onResourcesReady: () => options.onLayerReady?.(1),
+      onError: error => {
+        options.onLayerError?.(error);
+        return Boolean(options.onLayerError);
+      }
+    })
+  ];
 }

--- a/examples/deck/luspatial-taxi/luspatial-point-layer.ts
+++ b/examples/deck/luspatial-taxi/luspatial-point-layer.ts
@@ -22,6 +22,12 @@ export type LuSpatialPointLayerProps = LayerProps & {
   commandIndex: number;
   color: Color;
   radiusPixels: number;
+  /** Keeps a fully initialized replacement out of render and picking passes until commit. */
+  staged?: boolean;
+  /** Signals that this layer's render resources were created successfully. */
+  onResourcesReady?: () => void;
+  /** @internal Test hook for deterministic resource-initialization failures. */
+  onBeforeModelInitialization?: () => void;
 };
 
 type LuSpatialPointLayerState = {
@@ -124,33 +130,53 @@ export class LuSpatialPointLayer extends Layer<LuSpatialPointLayerProps> {
   static override layerName = 'LuSpatialPointLayer';
   static override defaultProps = {parameters: POINT_BLEND_PARAMETERS};
 
+  private staged = false;
+
   override getAttributeManager() {
     return null;
   }
 
   override initializeState({device}: LayerContext): void {
     if (device.type !== 'webgpu') throw new Error('LuSpatialPointLayer requires WebGPU');
-    const styleUniforms = device.createBuffer({
-      id: `${this.id}-style-uniforms`,
-      byteLength: 32,
-      usage: Buffer.UNIFORM | Buffer.COPY_DST
-    });
-    const model = new Model(device, {
-      ...this.getShaders({modules: [project32, picking], source: LUSPATIAL_POINT_SHADER}),
-      id: `${this.id}-model`,
-      topology: 'triangle-list',
-      isInstanced: true,
-      vertexCount: 6,
-      instanceCount: 0,
-      bufferLayout: [],
-      bindings: {
-        longitudeLatitudes: this.props.longitudeLatitudes,
-        visibleIds: this.props.visibleIds,
-        pointStyle: styleUniforms
-      },
-      parameters: POINT_BLEND_PARAMETERS
-    });
-    this.setState({model, styleUniforms} satisfies LuSpatialPointLayerState);
+    let styleUniforms: Buffer | null = null;
+    let model: Model | null = null;
+    try {
+      styleUniforms = device.createBuffer({
+        id: `${this.id}-style-uniforms`,
+        byteLength: 32,
+        usage: Buffer.UNIFORM | Buffer.COPY_DST
+      });
+      this.props.onBeforeModelInitialization?.();
+      model = new Model(device, {
+        ...this.getShaders({modules: [project32, picking], source: LUSPATIAL_POINT_SHADER}),
+        id: `${this.id}-model`,
+        topology: 'triangle-list',
+        isInstanced: true,
+        vertexCount: 6,
+        instanceCount: 0,
+        bufferLayout: [],
+        bindings: {
+          longitudeLatitudes: this.props.longitudeLatitudes,
+          visibleIds: this.props.visibleIds,
+          pointStyle: styleUniforms
+        },
+        parameters: POINT_BLEND_PARAMETERS
+      });
+      this.staged = Boolean(this.props.staged);
+      this.setState({model, styleUniforms} satisfies LuSpatialPointLayerState);
+    } catch (error) {
+      model?.destroy();
+      styleUniforms?.destroy();
+      throw error;
+    }
+    this.props.onResourcesReady?.();
+  }
+
+  /** Reveals a staged layer after every layer in its resident-data revision is ready. */
+  reveal(): void {
+    if (!this.staged) return;
+    this.staged = false;
+    this.setNeedsRedraw();
   }
 
   override getModels(): Model[] {
@@ -165,6 +191,7 @@ export class LuSpatialPointLayer extends Layer<LuSpatialPointLayerProps> {
     renderPass: RenderPass;
     shaderModuleProps?: {picking?: {isActive?: number | boolean}};
   }): void {
+    if (this.staged) return;
     const {model, styleUniforms} = this.state as LuSpatialPointLayerState;
     if (!model || !styleUniforms) return;
     const [red, green, blue, alpha = 255] = this.props.color;

--- a/examples/deck/luspatial-taxi/luspatial-query-effect.ts
+++ b/examples/deck/luspatial-taxi/luspatial-query-effect.ts
@@ -17,6 +17,8 @@ import {TAXI_GRID_SIZE, projectTaxiLongitudeLatitude, type LuSpatialTaxiData} fr
 
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
 
+type DestroyableResource = {destroy(): void};
+
 export type LuSpatialTaxiQueryStats = {
   residentPointCount: number;
   visiblePointCount: number;
@@ -28,12 +30,14 @@ export type LuSpatialTaxiQueryStats = {
 };
 
 export type LuSpatialTaxiQueryEffectOptions = {
+  /** Stable effect identity for this resident data revision. */
+  id?: string;
   onStats?: (stats: LuSpatialTaxiQueryStats) => void;
 };
 
 /** Deck effect that projects, indexes, and queries the resident taxi window on WebGPU. */
 export class LuSpatialTaxiQueryEffect implements Effect {
-  readonly id = 'luspatial-taxi-query-effect';
+  readonly id: string;
   readonly props = {};
   readonly useInPicking = true;
   readonly longitudeLatitudes: Buffer;
@@ -80,6 +84,7 @@ export class LuSpatialTaxiQueryEffect implements Effect {
   private queryInputsChanged = true;
   private lastViewportBounds: Float32Array | null = null;
   private destroyed = false;
+  private readonly ownedResources: DestroyableResource[] = [];
 
   constructor(
     device: Device,
@@ -91,80 +96,116 @@ export class LuSpatialTaxiQueryEffect implements Effect {
     }
     this.device = device;
     this.data = data;
+    this.id = options.id ?? 'luspatial-taxi-query-effect';
     this.onStats = options.onStats;
 
-    const cellCount = TAXI_GRID_SIZE[0] * TAXI_GRID_SIZE[1];
-    this.longitudeLatitudes = device.createBuffer({
-      id: 'luspatial-taxi-longitude-latitudes',
-      data: data.longitudeLatitudes,
-      usage: Buffer.STORAGE
-    });
-    this.projectedPositions = device.createBuffer({
-      id: 'luspatial-taxi-projected-positions',
-      byteLength: data.pointCount * 2 * Float32Array.BYTES_PER_ELEMENT,
-      usage: Buffer.STORAGE
-    });
-    this.cellOffsets = device.createBuffer({
-      id: 'luspatial-taxi-cell-offsets',
-      byteLength: (cellCount + 1) * UINT32_BYTE_LENGTH,
-      usage: Buffer.STORAGE | Buffer.COPY_SRC
-    });
-    this.indexRowIndices = device.createBuffer({
-      id: 'luspatial-taxi-index-row-indices',
-      byteLength: data.pointCount * UINT32_BYTE_LENGTH,
-      usage: Buffer.STORAGE | Buffer.COPY_SRC
-    });
-    this.indexCount = createScalarBuffer(device, 'luspatial-taxi-index-count');
-    this.indexOverflow = createScalarBuffer(device, 'luspatial-taxi-index-overflow');
-    this.viewportIds = device.createBuffer({
-      id: 'luspatial-taxi-viewport-ids',
-      byteLength: data.pointCount * UINT32_BYTE_LENGTH,
-      usage: Buffer.STORAGE | Buffer.COPY_SRC
-    });
-    this.selectedIds = device.createBuffer({
-      id: 'luspatial-taxi-selected-ids',
-      byteLength: data.pointCount * UINT32_BYTE_LENGTH,
-      usage: Buffer.STORAGE | Buffer.COPY_SRC
-    });
-    this.viewportQuery = device.createBuffer({
-      id: 'luspatial-taxi-viewport-query',
-      byteLength: 4 * Float32Array.BYTES_PER_ELEMENT,
-      usage: Buffer.STORAGE | Buffer.COPY_DST
-    });
-    this.selectionQuery = device.createBuffer({
-      id: 'luspatial-taxi-selection-query',
-      byteLength: 3 * Float32Array.BYTES_PER_ELEMENT,
-      usage: Buffer.STORAGE | Buffer.COPY_DST
-    });
-    this.viewportTotalCount = createScalarBuffer(device, 'luspatial-taxi-viewport-total-count');
-    this.selectionTotalCount = createScalarBuffer(device, 'luspatial-taxi-selection-total-count');
-    this.viewportOverflow = createScalarBuffer(device, 'luspatial-taxi-viewport-overflow');
-    this.selectionOverflow = createScalarBuffer(device, 'luspatial-taxi-selection-overflow');
-    this.drawCommands = new DrawCommandBuffer(device, {
-      id: 'luspatial-taxi-draw-commands',
-      type: 'draw',
-      capacity: 2,
-      commands: [
-        {vertexCount: 6, instanceCount: 0},
-        {vertexCount: 6, instanceCount: 0}
-      ]
-    });
+    try {
+      const cellCount = TAXI_GRID_SIZE[0] * TAXI_GRID_SIZE[1];
+      this.longitudeLatitudes = this.ownResource(
+        device.createBuffer({
+          id: 'luspatial-taxi-longitude-latitudes',
+          data: data.longitudeLatitudes,
+          usage: Buffer.STORAGE
+        })
+      );
+      this.projectedPositions = this.ownResource(
+        device.createBuffer({
+          id: 'luspatial-taxi-projected-positions',
+          byteLength: data.pointCount * 2 * Float32Array.BYTES_PER_ELEMENT,
+          usage: Buffer.STORAGE
+        })
+      );
+      this.cellOffsets = this.ownResource(
+        device.createBuffer({
+          id: 'luspatial-taxi-cell-offsets',
+          byteLength: (cellCount + 1) * UINT32_BYTE_LENGTH,
+          usage: Buffer.STORAGE | Buffer.COPY_SRC
+        })
+      );
+      this.indexRowIndices = this.ownResource(
+        device.createBuffer({
+          id: 'luspatial-taxi-index-row-indices',
+          byteLength: data.pointCount * UINT32_BYTE_LENGTH,
+          usage: Buffer.STORAGE | Buffer.COPY_SRC
+        })
+      );
+      this.indexCount = this.ownResource(createScalarBuffer(device, 'luspatial-taxi-index-count'));
+      this.indexOverflow = this.ownResource(
+        createScalarBuffer(device, 'luspatial-taxi-index-overflow')
+      );
+      this.viewportIds = this.ownResource(
+        device.createBuffer({
+          id: 'luspatial-taxi-viewport-ids',
+          byteLength: data.pointCount * UINT32_BYTE_LENGTH,
+          usage: Buffer.STORAGE | Buffer.COPY_SRC
+        })
+      );
+      this.selectedIds = this.ownResource(
+        device.createBuffer({
+          id: 'luspatial-taxi-selected-ids',
+          byteLength: data.pointCount * UINT32_BYTE_LENGTH,
+          usage: Buffer.STORAGE | Buffer.COPY_SRC
+        })
+      );
+      this.viewportQuery = this.ownResource(
+        device.createBuffer({
+          id: 'luspatial-taxi-viewport-query',
+          byteLength: 4 * Float32Array.BYTES_PER_ELEMENT,
+          usage: Buffer.STORAGE | Buffer.COPY_DST
+        })
+      );
+      this.selectionQuery = this.ownResource(
+        device.createBuffer({
+          id: 'luspatial-taxi-selection-query',
+          byteLength: 3 * Float32Array.BYTES_PER_ELEMENT,
+          usage: Buffer.STORAGE | Buffer.COPY_DST
+        })
+      );
+      this.viewportTotalCount = this.ownResource(
+        createScalarBuffer(device, 'luspatial-taxi-viewport-total-count')
+      );
+      this.selectionTotalCount = this.ownResource(
+        createScalarBuffer(device, 'luspatial-taxi-selection-total-count')
+      );
+      this.viewportOverflow = this.ownResource(
+        createScalarBuffer(device, 'luspatial-taxi-viewport-overflow')
+      );
+      this.selectionOverflow = this.ownResource(
+        createScalarBuffer(device, 'luspatial-taxi-selection-overflow')
+      );
+      this.drawCommands = this.ownResource(
+        new DrawCommandBuffer(device, {
+          id: 'luspatial-taxi-draw-commands',
+          type: 'draw',
+          capacity: 2,
+          commands: [
+            {vertexCount: 6, instanceCount: 0},
+            {vertexCount: 6, instanceCount: 0}
+          ]
+        })
+      );
 
-    this.buildGraph = this.createBuildGraph();
-    this.queryGraph = this.createQueryGraph();
-    this.inspector.registerGraph(this.buildGraph);
-    this.inspector.registerGraph(this.queryGraph);
-    const commandEncoder = device.createCommandEncoder({id: 'luspatial-taxi-index-build'});
-    const encoding = this.buildGraph.encode(commandEncoder, {parameters: undefined});
-    this.inspector.recordEncoding(this.buildGraph.id, encoding);
-    this.buildEncodingMilliseconds = encoding.stats.cpuEncodeTimeMilliseconds;
-    device.submit(commandEncoder.finish());
-    if (encoding.canReadGPUTimings) {
-      setTimeout(() => {
-        if (!this.destroyed) void this.inspector.recordGPUTimings(this.buildGraph.id, encoding);
-      }, 0);
+      this.buildGraph = this.ownResource(this.createBuildGraph());
+      this.queryGraph = this.ownResource(this.createQueryGraph());
+      this.inspector.registerGraph(this.buildGraph);
+      this.inspector.registerGraph(this.queryGraph);
+      const commandEncoder = device.createCommandEncoder({id: 'luspatial-taxi-index-build'});
+      const encoding = this.buildGraph.encode(commandEncoder, {parameters: undefined});
+      this.inspector.recordEncoding(this.buildGraph.id, encoding);
+      this.buildEncodingMilliseconds = encoding.stats.cpuEncodeTimeMilliseconds;
+      device.submit(commandEncoder.finish());
+      this.publishStats();
+      if (encoding.canReadGPUTimings) {
+        setTimeout(() => {
+          if (!this.destroyed) {
+            void this.inspector.recordGPUTimings(this.buildGraph.id, encoding);
+          }
+        }, 0);
+      }
+    } catch (error) {
+      this.destroyOwnedResources();
+      throw error;
     }
-    this.publishStats();
   }
 
   setup(_context: EffectContext): void {}
@@ -232,7 +273,9 @@ export class LuSpatialTaxiQueryEffect implements Effect {
       this.scheduleCountSample(0);
       if (encoding.canReadGPUTimings) {
         setTimeout(() => {
-          if (!this.destroyed) void this.inspector.recordGPUTimings(this.queryGraph.id, encoding);
+          if (!this.destroyed) {
+            void this.inspector.recordGPUTimings(this.queryGraph.id, encoding);
+          }
         }, 0);
       }
     }
@@ -240,28 +283,32 @@ export class LuSpatialTaxiQueryEffect implements Effect {
   }
 
   cleanup(_context: EffectContext): void {
+    this.destroy();
+  }
+
+  /** Releases GPU resources when a newly constructed effect cannot be adopted by deck.gl. */
+  destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
     if (this.countSampleTimer !== null) clearTimeout(this.countSampleTimer);
-    this.buildGraph.destroy();
-    this.queryGraph.destroy();
-    this.projection?.destroy();
+    this.destroyOwnedResources();
     this.projection = null;
-    this.drawCommands.destroy();
-    this.longitudeLatitudes.destroy();
-    this.projectedPositions.destroy();
-    this.cellOffsets.destroy();
-    this.indexRowIndices.destroy();
-    this.indexCount.destroy();
-    this.indexOverflow.destroy();
-    this.viewportIds.destroy();
-    this.selectedIds.destroy();
-    this.viewportQuery.destroy();
-    this.selectionQuery.destroy();
-    this.viewportTotalCount.destroy();
-    this.selectionTotalCount.destroy();
-    this.viewportOverflow.destroy();
-    this.selectionOverflow.destroy();
+  }
+
+  private ownResource<T extends DestroyableResource>(resource: T): T {
+    this.ownedResources.push(resource);
+    return resource;
+  }
+
+  private destroyOwnedResources(): void {
+    for (let index = this.ownedResources.length - 1; index >= 0; index--) {
+      try {
+        this.ownedResources[index]?.destroy();
+      } catch {
+        // Continue releasing the remaining resources after device loss or partial construction.
+      }
+    }
+    this.ownedResources.length = 0;
   }
 
   private createBuildGraph(): CompiledGPUCommandGraph<void> {
@@ -301,12 +348,14 @@ export class LuSpatialTaxiQueryEffect implements Effect {
       tolerance: 0.0005,
       maxDepth: 4
     });
-    const projection = new GPUProjection({
-      id: 'luspatial-taxi-luproj-project',
-      positions: source,
-      output: projected,
-      plan: projectionPlan
-    });
+    const projection = this.ownResource(
+      new GPUProjection({
+        id: 'luspatial-taxi-luproj-project',
+        positions: source,
+        output: projected,
+        plan: projectionPlan
+      })
+    );
     projection.addToGraph(graph);
     this.projection = projection;
     new GPUGridIndex({

--- a/examples/deck/luspatial-taxi/taxi-data.ts
+++ b/examples/deck/luspatial-taxi/taxi-data.ts
@@ -7,6 +7,11 @@ import {
   makeSyntheticTaxiPositions,
   makeTaxiZones
 } from '../../showcase/billion-point-spatial-atlas/spatial-atlas-data';
+import type {TaxiPointResidentWindow} from '../../showcase/billion-point-spatial-atlas/taxi-resident-window';
+import type {
+  TaxiPointSourceMetadata,
+  TaxiPointSourceTelemetry
+} from '../../showcase/billion-point-spatial-atlas/taxi-source';
 
 export const TAXI_POINT_COUNT = 1_000_000;
 export const TAXI_CORPUS_POINT_COUNT = PAUL_TAYLOR_POINT_COUNT;
@@ -22,9 +27,14 @@ const DEGREES_TO_RADIANS = Math.PI / 180;
 
 export type LuSpatialTaxiData = {
   pointCount: number;
+  corpusPointCount: number;
   longitudeLatitudes: Float32Array;
   sourceBounds: readonly [number, number, number, number];
   projectedBounds: readonly [number, number, number, number];
+  sourceRowIndices?: Float64Array;
+  sourceKind: 'synthetic' | 'packed';
+  sourceLabel: string;
+  sourceTelemetry?: TaxiPointSourceTelemetry;
 };
 
 export type LuSpatialTaxiDataGenerationOptions = {
@@ -111,22 +121,7 @@ function makeTaxiDataFromBounds(
   longitudeLatitudes: Float32Array,
   sourceBounds: number[]
 ): LuSpatialTaxiData {
-  const longitudeExtent =
-    Math.max(
-      TAXI_PROJECTION_ORIGIN[0] - sourceBounds[0],
-      sourceBounds[2] - TAXI_PROJECTION_ORIGIN[0]
-    ) + TAXI_SOURCE_BOUNDS_PADDING;
-  const latitudeExtent =
-    Math.max(
-      TAXI_PROJECTION_ORIGIN[1] - sourceBounds[1],
-      sourceBounds[3] - TAXI_PROJECTION_ORIGIN[1]
-    ) + TAXI_SOURCE_BOUNDS_PADDING;
-  const projectionSourceBounds = [
-    TAXI_PROJECTION_ORIGIN[0] - longitudeExtent,
-    TAXI_PROJECTION_ORIGIN[1] - latitudeExtent,
-    TAXI_PROJECTION_ORIGIN[0] + longitudeExtent,
-    TAXI_PROJECTION_ORIGIN[1] + latitudeExtent
-  ] as const;
+  const projectionSourceBounds = makeProjectionSourceBounds(sourceBounds);
   const projectedCorners = [
     projectTaxiLongitudeLatitude([sourceBounds[0], sourceBounds[1]]),
     projectTaxiLongitudeLatitude([sourceBounds[0], sourceBounds[3]]),
@@ -145,6 +140,7 @@ function makeTaxiDataFromBounds(
   const padding = 0.25;
   return {
     pointCount,
+    corpusPointCount: TAXI_CORPUS_POINT_COUNT,
     longitudeLatitudes,
     sourceBounds: projectionSourceBounds,
     projectedBounds: [
@@ -152,8 +148,32 @@ function makeTaxiDataFromBounds(
       projectedBounds[1] - padding,
       projectedBounds[2] + padding,
       projectedBounds[3] + padding
-    ]
+    ],
+    sourceKind: 'synthetic',
+    sourceLabel: 'Synthetic public-sample expansion'
   };
+}
+
+function makeProjectionSourceBounds(
+  sourceBounds: readonly number[]
+): readonly [number, number, number, number] {
+  const longitudeExtent =
+    Math.max(
+      TAXI_PROJECTION_ORIGIN[0] - sourceBounds[0],
+      sourceBounds[2] - TAXI_PROJECTION_ORIGIN[0]
+    ) + TAXI_SOURCE_BOUNDS_PADDING;
+  const latitudeExtent =
+    Math.max(
+      TAXI_PROJECTION_ORIGIN[1] - sourceBounds[1],
+      sourceBounds[3] - TAXI_PROJECTION_ORIGIN[1]
+    ) + TAXI_SOURCE_BOUNDS_PADDING;
+  const projectionSourceBounds = [
+    TAXI_PROJECTION_ORIGIN[0] - longitudeExtent,
+    TAXI_PROJECTION_ORIGIN[1] - latitudeExtent,
+    TAXI_PROJECTION_ORIGIN[0] + longitudeExtent,
+    TAXI_PROJECTION_ORIGIN[1] + latitudeExtent
+  ] as const;
+  return projectionSourceBounds;
 }
 
 function yieldTaxiGeneration(signal?: AbortSignal): Promise<void> {
@@ -169,6 +189,84 @@ function yieldTaxiGeneration(signal?: AbortSignal): Promise<void> {
 
     signal?.addEventListener('abort', abortGeneration, {once: true});
   });
+}
+
+/**
+ * Converts an explicitly WGS84 longitude/latitude resident window into deck.gl taxi data.
+ *
+ * Packed sources remain coordinate-neutral until this adapter. CRS84 and the browser convention
+ * for WGS84/EPSG:4326 are interpreted as X=longitude and Y=latitude.
+ */
+export function makeLuSpatialTaxiDataFromResidentWindow(
+  window: TaxiPointResidentWindow
+): LuSpatialTaxiData {
+  assertLongitudeLatitudeTaxiMetadata(window.metadata);
+  if (window.positions.length !== window.rowCount * 2) {
+    throw new Error('Taxi resident window positions must contain two values per row');
+  }
+  if (window.sourceRowIndices.length !== window.rowCount) {
+    throw new Error('Taxi resident window sourceRowIndices must align with positions');
+  }
+
+  const sourceBounds = [Infinity, Infinity, -Infinity, -Infinity];
+  const projectedBounds = [Infinity, Infinity, -Infinity, -Infinity];
+  let finiteRowCount = 0;
+  for (let rowIndex = 0; rowIndex < window.rowCount; rowIndex++) {
+    const longitude = window.positions[rowIndex * 2];
+    const latitude = window.positions[rowIndex * 2 + 1];
+    if (!Number.isFinite(longitude) || !Number.isFinite(latitude)) continue;
+    if (longitude < -180 || longitude > 180 || latitude < -90 || latitude > 90) {
+      throw new Error(
+        `Taxi source row ${window.sourceRowIndices[rowIndex]} is outside longitude/latitude bounds`
+      );
+    }
+    sourceBounds[0] = Math.min(sourceBounds[0], longitude);
+    sourceBounds[1] = Math.min(sourceBounds[1], latitude);
+    sourceBounds[2] = Math.max(sourceBounds[2], longitude);
+    sourceBounds[3] = Math.max(sourceBounds[3], latitude);
+    const [projectedX, projectedY] = projectTaxiLongitudeLatitude([longitude, latitude]);
+    projectedBounds[0] = Math.min(projectedBounds[0], projectedX);
+    projectedBounds[1] = Math.min(projectedBounds[1], projectedY);
+    projectedBounds[2] = Math.max(projectedBounds[2], projectedX);
+    projectedBounds[3] = Math.max(projectedBounds[3], projectedY);
+    finiteRowCount++;
+  }
+  if (finiteRowCount === 0) {
+    throw new Error('Taxi resident window does not contain a finite longitude/latitude row');
+  }
+
+  const padding = 0.25;
+  return {
+    pointCount: window.rowCount,
+    corpusPointCount: window.sourceRowCount,
+    longitudeLatitudes: window.positions,
+    sourceBounds: makeProjectionSourceBounds(sourceBounds),
+    projectedBounds: [
+      projectedBounds[0] - padding,
+      projectedBounds[1] - padding,
+      projectedBounds[2] + padding,
+      projectedBounds[3] + padding
+    ],
+    sourceRowIndices: window.sourceRowIndices,
+    sourceKind: 'packed',
+    sourceLabel: 'Packed row-group source',
+    sourceTelemetry: window.telemetry
+  };
+}
+
+/** Rejects source-XY data until its manifest explicitly declares WGS84 longitude/latitude. */
+export function assertLongitudeLatitudeTaxiMetadata(metadata: TaxiPointSourceMetadata): void {
+  const coordinateReferenceSystem = metadata.coordinateSpace.crs?.trim().toUpperCase();
+  if (
+    coordinateReferenceSystem !== 'OGC:CRS84' &&
+    coordinateReferenceSystem !== 'CRS84' &&
+    coordinateReferenceSystem !== 'EPSG:4326' &&
+    coordinateReferenceSystem !== 'WGS84'
+  ) {
+    throw new Error(
+      'luSpatial taxi sources must explicitly declare OGC:CRS84 or WGS84/EPSG:4326 longitude/latitude coordinates'
+    );
+  }
 }
 
 /** CPU projection provider and tiny query-input companion for the adaptive luProj GPU plan. */
@@ -211,12 +309,19 @@ export function makeTaxiZonePresets(): readonly TaxiZonePreset[] {
 export function getTaxiPoint(
   data: LuSpatialTaxiData,
   pointIndex: number
-): {longitude: number; latitude: number} | null {
+): {
+  longitude: number;
+  latitude: number;
+  sourceRowIndex: number;
+  sourceKind: LuSpatialTaxiData['sourceKind'];
+} | null {
   if (!Number.isSafeInteger(pointIndex) || pointIndex < 0 || pointIndex >= data.pointCount) {
     return null;
   }
   return {
     longitude: data.longitudeLatitudes[pointIndex * 2],
-    latitude: data.longitudeLatitudes[pointIndex * 2 + 1]
+    latitude: data.longitudeLatitudes[pointIndex * 2 + 1],
+    sourceRowIndex: data.sourceRowIndices?.[pointIndex] ?? pointIndex,
+    sourceKind: data.sourceKind
   };
 }

--- a/examples/showcase/billion-point-spatial-atlas/scripts/preprocess-paul-taxi.mjs
+++ b/examples/showcase/billion-point-spatial-atlas/scripts/preprocess-paul-taxi.mjs
@@ -21,15 +21,21 @@ const shardPointCount = parsePositiveInteger(
   argumentsByName['shard-points'] ?? String(DEFAULT_SHARD_POINT_COUNT),
   '--shard-points'
 );
+const coordinateReferenceSystem = parseCoordinateReferenceSystem(argumentsByName.crs);
 
 if (!inputPath) {
   printUsage();
   process.exitCode = 1;
 } else {
-  await preprocess(resolve(inputPath), outputDirectory, shardPointCount);
+  await preprocess(
+    resolve(inputPath),
+    outputDirectory,
+    shardPointCount,
+    coordinateReferenceSystem
+  );
 }
 
-async function preprocess(sourcePath, targetDirectory, pointsPerShard) {
+async function preprocess(sourcePath, targetDirectory, pointsPerShard, crs) {
   await mkdir(targetDirectory, {recursive: true});
   const temporaryDirectory = extname(sourcePath) === '.gz'
     ? await mkdtemp(join(tmpdir(), 'luma-spatial-atlas-'))
@@ -78,7 +84,7 @@ async function preprocess(sourcePath, targetDirectory, pointsPerShard) {
       source: DEFAULT_SOURCE_URL,
       sourceFile: basename(sourcePath),
       coordinateColumns: [xField.name, yField.name],
-      coordinateSpace: {kind: 'source-xy', crs: null},
+      coordinateSpace: {kind: 'source-xy', crs},
       format: 'float32x2-little-endian',
       pointCount: table.numRows,
       shardPointCount: pointsPerShard,
@@ -154,6 +160,15 @@ function parsePositiveInteger(value, name) {
   return parsed;
 }
 
+function parseCoordinateReferenceSystem(value) {
+  if (value === undefined) return null;
+  const normalized = value.trim();
+  if (normalized.length === 0) {
+    throw new Error('--crs must be a non-empty coordinate reference system identifier');
+  }
+  return normalized;
+}
+
 function parseArguments(values) {
   const parsed = {};
   for (let index = 0; index < values.length; index++) {
@@ -174,12 +189,13 @@ function parseArguments(values) {
 
 function printUsage() {
   process.stdout.write(`Usage:
-  yarn preprocess:taxi --input /path/to/168898952_points.arrow.gz [--output ./public/taxi-atlas] [--shard-points 1000000]
+  yarn preprocess:taxi --input /path/to/168898952_points.arrow.gz [--output ./public/taxi-atlas] [--shard-points 1000000] [--crs OGC:CRS84]
 
 The original 859 MB object does not expose browser CORS. Download it once, then run this command
 to emit streamable packed float32 shards and manifest.json. The conversion needs enough memory to
 open the decompressed Arrow IPC file; it never runs in the browser. Coordinates remain in the
-source X/Y space, and the manifest leaves the coordinate reference system unspecified.
+source X/Y space. The optional --crs value records an explicit coordinate reference system without
+transforming those values; omit it when the source coordinate system is unknown.
 
 Source:
   ${DEFAULT_SOURCE_URL}

--- a/examples/showcase/billion-point-spatial-atlas/taxi-resident-window.ts
+++ b/examples/showcase/billion-point-spatial-atlas/taxi-resident-window.ts
@@ -1,0 +1,161 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  TaxiPointSource,
+  TaxiPointSourceMetadata,
+  TaxiPointSourceTelemetry
+} from './taxi-source';
+
+/** Progress emitted after one source batch has been retained. */
+export type TaxiPointResidentWindowProgress = {
+  residentRowCount: number;
+  targetRowCount: number;
+  sourceRowCount: number;
+  rowGroupIndex: number;
+  telemetry: TaxiPointSourceTelemetry;
+};
+
+/** Options for one bounded, source-ordered resident window. */
+export type TaxiPointResidentWindowOptions = {
+  /** Maximum number of rows retained by the returned window. */
+  capacity: number;
+  signal?: AbortSignal;
+  onProgress?: (progress: TaxiPointResidentWindowProgress) => void;
+};
+
+/** Source-neutral rows retained for one GPU upload. */
+export type TaxiPointResidentWindow = {
+  /** Interleaved source X/Y values in original source order. */
+  positions: Float32Array;
+  /** Original source row for each retained resident row. */
+  sourceRowIndices: Float64Array;
+  rowCount: number;
+  sourceRowCount: number;
+  metadata: TaxiPointSourceMetadata;
+  telemetry: TaxiPointSourceTelemetry;
+};
+
+/**
+ * Streams the leading row groups needed to fill one capacity-bounded resident window.
+ *
+ * The returned arrays never exceed `capacity`. A source may still yield a final row group larger
+ * than the remaining capacity; that temporary decoded batch is released after its retained prefix
+ * is copied into the window.
+ */
+export async function loadTaxiPointResidentWindow(
+  source: TaxiPointSource,
+  options: TaxiPointResidentWindowOptions
+): Promise<TaxiPointResidentWindow> {
+  const {capacity, signal, onProgress} = options;
+  if (!Number.isSafeInteger(capacity) || capacity <= 0) {
+    throw new Error('Taxi resident window capacity must be a positive safe integer');
+  }
+  signal?.throwIfAborted();
+
+  const metadata = await source.getMetadata(signal);
+  const targetRowCount = Math.min(capacity, metadata.rowCount);
+  if (targetRowCount === 0) {
+    return {
+      positions: new Float32Array(0),
+      sourceRowIndices: new Float64Array(0),
+      rowCount: 0,
+      sourceRowCount: metadata.rowCount,
+      metadata,
+      telemetry: source.getTelemetry()
+    };
+  }
+
+  const selectedRowGroups: number[] = [];
+  const selectedRowGroupMetadata: TaxiPointSourceMetadata['rowGroups'][number][] = [];
+  let selectedRowCount = 0;
+  for (const rowGroup of metadata.rowGroups) {
+    if (selectedRowCount >= targetRowCount) break;
+    selectedRowGroups.push(rowGroup.index);
+    selectedRowGroupMetadata.push(rowGroup);
+    selectedRowCount += rowGroup.rowCount;
+  }
+
+  const positions = new Float32Array(targetRowCount * 2);
+  const sourceRowIndices = new Float64Array(targetRowCount);
+  let residentRowCount = 0;
+  let selectedRowGroupPosition = 0;
+  let expectedOriginalRowOffset = selectedRowGroupMetadata[0]?.originalRowOffset;
+  for await (const batch of source.read({
+    rowGroups: selectedRowGroups,
+    columns: metadata.coordinateColumns,
+    signal
+  })) {
+    signal?.throwIfAborted();
+    const selectedRowGroup = selectedRowGroupMetadata[selectedRowGroupPosition];
+    if (!selectedRowGroup) {
+      throw new Error(
+        `Taxi point source yielded unexpected row group ${batch.provenance.rowGroupIndex}`
+      );
+    }
+    if (batch.provenance.rowGroupIndex !== selectedRowGroup.index) {
+      throw new Error(
+        `Taxi point source yielded row group ${batch.provenance.rowGroupIndex}; expected ${selectedRowGroup.index}`
+      );
+    }
+    if (batch.provenance.originalRowOffset !== expectedOriginalRowOffset) {
+      throw new Error(
+        `Taxi point row group ${selectedRowGroup.index} starts batch at source row ${batch.provenance.originalRowOffset}; expected ${expectedOriginalRowOffset}`
+      );
+    }
+    if (!Number.isSafeInteger(batch.rowCount) || batch.rowCount <= 0) {
+      throw new Error(
+        `Taxi point batch ${selectedRowGroup.index} rowCount must be a positive safe integer`
+      );
+    }
+    const batchEndRow = batch.provenance.originalRowOffset + batch.rowCount;
+    const rowGroupEndRow = selectedRowGroup.originalRowOffset + selectedRowGroup.rowCount;
+    if (!Number.isSafeInteger(batchEndRow) || batchEndRow > rowGroupEndRow) {
+      throw new Error(`Taxi point batch ${selectedRowGroup.index} extends beyond its row group`);
+    }
+    if (batch.positions.length !== batch.rowCount * 2) {
+      throw new Error(
+        `Taxi point batch ${batch.provenance.rowGroupIndex} contains ${batch.positions.length} coordinate values for ${batch.rowCount} rows`
+      );
+    }
+    const retainedRowCount = Math.min(batch.rowCount, targetRowCount - residentRowCount);
+    positions.set(batch.positions.subarray(0, retainedRowCount * 2), residentRowCount * 2);
+    for (let localRowIndex = 0; localRowIndex < retainedRowCount; localRowIndex++) {
+      const sourceRowIndex = batch.provenance.originalRowOffset + localRowIndex;
+      if (!Number.isSafeInteger(sourceRowIndex) || sourceRowIndex < 0) {
+        throw new Error('Taxi point source row index must be a non-negative safe integer');
+      }
+      sourceRowIndices[residentRowCount + localRowIndex] = sourceRowIndex;
+    }
+    residentRowCount += retainedRowCount;
+    onProgress?.({
+      residentRowCount,
+      targetRowCount,
+      sourceRowCount: metadata.rowCount,
+      rowGroupIndex: batch.provenance.rowGroupIndex,
+      telemetry: source.getTelemetry()
+    });
+    if (residentRowCount === targetRowCount) break;
+    expectedOriginalRowOffset = batchEndRow;
+    if (batchEndRow === rowGroupEndRow) {
+      selectedRowGroupPosition++;
+      expectedOriginalRowOffset =
+        selectedRowGroupMetadata[selectedRowGroupPosition]?.originalRowOffset;
+    }
+  }
+
+  if (residentRowCount !== targetRowCount) {
+    throw new Error(
+      `Taxi point source yielded ${residentRowCount} resident rows; expected ${targetRowCount}`
+    );
+  }
+  return {
+    positions,
+    sourceRowIndices,
+    rowCount: residentRowCount,
+    sourceRowCount: metadata.rowCount,
+    metadata,
+    telemetry: source.getTelemetry()
+  };
+}

--- a/test/examples/billion-point-spatial-atlas-taxi-preprocess.node.spec.ts
+++ b/test/examples/billion-point-spatial-atlas-taxi-preprocess.node.spec.ts
@@ -28,7 +28,7 @@ test('taxi preprocessing preserves invalid rows, stored bounds, and little-endia
     });
     await writeFile(inputPath, arrow.tableToIPC(table, 'file'));
 
-    await runPreprocessor(inputPath, outputDirectory);
+    await runPreprocessor(inputPath, outputDirectory, ['--crs', 'OGC:CRS84']);
 
     const manifest: {
       version: number;
@@ -39,7 +39,7 @@ test('taxi preprocessing preserves invalid rows, stored bounds, and little-endia
     expect(manifest).toMatchObject({
       version: 2,
       coordinateColumns: ['x', 'y'],
-      coordinateSpace: {kind: 'source-xy', crs: null}
+      coordinateSpace: {kind: 'source-xy', crs: 'OGC:CRS84'}
     });
     expect(manifest.shards[0]?.bounds).toEqual([
       Math.fround(-0.1),
@@ -79,10 +79,12 @@ test('taxi preprocessing selects complete coordinate pairs without mixing aliase
 
     await runPreprocessor(inputPath, outputDirectory);
 
-    const manifest: {coordinateColumns: string[]} = JSON.parse(
-      await readFile(join(outputDirectory, 'manifest.json'), 'utf8')
-    );
+    const manifest: {
+      coordinateColumns: string[];
+      coordinateSpace: {kind: string; crs: string | null};
+    } = JSON.parse(await readFile(join(outputDirectory, 'manifest.json'), 'utf8'));
     expect(manifest.coordinateColumns).toEqual(['longitude', 'latitude']);
+    expect(manifest.coordinateSpace).toEqual({kind: 'source-xy', crs: null});
     const bytes = await readFile(join(outputDirectory, 'points-0000.f32'));
     const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     expect([dataView.getFloat32(0, true), dataView.getFloat32(4, true)]).toEqual([-73, 40]);
@@ -91,11 +93,24 @@ test('taxi preprocessing selects complete coordinate pairs without mixing aliase
   }
 });
 
-async function runPreprocessor(inputPath: string, outputDirectory: string): Promise<void> {
+async function runPreprocessor(
+  inputPath: string,
+  outputDirectory: string,
+  extraArguments: string[] = []
+): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     execFile(
       process.execPath,
-      [PREPROCESSOR_PATH, '--input', inputPath, '--output', outputDirectory, '--shard-points', '3'],
+      [
+        PREPROCESSOR_PATH,
+        '--input',
+        inputPath,
+        '--output',
+        outputDirectory,
+        '--shard-points',
+        '3',
+        ...extraArguments
+      ],
       error => (error ? reject(error) : resolve())
     );
   });

--- a/test/examples/billion-point-spatial-atlas-taxi-resident-window.node.spec.ts
+++ b/test/examples/billion-point-spatial-atlas-taxi-resident-window.node.spec.ts
@@ -1,0 +1,344 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {
+  assertLongitudeLatitudeTaxiMetadata,
+  getTaxiPoint,
+  makeLuSpatialTaxiData,
+  makeLuSpatialTaxiDataFromResidentWindow
+} from '../../examples/deck/luspatial-taxi/taxi-data';
+import {
+  loadTaxiPointResidentWindow,
+  type TaxiPointResidentWindow
+} from '../../examples/showcase/billion-point-spatial-atlas/taxi-resident-window';
+import type {
+  TaxiPointBatch,
+  TaxiPointSource,
+  TaxiPointSourceMetadata,
+  TaxiPointSourceReadOptions,
+  TaxiPointSourceTelemetry
+} from '../../examples/showcase/billion-point-spatial-atlas/taxi-source';
+
+describe('loadTaxiPointResidentWindow', () => {
+  test('retains a capacity-bounded prefix with original row provenance', async () => {
+    const metadata = makeMetadata();
+    const batches = new Map<number, TaxiPointBatch>([
+      [
+        0,
+        {
+          positions: new Float32Array([-73.99, 40.73, -73.98, 40.74]),
+          rowCount: 2,
+          provenance: {rowGroupIndex: 0, originalRowOffset: 0}
+        }
+      ],
+      [
+        1,
+        {
+          positions: new Float32Array([-73.97, 40.75, -73.96, 40.76, -73.95, 40.77]),
+          rowCount: 3,
+          provenance: {rowGroupIndex: 1, originalRowOffset: 2}
+        }
+      ]
+    ]);
+    const requestedRowGroups: number[][] = [];
+    const progressRowCounts: number[] = [];
+    const progressDecodedRowCounts: number[] = [];
+    const source = makeSource(metadata, batches, requestedRowGroups);
+
+    const residentWindow = await loadTaxiPointResidentWindow(source, {
+      capacity: 3,
+      onProgress: progress => {
+        progressRowCounts.push(progress.residentRowCount);
+        progressDecodedRowCounts.push(progress.telemetry.decodedRowCount);
+      }
+    });
+
+    expect(requestedRowGroups).toEqual([[0, 1]]);
+    expect(residentWindow.rowCount).toBe(3);
+    expect(residentWindow.sourceRowCount).toBe(5);
+    expect(Array.from(residentWindow.positions)).toEqual(
+      Array.from(new Float32Array([-73.99, 40.73, -73.98, 40.74, -73.97, 40.75]))
+    );
+    expect(Array.from(residentWindow.sourceRowIndices)).toEqual([0, 1, 2]);
+    expect(progressRowCounts).toEqual([2, 3]);
+    expect(progressDecodedRowCounts).toEqual([2, 5]);
+    expect(residentWindow.telemetry).toMatchObject({
+      decodedRowCount: 5,
+      downloadedByteCount: 40,
+      requestCount: 2
+    });
+  });
+
+  test('returns an empty window without reading row groups', async () => {
+    const metadata = makeMetadata({rowCount: 0, rowGroups: []});
+    const requestedRowGroups: number[][] = [];
+    const residentWindow = await loadTaxiPointResidentWindow(
+      makeSource(metadata, new Map(), requestedRowGroups),
+      {capacity: 10}
+    );
+
+    expect(residentWindow.rowCount).toBe(0);
+    expect(residentWindow.positions).toHaveLength(0);
+    expect(residentWindow.sourceRowIndices).toHaveLength(0);
+    expect(requestedRowGroups).toEqual([]);
+  });
+
+  test('rejects malformed, incomplete, and invalid-provenance batches', async () => {
+    const metadata = makeMetadata({
+      rowCount: 2,
+      rowGroups: [makeRowGroup(0, 2, 0)]
+    });
+    const malformedBatch: TaxiPointBatch = {
+      positions: new Float32Array([1, 2, 3]),
+      rowCount: 2,
+      provenance: {rowGroupIndex: 0, originalRowOffset: 0}
+    };
+    await expect(
+      loadTaxiPointResidentWindow(makeSource(metadata, new Map([[0, malformedBatch]])), {
+        capacity: 2
+      })
+    ).rejects.toThrow('contains 3 coordinate values for 2 rows');
+
+    const incompleteBatch: TaxiPointBatch = {
+      positions: new Float32Array([1, 2]),
+      rowCount: 1,
+      provenance: {rowGroupIndex: 0, originalRowOffset: 0}
+    };
+    await expect(
+      loadTaxiPointResidentWindow(makeSource(metadata, new Map([[0, incompleteBatch]])), {
+        capacity: 2
+      })
+    ).rejects.toThrow('yielded 1 resident rows; expected 2');
+
+    const invalidProvenanceBatch: TaxiPointBatch = {
+      positions: new Float32Array([1, 2, 3, 4]),
+      rowCount: 2,
+      provenance: {rowGroupIndex: 0, originalRowOffset: -1}
+    };
+    await expect(
+      loadTaxiPointResidentWindow(makeSource(metadata, new Map([[0, invalidProvenanceBatch]])), {
+        capacity: 2
+      })
+    ).rejects.toThrow('starts batch at source row -1; expected 0');
+  });
+
+  test('validates capacity and honors a pre-aborted signal before source access', async () => {
+    const metadata = makeMetadata();
+    const requestedRowGroups: number[][] = [];
+    const source = makeSource(metadata, new Map(), requestedRowGroups);
+    await expect(loadTaxiPointResidentWindow(source, {capacity: 0})).rejects.toThrow(
+      'capacity must be a positive safe integer'
+    );
+
+    const controller = new AbortController();
+    controller.abort(new Error('cancelled test source'));
+    await expect(
+      loadTaxiPointResidentWindow(source, {capacity: 1, signal: controller.signal})
+    ).rejects.toThrow('cancelled test source');
+    expect(requestedRowGroups).toEqual([]);
+  });
+
+  test('passes one cancellation signal through metadata and row-group reads', async () => {
+    const metadata = makeMetadata({rowCount: 1, rowGroups: [makeRowGroup(0, 1, 0)]});
+    const controller = new AbortController();
+    let metadataSignal: AbortSignal | undefined;
+    let readSignal: AbortSignal | undefined;
+    const source: TaxiPointSource = {
+      async getMetadata(signal): Promise<TaxiPointSourceMetadata> {
+        metadataSignal = signal;
+        return metadata;
+      },
+      async *read(options = {}): AsyncIterable<TaxiPointBatch> {
+        readSignal = options.signal;
+        yield {
+          positions: new Float32Array([-73.99, 40.73]),
+          rowCount: 1,
+          provenance: {rowGroupIndex: 0, originalRowOffset: 0}
+        };
+      },
+      getTelemetry: makeEmptyTelemetry,
+      close(): void {}
+    };
+
+    await loadTaxiPointResidentWindow(source, {capacity: 1, signal: controller.signal});
+
+    expect(metadataSignal).toBe(controller.signal);
+    expect(readSignal).toBe(controller.signal);
+  });
+});
+
+describe('luSpatial taxi resident-window adapter', () => {
+  test('accepts explicitly declared longitude/latitude data and preserves source rows', () => {
+    const residentWindow = makeResidentWindow({
+      positions: new Float32Array([-73.99, 40.73, Number.NaN, Number.NaN]),
+      sourceRowIndices: new Float64Array([18, 19]),
+      rowCount: 2,
+      sourceRowCount: 168_898_952
+    });
+
+    const taxiData = makeLuSpatialTaxiDataFromResidentWindow(residentWindow);
+
+    expect(taxiData).toMatchObject({
+      pointCount: 2,
+      corpusPointCount: 168_898_952,
+      sourceKind: 'packed',
+      sourceLabel: 'Packed row-group source'
+    });
+    expect(taxiData.longitudeLatitudes).toBe(residentWindow.positions);
+    expect(getTaxiPoint(taxiData, 0)).toEqual({
+      longitude: Math.fround(-73.99),
+      latitude: Math.fround(40.73),
+      sourceRowIndex: 18,
+      sourceKind: 'packed'
+    });
+    expect(getTaxiPoint(taxiData, 2)).toBeNull();
+  });
+
+  test('requires explicit supported CRS metadata before interpreting source XY as longitude/latitude', () => {
+    for (const crs of ['OGC:CRS84', 'crs84', 'WGS84', 'epsg:4326']) {
+      expect(() => assertLongitudeLatitudeTaxiMetadata(makeMetadata({crs}))).not.toThrow();
+    }
+    for (const crs of [null, 'EPSG:2263']) {
+      expect(() => assertLongitudeLatitudeTaxiMetadata(makeMetadata({crs}))).toThrow(
+        'must explicitly declare OGC:CRS84 or WGS84/EPSG:4326'
+      );
+    }
+  });
+
+  test('rejects impossible or entirely non-finite geographic windows', () => {
+    expect(() =>
+      makeLuSpatialTaxiDataFromResidentWindow(
+        makeResidentWindow({positions: new Float32Array([181, 40])})
+      )
+    ).toThrow('outside longitude/latitude bounds');
+    expect(() =>
+      makeLuSpatialTaxiDataFromResidentWindow(
+        makeResidentWindow({positions: new Float32Array([Number.NaN, Number.NaN])})
+      )
+    ).toThrow('does not contain a finite longitude/latitude row');
+  });
+
+  test('keeps the deterministic synthetic source as the default', () => {
+    const taxiData = makeLuSpatialTaxiData(2);
+    expect(taxiData).toMatchObject({
+      pointCount: 2,
+      corpusPointCount: 168_898_952,
+      sourceKind: 'synthetic',
+      sourceLabel: 'Synthetic public-sample expansion'
+    });
+    expect(taxiData.sourceRowIndices).toBeUndefined();
+    expect(getTaxiPoint(taxiData, 1)).toMatchObject({
+      sourceRowIndex: 1,
+      sourceKind: 'synthetic'
+    });
+  });
+});
+
+function makeSource(
+  metadata: TaxiPointSourceMetadata,
+  batches: ReadonlyMap<number, TaxiPointBatch>,
+  requestedRowGroups: number[][] = []
+): TaxiPointSource {
+  const telemetry: TaxiPointSourceTelemetry = {
+    downloadedByteCount: 0,
+    requestCount: 0,
+    networkTimeMilliseconds: 0,
+    decodeTimeMilliseconds: 0,
+    decodedRowCount: 0
+  };
+  return {
+    async getMetadata(): Promise<TaxiPointSourceMetadata> {
+      return metadata;
+    },
+    async *read(options: TaxiPointSourceReadOptions = {}): AsyncIterable<TaxiPointBatch> {
+      const rowGroups = [
+        ...(options.rowGroups ?? metadata.rowGroups.map(rowGroup => rowGroup.index))
+      ];
+      requestedRowGroups.push(rowGroups);
+      for (const rowGroupIndex of rowGroups) {
+        options.signal?.throwIfAborted();
+        const batch = batches.get(rowGroupIndex);
+        if (!batch) continue;
+        telemetry.requestCount++;
+        telemetry.downloadedByteCount += batch.positions.byteLength;
+        telemetry.decodedRowCount += batch.rowCount;
+        yield batch;
+      }
+    },
+    getTelemetry(): TaxiPointSourceTelemetry {
+      return {...telemetry};
+    },
+    close(): void {}
+  };
+}
+
+function makeEmptyTelemetry(): TaxiPointSourceTelemetry {
+  return {
+    downloadedByteCount: 0,
+    requestCount: 0,
+    networkTimeMilliseconds: 0,
+    decodeTimeMilliseconds: 0,
+    decodedRowCount: 0
+  };
+}
+
+function makeMetadata(
+  overrides: {
+    rowCount?: number;
+    rowGroups?: TaxiPointSourceMetadata['rowGroups'];
+    crs?: string | null;
+  } = {}
+): TaxiPointSourceMetadata {
+  const rowGroups = overrides.rowGroups ?? [makeRowGroup(0, 2, 0), makeRowGroup(1, 3, 2)];
+  return {
+    manifestVersion: 2,
+    rowCount: overrides.rowCount ?? 5,
+    rowGroups,
+    coordinateColumns: ['longitude', 'latitude'],
+    coordinateSpace: {
+      kind: 'source-xy',
+      crs: overrides.crs === undefined ? 'OGC:CRS84' : overrides.crs
+    },
+    bounds: [-74, 40.7, -73.9, 40.8],
+    source: 'https://example.test/taxi.arrow',
+    objectVersion: {etag: '"fixture"'}
+  };
+}
+
+function makeRowGroup(
+  index: number,
+  rowCount: number,
+  originalRowOffset: number
+): TaxiPointSourceMetadata['rowGroups'][number] {
+  return {
+    index,
+    rowCount,
+    originalRowOffset,
+    byteLength: rowCount * 2 * Float32Array.BYTES_PER_ELEMENT,
+    url: `https://example.test/points-${index}.f32`,
+    bounds: [-74, 40.7, -73.9, 40.8]
+  };
+}
+
+function makeResidentWindow(
+  overrides: Partial<TaxiPointResidentWindow> = {}
+): TaxiPointResidentWindow {
+  const positions = overrides.positions ?? new Float32Array([-73.99, 40.73]);
+  const rowCount = overrides.rowCount ?? positions.length / 2;
+  return {
+    positions,
+    sourceRowIndices: overrides.sourceRowIndices ?? new Float64Array(rowCount),
+    rowCount,
+    sourceRowCount: overrides.sourceRowCount ?? rowCount,
+    metadata: overrides.metadata ?? makeMetadata({rowCount}),
+    telemetry: overrides.telemetry ?? {
+      downloadedByteCount: positions.byteLength,
+      requestCount: 1,
+      networkTimeMilliseconds: 0,
+      decodeTimeMilliseconds: 0,
+      decodedRowCount: rowCount
+    }
+  };
+}

--- a/test/examples/gpgpu-responsive-data.node.spec.ts
+++ b/test/examples/gpgpu-responsive-data.node.spec.ts
@@ -112,7 +112,7 @@ describe('responsive GPU data examples', () => {
     expect(effectSource).toMatch(/from ['"]@luma\.gl\/experimental\/luproj['"]/);
     expect(effectSource).toMatch(/new GPUProjection\s*\(/);
     expect(effectSource).toMatch(/compileProjectionPlan\s*\(/);
-    expect(effectSource).toMatch(/this\.projection\?\.destroy\(\)/);
+    expect(effectSource).toMatch(/this\.ownResource\(\s*new GPUProjection\s*\(/);
     expect(effectSource).toMatch(/if\s*\(!viewportBoundsChanged && !this\.queryInputsChanged\)/);
     expect(appSource).toMatch(/makeLuSpatialTaxiDataAsync\s*\(/);
     expect(appSource).toMatch(/generationController\.abort\(\)/);
@@ -133,7 +133,7 @@ describe('responsive GPU data examples', () => {
     expect(zoneChangeSource?.[1]).toContain('latestSelectionCenter = zone.center;');
     expect(clickSource?.[1]).toContain('latestSelectionCenter = center;');
     expect(appSource).toContain(
-      'queryEffect.setSelection(latestSelectionCenter, queryRadiusKilometres);'
+      'nextQueryEffect.setSelection(latestSelectionCenter, queryRadiusKilometres);'
     );
   });
 

--- a/test/examples/luspatial-taxi-runtime.node.spec.ts
+++ b/test/examples/luspatial-taxi-runtime.node.spec.ts
@@ -1,0 +1,77 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Buffer, Device} from '@luma.gl/core';
+import type {LayerContext} from '@deck.gl/core';
+import type {DrawCommandBuffer} from '@luma.gl/experimental';
+import {describe, expect, test} from 'vitest';
+import {LuSpatialPointLayer} from '../../examples/deck/luspatial-taxi/luspatial-point-layer';
+import {LuSpatialTaxiQueryEffect} from '../../examples/deck/luspatial-taxi/luspatial-query-effect';
+import type {LuSpatialTaxiData} from '../../examples/deck/luspatial-taxi/taxi-data';
+
+describe('luSpatial taxi runtime resource safety', () => {
+  test('releases every completed effect allocation after a mid-construction failure', () => {
+    const destroyedResourceIds: string[] = [];
+    let bufferCreateCount = 0;
+    const device = {
+      type: 'webgpu',
+      createBuffer: ({id}: {id?: string}) => {
+        bufferCreateCount++;
+        if (bufferCreateCount === 3) throw new Error('injected buffer allocation failure');
+        const resourceId = id ?? `buffer-${bufferCreateCount}`;
+        return {
+          destroy: () => destroyedResourceIds.push(resourceId)
+        };
+      }
+    } as unknown as Device;
+    const taxiData: LuSpatialTaxiData = {
+      pointCount: 1,
+      corpusPointCount: 1,
+      longitudeLatitudes: new Float32Array([-73.99, 40.73]),
+      sourceBounds: [-74, 40.72, -73.94, 40.78],
+      projectedBounds: [-1, -1, 1, 1],
+      sourceKind: 'synthetic',
+      sourceLabel: 'test fixture'
+    };
+
+    expect(() => new LuSpatialTaxiQueryEffect(device, taxiData)).toThrow(
+      'injected buffer allocation failure'
+    );
+    expect(destroyedResourceIds).toEqual([
+      'luspatial-taxi-projected-positions',
+      'luspatial-taxi-longitude-latitudes'
+    ]);
+  });
+
+  test('releases layer resources and withholds readiness after model initialization fails', () => {
+    let styleBufferDestroyCount = 0;
+    let readinessCount = 0;
+    const device = {
+      type: 'webgpu',
+      createBuffer: () => ({
+        destroy: () => styleBufferDestroyCount++
+      })
+    } as unknown as Device;
+    const layer = new LuSpatialPointLayer({
+      id: 'injected-layer-failure',
+      data: [],
+      longitudeLatitudes: {} as Buffer,
+      visibleIds: {} as Buffer,
+      drawCommands: {} as DrawCommandBuffer,
+      commandIndex: 0,
+      color: [255, 255, 255, 255],
+      radiusPixels: 1,
+      onResourcesReady: () => readinessCount++,
+      onBeforeModelInitialization: () => {
+        throw new Error('injected model initialization failure');
+      }
+    });
+
+    expect(() => layer.initializeState({device} as LayerContext)).toThrow(
+      'injected model initialization failure'
+    );
+    expect(styleBufferDestroyCount).toBe(1);
+    expect(readinessCount).toBe(0);
+  });
+});

--- a/website/content/examples/deck/luspatial-taxi.mdx
+++ b/website/content/examples/deck/luspatial-taxi.mdx
@@ -26,7 +26,21 @@ path. Click the map to move the radius query, choose a taxi-zone preset to recen
 point to inspect its source row and coordinates.
 
 The one-million-point browser fixture is a deterministic expansion of the same public sample used
-by the Billion-Point Spatial Atlas. The corpus counter preserves the 168,898,952-row target while
-the resident counter states what is actually allocated on the current GPU. Open the command-graph
-inspector in the control card to compare projection/index construction with the per-frame viewport
-and radius queries.
+by the Billion-Point Spatial Atlas. It remains the default and does not issue taxi-data network
+requests. The corpus counter preserves the 168,898,952-row target while the resident counter states
+what is actually allocated on the current GPU. Open the command-graph inspector in the control card
+to compare projection/index construction with the per-frame viewport and radius queries.
+
+An opt-in packed source can be supplied with the `taxi-manifest` query parameter:
+
+```text
+?taxi-manifest=https://data.example/taxi/manifest.json
+```
+
+The app streams only the leading row groups needed for its capacity-bounded resident window, which
+defaults to one million rows. The manifest must explicitly declare `OGC:CRS84`, `CRS84`, `WGS84`,
+or browser-style `EPSG:4326` coordinates with X as longitude and Y as latitude. It rejects unknown
+and projected coordinate systems instead of placing them incorrectly on the basemap. Loading and
+GPU activation are atomic: a request, decode, CRS, or allocation failure leaves the deterministic
+fixture active and reports the failure in the source status. Cross-origin manifests and shards must
+permit browser CORS requests.

--- a/website/content/examples/showcase/billion-point-spatial-atlas.mdx
+++ b/website/content/examples/showcase/billion-point-spatial-atlas.mdx
@@ -47,6 +47,12 @@ cd examples/showcase/billion-point-spatial-atlas
 yarn preprocess:taxi --input ./168898952_points.arrow.gz --output ./public/taxi-atlas
 ```
 
+The preprocessor preserves source X/Y values; it does not transform coordinate systems. When a
+different input is already known to contain longitude/latitude in X/Y order, `--crs OGC:CRS84`
+records that fact in the manifest. Do not apply that flag to projected or unknown coordinates. The
+deck.gl luSpatial example only activates manifests that explicitly pass this geographic CRS gate;
+otherwise it keeps its deterministic browser fixture active.
+
 **NYC LiDAR** reads and retains nearby pages of the public USGS New York City EPT hierarchy. It
 selects LAZ nodes around the current query, renders each decoded tile progressively, and keeps the
 result in a point-capacity-bounded GPU LRU cache. Moving the query triggers periodic spatial


### PR DESCRIPTION
## Goals

- Connect the deck.gl luSpatial taxi example to the versioned packed point-source contract from #2905.
- Keep the deterministic synthetic fixture as the zero-network website default.
- Make resident-data replacement failure-safe so a source or GPU allocation failure never blanks the working visualization.

This is stacked on #2905; the reviewable diff is the single runtime commit above `codex/taxi-point-source`.

## Changes

- Adds a capacity-bounded resident-window loader with cancellation, row provenance, progress, and source telemetry.
- Accepts an injected `TaxiPointSource` or opt-in `?taxi-manifest=` URL; no source is fetched by default.
- Requires explicit CRS84/WGS84 metadata before interpreting packed XY values as longitude/latitude.
- Stages replacement effects and layers alongside the live revision, reveals them only after both layer models initialize, and rolls back without disturbing the prior dataset on failure.
- Makes effect and layer construction exception-safe and retires superseded GPU resources after the old layers leave the deck.
- Preserves original source-row IDs in picking tooltips and exposes source/download state in the compact controls.
- Documents the packed-source opt-in, CORS requirements, CRS limitation, and preprocessor annotation flag.

## Verification

- `nvm use`: Node 22.22.1 selected.
- `yarn install`: not rerun after the final rebase; the existing immutable workspace install was used and this change has no dependency or lockfile edits.
- `yarn lint fix`: passed after the final rebase.
- `yarn build`: passed after the final rebase.
- Focused source/resident-window/lifecycle tests: 21/21 passed after the final rebase.
- `yarn examples:typecheck`: passed after the final build.
- `yarn test`: node suite passed (444 passed, 2 skipped). The local headless run completed 1,499 tests with 25 skipped and three transient dynamic-import failures; all three affected specs passed on immediate focused retry (21/21). Clean CI is the remaining full-browser gate.
- `yarn website:build`: passed.
- `(cd website && yarn build)`: passed after the final rebase.

## Risks and follow-ups

- The original Paul Taylor corpus does not declare its XY CRS, so this path deliberately rejects it until preprocessing can supply an authoritative geographic CRS or transformation.
- V1 retains the leading row groups up to the configured capacity rather than implementing a moving geographic window.
- Atomic replacement briefly keeps both old and new GPU revisions resident; adapter limits cap the selectable tier.
