### PR TITLE
feat(splats): add WebGPU command-graph renderer

### DIFF
--- a/docs/api-reference/splats/README.md
+++ b/docs/api-reference/splats/README.md
@@ -37,6 +37,38 @@ nextSplatBatch.destroy();
 but never destroys caller-owned splat data. Appending new batches preserves their original order
 and does not concatenate source data or reupload existing batches.
 
+## WebGPU command-graph renderer
+
+`GPUSplatGraphRenderer` is a WebGPU-only renderer designed for large streamed captures:
+
+```ts
+import {GPUSplatGraphRenderer} from '@luma.gl/splats';
+
+const renderer = new GPUSplatGraphRenderer(webgpuDevice, {
+  data: preparedBatches,
+  viewportSize: [width, height]
+});
+
+const commandEncoder = webgpuDevice.createCommandEncoder();
+const encoding = renderer.encode(commandEncoder);
+webgpuDevice.submit(commandEncoder.finish());
+
+console.log(encoding?.stats.nodeCount, renderer.stats);
+```
+
+The compiled command graph projects and culls each original source batch into explicitly
+renderer-owned, camera-dependent records. One stable global radix sort orders all batches together,
+while GPU-written indirect draw arguments ensure that one render pass draws only visible rows. The
+graph processes 16 significant depth-key bits instead of executing the full 32-bit radix schedule.
+There are no per-frame CPU row projections, CPU depth sorts, sorted-index uploads, or implicit GPU
+readbacks.
+
+Source `GPUSplatData` objects remain borrowed, retain their original batch boundaries, and must
+outlive the renderer. Derived projected records, sort keys, graph scratch, per-batch uniforms, and
+indirect commands are explicitly owned by the graph renderer. HDR floating-point source colors,
+anisotropic covariance, opacity thresholds, exposure, and tone mapping are preserved. Continue to
+use `SplatRenderer` for WebGL2 devices or when comparing against CPU-based ordering.
+
 ## Source columns and rendering
 
 `SplatSource` contains framework-independent, decoded typed arrays. Positions and linear

--- a/examples/showcase/gaussian-splats/app.ts
+++ b/examples/showcase/gaussian-splats/app.ts
@@ -6,15 +6,22 @@ import {PanelSelect, type PanelSelectOption} from '@deck.gl-community/panels';
 import {makeGPUSplatDataFromArrowStream} from '@luma.gl/arrow';
 import type {Device} from '@luma.gl/core';
 import {AnimationLoopTemplate, type AnimationProps} from '@luma.gl/engine';
-import {OrbitControls} from '@luma.gl/experimental';
 import {
+  GPUCommandGraphInspector,
+  OrbitControls,
+  type GPUCommandGraphInspectorGraph
+} from '@luma.gl/experimental';
+import {
+  GPUSplatGraphRenderer,
   makeGPUSplatData,
   SplatRenderer,
   type GPUSplatData,
+  type SplatRendererProps,
   type SplatSortMode
 } from '@luma.gl/splats';
 import {Matrix4} from '@math.gl/core';
 import {h, render} from 'preact';
