### PR TITLE
fix(splats): stabilize software-GPU browser tests in CI

### DIFF
--- a/modules/splats/test/splat-renderer.spec.ts
+++ b/modules/splats/test/splat-renderer.spec.ts
@@ -168,6 +168,11 @@ test('SplatRenderer WebGPU pipeline writes visible Gaussian color into an offscr
     t.end();
     return;
   }
+  if (isSoftwareBackedDevice(device)) {
+    t.comment('Skipping Gaussian splat WebGPU pixel readback on a software-backed adapter');
+    t.end();
+    return;
+  }
 
   const colorTexture = device.createTexture({
     width: 16,
@@ -222,6 +227,11 @@ test('SplatRenderer WebGPU keeps dense cross-batch transparency stable as the ca
   const [device] = await getTestDevices(['webgpu']);
   if (!device) {
     t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+  if (isSoftwareBackedDevice(device)) {
+    t.comment('Skipping Gaussian splat WebGPU pixel readback on a software-backed adapter');
     t.end();
     return;
   }

--- a/modules/splats/test/splat-renderer.spec.ts
+++ b/modules/splats/test/splat-renderer.spec.ts
@@ -71,8 +71,8 @@ test('SplatRenderer preserves and tone-maps Float32 Gaussian radiance on WebGPU 
   t.ok(devices.length > 0, 'at least one browser graphics backend is available');
 
   for (const device of devices) {
-    if (device.type === 'webgl' && isSoftwareBackedDevice(device)) {
-      t.comment('Skipping Gaussian splat WebGL2 rendering on a software-backed adapter');
+    if (isSoftwareBackedDevice(device)) {
+      t.comment(`Skipping Gaussian splat ${device.type} HDR readback on a software-backed adapter`);
       continue;
     }
 

--- a/modules/splats/test/splat-renderer.spec.ts
+++ b/modules/splats/test/splat-renderer.spec.ts
@@ -3,7 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
-import {Buffer, Texture} from '@luma.gl/core';
+import {Buffer, type Device, Texture} from '@luma.gl/core';
 import {makeGPUSplatData, SplatRenderer, type SplatSource} from '@luma.gl/splats';
 import {getTestDevices} from '@luma.gl/test-utils';
 
@@ -12,6 +12,11 @@ test('SplatRenderer renders Gaussian source batches on WebGPU and WebGL2', async
   t.ok(devices.length > 0, 'at least one browser graphics backend is available');
 
   for (const device of devices) {
+    if (device.type === 'webgl' && isSoftwareBackedDevice(device)) {
+      t.comment('Skipping Gaussian splat WebGL2 rendering on a software-backed adapter');
+      continue;
+    }
+
     const firstBatch = makeGPUSplatData(device, makeBrowserSplatSource(0.5, 0));
     const secondBatch = makeGPUSplatData(device, makeBrowserSplatSource(0.25, 1));
     const renderer = new SplatRenderer(device, {
@@ -66,6 +71,11 @@ test('SplatRenderer preserves and tone-maps Float32 Gaussian radiance on WebGPU 
   t.ok(devices.length > 0, 'at least one browser graphics backend is available');
 
   for (const device of devices) {
+    if (device.type === 'webgl' && isSoftwareBackedDevice(device)) {
+      t.comment('Skipping Gaussian splat WebGL2 rendering on a software-backed adapter');
+      continue;
+    }
+
     const textureSize = 16;
     const colorTexture = device.createTexture({
       width: textureSize,
@@ -289,6 +299,12 @@ test('SplatRenderer WebGPU keeps dense cross-batch transparency stable as the ca
   colorTexture.destroy();
   t.end();
 });
+
+function isSoftwareBackedDevice(device: Device): boolean {
+  return (
+    device.info.gpu === 'software' || device.info.gpuType === 'cpu' || Boolean(device.info.fallback)
+  );
+}
 
 function makeBrowserSplatSource(depth: number, rowIndex: number): SplatSource {
   return {


### PR DESCRIPTION
## Goals

- Restore the failing `Browser coverage (2/3)` workflow on `master` and unblock dependent pull requests.
- Preserve meaningful Gaussian splat coverage for WebGPU and real hardware-backed WebGL2.

## Root cause

GitHub Actions launches Chromium with ANGLE SwiftShader. Software WebGL cannot compile the Gaussian splat shaders or create the required framebuffer, and software WebGPU loses its external instance during asynchronous GPU-to-CPU pixel readback. Skipping only one readback test causes the same failure to migrate to the next one. These failures were introduced by the recently merged Gaussian splat browser suite and are reproducible on `master`; the aggregate `test` job fails only because this coverage shard fails.

## Changes

- Skip the unsupported **software-backed WebGL iteration** in the basic mixed-backend Gaussian splat test.
- Skip the HDR and dedicated WebGPU pixel-readback tests on **software-backed adapters**; continue running every test on hardware GPUs.
- Use the same software/fallback adapter detection already employed by existing core and engine browser tests.
- Keep the basic software-WebGPU rendering test, all hardware-backed WebGPU/WebGL2 pixel/transparency coverage, and the full 15-test splat Node suite.

## Verification

- Focused browser suite with GitHub Actions-equivalent `CI=1` and ANGLE SwiftShader: **4/4 passed**.
- Focused hardware WebGPU/WebGL2 browser suite without CI software-adapter flags: **4/4 passed**.
- Gaussian splat Node regression suite: **15/15 passed**.
- Focused Biome formatting/lint checks and `git diff --check`: passed.
