### PR TITLE
fix(experimental): scale GPUScan dispatches

### DIFF
--- a/modules/experimental/src/gpu-primitives/gpu-dispatch-utils.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-dispatch-utils.ts
@@ -1,0 +1,65 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+const MAXIMUM_UINT32 = 0xffffffff;
+const UINT32_VALUE_COUNT = 0x100000000;
+
+/** Bounded three-dimensional WebGPU workgroup layout. @internal */
+export type GPUBoundedDispatchLayout = {
+  x: number;
+  y: number;
+  z: number;
+};
+
+/** Plans a bounded three-dimensional dispatch for a linear element range. @internal */
+export function getBoundedDispatchLayout(
+  operationName: string,
+  elementCount: number,
+  workgroupSize: number,
+  maxComputeWorkgroupsPerDimension: number
+): GPUBoundedDispatchLayout {
+  if (!Number.isSafeInteger(elementCount) || elementCount < 0 || elementCount > MAXIMUM_UINT32) {
+    throw new Error(`${operationName} element count must be a non-negative uint32`);
+  }
+  validateWorkgroupSize(operationName, workgroupSize);
+  const maximum = Math.floor(maxComputeWorkgroupsPerDimension);
+  if (!Number.isSafeInteger(maximum) || maximum < 1) {
+    throw new Error('maxComputeWorkgroupsPerDimension must be a positive integer');
+  }
+
+  const workgroupCount = Math.max(1, Math.ceil(elementCount / workgroupSize));
+  const x = Math.min(workgroupCount, maximum);
+  const y = Math.min(Math.ceil(workgroupCount / x), maximum);
+  const z = Math.ceil(workgroupCount / x / y);
+  if (z > maximum) {
+    throw new Error(
+      `${operationName} requires ${workgroupCount} workgroups, exceeding the 3D dispatch limit of ${maximum} per dimension`
+    );
+  }
+  return {x, y, z};
+}
+
+/** Returns WGSL that maps a bounded 3D dispatch to one linear element index. @internal */
+export function getBoundedInvocationIndexSource(
+  layout: GPUBoundedDispatchLayout,
+  workgroupSize: number
+): string {
+  validateWorkgroupSize('GPU dispatch', workgroupSize);
+  const maximumLinearWorkgroupCount = Math.floor(MAXIMUM_UINT32 / workgroupSize) + 1;
+  return `let workgroupIndex = (workgroupId.z * ${layout.y}u + workgroupId.y) * ${layout.x}u + workgroupId.x;
+  if (workgroupIndex >= ${maximumLinearWorkgroupCount}u) { return; }
+  let index = workgroupIndex * ${workgroupSize}u + localInvocationIndex;`;
+}
+
+/** Ensures the pre-multiplication guard exactly partitions the uint32 invocation range. */
+function validateWorkgroupSize(operationName: string, workgroupSize: number): void {
+  if (
+    !Number.isSafeInteger(workgroupSize) ||
+    workgroupSize < 2 ||
+    workgroupSize > MAXIMUM_UINT32 ||
+    UINT32_VALUE_COUNT % workgroupSize !== 0
+  ) {
+    throw new Error(`${operationName} workgroup size must be a power of two greater than one`);
+  }
+}

--- a/modules/experimental/src/gpu-primitives/gpu-grid-index-internals.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-grid-index-internals.ts
@@ -10,6 +10,11 @@ import {
   type GraphDataView,
   GraphVectorView
 } from './gpu-command-graph';
