### PR TITLE
feat(experimental): expose spatial query work counters

### DIFF
--- a/docs/api-reference/experimental/geospatial.md
+++ b/docs/api-reference/experimental/geospatial.md
@@ -245,6 +245,28 @@ disjoint aligned storage-binding ranges and must not overlap positions, source I
 index storage, or polygon storage. This includes the one-row binding footprint of a zero-capacity
 `ids` view. Result order is unspecified; no CPU readback is required for rendering.
 
+Two optional packed scalar views can be supplied directly to `GPUPointSpatialQuery` for
+GPU-resident broad-phase diagnostics:
+
+```ts
+new GPUPointSpatialQuery({
+  // ...query inputs and output...
+  intersectedCellCount,
+  candidateCount
+});
+```
+
+`intersectedCellCount` is the exact number of indexed cells dispatched for refinement. It is zero
+for scan queries, invalid queries, and indexed query envelopes outside the index domain.
+`candidateCount` is the exact number of rows presented to the narrow phase: every position row for
+a valid scan, or every retained row ID in the intersected indexed cells. It deliberately includes
+duplicate row IDs and invalid retained row IDs that the narrow phase later rejects. When an index
+overflows, the count covers only candidates retained by the capacity-bounded `rowIndices` view, not
+the missing source rows. These diagnostics are finalized by the existing query passes, require no
+CPU synchronization, and do not change `GPUSpatialQueryOutput` or its indirect-draw layout. Like the
+query outputs, both diagnostic views must be disjoint packed `uint32` scalars belonging to the same
+graph as every other binding.
+
 ### Run a live spatial-query benchmark
 
 Compare this real query kernel against an equivalent CPU bounds scan using your browser and GPU.

--- a/modules/experimental/src/geospatial/gpu-point-spatial-query.ts
+++ b/modules/experimental/src/geospatial/gpu-point-spatial-query.ts
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, type Binding} from '@luma.gl/core';
+import {type Binding, Buffer} from '@luma.gl/core';
 import {Computation, DynamicBuffer} from '@luma.gl/engine';
 import {
   GPUCommandGraph,
+  type GPUCommandGraphContributor,
   type GraphBufferUse,
-  type GraphDataView,
-  type GPUCommandGraphContributor
+  type GraphDataView
 } from '../gpu-primitives/gpu-command-graph';
+import type {GPUGridIndexBounds, GPUGridIndexSize} from '../gpu-primitives/gpu-grid-index';
 import {
   createTransientView,
   getViewBinding,
@@ -18,12 +19,11 @@ import {
   validatePackedUint32View,
   validatePackedView
 } from '../gpu-primitives/graph-data-view-utils';
-import type {GPUGridIndexBounds, GPUGridIndexSize} from '../gpu-primitives/gpu-grid-index';
 import {
   GEOSPATIAL_INTEGER_FP64_ARITHMETIC_MODULE,
+  type GeospatialDispatchLayout,
   getGeospatialDispatchLayout,
-  getGeospatialInvocationIndexSource,
-  type GeospatialDispatchLayout
+  getGeospatialInvocationIndexSource
 } from './geospatial-utils';
 import type {GPUSpatialQueryOutput} from './gpu-spatial-query-types';
 
@@ -84,6 +84,21 @@ export type GPUPointSpatialQueryProps = {
   polygon?: GPUPointSpatialQueryPolygon;
   /** Caller-owned compact query output. */
   output: GPUSpatialQueryOutput;
+  /**
+   * Optional packed scalar receiving the exact number of indexed cells dispatched for refinement.
+   *
+   * Scan queries write zero. Invalid queries and indexed envelopes outside the index domain also
+   * write zero.
+   */
+  intersectedCellCount?: GraphDataView<'uint32'>;
+  /**
+   * Optional packed scalar receiving the exact number of rows presented to the narrow phase.
+   *
+   * Indexed queries include duplicate and invalid retained row IDs. When the index overflowed,
+   * this counts only candidates retained by its capacity-bounded `rowIndices`. A valid scan query
+   * counts every position row, including rows later rejected for non-finite coordinates.
+   */
+  candidateCount?: GraphDataView<'uint32'>;
 };
 
 /**
@@ -94,7 +109,7 @@ export type GPUPointSpatialQueryProps = {
  * cells plus candidates instead of the complete index. The result count is safe to consume as an
  * indirect draw count: it is always clamped to `output.ids.length`; `totalCount` remains unclamped
  * over the candidates that refinement examined. An overflowing index makes that candidate set, and
- * therefore `totalCount`, incomplete relative to the original positions.
+ * therefore `totalCount` and `candidateCount`, incomplete relative to the original positions.
  * Results contain `sourceIds[rowIndex]` when aligned source IDs are supplied, or row indices by
  * default. Query-facing index entries are always row indices, independent of result identity.
  * Polygon tests use f32 even/odd fill semantics and include points on a ring boundary; they do not
@@ -109,6 +124,8 @@ export class GPUPointSpatialQuery implements GPUCommandGraphContributor {
   readonly query: GraphDataView<'float32'>;
   readonly polygon?: GPUPointSpatialQueryPolygon;
   readonly output: GPUSpatialQueryOutput;
+  readonly intersectedCellCount?: GraphDataView<'uint32'>;
+  readonly candidateCount?: GraphDataView<'uint32'>;
   readonly dimension: 2 | 3;
 
   /** Creates a query contributor without compiling or submitting GPU work. */
@@ -121,6 +138,8 @@ export class GPUPointSpatialQuery implements GPUCommandGraphContributor {
     this.query = props.query;
     this.polygon = props.polygon;
     this.output = props.output;
+    this.intersectedCellCount = props.intersectedCellCount;
+    this.candidateCount = props.candidateCount;
     this.dimension = this.positions.format === 'float32x2' ? 2 : 3;
 
     validatePackedView(this.positions, ['float32x2', 'float32x3'], `${this.id} positions`);
@@ -132,6 +151,12 @@ export class GPUPointSpatialQuery implements GPUCommandGraphContributor {
     }
     validatePackedView(this.query, ['float32'], `${this.id} query`);
     validateQueryOutput(this.id, this.output);
+    if (this.intersectedCellCount) {
+      validateQueryDiagnostic(this.id, 'intersectedCellCount', this.intersectedCellCount);
+    }
+    if (this.candidateCount) {
+      validateQueryDiagnostic(this.id, 'candidateCount', this.candidateCount);
+    }
     if (this.index) validateIndexView(this.id, this.index, this.dimension);
 
     const expectedQueryLength = this.kind === 'radius' ? this.dimension + 1 : this.dimension * 2;
@@ -163,6 +188,8 @@ export class GPUPointSpatialQuery implements GPUCommandGraphContributor {
       this.output.count,
       this.output.overflow,
       ...(this.output.totalCount ? [this.output.totalCount] : []),
+      ...(this.intersectedCellCount ? [this.intersectedCellCount] : []),
+      ...(this.candidateCount ? [this.candidateCount] : []),
       ...(this.index
         ? [this.index.cellOffsets, this.index.rowIndices, this.index.count, this.index.overflow]
         : []),
@@ -181,11 +208,16 @@ export class GPUPointSpatialQuery implements GPUCommandGraphContributor {
       format: 'uint32',
       length: QUERY_STATE_LENGTH
     });
-    const resultState = createTransientView(graph, `${this.id}-result-state`, 'uint32', 2);
+    const resultState = createTransientView(
+      graph,
+      `${this.id}-result-state`,
+      'uint32',
+      this.candidateCount ? 3 : 2
+    );
     addPreparePass(graph, this, queryState, resultState);
     addRefinementPass(graph, this, queryState, resultState);
     addSourceIdRemapPass(graph, this, resultState);
-    addFinalizePass(graph, this, resultState);
+    addFinalizePass(graph, this, queryState, resultState);
   }
 }
 
