### PR TITLE
fix: restore SPDX and RAPIDS source provenance

### DIFF
--- a/modules/anari/test/gltf-review-light-import.node.spec.ts
+++ b/modules/anari/test/gltf-review-light-import.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {readFile} from 'node:fs/promises';
 import {parse} from '@loaders.gl/core';

--- a/modules/anari/test/scene-interchange.node.spec.ts
+++ b/modules/anari/test/scene-interchange.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {readFile} from 'node:fs/promises';
 import {parse} from '@loaders.gl/core';

--- a/modules/engine/test/animation/morph-review-correctness.node.spec.ts
+++ b/modules/engine/test/animation/morph-review-correctness.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {
   decodeMorphTargetAttribute,

--- a/modules/engine/test/scenegraph/scenegraph-visibility.node.spec.ts
+++ b/modules/engine/test/scenegraph/scenegraph-visibility.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {GroupNode, ScenegraphNode} from '@luma.gl/engine';
 import {describe, expect, test} from 'vitest';

--- a/modules/experimental/src/lugraph/lu-graph-breadth-first-search-internals.ts
+++ b/modules/experimental/src/lugraph/lu-graph-breadth-first-search-internals.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
 
 import {type Binding} from '@luma.gl/core';
 import {Computation} from '@luma.gl/engine';

--- a/modules/experimental/src/lugraph/lu-graph-breadth-first-search.ts
+++ b/modules/experimental/src/lugraph/lu-graph-breadth-first-search.ts
@@ -1,6 +1,7 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+// SPDX-FileComment: Independently implemented for WebGPU; inspired by NVIDIA RAPIDS cuGraph.
 
 import type {Buffer} from '@luma.gl/core';
 import {DynamicBuffer} from '@luma.gl/engine';

--- a/modules/experimental/test/engine/scene-review-deformation.node.spec.ts
+++ b/modules/experimental/test/engine/scene-review-deformation.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Geometry} from '@luma.gl/engine';
 import {SceneRenderer, type SceneRenderOptions, type SceneSurface} from '@luma.gl/experimental';

--- a/modules/experimental/test/lugraph/lu-graph-breadth-first-search.node.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-breadth-first-search.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer} from '@luma.gl/core';
 import {DynamicBuffer} from '@luma.gl/engine';

--- a/modules/experimental/test/lugraph/lu-graph-breadth-first-search.spec.ts
+++ b/modules/experimental/test/lugraph/lu-graph-breadth-first-search.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer, type Device} from '@luma.gl/core';
 import {GPUCommandGraph} from '@luma.gl/experimental';

--- a/modules/gltf/src/export/gltf-exporter.ts
+++ b/modules/gltf/src/export/gltf-exporter.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 type GLTFExportTypedArray =
   | Int8Array

--- a/modules/gltf/src/gltf/gltf-instancing.ts
+++ b/modules/gltf/src/gltf/gltf-instancing.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {GLTFNodePostprocessed, GLTFPostprocessed} from '@loaders.gl/gltf';
 import {Matrix4} from '@math.gl/core';

--- a/modules/gltf/src/gltf/gltf-material-variants.ts
+++ b/modules/gltf/src/gltf/gltf-material-variants.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {RenderPipelineParameters} from '@luma.gl/core';
 import {GroupNode, Material, ModelNode} from '@luma.gl/engine';

--- a/modules/gltf/test/export/gltf-exporter.node.spec.ts
+++ b/modules/gltf/test/export/gltf-exporter.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {parse} from '@loaders.gl/core';
 import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';

--- a/modules/gltf/test/gltf/gltf-native-extensions.node.spec.ts
+++ b/modules/gltf/test/gltf/gltf-native-extensions.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {readFile} from 'node:fs/promises';
 import {parse} from '@loaders.gl/core';

--- a/modules/gltf/test/gltf/gltf-native-extensions.spec.ts
+++ b/modules/gltf/test/gltf/gltf-native-extensions.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {load} from '@loaders.gl/core';
 import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';

--- a/modules/gltf/test/gltf/gltf-review-correctness.node.spec.ts
+++ b/modules/gltf/test/gltf/gltf-review-correctness.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {readFile} from 'node:fs/promises';
 import {parse} from '@loaders.gl/core';

--- a/test/examples/gltf-showcase-identity.node.spec.ts
+++ b/test/examples/gltf-showcase-identity.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {readFileSync} from 'node:fs';
 import path from 'node:path';

--- a/test/examples/renderer-review-correctness.node.spec.ts
+++ b/test/examples/renderer-review-correctness.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {readFileSync} from 'node:fs';
 import path from 'node:path';


### PR DESCRIPTION
## Goals
- Restore the default branch provenance and SPDX checks that currently fail every pull request.
- Preserve accurate independent ownership and NVIDIA RAPIDS cuGraph inspiration notices.

## Changes
- Normalize SPDX copyright headers in 18 existing first-party source and test files.
- Add the required cuGraph inspiration notice to the two recently merged breadth-first-search implementations.
- No runtime behavior or feature implementation changes.

## Verification
- Both existing source-provenance test suites pass: 14 tests.
- git diff --check passes.