### PR TITLE
ci: consolidate smaller CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,53 +153,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  bundle-size:
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Setup Node (with Corepack)
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Enable Corepack / Yarn 4
-        run: |
-          corepack enable
-          corepack prepare yarn@4.13.0 --activate
-          yarn -v
-
-      - name: Cache Yarn Berry artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            ~/.yarn/berry/cache
-            .yarn/install-state.gz
-          key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn4-
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Check bundle-size budgets
-        run: |
-          bundleSizeStatus=0
-          yarn bundle-size --output .bundle-size || bundleSizeStatus=$?
-          cat .bundle-size/report.md >> "$GITHUB_STEP_SUMMARY"
-          exit "$bundleSizeStatus"
-
-      - name: Upload bundle-size report
-        if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
-        with:
-          name: bundle-size-report
-          path: .bundle-size
-          if-no-files-found: error
-          include-hidden-files: true
-
   test:
     needs: browser_coverage
     if: ${{ !cancelled() }}
@@ -245,7 +198,7 @@ jobs:
 
   examples:
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -274,6 +227,22 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Check bundle-size budgets
+        run: |
+          bundleSizeStatus=0
+          yarn bundle-size --output .bundle-size || bundleSizeStatus=$?
+          cat .bundle-size/report.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$bundleSizeStatus"
+
+      - name: Upload bundle-size report
+        if: always()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: bundle-size-report
+          path: .bundle-size
+          if-no-files-found: error
+          include-hidden-files: true
+
       - name: Build packages for example type declarations
         run: |
           yarn build
@@ -288,37 +257,6 @@ jobs:
       - name: Typecheck examples
         run: |
           yarn examples:typecheck
-
-  website:
-    runs-on: ubuntu-22.04
-    timeout-minutes: 15
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Setup Node (with Corepack)
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
-        with:
-          node-version-file: '.nvmrc'
-
-      - name: Enable Corepack / Yarn 4
-        run: |
-          corepack enable
-          corepack prepare yarn@4.13.0 --activate
-          yarn -v
-
-      - name: Cache Yarn Berry artifacts
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: |
-            ~/.yarn/berry/cache
-            .yarn/install-state.gz
-          key: ${{ runner.os }}-yarn4-${{ hashFiles('yarn.lock', '.yarnrc.yml', 'package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn4-
-
-      - name: Install website dependencies
-        run: yarn install --immutable
 
       - name: Synchronize website example assets
         run: node website/scripts/sync-example-assets.mjs


### PR DESCRIPTION
## Summary

- Combine bundle-size budgets and report uploads, package builds, lint, geospatial/example checks, and website builds in the existing `examples` job.
- Reduce CI from five workflow jobs/seven runner allocations to three workflow jobs/five runner allocations while preserving all three browser-coverage shards and the coverage-reporting `test` job.
- Preserve standalone website-example builds, Docusaurus memory settings, generated-documentation validation, and bundle-report uploads on failure; extend the combined job timeout to 30 minutes.

## Verification

- Parsed the workflow as YAML and asserted the browser-coverage and coverage-aggregation jobs are unchanged.
- Verified all bundle-size, package, geospatial, lint, example, and website steps remain present and ordered correctly.
- `git diff origin/master...HEAD --check`
- `node --check scripts/bundle-size.mjs`