### PR TITLE
feat(experimental): add graph inspector counters

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -424,21 +424,27 @@ if (encoding.canReadGPUTimings) {
   await observation.recordGPUTimings(encoding);
 }
 
+// The application remains responsible for any diagnostic-buffer readback.
+observation.recordCounters({candidates, matches});
+
 const snapshot = inspector.getSnapshot();
 observation.detach();
 ```
 
 `getSnapshot()` returns an immutable view of every registered graph in registration order. Each
 graph snapshot includes its compile-time `stats` and `capabilities`, encoding and failed-timing-read
-counts, bounded whole-graph CPU and GPU duration summaries, and per-node summaries in compiled
-schedule order. Duration summaries contain the retained sample count plus latest, p50, and p95
-milliseconds when samples exist. Pass `getNodeGroup` to the constructor to add application-specific
-semantic groups to node snapshots; pass `maxSamples` to bound each retained timing history.
+counts, bounded whole-graph CPU and GPU duration summaries, application-defined scalar counter
+summaries, and per-node summaries in compiled schedule order. Duration and counter summaries contain
+the retained sample count plus latest, p50, and p95 values. Counters remain in first-observed order.
+Pass `getNodeGroup` to the constructor to add application-specific semantic groups to node snapshots;
+pass `maxSamples` to bound every retained history.
 
 The inspector does not submit commands, poll frames, render a panel, or read GPU timestamps
 automatically. An observation does not own or destroy its graph. `detach()` stops that observation
 and removes its registration when it is still current; an old handle cannot remove a replacement
-with the same graph ID. A handle accepts timing reads only for encodings it produced and records at
-most one GPU sample per encoding. `clear()` removes all registrations. The lower-level
-`registerGraph()`, `recordEncoding()`, and `recordGPUTimings()` methods remain available for
-applications that cannot route graph encoding through an observation handle.
+with the same graph ID or publish delayed counters into it. A handle accepts timing reads only for
+encodings it produced and records at most one GPU sample per encoding. `recordCounters()` only
+stores caller-provided finite, non-negative values; it does not read a buffer or synchronize the
+device. `clear()` removes all registrations. The lower-level `registerGraph()`, `recordEncoding()`,
+`recordGPUTimings()`, and `recordCounters()` methods remain available for applications that cannot
+route graph activity through an observation handle.

--- a/examples/gpu-command-graph-inspector-panel.ts
+++ b/examples/gpu-command-graph-inspector-panel.ts
@@ -5,9 +5,19 @@
 import type {GPUCommandGraphInspectorSnapshot} from '@luma.gl/experimental';
 import {CompactDropdown} from './compact-dropdown';
 
+const STANDARD_COUNTER_FORMATTER = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1
+});
+const COMPACT_COUNTER_FORMATTER = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1
+});
+
 export type GPUCommandGraphInspectorPanelProps = {
   /** Optional human-readable graph names keyed by compiled graph ID. */
   graphLabels?: Readonly<Record<string, string>>;
+  /** Optional human-readable counter names keyed by application-defined counter ID. */
+  counterLabels?: Readonly<Record<string, string>>;
 };
 
 /**
@@ -19,6 +29,7 @@ export type GPUCommandGraphInspectorPanelProps = {
 export class GPUCommandGraphInspectorPanel {
   private readonly element: HTMLElement;
   private readonly graphLabels: Readonly<Record<string, string>>;
+  private readonly counterLabels: Readonly<Record<string, string>>;
   private snapshot: GPUCommandGraphInspectorSnapshot = {graphs: []};
   private selectedGraphId: string | null = null;
   private selectionIsManual = false;
@@ -28,6 +39,7 @@ export class GPUCommandGraphInspectorPanel {
   constructor(element: HTMLElement, props: GPUCommandGraphInspectorPanelProps = {}) {
     this.element = element;
     this.graphLabels = props.graphLabels ?? {};
+    this.counterLabels = props.counterLabels ?? {};
     this.element.innerHTML = `<div data-gpu-command-graph-inspector>
       <style>${GPU_COMMAND_GRAPH_INSPECTOR_CSS}</style>
       <span class="graph-inspector-empty" data-graph-inspector-empty>No graph activity recorded.</span>
