### PR TITLE
feat(experimental): add physically based environments and scene transmission

### DIFF
--- a/modules/experimental/src/engine/pbr-environment-shaders.ts
+++ b/modules/experimental/src/engine/pbr-environment-shaders.ts
@@ -1,0 +1,368 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {Texture} from '@luma.gl/core';
+import type {ShaderModule} from '@luma.gl/shadertools';
+
+export type PBREnvironmentFilterUniforms = {
+  face: number;
+  roughness: number;
+  mode: number;
+  sampleCount: number;
+  sourceEncoding: number;
+};
+
+export type PBREnvironmentFilterBindings = {
+  pbrEnvironmentSource: Texture;
+};
+
+export type PBREnvironmentFilterProps = PBREnvironmentFilterUniforms & PBREnvironmentFilterBindings;
+
+const GLSL_UNIFORMS = /* glsl */ `\
+layout(std140) uniform pbrEnvironmentFilterUniforms {
+  int face;
+  float roughness;
+  int mode;
+  int sampleCount;
+  int sourceEncoding;
+} pbrEnvironmentFilter;
+
+uniform sampler2D pbrEnvironmentSource;
+`;
+
+const WGSL_UNIFORMS = /* wgsl */ `\
+struct PBREnvironmentFilterUniforms {
+  face: i32,
+  roughness: f32,
+  mode: i32,
+  sampleCount: i32,
+  sourceEncoding: i32,
+};
+
+@group(0) @binding(auto) var<uniform> pbrEnvironmentFilter: PBREnvironmentFilterUniforms;
+@group(0) @binding(auto) var pbrEnvironmentSource: texture_2d<f32>;
+@group(0) @binding(auto) var pbrEnvironmentSourceSampler: sampler;
+`;
+
+export const pbrEnvironmentFilter = {
+  name: 'pbrEnvironmentFilter',
+  bindingLayout: [
+    {name: 'pbrEnvironmentFilter', group: 0},
+    {name: 'pbrEnvironmentSource', group: 0}
+  ],
+  fs: GLSL_UNIFORMS,
+  source: WGSL_UNIFORMS,
+  getUniforms: (properties: Partial<PBREnvironmentFilterProps>) => properties,
+  uniformTypes: {
+    face: 'i32',
+    roughness: 'f32',
+    mode: 'i32',
+    sampleCount: 'i32',
+    sourceEncoding: 'i32'
+  },
+  defaultUniforms: {
+    face: 0,
+    roughness: 0,
+    mode: 0,
+    sampleCount: 64,
+    sourceEncoding: 0
+  }
+} as const satisfies ShaderModule<
+  PBREnvironmentFilterProps,
+  PBREnvironmentFilterUniforms,
+  PBREnvironmentFilterBindings
+>;
+
+export const PBR_ENVIRONMENT_FRAGMENT_GLSL = /* glsl */ `\
+#version 300 es
+precision highp float;
+precision highp int;
+
+in vec2 uv;
+out vec4 fragmentColor;
+
+const float ENVIRONMENT_PI = 3.141592653589793;
+
+vec2 getEnvironmentHammersley(uint index, uint sampleCount)
+{
+  uint reversedBits = (index << 16u) | (index >> 16u);
+  reversedBits = ((reversedBits & 0x55555555u) << 1u) |
+    ((reversedBits & 0xAAAAAAAAu) >> 1u);
+  reversedBits = ((reversedBits & 0x33333333u) << 2u) |
+    ((reversedBits & 0xCCCCCCCCu) >> 2u);
+  reversedBits = ((reversedBits & 0x0F0F0F0Fu) << 4u) |
+    ((reversedBits & 0xF0F0F0F0u) >> 4u);
+  reversedBits = ((reversedBits & 0x00FF00FFu) << 8u) |
+    ((reversedBits & 0xFF00FF00u) >> 8u);
+  return vec2(
+    float(index) / float(sampleCount),
+    float(reversedBits) * 2.3283064365386963e-10
+  );
+}
+
+vec3 getEnvironmentFaceDirection(int face, vec2 textureCoordinate)
+{
+  vec2 coordinate = textureCoordinate * 2.0 - 1.0;
+  if (face == 0) return normalize(vec3(1.0, -coordinate.y, -coordinate.x));
+  if (face == 1) return normalize(vec3(-1.0, -coordinate.y, coordinate.x));
+  if (face == 2) return normalize(vec3(coordinate.x, 1.0, coordinate.y));
+  if (face == 3) return normalize(vec3(coordinate.x, -1.0, -coordinate.y));
+  if (face == 4) return normalize(vec3(coordinate.x, -coordinate.y, 1.0));
+  return normalize(vec3(-coordinate.x, -coordinate.y, -1.0));
+}
+
+mat3 getEnvironmentTangentBasis(vec3 normal)
+{
+  vec3 up = abs(normal.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+  vec3 tangent = normalize(cross(up, normal));
+  return mat3(tangent, cross(normal, tangent), normal);
+}
+
+vec3 sampleEnvironmentDirection(vec3 direction)
+{
+  vec3 normalizedDirection = normalize(direction);
+  vec2 textureCoordinate = vec2(
+    atan(normalizedDirection.z, normalizedDirection.x) / (2.0 * ENVIRONMENT_PI) + 0.5,
+    acos(clamp(normalizedDirection.y, -1.0, 1.0)) / ENVIRONMENT_PI
+  );
+  vec3 color = texture(pbrEnvironmentSource, textureCoordinate).rgb;
+  if (pbrEnvironmentFilter.sourceEncoding == 1) {
+    vec3 lower = color / 12.92;
+    vec3 upper = pow((color + 0.055) / 1.055, vec3(2.4));
+    color = mix(lower, upper, step(vec3(0.04045), color));
+  }
+  return color;
+}
+
+vec3 importanceSampleEnvironment(vec2 sequence, vec3 normal, float roughness)
+{
+  float alpha = max(roughness * roughness, 0.0001);
+  float azimuth = 2.0 * ENVIRONMENT_PI * sequence.x;
+  float cosine = sqrt(
+    (1.0 - sequence.y) / max(1.0 + (alpha * alpha - 1.0) * sequence.y, 0.0001)
+  );
+  float sine = sqrt(max(1.0 - cosine * cosine, 0.0));
+  vec3 halfVector = vec3(cos(azimuth) * sine, sin(azimuth) * sine, cosine);
+  return normalize(getEnvironmentTangentBasis(normal) * halfVector);
+}
+
+float getEnvironmentGeometry(float normalDotDirection, float roughness)
+{
+  float alpha = roughness * roughness;
+  float factor = alpha * 0.5;
+  return normalDotDirection / max(normalDotDirection * (1.0 - factor) + factor, 0.0001);
+}
+
+vec2 integrateEnvironmentBRDF(vec2 textureCoordinate, int sampleCount)
+{
+  float normalDotView = max(textureCoordinate.x, 0.001);
+  float roughness = 1.0 - textureCoordinate.y;
+  vec3 viewDirection = vec3(sqrt(max(1.0 - normalDotView * normalDotView, 0.0)), 0.0, normalDotView);
+  vec2 integration = vec2(0.0);
+
+  for (int sampleIndex = 0; sampleIndex < 1024; sampleIndex++) {
+    if (sampleIndex >= sampleCount) break;
+    vec3 halfVector = importanceSampleEnvironment(
+      getEnvironmentHammersley(uint(sampleIndex), uint(sampleCount)),
+      vec3(0.0, 0.0, 1.0),
+      roughness
+    );
+    vec3 lightDirection = normalize(2.0 * dot(viewDirection, halfVector) * halfVector - viewDirection);
+    float normalDotLight = max(lightDirection.z, 0.0);
+    float normalDotHalf = max(halfVector.z, 0.0);
+    float viewDotHalf = max(dot(viewDirection, halfVector), 0.0);
+    if (normalDotLight > 0.0) {
+      float visibility = getEnvironmentGeometry(normalDotView, roughness) *
+        getEnvironmentGeometry(normalDotLight, roughness) * viewDotHalf /
+        max(normalDotHalf * normalDotView, 0.0001);
+      float fresnel = pow(1.0 - viewDotHalf, 5.0);
+      integration += vec2(1.0 - fresnel, fresnel) * visibility;
+    }
+  }
+  return integration / float(sampleCount);
+}
+
+vec3 integrateEnvironmentDirection(vec3 normal, int sampleCount)
+{
+  vec3 accumulatedColor = vec3(0.0);
+  float accumulatedWeight = 0.0;
+
+  for (int sampleIndex = 0; sampleIndex < 1024; sampleIndex++) {
+    if (sampleIndex >= sampleCount) break;
+    vec2 sequence = getEnvironmentHammersley(uint(sampleIndex), uint(sampleCount));
+    vec3 direction;
+    float sampleWeight;
+
+    if (pbrEnvironmentFilter.mode == 1) {
+      float azimuth = 2.0 * ENVIRONMENT_PI * sequence.x;
+      float cosine = sqrt(1.0 - sequence.y);
+      float sine = sqrt(sequence.y);
+      direction = normalize(
+        getEnvironmentTangentBasis(normal) *
+        vec3(cos(azimuth) * sine, sin(azimuth) * sine, cosine)
+      );
+      sampleWeight = 1.0;
+    } else {
+      vec3 halfVector = importanceSampleEnvironment(sequence, normal, pbrEnvironmentFilter.roughness);
+      direction = normalize(2.0 * dot(normal, halfVector) * halfVector - normal);
+      sampleWeight = max(dot(normal, direction), 0.0);
+    }
+
+    accumulatedColor += sampleEnvironmentDirection(direction) * sampleWeight;
+    accumulatedWeight += sampleWeight;
+  }
+
+  return accumulatedColor / max(accumulatedWeight, 0.0001);
+}
+
+void main(void)
+{
+  int sampleCount = max(pbrEnvironmentFilter.sampleCount, 1);
+  if (pbrEnvironmentFilter.mode == 2) {
+    fragmentColor = vec4(integrateEnvironmentBRDF(uv, sampleCount), 0.0, 1.0);
+    return;
+  }
+
+  vec3 direction = getEnvironmentFaceDirection(pbrEnvironmentFilter.face, uv);
+  fragmentColor = vec4(integrateEnvironmentDirection(direction, sampleCount), 1.0);
+}
+`;
+
+export const PBR_ENVIRONMENT_FRAGMENT_WGSL = /* wgsl */ `\
+const ENVIRONMENT_PI: f32 = 3.141592653589793;
+
+fn getEnvironmentHammersley(index: u32, sampleCount: u32) -> vec2f {
+  return vec2f(f32(index) / f32(sampleCount), f32(reverseBits(index)) * 2.3283064365386963e-10);
+}
+
+fn getEnvironmentFaceDirection(face: i32, textureCoordinate: vec2f) -> vec3f {
+  let coordinate = textureCoordinate * 2.0 - 1.0;
+  if (face == 0) { return normalize(vec3f(1.0, -coordinate.y, -coordinate.x)); }
+  if (face == 1) { return normalize(vec3f(-1.0, -coordinate.y, coordinate.x)); }
+  if (face == 2) { return normalize(vec3f(coordinate.x, 1.0, coordinate.y)); }
+  if (face == 3) { return normalize(vec3f(coordinate.x, -1.0, -coordinate.y)); }
+  if (face == 4) { return normalize(vec3f(coordinate.x, -coordinate.y, 1.0)); }
+  return normalize(vec3f(-coordinate.x, -coordinate.y, -1.0));
+}
+
+fn getEnvironmentTangentBasis(normal: vec3f) -> mat3x3f {
+  var up = vec3f(1.0, 0.0, 0.0);
+  if (abs(normal.z) < 0.999) {
+    up = vec3f(0.0, 0.0, 1.0);
+  }
+  let tangent = normalize(cross(up, normal));
+  return mat3x3f(tangent, cross(normal, tangent), normal);
+}
+
+fn sampleEnvironmentDirection(direction: vec3f) -> vec3f {
+  let normalizedDirection = normalize(direction);
+  let textureCoordinate = vec2f(
+    atan2(normalizedDirection.z, normalizedDirection.x) / (2.0 * ENVIRONMENT_PI) + 0.5,
+    acos(clamp(normalizedDirection.y, -1.0, 1.0)) / ENVIRONMENT_PI
+  );
+  var color = textureSampleLevel(
+    pbrEnvironmentSource,
+    pbrEnvironmentSourceSampler,
+    textureCoordinate,
+    0.0
+  ).rgb;
+  if (pbrEnvironmentFilter.sourceEncoding == 1) {
+    let lower = color / 12.92;
+    let upper = pow((color + 0.055) / 1.055, vec3f(2.4));
+    color = mix(lower, upper, step(vec3f(0.04045), color));
+  }
+  return color;
+}
+
+fn importanceSampleEnvironment(sequence: vec2f, normal: vec3f, roughness: f32) -> vec3f {
+  let alpha = max(roughness * roughness, 0.0001);
+  let azimuth = 2.0 * ENVIRONMENT_PI * sequence.x;
+  let cosine = sqrt(
+    (1.0 - sequence.y) / max(1.0 + (alpha * alpha - 1.0) * sequence.y, 0.0001)
+  );
+  let sine = sqrt(max(1.0 - cosine * cosine, 0.0));
+  let halfVector = vec3f(cos(azimuth) * sine, sin(azimuth) * sine, cosine);
+  return normalize(getEnvironmentTangentBasis(normal) * halfVector);
+}
+
+fn getEnvironmentGeometry(normalDotDirection: f32, roughness: f32) -> f32 {
+  let alpha = roughness * roughness;
+  let factor = alpha * 0.5;
+  return normalDotDirection / max(normalDotDirection * (1.0 - factor) + factor, 0.0001);
+}
+
+fn integrateEnvironmentBRDF(textureCoordinate: vec2f, sampleCount: u32) -> vec2f {
+  let normalDotView = max(textureCoordinate.x, 0.001);
+  let roughness = 1.0 - textureCoordinate.y;
+  let viewDirection = vec3f(
+    sqrt(max(1.0 - normalDotView * normalDotView, 0.0)),
+    0.0,
+    normalDotView
+  );
+  var integration = vec2f(0.0);
+
+  for (var sampleIndex = 0u; sampleIndex < sampleCount; sampleIndex++) {
+    let halfVector = importanceSampleEnvironment(
+      getEnvironmentHammersley(sampleIndex, sampleCount),
+      vec3f(0.0, 0.0, 1.0),
+      roughness
+    );
+    let lightDirection = normalize(
+      2.0 * dot(viewDirection, halfVector) * halfVector - viewDirection
+    );
+    let normalDotLight = max(lightDirection.z, 0.0);
+    let normalDotHalf = max(halfVector.z, 0.0);
+    let viewDotHalf = max(dot(viewDirection, halfVector), 0.0);
+    if (normalDotLight > 0.0) {
+      let visibility = getEnvironmentGeometry(normalDotView, roughness) *
+        getEnvironmentGeometry(normalDotLight, roughness) * viewDotHalf /
+        max(normalDotHalf * normalDotView, 0.0001);
+      let fresnel = pow(1.0 - viewDotHalf, 5.0);
+      integration += vec2f(1.0 - fresnel, fresnel) * visibility;
+    }
+  }
+  return integration / f32(sampleCount);
+}
+
+fn integrateEnvironmentDirection(normal: vec3f, sampleCount: u32) -> vec3f {
+  var accumulatedColor = vec3f(0.0);
+  var accumulatedWeight = 0.0;
+
+  for (var sampleIndex = 0u; sampleIndex < sampleCount; sampleIndex++) {
+    let sequence = getEnvironmentHammersley(sampleIndex, sampleCount);
+    var direction: vec3f;
+    var sampleWeight: f32;
+
+    if (pbrEnvironmentFilter.mode == 1) {
+      let azimuth = 2.0 * ENVIRONMENT_PI * sequence.x;
+      let cosine = sqrt(1.0 - sequence.y);
+      let sine = sqrt(sequence.y);
+      direction = normalize(
+        getEnvironmentTangentBasis(normal) *
+        vec3f(cos(azimuth) * sine, sin(azimuth) * sine, cosine)
+      );
+      sampleWeight = 1.0;
+    } else {
+      let halfVector = importanceSampleEnvironment(sequence, normal, pbrEnvironmentFilter.roughness);
+      direction = normalize(2.0 * dot(normal, halfVector) * halfVector - normal);
+      sampleWeight = max(dot(normal, direction), 0.0);
+    }
+
+    accumulatedColor += sampleEnvironmentDirection(direction) * sampleWeight;
+    accumulatedWeight += sampleWeight;
+  }
+  return accumulatedColor / max(accumulatedWeight, 0.0001);
+}
+
+@fragment
+fn fragmentMain(inputs: FragmentInputs) -> @location(0) vec4f {
+  let sampleCount = u32(max(pbrEnvironmentFilter.sampleCount, 1));
+  if (pbrEnvironmentFilter.mode == 2) {
+    return vec4f(integrateEnvironmentBRDF(inputs.uv, sampleCount), 0.0, 1.0);
+  }
+
+  let direction = getEnvironmentFaceDirection(pbrEnvironmentFilter.face, inputs.uv);
+  return vec4f(integrateEnvironmentDirection(direction, sampleCount), 1.0);
+}
+`;

