### PR TITLE
fix(gltf): release owned scenegraph GPU resources

### DIFF
--- a/docs/api-reference/gltf/README.md
+++ b/docs/api-reference/gltf/README.md
@@ -86,9 +86,21 @@ bundle contains:
 | `gltfNodeIdToNodeMap`, `gltfNodeIndexToNodeMap` | Source-node lookup tables for application integration. |
 | `gltfMeshIdToNodeMap` | Source-mesh lookup table. |
 | `gltf` | The original postprocessed glTF document. |
+| `destroy()` | Idempotently releases scene-owned models, materials, buffers, and textures. |
 
 Each bounds object contains `bounds`, `center`, `size`, `radius`, and
 `recommendedOrbitDistance`.
+
+### Asset lifetime
+
+Release the returned scenegraphs when replacing or unloading an asset:
+
+```ts
+scenegraphs.destroy();
+```
+
+This includes hidden nodes, detached mesh templates, instancing buffers, and generated source-image
+textures. The application-owned device and borrowed image-based-lighting textures are not destroyed.
 
 ### Options
 

--- a/examples/showcase/gltf/gltf-catalog-app.ts
+++ b/examples/showcase/gltf/gltf-catalog-app.ts
@@ -952,10 +952,5 @@ function getModelLightSummary(modelLights: Light[]): string {
 }
 
 function destroyScenegraphs(scenegraphsFromGLTF?: ReturnType<typeof createScenegraphsFromGLTF>) {
-  for (const scene of scenegraphsFromGLTF?.scenes || []) {
-    scene.traverse(node => {
-      const model = (node as Partial<ModelNode>).model;
-      model?.destroy();
-    });
-  }
+  scenegraphsFromGLTF?.destroy();
 }

--- a/modules/gltf/src/gltf/create-scenegraph-from-gltf.ts
+++ b/modules/gltf/src/gltf/create-scenegraph-from-gltf.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Device} from '@luma.gl/core';
-import {GroupNode, Material} from '@luma.gl/engine';
+import {GroupNode, Material, ModelNode} from '@luma.gl/engine';
 import {GLTFPostprocessed} from '@loaders.gl/gltf';
 import {Light} from '@luma.gl/shadertools';
 import {parseGLTF, type ParseGLTFOptions} from '../parsers/parse-gltf';
@@ -67,6 +67,9 @@ export type GLTFScenegraphs = {
 
   /** Original post-processed glTF document. */
   gltf: GLTFPostprocessed;
+
+  /** Releases every asset-owned model, material, buffer, and source-image texture exactly once. */
+  destroy(): void;
 };
 
 /** Converts a post-processed glTF asset into luma.gl scenegraph nodes and animation helpers. */
@@ -79,8 +82,14 @@ export function createScenegraphsFromGLTF(
     assertSupportedGLTFExtensions(gltf);
   }
 
-  const {scenes, materials, gltfMeshIdToNodeMap, gltfNodeIdToNodeMap, gltfNodeIndexToNodeMap} =
-    parseGLTF(device, gltf, options);
+  const {
+    scenes,
+    materials,
+    gltfMeshIdToNodeMap,
+    gltfNodeIdToNodeMap,
+    gltfNodeIndexToNodeMap,
+    generatedTextures
+  } = parseGLTF(device, gltf, options);
 
   const animations = parseGLTFAnimations(gltf);
   const sourceLights =
