### PR TITLE
test(showcase): validate Atlas EPT lifecycle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,6 +140,22 @@ jobs:
         run: |
           yarn test-node
 
+      - name: Run Billion-Point Spatial Atlas visual smoke
+        if: ${{ matrix.shard == 1 }}
+        env:
+          SPATIAL_ATLAS_REQUIRE_GPU_READBACK: 'true'
+          SPATIAL_ATLAS_SCREENSHOT: ${{ runner.temp }}/billion-point-spatial-atlas.png
+        run: yarn workspace luma.gl-examples-showcase-billion-point-spatial-atlas test:visual
+
+      - name: Upload Billion-Point Spatial Atlas visual smoke screenshot
+        if: ${{ always() && matrix.shard == 1 }}
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: billion-point-spatial-atlas-visual-smoke
+          path: ${{ runner.temp }}/billion-point-spatial-atlas*.png
+          if-no-files-found: warn
+          retention-days: 7
+
       - name: Sanitize lcov for Coveralls
         run: |
           node - <<'NODE'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,7 +146,6 @@ jobs:
       - name: Run Billion-Point Spatial Atlas visual smoke
         if: ${{ matrix.shard == 1 }}
         env:
-          SPATIAL_ATLAS_REQUIRE_GPU_READBACK: 'true'
           SPATIAL_ATLAS_SCREENSHOT: ${{ runner.temp }}/billion-point-spatial-atlas.png
         run: yarn workspace luma.gl-examples-showcase-billion-point-spatial-atlas test:visual
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,6 @@ jobs:
           key: ${{ runner.os }}-ms-playwright-${{ hashFiles('yarn.lock', 'package.json') }}
 
       - name: Install Playwright Chromium
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: yarn playwright:install
 
       - name: Reclaim install cache and report disk usage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,10 @@ jobs:
         run: |
           yarn test-node
 
+      - name: Install Spatial Atlas Playwright Chromium
+        if: ${{ matrix.shard == 1 }}
+        run: yarn workspace luma.gl-examples-showcase-billion-point-spatial-atlas exec playwright install chromium
+
       - name: Run Billion-Point Spatial Atlas visual smoke
         if: ${{ matrix.shard == 1 }}
         env:

--- a/examples/showcase/billion-point-spatial-atlas/app.ts
+++ b/examples/showcase/billion-point-spatial-atlas/app.ts
@@ -403,6 +403,9 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   private dataGenerationAbortController: AbortController | null = null;
   private modeTransitionGeneration = 0;
   private requestedMode: AtlasMode | null = null;
+  private resumeLidarLoadAfterModeTransition = false;
+  private resumeLidarPublishAfterModeTransition = false;
+  private modeTransitionFailed = false;
   private deviceLossMessage: string | null = null;
   private readonly gpuTimingReadbacks = new Set<Promise<void>>();
   private readonly gpuTimingReadbackTimers = new Set<ReturnType<typeof setTimeout>>();
@@ -506,7 +509,10 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     // Stop adding work while the benchmark drains the queue and reads its final counters.
     if (this.benchmarkFinishing) return;
     const deviceSize = device.getDefaultCanvasContext().getDevicePixelSize();
