### PR TITLE
fix(experimental): normalize visibility workflow SPDX header

### DIFF
--- a/modules/experimental/test/gpu-primitives/gpu-visibility-workflow.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-visibility-workflow.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer} from '@luma.gl/core';
 import {GPUCommandGraph, GPUCompaction, GPUVisibilityWorkflow} from '@luma.gl/experimental';


### PR DESCRIPTION
## Goals

- Restore the repository SPDX ownership guard on `master`.
- Unblock the luSpatial leaf PR checks that inherit the same baseline failure.

## Changes

- Replace the legacy copyright comment in `gpu-visibility-workflow.node.spec.ts` with the canonical `SPDX-FileCopyrightText` form.
- No runtime or test behavior changes.

## Verification

- `test/examples/spdx-source-headers.node.spec.ts`: 6/6 passed.
- `git diff --check`: passed.
- Independent review: approved with no findings.
- `yarn lint fix`: attempted; the isolated checkout's linked dependency set lacks a runnable `ocular-lint`. The one-line comment-only diff is formatting-neutral.

## Risk

- Minimal: metadata-only change in a test-file header.
