### PR TITLE
feat(experimental): compute GPU-resident vertex degrees

### DIFF
--- a/modules/experimental/src/lugraph/index.ts
+++ b/modules/experimental/src/lugraph/index.ts
@@ -6,3 +6,5 @@ export {LuGraph} from './lu-graph';
 export type {LuGraphProps} from './lu-graph';
 export {LuGraphTopology} from './lu-graph-topology';
 export type {LuGraphAdjacency, LuGraphTopologyProps} from './lu-graph-topology';
+export {LuGraphDegree} from './lu-graph-degree';
+export type {LuGraphDegreeDirection, LuGraphDegreeProps} from './lu-graph-degree';

--- a/modules/experimental/src/lugraph/lu-graph-degree-internals.ts
+++ b/modules/experimental/src/lugraph/lu-graph-degree-internals.ts
@@ -1,0 +1,119 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {type Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import type {GPUCommandGraph, GraphDataView} from '../gpu-primitives/gpu-command-graph';
+import {
+  type GPUBoundedDispatchLayout,
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from '../gpu-primitives/gpu-dispatch-utils';
+import {getViewBinding, getViewElementOffset} from '../gpu-primitives/graph-data-view-utils';
+import type {LuGraphDegree} from './lu-graph-degree';
+
+const GRAPH_DEGREE_WORKGROUP_SIZE = 256;
+
+/** Adds one exact CSR degree pass using an explicit device dispatch limit. @internal */
+export function addLuGraphDegreeToGraphWithDispatchLimit<Parameters>(
+  degree: LuGraphDegree,
+  commandGraph: GPUCommandGraph<Parameters>,
+  maxComputeWorkgroupsPerDimension: number
+): void {
+  if (degree.topology.graph.vertexCount === 0) {
+    return;
+  }
+
+  const adjacency =
+    degree.direction === 'incoming' && degree.topology.graph.directed
+      ? degree.topology.reverse!
+      : degree.topology.forward;
+  const offsets = commandGraph.importGPUVector(`${degree.id}-offsets`, adjacency.offsets).data[0];
+  const output = commandGraph.importGPUVector(`${degree.id}-output`, degree.output).data[0];
+  const dispatchLayout = getLuGraphDegreeDispatchLayout(
+    degree.topology.graph.vertexCount,
+    maxComputeWorkgroupsPerDimension
+  );
+  const source = /* wgsl */ `
+const VERTEX_COUNT: u32 = ${degree.topology.graph.vertexCount}u;
+const OFFSETS_OFFSET: u32 = ${getViewElementOffset(offsets)}u;
+const OUTPUT_OFFSET: u32 = ${getViewElementOffset(output)}u;
+@group(0) @binding(0) var<storage, read> offsets: array<u32>;
+@group(0) @binding(1) var<storage, read_write> output: array<u32>;
+
+@compute @workgroup_size(${GRAPH_DEGREE_WORKGROUP_SIZE})
+fn main(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_index) localInvocationIndex: u32
+) {
+  ${getBoundedInvocationIndexSource(dispatchLayout, GRAPH_DEGREE_WORKGROUP_SIZE)}
+  if (index >= VERTEX_COUNT) { return; }
+  output[OUTPUT_OFFSET + index] =
+    offsets[OFFSETS_OFFSET + index + 1u] - offsets[OFFSETS_OFFSET + index];
+}`;
+
+  addDegreePass(commandGraph, {id: degree.id, offsets, output, source, dispatchLayout});
+}
+
+/** Compiles one two-binding degree kernel without allocating graph-owned scratch. */
+function addDegreePass<Parameters>(
+  commandGraph: GPUCommandGraph<Parameters>,
+  props: {
+    id: string;
+    offsets: GraphDataView<'uint32'>;
+    output: GraphDataView<'uint32'>;
+    source: string;
+    dispatchLayout: GPUBoundedDispatchLayout;
+  }
+): void {
+  commandGraph.addComputePass({
+    id: props.id,
+    resources: [
+      {buffer: props.offsets, usage: 'storage-read'},
+      {buffer: props.output, usage: 'storage-write'}
+    ],
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id: props.id,
+        source: props.source,
+        shaderLayout: {
+          bindings: [
+            {name: 'offsets', type: 'storage', group: 0, location: 0},
+            {name: 'output', type: 'storage', group: 0, location: 1}
+          ]
+        }
+      });
+
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {
+            offsets: getViewBinding(props.offsets, getBuffer),
+            output: getViewBinding(props.output, getBuffer)
+          };
+          computation.setBindings(bindings);
+          computation.dispatch(
+            computePass,
+            props.dispatchLayout.x,
+            props.dispatchLayout.y,
+            props.dispatchLayout.z
+          );
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+/** Plans a bounded three-dimensional dispatch for exact vertex degree extraction. @internal */
+export function getLuGraphDegreeDispatchLayout(
+  elementCount: number,
+  maxComputeWorkgroupsPerDimension: number
+): GPUBoundedDispatchLayout {
+  return getBoundedDispatchLayout(
+    'LuGraphDegree',
+    elementCount,
+    GRAPH_DEGREE_WORKGROUP_SIZE,
+    maxComputeWorkgroupsPerDimension
+  );
+}

--- a/modules/experimental/src/lugraph/lu-graph-degree.ts
+++ b/modules/experimental/src/lugraph/lu-graph-degree.ts
@@ -1,0 +1,146 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Buffer} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import type {GPUData, GPUVector} from '@luma.gl/tables';
+import type {GPUCommandGraph} from '../gpu-primitives/gpu-command-graph';
+import {addLuGraphDegreeToGraphWithDispatchLimit} from './lu-graph-degree-internals';
+import type {LuGraphAdjacency, LuGraphTopology} from './lu-graph-topology';
+
+const SCALAR_BYTE_LENGTH = 4;
+
+/** Orientation of graph edges counted for every vertex. */
+export type LuGraphDegreeDirection = 'outgoing' | 'incoming';
+
+/** Caller-owned graph topology and unsigned vertex-degree destination. */
+export type LuGraphDegreeProps = {
+  /** Prefix for generated command-graph node and imported-resource identifiers. */
+  id?: string;
+  /** Existing GPU topology with exact, untruncated compressed sparse row offsets. */
+  topology: LuGraphTopology;
+  /** One caller-owned packed unsigned degree row for every graph vertex. */
+  output: GPUVector<'uint32'>;
+  /** Edge orientation. Undirected adjacency gives the same degree in both directions. */
+  direction?: LuGraphDegreeDirection;
+};
+
+/**
+ * Computes exact unsigned vertex degrees directly from GPU-resident adjacency offsets.
+ *
+ * Invalid edges are already excluded by topology construction. Duplicate edges contribute once
+ * each, and an undirected self-loop contributes one. Degrees remain exact even when bounded
+ * adjacency storage overflows because compressed sparse row offsets are never truncated.
+ */
+export class LuGraphDegree {
+  /** Prefix for generated command-graph node and imported-resource identifiers. */
+  readonly id: string;
+  /** Existing caller-owned GPU topology. */
+  readonly topology: LuGraphTopology;
+  /** Caller-owned packed unsigned degree destination. */
+  readonly output: GPUVector<'uint32'>;
+  /** Outgoing or incoming edge orientation. */
+  readonly direction: LuGraphDegreeDirection;
+
+  /** Validates caller-owned metadata without allocating, submitting, or reading GPU work. */
+  constructor(props: LuGraphDegreeProps) {
+    this.id = props.id ?? 'lu-graph-degree';
+    this.topology = props.topology;
+    this.output = props.output;
+    this.direction = props.direction ?? 'outgoing';
+
+    if (this.direction !== 'outgoing' && this.direction !== 'incoming') {
+      throw new Error(`${this.id} direction must be outgoing or incoming`);
+    }
+    if (this.direction === 'incoming' && this.topology.graph.directed && !this.topology.reverse) {
+      throw new Error(`${this.id} incoming directed degree requires reverse adjacency`);
+    }
+    validateDegreeOutput(this.output, this.topology.graph.vertexCount, this.id);
+    validateDistinctDegreeOutput(this.topology, this.output, this.id);
+  }
+
+  /** Declares one bounded GPU degree pass without submitting commands or reading results. */
+  addToGraph<Parameters>(commandGraph: GPUCommandGraph<Parameters>): void {
+    addLuGraphDegreeToGraphWithDispatchLimit(
+      this,
+      commandGraph,
+      commandGraph.device.limits.maxComputeWorkgroupsPerDimension
+    );
+  }
+}
+
+/** Requires exactly one packed, aligned, vertex-length unsigned destination chunk. */
+function validateDegreeOutput(output: GPUVector<'uint32'>, vertexCount: number, id: string): void {
+  if (
+    output.data.length !== 1 ||
+    output.format !== 'uint32' ||
+    output.stride !== 1 ||
+    output.byteStride !== SCALAR_BYTE_LENGTH ||
+    output.rowByteLength !== SCALAR_BYTE_LENGTH ||
+    output.valueLength !== output.length ||
+    output.bufferLayout
+  ) {
+    throw new Error(`${id} output must contain one packed uint32 chunk`);
+  }
+  if (output.length !== vertexCount) {
+    throw new Error(`${id} output length must equal vertexCount`);
+  }
+
+  const chunk = output.data[0];
+  if (
+    chunk.format !== 'uint32' ||
+    chunk.length !== output.length ||
+    chunk.stride !== 1 ||
+    chunk.byteStride !== SCALAR_BYTE_LENGTH ||
+    chunk.rowByteLength !== SCALAR_BYTE_LENGTH ||
+    chunk.valueLength !== chunk.length ||
+    !Number.isSafeInteger(chunk.byteOffset) ||
+    chunk.byteOffset < 0 ||
+    chunk.byteOffset % SCALAR_BYTE_LENGTH !== 0
+  ) {
+    throw new Error(`${id} output must contain one packed, uint32-aligned chunk`);
+  }
+}
+
+/** Prevents degree publication from replacing any original graph or topology allocation. */
+function validateDistinctDegreeOutput(
+  topology: LuGraphTopology,
+  output: GPUVector<'uint32'>,
+  id: string
+): void {
+  const inputVectors = [
+    topology.graph.sourceVertices,
+    topology.graph.targetVertices,
+    ...(topology.graph.edgeWeights ? [topology.graph.edgeWeights] : []),
+    ...(topology.graph.edgeIds ? [topology.graph.edgeIds] : []),
+    ...getAdjacencyVectors(topology.forward),
+    ...(topology.reverse ? getAdjacencyVectors(topology.reverse) : []),
+    topology.invalidEdgeCount
+  ];
+  const outputBuffer = getPhysicalBuffer(output.data[0]);
+  for (const vector of inputVectors) {
+    if (vector.data.some(chunk => getPhysicalBuffer(chunk) === outputBuffer)) {
+      throw new Error(`${id} output must use a distinct physical buffer allocation`);
+    }
+  }
+}
+
+/** Lists existing caller-owned adjacency and status vectors without changing their identities. */
+function getAdjacencyVectors(
+  adjacency: LuGraphAdjacency
+): (GPUVector<'uint32'> | GPUVector<'float32'>)[] {
+  return [
+    adjacency.offsets,
+    adjacency.neighbors,
+    adjacency.edgeIds,
+    ...(adjacency.edgeWeights ? [adjacency.edgeWeights] : []),
+    adjacency.count,
+    adjacency.overflow
+  ];
+}
+
+/** Resolves a stable engine wrapper to the current concrete physical GPU allocation. */
+function getPhysicalBuffer(chunk: GPUData<'uint32'> | GPUData<'float32'>): Buffer {
+  return chunk.buffer instanceof DynamicBuffer ? chunk.buffer.buffer : chunk.buffer;
+}

--- a/modules/experimental/test/lugraph/lu-graph-degree.node.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-degree.node.spec.ts
@@ -1,0 +1,381 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer} from '@luma.gl/core';
+import {DynamicBuffer} from '@luma.gl/engine';
+import * as experimentalModule from '@luma.gl/experimental';
+import {
+  LuGraph,
+  LuGraphDegree,
+  LuGraphTopology,
+  type LuGraphAdjacency,
+  type LuGraphDegreeDirection,
+  type LuGraphDegreeProps
+} from '@luma.gl/experimental/lugraph';
+import {GPUData, GPUVector} from '@luma.gl/tables';
+import {NullDevice} from '@luma.gl/test-utils';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+
+type ScalarFormat = 'uint32' | 'float32';
+type ScalarValues = Uint32Array | Float32Array;
+
+type DegreeFixture = {
+  device: NullDevice;
+  buffers: Buffer[];
+  dynamicBuffers: DynamicBuffer[];
+  vectors: GPUVector[];
+};
+
+type VectorOptions = {
+  buffer?: Buffer | DynamicBuffer;
+  byteOffset?: number;
+  byteStride?: number;
+  rowByteLength?: number;
+  stride?: number;
+};
+
+const degreeFixtures: DegreeFixture[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const fixture of degreeFixtures.splice(0)) {
+    for (const vector of fixture.vectors) vector.destroy();
+    for (const dynamicBuffer of fixture.dynamicBuffers) dynamicBuffer.destroy();
+    for (const buffer of fixture.buffers) buffer.destroy();
+    fixture.device.destroy();
+  }
+});
+
+describe('LuGraphDegree optional API and caller ownership', () => {
+  test('keeps degree metrics in the optional luGraph subpath', () => {
+    expect(typeof LuGraphDegree).toBe('function');
+    expect('LuGraphDegree' in experimentalModule).toBe(false);
+  });
+
+  test('preserves original graph, topology, and output without allocating or executing work', () => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture, {reverse: true, weighted: true});
+    const createBufferSpy = vi.spyOn(fixture.device, 'createBuffer');
+    const createCommandEncoderSpy = vi.spyOn(fixture.device, 'createCommandEncoder');
+    const submitSpy = vi.spyOn(fixture.device, 'submit');
+    const readbackSpies = fixture.buffers.map(buffer => vi.spyOn(buffer, 'readAsync'));
+
+    const degree = new LuGraphDegree({...props, id: 'borrowed-degree'});
+
+    expect(degree.id).toBe('borrowed-degree');
+    expect(degree.topology).toBe(props.topology);
+    expect(degree.output).toBe(props.output);
+    expect(degree.direction).toBe('outgoing');
+    expect(degree.topology.graph.sourceVertices.data.map(chunk => chunk.length)).toEqual([2, 0, 3]);
+    expect(createBufferSpy).not.toHaveBeenCalled();
+    expect(createCommandEncoderSpy).not.toHaveBeenCalled();
+    expect(submitSpy).not.toHaveBeenCalled();
+    for (const readbackSpy of readbackSpies) expect(readbackSpy).not.toHaveBeenCalled();
+    expect(Reflect.has(degree, 'destroy')).toBe(false);
+
+    for (const vector of fixture.vectors) vector.destroy();
+    expect(fixture.buffers.every(buffer => !buffer.destroyed)).toBe(true);
+  });
+
+  test('accepts an empty graph with one physically allocated zero-length degree chunk', () => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture, {vertexCount: 0});
+    const degree = new LuGraphDegree(props);
+
+    expect(degree.output.length).toBe(0);
+    expect(degree.output.data).toHaveLength(1);
+    expect(degree.output.data[0].buffer.byteLength).toBeGreaterThanOrEqual(4);
+  });
+
+  test('accepts packed uint32 output at a non-256-byte-aligned storage offset', () => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture);
+    const output = createVector(
+      fixture,
+      'offset-degree-output',
+      'uint32',
+      [new Uint32Array(props.topology.graph.vertexCount)],
+      {byteOffset: 4}
+    );
+
+    expect(new LuGraphDegree({...props, output}).output.data[0].byteOffset).toBe(4);
+  });
+});
+
+describe('LuGraphDegree direction and output validation', () => {
+  test.each([
+    'outgoing',
+    'incoming'
+  ] as const)('accepts a directed graph direction when reverse topology is available: %s', direction => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture, {reverse: true});
+
+    expect(new LuGraphDegree({...props, direction}).direction).toBe(direction);
+  });
+
+  test.each([
+    'outgoing',
+    'incoming'
+  ] as const)('uses symmetric forward topology for either undirected direction: %s', direction => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture, {directed: false});
+
+    expect(new LuGraphDegree({...props, direction}).direction).toBe(direction);
+  });
+
+  test('requires transposed topology for incoming degree on a directed graph', () => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture);
+
+    expect(() => new LuGraphDegree({...props, direction: 'incoming'})).toThrow(
+      /incoming|reverse|directed/
+    );
+  });
+
+  test.each([
+    'both',
+    'reverse',
+    'outbound',
+    ''
+  ])('rejects unsupported degree direction: %s', invalidDirection => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture, {reverse: true});
+    const direction = invalidDirection as LuGraphDegreeDirection;
+
+    expect(() => new LuGraphDegree({...props, direction})).toThrow(/direction|outgoing|incoming/);
+  });
+
+  test.each([5, 7])('requires exactly one degree row per graph vertex: %i rows', length => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture);
+    const output = createVector(fixture, `degree-length-${length}`, 'uint32', [
+      new Uint32Array(length)
+    ]);
+
+    expect(() => new LuGraphDegree({...props, output})).toThrow(/output|vertexCount|length/);
+  });
+
+  test('requires uint32 degree output instead of float32', () => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture);
+    const output = createVector(fixture, 'float-degree', 'float32', [
+      new Float32Array(props.topology.graph.vertexCount)
+    ]) as unknown as GPUVector<'uint32'>;
+
+    expect(() => new LuGraphDegree({...props, output})).toThrow(/output|uint32|packed/);
+  });
+
+  test.each([0, 2])('requires exactly one physical output chunk: %i chunks', chunkCount => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture);
+    const chunks = chunkCount === 0 ? [] : [new Uint32Array(3), new Uint32Array(3)];
+    const output = createVector(fixture, 'partitioned-degree', 'uint32', chunks);
+
+    expect(() => new LuGraphDegree({...props, output})).toThrow(/output|one|single|chunk/);
+  });
+
+  test.each([
+    ['misaligned byte offset', {byteOffset: 2}],
+    ['padded byte stride', {byteStride: 8}],
+    ['oversized row payload', {rowByteLength: 8}],
+    ['multi-component scalar stride', {stride: 2}]
+  ] as [string, VectorOptions][])('rejects an unpacked degree output: %s', (_name, options) => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture);
+    const output = createVector(
+      fixture,
+      'unpacked-degree',
+      'uint32',
+      [new Uint32Array(props.topology.graph.vertexCount)],
+      options
+    );
+
+    expect(() => new LuGraphDegree({...props, output})).toThrow(/output|packed|aligned|uint32/);
+  });
+
+  test.each([
+    'sourceVertices',
+    'targetVertices',
+    'edgeWeights',
+    'edgeIds',
+    'forward.offsets',
+    'forward.neighbors',
+    'forward.edgeIds',
+    'forward.edgeWeights',
+    'forward.count',
+    'forward.overflow',
+    'reverse.offsets',
+    'reverse.neighbors',
+    'reverse.edgeIds',
+    'reverse.edgeWeights',
+    'reverse.count',
+    'reverse.overflow',
+    'invalidEdgeCount'
+  ])('rejects degree output backed by an existing physical allocation: %s', vectorName => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture, {vertexCount: 1, reverse: true, weighted: true});
+    const vector = getTopologyVector(props.topology, vectorName);
+    const buffer = vector.data[0].buffer;
+    const output = createVector(fixture, 'aliased-degree-output', 'uint32', [new Uint32Array(1)], {
+      buffer
+    });
+
+    expect(() => new LuGraphDegree({...props, output})).toThrow(
+      /output|distinct|physical|allocation/
+    );
+  });
+
+  test('detects a topology buffer hidden behind a borrowed DynamicBuffer wrapper', () => {
+    const fixture = createDegreeFixture();
+    const props = createDegreeProps(fixture);
+    const concreteBuffer = props.topology.forward.offsets.data[0].buffer as Buffer;
+    const dynamicBuffer = new DynamicBuffer(fixture.device, {
+      id: 'borrowed-offsets-wrapper',
+      buffer: concreteBuffer,
+      ownsBuffer: false
+    });
+    fixture.dynamicBuffers.push(dynamicBuffer);
+    const output = createVector(
+      fixture,
+      'dynamic-aliased-degree',
+      'uint32',
+      [new Uint32Array(props.topology.graph.vertexCount)],
+      {buffer: dynamicBuffer}
+    );
+
+    expect(() => new LuGraphDegree({...props, output})).toThrow(/distinct|physical|allocation/);
+    expect(concreteBuffer.destroyed).toBe(false);
+  });
+});
+
+function createDegreeFixture(): DegreeFixture {
+  const fixture = {device: new NullDevice({}), buffers: [], dynamicBuffers: [], vectors: []};
+  degreeFixtures.push(fixture);
+  return fixture;
+}
+
+function createDegreeProps(
+  fixture: DegreeFixture,
+  options: {vertexCount?: number; directed?: boolean; reverse?: boolean; weighted?: boolean} = {}
+): LuGraphDegreeProps {
+  const vertexCount = options.vertexCount ?? 6;
+  const sourceVertices = createVector(fixture, 'sourceVertices', 'uint32', [
+    Uint32Array.from([0, 2]),
+    new Uint32Array(0),
+    Uint32Array.from([2, 3, 4])
+  ]);
+  const targetVertices = createVector(fixture, 'targetVertices', 'uint32', [
+    Uint32Array.from([1, 4]),
+    new Uint32Array(0),
+    Uint32Array.from([3, 5, 1])
+  ]);
+  const edgeWeights = options.weighted
+    ? createVector(fixture, 'sourceWeights', 'float32', [
+        Float32Array.from([0.5, 2]),
+        new Float32Array(0),
+        Float32Array.from([1, 4, 8])
+      ])
+    : undefined;
+  const edgeIds = options.weighted
+    ? createVector(fixture, 'sourceEdgeIds', 'uint32', [
+        Uint32Array.from([10, 20]),
+        new Uint32Array(0),
+        Uint32Array.from([30, 40, 50])
+      ])
+    : undefined;
+  const graph = new LuGraph({
+    vertexCount,
+    sourceVertices,
+    targetVertices,
+    edgeWeights,
+    edgeIds,
+    directed: options.directed
+  });
+  const forward = createAdjacency(fixture, 'forward', vertexCount, 5, options.weighted);
+  const reverse = options.reverse
+    ? createAdjacency(fixture, 'reverse', vertexCount, 5, options.weighted)
+    : undefined;
+  const invalidEdgeCount = createVector(fixture, 'invalidEdgeCount', 'uint32', [
+    new Uint32Array(1)
+  ]);
+  const topology = new LuGraphTopology({graph, forward, reverse, invalidEdgeCount});
+  const output = createVector(fixture, 'degree', 'uint32', [new Uint32Array(vertexCount)]);
+  return {topology, output};
+}
+
+function createAdjacency(
+  fixture: DegreeFixture,
+  name: string,
+  vertexCount: number,
+  capacity: number,
+  weighted = false
+): LuGraphAdjacency {
+  return {
+    offsets: createVector(fixture, `${name}-offsets`, 'uint32', [new Uint32Array(vertexCount + 1)]),
+    neighbors: createVector(fixture, `${name}-neighbors`, 'uint32', [new Uint32Array(capacity)]),
+    edgeIds: createVector(fixture, `${name}-edgeIds`, 'uint32', [new Uint32Array(capacity)]),
+    edgeWeights: weighted
+      ? createVector(fixture, `${name}-weights`, 'float32', [new Float32Array(capacity)])
+      : undefined,
+    count: createVector(fixture, `${name}-count`, 'uint32', [new Uint32Array(1)]),
+    overflow: createVector(fixture, `${name}-overflow`, 'uint32', [new Uint32Array(1)])
+  };
+}
+
+function getTopologyVector(topology: LuGraphTopology, name: string): GPUVector {
+  if (name === 'invalidEdgeCount') return topology.invalidEdgeCount;
+  if (name === 'sourceVertices') return topology.graph.sourceVertices;
+  if (name === 'targetVertices') return topology.graph.targetVertices;
+  if (name === 'edgeWeights') return topology.graph.edgeWeights!;
+  if (name === 'edgeIds') return topology.graph.edgeIds!;
+
+  const [direction, vectorName] = name.split('.');
+  const adjacency = direction === 'forward' ? topology.forward : topology.reverse!;
+  return adjacency[vectorName as keyof LuGraphAdjacency]!;
+}
+
+function createVector<Format extends ScalarFormat>(
+  fixture: DegreeFixture,
+  name: string,
+  format: Format,
+  chunks: readonly ScalarValues[],
+  options: VectorOptions = {}
+): GPUVector<Format> {
+  const byteOffset = options.byteOffset ?? 0;
+  const byteStride = options.byteStride ?? Uint32Array.BYTES_PER_ELEMENT;
+  const rowByteLength = options.rowByteLength ?? Uint32Array.BYTES_PER_ELEMENT;
+  const stride = options.stride ?? 1;
+  const data = chunks.map((values, chunkIndex) => {
+    const buffer =
+      options.buffer ??
+      fixture.device.createBuffer({
+        id: `${name}-chunk-${chunkIndex}-${fixture.buffers.length}`,
+        byteLength: byteOffset + Math.max(Math.max(values.length, 1) * byteStride, rowByteLength),
+        usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+      });
+    if (!options.buffer) fixture.buffers.push(buffer as Buffer);
+    return new GPUData<Format>({
+      buffer,
+      format,
+      length: values.length,
+      byteOffset,
+      byteStride,
+      rowByteLength,
+      stride,
+      ownsBuffer: false
+    });
+  });
+  const vector = new GPUVector<Format>({
+    type: 'data',
+    name,
+    format,
+    data,
+    byteStride,
+    rowByteLength,
+    stride,
+    ownsData: false
+  });
+  fixture.vectors.push(vector);
+  return vector;
+}

