### PR TITLE
test(experimental): harden geospatial conformance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,6 +258,9 @@ jobs:
         run: |
           yarn build
 
+      - name: Verify experimental geospatial package imports
+        run: yarn test-geospatial-package
+
       - name: Run lint
         run: |
           yarn lint

--- a/modules/experimental/test/geospatial/geospatial-projection-distance.spec.ts
+++ b/modules/experimental/test/geospatial/geospatial-projection-distance.spec.ts
@@ -318,15 +318,10 @@ test('GPUHaversineDistance preserves raw binary64 coordinate deltas', async tape
   tapeTest.end();
 });
 
-test('point and point-to-segment distances match f32 and raw binary64 CPU oracles', async tapeTest => {
+test('point and point-to-segment f32 distances match CPU oracles', async tapeTest => {
   const device = await getWebGPUTestDevice();
   if (!device) {
     tapeTest.comment('WebGPU is not available');
-    tapeTest.end();
-    return;
-  }
-  if (isSoftwareBackedDevice(device)) {
-    tapeTest.comment('Skipping slow integer fp64 planar distance shaders on software WebGPU');
     tapeTest.end();
     return;
   }
@@ -335,32 +330,16 @@ test('point and point-to-segment distances match f32 and raw binary64 CPU oracle
   const floatOtherPoints = Float32Array.from([0, 0, 1, 2, 0, 0]);
   const floatStarts = Float32Array.from([0, 0, 0, 0, 0, 0]);
   const floatEnds = Float32Array.from([0, 2, 2, 0, 2, 0]);
-  const origin: Point = [20_000_000, 30_000_000];
-  const rawPoints: Point[] = [
-    [origin[0] + 0.5, origin[1] + 2 ** -20],
-    [origin[0] + 1.25, origin[1] + 0.5],
-    [origin[0] + 2 ** -22, origin[1] + 2 ** -20]
-  ];
-  const rawOtherPoints: Point[] = [origin, origin, origin];
-  const rawStarts: Point[] = [origin, origin, origin];
-  const rawEnds: Point[] = [[origin[0] + 1, origin[1]], [origin[0] + 1, origin[1]], origin];
   const inputBuffers = [
     createBuffer(device, floatPoints, Buffer.STORAGE),
     createBuffer(device, floatOtherPoints, Buffer.STORAGE),
     createBuffer(device, floatStarts, Buffer.STORAGE),
-    createBuffer(device, floatEnds, Buffer.STORAGE),
-    createBuffer(device, encodeFloat64Points(rawPoints), Buffer.STORAGE),
-    createBuffer(device, encodeFloat64Points(rawOtherPoints), Buffer.STORAGE),
-    createBuffer(device, encodeFloat64Points(rawStarts), Buffer.STORAGE),
-    createBuffer(device, encodeFloat64Points(rawEnds), Buffer.STORAGE)
+    createBuffer(device, floatEnds, Buffer.STORAGE)
   ];
   const floatPointOutputBuffer = createOutputBuffer(device, 12);
   const floatSegmentOutputBuffer = createOutputBuffer(device, 12);
-  const rawPointOutputBuffer = createOutputBuffer(device, rawPoints.length * 8);
-  const rawSegmentOutputBuffer = createOutputBuffer(device, rawPoints.length * 8);
-  const graph = new GPUCommandGraph(device, {id: 'point-distance-oracle-test'});
+  const graph = new GPUCommandGraph(device, {id: 'f32-point-distance-oracle-test'});
   const floatPointView = importView(graph, 'float-points', inputBuffers[0], 'float32x2', 3);
-  const rawPointView = importView(graph, 'raw-points', inputBuffers[4], 'uint32x4', 3);
 
   new GPUPairwisePointDistance({
     id: 'f32-point-distance',
@@ -375,22 +354,9 @@ test('point and point-to-segment distances match f32 and raw binary64 CPU oracle
     segmentEnds: importView(graph, 'float-ends', inputBuffers[3], 'float32x2', 3),
     output: importView(graph, 'float-segment-output', floatSegmentOutputBuffer, 'float32', 3)
   }).addToGraph(graph);
-  new GPUPairwisePointDistance({
-    id: 'raw-point-distance',
-    left: rawPointView,
-    right: importView(graph, 'raw-other', inputBuffers[5], 'uint32x4', 3),
-    output: importView(graph, 'raw-point-output', rawPointOutputBuffer, 'float32x2', 3)
-  }).addToGraph(graph);
-  new GPUPairwisePointSegmentDistance({
-    id: 'raw-segment-distance',
-    points: rawPointView,
-    segmentStarts: importView(graph, 'raw-starts', inputBuffers[6], 'uint32x4', 3),
-    segmentEnds: importView(graph, 'raw-ends', inputBuffers[7], 'uint32x4', 3),
-    output: importView(graph, 'raw-segment-output', rawSegmentOutputBuffer, 'float32x2', 3)
-  }).addToGraph(graph);
 
   const compiled = graph.compile();
-  const commandEncoder = device.createCommandEncoder({id: 'point-distance-oracle-encoding'});
+  const commandEncoder = device.createCommandEncoder({id: 'f32-point-distance-oracle-encoding'});
   compiled.encode(commandEncoder, {parameters: undefined});
   device.submit(commandEncoder.finish());
 
@@ -414,6 +380,65 @@ test('point and point-to-segment distances match f32 and raw binary64 CPU oracle
     !Number.isFinite(floatSegmentDistances[2]),
     'non-finite point-to-segment distance stays non-finite'
   );
+
+  compiled.destroy();
+  for (const buffer of [...inputBuffers, floatPointOutputBuffer, floatSegmentOutputBuffer]) {
+    buffer.destroy();
+  }
+  tapeTest.end();
+});
+
+test('point and point-to-segment raw binary64 distances match CPU oracles', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+  if (isSoftwareBackedDevice(device)) {
+    tapeTest.comment('Skipping slow integer fp64 planar distance shaders on software WebGPU');
+    tapeTest.end();
+    return;
+  }
+
+  const origin: Point = [20_000_000, 30_000_000];
+  const rawPoints: Point[] = [
+    [origin[0] + 0.5, origin[1] + 2 ** -20],
+    [origin[0] + 1.25, origin[1] + 0.5],
+    [origin[0] + 2 ** -22, origin[1] + 2 ** -20]
+  ];
+  const rawOtherPoints: Point[] = [origin, origin, origin];
+  const rawStarts: Point[] = [origin, origin, origin];
+  const rawEnds: Point[] = [[origin[0] + 1, origin[1]], [origin[0] + 1, origin[1]], origin];
+  const inputBuffers = [
+    createBuffer(device, encodeFloat64Points(rawPoints), Buffer.STORAGE),
+    createBuffer(device, encodeFloat64Points(rawOtherPoints), Buffer.STORAGE),
+    createBuffer(device, encodeFloat64Points(rawStarts), Buffer.STORAGE),
+    createBuffer(device, encodeFloat64Points(rawEnds), Buffer.STORAGE)
+  ];
+  const rawPointOutputBuffer = createOutputBuffer(device, rawPoints.length * 8);
+  const rawSegmentOutputBuffer = createOutputBuffer(device, rawPoints.length * 8);
+  const graph = new GPUCommandGraph(device, {id: 'raw-point-distance-oracle-test'});
+  const rawPointView = importView(graph, 'raw-points', inputBuffers[0], 'uint32x4', 3);
+
+  new GPUPairwisePointDistance({
+    id: 'raw-point-distance',
+    left: rawPointView,
+    right: importView(graph, 'raw-other', inputBuffers[1], 'uint32x4', 3),
+    output: importView(graph, 'raw-point-output', rawPointOutputBuffer, 'float32x2', 3)
+  }).addToGraph(graph);
+  new GPUPairwisePointSegmentDistance({
+    id: 'raw-segment-distance',
+    points: rawPointView,
+    segmentStarts: importView(graph, 'raw-starts', inputBuffers[2], 'uint32x4', 3),
+    segmentEnds: importView(graph, 'raw-ends', inputBuffers[3], 'uint32x4', 3),
+    output: importView(graph, 'raw-segment-output', rawSegmentOutputBuffer, 'float32x2', 3)
+  }).addToGraph(graph);
+
+  const compiled = graph.compile();
+  const commandEncoder = device.createCommandEncoder({id: 'raw-point-distance-oracle-encoding'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
 
   const rawPointDistances = await readFloat32(rawPointOutputBuffer, rawPoints.length * 2);
   const rawSegmentDistances = await readFloat32(rawSegmentOutputBuffer, rawPoints.length * 2);
@@ -442,13 +467,7 @@ test('point and point-to-segment distances match f32 and raw binary64 CPU oracle
   tapeTest.notEqual(rawSegmentDistances[3], 0, 'precise segment output retains a low limb');
 
   compiled.destroy();
-  for (const buffer of [
-    ...inputBuffers,
-    floatPointOutputBuffer,
-    floatSegmentOutputBuffer,
-    rawPointOutputBuffer,
-    rawSegmentOutputBuffer
-  ]) {
+  for (const buffer of [...inputBuffers, rawPointOutputBuffer, rawSegmentOutputBuffer]) {
     buffer.destroy();
   }
   tapeTest.end();
@@ -734,7 +753,52 @@ test('fixed kernels preserve vector chunks, empty chunks, and non-finite rows', 
   tapeTest.end();
 });
 
-test('point distance honors naturally aligned input and output offsets', async tapeTest => {
+test('f32 point distance honors naturally aligned input and output offsets', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const floatInputOffset = 264;
+  const floatOutputOffset = 260;
+  const floatLeftBuffer = device.createBuffer({
+    byteLength: 288,
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  const floatRightBuffer = device.createBuffer({
+    byteLength: 288,
+    usage: Buffer.STORAGE | Buffer.COPY_DST
+  });
+  floatLeftBuffer.write(Float32Array.from([3, 4]), floatInputOffset);
+  floatRightBuffer.write(Float32Array.from([0, 0]), floatInputOffset);
+  const floatOutputBuffer = createOutputBuffer(device, floatOutputOffset + 4);
+  const graph = new GPUCommandGraph(device, {id: 'geospatial-f32-aligned-offset-test'});
+
+  new GPUPairwisePointDistance({
+    id: 'offset-f32-point-distance',
+    left: importView(graph, 'float-left', floatLeftBuffer, 'float32x2', 1, floatInputOffset),
+    right: importView(graph, 'float-right', floatRightBuffer, 'float32x2', 1, floatInputOffset),
+    output: importView(graph, 'float-output', floatOutputBuffer, 'float32', 1, floatOutputOffset)
+  }).addToGraph(graph);
+
+  const compiled = graph.compile();
+  const commandEncoder = device.createCommandEncoder({id: 'geospatial-f32-offset-encoding'});
+  compiled.encode(commandEncoder, {parameters: undefined});
+  device.submit(commandEncoder.finish());
+
+  const floatBytes = await floatOutputBuffer.readAsync(floatOutputOffset, 4);
+  tapeTest.equal(new Float32Array(floatBytes.buffer, floatBytes.byteOffset, 1)[0], 5);
+
+  compiled.destroy();
+  for (const buffer of [floatLeftBuffer, floatRightBuffer, floatOutputBuffer]) {
+    buffer.destroy();
+  }
+  tapeTest.end();
+});
+
+test('raw point distance honors naturally aligned input and output offsets', async tapeTest => {
   const device = await getWebGPUTestDevice();
   if (!device) {
     tapeTest.comment('WebGPU is not available');
@@ -747,20 +811,8 @@ test('point distance honors naturally aligned input and output offsets', async t
     return;
   }
 
-  const floatInputOffset = 264;
-  const floatOutputOffset = 260;
   const rawInputOffset = 272;
   const rawOutputOffset = 264;
-  const floatLeftBuffer = device.createBuffer({
-    byteLength: 288,
-    usage: Buffer.STORAGE | Buffer.COPY_DST
-  });
-  const floatRightBuffer = device.createBuffer({
-    byteLength: 288,
-    usage: Buffer.STORAGE | Buffer.COPY_DST
-  });
-  floatLeftBuffer.write(Float32Array.from([3, 4]), floatInputOffset);
-  floatRightBuffer.write(Float32Array.from([0, 0]), floatInputOffset);
   const rawLeft: Point = [12_345_678.1250001, -7_654_321.5];
   const rawRight: Point = [12_345_678.125, -7_654_321.5];
   const rawLeftValues = new Uint32Array(rawInputOffset / 4 + 4);
@@ -769,16 +821,9 @@ test('point distance honors naturally aligned input and output offsets', async t
   rawRightValues.set(encodeFloat64Points([rawRight]), rawInputOffset / 4);
   const rawLeftBuffer = createBuffer(device, rawLeftValues, Buffer.STORAGE);
   const rawRightBuffer = createBuffer(device, rawRightValues, Buffer.STORAGE);
-  const floatOutputBuffer = createOutputBuffer(device, floatOutputOffset + 4);
   const rawOutputBuffer = createOutputBuffer(device, rawOutputOffset + 8);
-  const graph = new GPUCommandGraph(device, {id: 'geospatial-aligned-offset-test'});
+  const graph = new GPUCommandGraph(device, {id: 'geospatial-raw-aligned-offset-test'});
 
-  new GPUPairwisePointDistance({
-    id: 'offset-f32-point-distance',
-    left: importView(graph, 'float-left', floatLeftBuffer, 'float32x2', 1, floatInputOffset),
-    right: importView(graph, 'float-right', floatRightBuffer, 'float32x2', 1, floatInputOffset),
-    output: importView(graph, 'float-output', floatOutputBuffer, 'float32', 1, floatOutputOffset)
-  }).addToGraph(graph);
   new GPUPairwisePointDistance({
     id: 'offset-raw-point-distance',
     left: importView(graph, 'raw-left', rawLeftBuffer, 'uint32x4', 1, rawInputOffset),
@@ -787,12 +832,10 @@ test('point distance honors naturally aligned input and output offsets', async t
   }).addToGraph(graph);
 
   const compiled = graph.compile();
-  const commandEncoder = device.createCommandEncoder({id: 'geospatial-aligned-offset-encoding'});
+  const commandEncoder = device.createCommandEncoder({id: 'geospatial-raw-offset-encoding'});
   compiled.encode(commandEncoder, {parameters: undefined});
   device.submit(commandEncoder.finish());
 
-  const floatBytes = await floatOutputBuffer.readAsync(floatOutputOffset, 4);
-  tapeTest.equal(new Float32Array(floatBytes.buffer, floatBytes.byteOffset, 1)[0], 5);
   const rawBytes = await rawOutputBuffer.readAsync(rawOutputOffset, 8);
   const rawDistance = new Float32Array(rawBytes.buffer, rawBytes.byteOffset, 2);
   assertRelativeClose(
@@ -804,14 +847,7 @@ test('point distance honors naturally aligned input and output offsets', async t
   );
 
   compiled.destroy();
-  for (const buffer of [
-    floatLeftBuffer,
-    floatRightBuffer,
-    rawLeftBuffer,
-    rawRightBuffer,
-    floatOutputBuffer,
-    rawOutputBuffer
-  ]) {
+  for (const buffer of [rawLeftBuffer, rawRightBuffer, rawOutputBuffer]) {
     buffer.destroy();
   }
   tapeTest.end();

--- a/modules/experimental/test/geospatial/gpu-pairwise-point-in-polygon.spec.ts
+++ b/modules/experimental/test/geospatial/gpu-pairwise-point-in-polygon.spec.ts
@@ -23,89 +23,140 @@ test('GPUPairwisePointInPolygon classifies f32 polygons and malformed inputs', a
   }
 
   const square = makeSquare(0, 0, 10, 10, true);
-  const geometries: Geometry[] = [
-    [[square]],
-    [[square]],
-    [[square]],
-    [[square, makeSquare(3, 3, 7, 7)]],
-    [[makeSquare(-10, -10, -8, -8)], [makeSquare(20, 20, 30, 30)]],
-    [[square]],
-    [
-      [
+  const cases: PointInPolygonCase[] = [
+    {name: 'shell interior', point: [5, 5], geometry: [[square]]},
+    {name: 'shell exterior', point: [15, 5], geometry: [[square]]},
+    {name: 'vertical shell boundary', point: [0, 4], geometry: [[square]]},
+    {
+      name: 'hole interior',
+      point: [5, 5],
+      geometry: [[square, makeSquare(3, 3, 7, 7)]]
+    },
+    {
+      name: 'multipolygon interior',
+      point: [25, 25],
+      geometry: [[makeSquare(-10, -10, -8, -8)], [makeSquare(20, 20, 30, 30)]]
+    },
+    {name: 'non-finite point', point: [Number.NaN, 5], geometry: [[square]]},
+    {
+      name: 'non-finite vertex',
+      point: [5, 5],
+      geometry: [
         [
-          [0, 0],
-          [10, 0],
-          [Number.NaN, 10],
-          [0, 10]
+          [
+            [0, 0],
+            [10, 0],
+            [Number.NaN, 10],
+            [0, 10]
+          ]
         ]
       ]
-    ],
-    [
-      [
+    },
+    {
+      name: 'repeated-only ring',
+      point: [0.5, 0.25],
+      geometry: [
         [
-          [0, 0],
-          [1, 0],
-          [0, 0],
-          [0, 0]
+          [
+            [0, 0],
+            [1, 0],
+            [0, 0],
+            [0, 0]
+          ]
         ]
       ]
-    ],
-    [],
-    [[]],
-    [
-      [
+    },
+    {name: 'empty geometry', point: [0, 0], geometry: []},
+    {name: 'empty polygon', point: [0, 0], geometry: [[]]},
+    {
+      name: 'diagonal boundary',
+      point: [1, 1],
+      geometry: [
         [
-          [0, 0],
-          [2, 2],
-          [0, 2]
+          [
+            [0, 0],
+            [2, 2],
+            [0, 2]
+          ]
+        ]
+      ],
+      allowUncertain: true
+    },
+    {
+      name: 'one-ULP diagonal interior',
+      point: [0.5, Math.fround(0.5 + 2 ** -24)],
+      geometry: [
+        [
+          [
+            [0, 0],
+            [1, 1],
+            [0, 1]
+          ]
+        ]
+      ],
+      allowUncertain: true
+    },
+    {
+      name: 'all-collinear diagonal ring',
+      point: [0, 1],
+      geometry: [
+        [
+          [
+            [0, 0],
+            [1, 1],
+            [2, 2],
+            [3, 3]
+          ]
         ]
       ]
-    ],
-    [
-      [
+    },
+    {
+      name: 'all-collinear axis-aligned ring',
+      point: [1, 0],
+      geometry: [
         [
-          [0, 0],
-          [1, 1],
-          [0, 1]
+          [
+            [0, 0],
+            [1, 0],
+            [2, 0]
+          ]
         ]
       ]
-    ],
-    [
-      [
+    },
+    {
+      name: 'shell outside hole',
+      point: [1, 1],
+      geometry: [[square, makeSquare(3, 3, 7, 7)]]
+    },
+    {
+      name: 'hole boundary',
+      point: [3, 5],
+      geometry: [[square, makeSquare(3, 3, 7, 7)]]
+    },
+    {
+      name: 'multipolygon gap',
+      point: [15, 15],
+      geometry: [[makeSquare(0, 0, 10, 10)], [makeSquare(20, 20, 30, 30)]]
+    },
+    {
+      name: 'valid repeated vertex',
+      point: [5, 5],
+      geometry: [
         [
-          [0, 0],
-          [1, 1],
-          [2, 2],
-          [3, 3]
+          [
+            [0, 0],
+            [10, 0],
+            [10, 0],
+            [10, 10],
+            [0, 10]
+          ]
         ]
       ]
-    ],
-    [
-      [
-        [
-          [0, 0],
-          [1, 0],
-          [2, 0]
-        ]
-      ]
-    ]
+    },
+    {name: 'implicit closing edge boundary', point: [0, 4], geometry: [[makeSquare(0, 0, 10, 10)]]}
   ];
-  const points: Point[] = [
-    [5, 5],
-    [15, 5],
-    [0, 4],
-    [5, 5],
-    [25, 25],
-    [Number.NaN, 5],
-    [5, 5],
-    [0.5, 0.25],
-    [0, 0],
-    [0, 0],
-    [1, 1],
-    [0.5, Math.fround(0.5 + 2 ** -24)],
-    [0, 1],
-    [1, 0]
-  ];
+  const geometries = cases.map(testCase => testCase.geometry);
+  const points = cases.map(testCase => testCase.point);
   const hierarchy = flattenGeometries(geometries);
   const buffers = {
     points: createBuffer(device, encodeFloat32Points(points), Buffer.STORAGE),
@@ -200,7 +251,8 @@ test('GPUPairwisePointInPolygon classifies f32 polygons and malformed inputs', a
   );
 
   if (isSoftwareBackedDevice(device)) {
-    tapeTest.comment('Skipping slow integer fp64 point-in-polygon shader on software WebGPU');
+    // SwiftShader spends more than 100 seconds compiling integer-fp64, then loses the GPU device.
+    tapeTest.comment('Skipping precise f32 point-in-polygon execution on software WebGPU');
     for (const buffer of Object.values(buffers)) buffer.destroy();
     tapeTest.end();
     return;
@@ -209,37 +261,9 @@ test('GPUPairwisePointInPolygon classifies f32 polygons and malformed inputs', a
   const compiled = graph.compile();
   encode(device, compiled);
   const classifications = await readUint32(buffers.output, points.length);
-  tapeTest.deepEqual(classifications, [
-    inside,
-    outside,
-    boundary,
-    outside,
-    inside,
-    uncertain,
-    uncertain,
-    uncertain,
-    outside,
-    uncertain,
-    uncertain,
-    uncertain,
-    uncertain,
-    uncertain
-  ]);
-  tapeTest.equal(
-    classifications[10],
-    uncertain,
-    'diagonal product cancellation is not promoted to a proven boundary'
-  );
-  tapeTest.equal(
-    classifications[12],
-    uncertain,
-    'an all-collinear diagonal ring has no provable area'
-  );
-  tapeTest.equal(
-    classifications[13],
-    uncertain,
-    'an all-collinear axis-aligned ring remains uncertain instead of boundary'
-  );
+  for (let index = 0; index < cases.length; index++) {
+    assertPointInPolygonConformance(tapeTest, classifications[index], cases[index]);
+  }
 
   compiled.destroy();
   for (const buffer of Object.values(buffers)) buffer.destroy();
@@ -262,37 +286,54 @@ test('GPUPairwisePointInPolygon preserves raw binary64 deltas and explicit ambig
   const largeOrigin = 1_000_000_000_000;
   const smallOrigin = 20_000_000;
   const smallDelta = 2 ** -20;
-  const geometries: Geometry[] = [
-    [[makeSquare(largeOrigin, largeOrigin, largeOrigin + 1, largeOrigin + 1)]],
-    [[makeSquare(largeOrigin, largeOrigin, largeOrigin + 1, largeOrigin + 1)]],
-    [[makeSquare(largeOrigin, largeOrigin, largeOrigin + 1, largeOrigin + 1)]],
-    [
-      [
+  const largeSquare = makeSquare(largeOrigin, largeOrigin, largeOrigin + 1, largeOrigin + 1);
+  const cases: PointInPolygonCase[] = [
+    {
+      name: 'raw large-origin interior',
+      point: [largeOrigin + 0.5, largeOrigin + 0.5],
+      geometry: [[largeSquare]]
+    },
+    {
+      name: 'raw large-origin exterior',
+      point: [largeOrigin + 2, largeOrigin + 0.5],
+      geometry: [[largeSquare]]
+    },
+    {
+      name: 'raw large-origin boundary',
+      point: [largeOrigin, largeOrigin + 0.5],
+      geometry: [[largeSquare]]
+    },
+    {
+      name: 'raw diagonal ambiguity',
+      point: [largeOrigin + 0.5, largeOrigin + 0.5],
+      geometry: [
         [
-          [largeOrigin, largeOrigin],
-          [largeOrigin + 1, largeOrigin + 1],
-          [largeOrigin, largeOrigin + 1]
+          [
+            [largeOrigin, largeOrigin],
+            [largeOrigin + 1, largeOrigin + 1],
+            [largeOrigin, largeOrigin + 1]
+          ]
+        ]
+      ],
+      allowUncertain: true
+    },
+    {
+      name: 'raw sub-f32-delta interior',
+      point: [smallOrigin + smallDelta * 2, smallOrigin + smallDelta * 2],
+      geometry: [
+        [
+          [
+            [smallOrigin, smallOrigin],
+            [smallOrigin + smallDelta * 4, smallOrigin],
+            [smallOrigin + smallDelta * 4, smallOrigin + smallDelta * 4],
+            [smallOrigin, smallOrigin + smallDelta * 4]
+          ]
         ]
       ]
-    ],
-    [
-      [
-        [
-          [smallOrigin, smallOrigin],
-          [smallOrigin + smallDelta * 4, smallOrigin],
-          [smallOrigin + smallDelta * 4, smallOrigin + smallDelta * 4],
-          [smallOrigin, smallOrigin + smallDelta * 4]
-        ]
-      ]
-    ]
+    }
   ];
-  const points: Point[] = [
-    [largeOrigin + 0.5, largeOrigin + 0.5],
-    [largeOrigin + 2, largeOrigin + 0.5],
-    [largeOrigin, largeOrigin + 0.5],
-    [largeOrigin + 0.5, largeOrigin + 0.5],
-    [smallOrigin + smallDelta * 2, smallOrigin + smallDelta * 2]
-  ];
+  const geometries = cases.map(testCase => testCase.geometry);
+  const points = cases.map(testCase => testCase.point);
   const hierarchy = flattenGeometries(geometries);
   const buffers = {
     points: createBuffer(device, encodeFloat64Points(points), Buffer.STORAGE),
@@ -339,13 +380,10 @@ test('GPUPairwisePointInPolygon preserves raw binary64 deltas and explicit ambig
 
   const compiled = graph.compile();
   encode(device, compiled);
-  tapeTest.deepEqual(await readUint32(buffers.output, points.length), [
-    inside,
-    outside,
-    boundary,
-    uncertain,
-    inside
-  ]);
+  const classifications = await readUint32(buffers.output, points.length);
+  for (let index = 0; index < cases.length; index++) {
+    assertPointInPolygonConformance(tapeTest, classifications[index], cases[index]);
+  }
 
   compiled.destroy();
   for (const buffer of Object.values(buffers)) buffer.destroy();
@@ -356,6 +394,106 @@ type Point = readonly [number, number];
 type Ring = readonly Point[];
 type Polygon = readonly Ring[];
 type Geometry = readonly Polygon[];
+type PointInPolygonCase = {
+  name: string;
+  point: Point;
+  geometry: Geometry;
+  allowUncertain?: boolean;
+};
+
+function assertPointInPolygonConformance(
+  tapeTest: {equal: (actual: unknown, expected: unknown, message?: string) => void},
+  actual: number,
+  testCase: PointInPolygonCase
+): void {
+  const expected = getPointInPolygonClassification(testCase.point, testCase.geometry);
+  if (testCase.allowUncertain && actual === uncertain) {
+    tapeTest.equal(actual, uncertain, `${testCase.name} is explicitly classified as ambiguous`);
+    return;
+  }
+  tapeTest.equal(actual, expected, `${testCase.name} matches the deterministic CPU oracle`);
+}
+
+function getPointInPolygonClassification(point: Point, geometry: Geometry): number {
+  if (!isFinitePoint(point)) return uncertain;
+  let geometryInside = false;
+  let geometryBoundary = false;
+  let geometryUncertain = false;
+
+  for (const polygon of geometry) {
+    if (polygon.length === 0) {
+      geometryUncertain = true;
+      continue;
+    }
+    let polygonInside = false;
+    for (const ring of polygon) {
+      const ringClassification = getRingClassification(point, ring);
+      if (ringClassification === uncertain) geometryUncertain = true;
+      if (ringClassification === boundary) geometryBoundary = true;
+      if (ringClassification === inside) polygonInside = !polygonInside;
+    }
+    geometryInside = geometryInside || polygonInside;
+  }
+
+  if (geometryUncertain) return uncertain;
+  if (geometryBoundary) return boundary;
+  return geometryInside ? inside : outside;
+}
+
+function getRingClassification(point: Point, ring: Ring): number {
+  if (!ringHasArea(ring)) return uncertain;
+  let ringInside = false;
+  let previous = ring[ring.length - 1];
+  for (const current of ring) {
+    if (pointIsOnSegment(point, previous, current)) return boundary;
+    const upward = previous[1] <= point[1] && current[1] > point[1];
+    const downward = current[1] <= point[1] && previous[1] > point[1];
+    const orientation = getOrientation(point, previous, current);
+    if ((upward && orientation > 0) || (downward && orientation < 0)) {
+      ringInside = !ringInside;
+    }
+    previous = current;
+  }
+  return ringInside ? inside : outside;
+}
+
+function ringHasArea(ring: Ring): boolean {
+  if (ring.length < 3 || ring.some(point => !isFinitePoint(point))) return false;
+  const first = ring[0];
+  const second = ring.find(point => !pointsEqual(point, first));
+  if (!second) return false;
+  return ring.some(
+    point =>
+      !pointsEqual(point, first) &&
+      !pointsEqual(point, second) &&
+      getOrientation(first, second, point) !== 0
+  );
+}
+
+function pointIsOnSegment(point: Point, start: Point, end: Point): boolean {
+  return (
+    getOrientation(point, start, end) === 0 &&
+    point[0] >= Math.min(start[0], end[0]) &&
+    point[0] <= Math.max(start[0], end[0]) &&
+    point[1] >= Math.min(start[1], end[1]) &&
+    point[1] <= Math.max(start[1], end[1])
+  );
+}
+
+function getOrientation(origin: Point, first: Point, second: Point): number {
+  const crossProduct =
+    (first[0] - origin[0]) * (second[1] - origin[1]) -
+    (first[1] - origin[1]) * (second[0] - origin[0]);
+  return Math.sign(crossProduct);
+}
+
+function isFinitePoint(point: Point): boolean {
+  return Number.isFinite(point[0]) && Number.isFinite(point[1]);
+}
+
+function pointsEqual(first: Point, second: Point): boolean {
+  return first[0] === second[0] && first[1] === second[1];
+}
 
 function makeSquare(
   minimumX: number,

--- a/modules/experimental/test/geospatial/gpu-point-spatial-query.spec.ts
+++ b/modules/experimental/test/geospatial/gpu-point-spatial-query.spec.ts
@@ -336,6 +336,56 @@ test('GPUPointSpatialQuery keeps indexed row addressing separate from returned s
   tapeTest.end();
 });
 
+test('GPUPointSpatialQuery preserves duplicate source IDs as distinct matching rows', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const sharedProps = {
+    positions: Float32Array.from([0.25, 0.25, 0.75, 0.75, 1.25, 0.5, 2.5, 2.5]),
+    sourceIds: Uint32Array.from([42, 42, 7, 42]),
+    dimension: 2 as const,
+    kind: 'bounds' as const,
+    query: Float32Array.from([0, 0, 1, 1]),
+    gridSize: [4, 4] as const,
+    indexBounds: [0, 0, 4, 4] as const,
+    expectedIds: [42, 42]
+  };
+  const indexed = createQueryFixture(device, {
+    id: 'indexed-duplicate-source-ids',
+    ...sharedProps,
+    indexed: true
+  });
+  const scanned = createQueryFixture(device, {
+    id: 'scanned-duplicate-source-ids',
+    ...sharedProps
+  });
+
+  encode(device, indexed.compiled);
+  encode(device, scanned.compiled);
+  const indexedResult = await readResult(indexed);
+  const scannedResult = await readResult(scanned);
+  tapeTest.deepEqual(
+    indexedResult.ids.sort(sortNumbers),
+    [42, 42],
+    'the indexed path does not deduplicate equal application IDs from separate rows'
+  );
+  tapeTest.deepEqual(
+    scannedResult.ids.sort(sortNumbers),
+    [42, 42],
+    'the scan path preserves the same duplicate application IDs'
+  );
+  tapeTest.equal(indexedResult.count, 2, 'both matching rows contribute to the clamped count');
+  tapeTest.equal(indexedResult.totalCount, 2, 'both matching rows contribute to totalCount');
+
+  destroyFixture(indexed);
+  destroyFixture(scanned);
+  tapeTest.end();
+});
+
 test('GPUPointSpatialQuery applies even-odd polygon holes and includes ring boundaries', async tapeTest => {
   const device = await getWebGPUTestDevice();
   if (!device) {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test-browser": "ocular-test browser",
     "test-headless": "ocular-test headless",
     "test-coverage": "ocular-test headless --coverage",
+    "test-geospatial-package": "node ./scripts/verify-experimental-geospatial-package.mjs",
     "examples:typecheck": "node ./scripts/examples-typecheck.mjs",
     "test-fast": "yarn lint && yarn test-node",
     "test-website": "yarn website:build",


### PR DESCRIPTION
## Goals

- Turn the first-wave geospatial contracts into stronger, recurring regression checks.
- Ensure ordinary f32 planar coverage still runs on software-backed WebGPU even when raw integer-fp64 cases are too expensive there.
- Verify the experimental geospatial ESM, CJS, declaration, and root-isolation package boundaries after every CI build.

## Changes

- Adds a deterministic CPU point-in-polygon oracle and named shell, hole, multipolygon, boundary, repeated-vertex, malformed, non-finite, and ambiguous fixtures.
- Requires every definitive hardware GPU PIP classification to match the CPU oracle; only explicitly adversarial cases may return `uncertain`.
- Splits f32 and raw point/segment distance tests so f32 oracle and aligned-offset coverage no longer disappear behind the software raw-fp64 skip.
- Adds indexed and scanned query coverage for duplicate application source IDs.
- Adds `yarn test-geospatial-package` and runs the existing ESM/CJS/declaration verifier immediately after the CI build.

## Verification

- `nvm use`: not rerun; the existing repository Node environment was used.
- `yarn install --immutable`: attempted, but the approved registry currently returns 403 for Playwright 1.62.1 and `@vis.gl/dev-tools@2.0.0-alpha.3`.
- Focused hardware WebGPU coverage: 29/29 passed.
- Focused SwiftShader non-PIP coverage: 27/27 passed; the documented PIP skip path passed.
- `yarn build`: passed with the compatible installed build toolchain.
- `yarn test-geospatial-package`: passed after the build.
- Targeted Biome check and `git diff --check`: passed.
- Full `yarn test`, `yarn examples:typecheck`, `yarn website:build`, and `(cd website && yarn build)`: left to CI because the latest immutable install is registry-blocked.

## Risks and follow-up

- The production precise PIP shader still cannot execute reliably on SwiftShader: an unskipped run spent about 105 seconds compiling integer-fp64 code and then lost the WebGPU device. Hardware oracle coverage is strict, but software CI retains the explicit skip.
- Exact intersected-cell and candidate-work assertions still require a first-class diagnostics output or inspector seam; this PR deliberately does not infer those counts from unrelated index state.
- `VitestTape.timeoutAfter()` does not currently wrap a timeout set from inside an async callback; that harness repair is separate.
