### PR TITLE
fix(experimental): scale GPU graph traversal beyond 1D dispatch limits

### DIFF
--- a/modules/experimental/src/gpu-primitives/gpu-graph-traversal.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-graph-traversal.ts
@@ -11,6 +11,11 @@ import {
   type GraphDataView
 } from './gpu-command-graph';
 import {
+  type GPUBoundedDispatchLayout,
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from './gpu-dispatch-utils';
+import {
   createTransientView,
   createTransientVectorView,
   getViewBinding,
@@ -58,7 +63,7 @@ type TraversalPassProps = {
   source: string;
   resources: GraphBufferUse[];
   bindings: Record<string, GraphDataView<'uint32'>>;
-  dispatchCount: number;
+  dispatchLayout: GPUBoundedDispatchLayout;
 };
 
 /**
@@ -105,7 +110,7 @@ export class GPUGraphTraversal {
     this.activeDepth = props.activeDepth;
     this.direction = props.direction ?? 'outgoing';
 
-    const namedData = this.getNamedData();
+    const namedData = getNamedTraversalData(this);
     for (const [name, data] of namedData) {
       validateTraversalData(data, `${this.id} ${name}`);
     }
@@ -155,196 +160,260 @@ export class GPUGraphTraversal {
    * edges from rediscovering a previously reached node.
    */
   addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
-    for (const [, data] of this.getNamedData()) {
-      for (const view of getTraversalChunks(data)) {
-        if (view.buffer.graph !== graph) {
-          throw new Error(`${this.id} views must belong to the target graph`);
-        }
+    addGPUGraphTraversalToGraphWithDispatchLimit(
+      this,
+      graph,
+      graph.device.limits.maxComputeWorkgroupsPerDimension
+    );
+  }
+}
+
+/** Adds traversal using an explicit per-dimension dispatch limit. @internal */
+export function addGPUGraphTraversalToGraphWithDispatchLimit<Parameters>(
+  traversal: GPUGraphTraversal,
+  graph: GPUCommandGraph<Parameters>,
+  maxComputeWorkgroupsPerDimension: number
+): void {
+  for (const [, data] of getNamedTraversalData(traversal)) {
+    for (const view of getTraversalChunks(data)) {
+      if (view.buffer.graph !== graph) {
+        throw new Error(`${traversal.id} views must belong to the target graph`);
       }
     }
-    if (this.output.length === 0) {
-      return;
-    }
-
-    if (this.output instanceof GraphVectorView) {
-      this.addPartitionedToGraph(graph);
-      return;
-    }
-    this.addPackedToGraph(graph);
+  }
+  if (traversal.output.length === 0) {
+    return;
   }
 
-  /** Adds the original one-allocation traversal path. */
-  private addPackedToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
-    const output = this.output as GraphDataView<'uint32'>;
-    const offsets = this.offsets as GraphDataView<'uint32'>;
-    const neighbors = this.neighbors as GraphDataView<'uint32'>;
-    const reverseOffsets = this.reverseOffsets as GraphDataView<'uint32'> | undefined;
-    const reverseNeighbors = this.reverseNeighbors as GraphDataView<'uint32'> | undefined;
-    let currentFrontier = createTransientView(
-      graph,
-      `${this.id}-frontier-current`,
-      'uint32',
-      output.length
-    );
-    let nextFrontier = createTransientView(
-      graph,
-      `${this.id}-frontier-next`,
-      'uint32',
-      output.length
-    );
-    addInitializationPass(graph, this.id, output, currentFrontier);
-    if (this.seeds.length > 0) {
-      for (const seedChunk of getTraversalChunkRanges(this.seeds)) {
-        if (seedChunk.view.length > 0) {
-          addSeedPass(graph, {
+  if (traversal.output instanceof GraphVectorView) {
+    addPartitionedTraversalToGraph(traversal, graph, maxComputeWorkgroupsPerDimension);
+    return;
+  }
+  addPackedTraversalToGraph(traversal, graph, maxComputeWorkgroupsPerDimension);
+}
+
+/** Adds the original one-allocation traversal path. */
+function addPackedTraversalToGraph<Parameters>(
+  traversal: GPUGraphTraversal,
+  graph: GPUCommandGraph<Parameters>,
+  maxComputeWorkgroupsPerDimension: number
+): void {
+  const output = traversal.output as GraphDataView<'uint32'>;
+  const offsets = traversal.offsets as GraphDataView<'uint32'>;
+  const neighbors = traversal.neighbors as GraphDataView<'uint32'>;
+  const reverseOffsets = traversal.reverseOffsets as GraphDataView<'uint32'> | undefined;
+  const reverseNeighbors = traversal.reverseNeighbors as GraphDataView<'uint32'> | undefined;
+  let currentFrontier = createTransientView(
+    graph,
+    `${traversal.id}-frontier-current`,
+    'uint32',
+    output.length
+  );
+  let nextFrontier = createTransientView(
+    graph,
+    `${traversal.id}-frontier-next`,
+    'uint32',
+    output.length
+  );
+  addInitializationPass(
+    graph,
+    traversal.id,
+    output,
+    currentFrontier,
+    maxComputeWorkgroupsPerDimension
+  );
+  if (traversal.seeds.length > 0) {
+    for (const seedChunk of getTraversalChunkRanges(traversal.seeds)) {
+      if (seedChunk.view.length > 0) {
+        addSeedPass(
+          graph,
+          {
             id:
-              this.seeds instanceof GraphVectorView
-                ? `${this.id}-seed-${seedChunk.index}`
-                : `${this.id}-seed`,
+              traversal.seeds instanceof GraphVectorView
+                ? `${traversal.id}-seed-${seedChunk.index}`
+                : `${traversal.id}-seed`,
             seeds: seedChunk.view,
             seedBase: seedChunk.base,
-            seedCount: this.seedCount,
+            seedCount: traversal.seedCount,
             targetBase: 0,
             frontier: currentFrontier,
             output
-          });
-        }
-      }
-    }
-
-    for (let depth = 0; depth < this.maxDepth; depth++) {
-      addClearFrontierPass(graph, `${this.id}-depth-${depth}-clear`, nextFrontier);
-      if (this.direction !== 'incoming') {
-        addExpansionPass(graph, {
-          id: `${this.id}-depth-${depth}-outgoing`,
-          offsets,
-          neighbors,
-          frontier: currentFrontier,
-          nextFrontier,
-          output,
-          targetBase: 0,
-          activeDepth: this.activeDepth,
-          depth
-        });
-      }
-      if (this.direction !== 'outgoing') {
-        addExpansionPass(graph, {
-          id: `${this.id}-depth-${depth}-incoming`,
-          offsets: reverseOffsets!,
-          neighbors: reverseNeighbors!,
-          frontier: currentFrontier,
-          nextFrontier,
-          output,
-          targetBase: 0,
-          activeDepth: this.activeDepth,
-          depth
-        });
-      }
-      [currentFrontier, nextFrontier] = [nextFrontier, currentFrontier];
-    }
-  }
-
-  /** Adds partition-preserving traversal over local CSR rows and global stable neighbor IDs. */
-  private addPartitionedToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
-    const output = this.output as GraphVectorView<'uint32'>;
-    const offsets = this.offsets as GraphVectorView<'uint32'>;
-    const neighbors = this.neighbors as GraphVectorView<'uint32'>;
-    const reverseOffsets = this.reverseOffsets as GraphVectorView<'uint32'> | undefined;
-    const reverseNeighbors = this.reverseNeighbors as GraphVectorView<'uint32'> | undefined;
-    let currentFrontier = createTransientVectorView(graph, `${this.id}-frontier-current`, output);
-    let nextFrontier = createTransientVectorView(graph, `${this.id}-frontier-next`, output);
-    const outputRanges = getTraversalChunkRanges(output);
-    const seedRanges = getTraversalChunkRanges(this.seeds);
-
-    for (const outputRange of outputRanges) {
-      if (outputRange.view.length > 0) {
-        addInitializationPass(
-          graph,
-          `${this.id}-partition-${outputRange.index}`,
-          outputRange.view,
-          currentFrontier.data[outputRange.index]
+          },
+          maxComputeWorkgroupsPerDimension
         );
       }
     }
-    for (const seedRange of seedRanges) {
-      if (seedRange.view.length === 0) {
-        continue;
-      }
-      for (const targetRange of outputRanges) {
-        if (targetRange.view.length > 0) {
-          addSeedPass(graph, {
-            id: `${this.id}-seed-${seedRange.index}-target-${targetRange.index}`,
+  }
+
+  for (let depth = 0; depth < traversal.maxDepth; depth++) {
+    addClearFrontierPass(
+      graph,
+      `${traversal.id}-depth-${depth}-clear`,
+      nextFrontier,
+      maxComputeWorkgroupsPerDimension
+    );
+    if (traversal.direction !== 'incoming') {
+      addExpansionPass(
+        graph,
+        {
+          id: `${traversal.id}-depth-${depth}-outgoing`,
+          offsets,
+          neighbors,
+          frontier: currentFrontier,
+          nextFrontier,
+          output,
+          targetBase: 0,
+          activeDepth: traversal.activeDepth,
+          depth
+        },
+        maxComputeWorkgroupsPerDimension
+      );
+    }
+    if (traversal.direction !== 'outgoing') {
+      addExpansionPass(
+        graph,
+        {
+          id: `${traversal.id}-depth-${depth}-incoming`,
+          offsets: reverseOffsets!,
+          neighbors: reverseNeighbors!,
+          frontier: currentFrontier,
+          nextFrontier,
+          output,
+          targetBase: 0,
+          activeDepth: traversal.activeDepth,
+          depth
+        },
+        maxComputeWorkgroupsPerDimension
+      );
+    }
+    [currentFrontier, nextFrontier] = [nextFrontier, currentFrontier];
+  }
+}
+
+/** Adds partition-preserving traversal over local CSR rows and global stable neighbor IDs. */
+function addPartitionedTraversalToGraph<Parameters>(
+  traversal: GPUGraphTraversal,
+  graph: GPUCommandGraph<Parameters>,
+  maxComputeWorkgroupsPerDimension: number
+): void {
+  const output = traversal.output as GraphVectorView<'uint32'>;
+  const offsets = traversal.offsets as GraphVectorView<'uint32'>;
+  const neighbors = traversal.neighbors as GraphVectorView<'uint32'>;
+  const reverseOffsets = traversal.reverseOffsets as GraphVectorView<'uint32'> | undefined;
+  const reverseNeighbors = traversal.reverseNeighbors as GraphVectorView<'uint32'> | undefined;
+  let currentFrontier = createTransientVectorView(
+    graph,
+    `${traversal.id}-frontier-current`,
+    output
+  );
+  let nextFrontier = createTransientVectorView(graph, `${traversal.id}-frontier-next`, output);
+  const outputRanges = getTraversalChunkRanges(output);
+  const seedRanges = getTraversalChunkRanges(traversal.seeds);
+
+  for (const outputRange of outputRanges) {
+    if (outputRange.view.length > 0) {
+      addInitializationPass(
+        graph,
+        `${traversal.id}-partition-${outputRange.index}`,
+        outputRange.view,
+        currentFrontier.data[outputRange.index],
+        maxComputeWorkgroupsPerDimension
+      );
+    }
+  }
+  for (const seedRange of seedRanges) {
+    if (seedRange.view.length === 0) {
+      continue;
+    }
+    for (const targetRange of outputRanges) {
+      if (targetRange.view.length > 0) {
+        addSeedPass(
+          graph,
+          {
+            id: `${traversal.id}-seed-${seedRange.index}-target-${targetRange.index}`,
             seeds: seedRange.view,
             seedBase: seedRange.base,
-            seedCount: this.seedCount,
+            seedCount: traversal.seedCount,
             targetBase: targetRange.base,
             frontier: currentFrontier.data[targetRange.index],
             output: targetRange.view
-          });
-        }
+          },
+          maxComputeWorkgroupsPerDimension
+        );
       }
     }
+  }
 
-    for (let depth = 0; depth < this.maxDepth; depth++) {
-      for (const targetRange of outputRanges) {
-        if (targetRange.view.length > 0) {
-          addClearFrontierPass(
-            graph,
-            `${this.id}-depth-${depth}-clear-${targetRange.index}`,
-            nextFrontier.data[targetRange.index]
-          );
-        }
+  for (let depth = 0; depth < traversal.maxDepth; depth++) {
+    for (const targetRange of outputRanges) {
+      if (targetRange.view.length > 0) {
+        addClearFrontierPass(
+          graph,
+          `${traversal.id}-depth-${depth}-clear-${targetRange.index}`,
+          nextFrontier.data[targetRange.index],
+          maxComputeWorkgroupsPerDimension
+        );
       }
-      if (this.direction !== 'incoming') {
-        addPartitionedExpansionPasses(graph, {
-          id: `${this.id}-depth-${depth}-outgoing`,
+    }
+    if (traversal.direction !== 'incoming') {
+      addPartitionedExpansionPasses(
+        graph,
+        {
+          id: `${traversal.id}-depth-${depth}-outgoing`,
           offsets,
           neighbors,
           currentFrontier,
           nextFrontier,
           output,
-          activeDepth: this.activeDepth,
+          activeDepth: traversal.activeDepth,
           depth
-        });
-      }
-      if (this.direction !== 'outgoing') {
-        addPartitionedExpansionPasses(graph, {
-          id: `${this.id}-depth-${depth}-incoming`,
+        },
+        maxComputeWorkgroupsPerDimension
+      );
+    }
+    if (traversal.direction !== 'outgoing') {
+      addPartitionedExpansionPasses(
+        graph,
+        {
+          id: `${traversal.id}-depth-${depth}-incoming`,
           offsets: reverseOffsets!,
           neighbors: reverseNeighbors!,
           currentFrontier,
           nextFrontier,
           output,
-          activeDepth: this.activeDepth,
+          activeDepth: traversal.activeDepth,
           depth
-        });
-      }
-      [currentFrontier, nextFrontier] = [nextFrontier, currentFrontier];
+        },
+        maxComputeWorkgroupsPerDimension
+      );
     }
+    [currentFrontier, nextFrontier] = [nextFrontier, currentFrontier];
   }
+}
 
-  /** Returns caller-owned graph views in stable validation order. */
-  private getNamedData(): Array<[string, GPUGraphTraversalData]> {
-    const data: Array<[string, GPUGraphTraversalData]> = [
-      ['offsets', this.offsets],
-      ['neighbors', this.neighbors]
-    ];
-    if (this.reverseOffsets) {
-      data.push(['reverseOffsets', this.reverseOffsets]);
-    }
-    if (this.reverseNeighbors) {
-      data.push(['reverseNeighbors', this.reverseNeighbors]);
-    }
-    data.push(['seeds', this.seeds]);
-    if (this.seedCount) {
-      data.push(['seedCount', this.seedCount]);
-    }
-    if (this.activeDepth) {
-      data.push(['activeDepth', this.activeDepth]);
-    }
-    data.push(['output', this.output]);
-    return data;
+/** Returns caller-owned graph views in stable validation order. */
+function getNamedTraversalData(
+  traversal: GPUGraphTraversal
+): Array<[string, GPUGraphTraversalData]> {
+  const data: Array<[string, GPUGraphTraversalData]> = [
+    ['offsets', traversal.offsets],
+    ['neighbors', traversal.neighbors]
+  ];
+  if (traversal.reverseOffsets) {
+    data.push(['reverseOffsets', traversal.reverseOffsets]);
   }
+  if (traversal.reverseNeighbors) {
+    data.push(['reverseNeighbors', traversal.reverseNeighbors]);
+  }
+  data.push(['seeds', traversal.seeds]);
+  if (traversal.seedCount) {
+    data.push(['seedCount', traversal.seedCount]);
+  }
+  if (traversal.activeDepth) {
+    data.push(['activeDepth', traversal.activeDepth]);
+  }
+  data.push(['output', traversal.output]);
+  return data;
 }
 
 /** Clears the previous reached mask and creates the empty first frontier. */
@@ -352,8 +421,14 @@ function addInitializationPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
   output: GraphDataView<'uint32'>,
-  frontier: GraphDataView<'uint32'>
+  frontier: GraphDataView<'uint32'>,
+  maxComputeWorkgroupsPerDimension: number
 ): void {
+  const dispatchLayout = getGPUGraphTraversalDispatchLayout(
+    output.length,
+    maxComputeWorkgroupsPerDimension
+  );
+  const invocationIndex = getGPUGraphTraversalInvocationIndexSource(dispatchLayout);
   const source = /* wgsl */ `
 const NODE_COUNT: u32 = ${output.length}u;
 const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
@@ -362,8 +437,11 @@ const FRONTIER_OFFSET: u32 = ${getViewElementOffset(frontier)}u;
 @group(0) @binding(1) var<storage, read_write> frontier: array<atomic<u32>>;
 
 @compute @workgroup_size(${GRAPH_TRAVERSAL_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let index = globalId.x;
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${invocationIndex}
   if (index < NODE_COUNT) {
     atomicStore(&reached[OUTPUT_OFFSET + index], 0u);
     atomicStore(&frontier[FRONTIER_OFFSET + index], 0u);
@@ -377,7 +455,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
       {buffer: frontier, usage: 'storage-write'}
     ],
     bindings: {reached: output, frontier},
-    dispatchCount: Math.ceil(output.length / GRAPH_TRAVERSAL_WORKGROUP_SIZE)
+    dispatchLayout
   });
 }
 
@@ -392,8 +470,14 @@ function addSeedPass<Parameters>(
     targetBase: number;
     frontier: GraphDataView<'uint32'>;
     output: GraphDataView<'uint32'>;
-  }
+  },
+  maxComputeWorkgroupsPerDimension: number
 ): void {
+  const dispatchLayout = getGPUGraphTraversalDispatchLayout(
+    props.seeds.length,
+    maxComputeWorkgroupsPerDimension
+  );
+  const invocationIndex = getGPUGraphTraversalInvocationIndexSource(dispatchLayout);
   const countDeclaration = props.seedCount
     ? `const SEED_COUNT_OFFSET: u32 = ${getViewElementOffset(props.seedCount)}u;
 @group(0) @binding(3) var<storage, read> activeSeedCount: array<u32>;`
@@ -415,8 +499,12 @@ const FRONTIER_OFFSET: u32 = ${getViewElementOffset(props.frontier)}u;
 ${countDeclaration}
 
 @compute @workgroup_size(${GRAPH_TRAVERSAL_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let seedIndex = globalId.x;
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${invocationIndex}
+  let seedIndex = index;
   if (seedIndex >= SEED_CAPACITY || SEED_BASE + seedIndex >= ${effectiveCount}) {
     return;
   }
@@ -446,7 +534,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
     source,
     resources,
     bindings,
-    dispatchCount: Math.ceil(props.seeds.length / GRAPH_TRAVERSAL_WORKGROUP_SIZE)
+    dispatchLayout
   });
 }
 
@@ -454,17 +542,27 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
 function addClearFrontierPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
   id: string,
-  frontier: GraphDataView<'uint32'>
+  frontier: GraphDataView<'uint32'>,
+  maxComputeWorkgroupsPerDimension: number
 ): void {
+  const dispatchLayout = getGPUGraphTraversalDispatchLayout(
+    frontier.length,
+    maxComputeWorkgroupsPerDimension
+  );
+  const invocationIndex = getGPUGraphTraversalInvocationIndexSource(dispatchLayout);
   const source = /* wgsl */ `
 const NODE_COUNT: u32 = ${frontier.length}u;
 const FRONTIER_OFFSET: u32 = ${getViewElementOffset(frontier)}u;
 @group(0) @binding(0) var<storage, read_write> frontier: array<atomic<u32>>;
 
 @compute @workgroup_size(${GRAPH_TRAVERSAL_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  if (globalId.x < NODE_COUNT) {
-    atomicStore(&frontier[FRONTIER_OFFSET + globalId.x], 0u);
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${invocationIndex}
+  if (index < NODE_COUNT) {
+    atomicStore(&frontier[FRONTIER_OFFSET + index], 0u);
   }
 }`;
   addTraversalPass(graph, {
@@ -472,7 +570,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
     source,
     resources: [{buffer: frontier, usage: 'storage-write'}],
     bindings: {frontier},
-    dispatchCount: Math.ceil(frontier.length / GRAPH_TRAVERSAL_WORKGROUP_SIZE)
+    dispatchLayout
   });
 }
 
@@ -489,8 +587,14 @@ function addExpansionPass<Parameters>(
     targetBase: number;
     activeDepth?: GraphDataView<'uint32'>;
     depth: number;
-  }
+  },
+  maxComputeWorkgroupsPerDimension: number
 ): void {
+  const dispatchLayout = getGPUGraphTraversalDispatchLayout(
+    props.frontier.length,
+    maxComputeWorkgroupsPerDimension
+  );
+  const invocationIndex = getGPUGraphTraversalInvocationIndexSource(dispatchLayout);
   const activeDepthDeclaration = props.activeDepth
     ? `const ACTIVE_DEPTH_OFFSET: u32 = ${getViewElementOffset(props.activeDepth)}u;
 @group(0) @binding(5) var<storage, read> activeDepth: array<u32>;`
@@ -518,8 +622,12 @@ const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;
 ${activeDepthDeclaration}
 
 @compute @workgroup_size(${GRAPH_TRAVERSAL_WORKGROUP_SIZE})
-fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
-  let nodeIndex = globalId.x;
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${invocationIndex}
+  let nodeIndex = index;
   if (nodeIndex >= SOURCE_COUNT || frontier[FRONTIER_OFFSET + nodeIndex] == 0u) {
     return;
   }
@@ -559,7 +667,7 @@ fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
     source,
     resources,
     bindings,
-    dispatchCount: Math.ceil(props.frontier.length / GRAPH_TRAVERSAL_WORKGROUP_SIZE)
+    dispatchLayout
   });
 }
 
@@ -575,7 +683,8 @@ function addPartitionedExpansionPasses<Parameters>(
     output: GraphVectorView<'uint32'>;
     activeDepth?: GraphDataView<'uint32'>;
     depth: number;
-  }
+  },
+  maxComputeWorkgroupsPerDimension: number
 ): void {
   const sourceRanges = getTraversalChunkRanges(props.output);
   for (const sourceRange of sourceRanges) {
@@ -586,17 +695,21 @@ function addPartitionedExpansionPasses<Parameters>(
       if (targetRange.view.length === 0) {
         continue;
       }
-      addExpansionPass(graph, {
-        id: `${props.id}-source-${sourceRange.index}-target-${targetRange.index}`,
-        offsets: props.offsets.data[sourceRange.index],
-        neighbors: props.neighbors.data[sourceRange.index],
-        frontier: props.currentFrontier.data[sourceRange.index],
-        nextFrontier: props.nextFrontier.data[targetRange.index],
-        output: targetRange.view,
-        targetBase: targetRange.base,
-        activeDepth: props.activeDepth,
-        depth: props.depth
-      });
+      addExpansionPass(
+        graph,
+        {
+          id: `${props.id}-source-${sourceRange.index}-target-${targetRange.index}`,
+          offsets: props.offsets.data[sourceRange.index],
+          neighbors: props.neighbors.data[sourceRange.index],
+          frontier: props.currentFrontier.data[sourceRange.index],
+          nextFrontier: props.nextFrontier.data[targetRange.index],
+          output: targetRange.view,
+          targetBase: targetRange.base,
+          activeDepth: props.activeDepth,
+          depth: props.depth
+        },
+        maxComputeWorkgroupsPerDimension
+      );
     }
   }
 }
@@ -668,6 +781,26 @@ function validateTraversalData(data: GPUGraphTraversalData, name: string): void 
   }
 }
 
+/** Plans a bounded three-dimensional dispatch for one graph-traversal pass. @internal */
+export function getGPUGraphTraversalDispatchLayout(
+  elementCount: number,
+  maxComputeWorkgroupsPerDimension: number
+): GPUBoundedDispatchLayout {
+  return getBoundedDispatchLayout(
+    'GPUGraphTraversal',
+    elementCount,
+    GRAPH_TRAVERSAL_WORKGROUP_SIZE,
+    maxComputeWorkgroupsPerDimension
+  );
+}
+
+/** Returns WGSL mapping a bounded 3D graph-traversal dispatch to one row index. @internal */
+export function getGPUGraphTraversalInvocationIndexSource(
+  layout: GPUBoundedDispatchLayout
+): string {
+  return getBoundedInvocationIndexSource(layout, GRAPH_TRAVERSAL_WORKGROUP_SIZE);
+}
+
 /** Wraps generated WGSL in one graph-owned, lazily bound computation. */
 function addTraversalPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
@@ -696,7 +829,12 @@ function addTraversalPass<Parameters>(
             resolvedBindings[name] = getViewBinding(view, getBuffer);
           }
           computation.setBindings(resolvedBindings);
-          computation.dispatch(computePass, props.dispatchCount);
+          computation.dispatch(
+            computePass,
+            props.dispatchLayout.x,
+            props.dispatchLayout.y,
+            props.dispatchLayout.z
+          );
         },
         destroy: () => computation.destroy()
       };

--- a/modules/experimental/test/gpu-primitives/gpu-graph-traversal.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-graph-traversal.node.spec.ts
@@ -1,0 +1,70 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  getGPUGraphTraversalDispatchLayout,
+  getGPUGraphTraversalInvocationIndexSource
+} from '../../src/gpu-primitives/gpu-graph-traversal';
+
+test('GPUGraphTraversal plans bounded multidimensional dispatches', testCase => {
+  const maximumWorkgroupsPerDimension = 65_535;
+  const maximumOneDimensionalRowCount = maximumWorkgroupsPerDimension * 256;
+
+  testCase.deepEqual(getGPUGraphTraversalDispatchLayout(0, maximumWorkgroupsPerDimension), {
+    x: 1,
+    y: 1,
+    z: 1
+  });
+  testCase.deepEqual(
+    getGPUGraphTraversalDispatchLayout(
+      maximumOneDimensionalRowCount,
+      maximumWorkgroupsPerDimension
+    ),
+    {x: maximumWorkgroupsPerDimension, y: 1, z: 1},
+    'the largest single-dimensional dispatch exactly reaches its final row'
+  );
+  testCase.deepEqual(
+    getGPUGraphTraversalDispatchLayout(
+      maximumOneDimensionalRowCount + 1,
+      maximumWorkgroupsPerDimension
+    ),
+    {x: maximumWorkgroupsPerDimension, y: 2, z: 1},
+    'one additional row expands into the second dispatch dimension'
+  );
+  testCase.deepEqual(
+    getGPUGraphTraversalDispatchLayout(4 * 256 + 1, 2),
+    {x: 2, y: 2, z: 2},
+    'a synthetic device limit exercises the third dispatch dimension'
+  );
+  testCase.throws(
+    () => getGPUGraphTraversalDispatchLayout(8 * 256 + 1, 2),
+    /exceeding the 3D dispatch limit/,
+    'dispatches exceeding every available dimension fail explicitly'
+  );
+  testCase.throws(
+    () => getGPUGraphTraversalDispatchLayout(0x1_0000_0000, maximumWorkgroupsPerDimension),
+    /non-negative uint32/,
+    'row identifiers remain bounded unsigned 32-bit values'
+  );
+  testCase.end();
+});
+
+test('GPUGraphTraversal flattens workgroups before bounded invocation indexing', testCase => {
+  const source = getGPUGraphTraversalInvocationIndexSource({x: 3, y: 2, z: 2});
+
+  testCase.match(source, /workgroupId\.z \* 2u \+ workgroupId\.y/);
+  testCase.match(source, /\* 3u \+ workgroupId\.x/);
+  testCase.match(
+    source,
+    /workgroupIndex >= 16777216u/,
+    'padded workgroups cannot wrap their uint32 invocation index'
+  );
+  testCase.ok(
+    source.indexOf('workgroupIndex >= 16777216u') <
+      source.indexOf('workgroupIndex * 256u + localInvocationIndex'),
+    'the overflow guard executes before multiplication'
+  );
+  testCase.end();
+});

--- a/modules/experimental/test/gpu-primitives/gpu-trace-manipulation.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-trace-manipulation.spec.ts
@@ -4,6 +4,7 @@
 
 import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
 import {
   GPUAncestorProjection,
   GPUCommandGraph,
@@ -15,6 +16,8 @@ import {
 } from '@luma.gl/experimental';
 import {GPUData, GPUVector} from '@luma.gl/tables';
 import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {vi} from 'vitest';
+import {addGPUGraphTraversalToGraphWithDispatchLimit} from '../../src/gpu-primitives/gpu-graph-traversal';
 
 test('GPUMask composes canonical GPU selection masks', async t => {
   const device = await getWebGPUTestDevice();
@@ -193,6 +196,75 @@ test('GPUGraphTraversal expands outgoing, incoming, and bidirectional frontiers'
   t.end();
 });
 
+test('GPUGraphTraversal executes packed initialization, seeds, and expansion in three dimensions', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const seedCount = 4 * 256 + 1;
+  const nodeCount = seedCount + 1;
+  const sourceNodes = [0, 256, 512, 768, 1024];
+  const seeds = new Uint32Array(seedCount).fill(0xffffffff);
+  for (const sourceNode of sourceNodes) {
+    seeds[sourceNode] = sourceNode;
+  }
+  const offsets = createTraversalOffsets(nodeCount, sourceNodes);
+  const neighbors = Uint32Array.from(sourceNodes, sourceNode => sourceNode + 1);
+  const graph = new GPUCommandGraph(device, {id: 'packed-bounded-traversal-test'});
+  const buffers = {
+    offsets: createUint32Buffer(device, offsets, false),
+    neighbors: createUint32Buffer(device, neighbors, false),
+    seeds: createUint32Buffer(device, seeds, false),
+    output: createUint32Buffer(device, new Uint32Array(nodeCount).fill(7), true)
+  };
+  const traversal = new GPUGraphTraversal({
+    id: 'packed-bounded-traversal',
+    offsets: importUint32View(graph, 'offsets', buffers.offsets, offsets.length),
+    neighbors: importUint32View(graph, 'neighbors', buffers.neighbors, neighbors.length),
+    seeds: importUint32View(graph, 'seeds', buffers.seeds, seeds.length),
+    output: importUint32View(graph, 'output', buffers.output, nodeCount),
+    maxDepth: 1
+  });
+  addGPUGraphTraversalToGraphWithDispatchLimit(traversal, graph, 2);
+  const compiled = graph.compile();
+  const dispatchSpy = vi.spyOn(Computation.prototype, 'dispatch');
+
+  try {
+    submitGraph(device, compiled, 'packed-bounded-traversal-test');
+    const expectedOutput = new Uint32Array(nodeCount);
+    for (const sourceNode of sourceNodes) {
+      expectedOutput[sourceNode] = 1;
+      expectedOutput[sourceNode + 1] = 1;
+    }
+    t.deepEqual(
+      await readUint32(buffers.output, nodeCount),
+      Array.from(expectedOutput),
+      'initialization, seed publication, and outgoing expansion cover x, y, and z workgroups'
+    );
+
+    for (const passName of ['initialize', 'seed', 'depth-0-clear', 'depth-0-outgoing']) {
+      const dispatchIndex = dispatchSpy.mock.instances.findIndex(
+        computation => (computation as Computation).id === `packed-bounded-traversal-${passName}`
+      );
+      t.deepEqual(
+        dispatchSpy.mock.calls[dispatchIndex]?.slice(1),
+        [2, 2, 2],
+        `${passName} respects the synthetic two-workgroup limit in every dimension`
+      );
+    }
+  } finally {
+    dispatchSpy.mockRestore();
+    compiled.destroy();
+    for (const buffer of Object.values(buffers)) {
+      buffer.destroy();
+    }
+  }
+  t.end();
+});
+
 test('GPUGraphTraversal reads dynamic seed counts and traversal depth', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -243,6 +315,107 @@ test('GPUGraphTraversal follows global IDs across local CSR partitions', async t
       result.nodeOrder.includes('partitioned-traversal-depth-1-outgoing-source-2-target-3'),
     'source-to-target partition pairs make cross-partition routing explicit'
   );
+  t.end();
+});
+
+test('GPUGraphTraversal routes large seed and output partitions through three-dimensional dispatches', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const partitionLength = 4 * 256 + 1;
+  const sourceNodes = [0, 256, 512, 768, 1024];
+  const seedChunk = new Uint32Array(partitionLength).fill(0xffffffff);
+  for (const sourceNode of sourceNodes) {
+    seedChunk[sourceNode] = sourceNode;
+  }
+  const outputChunks = [
+    new Uint32Array(partitionLength),
+    new Uint32Array(0),
+    new Uint32Array(partitionLength)
+  ];
+  const offsetChunks = [
+    createTraversalOffsets(partitionLength, sourceNodes),
+    Uint32Array.from([0]),
+    createTraversalOffsets(partitionLength, sourceNodes)
+  ];
+  const neighborChunks = [
+    Uint32Array.from(sourceNodes, sourceNode => partitionLength + sourceNode),
+    new Uint32Array(0),
+    Uint32Array.from(sourceNodes, sourceNode =>
+      sourceNode === partitionLength - 1 ? sourceNode - 1 : sourceNode + 1
+    )
+  ];
+  const offsets = createVectorFixture(device, 'bounded-offsets', offsetChunks, false);
+  const neighbors = createVectorFixture(device, 'bounded-neighbors', neighborChunks, false);
+  const seeds = createVectorFixture(
+    device,
+    'bounded-seeds',
+    [seedChunk, new Uint32Array(0)],
+    false
+  );
+  const output = createVectorFixture(device, 'bounded-output', outputChunks, true);
+  output.buffers[0].write(new Uint32Array(partitionLength).fill(7));
+  output.buffers[2].write(new Uint32Array(partitionLength).fill(7));
+  const graph = new GPUCommandGraph(device, {id: 'partitioned-bounded-traversal-test'});
+  const traversal = new GPUGraphTraversal({
+    id: 'partitioned-bounded-traversal',
+    offsets: graph.importGPUVector('offsets', offsets.vector),
+    neighbors: graph.importGPUVector('neighbors', neighbors.vector),
+    seeds: graph.importGPUVector('seeds', seeds.vector),
+    output: graph.importGPUVector('output', output.vector),
+    maxDepth: 2
+  });
+  addGPUGraphTraversalToGraphWithDispatchLimit(traversal, graph, 2);
+  const compiled = graph.compile();
+  const dispatchSpy = vi.spyOn(Computation.prototype, 'dispatch');
+
+  try {
+    submitGraph(device, compiled, 'partitioned-bounded-traversal-test');
+    const expectedFirstPartition = new Uint32Array(partitionLength);
+    const expectedLastPartition = new Uint32Array(partitionLength);
+    for (const sourceNode of sourceNodes) {
+      expectedFirstPartition[sourceNode] = 1;
+      expectedFirstPartition[sourceNode === partitionLength - 1 ? sourceNode - 1 : sourceNode + 1] =
+        1;
+      expectedLastPartition[sourceNode] = 1;
+    }
+    t.deepEqual(
+      await readVectorFixture(output),
+      [Array.from(expectedFirstPartition), [], Array.from(expectedLastPartition)],
+      'large chunks preserve their empty partition while following global IDs in both directions'
+    );
+
+    for (const passName of [
+      'partition-0-initialize',
+      'partition-2-initialize',
+      'seed-0-target-0',
+      'seed-0-target-2',
+      'depth-0-clear-0',
+      'depth-0-clear-2',
+      'depth-0-outgoing-source-0-target-2',
+      'depth-1-outgoing-source-2-target-0'
+    ]) {
+      const dispatchIndex = dispatchSpy.mock.instances.findIndex(
+        computation =>
+          (computation as Computation).id === `partitioned-bounded-traversal-${passName}`
+      );
+      t.deepEqual(
+        dispatchSpy.mock.calls[dispatchIndex]?.slice(1),
+        [2, 2, 2],
+        `${passName} preserves the bounded three-dimensional dispatch`
+      );
+    }
+  } finally {
+    dispatchSpy.mockRestore();
+    compiled.destroy();
+    for (const fixture of [offsets, neighbors, seeds, output]) {
+      destroyVectorFixture(fixture);
+    }
+  }
   t.end();
 });
 
@@ -638,6 +811,17 @@ async function runTraversal(
     buffer.destroy();
   }
   return result;
+}
+
+function createTraversalOffsets(nodeCount: number, sourceNodes: readonly number[]): Uint32Array {
+  const offsets = new Uint32Array(nodeCount + 1);
+  for (const sourceNode of sourceNodes) {
+    offsets[sourceNode + 1]++;
+  }
+  for (let nodeIndex = 1; nodeIndex < offsets.length; nodeIndex++) {
+    offsets[nodeIndex] += offsets[nodeIndex - 1];
+  }
+  return offsets;
 }
 
 async function runPartitionedTraversal(device: Device): Promise<{


### PR DESCRIPTION
## Goals

- Remove the one-dimensional WebGPU dispatch ceiling from `GPUGraphTraversal` without changing its public API, reachability semantics, or source partition ownership.
- Provide an independently mergeable prerequisite for GPU-resident graph analytics.

## Changes

- Reuse bounded multidimensional dispatch helpers for traversal initialization, seed publication, frontier clearing, and CSR expansion.
- Flatten x/y/z workgroups into guarded uint32 invocation indices while preserving packed and partitioned traversal, dynamic seed/depth controls, directions, and cross-partition stable vertex IDs.
- Add focused Node coverage for the baseline one-dimensional limit, synthetic two-workgroup limits, three-dimensional overflow, and uint32-safe WGSL indexing.
- Add real-WebGPU packed and partitioned regressions with 1,025+ rows/seeds and verified `[2, 2, 2]` dispatches.

## Verification

- `nvm use`: passed; Node `v22.22.1`.
- `yarn install`: attempted normally and with escalation; blocked by HTTP 403 from the configured internal registry for uncached dependencies. Verification used an isolated APFS copy-on-write clone of an existing compatible local dependency installation and repaired workspace symlinks.
- `yarn lint fix`: passed; 1,525 files checked.
- `yarn build`: passed across every module.
- Focused Node traversal tests: 2 passed.
- Focused real Chromium/WebGPU traversal tests: 5 passed.
- `yarn test` with the repository's `CI=1` serial software-WebGPU configuration: **545 Node tests and 1,555 Chromium/WebGPU tests passed**; existing skips only.
- `yarn website:build`: passed.
- `(cd website && yarn build)`: passed.
- `yarn examples:typecheck`: passed for all 46 example workspaces.
- `yarn bundle-size`: all seven bundle budgets passed.
- Normal pre-commit hooks: lint and the complete Node suite passed.

## Risks / follow-up

- Existing 1,024-hop maximum and partition-pair scheduling characteristics remain unchanged.
- Physical-buffer aliasing across distinct imported graph handles or encoding overrides is intentionally deferred to a separate compatibility-focused change; this PR does not introduce sorting or rely on aliased outputs.