+import {
+  type GPUBoundedDispatchLayout,
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from './gpu-dispatch-utils';
 import type {
   GPUGridIndex,
   GPUGridIndexBounds,
@@ -17,19 +22,11 @@ import type {
   GPUGridIndexSize,
   GPUGridIndexSourceIds
 } from './gpu-grid-index';
-import {GPUScan} from './gpu-scan';
+import {addGPUScanToGraphWithDispatchLimit, GPUScan} from './gpu-scan';
 import {createTransientView, getViewBinding, getViewElementOffset} from './graph-data-view-utils';
 
 const GRID_INDEX_WORKGROUP_SIZE = 256;
-const MAXIMUM_UINT32 = 0xffffffff;
-const MAXIMUM_LINEAR_GRID_INDEX_WORKGROUP_COUNT =
-  Math.floor(MAXIMUM_UINT32 / GRID_INDEX_WORKGROUP_SIZE) + 1;
-
-type GPUGridIndexDispatchLayout = {
-  x: number;
-  y: number;
-  z: number;
-};
+type GPUGridIndexDispatchLayout = GPUBoundedDispatchLayout;
 
 /** Adds an index rebuild using an explicit device dispatch limit. @internal */
 export function addGPUGridIndexToGraphWithDispatchLimit<Parameters>(
@@ -92,11 +89,12 @@ export function addGPUGridIndexToGraphWithDispatchLimit<Parameters>(
       });
     }
   }
-  new GPUScan({
+  const scan = new GPUScan({
     id: `${index.id}-scan`,
     input: cellCounts,
     output: scannedOffsets
-  }).addToGraph(graph);
+  });
+  addGPUScanToGraphWithDispatchLimit(scan, graph, maxComputeWorkgroupsPerDimension);
   addFinalizePass(graph, {
     id: `${index.id}-finalize`,
     cellCounts,
@@ -467,30 +465,17 @@ export function getGPUGridIndexDispatchLayout(
   elementCount: number,
   maxComputeWorkgroupsPerDimension: number
 ): GPUGridIndexDispatchLayout {
-  if (!Number.isSafeInteger(elementCount) || elementCount < 0 || elementCount > MAXIMUM_UINT32) {
-    throw new Error('GPUGridIndex element count must be a non-negative uint32');
-  }
-  const maximum = Math.floor(maxComputeWorkgroupsPerDimension);
-  if (!Number.isSafeInteger(maximum) || maximum < 1) {
-    throw new Error('maxComputeWorkgroupsPerDimension must be a positive integer');
-  }
-  const workgroupCount = Math.max(1, Math.ceil(elementCount / GRID_INDEX_WORKGROUP_SIZE));
-  const x = Math.min(workgroupCount, maximum);
-  const y = Math.min(Math.ceil(workgroupCount / x), maximum);
-  const z = Math.ceil(workgroupCount / x / y);
-  if (z > maximum) {
-    throw new Error(
-      `GPUGridIndex requires ${workgroupCount} workgroups, exceeding the 3D dispatch limit of ${maximum} per dimension`
-    );
-  }
-  return {x, y, z};
+  return getBoundedDispatchLayout(
+    'GPUGridIndex',
+    elementCount,
+    GRID_INDEX_WORKGROUP_SIZE,
+    maxComputeWorkgroupsPerDimension
+  );
 }
 
 /** Returns WGSL that maps a bounded 3D dispatch to one linear element index. @internal */
 export function getGPUGridIndexInvocationIndexSource(layout: GPUGridIndexDispatchLayout): string {
-  return `let workgroupIndex = (workgroupId.z * ${layout.y}u + workgroupId.y) * ${layout.x}u + workgroupId.x;
-  if (workgroupIndex >= ${MAXIMUM_LINEAR_GRID_INDEX_WORKGROUP_COUNT}u) { return; }
-  let index = workgroupIndex * ${GRID_INDEX_WORKGROUP_SIZE}u + localInvocationIndex;`;
+  return getBoundedInvocationIndexSource(layout, GRID_INDEX_WORKGROUP_SIZE);
 }
 
 function getPositionChunks(

--- a/modules/experimental/src/gpu-primitives/gpu-scan.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-scan.ts
@@ -4,7 +4,12 @@
 
 import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUCommandGraph, GraphVectorView, type GraphDataView} from './gpu-command-graph';
+import {GPUCommandGraph, type GraphDataView, GraphVectorView} from './gpu-command-graph';
+import {
+  type GPUBoundedDispatchLayout,
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from './gpu-dispatch-utils';
 import {
   createTransientView,
   getViewBinding,
@@ -102,19 +107,36 @@ export class GPUScan {
    * or read data back.
    */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
-    validateScanOwnership(graph, this.input, this.id);
-    validateScanOwnership(graph, this.output, this.id);
-    if (this.segmentFlags) {
-      validateScanOwnership(graph, this.segmentFlags, this.id);
-    }
-    addChunkedScan(graph, {
-      id: this.id,
-      input: this.input,
-      output: this.output,
-      mode: this.mode,
-      segmentFlags: this.segmentFlags
-    });
+    addGPUScanToGraphWithDispatchLimit(
+      this,
+      graph,
+      graph.device.limits.maxComputeWorkgroupsPerDimension
+    );
   }
+}
+
+/** Adds a scan using an explicit per-dimension dispatch limit. @internal */
+export function addGPUScanToGraphWithDispatchLimit<Parameters>(
+  scan: GPUScan,
+  graph: GPUCommandGraph<Parameters>,
+  maxComputeWorkgroupsPerDimension: number
+): void {
+  validateScanOwnership(graph, scan.input, scan.id);
+  validateScanOwnership(graph, scan.output, scan.id);
+  if (scan.segmentFlags) {
+    validateScanOwnership(graph, scan.segmentFlags, scan.id);
+  }
+  addChunkedScan(
+    graph,
+    {
+      id: scan.id,
+      input: scan.input,
+      output: scan.output,
+      mode: scan.mode,
+      segmentFlags: scan.segmentFlags
+    },
+    maxComputeWorkgroupsPerDimension
+  );
 }
 
 /** Normalizes atomic and vector inputs and adds the required local scans and vector carries. */
@@ -126,7 +148,8 @@ function addChunkedScan<Parameters>(
     output: GPUScanInput;
     mode: 'exclusive' | 'inclusive';
     segmentFlags?: GPUScanInput;
-  }
+  },
+  maxComputeWorkgroupsPerDimension: number
 ): void {
   const inputChunks = getScanChunks(props.input);
   const outputChunks = getScanChunks(props.output);
@@ -150,7 +173,8 @@ function addChunkedScan<Parameters>(
       input: chunk.input,
       output: chunk.output,
       mode: props.mode,
-      segmentFlags: chunk.segmentFlags
+      segmentFlags: chunk.segmentFlags,
+      maxComputeWorkgroupsPerDimension
     });
     return;
   }
