### PR TITLE
feat(effects): cinematic bloom with fused WebGPU and FFT optics

### DIFF
--- a/docs/api-guide/shaders/shader-passes.md
+++ b/docs/api-guide/shaders/shader-passes.md
@@ -276,10 +276,22 @@ to explicitly trade edge quality for fewer shaded pixels and smaller history tex
 4. Apply the adapted exposure to HDR scene color or visualize luminance as a false-color heat map.
 
 Pair it with `createBloomShaderPassPipeline()`, which extracts HDR highlights at half resolution,
-then successively filters and blurs them at quarter and eighth resolution using `rgba16float`
-intermediate targets. Its optional `resolutionScale` controls the entire pyramid without clamping
-highlight radiance to 8-bit normalized color. Use the exact HDR order: temporal effects, auto
-exposure, bloom, then tone mapping.
+then progressively filters, blurs, and reconstructs two to five `rgba16float` pyramid levels.
+`quality: 'ultra'` reaches one-thirty-second resolution. `resolutionScale` controls the entire
+pyramid without clamping highlight radiance to 8-bit normalized color.
+
+Enable optional photographic optics through `lens`: aperture-diffraction starbursts, mirrored
+chromatic ghosts, and radial halos share one extra half-resolution pass. `lens.dirtIntensity`
+samples an application-provided `lensDirtTexture` during the existing composite and therefore adds
+no pass or intermediate render target. Pass that mask through
+`renderer.renderToScreen({sourceTexture, bindings: {lensDirtTexture}})`.
+
+`temporalStability` enables neighborhood-clamped, persistent half-resolution glow history for one
+additional pass. The default configuration allocates neither history nor lens artifacts. Baseline
+quality presets use 8, 12, 16, and 20 passes for low, medium, high, and ultra respectively;
+diffraction costs eight samples per ray, while each ghost costs one sample or three when chromatic
+aberration is enabled. Use the exact HDR order: temporal effects, auto exposure, bloom, then tone
+mapping.
 
 ### Recommended ordering
 

--- a/docs/api-guide/shaders/shader-passes.md
+++ b/docs/api-guide/shaders/shader-passes.md
@@ -40,7 +40,11 @@ It always exposes two logical texture sources:
 
 Pipelines may add named render targets. The renderer validates routing, manages
 their size, and prevents a subpass from reading and writing the same named
-target in one draw.
+target in one draw. Transient targets with non-overlapping lifetimes can set
+`aliasFor` to reuse an earlier allocation with identical dimensions, format, and sampler;
+persistent history targets cannot be aliased. Pipelines can also declare an optional WebGPU
+compute replacement while retaining equivalent fragment steps as the WebGL or unsupported-device
+fallback.
 
 Built-in effects consume `previous`, so the `shaderPasses` array has strict
 ordered-composition semantics even when it mixes plain `ShaderPass` objects and
@@ -278,7 +282,23 @@ to explicitly trade edge quality for fewer shaded pixels and smaller history tex
 Pair it with `createBloomShaderPassPipeline()`, which extracts HDR highlights at half resolution,
 then progressively filters, blurs, and reconstructs two to five `rgba16float` pyramid levels.
 `quality: 'ultra'` reaches one-thirty-second resolution. `resolutionScale` controls the entire
-pyramid without clamping highlight radiance to 8-bit normalized color.
+pyramid without clamping highlight radiance to 8-bit normalized color. `exposure` and
+`exposureCompensation` keep highlight thresholds aligned with camera adaptation, while
+`reconstruction: 'bicubic'` selects a normalized four-fetch B-spline instead of the default
+nine-tap tent.
+
+`downsample: 'auto'` fuses extraction and the complete downsampling pyramid into one WebGPU
+compute dispatch when the chosen format supports storage writes and the device has enough storage
+bindings. `downsample: 'render'` forces the portable fragment implementation. Expired extraction
+textures are reused for reconstruction by default; set `reuseRenderTargets: false` to retain
+separate allocations for inspection.
+
+| Quality | Portable render passes | WebGPU fused work | Physical targets with reuse |
+| --- | --- | --- | --- |
+| `low` | 8 | 6 render + 1 compute | 6 |
+| `medium` | 12 | 9 render + 1 compute | 9 |
+| `high` | 16 | 12 render + 1 compute | 12 |
+| `ultra` | 20 | 15 render + 1 compute | 15 |
 
 Enable optional photographic optics through `lens`: aperture-diffraction starbursts, mirrored
 chromatic ghosts, and radial halos share one extra half-resolution pass. `lens.dirtIntensity`
@@ -287,11 +307,12 @@ no pass or intermediate render target. Pass that mask through
 `renderer.renderToScreen({sourceTexture, bindings: {lensDirtTexture}})`.
 
 `temporalStability` enables neighborhood-clamped, persistent half-resolution glow history for one
-additional pass. The default configuration allocates neither history nor lens artifacts. Baseline
-quality presets use 8, 12, 16, and 20 passes for low, medium, high, and ultra respectively;
+additional pass. The default configuration allocates neither history nor lens artifacts. Screen-space
 diffraction costs eight samples per ray, while each ghost costs one sample or three when chromatic
-aberration is enabled. Use the exact HDR order: temporal effects, auto exposure, bloom, then tone
-mapping.
+aberration is enabled. Applications that require true aperture convolution can instead use
+`GPUConvolutionBloom` from `@luma.gl/experimental`, which performs independent RGB FFT transforms,
+caches an energy-normalized point-spread spectrum, and exposes exact memory/dispatch costs through
+`stats`. Use the HDR order: temporal effects, auto exposure, bloom, then tone mapping.
 
 ### Recommended ordering
 

--- a/examples/experimental/bloom/app.ts
+++ b/examples/experimental/bloom/app.ts
@@ -22,7 +22,8 @@ import {
 } from '../../example-panels';
 
 export const title = 'Bloom';
-export const description = 'Compare compact and HDR multiscale bloom on an animated HDR scene.';
+export const description =
+  'Explore HDR bloom, spectral lens flares, diffraction streaks, and textured lens dirt.';
 
 const BLOOM_TECHNIQUES = ['Multiscale HDR', 'Compact', 'Off'] as const;
 const BLOOM_QUALITIES = ['low', 'medium', 'high', 'ultra'] as const;
@@ -39,6 +40,18 @@ type BloomSettings = {
   softKnee: number;
   fireflyReduction: number;
   anamorphicRatio: number;
+  temporalStability: number;
+  starburstIntensity: number;
+  starburstSpikes: number;
+  starburstLength: number;
+  starburstRotation: number;
+  ghostIntensity: number;
+  ghostCount: number;
+  ghostSpacing: number;
+  haloIntensity: number;
+  haloRadius: number;
+  chromaticAberration: number;
+  dirtIntensity: number;
   animate: boolean;
 };
 type SceneUniforms = {
@@ -56,13 +69,26 @@ const DEFAULT_SETTINGS: BloomSettings = {
   scatter: 0.55,
   softKnee: 0.5,
   fireflyReduction: 0.15,
-  anamorphicRatio: 0,
+  anamorphicRatio: 0.2,
+  temporalStability: 0.58,
+  starburstIntensity: 0.72,
+  starburstSpikes: 4,
+  starburstLength: 52,
+  starburstRotation: 0.16,
+  ghostIntensity: 0.34,
+  ghostCount: 3,
+  ghostSpacing: 0.32,
+  haloIntensity: 0.24,
+  haloRadius: 0.32,
+  chromaticAberration: 0.44,
+  dirtIntensity: 0.42,
   animate: true
 };
 
 const BLOOM_BACKGROUND_HTML = `
 <p><b>Multiscale HDR bloom:</b> bright scene radiance is extracted once, filtered across an adaptive two-to-five-level pyramid, then progressively reconstructed before presentation. Normalized upsampling keeps the glow stable as wider levels are combined.</p>
-<p><b>Cinematic controls:</b> scatter balances tight highlights against broad glow, a soft knee smooths threshold transitions, firefly reduction stabilizes isolated HDR samples, and anamorphic ratio stretches the bloom horizontally or vertically.</p>
+<p><b>Lens optics:</b> one optional half-resolution pass adds adjustable aperture-diffraction streaks, chromatic lens-element ghosts, and a radial halo. A sampled dirt mask reuses the existing bloom composite without adding a pass.</p>
+<p><b>Stability and cost:</b> neighborhood-clamped glow history reduces highlight shimmer for one extra half-resolution pass. Diffraction cost grows with the number of rays; ghosts scale with their reflection count and spectral separation.</p>
 <p><b>Compact bloom:</b> the legacy single-pass glow samples one small neighborhood directly from the source image. It is cheaper, but it cannot spread highlights as naturally as the multiscale pyramid.</p>
 <p><b>Scene setup:</b> this page renders animated HDR emitters into an offscreen texture before bloom. The previous static image hid the useful part of the effect by baking most of the lighting into SDR pixels.</p>
 `;
@@ -301,6 +327,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   });
   readonly sceneModel: ClipSpace;
   readonly sceneColorTexture: Texture;
+  readonly lensDirtTexture: Texture;
   readonly sceneFramebuffer: Framebuffer;
   readonly settingsPanel: ExampleSettingsPanelManager;
   readonly panels: ExamplePanelManager;
@@ -326,6 +353,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
       format: this.colorFormat,
       usage: Texture.RENDER | Texture.SAMPLE
     });
+    this.lensDirtTexture = makeLensDirtTexture(device);
     this.sceneFramebuffer = device.createFramebuffer({
       id: 'bloom-hdr-scene-framebuffer',
       width,
@@ -348,6 +376,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.panels.finalize();
     this.sceneFramebuffer.destroy();
     this.sceneColorTexture.destroy();
+    this.lensDirtTexture.destroy();
     this.sceneModel.destroy();
     this.sceneShaderInputs.destroy();
     this.shaderPassRenderer?.destroy();
@@ -374,7 +403,11 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
     this.shaderPassRenderer.renderToScreen({
       sourceTexture: this.sceneFramebuffer.colorAttachments[0].texture,
-      uniforms: this.getRenderUniforms()
+      uniforms: this.getRenderUniforms(),
+      bindings:
+        this.settings.technique === 'Multiscale HDR' && this.settings.dirtIntensity > 0
+          ? {lensDirtTexture: this.lensDirtTexture}
+          : undefined
     });
   }
 
@@ -399,7 +432,21 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           scatter: this.settings.scatter,
           softKnee: this.settings.softKnee,
           fireflyReduction: this.settings.fireflyReduction,
-          anamorphicRatio: this.settings.anamorphicRatio
+          anamorphicRatio: this.settings.anamorphicRatio,
+          temporalStability: this.settings.temporalStability,
+          lens: {
+            starburstIntensity: this.settings.starburstIntensity,
+            starburstSpikes: this.settings.starburstSpikes,
+            starburstLength: this.settings.starburstLength,
+            starburstRotation: this.settings.starburstRotation,
+            ghostIntensity: this.settings.ghostIntensity,
+            ghostCount: this.settings.ghostCount,
+            ghostSpacing: this.settings.ghostSpacing,
+            haloIntensity: this.settings.haloIntensity,
+            haloRadius: this.settings.haloRadius,
+            chromaticAberration: this.settings.chromaticAberration,
+            dirtIntensity: this.settings.dirtIntensity
+          }
         })
       );
     } else if (this.settings.technique === 'Compact') {
@@ -479,6 +526,54 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         typeof settings['anamorphicRatio'] === 'number'
           ? clampNumber(settings['anamorphicRatio'], -1, 1)
           : this.settings.anamorphicRatio,
+      temporalStability:
+        typeof settings['temporalStability'] === 'number'
+          ? clampNumber(settings['temporalStability'], 0, 0.95)
+          : this.settings.temporalStability,
+      starburstIntensity:
+        typeof settings['starburstIntensity'] === 'number'
+          ? clampNumber(settings['starburstIntensity'], 0, 3)
+          : this.settings.starburstIntensity,
+      starburstSpikes:
+        typeof settings['starburstSpikes'] === 'number'
+          ? clampNumber(settings['starburstSpikes'], 2, 8)
+          : this.settings.starburstSpikes,
+      starburstLength:
+        typeof settings['starburstLength'] === 'number'
+          ? clampNumber(settings['starburstLength'], 0, 128)
+          : this.settings.starburstLength,
+      starburstRotation:
+        typeof settings['starburstRotation'] === 'number'
+          ? clampNumber(settings['starburstRotation'], 0, Math.PI)
+          : this.settings.starburstRotation,
+      ghostIntensity:
+        typeof settings['ghostIntensity'] === 'number'
+          ? clampNumber(settings['ghostIntensity'], 0, 3)
+          : this.settings.ghostIntensity,
+      ghostCount:
+        typeof settings['ghostCount'] === 'number'
+          ? clampNumber(settings['ghostCount'], 1, 6)
+          : this.settings.ghostCount,
+      ghostSpacing:
+        typeof settings['ghostSpacing'] === 'number'
+          ? clampNumber(settings['ghostSpacing'], 0, 1)
+          : this.settings.ghostSpacing,
+      haloIntensity:
+        typeof settings['haloIntensity'] === 'number'
+          ? clampNumber(settings['haloIntensity'], 0, 3)
+          : this.settings.haloIntensity,
+      haloRadius:
+        typeof settings['haloRadius'] === 'number'
+          ? clampNumber(settings['haloRadius'], 0, 1)
+          : this.settings.haloRadius,
+      chromaticAberration:
+        typeof settings['chromaticAberration'] === 'number'
+          ? clampNumber(settings['chromaticAberration'], 0, 1)
+          : this.settings.chromaticAberration,
+      dirtIntensity:
+        typeof settings['dirtIntensity'] === 'number'
+          ? clampNumber(settings['dirtIntensity'], 0, 3)
+          : this.settings.dirtIntensity,
       animate:
         typeof settings['animate'] === 'boolean' ? settings['animate'] : this.settings.animate
     };
@@ -499,11 +594,22 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
           : 'The final result uses standard dynamic-range presentation.';
     const techniqueDescription =
       this.settings.technique === 'Multiscale HDR'
-        ? 'Multiscale HDR is the default because it is the reusable public pipeline with smoother wide-radius glow.'
+        ? 'Multiscale HDR combines reusable wide-radius glow with optional photographic lens optics.'
         : this.settings.technique === 'Compact'
           ? 'Compact mode shows the older single-pass effect for direct comparison.'
           : 'Bloom is off so the underlying HDR emitters stay visible without postprocessing.';
-    return `<p>${techniqueDescription}</p><p>${processingDescription}</p><p>${presentationDescription}</p>`;
+    const levelCount = BLOOM_QUALITIES.indexOf(this.settings.quality) + 2;
+    const hasLensArtifacts =
+      this.settings.starburstIntensity > 0 ||
+      this.settings.ghostIntensity > 0 ||
+      this.settings.haloIntensity > 0;
+    const passCount =
+      levelCount * 4 + Number(hasLensArtifacts) + Number(this.settings.temporalStability > 0);
+    const performanceDescription =
+      this.settings.technique === 'Multiscale HDR'
+        ? `Current budget: ${passCount} passes across ${levelCount} pyramid levels. Lens optics share ${hasLensArtifacts ? 'one half-resolution pass' : 'no extra pass'}; lens dirt adds no pass.`
+        : 'Switch to Multiscale HDR to inspect the live optical-pass budget.';
+    return `<p>${techniqueDescription}</p><p>${processingDescription}</p><p>${performanceDescription}</p><p>${presentationDescription}</p>`;
   }
 }
 
@@ -620,15 +726,178 @@ export function makeBloomSettingsSchema(): SettingsSchema {
             step: 0.05
           },
           {
+            name: 'temporalStability',
+            label: 'Temporal Stability',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 0.95,
+            step: 0.05
+          },
+          {
             name: 'animate',
             label: 'Animate Scene',
             type: 'boolean',
             persist: 'none'
           }
         ]
+      },
+      {
+        id: 'lens-optics',
+        name: 'Lens Optics',
+        initiallyCollapsed: false,
+        settings: [
+          {
+            name: 'starburstIntensity',
+            label: 'Starburst Intensity',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 3,
+            step: 0.05
+          },
+          {
+            name: 'starburstSpikes',
+            label: 'Diffraction Rays',
+            type: 'number',
+            persist: 'none',
+            min: 2,
+            max: 8,
+            step: 2
+          },
+          {
+            name: 'starburstLength',
+            label: 'Diffraction Length',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 128,
+            step: 2
+          },
+          {
+            name: 'starburstRotation',
+            label: 'Diffraction Rotation',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: Math.PI,
+            step: 0.05
+          },
+          {
+            name: 'ghostIntensity',
+            label: 'Spectral Ghosts',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 3,
+            step: 0.05
+          },
+          {
+            name: 'ghostCount',
+            label: 'Ghost Reflections',
+            type: 'number',
+            persist: 'none',
+            min: 1,
+            max: 6,
+            step: 1
+          },
+          {
+            name: 'ghostSpacing',
+            label: 'Ghost Spacing',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1,
+            step: 0.05
+          },
+          {
+            name: 'haloIntensity',
+            label: 'Lens Halo',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 3,
+            step: 0.05
+          },
+          {
+            name: 'haloRadius',
+            label: 'Halo Radius',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1,
+            step: 0.05
+          },
+          {
+            name: 'chromaticAberration',
+            label: 'Spectral Separation',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 1,
+            step: 0.05
+          },
+          {
+            name: 'dirtIntensity',
+            label: 'Lens Dirt',
+            type: 'number',
+            persist: 'none',
+            min: 0,
+            max: 3,
+            step: 0.05
+          }
+        ]
       }
     ]
   };
