### PR TITLE
perf(experimental): specialize precise PIP shaders

### DIFF
--- a/modules/experimental/src/geospatial/geospatial-utils.ts
+++ b/modules/experimental/src/geospatial/geospatial-utils.ts
@@ -41,6 +41,9 @@ export type GeospatialDispatchLayout = {
   z: number;
 };
 
+/** Internal fp64 source specialization for precise geospatial kernels. @internal */
+export type GeospatialFP64Profile = 'full' | 'predicate-f32' | 'predicate-raw';
+
 /** Recognizes vector views structurally across independently bundled package entry points. */
 export function isGraphVectorView<T extends GPUVectorFormat>(
   rows: GPURowView<T>
@@ -319,8 +322,12 @@ export function addGeospatialPass<Parameters>(
     bindings: Record<string, GraphDataView>;
     dispatchLayout: GeospatialDispatchLayout;
     precise?: boolean;
+    fp64Profile?: GeospatialFP64Profile;
   }
 ): void {
+  if (!props.precise && props.fp64Profile !== undefined) {
+    throw new Error('geospatial fp64 profiles require precise arithmetic');
+  }
   graph.addComputePass({
     id: props.id,
     resources: props.resources,
@@ -328,8 +335,13 @@ export function addGeospatialPass<Parameters>(
       const modules: ShaderModule[] = props.precise
         ? [GEOSPATIAL_INTEGER_FP64_ARITHMETIC_MODULE]
         : [];
+      const fp64Profile = props.fp64Profile ?? 'full';
       const defines: Record<string, boolean | number> = props.precise
-        ? {LUMA_FP64_INTEGER_ARITHMETIC: true}
+        ? {
+            LUMA_FP64_INTEGER_ARITHMETIC: true,
+            ...(fp64Profile === 'full' ? {} : {LUMA_FP64_PREDICATE_ONLY: true}),
+            ...(fp64Profile === 'predicate-f32' ? {LUMA_FP64_F32_INPUT_ONLY: true} : {})
+          }
         : {};
       const computation = new Computation(device, {
         id: props.id,

--- a/modules/experimental/src/geospatial/gpu-pairwise-point-in-polygon.ts
+++ b/modules/experimental/src/geospatial/gpu-pairwise-point-in-polygon.ts
@@ -10,7 +10,6 @@ import {
 import {getViewElementOffset} from '../gpu-primitives/graph-data-view-utils';
 import {
   GEOSPATIAL_WORKGROUP_SIZE,
-  PRECISE_DISTANCE_WGSL,
   RAW_POINT_WGSL,
   addGeospatialPass,
   assertGraphOwnership,
@@ -20,6 +19,18 @@ import {
   validateDisjointGeospatialViews,
   validateRowView
 } from './geospatial-utils';
+
+const PRECISE_PREDICATE_WGSL = /* wgsl */ `
+fn geospatial_max_abs_fp64(first: vec2f, second: vec2f) -> f32 {
+  let normalizedFirst = normalize_fp64(first);
+  let normalizedSecond = normalize_fp64(second);
+  return max(abs(normalizedFirst.x), abs(normalizedSecond.x));
+}
+
+fn geospatial_div_fp64_f32(value: vec2f, divisor: f32) -> vec2f {
+  return normalize_fp64(vec2f(value.x / divisor, value.y / divisor));
+}
+`;
 
 /** Numeric values written by {@link GPUPairwisePointInPolygon}. */
 export const GPU_POINT_IN_POLYGON_CLASSIFICATION = {
@@ -162,7 +173,7 @@ export class GPUPairwisePointInPolygon implements GPUCommandGraphContributor {
     const raw = this.points.format === 'uint32x4';
     const source = /* wgsl */ `
 ${raw ? RAW_POINT_WGSL : ''}
-${PRECISE_DISTANCE_WGSL}
+${PRECISE_PREDICATE_WGSL}
 const OUTSIDE: u32 = ${GPU_POINT_IN_POLYGON_CLASSIFICATION.outside}u;
 const INSIDE: u32 = ${GPU_POINT_IN_POLYGON_CLASSIFICATION.inside}u;
 const BOUNDARY: u32 = ${GPU_POINT_IN_POLYGON_CLASSIFICATION.boundary}u;
@@ -214,7 +225,8 @@ fn main(
         classifications: this.output
       },
       dispatchLayout,
-      precise: true
+      precise: true,
+      fp64Profile: raw ? 'predicate-raw' : 'predicate-f32'
     });
   }
 }
@@ -234,8 +246,8 @@ function makePredicateHelpers(
   let deltaY = sub_fp64u32_to_fp64(vertex.y, point.y);`
     : `let exactZeroX = vertex.x == point.x;
   let exactZeroY = vertex.y == point.y;
-  let deltaX = sub_fp64(vec2f(vertex.x, 0.0), vec2f(point.x, 0.0));
-  let deltaY = sub_fp64(vec2f(vertex.y, 0.0), vec2f(point.y, 0.0));`;
+  let deltaX = twoSub(vertex.x, point.x);
+  let deltaY = twoSub(vertex.y, point.y);`;
   const rawHelpers = raw
     ? `fn rawScalarEqual(first: vec2u, second: vec2u) -> bool {
   let firstDecoded = fp64_decode_bits(first);

--- a/modules/experimental/src/geospatial/gpu-pairwise-point-in-polygon.ts
+++ b/modules/experimental/src/geospatial/gpu-pairwise-point-in-polygon.ts
@@ -21,14 +21,32 @@ import {
 } from './geospatial-utils';
 
 const PRECISE_PREDICATE_WGSL = /* wgsl */ `
+// Predicate arithmetic produces normalized high/low pairs. Keep these helpers
+// on that narrower contract so software backends do not repeatedly compile the
+// generic arbitrary-limb normalizer into every sign and finite check.
 fn geospatial_max_abs_fp64(first: vec2f, second: vec2f) -> f32 {
-  let normalizedFirst = normalize_fp64(first);
-  let normalizedSecond = normalize_fp64(second);
-  return max(abs(normalizedFirst.x), abs(normalizedSecond.x));
+  return max(abs(first.x), abs(second.x));
 }
 
 fn geospatial_div_fp64_f32(value: vec2f, divisor: f32) -> vec2f {
-  return normalize_fp64(vec2f(value.x / divisor, value.y / divisor));
+  return twoSum(value.x / divisor, value.y / divisor);
+}
+
+fn geospatial_is_finite_normalized_fp64(value: vec2f) -> bool {
+  let highMagnitude = bitcast<u32>(value.x) & 0x7fffffffu;
+  let lowMagnitude = bitcast<u32>(value.y) & 0x7fffffffu;
+  return highMagnitude < 0x7f800000u && lowMagnitude < 0x7f800000u;
+}
+
+fn geospatial_sign_normalized_fp64(value: vec2f) -> i32 {
+  let highBits = bitcast<u32>(value.x);
+  let lowBits = bitcast<u32>(value.y);
+  let highMagnitude = highBits & 0x7fffffffu;
+  let lowMagnitude = lowBits & 0x7fffffffu;
+  if (highMagnitude > 0x7f800000u || lowMagnitude > 0x7f800000u) { return 0; }
+  if (highMagnitude != 0u) { return select(1, -1, (highBits >> 31u) == 1u); }
+  if (lowMagnitude != 0u) { return select(1, -1, (lowBits >> 31u) == 1u); }
+  return 0;
 }
 `;
 
@@ -303,10 +321,12 @@ fn pointIsFinite(point: ${pointType}) -> bool {
 
 fn makeRelativePoint(vertex: ${pointType}, point: ${pointType}) -> RelativePoint {
   ${relativePoint}
-  let finite = is_finite_fp64(deltaX) && is_finite_fp64(deltaY);
+  let finite =
+    geospatial_is_finite_normalized_fp64(deltaX) &&
+    geospatial_is_finite_normalized_fp64(deltaY);
   let underresolved =
-    (!exactZeroX && sign_fp64(deltaX) == 0) ||
-    (!exactZeroY && sign_fp64(deltaY) == 0);
+    (!exactZeroX && geospatial_sign_normalized_fp64(deltaX) == 0) ||
+    (!exactZeroY && geospatial_sign_normalized_fp64(deltaY) == 0);
   return RelativePoint(deltaX, deltaY, finite, exactZeroX, exactZeroY, underresolved);
 }
 
@@ -319,8 +339,8 @@ fn readRelativePoint(vertexIndex: u32, point: ${pointType}) -> RelativePoint {
 }
 
 fn bracketsZero(first: vec2f, second: vec2f) -> bool {
-  let firstSign = sign_fp64(first);
-  let secondSign = sign_fp64(second);
+  let firstSign = geospatial_sign_normalized_fp64(first);
+  let secondSign = geospatial_sign_normalized_fp64(second);
   return firstSign == 0 || secondSign == 0 || firstSign != secondSign;
 }
 
@@ -345,22 +365,30 @@ fn getOrientation(start: RelativePoint, end: RelativePoint) -> Orientation {
   let approximateCross = approximateFirst - approximateSecond;
   let errorBound =
     (abs(approximateFirst) + abs(approximateSecond)) * 9.5367431640625e-7;
-  let orientationSign = sign_fp64(crossProduct);
+  let orientationSign = geospatial_sign_normalized_fp64(crossProduct);
   let nearErrorBound = orientationSign != 0 && abs(approximateCross) <= errorBound;
   let underresolved =
-    (sign_fp64(start.x) != 0 && sign_fp64(startX) == 0) ||
-    (sign_fp64(start.y) != 0 && sign_fp64(startY) == 0) ||
-    (sign_fp64(end.x) != 0 && sign_fp64(endX) == 0) ||
-    (sign_fp64(end.y) != 0 && sign_fp64(endY) == 0) ||
-    (sign_fp64(startX) != 0 && sign_fp64(endY) != 0 && sign_fp64(firstProduct) == 0) ||
-    (sign_fp64(startY) != 0 && sign_fp64(endX) != 0 && sign_fp64(secondProduct) == 0);
+    (geospatial_sign_normalized_fp64(start.x) != 0 &&
+      geospatial_sign_normalized_fp64(startX) == 0) ||
+    (geospatial_sign_normalized_fp64(start.y) != 0 &&
+      geospatial_sign_normalized_fp64(startY) == 0) ||
+    (geospatial_sign_normalized_fp64(end.x) != 0 &&
+      geospatial_sign_normalized_fp64(endX) == 0) ||
+    (geospatial_sign_normalized_fp64(end.y) != 0 &&
+      geospatial_sign_normalized_fp64(endY) == 0) ||
+    (geospatial_sign_normalized_fp64(startX) != 0 &&
+      geospatial_sign_normalized_fp64(endY) != 0 &&
+      geospatial_sign_normalized_fp64(firstProduct) == 0) ||
+    (geospatial_sign_normalized_fp64(startY) != 0 &&
+      geospatial_sign_normalized_fp64(endX) != 0 &&
+      geospatial_sign_normalized_fp64(secondProduct) == 0);
   return Orientation(
     orientationSign,
     underresolved ||
       nearErrorBound ||
-      !is_finite_fp64(firstProduct) ||
-      !is_finite_fp64(secondProduct) ||
-      !is_finite_fp64(crossProduct)
+      !geospatial_is_finite_normalized_fp64(firstProduct) ||
+      !geospatial_is_finite_normalized_fp64(secondProduct) ||
+      !geospatial_is_finite_normalized_fp64(crossProduct)
   );
 }
 
@@ -400,8 +428,8 @@ fn classifyEdge(start: RelativePoint, end: RelativePoint) -> EdgeClassification 
   if (startIsPoint || endIsPoint) {
     return EdgeClassification(false, true, false);
   }
-  let startYSign = sign_fp64(start.y);
-  let endYSign = sign_fp64(end.y);
+  let startYSign = geospatial_sign_normalized_fp64(start.y);
+  let endYSign = geospatial_sign_normalized_fp64(end.y);
   let upward = startYSign <= 0 && endYSign > 0;
   let downward = endYSign <= 0 && startYSign > 0;
   let straddlesY = upward || downward;

--- a/modules/experimental/test/geospatial/gpu-pairwise-point-in-polygon.spec.ts
+++ b/modules/experimental/test/geospatial/gpu-pairwise-point-in-polygon.spec.ts
@@ -250,6 +250,14 @@ test('GPUPairwisePointInPolygon classifies f32 polygons and malformed inputs', a
     /output and points must not overlap/
   );
 
+  if (isSoftwareBackedDevice(device)) {
+    // SwiftShader still exceeds the 60-second test budget after predicate-only source specialization.
+    tapeTest.comment('Skipping precise f32 point-in-polygon execution on software WebGPU');
+    for (const buffer of Object.values(buffers)) buffer.destroy();
+    tapeTest.end();
+    return;
+  }
+
   const compiled = graph.compile();
   encode(device, compiled);
   const classifications = await readUint32(buffers.output, points.length);

--- a/modules/experimental/test/geospatial/gpu-pairwise-point-in-polygon.spec.ts
+++ b/modules/experimental/test/geospatial/gpu-pairwise-point-in-polygon.spec.ts
@@ -250,14 +250,6 @@ test('GPUPairwisePointInPolygon classifies f32 polygons and malformed inputs', a
     /output and points must not overlap/
   );
 
-  if (isSoftwareBackedDevice(device)) {
-    // SwiftShader spends more than 100 seconds compiling integer-fp64, then loses the GPU device.
-    tapeTest.comment('Skipping precise f32 point-in-polygon execution on software WebGPU');
-    for (const buffer of Object.values(buffers)) buffer.destroy();
-    tapeTest.end();
-    return;
-  }
-
   const compiled = graph.compile();
   encode(device, compiled);
   const classifications = await readUint32(buffers.output, points.length);

--- a/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl-integer.ts
+++ b/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl-integer.ts
@@ -234,6 +234,7 @@ fn fp64_round_mul_integer(a: f32, b: f32) -> f32 {
   return fp64_two_prod_integer(a, b).x;
 }
 
+#ifndef LUMA_FP64_PREDICATE_ONLY
 fn fp64_f32_finite_exponent(value: Fp64F32Bits) -> i32 {
   let mostSignificantBit = 31u - countLeadingZeros(value.significand);
   return value.baseExponent + i32(mostSignificantBit);
@@ -287,6 +288,7 @@ fn fp64_divide_f32_integer(aValue: f32, bValue: f32) -> f32 {
   );
   return bitcast<f32>(quotientBits);
 }
+#endif
 
 fn split(a: f32) -> vec2f {
   let aBits = bitcast<u32>(a);
@@ -382,6 +384,7 @@ fn mul_fp64(a: vec2f, b: vec2f) -> vec2f {
   return fp64_two_sum_integer(product.x, product.y);
 }
 
+#ifndef LUMA_FP64_PREDICATE_ONLY
 fn fp64_scale_fp64_integer(value: vec2f, exponent: i32) -> vec2f {
   let high = fp64_scale_f32_integer(value.x, exponent);
   let low = fp64_scale_f32_integer(value.y, exponent);
@@ -451,4 +454,5 @@ fn sqrt_fp64(a: vec2f) -> vec2f {
   let normalizedRoot = fp64_sqrt_fp64_normalized(normalizedA);
   return fp64_scale_fp64_integer(normalizedRoot, evenExponent / 2);
 }
+#endif
 `;

--- a/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl-integer.ts
+++ b/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl-integer.ts
@@ -290,6 +290,7 @@ fn fp64_divide_f32_integer(aValue: f32, bValue: f32) -> f32 {
 }
 #endif
 
+#ifndef LUMA_FP64_PREDICATE_ONLY
 fn split(a: f32) -> vec2f {
   let aBits = bitcast<u32>(a);
   let decoded = fp64_decode_f32_bits(aBits);
@@ -334,10 +335,13 @@ fn split2(a: vec2f) -> vec2f {
   result.y = fp64_round_add_integer(result.y, a.y);
   return result;
 }
+#endif
 
+#ifndef LUMA_FP64_PREDICATE_ONLY
 fn quickTwoSum(a: f32, b: f32) -> vec2f {
   return fp64_two_sum_integer(a, b);
 }
+#endif
 
 fn twoSum(a: f32, b: f32) -> vec2f {
   return fp64_two_sum_integer(a, b);
@@ -349,6 +353,7 @@ fn twoSub(a: f32, b: f32) -> vec2f {
   return vec2f(bitcast<f32>(resultBits.x), bitcast<f32>(resultBits.y));
 }
 
+#ifndef LUMA_FP64_PREDICATE_ONLY
 fn twoSqr(a: f32) -> vec2f {
   return fp64_two_prod_integer(a, a);
 }
@@ -356,6 +361,7 @@ fn twoSqr(a: f32) -> vec2f {
 fn twoProd(a: f32, b: f32) -> vec2f {
   return fp64_two_prod_integer(a, b);
 }
+#endif
 
 fn sum_fp64(a: vec2f, b: vec2f) -> vec2f {
   var sum = fp64_two_sum_integer(a.x, b.x);

--- a/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl.ts
+++ b/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl.ts
@@ -13,6 +13,7 @@ struct Fp64ArithmeticUniforms {
 
 @group(0) @binding(auto) var<uniform> fp64arithmetic : Fp64ArithmeticUniforms;
 
+#ifndef LUMA_FP64_F32_INPUT_ONLY
 struct Fp64Bits {
   sign: u32,
   exponent: i32,
@@ -21,6 +22,7 @@ struct Fp64Bits {
   isInf: bool,
   isNan: bool,
 };
+#endif
 
 fn fp64_nan(seed: f32) -> f32 {
   let nanBits = 0x7fc00000u | select(0u, 1u, seed < 0.0);
@@ -204,6 +206,7 @@ fn fp64_make_f32_bits_from_u64(sign: u32, significand: vec2u, baseExponent: i32)
   return (sign << 31u) | mantissa;
 }
 
+#ifndef LUMA_FP64_F32_INPUT_ONLY
 fn fp64_decode_bits(bits: vec2u) -> Fp64Bits {
   let sign = bits.x >> 31u;
   let exponentBits = (bits.x >> 20u) & 0x7ffu;
@@ -230,6 +233,7 @@ fn fp64_finite_magnitude_compare(a: Fp64Bits, b: Fp64Bits) -> i32 {
   }
   return fp64_u64_compare(a.significand, b.significand);
 }
+#endif
 
 struct Fp64RawF32Bits {
   sign: u32,
@@ -337,6 +341,7 @@ fn fp64_split_raw_accumulator_bits(
   return vec2u(highBits, lowBits);
 }
 
+#ifndef LUMA_FP64_F32_INPUT_ONLY
 // Round an arithmetic accumulator to binary64 before splitting it. The
 // aligned add/subtract paths retain three guard bits plus a sticky bit, which
 // is sufficient for round-to-nearest-even at the binary64 boundary.
@@ -376,6 +381,7 @@ fn fp64_split_binary64_accumulator_bits(
   }
   return fp64_split_raw_accumulator_bits(sign, roundedMagnitude, roundedBaseExponent);
 }
+#endif
 
 fn fp64_add_raw_f32_bits(aBits: u32, bBits: u32) -> vec2u {
   let a = fp64_decode_raw_f32_bits(aBits);
@@ -442,6 +448,7 @@ fn fp64_add_raw_f32_bits(aBits: u32, bBits: u32) -> vec2u {
   );
 }
 
+#ifndef LUMA_FP64_F32_INPUT_ONLY
 fn fp64_add_aligned_magnitudes_to_fp64_bits(
   sign: u32,
   larger: Fp64Bits,
@@ -595,6 +602,7 @@ fn sub_fp64u32_to_fp64(aBits: vec2u, bBits: vec2u) -> vec2f {
   let resultBits = sub_fp64u32_to_fp64_bits(aBits, bBits);
   return vec2f(bitcast<f32>(resultBits.x), bitcast<f32>(resultBits.y));
 }
+#endif
 
 fn fp64_runtime_zero() -> f32 {
   return fp64arithmetic.ONE * 0.0;
@@ -761,6 +769,7 @@ fn mul_fp64(a: vec2f, b: vec2f) -> vec2f {
   return prod;
 }
 
+#ifndef LUMA_FP64_PREDICATE_ONLY
 fn div_fp64(a: vec2f, b: vec2f) -> vec2f {
   let xn = prevent_fp64_optimization(1.0 / b.x);
   let yn = mul_fp64(a, vec2f(xn, fp64_runtime_zero()));
@@ -793,6 +802,7 @@ fn sqrt_fp64(a: vec2f) -> vec2f {
   return sum_fp64(vec2f(yn, 0.0), prod);
 #endif
 }
+#endif
 #endif
 
 fn fp64_f32_bits_is_nan(bits: u32) -> bool {

--- a/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl.ts
+++ b/modules/shadertools/src/modules/math/fp64/fp64-arithmetic-wgsl.ts
@@ -24,10 +24,12 @@ struct Fp64Bits {
 };
 #endif
 
+#ifndef LUMA_FP64_PREDICATE_ONLY
 fn fp64_nan(seed: f32) -> f32 {
   let nanBits = 0x7fc00000u | select(0u, 1u, seed < 0.0);
   return bitcast<f32>(nanBits);
 }
+#endif
 
 fn fp64_u64_is_zero(value: vec2u) -> bool {
   return value.x == 0u && value.y == 0u;
@@ -115,6 +117,7 @@ fn fp64_u64_has_bits_below(value: vec2u, bitCount: u32) -> bool {
   return (value.y & lowMask) != 0u;
 }
 
+#ifndef LUMA_FP64_F32_INPUT_ONLY
 fn fp64_u64_shift_right_sticky(value: vec2u, shift: u32) -> vec2u {
   var shifted = fp64_u64_shift_right(value, shift);
   if (fp64_u64_has_bits_below(value, shift)) {
@@ -122,6 +125,7 @@ fn fp64_u64_shift_right_sticky(value: vec2u, shift: u32) -> vec2u {
   }
   return shifted;
 }
+#endif
 
 fn fp64_u64_count_leading_zeros(value: vec2u) -> u32 {
   if (value.x != 0u) {
@@ -145,6 +149,7 @@ fn fp64_round_shift_right_to_u32(value: vec2u, shift: u32) -> u32 {
   return rounded;
 }
 
+#ifndef LUMA_FP64_F32_INPUT_ONLY
 fn fp64_round_shift_right(value: vec2u, shift: u32) -> vec2u {
   if (shift == 0u) {
     return value;
@@ -158,6 +163,7 @@ fn fp64_round_shift_right(value: vec2u, shift: u32) -> vec2u {
   }
   return rounded;
 }
+#endif
 
 fn fp64_make_f32_bits_from_u64(sign: u32, significand: vec2u, baseExponent: i32) -> u32 {
   if (fp64_u64_is_zero(significand)) {
@@ -235,6 +241,7 @@ fn fp64_finite_magnitude_compare(a: Fp64Bits, b: Fp64Bits) -> i32 {
 }
 #endif
 
+#ifndef LUMA_FP64_F32_INPUT_ONLY
 struct Fp64RawF32Bits {
   sign: u32,
   baseExponent: i32,
@@ -340,6 +347,7 @@ fn fp64_split_raw_accumulator_bits(
   }
   return vec2u(highBits, lowBits);
 }
+#endif
 
 #ifndef LUMA_FP64_F32_INPUT_ONLY
 // Round an arithmetic accumulator to binary64 before splitting it. The
@@ -383,6 +391,7 @@ fn fp64_split_binary64_accumulator_bits(
 }
 #endif
 
+#ifndef LUMA_FP64_PREDICATE_ONLY
 fn fp64_add_raw_f32_bits(aBits: u32, bBits: u32) -> vec2u {
   let a = fp64_decode_raw_f32_bits(aBits);
   let b = fp64_decode_raw_f32_bits(bBits);
@@ -447,6 +456,7 @@ fn fp64_add_raw_f32_bits(aBits: u32, bBits: u32) -> vec2u {
     commonBaseExponent
   );
 }
+#endif
 
 #ifndef LUMA_FP64_F32_INPUT_ONLY
 fn fp64_add_aligned_magnitudes_to_fp64_bits(
@@ -604,6 +614,7 @@ fn sub_fp64u32_to_fp64(aBits: vec2u, bBits: vec2u) -> vec2f {
 }
 #endif
 
+#ifndef LUMA_FP64_PREDICATE_ONLY
 fn fp64_runtime_zero() -> f32 {
   return fp64arithmetic.ONE * 0.0;
 }
@@ -615,6 +626,7 @@ fn prevent_fp64_optimization(value: f32) -> f32 {
   return value;
 #endif
 }
+#endif
 
 #ifdef LUMA_FP64_INTEGER_ARITHMETIC
 ${fp64arithmeticWGSLInteger}
@@ -805,6 +817,7 @@ fn sqrt_fp64(a: vec2f) -> vec2f {
 #endif
 #endif
 
+#ifndef LUMA_FP64_PREDICATE_ONLY
 fn fp64_f32_bits_is_nan(bits: u32) -> bool {
   return (bits & 0x7fffffffu) > 0x7f800000u;
 }
@@ -891,4 +904,5 @@ fn compare_fp64(a: vec2f, b: vec2f) -> i32 {
   }
   return fp64_compare_f32_bits(aLowBits, bLowBits);
 }
+#endif
 `;

--- a/modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.ts
@@ -21,6 +21,19 @@ const PLATFORM_INFO: PlatformInfo = {
 
 const FP64_INTEGER_MARKER = 'fn fp64_two_sum_integer_bits';
 const FP64_CLASSIC_MARKER = 'let splitValue = prevent_fp64_optimization';
+const FP64_PREDICATE_MARKERS = [
+  'fn twoSub',
+  'fn mul_fp64',
+  'fn sub_fp64',
+  'fn normalize_fp64',
+  'fn sign_fp64'
+] as const;
+const FP64_RAW_MARKERS = ['fn fp64_decode_bits', 'fn sub_fp64u32_to_fp64'] as const;
+const FP64_DISTANCE_MARKERS = [
+  'fn fp64_scale_fp64_integer',
+  'fn div_fp64',
+  'fn sqrt_fp64'
+] as const;
 
 const APP_WGSL = /* wgsl */ `\
 struct AppFrameUniforms {
@@ -80,6 +93,47 @@ test('assembleWGSLShader#selects optimizer-independent fp64 arithmetic', t => {
     disabledSource.includes(FP64_INTEGER_MARKER),
     'false override removes integer arithmetic'
   );
+
+  t.end();
+});
+
+test('assembleWGSLShader#specializes integer fp64 predicate sources', t => {
+  const shaderAssembler = new WGSLShaderAssembler();
+  const assemble = (defines: Record<string, boolean>) =>
+    shaderAssembler.assembleWGSLShader({
+      platformInfo: PLATFORM_INFO,
+      source: APP_WGSL,
+      modules: [fp64arithmetic],
+      defines
+    }).source;
+
+  const fullSource = assemble({LUMA_FP64_INTEGER_ARITHMETIC: true});
+  const predicateRawSource = assemble({
+    LUMA_FP64_INTEGER_ARITHMETIC: true,
+    LUMA_FP64_PREDICATE_ONLY: true
+  });
+  const predicateF32Source = assemble({
+    LUMA_FP64_INTEGER_ARITHMETIC: true,
+    LUMA_FP64_PREDICATE_ONLY: true,
+    LUMA_FP64_F32_INPUT_ONLY: true
+  });
+
+  for (const marker of [...FP64_PREDICATE_MARKERS, ...FP64_RAW_MARKERS, ...FP64_DISTANCE_MARKERS]) {
+    t.ok(fullSource.includes(marker), `full source retains ${marker}`);
+  }
+  for (const marker of FP64_PREDICATE_MARKERS) {
+    t.ok(predicateF32Source.includes(marker), `f32 predicate source retains ${marker}`);
+    t.ok(predicateRawSource.includes(marker), `raw predicate source retains ${marker}`);
+  }
+  for (const marker of [...FP64_RAW_MARKERS, ...FP64_DISTANCE_MARKERS]) {
+    t.notOk(predicateF32Source.includes(marker), `f32 predicate source omits ${marker}`);
+  }
+  for (const marker of FP64_RAW_MARKERS) {
+    t.ok(predicateRawSource.includes(marker), `raw predicate source retains ${marker}`);
+  }
+  for (const marker of FP64_DISTANCE_MARKERS) {
+    t.notOk(predicateRawSource.includes(marker), `raw predicate source omits ${marker}`);
+  }
 
   t.end();
 });

--- a/modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.ts
+++ b/modules/shadertools/test/lib/shader-assembly/assemble-wgsl-auto-bindings.spec.ts
@@ -21,12 +21,14 @@ const PLATFORM_INFO: PlatformInfo = {
 
 const FP64_INTEGER_MARKER = 'fn fp64_two_sum_integer_bits';
 const FP64_CLASSIC_MARKER = 'let splitValue = prevent_fp64_optimization';
-const FP64_PREDICATE_MARKERS = [
-  'fn twoSub',
-  'fn mul_fp64',
-  'fn sub_fp64',
+const FP64_PREDICATE_MARKERS = ['fn twoSum', 'fn twoSub', 'fn mul_fp64', 'fn sub_fp64'] as const;
+const FP64_GENERIC_VALUE_MARKERS = [
+  'fn fp64_add_raw_f32_bits',
   'fn normalize_fp64',
-  'fn sign_fp64'
+  'fn is_nan_fp64',
+  'fn is_finite_fp64',
+  'fn sign_fp64',
+  'fn compare_fp64'
 ] as const;
 const FP64_RAW_MARKERS = ['fn fp64_decode_bits', 'fn sub_fp64u32_to_fp64'] as const;
 const FP64_DISTANCE_MARKERS = [
@@ -118,7 +120,12 @@ test('assembleWGSLShader#specializes integer fp64 predicate sources', t => {
     LUMA_FP64_F32_INPUT_ONLY: true
   });
 
-  for (const marker of [...FP64_PREDICATE_MARKERS, ...FP64_RAW_MARKERS, ...FP64_DISTANCE_MARKERS]) {
+  for (const marker of [
+    ...FP64_PREDICATE_MARKERS,
+    ...FP64_GENERIC_VALUE_MARKERS,
+    ...FP64_RAW_MARKERS,
+    ...FP64_DISTANCE_MARKERS
+  ]) {
     t.ok(fullSource.includes(marker), `full source retains ${marker}`);
   }
   for (const marker of FP64_PREDICATE_MARKERS) {
@@ -134,6 +141,18 @@ test('assembleWGSLShader#specializes integer fp64 predicate sources', t => {
   for (const marker of FP64_DISTANCE_MARKERS) {
     t.notOk(predicateRawSource.includes(marker), `raw predicate source omits ${marker}`);
   }
+  for (const marker of FP64_GENERIC_VALUE_MARKERS) {
+    t.notOk(predicateF32Source.includes(marker), `f32 predicate source omits ${marker}`);
+    t.notOk(predicateRawSource.includes(marker), `raw predicate source omits ${marker}`);
+  }
+  t.ok(
+    predicateRawSource.length < fullSource.length * 0.8,
+    'raw predicate source stays at least 20% smaller than full fp64'
+  );
+  t.ok(
+    predicateF32Source.length < fullSource.length * 0.5,
+    'f32 predicate source stays at least 50% smaller than full fp64'
+  );
 
   t.end();
 });


### PR DESCRIPTION
## Goals

- Reduce the compile surface of the production precise point-in-polygon shader without weakening its forced integer double-single arithmetic or four-way classification semantics.
- Keep every non-PIP fp64 consumer on the unchanged full source profile.
- Preserve the existing software-adapter guard until SwiftShader can compile this kernel inside the repository's 60-second test budget.

## Changes

- Adds internal `full`, `predicate-raw`, and `predicate-f32` fp64 source profiles for precise geospatial passes.
- Predicate profiles retain exact `twoSum`, `twoSub`, multiplication, subtraction, and raw binary64 conversion where required.
- Omits division, square-root, distance, generic normalization/comparison, NaN/finite, and other unused value helpers from predicate-only sources.
- Uses PIP-local normalized-limb finite/sign checks and exact error-free `twoSub(a, b)` for f32 coordinate deltas.
- Keeps the software-WebGPU PIP execution guard; hardware adapters continue to execute the conformance path.
- Adds assembly tests proving required helpers remain, excluded helpers are absent, and the specialized sources stay materially smaller.

## Verification

- Default/classic and full-integer preprocessed outputs are byte-for-byte identical to the previous implementation.
- Raw predicate source: 29,636 → 22,994 characters (22.4% smaller).
- f32 predicate source: 22,260 → 12,029 characters (46.0% smaller).
- WGSL reflection parses the full, raw-predicate, and f32-predicate sources.
- Required-helper and source-size regression checks pass.
- Focused Biome formatting and `git diff --check` pass.
- Independent correctness review found no P0/P1/P2 issues or dangling preprocessor dependencies.
- A direct SwiftShader compile of the reduced f32 source still exceeded roughly 90 seconds and was stopped. The previous CI run timed out during pipeline compilation before shader execution; it did not report a wrong classification.
- Full repository checks are running in CI. Local immutable install remains blocked by approved-registry 403 responses for Playwright 1.62.1 and `@vis.gl/dev-tools@2.0.0-alpha.3`.

## Risk and follow-up

- Production precision and uncertainty behavior are unchanged.
- The specialization defines are internal and paired with integer arithmetic by the geospatial adapter.
- Enabling software-backed PIP conformance remains a follow-up compiler/cold-path task; this PR does not hide it with a longer timeout.
