### PR TITLE
feat(splats): stream batches through reusable GPU graphs

### DIFF
--- a/docs/api-reference/splats/README.md
+++ b/docs/api-reference/splats/README.md
@@ -39,35 +39,162 @@ and does not concatenate source data or reupload existing batches.
 
 ## WebGPU command-graph renderer
 
-`GPUSplatGraphRenderer` is a WebGPU-only renderer designed for large streamed captures:
+`GPUSplatGraphRenderer` renders streamed Gaussian captures directly through a WebGPU command graph.
+The first prepared batch becomes visible without waiting for the entire scene, running a CPU
+preview, or relinquishing ownership of the original source buffers.
 
 ```ts
-import {GPUSplatGraphRenderer} from '@luma.gl/splats';
+import {GPUSplatGraphRenderer, type GPUSplatData} from '@luma.gl/splats';
 
 const renderer = new GPUSplatGraphRenderer(webgpuDevice, {
-  data: preparedBatches,
-  viewportSize: [width, height]
+  viewportSize: [width, height],
+  expectedSplatCount: 741_883,
+  expectedBatchCount: 12
 });
+const preparedBatches: GPUSplatData[] = [];
 
-const commandEncoder = webgpuDevice.createCommandEncoder();
-const encoding = renderer.encode(commandEncoder);
-webgpuDevice.submit(commandEncoder.finish());
+for await (const batch of preparedBatchStream) {
+  preparedBatches.push(batch);
+  renderer.appendData(batch);
 
-console.log(encoding?.stats.nodeCount, renderer.stats);
+  const commandEncoder = webgpuDevice.createCommandEncoder();
+  const encoding = renderer.encode(commandEncoder);
+  if (encoding) {
+    webgpuDevice.submit(commandEncoder.finish());
+
+    console.log(renderer.capacity, renderer.stats, encoding.stats.nodeCount);
+  }
+}
+
+renderer.destroy();
+for (const batch of preparedBatches) batch.destroy();
 ```
 
-The compiled command graph projects and culls each original source batch into explicitly
-renderer-owned, camera-dependent records. One stable global radix sort orders all batches together,
-while GPU-written indirect draw arguments ensure that one render pass draws only visible rows. The
-graph processes 16 significant depth-key bits instead of executing the full 32-bit radix schedule.
-There are no per-frame CPU row projections, CPU depth sorts, sorted-index uploads, or implicit GPU
-readbacks.
+The caller owns command submission. Within an existing animation loop, pass the loop's current
+command encoder to `renderer.encode(...)` and let the loop submit normally. The graph opens its own
+default-framebuffer render pass; do not open a second splat render pass around `encode()`.
 
-Source `GPUSplatData` objects remain borrowed, retain their original batch boundaries, and must
-outlive the renderer. Derived projected records, sort keys, graph scratch, per-batch uniforms, and
-indirect commands are explicitly owned by the graph renderer. HDR floating-point source colors,
-anisotropic covariance, opacity thresholds, exposure, and tone mapping are preserved. Continue to
-use `SplatRenderer` for WebGL2 devices or when comparing against CPU-based ordering.
+### Constructor options
+
+`GPUSplatGraphRenderer` accepts the existing camera, viewport, radius, opacity, exposure, and
+tone-mapping options from `SplatRenderer`, plus the following graph-specific properties:
+
+| Property | Type | Behavior |
+| --- | --- | --- |
+| `expectedSplatCount` | `number` | Optional positive final row-count hint; reserves projected records and global sort buffers once. |
+| `expectedBatchCount` | `number` | Optional positive final batch-count hint; reserves one reusable graph source slot per streamed batch. |
+| `clearColor` | `[number, number, number, number]` | Color used when the graph opens its default-framebuffer render pass. Defaults to transparent black. |
+
+Provide both expected counts when source metadata is available. For example, a 741,883-row Train
+capture streamed in twelve Arrow record batches can reuse one compiled graph throughout its entire
+download. Omit either hint when the corresponding dimension is unknown. The renderer always uses
+stable global GPU depth ordering and requires a WebGPU device; use `SplatRenderer` for WebGL2,
+source ordering, or tile ordering.
+
+### Progressive graph lifecycle
+
+Construction retains optional initial data but does not compile the graph or project source rows.
+`appendData(batch)` borrows another live `GPUSplatData` allocation from the same WebGPU device.
+The first `encode(commandEncoder)` with at least one row reserves capacity, compiles the graph, and
+encodes the first visible frame. Later batches update existing source slots and reuse that graph
+while their row and batch counts remain within its reserved capacities.
+
+```text
+Arrow batch 0 ──> borrowed GPU source slot 0 ─┐
+Arrow batch 1 ──> borrowed GPU source slot 1 ─┼─> initialize padded rows
+future batches ─> reusable source slots     ─┘            │
+                                                          v
+                         GPU project + cull each active source slot
+                                                          │
+                                                          v
+                         stable global 16-bit GPU radix depth sort
+                                                          │
+                                                          v
+                         one GPU-counted indirect Gaussian draw
+```
+
+The initialization pass assigns `65535` to every padded or unoccupied depth key and resets the
+indirect instance counter. Each active batch slot projects its original positions, anisotropic
+scales, rotations, colors, and opacity; culls invalid, transparent, offscreen, or clipped splats;
+writes a valid depth key from `0` through `65534`; and atomically increments the visible instance
+count. Inactive source slots do not dispatch projection work. One stable GPU radix sort orders
+every active batch together, leaving invalid padding at the end; one indirect draw consumes only
+the visible prefix. The complete Train graph contains 126 scheduled nodes: one initialization
+pass, twelve reusable source-slot passes, 112 radix and hierarchical scan passes, and one render
+pass.
+
+No source batches are concatenated, previously uploaded source columns are not reuploaded, and no
+frame requires a CPU source-row walk, CPU depth sort, sorted-index upload, or implicit GPU readback.
+Floating-point HDR radiance, mixed source color formats, opacity thresholds, exposure, and display
+tone mapping remain valid from the first streamed frame.
+
+`encode()` returns a `GPUCommandGraphEncoding` when it records work, or `undefined` when the source
+is empty, the renderer is destroyed, or neither its data nor its camera/style properties changed.
+Calling `setProps(...)` or `appendData(...)` marks the next frame dirty; a stationary, unchanged
+scene is not repeatedly projected or sorted.
+
+### Reserved capacity and unknown-size streams
+
+The graph must reserve both row storage and immutable source-slot nodes before its first frame:
+
+| Stream information | Initial row capacity | Initial batch capacity | Graph rebuilds |
+| --- | --- | --- | --- |
+| Final row and batch counts are known | `expectedSplatCount` | `expectedBatchCount` | None while both hints remain sufficient. |
+| Final size is unknown | At least four times the first nonempty batch, bounded by device limits. | At least four batch slots. | Only when accumulated rows or batches exceed their current capacity. |
+| A supplied hint is too small | The supplied row hint grows as needed. | The supplied batch hint grows as needed. | Only at an exceeded row or batch capacity boundary. |
+
+Unknown or exceeded capacities double geometrically. Growing capacity recompiles the graph and
+replaces renderer-owned working allocations, but existing `GPUSplatData` objects and their original
+GPU source buffers remain borrowed and intact. Inspect the currently allocated limits with
+`renderer.capacity`, which returns `{splatCount, batchCount}`; both values are zero before the
+first successful encoding.
+
+### Ownership, replacement, and diagnostics
+
+Every source batch remains caller-owned and must stay alive while the renderer references it.
+`renderer.destroy()` releases the compiled graph, projected records, global sort buffers, graph
+scratch, source-slot placeholders, uniforms, and indirect commands; it never destroys source
+batches. Destroy the renderer before independently destroying those batches.
+
+`renderer.setProps({data: replacementBatch})` replaces the borrowed source collection and
+invalidates its graph. The previous source batches are not destroyed; the caller remains
+responsible for their lifetime. The next nonempty `encode()` builds a graph for the replacement.
+
+The renderer exposes lightweight diagnostics without synchronizing GPU work:
+
+- `renderer.capacity` reports currently allocated row and source-slot limits.
+- `renderer.stats` reports loaded rows and batches, source and renderer GPU bytes, global ordering,
+  and the single indirect draw.
+- `renderer.graphStats` reports compiled node order and logical versus physically reused graph
+  resources; it is `undefined` before compilation.
+- `renderer.compiledGraph` and `renderer.lastEncoding` expose the current compiled graph and most
+  recent encoding for graph inspectors.
+- `renderer.sortedIndexBuffer` exposes the GPU-owned projected-row permutation after compilation.
+- `renderer.drawCommands` contains the GPU-written indirect command and exact visible instance
+  count.
+
+`renderer.stats.visibleSplatCount` currently reports the loaded row count without mapping a GPU
+buffer. The exact culled count is the indirect command's GPU-resident `instanceCount`; reading it
+back requires an explicit asynchronous buffer read after command submission.
+
+### Memory, ordering, and device limits
+
+The renderer allocates one 48-byte projected record and four 4-byte sort/index entries for every
+reserved row: **64 bytes per reserved splat**, before transient radix-sort scratch, source-slot
+placeholders, 128-byte per-slot uniforms, and caller-owned source columns. For the 741,883-splat
+Train scene, the primary renderer buffers use approximately 45.3 MiB and graph scratch uses
+approximately 19.8 MiB; packed source columns add approximately 36.8 MiB separately.
+
+The projected-record allocation must fit the device's `maxStorageBufferBindingSize`. A 128 MiB
+storage-binding limit supports at most 2,796,202 splats in one graph. Larger scenes or constrained
+adapters require a different rendering strategy; the showcase falls back to `SplatRenderer` when
+graph compilation fails synchronously.
+
+Reserving the final scene size avoids repeated graph compilation, but the global radix sort processes
+the entire reserved capacity on every dirty progressive frame, even while most source rows are
+still inactive. Oversized hints therefore trade higher early GPU work and memory for stable graph
+identity. The radix sort intentionally processes 16 significant depth bits; stable equal-key ties
+may be less precise than the CPU renderer's higher-precision depth ordering.
 
 ## Source columns and rendering
 
