### PR TITLE
feat(gltf): deliver reference-grade PBR and chromatic dispersion

### DIFF
--- a/docs/api-reference/anari/anari-materials-and-lights.md
+++ b/docs/api-reference/anari/anari-materials-and-lights.md
@@ -42,6 +42,7 @@ type ANARIMaterialParameters = {
   clearcoat?: number;
   clearcoatRoughness?: number;
   transmission?: number;
+  dispersion?: number;
   thickness?: number;
   attenuationDistance?: number;
   attenuationColor?: ANARIVector3;
@@ -99,6 +100,7 @@ type ANARIMaterialParameters = {
 | `specularColor`, `specularIntensity` | Dielectric specular color and strength. |
 | `clearcoat`, `clearcoatRoughness` | Secondary surface coating and coating roughness. |
 | `transmission`, `thickness` | Screen-space transmission strength and medium thickness. |
+| `dispersion` | Nonnegative chromatic transmission spread using the ratified glTF 20/Abbe-number parameterization; defaults to zero. |
 | `attenuationColor`, `attenuationDistance`, `indexOfRefraction` | Transmitted-light tint, attenuation distance, and IOR. |
 | `sheenColor`, `sheenRoughness` | Cloth-like sheen response. |
 | `iridescence`, `iridescenceIndexOfRefraction` | Thin-film iridescence strength and film IOR. |
@@ -108,9 +110,11 @@ type ANARIMaterialParameters = {
 When a retained material has nonzero `transmission`, ANARI's shared
 [experimental SceneRenderer](/docs/api-reference/experimental/scene-renderer) automatically
 captures opaque scene color and samples it for screen-space refraction. Thickness, attenuation,
-index of refraction, and roughness shape the transmitted result. This is a single opaque-scene
-capture, not ray tracing or arbitrary layered refraction. ANARI inherits this behavior from the
-shared renderer and does not implement a separate transmission pass.
+index of refraction, chromatic dispersion, and roughness shape the transmitted result. Opaque
+radiance is captured in linear HDR when supported, then exposed and tone-mapped only after the
+physical material response. This is a single opaque-scene capture, not ray tracing or arbitrary
+layered refraction. ANARI inherits this behavior from the shared renderer and does not implement a
+separate transmission pass.
 
 ### Supported image maps
 

--- a/docs/api-reference/experimental/scene-renderer.md
+++ b/docs/api-reference/experimental/scene-renderer.md
@@ -138,10 +138,10 @@ automatically calculate or bind joint matrices.
 
 Supported uniform families include base color, metallic/roughness, normal and occlusion maps,
 emission and emissive strength, specular color/intensity, index of refraction, transmission and
-volume factors, clearcoat, sheen, iridescence, anisotropy, alpha cutoff, per-map UV selection, and
-per-map UV transforms. Transmissive surfaces can sample an automatically captured opaque scene;
-the shared shader combines scene-color refraction with IOR, thickness, attenuation, Fresnel
-response, and roughness-aware filtering.
+volume factors, chromatic dispersion, clearcoat, sheen, iridescence, anisotropy, alpha cutoff,
+per-map UV selection, and per-map UV transforms. Transmissive surfaces sample automatically
+captured linear opaque-scene radiance; the shared shader combines refraction with IOR, thickness,
+attenuation, wavelength-dependent dispersion, Fresnel response, and roughness-aware filtering.
 
 Bind only maps that actually exist:
 
@@ -194,9 +194,33 @@ ordered back-to-front at the surface level.
 | `environment` | Optional complete `SceneEnvironment` image-based-lighting resource set. |
 | `transmission` | Enables automatic opaque-scene capture for transmissive materials; set `false` to disable it. |
 | `exposure` | Exposure multiplier; defaults to `1`. |
-| `toneMapMode` | Existing shared scene tone-mapping selector; defaults to `2`. |
+| `toneMapMode` | `0` disables tone mapping, `1` selects Reinhard, `2` selects Khronos PBR Neutral, and `3` selects ACES. SDR targets default to `2`; floating-point targets default to `0`. |
+| `outputColorSpace` | Optional `linear` or `srgb` output encoding. Floating-point and hardware-sRGB attachments default to linear output; ordinary SDR attachments default to exact sRGB encoding. |
 | `fogColor`, `fogDensity` | Optional exponential-fog inputs consumed by deferred lighting. |
 | `renderMode` | `default`, `debugNormals`, or `debugDepth`. |
+
+### Color management and HDR output
+
+The canonical shaders accumulate lighting, environment radiance, emission, and transmission in
+linear color space. Exposure is applied before tone mapping. Import the named selectors when
+configuring an output transform:
+
+```ts
+import {PBR_TONE_MAP_MODE} from '@luma.gl/shadertools';
+
+renderer.render({
+  ...options,
+  exposure: 1.5,
+  toneMapMode: PBR_TONE_MAP_MODE.KHRONOS_PBR_NEUTRAL,
+  outputColorSpace: 'srgb'
+});
+```
+
+An `rgba16float` framebuffer defaults to linear, untonemapped output, preserving radiance above
+one for subsequent HDR processing. A framebuffer with a hardware-sRGB attachment also receives
+linear shader output so the hardware performs the transfer exactly once. Explicit
+`outputColorSpace` overrides the automatic selection when the caller intentionally manages the
+target differently.
 
 ## Image-based lighting
 
@@ -288,7 +312,8 @@ const glassSurface: SceneSurface = {
       thicknessFactor: 0.35,
       attenuationDistance: 2,
       attenuationColor: [0.85, 0.95, 1],
-      ior: 1.5
+      ior: 1.5,
+      dispersion: 0.35
     }
   },
   transforms: [new Matrix4()]
@@ -306,9 +331,11 @@ material in `alphaMode: 'OPAQUE'`; it can refract background geometry while reta
 output alpha and participating in depth writes. Set `alphaMode: 'BLEND'` only when the material's
 authored alpha actually requires blending.
 
-The capture pass renders opaque or masked **nontransmissive** surfaces into a separate retained
-color/depth target. Transmissive and blended surfaces are excluded, so a target is never sampled
-while also being rendered. The final pass draws ordinary opaque surfaces before transmissive
+The capture pass renders opaque or masked **nontransmissive** surfaces into a separate retained,
+linear color/depth target. It uses `rgba16float` when that format can be rendered and filtered,
+falling back to `rgba8unorm` otherwise. Capture is not exposed, tone-mapped, or sRGB-encoded before
+the transmission shader samples it. Transmissive and blended surfaces are excluded, so a target is
+never sampled while also being rendered. The final pass draws ordinary opaque surfaces before transmissive
 opaque surfaces, then draws blended surfaces back-to-front. `drawCount` reports only final-pass
 draws; the internal capture draw is intentionally excluded.
 
@@ -319,7 +346,9 @@ behavior. Debug-normal/depth modes also disable capture.
 
 This is screen-space, single-opaque-capture transmission rather than ray tracing or layered
 multi-bounce refraction. Overlapping transmissive objects do not refract one another, and blended
-background surfaces do not appear in the opaque capture.
+background surfaces do not appear in the opaque capture. A positive `dispersion` applies the
+ratified `KHR_materials_dispersion` wavelength-dependent IOR model; zero keeps the ordinary
+single-refraction path.
 
 ## Retention and structural updates
 
@@ -328,8 +357,9 @@ Camera state, lights, material factors, instance matrix values, joint palettes, 
 update without rebuilding the retained model. Texture binding identity, geometry identity or
 `geometryVersion`, instance count, alpha mode, sidedness, shader defines, IBL availability,
 whether the specular environment has multiple mip levels, transmission-capture
-availability/dimensions, and debug mode are structural changes and recreate the affected
-pipeline/resources. Changing the exact mip count within an already mipmapped environment updates
+availability/dimensions, render-target color format, and debug mode are structural changes and
+recreate the affected pipeline/resources. Changing the exact mip count within an already mipmapped
+environment updates
 the scene uniform without recompiling that shader variant.
 
 Changing only `material.version` does not force a structural rebuild. Increment `geometryVersion`

--- a/docs/api-reference/gltf/gltf-extensions.mdx
+++ b/docs/api-reference/gltf/gltf-extensions.mdx
@@ -167,8 +167,9 @@ Status meanings:
       Thickness factor plus attenuation color and distance now tint transmitted light
       in the stock shader.
     </SupportRow>
-    <SupportRow name="KHR_materials_dispersion" support="❌">
-      Chromatic dispersion is not implemented in the stock PBR shader.
+    <SupportRow name="KHR_materials_dispersion" support="✅ 🚧" fromVersion="9.3">
+      Authored dispersion is parsed into the canonical PBR material. Shared experimental and ANARI
+      rendering separate transmitted RGB wavelengths using the ratified wavelength-dependent IOR.
     </SupportRow>
     <SupportRow name="KHR_materials_volume_scatter" support="❌">
       Volume scattering is not implemented in the stock PBR shader.

--- a/docs/api-reference/gltf/gltf-materials.md
+++ b/docs/api-reference/gltf/gltf-materials.md
@@ -40,8 +40,9 @@ defines, and generated textures. Source `OPAQUE`, `MASK`, and `BLEND` modes, cut
 double-sided materials, and unlit materials are preserved.
 
 Core metallic-roughness factors and supported extension factors include emissive strength,
-specular intensity/color, index of refraction, transmission, thickness/attenuation, clearcoat,
-sheen, iridescence, and anisotropy.
+specular intensity/color, index of refraction, transmission, thickness/attenuation, ratified
+chromatic dispersion, clearcoat, sheen, iridescence, and anisotropy. Authored sRGB color textures
+use the exact piecewise transfer function rather than an approximate gamma curve.
 
 ## Supported texture slots
 
@@ -201,11 +202,14 @@ refraction depends on the renderer:
 
 - The shared [experimental SceneRenderer](/docs/api-reference/experimental/scene-renderer) and
   retained ANARI path capture the opaque scene and sample it for screen-space refraction with
-  thickness, attenuation, index of refraction, and roughness-aware response.
+  thickness, attenuation, index of refraction, wavelength-dependent chromatic dispersion, and
+  roughness-aware response. Opaque scene color stays linear and uses an HDR capture attachment
+  when the device supports rendering and filtering `rgba16float`.
 - Standalone models produced by `createScenegraphsFromGLTF()` do not capture scene color and
   retain the established alpha/attenuation transmission approximation.
 
 Captured transmission is a single screen-space opaque pass, not ray tracing or arbitrary layered
-refraction. Advanced sheen, iridescence, and anisotropy also use the shared shader's existing
-approximations. See [glTF extension support](/docs/api-reference/gltf/gltf-extensions) for
+refraction. Advanced materials use Charlie-distributed sheen, anisotropic GGX
+distribution/visibility, spectral thin-film iridescence, and Fresnel-aware clearcoat/base-layer
+energy compensation. See [glTF extension support](/docs/api-reference/gltf/gltf-extensions) for
 format-level coverage.

--- a/examples/showcase/anari/gltf-to-anari.ts
+++ b/examples/showcase/anari/gltf-to-anari.ts
@@ -410,6 +410,7 @@ function getMaterialIdentifier(
         ? 'mask'
         : 'opaque';
   const clearcoat = sourceMaterial.extensions?.['KHR_materials_clearcoat'];
+  const dispersion = sourceMaterial.extensions?.['KHR_materials_dispersion'];
   const iridescence = sourceMaterial.extensions?.['KHR_materials_iridescence'];
   const transmission = sourceMaterial.extensions?.['KHR_materials_transmission'];
   const sheen = sourceMaterial.extensions?.['KHR_materials_sheen'];
@@ -434,6 +435,7 @@ function getMaterialIdentifier(
     clearcoatRoughness: clamp(clearcoat?.clearcoatRoughnessFactor ?? 0, 0, 1),
     iridescence: clamp(iridescence?.iridescenceFactor ?? 0, 0, 1),
     transmission: clamp(transmission?.transmissionFactor ?? 0, 0, 1),
+    dispersion: Math.max(dispersion?.dispersion ?? 0, 0),
     thickness: Math.max(volume?.thicknessFactor ?? 0, 0),
     attenuationColor: toVector3(volume?.attenuationColor, [1, 1, 1]),
     indexOfRefraction: clamp(indexOfRefraction?.ior ?? 1.5, 1, 2.5),

--- a/modules/anari/src/anari-scene-adapter.ts
+++ b/modules/anari/src/anari-scene-adapter.ts
@@ -347,6 +347,7 @@ export function makeSceneMaterial(material: ANARIMaterial): SceneMaterial {
     specularIntensityFactor: parameters.specularIntensity ?? 1,
     ior: parameters.indexOfRefraction ?? 1.5,
     transmissionFactor: parameters.transmission ?? 0,
+    dispersion: parameters.dispersion ?? 0,
     thicknessFactor: parameters.thickness ?? 0,
     attenuationDistance: parameters.attenuationDistance ?? 1e9,
     attenuationColor: parameters.attenuationColor || [1, 1, 1],

--- a/modules/anari/src/anari-types.ts
+++ b/modules/anari/src/anari-types.ts
@@ -103,6 +103,7 @@ export type ANARIMaterialParameters = {
   iridescence?: number;
   clearcoatRoughness?: number;
   transmission?: number;
+  dispersion?: number;
   thickness?: number;
   attenuationDistance?: number;
   attenuationColor?: ANARIVector3;

--- a/modules/anari/src/gltf.ts
+++ b/modules/anari/src/gltf.ts
@@ -91,6 +91,7 @@ const MATERIAL_PROPERTY_NAMES: Record<string, string> = {
   baseColorFactor: 'baseColor',
   clearcoatFactor: 'clearcoat',
   clearcoatRoughnessFactor: 'clearcoatRoughness',
+  dispersion: 'dispersion',
   emissiveFactor: 'emissive',
   emissiveStrength: 'emissiveStrength',
   ior: 'indexOfRefraction',

--- a/modules/anari/src/schemas.ts
+++ b/modules/anari/src/schemas.ts
@@ -112,6 +112,7 @@ const materialProperties = {
   clearcoatRoughness: unitNumberSchema.optional(),
   iridescence: unitNumberSchema.optional(),
   transmission: unitNumberSchema.optional(),
+  dispersion: nonnegativeNumberSchema.optional(),
   thickness: nonnegativeNumberSchema.optional(),
   attenuationDistance: positiveNumberSchema.optional(),
   attenuationColor: ANARIVector3Schema.optional(),

--- a/modules/anari/test/anari-material.node.spec.ts
+++ b/modules/anari/test/anari-material.node.spec.ts
@@ -20,6 +20,7 @@ test('ANARI material parameters translate into canonical shared PBR uniforms', t
     clearcoat: 0.8,
     clearcoatRoughness: 0.15,
     transmission: 0.45,
+    dispersion: 0.65,
     thickness: 1.2,
     attenuationDistance: 3,
     attenuationColor: [0.8, 0.6, 0.4],
@@ -53,6 +54,7 @@ test('ANARI material parameters translate into canonical shared PBR uniforms', t
   testContext.equal(uniforms.clearcoatFactor, 0.8, 'maps clearcoat amount');
   testContext.equal(uniforms.clearcoatRoughnessFactor, 0.15, 'maps clearcoat roughness');
   testContext.equal(uniforms.transmissionFactor, 0.45, 'maps transmission amount');
+  testContext.equal(uniforms.dispersion, 0.65, 'maps chromatic transmission dispersion');
   testContext.equal(uniforms.thicknessFactor, 1.2, 'maps volume thickness');
   testContext.equal(uniforms.attenuationDistance, 3, 'maps volume attenuation distance');
   testContext.deepEqual(uniforms.attenuationColor, [0.8, 0.6, 0.4], 'maps attenuation color');

--- a/modules/anari/test/anari-schemas.node.spec.ts
+++ b/modules/anari/test/anari-schemas.node.spec.ts
@@ -164,6 +164,7 @@ test('ANARI material schemas expose canonical PBR extension factors and alpha mo
     specularColor: [0.7, 0.8, 0.9],
     specularIntensity: 0.6,
     transmission: 0.5,
+    dispersion: 1.75,
     thickness: 1.2,
     attenuationDistance: 4,
     attenuationColor: [0.8, 0.7, 0.6],
@@ -193,6 +194,13 @@ test('ANARI material schemas expose canonical PBR extension factors and alpha mo
       alphaCutoff: 1.5
     }).success,
     'masked alpha cutoffs remain constrained to the normalized range'
+  );
+  testContext.notOk(
+    ANARIMaterialSchema.safeParse({
+      '@@type': 'physicallyBased',
+      dispersion: -0.1
+    }).success,
+    'chromatic dispersion remains nonnegative without limiting artistic values above one'
   );
   testContext.ok(
     ANARITextureSchema.safeParse({source: '/texture.png', textureCoordinateSet: 1}).success,

--- a/modules/anari/test/gltf-import.node.spec.ts
+++ b/modules/anari/test/gltf-import.node.spec.ts
@@ -269,6 +269,7 @@ test('glTF importer retains all canonical PBR textures, factors, color spaces, a
     KHR_materials_specular: {specularFactor: 0.42, specularColorFactor: [0.3, 0.4, 0.5]},
     KHR_materials_ior: {ior: 1.7},
     KHR_materials_transmission: {transmissionFactor: 0.56},
+    KHR_materials_dispersion: {dispersion: 2.4},
     KHR_materials_volume: {
       thicknessFactor: 0.6,
       attenuationDistance: 2.5,
@@ -417,6 +418,7 @@ test('glTF importer retains all canonical PBR textures, factors, color spaces, a
   testContext.equal(importedMaterial.specularIntensity, 0.42, 'specular intensity survives');
   testContext.equal(importedMaterial.indexOfRefraction, 1.7, 'index of refraction survives');
   testContext.equal(importedMaterial.transmission, 0.56, 'transmission factor survives');
+  testContext.equal(importedMaterial.dispersion, 2.4, 'ratified chromatic dispersion survives');
   testContext.equal(importedMaterial.thickness, 0.6, 'volume thickness survives');
   testContext.equal(
     importedMaterial.attenuationDistance,

--- a/modules/experimental/src/engine/scene-renderer.ts
+++ b/modules/experimental/src/engine/scene-renderer.ts
@@ -8,7 +8,8 @@ import {
   type Device,
   type Framebuffer,
   type RenderPass,
-  Texture
+  Texture,
+  type TextureFormatColor
 } from '@luma.gl/core';
 import {
   type Geometry,
@@ -20,6 +21,7 @@ import {
 } from '@luma.gl/engine';
 import {
   type Light,
+  PBR_TONE_MAP_MODE,
   type PBRMaterialBindings,
   type PBRMaterialUniforms,
   pbrMaterial,
@@ -125,8 +127,10 @@ export type SceneRenderOptions = {
   transmission?: boolean;
   /** Scene exposure multiplier. */
   exposure?: number;
-  /** Shared scene tone-mapping mode. */
+  /** Zero disables tone mapping; one selects Reinhard, two Khronos PBR Neutral, three ACES. */
   toneMapMode?: number;
+  /** Output transfer function; floating-point and hardware-sRGB targets default to linear. */
+  outputColorSpace?: 'linear' | 'srgb';
   /** Optional world-space fog color used by deferred lighting. */
   fogColor?: readonly number[];
   /** Optional exponential fog density used by deferred lighting. */
@@ -206,28 +210,36 @@ export class SceneRenderer {
   /** Compiles, updates, orders, and draws one retained frame. */
   render(options: SceneRenderOptions): SceneRenderStatistics {
     const transmission = this.getTransmissionResources(options);
-    const scene = this.prepareScene(options, transmission?.colorTexture);
     const background = options.background || [0, 0, 0, 1];
 
     if (transmission) {
+      const captureOptions: SceneRenderOptions = {
+        ...options,
+        id: getTransmissionCaptureIdentifier(options.id),
+        surfaces: options.surfaces.filter(
+          surface =>
+            !isTransmissiveSurface(surface) && getSceneAlphaMode(surface.material) !== 'BLEND'
+        ),
+        framebuffer: transmission.framebuffer,
+        exposure: 1,
+        toneMapMode: PBR_TONE_MAP_MODE.NONE,
+        outputColorSpace: 'linear',
+        transmission: false
+      };
+      const capturedScene = this.prepareScene(captureOptions);
       const capturePass = this.device.beginRenderPass({
         id: `scene-${options.id}-transmission`,
         framebuffer: transmission.framebuffer,
         clearColor: [background[0], background[1], background[2], background[3] ?? 1],
         clearDepth: 1
       });
-      this.drawPreparedScene(
-        {
-          ...scene,
-          surfaces: scene.surfaces.filter(
-            surface => !surface.transmissive && surface.alphaMode !== 'BLEND'
-          )
-        },
-        capturePass
-      );
+      this.drawPreparedScene(capturedScene, capturePass);
       capturePass.end();
+    } else {
+      this.destroyFrame(getTransmissionCaptureIdentifier(options.id));
     }
 
+    const scene = this.prepareScene(options, transmission?.colorTexture);
     const renderPass = this.device.beginRenderPass({
       id: `scene-${options.id}`,
       framebuffer: options.framebuffer,
@@ -251,6 +263,9 @@ export class SceneRenderer {
     }
     destroyTransmissionResources(resources.transmission);
     this.frames.delete(frameIdentifier);
+    if (resources.transmission) {
+      this.destroyFrame(getTransmissionCaptureIdentifier(frameIdentifier));
+    }
   }
 
   /** Releases all engine-owned scene models, materials, and instance buffers. */
@@ -422,6 +437,9 @@ export class SceneRenderer {
         bufferLayout,
         instanceCount: surface.transforms.length,
         shaderInputs: new ShaderInputs({pbrMaterial, pbrScene, ...(hasSkin ? {skin} : {})}),
+        colorAttachmentFormats: options.framebuffer?.colorAttachments.map(
+          attachment => attachment.texture.format as TextureFormatColor
+        ),
         parameters: {
           cullMode: surface.material.doubleSided ? 'none' : 'back',
           depthWriteEnabled: alphaMode !== 'BLEND',
@@ -442,6 +460,7 @@ export class SceneRenderer {
           USE_SCENE_ENVIRONMENT: hasCompleteEnvironment(options.environment),
           USE_TEX_LOD: hasMipmappedEnvironment(options.environment),
           USE_TRANSMISSION_FRAMEBUFFER: Boolean(transmissionTexture),
+          USE_SCENE_COLOR_MANAGEMENT: true,
           DEBUG_NORMALS: options.renderMode === 'debugNormals',
           DEBUG_DEPTH: options.renderMode === 'debugDepth',
           ...surface.material.defines,
@@ -509,7 +528,7 @@ export class SceneRenderer {
         id: `scene-${options.id}-transmission-color`,
         width,
         height,
-        format: this.device.preferredColorFormat,
+        format: getTransmissionTextureFormat(this.device),
         usage: Texture.SAMPLE | Texture.RENDER,
         sampler: {
           minFilter: 'linear',
@@ -584,6 +603,7 @@ function getSceneSurfaceSignature(
     transmission: Boolean(transmissionTexture),
     transmissionWidth: transmissionTexture?.width,
     transmissionHeight: transmissionTexture?.height,
+    colorFormat: options.framebuffer?.colorAttachments[0]?.texture.format,
     renderMode: options.renderMode || 'default'
   });
 }
@@ -642,10 +662,15 @@ function setSceneShaderInputs(
     },
     pbrScene: {
       exposure: options.exposure ?? 1,
-      toneMapMode: options.toneMapMode ?? 2,
+      toneMapMode:
+        options.toneMapMode ??
+        (getSceneColorFormat(model.device, options) === 'rgba16float'
+          ? PBR_TONE_MAP_MODE.NONE
+          : PBR_TONE_MAP_MODE.KHRONOS_PBR_NEUTRAL),
       environmentIntensity: options.environment?.intensity ?? 1,
       environmentRotation: options.environment?.rotation ?? 0,
       environmentMipCount: options.environment?.specularTexture?.mipLevels ?? 1,
+      outputEncoding: getSceneOutputEncoding(model.device, options),
       framebufferSize: [framebufferWidth, framebufferHeight],
       viewMatrix,
       projectionMatrix,
@@ -676,6 +701,27 @@ function hasMipmappedEnvironment(environment?: SceneEnvironment): boolean {
 
 function isTransmissiveSurface(surface: SceneSurface): boolean {
   return (surface.material.uniforms?.transmissionFactor ?? 0) > 0;
+}
+
+function getTransmissionCaptureIdentifier(frameIdentifier: string): string {
+  return `${frameIdentifier}::linear-transmission-capture`;
+}
+
+function getTransmissionTextureFormat(device: Device): 'rgba16float' | 'rgba8unorm' {
+  const capabilities = device.getTextureFormatCapabilities('rgba16float');
+  return capabilities.render && capabilities.filter ? 'rgba16float' : 'rgba8unorm';
+}
+
+function getSceneColorFormat(device: Device, options: SceneRenderOptions): string {
+  return options.framebuffer?.colorAttachments[0]?.texture.format || device.preferredColorFormat;
+}
+
+function getSceneOutputEncoding(device: Device, options: SceneRenderOptions): number {
+  if (options.outputColorSpace) {
+    return options.outputColorSpace === 'srgb' ? 1 : 0;
+  }
+  const format = getSceneColorFormat(device, options);
+  return format === 'rgba16float' || format.endsWith('-srgb') ? 0 : 1;
 }
 
 function getSceneRenderSize(device: Device, options: SceneRenderOptions): [number, number] {

--- a/modules/experimental/test/engine/scene-reference-pbr.spec.ts
+++ b/modules/experimental/test/engine/scene-reference-pbr.spec.ts
@@ -1,0 +1,382 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {Buffer, type Device, type Framebuffer, Texture} from '@luma.gl/core';
+import {Geometry} from '@luma.gl/engine';
+import {SceneRenderer, type SceneRenderOptions, type SceneSurface} from '@luma.gl/experimental';
+import {getTestDevices, getWebGLTestDevice} from '@luma.gl/test-utils';
+import {Matrix4} from '@math.gl/core';
+import test from 'test/utils/vitest-tape';
+
+type ReferenceRenderTarget = {
+  color: Texture;
+  depth: Texture;
+  framebuffer: Framebuffer;
+  destroy(): void;
+};
+
+test('SceneRenderer applies exposure, exact sRGB encoding, and selectable reference tone maps', async testCase => {
+  let testedDeviceCount = 0;
+
+  for (const device of await getReferenceTestDevices()) {
+    if (isSoftwareBackedWebGL(device)) {
+      testCase.comment('software WebGL cannot reliably compile full-suite reference PBR variants');
+      continue;
+    }
+
+    testedDeviceCount++;
+    const renderer = new SceneRenderer(device);
+    const target = makeRenderTarget(device, 'rgba8unorm');
+    const surface: SceneSurface = {
+      id: `${device.type}-reference-color-surface`,
+      geometry: makeFullscreenGeometry(),
+      material: {
+        id: `${device.type}-reference-color-material`,
+        uniforms: {unlit: true, baseColorFactor: [0.25, 0.5, 1, 1]}
+      },
+      transforms: [new Matrix4()]
+    };
+    const options = makeRenderOptions(device, [surface], target.framebuffer);
+
+    try {
+      options.toneMapMode = 0;
+      options.exposure = 1;
+      options.outputColorSpace = 'srgb';
+      testCase.equal(
+        renderer.render(options).drawCount,
+        1,
+        `${device.type} shades reference color`
+      );
+      device.submit();
+
+      if (supportsPixelReadback(device)) {
+        const standardColor = await readUnsignedPixel(target.color, 16, 16);
+        testCase.ok(
+          Math.abs(standardColor[0] - 137) <= 2 && Math.abs(standardColor[1] - 188) <= 2,
+          `${device.type} applies the exact linear-to-sRGB transfer function`
+        );
+
+        options.outputColorSpace = 'linear';
+        renderer.render(options);
+        device.submit();
+        const linearColor = await readUnsignedPixel(target.color, 16, 16);
+        testCase.ok(
+          Math.abs(linearColor[0] - 64) <= 2 && Math.abs(linearColor[1] - 128) <= 2,
+          `${device.type} preserves linear output without a second transfer function`
+        );
+
+        options.outputColorSpace = 'srgb';
+        options.exposure = 0.5;
+        renderer.render(options);
+        device.submit();
+        const lowExposure = await readUnsignedPixel(target.color, 16, 16);
+
+        options.exposure = 2;
+        renderer.render(options);
+        device.submit();
+        const highExposure = await readUnsignedPixel(target.color, 16, 16);
+        testCase.ok(
+          highExposure[0] > lowExposure[0] + 50,
+          `${device.type} applies scene exposure to physical fragment output`
+        );
+
+        options.toneMapMode = 1;
+        renderer.render(options);
+        device.submit();
+        const reinhardColor = await readUnsignedPixel(target.color, 16, 16);
+
+        options.toneMapMode = 2;
+        renderer.render(options);
+        device.submit();
+        const neutralColor = await readUnsignedPixel(target.color, 16, 16);
+
+        options.toneMapMode = 3;
+        renderer.render(options);
+        device.submit();
+        const acesColor = await readUnsignedPixel(target.color, 16, 16);
+
+        testCase.ok(
+          Math.abs(reinhardColor[2] - neutralColor[2]) > 10,
+          `${device.type} distinguishes Reinhard and Khronos PBR Neutral highlights`
+        );
+        testCase.ok(
+          Math.abs(acesColor[0] - neutralColor[0]) > 5,
+          `${device.type} distinguishes ACES from Khronos PBR Neutral tone mapping`
+        );
+      } else {
+        testCase.comment(
+          'software WebGPU renders exposure/tone modes without unsupported MAP_READ'
+        );
+      }
+    } finally {
+      renderer.destroy();
+      target.destroy();
+    }
+  }
+
+  testCase.ok(testedDeviceCount > 0, 'at least one portable reference-color backend runs');
+  testCase.end();
+});
+
+test('SceneRenderer preserves linear HDR radiance and captures chromatic physical dispersion', async testCase => {
+  let testedDeviceCount = 0;
+
+  for (const device of await getReferenceTestDevices()) {
+    if (isSoftwareBackedWebGL(device)) {
+      testCase.comment('software WebGL cannot reliably compile full-suite transmission variants');
+      continue;
+    }
+
+    testedDeviceCount++;
+    const renderer = new SceneRenderer(device);
+    const target = makeRenderTarget(device, 'rgba8unorm');
+    const background: SceneSurface = {
+      id: `${device.type}-dispersion-spectrum`,
+      geometry: makeFullscreenGeometry({vertexColors: true}),
+      material: {
+        id: `${device.type}-dispersion-spectrum-material`,
+        uniforms: {unlit: true, baseColorFactor: [1, 1, 1, 1]}
+      },
+      transforms: [new Matrix4().translate([0, 0, -1])]
+    };
+    const glass: SceneSurface = {
+      id: `${device.type}-dispersion-glass`,
+      geometry: makeFullscreenGeometry({tiltedNormal: true}),
+      material: {
+        id: `${device.type}-dispersion-glass-material`,
+        alphaMode: 'OPAQUE',
+        uniforms: {
+          baseColorFactor: [1, 1, 1, 1],
+          metallicRoughnessValues: [0, 0.05],
+          transmissionFactor: 1,
+          thicknessFactor: 2,
+          ior: 1.7,
+          dispersion: 0
+        }
+      },
+      transforms: [new Matrix4()]
+    };
+    const options = makeRenderOptions(device, [glass, background], target.framebuffer);
+    options.toneMapMode = 0;
+
+    try {
+      testCase.equal(renderer.render(options).drawCount, 2, `${device.type} captures opaque color`);
+      device.submit();
+
+      if (supportsPixelReadback(device)) {
+        const ordinaryRefraction = await readUnsignedPixel(target.color, 16, 16);
+        glass.material.uniforms = {...glass.material.uniforms, dispersion: 24};
+        renderer.render(options);
+        device.submit();
+        const dispersedRefraction = await readUnsignedPixel(target.color, 16, 16);
+        const colorDifference =
+          Math.abs(ordinaryRefraction[0] - dispersedRefraction[0]) +
+          Math.abs(ordinaryRefraction[1] - dispersedRefraction[1]) +
+          Math.abs(ordinaryRefraction[2] - dispersedRefraction[2]);
+        testCase.ok(
+          colorDifference >= 4,
+          `${device.type} separates transmission wavelengths using ratified dispersion (${colorDifference})`
+        );
+        testCase.equal(dispersedRefraction[3], 255, `${device.type} keeps dispersive glass opaque`);
+      } else {
+        glass.material.uniforms = {...glass.material.uniforms, dispersion: 24};
+        testCase.equal(renderer.render(options).drawCount, 2, 'software WebGPU renders dispersion');
+        device.submit();
+      }
+
+      const capabilities = device.getTextureFormatCapabilities('rgba16float');
+      if (capabilities.render && supportsPixelReadback(device)) {
+        const highDynamicRangeTarget = makeRenderTarget(device, 'rgba16float');
+        try {
+          const emissiveSurface: SceneSurface = {
+            id: `${device.type}-linear-hdr-emissive`,
+            geometry: makeFullscreenGeometry(),
+            material: {
+              id: `${device.type}-linear-hdr-emissive-material`,
+              uniforms: {unlit: true, baseColorFactor: [2, 0.5, 0.125, 1]}
+            },
+            transforms: [new Matrix4()]
+          };
+          const highDynamicRangeOptions = makeRenderOptions(
+            device,
+            [emissiveSurface],
+            highDynamicRangeTarget.framebuffer
+          );
+          highDynamicRangeOptions.exposure = 2;
+          testCase.equal(
+            renderer.render(highDynamicRangeOptions).drawCount,
+            1,
+            `${device.type} renders to a true HDR attachment`
+          );
+          device.submit();
+          const highDynamicRangePixel = await readFloat16Pixel(
+            highDynamicRangeTarget.color,
+            16,
+            16
+          );
+          testCase.ok(
+            Math.abs(highDynamicRangePixel[0] - 4) < 0.05,
+            `${device.type} preserves unclamped HDR linear red radiance (${highDynamicRangePixel[0]})`
+          );
+          testCase.ok(
+            Math.abs(highDynamicRangePixel[1] - 1) < 0.03,
+            `${device.type} applies exposure before linear HDR presentation`
+          );
+        } finally {
+          highDynamicRangeTarget.destroy();
+        }
+      }
+    } finally {
+      renderer.destroy();
+      target.destroy();
+    }
+  }
+
+  testCase.ok(testedDeviceCount > 0, 'at least one portable transmission backend runs');
+  testCase.end();
+});
+
+function makeFullscreenGeometry(
+  options: {vertexColors?: boolean; tiltedNormal?: boolean} = {}
+): Geometry {
+  const normal = options.tiltedNormal ? [0.8, 0, 0.6] : [0, 0, 1];
+  const attributes: ConstructorParameters<typeof Geometry>[0]['attributes'] = {
+    POSITION: {
+      size: 3,
+      value: new Float32Array([-5, -5, 0, 5, -5, 0, 5, 5, 0, -5, 5, 0])
+    },
+    NORMAL: {size: 3, value: new Float32Array([...normal, ...normal, ...normal, ...normal])}
+  };
+  if (options.vertexColors) {
+    attributes.COLOR_0 = {
+      size: 3,
+      value: new Float32Array([1, 0.05, 0, 0, 0.1, 1, 0, 1, 0.1, 1, 0, 0.05])
+    };
+  }
+  return new Geometry({
+    topology: 'triangle-list',
+    attributes,
+    indices: new Uint16Array([0, 1, 2, 0, 2, 3])
+  });
+}
+
+function makeRenderTarget(
+  device: Device,
+  format: 'rgba8unorm' | 'rgba16float'
+): ReferenceRenderTarget {
+  const color = device.createTexture({
+    width: 32,
+    height: 32,
+    format,
+    usage: Texture.RENDER | Texture.COPY_SRC
+  });
+  const depth = device.createTexture({
+    width: 32,
+    height: 32,
+    format: 'depth24plus',
+    usage: Texture.RENDER
+  });
+  const framebuffer = device.createFramebuffer({
+    width: 32,
+    height: 32,
+    colorAttachments: [color],
+    depthStencilAttachment: depth
+  });
+  return {
+    color,
+    depth,
+    framebuffer,
+    destroy() {
+      framebuffer.destroy();
+      color.destroy();
+      depth.destroy();
+    }
+  };
+}
+
+function makeRenderOptions(
+  device: Device,
+  surfaces: SceneSurface[],
+  framebuffer: Framebuffer
+): SceneRenderOptions {
+  return {
+    id: `${device.type}-reference-frame`,
+    surfaces,
+    framebuffer,
+    camera: {
+      viewMatrix: new Matrix4().lookAt({eye: [0, 0, 4], center: [0, 0, 0], up: [0, 1, 0]}),
+      projectionMatrix: new Matrix4().perspective({
+        fovy: Math.PI / 3,
+        aspect: 1,
+        near: 0.1,
+        far: 100
+      }),
+      position: [0, 0, 4]
+    },
+    background: [0, 0, 0, 1],
+    width: 32,
+    height: 32
+  };
+}
+
+async function getReferenceTestDevices(): Promise<Device[]> {
+  const [webglDevice, webgpuDevices] = await Promise.all([
+    getWebGLTestDevice(),
+    getTestDevices(['webgpu'])
+  ]);
+  return webglDevice ? [webglDevice, ...webgpuDevices] : webgpuDevices;
+}
+
+function isSoftwareBackedWebGL(device: Device): boolean {
+  return device.type === 'webgl' && isSoftwareBacked(device);
+}
+
+function supportsPixelReadback(device: Device): boolean {
+  return device.type !== 'webgpu' || !isSoftwareBacked(device);
+}
+
+function isSoftwareBacked(device: Device): boolean {
+  return (
+    device.info.gpu === 'software' || device.info.gpuType === 'cpu' || Boolean(device.info.fallback)
+  );
+}
+
+async function readPixelBytes(texture: Texture, x: number, y: number): Promise<Uint8Array> {
+  const layout = texture.computeMemoryLayout({width: 1, height: 1});
+  const buffer = texture.device.createBuffer({
+    byteLength: layout.byteLength,
+    usage: Buffer.COPY_DST | Buffer.MAP_READ
+  });
+  try {
+    texture.readBuffer({x, y, width: 1, height: 1}, buffer);
+    const data = await buffer.readAsync(0, layout.byteLength);
+    return new Uint8Array(data.buffer, data.byteOffset, data.byteLength).slice();
+  } finally {
+    buffer.destroy();
+  }
+}
+
+async function readUnsignedPixel(texture: Texture, x: number, y: number): Promise<Uint8Array> {
+  const bytes = await readPixelBytes(texture, x, y);
+  return bytes.slice(0, 4);
+}
+
+async function readFloat16Pixel(texture: Texture, x: number, y: number): Promise<number[]> {
+  const bytes = await readPixelBytes(texture, x, y);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return [0, 1, 2, 3].map(index => decodeFloat16(view.getUint16(index * 2, true)));
+}
+
+function decodeFloat16(value: number): number {
+  const sign = (value & 0x8000) === 0 ? 1 : -1;
+  const exponent = (value >> 10) & 0x1f;
+  const fraction = value & 0x03ff;
+  if (exponent === 0) {
+    return sign * 2 ** -14 * (fraction / 1024);
+  }
+  if (exponent === 31) {
+    return fraction ? Number.NaN : sign * Number.POSITIVE_INFINITY;
+  }
+  return sign * 2 ** (exponent - 15) * (1 + fraction / 1024);
+}

--- a/modules/experimental/test/engine/scene-renderer.node.spec.ts
+++ b/modules/experimental/test/engine/scene-renderer.node.spec.ts
@@ -230,7 +230,8 @@ describe('shared PBR material factories', () => {
         USE_IBL: true,
         USE_SCENE_ENVIRONMENT: true,
         USE_TEX_LOD: true,
-        USE_TRANSMISSION_FRAMEBUFFER: true
+        USE_TRANSMISSION_FRAMEBUFFER: true,
+        USE_SCENE_COLOR_MANAGEMENT: true
       }
     });
     const reflection = new WgslReflect(shader.source);
@@ -241,6 +242,15 @@ describe('shared PBR material factories', () => {
     expect(shader.source).toContain('sin(pbrScene.environmentRotation)');
     expect(shader.source).toContain('max(pbrScene.environmentIntensity, 0.0)');
     expect(shader.source).toContain('getTransmittedSceneColor(');
+    expect(shader.source).toContain('sampleTransmittedSceneColor(');
+    expect(shader.source).toContain(
+      '(max(pbrMaterial.ior, 1.0) - 1.0) * 0.025 * pbrMaterial.dispersion'
+    );
+    expect(shader.source).toContain('evaluateIridescenceSensitivity(');
+    expect(shader.source).toContain('calculateAnisotropicLightColor(');
+    expect(shader.source).toContain('toneMapKhronosPBRNeutral(');
+    expect(shader.source).toContain('pbrScene.exposure');
+    expect(shader.source).toContain('pbrScene.outputEncoding');
     expect(shader.source).toContain('pbr_transmissionFramebufferSampler');
     expect(shader.source).toContain('let alpha = clamp(baseColor.a, 0.0, 1.0)');
   });
@@ -422,7 +432,19 @@ describe('SceneRenderer', () => {
       const glassModel = renderer.draws[1].scene.surfaces[1].model;
       const captureTexture = glassModel.shaderInputs.getBindingValues()
         .pbr_transmissionFramebufferSampler as Texture;
-      expect(captureTexture).toMatchObject({width: 8, height: 8, format: 'rgba8unorm'});
+      expect(captureTexture).toMatchObject({width: 8, height: 8, format: 'rgba16float'});
+      const captureModel = renderer.draws[0].scene.surfaces[0].model;
+      expect(captureModel).not.toBe(opaqueModel);
+      expect(captureModel.shaderInputs.getUniformValues().pbrScene).toMatchObject({
+        exposure: 1,
+        toneMapMode: 0,
+        outputEncoding: 0
+      });
+      expect(opaqueModel.shaderInputs.getUniformValues().pbrScene).toMatchObject({
+        exposure: 1,
+        toneMapMode: 2,
+        outputEncoding: 1
+      });
       expect(opaqueModel.shaderInputs.getBindingValues()).not.toHaveProperty(
         'pbr_transmissionFramebufferSampler'
       );

--- a/modules/gltf/src/gltf/gltf-extension-support.ts
+++ b/modules/gltf/src/gltf/gltf-extension-support.ts
@@ -130,8 +130,9 @@ const GLTF_EXTENSION_SUPPORT_REGISTRY: Record<string, GLTFExtensionSupportDefini
     comment: 'Diffuse-transmission shading is not implemented in the stock PBR shader.'
   },
   KHR_materials_dispersion: {
-    supportLevel: 'none',
-    comment: 'Chromatic dispersion is not implemented in the stock PBR shader.'
+    supportLevel: 'parsed-and-wired',
+    comment:
+      'The canonical PBR shader separates red, green, and blue transmission using wavelength-dependent refraction.'
   },
   KHR_materials_volume_scatter: {
     supportLevel: 'none',

--- a/modules/gltf/src/parsers/parse-pbr-material.ts
+++ b/modules/gltf/src/parsers/parse-pbr-material.ts
@@ -79,6 +79,10 @@ type GLTFMaterialVolumeExtension = {
   attenuationColor?: [number, number, number];
 };
 
+type GLTFMaterialDispersionExtension = {
+  dispersion?: number;
+};
+
 type GLTFMaterialClearcoatExtension = {
   clearcoatFactor?: number;
   clearcoatTexture?: GLTFTexture;
@@ -119,6 +123,7 @@ type GLTFMaterialExtensions = {
   KHR_materials_ior?: GLTFMaterialIorExtension;
   KHR_materials_transmission?: GLTFMaterialTransmissionExtension;
   KHR_materials_volume?: GLTFMaterialVolumeExtension;
+  KHR_materials_dispersion?: GLTFMaterialDispersionExtension;
   KHR_materials_clearcoat?: GLTFMaterialClearcoatExtension;
   KHR_materials_sheen?: GLTFMaterialSheenExtension;
   KHR_materials_iridescence?: GLTFMaterialIridescenceExtension;
@@ -200,8 +205,7 @@ export function parsePBRMaterial(
   const parsedMaterial: ParsedPBRMaterial = {
     defines: {
       // TODO: Use EXT_sRGB if available (Standard in WebGL 2.0)
-      MANUAL_SRGB: true,
-      SRGB_FAST_APPROXIMATION: true
+      MANUAL_SRGB: true
     },
     bindings: {},
     uniforms: {
@@ -533,6 +537,7 @@ function parseMaterialExtensions(
     attributes
   );
   parseVolumeExtension(device, extensions.KHR_materials_volume, parsedMaterial, gltf, attributes);
+  parseDispersionExtension(extensions.KHR_materials_dispersion, parsedMaterial);
   parseClearcoatExtension(
     device,
     extensions.KHR_materials_clearcoat,
@@ -564,6 +569,7 @@ function hasMaterialExtensionShading(extensions: GLTFMaterialExtensions): boolea
       extensions.KHR_materials_ior ||
       extensions.KHR_materials_transmission ||
       extensions.KHR_materials_volume ||
+      extensions.KHR_materials_dispersion ||
       extensions.KHR_materials_clearcoat ||
       extensions.KHR_materials_sheen ||
       extensions.KHR_materials_iridescence ||
@@ -684,6 +690,15 @@ function parseVolumeExtension(
   }
   if (extension.attenuationColor) {
     parsedMaterial.uniforms.attenuationColor = extension.attenuationColor;
+  }
+}
+
+function parseDispersionExtension(
+  extension: GLTFMaterialDispersionExtension | undefined,
+  parsedMaterial: ParsedPBRMaterial
+): void {
+  if (extension?.dispersion !== undefined) {
+    parsedMaterial.uniforms.dispersion = Math.max(extension.dispersion, 0);
   }
 }
 

--- a/modules/gltf/test/parsers/parse-pbr-material.spec.ts
+++ b/modules/gltf/test/parsers/parse-pbr-material.spec.ts
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
-import {NullDevice} from '@luma.gl/test-utils';
 import {log} from '@luma.gl/core';
-
 import {parsePBRMaterial} from '@luma.gl/gltf/parsers/parse-pbr-material';
+import {NullDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
 
 const device = new NullDevice({});
 
@@ -182,6 +181,9 @@ test('gltf#parsePBRMaterial parses KHR_materials extensions', t => {
           attenuationDistance: 12,
           attenuationColor: [0.7, 0.8, 0.9]
         },
+        KHR_materials_dispersion: {
+          dispersion: 0.65
+        },
         KHR_materials_clearcoat: {
           clearcoatFactor: 0.8,
           clearcoatTexture: makeCompressedTextureInfo('clearcoat'),
@@ -231,6 +233,7 @@ test('gltf#parsePBRMaterial parses KHR_materials extensions', t => {
   );
   t.equal(parsedMaterial.uniforms.ior, 1.7, 'ior parsed');
   t.equal(parsedMaterial.uniforms.transmissionFactor, 0.6, 'transmission factor parsed');
+  t.equal(parsedMaterial.uniforms.dispersion, 0.65, 'ratified chromatic dispersion parsed');
   t.equal(parsedMaterial.uniforms.transmissionMapEnabled, true, 'transmission map enabled');
   t.equal(parsedMaterial.uniforms.thicknessFactor, 0.4, 'volume thickness parsed');
   t.ok(parsedMaterial.bindings.pbr_thicknessSampler, 'thickness binding created');

--- a/modules/gltf/test/parsers/parse-pbr-reference-material.node.spec.ts
+++ b/modules/gltf/test/parsers/parse-pbr-reference-material.node.spec.ts
@@ -1,0 +1,63 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {parsePBRMaterial} from '@luma.gl/gltf/parsers/parse-pbr-material';
+import {pbrMaterial} from '@luma.gl/shadertools';
+import {NullDevice} from '@luma.gl/test-utils';
+import {describe, expect, test} from 'vitest';
+
+describe('reference glTF physical material decoding', () => {
+  test('preserves the authored Khronos CompareDispersion material factors', () => {
+    const device = new NullDevice({});
+    try {
+      const material = parsePBRMaterial(
+        device,
+        {
+          pbrMetallicRoughness: {metallicFactor: 0, roughnessFactor: 0.1},
+          extensions: {
+            KHR_materials_dispersion: {dispersion: 5},
+            KHR_materials_ior: {ior: 2.42},
+            KHR_materials_transmission: {transmissionFactor: 1},
+            KHR_materials_volume: {attenuationDistance: 1, thicknessFactor: 0.5}
+          }
+        },
+        {},
+        {}
+      );
+
+      expect(material.uniforms).toMatchObject({
+        dispersion: 5,
+        ior: 2.42,
+        transmissionFactor: 1,
+        thicknessFactor: 0.5,
+        attenuationDistance: 1,
+        metallicRoughnessValues: [0, 0.1]
+      });
+      expect(material.defines.USE_MATERIAL_EXTENSIONS).toBe(true);
+      expect(material.defines.MANUAL_SRGB).toBe(true);
+      expect(material.defines).not.toHaveProperty('SRGB_FAST_APPROXIMATION');
+    } finally {
+      device.destroy();
+    }
+  });
+
+  test('keeps omitted dispersion at zero and safely clamps invalid negative factors', () => {
+    const device = new NullDevice({});
+    try {
+      const ordinaryMaterial = parsePBRMaterial(device, {}, {}, {});
+      const invalidMaterial = parsePBRMaterial(
+        device,
+        {extensions: {KHR_materials_dispersion: {dispersion: -2}}},
+        {},
+        {}
+      );
+
+      expect(ordinaryMaterial.uniforms.dispersion).toBeUndefined();
+      expect(pbrMaterial.defaultUniforms.dispersion).toBe(0);
+      expect(invalidMaterial.uniforms.dispersion).toBe(0);
+    } finally {
+      device.destroy();
+    }
+  });
+});

--- a/modules/shadertools/src/index.ts
+++ b/modules/shadertools/src/index.ts
@@ -174,9 +174,10 @@ export type {
 export type {
   PBRSceneBindings,
   PBRSceneProps,
-  PBRSceneUniforms
+  PBRSceneUniforms,
+  PBRToneMapMode
 } from './modules/lighting/pbr-material/pbr-scene';
 export type {PBRProjectionProps} from './modules/lighting/pbr-material/pbr-projection';
 
 export {pbrMaterial} from './modules/lighting/pbr-material/pbr-material';
-export {pbrScene} from './modules/lighting/pbr-material/pbr-scene';
+export {pbrScene, PBR_TONE_MAP_MODE} from './modules/lighting/pbr-material/pbr-scene';

--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-glsl.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-glsl.ts
@@ -115,6 +115,7 @@ layout(std140) uniform pbrMaterialUniforms {
   bool anisotropyMapEnabled;
 
   float emissiveStrength;
+  float dispersion;
   
   // IBL
   bool IBLenabled;
@@ -246,6 +247,8 @@ struct PBRInfo {
   vec3 specularColor;           // color contribution from specular lighting
   vec3 n;                       // normal at surface point
   vec3 v;                       // vector from surface point to camera
+  vec3 l;                       // direction from the surface toward the current light
+  vec3 h;                       // half vector between the current light and camera
 };
 
 const float M_PI = 3.141592653589793;
@@ -445,16 +448,125 @@ vec2 rotateDirection(vec2 direction, float rotation)
   return vec2(direction.x * c - direction.y * s, direction.x * s + direction.y * c);
 }
 
-vec3 getIridescenceTint(float iridescence, float thickness, float NdotV)
+vec3 encodeLinearSRGB(vec3 linearColor)
 {
-  if (iridescence <= 0.0) {
-    return vec3(1.0);
+  vec3 positiveColor = max(linearColor, vec3(0.0));
+  return mix(
+    positiveColor * 12.92,
+    1.055 * pow(positiveColor, vec3(1.0 / 2.4)) - 0.055,
+    greaterThan(positiveColor, vec3(0.0031308))
+  );
+}
+
+vec3 toneMapKhronosPBRNeutral(vec3 color)
+{
+  const float startCompression = 0.76;
+  float darkestChannel = min(color.r, min(color.g, color.b));
+  float offset = darkestChannel < 0.08
+    ? darkestChannel - 6.25 * darkestChannel * darkestChannel
+    : 0.04;
+  color -= vec3(offset);
+
+  float peak = maxComponent(color);
+  if (peak < startCompression) {
+    return color;
   }
 
-  float phase = 0.015 * thickness * pbrMaterial.iridescenceIor + (1.0 - NdotV) * 6.0;
-  vec3 thinFilmTint =
-    0.5 + 0.5 * cos(vec3(phase, phase + 2.0943951, phase + 4.1887902));
-  return mix(vec3(1.0), thinFilmTint, iridescence);
+  float compressionRange = 1.0 - startCompression;
+  float compressedPeak = 1.0 - compressionRange * compressionRange /
+    (peak + compressionRange - startCompression);
+  color *= compressedPeak / max(peak, 0.0001);
+  float desaturation = 1.0 - 1.0 / (0.15 * (peak - compressedPeak) + 1.0);
+  return mix(color, vec3(compressedPeak), desaturation);
+}
+
+vec3 applySceneColorManagement(vec3 sceneColor)
+{
+#ifdef USE_SCENE_COLOR_MANAGEMENT
+  vec3 color = max(sceneColor, vec3(0.0)) * max(pbrScene.exposure, 0.0);
+  if (pbrScene.toneMapMode == 1) {
+    color /= vec3(1.0) + color;
+  } else if (pbrScene.toneMapMode == 2) {
+    color = toneMapKhronosPBRNeutral(color);
+  } else if (pbrScene.toneMapMode == 3) {
+    color = clamp(
+      (color * (2.51 * color + 0.03)) / (color * (2.43 * color + 0.59) + 0.14),
+      vec3(0.0),
+      vec3(1.0)
+    );
+  }
+  return pbrScene.outputEncoding == 0 ? color : encodeLinearSRGB(color);
+#else
+  return pow(max(sceneColor, vec3(0.0)), vec3(1.0 / 2.2));
+#endif
+}
+
+float dielectricSchlick(float reflectance, float cosine)
+{
+  return reflectance + (1.0 - reflectance) * pow(clamp(1.0 - cosine, 0.0, 1.0), 5.0);
+}
+
+vec3 evaluateIridescenceSensitivity(float opticalPathDifference, vec3 phaseShift)
+{
+  float phase = 2.0 * M_PI * opticalPathDifference * 1.0e-9;
+  vec3 sensitivity = vec3(5.4856e-13, 4.4201e-13, 5.2481e-13);
+  vec3 position = vec3(1.6810e6, 1.7953e6, 2.2084e6);
+  vec3 variance = vec3(4.3278e9, 9.3046e9, 6.6121e9);
+  vec3 xyz = sensitivity * sqrt(2.0 * M_PI * variance) *
+    cos(position * phase + phaseShift) * exp(-phase * phase * variance);
+  xyz.x += 9.7470e-14 * sqrt(2.0 * M_PI * 4.5282e9) *
+    cos(2.2399e6 * phase + phaseShift.x) * exp(-4.5282e9 * phase * phase);
+  xyz /= 1.0685e-7;
+  return mat3(
+    3.2404542, -0.9692660, 0.0556434,
+    -1.5371385, 1.8760108, -0.2040259,
+    -0.4985314, 0.0415560, 1.0572252
+  ) * xyz;
+}
+
+vec3 getIridescenceTint(float iridescence, float thickness, float NdotV, vec3 baseReflectance)
+{
+  if (iridescence <= 0.0 || thickness <= 0.0) {
+    return baseReflectance;
+  }
+
+  float filmIor = max(pbrMaterial.iridescenceIor, 1.0);
+  float sineSquared = (1.0 - NdotV * NdotV) / (filmIor * filmIor);
+  float cosineSquared = 1.0 - sineSquared;
+  if (cosineSquared <= 0.0) {
+    return mix(baseReflectance, vec3(1.0), iridescence);
+  }
+  float filmCosine = sqrt(cosineSquared);
+  float firstInterfaceReflectance = dielectricSchlick(getDielectricF0(filmIor), NdotV);
+  float transmittedEnergy = 1.0 - firstInterfaceReflectance;
+
+  vec3 baseIor = (vec3(1.0) + sqrt(clamp(baseReflectance, vec3(0.0), vec3(0.9999)))) /
+    (vec3(1.0) - sqrt(clamp(baseReflectance, vec3(0.0), vec3(0.9999))));
+  vec3 secondInterfaceF0 = (baseIor - vec3(filmIor)) / (baseIor + vec3(filmIor));
+  secondInterfaceF0 *= secondInterfaceF0;
+  vec3 secondInterfaceReflectance = secondInterfaceF0 +
+    (vec3(1.0) - secondInterfaceF0) * pow(1.0 - filmCosine, 5.0);
+  vec3 phaseShift = vec3(M_PI);
+  phaseShift += mix(vec3(0.0), vec3(M_PI), lessThan(baseIor, vec3(filmIor)));
+  float opticalPathDifference = 2.0 * filmIor * thickness * filmCosine;
+  vec3 combinedReflectance = clamp(
+    firstInterfaceReflectance * secondInterfaceReflectance,
+    vec3(0.00001),
+    vec3(0.9999)
+  );
+  vec3 recurringAmplitude = sqrt(combinedReflectance);
+  vec3 interfaceResponse = transmittedEnergy * transmittedEnergy * secondInterfaceReflectance /
+    (vec3(1.0) - combinedReflectance);
+  vec3 reflectedSpectrum = vec3(firstInterfaceReflectance) + interfaceResponse;
+  vec3 harmonicAmplitude = interfaceResponse - vec3(transmittedEnergy);
+  for (int harmonic = 1; harmonic <= 2; harmonic++) {
+    harmonicAmplitude *= recurringAmplitude;
+    reflectedSpectrum += harmonicAmplitude * 2.0 * evaluateIridescenceSensitivity(
+      float(harmonic) * opticalPathDifference,
+      float(harmonic) * phaseShift
+    );
+  }
+  return mix(baseReflectance, clamp(reflectedSpectrum, vec3(0.0), vec3(1.0)), iridescence);
 }
 
 vec3 getVolumeAttenuation(float thickness)
@@ -470,18 +582,19 @@ vec3 getVolumeAttenuation(float thickness)
 }
 
 #ifdef USE_TRANSMISSION_FRAMEBUFFER
-vec3 getTransmittedSceneColor(
+vec3 sampleTransmittedSceneColor(
   vec3 position,
   vec3 normal,
   vec3 viewDirection,
   float thickness,
-  float perceptualRoughness
+  float perceptualRoughness,
+  float indexOfRefraction
 )
 {
   vec3 refractionDirection = refract(
     -viewDirection,
     normal,
-    1.0 / max(pbrMaterial.ior, 1.0)
+    1.0 / max(indexOfRefraction, 1.0)
   );
   vec3 refractedPosition = position + refractionDirection * thickness;
   vec4 clipPosition = pbrScene.projectionMatrix *
@@ -508,7 +621,44 @@ vec3 getTransmittedSceneColor(
     pbr_transmissionFramebufferSampler,
     textureCoordinate - vec2(0.0, blurRadius.y)
   ).rgb * 0.15;
-  return pow(max(sceneColor, vec3(0.0)), vec3(2.2));
+  return max(sceneColor, vec3(0.0));
+}
+
+vec3 getTransmittedSceneColor(
+  vec3 position,
+  vec3 normal,
+  vec3 viewDirection,
+  float thickness,
+  float perceptualRoughness
+)
+{
+  if (pbrMaterial.dispersion <= 0.0) {
+    return sampleTransmittedSceneColor(
+      position,
+      normal,
+      viewDirection,
+      thickness,
+      perceptualRoughness,
+      pbrMaterial.ior
+    );
+  }
+
+  float halfSpread = (max(pbrMaterial.ior, 1.0) - 1.0) * 0.025 * pbrMaterial.dispersion;
+  vec3 indicesOfRefraction = max(
+    vec3(pbrMaterial.ior - halfSpread, pbrMaterial.ior, pbrMaterial.ior + halfSpread),
+    vec3(1.0)
+  );
+  return vec3(
+    sampleTransmittedSceneColor(
+      position, normal, viewDirection, thickness, perceptualRoughness, indicesOfRefraction.r
+    ).r,
+    sampleTransmittedSceneColor(
+      position, normal, viewDirection, thickness, perceptualRoughness, indicesOfRefraction.g
+    ).g,
+    sampleTransmittedSceneColor(
+      position, normal, viewDirection, thickness, perceptualRoughness, indicesOfRefraction.b
+    ).b
+  );
 }
 #endif
 
@@ -532,7 +682,9 @@ PBRInfo createClearcoatPBRInfo(PBRInfo basePBRInfo, vec3 clearcoatNormal, float 
     vec3(0.0),
     vec3(0.04),
     clearcoatNormal,
-    basePBRInfo.v
+    basePBRInfo.v,
+    basePBRInfo.l,
+    basePBRInfo.h
   );
 }
 
@@ -578,28 +730,72 @@ vec3 calculateSheenContribution(
     return vec3(0.0);
   }
 
-  float sheenFresnel = pow(clamp(1.0 - pbrInfo.VdotH, 0.0, 1.0), 5.0);
-  float sheenVisibility = mix(1.0, pbrInfo.NdotL * pbrInfo.NdotV, sheenRoughness);
-  return pbrInfo.NdotL *
-    lightColor *
-    sheenColor *
-    (0.25 + 0.75 * sheenFresnel) *
-    sheenVisibility *
+  float alpha = max(sheenRoughness * sheenRoughness, 0.0001);
+  float inverseAlpha = 1.0 / alpha;
+  float sineSquared = max(1.0 - pbrInfo.NdotH * pbrInfo.NdotH, 0.0);
+  float distribution = (2.0 + inverseAlpha) * pow(sineSquared, inverseAlpha * 0.5) /
+    (2.0 * M_PI);
+  float visibility = 1.0 / max(
+    4.0 * (pbrInfo.NdotL + pbrInfo.NdotV - pbrInfo.NdotL * pbrInfo.NdotV),
+    0.0001
+  );
+  return pbrInfo.NdotL * lightColor * sheenColor * distribution * visibility *
     (1.0 - pbrInfo.metalness);
 }
 
-float calculateAnisotropyBoost(
+vec3 calculateAnisotropicLightColor(
   PBRInfo pbrInfo,
+  vec3 lightColor,
   vec3 anisotropyTangent,
   float anisotropyStrength
 ) {
   if (anisotropyStrength <= 0.0) {
-    return 1.0;
+    return calculateFinalColor(pbrInfo, lightColor);
   }
 
   vec3 anisotropyBitangent = normalize(cross(pbrInfo.n, anisotropyTangent));
-  float bitangentViewAlignment = abs(dot(pbrInfo.v, anisotropyBitangent));
-  return mix(1.0, 0.65 + 0.7 * bitangentViewAlignment, anisotropyStrength);
+  float tangentRoughness = mix(
+    pbrInfo.alphaRoughness,
+    1.0,
+    anisotropyStrength * anisotropyStrength
+  );
+  float bitangentRoughness = clamp(pbrInfo.alphaRoughness, 0.001, 1.0);
+  float roughnessProduct = tangentRoughness * bitangentRoughness;
+  vec3 distributionVector = vec3(
+    bitangentRoughness * dot(anisotropyTangent, pbrInfo.h),
+    tangentRoughness * dot(anisotropyBitangent, pbrInfo.h),
+    roughnessProduct * pbrInfo.NdotH
+  );
+  float distributionFactor = roughnessProduct /
+    max(dot(distributionVector, distributionVector), 0.000001);
+  float distribution = roughnessProduct * distributionFactor * distributionFactor / M_PI;
+  float viewMask = pbrInfo.NdotL * length(vec3(
+    tangentRoughness * dot(anisotropyTangent, pbrInfo.v),
+    bitangentRoughness * dot(anisotropyBitangent, pbrInfo.v),
+    pbrInfo.NdotV
+  ));
+  float lightMask = pbrInfo.NdotV * length(vec3(
+    tangentRoughness * dot(anisotropyTangent, pbrInfo.l),
+    bitangentRoughness * dot(anisotropyBitangent, pbrInfo.l),
+    pbrInfo.NdotL
+  ));
+  float visibility = clamp(0.5 / max(viewMask + lightMask, 0.000001), 0.0, 1.0);
+  vec3 fresnel = specularReflection(pbrInfo);
+  vec3 diffuseContribution = (vec3(1.0) - fresnel) * diffuse(pbrInfo);
+  return pbrInfo.NdotL * lightColor *
+    (diffuseContribution + fresnel * distribution * visibility);
+}
+
+vec3 getAnisotropicReflection(PBRInfo pbrInfo, vec3 anisotropyTangent, float anisotropyStrength)
+{
+  if (anisotropyStrength <= 0.0) {
+    return -normalize(reflect(pbrInfo.v, pbrInfo.n));
+  }
+  vec3 anisotropyBitangent = normalize(cross(pbrInfo.n, anisotropyTangent));
+  vec3 anisotropicNormal = normalize(cross(anisotropyBitangent, pbrInfo.v));
+  anisotropicNormal = normalize(cross(anisotropicNormal, anisotropyBitangent));
+  float bend = anisotropyStrength * (1.0 - pbrInfo.perceptualRoughness);
+  return -normalize(reflect(pbrInfo.v, normalize(mix(pbrInfo.n, anisotropicNormal, bend))));
 }
 
 vec3 calculateMaterialLightColor(
@@ -613,8 +809,12 @@ vec3 calculateMaterialLightColor(
   vec3 anisotropyTangent,
   float anisotropyStrength
 ) {
-  float anisotropyBoost = calculateAnisotropyBoost(pbrInfo, anisotropyTangent, anisotropyStrength);
-  vec3 color = calculateFinalColor(pbrInfo, lightColor) * anisotropyBoost;
+  vec3 color = calculateAnisotropicLightColor(
+    pbrInfo,
+    lightColor,
+    anisotropyTangent,
+    anisotropyStrength
+  );
   color += calculateClearcoatContribution(
     pbrInfo,
     lightColor,
@@ -631,6 +831,8 @@ void PBRInfo_setAmbientLight(inout PBRInfo pbrInfo) {
   pbrInfo.NdotH = 0.0;
   pbrInfo.LdotH = 0.0;
   pbrInfo.VdotH = 1.0;
+  pbrInfo.l = pbrInfo.n;
+  pbrInfo.h = pbrInfo.n;
 }
 
 void PBRInfo_setDirectionalLight(inout PBRInfo pbrInfo, vec3 lightDirection) {
@@ -643,6 +845,8 @@ void PBRInfo_setDirectionalLight(inout PBRInfo pbrInfo, vec3 lightDirection) {
   pbrInfo.NdotH = clamp(dot(n, h), 0.0, 1.0);
   pbrInfo.LdotH = clamp(dot(l, h), 0.0, 1.0);
   pbrInfo.VdotH = clamp(dot(v, h), 0.0, 1.0);
+  pbrInfo.l = l;
+  pbrInfo.h = h;
 }
 
 void PBRInfo_setPointLight(inout PBRInfo pbrInfo, PointLight pointLight) {
@@ -769,6 +973,7 @@ vec4 pbr_filterColor(vec4 vertexColor)
       abs(pbrMaterial.specularIntensityFactor - 1.0) > 0.0001 ||
       maxComponent(abs(pbrMaterial.specularColorFactor - vec3(1.0))) > 0.0001 ||
       abs(pbrMaterial.ior - 1.5) > 0.0001 ||
+      pbrMaterial.dispersion > 0.0001 ||
       pbrMaterial.transmissionMapEnabled ||
       pbrMaterial.transmissionFactor > 0.0001 ||
       pbrMaterial.clearcoatMapEnabled ||
@@ -821,7 +1026,9 @@ vec4 pbr_filterColor(vec4 vertexColor)
         diffuseColor,
         specularColor,
         n,
-        v
+        v,
+        n,
+        n
       );
 
 #ifdef USE_LIGHTS
@@ -879,7 +1086,7 @@ vec4 pbr_filterColor(vec4 vertexColor)
       color = mix(color, vec3(perceptualRoughness), pbrMaterial.scaleDiffBaseMR.w);
 #endif
 
-      return vec4(pow(color, vec3(1.0 / 2.2)), baseColor.a);
+      return vec4(applySceneColorManagement(color), baseColor.a);
     }
 
     float specularIntensity = pbrMaterial.specularIntensityFactor;
@@ -975,13 +1182,6 @@ vec4 pbr_filterColor(vec4 vertexColor)
     if (length(anisotropyTangent) < 0.0001) {
       anisotropyTangent = normalize(tbn[0]);
     }
-    float anisotropyViewAlignment = abs(dot(v, anisotropyTangent));
-    perceptualRoughness = mix(
-      perceptualRoughness,
-      clamp(perceptualRoughness * (1.0 - 0.6 * anisotropyViewAlignment), c_MinRoughness, 1.0),
-      anisotropyStrength
-    );
-
     // Roughness is authored as perceptual roughness; as is convention,
     // convert to material roughness by squaring the perceptual roughness [2].
     float alphaRoughness = perceptualRoughness * perceptualRoughness;
@@ -991,17 +1191,24 @@ vec4 pbr_filterColor(vec4 vertexColor)
       vec3(dielectricF0) * specularFactor * specularIntensity,
       vec3(1.0)
     );
-    vec3 iridescenceTint = getIridescenceTint(iridescence, iridescenceThickness, NdotV);
-    dielectricSpecularF0 = mix(
-      dielectricSpecularF0,
-      dielectricSpecularF0 * iridescenceTint,
-      iridescence
+    dielectricSpecularF0 = getIridescenceTint(
+      iridescence,
+      iridescenceThickness,
+      NdotV,
+      dielectricSpecularF0
     );
     vec3 diffuseColor = baseColor.rgb * (vec3(1.0) - dielectricSpecularF0);
     diffuseColor *= (1.0 - metallic) * (1.0 - transmission);
     vec3 specularColor = mix(dielectricSpecularF0, baseColor.rgb, metallic);
 
-    float baseLayerEnergy = 1.0 - clearcoatFactor * 0.25;
+    float clearcoatViewFresnel = dielectricSchlick(
+      0.04,
+      clamp(abs(dot(clearcoatNormal, v)), 0.0, 1.0)
+    );
+    float sheenDirectionalAlbedo = maxComponent(sheenColor) *
+      (0.157 + 0.343 * (1.0 - NdotV)) * (1.0 - sheenRoughness * 0.5);
+    float baseLayerEnergy = (1.0 - clearcoatFactor * clearcoatViewFresnel) *
+      (1.0 - clamp(sheenDirectionalAlbedo, 0.0, 1.0));
     diffuseColor *= baseLayerEnergy;
     specularColor *= baseLayerEnergy;
 
@@ -1031,7 +1238,9 @@ vec4 pbr_filterColor(vec4 vertexColor)
       diffuseColor,
       specularColor,
       n,
-      v
+      v,
+      n,
+      n
     );
 
 
@@ -1109,8 +1318,11 @@ vec4 pbr_filterColor(vec4 vertexColor)
     // Calculate lighting contribution from image based lighting source (IBL)
 #ifdef USE_IBL
     if (pbrMaterial.IBLenabled) {
-      color += getIBLContribution(pbrInfo, n, reflection) *
-        calculateAnisotropyBoost(pbrInfo, anisotropyTangent, anisotropyStrength);
+      color += getIBLContribution(
+        pbrInfo,
+        n,
+        getAnisotropicReflection(pbrInfo, anisotropyTangent, anisotropyStrength)
+      );
       color += calculateClearcoatIBLContribution(
         pbrInfo,
         clearcoatNormal,
@@ -1180,6 +1392,6 @@ vec4 pbr_filterColor(vec4 vertexColor)
 #else
   float alpha = clamp(baseColor.a * (1.0 - transmission), 0.0, 1.0);
 #endif
-  return vec4(pow(color,vec3(1.0/2.2)), alpha);
+  return vec4(applySceneColorManagement(color), alpha);
 }
 `;

--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-wgsl.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-material-wgsl.ts
@@ -73,6 +73,7 @@ uniform pbrMaterialUniforms {
   bool anisotropyMapEnabled;
 
   float emissiveStrength;
+  float dispersion;
   
   // IBL
   bool IBLenabled;
@@ -248,6 +249,7 @@ struct pbrMaterialUniforms {
   anisotropyMapEnabled: i32,
 
   emissiveStrength: f32,
+  dispersion: f32,
   
   // IBL
   IBLenabled: i32,
@@ -384,6 +386,8 @@ struct PBRInfo {
   specularColor: vec3f,           // color contribution from specular lighting
   n: vec3f,                       // normal at surface point
   v: vec3f,                       // vector from surface point to camera
+  l: vec3f,                       // direction from the surface toward the current light
+  h: vec3f                        // half vector between the current light and camera
 };
 
 const M_PI = 3.141592653589793;
@@ -623,17 +627,131 @@ fn rotateDirection(direction: vec2f, rotation: f32) -> vec2f {
   return vec2f(direction.x * c - direction.y * s, direction.x * s + direction.y * c);
 }
 
-fn getIridescenceTint(iridescence: f32, thickness: f32, NdotV: f32) -> vec3f {
-  if (iridescence <= 0.0) {
-    return vec3f(1.0);
+fn encodeLinearSRGB(linearColor: vec3f) -> vec3f {
+  let positiveColor = max(linearColor, vec3f(0.0));
+  return select(
+    positiveColor * 12.92,
+    1.055 * pow(positiveColor, vec3f(1.0 / 2.4)) - 0.055,
+    positiveColor > vec3f(0.0031308)
+  );
+}
+
+fn toneMapKhronosPBRNeutral(inputColor: vec3f) -> vec3f {
+  let startCompression = 0.76;
+  let darkestChannel = min(inputColor.r, min(inputColor.g, inputColor.b));
+  let offset = select(
+    0.04,
+    darkestChannel - 6.25 * darkestChannel * darkestChannel,
+    darkestChannel < 0.08
+  );
+  var color = inputColor - vec3f(offset);
+  let peak = maxComponent(color);
+  if (peak < startCompression) {
+    return color;
   }
 
-  let phase = 0.015 * thickness * pbrMaterial.iridescenceIor + (1.0 - NdotV) * 6.0;
-  let thinFilmTint =
-    0.5 +
-    0.5 *
-    cos(vec3f(phase, phase + 2.0943951, phase + 4.1887902));
-  return mix(vec3f(1.0), thinFilmTint, iridescence);
+  let compressionRange = 1.0 - startCompression;
+  let compressedPeak = 1.0 - compressionRange * compressionRange /
+    (peak + compressionRange - startCompression);
+  color *= compressedPeak / max(peak, 0.0001);
+  let desaturation = 1.0 - 1.0 / (0.15 * (peak - compressedPeak) + 1.0);
+  return mix(color, vec3f(compressedPeak), desaturation);
+}
+
+fn applySceneColorManagement(sceneColor: vec3f) -> vec3f {
+#ifdef USE_SCENE_COLOR_MANAGEMENT
+  var color = max(sceneColor, vec3f(0.0)) * max(pbrScene.exposure, 0.0);
+  if (pbrScene.toneMapMode == 1) {
+    color /= vec3f(1.0) + color;
+  } else if (pbrScene.toneMapMode == 2) {
+    color = toneMapKhronosPBRNeutral(color);
+  } else if (pbrScene.toneMapMode == 3) {
+    color = clamp(
+      (color * (2.51 * color + 0.03)) / (color * (2.43 * color + 0.59) + 0.14),
+      vec3f(0.0),
+      vec3f(1.0)
+    );
+  }
+  if (pbrScene.outputEncoding == 0) {
+    return color;
+  }
+  return encodeLinearSRGB(color);
+#else
+  return pow(max(sceneColor, vec3f(0.0)), vec3f(1.0 / 2.2));
+#endif
+}
+
+fn dielectricSchlick(reflectance: f32, cosine: f32) -> f32 {
+  return reflectance + (1.0 - reflectance) * pow(clamp(1.0 - cosine, 0.0, 1.0), 5.0);
+}
+
+fn evaluateIridescenceSensitivity(opticalPathDifference: f32, phaseShift: vec3f) -> vec3f {
+  let phase = 2.0 * M_PI * opticalPathDifference * 1.0e-9;
+  let sensitivity = vec3f(5.4856e-13, 4.4201e-13, 5.2481e-13);
+  let position = vec3f(1.6810e6, 1.7953e6, 2.2084e6);
+  let variance = vec3f(4.3278e9, 9.3046e9, 6.6121e9);
+  var xyz = sensitivity * sqrt(2.0 * M_PI * variance) *
+    cos(position * phase + phaseShift) * exp(-phase * phase * variance);
+  xyz.x += 9.7470e-14 * sqrt(2.0 * M_PI * 4.5282e9) *
+    cos(2.2399e6 * phase + phaseShift.x) * exp(-4.5282e9 * phase * phase);
+  xyz /= 1.0685e-7;
+  return mat3x3f(
+    vec3f(3.2404542, -0.9692660, 0.0556434),
+    vec3f(-1.5371385, 1.8760108, -0.2040259),
+    vec3f(-0.4985314, 0.0415560, 1.0572252)
+  ) * xyz;
+}
+
+fn getIridescenceTint(
+  iridescence: f32,
+  thickness: f32,
+  NdotV: f32,
+  baseReflectance: vec3f
+) -> vec3f {
+  if (iridescence <= 0.0 || thickness <= 0.0) {
+    return baseReflectance;
+  }
+
+  let filmIor = max(pbrMaterial.iridescenceIor, 1.0);
+  let sineSquared = (1.0 - NdotV * NdotV) / (filmIor * filmIor);
+  let cosineSquared = 1.0 - sineSquared;
+  if (cosineSquared <= 0.0) {
+    return mix(baseReflectance, vec3f(1.0), iridescence);
+  }
+  let filmCosine = sqrt(cosineSquared);
+  let firstInterfaceReflectance = dielectricSchlick(getDielectricF0(filmIor), NdotV);
+  let transmittedEnergy = 1.0 - firstInterfaceReflectance;
+  let squareRootReflectance = sqrt(clamp(baseReflectance, vec3f(0.0), vec3f(0.9999)));
+  let baseIor = (vec3f(1.0) + squareRootReflectance) /
+    (vec3f(1.0) - squareRootReflectance);
+  var secondInterfaceF0 = (baseIor - vec3f(filmIor)) / (baseIor + vec3f(filmIor));
+  secondInterfaceF0 *= secondInterfaceF0;
+  let secondInterfaceReflectance = secondInterfaceF0 +
+    (vec3f(1.0) - secondInterfaceF0) * pow(1.0 - filmCosine, 5.0);
+  let phaseShift = vec3f(M_PI) + select(
+    vec3f(0.0),
+    vec3f(M_PI),
+    baseIor < vec3f(filmIor)
+  );
+  let opticalPathDifference = 2.0 * filmIor * thickness * filmCosine;
+  let combinedReflectance = clamp(
+    firstInterfaceReflectance * secondInterfaceReflectance,
+    vec3f(0.00001),
+    vec3f(0.9999)
+  );
+  let recurringAmplitude = sqrt(combinedReflectance);
+  let interfaceResponse = transmittedEnergy * transmittedEnergy * secondInterfaceReflectance /
+    (vec3f(1.0) - combinedReflectance);
+  var reflectedSpectrum = vec3f(firstInterfaceReflectance) + interfaceResponse;
+  var harmonicAmplitude = interfaceResponse - vec3f(transmittedEnergy);
+  for (var harmonic = 1; harmonic <= 2; harmonic++) {
+    harmonicAmplitude *= recurringAmplitude;
+    reflectedSpectrum += harmonicAmplitude * 2.0 * evaluateIridescenceSensitivity(
+      f32(harmonic) * opticalPathDifference,
+      f32(harmonic) * phaseShift
+    );
+  }
+  return mix(baseReflectance, clamp(reflectedSpectrum, vec3f(0.0), vec3f(1.0)), iridescence);
 }
 
 fn getVolumeAttenuation(thickness: f32) -> vec3f {
@@ -648,17 +766,18 @@ fn getVolumeAttenuation(thickness: f32) -> vec3f {
 }
 
 #ifdef USE_TRANSMISSION_FRAMEBUFFER
-fn getTransmittedSceneColor(
+fn sampleTransmittedSceneColor(
   position: vec3f,
   normal: vec3f,
   viewDirection: vec3f,
   thickness: f32,
-  perceptualRoughness: f32
+  perceptualRoughness: f32,
+  indexOfRefraction: f32
 ) -> vec3f {
   let refractionDirection = refract(
     -viewDirection,
     normal,
-    1.0 / max(pbrMaterial.ior, 1.0)
+    1.0 / max(indexOfRefraction, 1.0)
   );
   let refractedPosition = position + refractionDirection * thickness;
   let clipPosition = pbrScene.projectionMatrix *
@@ -699,7 +818,43 @@ fn getTransmittedSceneColor(
     textureCoordinate - vec2f(0.0, blurRadius.y),
     0.0
   ).rgb * 0.15;
-  return pow(max(sceneColor, vec3f(0.0)), vec3f(2.2));
+  return max(sceneColor, vec3f(0.0));
+}
+
+fn getTransmittedSceneColor(
+  position: vec3f,
+  normal: vec3f,
+  viewDirection: vec3f,
+  thickness: f32,
+  perceptualRoughness: f32
+) -> vec3f {
+  if (pbrMaterial.dispersion <= 0.0) {
+    return sampleTransmittedSceneColor(
+      position,
+      normal,
+      viewDirection,
+      thickness,
+      perceptualRoughness,
+      pbrMaterial.ior
+    );
+  }
+
+  let halfSpread = (max(pbrMaterial.ior, 1.0) - 1.0) * 0.025 * pbrMaterial.dispersion;
+  let indicesOfRefraction = max(
+    vec3f(pbrMaterial.ior - halfSpread, pbrMaterial.ior, pbrMaterial.ior + halfSpread),
+    vec3f(1.0)
+  );
+  return vec3f(
+    sampleTransmittedSceneColor(
+      position, normal, viewDirection, thickness, perceptualRoughness, indicesOfRefraction.r
+    ).r,
+    sampleTransmittedSceneColor(
+      position, normal, viewDirection, thickness, perceptualRoughness, indicesOfRefraction.g
+    ).g,
+    sampleTransmittedSceneColor(
+      position, normal, viewDirection, thickness, perceptualRoughness, indicesOfRefraction.b
+    ).b
+  );
 }
 #endif
 
@@ -726,7 +881,9 @@ fn createClearcoatPBRInfo(
     vec3f(0.0),
     vec3f(0.04),
     clearcoatNormal,
-    basePBRInfo.v
+    basePBRInfo.v,
+    basePBRInfo.l,
+    basePBRInfo.h
   );
 }
 
@@ -772,28 +929,75 @@ fn calculateSheenContribution(
     return vec3f(0.0);
   }
 
-  let sheenFresnel = pow(clamp(1.0 - pbrInfo.VdotH, 0.0, 1.0), 5.0);
-  let sheenVisibility = mix(1.0, pbrInfo.NdotL * pbrInfo.NdotV, sheenRoughness);
-  return pbrInfo.NdotL *
-    lightColor *
-    sheenColor *
-    (0.25 + 0.75 * sheenFresnel) *
-    sheenVisibility *
+  let alpha = max(sheenRoughness * sheenRoughness, 0.0001);
+  let inverseAlpha = 1.0 / alpha;
+  let sineSquared = max(1.0 - pbrInfo.NdotH * pbrInfo.NdotH, 0.0);
+  let distribution = (2.0 + inverseAlpha) * pow(sineSquared, inverseAlpha * 0.5) /
+    (2.0 * M_PI);
+  let visibility = 1.0 / max(
+    4.0 * (pbrInfo.NdotL + pbrInfo.NdotV - pbrInfo.NdotL * pbrInfo.NdotV),
+    0.0001
+  );
+  return pbrInfo.NdotL * lightColor * sheenColor * distribution * visibility *
     (1.0 - pbrInfo.metalness);
 }
 
-fn calculateAnisotropyBoost(
+fn calculateAnisotropicLightColor(
   pbrInfo: PBRInfo,
+  lightColor: vec3f,
   anisotropyTangent: vec3f,
   anisotropyStrength: f32
-) -> f32 {
+) -> vec3f {
   if (anisotropyStrength <= 0.0) {
-    return 1.0;
+    return calculateFinalColor(pbrInfo, lightColor);
   }
 
   let anisotropyBitangent = normalize(cross(pbrInfo.n, anisotropyTangent));
-  let bitangentViewAlignment = abs(dot(pbrInfo.v, anisotropyBitangent));
-  return mix(1.0, 0.65 + 0.7 * bitangentViewAlignment, anisotropyStrength);
+  let tangentRoughness = mix(
+    pbrInfo.alphaRoughness,
+    1.0,
+    anisotropyStrength * anisotropyStrength
+  );
+  let bitangentRoughness = clamp(pbrInfo.alphaRoughness, 0.001, 1.0);
+  let roughnessProduct = tangentRoughness * bitangentRoughness;
+  let distributionVector = vec3f(
+    bitangentRoughness * dot(anisotropyTangent, pbrInfo.h),
+    tangentRoughness * dot(anisotropyBitangent, pbrInfo.h),
+    roughnessProduct * pbrInfo.NdotH
+  );
+  let distributionFactor = roughnessProduct /
+    max(dot(distributionVector, distributionVector), 0.000001);
+  let distribution = roughnessProduct * distributionFactor * distributionFactor / M_PI;
+  let viewMask = pbrInfo.NdotL * length(vec3f(
+    tangentRoughness * dot(anisotropyTangent, pbrInfo.v),
+    bitangentRoughness * dot(anisotropyBitangent, pbrInfo.v),
+    pbrInfo.NdotV
+  ));
+  let lightMask = pbrInfo.NdotV * length(vec3f(
+    tangentRoughness * dot(anisotropyTangent, pbrInfo.l),
+    bitangentRoughness * dot(anisotropyBitangent, pbrInfo.l),
+    pbrInfo.NdotL
+  ));
+  let visibility = clamp(0.5 / max(viewMask + lightMask, 0.000001), 0.0, 1.0);
+  let fresnel = specularReflection(pbrInfo);
+  let diffuseContribution = (vec3f(1.0) - fresnel) * diffuse(pbrInfo);
+  return pbrInfo.NdotL * lightColor *
+    (diffuseContribution + fresnel * distribution * visibility);
+}
+
+fn getAnisotropicReflection(
+  pbrInfo: PBRInfo,
+  anisotropyTangent: vec3f,
+  anisotropyStrength: f32
+) -> vec3f {
+  if (anisotropyStrength <= 0.0) {
+    return -normalize(reflect(pbrInfo.v, pbrInfo.n));
+  }
+  let anisotropyBitangent = normalize(cross(pbrInfo.n, anisotropyTangent));
+  var anisotropicNormal = normalize(cross(anisotropyBitangent, pbrInfo.v));
+  anisotropicNormal = normalize(cross(anisotropicNormal, anisotropyBitangent));
+  let bend = anisotropyStrength * (1.0 - pbrInfo.perceptualRoughness);
+  return -normalize(reflect(pbrInfo.v, normalize(mix(pbrInfo.n, anisotropicNormal, bend))));
 }
 
 fn calculateMaterialLightColor(
@@ -807,8 +1011,12 @@ fn calculateMaterialLightColor(
   anisotropyTangent: vec3f,
   anisotropyStrength: f32
 ) -> vec3f {
-  let anisotropyBoost = calculateAnisotropyBoost(pbrInfo, anisotropyTangent, anisotropyStrength);
-  var color = calculateFinalColor(pbrInfo, lightColor) * anisotropyBoost;
+  var color = calculateAnisotropicLightColor(
+    pbrInfo,
+    lightColor,
+    anisotropyTangent,
+    anisotropyStrength
+  );
   color += calculateClearcoatContribution(
     pbrInfo,
     lightColor,
@@ -825,6 +1033,8 @@ fn PBRInfo_setAmbientLight(pbrInfo: ptr<function, PBRInfo>) {
   (*pbrInfo).NdotH = 0.0;
   (*pbrInfo).LdotH = 0.0;
   (*pbrInfo).VdotH = 1.0;
+  (*pbrInfo).l = (*pbrInfo).n;
+  (*pbrInfo).h = (*pbrInfo).n;
 }
 
 fn PBRInfo_setDirectionalLight(pbrInfo: ptr<function, PBRInfo>, lightDirection: vec3<f32>) {
@@ -837,6 +1047,8 @@ fn PBRInfo_setDirectionalLight(pbrInfo: ptr<function, PBRInfo>, lightDirection: 
   (*pbrInfo).NdotH = clamp(dot(n, h), 0.0, 1.0);
   (*pbrInfo).LdotH = clamp(dot(l, h), 0.0, 1.0);
   (*pbrInfo).VdotH = clamp(dot(v, h), 0.0, 1.0);
+  (*pbrInfo).l = l;
+  (*pbrInfo).h = h;
 }
 
 fn PBRInfo_setPointLight(pbrInfo: ptr<function, PBRInfo>, pointLight: PointLight) {
@@ -964,6 +1176,7 @@ fn pbr_filterColor(vertexColor: vec4<f32>) -> vec4<f32> {
       abs(pbrMaterial.specularIntensityFactor - 1.0) > 0.0001 ||
       maxComponent(abs(pbrMaterial.specularColorFactor - vec3f(1.0))) > 0.0001 ||
       abs(pbrMaterial.ior - 1.5) > 0.0001 ||
+      pbrMaterial.dispersion > 0.0001 ||
       pbrMaterial.transmissionMapEnabled != 0 ||
       pbrMaterial.transmissionFactor > 0.0001 ||
       pbrMaterial.clearcoatMapEnabled != 0 ||
@@ -1013,7 +1226,9 @@ fn pbr_filterColor(vertexColor: vec4<f32>) -> vec4<f32> {
         diffuseColor,
         specularColor,
         n,
-        v
+        v,
+        n,
+        n
       );
 
       #ifdef USE_LIGHTS
@@ -1079,7 +1294,7 @@ fn pbr_filterColor(vertexColor: vec4<f32>) -> vec4<f32> {
       color = mix(color, vec3<f32>(perceptualRoughness), pbrMaterial.scaleDiffBaseMR.w);
       #endif
 
-      return vec4<f32>(pow(color, vec3<f32>(1.0 / 2.2)), baseColor.a);
+      return vec4<f32>(applySceneColorManagement(color), baseColor.a);
     }
 
     var specularIntensity = pbrMaterial.specularIntensityFactor;
@@ -1224,13 +1439,6 @@ fn pbr_filterColor(vertexColor: vec4<f32>) -> vec4<f32> {
     if (length(anisotropyTangent) < 0.0001) {
       anisotropyTangent = normalize(tbn[0]);
     }
-    let anisotropyViewAlignment = abs(dot(v, anisotropyTangent));
-    perceptualRoughness = mix(
-      perceptualRoughness,
-      clamp(perceptualRoughness * (1.0 - 0.6 * anisotropyViewAlignment), c_MinRoughness, 1.0),
-      anisotropyStrength
-    );
-
     // Roughness is authored as perceptual roughness; as is convention,
     // convert to material roughness by squaring the perceptual roughness [2].
     let alphaRoughness = perceptualRoughness * perceptualRoughness;
@@ -1240,17 +1448,24 @@ fn pbr_filterColor(vertexColor: vec4<f32>) -> vec4<f32> {
       vec3f(dielectricF0) * specularFactor * specularIntensity,
       vec3f(1.0)
     );
-    let iridescenceTint = getIridescenceTint(iridescence, iridescenceThickness, NdotV);
-    dielectricSpecularF0 = mix(
-      dielectricSpecularF0,
-      dielectricSpecularF0 * iridescenceTint,
-      iridescence
+    dielectricSpecularF0 = getIridescenceTint(
+      iridescence,
+      iridescenceThickness,
+      NdotV,
+      dielectricSpecularF0
     );
     var diffuseColor = baseColor.rgb * (vec3f(1.0) - dielectricSpecularF0);
     diffuseColor *= (1.0 - metallic) * (1.0 - transmission);
     var specularColor = mix(dielectricSpecularF0, baseColor.rgb, metallic);
 
-    let baseLayerEnergy = 1.0 - clearcoatFactor * 0.25;
+    let clearcoatViewFresnel = dielectricSchlick(
+      0.04,
+      clamp(abs(dot(clearcoatNormal, v)), 0.0, 1.0)
+    );
+    let sheenDirectionalAlbedo = maxComponent(sheenColor) *
+      (0.157 + 0.343 * (1.0 - NdotV)) * (1.0 - sheenRoughness * 0.5);
+    let baseLayerEnergy = (1.0 - clearcoatFactor * clearcoatViewFresnel) *
+      (1.0 - clamp(sheenDirectionalAlbedo, 0.0, 1.0));
     diffuseColor *= baseLayerEnergy;
     specularColor *= baseLayerEnergy;
 
@@ -1280,7 +1495,9 @@ fn pbr_filterColor(vertexColor: vec4<f32>) -> vec4<f32> {
       diffuseColor,
       specularColor,
       n,
-      v
+      v,
+      n,
+      n
     );
 
     #ifdef USE_LIGHTS
@@ -1360,8 +1577,11 @@ fn pbr_filterColor(vertexColor: vec4<f32>) -> vec4<f32> {
     // Calculate lighting contribution from image based lighting source (IBL)
     #ifdef USE_IBL
     if (pbrMaterial.IBLenabled != 0) {
-      color += getIBLContribution(pbrInfo, n, reflection) *
-        calculateAnisotropyBoost(pbrInfo, anisotropyTangent, anisotropyStrength);
+      color += getIBLContribution(
+        pbrInfo,
+        n,
+        getAnisotropicReflection(pbrInfo, anisotropyTangent, anisotropyStrength)
+      );
       color += calculateClearcoatIBLContribution(
         pbrInfo,
         clearcoatNormal,
@@ -1432,6 +1652,6 @@ fn pbr_filterColor(vertexColor: vec4<f32>) -> vec4<f32> {
   #else
   let alpha = clamp(baseColor.a * (1.0 - transmission), 0.0, 1.0);
   #endif
-  return vec4<f32>(pow(color, vec3<f32>(1.0 / 2.2)), alpha);
+  return vec4<f32>(applySceneColorManagement(color), alpha);
 }
 `;

--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-material.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-material.ts
@@ -7,20 +7,20 @@
 import type {Texture} from '@luma.gl/core';
 import type {
   Matrix3,
-  Vector2,
-  Vector3,
-  Vector4,
   NumberArray2,
   NumberArray3,
   NumberArray4,
-  NumberArray9
+  NumberArray9,
+  Vector2,
+  Vector3,
+  Vector4
 } from '@math.gl/core';
 
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
-import {lighting} from '../lights/lighting';
 import {ibl} from '../ibl/ibl';
+import {lighting} from '../lights/lighting';
 
-import {vs, fs} from './pbr-material-glsl';
+import {fs, vs} from './pbr-material-glsl';
 import {source} from './pbr-material-wgsl';
 import {pbrProjection} from './pbr-projection';
 
@@ -86,6 +86,9 @@ export type PBRMaterialUniforms = {
   specularIntensityMapEnabled?: boolean;
 
   ior?: number;
+
+  /** Chromatic transmission spread, expressed as 20 divided by the material Abbe number. */
+  dispersion?: number;
 
   transmissionFactor?: number;
   transmissionMapEnabled?: boolean;
@@ -223,6 +226,7 @@ export const pbrMaterial = {
     anisotropyMapEnabled: false,
 
     emissiveStrength: 1,
+    dispersion: 0,
 
     baseColorUVSet: 0,
     baseColorUVTransform: [1, 0, 0, 0, 1, 0, 0, 0, 1],
@@ -370,6 +374,7 @@ export const pbrMaterial = {
     anisotropyMapEnabled: 'i32',
 
     emissiveStrength: 'f32',
+    dispersion: 'f32',
 
     // IBL
     IBLenabled: 'i32',

--- a/modules/shadertools/src/modules/lighting/pbr-material/pbr-scene.ts
+++ b/modules/shadertools/src/modules/lighting/pbr-material/pbr-scene.ts
@@ -7,6 +7,16 @@ import type {NumberArray2, NumberArray16} from '@math.gl/core';
 
 import {ShaderModule} from '../../../lib/shader-module/shader-module';
 
+/** Portable scene tone-mapping modes shared by the GLSL and WGSL PBR implementations. */
+export const PBR_TONE_MAP_MODE = {
+  NONE: 0,
+  REINHARD: 1,
+  KHRONOS_PBR_NEUTRAL: 2,
+  ACES: 3
+} as const;
+
+export type PBRToneMapMode = (typeof PBR_TONE_MAP_MODE)[keyof typeof PBR_TONE_MAP_MODE];
+
 export type PBRSceneBindings = {
   pbr_transmissionFramebufferSampler?: Texture | null;
 };
@@ -17,6 +27,8 @@ export type PBRSceneUniforms = {
   environmentIntensity?: number;
   environmentRotation?: number;
   environmentMipCount?: number;
+  /** Zero keeps scene radiance linear; one applies the exact sRGB output transfer function. */
+  outputEncoding?: number;
   framebufferSize?: NumberArray2;
   viewMatrix?: NumberArray16;
   projectionMatrix?: NumberArray16;
@@ -33,6 +45,7 @@ layout(std140) uniform pbrSceneUniforms {
   float environmentIntensity;
   float environmentRotation;
   float environmentMipCount;
+  int outputEncoding;
   vec2 framebufferSize;
   mat4 viewMatrix;
   mat4 projectionMatrix;
@@ -50,6 +63,7 @@ struct pbrSceneUniforms {
   environmentIntensity: f32,
   environmentRotation: f32,
   environmentMipCount: f32,
+  outputEncoding: i32,
   framebufferSize: vec2<f32>,
   viewMatrix: mat4x4<f32>,
   projectionMatrix: mat4x4<f32>
@@ -79,16 +93,18 @@ export const pbrScene = {
     environmentIntensity: 'f32',
     environmentRotation: 'f32',
     environmentMipCount: 'f32',
+    outputEncoding: 'i32',
     framebufferSize: 'vec2<f32>',
     viewMatrix: 'mat4x4<f32>',
     projectionMatrix: 'mat4x4<f32>'
   },
   defaultUniforms: {
     exposure: 1,
-    toneMapMode: 2,
+    toneMapMode: PBR_TONE_MAP_MODE.KHRONOS_PBR_NEUTRAL,
     environmentIntensity: 1,
     environmentRotation: Math.PI * 0.5,
     environmentMipCount: 1,
+    outputEncoding: 1,
     framebufferSize: [1, 1],
     viewMatrix: IDENTITY_MATRIX,
     projectionMatrix: IDENTITY_MATRIX

--- a/modules/shadertools/test/modules/lighting/pbr-material.spec.ts
+++ b/modules/shadertools/test/modules/lighting/pbr-material.spec.ts
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) vis.gl contributors
 
-import test from 'test/utils/vitest-tape';
 import {makeShaderBlockLayout, ShaderBlockWriter, UniformStore} from '@luma.gl/core';
 import {
   getShaderModuleUniformBlockFields,
   getShaderModuleUniformLayoutValidationResult,
   getShaderModuleUniforms,
-  pbrMaterial,
-  type PBRMaterialUniforms
+  type PBRMaterialUniforms,
+  pbrMaterial
 } from '@luma.gl/shadertools';
+import test from 'test/utils/vitest-tape';
 
 const FLOAT32_EPSILON = 1e-6;
 
@@ -55,7 +55,8 @@ const CORE_UNIFORM_BUFFER_LAYOUT = {
   anisotropyDirection: {offset: 58, size: 2},
   anisotropyMapEnabled: {offset: 60, size: 1},
   emissiveStrength: {offset: 61, size: 1},
-  IBLenabled: {offset: 62, size: 1},
+  dispersion: {offset: 62, size: 1},
+  IBLenabled: {offset: 63, size: 1},
   scaleIBLAmbient: {offset: 64, size: 2},
   scaleDiffBaseMR: {offset: 68, size: 4},
   scaleFGDSpec: {offset: 72, size: 4}
@@ -140,6 +141,7 @@ const fullPBRUniforms: Required<PBRMaterialUniforms> = {
   anisotropyDirection: [0.6, -0.8],
   anisotropyMapEnabled: true,
   emissiveStrength: 4.2,
+  dispersion: 0.65,
   IBLenabled: true,
   scaleIBLAmbient: [1.25, 0.75],
   scaleDiffBaseMR: [1, 0.5, 0.25, 0.125],
@@ -283,7 +285,8 @@ test('shadertools#pbrMaterial serializes a full PBR sample into the expected buf
     iridescenceIor: 1.18,
     anisotropyStrength: 0.5,
     anisotropyRotation: 1.25,
-    emissiveStrength: 4.2
+    emissiveStrength: 4.2,
+    dispersion: 0.65
   } as const;
 
   for (const [uniformName, expectedValue] of Object.entries(expectedScalarValues)) {
@@ -326,7 +329,7 @@ test('shadertools#pbrMaterial serializes a full PBR sample into the expected buf
     attenuationColor: [],
     sheenColorFactor: [],
     anisotropyRotation: [57],
-    IBLenabled: [63]
+    IBLenabled: []
   } as const;
 
   for (const [uniformName, paddingSlots] of Object.entries(expectedPaddingSlots)) {

--- a/modules/shadertools/test/modules/lighting/pbr-scene.spec.ts
+++ b/modules/shadertools/test/modules/lighting/pbr-scene.spec.ts
@@ -6,6 +6,7 @@ import {makeShaderBlockLayout} from '@luma.gl/core';
 import {
   getShaderModuleUniformBlockFields,
   getShaderModuleUniformLayoutValidationResult,
+  PBR_TONE_MAP_MODE,
   pbrScene
 } from '@luma.gl/shadertools';
 import test from 'test/utils/vitest-tape';
@@ -16,12 +17,18 @@ const EXPECTED_UNIFORM_NAMES = [
   'environmentIntensity',
   'environmentRotation',
   'environmentMipCount',
+  'outputEncoding',
   'framebufferSize',
   'viewMatrix',
   'projectionMatrix'
 ];
 
 test('shadertools#pbrScene exposes stable uniform layout metadata', testCase => {
+  testCase.deepEqual(
+    PBR_TONE_MAP_MODE,
+    {NONE: 0, REINHARD: 1, KHRONOS_PBR_NEUTRAL: 2, ACES: 3},
+    'portable public tone-mapping mode selectors remain stable'
+  );
   testCase.deepEqual(
     Object.keys(pbrScene.uniformTypes),
     EXPECTED_UNIFORM_NAMES,
@@ -57,6 +64,11 @@ test('shadertools#pbrScene exposes stable uniform layout metadata', testCase => 
     shaderBlockLayout.fields.environmentMipCount.offset,
     4,
     'environment mip count occupies the previously unused scalar position'
+  );
+  testCase.equal(
+    shaderBlockLayout.fields.outputEncoding.offset,
+    5,
+    'output encoding occupies the remaining scene-uniform padding slot'
   );
   testCase.equal(
     shaderBlockLayout.fields.framebufferSize.offset,


### PR DESCRIPTION
## Goals

Close the remaining glTF physical-material gap without introducing an ANARI-specific shader, renderer, or BRDF. Make scene exposure and tone mapping actually affect rendering, preserve linear HDR radiance through transmission, and support the ratified `KHR_materials_dispersion` extension end to end.

## Changes

- Apply exposure, exact piecewise sRGB encoding, Reinhard, Khronos PBR Neutral, and ACES tone mapping consistently in the canonical GLSL and WGSL PBR shaders.
- Export stable `PBR_TONE_MAP_MODE` selectors and add explicit `SceneRenderOptions.outputColorSpace`; floating-point targets default to unclamped linear HDR output.
- Capture opaque scene color into separately retained linear targets, preferring filterable/renderable `rgba16float` and falling back to `rgba8unorm`; prevent double exposure, tone mapping, and gamma conversion before refraction.
- Implement wavelength-dependent RGB indices of refraction using the ratified Khronos dispersion parameterization while retaining opaque transmission alpha.
- Improve reference fidelity with anisotropic GGX distribution and correlated visibility, Charlie-distributed sheen, spectral thin-film interference, and Fresnel-aware clearcoat/sheen base-layer energy compensation.
- Decode authored glTF dispersion and exact sRGB source colors, preserve dispersion through the existing ANARI material handle/schema and showcase glTF importer, and accurately advertise extension support.
- Update experimental renderer, glTF material/extension, and retained ANARI documentation.

## Verification

- `node_modules/.bin/tspc -b modules/anari/tsconfig.json --pretty false --force`: all transitive production package source projects pass strict TypeScript compilation.
- `node_modules/.bin/vitest run --config /private/tmp/luma-anari-vitest.config.mjs modules/experimental/test/engine modules/anari/test modules/gltf/test/parsers modules/gltf/test/gltf`: **18 suites / 115 node tests passed**.
- Native Chromium Metal WebGL + WebGPU regression suite: **8 suites / 35 browser tests passed**, including actual pixel readbacks for exact sRGB transfer, exposure, distinct tone mappers, unclamped floating-point HDR, opaque alpha, and visible chromatic refraction.
- Full Docusaurus production website build succeeded, including all changed material/rendering documentation and generated search/LLM indexes.
- Equivalent scoped Biome formatting/lint validation and `git diff --check` passed.
- The standard `yarn examples:typecheck` command was attempted; this local checkout resolves stale linked workspace package declarations predating current master, so it reports pre-existing missing exports and unrelated example errors. Cross-package source builds, the complete ANARI importer regression, and the fresh-dependency GitHub Actions examples check cover the actual changes.

## Architecture / Ownership

- `@luma.gl/shadertools` owns shared BRDFs, transfer functions, tone mapping, physical-material uniforms, and portable GLSL/WGSL shading.
- `@luma.gl/experimental` owns retained scene orchestration, structural pipeline invalidation, and linear/HDR transmission capture.
- `@luma.gl/gltf` owns extension decoding and source-faithful texture color handling.
- `@luma.gl/anari` remains a thin retained-parameter/schema adapter and does not gain shader code, rendering implementations, or format parsing.
- Targets `master` directly and has no dependency on the concurrent native-extension, production-animation, or interchange pull requests.