### PR TITLE
fix(website): restore homepage WebGL rendering and safe picking

### DIFF
--- a/examples/showcase/instancing/app.ts
+++ b/examples/showcase/instancing/app.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
-import {Buffer, Device} from '@luma.gl/core';
+import {Buffer, Device, log} from '@luma.gl/core';
 import type {AnimationProps, ModelProps} from '@luma.gl/engine';
 import {
   AnimationLoopTemplate,
@@ -13,7 +13,6 @@ import {
   ShaderInputs,
   makeRandomGenerator,
   PickingManager,
-  supportsIndexPicking,
   picking,
   colorPicking,
   indexPicking
@@ -129,6 +128,17 @@ fn fragmentPicking(inputs: FragmentInputs) -> PickingFragmentOutputs {
 
 // GLSL
 
+const APP_UNIFORMS_GLSL = /* glsl */ `\
+uniform appUniforms {
+  mat4 modelMatrix;
+  mat4 viewMatrix;
+  mat4 projectionMatrix;
+  float geometryScale;
+  float time;
+  float highDynamicRange;
+} app;
+`;
+
 const VS_GLSL = /* glsl */ `\
 #version 300 es
 precision highp float;
@@ -140,14 +150,7 @@ in vec3 normals;
 in vec2 instanceOffsets;
 in vec3 instanceColors;
 
-uniform appUniforms {
-  mat4 modelMatrix;
-  mat4 viewMatrix;
-  mat4 projectionMatrix;
-  float geometryScale;
-  float time;
-  float highDynamicRange;
-} app;
+${APP_UNIFORMS_GLSL}
 
 out vec3 color;
 out float crestEnergy;
@@ -175,6 +178,8 @@ const FS_GLSL = /* glsl */ `\
 #version 300 es
 precision highp float;
 precision highp int;
+
+${APP_UNIFORMS_GLSL}
 
 in vec3 color;
 in float crestEnergy;
@@ -402,7 +407,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
 
     this.picker = new PickingManager(device, {
       shaderInputs: this.shaderInputs,
-      mode: 'auto'
+      mode: device.type === 'webgpu' ? 'index' : 'color'
     });
     this.settingsPanel = new ExampleSettingsPanelManager({
       id: 'showcase-instancing-settings',
@@ -478,7 +483,12 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
     pickingPass.end();
 
     this.shaderInputs.setProps({picking: {isActive: false}});
-    this.picker.updatePickInfo(mousePosition as [number, number]);
+    // WebGPU readback submits its own encoder, so let the animation loop submit the pick first.
+    void Promise.resolve()
+      .then(() => this.picker.updatePickInfo(mousePosition as [number, number]))
+      .catch(error => {
+        log.error('Instancing pick readback failed', error)();
+      });
   }
 
   createCube(): InstancedCube {
@@ -489,7 +499,7 @@ export default class AppAnimationLoopTemplate extends AnimationLoopTemplate {
   }
 
   createPickingCube(): Model | null {
-    if (!supportsIndexPicking(this.device)) {
+    if (this.device.type !== 'webgpu') {
       return null;
     }
 

--- a/modules/experimental/test/gpu-primitives/gpu-visibility-workflow.node.spec.ts
+++ b/modules/experimental/test/gpu-primitives/gpu-visibility-workflow.node.spec.ts
@@ -1,6 +1,6 @@
 // luma.gl
 // SPDX-License-Identifier: MIT
-// Copyright (c) vis.gl contributors
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
 
 import {Buffer} from '@luma.gl/core';
 import {GPUCommandGraph, GPUCompaction, GPUVisibilityWorkflow} from '@luma.gl/experimental';

--- a/test/examples/homepage-navigation.node.spec.ts
+++ b/test/examples/homepage-navigation.node.spec.ts
@@ -62,6 +62,20 @@ describe('homepage navigation', () => {
     expect(projectNameRule![1]).toContain('line-height: 0.96;');
   });
 
+  test('keeps the decorative GPU hero inert while preserving clickable foreground actions', () => {
+    const homepageStyles = readFileSync(HOMEPAGE_STYLES_PATH, 'utf8');
+    const heroExampleRule = homepageStyles.match(/\.heroExampleContainer\s*\{([^}]*)\}/);
+    const bannerContainerRule = homepageStyles.match(/\.bannerContainer\s*\{([^}]*)\}/);
+    const heroActionsRule = homepageStyles.match(/\.heroActions\s*\{([^}]*)\}/);
+
+    expect(heroExampleRule).not.toBeNull();
+    expect(bannerContainerRule).not.toBeNull();
+    expect(heroActionsRule).not.toBeNull();
+    expect(heroExampleRule![1]).toMatch(/\bpointer-events:\s*none\s*;/);
+    expect(bannerContainerRule![1]).toMatch(/\bpointer-events:\s*none\s*;/);
+    expect(heroActionsRule![1]).toMatch(/\bpointer-events:\s*auto\s*;/);
+  });
+
   test('reveals the flagship examples with an accessible, first-fold discovery cue', () => {
     const homepageSource = readFileSync(HOMEPAGE_SOURCE_PATH, 'utf8');
     const homepageStyles = readFileSync(HOMEPAGE_STYLES_PATH, 'utf8');

--- a/test/examples/instancing-shader-picking.node.spec.ts
+++ b/test/examples/instancing-shader-picking.node.spec.ts
@@ -1,0 +1,111 @@
+// luma.gl
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) vis.gl contributors
+
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+import {describe, expect, test} from 'vitest';
+
+const INSTANCING_APPLICATION_PATH = path.join(process.cwd(), 'examples/showcase/instancing/app.ts');
+
+function getGLSLSource(applicationSource: string, declarationName: string): string {
+  const declaration = `const ${declarationName} = /* glsl */`;
+  const declarationStart = applicationSource.indexOf(declaration);
+  const shaderStart = applicationSource.indexOf('\n', declarationStart) + 1;
+  const shaderEnd = applicationSource.indexOf('\n`;', shaderStart);
+
+  expect(declarationStart, `${declarationName} must declare a GLSL template`).toBeGreaterThan(0);
+  expect(shaderEnd, `${declarationName} must terminate its GLSL template`).toBeGreaterThan(
+    shaderStart
+  );
+
+  return applicationSource.slice(shaderStart, shaderEnd);
+}
+
+describe('homepage instancing shader and picking portability', () => {
+  test('declares the identical HDR application uniform block in both GLSL stages', () => {
+    const applicationSource = readFileSync(INSTANCING_APPLICATION_PATH, 'utf8');
+    const applicationUniforms = getGLSLSource(applicationSource, 'APP_UNIFORMS_GLSL');
+    const vertexSource = getGLSLSource(applicationSource, 'VS_GLSL');
+    const fragmentSource = getGLSLSource(applicationSource, 'FS_GLSL');
+    const uniformInterpolation = '${APP_UNIFORMS_GLSL}';
+    const applicationUniformPattern = /uniform\s+appUniforms\s*\{([\s\S]*?)\}\s*app\s*;/;
+
+    expect(applicationUniforms).toMatch(applicationUniformPattern);
+    expect(applicationUniforms).toContain('float highDynamicRange;');
+
+    for (const shaderSource of [vertexSource, fragmentSource]) {
+      expect(shaderSource.match(/\$\{APP_UNIFORMS_GLSL\}/g)).toHaveLength(1);
+
+      const expandedShaderSource = shaderSource.replace(uniformInterpolation, applicationUniforms);
+      const uniformDeclaration = expandedShaderSource.match(applicationUniformPattern);
+
+      expect(uniformDeclaration).not.toBeNull();
+      expect(uniformDeclaration![1]).toContain('float highDynamicRange;');
+      expect(expandedShaderSource.indexOf(uniformDeclaration![0])).toBeLessThan(
+        expandedShaderSource.indexOf('app.highDynamicRange')
+      );
+    }
+
+    expect(fragmentSource).toContain('app.highDynamicRange');
+    expect(fragmentSource).toContain('mix(fragColor.rgb, wideGamutColor, app.highDynamicRange)');
+  });
+
+  test('reserves integer attachment picking models for WebGPU and uses color picking on WebGL', () => {
+    const applicationSource = readFileSync(INSTANCING_APPLICATION_PATH, 'utf8');
+    const pickerStart = applicationSource.indexOf('this.picker = new PickingManager(device, {');
+    const pickerEnd = applicationSource.indexOf('\n    });', pickerStart);
+    const createPickingCubeStart = applicationSource.indexOf('createPickingCube(): Model | null {');
+    const createPickingCubeEnd = applicationSource.indexOf('\n  private ', createPickingCubeStart);
+
+    expect(pickerStart).toBeGreaterThan(0);
+    expect(pickerEnd).toBeGreaterThan(pickerStart);
+    expect(createPickingCubeStart).toBeGreaterThan(0);
+    expect(createPickingCubeEnd).toBeGreaterThan(createPickingCubeStart);
+
+    const pickerConfiguration = applicationSource.slice(pickerStart, pickerEnd);
+    const createPickingCube = applicationSource.slice(createPickingCubeStart, createPickingCubeEnd);
+
+    expect(pickerConfiguration).toMatch(
+      /mode:\s*device\.type\s*===\s*'webgpu'\s*\?\s*'index'\s*:\s*'color'/
+    );
+    expect(createPickingCube).toMatch(
+      /if\s*\(this\.device\.type\s*!==\s*'webgpu'\)\s*\{\s*return null;\s*\}/
+    );
+    expect(createPickingCube.indexOf('return null;')).toBeLessThan(
+      createPickingCube.indexOf('this.cube.createPickingModel(')
+    );
+    expect(applicationSource).toContain(
+      "modules: [dirlight, device.type === 'webgpu' ? indexPicking : colorPicking]"
+    );
+  });
+
+  test('ends the picking pass before deferring and handling asynchronous GPU readback', () => {
+    const applicationSource = readFileSync(INSTANCING_APPLICATION_PATH, 'utf8');
+    const pickInstanceStart = applicationSource.indexOf(
+      'pickInstance(mousePosition: number[] | null | undefined) {'
+    );
+    const pickInstanceEnd = applicationSource.indexOf(
+      '\n  createCube(): InstancedCube {',
+      pickInstanceStart
+    );
+
+    expect(pickInstanceStart).toBeGreaterThan(0);
+    expect(pickInstanceEnd).toBeGreaterThan(pickInstanceStart);
+
+    const pickInstance = applicationSource.slice(pickInstanceStart, pickInstanceEnd);
+    const renderPassStart = pickInstance.indexOf('this.picker.beginRenderPass()');
+    const renderPassEnd = pickInstance.indexOf('pickingPass.end()');
+    const deferredReadback = pickInstance.indexOf('void Promise.resolve()');
+    const updatePickInfo = pickInstance.indexOf('this.picker.updatePickInfo(');
+    const readbackFailureHandler = pickInstance.indexOf('.catch(error => {');
+
+    expect(pickInstance).toContain('this.picker.shouldPick(');
+    expect(renderPassStart).toBeGreaterThan(0);
+    expect(renderPassEnd).toBeGreaterThan(renderPassStart);
+    expect(deferredReadback).toBeGreaterThan(renderPassEnd);
+    expect(updatePickInfo).toBeGreaterThan(deferredReadback);
+    expect(readbackFailureHandler).toBeGreaterThan(updatePickInfo);
+    expect(pickInstance).toContain("log.error('Instancing pick readback failed', error)()");
+  });
+});

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -54,6 +54,7 @@
   position: absolute;
   z-index: 0;
   inset: 0;
+  pointer-events: none;
 }
 
 .bannerContainer {


### PR DESCRIPTION
## Problem

The deployed `/next` homepage renders the instancing showcase as its hero background. Its WebGL fragment shader reads `app.highDynamicRange` without declaring the application uniform block in that shader stage, causing both the regular and picking pipelines to fail compilation and covering the homepage with a shader error overlay.

## Changes

- Share the same application uniform block between the GLSL vertex and fragment shaders.
- Use color picking on WebGL and reserve integer picking attachments/models for WebGPU.
- Defer asynchronous pick readback until the animation loop submits its render commands, with explicit rejection handling.
- Prevent the decorative homepage background from receiving pointer events while preserving clickable foreground actions.
- Add targeted shader, picking, homepage-interaction, and async-ordering regressions.
- Restore one missing SPDX copyright declaration inherited from master so mandatory source-provenance checks pass.

## Verification

- Reproduced the deployed homepage WebGL fragment compilation error in a real browser.
- Verified the corrected standalone instancing scene renders and handles pointer movement without browser errors.
- Standalone Vite production build succeeded.
- Focused homepage/shader/SPDX suite: **23 tests passed**.
- Protected commit hooks: lint passed and **1,321 Node tests passed**.