### PR TITLE
docs: add comprehensive framework capabilities overview

### DIFF
--- a/docs/README.mdx
+++ b/docs/README.mdx
@@ -30,11 +30,23 @@ right here in your browser.
     <span>Explore living worlds, physical simulations, visual effects, and GPU-powered data directly in your browser.</span>
     <span className="docs-api-card__meta">No installation required</span>
   </a>
+  <a className="docs-api-card" href="/docs/capabilities">
+    <span className="docs-api-card__kind">Framework capabilities</span>
+    <strong>Explore the complete feature set</strong>
+    <span>See how portable rendering, physical simulation, GPU compute, immersive scenes, and streaming data fit together.</span>
+    <span className="docs-api-card__meta">Packages, techniques, and maturity</span>
+  </a>
   <a className="docs-api-card" href="/docs/tutorials">
     <span className="docs-api-card__kind">Learn</span>
     <strong>Follow the fundamentals</strong>
     <span>Build from a triangle to textured geometry, instancing, reusable shaders, and GPU transforms.</span>
     <span className="docs-api-card__meta">Live, backend-switchable examples</span>
+  </a>
+  <a className="docs-api-card" href="/examples">
+    <span className="docs-api-card__kind">See it in action</span>
+    <strong>Explore live GPU examples</strong>
+    <span>Launch interactive scenes for lighting, oceans, fire, Gaussian splats, effects, and data visualization.</span>
+    <span className="docs-api-card__meta">Interactive examples in your browser</span>
   </a>
   <a className="docs-api-card" href="/docs/api-guide">
     <span className="docs-api-card__kind">Design and concepts</span>