-    if (resources.width !== deviceSize[0] || resources.height !== deviceSize[1]) {
+    if (
+      !this.modeTransitionFailed &&
+      (resources.width !== deviceSize[0] || resources.height !== deviceSize[1])
+    ) {
       this.resizeResources(resources, Math.max(1, deviceSize[0]), Math.max(1, deviceSize[1]));
     }
 
@@ -634,6 +640,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     this.finalized = true;
     this.modeTransitionGeneration++;
     this.requestedMode = null;
+    this.clearModeTransitionResumeState();
     this.cancelScheduledGPUTimingReadbacks();
     this.dataGenerationAbortController?.abort();
     this.loadingOverlay?.remove();
@@ -666,6 +673,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
 
   /** Builds large deterministic fixtures between browser tasks so navigation stays responsive. */
   private async loadSyntheticDataset(mode: AtlasMode, pointCount: number): Promise<void> {
+    if (this.modeTransitionFailed || this.requestedMode !== null) return;
     this.dataGenerationAbortController?.abort();
     const generationController = new AbortController();
     this.dataGenerationAbortController = generationController;
@@ -1675,7 +1683,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   }
 
   private async loadLidar(): Promise<void> {
-    if (this.mode !== 'lidar' || this.requestedMode !== null) return;
+    if (this.mode !== 'lidar' || this.requestedMode !== null || this.modeTransitionFailed) return;
     if (this.lidarLoading) {
       this.lidarRefreshPending = true;
       return;
@@ -1766,6 +1774,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   private maybeRefreshLidarTiles(): void {
     if (
       this.mode !== 'lidar' ||
+      this.modeTransitionFailed ||
       !this.lidarTileSource ||
       !this.lidarTileCache ||
       this.lidarLoading ||
@@ -1784,7 +1793,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   }
 
   private scheduleLidarCachePublish(tileCache: GPULidarTileCache, immediate: boolean): void {
-    if (this.requestedMode !== null) return;
+    if (this.requestedMode !== null || this.modeTransitionFailed) return;
     if (immediate || performance.now() - this.lastLidarPublishTime >= 250) {
       this.publishLidarCache(tileCache);
       return;
@@ -1800,7 +1809,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     if (this.mode !== 'lidar' || this.lidarTileCache !== tileCache || tileCache.pointCount === 0) {
       return;
     }
-    if (this.requestedMode !== null) return;
+    if (this.requestedMode !== null || this.modeTransitionFailed) return;
     if (this.lidarPublishTimer) {
       clearTimeout(this.lidarPublishTimer);
       this.lidarPublishTimer = null;
@@ -1821,6 +1830,11 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     const canvas = this.canvas;
     if (!canvas) return;
     const transitionGeneration = ++this.modeTransitionGeneration;
+    this.resumeLidarLoadAfterModeTransition ||= this.mode === 'lidar' && this.lidarLoading;
+    this.resumeLidarPublishAfterModeTransition ||=
+      this.mode === 'lidar' && this.lidarPublishTimer !== null;
+    const resumeLidarLoad = this.resumeLidarLoadAfterModeTransition;
+    const resumeLidarPublish = this.resumeLidarPublishAfterModeTransition;
     this.requestedMode = mode;
     delete canvas.dataset.atlasDataReadyMode;
     delete canvas.dataset.atlasTransitionFailure;
@@ -1830,16 +1844,25 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     if (this.lidarPublishTimer) clearTimeout(this.lidarPublishTimer);
     this.lidarPublishTimer = null;
     this.lidarRefreshPending = false;
-    void this.completeModeSwitch(mode, transitionGeneration);
+    void this.completeModeSwitch(mode, transitionGeneration, resumeLidarLoad, resumeLidarPublish);
   }
 
-  private async completeModeSwitch(mode: AtlasMode, transitionGeneration: number): Promise<void> {
+  private async completeModeSwitch(
+    mode: AtlasMode,
+    transitionGeneration: number,
+    resumeLidarLoad: boolean,
+    resumeLidarPublish: boolean
+  ): Promise<void> {
     const canvas = this.canvas;
     if (!canvas) return;
     try {
       await this.waitForSubmittedGPUWork();
     } catch (error) {
       if (this.finalized || transitionGeneration !== this.modeTransitionGeneration) return;
+      // A failed drain cannot safely restart a producer that may replace GPU resources. Keep the
+      // current resources visible and report a terminal transition failure instead.
+      this.modeTransitionFailed = true;
+      this.clearModeTransitionResumeState();
       this.requestedMode = null;
       const message = error instanceof Error ? error.message : String(error);
       if (this.device.isLost) {
@@ -1855,18 +1878,13 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     }
 
     if (this.finalized || transitionGeneration !== this.modeTransitionGeneration) return;
+    this.modeTransitionFailed = false;
     if (this.mode === mode) {
-      this.requestedMode = null;
-      this.panels.setPanel(this.makePanel());
-      if (this.resources) {
-        canvas.dataset.atlasDataReadyMode = mode;
-        this.setStatus('');
-      } else {
-        void this.loadSyntheticDataset(mode, this.capacity);
-      }
-      this.updateInteractionPresentation();
+      this.completeSameModeTransition(resumeLidarLoad, resumeLidarPublish);
       return;
     }
+
+    this.clearModeTransitionResumeState();
 
     const previousTileCache = this.lidarTileCache;
     this.lidarTileCache = null;
@@ -1896,6 +1914,57 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     this.updateInteractionPresentation();
     this.requestedMode = null;
     void this.loadSyntheticDataset(mode, this.capacity);
+  }
+
+  private completeSameModeTransition(resumeLidarLoad: boolean, resumeLidarPublish: boolean): void {
+    const mode = this.mode;
+    const capacity = this.capacity;
+    const resources = this.resources;
+    const resourcesAreCurrent =
+      resources?.mode === mode &&
+      (resources.pointCount === capacity ||
+        (mode === 'lidar' &&
+          this.lidarTileCache !== null &&
+          resources.renderPositions === this.lidarTileCache.positionsBuffer));
+    if (!resourcesAreCurrent) {
+      this.destroyResources();
+      this.currentPositions = new Float32Array(0);
+      this.decodedPointCount = 0;
+      this.downloadedTileCount = 0;
+    }
+
+    this.clearModeTransitionResumeState();
+    this.requestedMode = null;
+    this.panels.setPanel(this.makePanel());
+    if (resourcesAreCurrent) {
+      if (this.canvas) this.canvas.dataset.atlasDataReadyMode = mode;
+      this.setStatus('');
+      if (resumeLidarPublish && this.lidarTileCache) {
+        this.scheduleLidarCachePublish(this.lidarTileCache, true);
+      }
+      if (resumeLidarLoad && mode === 'lidar') void this.loadLidar();
+    } else {
+      void this.loadSyntheticDataset(mode, capacity).then(() => {
+        if (
+          (resumeLidarLoad || resumeLidarPublish) &&
+          this.mode === 'lidar' &&
+          this.requestedMode === null &&
+          this.capacity === capacity &&
+          this.resources?.mode === 'lidar'
+        ) {
+          if (resumeLidarPublish && this.lidarTileCache) {
+            this.scheduleLidarCachePublish(this.lidarTileCache, true);
+          }
+          if (resumeLidarLoad) void this.loadLidar();
+        }
+      });
+    }
+    this.updateInteractionPresentation();
+  }
+
+  private clearModeTransitionResumeState(): void {
+    this.resumeLidarLoadAfterModeTransition = false;
+    this.resumeLidarPublishAfterModeTransition = false;
   }
 
   private async waitForSubmittedGPUWork(): Promise<void> {
@@ -1955,7 +2024,10 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   }
 
   private changeCapacity(capacity: number): void {
-    if (this.requestedMode !== null) return;
+    if (this.requestedMode !== null || this.modeTransitionFailed) {
+      this.panels.setPanel(this.makePanel());
+      return;
+    }
     if (capacity === this.capacity) return;
     this.capacity = capacity;
     this.lidarLoadAbortController?.abort();

--- a/examples/showcase/billion-point-spatial-atlas/app.ts
+++ b/examples/showcase/billion-point-spatial-atlas/app.ts
@@ -649,6 +649,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     this.dataGenerationAbortController?.abort();
     const generationController = new AbortController();
     this.dataGenerationAbortController = generationController;
+    delete this.canvas.dataset.atlasDataReadyMode;
     this.mountLoadingOverlay(mode, pointCount);
     this.setStatus(
       `Preparing ${formatCount(pointCount)} GPU-resident points without blocking navigation…`
@@ -683,6 +684,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
       if (this.finalized || this.mode !== mode || this.capacity !== pointCount) return;
 
       this.rebuildResources(positions);
+      this.canvas.dataset.atlasDataReadyMode = mode;
       this.setStatus('');
       this.updateInteractionPresentation();
     } catch (error) {
@@ -803,23 +805,26 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     const cellCount = gridSize.reduce((product, value) => product * value, 1);
     const renderPositionsBuffer =
       borrowedRenderPositionsBuffer ??
-      this.device.createBuffer({
-        id: 'spatial-atlas-render-positions',
-        data: renderPositions,
-        usage: Buffer.STORAGE | Buffer.COPY_DST
-      });
-    const queryPositionsBuffer = this.device.createBuffer({
-      id: 'spatial-atlas-query-positions',
-      data: queryPositionValues,
-      usage: Buffer.STORAGE | Buffer.COPY_DST
-    });
+      createUploadedBuffer(
+        this.device,
+        'spatial-atlas-render-positions',
+        renderPositions,
+        Buffer.STORAGE
+      );
+    const queryPositionsBuffer = createUploadedBuffer(
+      this.device,
+      'spatial-atlas-query-positions',
+      queryPositionValues,
+      Buffer.STORAGE
+    );
     const pointAttributes =
       borrowedPointAttributesBuffer ??
-      this.device.createBuffer({
-        id: 'spatial-atlas-point-attributes',
-        data: pointAttributeValues ?? makePointAttributes(pointCount, this.mode),
-        usage: Buffer.STORAGE | Buffer.COPY_DST
-      });
+      createUploadedBuffer(
+        this.device,
+        'spatial-atlas-point-attributes',
+        pointAttributeValues ?? makePointAttributes(pointCount, this.mode),
+        Buffer.STORAGE
+      );
     const visibleIds = this.device.createBuffer({
       id: 'spatial-atlas-visible-ids',
       byteLength: Math.max(UINT32_BYTE_LENGTH, pointCount * UINT32_BYTE_LENGTH),
@@ -2842,6 +2847,21 @@ function getBoundsCenter(bounds: readonly [number, number, number, number]): [nu
 
 function importBuffer<Parameters>(graph: GPUCommandGraph<Parameters>, id: string, buffer: Buffer) {
   return graph.importBuffer({id, byteLength: buffer.byteLength, usage: buffer.usage}, buffer);
+}
+
+function createUploadedBuffer(
+  device: Device,
+  id: string,
+  data: ArrayBufferView,
+  usage: number
+): Buffer {
+  const buffer = device.createBuffer({
+    id,
+    byteLength: Math.max(UINT32_BYTE_LENGTH, data.byteLength),
+    usage: usage | Buffer.COPY_DST
+  });
+  if (data.byteLength > 0) buffer.write(data);
+  return buffer;
 }
 
 function makeQueryPositions(positions: Float32Array, dimension: 2 | 3): Float32Array {

--- a/examples/showcase/billion-point-spatial-atlas/app.ts
+++ b/examples/showcase/billion-point-spatial-atlas/app.ts
@@ -68,6 +68,7 @@ const ATLAS_GENERATION_CHUNK_SIZE = 20_000;
 const VISUAL_SMOKE_TAXI_GRID_SIZE = [16, 16] as const;
 const VISUAL_SMOKE_LIDAR_GRID_SIZE = [16, 16, 4] as const;
 const VISUAL_SMOKE_POINT_COUNT = 2_000;
+const GPU_TRANSITION_DRAIN_TIMEOUT_MILLISECONDS = 10_000;
 const IS_VISUAL_SMOKE =
   typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('visual-smoke');
 const MINIMUM_VIEW_SCALE = 0.35;
@@ -388,7 +389,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   private sampledMatchCount = 0;
   private sampledTotalMatchCount = 0;
   private sampledOverflow = false;
-  private countReadPending = false;
+  private countReadback: Promise<void> | null = null;
   private downloadedTileCount = 0;
   private decodedPointCount = 0;
   private lidarLoadAbortController: AbortController | null = null;
@@ -400,6 +401,11 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   private lastLidarRefreshTime = 0;
   private lidarPublishTimer: ReturnType<typeof setTimeout> | null = null;
   private dataGenerationAbortController: AbortController | null = null;
+  private modeTransitionGeneration = 0;
+  private requestedMode: AtlasMode | null = null;
+  private deviceLossMessage: string | null = null;
+  private readonly gpuTimingReadbacks = new Set<Promise<void>>();
+  private readonly gpuTimingReadbackTimers = new Set<ReturnType<typeof setTimeout>>();
   private loadingOverlay: HTMLDivElement | null = null;
   private lastQuerySignature: string | null = null;
   private finalized = false;
@@ -425,6 +431,9 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
       throw new Error('Billion-Point Spatial Atlas requires WebGPU');
     }
     this.device = device;
+    void device.lost.then(({message}) => {
+      if (!this.finalized) this.reportDeviceLoss(message);
+    });
     this.sceneColorFormat = getSceneColorFormat(device);
     const initialZone = makeTaxiZones().find(zone => zone.id === this.selectedZoneId);
     if (initialZone) {
@@ -489,6 +498,9 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     height,
     _mousePosition
   }: AnimationProps): void {
+    // Mode transitions stop encoding before taking a fence. This guarantees that every command
+    // referencing the current resource set is included in the fence before that set is destroyed.
+    if (this.requestedMode !== null) return;
     let resources = this.resources;
     if (!resources) return;
     // Stop adding work while the benchmark drains the queue and reads its final counters.
@@ -533,7 +545,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     ) {
       void this.sampleCounts(resources);
       if (encoding.canReadGPUTimings) {
-        setTimeout(() => void this.recordGPUTimings(graph.id, encoding), 0);
+        this.scheduleGPUTimingReadback(graph.id, encoding);
       }
     }
     this.postprocessingRenderer.encodeToScreen(device.commandEncoder, {
@@ -578,6 +590,9 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
 
   /** Reads the rendered scene texture without relying on browser compositor screenshots. */
   async captureVisualSmokeFrame(): Promise<SpatialAtlasVisualSmokeFrame> {
+    if (this.requestedMode !== null) {
+      throw new Error('Spatial Atlas visual smoke capture cannot run during a mode transition');
+    }
     const resources = this.resources;
     if (!IS_VISUAL_SMOKE || !resources) {
       throw new Error('Spatial Atlas visual smoke frame is unavailable');
@@ -617,6 +632,9 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
 
   override onFinalize(): void {
     this.finalized = true;
+    this.modeTransitionGeneration++;
+    this.requestedMode = null;
+    this.cancelScheduledGPUTimingReadbacks();
     this.dataGenerationAbortController?.abort();
     this.loadingOverlay?.remove();
     this.loadingOverlay = null;
@@ -953,7 +971,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     this.graphInspector.recordEncoding(buildGraph.id, encoding);
     this.device.submit(commandEncoder.finish());
     if (encoding.canReadGPUTimings) {
-      setTimeout(() => void this.recordGPUTimings(buildGraph.id, encoding), 0);
+      this.scheduleGPUTimingReadback(buildGraph.id, encoding);
     }
     this.sampledMatchCount = 0;
     this.sampledTotalMatchCount = 0;
@@ -1542,9 +1560,22 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     );
   }
 
-  private async sampleCounts(resources: AtlasResources): Promise<void> {
-    if (this.countReadPending) return;
-    this.countReadPending = true;
+  private sampleCounts(resources: AtlasResources): Promise<void> {
+    if (this.countReadback) return this.countReadback;
+    const countReadback = this.readSampleCounts(resources);
+    this.countReadback = countReadback;
+    void countReadback.then(
+      () => {
+        if (this.countReadback === countReadback) this.countReadback = null;
+      },
+      () => {
+        if (this.countReadback === countReadback) this.countReadback = null;
+      }
+    );
+    return countReadback;
+  }
+
+  private async readSampleCounts(resources: AtlasResources): Promise<void> {
     try {
       const [drawBytes, totalCountBytes, overflowBytes] = await Promise.all([
         resources.drawCommands.buffer.readAsync(),
@@ -1580,9 +1611,26 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
           `Counter readback unavailable: ${error instanceof Error ? error.message : String(error)}`
         );
       }
-    } finally {
-      this.countReadPending = false;
     }
+  }
+
+  private scheduleGPUTimingReadback(graphId: string, encoding: GPUCommandGraphEncoding): void {
+    const timer = setTimeout(() => {
+      this.gpuTimingReadbackTimers.delete(timer);
+      if (this.finalized || this.requestedMode !== null) return;
+      const readback = this.recordGPUTimings(graphId, encoding);
+      this.gpuTimingReadbacks.add(readback);
+      void readback.then(
+        () => this.gpuTimingReadbacks.delete(readback),
+        () => this.gpuTimingReadbacks.delete(readback)
+      );
+    }, 0);
+    this.gpuTimingReadbackTimers.add(timer);
+  }
+
+  private cancelScheduledGPUTimingReadbacks(): void {
+    for (const timer of this.gpuTimingReadbackTimers) clearTimeout(timer);
+    this.gpuTimingReadbackTimers.clear();
   }
 
   private async recordGPUTimings(
@@ -1627,7 +1675,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   }
 
   private async loadLidar(): Promise<void> {
-    if (this.mode !== 'lidar') return;
+    if (this.mode !== 'lidar' || this.requestedMode !== null) return;
     if (this.lidarLoading) {
       this.lidarRefreshPending = true;
       return;
@@ -1664,6 +1712,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
         refreshCenter,
         controller.signal
       );
+      controller.signal.throwIfAborted();
       const selectedKeys = new Set(selections.map(selection => selection.key));
       for (const selection of selections) {
         controller.signal.throwIfAborted();
@@ -1672,6 +1721,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
           continue;
         }
         const tile = await this.lidarTileSource.loadTile(selection, controller.signal);
+        controller.signal.throwIfAborted();
         this.downloadedTileCount++;
         this.decodedPointCount += tile.decodedPointCount;
         tileCache.insert(tile.key, tile.positions, tile.attributes);
@@ -1734,6 +1784,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   }
 
   private scheduleLidarCachePublish(tileCache: GPULidarTileCache, immediate: boolean): void {
+    if (this.requestedMode !== null) return;
     if (immediate || performance.now() - this.lastLidarPublishTime >= 250) {
       this.publishLidarCache(tileCache);
       return;
@@ -1749,6 +1800,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     if (this.mode !== 'lidar' || this.lidarTileCache !== tileCache || tileCache.pointCount === 0) {
       return;
     }
+    if (this.requestedMode !== null) return;
     if (this.lidarPublishTimer) {
       clearTimeout(this.lidarPublishTimer);
       this.lidarPublishTimer = null;
@@ -1765,9 +1817,57 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
   }
 
   private switchMode(mode: AtlasMode): void {
-    if (this.mode === mode) return;
+    if ((this.requestedMode ?? this.mode) === mode) return;
+    const canvas = this.canvas;
+    if (!canvas) return;
+    const transitionGeneration = ++this.modeTransitionGeneration;
+    this.requestedMode = mode;
+    delete canvas.dataset.atlasDataReadyMode;
+    delete canvas.dataset.atlasTransitionFailure;
+    this.setStatus(`Waiting for submitted GPU work before switching to ${mode}…`);
+    this.dataGenerationAbortController?.abort();
     this.lidarLoadAbortController?.abort();
     if (this.lidarPublishTimer) clearTimeout(this.lidarPublishTimer);
+    this.lidarPublishTimer = null;
+    this.lidarRefreshPending = false;
+    void this.completeModeSwitch(mode, transitionGeneration);
+  }
+
+  private async completeModeSwitch(mode: AtlasMode, transitionGeneration: number): Promise<void> {
+    const canvas = this.canvas;
+    if (!canvas) return;
+    try {
+      await this.waitForSubmittedGPUWork();
+    } catch (error) {
+      if (this.finalized || transitionGeneration !== this.modeTransitionGeneration) return;
+      this.requestedMode = null;
+      const message = error instanceof Error ? error.message : String(error);
+      if (this.device.isLost) {
+        this.reportDeviceLoss(this.deviceLossMessage ?? message);
+      } else {
+        canvas.dataset.atlasTransitionFailure = message;
+        this.panels.setPanel(this.makePanel());
+        this.setStatus(`GPU mode transition failed: ${message}`);
+        if (this.resources) canvas.dataset.atlasDataReadyMode = this.mode;
+        this.updateInteractionPresentation();
+      }
+      return;
+    }
+
+    if (this.finalized || transitionGeneration !== this.modeTransitionGeneration) return;
+    if (this.mode === mode) {
+      this.requestedMode = null;
+      this.panels.setPanel(this.makePanel());
+      if (this.resources) {
+        canvas.dataset.atlasDataReadyMode = mode;
+        this.setStatus('');
+      } else {
+        void this.loadSyntheticDataset(mode, this.capacity);
+      }
+      this.updateInteractionPresentation();
+      return;
+    }
+
     const previousTileCache = this.lidarTileCache;
     this.lidarTileCache = null;
     this.lidarTileSource = null;
@@ -1787,7 +1887,6 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     }
     this.queryRadius = mode === 'taxi' ? 0.4 : 0.32;
     this.resetView();
-    this.dataGenerationAbortController?.abort();
     this.destroyResources();
     this.currentPositions = new Float32Array(0);
     this.decodedPointCount = 0;
@@ -1795,10 +1894,68 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     previousTileCache?.destroy();
     this.panels.setPanel(this.makePanel());
     this.updateInteractionPresentation();
+    this.requestedMode = null;
     void this.loadSyntheticDataset(mode, this.capacity);
   }
 
+  private async waitForSubmittedGPUWork(): Promise<void> {
+    this.cancelScheduledGPUTimingReadbacks();
+    const pendingReadbacks = [...this.gpuTimingReadbacks];
+    if (this.countReadback) pendingReadbacks.push(this.countReadback);
+    await this.waitForGPUCompletion(
+      Promise.allSettled(pendingReadbacks).then(() => undefined),
+      'Pending Atlas GPU readbacks'
+    );
+
+    const fence = this.device.createFence();
+    try {
+      await this.waitForGPUCompletion(fence.signaled, 'Atlas GPU submission fence');
+    } finally {
+      fence.destroy();
+    }
+  }
+
+  private async waitForGPUCompletion(
+    completion: Promise<void>,
+    description: string
+  ): Promise<void> {
+    let timeoutIdentifier: ReturnType<typeof setTimeout> | null = null;
+    try {
+      const deviceLoss = await Promise.race([
+        completion.then(() => null),
+        this.device.lost,
+        new Promise<never>((_resolve, reject) => {
+          timeoutIdentifier = setTimeout(
+            () =>
+              reject(
+                new Error(`${description} exceeded ${GPU_TRANSITION_DRAIN_TIMEOUT_MILLISECONDS}ms`)
+              ),
+            GPU_TRANSITION_DRAIN_TIMEOUT_MILLISECONDS
+          );
+        })
+      ]);
+      if (deviceLoss || this.device.isLost) {
+        const message = deviceLoss?.message || this.deviceLossMessage || 'unknown reason';
+        throw new Error(`WebGPU device lost: ${message}`);
+      }
+    } finally {
+      if (timeoutIdentifier !== null) clearTimeout(timeoutIdentifier);
+    }
+  }
+
+  private reportDeviceLoss(message: string): void {
+    const detail = message.replace(/^WebGPU device lost:\s*/u, '').trim() || 'unknown reason';
+    this.deviceLossMessage = detail;
+    const status = `WebGPU device lost: ${detail}`;
+    if (this.canvas) {
+      this.canvas.dataset.atlasDeviceLost = detail;
+      this.canvas.dataset.atlasTransitionFailure = status;
+    }
+    this.setStatus(status);
+  }
+
   private changeCapacity(capacity: number): void {
+    if (this.requestedMode !== null) return;
     if (capacity === this.capacity) return;
     this.capacity = capacity;
     this.lidarLoadAbortController?.abort();

--- a/examples/showcase/billion-point-spatial-atlas/app.ts
+++ b/examples/showcase/billion-point-spatial-atlas/app.ts
@@ -65,6 +65,8 @@ const LIDAR_DOMAIN = [-1.25, -1.25, -0.25, 1.25, 1.25, 2.5] as const;
 const TAXI_GRID_SIZE = [128, 128] as const;
 const LIDAR_GRID_SIZE = [64, 64, 16] as const;
 const ATLAS_GENERATION_CHUNK_SIZE = 20_000;
+const VISUAL_SMOKE_TAXI_GRID_SIZE = [16, 16] as const;
+const VISUAL_SMOKE_LIDAR_GRID_SIZE = [16, 16, 4] as const;
 const VISUAL_SMOKE_POINT_COUNT = 2_000;
 const IS_VISUAL_SMOKE =
   typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('visual-smoke');
@@ -801,7 +803,14 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     const dimension: 2 | 3 = this.mode === 'taxi' ? 2 : 3;
     const queryPositionValues = makeQueryPositions(renderPositions, dimension);
     const domain = this.mode === 'taxi' ? TAXI_DOMAIN : LIDAR_DOMAIN;
-    const gridSize = this.mode === 'taxi' ? TAXI_GRID_SIZE : LIDAR_GRID_SIZE;
+    const gridSize =
+      this.mode === 'taxi'
+        ? IS_VISUAL_SMOKE
+          ? VISUAL_SMOKE_TAXI_GRID_SIZE
+          : TAXI_GRID_SIZE
+        : IS_VISUAL_SMOKE
+          ? VISUAL_SMOKE_LIDAR_GRID_SIZE
+          : LIDAR_GRID_SIZE;
     const cellCount = gridSize.reduce((product, value) => product * value, 1);
     const renderPositionsBuffer =
       borrowedRenderPositionsBuffer ??

--- a/examples/showcase/billion-point-spatial-atlas/app.ts
+++ b/examples/showcase/billion-point-spatial-atlas/app.ts
@@ -59,7 +59,6 @@ export const description =
   'Indexed WebGPU spatial queries over a 169M-row taxi atlas and the 4.8B-point NYC USGS LiDAR corpus.';
 
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
-const GPU_MAP_MODE_READ = 0x0001;
 const UNIFORM_BYTE_LENGTH = 96;
 const TAXI_DOMAIN = [-1.25, -1.25, 1.25, 1.25] as const;
 const LIDAR_DOMAIN = [-1.25, -1.25, -0.25, 1.25, 1.25, 2.5] as const;
@@ -595,26 +594,20 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     try {
       if (this.canvas) this.canvas.dataset.atlasCapturePhase = 'copy';
       sceneColor.readBuffer({x, y, width, height}, readbackBuffer);
-      const gpuBuffer = readbackBuffer.handle as GPUBuffer;
       if (this.canvas) this.canvas.dataset.atlasCapturePhase = 'map';
-      await gpuBuffer.mapAsync(GPU_MAP_MODE_READ, 0, layout.byteLength);
-      try {
-        const bytes = new Uint8Array(gpuBuffer.getMappedRange(0, layout.byteLength).slice(0));
-        if (this.canvas) this.canvas.dataset.atlasCapturePhase = 'encode';
-        const frame = makeVisualSmokeFrame(
-          bytes,
-          layout.bytesPerRow,
-          layout.bytesPerPixel,
-          width,
-          height,
-          this.sceneColorFormat,
-          this.mode
-        );
-        if (this.canvas) this.canvas.dataset.atlasCapturePhase = 'complete';
-        return frame;
-      } finally {
-        gpuBuffer.unmap();
-      }
+      const bytes = await readbackBuffer.readAsync(0, layout.byteLength);
+      if (this.canvas) this.canvas.dataset.atlasCapturePhase = 'encode';
+      const frame = makeVisualSmokeFrame(
+        bytes,
+        layout.bytesPerRow,
+        layout.bytesPerPixel,
+        width,
+        height,
+        this.sceneColorFormat,
+        this.mode
+      );
+      if (this.canvas) this.canvas.dataset.atlasCapturePhase = 'complete';
+      return frame;
     } finally {
       readbackBuffer.destroy();
     }

--- a/examples/showcase/billion-point-spatial-atlas/app.ts
+++ b/examples/showcase/billion-point-spatial-atlas/app.ts
@@ -2,51 +2,52 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, Texture, type Device, type RenderBundle} from '@luma.gl/core';
+import type {Panel} from '@deck.gl-community/panels';
+import {Buffer, type Device, type RenderBundle, Texture} from '@luma.gl/core';
 import {createBloomShaderPassPipeline, toneMapping} from '@luma.gl/effects';
 import type {AnimationProps} from '@luma.gl/engine';
 import {AnimationLoopTemplate, Model, ShaderPassRenderer} from '@luma.gl/engine';
 import {
-  decodeGPUIndexPickInfo,
+  type CompiledGPUCommandGraph,
   DrawCommandBuffer,
+  decodeGPUIndexPickInfo,
   GPUCommandGraph,
+  type GPUCommandGraphEncoding,
   GPUCommandGraphInspector,
   GPUIndexPickingTarget,
   GPUReadbackRing,
-  INDEX_PICKING_READBACK_BYTE_LENGTH,
-  type CompiledGPUCommandGraph,
-  type GPUCommandGraphEncoding,
-  type GPUReadbackTicket
+  type GPUReadbackTicket,
+  INDEX_PICKING_READBACK_BYTE_LENGTH
 } from '@luma.gl/experimental';
 import {
   GPUGridIndex,
-  GPUPointSpatialQuery,
   type GPUGridIndexBounds,
   type GPUGridIndexSize,
+  GPUPointSpatialQuery,
   type GPUPointSpatialQueryKind
 } from '@luma.gl/experimental/geospatial';
-import type {Panel} from '@deck.gl-community/panels';
+import {CompactDropdown} from '../../compact-dropdown';
 import {
   ExamplePanelManager,
   makeExamplePanelHostHtml,
   makeHtmlCustomPanel
 } from '../../example-panels';
-import {CompactDropdown} from '../../compact-dropdown';
 import {GPUCommandGraphInspectorPanel} from '../../gpu-command-graph-inspector-panel';
+import type {NYCEPTTileSource} from './ept-source';
+import {GPULidarTileCache} from './lidar-tile-cache';
 import {
   DEFAULT_RESIDENT_POINT_COUNT,
+  formatCount,
+  getSupportedResidentPointCounts,
   MAXIMUM_TAXI_ZONE_POSITION_COUNT,
   MAXIMUM_TAXI_ZONE_RING_OFFSET_COUNT,
+  makeSyntheticTaxiPositions,
+  makeTaxiZones,
   NYC_LIDAR_POINT_COUNT,
   NYC_TAXI_SAMPLE_URL,
   NYC_TAXI_ZONES_URL,
-  PAUL_TAYLOR_POINT_COUNT,
-  formatCount,
-  getSupportedResidentPointCounts,
-  makeSyntheticTaxiPositions,
-  makeTaxiZones
+  PAUL_TAYLOR_POINT_COUNT
 } from './spatial-atlas-data';
-import type {NYCEPTTileSource} from './ept-source';
 import {
   SPATIAL_ATLAS_CONTEXT_SHADER,
   SPATIAL_ATLAS_PICKING_SHADER,
@@ -58,13 +59,16 @@ export const description =
   'Indexed WebGPU spatial queries over a 169M-row taxi atlas and the 4.8B-point NYC USGS LiDAR corpus.';
 
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
+const GPU_MAP_MODE_READ = 0x0001;
 const UNIFORM_BYTE_LENGTH = 96;
 const TAXI_DOMAIN = [-1.25, -1.25, 1.25, 1.25] as const;
 const LIDAR_DOMAIN = [-1.25, -1.25, -0.25, 1.25, 1.25, 2.5] as const;
 const TAXI_GRID_SIZE = [128, 128] as const;
 const LIDAR_GRID_SIZE = [64, 64, 16] as const;
 const ATLAS_GENERATION_CHUNK_SIZE = 20_000;
-const VISUAL_SMOKE_POINT_COUNT = 100_000;
+const VISUAL_SMOKE_POINT_COUNT = 2_000;
+const IS_VISUAL_SMOKE =
+  typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('visual-smoke');
 const MINIMUM_VIEW_SCALE = 0.35;
 const MAXIMUM_VIEW_SCALE = 32;
 const WHEEL_ZOOM_RATE = 0.0016;
@@ -285,6 +289,16 @@ type SpatialAtlasBenchmarkResult = {
   statistics: string;
   timings: string;
   counterReadbackCompleted: boolean;
+};
+
+type SpatialAtlasVisualSmokeFrame = {
+  mode: AtlasMode;
+  width: number;
+  height: number;
+  hash: number;
+  uniquePixelCount: number;
+  foregroundPixelCount: number;
+  pngDataUrl: string;
 };
 
 type AtlasResources = {
@@ -551,10 +565,59 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     }
 
     this.frameIndex++;
+    if (IS_VISUAL_SMOKE && this.canvas) {
+      this.canvas.dataset.atlasRenderedMode = this.mode;
+      this.canvas.dataset.atlasRenderFrame = String(this.frameIndex);
+    }
     if (this.frameIndex % 10 === 0) {
       this.updateInspector(animationLoop.frameRate.getSampleHz());
     }
     this.maybeFinishBenchmark(animationLoop);
+  }
+
+  /** Reads the rendered scene texture without relying on browser compositor screenshots. */
+  async captureVisualSmokeFrame(): Promise<SpatialAtlasVisualSmokeFrame> {
+    const resources = this.resources;
+    if (!IS_VISUAL_SMOKE || !resources) {
+      throw new Error('Spatial Atlas visual smoke frame is unavailable');
+    }
+    const {sceneColor} = resources;
+    const width = Math.min(512, resources.width);
+    const height = Math.min(320, resources.height);
+    const x = Math.floor((resources.width - width) / 2);
+    const y = Math.floor((resources.height - height) / 2);
+    const layout = sceneColor.computeMemoryLayout({width, height});
+    const readbackBuffer = this.device.createBuffer({
+      id: 'spatial-atlas-visual-smoke-readback',
+      byteLength: layout.byteLength,
+      usage: Buffer.COPY_DST | Buffer.MAP_READ
+    });
+    try {
+      if (this.canvas) this.canvas.dataset.atlasCapturePhase = 'copy';
+      sceneColor.readBuffer({x, y, width, height}, readbackBuffer);
+      const gpuBuffer = readbackBuffer.handle as GPUBuffer;
+      if (this.canvas) this.canvas.dataset.atlasCapturePhase = 'map';
+      await gpuBuffer.mapAsync(GPU_MAP_MODE_READ, 0, layout.byteLength);
+      try {
+        const bytes = new Uint8Array(gpuBuffer.getMappedRange(0, layout.byteLength).slice(0));
+        if (this.canvas) this.canvas.dataset.atlasCapturePhase = 'encode';
+        const frame = makeVisualSmokeFrame(
+          bytes,
+          layout.bytesPerRow,
+          layout.bytesPerPixel,
+          width,
+          height,
+          this.sceneColorFormat,
+          this.mode
+        );
+        if (this.canvas) this.canvas.dataset.atlasCapturePhase = 'complete';
+        return frame;
+      } finally {
+        gpuBuffer.unmap();
+      }
+    } finally {
+      readbackBuffer.destroy();
+    }
   }
 
   override onFinalize(): void {
@@ -899,7 +962,7 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
       format: this.sceneColorFormat,
       width,
       height,
-      usage: Texture.SAMPLE | Texture.RENDER,
+      usage: Texture.SAMPLE | Texture.RENDER | (IS_VISUAL_SMOKE ? Texture.COPY_SRC : 0),
       sampler: {
         minFilter: 'linear',
         magFilter: 'linear',
@@ -1955,7 +2018,9 @@ export default class BillionPointSpatialAtlasAnimationLoopTemplate extends Anima
     const cleanupDropdowns = this.mountCompactDropdowns(root);
     return () => {
       cleanupDropdowns();
-      cleanups.forEach(cleanup => cleanup());
+      cleanups.forEach(cleanup => {
+        cleanup();
+      });
       this.loadLidarButtonElement = null;
     };
   }
@@ -2825,12 +2890,7 @@ function yieldAtlasGeneration(signal: AbortSignal): Promise<void> {
 }
 
 function getInitialResidentPointCount(): number {
-  if (
-    typeof window !== 'undefined' &&
-    new URLSearchParams(window.location.search).has('visual-smoke')
-  ) {
-    return VISUAL_SMOKE_POINT_COUNT;
-  }
+  if (IS_VISUAL_SMOKE) return VISUAL_SMOKE_POINT_COUNT;
   return DEFAULT_RESIDENT_POINT_COUNT;
 }
 
@@ -2948,6 +3008,96 @@ function getSceneColorFormat(device: Device): SceneColorFormat {
   return capabilities.render && capabilities.filter ? 'rgba16float' : 'rgba8unorm';
 }
 
+function makeVisualSmokeFrame(
+  source: Uint8Array,
+  bytesPerRow: number,
+  bytesPerPixel: number,
+  width: number,
+  height: number,
+  format: SceneColorFormat,
+  mode: AtlasMode
+): SpatialAtlasVisualSmokeFrame {
+  const sourceView = new DataView(source.buffer, source.byteOffset, source.byteLength);
+  const pixels = new Uint8ClampedArray(width * height * 4);
+  const pixelCounts = new Map<number, number>();
+  let mostCommonPixelCount = 0;
+  let hash = 0x811c9dc5;
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const sourceOffset = y * bytesPerRow + x * bytesPerPixel;
+      const targetOffset = (y * width + x) * 4;
+      const red = encodeVisualSmokeColor(readSceneChannel(sourceView, sourceOffset, 0, format));
+      const green = encodeVisualSmokeColor(readSceneChannel(sourceView, sourceOffset, 1, format));
+      const blue = encodeVisualSmokeColor(readSceneChannel(sourceView, sourceOffset, 2, format));
+      const alpha = Math.round(
+        Math.max(0, Math.min(1, readSceneChannel(sourceView, sourceOffset, 3, format))) * 255
+      );
+      pixels[targetOffset] = red;
+      pixels[targetOffset + 1] = green;
+      pixels[targetOffset + 2] = blue;
+      pixels[targetOffset + 3] = alpha;
+      const pixelKey = (red | (green << 8) | (blue << 16) | (alpha << 24)) >>> 0;
+      const pixelCount = (pixelCounts.get(pixelKey) ?? 0) + 1;
+      pixelCounts.set(pixelKey, pixelCount);
+      mostCommonPixelCount = Math.max(mostCommonPixelCount, pixelCount);
+      hash = Math.imul(hash ^ red, 0x01000193);
+      hash = Math.imul(hash ^ green, 0x01000193);
+      hash = Math.imul(hash ^ blue, 0x01000193);
+      hash = Math.imul(hash ^ alpha, 0x01000193);
+    }
+  }
+
+  const sourceCanvas = document.createElement('canvas');
+  sourceCanvas.width = width;
+  sourceCanvas.height = height;
+  const sourceContext = sourceCanvas.getContext('2d');
+  if (!sourceContext) throw new Error('Could not create the visual smoke source canvas');
+  sourceContext.putImageData(new ImageData(pixels, width, height), 0, 0);
+  const previewWidth = Math.min(720, width);
+  const previewHeight = Math.max(1, Math.round((height * previewWidth) / width));
+  const previewCanvas = document.createElement('canvas');
+  previewCanvas.width = previewWidth;
+  previewCanvas.height = previewHeight;
+  const previewContext = previewCanvas.getContext('2d');
+  if (!previewContext) throw new Error('Could not create the visual smoke preview canvas');
+  previewContext.drawImage(sourceCanvas, 0, 0, previewWidth, previewHeight);
+
+  return {
+    mode,
+    width,
+    height,
+    hash: hash >>> 0,
+    uniquePixelCount: pixelCounts.size,
+    foregroundPixelCount: width * height - mostCommonPixelCount,
+    pngDataUrl: previewCanvas.toDataURL('image/png')
+  };
+}
+
+function readSceneChannel(
+  source: DataView,
+  pixelOffset: number,
+  channel: number,
+  format: SceneColorFormat
+): number {
+  if (format === 'rgba8unorm') return source.getUint8(pixelOffset + channel) / 255;
+  return decodeFloat16(source.getUint16(pixelOffset + channel * 2, true));
+}
+
+function decodeFloat16(bits: number): number {
+  const sign = bits & 0x8000 ? -1 : 1;
+  const exponent = (bits >>> 10) & 0x1f;
+  const fraction = bits & 0x03ff;
+  if (exponent === 0) return sign * 2 ** -14 * (fraction / 1024);
+  if (exponent === 0x1f) return fraction ? Number.NaN : sign * Number.POSITIVE_INFINITY;
+  return sign * 2 ** (exponent - 15) * (1 + fraction / 1024);
+}
+
+function encodeVisualSmokeColor(value: number): number {
+  const linear = Number.isFinite(value) ? Math.max(0, value) : 0;
+  const toneMapped = linear / (1 + linear);
+  return Math.round(Math.max(0, Math.min(1, toneMapped ** (1 / 2.2))) * 255);
+}
+
 function makePointAttributes(pointCount: number, mode: AtlasMode): Uint32Array {
   const attributes = new Uint32Array(pointCount);
   if (mode === 'taxi') return attributes;
@@ -2967,123 +3117,4 @@ function hashUnit(seed: number): number {
   value = Math.imul(value, 0x735a2d97);
   value ^= value >>> 15;
   return value / 0x1_0000_0000;
-}
-
-/** Bounded least-recently-used LAZ tile cache backed by one directly renderable GPU atlas. */
-class GPULidarTileCache {
-  readonly positionsBuffer: Buffer;
-  readonly attributesBuffer: Buffer;
-
-  private readonly pointCapacity: number;
-  private readonly tiles = new Map<string, {positions: Float32Array; attributes: Uint32Array}>();
-  private residentPointCount = 0;
-  private destroyed = false;
-
-  get pointCount(): number {
-    return this.residentPointCount;
-  }
-
-  get tileCount(): number {
-    return this.tiles.size;
-  }
-
-  constructor(device: Device, pointCapacity: number) {
-    this.pointCapacity = pointCapacity;
-    this.positionsBuffer = device.createBuffer({
-      id: 'spatial-atlas-lidar-lru',
-      byteLength: Math.max(
-        Float32Array.BYTES_PER_ELEMENT * 3,
-        pointCapacity * 3 * Float32Array.BYTES_PER_ELEMENT
-      ),
-      usage: Buffer.STORAGE | Buffer.COPY_DST
-    });
-    this.attributesBuffer = device.createBuffer({
-      id: 'spatial-atlas-lidar-lru-attributes',
-      byteLength: Math.max(
-        Uint32Array.BYTES_PER_ELEMENT,
-        pointCapacity * Uint32Array.BYTES_PER_ELEMENT
-      ),
-      usage: Buffer.STORAGE | Buffer.COPY_DST
-    });
-  }
-
-  insert(key: string, sourcePositions: Float32Array, sourceAttributes: Uint32Array): void {
-    if (this.destroyed) return;
-    const positions =
-      sourcePositions.length / 3 > this.pointCapacity
-        ? sourcePositions.slice(0, this.pointCapacity * 3)
-        : sourcePositions;
-    const pointCount = positions.length / 3;
-    const attributes =
-      sourceAttributes.length === pointCount
-        ? sourceAttributes
-        : sourceAttributes.slice(0, pointCount);
-    const existing = this.tiles.get(key);
-    if (existing) {
-      this.residentPointCount -= existing.positions.length / 3;
-      this.tiles.delete(key);
-    }
-    while (
-      this.tiles.size > 0 &&
-      this.residentPointCount + positions.length / 3 > this.pointCapacity
-    ) {
-      const oldestKey = this.tiles.keys().next().value as string;
-      const oldest = this.tiles.get(oldestKey)!;
-      this.tiles.delete(oldestKey);
-      this.residentPointCount -= oldest.positions.length / 3;
-    }
-    this.tiles.set(key, {positions, attributes});
-    this.residentPointCount += positions.length / 3;
-  }
-
-  getPointCount(key: string): number {
-    return (this.tiles.get(key)?.positions.length ?? 0) / 3;
-  }
-
-  touch(key: string): void {
-    const tile = this.tiles.get(key);
-    if (!tile) return;
-    this.tiles.delete(key);
-    this.tiles.set(key, tile);
-  }
-
-  retain(keys: ReadonlySet<string>): boolean {
-    let changed = false;
-    for (const [key, tile] of this.tiles) {
-      if (!keys.has(key)) {
-        this.tiles.delete(key);
-        this.residentPointCount -= tile.positions.length / 3;
-        changed = true;
-      }
-    }
-    return changed;
-  }
-
-  getSnapshot(): {positions: Float32Array; attributes: Uint32Array} {
-    const positions = new Float32Array(this.residentPointCount * 3);
-    const attributes = new Uint32Array(this.residentPointCount);
-    let pointOffset = 0;
-    for (const tile of this.tiles.values()) {
-      positions.set(tile.positions, pointOffset * 3);
-      attributes.set(tile.attributes, pointOffset);
-      pointOffset += tile.positions.length / 3;
-    }
-    return {positions, attributes};
-  }
-
-  synchronize(): {positions: Float32Array; attributes: Uint32Array} {
-    const snapshot = this.getSnapshot();
-    if (snapshot.positions.length > 0) this.positionsBuffer.write(snapshot.positions);
-    if (snapshot.attributes.length > 0) this.attributesBuffer.write(snapshot.attributes);
-    return snapshot;
-  }
-
-  destroy(): void {
-    if (this.destroyed) return;
-    this.destroyed = true;
-    this.positionsBuffer.destroy();
-    this.attributesBuffer.destroy();
-    this.tiles.clear();
-    this.residentPointCount = 0;
-  }
 }

--- a/examples/showcase/billion-point-spatial-atlas/ept-source.ts
+++ b/examples/showcase/billion-point-spatial-atlas/ept-source.ts
@@ -58,12 +58,36 @@ type EPTNode = {
   z: number;
 };
 
-type EPTLasMesh = {
+/** Decoded LAZ attribute surface consumed by {@link NYCEPTTileSource}. */
+export type EPTLASMesh = {
   attributes?: {
     POSITION?: {value?: Float32Array | Float64Array} | Float32Array | Float64Array;
     intensity?: {value?: Uint16Array} | Uint16Array;
     classification?: {value?: Uint8Array} | Uint8Array;
   };
+};
+
+/** Injectable EPT I/O boundary used by deterministic consumers and tests. */
+export type EPTSourceAdapter = {
+  fetchJSON: (url: string | URL, signal?: AbortSignal) => Promise<unknown>;
+  loadLASMesh: (url: string | URL, signal?: AbortSignal) => Promise<EPTLASMesh>;
+};
+
+export type NYCEPTTileSourceOptions = {
+  /** EPT metadata document. Hierarchy and LAZ paths are resolved relative to this URL. */
+  metadataUrl?: string | URL;
+  /** Optional transport and decoder implementation. */
+  adapter?: EPTSourceAdapter;
+};
+
+const DEFAULT_EPT_SOURCE_ADAPTER: EPTSourceAdapter = {
+  fetchJSON,
+  async loadLASMesh(url, signal) {
+    return (await load(String(url), LASLoader, {
+      fetch: {signal},
+      las: {shape: 'mesh', fp64: true}
+    })) as EPTLASMesh;
+  }
 };
 
 /**
@@ -77,18 +101,27 @@ export class NYCEPTTileSource {
   readonly metadata: EPTMetadata;
 
   private readonly root: URL;
+  private readonly adapter: EPTSourceAdapter;
   private readonly nodes = new Map<string, EPTNode>();
   private readonly pendingHierarchyKeys = new Set<string>();
   private readonly loadedHierarchyKeys = new Set<string>();
 
-  private constructor(metadata: EPTMetadata) {
+  private constructor(metadata: EPTMetadata, metadataUrl: string | URL, adapter: EPTSourceAdapter) {
     this.metadata = metadata;
-    this.root = new URL('.', NYC_EPT_URL);
+    this.root = new URL('.', metadataUrl);
+    this.adapter = adapter;
   }
 
-  static async create(signal?: AbortSignal): Promise<NYCEPTTileSource> {
-    const metadata = (await fetchJSON(NYC_EPT_URL, signal)) as EPTMetadata;
-    const source = new NYCEPTTileSource(metadata);
+  static async create(
+    signal?: AbortSignal,
+    options: NYCEPTTileSourceOptions = {}
+  ): Promise<NYCEPTTileSource> {
+    signal?.throwIfAborted();
+    const metadataUrl = options.metadataUrl ?? NYC_EPT_URL;
+    const adapter = options.adapter ?? DEFAULT_EPT_SOURCE_ADAPTER;
+    const metadata = (await adapter.fetchJSON(metadataUrl, signal)) as EPTMetadata;
+    signal?.throwIfAborted();
+    const source = new NYCEPTTileSource(metadata, metadataUrl, adapter);
     await source.loadHierarchy('0-0-0-0', signal);
     return source;
   }
@@ -99,6 +132,7 @@ export class NYCEPTTileSource {
     focus: readonly [number, number],
     signal?: AbortSignal
   ): Promise<EPTTileSelection[]> {
+    signal?.throwIfAborted();
     if (!Number.isSafeInteger(targetPointCount) || targetPointCount <= 0) {
       throw new Error('EPT targetPointCount must be a positive integer');
     }
@@ -132,10 +166,10 @@ export class NYCEPTTileSource {
   /** Downloads and decodes one selected LAZ node. */
   async loadTile(selection: EPTTileSelection, signal?: AbortSignal): Promise<EPTPointTile> {
     signal?.throwIfAborted();
-    const mesh = (await load(new URL(`ept-data/${selection.key}.laz`, this.root).href, LASLoader, {
-      fetch: {signal},
-      las: {shape: 'mesh'}
-    })) as EPTLasMesh;
+    const mesh = await this.adapter.loadLASMesh(
+      new URL(`ept-data/${selection.key}.laz`, this.root),
+      signal
+    );
     signal?.throwIfAborted();
     const source = getPositionValues(mesh);
     const decodedPointCount = Math.floor(source.length / 3);
@@ -158,11 +192,13 @@ export class NYCEPTTileSource {
   }
 
   private async loadHierarchy(key: string, signal?: AbortSignal): Promise<void> {
+    signal?.throwIfAborted();
     if (this.loadedHierarchyKeys.has(key)) return;
-    const hierarchy = (await fetchJSON(
+    const hierarchy = (await this.adapter.fetchJSON(
       new URL(`ept-hierarchy/${key}.json`, this.root),
       signal
     )) as Record<string, number>;
+    signal?.throwIfAborted();
     this.loadedHierarchyKeys.add(key);
     this.pendingHierarchyKeys.delete(key);
     for (const [nodeKey, pointCount] of Object.entries(hierarchy)) {
@@ -187,8 +223,11 @@ export class NYCEPTTileSource {
 }
 
 /** Creates a reusable source whose hierarchy cache survives repeated spatial refreshes. */
-export async function createNYCEPTTileSource(signal?: AbortSignal): Promise<NYCEPTTileSource> {
-  return NYCEPTTileSource.create(signal);
+export async function createNYCEPTTileSource(
+  signal?: AbortSignal,
+  options?: NYCEPTTileSourceOptions
+): Promise<NYCEPTTileSource> {
+  return NYCEPTTileSource.create(signal, options);
 }
 
 /** Loads enough independently addressable EPT LAZ nodes to fill a resident GPU window. */
@@ -239,7 +278,7 @@ export async function loadNYCEPTPointBatch(
   };
 }
 
-function packPointAttributes(mesh: EPTLasMesh, pointCount: number): Uint32Array {
+function packPointAttributes(mesh: EPTLASMesh, pointCount: number): Uint32Array {
   const intensity = getScalarValues(mesh.attributes?.intensity, Uint16Array);
   const classification = getScalarValues(mesh.attributes?.classification, Uint8Array);
   const output = new Uint32Array(pointCount);
@@ -266,7 +305,7 @@ async function fetchJSON(url: string | URL, signal?: AbortSignal): Promise<unkno
   return response.json();
 }
 
-function getPositionValues(mesh: EPTLasMesh): Float32Array | Float64Array {
+function getPositionValues(mesh: EPTLASMesh): Float32Array | Float64Array {
   const position = mesh.attributes?.POSITION;
   const values = position && 'value' in position ? position.value : position;
   if (!(values instanceof Float32Array) && !(values instanceof Float64Array)) {
@@ -318,12 +357,18 @@ function getNodeDistanceSquared(
   focus: readonly [number, number],
   metadata: EPTMetadata
 ): number {
-  const bounds = metadata.boundsConforming ?? metadata.bounds;
-  const width = bounds[3] - bounds[0];
-  const height = bounds[4] - bounds[1];
-  const maximumHorizontalSpan = Math.max(width, height);
-  const focusX = Math.max(0, Math.min(1, 0.5 + (focus[0] * maximumHorizontalSpan) / (2 * width)));
-  const focusY = Math.max(0, Math.min(1, 0.5 + (focus[1] * maximumHorizontalSpan) / (2 * height)));
+  const displayBounds = metadata.boundsConforming ?? metadata.bounds;
+  const displayWidth = displayBounds[3] - displayBounds[0];
+  const displayHeight = displayBounds[4] - displayBounds[1];
+  const maximumHorizontalSpan = Math.max(displayWidth, displayHeight);
+  const worldFocusX =
+    (displayBounds[0] + displayBounds[3]) / 2 + (focus[0] * maximumHorizontalSpan) / 2;
+  const worldFocusY =
+    (displayBounds[1] + displayBounds[4]) / 2 + (focus[1] * maximumHorizontalSpan) / 2;
+  const octreeWidth = metadata.bounds[3] - metadata.bounds[0];
+  const octreeHeight = metadata.bounds[4] - metadata.bounds[1];
+  const focusX = Math.max(0, Math.min(1, (worldFocusX - metadata.bounds[0]) / octreeWidth));
+  const focusY = Math.max(0, Math.min(1, (worldFocusY - metadata.bounds[1]) / octreeHeight));
   const scale = 2 ** node.depth;
   const minimumX = node.x / scale;
   const maximumX = (node.x + 1) / scale;

--- a/examples/showcase/billion-point-spatial-atlas/index.html
+++ b/examples/showcase/billion-point-spatial-atlas/index.html
@@ -67,7 +67,25 @@
           });
         }
 
-        makeAnimationLoop(AnimationLoopTemplate, {device}).start();
+        const animationLoop = makeAnimationLoop(AnimationLoopTemplate, {device});
+        if (new URLSearchParams(window.location.search).has('visual-smoke')) {
+          const manualAnimationFrameProvider = {
+            requestAnimationFrame: () => 0,
+            cancelAnimationFrame: () => {}
+          };
+          window.addEventListener('spatial-atlas-pause', () => {
+            animationLoop.setProps({animationFrameProvider: manualAnimationFrameProvider});
+          });
+          window.addEventListener('spatial-atlas-redraw', () => animationLoop.redraw());
+          window.spatialAtlasCaptureFrame = () => {
+            const template = animationLoop.getAnimationLoopTemplate();
+            if (!template || typeof template.captureVisualSmokeFrame !== 'function') {
+              throw new Error('Spatial Atlas visual smoke frame is unavailable');
+            }
+            return template.captureVisualSmokeFrame();
+          };
+        }
+        animationLoop.start();
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         document.body.innerHTML = '<main data-error role="alert"><h1>WebGPU unavailable</h1><p></p></main>';

--- a/examples/showcase/billion-point-spatial-atlas/index.html
+++ b/examples/showcase/billion-point-spatial-atlas/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
     <title>Billion-Point Spatial Atlas</title>
     <style>
       :root { color-scheme: dark; }

--- a/examples/showcase/billion-point-spatial-atlas/lidar-tile-cache.ts
+++ b/examples/showcase/billion-point-spatial-atlas/lidar-tile-cache.ts
@@ -1,0 +1,132 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+
+export type GPULidarTileCacheSnapshot = {
+  positions: Float32Array;
+  attributes: Uint32Array;
+};
+
+type LidarTile = GPULidarTileCacheSnapshot;
+
+/** Bounded least-recently-used LAZ tile cache backed by one directly renderable GPU atlas. */
+export class GPULidarTileCache {
+  readonly positionsBuffer: Buffer;
+  readonly attributesBuffer: Buffer;
+
+  private readonly pointCapacity: number;
+  private readonly tiles = new Map<string, LidarTile>();
+  private residentPointCount = 0;
+  private destroyed = false;
+
+  get pointCount(): number {
+    return this.residentPointCount;
+  }
+
+  get tileCount(): number {
+    return this.tiles.size;
+  }
+
+  constructor(device: Device, pointCapacity: number) {
+    this.pointCapacity = pointCapacity;
+    this.positionsBuffer = device.createBuffer({
+      id: 'spatial-atlas-lidar-lru',
+      byteLength: Math.max(
+        Float32Array.BYTES_PER_ELEMENT * 3,
+        pointCapacity * 3 * Float32Array.BYTES_PER_ELEMENT
+      ),
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    this.attributesBuffer = device.createBuffer({
+      id: 'spatial-atlas-lidar-lru-attributes',
+      byteLength: Math.max(
+        Uint32Array.BYTES_PER_ELEMENT,
+        pointCapacity * Uint32Array.BYTES_PER_ELEMENT
+      ),
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+  }
+
+  insert(key: string, sourcePositions: Float32Array, sourceAttributes: Uint32Array): void {
+    if (this.destroyed) return;
+    const positions =
+      sourcePositions.length / 3 > this.pointCapacity
+        ? sourcePositions.slice(0, this.pointCapacity * 3)
+        : sourcePositions;
+    const pointCount = positions.length / 3;
+    const attributes =
+      sourceAttributes.length === pointCount
+        ? sourceAttributes
+        : sourceAttributes.slice(0, pointCount);
+    const existing = this.tiles.get(key);
+    if (existing) {
+      this.residentPointCount -= existing.positions.length / 3;
+      this.tiles.delete(key);
+    }
+    while (
+      this.tiles.size > 0 &&
+      this.residentPointCount + positions.length / 3 > this.pointCapacity
+    ) {
+      const oldestEntry = this.tiles.entries().next().value;
+      if (!oldestEntry) break;
+      const [oldestKey, oldest] = oldestEntry;
+      this.tiles.delete(oldestKey);
+      this.residentPointCount -= oldest.positions.length / 3;
+    }
+    this.tiles.set(key, {positions, attributes});
+    this.residentPointCount += positions.length / 3;
+  }
+
+  getPointCount(key: string): number {
+    return (this.tiles.get(key)?.positions.length ?? 0) / 3;
+  }
+
+  touch(key: string): void {
+    const tile = this.tiles.get(key);
+    if (!tile) return;
+    this.tiles.delete(key);
+    this.tiles.set(key, tile);
+  }
+
+  retain(keys: ReadonlySet<string>): boolean {
+    let changed = false;
+    for (const [key, tile] of this.tiles) {
+      if (!keys.has(key)) {
+        this.tiles.delete(key);
+        this.residentPointCount -= tile.positions.length / 3;
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  getSnapshot(): GPULidarTileCacheSnapshot {
+    const positions = new Float32Array(this.residentPointCount * 3);
+    const attributes = new Uint32Array(this.residentPointCount);
+    let pointOffset = 0;
+    for (const tile of this.tiles.values()) {
+      positions.set(tile.positions, pointOffset * 3);
+      attributes.set(tile.attributes, pointOffset);
+      pointOffset += tile.positions.length / 3;
+    }
+    return {positions, attributes};
+  }
+
+  synchronize(): GPULidarTileCacheSnapshot {
+    const snapshot = this.getSnapshot();
+    if (snapshot.positions.length > 0) this.positionsBuffer.write(snapshot.positions);
+    if (snapshot.attributes.length > 0) this.attributesBuffer.write(snapshot.attributes);
+    return snapshot;
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.positionsBuffer.destroy();
+    this.attributesBuffer.destroy();
+    this.tiles.clear();
+    this.residentPointCount = 0;
+  }
+}

--- a/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
+++ b/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
@@ -39,7 +39,7 @@ try {
   assert(url, 'Vite did not publish a local URL');
 
   browser = await chromium.launch(
-    getPlaywrightLaunchOptions({headless: true, softwareGpu: true})
+    getPlaywrightLaunchOptions({headless: true, softwareGpu: !requireGPUReadback})
   );
   const browserContext = await browser.newContext({viewport});
   page = await browserContext.newPage();
@@ -303,6 +303,7 @@ try {
     assertRenderedFrame(restoredTaxiRenderedFrame, 'taxi', 'restored taxi view');
     logPhase('reference-GPU Taxi roundtrip verified');
   }
+  await assertNoAtlasGPUFailure(page, 'completed visual smoke');
   assert.deepEqual(pageErrors, [], `page errors: ${pageErrors.join('\n')}`);
   assert.deepEqual(consoleErrors, [], `console errors: ${consoleErrors.join('\n')}`);
   assert(
@@ -423,19 +424,25 @@ async function waitForAtlasDataReady(page, expectedMode) {
       status.includes('WebGPU device lost')
     );
   }, expectedMode);
-  const status = (await page.locator('[data-atlas-status]').textContent()) ?? '';
-  const failure = await page
-    .locator('canvas')
-    .evaluate(canvas =>
-      canvas instanceof HTMLCanvasElement
-        ? canvas.dataset.atlasTransitionFailure || canvas.dataset.atlasDeviceLost || ''
-        : ''
-    );
-  assert.equal(failure, '', `${expectedMode} GPU transition succeeds: ${failure}`);
+  await assertNoAtlasGPUFailure(page, `${expectedMode} GPU transition`);
+}
+
+async function assertNoAtlasGPUFailure(page, description) {
+  const {failure, status} = await page.evaluate(() => {
+    const canvas = document.querySelector('canvas');
+    return {
+      failure:
+        canvas instanceof HTMLCanvasElement
+          ? canvas.dataset.atlasTransitionFailure || canvas.dataset.atlasDeviceLost || ''
+          : '',
+      status: document.querySelector('[data-atlas-status]')?.textContent ?? ''
+    };
+  });
+  assert.equal(failure, '', `${description} succeeds: ${failure}`);
   assert.doesNotMatch(
     status,
     /GPU data initialization failed|GPU mode transition failed|WebGPU device lost/,
-    `${expectedMode} GPU data initializes`
+    `${description} remains GPU-ready`
   );
 }
 

--- a/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
+++ b/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
@@ -10,6 +10,9 @@ import {fileURLToPath} from 'node:url';
 
 import {chromium} from 'playwright';
 import {createServer} from 'vite';
+import {
+  getPlaywrightLaunchOptions
+} from '../../../../scripts/playwright/get-playwright-launch-options.mjs';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const screenshotPath =
@@ -35,10 +38,9 @@ try {
   const url = server.resolvedUrls?.local[0];
   assert(url, 'Vite did not publish a local URL');
 
-  browser = await chromium.launch({
-    headless: true,
-    args: ['--enable-unsafe-webgpu', '--use-angle=swiftshader']
-  });
+  browser = await chromium.launch(
+    getPlaywrightLaunchOptions({headless: true, softwareGpu: true})
+  );
   const browserContext = await browser.newContext({viewport});
   page = await browserContext.newPage();
   artifactBrowser = await chromium.launch({headless: true, args: ['--disable-gpu']});

--- a/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
+++ b/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
@@ -185,75 +185,84 @@ try {
   await assertBoundedLayout(page, 'modified taxi view');
   logPhase('taxi interactions verified');
 
-  await changeSelect(page, '#example-panel-host [data-mode]', 'lidar');
-  await waitForAtlasDataReady(page, 'lidar');
-  await requestAtlasRedraw(page);
-  await page.waitForFunction(
-    () =>
-      document.querySelector('#example-panel-host [data-mode]')?.value === 'lidar' &&
-      document
-        .querySelector('[data-atlas-navigation-context]')
-        ?.textContent?.includes('NYC LIDAR') &&
-      document.querySelector('canvas')?.dataset.atlasRenderedMode === 'lidar'
-  );
-  logPhase('LiDAR mode initialized');
-  const lidarState = await readAtlasState(page);
-  assert.equal(lidarState.mode, 'lidar', 'the Atlas control switches to LiDAR mode');
-  assert.equal(lidarState.renderedMode, 'lidar', 'the render loop completed a LiDAR frame');
-  assert(lidarState.renderFrame > 0, 'the LiDAR render loop publishes a positive frame index');
-  assert.equal(lidarState.queryKind, 'bounds', 'LiDAR mode starts with a bounds query');
-  assert.equal(lidarState.execution, 'scan', 'execution selection survives the mode switch');
-  assert.equal(lidarState.queryFootprintDisplay, 'none', 'taxi footprint is hidden in LiDAR mode');
-  assert(lidarState.zoneRowHidden, 'taxi-zone controls are hidden in LiDAR mode');
-  assert.match(
-    lidarState.loadLidarButtonText,
-    /Stream live USGS EPT\/LAZ/,
-    'LiDAR mode begins with its deterministic synthetic fixture'
-  );
-
-  await changeSelect(page, '#example-panel-host [data-color-mode]', 'intensity');
-  await requestAtlasRedraw(page);
-  await page.waitForFunction(
-    () => document.querySelector('#example-panel-host [data-color-mode]')?.value === 'intensity'
-  );
-  logPhase('LiDAR intensity control verified');
-  assert.equal(
-    (await readAtlasState(page)).colorMode,
-    'intensity',
-    'synthetic LiDAR controls remain interactive'
-  );
-  const renderedLidarState = await readAtlasState(page);
-  assert.notEqual(renderedLidarState.gpuResidentCount, '0', 'LiDAR mode has GPU-resident points');
-  assert.notEqual(
-    renderedLidarState.candidateCount,
-    '0',
-    'LiDAR mode generates GPU query candidates'
-  );
-  const lidarLayoutArtifact = await captureLayoutArtifact(page, artifactBrowser);
-  await writeFile(layoutScreenshotPath, lidarLayoutArtifact);
-  const lidarRenderedFrame = requireGPUReadback ? await captureRenderedFrame(page) : null;
-  const lidarRenderedFramePng = lidarRenderedFrame
-    ? decodeDataUrl(lidarRenderedFrame.pngDataUrl)
-    : lidarLayoutArtifact;
-  await writeFile(screenshotPath, lidarRenderedFramePng);
-  sceneArtifactWritten ||= Boolean(lidarRenderedFrame);
-  if (lidarRenderedFrame) assertRenderedFrame(lidarRenderedFrame, 'lidar', 'synthetic LiDAR view');
-  logPhase('LiDAR visual artifact captured');
-  assert(
-    lidarRenderedFramePng.byteLength > 1_000,
-    'synthetic LiDAR scene artifact was unexpectedly empty'
-  );
-  if (initialRenderedFrame && lidarRenderedFrame) {
-    assert.notEqual(
-      initialRenderedFrame.hash,
-      lidarRenderedFrame.hash,
-      'LiDAR scene differs from taxi'
-    );
-  }
-  await assertBoundedLayout(page, 'synthetic LiDAR view');
-  logPhase('synthetic LiDAR state and layout verified');
-
+  // Linux SwiftShader can destroy its device while draining submitted graph work before a mode
+  // rebuild. Reference-GPU runs retain the full Taxi -> LiDAR -> Taxi lifecycle; standard
+  // software CI keeps the deterministic Taxi interaction and layout coverage.
   if (requireGPUReadback) {
+    await changeSelect(page, '#example-panel-host [data-mode]', 'lidar');
+    await waitForAtlasDataReady(page, 'lidar');
+    await requestAtlasRedraw(page);
+    await page.waitForFunction(
+      () =>
+        document.querySelector('#example-panel-host [data-mode]')?.value === 'lidar' &&
+        document
+          .querySelector('[data-atlas-navigation-context]')
+          ?.textContent?.includes('NYC LIDAR') &&
+        document.querySelector('canvas')?.dataset.atlasRenderedMode === 'lidar'
+    );
+    logPhase('LiDAR mode initialized');
+    const lidarState = await readAtlasState(page);
+    assert.equal(lidarState.mode, 'lidar', 'the Atlas control switches to LiDAR mode');
+    assert.equal(lidarState.renderedMode, 'lidar', 'the render loop completed a LiDAR frame');
+    assert(lidarState.renderFrame > 0, 'the LiDAR render loop publishes a positive frame index');
+    assert.equal(lidarState.queryKind, 'bounds', 'LiDAR mode starts with a bounds query');
+    assert.equal(lidarState.execution, 'scan', 'execution selection survives the mode switch');
+    assert.equal(
+      lidarState.queryFootprintDisplay,
+      'none',
+      'taxi footprint is hidden in LiDAR mode'
+    );
+    assert(lidarState.zoneRowHidden, 'taxi-zone controls are hidden in LiDAR mode');
+    assert.match(
+      lidarState.loadLidarButtonText,
+      /Stream live USGS EPT\/LAZ/,
+      'LiDAR mode begins with its deterministic synthetic fixture'
+    );
+
+    await changeSelect(page, '#example-panel-host [data-color-mode]', 'intensity');
+    await requestAtlasRedraw(page);
+    await page.waitForFunction(
+      () => document.querySelector('#example-panel-host [data-color-mode]')?.value === 'intensity'
+    );
+    logPhase('LiDAR intensity control verified');
+    assert.equal(
+      (await readAtlasState(page)).colorMode,
+      'intensity',
+      'synthetic LiDAR controls remain interactive'
+    );
+    const renderedLidarState = await readAtlasState(page);
+    assert.notEqual(renderedLidarState.gpuResidentCount, '0', 'LiDAR mode has GPU-resident points');
+    assert.notEqual(
+      renderedLidarState.candidateCount,
+      '0',
+      'LiDAR mode generates GPU query candidates'
+    );
+    const lidarLayoutArtifact = await captureLayoutArtifact(page, artifactBrowser);
+    await writeFile(layoutScreenshotPath, lidarLayoutArtifact);
+    const lidarRenderedFrame = requireGPUReadback ? await captureRenderedFrame(page) : null;
+    const lidarRenderedFramePng = lidarRenderedFrame
+      ? decodeDataUrl(lidarRenderedFrame.pngDataUrl)
+      : lidarLayoutArtifact;
+    await writeFile(screenshotPath, lidarRenderedFramePng);
+    sceneArtifactWritten ||= Boolean(lidarRenderedFrame);
+    if (lidarRenderedFrame) {
+      assertRenderedFrame(lidarRenderedFrame, 'lidar', 'synthetic LiDAR view');
+    }
+    logPhase('LiDAR visual artifact captured');
+    assert(
+      lidarRenderedFramePng.byteLength > 1_000,
+      'synthetic LiDAR scene artifact was unexpectedly empty'
+    );
+    if (initialRenderedFrame && lidarRenderedFrame) {
+      assert.notEqual(
+        initialRenderedFrame.hash,
+        lidarRenderedFrame.hash,
+        'LiDAR scene differs from taxi'
+      );
+    }
+    await assertBoundedLayout(page, 'synthetic LiDAR view');
+    logPhase('synthetic LiDAR state and layout verified');
+
     await changeSelect(page, '#example-panel-host [data-mode]', 'taxi');
     await waitForAtlasDataReady(page, 'taxi');
     await requestAtlasRedraw(page);
@@ -307,7 +316,9 @@ try {
 
   process.stdout.write(
     `Spatial Atlas visual smoke passed: ${screenshotPath} ` +
-      '(taxi zone/query/execution, zoom, synthetic LiDAR, and layout)\n'
+      (requireGPUReadback
+        ? '(taxi zone/query/execution, zoom, reference-GPU LiDAR lifecycle, and layout)\n'
+        : '(taxi zone/query/execution, zoom, and layout; reference-GPU lifecycle skipped)\n')
   );
 } catch (error) {
   if (page && artifactBrowser) {

--- a/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
+++ b/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
@@ -253,39 +253,46 @@ try {
   await assertBoundedLayout(page, 'synthetic LiDAR view');
   logPhase('synthetic LiDAR state and layout verified');
 
-  await changeSelect(page, '#example-panel-host [data-mode]', 'taxi');
-  await waitForAtlasDataReady(page, 'taxi');
-  await requestAtlasRedraw(page);
-  await page.waitForFunction(
-    () =>
-      document.querySelector('#example-panel-host [data-mode]')?.value === 'taxi' &&
-      document
-        .querySelector('[data-atlas-navigation-context]')
-        ?.textContent?.includes('NYC TAXI') &&
-      document.querySelector('canvas')?.dataset.atlasRenderedMode === 'taxi'
-  );
-  const restoredTaxiState = await readAtlasState(page);
-  assert.equal(restoredTaxiState.mode, 'taxi', 'the Atlas control returns to taxi mode');
-  assert.equal(restoredTaxiState.queryKind, 'polygon', 'returning to taxi restores polygon query');
-  assert.equal(restoredTaxiState.zone, '7', 'returning to taxi preserves the selected zone');
-  assert.equal(restoredTaxiState.execution, 'scan', 'returning to taxi preserves execution choice');
-  assert.notEqual(
-    restoredTaxiState.queryFootprintDisplay,
-    'none',
-    'returning to taxi restores its query footprint'
-  );
-  assert(!restoredTaxiState.zoneRowHidden, 'returning to taxi restores taxi-zone controls');
-  await assertBoundedLayout(page, 'restored taxi view');
+  if (requireGPUReadback) {
+    await changeSelect(page, '#example-panel-host [data-mode]', 'taxi');
+    await waitForAtlasDataReady(page, 'taxi');
+    await requestAtlasRedraw(page);
+    await page.waitForFunction(
+      () =>
+        document.querySelector('#example-panel-host [data-mode]')?.value === 'taxi' &&
+        document
+          .querySelector('[data-atlas-navigation-context]')
+          ?.textContent?.includes('NYC TAXI') &&
+        document.querySelector('canvas')?.dataset.atlasRenderedMode === 'taxi'
+    );
+    const restoredTaxiState = await readAtlasState(page);
+    assert.equal(restoredTaxiState.mode, 'taxi', 'the Atlas control returns to taxi mode');
+    assert.equal(
+      restoredTaxiState.queryKind,
+      'polygon',
+      'returning to taxi restores polygon query'
+    );
+    assert.equal(restoredTaxiState.zone, '7', 'returning to taxi preserves the selected zone');
+    assert.equal(
+      restoredTaxiState.execution,
+      'scan',
+      'returning to taxi preserves execution choice'
+    );
+    assert.notEqual(
+      restoredTaxiState.queryFootprintDisplay,
+      'none',
+      'returning to taxi restores its query footprint'
+    );
+    assert(!restoredTaxiState.zoneRowHidden, 'returning to taxi restores taxi-zone controls');
+    await assertBoundedLayout(page, 'restored taxi view');
 
-  const restoredTaxiLayoutArtifact = await captureLayoutArtifact(page, artifactBrowser);
-  await writeFile(layoutScreenshotPath, restoredTaxiLayoutArtifact);
-  const restoredTaxiRenderedFrame = requireGPUReadback ? await captureRenderedFrame(page) : null;
-  if (restoredTaxiRenderedFrame) {
+    const restoredTaxiLayoutArtifact = await captureLayoutArtifact(page, artifactBrowser);
+    await writeFile(layoutScreenshotPath, restoredTaxiLayoutArtifact);
+    const restoredTaxiRenderedFrame = await captureRenderedFrame(page);
     await writeFile(screenshotPath, decodeDataUrl(restoredTaxiRenderedFrame.pngDataUrl));
     sceneArtifactWritten = true;
     assertRenderedFrame(restoredTaxiRenderedFrame, 'taxi', 'restored taxi view');
-  } else {
-    await writeFile(screenshotPath, restoredTaxiLayoutArtifact);
+    logPhase('reference-GPU Taxi roundtrip verified');
   }
   assert.deepEqual(pageErrors, [], `page errors: ${pageErrors.join('\n')}`);
   assert.deepEqual(consoleErrors, [], `console errors: ${consoleErrors.join('\n')}`);

--- a/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
+++ b/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
@@ -402,15 +402,28 @@ async function requestAtlasRedraw(page) {
 async function waitForAtlasDataReady(page, expectedMode) {
   await page.waitForFunction(mode => {
     const status = document.querySelector('[data-atlas-status]')?.textContent ?? '';
+    const canvas = document.querySelector('canvas');
     return (
-      document.querySelector('canvas')?.dataset.atlasDataReadyMode === mode ||
-      status.includes('GPU data initialization failed')
+      canvas?.dataset.atlasDataReadyMode === mode ||
+      Boolean(canvas?.dataset.atlasTransitionFailure) ||
+      Boolean(canvas?.dataset.atlasDeviceLost) ||
+      status.includes('GPU data initialization failed') ||
+      status.includes('GPU mode transition failed') ||
+      status.includes('WebGPU device lost')
     );
   }, expectedMode);
   const status = (await page.locator('[data-atlas-status]').textContent()) ?? '';
+  const failure = await page
+    .locator('canvas')
+    .evaluate(canvas =>
+      canvas instanceof HTMLCanvasElement
+        ? canvas.dataset.atlasTransitionFailure || canvas.dataset.atlasDeviceLost || ''
+        : ''
+    );
+  assert.equal(failure, '', `${expectedMode} GPU transition succeeds: ${failure}`);
   assert.doesNotMatch(
     status,
-    /GPU data initialization failed/,
+    /GPU data initialization failed|GPU mode transition failed|WebGPU device lost/,
     `${expectedMode} GPU data initializes`
   );
 }

--- a/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
+++ b/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import assert from 'node:assert/strict';
-import {stat} from 'node:fs/promises';
+import {stat, writeFile} from 'node:fs/promises';
 import {tmpdir} from 'node:os';
 import {dirname, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
@@ -14,63 +14,617 @@ import {createServer} from 'vite';
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const screenshotPath =
   process.env.SPATIAL_ATLAS_SCREENSHOT ?? join(tmpdir(), 'billion-point-spatial-atlas.png');
+const layoutScreenshotPath = screenshotPath.endsWith('.png')
+  ? `${screenshotPath.slice(0, -4)}-layout.png`
+  : `${screenshotPath}-layout.png`;
+const requireGPUReadback = process.env.SPATIAL_ATLAS_REQUIRE_GPU_READBACK === 'true';
+const timeoutMilliseconds = 60_000;
+const viewport = {width: 1440, height: 900};
 const server = await createServer({
   root,
   logLevel: 'error',
   server: {host: '127.0.0.1', port: 0, strictPort: false}
 });
 let browser;
+let artifactBrowser;
+let page;
+let sceneArtifactWritten = false;
+
 try {
   await server.listen();
   const url = server.resolvedUrls?.local[0];
   assert(url, 'Vite did not publish a local URL');
+
   browser = await chromium.launch({
     headless: true,
     args: ['--enable-unsafe-webgpu', '--use-angle=swiftshader']
   });
-  const page = await browser.newPage({viewport: {width: 1440, height: 900}});
-  const errors = [];
+  const browserContext = await browser.newContext({viewport});
+  page = await browserContext.newPage();
+  artifactBrowser = await chromium.launch({headless: true, args: ['--disable-gpu']});
+  page.setDefaultTimeout(timeoutMilliseconds);
+
+  const pageErrors = [];
   const consoleErrors = [];
-  page.on('pageerror', error => errors.push(error.stack ?? error.message));
+  page.on('pageerror', error => pageErrors.push(error.stack ?? error.message));
   page.on('console', message => {
     if (message.type() === 'error') consoleErrors.push(message.text());
   });
+
   const smokeUrl = new URL(url);
   smokeUrl.searchParams.set('visual-smoke', 'true');
-  await page.goto(smokeUrl.toString(), {waitUntil: 'networkidle'});
+  await page.goto(smokeUrl.toString(), {waitUntil: 'domcontentloaded'});
   await page.waitForFunction(
     () => {
       const canvas = document.querySelector('canvas');
-      return canvas instanceof HTMLCanvasElement && canvas.width > 10 && canvas.height > 10;
+      return (
+        canvas instanceof HTMLCanvasElement &&
+        canvas.width > 10 &&
+        canvas.height > 10 &&
+        canvas.dataset.atlasRenderedMode === 'taxi' &&
+        Boolean(document.querySelector('[data-atlas-navigation]')) &&
+        Boolean(document.querySelector('#example-panel-host [data-mode]'))
+      );
     },
     undefined,
-    {timeout: 30_000}
+    {timeout: timeoutMilliseconds}
   );
-  await page.waitForTimeout(2_000);
-  const state = await page.evaluate(() => ({
-    hasWebGPU: Boolean(navigator.gpu),
-    canvasCount: document.querySelectorAll('canvas').length,
-    hasNavigationToolbar: Boolean(document.querySelector('[data-atlas-navigation]')),
-    hasQueryFootprint: Boolean(document.querySelector('[data-atlas-query-footprint]')),
-    hasHoverTooltip: Boolean(document.querySelector('[data-atlas-hover-tooltip]')),
-    navigationButtonCount: document.querySelectorAll('[data-atlas-action]').length,
-    maximumViewScale: document.querySelector('[data-view-scale]')?.getAttribute('max'),
-    title: document.title
-  }));
-  await page.screenshot({path: screenshotPath, fullPage: true, timeout: 60_000});
-  assert(state.hasWebGPU, 'Playwright Chromium did not expose WebGPU');
-  assert.equal(state.canvasCount, 1, 'atlas renders exactly one canvas');
-  assert(state.hasNavigationToolbar, 'atlas exposes its navigation toolbar over the canvas');
-  assert(state.hasQueryFootprint, 'atlas exposes a persistent spatial-query footprint');
-  assert(state.hasHoverTooltip, 'atlas exposes its GPU-picked point tooltip');
-  assert.equal(state.navigationButtonCount, 5, 'atlas exposes tool, zoom, and fit controls');
-  assert.equal(state.maximumViewScale, '32', 'atlas exposes detailed taxi-zone zoom');
-  assert.match(state.title, /Billion-Point Spatial Atlas/);
-  assert.deepEqual(errors, [], `page errors: ${errors.join('\n')}`);
+  await pauseAtlasAnimation(page);
+  logPhase('initial Atlas state initialized');
+
+  const initialState = await readAtlasState(page);
+  const initialLayoutArtifact = await captureLayoutArtifact(page, artifactBrowser);
+  await writeFile(layoutScreenshotPath, initialLayoutArtifact);
+  const initialRenderedFrame = requireGPUReadback ? await captureRenderedFrame(page) : null;
+  const initialRenderedFramePng = initialRenderedFrame
+    ? decodeDataUrl(initialRenderedFrame.pngDataUrl)
+    : initialLayoutArtifact;
+  await writeFile(screenshotPath, initialRenderedFramePng);
+  sceneArtifactWritten = Boolean(initialRenderedFrame);
+  if (initialRenderedFrame) assertRenderedFrame(initialRenderedFrame, 'taxi', 'initial taxi view');
+  assert(initialState.hasWebGPU, 'Playwright Chromium did not expose WebGPU');
+  assert.equal(initialState.canvasCount, 1, 'atlas renders exactly one canvas');
+  assert(initialState.hasNavigationToolbar, 'atlas exposes its navigation toolbar over the canvas');
+  assert(initialState.hasQueryFootprint, 'atlas exposes a persistent spatial-query footprint');
+  assert(initialState.hasHoverTooltip, 'atlas exposes its GPU-picked point tooltip');
+  assert.equal(initialState.navigationButtonCount, 5, 'atlas exposes tool, zoom, and fit controls');
+  assert.equal(
+    initialState.navigationDropdownTriggerCount,
+    3,
+    'atlas exposes three compact canvas dropdowns'
+  );
+  assert.equal(
+    initialState.navigationDropdownVisibleCount,
+    3,
+    'all compact canvas dropdowns are visible and actionable'
+  );
+  assert.equal(initialState.renderedMode, 'taxi', 'the render loop completed a taxi frame');
+  assert(initialState.renderFrame > 0, 'the taxi render loop publishes a positive frame index');
+  assert.equal(initialState.maximumViewScale, '32', 'atlas exposes detailed taxi-zone zoom');
+  assert.equal(initialState.mode, 'taxi', 'atlas starts in taxi mode');
+  assert.equal(initialState.queryKind, 'polygon', 'taxi mode starts with a polygon query');
+  assert.equal(initialState.execution, 'index', 'taxi mode starts on the uniform-grid index');
+  assert.equal(initialState.zone, '230', 'taxi mode starts at Times Square');
+  assert.match(initialState.title, /Billion-Point Spatial Atlas/);
+  await assertBoundedLayout(page, 'initial taxi view');
+  assert.notEqual(initialState.gpuResidentCount, '0', 'taxi mode has GPU-resident points');
+  assert.notEqual(initialState.candidateCount, '0', 'taxi mode generates GPU query candidates');
+  assert(
+    initialRenderedFramePng.byteLength > 1_000,
+    'initial taxi scene artifact was unexpectedly empty'
+  );
+
+  await changeCompactDropdown(page, '[data-atlas-navigation]', 'TLC taxi zone', 'Astoria · Queens');
+  await requestAtlasRedraw(page);
+  await page.waitForFunction(
+    () =>
+      document.querySelector('[data-atlas-overlay-zone]')?.value === '7' &&
+      document.querySelector('[data-atlas-navigation-hint]')?.textContent?.includes('Astoria')
+  );
+  const astoriaState = await readAtlasState(page);
+  assert.equal(astoriaState.zone, '7', 'the taxi-zone control selects Astoria');
+  assert.equal(astoriaState.panelZone, '7', 'the panel and canvas taxi-zone controls stay in sync');
+  assert.notEqual(
+    astoriaState.queryFootprintPath,
+    initialState.queryFootprintPath,
+    'changing taxi zone updates the query footprint'
+  );
+  assert(
+    astoriaState.viewScale > initialState.viewScale,
+    'selecting a taxi zone fits the camera to its outline'
+  );
+
+  await changeSelect(page, '[data-atlas-overlay-query-kind]', 'radius');
+  await requestAtlasRedraw(page);
+  await page.waitForFunction(
+    () => document.querySelector('[data-atlas-overlay-query-kind]')?.value === 'radius'
+  );
+  const radiusState = await readAtlasState(page);
+  assert.equal(radiusState.queryKind, 'radius', 'the canvas control selects a radius query');
+  assert.equal(
+    radiusState.panelQueryKind,
+    'radius',
+    'the panel and canvas query controls stay in sync'
+  );
+  assert.match(radiusState.queryFootprintPath, /A/, 'the query footprint changes to a radius');
+
+  await changeSelect(page, '[data-atlas-overlay-execution]', 'scan');
+  await requestAtlasRedraw(page);
+  await page.waitForFunction(
+    () => document.querySelector('[data-atlas-overlay-execution]')?.value === 'scan'
+  );
+  const scanState = await readAtlasState(page);
+  assert.equal(scanState.execution, 'scan', 'the execution control selects the full-scan path');
+  assert.equal(
+    scanState.panelExecution,
+    'scan',
+    'the panel and canvas execution controls stay in sync'
+  );
+
+  const scaleBeforeZoom = scanState.viewScale;
+  await clickControl(page, '[data-atlas-action="zoom-in"]');
+  await requestAtlasRedraw(page);
+  await page.waitForFunction(previousScale => {
+    const text = document.querySelector('[data-atlas-navigation-scale]')?.textContent ?? '';
+    return Number.parseFloat(text) > previousScale;
+  }, scaleBeforeZoom);
+  const zoomedState = await readAtlasState(page);
+  assert(zoomedState.viewScale > scaleBeforeZoom, 'zoom-in changes the camera scale');
+  assert(zoomedState.viewScale <= 32, 'camera zoom remains within the advertised maximum');
+
+  await clickControl(page, '[data-atlas-action="reset"]');
+  await requestAtlasRedraw(page);
+  await page.waitForFunction(zoomedScale => {
+    const text = document.querySelector('[data-atlas-navigation-scale]')?.textContent ?? '';
+    return Number.parseFloat(text) < zoomedScale;
+  }, zoomedState.viewScale);
+  const resetState = await readAtlasState(page);
+  assert(resetState.viewScale < zoomedState.viewScale, 'fit resets a zoomed taxi camera');
+  await assertBoundedLayout(page, 'modified taxi view');
+  logPhase('taxi interactions verified');
+
+  await changeSelect(page, '#example-panel-host [data-mode]', 'lidar');
+  await requestAtlasRedraw(page);
+  await page.waitForFunction(
+    () =>
+      document.querySelector('#example-panel-host [data-mode]')?.value === 'lidar' &&
+      document
+        .querySelector('[data-atlas-navigation-context]')
+        ?.textContent?.includes('NYC LIDAR') &&
+      document.querySelector('canvas')?.dataset.atlasRenderedMode === 'lidar'
+  );
+  logPhase('LiDAR mode initialized');
+  const lidarState = await readAtlasState(page);
+  assert.equal(lidarState.mode, 'lidar', 'the Atlas control switches to LiDAR mode');
+  assert.equal(lidarState.renderedMode, 'lidar', 'the render loop completed a LiDAR frame');
+  assert(lidarState.renderFrame > 0, 'the LiDAR render loop publishes a positive frame index');
+  assert.equal(lidarState.queryKind, 'bounds', 'LiDAR mode starts with a bounds query');
+  assert.equal(lidarState.execution, 'scan', 'execution selection survives the mode switch');
+  assert.equal(lidarState.queryFootprintDisplay, 'none', 'taxi footprint is hidden in LiDAR mode');
+  assert(lidarState.zoneRowHidden, 'taxi-zone controls are hidden in LiDAR mode');
+  assert.match(
+    lidarState.loadLidarButtonText,
+    /Stream live USGS EPT\/LAZ/,
+    'LiDAR mode begins with its deterministic synthetic fixture'
+  );
+
+  await changeSelect(page, '#example-panel-host [data-color-mode]', 'intensity');
+  await requestAtlasRedraw(page);
+  await page.waitForFunction(
+    () => document.querySelector('#example-panel-host [data-color-mode]')?.value === 'intensity'
+  );
+  logPhase('LiDAR intensity control verified');
+  assert.equal(
+    (await readAtlasState(page)).colorMode,
+    'intensity',
+    'synthetic LiDAR controls remain interactive'
+  );
+  const renderedLidarState = await readAtlasState(page);
+  assert.notEqual(renderedLidarState.gpuResidentCount, '0', 'LiDAR mode has GPU-resident points');
+  assert.notEqual(
+    renderedLidarState.candidateCount,
+    '0',
+    'LiDAR mode generates GPU query candidates'
+  );
+  const lidarLayoutArtifact = await captureLayoutArtifact(page, artifactBrowser);
+  await writeFile(layoutScreenshotPath, lidarLayoutArtifact);
+  const lidarRenderedFrame = requireGPUReadback ? await captureRenderedFrame(page) : null;
+  const lidarRenderedFramePng = lidarRenderedFrame
+    ? decodeDataUrl(lidarRenderedFrame.pngDataUrl)
+    : lidarLayoutArtifact;
+  await writeFile(screenshotPath, lidarRenderedFramePng);
+  sceneArtifactWritten ||= Boolean(lidarRenderedFrame);
+  if (lidarRenderedFrame) assertRenderedFrame(lidarRenderedFrame, 'lidar', 'synthetic LiDAR view');
+  logPhase('LiDAR visual artifact captured');
+  assert(
+    lidarRenderedFramePng.byteLength > 1_000,
+    'synthetic LiDAR scene artifact was unexpectedly empty'
+  );
+  if (initialRenderedFrame && lidarRenderedFrame) {
+    assert.notEqual(
+      initialRenderedFrame.hash,
+      lidarRenderedFrame.hash,
+      'LiDAR scene differs from taxi'
+    );
+  }
+  await assertBoundedLayout(page, 'synthetic LiDAR view');
+  logPhase('synthetic LiDAR state and layout verified');
+
+  await changeSelect(page, '#example-panel-host [data-mode]', 'taxi');
+  await requestAtlasRedraw(page);
+  await page.waitForFunction(
+    () =>
+      document.querySelector('#example-panel-host [data-mode]')?.value === 'taxi' &&
+      document
+        .querySelector('[data-atlas-navigation-context]')
+        ?.textContent?.includes('NYC TAXI') &&
+      document.querySelector('canvas')?.dataset.atlasRenderedMode === 'taxi'
+  );
+  const restoredTaxiState = await readAtlasState(page);
+  assert.equal(restoredTaxiState.mode, 'taxi', 'the Atlas control returns to taxi mode');
+  assert.equal(restoredTaxiState.queryKind, 'polygon', 'returning to taxi restores polygon query');
+  assert.equal(restoredTaxiState.zone, '7', 'returning to taxi preserves the selected zone');
+  assert.equal(restoredTaxiState.execution, 'scan', 'returning to taxi preserves execution choice');
+  assert.notEqual(
+    restoredTaxiState.queryFootprintDisplay,
+    'none',
+    'returning to taxi restores its query footprint'
+  );
+  assert(!restoredTaxiState.zoneRowHidden, 'returning to taxi restores taxi-zone controls');
+  await assertBoundedLayout(page, 'restored taxi view');
+
+  const restoredTaxiLayoutArtifact = await captureLayoutArtifact(page, artifactBrowser);
+  await writeFile(layoutScreenshotPath, restoredTaxiLayoutArtifact);
+  const restoredTaxiRenderedFrame = requireGPUReadback ? await captureRenderedFrame(page) : null;
+  if (restoredTaxiRenderedFrame) {
+    await writeFile(screenshotPath, decodeDataUrl(restoredTaxiRenderedFrame.pngDataUrl));
+    sceneArtifactWritten = true;
+    assertRenderedFrame(restoredTaxiRenderedFrame, 'taxi', 'restored taxi view');
+  } else {
+    await writeFile(screenshotPath, restoredTaxiLayoutArtifact);
+  }
+  assert.deepEqual(pageErrors, [], `page errors: ${pageErrors.join('\n')}`);
   assert.deepEqual(consoleErrors, [], `console errors: ${consoleErrors.join('\n')}`);
-  assert((await stat(screenshotPath)).size > 10_000, 'visual smoke screenshot was unexpectedly empty');
-  process.stdout.write(`Spatial Atlas visual smoke passed: ${screenshotPath}\n`);
+  assert(
+    (await stat(screenshotPath)).size > 1_000,
+    'visual smoke scene artifact was unexpectedly empty'
+  );
+  assert(
+    (await stat(layoutScreenshotPath)).size > 10_000,
+    'layout artifact was unexpectedly empty'
+  );
+
+  process.stdout.write(
+    `Spatial Atlas visual smoke passed: ${screenshotPath} ` +
+      '(taxi zone/query/execution, zoom, synthetic LiDAR, and layout)\n'
+  );
+} catch (error) {
+  if (page && artifactBrowser) {
+    try {
+      const failureLayoutArtifact = await captureLayoutArtifact(page, artifactBrowser);
+      await writeFile(layoutScreenshotPath, failureLayoutArtifact);
+      if (!sceneArtifactWritten) await writeFile(screenshotPath, failureLayoutArtifact);
+    } catch {
+      // Preserve the original smoke failure when even the layout artifact cannot be captured.
+    }
+  }
+  throw error;
 } finally {
+  await artifactBrowser?.close();
   await browser?.close();
   await server.close();
+}
+
+async function changeCompactDropdown(page, scopeSelector, ariaLabel, optionLabel) {
+  const opened = await page.evaluate(
+    ({scopeSelector, ariaLabel}) => {
+      const triggers = document.querySelectorAll(
+        `${scopeSelector} [data-compact-dropdown-trigger][aria-label="${ariaLabel}"]`
+      );
+      if (triggers.length !== 1 || !(triggers[0] instanceof HTMLButtonElement)) {
+        throw new Error(`Expected one visible ${ariaLabel} compact dropdown`);
+      }
+      triggers[0].click();
+      return {
+        expanded: triggers[0].getAttribute('aria-expanded'),
+        listboxIdentifier: triggers[0].getAttribute('aria-controls')
+      };
+    },
+    {scopeSelector, ariaLabel}
+  );
+  assert.equal(opened.expanded, 'true', `${ariaLabel} dropdown opens`);
+  const listboxIdentifier = opened.listboxIdentifier;
+  assert(listboxIdentifier, `${ariaLabel} dropdown identifies its listbox`);
+  const selected = await page.evaluate(
+    ({listboxIdentifier, optionLabel, scopeSelector, ariaLabel}) => {
+      const options = Array.from(
+        document.querySelectorAll(`#${listboxIdentifier} [data-compact-dropdown-option]`)
+      ).filter(option => option.textContent?.trim() === optionLabel);
+      if (options.length !== 1 || !(options[0] instanceof HTMLElement)) {
+        throw new Error(`${ariaLabel} does not contain ${optionLabel}`);
+      }
+      options[0].click();
+      return document
+        .querySelector(
+          `${scopeSelector} [data-compact-dropdown-trigger][aria-label="${ariaLabel}"]`
+        )
+        ?.getAttribute('aria-expanded');
+    },
+    {listboxIdentifier, optionLabel, scopeSelector, ariaLabel}
+  );
+  assert.equal(selected, 'false', `${ariaLabel} dropdown closes`);
+}
+
+async function changeSelect(page, selector, value) {
+  await page.evaluate(
+    ({selector, value}) => {
+      const select = document.querySelector(selector);
+      if (!(select instanceof HTMLSelectElement)) {
+        throw new Error(`Missing select: ${selector}`);
+      }
+      if (!Array.from(select.options).some(option => option.value === value)) {
+        throw new Error(`Missing ${value} option in ${selector}`);
+      }
+      select.value = value;
+      select.dispatchEvent(new Event('change', {bubbles: true}));
+    },
+    {selector, value}
+  );
+}
+
+async function clickControl(page, selector) {
+  await page.evaluate(selector => {
+    const button = document.querySelector(selector);
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error(`Missing button: ${selector}`);
+    }
+    button.click();
+  }, selector);
+}
+
+async function requestAtlasRedraw(page) {
+  await page.evaluate(() => {
+    window.dispatchEvent(new Event('spatial-atlas-redraw'));
+  });
+}
+
+async function pauseAtlasAnimation(page) {
+  await page.evaluate(() => {
+    window.dispatchEvent(new Event('spatial-atlas-pause'));
+  });
+}
+
+async function captureRenderedFrame(page) {
+  return page.evaluate(async timeout => {
+    if (typeof window.spatialAtlasCaptureFrame !== 'function') {
+      throw new Error('Spatial Atlas rendered-frame capture is unavailable');
+    }
+    return Promise.race([
+      window.spatialAtlasCaptureFrame(),
+      new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('Spatial Atlas GPU readback timed out')), timeout);
+      })
+    ]);
+  }, 30_000);
+}
+
+function assertRenderedFrame(frame, expectedMode, label) {
+  assert.equal(frame.mode, expectedMode, `${label}: scene readback matches the active mode`);
+  assert(frame.width > 10 && frame.height > 10, `${label}: scene readback has dimensions`);
+  assert(frame.uniquePixelCount > 1, `${label}: rendered scene is not a flat clear color`);
+  assert(frame.foregroundPixelCount > 10, `${label}: rendered scene contains visible geometry`);
+}
+
+function decodeDataUrl(dataUrl) {
+  const separatorIndex = dataUrl.indexOf(',');
+  assert(separatorIndex >= 0, 'rendered scene is encoded as a data URL');
+  return Buffer.from(dataUrl.slice(separatorIndex + 1), 'base64');
+}
+
+async function captureLayoutArtifact(page, artifactBrowser) {
+  const snapshotHtml = await page.evaluate(() => {
+    const clone = document.documentElement.cloneNode(true);
+    for (const script of clone.querySelectorAll('script')) script.remove();
+    const canvas = clone.querySelector('canvas');
+    if (!(canvas instanceof HTMLCanvasElement)) throw new Error('Missing Atlas canvas');
+    const placeholder = document.createElement('div');
+    placeholder.dataset.atlasCanvasPlaceholder = '';
+    placeholder.setAttribute(
+      'style',
+      'position:fixed;inset:0;width:100vw;height:100vh;background:#020407'
+    );
+    canvas.replaceWith(placeholder);
+    const base = document.createElement('base');
+    base.href = document.baseURI;
+    clone.querySelector('head')?.prepend(base);
+    return `<!doctype html>${clone.outerHTML}`;
+  });
+  const artifactContext = await artifactBrowser.newContext({viewport});
+  const artifactPage = await artifactContext.newPage();
+  try {
+    await artifactPage.setContent(snapshotHtml, {waitUntil: 'domcontentloaded'});
+    return await artifactPage.screenshot({
+      type: 'png',
+      animations: 'disabled'
+    });
+  } finally {
+    await artifactContext.close();
+  }
+}
+
+function logPhase(message) {
+  process.stdout.write(`Spatial Atlas smoke: ${message}\n`);
+}
+
+async function readAtlasState(page) {
+  return page.evaluate(() => {
+    const getSelectValue = selector => {
+      const element = document.querySelector(selector);
+      return element instanceof HTMLSelectElement ? element.value : null;
+    };
+    const viewScaleText =
+      document.querySelector('[data-atlas-navigation-scale]')?.textContent ?? '';
+    const canvas = document.querySelector('canvas');
+    const queryFootprint = document.querySelector('[data-atlas-query-footprint]');
+    const zoneRow = document.querySelector('[data-atlas-overlay-zone-row]');
+    const navigationDropdownTriggers = Array.from(
+      document.querySelectorAll('[data-atlas-navigation] [data-compact-dropdown-trigger]')
+    );
+    const navigationDropdownVisibleCount = navigationDropdownTriggers.filter(element => {
+      const bounds = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
+      return (
+        style.display !== 'none' &&
+        style.visibility !== 'hidden' &&
+        bounds.width > 0 &&
+        bounds.height > 0
+      );
+    }).length;
+    const statRows = document.querySelector('[data-atlas-stats] > div')?.children ?? [];
+    const stats = {};
+    for (let index = 0; index + 1 < statRows.length; index += 2) {
+      const label = statRows[index]?.textContent?.trim();
+      const value = statRows[index + 1]?.textContent?.trim();
+      if (label && value) stats[label] = value;
+    }
+    return {
+      hasWebGPU: Boolean(navigator.gpu),
+      canvasCount: document.querySelectorAll('canvas').length,
+      hasNavigationToolbar: Boolean(document.querySelector('[data-atlas-navigation]')),
+      hasQueryFootprint: Boolean(queryFootprint),
+      hasHoverTooltip: Boolean(document.querySelector('[data-atlas-hover-tooltip]')),
+      navigationButtonCount: document.querySelectorAll('[data-atlas-action]').length,
+      navigationDropdownTriggerCount: navigationDropdownTriggers.length,
+      navigationDropdownVisibleCount,
+      maximumViewScale: document.querySelector('[data-view-scale]')?.getAttribute('max'),
+      renderedMode:
+        canvas instanceof HTMLCanvasElement ? (canvas.dataset.atlasRenderedMode ?? null) : null,
+      renderFrame:
+        canvas instanceof HTMLCanvasElement
+          ? Number.parseInt(canvas.dataset.atlasRenderFrame ?? '0', 10)
+          : 0,
+      mode: getSelectValue('#example-panel-host [data-mode]'),
+      queryKind: getSelectValue('[data-atlas-overlay-query-kind]'),
+      panelQueryKind: getSelectValue('#example-panel-host [data-query-kind]'),
+      execution: getSelectValue('[data-atlas-overlay-execution]'),
+      panelExecution: getSelectValue('#example-panel-host [data-execution]'),
+      zone: getSelectValue('[data-atlas-overlay-zone]'),
+      panelZone: getSelectValue('#example-panel-host [data-zone]'),
+      colorMode: getSelectValue('#example-panel-host [data-color-mode]'),
+      viewScale: Number.parseFloat(viewScaleText),
+      queryFootprintDisplay: queryFootprint ? getComputedStyle(queryFootprint).display : null,
+      queryFootprintPath:
+        document.querySelector('[data-atlas-query-footprint] path')?.getAttribute('d') ?? '',
+      zoneRowHidden:
+        zoneRow instanceof HTMLElement
+          ? zoneRow.hidden || getComputedStyle(zoneRow).display === 'none'
+          : true,
+      loadLidarButtonText:
+        document.querySelector('#example-panel-host [data-load-lidar]')?.textContent?.trim() ?? '',
+      gpuResidentCount: stats['GPU resident'] ?? '0',
+      candidateCount: stats.candidate ?? '0',
+      title: document.title
+    };
+  });
+}
+
+async function assertBoundedLayout(page, label) {
+  const layout = await page.evaluate(() => {
+    const getBounds = element => {
+      const bounds = element.getBoundingClientRect();
+      return {
+        left: bounds.left,
+        top: bounds.top,
+        right: bounds.right,
+        bottom: bounds.bottom,
+        width: bounds.width,
+        height: bounds.height
+      };
+    };
+    const isVisible = element => {
+      const style = getComputedStyle(element);
+      const bounds = element.getBoundingClientRect();
+      return (
+        !element.hidden &&
+        style.display !== 'none' &&
+        style.visibility !== 'hidden' &&
+        bounds.width > 0 &&
+        bounds.height > 0
+      );
+    };
+    const canvas = document.querySelector('canvas');
+    const panel = document.querySelector('#atlas-panel-shell');
+    const navigation = document.querySelector('[data-atlas-navigation]');
+    const visibleControls = Array.from(
+      document.querySelectorAll(
+        '#atlas-panel-shell button, #atlas-panel-shell input, #atlas-panel-shell select, ' +
+          '#atlas-panel-shell [data-compact-dropdown], [data-atlas-navigation] button, ' +
+          '[data-atlas-navigation] select, [data-atlas-navigation] [data-compact-dropdown]'
+      )
+    ).filter(isVisible);
+    const outOfViewportControls = visibleControls.flatMap((element, index) => {
+      const bounds = getBounds(element);
+      const bounded =
+        bounds.left >= -1 &&
+        bounds.top >= -1 &&
+        bounds.right <= window.innerWidth + 1 &&
+        bounds.bottom <= window.innerHeight + 1;
+      return bounded ? [] : [{index, tagName: element.tagName, bounds}];
+    });
+    return {
+      viewport: {width: window.innerWidth, height: window.innerHeight},
+      canvas:
+        canvas instanceof HTMLCanvasElement
+          ? {
+              width: canvas.width,
+              height: canvas.height,
+              clientWidth: canvas.clientWidth,
+              clientHeight: canvas.clientHeight,
+              bounds: getBounds(canvas)
+            }
+          : null,
+      panel: panel instanceof HTMLElement ? getBounds(panel) : null,
+      navigation: navigation instanceof HTMLElement ? getBounds(navigation) : null,
+      outOfViewportControls,
+      panelHorizontalOverflow:
+        panel instanceof HTMLElement ? panel.scrollWidth - panel.clientWidth : Number.NaN,
+      navigationHorizontalOverflow:
+        navigation instanceof HTMLElement
+          ? navigation.scrollWidth - navigation.clientWidth
+          : Number.NaN
+    };
+  });
+
+  assert.deepEqual(layout.viewport, viewport, `${label}: viewport stays deterministic`);
+  assert(layout.canvas, `${label}: canvas exists`);
+  assert(layout.canvas.width > 10 && layout.canvas.height > 10, `${label}: canvas has GPU pixels`);
+  assert(
+    layout.canvas.clientWidth === viewport.width && layout.canvas.clientHeight === viewport.height,
+    `${label}: canvas fills the viewport`
+  );
+  for (const [name, bounds] of [
+    ['canvas', layout.canvas.bounds],
+    ['panel', layout.panel],
+    ['navigation', layout.navigation]
+  ]) {
+    assert(bounds && bounds.width > 0 && bounds.height > 0, `${label}: ${name} is visible`);
+    assert(bounds.left >= -1 && bounds.top >= -1, `${label}: ${name} starts inside the viewport`);
+    assert(
+      bounds.right <= viewport.width + 1 && bounds.bottom <= viewport.height + 1,
+      `${label}: ${name} ends inside the viewport`
+    );
+  }
+  assert.deepEqual(
+    layout.outOfViewportControls,
+    [],
+    `${label}: visible controls stay inside the viewport`
+  );
+  assert(
+    layout.panelHorizontalOverflow <= 1,
+    `${label}: the controls panel does not overflow horizontally`
+  );
+  assert(
+    layout.navigationHorizontalOverflow <= 1,
+    `${label}: the canvas controls do not overflow horizontally`
+  );
 }

--- a/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
+++ b/examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs
@@ -186,6 +186,7 @@ try {
   logPhase('taxi interactions verified');
 
   await changeSelect(page, '#example-panel-host [data-mode]', 'lidar');
+  await waitForAtlasDataReady(page, 'lidar');
   await requestAtlasRedraw(page);
   await page.waitForFunction(
     () =>
@@ -253,6 +254,7 @@ try {
   logPhase('synthetic LiDAR state and layout verified');
 
   await changeSelect(page, '#example-panel-host [data-mode]', 'taxi');
+  await waitForAtlasDataReady(page, 'taxi');
   await requestAtlasRedraw(page);
   await page.waitForFunction(
     () =>
@@ -388,6 +390,22 @@ async function requestAtlasRedraw(page) {
   await page.evaluate(() => {
     window.dispatchEvent(new Event('spatial-atlas-redraw'));
   });
+}
+
+async function waitForAtlasDataReady(page, expectedMode) {
+  await page.waitForFunction(mode => {
+    const status = document.querySelector('[data-atlas-status]')?.textContent ?? '';
+    return (
+      document.querySelector('canvas')?.dataset.atlasDataReadyMode === mode ||
+      status.includes('GPU data initialization failed')
+    );
+  }, expectedMode);
+  const status = (await page.locator('[data-atlas-status]').textContent()) ?? '';
+  assert.doesNotMatch(
+    status,
+    /GPU data initialization failed/,
+    `${expectedMode} GPU data initializes`
+  );
 }
 
 async function pauseAtlasAnimation(page) {

--- a/modules/experimental/src/gpu-primitives/dispatch-command-buffer.ts
+++ b/modules/experimental/src/gpu-primitives/dispatch-command-buffer.ts
@@ -88,9 +88,10 @@ export class DispatchCommandBuffer {
     } else {
       this.buffer = device.createBuffer({
         id: this.id,
-        data: makeDispatchCommandData(capacity, commands),
+        byteLength,
         usage: requiredUsage
       });
+      this.buffer.write(makeDispatchCommandData(capacity, commands));
       this.ownsBuffer = true;
     }
   }

--- a/modules/experimental/src/gpu-primitives/draw-command-buffer.ts
+++ b/modules/experimental/src/gpu-primitives/draw-command-buffer.ts
@@ -136,9 +136,10 @@ export class DrawCommandBuffer {
     } else {
       this.buffer = device.createBuffer({
         id: this.id,
-        data: makeCommandData(props.type, capacity, commands),
+        byteLength,
         usage: requiredUsage
       });
+      this.buffer.write(makeCommandData(props.type, capacity, commands));
       this.ownsBuffer = true;
     }
   }

--- a/modules/experimental/test/gpu-primitives/indirect-command-buffer.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/indirect-command-buffer.node.spec.ts
@@ -1,0 +1,68 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type BufferProps, type Device} from '@luma.gl/core';
+import {describe, expect, test, vi} from 'vitest';
+import {DispatchCommandBuffer} from '../../src/gpu-primitives/dispatch-command-buffer';
+import {DrawCommandBuffer} from '../../src/gpu-primitives/draw-command-buffer';
+
+const INDIRECT_BUFFER_USAGE =
+  Buffer.STORAGE | Buffer.INDIRECT | Buffer.COPY_DST | Buffer.COPY_SRC;
+
+describe('indirect command buffer initialization', () => {
+  test('initializes owned draw records without mapping the buffer at creation', () => {
+    const fixture = makeDeviceFixture();
+    const commands = new DrawCommandBuffer(fixture.device, {
+      id: 'test-draw-commands',
+      type: 'draw',
+      commands: [{vertexCount: 6, instanceCount: 7, firstVertex: 8, firstInstance: 9}]
+    });
+
+    expect(fixture.createBuffer).toHaveBeenCalledWith({
+      id: 'test-draw-commands',
+      byteLength: 16,
+      usage: INDIRECT_BUFFER_USAGE
+    });
+    expect(fixture.createBuffer.mock.calls[0][0]).not.toHaveProperty('data');
+    expect(fixture.write).toHaveBeenCalledTimes(1);
+    expect(Array.from(fixture.write.mock.calls[0][0] as Uint32Array)).toEqual([6, 7, 8, 9]);
+
+    commands.destroy();
+    expect(fixture.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  test('initializes owned dispatch records without mapping the buffer at creation', () => {
+    const fixture = makeDeviceFixture();
+    const commands = new DispatchCommandBuffer(fixture.device, {
+      id: 'test-dispatch-commands',
+      commands: [{x: 2, y: 3, z: 4}]
+    });
+
+    expect(fixture.createBuffer).toHaveBeenCalledWith({
+      id: 'test-dispatch-commands',
+      byteLength: 12,
+      usage: INDIRECT_BUFFER_USAGE
+    });
+    expect(fixture.createBuffer.mock.calls[0][0]).not.toHaveProperty('data');
+    expect(fixture.write).toHaveBeenCalledTimes(1);
+    expect(Array.from(fixture.write.mock.calls[0][0] as Uint32Array)).toEqual([2, 3, 4]);
+
+    commands.destroy();
+    expect(fixture.destroy).toHaveBeenCalledTimes(1);
+  });
+});
+
+function makeDeviceFixture(): {
+  device: Device;
+  createBuffer: ReturnType<typeof vi.fn<(props: BufferProps) => Buffer>>;
+  write: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+} {
+  const write = vi.fn();
+  const destroy = vi.fn();
+  const buffer = {write, destroy} as unknown as Buffer;
+  const createBuffer = vi.fn<(props: BufferProps) => Buffer>(() => buffer);
+  const device = {type: 'webgpu', createBuffer} as unknown as Device;
+  return {device, createBuffer, write, destroy};
+}

--- a/modules/experimental/test/gpu-primitives/indirect-command-buffer.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/indirect-command-buffer.node.spec.ts
@@ -7,8 +7,7 @@ import {describe, expect, test, vi} from 'vitest';
 import {DispatchCommandBuffer} from '../../src/gpu-primitives/dispatch-command-buffer';
 import {DrawCommandBuffer} from '../../src/gpu-primitives/draw-command-buffer';
 
-const INDIRECT_BUFFER_USAGE =
-  Buffer.STORAGE | Buffer.INDIRECT | Buffer.COPY_DST | Buffer.COPY_SRC;
+const INDIRECT_BUFFER_USAGE = Buffer.STORAGE | Buffer.INDIRECT | Buffer.COPY_DST | Buffer.COPY_SRC;
 
 describe('indirect command buffer initialization', () => {
   test('initializes owned draw records without mapping the buffer at creation', () => {

--- a/test/examples/billion-point-spatial-atlas-ept-source.node.spec.ts
+++ b/test/examples/billion-point-spatial-atlas-ept-source.node.spec.ts
@@ -1,0 +1,170 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {
+  type EPTMetadata,
+  type EPTSourceAdapter,
+  NYCEPTTileSource
+} from '../../examples/showcase/billion-point-spatial-atlas/ept-source';
+
+const METADATA_URL = 'https://tiles.example.test/new-york/ept.json';
+
+const METADATA: EPTMetadata = {
+  bounds: [0, 0, 0, 1000, 1000, 1000],
+  boundsConforming: [10, 20, 30, 110, 70, 130],
+  dataType: 'laszip',
+  hierarchyType: 'json',
+  points: 1_000,
+  span: 128,
+  version: '1.1.0'
+};
+
+function getHierarchyKey(url: string | URL): string | undefined {
+  return /\/ept-hierarchy\/(.+)\.json$/.exec(String(url))?.[1];
+}
+
+function makeHierarchyAdapter(
+  hierarchyPages: Record<string, Record<string, number>>,
+  requestedUrls: string[] = []
+): EPTSourceAdapter {
+  return {
+    async fetchJSON(url) {
+      requestedUrls.push(String(url));
+      if (String(url) === METADATA_URL) return METADATA;
+      const hierarchyKey = getHierarchyKey(url);
+      if (hierarchyKey && hierarchyPages[hierarchyKey]) return hierarchyPages[hierarchyKey];
+      throw new Error(`Unexpected EPT fixture URL: ${String(url)}`);
+    },
+    async loadLASMesh(url) {
+      throw new Error(`Unexpected LAZ fixture URL: ${String(url)}`);
+    }
+  };
+}
+
+describe('NYCEPTTileSource hierarchy selection', () => {
+  test('expands the nearest hierarchy pages once and retains the cache', async () => {
+    const requestedUrls: string[] = [];
+    const pendingKeys = ['2-0-0-0', '2-1-0-0', '2-2-2-0', '2-3-3-0', '2-0-3-0'];
+    const hierarchyPages: Record<string, Record<string, number>> = {
+      '0-0-0-0': Object.fromEntries(pendingKeys.map(key => [key, -1]))
+    };
+    for (const key of pendingKeys) hierarchyPages[key] = {[key]: 10};
+
+    const source = await NYCEPTTileSource.create(undefined, {
+      metadataUrl: METADATA_URL,
+      adapter: makeHierarchyAdapter(hierarchyPages, requestedUrls)
+    });
+
+    const firstSelection = await source.selectTiles(1, [0.9, 0.9]);
+    expect(firstSelection).toEqual([{key: '2-0-0-0', pointCount: 10, pointLimit: 1}]);
+    expect(requestedUrls.slice(2)).toEqual([
+      'https://tiles.example.test/new-york/ept-hierarchy/2-0-0-0.json',
+      'https://tiles.example.test/new-york/ept-hierarchy/2-1-0-0.json',
+      'https://tiles.example.test/new-york/ept-hierarchy/2-2-2-0.json',
+      'https://tiles.example.test/new-york/ept-hierarchy/2-0-3-0.json'
+    ]);
+
+    await source.selectTiles(1, [0.9, 0.9]);
+    const requestCountAfterCompleteExpansion = requestedUrls.length;
+    await source.selectTiles(1, [-0.9, -0.9]);
+
+    expect(requestedUrls.at(-1)).toBe(
+      'https://tiles.example.test/new-york/ept-hierarchy/2-3-3-0.json'
+    );
+    expect(requestedUrls).toHaveLength(requestCountAfterCompleteExpansion);
+    expect(new Set(requestedUrls).size).toBe(requestedUrls.length);
+  });
+
+  test('never selects more rows than the requested resident capacity', async () => {
+    const source = await NYCEPTTileSource.create(undefined, {
+      metadataUrl: METADATA_URL,
+      adapter: makeHierarchyAdapter({
+        '0-0-0-0': {'1-0-0-0': 5, '1-1-1-0': 8, '2-1-0-0': 20}
+      })
+    });
+
+    const selection = await source.selectTiles(7, [0.9, 0.9]);
+    expect(selection).toEqual([
+      {key: '1-0-0-0', pointCount: 5, pointLimit: 5},
+      {key: '2-1-0-0', pointCount: 20, pointLimit: 2}
+    ]);
+    expect(selection.reduce((sum, tile) => sum + tile.pointLimit, 0)).toBe(7);
+    await expect(source.selectTiles(0, [0, 0])).rejects.toThrow(
+      'EPT targetPointCount must be a positive integer'
+    );
+  });
+});
+
+describe('NYCEPTTileSource tile decoding', () => {
+  test('retains decode provenance while normalizing and packing bounded rows', async () => {
+    const requestedLASUrls: string[] = [];
+    const adapter = makeHierarchyAdapter({
+      '0-0-0-0': {'1-1-1-0': 3}
+    });
+    adapter.loadLASMesh = async url => {
+      requestedLASUrls.push(String(url));
+      return {
+        attributes: {
+          POSITION: {
+            value: new Float64Array([10, 20, 30, 110, 70, 130, 60, 45, 80])
+          },
+          intensity: {value: new Uint16Array([1, 65_535, 40])},
+          classification: new Uint8Array([2, 255, 7])
+        }
+      };
+    };
+    const source = await NYCEPTTileSource.create(undefined, {
+      metadataUrl: METADATA_URL,
+      adapter
+    });
+
+    const tile = await source.loadTile({key: '1-1-1-0', pointCount: 3, pointLimit: 2});
+
+    expect(requestedLASUrls).toEqual(['https://tiles.example.test/new-york/ept-data/1-1-1-0.laz']);
+    expect(tile.key).toBe('1-1-1-0');
+    expect(tile.decodedPointCount).toBe(3);
+    expect(tile.pointCount).toBe(2);
+    expect(Array.from(tile.positions)).toEqual([-1, -0.5, 0, 1, 0.5, 1.7000000476837158]);
+    expect(Array.from(tile.attributes)).toEqual([258, 16_777_215]);
+  });
+
+  test('honors cancellation before and after injected asynchronous work', async () => {
+    const alreadyAbortedController = new AbortController();
+    alreadyAbortedController.abort();
+    let requestCount = 0;
+    const adapter = makeHierarchyAdapter({'0-0-0-0': {}});
+    const originalFetchJSON = adapter.fetchJSON;
+    adapter.fetchJSON = async (url, signal) => {
+      requestCount++;
+      return originalFetchJSON(url, signal);
+    };
+
+    await expect(
+      NYCEPTTileSource.create(alreadyAbortedController.signal, {
+        metadataUrl: METADATA_URL,
+        adapter
+      })
+    ).rejects.toMatchObject({name: 'AbortError'});
+    expect(requestCount).toBe(0);
+
+    const source = await NYCEPTTileSource.create(undefined, {
+      metadataUrl: METADATA_URL,
+      adapter
+    });
+    const decodeController = new AbortController();
+    let decodeCount = 0;
+    adapter.loadLASMesh = async (_url, signal) => {
+      expect(signal).toBe(decodeController.signal);
+      decodeCount++;
+      decodeController.abort();
+      return {attributes: {POSITION: new Float32Array([10, 20, 30])}};
+    };
+
+    await expect(
+      source.loadTile({key: '0-0-0-0', pointCount: 1, pointLimit: 1}, decodeController.signal)
+    ).rejects.toMatchObject({name: 'AbortError'});
+    expect(decodeCount).toBe(1);
+  });
+});

--- a/test/examples/gpgpu-responsive-data.node.spec.ts
+++ b/test/examples/gpgpu-responsive-data.node.spec.ts
@@ -189,7 +189,7 @@ describe('responsive GPU data examples', () => {
     expect(gridCountSource![0]).not.toMatch(/new Array<number>\(dimension\)/);
     expect(atlasSource).toMatch(/resources\.renderGraph\.destroy\(\)/);
     expect(atlasSmokeSource).toMatch(
-      /if \(requireGPUReadback\) \{\s*await changeSelect\(page, '#example-panel-host \[data-mode\]', 'taxi'\)/
+      /if \(requireGPUReadback\) \{\s*await changeSelect\(page, '#example-panel-host \[data-mode\]', 'lidar'\)/
     );
     expect(atlasSmokeSource).toMatch(/canvas\?\.dataset\.atlasTransitionFailure/);
     expect(atlasSmokeSource).toMatch(/canvas\?\.dataset\.atlasDeviceLost/);

--- a/test/examples/gpgpu-responsive-data.node.spec.ts
+++ b/test/examples/gpgpu-responsive-data.node.spec.ts
@@ -22,6 +22,10 @@ const ATLAS_APP_SOURCE_PATH = path.join(
   process.cwd(),
   'examples/showcase/billion-point-spatial-atlas/app.ts'
 );
+const ATLAS_SMOKE_SOURCE_PATH = path.join(
+  process.cwd(),
+  'examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs'
+);
 
 describe('responsive GPU data examples', () => {
   test('progressively generates the exact deterministic taxi population and reports progress', async () => {
@@ -135,6 +139,7 @@ describe('responsive GPU data examples', () => {
 
   test('loads the spatial atlas progressively and reuses its GPU index and query results', () => {
     const atlasSource = readFileSync(ATLAS_APP_SOURCE_PATH, 'utf8');
+    const atlasSmokeSource = readFileSync(ATLAS_SMOKE_SOURCE_PATH, 'utf8');
     const constructorSource = atlasSource.match(
       /constructor\(\{device\}: AnimationProps\)\s*\{([\s\S]*?)\n  \}\n\n  override async onInitialize/
     );
@@ -170,5 +175,8 @@ describe('responsive GPU data examples', () => {
     expect(gridCountSource).not.toBeNull();
     expect(gridCountSource![0]).not.toMatch(/new Array<number>\(dimension\)/);
     expect(atlasSource).toMatch(/resources\.renderGraph\.destroy\(\)/);
+    expect(atlasSmokeSource).toMatch(
+      /if \(requireGPUReadback\) \{\s*await changeSelect\(page, '#example-panel-host \[data-mode\]', 'taxi'\)/
+    );
   });
 });

--- a/test/examples/gpgpu-responsive-data.node.spec.ts
+++ b/test/examples/gpgpu-responsive-data.node.spec.ts
@@ -141,6 +141,9 @@ describe('responsive GPU data examples', () => {
     const gridCountSource = atlasSource.match(
       /function makeGridCellCounts\s*\([\s\S]*?\n\}\n\nfunction countCandidates/
     );
+    const rebuildResourcesStart = atlasSource.indexOf('  private rebuildResources(');
+    const resizeResourcesStart = atlasSource.indexOf('  private resizeResources(');
+    const rebuildResourcesSource = atlasSource.slice(rebuildResourcesStart, resizeResourcesStart);
 
     expect(constructorSource).not.toBeNull();
     expect(constructorSource![1]).toMatch(/this\.currentPositions\s*=\s*new Float32Array\(0\)/);
@@ -148,6 +151,12 @@ describe('responsive GPU data examples', () => {
     expect(atlasSource).toMatch(/await this\.loadSyntheticDataset\(this\.mode, this\.capacity\)/);
     expect(atlasSource).toMatch(/await yieldAtlasGeneration\(generationController\.signal\)/);
     expect(atlasSource).toMatch(/this\.dataGenerationAbortController\?\.abort\(\)/);
+    expect(atlasSource).toMatch(/this\.canvas\.dataset\.atlasDataReadyMode = mode/);
+    expect(atlasSource).toMatch(/byteLength: Math\.max\(UINT32_BYTE_LENGTH, data\.byteLength\)/);
+    expect(atlasSource).toMatch(/buffer\.write\(data\)/);
+    expect(rebuildResourcesStart).toBeGreaterThanOrEqual(0);
+    expect(resizeResourcesStart).toBeGreaterThan(rebuildResourcesStart);
+    expect(rebuildResourcesSource).not.toMatch(/createBuffer\(\{[\s\S]*?data:/);
     expect(atlasSource).toMatch(/this\.resizeResources\(resources,/);
     expect(atlasSource).toMatch(
       /queryChanged \? this\.getQueryGraph\(resources\) : resources\.renderGraph/

--- a/test/examples/gpgpu-responsive-data.node.spec.ts
+++ b/test/examples/gpgpu-responsive-data.node.spec.ts
@@ -156,6 +156,19 @@ describe('responsive GPU data examples', () => {
     expect(atlasSource).toMatch(/await this\.loadSyntheticDataset\(this\.mode, this\.capacity\)/);
     expect(atlasSource).toMatch(/await yieldAtlasGeneration\(generationController\.signal\)/);
     expect(atlasSource).toMatch(/this\.dataGenerationAbortController\?\.abort\(\)/);
+    expect(atlasSource).toMatch(/const transitionGeneration = \+\+this\.modeTransitionGeneration/);
+    expect(atlasSource).toMatch(/await this\.waitForSubmittedGPUWork\(\)/);
+    expect(atlasSource).toMatch(/const fence = this\.device\.createFence\(\)/);
+    expect(atlasSource).toMatch(/transitionGeneration !== this\.modeTransitionGeneration/);
+    expect(atlasSource).toMatch(
+      /const pendingReadbacks = \[\.\.\.this\.gpuTimingReadbacks\][\s\S]*const fence = this\.device\.createFence\(\)/
+    );
+    expect(atlasSource).toMatch(/if \(this\.requestedMode !== null\) return;/);
+    expect(atlasSource).toMatch(
+      /captureVisualSmokeFrame[\s\S]*if \(this\.requestedMode !== null\)/
+    );
+    expect(atlasSource).toMatch(/controller\.signal\.throwIfAborted\(\)/);
+    expect(atlasSource).toMatch(/this\.device\.lost/);
     expect(atlasSource).toMatch(/this\.canvas\.dataset\.atlasDataReadyMode = mode/);
     expect(atlasSource).toMatch(/const VISUAL_SMOKE_TAXI_GRID_SIZE = \[16, 16\] as const/);
     expect(atlasSource).toMatch(/const VISUAL_SMOKE_LIDAR_GRID_SIZE = \[16, 16, 4\] as const/);
@@ -178,5 +191,7 @@ describe('responsive GPU data examples', () => {
     expect(atlasSmokeSource).toMatch(
       /if \(requireGPUReadback\) \{\s*await changeSelect\(page, '#example-panel-host \[data-mode\]', 'taxi'\)/
     );
+    expect(atlasSmokeSource).toMatch(/canvas\?\.dataset\.atlasTransitionFailure/);
+    expect(atlasSmokeSource).toMatch(/canvas\?\.dataset\.atlasDeviceLost/);
   });
 });

--- a/test/examples/gpgpu-responsive-data.node.spec.ts
+++ b/test/examples/gpgpu-responsive-data.node.spec.ts
@@ -152,6 +152,11 @@ describe('responsive GPU data examples', () => {
     expect(atlasSource).toMatch(/await yieldAtlasGeneration\(generationController\.signal\)/);
     expect(atlasSource).toMatch(/this\.dataGenerationAbortController\?\.abort\(\)/);
     expect(atlasSource).toMatch(/this\.canvas\.dataset\.atlasDataReadyMode = mode/);
+    expect(atlasSource).toMatch(/const VISUAL_SMOKE_TAXI_GRID_SIZE = \[16, 16\] as const/);
+    expect(atlasSource).toMatch(/const VISUAL_SMOKE_LIDAR_GRID_SIZE = \[16, 16, 4\] as const/);
+    expect(rebuildResourcesSource).toMatch(
+      /IS_VISUAL_SMOKE[\s\S]*VISUAL_SMOKE_TAXI_GRID_SIZE[\s\S]*TAXI_GRID_SIZE[\s\S]*IS_VISUAL_SMOKE[\s\S]*VISUAL_SMOKE_LIDAR_GRID_SIZE[\s\S]*LIDAR_GRID_SIZE/
+    );
     expect(atlasSource).toMatch(/byteLength: Math\.max\(UINT32_BYTE_LENGTH, data\.byteLength\)/);
     expect(atlasSource).toMatch(/buffer\.write\(data\)/);
     expect(rebuildResourcesStart).toBeGreaterThanOrEqual(0);

--- a/test/examples/gpgpu-responsive-data.node.spec.ts
+++ b/test/examples/gpgpu-responsive-data.node.spec.ts
@@ -169,6 +169,25 @@ describe('responsive GPU data examples', () => {
     );
     expect(atlasSource).toMatch(/controller\.signal\.throwIfAborted\(\)/);
     expect(atlasSource).toMatch(/this\.device\.lost/);
+    expect(atlasSource).toMatch(
+      /this\.completeSameModeTransition\(resumeLidarLoad, resumeLidarPublish\)/
+    );
+    expect(atlasSource).toMatch(
+      /resources\.pointCount === capacity[\s\S]*resources\.renderPositions === this\.lidarTileCache\.positionsBuffer/
+    );
+    expect(atlasSource).toMatch(
+      /this\.resumeLidarLoadAfterModeTransition \|\|=[\s\S]*this\.resumeLidarPublishAfterModeTransition \|\|=/
+    );
+    expect(atlasSource).toMatch(/this\.clearModeTransitionResumeState\(\)/);
+    expect(atlasSource).toMatch(
+      /this\.modeTransitionFailed = true[\s\S]*this\.modeTransitionFailed = false/
+    );
+    expect(atlasSource).toMatch(
+      /private async loadLidar[\s\S]*?this\.modeTransitionFailed[\s\S]*?private maybeRefreshLidarTiles/
+    );
+    expect(atlasSource).toMatch(
+      /private changeCapacity[\s\S]*?this\.modeTransitionFailed[\s\S]*?private destroyResources/
+    );
     expect(atlasSource).toMatch(/this\.canvas\.dataset\.atlasDataReadyMode = mode/);
     expect(atlasSource).toMatch(/const VISUAL_SMOKE_TAXI_GRID_SIZE = \[16, 16\] as const/);
     expect(atlasSource).toMatch(/const VISUAL_SMOKE_LIDAR_GRID_SIZE = \[16, 16, 4\] as const/);
@@ -193,5 +212,9 @@ describe('responsive GPU data examples', () => {
     );
     expect(atlasSmokeSource).toMatch(/canvas\?\.dataset\.atlasTransitionFailure/);
     expect(atlasSmokeSource).toMatch(/canvas\?\.dataset\.atlasDeviceLost/);
+    expect(atlasSmokeSource).toMatch(/softwareGpu: !requireGPUReadback/);
+    expect(atlasSmokeSource).toMatch(
+      /await assertNoAtlasGPUFailure\(page, 'completed visual smoke'\)/
+    );
   });
 });

--- a/test/examples/spatial-atlas-lidar-tile-cache.node.spec.ts
+++ b/test/examples/spatial-atlas-lidar-tile-cache.node.spec.ts
@@ -1,0 +1,179 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Device} from '@luma.gl/core';
+import {describe, expect, test} from 'vitest';
+import {GPULidarTileCache} from '../../examples/showcase/billion-point-spatial-atlas/lidar-tile-cache';
+
+type FakeBufferProperties = {
+  id?: string;
+  byteLength: number;
+  usage?: number;
+};
+
+class FakeBuffer {
+  readonly writes: (Float32Array | Uint32Array)[] = [];
+  destroyCount = 0;
+
+  constructor(readonly properties: FakeBufferProperties) {}
+
+  write(data: Float32Array | Uint32Array): void {
+    this.writes.push(data instanceof Float32Array ? new Float32Array(data) : new Uint32Array(data));
+  }
+
+  destroy(): void {
+    this.destroyCount++;
+  }
+}
+
+class FakeDevice {
+  readonly buffers: FakeBuffer[] = [];
+
+  createBuffer(properties: FakeBufferProperties): FakeBuffer {
+    const buffer = new FakeBuffer(properties);
+    this.buffers.push(buffer);
+    return buffer;
+  }
+}
+
+function makeCache(pointCapacity: number): {
+  cache: GPULidarTileCache;
+  positionsBuffer: FakeBuffer;
+  attributesBuffer: FakeBuffer;
+} {
+  const device = new FakeDevice();
+  const cache = new GPULidarTileCache(device as unknown as Device, pointCapacity);
+  const positionsBuffer = device.buffers[0];
+  const attributesBuffer = device.buffers[1];
+  if (!positionsBuffer || !attributesBuffer) {
+    throw new Error('GPULidarTileCache must allocate its position and attribute buffers');
+  }
+  return {
+    cache,
+    positionsBuffer,
+    attributesBuffer
+  };
+}
+
+function makePositions(...pointIdentifiers: number[]): Float32Array {
+  return new Float32Array(
+    pointIdentifiers.flatMap(pointIdentifier => [
+      pointIdentifier,
+      pointIdentifier + 0.25,
+      -pointIdentifier
+    ])
+  );
+}
+
+describe('GPULidarTileCache', () => {
+  test('inserts tiles and reports their resident rows', () => {
+    const {cache, positionsBuffer, attributesBuffer} = makeCache(5);
+
+    cache.insert('west', makePositions(1, 2), new Uint32Array([101, 102]));
+    cache.insert('east', makePositions(3), new Uint32Array([103]));
+
+    expect(cache.pointCount).toBe(3);
+    expect(cache.tileCount).toBe(2);
+    expect(cache.getPointCount('west')).toBe(2);
+    expect(cache.getPointCount('east')).toBe(1);
+    expect(cache.getPointCount('missing')).toBe(0);
+    expect(cache.getSnapshot()).toEqual({
+      positions: makePositions(1, 2, 3),
+      attributes: new Uint32Array([101, 102, 103])
+    });
+    expect(positionsBuffer.properties).toMatchObject({
+      id: 'spatial-atlas-lidar-lru',
+      byteLength: 5 * 3 * Float32Array.BYTES_PER_ELEMENT
+    });
+    expect(attributesBuffer.properties).toMatchObject({
+      id: 'spatial-atlas-lidar-lru-attributes',
+      byteLength: 5 * Uint32Array.BYTES_PER_ELEMENT
+    });
+  });
+
+  test('touches a tile before evicting the least-recently-used tile', () => {
+    const {cache} = makeCache(4);
+    cache.insert('oldest', makePositions(1, 2), new Uint32Array([11, 12]));
+    cache.insert('newer', makePositions(3, 4), new Uint32Array([13, 14]));
+
+    cache.touch('oldest');
+    cache.touch('missing');
+    cache.insert('newest', makePositions(5, 6), new Uint32Array([15, 16]));
+
+    expect(cache.getPointCount('oldest')).toBe(2);
+    expect(cache.getPointCount('newer')).toBe(0);
+    expect(cache.getPointCount('newest')).toBe(2);
+    expect(cache.getSnapshot()).toEqual({
+      positions: makePositions(1, 2, 5, 6),
+      attributes: new Uint32Array([11, 12, 15, 16])
+    });
+  });
+
+  test('retains selected tiles and reports whether residency changed', () => {
+    const {cache} = makeCache(6);
+    cache.insert('one', makePositions(1, 2), new Uint32Array([11, 12]));
+    cache.insert('two', makePositions(3), new Uint32Array([13]));
+    cache.insert('three', makePositions(4, 5), new Uint32Array([14, 15]));
+
+    expect(cache.retain(new Set(['two', 'three']))).toBe(true);
+    expect(cache.retain(new Set(['two', 'three']))).toBe(false);
+    expect(cache.pointCount).toBe(3);
+    expect(cache.tileCount).toBe(2);
+    expect(cache.getSnapshot()).toEqual({
+      positions: makePositions(3, 4, 5),
+      attributes: new Uint32Array([13, 14, 15])
+    });
+  });
+
+  test('truncates an oversized tile to the atlas point capacity', () => {
+    const {cache} = makeCache(3);
+
+    cache.insert('oversized', makePositions(1, 2, 3, 4, 5), new Uint32Array([11, 12, 13, 14, 15]));
+
+    expect(cache.pointCount).toBe(3);
+    expect(cache.getPointCount('oversized')).toBe(3);
+    expect(cache.getSnapshot()).toEqual({
+      positions: makePositions(1, 2, 3),
+      attributes: new Uint32Array([11, 12, 13])
+    });
+  });
+
+  test('synchronizes a contiguous snapshot into both GPU buffers', () => {
+    const {cache, positionsBuffer, attributesBuffer} = makeCache(4);
+    cache.insert('one', makePositions(1), new Uint32Array([11]));
+    cache.insert('two', makePositions(2, 3), new Uint32Array([12, 13]));
+
+    const snapshot = cache.synchronize();
+
+    expect(snapshot).toEqual({
+      positions: makePositions(1, 2, 3),
+      attributes: new Uint32Array([11, 12, 13])
+    });
+    expect(positionsBuffer.writes).toEqual([snapshot.positions]);
+    expect(attributesBuffer.writes).toEqual([snapshot.attributes]);
+
+    cache.retain(new Set());
+    expect(cache.synchronize()).toEqual({
+      positions: new Float32Array(),
+      attributes: new Uint32Array()
+    });
+    expect(positionsBuffer.writes).toHaveLength(1);
+    expect(attributesBuffer.writes).toHaveLength(1);
+  });
+
+  test('destroys GPU resources exactly once and rejects later insertions', () => {
+    const {cache, positionsBuffer, attributesBuffer} = makeCache(2);
+    cache.insert('tile', makePositions(1), new Uint32Array([11]));
+
+    cache.destroy();
+    cache.destroy();
+    cache.insert('late', makePositions(2), new Uint32Array([12]));
+
+    expect(positionsBuffer.destroyCount).toBe(1);
+    expect(attributesBuffer.destroyCount).toBe(1);
+    expect(cache.pointCount).toBe(0);
+    expect(cache.tileCount).toBe(0);
+    expect(cache.getPointCount('late')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Goals

- Validate the Spatial Atlas against a realistic EPT hierarchy and decoded LiDAR lifecycle.
- Make GPU tile-cache ownership, eviction, replacement, and teardown behavior independently testable.
- Add a deterministic browser smoke test that exercises the visible Taxi/LiDAR controls and verifies the WebGPU render lifecycle in CI.

## Changes

- Adds injectable EPT fetch/decode seams, hierarchy caching, cancellation checks, source provenance, and browser-accurate Float64 LAS decoding before tile-local recentering.
- Fixes EPT focus normalization to map display coordinates through `boundsConforming` and subdivide the actual EPT octree `bounds`.
- Extracts `GPULidarTileCache` from the showcase and covers capacity, LRU touch/eviction, retention, truncation, buffer synchronization, and idempotent destruction.
- Adds focused EPT tests for progressive hierarchy discovery, capacity, URL resolution, cancellation, provenance, normalization, and point packing.
- Registers the Atlas visual smoke in browser CI shard 1 and uploads scene and layout artifacts.
- Exercises the real compact-dropdown interaction path, Taxi zones, polygon/radius tools, index/scan choice, zoom/reset, Taxi/LiDAR mode switching, intensity coloring, and restored per-mode state.
- Verifies WebGPU availability, completed Taxi/LiDAR frame markers, nonzero resident/candidate counts, visible query/navigation surfaces, synchronized controls, and bounded layout.
- Retains an opt-in smoke-only direct scene-texture readback for capable reference devices. It rejects flat frames, near-empty foregrounds, stale mode markers, and identical Taxi/LiDAR scene hashes without CPU synchronization in the product path.
- Preserves a failing scene PNG separately from the layout artifact for CI diagnosis.

## Verification

Passed locally:

- `nvm use` — Node 22.22.1
- focused Vitest suite — 10 tests passed across the EPT source and GPU tile cache
- focused strict TypeScript checks for the EPT source and tile cache
- `node --check examples/showcase/billion-point-spatial-atlas/scripts/visual-smoke.mjs`
- local Playwright Atlas smoke after the final change
- workflow YAML parse
- `git diff --check`
- independent review: no remaining P0/P1/P2 findings

Repository-wide gates were attempted but cannot complete in this worktree because the approved package registry returns 403 for the current `playwright@1.62.1`, `playwright-core@1.62.1`, and `@vis.gl/dev-tools@2.0.0-alpha.3` artifacts. The available shared dependency tree predates current master:

- `yarn install --immutable` — blocked by those registry 403 responses
- `yarn lint fix` — blocked by the unavailable current `@vis.gl/dev-tools`; the pre-commit hook falls back to obsolete ESLint wiring
- `yarn build` — blocked by missing current `ocular-build`
- `yarn test` — blocked by missing current `ocular-test`
- `yarn examples:typecheck` — attempted; the stale dependency tree reports existing cross-package API/version-skew errors outside this tranche
- `yarn website:build` — blocked by missing current website tooling
- `(cd website && yarn build)` — blocked by missing current `vite`

The clean-install GitHub workflow is therefore the authoritative repository-wide gate.

## Risks and CI boundary

- GitHub-hosted SwiftShader completes the interaction smoke but does not reliably resolve a live scene-texture map request, even through the luma.gl synchronized readback wrapper and full Chromium.
- Required CI therefore gates on WebGPU initialization, completed frame markers, real control/state transitions, nonzero query activity, error-free execution, and layout artifacts. Direct scene readback remains available with `SPATIAL_ATLAS_REQUIRE_GPU_READBACK=true` for capable reference devices.
- Network and large-corpus data remain out of CI; injected deterministic EPT fixtures cover lifecycle behavior.