### PR TITLE
feat(arrow): ingest fixed-size-list columns through GPU tables

### DIFF
--- a/docs/api-reference/arrow/arrow-conversion.mdx
+++ b/docs/api-reference/arrow/arrow-conversion.mdx
@@ -6,6 +6,44 @@ import {ArrowDocsTabs} from '@site/src/components/docs/arrow-docs-tabs';
 
 ## Arrow Vector Factories
 
+## Fixed-Size-List Storage Columns
+
+`makeGPUVectorFromArrow()` and `makeGPUTableFromArrowTable()` upload numeric
+Arrow `FixedSizeList` columns wider than four elements as ordinary
+`GPUVector<'fixed-size-list<format,size>'>` values. The vector remains aligned
+with its containing table: `length` counts source rows, `valueLength` counts
+flattened elements, and original Arrow record batches remain separate GPU
+record batches.
+
+When calling `makeGPUVectorFromArrow()` directly, provide
+`{format: 'fixed-size-list<float32,768>'}` to retain that exact fixed-list
+generic in TypeScript; Arrow's runtime `FixedSizeList` type cannot otherwise
+encode the numeric width in its compile-time type.
+
+```ts
+import {makeGPUTableFromArrowTable} from '@luma.gl/arrow';
+
+const table = makeGPUTableFromArrowTable(device, arrowTable, {
+  shaderLayout: {
+    attributes: [],
+    bindings: [
+      {name: 'embedding', type: 'read-only-storage', group: 0, location: 0},
+      {name: 'sourceIds', type: 'read-only-storage', group: 0, location: 1}
+    ]
+  },
+  validityColumns: {embedding: 'embeddingValidity'}
+});
+```
+
+The optional `validityColumns` mapping materializes a named, table-owned Uint32
+column that combines nullable parent rows and nullable child values. Stable row
+identifiers remain ordinary non-null sibling columns. Use
+`fixedSizeListColumns: ['embedding']` when a short one-to-four-element column
+should intentionally retain fixed-size-list storage semantics instead of its
+default vertex format. For physically padded rows, specify
+`validityColumns: {embedding: {name: 'embeddingValidity', dimensions: 3}}` to
+ignore nullable padding after the three meaningful coordinates.
+
 ## List Columns
 
 Arrow vector factories also support variable-length Arrow list columns whose

--- a/docs/api-reference/arrow/supported-arrow-types.mdx
+++ b/docs/api-reference/arrow/supported-arrow-types.mdx
@@ -57,6 +57,7 @@ migration.
 | `Float32` | `float32` | yes |
 | `FixedSizeList<Float32, 3>` | `float32x3` | yes |
 | `FixedSizeList<Uint8, 4>` as normalized color | `unorm8x4` | yes |
+| `FixedSizeList<Float32, 768>` embedding | `fixed-size-list<float32,768>` | no |
 | `List<FixedSizeList<Float32, 3>>` path coordinates | `vertex-list<float32x3>` | no |
 | `List<FixedSizeList<Uint8, 4>>` vertex colors | `vertex-list<unorm8x4>` | no |
 
@@ -64,6 +65,14 @@ migration.
 metadata owned by the producing adapter. They are not automatically exposed as
 ordinary vertex attributes; path, text, polygon, and geometry adapters must
 expand them or bind their flattened values explicitly.
+
+Numeric `FixedSizeList` columns wider than four elements become first-class
+`fixed-size-list<format,size>` storage columns. Their `GPUVector.length` is the
+logical table-row count, while `valueLength` counts flattened list elements.
+Short fixed-size lists retain their existing vertex-compatible formats unless
+the table adapter explicitly selects them with `fixedSizeListColumns`.
+`validityColumns` can materialize a caller-named Uint32 table column combining
+parent-row and child-coordinate validity.
 
 Status: ✅ directly supported, 🟡 conditionally supported, ❌ not supported.
 The `nullable` column refers to columns with actual null rows, not just nullable
@@ -73,7 +82,7 @@ schema fields with `nullCount: 0`.
 
 | Arrow data type | GPU<br/>upload | nullable | Upload notes | Shader-facing<br/>use | Higher-level<br/>model support |
 | --- | :---: | :---: | --- | --- | --- |
-| `Int8 \| Uint8 \| Int16 \| Uint16 \|`<br/>`Int32 \| Uint32 \| Float16 \| Float32` | ✅ | ❌ | Scalar `GPUVector` or selected `GPUTable` columns. | Scalar attributes or storage rows, subject to shader type and vertex format compatibility. | Numeric table workflows and scalar style rows such as text angles, text sizes, and path widths. |
+| `Int8 \| Uint8 \| Int16 \| Uint16 \|`<br/>`Int32 \| Uint32 \| Float16 \| Float32` | ✅ | ✅ | Scalar `GPUVector` or selected `GPUTable` columns preserve normalized null bitmaps and nullable Arrow readback. | Scalar attributes or storage rows, subject to shader type and vertex format compatibility; consumers must explicitly honor validity. | Numeric table workflows and scalar style rows such as text angles, text sizes, and path widths; stable source-ID consumers reject actual null identifiers. |
 | `Float64` | 🟡 | ❌ | Raw values can be copied into a `GPUVector`, but generic render paths should repack them to `Float32`, origin-relative `Float32`, or `u32` word pairs at conversion boundaries. | No generic `f64` vertex attribute or WGSL scalar path; use prepared Float32 values or custom word-pair helpers. | Matrix columns truncate to Float32; Float64 paths become per-row Float32 deltas plus retained origins. |
 | `Uint64` carrying DGGS cell keys | 🟡 | ❌ | DGGS WebGPU helpers retain Uint64 rows as word-pair storage. | Read through DGGS WGSL helpers or expand through `convertDggsCellKeysToGPUPaths()`; not a generic vertex attribute. | Global grid cell keys parsed from UTF-8 geohash, quadkey, S2, A5, or H3 IDs. |
 | `Bool` | ❌ | ❌ | Arrow Bool values are bit-packed, so they are not a directly uploadable scalar buffer. Repack to `Uint8` or `Uint32` when shaders need flags. | Use as integer 0/1 flags after repacking; otherwise keep on CPU as row metadata. | `closeArrowPaths()` accepts `Vector<Bool>` closed-path flags as CPU input; a future adapter could publish repacked flag columns. |
@@ -82,7 +91,8 @@ schema fields with `nullCount: 0`.
 
 | Arrow data type | GPU<br/>upload | nullable | Upload notes | Shader-facing<br/>use | Higher-level<br/>model support |
 | --- | :---: | :---: | --- | --- | --- |
-| `FixedSizeList<numeric,`<br/>`1 \| 2 \| 3 \| 4>` | ✅ | ❌ | Fixed-width GPU rows.<br/>Planned color adapter support will expand three-component RGB source rows to four-component RGBA rows. `FixedSizeList<Float16, 4>` is the compact scene-linear/HDR color form. | Vector attributes or storage rows; 3-component 8-bit and 16-bit integer formats are WebGL-only unless padded. | Positions, point rows, normalized colors, scene-linear/HDR colors, pixel offsets, clip rectangles, mesh attributes, and path style rows. |
+| `FixedSizeList<numeric,`<br/>`1 \| 2 \| 3 \| 4>` | ✅ | ✅ | Fixed-width GPU rows preserve parent and child validity for Arrow readback; optional `validityColumns` publishes explicit GPU row masks.<br/>Planned color adapter support will expand three-component RGB source rows to four-component RGBA rows. `FixedSizeList<Float16, 4>` is the compact scene-linear/HDR color form. | Vector attributes or storage rows; consuming models must explicitly honor validity, and 3-component 8-bit and 16-bit integer formats are WebGL-only unless padded. | Positions, point rows, normalized colors, scene-linear/HDR colors, pixel offsets, clip rectangles, mesh attributes, and path style rows. |
+| `FixedSizeList<numeric,`<br/>`5 \| 384 \| 768 \| 1536 \| ...>` | ✅ | ✅ | Row-aligned `fixed-size-list<format,size>` GPU table storage; optional `validityColumns` publishes explicit parent/child row masks. | WebGPU storage and compute; never synthesized into a generic vertex attribute. | High-dimensional embeddings, fixed-width feature vectors, and caller-owned table-based compute. |
 | `List<FixedSizeList<Float32,`<br/>`2 \| 3 \| 4>>` | ✅ | ❌ | Flattened GPU path-coordinate values plus copied list-offset metadata. | Not a single generic vertex attribute.<br/>`PathAttributeModel` expands to segment attributes; `PathStorageModel` keeps values in storage. | `ArrowPathRenderer.convertToGPUVectors()` uploads unchanged unless closed-path normalization is requested.<br/>Outputs feed `PathAttributeModel` and `PathStorageModel`. |
 | `List<FixedSizeList<Float64,`<br/>`2 \| 3 \| 4>>` | 🟡 | ❌ | Path conversion emits per-row Float32 deltas plus copied list-offset metadata.<br/>CPU Float64 per-row origins are retained separately. | Not a generic vertex attribute.<br/>Attribute paths convert deltas on CPU; WebGPU storage paths convert them on GPU before rendering. | `ArrowPathRenderer.convertToGPUVectors()` and `convertArrowPathToGPUVectors()` convert attribute paths.<br/>`ArrowPathRenderer.convertToGPUVectors(..., {model: 'storage'})` converts storage paths. |
 | `List<numeric \|`<br/>`FixedSizeList<numeric, 1 \| 2 \| 3 \| 4>>` | ✅ | ❌ | Flattened GPU values plus copied list-offset metadata. | Not a single generic vertex attribute; consume through storage/compute code or model-specific expansion. | Generic variable-length numeric storage/readback. Model support is documented by the model-specific rows above. |

--- a/docs/api-reference/tables/gpu-vector-format.mdx
+++ b/docs/api-reference/tables/gpu-vector-format.mdx
@@ -193,12 +193,15 @@ vectors or bind them explicitly through storage.
 | --- | --- |
 | `FixedSizeList<Float32, 3>` | `float32x3` |
 | `FixedSizeList<Uint8, 4>` as normalized color | `unorm8x4` |
+| `FixedSizeList<Float32, 384>` embedding | `fixed-size-list<float32,384>` |
+| `FixedSizeList<Float32, 768>` embedding | `fixed-size-list<float32,768>` |
+| `FixedSizeList<Float32, 1536>` embedding | `fixed-size-list<float32,1536>` |
 | `List<FixedSizeList<Float32, 3>>` path coordinates | `vertex-list<float32x3>` |
 | `List<FixedSizeList<Uint8, 4>>` vertex colors | `vertex-list<unorm8x4>` |
 
