### PR TITLE
feat(examples): inspect exact luSpatial query work

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -424,21 +424,27 @@ if (encoding.canReadGPUTimings) {
   await observation.recordGPUTimings(encoding);
 }
 
+// The application remains responsible for any diagnostic-buffer readback.
+observation.recordCounters({candidates, matches});
+
 const snapshot = inspector.getSnapshot();
 observation.detach();
 ```
 
 `getSnapshot()` returns an immutable view of every registered graph in registration order. Each
 graph snapshot includes its compile-time `stats` and `capabilities`, encoding and failed-timing-read
-counts, bounded whole-graph CPU and GPU duration summaries, and per-node summaries in compiled
-schedule order. Duration summaries contain the retained sample count plus latest, p50, and p95
-milliseconds when samples exist. Pass `getNodeGroup` to the constructor to add application-specific
-semantic groups to node snapshots; pass `maxSamples` to bound each retained timing history.
+counts, bounded whole-graph CPU and GPU duration summaries, application-defined scalar counter
+summaries, and per-node summaries in compiled schedule order. Duration and counter summaries contain
+the retained sample count plus latest, p50, and p95 values. Counters remain in first-observed order.
+Pass `getNodeGroup` to the constructor to add application-specific semantic groups to node snapshots;
+pass `maxSamples` to bound every retained history.
 
 The inspector does not submit commands, poll frames, render a panel, or read GPU timestamps
 automatically. An observation does not own or destroy its graph. `detach()` stops that observation
 and removes its registration when it is still current; an old handle cannot remove a replacement
-with the same graph ID. A handle accepts timing reads only for encodings it produced and records at
-most one GPU sample per encoding. `clear()` removes all registrations. The lower-level
-`registerGraph()`, `recordEncoding()`, and `recordGPUTimings()` methods remain available for
-applications that cannot route graph encoding through an observation handle.
+with the same graph ID or publish delayed counters into it. A handle accepts timing reads only for
+encodings it produced and records at most one GPU sample per encoding. `recordCounters()` only
+stores caller-provided finite, non-negative values; it does not read a buffer or synchronize the
+device. `clear()` removes all registrations. The lower-level `registerGraph()`, `recordEncoding()`,
+`recordGPUTimings()`, and `recordCounters()` methods remain available for applications that cannot
+route graph activity through an observation handle.

--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -405,26 +405,27 @@ buffers, textures, and external-image bindings remain caller-owned.
 
 ## `GPUCommandGraphInspector`
 
-`GPUCommandGraphInspector` is a data-only collector for one or more compiled graphs. Register each
-compiled graph once, record synchronous CPU measurements immediately after `encode()`, and request
-optional GPU timestamp readback only after submitting the command buffer:
+`GPUCommandGraphInspector` is a data-only collector for one or more compiled graphs. Its non-owning
+observation handle registers a graph and records synchronous CPU measurements whenever encoding is
+routed through the handle. Optional GPU timestamp readback remains explicit and happens only after
+the caller submits the command buffer:
 
 ```ts
 import {GPUCommandGraphInspector} from '@luma.gl/experimental';
 
 const inspector = new GPUCommandGraphInspector({maxSamples: 120});
-inspector.registerGraph(compiled);
+const observation = inspector.observeGraph(compiled);
 
 const commandEncoder = device.createCommandEncoder();
-const encoding = compiled.encode(commandEncoder, {parameters: {time}});
-inspector.recordEncoding(compiled.id, encoding);
+const encoding = observation.encode(commandEncoder, {parameters: {time}});
 device.submit(commandEncoder.finish());
 
 if (encoding.canReadGPUTimings) {
-  await inspector.recordGPUTimings(compiled.id, encoding);
+  await observation.recordGPUTimings(encoding);
 }
 
 const snapshot = inspector.getSnapshot();