@@ -227,6 +259,11 @@ function addPreparePass<Parameters>(
   const initialOverflow = index
     ? `min(indexOverflow[${getViewElementOffset(index.overflow)}u], 1u)`
     : '0u';
+  const candidateCountInitialization = query.candidateCount
+    ? `resultState[RESULT_OFFSET + 2u] = ${
+        index ? '0u' : `select(0u, ${query.positions.length}u, valid)`
+      };`
+    : '';
   const source = /* wgsl */ `
 const QUERY_OFFSET: u32 = ${getViewElementOffset(query.query)}u;
 const STATE_OFFSET: u32 = ${getViewElementOffset(queryState)}u;
@@ -301,6 +338,7 @@ fn divideRoundUp(value: u32, divisor: u32) -> u32 {
   queryState[STATE_OFFSET + 11u] = dispatchSize.y;
   resultState[RESULT_OFFSET] = 0u;
   resultState[RESULT_OFFSET + 1u] = ${initialOverflow};
+  ${candidateCountInitialization}
 }`;
   const bindings: Record<string, GraphDataView> = {
     queryValues: query.query,
@@ -358,6 +396,9 @@ const POLYGON_POSITION_COUNT: u32 = ${query.polygon.positions.length}u;
 const RING_OFFSETS_OFFSET: u32 = ${getViewElementOffset(query.polygon.ringOffsets)}u;
 const RING_COUNT: u32 = ${query.polygon.ringOffsets.length - 1}u;`
     : '';
+  const indexedCandidateCount = query.candidateCount
+    ? 'if (localId.x == 0u) { atomicAdd(&resultState[RESULT_OFFSET + 2u], cellEnd - cellStart); }'
+    : '';
   const rowSelection = index
     ? `let dispatchWidth = queryState[STATE_OFFSET + 10u];
   let workgroupCount = queryState[STATE_OFFSET + 9u];
@@ -380,6 +421,7 @@ const RING_COUNT: u32 = ${query.polygon.ringOffsets.length - 1}u;`
   let storedCount = min(cellOffsets[CELL_OFFSETS_OFFSET + CELL_COUNT], INDEX_CAPACITY);
   let cellStart = min(cellOffsets[CELL_OFFSETS_OFFSET + cellIndex], storedCount);
   let cellEnd = min(cellOffsets[CELL_OFFSETS_OFFSET + cellIndex + 1u], storedCount);
+  ${indexedCandidateCount}
   var candidateIndex = cellStart + localId.x;
   loop {
     if (candidateIndex >= cellEnd) { break; }
@@ -570,13 +612,37 @@ const OUTPUT_OFFSET: u32 = ${getViewElementOffset(query.output.ids)}u;
 function addFinalizePass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   query: GPUPointSpatialQuery,
+  queryState: GraphDataView<'uint32'>,
   resultState: GraphDataView<'uint32'>
 ): void {
+  let nextBinding = 3;
+  const totalCountBinding = query.output.totalCount ? nextBinding++ : undefined;
+  const queryStateBinding = query.intersectedCellCount ? nextBinding++ : undefined;
+  const intersectedCellCountBinding = query.intersectedCellCount ? nextBinding++ : undefined;
+  const candidateCountBinding = query.candidateCount ? nextBinding++ : undefined;
   const totalCountDeclaration = query.output.totalCount
     ? `const TOTAL_OFFSET: u32 = ${getViewElementOffset(query.output.totalCount)}u;
-@group(0) @binding(3) var<storage, read_write> outputTotalCount: array<u32>;`
+@group(0) @binding(${totalCountBinding}) var<storage, read_write> outputTotalCount: array<u32>;`
     : '';
   const totalCountWrite = query.output.totalCount ? 'outputTotalCount[TOTAL_OFFSET] = total;' : '';
+  const intersectedCellCountDeclaration = query.intersectedCellCount
+    ? `const STATE_OFFSET: u32 = ${getViewElementOffset(queryState)}u;
+const INTERSECTED_CELL_COUNT_OFFSET: u32 = ${getViewElementOffset(query.intersectedCellCount)}u;
+@group(0) @binding(${queryStateBinding}) var<storage, read> queryState: array<u32>;
+@group(0) @binding(${intersectedCellCountBinding}) var<storage, read_write> outputIntersectedCellCount: array<u32>;`
+    : '';
+  const intersectedCellCountWrite = query.intersectedCellCount
+    ? `outputIntersectedCellCount[INTERSECTED_CELL_COUNT_OFFSET] = ${
+        query.index ? 'queryState[STATE_OFFSET + 9u]' : '0u'
+      };`
+    : '';
+  const candidateCountDeclaration = query.candidateCount
+    ? `const CANDIDATE_COUNT_OFFSET: u32 = ${getViewElementOffset(query.candidateCount)}u;
+@group(0) @binding(${candidateCountBinding}) var<storage, read_write> outputCandidateCount: array<u32>;`
+    : '';
+  const candidateCountWrite = query.candidateCount
+    ? 'outputCandidateCount[CANDIDATE_COUNT_OFFSET] = resultState[RESULT_OFFSET + 2u];'
+    : '';
   const source = /* wgsl */ `
 const RESULT_OFFSET: u32 = ${getViewElementOffset(resultState)}u;
 const COUNT_OFFSET: u32 = ${getViewElementOffset(query.output.count)}u;
@@ -586,6 +652,8 @@ const OUTPUT_CAPACITY: u32 = ${query.output.ids.length}u;
 @group(0) @binding(1) var<storage, read_write> outputCount: array<u32>;
 @group(0) @binding(2) var<storage, read_write> outputOverflow: array<u32>;
 ${totalCountDeclaration}
+${intersectedCellCountDeclaration}
+${candidateCountDeclaration}
 @compute @workgroup_size(1) fn main() {
   let total = resultState[RESULT_OFFSET];
   outputCount[COUNT_OFFSET] = min(total, OUTPUT_CAPACITY);
@@ -594,6 +662,8 @@ ${totalCountDeclaration}
     select(0u, 1u, total > OUTPUT_CAPACITY)
   );
   ${totalCountWrite}
+  ${intersectedCellCountWrite}
+  ${candidateCountWrite}
 }`;
   addComputationPass(graph, {
     id: `${query.id}-finalize`,
@@ -604,13 +674,29 @@ ${totalCountDeclaration}
       {buffer: query.output.overflow, usage: 'storage-write'},
       ...(query.output.totalCount
         ? ([{buffer: query.output.totalCount, usage: 'storage-write'}] as GraphBufferUse[])
+        : []),
+      ...(query.intersectedCellCount
+        ? ([
+            {buffer: queryState, usage: 'storage-read'},
+            {buffer: query.intersectedCellCount, usage: 'storage-write'}
+          ] as GraphBufferUse[])
+        : []),
+      ...(query.candidateCount
+        ? ([{buffer: query.candidateCount, usage: 'storage-write'}] as GraphBufferUse[])
         : [])
     ],
     bindings: {
       resultState,
       outputCount: query.output.count,
       outputOverflow: query.output.overflow,
-      ...(query.output.totalCount ? {outputTotalCount: query.output.totalCount} : {})
+      ...(query.output.totalCount ? {outputTotalCount: query.output.totalCount} : {}),
+      ...(query.intersectedCellCount
+        ? {
+            queryState,
+            outputIntersectedCellCount: query.intersectedCellCount
+          }
+        : {}),
+      ...(query.candidateCount ? {outputCandidateCount: query.candidateCount} : {})
     },
     dispatchCount: 1
   });
@@ -797,6 +883,17 @@ function validateQueryOutput(id: string, output: GPUSpatialQueryOutput): void {
   }
 }
 
