### PR TITLE
feat(experimental): add nullable GPU-resident luDF derived columns

### DIFF
--- a/examples/experimental/gpu-data-analysis/src/app-shell.ts
+++ b/examples/experimental/gpu-data-analysis/src/app-shell.ts
@@ -1,0 +1,493 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+/** The example shell is intentionally readable: it doubles as an approachable integration guide. */
+export const GPU_DATA_ANALYSIS_TEMPLATE = `
+  <main class="analysis-example">
+    <header class="analysis-hero">
+      <div>
+        <p class="eyebrow"><span class="live-indicator"></span> WEBGPU / ANALYTICS WORKBENCH</p>
+        <h1>Data stays on the GPU.</h1>
+        <p class="hero-description">
+          Start with Arrow columns. Compose a command graph. Explore derived expressions,
+          distributions, and spatial patterns without copying rows back to the CPU.
+        </p>
+      </div>
+      <span class="device-badge">GRAPH-NATIVE EXECUTION</span>
+    </header>
+
+    <div class="pipeline" aria-label="GPU analytics pipeline">
+      <span>01 <strong>ARROW INGEST</strong></span>
+      <span>02 <strong>DERIVE</strong></span>
+      <span>03 <strong>FILTER</strong></span>
+      <span>04 <strong>AGGREGATE</strong></span>
+      <span>05 <strong>VISUALIZE</strong></span>
+    </div>
+
+    <section class="control-deck" aria-label="Command-graph controls">
+      <label>Dataset
+        <select data-dataset>
+          <option value="small">4,096 rows</option>
+          <option value="medium" selected>65,537 rows</option>
+          <option value="large">262,144 rows</option>
+        </select>
+      </label>
+      <label>Histogram
+        <select data-bins>
+          <option value="16">16 uniform bins</option>
+          <option value="64" selected>64 uniform bins</option>
+          <option value="300">300 uniform bins</option>
+          <option value="thresholds">8 threshold bins</option>
+        </select>
+      </label>
+      <label>Group filter
+        <select data-group-filter>
+          <option value="all">All values</option>
+          <option value="positive" selected>Positive values</option>
+          <option value="negative">Negative values</option>
+        </select>
+      </label>
+      <label>Spatial grid
+        <select data-grid>
+          <option>8</option>
+          <option selected>16</option>
+          <option>17</option>
+        </select>
+      </label>
+      <button class="run-button" data-run>Run command graph <span>→</span></button>
+    </section>
+
+    <p class="status" data-status role="status" aria-live="polite"></p>
+
+    <section class="graph-metrics" aria-label="Command-graph diagnostics">
+      <article><span>GRAPH NODES</span><strong data-nodes>—</strong></article>
+      <article><span>COMPILE TIME</span><strong data-compile-time>—</strong></article>
+      <article><span>TRANSIENT REUSE</span><strong data-reuse>—</strong></article>
+      <article><span>GPU / CPU VALIDATION</span><strong data-validation>—</strong></article>
+    </section>
+
+    <section class="dataframe-lab" aria-label="Interactive luDF derived-column lab">
+      <div class="lab-heading">
+        <div>
+          <p class="eyebrow">LUDF / DERIVED COLUMN LAB</p>
+          <h2>Write the expression. Watch the data move.</h2>
+          <p>Transform and filter the exact GPU buffers already driving the charts above.</p>
+        </div>
+        <span class="lab-badge">ZERO ROW COPIES</span>
+      </div>
+
+      <div class="expression-editor">
+        <div class="editor-titlebar">
+          <span class="editor-dots"><i></i><i></i><i></i></span>
+          <span>derived-query.ts</span>
+          <span>GPU-RESIDENT</span>
+        </div>
+        <div class="expression-code">
+          <p><span>01</span> <i>const</i> query = frame</p>
+          <p><span>02</span>   .<b>withColumn</b>(<em>'adjustedValue'</em>, expression)</p>
+          <p><span>03</span>   .<b>filter</b>(adjustedValue.greaterThan(threshold));</p>
+        </div>
+        <div class="live-expression">
+          <span>LIVE EXPRESSION</span>
+          <strong data-ludf-expression>value × 2 + 1 > 1</strong>
+        </div>
+      </div>
+
+      <div class="expression-controls">
+        <label>Multiplier
+          <select data-ludf-multiplier>
+            <option value="0.5">0.5×</option>
+            <option value="1">1×</option>
+            <option value="2" selected>2×</option>
+            <option value="4">4×</option>
+          </select>
+        </label>
+        <label>Adjustment
+          <input data-ludf-adjustment type="number" value="1" step="0.25">
+        </label>
+        <label>Threshold
+          <input data-ludf-threshold type="number" value="1" step="0.25">
+        </label>
+        <button class="query-button" data-ludf-run>Execute GPU query <span>→</span></button>
+      </div>
+
+      <div class="query-metrics" aria-label="Derived-query results">
+        <article><span>SELECTED ROWS</span><strong data-ludf-selected>—</strong></article>
+        <article><span>SELECTION RATE</span><strong data-ludf-rate>—</strong></article>
+        <article><span>QUERY + READBACK</span><strong data-ludf-execution>—</strong></article>
+        <article class="preview-metric"><span>GPU VALUE PREVIEW</span><strong data-ludf-preview>—</strong></article>
+      </div>
+
+      <p class="query-status" data-ludf-result role="status" aria-live="polite">
+        Derive and filter existing Arrow-backed GPU columns without copying rows.
+      </p>
+    </section>
+
+    <section class="visualizations" aria-label="GPU-computed analytics">
+      <article class="visualization-card histogram-card">
+        <p class="eyebrow">DISTRIBUTION / HISTOGRAM + CDF</p>
+        <h3>Value distribution</h3>
+        <p>GPU-computed histogram with inclusive cumulative counts.</p>
+        <div class="histogram" data-histogram></div>
+      </article>
+      <article class="visualization-card">
+        <p class="eyebrow">CATEGORICAL / FILTERED GROUPS</p>
+        <h3>Regional breakdown</h3>
+        <p>Filtered row counts and means, aggregated entirely on the GPU.</p>
+        <div class="groups" data-groups></div>
+      </article>
+      <article class="visualization-card heatmap-card">
+        <p class="eyebrow">SPATIAL / GRID AGGREGATION</p>
+        <h3>Density landscape</h3>
+        <p>Cell counts, weighted statistics, and segmented row prefixes.</p>
+        <div class="heatmap" data-heatmap></div>
+      </article>
+    </section>
+
+    <footer class="analysis-footer">
+      <span>APACHE ARROW → LUMA.GL → WEBGPU</span>
+      <span>Explicit graphs. Preserved batches. No hidden transfers.</span>
+    </footer>
+  </main>
+`;
+
+/** Scoped visual system: the example also renders inside the documentation website. */
+export const GPU_DATA_ANALYSIS_STYLES = `
+  .analysis-example {
+    --surface: rgba(15, 23, 38, 0.84);
+    --surface-raised: #111c2e;
+    --border: rgba(148, 163, 184, 0.16);
+    --muted: #8fa2bc;
+    --text: #eaf1fb;
+    --green: #55e1a0;
+    --blue: #73aafa;
+    --amber: #ffca74;
+    max-width: 1400px;
+    min-height: 100vh;
+    margin: 0 auto;
+    padding: 54px clamp(18px, 5vw, 72px) 28px;
+    color: var(--text);
+    background:
+      radial-gradient(ellipse at 14% 0%, rgba(53, 110, 133, 0.22), transparent 36%),
+      radial-gradient(ellipse at 86% 32%, rgba(91, 68, 143, 0.13), transparent 32%),
+      #090e19;
+    font: 14px/1.55 'SF Pro Display', 'Segoe UI', system-ui, sans-serif;
+  }
+
+  .analysis-example *, .analysis-example *::before, .analysis-example *::after {
+    box-sizing: border-box;
+  }
+
+  .analysis-hero, .lab-heading, .analysis-footer {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
+  }
+
+  .analysis-example .eyebrow {
+    margin: 0 0 10px;
+    color: var(--green);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 1.65px;
+  }
+
+  .live-indicator {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    margin-right: 7px;
+    border-radius: 50%;
+    background: var(--green);
+    box-shadow: 0 0 12px rgba(85, 225, 160, 0.7);
+  }
+
+  .analysis-hero h1 {
+    margin: 0 0 12px;
+    font-size: clamp(38px, 6vw, 66px);
+    line-height: 1.04;
+    letter-spacing: -2.8px;
+  }
+
+  .hero-description, .lab-heading > div > p:last-child, .visualization-card > p:last-of-type {
+    max-width: 680px;
+    margin: 0;
+    color: var(--muted);
+  }
+
+  .device-badge, .lab-badge {
+    padding: 8px 11px;
+    border: 1px solid rgba(85, 225, 160, 0.3);
+    border-radius: 999px;
+    color: var(--green);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.9px;
+    white-space: nowrap;
+  }
+
+  .pipeline {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    margin: 34px 0 24px;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+  }
+
+  .pipeline > span {
+    padding: 14px 12px;
+    border-right: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 10px;
+    letter-spacing: 0.55px;
+    text-align: center;
+  }
+
+  .pipeline > span:last-child { border-right: 0; }
+  .pipeline strong { margin-left: 5px; color: var(--text); }
+
+  .control-deck, .expression-controls {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr)) minmax(180px, 1.25fr);
+    align-items: end;
+    gap: 12px;
+  }
+
+  .analysis-example label {
+    display: grid;
+    gap: 7px;
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 600;
+  }
+
+  .analysis-example select, .analysis-example input, .analysis-example button {
+    width: 100%;
+    min-height: 42px;
+    padding: 0 11px;
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    color: var(--text);
+    background: var(--surface-raised);
+    font: inherit;
+  }
+
+  .analysis-example select:focus, .analysis-example input:focus, .analysis-example button:focus {
+    outline: 2px solid rgba(115, 170, 250, 0.65);
+    outline-offset: 2px;
+  }
+
+  .analysis-example button {
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 700;
+  }
+
+  .analysis-example button:disabled { cursor: progress; opacity: 0.55; }
+  .analysis-example .run-button { border-color: rgba(115, 170, 250, 0.4); color: var(--blue); }
+  .analysis-example button span { float: right; }
+
+  .status {
+    min-height: 20px;
+    margin: 15px 0 20px;
+    color: var(--muted);
+    font-size: 11px;
+  }
+
+  .status[data-state="error"], .query-status[data-state="error"] { color: #ff8585; }
+
+  .graph-metrics, .query-metrics {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+  }
+
+  .graph-metrics article, .query-metrics article {
+    min-width: 0;
+    padding: 15px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+  }
+
+  .graph-metrics article > span, .query-metrics article > span, .live-expression > span {
+    display: block;
+    margin-bottom: 7px;
+    color: var(--muted);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 1px;
+  }
+
+  .graph-metrics article > strong, .query-metrics article > strong {
+    display: block;
+    overflow: hidden;
+    color: var(--text);
+    font-size: 15px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  [data-validation][data-state="ok"] { color: var(--green) !important; }
+
+  .dataframe-lab {
+    margin-top: 35px;
+    padding: 25px;
+    border: 1px solid rgba(85, 225, 160, 0.24);
+    border-radius: 12px;
+    background: linear-gradient(135deg, rgba(15, 29, 35, 0.95), rgba(13, 18, 30, 0.98));
+  }
+
+  .lab-heading h2 {
+    margin: 0 0 7px;
+    font-size: clamp(19px, 3vw, 26px);
+    letter-spacing: -0.55px;
+  }
+
+  .expression-editor {
+    margin-top: 21px;
+    overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: rgba(7, 12, 21, 0.82);
+    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  }
+
+  .editor-titlebar {
+    display: flex;
+    justify-content: space-between;
+    padding: 10px 13px;
+    border-bottom: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 10px;
+  }
+
+  .editor-dots { display: flex; align-items: center; gap: 5px; }
+  .editor-dots i { width: 8px; height: 8px; border-radius: 50%; background: #ff776d; }
+  .editor-dots i:nth-child(2) { background: var(--amber); }
+  .editor-dots i:nth-child(3) { background: var(--green); }
+
+  .expression-code { padding: 12px 15px; }
+  .expression-code p { margin: 5px 0; color: #d9e4f4; font-size: 12px; }
+  .expression-code p > span { display: inline-block; width: 28px; color: #596980; }
+  .expression-code i { color: #d297ff; font-style: normal; }
+  .expression-code b { color: var(--blue); font-weight: 500; }
+  .expression-code em { color: var(--amber); font-style: normal; }
+
+  .live-expression {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 12px 15px;
+    border-top: 1px solid var(--border);
+  }
+
+  .live-expression > span { margin: 0; }
+  .live-expression > strong { color: var(--green); font-size: 14px; }
+
+  .expression-controls {
+    grid-template-columns: repeat(3, minmax(0, 1fr)) minmax(190px, 1.3fr);
+    margin-top: 17px;
+  }
+
+  .analysis-example .query-button {
+    border-color: rgba(85, 225, 160, 0.5);
+    color: #092014;
+    background: var(--green);
+  }
+
+  .query-metrics { margin-top: 18px; }
+  .query-metrics article { background: rgba(10, 16, 24, 0.6); }
+  .query-metrics .preview-metric strong { color: var(--amber); font-size: 12px; }
+
+  .query-status {
+    min-height: 18px;
+    margin: 13px 0 0;
+    color: var(--muted);
+    font-size: 11px;
+  }
+
+  .query-status[data-state="verified"] { color: var(--green); }
+
+  .visualizations {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-top: 31px;
+  }
+
+  .visualization-card {
+    min-width: 0;
+    padding: 20px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--surface);
+  }
+
+  .visualization-card h3 { margin: 0 0 5px; font-size: 19px; }
+  .visualization-card > p:last-of-type { font-size: 12px; }
+
+  .histogram {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 160px;
+    margin-top: 23px;
+  }
+
+  .histogram i {
+    flex: 1;
+    min-width: 1px;
+    border-radius: 3px 3px 0 0;
+    background: linear-gradient(180deg, #73aafa, rgba(78, 128, 199, 0.38));
+  }
+
+  .groups { display: grid; gap: 13px; margin-top: 25px; }
+  .groups > div { position: relative; display: grid; grid-template-columns: 90px 1fr; gap: 6px; }
+  .groups > div > span { color: var(--text); font-size: 11px; }
+  .groups > div > i {
+    align-self: center;
+    height: 8px;
+    border-radius: 5px;
+    background: linear-gradient(90deg, #37a979, var(--green));
+  }
+  .groups > div > strong { grid-column: 2; color: var(--muted); font-size: 10px; font-weight: 500; }
+
+  .heatmap-card { grid-column: 1 / -1; }
+  .heatmap { display: grid; gap: 3px; max-width: 620px; margin: 20px auto 0; }
+  .heatmap i { aspect-ratio: 1; border-radius: 2px; background: var(--amber); }
+
+  .analysis-footer {
+    margin-top: 25px;
+    padding-top: 15px;
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 10px;
+    letter-spacing: 0.3px;
+  }
+
+  @media (max-width: 900px) {
+    .control-deck { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .expression-controls { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .graph-metrics, .query-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .pipeline strong { display: block; margin: 4px 0 0; }
+  }
+
+  @media (max-width: 600px) {
+    .analysis-example { padding-top: 32px; }
+    .analysis-hero, .lab-heading, .analysis-footer { flex-direction: column; gap: 11px; }
+    .pipeline { grid-template-columns: 1fr; }
+    .pipeline > span { border-right: 0; border-bottom: 1px solid var(--border); text-align: left; }
+    .pipeline > span:last-child { border-bottom: 0; }
+    .pipeline strong { display: inline; margin-left: 7px; }
+    .dataframe-lab { padding: 15px; }
+    .visualizations { grid-template-columns: 1fr; }
+    .heatmap-card { grid-column: auto; }
+    .expression-code p { font-size: 10px; }
+    .live-expression { flex-direction: column; align-items: flex-start; gap: 5px; }
+  }
+`;