+observation.detach();
 ```
 
 `getSnapshot()` returns an immutable view of every registered graph in registration order. Each
@@ -435,5 +436,9 @@ milliseconds when samples exist. Pass `getNodeGroup` to the constructor to add a
 semantic groups to node snapshots; pass `maxSamples` to bound each retained timing history.
 
 The inspector does not submit commands, poll frames, render a panel, or read GPU timestamps
-automatically. `clear()` removes all registrations, while registering a new compiled graph with an
-existing ID replaces its captured metadata and resets its measurements.
+automatically. An observation does not own or destroy its graph. `detach()` stops that observation
+and removes its registration when it is still current; an old handle cannot remove a replacement
+with the same graph ID. A handle accepts timing reads only for encodings it produced and records at
+most one GPU sample per encoding. `clear()` removes all registrations. The lower-level
+`registerGraph()`, `recordEncoding()`, and `recordGPUTimings()` methods remain available for
+applications that cannot route graph encoding through an observation handle.

--- a/examples/deck/luspatial-taxi/app.ts
+++ b/examples/deck/luspatial-taxi/app.ts
@@ -19,7 +19,11 @@ import {
 import {ArrowDeck} from '../arrow-deck';
 import {getDeckExampleProps, type DeckExampleDeviceOptions} from '../deck-example-device';
 import {LuSpatialPointLayer} from './luspatial-point-layer';
-import {LuSpatialTaxiQueryEffect, type LuSpatialTaxiQueryStats} from './luspatial-query-effect';
+import {
+  LU_SPATIAL_TAXI_QUERY_COUNTER_IDS,
+  LuSpatialTaxiQueryEffect,
+  type LuSpatialTaxiQueryStats
+} from './luspatial-query-effect';
 import {
   TAXI_CORPUS_POINT_COUNT,
   TAXI_POINT_COUNT,
@@ -626,6 +630,14 @@ function createControlPanel(
     graphLabels: {
       'luspatial-taxi-build-graph': 'luProj projection + grid build',
       'luspatial-taxi-query-graph': 'Viewport + radius queries'
+    },
+    counterLabels: {
+      [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.viewportIntersectedCells]: 'Viewport cells',
+      [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.viewportCandidates]: 'Viewport candidates',
+      [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.viewportMatches]: 'Viewport matches',
+      [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.selectionIntersectedCells]: 'Selection cells',
+      [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.selectionCandidates]: 'Selection candidates',
+      [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.selectionMatches]: 'Selection matches'
     }
   });
 

--- a/examples/deck/luspatial-taxi/luspatial-query-effect.ts
+++ b/examples/deck/luspatial-taxi/luspatial-query-effect.ts
@@ -450,11 +450,7 @@ export class LuSpatialTaxiQueryEffect implements Effect {
       'selection-overflow',
       this.selectionOverflow
     );
-    const queryDiagnosticsBuffer = importBuffer(
-      graph,
-      'query-diagnostics',
-      this.queryDiagnostics
-    );
+    const queryDiagnosticsBuffer = importBuffer(graph, 'query-diagnostics', this.queryDiagnostics);
     const drawCommandBuffer = importBuffer(graph, 'draw-commands', this.drawCommands.buffer);
 
     const positions = graph.createDataView(projectedBuffer, {
@@ -565,23 +561,17 @@ export class LuSpatialTaxiQueryEffect implements Effect {
         this.queryDiagnostics.readAsync()
       ]);
       if (this.destroyed) return;
-      const counters = decodeLuSpatialTaxiQueryCounters(
-        drawCommandBytes,
-        queryDiagnosticBytes,
-        {
-          viewportInstanceCountByteOffset: this.drawCommands.getInstanceCountByteOffset(0),
-          selectionInstanceCountByteOffset: this.drawCommands.getInstanceCountByteOffset(1)
-        }
-      );
+      const counters = decodeLuSpatialTaxiQueryCounters(drawCommandBytes, queryDiagnosticBytes, {
+        viewportInstanceCountByteOffset: this.drawCommands.getInstanceCountByteOffset(0),
+        selectionInstanceCountByteOffset: this.drawCommands.getInstanceCountByteOffset(1)
+      });
       this.viewportIntersectedCellCount = counters.viewportIntersectedCellCount;
       this.viewportCandidateCount = counters.viewportCandidateCount;
       this.visiblePointCount = counters.visiblePointCount;
       this.selectionIntersectedCellCount = counters.selectionIntersectedCellCount;
       this.selectionCandidateCount = counters.selectionCandidateCount;
       this.selectedPointCount = counters.selectedPointCount;
-      this.queryGraphObservation.recordCounters(
-        makeLuSpatialTaxiQueryInspectorCounters(counters)
-      );
+      this.queryGraphObservation.recordCounters(makeLuSpatialTaxiQueryInspectorCounters(counters));
       this.publishStats();
     } catch {
       // Device loss or teardown can reject optional diagnostics after the render path has ended.

--- a/examples/deck/luspatial-taxi/luspatial-query-effect.ts
+++ b/examples/deck/luspatial-taxi/luspatial-query-effect.ts
@@ -8,6 +8,7 @@ import {
   DrawCommandBuffer,
   GPUCommandGraph,
   GPUCommandGraphInspector,
+  type GPUCommandGraphInspectorObservation,
   type GPUCommandGraphInspectorSnapshot,
   type CompiledGPUCommandGraph
 } from '@luma.gl/experimental';
@@ -69,6 +70,8 @@ export class LuSpatialTaxiQueryEffect implements Effect {
   private readonly selectionOverflow: Buffer;
   private readonly buildGraph: CompiledGPUCommandGraph<void>;
   private readonly queryGraph: CompiledGPUCommandGraph<void>;
+  private readonly buildGraphObservation: GPUCommandGraphInspectorObservation<void>;
+  private readonly queryGraphObservation: GPUCommandGraphInspectorObservation<void>;
   private readonly onStats?: (stats: LuSpatialTaxiQueryStats) => void;
   private projection: GPUProjection | null = null;
   private selectionCenter: readonly [number, number] = [-73.9855, 40.758];
@@ -187,18 +190,21 @@ export class LuSpatialTaxiQueryEffect implements Effect {
 
       this.buildGraph = this.ownResource(this.createBuildGraph());
       this.queryGraph = this.ownResource(this.createQueryGraph());
-      this.inspector.registerGraph(this.buildGraph);
-      this.inspector.registerGraph(this.queryGraph);
+      this.buildGraphObservation = this.ownObservation(
+        this.inspector.observeGraph(this.buildGraph)
+      );
+      this.queryGraphObservation = this.ownObservation(
+        this.inspector.observeGraph(this.queryGraph)
+      );
       const commandEncoder = device.createCommandEncoder({id: 'luspatial-taxi-index-build'});
-      const encoding = this.buildGraph.encode(commandEncoder, {parameters: undefined});
-      this.inspector.recordEncoding(this.buildGraph.id, encoding);
+      const encoding = this.buildGraphObservation.encode(commandEncoder, {parameters: undefined});
       this.buildEncodingMilliseconds = encoding.stats.cpuEncodeTimeMilliseconds;
       device.submit(commandEncoder.finish());
       this.publishStats();
       if (encoding.canReadGPUTimings) {
         setTimeout(() => {
           if (!this.destroyed) {
-            void this.inspector.recordGPUTimings(this.buildGraph.id, encoding);
+            void this.buildGraphObservation.recordGPUTimings(encoding);
           }
         }, 0);
       }
@@ -263,8 +269,9 @@ export class LuSpatialTaxiQueryEffect implements Effect {
       ])
     );
 
-    const encoding = this.queryGraph.encode(this.device.commandEncoder, {parameters: undefined});
-    this.inspector.recordEncoding(this.queryGraph.id, encoding);
+    const encoding = this.queryGraphObservation.encode(this.device.commandEncoder, {
+      parameters: undefined
+    });
     this.queryEncodingMilliseconds = encoding.stats.cpuEncodeTimeMilliseconds;
     this.frameIndex++;
     this.queryInputsChanged = false;
@@ -274,7 +281,7 @@ export class LuSpatialTaxiQueryEffect implements Effect {
       if (encoding.canReadGPUTimings) {
         setTimeout(() => {
           if (!this.destroyed) {
-            void this.inspector.recordGPUTimings(this.queryGraph.id, encoding);
+            void this.queryGraphObservation.recordGPUTimings(encoding);
           }
         }, 0);
       }
@@ -298,6 +305,11 @@ export class LuSpatialTaxiQueryEffect implements Effect {
   private ownResource<T extends DestroyableResource>(resource: T): T {
     this.ownedResources.push(resource);
     return resource;
+  }
+
+  private ownObservation<T extends {detach: () => void}>(observation: T): T {
+    this.ownedResources.push({destroy: () => observation.detach()});
+    return observation;
   }
 
   private destroyOwnedResources(): void {

--- a/examples/deck/luspatial-taxi/luspatial-query-effect.ts
+++ b/examples/deck/luspatial-taxi/luspatial-query-effect.ts
@@ -17,13 +17,41 @@ import {compileProjectionPlan, GPUProjection} from '@luma.gl/experimental/luproj
 import {TAXI_GRID_SIZE, projectTaxiLongitudeLatitude, type LuSpatialTaxiData} from './taxi-data';
 
 const UINT32_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
+const STORAGE_BUFFER_OFFSET_ALIGNMENT = 256;
+
+export const LU_SPATIAL_TAXI_QUERY_COUNTER_IDS = {
+  viewportIntersectedCells: 'viewport-intersected-cells',
+  viewportCandidates: 'viewport-candidates',
+  viewportMatches: 'viewport-matches',
+  selectionIntersectedCells: 'selection-intersected-cells',
+  selectionCandidates: 'selection-candidates',
+  selectionMatches: 'selection-matches'
+} as const;
+
+export const LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS = {
+  viewportIntersectedCellCount: 0,
+  viewportCandidateCount: STORAGE_BUFFER_OFFSET_ALIGNMENT,
+  selectionIntersectedCellCount: STORAGE_BUFFER_OFFSET_ALIGNMENT * 2,
+  selectionCandidateCount: STORAGE_BUFFER_OFFSET_ALIGNMENT * 3
+} as const;
+
+const QUERY_DIAGNOSTIC_BUFFER_BYTE_LENGTH =
+  LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.selectionCandidateCount + UINT32_BYTE_LENGTH;
 
 type DestroyableResource = {destroy(): void};
 
-export type LuSpatialTaxiQueryStats = {
-  residentPointCount: number;
+/** Exact work and result counts sampled from the two GPU spatial queries. */
+export type LuSpatialTaxiQueryCounters = {
+  viewportIntersectedCellCount: number;
+  viewportCandidateCount: number;
   visiblePointCount: number;
+  selectionIntersectedCellCount: number;
+  selectionCandidateCount: number;
   selectedPointCount: number;
+};
+
+export type LuSpatialTaxiQueryStats = LuSpatialTaxiQueryCounters & {
+  residentPointCount: number;
   graphNodeCount: number;
   buildEncodingMilliseconds: number;
   queryEncodingMilliseconds: number;
@@ -68,6 +96,7 @@ export class LuSpatialTaxiQueryEffect implements Effect {
   private readonly selectionTotalCount: Buffer;
   private readonly viewportOverflow: Buffer;
   private readonly selectionOverflow: Buffer;
+  private readonly queryDiagnostics: Buffer;
   private readonly buildGraph: CompiledGPUCommandGraph<void>;
   private readonly queryGraph: CompiledGPUCommandGraph<void>;
   private readonly buildGraphObservation: GPUCommandGraphInspectorObservation<void>;
@@ -78,6 +107,10 @@ export class LuSpatialTaxiQueryEffect implements Effect {
   private selectionRadiusKilometres = 0.35;
   private visiblePointCount = 0;
   private selectedPointCount = 0;
+  private viewportIntersectedCellCount = 0;
+  private viewportCandidateCount = 0;
+  private selectionIntersectedCellCount = 0;
+  private selectionCandidateCount = 0;
   private buildEncodingMilliseconds = 0;
   private queryEncodingMilliseconds = 0;
   private frameIndex = 0;
@@ -175,6 +208,13 @@ export class LuSpatialTaxiQueryEffect implements Effect {
       );
       this.selectionOverflow = this.ownResource(
         createScalarBuffer(device, 'luspatial-taxi-selection-overflow')
+      );
+      this.queryDiagnostics = this.ownResource(
+        device.createBuffer({
+          id: 'luspatial-taxi-query-diagnostics',
+          byteLength: QUERY_DIAGNOSTIC_BUFFER_BYTE_LENGTH,
+          usage: Buffer.STORAGE | Buffer.COPY_SRC
+        })
       );
       this.drawCommands = this.ownResource(
         new DrawCommandBuffer(device, {
@@ -410,6 +450,11 @@ export class LuSpatialTaxiQueryEffect implements Effect {
       'selection-overflow',
       this.selectionOverflow
     );
+    const queryDiagnosticsBuffer = importBuffer(
+      graph,
+      'query-diagnostics',
+      this.queryDiagnostics
+    );
     const drawCommandBuffer = importBuffer(graph, 'draw-commands', this.drawCommands.buffer);
 
     const positions = graph.createDataView(projectedBuffer, {
@@ -432,6 +477,26 @@ export class LuSpatialTaxiQueryEffect implements Effect {
       count: graph.createDataView(indexCountBuffer, {format: 'uint32', length: 1}),
       overflow: graph.createDataView(indexOverflowBuffer, {format: 'uint32', length: 1})
     };
+    const viewportIntersectedCellCount = graph.createDataView(queryDiagnosticsBuffer, {
+      format: 'uint32',
+      length: 1,
+      byteOffset: LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.viewportIntersectedCellCount
+    });
+    const viewportCandidateCount = graph.createDataView(queryDiagnosticsBuffer, {
+      format: 'uint32',
+      length: 1,
+      byteOffset: LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.viewportCandidateCount
+    });
+    const selectionIntersectedCellCount = graph.createDataView(queryDiagnosticsBuffer, {
+      format: 'uint32',
+      length: 1,
+      byteOffset: LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.selectionIntersectedCellCount
+    });
+    const selectionCandidateCount = graph.createDataView(queryDiagnosticsBuffer, {
+      format: 'uint32',
+      length: 1,
+      byteOffset: LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.selectionCandidateCount
+    });
 
     new GPUPointSpatialQuery({
       id: 'luspatial-taxi-viewport-query',
@@ -439,6 +504,8 @@ export class LuSpatialTaxiQueryEffect implements Effect {
       index,
       kind: 'bounds',
       query: graph.createDataView(viewportQueryBuffer, {format: 'float32', length: 4}),
+      intersectedCellCount: viewportIntersectedCellCount,
+      candidateCount: viewportCandidateCount,
       output: {
         ids: graph.createDataView(viewportIdsBuffer, {
           format: 'uint32',
@@ -463,6 +530,8 @@ export class LuSpatialTaxiQueryEffect implements Effect {
       index,
       kind: 'radius',
       query: graph.createDataView(selectionQueryBuffer, {format: 'float32', length: 3}),
+      intersectedCellCount: selectionIntersectedCellCount,
+      candidateCount: selectionCandidateCount,
       output: {
         ids: graph.createDataView(selectedIdsBuffer, {
           format: 'uint32',
@@ -491,15 +560,28 @@ export class LuSpatialTaxiQueryEffect implements Effect {
     }
     this.countReadPending = true;
     try {
-      const bytes = await this.drawCommands.buffer.readAsync();
+      const [drawCommandBytes, queryDiagnosticBytes] = await Promise.all([
+        this.drawCommands.buffer.readAsync(),
+        this.queryDiagnostics.readAsync()
+      ]);
       if (this.destroyed) return;
-      const values = new Uint32Array(
-        bytes.buffer,
-        bytes.byteOffset,
-        bytes.byteLength / UINT32_BYTE_LENGTH
+      const counters = decodeLuSpatialTaxiQueryCounters(
+        drawCommandBytes,
+        queryDiagnosticBytes,
+        {
+          viewportInstanceCountByteOffset: this.drawCommands.getInstanceCountByteOffset(0),
+          selectionInstanceCountByteOffset: this.drawCommands.getInstanceCountByteOffset(1)
+        }
       );
-      this.visiblePointCount = values[this.drawCommands.getInstanceCountByteOffset(0) / 4] ?? 0;
-      this.selectedPointCount = values[this.drawCommands.getInstanceCountByteOffset(1) / 4] ?? 0;
+      this.viewportIntersectedCellCount = counters.viewportIntersectedCellCount;
+      this.viewportCandidateCount = counters.viewportCandidateCount;
+      this.visiblePointCount = counters.visiblePointCount;
+      this.selectionIntersectedCellCount = counters.selectionIntersectedCellCount;
+      this.selectionCandidateCount = counters.selectionCandidateCount;
+      this.selectedPointCount = counters.selectedPointCount;
+      this.queryGraphObservation.recordCounters(
+        makeLuSpatialTaxiQueryInspectorCounters(counters)
+      );
       this.publishStats();
     } catch {
       // Device loss or teardown can reject optional diagnostics after the render path has ended.
@@ -526,7 +608,11 @@ export class LuSpatialTaxiQueryEffect implements Effect {
   private publishStats(): void {
     this.onStats?.({
       residentPointCount: this.data.pointCount,
+      viewportIntersectedCellCount: this.viewportIntersectedCellCount,
+      viewportCandidateCount: this.viewportCandidateCount,
       visiblePointCount: this.visiblePointCount,
+      selectionIntersectedCellCount: this.selectionIntersectedCellCount,
+      selectionCandidateCount: this.selectionCandidateCount,
       selectedPointCount: this.selectedPointCount,
       graphNodeCount:
         this.buildGraph.stats.nodeOrder.length + this.queryGraph.stats.nodeOrder.length,
@@ -535,6 +621,63 @@ export class LuSpatialTaxiQueryEffect implements Effect {
       inspectorSnapshot: this.inspector.getSnapshot()
     });
   }
+}
+
+/** Decodes one pair of sparse GPU query-counter and indirect-draw readbacks. */
+export function decodeLuSpatialTaxiQueryCounters(
+  drawCommandBytes: Uint8Array,
+  queryDiagnosticBytes: Uint8Array,
+  drawCommandLayout: {
+    viewportInstanceCountByteOffset: number;
+    selectionInstanceCountByteOffset: number;
+  }
+): LuSpatialTaxiQueryCounters {
+  return {
+    viewportIntersectedCellCount: readUint32AtByteOffset(
+      queryDiagnosticBytes,
+      LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.viewportIntersectedCellCount
+    ),
+    viewportCandidateCount: readUint32AtByteOffset(
+      queryDiagnosticBytes,
+      LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.viewportCandidateCount
+    ),
+    visiblePointCount: readUint32AtByteOffset(
+      drawCommandBytes,
+      drawCommandLayout.viewportInstanceCountByteOffset
+    ),
+    selectionIntersectedCellCount: readUint32AtByteOffset(
+      queryDiagnosticBytes,
+      LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.selectionIntersectedCellCount
+    ),
+    selectionCandidateCount: readUint32AtByteOffset(
+      queryDiagnosticBytes,
+      LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.selectionCandidateCount
+    ),
+    selectedPointCount: readUint32AtByteOffset(
+      drawCommandBytes,
+      drawCommandLayout.selectionInstanceCountByteOffset
+    )
+  };
+}
+
+/** Maps an exact query sample onto stable inspector counter identifiers. */
+export function makeLuSpatialTaxiQueryInspectorCounters(
+  counters: LuSpatialTaxiQueryCounters
+): Readonly<Record<string, number>> {
+  return {
+    [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.viewportIntersectedCells]:
+      counters.viewportIntersectedCellCount,
+    [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.viewportCandidates]: counters.viewportCandidateCount,
+    [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.viewportMatches]: counters.visiblePointCount,
+    [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.selectionIntersectedCells]:
+      counters.selectionIntersectedCellCount,
+    [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.selectionCandidates]: counters.selectionCandidateCount,
+    [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.selectionMatches]: counters.selectedPointCount
+  };
+}
+
+function readUint32AtByteOffset(bytes: Uint8Array, byteOffset: number): number {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(byteOffset, true);
 }
 
 function createScalarBuffer(device: Device, id: string): Buffer {

--- a/examples/gpu-command-graph-inspector-panel.ts
+++ b/examples/gpu-command-graph-inspector-panel.ts
@@ -5,9 +5,19 @@
 import type {GPUCommandGraphInspectorSnapshot} from '@luma.gl/experimental';
 import {CompactDropdown} from './compact-dropdown';
 
+const STANDARD_COUNTER_FORMATTER = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 1
+});
+const COMPACT_COUNTER_FORMATTER = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1
+});
+
 export type GPUCommandGraphInspectorPanelProps = {
   /** Optional human-readable graph names keyed by compiled graph ID. */
   graphLabels?: Readonly<Record<string, string>>;
+  /** Optional human-readable counter names keyed by application-defined counter ID. */
+  counterLabels?: Readonly<Record<string, string>>;
 };
 
 /**
@@ -19,6 +29,7 @@ export type GPUCommandGraphInspectorPanelProps = {
 export class GPUCommandGraphInspectorPanel {
   private readonly element: HTMLElement;
   private readonly graphLabels: Readonly<Record<string, string>>;
+  private readonly counterLabels: Readonly<Record<string, string>>;
   private snapshot: GPUCommandGraphInspectorSnapshot = {graphs: []};
   private selectedGraphId: string | null = null;
   private selectionIsManual = false;
@@ -28,6 +39,7 @@ export class GPUCommandGraphInspectorPanel {
   constructor(element: HTMLElement, props: GPUCommandGraphInspectorPanelProps = {}) {
     this.element = element;
     this.graphLabels = props.graphLabels ?? {};
+    this.counterLabels = props.counterLabels ?? {};
     this.element.innerHTML = `<div data-gpu-command-graph-inspector>
       <style>${GPU_COMMAND_GRAPH_INSPECTOR_CSS}</style>
       <span class="graph-inspector-empty" data-graph-inspector-empty>No graph activity recorded.</span>
