### PR TITLE
Route trace dependency endpoints by span chunk

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -67,13 +67,17 @@ import {
 import {
   getBatchVisibilityShader,
   getCandidateDensityShader,
-  getCandidateDependencyEndpointsShader,
+  getCandidateDependencyEndpointCountShader,
+  getCandidateDependencyEndpointScatterShader,
   getCandidateDependencyVisibilityShader,
   getCandidatePassDispatchShader,
   getCandidatePickShader,
   getCandidateVisibilityShader,
   getDensityClearShader,
   getDependencyBatchVisibilityShader,
+  getDependencyEndpointDispatchShader,
+  getDependencyEndpointResolveShader,
+  getDependencyEndpointRouteClearShader,
   getFocusFrontierClearShader,
   getFocusFrontierDispatchShader,
   getFocusFrontierExpansionShader,
@@ -1228,6 +1232,25 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
     ];
 
     if (resources.dependencyCount > 0) {
+      const endpointRoutingProps = {
+        dependencyCount: resources.dependencyCount,
+        spanChunks: resources.spanChunks
+      };
+      const dependencyEndpointJobs = graph.createTransientBuffer({
+        id: 'trace-dependency-endpoint-jobs',
+        byteLength: resources.dependencyCount * 2 * UINT32_BYTE_LENGTH,
+        usage: Buffer.STORAGE
+      });
+      const dependencyEndpointChunkState = graph.createTransientBuffer({
+        id: 'trace-dependency-endpoint-chunk-state',
+        byteLength: resources.spanChunks.length * 3 * UINT32_BYTE_LENGTH,
+        usage: Buffer.STORAGE
+      });
+      const dependencyEndpointDispatchCommands = graph.createTransientBuffer({
+        id: 'trace-dependency-endpoint-dispatch-commands',
+        byteLength: resources.spanChunks.length * 3 * UINT32_BYTE_LENGTH,
+        usage: Buffer.STORAGE | Buffer.INDIRECT
+      });
       const candidateDependencyBatchFlags = graph.createTransientBuffer({
         id: 'trace-candidate-dependency-batch-flags',
         byteLength: resources.dependencyBatchCount * UINT32_BYTE_LENGTH,
@@ -1279,22 +1302,61 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
         ],
         dispatchBuffer: handles.candidateDependencyDispatchCommands
       });
+      addTraceComputePass(graph, {
+        id: 'trace-clear-dependency-endpoint-routes',
+        source: getDependencyEndpointRouteClearShader(resources.spanChunks.length),
+        bindings: [storageWrite('endpointChunkState', dependencyEndpointChunkState)],
+        length: resources.spanChunks.length
+      });
+      addTraceIndirectComputePass(graph, {
+        id: 'trace-count-dependency-endpoint-routes',
+        source: getCandidateDependencyEndpointCountShader(endpointRoutingProps),
+        bindings: [
+          storageRead('dependencyBatches', handles.dependencyBatchIndex),
+          storageRead('candidateBatchIds', handles.candidateDependencyBatchIds),
+          storageRead('dependencyResults', handles.dependencyResults),
+          storageWrite('endpointChunkState', dependencyEndpointChunkState)
+        ],
+        dispatchBuffer: handles.candidateDependencyDispatchCommands
+      });
+      addTraceComputePass(graph, {
+        id: 'trace-publish-dependency-endpoint-routes',
+        source: getDependencyEndpointDispatchShader(resources.spanChunks.length),
+        bindings: [
+          storageWrite('endpointChunkState', dependencyEndpointChunkState),
+          storageWrite('endpointDispatchCommands', dependencyEndpointDispatchCommands)
+        ],
+        length: 1,
+        workgroupSize: 1
+      });
+      addTraceIndirectComputePass(graph, {
+        id: 'trace-scatter-dependency-endpoint-routes',
+        source: getCandidateDependencyEndpointScatterShader(endpointRoutingProps),
+        bindings: [
+          storageRead('dependencyBatches', handles.dependencyBatchIndex),
+          storageRead('candidateBatchIds', handles.candidateDependencyBatchIds),
+          storageRead('dependencyResults', handles.dependencyResults),
+          storageWrite('endpointChunkState', dependencyEndpointChunkState),
+          storageWrite('endpointJobs', dependencyEndpointJobs)
+        ],
+        dispatchBuffer: handles.candidateDependencyDispatchCommands
+      });
       for (const chunk of handles.spanChunks) {
         addTraceIndirectComputePass(graph, {
-          id: `trace-candidate-dependency-endpoints-${chunk.chunkIndex}`,
-          source: getCandidateDependencyEndpointsShader(chunk),
+          id: `trace-resolve-routed-dependency-endpoints-${chunk.chunkIndex}`,
+          source: getDependencyEndpointResolveShader(endpointRoutingProps, chunk.chunkIndex),
           bindings: [
             storageRead('spans', chunk.spans),
-            storageRead('dependencyBatches', handles.dependencyBatchIndex),
-            storageRead('candidateBatchIds', handles.candidateDependencyBatchIds),
+            storageRead('endpointJobs', dependencyEndpointJobs),
+            storageRead('endpointChunkState', dependencyEndpointChunkState),
             storageRead('dependencyResults', handles.dependencyResults),
             storageRead('processStates', handles.processStates),
             storageRead('threadStates', handles.threadStates),
             storageRead('threadOffsets', handles.threadOffsets),
-            uniformBinding('viewUniforms', handles.uniforms),
             storageWrite('dependencyEndpointPositions', handles.dependencyEndpointPositions)
           ],
-          dispatchBuffer: handles.candidateDependencyDispatchCommands
+          dispatchBuffer: dependencyEndpointDispatchCommands,
+          dispatchByteOffset: chunk.chunkIndex * 3 * UINT32_BYTE_LENGTH
         });
       }
       new GPUIndexedRangeCompaction({
@@ -2198,6 +2260,7 @@ function addTraceIndirectComputePass<Parameters>(
     source: string;
     bindings: readonly TraceComputePassBinding[];
     dispatchBuffer: GraphBufferHandle;
+    dispatchByteOffset?: number;
   }
 ): void {
   graph.addComputePass({
@@ -2225,7 +2288,11 @@ function addTraceIndirectComputePass<Parameters>(
             bindings[binding.name] = getBuffer(binding.buffer);
           }
           computation.setBindings(bindings);
-          computation.dispatchIndirect(computePass, getBuffer(props.dispatchBuffer));
+          computation.dispatchIndirect(
+            computePass,
+            getBuffer(props.dispatchBuffer),
+            props.dispatchByteOffset
+          );
         },
         destroy: () => computation.destroy()
       };

--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -67,7 +67,6 @@ import {
 import {
   getBatchVisibilityShader,
   getCandidateDensityShader,
-  getCandidateDependencyEndpointCountShader,
   getCandidateDependencyEndpointScatterShader,
   getCandidateDependencyVisibilityShader,
   getCandidatePassDispatchShader,
@@ -1287,9 +1286,15 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
           byteOffset: UINT32_BYTE_LENGTH
         })
       }).addToGraph(graph);
+      addTraceComputePass(graph, {
+        id: 'trace-clear-dependency-endpoint-routes',
+        source: getDependencyEndpointRouteClearShader(resources.spanChunks.length),
+        bindings: [storageWrite('endpointChunkState', dependencyEndpointChunkState)],
+        length: resources.spanChunks.length
+      });
       addTraceIndirectComputePass(graph, {
         id: 'trace-candidate-dependency-visibility',
-        source: getCandidateDependencyVisibilityShader(resources.spanCount),
+        source: getCandidateDependencyVisibilityShader(endpointRoutingProps),
         bindings: [
           storageRead('dependencies', handles.dependencies),
           storageRead('dependencyBatches', handles.dependencyBatchIndex),
@@ -1298,23 +1303,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
           storageRead('processStates', handles.processStates),
           storageRead('parentSpans', handles.parentSpans),
           uniformBinding('viewUniforms', handles.uniforms),
-          storageWrite('dependencyResults', handles.dependencyResults)
-        ],
-        dispatchBuffer: handles.candidateDependencyDispatchCommands
-      });
-      addTraceComputePass(graph, {
-        id: 'trace-clear-dependency-endpoint-routes',
-        source: getDependencyEndpointRouteClearShader(resources.spanChunks.length),
-        bindings: [storageWrite('endpointChunkState', dependencyEndpointChunkState)],
-        length: resources.spanChunks.length
-      });
-      addTraceIndirectComputePass(graph, {
-        id: 'trace-count-dependency-endpoint-routes',
-        source: getCandidateDependencyEndpointCountShader(endpointRoutingProps),
-        bindings: [
-          storageRead('dependencyBatches', handles.dependencyBatchIndex),
-          storageRead('candidateBatchIds', handles.candidateDependencyBatchIds),
-          storageRead('dependencyResults', handles.dependencyResults),
+          storageWrite('dependencyResults', handles.dependencyResults),
           storageWrite('endpointChunkState', dependencyEndpointChunkState)
         ],
         dispatchBuffer: handles.candidateDependencyDispatchCommands

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -843,11 +843,52 @@ fn main(
 }`;
 }
 
-/** Resolves dependency endpoint positions from one bounded source span chunk. */
-export function getCandidateDependencyEndpointsShader(props: TraceSpanChunkShaderProps): string {
+export type TraceDependencyEndpointRoutingShaderProps = {
+  dependencyCount: number;
+  spanChunks: readonly TraceSpanChunkShaderProps[];
+};
+
+function getDependencyEndpointRoutingDeclarations(
+  props: TraceDependencyEndpointRoutingShaderProps
+): string {
+  const chunkEnds = props.spanChunks
+    .map(chunk => `${chunk.firstSpanIndex + chunk.spanCount}u`)
+    .join(', ');
+  return `const DEPENDENCY_COUNT: u32 = ${props.dependencyCount}u;
+const CHUNK_COUNT: u32 = ${props.spanChunks.length}u;
+const INVALID_CHUNK_INDEX: u32 = 0xffffffffu;
+const CHUNK_ENDS = array<u32, ${props.spanChunks.length}>(${chunkEnds});
+
+fn getSpanChunkIndex(spanIndex: u32) -> u32 {
+  for (var chunkIndex = 0u; chunkIndex < CHUNK_COUNT; chunkIndex++) {
+    if (spanIndex < CHUNK_ENDS[chunkIndex]) {
+      return chunkIndex;
+    }
+  }
+  return INVALID_CHUNK_INDEX;
+}`;
+}
+
+/** Clears endpoint-route counts before candidate dependency routing. */
+export function getDependencyEndpointRouteClearShader(chunkCount: number): string {
   return /* wgsl */ `
-${TRACE_SHADER_DECLARATIONS}
-${getSpanChunkDeclarations(props)}
+const CHUNK_COUNT: u32 = ${chunkCount}u;
+@group(0) @binding(0) var<storage, read_write> endpointChunkState: array<atomic<u32>>;
+
+@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  if (globalId.x < CHUNK_COUNT) {
+    atomicStore(&endpointChunkState[globalId.x], 0u);
+  }
+}`;
+}
+
+/** Counts visible dependency endpoints per bounded source span chunk. */
+export function getCandidateDependencyEndpointCountShader(
+  props: TraceDependencyEndpointRoutingShaderProps
+): string {
+  return /* wgsl */ `
+${getDependencyEndpointRoutingDeclarations(props)}
 struct DependencyBatch {
   firstIndex: u32,
   count: u32,
@@ -856,15 +897,161 @@ struct DependencyBatch {
   familyMask: u32,
   batchIndex: u32,
 };
+@group(0) @binding(0) var<storage, read> dependencyBatches: array<DependencyBatch>;
+@group(0) @binding(1) var<storage, read> candidateBatchIds: array<u32>;
+@group(0) @binding(2) var<storage, read> dependencyResults: array<u32>;
+@group(0) @binding(3) var<storage, read_write> endpointChunkState: array<atomic<u32>>;
+var<workgroup> localChunkCounts: array<atomic<u32>, ${props.spanChunks.length}>;
+
+@compute @workgroup_size(${TRACE_DEPENDENCY_BATCH_CAPACITY})
+fn main(
+  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
+    atomicStore(&localChunkCounts[chunkIndex], 0u);
+  }
+  workgroupBarrier();
+
+  let batch = dependencyBatches[candidateBatchIds[workgroupId.y]];
+  if (localId.x < batch.count) {
+    let dependencyIndex = batch.firstIndex + localId.x;
+    if (dependencyResults[dependencyIndex] != 0u) {
+      let endpointResultOffset = DEPENDENCY_COUNT + dependencyIndex * 2u;
+      for (var endpointIndex = 0u; endpointIndex < 2u; endpointIndex++) {
+        let chunkIndex = getSpanChunkIndex(dependencyResults[endpointResultOffset + endpointIndex]);
+        if (chunkIndex != INVALID_CHUNK_INDEX) {
+          atomicAdd(&localChunkCounts[chunkIndex], 1u);
+        }
+      }
+    }
+  }
+  workgroupBarrier();
+
+  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
+    atomicAdd(&endpointChunkState[chunkIndex], atomicLoad(&localChunkCounts[chunkIndex]));
+  }
+}`;
+}
+
+/** Publishes chunk offsets, scatter cursors, and indirect endpoint dispatches. */
+export function getDependencyEndpointDispatchShader(chunkCount: number): string {
+  return /* wgsl */ `
+const CHUNK_COUNT: u32 = ${chunkCount}u;
+const ENDPOINT_WORKGROUP_SIZE: u32 = ${TRACE_WORKGROUP_SIZE}u;
+const OFFSET_BASE: u32 = ${chunkCount}u;
+const CURSOR_BASE: u32 = ${chunkCount * 2}u;
+@group(0) @binding(0) var<storage, read_write> endpointChunkState: array<atomic<u32>>;
+@group(0) @binding(1) var<storage, read_write> endpointDispatchCommands: array<u32>;
+
+@compute @workgroup_size(1)
+fn main() {
+  var offset = 0u;
+  for (var chunkIndex = 0u; chunkIndex < CHUNK_COUNT; chunkIndex++) {
+    let count = atomicLoad(&endpointChunkState[chunkIndex]);
+    atomicStore(&endpointChunkState[OFFSET_BASE + chunkIndex], offset);
+    atomicStore(&endpointChunkState[CURSOR_BASE + chunkIndex], offset);
+    endpointDispatchCommands[chunkIndex * 3u] =
+      (count + ENDPOINT_WORKGROUP_SIZE - 1u) / ENDPOINT_WORKGROUP_SIZE;
+    endpointDispatchCommands[chunkIndex * 3u + 1u] = 1u;
+    endpointDispatchCommands[chunkIndex * 3u + 2u] = 1u;
+    offset += count;
+  }
+}`;
+}
+
+/** Scatters visible endpoint jobs into the chunk ranges published by the count pass. */
+export function getCandidateDependencyEndpointScatterShader(
+  props: TraceDependencyEndpointRoutingShaderProps
+): string {
+  return /* wgsl */ `
+${getDependencyEndpointRoutingDeclarations(props)}
+const CURSOR_BASE: u32 = ${props.spanChunks.length * 2}u;
+struct DependencyBatch {
+  firstIndex: u32,
+  count: u32,
+  timeMin: f32,
+  timeMax: f32,
+  familyMask: u32,
+  batchIndex: u32,
+};
+@group(0) @binding(0) var<storage, read> dependencyBatches: array<DependencyBatch>;
+@group(0) @binding(1) var<storage, read> candidateBatchIds: array<u32>;
+@group(0) @binding(2) var<storage, read> dependencyResults: array<u32>;
+@group(0) @binding(3) var<storage, read_write> endpointChunkState: array<atomic<u32>>;
+@group(0) @binding(4) var<storage, read_write> endpointJobs: array<u32>;
+var<workgroup> localChunkCounts: array<atomic<u32>, ${props.spanChunks.length}>;
+var<workgroup> chunkOutputBases: array<u32, ${props.spanChunks.length}>;
+
+@compute @workgroup_size(${TRACE_DEPENDENCY_BATCH_CAPACITY})
+fn main(
+  @builtin(local_invocation_id) localId: vec3<u32>,
+  @builtin(workgroup_id) workgroupId: vec3<u32>
+) {
+  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
+    atomicStore(&localChunkCounts[chunkIndex], 0u);
+  }
+  workgroupBarrier();
+
+  var endpointChunks = array<u32, 2>(INVALID_CHUNK_INDEX, INVALID_CHUNK_INDEX);
+  var endpointLocalOffsets = array<u32, 2>(0u, 0u);
+  var dependencyIndex = 0u;
+  let batch = dependencyBatches[candidateBatchIds[workgroupId.y]];
+  if (localId.x < batch.count) {
+    dependencyIndex = batch.firstIndex + localId.x;
+    if (dependencyResults[dependencyIndex] != 0u) {
+      let endpointResultOffset = DEPENDENCY_COUNT + dependencyIndex * 2u;
+      for (var endpointIndex = 0u; endpointIndex < 2u; endpointIndex++) {
+        let chunkIndex = getSpanChunkIndex(dependencyResults[endpointResultOffset + endpointIndex]);
+        endpointChunks[endpointIndex] = chunkIndex;
+        if (chunkIndex != INVALID_CHUNK_INDEX) {
+          endpointLocalOffsets[endpointIndex] = atomicAdd(&localChunkCounts[chunkIndex], 1u);
+        }
+      }
+    }
+  }
+  workgroupBarrier();
+
+  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
+    chunkOutputBases[chunkIndex] = atomicAdd(
+      &endpointChunkState[CURSOR_BASE + chunkIndex],
+      atomicLoad(&localChunkCounts[chunkIndex])
+    );
+  }
+  workgroupBarrier();
+
+  for (var endpointIndex = 0u; endpointIndex < 2u; endpointIndex++) {
+    let chunkIndex = endpointChunks[endpointIndex];
+    if (chunkIndex != INVALID_CHUNK_INDEX) {
+      endpointJobs[chunkOutputBases[chunkIndex] + endpointLocalOffsets[endpointIndex]] =
+        dependencyIndex * 2u + endpointIndex;
+    }
+  }
+}`;
+}
+
+/** Resolves the routed endpoint jobs for one bounded source span chunk. */
+export function getDependencyEndpointResolveShader(
+  props: TraceDependencyEndpointRoutingShaderProps,
+  chunkIndex: number
+): string {
+  const chunk = props.spanChunks[chunkIndex];
+  return /* wgsl */ `
+${TRACE_SHADER_DECLARATIONS}
+${getSpanChunkDeclarations(chunk)}
+const DEPENDENCY_COUNT: u32 = ${props.dependencyCount}u;
+const CHUNK_COUNT: u32 = ${props.spanChunks.length}u;
+const CHUNK_INDEX: u32 = ${chunkIndex}u;
+const OFFSET_BASE: u32 = ${props.spanChunks.length}u;
 @group(0) @binding(0) var<storage, read> spans: array<TraceSpan>;
