### PR TITLE
fix(experimental): reject writable physical command-graph buffer aliases

### DIFF
--- a/docs/api-reference/experimental/gpu-primitives/README.md
+++ b/docs/api-reference/experimental/gpu-primitives/README.md
@@ -1042,8 +1042,10 @@ deferred.
 
 The first larger-compute slice can proceed independently of package graduation because it uses the
 existing table-independent graph contract. Tranche 8.1a is implemented: `GPUHashIndex` rebuilds a
-fixed-capacity sparse `uint32` identity map, and `GPUHashIndexQuery` performs bounded batch lookup
-with deterministic duplicate values, explicit invalid and overflow counts, and probe statistics.
+fixed-capacity sparse `uint32` identity map from one packed batch, `GPUBatchHashIndex` builds the
+same shared map from preserved right-side chunks without concatenation, and `GPUHashIndexQuery`
+performs bounded lookup against either index with deterministic duplicate values, explicit invalid
+and overflow counts, and probe statistics.
 Tranche 8.2a is also implemented: `GPUHashJoin` composes lookup and stable scan into bounded
 many-to-one row-pair materialization with exact required-count and overflow reporting. It
 propagates incomplete source indices rather than presenting partial matches as complete. Tranche
@@ -1092,8 +1094,9 @@ consumers.
    documented decision gate gains a requesting consumer and positive evidence.
 5. Graduate packages only after both scene consumers prove the final APIs and dependency direction.
 6. Develop the larger compute vocabulary independently where contracts are already bounded:
-   `GPUHashIndex` build/query, bounded many-to-one `GPUHashJoin`, and shared-right
-   `GPUBatchHashJoin` are implemented; require consumers and measurements before adding mutable
+   single-batch `GPUHashIndex`, preserved-right-batch `GPUBatchHashIndex`, bounded many-to-one
+   `GPUHashJoin`, and shared-right `GPUBatchHashJoin` are implemented; require consumers and
+   measurements before adding mutable
    maintenance, partitioned-right routing, multi-match joins, sparse graph algorithms, or
    generalized field solvers.
 
@@ -1660,6 +1663,7 @@ close enough to WebGPU that developers can reason about cost, ordering, and owne
 - [GPU trace picking](/docs/api-reference/experimental/gpu-primitives/gpu-trace-picking)
 - [`GPUGroupAggregation`](/docs/api-reference/experimental/gpu-primitives/gpu-group-aggregation)
 - [`GPUHashIndex`](/docs/api-reference/experimental/gpu-primitives/gpu-hash-index)
+- [`GPUBatchHashIndex`](/docs/api-reference/experimental/gpu-primitives/gpu-batch-hash-index)
 - [`GPUHashJoin`](/docs/api-reference/experimental/gpu-primitives/gpu-hash-join)
 - [`GPUBatchHashJoin`](/docs/api-reference/experimental/gpu-primitives/gpu-batch-hash-join)
 - [`GPUIndexPickingTarget`](/docs/api-reference/experimental/gpu-primitives/gpu-index-picking-target)