--- a/modules/experimental/src/engine/pbr-environment.ts
+++ b/modules/experimental/src/engine/pbr-environment.ts
@@ -1,0 +1,333 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {
+  assert,
+  type Device,
+  type Framebuffer,
+  Texture,
+  type TextureFormatColor,
+  type TextureView
+} from '@luma.gl/core';
+import {ClipSpace, ShaderInputs} from '@luma.gl/engine';
+import {
+  PBR_ENVIRONMENT_FRAGMENT_GLSL,
+  PBR_ENVIRONMENT_FRAGMENT_WGSL,
+  pbrEnvironmentFilter
+} from './pbr-environment-shaders';
+import type {SceneEnvironment} from './scene-renderer';
+
+/** Source and quality controls for preparing a portable physically based lighting environment. */
+export type PreparePBREnvironmentOptions = {
+  /** Caller-owned linear HDR or sRGB equirectangular source texture. */
+  source: Texture;
+  /** Source color encoding. HDR and floating-point sources are linear by default. */
+  sourceEncoding?: 'linear' | 'srgb';
+  /** Base dimension of the GGX-prefiltered specular cubemap. Defaults to 64 pixels. */
+  size?: number;
+  /** Dimension of the cosine-weighted diffuse irradiance cubemap. Defaults to 16 pixels. */
+  irradianceSize?: number;
+  /** Dimension of the integrated split-sum BRDF lookup texture. Defaults to 128 pixels. */
+  brdfLUTSize?: number;
+  /** Number of importance samples for each destination texel. Defaults to 64. */
+  sampleCount?: number;
+  /** Renderable output format. Defaults to rgba16float when filterable, otherwise rgba8unorm. */
+  format?: TextureFormatColor;
+  /** Environment radiance multiplier consumed by SceneRenderer. */
+  intensity?: number;
+  /** Horizontal environment rotation consumed by SceneRenderer, in radians. */
+  rotation?: number;
+};
+
+/** Complete, owned irradiance, filtered radiance, and BRDF integration resources. */
+export class PreparedPBREnvironment implements SceneEnvironment {
+  readonly diffuseTexture: Texture;
+  readonly specularTexture: Texture;
+  readonly brdfLUTTexture: Texture;
+  intensity: number;
+  rotation: number;
+
+  constructor(resources: {
+    diffuseTexture: Texture;
+    specularTexture: Texture;
+    brdfLUTTexture: Texture;
+    intensity?: number;
+    rotation?: number;
+  }) {
+    this.diffuseTexture = resources.diffuseTexture;
+    this.specularTexture = resources.specularTexture;
+    this.brdfLUTTexture = resources.brdfLUTTexture;
+    this.intensity = resources.intensity ?? 1;
+    this.rotation = resources.rotation ?? 0;
+  }
+
+  /** Releases only the generated resources; the original equirectangular source remains owned. */
+  destroy(): void {
+    this.diffuseTexture.destroy();
+    this.specularTexture.destroy();
+    this.brdfLUTTexture.destroy();
+  }
+}
+
+/** Reusable WebGL/WebGPU equirectangular-to-IBL importance-sampling pipeline. */
+export class PBREnvironmentGenerator {
+  readonly device: Device;
+
+  private model: ClipSpace | undefined;
+  private modelFormat: TextureFormatColor | undefined;
+
+  constructor(device: Device) {
+    this.device = device;
+  }
+
+  /** Integrates all six cube faces, every roughness mip, diffuse irradiance, and the BRDF LUT. */
+  prepare(options: PreparePBREnvironmentOptions): PreparedPBREnvironment {
+    // Equirectangular environment sources require ordinary two-dimensional texture coordinates.
+    assert(options.source.dimension === '2d');
+    const size = Math.max(1, Math.floor(options.size ?? 64));
+    const irradianceSize = Math.max(1, Math.floor(options.irradianceSize ?? 16));
+    const brdfLUTSize = Math.max(1, Math.floor(options.brdfLUTSize ?? 128));
+    const sampleCount = Math.max(1, Math.min(Math.floor(options.sampleCount ?? 64), 1024));
+    const format = options.format || getEnvironmentTextureFormat(this.device);
+    const mipLevels = this.device.getMipLevelCount(size, size);
+
+    const specularTexture = createEnvironmentTexture(this.device, {
+      id: 'pbr-environment-specular',
+      dimension: 'cube',
+      size,
+      mipLevels,
+      format
+    });
+    const diffuseTexture = createEnvironmentTexture(this.device, {
+      id: 'pbr-environment-diffuse',
+      dimension: 'cube',
+      size: irradianceSize,
+      mipLevels: 1,
+      format
+    });
+    const brdfLUTTexture = createEnvironmentTexture(this.device, {
+      id: 'pbr-environment-brdf-lut',
+      dimension: '2d',
+      size: brdfLUTSize,
+      mipLevels: 1,
+      format
+    });
+
+    const framebuffers: Framebuffer[] = [];
+    const views: TextureView[] = [];
+
+    try {
+      const model = this.getFilterModel(format);
+      const sourceEncoding =
+        options.sourceEncoding === 'srgb' && !options.source.format.endsWith('-srgb') ? 1 : 0;
+
+      for (let mipLevel = 0; mipLevel < mipLevels; mipLevel++) {
+        const mipSize = Math.max(1, size >> mipLevel);
+        const roughness = mipLevels > 1 ? mipLevel / (mipLevels - 1) : 0;
+        for (let face = 0; face < 6; face++) {
+          this.drawEnvironmentView({
+            texture: specularTexture,
+            size: mipSize,
+            mipLevel,
+            face,
+            roughness,
+            mode: 0,
+            source: options.source,
+            sourceEncoding,
+            sampleCount,
+            model,
+            framebuffers,
+            views
+          });
+        }
+      }
+
+      for (let face = 0; face < 6; face++) {
+        this.drawEnvironmentView({
+          texture: diffuseTexture,
+          size: irradianceSize,
+          mipLevel: 0,
+          face,
+          roughness: 1,
+          mode: 1,
+          source: options.source,
+          sourceEncoding,
+          sampleCount,
+          model,
+          framebuffers,
+          views
+        });
+      }
+
+      this.drawEnvironmentView({
+        texture: brdfLUTTexture,
+        size: brdfLUTSize,
+        mipLevel: 0,
+        face: 0,
+        roughness: 0,
+        mode: 2,
+        source: options.source,
+        sourceEncoding,
+        sampleCount,
+        model,
+        framebuffers,
+        views
+      });
+
+      // Destination resources are complete and safe for immediate reuse by the next render pass.
+      this.device.submit();
+
+      return new PreparedPBREnvironment({
+        diffuseTexture,
+        specularTexture,
+        brdfLUTTexture,
+        intensity: options.intensity,
+        rotation: options.rotation
+      });
+    } catch (error) {
+      specularTexture.destroy();
+      diffuseTexture.destroy();
+      brdfLUTTexture.destroy();
+      throw error;
+    } finally {
+      for (const framebuffer of framebuffers) {
+        framebuffer.destroy();
+      }
+      for (const view of views) {
+        view.destroy();
+      }
+    }
+  }
+
+  /** Releases the reusable integration pipeline without destroying generated environments. */
+  destroy(): void {
+    this.model?.destroy();
+    this.model = undefined;
+    this.modelFormat = undefined;
+  }
+
+  private getFilterModel(format: TextureFormatColor): ClipSpace {
+    if (this.model && this.modelFormat !== format) {
+      this.model.destroy();
+      this.model = undefined;
+    }
+
+    if (!this.model) {
+      this.model = new ClipSpace(this.device, {
+        id: 'pbr-environment-integration-model',
+        fs: PBR_ENVIRONMENT_FRAGMENT_GLSL,
+        source: PBR_ENVIRONMENT_FRAGMENT_WGSL,
+        modules: [pbrEnvironmentFilter],
+        shaderInputs: new ShaderInputs({pbrEnvironmentFilter}),
+        colorAttachmentFormats: [format],
+        parameters: {depthWriteEnabled: false}
+      });
+      this.modelFormat = format;
+    }
+
+    return this.model;
+  }
+
+  private drawEnvironmentView(options: {
+    texture: Texture;
+    size: number;
+    mipLevel: number;
+    face: number;
+    roughness: number;
+    mode: number;
+    source: Texture;
+    sourceEncoding: number;
+    sampleCount: number;
+    model: ClipSpace;
+    framebuffers: Framebuffer[];
+    views: TextureView[];
+  }): void {
+    const view = options.texture.createView({
+      id: `${options.texture.id}-${options.face}-${options.mipLevel}`,
+      dimension: '2d',
+      baseMipLevel: options.mipLevel,
+      mipLevelCount: 1,
+      baseArrayLayer: options.face,
+      arrayLayerCount: 1
+    });
+    options.views.push(view);
+
+    const framebuffer = this.device.createFramebuffer({
+      id: `${view.id}-framebuffer`,
+      width: options.size,
+      height: options.size,
+      colorAttachments: [view],
+      depthStencilAttachment: null
+    });
+    options.framebuffers.push(framebuffer);
+
+    options.model.shaderInputs.setProps({
+      pbrEnvironmentFilter: {
+        face: options.face,
+        roughness: options.roughness,
+        mode: options.mode,
+        sampleCount: options.sampleCount,
+        sourceEncoding: options.sourceEncoding,
+        pbrEnvironmentSource: options.source
+      }
+    });
+    options.model.predraw(this.device.commandEncoder);
+
+    const renderPass = this.device.beginRenderPass({
+      id: `${view.id}-integration`,
+      framebuffer,
+      clearColor: [0, 0, 0, 1],
+      clearDepth: false
+    });
+    options.model.draw(renderPass);
+    renderPass.end();
+  }
+}
+
+/** Prepares one caller-owned lighting environment without retaining the integration pipeline. */
+export function preparePBREnvironment(
+  device: Device,
+  options: PreparePBREnvironmentOptions
+): PreparedPBREnvironment {
+  const generator = new PBREnvironmentGenerator(device);
+  try {
+    return generator.prepare(options);
+  } finally {
+    generator.destroy();
+  }
+}
+
+function getEnvironmentTextureFormat(device: Device): TextureFormatColor {
+  const capabilities = device.getTextureFormatCapabilities('rgba16float');
+  return capabilities.render && capabilities.filter ? 'rgba16float' : 'rgba8unorm';
+}
+
+function createEnvironmentTexture(
+  device: Device,
+  options: {
+    id: string;
+    dimension: '2d' | 'cube';
+    size: number;
+    mipLevels: number;
+    format: TextureFormatColor;
+  }
+): Texture {
+  return device.createTexture({
+    id: options.id,
+    dimension: options.dimension,
+    width: options.size,
+    height: options.size,
+    depth: options.dimension === 'cube' ? 6 : 1,
+    mipLevels: options.mipLevels,
+    format: options.format,
+    usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_SRC,
+    sampler: {
+      minFilter: 'linear',
+      magFilter: 'linear',
+      mipmapFilter: 'linear',
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'clamp-to-edge'
+    }
+  });
+}

