### PR TITLE
feat(effects): add cinematic adaptive HDR bloom

### DIFF
--- a/examples/experimental/bloom/app.ts
+++ b/examples/experimental/bloom/app.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {Device, Framebuffer, TextureFormatColor} from '@luma.gl/core';
+import {Texture, type Device, type Framebuffer, type TextureFormatColor} from '@luma.gl/core';
 import {bloom, createBloomShaderPassPipeline, toneMapping} from '@luma.gl/effects';
 import {
   AnimationLoopTemplate,
@@ -25,13 +25,20 @@ export const title = 'Bloom';
 export const description = 'Compare compact and HDR multiscale bloom on an animated HDR scene.';
 
 const BLOOM_TECHNIQUES = ['Multiscale HDR', 'Compact', 'Off'] as const;
+const BLOOM_QUALITIES = ['low', 'medium', 'high', 'ultra'] as const;
 
 type BloomTechnique = (typeof BLOOM_TECHNIQUES)[number];
+type BloomQuality = (typeof BLOOM_QUALITIES)[number];
 type BloomSettings = {
   technique: BloomTechnique;
+  quality: BloomQuality;
   threshold: number;
   intensity: number;
   radius: number;
+  scatter: number;
+  softKnee: number;
+  fireflyReduction: number;
+  anamorphicRatio: number;
   animate: boolean;
 };
 type SceneUniforms = {
@@ -42,14 +49,20 @@ type ShaderPassLike = ShaderPass | ShaderPassPipeline;
 
 const DEFAULT_SETTINGS: BloomSettings = {
   technique: 'Multiscale HDR',
+  quality: 'high',
   threshold: 0.8,
   intensity: 1.35,
   radius: 12,
+  scatter: 0.55,
+  softKnee: 0.5,
+  fireflyReduction: 0.15,
+  anamorphicRatio: 0,
   animate: true
 };
 
 const BLOOM_BACKGROUND_HTML = `
-<p><b>Multiscale HDR bloom:</b> bright scene radiance is extracted once, blurred across half, quarter, and eighth-resolution targets, then composited before presentation. This is the reusable pipeline intended for richer effects integrations.</p>
+<p><b>Multiscale HDR bloom:</b> bright scene radiance is extracted once, filtered across an adaptive two-to-five-level pyramid, then progressively reconstructed before presentation. Normalized upsampling keeps the glow stable as wider levels are combined.</p>
+<p><b>Cinematic controls:</b> scatter balances tight highlights against broad glow, a soft knee smooths threshold transitions, firefly reduction stabilizes isolated HDR samples, and anamorphic ratio stretches the bloom horizontally or vertically.</p>
 <p><b>Compact bloom:</b> the legacy single-pass glow samples one small neighborhood directly from the source image. It is cheaper, but it cannot spread highlights as naturally as the multiscale pyramid.</p>
 <p><b>Scene setup:</b> this page renders animated HDR emitters into an offscreen texture before bloom. The previous static image hid the useful part of the effect by baking most of the lighting into SDR pixels.</p>
 `;
@@ -287,6 +300,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     scene: sceneShaderModule
   });
   readonly sceneModel: ClipSpace;
+  readonly sceneColorTexture: Texture;
   readonly sceneFramebuffer: Framebuffer;
   readonly settingsPanel: ExampleSettingsPanelManager;
   readonly panels: ExamplePanelManager;
@@ -305,11 +319,18 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       colorAttachmentFormats: [this.colorFormat],
       shaderInputs: this.sceneShaderInputs
     });
+    this.sceneColorTexture = device.createTexture({
+      id: 'bloom-hdr-scene-color',
+      width,
+      height,
+      format: this.colorFormat,
+      usage: Texture.RENDER | Texture.SAMPLE
+    });
     this.sceneFramebuffer = device.createFramebuffer({
       id: 'bloom-hdr-scene-framebuffer',
       width,
       height,
-      colorAttachments: [this.colorFormat]
+      colorAttachments: [this.sceneColorTexture]
     });
     this.settingsPanel = new ExampleSettingsPanelManager({
       id: 'bloom-settings',
@@ -326,6 +347,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.settingsPanel.finalize();
     this.panels.finalize();
     this.sceneFramebuffer.destroy();
+    this.sceneColorTexture.destroy();
     this.sceneModel.destroy();
     this.sceneShaderInputs.destroy();
     this.shaderPassRenderer?.destroy();
@@ -372,7 +394,12 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           colorFormat: this.colorFormat,
           threshold: this.settings.threshold,
           intensity: this.settings.intensity,
-          radius: this.settings.radius
+          radius: this.settings.radius,
+          quality: this.settings.quality,
+          scatter: this.settings.scatter,
+          softKnee: this.settings.softKnee,
+          fireflyReduction: this.settings.fireflyReduction,
+          anamorphicRatio: this.settings.anamorphicRatio
         })
       );
     } else if (this.settings.technique === 'Compact') {
@@ -423,6 +450,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       technique: isBloomTechnique(settings['technique'])
         ? settings['technique']
         : this.settings.technique,
+      quality: isBloomQuality(settings['quality']) ? settings['quality'] : this.settings.quality,
       threshold:
         typeof settings['threshold'] === 'number'
           ? clampNumber(settings['threshold'], 0, 4)
@@ -435,6 +463,22 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         typeof settings['radius'] === 'number'
           ? clampNumber(settings['radius'], 0, 24)
           : this.settings.radius,
+      scatter:
+        typeof settings['scatter'] === 'number'
+          ? clampNumber(settings['scatter'], 0, 1)
+          : this.settings.scatter,
+      softKnee:
+        typeof settings['softKnee'] === 'number'
+          ? clampNumber(settings['softKnee'], 0, 1)
+          : this.settings.softKnee,
+      fireflyReduction:
+        typeof settings['fireflyReduction'] === 'number'
+          ? clampNumber(settings['fireflyReduction'], 0, 1)
+          : this.settings.fireflyReduction,
+      anamorphicRatio:
+        typeof settings['anamorphicRatio'] === 'number'
+          ? clampNumber(settings['anamorphicRatio'], -1, 1)
+          : this.settings.anamorphicRatio,
       animate:
         typeof settings['animate'] === 'boolean' ? settings['animate'] : this.settings.animate
     };