--- a/docs/api-reference/experimental/gpu-primitives/gpu-batch-hash-index.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-batch-hash-index.md
@@ -1,0 +1,195 @@
+import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-docs-tabs';
+
+# GPUBatchHashIndex
+
+<GPUPrimitivesDocsTabs active="batch-hash-index" />
+
+## Overview
+
+`GPUBatchHashIndex` builds one fixed-capacity `uint32` key/value index from an ordered
+`GraphVectorView`. Every source chunk retains its existing GPU buffer, physical offset, and record
+batch boundary. The index clears its shared table once, processes chunks in source order, and
+publishes one cumulative set of build diagnostics without CPU readback or implicit concatenation.
+
+The result implements the same `GPUHashIndexView` contract as `GPUHashIndex`, so
+`GPUHashIndexQuery`, `GPUHashJoin`, and `GPUBatchHashJoin` can query it without knowing whether its
+right-side source occupied one buffer or many preserved record batches.
+
+## Why this feature exists
+
+`GPUHashIndex` accepts one packed `GraphDataView` and clears its table every time its build runs.
+Calling it separately for three streamed right-side batches would therefore overwrite the first
+two batches. Concatenating those batches beforehand would allocate new storage, copy their rows,
+erase their original offsets, and violate streaming ownership.
+
+`GPUBatchHashIndex` instead declares one table initialization followed by one ordered insertion
+and value-finalization sequence per nonempty chunk. It keeps source buffers borrowed, preserves
+empty batches, and retains the globally earliest source row when duplicate keys span chunks.
+
+Choose it for:
+
+- Arrow record batches arriving from a stream while interactive selections query one logical
+  property table.
+- Joining scene instances against a dictionary or feature registry split across independently
+  owned GPU allocations.
+- Preserving discontinuous source IDs such as batch bases `100`, `400`, and `900`.
+- Excluding nullable right-side keys without reporting ordinary nulls as invalid hash input.
+- Building one reusable sparse index for many left-side lookups or independently bounded joins.
+
+Use [`GPUHashIndex`](/docs/api-reference/experimental/gpu-primitives/gpu-hash-index) when the
+entire right side already occupies one packed chunk. Use
+[`GPUBatchHashJoin`](/docs/api-reference/experimental/gpu-primitives/gpu-batch-hash-join) when the
+left side also has several chunks; the right-index choice and left-join choice are independent.
+
+## Construction
+
+```ts
+new GPUBatchHashIndex({
+  id?,
+  keys,
+  values?,
+  validity?,
+  firstValues?,
+  tableKeys,
+  tableValues,
+  statistics,
+  maxProbeCount?
+});
+```
+
+| Property | Purpose |
+| --- | --- |
+| `keys` | Ordered packed `GraphVectorView<'uint32'>`; original chunks and empty batches are retained. |
+| `values` | Optional packed value vector with exactly the same ordered chunk topology as `keys`. |
+| `validity` | Optional aligned `uint32` validity vector; zero skips a source row and nonzero includes it. |
+| `firstValues` | Optional generated row-ID base for each chunk; cannot be combined with explicit `values`. |
+| `tableKeys` | Caller-owned packed unsigned key table with a positive power-of-two capacity. |
+| `tableValues` | Caller-owned value table with exactly the same capacity as `tableKeys`. |
+| `statistics` | Caller-owned packed unsigned view containing at least six cumulative counters. |
+| `maxProbeCount` | Maximum slots examined per included input row; defaults to the table capacity. |
+| `id` | Optional prefix used to name initialization and per-chunk graph commands. |
+
+`firstValues` defaults to contiguous logical source offsets. Supply an explicit array when original
+record-batch row IDs are discontinuous. An empty chunk still has a corresponding array entry so
+batch identity remains unambiguous.
+
+## Index streamed rows and query an interactive selection
+
+Import the already uploaded right-side vector once. The graph preserves its source buffers and
+uses caller-owned views for the persistent hash table and diagnostics:
+
+```ts
+const rightKeys = graph.importGPUVector('right-feature-ids', featureIdentifierVector);
+const rightValidity = graph.importGPUVector('right-key-validity', featureValidityVector);
+
+const featureIndex = new GPUBatchHashIndex({
+  id: 'streamed-feature-index',
+  keys: rightKeys,
+  validity: rightValidity,
+  firstValues: [100, 400, 900],
+  tableKeys: featureTableKeys,
+  tableValues: featureTableValues,
+  statistics: featureIndexStatistics,
+  maxProbeCount: 32
+});
+featureIndex.addToGraph(graph);
+
+new GPUHashIndexQuery({
+  id: 'lookup-visible-features',
+  index: featureIndex,
+  keys: selectedFeatureIds,
+  values: matchedFeatureRows,
+  found: matchedFeatureMask,
+  probes: lookupProbeCounts,
+  statistics: lookupStatistics
+}).addToGraph(graph);
+
+const compiled = graph.compile();
+const commandEncoder = device.createCommandEncoder();
+compiled.encode(commandEncoder);
+device.submit(commandEncoder.finish());
+```
+
+`matchedFeatureRows` and `matchedFeatureMask` remain GPU-resident. A later render or compute node
+can consume them directly. Reading the six index counters is an optional, explicit diagnostics
+operation; it is not performed by the index or the graph.
+
+## Join several left batches against several right batches
+
+The same shared index also composes with a preserved-batch left join:
+
+```ts
+const propertyIndex = new GPUBatchHashIndex({
+  id: 'property-index',
+  keys: rightPropertyIds,
+  values: rightPropertyRows,
+  validity: rightPropertyValidity,
+  tableKeys,
+  tableValues,
+  statistics: indexStatistics
+});
+propertyIndex.addToGraph(graph);
+
+new GPUBatchHashJoin({
+  id: 'join-instance-batches',
+  index: propertyIndex,
+  keys: instanceIdentifierBatches,
+  outputLeftRows: joinedInstanceRows,
+  outputRightRows: joinedPropertyRows,
+  counts: requiredMatchCounts,
+  overflows: batchOverflows,
+  statistics: batchLookupStatistics
+}).addToGraph(graph);
+```
+
+Left and right chunk topologies do not need to match. Right-side chunks contribute to one shared
+index; each left chunk independently preserves its own match capacity, stable row order, required
+count, overflow flag, and lookup diagnostics.
+
+## Duplicate, null, and reserved-key semantics
+
+The shared table retains one value per distinct key. Atomic source-row tracking selects the
+globally earliest valid occurrence across all chunks. For explicit values, that row contributes
+its aligned payload; for generated values, it contributes
+`firstValues[chunkIndex] + sourceRowWithinChunk`.
+
+An aligned validity value of zero silently excludes a row. This is different from an included
+row whose key is `GPU_HASH_INDEX_EMPTY_KEY` (`0xffffffff`): that key is reserved by the table and
+increments the invalid-row counter. Consequently, ordinary nullable keys do not invalidate an
+otherwise complete index, while malformed reserved keys remain visible in diagnostics.
+
+Duplicate rows do not generate additional matches. Consumers requiring a unique right-side table
+must inspect the duplicate counter and reject or otherwise handle nonzero values; duplicate
+expansion and many-to-many joins are intentionally outside this bounded primitive.
+
+## Build statistics and capacity
+
+`statistics` contains six cumulative `uint32` counters across every source chunk:
+
+```text
+[unique keys, duplicate rows, overflow rows, invalid rows, total probes, maximum probes]
+```
+
+An overflow means at least one included key could not claim a slot within `maxProbeCount`; the
+index must not be described as complete in that case. Increase the power-of-two capacity or probe
+bound and rebuild. Constructor validation rejects mismatched key/value/validity topology, outputs
+that physically overlap, invalid generated row IDs, non-packed views, and workloads whose worst
+possible cumulative probe count would overflow the counters.
+
+The implementation stores a global internal source ordinal for deterministic duplicate resolution
+while preserving caller-visible generated row IDs from `firstValues`. Empty input clears the table
+and counters without requiring a bound source row.
+
+## Ownership, commands, and repeated execution
+
+The application owns all imported input vectors, table buffers, and statistics. The graph owns
+its transient source-row bookkeeping and reclaims it when the compiled graph is destroyed.
+`GPUBatchHashIndex.addToGraph(graph)` only contributes command-graph nodes; it never compiles the
+graph, submits GPU work, copies rows, maps buffers, or destroys caller-owned data.
+
+Each repeated `CompiledGPUCommandGraph.encode()` rebuilds the index by clearing once and replaying
+its ordered chunk commands. Compile once when the workload shape is stable, reuse the compiled
+graph for successive frames or parameters, and keep imported resources alive until execution has
+completed. Shared physical buffers should be imported under one canonical graph handle whenever a
+command can write to them; see
+[physical buffer overlap and writable aliases](/docs/api-reference/experimental/gpu-primitives/gpu-command-graph#physical-buffer-overlap-and-writable-aliases).

--- a/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md
@@ -152,9 +152,9 @@ byte offsets must be divisible by four.
 
 Declares caller-owned storage. A default `Buffer` or `DynamicBuffer` may be supplied during graph
 construction, or the caller may provide a compatible override to each encoding. Represent each
-physical buffer with one logical handle and create multiple views from that handle. Distinct imported
-handles, including their per-encoding overrides, must not resolve to the same physical buffer because
-hazards are tracked by handle identity.
+physical buffer with one logical handle whenever any graph access writes to it. Separate active
+handles may resolve to the same physical buffer only when every access through both handles is
+read-only. The same rule applies to `DynamicBuffer` wrappers and per-encoding overrides.
 
 ### `createTransientBuffer(descriptor)`
 
@@ -176,6 +176,67 @@ Imports every fixed-width `GPUData` chunk without packing and returns a `GraphVe
 order, vector metadata, per-chunk offsets, and shared backing buffers are preserved. Interleaved and
 variable-length vectors require explicit adapters and are rejected.
 
+### Choosing a buffer feature
+
+Use `importBuffer()` when the application already owns persistent storage, such as source data,
+published results, or an indirect draw buffer. Use `createTransientBuffer()` for an intermediate
+that exists only while this graph executes; the compiler can safely reuse its allocation after its
+last scheduled use. Use `createDataView()` to describe a typed range of either kind of buffer.
+
+Use `importGPUData()` when one table chunk is the unit of work. Use `importGPUVector()` when the
+source arrived in several record batches and those boundaries matter. Importing a vector preserves
+its existing buffers, offsets, ordering, and empty chunks; it does not concatenate or upload rows.
+Multiple chunks backed by the same physical buffer reuse one canonical graph handle.
+
+### Physical buffer overlap and writable aliases
+
+Scheduling tracks buffer hazards by logical `GraphBufferHandle`, not by individual byte ranges.
+Two independently imported handles that resolve to one physical buffer would therefore hide a
+read-after-write or write-after-write dependency from the scheduler. Before recording any node,
+each `encode()` resolves defaults, `DynamicBuffer` wrappers, and `options.buffers` replacements to
+their actual physical buffers and applies these rules:
+
+| Active graph resources | Result | Why |
+| --- | --- | --- |
+| Two handles share a buffer and both are read-only | Allowed | Concurrent reads cannot corrupt each other. |
+| Two handles share a buffer and either has `storage-write`, `storage-read-write`, or `copy-destination` usage | Rejected before any node runs | Distinct handles cannot express the required write hazard. |
+| Several views share one canonical handle, including writable views | Allowed and ordered | Every access participates in the same inferred hazard chain. |
+| An otherwise duplicated import is not referenced by any graph node | Allowed | Inactive imports cannot race with graph commands. |
+| An encoding override introduces writable overlap | That encoding is rejected | Compatibility is checked against current physical bindings, not just graph defaults. |
+
+The safe pattern is to import shared storage once and derive each logical range from that handle:
+
+```ts
+const sharedStorage = graph.importBuffer(
+  {id: 'shared-storage', byteLength: sharedBuffer.byteLength, usage: Buffer.STORAGE},
+  sharedBuffer
+);
+const sourceRows = graph.createDataView(sharedStorage, {
+  id: 'source-rows',
+  format: 'uint32',
+  length: rowCount
+});
+const updatedRows = graph.createDataView(sharedStorage, {
+  id: 'updated-rows',
+  format: 'uint32',
+  length: rowCount
+});
+
+graph.addComputePass({
+  id: 'update-shared-rows',
+  resources: [
+    {buffer: sourceRows, usage: 'storage-read'},
+    {buffer: updatedRows, usage: 'storage-write'}
+  ],
+  compile: () => ({encode: encodeUpdatedRows})
+});
+```
+
+Do not work around this check by importing the same writable physical allocation under separate
+IDs. If two independently authored contributors need it, pass them the same handle or typed view.
+Validation never destroys caller-owned imports; after a rejected override, the caller can retry
+with distinct buffers or the original compatible defaults.
+
 ## Primitive multi-chunk support
 
 The multi-chunk column means that the primitive directly accepts a `GraphVectorView` and computes
@@ -196,6 +257,11 @@ its documented atomic graph resources; callers must select, adapt, or explicitly
 | `GPUGridBinning` | Position `GraphDataView` or `GraphVectorView` | ✅ |
 | `GPUGridAggregation` | Aligned position and weight views or vectors | ✅ |
 | `GPUGroupAggregation` | Dense group-key view or vector with optional aligned mask | ✅ |
+| `GPUHashIndex` | One packed unsigned-key `GraphDataView` | ❌ |
+| `GPUBatchHashIndex` | Ordered unsigned-key chunks and optional aligned values or validity | ✅ |
+| `GPUHashIndexQuery` | One packed left-key `GraphDataView` and a shared hash index | ❌ |
+| `GPUHashJoin` | One packed left-key `GraphDataView` and a shared hash index | ❌ |
+| `GPUBatchHashJoin` | Ordered left-key chunks and a shared single- or multi-batch right index | ✅ |
 | `GPUIndexPickingTarget` | Texture and readback resources | ❌ |
 | `DrawCommandBuffer` | Indirect command buffer | ❌ |
 
@@ -295,12 +361,89 @@ ordered after the render pass.
 Multisample resolve is currently a WebGPU contract. Render-pass callbacks cannot also supply their
 own framebuffer or resolve targets when graph attachments are present.
 
-## Node APIs
+## Node APIs and graph commands
 
-- `addComputePass(node)` compiles an executable callback that receives a graph-owned `ComputePass`.
-- `addRenderPass(node)` may declare graph texture `attachments`, resolve other `RenderPassProps`
-  for each encoding, and receives a graph-owned `RenderPass`.
-- `addCopyPass(node)` records directly on the caller's `CommandEncoder`.
+A graph command is a reusable description of GPU work, not a second command queue or a hidden
+submission API. `compile()` prepares node executables once; `encode(commandEncoder, options)`
+records them into the application's existing `CommandEncoder`; the application decides when to
+submit that encoder. This distinction lets analytics, rendering, and explicitly requested
+readback share one dependency-ordered execution without taking ownership of the frame loop.
+
+| Feature | Why it exists | Typical use |
+| --- | --- | --- |
+| `addComputePass()` | Schedule shader dispatch alongside its declared buffer and texture hazards. | Filtering, scans, sorting, hash-index construction, aggregation, and indirect-command generation. |
+| `addRenderPass()` | Schedule drawing with graph-managed attachments, resolves, and sampled resources. | Scene rendering, picking, off-screen layers, and multisampled frame composition. |
+| `addCopyPass()` | Express transfers or encoder-level operations in the same ordered graph. | Explicit compact-result readback, staging uploads, and copying finished render targets. |
+| `dependsOn` | Describe an ordering requirement that no shared graph resource can express. | External side effects, timestamp boundaries, and application-owned synchronization. |
+| Repeated `encode()` | Reuse compiled pipelines and scratch allocations with new parameters or imports. | Interactive filters, animation frames, changing selections, and reusable query plans. |
+
+### `addComputePass(node)`
+
+Use a compute node whenever a shader reads or writes resources that other graph features consume.
+The graph opens and closes its own `ComputePass`; the executable only records dispatch commands.
+Declaring every input as `storage-read` and every output as `storage-write` lets later compute,
+render, or copy nodes automatically wait for the produced data.
+
+```ts
+graph.addComputePass({
+  id: 'select-visible-rows',
+  resources: [
+    {buffer: inputRows, usage: 'storage-read'},
+    {buffer: visibilityMask, usage: 'storage-write'}
+  ],
+  compile: ({device}) => createVisibilityExecutable(device)
+});
+```
+
+Primitives such as `GPUBatchHashIndex`, `GPUScan`, and `GPUHashJoin` use this same public graph
+contract: `primitive.addToGraph(graph)` contributes compute nodes but does not compile, submit, or
+read back the graph on the application's behalf.
+
+### `addRenderPass(node)`
+
+Use a render node when graph-produced buffers or textures feed a draw, or when a draw produces a
+texture consumed by a later pass. Declare sampled and vertex inputs normally and supply graph-owned
+`attachments` when the graph should resolve the framebuffer. Multisampled attachments can provide
+`resolveTargets`; attachment writes then participate in ordinary texture hazard ordering.
+
+```ts
+graph.addRenderPass({
+  id: 'draw-visible-instances',
+  resources: [{buffer: visibleRows, usage: 'vertex'}],
+  attachments: {colorAttachments: [frameColor]},
+  compile: () => ({encode: encodeVisibleInstances})
+});
+```
+
+The graph owns the `RenderPass` lifecycle. The executable records drawing commands; it must not
+end the pass, submit the encoder, or replace a graph-managed framebuffer.
+
+### `addCopyPass(node)`
+
+Use a copy node when an operation belongs directly on the application's `CommandEncoder`, such as
+copying one small summary into an explicitly requested readback buffer. Copying is never implied by
+graph execution: an application that keeps all results GPU-resident should not add a readback
+node. Declare the source and destination so transfers are ordered after producers and before
+subsequent consumers.
+
+```ts
+graph.addCopyPass({
+  id: 'copy-result-summary',
+  resources: [
+    {buffer: resultSummary, usage: 'copy-source'},
+    {buffer: readbackSummary, usage: 'copy-destination'}
+  ],
+  compile: () => ({encode: encodeSummaryCopy})
+});
+```
+
+### Explicit dependencies and repeated encodings
+
+Prefer declared resource uses because they explain both ordering and transient lifetimes. Add
+`dependsOn: ['upstream-node-id']` only when an application-visible dependency has no corresponding
+buffer or texture hazard. Compile the complete graph once, then supply fresh parameters or
+compatible imported buffers through later `encode()` calls. Writable physical-buffer overlap is
+revalidated for every encoding before any node records work.
 
 Buffer nodes declare storage, uniform, copy, indirect, vertex, and index uses. Texture nodes declare
 `sampled`, storage, render-attachment, and copy uses. Render attachments are automatically treated

--- a/docs/api-reference/experimental/gpu-primitives/gpu-hash-index.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-hash-index.md
@@ -17,6 +17,24 @@ most `maxProbeCount` slots, one key value is reserved as the empty marker, and b
 publish collision-work statistics. This makes worst-case GPU work and memory visible to command-
 graph consumers instead of hiding resize, allocation, or readback behind a map-like API.
 
+## Choosing the right hash-graph feature
+
+These features compose; they do not provide competing command schedulers or silently concatenate
+their inputs:
+
+| Feature | Input it owns logically | Use it when |
+| --- | --- | --- |
+| `GPUHashIndex` | One packed right-side key batch. | The complete lookup dictionary or property table already lives in one contiguous chunk. |
+| [`GPUBatchHashIndex`](/docs/api-reference/experimental/gpu-primitives/gpu-batch-hash-index) | Several ordered right-side key chunks. | Streamed record batches must populate one shared index without repacking or losing source-row offsets. |
+| `GPUHashIndexQuery` | One left-side key batch against either index type. | Every source row must retain its position, a found mask, and an optional matched value. |
+| [`GPUHashJoin`](/docs/api-reference/experimental/gpu-primitives/gpu-hash-join) | One left-side key batch against either index type. | Only matching left/right row pairs should be published, with an explicit output capacity. |
+| [`GPUBatchHashJoin`](/docs/api-reference/experimental/gpu-primitives/gpu-batch-hash-join) | Several preserved left-side chunks against either index type. | Independent source batches need separate stable pairs, counts, capacities, and diagnostics. |
+
+The right-index choice and left-query choice are independent. For example, a
+`GPUBatchHashIndex` can index many Arrow record batches while `GPUHashIndexQuery` looks up one
+interactive selection, or `GPUBatchHashJoin` can join many left batches against that same shared
+multi-batch index. Every object contributes commands to the caller's existing `GPUCommandGraph`.
+
 ## Concepts
 
 ### Sparse identity is different from dense grouping
@@ -94,10 +112,11 @@ parallel insertion, and deterministic value-finalization passes; the graph owns 
 source-row buffer. Query contributes statistics initialization and lookup. Neither object compiles,
 encodes, submits, resizes, or reads back on its own.
 
-This first slice supports packed `uint32` keys and values and full rebuilds. Deletion and
-tombstones, preserved vector chunks, 64-bit keys, custom hash callbacks, partitioned tables, and
-join materialization remain future contracts. Starting with exact lookup keeps those additions
-grounded in real consumers rather than baking a general-purpose database into the primitive.
+This single-batch primitive supports packed `uint32` keys and values and full rebuilds.
+`GPUBatchHashIndex` adds preserved right-side vector chunks, while `GPUHashJoin` and
+`GPUBatchHashJoin` provide bounded row-pair publication. Deletion and tombstones, 64-bit keys,
+custom hash callbacks, independently partitioned right tables, and one-to-many matches remain
+outside the current contracts.
 
 ## Usage
 

--- a/docs/api-reference/experimental/gpu-primitives/gpu-hash-join.md
+++ b/docs/api-reference/experimental/gpu-primitives/gpu-hash-join.md
@@ -7,8 +7,8 @@ import {GPUPrimitivesDocsTabs} from '@site/src/components/docs/gpu-primitives-do
 ## Overview
 
 `GPUHashJoin` turns sparse exact lookup into stable, capacity-bounded inner-join row pairs. It
-queries a previously built `GPUHashIndex`, scans the match mask, and publishes aligned left and
-right row IDs without CPU selection, hidden submission, or readback.
+queries a previously built `GPUHashIndex` or `GPUBatchHashIndex`, scans the match mask, and
+publishes aligned left and right row IDs without CPU selection, hidden submission, or readback.
 
 This solves a common GPU data-boundary problem: one buffer contains observations, instances, or
 selected objects identified by sparse stable keys, while another buffer contains properties in a
@@ -46,8 +46,10 @@ the aligned diagnostics available even when the primary result is compacted.
 ### The first contract is many-to-one
 
 The right index stores one value per distinct key. If right-side input contains duplicate keys,
-`GPUHashIndex` deterministically retains the value from the lowest source row. The resulting join
-is therefore many-left-to-one-right: repeated left keys may all map to one right row.
+either hash-index implementation deterministically retains the value from the lowest source row.
+For `GPUBatchHashIndex`, that winner is the earliest row across all preserved right-side chunks.
+The resulting join is therefore many-left-to-one-right: repeated left keys may all map to one
+right row.
 
 This is intentional. One-to-many and many-to-many joins require a different right-side structure,
 usually key-group offsets plus a value list, and can expand output far beyond left input length.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -256,6 +256,7 @@
               "api-reference/experimental/gpu-primitives/gpu-trace-picking",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/gpu-hash-index",
+              "api-reference/experimental/gpu-primitives/gpu-batch-hash-index",
               "api-reference/experimental/gpu-primitives/gpu-hash-join",
               "api-reference/experimental/gpu-primitives/gpu-batch-hash-join",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"
@@ -385,6 +386,7 @@
               "api-reference/experimental/gpu-primitives/gpu-trace-picking",
               "api-reference/experimental/gpu-primitives/gpu-group-aggregation",
               "api-reference/experimental/gpu-primitives/gpu-hash-index",
+              "api-reference/experimental/gpu-primitives/gpu-batch-hash-index",
               "api-reference/experimental/gpu-primitives/gpu-hash-join",
               "api-reference/experimental/gpu-primitives/gpu-batch-hash-join",
               "api-reference/experimental/gpu-primitives/draw-command-buffer"

--- a/modules/experimental/src/gpu-primitives/gpu-batch-hash-index.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-batch-hash-index.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {GraphVectorView, type GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
 import {

--- a/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-command-graph.ts
@@ -248,9 +248,9 @@ export class GPUCommandGraph<Parameters = void> {
   /**
    * Declares a caller-owned buffer that can be supplied now or for each encoding.
    *
-   * Represent one physical buffer with one logical handle. Reuse that handle for multiple views;
-   * distinct imported handles and their per-encoding overrides must resolve to distinct physical
-   * buffers because graph hazards are tracked by handle identity.
+   * Represent one physical buffer with one logical handle whenever a graph access may write to
+   * it. Distinct active imported handles may share a physical buffer only when every graph access
+   * is read-only because write hazards are tracked by handle identity.
    *
    * @param descriptor Required capacity and usage.
    * @param defaultBuffer Optional default binding used when an encoding supplies no override.
@@ -731,6 +731,8 @@ export class CompiledGPUCommandGraph<Parameters = void> {
   private readonly textures: Map<string, GraphTextureHandle>;
   private readonly externalTextures: Map<string, GraphExternalTextureHandle>;
   private readonly compiledNodes: CompiledNode<Parameters>[];
+  private readonly activeImportedBufferHandles = new Set<GraphBufferHandle>();
+  private readonly writableImportedBufferHandles = new Set<GraphBufferHandle>();
   private readonly transientBuffers: Map<GraphBufferHandle, Buffer>;
   private readonly transientTextures: Map<GraphTextureHandle, Texture>;
   private readonly bufferTransientAllocations: BufferTransientAllocation[];
@@ -750,6 +752,23 @@ export class CompiledGPUCommandGraph<Parameters = void> {
     this.textures = props.textures;
     this.externalTextures = props.externalTextures;
     this.compiledNodes = props.compiledNodes;
+    for (const {node} of this.compiledNodes) {
+      for (const resource of node.resources ?? []) {
+        if (isGraphBufferUse(resource)) {
+          const handle = getBufferHandle(resource.buffer);
+          if (!handle.transient) {
+            this.activeImportedBufferHandles.add(handle);
+            if (
+              resource.usage === 'storage-write' ||
+              resource.usage === 'storage-read-write' ||
+              resource.usage === 'copy-destination'
+            ) {
+              this.writableImportedBufferHandles.add(handle);
+            }
+          }
+        }
+      }
+    }
     this.transientBuffers = props.transientBuffers;
     this.transientTextures = props.transientTextures;
     this.bufferTransientAllocations = props.bufferTransientAllocations;
@@ -763,7 +782,8 @@ export class CompiledGPUCommandGraph<Parameters = void> {
    *
    * Imported resources are resolved from per-encoding overrides first, then from defaults supplied
    * at graph construction. Buffer overrides for distinct handles must not alias the same physical
-   * buffer. This method records only; it does not finish or submit the encoder.
+   * buffer when either handle is written. This method records only; it does not finish or submit
+   * the encoder.
    *
    * @param commandEncoder Encoder that receives all graph commands.
    * @param options Per-encoding parameters and optional imported-resource replacements.
@@ -987,6 +1007,7 @@ export class CompiledGPUCommandGraph<Parameters = void> {
     overrides: Record<string, GraphImportedBuffer>
   ): Map<GraphBufferHandle, Buffer> {
     const resolved = new Map<GraphBufferHandle, Buffer>();
+    const activePhysicalBuffers = new Map<object, GraphBufferHandle>();
     for (const [id, handle] of this.buffers) {
       if (handle.transient) {
         continue;
@@ -996,7 +1017,29 @@ export class CompiledGPUCommandGraph<Parameters = void> {
         throw new Error(`GPUCommandGraph imported buffer "${id}" is required`);
       }
       validateImportedBuffer(importedBuffer, handle, this.device);
-      resolved.set(handle, getCoreBuffer(importedBuffer));
+      const coreBuffer = getCoreBuffer(importedBuffer);
+      if (this.activeImportedBufferHandles.has(handle)) {
+        const physicalHandle = coreBuffer.handle;
+        const physicalBuffer =
+          (typeof physicalHandle === 'object' && physicalHandle !== null) ||
+          typeof physicalHandle === 'function'
+            ? physicalHandle
+            : coreBuffer;
+        const previousHandle = activePhysicalBuffers.get(physicalBuffer);
+        if (
+          previousHandle &&
+          (this.writableImportedBufferHandles.has(previousHandle) ||
+            this.writableImportedBufferHandles.has(handle))
+        ) {
+          throw new Error(
+            `GPUCommandGraph imported buffers "${previousHandle.id}" and "${id}" resolve to the same physical buffer`
+          );
+        }
+        if (!previousHandle) {
+          activePhysicalBuffers.set(physicalBuffer, handle);
+        }
+      }
+      resolved.set(handle, coreBuffer);
     }
     for (const id of Object.keys(overrides)) {
       const handle = this.buffers.get(id);

--- a/modules/experimental/src/ludf/index.ts
+++ b/modules/experimental/src/ludf/index.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 export {LuDataFrame} from './lu-data-frame';
 export type {

--- a/modules/experimental/src/ludf/lu-data-frame.ts
+++ b/modules/experimental/src/ludf/lu-data-frame.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {BufferLayout} from '@luma.gl/core';
 import {

--- a/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer} from '@luma.gl/core';
 import {

--- a/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-alias.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-alias.node.spec.ts
@@ -1,0 +1,452 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import {
+  GPUCommandGraph,
+  type CompiledGPUCommandGraph,
+  type GraphBufferHandle,
+  type GraphDataView,
+  type GraphImportedBuffer
+} from '@luma.gl/experimental';
+import {NullDevice} from '@luma.gl/test-utils';
+import {describe, expect, test, vi} from 'vitest';
+
+type GraphAliasFixture = {
+  device: NullDevice;
+  graph: GPUCommandGraph;
+  buffers: Buffer[];
+  dynamicBuffers: DynamicBuffer[];
+};
+
+describe('GPUCommandGraph physical imported-buffer ownership', () => {
+  test('rejects one physical default buffer used by two active logical handles', () => {
+    const fixture = createGraphAliasFixture('duplicate-default');
+    const sharedBuffer = createGraphAliasBuffer(fixture, 'shared-default');
+    const input = importGraphAliasBuffer(fixture, 'input', sharedBuffer);
+    const output = importGraphAliasBuffer(fixture, 'output', sharedBuffer);
+    const encodeNode = vi.fn();
+    addGraphAliasCopyPass(fixture.graph, input, output, encodeNode);
+    const compiled = fixture.graph.compile();
+
+    try {
+      expect(() => encodeGraphAliasFixture(fixture, compiled)).toThrow(
+        /input.*output.*same physical buffer/i
+      );
+      expect(encodeNode).not.toHaveBeenCalled();
+      expect(sharedBuffer.destroyed).toBe(false);
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('allows distinct active logical handles to share a read-only physical buffer', () => {
+    const fixture = createGraphAliasFixture('shared-read-only-buffer');
+    const sharedBuffer = createGraphAliasBuffer(fixture, 'shared-read-only');
+    const firstReader = importGraphAliasBuffer(fixture, 'first-reader', sharedBuffer);
+    const secondReader = importGraphAliasBuffer(fixture, 'second-reader', sharedBuffer);
+    const encodeNode = vi.fn();
+    fixture.graph.addCopyPass({
+      id: 'observe-read-only-aliases',
+      resources: [
+        {buffer: firstReader, usage: 'storage-read'},
+        {buffer: secondReader, usage: 'storage-read'}
+      ],
+      compile: () => ({encode: encodeNode})
+    });
+    const compiled = fixture.graph.compile();
+
+    try {
+      encodeGraphAliasFixture(fixture, compiled);
+      expect(encodeNode).toHaveBeenCalledTimes(1);
+      expect(sharedBuffer.destroyed).toBe(false);
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test.each([
+    {
+      identifier: 'read-before-write',
+      firstUsage: 'storage-read',
+      secondUsage: 'storage-write',
+      bufferUsage: Buffer.STORAGE
+    },
+    {
+      identifier: 'write-before-read',
+      firstUsage: 'storage-write',
+      secondUsage: 'storage-read',
+      bufferUsage: Buffer.STORAGE
+    },
+    {
+      identifier: 'read-before-read-write',
+      firstUsage: 'storage-read',
+      secondUsage: 'storage-read-write',
+      bufferUsage: Buffer.STORAGE
+    },
+    {
+      identifier: 'read-before-copy-destination',
+      firstUsage: 'storage-read',
+      secondUsage: 'copy-destination',
+      bufferUsage: Buffer.STORAGE | Buffer.COPY_DST
+    }
+  ] as const)('rejects physically aliased active handles whenever an access mutates ($identifier)', ({
+    identifier,
+    firstUsage,
+    secondUsage,
+    bufferUsage
+  }) => {
+    const fixture = createGraphAliasFixture(identifier);
+    const sharedBuffer = createGraphAliasBuffer(fixture, 'shared-mutating-buffer', bufferUsage);
+    const first = importGraphAliasBuffer(fixture, 'first', sharedBuffer, bufferUsage);
+    const second = importGraphAliasBuffer(fixture, 'second', sharedBuffer, bufferUsage);
+    const encodeNode = vi.fn();
+    fixture.graph.addCopyPass({
+      id: 'observe-mutating-aliases',
+      resources: [
+        {buffer: first, usage: firstUsage},
+        {buffer: second, usage: secondUsage}
+      ],
+      compile: () => ({encode: encodeNode})
+    });
+    const compiled = fixture.graph.compile();
+
+    try {
+      expect(() => encodeGraphAliasFixture(fixture, compiled)).toThrow(
+        /first.*second.*same physical buffer/i
+      );
+      expect(encodeNode).not.toHaveBeenCalled();
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('rejects an initially read-only aliased handle that a later node writes', () => {
+    const fixture = createGraphAliasFixture('later-alias-write');
+    const sharedBuffer = createGraphAliasBuffer(fixture, 'shared-eventually-writable');
+    const first = importGraphAliasBuffer(fixture, 'first', sharedBuffer);
+    const second = importGraphAliasBuffer(fixture, 'second', sharedBuffer);
+    const encodeFirstNode = vi.fn();
+    const encodeSecondNode = vi.fn();
+    fixture.graph.addCopyPass({
+      id: 'read-both-aliased-handles',
+      resources: [
+        {buffer: first, usage: 'storage-read'},
+        {buffer: second, usage: 'storage-read'}
+      ],
+      compile: () => ({encode: encodeFirstNode})
+    });
+    fixture.graph.addCopyPass({
+      id: 'write-first-aliased-handle',
+      resources: [{buffer: first, usage: 'storage-write'}],
+      compile: () => ({encode: encodeSecondNode})
+    });
+    const compiled = fixture.graph.compile();
+
+    try {
+      expect(() => encodeGraphAliasFixture(fixture, compiled)).toThrow(
+        /first.*second.*same physical buffer/i
+      );
+      expect(encodeFirstNode).not.toHaveBeenCalled();
+      expect(encodeSecondNode).not.toHaveBeenCalled();
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('rejects an override alias and still accepts later distinct backing buffers', () => {
+    const fixture = createGraphAliasFixture('default-override');
+    const inputBuffer = createGraphAliasBuffer(fixture, 'input-default');
+    const outputBuffer = createGraphAliasBuffer(fixture, 'output-default');
+    const input = importGraphAliasBuffer(fixture, 'input', inputBuffer);
+    const output = importGraphAliasBuffer(fixture, 'output', outputBuffer);
+    const encodeNode = vi.fn();
+    addGraphAliasCopyPass(fixture.graph, input, output, encodeNode);
+    const compiled = fixture.graph.compile();
+
+    try {
+      expect(() => encodeGraphAliasFixture(fixture, compiled, {output: inputBuffer})).toThrow(
+        /input.*output.*same physical buffer/i
+      );
+      expect(encodeNode).not.toHaveBeenCalled();
+
+      encodeGraphAliasFixture(fixture, compiled, {output: outputBuffer});
+      expect(encodeNode).toHaveBeenCalledTimes(1);
+      expect(inputBuffer.destroyed).toBe(false);
+      expect(outputBuffer.destroyed).toBe(false);
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('rejects one override supplied for two active predeclared imports', () => {
+    const fixture = createGraphAliasFixture('override-override');
+    const sharedBuffer = createGraphAliasBuffer(fixture, 'shared-override');
+    const input = importGraphAliasBuffer(fixture, 'input');
+    const output = importGraphAliasBuffer(fixture, 'output');
+    const encodeNode = vi.fn();
+    addGraphAliasCopyPass(fixture.graph, input, output, encodeNode);
+    const compiled = fixture.graph.compile();
+
+    try {
+      expect(() =>
+        encodeGraphAliasFixture(fixture, compiled, {
+          input: sharedBuffer,
+          output: sharedBuffer
+        })
+      ).toThrow(/input.*output.*same physical buffer/i);
+      expect(encodeNode).not.toHaveBeenCalled();
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('compares DynamicBuffer defaults by their current core-buffer identity', () => {
+    const fixture = createGraphAliasFixture('dynamic-default');
+    const sharedBuffer = createGraphAliasBuffer(fixture, 'shared-dynamic-buffer');
+    const dynamicBuffer = new DynamicBuffer(fixture.device, {
+      id: 'borrowed-dynamic-buffer',
+      buffer: sharedBuffer,
+      ownsBuffer: false
+    });
+    fixture.dynamicBuffers.push(dynamicBuffer);
+    const input = importGraphAliasBuffer(fixture, 'dynamic-input', dynamicBuffer);
+    const output = importGraphAliasBuffer(fixture, 'core-output', sharedBuffer);
+    const encodeNode = vi.fn();
+    addGraphAliasCopyPass(fixture.graph, input, output, encodeNode);
+    const compiled = fixture.graph.compile();
+
+    try {
+      expect(() => encodeGraphAliasFixture(fixture, compiled)).toThrow(
+        /dynamic-input.*core-output.*same physical buffer/i
+      );
+      expect(encodeNode).not.toHaveBeenCalled();
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('rejects distinct core Buffer wrappers exposing the same physical handle', () => {
+    const fixture = createGraphAliasFixture('borrowed-buffer-wrappers');
+    const inputBuffer = createGraphAliasBuffer(fixture, 'input-wrapper');
+    const outputBuffer = createGraphAliasBuffer(fixture, 'output-wrapper');
+    const sharedPhysicalHandle = {};
+    Object.defineProperty(inputBuffer, 'handle', {value: sharedPhysicalHandle, writable: true});
+    Object.defineProperty(outputBuffer, 'handle', {value: sharedPhysicalHandle, writable: true});
+    const input = importGraphAliasBuffer(fixture, 'input-wrapper', inputBuffer);
+    const output = importGraphAliasBuffer(fixture, 'output-wrapper', outputBuffer);
+    const encodeNode = vi.fn();
+    addGraphAliasCopyPass(fixture.graph, input, output, encodeNode);
+    const compiled = fixture.graph.compile();
+
+    try {
+      expect(() => encodeGraphAliasFixture(fixture, compiled)).toThrow(
+        /input-wrapper.*output-wrapper.*same physical buffer/i
+      );
+      expect(encodeNode).not.toHaveBeenCalled();
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('rechecks resized DynamicBuffer backing storage on every graph encoding', () => {
+    const fixture = createGraphAliasFixture('dynamic-resize');
+    const dynamicBuffer = new DynamicBuffer(fixture.device, {
+      id: 'resizable-dynamic-buffer',
+      byteLength: 16,
+      usage: Buffer.STORAGE
+    });
+    fixture.dynamicBuffers.push(dynamicBuffer);
+    const separateBuffer = createGraphAliasBuffer(fixture, 'separate-output');
+    const input = importGraphAliasBuffer(fixture, 'dynamic-input', dynamicBuffer);
+    const output = importGraphAliasBuffer(fixture, 'output', separateBuffer);
+    const encodeNode = vi.fn();
+    addGraphAliasCopyPass(fixture.graph, input, output, encodeNode);
+    const compiled = fixture.graph.compile();
+
+    try {
+      encodeGraphAliasFixture(fixture, compiled);
+      expect(encodeNode).toHaveBeenCalledTimes(1);
+
+      dynamicBuffer.resize({byteLength: 32});
+      expect(() =>
+        encodeGraphAliasFixture(fixture, compiled, {output: dynamicBuffer.buffer})
+      ).toThrow(/dynamic-input.*output.*same physical buffer/i);
+      expect(encodeNode).toHaveBeenCalledTimes(1);
+
+      encodeGraphAliasFixture(fixture, compiled, {output: separateBuffer});
+      expect(encodeNode).toHaveBeenCalledTimes(2);
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('ignores unused alias handles and unused predeclared override bindings', () => {
+    const fixture = createGraphAliasFixture('inactive-imports');
+    const inputBuffer = createGraphAliasBuffer(fixture, 'active-input-buffer');
+    const outputBuffer = createGraphAliasBuffer(fixture, 'active-output-buffer');
+    const input = importGraphAliasBuffer(fixture, 'active-input', inputBuffer);
+    const output = importGraphAliasBuffer(fixture, 'active-output', outputBuffer);
+    importGraphAliasBuffer(fixture, 'unused-default-alias', inputBuffer);
+    importGraphAliasBuffer(fixture, 'unused-override-alias');
+    const encodeNode = vi.fn();
+    addGraphAliasCopyPass(fixture.graph, input, output, encodeNode);
+    const compiled = fixture.graph.compile();
+
+    try {
+      encodeGraphAliasFixture(fixture, compiled, {'unused-override-alias': inputBuffer});
+      expect(encodeNode).toHaveBeenCalledTimes(1);
+      expect(inputBuffer.destroyed).toBe(false);
+      expect(outputBuffer.destroyed).toBe(false);
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('allows multiple active ranges over one canonical logical buffer handle', () => {
+    const fixture = createGraphAliasFixture('shared-logical-handle');
+    const sharedBuffer = createGraphAliasBuffer(fixture, 'shared-ranges');
+    const handle = importGraphAliasBuffer(fixture, 'shared', sharedBuffer);
+    const input = fixture.graph.createDataView(handle, {
+      format: 'uint32',
+      length: 1,
+      byteOffset: 0
+    });
+    const output = fixture.graph.createDataView(handle, {
+      format: 'uint32',
+      length: 1,
+      byteOffset: Uint32Array.BYTES_PER_ELEMENT
+    });
+    const encodeNode = vi.fn();
+    addGraphAliasCopyPass(fixture.graph, input, output, encodeNode);
+    const compiled = fixture.graph.compile();
+
+    try {
+      encodeGraphAliasFixture(fixture, compiled);
+      expect(encodeNode).toHaveBeenCalledTimes(1);
+      expect(sharedBuffer.destroyed).toBe(false);
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+
+  test('preserves graph-owned transient-buffer lifetime reuse', () => {
+    const fixture = createGraphAliasFixture('transient-reuse');
+    const first = fixture.graph.createTransientBuffer({
+      id: 'first-transient',
+      byteLength: 16,
+      usage: Buffer.STORAGE
+    });
+    const second = fixture.graph.createTransientBuffer({
+      id: 'second-transient',
+      byteLength: 16,
+      usage: Buffer.STORAGE
+    });
+    const encodeFirst = vi.fn();
+    const encodeSecond = vi.fn();
+    fixture.graph.addCopyPass({
+      id: 'write-first-transient',
+      resources: [{buffer: first, usage: 'storage-write'}],
+      compile: () => ({encode: encodeFirst})
+    });
+    fixture.graph.addCopyPass({
+      id: 'write-second-transient',
+      resources: [{buffer: second, usage: 'storage-write'}],
+      compile: () => ({encode: encodeSecond})
+    });
+    const compiled = fixture.graph.compile();
+
+    try {
+      expect(compiled.stats.logicalTransientBufferCount).toBe(2);
+      expect(compiled.stats.physicalTransientBufferCount).toBe(1);
+      encodeGraphAliasFixture(fixture, compiled);
+      expect(encodeFirst).toHaveBeenCalledTimes(1);
+      expect(encodeSecond).toHaveBeenCalledTimes(1);
+    } finally {
+      compiled.destroy();
+      destroyGraphAliasFixture(fixture);
+    }
+  });
+});
+
+function createGraphAliasFixture(identifier: string): GraphAliasFixture {
+  const device = new NullDevice({id: `${identifier}-device`});
+  Object.defineProperty(device, 'type', {value: 'webgpu'});
+  return {
+    device,
+    graph: new GPUCommandGraph(device, {id: identifier}),
+    buffers: [],
+    dynamicBuffers: []
+  };
+}
+
+function createGraphAliasBuffer(
+  fixture: GraphAliasFixture,
+  identifier: string,
+  usage = Buffer.STORAGE
+): Buffer {
+  const buffer = fixture.device.createBuffer({
+    id: identifier,
+    byteLength: 16,
+    usage
+  });
+  fixture.buffers.push(buffer);
+  return buffer;
+}
+
+function importGraphAliasBuffer(
+  fixture: GraphAliasFixture,
+  identifier: string,
+  defaultBuffer?: GraphImportedBuffer,
+  usage = Buffer.STORAGE
+): GraphBufferHandle {
+  return fixture.graph.importBuffer({id: identifier, byteLength: 16, usage}, defaultBuffer);
+}
+
+function addGraphAliasCopyPass(
+  graph: GPUCommandGraph,
+  input: GraphBufferHandle | GraphDataView,
+  output: GraphBufferHandle | GraphDataView,
+  encode: () => void
+): void {
+  graph.addCopyPass({
+    id: 'observe-physical-buffers',
+    resources: [
+      {buffer: input, usage: 'storage-read'},
+      {buffer: output, usage: 'storage-write'}
+    ],
+    compile: () => ({encode})
+  });
+}
+
+function encodeGraphAliasFixture(
+  fixture: GraphAliasFixture,
+  graph: CompiledGPUCommandGraph,
+  buffers: Record<string, GraphImportedBuffer> = {}
+): void {
+  const encoder = fixture.device.createCommandEncoder({id: `${fixture.graph.id}-encoder`});
+  try {
+    graph.encode(encoder, {parameters: undefined, buffers});
+  } finally {
+    encoder.destroy();
+  }
+}
+
+function destroyGraphAliasFixture(fixture: GraphAliasFixture): void {
+  for (const dynamicBuffer of fixture.dynamicBuffers) dynamicBuffer.destroy();
+  for (const buffer of fixture.buffers) buffer.destroy();
+  fixture.device.destroy();
+}

--- a/modules/experimental/test/gpu-primitives/gpu-command-graph-alias.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-command-graph-alias.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer} from '@luma.gl/core';
 import {DynamicBuffer} from '@luma.gl/engine';

--- a/modules/experimental/test/gpu-primitives/gpu-sort.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-sort.spec.ts
@@ -360,6 +360,144 @@ test('GPUSort validates layouts, lengths, graph ownership, and output buffers', 
   t.end();
 });
 
+test('GPUSort rejects borrowed physical-buffer aliases before encoding either algorithm', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  for (const algorithm of ['bitonic', 'radix'] as const) {
+    const keysBuffer = makeReadableSortBuffer(device, `${algorithm}-keys`, [4, 1, 3, 2]);
+    const borrowedKeysBuffer = device.createBuffer({
+      id: `${algorithm}-borrowed-keys`,
+      handle: keysBuffer.handle,
+      byteLength: keysBuffer.byteLength,
+      usage: keysBuffer.usage,
+      _isHandleBorrowed: true
+    });
+    const valuesBuffer = makeReadableSortBuffer(device, `${algorithm}-values`, [40, 10, 30, 20]);
+    const outputKeysBuffer = makeReadableSortBuffer(device, `${algorithm}-output-keys`, 4);
+    const outputValuesBuffer = makeReadableSortBuffer(device, `${algorithm}-output-values`, 4);
+    const graph = new GPUCommandGraph(device, {id: `${algorithm}-physical-alias`});
+    const sort = new GPUSort({
+      id: `${algorithm}-physical-alias-sort`,
+      keys: importView(graph, 'keys', keysBuffer, 4),
+      values: importView(graph, 'values', valuesBuffer, 4),
+      outputKeys: importView(graph, 'output-keys', borrowedKeysBuffer, 4),
+      outputValues: importView(graph, 'output-values', outputValuesBuffer, 4),
+      algorithm
+    });
+    sort.addToGraph(graph);
+    const compiled = graph.compile();
+    const rejectedEncoder = device.createCommandEncoder({id: `${algorithm}-rejected-alias`});
+
+    t.throws(
+      () => compiled.encode(rejectedEncoder, {parameters: undefined}),
+      /keys.*output-keys.*same physical buffer/i,
+      `${algorithm} rejects distinct borrowed wrappers resolving to one physical GPUBuffer`
+    );
+    rejectedEncoder.destroy();
+    t.deepEqual(
+      await readUint32SortBuffer(keysBuffer, 4),
+      [4, 1, 3, 2],
+      `${algorithm} leaves caller-owned input unchanged`
+    );
+
+    const validEncoder = device.createCommandEncoder({id: `${algorithm}-valid-sort`});
+    compiled.encode(validEncoder, {
+      parameters: undefined,
+      buffers: {'output-keys': outputKeysBuffer}
+    });
+    device.submit(validEncoder.finish());
+    const [sortedKeys, sortedValues] = await Promise.all([
+      readUint32SortBuffer(outputKeysBuffer, 4),
+      readUint32SortBuffer(outputValuesBuffer, 4)
+    ]);
+    t.deepEqual(sortedKeys, [1, 2, 3, 4], `${algorithm} accepts a later distinct output override`);
+    t.deepEqual(sortedValues, [10, 20, 30, 40], `${algorithm} preserves paired payload values`);
+
+    compiled.destroy();
+    const importedBuffers = [
+      keysBuffer,
+      borrowedKeysBuffer,
+      valuesBuffer,
+      outputKeysBuffer,
+      outputValuesBuffer
+    ];
+    tAssertImportedBuffersAlive(importedBuffers);
+    borrowedKeysBuffer.destroy();
+    t.deepEqual(
+      await readUint32SortBuffer(keysBuffer, 4),
+      [4, 1, 3, 2],
+      `${algorithm} borrowed-wrapper destruction leaves the physical GPUBuffer intact`
+    );
+    for (const buffer of [keysBuffer, valuesBuffer, outputKeysBuffer, outputValuesBuffer]) {
+      buffer.destroy();
+    }
+  }
+
+  t.end();
+});
+
+test('GPUBatchSort rejects physically aliased output overrides before encoding', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const keysBuffer = makeReadableSortBuffer(device, 'batch-alias-keys', [3, 1, 2]);
+  const valuesBuffer = makeReadableSortBuffer(device, 'batch-alias-values', [30, 10, 20]);
+  const outputKeysBuffer = makeReadableSortBuffer(device, 'batch-alias-output-keys', 3);
+  const outputValuesBuffer = makeReadableSortBuffer(device, 'batch-alias-output-values', 3);
+  const graph = new GPUCommandGraph(device, {id: 'batch-sort-physical-alias'});
+  const sort = new GPUBatchSort({
+    id: 'batch-sort-physical-alias-sort',
+    keys: makeImportedGraphVector(graph, 'batch-keys', keysBuffer, 3),
+    values: makeImportedGraphVector(graph, 'batch-values', valuesBuffer, 3),
+    outputKeys: makeImportedGraphVector(graph, 'batch-output-keys', outputKeysBuffer, 3),
+    outputValues: makeImportedGraphVector(graph, 'batch-output-values', outputValuesBuffer, 3)
+  });
+  sort.addToGraph(graph);
+  const compiled = graph.compile();
+  const rejectedEncoder = device.createCommandEncoder({id: 'batch-sort-rejected-alias'});
+
+  t.throws(
+    () =>
+      compiled.encode(rejectedEncoder, {
+        parameters: undefined,
+        buffers: {'batch-output-keys': keysBuffer}
+      }),
+    /batch-keys.*batch-output-keys.*same physical buffer/i,
+    'rejects an encoding-time output override that aliases an active input chunk'
+  );
+  rejectedEncoder.destroy();
+  t.deepEqual(
+    await readUint32SortBuffer(keysBuffer, 3),
+    [3, 1, 2],
+    'rejected batch encoding leaves its caller-owned input chunk unchanged'
+  );
+
+  const validEncoder = device.createCommandEncoder({id: 'batch-sort-valid-encoding'});
+  compiled.encode(validEncoder, {parameters: undefined});
+  device.submit(validEncoder.finish());
+  const [sortedKeys, sortedValues] = await Promise.all([
+    readUint32SortBuffer(outputKeysBuffer, 3),
+    readUint32SortBuffer(outputValuesBuffer, 3)
+  ]);
+  t.deepEqual(sortedKeys, [1, 2, 3], 'batch graph accepts its original distinct output buffer');
+  t.deepEqual(sortedValues, [10, 20, 30], 'batch retry preserves paired chunk payload values');
+
+  compiled.destroy();
+  const importedBuffers = [keysBuffer, valuesBuffer, outputKeysBuffer, outputValuesBuffer];
+  tAssertImportedBuffersAlive(importedBuffers);
+  for (const buffer of importedBuffers) buffer.destroy();
+  t.end();
+});
+
 type SortResult = {
   keys: number[];
   values: number[];
@@ -556,12 +694,50 @@ function makeGraphVector(
   });
 }
 
+function makeImportedGraphVector(
+  graph: GPUCommandGraph,
+  id: string,
+  buffer: Buffer,
+  length: number
+): GraphVectorView<'uint32'> {
+  return new GraphVectorView({
+    id,
+    name: id,
+    format: 'uint32',
+    length,
+    valueLength: length,
+    stride: 1,
+    byteStride: Uint32Array.BYTES_PER_ELEMENT,
+    rowByteLength: Uint32Array.BYTES_PER_ELEMENT,
+    data: [importView(graph, id, buffer, length)]
+  });
+}
+
 function importView(graph: GPUCommandGraph, id: string, buffer: Buffer, length: number) {
   const handle = graph.importBuffer(
     {id, byteLength: buffer.byteLength, usage: buffer.usage},
     buffer
   );
   return graph.createDataView(handle, {format: 'uint32', length});
+}
+
+function makeReadableSortBuffer(
+  device: Device,
+  id: string,
+  valuesOrLength: number[] | number
+): Buffer {
+  return device.createBuffer({
+    id,
+    ...(typeof valuesOrLength === 'number'
+      ? {byteLength: valuesOrLength * Uint32Array.BYTES_PER_ELEMENT}
+      : {data: Uint32Array.from(valuesOrLength)}),
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+}
+
+async function readUint32SortBuffer(buffer: Buffer, length: number): Promise<number[]> {
+  const bytes = await buffer.readAsync();
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, length));
 }
 
 function makeUncompiledSort(

--- a/modules/experimental/test/ludf/lu-data-frame.node.spec.ts
+++ b/modules/experimental/test/ludf/lu-data-frame.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {readFileSync} from 'node:fs';
 

--- a/modules/experimental/test/ludf/lu-data-frame.spec.ts
+++ b/modules/experimental/test/ludf/lu-data-frame.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer, type Device} from '@luma.gl/core';
 import {LuDataFrame} from '@luma.gl/experimental/ludf';

--- a/test/examples/gpu-command-graph-features.node.spec.ts
+++ b/test/examples/gpu-command-graph-features.node.spec.ts
@@ -1,0 +1,89 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {describe, expect, test} from 'vitest';
+
+const REPOSITORY_ROOT = new URL('../..', import.meta.url);
+const BATCH_HASH_INDEX_DOCUMENT = 'api-reference/experimental/gpu-primitives/gpu-batch-hash-index';
+
+function readRepositoryText(repositoryPath: string): string {
+  return readFileSync(fileURLToPath(new URL(repositoryPath, REPOSITORY_ROOT)), 'utf8');
+}
+
+function countDocumentReferences(value: unknown, documentIdentifier: string): number {
+  if (typeof value === 'string') {
+    return Number(value === documentIdentifier);
+  }
+  if (Array.isArray(value)) {
+    return value.reduce<number>(
+      (referenceCount, item) => referenceCount + countDocumentReferences(item, documentIdentifier),
+      0
+    );
+  }
+  if (typeof value === 'object' && value !== null) {
+    return Object.values(value).reduce<number>(
+      (referenceCount, item) => referenceCount + countDocumentReferences(item, documentIdentifier),
+      0
+    );
+  }
+  return 0;
+}
+
+describe('GPU command graph feature documentation', () => {
+  test('explains active physical overlap, writable aliases, and every graph command type', () => {
+    const documentation = readRepositoryText(
+      'docs/api-reference/experimental/gpu-primitives/gpu-command-graph.md'
+    );
+
+    expect(documentation).toContain('Physical buffer overlap and writable aliases');
+    expect(documentation).toContain('both are read-only');
+    expect(documentation).toContain('storage-read-write');
+    expect(documentation).toContain('copy-destination');
+    expect(documentation).toContain('DynamicBuffer');
+    expect(documentation).toContain('options.buffers');
+    expect(documentation).toContain('### `addComputePass(node)`');
+    expect(documentation).toContain('### `addRenderPass(node)`');
+    expect(documentation).toContain('### `addCopyPass(node)`');
+    expect(documentation).toContain('| `GPUBatchHashIndex` |');
+    expect(documentation).not.toContain(
+      'handles, including their per-encoding overrides, must not resolve to the same physical buffer'
+    );
+  });
+
+  test('documents preserved-batch hash indexing, composition, diagnostics, and ownership', () => {
+    const documentation = readRepositoryText(`docs/${BATCH_HASH_INDEX_DOCUMENT}.md`);
+
+    for (const expectedFeature of [
+      'Why this feature exists',
+      'firstValues: [100, 400, 900]',
+      'GPUHashIndexQuery',
+      'GPUBatchHashJoin',
+      'outputLeftRows',
+      'outputRightRows',
+      'silently excludes a row',
+      '0xffffffff',
+      '[unique keys, duplicate rows, overflow rows, invalid rows, total probes, maximum probes]',
+      'Ownership, commands, and repeated execution'
+    ]) {
+      expect(documentation, expectedFeature).toContain(expectedFeature);
+    }
+  });
+
+  test('exposes batch hash indexing through both reference navigation trees and graph tabs', () => {
+    const tableOfContents = JSON.parse(readRepositoryText('docs/table-of-contents.json'));
+    const tabs = readRepositoryText('website/src/components/docs/gpu-primitives-docs-tabs.tsx');
+    const overview = readRepositoryText('docs/api-reference/experimental/gpu-primitives/README.md');
+    const hashIndex = readRepositoryText(
+      'docs/api-reference/experimental/gpu-primitives/gpu-hash-index.md'
+    );
+
+    expect(countDocumentReferences(tableOfContents, BATCH_HASH_INDEX_DOCUMENT)).toBe(2);
+    expect(tabs).toContain("id: 'batch-hash-index'");
+    expect(tabs).toContain(BATCH_HASH_INDEX_DOCUMENT);
+    expect(overview).toContain(BATCH_HASH_INDEX_DOCUMENT);
+    expect(hashIndex).toContain(BATCH_HASH_INDEX_DOCUMENT);
+  });
+});

--- a/website/src/components/docs/gpu-primitives-docs-tabs.tsx
+++ b/website/src/components/docs/gpu-primitives-docs-tabs.tsx
@@ -33,6 +33,7 @@ export type GPUPrimitivesDocsTabId =
   | 'trace-picking'
   | 'group-aggregation'
   | 'hash-index'
+  | 'batch-hash-index'
   | 'hash-join'
   | 'batch-hash-join'
   | 'index-picking'
@@ -194,6 +195,11 @@ const TABS: {id: GPUPrimitivesDocsTabId; label: string; href: string}[] = [
     id: 'hash-index',
     label: 'Hash Index',
     href: '/docs/api-reference/experimental/gpu-primitives/gpu-hash-index'
+  },
+  {
+    id: 'batch-hash-index',
+    label: 'Batch Hash Index',
+    href: '/docs/api-reference/experimental/gpu-primitives/gpu-batch-hash-index'
   },
   {
     id: 'hash-join',


### PR DESCRIPTION
## Goals

Prevent unsafe writable overlap between physical GPU command-graph buffers while preserving legitimate read-only sharing, and explain when, why, and how each graph command and related hash-index feature should be used.

## Changes

- Rebase the command-graph alias-safety feature onto current `master`, including the newly merged preserved-batch hash-index implementation.
- Track active imported handles and writable graph resource usages; reject cross-handle physical overlap before recording when either handle uses `storage-write`, `storage-read-write`, or `copy-destination`.
- Preserve read-only sharing, inactive duplicate imports, canonical shared handles, imported-buffer ownership, graph-owned transient reuse, valid retries, dynamic buffers, and per-encoding replacements.
- Expand command-graph documentation with a precise physical-overlap decision matrix, canonical shared-handle examples, separate compute/render/copy command guides, explicit dependencies, repeated encoding, ownership, and preserved-chunk feature comparisons.
- Add a complete `GPUBatchHashIndex` reference covering why single-batch indexes cannot ingest streamed right-hand batches, practical lookup/join examples, nullable keys, discontinuous source offsets, deterministic duplicates, bounded capacities, six GPU diagnostics, lifetimes, and composition with the existing hash index/query/join primitives.
- Add the new reference page to both documentation navigation trees and the primitive tabs; correct outdated single-batch hash-index and join guidance.
- Add focused documentation/navigation regression coverage and normalize inherited graph/luDF SPDX headers required by the newly merged repository-wide licensing test.

## Verification

- `nvm use`: Node `22.22.1`.
- `yarn install`: existing verified dependencies reused; no dependency or lockfile changes.
- `yarn lint fix`: passed; final `yarn lint` also passed.
- `yarn build`: passed for every package after final formatting.
- Full Node coverage: **170 files passed, 1 skipped; 1,085 tests passed, 1 skipped**, independently and again in the repository pre-commit hook.
- Focused graph alias, preserved-batch hash index, documentation, and SPDX suites: **31 tests passed across four files**.
- Experimental package `tspc --noEmit`: passed after rebuilding current package dependencies.
- `yarn website:build`: passed and validated **477 raw documentation pages**.
- `(cd website && yarn build)`: passed and validated **477 raw documentation pages**.
- Full local `yarn test`: browser stage not rerun because this machine currently has no installed Playwright Chromium; GitHub Actions will run all WebGPU/browser shards on the pushed head.

## Risks and compatibility

- Graphs that intentionally import the same writable physical buffer through separate active logical handles now fail before any node encodes; import once and pass canonical handles/views to each contributor.
- Separate read-only handles, unused imports, multiple views sharing one handle, and existing borrowed-buffer ownership remain supported.
- No public command-graph API changes; seven inherited SPDX-only edits repair the current `master` baseline and one additional header belongs to the existing alias regression file.