@@ -73,7 +85,7 @@ device adapters, and your first rendered frame.
 | --- | --- |
 | **luma.gl** | You are building a renderer, GPU compute workflow, visualization framework, or custom GPU feature and want explicit resource control. |
 | [deck.gl](https://deck.gl) | You need high-level geospatial or large-data visualization layers, picking, cameras, and interaction. |
-| Three.js or Babylon.js | You need a general-purpose scene engine with a large asset and material ecosystem. |
+| **A complete scene engine** | You need a batteries-included scene engine with an extensive asset and material ecosystem. |
 | Raw WebGPU | You need exact control over one backend and do not need luma.gl's portability, lifecycle, or shader tooling. |
 
 ## Three cooperating APIs

--- a/docs/api-guide/engine/anari-rendering.md
+++ b/docs/api-guide/engine/anari-rendering.md
@@ -1004,7 +1004,9 @@ The current package is a focused proof of concept, not a complete ANARI implemen
 - The `deferred` renderer is WebGPU-only and does not yet include clustered lighting, screen-space effects, bloom, or temporal velocity history.
 - Visibility, picking, volumes, clipping planes, shadows, and asynchronous frame mapping are not implemented.
 - Experimental OpenUSD import does not support binary USDC crates or complete USD composition semantics.
-- Experimental glTF import supports common PBR textures and selected material extensions, but not skinning or animations.
+- Experimental glTF import supports common PBR textures, selected material extensions, and
+  transform, material, and texture-coordinate animation; skeletal animation, morph targets, and
+  animated export are not yet supported.
 - WebGL 2 preserves the same scene API but does not support the WebGPU HDR presentation path.
 - The ANARI device releases its renderer resources but does not destroy the underlying shared luma.gl graphics device.
 

--- a/docs/capabilities.mdx
+++ b/docs/capabilities.mdx
@@ -1,0 +1,329 @@
+---
+title: Framework Capabilities
+description: Explore luma.gl's portable GPU architecture, real-time rendering, shader effects, GPU-native data, simulation, immersive experiences, and experimental modules.
+---
+
+# Everything your GPU can do.
+
+Build cinematic worlds, responsive simulations, immersive experiences, and massive data
+visualizations with one composable GPU framework. luma.gl connects portable rendering,
+expressive shader programming, advanced image effects, and GPU-native computation without
+forcing every application into the same abstraction.
+
+Start with a scene. Drop down to an individual render pass. Keep millions of records on the
+GPU. Compose the pieces your application needs and retain control over how they work together.
+
+**WebGPU and WebGL2. Rendering and compute. Graphics and data. One TypeScript-first toolkit.**
+
+## The framework, module by module
+
+<div className="docs-api-card-grid">
+  <a className="docs-api-card" href="/docs/api-reference/core">
+    <span className="docs-api-card__kind">Portable GPU foundation</span>
+    <strong>Core, WebGPU, and WebGL</strong>
+    <span>One application-facing device API for buffers, textures, pipelines, commands, and explicit GPU resource ownership.</span>
+    <span className="docs-api-card__meta">@luma.gl/core · @luma.gl/webgpu · @luma.gl/webgl</span>
+  </a>
+  <a className="docs-api-card" href="/docs/api-reference/engine">
+    <span className="docs-api-card__kind">Rendering engine</span>
+    <strong>Models, geometry, and animation</strong>
+    <span>Build with the classic luma.gl API: models, render loops, GPU geometry, instancing, and reusable animation mixing.</span>
+    <span className="docs-api-card__meta">@luma.gl/engine</span>
+  </a>
+  <a className="docs-api-card" href="/docs/api-reference/shadertools">
+    <span className="docs-api-card__kind">Shader programming</span>
+    <strong>Reusable shaders and modules</strong>
+    <span>Compose WGSL and GLSL with typed shader modules, injection hooks, shared uniforms, lighting, and precision utilities.</span>
+    <span className="docs-api-card__meta">@luma.gl/shadertools</span>
+  </a>
+  <a className="docs-api-card" href="/docs/api-guide/shaders/shader-passes">
+    <span className="docs-api-card__kind">Visual effects</span>
+    <strong>Composable image processing</strong>
+    <span>Chain bloom, ambient occlusion, reflections, indirect light, volumetrics, motion blur, and temporal antialiasing.</span>
+    <span className="docs-api-card__meta">@luma.gl/effects</span>
+  </a>
+  <a className="docs-api-card" href="/docs/api-reference/anari">
+    <span className="docs-api-card__kind">Experimental retained scenes</span>
+    <strong>Declarative 3D and scene import</strong>
+    <span>Describe cameras, geometry, lights, and renderers; explore glTF and experimental OpenUSD import in the ANARI Playground.</span>
+    <span className="docs-api-card__meta">@luma.gl/anari · experimental / private</span>
+  </a>
+  <a className="docs-api-card" href="/docs/api-reference/gltf">
+    <span className="docs-api-card__kind">Assets and materials</span>
+    <strong>glTF scenes and physically based shading</strong>
+    <span>Bring in portable 3D assets, PBR material extensions, compressed geometry and textures, and supported animation clips.</span>
+    <span className="docs-api-card__meta">@luma.gl/gltf</span>
+  </a>
+  <a className="docs-api-card" href="/docs/api-reference/splats">
+    <span className="docs-api-card__kind">Experimental neural rendering</span>
+    <strong>Streaming Gaussian splats</strong>
+    <span>Render captured scenes with anisotropic splats, GPU depth ordering, progressive batches, HDR color, and portable fallback.</span>
+    <span className="docs-api-card__meta">@luma.gl/splats · experimental / private</span>
+  </a>
+  <a className="docs-api-card" href="/docs/api-guide/gpu/gpu-data-processing">
+    <span className="docs-api-card__kind">GPU-native computation</span>
+    <strong>Compute, tables, and Arrow</strong>
+    <span>Connect GPU-resident columns, reusable operations, command graphs, filtering, aggregation, and zero-copy-aware data flows.</span>
+    <span className="docs-api-card__meta">@luma.gl/gpgpu · @luma.gl/tables</span>
+    <span className="docs-api-card__meta">@luma.gl/arrow · experimental / private</span>
+  </a>
+</div>
+
+The published GPU, engine, shader, effects, glTF, and data foundations can be combined
+independently. Some newer modules remain **experimental and private**: they are available in
+the repository but are not yet published as standalone npm packages.
+
+## What you can build today
+
+### One application-facing GPU API
+
+The [portable GPU API](/docs/api-reference/core) provides a common vocabulary across WebGPU and
+WebGL2 while preserving meaningful control over the hardware:
+
+- Select and initialize a GPU device, inspect supported features, and choose the appropriate
+  backend for your application.
+- Allocate buffers, textures, samplers, framebuffers, bindings, and render or compute pipelines.
+- Encode render passes and, on WebGPU, compute passes with explicit resource ownership and
+  submission boundaries.
+- Share shader inputs, uniform blocks, vertex layouts, texture views, and typed GPU data between
+  higher-level systems.
+- Present to canvases with backend-aware configuration, high-DPI sizing, and supported extended
+  color or HDR output.
+
+**Portability does not mean every backend has identical capabilities.** Compute shaders, storage
+textures, indirect GPU workflows, native WebGPU immersive layers, and selected presentation modes
+require compatible WebGPU hardware and browser support. Portable rendering and many effects also
+run on WebGL2.
+
+### Real-time rendering and image quality
+
+The [engine](/docs/api-reference/engine), [glTF module](/docs/api-reference/gltf), and
+[experimental rendering systems](/docs/api-reference/experimental) support a broad range of
+real-time techniques:
+
+- Forward and deferred rendering, instanced geometry, indirect draws, and GPU-driven visibility.
+- Physically based metallic-roughness materials, image-based lighting, normal maps, emissive
+  surfaces, and selected specular, clearcoat, sheen, iridescence, anisotropy, and transmission
+  extensions.
+- Directional, point, and spot lighting, including compute-clustered lighting for dense scenes.
+- Directional, spot, point, cascaded, soft, and contact shadows where the selected renderer
+  supports them.
+- High-dynamic-range scene buffers, adaptive exposure, tone mapping, wide-gamut presentation,
+  and floating-point bloom on supported devices.
+- Exact and weighted-blended order-independent transparency for overlapping transparent surfaces.
+- Optical glass, reflections, refraction, dispersion-inspired shading, and compute-generated
+  spectral caustics.
+- Hierarchical GPU geometry selection, frustum culling, stable compaction, and indirect draw
+  generation without per-frame CPU inspection.
+
+Explore these capabilities in [Lightstorm Megacity](/examples/showcase/lightstorm-megacity),
+[Illumination Lab](/examples/experimental/deferred-rendering),
+[Prism Cathedral](/examples/experimental/spectral-caustics), and
+[Virtual Geometry Canyon](/examples/experimental/virtual-geometry-canyon).
+
+### Shaders that work together
+
+[Shader tools](/docs/api-reference/shadertools) turn shader code into reusable application
+building blocks:
+
+- Author WebGPU shaders in WGSL and WebGL shaders in GLSL.
+- Assemble programs from composable shader modules, application hooks, and reusable shader
+  injections.
+- Share lighting, picking, materials, geometry deformation, color management, and precision
+  helpers across renderers.
+- Describe uniform layouts and bindings in a way that integrates with the core GPU and engine
+  APIs.
+- Apply high-precision visualization techniques when world coordinates or geospatial transforms
+  would otherwise lose detail.
+
+The goal is not to hide shaders. It is to make sophisticated shader programs easier to maintain,
+compose, and reuse.
+
+### Effects that compose into complete pipelines
+
+[Shader passes and effect pipelines](/docs/api-guide/shaders/shader-passes) consume rendered
+scene color and, when needed, depth, normals, velocity, or intermediate render targets:
+
+- Bloom, exposure control, color adjustment, blur, vignettes, and image-processing passes.
+- Screen-space ambient occlusion and higher-quality ground-truth ambient occlusion.
+- Screen-space global illumination and reflections with temporal stabilization.
+- Volumetric fog, participating media, clustered light scattering, and camera-depth god rays.
+- Temporal antialiasing, motion blur, outlines, and reusable multipass effect chains.
+- Explicit named targets and history resources so multiple effects can share a coherent frame.
+
+Try interactive combinations in [Effects: Image Processing](/examples/showcase/postprocessing)
+and [Visualization City](/examples/experimental/advanced-effects).
+
+### Data that stays on the GPU
+
+[GPU tables](/docs/api-reference/tables), [GPU operations](/docs/api-reference/gpgpu),
+[Apache Arrow adapters](/docs/api-reference/arrow), and
+[experimental GPU primitives](/docs/api-reference/experimental/gpu-primitives) connect
+computation directly to rendering:
+
+- Model GPU-resident columns and batches with `GPUData`, `GPUVector`, `GPURecordBatch`, and
+  `GPUTable`.
+- Upload Arrow-compatible data while preserving ownership, source chunk boundaries, and streamed
+  batches.
+- Compose command graphs that sequence compute passes, reuse transient resources, and generate
+  draw commands.
+- Filter, scan, compact, sort, reduce, bin, and aggregate large datasets without pulling every
+  source row back to the CPU.
+- Build histograms, spatial grids, bounding-volume hierarchies, hash indices, joins, and
+  two-dimensional fast Fourier transforms.
+- Drive linked crossfilter views, geospatial projection, spatial queries, hierarchical traces,
+  and visible-row rendering from GPU-resident data.
+
+Applications can still read back concise summaries or interaction results when needed; the point
+is to avoid unnecessary full-dataset round trips.
+
+See [Million-Row Crossfilter](/examples/showcase/million-row-crossfilter),
+[Billion-Point Spatial Atlas](/examples/showcase/billion-point-spatial-atlas),
+[GPU data analysis](/examples/experimental/gpu-data-analysis), and
+[GPU sorting](/examples/experimental/gpu-sort). Large source datasets are streamed within a
+bounded GPU-residency budget rather than assumed to fit entirely in GPU memory.
+
+### glTF, PBR, and standards-driven animation
+
+The [glTF integration](/docs/api-reference/gltf) reuses shared rendering and animation systems
+instead of creating separate asset-specific engines:
+
+- Load glTF and GLB scenes, including supported Draco and Meshopt compression, quantized
+  geometry, and Basis Universal/KTX2 textures through the asset-loading pipeline.
+- Render metallic-roughness materials with supported normal, occlusion, emissive, and
+  image-based-lighting inputs.
+- Interpret selected material extensions for specular response, index of refraction, clearcoat,
+  sheen, iridescence, anisotropy, and emissive intensity; initial transmission and volume effects
+  remain approximations rather than full scene-color refraction.
+- Represent supported authored tangents, vertex colors, UV transforms, and punctual lights;
+  end-to-end behavior varies by renderer and feature.
+- Play, blend, crossfade, pause, scrub, and loop animation clips using shared engine tracks and
+  step, linear, or cubic-spline interpolation.
+- Animate supported node transforms, material factors, and texture transforms through initial
+  `KHR_animation_pointer` integration.
+- Reuse existing joint-driven skinning in supported rendering paths while newer retained-scene
+  integration continues to mature.
+
+The ownership boundaries are intentional: `@luma.gl/gltf` interprets assets,
+`@luma.gl/shadertools` owns shared shading, `@luma.gl/engine` owns generic animation,
+`@luma.gl/experimental` explores higher-level rendering, and `@luma.gl/anari` orchestrates
+retained scene objects. A capability implemented in one layer should be reused rather than
+recreated in another.
+
+The [glTF extension support matrix](/docs/api-reference/gltf/gltf-extensions) distinguishes
+complete support, in-progress rendering paths, application-managed features, and unsupported
+extensions.
+
+### Declarative scenes and portable assets
+
+The experimental [ANARI-inspired scene API](/docs/api-reference/anari) adds a retained,
+declarative layer for applications that want scene objects rather than individual draw calls:
+
+- Describe cameras, lights, materials, surfaces, groups, instances, and worlds.
+- Switch between forward, deferred, normals, and depth-oriented renderer configurations.
+- Edit JSON scene descriptions and, in the ANARI Playground, import supported glTF and
+  experimental OpenUSD content.
+- Play supported transform, material, and texture-coordinate animation clips using the shared
+  engine animation system, including clip selection and interactive playback controls.
+- Reuse geometry and materials across many retained instances.
+- Select WebGPU or WebGL2 when the chosen renderer and device support the requested features.
+
+This API is **ANARI-inspired**, experimental, and not a claim of full standards conformance.
+OpenUSD and glTF coverage is intentionally scoped; consult the
+[glTF extension support matrix](/docs/api-reference/gltf/gltf-extensions) for precise asset
+capabilities.
+
+Explore the [ANARI Playground](/examples/experimental/anari-playground).
+
+### Simulation with visible results
+
+GPU simulation modules can share the same resources and command encoding model as the renderer:
+
+- A **three-dimensional fire** and smoke solver evolves velocity, pressure, fuel, temperature,
+  combustion, and obstacle interaction in a volumetric field.
+- Spectral ocean simulation uses GPU fast Fourier transforms to create animated waves,
+  displacement-derived normals, and compression-driven whitecaps.
+- A **two-dimensional MLS-MPM** liquid simulation supports particle/grid transfers, responsive
+  splashes, and interactive boundaries.
+- Spectral photon tracing creates wavelength-separated caustics beneath a refractive object.
+- GPU particles and procedural motion can feed directly into scene rendering without redundant
+  CPU copies.
+
+Try [Volumetric Fire Forge](/examples/experimental/volumetric-fire-forge),
+[Tempest Ocean](/examples/showcase/tempest-ocean), and
+[Fluid Foundry](/examples/experimental/fluid-foundry).
+
+### Captured worlds and Gaussian splats
+
+The experimental [Gaussian splat renderer](/docs/api-reference/splats) turns captured scenes
+into interactive renderable data:
+
+- Stream anisotropic splats in independently owned batches.
+- Preserve Arrow-oriented data layouts and explicit GPU ownership.
+- Project, cull, sort, and issue indirect rendering commands through reusable GPU workflows.
+- Preserve high-dynamic-range spherical-harmonic DC color on supported WebGPU targets.
+- Offer portable rendering paths and standard-dynamic-range fallback where appropriate.
+
+View a complete captured scene in the
+[Gaussian Splat Viewer](/examples/showcase/gaussian-splat-viewer). Higher-order,
+view-dependent spherical harmonics and dedicated GPU picking are still areas of active work.
+
+### Immersive AR and VR
+
+Experimental [WebXR integration](/docs/api-reference/experimental/webxr) connects immersive
+sessions to luma.gl rendering:
+
+- Drive rendering from WebXR animation frames and reference spaces.
+- Render immersive **AR and VR** views with per-eye transforms, viewports, and framebuffers.
+- Use WebGPU projection layers when the browser, device, and XR-compatible adapter support
+  them.
+- Preserve a WebGL2 immersive path and WebGL raw-camera access where available.
+
+Browser support and hardware support vary. Advanced spatial features such as hit testing,
+anchors, depth sensing, hand tracking, and WebGPU camera textures are not yet part of the
+experimental API.
+
+## Know what is stable—and what is still evolving
+
+| Capability area | Availability |
+| --- | --- |
+| Portable GPU devices, WebGPU/WebGL2 adapters, models, shader assembly, and effects | Published framework modules. Specific features depend on backend and device support. |
+| glTF loading, selected PBR extensions, animation foundations, GPU operations, and GPU tables | Published modules with documented, feature-specific support boundaries. |
+| Apache Arrow integration, ANARI-inspired scenes, Gaussian splats, GPU command graphs, advanced scene techniques, and WebXR | Experimental capabilities available in the repository. Several packages are private and not yet published independently. |
+| Full three-dimensional liquids, deformable physics, general scientific volume rendering, advanced asset virtualization, visual shader graphs, and path tracing | Areas for future development, not capabilities to assume in the current release. |
+
+The [`@luma.gl/experimental`](/docs/api-reference/experimental), `@luma.gl/anari`,
+`@luma.gl/splats`, and `@luma.gl/arrow` packages evolve independently of the published foundation.
+Their APIs, packaging, and browser requirements may change. No hardware ray-tracing API is
+required or implied.
+
+## Where the framework is growing
+
+luma.gl already spans portable graphics, GPU-native data, visual effects, physical simulation,
+and immersive rendering. Important opportunities remain:
+
+- **Full three-dimensional liquids** with free surfaces, richer collision behavior, and volumetric
+  fluid interaction.
+- **Cloth and soft-body simulation**, including ropes, flexible materials, and other deformable
+  systems.
+- **General scientific volume rendering** with measured three-dimensional fields, transfer
+  functions, clipping, and extracted isosurfaces.
+- **Production character deformation**, including robust skeletal animation, morph targets, and
+  richer animation retargeting; existing skinning and clip-mixing foundations should be shared
+  across the newer rendering paths rather than replaced.
+- **Complete asset fidelity**, including richer sampler and color handling, broader glTF material
+  and animation-pointer coverage, imported instancing, visibility, physically richer
+  transmission, and more faithful import/export round trips.
+- **Asset-backed virtual geometry** with imported mesh clusters, occlusion-driven selection, and
+  streamed residency; existing virtual geometry showcases currently use procedural geometry.
+- **Progressive path tracing** and other forms of off-screen light transport built on portable
+  GPU compute.
+- **Visual shader authoring** with live material graphs and reusable shader-module composition.
+- **More integrated scene rendering**, bringing advanced effects, shadows, simulation, splats,
+  and retained scenes together behind reusable application-level interfaces.
+
+These are development directions, not promises about release dates or browser availability.
+
+Ready to explore? [Open the interactive examples](/examples),
+[follow the fundamentals](/docs/tutorials), or
+[choose the API layer that fits your application](/docs/api-guide).

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -307,6 +307,15 @@ export function OnboardingPoster({image, alt, className, loading = 'lazy'}) {
         </p>
       </article>
     </div>
+
+    <div className="luma-onboarding__actions">
+      <Link
+        className="luma-onboarding__action luma-onboarding__action--secondary"
+        to="/docs/capabilities"
+      >
+        <span>Explore the complete feature set</span> <span aria-hidden="true">→</span>
+      </Link>
+    </div>
   </section>
 
   <section className="luma-onboarding__section" aria-labelledby="luma-onboarding-paths">

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -1,6 +1,7 @@
 [
   "README",
   "getting-started",
+  "capabilities",
   {
     "type": "category",
     "label": "Fundamentals",

--- a/test/examples/framework-capabilities.node.spec.ts
+++ b/test/examples/framework-capabilities.node.spec.ts
@@ -1,0 +1,224 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {existsSync, readFileSync} from 'node:fs';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+const DOCUMENTATION_DIRECTORY = path.join(process.cwd(), 'docs');
+const CAPABILITIES_SOURCE_PATH = path.join(DOCUMENTATION_DIRECTORY, 'capabilities.mdx');
+const EXAMPLE_CONTENT_DIRECTORY = path.join(process.cwd(), 'website/content/examples');
+const FRAMEWORK_PACKAGE_NAMES = [
+  '@luma.gl/core',
+  '@luma.gl/webgpu',
+  '@luma.gl/webgl',
+  '@luma.gl/engine',
+  '@luma.gl/shadertools',
+  '@luma.gl/effects',
+  '@luma.gl/anari',
+  '@luma.gl/gltf',
+  '@luma.gl/splats',
+  '@luma.gl/gpgpu',
+  '@luma.gl/tables',
+  '@luma.gl/arrow',
+  '@luma.gl/experimental'
+] as const;
+
+describe('framework capabilities documentation', () => {
+  test('introduces an official, noncomparative capabilities page', () => {
+    expect(existsSync(CAPABILITIES_SOURCE_PATH)).toBe(true);
+
+    const capabilitiesSource = readCapabilitiesSource();
+
+    expect(capabilitiesSource).toMatch(/^---\s*\n[\s\S]*?^---\s*$/m);
+    expect(capabilitiesSource).toMatch(/^title:\s*(?:Framework\s+)?Capabilities\s*$/im);
+    expect(capabilitiesSource).toMatch(/^description:\s*.+$/m);
+    expect(capabilitiesSource).toMatch(/^#\s+.+$/m);
+    expect(capabilitiesSource).not.toMatch(/\b(?:three\.js|threejs|babylon(?:\.js)?)\b/i);
+  });
+
+  test('presents every major framework layer and its actual package boundary', () => {
+    const capabilitiesSource = readCapabilitiesSource();
+
+    for (const packageName of FRAMEWORK_PACKAGE_NAMES) {
+      expect(capabilitiesSource, `${packageName} must remain discoverable`).toContain(packageName);
+    }
+
+    expect(capabilitiesSource).toMatch(/WebGPU/);
+    expect(capabilitiesSource).toMatch(/WebGL\s*2|WebGL2/);
+    expect(capabilitiesSource).toMatch(/compute\s+shader/i);
+    expect(capabilitiesSource).toMatch(/shader\s+module/i);
+    expect(capabilitiesSource).toMatch(/\bANARI\b/i);
+    expect(capabilitiesSource).toMatch(/Gaussian\s+splat/i);
+    expect(capabilitiesSource).toMatch(/Apache\s+Arrow/i);
+    expect(capabilitiesSource).toMatch(/command[\s-]+graph/i);
+    expect(capabilitiesSource).toMatch(/\bglTF\b/);
+  });
+
+  test('accurately scopes shared glTF, material, animation, and ANARI capabilities', () => {
+    const capabilitiesSource = readCapabilitiesSource();
+    const anariGuide = readFileSync(
+      path.join(DOCUMENTATION_DIRECTORY, 'api-guide/engine/anari-rendering.md'),
+      'utf8'
+    );
+    const ownershipDescription = capabilitiesSource.match(/ownership\s+boundaries[\s\S]*?\n\n/i);
+
+    expect(ownershipDescription).not.toBeNull();
+    for (const packageName of ['gltf', 'shadertools', 'engine', 'experimental', 'anari']) {
+      expect(ownershipDescription![0]).toContain(`@luma.gl/${packageName}`);
+    }
+
+    for (const capability of [
+      /joint[\s-]+(?:driven[\s-]+)?skinning/i,
+      /cross[\s-]*fade/i,
+      /interpolation/i,
+      /KHR_animation_pointer/,
+      /\bDraco\b/i,
+      /\bMeshopt\b/i,
+      /\bBasis(?:\s+Universal)?\b/i,
+      /clearcoat/i,
+      /sheen/i,
+      /iridescen(?:ce|t)/i,
+      /anisotrop(?:y|ic)/i,
+      /transmission[\s\S]{0,100}approximat(?:ion|ions|e)/i,
+      /@luma\.gl\/arrow[\s\S]{0,80}private/i
+    ]) {
+      expect(capabilitiesSource, `The shared asset overview must explain ${capability}`).toMatch(
+        capability
+      );
+    }
+
+    expect(anariGuide).not.toMatch(/\bnot\s+skinning\s+or\s+animations\b/i);
+    expect(anariGuide).toMatch(/transform[\s\S]{0,80}texture[\s-]+coordinate\s+animation/i);
+    expect(anariGuide).toMatch(
+      /skeletal\s+animation[\s\S]{0,100}morph\s+targets[\s\S]{0,100}not\s+yet\s+supported/i
+    );
+  });
+
+  test('describes rendering, simulation, visualization, compute, and immersive capabilities', () => {
+    const capabilitiesSource = readCapabilitiesSource();
+
+    for (const capability of [
+      /physically\s+based|\bPBR\b/i,
+      /\bHDR\b|high[\s-]+dynamic[\s-]+range/i,
+      /deferred|clustered/i,
+      /shadow/i,
+      /reflection/i,
+      /post[\s-]*processing|visual\s+effects/i,
+      /ocean/i,
+      /caustic/i,
+      /fluid|liquid/i,
+      /fire/i,
+      /(?:GPU|graphics)[\s-]+(?:table|data)/i,
+      /sort|filter|histogram/i,
+      /\bWebXR\b/i,
+      /\bVR\b/i,
+      /\bAR\b/i
+    ]) {
+      expect(
+        capabilitiesSource,
+        `${capability} must have an accurate capability description`
+      ).toMatch(capability);
+    }
+  });
+
+  test('links capability claims to real interactive examples', () => {
+    const capabilitiesSource = readCapabilitiesSource();
+    const exampleIdentifiers = new Set(
+      Array.from(
+        capabilitiesSource.matchAll(/\/examples\/((?:showcase|experimental|deck|v10)\/[\w-]+)/g),
+        match => match[1]
+      )
+    );
+
+    expect(exampleIdentifiers.size).toBeGreaterThanOrEqual(6);
+
+    for (const exampleIdentifier of exampleIdentifiers) {
+      expect(
+        existsSync(path.join(EXAMPLE_CONTENT_DIRECTORY, `${exampleIdentifier}.mdx`)),
+        `${exampleIdentifier} must resolve to a real live example`
+      ).toBe(true);
+    }
+  });
+
+  test('distinguishes shipped capabilities, experimental packages, and actual simulation dimensionality', () => {
+    const capabilitiesSource = readCapabilitiesSource();
+
+    expect(capabilitiesSource).toMatch(/\bexperimental\b/i);
+    expect(capabilitiesSource).toMatch(/not\s+(?:yet\s+)?published|private\s+package/i);
+    expect(capabilitiesSource).toMatch(
+      /(?:two[\s-]+dimensional|2D)[\s\S]{0,120}(?:MLS[\s-]*MPM|fluid|liquid)|(?:MLS[\s-]*MPM|fluid|liquid)[\s\S]{0,120}(?:two[\s-]+dimensional|2D)/i
+    );
+    expect(capabilitiesSource).toMatch(
+      /(?:three[\s-]+dimensional|3D)[\s\S]{0,120}fire|fire[\s\S]{0,120}(?:three[\s-]+dimensional|3D)/i
+    );
+    expect(capabilitiesSource).toMatch(
+      /WebGPU[\s\S]{0,120}(?:only|requir(?:e|ed|es))|requir(?:e|ed|es)\s+(?:compatible\s+)?WebGPU/i
+    );
+  });
+
+  test('acknowledges meaningful gaps without presenting future work as existing functionality', () => {
+    const capabilitiesSource = readCapabilitiesSource();
+
+    expect(capabilitiesSource).toMatch(/scientific\s+volume/i);
+    expect(capabilitiesSource).toMatch(
+      /(?:three[\s-]+dimensional|3D)[\s\S]{0,50}(?:liquid|fluid)|(?:liquid|fluid)[\s\S]{0,50}(?:three[\s-]+dimensional|3D)/i
+    );
+    expect(capabilitiesSource).toMatch(/cloth|soft[\s-]+body/i);
+    expect(capabilitiesSource).toMatch(/path[\s-]+trac(?:e|ing)|ray[\s-]+trac(?:e|ing)/i);
+  });
+
+  test('connects the capabilities page to introductory documentation and the primary sidebar', () => {
+    const documentationTableOfContents = JSON.parse(
+      readFileSync(path.join(DOCUMENTATION_DIRECTORY, 'table-of-contents.json'), 'utf8')
+    ) as Array<string | {label?: string}>;
+    const gettingStartedIndex = documentationTableOfContents.indexOf('getting-started');
+    const documentationOverview = readFileSync(
+      path.join(DOCUMENTATION_DIRECTORY, 'README.mdx'),
+      'utf8'
+    );
+    const gettingStartedSource = readFileSync(
+      path.join(DOCUMENTATION_DIRECTORY, 'getting-started.mdx'),
+      'utf8'
+    );
+
+    expect(gettingStartedIndex).toBeGreaterThanOrEqual(0);
+    expect(documentationTableOfContents[gettingStartedIndex + 1]).toBe('capabilities');
+    expect(documentationOverview).toContain('/docs/capabilities');
+    expect(gettingStartedSource).toContain('/docs/capabilities');
+  });
+
+  test('keeps the framework overview discoverable in generated AI-readable documentation', () => {
+    const websiteConfiguration = readFileSync(
+      path.join(process.cwd(), 'website/docusaurus.config.js'),
+      'utf8'
+    );
+    const extractionChecker = readFileSync(
+      path.join(process.cwd(), 'website/scripts/check-llm-output.mjs'),
+      'utf8'
+    );
+    const includeOrder = websiteConfiguration.match(/includeOrder:\s*\[([\s\S]*?)\]/);
+    const requiredIndexLinks = extractionChecker.match(
+      /const\s+requiredIndexLinks\s*=\s*\[([\s\S]*?)\]/
+    );
+
+    expect(includeOrder).not.toBeNull();
+    expect(requiredIndexLinks).not.toBeNull();
+
+    const includedRoutes = Array.from(
+      includeOrder![1].matchAll(/['"]([^'"]+)['"]/g),
+      match => match[1]
+    );
+    const gettingStartedIndex = includedRoutes.indexOf('/docs/getting-started');
+
+    expect(gettingStartedIndex).toBeGreaterThanOrEqual(0);
+    expect(includedRoutes[gettingStartedIndex + 1]).toBe('/docs/capabilities');
+    expect(requiredIndexLinks![1]).toMatch(/['"]docs\/capabilities\.md['"]/);
+    expect(extractionChecker).toMatch(/requireFile\(\s*['"]docs\/capabilities\.md['"]\s*\)/);
+  });
+});
+
+function readCapabilitiesSource(): string {
+  return readFileSync(CAPABILITIES_SOURCE_PATH, 'utf8');
+}

--- a/test/examples/getting-started-onboarding.node.spec.ts
+++ b/test/examples/getting-started-onboarding.node.spec.ts
@@ -225,6 +225,23 @@ describe('getting-started onboarding', () => {
     ]);
   });
 
+  test('makes the complete capability overview discoverable from introductory pages', () => {
+    const onboardingSource = readFileSync(ONBOARDING_SOURCE_PATH, 'utf8');
+    const documentationOverview = readFileSync(path.join(process.cwd(), 'docs/README.mdx'), 'utf8');
+    const tableOfContents = JSON.parse(
+      readFileSync(DOCUMENTATION_TABLE_OF_CONTENTS_PATH, 'utf8')
+    ) as Array<string | {label?: string}>;
+
+    expect(tableOfContents.slice(0, 3)).toEqual(['README', 'getting-started', 'capabilities']);
+    expect(documentationOverview).toMatch(
+      /<a\b(?=[^>]*\bclassName="docs-api-card")(?=[^>]*\bhref="\/docs\/capabilities")[^>]*>/
+    );
+    expect(onboardingSource).toMatch(
+      /<Link\b(?=[^>]*\bclassName="luma-onboarding__action luma-onboarding__action--secondary")(?=[^>]*\bto="\/docs\/capabilities")[^>]*>/
+    );
+    expect(documentationOverview).not.toMatch(/\b(?:Three\.js|Babylon\.js)\b/i);
+  });
+
   test('validates runnable LLM setup against Installing while keeping onboarding readable', () => {
     const extractionCheckerSource = readFileSync(EXTRACTION_CHECKER_PATH, 'utf8');
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -157,6 +157,7 @@ module.exports = {
         enableDescriptions: true,
         includeOrder: [
           '/docs/getting-started',
+          '/docs/capabilities',
           '/docs/tutorials/**',
           '/docs/api-guide/**',
           '/docs/api-reference/**',

--- a/website/scripts/check-llm-output.mjs
+++ b/website/scripts/check-llm-output.mjs
@@ -120,6 +120,7 @@ if (llmsTxt.includes('/examples/')) {
 
 const requiredIndexLinks = [
   'docs/getting-started.md',
+  'docs/capabilities.md',
   'docs/tutorials/hello-triangle.md',
   'docs/api-guide.md',
   'docs/api-reference.md',
@@ -136,6 +137,7 @@ const gettingStartedPath = requireFile('docs/getting-started.md');
 const installingPath = requireFile('docs/developer-guide/installing.md');
 const workingWithAiPath = requireFile('docs/developer-guide/working-with-ai.md');
 requireFile('docs.md');
+requireFile('docs/capabilities.md');
 requireFile('docs/api-guide.md');
 requireFile('docs/api-reference.md');
 


### PR DESCRIPTION
## Goals

Give developers an authoritative, noncomparative overview of what luma.gl can do, how its framework modules fit together, and which capabilities are published, experimental, or still evolving.

## Changes

- Add a new top-level **Framework Capabilities** documentation page immediately after Getting Started.
- Present portable WebGPU/WebGL2, the rendering engine, shader tools, composable effects, ANARI, glTF/PBR, Gaussian splats, GPU tables, Arrow, and GPGPU as a coherent modular framework.
- Document advanced rendering, HDR, shadows, screen-space lighting and reflections, GPU-native data operations, immersive AR/VR, 3D fire, spectral oceans, 2D MLS-MPM liquids, and streaming splat workflows.
- Incorporate the ANARI/glTF breakdown: shared animation mixing and crossfades, existing joint skinning, compression and texture formats, PBR extensions, animation pointers, and explicit package ownership boundaries.
- Clearly identify private/experimental packages and current limitations, including approximate transmission, incomplete morph/skeletal integration, scientific volumes, 3D liquids, cloth, streamed meshlets, and progressive path tracing.
- Link the overview from the documentation landing page, Getting Started, and the primary docs sidebar; remove named competing-framework comparisons.
- Include the new page in generated `llms.txt` and validate its extracted Markdown.
- Correct stale ANARI documentation that incorrectly stated imported glTF animations were unsupported.
- Add focused navigation, capability, maturity, asset-animation, and AI-documentation regression coverage.

## Verification

- `yarn lint fix`
- `yarn lint`
- `yarn workspace website-docusaurus check` — 930 MDX files compiled successfully.
- `yarn vitest run --project node test/examples/framework-capabilities.node.spec.ts test/examples/getting-started-onboarding.node.spec.ts test/examples/homepage-navigation.node.spec.ts` — 23 tests passed.
- `yarn test-node` — 685 passed, 1 skipped.
- `yarn website:build` — production site, capabilities page, search index, and `llms.txt` generated and validated successfully.