+import {GPUCommandGraphInspectorPanel} from '../../gpu-command-graph-inspector-panel';
 import {
   GAUSSIAN_SPLAT_BATCH_COUNT,
   GAUSSIAN_SPLATS_PER_BATCH,
@@ -30,7 +37,7 @@ import {
 
 export const title = 'Gaussian Splats';
 export const description =
-  'Progressively streamed, anisotropic 3D Gaussian splats with camera-dependent sorting on WebGPU and WebGL2.';
+  'Progressively streamed Gaussian splats with a WebGPU command graph and a WebGL2 fallback.';
 
 const BATCH_INTERVAL_MILLISECONDS = 750;
 const CLEAR_COLOR: [number, number, number, number] = [0.012, 0.016, 0.042, 1];
@@ -45,6 +52,13 @@ const SPLAT_SORT_OPTIONS: readonly PanelSelectOption[] = [
   {value: 'tile', label: 'Per-tile depth sort'},
   {value: 'none', label: 'Source order'}
 ];
+const SPLAT_EXECUTION_OPTIONS: readonly PanelSelectOption[] = [
+  {value: 'graph', label: 'WebGPU command graph'},
+  {value: 'cpu', label: 'CPU depth ordering'}
+];
+
+/** Execution path resolved from the current backend and optional comparison override. */
+export type GaussianSplatExecutionMode = 'graph' | 'cpu';
 
 type GaussianSplatCameraState = {
   yaw: number;
@@ -79,8 +93,16 @@ export function makeGaussianSplatInfoHtml(): string {
     <span>Backend</span><strong data-gaussian-splats-backend>Detecting…</strong>
   </div>
   <div style="display:flex;justify-content:space-between;font-size:12px">
+    <span>Pipeline</span><strong data-gaussian-splats-pipeline>Preparing…</strong>
+  </div>
+  <div data-gaussian-splats-pipeline-error hidden role="status" style="font-size:11px;line-height:1.45;color:#ffd08a"></div>
+  <div style="display:flex;justify-content:space-between;font-size:12px">
     <span>Source</span><strong data-gaussian-splats-source>Synthetic</strong>
   </div>
+  <label data-gaussian-splats-execution-control hidden style="gap:5px;font-size:12px">
+    <span>Execution pipeline</span>
+    <div data-gaussian-splats-execution></div>
+  </label>
   <label data-gaussian-splats-scene-control hidden style="gap:5px;font-size:12px">
     <span>Gaussian splat scene</span>
     <div data-gaussian-splats-scene></div>
@@ -109,7 +131,21 @@ export function makeGaussianSplatInfoHtml(): string {
   <label style="display:flex;align-items:center;gap:8px;font-size:12px">
     <input data-gaussian-splats-orbit type="checkbox" checked /> Cinematic orbit
   </label>
+  <details data-gaussian-splats-graph-details hidden style="font-size:12px">
+    <summary style="cursor:pointer">GPU graph inspector</summary>
+    <div data-gaussian-splats-graph-inspector style="margin-top:9px"></div>
+  </details>
 </section>`;
+}
+
+/** Uses GPU graph execution only on WebGPU unless the explicit CPU comparison is requested. */
+export function getGaussianSplatExecutionMode(
+  deviceType: Device['type'],
+  locationSearch = ''
+): GaussianSplatExecutionMode {
+  return deviceType === 'webgpu' && new URLSearchParams(locationSearch).get('renderer') !== 'cpu'
+    ? 'graph'
+    : 'cpu';
 }
 
 export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTemplate {
@@ -117,9 +153,14 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
   static props = {useDevicePixels: true};
 
   readonly device: Device;
-  readonly renderer: SplatRenderer;
+  renderer: SplatRenderer | GPUSplatGraphRenderer;
   readonly batches: GPUSplatData[];
 
+  private readonly executionMode: GaussianSplatExecutionMode;
+  private readonly graphInspector: GPUCommandGraphInspector | undefined;
+  private inspectedGraph: GPUCommandGraphInspectorGraph | undefined;
+  private readonly graphInspectorPanels: GPUCommandGraphInspectorPanel[] = [];
+  private graphFallbackReason: string | undefined;
   private readonly localLoadersConfiguration: LocalGaussianSplatLoadersConfiguration | undefined;
   private canvas: HTMLCanvasElement | null = null;
   private controlDisposers: Array<() => void> = [];
@@ -149,6 +190,21 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
   constructor({device, width, height}: AnimationProps) {
     super();
     this.device = device;
+    this.executionMode = getGaussianSplatExecutionMode(
+      device.type,
+      typeof window === 'undefined' ? '' : window.location.search
+    );
+    this.graphInspector =
+      this.executionMode === 'graph'
+        ? new GPUCommandGraphInspector({
+            maxSamples: 60,
+            getNodeGroup: node => {
+              if (node.id.includes('project')) return 'project';
+              if (node.id.includes('sort') || node.id.includes('radix')) return 'sort';
+              return node.type;
+            }
+          })
+        : undefined;
     this.localLoadersConfiguration = getLocalGaussianSplatLoadersConfiguration();
     this.cameraFrame = makeGaussianSplatCameraFrame(
       this.localLoadersConfiguration?.up ?? [0, 1, 0]
@@ -188,7 +244,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
       this.autoOrbit = false;
       this.isLoading = true;
     }
-    this.renderer = new SplatRenderer(device, {
+    const rendererProps: SplatRendererProps = {
       data: firstBatch,
       viewportSize: [Math.max(width, 1), Math.max(height, 1)],
       sortMode: 'global',
@@ -197,7 +253,13 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
       alphaCutoff: 1 / 255,
       gaussianSupportRadius: 3,
       kernel2DSize: 0.35
-    });
+    };
+    // Captured scenes keep the existing progressive preview until all source batches arrive.
+    // Compiling the immutable full-scene graph once avoids rebuilding it for every Arrow batch.
+    this.renderer =
+      this.executionMode === 'graph' && !this.localLoadersConfiguration
+        ? new GPUSplatGraphRenderer(device, {...rendererProps, clearColor: CLEAR_COLOR})
+        : new SplatRenderer(device, rendererProps);
   }
 
   override async onInitialize({canvas}: AnimationProps): Promise<void> {
@@ -286,15 +348,38 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
       return;
     }
 
-    this.renderer.predraw(device.commandEncoder);
-
-    const renderPass = device.beginRenderPass({clearColor: CLEAR_COLOR, clearDepth: 1});
-    this.renderer.draw(renderPass);
-    renderPass.end();
+    let graphChanged = false;
+    const activeRenderer = this.renderer;
+    if (activeRenderer instanceof GPUSplatGraphRenderer) {
+      try {
+        const encoding = activeRenderer.encode(device.commandEncoder);
+        if (!encoding) {
+          this.needsRedraw = false;
+          return;
+        }
+        const compiledGraph = activeRenderer.compiledGraph;
+        if (compiledGraph && this.graphInspector) {
+          if (this.inspectedGraph !== compiledGraph) {
+            this.graphInspector.registerGraph(compiledGraph);
+            this.inspectedGraph = compiledGraph;
+            graphChanged = true;
+          }
+          this.graphInspector.recordEncoding(compiledGraph.id, encoding);
+        }
+      } catch (error) {
+        this.activateCpuRendererFallback(error);
+      }
+    }
+    if (this.renderer instanceof SplatRenderer) {
+      this.renderer.predraw(device.commandEncoder);
+      const renderPass = device.beginRenderPass({clearColor: CLEAR_COLOR, clearDepth: 1});
+      this.renderer.draw(renderPass);
+      renderPass.end();
+    }
     this.needsRedraw = false;
 
     this.frameIndex++;
-    if (this.frameIndex % 20 === 0) {
+    if (graphChanged || this.frameIndex % 20 === 0) {
       this.updatePanel();
     }
   }
@@ -353,7 +438,13 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
         this.fitCameraToBatches();
       }
       this.updatePanel();
-      await waitForNextAnimationFrame();
+      if (
+        this.executionMode !== 'graph' ||
+        !this.expectedSplatCount ||
+        this.loadedSplatCount < this.expectedSplatCount
+      ) {
+        await waitForNextAnimationFrame();
+      }
     }
 
     if (this.isFinalized || this.loadAbortController.signal.aborted) {
@@ -369,6 +460,43 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     this.isLoading = false;
     this.expectedBatchCount = this.batches.length;
     this.expectedSplatCount = this.loadedSplatCount;
+    if (this.executionMode === 'graph') {
+      this.activateGraphRenderer();
+    }
+    this.updatePanel();
+  }
+
+  /** Replaces the progressive CPU preview without changing caller-owned Arrow source batches. */
+  private activateGraphRenderer(): void {
+    if (this.renderer instanceof GPUSplatGraphRenderer) {
+      return;
+    }
+    const previousRenderer = this.renderer;
+    const graphRenderer = new GPUSplatGraphRenderer(this.device, {
+      ...previousRenderer.props,
+      data: this.batches,
+      clearColor: CLEAR_COLOR
+    });
+    this.renderer = graphRenderer;
+    previousRenderer.destroy();
+    this.requestRedraw();
+  }
+
+  /** Keeps a captured scene usable when the selected WebGPU adapter cannot compile its graph. */
+  private activateCpuRendererFallback(error: unknown): void {
+    if (!(this.renderer instanceof GPUSplatGraphRenderer)) {
+      return;
+    }
+    const previousRenderer = this.renderer;
+    this.renderer = new SplatRenderer(this.device, {
+      ...previousRenderer.props,
+      data: this.batches
+    });
+    previousRenderer.destroy();
+    this.inspectedGraph = undefined;
+    this.graphInspector?.clear();
+    this.graphFallbackReason =
+      error instanceof Error ? error.message : 'The selected adapter cannot run the GPU graph.';
     this.updatePanel();
   }
 
@@ -501,16 +629,62 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     );
     const sceneControl = panel.querySelector<HTMLElement>('[data-gaussian-splats-scene-control]');
     const sceneElement = panel.querySelector<HTMLElement>('[data-gaussian-splats-scene]');
+    const executionControl = panel.querySelector<HTMLElement>(
+      '[data-gaussian-splats-execution-control]'
+    );
+    const executionElement = panel.querySelector<HTMLElement>('[data-gaussian-splats-execution]');
     const sortElement = panel.querySelector<HTMLElement>('[data-gaussian-splats-sort]');
     const radiusElement = panel.querySelector<HTMLInputElement>('[data-gaussian-splats-radius]');
     const opacityElement = panel.querySelector<HTMLInputElement>('[data-gaussian-splats-opacity]');
     const orbitElement = panel.querySelector<HTMLInputElement>('[data-gaussian-splats-orbit]');
+    const graphDetails = panel.querySelector<HTMLDetailsElement>(
+      '[data-gaussian-splats-graph-details]'
+    );
+    const graphInspectorElement = panel.querySelector<HTMLElement>(
+      '[data-gaussian-splats-graph-inspector]'
+    );
 
     if (this.localLoadersConfiguration && descriptionElement) {
       descriptionElement.textContent =
         this.localLoadersConfiguration.loaderMode === 'local'
           ? 'Complete Gaussian splat scenes streamed through the local loaders.gl 5 alpha checkout. Drag to orbit; scroll to zoom.'
           : 'Complete Gaussian splat scenes streamed through loaders.gl 5 alpha. Drag to orbit; scroll to zoom.';
+    }
+
+    if (this.device.type === 'webgpu' && executionControl && executionElement) {
+      executionControl.hidden = false;
+      executionControl.style.display = 'grid';
+      render(
+        h(PanelSelect, {
+          ariaLabel: 'Execution pipeline',
+          value: this.executionMode,
+          options: SPLAT_EXECUTION_OPTIONS,
+          onChange: value => {
+            const nextUrl = new URL(window.location.href);
+            if (value === 'cpu') {
+              nextUrl.searchParams.set('renderer', 'cpu');
+            } else {
+              nextUrl.searchParams.delete('renderer');
+            }
+            window.location.assign(nextUrl.toString());
+          }
+        }),
+        executionElement
+      );
+      this.controlDisposers.push(() => render(null, executionElement));
+    }
+
+    if (this.graphInspector && graphDetails && graphInspectorElement) {
+      graphDetails.hidden = false;
+      const inspectorPanel = new GPUCommandGraphInspectorPanel(graphInspectorElement);
+      this.graphInspectorPanels.push(inspectorPanel);
+      this.controlDisposers.push(() => {
+        inspectorPanel.destroy();
+        const panelIndex = this.graphInspectorPanels.indexOf(inspectorPanel);
+        if (panelIndex >= 0) {
+          this.graphInspectorPanels.splice(panelIndex, 1);
+        }
+      });
     }
 
     const hasBundledLoaders = Boolean(window.__lumaGaussianSplatsLoaderBundleUrl);
@@ -579,7 +753,10 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
           h(PanelSelect, {
             ariaLabel: 'Transparency ordering',
             value: sortMode,
-            options: SPLAT_SORT_OPTIONS,
+            options:
+              this.executionMode === 'graph'
+                ? SPLAT_SORT_OPTIONS.filter(option => option.value === 'global')
+                : SPLAT_SORT_OPTIONS,
             onChange: value => {
               const nextSortMode = getSplatSortMode(String(value));
               this.renderer.setProps({sortMode: nextSortMode});
@@ -665,6 +842,34 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     )) {
       backendElement.textContent = this.device.type === 'webgpu' ? 'WebGPU' : 'WebGL2';
     }
+    for (const pipelineElement of document.querySelectorAll<HTMLElement>(
+      '[data-gaussian-splats-pipeline]'
+    )) {
+      pipelineElement.textContent = this.graphFallbackReason
+        ? 'CPU fallback · graph unavailable'
+        : this.renderer instanceof GPUSplatGraphRenderer
+          ? this.renderer.compiledGraph
+            ? 'GPU command graph'
+            : 'Compiling GPU graph…'
+          : this.executionMode === 'graph'
+            ? 'CPU preview → GPU graph'
+            : this.device.type === 'webgpu'
+              ? 'CPU depth ordering'
+              : 'WebGL2 fallback';
+    }
+    for (const pipelineErrorElement of document.querySelectorAll<HTMLElement>(
+      '[data-gaussian-splats-pipeline-error]'
+    )) {
+      pipelineErrorElement.hidden = !this.graphFallbackReason;
+      pipelineErrorElement.textContent = this.graphFallbackReason
+        ? `GPU graph unavailable: ${this.graphFallbackReason}`
+        : '';
+    }
+    for (const graphDetails of document.querySelectorAll<HTMLDetailsElement>(
+      '[data-gaussian-splats-graph-details]'
+    )) {
+      graphDetails.hidden = !this.graphInspector || Boolean(this.graphFallbackReason);
+    }
     for (const sourceElement of document.querySelectorAll<HTMLElement>(
       '[data-gaussian-splats-source]'
     )) {
@@ -746,6 +951,13 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     )) {
       errorElement.hidden = !this.loadingError;
       errorElement.textContent = this.loadingError ?? '';
+    }
+
+    if (this.graphInspector) {
+      const snapshot = this.graphInspector.getSnapshot();
+      for (const inspectorPanel of this.graphInspectorPanels) {
+        inspectorPanel.update(snapshot, this.inspectedGraph?.id);
+      }
     }
   }
 

--- a/modules/experimental/src/gpu-primitives/gpu-sort.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-sort.ts
@@ -41,6 +41,8 @@ export type GPUSortProps = {
   algorithm?: GPUSortAlgorithm;
   /** Requested final order. Defaults to `'ascending'`. */
   direction?: GPUSortDirection;
+  /** Number of significant least-significant key bits processed by radix sort. Defaults to `32`. */
+  keyBits?: number;
 };
 
 type BitonicStage = {
@@ -71,6 +73,8 @@ export class GPUSort {
   readonly algorithm: GPUSortAlgorithm;
   /** Final key ordering. */
   readonly direction: GPUSortDirection;
+  /** Significant least-significant key bits processed by the radix implementation. */
+  readonly keyBits: number;
   /** Concrete implementation selected after resolving `'auto'`. */
   readonly resolvedAlgorithm: Exclude<GPUSortAlgorithm, 'auto'>;
 
@@ -88,6 +92,7 @@ export class GPUSort {
     this.outputValues = props.outputValues;
     this.algorithm = props.algorithm ?? 'auto';
     this.direction = props.direction ?? 'ascending';
+    this.keyBits = props.keyBits ?? 32;
 
     for (const [name, view] of [
       ['keys', this.keys],
@@ -102,6 +107,9 @@ export class GPUSort {
     }
     if (!['ascending', 'descending'].includes(this.direction)) {
       throw new Error(`${this.id} direction must be ascending or descending`);
+    }
+    if (!Number.isInteger(this.keyBits) || this.keyBits < 1 || this.keyBits > 32) {
+      throw new Error(`${this.id} keyBits must be an integer from 1 to 32`);
     }
     if (
       this.values.length !== this.keys.length ||
@@ -163,11 +171,18 @@ function validateSeparateWritableBuffers(sort: GPUSort): void {
   }
 }
 
-/** Copies a one-row key/value pair without allocating sort scratch. */
-function addCopyPairPass<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GPUSort): void {
+/** Copies key/value pairs without allocating additional sort scratch. */
+function addCopyPairPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  sort: GPUSort,
+  inputKeys: GraphDataView<'uint32'> = sort.keys,
+  inputValues: GraphDataView<'uint32'> = sort.values,
+  identifier = 'copy-pair'
+): void {
   const source = /* wgsl */ `
-const KEYS_OFFSET: u32 = ${getViewElementOffset(sort.keys)}u;
-const VALUES_OFFSET: u32 = ${getViewElementOffset(sort.values)}u;
+const ELEMENT_COUNT: u32 = ${sort.keys.length}u;
+const KEYS_OFFSET: u32 = ${getViewElementOffset(inputKeys)}u;
+const VALUES_OFFSET: u32 = ${getViewElementOffset(inputValues)}u;
 const OUTPUT_KEYS_OFFSET: u32 = ${getViewElementOffset(sort.outputKeys)}u;
 const OUTPUT_VALUES_OFFSET: u32 = ${getViewElementOffset(sort.outputValues)}u;
 @group(0) @binding(0) var<storage, read> keys: array<u32>;
@@ -175,26 +190,30 @@ const OUTPUT_VALUES_OFFSET: u32 = ${getViewElementOffset(sort.outputValues)}u;
 @group(0) @binding(2) var<storage, read_write> outputKeys: array<u32>;
 @group(0) @binding(3) var<storage, read_write> outputValues: array<u32>;
 
-@compute @workgroup_size(1) fn main() {
-  outputKeys[OUTPUT_KEYS_OFFSET] = keys[KEYS_OFFSET];
-  outputValues[OUTPUT_VALUES_OFFSET] = values[VALUES_OFFSET];
+@compute @workgroup_size(${RADIX_WORKGROUP_SIZE}) fn main(
+  @builtin(global_invocation_id) globalId: vec3<u32>
+) {
+  let index = globalId.x;
+  if (index >= ELEMENT_COUNT) { return; }
+  outputKeys[OUTPUT_KEYS_OFFSET + index] = keys[KEYS_OFFSET + index];
+  outputValues[OUTPUT_VALUES_OFFSET + index] = values[VALUES_OFFSET + index];
 }`;
   addComputationPass(graph, {
-    id: `${sort.id}-copy-pair`,
+    id: `${sort.id}-${identifier}`,
     source,
     resources: [
-      {buffer: sort.keys, usage: 'storage-read'},
-      {buffer: sort.values, usage: 'storage-read'},
+      {buffer: inputKeys, usage: 'storage-read'},
+      {buffer: inputValues, usage: 'storage-read'},
       {buffer: sort.outputKeys, usage: 'storage-write'},
       {buffer: sort.outputValues, usage: 'storage-write'}
     ],
     bindings: {
-      keys: sort.keys,
-      values: sort.values,
+      keys: inputKeys,
+      values: inputValues,
       outputKeys: sort.outputKeys,
       outputValues: sort.outputValues
     },
-    dispatchCount: 1
+    dispatchCount: Math.ceil(sort.keys.length / RADIX_WORKGROUP_SIZE)
   });
 }
 
@@ -373,7 +392,7 @@ const OUTPUT_VALUES_OFFSET: u32 = ${getViewElementOffset(sort.outputValues)}u;
   });
 }
 
-/** Adds 32 stable least-significant-bit radix partitions and the final output copy if needed. */
+/** Adds stable least-significant-bit radix partitions and the final output copy if needed. */
 function addRadixSort<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GPUSort): void {
   const scratchKeys = createTransientView(
     graph,
@@ -390,7 +409,7 @@ function addRadixSort<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GPUS
   let currentKeys = sort.keys;
   let currentValues = sort.values;
 
-  for (let bit = 0; bit < 32; bit++) {
+  for (let bit = 0; bit < sort.keyBits; bit++) {
     const flags = createTransientView(
       graph,
       `${sort.id}-radix-bit-${bit}-flags`,
@@ -424,6 +443,10 @@ function addRadixSort<Parameters>(graph: GPUCommandGraph<Parameters>, sort: GPUS
     );
     currentKeys = nextKeys;
     currentValues = nextValues;
+  }
+
+  if (sort.keyBits % 2 !== 0) {
+    addCopyPairPass(graph, sort, currentKeys, currentValues, 'radix-final-copy');
   }
 }
 

--- a/modules/experimental/test/gpu-primitives/gpu-sort.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-sort.spec.ts
@@ -62,6 +62,35 @@ test('GPUSort radix stably sorts paired uint32 values in both directions', async
   t.end();
 });
 
+test('GPUSort radix processes only the requested significant key bits', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const keys = Uint32Array.from([32_767, 12, 0, 4_096, 12, 255, 1]);
+  const values = Uint32Array.from(keys, (_, index) => index);
+  for (const keyBits of [15, 16]) {
+    const result = await runSort(device, keys, values, 'radix', 'ascending', keyBits);
+    const expected = getStableSortedPairs(keys, values, 'ascending');
+    t.deepEqual(result.keys, expected.keys, `${keyBits}-bit radix sorts every key`);
+    t.deepEqual(result.values, expected.values, `${keyBits}-bit radix remains stable`);
+    t.equal(
+      result.nodeOrder.filter(identifier => identifier.endsWith('-classify')).length,
+      keyBits,
+      `${keyBits}-bit radix emits only the required classify passes`
+    );
+    t.equal(
+      result.nodeOrder.includes('sort-radix-final-copy'),
+      keyBits % 2 !== 0,
+      'odd key widths copy their final scratch result into the caller-owned outputs'
+    );
+  }
+  t.end();
+});
+
 test('GPUSort handles empty and single-row inputs', async t => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -307,6 +336,13 @@ test('GPUSort validates layouts, lengths, graph ownership, and output buffers', 
     /separate buffers/,
     'input/output alias is rejected'
   );
+  for (const keyBits of [0, 33, 1.5, Number.NaN]) {
+    t.throws(
+      () => new GPUSort({keys, values, outputKeys, outputValues, keyBits}),
+      /keyBits must be an integer from 1 to 32/,
+      `invalid key width ${keyBits} is rejected`
+    );
+  }
   const unaligned = graph.createDataView(outputKeysHandle, {
     format: 'uint32',
     length: 1,
@@ -338,7 +374,8 @@ async function runSort(
   keys: Uint32Array,
   values: Uint32Array,
   algorithm: GPUSortAlgorithm,
-  direction: GPUSortDirection
+  direction: GPUSortDirection,
+  keyBits?: number
 ): Promise<SortResult> {
   const byteLength = Math.max(keys.length, 1) * Uint32Array.BYTES_PER_ELEMENT;
   const keysBuffer = device.createBuffer({
@@ -373,7 +410,8 @@ async function runSort(
     outputKeys: outputKeyView,
     outputValues: outputValueView,
     algorithm,
-    direction
+    direction,
+    keyBits
   });
   sort.addToGraph(graph);
   const compiled = graph.compile();

--- a/modules/splats/README.md
+++ b/modules/splats/README.md
@@ -41,6 +41,31 @@ renderer automatically applies Reinhard highlight compression on standard dynami
 preserves extended WebGPU presentation output, and supports explicit `exposure` and `toneMapping`
 controls.
 
+## WebGPU command-graph rendering
+
+`GPUSplatGraphRenderer` is a WebGPU-only alternative for large captured scenes. Its compiled GPU
+command graph projects and culls each borrowed source batch, globally sorts camera-dependent depth
+keys, and renders every visible Gaussian with one GPU-driven indirect draw:
+
+```ts
+import {GPUSplatGraphRenderer} from '@luma.gl/splats';
+
+const renderer = new GPUSplatGraphRenderer(webgpuDevice, {
+  data: preparedBatches,
+  viewportSize: [width, height]
+});
+
+const commandEncoder = webgpuDevice.createCommandEncoder();
+renderer.encode(commandEncoder);
+webgpuDevice.submit(commandEncoder.finish());
+```
+
+Projection, visibility, ordering, and the indirect instance count remain on the GPU; rendering does
+not read results back or sort source rows on the CPU. Original source batches remain independently
+owned and unchanged. Only camera-dependent projected records, depth keys, sort scratch, and the
+indirect command are owned by the graph renderer. Use `SplatRenderer` for WebGL2 or when CPU
+ordering is explicitly preferred.
+
 Keep format parsing in `@loaders.gl/splats`, Apache Arrow conversion and GPU upload in
 `@luma.gl/arrow`, and deck.gl-specific layers in downstream adapters. The luma.gl splat renderer
 consumes framework-neutral GPU data.

--- a/modules/splats/package.json
+++ b/modules/splats/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",
+    "@luma.gl/experimental": "9.4.0-alpha.4",
     "@luma.gl/shadertools": "9.4.0-alpha.4",
     "@luma.gl/tables": "9.4.0-alpha.4"
   }

--- a/modules/splats/src/gpu-splat-graph-renderer.ts
+++ b/modules/splats/src/gpu-splat-graph-renderer.ts
@@ -1,0 +1,708 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type CommandEncoder, type Device, type ShaderLayout} from '@luma.gl/core';
+import {Computation, Model} from '@luma.gl/engine';
+import {
+  DrawCommandBuffer,
+  GPUCommandGraph,
+  GPUSort,
+  type CompiledGPUCommandGraph,
+  type GPUCommandGraphEncoding,
+  type GPUCommandGraphStats,
+  type GraphBufferHandle,
+  type GraphDataView
+} from '@luma.gl/experimental';
+import {GPUSplatData} from './splat-data';
+import {
+  GPU_SPLAT_GRAPH_UNIFORM_BYTE_LENGTH,
+  GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH,
+  GPU_SPLAT_PROJECTION_SHADER,
+  GPU_SPLAT_PROJECTION_SHADER_LAYOUT,
+  GPU_SPLAT_RENDER_SHADER,
+  GPU_SPLAT_RENDER_SHADER_LAYOUT
+} from './gpu-splat-graph-shaders';
+import type {SplatRendererProps, SplatRendererStats} from './splat-renderer';
+import type {SplatSortMode} from './splat-sort';
+
+/** Camera, styling, borrowed data, and canvas clearing for graph-native Gaussian rendering. */
+export type GPUSplatGraphRendererProps = SplatRendererProps & {
+  /** Color used when the graph opens its single default-framebuffer render pass. */
+  clearColor?: [number, number, number, number];
+};
+
+type ResolvedGPUSplatGraphRendererProps = {
+  modelViewProjectionMatrix: [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number
+  ];
+  viewportSize: [number, number];
+  sortMode: SplatSortMode;
+  alphaCutoff: number;
+  screenSizeCutoffPixels: number;
+  gaussianSupportRadius: number;
+  kernel2DSize: number;
+  maxScreenSpaceSplatSize: number;
+  radiusScale: number;
+  alphaScale: number;
+  exposure: number;
+  toneMapping: 'none' | 'reinhard';
+};
+
+const INITIALIZE_SHADER_LAYOUT = {
+  attributes: [],
+  bindings: [
+    {name: 'sortValues', type: 'storage', group: 0, location: 0},
+    {name: 'drawCommands', type: 'storage', group: 0, location: 1}
+  ]
+} satisfies ShaderLayout;
+
+/**
+ * WebGPU-only Gaussian renderer composed entirely from reusable GPU command-graph nodes.
+ *
+ * Source record batches remain borrowed and separately allocated. Projection, culling, global
+ * radix sorting, and the visible-row indirect draw all execute on the GPU without CPU row walks,
+ * GPU readback, or intermediate submissions.
+ */
+export class GPUSplatGraphRenderer {
+  /** WebGPU device owning renderer allocations and compiled graph resources. */
+  readonly device: Device;
+  /** Caller-owned source batches retained in stream order and never repacked or destroyed. */
+  readonly batches: GPUSplatData[] = [];
+  /** GPU-written indirect draw command; its instance count is the current visible row count. */
+  readonly drawCommands: DrawCommandBuffer;
+  /** Resolved camera, visibility, and styling properties shared with the legacy renderer. */
+  readonly props: ResolvedGPUSplatGraphRendererProps;
+  /** Compiled graph, available after the first successful encoding. */
+  compiledGraph?: CompiledGPUCommandGraph;
+  /** Immediate CPU/node diagnostics from the most recent graph encoding. */
+  lastEncoding?: GPUCommandGraphEncoding;
+
+  private readonly clearColor: [number, number, number, number];
+  private readonly ownedBuffers: Buffer[] = [];
+  private readonly batchUniforms: Buffer[] = [];
+  private model?: Model;
+  private sortedValuesBuffer?: Buffer;
+  private requiresGraphRebuild = true;
+  private requiresEncoding = true;
+  private hasExplicitToneMapping: boolean;
+  private isDestroyed = false;
+
+  /** Retains supplied batches lazily; graph compilation waits until the first `encode()`. */
+  constructor(device: Device, props: GPUSplatGraphRendererProps = {}) {
+    if (device.type !== 'webgpu') {
+      throw new Error('GPUSplatGraphRenderer requires a WebGPU device');
+    }
+
+    this.device = device;
+    this.clearColor = [...(props.clearColor ?? [0, 0, 0, 0])];
+    this.props = {
+      modelViewProjectionMatrix: toSplatGraphMatrix(props.modelViewProjectionMatrix),
+      viewportSize: [...(props.viewportSize ?? [1, 1])],
+      sortMode: 'global',
+      alphaCutoff: props.alphaCutoff ?? props.opacityThreshold ?? 1 / 255,
+      screenSizeCutoffPixels: props.screenSizeCutoffPixels ?? 0,
+      gaussianSupportRadius: props.gaussianSupportRadius ?? 3,
+      kernel2DSize: props.kernel2DSize ?? 0.3,
+      maxScreenSpaceSplatSize: props.maxScreenSpaceSplatSize ?? 1024,
+      radiusScale: props.radiusScale ?? props.pointSize ?? 1,
+      alphaScale: props.alphaScale ?? 1,
+      exposure: props.exposure ?? 1,
+      toneMapping: props.toneMapping ?? 'none'
+    };
+    this.hasExplicitToneMapping = props.toneMapping !== undefined;
+    this.drawCommands = new DrawCommandBuffer(device, {
+      id: 'gaussian-splat-graph-draw-command',
+      type: 'draw',
+      commands: [{vertexCount: 4, instanceCount: 0}]
+    });
+    for (const batch of normalizeSplatGraphBatches(props.data)) {
+      this.appendData(batch);
+    }
+  }
+
+  /** Scheduling, resource-hazard, and transient-allocation diagnostics for the compiled graph. */
+  get graphStats(): GPUCommandGraphStats | undefined {
+    return this.compiledGraph?.stats;
+  }
+
+  /** GPU-produced globally sorted projected-record indices, available after compilation. */
+  get sortedIndexBuffer(): Buffer | undefined {
+    return this.sortedValuesBuffer;
+  }
+
+  /** Source and renderer allocation diagnostics without forcing GPU readback or CPU sorting. */
+  get stats(): SplatRendererStats {
+    return this.getStats();
+  }
+
+  /** Whether this borrowing renderer has already released its owned graph resources. */
+  get destroyed(): boolean {
+    return this.isDestroyed;
+  }
+
+  /** Borrows one source batch while preserving its original GPU column allocations. */
+  appendData(batch: GPUSplatData): void {
+    if (this.isDestroyed || batch.destroyed || batch.device !== this.device) {
+      throw new Error('GPUSplatGraphRenderer requires live data prepared on its own device');
+    }
+    this.batches.push(batch);
+    if (
+      !this.hasExplicitToneMapping &&
+      batch.colors.format === 'float32x4' &&
+      !hasHighDynamicRangeSplatPresentation(this.device)
+    ) {
+      this.props.toneMapping = 'reinhard';
+    }
+    this.requiresGraphRebuild = true;
+    this.requiresEncoding = true;
+  }
+
+  /** Updates camera or styling uniforms in O(batch count), never O(splat count). */
+  setProps(props: Partial<SplatRendererProps>): void {
+    if (props.data !== undefined) {
+      const replacementBatches = normalizeSplatGraphBatches(props.data);
+      const matchesRetainedBatches =
+        replacementBatches.length === this.batches.length &&
+        replacementBatches.every((batch, batchIndex) => batch === this.batches[batchIndex]);
+      if (!matchesRetainedBatches) {
+        this.releaseCompiledGraph();
+        this.batches.length = 0;
+        for (const batch of replacementBatches) {
+          this.appendData(batch);
+        }
+      }
+    }
+
+    if (
+      props.modelViewProjectionMatrix &&
+      !areSplatGraphValuesEqual(
+        this.props.modelViewProjectionMatrix,
+        props.modelViewProjectionMatrix
+      )
+    ) {
+      this.props.modelViewProjectionMatrix = toSplatGraphMatrix(props.modelViewProjectionMatrix);
+      this.requiresEncoding = true;
+    }
+    if (
+      props.viewportSize &&
+      !areSplatGraphValuesEqual(this.props.viewportSize, props.viewportSize)
+    ) {
+      this.props.viewportSize = [...props.viewportSize];
+      this.requiresEncoding = true;
+    }
+
+    const updates: Partial<ResolvedGPUSplatGraphRendererProps> = {
+      ...(props.alphaCutoff !== undefined || props.opacityThreshold !== undefined
+        ? {alphaCutoff: props.alphaCutoff ?? props.opacityThreshold}
+        : {}),
+      ...(props.radiusScale !== undefined || props.pointSize !== undefined
+        ? {radiusScale: props.radiusScale ?? props.pointSize}
+        : {}),
+      ...(props.screenSizeCutoffPixels !== undefined
+        ? {screenSizeCutoffPixels: props.screenSizeCutoffPixels}
+        : {}),
+      ...(props.gaussianSupportRadius !== undefined
+        ? {gaussianSupportRadius: props.gaussianSupportRadius}
+        : {}),
+      ...(props.kernel2DSize !== undefined ? {kernel2DSize: props.kernel2DSize} : {}),
+      ...(props.maxScreenSpaceSplatSize !== undefined
+        ? {maxScreenSpaceSplatSize: props.maxScreenSpaceSplatSize}
+        : {}),
+      ...(props.alphaScale !== undefined ? {alphaScale: props.alphaScale} : {}),
+      ...(props.exposure !== undefined ? {exposure: props.exposure} : {}),
+      ...(props.toneMapping !== undefined ? {toneMapping: props.toneMapping} : {})
+    };
+    if (props.toneMapping !== undefined) {
+      this.hasExplicitToneMapping = true;
+    }
+    for (const [propertyName, value] of Object.entries(updates)) {
+      if (this.props[propertyName as keyof ResolvedGPUSplatGraphRendererProps] !== value) {
+        Object.assign(this.props, {[propertyName]: value});
+        this.requiresEncoding = true;
+      }
+    }
+  }
+
+  /**
+   * Encodes projection, global sorting, and exactly one indirect canvas draw.
+   *
+   * The caller still owns command submission. An unchanged scene or an empty source returns
+   * `undefined`, ensuring a stationary camera never repeatedly projects or sorts every source row.
+   */
+  encode(commandEncoder: CommandEncoder): GPUCommandGraphEncoding | undefined {
+    if (this.isDestroyed || !this.requiresEncoding || this.getRowCount() === 0) {
+      return undefined;
+    }
+    if (this.requiresGraphRebuild) {
+      this.rebuildGraph();
+    }
+    if (!this.compiledGraph) {
+      return undefined;
+    }
+
+    this.writeBatchUniforms();
+    this.lastEncoding = this.compiledGraph.encode(commandEncoder, {parameters: undefined});
+    this.requiresEncoding = false;
+    return this.lastEncoding;
+  }
+
+  /** Returns source counts and allocation diagnostics without CPU projection or GPU readback. */
+  getStats(): SplatRendererStats {
+    const splatCount = this.getRowCount();
+    const sourceGpuByteLength = this.batches.reduce(
+      (totalByteLength, batch) => totalByteLength + batch.byteLength,
+      0
+    );
+    const rendererGpuByteLength =
+      this.drawCommands.buffer.byteLength +
+      this.ownedBuffers.reduce(
+        (totalByteLength, buffer) => totalByteLength + buffer.byteLength,
+        0
+      ) +
+      this.batchUniforms.reduce(
+        (totalByteLength, buffer) => totalByteLength + buffer.byteLength,
+        0
+      ) +
+      (this.compiledGraph?.stats.physicalTransientBytes ?? 0);
+    return {
+      splatCount,
+      rowCount: splatCount,
+      // The exact culled count remains GPU-resident in drawCommands; avoid a synchronous readback.
+      visibleSplatCount: splatCount,
+      batchCount: this.batches.length,
+      sortMode: 'global',
+      sourceGpuByteLength,
+      rendererGpuByteLength,
+      gpuByteLength: sourceGpuByteLength + rendererGpuByteLength,
+      drawCallCount: splatCount > 0 ? 1 : 0
+    };
+  }
+
+  /** Releases graph/model/scratch resources without touching caller-owned source allocations. */
+  destroy(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+    this.releaseCompiledGraph();
+    this.drawCommands.destroy();
+    this.isDestroyed = true;
+  }
+
+  private rebuildGraph(): void {
+    this.releaseCompiledGraph();
+    const rowCount = this.getRowCount();
+    if (rowCount === 0) {
+      this.requiresGraphRebuild = false;
+      return;
+    }
+
+    const projectedByteLength = rowCount * GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH;
+    if (
+      this.device.limits.maxStorageBufferBindingSize > 0 &&
+      projectedByteLength > this.device.limits.maxStorageBufferBindingSize
+    ) {
+      throw new Error('Gaussian splat projected records exceed the device storage binding limit');
+    }
+
+    const graph = new GPUCommandGraph(this.device, {id: 'gaussian-splat-render-graph'});
+    const projectedRecordsBuffer = this.createOwnedBuffer(
+      'gaussian-splat-projected-records',
+      projectedByteLength
+    );
+    const depthKeysBuffer = this.createOwnedBuffer(
+      'gaussian-splat-depth-keys',
+      rowCount * Uint32Array.BYTES_PER_ELEMENT
+    );
+    const sourceIndicesBuffer = this.createOwnedBuffer(
+      'gaussian-splat-source-indices',
+      rowCount * Uint32Array.BYTES_PER_ELEMENT
+    );
+    const sortedKeysBuffer = this.createOwnedBuffer(
+      'gaussian-splat-sorted-keys',
+      rowCount * Uint32Array.BYTES_PER_ELEMENT
+    );
+    this.sortedValuesBuffer = this.createOwnedBuffer(
+      'gaussian-splat-sorted-indices',
+      rowCount * Uint32Array.BYTES_PER_ELEMENT
+    );
+
+    const projectedRecords = this.importOwnedBuffer(graph, projectedRecordsBuffer);
+    const depthKeys = this.importUint32Buffer(graph, depthKeysBuffer, rowCount);
+    const sourceIndices = this.importUint32Buffer(graph, sourceIndicesBuffer, rowCount);
+    const sortedKeys = this.importUint32Buffer(graph, sortedKeysBuffer, rowCount);
+    const sortedIndices = this.importUint32Buffer(graph, this.sortedValuesBuffer, rowCount);
+    const drawCommandViews = this.drawCommands.importToGraph(graph);
+
+    this.addInitializationPass(graph, sourceIndices, drawCommandViews.buffer, rowCount);
+
+    let firstUniform: GraphBufferHandle | undefined;
+    for (const [batchIndex, batch] of this.batches.entries()) {
+      if (batch.length === 0) {
+        continue;
+      }
+      const uniformBuffer = this.device.createBuffer({
+        id: `gaussian-splat-graph-uniforms-${batchIndex}`,
+        byteLength: GPU_SPLAT_GRAPH_UNIFORM_BYTE_LENGTH,
+        usage: Buffer.UNIFORM | Buffer.COPY_DST
+      });
+      this.batchUniforms.push(uniformBuffer);
+      const uniforms = graph.importBuffer(
+        {id: uniformBuffer.id, byteLength: uniformBuffer.byteLength, usage: uniformBuffer.usage},
+        uniformBuffer
+      );
+      firstUniform ??= uniforms;
+      this.addProjectionPass(graph, {
+        batch,
+        batchIndex,
+        projectedRecords,
+        depthKeys,
+        drawCommands: drawCommandViews.buffer,
+        uniforms
+      });
+    }
+
+    new GPUSort({
+      id: 'gaussian-splat-global-depth-sort',
+      keys: depthKeys,
+      values: sourceIndices,
+      outputKeys: sortedKeys,
+      outputValues: sortedIndices,
+      algorithm: 'radix',
+      direction: 'ascending',
+      keyBits: 16
+    }).addToGraph(graph);
+
+    const firstUniformBuffer = this.batchUniforms[0];
+    if (!firstUniform) {
+      return;
+    }
+    this.model = new Model(this.device, {
+      id: 'gaussian-splat-graph-render-model',
+      source: GPU_SPLAT_RENDER_SHADER,
+      shaderLayout: GPU_SPLAT_RENDER_SHADER_LAYOUT,
+      isInstanced: true,
+      instanceCount: rowCount,
+      vertexCount: 4,
+      topology: 'triangle-strip',
+      bindings: {
+        graphUniforms: firstUniformBuffer,
+        projectedRecords: projectedRecordsBuffer,
+        sortedIds: this.sortedValuesBuffer
+      },
+      parameters: {
+        depthWriteEnabled: false,
+        depthCompare: 'less-equal',
+        blend: true,
+        blendColorOperation: 'add',
+        blendAlphaOperation: 'add',
+        blendColorSrcFactor: 'src-alpha',
+        blendColorDstFactor: 'one-minus-src-alpha',
+        blendAlphaSrcFactor: 'one',
+        blendAlphaDstFactor: 'one-minus-src-alpha'
+      }
+    });
+
+    graph.addRenderPass({
+      id: 'gaussian-splat-indirect-render',
+      resources: [
+        {buffer: projectedRecords, usage: 'storage-read'},
+        {buffer: sortedIndices, usage: 'storage-read'},
+        {buffer: firstUniform, usage: 'uniform'},
+        {buffer: drawCommandViews.buffer, usage: 'indirect'}
+      ],
+      compile: () => ({
+        getRenderPassProps: () => ({
+          id: 'gaussian-splat-graph-render-pass',
+          clearColor: this.clearColor,
+          clearDepth: 1,
+          clearStencil: false
+        }),
+        encode: ({renderPass, getBuffer}) => {
+          if (!this.model) {
+            return;
+          }
+          renderPass.setPipeline(this.model.pipeline);
+          renderPass.setVertexArray(this.model.vertexArray);
+          renderPass.setBindings({
+            graphUniforms: getBuffer(firstUniform),
+            projectedRecords: getBuffer(projectedRecords),
+            sortedIds: getBuffer(sortedIndices)
+          });
+          this.drawCommands.draw(renderPass, 0);
+        }
+      })
+    });
+
+    this.compiledGraph = graph.compile();
+    this.requiresGraphRebuild = false;
+  }
+
+  private addInitializationPass(
+    graph: GPUCommandGraph,
+    sourceIndices: GraphDataView<'uint32'>,
+    drawCommands: GraphBufferHandle,
+    rowCount: number
+  ): void {
+    const shader = /* wgsl */ `
+const ROW_COUNT: u32 = ${rowCount}u;
+@group(0) @binding(0) var<storage, read_write> sortValues: array<u32>;
+@group(0) @binding(1) var<storage, read_write> drawCommands: array<atomic<u32>>;
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
+  if (invocation.x < ROW_COUNT) {
+    sortValues[invocation.x] = invocation.x;
+  }
+  if (invocation.x == 0u) {
+    atomicStore(&drawCommands[1], 0u);
+  }
+}`;
+    graph.addComputePass({
+      id: 'gaussian-splat-initialize',
+      resources: [
+        {buffer: sourceIndices, usage: 'storage-write'},
+        {buffer: drawCommands, usage: 'storage-write'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: 'gaussian-splat-initialize',
+          source: shader,
+          shaderLayout: INITIALIZE_SHADER_LAYOUT
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({
+              sortValues: getBuffer(sourceIndices),
+              drawCommands: getBuffer(drawCommands)
+            });
+            computation.dispatch(computePass, Math.ceil(rowCount / 256));
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+
+  private addProjectionPass(
+    graph: GPUCommandGraph,
+    props: {
+      batch: GPUSplatData;
+      batchIndex: number;
+      projectedRecords: GraphBufferHandle;
+      depthKeys: GraphDataView<'uint32'>;
+      drawCommands: GraphBufferHandle;
+      uniforms: GraphBufferHandle;
+    }
+  ): void {
+    const {batch, batchIndex, projectedRecords, depthKeys, drawCommands, uniforms} = props;
+    const positions = graph.importGPUData(
+      `gaussian-splat-batch-${batchIndex}-positions`,
+      batch.positions.data[0]
+    );
+    const scales = graph.importGPUData(
+      `gaussian-splat-batch-${batchIndex}-scales`,
+      batch.scales.data[0]
+    );
+    const rotations = graph.importGPUData(
+      `gaussian-splat-batch-${batchIndex}-rotations`,
+      batch.rotations.data[0]
+    );
+    const colors = graph.importGPUData(
+      `gaussian-splat-batch-${batchIndex}-colors`,
+      batch.colors.data[0]
+    );
+    const opacities = graph.importGPUData(
+      `gaussian-splat-batch-${batchIndex}-opacities`,
+      batch.opacities.data[0]
+    );
+
+    graph.addComputePass({
+      id: `gaussian-splat-project-batch-${batchIndex}`,
+      resources: [
+        {buffer: positions, usage: 'storage-read'},
+        {buffer: scales, usage: 'storage-read'},
+        {buffer: rotations, usage: 'storage-read'},
+        {buffer: colors, usage: 'storage-read'},
+        {buffer: opacities, usage: 'storage-read'},
+        {buffer: projectedRecords, usage: 'storage-write'},
+        {buffer: depthKeys, usage: 'storage-write'},
+        {buffer: drawCommands, usage: 'storage-read-write'},
+        {buffer: uniforms, usage: 'uniform'}
+      ],
+      compile: ({device}) => {
+        const computation = new Computation(device, {
+          id: `gaussian-splat-project-batch-${batchIndex}`,
+          source: GPU_SPLAT_PROJECTION_SHADER,
+          shaderLayout: GPU_SPLAT_PROJECTION_SHADER_LAYOUT
+        });
+        return {
+          encode: ({computePass, getBuffer}) => {
+            computation.setBindings({
+              positions: getBuffer(positions),
+              scales: getBuffer(scales),
+              rotations: getBuffer(rotations),
+              colors: getBuffer(colors),
+              opacities: getBuffer(opacities),
+              projectedRecords: getBuffer(projectedRecords),
+              depthKeys: getBuffer(depthKeys),
+              drawCommands: getBuffer(drawCommands),
+              graphUniforms: getBuffer(uniforms)
+            });
+            computation.dispatch(computePass, Math.ceil(batch.length / 256));
+          },
+          destroy: () => computation.destroy()
+        };
+      }
+    });
+  }
+
+  private writeBatchUniforms(): void {
+    let batchOffset = 0;
+    let uniformIndex = 0;
+    for (const batch of this.batches) {
+      if (batch.length === 0) {
+        continue;
+      }
+      const uniformData = new ArrayBuffer(GPU_SPLAT_GRAPH_UNIFORM_BYTE_LENGTH);
+      const floatValues = new Float32Array(uniformData);
+      const integerValues = new Uint32Array(uniformData);
+      floatValues.set(this.props.modelViewProjectionMatrix, 0);
+      floatValues.set(this.props.viewportSize, 16);
+      floatValues[18] = this.props.radiusScale;
+      floatValues[19] = this.props.alphaScale;
+      floatValues[20] = this.props.alphaCutoff;
+      floatValues[21] = this.props.screenSizeCutoffPixels;
+      floatValues[22] = this.props.gaussianSupportRadius;
+      floatValues[23] = this.props.kernel2DSize;
+      floatValues[24] = this.props.maxScreenSpaceSplatSize;
+      floatValues[25] = this.props.exposure;
+      integerValues[26] = this.props.toneMapping === 'reinhard' ? 1 : 0;
+      integerValues[27] = batchOffset;
+      integerValues[28] = batch.length;
+      integerValues[29] = batch.colors.format === 'float32x4' ? 1 : 0;
+      this.batchUniforms[uniformIndex].write(new Uint8Array(uniformData));
+      batchOffset += batch.length;
+      uniformIndex++;
+    }
+  }
+
+  private createOwnedBuffer(id: string, byteLength: number): Buffer {
+    const buffer = this.device.createBuffer({
+      id,
+      byteLength,
+      usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+    });
+    this.ownedBuffers.push(buffer);
+    return buffer;
+  }
+
+  private importOwnedBuffer(graph: GPUCommandGraph, buffer: Buffer): GraphBufferHandle {
+    return graph.importBuffer(
+      {id: buffer.id, byteLength: buffer.byteLength, usage: buffer.usage},
+      buffer
+    );
+  }
+
+  private importUint32Buffer(
+    graph: GPUCommandGraph,
+    buffer: Buffer,
+    length: number
+  ): GraphDataView<'uint32'> {
+    return graph.createDataView(this.importOwnedBuffer(graph, buffer), {format: 'uint32', length});
+  }
+
+  private getRowCount(): number {
+    return this.batches.reduce((totalRowCount, batch) => totalRowCount + batch.length, 0);
+  }
+
+  private releaseCompiledGraph(): void {
+    this.compiledGraph?.destroy();
+    this.compiledGraph = undefined;
+    this.lastEncoding = undefined;
+    this.model?.destroy();
+    this.model = undefined;
+    for (const buffer of this.ownedBuffers) {
+      buffer.destroy();
+    }
+    this.ownedBuffers.length = 0;
+    for (const uniforms of this.batchUniforms) {
+      uniforms.destroy();
+    }
+    this.batchUniforms.length = 0;
+    this.sortedValuesBuffer = undefined;
+    this.requiresGraphRebuild = true;
+  }
+}
+
+function normalizeSplatGraphBatches(
+  data: GPUSplatData | readonly GPUSplatData[] | undefined
+): readonly GPUSplatData[] {
+  if (!data) {
+    return [];
+  }
+  return data instanceof GPUSplatData ? [data] : data;
+}
+
+function hasHighDynamicRangeSplatPresentation(device: Device): boolean {
+  return (
+    device.preferredColorFormat === 'rgba16float' &&
+    device.canvasContext?.props.toneMapping === 'extended'
+  );
+}
+
+function areSplatGraphValuesEqual(left: ArrayLike<number>, right: ArrayLike<number>): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let valueIndex = 0; valueIndex < left.length; valueIndex++) {
+    if (!Object.is(left[valueIndex], right[valueIndex])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function toSplatGraphMatrix(
+  matrix: ArrayLike<number> | undefined
+): ResolvedGPUSplatGraphRendererProps['modelViewProjectionMatrix'] {
+  if (!matrix) {
+    return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+  }
+  if (matrix.length !== 16) {
+    throw new Error('GPUSplatGraphRenderer requires a 16-element camera matrix');
+  }
+  return [
+    matrix[0],
+    matrix[1],
+    matrix[2],
+    matrix[3],
+    matrix[4],
+    matrix[5],
+    matrix[6],
+    matrix[7],
+    matrix[8],
+    matrix[9],
+    matrix[10],
+    matrix[11],
+    matrix[12],
+    matrix[13],
+    matrix[14],
+    matrix[15]
+  ];
+}

--- a/modules/splats/src/gpu-splat-graph-shaders.ts
+++ b/modules/splats/src/gpu-splat-graph-shaders.ts
@@ -1,0 +1,354 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {ShaderLayout} from '@luma.gl/core';
+
+/** Byte stride of one camera-dependent Gaussian projection owned by its renderer. */
+export const GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH = 48;
+
+/** Padded byte size of the camera, styling, and preserved-batch projection uniforms. */
+export const GPU_SPLAT_GRAPH_UNIFORM_BYTE_LENGTH = 128;
+
+/** Sentinel sorted after every valid 16-bit, back-to-front Gaussian depth key. */
+export const GPU_SPLAT_INVALID_DEPTH_KEY = 0xffff;
+
+/** Projection uses exactly eight storage bindings, the guaranteed WebGPU minimum. */
+export const GPU_SPLAT_PROJECTION_SHADER_LAYOUT = {
+  attributes: [],
+  bindings: [
+    {name: 'positions', type: 'read-only-storage', group: 0, location: 0},
+    {name: 'scales', type: 'read-only-storage', group: 0, location: 1},
+    {name: 'rotations', type: 'read-only-storage', group: 0, location: 2},
+    {name: 'colors', type: 'read-only-storage', group: 0, location: 3},
+    {name: 'opacities', type: 'read-only-storage', group: 0, location: 4},
+    {name: 'projectedRecords', type: 'storage', group: 0, location: 5},
+    {name: 'depthKeys', type: 'storage', group: 0, location: 6},
+    {name: 'drawCommands', type: 'storage', group: 0, location: 7},
+    {name: 'graphUniforms', type: 'uniform', group: 0, location: 8}
+  ]
+} satisfies ShaderLayout;
+
+/** Globally sorted projected records render in one draw without binding source batches. */
+export const GPU_SPLAT_RENDER_SHADER_LAYOUT = {
+  attributes: [],
+  bindings: [
+    {name: 'graphUniforms', type: 'uniform', group: 0, location: 0},
+    {name: 'projectedRecords', type: 'read-only-storage', group: 0, location: 1},
+    {name: 'sortedIds', type: 'read-only-storage', group: 0, location: 2}
+  ]
+} satisfies ShaderLayout;
+
+const GPU_SPLAT_GRAPH_SHARED = /* wgsl */ `\
+struct GraphSplatUniforms {
+  modelViewProjectionMatrix: mat4x4<f32>,
+  viewportSize: vec2<f32>,
+  radiusScale: f32,
+  alphaScale: f32,
+  alphaCutoff: f32,
+  screenSizeCutoffPixels: f32,
+  gaussianSupportRadius: f32,
+  kernel2DSize: f32,
+  maxScreenSpaceSplatSize: f32,
+  exposure: f32,
+  toneMapping: u32,
+  batchOffset: u32,
+  rowCount: u32,
+  isFloatColor: u32,
+};
+
+struct ProjectedSplat {
+  clipCenter: vec4<f32>,
+  axis0: vec2<f32>,
+  axis1: vec2<f32>,
+  color: vec4<f32>,
+};
+`;
+
+/** Projects one preserved source batch, culls invisible rows, and publishes global sort keys. */
+export const GPU_SPLAT_PROJECTION_SHADER = /* wgsl */ `\
+${GPU_SPLAT_GRAPH_SHARED}
+
+const INVALID_DEPTH_KEY: u32 = 65535u;
+const MAXIMUM_VALID_DEPTH_KEY: u32 = 65534u;
+const MINIMUM_PROJECTABLE_W: f32 = 0.000001;
+const MAXIMUM_FINITE_FLOAT: f32 = 3.402823466e38;
+
+@group(0) @binding(0) var<storage, read> positions: array<f32>;
+@group(0) @binding(1) var<storage, read> scales: array<f32>;
+@group(0) @binding(2) var<storage, read> rotations: array<vec4<f32>>;
+@group(0) @binding(3) var<storage, read> colors: array<u32>;
+@group(0) @binding(4) var<storage, read> opacities: array<f32>;
+@group(0) @binding(5) var<storage, read_write> projectedRecords: array<ProjectedSplat>;
+@group(0) @binding(6) var<storage, read_write> depthKeys: array<u32>;
+@group(0) @binding(7) var<storage, read_write> drawCommands: array<atomic<u32>>;
+@group(0) @binding(8) var<uniform> graphUniforms: GraphSplatUniforms;
+
+fn isFiniteSplatValue(value: f32) -> bool {
+  return abs(value) <= MAXIMUM_FINITE_FLOAT;
+}
+
+fn isFiniteSplatPosition(position: vec3<f32>) -> bool {
+  return isFiniteSplatValue(position.x) &&
+    isFiniteSplatValue(position.y) &&
+    isFiniteSplatValue(position.z);
+}
+
+fn clearProjectedSplat(rowIndex: u32) {
+  projectedRecords[rowIndex] = ProjectedSplat(
+    vec4<f32>(0.0, 0.0, 2.0, 1.0),
+    vec2<f32>(0.0),
+    vec2<f32>(0.0),
+    vec4<f32>(0.0)
+  );
+  depthKeys[rowIndex] = INVALID_DEPTH_KEY;
+}
+
+fn getProjectedScreenPosition(position: vec3<f32>) -> vec2<f32> {
+  let clipPosition = graphUniforms.modelViewProjectionMatrix * vec4<f32>(position, 1.0);
+  let inverseClipW = select(
+    0.0,
+    1.0 / clipPosition.w,
+    abs(clipPosition.w) > MINIMUM_PROJECTABLE_W
+  );
+  return vec2<f32>(
+    (clipPosition.x * inverseClipW * 0.5 + 0.5) * graphUniforms.viewportSize.x,
+    (0.5 - clipPosition.y * inverseClipW * 0.5) * graphUniforms.viewportSize.y
+  );
+}
+
+fn getProjectedRotation(quaternion: vec4<f32>) -> mat3x3<f32> {
+  let quaternionLength = length(quaternion);
+  let normalized = select(
+    vec4<f32>(1.0, 0.0, 0.0, 0.0),
+    quaternion / max(quaternionLength, MINIMUM_PROJECTABLE_W),
+    quaternionLength > MINIMUM_PROJECTABLE_W
+  );
+  let quaternionW = normalized.x;
+  let quaternionX = normalized.y;
+  let quaternionY = normalized.z;
+  let quaternionZ = normalized.w;
+  return mat3x3<f32>(
+    vec3<f32>(
+      1.0 - 2.0 * (quaternionY * quaternionY + quaternionZ * quaternionZ),
+      2.0 * (quaternionX * quaternionY + quaternionW * quaternionZ),
+      2.0 * (quaternionX * quaternionZ - quaternionW * quaternionY)
+    ),
+    vec3<f32>(
+      2.0 * (quaternionX * quaternionY - quaternionW * quaternionZ),
+      1.0 - 2.0 * (quaternionX * quaternionX + quaternionZ * quaternionZ),
+      2.0 * (quaternionY * quaternionZ + quaternionW * quaternionX)
+    ),
+    vec3<f32>(
+      2.0 * (quaternionX * quaternionZ + quaternionW * quaternionY),
+      2.0 * (quaternionY * quaternionZ - quaternionW * quaternionX),
+      1.0 - 2.0 * (quaternionX * quaternionX + quaternionY * quaternionY)
+    )
+  );
+}
+
+fn getProjectedColor(rowIndex: u32) -> vec4<f32> {
+  if (graphUniforms.isFloatColor != 0u) {
+    let colorIndex = rowIndex * 4u;
+    return vec4<f32>(
+      bitcast<f32>(colors[colorIndex]),
+      bitcast<f32>(colors[colorIndex + 1u]),
+      bitcast<f32>(colors[colorIndex + 2u]),
+      bitcast<f32>(colors[colorIndex + 3u])
+    );
+  }
+
+  let packedColor = colors[rowIndex];
+  return vec4<f32>(
+    f32(packedColor & 255u),
+    f32((packedColor >> 8u) & 255u),
+    f32((packedColor >> 16u) & 255u),
+    f32((packedColor >> 24u) & 255u)
+  ) / 255.0;
+}
+
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) globalInvocationId: vec3<u32>) {
+  let batchRowIndex = globalInvocationId.x;
+  if (batchRowIndex >= graphUniforms.rowCount) {
+    return;
+  }
+
+  let projectedRowIndex = graphUniforms.batchOffset + batchRowIndex;
+  let componentIndex = batchRowIndex * 3u;
+  let position = vec3<f32>(
+    positions[componentIndex],
+    positions[componentIndex + 1u],
+    positions[componentIndex + 2u]
+  );
+  if (!isFiniteSplatPosition(position)) {
+    clearProjectedSplat(projectedRowIndex);
+    return;
+  }
+
+  let clipCenter = graphUniforms.modelViewProjectionMatrix * vec4<f32>(position, 1.0);
+  if (
+    !isFiniteSplatValue(clipCenter.x) ||
+    !isFiniteSplatValue(clipCenter.y) ||
+    !isFiniteSplatValue(clipCenter.z) ||
+    !isFiniteSplatValue(clipCenter.w) ||
+    clipCenter.w <= MINIMUM_PROJECTABLE_W ||
+    clipCenter.z < -clipCenter.w ||
+    clipCenter.z > clipCenter.w
+  ) {
+    clearProjectedSplat(projectedRowIndex);
+    return;
+  }
+
+  let color = getProjectedColor(batchRowIndex);
+  let alpha = color.a * opacities[batchRowIndex] * graphUniforms.alphaScale;
+  if (!isFiniteSplatValue(alpha) || alpha < graphUniforms.alphaCutoff) {
+    clearProjectedSplat(projectedRowIndex);
+    return;
+  }
+
+  let scale = vec3<f32>(
+    scales[componentIndex],
+    scales[componentIndex + 1u],
+    scales[componentIndex + 2u]
+  );
+  if (!isFiniteSplatPosition(scale)) {
+    clearProjectedSplat(projectedRowIndex);
+    return;
+  }
+
+  let center = getProjectedScreenPosition(position);
+  let rotationMatrix = getProjectedRotation(rotations[batchRowIndex]);
+  let delta0 = getProjectedScreenPosition(position + rotationMatrix[0] * scale.x) - center;
+  let delta1 = getProjectedScreenPosition(position + rotationMatrix[1] * scale.y) - center;
+  let delta2 = getProjectedScreenPosition(position + rotationMatrix[2] * scale.z) - center;
+  let kernelVariance = graphUniforms.kernel2DSize * graphUniforms.kernel2DSize;
+  let covariance00 = dot(
+    vec3<f32>(delta0.x, delta1.x, delta2.x),
+    vec3<f32>(delta0.x, delta1.x, delta2.x)
+  ) + kernelVariance;
+  let covariance01 = dot(
+    vec3<f32>(delta0.x, delta1.x, delta2.x),
+    vec3<f32>(delta0.y, delta1.y, delta2.y)
+  );
+  let covariance11 = dot(
+    vec3<f32>(delta0.y, delta1.y, delta2.y),
+    vec3<f32>(delta0.y, delta1.y, delta2.y)
+  ) + kernelVariance;
+  let halfTrace = (covariance00 + covariance11) * 0.5;
+  let halfDifference = (covariance00 - covariance11) * 0.5;
+  let discriminant = sqrt(max(halfDifference * halfDifference + covariance01 * covariance01, 0.0));
+  let firstEigenvalue = max(halfTrace + discriminant, 0.0);
+  let secondEigenvalue = max(halfTrace - discriminant, 0.0);
+  var firstDirection = vec2<f32>(covariance01, firstEigenvalue - covariance00);
+  if (length(firstDirection) <= MINIMUM_PROJECTABLE_W) {
+    firstDirection = vec2<f32>(firstEigenvalue - covariance11, covariance01);
+  }
+  if (length(firstDirection) <= MINIMUM_PROJECTABLE_W) {
+    firstDirection = vec2<f32>(1.0, 0.0);
+  }
+  firstDirection = normalize(firstDirection);
+  let secondDirection = vec2<f32>(-firstDirection.y, firstDirection.x);
+  let firstAxisLength = max(sqrt(firstEigenvalue), 0.001);
+  let secondAxisLength = max(sqrt(secondEigenvalue), 0.001);
+  let maximumAxisLength = max(firstAxisLength, secondAxisLength);
+  if (
+    !isFiniteSplatValue(maximumAxisLength) ||
+    maximumAxisLength * graphUniforms.radiusScale < graphUniforms.screenSizeCutoffPixels
+  ) {
+    clearProjectedSplat(projectedRowIndex);
+    return;
+  }
+
+  let clampScale = min(
+    max(graphUniforms.maxScreenSpaceSplatSize, 0.001) / maximumAxisLength,
+    1.0
+  );
+  let supportScale = graphUniforms.gaussianSupportRadius * graphUniforms.radiusScale * clampScale;
+  let axis0 = firstDirection * firstAxisLength * supportScale;
+  let axis1 = secondDirection * secondAxisLength * supportScale;
+  let screenExtent = abs(axis0) + abs(axis1);
+  if (
+    center.x + screenExtent.x < 0.0 ||
+    center.y + screenExtent.y < 0.0 ||
+    center.x - screenExtent.x > graphUniforms.viewportSize.x ||
+    center.y - screenExtent.y > graphUniforms.viewportSize.y
+  ) {
+    clearProjectedSplat(projectedRowIndex);
+    return;
+  }
+
+  let normalizedDepth = clamp(clipCenter.z / clipCenter.w * 0.5 + 0.5, 0.0, 1.0);
+  let quantizedDepth = u32(round(normalizedDepth * f32(MAXIMUM_VALID_DEPTH_KEY)));
+  depthKeys[projectedRowIndex] = MAXIMUM_VALID_DEPTH_KEY - quantizedDepth;
+  projectedRecords[projectedRowIndex] = ProjectedSplat(
+    clipCenter,
+    axis0,
+    axis1,
+    vec4<f32>(color.rgb, alpha)
+  );
+  atomicAdd(&drawCommands[1u], 1u);
+}
+`;
+
+/** Renders globally sorted, preprojected HDR Gaussians without revisiting source batches. */
+export const GPU_SPLAT_RENDER_SHADER = /* wgsl */ `\
+${GPU_SPLAT_GRAPH_SHARED}
+
+@group(0) @binding(0) var<uniform> graphUniforms: GraphSplatUniforms;
+@group(0) @binding(1) var<storage, read> projectedRecords: array<ProjectedSplat>;
+@group(0) @binding(2) var<storage, read> sortedIds: array<u32>;
+
+struct GraphSplatFragmentInputs {
+  @builtin(position) position: vec4<f32>,
+  @location(0) gaussianCoordinate: vec2<f32>,
+  @location(1) color: vec4<f32>,
+};
+
+@vertex
+fn vertexMain(
+  @builtin(vertex_index) vertexIndex: u32,
+  @builtin(instance_index) instanceIndex: u32
+) -> GraphSplatFragmentInputs {
+  let corners = array<vec2<f32>, 4>(
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>(1.0, -1.0),
+    vec2<f32>(-1.0, 1.0),
+    vec2<f32>(1.0, 1.0)
+  );
+  let corner = corners[vertexIndex];
+  let projected = projectedRecords[sortedIds[instanceIndex]];
+  let screenOffset = corner.x * projected.axis0 + corner.y * projected.axis1;
+  let clipOffset = vec2<f32>(
+    screenOffset.x * 2.0 / max(graphUniforms.viewportSize.x, 1.0),
+    -screenOffset.y * 2.0 / max(graphUniforms.viewportSize.y, 1.0)
+  ) * projected.clipCenter.w;
+
+  var output: GraphSplatFragmentInputs;
+  output.position = vec4<f32>(
+    projected.clipCenter.xy + clipOffset,
+    projected.clipCenter.z,
+    projected.clipCenter.w
+  );
+  output.gaussianCoordinate = corner * graphUniforms.gaussianSupportRadius;
+  output.color = projected.color;
+  return output;
+}
+
+@fragment
+fn fragmentMain(input: GraphSplatFragmentInputs) -> @location(0) vec4<f32> {
+  let gaussianWeight = exp(-0.5 * dot(input.gaussianCoordinate, input.gaussianCoordinate));
+  let alpha = input.color.a * gaussianWeight;
+  if (alpha < graphUniforms.alphaCutoff) {
+    discard;
+  }
+
+  let linearColor = max(input.color.rgb * graphUniforms.exposure, vec3<f32>(0.0));
+  let mappedColor = select(
+    linearColor,
+    linearColor / (vec3<f32>(1.0) + linearColor),
+    graphUniforms.toneMapping == 1u
+  );
+  return vec4<f32>(mappedColor, alpha);
+}
+`;

--- a/modules/splats/src/index.ts
+++ b/modules/splats/src/index.ts
@@ -34,6 +34,10 @@ export {
   type SplatRendererStats
 } from './splat-renderer';
 export {
+  GPUSplatGraphRenderer,
+  type GPUSplatGraphRendererProps
+} from './gpu-splat-graph-renderer';
+export {
   SPLAT_ATTRIBUTE_SHADER_LAYOUT,
   SPLAT_ATTRIBUTE_WGSL_SHADER,
   SPLAT_FS_GLSL,

--- a/modules/splats/test/gpu-splat-graph-renderer.node.spec.ts
+++ b/modules/splats/test/gpu-splat-graph-renderer.node.spec.ts
@@ -1,0 +1,115 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {GPUSplatGraphRenderer, makeGPUSplatData, type SplatSource} from '@luma.gl/splats';
+import {NullDevice} from '@luma.gl/test-utils';
+
+test('GPUSplatGraphRenderer rejects devices without WebGPU command graphs', t => {
+  const device = new NullDevice({});
+  t.throws(
+    () => new GPUSplatGraphRenderer(device),
+    /requires a WebGPU device/,
+    'preserves the legacy renderer as the explicit WebGL2 fallback'
+  );
+  t.end();
+});
+
+test('GPUSplatGraphRenderer retains borrowed batches without eager CPU projection or graph compilation', t => {
+  const device = makeWebGPUNullDevice();
+  const firstBatch = makeGPUSplatData(device, makeGraphSplatSource([0.25, 0.75], 0));
+  const secondBatch = makeGPUSplatData(device, makeGraphSplatSource([0.5], 2));
+  const renderer = new GPUSplatGraphRenderer(device, {data: firstBatch, viewportSize: [32, 24]});
+  renderer.appendData(secondBatch);
+
+  t.equal(renderer.batches[0], firstBatch, 'retains the original first caller-owned batch');
+  t.equal(renderer.batches[1], secondBatch, 'retains the original second caller-owned batch');
+  t.equal(renderer.compiledGraph, undefined, 'defers immutable graph compilation until encoding');
+  t.equal(renderer.stats.splatCount, 3, 'aggregates source row counts without inspecting rows');
+  t.equal(renderer.stats.batchCount, 2, 'preserves independently streamed source batches');
+  t.equal(renderer.stats.drawCallCount, 1, 'plans one global indirect render draw');
+  t.equal(renderer.stats.sortMode, 'global', 'always uses a globally ordered GPU depth sort');
+
+  const sourceBuffer = firstBatch.positions.data[0].buffer;
+  const commandBuffer = renderer.drawCommands.buffer;
+  renderer.destroy();
+  renderer.destroy();
+  t.ok(renderer.destroyed, 'marks owned renderer resources destroyed');
+  t.ok(commandBuffer.destroyed, 'releases the renderer-owned indirect command allocation');
+  t.notOk(sourceBuffer.destroyed, 'never destroys a borrowed caller-owned source allocation');
+
+  firstBatch.destroy();
+  secondBatch.destroy();
+  t.end();
+});
+
+test('GPUSplatGraphRenderer preserves HDR radiance and resolves display tone mapping', t => {
+  const device = makeWebGPUNullDevice();
+  const source = makeGraphSplatSource([0.5], 0);
+  source.colors = new Float32Array([4, 2, 0.25, 1]);
+  const batch = makeGPUSplatData(device, source);
+  const renderer = new GPUSplatGraphRenderer(device, {data: batch});
+
+  t.equal(batch.colors.format, 'float32x4', 'retains Float32 source radiance without quantization');
+  t.equal(renderer.props.toneMapping, 'reinhard', 'tone-maps HDR highlights for SDR presentation');
+  renderer.setProps({exposure: 0.5, toneMapping: 'none', opacityThreshold: 0.2, pointSize: 1.5});
+  t.equal(renderer.props.exposure, 0.5, 'updates the display exposure');
+  t.equal(renderer.props.toneMapping, 'none', 'respects an explicit display tone-mapping override');
+  t.equal(renderer.props.alphaCutoff, 0.2, 'accepts the existing opacity-threshold alias');
+  t.equal(renderer.props.radiusScale, 1.5, 'accepts the existing point-size alias');
+
+  renderer.destroy();
+  batch.destroy();
+  t.end();
+});
+
+test('GPUSplatGraphRenderer validates borrowing and replacement ownership', t => {
+  const firstDevice = makeWebGPUNullDevice();
+  const secondDevice = makeWebGPUNullDevice();
+  const firstBatch = makeGPUSplatData(firstDevice, makeGraphSplatSource([0.25], 0));
+  const replacementBatch = makeGPUSplatData(firstDevice, makeGraphSplatSource([0.75], 1));
+  const foreignBatch = makeGPUSplatData(secondDevice, makeGraphSplatSource([0.5], 0));
+  const renderer = new GPUSplatGraphRenderer(firstDevice, {data: firstBatch});
+
+  t.throws(
+    () => renderer.appendData(foreignBatch),
+    /live data prepared on its own device/,
+    'rejects source allocations from another WebGPU device'
+  );
+  renderer.setProps({data: replacementBatch});
+  t.equal(renderer.batches.length, 1, 'replaces the ordered source batch list');
+  t.equal(renderer.batches[0], replacementBatch, 'retains the replacement caller-owned batch');
+  t.notOk(firstBatch.destroyed, 'never destroys the previous caller-owned source batch');
+
+  renderer.destroy();
+  firstBatch.destroy();
+  replacementBatch.destroy();
+  foreignBatch.destroy();
+  t.end();
+});
+
+function makeWebGPUNullDevice(): NullDevice {
+  const device = new NullDevice({});
+  Object.defineProperties(device, {
+    type: {value: 'webgpu'},
+    info: {value: {...device.info, type: 'webgpu', shadingLanguage: 'wgsl'}}
+  });
+  return device;
+}
+
+function makeGraphSplatSource(depths: readonly number[], rowIndexBase: number): SplatSource {
+  const positions = new Float32Array(depths.length * 3);
+  const scales = new Float32Array(depths.length * 3);
+  const rotations = new Float32Array(depths.length * 4);
+  const colors = new Uint8Array(depths.length * 4);
+  const opacities = new Float32Array(depths.length);
+  for (const [rowIndex, depth] of depths.entries()) {
+    positions[rowIndex * 3 + 2] = depth;
+    scales.set([0.1, 0.06, 0.03], rowIndex * 3);
+    rotations[rowIndex * 4] = 1;
+    colors.set([255, 128, 32, 255], rowIndex * 4);
+    opacities[rowIndex] = 1;
+  }
+  return {positions, scales, rotations, colors, opacities, rowIndexBase};
+}

--- a/modules/splats/test/gpu-splat-graph-renderer.spec.ts
+++ b/modules/splats/test/gpu-splat-graph-renderer.spec.ts
@@ -1,0 +1,126 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import type {Device} from '@luma.gl/core';
+import {GPUSplatGraphRenderer, makeGPUSplatData, type SplatSource} from '@luma.gl/splats';
+import {getTestDevices} from '@luma.gl/test-utils';
+
+test('GPUSplatGraphRenderer projects, culls, globally sorts, and indirectly draws preserved WebGPU batches', async t => {
+  const devices = await getTestDevices(['webgpu']);
+  t.ok(devices.length > 0, 'a browser WebGPU adapter is available');
+
+  for (const device of devices) {
+    const firstBatch = makeGPUSplatData(device, makeBrowserGraphSplatSource([0.2, 0.9], 0));
+    const secondSource = makeBrowserGraphSplatSource([0.6, 0.4], 2);
+    secondSource.opacities[1] = 0;
+    const secondBatch = makeGPUSplatData(device, secondSource);
+    const renderer = new GPUSplatGraphRenderer(device, {
+      data: [firstBatch, secondBatch],
+      viewportSize: [32, 32],
+      alphaCutoff: 0.01,
+      clearColor: [0, 0, 0, 0]
+    });
+
+    const encoding = renderer.encode(device.commandEncoder);
+    t.ok(
+      encoding,
+      'encodes every projection, global sort, and render node into the caller encoder'
+    );
+    t.ok(
+      renderer.compiledGraph?.stats.nodeOrder.includes('gaussian-splat-project-batch-0'),
+      'projects the first preserved source batch on the GPU'
+    );
+    t.ok(
+      renderer.compiledGraph?.stats.nodeOrder.includes('gaussian-splat-project-batch-1'),
+      'projects the second preserved source batch on the GPU'
+    );
+    t.ok(
+      renderer.compiledGraph?.stats.nodeOrder.includes('gaussian-splat-indirect-render'),
+      'schedules exactly one graph-native indirect render pass'
+    );
+    t.equal(
+      renderer.stats.drawCallCount,
+      1,
+      'renders all source batches through one indirect draw'
+    );
+    device.submit();
+
+    if (isSoftwareBackedGraphDevice(device)) {
+      t.comment('Skipping Gaussian splat GPU buffer readback on a software-backed adapter');
+    } else {
+      const commandBytes = await renderer.drawCommands.buffer.readAsync();
+      const commandWords = new Uint32Array(
+        commandBytes.buffer,
+        commandBytes.byteOffset,
+        commandBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+      );
+      t.deepEqual(
+        Array.from(commandWords),
+        [4, 3, 0, 0],
+        'GPU projection publishes three visible quad instances into its indirect command'
+      );
+
+      const sortedIndexBytes = await renderer.sortedIndexBuffer!.readAsync();
+      const sortedIndices = new Uint32Array(
+        sortedIndexBytes.buffer,
+        sortedIndexBytes.byteOffset,
+        sortedIndexBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+      );
+      t.deepEqual(
+        Array.from(sortedIndices),
+        [1, 2, 0, 3],
+        'globally sorts visible rows far-to-near and moves the culled sentinel to the end'
+      );
+    }
+
+    t.equal(
+      renderer.encode(device.commandEncoder),
+      undefined,
+      'does not repeat GPU projection and sorting when the camera remains stationary'
+    );
+    const previousGraph = renderer.compiledGraph;
+    renderer.setProps({radiusScale: 1.5});
+    t.ok(renderer.encode(device.commandEncoder), 'encodes updated camera/style uniforms');
+    t.equal(
+      renderer.compiledGraph,
+      previousGraph,
+      'reuses the compiled graph for property changes'
+    );
+    device.submit();
+
+    const firstPositionBuffer = firstBatch.positions.data[0].buffer;
+    renderer.destroy();
+    t.notOk(
+      firstPositionBuffer.destroyed,
+      'destroying the renderer preserves borrowed source data'
+    );
+    firstBatch.destroy();
+    secondBatch.destroy();
+  }
+
+  t.end();
+});
+
+function isSoftwareBackedGraphDevice(device: Device): boolean {
+  return (
+    device.info.gpu === 'software' || device.info.gpuType === 'cpu' || Boolean(device.info.fallback)
+  );
+}
+
+function makeBrowserGraphSplatSource(depths: readonly number[], rowIndexBase: number): SplatSource {
+  const positions = new Float32Array(depths.length * 3);
+  const scales = new Float32Array(depths.length * 3);
+  const rotations = new Float32Array(depths.length * 4);
+  const colors = new Uint8Array(depths.length * 4);
+  const opacities = new Float32Array(depths.length);
+  for (const [rowIndex, depth] of depths.entries()) {
+    positions[rowIndex * 3 + 2] = depth;
+    scales.set([0.2, 0.1, 0.03], rowIndex * 3);
+    rotations[rowIndex * 4] = 1;
+    colors.set([255, 128, 32, 255], rowIndex * 4);
+    opacities[rowIndex] = 1;
+  }
+  return {positions, scales, rotations, colors, opacities, rowIndexBase};
+}

--- a/modules/splats/test/gpu-splat-graph-shaders.node.spec.ts
+++ b/modules/splats/test/gpu-splat-graph-shaders.node.spec.ts
@@ -1,0 +1,163 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {WgslReflect} from 'wgsl_reflect';
+import {
+  GPU_SPLAT_GRAPH_UNIFORM_BYTE_LENGTH,
+  GPU_SPLAT_INVALID_DEPTH_KEY,
+  GPU_SPLAT_PROJECTION_SHADER,
+  GPU_SPLAT_PROJECTION_SHADER_LAYOUT,
+  GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH,
+  GPU_SPLAT_RENDER_SHADER,
+  GPU_SPLAT_RENDER_SHADER_LAYOUT
+} from '../src/gpu-splat-graph-shaders';
+
+test('GPU Gaussian shaders preserve the shared projected-record and uniform layouts', t => {
+  const projection = new WgslReflect(GPU_SPLAT_PROJECTION_SHADER);
+  const render = new WgslReflect(GPU_SPLAT_RENDER_SHADER);
+
+  for (const [name, shader] of [
+    ['projection', projection],
+    ['render', render]
+  ] as const) {
+    const projectedRecord = shader.structs.find(struct => struct.name === 'ProjectedSplat');
+    t.ok(projectedRecord, `${name}: projected record is reflected`);
+    t.equal(projectedRecord?.size, GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH, `${name}: stride is 48`);
+    t.deepEqual(
+      projectedRecord?.members.map(member => ({name: member.name, offset: member.offset})),
+      [
+        {name: 'clipCenter', offset: 0},
+        {name: 'axis0', offset: 16},
+        {name: 'axis1', offset: 24},
+        {name: 'color', offset: 32}
+      ],
+      `${name}: projected record retains center, anisotropic axes, and Float32 HDR color`
+    );
+
+    const graphUniforms = shader.uniforms.find(uniform => uniform.name === 'graphUniforms');
+    t.equal(graphUniforms?.size, GPU_SPLAT_GRAPH_UNIFORM_BYTE_LENGTH, `${name}: uniforms are 128`);
+    t.deepEqual(
+      graphUniforms?.members?.map(member => ({name: member.name, offset: member.offset})),
+      [
+        {name: 'modelViewProjectionMatrix', offset: 0},
+        {name: 'viewportSize', offset: 64},
+        {name: 'radiusScale', offset: 72},
+        {name: 'alphaScale', offset: 76},
+        {name: 'alphaCutoff', offset: 80},
+        {name: 'screenSizeCutoffPixels', offset: 84},
+        {name: 'gaussianSupportRadius', offset: 88},
+        {name: 'kernel2DSize', offset: 92},
+        {name: 'maxScreenSpaceSplatSize', offset: 96},
+        {name: 'exposure', offset: 100},
+        {name: 'toneMapping', offset: 104},
+        {name: 'batchOffset', offset: 108},
+        {name: 'rowCount', offset: 112},
+        {name: 'isFloatColor', offset: 116}
+      ],
+      `${name}: camera, styling, and preserved source-batch offsets are stable`
+    );
+  }
+
+  t.end();
+});
+
+test('GPU Gaussian projection stays within guaranteed WebGPU storage binding limits', t => {
+  const projection = new WgslReflect(GPU_SPLAT_PROJECTION_SHADER);
+  t.equal(projection.storage.length, 8, 'projection consumes exactly eight storage buffers');
+  t.deepEqual(
+    projection.storage.map(resource => ({name: resource.name, location: resource.binding})),
+    GPU_SPLAT_PROJECTION_SHADER_LAYOUT.bindings
+      .filter(binding => binding.type !== 'uniform')
+      .map(binding => ({name: binding.name, location: binding.location})),
+    'source columns and renderer-owned derived outputs match declared binding order'
+  );
+  t.equal(projection.uniforms[0]?.binding, 8, 'per-batch camera uniforms use binding eight');
+  t.equal(
+    projection.storage.find(resource => resource.name === 'projectedRecords')?.stride,
+    GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH,
+    'camera-projected records have a tightly packed 48-byte storage stride'
+  );
+
+  const render = new WgslReflect(GPU_SPLAT_RENDER_SHADER);
+  t.deepEqual(
+    [
+      ...render.uniforms.map(resource => ({name: resource.name, location: resource.binding})),
+      ...render.storage.map(resource => ({name: resource.name, location: resource.binding}))
+    ],
+    GPU_SPLAT_RENDER_SHADER_LAYOUT.bindings.map(binding => ({
+      name: binding.name,
+      location: binding.location
+    })),
+    'one draw consumes only camera uniforms, projected records, and globally sorted IDs'
+  );
+  t.end();
+});
+
+test('GPU Gaussian projection publishes stable 16-bit back-to-front visibility keys', t => {
+  const maximumValidDepthKey = GPU_SPLAT_INVALID_DEPTH_KEY - 1;
+  const getDepthKey = (clipDepth: number): number => {
+    const normalizedDepth = Math.min(Math.max(clipDepth * 0.5 + 0.5, 0), 1);
+    return maximumValidDepthKey - Math.round(normalizedDepth * maximumValidDepthKey);
+  };
+
+  t.equal(GPU_SPLAT_INVALID_DEPTH_KEY, 0xffff, 'culled rows use the final 16-bit sentinel');
+  t.equal(getDepthKey(1), 0, 'farthest visible rows sort first');
+  t.equal(getDepthKey(-1), maximumValidDepthKey, 'nearest visible rows sort last');
+  t.ok(getDepthKey(0.75) < getDepthKey(-0.75), 'ascending keys retain back-to-front blending');
+  t.ok(
+    getDepthKey(-1) < GPU_SPLAT_INVALID_DEPTH_KEY,
+    'visible rows never collide with the culled sentinel'
+  );
+  t.match(
+    GPU_SPLAT_PROJECTION_SHADER,
+    /depthKeys\[projectedRowIndex\]\s*=\s*MAXIMUM_VALID_DEPTH_KEY\s*-\s*quantizedDepth/,
+    'projection writes descending depth as an ascending 16-bit key'
+  );
+  t.match(
+    GPU_SPLAT_PROJECTION_SHADER,
+    /atomicAdd\(&drawCommands\[1u\],\s*1u\)/,
+    'visible rows increment the indirect draw instance-count word'
+  );
+  t.end();
+});
+
+test('GPU Gaussian shaders preserve rotated anisotropic HDR source data', t => {
+  t.match(
+    GPU_SPLAT_PROJECTION_SHADER,
+    /graphUniforms\.isFloatColor\s*!=\s*0u[\s\S]*?bitcast<f32>\(colors\[colorIndex\]\)/,
+    'Float32 source radiance is decoded without normalization or clamping'
+  );
+  t.match(
+    GPU_SPLAT_PROJECTION_SHADER,
+    /packedColor\s*>>\s*24u[\s\S]*?\/\s*255\.0/,
+    'packed RGBA8 source colors retain normalized alpha'
+  );
+  t.match(
+    GPU_SPLAT_PROJECTION_SHADER,
+    /getProjectedRotation\(rotations\[batchRowIndex\]\)/,
+    'anisotropic covariance preserves source quaternion rotation'
+  );
+  t.match(
+    GPU_SPLAT_PROJECTION_SHADER,
+    /let screenExtent\s*=\s*abs\(axis0\)\s*\+\s*abs\(axis1\)/,
+    'conservative screen culling retains the complete oriented Gaussian support'
+  );
+  t.match(
+    GPU_SPLAT_RENDER_SHADER,
+    /linearColor\s*\/\s*\(vec3<f32>\(1\.0\)\s*\+\s*linearColor\)/,
+    'projected rendering retains optional Reinhard HDR display mapping'
+  );
+  t.deepEqual(
+    new WgslReflect(GPU_SPLAT_RENDER_SHADER).entry.vertex.map(entry => entry.name),
+    ['vertexMain'],
+    'projected render shader exposes one instanced vertex entry point'
+  );
+  t.deepEqual(
+    new WgslReflect(GPU_SPLAT_RENDER_SHADER).entry.fragment.map(entry => entry.name),
+    ['fragmentMain'],
+    'projected render shader exposes one Gaussian fragment entry point'
+  );
+  t.end();
+});

--- a/modules/splats/test/gpu-splat-graph-shaders.spec.ts
+++ b/modules/splats/test/gpu-splat-graph-shaders.spec.ts
@@ -1,0 +1,34 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import {GPU_SPLAT_PROJECTION_SHADER, GPU_SPLAT_RENDER_SHADER} from '../src/gpu-splat-graph-shaders';
+
+test('GPU Gaussian projection and globally sorted rendering compile on WebGPU', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  for (const [name, source] of [
+    ['gaussian-splat-graph-projection', GPU_SPLAT_PROJECTION_SHADER],
+    ['gaussian-splat-graph-render', GPU_SPLAT_RENDER_SHADER]
+  ] as const) {
+    const shader = device.createShader({id: name, source});
+    try {
+      const errors = (await shader.getCompilationInfo())
+        .filter(message => message.type === 'error')
+        .map(message => `${message.lineNum}:${message.linePos} ${message.message}`)
+        .join('\n');
+      t.equal(errors, '', `${name} compiles${errors ? `\n${errors}` : ''}`);
+    } finally {
+      shader.destroy();
+    }
+  }
+
+  t.end();
+});

--- a/modules/splats/tsconfig.json
+++ b/modules/splats/tsconfig.json
@@ -10,6 +10,7 @@
   "references": [
     {"path": "../core"},
     {"path": "../engine"},
+    {"path": "../experimental"},
     {"path": "../shadertools"},
     {"path": "../tables"}
   ]

--- a/test/examples/gaussian-splat-viewer.node.spec.ts
+++ b/test/examples/gaussian-splat-viewer.node.spec.ts
@@ -7,6 +7,10 @@ import path from 'node:path';
 import {pathToFileURL} from 'node:url';
 import {afterEach, describe, expect, test, vi} from 'vitest';
 import {
+  getGaussianSplatExecutionMode,
+  makeGaussianSplatInfoHtml
+} from '../../examples/showcase/gaussian-splats/app';
+import {
   GAUSSIAN_SPLAT_SOURCE_CATALOG,
   getLocalGaussianSplatLoadersConfiguration,
   loadLocalGaussianSplatArrowSources,
@@ -23,6 +27,36 @@ afterEach(() => {
 });
 
 describe('published Gaussian splat viewer', () => {
+  test('defaults WebGPU to graph execution while preserving explicit CPU and WebGL fallbacks', () => {
+    expect(getGaussianSplatExecutionMode('webgpu')).toBe('graph');
+    expect(getGaussianSplatExecutionMode('webgpu', '?scene=truck')).toBe('graph');
+    expect(getGaussianSplatExecutionMode('webgpu', '?renderer=graph')).toBe('graph');
+    expect(getGaussianSplatExecutionMode('webgpu', '?renderer=cpu')).toBe('cpu');
+    expect(getGaussianSplatExecutionMode('webgl')).toBe('cpu');
+    expect(getGaussianSplatExecutionMode('webgl', '?renderer=graph')).toBe('cpu');
+  });
+
+  test('exposes the execution selector and graph diagnostics in the shared viewer panel', () => {
+    const viewerPanel = makeGaussianSplatInfoHtml();
+    const viewerSource = readFileSync(
+      path.join(process.cwd(), 'examples/showcase/gaussian-splats/app.ts'),
+      'utf8'
+    );
+    const viewerDocumentation = readFileSync(
+      path.join(process.cwd(), 'website/content/examples/showcase/gaussian-splat-viewer.mdx'),
+      'utf8'
+    );
+
+    expect(viewerPanel).toContain('data-gaussian-splats-pipeline');
+    expect(viewerPanel).toContain('data-gaussian-splats-execution');
+    expect(viewerPanel).toContain('data-gaussian-splats-graph-inspector');
+    expect(viewerSource).toContain('activeRenderer.encode(device.commandEncoder)');
+    expect(viewerSource).toContain('this.activateGraphRenderer()');
+    expect(viewerDocumentation).toContain('GPU command');
+    expect(viewerDocumentation).toContain('?renderer=cpu');
+    expect(viewerDocumentation).toContain('WebGL2');
+  });
+
   test('links the captured-scene viewer while preserving the synthetic showcase', () => {
     const tableOfContents = JSON.parse(
       readFileSync(

--- a/website/content/examples/showcase/gaussian-splat-viewer.mdx
+++ b/website/content/examples/showcase/gaussian-splat-viewer.mdx
@@ -1,13 +1,13 @@
 ---
 title: Gaussian Splat Viewer
-description: Stream complete captured Gaussian splat scenes from Hugging Face on WebGPU and WebGL2.
+description: Stream captured Gaussian splat scenes through a WebGPU command graph or WebGL2 fallback.
 sidebar_custom_props:
-  description: Stream complete captured Gaussian splat scenes from Hugging Face on WebGPU and WebGL2.
+  description: Stream complete Gaussian scenes through a WebGPU graph or WebGL2 fallback.
   backends: [webgpu, webgl2]
   display: hdr-capable
   difficulty: intermediate
   maturity: experimental
-  topics: [rendering, transparency, data, streaming, hdr]
+  topics: [rendering, transparency, streaming, gpu-graph, hdr]
 ---
 
 import {GaussianSplatViewerExample} from '@site/src/examples';
@@ -25,6 +25,13 @@ and `.ksplat` files without replacing the website's existing loaders.gl
 installation. [`@luma.gl/arrow`](/docs/api-reference/arrow) adapts each Apache Arrow record batch
 directly to [`@luma.gl/splats`](/docs/api-reference/splats), preserving batch ownership,
 floating-point HDR radiance, camera-aware transparency, and the WebGL2 fallback.
+
+On WebGPU, completed captures switch from their progressive preview to a compiled **GPU command
+graph**. Projection, visibility, depth ordering, and rendering remain GPU work rather than
+reprojecting hundreds of thousands of source rows on the main thread for every camera movement.
+Expand **GPU graph inspector** to see the real graph nodes, encoding timings, and transient-memory
+reuse. Choose **CPU depth ordering** in the execution selector, or append `?renderer=cpu`, to
+compare against the original renderer. WebGL2 always retains its compatible CPU-ordered fallback.
 
 Append `?scene=truck`, `?scene=drjohnson`, `?scene=playroom`, or `?scene=train-github` to select a
 capture directly. Provide `?source=https://example.com/scene.ply` for another compatible public

--- a/website/content/examples/showcase/gaussian-splats.mdx
+++ b/website/content/examples/showcase/gaussian-splats.mdx
@@ -1,13 +1,13 @@
 ---
 title: Gaussian Splats
-description: Render progressive anisotropic Gaussian splat batches on WebGPU and WebGL2.
+description: Render progressive Gaussian splats through a WebGPU command graph or WebGL2 fallback.
 sidebar_custom_props:
-  description: Render progressive anisotropic Gaussian splat batches on WebGPU and WebGL2.
+  description: Render progressive Gaussian splats through a WebGPU graph or WebGL2 fallback.
   backends: [webgpu, webgl2]
   display: hdr-capable
   difficulty: intermediate
   maturity: experimental
-  topics: [rendering, transparency, data, streaming, hdr]
+  topics: [rendering, transparency, streaming, gpu-graph, hdr]
 ---
 
 import {GaussianSplatsExample} from '@site/src/examples';
@@ -19,8 +19,10 @@ The Gaussian Splats showcase renders a deterministic, colorful scene with the ex
 owned, so additional splats can appear progressively without concatenating or reuploading the
 previously prepared GPU data.
 
-WebGPU uses storage-backed, camera-aware Gaussian rendering. WebGL2 provides an attribute-backed
-fallback using the same public renderer and prepared-data interfaces. The example keeps file
+WebGPU uses a compiled GPU command graph for camera-aware Gaussian projection, visibility,
+transparency ordering, and rendering. Expand **GPU graph inspector** for per-node encoding
+diagnostics, or select **CPU depth ordering** to compare against the original renderer. WebGL2
+provides its existing attribute-backed fallback. The example keeps file
 format parsing separate: loaders.gl owns `.ply`, `.splat`, `.ksplat`, and related loaders, while
 [`@luma.gl/arrow`](/docs/api-reference/arrow) converts Gaussian Apache Arrow batches into the
 framework-independent GPU representation.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4828,6 +4828,7 @@ __metadata:
   dependencies:
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
+    "@luma.gl/experimental": "npm:9.4.0-alpha.4"
     "@luma.gl/shadertools": "npm:9.4.0-alpha.4"
     "@luma.gl/tables": "npm:9.4.0-alpha.4"
   languageName: unknown


### PR DESCRIPTION
## Goals

- Move captured Gaussian splat projection, culling, global transparency ordering, and drawing onto a real WebGPU command graph.
- Preserve the existing WebGL2 renderer, caller-owned streamed Arrow batches, HDR radiance, and the production viewer introduced in #2932.

## Changes

- Add WebGPU-only `GPUSplatGraphRenderer` to the private `@luma.gl/splats` workspace. Each original source batch is projected independently into explicitly renderer-owned 48-byte screen-space records; the graph globally sorts all batches and issues one GPU-populated indirect draw.
- Extend reusable `GPUSort` with validated `keyBits` support, including odd-width finalization. Gaussian depth uses 16 significant bits, reducing the full-scene radix graph from 224 to 112 compute passes.
- Preserve anisotropic covariance, byte and floating-point HDR colors, automatic SDR Reinhard mapping, GPU-resident visibility counts, stationary-frame suppression, graph reuse, and borrowed source-buffer ownership.
- Default the production viewer to graph execution on WebGPU after streaming finishes. Keep progressive CPU previews, `?renderer=cpu` comparisons, automatic CPU fallback for unsupported devices, unchanged WebGL2 rendering, and a live command-graph inspector.
- Document the new API, execution modes, explicit resource ownership, device-limit fallback, and diagnostics.

## Verification

- `yarn build` — all packages compile successfully in dependency order.
- `yarn lint fix` — staged TypeScript/JSON checks pass without changes.
- Full Node suite: **550 passed**, one existing skipped.
- All **46** example workspaces typecheck successfully.
- Focused real-hardware WebGPU/WebGL suite: **14 passed**; CI-equivalent SwiftShader suite: **14 passed**.
- Production Docusaurus build, standalone ANARI assets, and **461** generated-document validations pass.
- Production browser verification covers WebGPU graph mode, the CPU selector, WebGL2 fallback, Hugging Face-to-GitHub two-batch fallback, idle suppression, and real canvas pixels (**91,653** non-background; **38,474** colored).
- A **741,883-splat** Train-size hardware run verifies globally sorted GPU output: **112 nodes**, **19.81 MiB** physical transient storage, **32.2 ms** one-time graph compilation, **4.3 ms** CPU command encoding, and **16.4 ms** GPU execution plus fenced readback.

## Risks and rollout

- Stacked on #2932; merge that production-viewer PR first.
- The projected-record buffer respects adapter storage limits: the default 128 MiB binding limit supports approximately 2.79 million splats, and the viewer automatically falls back to CPU rendering when a graph cannot be created.
- Software GPU coverage still executes projection, sorting, and indirect drawing; only fragile diagnostic readbacks are reserved for real hardware to avoid the existing SwiftShader/Dawn teardown issue.
