### PR TITLE
feat(experimental): add optional GPU graph foundation

### DIFF
--- a/modules/experimental/package.json
+++ b/modules/experimental/package.json
@@ -32,6 +32,11 @@
       "require": "./dist/geospatial/index.cjs",
       "types": "./dist/geospatial/index.d.ts"
     },
+    "./lugraph": {
+      "import": "./dist/lugraph/index.js",
+      "require": "./dist/lugraph/index.cjs",
+      "types": "./dist/lugraph/index.d.ts"
+    },
     "./luxfilter": {
       "import": "./dist/luxfilter/index.js",
       "require": "./dist/luxfilter/index.cjs",

--- a/modules/experimental/src/lugraph/index.ts
+++ b/modules/experimental/src/lugraph/index.ts
@@ -1,0 +1,6 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+export {LuGraph} from './lu-graph';
+export type {LuGraphProps} from './lu-graph';

--- a/modules/experimental/src/lugraph/lu-graph.ts
+++ b/modules/experimental/src/lugraph/lu-graph.ts
@@ -1,0 +1,199 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {GPURecordBatch, GPUTable, GPUVector} from '@luma.gl/tables';
+
+const MAXIMUM_VERTEX_COUNT = 0xfffffffe;
+const MAXIMUM_EDGE_COUNT = 0xffffffff;
+const SCALAR_BYTE_LENGTH = 4;
+const EMPTY_EDGE_BATCHES: readonly GPURecordBatch[] = Object.freeze([]);
+
+/** Existing, caller-owned GPU columns and optional graph property tables. */
+export type LuGraphProps = {
+  /** Explicit vertex count, including vertices absent from every edge. */
+  vertexCount: number;
+  /** Stable source vertex identifiers, preserved in their existing chunks. */
+  sourceVertices: GPUVector<'uint32'>;
+  /** Stable target vertex identifiers with the same source-batch topology. */
+  targetVertices: GPUVector<'uint32'>;
+  /** Optional source-aligned, single-precision edge weights. */
+  edgeWeights?: GPUVector<'float32'>;
+  /** Optional source-aligned stable edge identifiers. */
+  edgeIds?: GPUVector<'uint32'>;
+  /** Optional caller-owned vertex properties with one row per vertex. */
+  nodeAttributes?: GPUTable;
+  /** Optional caller-owned edge properties preserving original record batches. */
+  edgeAttributes?: GPUTable;
+  /** Whether source-to-target edges are directed. Defaults to true. */
+  directed?: boolean;
+};
+
+/**
+ * Lightweight graph metadata over existing GPU-resident columns.
+ *
+ * Construction preserves vector, chunk, record-batch, and source-identity references. It never
+ * allocates or destroys buffers, repacks source data, submits commands, or reads GPU memory.
+ */
+export class LuGraph {
+  /** Explicit vertex count, including isolated vertices. */
+  readonly vertexCount: number;
+  /** Existing source vertex identifiers in source-batch order. */
+  readonly sourceVertices: GPUVector<'uint32'>;
+  /** Existing target vertex identifiers in source-batch order. */
+  readonly targetVertices: GPUVector<'uint32'>;
+  /** Optional existing single-precision edge weights. */
+  readonly edgeWeights?: GPUVector<'float32'>;
+  /** Optional existing stable edge identifiers. */
+  readonly edgeIds?: GPUVector<'uint32'>;
+  /** Optional existing vertex property table. */
+  readonly nodeAttributes?: GPUTable;
+  /** Optional existing edge property table. */
+  readonly edgeAttributes?: GPUTable;
+  /** Whether source-to-target edges are directed. */
+  readonly directed: boolean;
+
+  /** Describes caller-owned graph sources without allocating or submitting GPU work. */
+  constructor({
+    vertexCount,
+    sourceVertices,
+    targetVertices,
+    edgeWeights,
+    edgeIds,
+    nodeAttributes,
+    edgeAttributes,
+    directed = true
+  }: LuGraphProps) {
+    if (
+      !Number.isSafeInteger(vertexCount) ||
+      vertexCount < 0 ||
+      vertexCount > MAXIMUM_VERTEX_COUNT
+    ) {
+      throw new Error('LuGraph vertexCount must leave room for uint32 adjacency offsets');
+    }
+
+    validateGraphVector(sourceVertices, 'uint32', 'sourceVertices');
+    validateGraphVector(targetVertices, 'uint32', 'targetVertices');
+    validateMatchingGraphVector(sourceVertices, targetVertices, 'targetVertices');
+
+    if (sourceVertices.length > MAXIMUM_EDGE_COUNT) {
+      throw new Error('LuGraph edgeCount must fit in uint32');
+    }
+    if (edgeWeights) {
+      validateGraphVector(edgeWeights, 'float32', 'edgeWeights');
+      validateMatchingGraphVector(sourceVertices, edgeWeights, 'edgeWeights');
+    }
+    if (edgeIds) {
+      validateGraphVector(edgeIds, 'uint32', 'edgeIds');
+      validateMatchingGraphVector(sourceVertices, edgeIds, 'edgeIds');
+    }
+    if (nodeAttributes && nodeAttributes.numRows !== vertexCount) {
+      throw new Error('LuGraph nodeAttributes must contain one row per vertex');
+    }
+    if (edgeAttributes) {
+      validateEdgeAttributes(edgeAttributes, sourceVertices, targetVertices, edgeWeights, edgeIds);
+    }
+
+    this.vertexCount = vertexCount;
+    this.sourceVertices = sourceVertices;
+    this.targetVertices = targetVertices;
+    this.edgeWeights = edgeWeights;
+    this.edgeIds = edgeIds;
+    this.nodeAttributes = nodeAttributes;
+    this.edgeAttributes = edgeAttributes;
+    this.directed = directed;
+  }
+
+  /** Number of original, unsymmetrized source edges. */
+  get edgeCount(): number {
+    return this.sourceVertices.length;
+  }
+
+  /** Original edge record batches, including empty batches and source-identity metadata. */
+  get sourceEdgeBatches(): readonly GPURecordBatch[] {
+    return this.edgeAttributes?.batches ?? EMPTY_EDGE_BATCHES;
+  }
+}
+
+/** Requires one fixed-width scalar vector and preserves its existing packed data chunks. */
+function validateGraphVector<Format extends 'uint32' | 'float32'>(
+  vector: GPUVector<Format>,
+  format: Format,
+  name: string
+): void {
+  if (
+    vector.format !== format ||
+    vector.stride !== 1 ||
+    vector.byteStride !== SCALAR_BYTE_LENGTH ||
+    vector.rowByteLength !== SCALAR_BYTE_LENGTH ||
+    vector.valueLength !== vector.length ||
+    vector.bufferLayout
+  ) {
+    throw new Error(`LuGraph ${name} must contain packed ${format} rows`);
+  }
+  for (const chunk of vector.data) {
+    if (
+      chunk.format !== format ||
+      chunk.stride !== 1 ||
+      chunk.byteStride !== SCALAR_BYTE_LENGTH ||
+      chunk.rowByteLength !== SCALAR_BYTE_LENGTH ||
+      chunk.byteOffset % SCALAR_BYTE_LENGTH !== 0 ||
+      chunk.valueLength !== chunk.length
+    ) {
+      throw new Error(`LuGraph ${name} must contain packed ${format} chunks`);
+    }
+  }
+}
+
+/** Preserves ordered source batch boundaries, including intentionally empty chunks. */
+function validateMatchingGraphVector(
+  source: GPUVector<'uint32'>,
+  vector: GPUVector<'uint32'> | GPUVector<'float32'>,
+  name: string
+): void {
+  if (
+    vector.length !== source.length ||
+    vector.data.length !== source.data.length ||
+    vector.data.some((chunk, chunkIndex) => chunk.length !== source.data[chunkIndex].length)
+  ) {
+    throw new Error(`LuGraph ${name} must preserve source edge chunk topology`);
+  }
+}
+
+/** Validates optional source-edge properties without requiring a particular property schema. */
+function validateEdgeAttributes(
+  edgeAttributes: GPUTable,
+  sourceVertices: GPUVector<'uint32'>,
+  targetVertices: GPUVector<'uint32'>,
+  edgeWeights?: GPUVector<'float32'>,
+  edgeIds?: GPUVector<'uint32'>
+): void {
+  if (edgeAttributes.numRows !== sourceVertices.length) {
+    throw new Error('LuGraph edgeAttributes must contain one row per edge');
+  }
+  if (
+    edgeAttributes.batches.length !== sourceVertices.data.length ||
+    edgeAttributes.batches.some(
+      (batch, batchIndex) => batch.numRows !== sourceVertices.data[batchIndex].length
+    )
+  ) {
+    throw new Error('LuGraph edgeAttributes must preserve source edge batch topology');
+  }
+
+  const graphColumns = {
+    sourceVertices,
+    targetVertices,
+    ...(edgeWeights ? {edgeWeights} : {}),
+    ...(edgeIds ? {edgeIds} : {})
+  };
+  for (const [name, vector] of Object.entries(graphColumns)) {
+    const attributeVector = edgeAttributes.gpuVectors[name];
+    if (
+      attributeVector &&
+      (attributeVector.data.length !== vector.data.length ||
+        attributeVector.data.some((chunk, chunkIndex) => chunk !== vector.data[chunkIndex]))
+    ) {
+      throw new Error(`LuGraph edgeAttributes ${name} must preserve source edge data`);
+    }
+  }
+}

--- a/modules/experimental/src/lugraph/lu-graph.ts
+++ b/modules/experimental/src/lugraph/lu-graph.ts
@@ -187,13 +187,15 @@ function validateEdgeAttributes(
     ...(edgeIds ? {edgeIds} : {})
   };
   for (const [name, vector] of Object.entries(graphColumns)) {
-    const attributeVector = edgeAttributes.gpuVectors[name];
-    if (
-      attributeVector &&
-      (attributeVector.data.length !== vector.data.length ||
-        attributeVector.data.some((chunk, chunkIndex) => chunk !== vector.data[chunkIndex]))
-    ) {
-      throw new Error(`LuGraph edgeAttributes ${name} must preserve source edge data`);
+    for (const columnName of new Set([name, vector.name])) {
+      const attributeVector = edgeAttributes.gpuVectors[columnName];
+      if (
+        attributeVector &&
+        (attributeVector.data.length !== vector.data.length ||
+          attributeVector.data.some((chunk, chunkIndex) => chunk !== vector.data[chunkIndex]))
+      ) {
+        throw new Error(`LuGraph edgeAttributes ${columnName} must preserve source edge data`);
+      }
     }
   }
 }

--- a/modules/experimental/test/lugraph/lu-graph.node.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph.node.spec.ts
@@ -1,0 +1,610 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+
+import {Buffer} from '@luma.gl/core';
+import * as experimentalModule from '@luma.gl/experimental';
+import * as luGraphModule from '@luma.gl/experimental/lugraph';
+import {LuGraph} from '@luma.gl/experimental/lugraph';
+import {GPUData, GPURecordBatch, GPUTable, GPUVector} from '@luma.gl/tables';
+import {NullDevice} from '@luma.gl/test-utils';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+
+type GraphScalarFormat = 'uint32' | 'float32' | 'sint32';
+type GraphScalarArray = Uint32Array | Float32Array | Int32Array;
+
+type GraphFixture = {
+  device: NullDevice;
+  buffers: Buffer[];
+  vectors: GPUVector[];
+  tables: GPUTable[];
+};
+
+type GraphVectorOptions = {
+  byteOffset?: number;
+  byteStride?: number;
+  rowByteLength?: number;
+  stride?: number;
+  vectorByteStride?: number;
+  vectorRowByteLength?: number;
+  vectorStride?: number;
+  ownsBuffer?: boolean;
+  ownsData?: boolean;
+};
+
+type GraphColumns = {
+  sourceVertices: GPUVector<'uint32'>;
+  targetVertices: GPUVector<'uint32'>;
+  edgeWeights: GPUVector<'float32'>;
+  edgeIds: GPUVector<'uint32'>;
+};
+
+const graphFixtures: GraphFixture[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const fixture of graphFixtures.splice(0)) {
+    for (const table of fixture.tables) table.destroy();
+    for (const vector of fixture.vectors) vector.destroy();
+    for (const buffer of fixture.buffers) buffer.destroy();
+    fixture.device.destroy();
+  }
+});
+
+describe('@luma.gl/experimental/lugraph package boundary', () => {
+  test('publishes an optional, side-effect-free conditional export without Apache Arrow', () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
+    ) as {
+      name?: string;
+      sideEffects?: boolean;
+      exports?: Record<string, Record<string, string>>;
+      dependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+      optionalDependencies?: Record<string, string>;
+    };
+
+    expect(packageJson.name).toBe('@luma.gl/experimental');
+    expect(packageJson.sideEffects).toBe(false);
+    expect(packageJson.exports?.['./lugraph']).toEqual({
+      import: './dist/lugraph/index.js',
+      require: './dist/lugraph/index.cjs',
+      types: './dist/lugraph/index.d.ts'
+    });
+    for (const dependencies of [
+      packageJson.dependencies,
+      packageJson.peerDependencies,
+      packageJson.optionalDependencies
+    ]) {
+      expect(dependencies?.['apache-arrow']).toBeUndefined();
+    }
+    for (const sourceFile of ['index.ts', 'lu-graph.ts']) {
+      const source = readFileSync(
+        new URL(`../../src/lugraph/${sourceFile}`, import.meta.url),
+        'utf8'
+      );
+      expect(source).not.toMatch(/['"]apache-arrow['"]/);
+    }
+  });
+
+  test('keeps graph runtime exports isolated from the root experimental entry point', () => {
+    expect(luGraphModule.LuGraph).toBe(LuGraph);
+    expect('LuGraph' in experimentalModule).toBe(false);
+  });
+});
+
+describe('LuGraph caller-owned graph representation', () => {
+  test('retains exact edge chunks, buffers, stable identities, record batches, and source metadata', () => {
+    const fixture = createGraphFixture();
+    const columns = createGraphColumns(fixture);
+    const edgeAttributes = createEdgeAttributeTable(fixture, columns);
+    const nodeAttributes = createPropertyTable(fixture, 'nodeScore', 'float32', [
+      new Float32Array(8)
+    ]);
+    const graph = new LuGraph({
+      vertexCount: 8,
+      ...columns,
+      nodeAttributes,
+      edgeAttributes
+    });
+
+    expect(graph.vertexCount).toBe(8);
+    expect(graph.edgeCount).toBe(5);
+    expect(graph.directed).toBe(true);
+    expect(graph.sourceVertices).toBe(columns.sourceVertices);
+    expect(graph.targetVertices).toBe(columns.targetVertices);
+    expect(graph.edgeWeights).toBe(columns.edgeWeights);
+    expect(graph.edgeIds).toBe(columns.edgeIds);
+    expect(graph.nodeAttributes).toBe(nodeAttributes);
+    expect(graph.edgeAttributes).toBe(edgeAttributes);
+    expect(graph.sourceEdgeBatches).toBe(edgeAttributes.batches);
+    expect(graph.sourceEdgeBatches.map(batch => batch.numRows)).toEqual([2, 0, 3]);
+    expect(graph.sourceVertices.data.map(chunk => chunk.length)).toEqual([2, 0, 3]);
+    expect(graph.targetVertices.data.map(chunk => chunk.length)).toEqual([2, 0, 3]);
+    expect(graph.edgeIds?.data.map(chunk => chunk.length)).toEqual([2, 0, 3]);
+    expect(graph.edgeWeights?.data.map(chunk => chunk.length)).toEqual([2, 0, 3]);
+
+    for (const [chunkIndex, sourceChunk] of columns.sourceVertices.data.entries()) {
+      const sourceBatch = edgeAttributes.batches[chunkIndex];
+      expect(graph.sourceVertices.data[chunkIndex]).toBe(sourceChunk);
+      expect(graph.sourceVertices.data[chunkIndex].buffer).toBe(sourceChunk.buffer);
+      expect(graph.sourceVertices.data[chunkIndex].readbackMetadata).toBe(
+        sourceChunk.readbackMetadata
+      );
+      expect(graph.sourceEdgeBatches[chunkIndex]).toBe(sourceBatch);
+      expect(graph.sourceEdgeBatches[chunkIndex].sourceInfo).toBe(sourceBatch.sourceInfo);
+      expect(sourceBatch.gpuData.sourceVertices).toBe(sourceChunk);
+      expect(sourceBatch.gpuData.targetVertices).toBe(columns.targetVertices.data[chunkIndex]);
+      expect(sourceBatch.gpuData.edgeIds).toBe(columns.edgeIds.data[chunkIndex]);
+    }
+
+    expect(graph.sourceEdgeBatches.map(batch => batch.sourceInfo)).toEqual([
+      {sourceBatchIndex: 0, sourceRowIndexOffset: 19, sourceRowCount: 2},
+      {sourceBatchIndex: 1, sourceRowIndexOffset: 21, sourceRowCount: 0},
+      {sourceBatchIndex: 2, sourceRowIndexOffset: 21, sourceRowCount: 3}
+    ]);
+  });
+
+  test('retains explicit directedness without symmetrizing or changing edge identities', () => {
+    const fixture = createGraphFixture();
+    const {sourceVertices, targetVertices, edgeIds} = createGraphColumns(fixture);
+    const graph = new LuGraph({
+      vertexCount: 8,
+      sourceVertices,
+      targetVertices,
+      edgeIds,
+      directed: false
+    });
+
+    expect(graph.directed).toBe(false);
+    expect(graph.edgeCount).toBe(5);
+    expect(graph.edgeIds).toBe(edgeIds);
+    expect(graph.sourceVertices.data).toBe(sourceVertices.data);
+    expect(graph.targetVertices.data).toBe(targetVertices.data);
+  });
+
+  test('preserves empty graphs, isolated vertices, and the maximum bounded vertex count', () => {
+    const fixture = createGraphFixture();
+    const sourceVertices = createGraphVector(fixture, 'emptySources', 'uint32', []);
+    const targetVertices = createGraphVector(fixture, 'emptyTargets', 'uint32', []);
+    const empty = new LuGraph({vertexCount: 0, sourceVertices, targetVertices});
+    const isolated = new LuGraph({vertexCount: 9, sourceVertices, targetVertices});
+    const maximum = new LuGraph({vertexCount: 0xfffffffe, sourceVertices, targetVertices});
+
+    expect(empty.vertexCount).toBe(0);
+    expect(empty.edgeCount).toBe(0);
+    expect(empty.sourceEdgeBatches).toEqual([]);
+    expect(Object.isFrozen(empty.sourceEdgeBatches)).toBe(true);
+    expect(isolated.vertexCount).toBe(9);
+    expect(isolated.edgeCount).toBe(0);
+    expect(isolated.sourceEdgeBatches).toBe(empty.sourceEdgeBatches);
+    expect(maximum.vertexCount).toBe(0xfffffffe);
+  });
+
+  test('constructs metadata without allocations, GPU submission, writes, or readback', () => {
+    const fixture = createGraphFixture();
+    const columns = createGraphColumns(fixture);
+    const edgeAttributes = createEdgeAttributeTable(fixture, columns);
+    const createBufferSpy = vi.spyOn(fixture.device, 'createBuffer');
+    const createCommandEncoderSpy = vi.spyOn(fixture.device, 'createCommandEncoder');
+    const submitSpy = vi.spyOn(fixture.device, 'submit');
+    const readbackSpies = fixture.buffers.map(buffer => vi.spyOn(buffer, 'readAsync'));
+    const mappedReadbackSpies = fixture.buffers.map(buffer => vi.spyOn(buffer, 'mapAndReadAsync'));
+    const writeSpies = fixture.buffers.map(buffer => vi.spyOn(buffer, 'write'));
+
+    const graph = new LuGraph({vertexCount: 8, ...columns, edgeAttributes});
+
+    expect(graph.edgeCount).toBe(5);
+    expect(createBufferSpy).not.toHaveBeenCalled();
+    expect(createCommandEncoderSpy).not.toHaveBeenCalled();
+    expect(submitSpy).not.toHaveBeenCalled();
+    for (const spy of [...readbackSpies, ...mappedReadbackSpies, ...writeSpies]) {
+      expect(spy).not.toHaveBeenCalled();
+    }
+  });
+
+  test('leaves destruction and every borrowed GPU buffer under caller control', () => {
+    const fixture = createGraphFixture();
+    const sourceVertices = createGraphVector(
+      fixture,
+      'ownedSources',
+      'uint32',
+      [Uint32Array.from([0, 1])],
+      {ownsBuffer: true, ownsData: true}
+    );
+    const targetVertices = createGraphVector(
+      fixture,
+      'ownedTargets',
+      'uint32',
+      [Uint32Array.from([1, 2])],
+      {ownsBuffer: true, ownsData: true}
+    );
+    const sourceBuffer = sourceVertices.data[0].buffer;
+    const targetBuffer = targetVertices.data[0].buffer;
+    const graph = new LuGraph({vertexCount: 3, sourceVertices, targetVertices});
+
+    expect(Reflect.has(graph, 'destroy')).toBe(false);
+    expect(sourceBuffer.destroyed).toBe(false);
+    expect(targetBuffer.destroyed).toBe(false);
+
+    sourceVertices.destroy();
+    expect(sourceBuffer.destroyed).toBe(true);
+    expect(targetBuffer.destroyed).toBe(false);
+
+    targetVertices.destroy();
+    expect(targetBuffer.destroyed).toBe(true);
+  });
+});
+
+describe('LuGraph bounded graph validation', () => {
+  test.each([
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    0xffffffff,
+    0x100000000
+  ])('rejects an unrepresentable vertex count: %s', vertexCount => {
+    const fixture = createGraphFixture();
+    const sourceVertices = createGraphVector(fixture, 'sources', 'uint32', []);
+    const targetVertices = createGraphVector(fixture, 'targets', 'uint32', []);
+
+    expect(() => new LuGraph({vertexCount, sourceVertices, targetVertices})).toThrow(
+      /vertexCount.*uint32/
+    );
+  });
+
+  test('rejects edge counts beyond uint32 without allocating a giant buffer', () => {
+    const fixture = createGraphFixture();
+    const sourceVertices = createGraphVector(fixture, 'sources', 'uint32', [Uint32Array.from([0])]);
+    const targetVertices = createGraphVector(fixture, 'targets', 'uint32', [Uint32Array.from([1])]);
+    sourceVertices.length = 0x100000000;
+    sourceVertices.valueLength = 0x100000000;
+    targetVertices.length = 0x100000000;
+    targetVertices.valueLength = 0x100000000;
+
+    expect(() => new LuGraph({vertexCount: 2, sourceVertices, targetVertices})).toThrow(
+      /edgeCount.*uint32/
+    );
+  });
+
+  test('rejects non-uint32 source and target vertex formats', () => {
+    const fixture = createGraphFixture();
+    const sourceVertices = createGraphVector(fixture, 'sources', 'uint32', [Uint32Array.from([0])]);
+    const targetVertices = createGraphVector(fixture, 'targets', 'uint32', [Uint32Array.from([1])]);
+    const signedVertices = createGraphVector(fixture, 'signedVertices', 'sint32', [
+      Int32Array.from([0])
+    ]);
+
+    expect(
+      () =>
+        new LuGraph({
+          vertexCount: 2,
+          sourceVertices: asVertexVector(signedVertices),
+          targetVertices
+        })
+    ).toThrow(/sourceVertices.*uint32/);
+    expect(
+      () =>
+        new LuGraph({
+          vertexCount: 2,
+          sourceVertices,
+          targetVertices: asVertexVector(signedVertices)
+        })
+    ).toThrow(/targetVertices.*uint32/);
+  });
+
+  test('requires float32 edge weights and uint32 stable edge identifiers', () => {
+    const fixture = createGraphFixture();
+    const {sourceVertices, targetVertices, edgeWeights, edgeIds} = createGraphColumns(fixture);
+
+    expect(
+      () =>
+        new LuGraph({
+          vertexCount: 8,
+          sourceVertices,
+          targetVertices,
+          edgeWeights: asWeightVector(edgeIds)
+        })
+    ).toThrow(/edgeWeights.*float32/);
+    expect(
+      () =>
+        new LuGraph({
+          vertexCount: 8,
+          sourceVertices,
+          targetVertices,
+          edgeIds: asVertexVector(edgeWeights)
+        })
+    ).toThrow(/edgeIds.*uint32/);
+  });
+
+  test.each([
+    ['misaligned chunk offsets', {byteOffset: 2}],
+    ['padded chunk byte strides', {byteStride: 8}],
+    ['oversized chunk rows', {rowByteLength: 8}],
+    ['multi-component chunk strides', {stride: 2}],
+    ['padded vector byte strides', {vectorByteStride: 8}],
+    ['oversized vector rows', {vectorRowByteLength: 8}],
+    ['multi-component vector strides', {vectorStride: 2}]
+  ] as Array<
+    [string, GraphVectorOptions]
+  >)('rejects unpacked vertex layouts: %s', (_description, options) => {
+    const fixture = createGraphFixture();
+    const sourceVertices = createGraphVector(
+      fixture,
+      'invalidSources',
+      'uint32',
+      [Uint32Array.from([0, 1])],
+      options
+    );
+    const targetVertices = createGraphVector(fixture, 'targets', 'uint32', [
+      Uint32Array.from([1, 2])
+    ]);
+
+    expect(() => new LuGraph({vertexCount: 3, sourceVertices, targetVertices})).toThrow(
+      /sourceVertices.*packed/
+    );
+  });
+
+  test('rejects a malformed format on an otherwise empty preserved edge chunk', () => {
+    const fixture = createGraphFixture();
+    const {sourceVertices, targetVertices} = createGraphColumns(fixture);
+    Object.defineProperty(sourceVertices.data[1], 'format', {value: 'float32'});
+
+    expect(() => new LuGraph({vertexCount: 8, sourceVertices, targetVertices})).toThrow(
+      /sourceVertices.*uint32.*chunks/
+    );
+  });
+
+  test.each([
+    ['a missing empty batch', [2, 3]],
+    ['different per-batch boundaries', [1, 0, 4]],
+    ['fewer total edge rows', [2, 0, 2]]
+  ])('rejects target edge topology with %s', (_description, chunkLengths) => {
+    const fixture = createGraphFixture();
+    const {sourceVertices} = createGraphColumns(fixture);
+    const targetVertices = createGraphVector(
+      fixture,
+      'mismatchedTargets',
+      'uint32',
+      chunkLengths.map(chunkLength => new Uint32Array(chunkLength))
+    );
+
+    expect(() => new LuGraph({vertexCount: 8, sourceVertices, targetVertices})).toThrow(
+      /targetVertices.*chunk topology/
+    );
+  });
+
+  test('requires edge weights and stable IDs to preserve every source chunk boundary', () => {
+    const fixture = createGraphFixture();
+    const {sourceVertices, targetVertices} = createGraphColumns(fixture);
+    const mismatchedWeights = createGraphVector(fixture, 'mismatchedWeights', 'float32', [
+      new Float32Array(2),
+      new Float32Array(3)
+    ]);
+    const mismatchedEdgeIds = createGraphVector(fixture, 'mismatchedIds', 'uint32', [
+      new Uint32Array(1),
+      new Uint32Array(0),
+      new Uint32Array(4)
+    ]);
+
+    expect(
+      () =>
+        new LuGraph({
+          vertexCount: 8,
+          sourceVertices,
+          targetVertices,
+          edgeWeights: mismatchedWeights
+        })
+    ).toThrow(/edgeWeights.*chunk topology/);
+    expect(
+      () =>
+        new LuGraph({vertexCount: 8, sourceVertices, targetVertices, edgeIds: mismatchedEdgeIds})
+    ).toThrow(/edgeIds.*chunk topology/);
+  });
+
+  test('requires vertex and edge property tables to match their logical row counts', () => {
+    const fixture = createGraphFixture();
+    const {sourceVertices, targetVertices} = createGraphColumns(fixture);
+    const shortNodeAttributes = createPropertyTable(fixture, 'nodeScore', 'float32', [
+      new Float32Array(7)
+    ]);
+    const shortEdgeAttributes = createPropertyTable(fixture, 'edgeScore', 'float32', [
+      new Float32Array(2),
+      new Float32Array(0),
+      new Float32Array(2)
+    ]);
+
+    expect(
+      () =>
+        new LuGraph({
+          vertexCount: 8,
+          sourceVertices,
+          targetVertices,
+          nodeAttributes: shortNodeAttributes
+        })
+    ).toThrow(/nodeAttributes.*one row per vertex/);
+    expect(
+      () =>
+        new LuGraph({
+          vertexCount: 8,
+          sourceVertices,
+          targetVertices,
+          edgeAttributes: shortEdgeAttributes
+        })
+    ).toThrow(/edgeAttributes.*one row per edge/);
+  });
+
+  test.each([
+    ['different batch counts', [2, 3]],
+    ['different source-aligned batch lengths', [1, 0, 4]]
+  ])('rejects edge property tables with %s', (_description, chunkLengths) => {
+    const fixture = createGraphFixture();
+    const {sourceVertices, targetVertices} = createGraphColumns(fixture);
+    const edgeAttributes = createPropertyTable(
+      fixture,
+      'edgeScore',
+      'float32',
+      chunkLengths.map(chunkLength => new Float32Array(chunkLength))
+    );
+
+    expect(
+      () => new LuGraph({vertexCount: 8, sourceVertices, targetVertices, edgeAttributes})
+    ).toThrow(/edgeAttributes.*batch topology/);
+  });
+
+  test('accepts arbitrary edge properties without requiring duplicate endpoint columns', () => {
+    const fixture = createGraphFixture();
+    const {sourceVertices, targetVertices} = createGraphColumns(fixture);
+    const edgeAttributes = createPropertyTable(fixture, 'edgeScore', 'float32', [
+      new Float32Array(2),
+      new Float32Array(0),
+      new Float32Array(3)
+    ]);
+    const graph = new LuGraph({vertexCount: 8, sourceVertices, targetVertices, edgeAttributes});
+
+    expect(graph.edgeAttributes).toBe(edgeAttributes);
+    expect(graph.sourceEdgeBatches).toBe(edgeAttributes.batches);
+  });
+
+  test('rejects edge property endpoint columns backed by different source chunks', () => {
+    const fixture = createGraphFixture();
+    const original = createGraphColumns(fixture);
+    const replacements = createGraphColumns(fixture);
+    const edgeAttributes = createEdgeAttributeTable(fixture, {
+      ...original,
+      sourceVertices: replacements.sourceVertices
+    });
+
+    expect(() => new LuGraph({vertexCount: 8, ...original, edgeAttributes})).toThrow(
+      /edgeAttributes sourceVertices.*source edge data/
+    );
+  });
+});
+
+function createGraphFixture(): GraphFixture {
+  const fixture = {device: new NullDevice({}), buffers: [], vectors: [], tables: []};
+  graphFixtures.push(fixture);
+  return fixture;
+}
+
+function createGraphColumns(fixture: GraphFixture): GraphColumns {
+  return {
+    sourceVertices: createGraphVector(fixture, 'sourceVertices', 'uint32', [
+      Uint32Array.from([0, 2]),
+      new Uint32Array(0),
+      Uint32Array.from([2, 3, 6])
+    ]),
+    targetVertices: createGraphVector(fixture, 'targetVertices', 'uint32', [
+      Uint32Array.from([1, 4]),
+      new Uint32Array(0),
+      Uint32Array.from([3, 5, 7])
+    ]),
+    edgeWeights: createGraphVector(fixture, 'edgeWeights', 'float32', [
+      Float32Array.from([0.5, 2]),
+      new Float32Array(0),
+      Float32Array.from([1, 4, 8])
+    ]),
+    edgeIds: createGraphVector(fixture, 'edgeIds', 'uint32', [
+      Uint32Array.from([10, 42]),
+      new Uint32Array(0),
+      Uint32Array.from([99, 101, 102])
+    ])
+  };
+}
+
+function createGraphVector<Format extends GraphScalarFormat>(
+  fixture: GraphFixture,
+  name: string,
+  format: Format,
+  chunks: readonly GraphScalarArray[],
+  options: GraphVectorOptions = {}
+): GPUVector<Format> {
+  const byteOffset = options.byteOffset ?? 0;
+  const byteStride = options.byteStride ?? Uint32Array.BYTES_PER_ELEMENT;
+  const rowByteLength = options.rowByteLength ?? Uint32Array.BYTES_PER_ELEMENT;
+  const data = chunks.map((values, chunkIndex) => {
+    const byteLength =
+      byteOffset +
+      Math.max(values.byteLength, Math.max(values.length, 1) * byteStride, rowByteLength);
+    const buffer = fixture.device.createBuffer({
+      id: `${name}-chunk-${chunkIndex}-${fixture.buffers.length}`,
+      byteLength,
+      usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+    });
+    fixture.buffers.push(buffer);
+    if (values.byteLength > 0) {
+      buffer.write(values, byteOffset);
+    }
+    return new GPUData<Format>({
+      buffer,
+      format,
+      length: values.length,
+      byteOffset,
+      byteStride,
+      rowByteLength,
+      stride: options.stride ?? 1,
+      ownsBuffer: options.ownsBuffer ?? false,
+      readbackMetadata: {columnName: name, sourceBatchIndex: chunkIndex}
+    });
+  });
+  const vector = new GPUVector<Format>({
+    type: 'data',
+    name,
+    format,
+    data,
+    byteStride: options.vectorByteStride ?? byteStride,
+    rowByteLength: options.vectorRowByteLength ?? rowByteLength,
+    stride: options.vectorStride ?? options.stride ?? 1,
+    ownsData: options.ownsData ?? false
+  });
+  fixture.vectors.push(vector);
+  return vector;
+}
+
+function createEdgeAttributeTable(fixture: GraphFixture, columns: GraphColumns): GPUTable {
+  let sourceRowIndexOffset = 19;
+  const batches = columns.sourceVertices.data.map((sourceVertices, sourceBatchIndex) => {
+    const batch = new GPURecordBatch({
+      gpuData: {
+        sourceVertices,
+        targetVertices: columns.targetVertices.data[sourceBatchIndex],
+        edgeWeights: columns.edgeWeights.data[sourceBatchIndex],
+        edgeIds: columns.edgeIds.data[sourceBatchIndex]
+      },
+      sourceInfo: {
+        sourceBatchIndex,
+        sourceRowIndexOffset,
+        sourceRowCount: sourceVertices.length
+      }
+    });
+    sourceRowIndexOffset += sourceVertices.length;
+    return batch;
+  });
+  const table = new GPUTable({batches});
+  fixture.tables.push(table);
+  return table;
+}
+
+function createPropertyTable<Format extends GraphScalarFormat>(
+  fixture: GraphFixture,
+  name: string,
+  format: Format,
+  chunks: readonly GraphScalarArray[]
+): GPUTable {
+  const vector = createGraphVector(fixture, name, format, chunks);
+  const batches = vector.data.map(data => new GPURecordBatch({gpuData: {[name]: data}}));
+  const table = new GPUTable({batches});
+  fixture.tables.push(table);
+  return table;
+}
+
+function asVertexVector(vector: GPUVector): GPUVector<'uint32'> {
+  return vector as GPUVector<'uint32'>;
+}
+
+function asWeightVector(vector: GPUVector): GPUVector<'float32'> {
+  return vector as GPUVector<'float32'>;
+}

