### PR TITLE
feat(gltf): add source-faithful animated asset interchange

### DIFF
--- a/docs/api-reference/README.md
+++ b/docs/api-reference/README.md
@@ -23,7 +23,7 @@ If you are looking for `Model`, start with [`@luma.gl/engine`][engine]. The `Mod
 | [`@luma.gl/text`][text]               | Experimental / Private | `TextRenderer` facade and caller-owned GPU text data.                                 |
 | [`@luma.gl/splats`][splats]           | Experimental / Private | Gaussian splat rendering and caller-owned prepared GPU splat data.                    |
 | [`@luma.gl/experimental`][experimental] | Experimental / Private | Experimental v10 APIs, including WebGPU/WebGL WebXR and WebGL raw camera helpers. |
-| [`@luma.gl/gltf`][gltf]               | Optional    | glTF scenegraph loading and instantiation etc.                                                  |
+| [`@luma.gl/gltf`][gltf]               | Optional    | Standards-first glTF assets, physical materials, character animation, and lossless interchange. |
 | [`@luma.gl/test-utils`][test-utils]   | Optional    | Test setups, in particular support for rendering and comparing images.                          |
 
 \* At least one backend, either WebGL or WebGPU, must be installed to enable GPU resource creation.
@@ -40,7 +40,7 @@ If you are looking for `Model`, start with [`@luma.gl/engine`][engine]. The `Mod
 - [`@luma.gl/text`][text] for `TextRenderer` and GPU text data; use [`@luma.gl/arrow`][arrow] for Arrow conversion.
 - [`@luma.gl/splats`][splats] for experimental Gaussian splat rendering and caller-owned prepared GPU data.
 - [`@luma.gl/experimental`][experimental] for v10 work-in-progress APIs, including experimental WebXR frame, view, and raw camera helpers.
-- [`@luma.gl/gltf`][gltf] for glTF scenegraph loading and extensions.
+- [`@luma.gl/gltf`][gltf] for standards-first glTF assets, physical materials, character animation, native extensions, and source-faithful `.gltf`/`.glb` interchange.
 - [`@luma.gl/webgl`][webgl] and [`@luma.gl/webgpu`][webgpu] for backend adapters used by `@luma.gl/core`.
 - [`@luma.gl/webgl/constants`](/docs/api-reference/webgl/constants) when you need raw numeric WebGL enums.
 

--- a/docs/api-reference/gltf/README.md
+++ b/docs/api-reference/gltf/README.md
@@ -5,10 +5,13 @@ import {GLTFExample} from '@site/src/examples';
 
 <GltfDocsTabs active="overview" />
 
-`@luma.gl/gltf` turns postprocessed glTF assets into ordinary luma.gl scenegraphs, physically
-based materials, punctual lights, and animated mesh data. File loading, decompression, and glTF
-postprocessing belong to `@loaders.gl/gltf`; animation primitives, geometry, and shader modules
-remain in their existing luma.gl packages.
+`@luma.gl/gltf` is a standards-first asset runtime for physically based materials, animated
+characters, morph deformation, native animation pointers, and source-faithful `.gltf` / `.glb`
+interchange across WebGPU and WebGL. It turns postprocessed glTF assets into ordinary luma.gl
+scenegraphs and exports generic scene descriptors without depending on a particular renderer.
+
+File loading, decompression, and glTF postprocessing belong to `@loaders.gl/gltf`; animation
+primitives, geometry, and shader modules remain in their existing luma.gl packages.
 
 <GLTFExample embedded showStats={false} />
 
@@ -129,6 +132,24 @@ and morph-target helpers preserve authored joint attributes, target deltas, and 
 See [glTF animation and deformation](/docs/api-reference/gltf/gltf-animation), the
 [engine animation guide](/docs/api-guide/engine/animation), and
 [glTF extension support](/docs/api-reference/gltf/gltf-extensions) for details and limitations.
+
+## Source-faithful asset interchange
+
+`exportGLTF()` serializes renderer-independent glTF scene descriptors as embedded JSON or binary
+GLB. Existing hierarchy, skins, inverse bind matrices, morph targets, animation clips, material
+pointers, variants, GPU instancing, cameras, punctual lights, sampler settings, and authored
+physical materials remain available to the output asset.
+
+```ts
+import {exportGLTF, type GLTFExportScene} from '@luma.gl/gltf';
+
+const scene: GLTFExportScene = {name: 'Exported scene', nodes: [{name: 'Root'}]};
+const document: string = exportGLTF(scene);
+const binary: ArrayBuffer = exportGLTF(scene, {binary: true});
+```
+
+See [glTF asset interchange](/docs/api-reference/gltf/gltf-interchange) for typed descriptors,
+RGBA vertex colors, normalized joint weights, animation pointers, and resource ownership.
 
 ## Package ownership
 

--- a/docs/api-reference/gltf/gltf-interchange.md
+++ b/docs/api-reference/gltf/gltf-interchange.md
@@ -1,0 +1,192 @@
+import {GltfDocsTabs} from '@site/src/components/docs/gltf-docs-tabs';
+
+# glTF Asset Interchange
+
+<GltfDocsTabs active="interchange" />
+
+`@luma.gl/gltf` owns format-native scene interchange. `exportGLTF()` writes standards-conformant
+embedded `.gltf` documents or aligned binary `.glb` assets without depending on an application
+renderer, an ANARI device, or browser-specific GPU resources.
+
+The same descriptors preserve authored node hierarchies, skins, inverse bind matrices, morph
+targets, animation clips, material-animation pointers, GPU instancing, variants, cameras,
+punctual-light extensions, and complete physical material records.
+
+## Export a scene
+
+```ts
+import {exportGLTF, type GLTFExportScene} from '@luma.gl/gltf';
+
+const scene: GLTFExportScene = {
+  name: 'Animated character',
+  nodes: [
+    {name: 'Root', children: [1]},
+    {name: 'Character', mesh: 0, weights: [0, 1]}
+  ],
+  meshes: [
+    {
+      name: 'Character mesh',
+      weights: [0, 1],
+      primitives: [
+        {
+          attributes: {
+            POSITION: {
+              data: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+              size: 3
+            },
+            COLOR_0: {
+              data: new Float32Array([1, 0, 0, 1, 0, 1, 0, 0.5, 0, 0, 1, 1]),
+              size: 4
+            }
+          },
+          indices: {data: new Uint16Array([0, 1, 2]), size: 1},
+          material: 0
+        }
+      ]
+    }
+  ],
+  materials: [
+    {
+      pbrMetallicRoughness: {
+        baseColorFactor: [0.8, 0.5, 0.3, 1],
+        metallicFactor: 0.2,
+        roughnessFactor: 0.4
+      }
+    }
+  ]
+};
+
+const gltf: string = exportGLTF(scene);
+const glb: ArrayBuffer = exportGLTF(scene, {binary: true});
+```
+
+JSON assets embed their geometry in a `data:` URI. GLB assets contain correctly padded JSON and
+binary chunks. Both formats can be loaded again using the existing loaders.gl `GLTFLoader`.
+
+## Geometry and typed accessors
+
+Every attribute retains its original glTF semantic. Do not replace source attribute keys with
+shader-facing aliases.
+
+```ts
+const attributes = {
+  POSITION: {data: new Float32Array(positions), size: 3},
+  NORMAL: {data: new Float32Array(normals), size: 3},
+  TANGENT: {data: new Float32Array(tangents), size: 4},
+  TEXCOORD_0: {data: new Float32Array(textureCoordinates), size: 2},
+  TEXCOORD_1: {data: new Float32Array(additionalTextureCoordinates), size: 2},
+  COLOR_0: {data: new Float32Array(vertexColors), size: 4},
+  JOINTS_0: {data: new Uint16Array(jointIndices), size: 4},
+  WEIGHTS_0: {data: new Uint8Array(jointWeights), size: 4, normalized: true},
+  _TEMPERATURE: {data: new Float32Array(temperatures), size: 1}
+};
+```
+
+The writer preserves authored component types, integer normalization, custom `_NAME` semantics,
+RGBA vertex colors, tangent handedness, and aligned buffer views. Position bounds are generated
+automatically unless explicit `min` and `max` values are supplied.
+
+Sparse attributes preserve both their base values and sparse overrides:
+
+```ts
+const sparseAttribute = {
+  data: new Float32Array([0, 0, 0]),
+  size: 1,
+  sparse: {
+    indices: new Uint16Array([1]),
+    values: new Float32Array([42])
+  }
+};
+```
+
+## Skins and morph targets
+
+Attach an existing glTF skin to the relevant node; joint indices address exported nodes.
+
+```ts
+const skinnedScene = {
+  nodes: [
+    {name: 'Root', children: [1, 2]},
+    {name: 'Character', mesh: 0, skin: 0},
+    {name: 'Joint'}
+  ],
+  skins: [
+    {
+      name: 'Character skeleton',
+      joints: [2],
+      skeleton: 2,
+      inverseBindMatrices: {
+        data: new Float32Array(inverseBindMatrices),
+        size: 16
+      }
+    }
+  ]
+};
+```
+
+Primitive morph targets retain `POSITION`, `NORMAL`, and three-component `TANGENT` displacements.
+Base tangents remain four-component vectors so their handedness is not lost.
+
+## Animation and animation pointers
+
+Use normal node targets for translation, rotation, scale, and morph weights. Use a pointer target
+to preserve a standards-native `KHR_animation_pointer` channel.
+
+```ts
+const animation = {
+  name: 'Animated roughness',
+  samplers: [
+    {
+      input: {data: new Float32Array([0, 1]), size: 1},
+      output: {data: new Float32Array([0.2, 0.8]), size: 1},
+      interpolation: 'LINEAR'
+    }
+  ],
+  channels: [
+    {
+      sampler: 0,
+      target: {
+        path: 'pointer',
+        pointer: '/materials/0/pbrMetallicRoughness/roughnessFactor'
+      }
+    }
+  ]
+};
+```
+
+Morph samplers preserve the glTF requirement that multi-target weight outputs remain flattened
+`SCALAR` accessors. The writer automatically discovers extension usage in material records,
+animation channels, primitive variant mappings, node instancing, and root extensions.
+
+## Images, materials, and extensions
+
+Material and sampler descriptors use their authored glTF JSON shape. This preserves all canonical
+PBR extension maps, texture-coordinate selection, wrapping, filtering, and `KHR_texture_transform`
+without introducing another material translation layer.
+
+```ts
+const image = {
+  name: 'Base color',
+  data: imageBytes,
+  mimeType: 'image/png'
+};
+
+const instances = {
+  TRANSLATION: {data: new Float32Array([0, 0, 0, 2, 0, 0]), size: 3},
+  _BATCH_ID: {data: new Uint16Array([0, 1]), size: 1}
+};
+```
+
+Image bytes become data URIs in JSON exports and embedded buffer views in GLB exports. Node
+`instances` become `EXT_mesh_gpu_instancing` accessors. Existing `KHR_materials_variants` records,
+punctual lights, cameras, and additional extension payloads remain intact.
+
+## Resource ownership
+
+All descriptors and typed arrays remain owned by the caller. Export never destroys GPU resources,
+mutates source arrays, changes material objects, or depends on `@luma.gl/anari`.
+
+Applications using the optional ANARI playground adapt their retained descriptions into these
+format-owned descriptors. That adapter preserves animated hierarchy, morph targets, joint
+attributes, compatible skin descriptions, material pointers, authored samplers, and all supported
+physical material slots.