+function validateQueryDiagnostic(
+  id: string,
+  name: 'intersectedCellCount' | 'candidateCount',
+  view: GraphDataView<'uint32'>
+): void {
+  validatePackedUint32View(view, `${id} ${name}`);
+  if (view.length !== 1) {
+    throw new Error(`${id} ${name} must be one packed uint32 scalar`);
+  }
+}
+
 function validateDisjointQueryViews(id: string, query: GPUPointSpatialQuery): void {
   const inputs: [string, GraphDataView][] = [
     ['positions', query.positions],
@@ -823,6 +920,12 @@ function validateDisjointQueryViews(id: string, query: GPUPointSpatialQuery): vo
     ['overflow', query.output.overflow],
     ...(query.output.totalCount
       ? ([['totalCount', query.output.totalCount]] as [string, GraphDataView][])
+      : []),
+    ...(query.intersectedCellCount
+      ? ([['intersectedCellCount', query.intersectedCellCount]] as [string, GraphDataView][])
+      : []),
+    ...(query.candidateCount
+      ? ([['candidateCount', query.candidateCount]] as [string, GraphDataView][])
       : [])
   ] as [string, GraphDataView][];
   for (let outputIndex = 0; outputIndex < outputs.length; outputIndex++) {

--- a/modules/experimental/src/geospatial/gpu-point-spatial-query.ts
+++ b/modules/experimental/src/geospatial/gpu-point-spatial-query.ts
@@ -617,7 +617,8 @@ function addFinalizePass<Parameters>(
 ): void {
   let nextBinding = 3;
   const totalCountBinding = query.output.totalCount ? nextBinding++ : undefined;
-  const queryStateBinding = query.intersectedCellCount ? nextBinding++ : undefined;
+  const readsQueryState = Boolean(query.intersectedCellCount && query.index);
+  const queryStateBinding = readsQueryState ? nextBinding++ : undefined;
   const intersectedCellCountBinding = query.intersectedCellCount ? nextBinding++ : undefined;
   const candidateCountBinding = query.candidateCount ? nextBinding++ : undefined;
   const totalCountDeclaration = query.output.totalCount
@@ -626,9 +627,13 @@ function addFinalizePass<Parameters>(
     : '';
   const totalCountWrite = query.output.totalCount ? 'outputTotalCount[TOTAL_OFFSET] = total;' : '';
   const intersectedCellCountDeclaration = query.intersectedCellCount
-    ? `const STATE_OFFSET: u32 = ${getViewElementOffset(queryState)}u;
+    ? `${
+        readsQueryState
+          ? `const STATE_OFFSET: u32 = ${getViewElementOffset(queryState)}u;
+@group(0) @binding(${queryStateBinding}) var<storage, read> queryState: array<u32>;`
+          : ''
+      }
 const INTERSECTED_CELL_COUNT_OFFSET: u32 = ${getViewElementOffset(query.intersectedCellCount)}u;
-@group(0) @binding(${queryStateBinding}) var<storage, read> queryState: array<u32>;
 @group(0) @binding(${intersectedCellCountBinding}) var<storage, read_write> outputIntersectedCellCount: array<u32>;`
     : '';
   const intersectedCellCountWrite = query.intersectedCellCount
@@ -677,7 +682,7 @@ ${candidateCountDeclaration}
         : []),
       ...(query.intersectedCellCount
         ? ([
-            {buffer: queryState, usage: 'storage-read'},
+            ...(readsQueryState ? [{buffer: queryState, usage: 'storage-read'}] : []),
             {buffer: query.intersectedCellCount, usage: 'storage-write'}
           ] as GraphBufferUse[])
         : []),
@@ -692,7 +697,7 @@ ${candidateCountDeclaration}
       ...(query.output.totalCount ? {outputTotalCount: query.output.totalCount} : {}),
       ...(query.intersectedCellCount
         ? {
-            queryState,
+            ...(readsQueryState ? {queryState} : {}),
             outputIntersectedCellCount: query.intersectedCellCount
           }
         : {}),

--- a/modules/experimental/test/geospatial/gpu-point-spatial-query-capacity.spec.ts
+++ b/modules/experimental/test/geospatial/gpu-point-spatial-query-capacity.spec.ts
@@ -2,17 +2,17 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type ComputePassProps, type Device} from '@luma.gl/core';
 import {DynamicBuffer} from '@luma.gl/engine';
 import {
+  type CompiledGPUCommandGraph,
   DrawCommandBuffer,
   GPUCommandGraph,
   GPUGridIndex,
-  type CompiledGPUCommandGraph,
   type GraphDataView
 } from '@luma.gl/experimental';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
 import {GPUPointSpatialQuery, type GPUSpatialQueryOutput} from '../../src/geospatial';
 
 const STORAGE_BINDING_ALIGNMENT = 256;
@@ -30,7 +30,7 @@ test('GPUPointSpatialQuery rejects every overlapping output pair', async tapeTes
   const queryBuffer = createInputBuffer(device, Float32Array.from([-1, -1, 1, 1]));
   const outputBuffer = createOutputBuffer(
     device,
-    (STORAGE_BINDING_ALIGNMENT * 3) / Uint32Array.BYTES_PER_ELEMENT + 1
+    (STORAGE_BINDING_ALIGNMENT * 5) / Uint32Array.BYTES_PER_ELEMENT + 1
   );
   const graph = new GPUCommandGraph(device, {id: 'spatial-query-output-aliases'});
   const positions = importView(graph, 'positions', positionsBuffer, 'float32x2', 1);
@@ -59,6 +59,16 @@ test('GPUPointSpatialQuery rejects every overlapping output pair', async tapeTes
     })
   };
   const outputNames = ['ids', 'count', 'overflow', 'totalCount'] as const;
+  const intersectedCellCount = graph.createDataView(outputHandle, {
+    format: 'uint32',
+    length: 1,
+    byteOffset: STORAGE_BINDING_ALIGNMENT * 4
+  });
+  const candidateCount = graph.createDataView(outputHandle, {
+    format: 'uint32',
+    length: 1,
+    byteOffset: STORAGE_BINDING_ALIGNMENT * 5
+  });
 
   for (let firstIndex = 0; firstIndex < outputNames.length; firstIndex++) {
     for (let secondIndex = firstIndex + 1; secondIndex < outputNames.length; secondIndex++) {
@@ -92,6 +102,87 @@ test('GPUPointSpatialQuery rejects every overlapping output pair', async tapeTes
       }),
     /output ids and sourceIds must not overlap/,
     'a writable output cannot alias a live source-ID read'
+  );
+
+  tapeTest.throws(
+    () =>
+      new GPUPointSpatialQuery({
+        id: 'diagnostic-output-alias',
+        positions,
+        kind: 'bounds',
+        query,
+        output: baseOutput,
+        candidateCount: baseOutput.count
+      }),
+    /output candidateCount and output count must not overlap/,
+    'candidate diagnostics cannot alias compact outputs'
+  );
+  tapeTest.throws(
+    () =>
+      new GPUPointSpatialQuery({
+        id: 'diagnostic-input-alias',
+        positions,
+        sourceIds,
+        kind: 'bounds',
+        query,
+        output: baseOutput,
+        intersectedCellCount: sourceIds
+      }),
+    /intersectedCellCount.*sourceIds must not overlap/,
+    'cell diagnostics cannot alias query inputs'
+  );
+  tapeTest.throws(
+    () =>
+      new GPUPointSpatialQuery({
+        id: 'diagnostic-pair-alias',
+        positions,
+        kind: 'bounds',
+        query,
+        output: baseOutput,
+        intersectedCellCount,
+        candidateCount: intersectedCellCount
+      }),
+    /output candidateCount and output intersectedCellCount must not overlap/,
+    'the two diagnostics cannot alias one another'
+  );
+  tapeTest.throws(
+    () =>
+      new GPUPointSpatialQuery({
+        id: 'diagnostic-not-scalar',
+        positions,
+        kind: 'bounds',
+        query,
+        output: baseOutput,
+        candidateCount: graph.createDataView(outputHandle, {
+          format: 'uint32',
+          length: 2,
+          byteOffset: STORAGE_BINDING_ALIGNMENT * 4
+        })
+      }),
+    /candidateCount must be one packed uint32 scalar/,
+    'diagnostics must be scalar views'
+  );
+
+  const foreignDiagnosticBuffer = createOutputBuffer(device, 1);
+  const foreignGraph = new GPUCommandGraph(device, {id: 'foreign-diagnostic-graph'});
+  const foreignQuery = new GPUPointSpatialQuery({
+    id: 'foreign-diagnostic',
+    positions,
+    kind: 'bounds',
+    query,
+    output: baseOutput,
+    candidateCount: importView(
+      foreignGraph,
+      'foreign-candidate-count',
+      foreignDiagnosticBuffer,
+      'uint32',
+      1
+    )
+  });
+  tapeTest.throws(
+    () => foreignQuery.addToGraph(graph),
+    /views must belong to the target graph/,
+    'diagnostics must belong to the target graph'
   );
 
   const packedOutputBuffer = createOutputBuffer(device, 4);
@@ -162,7 +253,9 @@ test('GPUPointSpatialQuery rejects every overlapping output pair', async tapeTes
     positions,
     kind: 'bounds',
     query,
-    output: baseOutput
+    output: baseOutput,
+    intersectedCellCount,
+    candidateCount
   }).addToGraph(graph);
   const compiled = graph.compile();
   encode(device, compiled);
@@ -182,6 +275,16 @@ test('GPUPointSpatialQuery rejects every overlapping output pair', async tapeTes
     1,
     'aligned output totalCount is writable'
   );
+  tapeTest.equal(
+    await readUint32At(outputBuffer, STORAGE_BINDING_ALIGNMENT * 4),
+    0,
+    'aligned intersectedCellCount is writable'
+  );
+  tapeTest.equal(
+    await readUint32At(outputBuffer, STORAGE_BINDING_ALIGNMENT * 5),
+    1,
+    'aligned candidateCount is writable'
+  );
 
   compiled.destroy();
   dynamicPositionsBuffer.destroy();
@@ -190,6 +293,7 @@ test('GPUPointSpatialQuery rejects every overlapping output pair', async tapeTes
   queryBuffer.destroy();
   outputBuffer.destroy();
   packedOutputBuffer.destroy();
+  foreignDiagnosticBuffer.destroy();
   tapeTest.end();
 });
 
@@ -209,6 +313,8 @@ test('GPUPointSpatialQuery clamps an indirect draw count but preserves totalCoun
   const idsBuffer = createOutputBuffer(device, 2);
   const overflowBuffer = createOutputBuffer(device, 1);
   const totalCountBuffer = createOutputBuffer(device, 1);
+  const intersectedCellCountBuffer = createOutputBuffer(device, 1);
+  const candidateCountBuffer = createOutputBuffer(device, 1);
   const drawCommands = new DrawCommandBuffer(device, {
     id: 'spatial-query-draw-count',
     type: 'draw',
@@ -226,7 +332,15 @@ test('GPUPointSpatialQuery clamps an indirect draw count but preserves totalCoun
       count: graph.importGPUData('draw-count', drawCommands.getInstanceCountData(0)),
       overflow: importView(graph, 'overflow', overflowBuffer, 'uint32', 1),
       totalCount: importView(graph, 'total-count', totalCountBuffer, 'uint32', 1)
-    }
+    },
+    intersectedCellCount: importView(
+      graph,
+      'intersected-cell-count',
+      intersectedCellCountBuffer,
+      'uint32',
+      1
+    ),
+    candidateCount: importView(graph, 'candidate-count', candidateCountBuffer, 'uint32', 1)
   }).addToGraph(graph);
 
   const compiled = graph.compile();
@@ -236,6 +350,16 @@ test('GPUPointSpatialQuery clamps an indirect draw count but preserves totalCoun
 
   tapeTest.equal(drawCount, 2, 'the DrawCommandBuffer instance count is clamped to ID capacity');
   tapeTest.equal((await readUint32(totalCountBuffer, 1))[0], 6, 'totalCount remains unclamped');
+  tapeTest.equal(
+    (await readUint32(intersectedCellCountBuffer, 1))[0],
+    0,
+    'a scan reports zero intersected cells'
+  );
+  tapeTest.equal(
+    (await readUint32(candidateCountBuffer, 1))[0],
+    6,
+    'a valid scan presents every position row to the narrow phase'
+  );
   tapeTest.equal((await readUint32(overflowBuffer, 1))[0], 1, 'result truncation sets overflow');
   tapeTest.equal(new Set(ids).size, 2, 'the retained rows are unique');
   tapeTest.ok(
@@ -250,6 +374,8 @@ test('GPUPointSpatialQuery clamps an indirect draw count but preserves totalCoun
   idsBuffer.destroy();
   overflowBuffer.destroy();
   totalCountBuffer.destroy();
+  intersectedCellCountBuffer.destroy();
+  candidateCountBuffer.destroy();
   tapeTest.end();
 });
 
@@ -275,6 +401,8 @@ test('GPUPointSpatialQuery propagates index overflow independently of result cap
   const countBuffer = createOutputBuffer(device, 1);
   const overflowBuffer = createOutputBuffer(device, 1);
   const totalCountBuffer = createOutputBuffer(device, 1);
+  const intersectedCellCountBuffer = createOutputBuffer(device, 1);
+  const candidateCountBuffer = createOutputBuffer(device, 1);
   const graph = new GPUCommandGraph(device, {id: 'spatial-query-index-capacity'});
   const positions = importView(graph, 'positions', positionsBuffer, 'float32x2', 5);
   const cellOffsets = importView(graph, 'cell-offsets', cellOffsetsBuffer, 'uint32', 2);
@@ -310,7 +438,15 @@ test('GPUPointSpatialQuery propagates index overflow independently of result cap
       count: importView(graph, 'count', countBuffer, 'uint32', 1),
       overflow: importView(graph, 'overflow', overflowBuffer, 'uint32', 1),
       totalCount: importView(graph, 'total-count', totalCountBuffer, 'uint32', 1)
-    }
+    },
+    intersectedCellCount: importView(
+      graph,
+      'intersected-cell-count',
+      intersectedCellCountBuffer,
+      'uint32',
+      1
+    ),
+    candidateCount: importView(graph, 'candidate-count', candidateCountBuffer, 'uint32', 1)
   }).addToGraph(graph);
 
   const compiled = graph.compile();
@@ -329,6 +465,16 @@ test('GPUPointSpatialQuery propagates index overflow independently of result cap
     (await readUint32(totalCountBuffer, 1))[0],
     2,
     'totalCount covers only the candidates retained by the overflowing index'
+  );
+  tapeTest.equal(
+    (await readUint32(intersectedCellCountBuffer, 1))[0],
+    1,
+    'the one-cell index reports one intersected cell'
+  );
+  tapeTest.equal(
+    (await readUint32(candidateCountBuffer, 1))[0],
+    2,
+    'candidateCount covers exactly the row IDs retained by the overflowing index'
   );
   tapeTest.equal((await readUint32(overflowBuffer, 1))[0], 1, 'query carries index overflow');
   tapeTest.equal(new Set(ids).size, 2, 'stored row indices remain unique');
@@ -349,14 +495,16 @@ test('GPUPointSpatialQuery propagates index overflow independently of result cap
     idsBuffer,
     countBuffer,
     overflowBuffer,
-    totalCountBuffer
+    totalCountBuffer,
+    intersectedCellCountBuffer,
+    candidateCountBuffer
   ]) {
     buffer.destroy();
   }
   tapeTest.end();
 });
 
-test('GPUPointSpatialQuery uses GPU-prepared indirect dispatch for indexed refinement', async tapeTest => {
+test('GPUPointSpatialQuery reports exact indexed broad-phase work without source-sized scratch', async tapeTest => {
   const device = await getWebGPUTestDevice();
   if (!device) {
     tapeTest.comment('WebGPU is not available');
@@ -364,48 +512,33 @@ test('GPUPointSpatialQuery uses GPU-prepared indirect dispatch for indexed refin
     return;
   }
 
-  const gridWidth = 16;
-  const positionsValues = new Float32Array(gridWidth * gridWidth * 2);
-  for (let row = 0; row < gridWidth; row++) {
-    for (let column = 0; column < gridWidth; column++) {
-      const index = row * gridWidth + column;
-      positionsValues[index * 2] = column + 0.5;
-      positionsValues[index * 2 + 1] = row + 0.5;
-    }
-  }
-  const pointCount = gridWidth * gridWidth;
-  const positionsBuffer = createInputBuffer(device, positionsValues);
-  const queryBuffer = createInputBuffer(device, Float32Array.from([8.49, 8.49, 8.51, 8.51]));
-  const cellOffsetsBuffer = createOutputBuffer(device, pointCount + 1);
-  const rowIndicesBuffer = createOutputBuffer(device, pointCount);
-  const indexCountBuffer = createOutputBuffer(device, 1);
-  const indexOverflowBuffer = createOutputBuffer(device, 1);
+  const gridWidth = 4;
+  const positionsBuffer = createInputBuffer(
+    device,
+    Float32Array.from([1.5, 1.5, 0.5, 0.5, 2.5, 2.5, 1.5, 1.5])
+  );
+  const queryBuffer = createInputBuffer(device, Float32Array.from([1.49, 1.49, 1.51, 1.51]));
+  const cellOffsetsBuffer = createInputBuffer(
+    device,
+    Uint32Array.from([0, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6])
+  );
+  // Row 1 is retained twice and row 999 is invalid. Row 3 is a matching poison row assigned to the
+  // far corner cell; indexed refinement must not visit it.
+  const rowIndicesBuffer = createInputBuffer(device, Uint32Array.from([1, 1, 999, 0, 2, 3]));
+  const indexCountBuffer = createInputBuffer(device, Uint32Array.from([6]));
+  const indexOverflowBuffer = createInputBuffer(device, Uint32Array.from([0]));
   const idsBuffer = createOutputBuffer(device, 4);
   const countBuffer = createOutputBuffer(device, 1);
   const overflowBuffer = createOutputBuffer(device, 1);
   const totalCountBuffer = createOutputBuffer(device, 1);
+  const intersectedCellCountBuffer = createOutputBuffer(device, 1);
+  const candidateCountBuffer = createOutputBuffer(device, 1);
   const graph = new GPUCommandGraph(device, {id: 'spatial-query-indirect-candidates'});
-  const positions = importView(graph, 'positions', positionsBuffer, 'float32x2', pointCount);
-  const cellOffsets = importView(
-    graph,
-    'cell-offsets',
-    cellOffsetsBuffer,
-    'uint32',
-    pointCount + 1
-  );
-  const rowIndices = importView(graph, 'row-indices', rowIndicesBuffer, 'uint32', pointCount);
+  const positions = importView(graph, 'positions', positionsBuffer, 'float32x2', 4);
+  const cellOffsets = importView(graph, 'cell-offsets', cellOffsetsBuffer, 'uint32', 17);
+  const rowIndices = importView(graph, 'row-indices', rowIndicesBuffer, 'uint32', 6);
   const indexCount = importView(graph, 'index-count', indexCountBuffer, 'uint32', 1);
   const indexOverflow = importView(graph, 'index-overflow', indexOverflowBuffer, 'uint32', 1);
-  new GPUGridIndex({
-    id: 'dispatch-index',
-    positions,
-    gridSize: [gridWidth, gridWidth],
-    bounds: [0, 0, gridWidth, gridWidth],
-    cellOffsets,
-    objectIds: rowIndices,
-    count: indexCount,
-    overflow: indexOverflow
-  }).addToGraph(graph);
   new GPUPointSpatialQuery({
     id: 'dispatch-query',
     positions,
@@ -424,7 +557,15 @@ test('GPUPointSpatialQuery uses GPU-prepared indirect dispatch for indexed refin
       count: importView(graph, 'count', countBuffer, 'uint32', 1),
       overflow: importView(graph, 'overflow', overflowBuffer, 'uint32', 1),
       totalCount: importView(graph, 'total-count', totalCountBuffer, 'uint32', 1)
-    }
+    },
+    intersectedCellCount: importView(
+      graph,
+      'intersected-cell-count',
+      intersectedCellCountBuffer,
+      'uint32',
+      1
+    ),
+    candidateCount: importView(graph, 'candidate-count', candidateCountBuffer, 'uint32', 1)
   }).addToGraph(graph);
 
   const compiled = graph.compile();
@@ -432,10 +573,61 @@ test('GPUPointSpatialQuery uses GPU-prepared indirect dispatch for indexed refin
   const count = (await readUint32(countBuffer, 1))[0];
 
   tapeTest.deepEqual(
-    compiled.stats.nodeOrder.slice(-3),
+    compiled.stats.nodeOrder,
     ['dispatch-query-prepare', 'dispatch-query-refine', 'dispatch-query-finalize'],
-    'GPU preparation precedes candidate refinement'
+    'diagnostics preserve prepare, refine, and finalize pass topology'
   );
+  tapeTest.equal(
+    compiled.stats.logicalTransientBytes,
+    15 * Uint32Array.BYTES_PER_ELEMENT,
+    'the query owns only its fixed 12-word dispatch state and optional three-word result state'
+  );
+  const baselineGraph = new GPUCommandGraph(device, {id: 'spatial-query-two-word-result-state'});
+  const baselinePositions = importView(
+    baselineGraph,
+    'baseline-positions',
+    positionsBuffer,
+    'float32x2',
+    4
+  );
+  new GPUPointSpatialQuery({
+    id: 'baseline-query',
+    positions: baselinePositions,
+    index: {
+      gridSize: [gridWidth, gridWidth],
+      bounds: [0, 0, gridWidth, gridWidth],
+      cellOffsets: importView(
+        baselineGraph,
+        'baseline-cell-offsets',
+        cellOffsetsBuffer,
+        'uint32',
+        17
+      ),
+      rowIndices: importView(baselineGraph, 'baseline-row-indices', rowIndicesBuffer, 'uint32', 6),
+      count: importView(baselineGraph, 'baseline-index-count', indexCountBuffer, 'uint32', 1),
+      overflow: importView(
+        baselineGraph,
+        'baseline-index-overflow',
+        indexOverflowBuffer,
+        'uint32',
+        1
+      )
+    },
+    kind: 'bounds',
+    query: importView(baselineGraph, 'baseline-query-values', queryBuffer, 'float32', 4),
+    output: {
+      ids: importView(baselineGraph, 'baseline-ids', idsBuffer, 'uint32', 4),
+      count: importView(baselineGraph, 'baseline-count', countBuffer, 'uint32', 1),
+      overflow: importView(baselineGraph, 'baseline-overflow', overflowBuffer, 'uint32', 1)
+    }
+  }).addToGraph(baselineGraph);
+  const baselineCompiled = baselineGraph.compile();
+  tapeTest.equal(
+    baselineCompiled.stats.logicalTransientBytes,
+    14 * Uint32Array.BYTES_PER_ELEMENT,
+    'omitting candidateCount preserves the two-word result state'
+  );
+  baselineCompiled.destroy();
   tapeTest.equal(dispatchProbe.indirect, 1, 'indexed refinement records one indirect dispatch');
   tapeTest.equal(
     dispatchProbe.direct,
@@ -443,7 +635,39 @@ test('GPUPointSpatialQuery uses GPU-prepared indirect dispatch for indexed refin
     'indexed refinement does not record a fixed full-N dispatch'
   );
   tapeTest.equal(count, 1, 'indexed refinement returns one exact match');
-  tapeTest.deepEqual(await readUint32(idsBuffer, count), [8 * gridWidth + 8]);
+  tapeTest.deepEqual(await readUint32(idsBuffer, count), [0], 'the far-cell poison is not visited');
+  tapeTest.equal(
+    (await readUint32(intersectedCellCountBuffer, 1))[0],
+    9,
+    'the conservative three-by-three cell range is reported exactly'
+  );
+  tapeTest.equal(
+    (await readUint32(candidateCountBuffer, 1))[0],
+    5,
+    'retained rows in active cells include duplicate and invalid row IDs exactly'
+  );
+
+  queryBuffer.write(Float32Array.from([Number.NaN, 0, 1, 1]));
+  encode(device, compiled);
+  tapeTest.deepEqual(
+    [
+      (await readUint32(intersectedCellCountBuffer, 1))[0],
+      (await readUint32(candidateCountBuffer, 1))[0]
+    ],
+    [0, 0],
+    'a mutable invalid query resets both diagnostics'
+  );
+
+  queryBuffer.write(Float32Array.from([10, 10, 11, 11]));
+  encode(device, compiled);
+  tapeTest.deepEqual(
+    [
+      (await readUint32(intersectedCellCountBuffer, 1))[0],
+      (await readUint32(candidateCountBuffer, 1))[0]
+    ],
+    [0, 0],
+    'a mutable query outside the index domain resets both diagnostics'
+  );
 
   compiled.destroy();
   for (const buffer of [
@@ -456,7 +680,9 @@ test('GPUPointSpatialQuery uses GPU-prepared indirect dispatch for indexed refin
     idsBuffer,
     countBuffer,
     overflowBuffer,
-    totalCountBuffer
+    totalCountBuffer,
+    intersectedCellCountBuffer,
+    candidateCountBuffer
   ]) {
     buffer.destroy();
   }

--- a/modules/experimental/test/geospatial/gpu-point-spatial-query-capacity.spec.ts
+++ b/modules/experimental/test/geospatial/gpu-point-spatial-query-capacity.spec.ts
@@ -346,9 +346,9 @@ test('GPUPointSpatialQuery clamps an indirect draw count but preserves totalCoun
   const compiled = graph.compile();
   encode(device, compiled);
   const drawCount = await readDrawCount(drawCommands);
-  const ids = await readUint32(idsBuffer, drawCount);
 
   tapeTest.equal(drawCount, 2, 'the DrawCommandBuffer instance count is clamped to ID capacity');
+  const ids = await readUint32(idsBuffer, Math.min(drawCount, 2));
   tapeTest.equal((await readUint32(totalCountBuffer, 1))[0], 6, 'totalCount remains unclamped');
   tapeTest.equal(
     (await readUint32(intersectedCellCountBuffer, 1))[0],


### PR DESCRIPTION
## Goals

- Make indexed-query work measurable instead of inferring it from index contents.
- Preserve GPU-driven indirect rendering and avoid CPU synchronization.
- Keep the existing shared query-output contract backward compatible.

## Changes

- Adds optional caller-owned `intersectedCellCount` and `candidateCount` scalar outputs to `GPUPointSpatialQuery`.
- Reuses the exact GPU-written active-cell count already produced by query preparation.
- Counts indexed candidates with one atomic addition per active cell; scan queries report every row presented to the narrow phase.
- Preserves the current prepare → indirect refine → finalize topology, indirect-dispatch layout, and two-word result state when candidate diagnostics are not requested.
- Documents duplicate/invalid retained ID and index-overflow semantics.
- Adds mutable-query, scan/index, index-overflow, result-capacity, aliasing, transient-size, and indirect-draw tests.

## Verification

- Source-only TypeScript 6.0.3 check: passed.
- Biome 2.4.8 formatting/lint rules: passed.
- Focused Node transform/load tests: 4/4 passed.
- `git diff --check`: passed.
- Independent P0/P1 review: clean, including all optional finalize-binding combinations and graph hazards.
- Repo-native `yarn install --immutable`: blocked by approved-registry 403 responses for Playwright 1.62.1 and `@vis.gl/dev-tools@2.0.0-alpha.3`.
- A prior-tooling headless bridge hung before test execution and was terminated; current CI is the headless WGSL execution gate.
- Full `yarn build`, `yarn test`, `yarn examples:typecheck`, `yarn website:build`, and `(cd website && yarn build)`: left to CI because the latest immutable install is registry-blocked.

## Semantics and risks

- `intersectedCellCount` reports conservative indexed cells that receive refinement workgroups; scans write zero.
- `candidateCount` reports rows presented to narrow-phase refinement, including duplicate and invalid retained row IDs.
- An overflowing index makes the count exact for retained rows but incomplete relative to the original source; the existing overflow output continues to communicate that state.
- Result-capacity overflow never clamps either diagnostic and does not change indirect draw-count clamping.
