### PR TITLE
fix(ci): preserve duplicate LCOV function counters

### DIFF
--- a/test/devtools/merge-lcov.node.spec.ts
+++ b/test/devtools/merge-lcov.node.spec.ts
@@ -23,6 +23,47 @@ describe('mergeLcovReports', () => {
     expect(merged).toContain('BRF:2\nBRH:2');
   });
 
+  test('preserves same-named function counters by definition', () => {
+    const first = makeDuplicateFunctionReport([1, 0]);
+    const second = makeDuplicateFunctionReport([2, 3]);
+    const merged = mergeLcovReports([first, second]);
+
+    expect(merged).toContain('FNF:2\nFNH:2');
+    expect(merged.match(/^FNDA:3,project$/gm)).toHaveLength(2);
+  });
+
+  test('preserves exact duplicate function definitions by occurrence', () => {
+    const first = makeExactDuplicateFunctionReport([1, 0]);
+    const second = makeExactDuplicateFunctionReport([2, 3]);
+    const merged = mergeLcovReports([first, second]);
+
+    expect(merged.match(/^FN:10,project$/gm)).toHaveLength(2);
+    expect(merged).toContain('FNF:2\nFNH:2');
+    expect(merged.match(/^FNDA:3,project$/gm)).toHaveLength(2);
+  });
+
+  test('keeps duplicate function occurrence order stable through staged merges', () => {
+    const functionHits = Array.from({length: 12}, (_, occurrence) => occurrence + 1);
+    const report = makeExactDuplicateFunctionReport(functionHits);
+    const stagedMerge = mergeLcovReports([mergeLcovReports([report]), report]);
+
+    expect(stagedMerge.match(/^FNDA:\d+,project$/gm)).toEqual(
+      functionHits.map(hits => `FNDA:${hits * 2},project`)
+    );
+  });
+
+  test('preserves same-named function counters across executed schemas', () => {
+    const first = makeSingleFunctionReport({startLine: 10, hits: 1});
+    const second = makeSingleFunctionReport({startLine: 30, hits: 2});
+    const merged = mergeLcovReports([first, second]);
+
+    expect(merged).toContain('FN:10,project');
+    expect(merged).toContain('FN:30,project');
+    expect(merged).toContain('FNF:2\nFNH:2');
+    expect(merged.match(/^FNDA:[12],project$/gm)).toHaveLength(2);
+    expect(merged).not.toContain('FNDA:3,project');
+  });
+
   test('drops an incompatible zero-hit schema once another shard executes the source', () => {
     const executed = makeReport({lineHits: [2, 0], branchHits: [2, 0], functionHits: 1});
     const zeroHitRawTypeScriptSchema = `TN:
@@ -166,6 +207,59 @@ BRDA:10,0,0,${branchHits[0]}
 BRDA:10,0,1,${branchHits[1]}
 BRF:2
 BRH:${branchHits.filter(hits => hits > 0).length}
+end_of_record
+`;
+}
+
+function makeDuplicateFunctionReport(functionHits: [number, number]): string {
+  return `TN:
+SF:src/project.ts
+FN:10,project
+FN:20,project
+FNF:2
+FNH:${functionHits.filter(hits => hits > 0).length}
+FNDA:${functionHits[0]},project
+FNDA:${functionHits[1]},project
+DA:10,${functionHits[0]}
+DA:20,${functionHits[1]}
+LF:2
+LH:${functionHits.filter(hits => hits > 0).length}
+BRF:0
+BRH:0
+end_of_record
+`;
+}
+
+function makeExactDuplicateFunctionReport(functionHits: number[]): string {
+  const functionDefinitions = functionHits.map(() => 'FN:10,project').join('\n');
+  const functionCounters = functionHits.map(hits => `FNDA:${hits},project`).join('\n');
+  return `TN:
+SF:src/project.ts
+${functionDefinitions}
+FNF:${functionHits.length}
+FNH:${functionHits.filter(hits => hits > 0).length}
+${functionCounters}
+DA:10,1
+LF:1
+LH:1
+BRF:0
+BRH:0
+end_of_record
+`;
+}
+
+function makeSingleFunctionReport(options: {startLine: number; hits: number}): string {
+  return `TN:
+SF:src/project.ts
+FN:${options.startLine},project
+FNF:1
+FNH:1
+FNDA:${options.hits},project
+DA:${options.startLine},${options.hits}
+LF:1
+LH:1
+BRF:0
+BRH:0
 end_of_record
 `;
 }

--- a/test/utils/merge-lcov.mjs
+++ b/test/utils/merge-lcov.mjs
@@ -70,6 +70,8 @@ function parseLcovRecord(lines) {
     additionalLines: new Set(),
     hasHits: false
   };
+  const functionDefinitionOccurrenceByKey = new Map();
+  const functionHitOccurrences = [];
 
   for (const line of lines) {
     if (!line || line.startsWith('TN:') || /^(FNF|FNH|LF|LH|BRF|BRH):/.test(line)) {
@@ -81,13 +83,19 @@ function parseLcovRecord(lines) {
     }
     if (line.startsWith('FN:')) {
       const definition = parseFunctionDefinition(line.slice(3));
+      const baseKey = definition.key;
+      const occurrence = functionDefinitionOccurrenceByKey.get(baseKey) || 0;
+      functionDefinitionOccurrenceByKey.set(baseKey, occurrence + 1);
+      definition.baseKey = baseKey;
+      definition.occurrence = occurrence;
+      definition.key = `${baseKey}#${occurrence}`;
       record.functionDefinitions.set(definition.key, definition);
       continue;
     }
     if (line.startsWith('FNDA:')) {
-      const {name, hits} = parseFunctionHits(line.slice(5));
-      record.functionHits.set(name, (record.functionHits.get(name) || 0) + hits);
-      record.hasHits ||= hits > 0;
+      const functionHits = parseFunctionHits(line.slice(5));
+      functionHitOccurrences.push(functionHits);
+      record.hasHits ||= functionHits.hits > 0;
       continue;
     }
     if (line.startsWith('DA:')) {
@@ -108,10 +116,40 @@ function parseLcovRecord(lines) {
   if (!record.sourceFile) {
     throw new Error('LCOV record is missing its SF source-file field');
   }
+  record.functionHits = matchFunctionHitsToDefinitions(
+    record.functionDefinitions,
+    functionHitOccurrences
+  );
   record.schema = getCoverageSchema(record);
   record.siteCount =
     record.functionDefinitions.size + record.lineHits.size + record.branchHits.size;
   return record;
+}
+
+function matchFunctionHitsToDefinitions(functionDefinitions, functionHitOccurrences) {
+  const definitionsByName = new Map();
+  for (const definition of functionDefinitions.values()) {
+    const matchingDefinitions = definitionsByName.get(definition.name) || [];
+    matchingDefinitions.push(definition);
+    definitionsByName.set(definition.name, matchingDefinitions);
+  }
+
+  const occurrenceByName = new Map();
+  const functionHitsByDefinition = new Map();
+  for (const functionHits of functionHitOccurrences) {
+    const occurrence = occurrenceByName.get(functionHits.name) || 0;
+    occurrenceByName.set(functionHits.name, occurrence + 1);
+    const definition = definitionsByName.get(functionHits.name)?.[occurrence];
+    const key = definition?.key || `unmatched:${occurrence},${functionHits.name}`;
+    functionHitsByDefinition.set(key, {
+      key,
+      name: functionHits.name,
+      hits: functionHits.hits,
+      occurrence,
+      definition
+    });
+  }
+  return functionHitsByDefinition;
 }
 
 function parseFunctionDefinition(value) {
@@ -239,8 +277,12 @@ function mergeLcovRecords(sourceFile, records) {
     for (const [key, definition] of record.functionDefinitions) {
       mergedRecord.functionDefinitions.set(key, definition);
     }
-    for (const [name, hits] of record.functionHits) {
-      mergedRecord.functionHits.set(name, (mergedRecord.functionHits.get(name) || 0) + hits);
+    for (const [key, functionHits] of record.functionHits) {
+      const previous = mergedRecord.functionHits.get(key);
+      mergedRecord.functionHits.set(key, {
+        ...functionHits,
+        hits: (previous?.hits || 0) + functionHits.hits
+      });
     }
     for (const lineCoverage of record.lineHits.values()) {
       mergeLineCoverage(mergedRecord.lineHits, lineCoverage);
@@ -280,7 +322,7 @@ function mergeBranchCoverage(branchHits, branchCoverage) {
 function formatLcovRecord(record) {
   const lines = ['TN:', `SF:${record.sourceFile}`];
   const functionDefinitions = [...record.functionDefinitions.values()].sort(
-    (first, second) => first.startLine - second.startLine || first.name.localeCompare(second.name)
+    compareFunctionDefinitions
   );
   for (const definition of functionDefinitions) {
     const location =
@@ -290,13 +332,12 @@ function formatLcovRecord(record) {
     lines.push(`FN:${location},${definition.name}`);
   }
   lines.push(`FNF:${functionDefinitions.length}`);
+  const functionHits = [...record.functionHits.values()].sort(compareFunctionHits);
   lines.push(
-    `FNH:${[...record.functionHits.values()].filter(functionHits => functionHits > 0).length}`
+    `FNH:${functionHits.filter(functionCoverage => functionCoverage.hits > 0).length}`
   );
-  for (const [name, hits] of [...record.functionHits].sort(([first], [second]) =>
-    first.localeCompare(second)
-  )) {
-    lines.push(`FNDA:${hits},${name}`);
+  for (const functionCoverage of functionHits) {
+    lines.push(`FNDA:${functionCoverage.hits},${functionCoverage.name}`);
   }
 
   const lineCoverage = [...record.lineHits.values()].sort(
@@ -325,6 +366,29 @@ function formatLcovRecord(record) {
   lines.push(...[...record.additionalLines].sort());
   lines.push('end_of_record');
   return lines.join('\n');
+}
+
+function compareFunctionHits(first, second) {
+  if (first.definition && second.definition) {
+    return compareFunctionDefinitions(first.definition, second.definition);
+  }
+  if (first.definition) {
+    return -1;
+  }
+  if (second.definition) {
+    return 1;
+  }
+  return first.name.localeCompare(second.name) || first.occurrence - second.occurrence;
+}
+
+function compareFunctionDefinitions(first, second) {
+  return (
+    first.startLine - second.startLine ||
+    (first.endLine || first.startLine) - (second.endLine || second.startLine) ||
+    first.name.localeCompare(second.name) ||
+    first.baseKey.localeCompare(second.baseKey) ||
+    first.occurrence - second.occurrence
+  );
 }
 
 function compareLcovIdentifier(first, second) {


### PR DESCRIPTION
## Goals

- Address the post-merge P2 review on [#2909](https://github.com/visgl/luma.gl/pull/2909) that found same-named LCOV functions were collapsed into one `FNDA` counter.
- Keep merged function totals and hit counts accurate when definitions share a name, move between executed schemas, or have identical source locations.

## Changes

- Give each `FN` definition a location-and-occurrence identity instead of keying function coverage only by name.
- Pair repeated `FNDA` counters with repeated same-named definitions in encounter order, matching established LCOV parser behavior.
- Merge and format counters by definition identity, with stable numeric ordering for exact duplicates.
- Add regression coverage for different-location duplicates, exact duplicate definitions, incompatible executed schemas, and a 12-occurrence staged merge.

## Verification

- `nvm use` — passed (Node 22.22.1).
- `yarn install --immutable` — passed with the repository's existing peer-dependency warnings.
- `yarn lint fix` — passed.
- `yarn test-node test/devtools/merge-lcov.node.spec.ts` — 11 tests passed.
- Commit hook node suite — 457 tests passed, 2 skipped.
- `yarn build` — passed.
- `yarn test` — not run separately; its node portion passed above and the draft PR CI will run the headless/browser coverage jobs.
- `yarn website:build` and `(cd website && yarn build)` — not run; this changes CI-only LCOV tooling and node tests, with no website code.

## Risks

- LCOV omits source locations from `FNDA` rows, so duplicate names must be associated by occurrence order. This follows the ordering used by `lcov-parse` and is covered by round-trip/staged-merge tests.
- No shipped package runtime or website behavior changes.