--- a/modules/experimental/test/lugraph/lu-graph-degree.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-degree.spec.ts
@@ -1,0 +1,537 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUCommandGraph} from '@luma.gl/experimental';
+import {
+  LuGraph,
+  LuGraphDegree,
+  LuGraphTopology,
+  type LuGraphAdjacency,
+  type LuGraphDegreeDirection
+} from '@luma.gl/experimental/lugraph';
+import {GPUData, GPUVector} from '@luma.gl/tables';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test, {type Test} from 'test/utils/vitest-tape';
+import {vi} from 'vitest';
+import {
+  addLuGraphDegreeToGraphWithDispatchLimit,
+  getLuGraphDegreeDispatchLayout
+} from '../../src/lugraph/lu-graph-degree-internals';
+
+type ScalarFormat = 'uint32' | 'float32';
+
+type DegreeScenario = {
+  name: string;
+  vertexCount: number;
+  sourceChunks: number[][];
+  targetChunks: number[][];
+  weightChunks?: number[][];
+  directed?: boolean;
+  reverse?: boolean;
+  direction?: LuGraphDegreeDirection;
+  capacity?: number;
+  reverseCapacity?: number;
+  maximumWorkgroups?: number;
+  offsetByteOffset?: number;
+  outputByteOffset?: number;
+};
+
+type ExpectedDegrees = {
+  values: number[];
+  invalidEdgeCount: number;
+  selectedAdjacencyCount: number;
+};
+
+type DegreeExecutionFixture = {
+  device: Device;
+  buffers: Buffer[];
+  vectors: GPUVector[];
+  graph: LuGraph;
+  topology: LuGraphTopology;
+  degree: LuGraphDegree;
+  commandGraph: GPUCommandGraph;
+  compiled?: ReturnType<GPUCommandGraph['compile']>;
+};
+
+const degreeScenarios: DegreeScenario[] = [
+  {
+    name: 'empty graphs retain a caller-owned zero-length degree vector',
+    vertexCount: 0,
+    sourceChunks: [],
+    targetChunks: [],
+    capacity: 0
+  },
+  {
+    name: 'isolated vertices and empty source chunks publish zero degrees',
+    vertexCount: 7,
+    sourceChunks: [[], []],
+    targetChunks: [[], []],
+    capacity: 0
+  },
+  {
+    name: 'directed outgoing degree counts all original source rows',
+    vertexCount: 6,
+    sourceChunks: [[0, 0], [], [2, 4, 4]],
+    targetChunks: [[1, 2], [], [1, 0, 5]]
+  },
+  {
+    name: 'directed incoming degree consumes exact reverse CSR offsets',
+    vertexCount: 6,
+    sourceChunks: [[0, 0], [], [2, 4, 4]],
+    targetChunks: [[1, 2], [], [1, 0, 5]],
+    reverse: true,
+    direction: 'incoming'
+  },
+  {
+    name: 'undirected outgoing degree symmetrizes edges and counts self-loops once',
+    vertexCount: 5,
+    sourceChunks: [[0, 1], [], [1, 3]],
+    targetChunks: [[1, 2], [], [1, 3]],
+    weightChunks: [[0.5, 2], [], [4, 8]],
+    directed: false
+  },
+  {
+    name: 'undirected incoming degree reuses symmetric forward adjacency',
+    vertexCount: 5,
+    sourceChunks: [[0, 1], [], [1, 3]],
+    targetChunks: [[1, 2], [], [1, 3]],
+    directed: false,
+    direction: 'incoming'
+  },
+  {
+    name: 'invalid source and target references never contribute to incoming degree',
+    vertexCount: 4,
+    sourceChunks: [[0, 9], [], [2, 3, 0]],
+    targetChunks: [[1, 2], [], [8, 3, 7]],
+    reverse: true,
+    direction: 'incoming'
+  },
+  {
+    name: 'duplicate edges and high-degree hubs retain every edge occurrence',
+    vertexCount: 4,
+    sourceChunks: [[0, 0, 0, 0, 2]],
+    targetChunks: [[1, 1, 0, 3, 2]]
+  },
+  {
+    name: 'zero neighbor capacity still publishes exact untruncated outgoing degree',
+    vertexCount: 4,
+    sourceChunks: [[0, 0, 1, 2]],
+    targetChunks: [[1, 2, 3, 3]],
+    capacity: 0
+  },
+  {
+    name: 'partial reverse capacity still publishes exact untruncated incoming degree',
+    vertexCount: 4,
+    sourceChunks: [[0, 0, 1, 2]],
+    targetChunks: [[1, 2, 3, 3]],
+    capacity: 1,
+    reverseCapacity: 1,
+    reverse: true,
+    direction: 'incoming'
+  },
+  {
+    name: 'non-256-aligned offsets and degree ranges use correct storage binding offsets',
+    vertexCount: 4,
+    sourceChunks: [[0, 1, 1]],
+    targetChunks: [[1, 2, 3]],
+    offsetByteOffset: 4,
+    outputByteOffset: 4
+  },
+  {
+    name: 'bounded three-dimensional dispatch evaluates the last of 1025 vertices',
+    vertexCount: 1025,
+    sourceChunks: [[0, 512, 1024]],
+    targetChunks: [[1, 513, 0]],
+    maximumWorkgroups: 2
+  }
+];
+
+test('LuGraphDegree plans bounded three-dimensional direct dispatch', tapeTest => {
+  tapeTest.deepEqual(getLuGraphDegreeDispatchLayout(0, 2), {x: 1, y: 1, z: 1});
+  tapeTest.deepEqual(getLuGraphDegreeDispatchLayout(512, 2), {x: 2, y: 1, z: 1});
+  tapeTest.deepEqual(getLuGraphDegreeDispatchLayout(513, 2), {x: 2, y: 2, z: 1});
+  tapeTest.deepEqual(getLuGraphDegreeDispatchLayout(1025, 2), {x: 2, y: 2, z: 2});
+  tapeTest.throws(() => getLuGraphDegreeDispatchLayout(2049, 2), /3D dispatch limit/);
+  tapeTest.end();
+});
+
+for (const scenario of degreeScenarios) {
+  test(`LuGraphDegree GPU metrics: ${scenario.name}`, async tapeTest => {
+    const device = await getWebGPUTestDevice();
+    if (!device) {
+      tapeTest.comment('WebGPU is not available');
+      tapeTest.end();
+      return;
+    }
+
+    const expected = calculateExpectedDegrees(scenario);
+    const fixture = createExecutionFixture(device, scenario, expected);
+    try {
+      compileMetrics(fixture, scenario.maximumWorkgroups);
+      executeMetrics(fixture);
+      await assertDegrees(tapeTest, fixture, expected);
+      tapeTest.deepEqual(
+        fixture.graph.sourceVertices.data.map(chunk => chunk.length),
+        scenario.sourceChunks.map(chunk => chunk.length),
+        'degree evaluation preserves original source chunks and empty batches'
+      );
+    } finally {
+      destroyExecutionFixture(tapeTest, fixture);
+    }
+
+    tapeTest.end();
+  });
+}
+
+test('LuGraphDegree recomputes incoming degrees after source updates without hidden execution', async tapeTest => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    tapeTest.comment('WebGPU is not available');
+    tapeTest.end();
+    return;
+  }
+
+  const original: DegreeScenario = {
+    name: 'repeated incoming evaluation',
+    vertexCount: 6,
+    sourceChunks: [[0, 1], [], [2, 3, 4]],
+    targetChunks: [[1, 2], [], [3, 4, 5]],
+    reverse: true,
+    direction: 'incoming',
+    capacity: 3,
+    reverseCapacity: 3
+  };
+  const fixture = createExecutionFixture(device, original, calculateExpectedDegrees(original));
+  const submitSpy = vi.spyOn(device, 'submit');
+  const sourceReadbackSpies = [
+    ...fixture.graph.sourceVertices.data,
+    ...fixture.graph.targetVertices.data
+  ].map(chunk => vi.spyOn(chunk.buffer, 'readAsync'));
+
+  try {
+    compileMetrics(fixture);
+    tapeTest.equal(
+      submitSpy.mock.calls.length,
+      0,
+      'construction and compilation never submit work'
+    );
+    tapeTest.ok(
+      sourceReadbackSpies.every(spy => spy.mock.calls.length === 0),
+      'topology and degree construction never read source buffers back'
+    );
+    submitSpy.mockRestore();
+    for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
+
+    executeMetrics(fixture);
+    await assertDegrees(tapeTest, fixture, calculateExpectedDegrees(original));
+
+    const sourceBuffer = fixture.graph.sourceVertices.data[0].buffer as Buffer;
+    sourceBuffer.write(Uint32Array.from([9, 9]));
+    const updated = {...original, sourceChunks: [[9, 9], [], [2, 3, 4]]};
+    executeMetrics(fixture);
+    await assertDegrees(tapeTest, fixture, calculateExpectedDegrees(updated));
+    tapeTest.equal(
+      fixture.graph.sourceVertices.data[0].buffer,
+      sourceBuffer,
+      'source updates preserve caller-owned source buffer identity'
+    );
+  } finally {
+    submitSpy.mockRestore();
+    for (const sourceReadbackSpy of sourceReadbackSpies) sourceReadbackSpy.mockRestore();
+    destroyExecutionFixture(tapeTest, fixture);
+  }
+
+  tapeTest.end();
+});
+
+/** Counts original valid graph edges rather than relying on bounded neighbor storage. */
+function calculateExpectedDegrees(scenario: DegreeScenario): ExpectedDegrees {
+  const values = new Array<number>(scenario.vertexCount).fill(0);
+  let invalidEdgeCount = 0;
+  let selectedAdjacencyCount = 0;
+  const incoming = scenario.direction === 'incoming' && scenario.directed !== false;
+
+  for (const [chunkIndex, sources] of scenario.sourceChunks.entries()) {
+    for (const [rowIndex, source] of sources.entries()) {
+      const target = scenario.targetChunks[chunkIndex][rowIndex];
+      if (source >= scenario.vertexCount || target >= scenario.vertexCount) {
+        invalidEdgeCount++;
+        continue;
+      }
+
+      if (scenario.directed === false) {
+        values[source]++;
+        selectedAdjacencyCount++;
+        if (source !== target) {
+          values[target]++;
+          selectedAdjacencyCount++;
+        }
+      } else {
+        values[incoming ? target : source]++;
+        selectedAdjacencyCount++;
+      }
+    }
+  }
+
+  return {values, invalidEdgeCount, selectedAdjacencyCount};
+}
+
+function createExecutionFixture(
+  device: Device,
+  scenario: DegreeScenario,
+  expected: ExpectedDegrees
+): DegreeExecutionFixture {
+  const buffers: Buffer[] = [];
+  const vectors: GPUVector[] = [];
+  const sourceVertices = createSourceVector(
+    device,
+    buffers,
+    vectors,
+    'source-vertices',
+    'uint32',
+    scenario.sourceChunks
+  );
+  const targetVertices = createSourceVector(
+    device,
+    buffers,
+    vectors,
+    'target-vertices',
+    'uint32',
+    scenario.targetChunks
+  );
+  const edgeWeights = scenario.weightChunks
+    ? createSourceVector(
+        device,
+        buffers,
+        vectors,
+        'source-weights',
+        'float32',
+        scenario.weightChunks
+      )
+    : undefined;
+  const graph = new LuGraph({
+    vertexCount: scenario.vertexCount,
+    sourceVertices,
+    targetVertices,
+    edgeWeights,
+    directed: scenario.directed
+  });
+  const capacity = scenario.capacity ?? expected.selectedAdjacencyCount;
+  const forward = createOutputAdjacency(
+    device,
+    buffers,
+    vectors,
+    'forward',
+    scenario.vertexCount,
+    capacity,
+    Boolean(edgeWeights),
+    scenario.offsetByteOffset
+  );
+  const reverse = scenario.reverse
+    ? createOutputAdjacency(
+        device,
+        buffers,
+        vectors,
+        'reverse',
+        scenario.vertexCount,
+        scenario.reverseCapacity ?? expected.selectedAdjacencyCount,
+        Boolean(edgeWeights),
+        scenario.offsetByteOffset
+      )
+    : undefined;
+  const invalidEdgeCount = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'invalid-edges',
+    'uint32',
+    1
+  );
+  const topology = new LuGraphTopology({graph, forward, reverse, invalidEdgeCount});
+  const output = createOutputVector(
+    device,
+    buffers,
+    vectors,
+    'vertex-degree',
+    'uint32',
+    scenario.vertexCount,
+    scenario.outputByteOffset
+  );
+  const degree = new LuGraphDegree({topology, output, direction: scenario.direction});
+  return {
+    device,
+    buffers,
+    vectors,
+    graph,
+    topology,
+    degree,
+    commandGraph: new GPUCommandGraph(device)
+  };
+}
+
+function createSourceVector<Format extends ScalarFormat>(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  format: Format,
+  chunks: readonly number[][]
+): GPUVector<Format> {
+  const data = chunks.map((chunk, chunkIndex) => {
+    const values = format === 'float32' ? Float32Array.from(chunk) : Uint32Array.from(chunk);
+    const buffer = device.createBuffer({
+      id: `${name}-chunk-${chunkIndex}`,
+      data: values.length > 0 ? values : new Uint32Array(1),
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    });
+    buffers.push(buffer);
+    return new GPUData<Format>({buffer, format, length: values.length, ownsBuffer: false});
+  });
+  const vector = new GPUVector<Format>({type: 'data', name, format, data, ownsData: false});
+  vectors.push(vector);
+  return vector;
+}
+
+function createOutputAdjacency(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  vertexCount: number,
+  capacity: number,
+  weighted: boolean,
+  offsetByteOffset = 0
+): LuGraphAdjacency {
+  return {
+    offsets: createOutputVector(
+      device,
+      buffers,
+      vectors,
+      `${name}-offsets`,
+      'uint32',
+      vertexCount + 1,
+      offsetByteOffset
+    ),
+    neighbors: createOutputVector(
+      device,
+      buffers,
+      vectors,
+      `${name}-neighbors`,
+      'uint32',
+      capacity
+    ),
+    edgeIds: createOutputVector(device, buffers, vectors, `${name}-edge-ids`, 'uint32', capacity),
+    edgeWeights: weighted
+      ? createOutputVector(device, buffers, vectors, `${name}-weights`, 'float32', capacity)
+      : undefined,
+    count: createOutputVector(device, buffers, vectors, `${name}-count`, 'uint32', 1),
+    overflow: createOutputVector(device, buffers, vectors, `${name}-overflow`, 'uint32', 1)
+  };
+}
+
+function createOutputVector<Format extends ScalarFormat>(
+  device: Device,
+  buffers: Buffer[],
+  vectors: GPUVector[],
+  name: string,
+  format: Format,
+  length: number,
+  byteOffset = 0
+): GPUVector<Format> {
+  const buffer = device.createBuffer({
+    id: name,
+    byteLength: byteOffset + Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  buffers.push(buffer);
+  const vector = new GPUVector<Format>({
+    type: 'buffer',
+    name,
+    format,
+    buffer,
+    length,
+    byteOffset,
+    ownsBuffer: false
+  });
+  vectors.push(vector);
+  return vector;
+}
+
+function compileMetrics(fixture: DegreeExecutionFixture, maximumWorkgroups?: number): void {
+  fixture.topology.addToGraph(fixture.commandGraph);
+  if (maximumWorkgroups === undefined) {
+    fixture.degree.addToGraph(fixture.commandGraph);
+  } else {
+    addLuGraphDegreeToGraphWithDispatchLimit(
+      fixture.degree,
+      fixture.commandGraph,
+      maximumWorkgroups
+    );
+  }
+  fixture.compiled = fixture.commandGraph.compile();
+}
+
+function executeMetrics(fixture: DegreeExecutionFixture): void {
+  const commandEncoder = fixture.device.createCommandEncoder({id: 'lu-graph-degree-test'});
+  fixture.compiled!.encode(commandEncoder, {parameters: undefined});
+  fixture.device.submit(commandEncoder.finish());
+}
+
+async function assertDegrees(
+  tapeTest: Test,
+  fixture: DegreeExecutionFixture,
+  expected: ExpectedDegrees
+): Promise<void> {
+  const selectedAdjacency =
+    fixture.degree.direction === 'incoming' && fixture.graph.directed
+      ? fixture.topology.reverse!
+      : fixture.topology.forward;
+  const [values, invalidEdgeCount, adjacencyCount, overflow] = await Promise.all([
+    readUint32Vector(fixture.degree.output),
+    readUint32Vector(fixture.topology.invalidEdgeCount),
+    readUint32Vector(selectedAdjacency.count),
+    readUint32Vector(selectedAdjacency.overflow)
+  ]);
+  tapeTest.deepEqual(
+    values,
+    expected.values,
+    'vertex degrees match the complete CPU edge reference'
+  );
+  tapeTest.equal(
+    invalidEdgeCount[0],
+    expected.invalidEdgeCount,
+    'invalid graph endpoints are excluded'
+  );
+  tapeTest.equal(
+    adjacencyCount[0],
+    expected.selectedAdjacencyCount,
+    'CSR records the exact edge count'
+  );
+  tapeTest.equal(
+    overflow[0],
+    Number(expected.selectedAdjacencyCount > selectedAdjacency.neighbors.length),
+    'degree remains exact even when selected neighbor storage overflows'
+  );
+}
+
+async function readUint32Vector(vector: GPUVector<'uint32'>): Promise<number[]> {
+  if (vector.length === 0) return [];
+  const data = vector.data[0];
+  const bytes = await (data.buffer as Buffer).readAsync(
+    data.byteOffset,
+    vector.length * Uint32Array.BYTES_PER_ELEMENT
+  );
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, vector.length));
+}
+
+function destroyExecutionFixture(tapeTest: Test, fixture: DegreeExecutionFixture): void {
+  fixture.compiled?.destroy();
+  for (const vector of fixture.vectors) vector.destroy();
+  tapeTest.ok(
+    fixture.buffers.every(buffer => !buffer.destroyed),
+    'destroying graph-owned scratch and borrowed vectors preserves all caller-owned buffers'
+  );
+  for (const buffer of fixture.buffers) buffer.destroy();
+}