--- a/docs/table-of-contents.json
+++ b/docs/table-of-contents.json
@@ -325,6 +325,7 @@
           "api-reference/gltf/README",
           "api-reference/gltf/gltf-materials",
           "api-reference/gltf/gltf-animation",
+          "api-reference/gltf/gltf-interchange",
           "api-reference/gltf/gltf-extensions"
         ]
       },

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -37,7 +37,8 @@ Target Release Date: Q3, 2026
 - **Authored samplers and mipmaps** - glTF and postprocessed loaders.gl sampler representations retain their wrapping, filtering, and mipmap settings; shared texture creation generates requested mip chains on both WebGL and WebGPU.
 - **[Skeletal and morph animation](/docs/api-reference/gltf/gltf-animation)** - Existing joint skinning now supports multiple skins, larger joint palettes, optional bind data, and normalized joint weights. Morph samplers correctly group multi-target weight channels, including cubic-spline data, and animate position, normal, and tangent deformation.
 - **Animated glTF properties** - `KHR_animation_pointer` channels drive supported node transforms, physical-material factors, and texture transforms through the shared engine animation mixer.
-- **Punctual lights and static interchange** - Source directional, point, and spot lights retain authored colors, intensity, and cones; static glTF export round-trips supported materials, all map slots, UV sets, texture transforms, and sampler settings.
+- **[Lossless animated asset interchange](/docs/api-reference/gltf/gltf-interchange)** - Format-owned `.gltf` and `.glb` export preserves hierarchy, animation clips, material pointers, skins, inverse bind matrices, morph targets, RGBA colors, joint attributes, material variants, GPU instancing, cameras, and punctual lights.
+- **Punctual lights and source-faithful materials** - Source directional, point, and spot lights retain authored colors, intensity, and cones; generic export round-trips supported materials, all map slots, UV sets, texture transforms, and sampler settings.
 
 **@luma.gl/anari (Experimental)**
 