--- a/modules/experimental/test/lugraph/lu-graph.node.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph.node.spec.ts
@@ -482,6 +482,44 @@ describe('LuGraph bounded graph validation', () => {
       /edgeAttributes sourceVertices.*source edge data/
     );
   });
+
+  test('accepts custom-named endpoint columns when they preserve original GPU data chunks', () => {
+    const fixture = createGraphFixture();
+    const original = createGraphColumns(fixture);
+    const sourceVertices = renameGraphVector(fixture, original.sourceVertices, 'fromVertex');
+    const targetVertices = renameGraphVector(fixture, original.targetVertices, 'toVertex');
+    const edgeAttributes = createNamedEndpointTable(fixture, sourceVertices, targetVertices);
+    const graph = new LuGraph({vertexCount: 8, sourceVertices, targetVertices, edgeAttributes});
+
+    expect(graph.sourceVertices.name).toBe('fromVertex');
+    expect(graph.targetVertices.name).toBe('toVertex');
+    expect(graph.edgeAttributes?.gpuVectors.fromVertex.data).toEqual(sourceVertices.data);
+    expect(graph.edgeAttributes?.gpuVectors.toVertex.data).toEqual(targetVertices.data);
+  });
+
+  test.each([
+    ['sourceVertices', 'fromVertex'],
+    ['targetVertices', 'toVertex']
+  ] as const)('rejects foreign GPU chunks under the actual custom %s vector name', (column, customName) => {
+    const fixture = createGraphFixture();
+    const original = createGraphColumns(fixture);
+    const replacements = createGraphColumns(fixture);
+    const sourceVertices = renameGraphVector(fixture, original.sourceVertices, 'fromVertex');
+    const targetVertices = renameGraphVector(fixture, original.targetVertices, 'toVertex');
+    const tableSources =
+      column === 'sourceVertices'
+        ? renameGraphVector(fixture, replacements.sourceVertices, sourceVertices.name)
+        : sourceVertices;
+    const tableTargets =
+      column === 'targetVertices'
+        ? renameGraphVector(fixture, replacements.targetVertices, targetVertices.name)
+        : targetVertices;
+    const edgeAttributes = createNamedEndpointTable(fixture, tableSources, tableTargets);
+
+    expect(
+      () => new LuGraph({vertexCount: 8, sourceVertices, targetVertices, edgeAttributes})
+    ).toThrow(new RegExp(`edgeAttributes ${customName}.*source edge data`));
+  });
 });
 
 function createGraphFixture(): GraphFixture {
@@ -583,6 +621,41 @@ function createEdgeAttributeTable(fixture: GraphFixture, columns: GraphColumns):
     sourceRowIndexOffset += sourceVertices.length;
     return batch;
   });
