### PR TITLE
Fuse trace dependency classification and routing

### DIFF
--- a/examples/experimental/gpu-trace-viewer/app.ts
+++ b/examples/experimental/gpu-trace-viewer/app.ts
@@ -67,7 +67,6 @@ import {
 import {
   getBatchVisibilityShader,
   getCandidateDensityShader,
-  getCandidateDependencyEndpointCountShader,
   getCandidateDependencyEndpointScatterShader,
   getCandidateDependencyVisibilityShader,
   getCandidatePassDispatchShader,
@@ -1287,9 +1286,15 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
           byteOffset: UINT32_BYTE_LENGTH
         })
       }).addToGraph(graph);
+      addTraceComputePass(graph, {
+        id: 'trace-clear-dependency-endpoint-routes',
+        source: getDependencyEndpointRouteClearShader(resources.spanChunks.length),
+        bindings: [storageWrite('endpointChunkState', dependencyEndpointChunkState)],
+        length: resources.spanChunks.length
+      });
       addTraceIndirectComputePass(graph, {
         id: 'trace-candidate-dependency-visibility',
-        source: getCandidateDependencyVisibilityShader(resources.spanCount),
+        source: getCandidateDependencyVisibilityShader(endpointRoutingProps),
         bindings: [
           storageRead('dependencies', handles.dependencies),
           storageRead('dependencyBatches', handles.dependencyBatchIndex),
@@ -1298,23 +1303,7 @@ export default class GPUTraceViewerAnimationLoopTemplate extends AnimationLoopTe
           storageRead('processStates', handles.processStates),
           storageRead('parentSpans', handles.parentSpans),
           uniformBinding('viewUniforms', handles.uniforms),
-          storageWrite('dependencyResults', handles.dependencyResults)
-        ],
-        dispatchBuffer: handles.candidateDependencyDispatchCommands
-      });
-      addTraceComputePass(graph, {
-        id: 'trace-clear-dependency-endpoint-routes',
-        source: getDependencyEndpointRouteClearShader(resources.spanChunks.length),
-        bindings: [storageWrite('endpointChunkState', dependencyEndpointChunkState)],
-        length: resources.spanChunks.length
-      });
-      addTraceIndirectComputePass(graph, {
-        id: 'trace-count-dependency-endpoint-routes',
-        source: getCandidateDependencyEndpointCountShader(endpointRoutingProps),
-        bindings: [
-          storageRead('dependencyBatches', handles.dependencyBatchIndex),
-          storageRead('candidateBatchIds', handles.candidateDependencyBatchIds),
-          storageRead('dependencyResults', handles.dependencyResults),
+          storageWrite('dependencyResults', handles.dependencyResults),
           storageWrite('endpointChunkState', dependencyEndpointChunkState)
         ],
         dispatchBuffer: handles.candidateDependencyDispatchCommands

--- a/examples/experimental/gpu-trace-viewer/trace-shaders.ts
+++ b/examples/experimental/gpu-trace-viewer/trace-shaders.ts
@@ -759,10 +759,15 @@ fn main() {
 }`;
 }
 
-/** Filters dependency rows inside GPU-selected candidate batches. */
-export function getCandidateDependencyVisibilityShader(spanCount: number): string {
+/** Filters dependency rows and counts visible endpoints by span chunk. */
+export function getCandidateDependencyVisibilityShader(
+  props: TraceDependencyEndpointRoutingShaderProps
+): string {
+  const spanCount = props.spanChunks.at(-1)?.spanCount || 0;
+  const firstSpanIndex = props.spanChunks.at(-1)?.firstSpanIndex || 0;
   return /* wgsl */ `
 ${TRACE_SHADER_DECLARATIONS}
+${getDependencyEndpointRoutingDeclarations(props)}
 struct DependencyBatch {
   firstIndex: u32,
   count: u32,
@@ -771,7 +776,7 @@ struct DependencyBatch {
   familyMask: u32,
   batchIndex: u32,
 };
-const SPAN_COUNT: u32 = ${spanCount}u;
+const SPAN_COUNT: u32 = ${firstSpanIndex + spanCount}u;
 const MAXIMUM_ANCESTOR_DEPTH: u32 = 32u;
 @group(0) @binding(0) var<storage, read> dependencies: array<TraceDependency>;
 @group(0) @binding(1) var<storage, read> dependencyBatches: array<DependencyBatch>;
@@ -781,6 +786,8 @@ const MAXIMUM_ANCESTOR_DEPTH: u32 = 32u;
 @group(0) @binding(5) var<storage, read> parentSpans: array<u32>;
 @group(0) @binding(6) var<uniform> viewUniforms: ViewUniforms;
 @group(0) @binding(7) var<storage, read_write> dependencyResults: array<u32>;
+@group(0) @binding(8) var<storage, read_write> endpointChunkState: array<atomic<u32>>;
+var<workgroup> localChunkCounts: array<atomic<u32>, ${props.spanChunks.length}>;
 
 fn resolveVisibleAncestor(sourceIndex: u32) -> u32 {
   var currentIndex = sourceIndex;
@@ -802,44 +809,60 @@ fn main(
   @builtin(local_invocation_id) localId: vec3<u32>,
   @builtin(workgroup_id) workgroupId: vec3<u32>
 ) {
-  let batch = dependencyBatches[candidateBatchIds[workgroupId.y]];
-  if (localId.x >= batch.count) {
-    return;
+  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
+    atomicStore(&localChunkCounts[chunkIndex], 0u);
   }
-  let index = batch.firstIndex + localId.x;
-  let dependency = dependencies[index];
-  let projectedSource = resolveVisibleAncestor(dependency.sourceIndex);
-  let projectedDestination = resolveVisibleAncestor(dependency.destinationIndex);
-  let sourceProcessIndex =
-    (dependency.flags >> ${TRACE_DEPENDENCY_SOURCE_PROCESS_SHIFT}u) &
-    ${TRACE_DEPENDENCY_PROCESS_MASK}u;
-  let destinationProcessIndex =
-    (dependency.flags >> ${TRACE_DEPENDENCY_DESTINATION_PROCESS_SHIFT}u) &
-    ${TRACE_DEPENDENCY_PROCESS_MASK}u;
-  let sourceCollapsed = processStates[sourceProcessIndex] == 0u;
-  let destinationCollapsed = processStates[destinationProcessIndex] == 0u;
-  let familyVisible = (viewUniforms.dependencyMask & (1u << dependency.family)) != 0u;
-  let sourceVisible =
-    spanVisibility[dependency.sourceIndex] == viewUniforms.visibilityGeneration || sourceCollapsed ||
-    projectedSource != 0xffffffffu;
-  let destinationVisible =
-    spanVisibility[dependency.destinationIndex] == viewUniforms.visibilityGeneration ||
-    destinationCollapsed || projectedDestination != 0xffffffffu;
-  let effectiveSource = select(projectedSource, dependency.sourceIndex, sourceCollapsed);
-  let effectiveDestination = select(
-    projectedDestination,
-    dependency.destinationIndex,
-    destinationCollapsed
-  );
-  let distinctEndpoints = effectiveSource != effectiveDestination;
-  dependencyResults[index] = select(
-    0u,
-    1u,
-    familyVisible && sourceVisible && destinationVisible && distinctEndpoints && !isDensityMode()
-  );
-  let endpointResultOffset = viewUniforms.dependencyEndpointOffset + index * 2u;
-  dependencyResults[endpointResultOffset] = effectiveSource;
-  dependencyResults[endpointResultOffset + 1u] = effectiveDestination;
+  workgroupBarrier();
+
+  let batch = dependencyBatches[candidateBatchIds[workgroupId.y]];
+  if (localId.x < batch.count) {
+    let index = batch.firstIndex + localId.x;
+    let dependency = dependencies[index];
+    let projectedSource = resolveVisibleAncestor(dependency.sourceIndex);
+    let projectedDestination = resolveVisibleAncestor(dependency.destinationIndex);
+    let sourceProcessIndex =
+      (dependency.flags >> ${TRACE_DEPENDENCY_SOURCE_PROCESS_SHIFT}u) &
+      ${TRACE_DEPENDENCY_PROCESS_MASK}u;
+    let destinationProcessIndex =
+      (dependency.flags >> ${TRACE_DEPENDENCY_DESTINATION_PROCESS_SHIFT}u) &
+      ${TRACE_DEPENDENCY_PROCESS_MASK}u;
+    let sourceCollapsed = processStates[sourceProcessIndex] == 0u;
+    let destinationCollapsed = processStates[destinationProcessIndex] == 0u;
+    let familyVisible = (viewUniforms.dependencyMask & (1u << dependency.family)) != 0u;
+    let sourceVisible =
+      spanVisibility[dependency.sourceIndex] == viewUniforms.visibilityGeneration || sourceCollapsed ||
+      projectedSource != 0xffffffffu;
+    let destinationVisible =
+      spanVisibility[dependency.destinationIndex] == viewUniforms.visibilityGeneration ||
+      destinationCollapsed || projectedDestination != 0xffffffffu;
+    let effectiveSource = select(projectedSource, dependency.sourceIndex, sourceCollapsed);
+    let effectiveDestination = select(
+      projectedDestination,
+      dependency.destinationIndex,
+      destinationCollapsed
+    );
+    let visible = familyVisible && sourceVisible && destinationVisible &&
+      effectiveSource != effectiveDestination && !isDensityMode();
+    dependencyResults[index] = select(0u, 1u, visible);
+    let endpointResultOffset = viewUniforms.dependencyEndpointOffset + index * 2u;
+    dependencyResults[endpointResultOffset] = effectiveSource;
+    dependencyResults[endpointResultOffset + 1u] = effectiveDestination;
+    if (visible) {
+      let sourceChunkIndex = getSpanChunkIndex(effectiveSource);
+      let destinationChunkIndex = getSpanChunkIndex(effectiveDestination);
+      if (sourceChunkIndex != INVALID_CHUNK_INDEX) {
+        atomicAdd(&localChunkCounts[sourceChunkIndex], 1u);
+      }
+      if (destinationChunkIndex != INVALID_CHUNK_INDEX) {
+        atomicAdd(&localChunkCounts[destinationChunkIndex], 1u);
+      }
+    }
+  }
+  workgroupBarrier();
+
+  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
+    atomicAdd(&endpointChunkState[chunkIndex], atomicLoad(&localChunkCounts[chunkIndex]));
+  }
 }`;
 }
 
@@ -879,57 +902,6 @@ const CHUNK_COUNT: u32 = ${chunkCount}u;
 fn main(@builtin(global_invocation_id) globalId: vec3<u32>) {
   if (globalId.x < CHUNK_COUNT) {
     atomicStore(&endpointChunkState[globalId.x], 0u);
-  }
-}`;
-}
-
-/** Counts visible dependency endpoints per bounded source span chunk. */
-export function getCandidateDependencyEndpointCountShader(
-  props: TraceDependencyEndpointRoutingShaderProps
-): string {
-  return /* wgsl */ `
-${getDependencyEndpointRoutingDeclarations(props)}
-struct DependencyBatch {
-  firstIndex: u32,
-  count: u32,
-  timeMin: f32,
-  timeMax: f32,
-  familyMask: u32,
-  batchIndex: u32,
-};
-@group(0) @binding(0) var<storage, read> dependencyBatches: array<DependencyBatch>;
-@group(0) @binding(1) var<storage, read> candidateBatchIds: array<u32>;
-@group(0) @binding(2) var<storage, read> dependencyResults: array<u32>;
-@group(0) @binding(3) var<storage, read_write> endpointChunkState: array<atomic<u32>>;
-var<workgroup> localChunkCounts: array<atomic<u32>, ${props.spanChunks.length}>;
-
-@compute @workgroup_size(${TRACE_DEPENDENCY_BATCH_CAPACITY})
-fn main(
-  @builtin(local_invocation_id) localId: vec3<u32>,
-  @builtin(workgroup_id) workgroupId: vec3<u32>
-) {
-  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
-    atomicStore(&localChunkCounts[chunkIndex], 0u);
-  }
-  workgroupBarrier();
-
-  let batch = dependencyBatches[candidateBatchIds[workgroupId.y]];
-  if (localId.x < batch.count) {
-    let dependencyIndex = batch.firstIndex + localId.x;
-    if (dependencyResults[dependencyIndex] != 0u) {
-      let endpointResultOffset = DEPENDENCY_COUNT + dependencyIndex * 2u;
-      for (var endpointIndex = 0u; endpointIndex < 2u; endpointIndex++) {
-        let chunkIndex = getSpanChunkIndex(dependencyResults[endpointResultOffset + endpointIndex]);
-        if (chunkIndex != INVALID_CHUNK_INDEX) {
-          atomicAdd(&localChunkCounts[chunkIndex], 1u);
-        }
-      }
-    }
-  }
-  workgroupBarrier();
-
-  for (var chunkIndex = localId.x; chunkIndex < CHUNK_COUNT; chunkIndex += ${TRACE_DEPENDENCY_BATCH_CAPACITY}u) {
-    atomicAdd(&endpointChunkState[chunkIndex], atomicLoad(&localChunkCounts[chunkIndex]));
   }
 }`;
 }

--- a/test/examples/gpu-trace-viewer.node.spec.ts
+++ b/test/examples/gpu-trace-viewer.node.spec.ts
@@ -39,7 +39,6 @@ import {
 import {
   getBatchVisibilityShader,
   getCandidateDensityShader,
-  getCandidateDependencyEndpointCountShader,
   getCandidateDependencyEndpointScatterShader,
   getCandidateDependencyVisibilityShader,
   getCandidatePassDispatchShader,
@@ -294,12 +293,11 @@ test('GPU trace adaptive LOD shaders parse as WGSL', t => {
     ]),
     getDependencyBatchVisibilityShader(3),
     getDependencyEndpointRouteClearShader(endpointRouting.spanChunks.length),
-    getCandidateDependencyEndpointCountShader(endpointRouting),
     getDependencyEndpointDispatchShader(endpointRouting.spanChunks.length),
     getCandidateDependencyEndpointScatterShader(endpointRouting),
     getDependencyEndpointResolveShader(endpointRouting, 0),
     getDependencyEndpointResolveShader(endpointRouting, 1),
-    getCandidateDependencyVisibilityShader(11),
+    getCandidateDependencyVisibilityShader(endpointRouting),
     getFocusFrontierSeedShader(11),
     getFocusFrontierClearShader(),
     getFocusFrontierExpansionShader({


### PR DESCRIPTION
## What changed

- fuse visible dependency classification with per-span-chunk endpoint counting
- keep the existing workgroup-local aggregation before publishing global chunk counts
- remove the standalone candidate endpoint-count shader and graph pass
- preserve compact endpoint scattering, indirect per-chunk resolution, and rendering semantics

## Why

The routed endpoint pipeline in #3023 classified candidate dependencies and then scanned the same candidate batches again to count endpoint destinations. Classification already has the effective visible endpoint IDs, so it can aggregate those counts without another full candidate scan.

This stacked tranche removes one graph node and one complete dependency-buffer traversal while deleting more code than it adds.

## Validation

- focused GPU trace viewer node/WGSL suite: 14/14 passed
- Biome check/write on the three changed files: passed
- live hardware WebGPU run: 10,000,000 spans, 5 span chunks, 250,000 dependencies, zero application/WebGPU errors
- `git diff --check`: passed
- `yarn lint fix`, `yarn build`, and `yarn test`: attempted; unavailable because the shared local dependency install predates the current `@vis.gl/dev-tools` command wiring (`ocular-*` commands not found)

CI will run the full gates from a clean install.

## Stack

- base: #3023
- this PR contains only the classification/count fusion commit