@@ -40,6 +52,10 @@ export class GPUCommandGraphInspectorPanel {
           ${makeMetric('GPU samples', '', 'gpu-samples')}
         </div>
         <div class="graph-inspector-memory" data-graph-inspector-memory></div>
+        <div class="graph-inspector-counters" data-graph-inspector-counters hidden>
+          <div class="graph-inspector-counter graph-inspector-counter-header"><span>Sampled counter</span><strong>Latest</strong><strong>50/95</strong></div>
+          <div class="graph-inspector-counter-rows" data-graph-inspector-counter-rows></div>
+        </div>
         <div class="graph-inspector-node graph-inspector-node-header"><span>Node</span><strong>CPU 50/95</strong><strong>GPU 50/95</strong></div>
         <div class="graph-inspector-nodes" data-graph-inspector-nodes></div>
       </div>
@@ -125,6 +141,15 @@ export class GPUCommandGraphInspectorPanel {
         </div>`
       )
       .join('');
+    const counterRows = graph.counters
+      .map(
+        counter => `<div class="graph-inspector-counter" title="${escapeHtml(counter.id)} · ${counter.sampleCount} samples">
+          <span>${escapeHtml(this.getCounterLabel(counter.id))}</span>
+          <strong>${formatCounterValue(counter.latestValue)}</strong>
+          <strong>${formatCounterValue(counter.p50Value)} / ${formatCounterValue(counter.p95Value)}</strong>
+        </div>`
+      )
+      .join('');
     this.setText('encoding-count', String(graph.encodingCount));
     this.setText('cpu-totals', formatDurationPair(graph.totals.cpu));
     this.setText('gpu-totals', formatDurationPair(graph.totals.gpu));
@@ -138,6 +163,12 @@ export class GPUCommandGraphInspectorPanel {
       <span>${formatBytes(graph.stats.physicalTransientResourceBytes)} scratch</span>
       <span>${reusePercentage ? `${reusePercentage.toFixed(0)}% reuse` : 'no reuse'}</span>
       <span>${gpuSampleCount ? 'GPU timings sampled' : 'CPU timings only'}</span>`;
+    const countersElement = this.element.querySelector<HTMLElement>(
+      '[data-graph-inspector-counters]'
+    )!;
+    countersElement.hidden = graph.counters.length === 0;
+    this.element.querySelector<HTMLElement>('[data-graph-inspector-counter-rows]')!.innerHTML =
+      counterRows;
     this.element.querySelector<HTMLElement>('[data-graph-inspector-nodes]')!.innerHTML = rows;
   }
 
@@ -147,7 +178,11 @@ export class GPUCommandGraphInspectorPanel {
   }
 
   private getGraphLabel(graphId: string): string {
-    return this.graphLabels[graphId] ?? graphId;
+    return getOwnLabel(this.graphLabels, graphId);
+  }
+
+  private getCounterLabel(counterId: string): string {
+    return getOwnLabel(this.counterLabels, counterId);
   }
 }
 