@@ -79,12 +206,13 @@ preserve high-dynamic-range spherical-harmonic DC radiance, including values abo
 zero, until rendering. Prepared GPU columns use the `float32x3`, `float32x4`, `unorm8x4`, and
 `float32` memory formats provided by [`@luma.gl/tables`](/docs/api-reference/tables).
 
-The renderer supports `none`, `global`, and `tile` depth-ordering modes alongside camera matrix,
-viewport, radius, opacity, and visibility controls. WebGPU uses GPU-ready splat buffers and WGSL;
-WebGL2 uses an attribute-backed GLSL fallback. Higher-order spherical harmonics and dedicated
-WebGPU picking are not part of the initial API. When globally sorted source batches are densely
-interleaved, the renderer bounds draw-call growth by grouping the rows into depth-ordered batch
-runs without changing or repacking their source buffers.
+`SplatRenderer` supports `none`, `global`, and `tile` depth-ordering modes alongside camera matrix,
+viewport, radius, opacity, and visibility controls; `GPUSplatGraphRenderer` always uses global
+GPU ordering. WebGPU uses GPU-ready splat buffers and WGSL; WebGL2 uses an attribute-backed GLSL
+fallback. Higher-order spherical harmonics and dedicated WebGPU picking are not part of the initial
+API. When globally sorted source batches are densely interleaved, `SplatRenderer` bounds draw-call
+growth by grouping the rows into depth-ordered batch runs without changing or repacking their
+source buffers.
 
 The `exposure` property scales linear color before display mapping. Floating-point source colors
 automatically enable Reinhard highlight compression on standard dynamic range targets; set

--- a/examples/showcase/gaussian-splats/app.ts
+++ b/examples/showcase/gaussian-splats/app.ts
@@ -254,11 +254,14 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
       gaussianSupportRadius: 3,
       kernel2DSize: 0.35
     };
-    // Captured scenes keep the existing progressive preview until all source batches arrive.
-    // Compiling the immutable full-scene graph once avoids rebuilding it for every Arrow batch.
     this.renderer =
-      this.executionMode === 'graph' && !this.localLoadersConfiguration
-        ? new GPUSplatGraphRenderer(device, {...rendererProps, clearColor: CLEAR_COLOR})
+      this.executionMode === 'graph'
+        ? new GPUSplatGraphRenderer(device, {
+            ...rendererProps,
+            clearColor: CLEAR_COLOR,
+            expectedSplatCount: this.localLoadersConfiguration?.expectedSplatCount,
+            expectedBatchCount: this.localLoadersConfiguration?.expectedBatchCount
+          })
         : new SplatRenderer(device, rendererProps);
   }
 
@@ -460,26 +463,7 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
     this.isLoading = false;
     this.expectedBatchCount = this.batches.length;
     this.expectedSplatCount = this.loadedSplatCount;
-    if (this.executionMode === 'graph') {
-      this.activateGraphRenderer();
-    }
     this.updatePanel();
-  }
-
-  /** Replaces the progressive CPU preview without changing caller-owned Arrow source batches. */
-  private activateGraphRenderer(): void {
-    if (this.renderer instanceof GPUSplatGraphRenderer) {
-      return;
-    }
-    const previousRenderer = this.renderer;
-    const graphRenderer = new GPUSplatGraphRenderer(this.device, {
-      ...previousRenderer.props,
-      data: this.batches,
-      clearColor: CLEAR_COLOR
-    });
-    this.renderer = graphRenderer;
-    previousRenderer.destroy();
-    this.requestRedraw();
   }
 
   /** Keeps a captured scene usable when the selected WebGPU adapter cannot compile its graph. */
@@ -851,11 +835,9 @@ export default class GaussianSplatsAnimationLoopTemplate extends AnimationLoopTe
           ? this.renderer.compiledGraph
             ? 'GPU command graph'
             : 'Compiling GPU graph…'
