### PR TITLE
fix(experimental): normalize luDF SPDX headers

### DIFF
--- a/modules/experimental/src/gpu-primitives/gpu-batch-hash-index.ts
+++ b/modules/experimental/src/gpu-primitives/gpu-batch-hash-index.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {GraphVectorView, type GPUCommandGraph, type GraphDataView} from './gpu-command-graph';
 import {

--- a/modules/experimental/src/ludf/index.ts
+++ b/modules/experimental/src/ludf/index.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 export {LuDataFrame} from './lu-data-frame';
 export type {

--- a/modules/experimental/src/ludf/lu-data-frame.ts
+++ b/modules/experimental/src/ludf/lu-data-frame.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import type {BufferLayout} from '@luma.gl/core';
 import {

--- a/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer} from '@luma.gl/core';
 import {

--- a/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-batch-hash-index.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import test from 'test/utils/vitest-tape';
 import {Buffer, type Device} from '@luma.gl/core';

--- a/modules/experimental/test/ludf/lu-data-frame.node.spec.ts
+++ b/modules/experimental/test/ludf/lu-data-frame.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {readFileSync} from 'node:fs';
 

--- a/modules/experimental/test/ludf/lu-data-frame.spec.ts
+++ b/modules/experimental/test/ludf/lu-data-frame.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer, type Device} from '@luma.gl/core';
 import {LuDataFrame} from '@luma.gl/experimental/ludf';


### PR DESCRIPTION
Goals

- Restore the SPDX source-header guard on current `master`.
- Keep the fix limited to ownership metadata with no runtime or test-semantic changes.

Changes

- Replace the legacy copyright line with the canonical `SPDX-FileCopyrightText` line in seven luDF/hash-index source and test files introduced by #2933 and #2960.

Verification

- `test/examples/spdx-source-headers.node.spec.ts`: 6/6 tests passed.
- `git diff --check`: passed.
- Reviewed the tracked diff: exactly seven one-line header replacements.
- `yarn lint fix`: attempted, but the reused dependency environment does not provide `ocular-lint`; the changes are comment-only and preserve the repository's canonical header format.
- `nvm use`, `yarn install`, `yarn build`, `yarn test`, `yarn website:build`, and `(cd website && yarn build)` were not rerun locally; CI is the authoritative full-suite gate for this metadata-only fix.

Risks

- None expected. This changes comments only.