@@ -127,6 +136,46 @@ export function createScenegraphsFromGLTF(
   const skins = new GLTFSkinController({gltf, scenes, gltfNodeIndexToNodeMap});
   animator.setUpdateHandler(() => skins.update());
 
+  let destroyed = false;
+  const destroy = (): void => {
+    if (destroyed) {
+      return;
+    }
+    destroyed = true;
+
+    const groups = new Set<GroupNode>([
+      ...scenes,
+      ...gltfMeshIdToNodeMap.values(),
+      ...gltfNodeIdToNodeMap.values()
+    ]);
+    const modelNodes = new Set<ModelNode>();
+    const ownedMaterials = new Set<Material>(materials);
+    for (const group of groups) {
+      group.preorderTraversal(node => {
+        if (node instanceof ModelNode) {
+          modelNodes.add(node);
+          if (node.model?.material) {
+            ownedMaterials.add(node.model.material);
+          }
+        }
+      });
+    }
+
+    for (const modelNode of modelNodes) {
+      modelNode.destroy();
+    }
+    for (const group of groups) {
+      group.destroy();
+    }
+    for (const material of ownedMaterials) {
+      material.destroy();
+    }
+    for (const texture of generatedTextures) {
+      texture.destroy();
+    }
+    generatedTextures.clear();
+  };
+
   return {
     scenes,
     materials,
@@ -142,7 +191,8 @@ export function createScenegraphsFromGLTF(
     gltfNodeIdToNodeMap,
     gltfNodeIndexToNodeMap,
     skins,
-    gltf
+    gltf,
+    destroy
   };
 }
 

--- a/modules/gltf/src/parsers/parse-gltf.ts
+++ b/modules/gltf/src/parsers/parse-gltf.ts
@@ -8,7 +8,7 @@ import {
   type GLTFNodePostprocessed,
   type GLTFPostprocessed
 } from '@loaders.gl/gltf';
-import {Device, type PrimitiveTopology} from '@luma.gl/core';
+import {Device, type PrimitiveTopology, type Texture} from '@luma.gl/core';
 import {
   Geometry,
   GeometryAttribute,
@@ -48,6 +48,10 @@ export type ParseGLTFOptions = {
   strictExtensions?: boolean;
 };
 
+type ParseGLTFInternalOptions = Required<ParseGLTFOptions> & {
+  generatedTextures: Set<Texture>;
+};
+
 const defaultOptions: Required<ParseGLTFOptions> = {
   modelOptions: {},
   pbrDebug: false,
@@ -77,13 +81,20 @@ export function parseGLTF(
   gltfNodeIndexToNodeMap: Map<number, GroupNode>;
   /** Map from glTF node ids to generated scenegraph nodes. */
   gltfNodeIdToNodeMap: Map<string, GroupNode>;
+  /** Textures generated while parsing source materials, primitives, and variants. */
+  generatedTextures: Set<Texture>;
 } {
-  const combinedOptions = {...defaultOptions, ...options};
+  const generatedTextures = new Set<Texture>();
+  const combinedOptions: ParseGLTFInternalOptions = {
+    ...defaultOptions,
+    ...options,
+    generatedTextures
+  };
   const materialFactory = new MaterialFactory(device, {modules: [pbrMaterial]});
   const materials = (gltf.materials || []).map((gltfMaterial, materialIndex) =>
     createGLTFMaterial(device, {
       id: getGLTFMaterialId(gltfMaterial, materialIndex),
-      parsedPPBRMaterial: parsePBRMaterial(
+      parsedPPBRMaterial: parseOwnedPBRMaterial(
         device,
         gltfMaterial as any,
         {},
@@ -203,14 +214,35 @@ export function parseGLTF(
     });
   });
 
-  return {scenes, materials, gltfMeshIdToNodeMap, gltfNodeIdToNodeMap, gltfNodeIndexToNodeMap};
+  return {
+    scenes,
+    materials,
+    gltfMeshIdToNodeMap,
+    gltfNodeIdToNodeMap,
+    gltfNodeIndexToNodeMap,
+    generatedTextures
+  };
+}
+
+/** Records every uploaded source texture without taking ownership of borrowed IBL textures. */
+function parseOwnedPBRMaterial(
+  device: Device,
+  material: Parameters<typeof parsePBRMaterial>[1],
+  attributes: Record<string, any>,
+  options: ParseGLTFInternalOptions & {gltf: GLTFPostprocessed; validateAttributes?: boolean}
+): ReturnType<typeof parsePBRMaterial> {
+  const parsedMaterial = parsePBRMaterial(device, material, attributes, options);
+  for (const texture of parsedMaterial.generatedTextures) {
+    options.generatedTextures.add(texture);
+  }
+  return parsedMaterial;
 }
 
 /** Creates a `GroupNode` for one glTF node transform. */
 function createNodeForGLTFNode(
   device: Device,
   gltfNode: GLTFNodePostprocessed,
-  options: Required<ParseGLTFOptions>
+  options: ParseGLTFInternalOptions
 ): GroupNode {
   return new GroupNode({
     id: gltfNode.name || gltfNode.id,
@@ -229,7 +261,7 @@ function createNodeForGLTFMesh(
   gltfMesh: GLTFMeshPostprocessed,
   gltf: GLTFPostprocessed,
   gltfMaterialIdToMaterialMap: Map<string, Material>,
-  options: Required<ParseGLTFOptions>,
+  options: ParseGLTFInternalOptions,
   instancing?: GLTFGPUInstancing
 ): GroupNode {
   const gltfPrimitives = gltfMesh.primitives || [];
@@ -261,7 +293,7 @@ type CreateNodeForGLTFPrimitiveOptions = {
   gltfMesh: GLTFMeshPostprocessed;
   gltf: GLTFPostprocessed;
   gltfMaterialIdToMaterialMap: Map<string, Material>;
-  options: Required<ParseGLTFOptions>;
+  options: ParseGLTFInternalOptions;
   instancing?: GLTFGPUInstancing;
 };
 
@@ -284,10 +316,12 @@ function createNodeForGLTFPrimitive({
 
   const geometry = createGeometry(id, gltfPrimitive, topology);
 
-  const parsedPPBRMaterial = parsePBRMaterial(device, gltfPrimitive.material, geometry.attributes, {
-    ...options,
-    gltf
-  });
+  const parsedPPBRMaterial = parseOwnedPBRMaterial(
+    device,
+    gltfPrimitive.material,
+    geometry.attributes,
+    {...options, gltf}
+  );
 
   const modelNode = createGLTFModel(device, {
     id,
@@ -320,10 +354,12 @@ function createNodeForGLTFPrimitive({
       if (!material) {
         continue;
       }
-      const variantMaterial = parsePBRMaterial(device, sourceMaterial as any, geometry.attributes, {
-        ...options,
-        gltf
-      });
+      const variantMaterial = parseOwnedPBRMaterial(
+        device,
+        sourceMaterial as any,
+        geometry.attributes,
+        {...options, gltf}
+      );
       for (const variantIndex of mapping.variants || []) {
         mappings.set(variantIndex, {
           material,

--- a/modules/gltf/test/gltf/gltf-resource-lifecycle.node.spec.ts
+++ b/modules/gltf/test/gltf/gltf-resource-lifecycle.node.spec.ts
@@ -1,0 +1,123 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {readFile} from 'node:fs/promises';
+import {parse} from '@loaders.gl/core';
+import {GLTFLoader, type GLTFPostprocessed, postProcessGLTF} from '@loaders.gl/gltf';
+import type {Buffer, Texture} from '@luma.gl/core';
+import {ModelNode} from '@luma.gl/engine';
+import {createScenegraphsFromGLTF, type PBREnvironment} from '@luma.gl/gltf';
+import {NullDevice} from '@luma.gl/test-utils';
+import {describe, expect, test} from 'vitest';
+
+async function loadLifecycleFixture(
+  name: 'CubeVisibility' | 'SimpleInstancing'
+): Promise<GLTFPostprocessed> {
+  const source = await readFile(new URL(`../data/${name}.glb`, import.meta.url));
+  return postProcessGLTF(await parse(source, GLTFLoader, {gltf: {loadImages: false}}));
+}
+
+function getActiveResourceCount(device: NullDevice, resource: 'Buffers' | 'Textures'): number {
+  return device.statsManager.getStats('Resource Counts').get(`${resource} Active`).count;
+}
+
+function makeSourceTexture(image: Record<string, unknown>): any {
+  return {id: 'owned-image', texture: {source: {image}, sampler: {parameters: {}}}};
+}
+
+describe('glTF scenegraph resource lifecycle', () => {
+  test('releases every source, primitive, and variant material texture exactly once', async () => {
+    const source = await loadLifecycleFixture('CubeVisibility');
+    const device = new NullDevice({});
+    const image = {
+      compressed: true,
+      mipmaps: true,
+      data: [{data: new Uint8Array(16), width: 4, height: 4, textureFormat: 'bc7-rgba-unorm'}]
+    };
+
+    for (const material of source.materials) {
+      material.pbrMetallicRoughness = {
+        ...material.pbrMetallicRoughness,
+        baseColorTexture: makeSourceTexture(image)
+      };
+    }
+    source.extensions = {
+      ...source.extensions,
+      KHR_materials_variants: {variants: [{name: 'Alternate'}]}
+    } as GLTFPostprocessed['extensions'];
+    source.meshes[0].primitives[0].extensions = {
+      KHR_materials_variants: {mappings: [{material: 1, variants: [0]}]}
+    };
+
+    const initialTextureCount = getActiveResourceCount(device, 'Textures');
+    const initialBufferCount = getActiveResourceCount(device, 'Buffers');
+    const scenegraphs = createScenegraphsFromGLTF(device, source);
+    const primitiveCount = source.meshes.reduce((count, mesh) => count + mesh.primitives.length, 0);
+    const expectedTextureCount = source.materials.length + primitiveCount + 1;
+    const materialTextures = scenegraphs.materials.map(
+      material => material.getBindings().pbr_baseColorSampler as Texture
+    );
+
+    expect(getActiveResourceCount(device, 'Textures')).toBe(
+      initialTextureCount + expectedTextureCount
+    );
+    expect(materialTextures.every(texture => !texture.destroyed)).toBe(true);
+    scenegraphs.variants.selectVariant('Alternate');
+
+    scenegraphs.destroy();
+    scenegraphs.destroy();
+
+    expect(materialTextures.every(texture => texture.destroyed)).toBe(true);
+    expect(getActiveResourceCount(device, 'Textures')).toBe(initialTextureCount);
+    expect(getActiveResourceCount(device, 'Buffers')).toBe(initialBufferCount);
+    device.destroy();
+  });
+
+  test('releases hidden instancing and detached templates without destroying borrowed IBL', async () => {
+    const source = await loadLifecycleFixture('SimpleInstancing');
+    const device = new NullDevice({});
+    const borrowedTexture = device.createTexture({width: 1, height: 1});
+    const imageBasedLightingEnvironment = {
+      diffuseEnvSampler: {texture: borrowedTexture},
+      specularEnvSampler: {texture: borrowedTexture},
+      brdfLutTexture: {texture: borrowedTexture}
+    } as PBREnvironment;
+    const initialBufferCount = getActiveResourceCount(device, 'Buffers');
+    const initialTextureCount = getActiveResourceCount(device, 'Textures');
+    const scenegraphs = createScenegraphsFromGLTF(device, source, {
+      imageBasedLightingEnvironment
+    });
+    const instanceBuffers: Buffer[] = [];
+    const detachedModelNodes: ModelNode[] = [];
+
+    scenegraphs.scenes[0].preorderTraversal(node => {
+      if (node instanceof ModelNode) {
+        instanceBuffers.push(...(node.managedResources as Buffer[]));
+      }
+    });
+    for (const sourceMesh of scenegraphs.gltfMeshIdToNodeMap.values()) {
+      sourceMesh.preorderTraversal(node => {
+        if (node instanceof ModelNode) {
+          detachedModelNodes.push(node);
+        }
+      });
+    }
+
+    expect(instanceBuffers).toHaveLength(4);
+    expect(instanceBuffers.every(buffer => !buffer.destroyed)).toBe(true);
+    expect(detachedModelNodes).toHaveLength(1);
+    scenegraphs.scenes[0].display = false;
+
+    scenegraphs.destroy();
+
+    expect(instanceBuffers.every(buffer => buffer.destroyed)).toBe(true);
+    expect(detachedModelNodes.every(node => node.model === null)).toBe(true);
+    expect(getActiveResourceCount(device, 'Buffers')).toBe(initialBufferCount);
+    expect(getActiveResourceCount(device, 'Textures')).toBe(initialTextureCount);
+    expect(borrowedTexture.destroyed).toBe(false);
+
+    borrowedTexture.destroy();
+    device.destroy();
+  });
+});


### PR DESCRIPTION
## Goals

Prevent glTF asset replacement from leaking GPU resources without introducing a public resource cache or cross-scene ownership API.

## Changes

- Add one idempotent public lifecycle method: `GLTFScenegraphs.destroy()`.
- Track every source-image texture created while parsing source materials, mesh primitives, and material variants in a private, per-asset `Set`.
- Release visible and hidden models, detached mesh templates, engine materials, geometry and instancing buffers, and all generated textures exactly once.
- Preserve caller ownership of the `Device`, source images, and supplied image-based-lighting textures.
- Wire the existing glTF Asset Studio to the real teardown API when models are replaced or the viewer shuts down.
- Document the lifecycle method and cover exact GPU-resource accounting with two compact `NullDevice` regressions.

This rewrite reduces the original proposal from **37 files / +878 lines** to **5 files / +241 lines**. Public caches, reference counting, cross-scene sharing, parsed-material specialization, unrelated documentation, and already-landed SPDX changes were removed. Texture-upload deduplication is intentionally deferred to a separate performance-focused change.

## Verification

- **18 related regression suites / 85 tests passed**, including glTF loading, native extensions, variants, instancing, animation, PBR materials, ANARI import/interchange, showcase identity, and SPDX provenance.
- New lifecycle coverage verifies all **7** source/primitive/variant image uploads return to baseline, all **4** hidden instancing buffers are released, detached models are destroyed, borrowed IBL remains alive, and repeated destruction is safe.
- Full cross-package TypeScript project-reference build passed.
- Public `ReturnType<typeof createScenegraphsFromGLTF>['destroy']` consumer contract passed.
- Scoped Biome formatting, MDX compilation, and `git diff --check` passed.
- Full production Docusaurus build, standalone ANARI example build, and LLM output validation passed for **481 documentation pages**.

## Architecture

Resource interpretation and ownership remain entirely inside `@luma.gl/gltf`. Existing engine node/model teardown is reused; no new runtime package, exported cache, shader implementation, renderer dependency, or ownership transfer is introduced.