@@ -510,6 +554,18 @@ export function makeBloomSettingsSchema(): SettingsSchema {
             step: 0.05
           },
           {
+            name: 'quality',
+            label: 'Pyramid Quality',
+            type: 'select',
+            persist: 'none',
+            options: [
+              {label: 'Low (2 levels)', value: 'low'},
+              {label: 'Medium (3 levels)', value: 'medium'},
+              {label: 'High (4 levels)', value: 'high'},
+              {label: 'Ultra (5 levels)', value: 'ultra'}
+            ]
+          },
+          {
             name: 'intensity',
             label: 'Glow Intensity',
             type: 'number',
@@ -526,6 +582,42 @@ export function makeBloomSettingsSchema(): SettingsSchema {
             min: 0,
             max: 24,
             step: 1
+          },
+          {
+            name: 'scatter',
+            label: 'Wide Glow Scatter',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1,
+            step: 0.05
+          },
+          {
+            name: 'softKnee',
+            label: 'Threshold Soft Knee',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1,
+            step: 0.05
+          },
+          {
+            name: 'fireflyReduction',
+            label: 'Firefly Reduction',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1,
+            step: 0.05
+          },
+          {
+            name: 'anamorphicRatio',
+            label: 'Anamorphic Stretch',
+            type: 'number',
+            persist: 'none',
+            min: -1,
+            max: 1,
+            step: 0.05
           },
           {
             name: 'animate',
@@ -545,6 +637,10 @@ function makeBloomSettingsState(settings: BloomSettings): SettingsState {
 
 function isBloomTechnique(value: unknown): value is BloomTechnique {
   return BLOOM_TECHNIQUES.includes(value as BloomTechnique);
+}
+
+function isBloomQuality(value: unknown): value is BloomQuality {
+  return BLOOM_QUALITIES.includes(value as BloomQuality);
 }
 
 function clampNumber(value: number, minimum: number, maximum: number): number {

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -1119,22 +1119,22 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       workgroupSize: 1
     });
     for (const chunk of handles.spanChunks) {
-    addTraceIndirectComputePass(graph, {
+      addTraceIndirectComputePass(graph, {
         id: `trace-candidate-span-visibility-${chunk.chunkIndex}`,
         source: getCandidateVisibilityShader(chunk),
-      bindings: [
+        bindings: [
           storageRead('spans', chunk.spans),
-        storageRead('spanBatches', handles.spanBatchIndex),
-        storageRead('candidateBatchIds', handles.candidateBatchIds),
-        uniformBinding('viewUniforms', handles.uniforms),
-        storageRead('processStates', handles.processStates),
-        storageRead('threadOffsets', handles.threadOffsets),
-        storageRead('threadStates', handles.threadStates),
-        storageRead('reachedSpans', handles.reachedSpans),
-        storageWrite('visibilityFlags', handles.spanVisibility)
-      ],
-      dispatchBuffer: handles.exactCandidateDispatchCommands
-    });
+          storageRead('spanBatches', handles.spanBatchIndex),
+          storageRead('candidateBatchIds', handles.candidateBatchIds),
+          uniformBinding('viewUniforms', handles.uniforms),
+          storageRead('processStates', handles.processStates),
+          storageRead('threadOffsets', handles.threadOffsets),
+          storageRead('threadStates', handles.threadStates),
+          storageRead('reachedSpans', handles.reachedSpans),
+          storageWrite('visibilityFlags', handles.spanVisibility)
+        ],
+        dispatchBuffer: handles.exactCandidateDispatchCommands
+      });
     }
     addTraceComputePass(graph, {
       id: 'trace-clear-density',
@@ -1144,37 +1144,37 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       workgroupSize: TRACE_WORKGROUP_SIZE
     });
     for (const chunk of handles.spanChunks) {
-    addTraceIndirectComputePass(graph, {
+      addTraceIndirectComputePass(graph, {
         id: `trace-candidate-density-${chunk.chunkIndex}`,
         source: getCandidateDensityShader(chunk),
-      bindings: [
+        bindings: [
           storageRead('spans', chunk.spans),
-        storageRead('spanBatches', handles.spanBatchIndex),
-        storageRead('candidateBatchIds', handles.candidateBatchIds),
-        uniformBinding('viewUniforms', handles.uniforms),
-        storageRead('processStates', handles.processStates),
-        storageRead('threadOffsets', handles.threadOffsets),
-        storageRead('threadStates', handles.threadStates),
-        storageRead('reachedSpans', handles.reachedSpans),
-        storageWrite('densityBins', handles.densityBins)
-      ],
-      dispatchBuffer: handles.densityCandidateDispatchCommands
-    });
-    addTraceIndirectComputePass(graph, {
+          storageRead('spanBatches', handles.spanBatchIndex),
+          storageRead('candidateBatchIds', handles.candidateBatchIds),
+          uniformBinding('viewUniforms', handles.uniforms),
+          storageRead('processStates', handles.processStates),
+          storageRead('threadOffsets', handles.threadOffsets),
+          storageRead('threadStates', handles.threadStates),
+          storageRead('reachedSpans', handles.reachedSpans),
+          storageWrite('densityBins', handles.densityBins)
+        ],
+        dispatchBuffer: handles.densityCandidateDispatchCommands
+      });
+      addTraceIndirectComputePass(graph, {
         id: `trace-candidate-pick-${chunk.chunkIndex}`,
         source: getCandidatePickShader(chunk),
-      bindings: [
+        bindings: [
           storageRead('spans', chunk.spans),
-        storageRead('spanBatches', handles.spanBatchIndex),
-        storageRead('candidateBatchIds', handles.candidateBatchIds),
-        uniformBinding('viewUniforms', handles.uniforms),
-        storageRead('processStates', handles.processStates),
-        storageRead('threadOffsets', handles.threadOffsets),
-        storageRead('threadStates', handles.threadStates),
-        storageWrite('pickResult', handles.pickResult)
-      ],
-      dispatchBuffer: handles.pickCandidateDispatchCommands
-    });
+          storageRead('spanBatches', handles.spanBatchIndex),
+          storageRead('candidateBatchIds', handles.candidateBatchIds),
+          uniformBinding('viewUniforms', handles.uniforms),
+          storageRead('processStates', handles.processStates),
+          storageRead('threadOffsets', handles.threadOffsets),
+          storageRead('threadStates', handles.threadStates),
+          storageWrite('pickResult', handles.pickResult)
+        ],
+        dispatchBuffer: handles.pickCandidateDispatchCommands
+      });
     }
     const visibleSpanCountBuffer = graph.createTransientBuffer({
       id: 'trace-visible-span-count',
@@ -1357,18 +1357,18 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     }
 
     if (resources.dependencyCount > 0) {
-    encoder.setPipeline(this.dependencyModel.pipeline);
-    encoder.setVertexArray(this.dependencyModel.vertexArray);
-    encoder.setBindings({
-      dependencies: resources.dependencies,
-      visibleDependencyIds: resources.visibleDependencyIds,
+      encoder.setPipeline(this.dependencyModel.pipeline);
+      encoder.setVertexArray(this.dependencyModel.vertexArray);
+      encoder.setBindings({
+        dependencies: resources.dependencies,
+        visibleDependencyIds: resources.visibleDependencyIds,
         spans: resources.spanChunks[0].buffer,
-      processStates: resources.processStates,
-      threadStates: resources.threadStates,
-      threadOffsets: resources.threadOffsets,
-      dependencyResults: resources.dependencyResults,
-      viewUniforms: this.viewUniformBuffer
-    });
+        processStates: resources.processStates,
+        threadStates: resources.threadStates,
+        threadOffsets: resources.threadOffsets,
+        dependencyResults: resources.dependencyResults,
+        viewUniforms: this.viewUniformBuffer
+      });
       resources.drawCommands.draw(encoder, resources.dependencyDrawCommandIndex);
     }
 

--- a/modules/effects/README.md
+++ b/modules/effects/README.md
@@ -37,15 +37,31 @@ deferred lighting, higher-quality ambient visibility, diffuse bounce, specular r
 participating-media scattering. Shared effects such as SSR use the same exported implementation
 in both scenes.
 
+`createBloomShaderPassPipeline` builds an HDR bloom pyramid with quality presets from two to five
+levels. The pyramid progressively reconstructs its levels with normalized tent filtering; `scatter`,
+`softKnee`, `fireflyReduction`, `anamorphicRatio`, and `tint` control the resulting glow without
+requiring application-owned intermediate textures. The source texture must allow both sampling and,
+when it is produced by an offscreen scene pass, rendering.
+
 `toneMapping` applies an ACES filmic curve after exposure and preserves the source alpha channel.
 Place it after bloom or other HDR effects so bright highlights roll off before presentation:
 
 ```typescript
 import {ShaderPassRenderer} from '@luma.gl/engine';
-import {bloomShaderPassPipeline, toneMapping} from '@luma.gl/effects';
+import {createBloomShaderPassPipeline, toneMapping} from '@luma.gl/effects';
 
 const renderer = new ShaderPassRenderer(device, {
-  shaderPasses: [bloomShaderPassPipeline, toneMapping]
+  shaderPasses: [
+    createBloomShaderPassPipeline({
+      quality: 'high',
+      threshold: 0.8,
+      intensity: 1.25,
+      scatter: 0.55,
+      softKnee: 0.5,
+      fireflyReduction: 0.15
+    }),
+    toneMapping
+  ]
 });
 
 renderer.renderToScreen({

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
@@ -13,6 +13,14 @@ import type {BloomProps, BloomUniforms} from './bloom';
 
 const MAX_BLOOM_BLUR_RADIUS = 24;
 const BLOOM_TARGET_SAMPLER = {minFilter: 'linear', magFilter: 'linear'} as const;
+const BLOOM_QUALITY_LEVELS = {low: 2, medium: 3, high: 4, ultra: 5} as const;
+const BLOOM_PYRAMID_LEVELS = [
+  {name: 'Half', scale: 0.5},
+  {name: 'Quarter', scale: 0.25},
+  {name: 'Eighth', scale: 0.125},
+  {name: 'Sixteenth', scale: 0.0625},
+  {name: 'ThirtySecond', scale: 0.03125}
+] as const;
 
 type BloomTargetName =
   | 'extractHalf'
@@ -27,9 +35,21 @@ type BloomTargetName =
 
 /** Construction options for HDR-capable multiscale bloom. */
 export type BloomShaderPassPipelineOptions = BloomProps & {
+  /** Controls the number of bloom pyramid levels: low=2, medium=3, high=4, ultra=5. */
+  quality?: keyof typeof BLOOM_QUALITY_LEVELS;
+  /** Normalized contribution from progressively wider bloom levels. Defaults to 0.55. */
+  scatter?: number;
+  /** Width of the soft highlight threshold relative to the threshold. Defaults to 0.5. */
+  softKnee?: number;
+  /** Luminance-weighted suppression of isolated bright samples. Defaults to 0. */
+  fireflyReduction?: number;
+  /** Negative values stretch vertically; positive values stretch horizontally. */
+  anamorphicRatio?: number;
+  /** RGB multiplier applied to the reconstructed bloom before composition. */
+  tint?: [number, number, number];
   /**
-   * Positive fractional size multiplier applied to the half, quarter, and eighth-resolution
-   * pyramid. The extraction filter adapts its source footprint to the resulting target size.
+   * Positive fractional size multiplier applied to every pyramid level. The extraction filter
+   * adapts its source footprint to the resulting target size.
    */
   resolutionScale?: number;
   /** Filterable color intermediate format. Defaults to rgba16float for HDR highlight energy. */
@@ -41,13 +61,15 @@ const bloomExtractPass = {
   source: /* wgsl */ `
 struct bloomExtractUniforms {
   threshold: f32,
+  softKnee: f32,
+  fireflyReduction: f32,
 };
 
 @group(0) @binding(auto) var<uniform> bloomExtract: bloomExtractUniforms;
 
 fn bloomExtract_applyThreshold(sourceColor: vec4f) -> vec4f {
   let luminance = dot(sourceColor.rgb, vec3f(0.2126, 0.7152, 0.0722));
-  let knee = max(bloomExtract.threshold * 0.5, 0.00001);
+  let knee = max(bloomExtract.threshold * bloomExtract.softKnee, 0.00001);
   let soft = clamp((luminance - bloomExtract.threshold + knee) / (2.0 * knee), 0.0, 1.0);
   let softContribution = soft * soft * knee;
   let hardContribution = max(luminance - bloomExtract.threshold, 0.0);
@@ -84,11 +106,17 @@ fn bloomExtract_sampleColor(
     let weightY = max(1.0 - abs(f32(sourceY) - sourceCenter.y) / filterRadius.y, 0.0);
     for (var sourceX = minimumCoordinate.x; sourceX <= maximumCoordinate.x; sourceX += 1) {
       let weightX = max(1.0 - abs(f32(sourceX) - sourceCenter.x) / filterRadius.x, 0.0);
-      let weight = weightX * weightY;
       let sourceColor = bloomExtract_loadColor(
         sourceTexture,
         vec2i(sourceX, sourceY)
       );
+      let luminance = dot(sourceColor.rgb, vec3f(0.2126, 0.7152, 0.0722));
+      let fireflyWeight = mix(
+        1.0,
+        1.0 / (1.0 + max(luminance, 0.0)),
+        clamp(bloomExtract.fireflyReduction, 0.0, 1.0)
+      );
+      let weight = weightX * weightY * fireflyWeight;
       color += bloomExtract_applyThreshold(sourceColor) * weight;
       totalWeight += weight;
     }
@@ -100,11 +128,13 @@ fn bloomExtract_sampleColor(
   fs: /* glsl */ `
 layout(std140) uniform bloomExtractUniforms {
   float threshold;
+  float softKnee;
+  float fireflyReduction;
 } bloomExtract;
 
 vec4 bloomExtract_applyThreshold(vec4 sourceColor) {
   float luminance = dot(sourceColor.rgb, vec3(0.2126, 0.7152, 0.0722));
-  float knee = max(bloomExtract.threshold * 0.5, 0.00001);
+  float knee = max(bloomExtract.threshold * bloomExtract.softKnee, 0.00001);
   float soft = clamp((luminance - bloomExtract.threshold + knee) / (2.0 * knee), 0.0, 1.0);
   float softContribution = soft * soft * knee;
   float hardContribution = max(luminance - bloomExtract.threshold, 0.0);
@@ -135,11 +165,17 @@ vec4 bloomExtract_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoo
     float weightY = max(1.0 - abs(float(sourceY) - sourceCenter.y) / filterRadius.y, 0.0);
     for (int sourceX = minimumCoordinate.x; sourceX <= maximumCoordinate.x; sourceX++) {
       float weightX = max(1.0 - abs(float(sourceX) - sourceCenter.x) / filterRadius.x, 0.0);
-      float weight = weightX * weightY;
       vec4 sourceColor = bloomExtract_loadColor(
         sourceTexture,
         ivec2(sourceX, sourceY)
       );
+      float luminance = dot(sourceColor.rgb, vec3(0.2126, 0.7152, 0.0722));
+      float fireflyWeight = mix(
+        1.0,
+        1.0 / (1.0 + max(luminance, 0.0)),
+        clamp(bloomExtract.fireflyReduction, 0.0, 1.0)
+      );
+      float weight = weightX * weightY * fireflyWeight;
       color += bloomExtract_applyThreshold(sourceColor) * weight;
       totalWeight += weight;
     }
@@ -149,13 +185,25 @@ vec4 bloomExtract_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoo
 }
 `,
   uniformTypes: {
-    threshold: 'f32'
+    threshold: 'f32',
+    softKnee: 'f32',
+    fireflyReduction: 'f32'
+  },
+  defaultUniforms: {
+    threshold: 0.8,
+    softKnee: 0.5,
+    fireflyReduction: 0
   },
   propTypes: {
-    threshold: {value: 0.8, min: 0, max: 1}
+    threshold: {value: 0.8, min: 0, max: 1},
+    softKnee: {value: 0.5, min: 0, max: 1},
+    fireflyReduction: {value: 0, min: 0, max: 1}
   },
   passes: [{sampler: true}]
-} as const satisfies ShaderPass<Pick<BloomProps, 'threshold'>, Pick<BloomUniforms, 'threshold'>>;
+} as const satisfies ShaderPass<
+  Pick<BloomShaderPassPipelineOptions, 'threshold' | 'softKnee' | 'fireflyReduction'>,
+  Pick<BloomUniforms, 'threshold'> & {softKnee?: number; fireflyReduction?: number}
+>;
 
 const bloomDownsamplePass = {
   name: 'bloomDownsample',
@@ -397,6 +445,99 @@ vec4 bloomBlur_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoord)
   Pick<BloomUniforms, 'radius'> & {delta?: [number, number]}
 >;
 
+type BloomUpsampleBindings = {
+  higherResolutionGlow?: Texture;
+};
+
+const bloomUpsamplePass = {
+  name: 'bloomUpsample',
+  source: /* wgsl */ `
+struct bloomUpsampleUniforms {
+  scatter: f32,
+};
+
+@group(0) @binding(auto) var<uniform> bloomUpsample: bloomUpsampleUniforms;
+@group(0) @binding(auto) var higherResolutionGlow: texture_2d<f32>;
+@group(0) @binding(auto) var higherResolutionGlowSampler: sampler;
+
+fn bloomUpsample_sampleLowerGlow(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texCoord: vec2f
+) -> vec4f {
+  let texel = 1.0 / vec2f(textureDimensions(sourceTexture));
+  let horizontalOffset = vec2f(texel.x, 0.0);
+  let verticalOffset = vec2f(0.0, texel.y);
+  let center = textureSample(sourceTexture, sourceTextureSampler, texCoord) * 4.0;
+  let edges = (
+    textureSample(sourceTexture, sourceTextureSampler, texCoord - horizontalOffset) +
+    textureSample(sourceTexture, sourceTextureSampler, texCoord + horizontalOffset) +
+    textureSample(sourceTexture, sourceTextureSampler, texCoord - verticalOffset) +
+    textureSample(sourceTexture, sourceTextureSampler, texCoord + verticalOffset)
+  ) * 2.0;
+  let corners =
+    textureSample(sourceTexture, sourceTextureSampler, texCoord - horizontalOffset - verticalOffset) +
+    textureSample(sourceTexture, sourceTextureSampler, texCoord + horizontalOffset - verticalOffset) +
+    textureSample(sourceTexture, sourceTextureSampler, texCoord - horizontalOffset + verticalOffset) +
+    textureSample(sourceTexture, sourceTextureSampler, texCoord + horizontalOffset + verticalOffset);
+  return (center + edges + corners) / 16.0;
+}
+
+fn bloomUpsample_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let lowerGlow = bloomUpsample_sampleLowerGlow(sourceTexture, sourceTextureSampler, texCoord);
+  let higherGlow = textureSample(higherResolutionGlow, higherResolutionGlowSampler, texCoord);
+  return mix(higherGlow, lowerGlow, clamp(bloomUpsample.scatter, 0.0, 1.0));
+}
+`,
+  fs: /* glsl */ `
+layout(std140) uniform bloomUpsampleUniforms {
+  float scatter;
+} bloomUpsample;
+
+uniform sampler2D higherResolutionGlow;
+
+vec4 bloomUpsample_sampleLowerGlow(sampler2D sourceTexture, vec2 texCoord) {
+  vec2 texel = 1.0 / vec2(textureSize(sourceTexture, 0));
+  vec2 horizontalOffset = vec2(texel.x, 0.0);
+  vec2 verticalOffset = vec2(0.0, texel.y);
+  vec4 center = texture(sourceTexture, texCoord) * 4.0;
+  vec4 edges = (
+    texture(sourceTexture, texCoord - horizontalOffset) +
+    texture(sourceTexture, texCoord + horizontalOffset) +
+    texture(sourceTexture, texCoord - verticalOffset) +
+    texture(sourceTexture, texCoord + verticalOffset)
+  ) * 2.0;
+  vec4 corners =
+    texture(sourceTexture, texCoord - horizontalOffset - verticalOffset) +
+    texture(sourceTexture, texCoord + horizontalOffset - verticalOffset) +
+    texture(sourceTexture, texCoord - horizontalOffset + verticalOffset) +
+    texture(sourceTexture, texCoord + horizontalOffset + verticalOffset);
+  return (center + edges + corners) / 16.0;
+}
+
+vec4 bloomUpsample_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoord) {
+  vec4 lowerGlow = bloomUpsample_sampleLowerGlow(sourceTexture, texCoord);
+  vec4 higherGlow = texture(higherResolutionGlow, texCoord);
+  return mix(higherGlow, lowerGlow, clamp(bloomUpsample.scatter, 0.0, 1.0));
+}
+`,
+  bindingLayout: [{name: 'higherResolutionGlow', group: 0}],
+  uniforms: {} as {scatter?: number},
+  bindings: {} as BloomUpsampleBindings,
+  uniformTypes: {scatter: 'f32'},
+  propTypes: {scatter: {value: 0.55, min: 0, max: 1}},
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  {scatter?: number} & BloomUpsampleBindings,
+  {scatter?: number},
+  BloomUpsampleBindings
+>;
+
 type BloomCompositeBindings = {
   glowHalf?: Texture;
   glowQuarter?: Texture;
@@ -468,6 +609,76 @@ vec4 bloomComposite_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texC
   Pick<BloomProps, 'intensity'> & BloomCompositeBindings,
   Pick<BloomUniforms, 'intensity'>,
   BloomCompositeBindings
+>;
+
+type BloomAdaptiveCompositeBindings = {
+  glowTexture?: Texture;
+};
+
+type BloomAdaptiveCompositeUniforms = {
+  tint?: [number, number, number];
+  intensity?: number;
+};
+
+const bloomAdaptiveCompositePass = {
+  name: 'bloomComposite',
+  source: /* wgsl */ `
+struct bloomCompositeUniforms {
+  tint: vec3f,
+  intensity: f32,
+};
+
+@group(0) @binding(auto) var<uniform> bloomComposite: bloomCompositeUniforms;
+@group(0) @binding(auto) var glowTexture: texture_2d<f32>;
+@group(0) @binding(auto) var glowTextureSampler: sampler;
+
+fn bloomComposite_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let sourceColor = textureSample(sourceTexture, sourceTextureSampler, texCoord);
+  let glowColor = textureSample(glowTexture, glowTextureSampler, texCoord).rgb;
+  let tintedGlow = glowColor * bloomComposite.tint * bloomComposite.intensity;
+  return vec4f(sourceColor.rgb + tintedGlow, sourceColor.a);
+}
+`,
+  fs: /* glsl */ `
+layout(std140) uniform bloomCompositeUniforms {
+  vec3 tint;
+  float intensity;
+} bloomComposite;
+
+uniform sampler2D glowTexture;
+
+vec4 bloomComposite_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoord) {
+  vec4 sourceColor = texture(sourceTexture, texCoord);
+  vec3 glowColor = texture(glowTexture, texCoord).rgb;
+  vec3 tintedGlow = glowColor * bloomComposite.tint * bloomComposite.intensity;
+  return vec4(sourceColor.rgb + tintedGlow, sourceColor.a);
+}
+`,
+  bindingLayout: [{name: 'glowTexture', group: 0}],
+  uniforms: {} as BloomAdaptiveCompositeUniforms,
+  bindings: {} as BloomAdaptiveCompositeBindings,
+  uniformTypes: {
+    tint: 'vec3<f32>',
+    intensity: 'f32'
+  },
+  defaultUniforms: {
+    tint: [1, 1, 1] as [number, number, number],
+    intensity: 1
+  },
+  propTypes: {
+    tint: {value: [1, 1, 1] as [number, number, number]},
+    intensity: {value: 1, min: 0, softMax: 3}
+  },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  BloomAdaptiveCompositeUniforms & BloomAdaptiveCompositeBindings,
+  BloomAdaptiveCompositeUniforms,
+  BloomAdaptiveCompositeBindings
 >;
 
 /**
@@ -558,43 +769,96 @@ export const bloomShaderPassPipeline = {
 /** Creates configurable multiscale bloom that preserves high-dynamic-range radiance. */
 export function createBloomShaderPassPipeline(
   options: BloomShaderPassPipelineOptions = {}
-): ShaderPassPipeline<BloomTargetName> {
+): ShaderPassPipeline {
   const resolutionScale = options.resolutionScale ?? 1;
   const colorFormat = options.colorFormat ?? 'rgba16float';
   const threshold = options.threshold ?? 0.8;
   const radius = options.radius ?? 8;
   const intensity = options.intensity ?? 1;
+  const quality = options.quality ?? 'high';
+  const scatter = options.scatter ?? 0.55;
+  const softKnee = options.softKnee ?? 0.5;
+  const fireflyReduction = options.fireflyReduction ?? 0;
+  const anamorphicRatio = Math.min(Math.max(options.anamorphicRatio ?? 0, -1), 1);
+  const tint = options.tint ?? [1, 1, 1];
+  const horizontalRadius = radius * (1 + Math.max(anamorphicRatio, 0));
+  const verticalRadius = radius * (1 + Math.max(-anamorphicRatio, 0));
+  const levels = BLOOM_PYRAMID_LEVELS.slice(0, BLOOM_QUALITY_LEVELS[quality]);
+  const renderTargets: Record<string, ShaderPassRenderTarget> = {};
+  const steps: ShaderPassPipelineStep[] = [];
   const makeRenderTarget = (scale: number): ShaderPassRenderTarget => ({
     scale: [scale * resolutionScale, scale * resolutionScale],
     format: colorFormat,
     sampler: BLOOM_TARGET_SAMPLER
   });
-  const makeStep = (step: ShaderPassPipelineStep<BloomTargetName>) => {
-    switch (step.shaderPass.name) {
-      case 'bloomExtract':
-        return {...step, uniforms: {...step.uniforms, threshold}};
-      case 'bloomBlur':
-        return {...step, uniforms: {...step.uniforms, radius}};
-      case 'bloomComposite':
-        return {...step, uniforms: {...step.uniforms, intensity}};
-      default:
-        return step;
+
+  for (const [levelIndex, level] of levels.entries()) {
+    const extractionTarget = `extract${level.name}`;
+    const blurScratchTarget = `blur${level.name}Scratch`;
+    const blurTarget = `blur${level.name}`;
+    renderTargets[extractionTarget] = makeRenderTarget(level.scale);
+    renderTargets[blurScratchTarget] = makeRenderTarget(level.scale);
+    renderTargets[blurTarget] = makeRenderTarget(level.scale);
+
+    if (levelIndex === 0) {
+      steps.push({
+        shaderPass: bloomExtractPass,
+        inputs: {sourceTexture: 'previous'},
+        output: extractionTarget,
+        uniforms: {threshold, softKnee, fireflyReduction}
+      });
+    } else {
+      const previousLevel = levels[levelIndex - 1];
+      steps.push({
+        shaderPass: bloomDownsamplePass,
+        inputs: {sourceTexture: `extract${previousLevel.name}`},
+        output: extractionTarget
+      });
     }
-  };
+
+    steps.push(
+      {
+        shaderPass: bloomBlurPass,
+        inputs: {sourceTexture: extractionTarget},
+        output: blurScratchTarget,
+        uniforms: {radius: horizontalRadius, delta: [1, 0]}
+      },
+      {
+        shaderPass: bloomBlurPass,
+        inputs: {sourceTexture: blurScratchTarget},
+        output: blurTarget,
+        uniforms: {radius: verticalRadius, delta: [0, 1]}
+      }
+    );
+  }
+
+  let reconstructedGlow = `blur${levels[levels.length - 1].name}`;
+  for (let levelIndex = levels.length - 2; levelIndex >= 0; levelIndex--) {
+    const level = levels[levelIndex];
+    const upsampleTarget = `upsample${level.name}`;
+    renderTargets[upsampleTarget] = makeRenderTarget(level.scale);
+    steps.push({
+      shaderPass: bloomUpsamplePass,
+      inputs: {
+        sourceTexture: reconstructedGlow,
+        higherResolutionGlow: `blur${level.name}`
+      },
+      output: upsampleTarget,
+      uniforms: {scatter}
+    });
+    reconstructedGlow = upsampleTarget;
+  }
+
+  steps.push({
+    shaderPass: bloomAdaptiveCompositePass,
+    inputs: {sourceTexture: 'previous', glowTexture: reconstructedGlow},
+    output: 'previous',
+    uniforms: {tint, intensity}
+  });
 
   return {
-    ...bloomShaderPassPipeline,
-    renderTargets: {
-      extractHalf: makeRenderTarget(0.5),
-      blurHalfScratch: makeRenderTarget(0.5),
-      blurHalf: makeRenderTarget(0.5),
-      extractQuarter: makeRenderTarget(0.25),
-      blurQuarterScratch: makeRenderTarget(0.25),
-      blurQuarter: makeRenderTarget(0.25),
-      extractEighth: makeRenderTarget(0.125),
-      blurEighthScratch: makeRenderTarget(0.125),
-      blurEighth: makeRenderTarget(0.125)
-    },
-    steps: bloomShaderPassPipeline.steps.map(makeStep)
+    name: bloomShaderPassPipeline.name,
+    renderTargets,
+    steps
   };
 }

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
@@ -781,8 +781,12 @@ export function createBloomShaderPassPipeline(
   const fireflyReduction = options.fireflyReduction ?? 0;
   const anamorphicRatio = Math.min(Math.max(options.anamorphicRatio ?? 0, -1), 1);
   const tint = options.tint ?? [1, 1, 1];
-  const horizontalRadius = radius * (1 + Math.max(anamorphicRatio, 0));
-  const verticalRadius = radius * (1 + Math.max(-anamorphicRatio, 0));
+  const anamorphicRadius = Math.min(
+    radius,
+    MAX_BLOOM_BLUR_RADIUS / (1 + Math.abs(anamorphicRatio))
+  );
+  const horizontalRadius = anamorphicRadius * (1 + Math.max(anamorphicRatio, 0));
+  const verticalRadius = anamorphicRadius * (1 + Math.max(-anamorphicRatio, 0));
   const levels = BLOOM_PYRAMID_LEVELS.slice(0, BLOOM_QUALITY_LEVELS[quality]);
   const renderTargets: Record<string, ShaderPassRenderTarget> = {};
   const steps: ShaderPassPipelineStep[] = [];

--- a/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
+++ b/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
@@ -284,6 +284,32 @@ test('createBloomShaderPassPipeline#adaptive pyramid reconstruction', testCase =
   testCase.end();
 });
 
+test('createBloomShaderPassPipeline#anamorphic radii stay within the shader kernel', testCase => {
+  const anamorphicCases = [
+    {radius: 12, anamorphicRatio: 1, horizontalRadius: 24, verticalRadius: 12},
+    {radius: 18, anamorphicRatio: 0.5, horizontalRadius: 24, verticalRadius: 16},
+    {radius: 18, anamorphicRatio: -0.5, horizontalRadius: 16, verticalRadius: 24},
+    {radius: 24, anamorphicRatio: 1, horizontalRadius: 24, verticalRadius: 12},
+    {radius: 24, anamorphicRatio: -1, horizontalRadius: 12, verticalRadius: 24},
+    {radius: 24, anamorphicRatio: 0, horizontalRadius: 24, verticalRadius: 24}
+  ];
+
+  for (const {radius, anamorphicRatio, horizontalRadius, verticalRadius} of anamorphicCases) {
+    const pipeline = createBloomShaderPassPipeline({radius, anamorphicRatio});
+    const blurSteps = pipeline.steps.filter(step => step.shaderPass.name === 'bloomBlur');
+
+    testCase.deepEqual(
+      blurSteps.map(step => step.uniforms?.radius),
+      Array.from({length: blurSteps.length}, (_, stepIndex) =>
+        stepIndex % 2 === 0 ? horizontalRadius : verticalRadius
+      ),
+      `radius ${radius} preserves anamorphic ratio ${anamorphicRatio} within every shader kernel`
+    );
+  }
+
+  testCase.end();
+});
+
 test('HDR bloom covers source texels at quarter pyramid resolution', async testCase => {
   const device = await getWebGPUTestDevice();
   if (!device) {

--- a/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
+++ b/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
@@ -156,6 +156,134 @@ test('bloomShaderPassPipeline#routing', t => {
   t.end();
 });
 
+test('createBloomShaderPassPipeline#adaptive pyramid reconstruction', testCase => {
+  const qualityLevels = [
+    {quality: 'low', levelCount: 2, coarsestLevel: 'Quarter'},
+    {quality: 'medium', levelCount: 3, coarsestLevel: 'Eighth'},
+    {quality: 'high', levelCount: 4, coarsestLevel: 'Sixteenth'},
+    {quality: 'ultra', levelCount: 5, coarsestLevel: 'ThirtySecond'}
+  ] as const;
+
+  for (const {quality, levelCount, coarsestLevel} of qualityLevels) {
+    const pipeline = createBloomShaderPassPipeline({quality});
+    const extractionSteps = pipeline.steps.filter(step => step.shaderPass.name === 'bloomExtract');
+    const downsampleSteps = pipeline.steps.filter(
+      step => step.shaderPass.name === 'bloomDownsample'
+    );
+    const blurSteps = pipeline.steps.filter(step => step.shaderPass.name === 'bloomBlur');
+    const upsampleSteps = pipeline.steps.filter(step => step.shaderPass.name === 'bloomUpsample');
+    const compositeStep = pipeline.steps.find(step => step.shaderPass.name === 'bloomComposite');
+
+    testCase.equal(extractionSteps.length, 1, `${quality} quality thresholds highlights once`);
+    testCase.equal(
+      downsampleSteps.length,
+      levelCount - 1,
+      `${quality} quality builds ${levelCount} successive pyramid levels`
+    );
+    testCase.equal(
+      blurSteps.length,
+      levelCount * 2,
+      `${quality} quality uses separable blur at every pyramid level`
+    );
+    testCase.equal(
+      upsampleSteps.length,
+      levelCount - 1,
+      `${quality} quality progressively reconstructs the complete pyramid`
+    );
+    testCase.equal(
+      Object.keys(pipeline.renderTargets || {}).length,
+      levelCount * 4 - 1,
+      `${quality} quality allocates only its required pyramid and reconstruction targets`
+    );
+    testCase.equal(
+      upsampleSteps[0]?.inputs?.sourceTexture,
+      `blur${coarsestLevel}`,
+      `${quality} reconstruction starts at its coarsest blurred level`
+    );
+    testCase.equal(
+      upsampleSteps[upsampleSteps.length - 1]?.output,
+      'upsampleHalf',
+      `${quality} reconstruction finishes at half resolution`
+    );
+    testCase.equal(
+      compositeStep?.inputs?.glowTexture,
+      'upsampleHalf',
+      `${quality} composition consumes one normalized reconstructed glow texture`
+    );
+  }
+
+  const pipeline = createBloomShaderPassPipeline({
+    quality: 'ultra',
+    radius: 10,
+    scatter: 0.7,
+    softKnee: 0.35,
+    fireflyReduction: 0.4,
+    anamorphicRatio: 0.5,
+    tint: [0.8, 1, 0.65]
+  });
+  const extractionStep = pipeline.steps.find(step => step.shaderPass.name === 'bloomExtract');
+  const blurSteps = pipeline.steps.filter(step => step.shaderPass.name === 'bloomBlur');
+  const upsampleSteps = pipeline.steps.filter(step => step.shaderPass.name === 'bloomUpsample');
+  const compositeStep = pipeline.steps.find(step => step.shaderPass.name === 'bloomComposite');
+
+  testCase.equal(extractionStep?.uniforms?.softKnee, 0.35, 'configures the soft highlight knee');
+  testCase.equal(
+    extractionStep?.uniforms?.fireflyReduction,
+    0.4,
+    'configures luminance-weighted firefly suppression'
+  );
+  testCase.equal(blurSteps[0]?.uniforms?.radius, 15, 'positive anamorphism widens horizontal blur');
+  testCase.equal(
+    blurSteps[1]?.uniforms?.radius,
+    10,
+    'positive anamorphism preserves vertical blur'
+  );
+  testCase.ok(
+    upsampleSteps.every(step => step.uniforms?.scatter === 0.7),
+    'applies the same normalized scatter to every reconstruction level'
+  );
+  testCase.deepEqual(compositeStep?.uniforms?.tint, [0.8, 1, 0.65], 'applies the requested tint');
+  testCase.deepEqual(
+    pipeline.renderTargets?.extractThirtySecond.scale,
+    [0.03125, 0.03125],
+    'ultra quality reaches the thirty-second-resolution pyramid level'
+  );
+
+  const upsamplePass = upsampleSteps[0]?.shaderPass;
+  testCase.match(
+    upsamplePass?.source || '',
+    /\(center \+ edges \+ corners\) \/ 16\.0/,
+    'WGSL reconstruction normalizes its nine-tap tent filter'
+  );
+  testCase.match(
+    upsamplePass?.fs || '',
+    /\(center \+ edges \+ corners\) \/ 16\.0/,
+    'GLSL reconstruction uses the matching normalized tent filter'
+  );
+  testCase.match(
+    upsamplePass?.source || '',
+    /mix\(higherGlow, lowerGlow, clamp\(bloomUpsample\.scatter, 0\.0, 1\.0\)\)/,
+    'WGSL mixes pyramid levels without duplicating highlight energy'
+  );
+  testCase.match(
+    upsamplePass?.fs || '',
+    /mix\(higherGlow, lowerGlow, clamp\(bloomUpsample\.scatter, 0\.0, 1\.0\)\)/,
+    'GLSL mixes pyramid levels without duplicating highlight energy'
+  );
+
+  const verticalPipeline = createBloomShaderPassPipeline({radius: 10, anamorphicRatio: -0.5});
+  const verticalBlurSteps = verticalPipeline.steps.filter(
+    step => step.shaderPass.name === 'bloomBlur'
+  );
+  testCase.equal(
+    verticalBlurSteps[0]?.uniforms?.radius,
+    10,
+    'negative anamorphism preserves width'
+  );
+  testCase.equal(verticalBlurSteps[1]?.uniforms?.radius, 15, 'negative anamorphism widens height');
+  testCase.end();
+});
+
 test('HDR bloom covers source texels at quarter pyramid resolution', async testCase => {
   const device = await getWebGPUTestDevice();
   if (!device) {
@@ -402,6 +530,121 @@ test('HDR bloom preserves radiance with symmetric, energy-bounded falloff', asyn
         readbackBuffer.destroy();
       }
     }
+  } finally {
+    renderer.destroy();
+    sourceTexture.destroy();
+  }
+
+  testCase.end();
+});
+
+test('HDR bloom suppresses fireflies and applies its cinematic tint', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU unavailable, skipping cinematic bloom image regression');
+    testCase.end();
+    return;
+  }
+
+  const capabilities = device.getTextureFormatCapabilities('rgba16float');
+  if (!capabilities.render || !capabilities.filter) {
+    testCase.comment('Renderable, filterable rgba16float textures are unavailable');
+    testCase.end();
+    return;
+  }
+
+  const width = 32;
+  const height = 32;
+  const highlightX = 16;
+  const highlightY = 16;
+  const sourcePixels = new Uint16Array(width * height * 4);
+  for (let pixelIndex = 0; pixelIndex < width * height; pixelIndex++) {
+    sourcePixels[pixelIndex * 4 + 3] = toHalfFloat(1);
+  }
+  sourcePixels.set(
+    [toHalfFloat(32), toHalfFloat(32), toHalfFloat(32), toHalfFloat(1)],
+    (highlightY * width + highlightX) * 4
+  );
+
+  const sourceTexture = device.createTexture({
+    id: 'cinematic-bloom-firefly-source',
+    data: sourcePixels,
+    format: 'rgba16float',
+    width,
+    height,
+    usage: Texture.SAMPLE | Texture.COPY_DST
+  });
+  const renderer = new ShaderPassRenderer(device, {
+    shaderPasses: [
+      createBloomShaderPassPipeline({
+        quality: 'medium',
+        radius: 5,
+        scatter: 0.4,
+        tint: [1, 0.5, 0.25]
+      })
+    ],
+    colorFormat: 'rgba16float',
+    flipY: false
+  });
+  renderer.resize([width, height]);
+
+  const readGlow = async (fireflyReduction: number): Promise<[number, number, number]> => {
+    const outputTexture = renderer.renderToTexture({
+      sourceTexture,
+      uniforms: {
+        bloomExtract: {threshold: 0.5, fireflyReduction},
+        bloomComposite: {intensity: 1}
+      }
+    });
+    device.submit();
+
+    testCase.ok(
+      outputTexture,
+      `cinematic bloom renders with firefly reduction ${fireflyReduction}`
+    );
+    if (!outputTexture) {
+      return [0, 0, 0];
+    }
+
+    const memoryLayout = outputTexture.computeMemoryLayout({width, height});
+    const readbackBuffer = device.createBuffer({
+      id: `cinematic-bloom-firefly-readback-${fireflyReduction}`,
+      byteLength: memoryLayout.byteLength,
+      usage: Buffer.COPY_DST | Buffer.MAP_READ
+    });
+
+    try {
+      outputTexture.readBuffer({width, height}, readbackBuffer);
+      const pixels = await readbackBuffer.readAsync(0, memoryLayout.byteLength);
+      const pixelView = new DataView(pixels.buffer, pixels.byteOffset, pixels.byteLength);
+      const pixelOffset = highlightY * memoryLayout.bytesPerRow + (highlightX + 3) * 8;
+      return [
+        fromHalfFloat(pixelView.getUint16(pixelOffset, true)),
+        fromHalfFloat(pixelView.getUint16(pixelOffset + 2, true)),
+        fromHalfFloat(pixelView.getUint16(pixelOffset + 4, true))
+      ];
+    } finally {
+      readbackBuffer.destroy();
+    }
+  };
+
+  try {
+    const unfilteredGlow = await readGlow(0);
+    const filteredGlow = await readGlow(1);
+
+    testCase.ok(unfilteredGlow[0] > 0, 'an isolated HDR highlight contributes visible bloom');
+    testCase.ok(
+      Math.abs(unfilteredGlow[1] / unfilteredGlow[0] - 0.5) < 0.02,
+      'the green bloom channel respects the configured tint'
+    );
+    testCase.ok(
+      Math.abs(unfilteredGlow[2] / unfilteredGlow[0] - 0.25) < 0.02,
+      'the blue bloom channel respects the configured tint'
+    );
+    testCase.ok(
+      filteredGlow[0] < unfilteredGlow[0] * 0.2,
+      'luminance-weighted extraction suppresses an isolated HDR firefly'
+    );
   } finally {
     renderer.destroy();
     sourceTexture.destroy();


### PR DESCRIPTION
## Goals
- Move reusable luma.gl HDR bloom toward production-quality, deck.gl-friendly post-processing without breaking the existing fixed bloom pipeline.
- Fix the bloom example's WebGPU scene-texture sampling validation failure.

## Changes
- Generate adaptive two-, three-, four-, or five-level HDR bloom pyramids from `low`, `medium`, `high`, and `ultra` quality presets.
- Reconstruct wider levels progressively with matching energy-normalized nine-tap WGSL and GLSL tent filters.
- Expose configurable scatter, soft highlight knee, luminance-weighted firefly suppression, anamorphic stretch, and RGB tint on `createBloomShaderPassPipeline`.
- Preserve the legacy exported three-level `bloomShaderPassPipeline` and existing compact bloom effect.
- Give the animated bloom example a texture with both render and sample usage, expose the new quality/cinematic controls, and document the reusable API.
- Cover every quality level, routing/allocation behavior, normalized reconstruction, anisotropic radii, HDR energy preservation, firefly suppression, and tinted pixel output.

## Verification
- `yarn lint fix`
- `yarn build`
- `PLAYWRIGHT_BROWSERS_PATH=/Users/ib/.cache/ms-playwright yarn test-headless modules/effects/test/passes/image-blur-filters/bloom.spec.ts` (6 passing Chromium/WebGPU tests)
- Production website build and broader example type checks are running locally.