### PR TITLE
feat(arrow): add renderer-independent GPU analytics ingestion

### DIFF
--- a/modules/arrow/src/arrow/gpu/arrow-gpu-analytics-adapters.ts
+++ b/modules/arrow/src/arrow/gpu/arrow-gpu-analytics-adapters.ts
@@ -1,0 +1,476 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {
+  GPUData,
+  GPURecordBatch,
+  GPUTable,
+  GPUVector,
+  isGPUTableIndexColumnName,
+  type GPUField,
+  type GPUTypeMap,
+  type GPUVectorBufferProps
+} from '@luma.gl/tables';
+import {
+  DataType,
+  Dictionary,
+  Precision,
+  type Data,
+  type Field,
+  type Float32,
+  type Int32,
+  type Table,
+  type TypeMap,
+  type Uint32,
+  type Utf8
+} from 'apache-arrow';
+import {makeGPUDataFromArrowData} from './arrow-gpu-table-adapters';
+
+/** Supported WebGPU-native scalar and categorical index storage formats. */
+type GPUAnalyticsVectorFormat = 'float32' | 'sint32' | 'uint32';
+
+/** Maps a typed Arrow schema to its exact portable GPU analytics column formats. */
+export type GPUAnalyticsTypeMapForArrow<T extends TypeMap> = {
+  [Name in keyof T & string]: T[Name] extends Float32
+    ? 'float32'
+    : T[Name] extends Int32
+      ? 'sint32'
+      : T[Name] extends Uint32
+        ? 'uint32'
+        : T[Name] extends Dictionary<Utf8, infer IndexType>
+          ? IndexType extends Int32
+            ? 'sint32'
+            : IndexType extends Uint32
+              ? 'uint32'
+              : never
+          : never;
+};
+
+/** CPU-owned category labels associated with one GPU-resident dictionary-index column. */
+export type GPUAnalyticsDictionary = {
+  /** Dictionary labels in the exact order referenced by uploaded integer indices. */
+  readonly values: readonly string[];
+  /** Whether the Arrow source declares these category labels ordered. */
+  readonly ordered: boolean;
+};
+
+/** Renderer-independent Arrow analytics upload options. */
+export type GPUAnalyticsTableFromArrowTableProps<T extends GPUTypeMap = GPUTypeMap> = {
+  /** Source columns to upload, in the desired order. Defaults to all source fields. */
+  columns?: readonly (keyof T & string)[];
+  /** Additional buffer properties; required storage and copy usage are always retained. */
+  bufferProps?: GPUVectorBufferProps;
+};
+
+/** GPU table plus explicit analytical metadata retained outside generic GPU table storage. */
+export type GPUAnalyticsTableFromArrowTableResult<T extends GPUTypeMap = GPUTypeMap> = {
+  /** Existing generic GPU table primitives, preserving every source record batch. */
+  table: GPUTable<T>;
+  /** One source-row-aligned uint32 GPU validity vector for every nullable selected field. */
+  validity: Partial<Record<keyof T & string, GPUVector<'uint32'>>>;
+  /** Explicit adapter-owned labels for selected UTF-8 dictionary columns. */
+  dictionaries: Partial<Record<keyof T & string, GPUAnalyticsDictionary>>;
+  /** Per-field Arrow null counts in source record-batch order. */
+  nullCounts: Partial<Record<keyof T & string, readonly number[]>>;
+};
+
+/** Fully validated source metadata collected before allocating any GPU resources. */
+type PreparedGPUAnalyticsColumn = {
+  field: Field;
+  format: GPUAnalyticsVectorFormat;
+  chunks: Data[];
+  validity: Uint32Array[];
+  nullCounts: number[];
+  dictionary?: GPUAnalyticsDictionary;
+};
+
+const GPU_ANALYTICS_BUFFER_USAGE =
+  Buffer.VERTEX | Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC;
+
+/**
+ * Uploads Arrow columns for GPU analytics without requiring renderer-specific shader metadata.
+ *
+ * Numeric values and dictionary indices stay in existing `GPUData`, `GPURecordBatch`, `GPUVector`,
+ * and `GPUTable` objects. Nullable rows receive separate batch-aligned uint32 validity vectors,
+ * while dictionary labels and source null counts remain explicit adapter-owned metadata.
+ */
+export function makeGPUAnalyticsTableFromArrowTable<T extends TypeMap>(
+  device: Device,
+  table: Table<T>,
+  options?: GPUAnalyticsTableFromArrowTableProps<GPUAnalyticsTypeMapForArrow<T>>
+): GPUAnalyticsTableFromArrowTableResult<GPUAnalyticsTypeMapForArrow<T>>;
+export function makeGPUAnalyticsTableFromArrowTable<T extends GPUTypeMap = GPUTypeMap>(
+  device: Device,
+  table: Table,
+  options: GPUAnalyticsTableFromArrowTableProps<T> = {}
+): GPUAnalyticsTableFromArrowTableResult<T> {
+  validateGPUAnalyticsBufferProps(options.bufferProps);
+  const columns = prepareGPUAnalyticsColumns(table, options.columns);
+  const requiredBufferProps = {
+    ...options.bufferProps,
+    usage: (options.bufferProps?.usage ?? 0) | GPU_ANALYTICS_BUFFER_USAGE
+  };
+  const allocatedData: GPUData[] = [];
+  const allocatedValidityData: GPUData<'uint32'>[] = [];
+  const validity: GPUAnalyticsTableFromArrowTableResult<T>['validity'] = {};
+  const dictionaries: GPUAnalyticsTableFromArrowTableResult<T>['dictionaries'] = {};
+  const nullCounts: GPUAnalyticsTableFromArrowTableResult<T>['nullCounts'] = {};
+  let gpuTable: GPUTable<T> | undefined;
+
+  try {
+    for (const column of columns) {
+      const columnName = column.field.name as keyof T & string;
+      nullCounts[columnName] = Object.freeze([...column.nullCounts]);
+      if (column.dictionary) {
+        dictionaries[columnName] = column.dictionary;
+      }
+    }
+
+    let sourceRowIndexOffset = 0;
+    const batches = table.batches.map((recordBatch, sourceBatchIndex) => {
+      const gpuData: Record<string, GPUData> = {};
+
+      for (const column of columns) {
+        const sourceData = column.chunks[sourceBatchIndex];
+        const data = makeGPUAnalyticsData(device, sourceData, column.format, requiredBufferProps);
+        allocatedData.push(data);
+        gpuData[column.field.name] = data;
+      }
+
+      const batch = new GPURecordBatch<T>({
+        gpuData,
+        fields: columns.map(column => makeGPUAnalyticsField(column)),
+        numRows: recordBatch.numRows,
+        metadata: new Map(recordBatch.schema.metadata),
+        sourceInfo: {
+          sourceBatchIndex,
+          sourceRowIndexOffset,
+          sourceRowCount: recordBatch.numRows
+        },
+        nullCount: recordBatch.nullCount
+      });
+      sourceRowIndexOffset += recordBatch.numRows;
+      return batch;
+    });
+
+    gpuTable =
+      batches.length > 0
+        ? new GPUTable<T>({batches})
+        : new GPUTable<T>({
+            schema: {
+              fields: columns.map(column => makeGPUAnalyticsField(column)) as GPUField<
+                keyof T & string
+              >[],
+              metadata: new Map(table.schema.metadata)
+            },
+            bufferLayout: columns.map(column => ({
+              name: column.field.name,
+              format: column.format,
+              byteStride: 4
+            }))
+          });
+
+    if (batches.length > 0) {
+      gpuTable.schema = {
+        fields: columns.map(column => makeGPUAnalyticsField(column)) as GPUField<
+          keyof T & string
+        >[],
+        metadata: new Map(table.schema.metadata)
+      };
+    }
+
+    for (const column of columns) {
+      if (!column.field.nullable || batches.length === 0) {
+        continue;
+      }
+
+      const chunks = column.validity.map(values => {
+        const data = makeGPUAnalyticsValidityData(device, values, requiredBufferProps);
+        allocatedValidityData.push(data);
+        return data;
+      });
+      validity[column.field.name as keyof T & string] = new GPUVector<'uint32'>({
+        type: 'data',
+        name: `${column.field.name}-validity`,
+        format: 'uint32',
+        data: chunks,
+        ownsData: true
+      });
+    }
+
+    return {table: gpuTable, validity, dictionaries, nullCounts};
+  } catch (error) {
+    gpuTable?.destroy();
+    for (const data of allocatedData) {
+      data.destroy();
+    }
+    for (const data of allocatedValidityData) {
+      data.destroy();
+    }
+    throw error;
+  }
+}
+
+/** Rejects caller props that would alias owned buffers or invalidate their logical layout. */
+function validateGPUAnalyticsBufferProps(bufferProps: GPUVectorBufferProps | undefined): void {
+  if (bufferProps?.handle !== undefined && bufferProps.handle !== null) {
+    throw new Error('GPU analytics buffers cannot adopt an external buffer handle');
+  }
+  if (bufferProps?._isHandleBorrowed) {
+    throw new Error('GPU analytics buffers cannot borrow an external buffer handle');
+  }
+  if (bufferProps?.byteOffset) {
+    throw new Error('GPU analytics buffers cannot use a nonzero byte offset');
+  }
+  if (((bufferProps?.usage ?? 0) & (Buffer.MAP_READ | Buffer.MAP_WRITE)) !== 0) {
+    throw new Error('GPU analytics storage buffers cannot declare mapped usage');
+  }
+}
+
+/** Validates every selected field, batch, bitmap, and dictionary before allocating GPU resources. */
+function prepareGPUAnalyticsColumns(
+  table: Table,
+  selectedNames: readonly string[] | undefined
+): PreparedGPUAnalyticsColumn[] {
+  const sourceFields = new Map<string, Field>();
+  for (const field of table.schema.fields) {
+    if (sourceFields.has(field.name)) {
+      throw new Error(`GPU analytics source contains duplicate column "${field.name}"`);
+    }
+    sourceFields.set(field.name, field);
+  }
+
+  const columnNames = selectedNames ?? table.schema.fields.map(field => field.name);
+  const encounteredNames = new Set<string>();
+  return columnNames.map(columnName => {
+    if (encounteredNames.has(columnName)) {
+      throw new Error(`GPU analytics column "${columnName}" cannot be selected more than once`);
+    }
+    encounteredNames.add(columnName);
+
+    const field = sourceFields.get(columnName);
+    if (!field) {
+      throw new Error(`GPU analytics column "${columnName}" does not exist`);
+    }
+    if (isGPUTableIndexColumnName(columnName)) {
+      throw new Error(`GPU analytics column "${columnName}" is reserved for table indices`);
+    }
+
+    const column: PreparedGPUAnalyticsColumn = {
+      field,
+      format: getGPUAnalyticsVectorFormat(field.type, columnName),
+      chunks: [],
+      validity: [],
+      nullCounts: []
+    };
+
+    for (const [batchIndex, batch] of table.batches.entries()) {
+      const vector = batch.getChild(columnName);
+      const data = vector?.data[0];
+      if (!vector || !data || vector.data.length !== 1 || data.length !== batch.numRows) {
+        throw new Error(
+          `GPU analytics column "${columnName}" has an incompatible chunk in batch ${batchIndex}`
+        );
+      }
+
+      if (getGPUAnalyticsVectorFormat(data.type, columnName) !== column.format) {
+        throw new Error(`GPU analytics column "${columnName}" changes type between batches`);
+      }
+
+      const validity = getGPUAnalyticsValidity(data, field.nullable, columnName);
+      if (DataType.isDictionary(field.type)) {
+        const dictionary = getGPUAnalyticsDictionary(data, columnName);
+        if (column.dictionary && !areGPUAnalyticsDictionariesEqual(column.dictionary, dictionary)) {
+          throw new Error(`GPU analytics dictionary column "${columnName}" changes across batches`);
+        }
+        column.dictionary ??= dictionary;
+        validateGPUAnalyticsDictionaryIndices(data, dictionary, validity, columnName);
+      }
+
+      column.chunks.push(data);
+      column.validity.push(validity);
+      column.nullCounts.push(data.nullCount);
+    }
+
+    return column;
+  });
+}
+
+/** Maps the intentionally limited portable Arrow analytics surface to canonical GPU formats. */
+function getGPUAnalyticsVectorFormat(type: DataType, columnName: string): GPUAnalyticsVectorFormat {
+  if (DataType.isFloat(type) && type.precision === Precision.SINGLE) {
+    return 'float32';
+  }
+  if (DataType.isInt(type) && type.bitWidth === 32) {
+    return type.isSigned ? 'sint32' : 'uint32';
+  }
+  if (
+    DataType.isDictionary(type) &&
+    DataType.isUtf8(type.dictionary) &&
+    DataType.isInt(type.indices) &&
+    type.indices.bitWidth === 32
+  ) {
+    return type.indices.isSigned ? 'sint32' : 'uint32';
+  }
+  throw new Error(`GPU analytics column "${columnName}" has unsupported Arrow type ${type}`);
+}
+
+/** Expands sliced Arrow validity bits into one 0/1 uint32 value per logical source row. */
+function getGPUAnalyticsValidity(data: Data, nullable: boolean, columnName: string): Uint32Array {
+  const nullCount = data.nullCount;
+  const sourceRowOffset = data.offset ?? 0;
+  if (
+    !Number.isSafeInteger(sourceRowOffset) ||
+    sourceRowOffset < 0 ||
+    !Number.isSafeInteger(nullCount) ||
+    nullCount < 0 ||
+    nullCount > data.length
+  ) {
+    throw new Error(`GPU analytics column "${columnName}" has malformed validity metadata`);
+  }
+  if (!nullable && nullCount > 0) {
+    throw new Error(`GPU analytics non-nullable column "${columnName}" contains null values`);
+  }
+
+  const bitmap = data.nullBitmap;
+  if (nullCount > 0 && (!bitmap || bitmap.byteLength === 0)) {
+    throw new Error(`GPU analytics column "${columnName}" is missing its validity bitmap`);
+  }
+  if (bitmap && bitmap.byteLength > 0 && bitmap.byteLength * 8 < sourceRowOffset + data.length) {
+    throw new Error(`GPU analytics column "${columnName}" has a truncated validity bitmap`);
+  }
+
+  const validity = new Uint32Array(data.length);
+  let observedNullCount = 0;
+  for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
+    const sourceBitIndex = sourceRowOffset + rowIndex;
+    const valid =
+      !bitmap || bitmap.byteLength === 0
+        ? true
+        : ((bitmap[sourceBitIndex >> 3] ?? 0) & (1 << (sourceBitIndex & 7))) !== 0;
+    validity[rowIndex] = valid ? 1 : 0;
+    if (!valid) {
+      observedNullCount++;
+    }
+  }
+  if (observedNullCount !== nullCount) {
+    throw new Error(`GPU analytics column "${columnName}" has inconsistent validity bitmap`);
+  }
+  return validity;
+}
+
+/** Copies dictionary labels into explicit CPU metadata without retaining the Arrow source vector. */
+function getGPUAnalyticsDictionary(data: Data, columnName: string): GPUAnalyticsDictionary {
+  if (!(data.type instanceof Dictionary) || !DataType.isUtf8(data.type.dictionary)) {
+    throw new Error(`GPU analytics column "${columnName}" requires a UTF-8 dictionary`);
+  }
+  if (!data.dictionary) {
+    throw new Error(`GPU analytics dictionary column "${columnName}" has no dictionary labels`);
+  }
+
+  const values: string[] = [];
+  for (const value of data.dictionary) {
+    if (typeof value !== 'string') {
+      throw new Error(`GPU analytics dictionary column "${columnName}" contains a null label`);
+    }
+    values.push(value);
+  }
+  return Object.freeze({values: Object.freeze(values), ordered: data.type.isOrdered});
+}
+
+/** Ensures every non-null dictionary row references an existing category label. */
+function validateGPUAnalyticsDictionaryIndices(
+  data: Data,
+  dictionary: GPUAnalyticsDictionary,
+  validity: Uint32Array,
+  columnName: string
+): void {
+  const indices = data.values as Int32Array | Uint32Array;
+  const sourceOffset = indices.length === data.length ? 0 : (data.offset ?? 0);
+  if (sourceOffset + data.length > indices.length) {
+    throw new Error(`GPU analytics dictionary column "${columnName}" has truncated indices`);
+  }
+  for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
+    if (!validity[rowIndex]) {
+      continue;
+    }
+    const categoryIndex = indices[sourceOffset + rowIndex];
+    if (categoryIndex < 0 || categoryIndex >= dictionary.values.length) {
+      throw new Error(`GPU analytics dictionary column "${columnName}" has an invalid index`);
+    }
+  }
+}
+
+/** Verifies independently supplied record batches use the same category encoding. */
+function areGPUAnalyticsDictionariesEqual(
+  first: GPUAnalyticsDictionary,
+  second: GPUAnalyticsDictionary
+): boolean {
+  return (
+    first.ordered === second.ordered &&
+    first.values.length === second.values.length &&
+    first.values.every((value, index) => value === second.values[index])
+  );
+}
+
+/** Reuses the existing Arrow GPU uploader while giving zero-row chunks usable storage capacity. */
+function makeGPUAnalyticsData(
+  device: Device,
+  source: Data,
+  format: GPUAnalyticsVectorFormat,
+  bufferProps: GPUVectorBufferProps
+): GPUData {
+  if (source.length > 0) {
+    return makeGPUDataFromArrowData(device, source, {...bufferProps, format});
+  }
+
+  const buffer = device.createBuffer({...bufferProps, byteLength: 4});
+  try {
+    return new GPUData({
+      buffer,
+      format,
+      length: 0,
+      stride: 1,
+      byteStride: 4,
+      rowByteLength: 4,
+      dataType: source.type,
+      ownsBuffer: true
+    });
+  } catch (error) {
+    buffer.destroy();
+    throw error;
+  }
+}
+
+/** Stores row-aligned validity in a separate owned GPU buffer for each source record batch. */
+function makeGPUAnalyticsValidityData(
+  device: Device,
+  validity: Uint32Array,
+  bufferProps: GPUVectorBufferProps
+): GPUData<'uint32'> {
+  const values = validity.length > 0 ? validity : new Uint32Array(1);
+  const buffer = device.createBuffer({...bufferProps, data: values});
+  try {
+    return new GPUData({
+      buffer,
+      format: 'uint32',
+      length: validity.length,
+      ownsBuffer: true
+    });
+  } catch (error) {
+    buffer.destroy();
+    throw error;
+  }
+}
+
+/** Copies source field nullability and metadata into the generic Arrow-free GPU schema. */
+function makeGPUAnalyticsField(column: PreparedGPUAnalyticsColumn): GPUField {
+  return {
+    name: column.field.name,
+    format: column.format,
+    nullable: column.field.nullable,
+    metadata: new Map(column.field.metadata)
+  };
+}

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -217,6 +217,13 @@ export {
   type PrepareArrowInputProps
 } from './arrow/gpu/arrow-input-schema';
 export {
+  makeGPUAnalyticsTableFromArrowTable,
+  type GPUAnalyticsDictionary,
+  type GPUAnalyticsTableFromArrowTableProps,
+  type GPUAnalyticsTableFromArrowTableResult,
+  type GPUAnalyticsTypeMapForArrow
+} from './arrow/gpu/arrow-gpu-analytics-adapters';
+export {
   getRequiredArrowGPUVectorDataType,
   makeGPUDataFromArrowData,
   makeGPURecordBatchFromArrowRecordBatch,

--- a/modules/arrow/test/arrow/arrow-gpu-analytics-adapters.node.spec.ts
+++ b/modules/arrow/test/arrow/arrow-gpu-analytics-adapters.node.spec.ts
@@ -1,0 +1,551 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+
+import {makeGPUAnalyticsTableFromArrowTable} from '@luma.gl/arrow';
+import {Buffer, type BufferProps} from '@luma.gl/core';
+import {GPUData, GPURecordBatch, GPUTable, GPUVector} from '@luma.gl/tables';
+import {NullDevice} from '@luma.gl/test-utils';
+import * as arrow from 'apache-arrow';
+import {describe, expect, test, vi} from 'vitest';
+
+type AnalyticsDictionaryIndex = arrow.Int32 | arrow.Uint32;
+type AnalyticsDictionaryType = arrow.Dictionary<arrow.Utf8, AnalyticsDictionaryIndex>;
+
+describe('makeGPUAnalyticsTableFromArrowTable package boundaries', () => {
+  test('keeps Arrow ingestion in its adapter package without introducing experimental cycles', () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
+    ) as {
+      dependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+    };
+
+    expect(typeof makeGPUAnalyticsTableFromArrowTable).toBe('function');
+    expect(packageJson.dependencies?.['apache-arrow']).toBeDefined();
+    expect(packageJson.dependencies?.['@luma.gl/tables']).toBeDefined();
+    expect(packageJson.dependencies?.['@luma.gl/experimental']).toBeUndefined();
+    expect(packageJson.peerDependencies?.['@luma.gl/experimental']).toBeUndefined();
+  });
+});
+
+describe('makeGPUAnalyticsTableFromArrowTable source preservation', () => {
+  test('uploads analytics columns without shader metadata while preserving source batches', async () => {
+    const device = new NullDevice({id: 'arrow-analytics-source'});
+    const source = createAnalyticsTable();
+    const submit = vi.spyOn(device, 'submit');
+    const createCommandEncoder = vi.spyOn(device, 'createCommandEncoder');
+    const result = makeGPUAnalyticsTableFromArrowTable(device, source);
+
+    expect(result.table).toBeInstanceOf(GPUTable);
+    expect(result.table.numRows).toBe(5);
+    expect(result.table.numCols).toBe(4);
+    expect(result.table.batches).toHaveLength(3);
+    expect(result.table.batches.every(batch => batch instanceof GPURecordBatch)).toBe(true);
+    expect(result.table.batches.map(batch => batch.numRows)).toEqual([2, 0, 3]);
+    expect(result.table.batches.map(batch => batch.sourceInfo)).toEqual([
+      {sourceBatchIndex: 0, sourceRowIndexOffset: 0, sourceRowCount: 2},
+      {sourceBatchIndex: 1, sourceRowIndexOffset: 2, sourceRowCount: 0},
+      {sourceBatchIndex: 2, sourceRowIndexOffset: 2, sourceRowCount: 3}
+    ]);
+    expect(
+      result.table.schema.fields.map(field => [field.name, field.format, field.nullable])
+    ).toEqual([
+      ['fare', 'float32', true],
+      ['distance', 'sint32', false],
+      ['category', 'sint32', true],
+      ['zone', 'uint32', false]
+    ]);
+    expect(result.table.bufferLayout.map(layout => layout.name)).toEqual([
+      'fare',
+      'distance',
+      'category',
+      'zone'
+    ]);
+    expect(result.table.gpuVectors['fare']).toBeInstanceOf(GPUVector);
+    expect(result.table.gpuVectors['fare'].data.map(data => data.length)).toEqual([2, 0, 3]);
+    expect(result.table.gpuVectors['category'].dataType).toBeInstanceOf(arrow.Dictionary);
+    expect(result.table.gpuVectors['fare'].data[1].buffer.byteLength).toBeGreaterThanOrEqual(4);
+
+    for (const batch of result.table.batches) {
+      for (const data of Object.values(batch.gpuData)) {
+        expect(data).toBeInstanceOf(GPUData);
+        expect(data.ownsBuffer).toBe(true);
+        expect(data.buffer.usage & Buffer.STORAGE).not.toBe(0);
+      }
+    }
+
+    expect(await readWords(result.table.gpuVectors['zone'])).toEqual([[7, 8], [], [9, 10, 11]]);
+    expect(submit).not.toHaveBeenCalled();
+    expect(createCommandEncoder).not.toHaveBeenCalled();
+
+    submit.mockRestore();
+    createCommandEncoder.mockRestore();
+    destroyAnalyticsResult(result);
+  });
+
+  test('keeps table, field, and source-batch metadata independent', () => {
+    const device = new NullDevice({id: 'arrow-analytics-metadata'});
+    const source = createAnalyticsTable();
+    const result = makeGPUAnalyticsTableFromArrowTable(device, source);
+
+    expect(result.table.schema.metadata.get('dataset')).toBe('taxi-rides');
+    expect(result.table.schema.metadata.get('scope')).toBe('table');
+    expect(result.table.batches.map(batch => batch.schema.metadata.get('batch'))).toEqual([
+      '0',
+      '1',
+      '2'
+    ]);
+    expect(result.table.schema.fields[0]?.metadata?.get('unit')).toBe('USD');
+
+    result.table.schema.metadata.set('scope', 'projected');
+    result.table.schema.fields[0]?.metadata?.set('unit', 'changed');
+    result.table.batches[0].schema.metadata.set('batch', 'changed');
+
+    expect(source.schema.metadata.get('scope')).toBe('table');
+    expect(source.schema.fields[0]?.metadata.get('unit')).toBe('USD');
+    expect(source.batches[0].schema.metadata.get('batch')).toBe('0');
+    expect(result.table.batches[1].schema.metadata.get('batch')).toBe('1');
+
+    destroyAnalyticsResult(result);
+  });
+
+  test('preserves caller-selected column ordering and supports zero-column batches', () => {
+    const device = new NullDevice({id: 'arrow-analytics-selection'});
+    const source = createAnalyticsTable();
+    const selected = makeGPUAnalyticsTableFromArrowTable(device, source, {
+      columns: ['category', 'fare']
+    });
+    const empty = makeGPUAnalyticsTableFromArrowTable(device, source, {columns: []});
+
+    expect(selected.table.schema.fields.map(field => field.name)).toEqual(['category', 'fare']);
+    expect(Object.keys(selected.table.gpuVectors)).toEqual(['category', 'fare']);
+    expect(Object.keys(selected.validity)).toEqual(['category', 'fare']);
+    expect(Object.keys(selected.dictionaries)).toEqual(['category']);
+    expect(selected.nullCounts).toEqual({category: [1, 0, 1], fare: [1, 0, 1]});
+
+    expect(empty.table.numRows).toBe(5);
+    expect(empty.table.numCols).toBe(0);
+    expect(empty.table.batches.map(batch => batch.numRows)).toEqual([2, 0, 3]);
+    expect(empty.table.batches.map(batch => Object.keys(batch.gpuData))).toEqual([[], [], []]);
+    expect(empty.validity).toEqual({});
+    expect(empty.dictionaries).toEqual({});
+    expect(empty.nullCounts).toEqual({});
+
+    destroyAnalyticsResult(selected);
+    destroyAnalyticsResult(empty);
+  });
+
+  test('distinguishes an empty schema-only Arrow table from an explicit empty source batch', () => {
+    const device = new NullDevice({id: 'arrow-analytics-empty'});
+    const source = createAnalyticsTable();
+    const createBuffer = vi.spyOn(device, 'createBuffer');
+    const schemaOnly = makeGPUAnalyticsTableFromArrowTable(device, new arrow.Table(source.schema));
+
+    expect(schemaOnly.table.numRows).toBe(0);
+    expect(schemaOnly.table.batches).toEqual([]);
+    expect(schemaOnly.table.schema.fields.map(field => field.name)).toEqual([
+      'fare',
+      'distance',
+      'category',
+      'zone'
+    ]);
+    expect(schemaOnly.table.schema.metadata.get('dataset')).toBe('taxi-rides');
+    expect(schemaOnly.validity).toEqual({});
+    expect(schemaOnly.dictionaries).toEqual({});
+    expect(createBuffer).not.toHaveBeenCalled();
+
+    const explicitEmpty = makeGPUAnalyticsTableFromArrowTable(
+      device,
+      new arrow.Table(source.schema, [source.batches[1]])
+    );
+    expect(explicitEmpty.table.batches).toHaveLength(1);
+    expect(explicitEmpty.table.batches[0].numRows).toBe(0);
+    expect(explicitEmpty.table.gpuVectors['fare'].data[0].length).toBe(0);
+    expect(explicitEmpty.table.gpuVectors['fare'].data[0].buffer.byteLength).toBeGreaterThanOrEqual(
+      4
+    );
+    expect(explicitEmpty.validity['fare']?.data[0].length).toBe(0);
+    expect(explicitEmpty.validity['fare']?.data[0].buffer.byteLength).toBeGreaterThanOrEqual(4);
+
+    createBuffer.mockRestore();
+    destroyAnalyticsResult(schemaOnly);
+    destroyAnalyticsResult(explicitEmpty);
+  });
+});
+
+describe('makeGPUAnalyticsTableFromArrowTable GPU validity', () => {
+  test('expands sliced Arrow validity bitmaps into separate source-aligned uint32 vectors', async () => {
+    const device = new NullDevice({id: 'arrow-analytics-validity'});
+    const source = createAnalyticsTable();
+    const result = makeGPUAnalyticsTableFromArrowTable(device, source);
+
+    expect(source.nullCount).toBe(0);
+    expect(source.batches.map(batch => batch.nullCount)).toEqual([0, 0, 0]);
+    expect(Object.keys(result.validity)).toEqual(['fare', 'category']);
+    expect(result.validity['fare']?.format).toBe('uint32');
+    expect(result.validity['fare']?.data.map(data => data.length)).toEqual([2, 0, 3]);
+    expect(result.validity['category']?.data.map(data => data.length)).toEqual([2, 0, 3]);
+    expect(await readWords(result.validity['fare']!)).toEqual([[0, 1], [], [0, 1, 1]]);
+    expect(await readWords(result.validity['category']!)).toEqual([[1, 0], [], [1, 0, 1]]);
+    expect(result.nullCounts).toEqual({
+      fare: [1, 0, 1],
+      distance: [0, 0, 0],
+      category: [1, 0, 1],
+      zone: [0, 0, 0]
+    });
+
+    for (const [columnName, validity] of Object.entries(result.validity)) {
+      for (const [batchIndex, data] of validity!.data.entries()) {
+        expect(data.ownsBuffer).toBe(true);
+        expect(data.buffer.usage & Buffer.STORAGE).not.toBe(0);
+        expect(data.buffer).not.toBe(result.table.batches[batchIndex].gpuData[columnName].buffer);
+      }
+    }
+
+    destroyAnalyticsResult(result);
+  });
+
+  test('materializes all-valid masks for nullable fields even when no bitmap was allocated', async () => {
+    const device = new NullDevice({id: 'arrow-analytics-all-valid'});
+    const field = new arrow.Field('fare', new arrow.Float32(), true);
+    const schema = new arrow.Schema([field]);
+    const values = arrow.makeVector(new Float32Array([10, 20, 30]));
+    const batch = new arrow.RecordBatch(
+      schema,
+      arrow.makeData({
+        type: new arrow.Struct(schema.fields),
+        length: values.length,
+        children: [values.data[0]]
+      })
+    );
+    const source = new arrow.Table(schema, [batch]);
+    const result = makeGPUAnalyticsTableFromArrowTable(device, source);
+
+    expect(source.schema.fields[0]?.nullable).toBe(true);
+    expect(result.validity['fare']).toBeInstanceOf(GPUVector);
+    expect(await readWords(result.validity['fare']!)).toEqual([[1, 1, 1]]);
+    expect(result.nullCounts['fare']).toEqual([0]);
+
+    destroyAnalyticsResult(result);
+  });
+
+  test('rejects positive null counts when Arrow validity bytes are missing or inconsistent', () => {
+    const device = new NullDevice({id: 'arrow-analytics-malformed-validity'});
+    const type = new arrow.Float32();
+    const missingBitmap = arrow.makeData({
+      type,
+      length: 3,
+      data: new Float32Array([1, 2, 3]),
+      nullCount: 1
+    });
+    const wrongCount = arrow.makeData({
+      type,
+      length: 3,
+      data: new Float32Array([1, 2, 3]),
+      nullBitmap: new Uint8Array([0b00000111]),
+      nullCount: 1
+    });
+
+    for (const data of [missingBitmap, wrongCount]) {
+      const source = new arrow.Table([new arrow.RecordBatch({fare: data})]);
+      expect(() => makeGPUAnalyticsTableFromArrowTable(device, source)).toThrow(
+        /validity|bitmap|null/i
+      );
+    }
+  });
+
+  test('rejects source null values declared through a nonnullable schema field', () => {
+    const device = new NullDevice({id: 'arrow-analytics-invalid-nonnullable'});
+    const field = new arrow.Field('fare', new arrow.Float32(), false);
+    const schema = new arrow.Schema([field]);
+    const data = arrow.vectorFromArray([1, null, 3], new arrow.Float32()).data[0];
+    const batch = new arrow.RecordBatch(
+      schema,
+      arrow.makeData({type: new arrow.Struct(schema.fields), length: 3, children: [data]})
+    );
+
+    expect(() =>
+      makeGPUAnalyticsTableFromArrowTable(device, new arrow.Table(schema, [batch]))
+    ).toThrow(/nullable|null|validity/i);
+  });
+});
+
+describe('makeGPUAnalyticsTableFromArrowTable categorical dictionaries', () => {
+  test.each([
+    {indexType: new arrow.Int32(), format: 'sint32'},
+    {indexType: new arrow.Uint32(), format: 'uint32'}
+  ])('preserves ordered UTF-8 dictionary labels and $format GPU indices', ({indexType, format}) => {
+    const device = new NullDevice({id: `arrow-analytics-dictionary-${format}`});
+    const source = createAnalyticsTable({dictionaryIndexType: indexType});
+    const result = makeGPUAnalyticsTableFromArrowTable(device, source, {columns: ['category']});
+
+    expect(result.table.gpuVectors['category'].format).toBe(format);
+    expect(result.dictionaries['category']).toEqual({
+      values: ['economy', 'premium', 'business'],
+      ordered: true
+    });
+    expect(result.nullCounts['category']).toEqual([1, 0, 1]);
+
+    destroyAnalyticsResult(result);
+  });
+
+  test('rejects dictionaries whose labels change across preserved source batches', () => {
+    const device = new NullDevice({id: 'arrow-analytics-dictionary-mismatch'});
+    const source = createAnalyticsTable({
+      dictionaryLabelsByBatch: [
+        ['economy', 'premium', 'business'],
+        ['economy', 'premium', 'business'],
+        ['premium', 'economy', 'business']
+      ]
+    });
+
+    expect(() => makeGPUAnalyticsTableFromArrowTable(device, source)).toThrow(
+      /dictionary|categorical|labels/i
+    );
+  });
+
+  test('rejects dictionary labels that would decode apparently valid rows as null', () => {
+    const device = new NullDevice({id: 'arrow-analytics-null-dictionary'});
+    const labels = arrow.vectorFromArray([null, 'premium'], new arrow.Utf8());
+    const dictionaryType = new arrow.Dictionary(new arrow.Utf8(), new arrow.Int32());
+    const data = arrow.makeData({
+      type: dictionaryType,
+      length: 2,
+      data: new Int32Array([0, 1]),
+      dictionary: labels
+    });
+    const source = new arrow.Table([new arrow.RecordBatch({category: data})]);
+
+    expect(() => makeGPUAnalyticsTableFromArrowTable(device, source)).toThrow(
+      /dictionary|null|label/i
+    );
+  });
+});
+
+describe('makeGPUAnalyticsTableFromArrowTable unsupported inputs and ownership', () => {
+  test.each([
+    ['Float64', arrow.vectorFromArray([1, 2], new arrow.Float64())],
+    ['Int64', arrow.vectorFromArray([1n, 2n], new arrow.Int64())],
+    ['Utf8', arrow.vectorFromArray(['alpha', 'beta'], new arrow.Utf8())],
+    ['Int8', arrow.vectorFromArray([1, 2], new arrow.Int8())],
+    ['Uint16', arrow.vectorFromArray([1, 2], new arrow.Uint16())]
+  ])('rejects unsupported browser-portable analytics type %s before allocating', (_name, vector) => {
+    const device = new NullDevice({id: 'arrow-analytics-unsupported'});
+    const createBuffer = vi.spyOn(device, 'createBuffer');
+    const source = new arrow.Table([new arrow.RecordBatch({unsupported: vector.data[0]})]);
+
+    expect(() => makeGPUAnalyticsTableFromArrowTable(device, source)).toThrow(
+      /unsupported|float|int|string|utf/i
+    );
+    expect(createBuffer).not.toHaveBeenCalled();
+    createBuffer.mockRestore();
+  });
+
+  test('rejects narrow dictionary indices before allocating GPU storage', () => {
+    const device = new NullDevice({id: 'arrow-analytics-narrow-dictionary'});
+    const createBuffer = vi.spyOn(device, 'createBuffer');
+    const dictionary = arrow.vectorFromArray(['economy', 'premium'], new arrow.Utf8());
+    const dictionaryType = new arrow.Dictionary(new arrow.Utf8(), new arrow.Int8());
+    const data = arrow.makeData({
+      type: dictionaryType,
+      length: 2,
+      data: new Int8Array([0, 1]),
+      dictionary
+    });
+
+    expect(() =>
+      makeGPUAnalyticsTableFromArrowTable(
+        device,
+        new arrow.Table([new arrow.RecordBatch({category: data})])
+      )
+    ).toThrow(/unsupported|dictionary|int/i);
+    expect(createBuffer).not.toHaveBeenCalled();
+    createBuffer.mockRestore();
+  });
+
+  test('rejects unknown and duplicated selected columns before allocating', () => {
+    const device = new NullDevice({id: 'arrow-analytics-invalid-columns'});
+    const source = createAnalyticsTable();
+    const createBuffer = vi.spyOn(device, 'createBuffer');
+
+    expect(() =>
+      makeGPUAnalyticsTableFromArrowTable(device, source, {columns: ['fare', 'missing']})
+    ).toThrow(/column|missing/i);
+    expect(() =>
+      makeGPUAnalyticsTableFromArrowTable(device, source, {columns: ['fare', 'fare']})
+    ).toThrow(/column|duplicate|once/i);
+    expect(createBuffer).not.toHaveBeenCalled();
+
+    createBuffer.mockRestore();
+  });
+
+  test('rejects shared external buffer handles and incompatible mapped-buffer usage', () => {
+    const device = new NullDevice({id: 'arrow-analytics-buffer-ownership'});
+    const source = createAnalyticsTable();
+    const createBuffer = vi.spyOn(device, 'createBuffer');
+
+    expect(() =>
+      makeGPUAnalyticsTableFromArrowTable(device, source, {
+        bufferProps: {handle: {external: true}}
+      })
+    ).toThrow(/handle|borrow|owned|buffer/i);
+    expect(() =>
+      makeGPUAnalyticsTableFromArrowTable(device, source, {
+        bufferProps: {_isHandleBorrowed: true}
+      })
+    ).toThrow(/handle|borrow|owned|buffer/i);
+    expect(() =>
+      makeGPUAnalyticsTableFromArrowTable(device, source, {
+        bufferProps: {usage: Buffer.MAP_READ}
+      })
+    ).toThrow(/map|usage|storage/i);
+    expect(() =>
+      makeGPUAnalyticsTableFromArrowTable(device, source, {
+        bufferProps: {usage: Buffer.MAP_WRITE}
+      })
+    ).toThrow(/map|usage|storage/i);
+    expect(() =>
+      makeGPUAnalyticsTableFromArrowTable(device, source, {
+        bufferProps: {byteOffset: 4}
+      })
+    ).toThrow(/offset|buffer|layout/i);
+    expect(createBuffer).not.toHaveBeenCalled();
+
+    createBuffer.mockRestore();
+  });
+
+  test('destroys every already-created GPU allocation if a later upload fails', () => {
+    const device = new NullDevice({id: 'arrow-analytics-cleanup'});
+    const source = createAnalyticsTable();
+    const allocatedBuffers: Buffer[] = [];
+    const createBuffer = device.createBuffer.bind(device);
+    const createBufferSpy = vi
+      .spyOn(device, 'createBuffer')
+      .mockImplementation((props: BufferProps) => {
+        if (allocatedBuffers.length === 4) {
+          throw new Error('injected analytics upload failure');
+        }
+        const buffer = createBuffer(props);
+        allocatedBuffers.push(buffer);
+        return buffer;
+      });
+
+    expect(() => makeGPUAnalyticsTableFromArrowTable(device, source)).toThrow(/injected/i);
+    expect(allocatedBuffers).toHaveLength(4);
+    expect(allocatedBuffers.every(buffer => buffer.destroyed)).toBe(true);
+
+    createBufferSpy.mockRestore();
+  });
+});
+
+type AnalyticsTableFixtureOptions = {
+  dictionaryIndexType?: AnalyticsDictionaryIndex;
+  dictionaryLabelsByBatch?: readonly (readonly string[])[];
+};
+
+function createAnalyticsTable({
+  dictionaryIndexType = new arrow.Int32(),
+  dictionaryLabelsByBatch
+}: AnalyticsTableFixtureOptions = {}): arrow.Table {
+  const dictionaryType = new arrow.Dictionary(new arrow.Utf8(), dictionaryIndexType, 41, true);
+  const fields = [
+    new arrow.Field('fare', new arrow.Float32(), true, new Map([['unit', 'USD']])),
+    new arrow.Field('distance', new arrow.Int32(), false),
+    new arrow.Field('category', dictionaryType, true),
+    new arrow.Field('zone', new arrow.Uint32(), false)
+  ];
+  const schema = new arrow.Schema(
+    fields,
+    new Map([
+      ['dataset', 'taxi-rides'],
+      ['scope', 'table']
+    ])
+  );
+  const fares = arrow.vectorFromArray(
+    [0, 1, 2, 3, 4, 5, 6, null, 8, null, 10, 11, null, 13],
+    new arrow.Float32()
+  );
+  const distances = arrow.vectorFromArray(
+    new Int32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),
+    new arrow.Int32()
+  );
+  const zones = arrow.vectorFromArray(
+    new Uint32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),
+    new arrow.Uint32()
+  );
+  const rowRanges = [
+    [7, 9],
+    [9, 9],
+    [9, 12]
+  ] as const;
+
+  const batches = rowRanges.map(([start, end], batchIndex) => {
+    const labels = dictionaryLabelsByBatch?.[batchIndex] ?? ['economy', 'premium', 'business'];
+    const categories = createDictionaryVector(dictionaryType, labels);
+    const children = [
+      fares.slice(start, end).data[0],
+      distances.slice(start, end).data[0],
+      categories.slice(start, end).data[0],
+      zones.slice(start, end).data[0]
+    ];
+    const batchSchema = new arrow.Schema(
+      fields,
+      new Map([
+        ['batch', String(batchIndex)],
+        ['scope', 'batch']
+      ])
+    );
+    return new arrow.RecordBatch(
+      batchSchema,
+      arrow.makeData({
+        type: new arrow.Struct(batchSchema.fields),
+        length: end - start,
+        children
+      })
+    );
+  });
+
+  return new arrow.Table(schema, batches);
+}
+
+function createDictionaryVector(
+  dictionaryType: AnalyticsDictionaryType,
+  labels: readonly string[]
+): arrow.Vector<AnalyticsDictionaryType> {
+  const dictionary = arrow.vectorFromArray(labels, new arrow.Utf8());
+  const Constructor = dictionaryType.indices instanceof arrow.Uint32 ? Uint32Array : Int32Array;
+  const indices = new Constructor([0, 1, 2, 0, 1, 2, 0, 1, 0, 2, 1, 0, 2, 1]);
+  const nullBitmap = new Uint8Array([0b11111111, 0b11111010]);
+  const data = arrow.makeData({
+    type: dictionaryType,
+    length: indices.length,
+    data: indices,
+    nullBitmap,
+    nullCount: 2,
+    dictionary
+  });
+
+  return new arrow.Vector([data]) as arrow.Vector<AnalyticsDictionaryType>;
+}
+
+async function readWords(vector: GPUVector): Promise<number[][]> {
+  return Promise.all(
+    vector.data.map(async data => {
+      if (data.length === 0) return [];
+      const bytes = await data.buffer.readAsync(data.byteOffset, data.length * data.byteStride);
+      const values = new Uint32Array(bytes.buffer, bytes.byteOffset, data.length);
+      return Array.from(values);
+    })
+  );
+}
+
+function destroyAnalyticsResult(result: {
+  table: GPUTable;
+  validity: Partial<Record<string, GPUVector<'uint32'>>>;
+}): void {
+  result.table.destroy();
+  for (const validity of Object.values(result.validity)) validity?.destroy();
+}

