### PR TITLE
docs(experimental): attribute RAPIDS-inspired GPU modules

### DIFF
--- a/docs/api-reference/experimental/geospatial.md
+++ b/docs/api-reference/experimental/geospatial.md
@@ -40,6 +40,18 @@ const compiled = graph.compile();
 The geospatial entry point is intentionally separate from the experimental root and standalone
 bundle. Importing the subpath is the explicit opt-in.
 
+## Attribution and licensing
+
+These geospatial operations are inspired by [NVIDIA RAPIDS cuSpatial](https://github.com/rapidsai/cuspatial)
+and the NVIDIA and RAPIDS contributors who pioneered GPU-accelerated spatial analytics. cuSpatial is
+distributed under the [Apache License 2.0](https://github.com/rapidsai/cuspatial/blob/branch-25.04/LICENSE).
+
+The luma.gl implementation is independently written TypeScript and WGSL for browser-native WebGPU;
+it does not copy or translate cuSpatial source code and remains
+[MIT-licensed](https://github.com/visgl/luma.gl/blob/master/LICENSE). Compatibility with selected
+documented mathematical conventions does not imply CUDA support, cuSpatial API compatibility,
+feature parity, NVIDIA affiliation, or NVIDIA endorsement.
+
 ## Coordinate and result formats
 
 Two packed position formats are accepted:

--- a/docs/api-reference/experimental/luproj.md
+++ b/docs/api-reference/experimental/luproj.md
@@ -13,6 +13,19 @@ strategy.
 That separation supports the wide range of coordinate systems handled by `@math.gl/proj4` without
 reimplementing every projection, datum, or coordinate-reference-system definition in WGSL.
 
+## Attribution and licensing
+
+luProj is inspired by
+[NVIDIA RAPIDS cuProj](https://github.com/rapidsai/cuspatial/tree/branch-25.04/cpp/cuproj), the
+coordinate-projection component of the archived cuSpatial project. cuProj and cuSpatial are
+distributed under the [Apache License 2.0](https://github.com/rapidsai/cuspatial/blob/branch-25.04/LICENSE).
+
+luProj is an independently written, [MIT-licensed](https://github.com/visgl/luma.gl/blob/master/LICENSE)
+vis.gl implementation. Its provider-driven adaptive polynomial patches and TypeScript/WGSL WebGPU
+execution do not copy or translate cuProj source code. It is not an API-compatible CUDA port, does
+not claim native GPU Float64 arithmetic or cuProj precision and feature parity, and is neither
+affiliated with nor endorsed by NVIDIA.
+
 ## Live CPU versus WebGPU benchmark
 
 This benchmark runs locally in your browser when you click the button. Every implementation receives

--- a/docs/api-reference/experimental/luxfilter.md
+++ b/docs/api-reference/experimental/luxfilter.md
@@ -100,9 +100,13 @@ selections can make large-scale exploratory analysis feel immediate. cuXfilter i
 the original [JavaScript Crossfilter](https://github.com/crossfilter/crossfilter); LuxFilter brings
 that family of ideas back into the browser with modern WebGPU execution.
 
-We gratefully acknowledge NVIDIA and the RAPIDS contributors for that pioneering work. LuxFilter is
-an independent luma.gl implementation, not a port of cuXfilter's Python code, a compatible API, or
-an NVIDIA/RAPIDS successor project.
+We gratefully acknowledge NVIDIA and the RAPIDS contributors for that pioneering work. cuXfilter
+is distributed under the
+[Apache License 2.0](https://github.com/rapidsai/cuxfilter/blob/main/LICENSE). LuxFilter is an
+independently written, [MIT-licensed](https://github.com/visgl/luma.gl/blob/master/LICENSE) vis.gl
+implementation; it does not copy or translate cuXfilter source code. It is not a CUDA port,
+compatible Python API, feature-parity claim, or NVIDIA/RAPIDS successor project, and is neither
+affiliated with nor endorsed by NVIDIA.
 
 The comparison below reflects the official cuXfilter
 [26.06 documentation](https://docs.rapids.ai/api/cuxfilter/stable/),

--- a/modules/experimental/src/geospatial/geospatial-utils.ts
+++ b/modules/experimental/src/geospatial/geospatial-utils.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuSpatial.
 
 import {type Binding, type Buffer} from '@luma.gl/core';
 import {Computation, DynamicBuffer} from '@luma.gl/engine';

--- a/modules/experimental/src/geospatial/gpu-haversine-distance.ts
+++ b/modules/experimental/src/geospatial/gpu-haversine-distance.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuSpatial.
 
 import {
   type GPUCommandGraph,

--- a/modules/experimental/src/geospatial/gpu-pairwise-point-distance.ts
+++ b/modules/experimental/src/geospatial/gpu-pairwise-point-distance.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuSpatial.
 
 import {
   type GPUCommandGraph,

--- a/modules/experimental/src/geospatial/gpu-pairwise-point-in-polygon.ts
+++ b/modules/experimental/src/geospatial/gpu-pairwise-point-in-polygon.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuSpatial.
 
 import {
   type GPUCommandGraph,

--- a/modules/experimental/src/geospatial/gpu-pairwise-point-linestring-nearest.ts
+++ b/modules/experimental/src/geospatial/gpu-pairwise-point-linestring-nearest.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuSpatial.
 
 import type {
   GPUCommandGraph,

--- a/modules/experimental/src/geospatial/gpu-pairwise-point-segment-distance.ts
+++ b/modules/experimental/src/geospatial/gpu-pairwise-point-segment-distance.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuSpatial.
 
 import {
   type GPUCommandGraph,

--- a/modules/experimental/src/geospatial/gpu-point-spatial-query.ts
+++ b/modules/experimental/src/geospatial/gpu-point-spatial-query.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuSpatial.
 
 import {type Binding, Buffer} from '@luma.gl/core';
 import {Computation, DynamicBuffer} from '@luma.gl/engine';

--- a/modules/experimental/src/geospatial/gpu-sinusoidal-projection.ts
+++ b/modules/experimental/src/geospatial/gpu-sinusoidal-projection.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuSpatial.
 
 import {
   type GPUCommandGraph,

--- a/modules/experimental/src/geospatial/gpu-spatial-query-types.ts
+++ b/modules/experimental/src/geospatial/gpu-spatial-query-types.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuSpatial.
 
 import type {GraphDataView} from '../gpu-primitives/gpu-command-graph';
 

--- a/modules/experimental/src/geospatial/index.ts
+++ b/modules/experimental/src/geospatial/index.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuSpatial.
 
 export type {
   GPUFloat32Positions,

--- a/modules/experimental/src/geospatial/types.ts
+++ b/modules/experimental/src/geospatial/types.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuSpatial.
 
 import type {GraphDataView, GraphVectorView} from '../gpu-primitives/gpu-command-graph';
 

--- a/modules/experimental/src/lugraph/README.md
+++ b/modules/experimental/src/lugraph/README.md
@@ -1,0 +1,17 @@
+# @luma.gl/experimental/lugraph
+
+`@luma.gl/experimental/lugraph` provides an optional, headless graph data model over existing,
+caller-owned GPU table vectors. Its current foundation preserves source and target vertex columns,
+optional edge weights and stable identifiers, property tables, and original chunk boundaries. It
+does not upload or copy source data, submit GPU work, render graphs, or provide a graph application.
+
+## Attribution and licensing
+
+The graph data model is inspired by [NVIDIA RAPIDS cuGraph](https://github.com/rapidsai/cugraph)
+and the NVIDIA and RAPIDS contributors advancing GPU graph analytics. cuGraph is distributed under
+the [Apache License 2.0](https://github.com/rapidsai/cugraph/blob/main/LICENSE).
+
+This module is an independently written, [MIT-licensed](https://github.com/visgl/luma.gl/blob/master/LICENSE)
+vis.gl implementation for browser-native WebGPU; it does not copy or translate cuGraph source code.
+It does not claim CUDA or cuGraph API compatibility, feature parity, NVIDIA affiliation, or NVIDIA
+endorsement.

--- a/modules/experimental/src/lugraph/index.ts
+++ b/modules/experimental/src/lugraph/index.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
 
 export {LuGraph} from './lu-graph';
 export type {LuGraphProps} from './lu-graph';

--- a/modules/experimental/src/lugraph/lu-graph-topology-internals.ts
+++ b/modules/experimental/src/lugraph/lu-graph-topology-internals.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
 
 import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';

--- a/modules/experimental/src/lugraph/lu-graph-topology.ts
+++ b/modules/experimental/src/lugraph/lu-graph-topology.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
 
 import type {Buffer} from '@luma.gl/core';
 import {DynamicBuffer} from '@luma.gl/engine';

--- a/modules/experimental/src/lugraph/lu-graph.ts
+++ b/modules/experimental/src/lugraph/lu-graph.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
 
 import type {GPURecordBatch, GPUTable, GPUVector} from '@luma.gl/tables';
 

--- a/modules/experimental/src/luproj/README.md
+++ b/modules/experimental/src/luproj/README.md
@@ -12,6 +12,18 @@ Float32 operations and origin-relative precision.
 This supports projection families understood by the provider without separately
 implementing every projection, datum, or coordinate reference system in WGSL.
 
+## Attribution and licensing
+
+luProj is inspired by
+[NVIDIA RAPIDS cuProj](https://github.com/rapidsai/cuspatial/tree/branch-25.04/cpp/cuproj), the
+projection component maintained in the archived cuSpatial repository. That upstream project is
+distributed under the [Apache License 2.0](https://github.com/rapidsai/cuspatial/blob/branch-25.04/LICENSE).
+
+This module is an independently written, [MIT-licensed](https://github.com/visgl/luma.gl/blob/master/LICENSE)
+vis.gl implementation; its TypeScript/WGSL adaptive-polynomial execution does not copy or translate
+cuProj source code. It does not claim CUDA API compatibility, native GPU Float64 arithmetic, cuProj
+feature or precision parity, NVIDIA affiliation, or NVIDIA endorsement.
+
 ## Compile and execute a projection
 
 ```ts

--- a/modules/experimental/src/luproj/benchmarks.ts
+++ b/modules/experimental/src/luproj/benchmarks.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuProj.
 
 export {runProjectionBenchmark} from './projection-benchmark';
 export type {

--- a/modules/experimental/src/luproj/gpu-projection-benchmark.ts
+++ b/modules/experimental/src/luproj/gpu-projection-benchmark.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuProj.
 
 import {Buffer, type Device, type QuerySet} from '@luma.gl/core';
 

--- a/modules/experimental/src/luproj/gpu-projection.ts
+++ b/modules/experimental/src/luproj/gpu-projection.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuProj.
 
 import {Buffer} from '@luma.gl/core';
 

--- a/modules/experimental/src/luproj/index.ts
+++ b/modules/experimental/src/luproj/index.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuProj.
 
 export type {
   CompileProjectionPlanOptions,

--- a/modules/experimental/src/luproj/projection-benchmark.ts
+++ b/modules/experimental/src/luproj/projection-benchmark.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuProj.
 
 import {
   compileProjectionPlan,

--- a/modules/experimental/src/luproj/projection-plan.ts
+++ b/modules/experimental/src/luproj/projection-plan.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuProj.
 
 import type {
   CompileProjectionPlanOptions,

--- a/modules/experimental/src/luproj/types.ts
+++ b/modules/experimental/src/luproj/types.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuProj.
 
 /** Two coordinates in a source or destination coordinate reference system. */
 export type ProjectionCoordinates = readonly [number, number];

--- a/modules/experimental/src/luproj/web-mercator.ts
+++ b/modules/experimental/src/luproj/web-mercator.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuProj.
 
 import type {ProjectionProvider} from './types';
 

--- a/modules/experimental/src/luxfilter/README.md
+++ b/modules/experimental/src/luxfilter/README.md
@@ -133,8 +133,13 @@ redraw only after a selection or layout changes.
 
 LuxFilter is inspired by [NVIDIA RAPIDS cuXfilter](https://github.com/rapidsai/cuxfilter) and the
 RAPIDS contributors who pioneered GPU-accelerated crossfiltering across coordinated views of large
-datasets. It independently adapts those interaction patterns to luma.gl and browser-native WebGPU;
-it is not a code port, compatible Python API, or NVIDIA/RAPIDS successor.
+datasets. cuXfilter is distributed under the
+[Apache License 2.0](https://github.com/rapidsai/cuxfilter/blob/main/LICENSE).
+
+LuxFilter is an independently written, [MIT-licensed](https://github.com/visgl/luma.gl/blob/master/LICENSE)
+vis.gl implementation for browser-native WebGPU; it does not copy or translate cuXfilter source
+code. It is not a CUDA port, compatible Python API, feature-parity claim, or NVIDIA/RAPIDS
+successor, and is neither affiliated with nor endorsed by NVIDIA.
 
 The [LuxFilter API reference](/docs/api-reference/experimental/luxfilter) includes the live
 Million-Row Crossfilter Explorer and a detailed feature comparison with cuXfilter's final

--- a/modules/experimental/src/luxfilter/gpu-selection.ts
+++ b/modules/experimental/src/luxfilter/gpu-selection.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuXfilter.
 
 import {Buffer, type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';

--- a/modules/experimental/src/luxfilter/index.ts
+++ b/modules/experimental/src/luxfilter/index.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuXfilter.
 
 export {LuxFilterSelection} from './gpu-selection';
 export type {

--- a/modules/experimental/src/luxfilter/lux-filter.ts
+++ b/modules/experimental/src/luxfilter/lux-filter.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuXfilter.
 
 import {
   GPUCommandGraph,

--- a/test/examples/rapids-attribution.node.spec.ts
+++ b/test/examples/rapids-attribution.node.spec.ts
@@ -1,0 +1,94 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {readdirSync, readFileSync} from 'node:fs';
+import {describe, expect, test} from 'vitest';
+
+type RapidsModuleAttribution = {
+  directory: string;
+  documentation: string[];
+  project: string;
+  repository: string;
+};
+
+const RAPIDS_MODULE_ATTRIBUTIONS: RapidsModuleAttribution[] = [
+  {
+    directory: 'geospatial',
+    documentation: ['docs/api-reference/experimental/geospatial.md'],
+    project: 'cuSpatial',
+    repository: 'https://github.com/rapidsai/cuspatial'
+  },
+  {
+    directory: 'luproj',
+    documentation: [
+      'docs/api-reference/experimental/luproj.md',
+      'modules/experimental/src/luproj/README.md'
+    ],
+    project: 'cuProj',
+    repository: 'https://github.com/rapidsai/cuspatial/tree/branch-25.04/cpp/cuproj'
+  },
+  {
+    directory: 'luxfilter',
+    documentation: [
+      'docs/api-reference/experimental/luxfilter.md',
+      'modules/experimental/src/luxfilter/README.md'
+    ],
+    project: 'cuXfilter',
+    repository: 'https://github.com/rapidsai/cuxfilter'
+  },
+  {
+    directory: 'lugraph',
+    documentation: ['modules/experimental/src/lugraph/README.md'],
+    project: 'cuGraph',
+    repository: 'https://github.com/rapidsai/cugraph'
+  }
+];
+
+const REPOSITORY_ROOT = new URL('../..', import.meta.url);
+
+describe('RAPIDS-inspired module provenance', () => {
+  for (const attribution of RAPIDS_MODULE_ATTRIBUTIONS) {
+    describe(attribution.directory, () => {
+      test('records independent MIT ownership and accurate upstream inspiration in every source file', () => {
+        const sourceDirectory = new URL(
+          `modules/experimental/src/${attribution.directory}/`,
+          REPOSITORY_ROOT
+        );
+        const sourceFiles = readdirSync(sourceDirectory).filter(fileName =>
+          fileName.endsWith('.ts')
+        );
+
+        expect(sourceFiles.length).toBeGreaterThan(0);
+
+        for (const sourceFile of sourceFiles) {
+          const source = readFileSync(new URL(sourceFile, sourceDirectory), 'utf8');
+
+          expect(source.split('\n').slice(0, 4), sourceFile).toEqual([
+            '// luma.gl',
+            '// SPDX-License-Identifier: MIT',
+            '// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors',
+            `// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS ${attribution.project}.`
+          ]);
+        }
+      });
+
+      test('distinguishes upstream Apache licensing from the independent MIT implementation', () => {
+        for (const documentationPath of attribution.documentation) {
+          const documentation = readFileSync(new URL(documentationPath, REPOSITORY_ROOT), 'utf8');
+
+          expect(documentation, documentationPath).toContain(
+            `NVIDIA RAPIDS ${attribution.project}`
+          );
+          expect(documentation, documentationPath).toContain(attribution.repository);
+          expect(documentation, documentationPath).toContain('Apache License 2.0');
+          expect(documentation, documentationPath).toContain('MIT-licensed');
+          expect(documentation, documentationPath).toMatch(
+            /do(?:es)? not copy or translate\s+\S+\s+source\s+code/
+          );
+          expect(documentation, documentationPath).toMatch(/endorse(?:d|ment)/);
+        }
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Goals

- Credit the NVIDIA RAPIDS projects that inspired luma.gl's existing GPU analytics modules.
- Keep independently written TypeScript and WGSL accurately licensed under MIT without inventing NVIDIA ownership or Apache obligations.

## Changes

- Add machine-readable SPDX license, vis.gl copyright, and RAPIDS provenance comments to every merged geospatial, luProj, LuxFilter, and luGraph production source file.
- Document the distinct upstream Apache-2.0 licenses, independent MIT implementations, and absence of NVIDIA endorsement in the canonical module documentation and packaged READMEs.
- Add the missing luGraph package README for the already-merged headless data model.
- Add regression tests covering every affected production file and module attribution.
- Preserve all implementation bodies and package dependency boundaries.

## Verification

- `nvm use`: passed, Node 22.22.1.
- `yarn install`: attempted; the configured package firewall returned HTTP 403 for several already-available dependencies, so a copy-on-write clone of an existing valid workspace installation was used instead.
- `yarn lint fix`: passed, 1,589 files checked and lockfile validated.
- `yarn build`: passed across all workspace packages.
- `yarn test-node`: passed, 144 files and 786 tests, plus one intentionally skipped file/test.
- Focused provenance/documentation regression suites: passed, four files and 20 tests.
- `yarn test`: node stage passes; the local Playwright headless stage intermittently loses its Chromium/WebGPU connection, including under serialized CI-mode settings. GitHub Actions remains the authoritative full-browser verification.
- `yarn website:build`: passed; generated and validated 473 raw documentation pages.
- `(cd website && yarn build)`: passed; generated and validated the production documentation build.

## Risks and follow-up

- These files are independently authored: adding Apache-2.0 to their SPDX license expressions or claiming NVIDIA copyright would be incorrect.
- Existing unrelated FXAA code appears to mix NVIDIA BSD and Cesium Apache provenance while declaring MIT; this needs a separate focused license review.
- Existing spatial-atlas sample and mirror provenance also need a separate dataset-attribution review.