-          : this.executionMode === 'graph'
-            ? 'CPU preview → GPU graph'
-            : this.device.type === 'webgpu'
-              ? 'CPU depth ordering'
-              : 'WebGL2 fallback';
+          : this.device.type === 'webgpu'
+            ? 'CPU depth ordering'
+            : 'WebGL2 fallback';
     }
     for (const pipelineErrorElement of document.querySelectorAll<HTMLElement>(
       '[data-gaussian-splats-pipeline-error]'

--- a/modules/splats/README.md
+++ b/modules/splats/README.md
@@ -48,24 +48,153 @@ command graph projects and culls each borrowed source batch, globally sorts came
 keys, and renders every visible Gaussian with one GPU-driven indirect draw:
 
 ```ts
-import {GPUSplatGraphRenderer} from '@luma.gl/splats';
+import {GPUSplatGraphRenderer, type GPUSplatData} from '@luma.gl/splats';
 
 const renderer = new GPUSplatGraphRenderer(webgpuDevice, {
-  data: preparedBatches,
-  viewportSize: [width, height]
+  viewportSize: [width, height],
+  expectedSplatCount: 741_883,
+  expectedBatchCount: 12
 });
 
-const commandEncoder = webgpuDevice.createCommandEncoder();
-renderer.encode(commandEncoder);
-webgpuDevice.submit(commandEncoder.finish());
+const preparedBatches: GPUSplatData[] = [];
+for await (const batch of preparedBatchStream) {
+  preparedBatches.push(batch);
+  renderer.appendData(batch);
+
+  const commandEncoder = webgpuDevice.createCommandEncoder();
+  renderer.encode(commandEncoder);
+  webgpuDevice.submit(commandEncoder.finish());
+}
+
+// Source batches belong to their caller and must outlive the borrowing renderer.
+renderer.destroy();
+for (const batch of preparedBatches) {
+  batch.destroy();
+}
 ```
 
-Projection, visibility, ordering, and the indirect instance count remain on the GPU; rendering does
-not read results back or sort source rows on the CPU. Original source batches remain independently
-owned and unchanged. Only camera-dependent projected records, depth keys, sort scratch, and the
-indirect command are owned by the graph renderer. Use `SplatRenderer` for WebGL2 or when CPU
-ordering is explicitly preferred.
+The example reserves room for the complete 741,883-splat Train scene and its twelve Arrow batches.
+The first nonempty batch compiles the graph and renders immediately; later batches replace their
+reserved source bindings without replacing the graph. The resulting pipeline is:
 
-Keep format parsing in `@loaders.gl/splats`, Apache Arrow conversion and GPU upload in
-`@luma.gl/arrow`, and deck.gl-specific layers in downstream adapters. The luma.gl splat renderer
-consumes framework-neutral GPU data.
+```text
+Caller-owned, independently allocated batches       One compiled GPU command graph
+
+batch 0: five original GPU columns --------+
+batch 1: five original GPU columns --------+--> reusable imported source slots
+batch N: five original GPU columns --------+              |
+                                                          v
+initialize every reserved row ---------------> project and cull populated slots
+identity indices + invalid depth keys           per-slot uniforms + 48-byte records
+reset indirect visible count                              |
+                                                          +--> global 16-bit radix sort --+
+                                                          |                              |
+                                                          +--> atomic visible count -----+
+                                                                                         |
+                                                                                         v
+                                                                                one indirect draw
+```
+
+### Source batches and reusable graph slots
+
+Parsing remains outside this package: `@loaders.gl/splats` recognizes file formats, `@luma.gl/arrow`
+converts individual Apache Arrow record batches to `GPUSplatData`, and this renderer consumes the
+resulting framework-neutral GPU objects. Source batches stay separate and retain their original
+buffer allocations throughout loading, rendering, capacity growth, and destruction.
+
+Each reserved graph slot represents exactly one source batch and imports five columns: positions,
+scales, rotations, colors, and opacities. Graph topology is immutable after compilation, so every
+slot initially has five distinct, renderer-owned placeholder buffers. Their minimum sizes are 12,
+12, 16, 4, and 4 bytes respectively. At encoding time, populated slots override those imported
+buffers with the original caller-owned allocations; unpopulated slots keep their harmless
+placeholders and do not dispatch projection work. This changes bindings, not graph topology, and
+never concatenates, repacks, copies, or reuploads existing source data.
+
+A separate 128-byte uniform buffer per slot carries the camera transform, viewport, Gaussian
+styling, batch offset, active row count, color format, exposure, and tone-mapping mode. Updating
+these uniforms costs work proportional to the reserved batch-slot count, not the splat-row count.
+
+### GPU execution phases
+
+Each necessary `encode(commandEncoder)` records the following dependent graph operations into the
+caller's command encoder. The caller still owns submission; no intermediate submissions or
+synchronous GPU readbacks are required.
+
+1. **Initialize reserved rows.** A compute pass writes stable identity indices across the entire
+   reserved row capacity, initializes every depth key to the invalid sentinel `65,535`, and resets
+   the indirect draw's visible-instance count to zero. Unfilled capacity therefore cannot be drawn.
+
+2. **Project and cull active batches.** One compute node per reserved slot processes its source
+   only when that slot contains a nonempty batch. Visible anisotropic Gaussians produce 48-byte
+   camera-dependent records containing clip position, screen-space axes, and linear RGBA radiance.
+   Invalid, clipped, transparent, or otherwise culled rows keep their sentinel keys. Valid rows
+   receive far-to-near keys in the range `0` through `65,534`, and each increments the indirect
+   visible-instance count atomically. Packed `Uint8Array` colors and floating-point HDR colors can
+   coexist in different batches.
+
+3. **Globally sort depth keys.** `GPUSort` performs a stable ascending radix sort using only the 16
+   meaningful depth-key bits. Its values are global projected-record indices, so transparent
+   Gaussians from different source batches share one correct back-to-front order. The maximum
+   sentinel sorts culled and inactive rows after every visible record.
+
+4. **Render once.** One graph-native indirect render pass consumes sorted projected-record indices
+   and the GPU-written visible count. The fragment shader expands and blends anisotropic Gaussian
+   quads, preserving source HDR radiance until exposure and display-appropriate tone mapping are
+   applied. No source-batch rebinding or one-draw-per-batch ordering is required in this pass.
+
+### Progressive capacity and graph lifetime
+
+`expectedSplatCount` and `expectedBatchCount` are optional, positive-integer capacity hints. When
+the complete source metadata is known, supplying both reserves the final row and batch-slot
+capacities up front. The first nonempty `encode()` compiles one graph; appending any batch that
+fits both capacities reuses the same `renderer.compiledGraph` object and only updates its imported
+source bindings and uniforms.
+
+Unknown or underestimated dimensions remain valid:
+
+- Without a row hint, the initial capacity is at least four times the first nonempty batch size;
+  without a batch hint, at least four source slots are reserved.
+- If incoming rows or batch slots exceed their current capacity, the corresponding capacity
+  doubles until it can accommodate the accumulated stream. A new graph is compiled only at that
+  growth boundary; subsequent fitting batches reuse it.
+- `renderer.capacity` exposes the current allocated row and slot counts, while `renderer.stats`
+  reports actual loaded rows, actual loaded batches, and source-versus-renderer GPU memory.
+- Appending a batch or changing camera/style properties marks the graph dirty. Once the stream and
+  camera are stationary, another `encode()` returns `undefined` instead of repeating projection,
+  sorting, and drawing.
+
+The lifecycle is therefore: no source rows means no graph; the first nonempty batch compiles and
+renders immediately; fitting batches stream through the same graph; capacity overflow occasionally
+recompiles; and a stationary completed scene performs no repeated GPU work. Replacing the entire
+source list with `setProps({data})` invalidates the old graph without destroying either the old or
+new caller-owned batches.
+
+### Ownership, precision, and performance tradeoffs
+
+`GPUSplatData` and all original source-column allocations remain caller-owned and must outlive the
+renderer. The renderer owns only derived projected records, depth keys, source indices, sorted
+keys/indices, radix-sort scratch, uniform buffers, slot placeholders, the indirect command, and its
+graph/model resources. Call `renderer.destroy()` before destroying the prepared source batches.
+
+The baseline persistent working buffers require 64 bytes per reserved row: 48 bytes for each
+projected record and four 4-byte key/index arrays. Reserving the complete 741,883-splat Train scene
+therefore uses approximately 45.28 MiB before graph scratch, per-slot uniforms/placeholders, and
+the separately owned source columns. `renderer.stats` and `renderer.graphStats` expose the actual
+allocation and scheduling diagnostics without reading back source rows or visible counts.
+
+The fixed-topology radix sort currently processes the **entire reserved row capacity on every dirty
+frame**, even while only the first streamed batch is populated. Exact final-size hints eliminate
+recompilation and improve CPU responsiveness, but front-load GPU memory and full-scene sorting
+work; unknown-size geometric growth trades occasional recompilation for less initially reserved
+capacity. Sixteen-bit keys reduce radix work but provide finite depth-ordering precision; the sort
+is stable when rows quantize to the same key.
+
+Projected records also must fit the adapter's `maxStorageBufferBindingSize`. For the common 128 MiB
+binding limit, the 48-byte stride permits at most 2,796,202 projected rows in one graph; actual
+available GPU memory or other implementation limits may lower that practical ceiling. Applications
+should retain their existing fallback policy when an adapter cannot allocate the requested scene.
+
+`GPUSplatGraphRenderer` requires WebGPU. Continue to use `SplatRenderer` for WebGL2 devices or for
+explicit CPU-ordered comparison; both renderers preserve caller ownership and original source-batch
+boundaries. Keep deck.gl-specific layers in downstream adapters instead of introducing framework
+or file-format dependencies into `@luma.gl/splats`.

--- a/modules/splats/src/gpu-splat-graph-renderer.ts
+++ b/modules/splats/src/gpu-splat-graph-renderer.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import {Buffer, type CommandEncoder, type Device, type ShaderLayout} from '@luma.gl/core';
+import {assert, Buffer, type CommandEncoder, type Device, type ShaderLayout} from '@luma.gl/core';
 import {Computation, Model} from '@luma.gl/engine';
 import {
   DrawCommandBuffer,
@@ -12,11 +12,13 @@ import {
   type GPUCommandGraphEncoding,
   type GPUCommandGraphStats,
   type GraphBufferHandle,
-  type GraphDataView
+  type GraphDataView,
+  type GraphImportedBuffer
 } from '@luma.gl/experimental';
 import {GPUSplatData} from './splat-data';
 import {
   GPU_SPLAT_GRAPH_UNIFORM_BYTE_LENGTH,
+  GPU_SPLAT_INVALID_DEPTH_KEY,
   GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH,
   GPU_SPLAT_PROJECTION_SHADER,
   GPU_SPLAT_PROJECTION_SHADER_LAYOUT,
@@ -30,6 +32,10 @@ import type {SplatSortMode} from './splat-sort';
 export type GPUSplatGraphRendererProps = SplatRendererProps & {
   /** Color used when the graph opens its single default-framebuffer render pass. */
   clearColor?: [number, number, number, number];
+  /** Optional final row count used to reserve one persistent progressively populated graph. */
+  expectedSplatCount?: number;
+  /** Optional final Arrow batch count used to reserve immutable borrowed-source binding slots. */
+  expectedBatchCount?: number;
 };
 
 type ResolvedGPUSplatGraphRendererProps = {
@@ -68,9 +74,20 @@ const INITIALIZE_SHADER_LAYOUT = {
   attributes: [],
   bindings: [
     {name: 'sortValues', type: 'storage', group: 0, location: 0},
-    {name: 'drawCommands', type: 'storage', group: 0, location: 1}
+    {name: 'drawCommands', type: 'storage', group: 0, location: 1},
+    {name: 'depthKeys', type: 'storage', group: 0, location: 2}
   ]
 } satisfies ShaderLayout;
+
+const SOURCE_SLOT_COLUMNS = [
+  {name: 'positions', minimumByteLength: 12},
+  {name: 'scales', minimumByteLength: 12},
+  {name: 'rotations', minimumByteLength: 16},
+  {name: 'colors', minimumByteLength: 4},
+  {name: 'opacities', minimumByteLength: 4}
+] as const;
+
+type SourceSlotColumnName = (typeof SOURCE_SLOT_COLUMNS)[number]['name'];
 
 /**
  * WebGPU-only Gaussian renderer composed entirely from reusable GPU command-graph nodes.
@@ -94,12 +111,16 @@ export class GPUSplatGraphRenderer {
   lastEncoding?: GPUCommandGraphEncoding;
 
   private readonly clearColor: [number, number, number, number];
+  private readonly expectedSplatCount?: number;
+  private readonly expectedBatchCount?: number;
   private readonly ownedBuffers: Buffer[] = [];
   private readonly batchUniforms: Buffer[] = [];
   private model?: Model;
   private sortedValuesBuffer?: Buffer;
   private requiresGraphRebuild = true;
   private requiresEncoding = true;
+  private allocatedSplatCapacity = 0;
+  private allocatedBatchCapacity = 0;
   private hasExplicitToneMapping: boolean;
   private isDestroyed = false;
 
@@ -108,8 +129,19 @@ export class GPUSplatGraphRenderer {
     if (device.type !== 'webgpu') {
       throw new Error('GPUSplatGraphRenderer requires a WebGPU device');
     }
+    // Expected stream capacities must be positive safe integers.
+    assert(
+      props.expectedSplatCount === undefined ||
+        (Number.isSafeInteger(props.expectedSplatCount) && props.expectedSplatCount > 0)
+    );
+    assert(
+      props.expectedBatchCount === undefined ||
+        (Number.isSafeInteger(props.expectedBatchCount) && props.expectedBatchCount > 0)
+    );
 
     this.device = device;
+    this.expectedSplatCount = props.expectedSplatCount;
+    this.expectedBatchCount = props.expectedBatchCount;
     this.clearColor = [...(props.clearColor ?? [0, 0, 0, 0])];
     this.props = {
       modelViewProjectionMatrix: toSplatGraphMatrix(props.modelViewProjectionMatrix),
@@ -141,6 +173,11 @@ export class GPUSplatGraphRenderer {
     return this.compiledGraph?.stats;
   }
 
+  /** Current immutable graph capacities; only overflow requires rebuilding its slots or rows. */
+  get capacity(): {splatCount: number; batchCount: number} {
+    return {splatCount: this.allocatedSplatCapacity, batchCount: this.allocatedBatchCapacity};
+  }
+
   /** GPU-produced globally sorted projected-record indices, available after compilation. */
   get sortedIndexBuffer(): Buffer | undefined {
     return this.sortedValuesBuffer;
@@ -169,7 +206,13 @@ export class GPUSplatGraphRenderer {
     ) {
       this.props.toneMapping = 'reinhard';
     }
-    this.requiresGraphRebuild = true;
+    if (
+      !this.compiledGraph ||
+      this.getRowCount() > this.allocatedSplatCapacity ||
+      this.batches.length > this.allocatedBatchCapacity
+    ) {
+      this.requiresGraphRebuild = true;
+    }
     this.requiresEncoding = true;
   }
 
@@ -257,7 +300,10 @@ export class GPUSplatGraphRenderer {
     }
 
     this.writeBatchUniforms();
-    this.lastEncoding = this.compiledGraph.encode(commandEncoder, {parameters: undefined});
+    this.lastEncoding = this.compiledGraph.encode(commandEncoder, {
+      parameters: undefined,
+      buffers: this.getSourceBufferOverrides()
+    });
     this.requiresEncoding = false;
     return this.lastEncoding;
   }
@@ -312,7 +358,10 @@ export class GPUSplatGraphRenderer {
       return;
     }
 
-    const projectedByteLength = rowCount * GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH;
+    this.allocatedSplatCapacity = this.resolveSplatCapacity(rowCount);
+    this.allocatedBatchCapacity = this.resolveBatchCapacity(this.batches.length);
+    const projectedByteLength =
+      this.allocatedSplatCapacity * GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH;
     if (
       this.device.limits.maxStorageBufferBindingSize > 0 &&
       projectedByteLength > this.device.limits.maxStorageBufferBindingSize
@@ -327,35 +376,50 @@ export class GPUSplatGraphRenderer {
     );
     const depthKeysBuffer = this.createOwnedBuffer(
       'gaussian-splat-depth-keys',
-      rowCount * Uint32Array.BYTES_PER_ELEMENT
+      this.allocatedSplatCapacity * Uint32Array.BYTES_PER_ELEMENT
     );
     const sourceIndicesBuffer = this.createOwnedBuffer(
       'gaussian-splat-source-indices',
-      rowCount * Uint32Array.BYTES_PER_ELEMENT
+      this.allocatedSplatCapacity * Uint32Array.BYTES_PER_ELEMENT
     );
     const sortedKeysBuffer = this.createOwnedBuffer(
       'gaussian-splat-sorted-keys',
-      rowCount * Uint32Array.BYTES_PER_ELEMENT
+      this.allocatedSplatCapacity * Uint32Array.BYTES_PER_ELEMENT
     );
     this.sortedValuesBuffer = this.createOwnedBuffer(
       'gaussian-splat-sorted-indices',
-      rowCount * Uint32Array.BYTES_PER_ELEMENT
+      this.allocatedSplatCapacity * Uint32Array.BYTES_PER_ELEMENT
     );
 
     const projectedRecords = this.importOwnedBuffer(graph, projectedRecordsBuffer);
-    const depthKeys = this.importUint32Buffer(graph, depthKeysBuffer, rowCount);
-    const sourceIndices = this.importUint32Buffer(graph, sourceIndicesBuffer, rowCount);
-    const sortedKeys = this.importUint32Buffer(graph, sortedKeysBuffer, rowCount);
-    const sortedIndices = this.importUint32Buffer(graph, this.sortedValuesBuffer, rowCount);
+    const depthKeys = this.importUint32Buffer(graph, depthKeysBuffer, this.allocatedSplatCapacity);
+    const sourceIndices = this.importUint32Buffer(
+      graph,
+      sourceIndicesBuffer,
+      this.allocatedSplatCapacity
+    );
+    const sortedKeys = this.importUint32Buffer(
+      graph,
+      sortedKeysBuffer,
+      this.allocatedSplatCapacity
+    );
+    const sortedIndices = this.importUint32Buffer(
+      graph,
+      this.sortedValuesBuffer,
+      this.allocatedSplatCapacity
+    );
     const drawCommandViews = this.drawCommands.importToGraph(graph);
 
-    this.addInitializationPass(graph, sourceIndices, drawCommandViews.buffer, rowCount);
+    this.addInitializationPass(
+      graph,
+      sourceIndices,
+      depthKeys,
+      drawCommandViews.buffer,
+      this.allocatedSplatCapacity
+    );
 
     let firstUniform: GraphBufferHandle | undefined;
-    for (const [batchIndex, batch] of this.batches.entries()) {
-      if (batch.length === 0) {
-        continue;
-      }
+    for (let batchIndex = 0; batchIndex < this.allocatedBatchCapacity; batchIndex++) {
       const uniformBuffer = this.device.createBuffer({
         id: `gaussian-splat-graph-uniforms-${batchIndex}`,
         byteLength: GPU_SPLAT_GRAPH_UNIFORM_BYTE_LENGTH,
@@ -368,7 +432,6 @@ export class GPUSplatGraphRenderer {
       );
       firstUniform ??= uniforms;
       this.addProjectionPass(graph, {
-        batch,
         batchIndex,
         projectedRecords,
         depthKeys,
@@ -397,7 +460,7 @@ export class GPUSplatGraphRenderer {
       source: GPU_SPLAT_RENDER_SHADER,
       shaderLayout: GPU_SPLAT_RENDER_SHADER_LAYOUT,
       isInstanced: true,
-      instanceCount: rowCount,
+      instanceCount: this.allocatedSplatCapacity,
       vertexCount: 4,
       topology: 'triangle-strip',
       bindings: {
@@ -456,18 +519,22 @@ export class GPUSplatGraphRenderer {
   private addInitializationPass(
     graph: GPUCommandGraph,
     sourceIndices: GraphDataView<'uint32'>,
+    depthKeys: GraphDataView<'uint32'>,
     drawCommands: GraphBufferHandle,
     rowCount: number
   ): void {
     const shader = /* wgsl */ `
 const ROW_COUNT: u32 = ${rowCount}u;
+const INVALID_DEPTH_KEY: u32 = ${GPU_SPLAT_INVALID_DEPTH_KEY}u;
 @group(0) @binding(0) var<storage, read_write> sortValues: array<u32>;
 @group(0) @binding(1) var<storage, read_write> drawCommands: array<atomic<u32>>;
+@group(0) @binding(2) var<storage, read_write> depthKeys: array<u32>;
 
 @compute @workgroup_size(256)
 fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
   if (invocation.x < ROW_COUNT) {
     sortValues[invocation.x] = invocation.x;
+    depthKeys[invocation.x] = INVALID_DEPTH_KEY;
   }
   if (invocation.x == 0u) {
     atomicStore(&drawCommands[1], 0u);
@@ -477,7 +544,8 @@ fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
       id: 'gaussian-splat-initialize',
       resources: [
         {buffer: sourceIndices, usage: 'storage-write'},
-        {buffer: drawCommands, usage: 'storage-write'}
+        {buffer: drawCommands, usage: 'storage-write'},
+        {buffer: depthKeys, usage: 'storage-write'}
       ],
       compile: ({device}) => {
         const computation = new Computation(device, {
@@ -489,7 +557,8 @@ fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
           encode: ({computePass, getBuffer}) => {
             computation.setBindings({
               sortValues: getBuffer(sourceIndices),
-              drawCommands: getBuffer(drawCommands)
+              drawCommands: getBuffer(drawCommands),
+              depthKeys: getBuffer(depthKeys)
             });
             computation.dispatch(computePass, Math.ceil(rowCount / 256));
           },
@@ -502,7 +571,6 @@ fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
   private addProjectionPass(
     graph: GPUCommandGraph,
     props: {
-      batch: GPUSplatData;
       batchIndex: number;
       projectedRecords: GraphBufferHandle;
       depthKeys: GraphDataView<'uint32'>;
@@ -510,27 +578,12 @@ fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
       uniforms: GraphBufferHandle;
     }
   ): void {
-    const {batch, batchIndex, projectedRecords, depthKeys, drawCommands, uniforms} = props;
-    const positions = graph.importGPUData(
-      `gaussian-splat-batch-${batchIndex}-positions`,
-      batch.positions.data[0]
-    );
-    const scales = graph.importGPUData(
-      `gaussian-splat-batch-${batchIndex}-scales`,
-      batch.scales.data[0]
-    );
-    const rotations = graph.importGPUData(
-      `gaussian-splat-batch-${batchIndex}-rotations`,
-      batch.rotations.data[0]
-    );
-    const colors = graph.importGPUData(
-      `gaussian-splat-batch-${batchIndex}-colors`,
-      batch.colors.data[0]
-    );
-    const opacities = graph.importGPUData(
-      `gaussian-splat-batch-${batchIndex}-opacities`,
-      batch.opacities.data[0]
-    );
+    const {batchIndex, projectedRecords, depthKeys, drawCommands, uniforms} = props;
+    const positions = this.importSourceSlotBuffer(graph, batchIndex, 'positions', 12);
+    const scales = this.importSourceSlotBuffer(graph, batchIndex, 'scales', 12);
+    const rotations = this.importSourceSlotBuffer(graph, batchIndex, 'rotations', 16);
+    const colors = this.importSourceSlotBuffer(graph, batchIndex, 'colors', 4);
+    const opacities = this.importSourceSlotBuffer(graph, batchIndex, 'opacities', 4);
 
     graph.addComputePass({
       id: `gaussian-splat-project-batch-${batchIndex}`,
@@ -553,6 +606,10 @@ fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
         });
         return {
           encode: ({computePass, getBuffer}) => {
+            const batch = this.batches[batchIndex];
+            if (!batch || batch.length === 0) {
+              return;
+            }
             computation.setBindings({
               positions: getBuffer(positions),
               scales: getBuffer(scales),
@@ -574,11 +631,8 @@ fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
 
   private writeBatchUniforms(): void {
     let batchOffset = 0;
-    let uniformIndex = 0;
-    for (const batch of this.batches) {
-      if (batch.length === 0) {
-        continue;
-      }
+    for (let batchIndex = 0; batchIndex < this.allocatedBatchCapacity; batchIndex++) {
+      const batch = this.batches[batchIndex];
       const uniformData = new ArrayBuffer(GPU_SPLAT_GRAPH_UNIFORM_BYTE_LENGTH);
       const floatValues = new Float32Array(uniformData);
       const integerValues = new Uint32Array(uniformData);
@@ -594,12 +648,75 @@ fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
       floatValues[25] = this.props.exposure;
       integerValues[26] = this.props.toneMapping === 'reinhard' ? 1 : 0;
       integerValues[27] = batchOffset;
-      integerValues[28] = batch.length;
-      integerValues[29] = batch.colors.format === 'float32x4' ? 1 : 0;
-      this.batchUniforms[uniformIndex].write(new Uint8Array(uniformData));
-      batchOffset += batch.length;
-      uniformIndex++;
+      integerValues[28] = batch?.length ?? 0;
+      integerValues[29] = batch?.colors.format === 'float32x4' ? 1 : 0;
+      this.batchUniforms[batchIndex].write(new Uint8Array(uniformData));
+      batchOffset += batch?.length ?? 0;
     }
+  }
+
+  private getSourceBufferOverrides(): Record<string, GraphImportedBuffer> {
+    const overrides: Record<string, GraphImportedBuffer> = {};
+    for (const [batchIndex, batch] of this.batches.entries()) {
+      if (batch.length === 0) {
+        continue;
+      }
+      for (const {name} of SOURCE_SLOT_COLUMNS) {
+        overrides[getSourceSlotBufferId(batchIndex, name)] = batch[name].data[0].buffer;
+      }
+    }
+    return overrides;
+  }
+
+  private importSourceSlotBuffer(
+    graph: GPUCommandGraph,
+    batchIndex: number,
+    columnName: SourceSlotColumnName,
+    minimumByteLength: number
+  ): GraphBufferHandle {
+    const sourceId = getSourceSlotBufferId(batchIndex, columnName);
+    const placeholder = this.createOwnedBuffer(`${sourceId}-placeholder`, minimumByteLength);
+    return graph.importBuffer(
+      {id: sourceId, byteLength: minimumByteLength, usage: Buffer.STORAGE},
+      placeholder
+    );
+  }
+
+  private resolveSplatCapacity(rowCount: number): number {
+    const maximumStorageByteLength = this.device.limits.maxStorageBufferBindingSize;
+    const maximumRowCapacity =
+      maximumStorageByteLength > 0
+        ? Math.floor(maximumStorageByteLength / GPU_SPLAT_PROJECTED_RECORD_BYTE_LENGTH)
+        : Number.MAX_SAFE_INTEGER;
+    if (rowCount > maximumRowCapacity || (this.expectedSplatCount ?? 0) > maximumRowCapacity) {
+      throw new Error('Gaussian splat projected records exceed the device storage binding limit');
+    }
+
+    if (this.allocatedSplatCapacity === 0) {
+      if (this.expectedSplatCount !== undefined) {
+        this.allocatedSplatCapacity = this.expectedSplatCount;
+      } else {
+        const firstNonemptyBatchLength = this.batches.find(batch => batch.length > 0)?.length ?? 1;
+        this.allocatedSplatCapacity = Math.min(
+          maximumRowCapacity,
+          Math.max(rowCount, firstNonemptyBatchLength * 4)
+        );
+      }
+    }
+    while (this.allocatedSplatCapacity < rowCount) {
+      this.allocatedSplatCapacity = Math.min(maximumRowCapacity, this.allocatedSplatCapacity * 2);
+    }
+    return this.allocatedSplatCapacity;
+  }
+
+  private resolveBatchCapacity(batchCount: number): number {
+    if (this.allocatedBatchCapacity === 0) {
+      this.allocatedBatchCapacity = this.expectedBatchCount ?? Math.max(batchCount, 4);
+    }
+    while (this.allocatedBatchCapacity < batchCount) {
+      this.allocatedBatchCapacity *= 2;
+    }
+    return this.allocatedBatchCapacity;
   }
 
   private createOwnedBuffer(id: string, byteLength: number): Buffer {
@@ -648,6 +765,10 @@ fn main(@builtin(global_invocation_id) invocation: vec3<u32>) {
     this.sortedValuesBuffer = undefined;
     this.requiresGraphRebuild = true;
   }
+}
+
+function getSourceSlotBufferId(batchIndex: number, columnName: SourceSlotColumnName): string {
+  return `gaussian-splat-batch-${batchIndex}-${columnName}`;
 }
 
 function normalizeSplatGraphBatches(

--- a/modules/splats/test/gpu-splat-graph-renderer.spec.ts
+++ b/modules/splats/test/gpu-splat-graph-renderer.spec.ts
@@ -69,9 +69,14 @@ test('GPUSplatGraphRenderer projects, culls, globally sorts, and indirectly draw
         sortedIndexBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
       );
       t.deepEqual(
-        Array.from(sortedIndices),
+        Array.from(sortedIndices.slice(0, 4)),
         [1, 2, 0, 3],
         'globally sorts visible rows far-to-near and moves the culled sentinel to the end'
+      );
+      t.deepEqual(
+        Array.from(sortedIndices.slice(4)),
+        [4, 5, 6, 7],
+        'retains inactive reserved row identifiers behind every populated source row'
       );
     }
 
@@ -102,6 +107,141 @@ test('GPUSplatGraphRenderer projects, culls, globally sorts, and indirectly draw
 
   t.end();
 });
+
+test('GPUSplatGraphRenderer progressively binds borrowed batches without rebuilding its reserved graph', async t => {
+  const devices = await getTestDevices(['webgpu']);
+
+  for (const device of devices) {
+    const firstBatch = makeGPUSplatData(device, makeBrowserGraphSplatSource([0.2, 0.9], 0));
+    const renderer = new GPUSplatGraphRenderer(device, {
+      data: firstBatch,
+      expectedSplatCount: 6,
+      expectedBatchCount: 3,
+      viewportSize: [32, 32],
+      alphaCutoff: 0.01
+    });
+    t.ok(renderer.encode(device.commandEncoder), 'renders the first streamed source batch');
+    device.submit();
+    const originalGraph = renderer.compiledGraph;
+    t.deepEqual(renderer.capacity, {splatCount: 6, batchCount: 3}, 'reserves exact stream totals');
+    await assertVisibleGraphInstanceCount(t, device, renderer, 2);
+
+    const secondSource = makeBrowserGraphSplatSource([0.6, 0.4], 2);
+    secondSource.colors = new Float32Array([2, 0.5, 0.25, 1, 3, 1, 0.5, 1]);
+    secondSource.opacities[1] = 0;
+    const secondBatch = makeGPUSplatData(device, secondSource);
+    renderer.appendData(secondBatch);
+    t.ok(renderer.encode(device.commandEncoder), 'renders the newly appended Float32 HDR batch');
+    device.submit();
+    t.equal(
+      renderer.compiledGraph,
+      originalGraph,
+      'reuses the original graph for the second batch'
+    );
+    t.equal(renderer.props.toneMapping, 'reinhard', 'adapts mixed HDR source colors on SDR');
+    await assertVisibleGraphInstanceCount(t, device, renderer, 3);
+
+    const thirdBatch = makeGPUSplatData(device, makeBrowserGraphSplatSource([0.75, 0.3], 4));
+    renderer.appendData(thirdBatch);
+    t.ok(renderer.encode(device.commandEncoder), 'renders the final appended Uint8 source batch');
+    device.submit();
+    t.equal(renderer.compiledGraph, originalGraph, 'still uses the graph compiled for batch one');
+    await assertVisibleGraphInstanceCount(t, device, renderer, 5);
+    if (!isSoftwareBackedGraphDevice(device)) {
+      const sortedBytes = await renderer.sortedIndexBuffer!.readAsync();
+      const sortedIndices = new Uint32Array(
+        sortedBytes.buffer,
+        sortedBytes.byteOffset,
+        sortedBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+      );
+      t.deepEqual(
+        Array.from(sortedIndices),
+        [1, 4, 2, 5, 0, 3],
+        'globally sorts three original mixed-format batches and retains the culled sentinel last'
+      );
+    }
+
+    const firstSourceBuffer = firstBatch.positions.data[0].buffer;
+    const secondSourceBuffer = secondBatch.colors.data[0].buffer;
+    renderer.destroy();
+    t.notOk(firstSourceBuffer.destroyed, 'preserves the original borrowed first source allocation');
+    t.notOk(secondSourceBuffer.destroyed, 'preserves the original borrowed HDR color allocation');
+    firstBatch.destroy();
+    secondBatch.destroy();
+    thirdBatch.destroy();
+  }
+
+  t.end();
+});
+
+test('GPUSplatGraphRenderer grows unknown stream capacity geometrically', async t => {
+  const devices = await getTestDevices(['webgpu']);
+
+  for (const device of devices) {
+    const batches = [makeGPUSplatData(device, makeBrowserGraphSplatSource([0.1], 0))];
+    const renderer = new GPUSplatGraphRenderer(device, {
+      data: batches[0],
+      viewportSize: [32, 32]
+    });
+    renderer.encode(device.commandEncoder);
+    device.submit();
+    const initialGraph = renderer.compiledGraph;
+    t.deepEqual(renderer.capacity, {splatCount: 4, batchCount: 4}, 'reserves four unknown slots');
+
+    for (let batchIndex = 1; batchIndex < 4; batchIndex++) {
+      const batch = makeGPUSplatData(
+        device,
+        makeBrowserGraphSplatSource([0.1 + batchIndex * 0.1], batchIndex)
+      );
+      batches.push(batch);
+      renderer.appendData(batch);
+      renderer.encode(device.commandEncoder);
+      device.submit();
+      t.equal(renderer.compiledGraph, initialGraph, 'keeps the graph until its capacity fills');
+    }
+
+    const overflowBatch = makeGPUSplatData(device, makeBrowserGraphSplatSource([0.8], 4));
+    batches.push(overflowBatch);
+    renderer.appendData(overflowBatch);
+    renderer.encode(device.commandEncoder);
+    device.submit();
+    t.notEqual(renderer.compiledGraph, initialGraph, 'rebuilds once when both capacities overflow');
+    t.deepEqual(
+      renderer.capacity,
+      {splatCount: 8, batchCount: 8},
+      'doubles reserved row and slot capacity'
+    );
+
+    renderer.destroy();
+    for (const batch of batches) {
+      batch.destroy();
+    }
+  }
+
+  t.end();
+});
+
+async function assertVisibleGraphInstanceCount(
+  assertion: {equal: (actual: number, expected: number, message: string) => void},
+  device: Device,
+  renderer: GPUSplatGraphRenderer,
+  expectedCount: number
+): Promise<void> {
+  if (isSoftwareBackedGraphDevice(device)) {
+    return;
+  }
+  const commandBytes = await renderer.drawCommands.buffer.readAsync();
+  const commandWords = new Uint32Array(
+    commandBytes.buffer,
+    commandBytes.byteOffset,
+    commandBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+  );
+  assertion.equal(
+    commandWords[1],
+    expectedCount,
+    `GPU culling publishes ${expectedCount} progressive indirect-draw instances`
+  );
+}
 
 function isSoftwareBackedGraphDevice(device: Device): boolean {
   return (

--- a/modules/splats/test/gpu-splat-progressive-renderer.node.spec.ts
+++ b/modules/splats/test/gpu-splat-progressive-renderer.node.spec.ts
@@ -1,0 +1,151 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test from 'test/utils/vitest-tape';
+import {GPUSplatGraphRenderer, makeGPUSplatData, type SplatSource} from '@luma.gl/splats';
+import {NullDevice} from '@luma.gl/test-utils';
+
+test('GPUSplatGraphRenderer reserves progressive hints lazily while borrowing original batches', t => {
+  const device = makeProgressiveWebGPUNullDevice();
+  const firstBatch = makeGPUSplatData(device, makeProgressiveNodeSplatSource([0.25, 0.75], 0));
+  const secondBatch = makeGPUSplatData(device, makeProgressiveNodeSplatSource([0.5], 2));
+  const firstPositionBuffer = firstBatch.positions.data[0].buffer;
+  const secondPositionBuffer = secondBatch.positions.data[0].buffer;
+  const renderer = new GPUSplatGraphRenderer(device, {
+    expectedSplatCount: 8,
+    expectedBatchCount: 4,
+    viewportSize: [32, 24]
+  });
+
+  t.equal(renderer.compiledGraph, undefined, 'does not compile anticipated slots before streaming');
+  renderer.appendData(firstBatch);
+  renderer.appendData(secondBatch);
+  t.equal(renderer.compiledGraph, undefined, 'does not compile eagerly while batches are appended');
+  t.equal(renderer.batches[0], firstBatch, 'retains the original first streamed GPU batch');
+  t.equal(renderer.batches[1], secondBatch, 'retains the original second streamed GPU batch');
+  t.equal(
+    renderer.stats.splatCount,
+    3,
+    'reports populated rows instead of reserved scene capacity'
+  );
+  t.equal(
+    renderer.stats.batchCount,
+    2,
+    'reports populated batches instead of reserved batch slots'
+  );
+  t.equal(
+    renderer.batches[0].positions.data[0].buffer,
+    firstPositionBuffer,
+    'preserves the first original source GPU allocation'
+  );
+  t.equal(
+    renderer.batches[1].positions.data[0].buffer,
+    secondPositionBuffer,
+    'preserves the second original source GPU allocation'
+  );
+
+  renderer.destroy();
+  t.notOk(firstPositionBuffer.destroyed, 'never destroys the first borrowed source allocation');
+  t.notOk(secondPositionBuffer.destroyed, 'never destroys the second borrowed source allocation');
+  firstBatch.destroy();
+  secondBatch.destroy();
+  t.end();
+});
+
+test('GPUSplatGraphRenderer preserves mixed packed and HDR progressive source formats', t => {
+  const device = makeProgressiveWebGPUNullDevice();
+  const packedBatch = makeGPUSplatData(device, makeProgressiveNodeSplatSource([0.25], 0));
+  const highDynamicRangeSource = makeProgressiveNodeSplatSource([0.75], 1);
+  highDynamicRangeSource.colors = new Float32Array([8, 2, 0.25, 1]);
+  const highDynamicRangeBatch = makeGPUSplatData(device, highDynamicRangeSource);
+  const renderer = new GPUSplatGraphRenderer(device, {
+    expectedSplatCount: 1,
+    expectedBatchCount: 1,
+    data: packedBatch
+  });
+
+  t.equal(packedBatch.colors.format, 'unorm8x4', 'retains packed streamed colors');
+  t.equal(renderer.props.toneMapping, 'none', 'does not tone-map packed SDR source data');
+  renderer.appendData(highDynamicRangeBatch);
+  t.equal(
+    highDynamicRangeBatch.colors.format,
+    'float32x4',
+    'preserves streamed HDR radiance without byte quantization'
+  );
+  t.equal(renderer.props.toneMapping, 'reinhard', 'automatically resolves streamed HDR display');
+  t.equal(renderer.stats.splatCount, 2, 'accepts more rows than an underestimated scene hint');
+  t.equal(renderer.stats.batchCount, 2, 'accepts more batches than an underestimated slot hint');
+  t.equal(renderer.compiledGraph, undefined, 'grows lazy anticipated capacity without compilation');
+
+  renderer.destroy();
+  t.notOk(packedBatch.destroyed, 'retains ownership of the initial packed batch');
+  t.notOk(highDynamicRangeBatch.destroyed, 'retains ownership of the progressive HDR batch');
+  packedBatch.destroy();
+  highDynamicRangeBatch.destroy();
+  t.end();
+});
+
+test('GPUSplatGraphRenderer replaces progressively retained batches without destroying sources', t => {
+  const device = makeProgressiveWebGPUNullDevice();
+  const firstBatch = makeGPUSplatData(device, makeProgressiveNodeSplatSource([0.25], 0));
+  const secondBatch = makeGPUSplatData(device, makeProgressiveNodeSplatSource([0.5], 1));
+  const replacementBatch = makeGPUSplatData(device, makeProgressiveNodeSplatSource([0.75], 2));
+  const firstPositionBuffer = firstBatch.positions.data[0].buffer;
+  const secondPositionBuffer = secondBatch.positions.data[0].buffer;
+  const replacementPositionBuffer = replacementBatch.positions.data[0].buffer;
+  const renderer = new GPUSplatGraphRenderer(device, {
+    expectedSplatCount: 8,
+    expectedBatchCount: 4,
+    data: firstBatch
+  });
+
+  renderer.appendData(secondBatch);
+  renderer.setProps({data: replacementBatch});
+  t.equal(renderer.batches.length, 1, 'replaces the entire previously streamed batch sequence');
+  t.equal(renderer.batches[0], replacementBatch, 'retains the exact replacement GPU batch');
+  t.equal(renderer.stats.splatCount, 1, 'resets populated scene row counts after replacement');
+  t.notOk(firstPositionBuffer.destroyed, 'preserves the previous first borrowed source allocation');
+  t.notOk(
+    secondPositionBuffer.destroyed,
+    'preserves the previous second borrowed source allocation'
+  );
+
+  renderer.destroy();
+  t.notOk(
+    replacementPositionBuffer.destroyed,
+    'destroying replacement graph slots preserves the caller-owned replacement allocation'
+  );
+  firstBatch.destroy();
+  secondBatch.destroy();
+  replacementBatch.destroy();
+  t.end();
+});
+
+function makeProgressiveWebGPUNullDevice(): NullDevice {
+  const device = new NullDevice({});
+  Object.defineProperties(device, {
+    type: {value: 'webgpu'},
+    info: {value: {...device.info, type: 'webgpu', shadingLanguage: 'wgsl'}}
+  });
+  return device;
+}
+
+function makeProgressiveNodeSplatSource(
+  depths: readonly number[],
+  rowIndexBase: number
+): SplatSource {
+  const positions = new Float32Array(depths.length * 3);
+  const scales = new Float32Array(depths.length * 3);
+  const rotations = new Float32Array(depths.length * 4);
+  const colors = new Uint8Array(depths.length * 4);
+  const opacities = new Float32Array(depths.length);
+  for (const [rowIndex, depth] of depths.entries()) {
+    positions[rowIndex * 3 + 2] = depth;
+    scales.set([0.1, 0.06, 0.03], rowIndex * 3);
+    rotations[rowIndex * 4] = 1;
+    colors.set([255, 128, 32, 255], rowIndex * 4);
+    opacities[rowIndex] = 1;
+  }
+  return {positions, scales, rotations, colors, opacities, rowIndexBase};
+}

--- a/modules/splats/test/gpu-splat-progressive-renderer.spec.ts
+++ b/modules/splats/test/gpu-splat-progressive-renderer.spec.ts
@@ -1,0 +1,321 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import test, {type Test} from 'test/utils/vitest-tape';
+import type {Device} from '@luma.gl/core';
+import {GPUSplatGraphRenderer, makeGPUSplatData, type SplatSource} from '@luma.gl/splats';
+import {getTestDevices} from '@luma.gl/test-utils';
+
+test('GPUSplatGraphRenderer progressively sorts preserved batches with one precompiled graph', async t => {
+  const devices = await getTestDevices(['webgpu']);
+  t.ok(devices.length > 0, 'a browser WebGPU adapter is available');
+
+  for (const device of devices) {
+    const firstBatch = makeGPUSplatData(device, makeProgressiveSplatSource([0.2, 0.8], 0));
+    const secondBatch = makeGPUSplatData(device, makeProgressiveSplatSource([0.8, 0.4], 2));
+    const highDynamicRangeSource = makeProgressiveSplatSource([0.95, 0.1], 4);
+    highDynamicRangeSource.colors = new Float32Array([4, 2, 0.5, 1, 2, 1, 0.25, 1]);
+    const thirdBatch = makeGPUSplatData(device, highDynamicRangeSource);
+    const sourceBuffers = [firstBatch, secondBatch, thirdBatch].map(
+      batch => batch.positions.data[0].buffer
+    );
+    const renderer = new GPUSplatGraphRenderer(device, {
+      expectedSplatCount: 6,
+      expectedBatchCount: 3,
+      viewportSize: [32, 32],
+      alphaCutoff: 0.01,
+      clearColor: [0, 0, 0, 0]
+    });
+
+    t.equal(renderer.compiledGraph, undefined, 'does not compile an empty anticipated graph');
+    renderer.appendData(firstBatch);
+    await verifyProgressiveFrame(t, device, renderer, [1, 0], [2, 3, 4, 5]);
+    const initialCompiledGraph = renderer.compiledGraph;
+    t.ok(initialCompiledGraph, 'compiles the graph when its first streamed batch is encoded');
+    t.ok(
+      (renderer.sortedIndexBuffer?.byteLength ?? 0) >= 6 * Uint32Array.BYTES_PER_ELEMENT,
+      'reserves enough globally sorted records for the complete anticipated scene'
+    );
+
+    renderer.appendData(secondBatch);
+    await verifyProgressiveFrame(t, device, renderer, [1, 2, 3, 0], [4, 5]);
+    t.equal(
+      renderer.compiledGraph,
+      initialCompiledGraph,
+      'binds the second independent source batch into the existing compiled graph'
+    );
+
+    renderer.appendData(thirdBatch);
+    t.equal(thirdBatch.colors.format, 'float32x4', 'preserves streamed HDR radiance as Float32');
+    t.equal(renderer.props.toneMapping, 'reinhard', 'automatically tone-maps streamed HDR colors');
+    await verifyProgressiveFrame(t, device, renderer, [4, 1, 2, 3, 0, 5]);
+    t.equal(
+      renderer.compiledGraph,
+      initialCompiledGraph,
+      'reuses one compiled graph across all three progressive source uploads'
+    );
+    t.deepEqual(
+      renderer.batches.map(batch => batch.positions.data[0].buffer),
+      sourceBuffers,
+      'projects the original caller-owned source allocations without repacking or copying'
+    );
+    t.equal(
+      renderer.encode(device.commandEncoder),
+      undefined,
+      'does not repeat GPU projection or global sorting after streaming and camera motion stop'
+    );
+
+    renderer.destroy();
+    for (const sourceBuffer of sourceBuffers) {
+      t.notOk(sourceBuffer.destroyed, 'destroying graph slots never destroys borrowed source data');
+    }
+    firstBatch.destroy();
+    secondBatch.destroy();
+    thirdBatch.destroy();
+  }
+
+  t.end();
+});
+
+test('GPUSplatGraphRenderer sorts progressive culled rows and reserved slots after visible rows', async t => {
+  const devices = await getTestDevices(['webgpu']);
+  t.ok(devices.length > 0, 'a browser WebGPU adapter is available');
+
+  for (const device of devices) {
+    const firstSource = makeProgressiveSplatSource([0.2, 0.8, 0.4], 0);
+    firstSource.opacities[1] = 0;
+    const firstBatch = makeGPUSplatData(device, firstSource);
+    const secondSource = makeProgressiveSplatSource([0.9, 0.6], 3);
+    secondSource.positions[3] = Number.NaN;
+    const secondBatch = makeGPUSplatData(device, secondSource);
+    const renderer = new GPUSplatGraphRenderer(device, {
+      expectedSplatCount: 6,
+      expectedBatchCount: 2,
+      viewportSize: [32, 32],
+      alphaCutoff: 0.01,
+      clearColor: [0, 0, 0, 0]
+    });
+
+    renderer.appendData(firstBatch);
+    await verifyProgressiveFrame(t, device, renderer, [2, 0], [1, 3, 4, 5]);
+    const initialCompiledGraph = renderer.compiledGraph;
+
+    renderer.appendData(secondBatch);
+    await verifyProgressiveFrame(t, device, renderer, [3, 2, 0], [1, 4, 5]);
+    t.equal(
+      renderer.compiledGraph,
+      initialCompiledGraph,
+      'reuses reserved batch bindings while visibility changes between progressive frames'
+    );
+
+    renderer.destroy();
+    t.notOk(firstBatch.destroyed, 'retains first caller-owned batch after destroying placeholders');
+    t.notOk(
+      secondBatch.destroyed,
+      'retains second caller-owned batch after destroying placeholders'
+    );
+    firstBatch.destroy();
+    secondBatch.destroy();
+  }
+
+  t.end();
+});
+
+test('GPUSplatGraphRenderer grows unknown progressive capacity geometrically', async t => {
+  const devices = await getTestDevices(['webgpu']);
+  t.ok(devices.length > 0, 'a browser WebGPU adapter is available');
+
+  for (const device of devices) {
+    const renderer = new GPUSplatGraphRenderer(device, {
+      viewportSize: [32, 32],
+      alphaCutoff: 0.01,
+      clearColor: [0, 0, 0, 0]
+    });
+    const streamedBatches = Array.from({length: 6}, (_, rowIndex) =>
+      makeGPUSplatData(device, makeProgressiveSplatSource([(rowIndex + 1) / 10], rowIndex))
+    );
+    const compiledGraphs = new Set<NonNullable<typeof renderer.compiledGraph>>();
+    const sortedRecordCapacities: number[] = [];
+
+    for (const [batchIndex, batch] of streamedBatches.entries()) {
+      renderer.appendData(batch);
+      t.ok(renderer.encode(device.commandEncoder), 'encodes each progressively available frame');
+      device.submit();
+      if (renderer.compiledGraph) {
+        compiledGraphs.add(renderer.compiledGraph);
+      }
+      const sortedRecordCapacity =
+        (renderer.sortedIndexBuffer?.byteLength ?? 0) / Uint32Array.BYTES_PER_ELEMENT;
+      sortedRecordCapacities.push(sortedRecordCapacity);
+      t.ok(sortedRecordCapacity >= batchIndex + 1, 'never sorts beyond allocated scene capacity');
+    }
+
+    t.ok(
+      compiledGraphs.size < streamedBatches.length,
+      'geometric capacity growth avoids rebuilding the graph for every streamed batch'
+    );
+    t.ok(
+      sortedRecordCapacities[0] >= streamedBatches[0].length * 4,
+      'unknown scene sizes reserve at least four times the first streamed batch length'
+    );
+    t.ok(
+      sortedRecordCapacities.every(
+        (capacity, capacityIndex) =>
+          capacityIndex === 0 || capacity >= sortedRecordCapacities[capacityIndex - 1]
+      ),
+      'progressive scene capacity never shrinks while source batches are appended'
+    );
+
+    await verifySubmittedProgressiveBuffers(t, device, renderer, [5, 4, 3, 2, 1, 0]);
+    renderer.destroy();
+    for (const batch of streamedBatches) {
+      t.notOk(batch.destroyed, 'capacity growth retains caller ownership of every source batch');
+      batch.destroy();
+    }
+  }
+
+  t.end();
+});
+
+test('GPUSplatGraphRenderer safely outgrows underestimated progressive scene hints', async t => {
+  const devices = await getTestDevices(['webgpu']);
+  t.ok(devices.length > 0, 'a browser WebGPU adapter is available');
+
+  for (const device of devices) {
+    const streamedBatches = [0.2, 0.9, 0.4, 0.6].map((depth, rowIndex) =>
+      makeGPUSplatData(device, makeProgressiveSplatSource([depth], rowIndex))
+    );
+    const sourceBuffers = streamedBatches.map(batch => batch.positions.data[0].buffer);
+    const renderer = new GPUSplatGraphRenderer(device, {
+      expectedSplatCount: 1,
+      expectedBatchCount: 1,
+      viewportSize: [32, 32],
+      alphaCutoff: 0.01,
+      clearColor: [0, 0, 0, 0]
+    });
+
+    renderer.appendData(streamedBatches[0]);
+    await verifyProgressiveFrame(t, device, renderer, [0]);
+    const originalCompiledGraph = renderer.compiledGraph;
+
+    renderer.appendData(streamedBatches[1]);
+    renderer.appendData(streamedBatches[2]);
+    await verifyProgressiveFrame(t, device, renderer, [1, 2, 0], [3]);
+    const grownCompiledGraph = renderer.compiledGraph;
+    t.notEqual(
+      grownCompiledGraph,
+      originalCompiledGraph,
+      'rebuilds the underestimated graph once after accumulated source rows and slots overflow'
+    );
+    t.ok(
+      (renderer.sortedIndexBuffer?.byteLength ?? 0) >= 4 * Uint32Array.BYTES_PER_ELEMENT,
+      'geometrically reserves space beyond the underestimated initial scene capacity'
+    );
+
+    renderer.appendData(streamedBatches[3]);
+    await verifyProgressiveFrame(t, device, renderer, [1, 3, 2, 0]);
+    t.equal(
+      renderer.compiledGraph,
+      grownCompiledGraph,
+      'reuses the grown graph when another streamed batch fits its expanded capacities'
+    );
+
+    renderer.destroy();
+    for (const [batchIndex, sourceBuffer] of sourceBuffers.entries()) {
+      t.notOk(sourceBuffer.destroyed, 'growth never destroys a caller-owned source allocation');
+      streamedBatches[batchIndex].destroy();
+    }
+  }
+
+  t.end();
+});
+
+async function verifyProgressiveFrame(
+  assertions: Test,
+  device: Device,
+  renderer: GPUSplatGraphRenderer,
+  expectedVisibleIndices: readonly number[],
+  expectedSentinelIndices: readonly number[] = []
+): Promise<void> {
+  assertions.ok(renderer.encode(device.commandEncoder), 'encodes the newly appended batch');
+  device.submit();
+  await verifySubmittedProgressiveBuffers(
+    assertions,
+    device,
+    renderer,
+    expectedVisibleIndices,
+    expectedSentinelIndices
+  );
+}
+
+async function verifySubmittedProgressiveBuffers(
+  assertions: Test,
+  device: Device,
+  renderer: GPUSplatGraphRenderer,
+  expectedVisibleIndices: readonly number[],
+  expectedSentinelIndices: readonly number[] = []
+): Promise<void> {
+  if (isSoftwareBackedProgressiveDevice(device)) {
+    assertions.comment('Skipping progressive Gaussian splat readback on a software-backed adapter');
+    return;
+  }
+
+  const commandBytes = await renderer.drawCommands.buffer.readAsync();
+  const commandWords = new Uint32Array(
+    commandBytes.buffer,
+    commandBytes.byteOffset,
+    commandBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+  );
+  assertions.deepEqual(
+    Array.from(commandWords),
+    [4, expectedVisibleIndices.length, 0, 0],
+    'GPU projection publishes the exact visible progressive instance count'
+  );
+
+  const sortedIndexBytes = await renderer.sortedIndexBuffer!.readAsync();
+  const sortedIndices = new Uint32Array(
+    sortedIndexBytes.buffer,
+    sortedIndexBytes.byteOffset,
+    sortedIndexBytes.byteLength / Uint32Array.BYTES_PER_ELEMENT
+  );
+  assertions.deepEqual(
+    Array.from(sortedIndices.subarray(0, expectedVisibleIndices.length)),
+    expectedVisibleIndices,
+    'globally sorts every visible progressive batch far-to-near with stable ties'
+  );
+  if (expectedSentinelIndices.length > 0) {
+    assertions.deepEqual(
+      Array.from(
+        sortedIndices.subarray(
+          expectedVisibleIndices.length,
+          expectedVisibleIndices.length + expectedSentinelIndices.length
+        )
+      ),
+      expectedSentinelIndices,
+      'places culled rows and currently inactive reserved slots after every visible row'
+    );
+  }
+}
+
+function isSoftwareBackedProgressiveDevice(device: Device): boolean {
+  return (
+    device.info.gpu === 'software' || device.info.gpuType === 'cpu' || Boolean(device.info.fallback)
+  );
+}
+
+function makeProgressiveSplatSource(depths: readonly number[], rowIndexBase: number): SplatSource {
+  const positions = new Float32Array(depths.length * 3);
+  const scales = new Float32Array(depths.length * 3);
+  const rotations = new Float32Array(depths.length * 4);
+  const colors = new Uint8Array(depths.length * 4);
+  const opacities = new Float32Array(depths.length);
+  for (const [rowIndex, depth] of depths.entries()) {
+    positions[rowIndex * 3 + 2] = depth;
+    scales.set([0.2, 0.1, 0.03], rowIndex * 3);
+    rotations[rowIndex * 4] = 1;
+    colors.set([255, 128, 32, 255], rowIndex * 4);
+    opacities[rowIndex] = 1;
+  }
+  return {positions, scales, rotations, colors, opacities, rowIndexBase};
+}

--- a/test/examples/gaussian-splat-viewer.node.spec.ts
+++ b/test/examples/gaussian-splat-viewer.node.spec.ts
@@ -6,7 +6,11 @@ import {readFileSync} from 'node:fs';
 import path from 'node:path';
 import {pathToFileURL} from 'node:url';
 import {afterEach, describe, expect, test, vi} from 'vitest';
+import type {AnimationProps} from '@luma.gl/engine';
+import {GPUSplatGraphRenderer, SplatRenderer} from '@luma.gl/splats';
+import {NullDevice} from '@luma.gl/test-utils';
 import {
+  default as GaussianSplatsAnimationLoopTemplate,
   getGaussianSplatExecutionMode,
   makeGaussianSplatInfoHtml
 } from '../../examples/showcase/gaussian-splats/app';
@@ -36,6 +40,42 @@ describe('published Gaussian splat viewer', () => {
     expect(getGaussianSplatExecutionMode('webgl', '?renderer=graph')).toBe('cpu');
   });
 
+  test('starts captured WebGPU scenes on the graph before the first streamed batch', () => {
+    installViewerWindow();
+    const device = makeViewerWebGPUDevice();
+    const animation = new GaussianSplatsAnimationLoopTemplate({
+      device,
+      width: 640,
+      height: 480
+    } as AnimationProps);
+
+    expect(animation.renderer).toBeInstanceOf(GPUSplatGraphRenderer);
+    expect(animation.renderer).not.toBeInstanceOf(SplatRenderer);
+    expect(animation.renderer.batches).toHaveLength(0);
+    if (animation.renderer instanceof GPUSplatGraphRenderer) {
+      expect(animation.renderer.compiledGraph).toBeUndefined();
+    }
+
+    animation.renderer.destroy();
+    device.destroy();
+  });
+
+  test('retains the explicit CPU comparison for captured WebGPU scenes', () => {
+    installViewerWindow('?renderer=cpu');
+    const device = makeViewerWebGPUDevice();
+    const animation = new GaussianSplatsAnimationLoopTemplate({
+      device,
+      width: 640,
+      height: 480
+    } as AnimationProps);
+
+    expect(animation.renderer).toBeInstanceOf(SplatRenderer);
+    expect(animation.renderer).not.toBeInstanceOf(GPUSplatGraphRenderer);
+
+    animation.renderer.destroy();
+    device.destroy();
+  });
+
   test('exposes the execution selector and graph diagnostics in the shared viewer panel', () => {
     const viewerPanel = makeGaussianSplatInfoHtml();
     const viewerSource = readFileSync(
@@ -51,8 +91,13 @@ describe('published Gaussian splat viewer', () => {
     expect(viewerPanel).toContain('data-gaussian-splats-execution');
     expect(viewerPanel).toContain('data-gaussian-splats-graph-inspector');
     expect(viewerSource).toContain('activeRenderer.encode(device.commandEncoder)');
-    expect(viewerSource).toContain('this.activateGraphRenderer()');
+    expect(viewerSource).toContain(
+      'expectedSplatCount: this.localLoadersConfiguration?.expectedSplatCount'
+    );
+    expect(viewerSource).not.toContain('this.activateGraphRenderer()');
+    expect(viewerSource).not.toContain('CPU preview → GPU graph');
     expect(viewerDocumentation).toContain('GPU command');
+    expect(viewerDocumentation).toContain('first');
     expect(viewerDocumentation).toContain('?renderer=cpu');
     expect(viewerDocumentation).toContain('WebGL2');
   });
@@ -249,6 +294,15 @@ describe('published Gaussian splat viewer', () => {
     expect(getLocalGaussianSplatLoadersConfiguration()).toBeUndefined();
   });
 });
+
+function makeViewerWebGPUDevice(): NullDevice {
+  const device = new NullDevice({});
+  Object.defineProperties(device, {
+    type: {value: 'webgpu'},
+    info: {value: {...device.info, type: 'webgpu', shadingLanguage: 'wgsl'}}
+  });
+  return device;
+}
 
 function installViewerWindow(
   search = '',

--- a/website/content/examples/showcase/gaussian-splat-viewer.mdx
+++ b/website/content/examples/showcase/gaussian-splat-viewer.mdx
@@ -26,9 +26,9 @@ installation. [`@luma.gl/arrow`](/docs/api-reference/arrow) adapts each Apache A
 directly to [`@luma.gl/splats`](/docs/api-reference/splats), preserving batch ownership,
 floating-point HDR radiance, camera-aware transparency, and the WebGL2 fallback.
 
-On WebGPU, completed captures switch from their progressive preview to a compiled **GPU command
-graph**. Projection, visibility, depth ordering, and rendering remain GPU work rather than
-reprojecting hundreds of thousands of source rows on the main thread for every camera movement.
+On WebGPU, every streamed batch renders through a compiled **GPU command graph** as soon as it
+arrives. Projection, visibility, depth ordering, and rendering remain GPU work from the first
+visible splats rather than reprojecting source rows on the main thread while the scene loads.
 Expand **GPU graph inspector** to see the real graph nodes, encoding timings, and transient-memory
 reuse. Choose **CPU depth ordering** in the execution selector, or append `?renderer=cpu`, to
 compare against the original renderer. WebGL2 always retains its compatible CPU-ordered fallback.


### PR DESCRIPTION
## Goals

Make progressive, batch-preserving streaming a first-class WebGPU Gaussian-splat rendering path instead of falling back to CPU rendering until a capture finishes downloading.

## Changes

- Add optional `expectedSplatCount` and `expectedBatchCount` reservation hints to `GPUSplatGraphRenderer`.
- Compile one reusable GPU command graph with independently rebound source-batch slots, per-batch uniforms, sentinel-initialized inactive rows, global GPU radix sorting, and one GPU-driven indirect draw.
- Render the first streamed Arrow batch immediately and reuse the same compiled graph for subsequent batches within its reserved capacity; unknown or underestimated streams grow geometrically.
- Preserve the original caller-owned Arrow/GPU buffers, individual batch boundaries, mixed packed/HDR colors, GPU visibility, and idle-frame skipping.
- Start the public Gaussian-splat viewer on its GPU graph immediately while keeping explicit CPU comparison mode and the WebGL fallback.
- Add comprehensive package and published API-reference architecture guides covering the persistent graph topology, source-slot rebinding and placeholders, initialization/sentinel sorting, projection, GPU indirect visibility, growth, lifetimes, diagnostics, memory budgets, ordering precision, and adapter limits.
- Cover stable graph identity, padded sorting, visibility, HDR, geometric growth, borrowed ownership, and delayed multi-batch rendering.

## Verification

- `yarn build`: all packages compile successfully, including strict cross-package TypeScript declarations.
- Four independent progressive browser regressions pass both on hardware WebGPU and CI-equivalent SwiftShader; they verify GPU indirect counts, global sorted indices, sentinel padding, exact compiled-graph reuse, mixed HDR, and geometric/underestimated-hint growth.
- Existing graph-renderer browser coverage also verifies three actual source-batch appends without replacing the compiled graph.
- The complete Node suite passes: 567 tests across 116 files, with one pre-existing skipped test.
- The complete CI-equivalent SwiftShader/browser suite passes: 1,562 tests across 290 files, with 25 pre-existing skipped tests.
- All 46 example workspaces pass TypeScript checking.
- An actual browser holds the second HTTP source response: the first 1,000 splats render immediately through the 126-node GPU graph, releasing the response updates the same graph to 2,000 splats, and CPU override, WebGL fallback, and unknown-size adaptive streaming all pass.
- The production ANARI and Docusaurus website builds pass, including generated LLM-output validation.
- `yarn lint fix` and `git diff --cached --check` both pass without modifying any files.

## Tradeoffs

- Known scene dimensions reserve their complete derived GPU working capacity up front, and radix sorting currently processes that reserved capacity even while only a prefix has arrived.
- Streams without reliable dimensions reserve geometrically and rebuild only when their row or batch-slot capacity is exceeded.
- Original source batches are never merged, copied into new source allocations, or destroyed by the renderer.