@@ -198,6 +233,45 @@ const GPU_COMMAND_GRAPH_INSPECTOR_CSS = /* css */ `
     gap: 3px 8px;
     color: #7286a2;
     font: 8px/1.35 ui-monospace, monospace;
+  }
+  [data-gpu-command-graph-inspector] .graph-inspector-counters[hidden] { display: none; }
+  [data-gpu-command-graph-inspector] .graph-inspector-counter-rows {
+    max-height: 110px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+  }
+  [data-gpu-command-graph-inspector] .graph-inspector-counter {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 52px 66px;
+    align-items: center;
+    gap: 7px;
+    min-height: 22px;
+    border-bottom: 1px solid rgb(137 166 211 / 9%);
+    color: #b9c8dc;
+    font: 8px/1.25 ui-monospace, monospace;
+  }
+  [data-gpu-command-graph-inspector] .graph-inspector-counter > span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  [data-gpu-command-graph-inspector] .graph-inspector-counter strong {
+    color: #dce8f7;
+    font-weight: 600;
+    text-align: right;
+  }
+  [data-gpu-command-graph-inspector] .graph-inspector-counter-header {
+    min-height: 17px;
+    border-bottom-color: rgb(137 166 211 / 18%);
+    color: #7186a3;
+    font: 7px/1.2 system-ui, sans-serif;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+  }
+  [data-gpu-command-graph-inspector] .graph-inspector-counter-header strong {
+    color: #7186a3;
+    font-weight: 600;
   }
   [data-gpu-command-graph-inspector] .graph-inspector-node {
     display: grid;
@@ -266,11 +340,19 @@ function formatCompactMilliseconds(value: number): string {
   return value.toFixed(value < 1 ? 3 : 2);
 }
 
+function formatCounterValue(value: number): string {
+  return (value >= 10_000 ? COMPACT_COUNTER_FORMATTER : STANDARD_COUNTER_FORMATTER).format(value);
+}
+
 function formatBytes(value: number): string {
   if (value < 1024) return `${value} B`;
   if (value < 1024 ** 2) return `${(value / 1024).toFixed(1)} KiB`;
   if (value < 1024 ** 3) return `${(value / 1024 ** 2).toFixed(1)} MiB`;
   return `${(value / 1024 ** 3).toFixed(1)} GiB`;
+}
+
+function getOwnLabel(labels: Readonly<Record<string, string>>, id: string): string {
+  return Object.prototype.hasOwnProperty.call(labels, id) ? labels[id] : id;
 }
 
 function escapeHtml(value: string): string {

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph-inspector.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph-inspector.ts
@@ -47,6 +47,8 @@ export type GPUCommandGraphInspectorObservableGraph<
  * Route graph encodings through {@link GPUCommandGraphInspectorObservation.encode} to collect CPU
  * measurements without repeating graph IDs. GPU timestamp readback remains an explicit,
  * post-submission operation through {@link GPUCommandGraphInspectorObservation.recordGPUTimings}.
+ * Caller-read scalar counters can be published through
+ * {@link GPUCommandGraphInspectorObservation.recordCounters}.
  */
 export type GPUCommandGraphInspectorObservation<
   Parameters = void,
@@ -61,6 +63,8 @@ export type GPUCommandGraphInspectorObservation<
   ) => Encoding;
   /** Reads GPU timings once for an encoding produced by this handle, after caller submission. */
   readonly recordGPUTimings: (encoding: Encoding) => Promise<void>;
+  /** Records one sample for each named, caller-read scalar counter. */
+  readonly recordCounters: (counters: Readonly<Record<string, number>>) => void;
   /** Stops observing this graph without destroying or otherwise mutating it. */
   readonly detach: () => void;
 };
@@ -77,7 +81,7 @@ export type GPUCommandGraphInspectorNodeIdentity = {
 
 /** Configuration for a reusable command-graph inspector. */
 export type GPUCommandGraphInspectorProps = {
-  /** Maximum CPU and GPU duration samples retained for each total or node. Defaults to `120`. */
+  /** Maximum samples retained for each duration or scalar counter. Defaults to `120`. */
   maxSamples?: number;
   /** Optional application-specific group assigned when a node is first observed. */
   getNodeGroup?: (node: GPUCommandGraphInspectorNodeIdentity) => string | undefined;
@@ -93,6 +97,20 @@ export type GPUCommandGraphInspectorDurationSnapshot = {
   readonly p50Milliseconds?: number;
   /** Nearest-rank 95th percentile across retained samples. */
   readonly p95Milliseconds?: number;
+};
+
+/** Immutable bounded-sample summary for one named scalar counter. */
+export type GPUCommandGraphInspectorCounterSnapshot = {
+  /** Stable application-defined counter identifier. */
+  readonly id: string;
+  /** Number of retained samples. */
+  readonly sampleCount: number;
+  /** Most recently recorded value. */
+  readonly latestValue: number;
+  /** Nearest-rank 50th percentile across retained samples. */
+  readonly p50Value: number;
+  /** Nearest-rank 95th percentile across retained samples. */
+  readonly p95Value: number;
 };
 
 /** Immutable timing summary for one scheduled graph node. */
@@ -134,6 +152,8 @@ export type GPUCommandGraphInspectorGraphSnapshot = {
     readonly cpu: GPUCommandGraphInspectorDurationSnapshot;
     readonly gpu: GPUCommandGraphInspectorDurationSnapshot;
   };
+  /** Application-defined scalar counters in first-observed order. */
+  readonly counters: readonly GPUCommandGraphInspectorCounterSnapshot[];
   /** Per-node duration summaries in compiled schedule order. */
   readonly nodes: readonly GPUCommandGraphInspectorNodeSnapshot[];
 };
@@ -160,20 +180,21 @@ type GraphInspectionState = {
   timingReadFailureCount: number;
   cpuSamples: number[];
   gpuSamples: number[];
+  counters: Map<string, number[]>;
   nodes: Map<string, NodeInspectionState>;
 };
 
 const DEFAULT_MAX_SAMPLES = 120;
 
 /**
- * Collects bounded CPU and GPU timing histories for compiled command graphs.
+ * Collects bounded timing and caller-published scalar-counter histories for compiled graphs.
  *
  * The inspector has no DOM or submission responsibilities. {@link observeGraph} provides a
- * reusable encoding and timing lifecycle for executable graphs. The lower-level
- * {@link registerGraph}, {@link recordEncoding}, and {@link recordGPUTimings} methods remain
- * available when an application cannot route encoding through an observation handle. Registering
- * a new compiled graph with an existing ID replaces the old registration and resets its
- * measurements.
+ * reusable encoding, timing, and counter lifecycle for executable graphs. The lower-level
+ * {@link registerGraph}, {@link recordEncoding}, {@link recordGPUTimings}, and
+ * {@link recordCounters} methods remain available when an application cannot route activity
+ * through an observation handle. Registering a new compiled graph with an existing ID replaces
+ * the old registration and resets its measurements.
  */
 export class GPUCommandGraphInspector {
   private readonly maxSamples: number;
@@ -209,6 +230,7 @@ export class GPUCommandGraphInspector {
       timingReadFailureCount: 0,
       cpuSamples: [],
       gpuSamples: [],
+      counters: new Map(),
       nodes: new Map()
     });
   }
@@ -218,8 +240,9 @@ export class GPUCommandGraphInspector {
    *
    * The handle records CPU measurements for every encoding routed through `encode()`. Call its
    * `recordGPUTimings()` only after submitting the command buffer; repeated calls for one encoding
-   * coalesce into a single timing sample. Detaching removes this graph's registration only while it
-   * is still current, so an older handle cannot remove a replacement graph that uses the same ID.
+   * coalesce into a single timing sample. Caller-read diagnostics can be passed to
+   * `recordCounters()`. Detaching removes this graph's registration only while it is still current,
+   * so an older handle cannot remove or publish delayed counters into a same-ID replacement.
    */
   observeGraph<
     Parameters,
@@ -256,6 +279,11 @@ export class GPUCommandGraphInspector {
           await timingRead;
         }
       },
+      recordCounters: (counters: Readonly<Record<string, number>>): void => {
+        if (isCurrent()) {
+          this.recordGraphCounters(registration, counters);
+        }
+      },
       detach: (): void => {
         if (!attached) {
           return;
@@ -279,6 +307,11 @@ export class GPUCommandGraphInspector {
     this.recordGraphEncoding(graph, encoding);
   }
 
+  /** Records one sample for each named scalar counter on a registered graph. */
+  recordCounters(graphId: string, counters: Readonly<Record<string, number>>): void {
+    this.recordGraphCounters(this.getGraph(graphId), counters);
+  }
+
   private recordGraphEncoding(
     graph: GraphInspectionState,
     encoding: GPUCommandGraphInspectorEncoding
@@ -290,6 +323,28 @@ export class GPUCommandGraphInspector {
     for (const nodeStats of stats.nodes) {
       const node = this.getNode(graph, nodeStats);
       this.addSample(node.cpuSamples, nodeStats.cpuEncodeTimeMilliseconds);
+    }
+  }
+
+  private recordGraphCounters(
+    graph: GraphInspectionState,
+    counters: Readonly<Record<string, number>>
+  ): void {
+    const entries = Object.entries(counters);
+    for (const [id, value] of entries) {
+      if (!id || !Number.isFinite(value) || value < 0) {
+        throw new Error(
+          'GPUCommandGraphInspector counters require an ID and a finite, non-negative value'
+        );
+      }
+    }
+    for (const [id, value] of entries) {
+      let samples = graph.counters.get(id);
+      if (!samples) {
+        samples = [];
+        graph.counters.set(id, samples);
+      }
+      this.addSample(samples, value);
     }
   }
 
@@ -404,6 +459,9 @@ export class GPUCommandGraphInspector {
         gpu: summarizeSamples(node.gpuSamples)
       })
     );
+    const counters = Array.from(graph.counters, ([id, samples]) =>
+      summarizeCounterSamples(id, samples)
+    );
     return Object.freeze({
       id: graph.id,
       stats: graph.stats,
@@ -414,6 +472,7 @@ export class GPUCommandGraphInspector {
         cpu: summarizeSamples(graph.cpuSamples),
         gpu: summarizeSamples(graph.gpuSamples)
       }),
+      counters: Object.freeze(counters),
       nodes: Object.freeze(nodes)
     });
   }
@@ -433,6 +492,20 @@ function summarizeSamples(samples: readonly number[]): GPUCommandGraphInspectorD
     latestMilliseconds: samples[samples.length - 1],
     p50Milliseconds: getPercentile(sortedSamples, 0.5),
     p95Milliseconds: getPercentile(sortedSamples, 0.95)
+  });
+}
+
+function summarizeCounterSamples(
+  id: string,
+  samples: readonly number[]
+): GPUCommandGraphInspectorCounterSnapshot {
+  const sortedSamples = [...samples].sort((left, right) => left - right);
+  return Object.freeze({
+    id,
+    sampleCount: samples.length,
+    latestValue: samples[samples.length - 1],
+    p50Value: getPercentile(sortedSamples, 0.5),
+    p95Value: getPercentile(sortedSamples, 0.95)
   });
 }
 

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -52,6 +52,7 @@ export type {
 export type {GPUCommandGraphContributor} from './gpu-command-graph';
 export {GPUCommandGraphInspector} from './gpu-command-graph-inspector';
 export type {
+  GPUCommandGraphInspectorCounterSnapshot,
   GPUCommandGraphInspectorDurationSnapshot,
   GPUCommandGraphInspectorEncoding,
   GPUCommandGraphInspectorGraph,

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-inspector-types.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-inspector-types.node.spec.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {
+  GPUCommandGraphInspectorCounterSnapshot,
   GPUCommandGraphInspectorEncoding,
   GPUCommandGraphInspectorObservableGraph,
   GPUCommandGraphInspectorObservation
@@ -22,4 +23,13 @@ test('GPUCommandGraphInspector observations preserve strict parameter types', ()
   >().not.toMatchTypeOf<
     GPUCommandGraphInspectorObservation<unknown, GPUCommandGraphInspectorEncoding>
   >();
+  expectTypeOf<
+    GPUCommandGraphInspectorObservation<StrictParameters>['recordCounters']
+  >().toEqualTypeOf<(counters: Readonly<Record<string, number>>) => void>();
+  expectTypeOf<GPUCommandGraphInspectorCounterSnapshot>().toMatchTypeOf<{
+    readonly id: string;
+    readonly latestValue: number;
+    readonly p50Value: number;
+    readonly p95Value: number;
+  }>();
 });

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-inspector.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-inspector.node.spec.ts
@@ -108,6 +108,46 @@ test('GPUCommandGraphInspector summarizes bounded CPU and GPU samples', async te
   testCase.end();
 });
 
+test('GPUCommandGraphInspector summarizes bounded scalar counters', testCase => {
+  const inspector = new GPUCommandGraphInspector({maxSamples: 2});
+  inspector.registerGraph(makeGraph('counters'));
+  inspector.recordCounters('counters', {candidates: 30, intersectedCells: 3});
+  inspector.recordCounters('counters', {candidates: 10, intersectedCells: 1});
+  inspector.recordCounters('counters', {candidates: 20, intersectedCells: 2});
+
+  testCase.deepEqual(
+    inspector.getSnapshot().graphs[0].counters,
+    [
+      {
+        id: 'candidates',
+        sampleCount: 2,
+        latestValue: 20,
+        p50Value: 10,
+        p95Value: 20
+      },
+      {
+        id: 'intersectedCells',
+        sampleCount: 2,
+        latestValue: 2,
+        p50Value: 1,
+        p95Value: 2
+      }
+    ],
+    'retains bounded samples and preserves first-observed counter order'
+  );
+  testCase.throws(
+    () => inspector.recordCounters('counters', {valid: 1, invalid: Number.NaN}),
+    /finite, non-negative value/,
+    'rejects invalid counter batches'
+  );
+  testCase.equal(
+    inspector.getSnapshot().graphs[0].counters.length,
+    2,
+    'validates the complete batch before recording any sample'
+  );
+  testCase.end();
+});
+
 test('GPUCommandGraphInspector returns immutable snapshots and copied graph metadata', testCase => {
   const stats = {...GRAPH_STATS, nodeOrder: [...GRAPH_STATS.nodeOrder]};
   const capabilities = {...GRAPH_CAPABILITIES};
@@ -115,6 +155,7 @@ test('GPUCommandGraphInspector returns immutable snapshots and copied graph meta
   const inspector = new GPUCommandGraphInspector();
   inspector.registerGraph(graph);
   inspector.recordEncoding('immutable', makeEncoding(1, 0.25, 0.5));
+  inspector.recordCounters('immutable', {candidates: 12});
 
   stats.nodeOrder[0] = 'changed';
   capabilities.timestampQueries = false;
@@ -129,6 +170,8 @@ test('GPUCommandGraphInspector returns immutable snapshots and copied graph meta
   testCase.ok(Object.isFrozen(graphSnapshot.stats.nodeOrder), 'freezes compiled node order');
   testCase.ok(Object.isFrozen(graphSnapshot.totals), 'freezes graph totals');
   testCase.ok(Object.isFrozen(graphSnapshot.totals.cpu), 'freezes duration summaries');
+  testCase.ok(Object.isFrozen(graphSnapshot.counters), 'freezes the counter list');
+  testCase.ok(Object.isFrozen(graphSnapshot.counters[0]), 'freezes each counter summary');
   testCase.ok(Object.isFrozen(graphSnapshot.nodes), 'freezes the node list');
   testCase.ok(Object.isFrozen(graphSnapshot.nodes[0]), 'freezes each node summary');
   testCase.end();
@@ -177,12 +220,14 @@ test('GPUCommandGraphInspector observations isolate same-id replacement lifecycl
 
   oldObservation.detach();
   await oldObservation.recordGPUTimings(oldEncoding);
+  oldObservation.recordCounters({candidates: 99});
   oldObservation.encode(COMMAND_ENCODER, {
     parameters: {cpuTimeMilliseconds: 5, gpuTimeMilliseconds: 50}
   });
   currentObservation.encode(COMMAND_ENCODER, {
     parameters: {cpuTimeMilliseconds: 7, gpuTimeMilliseconds: 70}
   });
+  currentObservation.recordCounters({candidates: 7});
 
   const graph = inspector.getSnapshot().graphs[0];
   testCase.equal(graph.encodingCount, 1, 'an old handle cannot record into its replacement');
@@ -192,7 +237,13 @@ test('GPUCommandGraphInspector observations isolate same-id replacement lifecycl
     0,
     'an old handle cannot attach pending timings to its replacement'
   );
+  testCase.equal(
+    graph.counters[0].latestValue,
+    7,
+    'an old handle cannot publish delayed counters into its replacement'
+  );
   currentObservation.detach();
+  currentObservation.recordCounters({candidates: 70});
   testCase.deepEqual(
     inspector.getSnapshot().graphs,
     [],

--- a/test/examples/gpu-command-graph-inspector-panel.spec.ts
+++ b/test/examples/gpu-command-graph-inspector-panel.spec.ts
@@ -1,0 +1,91 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {
+  GPUCommandGraphInspector,
+  type GPUCommandGraphCapabilities,
+  type GPUCommandGraphStats
+} from '@luma.gl/experimental';
+import {GPUCommandGraphInspectorPanel} from '../../examples/gpu-command-graph-inspector-panel';
+
+const EMPTY_GRAPH_STATS: GPUCommandGraphStats = {
+  nodeOrder: [],
+  importedBufferCount: 0,
+  importedBufferBytes: 0,
+  logicalBufferCount: 0,
+  logicalBufferBytes: 0,
+  logicalTransientBufferCount: 0,
+  physicalTransientBufferCount: 0,
+  logicalTransientBytes: 0,
+  physicalTransientBytes: 0,
+  reusedTransientBytes: 0,
+  reusePercentage: 0,
+  importedTextureCount: 0,
+  importedTextureBytes: 0,
+  logicalTextureCount: 0,
+  logicalTextureBytes: 0,
+  logicalTransientTextureCount: 0,
+  physicalTransientTextureCount: 0,
+  logicalTransientTextureBytes: 0,
+  physicalTransientTextureBytes: 0,
+  reusedTransientTextureBytes: 0,
+  textureReusePercentage: 0,
+  logicalResourceBytes: 0,
+  physicalTransientResourceBytes: 0
+};
+
+const GRAPH_CAPABILITIES: GPUCommandGraphCapabilities = {
+  timestampQueries: false,
+  softwareAdapter: false,
+  maxBufferByteLength: 1_000_000,
+  maxStorageBufferBindingByteLength: 500_000,
+  maxComputeInvocationsPerWorkgroup: 256,
+  maxComputeWorkgroupsPerDimension: 65_535
+};
+
+describe('GPUCommandGraphInspectorPanel', () => {
+  test('safely renders hostile IDs inside a bounded counter scroller', () => {
+    const inspector = new GPUCommandGraphInspector();
+    for (const id of ['constructor', 'toString', '__proto__']) {
+      inspector.registerGraph({id, stats: EMPTY_GRAPH_STATS, capabilities: GRAPH_CAPABILITIES});
+    }
+    inspector.recordCounters(
+      'constructor',
+      Object.fromEntries([
+        ['constructor', 1],
+        ['toString', 2],
+        ['__proto__', 3],
+        ...Array.from({length: 24}, (_, index) => [`counter-${index}`, index + 4])
+      ])
+    );
+
+    const host = document.createElement('div');
+    document.body.append(host);
+    const panel = new GPUCommandGraphInspectorPanel(host);
+    try {
+      const snapshot = inspector.getSnapshot();
+      panel.update(snapshot, 'constructor');
+
+      const counterRows = host.querySelector<HTMLElement>('[data-graph-inspector-counter-rows]')!;
+      expect(host.textContent).toContain('constructor');
+      expect(counterRows.textContent).toContain('toString');
+      expect(counterRows.textContent).toContain('__proto__');
+      expect(counterRows.children).toHaveLength(27);
+      expect(getComputedStyle(counterRows).maxHeight).toBe('110px');
+      expect(getComputedStyle(counterRows).overflowY).toBe('auto');
+      expect(
+        counterRows.previousElementSibling?.classList.contains('graph-inspector-counter-header')
+      ).toBe(true);
+
+      panel.update(snapshot, 'toString');
+      expect(host.textContent).toContain('toString');
+      panel.update(snapshot, '__proto__');
+      expect(host.textContent).toContain('__proto__');
+    } finally {
+      panel.destroy();
+      host.remove();
+    }
+  });
+});


### PR DESCRIPTION
## Goals

- Make command-graph inspectors reusable for application-defined scalar diagnostics, not only CPU/GPU durations.
- Preserve the graph library's data-only boundary: callers retain ownership of readback, submission, and sampling cadence.
- Let the luSpatial taxi demo publish exact sampled candidate/cell counts in a follow-up without adding geospatial concepts to the inspector.

## Changes

- Adds bounded scalar-counter histories to `GPUCommandGraphInspector` and immutable counter snapshots with latest, p50, and p95 values.
- Supports both graph-ID publishing and observation-scoped publishing; detached or replaced same-ID observations cannot publish delayed samples.
- Validates complete counter batches atomically and preserves first-observed counter order.
- Exports and documents the public snapshot type and caller-owned readback contract.
- Extends the shared examples inspector panel with optional counter labels and a compact sampled-counter section.
- Uses own-property-safe label lookup for prototype-colliding IDs and bounds arbitrary counter cardinality in a fixed-header scroller.
- Adds node/type tests plus a headless panel smoke test covering hostile IDs and 27 counter rows.

## Verification

- Focused Biome formatting and error-level lint: passed.
- Experimental package TypeScript build with `tspc -b`: passed.
- Inspector node/type tests: 2 files, 9 tests passed.
- Headless Chromium panel smoke test: 1 passed.
- Focused panel/test TypeScript no-emit check: passed.
- `git diff --check`: passed.
- Two-pass independent review: no remaining P0/P1/P2 findings.
- `nvm use`: Node 22.22.1 selected.
- `yarn install`: current immutable install remains blocked locally by approved-registry 403s for the newly landed dev-tools/Playwright versions.
- Full `yarn build`, `yarn test`, `yarn lint fix`, `yarn website:build`, and `(cd website && yarn build)`: left to CI because this linked worktree cannot complete the current immutable install.

## Risks

- Counter values are intentionally application-defined and sampled; the inspector does not imply per-frame freshness.
- Histories are bounded by the existing `maxSamples` setting.
- Existing panel consumers see no counter section until they publish samples.