@@ -191,7 +215,8 @@ function addChunkedScan<Parameters>(
       finalSum: createPackedSubview(graph, chunkTotals, partialIndex),
       finalSegmentFlag: chunkSegmentFlags
         ? createPackedSubview(graph, chunkSegmentFlags, partialIndex)
-        : undefined
+        : undefined,
+      maxComputeWorkgroupsPerDimension
     });
   }
   addScanLevels(graph, {
@@ -200,7 +225,8 @@ function addChunkedScan<Parameters>(
     output: chunkOffsets,
     mode: 'exclusive',
     segmentFlags: chunkSegmentFlags,
-    segmentSummaryInput: Boolean(chunkSegmentFlags)
+    segmentSummaryInput: Boolean(chunkSegmentFlags),
+    maxComputeWorkgroupsPerDimension
   });
   for (const [partialIndex, chunk] of nonEmptyChunks.entries()) {
     addOffsetPass(graph, {
@@ -209,7 +235,11 @@ function addChunkedScan<Parameters>(
       offsets: chunkOffsets,
       length: chunk.output.length,
       offsetIndex: partialIndex,
-      segmentPrefixes: chunkSegmentPrefixes?.[partialIndex]
+      segmentPrefixes: chunkSegmentPrefixes?.[partialIndex],
+      dispatchLayout: getGPUScanDispatchLayout(
+        chunk.output.length,
+        maxComputeWorkgroupsPerDimension
+      )
     });
   }
 }
@@ -228,6 +258,7 @@ function addScanLevels<Parameters>(
     finalSegmentFlag?: GraphDataView<'uint32'>;
     /** Summary flags report a start anywhere in one lower-level block, not at its first row. */
     segmentSummaryInput?: boolean;
+    maxComputeWorkgroupsPerDimension: number;
   }
 ): void {
   if (props.input.length === 0) {
@@ -293,7 +324,8 @@ function addScanLevels<Parameters>(
       finalSum: blockSums ? undefined : props.finalSum,
       finalSegmentFlag: blockSums ? undefined : props.finalSegmentFlag,
       length: levelLength,
-      blockCount
+      blockCount,
+      dispatchLayout: getGPUScanDispatchLayout(levelLength, props.maxComputeWorkgroupsPerDimension)
     });
     levels.push({output: levelOutput, length: levelLength, segmentPrefixes});
 
@@ -323,7 +355,8 @@ function addScanLevels<Parameters>(
       offsets: level.blockOffsets!,
       length: level.length,
       segmentPrefixes: level.segmentPrefixes,
-      offsetSegmentPrefixes: parentLevel.segmentPrefixes
+      offsetSegmentPrefixes: parentLevel.segmentPrefixes,
+      dispatchLayout: getGPUScanDispatchLayout(level.length, props.maxComputeWorkgroupsPerDimension)
     });
   }
 }