### PR DESCRIPTION
## Goals
- Publish exact GPU-resident in-degree, out-degree, and undirected vertex-importance values for graph visualization.
- Keep the increment independently reviewable and stacked directly on GPU CSR adjacency #2937.
- Preserve Arrow-free optional packaging, caller-owned GPU buffers, command-graph dependencies, and explicit overflow semantics.

## Changes
- Add `LuGraphDegree`, `LuGraphDegreeProps`, and `LuGraphDegreeDirection` exclusively to `@luma.gl/experimental/lugraph`.
- Compute vertex degrees directly from existing exact CSR offsets in one bounded three-dimensional WebGPU compute pass with only two storage bindings.
- Support outgoing and incoming directed degrees; require reverse adjacency for incoming directed queries, and reuse symmetric forward adjacency for either direction on undirected graphs.
- Preserve exact degrees even when neighbor/edge storage has overflowed, because CSR offsets remain untruncated.
- Exclude invalid edges, count duplicate edges independently, and count undirected self-loops once.
- Validate one packed caller-owned `uint32` output row per vertex and reject physical aliases with all graph/topology inputs and status buffers.
- Reuse imported GPU vector handles so command-graph hazards automatically order adjacency construction before degree evaluation; no hidden allocation, packing, command submission, readback, or destruction.
- Add 40 focused Node contract checks and 14 real-Chromium/WebGPU CPU-oracle scenarios covering zero/partial adjacency capacity, shifted buffer offsets, directed/reverse/undirected graphs, invalid endpoints, weighted self-loops, repeated encoding, and synthetic `[2,2,2]` dispatch.

