### PR TITLE
fix(experimental): normalize recent GPU data-frame SPDX headers

### DIFF
--- a/modules/experimental/src/gpu-primitives/gpu-batch-hash-index.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-batch-hash-index.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {GraphVectorView, type GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
 import {

--- a/modules/experimental/src/ludf/index.ts
+++ b/modules/experimental/src/ludf/index.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 export {LuDataFrame} from './lu-data-frame';
 export type {

--- a/modules/experimental/src/ludf/lu-data-frame.ts
+++ b/modules/experimental/src/ludf/lu-data-frame.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {BufferLayout} from '@luma.gl/core';
 import {

--- a/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer} from '@luma.gl/core';
 import {

--- a/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';

--- a/modules/experimental/test/ludf/lu-data-frame.node.spec.ts
+++ b/modules/experimental/test/ludf/lu-data-frame.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {readFileSync} from 'node:fs';
 

--- a/modules/experimental/test/ludf/lu-data-frame.spec.ts
+++ b/modules/experimental/test/ludf/lu-data-frame.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer, type Device} from '@luma.gl/core';
 import {LuDataFrame} from '@luma.gl/experimental/ludf';


### PR DESCRIPTION
## Goals

Restore the repository-wide SPDX source-header test on current `master` without changing runtime behavior or license ownership.

## Changes

- Normalize existing vis.gl copyright comments to `SPDX-FileCopyrightText` in the recently added experimental batched GPU hash index and luDF sources/tests.
- Preserve the existing MIT license expressions and the existing `vis.gl contributors` copyright holder verbatim.
- Keep this prerequisite separate from the command-graph, GPU-table, Arrow, and vector-similarity feature pull requests.

## Verification

- [x] `nvm use` (Node 22.22.1).
- [ ] `yarn install`: the configured package registry returns HTTP 403 for required tarballs; verification reuses the existing isolated dependency tree and CI performs the normal immutable install.
- [x] Focused repository-wide SPDX source-header suite.
- [x] `yarn lint fix`.
- [x] `yarn build` after final source and formatting changes.
- [x] `yarn test-node`.
- [x] `CI=true yarn test` with real Chromium/WebGPU coverage.
- [x] `yarn website:build`.
- [x] `(cd website && yarn build)`.

## Risks

Comment-only SPDX normalization; no runtime, type, API, or ownership changes.