@@ -384,6 +417,7 @@ function addBlockScanPass<Parameters>(
     finalSegmentFlag?: GraphDataView<'uint32'>;
     length: number;
     blockCount: number;
+    dispatchLayout: GPUScanDispatchLayout;
   }
 ): void {
   const sumOutput = props.blockSums ?? props.finalSum;
@@ -401,12 +435,12 @@ function addBlockScanPass<Parameters>(
     ? '@group(0) @binding(5) var<storage, read_write> summarySegmentFlags: array<u32>;'
     : '';
   const sumWrite = props.blockSums
-    ? 'sumValues[SUM_OFFSET + workgroupId.x] = scratch[255u];'
+    ? 'sumValues[SUM_OFFSET + workgroupIndex] = scratch[255u];'
     : props.finalSum
       ? 'sumValues[SUM_OFFSET] = scratch[255u];'
       : '';
   const segmentFlagWrite = props.blockSegmentFlags
-    ? 'summarySegmentFlags[SUMMARY_SEGMENT_FLAGS_OFFSET + workgroupId.x] = segmentScratch[255u];'
+    ? 'summarySegmentFlags[SUMMARY_SEGMENT_FLAGS_OFFSET + workgroupIndex] = segmentScratch[255u];'
     : props.finalSegmentFlag
       ? 'summarySegmentFlags[SUMMARY_SEGMENT_FLAGS_OFFSET] = segmentScratch[255u];'
       : '';
@@ -440,6 +474,7 @@ function addBlockScanPass<Parameters>(
     : '';
   const source = /* wgsl */ `
 const ELEMENT_COUNT: u32 = ${props.length}u;
+const BLOCK_COUNT: u32 = ${props.blockCount}u;
 const INPUT_OFFSET: u32 = ${getViewElementOffset(props.input)}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
 ${sumOutput ? `const SUM_OFFSET: u32 = ${getViewElementOffset(sumOutput)}u;` : ''}
@@ -456,12 +491,12 @@ var<workgroup> scratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;
 ${props.segmentFlags ? `var<workgroup> segmentScratch: array<u32, ${SCAN_WORKGROUP_SIZE}>;` : ''}
 
 @compute @workgroup_size(${SCAN_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) globalId: vec3<u32>,
-  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32,
   @builtin(workgroup_id) workgroupId: vec3<u32>
 ) {
-  let index = globalId.x;
-  let lane = localId.x;
+  ${getGPUScanInvocationIndexSource(props.dispatchLayout)}
+  if (workgroupIndex >= BLOCK_COUNT) { return; }
+  let lane = localInvocationIndex;
   var inputValue = 0u;
   var inputSegmentFlag = 0u;
   if (index < ELEMENT_COUNT) {
@@ -555,7 +590,12 @@ ${props.segmentFlags ? `var<workgroup> segmentScratch: array<u32, ${SCAN_WORKGRO
             bindings['summarySegmentFlags'] = getViewBinding(segmentFlagOutput, getBuffer);
           }
           computation.setBindings(bindings);
-          computation.dispatch(computePass, props.blockCount);
+          computation.dispatch(
+            computePass,
+            props.dispatchLayout.x,
+            props.dispatchLayout.y,
+            props.dispatchLayout.z
+          );
         },
         destroy: () => computation.destroy()
       };
@@ -574,6 +614,7 @@ function addOffsetPass<Parameters>(
     offsetIndex?: number;
     segmentPrefixes?: GraphDataView<'uint32'>;
     offsetSegmentPrefixes?: GraphDataView<'uint32'>;
+    dispatchLayout: GPUScanDispatchLayout;
   }
 ): void {
   const offsetIndex =
@@ -590,9 +631,10 @@ ${props.segmentPrefixes ? `@group(0) @binding(2) var<storage, ${props.offsetSegm
 ${props.offsetSegmentPrefixes ? '@group(0) @binding(3) var<storage, read> offsetSegmentPrefixes: array<u32>;' : ''}
 
 @compute @workgroup_size(${SCAN_WORKGROUP_SIZE}) fn main(
-  @builtin(global_invocation_id) globalId: vec3<u32>
+  @builtin(local_invocation_index) localInvocationIndex: u32,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
 ) {
-  let index = globalId.x;
+  ${getGPUScanInvocationIndexSource(props.dispatchLayout)}
   if (index < ELEMENT_COUNT) {
     ${props.offsetSegmentPrefixes ? `let offsetSegmentPrefix = offsetSegmentPrefixes[OFFSET_SEGMENT_PREFIXES_OFFSET + ${offsetIndex}];` : ''}
     ${
@@ -663,10 +705,35 @@ ${props.offsetSegmentPrefixes ? '@group(0) @binding(3) var<storage, read> offset
             );
           }
           computation.setBindings(bindings);
-          computation.dispatch(computePass, Math.ceil(props.length / SCAN_WORKGROUP_SIZE));
+          computation.dispatch(
+            computePass,
+            props.dispatchLayout.x,
+            props.dispatchLayout.y,
+            props.dispatchLayout.z
+          );
         },
         destroy: () => computation.destroy()
       };
     }
   });
+}
+
+type GPUScanDispatchLayout = GPUBoundedDispatchLayout;
+
+/** Plans a bounded three-dimensional dispatch for one scan pass. @internal */
+export function getGPUScanDispatchLayout(
+  elementCount: number,
+  maxComputeWorkgroupsPerDimension: number
+): GPUScanDispatchLayout {
+  return getBoundedDispatchLayout(
+    'GPUScan',
+    elementCount,
+    SCAN_WORKGROUP_SIZE,
+    maxComputeWorkgroupsPerDimension
+  );
+}
+
+/** Returns WGSL that maps a bounded 3D scan dispatch to one linear element index. @internal */
+export function getGPUScanInvocationIndexSource(layout: GPUScanDispatchLayout): string {
+  return getBoundedInvocationIndexSource(layout, SCAN_WORKGROUP_SIZE);
 }

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph.spec.ts
@@ -2,23 +2,32 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {Buffer, type Device, Texture} from '@luma.gl/core';
 import {DynamicBuffer, Model} from '@luma.gl/engine';
 import {
   createTransientView,
   DispatchCommandBuffer,
   DrawCommandBuffer,
-  getViewBinding,
-  getViewElementOffset,
   GPUCommandGraph,
+  type GPUCommandGraphContributor,
   GPUCompaction,
   GPUScan,
-  type GPUCommandGraphContributor,
-  GPUTextSelection
+  GPUTextSelection,
+  getViewBinding,
+  getViewElementOffset
 } from '@luma.gl/experimental';
 import {GPUData, GPUVector} from '@luma.gl/tables';
 import {getNullTestDevice, getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
+import {
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from '../../src/gpu-primitives/gpu-dispatch-utils';
+import {
+  addGPUScanToGraphWithDispatchLimit,
+  getGPUScanDispatchLayout,
+  getGPUScanInvocationIndexSource
+} from '../../src/gpu-primitives/gpu-scan';
 
 test('GPUCommandGraph compiles dependencies and reuses transient buffers', async t => {
   const device = await getWebGPUTestDevice();
@@ -652,6 +661,112 @@ test('CompiledGPUCommandGraph resolves DynamicBuffer replacements and preserves 
   t.end();
 });
 
+test('GPUScan plans bounded multidimensional direct dispatches', t => {
+  const maximum = 65_535;
+  const oneDimensionalRowCapacity = maximum * 256;
+
+  t.deepEqual(getGPUScanDispatchLayout(0, maximum), {x: 1, y: 1, z: 1});
+  t.deepEqual(getGPUScanDispatchLayout(oneDimensionalRowCapacity, maximum), {
+    x: maximum,
+    y: 1,
+    z: 1
+  });
+  t.deepEqual(getGPUScanDispatchLayout(oneDimensionalRowCapacity + 1, maximum), {
+    x: maximum,
+    y: 2,
+    z: 1
+  });
+  t.deepEqual(
+    getGPUScanDispatchLayout(4 * 256 + 1, 2),
+    {x: 2, y: 2, z: 2},
+    'a small synthetic limit exercises the third dispatch dimension'
+  );
+  t.throws(() => getGPUScanDispatchLayout(8 * 256 + 1, 2), /exceeding the 3D dispatch limit/);
+  t.throws(
+    () => getBoundedDispatchLayout('GPUScan', 1024, 3, maximum),
+    /power of two greater than one/,
+    'the shared uint32 guard rejects workgroup sizes that can wrap padded lanes'
+  );
+  t.throws(
+    () => getBoundedInvocationIndexSource({x: 1, y: 1, z: 1}, 1),
+    /power of two greater than one/,
+    'the source helper never emits an unrepresentable 2^32 guard literal'
+  );
+
+  const source = getGPUScanInvocationIndexSource({x: 3, y: 2, z: 2});
+  t.match(source, /workgroupId\.z \* 2u \+ workgroupId\.y/);
+  t.match(source, /\* 3u \+ workgroupId\.x/);
+  t.match(
+    source,
+    /workgroupIndex >= 16777216u/,
+    'padded workgroups cannot wrap the uint32 invocation index'
+  );
+  t.ok(
+    source.indexOf('workgroupIndex >= 16777216u') <
+      source.indexOf('workgroupIndex * 256u + localInvocationIndex'),
+    'the uint32 guard executes before invocation-index multiplication'
+  );
+  t.end();
+});
+
+test('GPUScan executes multidimensional block and offset dispatches', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const length = 4 * 256 + 1;
+  const values = Uint32Array.from({length}, (_, index) => (index % 11) + 1);
+  const segmentFlags = new Uint32Array(length);
+  for (const index of [0, 700]) {
+    segmentFlags[index] = 1;
+  }
+  const result = await runScan(device, values, {
+    mode: 'exclusive',
+    segmentFlags,
+    maxComputeWorkgroupsPerDimension: 2
+  });
+
+  t.deepEqual(
+    result,
+    getExpectedScan(values, 'exclusive', segmentFlags),
+    'five block scans and their offset pass execute through a padded 2x2x2 layout'
+  );
+  t.end();
+});
+
+test('GPUScan preserves vector segments and carries through multidimensional passes', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const valueChunks = [
+    Uint32Array.from([10]),
+    Uint32Array.from({length: 4 * 256 + 1}, () => 1),
+    Uint32Array.from([7])
+  ];
+  const segmentFlagChunks = valueChunks.map(chunk => new Uint32Array(chunk.length));
+  segmentFlagChunks[1][700] = 1;
+  const result = await runVectorScan(device, valueChunks, {
+    mode: 'exclusive',
+    segmentFlagChunks,
+    maxComputeWorkgroupsPerDimension: 2
+  });
+
+  t.deepEqual(result.chunks[0], [0], 'the first chunk starts the vector-wide prefix');
+  t.equal(result.chunks[1][0], 10, 'the preceding chunk carry reaches the 3D-dispatched chunk');
+  t.equal(result.chunks[1][699], 709, 'the carry survives x-to-y workgroup boundaries');
+  t.equal(result.chunks[1][700], 0, 'the interior segment start resets the carried prefix');
+  t.equal(result.chunks[1][1024], 324, 'the reset segment survives the padded z workgroup');
+  t.deepEqual(result.chunks[2], [325], 'the final chunk receives the last segment total');
+  t.end();
+});
+
 test('GPUScan computes exclusive uint32 prefixes', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -1240,6 +1355,7 @@ async function runVectorScan(
   options: {
     mode?: 'exclusive' | 'inclusive';
     segmentFlagChunks?: Uint32Array[];
+    maxComputeWorkgroupsPerDimension?: number;
   } = {}
 ): Promise<{chunks: number[][]; nodeOrder: string[]}> {
   const inputFixture = createUint32VectorFixture(device, 'input', chunks);
@@ -1253,7 +1369,12 @@ async function runVectorScan(
   const segmentFlags = segmentFlagsFixture
     ? graph.importGPUVector('segment-flags', segmentFlagsFixture.vector)
     : undefined;
-  new GPUScan({input, output, mode: options.mode, segmentFlags}).addToGraph(graph);
+  const scan = new GPUScan({input, output, mode: options.mode, segmentFlags});
+  if (options.maxComputeWorkgroupsPerDimension === undefined) {
+    scan.addToGraph(graph);
+  } else {
+    addGPUScanToGraphWithDispatchLimit(scan, graph, options.maxComputeWorkgroupsPerDimension);
+  }
   const compiled = graph.compile();
   const commandEncoder = device.createCommandEncoder({id: 'vector-scan-encoder'});
   compiled.encode(commandEncoder, {parameters: undefined});
@@ -1275,6 +1396,7 @@ async function runScan(
   options: {
     mode?: 'exclusive' | 'inclusive';
     segmentFlags?: Uint32Array;
+    maxComputeWorkgroupsPerDimension?: number;
   } = {}
 ): Promise<number[]> {
   const inputBuffer = device.createBuffer({
@@ -1315,7 +1437,12 @@ async function runScan(
   const segmentFlags = segmentFlagsHandle
     ? graph.createDataView(segmentFlagsHandle, {format: 'uint32', length: values.length})
     : undefined;
-  new GPUScan({input, output, mode: options.mode, segmentFlags}).addToGraph(graph);
+  const scan = new GPUScan({input, output, mode: options.mode, segmentFlags});
+  if (options.maxComputeWorkgroupsPerDimension === undefined) {
+    scan.addToGraph(graph);
+  } else {
+    addGPUScanToGraphWithDispatchLimit(scan, graph, options.maxComputeWorkgroupsPerDimension);
+  }
   const compiled = graph.compile();
   const commandEncoder = device.createCommandEncoder({id: 'scan-variant-encoder'});
   compiled.encode(commandEncoder, {parameters: undefined});

--- a/modules/experimental/test/gpu-primitives/gpu-grid-index.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-grid-index.spec.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {Buffer, type Device} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
 import {
   GPUCommandGraph,
   GPUGridIndex,
@@ -12,6 +13,7 @@ import {
 import {GPUData, GPUVector} from '@luma.gl/tables';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
 import test from 'test/utils/vitest-tape';
+import {vi} from 'vitest';
 import {
   addGPUGridIndexToGraphWithDispatchLimit,
   getGPUGridIndexDispatchLayout,
@@ -91,6 +93,58 @@ test('GPUGridIndex executes a small three-dimensional dispatch layout', async t 
     Array.from({length: positionCount}, (_, index) => index),
     'scatter visits every source row exactly once'
   );
+  t.end();
+});
+
+test('GPUGridIndex scans cell offsets through a multidimensional dispatch', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const cellCount = 4 * 256 + 1;
+  const dispatchSpy = vi.spyOn(Computation.prototype, 'dispatch');
+  let result: Awaited<ReturnType<typeof runGridIndex>>;
+  let scanDispatch: Parameters<Computation['dispatch']> | undefined;
+  try {
+    result = await runGridIndex(
+      device,
+      Float32Array.from([0.5, 0.5, 512.5, 0.5, 1024.5, 0.5]),
+      'float32x2',
+      [cellCount, 1],
+      [0, 0, cellCount, 1],
+      3,
+      {maxComputeWorkgroupsPerDimension: 2}
+    );
+    const scanDispatchIndex = dispatchSpy.mock.instances.findIndex(
+      computation => (computation as Computation).id === 'gpu-grid-index-scan-level-0-scan'
+    );
+    scanDispatch = dispatchSpy.mock.calls[scanDispatchIndex];
+  } finally {
+    dispatchSpy.mockRestore();
+  }
+  const expectedOffsets = Array.from({length: cellCount + 1}, (_, index) => {
+    if (index === 0) return 0;
+    if (index <= 512) return 1;
+    if (index <= 1024) return 2;
+    return 3;
+  });
+
+  t.deepEqual(
+    result.cellOffsets,
+    expectedOffsets,
+    'the five-block cell-count scan and offset pass preserve every empty cell'
+  );
+  t.deepEqual(
+    scanDispatch?.slice(1),
+    [2, 2, 2],
+    'the GridIndex synthetic device limit reaches its nested scan dispatch'
+  );
+  t.deepEqual(result.objectIds, [0, 1, 2], 'widely separated cells retain their source rows');
+  t.equal(result.count, 3, 'the complete index count survives the multidimensional scan');
+  t.equal(result.overflow, 0, 'the exact-capacity index does not overflow');
   t.end();
 });
 


### PR DESCRIPTION
## Goals

- Remove the one-dimensional workgroup ceiling from hierarchical GPUScan passes.
- Let GPUGridIndex build grids beyond roughly 16.8 million cells while staying within WebGPU three-dimensional dispatch limits.

## Changes

- Add one shared bounded 3D dispatch planner and overflow-safe WGSL invocation-index helper.
- Dispatch both block-scan and add-offset passes across x, y, and z dimensions.
- Propagate the explicit GridIndex dispatch limit into its nested GPUScan.
- Cover forced 2x2x2 direct, segmented, vector-carry, and nested GridIndex paths.

## Verification

- nvm use: passed with Node 22.22.1.
- Targeted Biome formatting and lint for all five changed files: passed.
- Strict TypeScript check for the changed source files: passed.
- Changed test files type-check with no diagnostics; the only diagnostic in that focused compilation is the existing test/utils/vitest-tape.ts ArrayBufferView cast.
- Dispatch-planner edge assertions: passed.
- git diff --check: passed.
- Independent WGSL and test review: no blocker.
- yarn install: unavailable locally because the configured registry returns 403 for current Playwright and @vis.gl/dev-tools artifacts.
- yarn lint fix, yarn build, and yarn test therefore cannot start in this worktree because ocular commands are absent; clean GitHub CI is the full-environment gate.

## Stack

- Stacked on #2914, which first scales the direct GPUGridIndex passes.

## Risk

This changes only experimental internal scheduling. Public scan and grid-index APIs are unchanged. The forced small device limit exercises padding and all three dispatch dimensions without allocating production-scale buffers.