+}
+
+function makeLensDirtTexture(device: Device): Texture {
+  const width = 192;
+  const height = 192;
+  const pixels = new Uint8Array(width * height * 4);
+  const smudges = [
+    {position: [0.18, 0.29], radius: 0.11, intensity: 0.48},
+    {position: [0.34, 0.74], radius: 0.16, intensity: 0.38},
+    {position: [0.69, 0.18], radius: 0.13, intensity: 0.58},
+    {position: [0.77, 0.64], radius: 0.19, intensity: 0.42},
+    {position: [0.49, 0.44], radius: 0.085, intensity: 0.32}
+  ];
+
+  for (let pixelY = 0; pixelY < height; pixelY++) {
+    for (let pixelX = 0; pixelX < width; pixelX++) {
+      const coordinateX = (pixelX + 0.5) / width;
+      const coordinateY = (pixelY + 0.5) / height;
+      let dirt = 0;
+      for (const smudge of smudges) {
+        const distanceX = coordinateX - smudge.position[0];
+        const distanceY = coordinateY - smudge.position[1];
+        const distanceSquared = distanceX * distanceX + distanceY * distanceY;
+        dirt += smudge.intensity * Math.exp(-distanceSquared / (smudge.radius * smudge.radius));
+      }
+
+      const grain = (((pixelX * 73856093) ^ (pixelY * 19349663)) >>> 0) / 4294967295;
+      const scratch =
+        Math.exp(-Math.abs(coordinateY - (0.15 + coordinateX * 0.085)) * 150) *
+        (0.25 + grain * 0.4);
+      dirt = Math.min(dirt + scratch + Math.max(grain - 0.985, 0) * 9, 1);
+      const pixelOffset = (pixelY * width + pixelX) * 4;
+      pixels[pixelOffset] = Math.round(dirt * 255);
+      pixels[pixelOffset + 1] = Math.round(dirt * 232);
+      pixels[pixelOffset + 2] = Math.round(dirt * 208);
+      pixels[pixelOffset + 3] = 255;
+    }
+  }
+
+  return device.createTexture({
+    id: 'bloom-lens-dirt-mask',
+    width,
+    height,
+    data: pixels,
+    format: 'rgba8unorm',
+    usage: Texture.SAMPLE | Texture.COPY_DST,
+    sampler: {minFilter: 'linear', magFilter: 'linear'}
+  });
 }
 
 function makeBloomSettingsState(settings: BloomSettings): SettingsState {

--- a/examples/experimental/bloom/app.ts
+++ b/examples/experimental/bloom/app.ts
@@ -11,6 +11,7 @@ import {
   ShaderInputs,
   ShaderPassRenderer
 } from '@luma.gl/engine';
+import {getGPUConvolutionBloomSupport, GPUConvolutionBloom} from '@luma.gl/experimental';
 import type {ShaderModule, ShaderPass, ShaderPassPipeline} from '@luma.gl/shadertools';
 import {type Panel, type SettingsSchema, type SettingsState} from '@deck.gl-community/panels';
 import {
@@ -25,21 +26,31 @@ export const title = 'Bloom';
 export const description =
   'Explore HDR bloom, spectral lens flares, diffraction streaks, and textured lens dirt.';
 
-const BLOOM_TECHNIQUES = ['Multiscale HDR', 'Compact', 'Off'] as const;
+const BLOOM_TECHNIQUES = ['Multiscale HDR', 'FFT Convolution', 'Compact', 'Off'] as const;
 const BLOOM_QUALITIES = ['low', 'medium', 'high', 'ultra'] as const;
+const BLOOM_RECONSTRUCTION_MODES = ['tent', 'bicubic'] as const;
+const BLOOM_DOWNSAMPLE_MODES = ['auto', 'render', 'compute'] as const;
 
 type BloomTechnique = (typeof BLOOM_TECHNIQUES)[number];
 type BloomQuality = (typeof BLOOM_QUALITIES)[number];
+type BloomReconstruction = (typeof BLOOM_RECONSTRUCTION_MODES)[number];
+type BloomDownsample = (typeof BLOOM_DOWNSAMPLE_MODES)[number];
 type BloomSettings = {
   technique: BloomTechnique;
   quality: BloomQuality;
   threshold: number;
+  exposure: number;
+  exposureCompensation: number;
   intensity: number;
   radius: number;
+  resolutionScale: number;
   scatter: number;
   softKnee: number;
   fireflyReduction: number;
   anamorphicRatio: number;
+  reconstruction: BloomReconstruction;
+  downsample: BloomDownsample;
+  reuseRenderTargets: boolean;
   temporalStability: number;
   starburstIntensity: number;
   starburstSpikes: number;
@@ -64,12 +75,18 @@ const DEFAULT_SETTINGS: BloomSettings = {
   technique: 'Multiscale HDR',
   quality: 'high',
   threshold: 0.8,
+  exposure: 1,
+  exposureCompensation: 0,
   intensity: 1.35,
   radius: 12,
+  resolutionScale: 1,
   scatter: 0.55,
   softKnee: 0.5,
   fireflyReduction: 0.15,
   anamorphicRatio: 0.2,
+  reconstruction: 'bicubic',
+  downsample: 'auto',
+  reuseRenderTargets: true,
   temporalStability: 0.58,
   starburstIntensity: 0.72,
   starburstSpikes: 4,
@@ -86,7 +103,8 @@ const DEFAULT_SETTINGS: BloomSettings = {
 };
 
 const BLOOM_BACKGROUND_HTML = `
-<p><b>Multiscale HDR bloom:</b> bright scene radiance is extracted once, filtered across an adaptive two-to-five-level pyramid, then progressively reconstructed before presentation. Normalized upsampling keeps the glow stable as wider levels are combined.</p>
+<p><b>Multiscale HDR bloom:</b> exposure-aware highlight extraction feeds an adaptive two-to-five-level pyramid. Supported WebGPU devices fuse every downsampling level into one compute dispatch, and expired extraction textures are reused during reconstruction.</p>
+<p><b>FFT convolution:</b> premium WebGPU optics transform each color channel into the frequency domain, multiply it by a cached aperture point-spread function, and reconstruct energy-conserving diffraction. The transform runs at one quarter of the selected processing resolution.</p>
 <p><b>Lens optics:</b> one optional half-resolution pass adds adjustable aperture-diffraction streaks, chromatic lens-element ghosts, and a radial halo. A sampled dirt mask reuses the existing bloom composite without adding a pass.</p>
 <p><b>Stability and cost:</b> neighborhood-clamped glow history reduces highlight shimmer for one extra half-resolution pass. Diffraction cost grows with the number of rays; ghosts scale with their reflection count and spectral separation.</p>
 <p><b>Compact bloom:</b> the legacy single-pass glow samples one small neighborhood directly from the source image. It is cheaper, but it cannot spread highlights as naturally as the multiscale pyramid.</p>
@@ -333,6 +351,8 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   readonly panels: ExamplePanelManager;
   settings: BloomSettings = {...DEFAULT_SETTINGS};
   shaderPassRenderer!: ShaderPassRenderer;
+  convolutionBloom?: GPUConvolutionBloom;
+  convolutionOutputTexture?: Texture;
 
   constructor({device, width, height}: AnimationProps) {
     super();
@@ -380,6 +400,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.sceneModel.destroy();
     this.sceneShaderInputs.destroy();
     this.shaderPassRenderer?.destroy();
+    this.destroyConvolutionBloom();
   }
 
   onRender({device, width, height, time}: AnimationProps): void {
@@ -401,11 +422,28 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     this.sceneModel.draw(sceneRenderPass);
     sceneRenderPass.end();
 
+    let sourceTexture = this.sceneFramebuffer.colorAttachments[0].texture;
+    if (this.settings.technique === 'FFT Convolution') {
+      const convolutionBloom = this.getConvolutionBloom(width, height);
+      if (convolutionBloom && this.convolutionOutputTexture) {
+        sourceTexture = convolutionBloom.encode(device.commandEncoder, {
+          sourceTexture,
+          outputTexture: this.convolutionOutputTexture,
+          threshold: this.settings.threshold,
+          intensity: this.settings.intensity,
+          exposure: this.settings.exposure,
+          exposureCompensation: this.settings.exposureCompensation
+        });
+      }
+    }
+
     this.shaderPassRenderer.renderToScreen({
-      sourceTexture: this.sceneFramebuffer.colorAttachments[0].texture,
+      sourceTexture,
       uniforms: this.getRenderUniforms(),
       bindings:
-        this.settings.technique === 'Multiscale HDR' && this.settings.dirtIntensity > 0
+        (this.settings.technique === 'Multiscale HDR' ||
+          (this.settings.technique === 'FFT Convolution' && !this.convolutionBloom)) &&
+        this.settings.dirtIntensity > 0
           ? {lensDirtTexture: this.lensDirtTexture}
           : undefined
     });
@@ -413,6 +451,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
   setShaderPasses(shaderPasses: ShaderPassLike[]): void {
     this.shaderPassRenderer?.destroy();
+    this.destroyConvolutionBloom();
     this.shaderPassRenderer = new ShaderPassRenderer(this.device, {
       shaderPasses,
       colorFormat: this.colorFormat
@@ -421,18 +460,29 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
   getShaderPasses(): ShaderPassLike[] {
     const shaderPasses: ShaderPassLike[] = [];
-    if (this.settings.technique === 'Multiscale HDR') {
+    if (
+      this.settings.technique === 'Multiscale HDR' ||
+      (this.settings.technique === 'FFT Convolution' &&
+        !this.getConvolutionSupport(this.sceneFramebuffer.width, this.sceneFramebuffer.height)
+          .supported)
+    ) {
       shaderPasses.push(
         createBloomShaderPassPipeline({
           colorFormat: this.colorFormat,
           threshold: this.settings.threshold,
+          exposure: this.settings.exposure,
+          exposureCompensation: this.settings.exposureCompensation,
           intensity: this.settings.intensity,
           radius: this.settings.radius,
+          resolutionScale: this.settings.resolutionScale,
           quality: this.settings.quality,
           scatter: this.settings.scatter,
           softKnee: this.settings.softKnee,
           fireflyReduction: this.settings.fireflyReduction,
           anamorphicRatio: this.settings.anamorphicRatio,
+          reconstruction: this.settings.reconstruction,
+          downsample: this.settings.downsample,
+          reuseRenderTargets: this.settings.reuseRenderTargets,
           temporalStability: this.settings.temporalStability,
           lens: {
             starburstIntensity: this.settings.starburstIntensity,
@@ -471,6 +521,50 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     };
   }
 
+  private getConvolutionBloom(width: number, height: number): GPUConvolutionBloom | undefined {
+    const support = this.getConvolutionSupport(width, height);
+    if (!support.supported || this.colorFormat !== 'rgba16float') {
+      return undefined;
+    }
+    if (this.convolutionBloom?.width === width && this.convolutionBloom.height === height) {
+      return this.convolutionBloom;
+    }
+
+    this.destroyConvolutionBloom();
+    this.convolutionOutputTexture = this.device.createTexture({
+      id: 'bloom-fft-convolution-output',
+      width,
+      height,
+      format: 'rgba16float',
+      usage: Texture.STORAGE | Texture.SAMPLE
+    });
+    this.convolutionBloom = new GPUConvolutionBloom(this.device, {
+      id: 'bloom-fft-convolution',
+      width,
+      height,
+      resolutionScale: this.settings.resolutionScale * 0.25,
+      apertureBlades: this.settings.starburstSpikes,
+      diffractionStrength: this.settings.starburstIntensity,
+      anamorphicRatio: this.settings.anamorphicRatio
+    });
+    return this.convolutionBloom;
+  }
+
+  private getConvolutionSupport(width: number, height: number) {
+    return getGPUConvolutionBloomSupport(this.device, {
+      width,
+      height,
+      resolutionScale: this.settings.resolutionScale * 0.25
+    });
+  }
+
+  private destroyConvolutionBloom(): void {
+    this.convolutionBloom?.destroy();
+    this.convolutionBloom = undefined;
+    this.convolutionOutputTexture?.destroy();
+    this.convolutionOutputTexture = undefined;
+  }
+
   private makePanel(): Panel {
     return makeExampleTabbedPanel({
       id: 'bloom-tabs',
@@ -502,6 +596,14 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         typeof settings['threshold'] === 'number'
           ? clampNumber(settings['threshold'], 0, 4)
           : this.settings.threshold,
+      exposure:
+        typeof settings['exposure'] === 'number'
+          ? clampNumber(settings['exposure'], 0.05, 8)
+          : this.settings.exposure,
+      exposureCompensation:
+        typeof settings['exposureCompensation'] === 'number'
+          ? clampNumber(settings['exposureCompensation'], -4, 4)
+          : this.settings.exposureCompensation,
       intensity:
         typeof settings['intensity'] === 'number'
           ? clampNumber(settings['intensity'], 0, 4)
@@ -510,6 +612,10 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         typeof settings['radius'] === 'number'
           ? clampNumber(settings['radius'], 0, 24)
           : this.settings.radius,
+      resolutionScale:
+        typeof settings['resolutionScale'] === 'number'
+          ? clampNumber(settings['resolutionScale'], 0.25, 1)
+          : this.settings.resolutionScale,
       scatter:
         typeof settings['scatter'] === 'number'
           ? clampNumber(settings['scatter'], 0, 1)
@@ -526,6 +632,16 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
         typeof settings['anamorphicRatio'] === 'number'
           ? clampNumber(settings['anamorphicRatio'], -1, 1)
           : this.settings.anamorphicRatio,
+      reconstruction: isBloomReconstruction(settings['reconstruction'])
+        ? settings['reconstruction']
+        : this.settings.reconstruction,
+      downsample: isBloomDownsample(settings['downsample'])
+        ? settings['downsample']
+        : this.settings.downsample,
+      reuseRenderTargets:
+        typeof settings['reuseRenderTargets'] === 'boolean'
+          ? settings['reuseRenderTargets']
+          : this.settings.reuseRenderTargets,
       temporalStability:
         typeof settings['temporalStability'] === 'number'
           ? clampNumber(settings['temporalStability'], 0, 0.95)
@@ -595,20 +711,39 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     const techniqueDescription =
       this.settings.technique === 'Multiscale HDR'
         ? 'Multiscale HDR combines reusable wide-radius glow with optional photographic lens optics.'
-        : this.settings.technique === 'Compact'
-          ? 'Compact mode shows the older single-pass effect for direct comparison.'
-          : 'Bloom is off so the underlying HDR emitters stay visible without postprocessing.';
+        : this.settings.technique === 'FFT Convolution'
+          ? 'FFT convolution applies a physically motivated, energy-normalized aperture point-spread function independently to red, green, and blue highlights.'
+          : this.settings.technique === 'Compact'
+            ? 'Compact mode shows the older single-pass effect for direct comparison.'
+            : 'Bloom is off so the underlying HDR emitters stay visible without postprocessing.';
     const levelCount = BLOOM_QUALITIES.indexOf(this.settings.quality) + 2;
     const hasLensArtifacts =
       this.settings.starburstIntensity > 0 ||
       this.settings.ghostIntensity > 0 ||
       this.settings.haloIntensity > 0;
+    const supportsCompute =
+      this.device.type === 'webgpu' &&
+      this.settings.downsample !== 'render' &&
+      this.device.getTextureFormatCapabilities(this.colorFormat).store &&
+      this.device.limits.maxStorageTexturesPerShaderStage >= levelCount;
     const passCount =
-      levelCount * 4 + Number(hasLensArtifacts) + Number(this.settings.temporalStability > 0);
+      levelCount * (supportsCompute ? 3 : 4) +
+      Number(hasLensArtifacts) +
+      Number(this.settings.temporalStability > 0);
+    const computeDescription = supportsCompute ? ' plus one fused compute dispatch' : '';
+    const convolutionSupport = this.getConvolutionSupport(
+      this.sceneFramebuffer.width,
+      this.sceneFramebuffer.height
+    );
+    const convolutionStats = convolutionSupport.stats;
     const performanceDescription =
       this.settings.technique === 'Multiscale HDR'
-        ? `Current budget: ${passCount} passes across ${levelCount} pyramid levels. Lens optics share ${hasLensArtifacts ? 'one half-resolution pass' : 'no extra pass'}; lens dirt adds no pass.`
-        : 'Switch to Multiscale HDR to inspect the live optical-pass budget.';
+        ? `Current budget: ${passCount} render passes${computeDescription} across ${levelCount} pyramid levels. Lens optics share ${hasLensArtifacts ? 'one half-resolution pass' : 'no extra pass'}; lens dirt adds no pass.`
+        : this.settings.technique === 'FFT Convolution'
+          ? convolutionSupport.supported && convolutionStats
+            ? `Premium budget: ${convolutionStats.steadyStateDispatchCount} steady-state compute dispatches at ${convolutionStats.transformWidth} x ${convolutionStats.transformHeight}, with ${(convolutionStats.totalComplexBufferByteLength / (1024 * 1024)).toFixed(1)} MiB of reusable complex buffers. Changing the aperture adds ${convolutionStats.kernelInitializationDispatchCount} one-time kernel dispatches.`
+            : `FFT convolution is unavailable: ${convolutionSupport.reason || 'floating-point storage is unsupported'}. The portable multiscale pipeline remains active.`
+          : 'Switch to Multiscale HDR or FFT Convolution to inspect the live optical budget.';
     return `<p>${techniqueDescription}</p><p>${processingDescription}</p><p>${performanceDescription}</p><p>${presentationDescription}</p>`;
   }
 }
@@ -639,6 +774,11 @@ export function makeBloomSettingsSchema(): SettingsSchema {
                 description: 'Recommended reusable pipeline for broad, smooth glow.'
               },
               {
+                label: 'FFT Convolution',
+                value: 'FFT Convolution',
+                description: 'Premium WebGPU aperture diffraction with exact FFT cost reporting.'
+              },
+              {
                 label: 'Compact',
                 value: 'Compact',
                 description: 'Legacy single-pass highlight glow for comparison.'
@@ -660,6 +800,24 @@ export function makeBloomSettingsSchema(): SettingsSchema {
             step: 0.05
           },
           {
+            name: 'exposure',
+            label: 'Camera Exposure',
+            type: 'number',
+            persist: 'none',
+            min: 0.05,
+            max: 8,
+            step: 0.05
+          },
+          {
+            name: 'exposureCompensation',
+            label: 'Exposure Stops',
+            type: 'number',
+            persist: 'none',
+            min: -4,
+            max: 4,
+            step: 0.25
+          },
+          {
             name: 'quality',
             label: 'Pyramid Quality',
             type: 'select',
@@ -669,6 +827,27 @@ export function makeBloomSettingsSchema(): SettingsSchema {
               {label: 'Medium (3 levels)', value: 'medium'},
               {label: 'High (4 levels)', value: 'high'},
               {label: 'Ultra (5 levels)', value: 'ultra'}
+            ]
+          },
+          {
+            name: 'downsample',
+            label: 'Pyramid Execution',
+            type: 'select',
+            persist: 'none',
+            options: [
+              {label: 'Auto (WebGPU compute)', value: 'auto'},
+              {label: 'Portable render passes', value: 'render'},
+              {label: 'Fused compute', value: 'compute'}
+            ]
+          },
+          {
+            name: 'reconstruction',
+            label: 'Reconstruction',
+            type: 'select',
+            persist: 'none',
+            options: [
+              {label: 'Normalized tent', value: 'tent'},
+              {label: 'Bicubic B-spline', value: 'bicubic'}
             ]
           },
           {
@@ -688,6 +867,21 @@ export function makeBloomSettingsSchema(): SettingsSchema {
             min: 0,
             max: 24,
             step: 1
+          },
+          {
+            name: 'resolutionScale',
+            label: 'Processing Resolution',
+            type: 'number',
+            persist: 'none',
+            min: 0.25,
+            max: 1,
+            step: 0.05
+          },
+          {
+            name: 'reuseRenderTargets',
+            label: 'Reuse Intermediates',
+            type: 'boolean',
+            persist: 'none'
           },
           {
             name: 'scatter',
@@ -910,6 +1104,14 @@ function isBloomTechnique(value: unknown): value is BloomTechnique {
 
 function isBloomQuality(value: unknown): value is BloomQuality {
   return BLOOM_QUALITIES.includes(value as BloomQuality);
+}
+
+function isBloomReconstruction(value: unknown): value is BloomReconstruction {
+  return BLOOM_RECONSTRUCTION_MODES.includes(value as BloomReconstruction);
+}
+
+function isBloomDownsample(value: unknown): value is BloomDownsample {
+  return BLOOM_DOWNSAMPLE_MODES.includes(value as BloomDownsample);
 }
 
 function clampNumber(value: number, minimum: number, maximum: number): number {

--- a/examples/experimental/bloom/package.json
+++ b/examples/experimental/bloom/package.json
@@ -12,6 +12,7 @@
     "@luma.gl/core": "9.4.0-alpha.4",
     "@luma.gl/effects": "9.4.0-alpha.4",
     "@luma.gl/engine": "9.4.0-alpha.4",
+    "@luma.gl/experimental": "9.4.0-alpha.4",
     "@luma.gl/shadertools": "9.4.0-alpha.4",
     "@luma.gl/webgl": "9.4.0-alpha.4",
     "@luma.gl/webgpu": "9.4.0-alpha.4"

--- a/modules/effects/README.md
+++ b/modules/effects/README.md
@@ -40,8 +40,25 @@ in both scenes.
 `createBloomShaderPassPipeline` builds an HDR bloom pyramid with quality presets from two to five
 levels. The pyramid progressively reconstructs its levels with normalized tent filtering; `scatter`,
 `softKnee`, `fireflyReduction`, `anamorphicRatio`, and `tint` control the resulting glow without
-requiring application-owned intermediate textures. The source texture must allow both sampling and,
-when it is produced by an offscreen scene pass, rendering.
+requiring application-owned intermediate textures. Optional `lens` controls add aperture
+diffraction, spectral lens-element ghosts, a radial halo, and sampled lens dirt. Set
+`temporalStability` to accumulate neighborhood-clamped glow history. Every lens feature and temporal
+history is disabled by default. The source texture must allow both sampling and, when it is produced
+by an offscreen scene pass, rendering.
+
+| Feature | Added render passes | Additional targets | Main sampling cost |
+| --- | --- | --- | --- |
+| Base bloom: low / medium / high / ultra | 8 / 12 / 16 / 20 total | 7 / 11 / 15 / 19 | Separable blur and normalized pyramid reconstruction. |
+| Lens dirt | 0 | 0 | One full-resolution mask sample in the existing composite. |
+| Spectral ghosts | 1 shared half-resolution lens pass | 1 half-resolution target | One sample per ghost, or three with chromatic separation. |
+| Lens halo | Shares the same lens pass | Shares the same target | One sample, or three with chromatic separation. |
+| Diffraction starburst | Shares the same lens pass | Shares the same target | Eight samples per configured diffraction ray. |
+| Temporal stability | 1 half-resolution history pass | 2 persistent half-resolution textures | Five current-neighborhood samples and one history sample. |
+
+The lens pass exists only when at least one of `starburstIntensity`, `ghostIntensity`, or
+`haloIntensity` is positive. Dirt-only configurations therefore preserve the base pass count. Reduce
+`quality`, `resolutionScale`, `starburstSpikes`, or `ghostCount` to trade optical detail for
+throughput.
 
 `toneMapping` applies an ACES filmic curve after exposure and preserves the source alpha channel.
 Place it after bloom or other HDR effects so bright highlights roll off before presentation:
@@ -58,7 +75,17 @@ const renderer = new ShaderPassRenderer(device, {
       intensity: 1.25,
       scatter: 0.55,
       softKnee: 0.5,
-      fireflyReduction: 0.15
+      fireflyReduction: 0.15,
+      temporalStability: 0.55,
+      lens: {
+        starburstIntensity: 0.65,
+        starburstSpikes: 4,
+        ghostIntensity: 0.3,
+        ghostCount: 3,
+        haloIntensity: 0.2,
+        chromaticAberration: 0.35,
+        dirtIntensity: 0.4
+      }
     }),
     toneMapping
   ]
@@ -66,11 +93,16 @@ const renderer = new ShaderPassRenderer(device, {
 
 renderer.renderToScreen({
   sourceTexture,
+  bindings: {lensDirtTexture},
   uniforms: {
     toneMapping: {exposure: 1}
   }
 });
 ```
+
+`lensDirtTexture` is an application-owned, sampled color texture. Omit the binding when
+`lens.dirtIntensity` is zero. Like other persistent effects, temporal bloom history is reset by
+`renderer.resetHistory()`, `resetHistory: true`, or resizing the renderer.
 
 See [Rendering Techniques and Tradeoffs](https://luma.gl/docs/api-guide/shaders/rendering-techniques)
 for comparisons between related effects, their GPU inputs, backend support, and composition order.

--- a/modules/effects/README.md
+++ b/modules/effects/README.md
@@ -38,19 +38,36 @@ participating-media scattering. Shared effects such as SSR use the same exported
 in both scenes.
 
 `createBloomShaderPassPipeline` builds an HDR bloom pyramid with quality presets from two to five
-levels. The pyramid progressively reconstructs its levels with normalized tent filtering; `scatter`,
-`softKnee`, `fireflyReduction`, `anamorphicRatio`, and `tint` control the resulting glow without
-requiring application-owned intermediate textures. Optional `lens` controls add aperture
-diffraction, spectral lens-element ghosts, a radial halo, and sampled lens dirt. Set
-`temporalStability` to accumulate neighborhood-clamped glow history. Every lens feature and temporal
-history is disabled by default. The source texture must allow both sampling and, when it is produced
-by an offscreen scene pass, rendering.
+levels. `exposure` and photographic `exposureCompensation` adjust the scene-referred threshold as
+`threshold / (exposure * 2 ** exposureCompensation)`. Choose normalized nine-tap tent filtering or
+four-fetch bicubic B-spline reconstruction with `reconstruction`. `scatter`, `softKnee`,
+`fireflyReduction`, `anamorphicRatio`, and `tint` shape the resulting glow without requiring
+application-owned intermediate textures.
+
+By default, `downsample: 'auto'` replaces the complete extraction/downsampling chain with one
+workgroup-local compute dispatch on supported WebGPU devices. WebGL and devices without enough
+floating-point storage bindings retain the complete render-pass implementation. Use
+`downsample: 'render'` to force portable fragment passes, or `downsample: 'compute'` to request
+compute while retaining the same capability fallback. `reuseRenderTargets` defaults to `true` and
+reuses expired extraction textures during reconstruction.
+
+| Quality | Pyramid levels | Portable render passes | Fused WebGPU work | Physical targets with / without reuse |
+| --- | --- | --- | --- | --- |
+| `low` | 2 | 8 | 6 render + 1 compute | 6 / 7 |
+| `medium` | 3 | 12 | 9 render + 1 compute | 9 / 11 |
+| `high` | 4 | 16 | 12 render + 1 compute | 12 / 15 |
+| `ultra` | 5 | 20 | 15 render + 1 compute | 15 / 19 |
+
+Optional `lens` controls add aperture diffraction, spectral lens-element ghosts, a radial halo,
+and sampled lens dirt. Set `temporalStability` to accumulate neighborhood-clamped glow history.
+Every lens feature and temporal history is disabled by default.
 
 | Feature | Added render passes | Additional targets | Main sampling cost |
 | --- | --- | --- | --- |
-| Base bloom: low / medium / high / ultra | 8 / 12 / 16 / 20 total | 7 / 11 / 15 / 19 | Separable blur and normalized pyramid reconstruction. |
+| Exposure-aware threshold | 0 | 0 | One exposure-scaled scalar threshold. |
+| Bicubic reconstruction | 0 | 0 | Four bilinear fetches instead of nine tent-filter taps per level. |
 | Lens dirt | 0 | 0 | One full-resolution mask sample in the existing composite. |
-| Spectral ghosts | 1 shared half-resolution lens pass | 1 half-resolution target | One sample per ghost, or three with chromatic separation. |
+| Spectral ghosts | 1 shared half-resolution lens pass | 1 artifact target and 1 retained highlight target when reuse is enabled | One sample per ghost, or three with chromatic separation. |
 | Lens halo | Shares the same lens pass | Shares the same target | One sample, or three with chromatic separation. |
 | Diffraction starburst | Shares the same lens pass | Shares the same target | Eight samples per configured diffraction ray. |
 | Temporal stability | 1 half-resolution history pass | 2 persistent half-resolution textures | Five current-neighborhood samples and one history sample. |
@@ -58,7 +75,9 @@ by an offscreen scene pass, rendering.
 The lens pass exists only when at least one of `starburstIntensity`, `ghostIntensity`, or
 `haloIntensity` is positive. Dirt-only configurations therefore preserve the base pass count. Reduce
 `quality`, `resolutionScale`, `starburstSpikes`, or `ghostCount` to trade optical detail for
-throughput.
+throughput. For physically based full-kernel diffraction, the separately owned
+`GPUConvolutionBloom` renderer in `@luma.gl/experimental` applies true RGB FFT convolution instead
+of the lower-cost screen-space starburst approximation.
 
 `toneMapping` applies an ACES filmic curve after exposure and preserves the source alpha channel.
 Place it after bloom or other HDR effects so bright highlights roll off before presentation:
@@ -72,7 +91,11 @@ const renderer = new ShaderPassRenderer(device, {
     createBloomShaderPassPipeline({
       quality: 'high',
       threshold: 0.8,
+      exposure: 1,
+      exposureCompensation: 0,
       intensity: 1.25,
+      reconstruction: 'bicubic',
+      downsample: 'auto',
       scatter: 0.55,
       softKnee: 0.5,
       fireflyReduction: 0.15,

--- a/modules/effects/src/index.ts
+++ b/modules/effects/src/index.ts
@@ -57,7 +57,10 @@ export type {
   BloomUniforms
 } from './passes/postprocessing/image-blur-filters/bloom';
 export {bloom} from './passes/postprocessing/image-blur-filters/bloom';
-export type {BloomShaderPassPipelineOptions} from './passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline';
+export type {
+  BloomLensEffectsOptions,
+  BloomShaderPassPipelineOptions
+} from './passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline';
 export {
   bloomShaderPassPipeline,
   createBloomShaderPassPipeline

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-compute-pyramid.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-compute-pyramid.ts
@@ -1,0 +1,165 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {TextureFormatColor} from '@luma.gl/core';
+import type {ShaderPassComputeOptimization} from '@luma.gl/shadertools';
+
+const BLOOM_COMPUTE_WORKGROUP_SIZE = 16;
+
+type BloomComputePyramidOptions = {
+  levelNames: readonly string[];
+  colorFormat: TextureFormatColor;
+  threshold: number;
+  softKnee: number;
+  fireflyReduction: number;
+  exposure: number;
+  exposureCompensation: number;
+};
+
+/** Builds a single-dispatch, workgroup-local HDR extraction and downsampling pyramid. */
+export function createBloomComputePyramid(
+  options: BloomComputePyramidOptions
+): ShaderPassComputeOptimization {
+  const outputs = Object.fromEntries(
+    options.levelNames.map(levelName => [`output${levelName}`, `extract${levelName}`])
+  );
+  const outputDeclarations = options.levelNames
+    .map(
+      (levelName, levelIndex) =>
+        `@group(0) @binding(${levelIndex + 2}) var output${levelName}: ` +
+        `texture_storage_2d<${options.colorFormat}, write>;`
+    )
+    .join('\n');
+  const reductionStages = options.levelNames
+    .slice(1)
+    .map((levelName, levelIndex) => makeReductionStage(levelName, levelIndex + 1))
+    .join('\n');
+
+  return {
+    name: 'bloomComputePyramid',
+    uniformModule: 'bloomExtract',
+    uniformBinding: 'bloomCompute',
+    uniformNames: ['threshold', 'softKnee', 'fireflyReduction', 'exposure', 'exposureCompensation'],
+    uniforms: {
+      threshold: options.threshold,
+      softKnee: options.softKnee,
+      fireflyReduction: options.fireflyReduction,
+      exposure: options.exposure,
+      exposureCompensation: options.exposureCompensation
+    },
+    input: 'previous',
+    outputs,
+    replacedPasses: ['bloomExtract', 'bloomDownsample'],
+    workgroupSize: [BLOOM_COMPUTE_WORKGROUP_SIZE, BLOOM_COMPUTE_WORKGROUP_SIZE],
+    source: /* wgsl */ `
+struct BloomComputeUniforms {
+  threshold: f32,
+  softKnee: f32,
+  fireflyReduction: f32,
+  exposure: f32,
+  exposureCompensation: f32,
+};
+
+@group(0) @binding(0) var<uniform> bloomCompute: BloomComputeUniforms;
+@group(0) @binding(1) var sourceTexture: texture_2d<f32>;
+${outputDeclarations}
+
+var<workgroup> bloomTile: array<vec4f, ${BLOOM_COMPUTE_WORKGROUP_SIZE ** 2}>;
+
+fn bloomCompute_applyThreshold(sourceColor: vec4f) -> vec4f {
+  let luminance = dot(sourceColor.rgb, vec3f(0.2126, 0.7152, 0.0722));
+  let exposure = max(bloomCompute.exposure * exp2(bloomCompute.exposureCompensation), 0.0001);
+  let threshold = bloomCompute.threshold / exposure;
+  let knee = max(threshold * bloomCompute.softKnee, 0.00001);
+  let soft = clamp((luminance - threshold + knee) / (2.0 * knee), 0.0, 1.0);
+  let softContribution = soft * soft * knee;
+  let hardContribution = max(luminance - threshold, 0.0);
+  let contribution = max(hardContribution, softContribution) / max(luminance, 0.00001);
+  return vec4f(sourceColor.rgb * contribution, sourceColor.a * contribution);
+}
+
+fn bloomCompute_extractHighlight(outputCoordinate: vec2u, outputDimensions: vec2u) -> vec4f {
+  let sourceDimensions = textureDimensions(sourceTexture);
+  let clampedCoordinate = min(outputCoordinate, outputDimensions - vec2u(1));
+  let sourceCenter =
+    (vec2f(clampedCoordinate) + vec2f(0.5)) * vec2f(sourceDimensions) /
+      vec2f(outputDimensions) - vec2f(0.5);
+  let filterRadius = max(vec2f(sourceDimensions) / vec2f(outputDimensions), vec2f(2.0));
+  let minimumCoordinate = vec2i(floor(sourceCenter - filterRadius)) + vec2i(1);
+  let maximumCoordinate = vec2i(ceil(sourceCenter + filterRadius)) - vec2i(1);
+  let maximumSourceCoordinate = vec2i(sourceDimensions) - vec2i(1);
+  var color = vec4f(0.0);
+  var totalWeight = 0.0;
+
+  for (var sourceY = minimumCoordinate.y; sourceY <= maximumCoordinate.y; sourceY += 1) {
+    let weightY = max(1.0 - abs(f32(sourceY) - sourceCenter.y) / filterRadius.y, 0.0);
+    for (var sourceX = minimumCoordinate.x; sourceX <= maximumCoordinate.x; sourceX += 1) {
+      let weightX = max(1.0 - abs(f32(sourceX) - sourceCenter.x) / filterRadius.x, 0.0);
+      let sourceColor = textureLoad(
+        sourceTexture,
+        clamp(vec2i(sourceX, sourceY), vec2i(0), maximumSourceCoordinate),
+        0
+      );
+      let luminance = dot(sourceColor.rgb, vec3f(0.2126, 0.7152, 0.0722));
+      let fireflyWeight = mix(
+        1.0,
+        1.0 / (1.0 + max(luminance, 0.0)),
+        clamp(bloomCompute.fireflyReduction, 0.0, 1.0)
+      );
+      let weight = weightX * weightY * fireflyWeight;
+      color += bloomCompute_applyThreshold(sourceColor) * weight;
+      totalWeight += weight;
+    }
+  }
+
+  return color / max(totalWeight, 0.00001);
+}
+
+@compute @workgroup_size(${BLOOM_COMPUTE_WORKGROUP_SIZE}, ${BLOOM_COMPUTE_WORKGROUP_SIZE})
+fn main(
+  @builtin(global_invocation_id) globalInvocation: vec3u,
+  @builtin(local_invocation_id) localInvocation: vec3u,
+  @builtin(workgroup_id) workgroupCoordinate: vec3u
+) {
+  let localCoordinate = localInvocation.xy;
+  let localIndex = localCoordinate.y * ${BLOOM_COMPUTE_WORKGROUP_SIZE}u + localCoordinate.x;
+  let halfDimensions = textureDimensions(outputHalf);
+  let halfCoordinate = globalInvocation.xy;
+  let extractedColor = bloomCompute_extractHighlight(halfCoordinate, halfDimensions);
+  bloomTile[localIndex] = extractedColor;
+  if (all(halfCoordinate < halfDimensions)) {
+    textureStore(outputHalf, vec2i(halfCoordinate), extractedColor);
+  }
+  workgroupBarrier();
+${reductionStages}
+}
+`
+  };
+}
+
+function makeReductionStage(levelName: string, levelIndex: number): string {
+  const tileWidth = BLOOM_COMPUTE_WORKGROUP_SIZE / 2 ** levelIndex;
+  const stageName = levelName.toLowerCase();
+  return /* wgsl */ `
+  var ${stageName}Color = vec4f(0.0);
+  if (localCoordinate.x < ${tileWidth}u && localCoordinate.y < ${tileWidth}u) {
+    let sourceCoordinate = localCoordinate * 2u;
+    let sourceIndex = sourceCoordinate.y * ${BLOOM_COMPUTE_WORKGROUP_SIZE}u + sourceCoordinate.x;
+    ${stageName}Color = (
+      bloomTile[sourceIndex] +
+      bloomTile[sourceIndex + 1u] +
+      bloomTile[sourceIndex + ${BLOOM_COMPUTE_WORKGROUP_SIZE}u] +
+      bloomTile[sourceIndex + ${BLOOM_COMPUTE_WORKGROUP_SIZE + 1}u]
+    ) * 0.25;
+  }
+  workgroupBarrier();
+  if (localCoordinate.x < ${tileWidth}u && localCoordinate.y < ${tileWidth}u) {
+    bloomTile[localIndex] = ${stageName}Color;
+    let ${stageName}Coordinate = workgroupCoordinate.xy * ${tileWidth}u + localCoordinate;
+    if (all(${stageName}Coordinate < textureDimensions(output${levelName}))) {
+      textureStore(output${levelName}, vec2i(${stageName}Coordinate), ${stageName}Color);
+    }
+  }
+  workgroupBarrier();`;
+}

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-lens-effects.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-lens-effects.ts
@@ -1,0 +1,556 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Texture} from '@luma.gl/core';
+import type {ShaderPass} from '@luma.gl/shadertools';
+
+export const MAX_BLOOM_LENS_GHOSTS = 6;
+export const MAX_BLOOM_LENS_SPIKES = 8;
+const BLOOM_LENS_STREAK_SAMPLES = 8;
+
+/** Optional photographic lens artifacts generated from the extracted HDR highlights. */
+export type BloomLensEffectsOptions = {
+  /** Brightness of aperture-diffraction streaks. Defaults to zero. */
+  starburstIntensity?: number;
+  /** Number of diffraction rays. Rounded to an even value between two and eight. */
+  starburstSpikes?: number;
+  /** Length of each diffraction ray in half-resolution source texels. Defaults to 48. */
+  starburstLength?: number;
+  /** Rotation of the diffraction pattern, in radians. Defaults to zero. */
+  starburstRotation?: number;
+  /** Brightness of chromatic lens-element reflections. Defaults to zero. */
+  ghostIntensity?: number;
+  /** Number of reflected lens ghosts, clamped between one and six. Defaults to three. */
+  ghostCount?: number;
+  /** Distance between successive lens-element reflections. Defaults to 0.32. */
+  ghostSpacing?: number;
+  /** Brightness of the radial lens halo. Defaults to zero. */
+  haloIntensity?: number;
+  /** Radius of the radial lens halo in normalized texture coordinates. Defaults to 0.34. */
+  haloRadius?: number;
+  /** Spectral separation applied to ghosts and halos. Defaults to zero. */
+  chromaticAberration?: number;
+  /**
+   * Brightness of the sampled lens dirt mask. When positive, provide a sampled texture through
+   * `ShaderPassRenderer.renderToTexture({bindings: {lensDirtTexture}})` or `renderToScreen()`.
+   */
+  dirtIntensity?: number;
+};
+
+type BloomLensUniforms = {
+  starburstIntensity: number;
+  starburstSpikes: number;
+  starburstLength: number;
+  starburstRotation: number;
+  ghostIntensity: number;
+  ghostCount: number;
+  ghostSpacing: number;
+  haloIntensity: number;
+  haloRadius: number;
+  chromaticAberration: number;
+};
+
+type BloomLensBindings = {
+  glowTexture?: Texture;
+};
+
+export const bloomLensArtifactsPass = {
+  name: 'bloomLens',
+  source: /* wgsl */ `
+const BLOOM_LENS_MAX_GHOSTS = ${MAX_BLOOM_LENS_GHOSTS};
+const BLOOM_LENS_MAX_DIRECTIONS = ${MAX_BLOOM_LENS_SPIKES / 2};
+const BLOOM_LENS_STREAK_SAMPLES = ${BLOOM_LENS_STREAK_SAMPLES};
+
+struct bloomLensUniforms {
+  starburstIntensity: f32,
+  starburstSpikes: f32,
+  starburstLength: f32,
+  starburstRotation: f32,
+  ghostIntensity: f32,
+  ghostCount: f32,
+  ghostSpacing: f32,
+  haloIntensity: f32,
+  haloRadius: f32,
+  chromaticAberration: f32,
+};
+
+@group(0) @binding(auto) var<uniform> bloomLens: bloomLensUniforms;
+@group(0) @binding(auto) var glowTexture: texture_2d<f32>;
+@group(0) @binding(auto) var glowTextureSampler: sampler;
+
+fn bloomLens_sampleSpectralHighlight(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  coordinate: vec2f,
+  direction: vec2f
+) -> vec3f {
+  if (any(coordinate < vec2f(0.0)) || any(coordinate > vec2f(1.0))) {
+    return vec3f(0.0);
+  }
+
+  if (bloomLens.chromaticAberration <= 0.0) {
+    return textureSampleLevel(sourceTexture, sourceTextureSampler, coordinate, 0.0).rgb;
+  }
+
+  let spectralOffset = direction * bloomLens.chromaticAberration * 0.018;
+  return vec3f(
+    textureSampleLevel(sourceTexture, sourceTextureSampler, coordinate + spectralOffset, 0.0).r,
+    textureSampleLevel(sourceTexture, sourceTextureSampler, coordinate, 0.0).g,
+    textureSampleLevel(sourceTexture, sourceTextureSampler, coordinate - spectralOffset, 0.0).b
+  );
+}
+
+fn bloomLens_sampleStarburst(texCoord: vec2f) -> vec3f {
+  let directionCount = max(bloomLens.starburstSpikes * 0.5, 1.0);
+  let glowDimensions = vec2f(textureDimensions(glowTexture));
+  var streakColor = vec3f(0.0);
+  var totalWeight = 0.0;
+
+  for (var directionIndex = 0; directionIndex < BLOOM_LENS_MAX_DIRECTIONS; directionIndex += 1) {
+    if (f32(directionIndex) >= directionCount) {
+      continue;
+    }
+
+    let angle = bloomLens.starburstRotation + f32(directionIndex) * 3.14159265359 / directionCount;
+    let direction = vec2f(cos(angle), sin(angle));
+    for (var sampleIndex = 1; sampleIndex <= BLOOM_LENS_STREAK_SAMPLES; sampleIndex += 1) {
+      let sampleDistance = f32(sampleIndex) / f32(BLOOM_LENS_STREAK_SAMPLES);
+      let offset = direction * bloomLens.starburstLength * sampleDistance / glowDimensions;
+      let sampleWeight = exp(-sampleDistance * 2.4);
+      let positiveColor = textureSampleLevel(
+        glowTexture,
+        glowTextureSampler,
+        clamp(texCoord + offset, vec2f(0.0), vec2f(1.0)),
+        0.0
+      ).rgb;
+      let negativeColor = textureSampleLevel(
+        glowTexture,
+        glowTextureSampler,
+        clamp(texCoord - offset, vec2f(0.0), vec2f(1.0)),
+        0.0
+      ).rgb;
+      streakColor += (positiveColor + negativeColor) * sampleWeight;
+      totalWeight += sampleWeight * 2.0;
+    }
+  }
+
+  return streakColor / max(totalWeight, 0.00001);
+}
+
+fn bloomLens_sampleGhosts(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texCoord: vec2f,
+  radialDirection: vec2f
+) -> vec3f {
+  let centeredCoordinate = texCoord - vec2f(0.5);
+  let reflectedCoordinate = vec2f(1.0) - texCoord;
+  var ghostColor = vec3f(0.0);
+  var totalWeight = 0.0;
+
+  for (var ghostIndex = 0; ghostIndex < BLOOM_LENS_MAX_GHOSTS; ghostIndex += 1) {
+    if (f32(ghostIndex) >= bloomLens.ghostCount) {
+      continue;
+    }
+
+    let ghostCoordinate = reflectedCoordinate +
+      centeredCoordinate * f32(ghostIndex) * bloomLens.ghostSpacing;
+    let radialFalloff = max(1.0 - length(ghostCoordinate - vec2f(0.5)) * 1.41421356, 0.0);
+    let ghostWeight = radialFalloff * (1.0 - f32(ghostIndex) / (bloomLens.ghostCount + 1.0));
+    ghostColor += bloomLens_sampleSpectralHighlight(
+      sourceTexture,
+      sourceTextureSampler,
+      ghostCoordinate,
+      radialDirection
+    ) * ghostWeight;
+    totalWeight += ghostWeight;
+  }
+
+  return ghostColor / max(totalWeight, 0.00001);
+}
+
+fn bloomLens_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let centeredCoordinate = texCoord - vec2f(0.5);
+  let radialDirection = centeredCoordinate / max(length(centeredCoordinate), 0.00001);
+  var lensColor = vec3f(0.0);
+
+  if (bloomLens.starburstIntensity > 0.0) {
+    lensColor += bloomLens_sampleStarburst(texCoord) * bloomLens.starburstIntensity;
+  }
+  if (bloomLens.ghostIntensity > 0.0) {
+    lensColor += bloomLens_sampleGhosts(
+      sourceTexture,
+      sourceTextureSampler,
+      texCoord,
+      radialDirection
+    ) * bloomLens.ghostIntensity;
+  }
+  if (bloomLens.haloIntensity > 0.0) {
+    let haloCoordinate = texCoord - radialDirection * bloomLens.haloRadius;
+    let haloFalloff = max(1.0 - length(centeredCoordinate) * 1.41421356, 0.0);
+    lensColor += bloomLens_sampleSpectralHighlight(
+      sourceTexture,
+      sourceTextureSampler,
+      haloCoordinate,
+      radialDirection
+    ) * bloomLens.haloIntensity * haloFalloff;
+  }
+
+  return vec4f(lensColor, 1.0);
+}
+`,
+  fs: /* glsl */ `
+#define BLOOM_LENS_MAX_GHOSTS ${MAX_BLOOM_LENS_GHOSTS}
+#define BLOOM_LENS_MAX_DIRECTIONS ${MAX_BLOOM_LENS_SPIKES / 2}
+#define BLOOM_LENS_STREAK_SAMPLES ${BLOOM_LENS_STREAK_SAMPLES}
+
+layout(std140) uniform bloomLensUniforms {
+  float starburstIntensity;
+  float starburstSpikes;
+  float starburstLength;
+  float starburstRotation;
+  float ghostIntensity;
+  float ghostCount;
+  float ghostSpacing;
+  float haloIntensity;
+  float haloRadius;
+  float chromaticAberration;
+} bloomLens;
+
+uniform sampler2D glowTexture;
+
+vec3 bloomLens_sampleSpectralHighlight(
+  sampler2D sourceTexture,
+  vec2 coordinate,
+  vec2 direction
+) {
+  if (any(lessThan(coordinate, vec2(0.0))) || any(greaterThan(coordinate, vec2(1.0)))) {
+    return vec3(0.0);
+  }
+
+  if (bloomLens.chromaticAberration <= 0.0) {
+    return textureLod(sourceTexture, coordinate, 0.0).rgb;
+  }
+
+  vec2 spectralOffset = direction * bloomLens.chromaticAberration * 0.018;
+  return vec3(
+    textureLod(sourceTexture, coordinate + spectralOffset, 0.0).r,
+    textureLod(sourceTexture, coordinate, 0.0).g,
+    textureLod(sourceTexture, coordinate - spectralOffset, 0.0).b
+  );
+}
+
+vec3 bloomLens_sampleStarburst(vec2 texCoord) {
+  float directionCount = max(bloomLens.starburstSpikes * 0.5, 1.0);
+  vec2 glowDimensions = vec2(textureSize(glowTexture, 0));
+  vec3 streakColor = vec3(0.0);
+  float totalWeight = 0.0;
+
+  for (int directionIndex = 0; directionIndex < BLOOM_LENS_MAX_DIRECTIONS; directionIndex++) {
+    if (float(directionIndex) >= directionCount) {
+      continue;
+    }
+
+    float angle = bloomLens.starburstRotation + float(directionIndex) * 3.14159265359 / directionCount;
+    vec2 direction = vec2(cos(angle), sin(angle));
+    for (int sampleIndex = 1; sampleIndex <= BLOOM_LENS_STREAK_SAMPLES; sampleIndex++) {
+      float sampleDistance = float(sampleIndex) / float(BLOOM_LENS_STREAK_SAMPLES);
+      vec2 offset = direction * bloomLens.starburstLength * sampleDistance / glowDimensions;
+      float sampleWeight = exp(-sampleDistance * 2.4);
+      vec3 positiveColor = textureLod(
+        glowTexture,
+        clamp(texCoord + offset, vec2(0.0), vec2(1.0)),
+        0.0
+      ).rgb;
+      vec3 negativeColor = textureLod(
+        glowTexture,
+        clamp(texCoord - offset, vec2(0.0), vec2(1.0)),
+        0.0
+      ).rgb;
+      streakColor += (positiveColor + negativeColor) * sampleWeight;
+      totalWeight += sampleWeight * 2.0;
+    }
+  }
+
+  return streakColor / max(totalWeight, 0.00001);
+}
+
+vec3 bloomLens_sampleGhosts(
+  sampler2D sourceTexture,
+  vec2 texCoord,
+  vec2 radialDirection
+) {
+  vec2 centeredCoordinate = texCoord - vec2(0.5);
+  vec2 reflectedCoordinate = vec2(1.0) - texCoord;
+  vec3 ghostColor = vec3(0.0);
+  float totalWeight = 0.0;
+
+  for (int ghostIndex = 0; ghostIndex < BLOOM_LENS_MAX_GHOSTS; ghostIndex++) {
+    if (float(ghostIndex) >= bloomLens.ghostCount) {
+      continue;
+    }
+
+    vec2 ghostCoordinate = reflectedCoordinate +
+      centeredCoordinate * float(ghostIndex) * bloomLens.ghostSpacing;
+    float radialFalloff = max(1.0 - length(ghostCoordinate - vec2(0.5)) * 1.41421356, 0.0);
+    float ghostWeight = radialFalloff * (1.0 - float(ghostIndex) / (bloomLens.ghostCount + 1.0));
+    ghostColor += bloomLens_sampleSpectralHighlight(
+      sourceTexture,
+      ghostCoordinate,
+      radialDirection
+    ) * ghostWeight;
+    totalWeight += ghostWeight;
+  }
+
+  return ghostColor / max(totalWeight, 0.00001);
+}
+
+vec4 bloomLens_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoord) {
+  vec2 centeredCoordinate = texCoord - vec2(0.5);
+  vec2 radialDirection = centeredCoordinate / max(length(centeredCoordinate), 0.00001);
+  vec3 lensColor = vec3(0.0);
+
+  if (bloomLens.starburstIntensity > 0.0) {
+    lensColor += bloomLens_sampleStarburst(texCoord) * bloomLens.starburstIntensity;
+  }
+  if (bloomLens.ghostIntensity > 0.0) {
+    lensColor += bloomLens_sampleGhosts(
+      sourceTexture,
+      texCoord,
+      radialDirection
+    ) * bloomLens.ghostIntensity;
+  }
+  if (bloomLens.haloIntensity > 0.0) {
+    vec2 haloCoordinate = texCoord - radialDirection * bloomLens.haloRadius;
+    float haloFalloff = max(1.0 - length(centeredCoordinate) * 1.41421356, 0.0);
+    lensColor += bloomLens_sampleSpectralHighlight(
+      sourceTexture,
+      haloCoordinate,
+      radialDirection
+    ) * bloomLens.haloIntensity * haloFalloff;
+  }
+
+  return vec4(lensColor, 1.0);
+}
+`,
+  bindingLayout: [{name: 'glowTexture', group: 0}],
+  uniforms: {} as BloomLensUniforms,
+  bindings: {} as BloomLensBindings,
+  uniformTypes: {
+    starburstIntensity: 'f32',
+    starburstSpikes: 'f32',
+    starburstLength: 'f32',
+    starburstRotation: 'f32',
+    ghostIntensity: 'f32',
+    ghostCount: 'f32',
+    ghostSpacing: 'f32',
+    haloIntensity: 'f32',
+    haloRadius: 'f32',
+    chromaticAberration: 'f32'
+  },
+  defaultUniforms: {
+    starburstIntensity: 0,
+    starburstSpikes: 4,
+    starburstLength: 48,
+    starburstRotation: 0,
+    ghostIntensity: 0,
+    ghostCount: 3,
+    ghostSpacing: 0.32,
+    haloIntensity: 0,
+    haloRadius: 0.34,
+    chromaticAberration: 0
+  },
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  Partial<BloomLensUniforms> & BloomLensBindings,
+  BloomLensUniforms,
+  BloomLensBindings
+>;
+
+type BloomTemporalBindings = {
+  historyTexture?: Texture;
+};
+
+export const bloomTemporalPass = {
+  name: 'bloomTemporal',
+  source: /* wgsl */ `
+struct bloomTemporalUniforms {
+  stability: f32,
+};
+
+@group(0) @binding(auto) var<uniform> bloomTemporal: bloomTemporalUniforms;
+@group(0) @binding(auto) var historyTexture: texture_2d<f32>;
+@group(0) @binding(auto) var historyTextureSampler: sampler;
+
+fn bloomTemporal_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let texel = 1.0 / vec2f(textureDimensions(sourceTexture));
+  let current = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord, 0.0).rgb;
+  let left = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord - vec2f(texel.x, 0.0), 0.0).rgb;
+  let right = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord + vec2f(texel.x, 0.0), 0.0).rgb;
+  let top = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord - vec2f(0.0, texel.y), 0.0).rgb;
+  let bottom = textureSampleLevel(sourceTexture, sourceTextureSampler, texCoord + vec2f(0.0, texel.y), 0.0).rgb;
+  let minimumColor = min(current, min(min(left, right), min(top, bottom)));
+  let maximumColor = max(current, max(max(left, right), max(top, bottom)));
+  let history = textureSampleLevel(historyTexture, historyTextureSampler, texCoord, 0.0);
+  let clampedHistory = clamp(history.rgb, minimumColor, maximumColor);
+  let historyWeight = select(0.0, clamp(bloomTemporal.stability, 0.0, 0.95), history.a > 0.5);
+  return vec4f(mix(current, clampedHistory, historyWeight), 1.0);
+}
+`,
+  fs: /* glsl */ `
+layout(std140) uniform bloomTemporalUniforms {
+  float stability;
+} bloomTemporal;
+
+uniform sampler2D historyTexture;
+
+vec4 bloomTemporal_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoord) {
+  vec2 texel = 1.0 / vec2(textureSize(sourceTexture, 0));
+  vec3 current = textureLod(sourceTexture, texCoord, 0.0).rgb;
+  vec3 left = textureLod(sourceTexture, texCoord - vec2(texel.x, 0.0), 0.0).rgb;
+  vec3 right = textureLod(sourceTexture, texCoord + vec2(texel.x, 0.0), 0.0).rgb;
+  vec3 top = textureLod(sourceTexture, texCoord - vec2(0.0, texel.y), 0.0).rgb;
+  vec3 bottom = textureLod(sourceTexture, texCoord + vec2(0.0, texel.y), 0.0).rgb;
+  vec3 minimumColor = min(current, min(min(left, right), min(top, bottom)));
+  vec3 maximumColor = max(current, max(max(left, right), max(top, bottom)));
+  vec4 history = textureLod(historyTexture, texCoord, 0.0);
+  vec3 clampedHistory = clamp(history.rgb, minimumColor, maximumColor);
+  float historyWeight = history.a > 0.5 ? clamp(bloomTemporal.stability, 0.0, 0.95) : 0.0;
+  return vec4(mix(current, clampedHistory, historyWeight), 1.0);
+}
+`,
+  bindingLayout: [{name: 'historyTexture', group: 0}],
+  uniforms: {} as {stability: number},
+  bindings: {} as BloomTemporalBindings,
+  uniformTypes: {stability: 'f32'},
+  defaultUniforms: {stability: 0},
+  passes: [{sampler: true}]
+} as const satisfies ShaderPass<
+  {stability?: number} & BloomTemporalBindings,
+  {stability: number},
+  BloomTemporalBindings
+>;
+
+type BloomLensCompositeUniforms = {
+  tint: [number, number, number];
+  intensity: number;
+  dirtIntensity: number;
+};
+
+type BloomLensCompositeBindings = {
+  glowTexture?: Texture;
+  lensTexture?: Texture;
+  lensDirtTexture?: Texture;
+};
+
+export function createBloomLensCompositePass(
+  includeLensArtifacts: boolean,
+  includeLensDirt: boolean
+): ShaderPass<
+  Partial<BloomLensCompositeUniforms> & BloomLensCompositeBindings,
+  BloomLensCompositeUniforms,
+  BloomLensCompositeBindings
+> {
+  const lensBindingsWGSL = includeLensArtifacts
+    ? `\n@group(0) @binding(auto) var lensTexture: texture_2d<f32>;
+@group(0) @binding(auto) var lensTextureSampler: sampler;`
+    : '';
+  const dirtBindingsWGSL = includeLensDirt
+    ? `\n@group(0) @binding(auto) var lensDirtTexture: texture_2d<f32>;
+@group(0) @binding(auto) var lensDirtTextureSampler: sampler;`
+    : '';
+  const lensSampleWGSL = includeLensArtifacts
+    ? 'textureSample(lensTexture, lensTextureSampler, texCoord).rgb'
+    : 'vec3f(0.0)';
+  const dirtSampleWGSL = includeLensDirt
+    ? 'textureSample(lensDirtTexture, lensDirtTextureSampler, texCoord).rgb'
+    : 'vec3f(0.0)';
+  const lensBindingsGLSL = includeLensArtifacts ? '\nuniform sampler2D lensTexture;' : '';
+  const dirtBindingsGLSL = includeLensDirt ? '\nuniform sampler2D lensDirtTexture;' : '';
+  const lensSampleGLSL = includeLensArtifacts ? 'texture(lensTexture, texCoord).rgb' : 'vec3(0.0)';
+  const dirtSampleGLSL = includeLensDirt
+    ? 'texture(lensDirtTexture, texCoord).rgb'
+    : 'vec3(0.0)';
+
+  return {
+    name: 'bloomComposite',
+    source: /* wgsl */ `
+struct bloomCompositeUniforms {
+  tint: vec3f,
+  intensity: f32,
+  dirtIntensity: f32,
+};
+
+@group(0) @binding(auto) var<uniform> bloomComposite: bloomCompositeUniforms;
+@group(0) @binding(auto) var glowTexture: texture_2d<f32>;
+@group(0) @binding(auto) var glowTextureSampler: sampler;${lensBindingsWGSL}${dirtBindingsWGSL}
+
+fn bloomComposite_sampleColor(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texSize: vec2f,
+  texCoord: vec2f
+) -> vec4f {
+  let sourceColor = textureSample(sourceTexture, sourceTextureSampler, texCoord);
+  let glowColor = textureSample(glowTexture, glowTextureSampler, texCoord).rgb;
+  let lensColor = ${lensSampleWGSL};
+  let dirtMask = ${dirtSampleWGSL};
+  let cinematicGlow = (glowColor + lensColor) * (vec3f(1.0) + dirtMask * bloomComposite.dirtIntensity);
+  return vec4f(
+    sourceColor.rgb + cinematicGlow * bloomComposite.tint * bloomComposite.intensity,
+    sourceColor.a
+  );
+}
+`,
+    fs: /* glsl */ `
+layout(std140) uniform bloomCompositeUniforms {
+  vec3 tint;
+  float intensity;
+  float dirtIntensity;
+} bloomComposite;
+
+uniform sampler2D glowTexture;${lensBindingsGLSL}${dirtBindingsGLSL}
+
+vec4 bloomComposite_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoord) {
+  vec4 sourceColor = texture(sourceTexture, texCoord);
+  vec3 glowColor = texture(glowTexture, texCoord).rgb;
+  vec3 lensColor = ${lensSampleGLSL};
+  vec3 dirtMask = ${dirtSampleGLSL};
+  vec3 cinematicGlow = (glowColor + lensColor) * (vec3(1.0) + dirtMask * bloomComposite.dirtIntensity);
+  return vec4(
+    sourceColor.rgb + cinematicGlow * bloomComposite.tint * bloomComposite.intensity,
+    sourceColor.a
+  );
+}
+`,
+    bindingLayout: [
+      {name: 'glowTexture', group: 0},
+      ...(includeLensArtifacts ? [{name: 'lensTexture', group: 0}] : []),
+      ...(includeLensDirt ? [{name: 'lensDirtTexture', group: 0}] : [])
+    ],
+    uniforms: {} as BloomLensCompositeUniforms,
+    bindings: {} as BloomLensCompositeBindings,
+    uniformTypes: {
+      tint: 'vec3<f32>',
+      intensity: 'f32',
+      dirtIntensity: 'f32'
+    },
+    defaultUniforms: {
+      tint: [1, 1, 1],
+      intensity: 1,
+      dirtIntensity: 0
+    },
+    passes: [{sampler: true}]
+  };
+}

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-lens-effects.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-lens-effects.ts
@@ -479,9 +479,7 @@ export function createBloomLensCompositePass(
   const lensBindingsGLSL = includeLensArtifacts ? '\nuniform sampler2D lensTexture;' : '';
   const dirtBindingsGLSL = includeLensDirt ? '\nuniform sampler2D lensDirtTexture;' : '';
   const lensSampleGLSL = includeLensArtifacts ? 'texture(lensTexture, texCoord).rgb' : 'vec3(0.0)';
-  const dirtSampleGLSL = includeLensDirt
-    ? 'texture(lensDirtTexture, texCoord).rgb'
-    : 'vec3(0.0)';
+  const dirtSampleGLSL = includeLensDirt ? 'texture(lensDirtTexture, texCoord).rgb' : 'vec3(0.0)';
 
   return {
     name: 'bloomComposite',

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
@@ -10,6 +10,7 @@ import type {
   ShaderPassRenderTarget
 } from '@luma.gl/shadertools';
 import type {BloomProps, BloomUniforms} from './bloom';
+import {createBloomComputePyramid} from './bloom-compute-pyramid';
 import {
   bloomLensArtifactsPass,
   bloomTemporalPass,
@@ -51,6 +52,10 @@ export type BloomShaderPassPipelineOptions = BloomProps & {
   scatter?: number;
   /** Width of the soft highlight threshold relative to the threshold. Defaults to 0.5. */
   softKnee?: number;
+  /** Camera exposure used to move the scene-referred highlight threshold. Defaults to one. */
+  exposure?: number;
+  /** Additional exposure compensation, measured in photographic stops. Defaults to zero. */
+  exposureCompensation?: number;
   /** Luminance-weighted suppression of isolated bright samples. Defaults to 0. */
   fireflyReduction?: number;
   /** Negative values stretch vertically; positive values stretch horizontally. */
@@ -61,6 +66,12 @@ export type BloomShaderPassPipelineOptions = BloomProps & {
   lens?: BloomLensEffectsOptions;
   /** Neighborhood-clamped history contribution for stable highlights. Defaults to zero. */
   temporalStability?: number;
+  /** Normalized tent reconstruction or four-fetch bicubic B-spline filtering. */
+  reconstruction?: 'tent' | 'bicubic';
+  /** Select fragment downsampling or the fused WebGPU compute pyramid when available. */
+  downsample?: 'auto' | 'render' | 'compute';
+  /** Reuse expired extraction textures during reconstruction. Defaults to true. */
+  reuseRenderTargets?: boolean;
   /**
    * Positive fractional size multiplier applied to every pyramid level. The extraction filter
    * adapts its source footprint to the resulting target size.
@@ -77,16 +88,20 @@ struct bloomExtractUniforms {
   threshold: f32,
   softKnee: f32,
   fireflyReduction: f32,
+  exposure: f32,
+  exposureCompensation: f32,
 };
 
 @group(0) @binding(auto) var<uniform> bloomExtract: bloomExtractUniforms;
 
 fn bloomExtract_applyThreshold(sourceColor: vec4f) -> vec4f {
   let luminance = dot(sourceColor.rgb, vec3f(0.2126, 0.7152, 0.0722));
-  let knee = max(bloomExtract.threshold * bloomExtract.softKnee, 0.00001);
-  let soft = clamp((luminance - bloomExtract.threshold + knee) / (2.0 * knee), 0.0, 1.0);
+  let exposure = max(bloomExtract.exposure * exp2(bloomExtract.exposureCompensation), 0.0001);
+  let threshold = bloomExtract.threshold / exposure;
+  let knee = max(threshold * bloomExtract.softKnee, 0.00001);
+  let soft = clamp((luminance - threshold + knee) / (2.0 * knee), 0.0, 1.0);
   let softContribution = soft * soft * knee;
-  let hardContribution = max(luminance - bloomExtract.threshold, 0.0);
+  let hardContribution = max(luminance - threshold, 0.0);
   let bloomContribution = max(hardContribution, softContribution) / max(luminance, 0.00001);
   return vec4f(sourceColor.rgb * bloomContribution, sourceColor.a * bloomContribution);
 }
@@ -144,14 +159,18 @@ layout(std140) uniform bloomExtractUniforms {
   float threshold;
   float softKnee;
   float fireflyReduction;
+  float exposure;
+  float exposureCompensation;
 } bloomExtract;
 
 vec4 bloomExtract_applyThreshold(vec4 sourceColor) {
   float luminance = dot(sourceColor.rgb, vec3(0.2126, 0.7152, 0.0722));
-  float knee = max(bloomExtract.threshold * bloomExtract.softKnee, 0.00001);
-  float soft = clamp((luminance - bloomExtract.threshold + knee) / (2.0 * knee), 0.0, 1.0);
+  float exposure = max(bloomExtract.exposure * exp2(bloomExtract.exposureCompensation), 0.0001);
+  float threshold = bloomExtract.threshold / exposure;
+  float knee = max(threshold * bloomExtract.softKnee, 0.00001);
+  float soft = clamp((luminance - threshold + knee) / (2.0 * knee), 0.0, 1.0);
   float softContribution = soft * soft * knee;
-  float hardContribution = max(luminance - bloomExtract.threshold, 0.0);
+  float hardContribution = max(luminance - threshold, 0.0);
   float bloomContribution = max(hardContribution, softContribution) / max(luminance, 0.00001);
   return vec4(sourceColor.rgb * bloomContribution, sourceColor.a * bloomContribution);
 }
@@ -201,22 +220,36 @@ vec4 bloomExtract_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoo
   uniformTypes: {
     threshold: 'f32',
     softKnee: 'f32',
-    fireflyReduction: 'f32'
+    fireflyReduction: 'f32',
+    exposure: 'f32',
+    exposureCompensation: 'f32'
   },
   defaultUniforms: {
     threshold: 0.8,
     softKnee: 0.5,
-    fireflyReduction: 0
+    fireflyReduction: 0,
+    exposure: 1,
+    exposureCompensation: 0
   },
   propTypes: {
     threshold: {value: 0.8, min: 0, max: 1},
     softKnee: {value: 0.5, min: 0, max: 1},
-    fireflyReduction: {value: 0, min: 0, max: 1}
+    fireflyReduction: {value: 0, min: 0, max: 1},
+    exposure: {value: 1, min: 0.0001, softMax: 8},
+    exposureCompensation: {value: 0, min: -8, max: 8}
   },
   passes: [{sampler: true}]
 } as const satisfies ShaderPass<
-  Pick<BloomShaderPassPipelineOptions, 'threshold' | 'softKnee' | 'fireflyReduction'>,
-  Pick<BloomUniforms, 'threshold'> & {softKnee?: number; fireflyReduction?: number}
+  Pick<
+    BloomShaderPassPipelineOptions,
+    'threshold' | 'softKnee' | 'fireflyReduction' | 'exposure' | 'exposureCompensation'
+  >,
+  Pick<BloomUniforms, 'threshold'> & {
+    softKnee?: number;
+    fireflyReduction?: number;
+    exposure?: number;
+    exposureCompensation?: number;
+  }
 >;
 
 const bloomDownsamplePass = {
@@ -468,6 +501,7 @@ const bloomUpsamplePass = {
   source: /* wgsl */ `
 struct bloomUpsampleUniforms {
   scatter: f32,
+  reconstruction: f32,
 };
 
 @group(0) @binding(auto) var<uniform> bloomUpsample: bloomUpsampleUniforms;
@@ -497,13 +531,71 @@ fn bloomUpsample_sampleLowerGlow(
   return (center + edges + corners) / 16.0;
 }
 
+fn bloomUpsample_sampleBicubicGlow(
+  sourceTexture: texture_2d<f32>,
+  sourceTextureSampler: sampler,
+  texCoord: vec2f
+) -> vec4f {
+  let dimensions = vec2f(textureDimensions(sourceTexture));
+  let texelPosition = texCoord * dimensions - vec2f(0.5);
+  let basePosition = floor(texelPosition);
+  let fraction = fract(texelPosition);
+  let complement = vec2f(1.0) - fraction;
+  let firstWeight = complement * complement * complement / 6.0;
+  let secondWeight =
+    (fraction * fraction * fraction * 3.0 - fraction * fraction * 6.0 + vec2f(4.0)) / 6.0;
+  let thirdWeight =
+    (-fraction * fraction * fraction * 3.0 + fraction * fraction * 3.0 + fraction * 3.0 +
+      vec2f(1.0)) / 6.0;
+  let fourthWeight = fraction * fraction * fraction / 6.0;
+  let firstPairWeight = firstWeight + secondWeight;
+  let secondPairWeight = thirdWeight + fourthWeight;
+  let firstPosition =
+    (basePosition - vec2f(1.0) + secondWeight / firstPairWeight + vec2f(0.5)) / dimensions;
+  let secondPosition =
+    (basePosition + vec2f(1.0) + fourthWeight / secondPairWeight + vec2f(0.5)) / dimensions;
+  let topLeft = textureSampleLevel(
+    sourceTexture,
+    sourceTextureSampler,
+    vec2f(firstPosition.x, firstPosition.y),
+    0.0
+  );
+  let topRight = textureSampleLevel(
+    sourceTexture,
+    sourceTextureSampler,
+    vec2f(secondPosition.x, firstPosition.y),
+    0.0
+  );
+  let bottomLeft = textureSampleLevel(
+    sourceTexture,
+    sourceTextureSampler,
+    vec2f(firstPosition.x, secondPosition.y),
+    0.0
+  );
+  let bottomRight = textureSampleLevel(
+    sourceTexture,
+    sourceTextureSampler,
+    vec2f(secondPosition.x, secondPosition.y),
+    0.0
+  );
+  return topLeft * firstPairWeight.x * firstPairWeight.y +
+    topRight * secondPairWeight.x * firstPairWeight.y +
+    bottomLeft * firstPairWeight.x * secondPairWeight.y +
+    bottomRight * secondPairWeight.x * secondPairWeight.y;
+}
+
 fn bloomUpsample_sampleColor(
   sourceTexture: texture_2d<f32>,
   sourceTextureSampler: sampler,
   texSize: vec2f,
   texCoord: vec2f
 ) -> vec4f {
-  let lowerGlow = bloomUpsample_sampleLowerGlow(sourceTexture, sourceTextureSampler, texCoord);
+  var lowerGlow: vec4f;
+  if (bloomUpsample.reconstruction > 0.5) {
+    lowerGlow = bloomUpsample_sampleBicubicGlow(sourceTexture, sourceTextureSampler, texCoord);
+  } else {
+    lowerGlow = bloomUpsample_sampleLowerGlow(sourceTexture, sourceTextureSampler, texCoord);
+  }
   let higherGlow = textureSample(higherResolutionGlow, higherResolutionGlowSampler, texCoord);
   return mix(higherGlow, lowerGlow, clamp(bloomUpsample.scatter, 0.0, 1.0));
 }
@@ -511,6 +603,7 @@ fn bloomUpsample_sampleColor(
   fs: /* glsl */ `
 layout(std140) uniform bloomUpsampleUniforms {
   float scatter;
+  float reconstruction;
 } bloomUpsample;
 
 uniform sampler2D higherResolutionGlow;
@@ -534,21 +627,59 @@ vec4 bloomUpsample_sampleLowerGlow(sampler2D sourceTexture, vec2 texCoord) {
   return (center + edges + corners) / 16.0;
 }
 
+vec4 bloomUpsample_sampleBicubicGlow(sampler2D sourceTexture, vec2 texCoord) {
+  vec2 dimensions = vec2(textureSize(sourceTexture, 0));
+  vec2 texelPosition = texCoord * dimensions - vec2(0.5);
+  vec2 basePosition = floor(texelPosition);
+  vec2 fraction = fract(texelPosition);
+  vec2 complement = vec2(1.0) - fraction;
+  vec2 firstWeight = complement * complement * complement / 6.0;
+  vec2 secondWeight =
+    (fraction * fraction * fraction * 3.0 - fraction * fraction * 6.0 + vec2(4.0)) / 6.0;
+  vec2 thirdWeight =
+    (-fraction * fraction * fraction * 3.0 + fraction * fraction * 3.0 + fraction * 3.0 +
+      vec2(1.0)) / 6.0;
+  vec2 fourthWeight = fraction * fraction * fraction / 6.0;
+  vec2 firstPairWeight = firstWeight + secondWeight;
+  vec2 secondPairWeight = thirdWeight + fourthWeight;
+  vec2 firstPosition =
+    (basePosition - vec2(1.0) + secondWeight / firstPairWeight + vec2(0.5)) / dimensions;
+  vec2 secondPosition =
+    (basePosition + vec2(1.0) + fourthWeight / secondPairWeight + vec2(0.5)) / dimensions;
+  vec4 topLeft = textureLod(sourceTexture, vec2(firstPosition.x, firstPosition.y), 0.0);
+  vec4 topRight = textureLod(sourceTexture, vec2(secondPosition.x, firstPosition.y), 0.0);
+  vec4 bottomLeft = textureLod(sourceTexture, vec2(firstPosition.x, secondPosition.y), 0.0);
+  vec4 bottomRight = textureLod(sourceTexture, vec2(secondPosition.x, secondPosition.y), 0.0);
+  return topLeft * firstPairWeight.x * firstPairWeight.y +
+    topRight * secondPairWeight.x * firstPairWeight.y +
+    bottomLeft * firstPairWeight.x * secondPairWeight.y +
+    bottomRight * secondPairWeight.x * secondPairWeight.y;
+}
+
 vec4 bloomUpsample_sampleColor(sampler2D sourceTexture, vec2 texSize, vec2 texCoord) {
-  vec4 lowerGlow = bloomUpsample_sampleLowerGlow(sourceTexture, texCoord);
+  vec4 lowerGlow;
+  if (bloomUpsample.reconstruction > 0.5) {
+    lowerGlow = bloomUpsample_sampleBicubicGlow(sourceTexture, texCoord);
+  } else {
+    lowerGlow = bloomUpsample_sampleLowerGlow(sourceTexture, texCoord);
+  }
   vec4 higherGlow = texture(higherResolutionGlow, texCoord);
   return mix(higherGlow, lowerGlow, clamp(bloomUpsample.scatter, 0.0, 1.0));
 }
 `,
   bindingLayout: [{name: 'higherResolutionGlow', group: 0}],
-  uniforms: {} as {scatter?: number},
+  uniforms: {} as {scatter?: number; reconstruction?: number},
   bindings: {} as BloomUpsampleBindings,
-  uniformTypes: {scatter: 'f32'},
-  propTypes: {scatter: {value: 0.55, min: 0, max: 1}},
+  uniformTypes: {scatter: 'f32', reconstruction: 'f32'},
+  defaultUniforms: {scatter: 0.55, reconstruction: 0},
+  propTypes: {
+    scatter: {value: 0.55, min: 0, max: 1},
+    reconstruction: {value: 0, min: 0, max: 1, private: true}
+  },
   passes: [{sampler: true}]
 } as const satisfies ShaderPass<
-  {scatter?: number} & BloomUpsampleBindings,
-  {scatter?: number},
+  {scatter?: number; reconstruction?: number} & BloomUpsampleBindings,
+  {scatter?: number; reconstruction?: number},
   BloomUpsampleBindings
 >;
 
@@ -793,6 +924,11 @@ export function createBloomShaderPassPipeline(
   const scatter = options.scatter ?? 0.55;
   const softKnee = options.softKnee ?? 0.5;
   const fireflyReduction = options.fireflyReduction ?? 0;
+  const exposure = Math.max(options.exposure ?? 1, 0.0001);
+  const exposureCompensation = options.exposureCompensation ?? 0;
+  const reconstruction = options.reconstruction === 'bicubic' ? 1 : 0;
+  const downsample = options.downsample ?? 'auto';
+  const reuseRenderTargets = options.reuseRenderTargets ?? true;
   const anamorphicRatio = Math.min(Math.max(options.anamorphicRatio ?? 0, -1), 1);
   const tint = options.tint ?? [1, 1, 1];
   const temporalStability = Math.min(Math.max(options.temporalStability ?? 0, 0), 0.95);
@@ -835,7 +971,10 @@ export function createBloomShaderPassPipeline(
     const extractionTarget = `extract${level.name}`;
     const blurScratchTarget = `blur${level.name}Scratch`;
     const blurTarget = `blur${level.name}`;
-    renderTargets[extractionTarget] = makeRenderTarget(level.scale);
+    renderTargets[extractionTarget] = {
+      ...makeRenderTarget(level.scale),
+      ...(downsample !== 'render' ? {storage: true} : {})
+    };
     renderTargets[blurScratchTarget] = makeRenderTarget(level.scale);
     renderTargets[blurTarget] = makeRenderTarget(level.scale);
 
@@ -844,7 +983,7 @@ export function createBloomShaderPassPipeline(
         shaderPass: bloomExtractPass,
         inputs: {sourceTexture: 'previous'},
         output: extractionTarget,
-        uniforms: {threshold, softKnee, fireflyReduction}
+        uniforms: {threshold, softKnee, fireflyReduction, exposure, exposureCompensation}
       });
     } else {
       const previousLevel = levels[levelIndex - 1];
@@ -875,7 +1014,12 @@ export function createBloomShaderPassPipeline(
   for (let levelIndex = levels.length - 2; levelIndex >= 0; levelIndex--) {
     const level = levels[levelIndex];
     const upsampleTarget = `upsample${level.name}`;
-    renderTargets[upsampleTarget] = makeRenderTarget(level.scale);
+    renderTargets[upsampleTarget] = {
+      ...makeRenderTarget(level.scale),
+      ...(reuseRenderTargets && (!hasLensArtifacts || level.name !== 'Half')
+        ? {aliasFor: `extract${level.name}`}
+        : {})
+    };
     steps.push({
       shaderPass: bloomUpsamplePass,
       inputs: {
@@ -883,7 +1027,7 @@ export function createBloomShaderPassPipeline(
         higherResolutionGlow: `blur${level.name}`
       },
       output: upsampleTarget,
-      uniforms: {scatter}
+      uniforms: {scatter, reconstruction}
     });
     reconstructedGlow = upsampleTarget;
   }
@@ -947,6 +1091,19 @@ export function createBloomShaderPassPipeline(
   return {
     name: bloomShaderPassPipeline.name,
     renderTargets,
-    steps
+    steps,
+    ...(downsample !== 'render'
+      ? {
+          compute: createBloomComputePyramid({
+            levelNames: levels.map(level => level.name),
+            colorFormat,
+            threshold,
+            softKnee,
+            fireflyReduction,
+            exposure,
+            exposureCompensation
+          })
+        }
+      : {})
   };
 }

--- a/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
+++ b/modules/effects/src/passes/postprocessing/image-blur-filters/bloom-shader-pass-pipeline.ts
@@ -10,6 +10,16 @@ import type {
   ShaderPassRenderTarget
 } from '@luma.gl/shadertools';
 import type {BloomProps, BloomUniforms} from './bloom';
+import {
+  bloomLensArtifactsPass,
+  bloomTemporalPass,
+  createBloomLensCompositePass,
+  MAX_BLOOM_LENS_GHOSTS,
+  MAX_BLOOM_LENS_SPIKES,
+  type BloomLensEffectsOptions
+} from './bloom-lens-effects';
+
+export type {BloomLensEffectsOptions} from './bloom-lens-effects';
 
 const MAX_BLOOM_BLUR_RADIUS = 24;
 const BLOOM_TARGET_SAMPLER = {minFilter: 'linear', magFilter: 'linear'} as const;
@@ -47,6 +57,10 @@ export type BloomShaderPassPipelineOptions = BloomProps & {
   anamorphicRatio?: number;
   /** RGB multiplier applied to the reconstructed bloom before composition. */
   tint?: [number, number, number];
+  /** Optional photographic diffraction, spectral ghosts, lens halo, and sampled dirt mask. */
+  lens?: BloomLensEffectsOptions;
+  /** Neighborhood-clamped history contribution for stable highlights. Defaults to zero. */
+  temporalStability?: number;
   /**
    * Positive fractional size multiplier applied to every pyramid level. The extraction filter
    * adapts its source footprint to the resulting target size.
@@ -781,6 +795,27 @@ export function createBloomShaderPassPipeline(
   const fireflyReduction = options.fireflyReduction ?? 0;
   const anamorphicRatio = Math.min(Math.max(options.anamorphicRatio ?? 0, -1), 1);
   const tint = options.tint ?? [1, 1, 1];
+  const temporalStability = Math.min(Math.max(options.temporalStability ?? 0, 0), 0.95);
+  const lens = options.lens;
+  const starburstIntensity = Math.max(lens?.starburstIntensity ?? 0, 0);
+  const starburstSpikes = Math.min(
+    Math.max(Math.round((lens?.starburstSpikes ?? 4) / 2) * 2, 2),
+    MAX_BLOOM_LENS_SPIKES
+  );
+  const starburstLength = Math.min(Math.max(lens?.starburstLength ?? 48, 0), 256);
+  const starburstRotation = lens?.starburstRotation ?? 0;
+  const ghostIntensity = Math.max(lens?.ghostIntensity ?? 0, 0);
+  const ghostCount = Math.min(
+    Math.max(Math.round(lens?.ghostCount ?? 3), 1),
+    MAX_BLOOM_LENS_GHOSTS
+  );
+  const ghostSpacing = Math.min(Math.max(lens?.ghostSpacing ?? 0.32, 0), 1);
+  const haloIntensity = Math.max(lens?.haloIntensity ?? 0, 0);
+  const haloRadius = Math.min(Math.max(lens?.haloRadius ?? 0.34, 0), 1);
+  const chromaticAberration = Math.min(Math.max(lens?.chromaticAberration ?? 0, 0), 1);
+  const dirtIntensity = Math.max(lens?.dirtIntensity ?? 0, 0);
+  const hasLensArtifacts = starburstIntensity > 0 || ghostIntensity > 0 || haloIntensity > 0;
+  const hasLensDirt = dirtIntensity > 0;
   const anamorphicRadius = Math.min(
     radius,
     MAX_BLOOM_BLUR_RADIUS / (1 + Math.abs(anamorphicRatio))
@@ -853,12 +888,61 @@ export function createBloomShaderPassPipeline(
     reconstructedGlow = upsampleTarget;
   }
 
-  steps.push({
-    shaderPass: bloomAdaptiveCompositePass,
-    inputs: {sourceTexture: 'previous', glowTexture: reconstructedGlow},
-    output: 'previous',
-    uniforms: {tint, intensity}
-  });
+  if (temporalStability > 0) {
+    renderTargets['bloomGlowHistory'] = {
+      ...makeRenderTarget(0.5),
+      lifetime: 'history',
+      initialize: {clearColor: [0, 0, 0, 0]}
+    };
+    steps.push({
+      shaderPass: bloomTemporalPass,
+      inputs: {sourceTexture: reconstructedGlow, historyTexture: 'bloomGlowHistory'},
+      output: 'bloomGlowHistory',
+      uniforms: {stability: temporalStability}
+    });
+    reconstructedGlow = 'bloomGlowHistory';
+  }
+
+  if (hasLensArtifacts) {
+    renderTargets['bloomLensArtifacts'] = makeRenderTarget(0.5);
+    steps.push({
+      shaderPass: bloomLensArtifactsPass,
+      inputs: {sourceTexture: 'extractHalf', glowTexture: reconstructedGlow},
+      output: 'bloomLensArtifacts',
+      uniforms: {
+        starburstIntensity,
+        starburstSpikes,
+        starburstLength,
+        starburstRotation,
+        ghostIntensity,
+        ghostCount,
+        ghostSpacing,
+        haloIntensity,
+        haloRadius,
+        chromaticAberration
+      }
+    });
+  }
+
+  if (hasLensArtifacts || hasLensDirt) {
+    steps.push({
+      shaderPass: createBloomLensCompositePass(hasLensArtifacts, hasLensDirt),
+      inputs: {
+        sourceTexture: 'previous',
+        glowTexture: reconstructedGlow,
+        ...(hasLensArtifacts ? {lensTexture: 'bloomLensArtifacts'} : {})
+      },
+      output: 'previous',
+      uniforms: {tint, intensity, dirtIntensity}
+    });
+  } else {
+    steps.push({
+      shaderPass: bloomAdaptiveCompositePass,
+      inputs: {sourceTexture: 'previous', glowTexture: reconstructedGlow},
+      output: 'previous',
+      uniforms: {tint, intensity}
+    });
+  }
 
   return {
     name: bloomShaderPassPipeline.name,

--- a/modules/effects/test/passes/image-blur-filters/bloom.node.spec.ts
+++ b/modules/effects/test/passes/image-blur-filters/bloom.node.spec.ts
@@ -1,0 +1,137 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {createBloomShaderPassPipeline} from '@luma.gl/effects';
+import {WgslReflect} from 'wgsl_reflect';
+import test from 'test/utils/vitest-tape';
+
+test('HDR bloom fuses every selected pyramid level into one WebGPU dispatch', testCase => {
+  const qualityLevels = [
+    {quality: 'low', levelCount: 2},
+    {quality: 'medium', levelCount: 3},
+    {quality: 'high', levelCount: 4},
+    {quality: 'ultra', levelCount: 5}
+  ] as const;
+
+  for (const {quality, levelCount} of qualityLevels) {
+    const pipeline = createBloomShaderPassPipeline({quality, downsample: 'auto'});
+    const optimization = pipeline.compute;
+
+    testCase.ok(optimization, `${quality} includes a portable fused-compute optimization`);
+    if (!optimization) {
+      continue;
+    }
+    const reflection = new WgslReflect(optimization.source);
+    testCase.equal(reflection.entry.compute.length, 1, `${quality} uses exactly one dispatch`);
+    testCase.equal(
+      Object.keys(optimization.outputs).length,
+      levelCount,
+      `${quality} writes each of its ${levelCount} pyramid levels`
+    );
+    testCase.deepEqual(
+      optimization.replacedPasses,
+      ['bloomExtract', 'bloomDownsample'],
+      `${quality} preserves its original extraction passes as the portable fallback`
+    );
+    testCase.match(
+      optimization.source,
+      /var<workgroup> bloomTile/,
+      'reduction reuses shared memory'
+    );
+    testCase.match(
+      optimization.source,
+      /workgroupBarrier\(\)/,
+      'reduction synchronizes tile writes'
+    );
+    testCase.ok(
+      Object.values(optimization.outputs).every(
+        targetName => pipeline.renderTargets?.[targetName].storage
+      ),
+      `${quality} explicitly enables storage only on writable extraction targets`
+    );
+  }
+
+  const portablePipeline = createBloomShaderPassPipeline({downsample: 'render'});
+  testCase.equal(portablePipeline.compute, undefined, 'render-only mode omits the compute stage');
+  testCase.ok(
+    Object.values(portablePipeline.renderTargets || {}).every(target => !target.storage),
+    'render-only mode avoids unnecessary storage texture usage'
+  );
+  testCase.end();
+});
+
+test('HDR bloom shares expired targets without overwriting live lens highlights', testCase => {
+  const reusedPipeline = createBloomShaderPassPipeline({quality: 'ultra'});
+  const dedicatedPipeline = createBloomShaderPassPipeline({
+    quality: 'ultra',
+    reuseRenderTargets: false
+  });
+  const opticalPipeline = createBloomShaderPassPipeline({
+    quality: 'ultra',
+    lens: {starburstIntensity: 1}
+  });
+
+  for (const levelName of ['Half', 'Quarter', 'Eighth', 'Sixteenth']) {
+    testCase.equal(
+      reusedPipeline.renderTargets?.[`upsample${levelName}`].aliasFor,
+      `extract${levelName}`,
+      `${levelName} reconstruction reuses its expired extraction allocation`
+    );
+    testCase.equal(
+      dedicatedPipeline.renderTargets?.[`upsample${levelName}`].aliasFor,
+      undefined,
+      `${levelName} can retain a dedicated target when diagnostics require it`
+    );
+  }
+  testCase.equal(
+    opticalPipeline.renderTargets?.upsampleHalf.aliasFor,
+    undefined,
+    'half-resolution highlights remain available to the later lens pass'
+  );
+  testCase.equal(
+    opticalPipeline.renderTargets?.upsampleQuarter.aliasFor,
+    'extractQuarter',
+    'optical artifacts do not prevent reuse at coarser expired levels'
+  );
+  testCase.end();
+});
+
+test('HDR bloom supports exposure-aware extraction and four-fetch bicubic reconstruction', testCase => {
+  const pipeline = createBloomShaderPassPipeline({
+    threshold: 1.5,
+    exposure: 2,
+    exposureCompensation: -1,
+    reconstruction: 'bicubic'
+  });
+  const extract = pipeline.steps.find(step => step.shaderPass.name === 'bloomExtract');
+  const upsample = pipeline.steps.filter(step => step.shaderPass.name === 'bloomUpsample');
+
+  testCase.equal(extract?.uniforms?.threshold, 1.5, 'the original scene threshold is retained');
+  testCase.equal(extract?.uniforms?.exposure, 2, 'adapted camera exposure reaches extraction');
+  testCase.equal(
+    extract?.uniforms?.exposureCompensation,
+    -1,
+    'photographic stop compensation reaches extraction'
+  );
+  testCase.deepEqual(
+    pipeline.compute?.uniforms,
+    {threshold: 1.5, softKnee: 0.5, fireflyReduction: 0, exposure: 2, exposureCompensation: -1},
+    'fragment and fused compute paths receive the same exposure-aware defaults'
+  );
+  testCase.ok(
+    upsample.every(step => step.uniforms?.reconstruction === 1),
+    'bicubic reconstruction is selected at every pyramid level'
+  );
+  testCase.match(
+    upsample[0]?.shaderPass.source || '',
+    /bloomUpsample_sampleBicubicGlow/,
+    'WGSL contains the normalized bicubic reconstruction path'
+  );
+  testCase.match(
+    upsample[0]?.shaderPass.fs || '',
+    /bloomUpsample_sampleBicubicGlow/,
+    'WebGL retains an equivalent bicubic fallback'
+  );
+  testCase.end();
+});

--- a/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
+++ b/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
@@ -310,6 +310,124 @@ test('createBloomShaderPassPipeline#anamorphic radii stay within the shader kern
   testCase.end();
 });
 
+test('createBloomShaderPassPipeline#optional cinematic lens effects', testCase => {
+  const defaultPipeline = createBloomShaderPassPipeline();
+  const dirtOnlyPipeline = createBloomShaderPassPipeline({lens: {dirtIntensity: 0.8}});
+  const cinematicPipeline = createBloomShaderPassPipeline({
+    quality: 'high',
+    temporalStability: 0.7,
+    lens: {
+      starburstIntensity: 1.1,
+      starburstSpikes: 7,
+      starburstLength: 64,
+      starburstRotation: 0.35,
+      ghostIntensity: 0.65,
+      ghostCount: 12,
+      ghostSpacing: 0.4,
+      haloIntensity: 0.45,
+      haloRadius: 0.28,
+      chromaticAberration: 0.6,
+      dirtIntensity: 0.35
+    }
+  });
+  const lensStep = cinematicPipeline.steps.find(step => step.shaderPass.name === 'bloomLens');
+  const temporalStep = cinematicPipeline.steps.find(
+    step => step.shaderPass.name === 'bloomTemporal'
+  );
+  const compositeStep = cinematicPipeline.steps.find(
+    step => step.shaderPass.name === 'bloomComposite'
+  );
+  const dirtOnlyComposite = dirtOnlyPipeline.steps.find(
+    step => step.shaderPass.name === 'bloomComposite'
+  );
+
+  testCase.equal(defaultPipeline.steps.length, 16, 'default high-quality bloom keeps its 16 passes');
+  testCase.equal(
+    dirtOnlyPipeline.steps.length,
+    defaultPipeline.steps.length,
+    'lens dirt reuses the existing composite without adding a render pass'
+  );
+  testCase.equal(
+    Object.keys(dirtOnlyPipeline.renderTargets || {}).length,
+    Object.keys(defaultPipeline.renderTargets || {}).length,
+    'lens dirt does not allocate another intermediate texture'
+  );
+  testCase.deepEqual(
+    dirtOnlyComposite?.shaderPass.bindingLayout?.map(binding => binding.name),
+    ['glowTexture', 'lensDirtTexture'],
+    'dirt-only composition requires only the glow and external dirt mask'
+  );
+  testCase.equal(
+    cinematicPipeline.steps.length,
+    defaultPipeline.steps.length + 2,
+    'all lens artifacts share one half-resolution pass and stabilization adds one history pass'
+  );
+  testCase.deepEqual(
+    cinematicPipeline.renderTargets?.['bloomLensArtifacts'].scale,
+    [0.5, 0.5],
+    'photographic artifacts render at half resolution'
+  );
+  testCase.equal(
+    cinematicPipeline.renderTargets?.['bloomGlowHistory'].lifetime,
+    'history',
+    'temporal stabilization owns persistent glow history'
+  );
+  testCase.deepEqual(
+    cinematicPipeline.renderTargets?.['bloomGlowHistory'].initialize,
+    {clearColor: [0, 0, 0, 0]},
+    'an invalid history marker prevents first-frame darkening'
+  );
+  testCase.deepEqual(
+    temporalStep?.inputs,
+    {sourceTexture: 'upsampleHalf', historyTexture: 'bloomGlowHistory'},
+    'temporal stabilization clamps reconstructed glow against its previous frame'
+  );
+  testCase.equal(temporalStep?.uniforms?.stability, 0.7, 'configures temporal history blending');
+  testCase.deepEqual(
+    lensStep?.inputs,
+    {sourceTexture: 'extractHalf', glowTexture: 'bloomGlowHistory'},
+    'lens artifacts combine sharp HDR highlights with stabilized glow'
+  );
+  testCase.equal(lensStep?.uniforms?.starburstSpikes, 8, 'rounds diffraction rays to an even count');
+  testCase.equal(lensStep?.uniforms?.ghostCount, 6, 'caps ghost reflections at their shader budget');
+  testCase.equal(
+    lensStep?.uniforms?.chromaticAberration,
+    0.6,
+    'configures spectral lens separation'
+  );
+  testCase.match(
+    lensStep?.shaderPass.source || '',
+    /textureSampleLevel\(sourceTexture/,
+    'WGSL lens reflections use explicit levels inside nonuniform screen-space branches'
+  );
+  testCase.match(
+    lensStep?.shaderPass.fs || '',
+    /textureLod\(sourceTexture/,
+    'GLSL lens reflections match the explicit sampling behavior'
+  );
+  testCase.deepEqual(
+    compositeStep?.shaderPass.bindingLayout?.map(binding => binding.name),
+    ['glowTexture', 'lensTexture', 'lensDirtTexture'],
+    'composition binds dirt and lens artifacts only when they are enabled'
+  );
+  testCase.equal(compositeStep?.uniforms?.dirtIntensity, 0.35, 'configures the dirt-mask strength');
+
+  const clampedPipeline = createBloomShaderPassPipeline({
+    temporalStability: 4,
+    lens: {starburstIntensity: 1, starburstSpikes: 1, starburstLength: 500}
+  });
+  const clampedLensStep = clampedPipeline.steps.find(step => step.shaderPass.name === 'bloomLens');
+  testCase.equal(
+    clampedPipeline.steps.find(step => step.shaderPass.name === 'bloomTemporal')?.uniforms
+      ?.stability,
+    0.95,
+    'limits history contribution to preserve responsiveness'
+  );
+  testCase.equal(clampedLensStep?.uniforms?.starburstSpikes, 2, 'keeps at least two diffraction rays');
+  testCase.equal(clampedLensStep?.uniforms?.starburstLength, 256, 'limits the diffraction radius');
+  testCase.end();
+});
+
 test('HDR bloom covers source texels at quarter pyramid resolution', async testCase => {
   const device = await getWebGPUTestDevice();
   if (!device) {

--- a/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
+++ b/modules/effects/test/passes/image-blur-filters/bloom.spec.ts
@@ -341,7 +341,11 @@ test('createBloomShaderPassPipeline#optional cinematic lens effects', testCase =
     step => step.shaderPass.name === 'bloomComposite'
   );
 
-  testCase.equal(defaultPipeline.steps.length, 16, 'default high-quality bloom keeps its 16 passes');
+  testCase.equal(
+    defaultPipeline.steps.length,
+    16,
+    'default high-quality bloom keeps its 16 passes'
+  );
   testCase.equal(
     dirtOnlyPipeline.steps.length,
     defaultPipeline.steps.length,
@@ -388,8 +392,16 @@ test('createBloomShaderPassPipeline#optional cinematic lens effects', testCase =
     {sourceTexture: 'extractHalf', glowTexture: 'bloomGlowHistory'},
     'lens artifacts combine sharp HDR highlights with stabilized glow'
   );
-  testCase.equal(lensStep?.uniforms?.starburstSpikes, 8, 'rounds diffraction rays to an even count');
-  testCase.equal(lensStep?.uniforms?.ghostCount, 6, 'caps ghost reflections at their shader budget');
+  testCase.equal(
+    lensStep?.uniforms?.starburstSpikes,
+    8,
+    'rounds diffraction rays to an even count'
+  );
+  testCase.equal(
+    lensStep?.uniforms?.ghostCount,
+    6,
+    'caps ghost reflections at their shader budget'
+  );
   testCase.equal(
     lensStep?.uniforms?.chromaticAberration,
     0.6,
@@ -423,8 +435,194 @@ test('createBloomShaderPassPipeline#optional cinematic lens effects', testCase =
     0.95,
     'limits history contribution to preserve responsiveness'
   );
-  testCase.equal(clampedLensStep?.uniforms?.starburstSpikes, 2, 'keeps at least two diffraction rays');
+  testCase.equal(
+    clampedLensStep?.uniforms?.starburstSpikes,
+    2,
+    'keeps at least two diffraction rays'
+  );
   testCase.equal(clampedLensStep?.uniforms?.starburstLength, 256, 'limits the diffraction radius');
+  testCase.end();
+});
+
+test('HDR bloom replaces fragment extraction with one exposure-aware WebGPU dispatch', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const capabilities = device.getTextureFormatCapabilities('rgba16float');
+  if (
+    !capabilities.render ||
+    !capabilities.filter ||
+    !capabilities.store ||
+    device.limits.maxStorageTexturesPerShaderStage < 3
+  ) {
+    testCase.comment('Fused floating-point storage textures are unavailable');
+    testCase.end();
+    return;
+  }
+
+  const width = 32;
+  const height = 32;
+  const highlightX = 16;
+  const highlightY = 10;
+  const sourcePixels = new Uint16Array(width * height * 4);
+  for (let pixelIndex = 0; pixelIndex < width * height; pixelIndex++) {
+    sourcePixels[pixelIndex * 4 + 3] = toHalfFloat(1);
+  }
+  sourcePixels.set(
+    [toHalfFloat(4), toHalfFloat(4), toHalfFloat(4), toHalfFloat(1)],
+    (highlightY * width + highlightX) * 4
+  );
+  const sourceTexture = device.createTexture({
+    id: 'fused-bloom-source',
+    width,
+    height,
+    format: 'rgba16float',
+    data: sourcePixels,
+    usage: Texture.SAMPLE | Texture.COPY_DST
+  });
+  const renderer = new ShaderPassRenderer(device, {
+    shaderPasses: [
+      createBloomShaderPassPipeline({
+        quality: 'medium',
+        threshold: 1,
+        radius: 3,
+        downsample: 'auto'
+      })
+    ],
+    colorFormat: 'rgba16float',
+    flipY: false
+  });
+  renderer.resize([width, height]);
+
+  const renderWithExposure = async (
+    exposure: number,
+    selectedRenderer: ShaderPassRenderer = renderer
+  ): Promise<{
+    highlight: number;
+    neighbor: number;
+    reflectedNeighbor: number;
+    renderPasses: number;
+    computePasses: number;
+  }> => {
+    const encoder = device.createCommandEncoder({id: `fused-bloom-exposure-${exposure}`});
+    let renderPasses = 0;
+    let computePasses = 0;
+    const beginRenderPass = encoder.beginRenderPass.bind(encoder);
+    const beginComputePass = encoder.beginComputePass.bind(encoder);
+    encoder.beginRenderPass = props => {
+      renderPasses++;
+      return beginRenderPass(props);
+    };
+    encoder.beginComputePass = props => {
+      computePasses++;
+      return beginComputePass(props);
+    };
+    const outputTexture = selectedRenderer.encodeToTexture(encoder, {
+      sourceTexture,
+      uniforms: {bloomExtract: {exposure}, bloomComposite: {intensity: 2}}
+    });
+    device.submit(encoder.finish());
+    if (!outputTexture) {
+      throw new Error('Fused bloom did not produce an output texture.');
+    }
+
+    const layout = outputTexture.computeMemoryLayout({width, height});
+    const readback = device.createBuffer({
+      id: `fused-bloom-readback-${exposure}`,
+      byteLength: layout.byteLength,
+      usage: Buffer.COPY_DST | Buffer.MAP_READ
+    });
+    try {
+      outputTexture.readBuffer({width, height}, readback);
+      device.submit();
+      const bytes = await readback.readAsync(0, layout.byteLength);
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      const readRed = (pixelX: number, pixelY = highlightY): number =>
+        fromHalfFloat(view.getUint16(pixelY * layout.bytesPerRow + pixelX * 8, true));
+      return {
+        highlight: readRed(highlightX),
+        neighbor: readRed(highlightX + 2),
+        reflectedNeighbor: readRed(highlightX + 2, height - highlightY - 1),
+        renderPasses,
+        computePasses
+      };
+    } finally {
+      readback.destroy();
+    }
+  };
+
+  try {
+    testCase.ok(
+      renderer.passRenderers[0].computeRenderer,
+      'the supported backend selects fused compute'
+    );
+    const lowExposure = await renderWithExposure(0.2);
+    const highExposure = await renderWithExposure(2);
+
+    testCase.equal(highExposure.computePasses, 1, 'all pyramid levels share one compute dispatch');
+    testCase.equal(
+      highExposure.renderPasses,
+      10,
+      'medium quality uses nine effect render passes plus one source-seeding pass'
+    );
+    testCase.ok(
+      highExposure.highlight > 4,
+      'HDR extraction contributes glow above the source peak'
+    );
+    testCase.ok(
+      highExposure.neighbor > lowExposure.neighbor,
+      'runtime camera exposure changes the effective threshold without rebuilding the renderer'
+    );
+
+    const flippedComputeRenderer = new ShaderPassRenderer(device, {
+      shaderPasses: [
+        createBloomShaderPassPipeline({
+          quality: 'medium',
+          threshold: 1,
+          radius: 3,
+          reconstruction: 'bicubic'
+        })
+      ],
+      colorFormat: 'rgba16float',
+      flipY: true
+    });
+    const flippedFragmentRenderer = new ShaderPassRenderer(device, {
+      shaderPasses: [
+        createBloomShaderPassPipeline({
+          quality: 'medium',
+          threshold: 1,
+          radius: 3,
+          downsample: 'render',
+          reconstruction: 'bicubic'
+        })
+      ],
+      colorFormat: 'rgba16float',
+      flipY: true
+    });
+    flippedComputeRenderer.resize([width, height]);
+    flippedFragmentRenderer.resize([width, height]);
+    try {
+      const flippedCompute = await renderWithExposure(2, flippedComputeRenderer);
+      const flippedFragment = await renderWithExposure(2, flippedFragmentRenderer);
+      testCase.equal(flippedCompute.computePasses, 1, 'flipped WebGPU extraction stays fused');
+      testCase.equal(flippedFragment.computePasses, 0, 'explicit fragment mode disables compute');
+      testCase.equal(
+        Math.sign(flippedCompute.neighbor - flippedCompute.reflectedNeighbor),
+        Math.sign(flippedFragment.neighbor - flippedFragment.reflectedNeighbor),
+        'fused extraction preserves the fragment fallback texture orientation'
+      );
+    } finally {
+      flippedComputeRenderer.destroy();
+      flippedFragmentRenderer.destroy();
+    }
+  } finally {
+    renderer.destroy();
+    sourceTexture.destroy();
+  }
   testCase.end();
 });
 

--- a/modules/engine/src/passes/shader-pass-renderer.ts
+++ b/modules/engine/src/passes/shader-pass-renderer.ts
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import type {Binding, CommandEncoder, TextureFormatColor} from '@luma.gl/core';
-import {Device, Framebuffer, RenderPass, Texture} from '@luma.gl/core';
+import type {Binding, BindingDeclaration, CommandEncoder, TextureFormatColor} from '@luma.gl/core';
+import {Buffer, Device, Framebuffer, RenderPass, Texture} from '@luma.gl/core';
 import type {
   ShaderPass,
+  ShaderPassComputeOptimization,
   ShaderPassInputSource,
   ShaderPassPipeline,
   ShaderPassRenderTarget
@@ -16,6 +17,7 @@ import {DynamicTexture} from '../dynamic-texture/dynamic-texture';
 import type {TextureBindingSource} from '../dynamic-texture/texture-binding-source';
 import {ClipSpace} from '../models/clip-space';
 import {SwapFramebuffers} from '../compute/swap';
+import {Computation} from '../compute/computation';
 import {BackgroundTextureModel} from '../models/billboard-texture-model';
 
 import {getFragmentShaderForRenderPass} from './get-fragment-shader';
@@ -237,6 +239,12 @@ export class ShaderPassRenderer {
     try {
       for (const passRenderer of this.passRenderers) {
         passRenderer.initializeHistoryTargets(originalTexture, this.textureModel, commandEncoder);
+        passRenderer.runComputeOptimization({
+          commandEncoder,
+          originalTexture,
+          previousTexture,
+          runtimeUniforms: options.uniforms || {}
+        });
         for (const execution of passRenderer.subPassExecutions) {
           const outputName = execution.output || 'previous';
           const outputFramebuffer: Framebuffer =
@@ -305,6 +313,7 @@ class PassRenderer {
   passDefinition: ShaderPassLike;
   renderTargets: Record<string, ManagedRenderTarget>;
   subPassExecutions: EffectiveSubPass[];
+  computeRenderer?: PipelineComputeRenderer;
 
   constructor(
     device: Device,
@@ -319,7 +328,20 @@ class PassRenderer {
     if (isShaderPassPipeline(passDefinition)) {
       validateRenderTargetNames(passDefinition.name, passDefinition.renderTargets || {});
       this.renderTargets = createManagedRenderTargets(device, passDefinition.renderTargets || {});
-      this.subPassExecutions = passDefinition.steps.flatMap(step =>
+      if (supportsComputeOptimization(device, passDefinition)) {
+        this.computeRenderer = new PipelineComputeRenderer(
+          device,
+          passDefinition.compute!,
+          this.renderTargets,
+          shaderInputs
+        );
+      }
+      const executableSteps = this.computeRenderer
+        ? passDefinition.steps.filter(
+            step => !passDefinition.compute!.replacedPasses.includes(step.shaderPass.name)
+          )
+        : passDefinition.steps;
+      this.subPassExecutions = executableSteps.flatMap(step =>
         this.createStepExecutions(passDefinition, step, flipY)
       );
       return;
@@ -334,6 +356,7 @@ class PassRenderer {
   }
 
   destroy() {
+    this.computeRenderer?.destroy();
     for (const execution of this.subPassExecutions) {
       execution.subPassRenderer.destroy();
     }
@@ -342,6 +365,26 @@ class PassRenderer {
 
   resize(size: [width: number, height: number]) {
     resizeManagedRenderTargets(this.device, this.renderTargets, size);
+  }
+
+  runComputeOptimization(options: {
+    commandEncoder: CommandEncoder;
+    originalTexture: Texture;
+    previousTexture: Texture;
+    runtimeUniforms: Record<string, Record<string, unknown>>;
+  }): void {
+    if (!this.computeRenderer) {
+      return;
+    }
+    const sourceTexture = this.resolveInputTexture(
+      this.computeRenderer.optimization.input,
+      options.originalTexture,
+      options.previousTexture
+    );
+    this.computeRenderer.encode(options.commandEncoder, sourceTexture, options.runtimeUniforms);
+    for (const targetName of Object.values(this.computeRenderer.optimization.outputs)) {
+      this.markTargetWritten(targetName);
+    }
   }
 
   resetHistory(): void {
@@ -458,7 +501,7 @@ class PassRenderer {
           `${execution.ownerName}: subpass cannot read and write render target "${outputName}" in the same draw`
         );
       }
-      if (bindingName === 'sourceTexture' && texture === outputTexture) {
+      if (texture === outputTexture) {
         throw new Error(
           `${execution.ownerName}: subpass cannot sample from the render target it is writing to`
         );
@@ -548,6 +591,109 @@ class PassRenderer {
   }
 }
 
+/** Executes one optional WebGPU compute replacement before the remaining fragment passes. */
+class PipelineComputeRenderer {
+  readonly optimization: ShaderPassComputeOptimization;
+
+  private readonly renderTargets: Record<string, ManagedRenderTarget>;
+  private readonly shaderInputs: ShaderInputs;
+  private readonly computation: Computation;
+  private readonly parameterBuffer: Buffer;
+
+  constructor(
+    device: Device,
+    optimization: ShaderPassComputeOptimization,
+    renderTargets: Record<string, ManagedRenderTarget>,
+    shaderInputs: ShaderInputs
+  ) {
+    this.optimization = optimization;
+    this.renderTargets = renderTargets;
+    this.shaderInputs = shaderInputs;
+    this.parameterBuffer = device.createBuffer({
+      id: `${optimization.name}-parameters`,
+      byteLength: Math.max(Math.ceil(optimization.uniformNames.length / 4) * 16, 16),
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    const outputBindings: BindingDeclaration[] = Object.entries(optimization.outputs).map(
+      ([bindingName, targetName], outputIndex) => ({
+        name: bindingName,
+        type: 'storage',
+        group: 0,
+        location: outputIndex + 2,
+        access: 'write-only',
+        format: renderTargets[targetName].texture.format
+      })
+    );
+    try {
+      this.computation = new Computation(device, {
+        id: optimization.name,
+        source: optimization.source,
+        shaderLayout: {
+          bindings: [
+            {name: optimization.uniformBinding, type: 'uniform', group: 0, location: 0},
+            {
+              name: 'sourceTexture',
+              type: 'texture',
+              group: 0,
+              location: 1,
+              sampleType: 'unfilterable-float'
+            },
+            ...outputBindings
+          ]
+        }
+      });
+    } catch (error) {
+      this.parameterBuffer.destroy();
+      throw error;
+    }
+  }
+
+  encode(
+    commandEncoder: CommandEncoder,
+    sourceTexture: Texture,
+    runtimeUniforms: Record<string, Record<string, unknown>>
+  ): void {
+    const effectiveUniforms = {
+      ...(this.shaderInputs.getUniformValues()[this.optimization.uniformModule] || {}),
+      ...this.optimization.uniforms,
+      ...(runtimeUniforms[this.optimization.uniformModule] || {})
+    };
+    const uniformValues = new Float32Array(
+      Math.max(Math.ceil(this.optimization.uniformNames.length / 4) * 4, 4)
+    );
+    for (const [uniformIndex, uniformName] of this.optimization.uniformNames.entries()) {
+      const value = effectiveUniforms[uniformName];
+      uniformValues[uniformIndex] = typeof value === 'number' ? value : 0;
+    }
+    this.parameterBuffer.write(uniformValues);
+
+    const outputEntries = Object.entries(this.optimization.outputs);
+    const bindings: Record<string, Binding> = {
+      [this.optimization.uniformBinding]: this.parameterBuffer,
+      sourceTexture: sourceTexture.view
+    };
+    for (const [bindingName, targetName] of outputEntries) {
+      bindings[bindingName] = this.renderTargets[targetName].texture.view;
+    }
+    this.computation.setBindings(bindings);
+    this.computation.predraw(commandEncoder);
+    const dispatchTarget = this.renderTargets[outputEntries[0][1]].texture;
+    const computePass = commandEncoder.beginComputePass({id: this.optimization.name});
+    this.computation.dispatch(
+      computePass,
+      Math.ceil(dispatchTarget.width / this.optimization.workgroupSize[0]),
+      Math.ceil(dispatchTarget.height / this.optimization.workgroupSize[1]),
+      1
+    );
+    computePass.end();
+  }
+
+  destroy(): void {
+    this.computation.destroy();
+    this.parameterBuffer.destroy();
+  }
+}
+
 /** Renders a single subpass of a `ShaderPass`. */
 class SubPassRenderer {
   model: ClipSpace;
@@ -616,6 +762,34 @@ function getExecutableShaderPasses(shaderPasses: ShaderPassLike[]): ShaderPass[]
 
 function isShaderPassPipeline(shaderPass: ShaderPassLike): shaderPass is ShaderPassPipeline {
   return 'steps' in shaderPass;
+}
+
+function supportsComputeOptimization(device: Device, pipeline: ShaderPassPipeline): boolean {
+  const optimization = pipeline.compute;
+  if (!optimization || device.type !== 'webgpu') {
+    return false;
+  }
+
+  const outputNames = Object.values(optimization.outputs);
+  if (
+    outputNames.length === 0 ||
+    outputNames.length > device.limits.maxStorageTexturesPerShaderStage ||
+    optimization.workgroupSize[0] > device.limits.maxComputeWorkgroupSizeX ||
+    optimization.workgroupSize[1] > device.limits.maxComputeWorkgroupSizeY ||
+    optimization.workgroupSize[0] * optimization.workgroupSize[1] >
+      device.limits.maxComputeInvocationsPerWorkgroup
+  ) {
+    return false;
+  }
+
+  return outputNames.every(targetName => {
+    const target = pipeline.renderTargets?.[targetName];
+    if (!target?.storage) {
+      return false;
+    }
+    const format = target.format || device.preferredColorFormat;
+    return device.getTextureFormatCapabilities(format).store;
+  });
 }
 
 function validateShaderPassDoesNotOwnRenderTargets(
@@ -706,17 +880,66 @@ function createManagedRenderTargets(
   renderTargets: Record<string, ShaderPassRenderTarget>
 ): Record<string, ManagedRenderTarget> {
   const size = device.getCanvasContext().getDrawingBufferSize();
-  return Object.entries(renderTargets).reduce(
-    (managedRenderTargets, [name, spec]) => ({
-      ...managedRenderTargets,
-      [name]: createManagedRenderTarget(device, name, spec, size)
-    }),
-    {} as Record<string, ManagedRenderTarget>
+  const managedRenderTargets: Record<string, ManagedRenderTarget> = {};
+
+  for (const [name, spec] of Object.entries(renderTargets)) {
+    if (spec.aliasFor) {
+      const aliasedTarget = managedRenderTargets[spec.aliasFor];
+      if (!aliasedTarget) {
+        throw new Error(`${name}: target alias references an unknown earlier target`);
+      }
+      const targetSize = getRenderTargetSize(size, spec.scale);
+      const targetFormat = spec.format || device.preferredColorFormat;
+      if (
+        spec.lifetime === 'history' ||
+        aliasedTarget.spec.lifetime === 'history' ||
+        !hasMatchingRenderTargetScale(spec, aliasedTarget.spec) ||
+        aliasedTarget.texture.width !== targetSize[0] ||
+        aliasedTarget.texture.height !== targetSize[1] ||
+        aliasedTarget.texture.format !== targetFormat ||
+        (spec.storage && !aliasedTarget.spec.storage) ||
+        !hasMatchingRenderTargetSampler(spec, aliasedTarget.spec)
+      ) {
+        throw new Error(
+          `${name}: target alias must match a transient target's size, format, and sampler`
+        );
+      }
+      managedRenderTargets[name] = aliasedTarget;
+      continue;
+    }
+
+    managedRenderTargets[name] = createManagedRenderTarget(device, name, spec, size);
+  }
+
+  return managedRenderTargets;
+}
+
+function hasMatchingRenderTargetScale(
+  firstTarget: ShaderPassRenderTarget,
+  secondTarget: ShaderPassRenderTarget
+): boolean {
+  const firstScale = firstTarget.scale || [1, 1];
+  const secondScale = secondTarget.scale || [1, 1];
+  return firstScale[0] === secondScale[0] && firstScale[1] === secondScale[1];
+}
+
+function hasMatchingRenderTargetSampler(
+  firstTarget: ShaderPassRenderTarget,
+  secondTarget: ShaderPassRenderTarget
+): boolean {
+  const firstSampler = firstTarget.sampler || {};
+  const secondSampler = secondTarget.sampler || {};
+  const firstEntries = Object.entries(firstSampler);
+  return (
+    firstEntries.length === Object.keys(secondSampler).length &&
+    firstEntries.every(
+      ([name, value]) => secondSampler[name as keyof typeof secondSampler] === value
+    )
   );
 }
 
 function destroyManagedRenderTargets(renderTargets: Record<string, ManagedRenderTarget>): void {
-  for (const renderTarget of Object.values(renderTargets)) {
+  for (const renderTarget of new Set(Object.values(renderTargets))) {
     renderTarget.framebuffer.destroy();
     renderTarget.texture.destroy();
     renderTarget.historyFramebuffer?.destroy();
@@ -729,7 +952,7 @@ function resizeManagedRenderTargets(
   renderTargets: Record<string, ManagedRenderTarget>,
   size: [width: number, height: number]
 ): void {
-  for (const renderTarget of Object.values(renderTargets)) {
+  for (const renderTarget of new Set(Object.values(renderTargets))) {
     const targetSize = getRenderTargetSize(size, renderTarget.spec.scale);
     if (
       renderTarget.texture.width === targetSize[0] &&
@@ -796,7 +1019,16 @@ function createTargetResources(
     width: targetSize[0],
     height: targetSize[1],
     format: spec.format || device.preferredColorFormat,
-    usage: Texture.SAMPLE | Texture.RENDER | Texture.COPY_SRC | Texture.COPY_DST,
+    usage:
+      Texture.SAMPLE |
+      Texture.RENDER |
+      Texture.COPY_SRC |
+      Texture.COPY_DST |
+      (spec.storage &&
+      device.type === 'webgpu' &&
+      device.getTextureFormatCapabilities(spec.format || device.preferredColorFormat).store
+        ? Texture.STORAGE
+        : 0),
     ...(spec.sampler ? {sampler: spec.sampler} : {})
   });
   const framebuffer = device.createFramebuffer({

--- a/modules/engine/test/passes/shader-pass-renderer.spec.ts
+++ b/modules/engine/test/passes/shader-pass-renderer.spec.ts
@@ -230,6 +230,54 @@ const selfAliasingPipeline: ShaderPassPipeline<'scratch'> = {
   ]
 };
 
+const reusedTargetPipeline: ShaderPassPipeline<'extract' | 'reconstructed'> = {
+  name: 'reusedTarget',
+  renderTargets: {
+    extract: {sampler: {minFilter: 'linear', magFilter: 'linear'}},
+    reconstructed: {
+      aliasFor: 'extract',
+      sampler: {minFilter: 'linear', magFilter: 'linear'}
+    }
+  },
+  steps: [
+    {
+      shaderPass: copyPass,
+      inputs: {sourceTexture: 'original'},
+      output: 'extract'
+    },
+    {
+      shaderPass: copyPass,
+      inputs: {sourceTexture: 'extract'},
+      output: 'previous'
+    },
+    {
+      shaderPass: invertPass,
+      inputs: {sourceTexture: 'previous'},
+      output: 'reconstructed'
+    },
+    {
+      shaderPass: copyPass,
+      inputs: {sourceTexture: 'reconstructed'},
+      output: 'previous'
+    }
+  ]
+};
+
+const indirectlyAliasingPipeline: ShaderPassPipeline<'extract' | 'reconstructed'> = {
+  name: 'indirectlyAliasing',
+  renderTargets: {
+    extract: {},
+    reconstructed: {aliasFor: 'extract'}
+  },
+  steps: [
+    {
+      shaderPass: combinePass,
+      inputs: {sourceTexture: 'previous', mixTexture: 'extract'},
+      output: 'reconstructed'
+    }
+  ]
+};
+
 const historyPipeline: ShaderPassPipeline<'historyColor'> = {
   name: 'historyPipeline',
   renderTargets: {
@@ -622,6 +670,64 @@ test('ShaderPassRenderer supports ShaderPassPipeline targets', async t => {
   t.end();
 });
 
+test('ShaderPassRenderer reuses compatible transient targets without double destruction', async t => {
+  const devices = await getTestDevices();
+  const device = devices.find(candidate => candidate.type !== 'webgpu');
+  if (!device) {
+    t.comment('WebGL is not available');
+    t.end();
+    return;
+  }
+
+  const sourceTexture = new DynamicTexture(device, {
+    id: 'reused-target-source',
+    usage: Texture.RENDER | Texture.COPY_SRC | Texture.COPY_DST,
+    dimension: '2d',
+    data: {data: new Uint8Array([255, 0, 0, 255]), width: 1, height: 1, format: 'rgba8unorm'}
+  });
+  await sourceTexture.ready;
+  const activeTextureCount = device.statsManager.getStats('Resource Counts').get('Textures Active');
+  const texturesBeforeRenderer = activeTextureCount.count;
+  const renderer = new ShaderPassRenderer(device, {
+    shaderPasses: [reusedTargetPipeline],
+    shaderInputs: new ShaderInputs({copy: copyPass, invert: invertPass})
+  });
+
+  const targets = renderer.passRenderers[0].renderTargets;
+  t.equal(
+    targets.extract,
+    targets.reconstructed,
+    'logical target names share one owned allocation'
+  );
+  const output = renderer.renderToTexture({sourceTexture});
+  t.deepEqual(
+    Array.from(await readPixels(output!)),
+    [0, 255, 255, 255],
+    'expired contents can be replaced by a later non-overlapping pass'
+  );
+
+  const previousTexture = targets.extract.texture;
+  renderer.resize([4, 4]);
+  t.ok(previousTexture.destroyed, 'resizing releases the old allocation');
+  t.equal(
+    targets.extract.texture,
+    targets.reconstructed.texture,
+    'resizing preserves target reuse'
+  );
+  t.equal(targets.extract.texture.width, 4, 'the shared allocation receives the new size');
+
+  const sharedTexture = targets.extract.texture;
+  renderer.destroy();
+  t.ok(sharedTexture.destroyed, 'renderer destruction releases the shared allocation');
+  t.equal(
+    activeTextureCount.count,
+    texturesBeforeRenderer,
+    'all renderer-owned texture allocations are released exactly once'
+  );
+  sourceTexture.destroy();
+  t.end();
+});
+
 test('ShaderPassRenderer supports persistent history targets', async t => {
   const devices = await getTestDevices();
   for (const device of devices) {
@@ -718,6 +824,28 @@ test('ShaderPassRenderer validates ShaderPassPipeline routing', async t => {
     'throws on reserved pipeline target names'
   );
 
+  for (const [description, alias] of [
+    ['unknown target', {aliasFor: 'missing'}],
+    ['mismatched scale', {aliasFor: 'extract', scale: [0.5, 0.5] as [number, number]}],
+    ['mismatched sampler', {aliasFor: 'extract', sampler: {minFilter: 'linear' as const}}],
+    ['persistent history', {aliasFor: 'extract', lifetime: 'history' as const}]
+  ] as const) {
+    const invalidAliasPipeline: ShaderPassPipeline<'extract' | 'reconstructed'> = {
+      name: 'invalidTargetAlias',
+      renderTargets: {extract: {}, reconstructed: alias},
+      steps: [{shaderPass: copyPass}]
+    };
+    t.throws(
+      () =>
+        new ShaderPassRenderer(webglDevice, {
+          shaderPasses: [invalidAliasPipeline],
+          shaderInputs: new ShaderInputs({copy: copyPass})
+        }),
+      /target alias/,
+      `rejects ${description} aliases`
+    );
+  }
+
   const sourceTexture = new DynamicTexture(webglDevice, {
     id: 'aliasing-source-texture',
     usage: Texture.RENDER | Texture.COPY_SRC | Texture.COPY_DST,
@@ -736,7 +864,18 @@ test('ShaderPassRenderer validates ShaderPassPipeline routing', async t => {
     'throws on self-aliasing pipeline target'
   );
 
+  const indirectAliasRenderer = new ShaderPassRenderer(webglDevice, {
+    shaderPasses: [indirectlyAliasingPipeline],
+    shaderInputs: new ShaderInputs({combine: combinePass})
+  });
+  t.throws(
+    () => indirectAliasRenderer.renderToTexture({sourceTexture}),
+    /cannot sample from the render target it is writing to/,
+    'rejects aliased targets sampled through a secondary texture binding'
+  );
+
   aliasingRenderer.destroy();
+  indirectAliasRenderer.destroy();
   sourceTexture.destroy();
   t.end();
 });

--- a/modules/experimental/README.md
+++ b/modules/experimental/README.md
@@ -8,10 +8,57 @@ These are experimental features that may change or be removed at any time. Use a
 
 The package currently includes experimental GPU command graphs and data-parallel primitives such
 as scan, compaction, stable key/value sort, two-dimensional FFT, and spectral ocean simulation,
+energy-conserving FFT aperture diffraction and photographic bloom,
 order-independent transparency renderers, composable cross-backend glass and reflective-material
 shader modules, packed pixel-format helpers, and v10 work-in-progress WebGPU/WebGL WebXR session
 and frame helpers, with WebGL-only raw camera textures. See the
 [luma.gl API reference](https://luma.gl/docs/api-reference/experimental) for documentation.
+
+## FFT Convolution Bloom
+
+`GPUConvolutionBloom` performs physically motivated optical convolution on WebGPU. It extracts
+exposure-aware HDR highlights, transforms red, green, and blue into frequency space, multiplies
+them by one cached aperture point-spread spectrum, applies inverse transforms, and composites the
+result into a caller-owned `rgba16float` storage texture. Generated aperture kernels support blade
+count, diffraction strength, and anamorphic stretch; applications can provide any nonnegative
+`Float32Array` point-spread function and replace it with `setPointSpreadFunction()`.
+
+```ts
+import {Texture} from '@luma.gl/core';
+import {GPUConvolutionBloom, getGPUConvolutionBloomSupport} from '@luma.gl/experimental';
+
+const support = getGPUConvolutionBloomSupport(device, {width, height, resolutionScale: 0.25});
+if (!support.supported) {
+  throw new Error(support.reason);
+}
+
+const outputTexture = device.createTexture({
+  width,
+  height,
+  format: 'rgba16float',
+  usage: Texture.STORAGE | Texture.SAMPLE
+});
+const bloom = new GPUConvolutionBloom(device, {
+  width,
+  height,
+  resolutionScale: 0.25,
+  apertureBlades: 6,
+  diffractionStrength: 0.3
+});
+
+const encoder = device.createCommandEncoder();
+bloom.encode(encoder, {sourceTexture, outputTexture, exposure: 1});
+device.submit(encoder.finish());
+```
+
+The caller owns source/output textures and command submission; the renderer owns reusable FFT
+buffers and its cached optical spectrum. `bloom.stats` publishes exact transform dimensions,
+complex-buffer allocation, steady-state dispatch count, and one-time kernel initialization work.
+At 1920 x 1080 with quarter-resolution sampling, the power-of-two transform is 512 x 512 and
+requires nine reusable complex buffers totaling 18 MiB, 123 steady-state dispatches, and 20
+additional dispatches whenever the point-spread function changes. Prefer the fused multiscale
+pipeline in `@luma.gl/effects` for routine real-time bloom; reserve FFT convolution for premium
+optical fidelity or applications with measured compute headroom.
 
 Optional algorithm entry points keep specialized workflows out of the default experimental bundle:
 

--- a/modules/experimental/src/index.ts
+++ b/modules/experimental/src/index.ts
@@ -153,6 +153,19 @@ export type {
   GBufferShaderPassBindings
 } from './rendering/g-buffer';
 export {GBuffer} from './rendering/g-buffer';
+export type {
+  BloomPointSpreadFunctionOptions,
+  GPUConvolutionBloomEncodeOptions,
+  GPUConvolutionBloomProps,
+  GPUConvolutionBloomStats,
+  GPUConvolutionBloomSupport
+} from './rendering/fft-bloom';
+export {
+  getGPUConvolutionBloomSupport,
+  GPUConvolutionBloom,
+  makeBloomPointSpreadFunction,
+  makeGPUConvolutionBloomStats
+} from './rendering/fft-bloom';
 export type {DeferredAmbientLightingProps} from './rendering/deferred-ambient-lighting';
 export {
   createDeferredAmbientLightingShaderPassPipeline,

--- a/modules/experimental/src/rendering/fft-bloom-shaders.ts
+++ b/modules/experimental/src/rendering/fft-bloom-shaders.ts
@@ -1,0 +1,138 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+export const FFT_BLOOM_WORKGROUP_DIMENSION = 8;
+export const FFT_BLOOM_MULTIPLY_WORKGROUP_SIZE = 64;
+export const FFT_BLOOM_MULTIPLY_WORKGROUPS_PER_ROW = 1024;
+export const FFT_BLOOM_PARAMETER_BYTE_LENGTH = 32;
+
+export const FFT_BLOOM_EXTRACT_SHADER = /* wgsl */ `
+struct FFTBloomParameters {
+  sourceDimensions: vec2u,
+  transformDimensions: vec2u,
+  threshold: f32,
+  intensity: f32,
+  exposure: f32,
+  exposureCompensation: f32,
+};
+
+@group(0) @binding(0) var<uniform> parameters: FFTBloomParameters;
+@group(0) @binding(1) var sourceTexture: texture_2d<f32>;
+@group(0) @binding(2) var<storage, read_write> redChannel: array<vec2f>;
+@group(0) @binding(3) var<storage, read_write> greenChannel: array<vec2f>;
+@group(0) @binding(4) var<storage, read_write> blueChannel: array<vec2f>;
+
+@compute @workgroup_size(${FFT_BLOOM_WORKGROUP_DIMENSION}, ${FFT_BLOOM_WORKGROUP_DIMENSION})
+fn main(@builtin(global_invocation_id) globalInvocation: vec3u) {
+  let coordinate = globalInvocation.xy;
+  if (any(coordinate >= parameters.transformDimensions)) {
+    return;
+  }
+
+  let sourceCoordinate = min(
+    vec2u((vec2f(coordinate) + vec2f(0.5)) * vec2f(parameters.sourceDimensions) /
+      vec2f(parameters.transformDimensions)),
+    parameters.sourceDimensions - vec2u(1)
+  );
+  let sourceColor = textureLoad(sourceTexture, vec2i(sourceCoordinate), 0).rgb;
+  let luminance = dot(sourceColor, vec3f(0.2126, 0.7152, 0.0722));
+  let exposure = max(parameters.exposure * exp2(parameters.exposureCompensation), 0.0001);
+  let threshold = parameters.threshold / exposure;
+  let contribution = max(luminance - threshold, 0.0) / max(luminance, 0.00001);
+  let index = coordinate.y * parameters.transformDimensions.x + coordinate.x;
+  redChannel[index] = vec2f(sourceColor.r * contribution, 0.0);
+  greenChannel[index] = vec2f(sourceColor.g * contribution, 0.0);
+  blueChannel[index] = vec2f(sourceColor.b * contribution, 0.0);
+}
+`;
+
+export const FFT_BLOOM_MULTIPLY_SHADER = /* wgsl */ `
+@group(0) @binding(0) var<storage, read> redSpectrum: array<vec2f>;
+@group(0) @binding(1) var<storage, read> greenSpectrum: array<vec2f>;
+@group(0) @binding(2) var<storage, read> blueSpectrum: array<vec2f>;
+@group(0) @binding(3) var<storage, read> kernelSpectrum: array<vec2f>;
+@group(0) @binding(4) var<storage, read_write> filteredRed: array<vec2f>;
+@group(0) @binding(5) var<storage, read_write> filteredGreen: array<vec2f>;
+@group(0) @binding(6) var<storage, read_write> filteredBlue: array<vec2f>;
+
+fn multiplyComplex(first: vec2f, second: vec2f) -> vec2f {
+  return vec2f(
+    first.x * second.x - first.y * second.y,
+    first.x * second.y + first.y * second.x
+  );
+}
+
+@compute @workgroup_size(${FFT_BLOOM_MULTIPLY_WORKGROUP_SIZE})
+fn main(@builtin(global_invocation_id) globalInvocation: vec3u) {
+  let index = globalInvocation.x + globalInvocation.y *
+    ${FFT_BLOOM_MULTIPLY_WORKGROUP_SIZE * FFT_BLOOM_MULTIPLY_WORKGROUPS_PER_ROW}u;
+  if (index >= arrayLength(&kernelSpectrum)) {
+    return;
+  }
+
+  let kernel = kernelSpectrum[index];
+  filteredRed[index] = multiplyComplex(redSpectrum[index], kernel);
+  filteredGreen[index] = multiplyComplex(greenSpectrum[index], kernel);
+  filteredBlue[index] = multiplyComplex(blueSpectrum[index], kernel);
+}
+`;
+
+export const FFT_BLOOM_COMPOSITE_SHADER = /* wgsl */ `
+struct FFTBloomParameters {
+  sourceDimensions: vec2u,
+  transformDimensions: vec2u,
+  threshold: f32,
+  intensity: f32,
+  exposure: f32,
+  exposureCompensation: f32,
+};
+
+@group(0) @binding(0) var<uniform> parameters: FFTBloomParameters;
+@group(0) @binding(1) var sourceTexture: texture_2d<f32>;
+@group(0) @binding(2) var<storage, read> redChannel: array<vec2f>;
+@group(0) @binding(3) var<storage, read> greenChannel: array<vec2f>;
+@group(0) @binding(4) var<storage, read> blueChannel: array<vec2f>;
+@group(0) @binding(5) var outputTexture: texture_storage_2d<rgba16float, write>;
+
+fn loadConvolvedColor(coordinate: vec2i) -> vec3f {
+  let clampedCoordinate = vec2u(clamp(
+    coordinate,
+    vec2i(0),
+    vec2i(parameters.transformDimensions) - vec2i(1)
+  ));
+  let index = clampedCoordinate.y * parameters.transformDimensions.x + clampedCoordinate.x;
+  return max(vec3f(redChannel[index].x, greenChannel[index].x, blueChannel[index].x), vec3f(0.0));
+}
+
+fn sampleConvolvedColor(sourceCoordinate: vec2u) -> vec3f {
+  let transformCoordinate =
+    (vec2f(sourceCoordinate) + vec2f(0.5)) * vec2f(parameters.transformDimensions) /
+      vec2f(parameters.sourceDimensions) - vec2f(0.5);
+  let baseCoordinate = vec2i(floor(transformCoordinate));
+  let fraction = fract(transformCoordinate);
+  let top = mix(
+    loadConvolvedColor(baseCoordinate),
+    loadConvolvedColor(baseCoordinate + vec2i(1, 0)),
+    fraction.x
+  );
+  let bottom = mix(
+    loadConvolvedColor(baseCoordinate + vec2i(0, 1)),
+    loadConvolvedColor(baseCoordinate + vec2i(1, 1)),
+    fraction.x
+  );
+  return mix(top, bottom, fraction.y);
+}
+
+@compute @workgroup_size(${FFT_BLOOM_WORKGROUP_DIMENSION}, ${FFT_BLOOM_WORKGROUP_DIMENSION})
+fn main(@builtin(global_invocation_id) globalInvocation: vec3u) {
+  let coordinate = globalInvocation.xy;
+  if (any(coordinate >= parameters.sourceDimensions)) {
+    return;
+  }
+
+  let sourceColor = textureLoad(sourceTexture, vec2i(coordinate), 0);
+  let glowColor = sampleConvolvedColor(coordinate) * parameters.intensity;
+  textureStore(outputTexture, vec2i(coordinate), vec4f(sourceColor.rgb + glowColor, sourceColor.a));
+}
+`;

--- a/modules/experimental/src/rendering/fft-bloom.ts
+++ b/modules/experimental/src/rendering/fft-bloom.ts
@@ -1,0 +1,635 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {
+  Buffer,
+  Texture,
+  type BindingDeclaration,
+  type CommandEncoder,
+  type Device
+} from '@luma.gl/core';
+import {Computation} from '@luma.gl/engine';
+import {getGPUFFT2DSupport, GPUFFT2D, makeGPUFFT2DStats} from '../gpu-primitives/gpu-fft2d';
+import {
+  FFT_BLOOM_COMPOSITE_SHADER,
+  FFT_BLOOM_EXTRACT_SHADER,
+  FFT_BLOOM_MULTIPLY_SHADER,
+  FFT_BLOOM_MULTIPLY_WORKGROUP_SIZE,
+  FFT_BLOOM_MULTIPLY_WORKGROUPS_PER_ROW,
+  FFT_BLOOM_PARAMETER_BYTE_LENGTH,
+  FFT_BLOOM_WORKGROUP_DIMENSION
+} from './fft-bloom-shaders';
+
+/** Construction options for frequency-domain photographic bloom. */
+export type GPUConvolutionBloomProps = {
+  id?: string;
+  width: number;
+  height: number;
+  /** Fractional source resolution before rounding up to power-of-two FFT dimensions. */
+  resolutionScale?: number;
+  /** Scene-referred highlight threshold. Defaults to 0.8. */
+  threshold?: number;
+  /** Additive intensity applied after energy-normalized optical convolution. */
+  intensity?: number;
+  /** Adapted camera exposure used to scale the highlight threshold. */
+  exposure?: number;
+  /** Additional exposure compensation measured in photographic stops. */
+  exposureCompensation?: number;
+  /** Aperture blade count used when generating the default diffraction kernel. */
+  apertureBlades?: number;
+  /** Weight of diffraction spikes relative to the central Airy-like lobe. */
+  diffractionStrength?: number;
+  /** Horizontal or vertical stretching applied to the generated point-spread function. */
+  anamorphicRatio?: number;
+  /** Optional custom point-spread kernel containing one scalar per transform pixel. */
+  pointSpreadFunction?: Float32Array;
+};
+
+/** Per-frame inputs and optical overrides for {@link GPUConvolutionBloom.encode}. */
+export type GPUConvolutionBloomEncodeOptions = {
+  sourceTexture: Texture;
+  /** Caller-owned rgba16float output with Texture.STORAGE usage. */
+  outputTexture: Texture;
+  threshold?: number;
+  intensity?: number;
+  exposure?: number;
+  exposureCompensation?: number;
+};
+
+/** Immutable resource and dispatch budget for the premium convolution path. */
+export type GPUConvolutionBloomStats = {
+  width: number;
+  height: number;
+  transformWidth: number;
+  transformHeight: number;
+  elementCount: number;
+  complexBufferCount: number;
+  complexBufferByteLength: number;
+  totalComplexBufferByteLength: number;
+  transformDispatchCount: number;
+  steadyStateDispatchCount: number;
+  kernelInitializationDispatchCount: number;
+};
+
+/** Capability result returned before allocating premium convolution resources. */
+export type GPUConvolutionBloomSupport = {
+  supported: boolean;
+  reason?: string;
+  stats?: GPUConvolutionBloomStats;
+};
+
+/** Parameters for constructing an energy-normalized aperture diffraction kernel. */
+export type BloomPointSpreadFunctionOptions = {
+  width: number;
+  height: number;
+  apertureBlades?: number;
+  diffractionStrength?: number;
+  anamorphicRatio?: number;
+};
+
+type GPUConvolutionBloomResources = {
+  transform: GPUFFT2D;
+  parameters: Buffer;
+  kernelSpatial: Buffer;
+  kernelSpectrum: Buffer;
+  spatialChannels: Buffer[];
+  spectralChannels: Buffer[];
+  extract: Computation;
+  multiply: Computation;
+  composite: Computation;
+};
+
+/**
+ * Computes physically motivated optical convolution using three complex 2D RGB transforms.
+ *
+ * The caller owns source/output textures and command submission. A custom point-spread function is
+ * transformed once, then cached until it changes. Every supplied or generated kernel is normalized
+ * before upload so convolution redistributes highlight energy without duplicating it.
+ */
+export class GPUConvolutionBloom {
+  readonly device: Device;
+  readonly id: string;
+  readonly width: number;
+  readonly height: number;
+  readonly stats: GPUConvolutionBloomStats;
+
+  private readonly resources: GPUConvolutionBloomResources;
+  private readonly defaults: Required<
+    Pick<GPUConvolutionBloomProps, 'threshold' | 'intensity' | 'exposure' | 'exposureCompensation'>
+  >;
+  private kernelNeedsTransform = true;
+  private destroyed = false;
+
+  constructor(device: Device, props: GPUConvolutionBloomProps) {
+    const support = getGPUConvolutionBloomSupport(device, props);
+    if (!support.supported || !support.stats) {
+      throw new Error(support.reason);
+    }
+
+    this.device = device;
+    this.id = props.id ?? 'gpu-convolution-bloom';
+    this.width = props.width;
+    this.height = props.height;
+    this.stats = support.stats;
+    this.defaults = {
+      threshold: props.threshold ?? 0.8,
+      intensity: props.intensity ?? 1,
+      exposure: props.exposure ?? 1,
+      exposureCompensation: props.exposureCompensation ?? 0
+    };
+
+    const pointSpreadFunction =
+      props.pointSpreadFunction ||
+      makeBloomPointSpreadFunction({
+        width: this.stats.transformWidth,
+        height: this.stats.transformHeight,
+        apertureBlades: props.apertureBlades,
+        diffractionStrength: props.diffractionStrength,
+        anamorphicRatio: props.anamorphicRatio
+      });
+    this.resources = createGPUConvolutionBloomResources(device, {
+      id: this.id,
+      stats: this.stats,
+      pointSpreadFunction
+    });
+  }
+
+  /** Replaces and normalizes the cached point-spread kernel without reallocating FFT resources. */
+  setPointSpreadFunction(pointSpreadFunction: Float32Array): void {
+    if (this.destroyed) {
+      throw new Error('GPUConvolutionBloom has been destroyed.');
+    }
+    this.resources.kernelSpatial.write(
+      makeComplexPointSpreadFunction(pointSpreadFunction, this.stats.elementCount)
+    );
+    this.kernelNeedsTransform = true;
+  }
+
+  /** Records extraction, RGB frequency multiplication, inverse transforms, and HDR composition. */
+  encode(commandEncoder: CommandEncoder, options: GPUConvolutionBloomEncodeOptions): Texture {
+    if (this.destroyed) {
+      throw new Error('GPUConvolutionBloom has been destroyed.');
+    }
+    if (commandEncoder.device !== this.device) {
+      throw new Error('GPUConvolutionBloom command encoder belongs to a different device.');
+    }
+    validateGPUConvolutionBloomTextures(this.device, this.stats, options);
+
+    this.resources.parameters.write(
+      makeGPUConvolutionBloomParameters(this.stats, {
+        threshold: options.threshold ?? this.defaults.threshold,
+        intensity: options.intensity ?? this.defaults.intensity,
+        exposure: options.exposure ?? this.defaults.exposure,
+        exposureCompensation: options.exposureCompensation ?? this.defaults.exposureCompensation
+      })
+    );
+
+    if (this.kernelNeedsTransform) {
+      this.resources.transform.encode(commandEncoder, {
+        inputBuffer: this.resources.kernelSpatial,
+        outputBuffer: this.resources.kernelSpectrum,
+        direction: 'forward'
+      });
+      this.kernelNeedsTransform = false;
+    }
+
+    this.resources.extract.setBindings({
+      parameters: this.resources.parameters,
+      sourceTexture: options.sourceTexture.view,
+      redChannel: this.resources.spatialChannels[0],
+      greenChannel: this.resources.spatialChannels[1],
+      blueChannel: this.resources.spatialChannels[2]
+    });
+    dispatchConvolutionComputation(
+      commandEncoder,
+      this.resources.extract,
+      `${this.id}-extract`,
+      Math.ceil(this.stats.transformWidth / FFT_BLOOM_WORKGROUP_DIMENSION),
+      Math.ceil(this.stats.transformHeight / FFT_BLOOM_WORKGROUP_DIMENSION)
+    );
+
+    for (let channelIndex = 0; channelIndex < 3; channelIndex++) {
+      this.resources.transform.encode(commandEncoder, {
+        inputBuffer: this.resources.spatialChannels[channelIndex],
+        outputBuffer: this.resources.spectralChannels[channelIndex],
+        direction: 'forward'
+      });
+    }
+
+    this.resources.multiply.setBindings({
+      redSpectrum: this.resources.spectralChannels[0],
+      greenSpectrum: this.resources.spectralChannels[1],
+      blueSpectrum: this.resources.spectralChannels[2],
+      kernelSpectrum: this.resources.kernelSpectrum,
+      filteredRed: this.resources.spatialChannels[0],
+      filteredGreen: this.resources.spatialChannels[1],
+      filteredBlue: this.resources.spatialChannels[2]
+    });
+    const multiplyWorkgroupCount = Math.ceil(
+      this.stats.elementCount / FFT_BLOOM_MULTIPLY_WORKGROUP_SIZE
+    );
+    dispatchConvolutionComputation(
+      commandEncoder,
+      this.resources.multiply,
+      `${this.id}-multiply`,
+      Math.min(multiplyWorkgroupCount, FFT_BLOOM_MULTIPLY_WORKGROUPS_PER_ROW),
+      Math.ceil(multiplyWorkgroupCount / FFT_BLOOM_MULTIPLY_WORKGROUPS_PER_ROW)
+    );
+
+    for (let channelIndex = 0; channelIndex < 3; channelIndex++) {
+      this.resources.transform.encode(commandEncoder, {
+        inputBuffer: this.resources.spatialChannels[channelIndex],
+        outputBuffer: this.resources.spectralChannels[channelIndex],
+        direction: 'inverse'
+      });
+    }
+
+    this.resources.composite.setBindings({
+      parameters: this.resources.parameters,
+      sourceTexture: options.sourceTexture.view,
+      redChannel: this.resources.spectralChannels[0],
+      greenChannel: this.resources.spectralChannels[1],
+      blueChannel: this.resources.spectralChannels[2],
+      outputTexture: options.outputTexture.view
+    });
+    dispatchConvolutionComputation(
+      commandEncoder,
+      this.resources.composite,
+      `${this.id}-composite`,
+      Math.ceil(this.width / FFT_BLOOM_WORKGROUP_DIMENSION),
+      Math.ceil(this.height / FFT_BLOOM_WORKGROUP_DIMENSION)
+    );
+    return options.outputTexture;
+  }
+
+  /** Releases the FFT, cached optical spectrum, compute pipelines, and all owned GPU buffers. */
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    destroyGPUConvolutionBloomResources(this.resources);
+  }
+}
+
+/** Reports the exact transform dimensions, steady-state GPU work, and capability failures. */
+export function getGPUConvolutionBloomSupport(
+  device: Device,
+  props: Pick<GPUConvolutionBloomProps, 'width' | 'height' | 'resolutionScale'>
+): GPUConvolutionBloomSupport {
+  let stats: GPUConvolutionBloomStats;
+  try {
+    stats = makeGPUConvolutionBloomStats(props);
+  } catch (error) {
+    return {supported: false, reason: error instanceof Error ? error.message : String(error)};
+  }
+
+  const transformSupport = getGPUFFT2DSupport(device, {
+    width: stats.transformWidth,
+    height: stats.transformHeight
+  });
+  if (!transformSupport.supported) {
+    return {supported: false, reason: transformSupport.reason, stats};
+  }
+  if (device.limits.maxStorageBuffersPerShaderStage < 7) {
+    return {supported: false, reason: 'GPUConvolutionBloom requires seven storage buffers.', stats};
+  }
+  if (device.limits.maxStorageTexturesPerShaderStage < 1) {
+    return {supported: false, reason: 'GPUConvolutionBloom requires one storage texture.', stats};
+  }
+  const multiplyWorkgroupCount = Math.ceil(stats.elementCount / FFT_BLOOM_MULTIPLY_WORKGROUP_SIZE);
+  if (
+    Math.min(multiplyWorkgroupCount, FFT_BLOOM_MULTIPLY_WORKGROUPS_PER_ROW) >
+      device.limits.maxComputeWorkgroupsPerDimension ||
+    Math.ceil(multiplyWorkgroupCount / FFT_BLOOM_MULTIPLY_WORKGROUPS_PER_ROW) >
+      device.limits.maxComputeWorkgroupsPerDimension
+  ) {
+    return {
+      supported: false,
+      reason: 'GPUConvolutionBloom frequency multiplication exceeds the device dispatch limit.',
+      stats
+    };
+  }
+  if (!device.getTextureFormatCapabilities('rgba16float').store) {
+    return {
+      supported: false,
+      reason: 'GPUConvolutionBloom requires rgba16float storage textures.',
+      stats
+    };
+  }
+  return {supported: true, stats};
+}
+
+/** Computes the bounded power-of-two transform and its exact steady-state dispatch budget. */
+export function makeGPUConvolutionBloomStats(
+  props: Pick<GPUConvolutionBloomProps, 'width' | 'height' | 'resolutionScale'>
+): GPUConvolutionBloomStats {
+  if (!Number.isInteger(props.width) || props.width <= 0) {
+    throw new Error('GPUConvolutionBloom width must be a positive integer.');
+  }
+  if (!Number.isInteger(props.height) || props.height <= 0) {
+    throw new Error('GPUConvolutionBloom height must be a positive integer.');
+  }
+  const resolutionScale = props.resolutionScale ?? 0.25;
+  if (!Number.isFinite(resolutionScale) || resolutionScale <= 0 || resolutionScale > 1) {
+    throw new Error(
+      'GPUConvolutionBloom resolutionScale must be greater than zero and at most one.'
+    );
+  }
+  const transformWidth = nextPowerOfTwo(Math.max(Math.ceil(props.width * resolutionScale), 2));
+  const transformHeight = nextPowerOfTwo(Math.max(Math.ceil(props.height * resolutionScale), 2));
+  const transformStats = makeGPUFFT2DStats(transformWidth, transformHeight);
+  const complexBufferCount = 9;
+
+  return Object.freeze({
+    width: props.width,
+    height: props.height,
+    transformWidth,
+    transformHeight,
+    elementCount: transformStats.elementCount,
+    complexBufferCount,
+    complexBufferByteLength: transformStats.complexBufferByteLength,
+    totalComplexBufferByteLength: transformStats.complexBufferByteLength * complexBufferCount,
+    transformDispatchCount: transformStats.dispatchCountPerEncode,
+    steadyStateDispatchCount: transformStats.dispatchCountPerEncode * 6 + 3,
+    kernelInitializationDispatchCount: transformStats.dispatchCountPerEncode
+  });
+}
+
+/** Builds a nonnegative, unit-energy aperture point-spread function with diffraction spokes. */
+export function makeBloomPointSpreadFunction(
+  options: BloomPointSpreadFunctionOptions
+): Float32Array {
+  if (!Number.isInteger(options.width) || options.width <= 0) {
+    throw new Error('Point-spread width must be a positive integer.');
+  }
+  if (!Number.isInteger(options.height) || options.height <= 0) {
+    throw new Error('Point-spread height must be a positive integer.');
+  }
+
+  const apertureBlades = Math.min(Math.max(Math.round(options.apertureBlades ?? 6), 3), 12);
+  const diffractionStrength = Math.max(options.diffractionStrength ?? 0.18, 0);
+  const anamorphicRatio = Math.min(Math.max(options.anamorphicRatio ?? 0, -1), 1);
+  const horizontalStretch = 1 + Math.max(anamorphicRatio, 0) * 2;
+  const verticalStretch = 1 + Math.max(-anamorphicRatio, 0) * 2;
+  const kernel = new Float32Array(options.width * options.height);
+  let totalEnergy = 0;
+
+  for (let pixelY = 0; pixelY < options.height; pixelY++) {
+    const signedY = pixelY <= options.height / 2 ? pixelY : pixelY - options.height;
+    for (let pixelX = 0; pixelX < options.width; pixelX++) {
+      const signedX = pixelX <= options.width / 2 ? pixelX : pixelX - options.width;
+      const normalizedX = signedX / horizontalStretch;
+      const normalizedY = signedY / verticalStretch;
+      const distance = Math.hypot(normalizedX, normalizedY);
+      const radialPhase = distance * 0.95;
+      const airyLobe = radialPhase < 0.00001 ? 1 : (Math.sin(radialPhase) / radialPhase) ** 2;
+      const diffractionAngle = Math.atan2(normalizedY, normalizedX);
+      const spoke = Math.abs(Math.cos(diffractionAngle * apertureBlades * 0.5)) ** 32;
+      const diffraction = spoke / (1 + distance * distance * 0.065);
+      const value = airyLobe + diffraction * diffractionStrength;
+      kernel[pixelY * options.width + pixelX] = value;
+      totalEnergy += value;
+    }
+  }
+
+  for (let pixelIndex = 0; pixelIndex < kernel.length; pixelIndex++) {
+    kernel[pixelIndex] /= totalEnergy;
+  }
+  return kernel;
+}
+
+function createGPUConvolutionBloomResources(
+  device: Device,
+  options: {id: string; stats: GPUConvolutionBloomStats; pointSpreadFunction: Float32Array}
+): GPUConvolutionBloomResources {
+  let transform: GPUFFT2D | undefined;
+  const buffers: Buffer[] = [];
+  const computations: Computation[] = [];
+  const makeStorageBuffer = (name: string, data?: Float32Array): Buffer => {
+    const buffer = device.createBuffer({
+      id: `${options.id}-${name}`,
+      ...(data ? {data} : {byteLength: options.stats.complexBufferByteLength}),
+      usage: Buffer.STORAGE | Buffer.COPY_DST | Buffer.COPY_SRC
+    });
+    buffers.push(buffer);
+    return buffer;
+  };
+
+  try {
+    transform = new GPUFFT2D(device, {
+      id: `${options.id}-fft`,
+      width: options.stats.transformWidth,
+      height: options.stats.transformHeight
+    });
+    const parameters = device.createBuffer({
+      id: `${options.id}-parameters`,
+      byteLength: FFT_BLOOM_PARAMETER_BYTE_LENGTH,
+      usage: Buffer.UNIFORM | Buffer.COPY_DST
+    });
+    buffers.push(parameters);
+    const kernelSpatial = makeStorageBuffer(
+      'kernel-spatial',
+      makeComplexPointSpreadFunction(options.pointSpreadFunction, options.stats.elementCount)
+    );
+    const kernelSpectrum = makeStorageBuffer('kernel-spectrum');
+    const spatialChannels = ['red', 'green', 'blue'].map(channel =>
+      makeStorageBuffer(`${channel}-spatial`)
+    );
+    const spectralChannels = ['red', 'green', 'blue'].map(channel =>
+      makeStorageBuffer(`${channel}-spectrum`)
+    );
+    const extract = makeConvolutionComputation(
+      device,
+      `${options.id}-extract`,
+      FFT_BLOOM_EXTRACT_SHADER,
+      [
+        {name: 'parameters', type: 'uniform', group: 0, location: 0},
+        {
+          name: 'sourceTexture',
+          type: 'texture',
+          group: 0,
+          location: 1,
+          sampleType: 'unfilterable-float'
+        },
+        {name: 'redChannel', type: 'storage', group: 0, location: 2},
+        {name: 'greenChannel', type: 'storage', group: 0, location: 3},
+        {name: 'blueChannel', type: 'storage', group: 0, location: 4}
+      ]
+    );
+    computations.push(extract);
+    const multiply = makeConvolutionComputation(
+      device,
+      `${options.id}-multiply`,
+      FFT_BLOOM_MULTIPLY_SHADER,
+      [
+        {name: 'redSpectrum', type: 'read-only-storage', group: 0, location: 0},
+        {name: 'greenSpectrum', type: 'read-only-storage', group: 0, location: 1},
+        {name: 'blueSpectrum', type: 'read-only-storage', group: 0, location: 2},
+        {name: 'kernelSpectrum', type: 'read-only-storage', group: 0, location: 3},
+        {name: 'filteredRed', type: 'storage', group: 0, location: 4},
+        {name: 'filteredGreen', type: 'storage', group: 0, location: 5},
+        {name: 'filteredBlue', type: 'storage', group: 0, location: 6}
+      ]
+    );
+    computations.push(multiply);
+    const composite = makeConvolutionComputation(
+      device,
+      `${options.id}-composite`,
+      FFT_BLOOM_COMPOSITE_SHADER,
+      [
+        {name: 'parameters', type: 'uniform', group: 0, location: 0},
+        {
+          name: 'sourceTexture',
+          type: 'texture',
+          group: 0,
+          location: 1,
+          sampleType: 'unfilterable-float'
+        },
+        {name: 'redChannel', type: 'read-only-storage', group: 0, location: 2},
+        {name: 'greenChannel', type: 'read-only-storage', group: 0, location: 3},
+        {name: 'blueChannel', type: 'read-only-storage', group: 0, location: 4},
+        {
+          name: 'outputTexture',
+          type: 'storage',
+          group: 0,
+          location: 5,
+          access: 'write-only',
+          format: 'rgba16float'
+        }
+      ]
+    );
+    computations.push(composite);
+
+    return {
+      transform,
+      parameters,
+      kernelSpatial,
+      kernelSpectrum,
+      spatialChannels,
+      spectralChannels,
+      extract,
+      multiply,
+      composite
+    };
+  } catch (error) {
+    for (const computation of computations) {
+      computation.destroy();
+    }
+    for (const buffer of buffers) {
+      buffer.destroy();
+    }
+    transform?.destroy();
+    throw error;
+  }
+}
+
+function makeConvolutionComputation(
+  device: Device,
+  id: string,
+  source: string,
+  bindings: BindingDeclaration[]
+): Computation {
+  return new Computation(device, {id, source, shaderLayout: {bindings}});
+}
+
+function dispatchConvolutionComputation(
+  commandEncoder: CommandEncoder,
+  computation: Computation,
+  id: string,
+  workgroupCountX: number,
+  workgroupCountY: number
+): void {
+  computation.predraw(commandEncoder);
+  const computePass = commandEncoder.beginComputePass({id});
+  computation.dispatch(computePass, workgroupCountX, workgroupCountY, 1);
+  computePass.end();
+}
+
+function makeComplexPointSpreadFunction(kernel: Float32Array, elementCount: number): Float32Array {
+  if (kernel.length !== elementCount) {
+    throw new Error('Point-spread function must match the transform dimensions.');
+  }
+
+  let energy = 0;
+  for (const value of kernel) {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error('Point-spread samples must be finite and nonnegative.');
+    }
+    energy += value;
+  }
+  if (energy <= 0) {
+    throw new Error('Point-spread function must contain positive energy.');
+  }
+
+  const complexKernel = new Float32Array(elementCount * 2);
+  for (let index = 0; index < elementCount; index++) {
+    complexKernel[index * 2] = kernel[index] / energy;
+  }
+  return complexKernel;
+}
+
+function makeGPUConvolutionBloomParameters(
+  stats: GPUConvolutionBloomStats,
+  options: {threshold: number; intensity: number; exposure: number; exposureCompensation: number}
+): ArrayBuffer {
+  const buffer = new ArrayBuffer(FFT_BLOOM_PARAMETER_BYTE_LENGTH);
+  const view = new DataView(buffer);
+  view.setUint32(0, stats.width, true);
+  view.setUint32(4, stats.height, true);
+  view.setUint32(8, stats.transformWidth, true);
+  view.setUint32(12, stats.transformHeight, true);
+  view.setFloat32(16, options.threshold, true);
+  view.setFloat32(20, options.intensity, true);
+  view.setFloat32(24, options.exposure, true);
+  view.setFloat32(28, options.exposureCompensation, true);
+  return buffer;
+}
+
+function validateGPUConvolutionBloomTextures(
+  device: Device,
+  stats: GPUConvolutionBloomStats,
+  options: GPUConvolutionBloomEncodeOptions
+): void {
+  if (options.sourceTexture.device !== device || options.outputTexture.device !== device) {
+    throw new Error('GPUConvolutionBloom textures must belong to the same device.');
+  }
+  if (
+    options.sourceTexture.width !== stats.width ||
+    options.sourceTexture.height !== stats.height ||
+    options.outputTexture.width !== stats.width ||
+    options.outputTexture.height !== stats.height
+  ) {
+    throw new Error('GPUConvolutionBloom textures must match the configured source dimensions.');
+  }
+  if (options.outputTexture.format !== 'rgba16float') {
+    throw new Error('GPUConvolutionBloom output must use rgba16float.');
+  }
+  if (((options.outputTexture.props.usage || 0) & Texture.STORAGE) === 0) {
+    throw new Error('GPUConvolutionBloom output requires Texture.STORAGE usage.');
+  }
+  if (
+    options.sourceTexture === options.outputTexture ||
+    options.sourceTexture.handle === options.outputTexture.handle
+  ) {
+    throw new Error('GPUConvolutionBloom source and output textures must be separate.');
+  }
+}
+
+function destroyGPUConvolutionBloomResources(resources: GPUConvolutionBloomResources): void {
+  resources.extract.destroy();
+  resources.multiply.destroy();
+  resources.composite.destroy();
+  resources.transform.destroy();
+  resources.parameters.destroy();
+  resources.kernelSpatial.destroy();
+  resources.kernelSpectrum.destroy();
+  for (const buffer of [...resources.spatialChannels, ...resources.spectralChannels]) {
+    buffer.destroy();
+  }
+}
+
+function nextPowerOfTwo(value: number): number {
+  return 2 ** Math.ceil(Math.log2(value));
+}

--- a/modules/experimental/test/index.ts
+++ b/modules/experimental/test/index.ts
@@ -13,6 +13,7 @@ import './engine/scene-next-pbr-materials.spec';
 import './engine/scene-deformation.spec';
 import './engine/deferred-scene-renderer.spec';
 import './rendering/deferred-lighting.spec';
+import './rendering/fft-bloom.spec';
 import './rendering/g-buffer.spec';
 import './rendering/volumetric-fire-simulation.spec';
 

--- a/modules/experimental/test/rendering/fft-bloom.node.spec.ts
+++ b/modules/experimental/test/rendering/fft-bloom.node.spec.ts
@@ -1,0 +1,179 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import type {Device} from '@luma.gl/core';
+import {
+  getGPUConvolutionBloomSupport,
+  makeBloomPointSpreadFunction,
+  makeGPUConvolutionBloomStats
+} from '@luma.gl/experimental';
+import {WgslReflect} from 'wgsl_reflect';
+import test from 'test/utils/vitest-tape';
+import {
+  FFT_BLOOM_COMPOSITE_SHADER,
+  FFT_BLOOM_EXTRACT_SHADER,
+  FFT_BLOOM_MULTIPLY_SHADER,
+  FFT_BLOOM_PARAMETER_BYTE_LENGTH
+} from '../../src/rendering/fft-bloom-shaders';
+
+test('GPUConvolutionBloom publishes bounded FFT memory and dispatch costs', testCase => {
+  const stats = makeGPUConvolutionBloomStats({width: 1920, height: 1080});
+
+  testCase.deepEqual(
+    stats,
+    {
+      width: 1920,
+      height: 1080,
+      transformWidth: 512,
+      transformHeight: 512,
+      elementCount: 262144,
+      complexBufferCount: 9,
+      complexBufferByteLength: 2097152,
+      totalComplexBufferByteLength: 18874368,
+      transformDispatchCount: 20,
+      steadyStateDispatchCount: 123,
+      kernelInitializationDispatchCount: 20
+    },
+    'a quarter-resolution 1080p kernel reports every RGB transform, buffer, and dispatch'
+  );
+  testCase.ok(Object.isFrozen(stats), 'the performance contract cannot be mutated');
+  testCase.throws(
+    () => makeGPUConvolutionBloomStats({width: 1920, height: 1080, resolutionScale: 0}),
+    /resolutionScale/,
+    'zero-resolution transforms are rejected'
+  );
+  testCase.throws(
+    () => makeGPUConvolutionBloomStats({width: 8192, height: 1080, resolutionScale: 1}),
+    /width must be from 2 through 2048/,
+    'oversized FFT plans fail before allocating GPU resources'
+  );
+  testCase.end();
+});
+
+test('makeBloomPointSpreadFunction preserves energy and models anamorphic apertures', testCase => {
+  const width = 32;
+  const height = 32;
+  const circular = makeBloomPointSpreadFunction({width, height, diffractionStrength: 0});
+  const horizontal = makeBloomPointSpreadFunction({
+    width,
+    height,
+    apertureBlades: 6,
+    diffractionStrength: 0,
+    anamorphicRatio: 1
+  });
+  const diffraction = makeBloomPointSpreadFunction({
+    width,
+    height,
+    apertureBlades: 6,
+    diffractionStrength: 1
+  });
+
+  testCase.equal(circular.length, width * height, 'the kernel covers the complete FFT domain');
+  testCase.ok(
+    Math.abs(circular.reduce((energy, value) => energy + value, 0) - 1) < 0.000001,
+    'the optical kernel conserves total highlight energy'
+  );
+  testCase.ok(
+    circular.every(value => Number.isFinite(value) && value >= 0),
+    'all aperture samples are finite and nonnegative'
+  );
+  testCase.ok(horizontal[2] > horizontal[width * 2], 'positive anamorphism widens horizontal glow');
+  testCase.notEqual(
+    diffraction[width * 4],
+    circular[width * 4],
+    'aperture diffraction changes the normalized optical profile'
+  );
+  testCase.throws(
+    () => makeBloomPointSpreadFunction({width: 0, height}),
+    /width must be a positive integer/,
+    'invalid kernel dimensions are rejected'
+  );
+  testCase.end();
+});
+
+test('getGPUConvolutionBloomSupport reports WebGPU and storage requirements', testCase => {
+  const supportedDevice = makeSupportDevice();
+  const supported = getGPUConvolutionBloomSupport(supportedDevice, {width: 256, height: 128});
+
+  testCase.equal(supported.supported, true, 'representative WebGPU limits support RGB convolution');
+  testCase.equal(supported.stats?.transformWidth, 64, 'support queries include the transform plan');
+  testCase.equal(
+    getGPUConvolutionBloomSupport(supportedDevice, {
+      width: 2048,
+      height: 2048,
+      resolutionScale: 1
+    }).supported,
+    true,
+    'two-dimensional frequency dispatch supports the largest bounded FFT without exceeding WebGPU limits'
+  );
+  testCase.match(
+    getGPUConvolutionBloomSupport(makeSupportDevice({type: 'webgl'}), {width: 64, height: 64})
+      .reason || '',
+    /requires WebGPU/,
+    'WebGL devices fall back before allocating premium resources'
+  );
+  testCase.match(
+    getGPUConvolutionBloomSupport(makeSupportDevice({maxStorageBuffersPerShaderStage: 6}), {
+      width: 64,
+      height: 64
+    }).reason || '',
+    /seven storage buffers/,
+    'RGB spectrum multiplication checks its seven simultaneous storage bindings'
+  );
+  testCase.match(
+    getGPUConvolutionBloomSupport(makeSupportDevice({store: false}), {width: 64, height: 64})
+      .reason || '',
+    /rgba16float storage textures/,
+    'HDR storage support is mandatory for the final composite'
+  );
+  testCase.end();
+});
+
+test('GPUConvolutionBloom WGSL exposes extraction, multiplication, and HDR output', testCase => {
+  const extract = new WgslReflect(FFT_BLOOM_EXTRACT_SHADER);
+  const multiply = new WgslReflect(FFT_BLOOM_MULTIPLY_SHADER);
+  const composite = new WgslReflect(FFT_BLOOM_COMPOSITE_SHADER);
+
+  testCase.equal(extract.entry.compute.length, 1, 'extraction exposes one bounded compute stage');
+  testCase.equal(multiply.entry.compute.length, 1, 'all RGB spectra share one multiply dispatch');
+  testCase.equal(composite.entry.compute.length, 1, 'HDR composition exposes one compute stage');
+  testCase.equal(multiply.storage.length, 7, 'frequency multiplication binds exactly seven fields');
+  testCase.match(
+    FFT_BLOOM_EXTRACT_SHADER,
+    /parameters\.exposure \* exp2\(parameters\.exposureCompensation\)/,
+    'highlight extraction applies exposure compensation in photographic stops'
+  );
+  testCase.match(
+    FFT_BLOOM_COMPOSITE_SHADER,
+    /texture_storage_2d<rgba16float, write>/,
+    'the optical result remains in floating-point HDR space'
+  );
+  testCase.match(
+    FFT_BLOOM_MULTIPLY_SHADER,
+    /globalInvocation\.y \*\s+65536u/,
+    'frequency multiplication tiles across both dispatch dimensions for maximum-sized transforms'
+  );
+  testCase.equal(FFT_BLOOM_PARAMETER_BYTE_LENGTH, 32, 'uniform packing remains explicitly bounded');
+  testCase.end();
+});
+
+function makeSupportDevice(overrides: Record<string, unknown> = {}): Device {
+  const {type = 'webgpu', store = true, ...limitOverrides} = overrides;
+  return {
+    type,
+    limits: {
+      maxStorageBuffersPerShaderStage: 8,
+      maxStorageTexturesPerShaderStage: 4,
+      maxUniformBuffersPerShaderStage: 12,
+      maxComputeInvocationsPerWorkgroup: 256,
+      maxComputeWorkgroupSizeX: 256,
+      maxComputeWorkgroupSizeY: 256,
+      maxComputeWorkgroupsPerDimension: 65535,
+      maxStorageBufferBindingSize: 128 * 1024 * 1024,
+      maxBufferSize: 256 * 1024 * 1024,
+      ...limitOverrides
+    },
+    getTextureFormatCapabilities: () => ({store})
+  } as Device;
+}

--- a/modules/experimental/test/rendering/fft-bloom.spec.ts
+++ b/modules/experimental/test/rendering/fft-bloom.spec.ts
@@ -1,0 +1,146 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {Buffer, Texture} from '@luma.gl/core';
+import {getGPUConvolutionBloomSupport, GPUConvolutionBloom} from '@luma.gl/experimental';
+import {fromHalfFloat, toHalfFloat} from '@luma.gl/shadertools';
+import {getWebGPUTestDevice} from '@luma.gl/test-utils';
+import test from 'test/utils/vitest-tape';
+
+test('GPUConvolutionBloom convolves RGB highlights with caller-supplied optical kernels', async testCase => {
+  const device = await getWebGPUTestDevice();
+  if (!device) {
+    testCase.comment('WebGPU is not available');
+    testCase.end();
+    return;
+  }
+
+  const width = 16;
+  const height = 16;
+  const support = getGPUConvolutionBloomSupport(device, {width, height, resolutionScale: 1});
+  if (!support.supported) {
+    testCase.comment(support.reason || 'FFT convolution is not supported');
+    testCase.end();
+    return;
+  }
+
+  const centerX = 8;
+  const centerY = 8;
+  const sourceValues = new Uint16Array(width * height * 4);
+  for (let pixelIndex = 0; pixelIndex < width * height; pixelIndex++) {
+    sourceValues[pixelIndex * 4 + 3] = toHalfFloat(1);
+  }
+  sourceValues.set(
+    [toHalfFloat(8), toHalfFloat(4), toHalfFloat(2), toHalfFloat(1)],
+    (centerY * width + centerX) * 4
+  );
+  const sourceTexture = device.createTexture({
+    id: 'fft-bloom-source',
+    width,
+    height,
+    format: 'rgba16float',
+    usage: Texture.SAMPLE | Texture.COPY_DST,
+    data: sourceValues
+  });
+  const outputTexture = device.createTexture({
+    id: 'fft-bloom-output',
+    width,
+    height,
+    format: 'rgba16float',
+    usage: Texture.SAMPLE | Texture.STORAGE | Texture.COPY_SRC
+  });
+  const identityKernel = new Float32Array(width * height);
+  identityKernel[0] = 1;
+  const renderer = new GPUConvolutionBloom(device, {
+    id: 'fft-bloom-optical-regression',
+    width,
+    height,
+    resolutionScale: 1,
+    threshold: 0.5,
+    pointSpreadFunction: identityKernel
+  });
+
+  try {
+    const identityEncoder = device.createCommandEncoder({id: 'fft-bloom-identity-encoder'});
+    testCase.equal(
+      renderer.encode(identityEncoder, {sourceTexture, outputTexture}),
+      outputTexture,
+      'encoding returns the caller-owned HDR destination'
+    );
+    device.submit(identityEncoder.finish());
+    const identityPixels = await readHDRPixels(outputTexture, width, height);
+    const readPixel = (pixels: number[], pixelX: number, pixelY: number, channel = 0): number =>
+      pixels[(pixelY * width + pixelX) * 4 + channel];
+
+    testCase.ok(
+      readPixel(identityPixels, centerX, centerY) > 14,
+      'an identity optical kernel preserves and composites the red HDR highlight'
+    );
+    testCase.ok(
+      readPixel(identityPixels, centerX, centerY, 1) > 7,
+      'the green channel is transformed independently'
+    );
+    testCase.ok(
+      readPixel(identityPixels, centerX + 1, centerY) < 0.02,
+      'the identity kernel does not invent neighboring diffraction'
+    );
+
+    const diffractionKernel = new Float32Array(width * height);
+    diffractionKernel[0] = 0.5;
+    diffractionKernel[1] = 0.25;
+    diffractionKernel[width - 1] = 0.25;
+    renderer.setPointSpreadFunction(diffractionKernel);
+    const diffractionEncoder = device.createCommandEncoder({id: 'fft-bloom-diffraction-encoder'});
+    renderer.encode(diffractionEncoder, {sourceTexture, outputTexture});
+    device.submit(diffractionEncoder.finish());
+    const diffractionPixels = await readHDRPixels(outputTexture, width, height);
+
+    testCase.ok(
+      readPixel(diffractionPixels, centerX - 1, centerY) > 1,
+      'a changed point-spread function redistributes energy left of the highlight'
+    );
+    testCase.ok(
+      readPixel(diffractionPixels, centerX + 1, centerY) > 1,
+      'a changed point-spread function redistributes energy right of the highlight'
+    );
+    testCase.ok(
+      readPixel(diffractionPixels, centerX, centerY) < readPixel(identityPixels, centerX, centerY),
+      'normalized diffraction reduces the central peak instead of duplicating energy'
+    );
+  } finally {
+    renderer.destroy();
+    renderer.destroy();
+    sourceTexture.destroy();
+    outputTexture.destroy();
+  }
+  testCase.end();
+});
+
+async function readHDRPixels(texture: Texture, width: number, height: number): Promise<number[]> {
+  const layout = texture.computeMemoryLayout({width, height});
+  const readback = texture.device.createBuffer({
+    id: 'fft-bloom-readback',
+    byteLength: layout.byteLength,
+    usage: Buffer.COPY_DST | Buffer.MAP_READ
+  });
+
+  try {
+    texture.readBuffer({width, height}, readback);
+    texture.device.submit();
+    const bytes = await readback.readAsync(0, layout.byteLength);
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const pixels: number[] = [];
+    for (let pixelY = 0; pixelY < height; pixelY++) {
+      for (let pixelX = 0; pixelX < width; pixelX++) {
+        const offset = pixelY * layout.bytesPerRow + pixelX * layout.bytesPerPixel;
+        for (let channel = 0; channel < 4; channel++) {
+          pixels.push(fromHalfFloat(view.getUint16(offset + channel * 2, true)));
+        }
+      }
+    }
+    return pixels;
+  } finally {
+    readback.destroy();
+  }
+}

--- a/modules/shadertools/src/index.ts
+++ b/modules/shadertools/src/index.ts
@@ -35,6 +35,7 @@ export type {
   ShaderSubPass
 } from './lib/shader-module/shader-pass';
 export type {
+  ShaderPassComputeOptimization,
   ShaderPassPipeline,
   ShaderPassPipelineStep
 } from './lib/shader-module/shader-pass-pipeline';

--- a/modules/shadertools/src/lib/shader-module/shader-pass-pipeline.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-pass-pipeline.ts
@@ -12,8 +12,34 @@ export type ShaderPassPipelineStep<TargetNameT extends string = string> = {
   uniforms?: Record<string, UniformValue>;
 };
 
+/** Optional WebGPU compute stage that replaces equivalent fragment-only fallback passes. */
+export type ShaderPassComputeOptimization<TargetNameT extends string = string> = {
+  /** Stable identifier used for compute resources and command labels. */
+  name: string;
+  /** Complete WGSL compute entry point with explicit binding locations. */
+  source: string;
+  /** Existing fragment module that owns the scalar runtime uniforms. */
+  uniformModule: string;
+  /** Explicit WGSL uniform-buffer binding name used by the compute entry point. */
+  uniformBinding: string;
+  /** Scalar uniform packing order used by the compute shader. */
+  uniformNames: readonly string[];
+  /** Pipeline-level scalar defaults layered below per-frame runtime overrides. */
+  uniforms: Record<string, number>;
+  /** Logical source image consumed by the fused compute dispatch. */
+  input: ShaderPassInputSource<TargetNameT>;
+  /** Mapping from compute storage-texture names to owned render targets. */
+  outputs: Record<string, TargetNameT>;
+  /** Fragment pass names removed when the WebGPU optimization is supported. */
+  replacedPasses: readonly string[];
+  /** Compute workgroup width and height in highest-resolution output texels. */
+  workgroupSize: readonly [number, number];
+};
+
 export type ShaderPassPipeline<TargetNameT extends string = string> = {
   name: string;
   renderTargets?: Record<TargetNameT, ShaderPassRenderTarget>;
   steps: ShaderPassPipelineStep<TargetNameT>[];
+  /** Optional fused WebGPU dispatch; existing fragment steps remain the portable fallback. */
+  compute?: ShaderPassComputeOptimization<TargetNameT>;
 };

--- a/modules/shadertools/src/lib/shader-module/shader-pass.ts
+++ b/modules/shadertools/src/lib/shader-module/shader-pass.ts
@@ -13,6 +13,10 @@ export type ShaderPassRenderTarget = {
   format?: TextureFormat;
   /** Optional sampling behavior when later passes read this target. */
   sampler?: SamplerProps;
+  /** Reuse an earlier transient target with an identical size, format, and sampler. */
+  aliasFor?: string;
+  /** Allow WebGPU compute shaders to write this target as a storage texture. */
+  storage?: boolean;
   /** Resource lifetime. History targets retain their last successfully rendered value. */
   lifetime?: 'transient' | 'history';
   /** Initial value used after construction, resize, or an explicit history reset. */

--- a/website/content/examples/experimental/bloom.mdx
+++ b/website/content/examples/experimental/bloom.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'Effects: Bloom'
-description: Extract bright HDR highlights, blur them across scales, and composite a tunable cinematic glow.
+description: Explore HDR bloom with spectral lens ghosts, diffraction starbursts, halos, temporal stability, and textured lens dirt.
 sidebar_custom_props:
   backends: [webgpu, webgl2]
   display: hdr-capable
   difficulty: advanced
   maturity: experimental
-  topics: [rendering, effects, bloom, hdr]
+  topics: [rendering, effects, bloom, hdr, lens-flare]
 ---
 
 import {BloomExample} from '@site/src/examples';

--- a/yarn.lock
+++ b/yarn.lock
@@ -15089,6 +15089,7 @@ __metadata:
     "@luma.gl/core": "npm:9.4.0-alpha.4"
     "@luma.gl/effects": "npm:9.4.0-alpha.4"
     "@luma.gl/engine": "npm:9.4.0-alpha.4"
+    "@luma.gl/experimental": "npm:9.4.0-alpha.4"
     "@luma.gl/shadertools": "npm:9.4.0-alpha.4"
     "@luma.gl/webgl": "npm:9.4.0-alpha.4"
     "@luma.gl/webgpu": "npm:9.4.0-alpha.4"


### PR DESCRIPTION
## Goals
- Deliver production-quality cinematic bloom with explicit quality, optical, and performance controls.
- Accelerate the portable bloom pipeline on supported WebGPU devices without breaking WebGL.
- Add physically motivated FFT aperture diffraction without introducing an effects-to-experimental dependency.
- Keep deck.gl integration explicitly out of scope.

## Changes
- Add exposure-aware highlight thresholds, optional four-fetch bicubic reconstruction, firefly suppression, anamorphic blur, configurable scatter, and HDR-preserving multiscale composition.
- Add optional aperture starbursts, chromatic lens-element ghosts, halos, application-provided lens dirt, and neighborhood-clamped temporal stabilization.
- Fuse highlight extraction and all pyramid downsampling levels into one workgroup-local WebGPU compute dispatch, with automatic capability checks and portable render-pass fallback.
- Reuse compatible transient render targets during reconstruction, reject unsafe aliases, preserve live lens highlights, and correctly resize/destroy shared allocations.
- Add reusable experimental GPUConvolutionBloom with RGB FFT convolution, cached normalized point-spread spectra, customizable aperture kernels, anamorphic diffraction, and exact resource/dispatch accounting.
- Extend the interactive bloom demo with FFT mode, exposure controls, reconstruction and execution selectors, intermediate reuse, real-time cost reporting, and WebGL fallback.
- Document quality presets, relative feature costs, reusable target counts, and premium FFT memory/dispatch tradeoffs.
- Add structural WGSL reflection, numerical RGB FFT convolution, runtime exposure, texture orientation, renderer aliasing, fallback, and maximum-sized FFT dispatch coverage.

## Performance
| Quality | Portable render passes | Fused WebGPU | Physical targets with reuse |
| --- | ---: | ---: | ---: |
| Low | 8 | 6 render + 1 compute | 6 |
| Medium | 12 | 9 render + 1 compute | 9 |
| High | 16 | 12 render + 1 compute | 12 |
| Ultra | 20 | 15 render + 1 compute | 15 |

At 1920 x 1080, quarter-resolution premium FFT uses a 512 x 512 transform, 18 MiB of reusable complex buffers, 123 steady-state compute dispatches, and 20 additional dispatches only when its point-spread function changes.

## Verification
- All 19 packages compile with the repository TypeScript compiler: `node_modules/.bin/tspc -b modules/*/tsconfig.json --pretty false`.
- Full Node suite: **1,335 passed, one existing skip**, across 191 files.
- Affected WebGPU/WebGL browser suites: **78 passed** across 33 effects, renderer, and experimental-rendering suites.
- Bloom example production build and isolated example typecheck both pass.
- Playwright visual smoke verifies a nonblank WebGPU canvas, cinematic controls, live FFT mode, cost reporting, and WebGL fallback.
- All existing bundle-size ceilings pass; `yarn constraints`, explicit Biome checks, and `git diff --cached --check` pass.
- The ordinary local Yarn build/test/lint wrappers cannot run in this isolated worktree because its inherited shared checkout contains incompatible `@vis.gl/dev-tools@1.0.2`; equivalent direct compiler, Vitest, Biome, Vite, and bundle-budget commands were run instead.