--- a/examples/experimental/gpu-data-analysis/src/app.ts
+++ b/examples/experimental/gpu-data-analysis/src/app.ts
@@ -16,7 +16,6 @@ import {
 } from '@luma.gl/experimental';
 import {
   column,
-  literal,
   LuDataFrame,
   parameter,
   type CompiledLuDataFrameQuery,
@@ -25,6 +24,7 @@ import {
 import {GPURecordBatch, GPUTable, type GPUVector} from '@luma.gl/tables';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 import * as arrow from 'apache-arrow';
+import {GPU_DATA_ANALYSIS_STYLES, GPU_DATA_ANALYSIS_TEMPLATE} from './app-shell';
 
 const APP_ID = 'gpu-data-analysis-app';
 const STYLE_ID = 'gpu-data-analysis-style';
@@ -52,8 +52,15 @@ type ExampleElements = {
   heatmap: HTMLElement;
   histogram: HTMLElement;
   luDataFrameAdjustment: HTMLInputElement;
+  luDataFrameExecution: HTMLElement;
+  luDataFrameExpression: HTMLElement;
+  luDataFrameMultiplier: HTMLSelectElement;
+  luDataFramePreview: HTMLElement;
+  luDataFrameRate: HTMLElement;
   luDataFrameResult: HTMLElement;
   luDataFrameRun: HTMLButtonElement;
+  luDataFrameSelected: HTMLElement;
+  luDataFrameThreshold: HTMLInputElement;
   nodes: HTMLElement;
   reuse: HTMLElement;
   run: HTMLButtonElement;
@@ -69,7 +76,7 @@ export function initializeGPUDataAnalysisExample(): GPUDataAnalysisExampleHandle
   const root = document.getElementById(APP_ID);
   if (!root) throw new Error(`GPU data-analysis example requires #${APP_ID}`);
   ensureStyles();
-  root.innerHTML = EXAMPLE_HTML;
+  root.innerHTML = GPU_DATA_ANALYSIS_TEMPLATE;
   const example = new GPUDataAnalysisExample(root);
   void example.initialize();
   return {destroy: () => example.destroy()};
@@ -80,10 +87,15 @@ class GPUDataAnalysisExample {
   private device: Device | null = null;
   private resources: ExampleResources | null = null;
   private destroyed = false;
+  private hasRunLuDataFrameDemo = false;
   private runVersion = 0;
 
   private readonly handleRun = (): void => void this.run();
   private readonly handleLuDataFrameRun = (): void => void this.runLuDataFrameDemo();
+  private readonly handleLuDataFrameInput = (): void => this.updateLuDataFrameExpression();
+  private readonly handleLuDataFrameChange = (): void => {
+    if (this.hasRunLuDataFrameDemo) void this.runLuDataFrameDemo();
+  };
 
   constructor(root: HTMLElement) {
     this.elements = getElements(root);
@@ -98,6 +110,11 @@ class GPUDataAnalysisExample {
     }
     this.elements.run.addEventListener('click', this.handleRun);
     this.elements.luDataFrameRun.addEventListener('click', this.handleLuDataFrameRun);
+    for (const control of this.getLuDataFrameControls()) {
+      control.addEventListener('input', this.handleLuDataFrameInput);
+      control.addEventListener('change', this.handleLuDataFrameChange);
+    }
+    this.updateLuDataFrameExpression();
   }
 
   async initialize(): Promise<void> {
@@ -123,6 +140,10 @@ class GPUDataAnalysisExample {
     this.destroyed = true;
     this.elements.run.removeEventListener('click', this.handleRun);
     this.elements.luDataFrameRun.removeEventListener('click', this.handleLuDataFrameRun);
+    for (const control of this.getLuDataFrameControls()) {
+      control.removeEventListener('input', this.handleLuDataFrameInput);
+      control.removeEventListener('change', this.handleLuDataFrameChange);
+    }
     for (const element of [
       this.elements.dataset,
       this.elements.bins,
@@ -583,13 +604,18 @@ class GPUDataAnalysisExample {
     }
 
     const adjustment = Number(this.elements.luDataFrameAdjustment.value);
-    if (!Number.isFinite(adjustment)) {
-      this.elements.luDataFrameResult.textContent = 'Enter a finite adjustment.';
+    const multiplier = Number(this.elements.luDataFrameMultiplier.value);
+    const threshold = Number(this.elements.luDataFrameThreshold.value);
+    if (![adjustment, multiplier, threshold].every(Number.isFinite)) {
+      this.elements.luDataFrameResult.textContent = 'Every expression parameter must be finite.';
       return;
     }
 
+    this.hasRunLuDataFrameDemo = true;
     this.elements.luDataFrameRun.disabled = true;
     this.elements.luDataFrameResult.textContent = 'Compiling GPU-resident derived columns...';
+    this.elements.luDataFrameResult.dataset.state = 'running';
+    const executionStarted = performance.now();
     let frame: LuDataFrame<{value: 'float32'; category: 'uint32'}> | undefined;
     let compiled:
       | CompiledLuDataFrameQuery<{category: 'uint32'; adjustedValue: 'float32'}>
@@ -606,9 +632,11 @@ class GPUDataAnalysisExample {
       const query = frame
         .withColumn(
           'adjustedValue',
-          column('value').multiply(literal(2)).add(parameter('adjustment', adjustment))
+          column('value')
+            .multiply(parameter('multiplier', multiplier))
+            .add(parameter('adjustment', adjustment))
         )
-        .filter(column('adjustedValue').greaterThan(literal(adjustment)))
+        .filter(column('adjustedValue').greaterThan(parameter('threshold', threshold)))
         .select(['category', 'adjustedValue']);
       const graph = new GPUCommandGraph<LuDataFrameQueryParameters>(device, {
         id: 'gpu-data-analysis-ludf-derived-demo'
@@ -616,7 +644,7 @@ class GPUDataAnalysisExample {
       compiled = query.compile(graph);
 
       const commandEncoder = device.createCommandEncoder({id: 'ludf-derived-demo'});
-      compiled.encode(commandEncoder, {adjustment});
+      compiled.encode(commandEncoder, {adjustment, multiplier, threshold});
       device.submit(commandEncoder.finish());
 
       const countData = compiled.selectedCounts.data[0];
@@ -635,7 +663,7 @@ class GPUDataAnalysisExample {
       ]);
       const selectedCount = new Uint32Array(countBytes.buffer, countBytes.byteOffset, 1)[0];
       const expectedCount = resources.sourceValues.reduce(
-        (count, value) => count + Number(value * 2 + adjustment > adjustment),
+        (count, value) => count + Number(value * multiplier + adjustment > threshold),
         0
       );
       const sample = Array.from(
@@ -645,19 +673,45 @@ class GPUDataAnalysisExample {
 
       if (!this.destroyed && this.resources === resources) {
         const validation = selectedCount === expectedCount ? 'CPU verified' : 'GPU/CPU mismatch';
+        const selectedPercentage = (selectedCount / resources.sourceValues.length) * 100;
+        this.elements.luDataFrameSelected.textContent = selectedCount.toLocaleString();
+        this.elements.luDataFrameRate.textContent = `${selectedPercentage.toFixed(1)}%`;
+        this.elements.luDataFrameExecution.textContent = `${(
+          performance.now() - executionStarted
+        ).toFixed(1)} ms`;
+        this.elements.luDataFramePreview.textContent = sample.join('   ');
+        this.elements.luDataFrameResult.dataset.state =
+          selectedCount === expectedCount ? 'verified' : 'error';
         this.elements.luDataFrameResult.textContent =
-          `${selectedCount.toLocaleString()} selected rows · adjusted = value × 2 + ${adjustment} · ` +
+          `${selectedCount.toLocaleString()} selected rows · adjusted = value × ${multiplier} + ${adjustment} · ` +
           `first GPU values [${sample.join(', ')}] · ${validation}`;
       }
     } catch (error) {
       if (!this.destroyed) {
         this.elements.luDataFrameResult.textContent = getErrorMessage(error);
+        this.elements.luDataFrameResult.dataset.state = 'error';
       }
     } finally {
       compiled?.destroy();
       frame?.destroy();
       if (!this.destroyed) this.elements.luDataFrameRun.disabled = false;
     }
+  }
+
+  /** Keeps the visible expression synchronized without allocating or dispatching GPU work. */
+  private updateLuDataFrameExpression(): void {
+    this.elements.luDataFrameExpression.textContent =
+      `value × ${this.elements.luDataFrameMultiplier.value} + ` +
+      `${this.elements.luDataFrameAdjustment.value} > ${this.elements.luDataFrameThreshold.value}`;
+  }
+
+  /** Returns the three lightweight controls that parameterize the reusable dataframe plan. */
+  private getLuDataFrameControls(): (HTMLInputElement | HTMLSelectElement)[] {
+    return [
+      this.elements.luDataFrameMultiplier,
+      this.elements.luDataFrameAdjustment,
+      this.elements.luDataFrameThreshold
+    ];
   }
 
   private setStatus(message: string, error = false): void {
@@ -938,8 +992,15 @@ function getElements(root: HTMLElement): ExampleElements {
     heatmap: get('[data-heatmap]'),
     histogram: get('[data-histogram]'),
     luDataFrameAdjustment: get('[data-ludf-adjustment]'),
+    luDataFrameExecution: get('[data-ludf-execution]'),
+    luDataFrameExpression: get('[data-ludf-expression]'),
+    luDataFrameMultiplier: get('[data-ludf-multiplier]'),
+    luDataFramePreview: get('[data-ludf-preview]'),
+    luDataFrameRate: get('[data-ludf-rate]'),
     luDataFrameResult: get('[data-ludf-result]'),
     luDataFrameRun: get('[data-ludf-run]'),
+    luDataFrameSelected: get('[data-ludf-selected]'),
+    luDataFrameThreshold: get('[data-ludf-threshold]'),
     nodes: get('[data-nodes]'),
     reuse: get('[data-reuse]'),
     run: get('[data-run]'),
@@ -952,14 +1013,10 @@ function ensureStyles(): void {
   if (document.getElementById(STYLE_ID)) return;
   const style = document.createElement('style');
   style.id = STYLE_ID;
-  style.textContent = STYLES;
+  style.textContent = GPU_DATA_ANALYSIS_STYLES;
   document.head.appendChild(style);
 }
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
-
-const EXAMPLE_HTML = `<main class="analysis-example"><header><p>EXPERIMENTAL · WEBGPU</p><h1>Command-graph data analysis</h1><span>Extent → histogram → inclusive CDF, composed with filtered group counts and means, spatial statistics, and segmented row prefixes.</span></header><section class="controls"><label>Dataset<select data-dataset><option value="small">4K rows</option><option value="medium" selected>65K rows</option><option value="large">262K rows</option></select></label><label>Histogram<select data-bins><option value="16">16 uniform bins</option><option value="64" selected>64 uniform bins</option><option value="300">300 uniform bins</option><option value="thresholds">8 threshold bins</option></select></label><label>Group filter<select data-group-filter><option value="all">All values</option><option value="positive" selected>Positive values</option><option value="negative">Negative values</option></select></label><label>Grid<select data-grid><option>8</option><option selected>16</option><option>17</option></select></label><button data-run>Run graph</button></section><p class="status" data-status></p><section class="metrics"><article><span>Nodes</span><strong data-nodes>—</strong></article><article><span>Compile</span><strong data-compile-time>—</strong></article><article><span>Transient reuse</span><strong data-reuse>—</strong></article><article><span>Validation</span><strong data-validation>—</strong></article></section><section class="controls"><label>luDF adjustment<input data-ludf-adjustment type="number" value="1" step="0.25"></label><button data-ludf-run>Run luDF derived-column demo</button><p data-ludf-result>Derive and filter existing Arrow-backed GPU columns without copying rows.</p></section><section class="visuals"><article><h2>Histogram</h2><div class="histogram" data-histogram></div></article><article><h2>Filtered groups</h2><div class="groups" data-groups></div></article><article><h2>Grid heatmap</h2><div class="heatmap" data-heatmap></div></article></section></main>`;
-
-const STYLES = `.analysis-example{min-height:100%;box-sizing:border-box;padding:30px;color:#172033;background:radial-gradient(circle at 90% 0,#d9f4ea,transparent 35%),#f6f8fb;font-family:Inter,ui-sans-serif,system-ui}.analysis-example *{box-sizing:border-box}.analysis-example>header,.analysis-example>section,.analysis-example>.status{max-width:1120px;margin-left:auto;margin-right:auto}.analysis-example header p{margin:0;color:#08745b;font-size:12px;font-weight:800;letter-spacing:.13em}.analysis-example h1{margin:5px 0;font-size:clamp(30px,5vw,52px);letter-spacing:-.04em}.analysis-example header span{color:#5d687b}.controls{display:flex;flex-wrap:wrap;gap:12px;align-items:end;margin-top:24px;padding:16px;border:1px solid #ccd6df;border-radius:15px;background:#fff}.controls label{display:grid;gap:5px;color:#596579;font-size:12px;font-weight:700}.controls select,.controls button{height:40px;padding:0 12px;border:1px solid #aebdcc;border-radius:8px;background:#fff;color:#172033}.controls button{background:#08745b;color:#fff;border-color:#08745b;font-weight:700}.status{padding:10px 2px;color:#596579}.status[data-state=error],[data-validation][data-state=error]{color:#b42318}.metrics{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}.metrics article,.visuals article{padding:16px;border:1px solid #d5dde6;border-radius:14px;background:#fff;box-shadow:0 10px 30px #25324a0a}.metrics span{display:block;color:#667085;font-size:12px}.metrics strong{display:block;margin-top:7px;font-size:18px}.visuals{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin-top:12px}.visuals h2{margin:0 0 12px;font-size:16px}.histogram{height:250px;display:flex;align-items:end;gap:2px;border-bottom:1px solid #b8c3cf}.histogram i{display:block;flex:1;min-width:1px;background:#2da98a;border-radius:2px 2px 0 0}.groups{height:250px;display:grid;align-content:center;gap:14px}.groups div{display:grid;grid-template-columns:76px 1fr minmax(110px,auto);align-items:center;gap:8px;color:#596579;font-size:12px}.groups i{display:block;height:14px;background:#875bc7;border-radius:2px}.groups strong{text-align:right;color:#172033}.heatmap{height:250px;aspect-ratio:1;display:grid;gap:1px;margin:auto;background:#e8edf1}.heatmap i{display:block;background:#315cc5}@media(max-width:900px){.visuals{grid-template-columns:1fr 1fr}.visuals article:last-child{grid-column:1/-1}}@media(max-width:760px){.analysis-example{padding:18px}.metrics{grid-template-columns:1fr 1fr}.visuals{grid-template-columns:1fr}.visuals article:last-child{grid-column:auto}}`;

--- a/examples/experimental/gpu-data-analysis/src/app.ts
+++ b/examples/experimental/gpu-data-analysis/src/app.ts
@@ -14,7 +14,15 @@ import {
   GPUScan,
   type CompiledGPUCommandGraph
 } from '@luma.gl/experimental';
-import type {GPUVector} from '@luma.gl/tables';
+import {
+  column,
+  literal,
+  LuDataFrame,
+  parameter,
+  type CompiledLuDataFrameQuery,
+  type LuDataFrameQueryParameters
+} from '@luma.gl/experimental/ludf';
+import {GPURecordBatch, GPUTable, type GPUVector} from '@luma.gl/tables';
 import {webgpuAdapter} from '@luma.gl/webgpu';
 import * as arrow from 'apache-arrow';
 
@@ -30,6 +38,7 @@ type ExampleResources = {
   selection: GPUVector<'uint32'>;
   values: GPUVector<'float32'>;
   positions: GPUVector<'float32x2'>;
+  sourceValues: Float32Array;
   outputs: Buffer[];
 };
 
@@ -42,6 +51,9 @@ type ExampleElements = {
   groups: HTMLElement;
   heatmap: HTMLElement;
   histogram: HTMLElement;
+  luDataFrameAdjustment: HTMLInputElement;
+  luDataFrameResult: HTMLElement;
+  luDataFrameRun: HTMLButtonElement;
   nodes: HTMLElement;
   reuse: HTMLElement;
   run: HTMLButtonElement;
@@ -71,6 +83,7 @@ class GPUDataAnalysisExample {
   private runVersion = 0;
 
   private readonly handleRun = (): void => void this.run();
+  private readonly handleLuDataFrameRun = (): void => void this.runLuDataFrameDemo();
 
   constructor(root: HTMLElement) {
     this.elements = getElements(root);
@@ -84,6 +97,7 @@ class GPUDataAnalysisExample {
       element.addEventListener('change', this.handleRun);
     }
     this.elements.run.addEventListener('click', this.handleRun);
+    this.elements.luDataFrameRun.addEventListener('click', this.handleLuDataFrameRun);
   }
 
   async initialize(): Promise<void> {
@@ -108,6 +122,7 @@ class GPUDataAnalysisExample {
     if (this.destroyed) return;
     this.destroyed = true;
     this.elements.run.removeEventListener('click', this.handleRun);
+    this.elements.luDataFrameRun.removeEventListener('click', this.handleLuDataFrameRun);
     for (const element of [
       this.elements.dataset,
       this.elements.bins,
@@ -385,6 +400,7 @@ class GPUDataAnalysisExample {
         positions: gpuPositions,
         groupKeys: gpuGroupKeys,
         selection: gpuSelection,
+        sourceValues: values,
         outputs
       };
 
@@ -555,6 +571,93 @@ class GPUDataAnalysisExample {
   private releaseResources(): void {
     destroyResources(this.resources);
     this.resources = null;
+  }
+
+  /** Runs an opt-in dataframe derivation directly over the existing Arrow-uploaded GPU columns. */
+  private async runLuDataFrameDemo(): Promise<void> {
+    const device = this.device;
+    const resources = this.resources;
+    if (!device || !resources || this.destroyed) {
+      this.elements.luDataFrameResult.textContent = 'Run the analysis graph first.';
+      return;
+    }
+
+    const adjustment = Number(this.elements.luDataFrameAdjustment.value);
+    if (!Number.isFinite(adjustment)) {
+      this.elements.luDataFrameResult.textContent = 'Enter a finite adjustment.';
+      return;
+    }
+
+    this.elements.luDataFrameRun.disabled = true;
+    this.elements.luDataFrameResult.textContent = 'Compiling GPU-resident derived columns...';
+    let frame: LuDataFrame<{value: 'float32'; category: 'uint32'}> | undefined;
+    let compiled:
+      | CompiledLuDataFrameQuery<{category: 'uint32'; adjustedValue: 'float32'}>
+      | undefined;
+
+    try {
+      const batches = resources.values.data.map(
+        (valueData, batchIndex) =>
+          new GPURecordBatch<{value: 'float32'; category: 'uint32'}>({
+            gpuData: {value: valueData, category: resources.groupKeys.data[batchIndex]}
+          })
+      );
+      frame = new LuDataFrame({table: new GPUTable({batches})});
+      const query = frame
+        .withColumn(
+          'adjustedValue',
+          column('value').multiply(literal(2)).add(parameter('adjustment', adjustment))
+        )
+        .filter(column('adjustedValue').greaterThan(literal(adjustment)))
+        .select(['category', 'adjustedValue']);
+      const graph = new GPUCommandGraph<LuDataFrameQueryParameters>(device, {
+        id: 'gpu-data-analysis-ludf-derived-demo'
+      });
+      compiled = query.compile(graph);
+
+      const commandEncoder = device.createCommandEncoder({id: 'ludf-derived-demo'});
+      compiled.encode(commandEncoder, {adjustment});
+      device.submit(commandEncoder.finish());
+
+      const countData = compiled.selectedCounts.data[0];
+      const derivedData = compiled.table.gpuVectors.adjustedValue.data[0];
+      const countBuffer =
+        countData.buffer instanceof Buffer ? countData.buffer : countData.buffer.buffer;
+      const derivedBuffer =
+        derivedData.buffer instanceof Buffer ? derivedData.buffer : derivedData.buffer.buffer;
+      const sampleLength = Math.min(derivedData.length, 4);
+      const [countBytes, sampleBytes] = await Promise.all([
+        countBuffer.readAsync(countData.byteOffset, Uint32Array.BYTES_PER_ELEMENT),
+        derivedBuffer.readAsync(
+          derivedData.byteOffset,
+          sampleLength * Float32Array.BYTES_PER_ELEMENT
+        )
+      ]);
+      const selectedCount = new Uint32Array(countBytes.buffer, countBytes.byteOffset, 1)[0];
+      const expectedCount = resources.sourceValues.reduce(
+        (count, value) => count + Number(value * 2 + adjustment > adjustment),
+        0
+      );
+      const sample = Array.from(
+        new Float32Array(sampleBytes.buffer, sampleBytes.byteOffset, sampleLength),
+        value => value.toFixed(2)
+      );
+
+      if (!this.destroyed && this.resources === resources) {
+        const validation = selectedCount === expectedCount ? 'CPU verified' : 'GPU/CPU mismatch';
+        this.elements.luDataFrameResult.textContent =
+          `${selectedCount.toLocaleString()} selected rows · adjusted = value × 2 + ${adjustment} · ` +
+          `first GPU values [${sample.join(', ')}] · ${validation}`;
+      }
+    } catch (error) {
+      if (!this.destroyed) {
+        this.elements.luDataFrameResult.textContent = getErrorMessage(error);
+      }
+    } finally {
+      compiled?.destroy();
+      frame?.destroy();
+      if (!this.destroyed) this.elements.luDataFrameRun.disabled = false;
+    }
   }
 
   private setStatus(message: string, error = false): void {
@@ -834,6 +937,9 @@ function getElements(root: HTMLElement): ExampleElements {
     groups: get('[data-groups]'),
     heatmap: get('[data-heatmap]'),
     histogram: get('[data-histogram]'),
+    luDataFrameAdjustment: get('[data-ludf-adjustment]'),
+    luDataFrameResult: get('[data-ludf-result]'),
+    luDataFrameRun: get('[data-ludf-run]'),
     nodes: get('[data-nodes]'),
     reuse: get('[data-reuse]'),
     run: get('[data-run]'),
@@ -854,6 +960,6 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-const EXAMPLE_HTML = `<main class="analysis-example"><header><p>EXPERIMENTAL · WEBGPU</p><h1>Command-graph data analysis</h1><span>Extent → histogram → inclusive CDF, composed with filtered group counts and means, spatial statistics, and segmented row prefixes.</span></header><section class="controls"><label>Dataset<select data-dataset><option value="small">4K rows</option><option value="medium" selected>65K rows</option><option value="large">262K rows</option></select></label><label>Histogram<select data-bins><option value="16">16 uniform bins</option><option value="64" selected>64 uniform bins</option><option value="300">300 uniform bins</option><option value="thresholds">8 threshold bins</option></select></label><label>Group filter<select data-group-filter><option value="all">All values</option><option value="positive" selected>Positive values</option><option value="negative">Negative values</option></select></label><label>Grid<select data-grid><option>8</option><option selected>16</option><option>17</option></select></label><button data-run>Run graph</button></section><p class="status" data-status></p><section class="metrics"><article><span>Nodes</span><strong data-nodes>—</strong></article><article><span>Compile</span><strong data-compile-time>—</strong></article><article><span>Transient reuse</span><strong data-reuse>—</strong></article><article><span>Validation</span><strong data-validation>—</strong></article></section><section class="visuals"><article><h2>Histogram</h2><div class="histogram" data-histogram></div></article><article><h2>Filtered groups</h2><div class="groups" data-groups></div></article><article><h2>Grid heatmap</h2><div class="heatmap" data-heatmap></div></article></section></main>`;
+const EXAMPLE_HTML = `<main class="analysis-example"><header><p>EXPERIMENTAL · WEBGPU</p><h1>Command-graph data analysis</h1><span>Extent → histogram → inclusive CDF, composed with filtered group counts and means, spatial statistics, and segmented row prefixes.</span></header><section class="controls"><label>Dataset<select data-dataset><option value="small">4K rows</option><option value="medium" selected>65K rows</option><option value="large">262K rows</option></select></label><label>Histogram<select data-bins><option value="16">16 uniform bins</option><option value="64" selected>64 uniform bins</option><option value="300">300 uniform bins</option><option value="thresholds">8 threshold bins</option></select></label><label>Group filter<select data-group-filter><option value="all">All values</option><option value="positive" selected>Positive values</option><option value="negative">Negative values</option></select></label><label>Grid<select data-grid><option>8</option><option selected>16</option><option>17</option></select></label><button data-run>Run graph</button></section><p class="status" data-status></p><section class="metrics"><article><span>Nodes</span><strong data-nodes>—</strong></article><article><span>Compile</span><strong data-compile-time>—</strong></article><article><span>Transient reuse</span><strong data-reuse>—</strong></article><article><span>Validation</span><strong data-validation>—</strong></article></section><section class="controls"><label>luDF adjustment<input data-ludf-adjustment type="number" value="1" step="0.25"></label><button data-ludf-run>Run luDF derived-column demo</button><p data-ludf-result>Derive and filter existing Arrow-backed GPU columns without copying rows.</p></section><section class="visuals"><article><h2>Histogram</h2><div class="histogram" data-histogram></div></article><article><h2>Filtered groups</h2><div class="groups" data-groups></div></article><article><h2>Grid heatmap</h2><div class="heatmap" data-heatmap></div></article></section></main>`;
 
 const STYLES = `.analysis-example{min-height:100%;box-sizing:border-box;padding:30px;color:#172033;background:radial-gradient(circle at 90% 0,#d9f4ea,transparent 35%),#f6f8fb;font-family:Inter,ui-sans-serif,system-ui}.analysis-example *{box-sizing:border-box}.analysis-example>header,.analysis-example>section,.analysis-example>.status{max-width:1120px;margin-left:auto;margin-right:auto}.analysis-example header p{margin:0;color:#08745b;font-size:12px;font-weight:800;letter-spacing:.13em}.analysis-example h1{margin:5px 0;font-size:clamp(30px,5vw,52px);letter-spacing:-.04em}.analysis-example header span{color:#5d687b}.controls{display:flex;flex-wrap:wrap;gap:12px;align-items:end;margin-top:24px;padding:16px;border:1px solid #ccd6df;border-radius:15px;background:#fff}.controls label{display:grid;gap:5px;color:#596579;font-size:12px;font-weight:700}.controls select,.controls button{height:40px;padding:0 12px;border:1px solid #aebdcc;border-radius:8px;background:#fff;color:#172033}.controls button{background:#08745b;color:#fff;border-color:#08745b;font-weight:700}.status{padding:10px 2px;color:#596579}.status[data-state=error],[data-validation][data-state=error]{color:#b42318}.metrics{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}.metrics article,.visuals article{padding:16px;border:1px solid #d5dde6;border-radius:14px;background:#fff;box-shadow:0 10px 30px #25324a0a}.metrics span{display:block;color:#667085;font-size:12px}.metrics strong{display:block;margin-top:7px;font-size:18px}.visuals{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin-top:12px}.visuals h2{margin:0 0 12px;font-size:16px}.histogram{height:250px;display:flex;align-items:end;gap:2px;border-bottom:1px solid #b8c3cf}.histogram i{display:block;flex:1;min-width:1px;background:#2da98a;border-radius:2px 2px 0 0}.groups{height:250px;display:grid;align-content:center;gap:14px}.groups div{display:grid;grid-template-columns:76px 1fr minmax(110px,auto);align-items:center;gap:8px;color:#596579;font-size:12px}.groups i{display:block;height:14px;background:#875bc7;border-radius:2px}.groups strong{text-align:right;color:#172033}.heatmap{height:250px;aspect-ratio:1;display:grid;gap:1px;margin:auto;background:#e8edf1}.heatmap i{display:block;background:#315cc5}@media(max-width:900px){.visuals{grid-template-columns:1fr 1fr}.visuals article:last-child{grid-column:1/-1}}@media(max-width:760px){.analysis-example{padding:18px}.metrics{grid-template-columns:1fr 1fr}.visuals{grid-template-columns:1fr}.visuals article:last-child{grid-column:auto}}`;

--- a/modules/experimental/src/ludf/index.ts
+++ b/modules/experimental/src/ludf/index.ts
@@ -13,6 +13,12 @@ export type {
   LuDataFrameValidity
 } from './lu-data-frame';
 export {LuDataFrameQuery} from './lu-data-frame-query';
+export type {
+  LuDataFrameDerivedColumn,
+  LuDataFrameDerivedColumnFormat,
+  LuDataFrameDerivedColumnFormatForExpression,
+  LuDataFrameDerivedColumnOptions
+} from './lu-data-frame-query';
 export {and, column, literal, LuExpression, not, or, parameter} from './lu-expression';
 export type {
   LuExpressionBinaryOperator,

--- a/modules/experimental/src/ludf/lu-data-frame-query.ts
+++ b/modules/experimental/src/ludf/lu-data-frame-query.ts
@@ -12,41 +12,74 @@ import {
   type LuDataFrameQueryParameters
 } from './lu-query-compiler';
 
+/** Portable scalar storage formats supported by computed dataframe columns. */
+export type LuDataFrameDerivedColumnFormat = 'float32' | 'sint32' | 'uint32';
+
+/** Immutable numerical expression materialized only when its dataframe query is compiled. */
+export type LuDataFrameDerivedColumn = Readonly<{
+  /** Logical dataframe field name, distinct from every existing source and derived field. */
+  name: string;
+  /** Numeric expression referencing currently available source or derived columns. */
+  expression: LuExpression<number | null, string>;
+  /** Optional explicit scalar format, which must agree with the referenced input format. */
+  format?: LuDataFrameDerivedColumnFormat;
+}>;
+
+/** Optional explicit scalar storage metadata for one computed dataframe column. */
+export type LuDataFrameDerivedColumnOptions<
+  Format extends LuDataFrameDerivedColumnFormat = LuDataFrameDerivedColumnFormat
+> = Readonly<{format?: Format}>;
+
+/** Infers a derived scalar format from its inputs, defaulting pure scalar expressions to float32. */
+export type LuDataFrameDerivedColumnFormatForExpression<
+  T extends GPUTypeMap,
+  ReferencedColumns extends keyof T & string
+> = [ReferencedColumns] extends [never]
+  ? 'float32'
+  : Extract<T[ReferencedColumns], LuDataFrameDerivedColumnFormat>;
+
 /**
  * Immutable dataframe query planned entirely on the CPU.
  *
- * Predicates always retain access to their complete source schema, while projection changes only
- * the eventual output columns. Planning borrows its source and never acquires a resource lease;
- * explicit compilation retains the source only for the compiled graph's actual lifetime.
+ * Predicates and derived expressions retain access to their complete source schema, while
+ * projection changes only the eventual output columns. Planning borrows its source and never
+ * acquires a resource lease; explicit compilation retains the source only for the compiled
+ * graph's actual lifetime.
  */
 export class LuDataFrameQuery<
-  T extends GPUTypeMap = GPUTypeMap,
-  SelectedColumns extends keyof T & string = keyof T & string
+  Logical extends GPUTypeMap = GPUTypeMap,
+  SelectedColumns extends keyof Logical & string = keyof Logical & string,
+  Source extends GPUTypeMap = Logical
 > {
   /** Original dataframe whose GPU buffers remain borrowed until explicit compilation. */
-  readonly source: LuDataFrame<T>;
+  readonly source: LuDataFrame<Source>;
   /** Immutable boolean predicates combined in source order. */
   readonly predicates: readonly LuExpression<boolean, string>[];
-  /** Source columns retained in the eventually compiled output dataframe. */
+  /** Source and derived columns retained in the eventually compiled output dataframe. */
   readonly selectedColumns: readonly SelectedColumns[];
+  /** Derived expressions in immutable dependency order, including hidden intermediate values. */
+  readonly derivedColumns: readonly LuDataFrameDerivedColumn[];
 
   constructor(
-    source: LuDataFrame<T>,
+    source: LuDataFrame<Source>,
     predicates: readonly LuExpression<boolean, string>[],
-    selectedColumns: readonly SelectedColumns[]
+    selectedColumns: readonly SelectedColumns[],
+    derivedColumns: readonly LuDataFrameDerivedColumn[] = []
   ) {
-    assertSelectedQueryColumns(source, selectedColumns);
+    const logicalColumns = assertDataFrameDerivedColumns(source, derivedColumns);
+    assertSelectedQueryColumns(selectedColumns, logicalColumns);
     for (const predicate of predicates) {
-      assertDataFrameQueryPredicate(source, predicate, source.columnNames);
+      assertDataFrameQueryPredicate(source, predicate, logicalColumns, logicalColumns);
     }
 
     this.source = source;
     this.predicates = Object.freeze([...predicates]);
     this.selectedColumns = Object.freeze([...selectedColumns]);
+    this.derivedColumns = Object.freeze([...derivedColumns]);
     Object.freeze(this);
   }
 
-  /** Selected source-column names in immutable output-projection order. */
+  /** Selected logical-column names in immutable output-projection order. */
   get columnNames(): readonly SelectedColumns[] {
     return this.selectedColumns;
   }
@@ -54,52 +87,176 @@ export class LuDataFrameQuery<
   /** Adds one boolean predicate without mutating sibling query plans or touching GPU resources. */
   filter<ReferencedColumns extends SelectedColumns>(
     predicate: LuExpression<boolean, ReferencedColumns>
-  ): LuDataFrameQuery<T, SelectedColumns> {
-    assertDataFrameQueryPredicate(this.source, predicate, this.selectedColumns);
-    return new LuDataFrameQuery(this.source, [...this.predicates, predicate], this.selectedColumns);
+  ): LuDataFrameQuery<Logical, SelectedColumns, Source> {
+    const logicalColumns = [
+      ...this.source.columnNames,
+      ...this.derivedColumns.map(({name}) => name)
+    ];
+    assertDataFrameQueryPredicate(this.source, predicate, this.selectedColumns, logicalColumns);
+    return new LuDataFrameQuery<Logical, SelectedColumns, Source>(
+      this.source,
+      [...this.predicates, predicate],
+      this.selectedColumns,
+      this.derivedColumns
+    );
   }
 
-  /** Narrows only the eventual output columns while retaining all source predicate inputs. */
+  /** Narrows only eventual output columns while retaining all predicate and derived dependencies. */
   select<ColumnName extends SelectedColumns>(
     columnNames: readonly ColumnName[]
-  ): LuDataFrameQuery<T, ColumnName> {
-    assertSelectedQueryColumns(this.source, columnNames, this.selectedColumns);
-    return new LuDataFrameQuery(this.source, this.predicates, columnNames);
+  ): LuDataFrameQuery<Logical, ColumnName, Source> {
+    assertSelectedQueryColumns(columnNames, this.selectedColumns);
+    return new LuDataFrameQuery<Logical, ColumnName, Source>(
+      this.source,
+      this.predicates,
+      columnNames,
+      this.derivedColumns
+    );
+  }
+
+  /** Adds one selected derived column without allocating GPU storage or retaining source leases. */
+  withColumn<
+    Name extends string,
+    ReferencedColumns extends SelectedColumns,
+    Format extends LuDataFrameDerivedColumnFormat = LuDataFrameDerivedColumnFormatForExpression<
+      Logical,
+      ReferencedColumns
+    >
+  >(
+    name: Name,
+    expression: LuExpression<number | null, ReferencedColumns>,
+    options: LuDataFrameDerivedColumnOptions<Format> = {}
+  ): LuDataFrameQuery<Logical & Record<Name, Format>, SelectedColumns | Name, Source> {
+    assertDataFrameDerivedColumnName(name);
+    assertDataFrameDerivedExpression(expression, this.selectedColumns);
+
+    const definition: LuDataFrameDerivedColumn = Object.freeze({
+      name,
+      expression,
+      ...(options.format ? {format: options.format} : {})
+    });
+
+    return new LuDataFrameQuery<Logical & Record<Name, Format>, SelectedColumns | Name, Source>(
+      this.source,
+      this.predicates,
+      [...this.selectedColumns, name],
+      [...this.derivedColumns, definition]
+    );
   }
 
   /** Materializes reusable GPU graph passes and compiler-owned selection/index/count outputs. */
   compile(
     graph: GPUCommandGraph<LuDataFrameQueryParameters>
-  ): CompiledLuDataFrameQuery<Pick<T, SelectedColumns>> {
-    return compileLuDataFrameQuery(this.source, this.predicates, this.selectedColumns, graph);
+  ): CompiledLuDataFrameQuery<Pick<Logical, SelectedColumns>> {
+    return compileLuDataFrameQuery<Source, Pick<Logical, SelectedColumns>>(
+      this.source,
+      this.predicates,
+      this.selectedColumns,
+      graph,
+      this.derivedColumns
+    );
   }
 }
 
-/** Rejects nonboolean predicates and unknown or currently unselected source references. */
+/** Rejects nonboolean predicates and unknown or currently unselected logical references. */
 export function assertDataFrameQueryPredicate<T extends GPUTypeMap>(
   source: LuDataFrame<T>,
   predicate: LuExpression<boolean, string>,
-  selectedColumns: readonly (keyof T & string)[]
+  selectedColumns: readonly string[],
+  logicalColumns: readonly string[] = source.columnNames
 ): void {
   if (!(predicate instanceof LuExpression) || !isBooleanExpressionNode(predicate.node)) {
     throw new Error('LuDataFrame filters require a boolean expression');
   }
 
-  const availableNames = new Set<string>(selectedColumns);
-  for (const columnName of getLuExpressionColumnNames(predicate)) {
-    if (!source.schema.fields.some(field => field.name === columnName)) {
+  assertDataFrameExpressionColumns(predicate, selectedColumns, logicalColumns);
+}
+
+/** Validates computed definitions in dependency order and returns all available logical fields. */
+function assertDataFrameDerivedColumns<T extends GPUTypeMap>(
+  source: LuDataFrame<T>,
+  derivedColumns: readonly LuDataFrameDerivedColumn[]
+): string[] {
+  const logicalColumns = [...source.columnNames];
+  const logicalFormats = new Map<string, string | undefined>(
+    source.schema.fields.map(
+      field => [field.name, source.table.gpuColumns[field.name]?.format ?? field.format] as const
+    )
+  );
+
+  for (const derivedColumn of derivedColumns) {
+    assertDataFrameDerivedColumnName(derivedColumn.name);
+    if (logicalFormats.has(derivedColumn.name)) {
+      throw new Error(`LuDataFrame derived column "${derivedColumn.name}" already exists`);
+    }
+    assertDataFrameDerivedExpression(derivedColumn.expression, logicalColumns);
+
+    const referencedFormats = new Set(
+      getLuExpressionColumnNames(derivedColumn.expression).map(columnName =>
+        logicalFormats.get(columnName)
+      )
+    );
+    if (referencedFormats.size > 1) {
+      throw new Error(`LuDataFrame derived column "${derivedColumn.name}" mixes scalar formats`);
+    }
+    const inferredFormat = referencedFormats.values().next().value ?? 'float32';
+    if (
+      inferredFormat !== 'float32' &&
+      inferredFormat !== 'sint32' &&
+      inferredFormat !== 'uint32'
+    ) {
+      throw new Error(`LuDataFrame derived column "${derivedColumn.name}" requires scalar inputs`);
+    }
+    if (derivedColumn.format !== undefined && derivedColumn.format !== inferredFormat) {
+      throw new Error(`LuDataFrame derived column "${derivedColumn.name}" format does not match`);
+    }
+
+    logicalFormats.set(derivedColumn.name, inferredFormat);
+    logicalColumns.push(derivedColumn.name);
+  }
+
+  return logicalColumns;
+}
+
+/** Validates one numerical derived expression against its currently selected logical inputs. */
+function assertDataFrameDerivedExpression(
+  expression: LuExpression<number | null, string>,
+  selectedColumns: readonly string[]
+): void {
+  if (!(expression instanceof LuExpression) || !isNumericExpressionNode(expression.node)) {
+    throw new Error('LuDataFrame derived columns require a numeric expression');
+  }
+
+  assertDataFrameExpressionColumns(expression, selectedColumns, selectedColumns);
+}
+
+/** Rejects unknown and currently hidden expression inputs before touching GPU resources. */
+function assertDataFrameExpressionColumns(
+  expression: LuExpression<any, string>,
+  selectedColumns: readonly string[],
+  logicalColumns: readonly string[]
+): void {
+  const selectedNames = new Set(selectedColumns);
+  const logicalNames = new Set(logicalColumns);
+  for (const columnName of getLuExpressionColumnNames(expression)) {
+    if (!logicalNames.has(columnName)) {
       throw new Error(`LuDataFrame expression column "${columnName}" does not exist`);
     }
-    if (!availableNames.has(columnName)) {
+    if (!selectedNames.has(columnName)) {
       throw new Error(`LuDataFrame expression column "${columnName}" is not selected`);
     }
   }
 }
 
-function assertSelectedQueryColumns<T extends GPUTypeMap>(
-  source: LuDataFrame<T>,
+function assertDataFrameDerivedColumnName(name: string): void {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new Error('LuDataFrame derived columns require a nonempty name');
+  }
+}
+
+function assertSelectedQueryColumns(
   columnNames: readonly string[],
-  availableColumns: readonly string[] = source.columnNames
+  availableColumns: readonly string[]
 ): void {
   const availableNames = new Set(availableColumns);
   const selectedNames = new Set<string>();
@@ -112,6 +269,27 @@ function assertSelectedQueryColumns<T extends GPUTypeMap>(
       throw new Error(`LuDataFrame query column "${columnName}" cannot be selected more than once`);
     }
     selectedNames.add(columnName);
+  }
+}
+
+function isNumericExpressionNode(node: LuExpressionNode): boolean {
+  switch (node.kind) {
+    case 'column':
+      return true;
+    case 'literal':
+    case 'parameter':
+      return node.value === null || typeof node.value === 'number';
+    case 'unary':
+      return node.operator === 'negate';
+    case 'binary':
+      return (
+        node.operator === 'add' ||
+        node.operator === 'subtract' ||
+        node.operator === 'multiply' ||
+        node.operator === 'divide'
+      );
+    default:
+      return false;
   }
 }
 

--- a/modules/experimental/src/ludf/lu-data-frame.ts
+++ b/modules/experimental/src/ludf/lu-data-frame.ts
@@ -15,7 +15,12 @@ import {
   type GPUTypeMap,
   type GPUVectorFormat
 } from '@luma.gl/tables';
-import {LuDataFrameQuery} from './lu-data-frame-query';
+import {
+  LuDataFrameQuery,
+  type LuDataFrameDerivedColumnFormat,
+  type LuDataFrameDerivedColumnFormatForExpression,
+  type LuDataFrameDerivedColumnOptions
+} from './lu-data-frame-query';
 import type {LuExpression} from './lu-expression';
 
 /** Whether a dataframe borrows its source resources or releases them after its final view. */
@@ -166,6 +171,24 @@ export class LuDataFrame<T extends GPUTypeMap = GPUTypeMap> {
   ): LuDataFrameQuery<T> {
     this.assertAvailable();
     return new LuDataFrameQuery(this, [predicate], this.columnNames);
+  }
+
+  /** Plans one selected numeric derived column without allocating or submitting GPU work. */
+  withColumn<
+    Name extends string,
+    ReferencedColumns extends keyof T & string,
+    Format extends LuDataFrameDerivedColumnFormat = LuDataFrameDerivedColumnFormatForExpression<
+      T,
+      ReferencedColumns
+    >
+  >(
+    name: Name,
+    expression: LuExpression<number | null, ReferencedColumns>,
+    options: LuDataFrameDerivedColumnOptions<Format> = {}
+  ): LuDataFrameQuery<T & Record<Name, Format>, (keyof T & string) | Name, T> {
+    this.assertAvailable();
+    const query = new LuDataFrameQuery<T, keyof T & string, T>(this, [], this.columnNames);
+    return query.withColumn<Name, ReferencedColumns, Format>(name, expression, options);
   }
 
   /**

--- a/modules/experimental/src/ludf/lu-expression-shader.ts
+++ b/modules/experimental/src/ludf/lu-expression-shader.ts
@@ -4,6 +4,7 @@
 
 import type {GPUTypeMap} from '@luma.gl/tables';
 import type {LuDataFrame} from './lu-data-frame';
+import type {LuDataFrameDerivedColumn} from './lu-data-frame-query';
 import type {
   LuExpression,
   LuExpressionBinaryOperator,
@@ -34,10 +35,21 @@ export type LuQueryExpressionControl = {
   index: number;
 };
 
+/** One selected numeric expression materialized into a source-aligned GPU vector. @internal */
+export type LuQueryExpressionOutput = {
+  name: string;
+  format: LuQueryScalarFormat;
+  nullable: boolean;
+  value: string;
+  valid: string;
+  index: number;
+};
+
 /** Closed WGSL statements and metadata required by a graph-native dataframe predicate. @internal */
 export type LuQueryExpressionShaderPlan = {
   columns: readonly LuQueryExpressionColumn[];
   controls: readonly LuQueryExpressionControl[];
+  outputs: readonly LuQueryExpressionOutput[];
   statements: readonly string[];
   condition: string;
 };
@@ -48,6 +60,7 @@ type LuQueryExpressionShaderValue = {
   format: LuQueryValueFormat;
   value: string;
   valid: string;
+  nullable: boolean;
 };
 
 type LuQueryExpressionConstant = {
@@ -58,13 +71,38 @@ type LuQueryExpressionConstant = {
 /** Lowers immutable expressions without embedding user-controlled identifiers or values in WGSL. */
 export function makeLuQueryExpressionShaderPlan<T extends GPUTypeMap>(
   source: LuDataFrame<T>,
-  predicates: readonly LuExpression<boolean, string>[]
+  predicates: readonly LuExpression<boolean, string>[],
+  derivedColumns: readonly LuDataFrameDerivedColumn[] = [],
+  selectedColumns: readonly string[] = []
 ): LuQueryExpressionShaderPlan {
-  if (predicates.length === 0) {
+  if (predicates.length === 0 && derivedColumns.length === 0) {
     throw new Error('LuDataFrame filtering requires at least one predicate');
   }
 
-  const planner = new LuQueryExpressionShaderPlanner(source);
+  const planner = new LuQueryExpressionShaderPlanner(source, derivedColumns);
+  const outputs = selectedColumns.flatMap(name => {
+    const derived = derivedColumns.find(column => column.name === name);
+    if (!derived) {
+      return [];
+    }
+    const expression = planner.emitDerived(derived);
+    if (expression.format === 'boolean') {
+      throw new Error('LuDataFrame derived columns require numeric expressions');
+    }
+    return [
+      {
+        name,
+        format: expression.format,
+        nullable: expression.nullable,
+        value: expression.value,
+        valid: expression.valid,
+        index: 0
+      }
+    ];
+  });
+  outputs.forEach((output, index) => {
+    output.index = index;
+  });
   const conditions = predicates.map(predicate => {
     const expression = planner.emit(predicate.node, 'boolean');
     if (expression.format !== 'boolean') {
@@ -76,8 +114,9 @@ export function makeLuQueryExpressionShaderPlan<T extends GPUTypeMap>(
   return {
     columns: planner.columns,
     controls: planner.controls,
+    outputs,
     statements: planner.statements,
-    condition: conditions.join(' && ')
+    condition: conditions.join(' && ') || 'true'
   };
 }
 
@@ -141,10 +180,45 @@ class LuQueryExpressionShaderPlanner<T extends GPUTypeMap> {
   private readonly source: LuDataFrame<T>;
   private readonly columnsByName = new Map<string, LuQueryExpressionColumn>();
   private readonly constantsByName = new Map<string, LuQueryExpressionConstant>();
+  private readonly derivedByName: ReadonlyMap<string, LuDataFrameDerivedColumn>;
+  private readonly derivedValues = new Map<string, LuQueryExpressionShaderValue>();
+  private readonly resolvingDerived = new Set<string>();
   private expressionCount = 0;
 
-  constructor(source: LuDataFrame<T>) {
+  constructor(source: LuDataFrame<T>, derivedColumns: readonly LuDataFrameDerivedColumn[]) {
     this.source = source;
+    this.derivedByName = new Map(derivedColumns.map(column => [column.name, column]));
+  }
+
+  emitDerived(column: LuDataFrameDerivedColumn): LuQueryExpressionShaderValue {
+    const existing = this.derivedValues.get(column.name);
+    if (existing) {
+      return existing;
+    }
+    if (this.resolvingDerived.has(column.name)) {
+      throw new Error('LuDataFrame derived column references a cyclic expression');
+    }
+    this.resolvingDerived.add(column.name);
+    try {
+      const inferred = this.inferFormat(column.expression.node);
+      if (inferred === 'boolean') {
+        throw new Error('LuDataFrame derived columns require numeric expressions');
+      }
+      if (column.format && inferred && column.format !== inferred) {
+        throw new Error('LuDataFrame derived column format does not match its expression');
+      }
+      const expression = this.emit(column.expression.node, column.format ?? inferred ?? 'float32');
+      if (
+        expression.format === 'boolean' ||
+        (column.format && expression.format !== column.format)
+      ) {
+        throw new Error('LuDataFrame derived column format does not match its expression');
+      }
+      this.derivedValues.set(column.name, expression);
+      return expression;
+    } finally {
+      this.resolvingDerived.delete(column.name);
+    }
   }
 
   emit(node: LuExpressionNode, expected?: LuQueryValueFormat): LuQueryExpressionShaderValue {
@@ -165,6 +239,14 @@ class LuQueryExpressionShaderPlanner<T extends GPUTypeMap> {
   }
 
   private emitColumn(name: string, expected?: LuQueryValueFormat): LuQueryExpressionShaderValue {
+    const derived = this.derivedByName.get(name);
+    if (derived) {
+      const expression = this.emitDerived(derived);
+      if (expected && expected !== expression.format && expected !== 'boolean') {
+        throw new Error('LuDataFrame expression combines incompatible scalar column formats');
+      }
+      return expression;
+    }
     const constant = this.getConstant(name);
     if (constant) {
       if (expected && expected !== constant.format && expected !== 'boolean') {
@@ -180,7 +262,7 @@ class LuQueryExpressionShaderPlanner<T extends GPUTypeMap> {
     const valid = column.nullable
       ? `validity${column.index}[VALIDITY_${column.index}_OFFSET + index] != 0u`
       : 'true';
-    return this.addValue(column.format, value, valid);
+    return this.addValue(column.format, value, valid, column.nullable);
   }
 
   private emitControl(
@@ -209,7 +291,7 @@ class LuQueryExpressionShaderPlanner<T extends GPUTypeMap> {
           : inferred === 'boolean'
             ? `${valueWord} != 0u`
             : valueWord;
-    return this.addValue(inferred, decoded, validity);
+    return this.addValue(inferred, decoded, validity, value === null || name !== undefined);
   }
 
   private emitUnary(
@@ -221,7 +303,7 @@ class LuQueryExpressionShaderPlanner<T extends GPUTypeMap> {
       case 'not': {
         const operand = this.emit(operandNode, 'boolean');
         this.assertBoolean(operand);
-        return this.addValue('boolean', `!${operand.value}`, operand.valid);
+        return this.addValue('boolean', `!${operand.value}`, operand.valid, operand.nullable);
       }
       case 'is-valid': {
         const operand = this.emit(operandNode, this.inferFormat(operandNode));
@@ -237,7 +319,7 @@ class LuQueryExpressionShaderPlanner<T extends GPUTypeMap> {
           throw new Error('LuDataFrame negation requires a signed numeric expression');
         }
         const operand = this.emit(operandNode, format);
-        return this.addValue(format, `-${operand.value}`, operand.valid);
+        return this.addValue(format, `-${operand.value}`, operand.valid, operand.nullable);
       }
       default:
         throw new Error('LuDataFrame expression contains an unsupported unary operation');
@@ -262,7 +344,7 @@ class LuQueryExpressionShaderPlanner<T extends GPUTypeMap> {
       const decisiveLeft = operator === 'and' ? `!${left.value}` : left.value;
       const decisiveRight = operator === 'and' ? `!${right.value}` : right.value;
       const valid = `(${left.valid} && ${right.valid}) || (${left.valid} && ${decisiveLeft}) || (${right.valid} && ${decisiveRight})`;
-      return this.addValue('boolean', value, valid);
+      return this.addValue('boolean', value, valid, left.nullable || right.nullable);
     }
 
     const leftFormat = this.inferFormat(leftNode);
@@ -288,13 +370,20 @@ class LuQueryExpressionShaderPlanner<T extends GPUTypeMap> {
     const symbol = getLuQueryBinaryOperator(operator);
     const value = `(${left.value} ${symbol} ${right.value})`;
     const valid = `${left.valid} && ${right.valid}`;
-    return this.addValue(arithmetic ? format : 'boolean', value, valid);
+    return this.addValue(
+      arithmetic ? format : 'boolean',
+      value,
+      valid,
+      left.nullable || right.nullable
+    );
   }
 
   private inferFormat(node: LuExpressionNode): LuQueryValueFormat | undefined {
     switch (node.kind) {
       case 'column':
-        return this.getConstant(node.name)?.format ?? this.getColumn(node.name).format;
+        return this.derivedByName.has(node.name)
+          ? this.emitDerived(this.derivedByName.get(node.name)!).format
+          : (this.getConstant(node.name)?.format ?? this.getColumn(node.name).format);
       case 'literal':
       case 'parameter':
         return typeof node.value === 'boolean' ? 'boolean' : undefined;
@@ -375,7 +464,8 @@ class LuQueryExpressionShaderPlanner<T extends GPUTypeMap> {
   private addValue(
     format: LuQueryValueFormat,
     source: string,
-    validity: string
+    validity: string,
+    nullable = false
   ): LuQueryExpressionShaderValue {
     const index = this.expressionCount++;
     const value = `expression${index}Value`;
@@ -383,7 +473,7 @@ class LuQueryExpressionShaderPlanner<T extends GPUTypeMap> {
     const type = getLuQueryShaderType(format);
     this.statements.push(`let ${value}: ${type} = ${source};`);
     this.statements.push(`let ${valid}: bool = ${validity};`);
-    return {format, value, valid};
+    return {format, value, valid, nullable};
   }
 
   private assertBoolean(expression: LuQueryExpressionShaderValue): void {

--- a/modules/experimental/src/ludf/lu-query-compiler.ts
+++ b/modules/experimental/src/ludf/lu-query-compiler.ts
@@ -2,9 +2,23 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import {Buffer, type Binding, type CommandEncoder, type Device} from '@luma.gl/core';
+import {
+  Buffer,
+  type Binding,
+  type BufferLayout,
+  type CommandEncoder,
+  type Device
+} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';
-import {GPUData, GPUVector, type GPUTable, type GPUTypeMap} from '@luma.gl/tables';
+import {
+  GPUData,
+  GPURecordBatch,
+  GPUTable,
+  GPUVector,
+  type GPUConstant,
+  type GPUField,
+  type GPUTypeMap
+} from '@luma.gl/tables';
 import {
   type CompiledGPUCommandGraph,
   type GPUCommandGraph,
@@ -23,14 +37,17 @@ import {
   getViewBinding,
   getViewElementOffset
 } from '../gpu-primitives/graph-data-view-utils';
-import type {LuDataFrame} from './lu-data-frame';
+import type {LuDataFrame, LuDataFrameDictionaries, LuDataFrameValidity} from './lu-data-frame';
+import type {LuDataFrameDerivedColumn} from './lu-data-frame-query';
 import type {LuExpression} from './lu-expression';
 import {
   encodeLuQueryExpressionControls,
   getLuQueryShaderType,
   makeLuQueryExpressionShaderPlan,
   type LuQueryExpressionColumn,
-  type LuQueryExpressionShaderPlan
+  type LuQueryExpressionOutput,
+  type LuQueryExpressionShaderPlan,
+  type LuQueryScalarFormat
 } from './lu-expression-shader';
 
 const LU_QUERY_WORKGROUP_SIZE = 256;
@@ -44,13 +61,28 @@ type LuQuerySourceView = {
   validity?: GraphVectorView<'uint32'>;
 };
 
+type LuQueryDerivedOutput = {
+  plan: LuQueryExpressionOutput;
+  values: GPUVector<LuQueryScalarFormat>;
+  validity?: GPUVector<'uint32'>;
+};
+
+type LuQueryDerivedView = {
+  values: GraphVectorView<LuQueryScalarFormat>;
+  validity?: GraphVectorView<'uint32'>;
+};
+
 type CompiledLuDataFrameQueryProps<T extends GPUTypeMap> = {
   table: GPUTable<T>;
+  validity: Readonly<LuDataFrameValidity<T>>;
+  dictionaries: Readonly<LuDataFrameDictionaries<T>>;
   selectionMask: GPUVector<'uint32'>;
   rowIndices: GPUVector<'uint32'>;
   selectedCounts: GPUVector<'uint32'>;
   graph: CompiledGPUCommandGraph<LuDataFrameQueryParameters>;
   sourceViews: readonly Pick<LuDataFrame, 'destroy'>[];
+  ownedTable?: GPUTable<T>;
+  ownedVectors?: readonly GPUVector[];
 };
 
 /**
@@ -62,6 +94,10 @@ type CompiledLuDataFrameQueryProps<T extends GPUTypeMap> = {
 export class CompiledLuDataFrameQuery<T extends GPUTypeMap = GPUTypeMap> {
   /** Non-destructive projection of the original source table. */
   readonly table: GPUTable<T>;
+  /** Explicit validity sidecars for every selected nullable source or derived column. */
+  readonly validity: Readonly<LuDataFrameValidity<T>>;
+  /** Source categorical labels retained for selected, unmodified dictionary columns. */
+  readonly dictionaries: Readonly<LuDataFrameDictionaries<T>>;
   /** Canonical 0/1 selection flags with exactly the original source batch topology. */
   readonly selectionMask: GPUVector<'uint32'>;
   /** Stable, batch-local compacted source-row identities. */
@@ -71,16 +107,22 @@ export class CompiledLuDataFrameQuery<T extends GPUTypeMap = GPUTypeMap> {
 
   private readonly graph: CompiledGPUCommandGraph<LuDataFrameQueryParameters>;
   private readonly sourceViews: readonly Pick<LuDataFrame, 'destroy'>[];
+  private readonly ownedTable?: GPUTable<T>;
+  private readonly ownedVectors: readonly GPUVector[];
   private destroyed = false;
 
   /** @internal */
   constructor(props: CompiledLuDataFrameQueryProps<T>) {
     this.table = props.table;
+    this.validity = props.validity;
+    this.dictionaries = props.dictionaries;
     this.selectionMask = props.selectionMask;
     this.rowIndices = props.rowIndices;
     this.selectedCounts = props.selectedCounts;
     this.graph = props.graph;
     this.sourceViews = props.sourceViews;
+    this.ownedTable = props.ownedTable;
+    this.ownedVectors = props.ownedVectors ?? [];
   }
 
   /** Encodes reusable graph work without finishing or submitting the application encoder. */
@@ -104,6 +146,10 @@ export class CompiledLuDataFrameQuery<T extends GPUTypeMap = GPUTypeMap> {
     this.selectionMask.destroy();
     this.rowIndices.destroy();
     this.selectedCounts.destroy();
+    this.ownedTable?.destroy();
+    for (const vector of this.ownedVectors) {
+      vector.destroy();
+    }
     for (const sourceView of this.sourceViews) {
       sourceView.destroy();
     }
@@ -111,44 +157,91 @@ export class CompiledLuDataFrameQuery<T extends GPUTypeMap = GPUTypeMap> {
 }
 
 /** Compiles immutable dataframe predicates into source-batch-preserving WebGPU command work. */
-export function compileLuDataFrameQuery<T extends GPUTypeMap, ColumnName extends keyof T & string>(
-  source: LuDataFrame<T>,
+export function compileLuDataFrameQuery<Source extends GPUTypeMap, Result extends GPUTypeMap>(
+  source: LuDataFrame<Source>,
   predicates: readonly LuExpression<boolean, string>[],
-  selectedColumns: readonly ColumnName[],
-  graph: GPUCommandGraph<LuDataFrameQueryParameters>
-): CompiledLuDataFrameQuery<Pick<T, ColumnName>> {
-  const retainedSource = source.select<keyof T & string>(source.columnNames);
-  let selectedSource: LuDataFrame<Pick<T, ColumnName>> | undefined;
+  selectedColumns: readonly (keyof Result & string)[],
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
+  derivedColumns: readonly LuDataFrameDerivedColumn[] = []
+): CompiledLuDataFrameQuery<Result> {
+  const retainedSource = source.select<keyof Source & string>(source.columnNames);
+  let selectedSource: LuDataFrame | undefined;
+  let ownedTable: GPUTable<Result> | undefined;
+  const derivedOutputs: LuQueryDerivedOutput[] = [];
   let selectionMask: GPUVector<'uint32'> | undefined;
   let rowIndices: GPUVector<'uint32'> | undefined;
   let selectedCounts: GPUVector<'uint32'> | undefined;
   let compiledGraph: CompiledGPUCommandGraph<LuDataFrameQueryParameters> | undefined;
 
   try {
-    selectedSource = retainedSource.select(selectedColumns) as LuDataFrame<Pick<T, ColumnName>>;
-    const plan = makeLuQueryExpressionShaderPlan(retainedSource, predicates);
+    const sourceColumns = selectedColumns.filter(columnName =>
+      retainedSource.schema.fields.some(field => field.name === columnName)
+    ) as (keyof Source & string)[];
+    selectedSource = retainedSource.select(sourceColumns) as unknown as LuDataFrame;
+    const plan = makeLuQueryExpressionShaderPlan(
+      retainedSource,
+      predicates,
+      derivedColumns,
+      selectedColumns
+    );
     validateLuQueryBatchCapacity(retainedSource, graph);
     validateLuQueryBindingCapacity(plan, graph);
 
     selectionMask = createLuQueryOutputVector(
       graph.device,
       'ludf-selection-mask',
-      retainedSource.batches.map(batch => batch.numRows)
+      retainedSource.batches.map(batch => batch.numRows),
+      'uint32'
     );
     rowIndices = createLuQueryOutputVector(
       graph.device,
       'ludf-row-indices',
       retainedSource.batches.map(batch => batch.numRows),
+      'uint32',
       true
     );
     selectedCounts = createLuQueryOutputVector(
       graph.device,
       'ludf-selected-counts',
-      retainedSource.batches.map(() => 1)
+      retainedSource.batches.map(() => 1),
+      'uint32'
     );
+    for (const output of plan.outputs) {
+      const values = createLuQueryOutputVector(
+        graph.device,
+        `ludf-derived-${output.index}`,
+        retainedSource.batches.map(batch => batch.numRows),
+        output.format,
+        false,
+        true
+      );
+      const derivedOutput: LuQueryDerivedOutput = {plan: output, values};
+      derivedOutputs.push(derivedOutput);
+      if (output.nullable && retainedSource.batches.length > 0) {
+        derivedOutput.validity = createLuQueryOutputVector(
+          graph.device,
+          `ludf-derived-${output.index}-validity`,
+          retainedSource.batches.map(batch => batch.numRows),
+          'uint32'
+        );
+      }
+    }
+    if (derivedOutputs.length > 0) {
+      ownedTable = createLuQueryDerivedTable<Result>(
+        selectedSource.table,
+        selectedColumns,
+        derivedOutputs
+      );
+    }
+
+    const validity = selectLuQueryValidity<Result>(selectedSource, derivedOutputs);
+    const dictionaries = Object.freeze({
+      ...selectedSource.dictionaries
+    }) as Readonly<LuDataFrameDictionaries<Result>>;
 
     const queryId = `${graph.id}-ludf-query`;
     const sourceViews = importLuQuerySourceViews(graph, retainedSource, plan, queryId);
+    const derivedViews = importLuQueryDerivedViews(graph, derivedOutputs, queryId);
     const maskView = graph.importGPUVector(`${queryId}-selection-mask`, selectionMask);
     const rowIndexView = graph.importGPUVector(`${queryId}-row-indices`, rowIndices);
     const countView = graph.importGPUVector(`${queryId}-selected-counts`, selectedCounts);
@@ -177,6 +270,7 @@ export function compileLuDataFrameQuery<T extends GPUTypeMap, ColumnName extends
           batchIndex,
           columns: plan.columns,
           sourceViews,
+          derivedViews,
           controls,
           output: mask,
           plan
@@ -195,19 +289,30 @@ export function compileLuDataFrameQuery<T extends GPUTypeMap, ColumnName extends
     }
 
     compiledGraph = graph.compile();
-    return new CompiledLuDataFrameQuery<Pick<T, ColumnName>>({
-      table: selectedSource.table,
+    return new CompiledLuDataFrameQuery<Result>({
+      table: ownedTable ?? (selectedSource.table as GPUTable<Result>),
+      validity,
+      dictionaries,
       selectionMask,
       rowIndices,
       selectedCounts,
       graph: compiledGraph,
-      sourceViews: [selectedSource, retainedSource]
+      sourceViews: [selectedSource, retainedSource],
+      ...(ownedTable ? {ownedTable} : {}),
+      ownedVectors: derivedOutputs.flatMap(output =>
+        output.validity ? [output.values, output.validity] : [output.values]
+      )
     });
   } catch (error) {
     compiledGraph?.destroy();
     selectionMask?.destroy();
     rowIndices?.destroy();
     selectedCounts?.destroy();
+    ownedTable?.destroy();
+    for (const output of derivedOutputs) {
+      output.values.destroy();
+      output.validity?.destroy();
+    }
     selectedSource?.destroy();
     retainedSource.destroy();
     throw error;
@@ -238,43 +343,192 @@ function validateLuQueryBindingCapacity(
     (bindingCount, column) => bindingCount + 1 + (column.nullable ? 1 : 0),
     0
   );
-  const bindingCount = sourceCount + (plan.controls.length > 0 ? 1 : 0) + 1;
+  const outputCount = plan.outputs.reduce(
+    (bindingCount, output) => bindingCount + 1 + (output.nullable ? 1 : 0),
+    0
+  );
+  const bindingCount = sourceCount + outputCount + (plan.controls.length > 0 ? 1 : 0) + 1;
   if (bindingCount > graph.device.limits.maxStorageBuffersPerShaderStage) {
     throw new Error('LuDataFrame filter exceeds the available WebGPU storage-buffer bindings');
   }
 }
 
 /** Creates one independently owned fixed-width GPU output chunk for every source batch. */
-function createLuQueryOutputVector(
+function createLuQueryOutputVector<Format extends LuQueryScalarFormat>(
   device: Device,
   name: string,
   lengths: readonly number[],
-  indexBuffer = false
-): GPUVector<'uint32'> {
-  const data: GPUData<'uint32'>[] = [];
+  format: Format,
+  indexBuffer = false,
+  vertexBuffer = false
+): GPUVector<Format> {
+  const data: GPUData<Format>[] = [];
   try {
     for (const [batchIndex, length] of lengths.entries()) {
       const buffer = device.createBuffer({
         id: `${name}-batch-${batchIndex}`,
         byteLength: Math.max(length, 1) * UINT32_BYTE_LENGTH,
         usage:
-          Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST | (indexBuffer ? Buffer.INDEX : 0),
+          Buffer.STORAGE |
+          Buffer.COPY_SRC |
+          Buffer.COPY_DST |
+          (indexBuffer ? Buffer.INDEX : 0) |
+          (vertexBuffer ? Buffer.VERTEX : 0),
         ...(indexBuffer ? {indexType: 'uint32' as const} : {})
       });
       try {
-        data.push(new GPUData({buffer, format: 'uint32', length, ownsBuffer: true}));
+        data.push(new GPUData({buffer, format, length, ownsBuffer: true}));
       } catch (error) {
         buffer.destroy();
         throw error;
       }
     }
-    return new GPUVector({type: 'data', name, format: 'uint32', data, ownsData: true});
+    return new GPUVector({type: 'data', name, format, data, ownsData: true});
   } catch (error) {
     for (const chunk of data) {
       chunk.destroy();
     }
     throw error;
   }
+}
+
+/** Preserves source sidecars while adding only independently owned derived validity vectors. */
+function selectLuQueryValidity<Result extends GPUTypeMap>(
+  selectedSource: LuDataFrame,
+  outputs: readonly LuQueryDerivedOutput[]
+): Readonly<LuDataFrameValidity<Result>> {
+  const validity: Record<string, GPUVector<'uint32'>> = {};
+  for (const [name, vector] of Object.entries(selectedSource.validity)) {
+    if (vector) {
+      validity[name] = vector;
+    }
+  }
+  for (const output of outputs) {
+    if (output.validity) {
+      validity[output.plan.name] = output.validity;
+    }
+  }
+  return Object.freeze(validity) as Readonly<LuDataFrameValidity<Result>>;
+}
+
+/** Builds a borrowed result table without repacking batches or changing ownership of source data. */
+function createLuQueryDerivedTable<Result extends GPUTypeMap>(
+  selectedSource: GPUTable,
+  selectedColumns: readonly (keyof Result & string)[],
+  outputs: readonly LuQueryDerivedOutput[]
+): GPUTable<Result> {
+  const outputsByName = new Map(outputs.map(output => [output.plan.name, output]));
+  const fields: GPUField<keyof Result & string>[] = selectedColumns.map(name => {
+    const output = outputsByName.get(name);
+    if (output) {
+      return {
+        name,
+        format: output.plan.format,
+        nullable: output.plan.nullable,
+        metadata: new Map()
+      };
+    }
+    const sourceField = selectedSource.schema.fields.find(field => field.name === name);
+    if (!sourceField) {
+      throw new Error(`LuDataFrame result column "${name}" does not exist`);
+    }
+    return {
+      ...(sourceField as GPUField<keyof Result & string>),
+      ...(sourceField.metadata ? {metadata: new Map(sourceField.metadata)} : {})
+    };
+  });
+  const layouts: BufferLayout[] = selectedColumns.flatMap(name => {
+    const output = outputsByName.get(name);
+    if (output) {
+      return [{name, format: output.plan.format, byteStride: UINT32_BYTE_LENGTH}];
+    }
+    return selectedSource.bufferLayout
+      .filter(layout => layout.name === name)
+      .map(layout => ({
+        ...layout,
+        ...(layout.attributes
+          ? {attributes: layout.attributes.map(attribute => ({...attribute}))}
+          : {})
+      }));
+  });
+  const metadata = new Map(selectedSource.schema.metadata);
+  if (selectedSource.batches.length === 0) {
+    return new GPUTable<Result>({schema: {fields, metadata}, bufferLayout: layouts});
+  }
+
+  const constants: Record<string, GPUConstant> = {};
+  for (const name of selectedColumns) {
+    const constant = selectedSource.gpuConstants[name];
+    if (constant) {
+      constants[name] = constant;
+    }
+  }
+
+  const batches: GPURecordBatch<Result>[] = [];
+  try {
+    for (const [batchIndex, sourceBatch] of selectedSource.batches.entries()) {
+      const gpuData: Record<string, GPUData> = {};
+      const varyingFields: GPUField[] = [];
+      for (const field of fields) {
+        const output = outputsByName.get(field.name);
+        const data = output ? output.values.data[batchIndex] : sourceBatch.gpuData[field.name];
+        if (!data) {
+          continue;
+        }
+        gpuData[field.name] = createLuQueryBorrowedData(data);
+        varyingFields.push(field);
+      }
+      batches.push(
+        new GPURecordBatch<Result>({
+          gpuData,
+          bufferLayout: layouts,
+          fields: varyingFields,
+          numRows: sourceBatch.numRows,
+          metadata: new Map(sourceBatch.schema.metadata),
+          sourceInfo: sourceBatch.sourceInfo,
+          nullCount: sourceBatch.nullCount
+        })
+      );
+    }
+    const table = new GPUTable<Result>({batches, constants});
+    table.schema = {fields, metadata};
+    table.numCols = fields.length;
+    for (const name of Object.keys(table.gpuColumns)) {
+      delete table.gpuColumns[name];
+    }
+    for (const name of selectedColumns) {
+      const column = table.gpuVectors[name] ?? table.gpuConstants[name];
+      if (column) {
+        table.gpuColumns[name] = column;
+      }
+    }
+    return table;
+  } catch (error) {
+    for (const batch of batches) {
+      batch.destroy();
+    }
+    throw error;
+  }
+}
+
+/** Copies complete chunk metadata while ensuring result-table destruction never owns a buffer. */
+function createLuQueryBorrowedData(source: GPUData): GPUData {
+  return new GPUData({
+    buffer: source.buffer,
+    format: source.format,
+    length: source.length,
+    valueLength: source.valueLength,
+    stride: source.stride,
+    byteOffset: source.byteOffset,
+    byteStride: source.byteStride,
+    rowByteLength: source.rowByteLength,
+    ownsBuffer: false,
+    readbackMetadata: source.readbackMetadata,
+    valueOffsets: source.valueOffsets,
+    nullBitmap: source.nullBitmap,
+    valueByteLength: source.valueByteLength,
+    dataType: source.dataType
+  });
 }
 
 /** Imports each referenced source vector and validity sidecar exactly once. */
@@ -300,6 +554,23 @@ function importLuQuerySourceViews<T extends GPUTypeMap>(
         ? graph.importGPUVector(`${queryId}-validity-${column.index}`, validityVector)
         : undefined;
     views.set(column.name, {values, ...(validity ? {validity} : {})});
+  }
+  return views;
+}
+
+/** Registers independently owned derived values and nullable sidecars without changing chunks. */
+function importLuQueryDerivedViews(
+  graph: GPUCommandGraph<LuDataFrameQueryParameters>,
+  outputs: readonly LuQueryDerivedOutput[],
+  queryId: string
+): Map<string, LuQueryDerivedView> {
+  const views = new Map<string, LuQueryDerivedView>();
+  for (const output of outputs) {
+    const values = graph.importGPUVector(`${queryId}-derived-${output.plan.index}`, output.values);
+    const validity = output.validity
+      ? graph.importGPUVector(`${queryId}-derived-${output.plan.index}-validity`, output.validity)
+      : undefined;
+    views.set(output.plan.name, {values, ...(validity ? {validity} : {})});
   }
   return views;
 }
@@ -331,6 +602,7 @@ function addLuQueryPredicatePass(
     batchIndex: number;
     columns: readonly LuQueryExpressionColumn[];
     sourceViews: ReadonlyMap<string, LuQuerySourceView>;
+    derivedViews: ReadonlyMap<string, LuQueryDerivedView>;
     controls?: GraphDataView<'uint32'>;
     output: GraphDataView<'uint32'>;
     plan: LuQueryExpressionShaderPlan;
@@ -381,6 +653,44 @@ function addLuQueryPredicatePass(
     resources.push({buffer: props.controls, usage: 'storage-read'});
   }
 
+  const derivedWrites: string[] = [];
+  for (const output of props.plan.outputs) {
+    const views = props.derivedViews.get(output.name);
+    const values = views?.values.data[props.batchIndex];
+    if (!values) {
+      throw new Error('LuDataFrame derived expression output chunk is missing');
+    }
+    declarations.push(
+      `const DERIVED_${output.index}_OFFSET: u32 = ${getViewElementOffset(values)}u;`
+    );
+    declarations.push(
+      `@group(0) @binding(${bindingIndex++}) var<storage, read_write> derived${output.index}: array<${getLuQueryShaderType(output.format)}>;`
+    );
+    bindings[`derived${output.index}`] = values;
+    resources.push({buffer: values, usage: 'storage-write'});
+    derivedWrites.push(
+      `derived${output.index}[DERIVED_${output.index}_OFFSET + index] = ${output.value};`
+    );
+
+    if (output.nullable) {
+      const validity = views?.validity?.data[props.batchIndex];
+      if (!validity) {
+        throw new Error('LuDataFrame derived expression validity chunk is missing');
+      }
+      declarations.push(
+        `const DERIVED_VALIDITY_${output.index}_OFFSET: u32 = ${getViewElementOffset(validity)}u;`
+      );
+      declarations.push(
+        `@group(0) @binding(${bindingIndex++}) var<storage, read_write> derivedValidity${output.index}: array<u32>;`
+      );
+      bindings[`derivedValidity${output.index}`] = validity;
+      resources.push({buffer: validity, usage: 'storage-write'});
+      derivedWrites.push(
+        `derivedValidity${output.index}[DERIVED_VALIDITY_${output.index}_OFFSET + index] = select(0u, 1u, ${output.valid});`
+      );
+    }
+  }
+
   declarations.push(`const OUTPUT_OFFSET: u32 = ${getViewElementOffset(props.output)}u;`);
   declarations.push(
     `@group(0) @binding(${bindingIndex}) var<storage, read_write> outputMask: array<u32>;`
@@ -408,6 +718,7 @@ fn main(
     return;
   }
   ${props.plan.statements.join('\n  ')}
+  ${derivedWrites.join('\n  ')}
   outputMask[OUTPUT_OFFSET + index] = select(0u, 1u, ${props.plan.condition});
 }`;
 

--- a/modules/experimental/test/index.ts
+++ b/modules/experimental/test/index.ts
@@ -40,6 +40,7 @@ import './simulation/spectral-ocean-simulation.spec';
 import './geospatial/geospatial-projection-distance.spec';
 import './ludf/lu-data-frame.spec';
 import './ludf/lu-data-frame-query.spec';
+import './ludf/lu-derived-columns.spec';
 import './luraster';
 import './luxfilter';
 import './luproj/luproj.spec';

--- a/modules/experimental/test/ludf/lu-derived-columns.node.spec.ts
+++ b/modules/experimental/test/ludf/lu-derived-columns.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer} from '@luma.gl/core';
 import {

--- a/modules/experimental/test/ludf/lu-derived-columns.node.spec.ts
+++ b/modules/experimental/test/ludf/lu-derived-columns.node.spec.ts
@@ -1,0 +1,314 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer} from '@luma.gl/core';
+import {
+  column,
+  literal,
+  LuDataFrame,
+  LuDataFrameQuery,
+  parameter,
+  type LuDataFrameDerivedColumnFormatForExpression
+} from '@luma.gl/experimental/ludf';
+import {
+  GPUData,
+  GPURecordBatch,
+  GPUTable,
+  type GPUField,
+  type GPURecordBatchSourceInfo
+} from '@luma.gl/tables';
+import {NullDevice} from '@luma.gl/test-utils';
+import {describe, expect, expectTypeOf, test, vi} from 'vitest';
+
+type DerivedSourceColumns = {fare: 'float32'; category: 'uint32'; distance: 'sint32'};
+
+type DerivedSourceFixture = {
+  device: NullDevice;
+  table: GPUTable<DerivedSourceColumns>;
+  buffers: Buffer[];
+};
+
+describe('LuDataFrame immutable derived-column planning', () => {
+  test('plans chained derived fields without allocating GPU storage or retaining source leases', () => {
+    const fixture = createDerivedSourceFixture([2, 0, 3]);
+    const source = new LuDataFrame({table: fixture.table, ownership: 'owned'});
+    const createBuffer = vi.spyOn(fixture.device, 'createBuffer');
+    const createCommandEncoder = vi.spyOn(fixture.device, 'createCommandEncoder');
+    const submit = vi.spyOn(fixture.device, 'submit');
+    const tableSelect = vi.spyOn(fixture.table, 'select');
+
+    const adjusted = source.withColumn(
+      'adjustedFare',
+      column('fare').add(parameter('adjustment', 2))
+    );
+    const scaled = adjusted.withColumn('scaledFare', column('adjustedFare').multiply(literal(3)));
+    const filtered = scaled
+      .filter(column('scaledFare').greaterThan(literal(10)))
+      .select(['scaledFare', 'category']);
+
+    expect(adjusted).toBeInstanceOf(LuDataFrameQuery);
+    expect(adjusted.source).toBe(source);
+    expect(adjusted.columnNames).toEqual(['fare', 'category', 'distance', 'adjustedFare']);
+    expect(scaled.columnNames).toEqual([
+      'fare',
+      'category',
+      'distance',
+      'adjustedFare',
+      'scaledFare'
+    ]);
+    expect(filtered.columnNames).toEqual(['scaledFare', 'category']);
+    expect(filtered.derivedColumns.map(({name}) => name)).toEqual(['adjustedFare', 'scaledFare']);
+    expect(filtered.predicates).toHaveLength(1);
+    expect(Object.isFrozen(adjusted)).toBe(true);
+    expect(Object.isFrozen(adjusted.derivedColumns)).toBe(true);
+    expect(Object.isFrozen(adjusted.derivedColumns[0])).toBe(true);
+    expect(createBuffer).not.toHaveBeenCalled();
+    expect(createCommandEncoder).not.toHaveBeenCalled();
+    expect(submit).not.toHaveBeenCalled();
+    expect(tableSelect).not.toHaveBeenCalled();
+
+    source.destroy();
+    expect(fixture.buffers.every(buffer => buffer.destroyed)).toBe(true);
+
+    createBuffer.mockRestore();
+    createCommandEncoder.mockRestore();
+    submit.mockRestore();
+    tableSelect.mockRestore();
+  });
+
+  test('preserves sibling plans, hidden dependency chains, and source-filter inputs', () => {
+    const fixture = createDerivedSourceFixture([2, 0, 3]);
+    const source = new LuDataFrame({table: fixture.table});
+    const filteredSource = source.filter(column('fare').greaterThan(literal(2)));
+    const adjusted = filteredSource.withColumn('adjustedFare', column('fare').add(literal(1)));
+    const doubled = adjusted.withColumn('doubledFare', column('adjustedFare').multiply(literal(2)));
+    const adjustedOnly = adjusted.select(['adjustedFare']);
+    const doubledOnly = doubled.select(['doubledFare']);
+    const final = doubledOnly.filter(column('doubledFare').lessThan(literal(100)));
+
+    expect(filteredSource.derivedColumns).toEqual([]);
+    expect(adjusted.derivedColumns.map(({name}) => name)).toEqual(['adjustedFare']);
+    expect(adjustedOnly.columnNames).toEqual(['adjustedFare']);
+    expect(doubledOnly.columnNames).toEqual(['doubledFare']);
+    expect(final.derivedColumns.map(({name}) => name)).toEqual(['adjustedFare', 'doubledFare']);
+    expect(final.predicates).toHaveLength(2);
+    expect(final.predicates[0]).toBe(filteredSource.predicates[0]);
+    expect(source.columnNames).toEqual(['fare', 'category', 'distance']);
+    expect(source.batches.map(batch => batch.numRows)).toEqual([2, 0, 3]);
+
+    source.destroy();
+    fixture.table.destroy();
+  });
+
+  test('retains precise source and derived scalar formats across typed chained projections', () => {
+    const fixture = createDerivedSourceFixture([2]);
+    const source = new LuDataFrame({table: fixture.table});
+    const floating = source.withColumn('adjustedFare', column('fare').add(literal(1)));
+    const signed = source.withColumn('shiftedDistance', column('distance').subtract(literal(2)));
+    const unsigned = source.withColumn('nextCategory', column('category').add(literal(1)), {
+      format: 'uint32'
+    });
+    const scalar = source.withColumn('constantValue', literal(4));
+    const chained = floating
+      .withColumn('doubledFare', column('adjustedFare').multiply(literal(2)))
+      .select(['doubledFare', 'category']);
+
+    expectTypeOf(floating).toEqualTypeOf<
+      LuDataFrameQuery<
+        DerivedSourceColumns & Record<'adjustedFare', 'float32'>,
+        keyof DerivedSourceColumns | 'adjustedFare',
+        DerivedSourceColumns
+      >
+    >();
+    expectTypeOf(signed).toEqualTypeOf<
+      LuDataFrameQuery<
+        DerivedSourceColumns & Record<'shiftedDistance', 'sint32'>,
+        keyof DerivedSourceColumns | 'shiftedDistance',
+        DerivedSourceColumns
+      >
+    >();
+    expectTypeOf(unsigned).toEqualTypeOf<
+      LuDataFrameQuery<
+        DerivedSourceColumns & Record<'nextCategory', 'uint32'>,
+        keyof DerivedSourceColumns | 'nextCategory',
+        DerivedSourceColumns
+      >
+    >();
+    expectTypeOf(scalar).toEqualTypeOf<
+      LuDataFrameQuery<
+        DerivedSourceColumns & Record<'constantValue', 'float32'>,
+        keyof DerivedSourceColumns | 'constantValue',
+        DerivedSourceColumns
+      >
+    >();
+    expectTypeOf(chained).toEqualTypeOf<
+      LuDataFrameQuery<
+        DerivedSourceColumns & Record<'adjustedFare', 'float32'> & Record<'doubledFare', 'float32'>,
+        'doubledFare' | 'category',
+        DerivedSourceColumns
+      >
+    >();
+    expectTypeOf<
+      LuDataFrameDerivedColumnFormatForExpression<DerivedSourceColumns, 'distance'>
+    >().toEqualTypeOf<'sint32'>();
+
+    expect(chained.columnNames).toEqual(['doubledFare', 'category']);
+
+    source.destroy();
+    fixture.table.destroy();
+  });
+
+  test('rejects unknown, hidden, repeated, nonnumeric, and format-incompatible definitions', () => {
+    const fixture = createDerivedSourceFixture([2]);
+    const source = new LuDataFrame({table: fixture.table});
+    const createBuffer = vi.spyOn(fixture.device, 'createBuffer');
+    const derived = source.withColumn('adjustedFare', column('fare').add(literal(1)));
+    const selected = derived.select(['adjustedFare']);
+
+    expect(() =>
+      // @ts-expect-error Derived expressions reject references outside the source schema.
+      source.withColumn('unknownValue', column('missing').add(literal(1)))
+    ).toThrow(/column|exist|missing/i);
+    expect(() =>
+      // @ts-expect-error Projected query expressions reject hidden source-column references.
+      selected.withColumn('hiddenFare', column('fare').add(literal(1)))
+    ).toThrow(/column|selected|exist/i);
+    expect(() => source.withColumn('fare', column('fare').add(literal(1)))).toThrow(/exist/i);
+    expect(() => derived.withColumn('adjustedFare', column('fare').add(literal(1)))).toThrow(
+      /exist/i
+    );
+    expect(() => source.withColumn('', column('fare').add(literal(1)))).toThrow(/name|nonempty/i);
+    expect(() =>
+      // @ts-expect-error Derived dataframe columns require numerical expression values.
+      source.withColumn('invalidBoolean', column('fare').greaterThan(literal(1)))
+    ).toThrow(/numeric/i);
+    expect(() =>
+      source.withColumn('invalidFormat', column('fare').add(literal(1)), {format: 'uint32'})
+    ).toThrow(/format|match/i);
+    expect(() => source.withColumn('mixedFormats', column('fare').add(column('distance')))).toThrow(
+      /format|mix/i
+    );
+    expect(createBuffer).not.toHaveBeenCalled();
+
+    createBuffer.mockRestore();
+    source.destroy();
+    fixture.table.destroy();
+  });
+
+  test('infers canonical vector formats when optional schema-field formats are omitted', () => {
+    const fixture = createDerivedSourceFixture([2]);
+    const source = new LuDataFrame({table: fixture.table});
+    for (const field of fixture.table.schema.fields) {
+      if (field.name === 'distance' || field.name === 'category') {
+        delete field.format;
+      }
+    }
+
+    const signed = source.withColumn('shiftedDistance', column('distance').subtract(literal(2)), {
+      format: 'sint32'
+    });
+    const unsigned = source.withColumn('nextCategory', column('category').add(literal(1)), {
+      format: 'uint32'
+    });
+
+    expect(signed.derivedColumns[0].format).toBe('sint32');
+    expect(unsigned.derivedColumns[0].format).toBe('uint32');
+    expect(fixture.table.gpuVectors.distance.format).toBe('sint32');
+    expect(fixture.table.gpuVectors.category.format).toBe('uint32');
+
+    source.destroy();
+    fixture.table.destroy();
+  });
+
+  test('preserves explicit nullable metadata and empty source batch topology during planning', () => {
+    for (const batchLengths of [[], [0], [0, 0]] as const) {
+      const fixture = createDerivedSourceFixture(batchLengths, {nullableFare: true});
+      const source = new LuDataFrame({table: fixture.table});
+      const adjusted = source.withColumn('adjustedFare', column('fare').add(literal(1)));
+      const projected = adjusted.select(['adjustedFare']);
+
+      expect(projected.columnNames).toEqual(['adjustedFare']);
+      expect(projected.source.batches.map(batch => batch.numRows)).toEqual(batchLengths);
+      expect(projected.source.schema.fields.find(field => field.name === 'fare')?.nullable).toBe(
+        true
+      );
+      expect(projected.source.validity.fare).toBeUndefined();
+      expect(projected.derivedColumns[0].expression.node.kind).toBe('binary');
+
+      source.destroy();
+      fixture.table.destroy();
+    }
+  });
+
+  test('rejects new derived plans after the source dataframe was destroyed', () => {
+    const fixture = createDerivedSourceFixture([2]);
+    const source = new LuDataFrame({table: fixture.table});
+    source.destroy();
+
+    expect(() => source.withColumn('adjustedFare', column('fare').add(literal(1)))).toThrow(
+      /destroyed/i
+    );
+    fixture.table.destroy();
+  });
+});
+
+function createDerivedSourceFixture(
+  batchLengths: readonly number[],
+  options: {nullableFare?: boolean} = {}
+): DerivedSourceFixture {
+  const device = new NullDevice({id: 'ludf-derived-node-device'});
+  const buffers: Buffer[] = [];
+  const fields: GPUField<keyof DerivedSourceColumns>[] = [
+    {name: 'fare', format: 'float32', nullable: options.nullableFare ?? false},
+    {name: 'category', format: 'uint32', nullable: false},
+    {name: 'distance', format: 'sint32', nullable: false}
+  ];
+  let sourceRowIndexOffset = 40;
+  const batches = batchLengths.map((length, sourceBatchIndex) => {
+    const sourceInfo: GPURecordBatchSourceInfo = {
+      sourceBatchIndex,
+      sourceRowIndexOffset,
+      sourceRowCount: length
+    };
+    sourceRowIndexOffset += length;
+
+    return new GPURecordBatch<DerivedSourceColumns>({
+      gpuData: {
+        fare: makeDerivedSourceData(device, buffers, length, 'float32'),
+        category: makeDerivedSourceData(device, buffers, length, 'uint32'),
+        distance: makeDerivedSourceData(device, buffers, length, 'sint32')
+      },
+      fields,
+      numRows: length,
+      sourceInfo
+    });
+  });
+
+  const table =
+    batches.length > 0
+      ? new GPUTable<DerivedSourceColumns>({batches})
+      : new GPUTable<DerivedSourceColumns>({
+          schema: {fields, metadata: new Map()},
+          bufferLayout: [
+            {name: 'fare', format: 'float32'},
+            {name: 'category', format: 'uint32'},
+            {name: 'distance', format: 'sint32'}
+          ]
+        });
+  return {device, table, buffers};
+}
+
+function makeDerivedSourceData<Format extends DerivedSourceColumns[keyof DerivedSourceColumns]>(
+  device: NullDevice,
+  buffers: Buffer[],
+  length: number,
+  format: Format
+): GPUData<Format> {
+  const buffer = device.createBuffer({
+    byteLength: Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  buffers.push(buffer);
+  return new GPUData({buffer, format, length, ownsBuffer: true});
+}

--- a/modules/experimental/test/ludf/lu-derived-columns.spec.ts
+++ b/modules/experimental/test/ludf/lu-derived-columns.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer, type Device} from '@luma.gl/core';
 import {GPUCommandGraph} from '@luma.gl/experimental';

--- a/modules/experimental/test/ludf/lu-derived-columns.spec.ts
+++ b/modules/experimental/test/ludf/lu-derived-columns.spec.ts
@@ -1,0 +1,598 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device} from '@luma.gl/core';
+import {GPUCommandGraph} from '@luma.gl/experimental';
+import {
+  LuDataFrame,
+  and,
+  column,
+  literal,
+  parameter,
+  type LuDataFrameQueryParameters
+} from '@luma.gl/experimental/ludf';
+import {GPUConstant, GPUData, GPURecordBatch, GPUTable, GPUVector} from '@luma.gl/tables';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
+import {vi} from 'vitest';
+
+type LuDerivedSourceSchema = {
+  fare: 'float32';
+  category: 'uint32';
+  distance: 'sint32';
+};
+
+type LuDerivedFixture = {
+  frame: LuDataFrame<LuDerivedSourceSchema>;
+  sourceBuffers: Buffer[];
+};
+
+type LuDerivedConstantSourceSchema = LuDerivedSourceSchema & {
+  tip: 'float32';
+  tier: 'uint32';
+};
+
+test('LuDataFrame materializes chained nullable GPU columns without disturbing source batches', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const fixture = createLuDerivedFixture(device);
+  const createBufferSpy = vi.spyOn(device, 'createBuffer');
+  const submitSpy = vi.spyOn(device, 'submit');
+
+  const query = fixture.frame
+    .withColumn('fareWithTip', column('fare').add(literal(5)), {format: 'float32'})
+    .withColumn('doubleFare', column('fareWithTip').multiply(literal(2)), {format: 'float32'})
+    .filter(column('doubleFare').greaterThan(literal(30)))
+    .select(['category', 'doubleFare']);
+
+  testContext.equal(
+    createBufferSpy.mock.calls.length,
+    0,
+    'chained derived-column planning never allocates GPU storage'
+  );
+  testContext.equal(
+    submitSpy.mock.calls.length,
+    0,
+    'derived-column planning never submits GPU work'
+  );
+  testContext.deepEqual(
+    fixture.frame.columnNames,
+    ['fare', 'category', 'distance'],
+    'source dataframe remains unchanged while new logical columns are planned'
+  );
+
+  const graph = new GPUCommandGraph<LuDataFrameQueryParameters>(device, {
+    id: 'ludf-chained-derived-columns'
+  });
+  const compiled = query.compile(graph);
+
+  try {
+    testContext.deepEqual(
+      compiled.table.schema.fields.map(field => field.name),
+      ['category', 'doubleFare'],
+      'hidden intermediate columns are not materialized in the selected result'
+    );
+    testContext.deepEqual(
+      compiled.table.batches.map(batch => batch.numRows),
+      [2, 0, 3],
+      'derived outputs preserve original record-batch boundaries'
+    );
+    testContext.equal(
+      compiled.table.schema.fields.find(field => field.name === 'doubleFare')?.nullable,
+      true,
+      'nullable arithmetic marks the resulting GPU field nullable'
+    );
+    testContext.deepEqual(
+      compiled.dictionaries.category,
+      {values: ['economy', 'standard', 'premium'], ordered: false},
+      'selected categorical source metadata survives the derived projection'
+    );
+
+    fixture.frame.destroy();
+    testContext.ok(
+      fixture.sourceBuffers.every(buffer => !buffer.destroyed),
+      'compiled derived queries retain the owned source lease'
+    );
+
+    const commandEncoder = device.createCommandEncoder({id: 'ludf-derived-first-encode'});
+    compiled.encode(commandEncoder);
+    testContext.equal(
+      submitSpy.mock.calls.length,
+      0,
+      'derived-column compilation only records GPU work'
+    );
+    device.submit(commandEncoder.finish());
+
+    const derivedVector = compiled.table.gpuVectors.doubleFare;
+    const derivedValidity = compiled.validity.doubleFare;
+    if (!derivedValidity) {
+      throw new Error('Expected a GPU validity vector for the nullable derived column');
+    }
+
+    testContext.deepEqual(
+      await readFloat32VectorChunks(derivedVector),
+      [[20, 40], [], [60, 208, 80]],
+      'chained GPU arithmetic materializes exact floating-point values in each source batch'
+    );
+    testContext.deepEqual(
+      await readUint32VectorChunks(derivedValidity),
+      [[1, 1], [], [1, 0, 1]],
+      'derived GPU validity propagates source nulls through every arithmetic expression'
+    );
+    testContext.deepEqual(
+      await readUint32VectorChunks(compiled.selectionMask),
+      [[0, 1], [], [1, 0, 1]],
+      'filters consume chained derived expressions without accepting null rows'
+    );
+    testContext.deepEqual(
+      await readUint32VectorChunks(compiled.selectedCounts),
+      [[1], [0], [2]],
+      'derived filters publish independent selection counts for empty and nonempty batches'
+    );
+    testContext.deepEqual(
+      await readSelectedSourceRows(compiled.rowIndices, compiled.selectedCounts),
+      [[41], [], [42, 44]],
+      'derived filtering preserves stable original source-row identities'
+    );
+
+    const derivedBuffers = [
+      ...derivedVector.data.map(getGPUDataBuffer),
+      ...derivedValidity.data.map(getGPUDataBuffer)
+    ];
+    compiled.destroy();
+    testContext.ok(
+      derivedBuffers.every(buffer => buffer.destroyed),
+      'compiled queries own and release their materialized derived value and validity buffers'
+    );
+    testContext.ok(
+      fixture.sourceBuffers.every(buffer => buffer.destroyed),
+      'source allocations are released only after the compiled derived query is destroyed'
+    );
+  } finally {
+    compiled.destroy();
+    fixture.frame.destroy();
+    createBufferSpy.mockRestore();
+    submitSpy.mockRestore();
+  }
+
+  testContext.end();
+});
+
+test('LuDataFrame computes signed derived columns without requiring an explicit filter', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const fixture = createLuDerivedFixture(device);
+  const graph = new GPUCommandGraph<LuDataFrameQueryParameters>(device, {
+    id: 'ludf-signed-derived-column'
+  });
+  const compiled = fixture.frame
+    .withColumn('distanceOffset', column('distance').subtract(literal(2)), {format: 'sint32'})
+    .select(['distanceOffset'])
+    .compile(graph);
+
+  try {
+    const commandEncoder = device.createCommandEncoder({id: 'ludf-signed-derived-encode'});
+    compiled.encode(commandEncoder);
+    device.submit(commandEncoder.finish());
+
+    testContext.deepEqual(
+      await readSignedVectorChunks(compiled.table.gpuVectors.distanceOffset),
+      [[-4, 1], [], [-3, 2, 6]],
+      'signed 32-bit derived arithmetic remains GPU-native and batch aligned'
+    );
+    testContext.equal(
+      compiled.validity.distanceOffset,
+      undefined,
+      'non-nullable derived values do not allocate unnecessary GPU validity sidecars'
+    );
+    testContext.deepEqual(
+      await readUint32VectorChunks(compiled.selectionMask),
+      [[1, 1], [], [1, 1, 1]],
+      'derived-only queries accept every source row without requiring a synthetic user filter'
+    );
+    testContext.deepEqual(
+      await readUint32VectorChunks(compiled.selectedCounts),
+      [[2], [0], [3]],
+      'derived-only queries retain independent source-batch row counts'
+    );
+  } finally {
+    compiled.destroy();
+    fixture.frame.destroy();
+  }
+
+  testContext.end();
+});
+
+test('LuDataFrame evaluates derived expressions containing immutable GPUConstant columns', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const fixture = createLuDerivedFixture(device);
+  const constants = {
+    tip: new GPUConstant({format: 'float32', value: Float32Array.of(5)}),
+    tier: new GPUConstant({format: 'uint32', value: Uint32Array.of(2)})
+  };
+  const frame = new LuDataFrame<LuDerivedConstantSourceSchema>({
+    table: new GPUTable<LuDerivedConstantSourceSchema>({
+      batches: fixture.frame.table.batches,
+      constants
+    }),
+    validity: fixture.frame.validity,
+    ownership: 'borrowed'
+  });
+  const graph = new GPUCommandGraph<LuDataFrameQueryParameters>(device, {
+    id: 'ludf-constant-derived-column'
+  });
+  const compiled = frame
+    .withColumn('totalFare', column('fare').add(column('tip')), {format: 'float32'})
+    .filter(
+      and(column('totalFare').greaterThan(literal(20)), column('category').lessThan(column('tier')))
+    )
+    .select(['tip', 'totalFare'])
+    .compile(graph);
+
+  try {
+    const commandEncoder = device.createCommandEncoder({id: 'ludf-constant-derived-encode'});
+    compiled.encode(commandEncoder);
+    device.submit(commandEncoder.finish());
+
+    const validity = compiled.validity.totalFare;
+    if (!validity) {
+      throw new Error('Expected nullable GPUConstant-derived validity');
+    }
+
+    testContext.deepEqual(
+      await readFloat32VectorChunks(compiled.table.gpuVectors.totalFare),
+      [[10, 20], [], [30, 104, 40]],
+      'trusted float32 constant controls participate in derived GPU arithmetic'
+    );
+    testContext.deepEqual(
+      await readUint32VectorChunks(validity),
+      [[1, 1], [], [1, 0, 1]],
+      'immutable GPU constants do not create false nulls in derived outputs'
+    );
+    testContext.deepEqual(
+      await readUint32VectorChunks(compiled.selectionMask),
+      [[0, 0], [], [0, 0, 1]],
+      'hidden unsigned constants remain available to mixed derived predicates'
+    );
+    testContext.equal(
+      compiled.table.gpuConstants.tip,
+      constants.tip,
+      'selected GPUConstant identities remain borrowed instead of being materialized'
+    );
+  } finally {
+    compiled.destroy();
+    frame.destroy();
+    fixture.frame.destroy();
+  }
+
+  testContext.end();
+});
+
+test('LuDataFrame updates derived values and null validity in one caller-owned command encoder', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const fixture = createLuDerivedFixture(device);
+  const graph = new GPUCommandGraph<LuDataFrameQueryParameters>(device, {
+    id: 'ludf-derived-ordered-parameters'
+  });
+  const compiled = fixture.frame
+    .withColumn('adjustedFare', column('fare').add(parameter('adjustment', 0)), {
+      format: 'float32'
+    })
+    .filter(column('adjustedFare').greaterThan(literal(10)))
+    .select(['adjustedFare'])
+    .compile(graph);
+  const validity = compiled.validity.adjustedFare;
+  if (!validity) {
+    throw new Error('Expected nullable parameter-derived validity');
+  }
+  const firstCounts = compiled.selectedCounts.data.map((_, batchIndex) =>
+    device.createBuffer({
+      id: `ludf-derived-first-count-${batchIndex}`,
+      byteLength: Uint32Array.BYTES_PER_ELEMENT,
+      usage: Buffer.COPY_DST | Buffer.COPY_SRC
+    })
+  );
+  const firstValidity = validity.data.map((chunk, batchIndex) =>
+    chunk.length > 0
+      ? device.createBuffer({
+          id: `ludf-derived-first-validity-${batchIndex}`,
+          byteLength: chunk.length * Uint32Array.BYTES_PER_ELEMENT,
+          usage: Buffer.COPY_DST | Buffer.COPY_SRC
+        })
+      : undefined
+  );
+
+  try {
+    const commandEncoder = device.createCommandEncoder({id: 'ludf-derived-two-encodes'});
+    compiled.encode(commandEncoder, {adjustment: 0});
+
+    for (const [batchIndex, count] of compiled.selectedCounts.data.entries()) {
+      commandEncoder.copyBufferToBuffer({
+        sourceBuffer: getGPUDataBuffer(count),
+        destinationBuffer: firstCounts[batchIndex],
+        size: Uint32Array.BYTES_PER_ELEMENT
+      });
+      const snapshot = firstValidity[batchIndex];
+      const chunk = validity.data[batchIndex];
+      if (snapshot && chunk.length > 0) {
+        commandEncoder.copyBufferToBuffer({
+          sourceBuffer: getGPUDataBuffer(chunk),
+          destinationBuffer: snapshot,
+          size: chunk.length * Uint32Array.BYTES_PER_ELEMENT
+        });
+      }
+    }
+
+    compiled.encode(commandEncoder, {adjustment: null});
+    device.submit(commandEncoder.finish());
+
+    testContext.deepEqual(
+      await Promise.all(firstCounts.map(async buffer => (await readUint32Buffer(buffer, 1))[0])),
+      [1, 0, 2],
+      'first encoded derived values use their own non-null parameter value'
+    );
+    testContext.deepEqual(
+      await Promise.all(
+        firstValidity.map((buffer, batchIndex) =>
+          buffer ? readUint32Buffer(buffer, validity.data[batchIndex].length) : Promise.resolve([])
+        )
+      ),
+      [[1, 1], [], [1, 0, 1]],
+      'encoder-ordered staging snapshots the first derived validity state'
+    );
+    testContext.deepEqual(
+      await readUint32VectorChunks(validity),
+      [[0, 0], [], [0, 0, 0]],
+      'a null parameter makes every derived value invalid on the second encoding'
+    );
+    testContext.deepEqual(
+      await readUint32VectorChunks(compiled.selectedCounts),
+      [[0], [0], [0]],
+      'filters reject null derived values after parameter changes without recompiling'
+    );
+  } finally {
+    for (const buffer of firstCounts) buffer.destroy();
+    for (const buffer of firstValidity) buffer?.destroy();
+    compiled.destroy();
+    fixture.frame.destroy();
+  }
+
+  testContext.end();
+});
+
+test('LuDataFrame retains derived schemas for source tables without any record batches', async testContext => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testContext.comment('WebGPU is not available');
+    testContext.end();
+    return;
+  }
+
+  const frame = new LuDataFrame<LuDerivedSourceSchema>({
+    table: new GPUTable<LuDerivedSourceSchema>({
+      schema: {
+        fields: [
+          {name: 'fare', format: 'float32', nullable: true},
+          {name: 'category', format: 'uint32', nullable: false},
+          {name: 'distance', format: 'sint32', nullable: false}
+        ],
+        metadata: new Map([['dataset', 'empty-derived']])
+      },
+      bufferLayout: [
+        {name: 'fare', format: 'float32', byteStride: 4},
+        {name: 'category', format: 'uint32', byteStride: 4},
+        {name: 'distance', format: 'sint32', byteStride: 4}
+      ]
+    }),
+    ownership: 'owned'
+  });
+  const graph = new GPUCommandGraph<LuDataFrameQueryParameters>(device, {
+    id: 'ludf-schema-only-derived'
+  });
+  const compiled = frame
+    .withColumn('fareWithTip', column('fare').add(literal(5)), {format: 'float32'})
+    .select(['fareWithTip'])
+    .compile(graph);
+
+  try {
+    testContext.deepEqual(
+      compiled.table.schema.fields,
+      [{name: 'fareWithTip', format: 'float32', nullable: true, metadata: new Map()}],
+      'schema-only derived columns preserve their inferred format and nullability'
+    );
+    testContext.equal(
+      compiled.table.schema.metadata.get('dataset'),
+      'empty-derived',
+      'result schema retains source adapter metadata'
+    );
+    testContext.deepEqual(
+      compiled.table.batches,
+      [],
+      'no source batches means no synthetic batches'
+    );
+    testContext.equal(
+      compiled.validity.fareWithTip,
+      undefined,
+      'schema-only derived columns do not create synthetic validity chunks'
+    );
+    testContext.deepEqual(
+      compiled.selectedCounts.data,
+      [],
+      'schema-only derived queries do not allocate selection counts'
+    );
+
+    const commandEncoder = device.createCommandEncoder({id: 'ludf-schema-only-derived-encode'});
+    compiled.encode(commandEncoder);
+    device.submit(commandEncoder.finish());
+  } finally {
+    compiled.destroy();
+    frame.destroy();
+  }
+
+  testContext.end();
+});
+
+function createLuDerivedFixture(device: Device): LuDerivedFixture {
+  const sourceBuffers: Buffer[] = [];
+  const fareValues = [
+    Float32Array.from([5, 15]),
+    new Float32Array(0),
+    Float32Array.from([25, 99, 35])
+  ];
+  const categoryValues = [
+    Uint32Array.from([0, 1]),
+    new Uint32Array(0),
+    Uint32Array.from([2, 0, 1])
+  ];
+  const distanceValues = [Int32Array.from([-2, 3]), new Int32Array(0), Int32Array.from([-1, 4, 8])];
+  const fareValidityValues = [
+    Uint32Array.from([1, 1]),
+    new Uint32Array(0),
+    Uint32Array.from([1, 0, 1])
+  ];
+  const fareValidityChunks: GPUData<'uint32'>[] = [];
+  let sourceRowIndexOffset = 40;
+
+  const batches = fareValues.map((values, batchIndex) => {
+    const batch = new GPURecordBatch<LuDerivedSourceSchema>({
+      gpuData: {
+        fare: createLuDerivedData(device, sourceBuffers, values, 'float32'),
+        category: createLuDerivedData(device, sourceBuffers, categoryValues[batchIndex], 'uint32'),
+        distance: createLuDerivedData(device, sourceBuffers, distanceValues[batchIndex], 'sint32')
+      },
+      fields: [
+        {name: 'fare', format: 'float32', nullable: true},
+        {name: 'category', format: 'uint32', nullable: false},
+        {name: 'distance', format: 'sint32', nullable: false}
+      ],
+      sourceInfo: {
+        sourceBatchIndex: batchIndex + 4,
+        sourceRowIndexOffset,
+        sourceRowCount: values.length
+      }
+    });
+    sourceRowIndexOffset += values.length;
+    fareValidityChunks.push(
+      createLuDerivedData(device, sourceBuffers, fareValidityValues[batchIndex], 'uint32')
+    );
+    return batch;
+  });
+
+  return {
+    frame: new LuDataFrame<LuDerivedSourceSchema>({
+      table: new GPUTable<LuDerivedSourceSchema>({batches}),
+      validity: {
+        fare: new GPUVector<'uint32'>({
+          type: 'data',
+          name: 'ludf-derived-fare-validity',
+          format: 'uint32',
+          data: fareValidityChunks,
+          ownsData: true
+        })
+      },
+      dictionaries: {
+        category: {values: ['economy', 'standard', 'premium'], ordered: false}
+      },
+      ownership: 'owned'
+    }),
+    sourceBuffers
+  };
+}
+
+function createLuDerivedData<Format extends 'float32' | 'sint32' | 'uint32'>(
+  device: Device,
+  sourceBuffers: Buffer[],
+  values: Float32Array | Int32Array | Uint32Array,
+  format: Format
+): GPUData<Format> {
+  const buffer = device.createBuffer({
+    byteLength: Math.max(values.byteLength, Uint32Array.BYTES_PER_ELEMENT),
+    usage: Buffer.STORAGE | Buffer.VERTEX | Buffer.COPY_SRC | Buffer.COPY_DST,
+    ...(values.byteLength > 0 ? {data: values} : {})
+  });
+  sourceBuffers.push(buffer);
+  return new GPUData({buffer, format, length: values.length, ownsBuffer: true});
+}
+
+function getGPUDataBuffer(data: GPUData): Buffer {
+  return data.buffer instanceof Buffer ? data.buffer : data.buffer.buffer;
+}
+
+async function readUint32Buffer(buffer: Buffer, length: number): Promise<number[]> {
+  if (length === 0) {
+    return [];
+  }
+  const values = await buffer.readAsync(0, length * Uint32Array.BYTES_PER_ELEMENT);
+  return Array.from(new Uint32Array(values.buffer, values.byteOffset, length));
+}
+
+async function readUint32VectorChunks(vector: GPUVector<'uint32'>): Promise<number[][]> {
+  return Promise.all(
+    vector.data.map(chunk => readUint32Buffer(getGPUDataBuffer(chunk), chunk.length))
+  );
+}
+
+async function readFloat32VectorChunks(vector: GPUVector): Promise<number[][]> {
+  return Promise.all(
+    vector.data.map(async chunk => {
+      if (chunk.length === 0) {
+        return [];
+      }
+      const values = await getGPUDataBuffer(chunk).readAsync(
+        0,
+        chunk.length * Float32Array.BYTES_PER_ELEMENT
+      );
+      return Array.from(new Float32Array(values.buffer, values.byteOffset, chunk.length));
+    })
+  );
+}
+
+async function readSignedVectorChunks(vector: GPUVector): Promise<number[][]> {
+  return Promise.all(
+    vector.data.map(async chunk => {
+      if (chunk.length === 0) {
+        return [];
+      }
+      const values = await getGPUDataBuffer(chunk).readAsync(
+        0,
+        chunk.length * Int32Array.BYTES_PER_ELEMENT
+      );
+      return Array.from(new Int32Array(values.buffer, values.byteOffset, chunk.length));
+    })
+  );
+}
+
+async function readSelectedSourceRows(
+  rowIndices: GPUVector<'uint32'>,
+  selectedCounts: GPUVector<'uint32'>
+): Promise<number[][]> {
+  const counts = await readUint32VectorChunks(selectedCounts);
+  return Promise.all(
+    rowIndices.data.map((chunk, batchIndex) =>
+      readUint32Buffer(getGPUDataBuffer(chunk), counts[batchIndex][0] ?? 0)
+    )
+  );
+}

--- a/test/examples/ludf-derived-columns.node.spec.ts
+++ b/test/examples/ludf-derived-columns.node.spec.ts
@@ -1,0 +1,42 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {describe, expect, test} from 'vitest';
+
+const REPOSITORY_ROOT = new URL('../..', import.meta.url);
+const EXAMPLE_SOURCE = readFileSync(
+  fileURLToPath(new URL('examples/experimental/gpu-data-analysis/src/app.ts', REPOSITORY_ROOT)),
+  'utf8'
+);
+
+describe('GPU data-analysis luDF derived-column demo', () => {
+  test('offers an explicit interactive derived-column action without changing automatic startup', () => {
+    expect(EXAMPLE_SOURCE).toContain('data-ludf-adjustment');
+    expect(EXAMPLE_SOURCE).toContain('data-ludf-run');
+    expect(EXAMPLE_SOURCE).toContain('data-ludf-result');
+    expect(EXAMPLE_SOURCE).toContain("addEventListener('click', this.handleLuDataFrameRun)");
+    expect(EXAMPLE_SOURCE).toContain("removeEventListener('click', this.handleLuDataFrameRun)");
+    expect(EXAMPLE_SOURCE).not.toContain('await this.runLuDataFrameDemo()');
+  });
+
+  test('reuses Arrow-uploaded GPU columns and validates parameterized derivation and filtering', () => {
+    expect(EXAMPLE_SOURCE).toContain("from '@luma.gl/experimental/ludf'");
+    expect(EXAMPLE_SOURCE).toContain('resources.values.data.map(');
+    expect(EXAMPLE_SOURCE).toContain(
+      'gpuData: {value: valueData, category: resources.groupKeys.data[batchIndex]}'
+    );
+    expect(EXAMPLE_SOURCE).toContain('.withColumn(');
+    expect(EXAMPLE_SOURCE).toContain("parameter('adjustment', adjustment)");
+    expect(EXAMPLE_SOURCE).toContain(
+      ".filter(column('adjustedValue').greaterThan(literal(adjustment)))"
+    );
+    expect(EXAMPLE_SOURCE).toContain(".select(['category', 'adjustedValue'])");
+    expect(EXAMPLE_SOURCE).toContain('compiled.selectedCounts');
+    expect(EXAMPLE_SOURCE).toContain('CPU verified');
+    expect(EXAMPLE_SOURCE).toContain('compiled?.destroy()');
+    expect(EXAMPLE_SOURCE).toContain('frame?.destroy()');
+  });
+});

--- a/test/examples/ludf-derived-columns.node.spec.ts
+++ b/test/examples/ludf-derived-columns.node.spec.ts
@@ -11,12 +11,24 @@ const EXAMPLE_SOURCE = readFileSync(
   fileURLToPath(new URL('examples/experimental/gpu-data-analysis/src/app.ts', REPOSITORY_ROOT)),
   'utf8'
 );
+const EXAMPLE_SHELL = readFileSync(
+  fileURLToPath(
+    new URL('examples/experimental/gpu-data-analysis/src/app-shell.ts', REPOSITORY_ROOT)
+  ),
+  'utf8'
+);
 
 describe('GPU data-analysis luDF derived-column demo', () => {
   test('offers an explicit interactive derived-column action without changing automatic startup', () => {
-    expect(EXAMPLE_SOURCE).toContain('data-ludf-adjustment');
-    expect(EXAMPLE_SOURCE).toContain('data-ludf-run');
-    expect(EXAMPLE_SOURCE).toContain('data-ludf-result');
+    expect(EXAMPLE_SHELL).toContain('LUDF / DERIVED COLUMN LAB');
+    expect(EXAMPLE_SHELL).toContain('data-ludf-adjustment');
+    expect(EXAMPLE_SHELL).toContain('data-ludf-multiplier');
+    expect(EXAMPLE_SHELL).toContain('data-ludf-threshold');
+    expect(EXAMPLE_SHELL).toContain('data-ludf-run');
+    expect(EXAMPLE_SHELL).toContain('data-ludf-result');
+    expect(EXAMPLE_SHELL).toContain('data-ludf-preview');
+    expect(EXAMPLE_SOURCE).toContain('GPU_DATA_ANALYSIS_TEMPLATE');
+    expect(EXAMPLE_SOURCE).not.toContain('const EXAMPLE_HTML');
     expect(EXAMPLE_SOURCE).toContain("addEventListener('click', this.handleLuDataFrameRun)");
     expect(EXAMPLE_SOURCE).toContain("removeEventListener('click', this.handleLuDataFrameRun)");
     expect(EXAMPLE_SOURCE).not.toContain('await this.runLuDataFrameDemo()');
@@ -30,9 +42,9 @@ describe('GPU data-analysis luDF derived-column demo', () => {
     );
     expect(EXAMPLE_SOURCE).toContain('.withColumn(');
     expect(EXAMPLE_SOURCE).toContain("parameter('adjustment', adjustment)");
-    expect(EXAMPLE_SOURCE).toContain(
-      ".filter(column('adjustedValue').greaterThan(literal(adjustment)))"
-    );
+    expect(EXAMPLE_SOURCE).toContain("parameter('multiplier', multiplier)");
+    expect(EXAMPLE_SOURCE).toContain("parameter('threshold', threshold)");
+    expect(EXAMPLE_SOURCE).toContain(".filter(column('adjustedValue').greaterThan(");
     expect(EXAMPLE_SOURCE).toContain(".select(['category', 'adjustedValue'])");
     expect(EXAMPLE_SOURCE).toContain('compiled.selectedCounts');
     expect(EXAMPLE_SOURCE).toContain('CPU verified');

--- a/test/examples/ludf-derived-columns.spec.ts
+++ b/test/examples/ludf-derived-columns.spec.ts
@@ -14,14 +14,39 @@ describe('GPU data-analysis luDF derived-column example', () => {
     const dataset = container.querySelector<HTMLSelectElement>('[data-dataset]');
     const button = container.querySelector<HTMLButtonElement>('[data-ludf-run]');
     const adjustment = container.querySelector<HTMLInputElement>('[data-ludf-adjustment]');
+    const expression = container.querySelector<HTMLElement>('[data-ludf-expression]');
+    const selected = container.querySelector<HTMLElement>('[data-ludf-selected]');
+    const rate = container.querySelector<HTMLElement>('[data-ludf-rate]');
+    const execution = container.querySelector<HTMLElement>('[data-ludf-execution]');
+    const preview = container.querySelector<HTMLElement>('[data-ludf-preview]');
+    const threshold = container.querySelector<HTMLInputElement>('[data-ludf-threshold]');
     const result = container.querySelector<HTMLElement>('[data-ludf-result]');
 
     try {
       expect(dataset).not.toBeNull();
       expect(button).not.toBeNull();
       expect(adjustment).not.toBeNull();
+      expect(expression).not.toBeNull();
+      expect(selected).not.toBeNull();
+      expect(rate).not.toBeNull();
+      expect(execution).not.toBeNull();
+      expect(preview).not.toBeNull();
+      expect(threshold).not.toBeNull();
       expect(result).not.toBeNull();
-      if (!dataset || !button || !adjustment || !result) return;
+      if (
+        !dataset ||
+        !button ||
+        !adjustment ||
+        !expression ||
+        !selected ||
+        !rate ||
+        !execution ||
+        !preview ||
+        !threshold ||
+        !result
+      ) {
+        return;
+      }
 
       dataset.value = 'small';
       await vi.waitFor(
@@ -34,7 +59,10 @@ describe('GPU data-analysis luDF derived-column example', () => {
       );
 
       expect(result.textContent).toContain('without copying rows');
+      expect(expression.textContent).toContain('value × 2 + 1 > 1');
       adjustment.value = '1.25';
+      adjustment.dispatchEvent(new Event('input', {bubbles: true}));
+      expect(expression.textContent).toContain('value × 2 + 1.25 > 1');
       button.click();
 
       await vi.waitFor(
@@ -42,6 +70,24 @@ describe('GPU data-analysis luDF derived-column example', () => {
           expect(result.textContent).toContain('selected rows');
           expect(result.textContent).toContain('value × 2 + 1.25');
           expect(result.textContent).toContain('first GPU values');
+          expect(result.textContent).toContain('CPU verified');
+          expect(selected.textContent).toMatch(/[\d,]+/);
+          expect(rate.textContent).toMatch(/\d+\.\d%/);
+          expect(execution.textContent).toMatch(/\d+\.\d ms/);
+          expect(preview.textContent).toMatch(/-?\d+\.\d{2}/);
+        },
+        {timeout: 30_000, interval: 100}
+      );
+
+      const previousSelection = selected.textContent;
+      threshold.value = '0.75';
+      threshold.dispatchEvent(new Event('input', {bubbles: true}));
+      threshold.dispatchEvent(new Event('change', {bubbles: true}));
+
+      await vi.waitFor(
+        () => {
+          expect(expression.textContent).toContain('> 0.75');
+          expect(selected.textContent).not.toBe(previousSelection);
           expect(result.textContent).toContain('CPU verified');
         },
         {timeout: 30_000, interval: 100}

--- a/test/examples/ludf-derived-columns.spec.ts
+++ b/test/examples/ludf-derived-columns.spec.ts
@@ -1,0 +1,54 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {describe, expect, test, vi} from 'vitest';
+import {initializeGPUDataAnalysisExample} from '../../examples/experimental/gpu-data-analysis/src/app';
+
+describe('GPU data-analysis luDF derived-column example', () => {
+  test('executes an opt-in derived-column filter over existing Arrow-backed GPU buffers', async () => {
+    const container = document.createElement('main');
+    container.id = 'gpu-data-analysis-app';
+    document.body.append(container);
+    const example = initializeGPUDataAnalysisExample();
+    const dataset = container.querySelector<HTMLSelectElement>('[data-dataset]');
+    const button = container.querySelector<HTMLButtonElement>('[data-ludf-run]');
+    const adjustment = container.querySelector<HTMLInputElement>('[data-ludf-adjustment]');
+    const result = container.querySelector<HTMLElement>('[data-ludf-result]');
+
+    try {
+      expect(dataset).not.toBeNull();
+      expect(button).not.toBeNull();
+      expect(adjustment).not.toBeNull();
+      expect(result).not.toBeNull();
+      if (!dataset || !button || !adjustment || !result) return;
+
+      dataset.value = 'small';
+      await vi.waitFor(
+        () => {
+          expect(container.querySelector('[data-validation]')?.getAttribute('data-state')).toBe(
+            'ok'
+          );
+        },
+        {timeout: 30_000, interval: 100}
+      );
+
+      expect(result.textContent).toContain('without copying rows');
+      adjustment.value = '1.25';
+      button.click();
+
+      await vi.waitFor(
+        () => {
+          expect(result.textContent).toContain('selected rows');
+          expect(result.textContent).toContain('value × 2 + 1.25');
+          expect(result.textContent).toContain('first GPU values');
+          expect(result.textContent).toContain('CPU verified');
+        },
+        {timeout: 30_000, interval: 100}
+      );
+    } finally {
+      example.destroy();
+      container.remove();
+    }
+  });
+});


### PR DESCRIPTION
## Goals

Extend the browser-native luDF dataframe with fully GPU-resident derived numeric columns, chained expressions, explicit nullable validity, and filtering. Ship an immediately usable interactive example in the existing GPU data-analysis experience rather than waiting for later aggregation or Arrow-adapter PRs.

## Changes

- Rebase onto current `master`, preserving the merged expression/filtering foundation, physical command-graph overlap protections, graph documentation, LuRaster registrations, and recent graph/renderer fixes.
- Add immutable, precisely typed `LuDataFrame.withColumn(...)` and query `.withColumn(...)` planning for `float32`, `sint32`, and `uint32` scalar expressions without allocating, submitting, repacking, or reading back GPU data during planning.
- Lower chained derived expressions, trusted scalar constants, mutable parameters, and filter predicates into fused per-batch WGSL; preserve hidden dependencies, source dictionaries, nullable sidecars, stable source IDs, empty chunks, and compiled-resource ownership.
- Add an opt-in **Run luDF derived-column demo** control to the already-routed `examples/experimental/gpu-data-analysis` experience. The demo reuses existing Arrow-uploaded GPU record-batch chunks, evaluates configurable `adjustedValue = value × 2 + adjustment`, filters the derived values on the GPU, reads only a selected-row count and four-value preview, and validates the result against a CPU reference.
- Add dedicated Node checks for opt-in interaction, zero-repacking composition, parameterized expressions, bounded result publication, and cleanup, plus a real Chromium/WebGPU browser test that mounts the example, clicks the demo, and verifies the rendered GPU/CPU result.
- Normalize the new derived-column test SPDX headers required by current repository checks.

## Verification

- `nvm use`: Node `22.22.1`.
- Existing verified dependencies reused; no dependency or lockfile changes.
- `yarn lint fix`: passed across 1,691 source files.
- `yarn build`: passed for every workspace package.
- `yarn examples:typecheck`: all 46 example workspaces passed; the GPU data-analysis example also passed its own `tspc --noEmit` project check.
- Complete Node suite: **1,326 passed, 1 skipped across 190 files**; the repository pre-commit hook independently reran and passed the same complete suite.
- Focused Node derived-column/example/SPDX coverage passed; post-rebase regression subset: **15 passed**.
- Focused real Chromium/WebGPU derived-column and interactive-example suites: **6 passed across two browser files**, including the actual opt-in UI workflow.

## Risks and follow-up

- Derived columns intentionally support append-only portable numeric scalar formats; replacements, arbitrary strings, Float64/Int64, and incompatible scalar arithmetic remain unsupported.
- The interactive example is opt-in, borrows its already uploaded source buffers, preserves source batch topology, publishes only a bounded count/preview, and destroys its compiled graph after completion.
- Grouped/global aggregation, stable numeric sorting, bounded joins, and the fuller Arrow-native benchmark remain separate follow-on increments.