--- a/examples/showcase/anari/scene-export.ts
+++ b/examples/showcase/anari/scene-export.ts
@@ -1,4 +1,17 @@
-import {convertSamplerToGLTF, getTextureTransformSlotDefinitions} from '@luma.gl/gltf';
+import {
+  convertSamplerToGLTF,
+  exportGLTF,
+  type GLTFExportAccessor,
+  type GLTFExportAnimation,
+  type GLTFExportAnimationChannel,
+  type GLTFExportAnimationSampler,
+  type GLTFExportMesh,
+  type GLTFExportNode,
+  type GLTFExportPrimitive,
+  type GLTFExportScene,
+  type GLTFExportSkin,
+  getTextureTransformSlotDefinitions
+} from '@luma.gl/gltf';
 import {Matrix4} from '@math.gl/core';
 import {
   type ANARIJSONScene,
@@ -25,20 +38,18 @@ type SurfacePlacement = {
   matrix: readonly number[];
 };
 
-type GLTFBufferView = {buffer: number; byteOffset: number; byteLength: number; target?: number};
-type GLTFAccessor = {
-  bufferView: number;
-  componentType: number;
-  count: number;
-  type: 'SCALAR' | 'VEC2' | 'VEC3';
-  min?: number[];
-  max?: number[];
-};
-
-export async function exportANARIJSONSceneToGLTF(scene: ANARIJSONScene): Promise<string> {
-  const bufferBuilder = new BinaryBufferBuilder();
-  const bufferViews: GLTFBufferView[] = [];
-  const accessors: GLTFAccessor[] = [];
+export function exportANARIJSONSceneToGLTF(
+  scene: ANARIJSONScene,
+  options?: {binary?: false}
+): Promise<string>;
+export function exportANARIJSONSceneToGLTF(
+  scene: ANARIJSONScene,
+  options: {binary: true}
+): Promise<ArrayBuffer>;
+export async function exportANARIJSONSceneToGLTF(
+  scene: ANARIJSONScene,
+  options: {binary?: boolean} = {}
+): Promise<string | ArrayBuffer> {
   const materials = Object.entries(scene.materials).map(([identifier, material]) =>
     makeGLTFMaterial(identifier, material, scene)
   );
@@ -56,7 +67,7 @@ export async function exportANARIJSONSceneToGLTF(scene: ANARIJSONScene): Promise
     resolveGLTFMaterialTextures(materials[materialIndex], sourceMaterial, textureIndices, scene);
   }
 
-  const meshes: object[] = [];
+  const meshes: GLTFExportMesh[] = [];
   const meshIndices = new Map<string, number>();
   for (const [surfaceIdentifier, surface] of Object.entries(scene.surfaces)) {
     const geometry = scene.geometries[surface.geometry];
@@ -64,81 +75,38 @@ export async function exportANARIJSONSceneToGLTF(scene: ANARIJSONScene): Promise
       continue;
     }
     const meshData = bakeGeometry(geometry);
-    const primitive: Record<string, unknown> = {
-      attributes: {
-        POSITION: addFloatAccessor(meshData.positions, 3, bufferBuilder, bufferViews, accessors)
-      },
-      indices: addIndexAccessor(meshData.indices, bufferBuilder, bufferViews, accessors),
-      material: materialIndices.get(surface.material) || 0
-    };
-    const attributes = primitive.attributes as Record<string, number>;
-    if (meshData.normals.length > 0) {
-      attributes['NORMAL'] = addFloatAccessor(
-        meshData.normals,
-        3,
-        bufferBuilder,
-        bufferViews,
-        accessors
-      );
-    }
-    if (meshData.textureCoordinates) {
-      attributes['TEXCOORD_0'] = addFloatAccessor(
-        meshData.textureCoordinates,
-        2,
-        bufferBuilder,
-        bufferViews,
-        accessors
-      );
-    }
-    if (meshData.additionalTextureCoordinates) {
-      attributes['TEXCOORD_1'] = addFloatAccessor(
-        meshData.additionalTextureCoordinates,
-        2,
-        bufferBuilder,
-        bufferViews,
-        accessors
-      );
-    }
-    if (meshData.colors) {
-      attributes['COLOR_0'] = addFloatAccessor(
-        meshData.colors,
-        3,
-        bufferBuilder,
-        bufferViews,
-        accessors
-      );
-    }
+    const primitive = makeExportPrimitive(
+      meshData,
+      geometry,
+      materialIndices.get(surface.material) || 0
+    );
     meshIndices.set(surfaceIdentifier, meshes.length);
-    meshes.push({name: surfaceIdentifier, primitives: [primitive]});
+    meshes.push({
+      name: surfaceIdentifier,
+      primitives: [primitive],
+      ...(geometry.morphWeights ? {weights: [...geometry.morphWeights]} : {})
+    });
   }
 
-  const nodes: object[] = [];
-  for (const placement of collectSurfacePlacements(scene)) {
-    const mesh = meshIndices.get(placement.surface);
-    if (mesh === undefined) {
-      continue;
-    }
-    nodes.push({name: placement.identifier, mesh, matrix: Array.from(placement.matrix)});
-  }
+  const {nodes, nodeIndices} = makeExportNodes(scene, meshIndices);
+  const skins = makeExportSkins(scene, nodes, nodeIndices);
   const cameraNode = addGLTFCamera(scene, nodes);
   const lightExtension = addGLTFLights(scene, nodes);
-  const sceneNodeIndices = nodes.map((_node, index) => index);
-  const gltf: Record<string, unknown> = {
-    asset: {version: '2.0', generator: '@luma.gl/anari experimental exporter'},
-    scene: 0,
-    scenes: [{name: scene.name, nodes: sceneNodeIndices}],
+  const gltf: GLTFExportScene = {
+    name: scene.name,
+    generator: '@luma.gl/anari via @luma.gl/gltf',
     nodes,
     meshes,
     materials,
-    buffers: [{byteLength: bufferBuilder.length, uri: bufferBuilder.toDataURI()}],
-    bufferViews,
-    accessors
+    ...(skins.length > 0 ? {skins} : {}),
+    ...(cameraNode ? {cameras: [cameraNode.camera]} : {}),
+    ...(lightExtension ? {extensions: {KHR_lights_punctual: {lights: lightExtension}}} : {})
   };
   if (textureEntries.length > 0) {
-    gltf['images'] = textureEntries.map(entry => ({name: entry.identifier, uri: entry.uri}));
+    gltf.images = textureEntries.map(entry => ({name: entry.identifier, uri: entry.uri}));
     const samplerIndices = new Map<string, number>();
     const samplers: ReturnType<typeof convertSamplerToGLTF>[] = [];
-    gltf['textures'] = textureEntries.map((entry, index) => {
+    gltf.textures = textureEntries.map((entry, index) => {
       const sampler = convertSamplerToGLTF({
         addressModeU: 'repeat',
         addressModeV: 'repeat',
@@ -155,25 +123,13 @@ export async function exportANARIJSONSceneToGLTF(scene: ANARIJSONScene): Promise
       }
       return {name: entry.identifier, source: index, sampler: samplerIndex};
     });
-    gltf['samplers'] = samplers;
+    gltf.samplers = samplers;
   }
-  if (cameraNode) {
-    gltf['cameras'] = [cameraNode.camera];
+  const animations = makeExportAnimations(scene, nodeIndices, materialIndices);
+  if (animations.length > 0) {
+    gltf.animations = animations;
   }
-  const extensionsUsed = [
-    ...collectMaterialExtensions(materials),
-    ...(Object.values(scene.textures || {}).some(texture => texture.transform)
-      ? ['KHR_texture_transform']
-      : []),
-    ...(lightExtension ? ['KHR_lights_punctual'] : [])
-  ];
-  if (extensionsUsed.length > 0) {
-    gltf['extensionsUsed'] = extensionsUsed;
-  }
-  if (lightExtension) {
-    gltf['extensions'] = {KHR_lights_punctual: {lights: lightExtension}};
-  }
-  return JSON.stringify(gltf, null, 2);
+  return options.binary ? exportGLTF(gltf, {binary: true}) : exportGLTF(gltf);
 }
 
 export function exportANARIJSONSceneToUSD(scene: ANARIJSONScene): string {
@@ -224,6 +180,336 @@ export function exportANARIJSONSceneToUSD(scene: ANARIJSONScene): string {
   appendUSDLights(lines, scene);
   lines.push('}');
   return lines.join('\n') + '\n';
+}
+
+function makeExportPrimitive(
+  mesh: MeshData,
+  geometry: JSONGeometryDeclaration,
+  material: number
+): GLTFExportPrimitive {
+  const vertexCount = mesh.positions.length / 3;
+  const attributes: Record<string, GLTFExportAccessor> = {
+    POSITION: {data: new Float32Array(mesh.positions), size: 3}
+  };
+  if (mesh.normals.length > 0) {
+    attributes['NORMAL'] = {data: new Float32Array(mesh.normals), size: 3};
+  }
+  if (mesh.textureCoordinates) {
+    attributes['TEXCOORD_0'] = {data: new Float32Array(mesh.textureCoordinates), size: 2};
+  }
+  if (mesh.additionalTextureCoordinates) {
+    attributes['TEXCOORD_1'] = {
+      data: new Float32Array(mesh.additionalTextureCoordinates),
+      size: 2
+    };
+  }
+  if (mesh.colors) {
+    const componentCount = mesh.colors.length === vertexCount * 4 ? 4 : 3;
+    attributes['COLOR_0'] = {data: new Float32Array(mesh.colors), size: componentCount};
+  }
+  if (geometry['vertex.tangent']) {
+    attributes['TANGENT'] = {data: new Float32Array(geometry['vertex.tangent']), size: 4};
+  }
+  if (geometry['vertex.joint']) {
+    const jointValues = geometry['vertex.joint'];
+    const joints = jointValues.some(value => value > 255)
+      ? new Uint16Array(jointValues)
+      : new Uint8Array(jointValues);
+    attributes['JOINTS_0'] = {data: joints, size: 4};
+  }
+  if (geometry['vertex.weight']) {
+    attributes['WEIGHTS_0'] = {data: new Float32Array(geometry['vertex.weight']), size: 4};
+  }
+
+  const indices = mesh.indices.some(index => index > 65535)
+    ? new Uint32Array(mesh.indices)
+    : new Uint16Array(mesh.indices);
+  const targets = geometry.morphTargets?.map(target => {
+    const attributes: Record<string, GLTFExportAccessor> = {};
+    for (const name of ['POSITION', 'NORMAL', 'TANGENT'] as const) {
+      if (target[name]) {
+        attributes[name] = {data: new Float32Array(target[name]), size: 3};
+      }
+    }
+    return attributes;
+  });
+
+  return {
+    attributes,
+    indices: {data: indices, size: 1},
+    material,
+    ...(targets?.length ? {targets} : {})
+  };
+}
+
+function makeExportNodes(
+  scene: ANARIJSONScene,
+  meshIndices: ReadonlyMap<string, number>
+): {nodes: GLTFExportNode[]; nodeIndices: Map<string, number>} {
+  const nodes: GLTFExportNode[] = [];
+  const nodeIndices = new Map<string, number>();
+  const nodeDeclarations = scene.nodes || {};
+
+  for (const [identifier, declaration] of Object.entries(nodeDeclarations)) {
+    const node: GLTFExportNode = {
+      name: identifier,
+      ...(declaration.translation ? {translation: [...declaration.translation]} : {}),
+      ...(declaration.rotation ? {rotation: [...declaration.rotation]} : {}),
+      ...(declaration.scale ? {scale: [...declaration.scale]} : {}),
+      ...(declaration.matrix ? {matrix: [...declaration.matrix]} : {}),
+      ...(declaration.weights ? {weights: [...declaration.weights]} : {})
+    };
+    nodeIndices.set(identifier, nodes.length);
+    nodes.push(node);
+  }
+
+  const boundInstances = new Set<string>();
+  for (const [identifier, declaration] of Object.entries(nodeDeclarations)) {
+    const nodeIndex = nodeIndices.get(identifier)!;
+    const node = nodes[nodeIndex];
+    if (declaration.parent) {
+      const parent = nodeIndices.get(declaration.parent);
+      if (parent !== undefined) {
+        nodes[parent].children = [...(nodes[parent].children || []), nodeIndex];
+      }
+    }
+
+    for (const instanceIdentifier of declaration.instances || []) {
+      boundInstances.add(instanceIdentifier);
+      const instance = scene.instances?.find(candidate => candidate['@@id'] === instanceIdentifier);
+      const surfaces = instance?.surface
+        ? [instance.surface]
+        : instance?.group
+          ? scene.groups?.[instance.group]?.surfaces || []
+          : [];
+      for (const surface of surfaces) {
+        const mesh = meshIndices.get(surface);
+        if (mesh === undefined) {
+          continue;
+        }
+        if (node.mesh === undefined) {
+          node.mesh = mesh;
+        } else {
+          nodes.push({name: `${instanceIdentifier}-${surface}`, mesh});
+          node.children = [...(node.children || []), nodes.length - 1];
+        }
+      }
+    }
+  }
+
+  for (const placement of collectSurfacePlacements(scene)) {
+    const instanceIdentifier = scene.instances?.find(instance =>
+      placement.identifier.startsWith(`${instance['@@id']}-`)
+    )?.['@@id'];
+    if (instanceIdentifier && boundInstances.has(instanceIdentifier)) {
+      continue;
+    }
+    const mesh = meshIndices.get(placement.surface);
+    if (mesh === undefined) {
+      continue;
+    }
+    const node = {name: placement.identifier, mesh, matrix: Array.from(placement.matrix)};
+    nodeIndices.set(placement.identifier, nodes.length);
+    nodes.push(node);
+  }
+
+  return {nodes, nodeIndices};
+}
+
+function makeExportAnimations(
+  scene: ANARIJSONScene,
+  nodeIndices: ReadonlyMap<string, number>,
+  materialIndices: ReadonlyMap<string, number>
+): GLTFExportAnimation[] {
+  return (scene.clips || []).flatMap(clip => {
+    const samplers: GLTFExportAnimationSampler[] = [];
+    const channels: GLTFExportAnimationChannel[] = [];
+    for (const track of clip.tracks) {
+      const target = makeExportAnimationTarget(track.target, scene, nodeIndices, materialIndices);
+      if (!target || track.times.length === 0 || track.values.length === 0) {
+        continue;
+      }
+
+      const componentCount = target.path === 'weights' ? 1 : track.values[0]?.length || 1;
+      if (componentCount < 1 || componentCount > 4) {
+        continue;
+      }
+      samplers.push({
+        input: {data: new Float32Array(track.times), size: 1},
+        output: {
+          data: new Float32Array(track.values.flat()),
+          size: componentCount as 1 | 2 | 3 | 4
+        },
+        ...(track.interpolation ? {interpolation: track.interpolation} : {})
+      });
+      channels.push({sampler: samplers.length - 1, target});
+    }
+    return channels.length > 0 ? [{name: clip.name, samplers, channels}] : [];
+  });
+}
+
+function makeExportSkins(
+  scene: ANARIJSONScene,
+  nodes: GLTFExportNode[],
+  nodeIndices: ReadonlyMap<string, number>
+): GLTFExportSkin[] {
+  const skins: GLTFExportSkin[] = [];
+  const skinIndices = new Map<string, number>();
+
+  for (const [identifier, surface] of Object.entries(scene.surfaces)) {
+    const skin = (
+      surface as typeof surface & {
+        skin?: {
+          node: string;
+          joints: readonly string[];
+          inverseBindMatrices?: readonly number[];
+        };
+      }
+    ).skin;
+    if (!skin) {
+      continue;
+    }
+    const node = nodeIndices.get(skin.node);
+    if (node === undefined) {
+      continue;
+    }
+    const joints = skin.joints.map(joint => nodeIndices.get(joint));
+    if (joints.some(joint => joint === undefined)) {
+      continue;
+    }
+    const key = JSON.stringify({
+      joints,
+      inverseBindMatrices: skin.inverseBindMatrices
+    });
+    let index = skinIndices.get(key);
+    if (index === undefined) {
+      index = skins.length;
+      skins.push({
+        name: `${identifier}-skin`,
+        joints: joints as number[],
+        ...(skin.inverseBindMatrices
+          ? {
+              inverseBindMatrices: {
+                data: new Float32Array(skin.inverseBindMatrices),
+                size: 16
+              }
+            }
+          : {})
+      });
+      skinIndices.set(key, index);
+    }
+    nodes[node].skin = index;
+  }
+
+  return skins;
+}
+
+function makeExportAnimationTarget(
+  target: NonNullable<ANARIJSONScene['clips']>[number]['tracks'][number]['target'],
+  scene: ANARIJSONScene,
+  nodeIndices: ReadonlyMap<string, number>,
+  materialIndices: ReadonlyMap<string, number>
+): GLTFExportAnimationChannel['target'] | undefined {
+  if (target.type === 'node') {
+    const node = nodeIndices.get(target.identifier);
+    const path = target.path;
+    if (
+      node !== undefined &&
+      (path === 'translation' || path === 'rotation' || path === 'scale' || path === 'weights')
+    ) {
+      return {node, path};
+    }
+  }
+
+  if (target.type === 'material') {
+    const material = materialIndices.get(target.identifier);
+    const property = getMaterialAnimationPointer(target.path);
+    if (material !== undefined && property) {
+      const component =
+        target.path === 'opacity'
+          ? '/3'
+          : target.component !== undefined
+            ? `/${target.component}`
+            : '';
+      return {path: 'pointer', pointer: `/materials/${material}/${property}${component}`};
+    }
+  }
+
+  if (target.type === 'sampler') {
+    for (const [identifier, material] of Object.entries(scene.materials)) {
+      const materialIndex = materialIndices.get(identifier);
+      if (materialIndex === undefined) {
+        continue;
+      }
+      for (const {slot, pathSegments} of getTextureTransformSlotDefinitions()) {
+        if (material[`${slot}Texture`] === target.identifier) {
+          const component = target.component !== undefined ? `/${target.component}` : '';
+          return {
+            path: 'pointer',
+            pointer:
+              `/materials/${materialIndex}/${pathSegments.join('/')}` +
+              `/extensions/KHR_texture_transform/${target.path}${component}`
+          };
+        }
+      }
+    }
+  }
+
+  if (target.type === 'light') {
+    const index = (scene.lights || [])
+      .filter(light => light['@@type'] !== 'ambient')
+      .findIndex(light => light['@@id'] === target.identifier);
+    if (index >= 0) {
+      return {
+        path: 'pointer',
+        pointer: `/extensions/KHR_lights_punctual/lights/${index}/${target.path}`
+      };
+    }
+  }
+
+  if (target.type === 'camera' && scene.camera) {
+    const cameraPath =
+      target.path === 'fovy'
+        ? 'perspective/yfov'
+        : target.path === 'near'
+          ? `${scene.camera['@@type']}/znear`
+          : target.path === 'far'
+            ? `${scene.camera['@@type']}/zfar`
+            : undefined;
+    return cameraPath ? {path: 'pointer', pointer: `/cameras/0/${cameraPath}`} : undefined;
+  }
+
+  return undefined;
+}
+
+function getMaterialAnimationPointer(path: string): string | undefined {
+  const properties: Record<string, string> = {
+    baseColor: 'pbrMetallicRoughness/baseColorFactor',
+    opacity: 'pbrMetallicRoughness/baseColorFactor',
+    metallic: 'pbrMetallicRoughness/metallicFactor',
+    roughness: 'pbrMetallicRoughness/roughnessFactor',
+    emissive: 'emissiveFactor',
+    alphaCutoff: 'alphaCutoff',
+    specularColor: 'extensions/KHR_materials_specular/specularColorFactor',
+    specularIntensity: 'extensions/KHR_materials_specular/specularFactor',
+    indexOfRefraction: 'extensions/KHR_materials_ior/ior',
+    transmission: 'extensions/KHR_materials_transmission/transmissionFactor',
+    thickness: 'extensions/KHR_materials_volume/thicknessFactor',
+    attenuationDistance: 'extensions/KHR_materials_volume/attenuationDistance',
+    attenuationColor: 'extensions/KHR_materials_volume/attenuationColor',
+    clearcoat: 'extensions/KHR_materials_clearcoat/clearcoatFactor',
+    clearcoatRoughness: 'extensions/KHR_materials_clearcoat/clearcoatRoughnessFactor',
+    sheenColor: 'extensions/KHR_materials_sheen/sheenColorFactor',
+    sheenRoughness: 'extensions/KHR_materials_sheen/sheenRoughnessFactor',
+    iridescence: 'extensions/KHR_materials_iridescence/iridescenceFactor',
+    iridescenceIndexOfRefraction: 'extensions/KHR_materials_iridescence/iridescenceIor',
+    iridescenceThicknessMinimum: 'extensions/KHR_materials_iridescence/iridescenceThicknessMinimum',
+    iridescenceThicknessMaximum: 'extensions/KHR_materials_iridescence/iridescenceThicknessMaximum',
+    anisotropyStrength: 'extensions/KHR_materials_anisotropy/anisotropyStrength',
+    anisotropyRotation: 'extensions/KHR_materials_anisotropy/anisotropyRotation',
+    emissiveStrength: 'extensions/KHR_materials_emissive_strength/emissiveStrength'
+  };
+  return properties[path];
 }
 
 function collectSurfacePlacements(scene: ANARIJSONScene): SurfacePlacement[] {
@@ -384,7 +670,7 @@ function makeGLTFMaterial(
   scene: ANARIJSONScene
 ): Record<string, unknown> {
   const baseColor = material.baseColor || material.color || [0.8, 0.8, 0.8];
-  const alpha = baseColor.length > 3 ? (baseColor[3] ?? 1) : (material.opacity ?? 1);
+  const alpha = material.opacity ?? (baseColor.length > 3 ? (baseColor[3] ?? 1) : 1);
   const result: Record<string, unknown> = {
     name: identifier,
     pbrMetallicRoughness: {
@@ -426,6 +712,10 @@ function makeGLTFMaterial(
     addGLTFMaterialExtension(result, 'KHR_materials_transmission', {
       transmissionFactor: material.transmission ?? 0
     });
+  }
+  const dispersion = (material as typeof material & {dispersion?: number}).dispersion;
+  if ((dispersion ?? 0) > 0) {
+    addGLTFMaterialExtension(result, 'KHR_materials_dispersion', {dispersion});
   }
   if (material.indexOfRefraction !== undefined && material.indexOfRefraction !== 1.5) {
     addGLTFMaterialExtension(result, 'KHR_materials_ior', {
@@ -575,20 +865,10 @@ function addGLTFMaterialExtension(
   );
 }
 
-function collectMaterialExtensions(materials: object[]): string[] {
-  const extensions = new Set<string>();
-  for (const material of materials) {
-    const materialExtensions = (material as Record<string, unknown>)['extensions'];
-    if (materialExtensions && typeof materialExtensions === 'object') {
-      for (const name of Object.keys(materialExtensions)) {
-        extensions.add(name);
-      }
-    }
-  }
-  return Array.from(extensions);
-}
-
-function addGLTFCamera(scene: ANARIJSONScene, nodes: object[]): {camera: object} | undefined {
+function addGLTFCamera(
+  scene: ANARIJSONScene,
+  nodes: GLTFExportNode[]
+): {camera: Record<string, unknown>} | undefined {
   if (!scene.camera) {
     return undefined;
   }
@@ -617,7 +897,7 @@ function addGLTFCamera(scene: ANARIJSONScene, nodes: object[]): {camera: object}
   return {camera};
 }
 
-function addGLTFLights(scene: ANARIJSONScene, nodes: object[]): object[] | undefined {
+function addGLTFLights(scene: ANARIJSONScene, nodes: GLTFExportNode[]): object[] | undefined {
   const lights = (scene.lights || []).filter(light => light['@@type'] !== 'ambient');
   if (lights.length === 0) {
     return undefined;
@@ -777,81 +1057,6 @@ function appendUSDLights(lines: string[], scene: ANARIJSONScene): void {
   }
 }
 
-function addFloatAccessor(
-  values: number[],
-  components: 2 | 3,
-  builder: BinaryBufferBuilder,
-  bufferViews: GLTFBufferView[],
-  accessors: GLTFAccessor[]
-): number {
-  const bytes = new Uint8Array(new Float32Array(values).buffer);
-  const bufferView = addBufferView(bytes, 34962, builder, bufferViews);
-  const accessor: GLTFAccessor = {
-    bufferView,
-    componentType: 5126,
-    count: values.length / components,
-    type: components === 2 ? 'VEC2' : 'VEC3'
-  };
-  if (components === 3) {
-    accessor.min = getComponentExtrema(values, components, Math.min);
-    accessor.max = getComponentExtrema(values, components, Math.max);
-  }
-  accessors.push(accessor);
-  return accessors.length - 1;
-}
-
-function addIndexAccessor(
-  values: number[],
-  builder: BinaryBufferBuilder,
-  bufferViews: GLTFBufferView[],
-  accessors: GLTFAccessor[]
-): number {
-  const useUint32 = values.some(value => value > 65535);
-  const bytes = useUint32
-    ? new Uint8Array(new Uint32Array(values).buffer)
-    : new Uint8Array(new Uint16Array(values).buffer);
-  const bufferView = addBufferView(bytes, 34963, builder, bufferViews);
-  accessors.push({
-    bufferView,
-    componentType: useUint32 ? 5125 : 5123,
-    count: values.length,
-    type: 'SCALAR'
-  });
-  return accessors.length - 1;
-}
-
-function addBufferView(
-  bytes: Uint8Array,
-  target: number,
-  builder: BinaryBufferBuilder,
-  bufferViews: GLTFBufferView[]
-): number {
-  const byteOffset = builder.append(bytes);
-  bufferViews.push({buffer: 0, byteOffset, byteLength: bytes.byteLength, target});
-  return bufferViews.length - 1;
-}
-
-class BinaryBufferBuilder {
-  private bytes: number[] = [];
-
-  get length(): number {
-    return this.bytes.length;
-  }
-
-  append(values: Uint8Array): number {
-    while (this.bytes.length % 4 !== 0) {
-      this.bytes.push(0);
-    }
-    const offset = this.bytes.length;
-    this.bytes.push(...values);
-    return offset;
-  }
-
-  toDataURI(): string {
-    return 'data:application/octet-stream;base64,' + encodeBase64(new Uint8Array(this.bytes));
-  }
-}
-
 async function makeDataURI(source: string): Promise<string> {
   if (source.startsWith('data:')) {
     return source;
@@ -890,20 +1095,6 @@ function toNumberArray(values: unknown): number[] {
 
 function makeSequentialIndices(count: number): number[] {
   return Array.from({length: count}, (_value, index) => index);
-}
-
-function getComponentExtrema(
-  values: number[],
-  components: number,
-  operation: (first: number, second: number) => number
-): number[] {
-  const extrema = values.slice(0, components);
-  for (let offset = components; offset < values.length; offset += components) {
-    for (let component = 0; component < components; component++) {
-      extrema[component] = operation(extrema[component], values[offset + component]);
-    }
-  }
-  return extrema;
 }
 
 function formatUSDVector(values: ArrayLike<number>): string {

--- a/modules/anari/test/scene-interchange.node.spec.ts
+++ b/modules/anari/test/scene-interchange.node.spec.ts
@@ -1,0 +1,120 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFile} from 'node:fs/promises';
+import {parse} from '@loaders.gl/core';
+import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
+import {describe, expect, test} from 'vitest';
+import {makeANARIJSONSceneFromGLTF} from '../../../examples/showcase/anari/gltf-to-anari';
+import {PLAYGROUND_PRESETS} from '../../../examples/showcase/anari/playground-presets';
+import {exportANARIJSONSceneToGLTF} from '../../../examples/showcase/anari/scene-export';
+
+describe('retained ANARI to glTF animated interchange', () => {
+  test('round-trips the real AnimatedMorphCube hierarchy, 127 keyframes, and both targets', async () => {
+    const asset = await readFile(
+      new URL('../../../examples/showcase/anari/public/gltf/AnimatedMorphCube.glb', import.meta.url)
+    );
+    const source = postProcessGLTF(await parse(asset, GLTFLoader, {gltf: {loadImages: false}}));
+    const scene = await makeANARIJSONSceneFromGLTF(source, 'Animated morph interchange');
+    const exported = JSON.parse(await exportANARIJSONSceneToGLTF(scene));
+
+    expect(exported.animations).toHaveLength(source.animations.length);
+    expect(exported.nodes.some(node => node.children?.length)).toBe(true);
+    expect(exported.nodes.some(node => node.weights?.length === 2)).toBe(true);
+
+    const weightChannel = exported.animations[0].channels.find(
+      channel => channel.target.path === 'weights'
+    );
+    const weightSampler = exported.animations[0].samplers[weightChannel.sampler];
+    expect(exported.accessors[weightSampler.input].count).toBe(127);
+    expect(exported.accessors[weightSampler.output].count).toBe(254);
+    expect(exported.accessors[weightSampler.output].type).toBe('SCALAR');
+
+    const primitive = exported.meshes.find(mesh => mesh.primitives[0].targets)?.primitives[0];
+    expect(primitive.targets).toHaveLength(2);
+    expect(Object.keys(primitive.targets[0])).toEqual(['POSITION', 'NORMAL', 'TANGENT']);
+    expect(exported.accessors[primitive.attributes.TANGENT].type).toBe('VEC4');
+    expect(exported.accessors[primitive.targets[0].TANGENT].type).toBe('VEC3');
+
+    const binary = await exportANARIJSONSceneToGLTF(scene, {binary: true});
+    const roundTripped = postProcessGLTF(
+      await parse(binary, GLTFLoader, {gltf: {loadImages: false}})
+    );
+    expect(roundTripped.animations).toHaveLength(1);
+    expect(roundTripped.meshes.some(mesh => mesh.primitives[0].targets?.length === 2)).toBe(true);
+  });
+
+  test('preserves RGBA colors, tangent handedness, joints, weights, and explicit opacity', async () => {
+    const scene = structuredClone(PLAYGROUND_PRESETS[0].scene);
+    scene.geometries.halo = {
+      '@@type': 'triangle',
+      'vertex.position': [0, 0, 0, 1, 0, 0, 0, 1, 0],
+      'vertex.tangent': [1, 0, 0, -1, 1, 0, 0, 1, 1, 0, 0, -1],
+      'vertex.attribute0': [1, 0, 0, 0.25, 0, 1, 0, 0.5, 0, 0, 1, 0.75],
+      'vertex.joint': [0, 0, 0, 0, 257, 0, 0, 0, 0, 0, 0, 0],
+      'vertex.weight': [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
+      'primitive.index': [0, 1, 2]
+    };
+    scene.materials.halo.baseColor = [0.2, 0.4, 0.6, 0.9];
+    scene.materials.halo.opacity = 0.35;
+
+    const document = JSON.parse(await exportANARIJSONSceneToGLTF(scene));
+    const primitive = document.meshes.find(mesh => mesh.name === 'halo').primitives[0];
+    const material = document.materials.find(candidate => candidate.name === 'halo');
+
+    expect(document.accessors[primitive.attributes.COLOR_0].type).toBe('VEC4');
+    expect(document.accessors[primitive.attributes.TANGENT].type).toBe('VEC4');
+    expect(document.accessors[primitive.attributes.JOINTS_0].componentType).toBe(5123);
+    expect(document.accessors[primitive.attributes.WEIGHTS_0].type).toBe('VEC4');
+    expect(material.pbrMetallicRoughness.baseColorFactor[3]).toBe(0.35);
+  });
+
+  test('round-trips source skin palettes and authored material-animation pointers', async () => {
+    const scene = structuredClone(PLAYGROUND_PRESETS[0].scene);
+    const identity = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+    scene.nodes = {
+      root: {},
+      joint: {parent: 'root'},
+      mesh: {
+        parent: 'root',
+        instances: [scene.instances?.find(instance => instance.surface === 'halo')?.['@@id'] || '']
+      }
+    };
+    (
+      scene.surfaces.halo as typeof scene.surfaces.halo & {
+        skin?: {node: string; joints: string[]; inverseBindMatrices: number[]};
+      }
+    ).skin = {node: 'mesh', joints: ['joint'], inverseBindMatrices: identity};
+    scene.clips = [
+      {
+        name: 'Material pointer',
+        tracks: [
+          {
+            target: {type: 'material', identifier: 'halo', path: 'roughness'},
+            times: [0, 1],
+            values: [[0.2], [0.8]],
+            interpolation: 'LINEAR'
+          }
+        ]
+      }
+    ];
+
+    const document = JSON.parse(await exportANARIJSONSceneToGLTF(scene));
+    expect(document.skins).toHaveLength(1);
+    expect(document.nodes.find(node => node.name === 'mesh').skin).toBe(0);
+    expect(document.skins[0].joints).toEqual([
+      document.nodes.findIndex(node => node.name === 'joint')
+    ]);
+    expect(document.accessors[document.skins[0].inverseBindMatrices].type).toBe('MAT4');
+    expect(document.animations[0].channels[0].target).toEqual({
+      path: 'pointer',
+      extensions: {
+        KHR_animation_pointer: {
+          pointer: '/materials/0/pbrMetallicRoughness/roughnessFactor'
+        }
+      }
+    });
+    expect(document.extensionsUsed).toContain('KHR_animation_pointer');
+  });
+});

--- a/modules/gltf/README.md
+++ b/modules/gltf/README.md
@@ -1,12 +1,12 @@
 # @luma.gl/gltf
 
-Converts postprocessed glTF assets into luma.gl scenegraphs, canonical physically based materials,
-punctual lights, and shared engine animation/deformation data.
+Standards-first glTF assets with physically based materials, animated skeletons, morph deformation,
+native animation pointers, and source-faithful `.gltf` / `.glb` interchange on WebGPU and WebGL.
 
 ```ts
 import {load} from '@loaders.gl/core';
 import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
-import {createScenegraphsFromGLTF} from '@luma.gl/gltf';
+import {createScenegraphsFromGLTF, exportGLTF} from '@luma.gl/gltf';
 
 const asset = await load('/models/model.glb', GLTFLoader);
 const gltf = postProcessGLTF(asset);
@@ -17,11 +17,17 @@ const {scenes, animator, lights, modelBounds} = createScenegraphsFromGLTF(device
 });
 
 animator.setTime(performance.now());
+
+const exportScene = {name: 'Exported scene', nodes: [{name: 'Root'}]};
+const gltfDocument = exportGLTF(exportScene);
+const binaryAsset = exportGLTF(exportScene, {binary: true});
 ```
 
 The module preserves all 17 supported core/PBR-extension texture slots, sampler filters and
 mipmaps, independent UV transforms and `TEXCOORD_1`, authored punctual lights, node transforms,
-material/texture animation pointers, skin attributes, and animated morph targets.
+material/texture animation pointers, skin attributes, and animated morph targets. Generic
+`exportGLTF()` descriptors also preserve hierarchy, skins, inverse bind matrices, morph targets,
+animation clips, variants, GPU instancing, cameras, lights, and source-faithful accessors.
 
 `@loaders.gl/gltf` owns asset loading and decompression. Generic animation, scenegraph, and morph
 primitives remain in `@luma.gl/engine`; shared PBR, lighting, and skinning shaders remain in
@@ -30,4 +36,5 @@ primitives remain in `@luma.gl/engine`; shared PBR, lighting, and skinning shade
 - [glTF API overview](https://luma.gl/docs/api-reference/gltf)
 - [Materials, textures, and lighting](https://luma.gl/docs/api-reference/gltf/gltf-materials)
 - [Animation and deformation](https://luma.gl/docs/api-reference/gltf/gltf-animation)
+- [Asset interchange and GLB export](https://luma.gl/docs/api-reference/gltf/gltf-interchange)
 - [glTF extension support](https://luma.gl/docs/api-reference/gltf/gltf-extensions)

--- a/modules/gltf/package.json
+++ b/modules/gltf/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@luma.gl/gltf",
   "version": "9.4.0-alpha.4",
-  "description": "glTF support for luma.gl",
+  "description": "Standards-first glTF rendering, physical materials, animation, and lossless asset interchange",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -12,9 +12,12 @@
     "access": "public"
   },
   "keywords": [
+    "gltf",
+    "glb",
+    "webgpu",
     "webgl",
-    "glsl",
-    "debug",
+    "pbr",
+    "animation",
     "3d"
   ],
   "types": "dist/index.d.ts",

--- a/modules/gltf/src/export/gltf-exporter.ts
+++ b/modules/gltf/src/export/gltf-exporter.ts
@@ -1,0 +1,564 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+type GLTFExportTypedArray =
+  | Int8Array
+  | Uint8Array
+  | Int16Array
+  | Uint16Array
+  | Uint32Array
+  | Float32Array;
+
+type GLTFExportAccessorSize = 1 | 2 | 3 | 4 | 9 | 16;
+
+/** Typed attribute or animation samples preserved without lossy numeric conversion. */
+export type GLTFExportAccessor = {
+  data: GLTFExportTypedArray | readonly number[];
+  size: GLTFExportAccessorSize;
+  normalized?: boolean;
+  min?: readonly number[];
+  max?: readonly number[];
+  sparse?: {
+    indices: Uint8Array | Uint16Array | Uint32Array;
+    values: GLTFExportTypedArray | readonly number[];
+  };
+};
+
+/** One glTF primitive, retaining authored semantics and morph-target displacement. */
+export type GLTFExportPrimitive = {
+  attributes: Readonly<Record<string, GLTFExportAccessor>>;
+  indices?: GLTFExportAccessor;
+  material?: number;
+  mode?: number;
+  targets?: readonly Readonly<Record<string, GLTFExportAccessor>>[];
+  extensions?: Record<string, unknown>;
+  extras?: unknown;
+};
+
+/** Reusable source-faithful glTF mesh. */
+export type GLTFExportMesh = {
+  name?: string;
+  primitives: readonly GLTFExportPrimitive[];
+  weights?: readonly number[];
+  extensions?: Record<string, unknown>;
+  extras?: unknown;
+};
+
+/** Hierarchical glTF node with optional existing GPU-instancing attributes. */
+export type GLTFExportNode = {
+  name?: string;
+  mesh?: number;
+  skin?: number;
+  camera?: number;
+  children?: readonly number[];
+  matrix?: readonly number[];
+  translation?: readonly number[];
+  rotation?: readonly number[];
+  scale?: readonly number[];
+  weights?: readonly number[];
+  instances?: Readonly<Record<string, GLTFExportAccessor>>;
+  extensions?: Record<string, unknown>;
+  extras?: unknown;
+};
+
+/** Existing joint hierarchy and inverse-bind matrices owned by an exported glTF skin. */
+export type GLTFExportSkin = {
+  name?: string;
+  joints: readonly number[];
+  skeleton?: number;
+  inverseBindMatrices?: GLTFExportAccessor;
+  extensions?: Record<string, unknown>;
+  extras?: unknown;
+};
+
+/** Existing glTF animation sampler; morph outputs retain their authored SCALAR layout. */
+export type GLTFExportAnimationSampler = {
+  input: GLTFExportAccessor;
+  output: GLTFExportAccessor;
+  interpolation?: 'STEP' | 'LINEAR' | 'CUBICSPLINE';
+};
+
+/** Core transform/morph target or standards-native KHR_animation_pointer target. */
+export type GLTFExportAnimationChannel = {
+  sampler: number;
+  target:
+    | {
+        node: number;
+        path: 'translation' | 'rotation' | 'scale' | 'weights';
+        extensions?: Record<string, unknown>;
+      }
+    | {
+        path: 'pointer';
+        pointer: string;
+      };
+};
+
+/** Named animation clip with independently retained sampler data. */
+export type GLTFExportAnimation = {
+  name?: string;
+  samplers: readonly GLTFExportAnimationSampler[];
+  channels: readonly GLTFExportAnimationChannel[];
+  extensions?: Record<string, unknown>;
+  extras?: unknown;
+};
+
+/** Caller-owned image bytes or authored URI. */
+export type GLTFExportImage = {
+  name?: string;
+  uri?: string;
+  data?: Uint8Array;
+  mimeType?: string;
+  extensions?: Record<string, unknown>;
+  extras?: unknown;
+};
+
+/** Format-owned asset description with no dependency on a renderer or ANARI facade. */
+export type GLTFExportScene = {
+  name?: string;
+  scene?: number;
+  scenes?: readonly {name?: string; nodes: readonly number[]}[];
+  nodes?: readonly GLTFExportNode[];
+  meshes?: readonly GLTFExportMesh[];
+  materials?: readonly Record<string, unknown>[];
+  textures?: readonly Record<string, unknown>[];
+  images?: readonly GLTFExportImage[];
+  samplers?: readonly Record<string, unknown>[];
+  cameras?: readonly Record<string, unknown>[];
+  skins?: readonly GLTFExportSkin[];
+  animations?: readonly GLTFExportAnimation[];
+  extensions?: Record<string, unknown>;
+  extensionsUsed?: readonly string[];
+  extensionsRequired?: readonly string[];
+  extras?: unknown;
+  generator?: string;
+};
+
+/** JSON or binary serialization options. */
+export type GLTFExportOptions = {
+  binary?: boolean;
+  pretty?: boolean;
+};
+
+type GLTFJSONRecord = Record<string, unknown>;
+
+const ARRAY_BUFFER_TARGET = 34962;
+const ELEMENT_ARRAY_BUFFER_TARGET = 34963;
+const GLB_MAGIC = 0x46546c67;
+const GLB_JSON_CHUNK = 0x4e4f534a;
+const GLB_BINARY_CHUNK = 0x004e4942;
+
+/** Serializes source-faithful glTF 2.0 scenes into embedded JSON assets. */
+export function exportGLTF(
+  scene: GLTFExportScene,
+  options?: GLTFExportOptions & {binary?: false}
+): string;
+/** Serializes source-faithful glTF 2.0 scenes into aligned binary GLB assets. */
+export function exportGLTF(
+  scene: GLTFExportScene,
+  options: GLTFExportOptions & {binary: true}
+): ArrayBuffer;
+export function exportGLTF(
+  scene: GLTFExportScene,
+  options: GLTFExportOptions = {}
+): string | ArrayBuffer {
+  const writer = new GLTFExportWriter(scene, options);
+  return writer.write();
+}
+
+class GLTFExportWriter {
+  private readonly scene: GLTFExportScene;
+  private readonly options: GLTFExportOptions;
+  private readonly binary = new GLTFBinaryBuilder();
+  private readonly bufferViews: GLTFJSONRecord[] = [];
+  private readonly accessors: GLTFJSONRecord[] = [];
+
+  constructor(scene: GLTFExportScene, options: GLTFExportOptions) {
+    this.scene = scene;
+    this.options = options;
+  }
+
+  write(): string | ArrayBuffer {
+    const document: GLTFJSONRecord = {
+      asset: {
+        version: '2.0',
+        generator: this.scene.generator || '@luma.gl/gltf'
+      },
+      scene: this.scene.scene ?? 0
+    };
+
+    if (this.scene.nodes?.length) {
+      document['nodes'] = this.scene.nodes.map(node => this.writeNode(node));
+    }
+    document['scenes'] = this.scene.scenes?.length
+      ? this.scene.scenes.map(scene => ({...scene, nodes: [...scene.nodes]}))
+      : [{...(this.scene.name ? {name: this.scene.name} : {}), nodes: this.collectRootNodes()}];
+
+    if (this.scene.meshes?.length) {
+      document['meshes'] = this.scene.meshes.map(mesh => this.writeMesh(mesh));
+    }
+    if (this.scene.materials?.length) {
+      document['materials'] = this.scene.materials.map(material => ({...material}));
+    }
+    if (this.scene.textures?.length) {
+      document['textures'] = this.scene.textures.map(texture => ({...texture}));
+    }
+    if (this.scene.images?.length) {
+      document['images'] = this.scene.images.map(image => this.writeImage(image));
+    }
+    if (this.scene.samplers?.length) {
+      document['samplers'] = this.scene.samplers.map(sampler => ({...sampler}));
+    }
+    if (this.scene.cameras?.length) {
+      document['cameras'] = this.scene.cameras.map(camera => ({...camera}));
+    }
+    if (this.scene.skins?.length) {
+      document['skins'] = this.scene.skins.map(skin => this.writeSkin(skin));
+    }
+    if (this.scene.animations?.length) {
+      document['animations'] = this.scene.animations.map(animation =>
+        this.writeAnimation(animation)
+      );
+    }
+    if (this.scene.extensions) {
+      document['extensions'] = {...this.scene.extensions};
+    }
+    if (this.scene.extras !== undefined) {
+      document['extras'] = this.scene.extras;
+    }
+
+    if (this.bufferViews.length) {
+      document['bufferViews'] = this.bufferViews;
+    }
+    if (this.accessors.length) {
+      document['accessors'] = this.accessors;
+    }
+
+    const binary = this.binary.finish();
+    if (binary.byteLength > 0) {
+      document['buffers'] = [
+        {
+          byteLength: binary.byteLength,
+          ...(!this.options.binary
+            ? {uri: `data:application/octet-stream;base64,${encodeGLTFBase64(binary)}`}
+            : {})
+        }
+      ];
+    }
+
+    const extensionsUsed = new Set(this.scene.extensionsUsed || []);
+    collectExtensionNames(document, extensionsUsed);
+    if (extensionsUsed.size > 0) {
+      document['extensionsUsed'] = [...extensionsUsed];
+    }
+    if (this.scene.extensionsRequired?.length) {
+      document['extensionsRequired'] = [...this.scene.extensionsRequired];
+    }
+
+    return this.options.binary
+      ? makeGLB(document, binary)
+      : JSON.stringify(document, null, this.options.pretty === false ? undefined : 2);
+  }
+
+  private collectRootNodes(): number[] {
+    const childNodes = new Set<number>();
+    for (const node of this.scene.nodes || []) {
+      for (const child of node.children || []) {
+        childNodes.add(child);
+      }
+    }
+    return (this.scene.nodes || []).flatMap((_node, index) =>
+      childNodes.has(index) ? [] : [index]
+    );
+  }
+
+  private writeNode(node: GLTFExportNode): GLTFJSONRecord {
+    const {instances, ...properties} = node;
+    const result: GLTFJSONRecord = {...properties};
+    if (node.children) {
+      result['children'] = [...node.children];
+    }
+    if (node.weights) {
+      result['weights'] = [...node.weights];
+    }
+    if (instances && Object.keys(instances).length > 0) {
+      const attributes: Record<string, number> = {};
+      for (const [name, accessor] of Object.entries(instances)) {
+        attributes[name] = this.writeAccessor(accessor);
+      }
+      result['extensions'] = {
+        ...node.extensions,
+        EXT_mesh_gpu_instancing: {attributes}
+      };
+    }
+    return result;
+  }
+
+  private writeMesh(mesh: GLTFExportMesh): GLTFJSONRecord {
+    return {
+      ...(mesh.name ? {name: mesh.name} : {}),
+      primitives: mesh.primitives.map(primitive => this.writePrimitive(primitive)),
+      ...(mesh.weights ? {weights: [...mesh.weights]} : {}),
+      ...(mesh.extensions ? {extensions: {...mesh.extensions}} : {}),
+      ...(mesh.extras !== undefined ? {extras: mesh.extras} : {})
+    };
+  }
+
+  private writePrimitive(primitive: GLTFExportPrimitive): GLTFJSONRecord {
+    const attributes: Record<string, number> = {};
+    for (const [name, accessor] of Object.entries(primitive.attributes)) {
+      attributes[name] = this.writeAccessor(accessor, {
+        target: ARRAY_BUFFER_TARGET,
+        includeBounds: name === 'POSITION'
+      });
+    }
+    const result: GLTFJSONRecord = {attributes};
+    if (primitive.indices) {
+      result['indices'] = this.writeAccessor(primitive.indices, {
+        target: ELEMENT_ARRAY_BUFFER_TARGET
+      });
+    }
+    if (primitive.material !== undefined) {
+      result['material'] = primitive.material;
+    }
+    if (primitive.mode !== undefined) {
+      result['mode'] = primitive.mode;
+    }
+    if (primitive.targets?.length) {
+      result['targets'] = primitive.targets.map(target =>
+        Object.fromEntries(
+          Object.entries(target).map(([name, accessor]) => [
+            name,
+            this.writeAccessor(accessor, {
+              target: ARRAY_BUFFER_TARGET,
+              includeBounds: name === 'POSITION'
+            })
+          ])
+        )
+      );
+    }
+    if (primitive.extensions) {
+      result['extensions'] = {...primitive.extensions};
+    }
+    if (primitive.extras !== undefined) {
+      result['extras'] = primitive.extras;
+    }
+    return result;
+  }
+
+  private writeSkin(skin: GLTFExportSkin): GLTFJSONRecord {
+    const {inverseBindMatrices, joints, ...properties} = skin;
+    return {
+      ...properties,
+      joints: [...joints],
+      ...(inverseBindMatrices ? {inverseBindMatrices: this.writeAccessor(inverseBindMatrices)} : {})
+    };
+  }
+
+  private writeAnimation(animation: GLTFExportAnimation): GLTFJSONRecord {
+    return {
+      ...(animation.name ? {name: animation.name} : {}),
+      samplers: animation.samplers.map(sampler => ({
+        input: this.writeAccessor(sampler.input, {includeBounds: true}),
+        output: this.writeAccessor(sampler.output),
+        ...(sampler.interpolation ? {interpolation: sampler.interpolation} : {})
+      })),
+      channels: animation.channels.map(channel => ({
+        sampler: channel.sampler,
+        target:
+          channel.target.path === 'pointer'
+            ? {
+                path: 'pointer',
+                extensions: {KHR_animation_pointer: {pointer: channel.target.pointer}}
+              }
+            : {...channel.target}
+      })),
+      ...(animation.extensions ? {extensions: {...animation.extensions}} : {}),
+      ...(animation.extras !== undefined ? {extras: animation.extras} : {})
+    };
+  }
+
+  private writeImage(image: GLTFExportImage): GLTFJSONRecord {
+    const {data, ...properties} = image;
+    if (!data) {
+      return {...properties};
+    }
+    const mimeType = image.mimeType || 'image/png';
+    if (!this.options.binary) {
+      return {...properties, uri: `data:${mimeType};base64,${encodeGLTFBase64(data)}`};
+    }
+    const bufferView = this.writeBufferView(data);
+    return {...properties, bufferView, mimeType};
+  }
+
+  private writeAccessor(
+    accessor: GLTFExportAccessor,
+    options: {target?: number; includeBounds?: boolean} = {}
+  ): number {
+    const data = toGLTFTypedArray(accessor.data);
+    const bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    const result: GLTFJSONRecord = {
+      bufferView: this.writeBufferView(bytes, options.target),
+      componentType: getGLTFComponentType(data),
+      count: data.length / accessor.size,
+      type: getGLTFAccessorType(accessor.size),
+      ...(accessor.normalized ? {normalized: true} : {})
+    };
+
+    if (accessor.min) {
+      result['min'] = [...accessor.min];
+    } else if (options.includeBounds) {
+      result['min'] = getGLTFExtrema(data, accessor.size, Math.min);
+    }
+    if (accessor.max) {
+      result['max'] = [...accessor.max];
+    } else if (options.includeBounds) {
+      result['max'] = getGLTFExtrema(data, accessor.size, Math.max);
+    }
+
+    if (accessor.sparse) {
+      const indices = accessor.sparse.indices;
+      const values = toGLTFTypedArray(accessor.sparse.values);
+      result['sparse'] = {
+        count: indices.length,
+        indices: {
+          bufferView: this.writeBufferView(
+            new Uint8Array(indices.buffer, indices.byteOffset, indices.byteLength)
+          ),
+          componentType: getGLTFComponentType(indices)
+        },
+        values: {
+          bufferView: this.writeBufferView(
+            new Uint8Array(values.buffer, values.byteOffset, values.byteLength)
+          )
+        }
+      };
+    }
+
+    this.accessors.push(result);
+    return this.accessors.length - 1;
+  }
+
+  private writeBufferView(bytes: Uint8Array, target?: number): number {
+    const byteOffset = this.binary.append(bytes);
+    this.bufferViews.push({
+      buffer: 0,
+      byteOffset,
+      byteLength: bytes.byteLength,
+      ...(target ? {target} : {})
+    });
+    return this.bufferViews.length - 1;
+  }
+}
+
+class GLTFBinaryBuilder {
+  private readonly chunks: Uint8Array[] = [];
+  private byteLength = 0;
+
+  append(values: Uint8Array): number {
+    const padding = (4 - (this.byteLength % 4)) % 4;
+    if (padding > 0) {
+      this.chunks.push(new Uint8Array(padding));
+      this.byteLength += padding;
+    }
+    const offset = this.byteLength;
+    this.chunks.push(values);
+    this.byteLength += values.byteLength;
+    return offset;
+  }
+
+  finish(): Uint8Array {
+    const bytes = new Uint8Array(this.byteLength);
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return bytes;
+  }
+}
+
+function toGLTFTypedArray(data: GLTFExportTypedArray | readonly number[]): GLTFExportTypedArray {
+  return Array.isArray(data) ? new Float32Array(data) : (data as GLTFExportTypedArray);
+}
+
+function getGLTFComponentType(data: GLTFExportTypedArray): number {
+  if (data instanceof Int8Array) return 5120;
+  if (data instanceof Uint8Array) return 5121;
+  if (data instanceof Int16Array) return 5122;
+  if (data instanceof Uint16Array) return 5123;
+  if (data instanceof Uint32Array) return 5125;
+  return 5126;
+}
+
+function getGLTFAccessorType(size: GLTFExportAccessorSize): string {
+  if (size === 1) return 'SCALAR';
+  if (size === 9) return 'MAT3';
+  if (size === 16) return 'MAT4';
+  return `VEC${size}`;
+}
+
+function getGLTFExtrema(
+  data: GLTFExportTypedArray,
+  size: GLTFExportAccessorSize,
+  operation: (first: number, second: number) => number
+): number[] {
+  const extrema = Array.from(data.subarray(0, size));
+  for (let offset = size; offset < data.length; offset += size) {
+    for (let component = 0; component < size; component++) {
+      extrema[component] = operation(extrema[component], data[offset + component]);
+    }
+  }
+  return extrema;
+}
+
+function collectExtensionNames(value: unknown, result: Set<string>): void {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+  for (const [name, child] of Object.entries(value)) {
+    if (name === 'extensions' && child && typeof child === 'object') {
+      for (const extension of Object.keys(child)) {
+        result.add(extension);
+      }
+    }
+    collectExtensionNames(child, result);
+  }
+}
+
+function makeGLB(document: GLTFJSONRecord, binary: Uint8Array): ArrayBuffer {
+  const json = new TextEncoder().encode(JSON.stringify(document));
+  const jsonPadding = (4 - (json.byteLength % 4)) % 4;
+  const binaryPadding = (4 - (binary.byteLength % 4)) % 4;
+  const jsonChunkLength = json.byteLength + jsonPadding;
+  const binaryChunkLength = binary.byteLength + binaryPadding;
+  const totalLength =
+    12 + 8 + jsonChunkLength + (binary.byteLength > 0 ? 8 + binaryChunkLength : 0);
+  const result = new ArrayBuffer(totalLength);
+  const bytes = new Uint8Array(result);
+  const view = new DataView(result);
+  view.setUint32(0, GLB_MAGIC, true);
+  view.setUint32(4, 2, true);
+  view.setUint32(8, totalLength, true);
+  view.setUint32(12, jsonChunkLength, true);
+  view.setUint32(16, GLB_JSON_CHUNK, true);
+  bytes.set(json, 20);
+  bytes.fill(0x20, 20 + json.byteLength, 20 + jsonChunkLength);
+
+  if (binary.byteLength > 0) {
+    const binaryHeaderOffset = 20 + jsonChunkLength;
+    view.setUint32(binaryHeaderOffset, binaryChunkLength, true);
+    view.setUint32(binaryHeaderOffset + 4, GLB_BINARY_CHUNK, true);
+    bytes.set(binary, binaryHeaderOffset + 8);
+  }
+  return result;
+}
+
+function encodeGLTFBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
+}

--- a/modules/gltf/src/index.ts
+++ b/modules/gltf/src/index.ts
@@ -30,6 +30,20 @@ export {
 export {parseGLTFAnimations} from './parsers/parse-gltf-animations';
 export {type ParseGLTFLightsOptions, parseGLTFLights} from './parsers/parse-gltf-lights';
 export {
+  exportGLTF,
+  type GLTFExportAccessor,
+  type GLTFExportAnimation,
+  type GLTFExportAnimationChannel,
+  type GLTFExportAnimationSampler,
+  type GLTFExportImage,
+  type GLTFExportMesh,
+  type GLTFExportNode,
+  type GLTFExportOptions,
+  type GLTFExportPrimitive,
+  type GLTFExportScene,
+  type GLTFExportSkin
+} from './export/gltf-exporter';
+export {
   type CreateGLTFTextureOptions,
   createGLTFTexture,
   type ParsePBRMaterialOptions,

--- a/modules/gltf/test/export/gltf-exporter.node.spec.ts
+++ b/modules/gltf/test/export/gltf-exporter.node.spec.ts
@@ -1,0 +1,251 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {parse} from '@loaders.gl/core';
+import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
+import {exportGLTF, type GLTFExportScene} from '@luma.gl/gltf';
+import {describe, expect, test} from 'vitest';
+
+describe('source-faithful glTF asset export', () => {
+  test('preserves hierarchy, complete geometry, normalized weights, skins, and morph targets', () => {
+    const document = JSON.parse(exportGLTF(makeAnimatedScene()));
+    const primitive = document.meshes[0].primitives[0];
+
+    expect(document.asset.version).toBe('2.0');
+    expect(document.scenes[0].nodes).toEqual([0]);
+    expect(document.nodes[0].children).toEqual([1, 2, 3]);
+    expect(document.nodes[1].skin).toBe(0);
+    expect(document.nodes[1].weights).toEqual([0.25, 0.75]);
+    expect(document.skins[0].joints).toEqual([2]);
+    expect(document.accessors[document.skins[0].inverseBindMatrices].type).toBe('MAT4');
+    expect(Object.keys(primitive.attributes)).toEqual([
+      'POSITION',
+      'NORMAL',
+      'TANGENT',
+      'TEXCOORD_0',
+      'TEXCOORD_1',
+      'COLOR_0',
+      'JOINTS_0',
+      'WEIGHTS_0',
+      '_TEMPERATURE'
+    ]);
+    expect(document.accessors[primitive.attributes.COLOR_0].type).toBe('VEC4');
+    expect(document.accessors[primitive.attributes.TANGENT].type).toBe('VEC4');
+    expect(document.accessors[primitive.attributes.JOINTS_0].componentType).toBe(5121);
+    expect(document.accessors[primitive.attributes.WEIGHTS_0].componentType).toBe(5121);
+    expect(document.accessors[primitive.attributes.WEIGHTS_0].normalized).toBe(true);
+    expect(document.accessors[primitive.attributes.POSITION].min).toEqual([0, 0, 0]);
+    expect(document.accessors[primitive.attributes.POSITION].max).toEqual([1, 1, 0]);
+    expect(primitive.targets).toHaveLength(2);
+    expect(Object.keys(primitive.targets[0])).toEqual(['POSITION', 'NORMAL', 'TANGENT']);
+    expect(document.accessors[primitive.targets[0].TANGENT].type).toBe('VEC3');
+    expect(document.accessors[primitive.attributes._TEMPERATURE].sparse.count).toBe(1);
+    expect(document.buffers[0].uri).toMatch(/^data:application\/octet-stream;base64,/);
+
+    for (const bufferView of document.bufferViews) {
+      expect(bufferView.byteOffset % 4).toBe(0);
+    }
+  });
+
+  test('round-trips animated pointers, variants, instancing, samplers, cameras, and lights', () => {
+    const document = JSON.parse(exportGLTF(makeAnimatedScene()));
+    const animation = document.animations[0];
+    const material = document.materials[0];
+
+    expect(animation.channels[0].target).toEqual({node: 1, path: 'translation'});
+    expect(animation.channels[1].target).toEqual({node: 1, path: 'weights'});
+    expect(animation.channels[2].target).toEqual({
+      path: 'pointer',
+      extensions: {
+        KHR_animation_pointer: {
+          pointer: '/materials/0/pbrMetallicRoughness/roughnessFactor'
+        }
+      }
+    });
+    expect(document.accessors[animation.samplers[1].output].type).toBe('SCALAR');
+    expect(document.accessors[animation.samplers[1].output].count).toBe(4);
+    expect(material.extensions.KHR_materials_clearcoat.clearcoatFactor).toBe(0.8);
+    expect(material.pbrMetallicRoughness.baseColorTexture.texCoord).toBe(1);
+    expect(document.samplers[0].minFilter).toBe(9987);
+    expect(document.cameras[0].perspective.yfov).toBe(0.8);
+    expect(document.extensions.KHR_lights_punctual.lights[0].intensity).toBe(2);
+    expect(document.extensions.KHR_materials_variants.variants[0].name).toBe('Copper');
+    expect(document.nodes[3].extensions.EXT_mesh_gpu_instancing.attributes).toEqual({
+      TRANSLATION: expect.any(Number),
+      _BATCH_ID: expect.any(Number)
+    });
+    expect(document.extensionsUsed).toEqual(
+      expect.arrayContaining([
+        'KHR_animation_pointer',
+        'KHR_materials_clearcoat',
+        'KHR_lights_punctual',
+        'KHR_materials_variants',
+        'EXT_mesh_gpu_instancing'
+      ])
+    );
+  });
+
+  test('creates standards-aligned GLB files accepted by the existing loaders.gl parser', async () => {
+    const binary = exportGLTF(makeAnimatedScene(), {binary: true});
+    const header = new DataView(binary);
+
+    expect(header.getUint32(0, true)).toBe(0x46546c67);
+    expect(header.getUint32(4, true)).toBe(2);
+    expect(header.getUint32(8, true)).toBe(binary.byteLength);
+    expect(header.getUint32(12, true) % 4).toBe(0);
+    expect(header.getUint32(16, true)).toBe(0x4e4f534a);
+
+    const source = await parse(binary, GLTFLoader, {gltf: {loadImages: false}});
+    const gltf = postProcessGLTF(source);
+    expect(gltf.scenes).toHaveLength(1);
+    expect(gltf.meshes[0].primitives[0].attributes['COLOR_0'].value).toHaveLength(12);
+    expect(gltf.meshes[0].primitives[0].attributes['JOINTS_0'].value).toBeInstanceOf(Uint8Array);
+    expect(gltf.meshes[0].primitives[0].targets).toHaveLength(2);
+    expect(gltf.skins).toHaveLength(1);
+    expect(gltf.animations).toHaveLength(1);
+  });
+
+  test('keeps all caller-owned source arrays and scene descriptors unchanged', () => {
+    const scene = makeAnimatedScene();
+    const sourcePosition = scene.meshes?.[0].primitives[0].attributes['POSITION'].data;
+    const sourceValues = [...(sourcePosition || [])];
+
+    exportGLTF(scene);
+    exportGLTF(scene, {binary: true});
+
+    expect([
+      ...((scene.meshes?.[0].primitives[0].attributes['POSITION'].data || []) as number[])
+    ]).toEqual(sourceValues);
+    expect(scene.nodes?.[1].weights).toEqual([0.25, 0.75]);
+    expect(scene.images?.[0].data).toEqual(new Uint8Array([137, 80, 78, 71]));
+  });
+});
+
+function makeAnimatedScene(): GLTFExportScene {
+  return {
+    name: 'Animated interchange',
+    nodes: [
+      {name: 'Root', children: [1, 2, 3]},
+      {name: 'Character', mesh: 0, skin: 0, weights: [0.25, 0.75]},
+      {name: 'Joint', translation: [0, 1, 0]},
+      {
+        name: 'Instances',
+        mesh: 0,
+        instances: {
+          TRANSLATION: {data: new Float32Array([0, 0, 0, 2, 0, 0]), size: 3},
+          _BATCH_ID: {data: new Uint16Array([4, 8]), size: 1}
+        }
+      }
+    ],
+    meshes: [
+      {
+        name: 'Animated mesh',
+        weights: [0.25, 0.75],
+        primitives: [
+          {
+            attributes: {
+              POSITION: {data: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]), size: 3},
+              NORMAL: {data: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]), size: 3},
+              TANGENT: {data: new Float32Array([1, 0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1]), size: 4},
+              TEXCOORD_0: {data: new Float32Array([0, 0, 1, 0, 0, 1]), size: 2},
+              TEXCOORD_1: {data: new Float32Array([0.2, 0.3, 0.8, 0.3, 0.2, 0.9]), size: 2},
+              COLOR_0: {
+                data: new Float32Array([1, 0, 0, 0.5, 0, 1, 0, 0.6, 0, 0, 1, 0.7]),
+                size: 4
+              },
+              JOINTS_0: {data: new Uint8Array(12), size: 4},
+              WEIGHTS_0: {
+                data: new Uint8Array([255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0]),
+                size: 4,
+                normalized: true
+              },
+              _TEMPERATURE: {
+                data: new Float32Array([1, 1, 1]),
+                size: 1,
+                sparse: {indices: new Uint8Array([1]), values: new Float32Array([42])}
+              }
+            },
+            indices: {data: new Uint16Array([0, 1, 2]), size: 1},
+            material: 0,
+            targets: [
+              {
+                POSITION: {data: new Float32Array([0, 1, 0, 0, 1, 0, 0, 1, 0]), size: 3},
+                NORMAL: {data: new Float32Array(9), size: 3},
+                TANGENT: {data: new Float32Array(9), size: 3}
+              },
+              {
+                POSITION: {data: new Float32Array([1, 0, 0, 1, 0, 0, 1, 0, 0]), size: 3}
+              }
+            ],
+            extensions: {
+              KHR_materials_variants: {mappings: [{material: 0, variants: [0]}]}
+            }
+          }
+        ]
+      }
+    ],
+    materials: [
+      {
+        name: 'Copper',
+        pbrMetallicRoughness: {
+          baseColorFactor: [0.8, 0.5, 0.3, 0.7],
+          baseColorTexture: {index: 0, texCoord: 1},
+          roughnessFactor: 0.4
+        },
+        extensions: {KHR_materials_clearcoat: {clearcoatFactor: 0.8}}
+      }
+    ],
+    textures: [{name: 'Base color', source: 0, sampler: 0}],
+    images: [{name: 'Color image', data: new Uint8Array([137, 80, 78, 71]), mimeType: 'image/png'}],
+    samplers: [{wrapS: 33071, wrapT: 33648, minFilter: 9987, magFilter: 9729}],
+    cameras: [{type: 'perspective', perspective: {yfov: 0.8, znear: 0.1}}],
+    skins: [
+      {
+        name: 'Skeleton',
+        joints: [2],
+        skeleton: 2,
+        inverseBindMatrices: {
+          data: new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+          size: 16
+        }
+      }
+    ],
+    animations: [
+      {
+        name: 'Animated material and morph',
+        samplers: [
+          {
+            input: {data: new Float32Array([0, 1]), size: 1},
+            output: {data: new Float32Array([0, 0, 0, 1, 0, 0]), size: 3}
+          },
+          {
+            input: {data: new Float32Array([0, 1]), size: 1},
+            output: {data: new Float32Array([0, 1, 1, 0]), size: 1},
+            interpolation: 'LINEAR'
+          },
+          {
+            input: {data: new Float32Array([0, 1]), size: 1},
+            output: {data: new Float32Array([0.1, 0.7]), size: 1},
+            interpolation: 'STEP'
+          }
+        ],
+        channels: [
+          {sampler: 0, target: {node: 1, path: 'translation'}},
+          {sampler: 1, target: {node: 1, path: 'weights'}},
+          {
+            sampler: 2,
+            target: {
+              path: 'pointer',
+              pointer: '/materials/0/pbrMetallicRoughness/roughnessFactor'
+            }
+          }
+        ]
+      }
+    ],
+    extensions: {
+      KHR_lights_punctual: {lights: [{type: 'point', intensity: 2}]},
+      KHR_materials_variants: {variants: [{name: 'Copper'}]}
+    }
+  };
+}

--- a/test/examples/gltf-showcase-identity.node.spec.ts
+++ b/test/examples/gltf-showcase-identity.node.spec.ts
@@ -1,0 +1,54 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+describe('glTF module and showcase identity', () => {
+  test('features the standards-first glTF showcase as a real homepage example card', () => {
+    const homepage = readFileSync(path.join(process.cwd(), 'website/src/pages/index.jsx'), 'utf8');
+    const featuredExamples = homepage.match(/const\s+FEATURED_EXAMPLES\s*=\s*\[([\s\S]*?)\n\];/);
+    const showcase = readFileSync(
+      path.join(process.cwd(), 'website/content/examples/showcase/gltf.mdx'),
+      'utf8'
+    );
+
+    expect(featuredExamples).not.toBeNull();
+    expect(featuredExamples![1]).toMatch(/title:\s*'glTF Asset Studio'/);
+    expect(featuredExamples![1]).toMatch(/route:\s*'showcase\/gltf'/);
+    expect(featuredExamples![1]).toMatch(/image:\s*'showcase\/gltf\.jpg'/);
+    expect(featuredExamples![1]).toMatch(/standards-first glTF/i);
+    expect(featuredExamples![1]).toMatch(/backends:\s*\['webgpu',\s*'webgl2'\]/);
+    expect(showcase).toMatch(/title:\s*glTF Asset Studio/);
+    expect(showcase).toMatch(/animated skeletons[\s\S]*morph targets/i);
+  });
+
+  test('describes glTF as an animated physical-asset and interchange module', () => {
+    const packageMetadata = JSON.parse(
+      readFileSync(path.join(process.cwd(), 'modules/gltf/package.json'), 'utf8')
+    );
+    const moduleDocumentation = readFileSync(
+      path.join(process.cwd(), 'docs/api-reference/gltf/README.md'),
+      'utf8'
+    );
+    const interchangeDocumentation = readFileSync(
+      path.join(process.cwd(), 'docs/api-reference/gltf/gltf-interchange.md'),
+      'utf8'
+    );
+    const tabs = readFileSync(
+      path.join(process.cwd(), 'website/src/components/docs/gltf-docs-tabs.tsx'),
+      'utf8'
+    );
+
+    expect(packageMetadata.description).toMatch(/physical materials[\s\S]*animation/i);
+    expect(packageMetadata.keywords).toEqual(
+      expect.arrayContaining(['gltf', 'glb', 'webgpu', 'pbr', 'animation'])
+    );
+    expect(moduleDocumentation).toMatch(/standards-first asset runtime/i);
+    expect(interchangeDocumentation).toContain('KHR_animation_pointer');
+    expect(interchangeDocumentation).toContain('EXT_mesh_gpu_instancing');
+    expect(tabs).toContain('/docs/api-reference/gltf/gltf-interchange');
+  });
+});

--- a/website/content/examples/showcase/gltf.mdx
+++ b/website/content/examples/showcase/gltf.mdx
@@ -1,12 +1,12 @@
 ---
-title: glTF
-description: Browse production glTF assets with PBR lighting, animation, camera controls, and extension-focused scenes.
+title: glTF Asset Studio
+description: Standards-first glTF assets with physically based materials, animated skeletons, morph targets, animation pointers, and WebGPU/WebGL rendering.
 sidebar_custom_props:
   backends: [webgpu, webgl2]
   display: hdr-capable
   difficulty: intermediate
   maturity: stable
-  topics: [rendering, gltf, materials, animation, hdr]
+  topics: [gltf, materials, animation, rendering, hdr]
 ---
 
 import {GLTFExample} from '@site/src/examples';

--- a/website/src/components/docs/gltf-docs-tabs.tsx
+++ b/website/src/components/docs/gltf-docs-tabs.tsx
@@ -4,12 +4,13 @@ import Link from '@docusaurus/Link';
 type GltfDocsTab = {id: GltfDocsTabId; label: string; href: string};
 
 /** glTF documentation tab identifiers. */
-export type GltfDocsTabId = 'overview' | 'materials' | 'animation' | 'extensions';
+export type GltfDocsTabId = 'overview' | 'materials' | 'animation' | 'interchange' | 'extensions';
 
 const GLTF_DOCS_TABS: GltfDocsTab[] = [
   {id: 'overview', label: 'Overview', href: '/docs/api-reference/gltf'},
   {id: 'materials', label: 'Materials', href: '/docs/api-reference/gltf/gltf-materials'},
   {id: 'animation', label: 'Animation', href: '/docs/api-reference/gltf/gltf-animation'},
+  {id: 'interchange', label: 'Interchange', href: '/docs/api-reference/gltf/gltf-interchange'},
   {id: 'extensions', label: 'Extensions', href: '/docs/api-reference/gltf/gltf-extensions'}
 ];
 

--- a/website/src/examples.tsx
+++ b/website/src/examples.tsx
@@ -732,7 +732,8 @@ export const ANARIPlaygroundExample: React.FC = () => {
 export const GLTFExample: React.FC<WebsiteExampleProps> = props => (
   <LumaExample
     id="gltf"
-    title="glTF"
+    title="glTF Asset Studio"
+    subtitle="Physical materials · animated characters · standards-native glTF"
     directory="showcase"
     template={GLTFApp}
     config={exampleConfig}

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -10,6 +10,19 @@ const HERO_CAPABILITIES = ['WebGPU', 'WebGL2', 'GPU compute', 'HDR rendering'];
 
 const FEATURED_EXAMPLES = [
   {
+    title: 'glTF Asset Studio',
+    route: 'showcase/gltf',
+    image: 'showcase/gltf.jpg',
+    description:
+      'Explore standards-first glTF assets with physical materials, animated characters, morph targets, native extensions, and portable WebGPU/WebGL rendering.',
+    category: 'glTF',
+    backends: ['webgpu', 'webgl2'],
+    highDynamicRange: true,
+    difficulty: 'intermediate',
+    maturity: 'stable',
+    topics: ['gltf', 'materials', 'animation']
+  },
+  {
     title: 'Lightstorm Megacity',
     route: 'showcase/lightstorm-megacity',
     image: 'showcase/lightstorm-megacity.jpg',
@@ -130,10 +143,10 @@ const CAPABILITY_STORIES = [
   },
   {
     index: '03',
-    title: 'Open by design',
+    title: 'Open assets, without compromise',
     description:
-      'Build with a TypeScript-first API across WebGPU and WebGL2, with natural paths into deck.gl, Arrow, and glTF.',
-    technologies: ['WebGPU + WebGL2', 'Apache Arrow', 'deck.gl + glTF']
+      'Load, animate, render, and round-trip standards-first glTF assets with shared physical materials, skeletons, morph targets, and native animation pointers.',
+    technologies: ['glTF 2.0 + GLB', 'PBR + animation', 'WebGPU + WebGL2']
   }
 ];
 


### PR DESCRIPTION
## Goals

Make `@luma.gl/gltf` a visibly first-class, standards-native asset module and provide source-faithful animated `.gltf` / `.glb` interchange without coupling the format package to ANARI or any renderer.

## Changes

- Add a generic `exportGLTF()` API and strongly typed scene, mesh, accessor, skin, animation, pointer, image, and instancing descriptors to `@luma.gl/gltf`.
- Preserve hierarchy, multi-scene roots, RGBA colors, tangents, custom semantics, normalized joint weights, sparse accessors, morph targets, inverse-bind matrices, animation clips, `KHR_animation_pointer`, `KHR_materials_variants`, `EXT_mesh_gpu_instancing`, cameras, lights, samplers, and arbitrary material extensions.
- Produce embedded JSON glTF or correctly aligned binary GLB with caller-owned resources and automatically declared extensions.
- Move existing ANARI export onto the format-owned writer, preserve real AnimatedMorphCube animation/hierarchy, fix RGBA vertex-color loss and explicit opacity precedence, and support retained skin descriptions and animated material/sampler pointers.
- Promote glTF Asset Studio to a featured homepage example card, strengthen the module package description and API overview, and add a discoverable glTF interchange reference page with release notes and regression coverage.

## Verification

- Strict ANARI dependency-graph TypeScript project-reference build and isolated full-source ANARI showcase typecheck passed.
- Cross-package runtime regression suite passed 27 files and 161 tests, including source-faithful AnimatedMorphCube import/export, 127 two-target morph keyframes, normalized joints, sparse data, hierarchy, variants, instancing, animated pointers, and real loaders.gl GLB re-import.
- Standalone ANARI Vite production build and full Docusaurus production build passed with the new featured card and interchange route.
- Changed source/tests passed project-equivalent Biome checks; changed Markdown/MDX compiled and all internal documentation links resolved.
- `nvm use` and `yarn install` were not rerun; the existing shared workspace installation was reused. Repository-native `yarn build`, `yarn test`, `yarn lint fix`, and `yarn website:build` are affected locally by the previously documented stale dev-tools / Yarn environment; direct project-reference, Vitest, formatter, Vite, and Docusaurus equivalents were run instead.

## Architecture

- `@luma.gl/gltf` owns format interpretation and asset serialization; `@loaders.gl/gltf` remains the loader/decompressor.
- ANARI only projects retained scene descriptors into the public generic exporter.
- No duplicate skeleton, morph runtime, mixer, material shader, renderer, or compression decoder.
