### PR TITLE
feat(gltf): ship production-ready automatic skinning and animation playback

### DIFF
--- a/examples/showcase/anari/gltf-to-anari.ts
+++ b/examples/showcase/anari/gltf-to-anari.ts
@@ -15,6 +15,7 @@ import {
   getTextureTransformSlotDefinitions,
   parseGLTFAnimations,
   parseGLTFLights,
+  resolveGLTFSkinIndex,
   resolveTextureCoordinateSet,
   resolveTextureTransform
 } from '@luma.gl/gltf';
@@ -104,7 +105,7 @@ export async function makeANARIJSONSceneFromGLTF(
   }
   state.scene.lights = makeImportedLights(gltf, state);
 
-  const materialIdentifiers = gltf.materials.map(material =>
+  const materialIdentifiers = (gltf.materials || []).map(material =>
     state.materialIdentifiers.get(material)
   );
   const samplerIdentifiers: Record<string, string> = {};
@@ -123,7 +124,7 @@ export async function makeANARIJSONSceneFromGLTF(
   const clips = makeANARIAnimationClipsFromGLTF(parseGLTFAnimations(gltf), {
     nodeIdentifiers: state.nodeIdentifiers,
     materialIdentifiers,
-    materialAlphaModes: gltf.materials.map(material =>
+    materialAlphaModes: (gltf.materials || []).map(material =>
       material.alphaMode === 'BLEND' ? 'BLEND' : material.alphaMode === 'MASK' ? 'MASK' : 'OPAQUE'
     ),
     samplerIdentifiers
@@ -299,7 +300,7 @@ function getSurfaceIdentifier(
     return undefined;
   }
 
-  const cacheKey = `${meshIdentifier}:${primitiveIndex}${primitive.targets?.length ? `:${node.id}` : ''}`;
+  const cacheKey = `${meshIdentifier}:${primitiveIndex}${primitive.targets?.length || node.skin !== undefined ? `:${node.id}` : ''}`;
   let surfaceIdentifier = state.surfaceIdentifiers.get(cacheKey);
   if (surfaceIdentifier) {
     return surfaceIdentifier;
@@ -373,8 +374,25 @@ function getSurfaceIdentifier(
   }
 
   const material = getMaterialIdentifier(primitive.material, state);
+  const sourceSkin =
+    node.skin === undefined
+      ? undefined
+      : state.gltf.skins?.[resolveGLTFSkinIndex(state.gltf, node.skin)];
+  const skin = sourceSkin
+    ? {
+        node: node.id,
+        joints: sourceSkin.joints.map(jointIndex => state.gltf.nodes[jointIndex].id),
+        ...(sourceSkin.inverseBindMatrices?.value
+          ? {inverseBindMatrices: Array.from(sourceSkin.inverseBindMatrices.value)}
+          : {})
+      }
+    : undefined;
   state.scene.geometries[surfaceIdentifier] = geometry;
-  state.scene.surfaces[surfaceIdentifier] = {geometry: surfaceIdentifier, material};
+  state.scene.surfaces[surfaceIdentifier] = {
+    geometry: surfaceIdentifier,
+    material,
+    ...(skin ? {skin} : {})
+  };
   state.surfaceIdentifiers.set(cacheKey, surfaceIdentifier);
   return surfaceIdentifier;
 }

--- a/examples/showcase/anari/playground-scene.ts
+++ b/examples/showcase/anari/playground-scene.ts
@@ -2,6 +2,7 @@ import {
   type ANARIAnimationClipDescription,
   type ANARIAnimationNodeDescription,
   type ANARIAnimationPlaybackDescription,
+  type ANARIAnimationSkinDescription,
   type ANARICameraParameters,
   type ANARICameraSubtype,
   type ANARIDevice,
@@ -110,6 +111,7 @@ export type JSONTextureDeclaration = {
 export type JSONSurfaceDeclaration = {
   geometry: string;
   material: string;
+  skin?: ANARIAnimationSkinDescription;
 };
 
 export type JSONGroupDeclaration = {
@@ -299,6 +301,7 @@ export function createANARIJSONScene(
   const textures: Texture[] = [];
   const materials = new Map<string, ANARIMaterial>();
   const surfaces = new Map<string, ANARISurface>();
+  const skins = new Map<ANARISurface, ANARIAnimationSkinDescription>();
   const lights = new Map<string, ANARILight>();
   const groups = new Map<string, ANARIGroup>();
   const instances = new Map<string, ANARIInstance>();
@@ -426,7 +429,17 @@ export function createANARIJSONScene(
   for (const [identifier, declaration] of Object.entries(scene.surfaces)) {
     const geometry = resolveReference(geometries, declaration.geometry, 'geometry');
     const material = resolveReference(materials, declaration.material, 'material');
-    surfaces.set(identifier, device.newSurface({geometry, material}));
+    const surface = device.newSurface({
+      geometry,
+      material,
+      ...(declaration.skin
+        ? {skin: {jointMatrices: new Float32Array(declaration.skin.joints.length * 16)}}
+        : {})
+    });
+    surfaces.set(identifier, surface);
+    if (declaration.skin) {
+      skins.set(surface, declaration.skin);
+    }
   }
 
   for (const declaration of scene.lights || []) {
@@ -525,9 +538,18 @@ export function createANARIJSONScene(
   assertSubtype('renderer', rendererSubtype, RENDERER_SUBTYPES);
   const renderer = device.newRenderer(rendererSubtype, rendererParameters);
   const frame = device.newFrame({world, camera, renderer});
-  const animations = scene.clips?.length
-    ? makeANARIAnimationScene(scene, {instances, geometries, materials, samplers, lights, camera})
-    : undefined;
+  const animations =
+    scene.clips?.length || skins.size > 0
+      ? makeANARIAnimationScene(scene, {
+          instances,
+          geometries,
+          materials,
+          samplers,
+          lights,
+          camera,
+          skins
+        })
+      : undefined;
 
   return {
     frame,

--- a/examples/showcase/anari/public/gltf/ASSET-LICENSE.md
+++ b/examples/showcase/anari/public/gltf/ASSET-LICENSE.md
@@ -6,6 +6,7 @@ These example assets are distributed under the Creative Commons Zero (CC0 1.0) p
 - `AnimatedMorphCube.glb` — Animated Morph Cube by Microsoft.
 - `AntiqueCamera.glb` — Antique Camera by Maximillan Kamps.
 - `Lantern.glb` — Lantern by sbtron and Frank Galligan.
+- `SimpleSkin.gltf` — Simple Skin by Marco Hutter.
 - `ToyCar.glb` — Toy Car by Guido Odendahl and Eric Chadwick.
 
 The files originate from the Khronos Group glTF Sample Assets collection:

--- a/examples/showcase/anari/public/gltf/SimpleSkin.gltf
+++ b/examples/showcase/anari/public/gltf/SimpleSkin.gltf
@@ -1,0 +1,131 @@
+{
+  "scene" : 0,
+  "scenes" : [ {
+    "nodes" : [ 0, 1 ]
+  } ],
+
+  "nodes" : [ {
+    "skin" : 0,
+    "mesh" : 0
+  }, {
+    "children" : [ 2 ]
+  }, {
+    "translation" : [ 0.0, 1.0, 0.0 ],
+    "rotation" : [ 0.0, 0.0, 0.0, 1.0 ]
+  } ],
+
+  "meshes" : [ {
+    "primitives" : [ {
+      "attributes" : {
+        "POSITION" : 1,
+        "JOINTS_0" : 2,
+        "WEIGHTS_0" : 3
+      },
+      "indices" : 0
+    } ]
+  } ],
+
+  "skins" : [ {
+    "inverseBindMatrices" : 4,
+    "joints" : [ 1, 2 ]
+  } ],
+
+  "animations" : [ {
+    "channels" : [ {
+      "sampler" : 0,
+      "target" : {
+        "node" : 2,
+        "path" : "rotation"
+      }
+    } ],
+    "samplers" : [ {
+      "input" : 5,
+      "interpolation" : "LINEAR",
+      "output" : 6
+    } ]
+  } ],
+
+  "buffers" : [ {
+    "uri" : "data:application/gltf-buffer;base64,AAABAAMAAAADAAIAAgADAAUAAgAFAAQABAAFAAcABAAHAAYABgAHAAkABgAJAAgAAAAAvwAAAAAAAAAAAAAAPwAAAAAAAAAAAAAAvwAAAD8AAAAAAAAAPwAAAD8AAAAAAAAAvwAAgD8AAAAAAAAAPwAAgD8AAAAAAAAAvwAAwD8AAAAAAAAAPwAAwD8AAAAAAAAAvwAAAEAAAAAAAAAAPwAAAEAAAAAA",
+    "byteLength" : 168
+  }, {
+    "uri" : "data:application/gltf-buffer;base64,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAABAPwAAgD4AAAAAAAAAAAAAQD8AAIA+AAAAAAAAAAAAAAA/AAAAPwAAAAAAAAAAAAAAPwAAAD8AAAAAAAAAAAAAgD4AAEA/AAAAAAAAAAAAAIA+AABAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAA=",
+    "byteLength" : 320
+  }, {
+    "uri" : "data:application/gltf-buffer;base64,AACAPwAAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAAAAAAAAACAPwAAgD8AAAAAAAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAIC/AAAAAAAAgD8=",
+    "byteLength" : 128
+  }, {
+    "uri" : "data:application/gltf-buffer;base64,AAAAAAAAAD8AAIA/AADAPwAAAEAAACBAAABAQAAAYEAAAIBAAACQQAAAoEAAALBAAAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAkxjEPkSLbD8AAAAAAAAAAPT9ND/0/TQ/AAAAAAAAAAD0/TQ/9P00PwAAAAAAAAAAkxjEPkSLbD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAkxjEvkSLbD8AAAAAAAAAAPT9NL/0/TQ/AAAAAAAAAAD0/TS/9P00PwAAAAAAAAAAkxjEvkSLbD8AAAAAAAAAAAAAAAAAAIA/",
+    "byteLength" : 240
+  } ],
+
+  "bufferViews" : [ {
+    "buffer" : 0,
+    "byteLength" : 48,
+    "target" : 34963
+  }, {
+    "buffer" : 0,
+    "byteOffset" : 48,
+    "byteLength" : 120,
+    "target" : 34962
+  }, {
+    "buffer" : 1,
+    "byteLength" : 320,
+    "byteStride" : 16
+  }, {
+    "buffer" : 2,
+    "byteLength" : 128
+  }, {
+    "buffer" : 3,
+    "byteLength" : 240
+  } ],
+
+  "accessors" : [ {
+    "bufferView" : 0,
+    "componentType" : 5123,
+    "count" : 24,
+    "type" : "SCALAR"
+  }, {
+    "bufferView" : 1,
+    "componentType" : 5126,
+    "count" : 10,
+    "type" : "VEC3",
+    "max" : [ 0.5, 2.0, 0.0 ],
+    "min" : [ -0.5, 0.0, 0.0 ]
+  }, {
+    "bufferView" : 2,
+    "componentType" : 5123,
+    "count" : 10,
+    "type" : "VEC4"
+  }, {
+    "bufferView" : 2,
+    "byteOffset" : 160,
+    "componentType" : 5126,
+    "count" : 10,
+    "type" : "VEC4"
+  }, {
+    "bufferView" : 3,
+    "componentType" : 5126,
+    "count" : 2,
+    "type" : "MAT4"
+  }, {
+    "bufferView" : 4,
+    "componentType" : 5126,
+    "count" : 12,
+    "type" : "SCALAR",
+    "max" : [ 5.5 ],
+    "min" : [ 0.0 ]
+  }, {
+    "bufferView" : 4,
+    "byteOffset" : 48,
+    "componentType" : 5126,
+    "count" : 12,
+    "type" : "VEC4",
+    "max" : [ 0.0, 0.0, 0.707, 1.0 ],
+    "min" : [ 0.0, 0.0, -0.707, 0.707 ]
+  } ],
+
+  "asset" : {
+    "version" : "2.0"
+  }
+}

--- a/modules/anari/src/animation-types.ts
+++ b/modules/anari/src/animation-types.ts
@@ -61,6 +61,16 @@ export type ANARIAnimationNodeDescription = {
   geometries?: readonly string[];
 };
 
+/** Format-independent hierarchy references required by one retained skinned surface. */
+export type ANARIAnimationSkinDescription = {
+  /** Animated transform node owning the skinned surface. */
+  node: string;
+  /** Animated joint nodes in their authored palette order. */
+  joints: readonly string[];
+  /** Optional column-major inverse bind matrix for each joint. */
+  inverseBindMatrices?: readonly number[];
+};
+
 /** Initial action settings for a serialized animated scene. */
 export type ANARIAnimationPlaybackDescription = {
   clip?: string;

--- a/modules/anari/src/gltf.ts
+++ b/modules/anari/src/gltf.ts
@@ -8,7 +8,8 @@ import {
   type AnimationLoopMode,
   AnimationMixer,
   AnimationTrack,
-  GroupNode
+  GroupNode,
+  updateSkinJointMatrices
 } from '@luma.gl/engine';
 import {
   type GLTFAnimation,
@@ -24,19 +25,22 @@ import type {
   ANARIInstance,
   ANARILight,
   ANARIMaterial,
-  ANARISampler
+  ANARISampler,
+  ANARISurface
 } from './anari-objects';
 import type {
   ANARICameraParameters,
   ANARIGeometryParameters,
   ANARILightParameters,
-  ANARIMaterialParameters
+  ANARIMaterialParameters,
+  ANARISurfaceParameters
 } from './anari-types';
 import type {
   ANARIAnimationClipDescription,
   ANARIAnimationInterpolation,
   ANARIAnimationNodeDescription,
   ANARIAnimationSceneDescription,
+  ANARIAnimationSkinDescription,
   ANARIAnimationTarget,
   ANARIAnimationTrackDescription
 } from './animation-types';
@@ -59,6 +63,7 @@ export type ANARIAnimationBindings = {
   samplers?: ReadonlyMap<string, ANARISampler>;
   lights?: ReadonlyMap<string, ANARILight>;
   camera?: ANARICamera;
+  skins?: ReadonlyMap<ANARISurface, ANARIAnimationSkinDescription>;
 };
 
 /** Shared mixer and orchestration helpers for one retained animated ANARI scene. */
@@ -80,7 +85,8 @@ type RetainedAnimationObject =
   | ANARIMaterial
   | ANARISampler
   | ANARILight
-  | ANARICamera;
+  | ANARICamera
+  | ANARISurface;
 
 const MATERIAL_PROPERTY_NAMES: Record<string, string> = {
   alphaCutoff: 'alphaCutoff',
@@ -399,6 +405,52 @@ export function makeANARIAnimationScene(
     }
   };
 
+  const queueSkinSurfaces = (): void => {
+    if (!bindings.skins?.size) {
+      return;
+    }
+
+    const worldMatrices = new Map<GroupNode, Matrix4>();
+    for (const [identifier, declaration] of Object.entries(nodeDeclarations)) {
+      if (!declaration.parent) {
+        nodes.get(identifier)?.preorderTraversal((node, {worldMatrix}) => {
+          if (node instanceof GroupNode) {
+            worldMatrices.set(node, new Matrix4(worldMatrix));
+          }
+        });
+      }
+    }
+
+    for (const [surface, description] of bindings.skins) {
+      const meshNode = nodes.get(description.node);
+      const joints = description.joints.flatMap(identifier => {
+        const joint = nodes.get(identifier);
+        return joint ? [joint] : [];
+      });
+      if (!meshNode || joints.length !== description.joints.length) {
+        continue;
+      }
+
+      const jointMatrices = updateSkinJointMatrices({
+        joints,
+        meshNode,
+        worldMatrices,
+        inverseBindMatrices: description.inverseBindMatrices
+      });
+      const existingMatrices = surface.getParameter('skin')?.jointMatrices;
+      if (
+        existingMatrices?.length === jointMatrices.length &&
+        jointMatrices.every((value, index) => value === existingMatrices[index])
+      ) {
+        continue;
+      }
+
+      const pendingValues = pendingObjects.get(surface) || {};
+      pendingValues['skin'] = {jointMatrices};
+      pendingObjects.set(surface, pendingValues);
+    }
+  };
+
   const flush = (): void => {
     if (hierarchyChanged) {
       for (const [identifier, declaration] of Object.entries(nodeDeclarations)) {
@@ -406,6 +458,7 @@ export function makeANARIAnimationScene(
           queueNodeInstances(identifier, new Matrix4());
         }
       }
+      queueSkinSurfaces();
       hierarchyChanged = false;
     }
 
@@ -428,6 +481,8 @@ export function makeANARIAnimationScene(
         (object as ANARILight).setParameters(changedValues as Partial<ANARILightParameters>);
       } else if (object.type === 'camera') {
         (object as ANARICamera).setParameters(changedValues as Partial<ANARICameraParameters>);
+      } else if (object.type === 'surface') {
+        (object as ANARISurface).setParameters(changedValues as Partial<ANARISurfaceParameters>);
       } else if (object.type === 'sampler') {
         (object as ANARISampler).setParameter(
           'transform',
@@ -440,6 +495,11 @@ export function makeANARIAnimationScene(
     }
     pendingObjects.clear();
   };
+
+  if (bindings.skins?.size) {
+    queueSkinSurfaces();
+    flush();
+  }
 
   return {
     mixer,

--- a/modules/anari/src/index.ts
+++ b/modules/anari/src/index.ts
@@ -51,6 +51,7 @@ export type {
   ANARIAnimationNodeDescription,
   ANARIAnimationPlaybackDescription,
   ANARIAnimationSceneDescription,
+  ANARIAnimationSkinDescription,
   ANARIAnimationTarget,
   ANARIAnimationTargetType,
   ANARIAnimationTextureTransform,

--- a/modules/anari/src/schemas.ts
+++ b/modules/anari/src/schemas.ts
@@ -290,8 +290,30 @@ export const ANARIRendererSchema = z
   .describe('Beauty or diagnostic renderer settings, including HDR and bloom controls.');
 
 export const ANARISurfaceSchema = z
-  .strictObject({geometry: identifierSchema, material: identifierSchema})
-  .describe('A named geometry/material pairing.');
+  .strictObject({
+    geometry: identifierSchema,
+    material: identifierSchema,
+    skin: z
+      .strictObject({
+        node: identifierSchema,
+        joints: z.array(identifierSchema).min(1),
+        inverseBindMatrices: z.array(numberSchema).optional()
+      })
+      .superRefine((skin, context) => {
+        if (
+          skin.inverseBindMatrices &&
+          skin.inverseBindMatrices.length !== skin.joints.length * 16
+        ) {
+          context.addIssue({
+            code: 'custom',
+            path: ['inverseBindMatrices'],
+            message: 'Each joint needs one inverse bind matrix.'
+          });
+        }
+      })
+      .optional()
+  })
+  .describe('A named geometry/material pairing with optional retained joint bindings.');
 
 export const ANARIGroupSchema = z
   .strictObject({
@@ -473,6 +495,24 @@ export const ANARISceneSchema = z
           path: ['surfaces', identifier, 'material'],
           message: `Unknown material "${surface.material}".`
         });
+      }
+      if (surface.skin) {
+        if (!(surface.skin.node in (scene.nodes || {}))) {
+          context.addIssue({
+            code: 'custom',
+            path: ['surfaces', identifier, 'skin', 'node'],
+            message: `Unknown skin node "${surface.skin.node}".`
+          });
+        }
+        for (const [jointIndex, joint] of surface.skin.joints.entries()) {
+          if (!(joint in (scene.nodes || {}))) {
+            context.addIssue({
+              code: 'custom',
+              path: ['surfaces', identifier, 'skin', 'joints', jointIndex],
+              message: `Unknown skin joint "${joint}".`
+            });
+          }
+        }
       }
     }
 

--- a/modules/anari/test/gltf-production-skin.node.spec.ts
+++ b/modules/anari/test/gltf-production-skin.node.spec.ts
@@ -1,0 +1,110 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFile} from 'node:fs/promises';
+import {parse} from '@loaders.gl/core';
+import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
+import {ANARIDevice, ANARIGroup, type ANARIInstance, type ANARISurface} from '@luma.gl/anari';
+import {ANARISceneSchema} from '@luma.gl/anari/schemas';
+import {NullDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
+import {makeANARIJSONSceneFromGLTF} from '../../../examples/showcase/anari/gltf-to-anari';
+import {createANARIJSONScene} from '../../../examples/showcase/anari/playground-scene';
+
+async function loadSimpleSkin() {
+  const asset = await readFile(
+    new URL('../../../examples/showcase/anari/public/gltf/SimpleSkin.gltf', import.meta.url)
+  );
+  return postProcessGLTF(await parse(asset, GLTFLoader, {gltf: {loadImages: false}}));
+}
+
+test('ANARI imports and animates authored SimpleSkin joint palettes without application setup', async testContext => {
+  const source = await loadSimpleSkin();
+  const description = await makeANARIJSONSceneFromGLTF(source, 'SIMPLE SKIN');
+  const declaredSurface = Object.values(description.surfaces).find(surface => surface.skin);
+
+  testContext.equal(declaredSurface?.skin?.joints.length, 2, 'retains both authored joint nodes');
+  testContext.equal(
+    declaredSurface?.skin?.inverseBindMatrices?.length,
+    32,
+    'preserves authored inverse bind matrices'
+  );
+  testContext.ok(
+    ANARISceneSchema.safeParse(description).success,
+    'validates portable skin bindings'
+  );
+
+  if (description.renderer) {
+    description.renderer.bloomIntensity = 0;
+  }
+  const device = new ANARIDevice(new NullDevice({}));
+  const scene = createANARIJSONScene(device, description);
+  const instances = scene.frame
+    .getParameter('world')!
+    .getParameter('instance') as readonly ANARIInstance[];
+  let retainedSurface: ANARISurface | undefined;
+
+  for (const instance of instances) {
+    const group = instance.getParameter('group');
+    if (!(group instanceof ANARIGroup)) {
+      continue;
+    }
+    for (const surface of group.getParameter('surface') || []) {
+      if (surface.getParameter('skin')) {
+        retainedSurface = surface;
+      }
+    }
+  }
+
+  testContext.ok(retainedSurface, 'creates a source-owned retained skin surface');
+  testContext.ok(scene.animations, 'uses the existing shared animation scene');
+  if (retainedSurface && scene.animations) {
+    const originalPalette = Array.from(retainedSurface.getParameter('skin')!.jointMatrices);
+    const originalVersion = retainedSurface.version;
+    scene.animations.seek(0.5);
+
+    testContext.notDeepEqual(
+      Array.from(retainedSurface.getParameter('skin')!.jointMatrices),
+      originalPalette,
+      'animated source joints update the retained mesh-local palette'
+    );
+    testContext.equal(
+      retainedSurface.version,
+      originalVersion + 1,
+      'commits each surface only once'
+    );
+    testContext.ok(scene.frame.render().drawCount > 0, 'renders the existing skinned PBR model');
+  }
+
+  scene.destroy();
+  device.destroy();
+  testContext.end();
+});
+
+test('ANARI skin schemas reject missing source joints and malformed inverse binds', async testContext => {
+  const source = await loadSimpleSkin();
+  const description = await makeANARIJSONSceneFromGLTF(source, 'SIMPLE SKIN');
+  const skin = Object.values(description.surfaces).find(surface => surface.skin)?.skin;
+  if (!skin) {
+    testContext.fail('the fixture should expose a retained skin');
+    testContext.end();
+    return;
+  }
+
+  skin.joints = [...skin.joints, 'missing-joint'];
+  const result = ANARISceneSchema.safeParse(description);
+  testContext.false(result.success, 'rejects unresolved retained joints');
+  if (!result.success) {
+    testContext.ok(
+      result.error.issues.some(issue => issue.path.includes('joints')),
+      'identifies the unresolved retained joint'
+    );
+    testContext.ok(
+      result.error.issues.some(issue => issue.path.includes('inverseBindMatrices')),
+      'rejects inverse bind palettes whose joint count no longer matches'
+    );
+  }
+
+  testContext.end();
+});

--- a/modules/anari/test/gltf-production-skin.spec.ts
+++ b/modules/anari/test/gltf-production-skin.spec.ts
@@ -1,0 +1,62 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {load} from '@loaders.gl/core';
+import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
+import {ANARIDevice} from '@luma.gl/anari';
+import {createScenegraphsFromGLTF} from '@luma.gl/gltf';
+import {getTestDevices, getWebGLTestDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
+import {makeANARIJSONSceneFromGLTF} from '../../../examples/showcase/anari/gltf-to-anari';
+import {createANARIJSONScene} from '../../../examples/showcase/anari/playground-scene';
+
+test('glTF SimpleSkin renders automatically animated retained joints on WebGL and WebGPU', async testContext => {
+  const asset = await load('/examples/showcase/anari/public/gltf/SimpleSkin.gltf', GLTFLoader, {
+    gltf: {loadImages: false}
+  });
+  const source = postProcessGLTF(asset);
+  const description = await makeANARIJSONSceneFromGLTF(source, 'GPU SIMPLE SKIN');
+  if (description.renderer) {
+    description.renderer.bloomIntensity = 0;
+  }
+
+  const [webglDevice, webgpuDevices] = await Promise.all([
+    getWebGLTestDevice(),
+    getTestDevices(['webgpu'])
+  ]);
+  const devices = webglDevice ? [webglDevice, ...webgpuDevices] : webgpuDevices;
+
+  for (const graphicsDevice of devices) {
+    const scenegraphs = createScenegraphsFromGLTF(graphicsDevice, source);
+    const binding = scenegraphs.skins.getBinding(0);
+    testContext.equal(binding?.joints.length, 2, `${graphicsDevice.type} binds authored joints`);
+    scenegraphs.animator.setTime(500);
+
+    const device = new ANARIDevice(graphicsDevice);
+    const scene = createANARIJSONScene(device, description);
+    try {
+      const before = scene.frame.render();
+      graphicsDevice.submit();
+      scene.animations?.seek(1);
+      const after = scene.frame.render();
+      graphicsDevice.submit();
+
+      testContext.ok(before.drawCount > 0, `${graphicsDevice.type} draws the authored skin`);
+      testContext.equal(
+        after.drawCount,
+        before.drawCount,
+        `${graphicsDevice.type} draws its animated pose without rebuilding the scene`
+      );
+    } finally {
+      scene.destroy();
+      device.destroy();
+      for (const sourceScene of scenegraphs.scenes) {
+        sourceScene.destroy();
+      }
+    }
+  }
+
+  testContext.ok(devices.length > 0, 'at least one live graphics backend is exercised');
+  testContext.end();
+});

--- a/modules/engine/src/animation/skin.ts
+++ b/modules/engine/src/animation/skin.ts
@@ -1,0 +1,50 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Matrix4, type NumericArray} from '@math.gl/core';
+
+import type {GroupNode} from '../scenegraph/group-node';
+
+/** Format-independent inputs for evaluating a skinned mesh's joint palette. */
+export type SkinJointMatricesProps = {
+  /** Joints in their authored palette order. */
+  joints: readonly GroupNode[];
+  /** Animated scenegraph node that owns the skinned mesh. */
+  meshNode?: GroupNode;
+  /** World transforms collected once for the animated scene hierarchy. */
+  worldMatrices: ReadonlyMap<GroupNode, Readonly<NumericArray>>;
+  /** Optional column-major inverse bind matrix for each joint. */
+  inverseBindMatrices?: ArrayLike<number>;
+  /** Existing output storage that can be reused across animation frames. */
+  target?: Float32Array;
+};
+
+/** Evaluates joint matrices in mesh-local space without owning a skeleton or GPU resources. */
+export function updateSkinJointMatrices(props: SkinJointMatricesProps): Float32Array {
+  const {joints, meshNode, worldMatrices, inverseBindMatrices, target} = props;
+  const matrixCount = joints.length;
+  const jointMatrices =
+    target && target.length === matrixCount * 16 ? target : new Float32Array(matrixCount * 16);
+  const meshWorldMatrix = meshNode ? worldMatrices.get(meshNode) || meshNode.matrix : undefined;
+  const inverseMeshMatrix = meshWorldMatrix ? new Matrix4(meshWorldMatrix).invert() : null;
+
+  for (let jointIndex = 0; jointIndex < matrixCount; jointIndex++) {
+    const jointNode = joints[jointIndex];
+    const jointWorldMatrix = worldMatrices.get(jointNode) || jointNode.matrix;
+    const jointMatrix = inverseMeshMatrix
+      ? new Matrix4(inverseMeshMatrix).multiplyRight(jointWorldMatrix)
+      : new Matrix4(jointWorldMatrix);
+    const offset = jointIndex * 16;
+    if (inverseBindMatrices && inverseBindMatrices.length >= offset + 16) {
+      const inverseBindMatrix = new Matrix4();
+      for (let componentIndex = 0; componentIndex < 16; componentIndex++) {
+        inverseBindMatrix[componentIndex] = inverseBindMatrices[offset + componentIndex];
+      }
+      jointMatrix.multiplyRight(inverseBindMatrix);
+    }
+    jointMatrices.set(jointMatrix, offset);
+  }
+
+  return jointMatrices;
+}

--- a/modules/engine/src/index.ts
+++ b/modules/engine/src/index.ts
@@ -21,6 +21,8 @@ export type {AnimationActionProps, AnimationLoopMode} from './animation/animatio
 export {AnimationAction, AnimationMixer} from './animation/animation-mixer';
 export type {MorphTargetAttributes} from './animation/morph-targets';
 export {applyMorphTargets, updateMorphTargetBuffers} from './animation/morph-targets';
+export type {SkinJointMatricesProps} from './animation/skin';
+export {updateSkinJointMatrices} from './animation/skin';
 export {Timeline} from './animation/timeline';
 export {KeyFrames} from './animation/key-frames';
 export type {AnimationProps} from './animation-loop/animation-props';

--- a/modules/engine/test/animation/skin.node.spec.ts
+++ b/modules/engine/test/animation/skin.node.spec.ts
@@ -1,0 +1,59 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {GroupNode, updateSkinJointMatrices} from '@luma.gl/engine';
+import {Matrix4} from '@math.gl/core';
+import test from 'test/utils/vitest-tape';
+
+test('Animation#updateSkinJointMatrices evaluates shared joints in mesh-local space', testContext => {
+  const meshNode = new GroupNode({id: 'mesh'});
+  const firstJoint = new GroupNode({id: 'first-joint'});
+  const secondJoint = new GroupNode({id: 'second-joint'});
+  const worldMatrices = new Map([
+    [meshNode, new Matrix4().translate([10, 0, 0])],
+    [firstJoint, new Matrix4().translate([11, 0, 0])],
+    [secondJoint, new Matrix4().translate([10, 4, 0])]
+  ]);
+  const inverseBindMatrices = new Float32Array([
+    ...new Matrix4(),
+    ...new Matrix4().translate([0, -2, 0])
+  ]);
+  const target = new Float32Array(32);
+
+  const jointMatrices = updateSkinJointMatrices({
+    joints: [firstJoint, secondJoint],
+    meshNode,
+    worldMatrices,
+    inverseBindMatrices,
+    target
+  });
+
+  testContext.equal(jointMatrices, target, 'reuses adapter-owned output storage');
+  testContext.equal(jointMatrices[12], 1, 'evaluates the first joint relative to the skinned mesh');
+  testContext.equal(jointMatrices[16 + 13], 2, 'applies authored inverse bind transforms');
+
+  worldMatrices.set(secondJoint, new Matrix4().translate([10, 7, 0]));
+  updateSkinJointMatrices({
+    joints: [firstJoint, secondJoint],
+    meshNode,
+    worldMatrices,
+    inverseBindMatrices,
+    target
+  });
+
+  testContext.equal(jointMatrices[16 + 13], 5, 'updates animated joints without reallocating');
+  testContext.end();
+});
+
+test('Animation#updateSkinJointMatrices defaults missing inverse bind matrices', testContext => {
+  const joint = new GroupNode({id: 'joint', position: [0, 3, 0]});
+  const matrices = updateSkinJointMatrices({
+    joints: [joint],
+    worldMatrices: new Map([[joint, new Matrix4().translate([0, 3, 0])]])
+  });
+
+  testContext.equal(matrices.length, 16, 'allocates only the authored joint palette');
+  testContext.equal(matrices[13], 3, 'uses an identity inverse bind transform by default');
+  testContext.end();
+});

--- a/modules/gltf/src/gltf/create-scenegraph-from-gltf.ts
+++ b/modules/gltf/src/gltf/create-scenegraph-from-gltf.ts
@@ -9,6 +9,7 @@ import {Light} from '@luma.gl/shadertools';
 import {parseGLTF, type ParseGLTFOptions} from '../parsers/parse-gltf';
 import {parseGLTFLights} from '../parsers/parse-gltf-lights';
 import {GLTFAnimator} from './gltf-animator';
+import {GLTFSkinController} from './gltf-skin';
 import {parseGLTFAnimations} from '../parsers/parse-gltf-animations';
 import type {GLTFAnimation} from './animations/animations';
 import {getGLTFExtensionSupport, type GLTFExtensionSupport} from './gltf-extension-support';
@@ -52,6 +53,9 @@ export type GLTFScenegraphs = {
   /** Map from glTF node ids to generated scenegraph nodes. */
   gltfNodeIdToNodeMap: Map<string, GroupNode>;
 
+  /** Automatically updated source skin bindings and reusable mesh-local joint palettes. */
+  skins: GLTFSkinController;
+
   /** Original post-processed glTF document. */
   gltf: GLTFPostprocessed;
 };
@@ -71,6 +75,8 @@ export function createScenegraphsFromGLTF(
   const extensionSupport = getGLTFExtensionSupport(gltf);
   const sceneBounds = scenes.map(scene => getScenegraphBounds(scene.getBounds()));
   const modelBounds = getCombinedScenegraphBounds(sceneBounds);
+  const skins = new GLTFSkinController({gltf, scenes, gltfNodeIndexToNodeMap});
+  animator.setUpdateHandler(() => skins.update());
 
   return {
     scenes,
@@ -84,6 +90,7 @@ export function createScenegraphsFromGLTF(
     gltfMeshIdToNodeMap,
     gltfNodeIdToNodeMap,
     gltfNodeIndexToNodeMap,
+    skins,
     gltf
   };
 }

--- a/modules/gltf/src/gltf/gltf-animator.ts
+++ b/modules/gltf/src/gltf/gltf-animator.ts
@@ -203,12 +203,28 @@ export type GLTFAnimatorProps = {
   gltfNodeIdToNodeMap: Map<string, GroupNode>;
   /** Materials aligned with the source glTF materials array. */
   materials?: Material[];
+  /** Called once after all animation channels have been evaluated. */
+  onUpdate?: () => void;
+  /** Optional initial clip policy; omitted preserves legacy simultaneous playback. */
+  autoplay?: 'all' | 'first' | false;
+};
+
+/** Optional transition settings when choosing an imported animation clip. */
+export type GLTFAnimationSelectionOptions = {
+  /** Crossfade duration in seconds; omitted selects the new clip immediately. */
+  crossFadeDuration?: number;
 };
 
 /** Coordinates playback of every animation found in a glTF scene. */
 export class GLTFAnimator extends Animator<GLTFAnimationClip> {
   /** Shared engine mixer containing every parsed glTF clip and target binding. */
   readonly mixer: AnimationMixer;
+
+  /** Name of the currently selected clip, when explicit selection has been requested. */
+  activeClip: string | undefined;
+
+  private onUpdate?: () => void;
+  private previousTimeSeconds: number | undefined;
 
   /** Creates an animator for the supplied glTF scenegraph. */
   constructor(props: GLTFAnimatorProps) {
@@ -225,20 +241,80 @@ export class GLTFAnimator extends Animator<GLTFAnimationClip> {
       })
     );
     this.mixer = mixer;
+    this.onUpdate = props.onUpdate;
+    this.activeClip = this.clips[0]?.name;
+
+    if (props.autoplay === false) {
+      this.clips.forEach(clip => {
+        clip.playing = false;
+        clip.action.stop();
+      });
+    } else if (props.autoplay === 'first' && this.activeClip) {
+      this.selectClip(this.activeClip);
+    }
+  }
+
+  /** Registers the dependent scenegraph update performed once after each animation frame. */
+  setUpdateHandler(callback: (() => void) | undefined): this {
+    this.onUpdate = callback;
+    return this;
   }
 
   /** Resolves legacy wall-clock milliseconds while evaluating all clips in one mixer pass. */
   override setTime(timeMs: number): void {
     const absoluteTimeSeconds = timeMs / 1000;
+    const elapsedSeconds =
+      this.previousTimeSeconds === undefined ? 0 : absoluteTimeSeconds - this.previousTimeSeconds;
+    this.previousTimeSeconds = absoluteTimeSeconds;
+    const scaledElapsedSeconds = elapsedSeconds * this.mixer.timeScale;
+
     this.clips.forEach(clip => {
       if (!clip.playing) {
         clip.action.stop();
         return;
       }
+      if (clip.action.paused) {
+        return;
+      }
       clip.action.resume();
-      clip.action.setTime(Math.max(0, absoluteTimeSeconds - clip.startTime) * clip.speed);
+      const localTime = Math.max(0, absoluteTimeSeconds - clip.startTime) * clip.speed;
+      clip.action.setTime(localTime - scaledElapsedSeconds * clip.action.timeScale);
     });
-    this.mixer.update(0);
+    this.mixer.update(elapsedSeconds);
+    this.onUpdate?.();
+  }
+
+  /** Advances clips using delta seconds without converting the legacy millisecond clock. */
+  update(deltaSeconds: number): void {
+    this.mixer.update(deltaSeconds);
+    this.onUpdate?.();
+  }
+
+  /** Selects one imported clip and optionally crossfades from the previous selection. */
+  selectClip(name: string, options: GLTFAnimationSelectionOptions = {}): GLTFAnimationClip {
+    const nextClip = this.clips.find(clip => clip.name === name);
+    if (!nextClip) {
+      throw new Error(`Unknown animation clip: ${name}`);
+    }
+
+    const previousClip = this.clips.find(clip => clip.name === this.activeClip);
+    const crossFadeDuration = options.crossFadeDuration || 0;
+    for (const clip of this.clips) {
+      if (clip !== nextClip && !(crossFadeDuration > 0 && clip === previousClip)) {
+        clip.playing = false;
+        clip.action.stop();
+      }
+    }
+
+    nextClip.playing = true;
+    if (crossFadeDuration > 0 && previousClip && previousClip !== nextClip) {
+      previousClip.playing = true;
+      previousClip.action.crossFadeTo(nextClip.action, crossFadeDuration);
+    } else {
+      nextClip.action.reset().setEffectiveWeight(1).play();
+    }
+    this.activeClip = name;
+    return nextClip;
   }
 }
 

--- a/modules/gltf/src/gltf/gltf-skin.ts
+++ b/modules/gltf/src/gltf/gltf-skin.ts
@@ -1,0 +1,159 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import type {GLTFPostprocessed} from '@loaders.gl/gltf';
+import {GroupNode, ModelNode, updateSkinJointMatrices} from '@luma.gl/engine';
+import {Matrix4} from '@math.gl/core';
+
+/** One glTF mesh node and the existing models driven by its source skin. */
+export type GLTFSkinBinding = {
+  /** Source glTF node that owns the skinned mesh. */
+  nodeIndex: number;
+  /** Source glTF skin selected for this mesh. */
+  skinIndex: number;
+  /** Animated scenegraph node that owns the skinned mesh. */
+  node: GroupNode;
+  /** Animated joint nodes in their source palette order. */
+  joints: readonly GroupNode[];
+  /** Optional authored inverse bind matrices. */
+  inverseBindMatrices?: Float32Array;
+  /** Reused, mesh-local joint palette supplied to the existing skin shader. */
+  jointMatrices: Float32Array;
+  /** Existing primitive models that share this skin binding. */
+  models: readonly ModelNode[];
+};
+
+/** Inputs already produced by the canonical glTF scenegraph parser. */
+export type GLTFSkinControllerProps = {
+  gltf: GLTFPostprocessed;
+  scenes: readonly GroupNode[];
+  gltfNodeIndexToNodeMap: ReadonlyMap<number, GroupNode>;
+};
+
+/** Updates glTF-owned joint palettes once per animation frame using existing model shaders. */
+export class GLTFSkinController {
+  readonly bindings: readonly GLTFSkinBinding[];
+
+  private readonly scenes: readonly GroupNode[];
+
+  constructor(props: GLTFSkinControllerProps) {
+    this.scenes = props.scenes;
+    this.bindings = makeSkinBindings(props);
+    this.update();
+  }
+
+  /** Re-evaluates every source skin after its animated node transforms have changed. */
+  update(): void {
+    if (this.bindings.length === 0) {
+      return;
+    }
+
+    const worldMatrices = new Map<GroupNode, Matrix4>();
+    for (const scene of this.scenes) {
+      scene.preorderTraversal((node, {worldMatrix}) => {
+        if (node instanceof GroupNode) {
+          worldMatrices.set(node, new Matrix4(worldMatrix));
+        }
+      });
+    }
+
+    for (const binding of this.bindings) {
+      updateSkinJointMatrices({
+        joints: binding.joints,
+        meshNode: binding.node,
+        worldMatrices,
+        inverseBindMatrices: binding.inverseBindMatrices,
+        target: binding.jointMatrices
+      });
+      for (const modelNode of binding.models) {
+        modelNode.model.shaderInputs.setProps({skin: {jointMatrices: binding.jointMatrices}});
+      }
+    }
+  }
+
+  /** Finds the binding for an authored glTF node index or generated scenegraph node. */
+  getBinding(node: number | GroupNode): GLTFSkinBinding | undefined {
+    return this.bindings.find(binding =>
+      typeof node === 'number' ? binding.nodeIndex === node : binding.node === node
+    );
+  }
+}
+
+function makeSkinBindings(props: GLTFSkinControllerProps): GLTFSkinBinding[] {
+  const {gltf, gltfNodeIndexToNodeMap} = props;
+  const bindings: GLTFSkinBinding[] = [];
+  const sourceSkins = gltf.skins || [];
+
+  for (const [nodeIndex, sourceNode] of gltf.nodes.entries()) {
+    const sourceNodeSkin = sourceNode.skin;
+    if (sourceNodeSkin === undefined || !sourceNode.mesh) {
+      continue;
+    }
+
+    const skinIndex = resolveGLTFSkinIndex(gltf, sourceNodeSkin);
+    const sourceSkin = sourceSkins[skinIndex];
+    const node = gltfNodeIndexToNodeMap.get(nodeIndex);
+    if (!sourceSkin || !node) {
+      continue;
+    }
+
+    const joints = sourceSkin.joints.flatMap(jointIndex => {
+      const joint = gltfNodeIndexToNodeMap.get(jointIndex);
+      return joint ? [joint] : [];
+    });
+    if (joints.length !== sourceSkin.joints.length) {
+      continue;
+    }
+
+    const sourceMesh = sourceNode.mesh;
+    const meshNode = node.children.find(
+      child => child instanceof GroupNode && child.id === (sourceMesh.name || sourceMesh.id)
+    );
+    if (!(meshNode instanceof GroupNode)) {
+      continue;
+    }
+
+    const models = meshNode.children.flatMap(child => (child instanceof ModelNode ? [child] : []));
+    const inverseBindMatrices = sourceSkin.inverseBindMatrices?.value;
+    bindings.push({
+      nodeIndex,
+      skinIndex,
+      node,
+      joints,
+      ...(inverseBindMatrices instanceof Float32Array ? {inverseBindMatrices} : {}),
+      jointMatrices: new Float32Array(joints.length * 16),
+      models
+    });
+  }
+
+  return bindings;
+}
+
+/** Resolves both numeric and loaders.gl-postprocessed source skin references. */
+export function resolveGLTFSkinIndex(
+  gltf: GLTFPostprocessed,
+  sourceSkin: number | {id?: string; joints?: readonly number[]; inverseBindMatrices?: unknown}
+): number {
+  if (typeof sourceSkin === 'number') {
+    return sourceSkin;
+  }
+
+  return (gltf.skins || []).findIndex(candidate => {
+    if (candidate === sourceSkin || (sourceSkin.id && candidate.id === sourceSkin.id)) {
+      return true;
+    }
+    if (
+      candidate.joints.length !== sourceSkin.joints?.length ||
+      !candidate.joints.every((joint, index) => joint === sourceSkin.joints?.[index])
+    ) {
+      return false;
+    }
+
+    if (typeof sourceSkin.inverseBindMatrices === 'number') {
+      const accessor = gltf.accessors[sourceSkin.inverseBindMatrices];
+      return !candidate.inverseBindMatrices || candidate.inverseBindMatrices === accessor;
+    }
+    return true;
+  });
+}

--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -19,6 +19,7 @@ export {
 export {
   GLTFAnimationClip,
   type GLTFAnimationClipProps,
+  type GLTFAnimationSelectionOptions,
   GLTFAnimator,
   type GLTFAnimatorProps
 } from './gltf/gltf-animator';
@@ -27,6 +28,12 @@ export {
   type GLTFExtensionSupportLevel,
   getGLTFExtensionSupport
 } from './gltf/gltf-extension-support';
+export {
+  type GLTFSkinBinding,
+  GLTFSkinController,
+  type GLTFSkinControllerProps,
+  resolveGLTFSkinIndex
+} from './gltf/gltf-skin';
 export {parseGLTFAnimations} from './parsers/parse-gltf-animations';
 export {type ParseGLTFLightsOptions, parseGLTFLights} from './parsers/parse-gltf-lights';
 export {

--- a/modules/gltf/test/gltf/gltf-production-animation.node.spec.ts
+++ b/modules/gltf/test/gltf/gltf-production-animation.node.spec.ts
@@ -1,0 +1,160 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFile} from 'node:fs/promises';
+import {parse} from '@loaders.gl/core';
+import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
+import {GroupNode} from '@luma.gl/engine';
+import {
+  createScenegraphsFromGLTF,
+  type GLTFAnimation,
+  GLTFAnimator,
+  GLTFSkinController
+} from '@luma.gl/gltf';
+import {NullDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
+
+async function loadSimpleSkin() {
+  const asset = await readFile(
+    new URL('../../../../examples/showcase/anari/public/gltf/SimpleSkin.gltf', import.meta.url)
+  );
+  return postProcessGLTF(await parse(asset, GLTFLoader, {gltf: {loadImages: false}}));
+}
+
+test('glTF SimpleSkin automatically binds and animates existing primitive joint palettes', async testContext => {
+  const source = await loadSimpleSkin();
+  const device = new NullDevice({});
+  const scenegraphs = createScenegraphsFromGLTF(device, source);
+  const binding = scenegraphs.skins.getBinding(0);
+
+  testContext.ok(scenegraphs.skins instanceof GLTFSkinController, 'exposes source-owned skins');
+  testContext.equal(scenegraphs.skins.bindings.length, 1, 'binds the authored skinned node');
+  testContext.equal(binding?.skinIndex, 0, 'resolves a postprocessed source skin');
+  testContext.equal(binding?.joints.length, 2, 'preserves both authored joints');
+  testContext.equal(binding?.models.length, 1, 'binds the existing primitive model');
+  testContext.equal(binding?.jointMatrices.length, 32, 'allocates only authored joint matrices');
+
+  if (binding) {
+    const startingPalette = Array.from(binding.jointMatrices);
+    const storage = binding.jointMatrices;
+    scenegraphs.animator.setTime(500);
+
+    testContext.equal(binding.jointMatrices, storage, 'reuses the same palette every frame');
+    testContext.notDeepEqual(
+      Array.from(binding.jointMatrices),
+      startingPalette,
+      'the existing imported clip updates its joint transforms'
+    );
+
+    const uniforms = binding.models[0].model.shaderInputs.getUniformValues();
+    testContext.ok(uniforms['skin'], 'the existing skin shader receives the automatic palette');
+  }
+
+  for (const scene of scenegraphs.scenes) {
+    scene.destroy();
+  }
+  device.destroy();
+  testContext.end();
+});
+
+test('GLTFSkinController preserves independent skins and mesh-local transforms', testContext => {
+  const firstMeshNode = new GroupNode({id: 'mesh-node-a', position: [10, 0, 0]});
+  const secondMeshNode = new GroupNode({id: 'mesh-node-b', position: [20, 0, 0]});
+  const firstJoint = new GroupNode({id: 'joint-a', position: [12, 0, 0]});
+  const secondJoint = new GroupNode({id: 'joint-b', position: [25, 0, 0]});
+  const firstMesh = new GroupNode({id: 'mesh-a'});
+  const secondMesh = new GroupNode({id: 'mesh-b'});
+  firstMeshNode.add(firstMesh);
+  secondMeshNode.add(secondMesh);
+  const scene = new GroupNode({
+    id: 'scene',
+    children: [firstMeshNode, secondMeshNode, firstJoint, secondJoint]
+  });
+  const gltf = {
+    nodes: [
+      {id: 'mesh-node-a', mesh: {id: 'mesh-a'}, skin: 0},
+      {id: 'mesh-node-b', mesh: {id: 'mesh-b'}, skin: 1},
+      {id: 'joint-a'},
+      {id: 'joint-b'}
+    ],
+    skins: [{joints: [2]}, {joints: [3]}],
+    accessors: []
+  } as any;
+  const controller = new GLTFSkinController({
+    gltf,
+    scenes: [scene],
+    gltfNodeIndexToNodeMap: new Map([
+      [0, firstMeshNode],
+      [1, secondMeshNode],
+      [2, firstJoint],
+      [3, secondJoint]
+    ])
+  });
+
+  testContext.equal(controller.bindings.length, 2, 'keeps both authored skins independent');
+  testContext.equal(controller.getBinding(0)?.jointMatrices[12], 2, 'localizes the first skin');
+  testContext.equal(
+    controller.getBinding(secondMeshNode)?.jointMatrices[12],
+    5,
+    'localizes the second skin'
+  );
+
+  secondJoint.setPosition([28, 0, 0]).updateMatrix();
+  controller.update();
+  testContext.equal(
+    controller.getBinding(1)?.jointMatrices[12],
+    8,
+    'updates only authored transforms'
+  );
+  testContext.end();
+});
+
+test('GLTFAnimator advances wall-clock crossfades and supports explicit clip selection', testContext => {
+  const node = new GroupNode({id: 'animated'});
+  let updateCount = 0;
+  const makeAnimation = (name: string, position: number): GLTFAnimation => ({
+    name,
+    channels: [
+      {
+        type: 'node',
+        path: 'translation',
+        targetNodeId: node.id,
+        sampler: {
+          input: [0, 2],
+          interpolation: 'LINEAR',
+          output: [
+            [position, 0, 0],
+            [position, 0, 0]
+          ]
+        }
+      }
+    ]
+  });
+  const animator = new GLTFAnimator({
+    animations: [makeAnimation('walk', 0), makeAnimation('run', 10)],
+    gltfNodeIdToNodeMap: new Map([[node.id, node]]),
+    autoplay: 'first',
+    onUpdate: () => updateCount++
+  });
+
+  testContext.equal(animator.activeClip, 'walk', 'initially selects the first authored clip');
+  testContext.false(animator.clips[1].action.playing, 'does not blend unrelated authored clips');
+  animator.setTime(0);
+  animator.selectClip('run', {crossFadeDuration: 1});
+  animator.setTime(500);
+
+  testContext.equal(animator.activeClip, 'run', 'exposes the newly selected authored clip');
+  testContext.equal(
+    node.position[0],
+    5,
+    'legacy millisecond playback advances both crossfade weights'
+  );
+  testContext.equal(updateCount, 2, 'runs dependent skin updates once per animation frame');
+
+  animator.setTime(1000);
+  testContext.equal(node.position[0], 10, 'crossfades finish at the incoming clip');
+  testContext.equal(updateCount, 3, 'does not evaluate dependent skins twice');
+  testContext.throws(() => animator.selectClip('missing'), 'unknown clip names remain explicit');
+  testContext.end();
+});


### PR DESCRIPTION
## Goals

Make authored glTF character animation work automatically across the existing canonical glTF scenegraph and thin ANARI facade, without creating a second skeleton, shader, or animation mixer.

## Changes

- Add a small engine-owned, format-independent joint-palette evaluator that reuses caller-owned storage and correctly combines mesh-local transforms with optional inverse bind matrices.
- Add glTF-owned skin bindings for postprocessed skin references, multiple skins, existing primitive models, and the existing Georgios Karnas skin shader; evaluate all joint transforms once per animation frame.
- Extend retained ANARI surfaces with portable node/joint/inverse-bind descriptions, translate authored glTF skins through the isolated adapter, and commit each animated retained surface at most once per frame.
- Fix frozen `GLTFAnimator` crossfades by advancing the shared mixer with actual wall-clock deltas while preserving the legacy millisecond API, and add explicit clip selection, optional first-clip autoplay, delta updates, and crossfade transitions.
- Vendor the complete 3.5 KB Khronos `SimpleSkin.gltf` fixture under its documented CC0 license and cover real imported joints, multiple skins, inverse binds, clip fades, retained commits, and actual WebGL/WebGPU rendering.
- Preserve the existing portable 64-joint shader limit and CPU morph path; larger GPU-backed palettes and GPU morphing remain independent follow-up work.

## Verification

- `node_modules/.bin/tspc -b modules/*/tsconfig.json --pretty false` — all package project-reference builds pass.
- Strict source-aliased TypeScript compilation of the complete ANARI showcase plus glTF/ANARI packages passes.
- 26 focused Node suites / 142 tests pass across engine animation, glTF, ANARI, experimental rendering, and the existing skin shader.
- Real Chromium runs the authored `SimpleSkin` asset through canonical glTF and retained ANARI on both WebGL and WebGPU.
- Direct Biome formatting/lint checks pass; actual four-branch three-way merge simulation reports zero conflicts.
- Local `yarn lint fix` and the unmodified global example typecheck cannot run cleanly because the shared local dependencies contain obsolete/missing `ocular-*` tooling and stale package declarations; equivalent scoped formatting, full package builds, strict showcase compilation, and browser/Node gates were run directly.

## Architecture / Ownership

`@luma.gl/engine` owns generic palette math and the existing mixer; `@luma.gl/gltf` owns glTF skin extraction, scenegraph binding, and playback compatibility; `@luma.gl/shadertools` continues to own the existing skin shader; `@luma.gl/anari` remains a retained descriptor/orchestration facade. This branch targets `master` directly and has no dependency on the parallel extension, physical-material, or interchange pull requests.