--- a/modules/arrow/test/arrow/arrow-gpu-analytics-adapters.spec.ts
+++ b/modules/arrow/test/arrow/arrow-gpu-analytics-adapters.spec.ts
@@ -1,0 +1,170 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {makeGPUAnalyticsTableFromArrowTable} from '@luma.gl/arrow';
+import {Buffer} from '@luma.gl/core';
+import {type GPUVector} from '@luma.gl/tables';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import * as arrow from 'apache-arrow';
+import test from 'test/utils/vitest-tape';
+import {vi} from 'vitest';
+
+test('Arrow analytics ingestion preserves WebGPU batches, sliced validity, and dictionaries', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const source = createBrowserAnalyticsTable();
+  const submit = vi.spyOn(device, 'submit');
+  const createCommandEncoder = vi.spyOn(device, 'createCommandEncoder');
+  const result = makeGPUAnalyticsTableFromArrowTable(device, source);
+
+  try {
+    testContext.deepEqual(
+      result.table.batches.map(batch => batch.numRows),
+      [2, 0, 3],
+      'preserves uneven and empty Arrow record batches'
+    );
+    testContext.deepEqual(
+      result.table.batches.map(batch => batch.sourceInfo),
+      [
+        {sourceBatchIndex: 0, sourceRowIndexOffset: 0, sourceRowCount: 2},
+        {sourceBatchIndex: 1, sourceRowIndexOffset: 2, sourceRowCount: 0},
+        {sourceBatchIndex: 2, sourceRowIndexOffset: 2, sourceRowCount: 3}
+      ],
+      'retains stable source identities without reading rows'
+    );
+    testContext.deepEqual(
+      result.table.schema.fields.map(field => [field.name, field.format]),
+      [
+        ['fare', 'float32'],
+        ['category', 'uint32']
+      ],
+      'uploads portable numerical values and dictionary indices'
+    );
+    testContext.deepEqual(
+      result.dictionaries['category'],
+      {values: ['economy', 'premium'], ordered: true},
+      'retains dictionary labels exclusively as adapter-owned metadata'
+    );
+    testContext.deepEqual(
+      result.nullCounts,
+      {fare: [1, 0, 1], category: [0, 0, 0]},
+      'retains accurate per-column and per-batch null counts'
+    );
+
+    for (const [batchIndex, batch] of result.table.batches.entries()) {
+      for (const [columnName, data] of Object.entries(batch.gpuData)) {
+        testContext.ok(data.buffer.usage & Buffer.STORAGE, 'source chunks support GPU analytics');
+        testContext.ok(data.ownsBuffer, 'source chunks retain explicit GPU ownership');
+        testContext.notEqual(
+          result.validity[columnName]?.data[batchIndex].buffer,
+          data.buffer,
+          'validity occupies a separate GPU-backed sidecar'
+        );
+        if (batch.numRows === 0) {
+          testContext.ok(
+            data.buffer.byteLength >= 4,
+            'empty source batches retain bindable nonzero physical allocations'
+          );
+          testContext.ok(
+            (result.validity[columnName]?.data[batchIndex].buffer.byteLength ?? 0) >= 4,
+            'empty validity chunks retain bindable nonzero physical allocations'
+          );
+        }
+      }
+    }
+
+    testContext.equal(submit.mock.calls.length, 0, 'ingestion never submits GPU command work');
+    testContext.equal(
+      createCommandEncoder.mock.calls.length,
+      0,
+      'ingestion never creates command encoders'
+    );
+
+    submit.mockRestore();
+    createCommandEncoder.mockRestore();
+
+    testContext.deepEqual(
+      await readGPUValidity(result.validity['fare']!),
+      [[0, 1], [], [0, 1, 1]],
+      'normalizes sliced Arrow bitmaps to per-row WebGPU validity masks'
+    );
+    testContext.deepEqual(
+      await readGPUValidity(result.validity['category']!),
+      [[1, 1], [], [1, 1, 1]],
+      'materializes all-valid nullable dictionary sidecars'
+    );
+  } finally {
+    submit.mockRestore();
+    createCommandEncoder.mockRestore();
+    const ownedBuffers = [
+      ...result.table.batches.flatMap(batch =>
+        Object.values(batch.gpuData).map(data => data.buffer)
+      ),
+      ...Object.values(result.validity).flatMap(vector => vector!.data.map(data => data.buffer))
+    ];
+    result.table.destroy();
+    for (const validity of Object.values(result.validity)) validity?.destroy();
+    testContext.ok(
+      ownedBuffers.every(buffer => buffer.destroyed),
+      'source chunks and independent validity sidecars release exactly their owned allocations'
+    );
+  }
+
+  testContext.end();
+});
+
+function createBrowserAnalyticsTable(): arrow.Table {
+  const dictionaryType = new arrow.Dictionary(new arrow.Utf8(), new arrow.Uint32(), 12, true);
+  const dictionary = arrow.vectorFromArray(['economy', 'premium'], new arrow.Utf8());
+  const fields = [
+    new arrow.Field('fare', new arrow.Float32(), true),
+    new arrow.Field('category', dictionaryType, true)
+  ];
+  const schema = new arrow.Schema(fields);
+  const fares = arrow.vectorFromArray(
+    [0, 1, 2, 3, 4, 5, 6, null, 8, null, 10, 11],
+    new arrow.Float32()
+  );
+  const categoryData = arrow.makeData({
+    type: dictionaryType,
+    length: 12,
+    data: new Uint32Array([0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]),
+    dictionary
+  });
+  const categories = new arrow.Vector([categoryData]);
+  const ranges = [
+    [7, 9],
+    [9, 9],
+    [9, 12]
+  ] as const;
+
+  const batches = ranges.map(
+    ([start, end]) =>
+      new arrow.RecordBatch(
+        schema,
+        arrow.makeData({
+          type: new arrow.Struct(schema.fields),
+          length: end - start,
+          children: [fares.slice(start, end).data[0], categories.slice(start, end).data[0]]
+        })
+      )
+  );
+
+  return new arrow.Table(schema, batches);
+}
+
+async function readGPUValidity(vector: GPUVector<'uint32'>): Promise<number[][]> {
+  return Promise.all(
+    vector.data.map(async data => {
+      if (data.length === 0) return [];
+      const bytes = await data.buffer.readAsync(data.byteOffset, data.length * data.byteStride);
+      return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, data.length));
+    })
+  );
+}

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -10,6 +10,7 @@ import './arrow/arrow-path-model.spec';
 import './arrow/arrow-splats.spec';
 import './arrow/dggs-gpu-polygons.spec';
 import './arrow/arrow-geometry.spec';