@@ -40,6 +52,10 @@ export class GPUCommandGraphInspectorPanel {
           ${makeMetric('GPU samples', '', 'gpu-samples')}
         </div>
         <div class="graph-inspector-memory" data-graph-inspector-memory></div>
+        <div class="graph-inspector-counters" data-graph-inspector-counters hidden>
+          <div class="graph-inspector-counter graph-inspector-counter-header"><span>Sampled counter</span><strong>Latest</strong><strong>50/95</strong></div>
+          <div class="graph-inspector-counter-rows" data-graph-inspector-counter-rows></div>
+        </div>
         <div class="graph-inspector-node graph-inspector-node-header"><span>Node</span><strong>CPU 50/95</strong><strong>GPU 50/95</strong></div>
         <div class="graph-inspector-nodes" data-graph-inspector-nodes></div>
       </div>
@@ -125,6 +141,15 @@ export class GPUCommandGraphInspectorPanel {
         </div>`
       )
       .join('');
+    const counterRows = graph.counters
+      .map(
+        counter => `<div class="graph-inspector-counter" title="${escapeHtml(counter.id)} · ${counter.sampleCount} samples">
+          <span>${escapeHtml(this.getCounterLabel(counter.id))}</span>
+          <strong>${formatCounterValue(counter.latestValue)}</strong>
+          <strong>${formatCounterValue(counter.p50Value)} / ${formatCounterValue(counter.p95Value)}</strong>
+        </div>`
+      )
+      .join('');
     this.setText('encoding-count', String(graph.encodingCount));
     this.setText('cpu-totals', formatDurationPair(graph.totals.cpu));
     this.setText('gpu-totals', formatDurationPair(graph.totals.gpu));
@@ -138,6 +163,12 @@ export class GPUCommandGraphInspectorPanel {
       <span>${formatBytes(graph.stats.physicalTransientResourceBytes)} scratch</span>
       <span>${reusePercentage ? `${reusePercentage.toFixed(0)}% reuse` : 'no reuse'}</span>
       <span>${gpuSampleCount ? 'GPU timings sampled' : 'CPU timings only'}</span>`;
+    const countersElement = this.element.querySelector<HTMLElement>(
+      '[data-graph-inspector-counters]'
+    )!;
+    countersElement.hidden = graph.counters.length === 0;
+    this.element.querySelector<HTMLElement>('[data-graph-inspector-counter-rows]')!.innerHTML =
+      counterRows;
     this.element.querySelector<HTMLElement>('[data-graph-inspector-nodes]')!.innerHTML = rows;
   }
 
@@ -147,7 +178,11 @@ export class GPUCommandGraphInspectorPanel {
   }
 
   private getGraphLabel(graphId: string): string {
-    return this.graphLabels[graphId] ?? graphId;
+    return getOwnLabel(this.graphLabels, graphId);
+  }
+
+  private getCounterLabel(counterId: string): string {
+    return getOwnLabel(this.counterLabels, counterId);
   }
 }
 
