### PR TITLE
feat(experimental): search borrowed fixed-size GPU table columns

### DIFF
--- a/modules/experimental/package.json
+++ b/modules/experimental/package.json
@@ -57,6 +57,11 @@
       "require": "./dist/luproj/index.cjs",
       "types": "./dist/luproj/index.d.ts"
     },
+    "./luvs": {
+      "import": "./dist/luvs/index.js",
+      "require": "./dist/luvs/index.cjs",
+      "types": "./dist/luvs/index.d.ts"
+    },
     "./luproj/benchmarks": {
       "import": "./dist/luproj/benchmarks.js",
       "require": "./dist/luproj/benchmarks.cjs",

--- a/modules/experimental/src/luvs/embedding-matrix.ts
+++ b/modules/experimental/src/luvs/embedding-matrix.ts
@@ -1,0 +1,352 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuVS.
+
+import {
+  GPURecordBatch,
+  GPU_TABLE_INDEX_COLUMN_NAME,
+  getGPUVectorFormatInfo,
+  isFixedSizeListGPUVectorFormat,
+  type FixedSizeList,
+  type GPUData,
+  type GPUTable,
+  type GPUVector
+} from '@luma.gl/tables';
+import type {GPUCommandGraph, GraphDataView} from '../gpu-primitives/gpu-command-graph';
+import type {GraphEmbeddingMatrix, GraphEmbeddingMatrixChunk} from './types';
+
+const FLOAT32_BYTE_LENGTH = Float32Array.BYTES_PER_ELEMENT;
+const INVALID_SOURCE_ROW_ID = 0xffff_ffff;
+
+/** Optional row-aligned metadata for importing a caller-owned embedding column. */
+export type ImportGPUEmbeddingVectorOptions = {
+  /** Prefix shared by the imported caller-owned graph buffers. */
+  id?: string;
+  /** Optional meaningful feature count when trailing fixed-list coordinates are padding. */
+  dimensions?: number;
+  /** Optional chunk-preserving stable identifiers for the embedding rows. */
+  sourceRowIds?: GPUVector<'uint32'>;
+  /** Optional chunk-preserving validity flags; zero rejects a row. */
+  validity?: GPUVector<'uint32'>;
+  /** Position of the first source row when chunk offsets are consecutive. */
+  sourceRowOffset?: number;
+  /** Explicit first source-row position for each preserved embedding chunk. */
+  sourceRowOffsets?: readonly number[];
+};
+
+/** Selects one caller-owned embedding column and optional row-aligned table columns. */
+export type ImportGPUEmbeddingTableOptions = {
+  /** Name of the fixed-size-list<float32,N> table or record-batch column. */
+  column: string;
+  /** Prefix shared by the imported caller-owned graph buffers. */
+  id?: string;
+  /** Optional meaningful feature count when trailing fixed-list coordinates are padding. */
+  dimensions?: number;
+  /** Optional name of the uint32 column providing stable source-row identifiers. */
+  sourceRowIds?: string;
+  /** Optional name of the uint32 column providing nonzero-valid row flags. */
+  validity?: string;
+};
+
+/** Caller-owned batch data that becomes one non-owning command-graph embedding chunk. */
+type GPUEmbeddingChunkSource = {
+  data: GPUData<FixedSizeList<'float32'>>;
+  sourceRowOffset: number;
+  sourceRowIds?: GPUData<'uint32'>;
+  validity?: GPUData<'uint32'>;
+};
+
+/**
+ * Borrows one first-class fixed-size-list<float32,N> GPU table column for graph-native search.
+ *
+ * GPUData chunks remain caller-owned and keep their logical row counts, byte offsets, physical
+ * padding, optional row metadata, and ordered batch boundaries. No GPU memory is allocated.
+ */
+export function importGPUEmbeddingVector<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  vector: GPUVector<FixedSizeList<'float32'>>,
+  options: ImportGPUEmbeddingVectorOptions = {}
+): GraphEmbeddingMatrix {
+  const dimensions = getEmbeddingDimensions(vector.format, 'Embedding vector', options.dimensions);
+  if (!Number.isSafeInteger(vector.length) || vector.length < 0) {
+    throw new Error('Embedding vector row count must be a non-negative safe integer');
+  }
+  validateOptionalRowVector(options.sourceRowIds, vector, 'source-row IDs');
+  validateOptionalRowVector(options.validity, vector, 'validity flags');
+  if (options.sourceRowOffsets && options.sourceRowOffsets.length !== vector.data.length) {
+    throw new Error('Embedding source-row offsets must preserve the vector chunk topology');
+  }
+
+  let nextSourceRowOffset = options.sourceRowOffset ?? 0;
+  const sources = vector.data.map((data, chunkIndex): GPUEmbeddingChunkSource => {
+    const sourceRowOffset = options.sourceRowOffsets?.[chunkIndex] ?? nextSourceRowOffset;
+    nextSourceRowOffset = sourceRowOffset + data.length;
+    return {
+      data,
+      sourceRowOffset,
+      ...(options.sourceRowIds ? {sourceRowIds: options.sourceRowIds.data[chunkIndex]} : {}),
+      ...(options.validity ? {validity: options.validity.data[chunkIndex]} : {})
+    };
+  });
+
+  return importEmbeddingChunks(
+    graph,
+    dimensions,
+    vector.length,
+    sources,
+    options.id ?? vector.name ?? 'embedding-vector'
+  );
+}
+
+/**
+ * Borrows one first-class embedding column from an existing GPU table or record batch.
+ *
+ * Existing GPURecordBatch.sourceInfo preserves source-row positions. Explicit stable identifiers
+ * and validity remain ordinary caller-selected uint32 sibling columns owned by the source table.
+ */
+export function importGPUEmbeddingTable<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  source: GPUTable | GPURecordBatch,
+  options: ImportGPUEmbeddingTableOptions
+): GraphEmbeddingMatrix {
+  const field = source.schema.fields.find(candidate => candidate.name === options.column);
+  if (!field) {
+    throw new Error(`Embedding table does not contain column "${options.column}"`);
+  }
+  const dimensions = getEmbeddingDimensions(
+    field.format,
+    `Embedding column "${options.column}"`,
+    options.dimensions
+  );
+  const batches = source instanceof GPURecordBatch ? [source] : source.batches;
+  let nextSourceRowOffset = 0;
+
+  const sources = batches.map((batch, batchIndex): GPUEmbeddingChunkSource => {
+    const data = batch.gpuData[options.column];
+    assertEmbeddingData(data, field.format, options.column);
+    const sourceRowOffset = batch.sourceInfo?.sourceRowIndexOffset ?? nextSourceRowOffset;
+    nextSourceRowOffset = sourceRowOffset + batch.numRows;
+    const sourceIdsName =
+      options.sourceRowIds ??
+      (batch.gpuData[GPU_TABLE_INDEX_COLUMN_NAME]?.format === 'uint32'
+        ? GPU_TABLE_INDEX_COLUMN_NAME
+        : undefined);
+    const sourceRowIds = sourceIdsName
+      ? getBatchRowData(batch, sourceIdsName, 'source-row IDs', batchIndex)
+      : undefined;
+    const validity = options.validity
+      ? getBatchRowData(batch, options.validity, 'validity flags', batchIndex)
+      : undefined;
+    return {
+      data,
+      sourceRowOffset,
+      ...(sourceRowIds ? {sourceRowIds} : {}),
+      ...(validity ? {validity} : {})
+    };
+  });
+
+  return importEmbeddingChunks(
+    graph,
+    dimensions,
+    source.numRows,
+    sources,
+    options.id ?? options.column
+  );
+}
+
+function getEmbeddingDimensions(
+  format: string | undefined,
+  name: string,
+  requestedDimensions?: number
+): number {
+  if (!format || !isFixedSizeListGPUVectorFormat(format)) {
+    throw new Error(`${name} must use a fixed-size-list<float32,N> GPU vector format`);
+  }
+  const formatInfo = getGPUVectorFormatInfo(format);
+  if (formatInfo.elementFormat !== 'float32' || !formatInfo.listSize) {
+    throw new Error(`${name} must use a fixed-size-list<float32,N> GPU vector format`);
+  }
+  const dimensions = requestedDimensions ?? formatInfo.listSize;
+  if (!Number.isSafeInteger(dimensions) || dimensions < 1 || dimensions > formatInfo.listSize) {
+    throw new Error(`${name} dimensions must be positive and fit within its fixed-size-list rows`);
+  }
+  return dimensions;
+}
+
+function assertEmbeddingData(
+  data: GPUData | undefined,
+  expectedFormat: string | undefined,
+  column: string
+): asserts data is GPUData<FixedSizeList<'float32'>> {
+  if (!data || data.format !== expectedFormat) {
+    throw new Error(`Embedding column "${column}" must retain the same format in every batch`);
+  }
+}
+
+function validateOptionalRowVector(
+  metadata: GPUVector<'uint32'> | undefined,
+  embeddings: GPUVector<FixedSizeList<'float32'>>,
+  name: string
+): void {
+  if (!metadata) return;
+  if (
+    metadata.format !== 'uint32' ||
+    metadata.length !== embeddings.length ||
+    metadata.data.length !== embeddings.data.length ||
+    metadata.data.some((data, chunkIndex) => data.length !== embeddings.data[chunkIndex].length)
+  ) {
+    throw new Error(`Embedding ${name} must be a chunk-aligned uint32 GPU vector`);
+  }
+}
+
+function getBatchRowData(
+  batch: GPURecordBatch,
+  column: string,
+  name: string,
+  batchIndex: number
+): GPUData<'uint32'> {
+  const data = batch.gpuData[column];
+  assertBatchRowData(data, batch.numRows, name, batchIndex);
+  return data;
+}
+
+function assertBatchRowData(
+  data: GPUData | undefined,
+  rowCount: number,
+  name: string,
+  batchIndex: number
+): asserts data is GPUData<'uint32'> {
+  if (!data || data.format !== 'uint32' || data.length !== rowCount) {
+    throw new Error(`Embedding ${name} must be a row-aligned uint32 column in batch ${batchIndex}`);
+  }
+}
+
+function importEmbeddingChunks<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  dimensions: number,
+  rowCount: number,
+  sources: readonly GPUEmbeddingChunkSource[],
+  identifier: string
+): GraphEmbeddingMatrix {
+  let totalRowCount = 0;
+  for (const source of sources) {
+    validateEmbeddingChunk(source, dimensions);
+    totalRowCount += source.data.length;
+  }
+  if (totalRowCount !== rowCount || totalRowCount > INVALID_SOURCE_ROW_ID) {
+    throw new Error('Embedding row count must equal its source chunk rows and fit into uint32');
+  }
+  const chunks = sources.map((source, chunkIndex) =>
+    importEmbeddingChunk(graph, source, dimensions, `${identifier}-chunk-${chunkIndex}`)
+  );
+  return {dimensions, rowCount, chunks};
+}
+
+function validateEmbeddingChunk(source: GPUEmbeddingChunkSource, dimensions: number): void {
+  const data = source.data;
+  const formatInfo = data.format ? getGPUVectorFormatInfo(data.format) : undefined;
+  const listSize = formatInfo?.listSize ?? 0;
+  const expectedValueLength = data.length * listSize;
+  if (
+    !Number.isSafeInteger(data.length) ||
+    data.length < 0 ||
+    !formatInfo?.fixedSizeList ||
+    formatInfo.elementFormat !== 'float32' ||
+    dimensions > listSize ||
+    !Number.isSafeInteger(expectedValueLength) ||
+    data.valueLength !== expectedValueLength ||
+    !Number.isSafeInteger(data.byteOffset) ||
+    data.byteOffset < 0 ||
+    data.byteOffset % FLOAT32_BYTE_LENGTH !== 0 ||
+    !Number.isSafeInteger(data.byteStride) ||
+    data.byteStride < listSize * FLOAT32_BYTE_LENGTH ||
+    data.byteStride % FLOAT32_BYTE_LENGTH !== 0 ||
+    !Number.isSafeInteger(data.rowByteLength) ||
+    data.rowByteLength < listSize * FLOAT32_BYTE_LENGTH ||
+    data.rowByteLength > data.byteStride ||
+    !Number.isSafeInteger(source.sourceRowOffset) ||
+    source.sourceRowOffset < 0 ||
+    source.sourceRowOffset + data.length > INVALID_SOURCE_ROW_ID
+  ) {
+    throw new Error('Embedding chunk must describe aligned, bounded fixed-size float32 rows');
+  }
+  const byteLength =
+    data.length === 0 ? 0 : (data.length - 1) * data.byteStride + dimensions * FLOAT32_BYTE_LENGTH;
+  if (
+    !Number.isSafeInteger(byteLength) ||
+    !Number.isSafeInteger(data.byteOffset + byteLength) ||
+    data.byteOffset + byteLength > data.buffer.byteLength
+  ) {
+    throw new Error('Embedding chunk rows exceed their declared GPUData byte range');
+  }
+  for (const metadata of [source.sourceRowIds, source.validity]) {
+    if (
+      metadata &&
+      (metadata.format !== 'uint32' ||
+        metadata.length !== data.length ||
+        metadata.byteStride !== Uint32Array.BYTES_PER_ELEMENT ||
+        metadata.rowByteLength !== Uint32Array.BYTES_PER_ELEMENT)
+    ) {
+      throw new Error('Embedding row metadata must be packed, row-aligned uint32 GPUData');
+    }
+  }
+  if (source.sourceRowIds && hasNullEmbeddingRows(source.sourceRowIds)) {
+    throw new Error('Embedding source-row IDs must not contain null values');
+  }
+  if (!source.validity && hasNullEmbeddingRows(data)) {
+    throw new Error('Embedding rows containing null values require explicit GPU validity flags');
+  }
+}
+
+function hasNullEmbeddingRows(data: GPUData): boolean {
+  const nullBitmap = data.nullBitmap;
+  if (!nullBitmap) return false;
+  for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
+    if ((nullBitmap[rowIndex >>> 3] & (1 << (rowIndex & 7))) === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function importEmbeddingChunk<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  source: GPUEmbeddingChunkSource,
+  dimensions: number,
+  identifier: string
+): GraphEmbeddingMatrixChunk {
+  const importedData = graph.importGPUData(`${identifier}-values`, source.data);
+  const rowStride = source.data.byteStride / FLOAT32_BYTE_LENGTH;
+  const valueLength =
+    source.data.length === 0 ? 0 : (source.data.length - 1) * rowStride + dimensions;
+  const values = graph.createDataView(importedData.buffer, {
+    format: 'float32',
+    length: valueLength,
+    byteOffset: source.data.byteOffset
+  });
+  const sourceRowIds = importOptionalRowData(
+    graph,
+    source.sourceRowIds,
+    `${identifier}-source-row-ids`
+  );
+  const validity = importOptionalRowData(graph, source.validity, `${identifier}-validity`);
+
+  return {
+    values,
+    rowCount: source.data.length,
+    rowStride,
+    byteOffset: source.data.byteOffset,
+    sourceRowOffset: source.sourceRowOffset,
+    ...(sourceRowIds ? {sourceRowIds} : {}),
+    ...(validity ? {validity} : {})
+  };
+}
+
+function importOptionalRowData<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  data: GPUData<'uint32'> | undefined,
+  identifier: string
+): GraphDataView<'uint32'> | undefined {
+  return data ? graph.importGPUData(identifier, data) : undefined;
+}