+import './arrow/arrow-gpu-analytics-adapters.spec';
 import './arrow/plain-gpu-table.spec';
 import './arrow/arrow-model.spec';
 import './arrow/arrow-shader-layout.spec';


### PR DESCRIPTION
## Goals

Provide a renderer-independent Apache Arrow ingestion path for browser-native GPU analytics and the optional luDF dataframe foundation in #2933, while preserving existing package boundaries and ownership semantics.

## Changes

- Add `makeGPUAnalyticsTableFromArrowTable` to `@luma.gl/arrow`; reuse existing `GPUTable`, `GPURecordBatch`, `GPUVector`, and `GPUData` objects without requiring shader-layout metadata or introducing Arrow dependencies into tables, GPGPU, or experimental packages.
- Support portable Arrow `Float32`, `Int32`, `Uint32`, and UTF-8 dictionary columns with signed/unsigned 32-bit indices; infer exact GPU storage formats from typed Arrow schemas.
- Preserve original record batches, column chunks, stable source-row offsets, projected column ordering, independent table/batch/field metadata, and per-column/per-batch null counts.
- Expand sliced Arrow validity bitmaps into separate, batch-aligned GPU `uint32` validity vectors; retain immutable dictionary labels and ordering as explicit adapter metadata.
- Preserve empty batches using bindable four-byte physical storage with zero logical rows, reject malformed bitmaps/dictionaries and unsafe external buffer options, and destroy all owned allocations when ingestion fails.
- Add 22 focused Node regressions plus a real Chromium/WebGPU integration test covering sliced null bitmaps, dictionary categories, empty batches, ownership cleanup, unsupported formats, and unsafe buffer options.