-@group(0) @binding(1) var<storage, read> dependencyBatches: array<DependencyBatch>;
-@group(0) @binding(2) var<storage, read> candidateBatchIds: array<u32>;
+@group(0) @binding(1) var<storage, read> endpointJobs: array<u32>;
+@group(0) @binding(2) var<storage, read> endpointChunkState: array<u32>;
 @group(0) @binding(3) var<storage, read> dependencyResults: array<u32>;
 @group(0) @binding(4) var<storage, read> processStates: array<u32>;
 @group(0) @binding(5) var<storage, read> threadStates: array<u32>;
 @group(0) @binding(6) var<storage, read> threadOffsets: array<u32>;
-@group(0) @binding(7) var<uniform> viewUniforms: ViewUniforms;
-@group(0) @binding(8) var<storage, read_write> dependencyEndpointPositions: array<vec2<f32>>;
+@group(0) @binding(7) var<storage, read_write> dependencyEndpointPositions: array<vec2<f32>>;
+@group(0) @binding(8) var<uniform> viewUniforms: ViewUniforms;
 
 fn getEndpointLane(span: TraceSpan) -> u32 {
   if (processStates[span.processIndex] == 0u) {
@@ -874,33 +1061,20 @@ fn getEndpointLane(span: TraceSpan) -> u32 {
   return threadOffsets[span.threadIndex] + localLane;
 }
 
-@compute @workgroup_size(${TRACE_DEPENDENCY_BATCH_CAPACITY})
-fn main(
-  @builtin(local_invocation_id) localId: vec3<u32>,
-  @builtin(workgroup_id) workgroupId: vec3<u32>
-) {
-  let batch = dependencyBatches[candidateBatchIds[workgroupId.y]];
-  if (localId.x >= batch.count) {
+@compute @workgroup_size(${TRACE_WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
+  let endpointCount = endpointChunkState[CHUNK_INDEX];
+  if (globalId.x >= endpointCount) {
     return;
   }
-  let dependencyIndex = batch.firstIndex + localId.x;
-  if (dependencyResults[dependencyIndex] == 0u) {
-    return;
-  }
-  let endpointResultOffset = viewUniforms.dependencyEndpointOffset + dependencyIndex * 2u;
-  for (var endpointIndex = 0u; endpointIndex < 2u; endpointIndex++) {
-    let sourceIndex = dependencyResults[endpointResultOffset + endpointIndex];
-    if (
-      sourceIndex >= CHUNK_FIRST_SPAN_INDEX &&
-      sourceIndex < CHUNK_FIRST_SPAN_INDEX + CHUNK_SPAN_COUNT
-    ) {
-      let span = spans[sourceIndex - CHUNK_FIRST_SPAN_INDEX];
-      let endpointTime = select(span.start + span.duration, span.start, endpointIndex == 1u);
-      dependencyEndpointPositions[dependencyIndex * 2u + endpointIndex] = vec2<f32>(
-        endpointTime,
-        f32(getEndpointLane(span)) + 0.4
-      );
-    }
-  }
+  let endpointJobIndex = endpointJobs[endpointChunkState[OFFSET_BASE + CHUNK_INDEX] + globalId.x];
+  let endpointIndex = endpointJobIndex & 1u;
+  let sourceIndex = dependencyResults[DEPENDENCY_COUNT + endpointJobIndex];
+  let span = spans[sourceIndex - CHUNK_FIRST_SPAN_INDEX];
+  let endpointTime = select(span.start + span.duration, span.start, endpointIndex == 1u);
+  dependencyEndpointPositions[endpointJobIndex] = vec2<f32>(
+    endpointTime,
+    f32(getEndpointLane(span)) + 0.4
+  );
 }`;
 }

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -759,10 +759,15 @@ fn main() {
 }`;
 }
 
-/** Filters dependency rows inside GPU-selected candidate batches. */
-export function getCandidateDependencyVisibilityShader(spanCount: number): string {
+/** Filters dependency rows and counts visible endpoints by span chunk. */
+export function getCandidateDependencyVisibilityShader(
+  props: TraceDependencyEndpointRoutingShaderProps
+): string {
+  const spanCount = props.spanChunks.at(-1)?.spanCount || 0;
+  const firstSpanIndex = props.spanChunks.at(-1)?.firstSpanIndex || 0;
   return /* wgsl */ `
 ${TRACE_SHADER_DECLARATIONS}
+${getDependencyEndpointRoutingDeclarations(props)}
 struct DependencyBatch {
   firstIndex: u32,
   count: u32,
@@ -771,7 +776,7 @@ struct DependencyBatch {
   familyMask: u32,
   batchIndex: u32,
 };
-const SPAN_COUNT: u32 = ${spanCount}u;
+const SPAN_COUNT: u32 = ${firstSpanIndex + spanCount}u;
 const MAXIMUM_ANCESTOR_DEPTH: u32 = 32u;
 @group(0) @binding(0) var<storage, read> dependencies: array<TraceDependency>;
 @group(0) @binding(1) var<storage, read> dependencyBatches: array<DependencyBatch>;
@@ -781,6 +786,8 @@ const MAXIMUM_ANCESTOR_DEPTH: u32 = 32u;
 @group(0) @binding(5) var<storage, read> parentSpans: array<u32>;
 @group(0) @binding(6) var<uniform> viewUniforms: ViewUniforms;
 @group(0) @binding(7) var<storage, read_write> dependencyResults: array<u32>;
+@group(0) @binding(8) var<storage, read_write> endpointChunkState: array<atomic<u32>>;
+var<workgroup> localChunkCounts: array<atomic<u32>, ${props.spanChunks.length}>;
 
 fn resolveVisibleAncestor(sourceIndex: u32) -> u32 {
   var currentIndex = sourceIndex;
@@ -802,44 +809,60 @@ fn main(
   @builtin(local_invocation_id) localId: vec3<u32>,
   @builtin(workgroup_id) workgroupId: vec3<u32>
 ) {
-  let batch = dependencyBatches[candidateBatchIds[workgroupId.y]];
-  if (localId.x >= batch.count) {
-    return;
+  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
+    atomicStore(&localChunkCounts[chunkIndex], 0u);
   }
-  let index = batch.firstIndex + localId.x;
-  let dependency = dependencies[index];
-  let projectedSource = resolveVisibleAncestor(dependency.sourceIndex);
-  let projectedDestination = resolveVisibleAncestor(dependency.destinationIndex);
-  let sourceProcessIndex =
-    (dependency.flags >> ${TRACE_DEPENDENCY_SOURCE_PROCESS_SHIFT}u) &
-    ${TRACE_DEPENDENCY_PROCESS_MASK}u;
-  let destinationProcessIndex =
-    (dependency.flags >> ${TRACE_DEPENDENCY_DESTINATION_PROCESS_SHIFT}u) &
-    ${TRACE_DEPENDENCY_PROCESS_MASK}u;
-  let sourceCollapsed = processStates[sourceProcessIndex] == 0u;
-  let destinationCollapsed = processStates[destinationProcessIndex] == 0u;
-  let familyVisible = (viewUniforms.dependencyMask & (1u << dependency.family)) != 0u;
-  let sourceVisible =
-    spanVisibility[dependency.sourceIndex] == viewUniforms.visibilityGeneration || sourceCollapsed ||
-    projectedSource != 0xffffffffu;
-  let destinationVisible =
-    spanVisibility[dependency.destinationIndex] == viewUniforms.visibilityGeneration ||
-    destinationCollapsed || projectedDestination != 0xffffffffu;
-  let effectiveSource = select(projectedSource, dependency.sourceIndex, sourceCollapsed);
-  let effectiveDestination = select(
-    projectedDestination,
-    dependency.destinationIndex,
-    destinationCollapsed
-  );
-  let distinctEndpoints = effectiveSource != effectiveDestination;
-  dependencyResults[index] = select(
-    0u,
-    1u,
-    familyVisible && sourceVisible && destinationVisible && distinctEndpoints && !isDensityMode()
-  );
-  let endpointResultOffset = viewUniforms.dependencyEndpointOffset + index * 2u;
-  dependencyResults[endpointResultOffset] = effectiveSource;
-  dependencyResults[endpointResultOffset + 1u] = effectiveDestination;
+  workgroupBarrier();
+
+  let batch = dependencyBatches[candidateBatchIds[workgroupId.y]];
+  if (localId.x < batch.count) {
+    let index = batch.firstIndex + localId.x;
+    let dependency = dependencies[index];
+    let projectedSource = resolveVisibleAncestor(dependency.sourceIndex);
+    let projectedDestination = resolveVisibleAncestor(dependency.destinationIndex);
+    let sourceProcessIndex =
+      (dependency.flags >> ${TRACE_DEPENDENCY_SOURCE_PROCESS_SHIFT}u) &
+      ${TRACE_DEPENDENCY_PROCESS_MASK}u;
+    let destinationProcessIndex =
+      (dependency.flags >> ${TRACE_DEPENDENCY_DESTINATION_PROCESS_SHIFT}u) &
+      ${TRACE_DEPENDENCY_PROCESS_MASK}u;
+    let sourceCollapsed = processStates[sourceProcessIndex] == 0u;
+    let destinationCollapsed = processStates[destinationProcessIndex] == 0u;
+    let familyVisible = (viewUniforms.dependencyMask & (1u << dependency.family)) != 0u;
+    let sourceVisible =
+      spanVisibility[dependency.sourceIndex] == viewUniforms.visibilityGeneration || sourceCollapsed ||
+      projectedSource != 0xffffffffu;
+    let destinationVisible =
+      spanVisibility[dependency.destinationIndex] == viewUniforms.visibilityGeneration ||
+      destinationCollapsed || projectedDestination != 0xffffffffu;
+    let effectiveSource = select(projectedSource, dependency.sourceIndex, sourceCollapsed);
+    let effectiveDestination = select(
+      projectedDestination,
+      dependency.destinationIndex,
+      destinationCollapsed
+    );
+    let visible = familyVisible && sourceVisible && destinationVisible &&
+      effectiveSource != effectiveDestination && !isDensityMode();
+    dependencyResults[index] = select(0u, 1u, visible);
+    let endpointResultOffset = viewUniforms.dependencyEndpointOffset + index * 2u;
+    dependencyResults[endpointResultOffset] = effectiveSource;
+    dependencyResults[endpointResultOffset + 1u] = effectiveDestination;
+    if (visible) {
+      let sourceChunkIndex = getSpanChunkIndex(effectiveSource);
+      let destinationChunkIndex = getSpanChunkIndex(effectiveDestination);
+      if (sourceChunkIndex != INVALID_CHUNK_INDEX) {
+        atomicAdd(&localChunkCounts[sourceChunkIndex], 1u);
+      }
+      if (destinationChunkIndex != INVALID_CHUNK_INDEX) {
+        atomicAdd(&localChunkCounts[destinationChunkIndex], 1u);
+      }
+    }
+  }
+  workgroupBarrier();
+
+  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
+    atomicAdd(&endpointChunkState[chunkIndex], atomicLoad(&localChunkCounts[chunkIndex]));
+  }
 }`;
 }
 
@@ -879,57 +902,6 @@ const CHUNK_COUNT: u32 = ${chunkCount}u;
 fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   if (globalId.x < CHUNK_COUNT) {
     atomicStore(&endpointChunkState[globalId.x], 0u);
-  }
-}`;
-}
-
-/** Counts visible dependency endpoints per bounded source span chunk. */
-export function getCandidateDependencyEndpointCountShader(
-  props: TraceDependencyEndpointRoutingShaderProps
-): string {
-  return /* wgsl */ `
-${getDependencyEndpointRoutingDeclarations(props)}
-struct DependencyBatch {
-  firstIndex: u32,
-  count: u32,
-  timeMin: f32,
-  timeMax: f32,
-  familyMask: u32,
-  batchIndex: u32,
-};
-@group(0) @binding(0) var<storage, read> dependencyBatches: array<DependencyBatch>;
-@group(0) @binding(1) var<storage, read> candidateBatchIds: array<u32>;
-@group(0) @binding(2) var<storage, read> dependencyResults: array<u32>;
-@group(0) @binding(3) var<storage, read_write> endpointChunkState: array<atomic<u32>>;
-var<workgroup> localChunkCounts: array<atomic<u32>, ${props.spanChunks.length}>;
-
-@compute @workgroup_size(${TRACE_DEPENDENCY_BATCH_CAPACITY})
-fn main(
-  @builtin(local_invocation_id) localId: vec3<u32>,
-  @builtin(workgroup_id) workgroupId: vec3<u32>
-) {
-  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
-    atomicStore(&localChunkCounts[chunkIndex], 0u);
-  }
-  workgroupBarrier();
-
-  let batch = dependencyBatches[candidateBatchIds[workgroupId.y]];
-  if (localId.x < batch.count) {
-    let dependencyIndex = batch.firstIndex + localId.x;
-    if (dependencyResults[dependencyIndex] != 0u) {
-      let endpointResultOffset = DEPENDENCY_COUNT + dependencyIndex * 2u;
-      for (var endpointIndex = 0u; endpointIndex < 2u; endpointIndex++) {
-        let chunkIndex = getSpanChunkIndex(dependencyResults[endpointResultOffset + endpointIndex]);
-        if (chunkIndex != INVALID_CHUNK_INDEX) {
-          atomicAdd(&localChunkCounts[chunkIndex], 1u);
-        }
-      }
-    }
-  }
-  workgroupBarrier();
-
-  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
-    atomicAdd(&endpointChunkState[chunkIndex], atomicLoad(&localChunkCounts[chunkIndex]));
   }
 }`;
 }

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -39,13 +39,17 @@ import {
 import {
   getBatchVisibilityShader,
   getCandidateDensityShader,
-  getCandidateDependencyEndpointsShader,
+  getCandidateDependencyEndpointCountShader,
+  getCandidateDependencyEndpointScatterShader,
   getCandidateDependencyVisibilityShader,
   getCandidatePassDispatchShader,
   getCandidatePickShader,
   getCandidateVisibilityShader,
   getDensityClearShader,
   getDependencyBatchVisibilityShader,
+  getDependencyEndpointDispatchShader,
+  getDependencyEndpointResolveShader,
+  getDependencyEndpointRouteClearShader,
   getFocusFrontierClearShader,
   getFocusFrontierDispatchShader,
   getFocusFrontierExpansionShader,
@@ -266,6 +270,13 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     firstBatchIndex: 0,
     batchCount: 3
   };
+  const endpointRouting = {
+    dependencyCount: 7,
+    spanChunks: [
+      {...spanChunk, spanCount: 6, batchCount: 2},
+      {firstSpanIndex: 6, spanCount: 5, firstBatchIndex: 2, batchCount: 1}
+    ]
+  };
   const shaders = [
     TRACE_RENDER_SHADER,
     TRACE_DEPENDENCY_RENDER_SHADER,
@@ -282,7 +293,12 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
       {firstBatchIndex: 2, batchCount: 1}
     ]),
     getDependencyBatchVisibilityShader(3),
-    getCandidateDependencyEndpointsShader(spanChunk),
+    getDependencyEndpointRouteClearShader(endpointRouting.spanChunks.length),
+    getCandidateDependencyEndpointCountShader(endpointRouting),
+    getDependencyEndpointDispatchShader(endpointRouting.spanChunks.length),
+    getCandidateDependencyEndpointScatterShader(endpointRouting),
+    getDependencyEndpointResolveShader(endpointRouting, 0),
+    getDependencyEndpointResolveShader(endpointRouting, 1),
     getCandidateDependencyVisibilityShader(11),
     getFocusFrontierSeedShader(11),
     getFocusFrontierClearShader(),
@@ -297,8 +313,12 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     }),
     getFocusFrontierDispatchShader()
   ];
-  for (const shader of shaders) {
-    t.ok(new WgslReflect(shader), 'shader parses');
+  for (const [shaderIndex, shader] of shaders.entries()) {
+    try {
+      t.ok(new WgslReflect(shader), 'shader parses');
+    } catch (error) {
+      throw new Error(`shader ${shaderIndex} failed to parse`, {cause: error});
+    }
   }
   t.end();
 });

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -39,7 +39,6 @@ import {
 import {
   getBatchVisibilityShader,
   getCandidateDensityShader,
-  getCandidateDependencyEndpointCountShader,
   getCandidateDependencyEndpointScatterShader,
   getCandidateDependencyVisibilityShader,
   getCandidatePassDispatchShader,
@@ -294,12 +293,11 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     ]),
     getDependencyBatchVisibilityShader(3),
     getDependencyEndpointRouteClearShader(endpointRouting.spanChunks.length),
-    getCandidateDependencyEndpointCountShader(endpointRouting),
     getDependencyEndpointDispatchShader(endpointRouting.spanChunks.length),
     getCandidateDependencyEndpointScatterShader(endpointRouting),
     getDependencyEndpointResolveShader(endpointRouting, 0),
     getDependencyEndpointResolveShader(endpointRouting, 1),
-    getCandidateDependencyVisibilityShader(11),
+    getCandidateDependencyVisibilityShader(endpointRouting),
     getFocusFrontierSeedShader(11),
     getFocusFrontierClearShader(),
     getFocusFrontierExpansionShader({


### PR DESCRIPTION
## What changed

- route visible dependency endpoints into a compact, chunk-partitioned GPU worklist
- count and scatter endpoint jobs with workgroup-local atomics
- publish per-chunk indirect dispatch commands and resolve each endpoint exactly once
- support byte offsets for indirect compute dispatches
- extend WGSL parsing coverage across the routing pipeline

## Why

The previous multi-chunk path scanned every candidate dependency batch once for every span chunk. At 10M spans, that duplicated endpoint-resolution work as chunk count grew. This changes the cost to two candidate scans plus one resolution per visible endpoint, independent of span chunk count.

## Validation

- focused GPU trace viewer node/WGSL suite: 14/14 passed
- Biome check/write on the three changed files: passed
- live hardware WebGPU run: 10,000,000 spans, 5 span chunks, 250,000 dependencies, zero browser/WebGPU errors
- `git diff --check`: passed
- `yarn lint fix`: attempted; unavailable because the shared local dependency install predates the current `@vis.gl/dev-tools` command wiring (`ocular-lint` not found)
- `yarn build`: attempted; same stale dependency install (`ocular-clean` not found)
- `yarn test`: attempted; same stale dependency install (`ocular-test` not found)

CI will run the full gates from a clean install.