## Verification
- `nvm use`: passed (Node v22.22.1).
- `yarn install`: attempted normally and with escalation; configured registry blocks unavailable dependencies with HTTP 403. Verification uses an isolated APFS copy-on-write clone of a previously installed compatible dependency tree and ignored Yarn state; no dependency/lockfile changes.
- `yarn lint fix`: passed (1,536 files).
- Final `yarn build`: passed across all packages after the final code and formatting changes.
- Focused Node degree tests: 40 passed.
- Focused real-WebGPU degree tests: 14 passed.
- Complete `CI=1 yarn test`: **644 Node tests and 1,582 real Chromium/WebGPU tests passed**; existing skips only.
- `yarn website:build`: passed.
- `(cd website && yarn build)`: passed.
- `yarn examples:typecheck`: all 46 example workspaces passed.
- `yarn bundle-size`: all seven bundle-size budgets passed.
- Built ESM and CommonJS package-subpath smoke checks: passed; `LuGraphDegree` remains absent from the experimental root.
- Normal commit hooks: lint and all 644 Node tests passed.

## Risks and follow-up
- Incoming directed degree intentionally requires explicitly constructed reverse adjacency.
- This increment publishes degree metrics only; breadth-first distances/predecessors, connected components, PageRank, and layout remain separately reviewable follow-ups.
- Stacked on #2937; keep the base as `codex/lugraph-csr-topology` until adjacency lands.