-Short fixed-size lists preserve their existing vertex-attribute mappings.
-Fixed-size-list GPU formats can describe wider caller-created table storage
-without inventing unsupported vertex formats such as `float32x768`.
+Short fixed-size lists preserve their existing vertex-attribute mappings. Wide
+fixed-size lists become ordinary row-aligned storage columns without inventing
+unsupported formats such as `float32x768`.
 
 Arrow data types remain adapter/readback metadata. Table core uses
 `GPUVectorFormat`.

--- a/modules/arrow/src/arrow/gpu/arrow-gpu-data.ts
+++ b/modules/arrow/src/arrow/gpu/arrow-gpu-data.ts
@@ -26,6 +26,14 @@ import {
 /** Compact CPU metadata required to reconstruct variable-width Arrow chunks after GPU readback. */
 export type GPUDataReadbackMetadata =
   | {
+      /** Metadata variant for nullable fixed-width numeric rows. */
+      kind: 'numeric';
+      /** Number of nullable rows in the source Arrow chunk. */
+      nullCount: number;
+      /** Copied row validity bitmap normalized to this data chunk. */
+      nullBitmap: Uint8Array;
+    }
+  | {
       /** Metadata variant for Arrow UTF-8 value bytes. */
       kind: 'utf8';
       /** Chunk-local Arrow value offsets normalized to the copied GPU byte range. */
@@ -48,6 +56,18 @@ export type GPUDataReadbackMetadata =
       nullBitmap?: Uint8Array;
       /** Number of flattened numeric value bytes to read back from the GPU buffer. */
       valueByteLength: number;
+    }
+  | {
+      /** Metadata variant for nullable fixed-size-list storage rows. */
+      kind: 'fixed-size-list';
+      /** Number of nullable parent rows in the source Arrow chunk. */
+      nullCount: number;
+      /** Optional copied parent validity bitmap normalized to this chunk. */
+      nullBitmap?: Uint8Array;
+      /** Number of nullable flattened child values in the uploaded rows. */
+      childNullCount: number;
+      /** Optional copied child validity bitmap normalized to this chunk. */
+      childNullBitmap?: Uint8Array;
     };
 
 type GPUVectorReadableBuffer = Pick<Buffer, 'readAsync'>;
@@ -108,6 +128,10 @@ export function getArrowDataBufferSource<T extends AttributeArrowType>(
   data: Data<T>
 ): NumericArrowType['TArray'];
 export function getArrowDataBufferSource(data: Data): NumericArrowType['TArray'] {
+  if (DataType.isFixedSizeList(data.type)) {
+    return getArrowFixedSizeListDataBufferSource(data as Data<FixedSizeList<NumericArrowType>>);
+  }
+
   const {values, startElement, elementCount} = getArrowDataValueRange(data);
   if (values.length < elementCount) {
     throw new Error('Arrow data values are shorter than the logical upload length');
@@ -181,6 +205,15 @@ export function getArrowVariableLengthAttributeDataBufferSource(
 
 /** Copy compact variable-width reconstruction metadata without retaining Arrow value buffers. */
 export function getArrowGPUDataReadbackMetadata(data: Data): GPUDataReadbackMetadata | undefined {
+  if (DataType.isInt(data.type) || DataType.isFloat(data.type)) {
+    const nullBitmap = copyNormalizedArrowNullBitmap(data);
+    return nullBitmap ? {kind: 'numeric', nullCount: data.nullCount, nullBitmap} : undefined;
+  }
+
+  if (DataType.isFixedSizeList(data.type)) {
+    return getArrowFixedSizeListReadbackMetadata(data as Data<FixedSizeList<NumericArrowType>>);
+  }
+
   if (DataType.isUtf8(data.type)) {
     const values = getArrowUtf8DataBufferSource(data as Data<Utf8>);
     return {
@@ -206,6 +239,35 @@ export function getArrowGPUDataReadbackMetadata(data: Data): GPUDataReadbackMeta
   }
 
   return undefined;
+}
+
+/** Returns row validity for a fixed-size list, including nullable selected child coordinates. */
+export function getArrowFixedSizeListRowValidity(
+  data: Data<FixedSizeList<NumericArrowType>>,
+  dimensions = data.type.listSize
+): Uint32Array | undefined {
+  const childData = data.children[0] as Data<NumericArrowType> | undefined;
+  if (!childData) {
+    throw new Error('Arrow FixedSizeList data has no child values');
+  }
+  if (!Number.isSafeInteger(dimensions) || dimensions < 1 || dimensions > data.type.listSize) {
+    throw new Error('Arrow FixedSizeList validity dimensions must fit within the list width');
+  }
+  if (data.nullCount === 0 && childData.nullCount === 0) {
+    return undefined;
+  }
+
+  const parentChildOffset = getArrowFixedSizeListParentChildOffset(data, childData);
+  const validity = new Uint32Array(data.length);
+  for (let rowIndex = 0; rowIndex < data.length; rowIndex++) {
+    let valid = isArrowDataValueValid(data, rowIndex);
+    for (let dimensionIndex = 0; valid && dimensionIndex < dimensions; dimensionIndex++) {
+      const childIndex = parentChildOffset + rowIndex * data.type.listSize + dimensionIndex;
+      valid = childIndex < childData.length && isArrowDataValueValid(childData, childIndex);
+    }
+    validity[rowIndex] = Number(valid);
+  }
+  return validity;
 }
 
 /** Returns a typed array that can be passed directly to `device.createBuffer()`. */
@@ -362,7 +424,140 @@ export async function readArrowGPUDataAsync<T extends DataType>(data: GPUData): 
     byteOffset: data.byteOffset,
     byteStride: data.byteStride
   });
-  return vector.data[0] as unknown as Data<T>;
+  const packedData = vector.data[0];
+  const metadata = data.readbackMetadata as GPUDataReadbackMetadata | undefined;
+  if (metadata?.kind === 'numeric') {
+    return new Data<T>(dataType, 0, data.length, metadata.nullCount, {
+      [BufferType.DATA]: packedData.values,
+      [BufferType.VALIDITY]: metadata.nullBitmap
+    });
+  }
+  if (DataType.isFixedSizeList(dataType) && metadata?.kind === 'fixed-size-list') {
+    return makeArrowNullableFixedSizeListData(
+      packedData as Data<FixedSizeList<NumericArrowType>>,
+      metadata
+    ) as unknown as Data<T>;
+  }
+  return packedData as unknown as Data<T>;
+}
+
+function getArrowFixedSizeListDataBufferSource(
+  data: Data<FixedSizeList<NumericArrowType>>
+): NumericArrowType['TArray'] {
+  const childData = data.children[0] as Data<NumericArrowType> | undefined;
+  const values = childData?.values as NumericArrowType['TArray'] | undefined;
+  if (!childData || !values) {
+    throw new Error('Arrow FixedSizeList data has no child values');
+  }
+
+  const rowStride = data.type.listSize;
+  const elementCount = data.length * rowStride;
+  const childValuesAlreadySliced =
+    values.length === elementCount || values.length <= childData.length;
+  const startElement = childValuesAlreadySliced
+    ? 0
+    : (childData.offset ?? 0) + data.offset * rowStride;
+  const availableElementCount = Math.max(
+    0,
+    Math.min(
+      elementCount,
+      values.length - startElement,
+      childData.length - (childValuesAlreadySliced ? 0 : data.offset * rowStride)
+    )
+  );
+  if (availableElementCount === elementCount) {
+    return values.subarray(startElement, startElement + elementCount) as NumericArrowType['TArray'];
+  }
+
+  for (
+    let rowIndex = Math.floor(availableElementCount / rowStride);
+    rowIndex < data.length;
+    rowIndex++
+  ) {
+    if (isArrowDataValueValid(data, rowIndex)) {
+      throw new Error('Arrow FixedSizeList child values are shorter than their logical row count');
+    }
+  }
+
+  const paddedValues = createTypedArrayLike(values, elementCount);
+  paddedValues.set(values.subarray(startElement, startElement + availableElementCount) as never);
+  return paddedValues;
+}
+
+function getArrowFixedSizeListReadbackMetadata(
+  data: Data<FixedSizeList<NumericArrowType>>
+): Extract<GPUDataReadbackMetadata, {kind: 'fixed-size-list'}> | undefined {
+  const childData = data.children[0] as Data<NumericArrowType> | undefined;
+  if (!childData) {
+    throw new Error('Arrow FixedSizeList data has no child values');
+  }
+  if (data.nullCount === 0 && childData.nullCount === 0) {
+    return undefined;
+  }
+
+  const flattenedLength = data.length * data.type.listSize;
+  const parentChildOffset = getArrowFixedSizeListParentChildOffset(data, childData);
+  const childNullBitmap = new Uint8Array(Math.ceil(flattenedLength / 8));
+  let childNullCount = 0;
+  for (let childIndex = 0; childIndex < flattenedLength; childIndex++) {
+    const sourceChildIndex = parentChildOffset + childIndex;
+    if (sourceChildIndex < childData.length && isArrowDataValueValid(childData, sourceChildIndex)) {
+      childNullBitmap[childIndex >> 3] |= 1 << (childIndex & 7);
+    } else {
+      childNullCount++;
+    }
+  }
+
+  return {
+    kind: 'fixed-size-list',
+    nullCount: data.nullCount,
+    nullBitmap: copyNormalizedArrowNullBitmap(data),
+    childNullCount,
+    ...(childNullCount > 0 ? {childNullBitmap} : {})
+  };
+}
+
+function getArrowFixedSizeListParentChildOffset(
+  data: Data<FixedSizeList<NumericArrowType>>,
+  childData: Data<NumericArrowType>
+): number {
+  const values = childData.values as NumericArrowType['TArray'];
+  const childValuesAlreadySliced =
+    values.length <= childData.length || values.length === data.length * data.type.listSize;
+  return childValuesAlreadySliced ? 0 : data.offset * data.type.listSize;
+}
+
+function isArrowDataValueValid(data: Data, valueIndex: number): boolean {
+  if (data.nullCount === 0 || !data.nullBitmap) {
+    return true;
+  }
+  const bitmapIndex = data.offset + valueIndex;
+  return ((data.nullBitmap[bitmapIndex >> 3] ?? 0) & (1 << (bitmapIndex & 7))) !== 0;
+}
+
+function makeArrowNullableFixedSizeListData(
+  data: Data<FixedSizeList<NumericArrowType>>,
+  metadata: Extract<GPUDataReadbackMetadata, {kind: 'fixed-size-list'}>
+): Data<FixedSizeList<NumericArrowType>> {
+  const packedChild = data.children[0] as Data<NumericArrowType>;
+  const child = new Data<NumericArrowType>(
+    packedChild.type,
+    0,
+    packedChild.length,
+    metadata.childNullCount,
+    {
+      [BufferType.DATA]: packedChild.values,
+      ...(metadata.childNullBitmap ? {[BufferType.VALIDITY]: metadata.childNullBitmap} : {})
+    }
+  );
+  return new Data<FixedSizeList<NumericArrowType>>(
+    data.type,
+    0,
+    data.length,
+    metadata.nullCount,
+    {...(metadata.nullBitmap ? {[BufferType.VALIDITY]: metadata.nullBitmap} : {})},
+    [child]
+  );
 }
 
 function getArrowDataValueRange(data: Data): {

--- a/modules/arrow/src/arrow/gpu/arrow-gpu-table-adapters.ts
+++ b/modules/arrow/src/arrow/gpu/arrow-gpu-table-adapters.ts
@@ -5,6 +5,7 @@
 import {
   Buffer,
   Device,
+  type BufferLayout,
   type ShaderLayout,
   type SignedDataType,
   type VertexFormat
@@ -15,6 +16,8 @@ import {
   GPURecordBatch,
   GPUTable,
   GPUVector,
+  getGPUVectorFormatInfo,
+  type FixedSizeList as GPUFixedSizeList,
   type GPURecordBatchSourceInfo,
   type GPUField,
   type GPUVectorBufferProps,
@@ -40,12 +43,14 @@ import {
   Uint32,
   Uint8,
   Utf8,
-  Vector
+  Vector,
+  makeData
 } from 'apache-arrow';
 import {getArrowFieldByPath, getArrowVectorByPath} from '../arrow-utils/arrow-paths';
 import {getArrowBufferLayout, type ArrowVertexFormatOptions} from '../engine/arrow-shader-layout';
 import {
   getArrowDataBufferSource,
+  getArrowFixedSizeListRowValidity,
   getArrowGPUDataReadbackMetadata,
   getArrowTypeByteStride,
   getArrowTypeStride,
@@ -62,6 +67,7 @@ import {
   isInstanceArrowType,
   isVariableLengthAttributeArrowType,
   type AttributeArrowType,
+  type NumericArrowType,
   type VariableLengthAttributeArrowType
 } from '../arrow-utils/arrow-types';
 import {getArrowMatrixVectorInfo} from '../vectors/arrow-matrix-vector';
@@ -94,6 +100,10 @@ type VertexFormatForArrowType<T extends DataType> =
   T extends FixedSizeList<infer ChildType>
     ? VertexFormatForArrowFixedSizeListType<ChildType>
     : VertexFormatForArrowScalarType<T>;
+type FixedSizeListFormatForArrowScalarType<T extends DataType> =
+  VertexFormatForArrowScalarType<T> extends infer Format extends VertexFormat
+    ? GPUFixedSizeList<Format>
+    : never;
 export type GPUVectorFormatForArrowType<T extends DataType = DataType> = T extends Utf8
   ? ValueList<'uint8'>
   : T extends Dictionary
@@ -102,9 +112,13 @@ export type GPUVectorFormatForArrowType<T extends DataType = DataType> = T exten
       ? VertexFormatForArrowType<ChildType> extends never
         ? GPUVectorFormat
         : VertexList<VertexFormatForArrowType<ChildType>>
-      : VertexFormatForArrowType<T> extends never
-        ? GPUVectorFormat
-        : VertexFormatForArrowType<T>;
+      : T extends FixedSizeList<infer ChildType>
+        ?
+            | VertexFormatForArrowFixedSizeListType<ChildType>
+            | FixedSizeListFormatForArrowScalarType<ChildType>
+        : VertexFormatForArrowType<T> extends never
+          ? GPUVectorFormat
+          : VertexFormatForArrowType<T>;
 
 /** Props for uploading one Arrow vector into GPU storage. */
 export type GPUVectorFromArrowProps<Format extends GPUVectorFormat = GPUVectorFormat> =
@@ -122,6 +136,16 @@ type ArrowGPUDataProps = GPUVectorBufferProps & {
   format?: GPUVectorFormat;
 };
 
+/** Caller-selected row-validity storage sibling for one fixed-size-list Arrow column. */
+export type ArrowGPUValidityColumn =
+  | string
+  | {
+      /** Name of the uint32 GPU table column that receives nonzero-valid row flags. */
+      name: string;
+      /** Meaningful leading child coordinates; nullable trailing padding is ignored. */
+      dimensions?: number;
+    };
+
 /** Props for uploading one Arrow record batch into a generic GPU record batch. */
 export type GPURecordBatchFromArrowRecordBatchProps = ArrowVertexFormatOptions & {
   /** Shader layout that selects which Arrow columns should be uploaded. */
@@ -130,8 +154,12 @@ export type GPURecordBatchFromArrowRecordBatchProps = ArrowVertexFormatOptions &
   arrowPaths?: Record<string, string>;
   /** Buffer props applied to Arrow-backed GPU vectors. */
   bufferProps?: GPUVectorBufferProps;
+  /** Storage-selected columns that should use fixed-size-list format even for short rows. */
+  fixedSizeListColumns?: readonly string[];
   /** Optional source-row identity retained for picking and diagnostics. */
   sourceInfo?: GPURecordBatchSourceInfo;
+  /** Explicitly materialized uint32 row-validity siblings keyed by selected column name. */
+  validityColumns?: Record<string, ArrowGPUValidityColumn>;
 };
 
 /** Props for uploading one Arrow table into a generic GPU table. */
@@ -142,6 +170,10 @@ export type GPUTableFromArrowTableProps = ArrowVertexFormatOptions & {
   arrowPaths?: Record<string, string>;
   /** Buffer props applied to Arrow-backed GPU vectors. */
   bufferProps?: GPUVectorBufferProps;
+  /** Storage-selected columns that should use fixed-size-list format even for short rows. */
+  fixedSizeListColumns?: readonly string[];
+  /** Explicitly materialized uint32 row-validity siblings keyed by selected column name. */
+  validityColumns?: Record<string, ArrowGPUValidityColumn>;
 };
 
 /** Returns the GPUVector memory format implied by an Arrow data type. */
@@ -153,11 +185,14 @@ function getGPUVectorFormatFromArrowDataType(type: DataType): GPUVectorFormat {
     : elementType;
   const size = DataType.isFixedSizeList(elementType) ? elementType.listSize : 1;
 
-  if (!Number.isInteger(size) || size < 1 || size > 4) {
+  if (!Number.isSafeInteger(size) || size < 1 || (size > 4 && isVertexList)) {
     throw new Error(`Cannot synthesize a GPUVector format for Arrow type ${type}`);
   }
 
   const signedDataType = getSignedArrowDataType(scalarType);
+  if (size > 4) {
+    return `fixed-size-list<${signedDataType},${size}>`;
+  }
   if (signedDataType === 'float16' && size === 3) {
     throw new Error('Cannot synthesize a float16x3 GPUVector format');
   }
@@ -219,6 +254,12 @@ export function makeGPUDataFromArrowData<T extends DataType>(
   const arrowType = data.type as T;
   const {format = getGPUVectorFormatForArrowType(arrowType), ...bufferProps} = props;
   const readbackMetadata = getArrowGPUDataReadbackMetadata(data) as GPUDataReadbackMetadata;
+  const variableLengthMetadata =
+    readbackMetadata?.kind === 'utf8' || readbackMetadata?.kind === 'variable-length-attribute'
+      ? readbackMetadata
+      : undefined;
+  const numericNullBitmap =
+    readbackMetadata?.kind === 'numeric' ? readbackMetadata.nullBitmap : undefined;
 
   if (isArrowUtf8DictionaryType(arrowType)) {
     const byteStride = getArrowTypeByteStride(arrowType.indices);
@@ -248,15 +289,15 @@ export function makeGPUDataFromArrowData<T extends DataType>(
       dataType: arrowType,
       format,
       length: data.length,
-      valueLength: readbackMetadata?.valueByteLength ?? 0,
+      valueLength: variableLengthMetadata?.valueByteLength ?? 0,
       stride: 1,
       byteStride: 1,
       rowByteLength: 1,
       ownsBuffer: true,
       readbackMetadata,
-      valueOffsets: readbackMetadata?.valueOffsets,
-      nullBitmap: readbackMetadata?.nullBitmap,
-      valueByteLength: readbackMetadata?.valueByteLength
+      valueOffsets: variableLengthMetadata?.valueOffsets,
+      nullBitmap: variableLengthMetadata?.nullBitmap,
+      valueByteLength: variableLengthMetadata?.valueByteLength
     });
   }
 
@@ -283,9 +324,9 @@ export function makeGPUDataFromArrowData<T extends DataType>(
       rowByteLength: byteStride,
       ownsBuffer: true,
       readbackMetadata,
-      valueOffsets: readbackMetadata?.valueOffsets,
-      nullBitmap: readbackMetadata?.nullBitmap,
-      valueByteLength: readbackMetadata?.valueByteLength
+      valueOffsets: variableLengthMetadata?.valueOffsets,
+      nullBitmap: variableLengthMetadata?.nullBitmap,
+      valueByteLength: variableLengthMetadata?.valueByteLength
     });
   }
 
@@ -303,7 +344,18 @@ export function makeGPUDataFromArrowData<T extends DataType>(
     byteStride,
     rowByteLength: byteStride,
     ownsBuffer: true,
-    readbackMetadata
+    readbackMetadata,
+    ...(readbackMetadata?.kind === 'fixed-size-list'
+      ? {
+          nullBitmap: makeArrowGPUValidityBitmap(
+            getArrowFixedSizeListRowValidity(
+              data as unknown as Data<FixedSizeList<NumericArrowType>>
+            )
+          )
+        }
+      : numericNullBitmap
+        ? {nullBitmap: numericNullBitmap}
+        : {})
   });
 }
 
@@ -330,6 +382,17 @@ export function makeGPUVectorFromArrow<T extends DataType>(
   const arrowType = vector.type as T;
   const matrixInfo = getArrowMatrixVectorInfo(vector);
   const isCanonicalFloat32Matrix = matrixInfo && isCanonicalFloat32ArrowMatrixInfo(matrixInfo);
+  if (
+    !preserveDataChunks &&
+    (DataType.isFixedSizeList(arrowType) ||
+      DataType.isInt(arrowType) ||
+      DataType.isFloat(arrowType)) &&
+    vector.data.some(data => data.nullCount > 0 || (data.children[0]?.nullCount ?? 0) > 0)
+  ) {
+    throw new Error(
+      'Nullable Arrow numeric and FixedSizeList vectors require preserved GPU data chunks'
+    );
+  }
   const requiresChunkedUpload =
     DataType.isUtf8(arrowType) ||
     isArrowUtf8DictionaryType(arrowType) ||
@@ -340,7 +403,12 @@ export function makeGPUVectorFromArrow<T extends DataType>(
     );
   }
 
-  if (!isInstanceArrowType(arrowType) && !isCanonicalFloat32Matrix && !requiresChunkedUpload) {
+  if (
+    !isInstanceArrowType(arrowType) &&
+    !isStorageFixedSizeListArrowType(arrowType) &&
+    !isCanonicalFloat32Matrix &&
+    !requiresChunkedUpload
+  ) {
     throw new Error(`GPUVector does not support Arrow type ${arrowType}`);
   }
 
@@ -387,10 +455,12 @@ export function makeGPUVectorFromArrow<T extends DataType>(
         dataType: arrowType,
         format: vectorFormat,
         length: vector.length,
-        valueLength: vector.data.reduce(
-          (totalValueLength, chunk) => totalValueLength + getArrowDataValueLength(chunk),
-          0
-        ),
+        valueLength: getGPUVectorFormatInfo(vectorFormat).fixedSizeList
+          ? vector.length * (getGPUVectorFormatInfo(vectorFormat).listSize ?? 1)
+          : vector.data.reduce(
+              (totalValueLength, chunk) => totalValueLength + getArrowDataValueLength(chunk),
+              0
+            ),
         stride,
         byteStride,
         rowByteLength: byteStride,
@@ -421,6 +491,9 @@ export function makeGPURecordBatchFromArrowRecordBatch(
   const selectedNames = new Set<string>();
 
   for (const layout of bufferLayout) {
+    if (options.fixedSizeListColumns?.includes(layout.name)) {
+      throw new Error('Arrow fixed-size-list GPU columns require a storage shader binding');
+    }
     const arrowPath = options.arrowPaths?.[layout.name] || layout.name;
     const vector = getArrowVectorByPath(table, arrowPath);
     const sourceField = getArrowFieldByPath(table, arrowPath);
@@ -449,11 +522,12 @@ export function makeGPURecordBatchFromArrowRecordBatch(
     if (!vector || !sourceField) {
       continue;
     }
-    gpuData[storageBinding.name] = makeGPUDataFromArrowRecordBatchVector(
-      device,
-      vector as Vector,
-      options.bufferProps
-    );
+    gpuData[storageBinding.name] = makeGPUDataFromArrowRecordBatchVector(device, vector as Vector, {
+      ...options.bufferProps,
+      ...(options.fixedSizeListColumns?.includes(storageBinding.name)
+        ? {format: getFixedSizeListGPUVectorFormatForArrowType(vector.type)}
+        : {})
+    });
     fields.push({
       name: storageBinding.name,
       format: gpuData[storageBinding.name].format,
@@ -461,6 +535,42 @@ export function makeGPURecordBatchFromArrowRecordBatch(
       metadata: new Map(sourceField.metadata)
     });
     selectedNames.add(storageBinding.name);
+  }
+
+  for (const columnName of options.fixedSizeListColumns ?? []) {
+    if (!selectedNames.has(columnName)) {
+      throw new Error('Arrow fixed-size-list GPU columns require a selected storage binding');
+    }
+  }
+
+  for (const [sourceName, validityColumn] of Object.entries(options.validityColumns ?? {})) {
+    const validityName = typeof validityColumn === 'string' ? validityColumn : validityColumn.name;
+    if (!selectedNames.has(sourceName) || selectedNames.has(validityName)) {
+      throw new Error('Arrow GPU validity columns require a selected source and unique output');
+    }
+    const arrowPath = options.arrowPaths?.[sourceName] || sourceName;
+    const vector = getArrowVectorByPath(table, arrowPath);
+    if (!DataType.isFixedSizeList(vector.type)) {
+      throw new Error('Arrow GPU validity columns require FixedSizeList source data');
+    }
+    const dimensions =
+      typeof validityColumn === 'string'
+        ? vector.type.listSize
+        : (validityColumn.dimensions ?? vector.type.listSize);
+    const [data, ...remainingData] = vector.data;
+    if (!data || remainingData.length > 0) {
+      throw new Error('Arrow RecordBatch columns require exactly one Arrow Data chunk');
+    }
+    const validity =
+      getArrowFixedSizeListRowValidity(data as Data<FixedSizeList<NumericArrowType>>, dimensions) ??
+      new Uint32Array(data.length).fill(1);
+    const validityData = makeData({type: new Uint32(), length: validity.length, data: validity});
+    gpuData[validityName] = makeGPUDataFromArrowData(device, validityData, {
+      ...options.bufferProps,
+      format: 'uint32'
+    });
+    fields.push({name: validityName, format: 'uint32', nullable: false, metadata: new Map()});
+    selectedNames.add(validityName);
   }
 
   return new GPURecordBatch({
@@ -491,7 +601,12 @@ function makeGPUDataFromArrowRecordBatchVector(
       'GPUVector matrix columns require canonical Float32 column-major wgsl-storage values; use convertArrowMatrixToGPUVector() first'
     );
   }
-  if (!isInstanceArrowType(arrowType) && !isCanonicalFloat32Matrix && !requiresChunkedUpload) {
+  if (
+    !isInstanceArrowType(arrowType) &&
+    !isStorageFixedSizeListArrowType(arrowType) &&
+    !isCanonicalFloat32Matrix &&
+    !requiresChunkedUpload
+  ) {
     throw new Error(`GPUVector does not support Arrow type ${arrowType}`);
   }
 
@@ -527,22 +642,15 @@ export function makeGPUTableFromArrowTable(
   const firstBatch = batches[0];
   const bufferLayout =
     firstBatch?.bufferLayout ??
-    getArrowBufferLayout(options.shaderLayout, {
-      arrowTable: table,
-      arrowPaths: options.arrowPaths,
-      allowWebGLOnlyFormats: options.allowWebGLOnlyFormats
-    });
+    (options.shaderLayout.attributes.length === 0 && table.batches.length === 0
+      ? []
+      : getArrowBufferLayout(options.shaderLayout, {
+          arrowTable: table,
+          arrowPaths: options.arrowPaths,
+          allowWebGLOnlyFormats: options.allowWebGLOnlyFormats
+        }));
   const schema = firstBatch?.schema ?? {
-    fields: bufferLayout.map(layout => {
-      const arrowPath = options.arrowPaths?.[layout.name] || layout.name;
-      const sourceField = getArrowFieldByPath(table, arrowPath);
-      return {
-        name: layout.name,
-        format: layout.format as GPUVectorFormat,
-        nullable: sourceField.nullable,
-        metadata: new Map(sourceField.metadata)
-      };
-    }),
+    fields: getArrowEmptyTableGPUFields(table, options, bufferLayout),
     metadata: new Map(table.schema.metadata)
   };
 
@@ -552,6 +660,79 @@ export function makeGPUTableFromArrowTable(
         schema,
         bufferLayout
       });
+}
+
+function getArrowEmptyTableGPUFields(
+  table: Table,
+  options: GPUTableFromArrowTableProps,
+  bufferLayout: BufferLayout[]
+): GPUField[] {
+  const fields: GPUField[] = bufferLayout.map(layout => {
+    const arrowPath = options.arrowPaths?.[layout.name] || layout.name;
+    const sourceField = getArrowFieldByPath(table, arrowPath);
+    return {
+      name: layout.name,
+      format: layout.format as GPUVectorFormat,
+      nullable: sourceField.nullable,
+      metadata: new Map(sourceField.metadata)
+    };
+  });
+  const selectedNames = new Set(fields.map(field => field.name));
+
+  for (const storageBinding of getArrowStorageBindings(options.shaderLayout)) {
+    if (selectedNames.has(storageBinding.name)) {
+      throw new Error(
+        `GPURecordBatch shader input "${storageBinding.name}" cannot be both an attribute and a storage binding`
+      );
+    }
+    const arrowPath = options.arrowPaths?.[storageBinding.name] || storageBinding.name;
+    const sourceField = tryGetArrowFieldByPath(table, arrowPath);
+    if (!sourceField) {
+      continue;
+    }
+    fields.push({
+      name: storageBinding.name,
+      format: options.fixedSizeListColumns?.includes(storageBinding.name)
+        ? getFixedSizeListGPUVectorFormatForArrowType(sourceField.type)
+        : getGPUVectorFormatForArrowType(sourceField.type),
+      nullable: sourceField.nullable,
+      metadata: new Map(sourceField.metadata)
+    });
+    selectedNames.add(storageBinding.name);
+  }
+
+  for (const columnName of options.fixedSizeListColumns ?? []) {
+    if (!selectedNames.has(columnName) || bufferLayout.some(layout => layout.name === columnName)) {
+      throw new Error('Arrow fixed-size-list GPU columns require a selected storage binding');
+    }
+  }
+
+  for (const [sourceName, validityColumn] of Object.entries(options.validityColumns ?? {})) {
+    const validityName = typeof validityColumn === 'string' ? validityColumn : validityColumn.name;
+    if (!selectedNames.has(sourceName) || selectedNames.has(validityName)) {
+      throw new Error('Arrow GPU validity columns require a selected source and unique output');
+    }
+    const arrowPath = options.arrowPaths?.[sourceName] || sourceName;
+    const sourceField = getArrowFieldByPath(table, arrowPath);
+    if (!DataType.isFixedSizeList(sourceField.type)) {
+      throw new Error('Arrow GPU validity columns require FixedSizeList source data');
+    }
+    const dimensions =
+      typeof validityColumn === 'string'
+        ? sourceField.type.listSize
+        : (validityColumn.dimensions ?? sourceField.type.listSize);
+    if (
+      !Number.isSafeInteger(dimensions) ||
+      dimensions < 1 ||
+      dimensions > sourceField.type.listSize
+    ) {
+      throw new Error('Arrow FixedSizeList validity dimensions must fit within the list width');
+    }
+    fields.push({name: validityName, format: 'uint32', nullable: false, metadata: new Map()});
+    selectedNames.add(validityName);
+  }
+
+  return fields;
 }
 
 /** Reads one generic GPU data range back into Arrow `Data`. */
@@ -602,6 +783,14 @@ function isArrowUtf8DictionaryType(type: DataType): type is ArrowUtf8Dictionary 
   );
 }
 
+function isStorageFixedSizeListArrowType(type: DataType): boolean {
+  return (
+    DataType.isFixedSizeList(type) &&
+    type.listSize > 4 &&
+    (DataType.isFloat(type.children[0]?.type) || DataType.isInt(type.children[0]?.type))
+  );
+}
+
 function getGPUVectorFormatForArrowType(type: DataType): GPUVectorFormat {
   const matrixInfo = getArrowMatrixVectorInfo({type});
   if (matrixInfo) {
@@ -619,6 +808,18 @@ function getGPUVectorFormatForArrowType(type: DataType): GPUVectorFormat {
     return getGPUVectorFormatFromArrowDataType(type.indices);
   }
   return getGPUVectorFormatFromArrowDataType(type);
+}
+
+function getFixedSizeListGPUVectorFormatForArrowType(type: DataType): GPUVectorFormat {
+  if (
+    !DataType.isFixedSizeList(type) ||
+    !Number.isSafeInteger(type.listSize) ||
+    type.listSize < 1
+  ) {
+    throw new Error('Arrow fixed-size-list GPU columns require valid FixedSizeList source data');
+  }
+  const signedDataType = getSignedArrowDataType(type.children[0].type);
+  return `fixed-size-list<${signedDataType},${type.listSize}>`;
 }
 
 function isCanonicalFloat32ArrowMatrixInfo(
@@ -644,6 +845,22 @@ function getArrowDataValueLength(data: Data): number {
   const firstValueOffset = valueOffsets[0] ?? 0;
   const lastValueOffset = valueOffsets[data.length] ?? firstValueOffset;
   return Math.max(0, lastValueOffset - firstValueOffset);
+}
+
+function makeArrowGPUValidityBitmap(validity: Uint32Array | undefined): Uint8Array | undefined {
+  if (!validity) {
+    return undefined;
+  }
+  const nullBitmap = new Uint8Array(Math.ceil(validity.length / 8));
+  let hasInvalidRows = false;
+  for (let rowIndex = 0; rowIndex < validity.length; rowIndex++) {
+    if (validity[rowIndex] !== 0) {
+      nullBitmap[rowIndex >> 3] |= 1 << (rowIndex & 7);
+    } else {
+      hasInvalidRows = true;
+    }
+  }
+  return hasInvalidRows ? nullBitmap : undefined;
 }
 
 function getArrowDictionaryIndexBufferSource(data: Data<ArrowUtf8Dictionary>): ArrayBufferView {

--- a/modules/arrow/src/index.ts
+++ b/modules/arrow/src/index.ts
@@ -224,6 +224,7 @@ export {
   makeGPUVectorFromArrow,
   readArrowGPUDataAsync,
   readArrowGPUVectorAsync,
+  type ArrowGPUValidityColumn,
   type GPURecordBatchFromArrowRecordBatchProps,
   type GPUTableFromArrowTableProps,
   type GPUVectorFromArrowProps,

--- a/modules/arrow/test/arrow/arrow-gpu-fixed-size-list.node.spec.ts
+++ b/modules/arrow/test/arrow/arrow-gpu-fixed-size-list.node.spec.ts
@@ -1,0 +1,5 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import './arrow-gpu-fixed-size-list.spec';

--- a/modules/arrow/test/arrow/arrow-gpu-fixed-size-list.spec.ts
+++ b/modules/arrow/test/arrow/arrow-gpu-fixed-size-list.spec.ts
@@ -1,0 +1,859 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {
+  makeGPUDataFromArrowData,
+  makeGPURecordBatchFromArrowRecordBatch,
+  makeGPUTableFromArrowTable,
+  makeGPUVectorFromArrow,
+  readArrowGPUDataAsync,
+  readArrowGPUVectorAsync
+} from '@luma.gl/arrow';
+import type {ShaderLayout} from '@luma.gl/core';
+import {GPUData, GPURecordBatch, GPUTable, GPUVector} from '@luma.gl/tables';
+import {getWebGPUTestDevice, NullDevice} from '@luma.gl/test-utils';
+import * as arrow from 'apache-arrow';
+
+type ArrowEmbeddingType = arrow.FixedSizeList<arrow.Float32>;
+
+test('Arrow GPU adapters represent high-dimensional FixedSizeList rows as table-native storage', async t => {
+  const device = new NullDevice({});
+
+  for (const dimensions of [5, 384, 768, 1536]) {
+    const values = Float32Array.from({length: dimensions * 2}, (_, index) => index + 0.5);
+    const source = makeArrowEmbeddingVector(dimensions, values);
+    const data = makeGPUDataFromArrowData(device, source.data[0]);
+    const vector = makeGPUVectorFromArrow(device, source, {name: 'embedding'});
+
+    t.equal(data.format, `fixed-size-list<float32,${dimensions}>`, 'data retains its row shape');
+    t.equal(
+      vector.format,
+      `fixed-size-list<float32,${dimensions}>`,
+      'vector retains its row shape'
+    );
+    t.equal(data.length, 2, 'GPUData length counts logical rows');
+    t.equal(vector.length, 2, 'GPUVector length counts logical rows');
+    t.equal(data.valueLength, values.length, 'GPUData value length counts flattened values');
+    t.equal(vector.valueLength, values.length, 'GPUVector value length counts flattened values');
+    t.equal(data.stride, dimensions, 'GPUData stride retains flattened row coordinates');
+    t.equal(vector.byteStride, dimensions * Float32Array.BYTES_PER_ELEMENT, 'retains row bytes');
+    t.deepEqual(await readFloat32Data(data), values, 'GPUData uploads the original coordinates');
+    t.deepEqual(
+      await readFloat32Data(vector.data[0]),
+      values,
+      'GPUVector uploads the original coordinates'
+    );
+
+    const dataBuffer = data.buffer;
+    const vectorBuffer = vector.data[0].buffer;
+    data.destroy();
+    vector.destroy();
+    t.ok(dataBuffer.destroyed, 'GPUData destroys its own buffer');
+    t.ok(vectorBuffer.destroyed, 'GPUVector destroys its owned chunk');
+  }
+
+  t.end();
+});
+
+test('Arrow GPU adapters preserve existing short vertex formats and explicitly requested storage rows', t => {
+  const device = new NullDevice({});
+
+  for (const dimensions of [1, 2, 3, 4]) {
+    const source = makeArrowEmbeddingVector(dimensions, Float32Array.from({length: dimensions}));
+    const vertex = makeGPUVectorFromArrow(device, source);
+    const storage = makeGPUVectorFromArrow(device, source, {
+      format: `fixed-size-list<float32,${dimensions}>`
+    });
+
+    t.equal(
+      vertex.format,
+      dimensions === 1 ? 'float32' : `float32x${dimensions}`,
+      'default short rows remain compatible with existing vertex attributes'
+    );
+    t.equal(
+      storage.format,
+      `fixed-size-list<float32,${dimensions}>`,
+      'explicit short storage rows retain a first-class fixed-size-list format'
+    );
+    t.equal(storage.length, 1, 'explicit storage rows remain row oriented');
+    t.equal(storage.valueLength, dimensions, 'explicit storage rows expose flattened values');
+
+    vertex.destroy();
+    storage.destroy();
+  }
+
+  t.end();
+});
+
+test('Arrow GPU vectors preserve original FixedSizeList chunks, including empty chunks', async t => {
+  const device = new NullDevice({});
+  const source = new arrow.Vector<ArrowEmbeddingType>([
+    makeArrowEmbeddingData(5, new Float32Array([1, 2, 3, 4, 5])),
+    makeArrowEmbeddingData(5, new Float32Array(0)),
+    makeArrowEmbeddingData(5, new Float32Array([6, 7, 8, 9, 10, 11, 12, 13, 14, 15]))
+  ]);
+  const vector = makeGPUVectorFromArrow(device, source);
+
+  t.deepEqual(
+    vector.data.map(data => data.length),
+    [1, 0, 2],
+    'every source chunk, including an empty chunk, remains independently owned'
+  );
+  t.deepEqual(
+    vector.data.map(data => data.valueLength),
+    [5, 0, 10],
+    'flattened coordinates remain chunk aligned'
+  );
+  t.equal(vector.length, 3, 'aggregate vectors count rows');
+  t.equal(vector.valueLength, 15, 'aggregate vectors count flattened coordinates');
+  t.deepEqual(
+    Array.from(await readFloat32Data(vector.data[2])),
+    [6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+    'later source chunks start at their own allocation'
+  );
+
+  const reconstructed = await readArrowGPUVectorAsync<ArrowEmbeddingType>(vector);
+  t.equal(reconstructed.data.length, 3, 'Arrow readback preserves all source chunk boundaries');
+  vector.destroy();
+  t.end();
+});
+
+test('explicit non-null FixedSizeList compaction preserves flattened row metadata', async t => {
+  const device = new NullDevice({});
+  const source = new arrow.Vector<ArrowEmbeddingType>([
+    makeArrowEmbeddingData(5, new Float32Array([1, 2, 3, 4, 5])),
+    makeArrowEmbeddingData(5, new Float32Array([6, 7, 8, 9, 10]))
+  ]);
+  const vector = makeGPUVectorFromArrow(device, source, {preserveDataChunks: false});
+
+  t.equal(vector.data.length, 1, 'explicit compaction combines source chunks only when requested');
+  t.equal(vector.length, 2, 'packed fixed-list columns retain logical row counts');
+  t.equal(vector.valueLength, 10, 'packed fixed-list columns retain flattened value counts');
+  t.deepEqual(
+    Array.from(await readFloat32Data(vector.data[0])),
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    'explicit compaction retains every source coordinate'
+  );
+
+  const sourceIds = new arrow.Vector<arrow.Uint32>([
+    arrow.makeData({type: new arrow.Uint32(), length: 1, data: new Uint32Array([11])}),
+    arrow.makeData({type: new arrow.Uint32(), length: 1, data: new Uint32Array([22])})
+  ]);
+  const compactIds = makeGPUVectorFromArrow(device, sourceIds, {preserveDataChunks: false});
+  t.equal(compactIds.data.length, 1, 'explicit non-null scalar compaction remains supported');
+  t.deepEqual(
+    Array.from(await readUint32Data(compactIds.data[0])),
+    [11, 22],
+    'packed non-null source IDs retain their original values'
+  );
+  t.notOk(
+    compactIds.data[0].nullBitmap,
+    'non-null source IDs retain the allocation-free fast path'
+  );
+
+  vector.destroy();
+  compactIds.destroy();
+  t.end();
+});
+
+test('nullable FixedSizeList compaction is rejected rather than discarding Arrow validity', t => {
+  const device = new NullDevice({});
+  const parentNulls = arrow.vectorFromArray(
+    [[1, 2, 3, 4, 5], null],
+    makeArrowEmbeddingType(5)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const childNulls = arrow.vectorFromArray(
+    [[1, null, 3, 4, 5]],
+    makeArrowEmbeddingType(5)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const shortParentNulls = arrow.vectorFromArray(
+    [[1, 2, 3], null],
+    makeArrowEmbeddingType(3)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+
+  for (const source of [parentNulls, childNulls, shortParentNulls]) {
+    t.throws(
+      () => makeGPUVectorFromArrow(device, source, {preserveDataChunks: false}),
+      /require preserved GPU data chunks/,
+      'explicit packing cannot silently discard nullable parent or child metadata'
+    );
+  }
+
+  const nullableSourceIds = arrow.vectorFromArray([11, null, 22], new arrow.Uint32());
+  t.throws(
+    () => makeGPUVectorFromArrow(device, nullableSourceIds, {preserveDataChunks: false}),
+    /require preserved GPU data chunks/,
+    'nullable scalar source IDs cannot be compacted into invented valid zero IDs'
+  );
+
+  t.end();
+});
+
+test('Arrow FixedSizeList uploads apply parent and child displacements exactly once', async t => {
+  const device = new NullDevice({});
+  const backingValues = Float32Array.from({length: 32}, (_, index) => index);
+  const child = new arrow.Data<arrow.Float32>(new arrow.Float32(), 2, 20, 0, {
+    [arrow.BufferType.DATA]: backingValues
+  });
+  const parent = new arrow.Data<ArrowEmbeddingType>(makeArrowEmbeddingType(5), 1, 2, 0, {}, [
+    child
+  ]);
+  const independentOffsets = makeGPUVectorFromArrow(device, new arrow.Vector([parent]));
+
+  t.deepEqual(
+    Array.from(await readFloat32Data(independentOffsets.data[0])),
+    [7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+    'independent parent and child offsets each contribute once'
+  );
+
+  const source = makeArrowEmbeddingVector(
+    5,
+    Float32Array.from({length: 20}, (_, index) => index)
+  );
+  const sliced = makeGPUVectorFromArrow(device, source.slice(1, 3));
+  t.deepEqual(
+    Array.from(await readFloat32Data(sliced.data[0])),
+    [5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+    'already-sliced Arrow child views are not displaced a second time'
+  );
+
+  independentOffsets.destroy();
+  sliced.destroy();
+  t.end();
+});
+
+test('nullable FixedSizeList Arrow readback preserves parent and child validity', async t => {
+  const device = new NullDevice({});
+  const source = arrow.vectorFromArray(
+    [[0, 1, 2, 3, 4], null, [10, null, 12, 13, 14], [15, 16, 17, 18, 19]],
+    makeArrowEmbeddingType(5)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const vector = makeGPUVectorFromArrow(device, source.slice(1, 4));
+  const data = await readArrowGPUDataAsync<ArrowEmbeddingType>(vector.data[0]);
+  const reconstructed = await readArrowGPUVectorAsync<ArrowEmbeddingType>(vector);
+
+  t.equal(vector.data[0].readbackMetadata?.kind, 'fixed-size-list', 'keeps compact null metadata');
+  t.deepEqual(
+    Array.from(vector.data[0].nullBitmap ?? []),
+    [4],
+    'generic row validity combines sliced parent and child nulls'
+  );
+  t.deepEqual(
+    Array.from(vector.data[0].readbackMetadata?.nullBitmap ?? []),
+    [6],
+    'Arrow readback metadata independently preserves original parent validity'
+  );
+  t.equal(data.nullCount, 1, 'retains parent null rows');
+  t.equal(data.children[0].nullCount, 6, 'retains null parent coordinates and nullable children');
+  t.deepEqual(
+    getArrowRows(reconstructed),
+    [null, [10, null, 12, 13, 14], [15, 16, 17, 18, 19]],
+    'readback reconstructs sliced parent and child nulls'
+  );
+
+  vector.destroy();
+  t.end();
+});
+
+test('nullable short FixedSizeList vertex rows retain existing formats and correct readback', async t => {
+  const device = new NullDevice({});
+  const source = arrow.vectorFromArray(
+    [[1, 2, 3], null, [4, null, 6], [7, 8, 9]],
+    makeArrowEmbeddingType(3)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const vector = makeGPUVectorFromArrow(device, source.slice(1, 4));
+
+  t.equal(vector.format, 'float32x3', 'nullable short lists retain the existing vertex format');
+  t.deepEqual(
+    getArrowRows(await readArrowGPUVectorAsync<ArrowEmbeddingType>(vector)),
+    [null, [4, null, 6], [7, 8, 9]],
+    'nullable sliced short-list parents and children survive readback'
+  );
+
+  vector.destroy();
+  t.end();
+});
+
+test('nullable numeric Arrow GPU data retains normalized row validity and readback', async t => {
+  const device = new NullDevice({});
+  const values: Array<number | null> = Array.from({length: 12}, (_, rowIndex) => rowIndex + 10);
+  values[10] = null;
+  const source = arrow.vectorFromArray(values, new arrow.Uint32()).slice(9, 12);
+  const vector = makeGPUVectorFromArrow(device, source);
+  const data = await readArrowGPUDataAsync<arrow.Uint32>(vector.data[0]);
+  const reconstructed = await readArrowGPUVectorAsync<arrow.Uint32>(vector);
+
+  t.equal(vector.format, 'uint32', 'nullable IDs remain ordinary scalar table data');
+  t.deepEqual(Array.from(vector.data[0].nullBitmap ?? []), [5], 'normalizes a sliced row bitmap');
+  t.equal(vector.data[0].readbackMetadata?.kind, 'numeric', 'retains compact scalar null metadata');
+  t.equal(data.nullCount, 1, 'retains nullable row counts on direct chunk readback');
+  t.deepEqual(
+    Array.from(reconstructed),
+    [19, null, 21],
+    'numeric Arrow readback preserves nullable source IDs'
+  );
+
+  const nonNullVector = makeGPUVectorFromArrow(device, arrow.makeVector(new Uint32Array([11, 22])));
+  t.notOk(nonNullVector.data[0].nullBitmap, 'non-null scalar chunks avoid validity copies');
+  t.notOk(nonNullVector.data[0].readbackMetadata, 'non-null scalar readback stays allocation free');
+
+  vector.destroy();
+  nonNullVector.destroy();
+  t.end();
+});
+
+test('Arrow FixedSizeList adapters zero-pad child coordinates omitted for trailing null rows', async t => {
+  const device = new NullDevice({});
+  const values = Float32Array.from({length: 384}, (_, index) => index + 1);
+  const source = arrow.vectorFromArray(
+    [Array.from(values), null, null],
+    makeArrowEmbeddingType(384)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const vector = makeGPUVectorFromArrow(device, source);
+  const uploaded = await readFloat32Data(vector.data[0]);
+
+  t.equal(source.data[0].children[0].length, 384, 'Arrow omitted both trailing null child rows');
+  t.equal(vector.length, 3, 'GPU storage retains every logical parent row');
+  t.equal(vector.valueLength, 3 * 384, 'GPU storage allocates every physical row');
+  t.deepEqual(uploaded.subarray(0, 384), values, 'the present row remains unchanged');
+  t.ok(
+    uploaded.subarray(384).every(value => value === 0),
+    'missing null rows become zero padding'
+  );
+  t.deepEqual(
+    getArrowRows(await readArrowGPUVectorAsync<ArrowEmbeddingType>(vector)),
+    [Array.from(values), null, null],
+    'readback preserves omitted trailing parent null rows'
+  );
+
+  const sliced = makeGPUVectorFromArrow(device, source.slice(1));
+  t.equal(sliced.length, 2, 'sliced trailing null rows remain logical rows');
+  t.ok(
+    (await readFloat32Data(sliced.data[0])).every(value => value === 0),
+    'sliced trailing null coordinates remain safely zero padded'
+  );
+
+  vector.destroy();
+  sliced.destroy();
+  t.end();
+});
+
+test('Arrow FixedSizeList adapters reject missing child values for non-null parent rows', t => {
+  const device = new NullDevice({});
+  const child = arrow.makeData({
+    type: new arrow.Float32(),
+    length: 5,
+    data: new Float32Array([1, 2, 3, 4, 5])
+  });
+  const parent = new arrow.Data<ArrowEmbeddingType>(makeArrowEmbeddingType(5), 0, 2, 0, {}, [
+    child
+  ]);
+
+  t.throws(
+    () => makeGPUDataFromArrowData(device, parent),
+    /shorter than their logical row count/,
+    'corrupt non-null rows are not silently padded'
+  );
+
+  t.end();
+});
+
+test('Arrow GPU tables preserve embedding batches, stable ID columns, and source provenance', async t => {
+  const device = new NullDevice({});
+  const dimensions = 384;
+  const firstBatch = makeArrowEmbeddingBatch(
+    dimensions,
+    Float32Array.from({length: dimensions * 2}, (_, index) => index),
+    new Uint32Array([91, 7])
+  );
+  const secondBatch = makeArrowEmbeddingBatch(
+    dimensions,
+    Float32Array.from({length: dimensions}, (_, index) => index + 1000),
+    new Uint32Array([42])
+  );
+  const table = makeGPUTableFromArrowTable(device, new arrow.Table([firstBatch, secondBatch]), {
+    shaderLayout: makeStorageShaderLayout('embedding', 'sourceIds'),
+    validityColumns: {embedding: 'embeddingValidity'}
+  });
+
+  t.ok(table instanceof GPUTable, 'uses the existing generic table owner');
+  t.ok(table.batches[0] instanceof GPURecordBatch, 'uses existing generic record batches');
+  t.ok(table.gpuVectors.embedding instanceof GPUVector, 'uses existing generic vector views');
+  t.ok(table.batches[0].gpuData.embedding instanceof GPUData, 'uses existing generic data chunks');
+  t.equal(table.gpuVectors.embedding.format, 'fixed-size-list<float32,384>', 'keeps row shape');
+  t.equal(table.gpuVectors.embedding.length, 3, 'embedding column length counts table rows');
+  t.deepEqual(
+    table.gpuVectors.embedding.data.map(data => data.length),
+    [2, 1],
+    'preserves Arrow record-batch boundaries'
+  );
+  t.deepEqual(
+    table.batches.map(batch => batch.sourceInfo),
+    [
+      {sourceBatchIndex: 0, sourceRowIndexOffset: 0, sourceRowCount: 2},
+      {sourceBatchIndex: 1, sourceRowIndexOffset: 2, sourceRowCount: 1}
+    ],
+    'preserves stable source-batch and source-row provenance'
+  );
+  t.deepEqual(
+    Array.from(await readUint32Data(table.batches[0].gpuData.sourceIds)),
+    [91, 7],
+    'stable IDs remain an ordinary uint32 sibling column'
+  );
+  t.deepEqual(
+    Array.from(await readUint32Data(table.batches[1].gpuData.sourceIds)),
+    [42],
+    'stable IDs preserve batch boundaries'
+  );
+  t.deepEqual(
+    Array.from(await readUint32Data(table.batches[0].gpuData.embeddingValidity)),
+    [1, 1],
+    'explicit validity siblings contain nonzero flags for valid rows'
+  );
+  t.deepEqual(table.bufferLayout, [], 'embedding storage does not become a vertex layout');
+
+  const ownedBuffers = table.batches.flatMap(batch =>
+    Object.values(batch.gpuData).map(data => data.buffer)
+  );
+  table.destroy();
+  t.ok(
+    ownedBuffers.every(buffer => buffer.destroyed),
+    'only the table hierarchy owns its buffers'
+  );
+  t.end();
+});
+
+test('Arrow GPU source-ID siblings preserve nullable scalar bitmaps instead of inventing ID zero', async t => {
+  const device = new NullDevice({});
+  const embedding = makeArrowEmbeddingVector(
+    5,
+    Float32Array.from({length: 15}, (_, index) => index)
+  );
+  const sourceIds = arrow.vectorFromArray([11, null, 22], new arrow.Uint32());
+  const table = makeGPUTableFromArrowTable(device, new arrow.Table({embedding, sourceIds}), {
+    shaderLayout: makeStorageShaderLayout('embedding', 'sourceIds')
+  });
+  const sourceIdData = table.batches[0].gpuData.sourceIds;
+
+  t.equal(sourceIdData.format, 'uint32', 'source IDs remain ordinary uint32 table data');
+  t.deepEqual(Array.from(sourceIdData.nullBitmap ?? []), [5], 'null source IDs remain observable');
+  t.deepEqual(
+    Array.from(await readUint32Data(sourceIdData)),
+    [11, 0, 22],
+    'the physical zero placeholder remains distinguishable through the null bitmap'
+  );
+  t.deepEqual(
+    Array.from(await readArrowGPUVectorAsync<arrow.Uint32>(table.gpuVectors.sourceIds)),
+    [11, null, 22],
+    'source-ID Arrow readback retains nulls rather than inventing a valid zero ID'
+  );
+
+  table.destroy();
+  t.end();
+});
+
+test('Arrow GPU record batches expose explicit FixedSizeList validity siblings', async t => {
+  const device = new NullDevice({});
+  const embedding = arrow.vectorFromArray(
+    [[0, 1, 2, 3, 4], null, [10, null, 12, 13, 14], [15, 16, 17, 18, 19]],
+    makeArrowEmbeddingType(5)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const arrowTable = new arrow.Table({
+    embedding: embedding.slice(1),
+    sourceIds: arrow.makeVector(new Uint32Array([90, 70, 50]))
+  });
+  const batch = makeGPURecordBatchFromArrowRecordBatch(device, arrowTable.batches[0], {
+    shaderLayout: makeStorageShaderLayout('embedding', 'sourceIds'),
+    validityColumns: {embedding: 'embeddingValidity'},
+    sourceInfo: {sourceBatchIndex: 3, sourceRowIndexOffset: 25, sourceRowCount: 3}
+  });
+
+  t.equal(batch.gpuData.embedding.format, 'fixed-size-list<float32,5>', 'keeps fixed row format');
+  t.deepEqual(
+    Array.from(await readUint32Data(batch.gpuData.embeddingValidity)),
+    [0, 0, 1],
+    'combines sliced parent validity and child-coordinate validity'
+  );
+  t.deepEqual(
+    Array.from(await readUint32Data(batch.gpuData.sourceIds)),
+    [90, 70, 50],
+    'explicit source IDs remain aligned with the sliced rows'
+  );
+  t.deepEqual(
+    batch.sourceInfo,
+    {sourceBatchIndex: 3, sourceRowIndexOffset: 25, sourceRowCount: 3},
+    'preserves explicit record-batch provenance'
+  );
+  t.deepEqual(
+    batch.schema.fields.map(field => field.name),
+    ['embedding', 'sourceIds', 'embeddingValidity'],
+    'the requested validity sibling participates in the ordinary GPU schema'
+  );
+
+  batch.destroy();
+  t.end();
+});
+
+test('sliced Arrow FixedSizeList validity remains aligned across bitmap byte boundaries', async t => {
+  const device = new NullDevice({});
+  const rows: Array<Array<number | null> | null> = Array.from({length: 12}, (_, rowIndex) =>
+    Array.from({length: 5}, (_, coordinateIndex) => rowIndex * 5 + coordinateIndex)
+  );
+  rows[9] = null;
+  rows[10] = [50, null, 52, 53, 54];
+  const source = arrow.vectorFromArray(
+    rows,
+    makeArrowEmbeddingType(5)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const table = makeGPUTableFromArrowTable(device, new arrow.Table({embedding: source.slice(9)}), {
+    shaderLayout: makeStorageShaderLayout('embedding'),
+    validityColumns: {embedding: 'embeddingValidity'}
+  });
+
+  t.deepEqual(
+    Array.from(await readUint32Data(table.batches[0].gpuData.embeddingValidity)),
+    [0, 0, 1],
+    'parent and child offsets remain correct after crossing bitmap byte boundaries'
+  );
+  t.deepEqual(
+    getArrowRows(await readArrowGPUVectorAsync<ArrowEmbeddingType>(table.gpuVectors.embedding)),
+    [null, [50, null, 52, 53, 54], [55, 56, 57, 58, 59]],
+    'Arrow readback retains sliced validity after the eighth parent row'
+  );
+
+  table.destroy();
+  t.end();
+});
+
+test('Arrow GPU tables distinguish semantic dimensions from nullable physical row padding', async t => {
+  const device = new NullDevice({});
+  const embedding = arrow.vectorFromArray(
+    [[1, 2, 3, null], [4, null, 6, 99], null],
+    makeArrowEmbeddingType(4)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const sourceTable = new arrow.Table({embedding});
+  const semanticTable = makeGPUTableFromArrowTable(device, sourceTable, {
+    shaderLayout: makeStorageShaderLayout('embedding'),
+    fixedSizeListColumns: ['embedding'],
+    validityColumns: {embedding: {name: 'embeddingValidity', dimensions: 3}}
+  });
+  const fullWidthTable = makeGPUTableFromArrowTable(device, sourceTable, {
+    shaderLayout: makeStorageShaderLayout('embedding'),
+    fixedSizeListColumns: ['embedding'],
+    validityColumns: {embedding: 'embeddingValidity'}
+  });
+
+  t.equal(
+    semanticTable.gpuVectors.embedding.format,
+    'fixed-size-list<float32,4>',
+    'explicitly requested short storage rows retain physical width'
+  );
+  t.equal(semanticTable.gpuVectors.embedding.byteStride, 16, 'retains padded row byte stride');
+  t.deepEqual(
+    Array.from(semanticTable.batches[0].gpuData.embedding.nullBitmap ?? []),
+    [0],
+    'generic physical-row validity conservatively includes nullable trailing padding'
+  );
+  t.deepEqual(
+    Array.from(await readUint32Data(semanticTable.batches[0].gpuData.embeddingValidity)),
+    [1, 0, 0],
+    'nullable trailing padding does not invalidate meaningful leading coordinates'
+  );
+  t.deepEqual(
+    Array.from(await readUint32Data(fullWidthTable.batches[0].gpuData.embeddingValidity)),
+    [0, 0, 0],
+    'default validity checks every physical child coordinate'
+  );
+
+  semanticTable.destroy();
+  fullWidthTable.destroy();
+  t.end();
+});
+
+test('Arrow GPU tables preserve existing short-list rendering layouts', t => {
+  const device = new NullDevice({});
+  const positions = makeArrowEmbeddingVector(3, new Float32Array([1, 2, 3, 4, 5, 6]));
+  const sourceTable = new arrow.Table({positions});
+  const vertexTable = makeGPUTableFromArrowTable(device, sourceTable, {
+    shaderLayout: {
+      attributes: [{name: 'positions', location: 0, type: 'vec3<f32>'}],
+      bindings: []
+    }
+  });
+  const storageTable = makeGPUTableFromArrowTable(device, sourceTable, {
+    shaderLayout: makeStorageShaderLayout('positions')
+  });
+
+  t.equal(vertexTable.gpuVectors.positions.format, 'float32x3', 'vertex columns remain unchanged');
+  t.deepEqual(
+    vertexTable.bufferLayout,
+    [{name: 'positions', format: 'float32x3'}],
+    'existing shader-facing vertex layouts remain unchanged'
+  );
+  t.equal(
+    storageTable.gpuVectors.positions.format,
+    'float32x3',
+    'existing short storage columns remain unchanged unless explicitly opted in'
+  );
+
+  vertexTable.destroy();
+  storageTable.destroy();
+  t.end();
+});
+
+test('empty Arrow GPU table schemas preserve FixedSizeList storage columns and validity siblings', t => {
+  const device = new NullDevice({});
+  const schema = new arrow.Schema([
+    new arrow.Field('embedding', makeArrowEmbeddingType(768), true),
+    new arrow.Field('sourceIds', new arrow.Uint32(), false)
+  ]);
+  const sourceTable = new arrow.Table(schema);
+  const table = makeGPUTableFromArrowTable(device, sourceTable, {
+    shaderLayout: makeStorageShaderLayout('embedding', 'sourceIds'),
+    validityColumns: {embedding: 'embeddingValidity'}
+  });
+
+  t.equal(table.numRows, 0, 'the table retains its empty row count');
+  t.equal(table.batches.length, 0, 'no synthetic source batch is introduced');
+  t.deepEqual(
+    table.schema.fields.map(field => [field.name, field.format]),
+    [
+      ['embedding', 'fixed-size-list<float32,768>'],
+      ['sourceIds', 'uint32'],
+      ['embeddingValidity', 'uint32']
+    ],
+    'the empty schema retains every selected storage and validity column'
+  );
+
+  table.destroy();
+  t.end();
+});
+
+test('Arrow GPU table fixed-list and validity options reject inconsistent selections', t => {
+  const device = new NullDevice({});
+  const sourceTable = new arrow.Table({
+    embedding: makeArrowEmbeddingVector(4, new Float32Array([1, 2, 3, 4])),
+    sourceIds: arrow.makeVector(new Uint32Array([10]))
+  });
+  const storageLayout = makeStorageShaderLayout('embedding', 'sourceIds');
+
+  t.throws(
+    () =>
+      makeGPUTableFromArrowTable(device, sourceTable, {
+        shaderLayout: storageLayout,
+        fixedSizeListColumns: ['missing']
+      }),
+    /selected storage binding/,
+    'rejects fixed-list columns that were not selected'
+  );
+  t.throws(
+    () =>
+      makeGPUTableFromArrowTable(device, sourceTable, {
+        shaderLayout: storageLayout,
+        fixedSizeListColumns: ['sourceIds']
+      }),
+    /FixedSizeList source data/,
+    'rejects scalar columns requested as fixed-size lists'
+  );
+  t.throws(
+    () =>
+      makeGPUTableFromArrowTable(device, sourceTable, {
+        shaderLayout: storageLayout,
+        validityColumns: {embedding: 'sourceIds'}
+      }),
+    /unique output/,
+    'rejects validity siblings that collide with existing table columns'
+  );
+  t.throws(
+    () =>
+      makeGPUTableFromArrowTable(device, sourceTable, {
+        shaderLayout: storageLayout,
+        validityColumns: {embedding: {name: 'embeddingValidity', dimensions: 5}}
+      }),
+    /validity dimensions/,
+    'rejects meaningful dimensions wider than the physical Arrow list'
+  );
+  t.throws(
+    () =>
+      makeGPUTableFromArrowTable(device, sourceTable, {
+        shaderLayout: {
+          attributes: [{name: 'embedding', location: 0, type: 'vec4<f32>'}],
+          bindings: []
+        },
+        fixedSizeListColumns: ['embedding']
+      }),
+    /storage shader binding/,
+    'rejects fixed-size-list columns exposed as vertex attributes'
+  );
+
+  t.end();
+});
+
+test('Arrow FixedSizeList table columns upload preserved batches to actual WebGPU buffers', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  for (const dimensions of [384, 768, 1536]) {
+    const firstValues = Float32Array.from({length: dimensions * 2}, (_, index) => index + 0.25);
+    const secondValues = Float32Array.from({length: dimensions}, (_, index) => index + 1000.5);
+    const source = new arrow.Table([
+      makeArrowEmbeddingBatch(dimensions, firstValues, new Uint32Array([12, 40])),
+      makeArrowEmbeddingBatch(dimensions, secondValues, new Uint32Array([8]))
+    ]);
+    const table = makeGPUTableFromArrowTable(device, source, {
+      shaderLayout: makeStorageShaderLayout('embedding', 'sourceIds'),
+      validityColumns: {embedding: 'embeddingValidity'}
+    });
+
+    t.equal(device.type, 'webgpu', 'the adapter uses a real browser WebGPU device');
+    t.deepEqual(
+      table.batches.map(batch => batch.numRows),
+      [2, 1],
+      `${dimensions}-dimensional rows preserve source record batches`
+    );
+    t.deepEqual(
+      await readFloat32Data(table.batches[0].gpuData.embedding),
+      firstValues,
+      `${dimensions}-dimensional first batch uploads intact`
+    );
+    t.deepEqual(
+      await readFloat32Data(table.batches[1].gpuData.embedding),
+      secondValues,
+      `${dimensions}-dimensional second batch uploads intact`
+    );
+    t.deepEqual(
+      Array.from(await readUint32Data(table.batches[0].gpuData.sourceIds)),
+      [12, 40],
+      'GPU-resident stable ID siblings preserve source rows'
+    );
+
+    const ownedBuffers = table.batches.flatMap(batch =>
+      Object.values(batch.gpuData).map(data => data.buffer)
+    );
+    table.destroy();
+    t.ok(
+      ownedBuffers.every(buffer => buffer.destroyed),
+      'the table owns every WebGPU buffer'
+    );
+  }
+
+  t.end();
+});
+
+test('nullable FixedSizeList rows and physical padding upload correctly on actual WebGPU', async t => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    t.comment('WebGPU is not available');
+    t.end();
+    return;
+  }
+
+  const embedding = arrow.vectorFromArray(
+    [[1, 2, 3, null], [4, null, 6, 99], null],
+    makeArrowEmbeddingType(4)
+  ) as arrow.Vector<ArrowEmbeddingType>;
+  const table = makeGPUTableFromArrowTable(device, new arrow.Table({embedding}), {
+    shaderLayout: makeStorageShaderLayout('embedding'),
+    fixedSizeListColumns: ['embedding'],
+    validityColumns: {embedding: {name: 'embeddingValidity', dimensions: 3}}
+  });
+
+  t.deepEqual(
+    Array.from(await readUint32Data(table.batches[0].gpuData.embeddingValidity)),
+    [1, 0, 0],
+    'actual GPU validity excludes nullable meaningful coordinates and null parents'
+  );
+  t.deepEqual(
+    Array.from(await readFloat32Data(table.batches[0].gpuData.embedding)),
+    [1, 2, 3, 0, 4, 0, 6, 99, 0, 0, 0, 0],
+    'actual GPU storage retains physical row padding and omitted trailing null rows'
+  );
+
+  table.destroy();
+  t.end();
+});
+
+function makeStorageShaderLayout(...names: string[]): ShaderLayout {
+  return {
+    attributes: [],
+    bindings: names.map((name, location) => ({
+      name,
+      type: 'read-only-storage',
+      group: 0,
+      location
+    }))
+  };
+}
+
+function makeArrowEmbeddingType(dimensions: number): ArrowEmbeddingType {
+  return new arrow.FixedSizeList(dimensions, new arrow.Field('value', new arrow.Float32(), true));
+}
+
+function makeArrowEmbeddingData(
+  dimensions: number,
+  values: Float32Array
+): arrow.Data<ArrowEmbeddingType> {
+  const child = arrow.makeData({type: new arrow.Float32(), length: values.length, data: values});
+  return arrow.makeData({
+    type: makeArrowEmbeddingType(dimensions),
+    length: values.length / dimensions,
+    child
+  });
+}
+
+function makeArrowEmbeddingVector(
+  dimensions: number,
+  values: Float32Array
+): arrow.Vector<ArrowEmbeddingType> {
+  return new arrow.Vector<ArrowEmbeddingType>([makeArrowEmbeddingData(dimensions, values)]);
+}
+
+function makeArrowEmbeddingBatch(
+  dimensions: number,
+  values: Float32Array,
+  sourceIds: Uint32Array
+): arrow.RecordBatch {
+  return new arrow.RecordBatch({
+    embedding: makeArrowEmbeddingData(dimensions, values),
+    sourceIds: arrow.makeData({type: new arrow.Uint32(), length: sourceIds.length, data: sourceIds})
+  });
+}
+
+function getArrowRows(
+  vector: arrow.Vector<ArrowEmbeddingType>
+): Array<Array<number | null> | null> {
+  const rows: Array<Array<number | null> | null> = [];
+  for (let rowIndex = 0; rowIndex < vector.length; rowIndex++) {
+    const row = vector.get(rowIndex);
+    rows.push(row ? Array.from(row) : null);
+  }
+  return rows;
+}
+
+async function readFloat32Data(data: GPUData): Promise<Float32Array> {
+  if (data.valueLength === 0) {
+    return new Float32Array(0);
+  }
+  const bytes = await data.buffer.readAsync(
+    data.byteOffset,
+    data.valueLength * Float32Array.BYTES_PER_ELEMENT
+  );
+  return new Float32Array(bytes.buffer, bytes.byteOffset, data.valueLength);
+}
+
+async function readUint32Data(data: GPUData): Promise<Uint32Array> {
+  if (data.length === 0) {
+    return new Uint32Array(0);
+  }
+  const bytes = await data.buffer.readAsync(
+    data.byteOffset,
+    data.length * Uint32Array.BYTES_PER_ELEMENT
+  );
+  return new Uint32Array(bytes.buffer, bytes.byteOffset, data.length);
+}

--- a/modules/arrow/test/index.ts
+++ b/modules/arrow/test/index.ts
@@ -5,6 +5,7 @@
 import './arrow/arrow-paths.spec';
 import './arrow/arrow-column-info.spec';
 import './arrow/arrow-fixed-size-list.spec';
+import './arrow/arrow-gpu-fixed-size-list.spec';
 import './arrow/arrow-variable-length-attribute-gpu-vector.spec';
 import './arrow/arrow-path-model.spec';
 import './arrow/arrow-splats.spec';


### PR DESCRIPTION
## Goals

Upload Apache Arrow fixed-size-list columns into the existing generic GPU table/vector model instead of adding a parallel embedding-specific storage owner.

## Changes

- Extend ordinary `makeGPUVectorFromArrow`, `makeGPURecordBatchFromArrowRecordBatch`, and `makeGPUTableFromArrowTable` adapters to emit first-class `fixed-size-list<format,size>` storage columns for wide Arrow lists.
- Preserve existing one-to-four-component vertex formats by default; expose explicit `fixedSizeListColumns` when a short column must retain fixed-list storage semantics.
- Add explicit caller-named `validityColumns` Uint32 siblings, combining parent-list and meaningful child-coordinate validity while supporting physical padding.
- Preserve original source chunks, record-batch provenance, arbitrary ordinary source-ID columns, independent parent/child slices, null bitmaps, trailing omitted null values, readback, and table ownership.
- Keep Apache Arrow dependencies exclusively in `@luma.gl/arrow`; introduce no luVS or experimental runtime dependency.
- Add focused Node and actual WebGPU regressions across 384/768/1536 widths, rendering-compatible short lists, offsets, nulls, valid/invalid trailing values, padding, IDs, and destruction.

## Verification

- [x] `nvm use` (Node 22.22.1).
- [ ] `yarn install`: the configured package registry returns HTTP 403 for required tarballs; verification reuses the existing isolated dependency tree and CI performs the normal immutable install.
- [x] Focused Arrow adapter Node and actual Chromium/WebGPU suites.
- [x] `yarn lint fix`.
- [x] `yarn build` after final source and formatting changes.
- [x] `yarn test-node`.
- [x] `CI=true yarn test` with real Chromium/WebGPU coverage.
- [x] `yarn website:build`.
- [x] `(cd website && yarn build)`.

## Risks

Nullable Arrow implementations may omit physical child values for trailing null rows; only invalid rows are zero-padded, while incomplete valid rows still fail explicitly. Validity upload is opt-in and owned by the ordinary GPU table.