## Verification

- `nvm use`: Node `22.22.1`, matching `.nvmrc`.
- `yarn install`: attempted, but the enterprise package registry returns HTTP 403 for upstream `@vis.gl/dev-tools@2.0.0-alpha.4`; reused the existing dependency tree with ignored local compatibility shims instead.
- `yarn lint fix`: passed across 1,527 files.
- `yarn build`: passed for every workspace package after the final formatting and API changes.
- Focused Node tests: **22 passed**.
- Focused real Chromium/WebGPU test: **1 passed**, including device acquisition and GPU-buffer readback.
- `CI=1 yarn test`: **565 Node tests passed** and **1,554 browser tests passed**, with existing skipped tests unchanged.
- `yarn website:build`: passed.
- `(cd website && yarn build)`: passed.
- `yarn examples:typecheck`: passed.
- `yarn bundle-size`: all existing budgets passed.
- Built ESM/CJS exports and strict NodeNext declarations were verified against #2933; typed Arrow schemas infer exact GPU formats, `new LuDataFrame({...analytics, ownership: 'owned'})` compiles, projections preserve generic narrowing, and all 12 owned runtime buffers are destroyed only after the final projected dataframe is released.

## Risks and follow-up

- This intentionally supports only WebGPU-portable 32-bit scalar and dictionary-index formats; native Float64/Int64, arbitrary GPU strings, and changing dictionary encodings remain unsupported.
- Nullable values use explicit row-aligned GPU validity sidecars rather than silently treating Arrow nulls as valid.
- Expression compilation, filtering, aggregation, sorting, joins, documentation, and benchmarks remain separate independently reviewable luDF increments.