+  const table = new GPUTable({batches});
+  fixture.tables.push(table);
+  return table;
+}
+
+function renameGraphVector(
+  fixture: GraphFixture,
+  vector: GPUVector<'uint32'>,
+  name: string
+): GPUVector<'uint32'> {
+  const renamed = new GPUVector<'uint32'>({
+    type: 'data',
+    name,
+    format: 'uint32',
+    data: vector.data,
+    ownsData: false
+  });
+  fixture.vectors.push(renamed);
+  return renamed;
+}
+
+function createNamedEndpointTable(
+  fixture: GraphFixture,
+  sourceVertices: GPUVector<'uint32'>,
+  targetVertices: GPUVector<'uint32'>
+): GPUTable {
+  const batches = sourceVertices.data.map(
+    (sourceChunk, chunkIndex) =>
+      new GPURecordBatch({
+        gpuData: {
+          [sourceVertices.name]: sourceChunk,
+          [targetVertices.name]: targetVertices.data[chunkIndex]
+        }
+      })
+  );
   const table = new GPUTable({batches});
   fixture.tables.push(table);
   return table;

--- a/modules/experimental/test/lugraph/lu-graph.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph.spec.ts
@@ -1,0 +1,132 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {LuGraph} from '@luma.gl/experimental/lugraph';
+import {GPUData, GPUVector} from '@luma.gl/tables';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
+import {vi} from 'vitest';
+
+test('LuGraph preserves caller-owned WebGPU graph chunks without executing GPU work', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const buffers: Buffer[] = [];
+  const sourceVertices = createGraphVector(device, buffers, 'sources', 'uint32', [
+    Uint32Array.from([0, 2]),
+    new Uint32Array(0),
+    Uint32Array.from([2, 3, 6])
+  ]);
+  const targetVertices = createGraphVector(device, buffers, 'targets', 'uint32', [
+    Uint32Array.from([1, 4]),
+    new Uint32Array(0),
+    Uint32Array.from([3, 5, 7])
+  ]);
+  const edgeWeights = createGraphVector(device, buffers, 'weights', 'float32', [
+    Float32Array.from([0.5, 2]),
+    new Float32Array(0),
+    Float32Array.from([1, 4, 8])
+  ]);
+  const edgeIds = createGraphVector(device, buffers, 'edge-ids', 'uint32', [
+    Uint32Array.from([10, 42]),
+    new Uint32Array(0),
+    Uint32Array.from([99, 101, 102])
+  ]);
+  const createBufferSpy = vi.spyOn(device, 'createBuffer');
+  const submitSpy = vi.spyOn(device, 'submit');
+  const readbackSpies = buffers.map(buffer => vi.spyOn(buffer, 'readAsync'));
+
+  try {
+    const graph = new LuGraph({
+      vertexCount: 9,
+      sourceVertices,
+      targetVertices,
+      edgeWeights,
+      edgeIds,
+      directed: false
+    });
+
+    tapeTest.equal(graph.vertexCount, 9, 'explicit vertex counts retain isolated vertices');
+    tapeTest.equal(graph.edgeCount, 5, 'undirected metadata does not symmetrize source edges');
+    tapeTest.equal(graph.directed, false, 'caller-selected directedness remains explicit');
+    tapeTest.equal(graph.sourceVertices, sourceVertices, 'source vector identity is preserved');
+    tapeTest.equal(graph.targetVertices, targetVertices, 'target vector identity is preserved');
+    tapeTest.equal(graph.edgeWeights, edgeWeights, 'float32 weight vector identity is preserved');
+    tapeTest.equal(graph.edgeIds, edgeIds, 'stable uint32 edge ID vector identity is preserved');
+
+    for (const vector of [sourceVertices, targetVertices, edgeWeights, edgeIds]) {
+      tapeTest.deepEqual(
+        vector.data.map(chunk => chunk.length),
+        [2, 0, 3],
+        `${vector.name} retains its empty middle GPUData chunk`
+      );
+      for (const chunk of vector.data) {
+        tapeTest.ok(
+          buffers.some(buffer => buffer === chunk.buffer),
+          `${vector.name} borrows its original buffer`
+        );
+      }
+    }
+
+    tapeTest.equal(createBufferSpy.mock.calls.length, 0, 'construction allocates no GPU buffers');
+    tapeTest.equal(submitSpy.mock.calls.length, 0, 'construction submits no GPU commands');
+    tapeTest.ok(
+      readbackSpies.every(spy => spy.mock.calls.length === 0),
+      'construction never reads source buffers back to the CPU'
+    );
+
+    for (const vector of [sourceVertices, targetVertices, edgeWeights, edgeIds]) {
+      vector.destroy();
+    }
+    tapeTest.ok(
+      buffers.every(buffer => !buffer.destroyed),
+      'destroying borrowed vectors leaves every WebGPU buffer under caller ownership'
+    );
+  } finally {
+    createBufferSpy.mockRestore();
+    submitSpy.mockRestore();
+    for (const spy of readbackSpies) {
+      spy.mockRestore();
+    }
+    for (const vector of [sourceVertices, targetVertices, edgeWeights, edgeIds]) {
+      vector.destroy();
+    }
+    for (const buffer of buffers) {
+      buffer.destroy();
+    }
+  }
+
+  tapeTest.end();
+});
+
+/** Creates borrowed scalar GPU vectors without changing empty source chunk boundaries. */
+function createGraphVector<Format extends 'uint32' | 'float32'>(
+  device: Device,
+  buffers: Buffer[],
+  name: string,
+  format: Format,
+  chunks: readonly (Uint32Array | Float32Array)[]
+): GPUVector<Format> {
+  const data = chunks.map((values, chunkIndex) => {
+    const buffer = device.createBuffer({
+      id: `${name}-chunk-${chunkIndex}`,
+      data: values.length > 0 ? values : new Uint32Array(1),
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    buffers.push(buffer);
+    return new GPUData<Format>({
+      buffer,
+      format,
+      length: values.length,
+      ownsBuffer: false
+    });
+  });
+
+  return new GPUVector<Format>({type: 'data', name, format, data, ownsData: false});
+}


### PR DESCRIPTION
## Goals

- Establish an optional, Arrow-free `@luma.gl/experimental/lugraph` foundation for browser-native GPU graph analytics without changing the experimental root API or bundle.
- Preserve explicit graph cardinality, source-owned GPU vectors, record batches, stable edge identities, and isolated vertices before introducing GPU topology construction.

## Changes

- Add conditional ESM, CommonJS, and TypeScript package exports for `@luma.gl/experimental/lugraph`.
- Introduce `LuGraph` and `LuGraphProps` over existing packed `GPUVector<'uint32'>` source/target columns, optional stable edge IDs, optional `GPUVector<'float32'>` edge weights, optional caller-owned node/edge property tables, and explicit directedness.
- Preserve original vector instances, GPUData chunks, empty source batches, backing buffers, record batches, and source-row identity metadata without allocation, copying, implicit repacking, command submission, readback, destruction, or Apache Arrow dependencies.
- Validate bounded uint32 vertex/edge counts, packed scalar layouts, source-aligned chunk topology, table row/batch topology, and existing named property-column identity under both canonical graph property names and custom source-vector column names.
- Add 36 focused Node regressions and a real-WebGPU ownership/zero-side-effect regression covering empty graphs, isolated vertices, malformed layouts, stable IDs, directedness, and preserved `[2, 0, 3]` chunks.
- Verify built ESM and CommonJS subpath imports while keeping `LuGraph` absent from the experimental root.

## Verification

- `nvm use`: passed; Node `v22.22.1`.
- `yarn install`: attempted; the configured internal registry returned HTTP 403 for uncached dependencies, so verification used an isolated APFS copy-on-write clone of an existing compatible local installation.
- `yarn lint fix`: passed.
- `yarn build`: passed across every module, including ESM, CommonJS, and TypeScript declaration outputs for `./lugraph`.
- Focused Node tests: 36 passed, including three regressions addressing automated review feedback for custom endpoint column names.
- Focused real Chromium/WebGPU test: passed.
- Built ESM and CommonJS package-subpath smoke checks: passed; `LuGraph` remains absent from the experimental root.
- `yarn test` with the repository's `CI=1` serial software-WebGPU configuration: **579 Node tests and 1,554 Chromium/WebGPU tests passed**; existing skips only.
- `yarn website:build`: passed.
- `(cd website && yarn build)`: passed.
- `yarn examples:typecheck`: passed for all 46 example workspaces.
- `yarn bundle-size`: all seven bundle budgets passed.
- Normal pre-commit hooks: lint and the complete Node suite passed.

## Scope / follow-up

- Descriptor and package boundary only. GPU CSR construction, reverse adjacency, traversal wrappers, graph metrics, PageRank, and force-directed layout remain independently reviewable follow-ups.
- Physical-buffer aliasing across distinct command-graph handles remains a separate compatibility-sensitive prerequisite.