--- a/modules/experimental/src/luvs/gpu-similarity-search.ts
+++ b/modules/experimental/src/luvs/gpu-similarity-search.ts
@@ -1,0 +1,1123 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuVS.
+
+import type {Binding} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {
+  type GPUCommandGraph,
+  type GPUCommandGraphContributor,
+  type GraphBufferUse,
+  type GraphDataView,
+  type GraphVectorView
+} from '../gpu-primitives/gpu-command-graph';
+import {
+  createTransientView,
+  doGraphDataViewsOverlap,
+  getViewBinding,
+  getViewBindingRange,
+  getViewElementOffset,
+  validatePackedUint32View,
+  validatePackedView
+} from '../gpu-primitives/graph-data-view-utils';
+import {
+  getBoundedDispatchLayout,
+  getBoundedInvocationIndexSource
+} from '../gpu-primitives/gpu-dispatch-utils';
+import {GPUHashIndex} from '../gpu-primitives/gpu-hash-index';
+import type {
+  GPUEmbeddingFilterMask,
+  GPUEmbeddingMetric,
+  GPUSimilaritySearchProps,
+  GraphEmbeddingMatrix,
+  GraphEmbeddingMatrixChunk
+} from './types';
+
+const SEARCH_WORKGROUP_SIZE = 64;
+const INVALID_SOURCE_ROW_ID = 0xffff_ffff;
+const STORAGE_BINDING_ALIGNMENT = 256;
+const SCALAR_BYTE_LENGTH = Uint32Array.BYTES_PER_ELEMENT;
+const LINEAR_CANDIDATE_ALLOWLIST_LIMIT = 16;
+
+type CandidateMembershipIndex = {
+  keys: GraphDataView<'uint32'>;
+  capacity: number;
+};
+
+type DatasetTile = {
+  chunk: GraphEmbeddingMatrixChunk;
+  chunkIndex: number;
+  chunkRowOffset: number;
+  sourceRowOffset: number;
+  rowCount: number;
+  values: GraphDataView<'float32'>;
+  sourceRowIds?: GraphDataView<'uint32'>;
+  validity?: GraphDataView<'uint32'>;
+  filterMask?: GraphDataView<'uint32'>;
+};
+
+type QueryTile = {
+  logicalRowOffset: number;
+  rowCount: number;
+  values: GraphDataView<'float32'>;
+  rowStride: number;
+  sourceRowOffset: number;
+  sourceRowIds?: GraphDataView<'uint32'>;
+  validity?: GraphDataView<'uint32'>;
+  rowMetadata: GraphDataView<'uint32'>;
+  outputIds: GraphDataView<'uint32'>;
+  outputScores: GraphDataView<'float32'>;
+  resultCounts: GraphDataView<'uint32'>;
+  candidateCounts?: GraphDataView<'uint32'>;
+};
+
+/**
+ * Exact, bounded, chunk-preserving WebGPU embedding similarity search.
+ *
+ * Squared Euclidean distance sorts ascending; inner product and cosine similarity sort descending.
+ * Equal scores always sort by stable source-row ID. Non-finite rows are excluded. Cosine similarity
+ * is one for two zero vectors and zero when exactly one vector is zero. Unfilled result slots use
+ * source ID `0xffffffff` and the metric's worst infinite score.
+ *
+ * Original allocations are sharded at the device storage-binding limit. Each query invocation keeps
+ * only its caller-owned top-K output, so no query-by-dataset distance matrix is materialized.
+ */
+export class GPUSimilaritySearch implements GPUCommandGraphContributor {
+  /** Prefix shared by bounded graph passes and transient eligibility metadata. */
+  readonly id: string;
+  /** Caller-owned, chunk-preserving dataset embeddings. */
+  readonly dataset: GraphEmbeddingMatrix;
+  /** Caller-owned, chunk-preserving query embeddings. */
+  readonly queries: GraphEmbeddingMatrix;
+  /** Packed, query-major stable source IDs. */
+  readonly outputIds: GraphDataView<'uint32'>;
+  /** Packed, query-major float32 distance or similarity scores. */
+  readonly outputScores: GraphDataView<'float32'>;
+  /** Number of actual top-K results for each query row. */
+  readonly resultCounts: GraphDataView<'uint32'>;
+  /** Optional total eligible candidate count before top-K truncation. */
+  readonly candidateCounts?: GraphDataView<'uint32'>;
+  /** Maximum result count per query. */
+  readonly k: number;
+  /** Score metric and corresponding ordering direction. */
+  readonly metric: GPUEmbeddingMetric;
+  /** Optional source-row-aligned LuxFilter-compatible selection flags. */
+  readonly filterMask?: GPUEmbeddingFilterMask;
+  /** Optional stable-ID candidate allowlist. */
+  readonly candidateIds?: GraphDataView<'uint32'>;
+  /** Optional query-major, source-row-aligned selection flags. */
+  readonly queryFilterMask?: GraphDataView<'uint32'>;
+  /** Whether candidates sharing the query's stable ID are rejected. */
+  readonly excludeSelf: boolean;
+  /** Optional additional per-pass candidate-row ceiling. */
+  readonly tileSize: number;
+
+  private registered = false;
+
+  /** Validates caller-owned resources without encoding, submitting, or reading GPU work. */
+  constructor(props: GPUSimilaritySearchProps) {
+    this.id = props.id ?? 'gpu-similarity-search';
+    this.dataset = props.dataset;
+    this.queries = props.queries;
+    this.outputIds = props.outputIds;
+    this.outputScores = props.outputScores;
+    this.resultCounts = props.resultCounts;
+    this.candidateCounts = props.candidateCounts;
+    this.k = props.k;
+    this.metric = props.metric ?? 'squared-euclidean';
+    this.filterMask = props.filterMask;
+    this.candidateIds = props.candidateIds;
+    this.queryFilterMask = props.queryFilterMask;
+    this.excludeSelf = props.excludeSelf ?? false;
+    this.tileSize = props.tileSize ?? INVALID_SOURCE_ROW_ID;
+
+    validateSearchConfiguration(this);
+  }
+
+  /**
+   * Adds reusable bounded passes without implicit submission or hidden CPU synchronization.
+   *
+   * Every pass declares all physical source/destination dependencies. Imported buffer overrides are
+   * resolved only during graph encoding, so one compiled search can run repeatedly with new inputs.
+   */
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    if (this.registered) {
+      throw new Error(`${this.id} similarity search has already been added to a command graph`);
+    }
+    validateSearchGraphOwnership(this, graph);
+    if (this.queries.rowCount === 0) {
+      this.registered = true;
+      return;
+    }
+
+    const sourceSpan = getSourceRowSpan(this.dataset);
+    const queryTiles = createQueryTiles(graph, this, sourceSpan);
+    for (const [queryTileIndex, queryTile] of queryTiles.entries()) {
+      addInitializeQueryPass(graph, this, queryTile, queryTileIndex);
+    }
+
+    if (this.dataset.rowCount === 0 || (this.k === 0 && !this.candidateCounts)) {
+      this.registered = true;
+      return;
+    }
+
+    const candidateMembership = createCandidateMembershipIndex(graph, this);
+    const datasetTiles = createDatasetTiles(graph, this);
+    for (const [datasetTileIndex, datasetTile] of datasetTiles.entries()) {
+      const eligibleSourceIds = createTransientView(
+        graph,
+        `${this.id}-eligible-source-ids-${datasetTileIndex}`,
+        'uint32',
+        datasetTile.rowCount
+      );
+      addPrepareDatasetTilePass(
+        graph,
+        this,
+        datasetTile,
+        datasetTileIndex,
+        eligibleSourceIds,
+        candidateMembership
+      );
+
+      for (const [queryTileIndex, queryTile] of queryTiles.entries()) {
+        const queryFilterMask = this.queryFilterMask
+          ? createQueryFilterTileView(
+              graph,
+              this.queryFilterMask,
+              queryTile,
+              datasetTile,
+              sourceSpan
+            )
+          : undefined;
+        if (queryTile.candidateCounts) {
+          addCountCandidatesPass(
+            graph,
+            this,
+            datasetTile,
+            queryTile,
+            datasetTileIndex,
+            queryTileIndex,
+            eligibleSourceIds,
+            queryFilterMask,
+            sourceSpan
+          );
+        }
+        if (this.k > 0) {
+          addSearchDatasetTilePass(
+            graph,
+            this,
+            datasetTile,
+            queryTile,
+            datasetTileIndex,
+            queryTileIndex,
+            eligibleSourceIds,
+            queryFilterMask,
+            sourceSpan
+          );
+        }
+      }
+    }
+    this.registered = true;
+  }
+}
+
+function validateSearchConfiguration(search: GPUSimilaritySearch): void {
+  if (
+    !Number.isSafeInteger(search.dataset.dimensions) ||
+    search.dataset.dimensions < 1 ||
+    search.dataset.dimensions !== search.queries.dimensions
+  ) {
+    throw new Error(`${search.id} dataset and query embedding dimensions must match`);
+  }
+  if (
+    !Number.isSafeInteger(search.k) ||
+    search.k < 0 ||
+    search.k > INVALID_SOURCE_ROW_ID ||
+    !Number.isSafeInteger(search.k * search.queries.rowCount) ||
+    search.k * search.queries.rowCount > INVALID_SOURCE_ROW_ID
+  ) {
+    throw new Error(`${search.id} result count and query-major output length must fit into uint32`);
+  }
+  if (!['squared-euclidean', 'inner-product', 'cosine'].includes(search.metric)) {
+    throw new Error(`${search.id} metric must be squared-euclidean, inner-product, or cosine`);
+  }
+  if (!Number.isSafeInteger(search.tileSize) || search.tileSize < 1) {
+    throw new Error(`${search.id} tileSize must be a positive safe integer`);
+  }
+
+  validateGraphEmbeddingMatrix(search.dataset, `${search.id} dataset`);
+  validateGraphEmbeddingMatrix(search.queries, `${search.id} queries`);
+  validatePackedUint32View(search.outputIds, `${search.id} output IDs`);
+  validatePackedView(search.outputScores, ['float32'], `${search.id} output scores`);
+  validatePackedUint32View(search.resultCounts, `${search.id} result counts`);
+  const outputLength = search.queries.rowCount * search.k;
+  if (search.outputIds.length < outputLength || search.outputScores.length < outputLength) {
+    throw new Error(`${search.id} result destinations must contain queryCount * k values`);
+  }
+  if (search.resultCounts.length < search.queries.rowCount) {
+    throw new Error(`${search.id} result counts must contain one value per query`);
+  }
+  if (search.candidateCounts) {
+    validatePackedUint32View(search.candidateCounts, `${search.id} candidate counts`);
+    if (search.candidateCounts.length < search.queries.rowCount) {
+      throw new Error(`${search.id} candidate counts must contain one value per query`);
+    }
+  }
+  if (search.candidateIds) {
+    validatePackedUint32View(search.candidateIds, `${search.id} candidate IDs`);
+  }
+  const sourceSpan = getSourceRowSpan(search.dataset);
+  if (search.filterMask) {
+    validateSearchFilterMask(search, sourceSpan);
+  }
+  if (search.queryFilterMask) {
+    validatePackedUint32View(search.queryFilterMask, `${search.id} query filter mask`);
+    if (
+      !Number.isSafeInteger(sourceSpan * search.queries.rowCount) ||
+      search.queryFilterMask.length < sourceSpan * search.queries.rowCount
+    ) {
+      throw new Error(`${search.id} query filter mask must contain query-major source flags`);
+    }
+  }
+  validateDistinctSearchOutputs(search);
+}
+
+function validateGraphEmbeddingMatrix(matrix: GraphEmbeddingMatrix, name: string): void {
+  if (!Number.isSafeInteger(matrix.rowCount) || matrix.rowCount < 0) {
+    throw new Error(`${name} row count must be a non-negative safe integer`);
+  }
+  let totalRowCount = 0;
+  for (const chunk of matrix.chunks) {
+    validatePackedView(chunk.values, ['float32'], `${name} flat values`);
+    if (
+      !Number.isSafeInteger(chunk.rowCount) ||
+      chunk.rowCount < 0 ||
+      !Number.isSafeInteger(chunk.rowStride) ||
+      chunk.rowStride < matrix.dimensions ||
+      chunk.byteOffset !== chunk.values.byteOffset ||
+      !Number.isSafeInteger(chunk.sourceRowOffset) ||
+      chunk.sourceRowOffset < 0 ||
+      chunk.sourceRowOffset + chunk.rowCount > INVALID_SOURCE_ROW_ID ||
+      (chunk.rowCount > 0 &&
+        chunk.values.length < (chunk.rowCount - 1) * chunk.rowStride + matrix.dimensions)
+    ) {
+      throw new Error(`${name} chunk must preserve aligned, bounded float32 embedding rows`);
+    }
+    for (const rowView of [chunk.sourceRowIds, chunk.validity]) {
+      if (rowView) {
+        validatePackedUint32View(rowView, `${name} row metadata`);
+        if (rowView.length < chunk.rowCount) {
+          throw new Error(`${name} row metadata must align with its source chunk`);
+        }
+      }
+    }
+    totalRowCount += chunk.rowCount;
+  }
+  if (totalRowCount !== matrix.rowCount || totalRowCount > INVALID_SOURCE_ROW_ID) {
+    throw new Error(`${name} row count must match its chunk rows and fit into uint32`);
+  }
+}
+
+function validateSearchFilterMask(search: GPUSimilaritySearch, sourceSpan: number): void {
+  const filterMask = search.filterMask;
+  if (!filterMask) return;
+  if (isGraphVectorView(filterMask)) {
+    if (
+      filterMask.data.length !== search.dataset.chunks.length ||
+      filterMask.data.some(
+        (chunk, chunkIndex) => chunk.length !== search.dataset.chunks[chunkIndex].rowCount
+      )
+    ) {
+      throw new Error(`${search.id} filter mask must preserve the dataset chunk topology`);
+    }
+    for (const chunk of filterMask.data) {
+      validatePackedUint32View(chunk, `${search.id} filter mask`);
+    }
+  } else {
+    validatePackedUint32View(filterMask, `${search.id} filter mask`);
+    if (filterMask.length < sourceSpan) {
+      throw new Error(`${search.id} filter mask must contain source-aligned selection flags`);
+    }
+  }
+}
+
+function validateDistinctSearchOutputs(search: GPUSimilaritySearch): void {
+  const inputs: GraphDataView[] = [
+    ...search.dataset.chunks.flatMap(getEmbeddingChunkViews),
+    ...search.queries.chunks.flatMap(getEmbeddingChunkViews),
+    ...(search.filterMask
+      ? isGraphVectorView(search.filterMask)
+        ? search.filterMask.data
+        : [search.filterMask]
+      : []),
+    ...(search.candidateIds ? [search.candidateIds] : []),
+    ...(search.queryFilterMask ? [search.queryFilterMask] : [])
+  ];
+  const outputs: GraphDataView[] = [
+    search.outputIds,
+    search.outputScores,
+    search.resultCounts,
+    ...(search.candidateCounts ? [search.candidateCounts] : [])
+  ];
+  for (const [outputIndex, output] of outputs.entries()) {
+    if (
+      inputs.some(input => doGraphDataViewsOverlap(input, output)) ||
+      outputs.slice(0, outputIndex).some(previous => doGraphDataViewsOverlap(previous, output))
+    ) {
+      throw new Error(`${search.id} writable outputs must not overlap source or destination data`);
+    }
+  }
+}
+
+function validateSearchGraphOwnership<Parameters>(
+  search: GPUSimilaritySearch,
+  graph: GPUCommandGraph<Parameters>
+): void {
+  const views = [
+    ...search.dataset.chunks.flatMap(getEmbeddingChunkViews),
+    ...search.queries.chunks.flatMap(getEmbeddingChunkViews),
+    search.outputIds,
+    search.outputScores,
+    search.resultCounts,
+    ...(search.candidateCounts ? [search.candidateCounts] : []),
+    ...(search.candidateIds ? [search.candidateIds] : []),
+    ...(search.queryFilterMask ? [search.queryFilterMask] : []),
+    ...(search.filterMask
+      ? isGraphVectorView(search.filterMask)
+        ? search.filterMask.data
+        : [search.filterMask]
+      : [])
+  ];
+  if (views.some(view => view.buffer.graph !== graph)) {
+    throw new Error(`${search.id} inputs and outputs must belong to their target command graph`);
+  }
+}
+
+function getEmbeddingChunkViews(chunk: GraphEmbeddingMatrixChunk): GraphDataView[] {
+  return [
+    chunk.values,
+    ...(chunk.sourceRowIds ? [chunk.sourceRowIds] : []),
+    ...(chunk.validity ? [chunk.validity] : [])
+  ];
+}
+
+function createDatasetTiles<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch
+): DatasetTile[] {
+  const maximumBindingSize = graph.device.limits.maxStorageBufferBindingSize;
+  const tiles: DatasetTile[] = [];
+  for (const [chunkIndex, chunk] of search.dataset.chunks.entries()) {
+    let chunkRowOffset = 0;
+    while (chunkRowOffset < chunk.rowCount) {
+      const rowCount = Math.min(
+        chunk.rowCount - chunkRowOffset,
+        search.tileSize,
+        getMaximumEmbeddingTileRows(
+          chunk,
+          chunkRowOffset,
+          search.dataset.dimensions,
+          maximumBindingSize
+        ),
+        Math.max(
+          1,
+          Math.floor((maximumBindingSize - STORAGE_BINDING_ALIGNMENT + 1) / SCALAR_BYTE_LENGTH)
+        )
+      );
+      const values = createEmbeddingTileView(
+        graph,
+        chunk,
+        chunkRowOffset,
+        rowCount,
+        search.dataset.dimensions
+      );
+      const tile: DatasetTile = {
+        chunk,
+        chunkIndex,
+        chunkRowOffset,
+        sourceRowOffset: chunk.sourceRowOffset + chunkRowOffset,
+        rowCount,
+        values,
+        ...(chunk.sourceRowIds
+          ? {sourceRowIds: createScalarSubview(graph, chunk.sourceRowIds, chunkRowOffset, rowCount)}
+          : {}),
+        ...(chunk.validity
+          ? {validity: createScalarSubview(graph, chunk.validity, chunkRowOffset, rowCount)}
+          : {})
+      };
+      const filterMask = createDatasetFilterTileView(graph, search.filterMask, tile);
+      if (filterMask) {
+        tile.filterMask = filterMask;
+      }
+      tiles.push(tile);
+      chunkRowOffset += rowCount;
+    }
+  }
+  return tiles;
+}
+
+function createQueryTiles<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch,
+  sourceSpan: number
+): QueryTile[] {
+  const maximumBindingSize = graph.device.limits.maxStorageBufferBindingSize;
+  const maximumOutputRows = Math.max(
+    1,
+    Math.floor(
+      (maximumBindingSize - STORAGE_BINDING_ALIGNMENT + 1) /
+        (Math.max(search.k, 1) * SCALAR_BYTE_LENGTH)
+    )
+  );
+  const maximumFilterRows = search.queryFilterMask
+    ? Math.max(
+        1,
+        Math.floor(
+          (maximumBindingSize - STORAGE_BINDING_ALIGNMENT + 1) /
+            (Math.max(sourceSpan, 1) * SCALAR_BYTE_LENGTH)
+        )
+      )
+    : INVALID_SOURCE_ROW_ID;
+  const maximumRows = Math.min(maximumOutputRows, maximumFilterRows);
+  const queryTiles: QueryTile[] = [];
+  let logicalRowOffset = 0;
+  for (const chunk of search.queries.chunks) {
+    let chunkRowOffset = 0;
+    while (chunkRowOffset < chunk.rowCount) {
+      const rowCount = Math.min(
+        chunk.rowCount - chunkRowOffset,
+        maximumRows,
+        getMaximumEmbeddingTileRows(
+          chunk,
+          chunkRowOffset,
+          search.queries.dimensions,
+          maximumBindingSize
+        )
+      );
+      const queryOffset = logicalRowOffset + chunkRowOffset;
+      const outputOffset = queryOffset * search.k;
+      const queryTile: QueryTile = {
+        logicalRowOffset: queryOffset,
+        rowCount,
+        values: createEmbeddingTileView(
+          graph,
+          chunk,
+          chunkRowOffset,
+          rowCount,
+          search.queries.dimensions
+        ),
+        rowStride: chunk.rowStride,
+        sourceRowOffset: chunk.sourceRowOffset + chunkRowOffset,
+        rowMetadata: createTransientView(
+          graph,
+          `${search.id}-query-metadata-${queryTiles.length}`,
+          'uint32',
+          rowCount
+        ),
+        outputIds: createScalarSubview(graph, search.outputIds, outputOffset, rowCount * search.k),
+        outputScores: createScalarSubview(
+          graph,
+          search.outputScores,
+          outputOffset,
+          rowCount * search.k
+        ),
+        resultCounts: createScalarSubview(graph, search.resultCounts, queryOffset, rowCount),
+        ...(search.candidateCounts
+          ? {
+              candidateCounts: createScalarSubview(
+                graph,
+                search.candidateCounts,
+                queryOffset,
+                rowCount
+              )
+            }
+          : {}),
+        ...(chunk.sourceRowIds
+          ? {sourceRowIds: createScalarSubview(graph, chunk.sourceRowIds, chunkRowOffset, rowCount)}
+          : {}),
+        ...(chunk.validity
+          ? {validity: createScalarSubview(graph, chunk.validity, chunkRowOffset, rowCount)}
+          : {})
+      };
+      queryTiles.push(queryTile);
+      chunkRowOffset += rowCount;
+    }
+    logicalRowOffset += chunk.rowCount;
+  }
+  return queryTiles;
+}
+
+function createEmbeddingTileView<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  chunk: GraphEmbeddingMatrixChunk,
+  rowOffset: number,
+  rowCount: number,
+  dimensions: number
+): GraphDataView<'float32'> {
+  return graph.createDataView(chunk.values.buffer, {
+    format: 'float32',
+    length: rowCount === 0 ? 0 : (rowCount - 1) * chunk.rowStride + dimensions,
+    byteOffset: chunk.byteOffset + rowOffset * chunk.rowStride * Float32Array.BYTES_PER_ELEMENT
+  });
+}
+
+function createScalarSubview<Format extends 'float32' | 'uint32', Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  view: GraphDataView<Format>,
+  rowOffset: number,
+  rowCount: number
+): GraphDataView<Format> {
+  return graph.createDataView(view.buffer, {
+    format: view.format,
+    length: rowCount,
+    byteOffset: view.byteOffset + rowOffset * SCALAR_BYTE_LENGTH
+  });
+}
+
+function createDatasetFilterTileView<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  filterMask: GPUEmbeddingFilterMask | undefined,
+  tile: DatasetTile
+): GraphDataView<'uint32'> | undefined {
+  if (!filterMask) return undefined;
+  if (isGraphVectorView(filterMask)) {
+    return createScalarSubview(
+      graph,
+      filterMask.data[tile.chunkIndex],
+      tile.chunkRowOffset,
+      tile.rowCount
+    );
+  }
+  return createScalarSubview(graph, filterMask, tile.sourceRowOffset, tile.rowCount);
+}
+
+function createQueryFilterTileView<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  queryFilterMask: GraphDataView<'uint32'>,
+  queryTile: QueryTile,
+  datasetTile: DatasetTile,
+  sourceSpan: number
+): GraphDataView<'uint32'> {
+  const firstRowOffset = queryTile.logicalRowOffset * sourceSpan + datasetTile.sourceRowOffset;
+  const rowCount = (queryTile.rowCount - 1) * sourceSpan + datasetTile.rowCount;
+  const view = createScalarSubview(graph, queryFilterMask, firstRowOffset, rowCount);
+  if (getViewBindingRange(view).size > graph.device.limits.maxStorageBufferBindingSize) {
+    throw new Error('GPU embedding query filter tile exceeds maxStorageBufferBindingSize');
+  }
+  return view;
+}
+
+function getMaximumEmbeddingTileRows(
+  chunk: GraphEmbeddingMatrixChunk,
+  rowOffset: number,
+  dimensions: number,
+  maximumBindingSize: number
+): number {
+  const byteOffset = chunk.byteOffset + rowOffset * chunk.rowStride * SCALAR_BYTE_LENGTH;
+  const alignmentPrefix = byteOffset % STORAGE_BINDING_ALIGNMENT;
+  const requiredRowBytes = dimensions * SCALAR_BYTE_LENGTH;
+  const availableBytes = maximumBindingSize - alignmentPrefix;
+  if (availableBytes < requiredRowBytes) {
+    throw new Error('GPU embedding row exceeds maxStorageBufferBindingSize');
+  }
+  return (
+    Math.floor((availableBytes - requiredRowBytes) / (chunk.rowStride * SCALAR_BYTE_LENGTH)) + 1
+  );
+}
+
+function getSourceRowSpan(matrix: GraphEmbeddingMatrix): number {
+  return matrix.chunks.reduce(
+    (maximum, chunk) => Math.max(maximum, chunk.sourceRowOffset + chunk.rowCount),
+    0
+  );
+}
+
+function isGraphVectorView(view: GPUEmbeddingFilterMask): view is GraphVectorView<'uint32'> {
+  return Array.isArray((view as GraphVectorView<'uint32'>).data);
+}
+
+/** Builds bounded GPU membership for substantial allowlists without O(datasetRows * ID count). */
+function createCandidateMembershipIndex<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch
+): CandidateMembershipIndex | undefined {
+  if (!search.candidateIds) return undefined;
+  const maximumBindingSize = graph.device.limits.maxStorageBufferBindingSize;
+  if (getViewBindingRange(search.candidateIds).size > maximumBindingSize) {
+    throw new Error(`${search.id} candidate IDs exceed maxStorageBufferBindingSize`);
+  }
+  if (search.candidateIds.length <= LINEAR_CANDIDATE_ALLOWLIST_LIMIT) {
+    return undefined;
+  }
+
+  let capacity = 2;
+  const requestedCapacity = search.candidateIds.length * 2;
+  while (capacity < requestedCapacity) {
+    capacity *= 2;
+  }
+  if (capacity * SCALAR_BYTE_LENGTH > maximumBindingSize) {
+    throw new Error(
+      `${search.id} candidate-ID membership exceeds maxStorageBufferBindingSize; use a source-aligned filter mask`
+    );
+  }
+
+  const tableKeys = createTransientView(
+    graph,
+    `${search.id}-candidate-index-keys`,
+    'uint32',
+    capacity
+  );
+  const tableValues = createTransientView(
+    graph,
+    `${search.id}-candidate-index-values`,
+    'uint32',
+    capacity
+  );
+  const statistics = createTransientView(
+    graph,
+    `${search.id}-candidate-index-statistics`,
+    'uint32',
+    6
+  );
+  new GPUHashIndex({
+    id: `${search.id}-candidate-index`,
+    keys: search.candidateIds,
+    tableKeys,
+    tableValues,
+    statistics
+  }).addToGraph(graph);
+  return {keys: tableKeys, capacity};
+}
+
+function addInitializeQueryPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch,
+  tile: QueryTile,
+  tileIndex: number
+): void {
+  const id = `${search.id}-initialize-query-tile-${tileIndex}`;
+  const bindings: Record<string, GraphDataView> = {
+    queryValues: tile.values,
+    queryMetadata: tile.rowMetadata,
+    outputIds: tile.outputIds,
+    outputScores: tile.outputScores,
+    resultCounts: tile.resultCounts,
+    ...(tile.candidateCounts ? {candidateCounts: tile.candidateCounts} : {}),
+    ...(tile.validity ? {queryValidity: tile.validity} : {}),
+    ...(tile.sourceRowIds ? {querySourceIds: tile.sourceRowIds} : {})
+  };
+  const source = /* wgsl */ `
+${getCommonWGSLConstants(search, tile.rowCount)}
+const QUERY_OFFSET: u32 = ${getViewElementOffset(tile.values)}u;
+const QUERY_STRIDE: u32 = ${tile.rowStride}u;
+const QUERY_SOURCE_OFFSET: u32 = ${tile.sourceRowOffset}u;
+const QUERY_METADATA_OFFSET: u32 = ${getViewElementOffset(tile.rowMetadata)}u;
+const OUTPUT_ID_OFFSET: u32 = ${getViewElementOffset(tile.outputIds)}u;
+const OUTPUT_SCORE_OFFSET: u32 = ${getViewElementOffset(tile.outputScores)}u;
+const RESULT_COUNT_OFFSET: u32 = ${getViewElementOffset(tile.resultCounts)}u;
+${tile.candidateCounts ? `const CANDIDATE_COUNT_OFFSET: u32 = ${getViewElementOffset(tile.candidateCounts)}u;` : ''}
+${tile.validity ? `const QUERY_VALIDITY_OFFSET: u32 = ${getViewElementOffset(tile.validity)}u;` : ''}
+${tile.sourceRowIds ? `const QUERY_SOURCE_ID_OFFSET: u32 = ${getViewElementOffset(tile.sourceRowIds)}u;` : ''}
+@group(0) @binding(auto) var<storage, read> queryValues: array<f32>;
+@group(0) @binding(auto) var<storage, read_write> queryMetadata: array<u32>;
+@group(0) @binding(auto) var<storage, read_write> outputIds: array<u32>;
+@group(0) @binding(auto) var<storage, read_write> outputScores: array<u32>;
+@group(0) @binding(auto) var<storage, read_write> resultCounts: array<u32>;
+${tile.candidateCounts ? '@group(0) @binding(auto) var<storage, read_write> candidateCounts: array<u32>;' : ''}
+${tile.validity ? '@group(0) @binding(auto) var<storage, read> queryValidity: array<u32>;' : ''}
+${tile.sourceRowIds ? '@group(0) @binding(auto) var<storage, read> querySourceIds: array<u32>;' : ''}
+
+${getFiniteFloatWGSL()}
+
+@compute @workgroup_size(${SEARCH_WORKGROUP_SIZE})
+fn main(@builtin(workgroup_id) workgroupId: vec3u, @builtin(local_invocation_index) localInvocationIndex: u32) {
+  ${getInvocationIndexSource(id, tile.rowCount, graph)}
+  if (index >= QUERY_COUNT) { return; }
+  var valid = ${tile.validity ? 'queryValidity[QUERY_VALIDITY_OFFSET + index] != 0u' : 'true'};
+  for (var dimension = 0u; dimension < DIMENSIONS; dimension++) {
+    if (!isFiniteFloat(queryValues[QUERY_OFFSET + index * QUERY_STRIDE + dimension])) {
+      valid = false;
+    }
+  }
+  let sourceId = ${tile.sourceRowIds ? 'querySourceIds[QUERY_SOURCE_ID_OFFSET + index]' : 'QUERY_SOURCE_OFFSET + index'};
+  queryMetadata[QUERY_METADATA_OFFSET + index] = select(INVALID_ID, sourceId, valid && sourceId != INVALID_ID);
+  resultCounts[RESULT_COUNT_OFFSET + index] = 0u;
+  ${tile.candidateCounts ? 'candidateCounts[CANDIDATE_COUNT_OFFSET + index] = 0u;' : ''}
+  for (var resultIndex = 0u; resultIndex < MAX_RESULTS; resultIndex++) {
+    let outputIndex = index * MAX_RESULTS + resultIndex;
+    outputIds[OUTPUT_ID_OFFSET + outputIndex] = INVALID_ID;
+    outputScores[OUTPUT_SCORE_OFFSET + outputIndex] = ${search.metric === 'squared-euclidean' ? '0x7f800000u' : '0xff800000u'};
+  }
+}`;
+  addSearchComputationPass(
+    graph,
+    id,
+    source,
+    bindings,
+    tile.rowCount,
+    new Set(['queryValues', 'queryValidity', 'querySourceIds'])
+  );
+}
+
+function addPrepareDatasetTilePass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch,
+  tile: DatasetTile,
+  tileIndex: number,
+  eligibleSourceIds: GraphDataView<'uint32'>,
+  candidateMembership: CandidateMembershipIndex | undefined
+): void {
+  const id = `${search.id}-prepare-dataset-tile-${tileIndex}`;
+  const bindings: Record<string, GraphDataView> = {
+    datasetValues: tile.values,
+    eligibleSourceIds,
+    ...(tile.sourceRowIds ? {sourceRowIds: tile.sourceRowIds} : {}),
+    ...(tile.validity ? {sourceValidity: tile.validity} : {}),
+    ...(tile.filterMask ? {selectionMask: tile.filterMask} : {}),
+    ...(candidateMembership
+      ? {candidateIndexKeys: candidateMembership.keys}
+      : search.candidateIds
+        ? {candidateIds: search.candidateIds}
+        : {})
+  };
+  const source = /* wgsl */ `
+${getCommonWGSLConstants(search, tile.rowCount)}
+const ROW_COUNT: u32 = ${tile.rowCount}u;
+const DATASET_OFFSET: u32 = ${getViewElementOffset(tile.values)}u;
+const DATASET_STRIDE: u32 = ${tile.chunk.rowStride}u;
+const SOURCE_ROW_OFFSET: u32 = ${tile.sourceRowOffset}u;
+const ELIGIBLE_OFFSET: u32 = ${getViewElementOffset(eligibleSourceIds)}u;
+${tile.sourceRowIds ? `const SOURCE_ID_OFFSET: u32 = ${getViewElementOffset(tile.sourceRowIds)}u;` : ''}
+${tile.validity ? `const VALIDITY_OFFSET: u32 = ${getViewElementOffset(tile.validity)}u;` : ''}
+${tile.filterMask ? `const SELECTION_OFFSET: u32 = ${getViewElementOffset(tile.filterMask)}u;` : ''}
+${
+  candidateMembership
+    ? `const CANDIDATE_INDEX_OFFSET: u32 = ${getViewElementOffset(candidateMembership.keys)}u;\nconst CANDIDATE_INDEX_MASK: u32 = ${candidateMembership.capacity - 1}u;\nconst CANDIDATE_INDEX_CAPACITY: u32 = ${candidateMembership.capacity}u;`
+    : search.candidateIds
+      ? `const CANDIDATE_ID_OFFSET: u32 = ${getViewElementOffset(search.candidateIds)}u;\nconst CANDIDATE_ID_COUNT: u32 = ${search.candidateIds.length}u;`
+      : ''
+}
+@group(0) @binding(auto) var<storage, read> datasetValues: array<f32>;
+@group(0) @binding(auto) var<storage, read_write> eligibleSourceIds: array<u32>;
+${tile.sourceRowIds ? '@group(0) @binding(auto) var<storage, read> sourceRowIds: array<u32>;' : ''}
+${tile.validity ? '@group(0) @binding(auto) var<storage, read> sourceValidity: array<u32>;' : ''}
+${tile.filterMask ? '@group(0) @binding(auto) var<storage, read> selectionMask: array<u32>;' : ''}
+${
+  candidateMembership
+    ? '@group(0) @binding(auto) var<storage, read> candidateIndexKeys: array<u32>;'
+    : search.candidateIds
+      ? '@group(0) @binding(auto) var<storage, read> candidateIds: array<u32>;'
+      : ''
+}
+
+${getFiniteFloatWGSL()}
+${
+  candidateMembership
+    ? `fn hashCandidateKey(key: u32) -> u32 {\n  var value = key;\n  value = (value ^ (value >> 16u)) * 0x7feb352du;\n  value = (value ^ (value >> 15u)) * 0x846ca68bu;\n  return value ^ (value >> 16u);\n}`
+    : ''
+}
+
+@compute @workgroup_size(${SEARCH_WORKGROUP_SIZE})
+fn main(@builtin(workgroup_id) workgroupId: vec3u, @builtin(local_invocation_index) localInvocationIndex: u32) {
+  ${getInvocationIndexSource(id, tile.rowCount, graph)}
+  if (index >= ROW_COUNT) { return; }
+  let sourceId = ${tile.sourceRowIds ? 'sourceRowIds[SOURCE_ID_OFFSET + index]' : 'SOURCE_ROW_OFFSET + index'};
+  var eligible = sourceId != INVALID_ID;
+  ${tile.validity ? 'eligible = eligible && sourceValidity[VALIDITY_OFFSET + index] != 0u;' : ''}
+  ${tile.filterMask ? 'eligible = eligible && selectionMask[SELECTION_OFFSET + index] != 0u;' : ''}
+  for (var dimension = 0u; dimension < DIMENSIONS; dimension++) {
+    if (!isFiniteFloat(datasetValues[DATASET_OFFSET + index * DATASET_STRIDE + dimension])) {
+      eligible = false;
+    }
+  }
+  ${
+    candidateMembership
+      ? `var allowed = false;\n  let firstSlot = hashCandidateKey(sourceId) & CANDIDATE_INDEX_MASK;\n  for (var probe = 0u; probe < CANDIDATE_INDEX_CAPACITY; probe++) {\n    let stored = candidateIndexKeys[CANDIDATE_INDEX_OFFSET + ((firstSlot + probe) & CANDIDATE_INDEX_MASK)];\n    if (stored == INVALID_ID) { break; }\n    if (stored == sourceId) { allowed = true; break; }\n  }\n  eligible = eligible && allowed;`
+      : search.candidateIds
+        ? `var allowed = false;\n  for (var candidateIndex = 0u; candidateIndex < CANDIDATE_ID_COUNT; candidateIndex++) {\n    allowed = allowed || candidateIds[CANDIDATE_ID_OFFSET + candidateIndex] == sourceId;\n  }\n  eligible = eligible && allowed;`
+        : ''
+  }
+  eligibleSourceIds[ELIGIBLE_OFFSET + index] = select(INVALID_ID, sourceId, eligible);
+}`;
+  addSearchComputationPass(
+    graph,
+    id,
+    source,
+    bindings,
+    tile.rowCount,
+    new Set(Object.keys(bindings).filter(name => name !== 'eligibleSourceIds'))
+  );
+}
+
+function addCountCandidatesPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch,
+  datasetTile: DatasetTile,
+  queryTile: QueryTile,
+  datasetTileIndex: number,
+  queryTileIndex: number,
+  eligibleSourceIds: GraphDataView<'uint32'>,
+  queryFilterMask: GraphDataView<'uint32'> | undefined,
+  sourceSpan: number
+): void {
+  if (!queryTile.candidateCounts) return;
+  const id = `${search.id}-count-candidates-${datasetTileIndex}-${queryTileIndex}`;
+  const bindings: Record<string, GraphDataView> = {
+    eligibleSourceIds,
+    queryMetadata: queryTile.rowMetadata,
+    candidateCounts: queryTile.candidateCounts,
+    ...(queryFilterMask ? {queryFilterMask} : {})
+  };
+  const source = /* wgsl */ `
+${getCommonWGSLConstants(search, queryTile.rowCount)}
+const ROW_COUNT: u32 = ${datasetTile.rowCount}u;
+const ELIGIBLE_OFFSET: u32 = ${getViewElementOffset(eligibleSourceIds)}u;
+const QUERY_METADATA_OFFSET: u32 = ${getViewElementOffset(queryTile.rowMetadata)}u;
+const CANDIDATE_COUNT_OFFSET: u32 = ${getViewElementOffset(queryTile.candidateCounts)}u;
+${queryFilterMask ? `const QUERY_FILTER_OFFSET: u32 = ${getViewElementOffset(queryFilterMask)}u;\nconst SOURCE_SPAN: u32 = ${sourceSpan}u;` : ''}
+@group(0) @binding(auto) var<storage, read> eligibleSourceIds: array<u32>;
+@group(0) @binding(auto) var<storage, read> queryMetadata: array<u32>;
+@group(0) @binding(auto) var<storage, read_write> candidateCounts: array<u32>;
+${queryFilterMask ? '@group(0) @binding(auto) var<storage, read> queryFilterMask: array<u32>;' : ''}
+
+@compute @workgroup_size(${SEARCH_WORKGROUP_SIZE})
+fn main(@builtin(workgroup_id) workgroupId: vec3u, @builtin(local_invocation_index) localInvocationIndex: u32) {
+  ${getInvocationIndexSource(id, queryTile.rowCount, graph)}
+  if (index >= QUERY_COUNT) { return; }
+  let querySourceId = queryMetadata[QUERY_METADATA_OFFSET + index];
+  if (querySourceId == INVALID_ID) { return; }
+  var count = candidateCounts[CANDIDATE_COUNT_OFFSET + index];
+  for (var candidateIndex = 0u; candidateIndex < ROW_COUNT; candidateIndex++) {
+    let sourceId = eligibleSourceIds[ELIGIBLE_OFFSET + candidateIndex];
+    var accepted = sourceId != INVALID_ID;
+    ${search.excludeSelf ? 'accepted = accepted && sourceId != querySourceId;' : ''}
+    ${queryFilterMask ? 'accepted = accepted && queryFilterMask[QUERY_FILTER_OFFSET + index * SOURCE_SPAN + candidateIndex] != 0u;' : ''}
+    if (accepted) { count++; }
+  }
+  candidateCounts[CANDIDATE_COUNT_OFFSET + index] = count;
+}`;
+  addSearchComputationPass(
+    graph,
+    id,
+    source,
+    bindings,
+    queryTile.rowCount,
+    new Set(['eligibleSourceIds', 'queryMetadata', 'queryFilterMask'])
+  );
+}
+
+function addSearchDatasetTilePass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  search: GPUSimilaritySearch,
+  datasetTile: DatasetTile,
+  queryTile: QueryTile,
+  datasetTileIndex: number,
+  queryTileIndex: number,
+  eligibleSourceIds: GraphDataView<'uint32'>,
+  queryFilterMask: GraphDataView<'uint32'> | undefined,
+  sourceSpan: number
+): void {
+  const id = `${search.id}-search-dataset-${datasetTileIndex}-queries-${queryTileIndex}`;
+  const bindings: Record<string, GraphDataView> = {
+    queryValues: queryTile.values,
+    datasetValues: datasetTile.values,
+    eligibleSourceIds,
+    queryMetadata: queryTile.rowMetadata,
+    outputIds: queryTile.outputIds,
+    outputScores: queryTile.outputScores,
+    resultCounts: queryTile.resultCounts,
+    ...(queryFilterMask ? {queryFilterMask} : {})
+  };
+  const source = /* wgsl */ `
+${getCommonWGSLConstants(search, queryTile.rowCount)}
+const ROW_COUNT: u32 = ${datasetTile.rowCount}u;
+const QUERY_OFFSET: u32 = ${getViewElementOffset(queryTile.values)}u;
+const QUERY_STRIDE: u32 = ${queryTile.rowStride}u;
+const DATASET_OFFSET: u32 = ${getViewElementOffset(datasetTile.values)}u;
+const DATASET_STRIDE: u32 = ${datasetTile.chunk.rowStride}u;
+const ELIGIBLE_OFFSET: u32 = ${getViewElementOffset(eligibleSourceIds)}u;
+const QUERY_METADATA_OFFSET: u32 = ${getViewElementOffset(queryTile.rowMetadata)}u;
+const OUTPUT_ID_OFFSET: u32 = ${getViewElementOffset(queryTile.outputIds)}u;
+const OUTPUT_SCORE_OFFSET: u32 = ${getViewElementOffset(queryTile.outputScores)}u;
+const RESULT_COUNT_OFFSET: u32 = ${getViewElementOffset(queryTile.resultCounts)}u;
+${queryFilterMask ? `const QUERY_FILTER_OFFSET: u32 = ${getViewElementOffset(queryFilterMask)}u;\nconst SOURCE_SPAN: u32 = ${sourceSpan}u;` : ''}
+@group(0) @binding(auto) var<storage, read> queryValues: array<f32>;
+@group(0) @binding(auto) var<storage, read> datasetValues: array<f32>;
+@group(0) @binding(auto) var<storage, read> eligibleSourceIds: array<u32>;
+@group(0) @binding(auto) var<storage, read> queryMetadata: array<u32>;
+@group(0) @binding(auto) var<storage, read_write> outputIds: array<u32>;
+@group(0) @binding(auto) var<storage, read_write> outputScores: array<f32>;
+@group(0) @binding(auto) var<storage, read_write> resultCounts: array<u32>;
+${queryFilterMask ? '@group(0) @binding(auto) var<storage, read> queryFilterMask: array<u32>;' : ''}
+
+${getFiniteFloatWGSL()}
+
+fn candidateScore(queryIndex: u32, candidateIndex: u32) -> f32 {
+  var dotProduct = 0.0;
+  var queryNorm = 0.0;
+  var candidateNorm = 0.0;
+  var squaredDistance = 0.0;
+  var queryScale = 0.0;
+  var candidateScale = 0.0;
+  for (var dimension = 0u; dimension < DIMENSIONS; dimension++) {
+    let queryValue = queryValues[QUERY_OFFSET + queryIndex * QUERY_STRIDE + dimension];
+    let candidateValue = datasetValues[DATASET_OFFSET + candidateIndex * DATASET_STRIDE + dimension];
+    ${
+      search.metric === 'squared-euclidean'
+        ? 'let delta = queryValue - candidateValue;\n    squaredDistance += delta * delta;'
+        : search.metric === 'inner-product'
+          ? 'dotProduct += queryValue * candidateValue;'
+          : 'queryScale = max(queryScale, abs(queryValue));\n    candidateScale = max(candidateScale, abs(candidateValue));'
+    }
+  }
+  ${
+    search.metric === 'squared-euclidean'
+      ? 'return squaredDistance;'
+      : search.metric === 'inner-product'
+        ? 'return dotProduct;'
+        : `if (queryScale == 0.0 && candidateScale == 0.0) { return 1.0; }\n  if (queryScale == 0.0 || candidateScale == 0.0) { return 0.0; }\n  // Clamp divisors so reciprocal-lowering GPU backends never flush them to zero.\n  let minimumDivisor = bitcast<f32>(0x00800000u);\n  let maximumDivisor = bitcast<f32>(0x7e800000u);\n  let queryDivisor = clamp(queryScale, minimumDivisor, maximumDivisor);\n  let candidateDivisor = clamp(candidateScale, minimumDivisor, maximumDivisor);\n  for (var dimension = 0u; dimension < DIMENSIONS; dimension++) {\n    let normalizedQuery = queryValues[QUERY_OFFSET + queryIndex * QUERY_STRIDE + dimension] / queryDivisor;\n    let normalizedCandidate = datasetValues[DATASET_OFFSET + candidateIndex * DATASET_STRIDE + dimension] / candidateDivisor;\n    dotProduct += normalizedQuery * normalizedCandidate;\n    queryNorm += normalizedQuery * normalizedQuery;\n    candidateNorm += normalizedCandidate * normalizedCandidate;\n  }\n  return dotProduct / (sqrt(queryNorm) * sqrt(candidateNorm));`
+  }
+}
+
+fn isBetter(score: f32, sourceId: u32, previousScore: f32, previousId: u32) -> bool {
+  if (previousId == INVALID_ID) { return true; }
+  if (score == previousScore) { return sourceId < previousId; }
+  return score ${search.metric === 'squared-euclidean' ? '<' : '>'} previousScore;
+}
+
+@compute @workgroup_size(${SEARCH_WORKGROUP_SIZE})
+fn main(@builtin(workgroup_id) workgroupId: vec3u, @builtin(local_invocation_index) localInvocationIndex: u32) {
+  ${getInvocationIndexSource(id, queryTile.rowCount, graph)}
+  if (index >= QUERY_COUNT) { return; }
+  let querySourceId = queryMetadata[QUERY_METADATA_OFFSET + index];
+  if (querySourceId == INVALID_ID) { return; }
+  let queryResultOffset = index * MAX_RESULTS;
+  var resultCount = resultCounts[RESULT_COUNT_OFFSET + index];
+  for (var candidateIndex = 0u; candidateIndex < ROW_COUNT; candidateIndex++) {
+    let sourceId = eligibleSourceIds[ELIGIBLE_OFFSET + candidateIndex];
+    if (sourceId == INVALID_ID) { continue; }
+    ${search.excludeSelf ? 'if (sourceId == querySourceId) { continue; }' : ''}
+    ${queryFilterMask ? 'if (queryFilterMask[QUERY_FILTER_OFFSET + index * SOURCE_SPAN + candidateIndex] == 0u) { continue; }' : ''}
+    let score = candidateScore(index, candidateIndex);
+    // Finite source values may legitimately overflow a Float32 distance or inner product.
+    if ((bitcast<u32>(score) & 0x7fffffffu) > 0x7f800000u) { continue; }
+
+    var insertionIndex = min(resultCount, MAX_RESULTS);
+    for (var resultIndex = 0u; resultIndex < resultCount; resultIndex++) {
+      let currentId = outputIds[OUTPUT_ID_OFFSET + queryResultOffset + resultIndex];
+      let currentScore = outputScores[OUTPUT_SCORE_OFFSET + queryResultOffset + resultIndex];
+      if (isBetter(score, sourceId, currentScore, currentId)) {
+        insertionIndex = resultIndex;
+        break;
+      }
+    }
+    if (insertionIndex >= MAX_RESULTS) { continue; }
+    var destinationIndex = min(resultCount, MAX_RESULTS - 1u);
+    while (destinationIndex > insertionIndex) {
+      let destination = queryResultOffset + destinationIndex;
+      let previous = destination - 1u;
+      outputIds[OUTPUT_ID_OFFSET + destination] = outputIds[OUTPUT_ID_OFFSET + previous];
+      outputScores[OUTPUT_SCORE_OFFSET + destination] = outputScores[OUTPUT_SCORE_OFFSET + previous];
+      destinationIndex--;
+    }
+    outputIds[OUTPUT_ID_OFFSET + queryResultOffset + insertionIndex] = sourceId;
+    outputScores[OUTPUT_SCORE_OFFSET + queryResultOffset + insertionIndex] = score;
+    resultCount = min(resultCount + 1u, MAX_RESULTS);
+  }
+  resultCounts[RESULT_COUNT_OFFSET + index] = resultCount;
+}`;
+  addSearchComputationPass(
+    graph,
+    id,
+    source,
+    bindings,
+    queryTile.rowCount,
+    new Set([
+      'queryValues',
+      'datasetValues',
+      'eligibleSourceIds',
+      'queryMetadata',
+      'queryFilterMask'
+    ])
+  );
+}
+
+function addSearchComputationPass<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  id: string,
+  source: string,
+  views: Record<string, GraphDataView>,
+  elementCount: number,
+  readOnlyBindings: ReadonlySet<string>
+): void {
+  const resources: GraphBufferUse[] = Object.entries(views).map(([name, buffer]) => ({
+    buffer,
+    usage: readOnlyBindings.has(name) ? 'storage-read' : 'storage-read-write'
+  }));
+  const layout = getBoundedDispatchLayout(
+    id,
+    elementCount,
+    SEARCH_WORKGROUP_SIZE,
+    graph.device.limits.maxComputeWorkgroupsPerDimension
+  );
+  graph.addComputePass({
+    id,
+    resources,
+    compile: ({device}) => {
+      const computation = new Computation(device, {
+        id,
+        source,
+        shaderLayout: {
+          bindings: Object.keys(views).map((name, location) => ({
+            name,
+            type: 'storage' as const,
+            group: 0,
+            location
+          }))
+        }
+      });
+      return {
+        encode: ({computePass, getBuffer}) => {
+          const bindings: Record<string, Binding> = {};
+          for (const [name, view] of Object.entries(views)) {
+            if (getViewBindingRange(view).size > device.limits.maxStorageBufferBindingSize) {
+              throw new Error(`${id} storage binding exceeds maxStorageBufferBindingSize`);
+            }
+            bindings[name] = getViewBinding(view, getBuffer);
+          }
+          computation.setBindings(bindings);
+          computation.dispatch(computePass, layout.x, layout.y, layout.z);
+        },
+        destroy: () => computation.destroy()
+      };
+    }
+  });
+}
+
+function getInvocationIndexSource<Parameters>(
+  operationName: string,
+  elementCount: number,
+  graph: GPUCommandGraph<Parameters>
+): string {
+  const layout = getBoundedDispatchLayout(
+    operationName,
+    elementCount,
+    SEARCH_WORKGROUP_SIZE,
+    graph.device.limits.maxComputeWorkgroupsPerDimension
+  );
+  return getBoundedInvocationIndexSource(layout, SEARCH_WORKGROUP_SIZE);
+}
+
+function getCommonWGSLConstants(search: GPUSimilaritySearch, queryCount: number): string {
+  return `const INVALID_ID: u32 = 0xffffffffu;
+const DIMENSIONS: u32 = ${search.dataset.dimensions}u;
+const QUERY_COUNT: u32 = ${queryCount}u;
+const MAX_RESULTS: u32 = ${search.k}u;`;
+}
+
+function getFiniteFloatWGSL(): string {
+  return `fn isFiniteFloat(value: f32) -> bool {
+  return (bitcast<u32>(value) & 0x7f800000u) != 0x7f800000u;
+}`;
+}

--- a/modules/experimental/src/luvs/index.ts
+++ b/modules/experimental/src/luvs/index.ts
@@ -1,0 +1,19 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuVS.
+
+export {
+  importGPUEmbeddingTable,
+  importGPUEmbeddingVector,
+  type ImportGPUEmbeddingTableOptions,
+  type ImportGPUEmbeddingVectorOptions
+} from './embedding-matrix';
+export {GPUSimilaritySearch} from './gpu-similarity-search';
+export type {
+  GPUEmbeddingFilterMask,
+  GPUEmbeddingMetric,
+  GPUSimilaritySearchProps,
+  GraphEmbeddingMatrix,
+  GraphEmbeddingMatrixChunk
+} from './types';

--- a/modules/experimental/src/luvs/types.ts
+++ b/modules/experimental/src/luvs/types.ts
@@ -1,0 +1,72 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuVS.
+
+import type {GraphDataView, GraphVectorView} from '../gpu-primitives/gpu-command-graph';
+
+/** Exact distance or similarity used to order embedding search results. */
+export type GPUEmbeddingMetric = 'squared-euclidean' | 'inner-product' | 'cosine';
+
+/** Non-owning graph metadata and borrowed views for one fixed-size-list embedding chunk. */
+export type GraphEmbeddingMatrixChunk = {
+  /** Flat scalar view beginning at the first logical embedding row. */
+  readonly values: GraphDataView<'float32'>;
+  /** Number of logical embedding rows represented by this graph view. */
+  readonly rowCount: number;
+  /** Number of float32 elements between consecutive embedding rows. */
+  readonly rowStride: number;
+  /** Physical byte offset of the first logical row in the values buffer. */
+  readonly byteOffset: number;
+  /** Stable source position of the first logical row in this chunk. */
+  readonly sourceRowOffset: number;
+  /** Optional chunk-row-aligned stable source identifiers. */
+  readonly sourceRowIds?: GraphDataView<'uint32'>;
+  /** Optional chunk-row-aligned nonzero-valid row flags. */
+  readonly validity?: GraphDataView<'uint32'>;
+};
+
+/** Non-owning embedding-column view imported into one caller-owned GPU command graph. */
+export type GraphEmbeddingMatrix = {
+  /** Logical embedding dimensionality, independent from GPU vertex formats. */
+  readonly dimensions: number;
+  /** Total number of rows across original source chunks. */
+  readonly rowCount: number;
+  /** Ordered, source-preserving views over GPUData chunks owned by the source table or vector. */
+  readonly chunks: readonly GraphEmbeddingMatrixChunk[];
+};
+
+/** Source-aligned selection flags, including chunk-preserving LuxFilter output. */
+export type GPUEmbeddingFilterMask = GraphDataView<'uint32'> | GraphVectorView<'uint32'>;
+
+/** Properties accepted by an exact, graph-native embedding similarity search. */
+export type GPUSimilaritySearchProps = {
+  /** Prefix shared by generated graph nodes and bounded scratch resources. */
+  id?: string;
+  /** Chunk-preserving candidate embedding rows. */
+  dataset: GraphEmbeddingMatrix;
+  /** Chunk-preserving query embedding rows with matching dimensions. */
+  queries: GraphEmbeddingMatrix;
+  /** Caller-owned packed result identifiers, with `queryCount * k` slots. */
+  outputIds: GraphDataView<'uint32'>;
+  /** Caller-owned packed float32 distances or similarity scores. */
+  outputScores: GraphDataView<'float32'>;
+  /** Caller-owned number of actual results for each query row. */
+  resultCounts: GraphDataView<'uint32'>;
+  /** Optional caller-owned number of eligible candidates for each query. */
+  candidateCounts?: GraphDataView<'uint32'>;
+  /** Requested maximum result count for each query. */
+  k: number;
+  /** Distance or similarity metric. Defaults to squared Euclidean distance. */
+  metric?: GPUEmbeddingMetric;
+  /** Optional source-row-aligned selection flags, including LuxFilter masks. */
+  filterMask?: GPUEmbeddingFilterMask;
+  /** Optional stable source identifiers restricting eligible candidates. */
+  candidateIds?: GraphDataView<'uint32'>;
+  /** Optional packed query-major, source-row-aligned selection flags. */
+  queryFilterMask?: GraphDataView<'uint32'>;
+  /** Reject candidates whose stable source ID matches their query row ID. */
+  excludeSelf?: boolean;
+  /** Optional upper bound on dataset rows visited by one graph pass. */
+  tileSize?: number;
+};

--- a/modules/experimental/test/index.ts
+++ b/modules/experimental/test/index.ts
@@ -41,3 +41,4 @@ import './ludf/lu-data-frame.spec';
 import './luxfilter';
 import './luproj/luproj.spec';
 import './luproj/projection-benchmark.spec';
+import './luvs/gpu-similarity-search.spec';

--- a/modules/experimental/test/luvs/gpu-similarity-search.node.spec.ts
+++ b/modules/experimental/test/luvs/gpu-similarity-search.node.spec.ts
@@ -1,0 +1,5 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import './gpu-similarity-search.spec';

--- a/modules/experimental/test/luvs/gpu-similarity-search.spec.ts
+++ b/modules/experimental/test/luvs/gpu-similarity-search.spec.ts
@@ -1,0 +1,2166 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {makeGPUTableFromArrowTable} from '@luma.gl/arrow';
+import {Buffer, type Device, type ShaderLayout} from '@luma.gl/core';
+import {GPUCommandGraph, type GraphDataView, type GraphVectorView} from '@luma.gl/experimental';
+import {GPUData, GPURecordBatch, GPUTable, GPUVector, type FixedSizeList} from '@luma.gl/tables';
+import {getWebGPUTestDevice, NullDevice} from '@luma.gl/test-utils';
+import * as arrow from 'apache-arrow';
+import test, {type Test} from 'test/utils/vitest-tape';
+import {importGPUEmbeddingTable, importGPUEmbeddingVector} from '../../src/luvs/embedding-matrix';
+import {GPUSimilaritySearch} from '../../src/luvs/gpu-similarity-search';
+import type {GPUEmbeddingMetric, GraphEmbeddingMatrix} from '../../src/luvs/types';
+
+const INVALID_SOURCE_ROW_ID = 0xffff_ffff;
+
+type EmbeddingChunkFixture = {
+  rows: readonly (readonly number[])[];
+  rowStride?: number;
+  prefix?: readonly number[];
+  sourceRowOffset?: number;
+  sourceRowIds?: readonly number[];
+  validity?: readonly number[];
+};
+
+type SimilaritySearchFixture = {
+  dimensions: number;
+  dataset: readonly EmbeddingChunkFixture[];
+  queries: readonly EmbeddingChunkFixture[];
+  k: number;
+  metric?: GPUEmbeddingMetric;
+  filterMask?: readonly number[];
+  chunkedFilterMask?: readonly (readonly number[])[];
+  queryFilterMask?: readonly number[];
+  candidateIds?: readonly number[];
+  excludeSelf?: boolean;
+  tileSize?: number;
+  candidateCounts?: boolean;
+};
+
+type CPUSourceEmbeddingRow = {
+  values: number[];
+  sourceRowId: number;
+  sourceRowPosition: number;
+  valid: boolean;
+  chunkIndex: number;
+  chunkRowIndex: number;
+};
+
+/** One caller-owned, row-oriented fixed-size-list column plus optional sibling metadata. */
+type GPUEmbeddingVectorFixture = {
+  vector: GPUVector<FixedSizeList<'float32'>>;
+  sourceRowIds?: GPUVector<'uint32'>;
+  validity?: GPUVector<'uint32'>;
+  sourceRowOffsets: number[];
+  rows: CPUSourceEmbeddingRow[];
+};
+
+type CPUSimilarityResult = {
+  sourceRowIds: number[];
+  scores: number[];
+  resultCounts: number[];
+  candidateCounts: number[];
+};
+
+type SearchExecution = {
+  sourceRowIds: number[];
+  scores: number[];
+  resultCounts: number[];
+  candidateCounts?: number[];
+  nodeOrder: readonly string[];
+  logicalTransientCount: number;
+  physicalTransientCount: number;
+  importedBuffersSurviveDestruction: boolean;
+};
+
+let fixtureSequence = 0;
+
+test('GPUSimilaritySearch CPU oracle independently defines metrics, zero vectors, and tie ordering', t => {
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [1, 0],
+          [-1, 0],
+          [0, 0],
+          [1, 0]
+        ],
+        sourceRowIds: [9, 4, 2, 3]
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [1, 0],
+          [0, 0]
+        ]
+      }
+    ],
+    k: 4,
+    candidateCounts: true
+  };
+  const dataset = getCPUFixtureRows(fixture.dataset, fixture.dimensions);
+  const queries = getCPUFixtureRows(fixture.queries, fixture.dimensions);
+
+  const euclidean = getIndependentCPUSimilarityResults(fixture, dataset, queries);
+  t.deepEqual(
+    euclidean.sourceRowIds.slice(0, 4),
+    [3, 9, 2, 4],
+    'distance ties use stable source IDs'
+  );
+  t.deepEqual(euclidean.scores.slice(0, 4), [0, 0, 1, 4], 'squared Euclidean distances are exact');
+
+  const innerProduct = getIndependentCPUSimilarityResults(
+    {...fixture, metric: 'inner-product'},
+    dataset,
+    queries
+  );
+  t.deepEqual(
+    innerProduct.sourceRowIds.slice(0, 4),
+    [3, 9, 2, 4],
+    'inner products sort descending'
+  );
+  t.deepEqual(
+    innerProduct.scores.slice(0, 4),
+    [1, 1, 0, -1],
+    'inner-product values are independent'
+  );
+
+  const cosine = getIndependentCPUSimilarityResults(
+    {...fixture, metric: 'cosine'},
+    dataset,
+    queries
+  );
+  t.deepEqual(
+    cosine.sourceRowIds.slice(4, 8),
+    [2, 3, 4, 9],
+    'zero-query cosine ties remain stable'
+  );
+  t.deepEqual(
+    cosine.scores.slice(4, 8),
+    [1, 0, 0, 0],
+    'two zero vectors have unit cosine similarity'
+  );
+  t.deepEqual(cosine.candidateCounts, [4, 4], 'candidate counts remain independent from top-K');
+  t.end();
+});
+
+test('GPUSimilaritySearch validates generic matrix shape and independent writable outputs', t => {
+  const device = new NullDevice({});
+  Object.defineProperty(device, 'type', {value: 'webgpu'});
+  const graph = new GPUCommandGraph(device, {id: 'similarity-node-validation'});
+  const ownedVectors: GPUVector[] = [];
+  const dataset = createEmbeddingVector(
+    device,
+    'validation-dataset',
+    2,
+    [{rows: [[1, 2]]}],
+    ownedVectors
+  );
+  const queries = createEmbeddingVector(
+    device,
+    'validation-queries',
+    2,
+    [{rows: [[1, 2]]}],
+    ownedVectors
+  );
+  const importedDataset = importEmbeddingFixture(graph, dataset, 'dataset');
+  const importedQueries = importEmbeddingFixture(graph, queries, 'queries');
+  const outputIds = createUint32View(graph, ownedVectors, 'output-ids', 1);
+  const outputScores = createFloat32View(graph, ownedVectors, 'output-scores', 1);
+  const resultCounts = createUint32View(graph, ownedVectors, 'result-counts', 1);
+  const validProps = {
+    dataset: importedDataset,
+    queries: importedQueries,
+    outputIds,
+    outputScores,
+    resultCounts,
+    k: 1
+  };
+
+  t.doesNotThrow(
+    () => new GPUSimilaritySearch(validProps),
+    'accepts distinct caller-owned buffers'
+  );
+  t.throws(
+    () => new GPUSimilaritySearch({...validProps, k: -1}),
+    /result count/,
+    'rejects negative result counts'
+  );
+  t.throws(
+    () => new GPUSimilaritySearch({...validProps, tileSize: 0}),
+    /tileSize/,
+    'rejects nonpositive tile bounds'
+  );
+  t.throws(
+    () =>
+      new GPUSimilaritySearch({
+        ...validProps,
+        metric: 'euclidean' as GPUEmbeddingMetric
+      }),
+    /metric/,
+    'rejects unsupported metrics'
+  );
+  t.throws(
+    () => new GPUSimilaritySearch({...validProps, resultCounts: outputIds}),
+    /must not overlap/,
+    'rejects aliased writable result buffers'
+  );
+  const malformedStride = new GPUData<FixedSizeList<'float32', 2>>({
+    buffer: dataset.vector.data[0].buffer,
+    format: 'fixed-size-list<float32,2>',
+    length: 1,
+    byteStride: 2 * Float32Array.BYTES_PER_ELEMENT,
+    rowByteLength: 2 * Float32Array.BYTES_PER_ELEMENT
+  });
+  Object.defineProperty(malformedStride, 'byteStride', {value: Float32Array.BYTES_PER_ELEMENT});
+  const malformedVector = new GPUVector({
+    type: 'data',
+    name: 'malformed-embedding-stride',
+    format: 'fixed-size-list<float32,2>',
+    data: [malformedStride]
+  });
+  t.throws(
+    () => importGPUEmbeddingVector(graph, malformedVector),
+    /aligned, bounded fixed-size float32 rows/,
+    'rejects physical row strides narrower than the embedding dimensions'
+  );
+
+  const mismatchedRows = new GPUVector({
+    type: 'data',
+    name: 'mismatched-embedding-rows',
+    format: 'fixed-size-list<float32,2>',
+    data: dataset.vector.data
+  });
+  Object.defineProperty(mismatchedRows, 'length', {value: 2});
+  t.throws(
+    () => importGPUEmbeddingVector(graph, mismatchedRows),
+    /source chunk rows/,
+    'rejects aggregate row counts that disagree with source topology'
+  );
+  t.throws(
+    () =>
+      importGPUEmbeddingVector(graph, dataset.vector, {
+        id: 'invalid-source-offset',
+        sourceRowOffset: INVALID_SOURCE_ROW_ID
+      }),
+    /aligned, bounded fixed-size float32 rows/,
+    'reserves the maximum uint32 value for invalid result slots'
+  );
+
+  const boundedValues = new GPUVector<FixedSizeList<'float32', 2>>({
+    type: 'buffer',
+    name: 'bounded-embedding-values',
+    buffer: device.createBuffer({
+      data: Float32Array.from([1, 2, 90, 91]),
+      usage: Buffer.STORAGE | Buffer.COPY_DST
+    }),
+    format: 'fixed-size-list<float32,2>',
+    length: 1,
+    byteOffset: 2 * Float32Array.BYTES_PER_ELEMENT,
+    ownsBuffer: true
+  });
+  Object.defineProperty(boundedValues, 'length', {value: 2});
+  Object.defineProperty(boundedValues.data[0], 'length', {value: 2});
+  Object.defineProperty(boundedValues.data[0], 'valueLength', {value: 4});
+  ownedVectors.push(boundedValues);
+  t.throws(
+    () => importGPUEmbeddingVector(graph, boundedValues),
+    /declared GPUData byte range/,
+    'never exposes unrelated bytes beyond the declared GPUData slice'
+  );
+
+  t.throws(
+    () => importGPUEmbeddingVector(graph, dataset.vector, {dimensions: 3}),
+    /fit within its fixed-size-list rows/,
+    'rejects meaningful dimensions beyond the physical fixed-size-list cardinality'
+  );
+  t.throws(
+    () => importGPUEmbeddingVector(graph, dataset.vector, {dimensions: 0}),
+    /fit within its fixed-size-list rows/,
+    'rejects zero meaningful embedding dimensions'
+  );
+
+  destroyOwnedVectors(ownedVectors);
+  t.end();
+});
+
+test('importGPUEmbeddingTable borrows fixed-size-list batches and row-aligned table metadata', t => {
+  const device = new NullDevice({});
+  Object.defineProperty(device, 'type', {value: 'webgpu'});
+  const graph = new GPUCommandGraph(device, {id: 'embedding-table-node-validation'});
+  const ownedVectors: GPUVector[] = [];
+  const fixture = createEmbeddingVector(
+    device,
+    'table-source',
+    3,
+    [
+      {
+        rows: [
+          [1, 2, 3],
+          [4, 5, 6]
+        ],
+        rowStride: 5,
+        prefix: [777],
+        sourceRowOffset: 9,
+        sourceRowIds: [90, 12]
+      },
+      {rows: [], sourceRowOffset: 11},
+      {
+        rows: [[7, 8, 9]],
+        sourceRowOffset: 27,
+        sourceRowIds: [44],
+        validity: [0]
+      }
+    ],
+    ownedVectors
+  );
+  const batches = fixture.vector.data.map(
+    (data, batchIndex) =>
+      new GPURecordBatch({
+        gpuData: {
+          embedding: data,
+          stableId: fixture.sourceRowIds!.data[batchIndex],
+          valid: fixture.validity!.data[batchIndex]
+        },
+        sourceInfo: {
+          sourceBatchIndex: batchIndex,
+          sourceRowIndexOffset: fixture.sourceRowOffsets[batchIndex],
+          sourceRowCount: data.length
+        }
+      })
+  );
+  const table = new GPUTable({batches});
+  const imported = importGPUEmbeddingTable(graph, table, {
+    column: 'embedding',
+    sourceRowIds: 'stableId',
+    validity: 'valid',
+    id: 'table-column'
+  });
+
+  t.equal(imported.dimensions, 3, 'embedding dimensions come from fixed-size-list schema metadata');
+  t.equal(imported.rowCount, 3, 'logical row count is independent from flattened coordinate count');
+  t.deepEqual(
+    imported.chunks.map(chunk => chunk.rowCount),
+    [2, 0, 1],
+    'empty and uneven record-batch boundaries are preserved without packing'
+  );
+  t.deepEqual(
+    imported.chunks.map(chunk => chunk.sourceRowOffset),
+    [9, 11, 27],
+    'existing record-batch source provenance becomes the implicit stable row positions'
+  );
+  t.equal(imported.chunks[0].rowStride, 5, 'padded physical row stride stays in float32 units');
+  t.equal(
+    imported.chunks[0].byteOffset,
+    Float32Array.BYTES_PER_ELEMENT,
+    'nonzero GPUData offsets are preserved'
+  );
+  t.equal(imported.chunks[0].values.length, 8, 'the final row does not require trailing padding');
+  t.ok(
+    imported.chunks.every(chunk => chunk.sourceRowIds),
+    'stable IDs remain table-owned columns'
+  );
+  t.ok(
+    imported.chunks.every(chunk => chunk.validity),
+    'validity remains a table-owned column'
+  );
+  t.equal(table.gpuVectors.embedding.length, 3, 'the aggregate source column remains row-oriented');
+  t.equal(table.gpuVectors.embedding.valueLength, 9, 'flattened value count remains separate');
+
+  const singleBatch = importGPUEmbeddingTable(graph, batches[0], {
+    column: 'embedding',
+    dimensions: 2,
+    sourceRowIds: 'stableId',
+    validity: 'valid',
+    id: 'single-batch'
+  });
+  t.equal(singleBatch.dimensions, 2, 'callers may explicitly ignore trailing fixed-list features');
+  t.equal(singleBatch.chunks[0].rowStride, 5, 'physical row stride survives feature truncation');
+  t.equal(singleBatch.chunks[0].values.length, 7, 'only meaningful coordinates enter the view');
+
+  const sourceIdData = fixture.sourceRowIds!.data[0];
+  Object.defineProperty(sourceIdData, 'nullBitmap', {value: Uint8Array.from([0b11])});
+  t.doesNotThrow(
+    () =>
+      importGPUEmbeddingTable(graph, batches[0], {
+        id: 'nullable-schema-all-valid',
+        column: 'embedding',
+        sourceRowIds: 'stableId'
+      }),
+    'nullable source-ID schemas are allowed when every actual row remains valid'
+  );
+  Object.defineProperty(sourceIdData, 'nullBitmap', {value: Uint8Array.from([0b01])});
+  t.throws(
+    () =>
+      importGPUEmbeddingVector(graph, fixture.vector, {
+        id: 'nullable-source-id-vector',
+        sourceRowIds: fixture.sourceRowIds
+      }),
+    /source-row IDs must not contain null/,
+    'vector imports reject actual null stable IDs without GPU readback'
+  );
+  t.throws(
+    () =>
+      importGPUEmbeddingTable(graph, table, {
+        id: 'nullable-source-id-table',
+        column: 'embedding',
+        sourceRowIds: 'stableId'
+      }),
+    /source-row IDs must not contain null/,
+    'table imports reject null stable IDs before treating physical zero as a real ID'
+  );
+  Object.defineProperty(sourceIdData, 'nullBitmap', {value: undefined});
+
+  const embeddingData = fixture.vector.data[0];
+  Object.defineProperty(embeddingData, 'nullBitmap', {value: Uint8Array.from([0b01])});
+  t.throws(
+    () => importGPUEmbeddingVector(graph, fixture.vector, {id: 'nullable-vector-without-mask'}),
+    /null values require explicit GPU validity flags/,
+    'nullable vector rows cannot silently enter search without a caller-owned GPU validity mask'
+  );
+  t.throws(
+    () =>
+      importGPUEmbeddingTable(graph, batches[0], {
+        id: 'nullable-table-without-mask',
+        column: 'embedding'
+      }),
+    /null values require explicit GPU validity flags/,
+    'nullable table rows cannot silently enter search without a selected GPU validity column'
+  );
+  t.doesNotThrow(
+    () =>
+      importGPUEmbeddingVector(graph, fixture.vector, {
+        id: 'nullable-vector-with-mask',
+        validity: fixture.validity
+      }),
+    'an explicitly selected GPU validity vector permits intentional nullable-row filtering'
+  );
+  t.doesNotThrow(
+    () =>
+      importGPUEmbeddingTable(graph, batches[0], {
+        id: 'nullable-table-with-mask',
+        column: 'embedding',
+        validity: 'valid'
+      }),
+    'an explicitly selected GPU validity column permits intentional nullable-row filtering'
+  );
+  Object.defineProperty(embeddingData, 'nullBitmap', {value: undefined});
+
+  t.throws(
+    () => importGPUEmbeddingTable(graph, table, {column: 'missing'}),
+    /does not contain column/,
+    'rejects missing embedding columns'
+  );
+  t.throws(
+    () => importGPUEmbeddingTable(graph, table, {column: 'embedding', validity: 'missing'}),
+    /row-aligned uint32 column/,
+    'rejects absent explicitly requested validity columns'
+  );
+  t.throws(
+    () => importGPUEmbeddingTable(graph, table, {column: 'embedding', dimensions: 4}),
+    /fit within its fixed-size-list rows/,
+    'rejects meaningful dimensions beyond the existing fixed-list cardinality'
+  );
+
+  const compiled = graph.compile();
+  compiled.destroy();
+  t.ok(
+    ownedVectors.every(vector => vector.data.every(chunk => !chunk.buffer.destroyed)),
+    'graph destruction never destroys buffers owned by existing table columns'
+  );
+  destroyOwnedVectors(ownedVectors);
+  t.end();
+});
+
+test('importGPUEmbeddingTable retains schema dimensions for an empty caller-owned GPU table', t => {
+  const device = new NullDevice({});
+  Object.defineProperty(device, 'type', {value: 'webgpu'});
+  const graph = new GPUCommandGraph(device, {id: 'empty-embedding-table'});
+  const table = new GPUTable({
+    schema: {
+      fields: [{name: 'embedding', format: 'fixed-size-list<float32,768>'}],
+      metadata: new Map()
+    }
+  });
+  const imported = importGPUEmbeddingTable(graph, table, {column: 'embedding'});
+  t.equal(imported.dimensions, 768, 'schema metadata remains available without uploaded batches');
+  t.equal(imported.rowCount, 0, 'empty table imports have no logical rows');
+  t.deepEqual(imported.chunks, [], 'no placeholder GPU allocations are invented');
+  t.end();
+});
+
+test('GPUSimilaritySearch consumes nullable Arrow fixed-size lists through ordinary GPU tables', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const embeddingType = new arrow.FixedSizeList(
+    4,
+    new arrow.Field('feature', new arrow.Float32(), true)
+  );
+  const firstBatch = new arrow.Table({
+    embedding: arrow.vectorFromArray(
+      [
+        [0, 0, 0, null],
+        [1, 0, 0, null]
+      ],
+      embeddingType
+    ),
+    sourceIds: arrow.vectorFromArray([42, 7], new arrow.Uint32())
+  }).batches[0];
+  const secondBatch = new arrow.Table({
+    embedding: arrow.vectorFromArray([null, [0, 0, 1, null]], embeddingType),
+    sourceIds: arrow.vectorFromArray([99, 3], new arrow.Uint32())
+  }).batches[0];
+  const querySource = new arrow.Table({
+    embedding: arrow.vectorFromArray([[0, 0, 0, null]], embeddingType),
+    sourceIds: arrow.vectorFromArray([500], new arrow.Uint32())
+  });
+  const shaderLayout: ShaderLayout = {
+    attributes: [],
+    bindings: [
+      {name: 'embedding', type: 'read-only-storage', group: 0, location: 0},
+      {name: 'sourceIds', type: 'read-only-storage', group: 0, location: 1}
+    ]
+  };
+  const tableOptions = {
+    shaderLayout,
+    fixedSizeListColumns: ['embedding'],
+    validityColumns: {embedding: {name: 'embeddingValidity', dimensions: 3}}
+  };
+  const datasetTable = makeGPUTableFromArrowTable(
+    device,
+    new arrow.Table([firstBatch, secondBatch]),
+    tableOptions
+  );
+  const queryTable = makeGPUTableFromArrowTable(device, querySource, tableOptions);
+  const graph = new GPUCommandGraph(device, {id: 'arrow-fixed-size-list-similarity'});
+  const ownedVectors: GPUVector[] = [];
+  t.throws(
+    () =>
+      importGPUEmbeddingTable(graph, datasetTable, {
+        id: 'dataset-without-validity',
+        column: 'embedding',
+        dimensions: 3,
+        sourceRowIds: 'sourceIds'
+      }),
+    /null values require explicit GPU validity flags/,
+    'nullable Arrow parent rows and nullable padding cannot bypass explicit GPU validity'
+  );
+  const dataset = importGPUEmbeddingTable(graph, datasetTable, {
+    id: 'dataset',
+    column: 'embedding',
+    dimensions: 3,
+    sourceRowIds: 'sourceIds',
+    validity: 'embeddingValidity'
+  });
+  const queries = importGPUEmbeddingTable(graph, queryTable, {
+    id: 'queries',
+    column: 'embedding',
+    dimensions: 3,
+    validity: 'embeddingValidity'
+  });
+  const outputIds = createUint32View(graph, ownedVectors, 'arrow-result-ids', 3);
+  const outputScores = createFloat32View(graph, ownedVectors, 'arrow-result-scores', 3);
+  const resultCounts = createUint32View(graph, ownedVectors, 'arrow-result-counts', 1);
+  const candidateCounts = createUint32View(graph, ownedVectors, 'arrow-candidate-counts', 1);
+
+  new GPUSimilaritySearch({
+    id: 'arrow-fixed-size-list',
+    dataset,
+    queries,
+    outputIds,
+    outputScores,
+    resultCounts,
+    candidateCounts,
+    k: 3
+  }).addToGraph(graph);
+  const compiled = graph.compile();
+  try {
+    const encoder = device.createCommandEncoder({id: 'arrow-fixed-size-list-encoder'});
+    compiled.encode(encoder, {parameters: undefined});
+    device.submit(encoder.finish());
+
+    t.equal(datasetTable.gpuVectors.embedding.format, 'fixed-size-list<float32,4>');
+    t.equal(datasetTable.gpuVectors.embedding.length, 4, 'embedding values remain table rows');
+    t.equal(
+      datasetTable.gpuVectors.embedding.valueLength,
+      16,
+      'physical coordinates remain values'
+    );
+    t.deepEqual(
+      dataset.chunks.map(chunk => chunk.rowCount),
+      [2, 2],
+      'Arrow batches stay distinct'
+    );
+    t.equal(
+      dataset.dimensions,
+      3,
+      'explicit dimensions ignore the nullable fourth padding feature'
+    );
+    t.equal(dataset.chunks[0].rowStride, 4, 'physical Arrow fixed-list cardinality stays intact');
+    t.deepEqual(
+      await readUint32View(ownedVectors, outputIds, 3),
+      [42, 3, 7],
+      'parent-null rows are removed while nullable padding and stable Arrow source IDs are honored'
+    );
+    t.deepEqual(await readFloat32View(ownedVectors, outputScores, 3), [0, 1, 1]);
+    t.deepEqual(await readUint32View(ownedVectors, resultCounts, 1), [3]);
+    t.deepEqual(await readUint32View(ownedVectors, candidateCounts, 1), [3]);
+
+    compiled.destroy();
+    t.ok(
+      datasetTable.batches.every(batch =>
+        Object.values(batch.gpuData).every(data => !data.buffer.destroyed)
+      ),
+      'graph destruction never takes ownership away from the ordinary GPU table'
+    );
+  } finally {
+    compiled.destroy();
+    destroyOwnedVectors(ownedVectors);
+    datasetTable.destroy();
+    queryTable.destroy();
+  }
+  t.end();
+});
+
+test('GPUSimilaritySearch searches 384-, 768-, and 1536-dimensional fixed-size GPU table rows', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  for (const dimensions of [384, 768, 1536]) {
+    const identifier = `high-dimensional-table-${dimensions}`;
+    const format: FixedSizeList<'float32'> = `fixed-size-list<float32,${dimensions}>`;
+    const physicalRowStride = dimensions + 1;
+    const datasetValues = new Float32Array(1 + physicalRowStride + dimensions);
+    datasetValues[0] = 777;
+    datasetValues[1] = 1;
+    datasetValues[1 + physicalRowStride + dimensions - 1] = 1;
+    const queryValues = new Float32Array(dimensions);
+    queryValues[dimensions - 1] = 1;
+    const datasetData = new GPUData<FixedSizeList<'float32'>>({
+      buffer: device.createBuffer({
+        id: `${identifier}-dataset-values`,
+        data: datasetValues,
+        usage: Buffer.STORAGE | Buffer.COPY_DST
+      }),
+      format,
+      length: 2,
+      byteOffset: Float32Array.BYTES_PER_ELEMENT,
+      byteStride: physicalRowStride * Float32Array.BYTES_PER_ELEMENT,
+      ownsBuffer: true
+    });
+    const sourceIds = new GPUData<'uint32'>({
+      buffer: device.createBuffer({
+        id: `${identifier}-source-ids`,
+        data: Uint32Array.from([80, 7]),
+        usage: Buffer.STORAGE | Buffer.COPY_DST
+      }),
+      format: 'uint32',
+      length: 2,
+      ownsBuffer: true
+    });
+    const queryData = new GPUData<FixedSizeList<'float32'>>({
+      buffer: device.createBuffer({
+        id: `${identifier}-query-values`,
+        data: queryValues,
+        usage: Buffer.STORAGE | Buffer.COPY_DST
+      }),
+      format,
+      length: 1,
+      ownsBuffer: true
+    });
+    const datasetTable = new GPUTable({
+      batches: [
+        new GPURecordBatch({
+          gpuData: {embedding: datasetData, sourceIds},
+          sourceInfo: {sourceBatchIndex: 0, sourceRowIndexOffset: 5, sourceRowCount: 2}
+        })
+      ]
+    });
+    const queryTable = new GPUTable({
+      batches: [new GPURecordBatch({gpuData: {embedding: queryData}})]
+    });
+    const graph = new GPUCommandGraph(device, {id: identifier});
+    const ownedVectors: GPUVector[] = [];
+    const dataset = importGPUEmbeddingTable(graph, datasetTable, {
+      id: `${identifier}-dataset`,
+      column: 'embedding',
+      sourceRowIds: 'sourceIds'
+    });
+    const queries = importGPUEmbeddingTable(graph, queryTable, {
+      id: `${identifier}-query`,
+      column: 'embedding'
+    });
+    const outputIds = createUint32View(graph, ownedVectors, `${identifier}-result-ids`, 2);
+    const outputScores = createFloat32View(graph, ownedVectors, `${identifier}-result-scores`, 2);
+    const resultCounts = createUint32View(graph, ownedVectors, `${identifier}-result-counts`, 1);
+    new GPUSimilaritySearch({
+      id: `${identifier}-search`,
+      dataset,
+      queries,
+      outputIds,
+      outputScores,
+      resultCounts,
+      k: 2,
+      tileSize: 1
+    }).addToGraph(graph);
+    const compiled = graph.compile();
+
+    try {
+      const encoder = device.createCommandEncoder({id: `${identifier}-encoder`});
+      compiled.encode(encoder, {parameters: undefined});
+      device.submit(encoder.finish());
+      t.equal(dataset.dimensions, dimensions, `${dimensions} features derive from table schema`);
+      t.equal(dataset.chunks[0].rowStride, dimensions + 1, 'physical row padding is retained');
+      t.equal(dataset.chunks[0].byteOffset, 4, 'table chunk offsets survive graph import');
+      t.equal(
+        dataset.chunks[0].values.length,
+        2 * dimensions + 1,
+        'the final padded row needs only its meaningful payload'
+      );
+      t.equal(dataset.chunks[0].sourceRowOffset, 5, 'record-batch source provenance survives');
+      t.deepEqual(
+        await readUint32View(ownedVectors, outputIds, 2),
+        [7, 80],
+        `${dimensions}-dimensional rows search their original table-owned buffers`
+      );
+      t.deepEqual(await readFloat32View(ownedVectors, outputScores, 2), [0, 2]);
+      t.deepEqual(await readUint32View(ownedVectors, resultCounts, 1), [2]);
+    } finally {
+      compiled.destroy();
+      destroyOwnedVectors(ownedVectors);
+      datasetTable.destroy();
+      queryTable.destroy();
+    }
+  }
+  t.end();
+});
+
+test('importGPUEmbeddingTable rejects sliced nullable Arrow source IDs across preserved batches', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const embeddingType = new arrow.FixedSizeList(
+    2,
+    new arrow.Field('feature', new arrow.Float32(), false)
+  );
+  const slicedSourceIds = arrow.vectorFromArray([900, 11, null], new arrow.Uint32()).slice(1, 3);
+  const firstBatch = new arrow.Table({
+    embedding: arrow.vectorFromArray(
+      [
+        [0, 0],
+        [1, 0]
+      ],
+      embeddingType
+    ),
+    sourceIds: slicedSourceIds
+  }).batches[0];
+  const secondBatch = new arrow.Table({
+    embedding: arrow.vectorFromArray([[2, 0]], embeddingType),
+    sourceIds: arrow.vectorFromArray([22], new arrow.Uint32())
+  }).batches[0];
+  const table = makeGPUTableFromArrowTable(device, new arrow.Table([firstBatch, secondBatch]), {
+    shaderLayout: {
+      attributes: [],
+      bindings: [
+        {name: 'embedding', type: 'read-only-storage', group: 0, location: 0},
+        {name: 'sourceIds', type: 'read-only-storage', group: 0, location: 1}
+      ]
+    },
+    fixedSizeListColumns: ['embedding']
+  });
+  const graph = new GPUCommandGraph(device, {id: 'nullable-arrow-source-row-ids'});
+
+  try {
+    t.equal(table.batches.length, 2, 'the Arrow upload retains both source record batches');
+    t.ok(
+      table.batches[0].gpuData.sourceIds.nullBitmap,
+      'nullable numeric IDs retain generic validity'
+    );
+    t.throws(
+      () =>
+        importGPUEmbeddingTable(graph, table, {
+          column: 'embedding',
+          sourceRowIds: 'sourceIds'
+        }),
+      /source-row IDs must not contain null/,
+      'sliced null IDs never silently collide with a real stable ID of zero'
+    );
+  } finally {
+    table.destroy();
+  }
+  t.end();
+});
+
+test('GPUSimilaritySearch matches independent CPU exact search for every metric', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const sharedFixture = {
+    dimensions: 5,
+    dataset: [
+      {
+        rows: [
+          [1, 2, 3, 0, 0],
+          [-1, 0, 2, 1, 0],
+          [1, 2, 3, 0, 0]
+        ],
+        sourceRowIds: [30, 7, 4]
+      },
+      {
+        rows: [
+          [0, 0, 0, 0, 0],
+          [2, -1, 0.5, 4, 1]
+        ],
+        sourceRowIds: [20, 13]
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [1, 2, 3, 0, 0],
+          [-2, 1, 0, 0, 2],
+          [0, 0, 0, 0, 0]
+        ]
+      }
+    ],
+    k: 4,
+    candidateCounts: true
+  } satisfies SimilaritySearchFixture;
+
+  for (const metric of ['squared-euclidean', 'inner-product', 'cosine'] as const) {
+    const fixture = {...sharedFixture, metric};
+    const result = await runGPUSimilaritySearch(device, fixture);
+    assertMatchesIndependentCPU(t, fixture, result, `${metric} batched exact search`);
+  }
+
+  t.end();
+});
+
+test('GPUSimilaritySearch preserves chunk boundaries, offsets, padding, validity, and global ties', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 3,
+    dataset: [
+      {
+        rows: [
+          [2, 0, 0],
+          [1, 0, 0]
+        ],
+        prefix: [111, 222],
+        rowStride: 5,
+        sourceRowIds: [19, 80]
+      },
+      {rows: [], rowStride: 3},
+      {
+        rows: [
+          [1, 0, 0],
+          [99, 99, 99],
+          [0, 1, 0]
+        ],
+        rowStride: 4,
+        prefix: [333],
+        sourceRowIds: [4, 2, 11],
+        validity: [1, 0, 1]
+      }
+    ],
+    queries: [
+      {rows: [[1, 0, 0]], rowStride: 4, prefix: [777]},
+      {rows: [], rowStride: 3},
+      {rows: [[0, 1, 0]], rowStride: 5, prefix: [888, 999]}
+    ],
+    k: 4,
+    tileSize: 1,
+    candidateCounts: true
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'chunk-preserving globally merged top-K');
+  t.deepEqual(result.sourceRowIds.slice(0, 2), [4, 80], 'cross-shard score ties sort by source ID');
+  t.ok(
+    result.nodeOrder.filter(identifier => identifier.includes('prepare-dataset-tile')).length === 5,
+    'bounded tiles preserve every nonempty source row without materializing a distance matrix'
+  );
+  t.ok(result.importedBuffersSurviveDestruction, 'graph destruction preserves caller-owned chunks');
+  t.end();
+});
+
+test('GPUSimilaritySearch defines zero-vector cosine and rejects invalid, NaN, and Infinity rows', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 3,
+    dataset: [
+      {
+        rows: [
+          [0, 0, 0],
+          [1, 0, 0],
+          [Number.NaN, 1, 0],
+          [Number.POSITIVE_INFINITY, 0, 1],
+          [0, -2, 0]
+        ],
+        sourceRowIds: [10, 4, 3, 2, 7],
+        validity: [1, 1, 1, 1, 1]
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [0, 0, 0],
+          [1, 0, 0],
+          [Number.NaN, 0, 0],
+          [0, Number.NEGATIVE_INFINITY, 0],
+          [0, 1, 0]
+        ],
+        validity: [1, 1, 1, 1, 0]
+      }
+    ],
+    metric: 'cosine',
+    k: 4,
+    candidateCounts: true
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'nonfinite-aware cosine semantics');
+  t.equal(result.sourceRowIds[0], 10, 'two zero vectors are the best cosine match');
+  t.equal(result.scores[0], 1, 'two zero vectors have unit cosine similarity');
+  t.deepEqual(result.resultCounts, [3, 3, 0, 0, 0], 'invalid query rows produce no matches');
+  t.deepEqual(result.candidateCounts, [3, 3, 0, 0, 0], 'invalid query rows report no candidates');
+  t.end();
+});
+
+test('GPUSimilaritySearch retains infinite scores produced by finite Float32 embeddings', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const magnitude = Math.fround(3e38);
+  const innerProduct = await runGPUSimilaritySearch(device, {
+    dimensions: 1,
+    dataset: [{rows: [[magnitude], [1], [-magnitude]], sourceRowIds: [9, 5, 2]}],
+    queries: [{rows: [[magnitude]]}],
+    metric: 'inner-product',
+    k: 3,
+    candidateCounts: true
+  });
+
+  t.deepEqual(
+    innerProduct.sourceRowIds,
+    [9, 5, 2],
+    'positive and negative overflow remain ordered around finite inner products'
+  );
+  t.equal(innerProduct.scores[0], Number.POSITIVE_INFINITY, 'positive overflow remains a result');
+  t.equal(innerProduct.scores[2], Number.NEGATIVE_INFINITY, 'negative overflow remains a result');
+  t.deepEqual(innerProduct.resultCounts, [3], 'all finite embedding rows fill the top-K outputs');
+  t.deepEqual(innerProduct.candidateCounts, [3], 'candidate and result populations stay aligned');
+
+  const squaredDistance = await runGPUSimilaritySearch(device, {
+    dimensions: 1,
+    dataset: [{rows: [[magnitude], [0], [-magnitude]], sourceRowIds: [9, 5, 2]}],
+    queries: [{rows: [[magnitude]]}],
+    metric: 'squared-euclidean',
+    k: 3,
+    candidateCounts: true
+  });
+
+  t.deepEqual(
+    squaredDistance.sourceRowIds,
+    [9, 2, 5],
+    'overflowed squared distances remain deterministic under stable source-ID ties'
+  );
+  t.deepEqual(
+    squaredDistance.scores,
+    [0, Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY],
+    'valid finite rows keep their overflowed Float32 distance values'
+  );
+  t.deepEqual(squaredDistance.resultCounts, [3], 'infinite distances still fill oversized top-K');
+
+  const indeterminateInnerProduct = await runGPUSimilaritySearch(device, {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [magnitude, magnitude],
+          [magnitude, 0]
+        ],
+        sourceRowIds: [4, 7]
+      }
+    ],
+    queries: [{rows: [[magnitude, -magnitude]]}],
+    metric: 'inner-product',
+    k: 2,
+    candidateCounts: true
+  });
+
+  t.deepEqual(
+    indeterminateInnerProduct.sourceRowIds,
+    [7, INVALID_SOURCE_ROW_ID],
+    'indeterminate infinity-minus-infinity scores remain excluded'
+  );
+  t.deepEqual(indeterminateInnerProduct.resultCounts, [1], 'only non-NaN scores become results');
+  t.deepEqual(
+    indeterminateInnerProduct.candidateCounts,
+    [2],
+    'candidate counts still describe finite eligible source rows'
+  );
+  t.end();
+});
+
+test('GPUSimilaritySearch preserves finite-magnitude cosine ordering without intermediate overflow', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  for (const magnitude of [1e10, 1e20, 3e38, 1e-20]) {
+    const fixture: SimilaritySearchFixture = {
+      dimensions: 2,
+      dataset: [
+        {
+          rows: [
+            [magnitude, 0],
+            [0, magnitude],
+            [-magnitude, 0]
+          ],
+          sourceRowIds: [9, 2, 4]
+        }
+      ],
+      queries: [{rows: [[magnitude, 0]]}],
+      metric: 'cosine',
+      k: 3,
+      candidateCounts: true
+    };
+    const result = await runGPUSimilaritySearch(device, fixture);
+
+    assertMatchesIndependentCPU(t, fixture, result, `finite ${magnitude}-magnitude cosine search`);
+    t.deepEqual(
+      result.sourceRowIds,
+      [9, 2, 4],
+      `${magnitude}-magnitude aligned, orthogonal, and opposite vectors remain ordered`
+    );
+    for (const [scoreIndex, expectedScore] of [1, 0, -1].entries()) {
+      t.ok(
+        Math.abs(result.scores[scoreIndex] - expectedScore) < 0.000001,
+        `${magnitude}-magnitude cosine ${scoreIndex} stays within Float32 rounding tolerance`
+      );
+    }
+  }
+  t.end();
+});
+
+test('GPUSimilaritySearch applies packed source-aligned GPU masks at sparse source offsets', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const baseFixture = {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [0, 0],
+          [1, 0],
+          [2, 0],
+          [3, 0]
+        ],
+        sourceRowOffset: 5,
+        sourceRowIds: [90, 40, 70, 20]
+      }
+    ],
+    queries: [{rows: [[0.5, 0]]}],
+    k: 5,
+    candidateCounts: true
+  } satisfies SimilaritySearchFixture;
+
+  for (const filterMask of [
+    [0, 0, 0, 0, 0, 1, 1, 1, 1],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 1, 0, 1],
+    [0, 0, 0, 0, 0, 1, 1, 1, 0]
+  ]) {
+    const fixture = {...baseFixture, filterMask};
+    const result = await runGPUSimilaritySearch(device, fixture);
+    assertMatchesIndependentCPU(
+      t,
+      fixture,
+      result,
+      `packed filter ${filterMask.slice(5).join('')}`
+    );
+  }
+
+  t.end();
+});
+
+test('GPUSimilaritySearch accepts LuxFilter-compatible chunk-preserving selection masks', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [0, 0],
+          [1, 0]
+        ],
+        sourceRowIds: [80, 7]
+      },
+      {rows: [], sourceRowIds: []},
+      {
+        rows: [
+          [2, 0],
+          [3, 0],
+          [4, 0]
+        ],
+        sourceRowIds: [2, 50, 11]
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [2.1, 0],
+          [0, 0]
+        ]
+      }
+    ],
+    chunkedFilterMask: [[0, 1], [], [1, 0, 1]],
+    k: 4,
+    tileSize: 2,
+    candidateCounts: true
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'LuxFilter-compatible chunked GPU masks');
+  t.deepEqual(result.candidateCounts, [3, 3], 'sparse chunk masks expose exact eligible counts');
+  t.end();
+});
+
+test('GPUSimilaritySearch combines query-specific GPU masks and stable candidate-ID allowlists', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [0, 0],
+          [1, 0]
+        ],
+        sourceRowOffset: 2,
+        sourceRowIds: [90, 20]
+      },
+      {
+        rows: [
+          [2, 0],
+          [3, 0]
+        ],
+        sourceRowOffset: 4,
+        sourceRowIds: [70, 10]
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [0, 0],
+          [3, 0]
+        ]
+      }
+    ],
+    queryFilterMask: [0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 1],
+    candidateIds: [90, 70, 10],
+    k: 4,
+    tileSize: 1,
+    candidateCounts: true
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'per-query masks with stable-ID allowlists');
+  t.deepEqual(
+    result.candidateCounts,
+    [2, 2],
+    'candidate counts include every combined restriction'
+  );
+  t.end();
+});
+
+test('GPUSimilaritySearch indexes substantial stable candidate-ID allowlists on the GPU', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const rows = Array.from({length: 64}, (_, rowIndex) => [rowIndex, rowIndex % 5]);
+  const sourceRowIds = rows.map((_, rowIndex) => 4000 + rowIndex * 17);
+  const selectedIds = sourceRowIds.filter((_, rowIndex) => rowIndex % 3 === 0);
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [{rows, sourceRowIds}],
+    queries: [
+      {
+        rows: [
+          [20.25, 1],
+          [61, 0]
+        ]
+      }
+    ],
+    candidateIds: [...selectedIds, selectedIds[2], selectedIds[6]],
+    k: 6,
+    tileSize: 7,
+    candidateCounts: true
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'hashed stable candidate-ID membership');
+  t.ok(
+    result.nodeOrder.some(nodeId => nodeId.includes('-candidate-index-build')),
+    'substantial allowlists build bounded GPU membership instead of repeated linear scans'
+  );
+  t.deepEqual(
+    result.candidateCounts,
+    [selectedIds.length, selectedIds.length],
+    'duplicate requested IDs do not duplicate eligible dataset rows'
+  );
+  t.end();
+});
+
+test('GPUSimilaritySearch excludes query source IDs without conflating row position and identity', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [0, 0],
+          [1, 0]
+        ],
+        sourceRowIds: [40, 8]
+      },
+      {
+        rows: [
+          [2, 0],
+          [3, 0]
+        ],
+        sourceRowIds: [20, 2]
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [1, 0],
+          [3, 0]
+        ],
+        sourceRowIds: [8, 2]
+      }
+    ],
+    k: 4,
+    excludeSelf: true,
+    candidateCounts: true,
+    tileSize: 1
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'explicit stable-ID self exclusion');
+  t.deepEqual(result.candidateCounts, [3, 3], 'self-exclusion reduces eligible candidate counts');
+  t.notOk(
+    result.sourceRowIds.slice(0, 4).includes(8),
+    'the first query excludes its own source ID'
+  );
+  t.notOk(
+    result.sourceRowIds.slice(4, 8).includes(2),
+    'the second query excludes its own source ID'
+  );
+  t.end();
+});
+
+test('GPUSimilaritySearch handles zero K, oversized K, empty datasets, and zero query rows', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const edgeFixtures: SimilaritySearchFixture[] = [
+    {
+      dimensions: 2,
+      dataset: [
+        {
+          rows: [
+            [1, 0],
+            [2, 0]
+          ]
+        }
+      ],
+      queries: [
+        {
+          rows: [
+            [0, 0],
+            [3, 0]
+          ]
+        }
+      ],
+      k: 0,
+      candidateCounts: true
+    },
+    {
+      dimensions: 2,
+      dataset: [
+        {
+          rows: [
+            [1, 0],
+            [2, 0]
+          ]
+        }
+      ],
+      queries: [{rows: [[0, 0]]}],
+      k: 5,
+      candidateCounts: true
+    },
+    {
+      dimensions: 2,
+      dataset: [{rows: []}, {rows: []}],
+      queries: [
+        {
+          rows: [
+            [0, 0],
+            [1, 1]
+          ]
+        }
+      ],
+      k: 3,
+      candidateCounts: true
+    },
+    {
+      dimensions: 2,
+      dataset: [{rows: [[1, 0]]}],
+      queries: [{rows: []}],
+      k: 3,
+      candidateCounts: true
+    }
+  ];
+
+  for (const [fixtureIndex, fixture] of edgeFixtures.entries()) {
+    const result = await runGPUSimilaritySearch(device, fixture);
+    assertMatchesIndependentCPU(t, fixture, result, `empty-result edge case ${fixtureIndex}`);
+  }
+
+  t.end();
+});
+
+test('GPUSimilaritySearch globally merges bounded shards with exact stable ordering', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const rows = Array.from({length: 41}, (_, rowIndex) => [
+    ((rowIndex * 17) % 23) - 11,
+    ((rowIndex * 13) % 19) - 9,
+    rowIndex % 3
+  ]);
+  const sourceRowIds = Array.from({length: rows.length}, (_, rowIndex) => rows.length - rowIndex);
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 3,
+    dataset: [
+      {rows: rows.slice(0, 8), sourceRowIds: sourceRowIds.slice(0, 8)},
+      {rows: []},
+      {rows: rows.slice(8, 27), rowStride: 5, sourceRowIds: sourceRowIds.slice(8, 27)},
+      {rows: rows.slice(27), sourceRowIds: sourceRowIds.slice(27)}
+    ],
+    queries: [
+      {
+        rows: [
+          [0, 0, 0],
+          [4, -2, 1]
+        ]
+      },
+      {
+        rows: [
+          [-7, 3, 2],
+          [11, 8, 0]
+        ]
+      }
+    ],
+    k: 7,
+    tileSize: 3,
+    candidateCounts: true
+  };
+  const result = await runGPUSimilaritySearch(device, fixture);
+
+  assertMatchesIndependentCPU(t, fixture, result, 'globally merged bounded shard selection');
+  t.ok(
+    result.nodeOrder.filter(identifier => identifier.includes('prepare-dataset-tile')).length >= 14,
+    'small tile limits produce independent bounded candidate passes'
+  );
+  t.equal(result.candidateCounts?.[0], 41, 'global candidate counts include every source chunk');
+  t.end();
+});
+
+test('GPUSimilaritySearch shards physical bindings while preserving padded rows and exact results', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 3,
+    dataset: [
+      {
+        rows: Array.from({length: 57}, (_, rowIndex) => [
+          rowIndex % 13,
+          (rowIndex * 3) % 17,
+          rowIndex % 5
+        ]),
+        prefix: new Array(63).fill(-99),
+        rowStride: 5
+      }
+    ],
+    queries: [
+      {
+        rows: [
+          [1, 2, 3],
+          [8, 4, 1],
+          [0, 0, 0]
+        ]
+      }
+    ],
+    k: 5,
+    candidateCounts: true
+  };
+
+  const result = await withReducedDeviceLimits(device, {maxStorageBufferBindingSize: 512}, () =>
+    runGPUSimilaritySearch(device, fixture)
+  );
+  assertMatchesIndependentCPU(t, fixture, result, 'storage-binding-aware physical sharding');
+  t.ok(
+    result.nodeOrder.filter(identifier => identifier.includes('prepare-dataset-tile')).length > 1,
+    'artificially small storage bindings force exact multi-pass sharding'
+  );
+  t.end();
+});
+
+test('GPUSimilaritySearch uses bounded multidimensional dispatch for query batches', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const fixture: SimilaritySearchFixture = {
+    dimensions: 2,
+    dataset: [
+      {
+        rows: [
+          [0, 0],
+          [1, 0],
+          [2, 0],
+          [3, 0]
+        ]
+      }
+    ],
+    queries: [
+      {
+        rows: Array.from({length: 257}, (_, rowIndex) => [rowIndex % 4, 0])
+      }
+    ],
+    k: 2,
+    candidateCounts: true
+  };
+  const result = await withReducedDeviceLimits(device, {maxComputeWorkgroupsPerDimension: 2}, () =>
+    runGPUSimilaritySearch(device, fixture)
+  );
+
+  assertMatchesIndependentCPU(t, fixture, result, 'bounded multidimensional query dispatch');
+  t.equal(result.resultCounts.length, 257, 'every query survives the artificial dispatch limit');
+  t.end();
+});
+
+test('GPUSimilaritySearch reuses compiled graphs for dynamic GPU selections and buffer overrides', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) return finishWithoutWebGPU(t);
+
+  const identifier = `similarity-repeat-${fixtureSequence++}`;
+  const graph = new GPUCommandGraph(device, {id: identifier});
+  const ownedVectors: GPUVector[] = [];
+  const dataset = createEmbeddingVector(
+    device,
+    `${identifier}-dataset`,
+    2,
+    [
+      {
+        rows: [
+          [0, 0],
+          [2, 0]
+        ],
+        sourceRowIds: [50, 3]
+      }
+    ],
+    ownedVectors
+  );
+  const queries = createEmbeddingVector(
+    device,
+    `${identifier}-queries`,
+    2,
+    [{rows: [[0, 0]], sourceRowIds: [90]}],
+    ownedVectors
+  );
+  const importedDataset = importEmbeddingFixture(graph, dataset, `${identifier}-dataset`);
+  const importedQueries = importEmbeddingFixture(graph, queries, `${identifier}-queries`);
+  const outputIds = createUint32View(graph, ownedVectors, `${identifier}-output-ids`, 2);
+  const outputScores = createFloat32View(graph, ownedVectors, `${identifier}-output-scores`, 2);
+  const resultCounts = createUint32View(graph, ownedVectors, `${identifier}-result-counts`, 1);
+  const candidateCounts = createUint32View(
+    graph,
+    ownedVectors,
+    `${identifier}-candidate-counts`,
+    1
+  );
+  const filterMask = createUint32View(
+    graph,
+    ownedVectors,
+    `${identifier}-filter-mask`,
+    2,
+    new Uint32Array([1, 0])
+  );
+  const search = new GPUSimilaritySearch({
+    id: identifier,
+    dataset: importedDataset,
+    queries: importedQueries,
+    outputIds,
+    outputScores,
+    resultCounts,
+    candidateCounts,
+    filterMask,
+    k: 2
+  });
+  search.addToGraph(graph);
+  const compiled = graph.compile();
+  const replacementQuery = device.createBuffer({
+    id: `${identifier}-replacement-query`,
+    data: new Float32Array([2, 0]),
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+
+  try {
+    const firstEncoder = device.createCommandEncoder({id: `${identifier}-first-encoder`});
+    compiled.encode(firstEncoder, {parameters: undefined});
+    device.submit(firstEncoder.finish());
+    t.deepEqual(
+      await readUint32View(ownedVectors, outputIds, 2),
+      [50, INVALID_SOURCE_ROW_ID],
+      'the first graph encoding consumes the current source selection'
+    );
+    t.deepEqual(await readUint32View(ownedVectors, candidateCounts, 1), [1]);
+
+    const selectionVector = ownedVectors.find(vector => vector.name === filterMask.buffer.id);
+    selectionVector!.data[0].buffer.write(new Uint32Array([0, 1]));
+    const secondEncoder = device.createCommandEncoder({id: `${identifier}-second-encoder`});
+    compiled.encode(secondEncoder, {parameters: undefined});
+    device.submit(secondEncoder.finish());
+    t.deepEqual(
+      await readUint32View(ownedVectors, outputIds, 2),
+      [3, INVALID_SOURCE_ROW_ID],
+      'dynamic GPU selection changes are observed without graph recompilation'
+    );
+    t.deepEqual(
+      await readUint32View(ownedVectors, candidateCounts, 1),
+      [1],
+      'repeated graph encodings reset candidate counts instead of accumulating stale results'
+    );
+
+    selectionVector!.data[0].buffer.write(new Uint32Array([1, 1]));
+    const thirdEncoder = device.createCommandEncoder({id: `${identifier}-third-encoder`});
+    compiled.encode(thirdEncoder, {
+      parameters: undefined,
+      buffers: {[`${identifier}-queries-chunk-0-values`]: replacementQuery}
+    });
+    device.submit(thirdEncoder.finish());
+    t.deepEqual(
+      await readUint32View(ownedVectors, outputIds, 2),
+      [3, 50],
+      'encoded buffer overrides replace query values without recompilation'
+    );
+    t.deepEqual(await readUint32View(ownedVectors, resultCounts, 1), [2]);
+    t.deepEqual(await readUint32View(ownedVectors, candidateCounts, 1), [2]);
+
+    compiled.destroy();
+    t.ok(
+      ownedVectors.every(vector => vector.data.every(chunk => !chunk.buffer.destroyed)),
+      'compiled graph destruction never claims original caller-owned buffers'
+    );
+    t.notOk(replacementQuery.destroyed, 'compiled graph destruction never claims override buffers');
+  } finally {
+    compiled.destroy();
+    replacementQuery.destroy();
+    destroyOwnedVectors(ownedVectors);
+  }
+
+  t.end();
+});
+
+function finishWithoutWebGPU(testContext: Test): void {
+  testContext.comment('WebGPU is not available');
+  testContext.end();
+}
+
+function getCPUFixtureRows(
+  chunks: readonly EmbeddingChunkFixture[],
+  dimensions: number
+): CPUSourceEmbeddingRow[] {
+  const rows: CPUSourceEmbeddingRow[] = [];
+  let nextSourceRowOffset = 0;
+  for (const [chunkIndex, chunk] of chunks.entries()) {
+    const sourceRowOffset = chunk.sourceRowOffset ?? nextSourceRowOffset;
+    for (const [chunkRowIndex, row] of chunk.rows.entries()) {
+      rows.push({
+        values: Array.from(Float32Array.from(row.slice(0, dimensions))),
+        sourceRowId: chunk.sourceRowIds?.[chunkRowIndex] ?? sourceRowOffset + chunkRowIndex,
+        sourceRowPosition: sourceRowOffset + chunkRowIndex,
+        valid: chunk.validity?.[chunkRowIndex] !== 0,
+        chunkIndex,
+        chunkRowIndex
+      });
+    }
+    nextSourceRowOffset = sourceRowOffset + chunk.rows.length;
+  }
+  return rows;
+}
+
+function getIndependentCPUSimilarityResults(
+  fixture: SimilaritySearchFixture,
+  dataset: readonly CPUSourceEmbeddingRow[],
+  queries: readonly CPUSourceEmbeddingRow[]
+): CPUSimilarityResult {
+  const metric = fixture.metric ?? 'squared-euclidean';
+  const sourceSpan = dataset.reduce(
+    (maximum, candidate) => Math.max(maximum, candidate.sourceRowPosition + 1),
+    0
+  );
+  const sourceRowIds: number[] = [];
+  const scores: number[] = [];
+  const resultCounts: number[] = [];
+  const candidateCounts: number[] = [];
+  const candidateIdSet = fixture.candidateIds ? new Set(fixture.candidateIds) : undefined;
+
+  for (const [queryIndex, query] of queries.entries()) {
+    const matches: {sourceRowId: number; score: number}[] = [];
+    let eligibleCount = 0;
+    const queryIsValid =
+      query.valid &&
+      query.sourceRowId !== INVALID_SOURCE_ROW_ID &&
+      query.values.every(value => Number.isFinite(value));
+
+    if (queryIsValid) {
+      for (const candidate of dataset) {
+        const sourceMaskSelected = fixture.filterMask
+          ? fixture.filterMask[candidate.sourceRowPosition] !== 0
+          : true;
+        const chunkMaskSelected = fixture.chunkedFilterMask
+          ? fixture.chunkedFilterMask[candidate.chunkIndex][candidate.chunkRowIndex] !== 0
+          : true;
+        const queryMaskSelected = fixture.queryFilterMask
+          ? fixture.queryFilterMask[queryIndex * sourceSpan + candidate.sourceRowPosition] !== 0
+          : true;
+        const allowedCandidate = candidateIdSet ? candidateIdSet.has(candidate.sourceRowId) : true;
+        if (
+          !candidate.valid ||
+          candidate.sourceRowId === INVALID_SOURCE_ROW_ID ||
+          !candidate.values.every(value => Number.isFinite(value)) ||
+          !sourceMaskSelected ||
+          !chunkMaskSelected ||
+          !queryMaskSelected ||
+          !allowedCandidate ||
+          (fixture.excludeSelf && candidate.sourceRowId === query.sourceRowId)
+        ) {
+          continue;
+        }
+
+        eligibleCount++;
+        const score = calculateIndependentCPUScore(metric, query.values, candidate.values);
+        if (Number.isFinite(score)) {
+          matches.push({sourceRowId: candidate.sourceRowId, score});
+        }
+      }
+    }
+
+    matches.sort((first, second) => {
+      const scoreOrder =
+        metric === 'squared-euclidean' ? first.score - second.score : second.score - first.score;
+      return scoreOrder || first.sourceRowId - second.sourceRowId;
+    });
+    const selected = matches.slice(0, fixture.k);
+    resultCounts.push(selected.length);
+    candidateCounts.push(eligibleCount);
+    for (let resultIndex = 0; resultIndex < fixture.k; resultIndex++) {
+      sourceRowIds.push(selected[resultIndex]?.sourceRowId ?? INVALID_SOURCE_ROW_ID);
+      scores.push(
+        selected[resultIndex]?.score ??
+          (metric === 'squared-euclidean' ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY)
+      );
+    }
+  }
+
+  return {sourceRowIds, scores, resultCounts, candidateCounts};
+}
+
+function calculateIndependentCPUScore(
+  metric: GPUEmbeddingMetric,
+  query: readonly number[],
+  candidate: readonly number[]
+): number {
+  let dotProduct = 0;
+  let queryNorm = 0;
+  let candidateNorm = 0;
+  let squaredDistance = 0;
+  for (let dimensionIndex = 0; dimensionIndex < query.length; dimensionIndex++) {
+    const queryValue = query[dimensionIndex];
+    const candidateValue = candidate[dimensionIndex];
+    const difference = queryValue - candidateValue;
+    squaredDistance += difference * difference;
+    dotProduct += queryValue * candidateValue;
+    queryNorm += queryValue * queryValue;
+    candidateNorm += candidateValue * candidateValue;
+  }
+  if (metric === 'squared-euclidean') return squaredDistance;
+  if (metric === 'inner-product') return dotProduct;
+  if (queryNorm === 0 && candidateNorm === 0) return 1;
+  if (queryNorm === 0 || candidateNorm === 0) return 0;
+  return dotProduct / Math.sqrt(queryNorm * candidateNorm);
+}
+
+function assertMatchesIndependentCPU(
+  testContext: Test,
+  fixture: SimilaritySearchFixture,
+  result: SearchExecution,
+  message: string
+): void {
+  const expected = getIndependentCPUSimilarityResults(
+    fixture,
+    getCPUFixtureRows(fixture.dataset, fixture.dimensions),
+    getCPUFixtureRows(fixture.queries, fixture.dimensions)
+  );
+  testContext.deepEqual(result.sourceRowIds, expected.sourceRowIds, `${message}: source IDs`);
+  testContext.deepEqual(result.resultCounts, expected.resultCounts, `${message}: result counts`);
+  if (fixture.candidateCounts) {
+    testContext.deepEqual(
+      result.candidateCounts,
+      expected.candidateCounts,
+      `${message}: candidate counts`
+    );
+  }
+  testContext.equal(result.scores.length, expected.scores.length, `${message}: score count`);
+  for (const [scoreIndex, score] of result.scores.entries()) {
+    const expectedScore = expected.scores[scoreIndex];
+    const matches = Number.isFinite(expectedScore)
+      ? Math.abs(score - expectedScore) <= 0.00005 * Math.max(1, Math.abs(expectedScore))
+      : Object.is(score, expectedScore);
+    testContext.ok(
+      matches,
+      `${message}: score ${scoreIndex} equals ${expectedScore} (got ${score})`
+    );
+  }
+}
+
+async function runGPUSimilaritySearch(
+  device: Device,
+  fixture: SimilaritySearchFixture
+): Promise<SearchExecution> {
+  const identifier = `similarity-fixture-${fixtureSequence++}`;
+  const graph = new GPUCommandGraph(device, {id: identifier});
+  const ownedVectors: GPUVector[] = [];
+  const dataset = createEmbeddingVector(
+    device,
+    `${identifier}-dataset`,
+    fixture.dimensions,
+    fixture.dataset,
+    ownedVectors
+  );
+  const queries = createEmbeddingVector(
+    device,
+    `${identifier}-queries`,
+    fixture.dimensions,
+    fixture.queries,
+    ownedVectors
+  );
+  const importedDataset = importEmbeddingFixture(graph, dataset, `${identifier}-dataset`);
+  const importedQueries = importEmbeddingFixture(graph, queries, `${identifier}-queries`);
+  const outputLength = queries.vector.length * fixture.k;
+  const outputIds = createUint32View(graph, ownedVectors, `${identifier}-output-ids`, outputLength);
+  const outputScores = createFloat32View(
+    graph,
+    ownedVectors,
+    `${identifier}-output-scores`,
+    outputLength
+  );
+  const resultCounts = createUint32View(
+    graph,
+    ownedVectors,
+    `${identifier}-result-counts`,
+    queries.vector.length
+  );
+  const candidateCounts = fixture.candidateCounts
+    ? createUint32View(graph, ownedVectors, `${identifier}-candidate-counts`, queries.vector.length)
+    : undefined;
+  const filterMask = fixture.filterMask
+    ? createUint32View(
+        graph,
+        ownedVectors,
+        `${identifier}-filter-mask`,
+        fixture.filterMask.length,
+        Uint32Array.from(fixture.filterMask)
+      )
+    : fixture.chunkedFilterMask
+      ? createChunkedFilterMask(
+          graph,
+          ownedVectors,
+          `${identifier}-filter-mask`,
+          fixture.chunkedFilterMask
+        )
+      : undefined;
+  const queryFilterMask = fixture.queryFilterMask
+    ? createUint32View(
+        graph,
+        ownedVectors,
+        `${identifier}-query-filter-mask`,
+        fixture.queryFilterMask.length,
+        Uint32Array.from(fixture.queryFilterMask)
+      )
+    : undefined;
+  const candidateIds = fixture.candidateIds
+    ? createUint32View(
+        graph,
+        ownedVectors,
+        `${identifier}-candidate-ids`,
+        fixture.candidateIds.length,
+        Uint32Array.from(fixture.candidateIds)
+      )
+    : undefined;
+
+  const search = new GPUSimilaritySearch({
+    id: identifier,
+    dataset: importedDataset,
+    queries: importedQueries,
+    outputIds,
+    outputScores,
+    resultCounts,
+    ...(candidateCounts ? {candidateCounts} : {}),
+    ...(filterMask ? {filterMask} : {}),
+    ...(queryFilterMask ? {queryFilterMask} : {}),
+    ...(candidateIds ? {candidateIds} : {}),
+    ...(fixture.metric ? {metric: fixture.metric} : {}),
+    ...(fixture.tileSize ? {tileSize: fixture.tileSize} : {}),
+    excludeSelf: fixture.excludeSelf,
+    k: fixture.k
+  });
+  search.addToGraph(graph);
+  const compiled = graph.compile();
+  let importedBuffersSurviveDestruction = false;
+
+  try {
+    const encoder = device.createCommandEncoder({id: `${identifier}-encoder`});
+    compiled.encode(encoder, {parameters: undefined});
+    device.submit(encoder.finish());
+
+    const [sourceRowIds, scores, actualResultCounts, actualCandidateCounts] = await Promise.all([
+      readUint32View(ownedVectors, outputIds, outputLength),
+      readFloat32View(ownedVectors, outputScores, outputLength),
+      readUint32View(ownedVectors, resultCounts, queries.vector.length),
+      candidateCounts
+        ? readUint32View(ownedVectors, candidateCounts, queries.vector.length)
+        : Promise.resolve(undefined)
+    ]);
+    const nodeOrder = compiled.stats.nodeOrder.slice();
+    const logicalTransientCount = compiled.stats.logicalTransientBufferCount;
+    const physicalTransientCount = compiled.stats.physicalTransientBufferCount;
+
+    compiled.destroy();
+    importedBuffersSurviveDestruction = ownedVectors.every(vector =>
+      vector.data.every(chunk => !chunk.buffer.destroyed)
+    );
+    return {
+      sourceRowIds,
+      scores,
+      resultCounts: actualResultCounts,
+      ...(actualCandidateCounts ? {candidateCounts: actualCandidateCounts} : {}),
+      nodeOrder,
+      logicalTransientCount,
+      physicalTransientCount,
+      importedBuffersSurviveDestruction
+    };
+  } finally {
+    compiled.destroy();
+    destroyOwnedVectors(ownedVectors);
+  }
+}
+
+function createEmbeddingVector(
+  device: Device,
+  identifier: string,
+  dimensions: number,
+  chunks: readonly EmbeddingChunkFixture[],
+  ownedVectors: GPUVector[]
+): GPUEmbeddingVectorFixture {
+  const rows = getCPUFixtureRows(chunks, dimensions);
+  const format: FixedSizeList<'float32'> = `fixed-size-list<float32,${dimensions}>`;
+  const hasSourceRowIds = chunks.some(chunk => chunk.sourceRowIds !== undefined);
+  const hasValidity = chunks.some(chunk => chunk.validity !== undefined);
+  const valuesData: GPUData<FixedSizeList<'float32'>>[] = [];
+  const sourceRowIdsData: GPUData<'uint32'>[] = [];
+  const validityData: GPUData<'uint32'>[] = [];
+  const sourceRowOffsets: number[] = [];
+  let nextSourceRowOffset = 0;
+  for (const [chunkIndex, chunk] of chunks.entries()) {
+    const rowStride = chunk.rowStride ?? dimensions;
+    const prefix = chunk.prefix ?? [];
+    const sourceRowOffset = chunk.sourceRowOffset ?? nextSourceRowOffset;
+    const flattenedValues = new Float32Array(prefix.length + chunk.rows.length * rowStride);
+    flattenedValues.set(prefix, 0);
+    for (const [rowIndex, row] of chunk.rows.entries()) {
+      flattenedValues.set(row.slice(0, dimensions), prefix.length + rowIndex * rowStride);
+      for (let paddingIndex = dimensions; paddingIndex < rowStride; paddingIndex++) {
+        flattenedValues[prefix.length + rowIndex * rowStride + paddingIndex] = -12345;
+      }
+    }
+    const storage = flattenedValues.length > 0 ? flattenedValues : new Float32Array(1);
+    const byteOffset = prefix.length * Float32Array.BYTES_PER_ELEMENT;
+    const valueBuffer = device.createBuffer({
+      id: `${identifier}-${chunkIndex}-values`,
+      data: storage,
+      usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+    });
+    const valueData = new GPUData<FixedSizeList<'float32'>>({
+      buffer: valueBuffer,
+      format,
+      length: chunk.rows.length,
+      byteStride: rowStride * Float32Array.BYTES_PER_ELEMENT,
+      rowByteLength: dimensions * Float32Array.BYTES_PER_ELEMENT,
+      byteOffset,
+      ownsBuffer: true
+    });
+    valuesData.push(valueData);
+    sourceRowOffsets.push(sourceRowOffset);
+    if (hasSourceRowIds) {
+      const sourceIds =
+        chunk.sourceRowIds ??
+        Array.from({length: chunk.rows.length}, (_, rowIndex) => sourceRowOffset + rowIndex);
+      sourceRowIdsData.push(
+        createOwnedUint32Vector(
+          device,
+          ownedVectors,
+          `${identifier}-${chunkIndex}-source-row-ids`,
+          Uint32Array.from(sourceIds)
+        ).data[0]
+      );
+    }
+    if (hasValidity) {
+      const validityFlags = chunk.validity ?? Array.from({length: chunk.rows.length}, () => 1);
+      validityData.push(
+        createOwnedUint32Vector(
+          device,
+          ownedVectors,
+          `${identifier}-${chunkIndex}-validity`,
+          Uint32Array.from(validityFlags)
+        ).data[0]
+      );
+    }
+    nextSourceRowOffset = sourceRowOffset + chunk.rows.length;
+  }
+  const vector = new GPUVector<FixedSizeList<'float32'>>({
+    type: 'data',
+    name: `${identifier}-values`,
+    format,
+    data: valuesData,
+    ownsData: true
+  });
+  ownedVectors.push(vector);
+  const sourceRowIds = hasSourceRowIds
+    ? new GPUVector({
+        type: 'data',
+        name: `${identifier}-source-row-ids`,
+        format: 'uint32',
+        data: sourceRowIdsData
+      })
+    : undefined;
+  const validity = hasValidity
+    ? new GPUVector({
+        type: 'data',
+        name: `${identifier}-validity`,
+        format: 'uint32',
+        data: validityData
+      })
+    : undefined;
+  return {
+    vector,
+    ...(sourceRowIds ? {sourceRowIds} : {}),
+    ...(validity ? {validity} : {}),
+    sourceRowOffsets,
+    rows
+  };
+}
+
+function importEmbeddingFixture(
+  graph: GPUCommandGraph,
+  fixture: GPUEmbeddingVectorFixture,
+  identifier: string
+): GraphEmbeddingMatrix {
+  return importGPUEmbeddingVector(graph, fixture.vector, {
+    id: identifier,
+    sourceRowOffsets: fixture.sourceRowOffsets,
+    ...(fixture.sourceRowIds ? {sourceRowIds: fixture.sourceRowIds} : {}),
+    ...(fixture.validity ? {validity: fixture.validity} : {})
+  });
+}
+
+function createOwnedUint32Vector(
+  device: Device,
+  ownedVectors: GPUVector[],
+  identifier: string,
+  values: Uint32Array
+): GPUVector<'uint32'> {
+  const buffer = device.createBuffer({
+    id: identifier,
+    data: values.length > 0 ? values : new Uint32Array(1),
+    usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+  });
+  const vector = new GPUVector({
+    type: 'buffer',
+    name: identifier,
+    buffer,
+    format: 'uint32',
+    length: values.length,
+    ownsBuffer: true
+  });
+  ownedVectors.push(vector);
+  return vector;
+}
+
+function createUint32View(
+  graph: GPUCommandGraph,
+  ownedVectors: GPUVector[],
+  identifier: string,
+  length: number,
+  values: Uint32Array = new Uint32Array(length)
+): GraphDataView<'uint32'> {
+  const vector = createOwnedUint32Vector(graph.device, ownedVectors, identifier, values);
+  return graph.importGPUData(identifier, vector.data[0]);
+}
+
+function createFloat32View(
+  graph: GPUCommandGraph,
+  ownedVectors: GPUVector[],
+  identifier: string,
+  length: number
+): GraphDataView<'float32'> {
+  const buffer = graph.device.createBuffer({
+    id: identifier,
+    byteLength: Math.max(length, 1) * Float32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC | Buffer.COPY_DST
+  });
+  const vector = new GPUVector({
+    type: 'buffer',
+    name: identifier,
+    buffer,
+    format: 'float32',
+    length,
+    ownsBuffer: true
+  });
+  ownedVectors.push(vector);
+  return graph.importGPUData(identifier, vector.data[0]);
+}
+
+function createChunkedFilterMask(
+  graph: GPUCommandGraph,
+  ownedVectors: GPUVector[],
+  identifier: string,
+  chunks: readonly (readonly number[])[]
+): GraphVectorView<'uint32'> {
+  const data = chunks.map((chunk, chunkIndex) => {
+    const vector = createOwnedUint32Vector(
+      graph.device,
+      ownedVectors,
+      `${identifier}-${chunkIndex}`,
+      Uint32Array.from(chunk)
+    );
+    return vector.data[0];
+  });
+  const vector = new GPUVector({
+    type: 'data',
+    name: identifier,
+    format: 'uint32',
+    data,
+    ownsData: false
+  });
+  ownedVectors.push(vector);
+  return graph.importGPUVector(identifier, vector);
+}
+
+async function readUint32View(
+  ownedVectors: readonly GPUVector[],
+  view: GraphDataView<'uint32'>,
+  length: number
+): Promise<number[]> {
+  if (length === 0) return [];
+  const vector = ownedVectors.find(candidate => candidate.name === view.buffer.id);
+  if (!vector) throw new Error(`Missing owned output vector ${view.buffer.id}`);
+  const bytes = await vector.data[0].buffer.readAsync(
+    view.byteOffset,
+    length * Uint32Array.BYTES_PER_ELEMENT
+  );
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, length));
+}
+
+async function readFloat32View(
+  ownedVectors: readonly GPUVector[],
+  view: GraphDataView<'float32'>,
+  length: number
+): Promise<number[]> {
+  if (length === 0) return [];
+  const vector = ownedVectors.find(candidate => candidate.name === view.buffer.id);
+  if (!vector) throw new Error(`Missing owned output vector ${view.buffer.id}`);
+  const bytes = await vector.data[0].buffer.readAsync(
+    view.byteOffset,
+    length * Float32Array.BYTES_PER_ELEMENT
+  );
+  return Array.from(new Float32Array(bytes.buffer, bytes.byteOffset, length));
+}
+
+function destroyOwnedVectors(vectors: readonly GPUVector[]): void {
+  for (const vector of vectors) vector.destroy();
+}
+
+async function withReducedDeviceLimits<Result>(
+  device: Device,
+  overrides: Partial<
+    Pick<Device['limits'], 'maxStorageBufferBindingSize' | 'maxComputeWorkgroupsPerDimension'>
+  >,
+  callback: () => Promise<Result>
+): Promise<Result> {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(device, 'limits');
+  const originalLimits = device.limits;
+  Object.defineProperty(device, 'limits', {
+    configurable: true,
+    enumerable: originalDescriptor?.enumerable ?? true,
+    writable: true,
+    value: new Proxy(originalLimits, {
+      get(target, property) {
+        if (property === 'maxStorageBufferBindingSize' && overrides.maxStorageBufferBindingSize) {
+          return overrides.maxStorageBufferBindingSize;
+        }
+        if (
+          property === 'maxComputeWorkgroupsPerDimension' &&
+          overrides.maxComputeWorkgroupsPerDimension
+        ) {
+          return overrides.maxComputeWorkgroupsPerDimension;
+        }
+        return Reflect.get(target, property, target);
+      }
+    })
+  });
+  try {
+    return await callback();
+  } finally {
+    if (originalDescriptor) {
+      Object.defineProperty(device, 'limits', originalDescriptor);
+    } else {
+      Object.defineProperty(device, 'limits', {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: originalLimits
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Goals

Introduce an optional WebGPU exact-similarity backend that borrows ordinary fixed-size-list GPU table/vector columns without taking ownership of their allocations.

## Changes

- Add the tree-shakeable `@luma.gl/experimental/luvs` subpath without expanding the main experimental entry point.
- Import `GPUVector<FixedSizeList<'float32', N>>`, `GPUTable`, and `GPURecordBatch` into non-owning graph views while preserving row counts, source batches, padding, offsets, ordinary source-ID/validity siblings, and table ownership.
- Implement bounded, cross-shard global top-K for squared Euclidean distance, cosine similarity, and inner product.
- Support batched queries, deterministic score/source-ID ordering, LuxFilter masks, bounded GPU-hashed candidate allowlists, query-specific masks, self-exclusion, and caller-owned GPU outputs.
- Verify CPU-oracle equivalence, full Float32-range cosine normalization, invalid values, zero vectors, empty inputs, storage/dispatch limits, repeated encoding, and real Arrow-table-to-search execution.
- Keep Apache Arrow entirely outside production luVS code; Arrow is used only by an end-to-end test.

## Verification

- [x] `nvm use` (Node 22.22.1).
- [ ] `yarn install`: the configured package registry returns HTTP 403 for required tarballs; verification reuses the existing isolated dependency tree and CI performs the normal immutable install.
- [x] Focused exact-search Node and actual Chromium/WebGPU browser coverage with an independent CPU oracle.
- [x] `yarn lint fix`.
- [x] `yarn build` after final source and formatting changes.
- [x] `yarn test-node`.
- [x] `CI=true yarn test` with real Chromium/WebGPU coverage.
- [x] `yarn website:build`.
- [x] `(cd website && yarn build)`.

## Risks

Imported graph views are borrowed and remain valid only while their source table/vector allocations remain alive; oversized candidate-ID indexes fail early and recommend source-aligned masks.
