### PR TITLE
Enable dependencies across trace span chunks

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -58,7 +58,6 @@ import {
   TRACE_PROCESS_COUNT,
   TRACE_SPAN_BATCH_CAPACITY,
   TRACE_SPAN_CHUNK_TARGET_BYTE_LENGTH,
-  TRACE_SPAN_RECORD_WORD_LENGTH,
   TRACE_STATUS_COUNT,
   TRACE_THREAD_COUNT,
   TRACE_THREADS_PER_PROCESS,
@@ -68,6 +67,7 @@ import {
 import {
   getBatchVisibilityShader,
   getCandidateDensityShader,
+  getCandidateDependencyEndpointsShader,
   getCandidateDependencyVisibilityShader,
   getCandidatePassDispatchShader,
   getCandidatePickShader,
@@ -192,6 +192,7 @@ type TraceGraphResources = {
   focusTraversalState: Buffer;
   reachedSpans: Buffer;
   dependencyResults: Buffer;
+  dependencyEndpointPositions: Buffer;
   spanVisibility: Buffer;
   visibleDependencyIds: Buffer;
   densityBins: Buffer;
@@ -231,6 +232,7 @@ function getTraceResourceBuffers(resources: TraceGraphResources): Array<{byteLen
     resources.focusTraversalState,
     resources.reachedSpans,
     resources.dependencyResults,
+    resources.dependencyEndpointPositions,
     resources.spanVisibility,
     resources.visibleDependencyIds,
     resources.densityBins,
@@ -504,12 +506,13 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         bindings: [
           {name: 'dependencies', type: 'read-only-storage', group: 0, location: 0},
           {name: 'visibleDependencyIds', type: 'read-only-storage', group: 0, location: 1},
-          {name: 'spans', type: 'read-only-storage', group: 0, location: 2},
-          {name: 'processStates', type: 'read-only-storage', group: 0, location: 3},
-          {name: 'threadStates', type: 'read-only-storage', group: 0, location: 4},
-          {name: 'threadOffsets', type: 'read-only-storage', group: 0, location: 5},
-          {name: 'dependencyResults', type: 'read-only-storage', group: 0, location: 6},
-          {name: 'viewUniforms', type: 'uniform', group: 0, location: 7}
+          {
+            name: 'dependencyEndpointPositions',
+            type: 'read-only-storage',
+            group: 0,
+            location: 2
+          },
+          {name: 'viewUniforms', type: 'uniform', group: 0, location: 3}
         ]
       },
       parameters: makeTraceBlendParameters()
@@ -539,7 +542,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     const started = performance.now();
     this.destroyResources();
     this.spanCapacity = spanCapacity;
-    this.dependencyCapacity = this.getSupportedDependencyCapacity(spanCapacity, dependencyCapacity);
+    this.dependencyCapacity = dependencyCapacity;
     this.selectedSpanIndex = INVALID_SPAN_INDEX;
     const dataset = makeTraceDataset(spanCapacity, this.dependencyCapacity);
     const resources = this.createResources(dataset);
@@ -561,16 +564,6 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     this.updateInspector();
   }
 
-  private getSupportedDependencyCapacity(spanCapacity: number, dependencyCapacity: number): number {
-    const spanByteLength =
-      spanCapacity * TRACE_SPAN_RECORD_WORD_LENGTH * Uint32Array.BYTES_PER_ELEMENT;
-    const maximumMonolithicSpanByteLength = Math.min(
-      this.device.limits.maxStorageBufferBindingSize,
-      this.device.limits.maxBufferSize
-    );
-    return spanByteLength <= maximumMonolithicSpanByteLength ? dependencyCapacity : 0;
-  }
-
   /** Uploads each canonical source or mutable interaction allocation exactly once. */
   private createResources(dataset: TraceDatasetData): TraceGraphResources {
     const groups = dataset.groups.map(group => ({
@@ -588,19 +581,15 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       this.device.limits.maxStorageBufferBindingSize,
       this.device.limits.maxBufferSize
     );
-    const maximumSpanChunkByteLength =
-      dataset.dependencyCount > 0
-        ? maximumDirectSpanByteLength
-        : Math.min(maximumDirectSpanByteLength, this.spanChunkByteLength);
+    const maximumSpanChunkByteLength = Math.min(
+      maximumDirectSpanByteLength,
+      this.spanChunkByteLength
+    );
     const spanChunkData = makeTraceSpanChunks(
       dataset.spans,
       dataset.spanBatches,
       maximumSpanChunkByteLength
     );
-    // Dependency endpoint rendering currently requires one directly addressable span allocation.
-    if (spanChunkData.length > 1 && dataset.dependencyCount > 0) {
-      throw new Error();
-    }
     const spanDraws: TraceSpanDrawResources[] = spanChunkData.flatMap(chunk =>
       groups.flatMap((_, groupIndex) => {
         const chunkBatches = dataset.spanBatches
@@ -752,6 +741,10 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         Math.max(dataset.dependencyCount * 3, 1) * UINT32_BYTE_LENGTH,
         Buffer.COPY_SRC
       ),
+      dependencyEndpointPositions: this.createStorageBuffer(
+        'gpu-trace-dependency-endpoint-positions',
+        Math.max(dataset.dependencyCount * 4, 1) * UINT32_BYTE_LENGTH
+      ),
       spanVisibility: this.createStorageBuffer('gpu-trace-span-visibility', spanMaskByteLength),
       visibleDependencyIds: this.createStorageBuffer(
         'gpu-trace-visible-dependencies',
@@ -886,6 +879,11 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         graph,
         'dependency-results',
         resources.dependencyResults
+      ),
+      dependencyEndpointPositions: importTraceBuffer(
+        graph,
+        'dependency-endpoint-positions',
+        resources.dependencyEndpointPositions
       ),
       spanVisibility: importTraceBuffer(graph, 'span-visibility', resources.spanVisibility),
       visibleDependencyIds: importTraceBuffer(
@@ -1222,11 +1220,8 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       ]),
       {buffer: handles.visibleSpanIds, usage: 'storage-read'},
       {buffer: handles.dependencies, usage: 'storage-read'},
-      {buffer: handles.processStates, usage: 'storage-read'},
-      {buffer: handles.threadStates, usage: 'storage-read'},
-      {buffer: handles.threadOffsets, usage: 'storage-read'},
       {buffer: handles.reachedSpans, usage: 'storage-read'},
-      {buffer: handles.dependencyResults, usage: 'storage-read'},
+      {buffer: handles.dependencyEndpointPositions, usage: 'storage-read'},
       {buffer: handles.densityBins, usage: 'storage-read'},
       {buffer: handles.uniforms, usage: 'uniform'},
       {buffer: handles.drawCommands, usage: 'indirect'}
@@ -1284,6 +1279,24 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         ],
         dispatchBuffer: handles.candidateDependencyDispatchCommands
       });
+      for (const chunk of handles.spanChunks) {
+        addTraceIndirectComputePass(graph, {
+          id: `trace-candidate-dependency-endpoints-${chunk.chunkIndex}`,
+          source: getCandidateDependencyEndpointsShader(chunk),
+          bindings: [
+            storageRead('spans', chunk.spans),
+            storageRead('dependencyBatches', handles.dependencyBatchIndex),
+            storageRead('candidateBatchIds', handles.candidateDependencyBatchIds),
+            storageRead('dependencyResults', handles.dependencyResults),
+            storageRead('processStates', handles.processStates),
+            storageRead('threadStates', handles.threadStates),
+            storageRead('threadOffsets', handles.threadOffsets),
+            uniformBinding('viewUniforms', handles.uniforms),
+            storageWrite('dependencyEndpointPositions', handles.dependencyEndpointPositions)
+          ],
+          dispatchBuffer: handles.candidateDependencyDispatchCommands
+        });
+      }
       new GPUIndexedRangeCompaction({
         id: 'trace-visible-dependencies',
         flags: graph.createDataView(handles.dependencyResults, {
@@ -1362,11 +1375,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       encoder.setBindings({
         dependencies: resources.dependencies,
         visibleDependencyIds: resources.visibleDependencyIds,
-        spans: resources.spanChunks[0].buffer,
-        processStates: resources.processStates,
-        threadStates: resources.threadStates,
-        threadOffsets: resources.threadOffsets,
-        dependencyResults: resources.dependencyResults,
+        dependencyEndpointPositions: resources.dependencyEndpointPositions,
         viewUniforms: this.viewUniformBuffer
       });
       resources.drawCommands.draw(encoder, resources.dependencyDrawCommandIndex);
@@ -1553,6 +1562,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
       resources.focusTraversalState,
       resources.reachedSpans,
       resources.dependencyResults,
+      resources.dependencyEndpointPositions,
       resources.spanVisibility,
       resources.visibleDependencyIds,
       resources.densityBins,
@@ -1636,7 +1646,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
             `<option value="${value}"${value === this.dependencyCapacity ? ' selected' : ''}>${formatCount(value)}</option>`
         )
         .join('')}</select></label>
-      <small>Dependencies automatically switch off when the selected span source requires multiple GPU chunks.</small>
+      <small>Span and dependency capacity are independent; endpoint positions resolve across bounded GPU chunks.</small>
       <fieldset style="display:grid;gap:4px"><legend>Span groups</legend>${groupControls}</fieldset>
       <fieldset style="display:grid;gap:4px"><legend>Status</legend>${statusControls}</fieldset>
       <label>Minimum duration <input type="range" min="0" max="20" step="0.25" value="0" data-duration> <span data-duration-value>0.00 ms</span></label>

--- a/examples/experimental/gpu-trace-viewer/trace-benchmark.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-benchmark.ts
@@ -133,8 +133,7 @@ export function getTraceCapacityContract(
   const fitsChunkedDeviceLimits =
     maximumSpanChunkByteLength >= TRACE_SPAN_RECORD_WORD_LENGTH * UINT32_BYTE_LENGTH &&
     dependencyBufferByteLength <= limits.maxStorageBufferBindingSize &&
-    dependencyBufferByteLength <= limits.maxBufferSize &&
-    (dependencyCapacity === 0 || (fitsStorageBufferBindingSize && fitsMaxBufferSize));
+    dependencyBufferByteLength <= limits.maxBufferSize;
   return Object.freeze({
     spanCapacity,
     dependencyCapacity,

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -212,29 +212,13 @@ ${TRACE_SHADER_DECLARATIONS}
 
 @group(0) @binding(0) var<storage, read> dependencies: array<TraceDependency>;
 @group(0) @binding(1) var<storage, read> visibleDependencyIds: array<u32>;
-@group(0) @binding(2) var<storage, read> spans: array<TraceSpan>;
-@group(0) @binding(3) var<storage, read> processStates: array<u32>;
-@group(0) @binding(4) var<storage, read> threadStates: array<u32>;
-@group(0) @binding(5) var<storage, read> threadOffsets: array<u32>;
-@group(0) @binding(6) var<storage, read> dependencyResults: array<u32>;
-@group(0) @binding(7) var<uniform> viewUniforms: ViewUniforms;
+@group(0) @binding(2) var<storage, read> dependencyEndpointPositions: array<vec2<f32>>;
+@group(0) @binding(3) var<uniform> viewUniforms: ViewUniforms;
 
 struct DependencyVertexOutput {
   @builtin(position) position: vec4<f32>,
   @location(0) color: vec4<f32>,
 };
-
-fn getEndpointLane(span: TraceSpan) -> u32 {
-  if (processStates[span.processIndex] == 0u) {
-    return threadOffsets[span.processIndex * THREADS_PER_PROCESS];
-  }
-  let localLane = select(0u, span.lane % LANES_PER_THREAD, threadStates[span.threadIndex] != 0u);
-  return threadOffsets[span.threadIndex] + localLane;
-}
-
-fn getResolvedEndpoint(endpointResultIndex: u32) -> TraceSpan {
-  return spans[dependencyResults[viewUniforms.dependencyEndpointOffset + endpointResultIndex]];
-}
 
 @vertex fn vertexMain(
   @builtin(vertex_index) vertexIndex: u32,
@@ -243,16 +227,14 @@ fn getResolvedEndpoint(endpointResultIndex: u32) -> TraceSpan {
   let dependency = dependencies[visibleDependencyIds[instanceIndex]];
   let dependencyIndex = visibleDependencyIds[instanceIndex];
   let endpointResultIndex = dependencyIndex * 2u + select(0u, 1u, vertexIndex == 1u);
-  let span = getResolvedEndpoint(endpointResultIndex);
+  let endpointPosition = dependencyEndpointPositions[endpointResultIndex];
   let timeRange = max(viewUniforms.timeMax - viewUniforms.timeMin, 0.0001);
   let laneRange = max(viewUniforms.laneMax - viewUniforms.laneMin, 1.0);
-  let endpointTime = select(span.start + span.duration, span.start, vertexIndex == 1u);
-  let endpointLane = f32(getEndpointLane(span)) + 0.4;
   let crossProcess = dependency.family != 0u;
   var output: DependencyVertexOutput;
   output.position = vec4<f32>(
-    ((endpointTime - viewUniforms.timeMin) / timeRange) * 2.0 - 1.0,
-    1.0 - ((endpointLane - viewUniforms.laneMin) / laneRange) * 2.0,
+    ((endpointPosition.x - viewUniforms.timeMin) / timeRange) * 2.0 - 1.0,
+    1.0 - ((endpointPosition.y - viewUniforms.laneMin) / laneRange) * 2.0,
     0.0,
     1.0
   );
@@ -858,5 +840,67 @@ fn main(
   let endpointResultOffset = viewUniforms.dependencyEndpointOffset + index * 2u;
   dependencyResults[endpointResultOffset] = effectiveSource;
   dependencyResults[endpointResultOffset + 1u] = effectiveDestination;
+}`;
+}
+
+/** Resolves dependency endpoint positions from one bounded source span chunk. */
+export function getCandidateDependencyEndpointsShader(props: TraceSpanChunkShaderProps): string {
+  return /* wgsl */ `
+${TRACE_SHADER_DECLARATIONS}
+${getSpanChunkDeclarations(props)}
+struct DependencyBatch {
+  firstIndex: u32,
+  count: u32,
+  timeMin: f32,
+  timeMax: f32,
+  familyMask: u32,
+  batchIndex: u32,
+};
+@group(0) @binding(0) var<storage, read> spans: array<TraceSpan>;
+@group(0) @binding(1) var<storage, read> dependencyBatches: array<DependencyBatch>;
+@group(0) @binding(2) var<storage, read> candidateBatchIds: array<u32>;
+@group(0) @binding(3) var<storage, read> dependencyResults: array<u32>;
+@group(0) @binding(4) var<storage, read> processStates: array<u32>;
+@group(0) @binding(5) var<storage, read> threadStates: array<u32>;
+@group(0) @binding(6) var<storage, read> threadOffsets: array<u32>;
+@group(0) @binding(7) var<uniform> viewUniforms: ViewUniforms;
+@group(0) @binding(8) var<storage, read_write> dependencyEndpointPositions: array<vec2<f32>>;
+
+fn getEndpointLane(span: TraceSpan) -> u32 {
+  if (processStates[span.processIndex] == 0u) {
+    return threadOffsets[span.processIndex * THREADS_PER_PROCESS];
+  }
+  let localLane = select(0u, span.lane % LANES_PER_THREAD, threadStates[span.threadIndex] != 0u);
+  return threadOffsets[span.threadIndex] + localLane;
+}
+
+@compute @workgroup_size(${TRACE_DEPENDENCY_BATCH_CAPACITY})
+fn main(
+  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  let batch = dependencyBatches[candidateBatchIds[workgroupId.y]];
+  if (localId.x >= batch.count) {
+    return;
+  }
+  let dependencyIndex = batch.firstIndex + localId.x;
+  if (dependencyResults[dependencyIndex] == 0u) {
+    return;
+  }
+  let endpointResultOffset = viewUniforms.dependencyEndpointOffset + dependencyIndex * 2u;
+  for (var endpointIndex = 0u; endpointIndex < 2u; endpointIndex++) {
+    let sourceIndex = dependencyResults[endpointResultOffset + endpointIndex];
+    if (
+      sourceIndex >= CHUNK_FIRST_SPAN_INDEX &&
+      sourceIndex < CHUNK_FIRST_SPAN_INDEX + CHUNK_SPAN_COUNT
+    ) {
+      let span = spans[sourceIndex - CHUNK_FIRST_SPAN_INDEX];
+      let endpointTime = select(span.start + span.duration, span.start, endpointIndex == 1u);
+      dependencyEndpointPositions[dependencyIndex * 2u + endpointIndex] = vec2<f32>(
+        endpointTime,
+        f32(getEndpointLane(span)) + 0.4
+      );
+    }
+  }
 }`;
 }

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -39,6 +39,7 @@ import {
 import {
   getBatchVisibilityShader,
   getCandidateDensityShader,
+  getCandidateDependencyEndpointsShader,
   getCandidateDependencyVisibilityShader,
   getCandidatePassDispatchShader,
   getCandidatePickShader,
@@ -171,7 +172,7 @@ test('GPU trace supremacy contract exposes standard scales and interaction scena
   t.end();
 });
 
-test('GPU trace capacity contract makes the monolithic 10M limit explicit', t => {
+test('GPU trace capacity contract separates chunked spans from dependency capacity', t => {
   const portable = getTraceCapacityContract(10_000_000, 10_000_000, {
     maxStorageBufferBindingSize: 128 * 1024 * 1024,
     maxBufferSize: 256 * 1024 * 1024
@@ -190,15 +191,15 @@ test('GPU trace capacity contract makes the monolithic 10M limit explicit', t =>
       maxBufferSize: 256 * 1024 * 1024
     }).fitsChunkedDeviceLimits,
     true,
-    'portable limits admit ten million spans when dependency endpoint lookup is disabled'
+    'portable limits admit ten million spans without dependencies'
   );
   t.equal(
     getTraceCapacityContract(10_000_000, 250_000, {
       maxStorageBufferBindingSize: 128 * 1024 * 1024,
       maxBufferSize: 256 * 1024 * 1024
     }).fitsChunkedDeviceLimits,
-    false,
-    'dependency endpoint lookup keeps its monolithic span requirement explicit'
+    true,
+    'chunk-resolved endpoints admit dependencies without a monolithic span allocation'
   );
 
   const maximum = getTraceCapacityContract(10_000_000, 10_000_000, {
@@ -281,6 +282,7 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
       {firstBatchIndex: 2, batchCount: 1}
     ]),
     getDependencyBatchVisibilityShader(3),
+    getCandidateDependencyEndpointsShader(spanChunk),
     getCandidateDependencyVisibilityShader(11),
     getFocusFrontierSeedShader(11),
     getFocusFrontierClearShader(),

--- a/test/examples/gpu-trace-viewer.spec.ts
+++ b/test/examples/gpu-trace-viewer.spec.ts
@@ -376,7 +376,7 @@ describe('GPU hierarchical trace viewer', () => {
     }
   }, 30_000);
 
-  test('renders exact spans from multiple bounded source chunks', async () => {
+  test('renders exact spans and dependencies from multiple bounded source chunks', async () => {
     const device = await getWebGPUTestDevice('core');
     if (!device) {
       return;
@@ -399,7 +399,7 @@ describe('GPU hierarchical trace viewer', () => {
       viewer = new GPUTraceViewerAnimationLoopTemplate({
         device,
         traceCapacity: 4096,
-        dependencyCapacity: 0,
+        dependencyCapacity: 250_000,
         spanChunkByteLength
       } as AnimationProps & {
         traceCapacity: number;
@@ -411,11 +411,12 @@ describe('GPU hierarchical trace viewer', () => {
           drawCommands: {buffer: {readAsync: () => Promise<Uint8Array>}};
           spanChunks: Array<{buffer: {byteLength: number}}>;
           spanDraws: Array<{commandIndex: number; chunkIndex: number}>;
+          dependencyDrawCommandIndex: number;
           dependencyCount: number;
         };
       };
 
-      expect(state.resources.dependencyCount).toBe(0);
+      expect(state.resources.dependencyCount).toBeGreaterThan(0);
       expect(state.resources.spanChunks.length).toBeGreaterThan(1);
       expect(state.resources.spanDraws.length).toBeGreaterThan(3);
       expect(
@@ -440,6 +441,7 @@ describe('GPU hierarchical trace viewer', () => {
         0
       );
       expect(visibleSpanCount).toBeGreaterThan(0);
+      expect(drawCommands[state.resources.dependencyDrawCommandIndex * 4 + 1]).toBeGreaterThan(0);
     } finally {
       viewer?.onFinalize();
       host.remove();


### PR DESCRIPTION
## What changed

- resolve dependency endpoint time and lane positions with one GPU compute pass per bounded span chunk
- render dependencies from the compact endpoint-position buffer instead of directly indexing one monolithic span buffer
- keep dependency capacity independent when the span source is split across GPU buffers
- extend the capacity contract, WGSL parsing coverage, and WebGPU multi-chunk fixture

## Why

The 10M-span trace path already chunks span storage, but dependency rendering still required the entire span table to fit in one storage binding. That forced dependencies off at the largest portable span capacity.

This change removes that last monolithic span dependency while preserving GPU visibility, stable compaction, and indirect rendering.

## Validation

- `nvm use`
- focused GPU trace node/WGSL suite: 14 tests passed
- formatting checked with the repository's Biome 2.4.8 settings
- `yarn build` and `yarn test` were attempted, but this isolated worktree could not install the newly pinned toolchain through the configured registry; CI will run the full gates with a clean dependency environment
- the WebGPU browser fixture was updated, but local execution was blocked by the missing matching Playwright Chromium binary
