### PR TITLE
feat(experimental): build shared GPU hash indexes from preserved batches

### DIFF
--- a/modules/experimental/src/gpu-primitives/gpu-batch-hash-index.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-batch-hash-index.ts
@@ -1,0 +1,223 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {GraphVectorView, type GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
+import {
+  doGraphDataViewsOverlap,
+  validateMatchingVectorTopology,
+  validatePackedUint32View
+} from './graph-data-view-utils';
+import {
+  addGPUHashIndexBuildBatchesToGraph,
+  GPU_HASH_INDEX_STATISTICS_LENGTH,
+  type GPUHashIndexBuildBatch,
+  type GPUHashIndexStats,
+  type GPUHashIndexView
+} from './gpu-hash-index';
+
+const MAXIMUM_UINT32 = 0xffffffff;
+
+/** Properties for rebuilding one hash index from ordered, preserved source batches. */
+export type GPUBatchHashIndexProps = {
+  /** Prefix for the shared initialization and ordered per-batch graph passes. */
+  id?: string;
+  /** Ordered packed unsigned key chunks. */
+  keys: GraphVectorView<'uint32'>;
+  /** Optional packed values with exactly the same ordered chunk topology as `keys`. */
+  values?: GraphVectorView<'uint32'>;
+  /** Optional packed nonzero/zero validity with exactly the same source topology. */
+  validity?: GraphVectorView<'uint32'>;
+  /** First generated value for each source chunk. Mutually exclusive with `values`. */
+  firstValues?: readonly number[];
+  /** Caller-owned power-of-two key table shared by all source chunks. */
+  tableKeys: GraphDataView<'uint32'>;
+  /** Caller-owned values aligned with `tableKeys`. */
+  tableValues: GraphDataView<'uint32'>;
+  /** Caller-owned six-row cumulative build-statistics block. */
+  statistics: GraphDataView<'uint32'>;
+  /** Maximum slots examined per valid input row. Defaults to table capacity. */
+  maxProbeCount?: number;
+};
+
+/** CPU-visible storage, bounded-work, and preserved source-topology facts. */
+export type GPUBatchHashIndexStats = GPUHashIndexStats & {
+  batchCount: number;
+  inputLength: number;
+};
+
+/**
+ * Rebuilds one packed unsigned-key hash index from ordered source chunks.
+ *
+ * Chunks retain their original GPU buffers and are processed in source order. Duplicate keys
+ * retain the globally earliest source row, including duplicates encountered in later chunks.
+ * Zero-validity rows are silently excluded; valid reserved keys increment the invalid statistic.
+ */
+export class GPUBatchHashIndex implements GPUHashIndexView {
+  readonly id: string;
+  readonly keys: GraphVectorView<'uint32'>;
+  readonly values?: GraphVectorView<'uint32'>;
+  readonly validity?: GraphVectorView<'uint32'>;
+  readonly firstValues: readonly number[];
+  readonly tableKeys: GraphDataView<'uint32'>;
+  readonly tableValues: GraphDataView<'uint32'>;
+  readonly statistics: GraphDataView<'uint32'>;
+  readonly maxProbeCount: number;
+  readonly stats: GPUBatchHashIndexStats;
+  readonly updatePolicy = 'rebuild' as const;
+
+  constructor(props: GPUBatchHashIndexProps) {
+    this.id = props.id ?? 'gpu-batch-hash-index';
+    this.keys = props.keys;
+    this.values = props.values;
+    this.validity = props.validity;
+    this.tableKeys = props.tableKeys;
+    this.tableValues = props.tableValues;
+    this.statistics = props.statistics;
+    this.maxProbeCount = props.maxProbeCount ?? this.tableKeys.length;
+
+    validateSourceVector(this.keys, `${this.id} keys`);
+    if (this.values) {
+      validateSourceVector(this.values, `${this.id} values`);
+      validateMatchingVectorTopology(this.keys, this.values, `${this.id} values`);
+    }
+    if (this.validity) {
+      validateSourceVector(this.validity, `${this.id} validity`);
+      validateMatchingVectorTopology(this.keys, this.validity, `${this.id} validity`);
+    }
+    if (this.values && props.firstValues !== undefined) {
+      throw new Error(`${this.id} values and firstValues are mutually exclusive`);
+    }
+
+    let firstSourceRow = 0;
+    const defaultFirstValues = this.keys.data.map(chunk => {
+      const firstValue = firstSourceRow;
+      firstSourceRow += chunk.length;
+      return firstValue;
+    });
+    this.firstValues = Object.freeze(
+      props.firstValues === undefined ? defaultFirstValues : [...props.firstValues]
+    );
+    if (this.firstValues.length !== this.keys.data.length) {
+      throw new Error(`${this.id} firstValues must contain one value per source chunk`);
+    }
+    for (const [chunkIndex, chunk] of this.keys.data.entries()) {
+      const firstValue = this.firstValues[chunkIndex];
+      if (
+        !Number.isSafeInteger(firstValue) ||
+        firstValue < 0 ||
+        firstValue > MAXIMUM_UINT32 ||
+        (chunk.length > 0 && firstValue + chunk.length - 1 > MAXIMUM_UINT32)
+      ) {
+        throw new Error(`${this.id} generated values must fit in uint32`);
+      }
+    }
+
+    for (const [view, name] of [
+      [this.tableKeys, 'tableKeys'],
+      [this.tableValues, 'tableValues'],
+      [this.statistics, 'statistics']
+    ] as const) {
+      validatePackedUint32View(view, `${this.id} ${name}`);
+    }
+    if (
+      !Number.isSafeInteger(this.tableKeys.length) ||
+      this.tableKeys.length < 1 ||
+      !Number.isInteger(Math.log2(this.tableKeys.length))
+    ) {
+      throw new Error(`${this.id} table capacity must be a positive power of two`);
+    }
+    if (this.tableKeys.length > MAXIMUM_UINT32) {
+      throw new Error(`${this.id} table capacity must fit in uint32`);
+    }
+    if (this.tableValues.length !== this.tableKeys.length) {
+      throw new Error(`${this.id} table key and value capacities must match`);
+    }
+    if (this.statistics.length < GPU_HASH_INDEX_STATISTICS_LENGTH) {
+      throw new Error(`${this.id} statistics must contain six uint32 rows`);
+    }
+    if (
+      !Number.isSafeInteger(this.maxProbeCount) ||
+      this.maxProbeCount < 1 ||
+      this.maxProbeCount > this.tableKeys.length
+    ) {
+      throw new Error(`${this.id} maxProbeCount must be an integer from one through capacity`);
+    }
+    if (this.keys.length * this.maxProbeCount > MAXIMUM_UINT32) {
+      throw new Error(`${this.id} aggregate probe count must fit in uint32 statistics`);
+    }
+    validateDisjointViews(this);
+
+    this.stats = Object.freeze({
+      capacity: this.tableKeys.length,
+      maxProbeCount: this.maxProbeCount,
+      tableByteLength: this.tableKeys.length * 8,
+      statisticsByteLength: GPU_HASH_INDEX_STATISTICS_LENGTH * 4,
+      outputByteLength: this.tableKeys.length * 8 + GPU_HASH_INDEX_STATISTICS_LENGTH * 4,
+      batchCount: this.keys.data.length,
+      inputLength: this.keys.length
+    });
+  }
+
+  /** Adds one shared clear and sequential chunk-local build/finalize passes to a graph. */
+  addToGraph<Parameters>(graph: GPUCommandGraph<Parameters>): void {
+    const views = [
+      ...this.keys.data,
+      ...(this.values?.data ?? []),
+      ...(this.validity?.data ?? []),
+      this.tableKeys,
+      this.tableValues,
+      this.statistics
+    ];
+    if (views.some(view => view.buffer.graph !== graph)) {
+      throw new Error(`${this.id} views must belong to the target graph`);
+    }
+
+    const batches: GPUHashIndexBuildBatch[] = this.keys.data.map((keys, chunkIndex) => ({
+      keys,
+      ...(this.values ? {values: this.values.data[chunkIndex]} : {}),
+      ...(this.validity ? {validity: this.validity.data[chunkIndex]} : {}),
+      firstValue: this.firstValues[chunkIndex]
+    }));
+    addGPUHashIndexBuildBatchesToGraph(graph, this, batches);
+  }
+}
+
+function validateSourceVector(vector: GraphVectorView<'uint32'>, name: string): void {
+  if (!(vector instanceof GraphVectorView) || vector.format !== 'uint32') {
+    throw new Error(`${name} must be a uint32 GraphVectorView`);
+  }
+  if (
+    !Number.isSafeInteger(vector.length) ||
+    vector.length < 0 ||
+    vector.data.reduce((length, chunk) => length + chunk.length, 0) !== vector.length
+  ) {
+    throw new Error(`${name} length must equal its ordered source chunks`);
+  }
+  for (const [chunkIndex, chunk] of vector.data.entries()) {
+    validatePackedUint32View(chunk, `${name} chunk ${chunkIndex}`);
+  }
+}
+
+function validateDisjointViews(index: GPUBatchHashIndex): void {
+  const inputs = [
+    ...index.keys.data,
+    ...(index.values?.data ?? []),
+    ...(index.validity?.data ?? [])
+  ];
+  const outputs = [index.tableKeys, index.tableValues, index.statistics];
+  for (const input of inputs) {
+    for (const output of outputs) {
+      if (doGraphDataViewsOverlap(input, output)) {
+        throw new Error(`${index.id} input and output views must not overlap`);
+      }
+    }
+  }
+  for (let first = 0; first < outputs.length; first++) {
+    for (let second = first + 1; second < outputs.length; second++) {
+      if (doGraphDataViewsOverlap(outputs[first], outputs[second])) {
+        throw new Error(`${index.id} output views must not overlap`);
+      }
+    }
+  }
+}

--- a/modules/experimental/src/gpu-primitives/gpu-hash-index.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-hash-index.ts
@@ -35,6 +35,24 @@ export type GPUHashIndexView = {
   maxProbeCount: number;
 };
 
+/** One preserved packed source chunk contributed to a shared hash-index rebuild. @internal */
+export type GPUHashIndexBuildBatch = {
+  keys: GraphDataView<'uint32'>;
+  values?: GraphDataView<'uint32'>;
+  validity?: GraphDataView<'uint32'>;
+  firstValue: number;
+};
+
+type GPUHashIndexBuildTarget = GPUHashIndexView & {
+  id: string;
+  statistics: GraphDataView<'uint32'>;
+};
+
+type GPUHashIndexBuildPass = GPUHashIndexBuildBatch & {
+  id: string;
+  firstSourceRow: number;
+};
+
 /** Properties for one packed fixed-capacity hash-index rebuild. */
 export type GPUHashIndexProps = {
   id?: string;
@@ -161,9 +179,45 @@ export class GPUHashIndex implements GPUHashIndexView {
       'uint32',
       this.tableKeys.length
     );
+    const batch: GPUHashIndexBuildPass = {
+      id: this.id,
+      keys: this.keys,
+      ...(this.values ? {values: this.values} : {}),
+      firstValue: this.firstValue,
+      firstSourceRow: 0
+    };
     addBuildInitializePass(graph, this, sourceRows);
-    if (this.keys.length > 0) addBuildPass(graph, this, sourceRows);
-    addBuildFinalizePass(graph, this, sourceRows);
+    if (this.keys.length > 0) addBuildPass(graph, this, sourceRows, batch);
+    addBuildFinalizePass(graph, this, sourceRows, batch);
+  }
+}
+
+/** Rebuilds one shared index from ordered source chunks without concatenating their buffers. @internal */
+export function addGPUHashIndexBuildBatchesToGraph<Parameters>(
+  graph: GPUCommandGraph<Parameters>,
+  index: GPUHashIndexBuildTarget,
+  batches: readonly GPUHashIndexBuildBatch[]
+): void {
+  const sourceRows = createTransientView(
+    graph,
+    `${index.id}-source-rows`,
+    'uint32',
+    index.tableKeys.length
+  );
+  addBuildInitializePass(graph, index, sourceRows);
+
+  let firstSourceRow = 0;
+  for (const [batchIndex, batch] of batches.entries()) {
+    if (batch.keys.length > 0) {
+      const pass: GPUHashIndexBuildPass = {
+        ...batch,
+        id: `${index.id}-batch-${batchIndex}`,
+        firstSourceRow
+      };
+      addBuildPass(graph, index, sourceRows, pass);
+      addBuildFinalizePass(graph, index, sourceRows, pass);
+    }
+    firstSourceRow += batch.keys.length;
   }
 }
 