@@ -198,6 +233,45 @@ const GPU_COMMAND_GRAPH_INSPECTOR_CSS = /* css */ `
     gap: 3px 8px;
     color: #7286a2;
     font: 8px/1.35 ui-monospace, monospace;
+  }
+  [data-gpu-command-graph-inspector] .graph-inspector-counters[hidden] { display: none; }
+  [data-gpu-command-graph-inspector] .graph-inspector-counter-rows {
+    max-height: 110px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+  }
+  [data-gpu-command-graph-inspector] .graph-inspector-counter {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 52px 66px;
+    align-items: center;
+    gap: 7px;
+    min-height: 22px;
+    border-bottom: 1px solid rgb(137 166 211 / 9%);
+    color: #b9c8dc;
+    font: 8px/1.25 ui-monospace, monospace;
+  }
+  [data-gpu-command-graph-inspector] .graph-inspector-counter > span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  [data-gpu-command-graph-inspector] .graph-inspector-counter strong {
+    color: #dce8f7;
+    font-weight: 600;
+    text-align: right;
+  }
+  [data-gpu-command-graph-inspector] .graph-inspector-counter-header {
+    min-height: 17px;
+    border-bottom-color: rgb(137 166 211 / 18%);
+    color: #7186a3;
+    font: 7px/1.2 system-ui, sans-serif;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+  }
+  [data-gpu-command-graph-inspector] .graph-inspector-counter-header strong {
+    color: #7186a3;
+    font-weight: 600;
   }
   [data-gpu-command-graph-inspector] .graph-inspector-node {
     display: grid;
@@ -266,11 +340,19 @@ function formatCompactMilliseconds(value: number): string {
   return value.toFixed(value < 1 ? 3 : 2);
 }
 
+function formatCounterValue(value: number): string {
+  return (value >= 10_000 ? COMPACT_COUNTER_FORMATTER : STANDARD_COUNTER_FORMATTER).format(value);
+}
+
 function formatBytes(value: number): string {
   if (value < 1024) return `${value} B`;
   if (value < 1024 ** 2) return `${(value / 1024).toFixed(1)} KiB`;
   if (value < 1024 ** 3) return `${(value / 1024 ** 2).toFixed(1)} MiB`;
   return `${(value / 1024 ** 3).toFixed(1)} GiB`;
+}
+
+function getOwnLabel(labels: Readonly<Record<string, string>>, id: string): string {
+  return Object.prototype.hasOwnProperty.call(labels, id) ? labels[id] : id;
 }
 
 function escapeHtml(value: string): string {

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph-inspector.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph-inspector.ts
@@ -47,6 +47,8 @@ export type GPUCommandGraphInspectorObservableGraph<
  * Route graph encodings through {@link GPUCommandGraphInspectorObservation.encode} to collect CPU
  * measurements without repeating graph IDs. GPU timestamp readback remains an explicit,
  * post-submission operation through {@link GPUCommandGraphInspectorObservation.recordGPUTimings}.
+ * Caller-read scalar counters can be published through
+ * {@link GPUCommandGraphInspectorObservation.recordCounters}.
  */
 export type GPUCommandGraphInspectorObservation<
   Parameters = void,
@@ -61,6 +63,8 @@ export type GPUCommandGraphInspectorObservation<
   ) => Encoding;
   /** Reads GPU timings once for an encoding produced by this handle, after caller submission. */
   readonly recordGPUTimings: (encoding: Encoding) => Promise<void>;
+  /** Records one sample for each named, caller-read scalar counter. */
+  readonly recordCounters: (counters: Readonly<Record<string, number>>) => void;
   /** Stops observing this graph without destroying or otherwise mutating it. */
   readonly detach: () => void;
 };
@@ -77,7 +81,7 @@ export type GPUCommandGraphInspectorNodeIdentity = {
 
 /** Configuration for a reusable command-graph inspector. */
 export type GPUCommandGraphInspectorProps = {
-  /** Maximum CPU and GPU duration samples retained for each total or node. Defaults to `120`. */
+  /** Maximum samples retained for each duration or scalar counter. Defaults to `120`. */
   maxSamples?: number;
   /** Optional application-specific group assigned when a node is first observed. */
   getNodeGroup?: (node: GPUCommandGraphInspectorNodeIdentity) => string | undefined;
@@ -93,6 +97,20 @@ export type GPUCommandGraphInspectorDurationSnapshot = {
   readonly p50Milliseconds?: number;
   /** Nearest-rank 95th percentile across retained samples. */
   readonly p95Milliseconds?: number;
+};
+
+/** Immutable bounded-sample summary for one named scalar counter. */
+export type GPUCommandGraphInspectorCounterSnapshot = {
+  /** Stable application-defined counter identifier. */
+  readonly id: string;
+  /** Number of retained samples. */
+  readonly sampleCount: number;
+  /** Most recently recorded value. */
+  readonly latestValue: number;
+  /** Nearest-rank 50th percentile across retained samples. */
+  readonly p50Value: number;
+  /** Nearest-rank 95th percentile across retained samples. */
+  readonly p95Value: number;
 };
 
 /** Immutable timing summary for one scheduled graph node. */
@@ -134,6 +152,8 @@ export type GPUCommandGraphInspectorGraphSnapshot = {
     readonly cpu: GPUCommandGraphInspectorDurationSnapshot;
     readonly gpu: GPUCommandGraphInspectorDurationSnapshot;
   };
+  /** Application-defined scalar counters in first-observed order. */
+  readonly counters: readonly GPUCommandGraphInspectorCounterSnapshot[];
   /** Per-node duration summaries in compiled schedule order. */
   readonly nodes: readonly GPUCommandGraphInspectorNodeSnapshot[];
 };
@@ -160,20 +180,21 @@ type GraphInspectionState = {
   timingReadFailureCount: number;
   cpuSamples: number[];
   gpuSamples: number[];
+  counters: Map<string, number[]>;
   nodes: Map<string, NodeInspectionState>;
 };
 
 const DEFAULT_MAX_SAMPLES = 120;
 
 /**
- * Collects bounded CPU and GPU timing histories for compiled command graphs.
+ * Collects bounded timing and caller-published scalar-counter histories for compiled graphs.
  *
  * The inspector has no DOM or submission responsibilities. {@link observeGraph} provides a
- * reusable encoding and timing lifecycle for executable graphs. The lower-level
- * {@link registerGraph}, {@link recordEncoding}, and {@link recordGPUTimings} methods remain
- * available when an application cannot route encoding through an observation handle. Registering
- * a new compiled graph with an existing ID replaces the old registration and resets its
- * measurements.
+ * reusable encoding, timing, and counter lifecycle for executable graphs. The lower-level
+ * {@link registerGraph}, {@link recordEncoding}, {@link recordGPUTimings}, and
+ * {@link recordCounters} methods remain available when an application cannot route activity
+ * through an observation handle. Registering a new compiled graph with an existing ID replaces
+ * the old registration and resets its measurements.
  */
 export class GPUCommandGraphInspector {
   private readonly maxSamples: number;
@@ -209,6 +230,7 @@ export class GPUCommandGraphInspector {
       timingReadFailureCount: 0,
       cpuSamples: [],
       gpuSamples: [],
+      counters: new Map(),
       nodes: new Map()
     });
   }
@@ -218,8 +240,9 @@ export class GPUCommandGraphInspector {
    *
    * The handle records CPU measurements for every encoding routed through `encode()`. Call its
    * `recordGPUTimings()` only after submitting the command buffer; repeated calls for one encoding
-   * coalesce into a single timing sample. Detaching removes this graph's registration only while it
-   * is still current, so an older handle cannot remove a replacement graph that uses the same ID.
+   * coalesce into a single timing sample. Caller-read diagnostics can be passed to
+   * `recordCounters()`. Detaching removes this graph's registration only while it is still current,
+   * so an older handle cannot remove or publish delayed counters into a same-ID replacement.
    */
   observeGraph<
     Parameters,
@@ -256,6 +279,11 @@ export class GPUCommandGraphInspector {
           await timingRead;
         }
       },
+      recordCounters: (counters: Readonly<Record<string, number>>): void => {
+        if (isCurrent()) {
+          this.recordGraphCounters(registration, counters);
+        }
+      },
       detach: (): void => {
         if (!attached) {
           return;
@@ -279,6 +307,11 @@ export class GPUCommandGraphInspector {
     this.recordGraphEncoding(graph, encoding);
   }
 
+  /** Records one sample for each named scalar counter on a registered graph. */
+  recordCounters(graphId: string, counters: Readonly<Record<string, number>>): void {
+    this.recordGraphCounters(this.getGraph(graphId), counters);
+  }
+
   private recordGraphEncoding(
     graph: GraphInspectionState,
     encoding: GPUCommandGraphInspectorEncoding
@@ -290,6 +323,28 @@ export class GPUCommandGraphInspector {
     for (const nodeStats of stats.nodes) {
       const node = this.getNode(graph, nodeStats);
       this.addSample(node.cpuSamples, nodeStats.cpuEncodeTimeMilliseconds);
+    }
+  }
+
+  private recordGraphCounters(
+    graph: GraphInspectionState,
+    counters: Readonly<Record<string, number>>
+  ): void {
+    const entries = Object.entries(counters);
+    for (const [id, value] of entries) {
+      if (!id || !Number.isFinite(value) || value < 0) {
+        throw new Error(
+          'GPUCommandGraphInspector counters require an ID and a finite, non-negative value'
+        );
+      }
+    }
+    for (const [id, value] of entries) {
+      let samples = graph.counters.get(id);
+      if (!samples) {
+        samples = [];
+        graph.counters.set(id, samples);
+      }
+      this.addSample(samples, value);
     }
   }
 
@@ -404,6 +459,9 @@ export class GPUCommandGraphInspector {
         gpu: summarizeSamples(node.gpuSamples)
       })
     );
+    const counters = Array.from(graph.counters, ([id, samples]) =>
+      summarizeCounterSamples(id, samples)
+    );
     return Object.freeze({
       id: graph.id,
       stats: graph.stats,
@@ -414,6 +472,7 @@ export class GPUCommandGraphInspector {
         cpu: summarizeSamples(graph.cpuSamples),
         gpu: summarizeSamples(graph.gpuSamples)
       }),
+      counters: Object.freeze(counters),
       nodes: Object.freeze(nodes)
     });
   }
@@ -433,6 +492,20 @@ function summarizeSamples(samples: readonly number[]): GPUCommandGraphInspectorD
     latestMilliseconds: samples[samples.length - 1],
     p50Milliseconds: getPercentile(sortedSamples, 0.5),
     p95Milliseconds: getPercentile(sortedSamples, 0.95)
+  });
+}
+
+function summarizeCounterSamples(
+  id: string,
+  samples: readonly number[]
+): GPUCommandGraphInspectorCounterSnapshot {
+  const sortedSamples = [...samples].sort((left, right) => left - right);
+  return Object.freeze({
+    id,
+    sampleCount: samples.length,
+    latestValue: samples[samples.length - 1],
+    p50Value: getPercentile(sortedSamples, 0.5),
+    p95Value: getPercentile(sortedSamples, 0.95)
   });
 }
 

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph-inspector.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph-inspector.ts
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import type {CommandEncoder} from '@luma.gl/core';
 import type {GPUCommandGraphEncoding} from './gpu-command-graph';
 import type {
   GPUCommandGraphCapabilities,
+  GPUCommandGraphEncodeOptions,
   GPUCommandGraphEncodingStats,
   GPUCommandGraphNodeType,
   GPUCommandGraphStats,
@@ -26,6 +28,42 @@ export type GPUCommandGraphInspectorEncoding = Pick<
   GPUCommandGraphEncoding,
   'stats' | 'readTimings'
 >;
+
+/** Minimal executable graph surface supported by {@link GPUCommandGraphInspector.observeGraph}. */
+export type GPUCommandGraphInspectorObservableGraph<
+  Parameters = void,
+  Encoding extends GPUCommandGraphInspectorEncoding = GPUCommandGraphEncoding
+> = GPUCommandGraphInspectorGraph & {
+  /** Records the graph into a caller-owned command encoder. */
+  readonly encode: (
+    commandEncoder: CommandEncoder,
+    options: GPUCommandGraphEncodeOptions<Parameters>
+  ) => Encoding;
+};
+
+/**
+ * Non-owning observation handle for one executable command graph.
+ *
+ * Route graph encodings through {@link GPUCommandGraphInspectorObservation.encode} to collect CPU
+ * measurements without repeating graph IDs. GPU timestamp readback remains an explicit,
+ * post-submission operation through {@link GPUCommandGraphInspectorObservation.recordGPUTimings}.
+ */
+export type GPUCommandGraphInspectorObservation<
+  Parameters = void,
+  Encoding extends GPUCommandGraphInspectorEncoding = GPUCommandGraphEncoding
+> = {
+  /** Graph whose encodings are observed. */
+  readonly graph: GPUCommandGraphInspectorObservableGraph<Parameters, Encoding>;
+  /** Encodes the graph and records its immediately available CPU measurements. */
+  readonly encode: (
+    commandEncoder: CommandEncoder,
+    options: GPUCommandGraphEncodeOptions<Parameters>
+  ) => Encoding;
+  /** Reads GPU timings once for an encoding produced by this handle, after caller submission. */
+  readonly recordGPUTimings: (encoding: Encoding) => Promise<void>;
+  /** Stops observing this graph without destroying or otherwise mutating it. */
+  readonly detach: () => void;
+};
 
 /** Stable identity supplied to a semantic node-group callback. */
 export type GPUCommandGraphInspectorNodeIdentity = {
@@ -130,10 +168,12 @@ const DEFAULT_MAX_SAMPLES = 120;
 /**
  * Collects bounded CPU and GPU timing histories for compiled command graphs.
  *
- * The inspector has no DOM or submission responsibilities. Call {@link recordEncoding}
- * synchronously after encoding, then call {@link recordGPUTimings} after submission when explicit
- * timestamp readback is desired. Registering a new compiled graph with an existing ID replaces
- * the old registration and resets its measurements.
+ * The inspector has no DOM or submission responsibilities. {@link observeGraph} provides a
+ * reusable encoding and timing lifecycle for executable graphs. The lower-level
+ * {@link registerGraph}, {@link recordEncoding}, and {@link recordGPUTimings} methods remain
+ * available when an application cannot route encoding through an observation handle. Registering
+ * a new compiled graph with an existing ID replaces the old registration and resets its
+ * measurements.
  */
 export class GPUCommandGraphInspector {
   private readonly maxSamples: number;
@@ -173,6 +213,61 @@ export class GPUCommandGraphInspector {
     });
   }
 
+  /**
+   * Registers an executable graph and returns a non-owning observation handle.
+   *
+   * The handle records CPU measurements for every encoding routed through `encode()`. Call its
+   * `recordGPUTimings()` only after submitting the command buffer; repeated calls for one encoding
+   * coalesce into a single timing sample. Detaching removes this graph's registration only while it
+   * is still current, so an older handle cannot remove a replacement graph that uses the same ID.
+   */
+  observeGraph<
+    Parameters,
+    Encoding extends GPUCommandGraphInspectorEncoding = GPUCommandGraphEncoding
+  >(
+    graph: GPUCommandGraphInspectorObservableGraph<Parameters, Encoding>
+  ): GPUCommandGraphInspectorObservation<Parameters, Encoding> {
+    this.registerGraph(graph);
+    const registration = this.getGraph(graph.id);
+    const timingReadPromises = new WeakMap<GPUCommandGraphInspectorEncoding, Promise<void>>();
+    let attached = true;
+    const isCurrent = (): boolean => attached && this.graphs.get(graph.id) === registration;
+    return Object.freeze({
+      graph,
+      encode: (
+        commandEncoder: CommandEncoder,
+        options: GPUCommandGraphEncodeOptions<Parameters>
+      ): Encoding => {
+        const encoding = graph.encode(commandEncoder, options);
+        if (isCurrent()) {
+          this.recordGraphEncoding(registration, encoding);
+        }
+        return encoding;
+      },
+      recordGPUTimings: async (encoding: Encoding): Promise<void> => {
+        const existingRead = timingReadPromises.get(encoding);
+        if (existingRead) {
+          await existingRead;
+          return;
+        }
+        if (isCurrent() && this.encodingGraphs.get(encoding) === registration) {
+          const timingRead = this.recordGraphGPUTimings(graph.id, registration, encoding);
+          timingReadPromises.set(encoding, timingRead);
+          await timingRead;
+        }
+      },
+      detach: (): void => {
+        if (!attached) {
+          return;
+        }
+        attached = false;
+        if (this.graphs.get(graph.id) === registration) {
+          this.graphs.delete(graph.id);
+        }
+      }
+    });
+  }
+
   /** Removes every graph and invalidates any timing reads still pending for those registrations. */
   clear(): void {
     this.graphs.clear();
@@ -181,6 +276,13 @@ export class GPUCommandGraphInspector {
   /** Records immediately available whole-graph and per-node CPU encoding durations. */
   recordEncoding(graphId: string, encoding: GPUCommandGraphInspectorEncoding): void {
     const graph = this.getGraph(graphId);
+    this.recordGraphEncoding(graph, encoding);
+  }
+
+  private recordGraphEncoding(
+    graph: GraphInspectionState,
+    encoding: GPUCommandGraphInspectorEncoding
+  ): void {
     this.encodingGraphs.set(encoding, graph);
     const {stats} = encoding;
     graph.encodingCount++;
@@ -203,6 +305,14 @@ export class GPUCommandGraphInspector {
   ): Promise<void> {
     const recordedGraph = this.encodingGraphs.get(encoding);
     const graph = recordedGraph ?? this.getGraph(graphId);
+    await this.recordGraphGPUTimings(graphId, graph, encoding);
+  }
+
+  private async recordGraphGPUTimings(
+    graphId: string,
+    graph: GraphInspectionState,
+    encoding: GPUCommandGraphInspectorEncoding
+  ): Promise<void> {
     if (this.graphs.get(graphId) !== graph) {
       return;
     }

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -58,6 +58,8 @@ export type {
   GPUCommandGraphInspectorGraphSnapshot,
   GPUCommandGraphInspectorNodeIdentity,
   GPUCommandGraphInspectorNodeSnapshot,
+  GPUCommandGraphInspectorObservableGraph,
+  GPUCommandGraphInspectorObservation,
   GPUCommandGraphInspectorProps,
   GPUCommandGraphInspectorSnapshot,
   GPUCommandGraphInspectorStatsSnapshot

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -52,6 +52,7 @@ export type {
 export type {GPUCommandGraphContributor} from './gpu-command-graph';
 export {GPUCommandGraphInspector} from './gpu-command-graph-inspector';
 export type {
+  GPUCommandGraphInspectorCounterSnapshot,
   GPUCommandGraphInspectorDurationSnapshot,
   GPUCommandGraphInspectorEncoding,
   GPUCommandGraphInspectorGraph,

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-inspector-types.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-inspector-types.node.spec.ts
@@ -1,0 +1,25 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {
+  GPUCommandGraphInspectorEncoding,
+  GPUCommandGraphInspectorObservableGraph,
+  GPUCommandGraphInspectorObservation
+} from '@luma.gl/experimental';
+import {expectTypeOf, test} from 'vitest';
+
+type StrictParameters = {value: number};
+
+test('GPUCommandGraphInspector observations preserve strict parameter types', () => {
+  expectTypeOf<
+    GPUCommandGraphInspectorObservableGraph<StrictParameters, GPUCommandGraphInspectorEncoding>
+  >().not.toMatchTypeOf<
+    GPUCommandGraphInspectorObservableGraph<unknown, GPUCommandGraphInspectorEncoding>
+  >();
+  expectTypeOf<
+    GPUCommandGraphInspectorObservation<StrictParameters, GPUCommandGraphInspectorEncoding>
+  >().not.toMatchTypeOf<
+    GPUCommandGraphInspectorObservation<unknown, GPUCommandGraphInspectorEncoding>
+  >();
+});

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-inspector-types.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-inspector-types.node.spec.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import type {
+  GPUCommandGraphInspectorCounterSnapshot,
   GPUCommandGraphInspectorEncoding,
   GPUCommandGraphInspectorObservableGraph,
   GPUCommandGraphInspectorObservation
@@ -22,4 +23,13 @@ test('GPUCommandGraphInspector observations preserve strict parameter types', ()
   >().not.toMatchTypeOf<
     GPUCommandGraphInspectorObservation<unknown, GPUCommandGraphInspectorEncoding>
   >();
+  expectTypeOf<
+    GPUCommandGraphInspectorObservation<StrictParameters>['recordCounters']
+  >().toEqualTypeOf<(counters: Readonly<Record<string, number>>) => void>();
+  expectTypeOf<GPUCommandGraphInspectorCounterSnapshot>().toMatchTypeOf<{
+    readonly id: string;
+    readonly latestValue: number;
+    readonly p50Value: number;
+    readonly p95Value: number;
+  }>();
 });

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-inspector.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-inspector.node.spec.ts
@@ -108,6 +108,46 @@ test('GPUCommandGraphInspector summarizes bounded CPU and GPU samples', async te
   testCase.end();
 });
 
+test('GPUCommandGraphInspector summarizes bounded scalar counters', testCase => {
+  const inspector = new GPUCommandGraphInspector({maxSamples: 2});
+  inspector.registerGraph(makeGraph('counters'));
+  inspector.recordCounters('counters', {candidates: 30, intersectedCells: 3});
+  inspector.recordCounters('counters', {candidates: 10, intersectedCells: 1});
+  inspector.recordCounters('counters', {candidates: 20, intersectedCells: 2});
+
+  testCase.deepEqual(
+    inspector.getSnapshot().graphs[0].counters,
+    [
+      {
+        id: 'candidates',
+        sampleCount: 2,
+        latestValue: 20,
+        p50Value: 10,
+        p95Value: 20
+      },
+      {
+        id: 'intersectedCells',
+        sampleCount: 2,
+        latestValue: 2,
+        p50Value: 1,
+        p95Value: 2
+      }
+    ],
+    'retains bounded samples and preserves first-observed counter order'
+  );
+  testCase.throws(
+    () => inspector.recordCounters('counters', {valid: 1, invalid: Number.NaN}),
+    /finite, non-negative value/,
+    'rejects invalid counter batches'
+  );
+  testCase.equal(
+    inspector.getSnapshot().graphs[0].counters.length,
+    2,
+    'validates the complete batch before recording any sample'
+  );
+  testCase.end();
+});
+
 test('GPUCommandGraphInspector returns immutable snapshots and copied graph metadata', testCase => {
   const stats = {...GRAPH_STATS, nodeOrder: [...GRAPH_STATS.nodeOrder]};
   const capabilities = {...GRAPH_CAPABILITIES};
@@ -115,6 +155,7 @@ test('GPUCommandGraphInspector returns immutable snapshots and copied graph meta
   const inspector = new GPUCommandGraphInspector();
   inspector.registerGraph(graph);
   inspector.recordEncoding('immutable', makeEncoding(1, 0.25, 0.5));
+  inspector.recordCounters('immutable', {candidates: 12});
 
   stats.nodeOrder[0] = 'changed';
   capabilities.timestampQueries = false;
@@ -129,6 +170,8 @@ test('GPUCommandGraphInspector returns immutable snapshots and copied graph meta
   testCase.ok(Object.isFrozen(graphSnapshot.stats.nodeOrder), 'freezes compiled node order');
   testCase.ok(Object.isFrozen(graphSnapshot.totals), 'freezes graph totals');
   testCase.ok(Object.isFrozen(graphSnapshot.totals.cpu), 'freezes duration summaries');
+  testCase.ok(Object.isFrozen(graphSnapshot.counters), 'freezes the counter list');
+  testCase.ok(Object.isFrozen(graphSnapshot.counters[0]), 'freezes each counter summary');
   testCase.ok(Object.isFrozen(graphSnapshot.nodes), 'freezes the node list');
   testCase.ok(Object.isFrozen(graphSnapshot.nodes[0]), 'freezes each node summary');
   testCase.end();
@@ -177,12 +220,14 @@ test('GPUCommandGraphInspector observations isolate same-id replacement lifecycl
 
   oldObservation.detach();
   await oldObservation.recordGPUTimings(oldEncoding);
+  oldObservation.recordCounters({candidates: 99});
   oldObservation.encode(COMMAND_ENCODER, {
     parameters: {cpuTimeMilliseconds: 5, gpuTimeMilliseconds: 50}
   });
   currentObservation.encode(COMMAND_ENCODER, {
     parameters: {cpuTimeMilliseconds: 7, gpuTimeMilliseconds: 70}
   });
+  currentObservation.recordCounters({candidates: 7});
 
   const graph = inspector.getSnapshot().graphs[0];
   testCase.equal(graph.encodingCount, 1, 'an old handle cannot record into its replacement');
@@ -192,7 +237,13 @@ test('GPUCommandGraphInspector observations isolate same-id replacement lifecycl
     0,
     'an old handle cannot attach pending timings to its replacement'
   );
+  testCase.equal(
+    graph.counters[0].latestValue,
+    7,
+    'an old handle cannot publish delayed counters into its replacement'
+  );
   currentObservation.detach();
+  currentObservation.recordCounters({candidates: 70});
   testCase.deepEqual(
     inspector.getSnapshot().graphs,
     [],

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-inspector.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-inspector.node.spec.ts
@@ -3,15 +3,24 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
+import type {CommandEncoder} from '@luma.gl/core';
 import {
   GPUCommandGraphInspector,
   type GPUCommandGraphCapabilities,
   type GPUCommandGraphEncodingStats,
   type GPUCommandGraphInspectorEncoding,
   type GPUCommandGraphInspectorGraph,
+  type GPUCommandGraphInspectorObservableGraph,
   type GPUCommandGraphStats,
   type GPUCommandGraphTimingReport
 } from '@luma.gl/experimental';
+
+type ObservationParameters = {
+  cpuTimeMilliseconds: number;
+  gpuTimeMilliseconds: number;
+};
+
+const COMMAND_ENCODER = {} as CommandEncoder;
 
 const GRAPH_STATS: GPUCommandGraphStats = {
   nodeOrder: ['prepare', 'render'],
@@ -125,6 +134,134 @@ test('GPUCommandGraphInspector returns immutable snapshots and copied graph meta
   testCase.end();
 });
 
+test('GPUCommandGraphInspector observes encode and post-submit timing lifecycles', async testCase => {
+  const inspector = new GPUCommandGraphInspector();
+  const graph = makeObservableGraph('observed');
+  const observation = inspector.observeGraph(graph);
+  const encoding = observation.encode(COMMAND_ENCODER, {
+    parameters: {cpuTimeMilliseconds: 8, gpuTimeMilliseconds: 80}
+  });
+  await observation.recordGPUTimings(encoding);
+
+  const graphSnapshot = inspector.getSnapshot().graphs[0];
+  testCase.equal(observation.graph, graph, 'exposes the observed graph without wrapping ownership');
+  testCase.ok(Object.isFrozen(observation), 'returns an immutable observation handle');
+  testCase.equal(graphSnapshot.encodingCount, 1, 'records CPU stats while delegating encode');
+  testCase.equal(graphSnapshot.totals.cpu.latestMilliseconds, 8, 'records delegated CPU time');
+  testCase.equal(
+    graphSnapshot.totals.gpu.latestMilliseconds,
+    80,
+    'records explicit post-submit GPU time without a repeated graph id'
+  );
+
+  observation.detach();
+  observation.detach();
+  observation.encode(COMMAND_ENCODER, {
+    parameters: {cpuTimeMilliseconds: 16, gpuTimeMilliseconds: 160}
+  });
+  testCase.deepEqual(
+    inspector.getSnapshot().graphs,
+    [],
+    'detach is idempotent and stops observation without disabling graph encoding'
+  );
+  testCase.end();
+});
+
+test('GPUCommandGraphInspector observations isolate same-id replacement lifecycles', async testCase => {
+  const inspector = new GPUCommandGraphInspector();
+  const oldObservation = inspector.observeGraph(makeObservableGraph('replaceable'));
+  const oldEncoding = oldObservation.encode(COMMAND_ENCODER, {
+    parameters: {cpuTimeMilliseconds: 3, gpuTimeMilliseconds: 30}
+  });
+  const currentObservation = inspector.observeGraph(makeObservableGraph('replaceable'));
+
+  oldObservation.detach();
+  await oldObservation.recordGPUTimings(oldEncoding);
+  oldObservation.encode(COMMAND_ENCODER, {
+    parameters: {cpuTimeMilliseconds: 5, gpuTimeMilliseconds: 50}
+  });
+  currentObservation.encode(COMMAND_ENCODER, {
+    parameters: {cpuTimeMilliseconds: 7, gpuTimeMilliseconds: 70}
+  });
+
+  const graph = inspector.getSnapshot().graphs[0];
+  testCase.equal(graph.encodingCount, 1, 'an old handle cannot record into its replacement');
+  testCase.equal(graph.totals.cpu.latestMilliseconds, 7, 'keeps only the current observation');
+  testCase.equal(
+    graph.totals.gpu.sampleCount,
+    0,
+    'an old handle cannot attach pending timings to its replacement'
+  );
+  currentObservation.detach();
+  testCase.deepEqual(
+    inspector.getSnapshot().graphs,
+    [],
+    'the current handle owns its registration'
+  );
+  testCase.end();
+});
+
+test('GPUCommandGraphInspector observations reject foreign encodings', async testCase => {
+  const inspector = new GPUCommandGraphInspector();
+  const firstObservation = inspector.observeGraph(makeObservableGraph('first'));
+  const secondObservation = inspector.observeGraph(makeObservableGraph('second'));
+  const firstEncoding = firstObservation.encode(COMMAND_ENCODER, {
+    parameters: {cpuTimeMilliseconds: 4, gpuTimeMilliseconds: 40}
+  });
+
+  await secondObservation.recordGPUTimings(firstEncoding);
+  testCase.deepEqual(
+    inspector.getSnapshot().graphs.map(graph => graph.totals.gpu.sampleCount),
+    [0, 0],
+    "does not attribute another observation's timing report to the current graph"
+  );
+  await firstObservation.recordGPUTimings(firstEncoding);
+  testCase.equal(
+    inspector.getSnapshot().graphs[0].totals.gpu.latestMilliseconds,
+    40,
+    'the originating observation can read its own encoding'
+  );
+  firstObservation.detach();
+  secondObservation.detach();
+  testCase.end();
+});
+
+test('GPUCommandGraphInspector observations coalesce repeated timing reads', async testCase => {
+  const inspector = new GPUCommandGraphInspector();
+  let timingReadCount = 0;
+  let resolveTiming: ((report: GPUCommandGraphTimingReport) => void) | undefined;
+  const encoding = makeEncoding(6, 1, 2, undefined, undefined, undefined, () => {
+    timingReadCount++;
+    return new Promise(resolve => {
+      resolveTiming = resolve;
+    });
+  });
+  const graph: GPUCommandGraphInspectorObservableGraph<
+    ObservationParameters,
+    GPUCommandGraphInspectorEncoding
+  > = {
+    ...makeGraph('coalesced'),
+    encode: () => encoding
+  };
+  const observation = inspector.observeGraph(graph);
+  observation.encode(COMMAND_ENCODER, {
+    parameters: {cpuTimeMilliseconds: 6, gpuTimeMilliseconds: 60}
+  });
+
+  const firstRead = observation.recordGPUTimings(encoding);
+  const secondRead = observation.recordGPUTimings(encoding);
+  testCase.equal(timingReadCount, 1, 'starts only one timing read for concurrent calls');
+  resolveTiming?.(makeTimingReport(6, 60, 10, 20));
+  await Promise.all([firstRead, secondRead]);
+  await observation.recordGPUTimings(encoding);
+
+  const graphSnapshot = inspector.getSnapshot().graphs[0];
+  testCase.equal(timingReadCount, 1, 'reuses the completed timing read');
+  testCase.equal(graphSnapshot.totals.gpu.sampleCount, 1, 'records one GPU sample per encoding');
+  observation.detach();
+  testCase.end();
+});
+
 test('GPUCommandGraphInspector resets replacements and isolates asynchronous timing reads', async testCase => {
   const inspector = new GPUCommandGraphInspector();
   inspector.registerGraph(makeGraph('replaceable'));
@@ -173,6 +310,26 @@ function makeGraph(id: string, timestampQueries = true): GPUCommandGraphInspecto
     id,
     stats: {...GRAPH_STATS, nodeOrder: [...GRAPH_STATS.nodeOrder]},
     capabilities: {...GRAPH_CAPABILITIES, timestampQueries}
+  };
+}
+
+function makeObservableGraph(
+  id: string
+): GPUCommandGraphInspectorObservableGraph<
+  ObservationParameters,
+  GPUCommandGraphInspectorEncoding
+> {
+  return {
+    ...makeGraph(id),
+    encode: (_commandEncoder, options) =>
+      makeEncoding(
+        options.parameters.cpuTimeMilliseconds,
+        options.parameters.cpuTimeMilliseconds / 4,
+        options.parameters.cpuTimeMilliseconds / 2,
+        options.parameters.gpuTimeMilliseconds,
+        options.parameters.gpuTimeMilliseconds / 4,
+        options.parameters.gpuTimeMilliseconds / 2
+      )
   };
 }
 

--- a/test/examples/gpu-command-graph-inspector-panel.spec.ts
+++ b/test/examples/gpu-command-graph-inspector-panel.spec.ts
@@ -1,0 +1,91 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {describe, expect, test} from 'vitest';
+import {
+  GPUCommandGraphInspector,
+  type GPUCommandGraphCapabilities,
+  type GPUCommandGraphStats
+} from '@luma.gl/experimental';
+import {GPUCommandGraphInspectorPanel} from '../../examples/gpu-command-graph-inspector-panel';
+
+const EMPTY_GRAPH_STATS: GPUCommandGraphStats = {
+  nodeOrder: [],
+  importedBufferCount: 0,
+  importedBufferBytes: 0,
+  logicalBufferCount: 0,
+  logicalBufferBytes: 0,
+  logicalTransientBufferCount: 0,
+  physicalTransientBufferCount: 0,
+  logicalTransientBytes: 0,
+  physicalTransientBytes: 0,
+  reusedTransientBytes: 0,
+  reusePercentage: 0,
+  importedTextureCount: 0,
+  importedTextureBytes: 0,
+  logicalTextureCount: 0,
+  logicalTextureBytes: 0,
+  logicalTransientTextureCount: 0,
+  physicalTransientTextureCount: 0,
+  logicalTransientTextureBytes: 0,
+  physicalTransientTextureBytes: 0,
+  reusedTransientTextureBytes: 0,
+  textureReusePercentage: 0,
+  logicalResourceBytes: 0,
+  physicalTransientResourceBytes: 0
+};
+
+const GRAPH_CAPABILITIES: GPUCommandGraphCapabilities = {
+  timestampQueries: false,
+  softwareAdapter: false,
+  maxBufferByteLength: 1_000_000,
+  maxStorageBufferBindingByteLength: 500_000,
+  maxComputeInvocationsPerWorkgroup: 256,
+  maxComputeWorkgroupsPerDimension: 65_535
+};
+
+describe('GPUCommandGraphInspectorPanel', () => {
+  test('safely renders hostile IDs inside a bounded counter scroller', () => {
+    const inspector = new GPUCommandGraphInspector();
+    for (const id of ['constructor', 'toString', '__proto__']) {
+      inspector.registerGraph({id, stats: EMPTY_GRAPH_STATS, capabilities: GRAPH_CAPABILITIES});
+    }
+    inspector.recordCounters(
+      'constructor',
+      Object.fromEntries([
+        ['constructor', 1],
+        ['toString', 2],
+        ['__proto__', 3],
+        ...Array.from({length: 24}, (_, index) => [`counter-${index}`, index + 4])
+      ])
+    );
+
+    const host = document.createElement('div');
+    document.body.append(host);
+    const panel = new GPUCommandGraphInspectorPanel(host);
+    try {
+      const snapshot = inspector.getSnapshot();
+      panel.update(snapshot, 'constructor');
+
+      const counterRows = host.querySelector<HTMLElement>('[data-graph-inspector-counter-rows]')!;
+      expect(host.textContent).toContain('constructor');
+      expect(counterRows.textContent).toContain('toString');
+      expect(counterRows.textContent).toContain('__proto__');
+      expect(counterRows.children).toHaveLength(27);
+      expect(getComputedStyle(counterRows).maxHeight).toBe('110px');
+      expect(getComputedStyle(counterRows).overflowY).toBe('auto');
+      expect(
+        counterRows.previousElementSibling?.classList.contains('graph-inspector-counter-header')
+      ).toBe(true);
+
+      panel.update(snapshot, 'toString');
+      expect(host.textContent).toContain('toString');
+      panel.update(snapshot, '__proto__');
+      expect(host.textContent).toContain('__proto__');
+    } finally {
+      panel.destroy();
+      host.remove();
+    }
+  });
+});

--- a/test/examples/luspatial-taxi-runtime.node.spec.ts
+++ b/test/examples/luspatial-taxi-runtime.node.spec.ts
@@ -7,7 +7,13 @@ import type {LayerContext} from '@deck.gl/core';
 import type {DrawCommandBuffer} from '@luma.gl/experimental';
 import {describe, expect, test} from 'vitest';
 import {LuSpatialPointLayer} from '../../examples/deck/luspatial-taxi/luspatial-point-layer';
-import {LuSpatialTaxiQueryEffect} from '../../examples/deck/luspatial-taxi/luspatial-query-effect';
+import {
+  LU_SPATIAL_TAXI_QUERY_COUNTER_IDS,
+  LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS,
+  LuSpatialTaxiQueryEffect,
+  decodeLuSpatialTaxiQueryCounters,
+  makeLuSpatialTaxiQueryInspectorCounters
+} from '../../examples/deck/luspatial-taxi/luspatial-query-effect';
 import type {LuSpatialTaxiData} from '../../examples/deck/luspatial-taxi/taxi-data';
 
 describe('luSpatial taxi runtime resource safety', () => {
@@ -73,5 +79,78 @@ describe('luSpatial taxi runtime resource safety', () => {
     );
     expect(styleBufferDestroyCount).toBe(1);
     expect(readinessCount).toBe(0);
+  });
+});
+
+describe('luSpatial taxi query telemetry', () => {
+  test('decodes aligned GPU diagnostics and publishes a complete inspector sample', () => {
+    expect(Object.values(LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS)).toEqual([
+      0, 256, 512, 768
+    ]);
+    const drawCommandBytes = new Uint8Array(80).subarray(8, 72);
+    const viewportInstanceCountByteOffset = 20;
+    const selectionInstanceCountByteOffset = 52;
+    const drawCommandView = new DataView(
+      drawCommandBytes.buffer,
+      drawCommandBytes.byteOffset,
+      drawCommandBytes.byteLength
+    );
+    drawCommandView.setUint32(viewportInstanceCountByteOffset, 41, true);
+    drawCommandView.setUint32(selectionInstanceCountByteOffset, 7, true);
+
+    const queryDiagnosticByteLength =
+      LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.selectionCandidateCount +
+      Uint32Array.BYTES_PER_ELEMENT;
+    const queryDiagnosticBytes = new Uint8Array(queryDiagnosticByteLength + 12).subarray(
+      4,
+      4 + queryDiagnosticByteLength
+    );
+    const queryDiagnosticView = new DataView(
+      queryDiagnosticBytes.buffer,
+      queryDiagnosticBytes.byteOffset,
+      queryDiagnosticBytes.byteLength
+    );
+    queryDiagnosticView.setUint32(
+      LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.viewportIntersectedCellCount,
+      12,
+      true
+    );
+    queryDiagnosticView.setUint32(
+      LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.viewportCandidateCount,
+      83,
+      true
+    );
+    queryDiagnosticView.setUint32(
+      LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.selectionIntersectedCellCount,
+      3,
+      true
+    );
+    queryDiagnosticView.setUint32(
+      LU_SPATIAL_TAXI_QUERY_DIAGNOSTIC_BYTE_OFFSETS.selectionCandidateCount,
+      19,
+      true
+    );
+
+    const counters = decodeLuSpatialTaxiQueryCounters(
+      drawCommandBytes,
+      queryDiagnosticBytes,
+      {viewportInstanceCountByteOffset, selectionInstanceCountByteOffset}
+    );
+    expect(counters).toEqual({
+      viewportIntersectedCellCount: 12,
+      viewportCandidateCount: 83,
+      visiblePointCount: 41,
+      selectionIntersectedCellCount: 3,
+      selectionCandidateCount: 19,
+      selectedPointCount: 7
+    });
+    expect(makeLuSpatialTaxiQueryInspectorCounters(counters)).toEqual({
+      [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.viewportIntersectedCells]: 12,
+      [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.viewportCandidates]: 83,
+      [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.viewportMatches]: 41,
+      [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.selectionIntersectedCells]: 3,
+      [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.selectionCandidates]: 19,
+      [LU_SPATIAL_TAXI_QUERY_COUNTER_IDS.selectionMatches]: 7
+    });
   });
 });

--- a/test/examples/luspatial-taxi-runtime.node.spec.ts
+++ b/test/examples/luspatial-taxi-runtime.node.spec.ts
@@ -131,11 +131,10 @@ describe('luSpatial taxi query telemetry', () => {
       true
     );
 
-    const counters = decodeLuSpatialTaxiQueryCounters(
-      drawCommandBytes,
-      queryDiagnosticBytes,
-      {viewportInstanceCountByteOffset, selectionInstanceCountByteOffset}
-    );
+    const counters = decodeLuSpatialTaxiQueryCounters(drawCommandBytes, queryDiagnosticBytes, {
+      viewportInstanceCountByteOffset,
+      selectionInstanceCountByteOffset
+    });
     expect(counters).toEqual({
       viewportIntersectedCellCount: 12,
       viewportCandidateCount: 83,


### PR DESCRIPTION
## Goals

- Connect the exact indexed-work diagnostics from #2916 to the deck.gl luSpatial taxi runtime.
- Publish useful viewport and selection work histories through the reusable command-graph inspector from #2918.
- Preserve GPU-driven drawing and the existing sparse, coalesced diagnostic cadence.

## Changes

- Adds one 772-byte query-diagnostics buffer with four disjoint storage views at 0/256/512/768 bytes for viewport/selection intersected-cell and candidate counts.
- Wires those views into the bounds and radius `GPUPointSpatialQuery` contributors.
- Samples diagnostics together with indirect draw counts only on the existing bounded readback cadence.
- Publishes cells, candidates, and matches for both queries through `queryGraphObservation.recordCounters()`.
- Adds concise inspector labels and exposes the exact sampled values in `LuSpatialTaxiQueryStats`.
- Adds subview-safe little-endian decoding and counter-mapping coverage, including nonzero `Uint8Array.byteOffset` values.

## Dependencies

- Stacked on #2918 for `GPUCommandGraphInspectorObservation.recordCounters()` and panel counter rendering.
- Temporarily includes the two focused implementation commits from #2916 so the branch compiles before that sibling stack lands. Those commits will be dropped during the final rebase after #2916 merges.
- The integration-specific review delta is commit `79fb417ea`.

## Verification

Passed locally:

- `nvm use` — Node 22.22.1
- focused Vitest runtime suite with source aliases — 3 tests passed
- source-based TypeScript check — no errors in the changed query effect or runtime test
- `git diff --check`
- independent diff review — no P0/P1/P2 findings

Repository-wide commands are currently blocked in this worktree by the same local dependency skew documented on #2919:

- `yarn install` — current registry artifacts return 403
- `yarn lint fix` — attempted; current `ocular-lint` is unavailable
- `yarn build` — unavailable current build tooling
- `yarn test` — unavailable current test tooling
- `yarn website:build` — unavailable current website tooling
- `(cd website && yarn build)` — unavailable current Vite tooling

Clean-install GitHub CI is the repository-wide authority for this branch.

## Risk

- Telemetry remains optional and does not affect the query or indirect-draw path if readback is unavailable.
- The shared diagnostics views use the graph library’s required 256-byte storage-binding spacing; the focused test locks that layout down.