--- a/modules/experimental/src/engine/pbr-model.ts
+++ b/modules/experimental/src/engine/pbr-model.ts
@@ -288,7 +288,7 @@ export type CreatePBRModelOptions = ModelProps & {
 
 /** Creates a WebGPU/WebGL PBR model shared by retained scenes and format adapters. */
 export function createPBRModel(device: Device, options: CreatePBRModelOptions): Model {
-  const shaderModules = [pbrMaterial, pbrScene, ...(options.modules || [])];
+  const shaderModules = [pbrScene, pbrMaterial, ...(options.modules || [])];
   const modules = shaderModules.filter(
     (module, moduleIndex) =>
       shaderModules.findIndex(candidate => candidate.name === module.name) === moduleIndex

--- a/modules/experimental/src/engine/scene-renderer.ts
+++ b/modules/experimental/src/engine/scene-renderer.ts
@@ -8,7 +8,7 @@ import {
   type Device,
   type Framebuffer,
   type RenderPass,
-  type Texture
+  Texture
 } from '@luma.gl/core';
 import {type Geometry, type Model, type ModelProps, ShaderInputs} from '@luma.gl/engine';
 import {
@@ -106,6 +106,8 @@ export type SceneRenderOptions = {
   height?: number;
   /** Optional complete image-based-lighting environment. */
   environment?: SceneEnvironment;
+  /** Captures opaque scene color for physical transmission. Enabled automatically by default. */
+  transmission?: boolean;
   /** Scene exposure multiplier. */
   exposure?: number;
   /** Shared scene tone-mapping mode. */
@@ -137,17 +139,30 @@ type CompiledSceneSurface = {
   textureBindings: [string, unknown][];
   triangleCount: number;
   alphaMode: SceneAlphaMode;
+  transmissive: boolean;
   depth: number;
+};
+
+type SceneTransmissionResources = {
+  colorTexture: Texture;
+  depthTexture: Texture;
+  framebuffer: Framebuffer;
 };
 
 type SceneFrameResources = {
   surfaces: Map<string, CompiledSceneSurface>;
+  transmission?: SceneTransmissionResources;
 };
 
 /** Prepared scene data available to specialized renderers before opening a render pass. */
 export type PreparedScene = {
   /** Prepared opaque and blended model batches in draw order. */
-  surfaces: readonly {model: Model; alphaMode: SceneAlphaMode; depth: number}[];
+  surfaces: readonly {
+    model: Model;
+    alphaMode: SceneAlphaMode;
+    depth: number;
+    transmissive?: boolean;
+  }[];
   /** Surface, instance, and triangle counts; draw count is populated after the render pass. */
   statistics: SceneRenderStatistics;
 };
@@ -174,8 +189,29 @@ export class SceneRenderer {
 
   /** Compiles, updates, orders, and draws one retained frame. */
   render(options: SceneRenderOptions): SceneRenderStatistics {
-    const scene = this.prepareScene(options);
+    const transmission = this.getTransmissionResources(options);
+    const scene = this.prepareScene(options, transmission?.colorTexture);
     const background = options.background || [0, 0, 0, 1];
+
+    if (transmission) {
+      const capturePass = this.device.beginRenderPass({
+        id: `scene-${options.id}-transmission`,
+        framebuffer: transmission.framebuffer,
+        clearColor: [background[0], background[1], background[2], background[3] ?? 1],
+        clearDepth: 1
+      });
+      this.drawPreparedScene(
+        {
+          ...scene,
+          surfaces: scene.surfaces.filter(
+            surface => !surface.transmissive && surface.alphaMode !== 'BLEND'
+          )
+        },
+        capturePass
+      );
+      capturePass.end();
+    }
+
     const renderPass = this.device.beginRenderPass({
       id: `scene-${options.id}`,
       framebuffer: options.framebuffer,
@@ -197,6 +233,7 @@ export class SceneRenderer {
     for (const surface of resources.surfaces.values()) {
       destroyCompiledSceneSurface(surface);
     }
+    destroyTransmissionResources(resources.transmission);
     this.frames.delete(frameIdentifier);
   }
 
@@ -208,7 +245,10 @@ export class SceneRenderer {
   }
 
   /** Creates or updates all models and uploads uniforms before a render pass begins. */
-  protected prepareScene(options: SceneRenderOptions): PreparedScene {
+  protected prepareScene(
+    options: SceneRenderOptions,
+    transmissionTexture?: Texture
+  ): PreparedScene {
     let resources = this.frames.get(options.id);
     if (!resources) {
       resources = {surfaces: new Map()};
@@ -225,7 +265,15 @@ export class SceneRenderer {
         continue;
       }
 
-      const compiledSurface = this.getCompiledSurface(resources, surface, options);
+      const surfaceTransmissionTexture = isTransmissiveSurface(surface)
+        ? transmissionTexture
+        : undefined;
+      const compiledSurface = this.getCompiledSurface(
+        resources,
+        surface,
+        options,
+        surfaceTransmissionTexture
+      );
       updateInstanceTransforms(compiledSurface, surface.transforms);
       compiledSurface.material.setProps({
         pbrMaterial: {
@@ -235,7 +283,7 @@ export class SceneRenderer {
           IBLenabled: hasCompleteEnvironment(options.environment)
         }
       });
-      setSceneShaderInputs(compiledSurface.model, options);
+      setSceneShaderInputs(compiledSurface.model, options, surfaceTransmissionTexture);
       compiledSurface.model.predraw(this.device.commandEncoder);
       compiledSurface.depth = getSurfaceDepth(surface.transforms, options.camera.viewMatrix);
       surfaceIdentifiers.add(surface.id);
@@ -256,6 +304,9 @@ export class SceneRenderer {
       const secondIsTransparent = secondSurface.alphaMode === 'BLEND';
       if (firstIsTransparent !== secondIsTransparent) {
         return firstIsTransparent ? 1 : -1;
+      }
+      if (!firstIsTransparent && firstSurface.transmissive !== secondSurface.transmissive) {
+        return firstSurface.transmissive ? 1 : -1;
       }
       return firstIsTransparent ? secondSurface.depth - firstSurface.depth : 0;
     });
@@ -293,10 +344,11 @@ export class SceneRenderer {
   private getCompiledSurface(
     resources: SceneFrameResources,
     surface: SceneSurface,
-    options: SceneRenderOptions
+    options: SceneRenderOptions,
+    transmissionTexture?: Texture
   ): CompiledSceneSurface {
     const alphaMode = getSceneAlphaMode(surface.material);
-    const signature = getSceneSurfaceSignature(surface, options, alphaMode);
+    const signature = getSceneSurfaceSignature(surface, options, alphaMode, transmissionTexture);
     const textureBindings = Object.entries(surface.material.bindings || {}).filter(([, texture]) =>
       Boolean(texture)
     );
@@ -366,6 +418,9 @@ export class SceneRenderer {
           USE_MATERIAL_EXTENSIONS: true,
           ALPHA_CUTOFF: alphaMode === 'MASK',
           USE_IBL: hasCompleteEnvironment(options.environment),
+          USE_SCENE_ENVIRONMENT: hasCompleteEnvironment(options.environment),
+          USE_TEX_LOD: hasMipmappedEnvironment(options.environment),
+          USE_TRANSMISSION_FRAMEBUFFER: Boolean(transmissionTexture),
           DEBUG_NORMALS: options.renderMode === 'debugNormals',
           DEBUG_DEPTH: options.renderMode === 'debugDepth',
           ...surface.material.defines,
@@ -386,6 +441,7 @@ export class SceneRenderer {
           (surface.geometry.indices?.value.length || surface.geometry.vertexCount) / 3
         ),
         alphaMode,
+        transmissive: Boolean(transmissionTexture),
         depth: 0
       };
       resources.surfaces.set(surface.id, compiledSurface);
@@ -393,6 +449,72 @@ export class SceneRenderer {
 
     compiledSurface.source = surface;
     return compiledSurface;
+  }
+
+  private getTransmissionResources(
+    options: SceneRenderOptions
+  ): SceneTransmissionResources | undefined {
+    const captureEnabled =
+      options.transmission !== false &&
+      (!options.renderMode || options.renderMode === 'default') &&
+      options.surfaces.some(isTransmissiveSurface);
+    let resources = this.frames.get(options.id);
+
+    if (!captureEnabled) {
+      if (resources?.transmission) {
+        destroyTransmissionResources(resources.transmission);
+        resources.transmission = undefined;
+      }
+      return undefined;
+    }
+
+    if (!resources) {
+      resources = {surfaces: new Map()};
+      this.frames.set(options.id, resources);
+    }
+
+    const [width, height] = getSceneRenderSize(this.device, options);
+    if (
+      resources.transmission &&
+      (resources.transmission.colorTexture.width !== width ||
+        resources.transmission.colorTexture.height !== height)
+    ) {
+      destroyTransmissionResources(resources.transmission);
+      resources.transmission = undefined;
+    }
+
+    if (!resources.transmission) {
+      const colorTexture = this.device.createTexture({
+        id: `scene-${options.id}-transmission-color`,
+        width,
+        height,
+        format: this.device.preferredColorFormat,
+        usage: Texture.SAMPLE | Texture.RENDER,
+        sampler: {
+          minFilter: 'linear',
+          magFilter: 'linear',
+          addressModeU: 'clamp-to-edge',
+          addressModeV: 'clamp-to-edge'
+        }
+      });
+      const depthTexture = this.device.createTexture({
+        id: `scene-${options.id}-transmission-depth`,
+        width,
+        height,
+        format: 'depth24plus',
+        usage: Texture.RENDER
+      });
+      const framebuffer = this.device.createFramebuffer({
+        id: `scene-${options.id}-transmission-framebuffer`,
+        width,
+        height,
+        colorAttachments: [colorTexture],
+        depthStencilAttachment: depthTexture
+      });
+      resources.transmission = {colorTexture, depthTexture, framebuffer};
+    }
+
+    return resources.transmission;
   }
 }
 
@@ -407,7 +529,8 @@ export function getSceneAlphaMode(material: SceneMaterial): SceneAlphaMode {
 function getSceneSurfaceSignature(
   surface: SceneSurface,
   options: SceneRenderOptions,
-  alphaMode: SceneAlphaMode
+  alphaMode: SceneAlphaMode,
+  transmissionTexture?: Texture
 ): string {
   return JSON.stringify({
     geometryVersion: surface.geometryVersion,
@@ -419,6 +542,10 @@ function getSceneSurfaceSignature(
       first.localeCompare(second)
     ),
     environment: hasCompleteEnvironment(options.environment),
+    environmentMipmapped: hasMipmappedEnvironment(options.environment),
+    transmission: Boolean(transmissionTexture),
+    transmissionWidth: transmissionTexture?.width,
+    transmissionHeight: transmissionTexture?.height,
     renderMode: options.renderMode || 'default'
   });
 }
@@ -456,11 +583,17 @@ function updateInstanceTransforms(
   }
 }
 
-function setSceneShaderInputs(model: Model, options: SceneRenderOptions): void {
+function setSceneShaderInputs(
+  model: Model,
+  options: SceneRenderOptions,
+  transmissionTexture?: Texture
+): void {
   const viewMatrix = new Matrix4(options.camera.viewMatrix);
   const projectionMatrix = new Matrix4(options.camera.projectionMatrix);
-  const framebufferWidth = options.framebuffer?.width || options.width || 1;
-  const framebufferHeight = options.framebuffer?.height || options.height || 1;
+  const framebufferWidth =
+    options.framebuffer?.width || options.width || transmissionTexture?.width || 1;
+  const framebufferHeight =
+    options.framebuffer?.height || options.height || transmissionTexture?.height || 1;
 
   model.shaderInputs.setProps({
     pbrProjection: {
@@ -474,9 +607,11 @@ function setSceneShaderInputs(model: Model, options: SceneRenderOptions): void {
       toneMapMode: options.toneMapMode ?? 2,
       environmentIntensity: options.environment?.intensity ?? 1,
       environmentRotation: options.environment?.rotation ?? 0,
+      environmentMipCount: options.environment?.specularTexture?.mipLevels ?? 1,
       framebufferSize: [framebufferWidth, framebufferHeight],
       viewMatrix,
-      projectionMatrix
+      projectionMatrix,
+      ...(transmissionTexture ? {pbr_transmissionFramebufferSampler: transmissionTexture} : {})
     },
     lighting: {lights: Array.from(options.lights || []), useByteColors: false},
     ...(hasCompleteEnvironment(options.environment)
@@ -495,6 +630,33 @@ function hasCompleteEnvironment(environment?: SceneEnvironment): boolean {
   return Boolean(
     environment?.diffuseTexture && environment.specularTexture && environment.brdfLUTTexture
   );
+}
+
+function hasMipmappedEnvironment(environment?: SceneEnvironment): boolean {
+  return hasCompleteEnvironment(environment) && (environment?.specularTexture?.mipLevels ?? 1) > 1;
+}
+
+function isTransmissiveSurface(surface: SceneSurface): boolean {
+  return (surface.material.uniforms?.transmissionFactor ?? 0) > 0;
+}
+
+function getSceneRenderSize(device: Device, options: SceneRenderOptions): [number, number] {
+  if (options.framebuffer) {
+    return [options.framebuffer.width, options.framebuffer.height];
+  }
+  if (options.width && options.height) {
+    return [options.width, options.height];
+  }
+  return device.getDefaultCanvasContext().getDrawingBufferSize();
+}
+
+function destroyTransmissionResources(resources?: SceneTransmissionResources): void {
+  if (!resources) {
+    return;
+  }
+  resources.framebuffer.destroy();
+  resources.colorTexture.destroy();
+  resources.depthTexture.destroy();
 }
 
 function getSurfaceDepth(

--- a/modules/experimental/src/index.ts
+++ b/modules/experimental/src/index.ts
@@ -26,6 +26,12 @@ export type {
 } from './engine/scene-renderer';
 export {getSceneAlphaMode, SceneRenderer} from './engine/scene-renderer';
 export {DeferredSceneRenderer, supportsDeferredScene} from './engine/deferred-scene-renderer';
+export type {PreparePBREnvironmentOptions} from './engine/pbr-environment';
+export {
+  PBREnvironmentGenerator,
+  PreparedPBREnvironment,
+  preparePBREnvironment
+} from './engine/pbr-environment';
 
 export {type TextureFormatPacked, RGBADecoder} from './textures/rgba-decoder';
 

--- a/modules/experimental/test/engine/scene-renderer.node.spec.ts
+++ b/modules/experimental/test/engine/scene-renderer.node.spec.ts
@@ -3,6 +3,7 @@
 // Copyright (c) vis.gl contributors
 
 import {readFileSync} from 'node:fs';
+import type {RenderPass, Texture} from '@luma.gl/core';
 import {Geometry} from '@luma.gl/engine';
 import {
   createPBRMaterial,
@@ -10,6 +11,10 @@ import {
   getPBRGeometryDefines,
   getPBRTextureDefines,
   getSceneAlphaMode,
+  PBREnvironmentGenerator,
+  PreparedPBREnvironment,
+  type PreparedScene,
+  preparePBREnvironment,
   type SceneMaterial,
   SceneRenderer,
   type SceneRenderOptions,
@@ -70,8 +75,15 @@ describe('scene rendering package architecture', () => {
 });
 
 class InspectableSceneRenderer extends SceneRenderer {
+  readonly draws: {id: string; scene: PreparedScene}[] = [];
+
   inspect(options: SceneRenderOptions) {
     return this.prepareScene(options);
+  }
+
+  protected override drawPreparedScene(scene: PreparedScene, renderPass: RenderPass): number {
+    this.draws.push({id: renderPass.id, scene});
+    return super.drawPreparedScene(scene, renderPass);
   }
 }
 
@@ -204,6 +216,47 @@ describe('shared PBR material factories', () => {
       ])
     );
   });
+
+  test('specializes scene refraction bindings and roughness-aware IBL independently', () => {
+    const shader = new WGSLShaderAssembler().assembleWGSLShader({
+      platformInfo: WEBGPU_PLATFORM,
+      source: PBR_MODEL_WGSL_SHADER,
+      modules: [pbrMaterial, pbrScene],
+      defines: {
+        HAS_NORMALS: true,
+        HAS_UV: true,
+        HAS_INSTANCING: true,
+        USE_MATERIAL_EXTENSIONS: true,
+        USE_IBL: true,
+        USE_SCENE_ENVIRONMENT: true,
+        USE_TEX_LOD: true,
+        USE_TRANSMISSION_FRAMEBUFFER: true
+      }
+    });
+    const reflection = new WgslReflect(shader.source);
+
+    expect(reflection.entry.vertex.map(entry => entry.name)).toEqual(['vertexMain']);
+    expect(reflection.entry.fragment.map(entry => entry.name)).toEqual(['fragmentMain']);
+    expect(shader.source).toContain('pbrScene.environmentMipCount - 1.0');
+    expect(shader.source).toContain('sin(pbrScene.environmentRotation)');
+    expect(shader.source).toContain('max(pbrScene.environmentIntensity, 0.0)');
+    expect(shader.source).toContain('getTransmittedSceneColor(');
+    expect(shader.source).toContain('pbr_transmissionFramebufferSampler');
+    expect(shader.source).toContain('let alpha = clamp(baseColor.a, 0.0, 1.0)');
+  });
+
+  test('retains legacy glTF IBL without requiring scene-only uniforms', () => {
+    const shader = new WGSLShaderAssembler().assembleWGSLShader({
+      platformInfo: WEBGPU_PLATFORM,
+      source: PBR_MODEL_WGSL_SHADER,
+      modules: [pbrMaterial],
+      defines: {HAS_NORMALS: true, USE_IBL: true, USE_TEX_LOD: true}
+    });
+
+    expect(shader.source).toContain('let maximumMipLevel = 9.0');
+    expect(shader.source).not.toContain('pbrScene.environmentMipCount');
+    expect(shader.source).not.toContain('pbr_transmissionFramebufferSampler');
+  });
 });
 
 describe('SceneRenderer', () => {
@@ -312,6 +365,305 @@ describe('SceneRenderer', () => {
     } finally {
       renderer.destroy();
       texture.destroy();
+    }
+  });
+
+  test('captures only opaque scene color and binds it only to transmissive models', async () => {
+    const device = await getNullTestDevice();
+    const renderer = new InspectableSceneRenderer(device);
+    const geometry = makeGeometry();
+    const glass: SceneSurface = {
+      id: 'glass-surface',
+      geometry,
+      material: {
+        id: 'glass-material',
+        alphaMode: 'OPAQUE',
+        uniforms: {
+          baseColorFactor: [1, 1, 1, 1],
+          transmissionFactor: 0.9,
+          thicknessFactor: 0.5,
+          attenuationDistance: 1.5,
+          attenuationColor: [0.8, 0.9, 1],
+          ior: 1.45
+        }
+      },
+      transforms: [new Matrix4()]
+    };
+    const opaque: SceneSurface = {
+      id: 'opaque-background',
+      geometry,
+      material: {id: 'opaque-background-material'},
+      transforms: [new Matrix4().translate([0, 0, -1])]
+    };
+    const translucent: SceneSurface = {
+      id: 'blended-background',
+      geometry,
+      material: {id: 'blended-background-material', alphaMode: 'BLEND'},
+      transforms: [new Matrix4().translate([0, 0, -2])]
+    };
+
+    try {
+      const statistics = renderer.render(makeOptions([glass, opaque, translucent]));
+      expect(statistics).toMatchObject({surfaceCount: 3, instanceCount: 3, drawCount: 3});
+      expect(renderer.draws.map(draw => draw.id)).toEqual([
+        'scene-shared-scene-transmission',
+        'scene-shared-scene'
+      ]);
+      expect(renderer.draws[0].scene.surfaces.map(surface => surface.model.id)).toEqual([
+        'opaque-background-model'
+      ]);
+      expect(renderer.draws[1].scene.surfaces.map(surface => surface.model.id)).toEqual([
+        'opaque-background-model',
+        'glass-surface-model',
+        'blended-background-model'
+      ]);
+
+      const opaqueModel = renderer.draws[1].scene.surfaces[0].model;
+      const glassModel = renderer.draws[1].scene.surfaces[1].model;
+      const captureTexture = glassModel.shaderInputs.getBindingValues()
+        .pbr_transmissionFramebufferSampler as Texture;
+      expect(captureTexture).toMatchObject({width: 8, height: 8, format: 'rgba8unorm'});
+      expect(opaqueModel.shaderInputs.getBindingValues()).not.toHaveProperty(
+        'pbr_transmissionFramebufferSampler'
+      );
+      expect(glassModel.parameters.blend).toBe(false);
+      expect(glassModel.parameters.depthWriteEnabled).toBe(true);
+
+      renderer.destroyFrame('shared-scene');
+      expect(captureTexture.destroyed).toBe(true);
+    } finally {
+      renderer.destroy();
+    }
+  });
+
+  test('reuses, resizes, disables, and structurally invalidates scene-color capture', async () => {
+    const device = await getNullTestDevice();
+    const renderer = new InspectableSceneRenderer(device);
+    const surface: SceneSurface = {
+      id: 'resizable-glass',
+      geometry: makeGeometry(),
+      material: {id: 'resizable-glass-material', uniforms: {transmissionFactor: 0.75}},
+      transforms: [new Matrix4()]
+    };
+    const options = makeOptions([surface]);
+
+    try {
+      renderer.render(options);
+      const originalModel = renderer.draws.at(-1)!.scene.surfaces[0].model;
+      const originalTexture = originalModel.shaderInputs.getBindingValues()
+        .pbr_transmissionFramebufferSampler as Texture;
+
+      renderer.render(options);
+      const reusedModel = renderer.draws.at(-1)!.scene.surfaces[0].model;
+      expect(reusedModel).toBe(originalModel);
+      expect(reusedModel.shaderInputs.getBindingValues().pbr_transmissionFramebufferSampler).toBe(
+        originalTexture
+      );
+
+      options.width = 16;
+      options.height = 12;
+      renderer.render(options);
+      const resizedModel = renderer.draws.at(-1)!.scene.surfaces[0].model;
+      const resizedTexture = resizedModel.shaderInputs.getBindingValues()
+        .pbr_transmissionFramebufferSampler as Texture;
+      expect(resizedModel).not.toBe(originalModel);
+      expect(resizedTexture).toMatchObject({width: 16, height: 12});
+      expect(originalTexture.destroyed).toBe(true);
+
+      options.transmission = false;
+      renderer.draws.length = 0;
+      renderer.render(options);
+      expect(renderer.draws).toHaveLength(1);
+      expect(renderer.draws[0].scene.surfaces[0].model).not.toBe(resizedModel);
+      expect(
+        renderer.draws[0].scene.surfaces[0].model.shaderInputs.getBindingValues()
+      ).not.toHaveProperty('pbr_transmissionFramebufferSampler');
+      expect(resizedTexture.destroyed).toBe(true);
+    } finally {
+      renderer.destroy();
+    }
+  });
+
+  test('passes exact specular mip counts without imposing environment bindings on ordinary scenes', async () => {
+    const device = await getNullTestDevice();
+    const renderer = new InspectableSceneRenderer(device);
+    const diffuseTexture = device.createTexture({
+      dimension: 'cube',
+      width: 4,
+      height: 4,
+      format: 'rgba8unorm'
+    });
+    const specularTexture = device.createTexture({
+      dimension: 'cube',
+      width: 8,
+      height: 8,
+      mipLevels: 4,
+      format: 'rgba8unorm'
+    });
+    const brdfLUTTexture = device.createTexture({width: 4, height: 4, format: 'rgba8unorm'});
+    const surface: SceneSurface = {
+      id: 'environment-surface',
+      geometry: makeGeometry(),
+      material: {id: 'environment-material'},
+      transforms: [new Matrix4()]
+    };
+    const options = makeOptions([surface]);
+
+    try {
+      renderer.render(options);
+      const noEnvironmentModel = renderer.draws.at(-1)!.scene.surfaces[0].model;
+      expect(noEnvironmentModel.shaderInputs.getUniformValues().pbrScene).toMatchObject({
+        environmentMipCount: 1
+      });
+
+      options.environment = {diffuseTexture, specularTexture, brdfLUTTexture};
+      renderer.render(options);
+      const environmentModel = renderer.draws.at(-1)!.scene.surfaces[0].model;
+      expect(environmentModel).not.toBe(noEnvironmentModel);
+      expect(environmentModel.shaderInputs.getUniformValues().pbrScene).toMatchObject({
+        environmentMipCount: 4
+      });
+      expect(environmentModel.shaderInputs.getBindingValues()).toMatchObject({
+        pbr_diffuseEnvSampler: diffuseTexture,
+        pbr_specularEnvSampler: specularTexture,
+        pbr_brdfLUT: brdfLUTTexture
+      });
+    } finally {
+      renderer.destroy();
+      diffuseTexture.destroy();
+      specularTexture.destroy();
+      brdfLUTTexture.destroy();
+    }
+  });
+});
+
+describe('PBREnvironmentGenerator', () => {
+  test('prepares complete roughness-mapped cubemaps, irradiance, and BRDF resources', async () => {
+    const device = await getNullTestDevice();
+    const source = device.createTexture({width: 16, height: 8, format: 'rgba8unorm'});
+    const generator = new PBREnvironmentGenerator(device);
+
+    try {
+      const environment = generator.prepare({
+        source,
+        size: 8,
+        irradianceSize: 4,
+        brdfLUTSize: 4,
+        sampleCount: 8,
+        format: 'rgba8unorm',
+        sourceEncoding: 'srgb',
+        intensity: 2,
+        rotation: 0.5
+      });
+
+      expect(environment).toBeInstanceOf(PreparedPBREnvironment);
+      expect(environment.specularTexture).toMatchObject({
+        dimension: 'cube',
+        width: 8,
+        depth: 6,
+        mipLevels: 4
+      });
+      expect(environment.diffuseTexture).toMatchObject({
+        dimension: 'cube',
+        width: 4,
+        depth: 6,
+        mipLevels: 1
+      });
+      expect(environment.brdfLUTTexture).toMatchObject({
+        dimension: '2d',
+        width: 4,
+        mipLevels: 1
+      });
+      expect(environment.intensity).toBe(2);
+      expect(environment.rotation).toBe(0.5);
+
+      environment.destroy();
+      expect(environment.specularTexture.destroyed).toBe(true);
+      expect(environment.diffuseTexture.destroyed).toBe(true);
+      expect(environment.brdfLUTTexture.destroyed).toBe(true);
+      expect(source.destroyed).toBe(false);
+    } finally {
+      generator.destroy();
+      source.destroy();
+    }
+  });
+
+  test('supports one-shot generation and rejects non-equirectangular texture dimensions', async () => {
+    const device = await getNullTestDevice();
+    const source = device.createTexture({width: 4, height: 2, format: 'rgba8unorm'});
+    const cube = device.createTexture({
+      dimension: 'cube',
+      width: 4,
+      height: 4,
+      format: 'rgba8unorm'
+    });
+    const generator = new PBREnvironmentGenerator(device);
+
+    try {
+      expect(() => generator.prepare({source: cube})).toThrow();
+      const environment = preparePBREnvironment(device, {
+        source,
+        size: 2,
+        irradianceSize: 2,
+        brdfLUTSize: 2,
+        sampleCount: 2,
+        format: 'rgba8unorm'
+      });
+      expect(environment.specularTexture.mipLevels).toBe(2);
+      environment.destroy();
+    } finally {
+      generator.destroy();
+      source.destroy();
+      cube.destroy();
+    }
+  });
+
+  test('never manually decodes hardware-sRGB source textures a second time', async () => {
+    const device = await getNullTestDevice();
+    const rawSRGBSource = device.createTexture({
+      width: 4,
+      height: 2,
+      format: 'rgba8unorm'
+    });
+    const hardwareSRGBSource = device.createTexture({
+      width: 4,
+      height: 2,
+      format: 'rgba8unorm-srgb'
+    });
+    const generator = new PBREnvironmentGenerator(device);
+    const prepareOptions = {
+      size: 2,
+      irradianceSize: 2,
+      brdfLUTSize: 2,
+      sampleCount: 2,
+      format: 'rgba8unorm' as const,
+      sourceEncoding: 'srgb' as const
+    };
+
+    try {
+      const rawEnvironment = generator.prepare({...prepareOptions, source: rawSRGBSource});
+      const filterModel = (
+        generator as unknown as {
+          model: {shaderInputs: {getUniformValues(): Record<string, {sourceEncoding: number}>}};
+        }
+      ).model;
+      expect(filterModel.shaderInputs.getUniformValues().pbrEnvironmentFilter.sourceEncoding).toBe(
+        1
+      );
+      rawEnvironment.destroy();
+
+      const hardwareEnvironment = generator.prepare({
+        ...prepareOptions,
+        source: hardwareSRGBSource
+      });
+      expect(filterModel.shaderInputs.getUniformValues().pbrEnvironmentFilter.sourceEncoding).toBe(
+        0
+      );
+      hardwareEnvironment.destroy();
+    } finally {
+      generator.destroy();
+      rawSRGBSource.destroy();
+      hardwareSRGBSource.destroy();
     }
   });
 });

--- a/modules/experimental/test/engine/scene-renderer.spec.ts
+++ b/modules/experimental/test/engine/scene-renderer.spec.ts
@@ -154,13 +154,17 @@ test('SceneRenderer refracts captured opaque color while preserving opaque trans
         makePhysicalRenderOptions(device, [glassSurface, backgroundSurface], framebuffer)
       );
       device.submit();
-      const pixel = await readPhysicalTestPixel(colorTexture, 16, 16);
-      const red = colorTexture.format.startsWith('bgra') ? pixel[2] : pixel[0];
-      const green = pixel[1];
-
       testCase.equal(statistics.drawCount, 2, `${device.type} counts only final scene draws`);
-      testCase.ok(red > green * 2, `${device.type} refracts captured red opaque scene color`);
-      testCase.equal(pixel[3], 255, `${device.type} keeps physical transmission opaque`);
+
+      if (supportsPhysicalPixelReadback(device)) {
+        const pixel = await readPhysicalTestPixel(colorTexture, 16, 16);
+        const red = colorTexture.format.startsWith('bgra') ? pixel[2] : pixel[0];
+        const green = pixel[1];
+        testCase.ok(red > green * 2, `${device.type} refracts captured red opaque scene color`);
+        testCase.equal(pixel[3], 255, `${device.type} keeps physical transmission opaque`);
+      } else {
+        testCase.comment('software WebGPU renders transmission without unsupported pixel readback');
+      }
     } finally {
       renderer.destroy();
       framebuffer.destroy();
@@ -214,25 +218,30 @@ test('PBREnvironmentGenerator integrates cubemap roughness mips and renders port
           3,
           `${device.type} generates all mips`
         );
-        const specularPixel = await readPhysicalTestPixel(environment.specularTexture, 0, 0);
-        const roughSpecularPixel = await readPhysicalTestPixel(
-          environment.specularTexture,
-          0,
-          0,
-          2
-        );
-        const diffusePixel = await readPhysicalTestPixel(environment.diffuseTexture, 0, 0);
-        const brdfPixel = await readPhysicalTestPixel(environment.brdfLUTTexture, 2, 2);
-        testCase.ok(specularPixel[0] > specularPixel[1], `${device.type} filters source radiance`);
-        testCase.ok(
-          Math.abs(specularPixel[1] - roughSpecularPixel[1]) > 5,
-          `${device.type} integrates different radiance at rough specular mip levels`
-        );
-        testCase.ok(
-          diffusePixel[0] > diffusePixel[1],
-          `${device.type} integrates diffuse irradiance`
-        );
-        testCase.ok(brdfPixel[0] > 0, `${device.type} integrates the split-sum BRDF lookup`);
+        if (supportsPhysicalPixelReadback(device)) {
+          const specularPixel = await readPhysicalTestPixel(environment.specularTexture, 0, 0);
+          const roughSpecularPixel = await readPhysicalTestPixel(
+            environment.specularTexture,
+            0,
+            0,
+            2
+          );
+          const diffusePixel = await readPhysicalTestPixel(environment.diffuseTexture, 0, 0);
+          const brdfPixel = await readPhysicalTestPixel(environment.brdfLUTTexture, 2, 2);
+          testCase.ok(
+            specularPixel[0] > specularPixel[1],
+            `${device.type} filters source radiance`
+          );
+          testCase.ok(
+            Math.abs(specularPixel[1] - roughSpecularPixel[1]) > 5,
+            `${device.type} integrates different radiance at rough specular mip levels`
+          );
+          testCase.ok(
+            diffusePixel[0] > diffusePixel[1],
+            `${device.type} integrates diffuse irradiance`
+          );
+          testCase.ok(brdfPixel[0] > 0, `${device.type} integrates the split-sum BRDF lookup`);
+        }
 
         const surface: SceneSurface = {
           id: `${device.type}-environment-surface`,
@@ -262,16 +271,19 @@ test('PBREnvironmentGenerator integrates cubemap roughness mips and renders port
           sourceEncoding: 'srgb'
         });
         try {
-          const linearSourcePixel = await readPhysicalTestPixel(environment.diffuseTexture, 0, 0);
-          const convertedSourcePixel = await readPhysicalTestPixel(
-            srgbEnvironment.diffuseTexture,
-            0,
-            0
-          );
-          testCase.ok(
-            convertedSourcePixel[0] < linearSourcePixel[0],
-            `${device.type} converts sRGB source radiance exactly once`
-          );
+          let convertedSourcePixel: Uint8Array | undefined;
+          if (supportsPhysicalPixelReadback(device)) {
+            const linearSourcePixel = await readPhysicalTestPixel(environment.diffuseTexture, 0, 0);
+            convertedSourcePixel = await readPhysicalTestPixel(
+              srgbEnvironment.diffuseTexture,
+              0,
+              0
+            );
+            testCase.ok(
+              convertedSourcePixel[0] < linearSourcePixel[0],
+              `${device.type} converts sRGB source radiance exactly once`
+            );
+          }
 
           const hardwareSRGBSource = device.createTexture({
             id: `${device.type}-hardware-srgb-environment`,
@@ -291,15 +303,17 @@ test('PBREnvironmentGenerator integrates cubemap roughness mips and renders port
               sourceEncoding: 'srgb'
             });
             try {
-              const hardwareConvertedPixel = await readPhysicalTestPixel(
-                hardwareSRGBEnvironment.diffuseTexture,
-                0,
-                0
-              );
-              testCase.ok(
-                Math.abs(hardwareConvertedPixel[0] - convertedSourcePixel[0]) <= 2,
-                `${device.type} avoids double-decoding hardware sRGB environment textures`
-              );
+              if (convertedSourcePixel) {
+                const hardwareConvertedPixel = await readPhysicalTestPixel(
+                  hardwareSRGBEnvironment.diffuseTexture,
+                  0,
+                  0
+                );
+                testCase.ok(
+                  Math.abs(hardwareConvertedPixel[0] - convertedSourcePixel[0]) <= 2,
+                  `${device.type} avoids double-decoding hardware sRGB environment textures`
+                );
+              }
             } finally {
               hardwareSRGBEnvironment.destroy();
             }
@@ -370,6 +384,15 @@ async function getLiveRenderingDevices(): Promise<Device[]> {
 function isSoftwareBackedWebGLDevice(device: Device): boolean {
   return (
     device.type === 'webgl' &&
+    (device.info.gpu === 'software' ||
+      device.info.gpuType === 'cpu' ||
+      Boolean(device.info.fallback))
+  );
+}
+
+function supportsPhysicalPixelReadback(device: Device): boolean {
+  return !(
+    device.type === 'webgpu' &&
     (device.info.gpu === 'software' ||
       device.info.gpuType === 'cpu' ||
       Boolean(device.info.fallback))

--- a/modules/experimental/test/engine/scene-renderer.spec.ts
+++ b/modules/experimental/test/engine/scene-renderer.spec.ts
@@ -2,9 +2,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
+import {Buffer, type Device, Texture} from '@luma.gl/core';
 import {Geometry} from '@luma.gl/engine';
-import {SceneRenderer, type SceneSurface} from '@luma.gl/experimental';
-import {getTestDevices} from '@luma.gl/test-utils';
+import {
+  PBREnvironmentGenerator,
+  SceneRenderer,
+  type SceneRenderOptions,
+  type SceneSurface
+} from '@luma.gl/experimental';
+import {getTestDevices, getWebGLTestDevice} from '@luma.gl/test-utils';
 import {Matrix4} from '@math.gl/core';
 import test from 'test/utils/vitest-tape';
 
@@ -84,3 +90,309 @@ test('SceneRenderer draws canonical instanced physical materials on available ba
   }
   testCase.end();
 });
+
+test('SceneRenderer refracts captured opaque color while preserving opaque transmission alpha', async testCase => {
+  let testedDeviceCount = 0;
+  for (const device of await getLiveRenderingDevices()) {
+    if (isSoftwareBackedWebGLDevice(device)) {
+      testCase.comment('software WebGL cannot reliably compile scene-texture PBR variants');
+      continue;
+    }
+
+    testedDeviceCount++;
+    const colorTexture = device.createTexture({
+      id: `${device.type}-refraction-output`,
+      width: 32,
+      height: 32,
+      format: device.preferredColorFormat,
+      usage: Texture.RENDER | Texture.COPY_SRC
+    });
+    const depthTexture = device.createTexture({
+      width: 32,
+      height: 32,
+      format: 'depth24plus',
+      usage: Texture.RENDER
+    });
+    const framebuffer = device.createFramebuffer({
+      width: 32,
+      height: 32,
+      colorAttachments: [colorTexture],
+      depthStencilAttachment: depthTexture
+    });
+    const renderer = new SceneRenderer(device);
+    const geometry = makePhysicalTestGeometry();
+    const backgroundSurface: SceneSurface = {
+      id: `${device.type}-opaque-color`,
+      geometry,
+      material: {
+        id: `${device.type}-opaque-color-material`,
+        uniforms: {unlit: true, baseColorFactor: [1, 0.02, 0.02, 1]}
+      },
+      transforms: [new Matrix4().translate([0, 0, -1])]
+    };
+    const glassSurface: SceneSurface = {
+      id: `${device.type}-transmissive-glass`,
+      geometry,
+      material: {
+        id: `${device.type}-transmissive-glass-material`,
+        alphaMode: 'OPAQUE',
+        uniforms: {
+          baseColorFactor: [1, 1, 1, 1],
+          metallicRoughnessValues: [0, 0.15],
+          transmissionFactor: 1,
+          thicknessFactor: 0.3,
+          attenuationDistance: 2,
+          attenuationColor: [1, 0.95, 0.95],
+          ior: 1.5
+        }
+      },
+      transforms: [new Matrix4()]
+    };
+
+    try {
+      const statistics = renderer.render(
+        makePhysicalRenderOptions(device, [glassSurface, backgroundSurface], framebuffer)
+      );
+      device.submit();
+      const pixel = await readPhysicalTestPixel(colorTexture, 16, 16);
+      const red = colorTexture.format.startsWith('bgra') ? pixel[2] : pixel[0];
+      const green = pixel[1];
+
+      testCase.equal(statistics.drawCount, 2, `${device.type} counts only final scene draws`);
+      testCase.ok(red > green * 2, `${device.type} refracts captured red opaque scene color`);
+      testCase.equal(pixel[3], 255, `${device.type} keeps physical transmission opaque`);
+    } finally {
+      renderer.destroy();
+      framebuffer.destroy();
+      colorTexture.destroy();
+      depthTexture.destroy();
+    }
+  }
+
+  testCase.ok(testedDeviceCount > 0, 'at least one hardware or WebGPU transmission backend runs');
+  testCase.end();
+});
+
+test('PBREnvironmentGenerator integrates cubemap roughness mips and renders portable IBL', async testCase => {
+  let testedDeviceCount = 0;
+  for (const device of await getLiveRenderingDevices()) {
+    if (isSoftwareBackedWebGLDevice(device)) {
+      testCase.comment('software WebGL cannot reliably compile environment-texture PBR variants');
+      continue;
+    }
+
+    testedDeviceCount++;
+    const sourceData = new Uint8Array(4 * 2 * 4);
+    for (let index = 0; index < sourceData.length; index += 4) {
+      const horizontalCoordinate = (index / 4) % 4;
+      sourceData.set(horizontalCoordinate < 2 ? [240, 20, 20, 255] : [240, 180, 20, 255], index);
+    }
+    const source = device.createTexture({
+      id: `${device.type}-environment-equirectangular`,
+      width: 4,
+      height: 2,
+      format: 'rgba8unorm',
+      data: sourceData
+    });
+    const generator = new PBREnvironmentGenerator(device);
+    const renderer = new SceneRenderer(device);
+
+    try {
+      const environment = generator.prepare({
+        source,
+        size: 4,
+        irradianceSize: 2,
+        brdfLUTSize: 4,
+        sampleCount: 8,
+        format: 'rgba8unorm',
+        sourceEncoding: 'linear'
+      });
+
+      try {
+        testCase.equal(
+          environment.specularTexture.mipLevels,
+          3,
+          `${device.type} generates all mips`
+        );
+        const specularPixel = await readPhysicalTestPixel(environment.specularTexture, 0, 0);
+        const roughSpecularPixel = await readPhysicalTestPixel(
+          environment.specularTexture,
+          0,
+          0,
+          2
+        );
+        const diffusePixel = await readPhysicalTestPixel(environment.diffuseTexture, 0, 0);
+        const brdfPixel = await readPhysicalTestPixel(environment.brdfLUTTexture, 2, 2);
+        testCase.ok(specularPixel[0] > specularPixel[1], `${device.type} filters source radiance`);
+        testCase.ok(
+          Math.abs(specularPixel[1] - roughSpecularPixel[1]) > 5,
+          `${device.type} integrates different radiance at rough specular mip levels`
+        );
+        testCase.ok(
+          diffusePixel[0] > diffusePixel[1],
+          `${device.type} integrates diffuse irradiance`
+        );
+        testCase.ok(brdfPixel[0] > 0, `${device.type} integrates the split-sum BRDF lookup`);
+
+        const surface: SceneSurface = {
+          id: `${device.type}-environment-surface`,
+          geometry: makePhysicalTestGeometry(),
+          material: {
+            id: `${device.type}-environment-material`,
+            uniforms: {baseColorFactor: [1, 1, 1, 1], metallicRoughnessValues: [0.7, 0.8]}
+          },
+          transforms: [new Matrix4()]
+        };
+        const options = makePhysicalRenderOptions(device, [surface]);
+        options.environment = environment;
+        testCase.equal(
+          renderer.render(options).drawCount,
+          1,
+          `${device.type} shades generated IBL`
+        );
+        device.submit();
+
+        const srgbEnvironment = generator.prepare({
+          source,
+          size: 2,
+          irradianceSize: 2,
+          brdfLUTSize: 2,
+          sampleCount: 8,
+          format: 'rgba8unorm',
+          sourceEncoding: 'srgb'
+        });
+        try {
+          const linearSourcePixel = await readPhysicalTestPixel(environment.diffuseTexture, 0, 0);
+          const convertedSourcePixel = await readPhysicalTestPixel(
+            srgbEnvironment.diffuseTexture,
+            0,
+            0
+          );
+          testCase.ok(
+            convertedSourcePixel[0] < linearSourcePixel[0],
+            `${device.type} converts sRGB source radiance exactly once`
+          );
+
+          const hardwareSRGBSource = device.createTexture({
+            id: `${device.type}-hardware-srgb-environment`,
+            width: 4,
+            height: 2,
+            format: 'rgba8unorm-srgb',
+            data: sourceData
+          });
+          try {
+            const hardwareSRGBEnvironment = generator.prepare({
+              source: hardwareSRGBSource,
+              size: 2,
+              irradianceSize: 2,
+              brdfLUTSize: 2,
+              sampleCount: 8,
+              format: 'rgba8unorm',
+              sourceEncoding: 'srgb'
+            });
+            try {
+              const hardwareConvertedPixel = await readPhysicalTestPixel(
+                hardwareSRGBEnvironment.diffuseTexture,
+                0,
+                0
+              );
+              testCase.ok(
+                Math.abs(hardwareConvertedPixel[0] - convertedSourcePixel[0]) <= 2,
+                `${device.type} avoids double-decoding hardware sRGB environment textures`
+              );
+            } finally {
+              hardwareSRGBEnvironment.destroy();
+            }
+          } finally {
+            hardwareSRGBSource.destroy();
+          }
+        } finally {
+          srgbEnvironment.destroy();
+        }
+      } finally {
+        environment.destroy();
+      }
+    } finally {
+      renderer.destroy();
+      generator.destroy();
+      source.destroy();
+    }
+  }
+
+  testCase.ok(testedDeviceCount > 0, 'at least one hardware or WebGPU environment backend runs');
+  testCase.end();
+});
+
+function makePhysicalTestGeometry(): Geometry {
+  return new Geometry({
+    topology: 'triangle-list',
+    attributes: {
+      POSITION: {size: 3, value: new Float32Array([-4, -4, 0, 4, -4, 0, 0, 4, 0])},
+      NORMAL: {size: 3, value: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1])}
+    },
+    indices: new Uint16Array([0, 1, 2])
+  });
+}
+
+function makePhysicalRenderOptions(
+  device: Device,
+  surfaces: SceneSurface[],
+  framebuffer?: SceneRenderOptions['framebuffer']
+): SceneRenderOptions {
+  return {
+    id: `${device.type}-physical-frame`,
+    surfaces,
+    framebuffer,
+    camera: {
+      viewMatrix: new Matrix4().lookAt({eye: [0, 0, 4], center: [0, 0, 0], up: [0, 1, 0]}),
+      projectionMatrix: new Matrix4().perspective({
+        fovy: Math.PI / 3,
+        aspect: 1,
+        near: 0.1,
+        far: 100
+      }),
+      position: [0, 0, 4]
+    },
+    background: [0.02, 0.65, 0.1, 1],
+    width: 32,
+    height: 32
+  };
+}
+
+async function getLiveRenderingDevices(): Promise<Device[]> {
+  const [webglDevice, webgpuDevices] = await Promise.all([
+    getWebGLTestDevice(),
+    getTestDevices(['webgpu'])
+  ]);
+  return webglDevice ? [webglDevice, ...webgpuDevices] : webgpuDevices;
+}
+
+function isSoftwareBackedWebGLDevice(device: Device): boolean {
+  return (
+    device.type === 'webgl' &&
+    (device.info.gpu === 'software' ||
+      device.info.gpuType === 'cpu' ||
+      Boolean(device.info.fallback))
+  );
+}
+
+async function readPhysicalTestPixel(
+  texture: Texture,
+  x: number,
+  y: number,
+  mipLevel = 0
+): Promise<Uint8Array> {
+  const layout = texture.computeMemoryLayout({width: 1, height: 1, mipLevel});
+  const buffer = texture.device.createBuffer({
+    byteLength: layout.byteLength,
+    usage: Buffer.COPY_DST | Buffer.MAP_READ
+  });
+
+  try {
+    texture.readBuffer({x, y, width: 1, height: 1, mipLevel}, buffer);
+    const result = await buffer.readAsync(0, layout.byteLength);
+    return new Uint8Array(result.buffer, result.byteOffset, 4);
+  } finally {
+    buffer.destroy();
+  }
+}

--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-glsl.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-glsl.ts
@@ -335,17 +335,29 @@ vec3 getClearcoatNormal(mat3 tbn, vec3 baseNormal, vec2 uv)
 #ifdef USE_IBL
 vec3 getIBLContribution(PBRInfo pbrInfo, vec3 n, vec3 reflection)
 {
-  float mipCount = 9.0; // resolution of 512x512
-  float lod = (pbrInfo.perceptualRoughness * mipCount);
+#ifdef USE_SCENE_ENVIRONMENT
+  float maximumMipLevel = max(pbrScene.environmentMipCount - 1.0, 0.0);
+  float rotationSine = sin(pbrScene.environmentRotation);
+  float rotationCosine = cos(pbrScene.environmentRotation);
+  mat2 environmentRotation = mat2(rotationCosine, rotationSine, -rotationSine, rotationCosine);
+  vec3 environmentNormal = vec3(environmentRotation * n.xz, n.y).xzy;
+  vec3 environmentReflection = vec3(environmentRotation * reflection.xz, reflection.y).xzy;
+#else
+  float maximumMipLevel = 9.0;
+  vec3 environmentNormal = n;
+  vec3 environmentReflection = reflection;
+#endif
+  float lod = pbrInfo.perceptualRoughness * maximumMipLevel;
   // retrieve a scale and bias to F0. See [1], Figure 3
   vec3 brdf = SRGBtoLINEAR(texture(pbr_brdfLUT,
     vec2(pbrInfo.NdotV, 1.0 - pbrInfo.perceptualRoughness))).rgb;
-  vec3 diffuseLight = SRGBtoLINEAR(texture(pbr_diffuseEnvSampler, n)).rgb;
+  vec3 diffuseLight = SRGBtoLINEAR(texture(pbr_diffuseEnvSampler, environmentNormal)).rgb;
 
 #ifdef USE_TEX_LOD
-  vec3 specularLight = SRGBtoLINEAR(texture(pbr_specularEnvSampler, reflection, lod)).rgb;
+  vec3 specularLight =
+    SRGBtoLINEAR(textureLod(pbr_specularEnvSampler, environmentReflection, lod)).rgb;
 #else
-  vec3 specularLight = SRGBtoLINEAR(texture(pbr_specularEnvSampler, reflection)).rgb;
+  vec3 specularLight = SRGBtoLINEAR(texture(pbr_specularEnvSampler, environmentReflection)).rgb;
 #endif
 
   vec3 diffuse = diffuseLight * pbrInfo.diffuseColor;
@@ -355,7 +367,11 @@ vec3 getIBLContribution(PBRInfo pbrInfo, vec3 n, vec3 reflection)
   diffuse *= pbrMaterial.scaleIBLAmbient.x;
   specular *= pbrMaterial.scaleIBLAmbient.y;
 
+#ifdef USE_SCENE_ENVIRONMENT
+  return (diffuse + specular) * max(pbrScene.environmentIntensity, 0.0);
+#else
   return diffuse + specular;
+#endif
 }
 #endif
 
@@ -452,6 +468,49 @@ vec3 getVolumeAttenuation(float thickness)
     max(pbrMaterial.attenuationDistance, 0.0001);
   return exp(-attenuationCoefficient * thickness);
 }
+
+#ifdef USE_TRANSMISSION_FRAMEBUFFER
+vec3 getTransmittedSceneColor(
+  vec3 position,
+  vec3 normal,
+  vec3 viewDirection,
+  float thickness,
+  float perceptualRoughness
+)
+{
+  vec3 refractionDirection = refract(
+    -viewDirection,
+    normal,
+    1.0 / max(pbrMaterial.ior, 1.0)
+  );
+  vec3 refractedPosition = position + refractionDirection * thickness;
+  vec4 clipPosition = pbrScene.projectionMatrix *
+    pbrScene.viewMatrix * vec4(refractedPosition, 1.0);
+  vec2 textureCoordinate = clipPosition.xy / max(clipPosition.w, 0.0001) * 0.5 + 0.5;
+  textureCoordinate = clamp(textureCoordinate, vec2(0.001), vec2(0.999));
+
+  vec2 blurRadius = perceptualRoughness * perceptualRoughness * 8.0 /
+    max(pbrScene.framebufferSize, vec2(1.0));
+  vec3 sceneColor = texture(pbr_transmissionFramebufferSampler, textureCoordinate).rgb * 0.4;
+  sceneColor += texture(
+    pbr_transmissionFramebufferSampler,
+    textureCoordinate + vec2(blurRadius.x, 0.0)
+  ).rgb * 0.15;
+  sceneColor += texture(
+    pbr_transmissionFramebufferSampler,
+    textureCoordinate - vec2(blurRadius.x, 0.0)
+  ).rgb * 0.15;
+  sceneColor += texture(
+    pbr_transmissionFramebufferSampler,
+    textureCoordinate + vec2(0.0, blurRadius.y)
+  ).rgb * 0.15;
+  sceneColor += texture(
+    pbr_transmissionFramebufferSampler,
+    textureCoordinate - vec2(0.0, blurRadius.y)
+  ).rgb * 0.15;
+  return pow(max(sceneColor, vec3(0.0)), vec3(2.2));
+}
+#endif
 
 PBRInfo createClearcoatPBRInfo(PBRInfo basePBRInfo, vec3 clearcoatNormal, float clearcoatRoughness)
 {
@@ -1080,7 +1139,22 @@ vec4 pbr_filterColor(vec4 vertexColor)
     color += emissive * pbrMaterial.emissiveStrength;
 
     if (transmission > 0.0) {
+#ifdef USE_TRANSMISSION_FRAMEBUFFER
+      float dielectricFresnel = getDielectricF0(pbrMaterial.ior);
+      float transmissionFresnel = dielectricFresnel +
+        (1.0 - dielectricFresnel) * pow(1.0 - NdotV, 5.0);
+      vec3 transmittedColor = getTransmittedSceneColor(
+        pbr_vPosition,
+        n,
+        v,
+        thickness,
+        perceptualRoughness
+      );
+      color += transmittedColor * getVolumeAttenuation(thickness) *
+        transmission * (1.0 - transmissionFresnel);
+#else
       color = mix(color, color * getVolumeAttenuation(thickness), transmission);
+#endif
     }
 
     // This section uses mix to override final color for reference app visualization
@@ -1101,7 +1175,11 @@ vec4 pbr_filterColor(vec4 vertexColor)
 
   }
 
+#ifdef USE_TRANSMISSION_FRAMEBUFFER
+  float alpha = clamp(baseColor.a, 0.0, 1.0);
+#else
   float alpha = clamp(baseColor.a * (1.0 - transmission), 0.0, 1.0);
+#endif
   return vec4(pow(color,vec3(1.0/2.2)), alpha);
 }
 `;

--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-wgsl.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-wgsl.ts
@@ -490,8 +490,24 @@ fn getClearcoatNormal(tbn: mat3x3f, baseNormal: vec3f, uv: vec2f) -> vec3f
 #ifdef USE_IBL
 fn getIBLContribution(pbrInfo: PBRInfo, n: vec3f, reflection: vec3f) -> vec3f
 {
-  let mipCount: f32 = 9.0; // resolution of 512x512
-  let lod: f32 = pbrInfo.perceptualRoughness * mipCount;
+#ifdef USE_SCENE_ENVIRONMENT
+  let maximumMipLevel = max(pbrScene.environmentMipCount - 1.0, 0.0);
+  let rotationSine = sin(pbrScene.environmentRotation);
+  let rotationCosine = cos(pbrScene.environmentRotation);
+  let environmentRotation = mat2x2f(
+    vec2f(rotationCosine, rotationSine),
+    vec2f(-rotationSine, rotationCosine)
+  );
+  let rotatedNormal = environmentRotation * n.xz;
+  let rotatedReflection = environmentRotation * reflection.xz;
+  let environmentNormal = vec3f(rotatedNormal.x, n.y, rotatedNormal.y);
+  let environmentReflection = vec3f(rotatedReflection.x, reflection.y, rotatedReflection.y);
+#else
+  let maximumMipLevel = 9.0;
+  let environmentNormal = n;
+  let environmentReflection = reflection;
+#endif
+  let lod = pbrInfo.perceptualRoughness * maximumMipLevel;
   // retrieve a scale and bias to F0. See [1], Figure 3
   let brdf = SRGBtoLINEAR(
     textureSampleLevel(
@@ -503,13 +519,18 @@ fn getIBLContribution(pbrInfo: PBRInfo, n: vec3f, reflection: vec3f) -> vec3f
   ).rgb;
   let diffuseLight =
     SRGBtoLINEAR(
-      textureSampleLevel(pbr_diffuseEnvSampler, pbr_diffuseEnvSamplerSampler, n, 0.0)
+      textureSampleLevel(
+        pbr_diffuseEnvSampler,
+        pbr_diffuseEnvSamplerSampler,
+        environmentNormal,
+        0.0
+      )
     ).rgb;
   var specularLight = SRGBtoLINEAR(
     textureSampleLevel(
       pbr_specularEnvSampler,
       pbr_specularEnvSamplerSampler,
-      reflection,
+      environmentReflection,
       0.0
     )
   ).rgb;
@@ -518,7 +539,7 @@ fn getIBLContribution(pbrInfo: PBRInfo, n: vec3f, reflection: vec3f) -> vec3f
     textureSampleLevel(
       pbr_specularEnvSampler,
       pbr_specularEnvSamplerSampler,
-      reflection,
+      environmentReflection,
       lod
     )
   ).rgb;
@@ -528,7 +549,11 @@ fn getIBLContribution(pbrInfo: PBRInfo, n: vec3f, reflection: vec3f) -> vec3f
   let specular =
     specularLight * (pbrInfo.specularColor * brdf.x + brdf.y) * pbrMaterial.scaleIBLAmbient.y;
 
+#ifdef USE_SCENE_ENVIRONMENT
+  return (diffuse + specular) * max(pbrScene.environmentIntensity, 0.0);
+#else
   return diffuse + specular;
+#endif
 }
 #endif
 
@@ -621,6 +646,62 @@ fn getVolumeAttenuation(thickness: f32) -> vec3f {
     max(pbrMaterial.attenuationDistance, 0.0001);
   return exp(-attenuationCoefficient * thickness);
 }
+
+#ifdef USE_TRANSMISSION_FRAMEBUFFER
+fn getTransmittedSceneColor(
+  position: vec3f,
+  normal: vec3f,
+  viewDirection: vec3f,
+  thickness: f32,
+  perceptualRoughness: f32
+) -> vec3f {
+  let refractionDirection = refract(
+    -viewDirection,
+    normal,
+    1.0 / max(pbrMaterial.ior, 1.0)
+  );
+  let refractedPosition = position + refractionDirection * thickness;
+  let clipPosition = pbrScene.projectionMatrix *
+    pbrScene.viewMatrix * vec4f(refractedPosition, 1.0);
+  var textureCoordinate = clipPosition.xy / max(clipPosition.w, 0.0001) * 0.5 + 0.5;
+  textureCoordinate.y = 1.0 - textureCoordinate.y;
+  textureCoordinate = clamp(textureCoordinate, vec2f(0.001), vec2f(0.999));
+
+  let blurRadius = perceptualRoughness * perceptualRoughness * 8.0 /
+    max(pbrScene.framebufferSize, vec2f(1.0));
+  var sceneColor = textureSampleLevel(
+    pbr_transmissionFramebufferSampler,
+    pbr_transmissionFramebufferSamplerSampler,
+    textureCoordinate,
+    0.0
+  ).rgb * 0.4;
+  sceneColor += textureSampleLevel(
+    pbr_transmissionFramebufferSampler,
+    pbr_transmissionFramebufferSamplerSampler,
+    textureCoordinate + vec2f(blurRadius.x, 0.0),
+    0.0
+  ).rgb * 0.15;
+  sceneColor += textureSampleLevel(
+    pbr_transmissionFramebufferSampler,
+    pbr_transmissionFramebufferSamplerSampler,
+    textureCoordinate - vec2f(blurRadius.x, 0.0),
+    0.0
+  ).rgb * 0.15;
+  sceneColor += textureSampleLevel(
+    pbr_transmissionFramebufferSampler,
+    pbr_transmissionFramebufferSamplerSampler,
+    textureCoordinate + vec2f(0.0, blurRadius.y),
+    0.0
+  ).rgb * 0.15;
+  sceneColor += textureSampleLevel(
+    pbr_transmissionFramebufferSampler,
+    pbr_transmissionFramebufferSamplerSampler,
+    textureCoordinate - vec2f(0.0, blurRadius.y),
+    0.0
+  ).rgb * 0.15;
+  return pow(max(sceneColor, vec3f(0.0)), vec3f(2.2));
+}
+#endif
 
 fn createClearcoatPBRInfo(
   basePBRInfo: PBRInfo,
@@ -1311,7 +1392,22 @@ fn pbr_filterColor(vertexColor: vec4<f32>) -> vec4<f32> {
     color += emissive * pbrMaterial.emissiveStrength;
 
     if (transmission > 0.0) {
+      #ifdef USE_TRANSMISSION_FRAMEBUFFER
+      let dielectricFresnel = getDielectricF0(pbrMaterial.ior);
+      let transmissionFresnel = dielectricFresnel +
+        (1.0 - dielectricFresnel) * pow(1.0 - NdotV, 5.0);
+      let transmittedColor = getTransmittedSceneColor(
+        fragmentInputs.pbr_vPosition,
+        n,
+        v,
+        thickness,
+        perceptualRoughness
+      );
+      color += transmittedColor * getVolumeAttenuation(thickness) *
+        transmission * (1.0 - transmissionFresnel);
+      #else
       color = mix(color, color * getVolumeAttenuation(thickness), transmission);
+      #endif
     }
 
     // This section uses mix to override final color for reference app visualization
@@ -1331,7 +1427,11 @@ fn pbr_filterColor(vertexColor: vec4<f32>) -> vec4<f32> {
     #endif
   }
 
+  #ifdef USE_TRANSMISSION_FRAMEBUFFER
+  let alpha = clamp(baseColor.a, 0.0, 1.0);
+  #else
   let alpha = clamp(baseColor.a * (1.0 - transmission), 0.0, 1.0);
+  #endif
   return vec4<f32>(pow(color, vec3<f32>(1.0 / 2.2)), alpha);
 }
 `;

--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-scene.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-scene.ts
@@ -16,6 +16,7 @@ export type PBRSceneUniforms = {
   toneMapMode?: number;
   environmentIntensity?: number;
   environmentRotation?: number;
+  environmentMipCount?: number;
   framebufferSize?: NumberArray2;
   viewMatrix?: NumberArray16;
   projectionMatrix?: NumberArray16;
@@ -31,6 +32,7 @@ layout(std140) uniform pbrSceneUniforms {
   int toneMapMode;
   float environmentIntensity;
   float environmentRotation;
+  float environmentMipCount;
   vec2 framebufferSize;
   mat4 viewMatrix;
   mat4 projectionMatrix;
@@ -47,6 +49,7 @@ struct pbrSceneUniforms {
   toneMapMode: i32,
   environmentIntensity: f32,
   environmentRotation: f32,
+  environmentMipCount: f32,
   framebufferSize: vec2<f32>,
   viewMatrix: mat4x4<f32>,
   projectionMatrix: mat4x4<f32>
@@ -75,6 +78,7 @@ export const pbrScene = {
     toneMapMode: 'i32',
     environmentIntensity: 'f32',
     environmentRotation: 'f32',
+    environmentMipCount: 'f32',
     framebufferSize: 'vec2<f32>',
     viewMatrix: 'mat4x4<f32>',
     projectionMatrix: 'mat4x4<f32>'
@@ -84,6 +88,7 @@ export const pbrScene = {
     toneMapMode: 2,
     environmentIntensity: 1,
     environmentRotation: Math.PI * 0.5,
+    environmentMipCount: 1,
     framebufferSize: [1, 1],
     viewMatrix: IDENTITY_MATRIX,
     projectionMatrix: IDENTITY_MATRIX

--- a/modules/shadertools/test/modules/lighting/pbr-scene.spec.ts
+++ b/modules/shadertools/test/modules/lighting/pbr-scene.spec.ts
@@ -2,19 +2,20 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {makeShaderBlockLayout} from '@luma.gl/core';
 import {
   getShaderModuleUniformBlockFields,
   getShaderModuleUniformLayoutValidationResult,
   pbrScene
 } from '@luma.gl/shadertools';
+import test from 'test/utils/vitest-tape';
 
 const EXPECTED_UNIFORM_NAMES = [
   'exposure',
   'toneMapMode',
   'environmentIntensity',
   'environmentRotation',
+  'environmentMipCount',
   'framebufferSize',
   'viewMatrix',
   'projectionMatrix'
@@ -47,9 +48,20 @@ test('shadertools#pbrScene exposes stable uniform layout metadata', testCase => 
   );
 
   const shaderBlockLayout = makeShaderBlockLayout(pbrScene.uniformTypes);
-  testCase.ok(
-    shaderBlockLayout.byteLength >= 160,
-    'uniform block is large enough for matrices and scene controls'
+  testCase.equal(
+    shaderBlockLayout.byteLength,
+    160,
+    'scene controls preserve the packed block size'
+  );
+  testCase.equal(
+    shaderBlockLayout.fields.environmentMipCount.offset,
+    4,
+    'environment mip count occupies the previously unused scalar position'
+  );
+  testCase.equal(
+    shaderBlockLayout.fields.framebufferSize.offset,
+    6,
+    'framebuffer dimensions retain vector alignment after the mip count'
   );
   testCase.deepEqual(
     Object.keys(shaderBlockLayout.fields),


### PR DESCRIPTION
## Goals

Improve glTF/PBR visual fidelity through shared, physically grounded environment lighting and scene-color transmission without adding renderer, shader, or BRDF ownership to ANARI or the stable engine.

## Changes

### Shared physical shading

- Extend canonical GLSL and WGSL PBR shaders with screen-space Snell refraction, Schlick/Fresnel transmission weighting, Beer-Lambert thickness/attenuation, roughness-aware five-tap scene-color filtering, and correct opaque transmission alpha.
- Sample roughness-prefiltered specular environment mip levels using the actual cubemap mip count instead of a hard-coded 512px assumption; apply environment rotation and radiance intensity consistently on WebGL and WebGPU.
- Add the scene environment mip count to the existing 160-byte portable uniform block without growing it or breaking legacy glTF PBR shader composition.

### Experimental renderer and environment resources

- Add reusable `PBREnvironmentGenerator`, `PreparedPBREnvironment`, and `preparePBREnvironment` APIs that integrate an equirectangular source into a GGX-importance-sampled specular cubemap with a complete roughness mip chain, cosine-weighted diffuse irradiance cubemap, and split-sum BRDF lookup texture.
- Preserve linear/HDR color using filterable `rgba16float` when supported; fall back to `rgba8unorm`, decode raw sRGB sources once, and avoid double-decoding hardware `*-srgb` texture formats.
- Automatically capture opaque scene color into a dedicated sampleable color/depth framebuffer before the final forward pass when a material uses transmission; exclude transmissive and blended surfaces from capture, specialize optional bindings per material, preserve final-pass draw statistics, and retain/resize/destroy owned targets safely.
- Add an optional `SceneRenderOptions.transmission` switch, preserve existing no-environment/no-transmission paths, retain instanced batching and transparent ordering, and keep deferred advanced-material fallback intact.
- Order scene and material shader modules correctly for strict WebGL GLSL declaration rules; replace unsupported GLSL ES bit reversal with a portable implementation.

## Verification

- `node_modules/.bin/tspc -b modules/anari/tsconfig.json --pretty false --force` — passed; compiles the complete ANARI, experimental, glTF, engine, shadertools, and core project-reference graph.
- `node_modules/.bin/vitest run --config /private/tmp/luma-pbr-environment-node-vitest.config.mjs modules/core/test modules/engine/test modules/shadertools/test modules/gltf/test modules/experimental/test modules/anari/test --maxWorkers=4` — **56 suites / 261 tests passed**.
- Native Metal-backed hardware WebGL **and** WebGPU Chromium integration — **4 suites / 15 tests passed**, covering transmitted opaque-backdrop pixel readback, opaque alpha, genuinely different roughness mip pixels, diffuse irradiance, BRDF lookup, raw-vs-hardware sRGB equivalence, generated IBL rendering, existing glTF models, deferred fallback, and ANARI rendering.
- Strict isolated Biome verification passed for all 11 changed files; actual three-way merge audit against the independent asset-fidelity and skin/morph tranches reports no conflicts.
- Normal `yarn lint fix`, `yarn build`, `yarn test-node`, and `yarn test` remain blocked in this pre-existing local checkout because the shared `@vis.gl/dev-tools` installation is version 1.0.2 and Yarn cannot resolve the repository-required `ocular-clean`/`ocular-test` tooling. Equivalent direct Biome, forced project-reference build, bounded cross-package node suites, and real hardware browser suites all pass.

## Architecture / Ownership

- `@luma.gl/shadertools` owns the canonical GLSL/WGSL BRDF, transmission, IBL sampling, and scene uniform layout.
- `@luma.gl/experimental/src/engine` owns the opinionated forward-renderer scene capture, environment GPU preparation, retained resources, and specialized pipelines.
- `@luma.gl/engine`, `@luma.gl/gltf`, and `@luma.gl/anari` gain no private rendering/shading implementation and no reverse dependency.
- This branch targets `master` directly and merges cleanly alongside the independent glTF asset-fidelity and deformation/animation PRs.

## Limitations

Transmission is an intentional single-layer, opaque-scene screen-space approximation with roughness-filtered samples; it does not claim full multi-bounce/path-traced refraction, nested transparent-object capture, or a production PMREM atlas.