@@ -261,7 +315,7 @@ export class GPUHashIndexQuery {
 
 function addBuildInitializePass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
-  index: GPUHashIndex,
+  index: GPUHashIndexBuildTarget,
   sourceRows: GraphDataView<'uint32'>
 ): void {
   const layout = getDispatchLayout(
@@ -316,27 +370,38 @@ const STATISTICS_OFFSET: u32 = ${getViewElementOffset(index.statistics)}u;
 
 function addBuildPass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
-  index: GPUHashIndex,
-  sourceRows: GraphDataView<'uint32'>
+  index: GPUHashIndexBuildTarget,
+  sourceRows: GraphDataView<'uint32'>,
+  batch: GPUHashIndexBuildPass
 ): void {
   const layout = getDispatchLayout(
-    index.keys.length,
+    batch.keys.length,
     graph.device.limits.maxComputeWorkgroupsPerDimension
   );
+  const validityBinding = batch.validity
+    ? '@group(0) @binding(1) var<storage, read> inputValidity: array<u32>;'
+    : '';
+  const firstTableBinding = batch.validity ? 2 : 1;
+  const validityOffset = batch.validity ? getViewElementOffset(batch.validity) : 0;
+  const rejectInvalid = batch.validity
+    ? `if (inputValidity[${validityOffset}u + inputIndex] == 0u) { return; }`
+    : '';
   const source = /* wgsl */ `
-const ELEMENT_COUNT: u32 = ${index.keys.length}u;
+const ELEMENT_COUNT: u32 = ${batch.keys.length}u;
 const CAPACITY_MASK: u32 = ${index.tableKeys.length - 1}u;
 const MAX_PROBES: u32 = ${index.maxProbeCount}u;
 const DISPATCH_X: u32 = ${layout.x}u;
 const DISPATCH_Y: u32 = ${layout.y}u;
-const KEYS_OFFSET: u32 = ${getViewElementOffset(index.keys)}u;
+const KEYS_OFFSET: u32 = ${getViewElementOffset(batch.keys)}u;
 const TABLE_KEYS_OFFSET: u32 = ${getViewElementOffset(index.tableKeys)}u;
 const SOURCE_ROWS_OFFSET: u32 = ${getViewElementOffset(sourceRows)}u;
 const STATISTICS_OFFSET: u32 = ${getViewElementOffset(index.statistics)}u;
+const FIRST_SOURCE_ROW: u32 = ${batch.firstSourceRow}u;
 @group(0) @binding(0) var<storage, read> inputKeys: array<u32>;
-@group(0) @binding(1) var<storage, read_write> tableKeys: array<atomic<u32>>;
-@group(0) @binding(2) var<storage, read_write> sourceRows: array<atomic<u32>>;
-@group(0) @binding(3) var<storage, read_write> statistics: array<atomic<u32>>;
+${validityBinding}
+@group(0) @binding(${firstTableBinding}) var<storage, read_write> tableKeys: array<atomic<u32>>;
+@group(0) @binding(${firstTableBinding + 1}) var<storage, read_write> sourceRows: array<atomic<u32>>;
+@group(0) @binding(${firstTableBinding + 2}) var<storage, read_write> statistics: array<atomic<u32>>;
 
 fn hashKey(key: u32) -> u32 {
   var value = key;
@@ -352,6 +417,7 @@ fn hashKey(key: u32) -> u32 {
   let workgroupIndex = (workgroupId.z * DISPATCH_Y + workgroupId.y) * DISPATCH_X + workgroupId.x;
   let inputIndex = workgroupIndex * ${HASH_INDEX_WORKGROUP_SIZE}u + localIndex;
   if (inputIndex >= ELEMENT_COUNT) { return; }
+  ${rejectInvalid}
   let key = inputKeys[KEYS_OFFSET + inputIndex];
   if (key == ${GPU_HASH_INDEX_EMPTY_KEY}u) {
     atomicAdd(&statistics[STATISTICS_OFFSET + 3u], 1u);
@@ -383,7 +449,7 @@ fn hashKey(key: u32) -> u32 {
       break;
     }
     if (result.exchanged || result.old_value == key) {
-      atomicMin(&sourceRows[SOURCE_ROWS_OFFSET + slot], inputIndex);
+      atomicMin(&sourceRows[SOURCE_ROWS_OFFSET + slot], FIRST_SOURCE_ROW + inputIndex);
       inserted = result.exchanged;
       duplicate = !result.exchanged;
       break;
@@ -400,16 +466,20 @@ fn hashKey(key: u32) -> u32 {
   }
 }`;
   addComputationPass(graph, {
-    id: `${index.id}-build`,
+    id: `${batch.id}-build`,
     source,
     resources: [
-      {buffer: index.keys, usage: 'storage-read'},
+      {buffer: batch.keys, usage: 'storage-read'},
+      ...(batch.validity
+        ? ([{buffer: batch.validity, usage: 'storage-read'}] as GraphBufferUse[])
+        : []),
       {buffer: index.tableKeys, usage: 'storage-read-write'},
       {buffer: sourceRows, usage: 'storage-read-write'},
       {buffer: index.statistics, usage: 'storage-read-write'}
     ],
     bindings: {
-      inputKeys: index.keys,
+      inputKeys: batch.keys,
+      ...(batch.validity ? {inputValidity: batch.validity} : {}),
       tableKeys: index.tableKeys,
       sourceRows,
       statistics: index.statistics
@@ -420,22 +490,25 @@ fn hashKey(key: u32) -> u32 {
 
 function addBuildFinalizePass<Parameters>(
   graph: GPUCommandGraph<Parameters>,
-  index: GPUHashIndex,
-  sourceRows: GraphDataView<'uint32'>
+  index: GPUHashIndexBuildTarget,
+  sourceRows: GraphDataView<'uint32'>,
+  batch: GPUHashIndexBuildPass
 ): void {
   const layout = getDispatchLayout(
     index.tableKeys.length,
     graph.device.limits.maxComputeWorkgroupsPerDimension
   );
-  const hasExplicitValues = Boolean(index.values && index.keys.length > 0);
+  const hasExplicitValues = Boolean(batch.values && batch.keys.length > 0);
   const valueBinding = hasExplicitValues
     ? '@group(0) @binding(3) var<storage, read> inputValues: array<u32>;'
     : '';
   const valueExpression = hasExplicitValues
-    ? `inputValues[${getViewElementOffset(index.values!)}u + sourceRow]`
-    : `${index.firstValue}u + sourceRow`;
+    ? `inputValues[${getViewElementOffset(batch.values!)}u + localSourceRow]`
+    : `${batch.firstValue}u + localSourceRow`;
   const source = /* wgsl */ `
 const CAPACITY: u32 = ${index.tableKeys.length}u;
+const FIRST_SOURCE_ROW: u32 = ${batch.firstSourceRow}u;
+const SOURCE_ROW_COUNT: u32 = ${batch.keys.length}u;
 const DISPATCH_X: u32 = ${layout.x}u;
 const DISPATCH_Y: u32 = ${layout.y}u;
 const TABLE_KEYS_OFFSET: u32 = ${getViewElementOffset(index.tableKeys)}u;
@@ -453,24 +526,26 @@ ${valueBinding}
   let slot = workgroupIndex * ${HASH_INDEX_WORKGROUP_SIZE}u + localIndex;
   if (slot >= CAPACITY || tableKeys[TABLE_KEYS_OFFSET + slot] == ${GPU_HASH_INDEX_EMPTY_KEY}u) { return; }
   let sourceRow = sourceRows[SOURCE_ROWS_OFFSET + slot];
+  if (sourceRow < FIRST_SOURCE_ROW || sourceRow - FIRST_SOURCE_ROW >= SOURCE_ROW_COUNT) { return; }
+  let localSourceRow = sourceRow - FIRST_SOURCE_ROW;
   tableValues[TABLE_VALUES_OFFSET + slot] = ${valueExpression};
 }`;
   addComputationPass(graph, {
-    id: `${index.id}-finalize`,
+    id: `${batch.id}-finalize`,
     source,
     resources: [
       {buffer: index.tableKeys, usage: 'storage-read'},
       {buffer: sourceRows, usage: 'storage-read'},
       {buffer: index.tableValues, usage: 'storage-write'},
       ...(hasExplicitValues
-        ? ([{buffer: index.values!, usage: 'storage-read'}] as GraphBufferUse[])
+        ? ([{buffer: batch.values!, usage: 'storage-read'}] as GraphBufferUse[])
         : [])
     ],
     bindings: {
       tableKeys: index.tableKeys,
       sourceRows,
       tableValues: index.tableValues,
-      ...(hasExplicitValues ? {inputValues: index.values!} : {})
+      ...(hasExplicitValues ? {inputValues: batch.values!} : {})
     },
     dispatchSize: layout
   });

--- a/modules/experimental/src/gpu-primitives/index.ts
+++ b/modules/experimental/src/gpu-primitives/index.ts
@@ -300,6 +300,9 @@ export type {
   GPUHashIndexView
 } from './gpu-hash-index';
 
+export {GPUBatchHashIndex} from './gpu-batch-hash-index';
+export type {GPUBatchHashIndexProps, GPUBatchHashIndexStats} from './gpu-batch-hash-index';
+
 export {GPUHashJoin} from './gpu-hash-join';
 export type {GPUHashJoinProps, GPUHashJoinStats} from './gpu-hash-join';
 export {GPUBatchHashJoin} from './gpu-batch-hash-join';

--- a/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.node.spec.ts
@@ -1,0 +1,278 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer} from '@luma.gl/core';
+import {
+  GPUBatchHashIndex,
+  GPUCommandGraph,
+  GraphVectorView,
+  type GPUBatchHashIndexProps,
+  type GraphDataView
+} from '@luma.gl/experimental';
+import {NullDevice} from '@luma.gl/test-utils';
+import {describe, expect, test, vi} from 'vitest';
+
+describe('GPUBatchHashIndex planning', () => {
+  test('preserves source batches, empty chunks, offsets, and allocation-free graph planning', () => {
+    const fixture = createGraphFixture();
+    const createBuffer = vi.spyOn(fixture.device, 'createBuffer');
+    const addComputePass = vi.spyOn(fixture.graph, 'addComputePass');
+
+    try {
+      const index = new GPUBatchHashIndex({
+        ...createIndexProps(fixture.graph, [2, 0, 3]),
+        validity: createVector(fixture.graph, 'validity', [2, 0, 3]),
+        firstValues: [40, 100, 500]
+      });
+      expect(index.firstValues).toEqual([40, 100, 500]);
+      expect(Object.isFrozen(index.firstValues)).toBe(true);
+      expect(index.stats).toEqual({
+        capacity: 8,
+        maxProbeCount: 8,
+        tableByteLength: 64,
+        statisticsByteLength: 24,
+        outputByteLength: 88,
+        batchCount: 3,
+        inputLength: 5
+      });
+      expect(index.updatePolicy).toBe('rebuild');
+      expect(createBuffer).not.toHaveBeenCalled();
+
+      index.addToGraph(fixture.graph);
+
+      expect(addComputePass.mock.calls.map(([pass]) => pass.id)).toEqual([
+        'node-batch-index-initialize',
+        'node-batch-index-batch-0-build',
+        'node-batch-index-batch-0-finalize',
+        'node-batch-index-batch-2-build',
+        'node-batch-index-batch-2-finalize'
+      ]);
+      expect(createBuffer).not.toHaveBeenCalled();
+    } finally {
+      createBuffer.mockRestore();
+      addComputePass.mockRestore();
+      fixture.device.destroy();
+    }
+  });
+
+  test('generates contiguous batch offsets and accepts explicit aligned payload vectors', () => {
+    const fixture = createGraphFixture();
+
+    try {
+      const props = createIndexProps(fixture.graph, [2, 0, 3]);
+      const values = createVector(fixture.graph, 'values', [2, 0, 3]);
+      const index = new GPUBatchHashIndex({...props, values});
+
+      expect(index.values).toBe(values);
+      expect(index.firstValues).toEqual([0, 2, 2]);
+      expect(() => new GPUBatchHashIndex({...props, values, firstValues: [0, 2, 2]})).toThrow(
+        /values and firstValues are mutually exclusive/
+      );
+    } finally {
+      fixture.device.destroy();
+    }
+  });
+
+  test('rejects mismatched ordered topology and unsupported scalar layouts', () => {
+    const fixture = createGraphFixture();
+
+    try {
+      const props = createIndexProps(fixture.graph, [2, 0, 3]);
+      expect(
+        () =>
+          new GPUBatchHashIndex({
+            ...props,
+            values: createVector(fixture.graph, 'mismatched-values', [1, 0, 4])
+          })
+      ).toThrow(/same chunk topology/);
+      expect(
+        () =>
+          new GPUBatchHashIndex({
+            ...props,
+            validity: createVector(fixture.graph, 'mismatched-validity', [2, 3])
+          })
+      ).toThrow(/same chunk topology/);
+      expect(
+        () =>
+          new GPUBatchHashIndex({
+            ...props,
+            keys: createVector(fixture.graph, 'incorrect-length', [2, 0, 3], {length: 4})
+          })
+      ).toThrow(/length must equal its ordered source chunks/);
+      expect(
+        () =>
+          new GPUBatchHashIndex({
+            ...props,
+            keys: createVector(fixture.graph, 'strided-keys', [2, 0, 3], {byteStride: 8})
+          })
+      ).toThrow(/packed, uint32-aligned uint32/);
+    } finally {
+      fixture.device.destroy();
+    }
+  });
+
+  test('rejects ambiguous offsets, uint32 source identities, and cumulative probe overflow', () => {
+    const fixture = createGraphFixture();
+
+    try {
+      const props = createIndexProps(fixture.graph, [2, 0, 3]);
+      expect(() => new GPUBatchHashIndex({...props, firstValues: [0, 2]})).toThrow(
+        /one value per source chunk/
+      );
+      expect(() => new GPUBatchHashIndex({...props, firstValues: [0xffffffff, 2, 2]})).toThrow(
+        /generated values must fit in uint32/
+      );
+      expect(() => new GPUBatchHashIndex({...props, firstValues: [-1, 2, 2]})).toThrow(
+        /generated values must fit in uint32/
+      );
+      expect(() => new GPUBatchHashIndex({...props, maxProbeCount: 9})).toThrow(
+        /one through capacity/
+      );
+
+      const oversizedKeys = createVector(fixture.graph, 'oversized-keys', [0x40000000, 0x40000000]);
+      expect(
+        () => new GPUBatchHashIndex({...props, keys: oversizedKeys, maxProbeCount: 2})
+      ).toThrow(/aggregate probe count must fit in uint32/);
+    } finally {
+      fixture.device.destroy();
+    }
+  });
+
+  test('rejects shared output ranges and source/output aliases', () => {
+    const fixture = createGraphFixture();
+
+    try {
+      const props = createIndexProps(fixture.graph, [2, 0, 3]);
+      expect(() => new GPUBatchHashIndex({...props, tableValues: props.tableKeys})).toThrow(
+        /output views must not overlap/
+      );
+      expect(
+        () =>
+          new GPUBatchHashIndex({
+            ...props,
+            statistics: fixture.graph.createDataView(props.keys.data[0].buffer, {
+              format: 'uint32',
+              length: 2
+            })
+          })
+      ).toThrow(/statistics must contain six uint32 rows/);
+
+      const sourceAlias = fixture.graph.createDataView(props.tableKeys.buffer, {
+        format: 'uint32',
+        length: 2
+      });
+      const aliasedKeys = createVector(fixture.graph, 'alias-keys', [2, 0, 3], {
+        firstChunk: sourceAlias
+      });
+      expect(() => new GPUBatchHashIndex({...props, keys: aliasedKeys})).toThrow(
+        /input and output views must not overlap/
+      );
+    } finally {
+      fixture.device.destroy();
+    }
+  });
+
+  test('clears empty topologies exactly once without importing empty input bindings', () => {
+    for (const lengths of [[], [0, 0]] as readonly number[][]) {
+      const fixture = createGraphFixture();
+      const addComputePass = vi.spyOn(fixture.graph, 'addComputePass');
+      const createBuffer = vi.spyOn(fixture.device, 'createBuffer');
+
+      try {
+        new GPUBatchHashIndex(createIndexProps(fixture.graph, lengths)).addToGraph(fixture.graph);
+        expect(addComputePass.mock.calls.map(([pass]) => pass.id)).toEqual([
+          'node-batch-index-initialize'
+        ]);
+        expect(createBuffer).not.toHaveBeenCalled();
+      } finally {
+        addComputePass.mockRestore();
+        createBuffer.mockRestore();
+        fixture.device.destroy();
+      }
+    }
+  });
+
+  test('rejects views owned by a different command graph before adding compute passes', () => {
+    const fixture = createGraphFixture();
+    const other = createGraphFixture();
+    const addComputePass = vi.spyOn(fixture.graph, 'addComputePass');
+
+    try {
+      const props = createIndexProps(fixture.graph, [2, 0, 3]);
+      const index = new GPUBatchHashIndex({
+        ...props,
+        validity: createVector(other.graph, 'external-validity', [2, 0, 3])
+      });
+      expect(() => index.addToGraph(fixture.graph)).toThrow(
+        /views must belong to the target graph/
+      );
+      expect(addComputePass).not.toHaveBeenCalled();
+    } finally {
+      addComputePass.mockRestore();
+      fixture.device.destroy();
+      other.device.destroy();
+    }
+  });
+});
+
+function createGraphFixture(): {device: NullDevice; graph: GPUCommandGraph} {
+  const device = new NullDevice({id: 'batch-hash-index-node-device'});
+  Object.defineProperty(device, 'type', {value: 'webgpu'});
+  device.limits.maxComputeWorkgroupsPerDimension = 65_535;
+  device.limits.maxBufferSize = Number.MAX_SAFE_INTEGER;
+  return {device, graph: new GPUCommandGraph(device, {id: 'batch-hash-index-node-graph'})};
+}
+
+function createIndexProps(
+  graph: GPUCommandGraph,
+  chunkLengths: readonly number[]
+): GPUBatchHashIndexProps {
+  return {
+    id: 'node-batch-index',
+    keys: createVector(graph, 'keys', chunkLengths),
+    tableKeys: createView(graph, 'table-keys', 8),
+    tableValues: createView(graph, 'table-values', 8),
+    statistics: createView(graph, 'statistics', 6)
+  };
+}
+
+function createVector(
+  graph: GPUCommandGraph,
+  id: string,
+  chunkLengths: readonly number[],
+  options: {length?: number; byteStride?: number; firstChunk?: GraphDataView<'uint32'>} = {}
+): GraphVectorView<'uint32'> {
+  const sourceLength = chunkLengths.reduce((length, chunkLength) => length + chunkLength, 0);
+  const length = options.length ?? sourceLength;
+  const byteStride = options.byteStride ?? Uint32Array.BYTES_PER_ELEMENT;
+  return new GraphVectorView({
+    id,
+    name: id,
+    format: 'uint32',
+    length,
+    valueLength: length,
+    stride: 1,
+    byteStride,
+    rowByteLength: Uint32Array.BYTES_PER_ELEMENT,
+    data: chunkLengths.map((chunkLength, chunkIndex) =>
+      chunkIndex === 0 && options.firstChunk
+        ? options.firstChunk
+        : createView(graph, `${id}-chunk-${chunkIndex}`, chunkLength, byteStride)
+    )
+  });
+}
+
+function createView(
+  graph: GPUCommandGraph,
+  id: string,
+  length: number,
+  byteStride = Uint32Array.BYTES_PER_ELEMENT
+): GraphDataView<'uint32'> {
+  const buffer = graph.createTransientBuffer({
+    id,
+    byteLength: Math.max(length, 1) * byteStride,
+    usage: Buffer.STORAGE
+  });
+  return graph.createDataView(buffer, {format: 'uint32', length, byteStride});
+}

--- a/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.spec.ts
@@ -1,0 +1,304 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {Buffer, type Device} from '@luma.gl/core';
+import {
+  GPUBatchHashIndex,
+  GPUCommandGraph,
+  GPUHashIndexQuery,
+  GPU_HASH_INDEX_EMPTY_KEY,
+  GraphVectorView,
+  type GraphDataView
+} from '@luma.gl/experimental';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+
+test('GPUBatchHashIndex preserves nullable batches, earliest duplicates, and source offsets', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const result = await runBatchHashIndex(device, {
+    keys: [[7, 10], [], [10, GPU_HASH_INDEX_EMPTY_KEY, 20, 30, GPU_HASH_INDEX_EMPTY_KEY]],
+    validity: [[1, 1], [], [1, 1, 0, 1, 0]],
+    firstValues: [40, 100, 500],
+    queryKeys: [7, 10, 20, 30, GPU_HASH_INDEX_EMPTY_KEY, 99],
+    capacity: 8,
+    encodingCount: 2
+  });
+
+  testCase.deepEqual(
+    result.values,
+    [40, 41, GPU_HASH_INDEX_EMPTY_KEY, 503, GPU_HASH_INDEX_EMPTY_KEY, GPU_HASH_INDEX_EMPTY_KEY],
+    'generated values retain discontinuous batch offsets and globally earliest duplicates'
+  );
+  testCase.deepEqual(result.found, [1, 1, 0, 1, 0, 0], 'nullable keys are excluded from lookups');
+  testCase.deepEqual(
+    result.buildStatistics.slice(0, 4),
+    [3, 1, 0, 1],
+    'counts valid duplicates and reserved keys while silently skipping invalid/null rows'
+  );
+  testCase.equal(
+    result.tableKeys.filter(key => key !== GPU_HASH_INDEX_EMPTY_KEY).length,
+    3,
+    'one shared table slot is retained per distinct valid key'
+  );
+  testCase.ok(result.buildStatistics[4] >= 4, 'cumulative probes include every non-null valid row');
+  testCase.ok(result.buildStatistics[5] <= 8, 'all chunks obey the common probe bound');
+  testCase.deepEqual(result.queryStatistics.slice(0, 2), [3, 3], 're-encoding resets diagnostics');
+  testCase.end();
+});
+
+test('GPUBatchHashIndex resolves explicit payloads across offset chunk views', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const result = await runBatchHashIndex(device, {
+    keys: [[5, 8], [], [8, 13, 21]],
+    values: [[500, 800], [], [801, 1300, 2100]],
+    queryKeys: [5, 8, 13, 21],
+    capacity: 8,
+    sourceByteOffset: 8
+  });
+
+  testCase.deepEqual(
+    result.values,
+    [500, 800, 1300, 2100],
+    'later duplicate chunks cannot overwrite the globally first explicit payload'
+  );
+  testCase.deepEqual(result.found, [1, 1, 1, 1], 'finds keys originating in distinct GPU buffers');
+  testCase.deepEqual(
+    result.buildStatistics.slice(0, 4),
+    [4, 1, 0, 0],
+    'accumulates chunk statistics'
+  );
+  testCase.end();
+});
+
+test('GPUBatchHashIndex accumulates bounded overflow without resetting between chunks', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const result = await runBatchHashIndex(device, {
+    keys: [[1, 2], [], [3, 4]],
+    firstValues: [10, 99, 30],
+    queryKeys: [1, 2, 3, 4],
+    capacity: 2
+  });
+
+  testCase.deepEqual(
+    result.buildStatistics.slice(0, 4),
+    [2, 0, 2, 0],
+    'later distinct keys report fixed-capacity overflow without clearing earlier rows'
+  );
+  testCase.deepEqual(result.found, [1, 1, 0, 0], 'only first-batch keys remain available');
+  testCase.deepEqual(
+    result.values,
+    [10, 11, GPU_HASH_INDEX_EMPTY_KEY, GPU_HASH_INDEX_EMPTY_KEY],
+    'surviving keys preserve original first-source offsets'
+  );
+  testCase.end();
+});
+
+test('GPUBatchHashIndex clears zero-chunk and empty-chunk index topologies', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  for (const keys of [[], [[], []]] as readonly (readonly number[])[][]) {
+    const result = await runBatchHashIndex(device, {keys, queryKeys: [1], capacity: 4});
+    testCase.deepEqual(
+      result.tableKeys,
+      [
+        GPU_HASH_INDEX_EMPTY_KEY,
+        GPU_HASH_INDEX_EMPTY_KEY,
+        GPU_HASH_INDEX_EMPTY_KEY,
+        GPU_HASH_INDEX_EMPTY_KEY
+      ],
+      'empty source topologies initialize every shared table slot'
+    );
+    testCase.deepEqual(
+      result.buildStatistics,
+      [0, 0, 0, 0, 0, 0],
+      'empty chunks add no statistics'
+    );
+    testCase.deepEqual(result.found, [0], 'empty tables do not publish matches');
+  }
+  testCase.end();
+});
+
+type BatchHashIndexFixture = {
+  keys: readonly (readonly number[])[];
+  values?: readonly (readonly number[])[];
+  validity?: readonly (readonly number[])[];
+  firstValues?: readonly number[];
+  queryKeys: readonly number[];
+  capacity: number;
+  encodingCount?: number;
+  sourceByteOffset?: number;
+};
+
+async function runBatchHashIndex(device: Device, fixture: BatchHashIndexFixture) {
+  const graph = new GPUCommandGraph(device, {id: 'batch-hash-index-browser'});
+  const resources: Buffer[] = [];
+  const keys = createImportedVector(
+    graph,
+    device,
+    resources,
+    'input-keys',
+    fixture.keys,
+    fixture.sourceByteOffset
+  );
+  const values = fixture.values
+    ? createImportedVector(
+        graph,
+        device,
+        resources,
+        'input-values',
+        fixture.values,
+        fixture.sourceByteOffset
+      )
+    : undefined;
+  const validity = fixture.validity
+    ? createImportedVector(
+        graph,
+        device,
+        resources,
+        'input-validity',
+        fixture.validity,
+        fixture.sourceByteOffset
+      )
+    : undefined;
+  const queryKeys = createImportedView(graph, device, resources, 'query-keys', fixture.queryKeys);
+  const tableKeys = createOutputView(graph, device, resources, 'table-keys', fixture.capacity);
+  const tableValues = createOutputView(graph, device, resources, 'table-values', fixture.capacity);
+  const buildStatistics = createOutputView(graph, device, resources, 'build-statistics', 6);
+  const outputValues = createOutputView(graph, device, resources, 'query-values', queryKeys.length);
+  const found = createOutputView(graph, device, resources, 'query-found', queryKeys.length);
+  const probes = createOutputView(graph, device, resources, 'query-probes', queryKeys.length);
+  const queryStatistics = createOutputView(graph, device, resources, 'query-statistics', 4);
+
+  const index = new GPUBatchHashIndex({
+    id: 'browser-batch-index',
+    keys,
+    ...(values ? {values} : {}),
+    ...(validity ? {validity} : {}),
+    ...(fixture.firstValues ? {firstValues: fixture.firstValues} : {}),
+    tableKeys: tableKeys.view,
+    tableValues: tableValues.view,
+    statistics: buildStatistics.view
+  });
+  index.addToGraph(graph);
+  new GPUHashIndexQuery({
+    id: 'browser-batch-query',
+    index,
+    keys: queryKeys,
+    values: outputValues.view,
+    found: found.view,
+    probes: probes.view,
+    statistics: queryStatistics.view
+  }).addToGraph(graph);
+
+  const compiled = graph.compile();
+  try {
+    for (let encoding = 0; encoding < (fixture.encodingCount ?? 1); encoding++) {
+      const commandEncoder = device.createCommandEncoder({id: `batch-hash-index-${encoding}`});
+      compiled.encode(commandEncoder, {parameters: undefined});
+      device.submit(commandEncoder.finish());
+    }
+    return {
+      tableKeys: await readUint32(tableKeys.buffer, fixture.capacity),
+      buildStatistics: await readUint32(buildStatistics.buffer, 6),
+      values: await readUint32(outputValues.buffer, queryKeys.length),
+      found: await readUint32(found.buffer, queryKeys.length),
+      probes: await readUint32(probes.buffer, queryKeys.length),
+      queryStatistics: await readUint32(queryStatistics.buffer, 4)
+    };
+  } finally {
+    compiled.destroy();
+    for (const resource of resources) resource.destroy();
+  }
+}
+
+function createImportedVector(
+  graph: GPUCommandGraph,
+  device: Device,
+  resources: Buffer[],
+  id: string,
+  chunks: readonly (readonly number[])[],
+  byteOffset = 0
+): GraphVectorView<'uint32'> {
+  const length = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  return new GraphVectorView({
+    id,
+    name: id,
+    format: 'uint32',
+    length,
+    valueLength: length,
+    stride: 1,
+    byteStride: Uint32Array.BYTES_PER_ELEMENT,
+    rowByteLength: Uint32Array.BYTES_PER_ELEMENT,
+    data: chunks.map((chunk, chunkIndex) =>
+      createImportedView(graph, device, resources, `${id}-chunk-${chunkIndex}`, chunk, byteOffset)
+    )
+  });
+}
+
+function createImportedView(
+  graph: GPUCommandGraph,
+  device: Device,
+  resources: Buffer[],
+  id: string,
+  values: readonly number[],
+  byteOffset = 0
+): GraphDataView<'uint32'> {
+  const prefixLength = byteOffset / Uint32Array.BYTES_PER_ELEMENT;
+  const data = new Uint32Array(prefixLength + Math.max(values.length, 1));
+  data.set(values, prefixLength);
+  const buffer = device.createBuffer({data, usage: Buffer.STORAGE | Buffer.COPY_DST});
+  resources.push(buffer);
+  const handle = graph.importBuffer(
+    {id, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return graph.createDataView(handle, {format: 'uint32', length: values.length, byteOffset});
+}
+
+function createOutputView(
+  graph: GPUCommandGraph,
+  device: Device,
+  resources: Buffer[],
+  id: string,
+  length: number
+): {buffer: Buffer; view: GraphDataView<'uint32'>} {
+  const buffer = device.createBuffer({
+    byteLength: Math.max(length, 1) * Uint32Array.BYTES_PER_ELEMENT,
+    usage: Buffer.STORAGE | Buffer.COPY_SRC
+  });
+  resources.push(buffer);
+  const handle = graph.importBuffer(
+    {id, byteLength: buffer.byteLength, usage: buffer.usage},
+    buffer
+  );
+  return {buffer, view: graph.createDataView(handle, {format: 'uint32', length})};
+}
+
+async function readUint32(buffer: Buffer, length: number): Promise<number[]> {
+  const bytes = await buffer.readAsync();
+  return Array.from(new Uint32Array(bytes.buffer, bytes.byteOffset, length));
+}


### PR DESCRIPTION
## Goals

Build one reusable GPU hash index from streamed, independently owned record batches so hash joins can support multi-batch right-hand tables without implicit concatenation, repacking, CPU readback, or command submission.

## Changes

- Add public `GPUBatchHashIndex`, typed properties, and batch-aware storage statistics over ordered `GraphVectorView<'uint32'>` key chunks.
- Support aligned per-chunk payload vectors or explicit per-batch stable source-row offsets, plus optional GPU validity masks.
- Clear the shared table and diagnostics once, then insert/finalize each source chunk in order while preserving globally earliest duplicate selection and accumulating six GPU-resident statistics.
- Exclude ordinary nulls silently; report valid reserved keys, duplicate valid keys, probe overflow, and bounded probe statistics explicitly.
- Refactor existing single-batch `GPUHashIndex` build passes without changing its API or existing graph node identifiers.
- Add focused Node and real-WebGPU regressions for `[2,0,3]` topology, mismatched chunks, discontinuous source offsets, sliced physical offsets, nullable rows, reserved keys, duplicates, capacity overflow, empty inputs, aliases, and repeated encoding.

## Verification

- `nvm use`: Node v22.22.1.
- `yarn install`: not rerun; reused the already verified dependency tree because the existing enterprise alpha registry dependency returns HTTP 403.
- `yarn lint fix`: passed after final changes.
- `yarn build`: passed after final formatting.
- `yarn test`: Node 550 passed/1 skipped; real Chromium/WebGPU 1,557 passed/25 skipped.
- `yarn test-node`: 550 passed/1 skipped.
- Focused new real-WebGPU tests: 4 passed; existing hash-index/hash-join integration: 15 passed.
- `yarn website:build` and `(cd website && yarn build)`: both passed and validated 461 documentation pages.
- `yarn examples:typecheck`: all 46 workspaces passed.
- `yarn bundle-size`: all seven budgets passed.

## Risks

- Reserved key `0xffffffff` remains unsupported and is explicitly counted; null rows do not increment invalid-key diagnostics.
- Existing single-batch `GPUHashIndex` behavior and public graph node IDs are preserved.
- Source rows, buffers, and command submission remain caller owned.
