### PR TITLE
Document PR review and CI workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,9 @@
 - Format code: `yarn lint fix`
 - Always `yarn lint fix` after making changes to ensure that Biome formatting is maintained.
 
+## Pull requests
+- When opening a PR, wait 15 minutes for review comments, address them and respond, then make sure CI is green.
+
 ## Merge preparation
 - When asked to "get ready for merge", create a copyable Markdown description of the changes versus `master`.
 - Start that Markdown description with `Goals` and `Changes` sections, then include verification, risks, follow-up notes, or other merge-relevant sections when useful.


### PR DESCRIPTION
## What changed

- add a concise pull-request workflow instruction to `AGENTS.md`

## Why

Agents opening pull requests should explicitly wait for review feedback, address and respond to it, and verify that CI is green before handing off.

## Verification

- `git diff --check`
- `yarn lint fix` was attempted, but this isolated documentation worktree has no installed `node_modules` state
